### PR TITLE
[DON'T MERGE] Fix `mongooseimctl started`

### DIFF
--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -57,7 +57,7 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
 [{sys, [
         {lib_dirs, ["../apps", "../deps"]},
         {incl_cond, exclude},
-        {rel, "mongooseim", "", [mongoose | AppsToRun]},
+        {rel, "mongooseim", "", [mongooseim | AppsToRun]},
         {rel, "start_clean", "", [kernel,stdlib]},
         {boot_rel, "mongooseim"},
         {profile, embedded},
@@ -65,7 +65,7 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
         {excl_sys_filters, ["^bin/.*",
                             "^erts.*/bin/(dialyzer|typer)"]},
 
-        {app, mongoose, [{incl_cond, include}, {lib_dir, ".."}]}
+        {app, mongooseim, [{incl_cond, include}, {lib_dir, ".."}]}
        ] ++ IncludeApps},
 
 


### PR DESCRIPTION
`reltool.config.script` referenced application `mongoose` instead
of `mongooseim`. Such application doesn't exist, hence wasn't included
in the release.
Since `ejabberd_ctl.erl` used by `mongooseimctl` looks in
`application:loaded_applications/0` for name `mongooseim`,
the subcommand `started` looped until all retries were exhausted and
always returned a failure, irrelevant of the fact that the server was
already running in the background.