### PR TITLE
Change vcard_search.server to varchar(100)

### DIFF
--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -81,7 +81,7 @@ CREATE TABLE vcard (
 CREATE TABLE vcard_search (
     username varchar(150) NOT NULL,
     lusername varchar(100),
-    server varchar(250),
+    server varchar(100),
     fn text NOT NULL,
     lfn varchar(250) NOT NULL,
     family text NOT NULL,


### PR DESCRIPTION
A varchar(100)+varchar(250) key in UTF8 produces the following error in MySQL: 

ERROR 1071 (42000): Specified key was too long; max key length is 1000 bytes

I suppose server should be a varchar(100) like in vcard table.
