### PR TITLE
No rel required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,15 @@ test_preset: test_deps
 
 run: deps compile quickrun
 
-quickrun:
-	erl -sname ejabberd -setcookie ejabberd -pa deps/*/ebin apps/*/ebin -config rel/files/app.run.config -s ejabberd -s sync
+quickrun: etc/ejabberd.cfg
+	erl -sname mongooseim@localhost -setcookie ejabberd -pa deps/*/ebin apps/*/ebin -config rel/files/app.config -s ejabberd
+
+etc/ejabberd.cfg:
+	erl -pa deps/mustache/ebin -noshell -eval \
+		'{ok, Template} = file:read_file("rel/files/ejabberd.cfg"), \
+		{ok, Vars} = file:consult("rel/vars.config"), \
+		file:write_file("etc/ejabberd.cfg", mustache:render(binary_to_list(Template), dict:from_list(Vars))), \
+		init:stop()'
 
 cover_test: test_deps
 	cd test/ejabberd_tests; make cover_test

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,8 @@ quickrun: etc/ejabberd.cfg
 	erl -sname mongooseim@localhost -setcookie ejabberd -pa deps/*/ebin apps/*/ebin -config rel/files/app.config -s ejabberd
 
 etc/ejabberd.cfg:
-	erl -pa deps/mustache/ebin -noshell -eval \
-		'{ok, Template} = file:read_file("rel/files/ejabberd.cfg"), \
-		{ok, Vars} = file:consult("rel/vars.config"), \
-		file:write_file("etc/ejabberd.cfg", mustache:render(binary_to_list(Template), dict:from_list(Vars))), \
-		init:stop()'
+	tools/generate_cfg.es etc/ejabberd.cfg
+
 
 cover_test: test_deps
 	cd test/ejabberd_tests; make cover_test

--- a/rebar.config
+++ b/rebar.config
@@ -31,7 +31,8 @@
   {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
 
   {pa, ".*", {git, "git://github.com/lavrin/pa.git", "c616d3f9"}},
-  {ecoveralls, ".*", {git, "git://github.com/nifoc/ecoveralls.git", "40fa0d2f2057fff29e964f94fccf6ef2f13d34d2"}}
+  {ecoveralls, ".*", {git, "git://github.com/nifoc/ecoveralls.git", "40fa0d2f2057fff29e964f94fccf6ef2f13d34d2"}},
+  {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", "d0246fe143058b6404f66cf99fece3ff6e87b7ed"}}
  ]}.
 
 {ct_extra_params, "-pa apps/ejabberd/ebin "

--- a/tools/generate_cfg.es
+++ b/tools/generate_cfg.es
@@ -1,0 +1,8 @@
+#!/usr/bin/env escript
+%%! -pa deps/mustache/ebin
+
+main([OutputFilePath]) ->
+    {ok, Template} = file:read_file("rel/files/ejabberd.cfg"),
+    {ok, Vars} = file:consult("rel/vars.config"),
+    CfgFile = mustache:render(binary_to_list(Template), dict:from_list(Vars)),
+    file:write_file(OutputFilePath, CfgFile).


### PR DESCRIPTION
`make quickrun` starts Mongoose node without the need of creating release.