### PR TITLE
Remove obsolete XEP-0091 timestamp

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1768,9 +1768,9 @@ process_presence_probe(From, To, StateData) ->
                     Packet = xml:append_subtags(
                                StateData#state.pres_last,
                                %% To is the one sending the presence (the target of the probe)
-                               [jlib:timestamp_to_xml(Timestamp, utc, To, <<>>),
+                               [jlib:timestamp_to_xml(Timestamp, utc, To, <<>>)]),
                                 %% TODO: Delete the next line once XEP-0091 is Obsolete
-                                jlib:timestamp_to_xml(Timestamp)]),
+                                %% jlib:timestamp_to_xml(Timestamp)]),
                     case privacy_check_packet(StateData, To, From, Packet, out) of
                         deny ->
                             ok;
@@ -2957,8 +2957,9 @@ add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
         false ->
             %% TODO: Delete the next element once XEP-0091 is Obsolete
             TimeStampLegacyXML = timestamp_legacy_xml(Server, Time),
-            TimeStampXML = jlib:timestamp_to_xml(Time),
-            xml:append_subtags(Packet, [TimeStampLegacyXML, TimeStampXML]);
+            %% TimeStampXML = jlib:timestamp_to_xml(Time),
+            %% xml:append_subtags(Packet, [TimeStampLegacyXML, TimeStampXML]);
+            xml:append_subtags(Packet, [TimeStampLegacyXML]);
         _ ->
             Packet
     end.

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2953,13 +2953,13 @@ add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     Time = {D,{H,M,S, Micro}},
     case xml:get_subtag(Packet, <<"delay">>) of
         false ->
-            TimeStampLegacyXML = timestamp_legacy_xml(Server, Time),
-            xml:append_subtags(Packet, [TimeStampLegacyXML]);
+            TimeStampXML = timestamp_xml(Server, Time),
+            xml:append_subtags(Packet, [TimeStampXML]);
         _ ->
             Packet
     end.
 
-timestamp_legacy_xml(Server, Time) ->
+timestamp_xml(Server, Time) ->
     FromJID = jlib:make_jid(<<>>, Server, <<>>),
     jlib:timestamp_to_xml(Time, utc, FromJID, <<"SM Storage">>).
 

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1769,8 +1769,6 @@ process_presence_probe(From, To, StateData) ->
                                StateData#state.pres_last,
                                %% To is the one sending the presence (the target of the probe)
                                [jlib:timestamp_to_xml(Timestamp, utc, To, <<>>)]),
-                                %% TODO: Delete the next line once XEP-0091 is Obsolete
-                                %% jlib:timestamp_to_xml(Timestamp)]),
                     case privacy_check_packet(StateData, To, From, Packet, out) of
                         deny ->
                             ok;
@@ -2955,10 +2953,7 @@ add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     Time = {D,{H,M,S, Micro}},
     case xml:get_subtag(Packet, <<"delay">>) of
         false ->
-            %% TODO: Delete the next element once XEP-0091 is Obsolete
             TimeStampLegacyXML = timestamp_legacy_xml(Server, Time),
-            %% TimeStampXML = jlib:timestamp_to_xml(Time),
-            %% xml:append_subtags(Packet, [TimeStampLegacyXML, TimeStampXML]);
             xml:append_subtags(Packet, [TimeStampLegacyXML]);
         _ ->
             Packet

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -52,7 +52,6 @@
          iq_query_or_response_info/1,
          iq_to_xml/1,
          parse_xdata_submit/1,
-         timestamp_to_iso/1, % TODO: Remove once XEP-0091 is Obsolete
          timestamp_to_xml/4,
          timestamp_to_mam_xml/4,
          now_to_utc_binary/1,
@@ -741,13 +740,6 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
                 io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh),TZm])
         end,
     {Timestamp_string, Timezone_string}.
-
-
--spec timestamp_to_iso(calendar:datetime()) -> string().
-timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}) ->
-    lists:flatten(
-      io_lib:format("~4..0w~2..0w~2..0wT~2..0w:~2..0w:~2..0w",
-                    [Year, Month, Day, Hour, Minute, Second])).
 
 
 -spec timestamp_to_xml(DateTime :: calendar:datetime(),

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -54,7 +54,6 @@
          parse_xdata_submit/1,
          timestamp_to_iso/1, % TODO: Remove once XEP-0091 is Obsolete
          timestamp_to_xml/4,
-         timestamp_to_xml/1, % TODO: Remove once XEP-0091 is Obsolete
          timestamp_to_mam_xml/4,
          now_to_utc_binary/1,
          datetime_binary_to_timestamp/1,
@@ -777,24 +776,6 @@ timestamp_to_mam_xml(DateTime, Timezone, QueryID, MessageUID) ->
                     {<<"stamp">>, list_to_binary(T_string ++ Tz_string)},
                     {<<"id">>, MessageUID}] ++
                    [{<<"queryid">>, QueryID} || QueryID =/= undefined, QueryID =/= <<>>]}.
-
-
-%% @doc TODO: Remove this function once XEP-0091 is Obsolete
--spec timestamp_to_xml(calendar:datetime()) -> xmlel().
-timestamp_to_xml({{Year, Month, Day}, {Hour, Minute, Second, Micro}}) ->
-    #xmlel{name = <<"x">>,
-           attrs = [{<<"xmlns">>, ?NS_DELAY91},
-                    {<<"stamp">>, lists:flatten(
-                                    io_lib:format("~4..0w~2..0w~2..0wT~2..0w:~2..0w:~2..0w.~6..0w",
-                                                  [Year, Month, Day, Hour, Minute, Second, Micro]))}]};
-
-timestamp_to_xml({{Year, Month, Day}, {Hour, Minute, Second}}) ->
-    #xmlel{name = <<"x">>,
-           attrs = [{<<"xmlns">>, ?NS_DELAY91},
-                    {<<"stamp">>, lists:flatten(
-                                    io_lib:format("~4..0w~2..0w~2..0wT~2..0w:~2..0w:~2..0w",
-                                                  [Year, Month, Day, Hour, Minute, Second]))}]}.
-
 
 -spec now_to_utc_string(erlang:timestamp()) -> string().
 now_to_utc_string({MegaSecs, Secs, MicroSecs}) ->

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -52,6 +52,7 @@
          iq_query_or_response_info/1,
          iq_to_xml/1,
          parse_xdata_submit/1,
+         timestamp_to_iso/1, % TODO: Remove once XEP-0091 is Obsolete
          timestamp_to_xml/4,
          timestamp_to_mam_xml/4,
          now_to_utc_binary/1,
@@ -740,6 +741,13 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
                 io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh),TZm])
         end,
     {Timestamp_string, Timezone_string}.
+
+
+-spec timestamp_to_iso(calendar:datetime()) -> string().
+timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}) ->
+    lists:flatten(
+      io_lib:format("~4..0w~2..0w~2..0wT~2..0w:~2..0w:~2..0w",
+                    [Year, Month, Day, Hour, Minute, Second])).
 
 
 -spec timestamp_to_xml(DateTime :: calendar:datetime(),

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -52,7 +52,6 @@
          iq_query_or_response_info/1,
          iq_to_xml/1,
          parse_xdata_submit/1,
-         timestamp_to_iso/1, % TODO: Remove once XEP-0091 is Obsolete
          timestamp_to_xml/4,
          timestamp_to_mam_xml/4,
          now_to_utc_binary/1,
@@ -741,14 +740,6 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
                 io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh),TZm])
         end,
     {Timestamp_string, Timezone_string}.
-
-
--spec timestamp_to_iso(calendar:datetime()) -> string().
-timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}) ->
-    lists:flatten(
-      io_lib:format("~4..0w~2..0w~2..0wT~2..0w:~2..0w:~2..0w",
-                    [Year, Month, Day, Hour, Minute, Second])).
-
 
 -spec timestamp_to_xml(DateTime :: calendar:datetime(),
                        Timezone :: tz(),

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -245,7 +245,7 @@ set_random_password(User, Server, Reason) ->
 
 -spec build_random_password(Reason :: binary()) -> binary().
 build_random_password(Reason) ->
-    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:datetime(now()),
+    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:now_to_universal_time(now()),
     Date = list_to_binary(
              lists:flatten(
                io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w",

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -245,8 +245,13 @@ set_random_password(User, Server, Reason) ->
 
 -spec build_random_password(Reason :: binary()) -> binary().
 build_random_password(Reason) ->
+    {{Year,Month,Day},{Hour,Minute,Second}} = calendar:universal_time(),
+    Date = list_to_binary(
+             lists:flatten(
+               io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0wZ",
+                             [Year, Month, Day, Hour, Minute, Second]))),
     RandomString = list_to_binary(randoms:get_string()),
-    <<"BANNED_ACCOUNT--", RandomString/binary, "--", Reason/binary>>.
+    <<"BANNED_ACCOUNT--", Date/binary, "--", RandomString/binary, "--", Reason/binary>>.
 
 
 -spec set_password_auth(ejabberd:user(), ejabberd:server(), binary()) -> 'ok'.

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -245,7 +245,12 @@ set_random_password(User, Server, Reason) ->
 
 -spec build_random_password(Reason :: binary()) -> binary().
 build_random_password(Reason) ->
-    Date = list_to_binary(jlib:timestamp_to_iso(calendar:universal_time())),
+    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:datetime(now()),
+    Date = list_to_binary(
+             lists:flatten(
+               io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w",
+                             [Year, Month, Day, Hour, Minute, Second]))),
+
     RandomString = list_to_binary(randoms:get_string()),
     <<"BANNED_ACCOUNT--", Date/binary, "--", RandomString/binary, "--", Reason/binary>>.
 

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -245,14 +245,8 @@ set_random_password(User, Server, Reason) ->
 
 -spec build_random_password(Reason :: binary()) -> binary().
 build_random_password(Reason) ->
-    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:now_to_universal_time(now()),
-    Date = list_to_binary(
-             lists:flatten(
-               io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w",
-                             [Year, Month, Day, Hour, Minute, Second]))),
-
     RandomString = list_to_binary(randoms:get_string()),
-    <<"BANNED_ACCOUNT--", Date/binary, "--", RandomString/binary, "--", Reason/binary>>.
+    <<"BANNED_ACCOUNT--", RandomString/binary, "--", Reason/binary>>.
 
 
 -spec set_password_auth(ejabberd:user(), ejabberd:server(), binary()) -> 'ok'.

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -2463,8 +2463,6 @@ add_message_to_history(FromNick, FromJID, Packet, StateData) ->
     end,
     TSPacket = xml:append_subtags(Packet,
                   [jlib:timestamp_to_xml(TimeStamp, utc, SenderJid, <<>>)]),
-                   %% TODO: Delete the next line once XEP-0091 is Obsolete
-                   %% jlib:timestamp_to_xml(TimeStamp)]),
     SPacket = jlib:replace_from_to(
         jlib:jid_replace_resource(StateData#state.jid, FromNick),
         StateData#state.jid,

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -2462,9 +2462,9 @@ add_message_to_history(FromNick, FromJID, Packet, StateData) ->
     false -> FromJID
     end,
     TSPacket = xml:append_subtags(Packet,
-                  [jlib:timestamp_to_xml(TimeStamp, utc, SenderJid, <<>>),
+                  [jlib:timestamp_to_xml(TimeStamp, utc, SenderJid, <<>>)]),
                    %% TODO: Delete the next line once XEP-0091 is Obsolete
-                   jlib:timestamp_to_xml(TimeStamp)]),
+                   %% jlib:timestamp_to_xml(TimeStamp)]),
     SPacket = jlib:replace_from_to(
         jlib:jid_replace_resource(StateData#state.jid, FromNick),
         StateData#state.jid,

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -445,8 +445,9 @@ add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     Time = {D,{H,M,S, Micro}},
     %% TODO: Delete the next element once XEP-0091 is Obsolete
     TimeStampLegacyXML = timestamp_legacy_xml(Server, Time),
-    TimeStampXML = jlib:timestamp_to_xml(Time),
-    xml:append_subtags(Packet, [TimeStampLegacyXML, TimeStampXML]).
+    %% TimeStampXML = jlib:timestamp_to_xml(Time),
+    %% xml:append_subtags(Packet, [TimeStampLegacyXML, TimeStampXML]).
+    xml:append_subtags(Packet, [TimeStampLegacyXML]).
 
 timestamp_legacy_xml(Server, Time) ->
     FromJID = jlib:make_jid(<<>>, Server, <<>>),

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -443,10 +443,7 @@ add_timestamp(undefined, _Server, Packet) ->
 add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     {D,{H,M,S}} = calendar:now_to_universal_time(TimeStamp),
     Time = {D,{H,M,S, Micro}},
-    %% TODO: Delete the next element once XEP-0091 is Obsolete
     TimeStampLegacyXML = timestamp_legacy_xml(Server, Time),
-    %% TimeStampXML = jlib:timestamp_to_xml(Time),
-    %% xml:append_subtags(Packet, [TimeStampLegacyXML, TimeStampXML]).
     xml:append_subtags(Packet, [TimeStampLegacyXML]).
 
 timestamp_legacy_xml(Server, Time) ->

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -443,10 +443,10 @@ add_timestamp(undefined, _Server, Packet) ->
 add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     {D,{H,M,S}} = calendar:now_to_universal_time(TimeStamp),
     Time = {D,{H,M,S, Micro}},
-    TimeStampLegacyXML = timestamp_legacy_xml(Server, Time),
-    xml:append_subtags(Packet, [TimeStampLegacyXML]).
+    TimeStampXML = timestamp_xml(Server, Time),
+    xml:append_subtags(Packet, [TimeStampXML]).
 
-timestamp_legacy_xml(Server, Time) ->
+timestamp_xml(Server, Time) ->
     FromJID = jlib:make_jid(<<>>, Server, <<>>),
     jlib:timestamp_to_xml(Time, utc, FromJID, <<"Offline Storage">>).
 


### PR DESCRIPTION
Hi guys, at my company we are developing a mobile chat based on MongooseIM. For our android client we are using the ASmack library and we get an date parsing error when the client receives an offline message.

The offending date is the one passed inside the x tag of the [XEP-0091](http://xmpp.org/extensions/xep-0091.html) extension. Since I noticed it has obsoleted, I thought I could have removed it from MongooseIM.

But I'm a Ruby developer and know just the very basics of Erlang. I've managed to remove the <x> tag from the message stanza, recompiled the repo and the server works. No date parsing error on the client anymore.

But I don't know if I need to add some tests around my changes or if the changes are correct (ie. do I need to remove/add something else?). I'd love to contribute to the project and I'd like to hear your feedback.

Bye