### PR TITLE
Fixed RSM in room discovery.

### DIFF
--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -609,14 +609,20 @@ iq_disco_items(Host, From, Lang, Rsm) ->
 		     end
 	     end, Rooms) ++ RsmOut.
 
-get_vh_rooms(Host, #rsm_in{max=M, direction=Direction, id=I, index=Index})->
+get_vh_rooms(Host, #rsm_in{max=M, direction=Direction, id=I, index=Index}) ->
     AllRooms = lists:sort(get_vh_rooms(Host)),
     Count = erlang:length(AllRooms),
     Guard = case Direction of
-		_ when Index =/= undefined -> [{'==', {element, 2, '$1'}, Host}];
-		aft -> [{'==', {element, 2, '$1'}, Host}, {'>=',{element, 1, '$1'} ,I}];
-		before when I =/= []-> [{'==', {element, 2, '$1'}, Host}, {'=<',{element, 1, '$1'} ,I}];
-		_ -> [{'==', {element, 2, '$1'}, Host}]
+		_ when Index =/= undefined ->
+            [{'=:=', {element, 2, '$1'}, Host}];
+		aft ->
+            [{'=:=', {element, 2, '$1'}, Host},
+             {'>',   {element, 1, '$1'}, I}]; %% not exact here
+        before when I =/= <<>> ->
+            [{'=:=', {element, 2, '$1'}, Host},
+             {'<',   {element, 1, '$1'}, I}]; %% not exact here
+		_ ->
+            [{'=:=', {element, 2, '$1'}, Host}]
 	    end,
     L = lists:sort(
 	  mnesia:dirty_select(muc_online_room,


### PR DESCRIPTION
There is a bug with an item identified by `#rsm_in.id`. The original ejabberd includes it.
But according [http://xmpp.org/extensions/xep-0059.html#backwards](XEP-046) it MUST not.

> Paging Backwards Through a Result Set
> The last item in the page returned by the responding entity MUST be the item that immediately preceeds the item that the requesting entity indicated it has already received.

That is the reason why I changed `=<` on `<`.
Tests are here https://github.com/esl/ejabberd_tests/pull/26
