### PR TITLE
ODBC keep-alive

### DIFF
--- a/apps/ejabberd/rebar.config
+++ b/apps/ejabberd/rebar.config
@@ -23,6 +23,9 @@
                deprecated_function_calls,
                deprecated_functions]}.
 
+{ct_extra_params, "-pa ../mysql/ebin "
+                  "-pa ../pgsql/ebin "}.
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -211,6 +211,8 @@ get_vh_registered_users(LServer, Opts) ->
                                     ) -> integer().
 get_vh_registered_users_number(LServer) ->
     case catch odbc_queries:users_number(LServer) of
+        {selected, [_], [{Res}]} when is_integer(Res) ->
+            Res;
         {selected, [_], [{Res}]} ->
             list_to_integer(binary_to_list(Res));
         _ ->

--- a/apps/ejabberd/src/ejabberd_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_odbc.erl
@@ -174,7 +174,7 @@ keep_alive(PID) ->
         {selected, _, _} ->
             ok;
         {error, _} ->
-            ?ERROR_MSG("Keepalive query failed, killing ~p", [PID]),
+            ?ERROR_MSG("Keep-alive query failed, killing ~p", [PID]),
             exit(PID, kill)
     end.
 
@@ -584,7 +584,7 @@ sql_query_internal(Query) ->
     State = get(?STATE_KEY),
     Res = case State#state.db_type of
               odbc ->
-                  binaryze_odbc(odbc:sql_query(State#state.db_ref, Query, 5000));
+                  binaryze_odbc(odbc:sql_query(State#state.db_ref, Query));
               pgsql ->
                   ?DEBUG("Postres, Send query~n~p~n", [Query]),
                   pgsql_to_odbc(pgsql:squery(State#state.db_ref, Query));

--- a/apps/ejabberd/src/ejabberd_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_odbc.erl
@@ -168,7 +168,7 @@ sql_call({_Host, Pid}, Msg) when is_pid(Pid) ->
 
 %% @doc perform a harmless query on all opened connexions to avoid connexion close.
 keep_alive(PID) ->
-    ?GEN_FSM:sync_send_event(PID, {sql_cmd, {sql_query, ?KEEPALIVE_QUERY}, now()},
+    ?GEN_FSM:sync_send_event(PID, {sql_cmd, {sql_query, [?KEEPALIVE_QUERY]}, now()},
                              ?KEEPALIVE_TIMEOUT).
 
 get_db_info(Pid) ->
@@ -577,7 +577,7 @@ sql_query_internal(Query) ->
     State = get(?STATE_KEY),
     Res = case State#state.db_type of
               odbc ->
-                  binaryze_odbc(odbc:sql_query(State#state.db_ref, Query));
+                  binaryze_odbc(odbc:sql_query(State#state.db_ref, Query, 5000));
               pgsql ->
                   ?DEBUG("Postres, Send query~n~p~n", [Query]),
                   pgsql_to_odbc(pgsql:squery(State#state.db_ref, Query));

--- a/apps/ejabberd/src/ejabberd_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_odbc.erl
@@ -619,7 +619,10 @@ abort_on_driver_error(Reply, From) ->
 -spec odbc_connect(ConnString :: string()) -> {ok | error, _}.
 odbc_connect(SQLServer) ->
     application:start(odbc),
-    odbc:connect(SQLServer, [{scrollable_cursors, off}, {binary_strings, on}]).
+    Opts = [{scrollable_cursors, off},
+            {binary_strings, on},
+            {timeout, 5000}],
+    odbc:connect(SQLServer, Opts).
 
 binaryze_odbc(ODBCResults) when is_list(ODBCResults) ->
     lists:map(fun binaryze_odbc/1, ODBCResults);

--- a/apps/ejabberd/src/odbc_queries.erl
+++ b/apps/ejabberd/src/odbc_queries.erl
@@ -344,7 +344,13 @@ list_users(LServer, [{prefix, Prefix},
          "offset ">>, integer_to_list(Offset)]).
 
 users_number(LServer) ->
-    case element(1, ejabberd_config:get_local_option({odbc_server, LServer})) of
+    Database = case ejabberd_config:get_local_option({odbc_server, LServer}) of
+        Tuple when is_tuple(Tuple) ->
+            element(1, Tuple);
+        _Other ->
+            ejabberd_config:get_local_option({odbc_server_type, LServer})
+    end,
+    case Database of
         mysql ->
             ejabberd_odbc:sql_query(
               LServer,
@@ -363,7 +369,7 @@ users_number(LServer) ->
         _ ->
             ejabberd_odbc:sql_query(
               LServer,
-              <<"select count(*) from users">>)
+              [<<"select count(*) from users">>])
     end.
 
 users_number(LServer, [{prefix, Prefix}]) when is_list(Prefix) ->

--- a/apps/ejabberd/src/odbc_queries.erl
+++ b/apps/ejabberd/src/odbc_queries.erl
@@ -344,13 +344,7 @@ list_users(LServer, [{prefix, Prefix},
          "offset ">>, integer_to_list(Offset)]).
 
 users_number(LServer) ->
-    Database = case ejabberd_config:get_local_option({odbc_server, LServer}) of
-        Tuple when is_tuple(Tuple) ->
-            element(1, Tuple);
-        _Other ->
-            ejabberd_config:get_local_option({odbc_server_type, LServer})
-    end,
-    case Database of
+    case ejabberd_odbc:db_engine(LServer) of
         mysql ->
             ejabberd_odbc:sql_query(
               LServer,

--- a/apps/ejabberd/test/ejabberd_odbc_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_odbc_SUITE.erl
@@ -21,6 +21,9 @@ all() ->
 init_per_suite(Config) ->
     Config.
 
+end_per_suite(_Config) ->
+    meck:unload().
+
 groups() ->
     [{odbc, [], tests()},
      {mysql, [], tests()},

--- a/apps/ejabberd/test/ejabberd_odbc_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_odbc_SUITE.erl
@@ -1,0 +1,158 @@
+-module(ejabberd_odbc_SUITE).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("ejabberd/include/ejabberd.hrl").
+
+-compile([export_all]).
+
+-define(_eq(E, I), ?_assertEqual(E, I)).
+-define(eq(E, I), ?assertEqual(E, I)).
+-define(ne(E, I), ?assert(E =/= I)).
+
+-define(HOST, <<"localhost">>).
+-define(KEEPALIVE_INTERVAL, 1).
+-define(KEEPALIVE_QUERY, <<"SELECT 1;">>).
+
+all() -> 
+    [{group, odbc},
+     {group, mysql},
+     {group, pgsql}].
+
+init_per_suite(Config) ->
+    Config.
+
+groups() ->
+    [{odbc, [], tests()},
+     {mysql, [], tests()},
+     {pgsql, [], tests()}].
+
+tests() ->
+    [keepalive_interval,
+     keepalive_exit].
+
+init_per_group(Group, Config) ->
+    [{db_type, Group} | Config].
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(_, Config) ->
+    DbType = ?config(db_type, Config),
+    meck_config(DbType, ?KEEPALIVE_INTERVAL),
+    meck_db(DbType),
+    Config.
+
+end_per_testcase(_, Config) ->
+    meck_unload(?config(db_type, Config)),
+    Config.
+
+%% Test cases
+keepalive_interval(Config) ->
+    {ok, Pid} = ejabberd_odbc:start_link(?HOST, 1000, true),
+    true = erlang:unlink(Pid),
+    timer:sleep(5500),
+    ?eq(5, query_calls(Config)),
+    true = erlang:exit(Pid, kill),
+    ok.
+
+keepalive_exit(Config) ->
+    {ok, Pid} = ejabberd_odbc:start_link(?HOST, 1000, true),
+    true = erlang:unlink(Pid),
+    Monitor = erlang:monitor(process, Pid),
+    timer:sleep(3500),
+    ?eq(3, query_calls(Config)),
+    meck_error(?config(db_type, Config)),
+    timer:sleep(1500),
+    receive
+        {'DOWN', Monitor, process, Pid, {keepalive_failed, _}} ->
+            ok
+    after 0 ->
+        ct:fail(no_down_message)
+    end.
+
+%% Mocks
+meck_config(Server, KeepaliveInterval) ->
+    meck:new(ejabberd_config, [no_link]),
+    meck:expect(ejabberd_config, get_local_option,
+                fun({odbc_keepalive_interval, _Host}) -> KeepaliveInterval;
+                   (max_fsm_queue) -> 1024;
+                   ({odbc_server, _}) -> server(Server);
+                   (Arg) -> meck:passthrough([Arg])
+                end).
+
+meck_db(odbc) ->
+    meck:new(odbc, [no_link]),
+    meck:expect(odbc, connect, fun(_, _) -> {ok, self()} end),
+    meck:expect(odbc, sql_query,
+                fun(_Ref, _Query) ->
+                        {selected, ["column"], ["row"]}
+                end);
+meck_db(mysql) ->
+    meck:new(mysql_conn, [no_link]),
+    meck:expect(mysql_conn, start, fun(_, _, _, _, _, _) -> {ok, self()} end),
+    meck:expect(mysql_conn, fetch,
+               fun(_Ref, _Query, _Pid) ->
+                       {data, {mysql_result, [], [], 0, ""}}
+               end);
+meck_db(pgsql) ->
+    meck:new(pgsql, [no_link]),
+    meck:expect(pgsql, connect, fun(_) -> {ok, self()} end),
+    meck:expect(pgsql, squery,
+                fun(_Ref, "SET" ++ _) ->
+                        {ok, [<<"SET">>]};
+                   (_Ref, [<<"SELECT", _/binary>>]) ->
+                        {ok, [{<<"SELECT">>, [], []}]}
+                end).
+
+meck_error(odbc) ->
+    meck:expect(odbc, sql_query,
+                fun(_Ref, _Query) ->
+                        {error, "connection broken"}
+                end);
+meck_error(mysql) ->
+    meck:expect(mysql_conn, fetch,
+                fun(_Ref, _Query, _Pid) ->
+                        {error, "connection broken"}
+                end);
+meck_error(pgsql) ->
+    meck:expect(pgsql, squery,
+                fun(_Ref, _Query) ->
+                        {ok, [{error, "connection broken"}]}
+                end).
+
+meck_unload(DbType) ->
+    meck:unload(ejabberd_config),
+    do_meck_unload(DbType).
+
+do_meck_unload(odbc) ->
+    meck:unload(odbc);
+do_meck_unload(mysql) ->
+    meck:unload(mysql_conn);
+do_meck_unload(pgsql) ->
+    meck:unload(pgsql).
+
+query_calls(Config) ->
+    DbType = ?config(db_type, Config),
+    {M, F} = mf(DbType),
+    meck:num_calls(M, F, a(DbType)).
+
+mf(odbc) ->
+    {odbc, sql_query};
+mf(mysql) ->
+    {mysql_conn, fetch};
+mf(pgsql) ->
+    {pgsql, squery}.
+
+a(odbc) ->
+    ['_', [?KEEPALIVE_QUERY]];
+a(mysql) ->
+    ['_', [?KEEPALIVE_QUERY], '_'];
+a(pgsql) ->
+    ['_', [?KEEPALIVE_QUERY]].
+
+server(odbc) ->
+    "fake-connection-string";
+server(mysql) ->
+    {mysql, "fake-host", "fake-db", "fake-user", "fake-pass"};
+server(pgsql) ->
+    {pgsql, "fake-host", "fake-db", "fake-user", "fake-pass"}.

--- a/apps/ejabberd/test/ejabberd_odbc_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_odbc_SUITE.erl
@@ -87,39 +87,39 @@ meck_db(odbc) ->
     meck:new(odbc, [no_link]),
     meck:expect(odbc, connect, fun(_, _) -> {ok, self()} end),
     meck:expect(odbc, sql_query,
-                fun(_Ref, _Query) ->
+                fun(_Ref, _Query, _Timeout) ->
                         {selected, ["column"], ["row"]}
                 end);
 meck_db(mysql) ->
     meck:new(mysql_conn, [no_link]),
     meck:expect(mysql_conn, start, fun(_, _, _, _, _, _) -> {ok, self()} end),
     meck:expect(mysql_conn, fetch,
-               fun(_Ref, _Query, _Pid) ->
+               fun(_Ref, _Query, _Pid, _Timeout) ->
                        {data, {mysql_result, [], [], 0, ""}}
                end);
 meck_db(pgsql) ->
     meck:new(pgsql, [no_link]),
     meck:expect(pgsql, connect, fun(_) -> {ok, self()} end),
     meck:expect(pgsql, squery,
-                fun(_Ref, "SET" ++ _) ->
+                fun(_Ref, "SET" ++ _, _Timeout) ->
                         {ok, [<<"SET">>]};
-                   (_Ref, [<<"SELECT", _/binary>>]) ->
+                   (_Ref, [<<"SELECT", _/binary>>], _Timeout) ->
                         {ok, [{<<"SELECT">>, [], []}]}
                 end).
 
 meck_error(odbc) ->
     meck:expect(odbc, sql_query,
-                fun(_Ref, _Query) ->
+                fun(_Ref, _Query, _Timeout) ->
                         {error, "connection broken"}
                 end);
 meck_error(mysql) ->
     meck:expect(mysql_conn, fetch,
-                fun(_Ref, _Query, _Pid) ->
+                fun(_Ref, _Query, _Pid, _Timeout) ->
                         {error, "connection broken"}
                 end);
 meck_error(pgsql) ->
     meck:expect(pgsql, squery,
-                fun(_Ref, _Query) ->
+                fun(_Ref, _Query, _Timeout) ->
                         {ok, [{error, "connection broken"}]}
                 end).
 
@@ -147,11 +147,11 @@ mf(pgsql) ->
     {pgsql, squery}.
 
 a(odbc) ->
-    ['_', [?KEEPALIVE_QUERY]];
-a(mysql) ->
     ['_', [?KEEPALIVE_QUERY], '_'];
+a(mysql) ->
+    ['_', [?KEEPALIVE_QUERY], '_', '_'];
 a(pgsql) ->
-    ['_', [?KEEPALIVE_QUERY]].
+    ['_', [?KEEPALIVE_QUERY], '_'].
 
 server(odbc) ->
     "fake-connection-string";

--- a/apps/pgsql/src/pgsql.erl
+++ b/apps/pgsql/src/pgsql.erl
@@ -10,10 +10,11 @@
 -module(pgsql).
 -export([connect/1, connect/4, connect/5]).
 
--export([squery/2, 
-	 pquery/3, 
-	 terminate/1, 
-	 prepare/3, unprepare/2, 
+-export([squery/2, squery/3,
+	 pquery/3, pquery/4,
+	 terminate/1, terminate/2,
+	 prepare/3, prepare/4,
+	 unprepare/2,  unprepare/3,
 	 execute/3]).
 
 
@@ -37,6 +38,9 @@ connect(Options) ->
 terminate(Db) ->
     gen_server:call(Db, terminate).
 
+terminate(Db, Timeout) ->
+    gen_server:call(Db, terminate, Timeout).
+
 %%% In the "simple query" protocol, the frontend just sends a 
 %%% textual query string, which is parsed and immediately 
 %%% executed by the backend.  
@@ -50,6 +54,14 @@ terminate(Db) ->
 %%% Result = {"SELECT", RowDesc, ResultSet} | ...
 squery(Db, Query) ->
     gen_server:call(Db, {squery, Query}, infinity).
+
+%%% squery(Db, Query, Timeout) -> {ok, Results} | ... no real error handling
+%%% Query = string()
+%%% Timeout = milliseconds()
+%%% Results = [Result]
+%%% Result = {"SELECT", RowDesc, ResultSet} | ...
+squery(Db, Query, Timeout) ->
+    gen_server:call(Db, {squery, Query}, Timeout).
 
 %%% In the "extended query" protocol, processing of queries is 
 %%% separated into multiple steps: parsing, binding of parameter
@@ -66,6 +78,9 @@ squery(Db, Query) ->
 pquery(Db, Query, Params) ->
     gen_server:call(Db, {equery, {Query, Params}}).
 
+pquery(Db, Query, Params, Timeout) ->
+    gen_server:call(Db, {equery, {Query, Params}}, Timeout).
+
 %%% prepare(Db, Name, Query) -> {ok, Status, ParamTypes, ResultTypes}
 %%% Status = idle | transaction | failed_transaction
 %%% ParamTypes = [atom()]
@@ -73,10 +88,16 @@ pquery(Db, Query, Params) ->
 prepare(Db, Name, Query) when is_atom(Name) ->
     gen_server:call(Db, {prepare, {atom_to_list(Name), Query}}).
 
+prepare(Db, Name, Query, Timeout) when is_atom(Name) ->
+    gen_server:call(Db, {prepare, {atom_to_list(Name), Query}}, Timeout).
+
 %%% unprepare(Db, Name) -> ok | timeout | ...
 %%% Name = atom()
 unprepare(Db, Name) when is_atom(Name) ->
     gen_server:call(Db, {unprepare, atom_to_list(Name)}).
+
+unprepare(Db, Name, Timeout) when is_atom(Name) ->
+    gen_server:call(Db, {unprepare, atom_to_list(Name)}, Timeout).
 
 %%% execute(Db, Name, Params) -> {ok, Result} | timeout | ...
 %%% Result = {'INSERT', NRows} |
@@ -86,6 +107,9 @@ unprepare(Db, Name) when is_atom(Name) ->
 %%% ResultSet = [Row]
 %%% Row = list()
 execute(Db, Name, Params) when is_atom(Name), is_list(Params) ->
+    %% TODO: Lameness alert! This might leave unreceived responses
+    %%       in the caller's message queue if Db is not down
+    %%       and eventually (i.e. after the timeout) responds!
     Ref = make_ref(),
     Db ! {execute, Ref, self(), {atom_to_list(Name), Params}},
     receive

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -4,7 +4,7 @@ For advanced configuration use the following files: `ejabberd.cfg`, `vm.args` an
 
 This file consists of multiple erlang tuples, terminated with a period. It can be found in `[MongooseIM root]/rel/files/`.
 
-The tuple order is important, unless the no host_config option is set. Retaining the default layout is recommended so that experienced MongooseIM users can smoothly traverse the file. 
+The tuple order is important, unless the no `host_config` option is set. Retaining the default layout is recommended so that experienced MongooseIM users can smoothly traverse the file.
 
 `ejabberd.cfg` is full of useful comments and in most cases they should be sufficient help in changing the configuration.
 
@@ -147,6 +147,11 @@ The tuple order is important, unless the no host_config option is set. Retaining
 
 * **odbc_keepalive_interval** (local)
     * **Description:** When enabled, will send `SELECT 1` query through every DB connection at given interval to keep them open.
+    This option should be used to ensure that database connections are
+    restarted after they became broken (e.g. due to database restart or a load
+    balancer dropping connections). Currently, not every network related error
+    returned from a database driver to a regular query will imply a connection
+    restart.
 
 You should remember that SQL databases require also defining schema.
 See [Database backends configuration](./advanced-configuration/database-backends-configuration.md) for more information
@@ -221,7 +226,7 @@ Section below describes the default options.
 
 ## Options
 
-*    `-sname` - Erlang node name. Can be changed to `name`, if necessary
+* `-sname` - Erlang node name. Can be changed to `name`, if necessary
 * `-setcookie` - Erlang cookie. All nodes in a cluster must use the same cookie value.
 * `+K` - Enables kernel polling. It improves the stability when a large number of sockets is opened, but some systems might benefit from disabling it. Might be a subject of individual load testing.
 * `+A 5` - Sets the asynchronous threads number. Async threads improve I/O operations efficiency by relieving scheduler threads of IO waits.


### PR DESCRIPTION
This pull request fixes a couple of SQL queries. Above all it fixes the keep-alive query that was wrongly prepared for the ODBC layer and was not restarting a connection worker when the query failed.