### PR TITLE
Delete weak ciphers and disable SSL2

### DIFF
--- a/apps/ejabberd/c_src/tls_drv.c
+++ b/apps/ejabberd/c_src/tls_drv.c
@@ -215,6 +215,7 @@ static SSL_CTX *hash_table_lookup(char *key_file, time_t *pmtime)
 
 static ErlDrvData tls_drv_start(ErlDrvPort port, char *buff)
 {
+   driver_lock_driver(port);
    tls_data *d = (tls_data *)driver_alloc(sizeof(tls_data));
    d->port = port;
    d->bio_read = NULL;

--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -231,6 +231,8 @@ load_drivers([Driver | Rest]) ->
     case erl_ddll:load_driver(ejabberd:get_so_path(), Driver) of
         ok ->
             load_drivers(Rest);
+        {error, permanent} ->
+            load_drivers(Rest);
         {error, already_loaded} ->
             load_drivers(Rest);
         {error, Reason} ->


### PR DESCRIPTION
This PR does not do much on my computer with OpenSSL v1.0.1e
# Before

SSL 2.0 is not supported.

SSL 3.0 ciphers:
['SSL_RSA_WITH_3DES_EDE_CBC_SHA','SSL_RSA_WITH_DES_CBC_SHA','SSL_RSA_WITH_RC4_128_SHA',
  'SSL_RSA_WITH_RC4_128_MD5']

TLS 1.0
['RSA_WITH_SEED_CBC_SHA',
 'TLS_RSA_WITH_CAMELLIA_256_CBC_SHA',
 'TLS_RSA_WITH_CAMELLIA_128_CBC_SHA',
 'TLS_RSA_WITH_AES_256_CBC_SHA',
 'TLS_RSA_WITH_AES_128_CBC_SHA',
 'TLS_RSA_WITH_3DES_EDE_CBC_SHA',
 'TLS_RSA_WITH_DES_CBC_SHA',
 'TLS_RSA_WITH_RC4_128_SHA',
 'TLS_RSA_WITH_RC4_128_MD5']
# After

SSL 2.0 is not supported.

SSL 3.0 ciphers:
['SSL_RSA_WITH_3DES_EDE_CBC_SHA','SSL_RSA_WITH_RC4_128_SHA','SSL_RSA_WITH_RC4_128_MD5']

Deleted ciphers:
['SSL_RSA_WITH_DES_CBC_SHA']

TLS 1.0 ciphers:
['TLS_RSA_WITH_SEED_CBC_SHA',
 'TLS_RSA_WITH_CAMELLIA_256_CBC_SHA',
 'TLS_RSA_WITH_CAMELLIA_128_CBC_SHA',
 'TLS_RSA_WITH_AES_256_CBC_SHA',
 'TLS_RSA_WITH_AES_128_CBC_SHA',
 'TLS_RSA_WITH_3DES_EDE_CBC_SHA',
 'TLS_RSA_WITH_RC4_128_SHA',
 'TLS_RSA_WITH_RC4_128_MD5']

Deleted ciphers:
['TLS_RSA_WITH_DES_CBC_SHA']
