### PR TITLE
Fix bugs in MUC IQ handling

### DIFF
--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -246,7 +246,7 @@ is_query_allowed(Query) ->
         (xml:get_tag_attr_s(<<"type">>, X) == <<"submit">> orelse
         xml:get_tag_attr_s(<<"type">>, X)== <<"cancel">>)).
 
-locked_state_process_owner_iq(From, Query, Lang, <<"set">>, StateData) ->
+locked_state_process_owner_iq(From, Query, Lang, set, StateData) ->
     Result = case is_query_allowed(Query) of
                  true ->
                      process_iq_owner(From, set, Lang, Query, StateData);
@@ -255,7 +255,7 @@ locked_state_process_owner_iq(From, Query, Lang, <<"set">>, StateData) ->
              end,
     {Result, normal_state};
 
-locked_state_process_owner_iq(From, Query, Lang, <<"get">>, StateData) ->
+locked_state_process_owner_iq(From, Query, Lang, get, StateData) ->
     {process_iq_owner(From, get, Lang, Query, StateData), locked_state};
 
 locked_state_process_owner_iq(_From, _Query, Lang, _Type, _StateData) ->


### PR DESCRIPTION
Three commits:
1) When configuring a locked (newly created) MUC room, IQ responses are currently sent with an empty id attribute, which confuses some MUC clients.  This commit corrects the problem by building the IQ response from the IQ request (like route_iq/do_route_iq in mod_muc_room do), which ensures that the id is copied into the response, and also simplifies the code a bit.
2) Minor unrelated cleanup on mod_muc_room.erl
3) Commit 5d1645d2 introduced some bugs in handling of IQ queries to MUC room members, as route_nick_iq() expects #routed_nick_iq to have a populated 'from' field, but normal_state() does not set that field.  This commit corrects the problem my populating the 'from' field in normal_state().
