### PR TITLE
Check if container exists not whether it's running or not

### DIFF
--- a/tools/docker/start_and_prepare_slapd.sh
+++ b/tools/docker/start_and_prepare_slapd.sh
@@ -9,7 +9,7 @@ LDAP_ROOTPASS="mongoose"
 
 LDAP_CONT_NAME="mongooseim_ldap"
 
-MIM_LDAP_CONTAINERS=`docker ps -s -f "name=${LDAP_CONT_NAME}" | wc -l`
+MIM_LDAP_CONTAINERS=`docker ps -a -s -f "name=${LDAP_CONT_NAME}" | wc -l`
 
 if [ ${MIM_LDAP_CONTAINERS} -le 1 ]; then
 


### PR DESCRIPTION
`docker ps` without `-a` only checks whether a container is running, not whether it exists or not. Therefore, the test performed in the script checked whether there was a running container named `mongooseim_ldap` and if not (if none was running, **not** if none existed) it tried to do `docker run` - which could result in an error (see below for the gory details). Now the check verifies whether a container exists at all - running or not.

Context:

```
17:14:42 erszcz @ x4 : ~/work/esl/mongooseim (c-766964796f *)
$ tools/docker/start_and_prepare_slapd.sh
+ boot2docker up
Waiting for VM and Docker daemon to start...
.o
Started.
Writing /Users/erszcz/.boot2docker/certs/boot2docker-vm/ca.pem
Writing /Users/erszcz/.boot2docker/certs/boot2docker-vm/cert.pem
Writing /Users/erszcz/.boot2docker/certs/boot2docker-vm/key.pem
Your environment variables are already set correctly.

++ boot2docker shellinit
Writing /Users/erszcz/.boot2docker/certs/boot2docker-vm/ca.pem
Writing /Users/erszcz/.boot2docker/certs/boot2docker-vm/cert.pem
Writing /Users/erszcz/.boot2docker/certs/boot2docker-vm/key.pem
+ eval '    export DOCKER_HOST=tcp://192.168.59.103:2376
    export DOCKER_CERT_PATH=/Users/erszcz/.boot2docker/certs/boot2docker-vm
    export DOCKER_TLS_VERIFY=1'
++ export DOCKER_HOST=tcp://192.168.59.103:2376
++ DOCKER_HOST=tcp://192.168.59.103:2376
++ export DOCKER_CERT_PATH=/Users/erszcz/.boot2docker/certs/boot2docker-vm
++ DOCKER_CERT_PATH=/Users/erszcz/.boot2docker/certs/boot2docker-vm
++ export DOCKER_TLS_VERIFY=1
++ DOCKER_TLS_VERIFY=1
+ LDAP_PORT=1389
++ boot2docker ip
+ LDAP_HOST=192.168.59.103
+ LDAP_ROOTPASS=mongoose
+ LDAP_CONT_NAME=mongooseim_ldap
++ docker ps -s -f name=mongooseim_ldap
++ wc -l
+ MIM_LDAP_CONTAINERS='       1'
+ '[' 1 -le 1 ']'
+ docker run --name mongooseim_ldap -p 1389:389 -e LDAP_DOMAIN=esl.com -e LDAP_ORGANISATION=MongooseIM -e LDAP_ROOTPASS=mongoose -d nickstenning/slapd
FATA[0000] Error response from daemon: Conflict. The name "mongooseim_ldap" is already in use by container b3b94b279964. You have to delete (or rename) that container to be able to reuse that name.
+ LDIF_FILE_PATH=/tmp/init_entries.ldif
+ cat
+ ldapadd -h 192.168.59.103 -p 1389 -c -x -D cn=admin,dc=esl,dc=com -w mongoose -f /tmp/init_entries.ldif
ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
17:14:45 erszcz @ x4 : ~/work/esl/mongooseim (c-766964796f *)
$ docker ps -s -f name=mongooseim_ldap | wc -l
       1
17:15:28 erszcz @ x4 : ~/work/esl/mongooseim (c-766964796f *)
$ docker ps -s -f name=mongooseim_ldap
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES               SIZE
17:15:31 erszcz @ x4 : ~/work/esl/mongooseim (c-766964796f *)
$ docker images
REPOSITORY             TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
mongooseim-cdk-test    latest              01c9a2642d08        5 months ago        791.8 MB
mongooseim-cdk-build   latest              dfbb214ee4b8        5 months ago        717.5 MB
mongooseim-cdk         latest              a8269f02ca0c        5 months ago        791.8 MB
<none>                 <none>              2b878cd9a279        5 months ago        748.3 MB
<none>                 <none>              8fa3dfea1e41        5 months ago        691.7 MB
<none>                 <none>              4b519867e1c0        5 months ago        748.3 MB
<none>                 <none>              bd1ac1baee5c        5 months ago        748.3 MB
<none>                 <none>              a6607a453fb6        5 months ago        748.3 MB
<none>                 <none>              ef0caede53a8        5 months ago        748.3 MB
<none>                 <none>              8288dc4446af        5 months ago        748.3 MB
<none>                 <none>              f6f01483ef6c        5 months ago        748.3 MB
<none>                 <none>              ec5d2a0608a6        5 months ago        748.3 MB
<none>                 <none>              d6b425ce802e        5 months ago        748.3 MB
<none>                 <none>              307d9719d4af        5 months ago        748.3 MB
<none>                 <none>              e24a54707f15        5 months ago        748.3 MB
<none>                 <none>              487b828d5cbf        5 months ago        748.3 MB
<none>                 <none>              61c4d3a74f53        5 months ago        674 MB
<none>                 <none>              1b781e601244        5 months ago        748.3 MB
<none>                 <none>              170c7911e3ef        5 months ago        748.3 MB
<none>                 <none>              e6f9d37fee98        5 months ago        748.3 MB
<none>                 <none>              5839a3807ad5        5 months ago        748.3 MB
<none>                 <none>              cf9b7d8959ee        5 months ago        748.3 MB
<none>                 <none>              ba4700d2ddc9        5 months ago        748.3 MB
<none>                 <none>              aa78c888f19e        5 months ago        748.3 MB
<none>                 <none>              0347616d5c36        5 months ago        713.4 MB
<none>                 <none>              131800ac7400        5 months ago        713.4 MB
<none>                 <none>              4a42848d3ca7        5 months ago        713.4 MB
<none>                 <none>              5a2fb790dc47        5 months ago        713.4 MB
<none>                 <none>              32cf7e24c8a3        5 months ago        748.3 MB
<none>                 <none>              18d5b125729a        5 months ago        748.3 MB
<none>                 <none>              07d4d5c263a3        5 months ago        748.3 MB
<none>                 <none>              1e71440f931d        5 months ago        674 MB
<none>                 <none>              4794ea13c3f5        5 months ago        674 MB
<none>                 <none>              2b77aece8815        5 months ago        674 MB
<none>                 <none>              3ceb0eec00e5        5 months ago        674 MB
<none>                 <none>              2971a6e601f2        5 months ago        674 MB
<none>                 <none>              3124de9f4425        5 months ago        776.9 MB
mongooseim-cdk         4-293-gcadad01      25b621e7f010        5 months ago        776.9 MB
<none>                 <none>              89d3047e60a5        5 months ago        776.9 MB
<none>                 <none>              fccce2fd6ef8        5 months ago        776.9 MB
<none>                 <none>              04dbc3887bfe        5 months ago        776.9 MB
<none>                 <none>              a000e2a58452        5 months ago        776.9 MB
<none>                 <none>              a0c3713c4f0f        5 months ago        759.1 MB
<none>                 <none>              ce12b059637d        5 months ago        504.5 MB
mongooseim-stable      latest              27b18c503757        5 months ago        590.3 MB
<none>                 <none>              0fa16dc60a64        5 months ago        590.3 MB
ubuntu                 14.10               d191563ad36b        5 months ago        194.5 MB
progrium/consul        latest              e2a3eec4bab6        5 months ago        60.74 MB
nickstenning/slapd     latest              dcc50e8c3dda        19 months ago       533 MB
17:16:28 erszcz @ x4 : ~/work/esl/mongooseim (c-766964796f *)
$ docker ps -a
CONTAINER ID        IMAGE                                                                     COMMAND                CREATED             STATUS                      PORTS                                                             NAMES
b3b94b279964        nickstenning/slapd:latest                                                 "/sbin/my_init"        4 hours ago         Exited (0) 4 minutes ago                                                                      mongooseim_ldap
dbd1649a4a99        mongooseim-cdk-test:latest                                                "bash"                 5 months ago        Exited (130) 4 months ago                                                                     cdk-test
31ae5ee12c0d        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (0) 6 weeks ago      4369/tcp, 5269/tcp, 5280/tcp, 9100/tcp, 0.0.0.0:52223->5222/tcp   cdk-3
ce8e2523c18f        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 4 months ago                                                                     cdk-2
317b8019d957        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 4 months ago                                                                     cdk-1
b8d9633da2fd        mongooseim-cdk-build:latest                                               "/build.sh"            5 months ago        Exited (0) 5 months ago                                                                       cdk-build
603ffd272a49        0347616d5c3640bbac0c119d0b42d651d45a6904a12174b5e50b02960f579622:latest   "/bin/sh -c /deploy.   5 months ago        Exited (127) 5 months ago                                                                     angry_hopper
cf56c7c5e496        131800ac7400d327abd859393f38fa09c5c8fa9a2eea8e3d61b2a4252a016fad:latest   "/bin/sh -c /deploy.   5 months ago        Exited (2) 5 months ago                                                                       compassionate_blackwell
dd10df37a9df        4a42848d3ca74c4d943bef1bba58dab6f8b12aa9cf3d40610ba62428985a149b:latest   "/bin/sh -c /deploy.   5 months ago        Exited (127) 5 months ago                                                                     dreamy_kowalevski
d1f03eb78da6        5a2fb790dc47847702d0b963cb0986cd77227ac85e175af02c5d0c8a1e1f6684:latest   "/bin/sh -c /deploy.   5 months ago        Exited (1) 5 months ago                                                                       elated_einstein
3a58682f8be9        0f0d7f4dd513f8bf28877823ac3997a7cde29e63526bd1a04d244d3aab0c88ff:latest   "/bin/sh -c 'apt-get   5 months ago        Exited (137) 5 months ago                                                                     angry_sinoussi
3a68d8878ab2        progrium/consul:latest                                                    "/bin/start -server    5 months ago        Exited (0) 5 months ago                                                                       tender_elion
78759ad6e74d        progrium/consul:latest                                                    "/bin/start -server    5 months ago        Exited (0) 5 months ago                                                                       grave_fermi
1bc1b0c60fc7        progrium/consul:latest                                                    "/bin/start -server    5 months ago        Exited (0) 5 months ago                                                                       angry_euclid
0cc197245d10        progrium/consul:latest                                                    "/bin/start -server    5 months ago                                                                                                      drunk_bohr
f5c0b1a2a73a        progrium/consul:latest                                                    "/bin/start -server    5 months ago        Exited (1) 5 months ago                                                                       consul-server
ac04313d184f        progrium/consul:latest                                                    "/bin/start -server    5 months ago        Exited (0) 5 months ago                                                                       prickly_mcclintock
61a19bb6e76e        progrium/consul:latest                                                    "/bin/start"           5 months ago        Exited (0) 5 months ago                                                                       prickly_colden
072fce135d04        progrium/consul:latest                                                    "/bin/start"           5 months ago        Exited (0) 5 months ago                                                                       sharp_morse
c7c7e945f33c        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 5 months ago                                                                     dreamy_poincare
3eecbdc29277        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 5 months ago                                                                     backstabbing_darwin
9c3d64932730        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 5 months ago                                                                     cocky_archimedes
bdb6c41286e7        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 5 months ago                                                                     sad_jones
b21cb1720296        mongooseim-cdk:latest                                                     "./start.sh"           5 months ago        Exited (130) 5 months ago                                                                     grave_bohr
80fdb8bc63aa        ce12b059637d91f53b07279f2684ab6a306854ad445f0f740fffdef573e45ec6:latest   "/bin/sh -c 'git clo   5 months ago        Exited (2) 5 months ago                                                                       boring_torvalds
1526e26d37cd        ce12b059637d91f53b07279f2684ab6a306854ad445f0f740fffdef573e45ec6:latest   "/bin/sh -c 'git clo   5 months ago        Exited (2) 5 months ago                                                                       lonely_goodall
90c20b98961f        ce12b059637d91f53b07279f2684ab6a306854ad445f0f740fffdef573e45ec6:latest   "/bin/sh -c 'git clo   5 months ago        Exited (128) 5 months ago                                                                     tender_nobel
1d41545bf948        mongooseim-stable:latest                                                  "./start.sh"           5 months ago        Exited (130) 5 months ago                                                                     distracted_payne
676719f368ed        mongooseim-stable:latest                                                  "./start.sh"           5 months ago        Exited (137) 5 months ago                                                                     lonely_hawking
17:16:47 erszcz @ x4 : ~/work/esl/mongooseim (c-766964796f *)
$ docker ps -a | grip ldap
b3b94b279964        nickstenning/slapd:latest                                                 "/sbin/my_init"        4 hours ago         Exited (0) 4 minutes ago                                                                      mongooseim_ldap
```