### PR TITLE
Inconsistent `mongooseimctl` help text 

### DIFF
--- a/apps/ejabberd/src/ejabberd_commands.erl
+++ b/apps/ejabberd/src/ejabberd_commands.erl
@@ -165,10 +165,8 @@
 %%%
 %%% == Frontend to ejabberd commands ==
 %%%
-%%% Currently there are two frontends to ejabberd commands: the shell
-%%% script {@link ejabberd_ctl. mongooseimctl}, and the XML-RPC server
-%%% ejabberd_xmlrpc.
-%%%
+%%% Currently there is one frontend to ejabberd commands: the shell
+%%% script - mongooseimctl
 %%%
 %%% === mongooseimctl as a frontend to ejabberd commands ===
 %%%
@@ -184,8 +182,7 @@
 %%% TODO: consider this feature:
 %%% All commands are catched. If an error happens, return the restuple:
 %%%   {error, flattened error string}
-%%% This means that ecomm call APIs (ejabberd_ctl, ejabberd_xmlrpc) need to allows this.
-%%% And ejabberd_xmlrpc must be prepared to handle such an unexpected response.
+%%% This means that ecomm call APIs ejabberd_ctl need to allows this.
 
 
 -module(ejabberd_commands).

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -502,22 +502,8 @@ get_list_commands() ->
 -spec tuple_command_help(ejabberd_commands:list_cmd()) -> cmd().
 tuple_command_help({Name, Args, Desc}) ->
     Arguments = [atom_to_list(ArgN) || {ArgN, _ArgF} <- Args],
-    Prepend = case is_supported_args(Args) of
-                  true -> "";
-                  false -> "*"
-              end,
     CallString = atom_to_list(Name),
-    {CallString, Arguments, Prepend ++ Desc}.
-
-
--spec is_supported_args([{atom(),_}]) -> boolean().
-is_supported_args(Args) ->
-    lists:all(
-      fun({_Name, Format}) ->
-              (Format == integer)
-                  or (Format == string)
-      end,
-      Args).
+    {CallString, Arguments, Desc}.
 
 
 -spec get_list_ctls() -> [cmd()].
@@ -883,12 +869,7 @@ print_usage_command(Cmd, C, MaxC, ShCode) ->
                       _ -> ["", prepare_description(0, MaxC, LongDesc), "\n\n"]
                   end,
 
-    NoteEjabberdctl = case is_supported_args(ArgsDef) of
-                          true -> "";
-                          false -> ["  ", ?B("Note:"), " This command cannot be executed using mongooseimctl.\n\n"]
-                      end,
-
-    ?PRINT(["\n", NameFmt, "\n", ArgsFmt, "\n", ReturnsFmt, "\n\n", XmlrpcFmt, TagsFmt, "\n\n", DescFmt, "\n\n", LongDescFmt, NoteEjabberdctl], []).
+    ?PRINT(["\n", NameFmt, "\n", ArgsFmt, "\n", ReturnsFmt, "\n\n", XmlrpcFmt, TagsFmt, "\n\n", DescFmt, "\n\n", LongDescFmt], []).
 
 
 format_usage_ctype(Type, _Indentation)

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -858,8 +858,6 @@ print_usage_command(Cmd, C, MaxC, ShCode) ->
     ResultFmt = format_usage_ctype(ResultDef, 11),
     ReturnsFmt = ["  ",?B("Returns"),": ", ResultFmt],
 
-    XmlrpcFmt = "", %%+++ ["  ",?B("XML-RPC"),": ", format_usage_xmlrpc(ArgsDef, ResultDef), "\n\n"],
-
     TagsFmt = ["  ",?B("Tags"),": ", prepare_long_line(8, MaxC, [atom_to_list(TagA) || TagA <- TagsAtoms])],
 
     DescFmt = ["  ",?B("Description"),": ", prepare_description(15, MaxC, Desc)],
@@ -869,7 +867,7 @@ print_usage_command(Cmd, C, MaxC, ShCode) ->
                       _ -> ["", prepare_description(0, MaxC, LongDesc), "\n\n"]
                   end,
 
-    ?PRINT(["\n", NameFmt, "\n", ArgsFmt, "\n", ReturnsFmt, "\n\n", XmlrpcFmt, TagsFmt, "\n\n", DescFmt, "\n\n", LongDescFmt], []).
+    ?PRINT(["\n", NameFmt, "\n", ArgsFmt, "\n", ReturnsFmt, "\n\n", TagsFmt, "\n\n", DescFmt, "\n\n", LongDescFmt], []).
 
 
 format_usage_ctype(Type, _Indentation)

--- a/apps/ejabberd/src/mod_admin_extra_roster.erl
+++ b/apps/ejabberd/src/mod_admin_extra_roster.erl
@@ -241,13 +241,13 @@ get_roster(User, Server) ->
     LUser = jlib:nodeprep(User),
     LServer = jlib:nameprep(Server),
     Items = ejabberd_hooks:run_fold(roster_get, Server, [], [{LUser, LServer}]),
-    make_roster_xmlrpc(Items).
+    make_roster(Items).
 
 
 %% @doc Note: if a contact is in several groups, the contact is returned
 %% several times, each one in a different group.
--spec make_roster_xmlrpc([mod_roster:roster()]) -> [jids_nick_subs_ask_grp()].
-make_roster_xmlrpc(Roster) ->
+-spec make_roster([mod_roster:roster()]) -> [jids_nick_subs_ask_grp()].
+make_roster(Roster) ->
     lists:foldl(
         fun(Item, Res) ->
                 JIDS = jlib:jid_to_binary(Item#roster.jid),


### PR DESCRIPTION
This PR fixes #381 

There was a function, that checked the types of input arguments. If the arguments weren't integer or string - it was displaying a note about the ejabberd_xmlrpc module +  was marking these function with "*" in the general commands listing.  
I believe that the change is so simple and more like documentation/help change, that we don't need to test it. Am I right ;)?