### PR TITLE
Reject clients using SSL connection. Allow only TLS.

### DIFF
--- a/apps/ejabberd/c_src/tls_drv.c
+++ b/apps/ejabberd/c_src/tls_drv.c
@@ -452,9 +452,15 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 	 SSL_set_bio(d->ssl, d->bio_read, d->bio_write);
 
 	 if (command == SET_CERTIFICATE_FILE_ACCEPT) {
+            SSL_set_options(
+               d->ssl,
+               SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 	    SSL_set_accept_state(d->ssl);
 	 } else {
-	    SSL_set_connect_state(d->ssl);
+            SSL_set_options(
+               d->ssl,
+               SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+            SSL_set_connect_state(d->ssl);
 	 }
 	 break;
       }


### PR DESCRIPTION
This change is motivated by the article on online security:
http://googleonlinesecurity.blogspot.de/2014/10/this-poodle-bites-exploiting-ssl-30.html

This should be merged along with esl/ejabberd_tests#84 and esl/escalus#45.
