### PR TITLE
Fixed the error bad_module when using a custom log path.

### DIFF
--- a/apps/ejabberd/src/ejabberd.app.src
+++ b/apps/ejabberd/src/ejabberd.app.src
@@ -6,7 +6,7 @@
   {modules, []},
   {registered, [
                ]},
-  {applications, [kernel, stdlib, sasl, mnesia, public_key, ssl, crypto, stringprep, inets, lager, exml, ranch, cowboy]},
+  {applications, [kernel, stdlib, sasl, mnesia, public_key, ssl, crypto, stringprep, inets, exml, ranch, cowboy]},
   {env, []},
   {mod, {ejabberd_app, []}}]}.
 

--- a/apps/ejabberd/src/ejabberd_loglevel.erl
+++ b/apps/ejabberd/src/ejabberd_loglevel.erl
@@ -46,7 +46,16 @@
 
 -define(ETS_TRACE_TAB, ejabberd_lager_traces).
 
+%% @private
+log_path() ->
+    ejabberd_app:get_log_path().
+
 init() ->
+    %% If path is not default, reload lager with new settings.
+    case log_path() of
+        ?LOG_PATH  -> lager:start();
+        CustomPath -> apply_custom_log_path(CustomPath)
+    end,
     ets:new(?ETS_TRACE_TAB, [set, named_table, public]).
 
 -spec get() -> {integer(), atom()}.
@@ -58,16 +67,18 @@ set(Level) when is_integer(Level) ->
     {_, Name} = lists:keyfind(Level, 1, ?LOG_LEVELS),
     set(Name);
 set(Level) ->
+    Path = log_path(),
     ok = lager:set_loglevel(lager_console_backend, Level),
-    ok = lager:set_loglevel(lager_file_backend, ?LOG_PATH, Level).
+    ok = lager:set_loglevel(lager_file_backend, Path, Level).
 
 set_custom(Module, Level) when is_integer(Level) ->
     {_, Name} = lists:keyfind(Level, 1, ?LOG_LEVELS),
     set_custom(Module, Name);
 set_custom(Module, Level) when is_atom(Level) ->
     clear_custom(Module),
+    Path = log_path(),
     {ok, ConsoleTrace} = lager:trace_console([{module, Module}], Level),
-    {ok, FileTrace}  = lager:trace_file(?LOG_PATH, [{module, Module}], Level),
+    {ok, FileTrace}  = lager:trace_file(Path, [{module, Module}], Level),
     ets:insert(?ETS_TRACE_TAB, {Module, ConsoleTrace, FileTrace}).
     
 clear_custom() ->
@@ -83,3 +94,15 @@ clear_custom(Module) when is_atom(Module) ->
             ok
     end.
 
+apply_custom_log_path(Path) ->
+    {ok, Handlers} = application:get_env(lager, handlers),
+    LagerFileBackend = proplists:get_value(lager_file_backend, Handlers),
+    Handlers2 = proplists:delete(lager_file_backend, Handlers),
+    LagerFileBackend2 = proplists:delete(file, LagerFileBackend),
+    LagerFileBackend3 = [{file, Path}|LagerFileBackend2],
+    Handlers3 = [{lager_file_backend, LagerFileBackend3}|Handlers2],
+    application:stop(lager),
+    application:load(lager),
+    application:set_env(lager, handlers, Handlers3),
+    application:start(lager),
+    ok.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -2,6 +2,7 @@
 {lager, [
     {handlers, [
         {lager_console_backend, [info, {lager_default_formatter,[{eol, "\r\n"}]}]},
+        %% file is shadowed by ejabberd.cfg
         {lager_file_backend, [{file, "log/ejabberd.log"}, {level, info}, {size, 2097152}, {date, "$D0"}, {count, 5}]}
     ]}
   ]}


### PR DESCRIPTION
If a log path is not `"log/ejabberd.log"` (for example, `EJABBERD_LOG_PATH` is set), then the error will occur.

```
{"init terminating in do_boot",
 {{badmatch,{error,{bad_return,{{ejabberd_app,start,
                                              [normal,[]]},
                                {'EXIT',{{badmatch,{error,bad_module}},
                                         [{ejabberd_loglevel,set,1,
                                                             [{file,"src/ejabberd_loglevel.erl"},{line,62}]},
                                          {ejabberd_app,start,2,
                                                        [{file,"src/ejabberd_app.erl"},{line,43}]},
                                          {application_master,start_it_old,4,
                                                              [{file,"application_master.erl"},{line,274}]}]}}}}}},
  [{ejabberd,start,0,[{file,"src/ejabberd.erl"},{line,36}]},
   {init,start_it,1,[]},
   {init,start_em,1,[]}]}}
```
