### PR TITLE
Update mod_sic according to xep-0279 version 0.2

### DIFF
--- a/apps/ejabberd/src/mod_sic.erl
+++ b/apps/ejabberd/src/mod_sic.erl
@@ -83,7 +83,7 @@ get_ip({User, Server, Resource},
                     #xmlel{name = <<"ip">>,
                         children = [#xmlcdata{content = list_to_binary(inet_parse:ntoa(IP))}]},
                     #xmlel{name = <<"port">>,
-                        children = [#xmlcdata{content = list_to_binary(integer_to_list(Port))}]}
+                        children = [#xmlcdata{content = integer_to_binary(Port)}]}
 		       ]
 	        }]};
 	_ ->


### PR DESCRIPTION
The specification for xep-0279 has changed: http://xmpp.org/extensions/xep-0279.html, so I modified mod_sic to reflect the changes.

If accepted, an update of https://github.com/esl/ejabberd_tests/blob/master/tests/sic_SUITE.erl is ready to follow as a pull request also!
