### PR TITLE
Preserve initial `from` and `to` attributes in BOSH session state

### DIFF
--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -54,7 +54,9 @@
 -type cached_response() :: {rid(), erlang:timestamp(), jlib:xmlel()}.
 -type rid() :: pos_integer().
 
--record(state, {c2s_pid         :: pid(),
+-record(state, {from            :: binary(),
+                to              :: binary(),
+                c2s_pid         :: pid(),
                 handlers = []   :: [{rid(), reference(), pid()}],
                 %% Elements buffered for sending to the client.
                 pending = []    :: [jlib:xmlstreamel()],
@@ -803,22 +805,30 @@ return_surplus_handlers(SName, #state{pending = Pending} = S)
     return_surplus_handlers(normal, NS).
 
 
--spec bosh_unwrap(EventTag :: mod_bosh:event_type(), jlib:xmlel(), state()
-                 ) -> {[jlib:xmlstreamel()], state()}.
+-spec bosh_unwrap(EventTag :: mod_bosh:event_type(), jlib:xmlel(), state())
+   -> {[jlib:xmlstreamel()], state()}.
 bosh_unwrap(StreamEvent, Body, #state{} = S)
-       when StreamEvent =:= streamstart;
-            StreamEvent =:= restart ->
+  when StreamEvent =:= streamstart ->
     Wait = min(get_attr(<<"wait">>, Body, S#state.wait), mod_bosh:get_max_wait()),
     Hold = get_attr(<<"hold">>, Body, S#state.hold),
     ClientAcks = get_client_acks(StreamEvent, Body, S#state.client_acks),
-    E = stream_start(exml_query:attr(Body, <<"from">>),
-                     exml_query:attr(Body, <<"to">>)),
+    From = exml_query:attr(Body, <<"from">>),
+    To = exml_query:attr(Body, <<"to">>),
+    E = stream_start(From, To),
     {[E], record_set(S, [{#state.wait, Wait},
                          {#state.hold, Hold},
-                         {#state.client_acks, ClientAcks}])};
+                         {#state.client_acks, ClientAcks},
+                         {#state.from, From},
+                         {#state.to, To}])};
+
+bosh_unwrap(StreamEvent, _Body, #state{} = S)
+  when StreamEvent =:= restart ->
+    {[stream_start(S#state.from, S#state.to)], S};
+
 bosh_unwrap(streamend, Body, State) ->
     {Els, NewState} = bosh_unwrap(normal, Body, State),
     {Els ++ [#xmlstreamend{name = <<>>}], NewState};
+
 bosh_unwrap(normal, Body, #state{sid = Sid} = State) ->
     Sid = exml_query:attr(Body, <<"sid">>),
     ?NS_HTTPBIND = exml_query:attr(Body, <<"xmlns">>),


### PR DESCRIPTION
The XEP[1](http://xmpp.org/extensions/xep-0124.html) states:

```
The <body/> element of the first request SHOULD possess the following
attributes (they SHOULD NOT be included in any other requests [...]):

- 'to' -- This attribute specifies the target domain of the first stream.

[...]

The <body/> element of the first request MAY also possess
a 'from' attribute.
```

This fixes stream restart problem reported in #306.
