### PR TITLE
mod_mam cassandra: pass config to workers (eg credentials)

### DIFF
--- a/apps/ejabberd/src/mod_mam_con_ca_arch.erl
+++ b/apps/ejabberd/src/mod_mam_con_ca_arch.erl
@@ -24,7 +24,7 @@
 -export([get_conversations_after/3]).
 
 %% Internal exports
--export([start_link/3]).
+-export([start_link/4]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -103,7 +103,7 @@
 
 start(Host, Opts) ->
     create_worker_pool(Host),
-    mod_mam_con_ca_sup:start(Host, servers(Host)),
+    mod_mam_con_ca_sup:start(Host, cassandra_config(Host)),
     case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
         true ->
             start_pm(Host, Opts);
@@ -133,8 +133,10 @@ stop(Host) ->
     delete_worker_pool(Host),
     mod_mam_con_ca_sup:stop(Host).
 
-servers(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, servers, [{"localhost", 9042, 1}]).
+cassandra_config(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, cassandra_config, [{servers, [{"localhost", 9042, 1}]},
+                                                             {keyspace, "mam"},
+                                                             {credentials, undefined}]).
 
 
 %% ----------------------------------------------------------------------
@@ -235,8 +237,8 @@ select_worker(Host, UserJID) ->
 group_name(Host) ->
     {mam_ca, Host}.
 
-start_link(Host, Addr, Port) ->
-    gen_server:start_link(?MODULE, [Host, Addr, Port], []).
+start_link(Host, Addr, Port, ClientOptions) ->
+    gen_server:start_link(?MODULE, [Host, Addr, Port, ClientOptions], []).
 
 
 %% ----------------------------------------------------------------------
@@ -912,9 +914,8 @@ forward_query_respond(ResultF, QueryRef,
 %%                         {stop, Reason}
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
-init([Host, Addr, Port]) ->
+init([Host, Addr, Port, ClientOptions]) ->
     register_worker(Host, self()),
-    ClientOptions = [{keyspace, "mam"}],
     {ok, ConnPid} = seestar_session:start_link(Addr, Port, ClientOptions),
 
     InsertQuery = "INSERT INTO mam_con_message "

--- a/apps/ejabberd/src/mod_mam_con_ca_sup.erl
+++ b/apps/ejabberd/src/mod_mam_con_ca_sup.erl
@@ -5,39 +5,40 @@
 
 -export([start/2, stop/1, start_link/2, init/1]).
 
-start(Host, Addresses) ->
-    supervisor:start_child(ejabberd_sup, supervisor_spec(Host, Addresses)).
+start(Host, Config) ->
+    supervisor:start_child(ejabberd_sup, supervisor_spec(Host, Config)).
 
 stop(Host) ->
     Tag = {mod_mam_con_ca_sup, Host},
     supervisor:terminate_child(ejabberd_sup, Tag),
     supervisor:delete_child(ejabberd_sup, Tag).
 
-start_link(Host, Addresses) ->
-    supervisor2:start_link({local, ?MODULE}, ?MODULE, [Host, Addresses]).
+start_link(Host, Config) ->
+    supervisor2:start_link({local, ?MODULE}, ?MODULE, [Host, Config]).
 
-supervisor_spec(Host, Addresses) ->
+supervisor_spec(Host, Config) ->
     {{mod_mam_con_ca_sup, Host},
-     {?MODULE, start_link, [Host, Addresses]},
+     {?MODULE, start_link, [Host, Config]},
      permanent,
      infinity,
      supervisor,
      [?MODULE]}.
 
-worker_spec(Host, Addr, Port, WorkerNumber) ->
+worker_spec(Host, Addr, Port, WorkerNumber, ClientOptions) ->
     {{Host, Addr, Port, WorkerNumber},
-     {mod_mam_con_ca_arch, start_link, [Host, Addr, Port]},
+     {mod_mam_con_ca_arch, start_link, [Host, Addr, Port, ClientOptions]},
      {permanent, 10}, %% Delay is 10 seconds
      infinity,
      worker,
      [mod_mam_con_ca_arch]}.
 
-worker_specs(Host, Addresses) ->
-    [worker_spec(Host, Addr, Port, WorkerNumber)
-     || {Addr, Port, WorkerCount} <- Addresses,
+worker_specs(Host, Servers, ClientOptions) ->
+    [worker_spec(Host, Addr, Port, WorkerNumber, ClientOptions)
+     || {Addr, Port, WorkerCount} <- Servers,
         WorkerNumber <- lists:seq(1, WorkerCount)].
 
-init([Host, Addresses]) ->
-    Specs = worker_specs(Host, Addresses),
+init([Host, ClientOptions]) ->
+    Servers = proplists:get_value(servers, ClientOptions),
+    Specs = worker_specs(Host, Servers, ClientOptions),
     {ok, {{one_for_one, 10, 1}, Specs}}.
 


### PR DESCRIPTION
This allows amongst others to pass credentials to mod_mam_con_ca_arch wokers for connecting to cassandra.