### PR TITLE
Check user allowed hook

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -220,8 +220,6 @@ do_check_password_loop([AuthModule | AuthModules], Args) ->
 -spec check_digest(binary(), fun(), binary(), binary()) -> boolean().
 check_digest(<<>>, _, <<>>, _) ->
     false; %%empty digest and password
-check_digest(<<>>, _, Password, Passwd) ->
-    Passwd == Password;
 check_digest(Digest, DigestGen, _Password, Passwd) ->
     Digest == DigestGen(Passwd).
 

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -218,18 +218,13 @@ do_check_password_loop([AuthModule | AuthModules], Args) ->
     end.
 
 -spec check_digest(binary(), fun(), binary(), binary()) -> boolean().
-check_digest(Digest, DigestGen, Password, Passwd) ->
-    DigRes = if
-                 Digest /= <<>> ->
-                     Digest == DigestGen(Passwd);
-                 true ->
-                     false
-             end,
-    if DigRes ->
-           true;
-       true ->
-           (Passwd == Password) and (Password /= <<>>)
-    end.
+check_digest(<<>>, _, <<>>, _) ->
+    false; %%empty digest and password
+check_digest(<<>>, _, Password, Passwd) ->
+    Passwd == Password;
+check_digest(Digest, DigestGen, _Password, Passwd) ->
+    ?WARNING_MSG("Computed digest for password ~p is: ~p", [Passwd, DigestGen(Passwd)]),
+    Digest == DigestGen(Passwd).
 
 -spec set_password(User :: ejabberd:user(),
                    Server :: ejabberd:server(),

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -1,4 +1,4 @@
-%%%----------------------------------------------------------------------
+
 %%% File    : ejabberd_auth.erl
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
 %%% Purpose : Authentification
@@ -223,7 +223,6 @@ check_digest(<<>>, _, <<>>, _) ->
 check_digest(<<>>, _, Password, Passwd) ->
     Passwd == Password;
 check_digest(Digest, DigestGen, _Password, Passwd) ->
-    ?WARNING_MSG("Computed digest for password ~p is: ~p", [Passwd, DigestGen(Passwd)]),
     Digest == DigestGen(Passwd).
 
 -spec set_password(User :: ejabberd:user(),

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -479,8 +479,9 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
         {auth, _ID, set, {U, P, D, R}} ->
             JID = jlib:make_jid(U, StateData#state.server, R),
             case (JID /= error) andalso
-                 (acl:match_rule(StateData#state.server,
-                                 StateData#state.access, JID) == allow) of
+                 (allow == ejabberd_hooks:run_fold(check_user_allowed,
+                                                   StateData#state.server,
+                                                   deny, [JID])) of
                 true ->
                     DGen = fun(PW) ->
                                    sha:sha1_hex(StateData#state.streamid
@@ -790,8 +791,9 @@ wait_for_session_or_sm({xmlstreamelement, El}, StateData0) ->
             U = StateData#state.user,
             R = StateData#state.resource,
             JID = StateData#state.jid,
-            case acl:match_rule(StateData#state.server,
-                                StateData#state.access, JID) of
+            case ejabberd_hooks:run_fold(check_user_allowed,
+                                         StateData#state.server,
+                                         deny, [JID]) of
                 allow ->
                     ?INFO_MSG("(~w) Opened session for ~s",
                               [StateData#state.socket,

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -478,91 +478,7 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
             fsm_next_state(wait_for_auth, StateData);
         {auth, _ID, set, {U, P, D, R}} ->
             JID = jlib:make_jid(U, StateData#state.server, R),
-            case (JID /= error) andalso user_allowed(JID, StateData) of
-                true ->
-                    DGen = fun(PW) ->
-                                   Sid = StateData#state.streamid,
-                                   sha:sha1_hex(<<Sid/binary,
-                                                PW/binary>>)
-                           end,
-                    case ejabberd_auth:check_password_with_authmodule(
-                           U, StateData#state.server, P, D, DGen) of
-                        {true, AuthModule} ->
-                            ?INFO_MSG(
-                               "(~w) Accepted legacy authentication for ~s by ~p",
-                               [StateData#state.socket,
-                                jlib:jid_to_binary(JID), AuthModule]),
-                            SID = {now(), self()},
-                            Conn = get_conn_type(StateData),
-                            Info = [{ip, StateData#state.ip}, {conn, Conn},
-                                    {auth_module, AuthModule}],
-                            Res1 = jlib:make_result_iq_reply(El),
-                            Res = setelement(4, Res1, []),
-                            send_element(StateData, Res),
-                            ejabberd_sm:open_session(
-                              SID, U, StateData#state.server, R, Info),
-                            change_shaper(StateData, JID),
-                            {Fs, Ts, Pending} = ejabberd_hooks:run_fold(
-                                                  roster_get_subscription_lists,
-                                                  StateData#state.server,
-                                                  {[], [], []},
-                                                  [U, StateData#state.server]),
-                            LJID = jlib:jid_tolower(
-                                     jlib:jid_remove_resource(JID)),
-                            Fs1 = [LJID | Fs],
-                            Ts1 = [LJID | Ts],
-                            PrivList =
-                            ejabberd_hooks:run_fold(
-                              privacy_get_user_list, StateData#state.server,
-                              #userlist{},
-                              [U, StateData#state.server]),
-                            NewStateData =
-                            StateData#state{
-                              user = U,
-                              resource = R,
-                              jid = JID,
-                              sid = SID,
-                              conn = Conn,
-                              auth_module = AuthModule,
-                              pres_f = ?SETS:from_list(Fs1),
-                              pres_t = ?SETS:from_list(Ts1),
-                              pending_invitations = Pending,
-                              privacy_list = PrivList},
-                            fsm_next_state_pack(session_established,
-                                                NewStateData);
-                        _ ->
-                            IP = peerip(StateData#state.sockmod, StateData#state.socket),
-                            ?INFO_MSG(
-                               "(~w) Failed legacy authentication for ~s from IP ~s (~w)",
-                               [StateData#state.socket,
-                                jlib:jid_to_binary(JID), jlib:ip_to_list(IP), IP]),
-                            Err = jlib:make_error_reply(
-                                    El, ?ERR_NOT_AUTHORIZED),
-                            ejabberd_hooks:run(auth_failed, StateData#state.server,
-                                               [U, StateData#state.server]),
-                            send_element(StateData, Err),
-                            fsm_next_state(wait_for_auth, StateData)
-                    end;
-                _ ->
-                    if
-                        JID == error ->
-                            ?INFO_MSG(
-                               "(~w) Forbidden legacy authentication for "
-                               "username '~s' with resource '~s'",
-                               [StateData#state.socket, U, R]),
-                            Err = jlib:make_error_reply(El, ?ERR_JID_MALFORMED),
-                            send_element(StateData, Err),
-                            fsm_next_state(wait_for_auth, StateData);
-                        true ->
-                            ?INFO_MSG(
-                               "(~w) Forbidden legacy authentication for ~s",
-                               [StateData#state.socket,
-                                jlib:jid_to_binary(JID)]),
-                            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
-                            send_element(StateData, Err),
-                            fsm_next_state(wait_for_auth, StateData)
-                    end
-            end;
+            maybe_legacy_auth(JID, El, StateData, U, P, D, R);
         _ ->
             process_unauthenticated_stanza(StateData, El),
             fsm_next_state(wait_for_auth, StateData)
@@ -578,6 +494,66 @@ wait_for_auth({xmlstreamerror, _}, StateData) ->
     {stop, normal, StateData};
 wait_for_auth(closed, StateData) ->
     {stop, normal, StateData}.
+
+maybe_legacy_auth(error, El, StateData, U, _P, _D, R) ->
+    ?INFO_MSG(
+       "(~w) Forbidden legacy authentication for "
+       "username '~s' with resource '~s'",
+       [StateData#state.socket, U, R]),
+    Err = jlib:make_error_reply(El, ?ERR_JID_MALFORMED),
+    send_element(StateData, Err),
+    fsm_next_state(wait_for_auth, StateData);
+maybe_legacy_auth(JID, El, StateData, U, P, D, R) ->
+    case user_allowed(JID, StateData) of
+        true ->
+            DGen = fun(PW) ->
+                           Sid = StateData#state.streamid,
+                           sha:sha1_hex(<<Sid/binary,
+                                          PW/binary>>)
+                   end,
+            case ejabberd_auth:check_password_with_authmodule(
+                   U, StateData#state.server, P, D, DGen) of
+                {true, AuthModule} ->
+                    do_open_legacy_session(El, StateData, U, R, JID,
+                                           AuthModule);
+                _ ->
+                    IP = peerip(StateData#state.sockmod, StateData#state.socket),
+                    ?INFO_MSG(
+                       "(~w) Failed legacy authentication for ~s from IP ~s (~w)",
+                       [StateData#state.socket,
+                        jlib:jid_to_binary(JID), jlib:ip_to_list(IP), IP]),
+                    Err = jlib:make_error_reply(
+                            El, ?ERR_NOT_AUTHORIZED),
+                    ejabberd_hooks:run(auth_failed, StateData#state.server,
+                                       [U, StateData#state.server]),
+                    send_element(StateData, Err),
+                    fsm_next_state(wait_for_auth, StateData)
+            end;
+        _ ->
+
+            ?INFO_MSG(
+               "(~w) Forbidden legacy authentication for ~s",
+               [StateData#state.socket,
+                jlib:jid_to_binary(JID)]),
+            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
+            send_element(StateData, Err),
+            fsm_next_state(wait_for_auth, StateData)
+    end.
+
+do_open_legacy_session(El, StateData, U, R, JID, AuthModule) ->
+    ?INFO_MSG(
+       "(~w) Accepted legacy authentication for ~s by ~p",
+       [StateData#state.socket,
+        jlib:jid_to_binary(JID), AuthModule]),
+    Res1 = jlib:make_result_iq_reply(El),
+    Res = Res1#xmlel{children = []},
+    send_element(StateData, Res),
+    NewStateData = StateData#state{
+                     user = U,
+                     resource = R,
+                     jid = JID,
+                     auth_module = AuthModule},
+    do_open_session_common(JID, NewStateData).
 
 -spec wait_for_feature_request(Item :: ejabberd:xml_stream_item(),
                                State :: state()) -> fsm_return().
@@ -787,57 +763,7 @@ wait_for_session_or_sm({xmlstreamelement, El}, StateData0) ->
                                             StateData0),
     case jlib:iq_query_info(El) of
         #iq{type = set, xmlns = ?NS_SESSION} ->
-            U = StateData#state.user,
-            R = StateData#state.resource,
-            JID = StateData#state.jid,
-            case user_allowed(JID, StateData) of
-                true ->
-                    ?INFO_MSG("(~w) Opened session for ~s",
-                              [StateData#state.socket,
-                               jlib:jid_to_binary(JID)]),
-                    Res = jlib:make_result_iq_reply(El),
-                    Packet = {jlib:jid_remove_resource(StateData#state.jid), StateData#state.jid, Res},
-                    {_, _, NewStateData0, _} = send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm),
-                    change_shaper(NewStateData0, JID),
-                    {Fs, Ts, Pending} = ejabberd_hooks:run_fold(
-                                          roster_get_subscription_lists,
-                                          NewStateData0#state.server,
-                                          {[], [], []},
-                                          [U, NewStateData0#state.server]),
-                    LJID = jlib:jid_tolower(jlib:jid_remove_resource(JID)),
-                    Fs1 = [LJID | Fs],
-                    Ts1 = [LJID | Ts],
-                    PrivList =
-                    ejabberd_hooks:run_fold(
-                      privacy_get_user_list, NewStateData0#state.server,
-                      #userlist{},
-                      [U, NewStateData0#state.server]),
-                    SID = {now(), self()},
-                    Conn = get_conn_type(NewStateData0),
-                    Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
-                            {auth_module, NewStateData0#state.auth_module}],
-                    ejabberd_sm:open_session(
-                      SID, U, NewStateData0#state.server, R, Info),
-                    NewStateData =
-                    NewStateData0#state{
-                      sid = SID,
-                      conn = Conn,
-                      pres_f = ?SETS:from_list(Fs1),
-                      pres_t = ?SETS:from_list(Ts1),
-                      pending_invitations = Pending,
-                      privacy_list = PrivList},
-                    fsm_next_state_pack(session_established,
-                                        NewStateData);
-                _ ->
-                    ejabberd_hooks:run(forbidden_session_hook,
-                                       StateData#state.server, [JID]),
-                    ?INFO_MSG("(~w) Forbidden session for ~s",
-                              [StateData#state.socket,
-                               jlib:jid_to_binary(JID)]),
-                    Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
-                    send_element(StateData, Err),
-                    fsm_next_state(wait_for_session_or_sm, StateData)
-            end;
+            maybe_open_session(El, StateData);
         _ ->
             fsm_next_state(wait_for_session_or_sm, StateData)
     end;
@@ -856,6 +782,62 @@ wait_for_session_or_sm({xmlstreamerror, _}, StateData) ->
 
 wait_for_session_or_sm(closed, StateData) ->
     {stop, normal, StateData}.
+
+maybe_open_session(El, #state{jid = JID} = StateData) ->
+    case user_allowed(JID, StateData) of
+        true ->
+            do_open_session(El, JID, StateData);
+        _ ->
+            ejabberd_hooks:run(forbidden_session_hook,
+                               StateData#state.server, [JID]),
+            ?INFO_MSG("(~w) Forbidden session for ~s",
+                      [StateData#state.socket,
+                       jlib:jid_to_binary(JID)]),
+            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
+            send_element(StateData, Err),
+            fsm_next_state(wait_for_session_or_sm, StateData)
+    end.
+
+do_open_session(El, JID, StateData) ->
+    ?INFO_MSG("(~w) Opened session for ~s",
+              [StateData#state.socket,
+               jlib:jid_to_binary(JID)]),
+    Res = jlib:make_result_iq_reply(El),
+    Packet = {jlib:jid_remove_resource(StateData#state.jid), StateData#state.jid, Res},
+    {_, _, NewStateData0, _} = send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm),
+    do_open_session_common(JID, NewStateData0).
+
+do_open_session_common(JID, #state{user = U, resource = R} = NewStateData0) ->
+    change_shaper(NewStateData0, JID),
+    {Fs, Ts, Pending} = ejabberd_hooks:run_fold(
+                          roster_get_subscription_lists,
+                          NewStateData0#state.server,
+                          {[], [], []},
+                          [U, NewStateData0#state.server]),
+    LJID = jlib:jid_tolower(jlib:jid_remove_resource(JID)),
+    Fs1 = [LJID | Fs],
+    Ts1 = [LJID | Ts],
+    PrivList =
+    ejabberd_hooks:run_fold(
+      privacy_get_user_list, NewStateData0#state.server,
+      #userlist{},
+      [U, NewStateData0#state.server]),
+    SID = {now(), self()},
+    Conn = get_conn_type(NewStateData0),
+    Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
+            {auth_module, NewStateData0#state.auth_module}],
+    ejabberd_sm:open_session(
+      SID, U, NewStateData0#state.server, R, Info),
+    NewStateData =
+    NewStateData0#state{
+      sid = SID,
+      conn = Conn,
+      pres_f = ?SETS:from_list(Fs1),
+      pres_t = ?SETS:from_list(Ts1),
+      pending_invitations = Pending,
+      privacy_list = PrivList},
+    fsm_next_state_pack(session_established,
+                        NewStateData).
 
 -spec session_established(Item :: ejabberd:xml_stream_item(),
                           State :: state()) -> fsm_return().
@@ -2282,8 +2264,7 @@ is_ip_blacklisted({IP,_Port}) ->
 
 %% @doc Check from attributes.
 -spec check_from(El, FromJID) -> Result when
-      El :: jlib:xmlel(),
-      FromJID :: ejabberd:jid(),
+      El :: jlib:xmlel(), FromJID :: ejabberd:jid(),
       Result :: 'invalid-from'  | jlib:xmlel().
 check_from(El, FromJID) ->
     case xml:get_tag_attr(<<"from">>, El) of

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2880,12 +2880,12 @@ handle_sasl_step(#state{server = Server, socket= Sock} = State, StepRes) ->
 user_allowed(JID, #state{server = Server, access = Access}) ->
     case acl:match_rule(Server, Access, JID)  of
         allow ->
-            user_allowed_hook(Server, JID);
+            open_session_allowed_hook(Server, JID);
         deny ->
             false
     end.
 
-user_allowed_hook(Server, JID) ->
-    allow == ejabberd_hooks:run_fold(check_user_allowed,
+open_session_allowed_hook(Server, JID) ->
+    allow == ejabberd_hooks:run_fold(session_opening_allowed_for_user,
                                      Server,
                                      allow, [JID]).

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -48,8 +48,6 @@
          bounce_resource_packet/3
         ]).
 
--export([acl_match/2]).
-
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
@@ -237,15 +235,6 @@ register_host(Host) ->
 unregister_host(Host) ->
     gen_server:call(?MODULE,{unregister_host,Host}).
 
--spec acl_match(Acc :: allow | deny, JID :: ejabberd:jid()) ->
-    {stop, deny} | allow.
-acl_match(_Acc, #jid{lserver = Server} = JID) ->
-     case acl:match_rule(Server, c2s, JID) of
-         allow ->
-             allow;
-         deny ->
-             {stop, deny}
-     end.
 
 %%====================================================================
 %% gen_server callbacks
@@ -463,14 +452,12 @@ cancel_timer(TRef) ->
     end.
 
 do_register_host(Host) ->
-    ejabberd_hooks:add(check_user_allowed, Host, ?MODULE, acl_match, 10),
     ejabberd_router:register_route(Host, {apply, ?MODULE, route}),
     ejabberd_hooks:add(local_send_to_resource_hook, Host,
                        ?MODULE, bounce_resource_packet, 100).
 
 do_unregister_host(Host) ->
     ejabberd_router:unregister_route(Host),
-    ejabberd_hooks:delete(check_user_allowed, Host, ?MODULE, acl_match, 10),
     ejabberd_hooks:delete(local_send_to_resource_hook, Host,
                           ?MODULE, bounce_resource_packet, 100).
 

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -105,6 +105,7 @@ way - in a process state, persistent storage or by notifying some external
 service.
 
 ## `node_cleanup`
+
 ```erlang
 ejabberd_hooks:run(node_cleanup, [Node])
 ```
@@ -118,3 +119,18 @@ situations the hook may be run on more than one node in the cluster, especially
 when there is little garbage to clean after the dead node. Setting retries to 0
 is not good decision as it was observed that in some setups it may abort the
 transaction on all nodes.
+
+## `session_opening_allowed_for_user`
+```erlang
+ejabberd_hooks:run_fold(session_opening_allowed_for_user,
+                        Server,
+                        allow, [JID]).
+```
+
+This hook is run after authentication when user sends the iq opening a session.
+Handler function are expected to return:
+
+* `allow` if given JID is allowed to open a new sessions
+* `deny` if the JID is not allowed but other handlers should be run
+* `{stop, deny}` if the JID is not allowed but other handlers should be run
+

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -132,5 +132,5 @@ Handler function are expected to return:
 
 * `allow` if given JID is allowed to open a new sessions
 * `deny` if the JID is not allowed but other handlers should be run
-* `{stop, deny}` if the JID is not allowed but other handlers should be run
+* `{stop, deny}` if the JID is not allowed but other handlers should **not** be run
 

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,7 +4,7 @@
 {require_otp_vsn, "R?1[45678]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "2.6.2"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "check-session-reply"}}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "2.2.0"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,7 +4,7 @@
 {require_otp_vsn, "R?1[45678]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "check-session-reply"}}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "7310978"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "2.2.0"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},

--- a/test/ejabberd_tests/tests/legacy_stream_helper.erl
+++ b/test/ejabberd_tests/tests/legacy_stream_helper.erl
@@ -76,19 +76,19 @@ legacy_auth_plain(Conn, Props, UnusedFeatures) ->
 
 res(Res) when is_binary(Res) ->
     #xmlel{name = <<"resource">>,
-           children = [exml:escape_cdata(Res)]}.
+           children = [#xmlcdata{content = Res}]}.
 
 username(Username) when is_binary(Username) ->
     #xmlel{name = <<"username">>,
-           children = [exml:escape_cdata(Username)]}.
+           children = [#xmlcdata{content = Username}]}.
 
 digest(Digest) when is_binary(Digest) ->
     #xmlel{name = <<"digest">>,
-           children = [exml:escape_cdata(Digest)]}.
+           children = [#xmlcdata{content = Digest}]}.
 
 password(Password) when is_binary(Password) ->
     #xmlel{name = <<"password">>,
-           children = [exml:escape_cdata(Password)]}.
+           children = [#xmlcdata{content = Password}]}.
 
 generate_digest(SID, Password) ->
     %% compute digest

--- a/test/ejabberd_tests/tests/legacy_stream_helper.erl
+++ b/test/ejabberd_tests/tests/legacy_stream_helper.erl
@@ -1,0 +1,113 @@
+-module(legacy_stream_helper).
+
+-export([stream_start/1]).
+-export([stream_start_pre_xmpp_1_0/1]).
+-export([start_stream_pre_xmpp_1_0/3]).
+-export([failed_legacy_auth/3]).
+-export([legacy_auth_digest/3]).
+-export([legacy_auth_plain/3]).
+
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("exml/include/exml_stream.hrl").
+
+-define(NS_AUTH, <<"jabber:iq:auth">>).
+
+
+stream_start_pre_xmpp_1_0(To) ->
+    stream_start(lists:keystore(version, 1, default_context(To), {version, <<>>})).
+
+
+stream_start(Context) ->
+    %% Be careful! The closing slash here is a hack to enable implementation of from_template/2
+    %% to parse the snippet properly. In standard XMPP <stream:stream> is just opening of an XML
+    %% element, NOT A SELF CLOSING element.
+    T = <<"<stream:stream {{version}} xml:lang='en' xmlns='jabber:client' "
+          "               to='{{to}}' "
+          "               xmlns:stream='{{stream_ns}}' />">>,
+    %% So we rewrap the parsed contents from #xmlel{} to #xmlstreamstart{} here.
+    #xmlel{name = Name, attrs = Attrs, children = []} = escalus_stanza:from_template(T, Context),
+    #xmlstreamstart{name = Name, attrs = Attrs}.
+
+default_context(To) ->
+    [{version, <<"version='1.0'">>},
+     {to, To},
+     {stream_ns, ?NS_XMPP}].
+
+start_stream_pre_xmpp_1_0(Conn, Props, UnusedFeatures) ->
+    escalus:send(Conn, stream_start_pre_xmpp_1_0(escalus_users:get_server([], Props))),
+    #xmlstreamstart{attrs = StreamAttrs} = StreamStart = escalus:wait_for_stanza(Conn),
+    escalus:assert(is_stream_start, StreamStart),
+    {<<"id">>, StreamID} = lists:keyfind(<<"id">>, 1, StreamAttrs),
+    {Conn, [{stream_id, StreamID} | Props], UnusedFeatures}.
+
+failed_legacy_auth(Conn, Props, UnusedFeatures) ->
+    {stream_id, StreamID} = lists:keyfind(stream_id, 1, Props),
+    [Username, _, Password] = escalus_users:get_usp([], Props),
+    Digest = list_to_binary(generate_digest(StreamID, Password)),
+    AuthReq = escalus_stanza:iq_set(?NS_AUTH, [username(Username), digest(Digest)]),
+    escalus:send(Conn, AuthReq),
+    Response = escalus:wait_for_stanza(Conn),
+    %% This is the success case - we want to assert the error case.
+    %% And the error case is achived by sending req without resource
+    escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Response),
+    {Conn, Props, UnusedFeatures}.
+
+legacy_auth_digest(Conn, Props, UnusedFeatures) ->
+    {stream_id, StreamID} = lists:keyfind(stream_id, 1, Props),
+    [Username, _, Password] = escalus_users:get_usp([], Props),
+    Digest = list_to_binary(generate_digest(StreamID, Password)),
+    AuthReq = escalus_stanza:iq_set(?NS_AUTH,
+                                    [username(Username), digest(Digest), res(<<"res">>)]),
+    escalus:send(Conn, AuthReq),
+    Response = escalus:wait_for_stanza(Conn),
+    escalus:assert(is_iq_result, [AuthReq], Response),
+    {Conn, Props, UnusedFeatures}.
+
+legacy_auth_plain(Conn, Props, UnusedFeatures) ->
+    [Username, _, Password] = escalus_users:get_usp([], Props),
+    AuthReq = escalus_stanza:iq_set(?NS_AUTH,
+                                    [username(Username), password(Password), res(<<"res">>)]),
+    escalus:send(Conn, AuthReq),
+    Response = escalus:wait_for_stanza(Conn),
+    escalus:assert(is_iq_result, [AuthReq], Response),
+    {Conn, Props, UnusedFeatures}.
+
+res(Res) when is_binary(Res) ->
+    #xmlel{name = <<"resource">>,
+           children = [exml:escape_cdata(Res)]}.
+
+username(Username) when is_binary(Username) ->
+    #xmlel{name = <<"username">>,
+           children = [exml:escape_cdata(Username)]}.
+
+digest(Digest) when is_binary(Digest) ->
+    #xmlel{name = <<"digest">>,
+           children = [exml:escape_cdata(Digest)]}.
+
+password(Password) when is_binary(Password) ->
+    #xmlel{name = <<"password">>,
+           children = [exml:escape_cdata(Password)]}.
+
+generate_digest(SID, Password) ->
+    %% compute digest
+    D = binary_to_list(SID) ++ binary_to_list(Password),
+    sha(D).
+
+digit_to_xchar(D) when (D >= 0) and (D < 10) ->
+    D + 48;
+digit_to_xchar(D) ->
+    D + 87.
+
+sha(Text) ->
+    Bin = crypto:hash(sha256, Text),
+    lists:reverse(ints_to_rxstr(binary_to_list(Bin), [])).
+
+ints_to_rxstr([], Res) ->
+    Res;
+ints_to_rxstr([N | Ns], Res) ->
+    ints_to_rxstr(Ns, [digit_to_xchar(N rem 16),
+                       digit_to_xchar(N div 16) | Res]).
+
+

--- a/test/ejabberd_tests/tests/legacy_stream_helper.erl
+++ b/test/ejabberd_tests/tests/legacy_stream_helper.erl
@@ -101,7 +101,7 @@ digit_to_xchar(D) ->
     D + 87.
 
 sha(Text) ->
-    Bin = crypto:hash(sha256, Text),
+    Bin = crypto:hash(sha, Text),
     lists:reverse(ints_to_rxstr(binary_to_list(Bin), [])).
 
 ints_to_rxstr([], Res) ->

--- a/test/ejabberd_tests/tests/login_SUITE.erl
+++ b/test/ejabberd_tests/tests/login_SUITE.erl
@@ -45,7 +45,7 @@ groups() ->
      {login_scram, [sequence], scram_tests()},
      {login_scram_store_plain, [sequence], scram_tests()},
      {legacy_auth, [sequence], [legacy_successful_plain,
-                                %legacy_successful_digest,
+                                legacy_successful_digest,
                                 legacy_blocked_user]},
      {messages, [sequence], [messages_story, message_zlib_limit]}].
 

--- a/test/ejabberd_tests/tests/login_SUITE.erl
+++ b/test/ejabberd_tests/tests/login_SUITE.erl
@@ -115,7 +115,8 @@ end_per_group(_GroupName, Config) ->
 
 init_per_testcase(DigestOrScram, Config) when
       DigestOrScram =:= log_one_digest; DigestOrScram =:= log_non_existent_digest;
-      DigestOrScram =:= log_one_scram; DigestOrScram =:= log_non_existent_scram ->
+      DigestOrScram =:= log_one_scram; DigestOrScram =:= log_non_existent_scram;
+      DigestOrScram =:= legacy_successful_digest ->
     case get_auth_method() of
         external ->
             {skip, "external authentication requires plain password"};


### PR DESCRIPTION
The idea behind this PR is to make user blocking/banning easier. Now the first phase is the old acl matching. If this allows a user the the hook `check_user_allowed` is run (as run_fold) with initial value `allow`.