### PR TITLE
Fix error badarg erlang:list_to_binary

### DIFF
--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -1,4 +1,4 @@
-{hosts, "[ \"localhost2\", \"michał\"]"}.
+{hosts, "[ \"localhost2\", \"michal\"]"}.
 {outgoing_s2s_port, 5269}.
 {odbc_server, ""}.
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.


### PR DESCRIPTION
non latin1 character in host name cause badarg error

$ make devrel
...
building node1
(cd rel && ../rebar generate -f target_dir=../dev/mongooseim_node1 overlay_vars=./reltool_vars/node1_vars.config)
==> rel (generate)
cp apps/ejabberd/src/*.erl `ls -dt dev/mongooseim_node1/lib/ejabberd-2.1.8*/ebin/ | head -1`
cp -R `dirname /usr/lib/erlang/bin/erl`/../lib/tools-* dev/mongooseim_node1/lib/
building node2
(cd rel && ../rebar generate -f target_dir=../dev/mongooseim_node2 overlay_vars=./reltool_vars/node2_vars.config)
==> rel (generate)
ERROR: Unexpected error: {'EXIT',
                             {badarg,
                                 [{erlang,list_to_binary,
                                      [[91,32,34,108,111,99,97,108,104,111,
                                        115,116,50,34,44,32,34,109,105,99,104,
                                        97,322,34,93]],
                                      []},
                                  {rebar_templater,resolve_variables,2,[]},
                                  {rebar_reltool,process_overlay,2,[]},
                                  {rebar_reltool,generate,2,[]},
                                  {rebar_core,run_modules,4,[]},
                                  {rebar_core,execute,5,[]},
                                  {rebar_core,process_dir1,6,[]},
                                  {rebar_core,process_commands,2,[]}]}}
ERROR: generate failed while processing /home/algis/repos/MongooseIM/rel: rebar_abort
make: *** [node2] Error 1

versions:
Linux alg 3.13.0-36-generic #63-Ubuntu SMP Wed Sep 3 21:30:07 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
Erlang/OTP 17 [erts-6.0] [source-07b8f44] [64-bit] [smp:4:4] [async-threads:10] [kernel-poll:false]