### PR TITLE
set ssl session_lifetime to 10 minutes

### DIFF
--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -234,9 +234,19 @@ Section below describes the default options.
 
 # app.config
 
-A file with Erlang application configuration. It can be found in `[MongooseIM root]/rel/files/`. By default only Lager config can be found there. Check [Lager's documentation](https://github.com/basho/lager) for more information.
+A file with Erlang application configuration. It can be found in `[MongooseIM root]/rel/files/`.
+By default only following applications can be found there:
 
-Here you can change logs location and file names (`file`), rotation strategy (`size` and `count`) and date formatting (`date`). Ignore log level parameters - they are overridden with the value in `ejabberd.cfg`.
+* `lager` - check [Lager's documentation](https://github.com/basho/lager) for more information.
+   
+    Here you can change logs location and file names (`file`), rotation strategy (`size` and `count`) 
+   and date formatting (`date`). Ignore log level parameters - they are overridden with the value in `ejabberd.cfg`.
+
+* `ssl` only `session_lifetime` parameter is specified in
+    this file. Its default value is **600s**. This parameter says for how
+    long ssl session should remain in the cache for further re-use,
+    should `ssl session resumption` happen.
+
 
 # Configuring TLS: Certificates & Keys
 

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -1,5 +1,6 @@
 [
-{lager, [
+ {ssl, [{session_lifetime, 600}]}, %% 10 minutes
+ {lager, [
     {log_root, {{app_config_lager_log_dir}} },
     {crash_log, "crash.log"},
     {handlers, [


### PR DESCRIPTION
I  found a memory "leak" while load testing, the increased memory usage was caused by TLS processes.
The processes were started by fusco, through which the external API was called. 

I found the solution here: https://github.com/ninenines/gun/issues/68, although I don't know if 10 minutes is a sane value. I will remove the do-no-merge label after testing this value - especially, I need to check if it influence server side(in our case cowboy connections).

More info about the bug: https://support.process-one.net/browse/TSUN-225