### PR TITLE
Refactor ejabberd_c2s:handle_info/3

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1204,6 +1204,8 @@ handle_routed(_, _From, _To, Packet, StateData) ->
 
 handle_routed_iq(From, To, Packet = #xmlel{attrs = Attrs}, StateData) ->
     case jlib:iq_query_info(Packet) of
+	%% TODO: Support for mod_last / XEP-0012. Can we move it to the respective module?
+	%%	 Thanks to add_iq_handler(ejabberd_sm, ...)?
 	#iq{xmlns = ?NS_LAST} ->
 	    HasFromSub = ( is_subscribed_to_my_presence(From, StateData)
 			   andalso is_privacy_allow(StateData, To, From,


### PR DESCRIPTION
Split `ejabberd_c2s:handle_info/3` into multiple functions, remove redundant code, extract named predicates, reformat.