### PR TITLE
Fix bosh response when origin isn't set

### DIFF
--- a/apps/ejabberd/src/mod_bosh.erl
+++ b/apps/ejabberd/src/mod_bosh.erl
@@ -186,7 +186,7 @@ init(_Transport, Req, _Opts) ->
 
 -spec info(info(), req(), rstate()) -> {'ok',req(),_}.
 info(accept_options, Req, State) ->
-    {Origin, Req2} = cowboy_req:header(<<"origin">>, Req),
+    {Origin, Req2} = cowboy_req:header(<<"origin">>, Req, <<"*">>),
     Headers = ac_all(Origin),
     ?DEBUG("OPTIONS response: ~p~n", [Headers]),
     {ok, strip_ok(cowboy_req:reply(200, Headers, <<>>, Req2)), State};


### PR DESCRIPTION
If origin isn't explicitly it should just be *. The current behavior is
to not give a response at all.

You can test with `curl -X OPTIONS -v 'http://localhost:5280/http-bind'`. Without this commit you will not get a response from the server.