### PR TITLE
Keep alive hook

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1065,6 +1065,10 @@ resume_session(resume, _From, SD) ->
 %%          {next_state, NextStateName, NextStateData, Timeout} |
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
+handle_event(keep_alive_packet, session_established,
+             #state{server = Server, jid = JID} = StateData) ->
+    ejabberd_hooks:run(user_sent_keep_alive, Server, [JID]),
+    fsm_next_state(session_established, StateData);
 handle_event(_Event, StateName, StateData) ->
     fsm_next_state(StateName, StateData).
 

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -344,7 +344,7 @@ process_data(Data,
     State#state{xml_stream_state = XMLStreamState1,
                 shaper_state = NewShaperState}.
 
-maybe_pause(_, #state{c2s_pid = undefinde}) ->
+maybe_pause(_, #state{c2s_pid = undefined}) ->
     ok;
 maybe_pause(Pause, _State) when Pause > 0 ->
     erlang:start_timer(Pause, self(), activate);

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -333,23 +333,31 @@ process_data([Element|Els], #state{c2s_pid = C2SPid} = State)
 %% Data processing for connectors receivind data as string.
 process_data(Data,
              #state{xml_stream_state = XMLStreamState,
-                    shaper_state = ShaperState,
-                    c2s_pid = C2SPid} = State) ->
+                    shaper_state = ShaperState} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
     Size = size(Data),
     mongoose_metrics:update([data, xmpp, received, xml_stanza_size], Size),
+    maybe_run_keep_alive_hook(Size, State),
     XMLStreamState1 = xml_stream:parse(XMLStreamState, Data),
     {NewShaperState, Pause} = shaper:update(ShaperState, Size),
-    if
-        C2SPid == undefined ->
-            ok;
-        Pause > 0 ->
-            erlang:start_timer(Pause, self(), activate);
-        true ->
-            activate_socket(State)
-    end,
+    maybe_pause(Pause, State),
     State#state{xml_stream_state = XMLStreamState1,
                 shaper_state = NewShaperState}.
+
+maybe_pause(_, #state{c2s_pid = undefinde}) ->
+    ok;
+maybe_pause(Pause, _State) when Pause > 0 ->
+    erlang:start_timer(Pause, self(), activate);
+maybe_pause(_, State) ->
+    activate_socket(State).
+
+maybe_run_keep_alive_hook(Size, #state{c2s_pid = C2SPid})
+  when Size < 3, is_pid(C2SPid) ->
+    %% yes it can happen that the data is shorter than 3 bytes and contain some part of xml
+    %% but this will not harm the keep_alive_hook
+    gen_fsm:send_all_state_event(C2SPid, keep_alive_packet);
+maybe_run_keep_alive_hook(_, _) ->
+    ok.
 
 %% @doc Element coming from XML parser are wrapped inside xmlstreamelement
 %% When we receive directly xmlel tuple (from a socket module


### PR DESCRIPTION
This PR introduces keep alive hook which is run when the client sends XMPP whitespace keep alive packets. This can be useful in mod_ping if we want to reset the timer after such packets. 