### PR TITLE
Fix small errors in auth modules

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth_anonymous.erl
+++ b/apps/ejabberd/src/ejabberd_auth_anonymous.erl
@@ -53,10 +53,10 @@
 	 remove_user/3,
 	 store_type/1,
 	 plain_password_required/0,
-	 get_vh_registered_users/2,        % not impl
-     get_vh_registered_users_number/1, % not impl
-     get_vh_registered_users_number/2, % not impl
-     get_password_s/2                  % not impl
+	 get_vh_registered_users/2,       
+	 get_vh_registered_users_number/1,
+	 get_vh_registered_users_number/2,
+	 get_password_s/2                  % not impl
 ]).
 
 -include("ejabberd.hrl").
@@ -322,10 +322,11 @@ plain_password_required() ->
     false.
 
 store_type(_) ->
-	plain.
+    plain.
 
+get_vh_registered_users_number(_Server) -> 0.
+
+get_vh_registered_users_number(_Server, _Opts) -> 0.
 
 %% @doc gen_auth unimplemented callbacks
-get_vh_registered_users_number(_Server) -> erlang:error(not_implemented).
-get_vh_registered_users_number(_Server, _Opts) -> erlang:error(not_implemented).
 get_password_s(_User, _Server) -> erlang:error(not_implemented).

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -147,7 +147,7 @@ set_password(User, Server, Password) ->
 	    {error, invalid_jid};
 	true ->
 	    F = fun() ->
-			Password2 = case scram:enabled() of
+			Password2 = case scram:enabled(Server) of
 					true -> scram:password_to_scram(Password, scram:iterations(Server));
 					false -> Password
 				    end,


### PR DESCRIPTION
`auth_internal` used `scram:enabled/0` instead of `scram:enabled/1`.
`auth_anonymous` returned `not_implemented` when requesting registered user count. It broke `mongooseimctl` functionality and it is perfectly fine to return 0 in such case.
