### PR TITLE
ejabberd_cowboy module: Common listener/router for Cowboy modules

### DIFF
--- a/apps/ejabberd/src/ejabberd_cowboy.erl
+++ b/apps/ejabberd/src/ejabberd_cowboy.erl
@@ -1,0 +1,149 @@
+%%%===================================================================
+%%% @doc Common listener/router for modules that use Cowboy.
+%%%
+%%% The 'modules' configuration option should be a list of
+%%% {Host, BasePath, Module} tuples, where a Host of "_" will match
+%%% any host.
+%%%
+%%% Modules may export the following function to configure Cowboy
+%%% routing for sub-paths:
+%%% cowboy_router_paths(BasePath) -> [{PathMatch, Handler, Opts}]
+%%% If not implemented, [{BasePath, Module, []}] is assumed.
+%%% @end
+%%%===================================================================
+-module(ejabberd_cowboy).
+-behaviour(gen_mod).
+-behavior(gen_server).
+
+%% ejabberd_listener API
+-export([socket_type/0,
+         start_listener/2]).
+
+%% gen_server API
+-export([start_link/1]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2]).
+
+%% gen_mod API
+-export([start/2,
+         stop/1]).
+
+-include("ejabberd.hrl").
+
+%%--------------------------------------------------------------------
+%% ejabberd_listener API
+%%--------------------------------------------------------------------
+
+socket_type() ->
+    independent.
+
+start_listener({Port, IP, tcp}, Opts) ->
+    %% ejabberd_listener brutally kills its children, and doesn't provide any
+    %% mechanism for doing a clean shutdown.  To work around this, we could
+    %% start two linked processes: one to be killed, and another to trap the
+    %% exit signal and shut down Cowboy cleanly.  However, a simpler solution is
+    %% to manually configure supervision and not use brutal_kill.  Calling
+    %% supervisor:start_child(ejabberd_listeners, ...) would hang since we're
+    %% running in the ejabberd_listeners process and start_child() is
+    %% synchronous.  So, simply use ejabberd_sup as the supervisor instead.
+    IPPort = [inet_parse:ntoa(IP), <<"_">>, integer_to_list(Port)],
+    ChildSpec = {cowboy_ref(IPPort), {?MODULE, start_link, [IPPort]}, permanent,
+                 infinity, worker, [?MODULE]},
+    supervisor:start_child(ejabberd_sup, ChildSpec),
+    start_cowboy(IPPort, [{port, Port}, {ip, IP} | Opts]),
+    %% Tell ejabberd_listener not to supervise us
+    ignore.
+
+%% gen_server for handling shutdown when started via ejabberd_listener
+start_link(Ref) ->
+    gen_server:start_link(?MODULE, [Ref], []).
+init(Ref) ->
+    process_flag(trap_exit, true),
+    {ok, Ref}.
+handle_call(_Request, _From, Ref) ->
+    {noreply, Ref}.
+handle_cast(_Request, Ref) ->
+    {noreply, Ref}.
+handle_info(_Info, Ref) ->
+    {noreply, Ref}.
+code_change(_OldVsn, Ref, _Extra) ->
+    {ok, Ref}.
+terminate(_Reason, Ref) ->
+    stop_cowboy(Ref).
+
+%%--------------------------------------------------------------------
+%% gen_mod API
+%%--------------------------------------------------------------------
+
+start(Host, Opts) ->
+    start_cowboy(Host, Opts).
+
+stop(Host) ->
+    stop_cowboy(Host).
+
+%%--------------------------------------------------------------------
+%% Internal Functions
+%%--------------------------------------------------------------------
+
+start_cowboy(Ref, Opts) ->
+    %% Port and Dispatch are required
+    Port = gen_mod:get_opt(port, Opts),
+    IP = gen_mod:get_opt(ip, Opts, {0,0,0,0}),
+    SSLCert = gen_mod:get_opt(cert, Opts, undefined),
+    SSLKey = gen_mod:get_opt(key, Opts, undefined),
+    SSLKeyPass = gen_mod:get_opt(key_pass, Opts, undefined),
+    NumAcceptors = gen_mod:get_opt(num_acceptors, Opts, 100),
+    Dispatch = cowboy_router:compile(get_routes(gen_mod:get_opt(modules, Opts))),
+    case {SSLCert, SSLKey} of
+        {undefined, undefined} ->
+            cowboy:start_http(cowboy_ref(Ref), NumAcceptors,
+                              [{port, Port}, {ip, IP}],
+                              [{env, [{dispatch, Dispatch}]}]);
+        _ ->
+            cowboy:start_https(cowboy_ref(Ref), NumAcceptors,
+                               [{port, Port}, {ip, IP}, {certfile, SSLCert},
+                                {keyfile, SSLKey}, {password, SSLKeyPass}],
+                               [{env, [{dispatch, Dispatch}]}])
+    end.
+
+stop_cowboy(Ref) ->
+    cowboy:stop_listener(cowboy_ref(Ref)),
+    ok.
+
+cowboy_ref(Ref) ->
+    ModRef = [?MODULE_STRING, <<"_">>, Ref],
+    list_to_atom(binary_to_list(iolist_to_binary(ModRef))).
+
+%% Cowboy will search for a matching Host, then for a matching Path.  If no Path
+%% matches, Cowboy will not search for another matching Host.  So, we must merge
+%% all Paths for each Host, add any wildcard Paths to each Host, and ensure that
+%% the wildcard Host is listed last.  A dict would be slightly easier to use
+%% here, but a proplist ensures that the user can influence Host ordering if
+%% other wildcards like "[...]" are used.
+get_routes(Modules) ->
+    Routes = get_routes(Modules, []),
+    WildcardPaths = proplists:get_value('_', Routes, []),
+    Merge = fun(Paths) -> Paths ++ WildcardPaths end,
+    Merged = lists:keymap(Merge, 2, proplists:delete('_', Routes)),
+    Final = Merged ++ [{'_', WildcardPaths}],
+    ?DEBUG("Configured Cowboy Routes: ~p", [Final]),
+    Final.
+get_routes([], Routes) ->
+    Routes;
+get_routes([{Host, BasePath, Module} | Tail], Routes) ->
+    %% ejabberd_config tries to expand the atom '_' as a Macro, which fails.
+    %% To work around that, use "_" instead and translate it to '_' here.
+    CowboyHost = case Host of
+        "_" -> '_';
+        _ -> Host
+    end,
+    Paths = proplists:get_value(CowboyHost, Routes, []) ++
+    case erlang:function_exported(Module, cowboy_router_paths, 1) of
+        true -> Module:cowboy_router_paths(BasePath);
+        _ -> [{BasePath, Module, []}]
+    end,
+    get_routes(Tail, lists:keystore(CowboyHost, 1, Routes, {CowboyHost, Paths})).

--- a/apps/ejabberd/src/mod_bosh.erl
+++ b/apps/ejabberd/src/mod_bosh.erl
@@ -34,7 +34,6 @@
 -include("mod_bosh.hrl").
 
 -define(LISTENER, ?MODULE).
--define(DEFAULT_PORT, 5280).
 -define(DEFAULT_BACKEND, mnesia).
 -define(DEFAULT_MAX_AGE, 1728000).  %% 20 days in seconds
 -define(DEFAULT_INACTIVITY, 30).  %% seconds
@@ -87,9 +86,13 @@ set_server_acks(EnableServerAcks) ->
 %%--------------------------------------------------------------------
 
 start(_Host, Opts) ->
-    Port = gen_mod:get_opt(port, Opts, ?DEFAULT_PORT),
     try
-        ok = start_cowboy(Port, Opts),
+        case gen_mod:get_opt(port, Opts, undefined) of
+            undefined ->
+                ok;
+            Port ->
+                ok = start_cowboy(Port, Opts)
+        end,
         ok = start_backend(Opts),
         {ok, _Pid} = mod_bosh_socket:start_supervisor()
     catch

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -138,7 +138,19 @@
 {listen,
  [
 
-  { {{mod_bosh_port}}, mod_bosh, [{num_acceptors, 10}]},
+  { {{cowboy_port}}, ejabberd_cowboy, [
+      {num_acceptors, 10},
+      %% Uncomment for HTTPS
+      %{cert, "priv/server.crt"},
+      %{key, "priv/server.key"},
+      %{key_pass, ""},
+      {modules, [
+          %% Modules used here should also be listed in the MODULES section.
+          {"_", "/http-bind", mod_bosh},
+          {"_", "/ws-xmpp", mod_websockets},
+          {"localhost", "/metrics", mod_metrics}
+      ]}
+  ]},
 
   { {{ejabberd_c2s_port}}, ejabberd_c2s, [
 
@@ -154,19 +166,6 @@
 			{max_stanza_size, 65536}
 		       ]},
 
-  { { {{mod_websockets_port}}, ws}, mod_websockets, [
-                  {host, "localhost"},
-                  {prefix, "/ws-xmpp"}
-            ]},
-
-  %% websockets secure
-  % { {5289, wss}, mod_websockets, [
-  %                 {host, "localhost"},
-  %                 {prefix, "/ws-xmpp"},
-  %                 {cert, "priv/server.crt"},
-  %                 {key, "priv/server.key"},
-  %                 {key_pass, ""}
-  %           ]},
   %%
   %% To enable the old SSL connection method on port 5223:
   %%
@@ -572,14 +571,9 @@
   {{mod_roster}}
   {mod_sic, []},
   {{mod_vcard}}
-  {mod_metrics, [{port, {{mod_metrics_port}} }]}
-  % {mod_websockets, [
-  %               {host, "localhost"},
-  %               {prefix, "/ws-xmpp"},
-  %               {port, 5288},
-  %               {ssl_port, 5289}
-  %               {{wss_config}}
-  %           ]}
+  {mod_bosh, []},
+  {mod_websockets, []},
+  {mod_metrics, []}
  ]}.
 
 {{module_host_config}}

--- a/rel/reltool_vars/node1_vars.config
+++ b/rel/reltool_vars/node1_vars.config
@@ -24,9 +24,7 @@
                 "%{search, true},\n"
                 "%{host, directory.@HOST@}\n"
                 "]},"}.
-{mod_bosh_port, 5280}.
-{mod_websockets_port, 5288}.
-{mod_metrics_port, 8081}.
+{cowboy_port, 5280}.
 {tls_config, "{certfile, \"/tmp/server.pem\"}, starttls,"}.
 { {s2s_addr, "localhost2"}, {127,0,0,1} }.
 { {s2s_addr, "michał"}, {127,0,0,1} }.

--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -6,9 +6,7 @@
 {node_name, "ejabberd2@localhost"}.
 {ejabberd_c2s_port, 5232}.
 {ejabberd_s2s_in_port, 5279}.
-{mod_bosh_port, 5281}.
-{mod_websockets_port, 5289}.
-{mod_metrics_port, 8082}.
+{cowboy_port, 5281}.
 {mod_last, "{mod_last, []},"}.
 {mod_privacy, "{mod_privacy, []},"}.
 {mod_private, "{mod_private, []},"}.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -7,9 +7,7 @@
 {node_name, "ejabberd@localhost"}.
 {ejabberd_c2s_port, 5222}.
 {ejabberd_s2s_in_port, 5269}.
-{mod_bosh_port, 5280}.
-{mod_websockets_port, 5288}.
-{mod_metrics_port, 8081}.
+{cowboy_port, 5280}.
 {mod_last, "{mod_last, []},"}.
 {mod_offline, "%{mod_offline, [{access_max_user_messages, max_user_offline_messages}]},"}.
 {mod_privacy, "{mod_privacy, []},"}.


### PR DESCRIPTION
Currently, a separate listener and router is used for each ejabberd
module that uses Cowboy.  Thus, a separate listening IP/port is required
for each module.

This module provides a common Cowboy listener/router (similar to
ejabberd_http in P1) that allows multiple Cowboy modules to share the
same listening IP/port and separate traffic based on the Host and/or
Path of HTTP requests.

This commit also includes minor and backwards-compatible updates to
mod_bosh and mod_metrics to make them compatible with ejabberd_cowboy,
as as well as updates to the example ejabberd.cfg.
