### PR TITLE
Add a dummy application resource file to support building as a rebar dependency

### DIFF
--- a/ebin/ejabberd.app
+++ b/ebin/ejabberd.app
@@ -1,0 +1,8 @@
+%% Dummy application resource file so that ejabberd may be used as a rebar
+%% dependency in other erlang applications.
+{application,ejabberd,
+             [{description,"ejabberd_mim"},
+              {vsn,"2.1.8+mim1.2"},
+              {modules,[]},
+              {registered,[]},
+              {applications,[]}]}.


### PR DESCRIPTION
I'm trying to build an erlang release that includes ejabberd and a bunch of external modules, and I'm trying to avoid having to modify ejabberd's rebar.config and reltool.config to build my release.

The obvious solution is to simply write my own rebar.config/reltool.config and include ejabberd as a dependency, but that does not work ... rebar fails with a 'missing_app_file' error immediately after downloading ejabberd because there is no src/ejabberd.app.src or ebin/ejabberd.app file.

I've tried various hacks in rebar to work around this, for example:
{deps, [
  %% Grab esl-ejabberd and its dependencies, but don't try to compile esl-ejabberd:
  %% (Requires rebar 2.1.0 or later)
  {'esl-ejabberd', "._", {git, "git://github.com/esl/ejabberd.git", {branch, "master"}}, [raw]},
  %% Then use symlinks to treat the various esl-ejabberd apps as normal deps (see post_hooks):
  ejabberd, mysql, stringprep
]}.
{post_hooks, [
  {'get-deps', "sh -c 'cd deps/ ; ln -f -s esl-ejabberd/apps/_/ .'"}
]}.
However, that causes a number of weird rebar dependency issues that aren't easy to fix.

So, as best as I can tell, the best way to fix this is to add a dummy ebin/ejabberd.app file to ejabberd.

Let me know if you have any better ideas...
