### PR TITLE
adds `Reason` arg to sm_remove_connection_hook

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth_anonymous.erl
+++ b/apps/ejabberd/src/ejabberd_auth_anonymous.erl
@@ -35,7 +35,7 @@
   anonymous_user_exist/2,
   allow_multiple_connections/1,
   register_connection/3,
-  unregister_connection/3
+  unregister_connection/4
   ]).
 
 -behaviour(ejabberd_gen_auth).
@@ -193,8 +193,8 @@ register_connection(SID, #jid{luser = LUser, lserver = LServer}, Info) ->
 %% @doc Remove an anonymous user from the anonymous users table
 -spec unregister_connection(SID :: ejabberd_sm:sid(),
                             JID :: ejabberd:jid(),
-                            any()) -> {atomic|error|aborted, _}.
-unregister_connection(SID, #jid{luser = LUser, lserver = LServer}, _) ->
+                            any(), ejabberd_sm:close_reason()) -> {atomic|error|aborted, _}.
+unregister_connection(SID, #jid{luser = LUser, lserver = LServer}, _, _) ->
     purge_hook(anonymous_user_exist(LUser, LServer),
                LUser, LServer),
     remove_connection(SID, LUser, LServer).

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1376,7 +1376,8 @@ terminate(_Reason, StateName, StateData) ->
                       StateData#state.user,
                       StateData#state.server,
                       StateData#state.resource,
-                      "Replaced by new connection"),
+                      "Replaced by new connection",
+                      replaced),
                     presence_broadcast(
                       StateData, From, StateData#state.pres_a, Packet),
                     presence_broadcast(
@@ -1400,7 +1401,8 @@ terminate(_Reason, StateName, StateData) ->
                             ejabberd_sm:close_session(StateData#state.sid,
                                                       StateData#state.user,
                                                       StateData#state.server,
-                                                      StateData#state.resource);
+                                                      StateData#state.resource,
+                                                      normal);
                         _ ->
                             From = StateData#state.jid,
                             Packet = #xmlel{name = <<"presence">>,
@@ -1410,7 +1412,8 @@ terminate(_Reason, StateName, StateData) ->
                               StateData#state.user,
                               StateData#state.server,
                               StateData#state.resource,
-                              ""),
+                              "",
+                              normal),
                             presence_broadcast(
                               StateData, From, StateData#state.pres_a, Packet),
                             presence_broadcast(
@@ -2785,7 +2788,8 @@ handover_session(SD) ->
     ejabberd_sm:close_session(SD#state.sid,
                               SD#state.user,
                               SD#state.server,
-                              SD#state.resource),
+                              SD#state.resource,
+                              resumed),
     {N, Messages} = flush_messages(),
     NewSize = N + SD#state.stream_mgmt_buffer_size,
     NewBuffer = Messages ++ SD#state.stream_mgmt_buffer,

--- a/apps/ejabberd/src/mod_ping.erl
+++ b/apps/ejabberd/src/mod_ping.erl
@@ -50,7 +50,7 @@
          handle_info/2, code_change/3]).
 
 %% Hook callbacks
--export([iq_ping/3, user_online/3, user_offline/3, user_send/3]).
+-export([iq_ping/3, user_online/3, user_offline/4, user_send/3]).
 
 -record(state, {host = <<"">>,
                 send_pings = ?DEFAULT_SEND_PINGS,
@@ -190,7 +190,7 @@ iq_ping(_From, _To, #iq{type = Type, sub_el = SubEl} = IQ) ->
 user_online(_SID, JID, _Info) ->
     start_ping(JID#jid.lserver, JID).
 
-user_offline(_SID, JID, _Info) ->
+user_offline(_SID, JID, _Info, _Reason) ->
     stop_ping(JID#jid.lserver, JID).
 
 user_send(JID, _From, _Packet) ->

--- a/apps/ejabberd/src/mod_stream_management.erl
+++ b/apps/ejabberd/src/mod_stream_management.erl
@@ -8,7 +8,7 @@
 
 %% `ejabberd_hooks' handlers
 -export([add_sm_feature/2,
-         remove_smid/3]).
+         remove_smid/4]).
 
 %% `ejabberd.cfg' options (don't use outside of tests)
 -export([get_buffer_max/1,
@@ -60,7 +60,7 @@ sm() ->
     #xmlel{name = <<"sm">>,
            attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]}.
 
-remove_smid(SID, _JID, _Info) ->
+remove_smid(SID, _JID, _Info, _Reason) ->
     case mnesia:dirty_index_read(sm_session, SID, #sm_session.sid) of
         [] ->
             ok;

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -17,7 +17,7 @@
 %% Internal exports
 %%-------------------
 -export([sm_register_connection_hook/3,
-         sm_remove_connection_hook/3,
+         sm_remove_connection_hook/4,
          auth_failed/2,
          user_send_packet/3,
          user_receive_packet/4,
@@ -113,9 +113,10 @@ sm_register_connection_hook(_,#jid{server = Server}, _) ->
     mongoose_metrics:update({Server, sessionSuccessfulLogins}, 1),
     mongoose_metrics:update({Server, sessionCount}, 1).
 
--spec sm_remove_connection_hook(tuple(), ejabberd:jid(), term()
+-spec sm_remove_connection_hook(tuple(), ejabberd:jid(),
+                                term(), ejabberd_sm:close_reason()
                                ) -> metrics_notify_return().
-sm_remove_connection_hook(_,#jid{server = Server},_) ->
+sm_remove_connection_hook(_,#jid{server = Server},_, _Reason) ->
     mongoose_metrics:update({Server, sessionLogouts}, 1),
     mongoose_metrics:update({Server, sessionCount}, -1).
 

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -4,7 +4,7 @@
 setup() ->
     meck:new(ejabberd_sm),
     meck:expect(ejabberd_sm, close_session,
-                fun(_SID, _User, _Server, _Resource) -> ok end),
+                fun(_SID, _User, _Server, _Resource, _Reason) -> ok end),
 
     meck:new(ejabberd_socket),
     meck:expect(ejabberd_socket, close,


### PR DESCRIPTION
`Reason` says how the connection was closed:
 * normal
 * replaced
 * resumed