### PR TITLE
More metrics 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test_preset: test_deps
 run: deps compile quickrun
 
 quickrun: etc/ejabberd.cfg certs_priv
-	erl -sname mongooseim@localhost -setcookie ejabberd -pa deps/*/ebin apps/*/ebin -config rel/files/app.config -s ejabberd
+	erl -sname mongooseim@localhost -setcookie ejabberd -pa ebin deps/*/ebin apps/*/ebin -config rel/files/app.config -s mongooseim
 
 etc/ejabberd.cfg:
 	@mkdir -p $(@D)

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1592,7 +1592,7 @@ change_shaper(StateData, JID) ->
 send_text(StateData, Text) ->
     ?DEBUG("Send XML on stream = ~p", [Text]),
     Size = size(Text),
-    mongoose_metrics:update([data, sent, xml_stanza_size], Size),
+    mongoose_metrics:update([data, xmpp, sent, xml_stanza_size], Size),
     (StateData#state.sockmod):send(StateData#state.socket, Text).
 
 -spec maybe_send_element_safe(state(), El :: jlib:xmlel()) -> any().

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1592,7 +1592,7 @@ change_shaper(StateData, JID) ->
 send_text(StateData, Text) ->
     ?DEBUG("Send XML on stream = ~p", [Text]),
     Size = size(Text),
-    mongoose_metrics:update([global, sent, xml_stanza_size], Size),
+    mongoose_metrics:update([data, sent, xml_stanza_size], Size),
     (StateData#state.sockmod):send(StateData#state.socket, Text).
 
 -spec maybe_send_element_safe(state(), El :: jlib:xmlel()) -> any().

--- a/apps/ejabberd/src/ejabberd_c2s.hrl
+++ b/apps/ejabberd/src/ejabberd_c2s.hrl
@@ -118,7 +118,7 @@
         "id='~s' from='~s'~s~s>"
        ).
 
--define(STREAM_TRAILER, "</stream:stream>").
+-define(STREAM_TRAILER, <<"</stream:stream>">>).
 
 -define(INVALID_NS_ERR, ?SERR_INVALID_NAMESPACE).
 -define(INVALID_XML_ERR, ?SERR_XML_NOT_WELL_FORMED).

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -217,10 +217,9 @@ handle_info({Tag, _TCPSocket, Data},
 		   c2s_pid = C2SPid,
 		   sock_mod = SockMod} = State)
   when (Tag == tcp) or (Tag == ssl) ->
-    RawSize = size(Data),
-    mongoose_metrics:update([global, raw_data_size], RawSize),
     case SockMod of
 	ejabberd_tls ->
+        mongoose_metrics:update([global, received, encrypted_data_size], size(Data)),
 	    case ejabberd_tls:recv_data(Socket, Data) of
 		{ok, TLSData} ->
 		    {noreply, process_data(TLSData, State),
@@ -229,6 +228,7 @@ handle_info({Tag, _TCPSocket, Data},
 		    {stop, normal, State}
 	    end;
 	ejabberd_zlib ->
+        mongoose_metrics:update([global, received, compressed_data_size], size(Data)),
 	    case ejabberd_zlib:recv_data(Socket, Data) of
 		{ok, ZlibData} ->
 		    {noreply, process_data(ZlibData, State),
@@ -337,7 +337,7 @@ process_data(Data,
                     c2s_pid = C2SPid} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
     Size = size(Data),
-    mongoose_metrics:update([global, xml_stanza_size], Size),
+    mongoose_metrics:update([global, received, xml_stanza_size], Size),
     XMLStreamState1 = xml_stream:parse(XMLStreamState, Data),
     {NewShaperState, Pause} = shaper:update(ShaperState, Size),
     if

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -219,7 +219,7 @@ handle_info({Tag, _TCPSocket, Data},
   when (Tag == tcp) or (Tag == ssl) ->
     case SockMod of
 	ejabberd_tls ->
-        mongoose_metrics:update([global, received, encrypted_data_size], size(Data)),
+        mongoose_metrics:update([data, received, encrypted_data_size], size(Data)),
 	    case ejabberd_tls:recv_data(Socket, Data) of
 		{ok, TLSData} ->
 		    {noreply, process_data(TLSData, State),
@@ -228,7 +228,7 @@ handle_info({Tag, _TCPSocket, Data},
 		    {stop, normal, State}
 	    end;
 	ejabberd_zlib ->
-        mongoose_metrics:update([global, received, compressed_data_size], size(Data)),
+        mongoose_metrics:update([data, received, compressed_data_size], size(Data)),
 	    case ejabberd_zlib:recv_data(Socket, Data) of
 		{ok, ZlibData} ->
 		    {noreply, process_data(ZlibData, State),
@@ -337,7 +337,7 @@ process_data(Data,
                     c2s_pid = C2SPid} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
     Size = size(Data),
-    mongoose_metrics:update([global, received, xml_stanza_size], Size),
+    mongoose_metrics:update([data, received, xml_stanza_size], Size),
     XMLStreamState1 = xml_stream:parse(XMLStreamState, Data),
     {NewShaperState, Pause} = shaper:update(ShaperState, Size),
     if

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -219,7 +219,7 @@ handle_info({Tag, _TCPSocket, Data},
   when (Tag == tcp) or (Tag == ssl) ->
     case SockMod of
 	ejabberd_tls ->
-        mongoose_metrics:update([data, received, encrypted_data_size], size(Data)),
+        mongoose_metrics:update([data, xmpp, received, encrypted_size], size(Data)),
 	    case ejabberd_tls:recv_data(Socket, Data) of
 		{ok, TLSData} ->
 		    {noreply, process_data(TLSData, State),
@@ -228,7 +228,7 @@ handle_info({Tag, _TCPSocket, Data},
 		    {stop, normal, State}
 	    end;
 	ejabberd_zlib ->
-        mongoose_metrics:update([data, received, compressed_data_size], size(Data)),
+        mongoose_metrics:update([data, xmpp, received, compressed_size], size(Data)),
 	    case ejabberd_zlib:recv_data(Socket, Data) of
 		{ok, ZlibData} ->
 		    {noreply, process_data(ZlibData, State),
@@ -337,7 +337,7 @@ process_data(Data,
                     c2s_pid = C2SPid} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
     Size = size(Data),
-    mongoose_metrics:update([data, received, xml_stanza_size], Size),
+    mongoose_metrics:update([data, xmpp, received, xml_stanza_size], Size),
     XMLStreamState1 = xml_stream:parse(XMLStreamState, Data),
     {NewShaperState, Pause} = shaper:update(ShaperState, Size),
     if

--- a/apps/ejabberd/src/ejabberd_socket.erl
+++ b/apps/ejabberd/src/ejabberd_socket.erl
@@ -33,7 +33,6 @@
 	 connect/4,
 	 starttls/2,
 	 starttls/3,
-	 compress/1,
 	 compress/3,
 	 reset_stream/1,
 	 send/2,
@@ -170,16 +169,6 @@ starttls(SocketData, TLSOpts, Data) ->
     ejabberd_receiver:starttls(SocketData#socket_state.receiver, TLSSocket),
     send(SocketData, Data),
     SocketData#socket_state{socket = TLSSocket, sockmod = ejabberd_tls}.
-
-
--spec compress(socket_state()) -> socket_state().
-compress(SocketData) ->
-    {ok, ZlibSocket} = ejabberd_zlib:enable_zlib(
-                         SocketData#socket_state.sockmod,
-                         SocketData#socket_state.socket),
-    ejabberd_receiver:compress(SocketData#socket_state.receiver, ZlibSocket),
-    SocketData#socket_state{socket = ZlibSocket, sockmod = ejabberd_zlib}.
-
 
 -spec compress(socket_state(), integer(), _) -> socket_state().
 compress(SocketData, InflateSizeLimit, Data) ->

--- a/apps/ejabberd/src/ejabberd_sup.erl
+++ b/apps/ejabberd/src/ejabberd_sup.erl
@@ -169,6 +169,10 @@ init([]) ->
          brutal_kill,
          worker,
          [mod_muc_iq]},
+    MAM =
+        {mod_mam_sup,
+         {mod_mam_sup, start_link, []},
+         permanent, infinity, supervisor, [mod_mam_sup]},
     ShaperSpecs = shaper_srv:child_specs(),
 
     {ok, {{one_for_one, 10, 1},
@@ -190,4 +194,5 @@ init([]) ->
            IQSupervisor,
            STUNSupervisor,
            Listener,
-           MucIQ]}}.
+           MucIQ,
+           MAM]}}.

--- a/apps/ejabberd/src/ejabberd_tls.erl
+++ b/apps/ejabberd/src/ejabberd_tls.erl
@@ -149,6 +149,7 @@ send(#tlssock{tcpsock = TCPSocket, tlsport = Port} = TLSSock, Packet) ->
             %?PRINT("OUT: ~p~n", [{TCPSocket, lists:flatten(Packet)}]),
             case port_control(Port, ?GET_ENCRYPTED_OUTPUT, []) of
                 <<0, Out/binary>> ->
+                    mongoose_metrics:update([global, sent, encrypted_data_size], size(Out)),
                     gen_tcp:send(TCPSocket, Out);
                 <<1, Error/binary>> ->
                     {error, binary_to_list(Error)}

--- a/apps/ejabberd/src/ejabberd_tls.erl
+++ b/apps/ejabberd/src/ejabberd_tls.erl
@@ -149,7 +149,7 @@ send(#tlssock{tcpsock = TCPSocket, tlsport = Port} = TLSSock, Packet) ->
             %?PRINT("OUT: ~p~n", [{TCPSocket, lists:flatten(Packet)}]),
             case port_control(Port, ?GET_ENCRYPTED_OUTPUT, []) of
                 <<0, Out/binary>> ->
-                    mongoose_metrics:update([data, sent, encrypted_data_size], size(Out)),
+                    mongoose_metrics:update([data, xmpp, sent, encrypted_size], size(Out)),
                     gen_tcp:send(TCPSocket, Out);
                 <<1, Error/binary>> ->
                     {error, binary_to_list(Error)}

--- a/apps/ejabberd/src/ejabberd_tls.erl
+++ b/apps/ejabberd/src/ejabberd_tls.erl
@@ -149,7 +149,7 @@ send(#tlssock{tcpsock = TCPSocket, tlsport = Port} = TLSSock, Packet) ->
             %?PRINT("OUT: ~p~n", [{TCPSocket, lists:flatten(Packet)}]),
             case port_control(Port, ?GET_ENCRYPTED_OUTPUT, []) of
                 <<0, Out/binary>> ->
-                    mongoose_metrics:update([global, sent, encrypted_data_size], size(Out)),
+                    mongoose_metrics:update([data, sent, encrypted_data_size], size(Out)),
                     gen_tcp:send(TCPSocket, Out);
                 <<1, Error/binary>> ->
                     {error, binary_to_list(Error)}

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -95,7 +95,7 @@ send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of
 	<<0, Out/binary>> ->
-        mongoose_metrics:update([global, sent, compressed_data_size], size(Out)),
+        mongoose_metrics:update([data, sent, compressed_data_size], size(Out)),
 	    SockMod:send(Socket, Out);
 	<<1, Error/binary>> ->
 	    {error, erlang:binary_to_existing_atom(Error, utf8)};

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -95,7 +95,7 @@ send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of
 	<<0, Out/binary>> ->
-        mongoose_metrics:update([data, sent, compressed_data_size], size(Out)),
+        mongoose_metrics:update([data, xmpp, sent, compressed_size], size(Out)),
 	    SockMod:send(Socket, Out);
 	<<1, Error/binary>> ->
 	    {error, erlang:binary_to_existing_atom(Error, utf8)};

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -95,6 +95,7 @@ send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of
 	<<0, Out/binary>> ->
+        mongoose_metrics:update([global, sent, compressed_data_size], size(Out)),
 	    SockMod:send(Socket, Out);
 	<<1, Error/binary>> ->
 	    {error, erlang:binary_to_existing_atom(Error, utf8)};

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -82,7 +82,7 @@
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
 
-    gen_mod:start_backend_module(?MODULE, Opts),
+    gen_mod:start_backend_module(?MODULE, Opts, [get_last, set_last_info]),
     ?BACKEND:init(Host, Opts),
 
     gen_iq_handler:add_iq_handler(ejabberd_local, Host,
@@ -219,7 +219,7 @@ get_last_iq(IQ, SubEl, LUser, LServer) ->
     end.
 
 get_last(LUser, LServer) ->
-    ?BACKEND:get_last(LUser, LServer).
+    gen_mod:apply_backend_op(?BACKEND, get_last, [LUser, LServer]).
 
 -spec count_active_users(ejabberd:lserver(), non_neg_integer(), '<' | '>')
         -> non_neg_integer().
@@ -235,7 +235,7 @@ on_presence_update(LUser, LServer, _Resource, Status) ->
 -spec store_last_info(ejabberd:user(), ejabberd:server(), erlang:timestamp(),
                       Status :: binary()) -> {'aborted',_} | {'atomic',_}.
 store_last_info(LUser, LServer, TimeStamp, Status) ->
-    ?BACKEND:set_last_info(LUser, LServer, TimeStamp, Status).
+    gen_mod:apply_backend_op(?BACKEND, set_last_info, [LUser, LServer, TimeStamp, Status]).
 
 -spec get_last_info(ejabberd:luser(), ejabberd:lserver())
         -> 'not_found' | {'ok',integer(),string()}.

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -46,7 +46,7 @@
 -include("mod_privacy.hrl").
 -include("mod_last.hrl").
 
--define(BACKEND, (mod_last_backend:backend())).
+-define(BACKEND, mod_last_backend).
 
 %% ------------------------------------------------------------------
 %% Backend callbacks
@@ -219,7 +219,7 @@ get_last_iq(IQ, SubEl, LUser, LServer) ->
     end.
 
 get_last(LUser, LServer) ->
-    gen_mod:apply_backend_op(?BACKEND, get_last, [LUser, LServer]).
+    ?BACKEND:get_last(LUser, LServer).
 
 -spec count_active_users(ejabberd:lserver(), non_neg_integer(), '<' | '>')
         -> non_neg_integer().
@@ -235,7 +235,7 @@ on_presence_update(LUser, LServer, _Resource, Status) ->
 -spec store_last_info(ejabberd:user(), ejabberd:server(), erlang:timestamp(),
                       Status :: binary()) -> {'aborted',_} | {'atomic',_}.
 store_last_info(LUser, LServer, TimeStamp, Status) ->
-    gen_mod:apply_backend_op(?BACKEND, set_last_info, [LUser, LServer, TimeStamp, Status]).
+    ?BACKEND:set_last_info(LUser, LServer, TimeStamp, Status).
 
 -spec get_last_info(ejabberd:luser(), ejabberd:lserver())
         -> 'not_found' | {'ok',integer(),string()}.

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -374,6 +374,8 @@ init([Host, N]) ->
 %%--------------------------------------------------------------------
 -spec handle_call('wait_flushing', _, state())
       -> {'noreply', state()} | {'reply','ok',state()}.
+handle_call(get_connection, _From, State=#state{conn = Conn}) ->
+    {reply, Conn, State};
 handle_call(wait_flushing, _From, State=#state{acc=[]}) ->
     {reply, ok, State};
 handle_call(wait_flushing, From,

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -157,14 +157,14 @@ start_worker(WriterProc, N, Host) ->
      5000,
      worker,
      [mod_mam_muc_odbc_async_writer]},
-    supervisor:start_child(ejabberd_sup, WriterChildSpec).
+    supervisor:start_child(mod_mam_sup, WriterChildSpec).
 
 
 -spec stop_worker(atom()) -> 'ok'
         | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_worker(Proc) ->
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    supervisor:terminate_child(mod_mam_sup, Proc),
+    supervisor:delete_child(mod_mam_sup, Proc).
 
 
 -spec start_link(atom(),_,_) -> 'ignore' | {'error',_} | {'ok',pid()}.

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_writer.erl
@@ -282,6 +282,8 @@ init([Host]) ->
 %%--------------------------------------------------------------------
 -spec handle_call('wait_flushing',_, state()) -> {'noreply',state()}
                                                | {'reply','ok',state()}.
+handle_call(get_connection, _From, State=#state{conn = Conn}) ->
+    {reply, Conn, State};
 handle_call(wait_flushing, _From, State=#state{acc=[]}) ->
     {reply, ok, State};
 handle_call(wait_flushing, From, State=#state{subscribers=Subs}) ->

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_writer.erl
@@ -219,15 +219,15 @@ is_recent_entries_required(_End, _Now) ->
                                                 | {'ok','undefined' | pid(),_}.
 start_server(Host) ->
     WriterProc = srv_name(Host),
-    supervisor:start_child(ejabberd_sup, writer_child_spec(WriterProc, Host)).
+    supervisor:start_child(mod_mam_sup, writer_child_spec(WriterProc, Host)).
 
 
 -spec stop_server(ejabberd:server()) -> 'ok'
         | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_server(Host) ->
     Proc = srv_name(Host),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    supervisor:terminate_child(mod_mam_sup, Proc),
+    supervisor:delete_child(mod_mam_sup, Proc).
 
 writer_child_spec(WriterProc, Host) ->
     {WriterProc,

--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -175,11 +175,11 @@ start_worker(WriterProc, N, Host) ->
      5000,
      worker,
      [mod_mam_odbc_async_writer]},
-    supervisor:start_child(ejabberd_sup, WriterChildSpec).
+    supervisor:start_child(mod_mam_sup, WriterChildSpec).
 
 stop_worker(Proc) ->
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    supervisor:terminate_child(mod_mam_sup, Proc),
+    supervisor:delete_child(mod_mam_sup, Proc).
 
 
 start_link(ProcName, N, Host) ->

--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -370,6 +370,8 @@ init([Host, N]) ->
 %%                                      {stop, Reason, State}
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
+handle_call(get_connection, _From, State=#state{conn = Conn}) ->
+    {reply, Conn, State};
 handle_call(wait_flushing, _From, State=#state{acc=[]}) ->
     {reply, ok, State};
 handle_call(wait_flushing, From,

--- a/apps/ejabberd/src/mod_mam_odbc_async_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_writer.erl
@@ -255,7 +255,6 @@ is_recent_entries_required(End, Now) when is_integer(End) ->
 is_recent_entries_required(_End, _Now) ->
     true.
 
-
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -333,6 +332,8 @@ init([Host]) ->
 %%--------------------------------------------------------------------
 -spec handle_call('wait_flushing', _, state()) -> {'noreply',state()}
                                                 | {'reply','ok',state()}.
+handle_call(get_connection, _From, State=#state{conn = Conn}) ->
+    {reply, Conn, State};
 handle_call(wait_flushing, _From, State=#state{acc=[]}) ->
     {reply, ok, State};
 handle_call(wait_flushing, From, State=#state{subscribers=Subs}) ->

--- a/apps/ejabberd/src/mod_mam_odbc_async_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_writer.erl
@@ -264,7 +264,7 @@ is_recent_entries_required(_End, _Now) ->
             | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
 start_server(Host) ->
     WriterProc = srv_name(Host),
-    supervisor:start_child(ejabberd_sup, writer_child_spec(WriterProc, Host)).
+    supervisor:start_child(mod_mam_sup, writer_child_spec(WriterProc, Host)).
 
 
 -spec stop_server(ejabberd:server()) -> 'ok'

--- a/apps/ejabberd/src/mod_mam_sup.erl
+++ b/apps/ejabberd/src/mod_mam_sup.erl
@@ -1,0 +1,76 @@
+%%==============================================================================
+%% Copyright 2014 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mod_mam_sup).
+
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the supervisor
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec(start_link() ->
+    {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%%===================================================================
+%%% Supervisor callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a supervisor is started using supervisor:start_link/[2,3],
+%% this function is called by the new process to find out about
+%% restart strategy, maximum restart frequency and child
+%% specifications.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec(init(Args :: term()) ->
+    {ok, {SupFlags :: {RestartStrategy :: supervisor:strategy(),
+        MaxR :: non_neg_integer(), MaxT :: non_neg_integer()},
+        [ChildSpec :: supervisor:child_spec()]
+    }} |
+    ignore |
+    {error, Reason :: term()}).
+init([]) ->
+    RestartStrategy = one_for_one,
+    MaxRestarts = 1000,
+    MaxSecondsBetweenRestarts = 3600,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    {ok, {SupFlags, []}}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -42,7 +42,7 @@
 -include("jlib.hrl").
 -include("mod_privacy.hrl").
 
--define(BACKEND, (mod_privacy_backend:backend())).
+-define(BACKEND, mod_privacy_backend).
 
 -export_type([userlist/0]).
 
@@ -114,7 +114,10 @@
 %% ------------------------------------------------------------------
 
 start(Host, Opts) ->
-    gen_mod:start_backend_module(?MODULE, Opts),
+    gen_mod:start_backend_module(?MODULE, Opts, [get_privacy_list,get_list_names,
+                                                 set_default_list, forget_default_list,
+                                                 remove_privacy_list, replace_privacy_list,
+                                                 get_default_list]),
     ?BACKEND:init(Host, Opts),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     ejabberd_hooks:add(privacy_iq_get, Host,

--- a/apps/ejabberd/src/mod_privacy_odbc.erl
+++ b/apps/ejabberd/src/mod_privacy_odbc.erl
@@ -351,4 +351,3 @@ sql_del_privacy_lists(LUser, LServer) ->
     Username = ejabberd_odbc:escape(LUser),
     Server = ejabberd_odbc:escape(LServer),
     odbc_queries:del_privacy_lists(LServer, Server, Username).
-

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -71,7 +71,7 @@
 %% gen_mod callbacks
 
 start(Host, Opts) ->
-    gen_mod:start_backend_module(?MODULE, Opts),
+    gen_mod:start_backend_module(?MODULE, Opts, [multi_get_data, multi_set_data]),
     ?BACKEND:init(Host, Opts),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     ejabberd_hooks:add(remove_user, Host, ?MODULE, remove_user, 50),
@@ -103,11 +103,11 @@ process_sm_iq(
     case Strategy of
         get ->
             NS2XML = to_map(Elems),
-            XMLs = ?BACKEND:multi_get_data(LUser, LServer, NS2XML),
+            XMLs = gen_mod:apply_backend_op(?BACKEND, multi_get_data, [LUser, LServer, NS2XML]),
             IQ#iq{type = result, sub_el = [SubElem#xmlel{children = XMLs}]};
         set ->
             NS2XML = to_map(Elems),
-            Result = ?BACKEND:multi_set_data(LUser, LServer, NS2XML),
+            Result = gen_mod:apply_backend_op(?BACKEND, multi_set_data, [LUser, LServer, NS2XML]),
             case Result of
                 {atomic, ok} ->
                     IQ#iq{type = result, sub_el = [SubElem]};

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -37,7 +37,7 @@
 -include("ejabberd.hrl").
 -include("jlib.hrl").
 
--define(BACKEND, (mod_private_backend:backend())).
+-define(BACKEND, mod_private_backend).
 
 %% ------------------------------------------------------------------
 %% Backend callbacks
@@ -103,11 +103,11 @@ process_sm_iq(
     case Strategy of
         get ->
             NS2XML = to_map(Elems),
-            XMLs = gen_mod:apply_backend_op(?BACKEND, multi_get_data, [LUser, LServer, NS2XML]),
+            XMLs = ?BACKEND:multi_get_data(LUser, LServer, NS2XML),
             IQ#iq{type = result, sub_el = [SubElem#xmlel{children = XMLs}]};
         set ->
             NS2XML = to_map(Elems),
-            Result = gen_mod:apply_backend_op(?BACKEND, multi_set_data, [LUser, LServer, NS2XML]),
+            Result = ?BACKEND:multi_set_data(LUser, LServer, NS2XML),
             case Result of
                 {atomic, ok} ->
                     IQ#iq{type = result, sub_el = [SubElem]};

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -124,12 +124,22 @@
     Result :: term().
 
 
--define(BACKEND, (mod_roster_backend:backend())).
+-define(BACKEND, mod_roster_backend).
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
-
-    gen_mod:start_backend_module(?MODULE, Opts),
+    TrackedFuns = [read_roster_version,
+                   write_roster_version,
+                   get_roster,
+                   get_roster_by_jid_t,
+                   get_subscription_lists,
+                   roster_subscribe_t,
+                   get_roster_by_jid_with_groups_t,
+                   update_roster_t,
+                   del_roster_t,
+                   read_subscription_and_groups
+                   ],
+    gen_mod:start_backend_module(?MODULE, Opts, TrackedFuns),
     ?BACKEND:init(Host, Opts),
 
     ejabberd_hooks:add(roster_get, Host,

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -123,6 +123,11 @@
     LJid :: ejabberd:simple_bare_jid(),
     Result :: term().
 
+-callback raw_to_record(LServer, Item) -> Result when
+    LServer :: ejabberd:lserver(),
+    Item :: term(),
+    Result :: error | roster().
+
 
 -define(BACKEND, mod_roster_backend).
 

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -64,6 +64,66 @@
 
 -type roster() :: #roster{}.
 
+-callback init(Host, Opts) -> ok when
+    Host :: ejabberd:server(),
+    Opts :: list().
+-callback read_roster_version(LUser, LServer) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    Result :: term().
+-callback write_roster_version(LUser, LServer, InTransaction, Ver) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    InTransaction :: boolean(),
+    Ver :: binary(),
+    Result :: term().
+-callback get_roster(LUser, LServer) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    Result :: term().
+-callback get_roster_by_jid_t(LUser, LServer, LJid) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    LJid :: ejabberd:simple_bare_jid(),
+    Result :: term().
+-callback get_subscription_lists(Acc, LUser, LServer) -> Result when
+    Acc :: term(),
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    Result :: term().
+-callback roster_subscribe_t(LUser, LServer, LJid, SJid) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    LJid :: ejabberd:simple_bare_jid(),
+    SJid :: roster(),
+    Result :: term().
+-callback get_roster_by_jid_with_groups_t(LUser, LServer, LJid) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    LJid :: ejabberd:simple_bare_jid(),
+    Result :: term().
+-callback remove_user(LUser, LServer) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    Result :: term().
+-callback update_roster_t(LUser, LServer, LJid, Item) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    LJid :: ejabberd:simple_bare_jid(),
+    Item :: roster(),
+    Result :: term().
+-callback del_roster_t(LUser, LServer, LJid) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    LJid :: ejabberd:simple_bare_jid(),
+    Result :: term().
+-callback read_subscription_and_groups(LUser, LServer, LJid) -> Result when
+    LUser :: ejabberd:luser(),
+    LServer :: ejabberd:lserver(),
+    LJid :: ejabberd:simple_bare_jid(),
+    Result :: term().
+
+
 -define(BACKEND, (mod_roster_backend:backend())).
 
 start(Host, Opts) ->

--- a/apps/ejabberd/src/mod_roster_mnesia.erl
+++ b/apps/ejabberd/src/mod_roster_mnesia.erl
@@ -13,6 +13,8 @@
 -include("mod_roster.hrl").
 -include("jlib.hrl").
 
+-behaviour(mod_roster).
+
 %% API
 -export([init/2,
          read_roster_version/2,

--- a/apps/ejabberd/src/mod_roster_odbc.erl
+++ b/apps/ejabberd/src/mod_roster_odbc.erl
@@ -14,6 +14,8 @@
 -include("mod_roster.hrl").
 -include("jlib.hrl").
 
+-behaviour(mod_roster).
+
 %% API
 -export([init/2,
          read_roster_version/2,

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -55,7 +55,7 @@
 -export([config_change/4]).
 
 -define(PROCNAME, ejabberd_mod_vcard).
--define(BACKEND, (mod_vcard_backend:backend())).
+-define(BACKEND, mod_vcard_backend).
 
 -record(state,{search           :: boolean(),
                host             :: binary(),
@@ -100,7 +100,7 @@
 %% gen_mod callbacks
 %%--------------------------------------------------------------------
 start(VHost, Opts) ->
-    gen_mod:start_backend_module(?MODULE, Opts),
+    gen_mod:start_backend_module(?MODULE, Opts, [set_vcard, get_vcard, search]),
     Proc = gen_mod:get_module_proc(VHost,?PROCNAME),
     ChildSpec = {Proc, {?MODULE, start_link, [VHost,Opts]},
                  transient, 1000, worker, [?MODULE]},

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -70,7 +70,9 @@ get_global_metric_names() ->
     get_host_metric_names(global).
 
 get_metric_value({Host, Name}) ->
-    exometer:get_value([Host, Name]).
+    get_metric_value([Host, Name]);
+get_metric_value(Metric) ->
+    exometer:get_value(Metric).
 
 get_metric_values(Host) ->
     exometer:get_values([Host]).
@@ -273,7 +275,12 @@ get_histograms(Host) ->
         ]
 ).
 
--define(GLOBAL_HISTOGRAMS, [raw_data_size, xml_stanza_size]).
+-define(GLOBAL_HISTOGRAMS, [[global, received, encrypted_data_size],
+                            [global, received, compressed_data_size],
+                            [global, received, xml_stanza_size],
+                            [global, sent, encrypted_data_size],
+                            [global, sent, compressed_data_size],
+                            [global, sent, xml_stanza_size]]).
 
 create_global_metrics() ->
     lists:foreach(fun({Metric, FunSpec, DataPoints}) ->
@@ -282,7 +289,7 @@ create_global_metrics() ->
     end, get_vm_stats()),
     lists:foreach(fun({Metric, Spec}) -> exometer:new(Metric, Spec) end,
                   ?GLOBAL_COUNTERS),
-    lists:foreach(fun(Metric) -> exometer:new([global, Metric], histogram) end,
+    lists:foreach(fun(Metric) -> exometer:new(Metric, histogram) end,
                   ?GLOBAL_HISTOGRAMS).
 
 get_vm_stats() ->

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -275,12 +275,12 @@ get_histograms(Host) ->
         ]
 ).
 
--define(GLOBAL_HISTOGRAMS, [[global, received, encrypted_data_size],
-                            [global, received, compressed_data_size],
-                            [global, received, xml_stanza_size],
-                            [global, sent, encrypted_data_size],
-                            [global, sent, compressed_data_size],
-                            [global, sent, xml_stanza_size]]).
+-define(GLOBAL_HISTOGRAMS, [[data, received, encrypted_data_size],
+                            [data, received, compressed_data_size],
+                            [data, received, xml_stanza_size],
+                            [data, sent, encrypted_data_size],
+                            [data, sent, compressed_data_size],
+                            [data, sent, xml_stanza_size]]).
 
 create_global_metrics() ->
     lists:foreach(fun({Metric, FunSpec, DataPoints}) ->

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -81,8 +81,11 @@ get_metric_value({Host, Name}) ->
 get_metric_value(Metric) ->
     exometer:get_value(Metric).
 
+get_metric_values(Metric) when is_list(Metric) ->
+    exometer:get_values(Metric);
 get_metric_values(Host) ->
     exometer:get_values([Host]).
+
 
 get_aggregated_values(Metric) ->
     exometer:aggregate([{{['_',Metric],'_','_'},[],[true]}], [one, count, value]).

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -124,7 +124,7 @@ get_odbc_stats(ODBCWorkers) ->
     merge_stats(PortStats).
 %%
 
-get_port_from_odbc_connection({ok, mysql, Pid}) ->
+get_port_from_odbc_connection({ok, DbType, Pid}) when DbType =:= mysql; DbType =:= pgsql ->
     %% Pid of mysql_conn process
     {links, [MySQLRecv]} = erlang:process_info(Pid, links),
     %% Port is hold by mysql_recv process which is linked to the mysql_conn

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -35,6 +35,7 @@
          increment_generic_hook_metric/2,
          get_odbc_data_stats/0,
          get_odbc_mam_async_stats/0,
+         get_dist_data_stats/0,
          remove_host_metrics/1,
          remove_all_metrics/0]).
 
@@ -110,6 +111,9 @@ do_increment_generic_hook_metric({_, skip}) ->
 do_increment_generic_hook_metric(MetricName) ->
     update(MetricName, 1).
 
+get_dist_data_stats() ->
+    DistStats = [inet_stats(Port) || {_, Port} <- erlang:system_info(dist_ctrl)],
+    [{connections, length(DistStats)} | merge_stats(DistStats)].
 
 get_odbc_data_stats() ->
     RegularODBCWorkers = [ejabberd_odbc_sup:get_pids(Host) || Host <- ?MYHOSTS],

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -20,10 +20,12 @@
 %% API
 -export([update/2,
          start_graphite_reporter/1,
+         start_graphite_reporter/2,
          start_host_metrics_subscriptions/3,
          start_vm_metrics_subscriptions/2,
          start_global_metrics_subscriptions/2,
          start_data_metrics_subscriptions/2,
+         start_backend_metrics_subscriptions/2,
          get_metric_value/1,
          get_metric_values/1,
          get_host_metric_names/1,
@@ -46,11 +48,11 @@ update(Name, Change) ->
     exometer:update(Name, Change).
 
 start_graphite_reporter(GraphiteHost) ->
+    start_graphite_reporter(GraphiteHost, []).
+start_graphite_reporter(GraphiteHost, Opts) ->
     GraphiteOpts = [{prefix, "exometer." ++ atom_to_list(node())},
-        {host, GraphiteHost},
-        {connect_timeout, 5000},
-        {port, 2003},
-        {api_key, ""}],
+                    {host, GraphiteHost}]
+                   ++ merge_opts(Opts),
     case exometer_report:add_reporter(exometer_report_graphite, GraphiteOpts) of
         ok ->
             {ok, exometer_report_graphite};
@@ -59,7 +61,7 @@ start_graphite_reporter(GraphiteHost) ->
     end.
 
 start_host_metrics_subscriptions(Reporter, Host, Interval) ->
-    do_start_host_metrics_subscriptions(check_reporter(Reporter), Host, Interval).
+    do_start_metrics_subscriptions(check_reporter(Reporter), Interval, [Host]).
 
 start_vm_metrics_subscriptions(Reporter, Interval) ->
     do_start_vm_metrics_subscriptions(check_reporter(Reporter), Interval).
@@ -68,7 +70,10 @@ start_global_metrics_subscriptions(Reporter, Interval) ->
     do_start_global_metrics_subscriptions(check_reporter(Reporter), Interval).
 
 start_data_metrics_subscriptions(Reporter, Interval) ->
-    do_start_data_metrics_subscriptions(check_reporter(Reporter), Interval).
+    do_start_metrics_subscriptions(check_reporter(Reporter), Interval, [data]).
+
+start_backend_metrics_subscriptions(Reporter, Interval) ->
+    do_start_metrics_subscriptions(check_reporter(Reporter), Interval, [backends]).
 
 get_host_metric_names(Host) ->
     [MetricName || {[_Host, MetricName | _], _, _} <- exometer:find_entries([Host])].
@@ -124,7 +129,7 @@ get_odbc_data_stats() ->
 
 get_odbc_mam_async_stats() ->
     %% MAM async ODBC workers are organized differently...
-    MamAsynODBCWorkers = [element(2, gen_server:call(Pid, get_connection)) || {_, Pid, worker, _} <- supervisor:which_children(mod_mam_sup)],
+    MamAsynODBCWorkers = [catch element(2, gen_server:call(Pid, get_connection, 1000)) || {_, Pid, worker, _} <- supervisor:which_children(mod_mam_sup)],
     get_odbc_stats(MamAsynODBCWorkers).
 
 get_odbc_stats(ODBCWorkers) ->
@@ -405,11 +410,6 @@ check_reporter(Reporter) ->
             {error, {no_such_reporter}}
     end.
 
-do_start_host_metrics_subscriptions({ok, Reporter}, Host, Interval) ->
-    [subscribe_metric(Reporter, Metric, Interval)
-     || Metric <- exometer:find_entries([Host])];
-do_start_host_metrics_subscriptions(Error, _, _) ->
-    Error.
 
 do_start_vm_metrics_subscriptions({ok, Reporter}, Interval) ->
     [exometer_report:subscribe(Reporter, Metric, DataPoints, Interval)
@@ -417,18 +417,18 @@ do_start_vm_metrics_subscriptions({ok, Reporter}, Interval) ->
 do_start_vm_metrics_subscriptions(Error, _) ->
     Error.
 
-
 do_start_global_metrics_subscriptions({ok, Reporter}, Interval) ->
     [exometer_report:subscribe(Reporter, Metric, default, Interval)
      || {Metric, _} <- ?GLOBAL_COUNTERS];
 do_start_global_metrics_subscriptions(Error, _) ->
     Error.
 
-do_start_data_metrics_subscriptions({ok, Reporter}, Interval) ->
+do_start_metrics_subscriptions({ok, Reporter}, Interval, MetricPrefix) ->
     [subscribe_metric(Reporter, Metric, Interval)
-     || Metric <- exometer:find_entries([data])];
-do_start_data_metrics_subscriptions(Error, _) ->
+     || Metric <- exometer:find_entries(MetricPrefix)];
+do_start_metrics_subscriptions(Error, _, _) ->
     Error.
+
 
 subscribe_metric(Reporter, {Name, counter, _}, Interval) ->
     exometer_report:subscribe(Reporter, Name, [value], Interval);
@@ -436,3 +436,13 @@ subscribe_metric(Reporter, {Name, histogram, _}, Interval) ->
     exometer_report:subscribe(Reporter, Name, [min, mean, max, median, 95, 99, 999], Interval);
 subscribe_metric(Reporter, {Name, _, _}, Interval) ->
     exometer_report:subscribe(Reporter, Name, default, Interval).
+
+merge_opts(Opts) ->
+    Defaults = [{connect_timeout, 5000},
+                {port, 2003},
+                {api_key, ""}],
+
+    MergeFun = fun(_, _, V2) -> V2 end,
+    orddict:to_list(orddict:merge(MergeFun,
+                                  orddict:from_list(Defaults),
+                                  orddict:from_list(Opts))).

--- a/apps/ejabberd/src/xml_stream.erl
+++ b/apps/ejabberd/src/xml_stream.erl
@@ -119,10 +119,7 @@ parse(#xml_stream_state{callback_pid = CallbackPid,
                         stack = Stack,
                         size = Size,
                         maxsize = MaxSize} = State, Str) ->
-    StrSize = if
-                  is_list(Str) -> length(Str);
-                  is_binary(Str) -> size(Str)
-              end,
+    StrSize = size(Str),
     Res = port_control(Port, ?PARSE_COMMAND, Str),
     {NewStack, NewSize} =
         lists:foldl(

--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -60,7 +60,7 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
 [{sys, [
         {lib_dirs, ["../apps", "../deps"]},
         {incl_cond, exclude},
-        {rel, "mongooseim", "", [mongoose | AppsToRun]},
+        {rel, "mongooseim", "", [mongooseim | AppsToRun]},
         {rel, "start_clean", "", [kernel,stdlib]},
         {boot_rel, "mongooseim"},
         {profile, embedded},
@@ -68,7 +68,7 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
         {excl_sys_filters, ["^bin/.*",
                             "^erts.*/bin/(dialyzer|typer)"]},
 
-        {app, mongoose, [{incl_cond, include}, {lib_dir, ".."}]}
+        {app, mongooseim, [{incl_cond, include}, {lib_dir, ".."}]}
        ] ++ IncludeApps},
 
 

--- a/src/mongooseim.erl
+++ b/src/mongooseim.erl
@@ -1,0 +1,24 @@
+%%==============================================================================
+%% Copyright 2014 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mongooseim).
+
+
+%% API
+-export([start/0]).
+
+start() ->
+    application:start(mongooseim),
+    ejabberd:start().

--- a/tools/summarise-ct-results
+++ b/tools/summarise-ct-results
@@ -21,5 +21,5 @@ main(Directories) ->
         true ->
             erlang:halt(100404);
         _ ->
-            erlang:halt(Failed)
+            erlang:halt(Failed + AutoSkipped)
     end.


### PR DESCRIPTION
* add metrics related to received and sent xmpp data size
* inet stats for:
    * regular odbc workers (all types)
    * async mam workers
    * distributed Erlang
* allows to specify time execution of which backend functions should be measured
* improve global metrics to be properly reported
* other minor improvements