### PR TITLE
Always call erl_ddll:format_error on driver load failure

### DIFF
--- a/apps/ejabberd/src/ejabberd_tls.erl
+++ b/apps/ejabberd/src/ejabberd_tls.erl
@@ -67,7 +67,9 @@ start() ->
     case erl_ddll:load_driver(ejabberd:get_so_path(), tls_drv) of
 	ok -> ok;
 	{error, permanent} -> ok;
-	{error, already_loaded} -> ok
+	{error, already_loaded} -> ok;
+	{error, OtherError} ->
+	    erlang:error({cannot_load_tls_drv, erl_ddll:format_error(OtherError)})
     end.
 
 

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -61,7 +61,9 @@ start_link() ->
 init([]) ->
     case erl_ddll:load_driver(ejabberd:get_so_path(), ejabberd_zlib_drv) of
 	ok -> ok;
-	{error, already_loaded} -> ok
+	{error, already_loaded} -> ok;
+	{error, OtherError} ->
+	    erlang:error({cannot_load_ejabberd_zlib_drv, erl_ddll:format_error(OtherError)})
     end,
     Port = open_port({spawn, ejabberd_zlib_drv}, [binary]),
     {ok, Port}.
@@ -97,7 +99,9 @@ terminate(_Reason, Port) ->
 enable_zlib(SockMod, Socket, InflateSizeLimit) ->
     case erl_ddll:load_driver(ejabberd:get_so_path(), ejabberd_zlib_drv) of
 	ok -> ok;
-	{error, already_loaded} -> ok
+	{error, already_loaded} -> ok;
+	{error, OtherError} ->
+	    erlang:error({cannot_load_ejabberd_zlib_drv, erl_ddll:format_error(OtherError)})
     end,
     Port = open_port({spawn, ejabberd_zlib_drv}, [binary]),
     {ok, #zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port,

--- a/apps/stringprep/src/stringprep.erl
+++ b/apps/stringprep/src/stringprep.erl
@@ -65,7 +65,9 @@ init([]) ->
               end,
     case erl_ddll:load_driver(DrvPath, stringprep_drv) of
         ok -> ok;
-        {error, already_loaded} -> ok
+        {error, already_loaded} -> ok;
+        {error, OtherError} ->
+            erlang:error({cannot_load_stringprep_drv, erl_ddll:format_error(OtherError)})
     end,
     Port = open_port({spawn, stringprep_drv}, [binary]),
     register(?STRINGPREP_PORT, Port),


### PR DESCRIPTION
This is the difference between:

```
no case clause matching {error,{open_error,-10}}
```

and

```
{cannot_load_stringprep_drv,"dlopen(/Users/magnus/src/MongooseIM/dev/mongooseim_node1/lib/stringprep-1.0/priv/lib/stringprep_drv.so, 2): no suitable image found.  Did find:\n\t/Users/magnus/src/MongooseIM/dev/mongooseim_node1/lib/stringprep-1.0/priv/lib/stringprep_drv.so: mach-o, but wrong architecture"}
```

The latter message helped me find and fix the problem quickly.
