### PR TITLE
Ignore {error,bad_module} in ejabberd_loglevel:set/1.

### DIFF
--- a/apps/ejabberd/src/ejabberd_loglevel.erl
+++ b/apps/ejabberd/src/ejabberd_loglevel.erl
@@ -68,8 +68,8 @@ set(Level) when is_integer(Level) ->
     set(Name);
 set(Level) ->
     Path = log_path(),
-    ok = lager:set_loglevel(lager_console_backend, Level),
-    ok = lager:set_loglevel(lager_file_backend, Path, Level).
+    lager:set_loglevel(lager_console_backend, Level),
+    lager:set_loglevel(lager_file_backend, Path, Level).
 
 set_custom(Module, Level) when is_integer(Level) ->
     {_, Name} = lists:keyfind(Level, 1, ?LOG_LEVELS),


### PR DESCRIPTION
Two errors reported:
- no match of right hand value {error,bad_module} in ejabberd_loglevel:set/1 line 71     <<<== This is where lager_console_backend log level is set.
- @lager_handler_watcher:98 Lager fatally failed to install handler lager_console_backend into lager_event, NOT retrying: old_shell

Here is the link to the log files generated (erl CRASH and ejabberd.log)
http://pastie.org/private/xgwkxlh6jj2sfc9tknigew
