### PR TITLE
Do not create nor update skipped hooks

### DIFF
--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -44,6 +44,9 @@
          remove_host_metrics/1,
          remove_all_metrics/0]).
 
+-define(DEFAULT_REPORT_INTERVAL, 60000). %%60s
+
+
 -spec init() -> ok.
 init() ->
     create_global_metrics(),
@@ -57,9 +60,17 @@ init_subscriptions() ->
     Reporters = exometer_report:list_reporters(),
     lists:foreach(
         fun({Name, _ReporterPid}) ->
-                Interval = application:get_env(exometer, mongooseim_report_interval, 60000),
+                Interval = get_report_interval(),
                 subscribe_to_all(Name, Interval)
         end, Reporters).
+
+get_report_interval() ->
+    case application:get_env(exometer, mongooseim_report_interval) of
+        undefined ->
+            ?DEFAULT_REPORT_INTERVAL;
+        {ok, Val} ->
+            Val
+    end.
 
 -spec update({term(), term()} | list(), term()) -> any().
 update(Name, Change) when is_tuple(Name)->

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -81,7 +81,7 @@ start_global_metrics_subscriptions(Reporter, Interval) ->
     do_start_global_metrics_subscriptions(Reporter, Interval).
 
 start_data_metrics_subscriptions(Reporter, Interval) ->
-    do_start_metrics_subscriptions(Reporter, Interval, [data]).
+    do_start_metrics_subscriptions(Reporter, Interval, [data, xmpp]).
 
 start_backend_metrics_subscriptions(Reporter, Interval) ->
     do_start_metrics_subscriptions(Reporter, Interval, [backends]).
@@ -269,8 +269,6 @@ create_metrics(Host) ->
     lists:foreach(fun(Name) -> ensure_metric(Name, counter) end,
                   get_total_counters(Host)).
 
-ensure_metric(Metric, Type) when is_tuple(Metric)->
-    ensure_metric(tuple_to_list(Metric), Type);
 ensure_metric(Metric, Type) when is_list(Metric) ->
     case exometer:info(Metric, type) of
         Type -> {ok, already_present};

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -19,6 +19,7 @@
 
 %% API
 -export([init/0,
+         init_subscriptions/0,
          update/2,
          create/2,
          ensure_metric/2,
@@ -50,6 +51,9 @@ init() ->
         fun(Host) ->
             mongoose_metrics:init_predefined_host_metrics(Host)
         end, ?MYHOSTS),
+    init_subscriptions().
+
+init_subscriptions() ->
     Reporters = exometer_report:list_reporters(),
     lists:foreach(
         fun({Name, _ReporterPid}) ->
@@ -121,10 +125,14 @@ get_up_time() ->
     {value, erlang:round(element(1, erlang:statistics(wall_clock))/1000)}.
 
 -spec do_create_generic_hook_metric(list()) -> ok | {ok, already_present}.
+do_create_generic_hook_metric([_, skip]) ->
+    ok;
 do_create_generic_hook_metric(MetricName) ->
     ensure_metric(MetricName, spiral).
 
 -spec do_increment_generic_hook_metric(list()) -> ok | {error, any()}.
+do_increment_generic_hook_metric([_, skip]) ->
+    ok;
 do_increment_generic_hook_metric(MetricName) ->
     update(MetricName, 1).
 

--- a/apps/ejabberd/test/carbon_cache_server.erl
+++ b/apps/ejabberd/test/carbon_cache_server.erl
@@ -1,7 +1,8 @@
--module(carbon_server).
+-module(carbon_cache_server).
 
 -export([start/2]).
 -export([server/2]).
+-export([wait_for_accepting/0]).
 
 start(Num,LPort) ->
     case gen_tcp:listen(LPort,[{active, false},{packet,2}]) of
@@ -45,4 +46,10 @@ loop(S) ->
         {tcp_closed,S} ->
             io:format("Socket ~w closed [~w]~n",[S,self()]),
             ok
+    end.
+
+wait_for_accepting() ->
+    receive
+        {accepting, Pid} ->
+            Pid
     end.

--- a/apps/ejabberd/test/carbon_server.erl
+++ b/apps/ejabberd/test/carbon_server.erl
@@ -1,0 +1,48 @@
+-module(carbon_server).
+
+-export([start/2]).
+-export([server/2]).
+
+start(Num,LPort) ->
+    case gen_tcp:listen(LPort,[{active, false},{packet,2}]) of
+        {ok, ListenSock} ->
+            start_servers(Num,ListenSock),
+            {ok, Port} = inet:port(ListenSock),
+            {Port, ListenSock};
+        {error,Reason} ->
+            {error,Reason}
+    end.
+
+start_servers(0,_) ->
+    ok;
+start_servers(Num,LS) ->
+    spawn(?MODULE,server,[LS, self()]),
+    start_servers(Num-1,LS).
+
+server(LS, Parent) ->
+    Parent ! {accepting, self()},
+    server(LS).
+
+server(LS) ->
+    case gen_tcp:accept(LS) of
+        {ok,S} ->
+            loop(S),
+            server(LS);
+        Other ->
+            io:format("accept returned ~w - goodbye!~n",[Other]),
+            ok
+    end.
+
+loop(S) ->
+    inet:setopts(S,[{active,once}]),
+    receive
+        {tcp,S,_Data} ->
+            %Answer = process(Data), % Not implemented in this example
+            %gen_tcp:send(S,Answer),
+            %ct:print("~s",[Data]),
+            exometer:update([carbon, packets], 1),
+            loop(S);
+        {tcp_closed,S} ->
+            io:format("Socket ~w closed [~w]~n",[S,self()]),
+            ok
+    end.

--- a/apps/ejabberd/test/ejabberd_helper.erl
+++ b/apps/ejabberd/test/ejabberd_helper.erl
@@ -4,6 +4,8 @@
          stop_ejabberd/0,
          use_config_file/2]).
 
+-export([ensure_all_started/1]).
+
 -spec start_ejabberd(any()) -> 'ok' | {error, any()}.
 start_ejabberd(_Config) ->
     {ok, Deps} = application:get_key(ejabberd, applications),
@@ -16,6 +18,20 @@ start_deps([Dep | Deps]) ->
         {error, {already_started, Dep}} -> start_deps(Deps);
         {error, {not_started, NewDep}} -> start_deps([NewDep, Dep | Deps]);
         ok -> start_deps(Deps)
+    end.
+
+ensure_all_started(App) ->
+    do_ensure_all_started(App, []).
+
+do_ensure_all_started(App, AccDeps) ->
+    case application:start(App) of
+        ok ->
+            {ok, [App | AccDeps]};
+        {error, {already_started, _Dep}} ->
+            {ok, AccDeps};
+        {error, {not_started, Dep}} ->
+            {ok, Acc2} = do_ensure_all_started(Dep, AccDeps),
+            do_ensure_all_started(App, Acc2)
     end.
 
 -spec stop_ejabberd() -> 'ok' | {error, any()}.

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -1,5 +1,6 @@
 -module(ejabberd_sm_SUITE).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 -include_lib("ejabberd/src/ejabberd_c2s.hrl").
 -include_lib("ejabberd/include/ejabberd.hrl").
 -compile([export_all]).
@@ -28,6 +29,11 @@ init_per_suite(C) ->
     end,
     Pid = spawn(F),
     [{pid, Pid} | C].
+
+end_per_suite(C) ->
+    Pid = ?config(pid, C),
+    Pid ! stop,
+    application:stop(exometer).
 
 groups() ->
     [{mnesia, [], tests()},

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -18,11 +18,7 @@ all() -> [{group, mnesia}, {group, redis}].
 
 init_per_suite(C) ->
     application:start(p1_stringprep),
-    application:start(syntax_tools),
-    application:start(compiler),
-    application:start(goldrush),
-    application:start(lager),
-    application:start(exometer),
+    ejabberd_helper:ensure_all_started(exometer),
     F = fun() ->
         ejabberd_sm_backend_sup:start_link(),
         receive stop -> ok end

--- a/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
+++ b/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
@@ -62,7 +62,6 @@ end_per_suite(C) ->
 
 subscriptions_initialised(_C) ->
     mongoose_metrics:init(),
-    ct:sleep(timer:seconds(10)),
     true = wait_for_update(exometer:get_value([carbon, packets], count), 60).
 
 wait_for_update({ok, [{count,X}]}, 0) ->

--- a/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
+++ b/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
@@ -1,0 +1,92 @@
+-module(mongooseim_metrics_SUITE).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-compile([export_all]).
+
+all() -> [subscriptions_initialised].
+
+init_per_suite(C) ->
+    application:load(exometer),
+    application:set_env(exometer, mongooseim_report_interval, 1000),
+    {Port, Socket} = carbon_server:start(1, 0),
+    Sup = spawn(fun() ->
+                        mim_ct_sup:start_link(ejabberd_sup),
+                        Hooks =
+                        {ejabberd_hooks,
+                         {ejabberd_hooks, start_link, []},
+                         permanent,
+                         brutal_kill,
+                         worker,
+                         [ejabberd_hooks]},
+                        C2SSupervisor =
+                        {ejabberd_c2s_sup,
+                         {ejabberd_tmp_sup, start_link, [ejabberd_c2s_sup, ejabberd_c2s]},
+                         permanent,
+                         infinity,
+                         supervisor,
+                         [ejabberd_tmp_sup]},
+                        supervisor:start_child(ejabberd_sup, Hooks),
+                        supervisor:start_child(ejabberd_sup, C2SSupervisor),
+                        receive
+                            stop ->
+                                ok
+                        end
+                end),
+    Reporters = get_reporters_cfg(Port),
+    application:set_env(exometer, report, Reporters),
+    PortServer = receive
+                     {accepting, Pid} ->
+                         Pid
+                 end,
+    {ok, Apps} = application:ensure_all_started(exometer),
+    ct:print("started apps ~p", [Apps]),
+    setup_meck(),
+    exometer:new([carbon, packets], spiral),
+    [{carbon_port, Port}, {test_sup, Sup}, {carbon_server, PortServer}, {carbon_socket, Socket} | C].
+
+end_per_suite(C) ->
+    Sup = ?config(test_sup, C),
+    Sup ! stop,
+    CarbonServer = ?config(carbon_server, C),
+    erlang:exit(CarbonServer, kill),
+    CarbonSocket = ?config(carbon_socket, C),
+    gen_tcp:close(CarbonSocket),
+    meck:unload(),
+    application:stop(exometer),
+    C.
+
+
+subscriptions_initialised(_C) ->
+    mongoose_metrics:init(),
+    ct:sleep(timer:seconds(10)),
+    true = wait_for_update(exometer:get_value([carbon, packets], count), 60).
+
+wait_for_update({ok, [{count,X}]}, 0) ->
+    X > 0;
+wait_for_update({ok, [{count,X}]}, _N) when X > 0 ->
+    true;
+wait_for_update({ok, [{count,0}]}, N) ->
+    timer:sleep(1000),
+    wait_for_update(exometer:get_value([carbon, packets], count), N-1).
+
+setup_meck() ->
+    meck:new(ejabberd_config, [no_link]),
+    meck:expect(ejabberd_config, get_global_option, fun(hosts) -> [<<"localhost">>] end),
+    ok.
+
+get_reporters_cfg(Port) ->
+    [{reporters, [
+                 {exometer_report_graphite, [
+                                             {prefix, "mongooseim"},
+                                             {connect_timeout, 5000},
+                                             {host, "127.0.0.1"},
+                                             {port, Port},
+                                             {api_key, ""}
+                                            ]}
+                ]}].
+

--- a/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
+++ b/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
@@ -43,8 +43,7 @@ init_per_suite(C) ->
                      {accepting, Pid} ->
                          Pid
                  end,
-    {ok, Apps} = application:ensure_all_started(exometer),
-    ct:print("started apps ~p", [Apps]),
+    {ok, _Apps} = ejabberd_helper:ensure_all_started(exometer),
     setup_meck(),
     exometer:new([carbon, packets], spiral),
     [{carbon_port, Port}, {test_sup, Sup}, {carbon_server, PortServer}, {carbon_socket, Socket} | C].

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -556,7 +556,17 @@ init_state(_, _, Config) ->
     clean_archives(Config).
 
 
-init_per_testcase(C=archived, Config) ->
+init_per_testcase(C=archived, ConfigIn) ->
+    Config = case ?config(configuration, ConfigIn) of
+                 odbc_async_pool ->
+                     MongooseMetrics = [
+                                        {[data, odbc, mam_async],
+                                         [{recv_oct, '>'}, {send_oct, '>'}]}
+                                       ],
+                     [{mongoose_metrics, MongooseMetrics} | ConfigIn];
+                 _ ->
+                     ConfigIn
+             end,
     escalus:init_per_testcase(C, clean_archives(Config));
 init_per_testcase(C=strip_archived, Config) ->
     escalus:init_per_testcase(C, clean_archives(Config));


### PR DESCRIPTION
This PR prevents creating a spiral metric for skipped hook. Such metric is dangerous because it may have lot of (tens of thousands) updates in a minute which can lead to too long message inbox for process holding this metric and can crash `exometer_reporter`. 

Also, this PR adds some tests for metric subscriptions.