### PR TITLE
Fix a minor bug in jlib:iq_to_xml/1.

### DIFF
--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -428,11 +428,20 @@ iq_to_xml(#iq{id = ID, type = Type, sub_el = SubEl}) ->
     if
         ID /= "" ->
             {xmlelement, <<"iq">>,
-             [{<<"id">>, ID}, {<<"type">>, iq_type_to_binary(Type)}], SubEl};
+             [{<<"id">>, ID}, {<<"type">>, iq_type_to_binary(Type)}],
+              sub_el_to_els(SubEl)};
         true ->
             {xmlelement, <<"iq">>,
-             [{<<"type">>, iq_type_to_binary(Type)}], SubEl}
+             [{<<"type">>, iq_type_to_binary(Type)}],
+              sub_el_to_els(SubEl)}
     end.
+
+%% @doc Convert `#iq.sub_el' back to `#xmlelement.children'.
+%% @end
+%% for requests.
+sub_el_to_els({xmlelement,_,_,_}=E) -> [E];
+%% for replies.
+sub_el_to_els(Es) when is_list(Es) -> Es.
 
 
 parse_xdata_submit(El) ->


### PR DESCRIPTION
We know from source code: 

```
            %% The iq record is a bit strange.  The sub_el field is an
            %% XML tuple for requests, but a list of XML tuples for
            %% responses.
```

This PR changes `iq_to_xml/1` according to `iq_info_internal/1`.
Output before:

```
{xmlelement,<<"iq">>,
[{<<"id">>,<<"c3a5e0900a1162db7b7229aba1e48107">>},{<<"type">>,<<"get">>}],
{xmlelement,<<"query">>,[{<<"xmlns">>,<<"urn:xmpp:mam:tmp">>}],[]}}
```

Output after:

```
{xmlelement,<<"iq">>,
[{<<"id">>,<<"c3a5e0900a1162db7b7229aba1e48107">>},{<<"type">>,<<"get">>}],
[{xmlelement,<<"query">>,[{<<"xmlns">>,<<"urn:xmpp:mam:tmp">>}],[]}]}
```
