### PR TITLE
Fix #socket_state.sockmod to use ejabberd_tls

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1607,11 +1607,11 @@ get_auth_tags([], U, P, D, R) ->
 get_conn_type(StateData) ->
     case (StateData#state.sockmod):get_sockmod(StateData#state.socket) of
     gen_tcp -> c2s;
-    tls -> c2s_tls;
+    ejabberd_tls -> c2s_tls;
     ejabberd_zlib ->
 	case ejabberd_zlib:get_sockmod((StateData#state.socket)#socket_state.socket) of
 	    gen_tcp -> c2s_compressed;
-	    tls -> c2s_compressed_tls
+	    ejabberd_tls -> c2s_compressed_tls
 	end;
     ejabberd_http_poll -> http_poll;
     ejabberd_http_bind -> http_bind;

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -140,7 +140,7 @@ handle_call({starttls, TLSSocket}, _From,
     close_stream(XMLStreamState),
     NewXMLStreamState = xml_stream:new(C2SPid, MaxStanzaSize),
     NewState = State#state{socket = TLSSocket,
-			   sock_mod = tls,
+			   sock_mod = ejabberd_tls,
 			   xml_stream_state = NewXMLStreamState},
     case ejabberd_tls:recv_data(TLSSocket, "") of
 	{ok, TLSData} ->
@@ -208,7 +208,7 @@ handle_info({Tag, _TCPSocket, Data},
 		   sock_mod = SockMod} = State)
   when (Tag == tcp) or (Tag == ssl) or (Tag == ejabberd_xml) ->
     case SockMod of
-	tls ->
+	ejabberd_tls ->
 	    case ejabberd_tls:recv_data(Socket, Data) of
 		{ok, TLSData} ->
 		    {noreply, process_data(TLSData, State),

--- a/apps/ejabberd/src/ejabberd_socket.erl
+++ b/apps/ejabberd/src/ejabberd_socket.erl
@@ -137,13 +137,13 @@ connect(Addr, Port, Opts, Timeout) ->
 starttls(SocketData, TLSOpts) ->
     {ok, TLSSocket} = ejabberd_tls:tcp_to_tls(SocketData#socket_state.socket, TLSOpts),
     ejabberd_receiver:starttls(SocketData#socket_state.receiver, TLSSocket),
-    SocketData#socket_state{socket = TLSSocket, sockmod = tls}.
+    SocketData#socket_state{socket = TLSSocket, sockmod = ejabberd_tls}.
 
 starttls(SocketData, TLSOpts, Data) ->
     {ok, TLSSocket} = ejabberd_tls:tcp_to_tls(SocketData#socket_state.socket, TLSOpts),
     ejabberd_receiver:starttls(SocketData#socket_state.receiver, TLSSocket),
     send(SocketData, Data),
-    SocketData#socket_state{socket = TLSSocket, sockmod = tls}.
+    SocketData#socket_state{socket = TLSSocket, sockmod = ejabberd_tls}.
 
 compress(SocketData) ->
     {ok, ZlibSocket} = ejabberd_zlib:enable_zlib(
@@ -166,7 +166,7 @@ reset_stream(SocketData) when is_atom(SocketData#socket_state.receiver) ->
     (SocketData#socket_state.receiver):reset_stream(
       SocketData#socket_state.socket).
 
-%% sockmod=gen_tcp|tls|ejabberd_zlib
+%% sockmod=gen_tcp|ejabberd_tls|ejabberd_zlib
 send(SocketData, Data) ->
     case catch (SocketData#socket_state.sockmod):send(
 	     SocketData#socket_state.socket, Data) of


### PR DESCRIPTION
Some places in the code which called `tls` indirectly (through module name hidden as a variable, e.g. `SockMod:setopts` or `SockMod:peername` in `ejabberd_receiver.erl`) crashed as the module name in corresponding records wasn't updated when merging PR #97 from @twonds.
