### PR TITLE
Requests for empty string preparation will not be passed to the port driver.

### DIFF
--- a/apps/stringprep/src/stringprep.erl
+++ b/apps/stringprep/src/stringprep.erl
@@ -97,15 +97,21 @@ terminate(_Reason, Port) ->
     ok.
 
 
+tolower(<<>>) ->
+    <<>>;
 tolower(Binary) ->
     control(?TOLOWER_COMMAND, Binary).
 
+nameprep(<<>>) ->
+    <<>>;
 nameprep(Binary) ->
     control(?NAMEPREP_COMMAND, Binary).
 
 nodeprep(Binary) ->
     control(?NODEPREP_COMMAND, Binary).
 
+resourceprep(<<>>) ->
+    <<>>;
 resourceprep(Binary) ->
     control(?RESOURCEPREP_COMMAND, Binary).
 


### PR DESCRIPTION
String preparation is a popular operation. Strings are often empty too (for example, we have a JID without resource). This commit is a tiny optimization to not disturb the port driver, when the case is trivial.
