### PR TITLE
Fix inactivity timer not being set correctly

### DIFF
--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -387,8 +387,9 @@ handle_info({wait_timeout, {Rid, Pid}}, SName,
         false ->
             {next_state, SName, S};
         {value, {Rid, _, Pid}, NewHandlers} ->
-            NS = send_to_handler({Rid, Pid}, [], S),
-            {next_state, SName, NS#state{handlers = NewHandlers}}
+            NS = send_to_handler({Rid, Pid}, [],
+                                 S#state{handlers = NewHandlers}),
+            {next_state, SName, NS}
     end;
 handle_info(Info, SName, State) ->
     ?DEBUG("Unhandled info in '~s' state: ~w~n", [SName, Info]),


### PR DESCRIPTION
Don't defer updating #state.handlers until after the call to send_to_handler/3.
send_to_handler/3 calls send_wrapped_to_handler/3 which only sets up the inactivity timer if #state.handlers is empty!

(cherry picked from commit 7aeac8eddce2fbd42b5d0b8e3a77162f9fc31bde)