### PR TITLE
Change `ejabberdctl` leftovers to `mongooseimctl`, closes #258

### DIFF
--- a/apps/ejabberd/src/ejabberd_commands.erl
+++ b/apps/ejabberd/src/ejabberd_commands.erl
@@ -133,7 +133,7 @@
 %%% That's all! Now when your module is started, the command will be
 %%% registered and any frontend can access it. For example:
 %%%
-%%% <pre>$ ejabberdctl help pow
+%%% <pre>$ mongooseimctl help pow
 %%%
 %%%   Command Name: pow
 %%%
@@ -149,7 +149,7 @@
 %%% This is an example command. The formula is:
 %%%  power = base ^ exponent
 %%%
-%%% $ ejabberdctl pow 3 4
+%%% $ mongooseimctl pow 3 4
 %%% 81
 %%% </pre>
 %%%
@@ -166,39 +166,21 @@
 %%% == Frontend to ejabberd commands ==
 %%%
 %%% Currently there are two frontends to ejabberd commands: the shell
-%%% script {@link ejabberd_ctl. ejabberdctl}, and the XML-RPC server
+%%% script {@link ejabberd_ctl. mongooseimctl}, and the XML-RPC server
 %%% ejabberd_xmlrpc.
 %%%
 %%%
-%%% === ejabberdctl as a frontend to ejabberd commands ===
+%%% === mongooseimctl as a frontend to ejabberd commands ===
 %%%
-%%% It is possible to use ejabberdctl to get documentation of any
-%%% command. But ejabberdctl does not support all the argument types
+%%% It is possible to use mongooseimctl to get documentation of any
+%%% command. But mongooseimctl does not support all the argument types
 %%% allowed in ejabberd commands, so there are some ejabberd commands
-%%% that cannot be executed using ejabberdctl.
+%%% that cannot be executed using mongooseimctl.
 %%%
-%%% Also note that the ejabberdctl shell administration script also
-%%% manages ejabberdctl commands, which are unrelated to ejabberd
-%%% commands and can only be executed using ejabberdctl.
+%%% Also note that the mongooseimctl shell administration script also
+%%% manages mongooseimctl commands, which are unrelated to ejabberd
+%%% commands and can only be executed using mongooseimctl.
 %%%
-%%%
-%%% === ejabberd_xmlrpc as a frontend to ejabberd commands ===
-%%%
-%%% ejabberd_xmlrpc provides an XML-RPC server to execute ejabberd commands.
-%%% ejabberd_xmlrpc is a contributed module published in ejabberd-modules SVN.
-%%%
-%%% Since ejabberd_xmlrpc does not provide any method to get documentation
-%%% of the ejabberd commands, please use ejabberdctl to know which
-%%% commands are available, and their usage.
-%%%
-%%% The number and format of the arguments provided when calling an
-%%% ejabberd command must match the definition of that command. Please
-%%% make sure the XML-RPC call provides the required arguments, with
-%%% the specified format. The order of the arguments in an XML-RPC
-%%% call is not important, because all the data is tagged and will be
-%%% correctly prepared by ejabberd_xmlrpc before executing the ejabberd
-%%% command.
-
 %%% TODO: consider this feature:
 %%% All commands are catched. If an error happens, return the restuple:
 %%%   {error, flattened error string}

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -89,7 +89,7 @@
                     | {watchdog_admins, _}
                     | {watchdog_large_heap, _}
                     | {registration_timeout, integer()}
-                    | {ejabberdctl_access_commands, list()}
+                    | {mongooseimctl_access_commands, list()}
                     | {loglevel, _}
                     | {max_fsm_queue, _}
                     | host_term().
@@ -526,8 +526,8 @@ process_term(Term, State) ->
             add_option(watchdog_large_heap, LH, State);
         {registration_timeout, Timeout} ->
             add_option(registration_timeout, Timeout, State);
-        {ejabberdctl_access_commands, ACs} ->
-            add_option(ejabberdctl_access_commands, ACs, State);
+        {mongooseimctl_access_commands, ACs} ->
+            add_option(mongooseimctl_access_commands, ACs, State);
         {loglevel, Loglevel} ->
             ejabberd_loglevel:set(Loglevel),
             State;

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -26,11 +26,11 @@
 
 %%% @headerfile "ejabberd_ctl.hrl"
 
-%%% @doc Management of ejabberdctl commands and frontend to ejabberd commands.
+%%% @doc Management of mongooseimctl commands and frontend to ejabberd commands.
 %%%
-%%% An ejabberdctl command is an abstract function identified by a
+%%% An mongooseimctl command is an abstract function identified by a
 %%% name, with a defined number of calling arguments, that can be
-%%% defined in any Erlang module and executed using ejabberdctl
+%%% defined in any Erlang module and executed using mongooseimctl
 %%% administration script.
 %%%
 %%% Note: strings cannot have blankspaces
@@ -109,7 +109,7 @@ init() ->
 
 
 %%-----------------------------
-%% ejabberdctl Command managment
+%% mongooseimctl Command managment
 %%-----------------------------
 
 -spec register_commands(CmdDescs :: [tuple()] | tuple(),
@@ -252,7 +252,7 @@ process2(Args, Auth, AccessCommands) ->
 
 -spec get_accesscommands() -> [char() | tuple()].
 get_accesscommands() ->
-    case ejabberd_config:get_local_option(ejabberdctl_access_commands) of
+    case ejabberd_config:get_local_option(mongooseimctl_access_commands) of
         ACs when is_list(ACs) -> ACs;
         _ -> []
     end.
@@ -278,12 +278,12 @@ try_run_ctp(Args, Auth, AccessCommands) ->
     catch
         exit:Why ->
             print_usage(),
-            {io_lib:format("Error in ejabberd ctl process: ~p", [Why]), ?STATUS_USAGE};
+            {io_lib:format("Error in mongooseimctl process: ~p", [Why]), ?STATUS_USAGE};
         Error:Why ->
             %% In this case probably ejabberd is not started, so let's show Status
             process(["status"]),
             ?PRINT("~n", []),
-            {io_lib:format("Error in ejabberd ctl process: '~p' ~p", [Error, Why]), ?STATUS_USAGE}
+            {io_lib:format("Error in mongooseimctl process: '~p' ~p", [Error, Why]), ?STATUS_USAGE}
     end.
 
 
@@ -554,26 +554,26 @@ print_usage() ->
 print_usage(HelpMode, MaxC, ShCode) ->
     AllCommands =
         [
-         {"status", [], "Get ejabberd status"},
-         {"stop", [], "Stop ejabberd"},
-         {"restart", [], "Restart ejabberd"},
-         {"help", ["[--tags [tag] | com?*]"], "Show help (try: ejabberdctl help help)"},
+         {"status", [], "Get MongooseIM status"},
+         {"stop", [], "Stop MongooseIM"},
+         {"restart", [], "Restart MongooseIM"},
+         {"help", ["[--tags [tag] | com?*]"], "Show help (try: mongooseimctl help help)"},
          {"mnesia", ["[info]"], "show information of Mnesia system"}] ++
         get_list_commands() ++
         get_list_ctls(),
 
     ?PRINT(
-       ["Usage: ", ?B("ejabberdctl"), " [--node ", ?U("nodename"), "] [--auth ",
+       ["Usage: ", ?B("mongooseimctl"), " [--node ", ?U("nodename"), "] [--auth ",
         ?U("user"), " ", ?U("host"), " ", ?U("password"), "] ",
         ?U("command"), " [", ?U("options"), "]\n"
         "\n"
-        "Available commands in this ejabberd node:\n"], []),
+        "Available commands in this MongooseIM node:\n"], []),
     print_usage_commands(HelpMode, MaxC, ShCode, AllCommands),
     ?PRINT(
        ["\n"
         "Examples:\n"
-        "  ejabberdctl restart\n"
-        "  ejabberdctl --node ejabberd@host restart\n"],
+        "  mongooseimctl restart\n"
+        "  mongooseimctl --node mongooseim@host restart\n"],
        []).
 
 
@@ -756,8 +756,8 @@ print_usage_tags(Tag, MaxC, ShCode) ->
 
 print_usage_help(MaxC, ShCode) ->
     LongDesc =
-        ["The special 'help' ejabberdctl command provides help of ejabberd commands.\n\n"
-         "The format is:\n  ", ?B("ejabberdctl"), " ", ?B("help"), " [", ?B("--tags"), " ", ?U("[tag]"), " | ", ?U("com?*"), "]\n\n"
+        ["The special 'help' mongooseimctl command provides help of MongooseIM commands.\n\n"
+         "The format is:\n  ", ?B("mongooseimctl"), " ", ?B("help"), " [", ?B("--tags"), " ", ?U("[tag]"), " | ", ?U("com?*"), "]\n\n"
          "The optional arguments:\n"
          "  ",?B("--tags"),"      Show all tags and the names of commands in each tag\n"
          "  ",?B("--tags"), " ", ?U("tag"),"  Show description of commands in this tag\n"
@@ -767,18 +767,18 @@ print_usage_help(MaxC, ShCode) ->
          "              and * to match several characters.\n"
          "\n",
          "Some example usages:\n",
-         "  ejabberdctl help\n",
-         "  ejabberdctl help --tags\n",
-         "  ejabberdctl help --tags accounts\n",
-         "  ejabberdctl help register\n",
-         "  ejabberdctl help regist*\n",
+         " mongooseimctl help\n",
+         " mongooseimctl help --tags\n",
+         " mongooseimctl help --tags accounts\n",
+         " mongooseimctl help register\n",
+         " mongooseimctl help regist*\n",
          "\n",
-         "Please note that 'ejabberdctl help' shows all ejabberd commands,\n",
-         "even those that cannot be used in the shell with ejabberdctl.\n",
+         "Please note that 'mongooseimctl help' shows all MongooseIM commands,\n",
+         "even those that cannot be used in the shell with mongooseimctl.\n",
          "Those commands can be identified because the description starts with: *"],
     ArgsDef = [],
     C = #ejabberd_commands{
-      desc = "Show help of ejabberd commands",
+      desc = "Show help of MongooseIM commands",
       longdesc = LongDesc,
       args = ArgsDef,
       result = {help, string}},
@@ -883,7 +883,7 @@ print_usage_command(Cmd, C, MaxC, ShCode) ->
 
     NoteEjabberdctl = case is_supported_args(ArgsDef) of
                           true -> "";
-                          false -> ["  ", ?B("Note:"), " This command cannot be executed using ejabberdctl. Try ejabberd_xmlrpc.\n\n"]
+                          false -> ["  ", ?B("Note:"), " This command cannot be executed using mongooseimctl.\n\n"]
                       end,
 
     ?PRINT(["\n", NameFmt, "\n", ArgsFmt, "\n", ReturnsFmt, "\n\n", XmlrpcFmt, TagsFmt, "\n\n", DescFmt, "\n\n", LongDescFmt, NoteEjabberdctl], []).

--- a/apps/ejabberd/src/mod_admin_extra_private.erl
+++ b/apps/ejabberd/src/mod_admin_extra_private.erl
@@ -63,8 +63,8 @@ commands() ->
 %%%
 
 %% Example usage:
-%% $ ejabberdctl private_set badlop localhost "\<aa\ xmlns=\'bb\'\>Cluth\</aa\>"
-%% $ ejabberdctl private_get badlop localhost aa bb
+%% $ mongooseimctl private_set badlop localhost "\<aa\ xmlns=\'bb\'\>Cluth\</aa\>"
+%% $ mongooseimctl private_get badlop localhost aa bb
 %% <aa xmlns='bb'>Cluth</aa>
 
 -spec private_get(ejabberd:user(), ejabberd:server(), jlib:xmlel(),

--- a/apps/ejabberd/src/mod_admin_extra_srg.erl
+++ b/apps/ejabberd/src/mod_admin_extra_srg.erl
@@ -59,7 +59,7 @@ commands() ->
                            "put  \\ \" around the argument and\nseparate the "
                            "identifiers with \\ \\ n\n"
                            "For example:\n"
-                           "  ejabberdctl srg_create group3 localhost "
+                           "  mongooseimctl srg_create group3 localhost "
                            "name desc \\\"group1\\\\ngroup2\\\"",
                            module = ?MODULE, function = srg_create,
                            args = [{group, binary}, {host, binary},


### PR DESCRIPTION
Changed all occurences of `ejabberdctl` into `mongooseimctl` that might be visible to end user.
