### PR TITLE
Fix potential file ownership conflict in mongooseim script

### DIFF
--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -8,7 +8,7 @@ RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
 RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc
 RUNNER_LOG_DIR=$RUNNER_BASE_DIR/log
 # Note the trailing slash on $PIPE_DIR/
-PIPE_DIR=/tmp/mongooseim_pipe_`whoami`
+PIPE_DIR=/tmp/mongooseim_pipe_`whoami`/
 RUNNER_USER=
 
 EJABBERD_SO_PATH=`ls -dt $RUNNER_BASE_DIR/lib/ejabberd-2.1.8*/priv/lib | head -1`


### PR DESCRIPTION
In the situation where two users (`user1`, `user2`) on the same machine try to use the mongooseim script, the one who tries to launch second will receive the following error:

```
[user2@multiuser-machine MongooseIM]$ ./rel/mongooseim/bin/mongooseim start
mkdir: cannot create directory `/tmp//home/user2': Permission denied
```

This commit changes the PIPE_DIR temporary directory to a flat one, thereby avoiding conflicts on `/tmp/home`
