### PR TITLE
Fix get_loglevel

### DIFF
--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -94,8 +94,7 @@ commands() ->
                         module = ejabberd_loglevel, function = get,
                         args = [],
                         result = {leveltuple, {tuple, [{levelnumber, integer},
-                                                       {levelatom, atom},
-                                                       {leveldesc, string}
+                                                       {levelatom, atom}
                                                       ]}}},
 
 %     #ejabberd_commands{name = update_list, tags = [server],


### PR DESCRIPTION
(cherry picked from commit c7d41b8d2736bb39b0b5e16b2945a7e2244d454a)