### PR TITLE
Fix source of cowoby dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
   {redo, ".*", {git, "git://github.com/JacobVorreuter/redo.git", "7c7eaef"}},
   {exml, "2.1.5", {git, "git://github.com/esl/exml.git", "2.1.5"}},
   {lager, "2.0.3", {git, "git://github.com/basho/lager.git", "2.0.3"}},
-  {cowboy, "0.9.0", {git, "git://github.com/extend/cowboy.git", "0.9.0"}},
+  {cowboy, "0.9.0", {git, "git://github.com/ninenines/cowboy.git", "0.9.0"}},
   {folsom, ".*", {git, "git://github.com/boundary/folsom.git", "4824aec693c7f284363f19d999289952ec4ed586"}},
   {mochijson2, ".*", {git, "git://github.com/bjnortier/mochijson2.git", {branch, "master"}}},
   {alarms, ".*", {git, "git://github.com/chrzaszcz/alarms.git", {branch, "master"}}},


### PR DESCRIPTION
"extend" has been changed to "ninenines" and even though the name is
redirects to ninenines it makes rebar checkout the master repo.

master doesn't build for me without this change.