### PR TITLE
commandline arguments with whitespace

### DIFF
--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -62,6 +62,8 @@
 -type format_type() :: binary() | string() | char().
 -type cmd() :: {CallString :: string(), Args :: [string()], Desc :: string()}.
 
+-define(ASCII_SPACE_CHARACTER, $\s).
+
 %%-----------------------------
 %% Module
 %%-----------------------------
@@ -369,7 +371,7 @@ args_join_strings([ "\"", NextArg | RArgs ]) ->
     args_join_strings([ "\"" ++ NextArg | RArgs ]);
 args_join_strings([ [ $" | _ ] = Arg | RArgs ]) ->
     case lists:nthtail(length(Arg)-2, Arg) of
-        [C1, $"] when C1 /= $\ ->
+        [C1, $"] when C1 /= ?ASCII_SPACE_CHARACTER ->
             [ string:substr(Arg, 2, length(Arg)-2) | args_join_strings(RArgs) ];
         _ ->
             [NextArg | RArgs1] = RArgs,

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -391,7 +391,7 @@ bal(String, Left, Right) ->
 -spec bal(string(), L :: char(), R :: char(), Bal :: integer()) -> boolean().
 bal([], _Left, _Right, Bal) ->
     Bal == 0;
-bal([$\ , _NextChar | T], Left, Right, Bal) ->
+bal([?ASCII_SPACE_CHARACTER, _NextChar | T], Left, Right, Bal) ->
     bal(T, Left, Right, Bal);
 bal([Left | T], Left, Right, Bal) ->
     bal(T, Left, Right, Bal-1);
@@ -646,7 +646,7 @@ prepare_description(DescInit, MaxC, Desc) ->
                         ) -> [[[any()]],...].
 prepare_long_line(DescInit, MaxC, Words) ->
     MaxSegmentLen = MaxC - DescInit,
-    MarginString = lists:duplicate(DescInit, $\s), % Put spaces
+    MarginString = lists:duplicate(DescInit, ?ASCII_SPACE_CHARACTER), % Put spaces
     [FirstSegment | MoreSegments] = split_desc_segments(MaxSegmentLen, Words),
     MoreSegmentsMixed = mix_desc_segments(MarginString, MoreSegments),
     [FirstSegment | MoreSegmentsMixed].
@@ -706,7 +706,7 @@ format_command_lines(CALD, MaxCmdLen, MaxC, ShCode, dual) ->
     lists:map(
       fun({Cmd, Args, CmdArgsL, Desc}) ->
               DescFmt = prepare_description(MaxCmdLen+4, MaxC, Desc),
-              ["  ", ?B(Cmd), " ", [[?U(Arg), " "] || Arg <- Args], string:chars($\s, MaxCmdLen - CmdArgsL + 1),
+              ["  ", ?B(Cmd), " ", [[?U(Arg), " "] || Arg <- Args], string:chars(?ASCII_SPACE_CHARACTER, MaxCmdLen - CmdArgsL + 1),
                DescFmt, "\n"]
       end, CALD);
 format_command_lines(CALD, _MaxCmdLen, MaxC, ShCode, long) ->
@@ -866,7 +866,7 @@ print_usage_command(Cmd, C, MaxC, ShCode) ->
 
     %% Initial indentation of result is 13 = length("  Arguments: ")
     Args = [format_usage_ctype(ArgDef, 13) || ArgDef <- ArgsDef],
-    ArgsMargin = lists:duplicate(13, $\s),
+    ArgsMargin = lists:duplicate(13, ?ASCII_SPACE_CHARACTER),
     ArgsListFmt = case Args of
                       [] -> "\n";
                       _ -> [ [Arg, "\n", ArgsMargin] || Arg <- Args]
@@ -920,7 +920,7 @@ format_usage_tuple([ElementDef], Indentation) ->
     [format_usage_ctype(ElementDef, Indentation) , " }"];
 format_usage_tuple([ElementDef | ElementsDef], Indentation) ->
     ElementFmt = format_usage_ctype(ElementDef, Indentation),
-    MarginString = lists:duplicate(Indentation, $\s), % Put spaces
+    MarginString = lists:duplicate(Indentation, ?ASCII_SPACE_CHARACTER), % Put spaces
     [ElementFmt, ",\n", MarginString, format_usage_tuple(ElementsDef, Indentation)].
 
 %%-----------------------------

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -8,7 +8,7 @@ while [ $# -ne 0 ] ; do
     shift
     case $PARAM in
         --) break ;;
-        *) ARGS="$ARGS $PARAM" ;;
+        *) ARGS="$ARGS \"$PARAM\"" ;;
     esac
 done
 
@@ -79,7 +79,7 @@ help ()
 # common control function
 ctl ()
 {
-    COMMAND=$@
+    COMMAND="$@"
 
     # Control number of connections identifiers
     # using flock if available. Expects a linux-style
@@ -156,7 +156,7 @@ ctl ()
 ctlexec ()
 {
     CONN_NAME=$1; shift
-    COMMAND=$@
+    COMMAND="$@"
     $ERL \
       $NAME_TYPE ${CONN_NAME} \
       -noinput \

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -1,17 +1,5 @@
 #!/bin/sh
 
-
-# parse command line parameters
-ARGS=
-while [ $# -ne 0 ] ; do
-    PARAM=$1
-    shift
-    case $PARAM in
-        --) break ;;
-        *) ARGS="$ARGS \"$PARAM\"" ;;
-    esac
-done
-
 RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
 EJABBERD_DIR=${RUNNER_SCRIPT_DIR%/*}
 EJABBERD_VMARGS_PATH=$EJABBERD_DIR/etc/vm.args
@@ -79,7 +67,7 @@ help ()
 # common control function
 ctl ()
 {
-    COMMAND="$@"
+    COMMAND=$@
 
     # Control number of connections identifiers
     # using flock if available. Expects a linux-style
@@ -156,7 +144,7 @@ ctl ()
 ctlexec ()
 {
     CONN_NAME=$1; shift
-    COMMAND="$@"
+    COMMAND=$@
     $ERL \
       $NAME_TYPE ${CONN_NAME} \
       -noinput \
@@ -204,13 +192,27 @@ wait_for_status()
     return $status
 }
 
-case "$ARGS" in
-    ' start') start;;
-    \ add_to_cluster*) add_to_cluster;;
-    \ remove_from_cluster*) remove_from_cluster;;
-    ' debug') debug;;
-    ' live') live;;
-    ' started') wait_for_status 0 30 2;; # wait 30x2s before timeout
-    ' stopped') wait_for_status 3 15 2; stop_epmd;; # wait 15x2s before timeout
-    *) ctl $ARGS;;
+
+# parse command line parameters
+ARGS=""; QUOTED_ARGS=""
+for PARAM in "$@"
+do
+    case $PARAM in
+        --)
+	    break ;;
+         *)
+	    ARGS+=$PARAM; ARGS+=" ";
+	    QUOTED_ARGS+='"'$PARAM'"'; QUOTED_ARGS+=" " ;;
+    esac
+done
+
+case $1 in
+    'start') start;;
+    'add_to_cluster') add_to_cluster;;
+    'remove_from_cluster') remove_from_cluster;;
+    'debug') debug;;
+    'live') live;;
+    'started') wait_for_status 0 30 2;; # wait 30x2s before timeout
+    'stopped') wait_for_status 3 15 2; stop_epmd;; # wait 15x2s before timeout
+    *) ctl $QUOTED_ARGS;;
 esac

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -201,8 +201,8 @@ do
         --)
 	    break ;;
          *)
-	    ARGS+=$PARAM; ARGS+=" ";
-	    QUOTED_ARGS+='"'$PARAM'"'; QUOTED_ARGS+=" " ;;
+	    ARGS="$ARGS$PARAM"; ARGS="$ARGS ";
+	    QUOTED_ARGS=$QUOTED_ARGS'"'$PARAM'"'; QUOTED_ARGS=$QUOTED_ARGS" " ;;
     esac
 done
 

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -33,18 +33,17 @@ add_node_to_cluster(ConfigIn) ->
     MnesiaDir = filename:join([get_cwd(Node2, Config), "Mnesia*"]),
     MnesiaCmd = "rm -rf " ++ MnesiaDir,
 
-    Res1 = call_fun(Node, os, cmd, [MnesiaCmd]),
-    Res2 = call_fun(Node, os, cmd, [StopCmd]),
+    Res1 = call_fun(Node, os, cmd, [StopCmd]),
+    ?assertEqual("", Res1),
     wait_until_stopped(StatusCmd, 120),
+    Res2 = call_fun(Node, os, cmd, [MnesiaCmd]),
+    ?assertEqual("", Res2),
 
     Res3 = call_fun(Node, os, cmd, [AddToClusterCmd]),
+    ?assertMatch("Node added to cluster" ++ _, Res3),
     Res4 = call_fun(Node, os, cmd, [StartCmd]),
+    ?assertEqual("", Res4),
     wait_until_started(StatusCmd, 120),
-
-    ?assertEqual(Res1, ""),
-    ?assertEqual(Res2, ""),
-    "Node added to cluster" ++ _ = Res3,
-    ?assertEqual(Res4, ""),
 
     verify_result(add),
 


### PR DESCRIPTION
When invoking `mongooseimctl` with arguments containing spaces, instead of needing two levels of nested quoting, just use one. See the issue for an example: #494. Personally I think we could read command-line arguments more elegantly, with something like:

```sh
ARGS=""
for ARG in "$@"
do
    if [ "$ARG" = '--' ]
    then
    	break
    else
    	ARGS+='"'$ARG'" '
    fi
done
```

Or using a `case`.