### PR TITLE
Cowboy key_pass should be a empty string default

### DIFF
--- a/apps/ejabberd/src/ejabberd_cowboy.erl
+++ b/apps/ejabberd/src/ejabberd_cowboy.erl
@@ -100,7 +100,7 @@ start_cowboy(Ref, Opts) ->
     IP = gen_mod:get_opt(ip, Opts, {0,0,0,0}),
     SSLCert = gen_mod:get_opt(cert, Opts, undefined),
     SSLKey = gen_mod:get_opt(key, Opts, undefined),
-    SSLKeyPass = gen_mod:get_opt(key_pass, Opts, undefined),
+    SSLKeyPass = gen_mod:get_opt(key_pass, Opts, ""),
     NumAcceptors = gen_mod:get_opt(num_acceptors, Opts, 100),
     MaxConns = gen_mod:get_opt(max_connections, Opts, 1024),
     Middlewares = case gen_mod:get_opt(middlewares, Opts, undefined) of


### PR DESCRIPTION
Passing `undefined` (i.e. not configuring this option within the listener section) will lead to the following error:

```
2015-03-10 12:04:26.187 [error] <0.333.0> CRASH REPORT Process <0.333.0> with 0 neighbours exited with reason: no match of right hand value {error,{options,{password,undefined}}} in ranch_acceptors_sup:init/1 line 38 in gen_server:init_it/6 line 330
2015-03-10 12:04:26.188 [error] <0.331.0> Supervisor {<0.331.0>,ranch_listener_sup} had child ranch_acceptors_sup started with ranch_acceptors_sup:start_link('ejabberd_cowboy_0.0.0.0_5280', 10, ranch_ssl, [{port,5280},{ip,{0,0,0,0}},{max_connections,1024},{certfile,"/etc/ssl/custom/server.crt"},{keyfile,...},...]) at undefined exit with reason no match of right hand value {error,{options,{password,undefined}}} in ranch_acceptors_sup:init/1 line 38 in context start_error
```