### PR TITLE
Remove duplicate code, make abstract xmpp_router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,10 @@ ct: deps quick_compile
 # $ make qct SUITE=amp_resolver_SUITE
 qct:
 	mkdir -p /tmp/ct_log
-	ct_run -pa apps/*/ebin -pa deps/*/ebin -pa ebin -dir apps/*/test\
-        -I apps/*/include -logdir /tmp/ct_log -suite $(SUITE)_SUITE -noshell
+	@if [ "$(SUITE)" ]; then ct_run -pa apps/*/ebin -pa deps/*/ebin -pa ebin -dir apps/*/test\
+        -I apps/*/include -logdir /tmp/ct_log -suite $(SUITE)_SUITE -noshell;\
+	else ct_run -pa apps/*/ebin -pa deps/*/ebin -pa ebin -dir apps/*/test\
+        -I apps/*/include -logdir /tmp/ct_log -noshell; fi
 
 test: test_deps
 	cd test/ejabberd_tests; make test

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -28,7 +28,7 @@
 -author('alexey@process-one.net').
 
 -behaviour(gen_server).
-
+-behaviour(xmpp_router).
 %% API
 -export([route/3,
          route_error/4,
@@ -42,6 +42,9 @@
         ]).
 
 -export([start_link/0]).
+
+%% xmpp_router callback
+-export([do_route/3]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -70,19 +73,11 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-
 -spec route(From   :: ejabberd:jid(),
             To     :: ejabberd:jid(),
             Packet :: jlib:xmlel()) -> ok.
 route(From, To, Packet) ->
-    case catch do_route(From, To, Packet) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("~p~nwhen processing: ~p",
-                       [Reason, {From, To, Packet}]),
-            ok;
-        _ ->
-            ok
-    end.
+    xmpp_router:route(?MODULE, From, To, Packet).
 
 %% Route the error packet only if the originating packet is not an error itself.
 %% RFC3920 9.3.1
@@ -208,13 +203,7 @@ handle_cast(_Msg, State) ->
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 handle_info({route, From, To, Packet}, State) ->
-    case catch do_route(From, To, Packet) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("~p~nwhen processing: ~p",
-                       [Reason, {From, To, Packet}]);
-        _ ->
-            ok
-    end,
+    route(From, To, Packet),
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -1,15 +1,21 @@
 -module(xmpp_router).
 -export([route/4]).
--include_lib("ejabberd/include/ejabberd.hrl").
+
+-include("ejabberd.hrl").
 
 
--callback do_route(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) -> ok.
+-callback do_route(From :: ejabberd:jid(), To :: ejabberd:jid(),
+                   Packet :: jlib:xmlel()) -> ok.
+
+-spec route(Module :: module(), From :: ejabberd:jid(), To :: ejabberd:jid(),
+            Packet :: jlib:xmlel()) -> ok.
 route(Module,From,To,Packet) ->
     case (catch Module:do_route(From,To,Packet)) of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("~p when routing ~ts from ~ts to ~ts in module: ~p",
-                       [Reason, exml:to_binary(Packet),
-                        jlib:jid_to_binary(From), jlib:jid_to_binary(To),
-                        Module]);
+            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
+                       [jid:to_binary(From), jid:to_binary(To),
+                        Module, Reason, exml:to_binary(Packet),
+                        erlang:get_stacktrace()]);
         _ -> ok
     end.
+

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -1,0 +1,15 @@
+-module(xmpp_router).
+-export([route/4]).
+-include_lib("ejabberd/include/ejabberd.hrl").
+
+
+-callback do_route(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) -> ok.
+route(Module,From,To,Packet) ->
+    case (catch Module:do_route(From,To,Packet)) of
+        {'EXIT', Reason} ->
+            ?ERROR_MSG("~p when routing ~ts from ~ts to ~ts in module: ~p",
+                       [Reason, exml:to_binary(Packet),
+                        jlib:jid_to_binary(From), jlib:jid_to_binary(To),
+                        Module]);
+        _ -> ok
+    end.

--- a/apps/ejabberd/test/xmpp_route_SUITE.erl
+++ b/apps/ejabberd/test/xmpp_route_SUITE.erl
@@ -1,0 +1,62 @@
+-module(xmpp_route_SUITE).
+-compile([export_all]).
+
+-include_lib("exml/include/exml.hrl").
+
+
+all() ->
+    [ success_with_module_implementing_behaviour,
+      fail_with_module_not_implementing_behaviour,
+      fail_when_do_route_crashes
+    ].
+
+init_per_suite(C) ->
+    application:start(p1_stringprep),
+    ejabberd_helper:ensure_all_started(lager),
+    C.
+
+success_with_module_implementing_behaviour(_C) ->
+    meck:new(xmpp_router_correct, [non_strict]),
+    meck:expect(xmpp_router_correct, do_route,
+                fun(_From, _To, _Packet) -> ok end),
+    ok = xmpp_router:route(xmpp_router_correct,
+                           jid:from_binary(<<"ala@localhost">>),
+                           jid:from_binary(<<"bob@localhost">>),
+                           message()),
+    meck:validate(xmpp_router_correct),
+    meck:unload(xmpp_router_correct),
+    ok.
+
+fail_with_module_not_implementing_behaviour(_C) ->
+    meck:new(xmpp_router_incorrect, [non_strict]),
+    meck:expect(xmpp_router_incorrect, no_do_route,
+                fun(_From, _To, _Packet) -> ok end),
+    meck:new(lager, [unstick, passthrough]),
+    ok = xmpp_router:route(xmpp_router_incorrect,
+                           jid:from_binary(<<"ala@localhost">>),
+                           jid:from_binary(<<"bob@localhost">>),
+                           message()),
+    meck:validate(lager),
+    meck:unload(xmpp_router_incorrect),
+    meck:unload(lager),
+    ok.
+
+
+fail_when_do_route_crashes(_C) ->
+    meck:new(xmpp_router_crashing, [non_strict]),
+    meck:expect(xmpp_router_crashing, do_route,
+                fun(_From, _To, _Packet) -> meck:exception(error, sth_wrong) end),
+    meck:new(lager, [unstick, passthrough]),
+    ok = xmpp_router:route(xmpp_router_crashing,
+                           jid:from_binary(<<"ala@localhost">>),
+                           jid:from_binary(<<"bob@localhost">>),
+                           message()),
+    meck:validate(xmpp_router_crashing),
+    meck:validate(lager),
+    meck:unload(xmpp_router_crashing),
+    meck:unload(lager),
+    ok.
+
+message() ->
+    #xmlel{name = <<"message">>}.
+


### PR DESCRIPTION
I removed 8 instances of identical code from 4 separate modules, and implemented them as a generic `xmpp_router`. The modules now expose their own distinct implementations, under `Module:do_route/3`. These module-specific implemenations were not changed.

Edit: yes, this makes the ?ERROR_MSG in the generic implementation a little less informative, as the trace will always be logged as coming from `xmpp_router`. This is why the implementation module is referenced in the error message itself. I believe the cleanup is worth the tradeoff.