### PR TITLE
Made tls_drv permanent.

### DIFF
--- a/apps/ejabberd/c_src/tls_drv.c
+++ b/apps/ejabberd/c_src/tls_drv.c
@@ -213,6 +213,7 @@ static SSL_CTX *hash_table_lookup(char *key_file, time_t *pmtime)
 
 static ErlDrvData tls_drv_start(ErlDrvPort port, char *buff)
 {
+   driver_lock_driver(port);
    tls_data *d = (tls_data *)driver_alloc(sizeof(tls_data));
    d->port = port;
    d->bio_read = NULL;

--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -231,6 +231,8 @@ load_drivers([Driver | Rest]) ->
     case erl_ddll:load_driver(ejabberd:get_so_path(), Driver) of
         ok ->
             load_drivers(Rest);
+        {error, permanent} ->
+            load_drivers(Rest);
         {error, already_loaded} ->
             load_drivers(Rest);
         {error, Reason} ->


### PR DESCRIPTION
This PR is a workaround for crashing under testing.
It also deletes an unused gen_server.
