### PR TITLE
Add `make reload` task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clean: rebar
 quick_compile: rebar
 	./rebar compile skip_deps=true
 
+reload: quick_compile
+	@E=`ls ./rel/mongooseim/lib/ | grep ejabberd-2 | sort -r | head -n 1` ;\
+	rsync -uW ./apps/ejabberd/ebin/*beam ./rel/mongooseim/lib/$$E/ebin/ ;\
+
 ct: deps quick_compile
 	@if [ "$(SUITE)" ]; then ./rebar -q ct suite=$(SUITE) skip_deps=true;\
 	else ./rebar -q ct skip_deps=true; fi


### PR DESCRIPTION
`make reload` will perform a `quick_compile` and then rsync all files under `apps/ejabberd/ebin` into the highest-versioned `ejabberd-2*` directory in `./rel/mongooseim/lib/`. 

If the `reloader` app is running on the mongooseim node, then the relevant modules will get reloaded automagically. If not, then the shell command `l(ModuleName)` is your friend.

Currently, only `apps/ejabberd` is considered.
