### PR TITLE
Auth refactoring

### DIFF
--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -340,9 +340,9 @@ update_module(ModuleNameString) ->
                                       | {'ok', io_lib:chars()}.
 register(User, Host, Password) ->
     case ejabberd_auth:try_register(User, Host, Password) of
-        {atomic, ok} ->
+        ok ->
             {ok, io_lib:format("User ~s@~s successfully registered", [User, Host])};
-        {atomic, exists} ->
+        {error, exists} ->
             String = io_lib:format("User ~s@~s already registered at node ~p",
                                    [User, Host, node()]),
             {exists, String};

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -419,8 +419,7 @@ do_does_user_exist(LUser, LServer) when LUser =:= error; LServer =:= error ->
 do_does_user_exist(LUser, LServer) ->
     lists:any(
         fun(M) ->
-            %%TODO change the name in backend modules
-            case M:is_user_exists(LUser, LServer) of
+            case M:does_user_exist(LUser, LServer) of
                 {error, Error} ->
                     ?ERROR_MSG("The authentication module ~p returned an "
                     "error~nwhen checking user ~p in server ~p~n"

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -318,16 +318,9 @@ get_vh_registered_users(Server, Opts) ->
 do_get_vh_registered_users(error, _) ->
     [];
 do_get_vh_registered_users(LServer, Opts) ->
-    %%TODO do not check if function exported - implement this in backend modules
     lists:flatmap(
         fun(M) ->
-            case erlang:function_exported(
-                M, get_vh_registered_users, 2) of
-                true ->
-                    M:get_vh_registered_users(LServer, Opts);
-                false ->
-                    M:get_vh_registered_users(LServer)
-            end
+            M:get_vh_registered_users(LServer, Opts)
         end, auth_modules(LServer)).
 
 
@@ -356,17 +349,10 @@ get_vh_registered_users_number(Server, Opts) ->
 do_get_vh_registered_users_number(error, _) ->
     0;
 do_get_vh_registered_users_number(LServer, Opts) ->
-    %%TODO do not check if function exported - implement this in backend modules
     lists:sum(
         lists:map(
             fun(M) ->
-                case erlang:function_exported(
-                    M, get_vh_registered_users_number, 2) of
-                    true ->
-                        M:get_vh_registered_users_number(LServer, Opts);
-                    false ->
-                        length(M:get_vh_registered_users(LServer))
-                end
+                M:get_vh_registered_users_number(LServer, Opts)
             end, auth_modules(LServer))).
 
 
@@ -389,17 +375,15 @@ do_get_password(LUser, LServer) ->
         end, false, auth_modules(LServer)).
 
 
--spec get_password_s(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> binary().
-get_password_s(User, Server) ->
-    %%TODO use get_password_s from modules
-    case get_password(User, Server) of
-        false ->
-            <<"">>;
-        Password ->
-            Password
-    end.
-
+-spec get_password_s(User :: ejabberd:luser(),
+                     Server :: ejabberd:lserver()) -> binary().
+get_password_s(LUser, LServer) ->
+    lists:foldl(
+        fun(M, false) ->
+            M:get_password_s(LUser, LServer);
+            (_M, Password) ->
+                Password
+        end, <<"">>, auth_modules(LServer)).
 
 %% @doc Get the password of the user and the auth module.
 -spec get_password_with_authmodule(User :: ejabberd:user(),

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -24,8 +24,6 @@
 %%%
 %%%----------------------------------------------------------------------
 
-%% TODO: Use the functions in ejabberd auth to add and remove users.
-
 -module(ejabberd_auth).
 -author('alexey@process-one.net').
 
@@ -119,7 +117,15 @@ store_type(Server) ->
                      Server :: ejabberd:server(),
                      Password :: binary() ) -> boolean().
 check_password(User, Server, Password) ->
-    case check_password_with_authmodule(User, Server, Password) of
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_check_password(LUser, LServer, Password).
+
+-spec do_check_password(ejabberd:luser(), ejabberd:lserver(), binary()) -> boolean().
+do_check_password(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+    false;
+do_check_password(LUser, LServer, Password) ->
+    case check_password_with_authmodule(LUser, LServer, Password) of
         {true, _AuthModule} -> true;
         false -> false
     end.
@@ -131,8 +137,20 @@ check_password(User, Server, Password) ->
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
 check_password(User, Server, Password, Digest, DigestGen) ->
-    case check_password_with_authmodule(User, Server, Password,
-                                        Digest, DigestGen) of
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_check_password(LUser, LServer, Password, Digest, DigestGen).
+
+-spec do_check_password(User :: ejabberd:luser(),
+                     Server :: ejabberd:lserver(),
+                     Password :: binary(),
+                     Digest :: binary(),
+                     DigestGen :: fun()) -> boolean().
+do_check_password(LUser, LServer, _,_,_)
+    when LUser =:= error; LServer =:= error ->
+    false;
+do_check_password(LUser, LServer, Password, Digest, DigestGen) ->
+    case check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen) of
         {true, _AuthModule} -> true;
         false -> false
     end.
@@ -145,7 +163,15 @@ check_password(User, Server, Password, Digest, DigestGen) ->
                                      Password :: binary()
                                      ) -> 'false' | {'true', authmodule()}.
 check_password_with_authmodule(User, Server, Password) ->
-    check_password_loop(auth_modules(Server), [User, Server, Password]).
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_check_password_with_authmodule(LUser, LServer, Password).
+
+do_check_password_with_authmodule(LUser, LServer, _)
+    when LUser =:= error; LServer =:= error ->
+    false;
+do_check_password_with_authmodule(LUser, LServer, Password) ->
+    check_password_loop(auth_modules(LServer), [LUser, LServer, Password]).
 
 -spec check_password_with_authmodule(User :: binary(),
                                      Server :: binary(),
@@ -154,7 +180,15 @@ check_password_with_authmodule(User, Server, Password) ->
                                      DigestGen :: fun()
                                      ) -> 'false' | {'true', authmodule()}.
 check_password_with_authmodule(User, Server, Password, Digest, DigestGen) ->
-    check_password_loop(auth_modules(Server), [User, Server, Password,
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen).
+
+do_check_password_with_authmodule(LUser, LServer, _, _, _)
+    when LUser =:= error; LServer =:= error ->
+    false;
+do_check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen) ->
+    check_password_loop(auth_modules(LServer), [LUser, LServer, Password,
                                                Digest, DigestGen]).
 
 -spec check_password_loop(AuthModules :: [authmodule()],
@@ -170,6 +204,7 @@ check_password_loop([AuthModule | AuthModules], Args) ->
             check_password_loop(AuthModules, Args)
     end.
 
+-spec check_digest(binary(), fun(), binary(), binary()) -> boolean().
 check_digest(Digest, DigestGen, Password, Passwd) ->
     DigRes = if
                  Digest /= <<>> ->
@@ -191,12 +226,19 @@ set_password(_User, _Server, "") ->
     %% We do not allow empty password
     {error, empty_password};
 set_password(User, Server, Password) ->
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nodeprep(Server),
+    do_set_password(LUser, LServer, Password).
+
+do_set_password(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+    {error, invalid_jid};
+do_set_password(LUser, LServer, Password) ->
     lists:foldl(
       fun(M, {error, _}) ->
-              M:set_password(User, Server, Password);
+              M:set_password(LUser, LServer, Password);
          (_M, Res) ->
               Res
-      end, {error, not_allowed}, auth_modules(Server)).
+      end, {error, not_allowed}, auth_modules(LServer)).
 
 
 -spec try_register(User :: ejabberd:user(),
@@ -207,28 +249,38 @@ try_register(_User, _Server, "") ->
     %% We do not allow empty password
     {error, not_allowed};
 try_register(User, Server, Password) ->
-    case is_user_exists(User,Server) of
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nodeprep(Server),
+    do_try_register(LUser, LServer, Password).
+
+-spec do_try_register(ejabberd:luser(), ejabberd:lserver(),binary())
+        -> ok | {error, exists | not_allowed | invalid_jid}.
+do_try_register(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+    {error, invalid_jid};
+do_try_register(LUser, LServer, Password) ->
+    Exists = is_user_exists(LUser,LServer),
+    do_try_register_if_does_not_exist(Exists, LUser, LServer, Password).
+
+do_try_register_if_does_not_exist(true, _, _, _) ->
+    {error, exists};
+do_try_register_if_does_not_exist(_, LUser, LServer, Password) ->
+    case lists:member(LServer, ?MYHOSTS) of
         true ->
-            {error, exists};
+            Res = lists:foldl(
+                fun(_M, {atomic, ok} = Res) ->
+                    Res;
+                    (M, _) ->
+                        M:try_register(LUser, LServer, Password)
+                end, {error, not_allowed}, auth_modules(LServer)),
+            case Res of
+                ok ->
+                    ejabberd_hooks:run(register_user, LServer,
+                        [LUser, LServer]),
+                    ok;
+                _ -> Res
+            end;
         false ->
-            case lists:member(jlib:nameprep(Server), ?MYHOSTS) of
-                true ->
-                    Res = lists:foldl(
-                      fun(_M, {atomic, ok} = Res) ->
-                              Res;
-                         (M, _) ->
-                              M:try_register(User, Server, Password)
-                      end, {error, not_allowed}, auth_modules(Server)),
-                    case Res of
-                        ok ->
-                            ejabberd_hooks:run(register_user, Server,
-                                               [User, Server]),
-                            ok;
-                        _ -> Res
-                    end;
-                false ->
-                    {error, not_allowed}
-            end
+            {error, not_allowed}
     end.
 
 
@@ -245,74 +297,102 @@ dirty_get_registered_users() ->
 -spec get_vh_registered_users(Server :: ejabberd:server()
                              ) -> [ejabberd:simple_jid()].
 get_vh_registered_users(Server) ->
+    LServer = jlib:nameprep(Server),
+    do_get_vh_registered_users(LServer).
+
+do_get_vh_registered_users(error) ->
+    [];
+do_get_vh_registered_users(LServer) ->
     lists:flatmap(
       fun(M) ->
-              M:get_vh_registered_users(Server)
-      end, auth_modules(Server)).
+              M:get_vh_registered_users(LServer)
+      end, auth_modules(LServer)).
 
 
 -spec get_vh_registered_users(Server :: ejabberd:server(),
                               Opts :: [any()]) -> [ejabberd:simple_jid()].
 get_vh_registered_users(Server, Opts) ->
+    LServer = jlib:nameprep(Server),
+    do_get_vh_registered_users(LServer, Opts).
+
+do_get_vh_registered_users(error, _) ->
+    [];
+do_get_vh_registered_users(LServer, Opts) ->
+    %%TODO do not check if function exported - implement this in backend modules
     lists:flatmap(
-      fun(M) ->
-                case erlang:function_exported(
-                       M, get_vh_registered_users, 2) of
-                    true ->
-                        M:get_vh_registered_users(Server, Opts);
-                    false ->
-                        M:get_vh_registered_users(Server)
-                end
-      end, auth_modules(Server)).
+        fun(M) ->
+            case erlang:function_exported(
+                M, get_vh_registered_users, 2) of
+                true ->
+                    M:get_vh_registered_users(LServer, Opts);
+                false ->
+                    M:get_vh_registered_users(LServer)
+            end
+        end, auth_modules(LServer)).
 
 
 -spec get_vh_registered_users_number(Server :: ejabberd:server()
                                     ) -> integer().
 get_vh_registered_users_number(Server) ->
+    LServer = jlib:nameprep(Server),
+    do_get_vh_registered_users_number(LServer).
+
+do_get_vh_registered_users_number(error) ->
+    0;
+do_get_vh_registered_users_number(LServer) ->
     lists:sum(
-      lists:map(
-        fun(M) ->
-                case erlang:function_exported(
-                       M, get_vh_registered_users_number, 1) of
-                    true ->
-                        M:get_vh_registered_users_number(Server);
-                    false ->
-                        length(M:get_vh_registered_users(Server))
-                end
-        end, auth_modules(Server))).
+        lists:map(
+            fun(M) ->
+                M:get_vh_registered_users_number(LServer)
+            end, auth_modules(LServer))).
 
 
 -spec get_vh_registered_users_number(Server :: ejabberd:server(),
                                      Opts :: list()) -> integer().
 get_vh_registered_users_number(Server, Opts) ->
+    LServer = jlib:nameprep(Server),
+    do_get_vh_registered_users_number(LServer, Opts).
+
+do_get_vh_registered_users_number(error, _) ->
+    0;
+do_get_vh_registered_users_number(LServer, Opts) ->
+    %%TODO do not check if function exported - implement this in backend modules
     lists:sum(
-      lists:map(
-        fun(M) ->
+        lists:map(
+            fun(M) ->
                 case erlang:function_exported(
-                       M, get_vh_registered_users_number, 2) of
+                    M, get_vh_registered_users_number, 2) of
                     true ->
-                        M:get_vh_registered_users_number(Server, Opts);
+                        M:get_vh_registered_users_number(LServer, Opts);
                     false ->
-                        length(M:get_vh_registered_users(Server))
+                        length(M:get_vh_registered_users(LServer))
                 end
-        end, auth_modules(Server))).
+            end, auth_modules(LServer))).
 
 
 %% @doc Get the password of the user.
 -spec get_password(User :: ejabberd:user(),
                    Server :: ejabberd:server()) -> binary() | false.
 get_password(User, Server) ->
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_get_password(LUser, LServer).
+
+do_get_password(LUser, LServer) when LUser =:= error; LServer =:= error ->
+    false;
+do_get_password(LUser, LServer) ->
     lists:foldl(
-      fun(M, false) ->
-              M:get_password(User, Server);
-         (_M, Password) ->
-              Password
-      end, false, auth_modules(Server)).
+        fun(M, false) ->
+            M:get_password(LUser, LServer);
+            (_M, Password) ->
+                Password
+        end, false, auth_modules(LServer)).
 
 
 -spec get_password_s(User :: ejabberd:user(),
                      Server :: ejabberd:server()) -> binary().
 get_password_s(User, Server) ->
+    %%TODO use get_password_s from modules
     case get_password(User, Server) of
         false ->
             <<"">>;
@@ -326,32 +406,47 @@ get_password_s(User, Server) ->
                                    Server :: ejabberd:server())
       -> {Password::binary(), AuthModule :: authmodule()} | {'false', 'none'}.
 get_password_with_authmodule(User, Server) ->
-    lists:foldl(
-      fun(M, {false, _}) ->
-              {M:get_password(User, Server), M};
-         (_M, {Password, AuthModule}) ->
-              {Password, AuthModule}
-      end, {false, none}, auth_modules(Server)).
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_get_password_with_authmodule(LUser, LServer).
 
+do_get_password_with_authmodule(LUser, LServer)
+    when LUser =:= error; LServer =:= error ->
+    {false, none};
+do_get_password_with_authmodule(LUser, LServer) ->
+    lists:foldl(
+        fun(M, {false, _}) ->
+            {M:get_password(LUser, LServer), M};
+            (_M, {Password, AuthModule}) ->
+                {Password, AuthModule}
+        end, {false, none}, auth_modules(LServer)).
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
 -spec is_user_exists(User :: ejabberd:user(),
                      Server :: ejabberd:server()) -> boolean().
 is_user_exists(User, Server) ->
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_does_user_exist(LUser, LServer).
+
+do_does_user_exist(LUser, LServer) when LUser =:= error; LServer =:= error ->
+    false;
+do_does_user_exist(LUser, LServer) ->
     lists:any(
-      fun(M) ->
-              case M:is_user_exists(User, Server) of
-                  {error, Error} ->
-                      ?ERROR_MSG("The authentication module ~p returned an "
-                                 "error~nwhen checking user ~p in server ~p~n"
-                                 "Error message: ~p",
-                                 [M, User, Server, Error]),
-                      false;
-                  Else ->
-                      Else
-              end
-      end, auth_modules(Server)).
+        fun(M) ->
+            %%TODO change the name in backend modules
+            case M:is_user_exists(LUser, LServer) of
+                {error, Error} ->
+                    ?ERROR_MSG("The authentication module ~p returned an "
+                    "error~nwhen checking user ~p in server ~p~n"
+                    "Error message: ~p",
+                        [M, LUser, LServer, Error]),
+                    false;
+                Else ->
+                    Else
+            end
+        end, auth_modules(LServer)).
 
 %% Check if the user exists in all authentications module except the module
 %% passed as parameter
@@ -360,19 +455,27 @@ is_user_exists(User, Server) ->
                                       Server :: ejabberd:server()
                                       ) -> boolean() | 'maybe'.
 is_user_exists_in_other_modules(Module, User, Server) ->
-    is_user_exists_in_other_modules_loop(
-      auth_modules(Server)--[Module],
-      User, Server).
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_does_user_exist_in_other_modules(Module, LUser, LServer).
 
-
-is_user_exists_in_other_modules_loop([], _User, _Server) ->
+do_does_user_exist_in_other_modules(_, LUser, LServer)
+    when LUser =:= error; LServer =:= error ->
     false;
-is_user_exists_in_other_modules_loop([AuthModule|AuthModules], User, Server) ->
+do_does_user_exist_in_other_modules(Module, LUser, LServer) ->
+    does_user_exist_in_other_modules_loop(
+        auth_modules(LServer)--[Module],
+        LUser, LServer).
+
+
+does_user_exist_in_other_modules_loop([], _User, _Server) ->
+    false;
+does_user_exist_in_other_modules_loop([AuthModule|AuthModules], User, Server) ->
     case AuthModule:is_user_exists(User, Server) of
         true ->
             true;
         false ->
-            is_user_exists_in_other_modules_loop(AuthModules, User, Server);
+            does_user_exist_in_other_modules_loop(AuthModules, User, Server);
         {error, Error} ->
             ?DEBUG("The authentication module ~p returned an error~nwhen "
                    "checking user ~p in server ~p~nError message: ~p",
@@ -386,8 +489,15 @@ is_user_exists_in_other_modules_loop([AuthModule|AuthModules], User, Server) ->
 -spec remove_user(User :: ejabberd:user(),
                   Server :: ejabberd:server()) -> ok | error | {error, not_allowed}.
 remove_user(User, Server) ->
-    [M:remove_user(User, Server) || M <- auth_modules(Server)],
-    ejabberd_hooks:run(remove_user, jlib:nameprep(Server), [User, Server]),
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_remove_user(LUser, LServer).
+
+do_remove_user(LUser, LServer) when LUser =:= error; LServer =:= error ->
+    error;
+do_remove_user(LUser, LServer) ->
+    [M:remove_user(LUser, LServer) || M <- auth_modules(LServer)],
+    ejabberd_hooks:run(remove_user, LServer, [LUser, LServer]),
     ok.
 
 %% @doc Try to remove user if the provided password is correct.
@@ -399,15 +509,22 @@ remove_user(User, Server) ->
                   Password :: binary()
                   ) -> ok | not_exists | not_allowed | bad_request | error.
 remove_user(User, Server, Password) ->
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_remove_user(LUser, LServer, Password).
+
+do_remove_user(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+    error;
+do_remove_user(LUser, LServer, Password) ->
     R = lists:foldl(
-      fun(_M, ok = Res) ->
-              Res;
-         (M, _) ->
-              M:remove_user(User, Server, Password)
-      end, error, auth_modules(Server)),
+        fun(_M, ok = Res) ->
+            Res;
+            (M, _) ->
+                M:remove_user(LUser, LServer, Password)
+        end, error, auth_modules(LServer)),
     case R of
-      ok -> ejabberd_hooks:run(remove_user, jlib:nameprep(Server), [User, Server]);
-      _ -> none
+        ok -> ejabberd_hooks:run(remove_user, LServer, [LUser, LServer]);
+        _ -> none
     end,
     R.
 
@@ -450,9 +567,8 @@ auth_modules() ->
 
 
 %% Return the list of authenticated modules for a given host
--spec auth_modules(Server :: ejabberd:server()) -> [authmodule()].
-auth_modules(Server) ->
-    LServer = jlib:nameprep(Server),
+-spec auth_modules(Server :: ejabberd:lserver()) -> [authmodule()].
+auth_modules(LServer) ->
     Method = ejabberd_config:get_local_option({auth_method, LServer}),
     Methods = if
                   Method == undefined -> [];

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -375,11 +375,18 @@ do_get_password(LUser, LServer) ->
         end, false, auth_modules(LServer)).
 
 
--spec get_password_s(User :: ejabberd:luser(),
-                     Server :: ejabberd:lserver()) -> binary().
-get_password_s(LUser, LServer) ->
+-spec get_password_s(User :: ejabberd:user(),
+                     Server :: ejabberd:server()) -> binary().
+get_password_s(User, Server) ->
+    LUser = jlib:nodeprep(User),
+    LServer = jlib:nameprep(Server),
+    do_get_password_s(LUser, LServer).
+
+do_get_password_s(LUser, LServer) when LUser =:= error; LServer =:= error ->
+    <<"">>;
+do_get_password_s(LUser, LServer) ->
     lists:foldl(
-        fun(M, false) ->
+        fun(M, <<"">>) ->
             M:get_password_s(LUser, LServer);
             (_M, Password) ->
                 Password

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -202,14 +202,14 @@ set_password(User, Server, Password) ->
 -spec try_register(User :: ejabberd:user(),
                    Server :: ejabberd:server(),
                    Password :: binary()
-                   ) -> {atomic, ok | exists} | {error, not_allowed}.
+                   ) -> ok | {error, exists | not_allowed | invalid_jid}.
 try_register(_User, _Server, "") ->
     %% We do not allow empty password
     {error, not_allowed};
 try_register(User, Server, Password) ->
     case is_user_exists(User,Server) of
         true ->
-            {atomic, exists};
+            {error, exists};
         false ->
             case lists:member(jlib:nameprep(Server), ?MYHOSTS) of
                 true ->
@@ -220,10 +220,10 @@ try_register(User, Server, Password) ->
                               M:try_register(User, Server, Password)
                       end, {error, not_allowed}, auth_modules(Server)),
                     case Res of
-                        {atomic, ok} ->
+                        ok ->
                             ejabberd_hooks:run(register_user, Server,
                                                [User, Server]),
-                            {atomic, ok};
+                            ok;
                         _ -> Res
                     end;
                 false ->

--- a/apps/ejabberd/src/ejabberd_auth_anonymous.erl
+++ b/apps/ejabberd/src/ejabberd_auth_anonymous.erl
@@ -90,14 +90,14 @@ stop(Host) ->
 
 
 %% @doc Return true if anonymous is allowed for host or false otherwise
--spec allow_anonymous(Host :: ejabberd:server()) -> boolean().
+-spec allow_anonymous(Host :: ejabberd:lserver()) -> boolean().
 allow_anonymous(Host) ->
     lists:member(?MODULE, ejabberd_auth:auth_modules(Host)).
 
 
 %% @doc Return true if anonymous mode is enabled and if anonymous protocol is
 %% SASL anonymous protocol can be: sasl_anon|login_anon|both
--spec is_sasl_anonymous_enabled(Host :: ejabberd:server()) -> boolean().
+-spec is_sasl_anonymous_enabled(Host :: ejabberd:lserver()) -> boolean().
 is_sasl_anonymous_enabled(Host) ->
     case allow_anonymous(Host) of
         false -> false;
@@ -113,7 +113,7 @@ is_sasl_anonymous_enabled(Host) ->
 %% @doc Return true if anonymous login is enabled on the server
 %% anonymous login can be use using standard authentication method (i.e. with
 %% clients that do not support anonymous login)
--spec is_login_anonymous_enabled(Host :: ejabberd:server()) -> boolean().
+-spec is_login_anonymous_enabled(Host :: ejabberd:lserver()) -> boolean().
 is_login_anonymous_enabled(Host) ->
     case allow_anonymous(Host) of
         false -> false;
@@ -128,7 +128,7 @@ is_login_anonymous_enabled(Host) ->
 
 %% @doc Return the anonymous protocol to use: sasl_anon|login_anon|both
 %% defaults to login_anon
--spec anonymous_protocol(Host :: ejabberd:server()) ->
+-spec anonymous_protocol(Host :: ejabberd:lserver()) ->
                                       'both' | 'login_anon' | 'sasl_anon'.
 anonymous_protocol(Host) ->
     case ejabberd_config:get_local_option({anonymous_protocol, Host}) of
@@ -141,17 +141,15 @@ anonymous_protocol(Host) ->
 
 %% @doc Return true if multiple connections have been allowed in the config file
 %% defaults to false
--spec allow_multiple_connections(Host :: ejabberd:server()) -> boolean().
+-spec allow_multiple_connections(Host :: ejabberd:lserver()) -> boolean().
 allow_multiple_connections(Host) ->
     ejabberd_config:get_local_option({allow_multiple_connections, Host}) =:= true.
 
 
 %% @doc Check if user exist in the anonymus database
--spec anonymous_user_exist(User :: ejabberd:user(),
-                           Server :: ejabberd:server()) -> boolean().
-anonymous_user_exist(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+-spec anonymous_user_exist(LUser :: ejabberd:luser(),
+                           LServer :: ejabberd:lserver()) -> boolean().
+anonymous_user_exist(LUser, LServer) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read({anonymous, US}) of
         [] ->
@@ -215,35 +213,35 @@ purge_hook(true, LUser, LServer) ->
 
 %% @doc When anonymous login is enabled, check the password for permenant users
 %% before allowing access
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary()) -> boolean().
-check_password(User, Server, Password) ->
-    check_password(User, Server, Password, undefined, undefined).
-check_password(User, Server, _Password, _Digest, _DigestGen) ->
+check_password(LUser, LServer, Password) ->
+    check_password(LUser, LServer, Password, undefined, undefined).
+check_password(LUser, LServer, _Password, _Digest, _DigestGen) ->
     %% We refuse login for registered accounts (They cannot logged but
     %% they however are "reserved")
     case ejabberd_auth:is_user_exists_in_other_modules(?MODULE,
-                                                       User, Server) of
+                                                       LUser, LServer) of
         %% If user exists in other module, reject anonnymous authentication
         true  -> false;
         %% If we are not sure whether the user exists in other module, reject anon auth
         maybe  -> false;
-        false -> login(User, Server)
+        false -> login(LUser, LServer)
     end.
 
 
--spec login(User :: ejabberd:user(),
-            Server :: ejabberd:server()) -> boolean().
-login(User, Server) ->
-    case is_login_anonymous_enabled(Server) of
+-spec login(LUser :: ejabberd:luser(),
+            LServer :: ejabberd:lserver()) -> boolean().
+login(LUser, LServer) ->
+    case is_login_anonymous_enabled(LServer) of
         false -> false;
         true  ->
-            case anonymous_user_exist(User, Server) of
+            case anonymous_user_exist(LUser, LServer) of
                 %% Reject the login if an anonymous user with the same login
                 %% is already logged and if multiple login has not been enable
                 %% in the config file.
-                true  -> allow_multiple_connections(Server);
+                true  -> allow_multiple_connections(LServer);
                 %% Accept login and add user to the anonymous table
                 false -> true
             end
@@ -252,11 +250,11 @@ login(User, Server) ->
 
 %% @doc When anonymous login is enabled, check that the user is permanent before
 %% changing its password
--spec set_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec set_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()) -> ok | {error, not_allowed}.
-set_password(User, Server, _Password) ->
-    case anonymous_user_exist(User, Server) of
+set_password(LUser, LServer, _Password) ->
+    case anonymous_user_exist(LUser, LServer) of
         true ->
             ok;
         false ->
@@ -265,37 +263,37 @@ set_password(User, Server, _Password) ->
 
 %% @doc When anonymous login is enabled, check if permanent users are allowed on
 %% the server:
--spec try_register(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec try_register(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()) -> {error, not_allowed}.
-try_register(_User, _Server, _Password) ->
+try_register(_LUser, _LServer, _Password) ->
     {error, not_allowed}.
 
 -spec dirty_get_registered_users() -> [].
 dirty_get_registered_users() ->
     [].
 
--spec get_vh_registered_users(Server :: ejabberd:server()
+-spec get_vh_registered_users(LServer :: ejabberd:lserver()
                              ) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server) ->
-    [{U, S} || {{U, S, _R}, _, _, _} <- ejabberd_sm:get_vh_session_list(Server)].
+get_vh_registered_users(LServer) ->
+    [{U, S} || {{U, S, _R}, _, _, _} <- ejabberd_sm:get_vh_session_list(LServer)].
 
-get_vh_registered_users(Server, _Opts) ->
-  get_vh_registered_users(Server).
+get_vh_registered_users(LServer, _Opts) ->
+  get_vh_registered_users(LServer).
 
 
 %% @doc Return password of permanent user or false for anonymous users
--spec get_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server()) -> binary() | false.
-get_password(User, Server) ->
-    get_password(User, Server, "").
+-spec get_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver()) -> binary() | false.
+get_password(LUser, LServer) ->
+    get_password(LUser, LServer, "").
 
 
--spec get_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec get_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    DefaultValue :: binary()) -> binary() | false.
-get_password(User, Server, DefaultValue) ->
-    case anonymous_user_exist(User, Server) or login(User, Server) of
+get_password(LUser, LServer, DefaultValue) ->
+    case anonymous_user_exist(LUser, LServer) or login(LUser, LServer) of
         %% We return the default value if the user is anonymous
         true ->
             DefaultValue;
@@ -307,22 +305,22 @@ get_password(User, Server, DefaultValue) ->
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
--spec is_user_exists(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> boolean().
-is_user_exists(User, Server) ->
-    anonymous_user_exist(User, Server).
+-spec is_user_exists(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()) -> boolean().
+is_user_exists(LUser, LServer) ->
+    anonymous_user_exist(LUser, LServer).
 
 
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server()) -> {error, not_allowed}.
-remove_user(_User, _Server) ->
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver()) -> {error, not_allowed}.
+remove_user(_LUser, _LServer) ->
     {error, not_allowed}.
 
 
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server(),
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver(),
                   Password :: binary()) -> 'not_allowed'.
-remove_user(_User, _Server, _Password) ->
+remove_user(_LUser, _LServer, _Password) ->
     not_allowed.
 
 
@@ -333,9 +331,9 @@ plain_password_required() ->
 store_type(_) ->
     plain.
 
-get_vh_registered_users_number(_Server) -> 0.
+get_vh_registered_users_number(_LServer) -> 0.
 
-get_vh_registered_users_number(_Server, _Opts) -> 0.
+get_vh_registered_users_number(_LServer, _Opts) -> 0.
 
 %% @doc gen_auth unimplemented callbacks
-get_password_s(_User, _Server) -> erlang:error(not_implemented).
+get_password_s(_LUser, _LServer) -> erlang:error(not_implemented).

--- a/apps/ejabberd/src/ejabberd_auth_anonymous.erl
+++ b/apps/ejabberd/src/ejabberd_auth_anonymous.erl
@@ -49,7 +49,7 @@
 	 get_vh_registered_users/1,
 	 get_password/2,
 	 get_password/3,
-	 is_user_exists/2,
+	 does_user_exist/2,
 	 remove_user/2,
 	 remove_user/3,
 	 store_type/1,
@@ -305,9 +305,9 @@ get_password(LUser, LServer, DefaultValue) ->
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
--spec is_user_exists(LUser :: ejabberd:luser(),
+-spec does_user_exist(LUser :: ejabberd:luser(),
                      LServer :: ejabberd:lserver()) -> boolean().
-is_user_exists(LUser, LServer) ->
+does_user_exist(LUser, LServer) ->
     anonymous_user_exist(LUser, LServer).
 
 

--- a/apps/ejabberd/src/ejabberd_auth_external.erl
+++ b/apps/ejabberd/src/ejabberd_auth_external.erl
@@ -343,7 +343,7 @@ check_password_external_cache(User, Server, Password) ->
 %% @doc Try to register using extauth; if success then cache it
 try_register_external_cache(User, Server, Password) ->
     case try_register_extauth(User, Server, Password) of
-        {atomic, ok} = R ->
+        ok = R ->
             set_password_internal(User, Server, Password),
             R;
         _ -> {error, not_allowed}

--- a/apps/ejabberd/src/ejabberd_auth_external.erl
+++ b/apps/ejabberd/src/ejabberd_auth_external.erl
@@ -97,59 +97,44 @@ plain_password_required() ->
 store_type(_) ->
 	external.
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary()) -> boolean().
-check_password(User, Server, Password) ->
-    do_check_password(jlib:nodeprep(User), Server, Password).
-
-do_check_password(LUser, Server, Password) ->
-    case get_cache_option(Server) of
-        false -> check_password_extauth(LUser, Server, Password);
-        {true, CacheTime} -> check_password_cache(LUser, Server, Password, CacheTime)
+check_password(LUser, LServer, Password) ->
+    case get_cache_option(LServer) of
+        false -> check_password_extauth(LUser, LServer, Password);
+        {true, CacheTime} -> check_password_cache(LUser, LServer, Password, CacheTime)
     end.
 
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary(),
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
-check_password(User, Server, Password, _Digest, _DigestGen) ->
-    check_password(User, Server, Password).
+check_password(LUser, LServer, Password, _Digest, _DigestGen) ->
+    check_password(LUser, LServer, Password).
 
 
--spec set_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec set_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()) -> ok | {error, not_allowed}.
-set_password(User, Server, Password) ->
-    do_set_password(jlib:nodeprep(User), Server, Password).
-
-do_set_password(LUser, Server, Password) ->
-    case extauth:set_password(LUser, Server, Password) of
-        true -> set_password_internal(LUser, Server, Password),
+set_password(LUser, LServer, Password) ->
+    case extauth:set_password(LUser, LServer, Password) of
+        true -> set_password_internal(LUser, LServer, Password),
                 ok;
         _ -> {error, unknown_problem}
     end.
 
 
--spec try_register(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec try_register(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()
                    ) -> {atomic, ok | exists} | {error, not_allowed}.
-try_register(User, Server, Password) ->
-    do_try_register(jlib:nodeprep(User), Server, Password).
-
--spec do_try_register(User :: error | ejabberd:luser(),
-                      Server :: ejabberd:server(),
-                      Password :: binary()
-                      ) -> {atomic, ok | exists} | {error, not_allowed}.
-do_try_register(error, _, _) ->
-    {error, invalid_jid};
-do_try_register(LUser, Server, Password) ->
-    case get_cache_option(Server) of
-        false -> try_register_extauth(LUser, Server, Password);
-        {true, _CacheTime} -> try_register_external_cache(LUser, Server, Password)
+try_register(LUser, LServer, Password) ->
+    case get_cache_option(LServer) of
+        false -> try_register_extauth(LUser, LServer, Password);
+        {true, _CacheTime} -> try_register_external_cache(LUser, LServer, Password)
     end.
 
 
@@ -158,89 +143,85 @@ dirty_get_registered_users() ->
     ejabberd_auth_internal:dirty_get_registered_users().
 
 
--spec get_vh_registered_users(Server :: ejabberd:server()) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server) ->
-    ejabberd_auth_internal:get_vh_registered_users(Server).
+-spec get_vh_registered_users(LServer :: ejabberd:lserver()) -> [ejabberd:simple_jid()].
+get_vh_registered_users(LServer) ->
+    ejabberd_auth_internal:get_vh_registered_users(LServer).
 
 
--spec get_vh_registered_users(Server :: ejabberd:server(),
+-spec get_vh_registered_users(LServer :: ejabberd:lserver(),
                               Opts :: list()) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server, Opts)  ->
-    ejabberd_auth_internal:get_vh_registered_users(Server, Opts).
+get_vh_registered_users(LServer, Opts)  ->
+    ejabberd_auth_internal:get_vh_registered_users(LServer, Opts).
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server()) -> integer().
-get_vh_registered_users_number(Server) ->
-    ejabberd_auth_internal:get_vh_registered_users_number(Server).
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver()) -> integer().
+get_vh_registered_users_number(LServer) ->
+    ejabberd_auth_internal:get_vh_registered_users_number(LServer).
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server(),
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver(),
                                      Opts :: list()) -> integer().
-get_vh_registered_users_number(Server, Opts) ->
-    ejabberd_auth_internal:get_vh_registered_users_number(Server, Opts).
+get_vh_registered_users_number(LServer, Opts) ->
+    ejabberd_auth_internal:get_vh_registered_users_number(LServer, Opts).
 
 
 %% @doc The password can only be returned if cache is enabled, cached info
 %% exists and is fresh enough.
--spec get_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server()) -> binary() | false.
-get_password(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    case get_cache_option(Server) of
+-spec get_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver()) -> binary() | false.
+get_password(LUser, LServer) ->
+    case get_cache_option(LServer) of
         false -> false;
-        {true, CacheTime} -> get_password_cache(LUser, Server, CacheTime)
+        {true, CacheTime} -> get_password_cache(LUser, LServer, CacheTime)
     end.
 
 
--spec get_password_s(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> binary().
-get_password_s(User, Server) ->
-    case get_password(User, Server) of
-        false -> [];
+-spec get_password_s(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()) -> binary().
+get_password_s(LUser, LServer) ->
+    case get_password(LUser, LServer) of
+        false -> <<"">>;
         Other -> Other
     end.
 
 
--spec is_user_exists(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> boolean() | {error, atom()}.
-is_user_exists(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    try extauth:is_user_exists(LUser, Server) of
+-spec is_user_exists(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()) -> boolean() | {error, atom()}.
+is_user_exists(LUser, LServer) ->
+    try extauth:is_user_exists(LUser, LServer) of
         Res -> Res
     catch
         _:Error -> {error, Error}
     end.
 
 
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server()
+-spec remove_user(User :: ejabberd:luser(),
+                  Server :: ejabberd:lserver()
                   ) -> ok | error | {error, not_allowed}.
-remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    case extauth:remove_user(LUser, Server) of
+remove_user(LUser, LServer) ->
+    case extauth:remove_user(LUser, LServer) of
         false -> false;
         true ->
-            case get_cache_option(Server) of
+            case get_cache_option(LServer) of
                 false -> false;
                 {true, _CacheTime} ->
-                    ejabberd_auth_internal:remove_user(LUser, Server)
+                    ejabberd_auth_internal:remove_user(LUser, LServer)
             end
     end.
 
 
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server(),
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver(),
                   Password :: binary()
                   ) -> ok | not_exists | not_allowed | bad_request | error.
-remove_user(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    case extauth:remove_user(LUser, Server, Password) of
+remove_user(LUser, LServer, Password) ->
+    case extauth:remove_user(LUser, LServer, Password) of
         false -> false;
         true ->
-            case get_cache_option(Server) of
+            case get_cache_option(LServer) of
                 false -> false;
                 {true, _CacheTime} ->
-                    ejabberd_auth_internal:remove_user(LUser, Server, Password)
+                    ejabberd_auth_internal:remove_user(LUser, LServer, Password)
             end
     end.
 
@@ -248,7 +229,7 @@ remove_user(User, Server, Password) ->
 %%% Extauth cache management
 %%%
 
--spec get_cache_option(Host :: ejabberd:server()
+-spec get_cache_option(Host :: ejabberd:lserver()
                       ) -> false | {true, CacheTime::integer()}.
 get_cache_option(Host) ->
     case ejabberd_config:get_local_option({extauth_cache, Host}) of
@@ -257,64 +238,64 @@ get_cache_option(Host) ->
     end.
 
 
--spec check_password_extauth(User :: ejabberd:user(),
-                             Server :: ejabberd:server(),
+-spec check_password_extauth(LUser :: ejabberd:luser(),
+                             LServer :: ejabberd:lserver(),
                              Password :: binary()) -> boolean().
-check_password_extauth(User, Server, Password) ->
-    extauth:check_password(User, Server, Password) andalso Password /= "".
+check_password_extauth(LUser, LServer, Password) ->
+    extauth:check_password(LUser, LServer, Password) andalso Password /= "".
 
 
--spec try_register_extauth(User :: ejabberd:user(),
-                           Server :: ejabberd:server(),
+-spec try_register_extauth(LUser :: ejabberd:luser(),
+                           LServer :: ejabberd:lserver(),
                            Password :: binary()) -> boolean().
-try_register_extauth(User, Server, Password) ->
-    extauth:try_register(User, Server, Password).
+try_register_extauth(LUser, LServer, Password) ->
+    extauth:try_register(LUser, LServer, Password).
 
 
--spec check_password_cache(User :: ejabberd:user(),
-                           Server :: ejabberd:server(),
+-spec check_password_cache(LUser :: ejabberd:luser(),
+                           LServer :: ejabberd:lserver(),
                            Password :: binary(),
                            CacheTime :: integer()) -> boolean().
-check_password_cache(User, Server, Password, CacheTime) ->
-    case get_last_access(User, Server) of
+check_password_cache(LUser, LServer, Password, CacheTime) ->
+    case get_last_access(LUser, LServer) of
         online ->
-            check_password_internal(User, Server, Password);
+            check_password_internal(LUser, LServer, Password);
         never ->
-            check_password_external_cache(User, Server, Password);
+            check_password_external_cache(LUser, LServer, Password);
         mod_last_required ->
             ?ERROR_MSG("extauth is used, extauth_cache is enabled but mod_last is not enabled in that host", []),
-            check_password_external_cache(User, Server, Password);
+            check_password_external_cache(LUser, LServer, Password);
         TimeStamp ->
             %% If last access exists, compare last access with cache refresh time
             case is_fresh_enough(TimeStamp, CacheTime) of
                 %% If no need to refresh, check password against Mnesia
                 true ->
-                    case check_password_internal(User, Server, Password) of
+                    case check_password_internal(LUser, LServer, Password) of
                         %% If password valid in Mnesia, accept it
                         true ->
                             true;
                         %% Else (password nonvalid in Mnesia), check in extauth and cache result
                         false ->
-                            check_password_external_cache(User, Server, Password)
+                            check_password_external_cache(LUser, LServer, Password)
                     end;
                 %% Else (need to refresh), check in extauth and cache result
                 false ->
-                    check_password_external_cache(User, Server, Password)
+                    check_password_external_cache(LUser, LServer, Password)
             end
     end.
 
 
-get_password_internal(User, Server) ->
-    ejabberd_auth_internal:get_password(User, Server).
+get_password_internal(LUser, LServer) ->
+    ejabberd_auth_internal:get_password(LUser, LServer).
 
 
--spec get_password_cache(User :: ejabberd:user(),
-                         Server :: ejabberd:server(),
+-spec get_password_cache(LUser :: ejabberd:luser(),
+                         LServer :: ejabberd:lserver(),
                          CacheTime :: integer()) -> false | string().
-get_password_cache(User, Server, CacheTime) ->
-    case get_last_access(User, Server) of
+get_password_cache(LUser, LServer, CacheTime) ->
+    case get_last_access(LUser, LServer) of
         online ->
-            get_password_internal(User, Server);
+            get_password_internal(LUser, LServer);
         never ->
             false;
         mod_last_required ->
@@ -323,7 +304,7 @@ get_password_cache(User, Server, CacheTime) ->
         TimeStamp ->
             case is_fresh_enough(TimeStamp, CacheTime) of
                 true ->
-                    get_password_internal(User, Server);
+                    get_password_internal(LUser, LServer);
                 false ->
                     false
             end
@@ -331,37 +312,37 @@ get_password_cache(User, Server, CacheTime) ->
 
 
 %% @doc Check the password using extauth; if success then cache it
-check_password_external_cache(User, Server, Password) ->
-    case check_password_extauth(User, Server, Password) of
+check_password_external_cache(LUser, LServer, Password) ->
+    case check_password_extauth(LUser, LServer, Password) of
         true ->
-            set_password_internal(User, Server, Password), true;
+            set_password_internal(LUser, LServer, Password), true;
         false ->
             false
     end.
 
 
 %% @doc Try to register using extauth; if success then cache it
-try_register_external_cache(User, Server, Password) ->
-    case try_register_extauth(User, Server, Password) of
+try_register_external_cache(LUser, LServer, Password) ->
+    case try_register_extauth(LUser, LServer, Password) of
         ok = R ->
-            set_password_internal(User, Server, Password),
+            set_password_internal(LUser, LServer, Password),
             R;
         _ -> {error, not_allowed}
     end.
 
 
--spec check_password_internal(User :: ejabberd:user(),
-                              Server :: ejabberd:server(),
+-spec check_password_internal(LUser :: ejabberd:luser(),
+                              LServer :: ejabberd:lserver(),
                               Password :: binary()) -> boolean().
-check_password_internal(User, Server, Password) ->
-    ejabberd_auth_internal:check_password(User, Server, Password).
+check_password_internal(LUser, LServer, Password) ->
+    ejabberd_auth_internal:check_password(LUser, LServer, Password).
 
 
--spec set_password_internal(User :: ejabberd:user(),
-                            Server :: ejabberd:server(),
+-spec set_password_internal(LUser :: ejabberd:luser(),
+                            LServer :: ejabberd:lserver(),
                             Password :: binary()) -> ok | {error, invalid_jid}.
-set_password_internal(User, Server, Password) ->
-    ejabberd_auth_internal:set_password(User, Server, Password).
+set_password_internal(LUser, LServer, Password) ->
+    ejabberd_auth_internal:set_password(LUser, LServer, Password).
 
 
 -spec is_fresh_enough(TimeLast :: online | never | integer(),

--- a/apps/ejabberd/src/ejabberd_auth_external.erl
+++ b/apps/ejabberd/src/ejabberd_auth_external.erl
@@ -42,7 +42,7 @@
          get_vh_registered_users_number/2,
          get_password/2,
          get_password_s/2,
-         is_user_exists/2,
+         does_user_exist/2,
          remove_user/2,
          remove_user/3,
          store_type/1,
@@ -185,9 +185,9 @@ get_password_s(LUser, LServer) ->
     end.
 
 
--spec is_user_exists(LUser :: ejabberd:luser(),
+-spec does_user_exist(LUser :: ejabberd:luser(),
                      LServer :: ejabberd:lserver()) -> boolean() | {error, atom()}.
-is_user_exists(LUser, LServer) ->
+does_user_exist(LUser, LServer) ->
     try extauth:is_user_exists(LUser, LServer) of
         Res -> Res
     catch

--- a/apps/ejabberd/src/ejabberd_auth_http.erl
+++ b/apps/ejabberd/src/ejabberd_auth_http.erl
@@ -88,9 +88,8 @@ check_password(User, Server, Password, Digest, DigestGen) ->
             case scram:enabled(LServer) of
                 true ->
                     case scram:deserialize(GotPasswd) of
-                        {ok, #scram{storedkey = StoredKey}} ->
-                            Passwd = base64:decode(StoredKey),
-                            ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
+                        {ok, #scram{} = Scram} ->
+                            scram:check_digest(Scram, Digest, DigestGen, Password);
                         _ ->
                             false
                     end;
@@ -158,10 +157,7 @@ get_password(User, Server) ->
                 true ->
                     case scram:deserialize(Password) of
                         {ok, #scram{} = Scram} ->
-                            {base64:decode(Scram#scram.storedkey),
-                             base64:decode(Scram#scram.serverkey),
-                             base64:decode(Scram#scram.salt),
-                             Scram#scram.iterationcount};
+                            scram:scram_to_tuple(Scram);
                         _ ->
                             false
                     end;

--- a/apps/ejabberd/src/ejabberd_auth_http.erl
+++ b/apps/ejabberd/src/ejabberd_auth_http.erl
@@ -23,7 +23,7 @@
          get_vh_registered_users_number/2,
          get_password/2,
          get_password_s/2,
-         is_user_exists/2,
+         does_user_exist/2,
          remove_user/2,
          remove_user/3,
          plain_password_required/0,
@@ -169,8 +169,8 @@ get_password_s(User, Server) ->
         _ -> <<>>
     end.
 
--spec is_user_exists(ejabberd:luser(), ejabberd:lserver()) -> boolean().
-is_user_exists(LUser, LServer) ->
+-spec does_user_exist(ejabberd:luser(), ejabberd:lserver()) -> boolean().
+does_user_exist(LUser, LServer) ->
     case make_req(get, <<"user_exists">>, LUser, LServer, <<"">>) of
         {ok, <<"true">>} -> true;
         _ -> false

--- a/apps/ejabberd/src/ejabberd_auth_http.erl
+++ b/apps/ejabberd/src/ejabberd_auth_http.erl
@@ -8,6 +8,8 @@
 -module(ejabberd_auth_http).
 -author('piotr.nosek@erlang-solutions.com').
 
+-behaviour(ejabberd_gen_auth).
+
 %% External exports
 -export([start/1,
          set_password/3,
@@ -25,8 +27,9 @@
          remove_user/2,
          remove_user/3,
          plain_password_required/0,
-         store_type/1
-        ]).
+         store_type/1,
+         login/2,
+         get_password/3]).
 
 -include("ejabberd.hrl").
 
@@ -118,8 +121,8 @@ try_register(User, Server, Password) ->
                         false -> Password
                     end,
     case make_req(post, <<"register">>, LUser, LServer, PasswordFinal) of
-        {ok, created} -> {atomic, ok};
-        {error, conflict} -> {atomic, exists};
+        {ok, created} -> ok;
+        {error, conflict} -> {error, exists};
         Error -> Error
     end.
 
@@ -288,3 +291,9 @@ verify_scram_password(LUser, LServer, Password) ->
         _ ->
             {error, not_exists}
     end.
+
+login(_User, _Server) ->
+    erlang:error(not_implemented).
+
+get_password(_User, _Server, _DefaultValue) ->
+    erlang:error(not_implemented).

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -42,7 +42,7 @@
          get_vh_registered_users_number/2,
          get_password/2,
          get_password_s/2,
-         is_user_exists/2,
+         does_user_exist/2,
          remove_user/2,
          remove_user/3,
          store_type/1,
@@ -312,10 +312,10 @@ get_password_s(LUser, LServer) ->
     end.
 
 
--spec is_user_exists(LUser :: ejabberd:luser(),
+-spec does_user_exist(LUser :: ejabberd:luser(),
                      LServer :: ejabberd:lserver()
                      ) -> boolean() | {error, atom()}.
-is_user_exists(LUser, LServer) ->
+does_user_exist(LUser, LServer) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read({passwd, US}) of
         [] ->

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -199,7 +199,14 @@ try_register(User, Server, Password) ->
 				exists
 			end
 		end,
-	    mnesia:transaction(F)
+	    case mnesia:transaction(F) of
+            {atomic, ok} ->
+                ok;
+            {atomic, exists} ->
+                {error, exists};
+            {aborted, _} = Aborted ->
+                {error, Aborted}
+        end
     end.
 
 

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -107,12 +107,10 @@ store_type(Server) ->
         true -> scram
     end.
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary()) -> boolean().
-check_password(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+check_password(LUser, LServer, Password) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read({passwd, US}) of
         [#passwd{password = Scram}] when is_record(Scram, scram) ->
@@ -124,14 +122,12 @@ check_password(User, Server, Password) ->
     end.
 
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary(),
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
-check_password(User, Server, Password, Digest, DigestGen) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+check_password(LUser, LServer, Password, Digest, DigestGen) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read({passwd, US}) of
 	[#passwd{password = Scram}] when is_record(Scram, scram) ->
@@ -144,69 +140,57 @@ check_password(User, Server, Password, Digest, DigestGen) ->
     end.
 
 
--spec set_password(User :: ejabberd:user(),
-             Server :: ejabberd:server(),
-             Password :: binary()) -> ok | {error, not_allowed | invalid_jid}.
-set_password(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+-spec set_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
+                   Password :: binary()) -> ok | {error, not_allowed | invalid_jid}.
+set_password(LUser, LServer, Password) ->
     US = {LUser, LServer},
-    if
-	(LUser == error) or (LServer == error) ->
-	    {error, invalid_jid};
-	true ->
-	    F = fun() ->
-			Password2 = case scram:enabled(Server) of
-					true -> scram:password_to_scram(Password, scram:iterations(Server));
-					false -> Password
-				    end,
-			mnesia:write(#passwd{us = US,
-					     password = Password2})
-		end,
-	    {atomic, ok} = mnesia:transaction(F),
-	    ok
-    end.
+    F = fun() ->
+        Password2 = case scram:enabled(LServer) of
+                        true ->
+                            scram:password_to_scram(Password, scram:iterations(LServer));
+                        false -> Password
+                    end,
+        mnesia:write(#passwd{us = US,
+            password = Password2})
+    end,
+    {atomic, ok} = mnesia:transaction(F),
+    ok.
 
 
--spec try_register(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec try_register(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()
                    ) -> {atomic, ok | exists}
                       | {error, invalid_jid | not_allowed}
                       | {aborted, _}.
-try_register(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+try_register(LUser, LServer, Password) ->
     US = {LUser, LServer},
-    if
-	(LUser == error) or (LServer == error) ->
-	    {error, invalid_jid};
-	true ->
-	    F = fun() ->
-			case mnesia:read({passwd, US}) of
-			    [] ->
-				Password2 = case scram:enabled(Server) and is_binary(Password) of
-						true -> scram:password_to_scram(Password, scram:iterations(Server));
-						false -> Password
-					    end,
-				mnesia:write(#passwd{us = US,
-						     password = Password2}),
-				mnesia:dirty_update_counter(
-						    reg_users_counter,
-						    LServer, 1),
-				ok;
-			    [_E] ->
-				exists
-			end
-		end,
-	    case mnesia:transaction(F) of
-            {atomic, ok} ->
+    F = fun() ->
+        case mnesia:read({passwd, US}) of
+            [] ->
+                Password2 = case scram:enabled(LServer) and is_binary(Password) of
+                                true ->
+                                    scram:password_to_scram(Password, scram:iterations(LServer));
+                                false -> Password
+                            end,
+                mnesia:write(#passwd{us = US,
+                    password = Password2}),
+                mnesia:dirty_update_counter(
+                    reg_users_counter,
+                    LServer, 1),
                 ok;
-            {atomic, exists} ->
-                {error, exists};
-            {aborted, _} = Aborted ->
-                {error, Aborted}
+            [_E] ->
+                exists
         end
+    end,
+    case mnesia:transaction(F) of
+        {atomic, ok} ->
+            ok;
+        {atomic, exists} ->
+            {error, exists};
+        {aborted, _} = Aborted ->
+            {error, Aborted}
     end.
 
 
@@ -216,10 +200,9 @@ dirty_get_registered_users() ->
     mnesia:dirty_all_keys(passwd).
 
 
--spec get_vh_registered_users(Server :: ejabberd:server()
+-spec get_vh_registered_users(LServer :: ejabberd:lserver()
                              ) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server) ->
-    LServer = jlib:nameprep(Server),
+get_vh_registered_users(LServer) ->
     mnesia:dirty_select(
       passwd,
       [{#passwd{us = '$1', _ = '_'},
@@ -229,15 +212,15 @@ get_vh_registered_users(Server) ->
 
 -type query_keyword() :: from | to | limit | offset | prefix.
 -type query_value() :: integer() | string().
--spec get_vh_registered_users(Server :: ejabberd:server(),
+-spec get_vh_registered_users(LServer :: ejabberd:lserver(),
                               Query :: [{query_keyword(), query_value()}]
                               ) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server, [{from, Start}, {to, End}])
+get_vh_registered_users(LServer, [{from, Start}, {to, End}])
         when is_integer(Start) and is_integer(End) ->
-    get_vh_registered_users(Server, [{limit, End-Start+1}, {offset, Start}]);
-get_vh_registered_users(Server, [{limit, Limit}, {offset, Offset}])
+    get_vh_registered_users(LServer, [{limit, End-Start+1}, {offset, Start}]);
+get_vh_registered_users(LServer, [{limit, Limit}, {offset, Offset}])
         when is_integer(Limit) and is_integer(Offset) ->
-    case get_vh_registered_users(Server) of
+    case get_vh_registered_users(LServer) of
     [] ->
         [];
     Users ->
@@ -249,16 +232,16 @@ get_vh_registered_users(Server, [{limit, Limit}, {offset, Offset}])
                 end,
         lists:sublist(Set, Start, Limit)
     end;
-get_vh_registered_users(Server, [{prefix, Prefix}])
+get_vh_registered_users(LServer, [{prefix, Prefix}])
         when is_list(Prefix) ->
-    Set = [{U,S} || {U, S} <- get_vh_registered_users(Server), lists:prefix(Prefix, U)],
+    Set = [{U,S} || {U, S} <- get_vh_registered_users(LServer), lists:prefix(Prefix, U)],
     lists:keysort(1, Set);
-get_vh_registered_users(Server, [{prefix, Prefix}, {from, Start}, {to, End}])
+get_vh_registered_users(LServer, [{prefix, Prefix}, {from, Start}, {to, End}])
         when is_list(Prefix) and is_integer(Start) and is_integer(End) ->
-    get_vh_registered_users(Server, [{prefix, Prefix}, {limit, End-Start+1}, {offset, Start}]);
-get_vh_registered_users(Server, [{prefix, Prefix}, {limit, Limit}, {offset, Offset}])
+    get_vh_registered_users(LServer, [{prefix, Prefix}, {limit, End-Start+1}, {offset, Start}]);
+get_vh_registered_users(LServer, [{prefix, Prefix}, {limit, Limit}, {offset, Offset}])
         when is_list(Prefix) and is_integer(Limit) and is_integer(Offset) ->
-    case [{U,S} || {U, S} <- get_vh_registered_users(Server), lists:prefix(Prefix, U)] of
+    case [{U,S} || {U, S} <- get_vh_registered_users(LServer), lists:prefix(Prefix, U)] of
     [] ->
         [];
     Users ->
@@ -270,14 +253,13 @@ get_vh_registered_users(Server, [{prefix, Prefix}, {limit, Limit}, {offset, Offs
                 end,
         lists:sublist(Set, Start, Limit)
     end;
-get_vh_registered_users(Server, _) ->
-    get_vh_registered_users(Server).
+get_vh_registered_users(LServer, _) ->
+    get_vh_registered_users(LServer).
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server()
+-spec get_vh_registered_users_number(LServer :: ejabberd:server()
                                     ) -> non_neg_integer().
-get_vh_registered_users_number(Server) ->
-    LServer = jlib:nameprep(Server),
+get_vh_registered_users_number(LServer) ->
     Query = mnesia:dirty_select(
                 reg_users_counter,
                 [{#reg_users_counter{vhost = LServer, count = '$1'},
@@ -290,21 +272,19 @@ get_vh_registered_users_number(Server) ->
     end.
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server(),
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver(),
                                      Query :: [{prefix, string()}]
                                      ) -> integer().
-get_vh_registered_users_number(Server, [{prefix, Prefix}]) when is_list(Prefix) ->
-    Set = [{U, S} || {U, S} <- get_vh_registered_users(Server), lists:prefix(Prefix, U)],
+get_vh_registered_users_number(LServer, [{prefix, Prefix}]) when is_list(Prefix) ->
+    Set = [{U, S} || {U, S} <- get_vh_registered_users(LServer), lists:prefix(Prefix, U)],
     length(Set);
-get_vh_registered_users_number(Server, _) ->
-    get_vh_registered_users_number(Server).
+get_vh_registered_users_number(LServer, _) ->
+    get_vh_registered_users_number(LServer).
 
 
--spec get_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server()) -> binary() | false.
-get_password(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+-spec get_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver()) -> binary() | false.
+get_password(LUser, LServer) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read(passwd, US) of
 	[#passwd{password = Scram}] when is_record(Scram, scram) ->
@@ -318,12 +298,9 @@ get_password(User, Server) ->
 	    false
     end.
 
-
--spec get_password_s(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> binary() | false.
-get_password_s(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+-spec get_password_s(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()) -> binary() | false.
+get_password_s(LUser, LServer) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read(passwd, US) of
 	[#passwd{password = Scram}] when is_record(Scram, scram) ->
@@ -335,12 +312,10 @@ get_password_s(User, Server) ->
     end.
 
 
--spec is_user_exists(User :: ejabberd:user(),
-                     Server :: ejabberd:server()
+-spec is_user_exists(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()
                      ) -> boolean() | {error, atom()}.
-is_user_exists(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+is_user_exists(LUser, LServer) ->
     US = {LUser, LServer},
     case catch mnesia:dirty_read({passwd, US}) of
         [] ->
@@ -354,12 +329,10 @@ is_user_exists(User, Server) ->
 
 %% @doc Remove user.
 %% Note: it returns ok even if there was some problem removing the user.
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server()
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver()
                   ) -> ok | error | {error, not_allowed}.
-remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+remove_user(LUser, LServer) ->
     US = {LUser, LServer},
     F = fun() ->
                 mnesia:delete({passwd, US}),
@@ -367,17 +340,15 @@ remove_user(User, Server) ->
                                             LServer, -1)
         end,
     mnesia:transaction(F),
-        ok.
+    ok.
 
 
 %% @doc Remove user if the provided password is correct.
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server(),
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver(),
                   Password :: binary()
                   ) -> ok | not_exists | not_allowed | bad_request | error.
-remove_user(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+remove_user(LUser, LServer, Password) ->
     US = {LUser, LServer},
     F = fun() ->
                 case mnesia:read({passwd, US}) of

--- a/apps/ejabberd/src/ejabberd_auth_ldap.erl
+++ b/apps/ejabberd/src/ejabberd_auth_ldap.erl
@@ -48,7 +48,7 @@
     get_vh_registered_users_number/2,
     get_password/2,
     get_password_s/2,
-    is_user_exists/2,
+    does_user_exist/2,
     remove_user/2,
     remove_user/3,
     store_type/1,
@@ -243,10 +243,10 @@ get_password(_LUser, _LServer) -> false.
 get_password_s(_LUser, _LServer) -> <<"">>.
 
 
--spec is_user_exists(LUser :: ejabberd:luser(),
+-spec does_user_exist(LUser :: ejabberd:luser(),
                      LServer :: ejabberd:lserver()
                      ) -> boolean() | {error, atom()}.
-is_user_exists(LUser, LServer) ->
+does_user_exist(LUser, LServer) ->
     case catch is_user_exists_ldap(LUser, LServer) of
       {'EXIT', Error} -> {error, Error};
       Result -> Result

--- a/apps/ejabberd/src/ejabberd_auth_ldap.erl
+++ b/apps/ejabberd/src/ejabberd_auth_ldap.erl
@@ -193,8 +193,8 @@ try_register(User, Server, Password) ->
               {"userPassword",[binary_to_list(Password)]},
               {"uid",[UserStr]}],
     case eldap_pool:add(State#state.eldap_id,DN,Attrs) of
-        ok -> {atomic, ok};
-        _ -> {atomic, exists}
+        ok -> ok;
+        _ -> {error, exists}
     end.
 
 

--- a/apps/ejabberd/src/ejabberd_auth_ldap.erl
+++ b/apps/ejabberd/src/ejabberd_auth_ldap.erl
@@ -63,10 +63,10 @@
 -include("eldap.hrl").
 
 -record(state,
-       {host = <<"">>          :: ejabberd:server(),
+       {host = <<"">>          :: ejabberd:lserver(),
         eldap_id = <<"">>      :: binary(),
         bind_eldap_id = <<"">> :: binary(),
-        servers = []           :: [ejabberd:server()],
+        servers = []           :: [ejabberd:lserver()],
         backups = []           :: [binary()],
         port = ?LDAP_PORT      :: inet:port_number(),
         tls_options = []       :: list(),
@@ -115,7 +115,7 @@ start_link(Host) ->
 
 terminate(_Reason, _State) -> ok.
 
--spec init(Host :: ejabberd:server()) -> {'ok', state()}.
+-spec init(Host :: ejabberd:lserver()) -> {'ok', state()}.
 init(Host) ->
     State = parse_options(Host),
     eldap_pool:start_link(State#state.eldap_id,
@@ -140,13 +140,13 @@ config_change(Acc, Host, ldap, _NewConfig) ->
 config_change(Acc, _, _, _) ->
     Acc.
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary()) -> boolean().
-check_password(User, Server, Password) ->
+check_password(LUser, LServer, Password) ->
     if Password == <<"">> -> false;
        true ->
-           case catch check_password_ldap(User, Server, Password)
+           case catch check_password_ldap(LUser, LServer, Password)
                of
              {'EXIT', _} -> false;
              Result -> Result
@@ -154,23 +154,23 @@ check_password(User, Server, Password) ->
     end.
 
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary(),
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
-check_password(User, Server, Password, _Digest,
+check_password(LUser, LServer, Password, _Digest,
                _DigestGen) ->
-    check_password(User, Server, Password).
+    check_password(LUser, LServer, Password).
 
 
--spec set_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec set_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary())
       -> ok | {error, not_allowed | invalid_jid}.
-set_password(User, Server, Password) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
-    case find_user_dn(User, State) of
+set_password(LUser, LServer, Password) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
+    case find_user_dn(LUser, State) of
       false -> {error, user_not_found};
       DN ->
           eldap_pool:modify_passwd(State#state.eldap_id, DN,
@@ -178,14 +178,14 @@ set_password(User, Server, Password) ->
     end.
 
 
--spec try_register(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec try_register(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()) -> {atomic, ok | exists}
                             | {error, invalid_jid | not_allowed}
                             | {aborted, _}.
-try_register(User, Server, Password) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
-    UserStr=binary_to_list(User),
+try_register(LUser, LServer, Password) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
+    UserStr=binary_to_list(LUser),
     DN = "cn="++UserStr++","++binary_to_list(State#state.base),
     Attrs =   [{"objectclass", ["inetOrgPerson"]},
               {"cn", [UserStr]},
@@ -200,77 +200,77 @@ try_register(User, Server, Password) ->
 
 -spec dirty_get_registered_users() -> [ejabberd:simple_jid()].
 dirty_get_registered_users() ->
-    Servers = ejabberd_config:get_vh_by_auth_method(ldap),
-    lists:flatmap(fun (Server) ->
-                          get_vh_registered_users(Server)
+    LServers = ejabberd_config:get_vh_by_auth_method(ldap),
+    lists:flatmap(fun (LServer) ->
+                          get_vh_registered_users(LServer)
                   end,
-                  Servers).
+                  LServers).
 
 
--spec get_vh_registered_users(Server :: ejabberd:server()
+-spec get_vh_registered_users(LServer :: ejabberd:lserver()
                              ) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server) ->
-    case catch get_vh_registered_users_ldap(Server) of
+get_vh_registered_users(LServer) ->
+    case catch get_vh_registered_users_ldap(LServer) of
       {'EXIT', _} -> [];
       Result -> Result
     end.
 
 
--spec get_vh_registered_users(Server :: ejabberd:server(),
+-spec get_vh_registered_users(LServer :: ejabberd:lserver(),
                               Opts :: list()) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server, _) ->
-    get_vh_registered_users(Server).
+get_vh_registered_users(LServer, _) ->
+    get_vh_registered_users(LServer).
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server()) -> integer().
-get_vh_registered_users_number(Server) ->
-    length(get_vh_registered_users(Server)).
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver()) -> integer().
+get_vh_registered_users_number(LServer) ->
+    length(get_vh_registered_users(LServer)).
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server(),
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver(),
                                      Opts :: list()) -> integer().
-get_vh_registered_users_number(Server, _) ->
-    get_vh_registered_users_number(Server).
+get_vh_registered_users_number(LServer, _) ->
+    get_vh_registered_users_number(LServer).
 
 
--spec get_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server()) -> binary() | false.
-get_password(_User, _Server) -> false.
+-spec get_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver()) -> binary() | false.
+get_password(_LUser, _LServer) -> false.
 
 
--spec get_password_s(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> binary().
-get_password_s(_User, _Server) -> <<"">>.
+-spec get_password_s(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()) -> binary().
+get_password_s(_LUser, _LServer) -> <<"">>.
 
 
--spec is_user_exists(User :: ejabberd:user(),
-                     Server :: ejabberd:server()
+-spec is_user_exists(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()
                      ) -> boolean() | {error, atom()}.
-is_user_exists(User, Server) ->
-    case catch is_user_exists_ldap(User, Server) of
+is_user_exists(LUser, LServer) ->
+    case catch is_user_exists_ldap(LUser, LServer) of
       {'EXIT', Error} -> {error, Error};
       Result -> Result
     end.
 
 
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server()
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver()
                   ) -> ok | error | {error, not_allowed}.
-remove_user(User, Server) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
-    case find_user_dn(User, State) of
+remove_user(LUser, LServer) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
+    case find_user_dn(LUser, State) of
       false -> error;
       DN -> eldap_pool:delete(State#state.eldap_id,DN)
     end.
 
 
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server(),
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver(),
                   Password :: binary()
                   ) -> ok | not_exists | not_allowed | bad_request | error.
-remove_user(User, Server, Password) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
-    case find_user_dn(User, State) of
+remove_user(LUser, LServer, Password) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
+    case find_user_dn(LUser, State) of
       false -> false;
       DN ->
             case eldap_pool:bind(State#state.bind_eldap_id, DN,Password) of
@@ -284,12 +284,12 @@ remove_user(User, Server, Password) ->
 %%% Internal functions
 %%%----------------------------------------------------------------------
 
--spec check_password_ldap(User :: ejabberd:user(),
-                          Server :: ejabberd:server(),
+-spec check_password_ldap(LUser :: ejabberd:luser(),
+                          LServer :: ejabberd:lserver(),
                           Password :: binary()) -> boolean().
-check_password_ldap(User, Server, Password) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
-    case find_user_dn(User, State) of
+check_password_ldap(LUser, LServer, Password) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
+    case find_user_dn(LUser, State) of
       false -> false;
       DN ->
           case eldap_pool:bind(State#state.bind_eldap_id, DN, Password) of
@@ -299,13 +299,13 @@ check_password_ldap(User, Server, Password) ->
     end.
 
 
--spec get_vh_registered_users_ldap(Server :: ejabberd:server()
+-spec get_vh_registered_users_ldap(LServer :: ejabberd:lserver()
                                   ) -> [ejabberd:simple_jid()].
-get_vh_registered_users_ldap(Server) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
+get_vh_registered_users_ldap(LServer) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
     UIDs = State#state.uids,
     Eldap_ID = State#state.eldap_id,
-    Server = State#state.host,
+    LServer = State#state.host,
     ResAttrs = result_attrs(State),
     case eldap_filter:parse(State#state.sfilter) of
       {ok, EldapFilter} ->
@@ -333,12 +333,7 @@ get_vh_registered_users_ldap(Server) ->
                                                                               UIDFormat)
                                                       of
                                                     {ok, U} ->
-                                                        case jlib:nodeprep(U) of
-                                                          error -> [];
-                                                          LU ->
-                                                              [{LU,
-                                                                jlib:nameprep(Server)}]
-                                                        end;
+                                                        [{U, LServer}];
                                                     _ -> []
                                                   end
                                             end
@@ -351,11 +346,11 @@ get_vh_registered_users_ldap(Server) ->
     end.
 
 
--spec is_user_exists_ldap(User :: ejabberd:user(),
-                          Server :: ejabberd:server()) -> boolean().
-is_user_exists_ldap(User, Server) ->
-    {ok, State} = eldap_utils:get_state(Server, ?MODULE),
-    case find_user_dn(User, State) of
+-spec is_user_exists_ldap(LUser :: ejabberd:luser(),
+                          LServer :: ejabberd:lserver()) -> boolean().
+is_user_exists_ldap(LUser, LServer) ->
+    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
+    case find_user_dn(LUser, State) of
       false -> false;
       _DN -> true
     end.
@@ -370,12 +365,12 @@ handle_call(_Request, _From, State) ->
     {reply, bad_request, State}.
 
 
--spec find_user_dn(User :: ejabberd:user(),
+-spec find_user_dn(LUser :: ejabberd:luser(),
                    State :: state()) -> 'false' | binary().
-find_user_dn(User, State) ->
+find_user_dn(LUser, State) ->
     ResAttrs = result_attrs(State),
     case eldap_filter:parse(State#state.ufilter,
-                            [{<<"%u">>, User}])
+                            [{<<"%u">>, LUser}])
         of
       {ok, Filter} ->
           case eldap_pool:search(State#state.eldap_id,
@@ -487,7 +482,7 @@ result_attrs(#state{uids = UIDs,
 %%% Auxiliary functions
 %%%----------------------------------------------------------------------
 
--spec parse_options(Host :: ejabberd:server()) -> state().
+-spec parse_options(Host :: ejabberd:lserver()) -> state().
 parse_options(Host) ->
     Cfg = eldap_utils:get_config(Host, []),
     Eldap_ID = atom_to_binary(gen_mod:get_module_proc(Host, ?MODULE),utf8),
@@ -556,5 +551,5 @@ check_filter(F) ->
 
 
 %% @doc gen_auth unimplemented callbacks
-login(_User, _Server) -> erlang:error(not_implemented).
-get_password(_User, _Server, _DefaultValue) -> erlang:error(not_implemented).
+login(_LUser, _LServer) -> erlang:error(not_implemented).
+get_password(_LUser, _LServer, _DefaultValue) -> erlang:error(not_implemented).

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -194,9 +194,9 @@ try_register(User, Server, Password) ->
                     LServer = jlib:nameprep(Server),
                     case catch odbc_queries:add_user(LServer, Username, Pass) of
                         {updated, 1} ->
-                            {atomic, ok};
+                            ok;
                         _ ->
-                            {atomic, exists}
+                            {error, exists}
                     end
             end
     end.

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -109,9 +109,8 @@ check_password(User, Server, Password, Digest, DigestGen) ->
                     ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
                 {selected, [<<"password">>, <<"pass_details">>], [{_Passwd, PassDetails}]} ->
                     case scram:deserialize(PassDetails) of
-                        #scram{storedkey = StoredKey} ->
-                            Passwd = base64:decode(StoredKey),
-                            ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
+                        #scram{} = Scram ->
+                            scram:check_digest(Scram, Digest, DigestGen, Password);
                         _ ->
                             false
                     end;

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -77,58 +77,46 @@ store_type(Server) ->
         true -> scram
     end.
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary()) -> boolean().
-check_password(User, Server, Password) ->
-    case jlib:nodeprep(User) of
-	error ->
-	    false;
-	LUser ->
-	    Username = ejabberd_odbc:escape(LUser),
-	    LServer = jlib:nameprep(Server),
-	    check_password_wo_escape(Username, LServer, Password)
-    end.
+check_password(LUser, LServer, Password) ->
+    Username = ejabberd_odbc:escape(LUser),
+    check_password_wo_escape(Username, LServer, Password).
 
 
--spec check_password(User :: ejabberd:user(),
-                     Server :: ejabberd:server(),
+-spec check_password(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver(),
                      Password :: binary(),
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
-check_password(User, Server, Password, Digest, DigestGen) ->
-    case jlib:nodeprep(User) of
-        error ->
-            false;
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            LServer = jlib:nameprep(Server),
-            try odbc_queries:get_password(LServer, Username) of
-                %% Account exists, check if password is valid
-                {selected, [<<"password">>, <<"pass_details">>], [{Passwd, null}]} ->
-                    ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
-                {selected, [<<"password">>, <<"pass_details">>], [{_Passwd, PassDetails}]} ->
-                    case scram:deserialize(PassDetails) of
-                        #scram{} = Scram ->
-                            scram:check_digest(Scram, Digest, DigestGen, Password);
-                        _ ->
-                            false
-                    end;
-                {selected, [<<"password">>, <<"pass_details">>], []} ->
-                    false; %% Account does not exist
-                {error, _Error} ->
-                    false %% Typical error is that table doesn't exist
-            catch
-                _:_ ->
-                    false %% Typical error is database not accessible
-            end
+check_password(LUser, LServer, Password, Digest, DigestGen) ->
+    Username = ejabberd_odbc:escape(LUser),
+    try odbc_queries:get_password(LServer, Username) of
+        %% Account exists, check if password is valid
+        {selected, [<<"password">>, <<"pass_details">>], [{Passwd, null}]} ->
+            ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
+        {selected, [<<"password">>, <<"pass_details">>], [{_Passwd, PassDetails}]} ->
+            case scram:deserialize(PassDetails) of
+                #scram{} = Scram ->
+                    scram:check_digest(Scram, Digest, DigestGen, Password);
+                _ ->
+                    false
+            end;
+        {selected, [<<"password">>, <<"pass_details">>], []} ->
+            false; %% Account does not exist
+        {error, _Error} ->
+            false %% Typical error is that table doesn't exist
+    catch
+        _:_ ->
+            false %% Typical error is database not accessible
     end.
 
--spec check_password_wo_escape(User::ejabberd:user(),
-                               Server::ejabberd:server(),
+-spec check_password_wo_escape(LUser::ejabberd:luser(),
+                               LServer::ejabberd:lserver(),
                                Password::binary()) -> boolean() | not_exists.
-check_password_wo_escape(User, Server, Password) ->
-    try odbc_queries:get_password(Server, User) of
+check_password_wo_escape(LUser, LServer, Password) ->
+    try odbc_queries:get_password(LServer, LUser) of
         {selected, [<<"password">>, <<"pass_details">>], [{Password, null}]} ->
             Password /= <<"">>; %% Password is correct, and not empty
         {selected, [<<"password">>, <<"pass_details">>], [{_Password2, null}]} ->
@@ -150,56 +138,43 @@ check_password_wo_escape(User, Server, Password) ->
     end.
 
 
--spec set_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec set_password(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()
                    ) -> ok | {error, not_allowed | invalid_jid}.
-set_password(User, Server, Password) ->
-    case jlib:nodeprep(User) of
-        error ->
-            {error, invalid_jid};
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            LServer = jlib:nameprep(Server),
-            case prepare_password(Server, Password) of
-                false ->
-                    {error, invalid_password};
-                Pass ->
-                    case catch odbc_queries:set_password_t(LServer, Username, Pass) of
-                        {atomic, ok} ->
-                            ok;
-                        Other ->
-                            {error, Other}
-                    end
+set_password(LUser, LServer, Password) ->
+    Username = ejabberd_odbc:escape(LUser),
+    case prepare_password(LServer, Password) of
+        false ->
+            {error, invalid_password};
+        Pass ->
+            case catch odbc_queries:set_password_t(LServer, Username, Pass) of
+                {atomic, ok} ->
+                    ok;
+                Other ->
+                    {error, Other}
             end
     end.
 
 
--spec try_register(User :: ejabberd:user(),
-                   Server :: ejabberd:server(),
+-spec try_register(LUser :: ejabberd:luser(),
+                   LServer :: ejabberd:lserver(),
                    Password :: binary()
                    ) -> {atomic, ok | exists}
                       | {error, invalid_jid | not_allowed} | {aborted, _}.
-try_register(User, Server, Password) ->
-    case jlib:nodeprep(User) of
-        error ->
-            {error, invalid_jid};
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            case prepare_password(Server, Password) of
-                false ->
-                    {error, invalid_password};
-                Pass ->
-                    LServer = jlib:nameprep(Server),
-                    case catch odbc_queries:add_user(LServer, Username, Pass) of
-                        {updated, 1} ->
-                            ok;
-                        _ ->
-                            {error, exists}
-                    end
+try_register(LUser, LServer, Password) ->
+    Username = ejabberd_odbc:escape(LUser),
+    case prepare_password(LServer, Password) of
+        false ->
+            {error, invalid_password};
+        Pass ->
+            case catch odbc_queries:add_user(LServer, Username, Pass) of
+                {updated, 1} ->
+                    ok;
+                _ ->
+                    {error, exists}
             end
     end.
-
 
 -spec dirty_get_registered_users() -> [ejabberd:simple_jid()].
 dirty_get_registered_users() ->
@@ -210,10 +185,9 @@ dirty_get_registered_users() ->
       end, Servers).
 
 
--spec get_vh_registered_users(Server :: ejabberd:server()
+-spec get_vh_registered_users(LServer :: ejabberd:lserver()
                              ) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server) ->
-    LServer = jlib:nameprep(Server),
+get_vh_registered_users(LServer) ->
     case catch odbc_queries:list_users(LServer) of
         {selected, [<<"username">>], Res} ->
             [{U, LServer} || {U} <- Res];
@@ -222,10 +196,9 @@ get_vh_registered_users(Server) ->
     end.
 
 
--spec get_vh_registered_users(Server :: ejabberd:server(), Opts :: list()
+-spec get_vh_registered_users(LServer :: ejabberd:lserver(), Opts :: list()
                              ) -> [ejabberd:simple_jid()].
-get_vh_registered_users(Server, Opts) ->
-    LServer = jlib:nameprep(Server),
+get_vh_registered_users(LServer, Opts) ->
     case catch odbc_queries:list_users(LServer, Opts) of
         {selected, [<<"username">>], Res} ->
             [{U, LServer} || {U} <- Res];
@@ -234,10 +207,9 @@ get_vh_registered_users(Server, Opts) ->
     end.
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server()
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver()
                                     ) -> integer().
-get_vh_registered_users_number(Server) ->
-    LServer = jlib:nameprep(Server),
+get_vh_registered_users_number(LServer) ->
     case catch odbc_queries:users_number(LServer) of
         {selected, [_], [{Res}]} ->
             list_to_integer(binary_to_list(Res));
@@ -246,10 +218,9 @@ get_vh_registered_users_number(Server) ->
     end.
 
 
--spec get_vh_registered_users_number(Server :: ejabberd:server(),
+-spec get_vh_registered_users_number(LServer :: ejabberd:lserver(),
                                      Opts :: list()) -> integer().
-get_vh_registered_users_number(Server, Opts) ->
-    LServer = jlib:nameprep(Server),
+get_vh_registered_users_number(LServer, Opts) ->
     case catch odbc_queries:users_number(LServer, Opts) of
         {selected, [_], [{Res}]} ->
             list_to_integer(Res);
@@ -258,114 +229,84 @@ get_vh_registered_users_number(Server, Opts) ->
     end.
 
 
--spec get_password(User :: ejabberd:user(),
-                   Server :: ejabberd:server()) -> binary() | false.
-get_password(User, Server) ->
-    case jlib:nodeprep(User) of
-        error ->
-            false;
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            LServer = jlib:nameprep(Server),
-            case catch odbc_queries:get_password(LServer, Username) of
-                {selected, [<<"password">>, <<"pass_details">>], [{Password, null}]} ->
-                    Password; %%Plain password
-                {selected, [<<"password">>, <<"pass_details">>], [{_Password, PassDetails}]} ->
-                    case scram:deserialize(PassDetails) of
-                        {ok, Scram} ->
-                            scram:scram_to_tuple(Scram);
-                        _ ->
-                            false
-                    end;
+-spec get_password(User :: ejabberd:luser(),
+                   Server :: ejabberd:lserver()) -> binary() | false.
+get_password(LUser, LServer) ->
+    Username = ejabberd_odbc:escape(LUser),
+    case catch odbc_queries:get_password(LServer, Username) of
+        {selected, [<<"password">>, <<"pass_details">>], [{Password, null}]} ->
+            Password; %%Plain password
+        {selected, [<<"password">>, <<"pass_details">>], [{_Password, PassDetails}]} ->
+            case scram:deserialize(PassDetails) of
+                {ok, Scram} ->
+                    scram:scram_to_tuple(Scram);
                 _ ->
                     false
-            end
+            end;
+        _ ->
+            false
     end.
 
 
--spec get_password_s(User :: ejabberd:user(),
-                     Server :: ejabberd:server()) -> binary().
-get_password_s(User, Server) ->
-    case jlib:nodeprep(User) of
-        error ->
-            <<"">>;
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            LServer = jlib:nameprep(Server),
-            case catch odbc_queries:get_password(LServer, Username) of
-                {selected, [<<"password">>, <<"pass_details">>], [{Password, _}]} ->
-                    Password;
-                _ ->
-                    <<"">>
-            end
+-spec get_password_s(LUser :: ejabberd:user(),
+                     LServer :: ejabberd:server()) -> binary().
+get_password_s(LUser, LServer) ->
+    Username = ejabberd_odbc:escape(LUser),
+    case catch odbc_queries:get_password(LServer, Username) of
+        {selected, [<<"password">>, <<"pass_details">>], [{Password, _}]} ->
+            Password;
+        _ ->
+            <<"">>
     end.
 
 
--spec is_user_exists(User :: ejabberd:user(),
-                     Server :: ejabberd:server()
+-spec is_user_exists(LUser :: ejabberd:luser(),
+                     LServer :: ejabberd:lserver()
                     ) -> boolean() | {error, atom()}.
-is_user_exists(User, Server) ->
-    case jlib:nodeprep(User) of
-        error ->
-            false;
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            LServer = jlib:nameprep(Server),
-            try odbc_queries:get_password(LServer, Username) of
-                {selected, [<<"password">>, <<"pass_details">>], [{_Password, _}]} ->
-                    true; %% Account exists
-                {selected, [<<"password">>, <<"pass_details">>], []} ->
-                    false; %% Account does not exist
-                {error, Error} ->
-                    {error, Error} %% Typical error is that table doesn't exist
-            catch
-                _:B ->
-                    {error, B} %% Typical error is database not accessible
-            end
+is_user_exists(LUser, LServer) ->
+    Username = ejabberd_odbc:escape(LUser),
+    try odbc_queries:get_password(LServer, Username) of
+        {selected, [<<"password">>, <<"pass_details">>], [{_Password, _}]} ->
+            true; %% Account exists
+        {selected, [<<"password">>, <<"pass_details">>], []} ->
+            false; %% Account does not exist
+        {error, Error} ->
+            {error, Error} %% Typical error is that table doesn't exist
+    catch
+        _:B ->
+            {error, B} %% Typical error is database not accessible
     end.
 
 
 %% @doc Remove user.
 %% Note: it may return ok even if there was some problem removing the user.
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server()
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver()
                   ) -> ok | error | {error, not_allowed}.
-remove_user(User, Server) ->
-    case jlib:nodeprep(User) of
-        error ->
-            error;
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            LServer = jlib:nameprep(Server),
-            catch odbc_queries:del_user(LServer, Username),
-            ok
-    end.
+remove_user(LUser, LServer) ->
+    Username = ejabberd_odbc:escape(LUser),
+    catch odbc_queries:del_user(LServer, Username),
+    ok.
 
 
 %% @doc Remove user if the provided password is correct.
--spec remove_user(User :: ejabberd:user(),
-                  Server :: ejabberd:server(),
+-spec remove_user(LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver(),
                   Password :: binary()
                  ) -> ok | not_exists | not_allowed | bad_request | error.
-remove_user(User, Server, Password) ->
-    case jlib:nodeprep(User) of
-        error ->
-            error;
-        LUser ->
-            Username = ejabberd_odbc:escape(LUser),
-            Pass = ejabberd_odbc:escape(Password),
-            LServer = jlib:nameprep(Server),
-            case check_password_wo_escape(Username, LServer, Pass) of
-                true ->
-                    case catch odbc_queries:del_user(LServer, Username) of
-                        {'EXIT', _} -> error;
-                        _ -> ok
-                    end;
-                not_exists ->
-                    not_exists;
-                false ->
-                    not_allowed
-            end
+remove_user(LUser, LServer, Password) ->
+    Username = ejabberd_odbc:escape(LUser),
+    Pass = ejabberd_odbc:escape(Password),
+    case check_password_wo_escape(Username, LServer, Pass) of
+        true ->
+            case catch odbc_queries:del_user(LServer, Username) of
+                {'EXIT', _} -> error;
+                _ -> ok
+            end;
+        not_exists ->
+            not_exists;
+        false ->
+            not_allowed
     end.
 
 %%%------------------------------------------------------------------

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -274,10 +274,7 @@ get_password(User, Server) ->
                 {selected, [<<"password">>, <<"pass_details">>], [{_Password, PassDetails}]} ->
                     case scram:deserialize(PassDetails) of
                         {ok, Scram} ->
-                            {base64:decode(Scram#scram.storedkey),
-                             base64:decode(Scram#scram.serverkey),
-                             base64:decode(Scram#scram.salt),
-                             Scram#scram.iterationcount};
+                            scram:scram_to_tuple(Scram);
                         _ ->
                             false
                     end;

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -42,7 +42,7 @@
          get_vh_registered_users_number/2,
          get_password/2,
          get_password_s/2,
-         is_user_exists/2,
+         does_user_exist/2,
          remove_user/2,
          remove_user/3,
          store_type/1,
@@ -260,10 +260,10 @@ get_password_s(LUser, LServer) ->
     end.
 
 
--spec is_user_exists(LUser :: ejabberd:luser(),
+-spec does_user_exist(LUser :: ejabberd:luser(),
                      LServer :: ejabberd:lserver()
                     ) -> boolean() | {error, atom()}.
-is_user_exists(LUser, LServer) ->
+does_user_exist(LUser, LServer) ->
     Username = ejabberd_odbc:escape(LUser),
     try odbc_queries:get_password(LServer, Username) of
         {selected, [<<"password">>, <<"pass_details">>], [{_Password, _}]} ->

--- a/apps/ejabberd/src/ejabberd_gen_auth.erl
+++ b/apps/ejabberd/src/ejabberd_gen_auth.erl
@@ -7,57 +7,57 @@
 %%%-------------------------------------------------------------------
 -module(ejabberd_gen_auth).
 
--callback start(Host :: ejabberd:server()) -> ok.
+-callback start(Host :: ejabberd:lserver()) -> ok.
 
--callback stop(Host :: ejabberd:server()) -> ok.
+-callback stop(Host :: ejabberd:lserver()) -> ok.
 
--callback store_type(Host :: ejabberd:server()) -> scram | plain.
+-callback store_type(Host :: ejabberd:lserver()) -> scram | plain.
 
--callback login(User :: ejabberd:user(),
-                Server :: ejabberd:server()) -> boolean().
--callback set_password(User :: ejabberd:user(),
-                       Server :: ejabberd:server(),
+-callback login(User :: ejabberd:luser(),
+                Server :: ejabberd:lserver()) -> boolean().
+-callback set_password(User :: ejabberd:luser(),
+                       Server :: ejabberd:lserver(),
                        Password :: binary()
                       ) -> ok | {error, not_allowed | invalid_jid}.
--callback check_password(User :: ejabberd:user(),
-                         Server :: ejabberd:server(),
+-callback check_password(User :: ejabberd:luser(),
+                         Server :: ejabberd:lserver(),
                          Password :: binary()) -> boolean().
--callback check_password(User :: ejabberd:user(),
-                         Server :: ejabberd:server(),
+-callback check_password(User :: ejabberd:luser(),
+                         Server :: ejabberd:lserver(),
                          Password :: binary(),
                          Digest :: binary(),
                          DigestGen :: fun()) -> boolean().
--callback try_register(User :: ejabberd:user(),
-                       Server :: ejabberd:server(),
+-callback try_register(User :: ejabberd:luser(),
+                       Server :: ejabberd:lserver(),
                        Password :: binary()
                        ) -> ok
                           | {error, invalid_jid | exists | not_allowed | {aborted, _}}.
 -callback dirty_get_registered_users() -> [ejabberd:simple_jid()].
 
--callback get_vh_registered_users(Server :: ejabberd:server()
+-callback get_vh_registered_users(Server :: ejabberd:lserver()
                                  ) -> [ejabberd:simple_jid()].
--callback get_vh_registered_users(Server :: ejabberd:server(),
+-callback get_vh_registered_users(Server :: ejabberd:lserver(),
                                   Opts :: list()) -> [ejabberd:simple_jid()].
--callback get_vh_registered_users_number(Server :: ejabberd:server()
+-callback get_vh_registered_users_number(Server :: ejabberd:lserver()
                                         ) -> integer().
--callback get_vh_registered_users_number(Server :: ejabberd:server(),
+-callback get_vh_registered_users_number(Server :: ejabberd:lserver(),
                                          Opts :: list()) -> integer().
 
--callback get_password(User :: ejabberd:user(),
-                       Server :: ejabberd:server()) -> binary() | false.
--callback get_password_s(User :: ejabberd:user(),
-                         Server :: ejabberd:server()) -> binary().
--callback get_password(User :: ejabberd:user(),
-                       Server :: ejabberd:server(),
+-callback get_password(User :: ejabberd:luser(),
+                       Server :: ejabberd:lserver()) -> binary() | false.
+-callback get_password_s(User :: ejabberd:luser(),
+                         Server :: ejabberd:lserver()) -> binary().
+-callback get_password(User :: ejabberd:luser(),
+                       Server :: ejabberd:lserver(),
                        DefaultValue :: binary()) -> binary() | false.
--callback is_user_exists(User :: ejabberd:user(),
-                         Server :: ejabberd:server()
+-callback is_user_exists(User :: ejabberd:luser(),
+                         Server :: ejabberd:lserver()
                          ) -> boolean() | {error, atom()}.
--callback remove_user(User :: ejabberd:user(),
-                      Server :: ejabberd:server()
+-callback remove_user(User :: ejabberd:luser(),
+                      Server :: ejabberd:lserver()
                       ) -> ok | error | {error, not_allowed}.
--callback remove_user(User :: ejabberd:user(),
-                      Server :: ejabberd:server(),
+-callback remove_user(User :: ejabberd:luser(),
+                      Server :: ejabberd:lserver(),
                       Password :: binary()
                       ) -> ok | not_exists | not_allowed | bad_request | error.
 -callback plain_password_required() -> boolean().

--- a/apps/ejabberd/src/ejabberd_gen_auth.erl
+++ b/apps/ejabberd/src/ejabberd_gen_auth.erl
@@ -9,6 +9,8 @@
 
 -callback start(Host :: ejabberd:server()) -> ok.
 
+-callback stop(Host :: ejabberd:server()) -> ok.
+
 -callback store_type(Host :: ejabberd:server()) -> scram | plain.
 
 -callback login(User :: ejabberd:user(),

--- a/apps/ejabberd/src/ejabberd_gen_auth.erl
+++ b/apps/ejabberd/src/ejabberd_gen_auth.erl
@@ -50,8 +50,8 @@
 -callback get_password(User :: ejabberd:luser(),
                        Server :: ejabberd:lserver(),
                        DefaultValue :: binary()) -> binary() | false.
--callback is_user_exists(User :: ejabberd:luser(),
-                         Server :: ejabberd:lserver()
+-callback does_user_exist(User :: ejabberd:luser(),
+                          Server :: ejabberd:lserver()
                          ) -> boolean() | {error, atom()}.
 -callback remove_user(User :: ejabberd:luser(),
                       Server :: ejabberd:lserver()

--- a/apps/ejabberd/src/ejabberd_gen_auth.erl
+++ b/apps/ejabberd/src/ejabberd_gen_auth.erl
@@ -7,6 +7,10 @@
 %%%-------------------------------------------------------------------
 -module(ejabberd_gen_auth).
 
+-callback start(Host :: ejabberd:server()) -> ok.
+
+-callback store_type(Host :: ejabberd:server()) -> scram | plain.
+
 -callback login(User :: ejabberd:user(),
                 Server :: ejabberd:server()) -> boolean().
 -callback set_password(User :: ejabberd:user(),
@@ -24,8 +28,8 @@
 -callback try_register(User :: ejabberd:user(),
                        Server :: ejabberd:server(),
                        Password :: binary()
-                       ) -> {atomic, ok | exists}
-                          | {error, invalid_jid | not_allowed} | {aborted, _}.
+                       ) -> ok
+                          | {error, invalid_jid | exists | not_allowed | {aborted, _}}.
 -callback dirty_get_registered_users() -> [ejabberd:simple_jid()].
 
 -callback get_vh_registered_users(Server :: ejabberd:server()

--- a/apps/ejabberd/src/extauth.erl
+++ b/apps/ejabberd/src/extauth.erl
@@ -106,7 +106,7 @@ set_password(User, Server, Password) ->
                   ) -> {atomic|error, ok|not_allowed}.
 try_register(User, Server, Password) ->
     case call_port(Server, [<<"tryregister">>, User, Server, Password]) of
-        true -> {atomic, ok};
+        true -> ok;
         false -> {error, not_allowed}
     end.
 

--- a/apps/ejabberd/src/mod_register.erl
+++ b/apps/ejabberd/src/mod_register.erl
@@ -278,14 +278,14 @@ try_register(User, Server, Password, SourceRaw, Lang) ->
 				true ->
 				    case ejabberd_auth:try_register(
 					   User, Server, Password) of
-					{atomic, ok} ->
+					ok ->
                         send_welcome_message(JID),
 					    send_registration_notifications(JID, Source),
 					    ok;
 					Error ->
 					    remove_timeout(Source),
  					    case Error of
-						{atomic, exists} ->
+						{error, exists} ->
 						    {error, ?ERR_CONFLICT};
 						{error, invalid_jid} ->
 						    {error, ?ERR_JID_MALFORMED};

--- a/apps/ejabberd/src/mongoose_api_users.erl
+++ b/apps/ejabberd/src/mongoose_api_users.erl
@@ -96,9 +96,9 @@ maybe_register_user(Username, Host, Password) ->
     case ejabberd_auth:try_register(Username, Host, Password) of
         {error, not_allowed} ->
             ?ERROR;
-        {atomic, exists} ->
+        {error, exists} ->
             maybe_change_password(Username, Host, Password);
-        {atomic, ok} ->
+        ok ->
             ok
     end.
 

--- a/apps/ejabberd/src/scram.erl
+++ b/apps/ejabberd/src/scram.erl
@@ -52,6 +52,8 @@
 
 -export([serialize/1, deserialize/1]).
 
+-export([scram_to_tuple/1]).
+
 -define(SALT_LENGTH, 16).
 -define(SCRAM_DEFAULT_ITERATION_COUNT, 4096).
 -define(SCRAM_SERIAL_PREFIX, "==SCRAM==,").
@@ -167,6 +169,11 @@ deserialize(Bin) ->
     ?WARNING_MSG("Corrupted serialized SCRAM: ~p, ~p", [Bin]),
     {error, corrupted_scram}.
 
+scram_to_tuple(Scram) ->
+    {base64:decode(Scram#scram.storedkey),
+     base64:decode(Scram#scram.serverkey),
+     base64:decode(Scram#scram.salt),
+     Scram#scram.iterationcount}.
 
 -ifdef(no_crypto_hmac).
 crypto_hmac(sha, Key, Data) ->

--- a/apps/ejabberd/src/scram.erl
+++ b/apps/ejabberd/src/scram.erl
@@ -47,7 +47,8 @@
          iterations/1,
          password_to_scram/1,
          password_to_scram/2,
-         check_password/2
+         check_password/2,
+         check_digest/4
         ]).
 
 -export([serialize/1, deserialize/1]).
@@ -169,11 +170,17 @@ deserialize(Bin) ->
     ?WARNING_MSG("Corrupted serialized SCRAM: ~p, ~p", [Bin]),
     {error, corrupted_scram}.
 
+-spec scram_to_tuple(scram()) -> {binary(), binary(), binary(), non_neg_integer()}.
 scram_to_tuple(Scram) ->
     {base64:decode(Scram#scram.storedkey),
      base64:decode(Scram#scram.serverkey),
      base64:decode(Scram#scram.salt),
      Scram#scram.iterationcount}.
+
+-spec check_digest(scram(), binary(), fun(), binary()) -> boolean().
+check_digest(#scram{storedkey = StoredKey}, Digest, DigestGen, Password) ->
+    Passwd = base64:decode(StoredKey),
+    ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd).
 
 -ifdef(no_crypto_hmac).
 crypto_hmac(sha, Key, Data) ->

--- a/apps/ejabberd/test/auth_http_SUITE.erl
+++ b/apps/ejabberd/test/auth_http_SUITE.erl
@@ -125,9 +125,9 @@ set_password(_Config) ->
     ok = ejabberd_auth_http:set_password(<<"alice">>, ?DOMAIN1, <<"makota">>).
 
 try_register(_Config) ->
-    {atomic, ok} = ejabberd_auth_http:try_register(<<"nonexistent">>, ?DOMAIN1, <<"newpass">>),
+    ok = ejabberd_auth_http:try_register(<<"nonexistent">>, ?DOMAIN1, <<"newpass">>),
     true = ejabberd_auth_http:check_password(<<"nonexistent">>, ?DOMAIN1, <<"newpass">>),
-    {atomic, exists} = ejabberd_auth_http:try_register(<<"nonexistent">>, ?DOMAIN1, <<"anypass">>).
+    {error, exists} = ejabberd_auth_http:try_register(<<"nonexistent">>, ?DOMAIN1, <<"anypass">>).
 
 % get_password + get_password_s
 get_password(_Config) ->

--- a/apps/ejabberd/test/auth_http_SUITE.erl
+++ b/apps/ejabberd/test/auth_http_SUITE.erl
@@ -144,20 +144,20 @@ get_password(_Config) ->
     <<>> = ejabberd_auth_http:get_password_s(<<"anakin">>, ?DOMAIN1).
     
 is_user_exists(_Config) ->
-    true = ejabberd_auth_http:is_user_exists(<<"alice">>, ?DOMAIN1),
-    false = ejabberd_auth_http:is_user_exists(<<"madhatter">>, ?DOMAIN1).
+    true = ejabberd_auth_http:does_user_exist(<<"alice">>, ?DOMAIN1),
+    false = ejabberd_auth_http:does_user_exist(<<"madhatter">>, ?DOMAIN1).
 
 % remove_user/2,3
 remove_user(_Config) ->
-    true = ejabberd_auth_http:is_user_exists(<<"toremove1">>, ?DOMAIN1),
+    true = ejabberd_auth_http:does_user_exist(<<"toremove1">>, ?DOMAIN1),
     ok = ejabberd_auth_http:remove_user(<<"toremove1">>, ?DOMAIN1),
-    false = ejabberd_auth_http:is_user_exists(<<"toremove1">>, ?DOMAIN1),
+    false = ejabberd_auth_http:does_user_exist(<<"toremove1">>, ?DOMAIN1),
 
-    true = ejabberd_auth_http:is_user_exists(<<"toremove2">>, ?DOMAIN1),
+    true = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
     not_allowed = ejabberd_auth_http:remove_user(<<"toremove2">>, ?DOMAIN1, <<"wrongpass">>),
-    true = ejabberd_auth_http:is_user_exists(<<"toremove2">>, ?DOMAIN1),
+    true = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
     ok = ejabberd_auth_http:remove_user(<<"toremove2">>, ?DOMAIN1, <<"pass">>),
-    false = ejabberd_auth_http:is_user_exists(<<"toremove2">>, ?DOMAIN1),
+    false = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
 
     not_exists = ejabberd_auth_http:remove_user(<<"toremove3">>, ?DOMAIN1, <<"wrongpass">>).
 

--- a/rebar.tests.config
+++ b/rebar.tests.config
@@ -6,5 +6,5 @@
 {deps_dir, "test"}.
 
 {deps, [
-    {ejabberd_tests, ".*", {git, "https://github.com/michalwski/ejabberd_tests.git", "riak-base"}}
+    {ejabberd_tests, ".*", {git, "https://github.com/esl/ejabberd_tests.git", "master"}}
 ]}.

--- a/rebar.tests.config
+++ b/rebar.tests.config
@@ -6,5 +6,5 @@
 {deps_dir, "test"}.
 
 {deps, [
-    {ejabberd_tests, ".*", {git, "git://github.com/esl/ejabberd_tests.git", "master"}}
+    {ejabberd_tests, ".*", {git, "https://github.com/michalwski/ejabberd_tests.git", "riak-base"}}
 ]}.


### PR DESCRIPTION
Refactoring of auth-related modules.

One of the most significant changes is that all auth backend modules expect `ejabberd:luser()` and `ejabberd:lserver()` now in callbacks defined by `ejabberd_gen_auth` behaviour. In other words they don't do `jlib:nodeprep(User)` or `jlib:nameprep(Server)`

All changes taken from PR #378