### PR TITLE
Refactor ejabberd_c2s:wait_for_stream/2

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -120,10 +120,8 @@ get_subscription(From = #jid{}, StateData) ->
     get_subscription(jlib:jid_tolower(From), StateData);
 get_subscription(LFrom, StateData) ->
     LBFrom = setelement(3, LFrom, <<>>),
-    F = ?SETS:is_element(LFrom, StateData#state.pres_f) orelse
-    ?SETS:is_element(LBFrom, StateData#state.pres_f),
-    T = ?SETS:is_element(LFrom, StateData#state.pres_t) orelse
-    ?SETS:is_element(LBFrom, StateData#state.pres_t),
+    F = is_subscribed_to_my_presence(LFrom, LBFrom, StateData),
+    T = am_i_subscribed_to_presence(LFrom, LBFrom, StateData),
     if F and T -> both;
        F -> from;
        T -> to;
@@ -1663,6 +1661,11 @@ is_subscribed_to_my_presence(LFrom, LBareFrom, S) ->
     ?SETS:is_element(LFrom, S#state.pres_f)
     orelse (LFrom /= LBareFrom)
     andalso ?SETS:is_element(LBareFrom, S#state.pres_f).
+
+am_i_subscribed_to_presence(LJID, LBareJID, S) ->
+    ?SETS:is_element(LJID, S#state.pres_t)
+    orelse (LJID /= LBareJID)
+    andalso ?SETS:is_element(LBareJID, S#state.pres_t).
 
 lowcase_and_bare(JID) ->
     LJID = jlib:jid_tolower(JID),

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -227,6 +227,9 @@ wait_for_stream({xmlstreamstart, _Name, _} = StreamStart, StateData) ->
     handle_stream_start(StreamStart, StateData);
 wait_for_stream(timeout, StateData) ->
     {stop, normal, StateData};
+%% TODO: this clause is most likely dead code - can't be triggered
+%%       with XMPP level tests;
+%%       see github.com/esl/ejabberd_tests/tree/element-before-stream-start
 wait_for_stream({xmlstreamelement, _}, StateData) ->
     c2s_stream_error(?INVALID_XML_ERR, StateData);
 wait_for_stream({xmlstreamend, _}, StateData) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -711,15 +711,6 @@ wait_for_bind_or_resume({xmlstreamelement, El}, StateData) ->
                     fsm_next_state(wait_for_bind_or_resume, StateData);
                 _ ->
                     JID = jlib:make_jid(U, StateData#state.server, R),
-                    %%Server = StateData#state.server,
-                    %%RosterVersioningFeature =
-                    %%  ejabberd_hooks:run_fold(
-                    %%  roster_get_versioning_feature, Server, [], [Server]),
-                    %%StreamFeatures = [{xmlel, "session",
-                    %%             [{"xmlns", ?NS_SESSION}], []} |
-                    %%            RosterVersioningFeature],
-                    %%send_element(StateData, {xmlel, "stream:features",
-                    %%               [], StreamFeatures}),
                     Res = IQ#iq{type = result,
                                 sub_el = [#xmlel{name = <<"bind">>,
                                                  attrs = [{<<"xmlns">>, ?NS_BIND}],
@@ -2141,18 +2132,7 @@ resend_offline_messages(StateData) ->
                              end,
                       if
                           Pass ->
-                              %% Attrs2 = jlib:replace_from_to_attrs(
-                              %%                 jlib:jid_to_binary(From),
-                              %%                 jlib:jid_to_binary(To),
-                              %%                 Attrs),
-                              %% FixedPacket = {xmlel, Name, Attrs2, Els},
-                              %% Use route instead of send_element to go through standard workflow
                               ejabberd_router:route(From, To, Packet);
-                          %% send_element(StateData, FixedPacket),
-                          %% ejabberd_hooks:run(user_receive_packet,
-                          %%                         StateData#state.server,
-                          %%                         [StateData#state.jid,
-                          %%                          From, To, FixedPacket]);
                           true ->
                               ok
                       end


### PR DESCRIPTION
Local tests and coverage reports show almost complete coverage of the refactored FSM state. Testing against the version just before refactoring shows similar coverage and the same tests pass without modification.

I couldn't come up with a test case which would fall into `wait_for_stream({xmlstreamelement, _}, ...)` clause - if the first element sent on a newly opened socket is not `<stream:stream>` it still gets passed to the function wrapped as `{xmlstreamstart, _, _}`, not `{xmlstreamelement, _}`. See https://github.com/esl/ejabberd_tests/tree/element-before-stream-start for a tried but finally dropped approach. It's probably something lower (even lower than `ejabberd_receiver`, probably XML parser in `xml`).

Ready to merge once Travis passes.