### PR TITLE
Fix zlib driver crashing on 1024-bytes chunks

### DIFF
--- a/apps/ejabberd/c_src/ejabberd_zlib_drv.c
+++ b/apps/ejabberd/c_src/ejabberd_zlib_drv.c
@@ -141,6 +141,13 @@ static ErlDrvSSizeT ejabberd_zlib_drv_control(ErlDrvData handle,
                 d->d_stream->avail_out = BUF_SIZE;
 
                 err = deflate(d->d_stream, Z_SYNC_FLUSH);
+
+               // Output buffer was completely consumed and we have no more data to process
+               // http://www.zlib.net/zlib_faq.html#faq05
+               if(err == Z_BUF_ERROR && d->d_stream->avail_out == BUF_SIZE) {
+                  break;
+               }
+
                 die_unless((err == Z_OK) || (err == Z_STREAM_END),
                         "deflate_error");
 
@@ -169,6 +176,13 @@ static ErlDrvSSizeT ejabberd_zlib_drv_control(ErlDrvData handle,
                     d->i_stream->avail_out = BUF_SIZE;
 
                     err = inflate(d->i_stream, Z_SYNC_FLUSH);
+
+                    // Output buffer was completely consumed and we have no more data to process
+                    // http://www.zlib.net/zlib_faq.html#faq05
+                    if(err == Z_BUF_ERROR && d->i_stream->avail_out == BUF_SIZE) {
+                       break;
+                    }
+
                     die_unless((err == Z_OK) || (err == Z_STREAM_END),
                             "inflate_error");
 

--- a/apps/ejabberd/test/zlib_driver_SUITE.erl
+++ b/apps/ejabberd/test/zlib_driver_SUITE.erl
@@ -1,0 +1,24 @@
+-module(zlib_driver_SUITE).
+
+-compile(export_all).
+
+all()->
+    [stanza_1024].
+
+stanza_1024(_)->
+    DeflateCmd = 1,
+    InflateCmd = 2,
+    %% Just random 1024 bytes data
+    Data = <<"iGzHvZgQbX6oTJYViq9Xy3MncZtDlypeFWNF61owolz8boGSqsr5wxtfT42QSJIMShM6MZInMHBUh9unSYpuwqfzlLIZ3ZNfjje7YsLhaITQzXXNABsXdvjUMU437FJppLeLVob9M4ZcUpAOdMSpCB1t6KKgWBmNEdkbo9VL2seDdpYT3AcZlGOsy73pk7og3KirclNJM6NFI2wARifUdE9ShEJhlncjOQnG3ExCnjGsRSGcJl8eh6Vjsq8pavfhOTYyE6z4xBPG4jKtZCiqVO1uaWQjeTOPZnhPdnVThcrpVS1GiB33xZz9p6pRw2ricGbsbZoUNIQQqBsL5VGZeNQhRLAoiNsT1S3kJl43Mm6rvIy8rM5Jm9y4NXvkZcjgPpmfySmgXSygWshbjGbaUlwub2ZCe7C5Z1vQL7n5DutDefQcFXJScMWiOW11ye9UIx9u29qVp2HhzhJ1dtAheBBk6unVNTVkQJoyMcdVAFSQ4yob66WKm33xkrtxgvyAFesdWwXFc6VNGxtXjBYu2Hd8jyDSAzl9wK3CRF9rraKSLSv3ycTFty16noELhJwzQQ2zjkQerms7MR98nmmGFLA1DgaZXSwQnWl4A3k8mTvxsWfhVgZDdkcvwqmFB3JHJsKfUuakt921dJ3uXI5ywsV3nVi3Skpuj3OiV9mfZzNp2J8mE7zxX5RtgV3phcfIEA52gBb8TngbL8hnPPkJy1tTaYYtNCcZEHaLd8XKUPa2aAr7rMdLzqhiaGPY6JWIncDWKGW8EOCOXXKVIgXtFEhAjZlc6e7LSOvkBbJTkh3hoS9Ow9daLJrnIGIMDRT1NxhHX9iYzvUAs9c78zZjTA7CWFWRhj5Ui7koQrMXzIszmVDTGe3y5Ml6bNMMUtZUT2eK7QSnU4wFwFqeviN56XN4qugVMW9J6YbVY5bZA77fpUW92TUHXA2jhXldNpFL8cc82p5XNNQERaqBDA15EHuotqaVDZGCYPkvPLqXlx9UjOLJltDAAKYlifQQonPW">>,
+
+    case erl_ddll:load_driver("../../../ejabberd/priv/lib", ejabberd_zlib_drv) of
+	ok -> ok;
+	{error, already_loaded} -> ok
+    end,
+
+    Port = open_port({spawn, ejabberd_zlib_drv}, [binary]),
+
+    <<0, Deflated/binary>> = port_control(Port, DeflateCmd, Data),
+    <<0, Data/binary>> = port_control(Port, InflateCmd, Deflated),
+
+    ok.


### PR DESCRIPTION
We have found an issue in our production ejabberd node. Upon stream compression has been initiated any incoming stanza which is exactly 1024 bytes long would crash the zlib driver and connection would terminate. The problem is the following:

in apps/ejabberd/c_src/ejabberd_zlib_drv.c file internal buffer size is defined to be equal 1024 bytes.
In inflate logic one edge case is not properly handled, namely when original chunk (before deflated) is exactly BUF_SIZE bytes long.
Internal loop: while (err == Z_OK && d->i_stream->avail_out == 0) checks for the avail_out field to be greater than zero, however when original chunk is exactly BUF_SIZE bytes avail_zero is 0 because the output buffer was completely filled by inflating the chunk. So code enters the loop one extra time despite the fact that we do not have any more data to process. zlib in this case returns Z_BUF_ERROR to indicate exactly the situation we have (http://www.zlib.net/zlib_faq.html#faq05) and current code just checks for return code to be either Z_OK or Z_STREAM_END, otherwise it throws an error. 

Quote on this problem from http://www.zlib.net/zlib_how.html:

> The way we tell that deflate() has no more output is by seeing that it did not fill the output buffer, leaving avail_out greater than zero. However suppose that deflate() has no more output, but just so happened to exactly fill the output buffer! avail_out is zero, and we can't tell that deflate() has done all it can. As far as we know, deflate() has more output for us. So we call it again. But now deflate() produces no output at all, and avail_out remains unchanged as CHUNK. That deflate() call wasn't able to do anything, either consume input or produce output, and so it returns Z_BUF_ERROR. (See, I told you I'd cover this later.) However this is not a problem at all. Now we finally have the desired indication that deflate() is really done, and so we drop out of the inner loop to provide more input to deflate(). 

For deflate case this problem is the opposite - it would crash if the compressed chunk is exactly 1024 bytes long.
Here's the simple test module for the problem:  https://gist.github.com/syhpoon/804d1f9194f17f6421fa