### PR TITLE
Create ./etc if doesn't exist for quickrun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ quickrun: etc/ejabberd.cfg
 	erl -sname mongooseim@localhost -setcookie ejabberd -pa deps/*/ebin apps/*/ebin -config rel/files/app.config -s ejabberd
 
 etc/ejabberd.cfg:
+	@mkdir -p $(@D)
 	tools/generate_cfg.es etc/ejabberd.cfg
 
 


### PR DESCRIPTION
Doing `$ make quickrun` doesn't work on a clean build because ./etc
doesn't exist