### PR TITLE
Change vcard.server and vcard_search.server to varchar(150)

### DIFF
--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -71,7 +71,7 @@ CREATE INDEX i_despool USING BTREE ON spool(username);
 
 CREATE TABLE vcard (
     username varchar(150),
-    server varchar(100),
+    server varchar(150),
     vcard mediumtext NOT NULL,
     created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (username, server)
@@ -81,7 +81,7 @@ CREATE TABLE vcard (
 CREATE TABLE vcard_search (
     username varchar(150) NOT NULL,
     lusername varchar(100),
-    server varchar(250),
+    server varchar(150),
     fn text NOT NULL,
     lfn varchar(250) NOT NULL,
     family text NOT NULL,


### PR DESCRIPTION
The purpose of this change is to make the SQL script compatible with MySQL 5.1.70. Without this change the **CREATE TABLE vcard_search** query fails as follows:

```
ERROR 1071 (42000): Specified key was too long; max key length is 1000 bytes
```

This is because this table's primary key is composed of the columns **lusername** and **server**, resulting in a key that exceeds MySQL 5.1.70's length limitation. **varchar(150)** is the longest round number that I have tested succesfully.

The change is **vcard.server**'s type is to make it equal to **vcard_search.server**.
