### PR TITLE
Add stop_listeners call in ejabberd_app

### DIFF
--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -79,6 +79,7 @@ start(_, _) ->
 %% This function is called when an application is about to be stopped,
 %% before shutting down the processes of the application.
 prep_stop(State) ->
+    ejabberd_listener:stop_listeners(),
     stop_modules(),
     broadcast_c2s_shutdown(),
     mod_websockets:stop(),


### PR DESCRIPTION
In rare cases it can be observed that after `stop_modules()` call some clients actually manage to create new sessions before closing the node. Can be problematic when using Redis for session storage.
