### PR TITLE
Add an optional IP parameter for mod_bosh, mod_metrics, mod_websockets.

### DIFF
--- a/apps/ejabberd/src/mod_metrics.erl
+++ b/apps/ejabberd/src/mod_metrics.erl
@@ -94,6 +94,7 @@ get_total_counters(Host) ->
 
 start_cowboy(Opts) ->
     NumAcceptors = gen_mod:get_opt(num_acceptors, Opts, 10),
+    IP = gen_mod:get_opt(ip, Opts, {0,0,0,0}),
     case gen_mod:get_opt(port, Opts, undefined) of
         undefined ->
             ok;
@@ -106,7 +107,7 @@ start_cowboy(Opts) ->
                                 {"/metrics/host/:host", ?REST_LISTENER, [host_metrics]}
                                 ]}]),
             case cowboy:start_http(?REST_LISTENER, NumAcceptors,
-                                   [{port, Port}],
+                                   [{port, Port}, {ip, IP}],
                                    [{env, [{dispatch, Dispatch}]}]) of
                 {error, {already_started, _Pid}} ->
                     ok;


### PR DESCRIPTION
Many modules allow not only define a listen port, but ip address too.
This PR allows to define a listen ip for other modules.
