### PR TITLE
fix compatibility issues with OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,7 @@ $(DEVNODES): rebar deps compile deps_dev
 	@echo "building $@"
 	(cd rel && ../rebar generate -f target_dir=../dev/mongooseim_$@ overlay_vars=./reltool_vars/$@_vars.config)
 	cp apps/ejabberd/src/*.erl `ls -dt dev/mongooseim_$@/lib/ejabberd-2.1.8*/ebin/ | head -1`
-ifeq ($(shell uname), Linux)
-	cp -R `dirname $(shell readlink -f $(shell which erl))`/../lib/tools-* dev/mongooseim_$@/lib/
-else
-	cp -R `which erl`/../../lib/tools-* dev/mongooseim_$@/lib/
-endif
+	cp -R `dirname $(shell ./readlink.sh $(shell which erl))`/../lib/tools-* dev/mongooseim_$@/lib/
 
 deps_dev:
 	mkdir -p dev

--- a/readlink.sh
+++ b/readlink.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# used for MacOS, because readlink -f does not work here.
+# see http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+
+TARGET_FILE=$1
+
+cd `dirname $TARGET_FILE`
+TARGET_FILE=`basename $TARGET_FILE`
+
+# Iterate down a (possible) chain of symlinks
+while [ -L "$TARGET_FILE" ]
+do
+    TARGET_FILE=`readlink $TARGET_FILE`
+    cd `dirname $TARGET_FILE`
+    TARGET_FILE=`basename $TARGET_FILE`
+done
+
+# Compute the canonicalized name by finding the physical path
+# for the directory we're in and appending the target file.
+PHYS_DIR=`pwd -P`
+RESULT=$PHYS_DIR/$TARGET_FILE
+echo $RESULT


### PR DESCRIPTION
This fix ensures we're able to find the correct erlang environment no matter if linux or OS X, no matter if installed from esl distribution or homebrew.
