### PR TITLE
Introduce jid module

### DIFF
--- a/apps/ejabberd/include/mod_vcard.hrl
+++ b/apps/ejabberd/include/mod_vcard.hrl
@@ -50,7 +50,7 @@
                         [{xmlcdata,
                           <<(translate:translate(Lang,
                                                  <<"Search users in ">>))/binary,
-                            (jlib:jid_to_binary(JID))/binary>>}]},
+                            (jid:to_binary(JID))/binary>>}]},
                  #xmlel{name = <<"instructions">>, attrs = [],
                         children =
                         [{xmlcdata,

--- a/apps/ejabberd/src/acl.erl
+++ b/apps/ejabberd/src/acl.erl
@@ -136,7 +136,7 @@ add_list(Host, ACLs, Clear) ->
 normalize(A) when is_list(A) ->
     normalize(list_to_binary(A));
 normalize(A) ->
-    jlib:nodeprep(A).
+    jid:nodeprep(A).
 
 -spec normalize_spec(aclspec())
       -> aclspec()
@@ -219,7 +219,7 @@ match_acl(ACL, JID, Host) ->
         all -> true;
         none -> false;
         _ ->
-            {User, Server, Resource} = jlib:jid_tolower(JID),
+            {User, Server, Resource} = jid:to_lower(JID),
             lists:any(fun(#acl{aclspec = Spec}) ->
                               case Spec of
                                   all ->

--- a/apps/ejabberd/src/amp.erl
+++ b/apps/ejabberd/src/amp.erl
@@ -54,7 +54,7 @@ extract_requested_rules(#xmlel{} = Stanza) ->
 -spec make_response(amp_rule(), jid(), #xmlel{}) -> #xmlel{}.
 make_response(Rule, User, Packet) ->
     OriginalId = exml_query:attr(Packet, <<"id">>, <<"original-id-missing">>),
-    OriginalSender = jlib:jid_to_binary(User),
+    OriginalSender = jid:to_binary(User),
     OriginalRecipient = exml_query:attr(Packet, <<"to">>),
 
     Amp = #xmlel{name = <<"amp">>,
@@ -87,7 +87,7 @@ make_error_response(Errors,Rules,User,Packet) ->
     error(invalid_data).
 
 error_amp_attrs('undefined-condition', User, Packet) ->
-    OriginalSender = jlib:jid_to_binary(User),
+    OriginalSender = jid:to_binary(User),
     OriginalRecipient = exml_query:attr(Packet, <<"to">>),
     [{<<"status">>, <<"error">>},
      {<<"to">>, OriginalRecipient},

--- a/apps/ejabberd/src/amp_strategy.erl
+++ b/apps/ejabberd/src/amp_strategy.erl
@@ -33,7 +33,7 @@ null_strategy() ->
 
 %% Internals
 get_target_resources(MessageTarget) ->
-    {User,Server,Resource} = jlib:jid_to_lower(MessageTarget),
+    {User,Server,Resource} = jid:to_lower(MessageTarget),
     ResourceSession = ejabberd_sm:get_session(User, Server, Resource),
     UserResources = ejabberd_sm:get_user_resources(User, Server),
     {ResourceSession, UserResources}.

--- a/apps/ejabberd/src/cyrsasl.erl
+++ b/apps/ejabberd/src/cyrsasl.erl
@@ -136,7 +136,7 @@ ets_insert_mechanism(MechanismRec) ->
 
 -spec check_credentials(sasl_state(), list()) -> 'ok' | {'error', binary()}.
 check_credentials(_State, Props) ->
-    case jlib:nodeprep(proplists:get_value(username, Props, <<>>)) of
+    case jid:nodeprep(proplists:get_value(username, Props, <<>>)) of
         error ->
             {error, <<"not-authorized">>};
         <<>> ->

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -115,8 +115,8 @@ store_type(Server) ->
                      Server :: ejabberd:server(),
                      Password :: binary() ) -> boolean().
 check_password(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_check_password(LUser, LServer, Password).
 
 -spec do_check_password(ejabberd:luser(), ejabberd:lserver(), binary()) -> boolean().
@@ -135,8 +135,8 @@ do_check_password(LUser, LServer, Password) ->
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
 check_password(User, Server, Password, Digest, DigestGen) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_check_password(LUser, LServer, Password, Digest, DigestGen).
 
 -spec do_check_password(User :: ejabberd:luser(),
@@ -161,8 +161,8 @@ do_check_password(LUser, LServer, Password, Digest, DigestGen) ->
                                      Password :: binary()
                                      ) -> 'false' | {'true', authmodule()}.
 check_password_with_authmodule(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_check_password_with_authmodule(LUser, LServer, Password).
 
 -spec do_check_password_with_authmodule(LUser :: ejabberd:luser(),
@@ -182,8 +182,8 @@ do_check_password_with_authmodule(LUser, LServer, Password) ->
                                      DigestGen :: fun()
                                      ) -> 'false' | {'true', authmodule()}.
 check_password_with_authmodule(User, Server, Password, Digest, DigestGen) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen).
 
 -spec do_check_password_with_authmodule(LUser :: ejabberd:luser(),
@@ -231,8 +231,8 @@ set_password(_User, _Server, "") ->
     %% We do not allow empty password
     {error, empty_password};
 set_password(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nodeprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nodeprep(Server),
     do_set_password(LUser, LServer, Password).
 
 do_set_password(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
@@ -254,8 +254,8 @@ try_register(_User, _Server, "") ->
     %% We do not allow empty password
     {error, not_allowed};
 try_register(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nodeprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nodeprep(Server),
     do_try_register(LUser, LServer, Password).
 
 -spec do_try_register(ejabberd:luser(), ejabberd:lserver(),binary())
@@ -305,7 +305,7 @@ dirty_get_registered_users() ->
 -spec get_vh_registered_users(Server :: ejabberd:server()
                              ) -> [ejabberd:simple_bare_jid()].
 get_vh_registered_users(Server) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     do_get_vh_registered_users(LServer).
 
 do_get_vh_registered_users(error) ->
@@ -320,7 +320,7 @@ do_get_vh_registered_users(LServer) ->
 -spec get_vh_registered_users(Server :: ejabberd:server(),
                               Opts :: [any()]) -> [ejabberd:simple_bare_jid()].
 get_vh_registered_users(Server, Opts) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     do_get_vh_registered_users(LServer, Opts).
 
 do_get_vh_registered_users(error, _) ->
@@ -335,7 +335,7 @@ do_get_vh_registered_users(LServer, Opts) ->
 -spec get_vh_registered_users_number(Server :: ejabberd:server()
                                     ) -> integer().
 get_vh_registered_users_number(Server) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     do_get_vh_registered_users_number(LServer).
 
 do_get_vh_registered_users_number(error) ->
@@ -351,7 +351,7 @@ do_get_vh_registered_users_number(LServer) ->
 -spec get_vh_registered_users_number(Server :: ejabberd:server(),
                                      Opts :: list()) -> integer().
 get_vh_registered_users_number(Server, Opts) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     do_get_vh_registered_users_number(LServer, Opts).
 
 do_get_vh_registered_users_number(error, _) ->
@@ -368,8 +368,8 @@ do_get_vh_registered_users_number(LServer, Opts) ->
 -spec get_password(User :: ejabberd:user(),
                    Server :: ejabberd:server()) -> binary() | false.
 get_password(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_get_password(LUser, LServer).
 
 do_get_password(LUser, LServer) when LUser =:= error; LServer =:= error ->
@@ -386,8 +386,8 @@ do_get_password(LUser, LServer) ->
 -spec get_password_s(User :: ejabberd:user(),
                      Server :: ejabberd:server()) -> binary().
 get_password_s(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_get_password_s(LUser, LServer).
 
 do_get_password_s(LUser, LServer) when LUser =:= error; LServer =:= error ->
@@ -405,8 +405,8 @@ do_get_password_s(LUser, LServer) ->
                                    Server :: ejabberd:server())
       -> {Password::binary(), AuthModule :: authmodule()} | {'false', 'none'}.
 get_password_with_authmodule(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_get_password_with_authmodule(LUser, LServer).
 
 do_get_password_with_authmodule(LUser, LServer)
@@ -425,8 +425,8 @@ do_get_password_with_authmodule(LUser, LServer) ->
 -spec is_user_exists(User :: ejabberd:user(),
                      Server :: ejabberd:server()) -> boolean().
 is_user_exists(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_does_user_exist(LUser, LServer).
 
 do_does_user_exist(LUser, LServer) when LUser =:= error; LServer =:= error ->
@@ -456,8 +456,8 @@ does_user_exist_timed(LUser, LServer) ->
                                       Server :: ejabberd:server()
                                       ) -> boolean() | 'maybe'.
 is_user_exists_in_other_modules(Module, User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_does_user_exist_in_other_modules(Module, LUser, LServer).
 
 do_does_user_exist_in_other_modules(_, LUser, LServer)
@@ -490,8 +490,8 @@ does_user_exist_in_other_modules_loop([AuthModule|AuthModules], User, Server) ->
 -spec remove_user(User :: ejabberd:user(),
                   Server :: ejabberd:server()) -> ok | error | {error, not_allowed}.
 remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_remove_user(LUser, LServer).
 
 do_remove_user(LUser, LServer) when LUser =:= error; LServer =:= error ->
@@ -510,8 +510,8 @@ do_remove_user(LUser, LServer) ->
                   Password :: binary()
                   ) -> ok | not_exists | not_allowed | bad_request | error.
 remove_user(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     do_remove_user(LUser, LServer, Password).
 
 do_remove_user(LUser, LServer, _) when LUser =:= error; LServer =:= error ->

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -97,7 +97,7 @@ stop(_Host) ->
 update_reg_users_counter_table(Server) ->
     Set = get_vh_registered_users(Server),
     Size = length(Set),
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     F = fun() ->
             write_counter(#reg_users_counter{vhost = LServer, count = Size})
         end,

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -330,7 +330,7 @@ scram_passwords(Server, ScramIterationCount) ->
     scram_passwords(Server, ?DEFAULT_SCRAMMIFY_COUNT, ?DEFAULT_SCRAMMIFY_INTERVAL, ScramIterationCount).
 
 scram_passwords(Server, Count, Interval, ScramIterationCount) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     ?INFO_MSG("Converting the stored passwords into SCRAM bits", []),
     ToConvertCount = case catch odbc_queries:get_users_without_scram_count(LServer) of
         {selected, [_], [{Res}]} -> binary_to_integer(Res);

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -527,7 +527,7 @@ do_legacy_auth(JID, El, StateData, U, P, D, R) ->
             ?INFO_MSG(
                "(~w) Failed legacy authentication for ~s from IP ~s (~w)",
                [StateData#state.socket,
-                jlib:jid_to_binary(JID), jlib:ip_to_list(IP), IP]),
+                jid:to_binary(JID), jlib:ip_to_list(IP), IP]),
             Err = jlib:make_error_reply(
                     El, ?ERR_NOT_AUTHORIZED),
             ejabberd_hooks:run(auth_failed, StateData#state.server,
@@ -551,7 +551,7 @@ do_open_legacy_session(El, StateData, U, R, JID, AuthModule) ->
     ?INFO_MSG(
        "(~w) Accepted legacy authentication for ~s by ~p",
        [StateData#state.socket,
-        jlib:jid_to_binary(JID), AuthModule]),
+        jid:to_binary(JID), AuthModule]),
     Res1 = jlib:make_result_iq_reply(El),
     Res = Res1#xmlel{children = []},
     send_element(StateData, Res),
@@ -799,7 +799,7 @@ maybe_open_session(El, #state{jid = JID} = StateData) ->
                                StateData#state.server, [JID]),
             ?INFO_MSG("(~w) Forbidden session for ~s",
                       [StateData#state.socket,
-                       jlib:jid_to_binary(JID)]),
+                       jid:to_binary(JID)]),
             Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
             send_element(StateData, Err),
             fsm_next_state(wait_for_session_or_sm, StateData)

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -810,7 +810,7 @@ do_open_session(El, JID, StateData) ->
                               [StateData#state.socket,
                                jid:to_binary(JID)]),
                     Res = jlib:make_result_iq_reply(El),
-                    Packet = {jid:remove_resource(StateData#state.jid), StateData#state.jid, Res},
+                    Packet = {jid:to_bare(StateData#state.jid), StateData#state.jid, Res},
                     {_, _, NewStateData0, _} = send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm),
     do_open_session_common(JID, NewStateData0).
 
@@ -821,7 +821,7 @@ do_open_session_common(JID, #state{user = U, resource = R} = NewStateData0) ->
                                           NewStateData0#state.server,
                                           {[], [], []},
                                           [U, NewStateData0#state.server]),
-                    LJID = jid:to_lower(jid:remove_resource(JID)),
+                    LJID = jid:to_lower(jid:to_bare(JID)),
                     Fs1 = [LJID | Fs],
                     Ts1 = [LJID | Ts],
                     PrivList =
@@ -1253,7 +1253,7 @@ handle_routed_broadcast({privacy_list, PrivList, PrivListName}, StateData) ->
             {new_state, StateData};
         NewPL ->
             PrivPushIQ = privacy_list_push_iq(PrivListName),
-            F = jid:remove_resource(StateData#state.jid),
+            F = jid:to_bare(StateData#state.jid),
             T = StateData#state.jid,
             PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
             {send_new, F, T, PrivPushEl, StateData#state{privacy_list = NewPL}}
@@ -1675,7 +1675,7 @@ am_i_subscribed_to_presence(LJID, LBareJID, S) ->
 
 lowcase_and_bare(JID) ->
     LJID = jid:to_lower(JID),
-    { LJID, jid:remove_resource(LJID)}.
+    { LJID, jid:to_bare(LJID)}.
 
 invisible_to(LFrom, LBareFrom, S) ->
     ?SETS:is_element(LFrom, S#state.pres_i)
@@ -1828,28 +1828,28 @@ presence_track(From, To, Packet, StateData) ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, subscribe]),
-            check_privacy_route(From, StateData, jid:remove_resource(From),
+            check_privacy_route(From, StateData, jid:to_bare(From),
                                 To, Packet),
             StateData;
         <<"subscribed">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, subscribed]),
-            check_privacy_route(From, StateData, jid:remove_resource(From),
+            check_privacy_route(From, StateData, jid:to_bare(From),
                                 To, Packet),
             StateData;
         <<"unsubscribe">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, unsubscribe]),
-            check_privacy_route(From, StateData, jid:remove_resource(From),
+            check_privacy_route(From, StateData, jid:to_bare(From),
                                 To, Packet),
             StateData;
         <<"unsubscribed">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, unsubscribed]),
-            check_privacy_route(From, StateData, jid:remove_resource(From),
+            check_privacy_route(From, StateData, jid:to_bare(From),
                                 To, Packet),
             StateData;
         <<"error">> ->
@@ -2272,7 +2272,7 @@ is_ip_blacklisted({IP,_Port}) ->
 %% @doc Check from attributes.
 -spec check_from(El, FromJID) -> Result when
       El :: jlib:xmlel(), FromJID :: ejabberd:jid(),
-                Result :: 'invalid-from'  | jlib:xmlel().
+      Result :: 'invalid-from'  | jlib:xmlel().
 check_from(El, FromJID) ->
     case xml:get_tag_attr(<<"from">>, El) of
         false ->
@@ -2366,7 +2366,7 @@ route_blocking(What, StateData) ->
     PrivPushIQ = #iq{type = set, xmlns = ?NS_BLOCKING,
                      id = <<"push">>,
                      sub_el = [SubEl]},
-    F = jid:remove_resource(StateData#state.jid),
+    F = jid:to_bare(StateData#state.jid),
     T = StateData#state.jid,
     PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
     ejabberd_router:route(F, T, PrivPushEl),

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -117,7 +117,7 @@ del_aux_field(Key, #state{aux_fields = Opts} = State) ->
 -spec get_subscription(From :: ejabberd:jid() | ejabberd:simple_jid(),
                        State :: state()) -> 'both' | 'from' | 'none' | 'to'.
 get_subscription(From = #jid{}, StateData) ->
-    get_subscription(jlib:jid_to_lower(From), StateData);
+    get_subscription(jid:to_lower(From), StateData);
 get_subscription(LFrom, StateData) ->
     LBFrom = setelement(3, LFrom, <<>>),
     F = is_subscribed_to_my_presence(LFrom, LBFrom, StateData),
@@ -231,13 +231,13 @@ wait_for_stream(closed, StateData) ->
     {stop, normal, StateData}.
 
 handle_stream_start({xmlstreamstart, _Name, Attrs}, #state{} = S0) ->
-    Server = jlib:nameprep(xml:get_attr_s(<<"to">>, Attrs)),
+    Server = jid:nameprep(xml:get_attr_s(<<"to">>, Attrs)),
     Lang = get_xml_lang(Attrs),
     S = S0#state{server = Server, lang = Lang},
     case {xml:get_attr_s(<<"xmlns:stream">>, Attrs),
           lists:member(Server, ?MYHOSTS)} of
         {?NS_STREAM, true} ->
-            change_shaper(S, jlib:make_jid(<<>>, Server, <<>>)),
+            change_shaper(S, jid:make(<<>>, Server, <<>>)),
             Version = xml:get_attr_s(<<"version">>, Attrs),
             stream_start_by_protocol_version(Version, S);
         {?NS_STREAM, false} ->
@@ -476,12 +476,12 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
             send_element(StateData, Err),
             fsm_next_state(wait_for_auth, StateData);
         {auth, _ID, set, {U, P, D, R}} ->
-            JID = jlib:make_jid(U, StateData#state.server, R),
+            JID = jid:make(U, StateData#state.server, R),
             maybe_legacy_auth(JID, El, StateData, U, P, D, R);
-        _ ->
+                        _ ->
             process_unauthenticated_stanza(StateData, El),
-            fsm_next_state(wait_for_auth, StateData)
-    end;
+                            fsm_next_state(wait_for_auth, StateData)
+                    end;
 wait_for_auth(timeout, StateData) ->
     {stop, normal, StateData};
 wait_for_auth({xmlstreamend, _Name}, StateData) ->
@@ -495,26 +495,26 @@ wait_for_auth(closed, StateData) ->
     {stop, normal, StateData}.
 
 maybe_legacy_auth(error, El, StateData, U, _P, _D, R) ->
-    ?INFO_MSG(
-       "(~w) Forbidden legacy authentication for "
-       "username '~s' with resource '~s'",
-       [StateData#state.socket, U, R]),
-    Err = jlib:make_error_reply(El, ?ERR_JID_MALFORMED),
-    send_element(StateData, Err),
-    fsm_next_state(wait_for_auth, StateData);
+                            ?INFO_MSG(
+                               "(~w) Forbidden legacy authentication for "
+                               "username '~s' with resource '~s'",
+                               [StateData#state.socket, U, R]),
+                            Err = jlib:make_error_reply(El, ?ERR_JID_MALFORMED),
+                            send_element(StateData, Err),
+                            fsm_next_state(wait_for_auth, StateData);
 maybe_legacy_auth(JID, El, StateData, U, P, D, R) ->
     case user_allowed(JID, StateData) of
-        true ->
+                        true ->
             do_legacy_auth(JID, El, StateData, U, P, D, R);
         _ ->
 
-            ?INFO_MSG(
-               "(~w) Forbidden legacy authentication for ~s",
-               [StateData#state.socket,
-                jlib:jid_to_binary(JID)]),
-            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
-            send_element(StateData, Err),
-            fsm_next_state(wait_for_auth, StateData)
+                            ?INFO_MSG(
+                               "(~w) Forbidden legacy authentication for ~s",
+                               [StateData#state.socket,
+                                jid:to_binary(JID)]),
+                            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
+                            send_element(StateData, Err),
+                            fsm_next_state(wait_for_auth, StateData)
     end.
 
 do_legacy_auth(JID, El, StateData, U, P, D, R) ->
@@ -709,7 +709,7 @@ wait_for_bind_or_resume({xmlstreamelement, El}, StateData) ->
         #iq{type = set, xmlns = ?NS_BIND, sub_el = SubEl} = IQ ->
             U = StateData#state.user,
             R1 = xml:get_path_s(SubEl, [{elem, <<"resource">>}, cdata]),
-            R = case jlib:resourceprep(R1) of
+            R = case jid:resourceprep(R1) of
                     error -> error;
                     <<>> ->
                         list_to_binary(lists:concat(
@@ -722,12 +722,12 @@ wait_for_bind_or_resume({xmlstreamelement, El}, StateData) ->
                     send_element(StateData, Err),
                     fsm_next_state(wait_for_bind_or_resume, StateData);
                 _ ->
-                    JID = jlib:make_jid(U, StateData#state.server, R),
+                    JID = jid:make(U, StateData#state.server, R),
                     Res = IQ#iq{type = result,
                                 sub_el = [#xmlel{name = <<"bind">>,
                                                  attrs = [{<<"xmlns">>, ?NS_BIND}],
                                                  children = [#xmlel{name = <<"jid">>,
-                                                                    children = [#xmlcdata{content = jlib:jid_to_binary(JID)}]}]}]},
+                                                                    children = [#xmlcdata{content = jid:to_binary(JID)}]}]}]},
                     XmlEl = jlib:iq_to_xml(Res),
                     send_element(StateData, XmlEl),
                     fsm_next_state(wait_for_session_or_sm,
@@ -806,44 +806,44 @@ maybe_open_session(El, #state{jid = JID} = StateData) ->
     end.
 
 do_open_session(El, JID, StateData) ->
-    ?INFO_MSG("(~w) Opened session for ~s",
-              [StateData#state.socket,
-               jlib:jid_to_binary(JID)]),
-    Res = jlib:make_result_iq_reply(El),
-    Packet = {jlib:jid_remove_resource(StateData#state.jid), StateData#state.jid, Res},
-    {_, _, NewStateData0, _} = send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm),
+                    ?INFO_MSG("(~w) Opened session for ~s",
+                              [StateData#state.socket,
+                               jid:to_binary(JID)]),
+                    Res = jlib:make_result_iq_reply(El),
+                    Packet = {jid:remove_resource(StateData#state.jid), StateData#state.jid, Res},
+                    {_, _, NewStateData0, _} = send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm),
     do_open_session_common(JID, NewStateData0).
 
 do_open_session_common(JID, #state{user = U, resource = R} = NewStateData0) ->
-    change_shaper(NewStateData0, JID),
-    {Fs, Ts, Pending} = ejabberd_hooks:run_fold(
-                          roster_get_subscription_lists,
-                          NewStateData0#state.server,
-                          {[], [], []},
-                          [U, NewStateData0#state.server]),
-    LJID = jlib:jid_tolower(jlib:jid_remove_resource(JID)),
-    Fs1 = [LJID | Fs],
-    Ts1 = [LJID | Ts],
-    PrivList =
-    ejabberd_hooks:run_fold(
-      privacy_get_user_list, NewStateData0#state.server,
-      #userlist{},
-      [U, NewStateData0#state.server]),
-    SID = {now(), self()},
-    Conn = get_conn_type(NewStateData0),
-    Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
-            {auth_module, NewStateData0#state.auth_module}],
-    ejabberd_sm:open_session(
-      SID, U, NewStateData0#state.server, R, Info),
-    NewStateData =
-    NewStateData0#state{
-      sid = SID,
-      conn = Conn,
-      pres_f = ?SETS:from_list(Fs1),
-      pres_t = ?SETS:from_list(Ts1),
-      pending_invitations = Pending,
-      privacy_list = PrivList},
-    fsm_next_state_pack(session_established,
+                    change_shaper(NewStateData0, JID),
+                    {Fs, Ts, Pending} = ejabberd_hooks:run_fold(
+                                          roster_get_subscription_lists,
+                                          NewStateData0#state.server,
+                                          {[], [], []},
+                                          [U, NewStateData0#state.server]),
+                    LJID = jid:to_lower(jid:remove_resource(JID)),
+                    Fs1 = [LJID | Fs],
+                    Ts1 = [LJID | Ts],
+                    PrivList =
+                    ejabberd_hooks:run_fold(
+                      privacy_get_user_list, NewStateData0#state.server,
+                      #userlist{},
+                      [U, NewStateData0#state.server]),
+                    SID = {now(), self()},
+                    Conn = get_conn_type(NewStateData0),
+                    Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
+                            {auth_module, NewStateData0#state.auth_module}],
+                    ejabberd_sm:open_session(
+                      SID, U, NewStateData0#state.server, R, Info),
+                    NewStateData =
+                    NewStateData0#state{
+                      sid = SID,
+                      conn = Conn,
+                      pres_f = ?SETS:from_list(Fs1),
+                      pres_t = ?SETS:from_list(Ts1),
+                      pending_invitations = Pending,
+                      privacy_list = PrivList},
+                    fsm_next_state_pack(session_established,
                         NewStateData).
 
 -spec session_established(Item :: ejabberd:xml_stream_item(),
@@ -920,9 +920,9 @@ session_established2(El, StateData) ->
     To = xml:get_attr_s(<<"to">>, Attrs),
     ToJID = case To of
                 <<>> ->
-                    jlib:make_jid(User, Server, <<>>);
+                    jid:make(User, Server, <<>>);
                 _ ->
-                    jlib:binary_to_jid(To)
+                    jid:from_binary(To)
             end,
     NewEl1 = jlib:remove_attr(<<"xmlns">>, jlib:remove_delay_tags(El)),
     NewEl = case xml:get_attr_s(<<"xml:lang">>, Attrs) of
@@ -1116,8 +1116,8 @@ handle_info({route, From, To, Packet}, StateName, StateData) ->
         PacketName ->
             case handle_routed(PacketName, From, To, Packet, StateData) of
                 {true, NewAttrs, NewState} ->
-                    Attrs2 = jlib:replace_from_to_attrs(jlib:jid_to_binary(From),
-                                                        jlib:jid_to_binary(To),
+                    Attrs2 = jlib:replace_from_to_attrs(jid:to_binary(From),
+                                                        jid:to_binary(To),
                                                         NewAttrs),
                     FixedPacket = Packet#xmlel{attrs = Attrs2},
                     ejabberd_hooks:run(user_receive_packet,
@@ -1253,7 +1253,7 @@ handle_routed_broadcast({privacy_list, PrivList, PrivListName}, StateData) ->
             {new_state, StateData};
         NewPL ->
             PrivPushIQ = privacy_list_push_iq(PrivListName),
-            F = jlib:jid_remove_resource(StateData#state.jid),
+            F = jid:remove_resource(StateData#state.jid),
             T = StateData#state.jid,
             PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
             {send_new, F, T, PrivPushEl, StateData#state{privacy_list = NewPL}}
@@ -1298,7 +1298,7 @@ handle_routed_presence(From, To, Packet = #xmlel{attrs = Attrs}, StateData) ->
             process_presence_probe(From, To, NewState),
             {false, Attrs, NewState};
         <<"error">> ->
-            NewA = ?SETS:del_element(jlib:jid_tolower(From), State#state.pres_a),
+            NewA = ?SETS:del_element(jid:to_lower(From), State#state.pres_a),
             {true, Attrs, State#state{pres_a = NewA}};
         <<"invisible">> ->
             Attrs1 = lists:keydelete(<<"type">>, 1, Attrs),
@@ -1375,7 +1375,7 @@ terminate(_Reason, StateName, StateData) ->
                 replaced ->
                     ?INFO_MSG("(~w) Replaced session for ~s",
                               [StateData#state.socket,
-                               jlib:jid_to_binary(StateData#state.jid)]),
+                               jid:to_binary(StateData#state.jid)]),
                     From = StateData#state.jid,
                     Packet = #xmlel{name = <<"presence">>,
                                     attrs = [{<<"type">>, <<"unavailable">>}],
@@ -1396,11 +1396,11 @@ terminate(_Reason, StateName, StateData) ->
                     ?INFO_MSG("(~w) Stream ~p resumed for ~s",
                               [StateData#state.socket,
                                StateData#state.stream_mgmt_id,
-                               jlib:jid_to_binary(StateData#state.jid)]);
+                               jid:to_binary(StateData#state.jid)]);
                 _ ->
                     ?INFO_MSG("(~w) Close session for ~s",
                               [StateData#state.socket,
-                               jlib:jid_to_binary(StateData#state.jid)]),
+                               jid:to_binary(StateData#state.jid)]),
 
                     EmptySet = ?SETS:new(),
                     case StateData of
@@ -1616,7 +1616,7 @@ get_conn_type(StateData) ->
                              To :: ejabberd:jid(),
                              State :: state()) -> 'ok'.
 process_presence_probe(From, To, StateData) ->
-    LFrom = jlib:jid_tolower(From),
+    LFrom = jid:to_lower(From),
     LBareFrom = setelement(3, LFrom, <<>>),
     case StateData#state.pres_last of
         undefined ->
@@ -1639,7 +1639,7 @@ process_presence_probe(From, To, StateData) ->
                                                StateData#state.server,
                                                [From, To, Pid]),
                             %% Don't route a presence probe to oneself
-                            case jlib:are_equal_jids(From, To) of
+                            case jid:are_equal(From, To) of
                                 false ->
                                     ejabberd_router:route(To, From, Packet);
                                 true ->
@@ -1674,8 +1674,8 @@ am_i_subscribed_to_presence(LJID, LBareJID, S) ->
     andalso ?SETS:is_element(LBareJID, S#state.pres_t).
 
 lowcase_and_bare(JID) ->
-    LJID = jlib:jid_tolower(JID),
-    { LJID, jlib:jid_remove_resource(LJID) }.
+    LJID = jid:to_lower(JID),
+    { LJID, jid:remove_resource(LJID)}.
 
 invisible_to(LFrom, LBareFrom, S) ->
     ?SETS:is_element(LFrom, S#state.pres_i)
@@ -1808,7 +1808,7 @@ presence_update(From, Packet, StateData) ->
                      State :: state()) -> state().
 presence_track(From, To, Packet, StateData) ->
     #xmlel{attrs = Attrs} = Packet,
-    LTo = jlib:jid_tolower(To),
+    LTo = jid:to_lower(To),
     User = StateData#state.user,
     Server = StateData#state.server,
     case xml:get_attr_s(<<"type">>, Attrs) of
@@ -1828,28 +1828,28 @@ presence_track(From, To, Packet, StateData) ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, subscribe]),
-            check_privacy_route(From, StateData, jlib:jid_remove_resource(From),
+            check_privacy_route(From, StateData, jid:remove_resource(From),
                                 To, Packet),
             StateData;
         <<"subscribed">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, subscribed]),
-            check_privacy_route(From, StateData, jlib:jid_remove_resource(From),
+            check_privacy_route(From, StateData, jid:remove_resource(From),
                                 To, Packet),
             StateData;
         <<"unsubscribe">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, unsubscribe]),
-            check_privacy_route(From, StateData, jlib:jid_remove_resource(From),
+            check_privacy_route(From, StateData, jid:remove_resource(From),
                                 To, Packet),
             StateData;
         <<"unsubscribed">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, unsubscribed]),
-            check_privacy_route(From, StateData, jlib:jid_remove_resource(From),
+            check_privacy_route(From, StateData, jid:remove_resource(From),
                                 To, Packet),
             StateData;
         <<"error">> ->
@@ -1917,7 +1917,7 @@ is_privacy_allow(StateData, From, To, Packet, Dir) ->
                          Packet :: jlib:xmlel()) -> 'ok'.
 presence_broadcast(StateData, From, JIDSet, Packet) ->
     lists:foreach(fun(JID) ->
-                          FJID = jlib:make_jid(JID),
+                          FJID = jid:make(JID),
                           case privacy_check_packet(StateData, From, FJID, Packet, out) of
                               deny ->
                                   ok;
@@ -1937,7 +1937,7 @@ presence_broadcast_to_trusted(StateData, From, T, A, Packet) ->
       fun(JID) ->
               case ?SETS:is_element(JID, T) of
                   true ->
-                      FJID = jlib:make_jid(JID),
+                      FJID = jid:make(JID),
                       case privacy_check_packet(StateData, From, FJID, Packet, out) of
                           deny ->
                               ok;
@@ -1957,7 +1957,7 @@ presence_broadcast_first(From, StateData, Packet) ->
     ?SETS:fold(fun(JID, X) ->
                        ejabberd_router:route(
                          From,
-                         jlib:make_jid(JID),
+                         jid:make(JID),
                          #xmlel{name = <<"presence">>,
                                 attrs = [{<<"type">>, <<"probe">>}]}),
                        X
@@ -1970,7 +1970,7 @@ presence_broadcast_first(From, StateData, Packet) ->
         true ->
             As = ?SETS:fold(
                     fun(JID, A) ->
-                            FJID = jlib:make_jid(JID),
+                            FJID = jid:make(JID),
                             case privacy_check_packet(StateData, From, FJID, Packet, out) of
                                 deny ->
                                     ok;
@@ -1988,7 +1988,7 @@ presence_broadcast_first(From, StateData, Packet) ->
                     ISubscription :: from | to | both | none,
                     State :: state()) -> state().
 roster_change(IJID, ISubscription, StateData) ->
-    LIJID = jlib:jid_tolower(IJID),
+    LIJID = jid:to_lower(IJID),
     IsFrom = (ISubscription == both) or (ISubscription == from),
     IsTo   = (ISubscription == both) or (ISubscription == to),
     OldIsFrom = ?SETS:is_element(LIJID, StateData#state.pres_f),
@@ -2010,7 +2010,7 @@ roster_change(IJID, ISubscription, StateData) ->
         P ->
             ?DEBUG("roster changed for ~p~n", [StateData#state.user]),
             From = StateData#state.jid,
-            To = jlib:make_jid(IJID),
+            To = jid:make(IJID),
             Cond1 = ( (not StateData#state.pres_invis) and IsFrom
                       and (not OldIsFrom) ),
             Cond2 = ( (not IsFrom) and OldIsFrom
@@ -2206,8 +2206,8 @@ process_unauthenticated_stanza(StateData, El) ->
                     ResIQ = IQ#iq{type = error,
                                   sub_el = [?ERR_SERVICE_UNAVAILABLE]},
                     Res1 = jlib:replace_from_to(
-                             jlib:make_jid(<<>>, StateData#state.server, <<>>),
-                             jlib:make_jid(<<>>, <<>>, <<>>),
+                             jid:make(<<>>, StateData#state.server, <<>>),
+                             jid:make(<<>>, <<>>, <<>>),
                              jlib:iq_to_xml(ResIQ)),
                     send_element(StateData, jlib:remove_attr(<<"to">>, Res1));
                 _ ->
@@ -2272,13 +2272,13 @@ is_ip_blacklisted({IP,_Port}) ->
 %% @doc Check from attributes.
 -spec check_from(El, FromJID) -> Result when
       El :: jlib:xmlel(), FromJID :: ejabberd:jid(),
-      Result :: 'invalid-from'  | jlib:xmlel().
+                Result :: 'invalid-from'  | jlib:xmlel().
 check_from(El, FromJID) ->
     case xml:get_tag_attr(<<"from">>, El) of
         false ->
             El;
         {value, SJID} ->
-            JID = jlib:binary_to_jid(SJID),
+            JID = jid:from_binary(SJID),
             case JID of
                 error ->
                     'invalid-from';
@@ -2349,7 +2349,7 @@ route_blocking(What, StateData) ->
                    children = lists:map(
                                 fun(JID) ->
                                         #xmlel{name = <<"item">>,
-                                               attrs = [{<<"jid">>, jlib:jid_to_binary(JID)}]}
+                                               attrs = [{<<"jid">>, jid:to_binary(JID)}]}
                                 end, JIDs)};
         {unblock, JIDs} ->
             #xmlel{name = <<"unblock">>,
@@ -2357,7 +2357,7 @@ route_blocking(What, StateData) ->
                    children = lists:map(
                                 fun(JID) ->
                                         #xmlel{name = <<"item">>,
-                                               attrs = [{<<"jid">>, jlib:jid_to_binary(JID)}]}
+                                               attrs = [{<<"jid">>, jid:to_binary(JID)}]}
                                 end, JIDs)};
         unblock_all ->
             #xmlel{name = <<"unblock">>,
@@ -2366,7 +2366,7 @@ route_blocking(What, StateData) ->
     PrivPushIQ = #iq{type = set, xmlns = ?NS_BLOCKING,
                      id = <<"push">>,
                      sub_el = [SubEl]},
-    F = jlib:jid_remove_resource(StateData#state.jid),
+    F = jid:remove_resource(StateData#state.jid),
     T = StateData#state.jid,
     PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
     ejabberd_router:route(F, T, PrivPushEl),
@@ -2375,9 +2375,6 @@ route_blocking(What, StateData) ->
     %% Privacy List pushes
     ok.
 
-%%%----------------------------------------------------------------------
-%%% JID Set memory footprint reduction code
-%%%----------------------------------------------------------------------
 
 -type pack_tree() :: gb_trees:tree(binary() | ejabberd:simple_jid(),
                                    binary() | ejabberd:simple_jid()).
@@ -2808,7 +2805,7 @@ add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     end.
 
 timestamp_xml(Server, Time) ->
-    FromJID = jlib:make_jid(<<>>, Server, <<>>),
+    FromJID = jid:make(<<>>, Server, <<>>),
     jlib:timestamp_to_xml(Time, utc, FromJID, <<"SM Storage">>).
 
 defer_resource_constraint_check(#state{stream_mgmt_constraint_check_tref = undefined} = State)->

--- a/apps/ejabberd/src/ejabberd_commands.erl
+++ b/apps/ejabberd/src/ejabberd_commands.erl
@@ -437,7 +437,7 @@ check_access(_, noauth) ->
 check_access(Access, Auth) ->
     {ok, User, Server} = check_auth(Auth),
     %% Check this user has access permission
-    case acl:match_rule(Server, Access, jlib:make_jid(User, Server, <<"">>)) of
+    case acl:match_rule(Server, Access, jid:make(User, Server, <<"">>)) of
         allow -> true;
         deny -> false
     end.

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -261,7 +261,7 @@ normalize_hosts(Hosts) ->
 normalize_hosts([], PrepHosts) ->
     lists:reverse(PrepHosts);
 normalize_hosts([Host|Hosts], PrepHosts) ->
-    case jlib:nodeprep(host_to_binary(Host)) of
+    case jid:nodeprep(host_to_binary(Host)) of
         error ->
             ?ERROR_MSG("Can't load config file: "
                        "invalid host name [~p]", [Host]),

--- a/apps/ejabberd/src/ejabberd_rdbms.erl
+++ b/apps/ejabberd/src/ejabberd_rdbms.erl
@@ -89,7 +89,7 @@ stop_odbc(Host) ->
 %% @doc Returns true if we have configured odbc_server for the given host
 -spec needs_odbc(_) -> boolean().
 needs_odbc(Host) ->
-    LHost = jlib:nameprep(Host),
+    LHost = jid:nameprep(Host),
     case ejabberd_config:get_local_option({odbc_server, LHost}) of
         undefined ->
             false;

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -106,7 +106,7 @@ register_route(Domain) ->
 -spec register_route(Domain :: domain(),
                      Handler :: handler()) -> any().
 register_route(Domain, Handler) ->
-    register_route_to_ldomain(jlib:nameprep(Domain), Domain, Handler).
+    register_route_to_ldomain(jid:nameprep(Domain), Domain, Handler).
 
 -spec register_routes([domain()]) -> 'ok'.
 register_routes(Domains) ->
@@ -136,7 +136,7 @@ make_handler({apply, Module, Function} = Handler)
     Handler.
 
 unregister_route(Domain) ->
-    case jlib:nameprep(Domain) of
+    case jid:nameprep(Domain) of
         error ->
             erlang:error({invalid_domain, Domain});
         LDomain ->

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -275,8 +275,8 @@ do_route(From, To, Packet) ->
         {atomic, Pid} when is_pid(Pid) ->
             ?DEBUG("sending to process ~p~n", [Pid]),
             #xmlel{attrs = Attrs} = Packet,
-            NewAttrs = jlib:replace_from_to_attrs(jlib:jid_to_binary(From),
-                                                  jlib:jid_to_binary(To),
+            NewAttrs = jlib:replace_from_to_attrs(jid:to_binary(From),
+                                                  jid:to_binary(To),
                                                   Attrs),
             #jid{lserver = MyServer} = From,
             ejabberd_hooks:run(
@@ -357,7 +357,7 @@ choose_pid(From, Pids) ->
     % Use sticky connections based on the JID of the sender (whithout
     % the resource to ensure that a muc room always uses the same
     % connection)
-    Pid = lists:nth(erlang:phash(jlib:jid_remove_resource(From), length(Pids1)),
+    Pid = lists:nth(erlang:phash(jid:remove_resource(From), length(Pids1)),
                     Pids1),
     ?DEBUG("Using ejabberd_s2s_out ~p~n", [Pid]),
     Pid.
@@ -416,7 +416,7 @@ new_connection(MyServer, Server, From, FromTo,
 -spec max_s2s_connections_number(fromto()) -> pos_integer().
 max_s2s_connections_number({From, To}) ->
     case acl:match_rule(
-           From, max_s2s_connections, jlib:make_jid(<<"">>, To, <<"">>)) of
+           From, max_s2s_connections, jid:make(<<"">>, To, <<"">>)) of
         Max when is_integer(Max) -> Max;
         _ -> ?DEFAULT_MAX_S2S_CONNECTIONS_NUMBER
     end.
@@ -424,7 +424,7 @@ max_s2s_connections_number({From, To}) ->
 -spec max_s2s_connections_number_per_node(fromto()) -> pos_integer().
 max_s2s_connections_number_per_node({From, To}) ->
     case acl:match_rule(
-           From, max_s2s_connections_per_node, jlib:make_jid(<<"">>, To, <<"">>)) of
+           From, max_s2s_connections_per_node, jid:make(<<"">>, To, <<"">>)) of
         Max when is_integer(Max) -> Max;
         _ -> ?DEFAULT_MAX_S2S_CONNECTIONS_NUMBER_PER_NODE
     end.

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -357,7 +357,7 @@ choose_pid(From, Pids) ->
     % Use sticky connections based on the JID of the sender (whithout
     % the resource to ensure that a muc room always uses the same
     % connection)
-    Pid = lists:nth(erlang:phash(jid:remove_resource(From), length(Pids1)),
+    Pid = lists:nth(erlang:phash(jid:to_bare(From), length(Pids1)),
                     Pids1),
     ?DEBUG("Using ejabberd_s2s_out ~p~n", [Pid]),
     Pid.

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -988,8 +988,8 @@ bounce_element(El, Error) ->
         <<"result">> -> ok;
         _ ->
             Err = jlib:make_error_reply(El, Error),
-            From = jlib:binary_to_jid(xml:get_tag_attr_s(<<"from">>, El)),
-            To = jlib:binary_to_jid(xml:get_tag_attr_s(<<"to">>, El)),
+            From = jid:from_binary(xml:get_tag_attr_s(<<"from">>, El)),
+            To = jid:from_binary(xml:get_tag_attr_s(<<"to">>, El)),
             ejabberd_router:route(To, From, Err)
     end.
 

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -260,10 +260,10 @@ stream_established({xmlstreamelement, El}, StateData) ->
                   %% when accept packets from any address.
                   %% In this case, the component can send packet of
                   %% behalf of the server users.
-                  false -> jlib:binary_to_jid(From);
+                  false -> jid:from_binary(From);
                   %% The default is the standard behaviour in XEP-0114
                   _ ->
-                      FromJID1 = jlib:binary_to_jid(From),
+                      FromJID1 = jid:from_binary(From),
                       case FromJID1 of
                           #jid{lserver = Server} ->
                               case lists:member(Server, StateData#state.hosts) of
@@ -276,7 +276,7 @@ stream_established({xmlstreamelement, El}, StateData) ->
     To = xml:get_attr_s(<<"to">>, Attrs),
     ToJID = case To of
                 <<>> -> error;
-                _ -> jlib:binary_to_jid(To)
+                _ -> jid:from_binary(To)
             end,
     if ((Name == <<"iq">>) or
         (Name == <<"message">>) or
@@ -356,11 +356,11 @@ handle_info({route, From, To, Packet}, StateName, StateData) ->
     case acl:match_rule(global, StateData#state.access, From) of
         allow ->
            #xmlel{name =Name, attrs = Attrs,children = Els} = Packet,
-            Attrs2 = jlib:replace_from_to_attrs(jlib:jid_to_binary(From),
-                                                jlib:jid_to_binary(To),
-                                                Attrs),
-            Text = exml:to_binary( #xmlel{name = Name, attrs = Attrs2,children = Els}),
-            send_text(StateData, Text);
+           Attrs2 = jlib:replace_from_to_attrs(jid:to_binary(From),
+                                               jid:to_binary(To),
+                                               Attrs),
+           Text = exml:to_binary(#xmlel{name = Name, attrs = Attrs2, children = Els}),
+           send_text(StateData, Text);
         deny ->
             Err = jlib:make_error_reply(Packet, ?ERR_NOT_ALLOWED),
             ejabberd_router:route_error(To, From, Err, Packet)

--- a/apps/ejabberd/src/extauth.erl
+++ b/apps/ejabberd/src/extauth.erl
@@ -123,7 +123,7 @@ remove_user(User, Server, Password) ->
 
 -spec call_port(ejabberd:server(), [any(),...]) -> any().
 call_port(Server, Msg) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     ProcessName = get_process_name(LServer, random_instance(get_instances(LServer))),
     ProcessName ! {call, self(), Msg},
     receive

--- a/apps/ejabberd/src/jid.erl
+++ b/apps/ejabberd/src/jid.erl
@@ -1,0 +1,212 @@
+%%==============================================================================
+%% Copyright 2015 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(jid).
+
+-export([make/3]).
+-export([make/1]).
+-export([are_equal/2]).
+-export([from_binary/1]).
+-export([to_binary/1]).
+-export([is_nodename/1]).
+-export([nodeprep/1]).
+-export([nameprep/1]).
+-export([resourceprep/1]).
+-export([to_lower/1]).
+-export([remove_resource/1]).
+-export([replace_resource/2]).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("exml/include/exml_stream.hrl"). % only used to define stream types
+-include("jlib.hrl").
+
+-define(SANE_LIMIT, 1024).
+
+-spec make(User :: ejabberd:user(), Server :: ejabberd:server(),
+           Resource :: ejabberd:resource()) ->
+    ejabberd:jid()  | error.
+make(User, Server, Resource) ->
+    case nodeprep(User) of
+        error -> error;
+        LUser ->
+            case nameprep(Server) of
+                error -> error;
+                LServer ->
+                    case resourceprep(Resource) of
+                        error -> error;
+                        LResource ->
+                            #jid{user = User,
+                                 server = Server,
+                                 resource = Resource,
+                                 luser = LUser,
+                                 lserver = LServer,
+                                 lresource = LResource}
+                    end
+            end
+    end.
+
+-spec make(ejabberd:simple_jid()) ->  ejabberd:jid()  | error.
+make({User, Server, Resource}) ->
+    make(User, Server, Resource).
+
+
+-spec are_equal(ejabberd:jid(), ejabberd:jid()) ->  boolean().
+are_equal(#jid{luser = LUser, lserver = LServer, lresource = LRes},
+          #jid{luser = LUser, lserver = LServer, lresource = LRes}) ->
+    true;
+are_equal(_, _) ->
+    false.
+
+
+-spec from_binary(binary()) ->  error  | ejabberd:jid().
+from_binary(J) ->
+    binary_to_jid1(J, []).
+
+
+-spec binary_to_jid1(binary(), [byte()]) -> 'error' | ejabberd:jid().
+binary_to_jid1(<<$@, _J/binary>>, []) ->
+    error;
+binary_to_jid1(<<$@, J/binary>>, N) ->
+    binary_to_jid2(J, lists:reverse(N), []);
+binary_to_jid1(<<$/, _J/binary>>, []) ->
+    error;
+binary_to_jid1(<<$/, J/binary>>, N) ->
+    binary_to_jid3(J, [], lists:reverse(N), []);
+binary_to_jid1(<<C, J/binary>>, N) ->
+    binary_to_jid1(J, [C | N]);
+binary_to_jid1(<<>>, []) ->
+    error;
+binary_to_jid1(<<>>, N) ->
+    make(<<>>, list_to_binary(lists:reverse(N)), <<>>).
+
+
+%% @doc Only one "@" is admitted per JID
+-spec binary_to_jid2(binary(),[byte()],[byte()]) -> 'error' | ejabberd:jid().
+binary_to_jid2(<<$@, _J/binary>>, _N, _S) ->
+    error;
+binary_to_jid2(<<$/, _J/binary>>, _N, []) ->
+    error;
+binary_to_jid2(<<$/, J/binary>>, N, S) ->
+    binary_to_jid3(J, N, lists:reverse(S), []);
+binary_to_jid2(<<C, J/binary>>, N, S) ->
+    binary_to_jid2(J, N, [C | S]);
+binary_to_jid2(<<>>, _N, []) ->
+    error;
+binary_to_jid2(<<>>, N, S) ->
+    make(list_to_binary(N), list_to_binary(lists:reverse(S)), <<>>).
+
+
+-spec binary_to_jid3(binary(),[byte()],[byte()],[byte()]) -> 'error' | ejabberd:jid().
+binary_to_jid3(<<C, J/binary>>, N, S, R) ->
+    binary_to_jid3(J, N, S, [C | R]);
+binary_to_jid3(<<>>, N, S, R) ->
+    make(list_to_binary(N), list_to_binary(S), list_to_binary(lists:reverse(R))).
+
+
+-spec to_binary(ejabberd:simple_jid()  | ejabberd:jid()) ->  binary().
+to_binary(#jid{user = User, server = Server, resource = Resource}) ->
+    to_binary({User, Server, Resource});
+to_binary({Node, Server, Resource}) ->
+    S1 = case Node of
+             <<>> ->
+                 <<>>;
+             _ ->
+                 <<Node/binary, "@">>
+         end,
+    S2 = <<S1/binary, Server/binary>>,
+    S3 = case Resource of
+             <<>> ->
+                 S2;
+             _ ->
+                 <<S2/binary, "/", Resource/binary>>
+         end,
+    S3.
+
+-spec is_nodename(<<>> | binary()) -> boolean().
+is_nodename(<<>>) ->
+    false;
+is_nodename(J) ->
+    nodeprep(J) /= error.
+
+-spec nodeprep(ejabberd:user()) -> 'error' | ejabberd:lserver().
+nodeprep(S) when is_binary(S), size(S) < ?SANE_LIMIT ->
+    R = stringprep:nodeprep(S),
+    if
+        size(R) < ?SANE_LIMIT -> R;
+        true -> error
+    end;
+nodeprep(_) ->
+    error.
+
+
+-spec nameprep(ejabberd:server()) -> 'error' | ejabberd:luser().
+nameprep(S) when is_binary(S), size(S) < ?SANE_LIMIT ->
+    R = stringprep:nameprep(S),
+    if
+        size(R) < ?SANE_LIMIT -> R;
+        true -> error
+    end;
+nameprep(_) ->
+    error.
+
+
+-spec resourceprep(ejabberd:resource()) ->
+    'error' | ejabberd:lresource().
+resourceprep(S) when size(S) < ?SANE_LIMIT ->
+    R = stringprep:resourceprep(S),
+    if
+        size(R) < ?SANE_LIMIT -> R;
+        true -> error
+    end;
+resourceprep(_) ->
+    error.
+
+
+-spec to_lower(JID :: ejabberd:simple_jid() | ejabberd:jid()) ->
+    error | ejabberd:simple_jid().
+to_lower(#jid{luser = U, lserver = S, lresource = R}) ->
+    {U, S, R};
+to_lower({U, S, R}) ->
+    case jid:nodeprep(U) of
+        error -> error;
+        LUser ->
+            case jid:nameprep(S) of
+                error -> error;
+                LServer ->
+                    case jid:resourceprep(R) of
+                        error -> error;
+                        LResource ->
+                            {LUser, LServer, LResource}
+                    end
+            end
+    end.
+
+
+-spec remove_resource(ejabberd:simple_jid()  | ejabberd:jid()) ->
+    ejabberd:simple_jid()  | ejabberd:jid().
+remove_resource(#jid{} = JID) ->
+    JID#jid{resource = <<>>, lresource = <<>>};
+remove_resource({U, S, _R}) ->
+    {U, S, <<>>}.
+
+
+-spec replace_resource(ejabberd:jid(), ejabberd:resource()) ->
+                          error  | ejabberd:jid().
+replace_resource(JID, Resource) ->
+    case resourceprep(Resource) of
+        error -> error;
+        LResource ->
+            JID#jid{resource = Resource, lresource = LResource}
+    end.

--- a/apps/ejabberd/src/jid.erl
+++ b/apps/ejabberd/src/jid.erl
@@ -25,7 +25,7 @@
 -export([nameprep/1]).
 -export([resourceprep/1]).
 -export([to_lower/1]).
--export([remove_resource/1]).
+-export([to_bare/1]).
 -export([replace_resource/2]).
 
 -include_lib("exml/include/exml.hrl").
@@ -194,11 +194,11 @@ to_lower({U, S, R}) ->
     end.
 
 
--spec remove_resource(ejabberd:simple_jid()  | ejabberd:jid()) ->
-    ejabberd:simple_jid()  | ejabberd:jid().
-remove_resource(#jid{} = JID) ->
+-spec to_bare(ejabberd:simple_jid()  | ejabberd:jid()) -> 
+                 ejabberd:simple_jid()  | ejabberd:jid().
+to_bare(#jid{} = JID) ->
     JID#jid{resource = <<>>, lresource = <<>>};
-remove_resource({U, S, _R}) ->
+to_bare({U, S, _R}) ->
     {U, S, <<>>}.
 
 

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -68,11 +68,12 @@
          stanza_errort/5,
          stream_error/1,
          stream_errort/3,
-	     remove_delay_tags/1]).
+         remove_delay_tags/1]).
 
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl"). % only used to define stream types
 -include("jlib.hrl").
+-include("ejabberd.hrl").
 
 -type xmlel()           :: #xmlel{}.
 %% Stream types defined in exml/include/exml_stream.hrl
@@ -181,7 +182,7 @@ make_config_change_message(Status) ->
                       Reason :: binary()) -> xmlel().
 make_invitation(From, Password, Reason) ->
     Elements = [#xmlel{name = <<"invite">>,
-                       attrs = [{<<"from">>, jlib:jid_to_binary(From)}]}],
+                       attrs = [{<<"from">>, jid:to_binary(From)}]}],
     Elements2 = case Password of
         <<>> -> Elements;
         _ -> [#xmlel{name = <<"password">>,
@@ -218,7 +219,7 @@ form_field({Var, Type, Value}) ->
 make_voice_approval_form(From, Nick, Role) ->
   Fields = [{<<"FORM_TYPE">>, <<"hidden">>, ?NS_MUC_REQUEST},
     {<<"muc#role">>, <<"text-single">>, Role, <<"Request role">>},
-    {<<"muc#jid">>, <<"jid-single">>, jid_to_binary(From), <<"User ID">>},
+    {<<"muc#jid">>, <<"jid-single">>, jid:to_binary(From), <<"User ID">>},
     {<<"muc#roomnick">>, <<"text-single">>, Nick, <<"Room Nickname">>},
     {<<"muc#request_allow">>, <<"boolean">>, <<"false">>, <<"Grant voice to this person?">>}
   ],
@@ -250,8 +251,8 @@ replace_from_to_attrs(From, To, Attrs) ->
                       To :: ejabberd:simple_jid() | ejabberd:jid(),
                       XE :: xmlel()) -> xmlel().
 replace_from_to(From, To, XE = #xmlel{attrs = Attrs}) ->
-    NewAttrs = replace_from_to_attrs(jlib:jid_to_binary(From),
-                                     jlib:jid_to_binary(To),
+    NewAttrs = replace_from_to_attrs(jid:to_binary(From),
+                                     jid:to_binary(To),
                                      Attrs),
     XE#xmlel{attrs = NewAttrs}.
 
@@ -266,188 +267,79 @@ remove_attr(Attr, XE = #xmlel{attrs = Attrs}) ->
                Server   :: ejabberd:server(),
                Resource :: ejabberd:resource()) -> ejabberd:jid() | error.
 make_jid(User, Server, Resource) ->
-    case nodeprep(User) of
-        error -> error;
-        LUser ->
-            case nameprep(Server) of
-                error -> error;
-                LServer ->
-                    case resourceprep(Resource) of
-                        error -> error;
-                        LResource ->
-                            #jid{user = User,
-                                 server = Server,
-                                 resource = Resource,
-                                 luser = LUser,
-                                 lserver = LServer,
-                                 lresource = LResource}
-                    end
-            end
-    end.
-
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:make(User, Server, Resource).
 
 -spec make_jid(ejabberd:simple_jid()) -> ejabberd:jid() | error.
 make_jid({User, Server, Resource}) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
     make_jid(User, Server, Resource).
 
 -spec are_equal_jids(ejabberd:jid(), ejabberd:jid()) -> boolean().
-are_equal_jids(#jid{luser = LUser, lserver = LServer, lresource = LRes},
-               #jid{luser = LUser, lserver = LServer, lresource = LRes}) ->
-    true;
-are_equal_jids(_, _) ->
-    false.
+are_equal_jids(JID1, JID2) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:are_equal(JID1, JID2).
 
 
 -spec binary_to_jid(binary()) -> 'error' | ejabberd:jid().
 binary_to_jid(J) ->
-    binary_to_jid1(J, []).
-
-
--spec binary_to_jid1(binary(), [byte()]) -> 'error' | ejabberd:jid().
-binary_to_jid1(<<$@, _J/binary>>, []) ->
-    error;
-binary_to_jid1(<<$@, J/binary>>, N) ->
-    binary_to_jid2(J, lists:reverse(N), []);
-binary_to_jid1(<<$/, _J/binary>>, []) ->
-    error;
-binary_to_jid1(<<$/, J/binary>>, N) ->
-    binary_to_jid3(J, [], lists:reverse(N), []);
-binary_to_jid1(<<C, J/binary>>, N) ->
-    binary_to_jid1(J, [C | N]);
-binary_to_jid1(<<>>, []) ->
-    error;
-binary_to_jid1(<<>>, N) ->
-    make_jid(<<>>, list_to_binary(lists:reverse(N)), <<>>).
-
-
-%% @doc Only one "@" is admitted per JID
--spec binary_to_jid2(binary(),[byte()],[byte()]) -> 'error' | ejabberd:jid().
-binary_to_jid2(<<$@, _J/binary>>, _N, _S) ->
-    error;
-binary_to_jid2(<<$/, _J/binary>>, _N, []) ->
-    error;
-binary_to_jid2(<<$/, J/binary>>, N, S) ->
-    binary_to_jid3(J, N, lists:reverse(S), []);
-binary_to_jid2(<<C, J/binary>>, N, S) ->
-    binary_to_jid2(J, N, [C | S]);
-binary_to_jid2(<<>>, _N, []) ->
-    error;
-binary_to_jid2(<<>>, N, S) ->
-    make_jid(list_to_binary(N), list_to_binary(lists:reverse(S)), <<>>).
-
-
--spec binary_to_jid3(binary(),[byte()],[byte()],[byte()]) -> 'error' | ejabberd:jid().
-binary_to_jid3(<<C, J/binary>>, N, S, R) ->
-    binary_to_jid3(J, N, S, [C | R]);
-binary_to_jid3(<<>>, N, S, R) ->
-    make_jid(list_to_binary(N), list_to_binary(S), list_to_binary(lists:reverse(R))).
-
-
-
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:from_binary(J).
 
 
 -spec jid_to_binary(ejabberd:simple_jid() | ejabberd:jid()) -> binary().
-jid_to_binary(#jid{user = User, server = Server, resource = Resource}) ->
-    jid_to_binary({User, Server, Resource});
-jid_to_binary({Node, Server, Resource}) ->
-    S1 = case Node of
-             <<>> ->
-                 <<>>;
-             _ ->
-                 <<Node/binary, "@">>
-         end,
-    S2 = <<S1/binary, Server/binary>>,
-    S3 = case Resource of
-             <<>> ->
-                 S2;
-             _ ->
-                 <<S2/binary, "/", Resource/binary>>
-         end,
-    S3.
+jid_to_binary(JID) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:to_binary(JID).
 
 -spec is_nodename(<<>> | binary()) -> boolean().
-is_nodename(<<>>) ->
-    false;
 is_nodename(J) ->
-    nodeprep(J) /= error.
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:is_nodename(J).
 
--define(SANE_LIMIT, 1024).
 -spec nodeprep(ejabberd:user()) -> 'error' | ejabberd:lserver().
-nodeprep(S) when is_binary(S), size(S) < ?SANE_LIMIT ->
-    R = stringprep:nodeprep(S),
-    if
-        size(R) < ?SANE_LIMIT -> R;
-        true -> error
-    end;
-nodeprep(_) ->
-    error.
+nodeprep(S) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:nodeprep(S).
 
 
 -spec nameprep(ejabberd:server()) -> 'error' | ejabberd:luser().
-nameprep(S) when is_binary(S), size(S) < ?SANE_LIMIT ->
-    R = stringprep:nameprep(S),
-    if
-        size(R) < ?SANE_LIMIT -> R;
-        true -> error
-    end;
-nameprep(_) ->
-    error.
-
+nameprep(S) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:nameprep(S).
 
 -spec resourceprep(ejabberd:resource()) ->
-                                        'error' | ejabberd:lresource().
-resourceprep(S) when size(S) < ?SANE_LIMIT ->
-    R = stringprep:resourceprep(S),
-    if
-        size(R) < ?SANE_LIMIT -> R;
-        true -> error
-    end;
-resourceprep(_) ->
-    error.
+    'error' | ejabberd:lresource().
+resourceprep(S) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:resourceprep(S).
 
 
 %% @doc You are a bad person if you use this function.
 -spec jid_tolower(JID :: ejabberd:simple_jid() | ejabberd:jid()
                  ) -> error | ejabberd:simple_jid().
-jid_tolower(Any) -> jid_to_lower(Any).
-
+jid_tolower(Any) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:to_lower(Any).
 
 -spec jid_to_lower(JID :: ejabberd:simple_jid() | ejabberd:jid()
                  ) -> error | ejabberd:simple_jid().
-jid_to_lower(#jid{luser = U, lserver = S, lresource = R}) ->
-    {U, S, R};
-jid_to_lower({U, S, R}) ->
-    case nodeprep(U) of
-        error -> error;
-        LUser ->
-            case nameprep(S) of
-                error -> error;
-                LServer ->
-                    case resourceprep(R) of
-                        error -> error;
-                        LResource ->
-                            {LUser, LServer, LResource}
-                    end
-            end
-    end.
-
+jid_to_lower(JID) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:to_lower(JID).
 
 -spec jid_remove_resource(ejabberd:simple_jid() | ejabberd:jid()) ->
                           ejabberd:simple_jid() | ejabberd:jid().
-jid_remove_resource(#jid{} = JID) ->
-    JID#jid{resource = <<>>, lresource = <<>>};
-jid_remove_resource({U, S, _R}) ->
-    {U, S, <<>>}.
+jid_remove_resource(JID) ->
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:remove_resource(JID).
 
 
 -spec jid_replace_resource(ejabberd:jid(), ejabberd:resource()) ->
                                                   'error' | ejabberd:jid().
 jid_replace_resource(JID, Resource) ->
-    case resourceprep(Resource) of
-        error -> error;
-        LResource ->
-            JID#jid{resource = Resource, lresource = LResource}
-    end.
+    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
+    jid:replace_resource(JID, Resource).
 
 
 -spec iq_query_info(xmlel()) -> 'invalid' | 'not_iq' | 'reply' | ejabberd:iq().
@@ -729,7 +621,7 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
 timestamp_to_xml(DateTime, Timezone, FromJID, Desc) ->
     {T_string, Tz_string} = timestamp_to_iso(DateTime, Timezone),
     Text = [#xmlcdata{content = Desc}],
-    From = jlib:jid_to_binary(FromJID),
+    From = jid:to_binary(FromJID),
     #xmlel{name = <<"delay">>,
            attrs = [{<<"xmlns">>, ?NS_DELAY},
                     {<<"from">>, From},

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -332,7 +332,7 @@ jid_to_lower(JID) ->
                           ejabberd:simple_jid() | ejabberd:jid().
 jid_remove_resource(JID) ->
     ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:remove_resource(JID).
+    jid:to_bare(JID).
 
 
 -spec jid_replace_resource(ejabberd:jid(), ejabberd:resource()) ->

--- a/apps/ejabberd/src/mod_adhoc.erl
+++ b/apps/ejabberd/src/mod_adhoc.erl
@@ -123,7 +123,7 @@ get_sm_commands(Acc, _From, #jid{lserver = LServer} = To, <<"">>, Lang) ->
                         _ -> []
                     end,
             Nodes = [#xmlel{name = <<"item">>,
-                            attrs = [{<<"jid">>, jlib:jid_to_binary(To)},
+                            attrs = [{<<"jid">>, jid:to_binary(To)},
                                      {<<"node">>, ?NS_COMMANDS},
                                      {<<"name">>, translate:translate(Lang, <<"Commands">>)}]}],
             {result, Items ++ Nodes}

--- a/apps/ejabberd/src/mod_admin_extra_last.erl
+++ b/apps/ejabberd/src/mod_admin_extra_last.erl
@@ -63,7 +63,7 @@ commands() ->
 -spec set_last(ejabberd:user(), ejabberd:server(), _, _) -> 'ok'.
 set_last(User, Server, Timestamp, Status) ->
     Mod = get_lastactivity_module(Server),
-    Mod:store_last_info(jlib:nodeprep(User), jlib:nameprep(Server), Timestamp, Status),
+    Mod:store_last_info(jid:nodeprep(User), jid:nameprep(Server), Timestamp, Status),
     ok.
 
 

--- a/apps/ejabberd/src/mod_admin_extra_private.erl
+++ b/apps/ejabberd/src/mod_admin_extra_private.erl
@@ -70,8 +70,8 @@ commands() ->
 -spec private_get(ejabberd:user(), ejabberd:server(), binary(), binary()) -> binary().
 private_get(Username, Host, Element, Ns) ->
     M = get_private_module(Host),
-    From = jlib:make_jid(Username, Host, <<"">>),
-    To = jlib:make_jid(Username, Host, <<"">>),
+    From = jid:make(Username, Host, <<"">>),
+    To = jid:make(Username, Host, <<"">>),
     IQ = {iq, <<"">>, get, ?NS_PRIVATE, <<"">>,
           #xmlel{ name = <<"query">>,
                  attrs = [{<<"xmlns">>,?NS_PRIVATE}],
@@ -99,8 +99,8 @@ private_set(Username, Host, ElementString) ->
 -spec private_set2(ejabberd:user(), ejabberd:server(), Xml :: jlib:xmlel()) -> ok.
 private_set2(Username, Host, Xml) ->
     M = get_private_module(Host),
-    From = jlib:make_jid(Username, Host, <<"">>),
-    To = jlib:make_jid(Username, Host, <<"">>),
+    From = jid:make(Username, Host, <<"">>),
+    To = jid:make(Username, Host, <<"">>),
     IQ = {iq, <<"">>, set, ?NS_PRIVATE, <<"">>,
           #xmlel{ name = <<"query">>,
                  attrs = [{<<"xmlns">>,?NS_PRIVATE}],

--- a/apps/ejabberd/src/mod_admin_extra_sessions.erl
+++ b/apps/ejabberd/src/mod_admin_extra_sessions.erl
@@ -199,8 +199,8 @@ kick_session(User, Server, Resource, ReasonText) ->
         Reason :: binary()) -> ok | {error, lager_not_started}.
 kick_this_session(User, Server, Resource, Reason) ->
     ejabberd_sm:route(
-        jlib:make_jid(<<"">>, <<"">>, <<"">>),
-        jlib:make_jid(User, Server, Resource),
+        jid:make(<<"">>, <<"">>, <<"">>),
+        jid:make(User, Server, Resource),
         {broadcast, {exit, Reason}}).
 
 

--- a/apps/ejabberd/src/mod_admin_extra_srg.erl
+++ b/apps/ejabberd/src/mod_admin_extra_srg.erl
@@ -137,7 +137,7 @@ srg_get_info(Group, Host) ->
 -spec srg_get_members(group(), ejabberd:server()) -> [binary()].
 srg_get_members(Group, Host) ->
     Members = mod_shared_roster:get_group_explicit_users(Host,Group),
-    [jlib:jid_to_binary(jlib:make_jid(MUser, MServer, <<"">>))
+    [jid:to_binary(jid:make(MUser, MServer, <<"">>))
      || {MUser, MServer} <- Members].
 
 

--- a/apps/ejabberd/src/mod_admin_extra_stanza.erl
+++ b/apps/ejabberd/src/mod_admin_extra_stanza.erl
@@ -96,8 +96,8 @@ send_message_headline(From, To, Subject, Body) ->
 -spec send_packet_all_resources(FromJIDStr :: binary(), ToJIDString :: binary(),
                                 jlib:xmlel()) -> 'ok'.
 send_packet_all_resources(FromJIDString, ToJIDString, Packet) ->
-    FromJID = jlib:binary_to_jid(FromJIDString),
-    ToJID = jlib:binary_to_jid(ToJIDString),
+    FromJID = jid:from_binary(FromJIDString),
+    ToJID = jid:from_binary(ToJIDString),
     ToUser = ToJID#jid.user,
     ToServer = ToJID#jid.server,
     case ToJID#jid.resource of
@@ -129,7 +129,7 @@ send_packet_all_resources(FromJID, ToUser, ToServer, Packet) ->
 -spec send_packet_all_resources(ejabberd:jid(), ToU :: binary(), ToS :: binary(),
                                 ToR :: binary(), jlib:xmlel()) -> 'ok'.
 send_packet_all_resources(FromJID, ToU, ToS, ToR, Packet) ->
-    ToJID = jlib:make_jid(ToU, ToS, ToR),
+    ToJID = jid:make(ToU, ToS, ToR),
     ejabberd_router:route(FromJID, ToJID, Packet).
 
 

--- a/apps/ejabberd/src/mod_admin_extra_vcard.erl
+++ b/apps/ejabberd/src/mod_admin_extra_vcard.erl
@@ -145,7 +145,7 @@ get_module_resource(Server) ->
             -> [Cdata :: binary()] | none().
 get_vcard_content(User, Server, Data) ->
     [{_, Module, Function, _Opts}] = ets:lookup(sm_iqtable, {?NS_VCARD, Server}),
-    JID = jlib:make_jid(User, Server, list_to_binary(get_module_resource(Server))),
+    JID = jid:make(User, Server, list_to_binary(get_module_resource(Server))),
     IQ = #iq{type = get, xmlns = ?NS_VCARD},
     %% TODO: This may benefit from better type control
     IQr = Module:Function(JID, JID, IQ),
@@ -173,7 +173,7 @@ set_vcard_content(U, S, D, SomeContent) when is_binary(SomeContent) ->
     set_vcard_content(U, S, D, [SomeContent]);
 set_vcard_content(User, Server, Data, ContentList) ->
     [{_, Module, Function, _Opts}] = ets:lookup(sm_iqtable, {?NS_VCARD, Server}),
-    JID = jlib:make_jid(User, Server, <<>>),
+    JID = jid:make(User, Server, <<>>),
     IQ = #iq{type = get, xmlns = ?NS_VCARD},
     IQr = Module:Function(JID, JID, IQ),
 

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -177,11 +177,11 @@ is_supported_rule(_)              -> false.
 hd_host({#jid{lserver=Host}, _}) -> Host.
 
 server_jid(#jid{lserver = Host}) ->
-    jlib:binary_to_jid(Host).
+    jid:from_binary(Host).
 
 -spec message_target(hook_data()) -> jid() | undefined.
 message_target({_,El}) ->
     case exml_query:attr(El, <<"to">>) of
         undefined -> undefined;
-        J         -> jlib:binary_to_jid(J)
+        J -> jid:from_binary(J)
     end.

--- a/apps/ejabberd/src/mod_disco.erl
+++ b/apps/ejabberd/src/mod_disco.erl
@@ -457,7 +457,7 @@ get_sm_features(Acc, _From, _To, _Node, _Lang) ->
 get_user_resources(User, Server) ->
     Rs = ejabberd_sm:get_user_resources(User, Server),
     lists:map(fun(R) ->
-                JID = jlib:jid_to_binary({User, Server, R}),
+                JID = jid:to_binary({User, Server, R}),
                 #xmlel{name = <<"item">>,
                        attrs = [{<<"jid">>, JID}, {<<"name">>, User}]}
               end, lists:sort(Rs)).

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -247,7 +247,7 @@ get_last_info(LUser, LServer) ->
 
 -spec remove_user(ejabberd:user(), ejabberd:server()) -> ok | {error, term()}.
 remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     ?BACKEND:remove_user(LUser, LServer).
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -267,7 +267,7 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Packet}) ->
             undefined -> Packet;
             MessID ->
                 ?DEBUG("Archived incoming ~p", [MessID]),
-                BareTo = jid:to_binary(jid:remove_resource(To)),
+                BareTo = jid:to_binary(jid:to_bare(To)),
                 replace_archived_elem(BareTo, MessID, Packet)
         end
     end,
@@ -305,8 +305,8 @@ is_action_allowed_by_default(_Action, From, To) ->
 -spec compare_bare_jids(ejabberd:simple_jid() | ejabberd:jid(),
                         ejabberd:simple_jid() | ejabberd:jid()) -> boolean().
 compare_bare_jids(JID1, JID2) ->
-    jid:remove_resource(JID1) =:=
-    jid:remove_resource(JID2).
+    jid:to_bare(JID1) =:=
+    jid:to_bare(JID2).
 
 
 -spec action_to_shaper_name(action()) -> atom().
@@ -571,9 +571,9 @@ remove_archive(Host, ArcID, ArcJID=#jid{}) ->
                       PageSize :: non_neg_integer(), LimitPassed :: boolean(),
                       MaxResultLimit :: non_neg_integer(),
                       IsSimple :: boolean()  | opt_count) ->
-                         {ok, mod_mam:lookup_result()}
-                          | {error, 'policy-violation'}
-                          | {error, Reason :: term()}.
+    {ok, mod_mam:lookup_result()}
+    | {error, 'policy-violation'}
+    | {error, Reason :: term()}.
 lookup_messages(Host, ArcID, ArcJID, RSM, Borders, Start, End, Now,
                 WithJID, PageSize, LimitPassed, MaxResultLimit, IsSimple) ->
     StartT = os:timestamp(),
@@ -602,8 +602,8 @@ archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
                            MessID :: message_id(), ArcID :: archive_id(),
                            ArcJID :: ejabberd:jid(),
                            Now :: unix_timestamp()) ->
-                              ok  | {error, 'not-found'}
-                               | {error, Reason :: term()}.
+    ok  | {error, 'not-found'}
+    | {error, Reason :: term()}.
 purge_single_message(Host, MessID, ArcID, ArcJID, Now) ->
     ejabberd_hooks:run_fold(mam_purge_single_message, Host, ok,
         [Host, MessID, ArcID, ArcJID, Now]).
@@ -709,8 +709,8 @@ return_purge_multiple_message_iq(IQ, {error, Reason}) ->
 
 -spec return_purge_single_message_iq(ejabberd:iq(),
                                      ok  | {error, 'not-found'}
-                                      | {error, Reason :: term()}) ->
-                                        ejabberd:iq().
+                                     | {error, Reason :: term()}) ->
+    ejabberd:iq().
 return_purge_single_message_iq(IQ, ok) ->
     return_purge_success(IQ);
 return_purge_single_message_iq(IQ, {error, 'not-found'}) ->

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -144,7 +144,7 @@ max_result_limit() -> 50.
 delete_archive(Server, User)
     when is_binary(Server), is_binary(User) ->
     ?DEBUG("Remove user ~p from ~p.", [User, Server]),
-    ArcJID = jlib:make_jid(User, Server, <<>>),
+    ArcJID = jid:make(User, Server, <<>>),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     remove_archive(Host, ArcID, ArcJID),
@@ -154,7 +154,7 @@ delete_archive(Server, User)
 -spec archive_size(ejabberd:server(), ejabberd:user()) -> integer().
 archive_size(Server, User)
     when is_binary(Server), is_binary(User) ->
-    ArcJID = jlib:make_jid(User, Server, <<>>),
+    ArcJID = jid:make(User, Server, <<>>),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     archive_size(Host, ArcID, ArcJID).
@@ -163,7 +163,7 @@ archive_size(Server, User)
 -spec archive_id(ejabberd:server(), ejabberd:user()) -> integer().
 archive_id(Server, User)
     when is_binary(Server), is_binary(User) ->
-    ArcJID = jlib:make_jid(User, Server, <<>>),
+    ArcJID = jid:make(User, Server, <<>>),
     Host = server_host(ArcJID),
     archive_id_int(Host, ArcJID).
 
@@ -267,7 +267,7 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Packet}) ->
             undefined -> Packet;
             MessID ->
                 ?DEBUG("Archived incoming ~p", [MessID]),
-                BareTo = jlib:jid_to_binary(jlib:jid_remove_resource(To)),
+                BareTo = jid:to_binary(jid:remove_resource(To)),
                 replace_archived_elem(BareTo, MessID, Packet)
         end
     end,
@@ -305,8 +305,8 @@ is_action_allowed_by_default(_Action, From, To) ->
 -spec compare_bare_jids(ejabberd:simple_jid() | ejabberd:jid(),
                         ejabberd:simple_jid() | ejabberd:jid()) -> boolean().
 compare_bare_jids(JID1, JID2) ->
-    jlib:jid_remove_resource(JID1) =:=
-    jlib:jid_remove_resource(JID2).
+    jid:remove_resource(JID1) =:=
+    jid:remove_resource(JID2).
 
 
 -spec action_to_shaper_name(action()) -> atom().
@@ -383,7 +383,7 @@ handle_get_prefs_result({DefaultMode, AlwaysJIDs, NeverJIDs}, IQ) ->
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};
 handle_get_prefs_result({error, Reason}, IQ) ->
     return_error_iq(IQ, Reason).
-    
+
 
 -spec handle_lookup_messages(From :: ejabberd:jid(), ArcJID :: ejabberd:jid(),
                              IQ :: ejabberd:iq()) ->
@@ -413,7 +413,7 @@ handle_lookup_messages(
                          Start, End, Now, With,
                          PageSize, LimitPassed, max_result_limit(), IsSimple) of
     {error, 'policy-violation'} ->
-        ?DEBUG("Policy violation by ~p.", [jlib:jid_to_binary(From)]),
+        ?DEBUG("Policy violation by ~p.", [jid:to_binary(From)]),
         ErrorEl = jlib:stanza_errort(<<"">>, <<"modify">>, <<"policy-violation">>,
                                  <<"en">>, <<"Too many results">>),
         IQ#iq{type = error, sub_el = [ErrorEl]};
@@ -560,16 +560,20 @@ remove_archive(Host, ArcID, ArcJID=#jid{}) ->
 %% `opt_count' can be passed inside an IQ.
 %% Same for mod_mam_muc.
 -spec lookup_messages(Host :: ejabberd:server(),
-        ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid(),
-        RSM :: jlib:rsm_in() | undefined, Borders :: mod_mam:borders() | undefined,
-        Start :: mod_mam:unix_timestamp() | undefined,
-        End :: mod_mam:unix_timestamp() | undefined, Now :: mod_mam:unix_timestamp(),
-        WithJID :: ejabberd:jid() | undefined, PageSize :: non_neg_integer(),
-        LimitPassed :: boolean(), MaxResultLimit :: non_neg_integer(),
-        IsSimple :: boolean() | opt_count) ->
-            {ok, mod_mam:lookup_result()}
-            | {error, 'policy-violation'}
-            | {error, Reason :: term()}.
+                      ArchiveID :: mod_mam:archive_id(),
+                      ArchiveJID :: ejabberd:jid(),
+                      RSM :: jlib:rsm_in()  | undefined,
+                      Borders :: mod_mam:borders()  | undefined,
+                      Start :: mod_mam:unix_timestamp()  | undefined,
+                      End :: mod_mam:unix_timestamp()  | undefined,
+                      Now :: mod_mam:unix_timestamp(),
+                      WithJID :: ejabberd:jid()  | undefined,
+                      PageSize :: non_neg_integer(), LimitPassed :: boolean(),
+                      MaxResultLimit :: non_neg_integer(),
+                      IsSimple :: boolean()  | opt_count) ->
+                         {ok, mod_mam:lookup_result()}
+                          | {error, 'policy-violation'}
+                          | {error, Reason :: term()}.
 lookup_messages(Host, ArcID, ArcJID, RSM, Borders, Start, End, Now,
                 WithJID, PageSize, LimitPassed, MaxResultLimit, IsSimple) ->
     StartT = os:timestamp(),
@@ -594,9 +598,12 @@ archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
     mongoose_metrics:update([backends, ?MODULE, archive], Diff),
     R.
 
--spec purge_single_message(Host :: ejabberd:server(), MessID :: message_id(),
-    ArcID  :: archive_id(), ArcJID :: ejabberd:jid(), Now :: unix_timestamp()
-    ) -> ok | {error, 'not-found'} | {error, Reason :: term()}.
+-spec purge_single_message(Host :: ejabberd:server(),
+                           MessID :: message_id(), ArcID :: archive_id(),
+                           ArcJID :: ejabberd:jid(),
+                           Now :: unix_timestamp()) ->
+                              ok  | {error, 'not-found'}
+                               | {error, Reason :: term()}.
 purge_single_message(Host, MessID, ArcID, ArcJID, Now) ->
     ejabberd_hooks:run_fold(mam_purge_single_message, Host, ok,
         [Host, MessID, ArcID, ArcJID, Now]).
@@ -644,7 +651,7 @@ message_row_to_ext_id({MessID,_,_}) ->
 maybe_jid(<<>>) ->
     undefined;
 maybe_jid(JID) when is_binary(JID) ->
-    jlib:binary_to_jid(JID).
+    jid:from_binary(JID).
 
 
 %% @doc Convert id into internal format.
@@ -701,8 +708,9 @@ return_purge_multiple_message_iq(IQ, {error, Reason}) ->
     return_error_iq(IQ, Reason).
 
 -spec return_purge_single_message_iq(ejabberd:iq(),
-        ok|{error, 'not-found'}|{error, Reason :: term()}
-                                    ) -> ejabberd:iq().
+                                     ok  | {error, 'not-found'}
+                                      | {error, Reason :: term()}) ->
+                                        ejabberd:iq().
 return_purge_single_message_iq(IQ, ok) ->
     return_purge_success(IQ);
 return_purge_single_message_iq(IQ, {error, 'not-found'}) ->

--- a/apps/ejabberd/src/mod_mam_con_ca_arch.erl
+++ b/apps/ejabberd/src/mod_mam_con_ca_arch.erl
@@ -310,28 +310,22 @@ safe_lookup_messages(Result, Host,
         {error, Reason}
     end.
 
--spec lookup_messages(Result, Host,
-                      _UserID, UserJID, RSM, Borders,
-                      Start, End, Now, WithJID,
-                      PageSize, LimitPassed, MaxResultLimit,
-                      IsSimple) -> Result when
-    Host    :: server_host(),
-    UserJID :: #jid{},
-    _UserID  :: user_id(),
-    RSM     :: #rsm_in{} | undefined,
-    Borders :: #mam_borders{} | undefined,
-    Start   :: unix_timestamp() | undefined,
-    End     :: unix_timestamp() | undefined,
-    Now     :: unix_timestamp(),
-    PageSize :: non_neg_integer(),
-    WithJID :: #jid{} | undefined,
-    LimitPassed :: boolean(),
-    MaxResultLimit :: non_neg_integer(),
-    IsSimple :: boolean(),
-    Result :: {ok, {TotalCount, Offset, MessageRows}} | {error, 'policy-violation'},
-    TotalCount :: non_neg_integer(),
-    Offset  :: non_neg_integer(),
-    MessageRows :: list(tuple()).
+-spec lookup_messages(Result, Host, _UserID, UserJID, RSM, Borders,
+                      Start, End, Now, WithJID, PageSize, LimitPassed,
+                      MaxResultLimit, IsSimple) ->
+                         Result when
+                     Host :: server_host(), UserJID :: #jid{},
+                     _UserID :: user_id(), RSM :: #rsm_in{}  | undefined,
+                     Borders :: #mam_borders{}  | undefined,
+                     Start :: unix_timestamp()  | undefined,
+                     End :: unix_timestamp()  | undefined,
+                     Now :: unix_timestamp(), PageSize :: non_neg_integer(),
+                     WithJID :: #jid{}  | undefined, LimitPassed :: boolean(),
+                     MaxResultLimit :: non_neg_integer(), IsSimple :: boolean(),
+                     Result :: {ok, {TotalCount, Offset, MessageRows}}
+                                | {error, 'policy-violation'},
+                     TotalCount :: non_neg_integer(),
+                     Offset :: non_neg_integer(), MessageRows :: [tuple()].
 
 lookup_messages(_Result, _Host, _UserID, _UserJID,
                 _RSM, Borders,
@@ -393,8 +387,8 @@ lookup_messages(_Result, Host, _UserID, UserJID = #jid{},
 
 
 %% Cannot be optimized:
-%% - #rsm_in{direction = aft, id = ID} 
-%% - #rsm_in{direction = before, id = ID} 
+%% - #rsm_in{direction = aft, id = ID}
+%% - #rsm_in{direction = before, id = ID}
 
 lookup_messages(_Result, Host, _UserID, UserJID = #jid{},
                 #rsm_in{direction = before, id = undefined}, Borders,
@@ -483,7 +477,7 @@ lookup_messages(_Result, Host, _UserID, UserJID = #jid{},
     Offset     = calc_offset(Worker, Host, Filter, PageSize, TotalCount, RSM),
     %% If a query returns a number of stanzas greater than this limit and the
     %% client did not specify a limit using RSM then the server should return
-    %% a policy-violation error to the client. 
+    %% a policy-violation error to the client.
     case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
         true ->
             {error, 'policy-violation'};
@@ -507,7 +501,7 @@ lookup_messages(_Result, Host, _UserID, UserJID = #jid{},
     Offset     = calc_offset(Worker, Host, Filter, PageSize, TotalCount, RSM),
     %% If a query returns a number of stanzas greater than this limit and the
     %% client did not specify a limit using RSM then the server should return
-    %% a policy-violation error to the client. 
+    %% a policy-violation error to the client.
     case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
         true ->
             {error, 'policy-violation'};
@@ -531,7 +525,7 @@ lookup_messages(_Result, Host, _UserID, UserJID = #jid{},
     Offset     = calc_offset(Worker, Host, Filter, PageSize, TotalCount, RSM),
     %% If a query returns a number of stanzas greater than this limit and the
     %% client did not specify a limit using RSM then the server should return
-    %% a policy-violation error to the client. 
+    %% a policy-violation error to the client.
     case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
         true ->
             {error, 'policy-violation'};
@@ -624,35 +618,31 @@ does_conversation_exist(Worker, BUserJID, BWithJID) ->
         0 -> false
     end.
 
--spec purge_single_message(_Result, Host, MessID, _UserID, UserJID, Now) ->
-    ok | {error, 'not-supported'} when
-    Host    :: server_host(),
-    MessID  :: message_id(),
-    _UserID  :: user_id(),
-    UserJID :: #jid{},
-    Now     :: unix_timestamp().
+-spec purge_single_message(_Result, Host, MessID, _UserID, UserJID,
+                           Now) ->
+                              ok  | {error, 'not-supported'} when
+                          Host :: server_host(), MessID :: message_id(),
+                          _UserID :: user_id(), UserJID :: #jid{},
+                          Now :: unix_timestamp().
 purge_single_message(_Result, Host, MessID, _UserID, _UserJID, _Now) ->
    {error, 'not-supported'}.
 
 
--spec purge_multiple_messages(_Result, Host,
-                              _UserID, UserJID, Borders,
+-spec purge_multiple_messages(_Result, Host, _UserID, UserJID, Borders,
                               Start, End, Now, WithJID) ->
-    {error, 'not-supported'} when
-    Host    :: server_host(),
-    _UserID  :: user_id(),
-    UserJID :: #jid{},
-    Borders :: #mam_borders{},
-    Start   :: unix_timestamp() | undefined,
-    End     :: unix_timestamp() | undefined,
-    Now     :: unix_timestamp(),
-    WithJID :: #jid{} | undefined.
+                                 {error, 'not-supported'} when
+                             Host :: server_host(), _UserID :: user_id(),
+                             UserJID :: #jid{}, Borders :: #mam_borders{},
+                             Start :: unix_timestamp()  | undefined,
+                             End :: unix_timestamp()  | undefined,
+                             Now :: unix_timestamp(),
+                             WithJID :: #jid{}  | undefined.
 purge_multiple_messages(_Result, Host, _UserID, UserJID, Borders,
                         Start, End, _Now, WithJID) ->
    {error, 'not-supported'}.
 
 
-%% Each record is a tuple of form 
+%% Each record is a tuple of form
 %% `{<<"13663125233">>,<<"bob@localhost">>,<<"res1">>,<<binary>>}'.
 %% Columns are `["id","from_jid","message"]'.
 -spec extract_messages(Worker, Host, Filter, IOffset, IMax, ReverseLimit) ->
@@ -762,10 +752,10 @@ select_filter(#mam_ca_filter{
     select_filter(StartID, EndID).
 
 
--spec select_filter(StartID, EndID) -> all | 'end' | start | start_end
-    when
-    StartID :: integer() | undefined,
-    EndID   :: integer() | undefined.
+-spec select_filter(StartID, EndID) ->
+                       all  | 'end'  | start  | start_end when
+                   StartID :: integer()  | undefined,
+                   EndID :: integer()  | undefined.
 select_filter(undefined, undefined) ->
     all;
 select_filter(undefined, _) ->
@@ -824,10 +814,10 @@ maybe_encode_compact_uuid(Microseconds, NodeID) ->
     encode_compact_uuid(Microseconds, NodeID).
 
 serialize_jid(JID) ->
-    jlib:jid_to_binary(jlib:jid_tolower(jlib:jid_remove_resource(JID))).
+    jid:to_binary(jid:to_lower(jid:remove_resource(JID))).
 
 unserialize_jid(BJID) ->
-    jlib:binary_to_jid(BJID).
+    jid:from_binary(BJID).
 
 is_user_exists(#jid{lserver=LServer, luser=LUser}) ->
     ejabberd_users:is_user_exists(LUser, LServer).
@@ -873,7 +863,7 @@ execute_calc_count(ConnPid, Handler, Filter) ->
     FilterName = select_filter(Filter),
     PreparedQuery = dict:fetch(FilterName, Handler),
     execute_prepared_query(ConnPid, PreparedQuery, Params).
-    
+
 prepare_query(ConnPid, Query) ->
     {ok, Res} = seestar_session:prepare(ConnPid, Query),
     Types = seestar_result:types(Res),
@@ -1053,7 +1043,7 @@ handle_call({remove_conversations, BUserJID}, From,
     {noreply, save_query_ref(From, QueryRef, State)};
 handle_call(_, _From, State=#state{}) ->
     {reply, ok, State}.
- 
+
 
 %%--------------------------------------------------------------------
 %% Function: handle_cast(Msg, State) -> {noreply, State} |

--- a/apps/ejabberd/src/mod_mam_con_ca_arch.erl
+++ b/apps/ejabberd/src/mod_mam_con_ca_arch.erl
@@ -313,20 +313,19 @@ safe_lookup_messages(Result, Host,
 -spec lookup_messages(Result, Host, _UserID, UserJID, RSM, Borders,
                       Start, End, Now, WithJID, PageSize, LimitPassed,
                       MaxResultLimit, IsSimple) ->
-                         Result when
-                     Host :: server_host(), UserJID :: #jid{},
-                     _UserID :: user_id(), RSM :: #rsm_in{}  | undefined,
-                     Borders :: #mam_borders{}  | undefined,
-                     Start :: unix_timestamp()  | undefined,
-                     End :: unix_timestamp()  | undefined,
-                     Now :: unix_timestamp(), PageSize :: non_neg_integer(),
-                     WithJID :: #jid{}  | undefined, LimitPassed :: boolean(),
-                     MaxResultLimit :: non_neg_integer(), IsSimple :: boolean(),
-                     Result :: {ok, {TotalCount, Offset, MessageRows}}
-                                | {error, 'policy-violation'},
-                     TotalCount :: non_neg_integer(),
-                     Offset :: non_neg_integer(), MessageRows :: [tuple()].
-
+    Result when
+      Host :: server_host(), UserJID :: #jid{},
+      _UserID :: user_id(), RSM :: #rsm_in{}  | undefined,
+      Borders :: #mam_borders{}  | undefined,
+      Start :: unix_timestamp()  | undefined,
+      End :: unix_timestamp()  | undefined,
+      Now :: unix_timestamp(), PageSize :: non_neg_integer(),
+      WithJID :: #jid{}  | undefined, LimitPassed :: boolean(),
+      MaxResultLimit :: non_neg_integer(), IsSimple :: boolean(),
+      Result :: {ok, {TotalCount, Offset, MessageRows}}
+      | {error, 'policy-violation'},
+      TotalCount :: non_neg_integer(),
+      Offset :: non_neg_integer(), MessageRows :: [tuple()].
 lookup_messages(_Result, _Host, _UserID, _UserJID,
                 _RSM, Borders,
                 Start, End, _Now, undefined,
@@ -620,23 +619,23 @@ does_conversation_exist(Worker, BUserJID, BWithJID) ->
 
 -spec purge_single_message(_Result, Host, MessID, _UserID, UserJID,
                            Now) ->
-                              ok  | {error, 'not-supported'} when
-                          Host :: server_host(), MessID :: message_id(),
-                          _UserID :: user_id(), UserJID :: #jid{},
-                          Now :: unix_timestamp().
+    ok  | {error, 'not-supported'} when
+      Host :: server_host(), MessID :: message_id(),
+      _UserID :: user_id(), UserJID :: #jid{},
+      Now :: unix_timestamp().
 purge_single_message(_Result, Host, MessID, _UserID, _UserJID, _Now) ->
    {error, 'not-supported'}.
 
 
 -spec purge_multiple_messages(_Result, Host, _UserID, UserJID, Borders,
                               Start, End, Now, WithJID) ->
-                                 {error, 'not-supported'} when
-                             Host :: server_host(), _UserID :: user_id(),
-                             UserJID :: #jid{}, Borders :: #mam_borders{},
-                             Start :: unix_timestamp()  | undefined,
-                             End :: unix_timestamp()  | undefined,
-                             Now :: unix_timestamp(),
-                             WithJID :: #jid{}  | undefined.
+    {error, 'not-supported'} when
+      Host :: server_host(), _UserID :: user_id(),
+      UserJID :: #jid{}, Borders :: #mam_borders{},
+      Start :: unix_timestamp()  | undefined,
+      End :: unix_timestamp()  | undefined,
+      Now :: unix_timestamp(),
+      WithJID :: #jid{}  | undefined.
 purge_multiple_messages(_Result, Host, _UserID, UserJID, Borders,
                         Start, End, _Now, WithJID) ->
    {error, 'not-supported'}.
@@ -753,9 +752,9 @@ select_filter(#mam_ca_filter{
 
 
 -spec select_filter(StartID, EndID) ->
-                       all  | 'end'  | start  | start_end when
-                   StartID :: integer()  | undefined,
-                   EndID :: integer()  | undefined.
+    all  | 'end'  | start  | start_end when
+      StartID :: integer()  | undefined,
+      EndID :: integer()  | undefined.
 select_filter(undefined, undefined) ->
     all;
 select_filter(undefined, _) ->
@@ -814,7 +813,7 @@ maybe_encode_compact_uuid(Microseconds, NodeID) ->
     encode_compact_uuid(Microseconds, NodeID).
 
 serialize_jid(JID) ->
-    jid:to_binary(jid:to_lower(jid:remove_resource(JID))).
+    jid:to_binary(jid:to_lower(jid:to_bare(JID))).
 
 unserialize_jid(BJID) ->
     jid:from_binary(BJID).

--- a/apps/ejabberd/src/mod_mam_mnesia_dirty_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_dirty_prefs.erl
@@ -216,7 +216,7 @@ su_key(#jid{lserver=LocLServer, luser=LocLUser}) ->
     [ejabberd:literal_jid() | ejabberd:simple_bare_jid() | ejabberd:simple_jid()]
     ) -> [ejabberd:literal_jid()].
 jids(ArcJID, Rules) ->
-    [jlib:jid_to_binary(rule_to_jid(ArcJID, Rule)) || Rule <- Rules].
+    [jid:to_binary(rule_to_jid(ArcJID, Rule)) || Rule <- Rules].
 
 
 -spec rule_to_jid(ejabberd:jid(),
@@ -233,7 +233,7 @@ rule_to_jid(_ArcJID, {RemLServer, RemLUser}) ->
 -spec rules(ejabberd:jid(), [ejabberd:literal_jid()]) ->
     [ejabberd:literal_jid() | ejabberd:simple_bare_jid() | ejabberd:simple_jid()].
 rules(ArcJID, BinJIDs) ->
-    [rule(ArcJID, jlib:binary_to_jid(BinJID)) || BinJID <- BinJIDs].
+    [rule(ArcJID, jid:from_binary(BinJID)) || BinJID <- BinJIDs].
 
 
 -spec rule(ejabberd:jid(), ejabberd:jid()) ->
@@ -257,7 +257,7 @@ match_jid(ArcJID, JID, JIDs) ->
     true ->
         ordsets:is_element(rule(ArcJID, JID), JIDs);
     false ->
-        BareJID = jlib:jid_remove_resource(JID),
+        BareJID = jid:remove_resource(JID),
         ordsets:is_element(rule(ArcJID, BareJID), JIDs)
             orelse
         ordsets:is_element(rule(ArcJID, JID), JIDs)

--- a/apps/ejabberd/src/mod_mam_mnesia_dirty_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_dirty_prefs.erl
@@ -257,7 +257,7 @@ match_jid(ArcJID, JID, JIDs) ->
     true ->
         ordsets:is_element(rule(ArcJID, JID), JIDs);
     false ->
-        BareJID = jid:remove_resource(JID),
+        BareJID = jid:to_bare(JID),
         ordsets:is_element(rule(ArcJID, BareJID), JIDs)
             orelse
         ordsets:is_element(rule(ArcJID, JID), JIDs)

--- a/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
@@ -236,7 +236,7 @@ key(#jid{lserver=LocLServer, luser=LocLUser}, {RemLServer, RemLUser, RemLResourc
 
 -spec jids([{ls(),lu()} | {ls(),lu(),lr()}]) -> [ejabberd:literal_jid()].
 jids(Rules) ->
-    [jlib:jid_to_binary(rule_to_jid(Rule)) || Rule <- Rules].
+    [jid:to_binary(rule_to_jid(Rule)) || Rule <- Rules].
 
 
 -spec rule_to_jid({ls(), lu()} | {ls(), lu(), lr()}) -> {lu(), ls(), lr()}.
@@ -248,7 +248,7 @@ rule_to_jid({RemLServer, RemLUser}) ->
 
 -spec rules([ejabberd:literal_jid()]) -> [{ls(), lu()} | {ls(), lu(), lr()}].
 rules(BinJIDs) ->
-    [rule(jlib:binary_to_jid(BinJID)) || BinJID <- BinJIDs].
+    [rule(jid:from_binary(BinJID)) || BinJID <- BinJIDs].
 
 
 -spec rule(ejabberd:jid()) -> {ls(), lu()} | {ls(), lu(), lr()}.

--- a/apps/ejabberd/src/mod_mam_muc_ca_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_ca_arch.erl
@@ -179,28 +179,22 @@ archive_message(_Result, Host, MessID, RoomID,
 write_message(Worker, Host, MessID, RoomID, FromNick, Data) ->
     gen_server:cast(Worker, {write_message, MessID, RoomID, FromNick, Data}).
 
--spec lookup_messages(Result, Host,
-                      RoomID, RoomJID, RSM, Borders,
-                      Start, End, Now, WithJID,
-                      PageSize, LimitPassed, MaxResultLimit,
-                      IsSimple) -> Result when
-    Host    :: server_host(),
-    RoomJID :: #jid{},
-    RoomID  :: room_id(),
-    RSM     :: #rsm_in{} | undefined,
-    Borders :: #mam_borders{} | undefined,
-    Start   :: unix_timestamp() | undefined,
-    End     :: unix_timestamp() | undefined,
-    Now     :: unix_timestamp(),
-    PageSize :: non_neg_integer(),
-    WithJID :: #jid{} | undefined,
-    LimitPassed :: boolean(),
-    MaxResultLimit :: non_neg_integer(),
-    IsSimple :: boolean(),
-    Result :: {ok, {TotalCount, Offset, MessageRows}} | {error, 'policy-violation'},
-    TotalCount :: non_neg_integer(),
-    Offset  :: non_neg_integer(),
-    MessageRows :: list(tuple()).
+-spec lookup_messages(Result, Host, RoomID, RoomJID, RSM, Borders,
+                      Start, End, Now, WithJID, PageSize, LimitPassed,
+                      MaxResultLimit, IsSimple) ->
+                         Result when
+                     Host :: server_host(), RoomJID :: #jid{},
+                     RoomID :: room_id(), RSM :: #rsm_in{}  | undefined,
+                     Borders :: #mam_borders{}  | undefined,
+                     Start :: unix_timestamp()  | undefined,
+                     End :: unix_timestamp()  | undefined,
+                     Now :: unix_timestamp(), PageSize :: non_neg_integer(),
+                     WithJID :: #jid{}  | undefined, LimitPassed :: boolean(),
+                     MaxResultLimit :: non_neg_integer(), IsSimple :: boolean(),
+                     Result :: {ok, {TotalCount, Offset, MessageRows}}
+                                | {error, 'policy-violation'},
+                     TotalCount :: non_neg_integer(),
+                     Offset :: non_neg_integer(), MessageRows :: [tuple()].
 
 lookup_messages(_Result, _Host, _RoomID, _RoomJID,
                 _RSM, Borders,
@@ -246,8 +240,8 @@ lookup_messages(_Result, Host, RoomID, RoomJID = #jid{},
 
 
 %% Cannot be optimized:
-%% - #rsm_in{direction = aft, id = ID} 
-%% - #rsm_in{direction = before, id = ID} 
+%% - #rsm_in{direction = aft, id = ID}
+%% - #rsm_in{direction = before, id = ID}
 
 lookup_messages(_Result, Host, RoomID, RoomJID = #jid{},
                 #rsm_in{direction = before, id = undefined}, Borders,
@@ -320,7 +314,7 @@ lookup_messages(_Result, Host, RoomID, RoomJID = #jid{},
     Offset     = calc_offset(Worker, Host, RoomID, Filter, PageSize, TotalCount, RSM),
     %% If a query returns a number of stanzas greater than this limit and the
     %% client did not specify a limit using RSM then the server should return
-    %% a policy-violation error to the client. 
+    %% a policy-violation error to the client.
     case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
         true ->
             {error, 'policy-violation'};
@@ -340,7 +334,7 @@ lookup_messages(_Result, Host, RoomID, RoomJID = #jid{},
     Offset     = calc_offset(Worker, Host, RoomID, Filter, PageSize, TotalCount, RSM),
     %% If a query returns a number of stanzas greater than this limit and the
     %% client did not specify a limit using RSM then the server should return
-    %% a policy-violation error to the client. 
+    %% a policy-violation error to the client.
     case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
         true ->
             {error, 'policy-violation'};
@@ -360,7 +354,7 @@ lookup_messages(_Result, Host, RoomID, RoomJID = #jid{},
     Offset     = calc_offset(Worker, Host, RoomID, Filter, PageSize, TotalCount, RSM),
     %% If a query returns a number of stanzas greater than this limit and the
     %% client did not specify a limit using RSM then the server should return
-    %% a policy-violation error to the client. 
+    %% a policy-violation error to the client.
     case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
         true ->
             {error, 'policy-violation'};
@@ -385,7 +379,7 @@ rows_to_uniform_format(Host, RoomJID, MessageRows) ->
     [row_to_uniform_format(RoomJID, Row) || Row <- MessageRows].
 
 row_to_uniform_format(RoomJID, [MessID,BNick,Data]) ->
-    SrcJID = jlib:jid_replace_resource(RoomJID, BNick),
+    SrcJID = jid:replace_resource(RoomJID, BNick),
     Packet = binary_to_term(Data),
     {MessID, SrcJID, Packet}.
 
@@ -396,35 +390,31 @@ remove_archive(Host, RoomID, _RoomJID) ->
     Worker = select_worker(Host, RoomID),
     gen_server:call(Worker, {remove_archive, RoomID}).
 
--spec purge_single_message(_Result, Host, MessID, RoomID, RoomJID, Now) ->
-    {error, 'not-supported'} when
-    Host    :: server_host(),
-    MessID  :: message_id(),
-    RoomID  :: room_id(),
-    RoomJID :: #jid{},
-    Now     :: unix_timestamp().
+-spec purge_single_message(_Result, Host, MessID, RoomID, RoomJID,
+                           Now) ->
+                              {error, 'not-supported'} when
+                          Host :: server_host(), MessID :: message_id(),
+                          RoomID :: room_id(), RoomJID :: #jid{},
+                          Now :: unix_timestamp().
 purge_single_message(_Result, Host, MessID, RoomID, _RoomJID, _Now) ->
    {error, 'not-supported'}.
 
 
--spec purge_multiple_messages(_Result, Host,
-                              RoomID, RoomJID, Borders,
+-spec purge_multiple_messages(_Result, Host, RoomID, RoomJID, Borders,
                               Start, End, Now, WithJID) ->
-    {error, 'not-supported'} when
-    Host    :: server_host(),
-    RoomID  :: room_id(),
-    RoomJID :: #jid{},
-    Borders :: #mam_borders{},
-    Start   :: unix_timestamp() | undefined,
-    End     :: unix_timestamp() | undefined,
-    Now     :: unix_timestamp(),
-    WithJID :: #jid{} | undefined.
+                                 {error, 'not-supported'} when
+                             Host :: server_host(), RoomID :: room_id(),
+                             RoomJID :: #jid{}, Borders :: #mam_borders{},
+                             Start :: unix_timestamp()  | undefined,
+                             End :: unix_timestamp()  | undefined,
+                             Now :: unix_timestamp(),
+                             WithJID :: #jid{}  | undefined.
 purge_multiple_messages(_Result, Host, RoomID, RoomJID, Borders,
                         Start, End, _Now, _WithJID) ->
    {error, 'not-supported'}.
 
 
-%% Each record is a tuple of form 
+%% Each record is a tuple of form
 %% `{<<"13663125233">>,<<"bob@localhost">>,<<"res1">>,<<binary>>}'.
 %% Columns are `["id","from_jid","message"]'.
 -spec extract_messages(Worker, Host, _RoomID, Filter, IOffset, IMax, ReverseLimit) ->
@@ -535,10 +525,10 @@ select_filter(#mam_muc_ca_filter{
     select_filter(StartID, EndID).
 
 
--spec select_filter(StartID, EndID) -> all | 'end' | start | start_end
-    when
-    StartID :: integer() | undefined,
-    EndID   :: integer() | undefined.
+-spec select_filter(StartID, EndID) ->
+                       all  | 'end'  | start  | start_end when
+                   StartID :: integer()  | undefined,
+                   EndID :: integer()  | undefined.
 select_filter(undefined, undefined) ->
     all;
 select_filter(undefined, _) ->
@@ -635,7 +625,7 @@ execute_calc_count(ConnPid, Handler, Filter) ->
     FilterName = select_filter(Filter),
     PreparedQuery = dict:fetch(FilterName, Handler),
     execute_prepared_query(ConnPid, PreparedQuery, Params).
-    
+
 prepare_query(ConnPid, Query) ->
     {ok, Res} = seestar_session:prepare(ConnPid, Query),
     Types = seestar_result:types(Res),
@@ -742,7 +732,7 @@ handle_call({remove_archive, RoomID}, From,
     {noreply, save_query_ref(From, QueryRef, State)};
 handle_call(_, _From, State=#state{}) ->
     {reply, ok, State}.
- 
+
 
 %%--------------------------------------------------------------------
 %% Function: handle_cast(Msg, State) -> {noreply, State} |

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -234,15 +234,19 @@ safe_lookup_messages(Result, Host,
     end.
 
 -spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-        ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid(),
-        RSM :: jlib:rsm_in() | undefined, Borders :: mod_mam:borders() | undefined,
-        Start :: mod_mam:unix_timestamp() | undefined,
-        End :: mod_mam:unix_timestamp() | undefined, Now :: mod_mam:unix_timestamp(),
-        WithJID :: ejabberd:jid() | undefined, PageSize :: integer(),
-        LimitPassed :: boolean(), MaxResultLimit :: integer(),
-        IsSimple :: boolean() | opt_count) ->
-            {ok, mod_mam:lookup_result()}
-            | {error, 'policy-violation'}.
+                      ArchiveID :: mod_mam:archive_id(),
+                      ArchiveJID :: ejabberd:jid(),
+                      RSM :: jlib:rsm_in()  | undefined,
+                      Borders :: mod_mam:borders()  | undefined,
+                      Start :: mod_mam:unix_timestamp()  | undefined,
+                      End :: mod_mam:unix_timestamp()  | undefined,
+                      Now :: mod_mam:unix_timestamp(),
+                      WithJID :: ejabberd:jid()  | undefined,
+                      PageSize :: integer(), LimitPassed :: boolean(),
+                      MaxResultLimit :: integer(),
+                      IsSimple :: boolean()  | opt_count) ->
+                         {ok, mod_mam:lookup_result()}
+                          | {error, 'policy-violation'}.
 lookup_messages(_Result, Host, RoomID, RoomJID = #jid{},
                 #rsm_in{direction = aft, id = ID}, Borders,
                 Start, End, _Now, WithJID,
@@ -416,7 +420,7 @@ rows_to_uniform_format(MessageRows, Host, RoomJID) ->
 -spec row_to_uniform_format(atom(), atom(), raw_row(), ejabberd:jid()) -> mod_mam_muc:row().
 row_to_uniform_format(DbEngine, EscFormat, {BMessID,BNick,SDataRaw}, RoomJID) ->
     MessID = list_to_integer(binary_to_list(BMessID)),
-    SrcJID = jlib:jid_replace_resource(RoomJID, BNick),
+    SrcJID = jid:replace_resource(RoomJID, BNick),
     SData = ejabberd_odbc:unescape_odbc_binary(DbEngine, SDataRaw),
     Data = ejabberd_odbc:unescape_binary(EscFormat, SData),
     Packet = binary_to_term(Data),
@@ -439,9 +443,11 @@ remove_archive(Host, RoomID, _RoomJID) ->
 
 
 -spec purge_single_message(_Result, Host :: ejabberd:server(),
-        MessID :: mod_mam:message_id(), RoomID :: mod_mam:archive_id(),
-        RoomJID :: ejabberd:jid(), Now :: unix_timestamp())
-            -> ok | {error, 'not-allowed' | 'not-found'}.
+                           MessID :: mod_mam:message_id(),
+                           RoomID :: mod_mam:archive_id(),
+                           RoomJID :: ejabberd:jid(),
+                           Now :: unix_timestamp()) ->
+                              ok  | {error, 'not-allowed'  | 'not-found'}.
 purge_single_message(_Result, Host, MessID, RoomID, _RoomJID, _Now) ->
     Result =
     mod_mam_utils:success_sql_query(
@@ -456,11 +462,14 @@ purge_single_message(_Result, Host, MessID, RoomID, _RoomJID, _Now) ->
 
 
 -spec purge_multiple_messages(_Result, Host :: ejabberd:server(),
-        RoomID :: mod_mam:archive_id(), RoomJID :: ejabberd:jid(),
-        Borders :: mod_mam:borders() | undefined,
-        Start :: unix_timestamp() | undefined,
-        End :: unix_timestamp() | undefined, Now :: unix_timestamp(),
-        WithJID :: ejabberd:jid() | undefined) -> ok | {error, 'not-allowed'}.
+                              RoomID :: mod_mam:archive_id(),
+                              RoomJID :: ejabberd:jid(),
+                              Borders :: mod_mam:borders()  | undefined,
+                              Start :: unix_timestamp()  | undefined,
+                              End :: unix_timestamp()  | undefined,
+                              Now :: unix_timestamp(),
+                              WithJID :: ejabberd:jid()  | undefined) ->
+                                 ok  | {error, 'not-allowed'}.
 purge_multiple_messages(_Result, Host, RoomID, _RoomJID, Borders,
                         Start, End, _Now, WithJID) ->
     Filter = prepare_filter(RoomID, Borders, Start, End, WithJID),

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -333,8 +333,7 @@ safe_lookup_messages(Result, Host,
                       PageSize :: non_neg_integer(), LimitPassed :: boolean(),
                       MaxResultLimit :: non_neg_integer(),
                       IsSimple :: boolean()  | opt_count) ->
-                         {ok, mod_mam:lookup_result()}
-                          | {error, 'policy-violation'}.
+    {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
 lookup_messages(_Result, Host, UserID, UserJID = #jid{},
                 #rsm_in{direction = aft, id = ID}, Borders,
                 Start, End, _Now, WithJID,
@@ -523,7 +522,7 @@ remove_archive(Host, UserID, _UserJID) ->
                            ArchiveID :: mod_mam:archive_id(),
                            RoomJID :: ejabberd:jid(),
                            Now :: mod_mam:unix_timestamp()) ->
-                              ok  | {error, 'not-allowed'  | 'not-found'}.
+    ok  | {error, 'not-allowed'  | 'not-found'}.
 purge_single_message(_Result, Host, MessID, UserID, _UserJID, _Now) ->
     Result =
     mod_mam_utils:success_sql_query(
@@ -721,7 +720,7 @@ escape_user_id(UserID) when is_integer(UserID) ->
 
 %% @doc Strip resource, minify and escape JID.
 minify_and_escape_bare_jid(LocJID, JID) ->
-    ejabberd_odbc:escape(jid_to_opt_binary(LocJID, jid:remove_resource(JID))).
+    ejabberd_odbc:escape(jid_to_opt_binary(LocJID, jid:to_bare(JID))).
 
 minify_and_escape_jid(LocJID, JID) ->
     ejabberd_odbc:escape(jid_to_opt_binary(LocJID, JID)).

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -322,15 +322,19 @@ safe_lookup_messages(Result, Host,
     end.
 
 -spec lookup_messages(Result :: any(), Host :: ejabberd:server(),
-        ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid(),
-        RSM :: jlib:rsm_in() | undefined, Borders :: mod_mam:borders() | undefined,
-        Start :: mod_mam:unix_timestamp() | undefined,
-        End :: mod_mam:unix_timestamp() | undefined, Now :: mod_mam:unix_timestamp(),
-        WithJID :: ejabberd:jid() | undefined, PageSize :: non_neg_integer(),
-        LimitPassed :: boolean(), MaxResultLimit :: non_neg_integer(),
-        IsSimple :: boolean() | opt_count) ->
-                {ok, mod_mam:lookup_result()}
-                | {error, 'policy-violation'}.
+                      ArchiveID :: mod_mam:archive_id(),
+                      ArchiveJID :: ejabberd:jid(),
+                      RSM :: jlib:rsm_in()  | undefined,
+                      Borders :: mod_mam:borders()  | undefined,
+                      Start :: mod_mam:unix_timestamp()  | undefined,
+                      End :: mod_mam:unix_timestamp()  | undefined,
+                      Now :: mod_mam:unix_timestamp(),
+                      WithJID :: ejabberd:jid()  | undefined,
+                      PageSize :: non_neg_integer(), LimitPassed :: boolean(),
+                      MaxResultLimit :: non_neg_integer(),
+                      IsSimple :: boolean()  | opt_count) ->
+                         {ok, mod_mam:lookup_result()}
+                          | {error, 'policy-violation'}.
 lookup_messages(_Result, Host, UserID, UserJID = #jid{},
                 #rsm_in{direction = aft, id = ID}, Borders,
                 Start, End, _Now, WithJID,
@@ -494,7 +498,7 @@ rows_to_uniform_format(Host, UserJID, MessageRows) ->
 
 row_to_uniform_format(DbEngine, UserJID, EscFormat, {BMessID,BSrcJID,SDataRaw}) ->
     MessID = list_to_integer(binary_to_list(BMessID)),
-    SrcJID = jlib:binary_to_jid(expand_minified_jid(UserJID, BSrcJID)),
+    SrcJID = jid:from_binary(expand_minified_jid(UserJID, BSrcJID)),
     SData = ejabberd_odbc:unescape_odbc_binary(DbEngine, SDataRaw),
     Data = ejabberd_odbc:unescape_binary(EscFormat, SData),
     Packet = binary_to_term(Data),
@@ -515,9 +519,11 @@ remove_archive(Host, UserID, _UserJID) ->
     ok.
 
 -spec purge_single_message(Result :: any(), Host :: ejabberd:server(),
-        MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),
-        RoomJID :: ejabberd:jid(), Now :: mod_mam:unix_timestamp())
-            -> ok | {error, 'not-allowed' | 'not-found'}.
+                           MessID :: mod_mam:message_id(),
+                           ArchiveID :: mod_mam:archive_id(),
+                           RoomJID :: ejabberd:jid(),
+                           Now :: mod_mam:unix_timestamp()) ->
+                              ok  | {error, 'not-allowed'  | 'not-found'}.
 purge_single_message(_Result, Host, MessID, UserID, _UserJID, _Now) ->
     Result =
     mod_mam_utils:success_sql_query(
@@ -530,13 +536,16 @@ purge_single_message(_Result, Host, MessID, UserID, _UserJID, _Now) ->
         {updated, 1} -> ok
     end.
 
--spec purge_multiple_messages(Result :: any(), Host :: ejabberd:server(),
-        ArchiveID :: mod_mam:archive_id(), RoomJID :: ejabberd:jid(),
-        Borders :: mod_mam:borders() | undefined,
-        Start :: mod_mam:unix_timestamp() | undefined,
-        End :: mod_mam:unix_timestamp() | undefined,
-        Now :: mod_mam:unix_timestamp(),
-        WithJID :: ejabberd:jid() | undefined) -> ok | {error, 'not-allowed'}.
+-spec purge_multiple_messages(Result :: any(),
+                              Host :: ejabberd:server(),
+                              ArchiveID :: mod_mam:archive_id(),
+                              RoomJID :: ejabberd:jid(),
+                              Borders :: mod_mam:borders()  | undefined,
+                              Start :: mod_mam:unix_timestamp()  | undefined,
+                              End :: mod_mam:unix_timestamp()  | undefined,
+                              Now :: mod_mam:unix_timestamp(),
+                              WithJID :: ejabberd:jid()  | undefined) ->
+                                 ok  | {error, 'not-allowed'}.
 purge_multiple_messages(_Result, Host, UserID, UserJID, Borders,
                         Start, End, _Now, WithJID) ->
     Filter = prepare_filter(UserID, UserJID, Borders, Start, End, WithJID),
@@ -712,7 +721,7 @@ escape_user_id(UserID) when is_integer(UserID) ->
 
 %% @doc Strip resource, minify and escape JID.
 minify_and_escape_bare_jid(LocJID, JID) ->
-    ejabberd_odbc:escape(jid_to_opt_binary(LocJID, jlib:jid_remove_resource(JID))).
+    ejabberd_odbc:escape(jid_to_opt_binary(LocJID, jid:remove_resource(JID))).
 
 minify_and_escape_jid(LocJID, JID) ->
     ejabberd_odbc:escape(jid_to_opt_binary(LocJID, JID)).

--- a/apps/ejabberd/src/mod_mam_odbc_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_prefs.erl
@@ -110,7 +110,7 @@ stop_muc(Host) ->
         LocJID :: ejabberd:jid(), RemJID :: ejabberd:jid()) -> any().
 get_behaviour(DefaultBehaviour, Host, UserID, _LocJID, RemJID) ->
     RemLJID      = jid:to_lower(RemJID),
-    SRemLBareJID = esc_jid(jid:remove_resource(RemLJID)),
+    SRemLBareJID = esc_jid(jid:to_bare(RemLJID)),
     SRemLJID     = esc_jid(jid:to_lower(RemJID)),
     SUserID      = integer_to_list(UserID),
     case query_behaviour(Host, SUserID, SRemLJID, SRemLBareJID) of

--- a/apps/ejabberd/src/mod_mam_odbc_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_prefs.erl
@@ -109,9 +109,9 @@ stop_muc(Host) ->
         Host :: ejabberd:server(), ArchiveID :: mod_mam:archive_id(),
         LocJID :: ejabberd:jid(), RemJID :: ejabberd:jid()) -> any().
 get_behaviour(DefaultBehaviour, Host, UserID, _LocJID, RemJID) ->
-    RemLJID      = jlib:jid_tolower(RemJID),
-    SRemLBareJID = esc_jid(jlib:jid_remove_resource(RemLJID)),
-    SRemLJID     = esc_jid(jlib:jid_tolower(RemJID)),
+    RemLJID      = jid:to_lower(RemJID),
+    SRemLBareJID = esc_jid(jid:remove_resource(RemLJID)),
+    SRemLJID     = esc_jid(jid:to_lower(RemJID)),
     SUserID      = integer_to_list(UserID),
     case query_behaviour(Host, SUserID, SRemLJID, SRemLBareJID) of
         {selected, ["behaviour"], [{Behavour}]} ->
@@ -207,7 +207,7 @@ decode_behaviour(<<"N">>) -> never.
 
 -spec esc_jid(ejabberd:simple_jid() | ejabberd:jid()) -> binary().
 esc_jid(JID) ->
-    ejabberd_odbc:escape(jlib:jid_to_binary(JID)).
+    ejabberd_odbc:escape(jid:to_binary(JID)).
 
 
 -spec encode_first_config_row(SUserID :: string(), SBehaviour :: [65|78|82,...],

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -387,7 +387,7 @@ calculate_msg_id_borders(_RSM, Borders, Start, End) ->
 
 bare_jid(undefined) -> undefined;
 bare_jid(JID) ->
-    jid:to_binary(jid:remove_resource(jid:to_lower(JID))).
+    jid:to_binary(jid:to_bare(jid:to_lower(JID))).
 
 
 maybe_encode_compact_uuid(undefined, _) ->

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -238,7 +238,7 @@ get_message2(MsgId, Bucket, Key) ->
             SourceJID = riakc_map:fetch({<<"source_jid">>, register}, RiakMap),
             PacketBin = riakc_map:fetch({<<"packet">>, register}, RiakMap),
             {ok, Packet} = exml:parse(PacketBin),
-            {MsgId, jlib:binary_to_jid(SourceJID), Packet};
+            {MsgId, jid:from_binary(SourceJID), Packet};
         _ ->
             []
     end.
@@ -387,7 +387,7 @@ calculate_msg_id_borders(_RSM, Borders, Start, End) ->
 
 bare_jid(undefined) -> undefined;
 bare_jid(JID) ->
-    jlib:jid_to_binary(jlib:jid_remove_resource(jlib:jid_to_lower(JID))).
+    jid:to_binary(jid:remove_resource(jid:to_lower(JID))).
 
 
 maybe_encode_compact_uuid(undefined, _) ->

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -296,7 +296,7 @@ is_valid_message_children(_,      _,    _    ) -> false.
 wrap_message(Packet, QueryID, MessageUID, DateTime, SrcJID) ->
     Delay = delay(DateTime, SrcJID, QueryID, MessageUID),
     Packet2 = xml:append_subtags(Packet, [Delay]),
-    xml:replace_tag_attr(<<"from">>, jlib:jid_to_binary(SrcJID), Packet2).
+    xml:replace_tag_attr(<<"from">>, jid:to_binary(SrcJID), Packet2).
 
 
 -spec delay(DateTime :: calendar:datetime(), SrcJID :: ejabberd:jid(),
@@ -543,10 +543,10 @@ expand_minified_jid_2({Pos, 1}, #jid{lserver=ThisServer}, Encoded) ->
 
 jid_to_opt_binary_test_() ->
     check_stringprep(),
-    UserJID = jlib:binary_to_jid(<<"alice@room">>),
+    UserJID = jid:from_binary(<<"alice@room">>),
     [?_assertEqual(JID,
-        expand_minified_jid(UserJID,
-            jid_to_opt_binary(UserJID, jlib:binary_to_jid(JID))))
+        (expand_minified_jid(UserJID,
+              jid_to_opt_binary(UserJID, jid:from_binary(JID)))))
      || JID <- test_jids()].
 
 test_jids() ->
@@ -646,7 +646,7 @@ maybe_previous_id(X) ->
 
 send_message(_From, To, Mess) ->
     {value, BFrom} = xml:get_tag_attr(<<"from">>, Mess),
-    From = jlib:binary_to_jid(BFrom),
+    From = jid:from_binary(BFrom),
     ejabberd_sm:route(From, To, Mess).
 
 -else.
@@ -660,7 +660,7 @@ send_message(From, To, Mess) ->
 -spec is_jid_in_user_roster(ejabberd:jid(), ejabberd:jid()) -> boolean().
 is_jid_in_user_roster(#jid{lserver=LServer, luser=LUser},
                       #jid{} = RemJID) ->
-    RemBareJID = jlib:jid_remove_resource(RemJID),
+    RemBareJID = jid:remove_resource(RemJID),
     {Subscription, _Groups} =
     ejabberd_hooks:run_fold(
         roster_get_jid_info, LServer,

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -660,7 +660,7 @@ send_message(From, To, Mess) ->
 -spec is_jid_in_user_roster(ejabberd:jid(), ejabberd:jid()) -> boolean().
 is_jid_in_user_roster(#jid{lserver=LServer, luser=LUser},
                       #jid{} = RemJID) ->
-    RemBareJID = jid:remove_resource(RemJID),
+    RemBareJID = jid:to_bare(RemJID),
     {Subscription, _Groups} =
     ejabberd_hooks:run_fold(
         roster_get_jid_info, LServer,

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -227,7 +227,7 @@ process_iq_disco_items(Host, From, To, #iq{lang = Lang} = IQ) ->
 can_use_nick(_Host, _JID, <<>>) ->
     false;
 can_use_nick(Host, JID, Nick) ->
-    {LUser, LServer, _} = jlib:jid_tolower(JID),
+    {LUser, LServer, _} = jid:to_lower(JID),
     LUS = {LUser, LServer},
     case catch mnesia:dirty_select(
                  muc_registered,
@@ -431,7 +431,7 @@ route_by_privilege({From, To, Packet} = Routed,
                           server_host=ServerHost} = State) ->
     case acl:match_rule(ServerHost, AccessRoute, From) of
         allow ->
-            {Room, _, _} = jlib:jid_tolower(To),
+            {Room, _, _} = jid:to_lower(To),
             route_to_room(Room, Routed, State);
         _ ->
             #xmlel{attrs = Attrs} = Packet,
@@ -445,7 +445,7 @@ route_by_privilege({From, To, Packet} = Routed,
 
 -spec route_to_room(room(), from_to_packet(), state()) -> 'ok' | pid().
 route_to_room(<<>>, {_,To,_} = Routed, State) ->
-    {_, _, Nick} = jlib:jid_tolower(To),
+    {_, _, Nick} = jid:to_lower(To),
     route_by_nick(Nick, Routed, State);
 route_to_room(Room, {From,To,Packet} = Routed, #state{host=Host} = State) ->
     case mnesia:dirty_read(muc_online_room, {Room, Host}) of
@@ -454,7 +454,7 @@ route_to_room(Room, {From,To,Packet} = Routed, #state{host=Host} = State) ->
         [R] ->
             Pid = R#muc_online_room.pid,
             ?DEBUG("MUC: send to process ~p~n", [Pid]),
-            {_, _, Nick} = jlib:jid_tolower(To),
+            {_, _, Nick} = jid:to_lower(To),
             mod_muc_room:route(Pid, From, Nick, Packet),
             ok
     end.
@@ -476,7 +476,7 @@ route_to_nonexistent_room(Room, {From, To, Packet},
                     HistorySize = State#state.history_size,
                     RoomShaper  = State#state.room_shaper,
                     DefRoomOpts = State#state.default_room_opts,
-                    {_, _, Nick} = jlib:jid_tolower(To),
+                    {_, _, Nick} = jid:to_lower(To),
                     {ok, Pid} = start_new_room(Host, ServerHost, Access, Room,
                                                HistorySize, RoomShaper, From,
                                                Nick, DefRoomOpts),
@@ -708,7 +708,7 @@ iq_disco_items(Host, From, Lang, none) ->
                              flush(),
                              {true,
                               #xmlel{name = <<"item">>,
-                                     attrs = [{<<"jid">>, jlib:jid_to_binary({Name, Host, <<>>})},
+                                     attrs = [{<<"jid">>, jid:to_binary({Name, Host, <<>>})},
                                               {<<"name">>, Desc}]}};
                          _ ->
                              false
@@ -724,7 +724,7 @@ iq_disco_items(Host, From, Lang, Rsm) ->
                              flush(),
                              {true,
                               #xmlel{name = <<"item">>,
-                                     attrs = [{<<"jid">>, jlib:jid_to_binary({Name, Host, <<>>})},
+                                     attrs = [{<<"jid">>, jid:to_binary({Name, Host, <<>>})},
                                               {<<"name">>, Desc}]}};
                          _ ->
                              false
@@ -825,7 +825,7 @@ iq_get_unique(From) ->
         ejabberd:simple_jid() | ejabberd:jid(), ejabberd:lang())
             -> [jlib:xmlel(),...].
 iq_get_register_info(Host, From, Lang) ->
-    {LUser, LServer, _} = jlib:jid_tolower(From),
+    {LUser, LServer, _} = jid:to_lower(From),
     LUS = {LUser, LServer},
     {Nick, Registered} =
         case catch mnesia:dirty_read(muc_registered, {LUS, Host}) of
@@ -854,7 +854,7 @@ iq_get_register_info(Host, From, Lang) ->
         ejabberd:simple_jid() | ejabberd:jid(), nick(), ejabberd:lang())
             -> {'error',jlib:xmlel()} | {'result',[]}.
 iq_set_register_info(Host, From, Nick, Lang) ->
-    {LUser, LServer, _} = jlib:jid_tolower(From),
+    {LUser, LServer, _} = jid:to_lower(From),
     LUS = {LUser, LServer},
     F = fun() ->
                 case Nick of

--- a/apps/ejabberd/src/mod_muc_log.erl
+++ b/apps/ejabberd/src/mod_muc_log.erl
@@ -311,7 +311,7 @@ build_filename_string(TimeStamp, OutDir, RoomJID, DirType, DirName, FileFormat) 
 
 -spec get_room_name(ejabberd:literal_jid()) -> mod_muc:room().
 get_room_name(RoomJID) ->
-    JID = jlib:binary_to_jid(RoomJID),
+    JID = jid:from_binary(RoomJID),
     JID#jid.user.
 
 
@@ -1000,7 +1000,7 @@ role_users_to_string(RoleS, Users) ->
 
 -spec get_room_occupants(ejabberd:literal_jid()) -> [jid_nick_role()].
 get_room_occupants(RoomJIDString) ->
-    RoomJID = jlib:binary_to_jid(RoomJIDString),
+    RoomJID = jid:from_binary(RoomJIDString),
     {ok, Users} = mod_muc_room:get_room_users(RoomJID),
     [{U#user.jid, U#user.nick, U#user.role}
      || U <- Users].

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -1046,7 +1046,7 @@ is_user_online_iq(StanzaId, JID, StateData) when JID#jid.lresource == <<>> ->
                       binary(), any(), jlib:xmlel()) ->
                 {ejabberd:simple_jid() | ejabberd:jid(), jlib:xmlel()}.
 handle_iq_vcard(FromFull, ToJID, StanzaId, NewId, Packet) ->
-    ToBareJID = jid:remove_resource(ToJID),
+    ToBareJID = jid:to_bare(ToJID),
     IQ = jlib:iq_query_info(Packet),
     handle_iq_vcard2(FromFull, ToJID, ToBareJID, StanzaId, NewId, IQ, Packet).
 
@@ -1226,7 +1226,7 @@ access_persistent(#state{access=Access}) ->
 -spec set_affiliation(ejabberd:jid(), mod_muc:affiliation(), state()) -> state().
 set_affiliation(JID, Affiliation, StateData)
         when is_atom(Affiliation) ->
-    LJID = jid:remove_resource(jid:to_lower(JID)),
+    LJID = jid:to_bare(jid:to_lower(JID)),
     Affiliations = case Affiliation of
                none ->
                ?DICT:erase(LJID,
@@ -1243,7 +1243,7 @@ set_affiliation(JID, Affiliation, StateData)
                                  state()) -> state().
 set_affiliation_and_reason(JID, Affiliation, Reason, StateData)
         when is_atom(Affiliation) ->
-    LJID = jid:remove_resource(jid:to_lower(JID)),
+    LJID = jid:to_bare(jid:to_lower(JID)),
     Affiliations = case Affiliation of
                none ->
                ?DICT:erase(LJID,
@@ -1269,7 +1269,7 @@ get_affiliation(JID, StateData) ->
             {ok, Affiliation} ->
             Affiliation;
             _ ->
-            LJID1 = jid:remove_resource(LJID),
+            LJID1 = jid:to_bare(LJID),
             case ?DICT:find(LJID1, StateData#state.affiliations) of
                 {ok, Affiliation} ->
                 Affiliation;
@@ -1279,7 +1279,7 @@ get_affiliation(JID, StateData) ->
                     {ok, Affiliation} ->
                     Affiliation;
                     _ ->
-                    LJID3 = jid:remove_resource(LJID2),
+                    LJID3 = jid:to_bare(LJID2),
                     case ?DICT:find(LJID3, StateData#state.affiliations) of
                         {ok, Affiliation} ->
                         Affiliation;
@@ -2785,8 +2785,8 @@ find_changed_items(UJID, UAffiliation, URole,
                         check_owner ->
                         case search_affiliation(owner, StateData) of
                             [{OJID, _}] ->
-                            jid:remove_resource(OJID) /=
-                                jid:to_lower(jid:remove_resource(UJID));
+                            jid:to_bare(OJID) /=
+                                jid:to_lower(jid:to_bare(UJID));
                             _ ->
                             true
                         end;
@@ -2805,7 +2805,7 @@ find_changed_items(UJID, UAffiliation, URole,
                           UJID,
                           UAffiliation, URole,
                           Items, Lang, StateData,
-                          [{jid:remove_resource(JID),
+                          [{jid:to_bare(JID),
                         affiliation, Affiliation, decode_reason(Item)} | Res]);
                     cancel ->
                         {error, ?ERR_NOT_ALLOWED};
@@ -2835,8 +2835,8 @@ find_changed_items(UJID, UAffiliation, URole,
                     check_owner ->
                     case search_affiliation(owner, StateData) of
                         [{OJID, _}] ->
-                        jid:remove_resource(OJID) /=
-                            jid:to_lower(jid:remove_resource(UJID));
+                        jid:to_bare(OJID) /=
+                            jid:to_lower(jid:to_bare(UJID));
                         _ ->
                         true
                     end;

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -230,12 +230,12 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, Creator, _Nick,
                                    access = Access,
                                    room = Room,
                                    history = lqueue_new(HistorySize),
-                                   jid = jlib:make_jid(Room, Host, <<>>),
+                                   jid = jid:make(Room, Host, <<>>),
                                    just_created = true,
                                    room_shaper = Shaper}),
     State1 = set_opts(DefRoomOpts, State),
     ?INFO_MSG("Created MUC room ~s@~s by ~s",
-              [Room, Host, jlib:jid_to_binary(Creator)]),
+              [Room, Host, jid:to_binary(Creator)]),
     add_to_log(room_existence, created, State1),
     NextState = case proplists:get_value(instant, DefRoomOpts, false) of
                     true ->
@@ -258,7 +258,7 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, Opts]) ->
                                   access = Access,
                                   room = Room,
                                   history = lqueue_new(HistorySize),
-                                  jid = jlib:make_jid(Room, Host, <<>>),
+                                  jid = jid:make(Room, Host, <<>>),
                                   room_shaper = Shaper}),
     add_to_log(room_existence, started, State),
     {ok, normal_state, State}.
@@ -282,8 +282,8 @@ locked_error({route, From, ToNick, #xmlel{attrs = Attrs} = Packet},
     ErrText = <<"This room is locked">>,
     Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
     Err = jlib:make_error_reply(Packet, ?ERRT_ITEM_NOT_FOUND(Lang, ErrText)),
-    ejabberd_router:route(jlib:jid_replace_resource(StateData#state.jid,
-                                                    ToNick),
+    ejabberd_router:route(jid:replace_resource(StateData#state.jid,
+                                               ToNick),
                           From, Err),
     {next_state, NextState, StateData}.
 
@@ -528,12 +528,12 @@ handle_event({destroy, Reason}, _StateName, StateData) ->
                                             children = [#xmlcdata{content = Reason}]}]
                             end}, StateData),
     ?INFO_MSG("Destroyed MUC room ~s with reason: ~p",
-          [jlib:jid_to_binary(StateData#state.jid), Reason]),
+          [jid:to_binary(StateData#state.jid), Reason]),
     add_to_log(room_existence, destroyed, StateData),
     {stop, shutdown, StateData};
 handle_event(destroy, StateName, StateData) ->
     ?INFO_MSG("Destroyed MUC room ~s",
-          [jlib:jid_to_binary(StateData#state.jid)]),
+          [jid:to_binary(StateData#state.jid)]),
     handle_event({destroy, none}, StateName, StateData);
 
 handle_event({set_affiliations, Affiliations}, StateName, StateData) ->
@@ -667,7 +667,7 @@ terminate(Reason, _StateName, StateData) ->
            case Reason of
            shutdown ->
                ejabberd_router:route(
-             jlib:jid_replace_resource(StateData#state.jid, Nick),
+             jid:replace_resource(StateData#state.jid, Nick),
              Info#user.jid,
              Packet);
            _ -> ok
@@ -685,7 +685,7 @@ terminate(Reason, _StateName, StateData) ->
 
 -spec occupant_jid(user(), 'undefined' | ejabberd:jid()) -> 'error' | ejabberd:jid().
 occupant_jid(#user{nick=Nick}, RoomJID) ->
-    jlib:jid_replace_resource(RoomJID, Nick).
+    jid:replace_resource(RoomJID, Nick).
 
 
 -spec route(atom() | pid() | port() | {atom(),_} | {'via',_,_},
@@ -750,8 +750,8 @@ broadcast_changed_subject(From, FromNick, Packet, StateData) ->
         drop ->
             {next_state, normal_state, StateData};
         FilteredPacket ->
-            RouteFrom = jlib:jid_replace_resource(StateData#state.jid,
-                                                  FromNick),
+            RouteFrom = jid:replace_resource(StateData#state.jid,
+                                             FromNick),
             lists:foreach(fun({_LJID, Info}) ->
                                   ejabberd_router:route(RouteFrom,
                                                         Info#user.jid,
@@ -773,8 +773,8 @@ change_subject_error(From, FromNick, Packet, Lang, StateData) ->
                   ?ERRT_FORBIDDEN(Lang,
                                   <<"Only moderators are allowed to change the subject in this room">>)
           end,
-    ejabberd_router:route(jlib:jid_replace_resource(StateData#state.jid,
-                                                    FromNick),
+    ejabberd_router:route(jid:replace_resource(StateData#state.jid,
+                                               FromNick),
                           From,
                           jlib:make_error_reply(Packet, Err)).
 
@@ -821,7 +821,7 @@ is_allowed_nonparticipant(JID, StateData) ->
 -spec get_participant_data(ejabberd:simple_jid() | ejabberd:jid(),
                            state()) -> {_,_}.
 get_participant_data(From, StateData) ->
-    case ?DICT:find(jlib:jid_tolower(From), StateData#state.users) of
+    case ?DICT:find(jid:to_lower(From), StateData#state.users) of
         {ok, #user{nick = FromNick, role = Role}} ->
             {FromNick, Role};
         error ->
@@ -858,7 +858,7 @@ destroy_temporary_room_if_empty(StateData=#state{config=C=#config{}}) ->
     case (not C#config.persistent) andalso is_empty_room(StateData) of
         true ->
             ?INFO_MSG("Destroyed MUC room ~s because it's temporary and empty",
-                  [jlib:jid_to_binary(StateData#state.jid)]),
+                  [jid:to_binary(StateData#state.jid)]),
             add_to_log(room_existence, destroyed, StateData),
             {stop, normal, StateData};
         _ ->
@@ -1000,7 +1000,7 @@ handle_new_user(From, Nick = <<>>, _Packet, StateData, Attrs) ->
                 #xmlel{name = <<"presence">>},
                 ?ERRT_JID_MALFORMED(Lang, ErrText)),
     %ejabberd_route(From, To, Packet),
-    ejabberd_router:route(jlib:jid_replace_resource(StateData#state.jid, Nick), From, Error),
+    ejabberd_router:route(jid:replace_resource(StateData#state.jid, Nick), From, Error),
     StateData;
 handle_new_user(From, Nick, Packet, StateData, _Attrs) ->
     add_new_user(From, Nick, Packet, StateData).
@@ -1008,7 +1008,7 @@ handle_new_user(From, Nick, Packet, StateData, _Attrs) ->
 
 -spec is_user_online(ejabberd:simple_jid() | ejabberd:jid(), state()) -> boolean().
 is_user_online(JID, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     ?DICT:is_key(LJID, StateData#state.users).
 
 
@@ -1033,7 +1033,7 @@ is_user_online_iq(StanzaId, JID, StateData) when JID#jid.lresource /= <<>> ->
 is_user_online_iq(StanzaId, JID, StateData) when JID#jid.lresource == <<>> ->
     try stanzaid_unpack(StanzaId) of
         {OriginalId, Resource} ->
-            JIDWithResource = jlib:jid_replace_resource(JID, Resource),
+            JIDWithResource = jid:replace_resource(JID, Resource),
             {is_user_online(JIDWithResource, StateData),
              OriginalId, JIDWithResource}
     catch
@@ -1046,7 +1046,7 @@ is_user_online_iq(StanzaId, JID, StateData) when JID#jid.lresource == <<>> ->
                       binary(), any(), jlib:xmlel()) ->
                 {ejabberd:simple_jid() | ejabberd:jid(), jlib:xmlel()}.
 handle_iq_vcard(FromFull, ToJID, StanzaId, NewId, Packet) ->
-    ToBareJID = jlib:jid_remove_resource(ToJID),
+    ToBareJID = jid:remove_resource(ToJID),
     IQ = jlib:iq_query_info(Packet),
     handle_iq_vcard2(FromFull, ToJID, ToBareJID, StanzaId, NewId, IQ, Packet).
 
@@ -1139,7 +1139,7 @@ decide_fate_message(<<"error">>, Packet, From, StateData) ->
          %% If this is an error stanza and its condition matches a criteria
          true ->
          Reason = "This participant is considered a ghost and is expulsed: " ++
-            binary_to_list(jlib:jid_to_binary(From)),
+            binary_to_list(jid:to_binary(From)),
          {expulse_sender, Reason};
          false ->
          continue_delivery
@@ -1226,7 +1226,7 @@ access_persistent(#state{access=Access}) ->
 -spec set_affiliation(ejabberd:jid(), mod_muc:affiliation(), state()) -> state().
 set_affiliation(JID, Affiliation, StateData)
         when is_atom(Affiliation) ->
-    LJID = jlib:jid_remove_resource(jlib:jid_tolower(JID)),
+    LJID = jid:remove_resource(jid:to_lower(JID)),
     Affiliations = case Affiliation of
                none ->
                ?DICT:erase(LJID,
@@ -1243,7 +1243,7 @@ set_affiliation(JID, Affiliation, StateData)
                                  state()) -> state().
 set_affiliation_and_reason(JID, Affiliation, Reason, StateData)
         when is_atom(Affiliation) ->
-    LJID = jlib:jid_remove_resource(jlib:jid_tolower(JID)),
+    LJID = jid:remove_resource(jid:to_lower(JID)),
     Affiliations = case Affiliation of
                none ->
                ?DICT:erase(LJID,
@@ -1264,12 +1264,12 @@ get_affiliation(JID, StateData) ->
         allow ->
         owner;
         _ ->
-        LJID = jlib:jid_tolower(JID),
+        LJID = jid:to_lower(JID),
         case ?DICT:find(LJID, StateData#state.affiliations) of
             {ok, Affiliation} ->
             Affiliation;
             _ ->
-            LJID1 = jlib:jid_remove_resource(LJID),
+            LJID1 = jid:remove_resource(LJID),
             case ?DICT:find(LJID1, StateData#state.affiliations) of
                 {ok, Affiliation} ->
                 Affiliation;
@@ -1279,7 +1279,7 @@ get_affiliation(JID, StateData) ->
                     {ok, Affiliation} ->
                     Affiliation;
                     _ ->
-                    LJID3 = jlib:jid_remove_resource(LJID2),
+                    LJID3 = jid:remove_resource(LJID2),
                     case ?DICT:find(LJID3, StateData#state.affiliations) of
                         {ok, Affiliation} ->
                         Affiliation;
@@ -1319,7 +1319,7 @@ set_role(JID, Role, StateData) ->
 
 -spec get_role( ejabberd:jid(), state()) -> mod_muc:role().
 get_role(JID, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     case ?DICT:find(LJID, StateData#state.users) of
     {ok, #user{role = Role}} ->
         Role;
@@ -1405,7 +1405,7 @@ get_max_users_admin_threshold(StateData) ->
 -spec get_user_activity(ejabberd:simple_jid() | ejabberd:jid(), state())
                         -> activity().
 get_user_activity(JID, StateData) ->
-    case treap:lookup(jlib:jid_tolower(JID),
+    case treap:lookup(jid:to_lower(JID),
               StateData#state.activity) of
     {ok, _P, A} -> A;
     error ->
@@ -1433,7 +1433,7 @@ store_user_activity(JID, UserActivity, StateData) ->
     gen_mod:get_module_opt(
       StateData#state.server_host,
       mod_muc, min_presence_interval, 0),
-    Key = jlib:jid_tolower(JID),
+    Key = jid:to_lower(JID),
     Now = now_to_usec(os:timestamp()),
     Activity1 = clean_treap(StateData#state.activity, {1, -Now}),
     Activity =
@@ -1548,7 +1548,7 @@ is_last_session(Nick, StateData) ->
 -spec add_online_user(ejabberd:jid(), mod_muc:nick(), mod_muc:role(), state())
                         -> state().
 add_online_user(JID, Nick, Role, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     Sessions = ?DICT:append(Nick, JID, StateData#state.sessions),
     Users = ?DICT:store(LJID,
             #user{jid = JID,
@@ -1573,7 +1573,7 @@ remove_online_user(JID, StateData) ->
 -spec remove_online_user(ejabberd:jid(), state(), Reason :: binary()) -> state().
 remove_online_user(JID, StateData, Reason) ->
 
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     {ok, #user{nick = Nick}} =
         ?DICT:find(LJID, StateData#state.users),
     Sessions = case is_last_session(Nick, StateData) of
@@ -1582,7 +1582,7 @@ remove_online_user(JID, StateData, Reason) ->
             tab_remove_online_user(JID, StateData),
             ?DICT:erase(Nick, StateData#state.sessions);
         false ->
-            IsOtherLJID = fun(J) -> jlib:jid_tolower(J) /= LJID end,
+            IsOtherLJID = fun(J) -> jid:to_lower(J) /= LJID end,
             F = fun (JIDs) -> lists:filter(IsOtherLJID, JIDs) end,
             ?DICT:update(Nick, F, StateData#state.sessions)
     end,
@@ -1624,7 +1624,7 @@ strip_status(#xmlel{name = <<"presence">>, attrs = Attrs,
 
 -spec add_user_presence(ejabberd:jid(), jlib:xmlel(), state()) -> state().
 add_user_presence(JID, Presence, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     FPresence = filter_presence(Presence),
     Users =
     ?DICT:update(
@@ -1638,7 +1638,7 @@ add_user_presence(JID, Presence, StateData) ->
 -spec add_user_presence_un(ejabberd:simple_jid() | ejabberd:jid(), jlib:xmlel(),
                         state()) -> state().
 add_user_presence_un(JID, Presence, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     FPresence = filter_presence(Presence),
     Users =
     ?DICT:update(
@@ -1664,7 +1664,7 @@ find_jids_by_nick(Nick, StateData) ->
 -spec is_nick_change(ejabberd:simple_jid() | ejabberd:jid(), mod_muc:nick(),
                      state()) -> boolean().
 is_nick_change(JID, Nick, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     case Nick of
     <<>> ->
         false;
@@ -1976,7 +1976,7 @@ send_update_presence(JID, Reason, StateData) ->
 
 -spec foreach_matched_jid(fun((_) -> 'ok'), ejabberd:jid(), state()) -> ok.
 foreach_matched_jid(F, JID, #state{users=Users}) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     case LJID of
         %% Match by bare JID
         {U, S, <<>>} ->
@@ -2002,7 +2002,7 @@ foreach_matched_jid(F, JID, #state{users=Users}) ->
 -spec foreach_matched_user(fun((_) -> 'ok'), ejabberd:simple_jid() | ejabberd:jid(),
                            state()) -> ok.
 foreach_matched_user(F, JID, #state{users=Users}) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     case LJID of
         %% Match by bare JID
         {U, S, <<>>} ->
@@ -2029,7 +2029,7 @@ foreach_user(F, #state{users=Users}) ->
 
 -spec erase_matched_users(ejabberd:simple_jid() | ejabberd:jid(), state()) -> state().
 erase_matched_users(JID, StateData=#state{users=Users, sessions=Sessions}) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     {NewUsers, NewSessions} = erase_matched_users_dict(LJID, Users, Sessions),
     StateData#state{users=NewUsers, sessions=NewSessions}.
 
@@ -2058,7 +2058,7 @@ erase_matched_users_dict(LJID, Users, Sessions) ->
 -spec update_matched_users(F :: fun((user()) -> user()), JID :: ejabberd:jid(),
                            state()) -> state().
 update_matched_users(F, JID, StateData=#state{users=Users}) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     NewUsers = update_matched_users_dict(F, LJID, Users),
     StateData#state{users=NewUsers}.
 
@@ -2091,14 +2091,14 @@ send_new_presence_un(NJID, StateData) ->
 
 -spec send_new_presence_un(ejabberd:jid(), binary(), state()) -> 'ok'.
 send_new_presence_un(NJID, Reason, StateData) ->
-    {ok, #user{ nick = Nick }} = ?DICT:find(jlib:jid_tolower(NJID), StateData#state.users),
+    {ok, #user{nick = Nick}} = ?DICT:find(jid:to_lower(NJID), StateData#state.users),
     case is_last_session(Nick, StateData) of
         true ->
             send_new_presence(NJID, Reason, StateData);
         false ->
             UserJIDs = ?DICT:fetch(Nick, StateData#state.sessions),
             GetUserTupleByJID = fun(JID) ->
-                LJID = jlib:jid_tolower(JID),
+                LJID = jid:to_lower(JID),
                 {LJID, ?DICT:fetch(LJID, StateData#state.users)}
             end,
             CurrentSessionUsers = lists:map(GetUserTupleByJID, UserJIDs),
@@ -2122,7 +2122,7 @@ send_new_presence_to(NJID, Reason, Receivers, StateData) ->
            nick = Nick,
            role = Role,
            last_presence = Presence}} =
-    ?DICT:find(jlib:jid_tolower(NJID), StateData#state.users),
+    ?DICT:find(jid:to_lower(NJID), StateData#state.users),
     Affiliation = get_affiliation(NJID, StateData),
     BAffiliation = affiliation_to_binary(Affiliation),
     BRole = role_to_binary(Role),
@@ -2132,7 +2132,7 @@ send_new_presence_to(NJID, Reason, Receivers, StateData) ->
           case (Info#user.role == moderator) orelse
               ((StateData#state.config)#config.anonymous == false) of
               true ->
-              [{<<"jid">>, jlib:jid_to_binary(RealJID)},
+              [{<<"jid">>, jid:to_binary(RealJID)},
                {<<"affiliation">>, BAffiliation},
                {<<"role">>, BRole}];
               _ ->
@@ -2180,7 +2180,7 @@ send_new_presence_to(NJID, Reason, Receivers, StateData) ->
                      children = [#xmlel{name = <<"item">>, attrs = ItemAttrs,
                                         children = ItemEls} | Status2]}]),
           ejabberd_router:route(
-            jlib:jid_replace_resource(StateData#state.jid, Nick),
+            jid:replace_resource(StateData#state.jid, Nick),
             Info#user.jid,
             Packet)
       end, Receivers).
@@ -2188,7 +2188,7 @@ send_new_presence_to(NJID, Reason, Receivers, StateData) ->
 
 -spec send_existing_presences(ejabberd:jid(), state()) -> 'ok'.
 send_existing_presences(ToJID, StateData) ->
-    LToJID = jlib:jid_tolower(ToJID),
+    LToJID = jid:to_lower(ToJID),
     {ok, #user{jid = RealToJID, role = Role, nick = _Nick}} =
     ?DICT:find(LToJID, StateData#state.users),
     % if you don't want to send presences of other sessions of occupant with ToJID
@@ -2209,7 +2209,7 @@ send_existing_presences(ToJID, StateData) ->
                     case (Role == moderator) orelse
                          ((StateData#state.config)#config.anonymous == false) of
                         true ->
-                            [{<<"jid">>, jlib:jid_to_binary(FromJID)},
+                            [{<<"jid">>, jid:to_binary(FromJID)},
                             {<<"affiliation">>,
                             affiliation_to_binary(FromAffiliation)},
                             {<<"role">>, role_to_binary(FromRole)}];
@@ -2225,10 +2225,10 @@ send_existing_presences(ToJID, StateData) ->
                                 children = [#xmlel{name = <<"item">>,
                                                    attrs = ItemAttrs}]}]),
                         ejabberd_router:route(
-                            jlib:jid_replace_resource(
-                                StateData#state.jid, FromNick),
-                            RealToJID,
-                            Packet)
+                    jid:replace_resource(
+                   StateData#state.jid, FromNick),
+                    RealToJID,
+                    Packet)
             end
         end, ?DICT:to_list(StateData#state.users)).
 
@@ -2262,7 +2262,7 @@ send_invitation(From, To, Reason, StateData=#state{host=Host, server_host=Server
         RoomJID,
         To,
         jlib:make_invitation(
-            jlib:jid_replace_resource(From, <<>>), Password, Reason)).
+            jid:replace_resource(From, <<>>), Password, Reason)).
 
 
 -spec now_to_usec(erlang:timestamp()) -> non_neg_integer().
@@ -2272,7 +2272,7 @@ now_to_usec({MSec, Sec, USec}) ->
 
 -spec change_nick(ejabberd:jid(), binary(), state()) -> state().
 change_nick(JID, Nick, StateData) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     {ok, #user{nick = OldNick}} =
     ?DICT:find(LJID, StateData#state.users),
     Users =
@@ -2291,7 +2291,7 @@ change_nick(JID, Nick, StateData) ->
 
 -spec send_nick_changing(ejabberd:jid(), mod_muc:nick(), state()) -> 'ok'.
 send_nick_changing(JID, OldNick, StateData) ->
-    User = ?DICT:find(jlib:jid_tolower(JID), StateData#state.users),
+    User = ?DICT:find(jid:to_lower(JID), StateData#state.users),
     {ok, #user{jid = RealJID,
                nick = Nick,
                role = Role,
@@ -2320,11 +2320,11 @@ send_nick_change(Presence, OldNick, JID, RealJID, Affiliation, Role,
                             end,
     Unavailable = nick_unavailable_presence(MaybePublicJID, Nick, Affiliation,
                                             Role, MaybeSelfPresenceCode),
-    ejabberd_router:route(jlib:jid_replace_resource(S#state.jid, OldNick),
+    ejabberd_router:route(jid:replace_resource(S#state.jid, OldNick),
                           Info#user.jid, Unavailable),
     Available = nick_available_presence(Presence, MaybePublicJID, Affiliation,
                                         Role, MaybeSelfPresenceCode),
-    ejabberd_router:route(jlib:jid_replace_resource(S#state.jid, Nick),
+    ejabberd_router:route(jid:replace_resource(S#state.jid, Nick),
                           Info#user.jid, Available).
 
 -spec is_nick_change_public(user(), config()) -> boolean().
@@ -2371,7 +2371,7 @@ nick_available_presence(LastPresence, MaybeJID, Affiliation, Role, MaybeCode) ->
       Role :: mod_muc:role().
 muc_user_item(MaybeJID, MaybeNick, Affiliation, Role) ->
     #xmlel{name = <<"item">>,
-           attrs = [{<<"jid">>, jlib:jid_to_binary(MaybeJID)}
+           attrs = [{<<"jid">>, jid:to_binary(MaybeJID)}
                     || MaybeJID /= undefined] ++
                    [{<<"nick">>, MaybeNick} || MaybeNick /= undefined] ++
                    [{<<"affiliation">>, affiliation_to_binary(Affiliation)},
@@ -2441,14 +2441,14 @@ add_message_to_history(FromNick, FromJID, Packet, StateData) ->
     %% the decision to include the original sender's JID or not is based on the
     %% chatroom configuration when the message was originally sent.
     %% Also, if the chatroom is anonymous, even moderators will not get the real JID
-    SenderJid = case ((StateData#state.config)#config.anonymous) of
+    SenderJid = case   (StateData#state.config)#config.anonymous of
     true -> StateData#state.jid;
     false -> FromJID
     end,
     TSPacket = xml:append_subtags(Packet,
                   [jlib:timestamp_to_xml(TimeStamp, utc, SenderJid, <<>>)]),
     SPacket = jlib:replace_from_to(
-        jlib:jid_replace_resource(StateData#state.jid, FromNick),
+        jid:replace_resource(StateData#state.jid, FromNick),
         StateData#state.jid,
         TSPacket),
     Size = element_size(SPacket),
@@ -2465,7 +2465,7 @@ send_history(JID, Shift, StateData) ->
     lists:foldl(
       fun({Nick, Packet, HaveSubject, _TimeStamp, _Size}, B) ->
           ejabberd_router:route(
-        jlib:jid_replace_resource(StateData#state.jid, Nick),
+        jid:replace_resource(StateData#state.jid, Nick),
         JID,
         Packet),
           B or HaveSubject
@@ -2583,13 +2583,13 @@ items_with_affiliation(BAffiliation, StateData) ->
       fun({JID, {Affiliation, Reason}}) ->
           #xmlel{name = <<"item">>,
                  attrs = [{<<"affiliation">>, affiliation_to_binary(Affiliation)},
-                      {<<"jid">>, jlib:jid_to_binary(JID)}],
+                      {<<"jid">>, jid:to_binary(JID)}],
                  children = [#xmlel{name = <<"reason">>,
                                     children = [#xmlcdata{content = Reason}]}]};
          ({JID, Affiliation}) ->
               #xmlel{name = <<"item">>,
                      attrs = [{<<"affiliation">>, affiliation_to_binary(Affiliation)},
-                          {<<"jid">>, jlib:jid_to_binary(JID)}]}
+                          {<<"jid">>, jid:to_binary(JID)}]}
       end, search_affiliation(BAffiliation, StateData)).
 
 
@@ -2603,7 +2603,7 @@ user_to_item(#user{role = Role,
            attrs = [{<<"role">>, role_to_binary(Role)},
                     {<<"affiliation">>, affiliation_to_binary(Affiliation)},
                     {<<"nick">>, Nick},
-                    {<<"jid">>, jlib:jid_to_binary(JID)}]}.
+                    {<<"jid">>, jid:to_binary(JID)}]}.
 
 
 -spec search_role(mod_muc:role(), state()) -> [{_,_}].
@@ -2635,49 +2635,49 @@ process_admin_items_set(UJID, Items, Lang, StateData) ->
     case find_changed_items(UJID, UAffiliation, URole, Items, Lang, StateData, []) of
     {result, Res} ->
         ?INFO_MSG("Processing MUC admin query from ~s in room ~s:~n ~p",
-              [jlib:jid_to_binary(UJID), jlib:jid_to_binary(StateData#state.jid), Res]),
+              [jid:to_binary(UJID), jid:to_binary(StateData#state.jid), Res]),
         NSD =
         lists:foldl(
           fun(E, SD) ->
-              case catch (
-                 case E of
-                     {JID, affiliation, owner, _}
-                     when (JID#jid.luser == <<>>) ->
-                     %% If the provided JID does not have username,
-                     %% forget the affiliation completely
-                     SD;
-                     {JID, role, none, Reason} ->
-                     catch send_kickban_presence(
-                         JID, Reason, <<"307">>, SD),
-                     set_role(JID, none, SD);
-                     {JID, affiliation, none, Reason} ->
-                     case (SD#state.config)#config.members_only of
-                         true ->
-                         catch send_kickban_presence(
-                             JID, Reason, <<"321">>, none, SD),
-                         SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
-                         set_role(JID, none, SD1);
-                         _ ->
-                         SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
-                         send_update_presence(JID, Reason, SD1),
-                         SD1
-                     end;
-                     {JID, affiliation, outcast, Reason} ->
-                     catch send_kickban_presence(
-                         JID, Reason, <<"301">>, outcast, SD),
-                     set_affiliation_and_reason(
-                       JID, outcast, Reason,
-                       set_role(JID, none, SD));
-                     {JID, affiliation, A, Reason} when
-                       (A == admin) or (A == owner) ->
-                     SD1 = set_affiliation_and_reason(JID, A, Reason, SD),
-                     SD2 = set_role(JID, moderator, SD1),
-                     send_update_presence(JID, Reason, SD2),
-                     SD2;
-                     {JID, affiliation, member, Reason} ->
-                        case (SD#state.config)#config.members_only of
-                            true -> send_invitation(UJID, JID, Reason, SD);
-                            _ -> ok
+              case catch
+                 (case E of
+                      {JID, affiliation, owner, _}
+                      when (JID#jid.luser == <<>>) ->
+                      %% If the provided JID does not have username,
+                      %% forget the affiliation completely
+                      SD;
+                      {JID, role, none, Reason} ->
+                      catch send_kickban_presence(
+                          JID, Reason, <<"307">>, SD),
+                      set_role(JID, none, SD);
+                      {JID, affiliation, none, Reason} ->
+                      case  (SD#state.config)#config.members_only of
+                          true ->
+                          catch send_kickban_presence(
+                              JID, Reason, <<"321">>, none, SD),
+                          SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
+                          set_role(JID, none, SD1);
+                          _ ->
+                          SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
+                          send_update_presence(JID, Reason, SD1),
+                          SD1
+                      end;
+                      {JID, affiliation, outcast, Reason} ->
+                      catch send_kickban_presence(
+                          JID, Reason, <<"301">>, outcast, SD),
+                      set_affiliation_and_reason(
+                        JID, outcast, Reason,
+                        set_role(JID, none, SD));
+                      {JID, affiliation, A, Reason} when
+                         (A == admin) or (A == owner) ->
+                      SD1 = set_affiliation_and_reason(JID, A, Reason, SD),
+                      SD2 = set_role(JID, moderator, SD1),
+                      send_update_presence(JID, Reason, SD2),
+                      SD2;
+                      {JID, affiliation, member, Reason} ->
+                         case  (SD#state.config)#config.members_only of
+                             true -> send_invitation(UJID, JID, Reason, SD);
+                             _ -> ok
                          end,
                          SD1 = set_affiliation_and_reason(
                              JID, member, Reason, SD),
@@ -2692,8 +2692,8 @@ process_admin_items_set(UJID, Items, Lang, StateData) ->
                      SD1 = set_affiliation(JID, A, SD),
                      send_update_presence(JID, Reason, SD1),
                      SD1
-                       end
-                ) of
+                  end)
+                  of
                   {'EXIT', ErrReason} ->
                   ?ERROR_MSG("MUC ITEMS SET ERR: ~p~n",
                          [ErrReason]),
@@ -2730,7 +2730,7 @@ find_changed_items(UJID, UAffiliation, URole,
            Lang, StateData, Res) ->
     TJID = case xml:get_attr(<<"jid">>, Attrs) of
            {value, S} ->
-           case jlib:binary_to_jid(S) of
+           case jid:from_binary(S) of
                error ->
                ErrText = <<(translate:translate(Lang, <<"Jabber ID ">>))/binary,
                   S/binary, (translate:translate(Lang, <<" is invalid">>))/binary>>,
@@ -2785,8 +2785,8 @@ find_changed_items(UJID, UAffiliation, URole,
                         check_owner ->
                         case search_affiliation(owner, StateData) of
                             [{OJID, _}] ->
-                            jlib:jid_remove_resource(OJID) /=
-                                jlib:jid_tolower(jlib:jid_remove_resource(UJID));
+                            jid:remove_resource(OJID) /=
+                                jid:to_lower(jid:remove_resource(UJID));
                             _ ->
                             true
                         end;
@@ -2805,7 +2805,7 @@ find_changed_items(UJID, UAffiliation, URole,
                           UJID,
                           UAffiliation, URole,
                           Items, Lang, StateData,
-                          [{jlib:jid_remove_resource(JID),
+                          [{jid:remove_resource(JID),
                         affiliation, Affiliation, decode_reason(Item)} | Res]);
                     cancel ->
                         {error, ?ERR_NOT_ALLOWED};
@@ -2835,8 +2835,8 @@ find_changed_items(UJID, UAffiliation, URole,
                     check_owner ->
                     case search_affiliation(owner, StateData) of
                         [{OJID, _}] ->
-                        jlib:jid_remove_resource(OJID) /=
-                            jlib:jid_tolower(jlib:jid_remove_resource(UJID));
+                        jid:remove_resource(OJID) /=
+                            jid:to_lower(jid:remove_resource(UJID));
                         _ ->
                         true
                     end;
@@ -3057,9 +3057,9 @@ send_kickban_presence(JID, Reason, Code, NewAffiliation, StateData) ->
 send_kickban_presence1(UJID, Reason, Code, Affiliation, StateData) ->
     {ok, #user{jid = RealJID,
            nick = Nick}} =
-    ?DICT:find(jlib:jid_tolower(UJID), StateData#state.users),
+    ?DICT:find(jid:to_lower(UJID), StateData#state.users),
     BAffiliation = affiliation_to_binary(Affiliation),
-    BannedJIDString = jlib:jid_to_binary(RealJID),
+    BannedJIDString = jid:to_binary(RealJID),
     lists:foreach(
       fun({_LJID, Info}) ->
           JidAttrList = case (Info#user.role == moderator) orelse
@@ -3086,7 +3086,7 @@ send_kickban_presence1(UJID, Reason, Code, Affiliation, StateData) ->
                                                          #xmlel{name = <<"status">>,
                                                                 attrs = [{<<"code">>, Code}]}]}]},
           ejabberd_router:route(
-        jlib:jid_replace_resource(StateData#state.jid, Nick),
+        jid:replace_resource(StateData#state.jid, Nick),
         Info#user.jid,
         Packet)
       end, ?DICT:to_list(StateData#state.users)).
@@ -3109,7 +3109,7 @@ process_iq_owner(From, set, Lang, SubEl, StateData) ->
               xml:get_tag_attr_s(<<"type">>, XEl)} of
             {?NS_XDATA, <<"cancel">>} ->
                 ?INFO_MSG("Destroyed MUC room ~s by the owner ~s : cancelled",
-                    [jlib:jid_to_binary(StateData#state.jid), jlib:jid_to_binary(From)]),
+                    [jid:to_binary(StateData#state.jid), jid:to_binary(From)]),
                 add_to_log(room_existence, destroyed, StateData),
                 destroy_room(XEl, StateData);
             {?NS_XDATA, <<"submit">>} ->
@@ -3135,7 +3135,7 @@ process_iq_owner(From, set, Lang, SubEl, StateData) ->
             end;
         [#xmlel{name = <<"destroy">>} = SubEl1] ->
             ?INFO_MSG("Destroyed MUC room ~s by the owner ~s",
-                  [jlib:jid_to_binary(StateData#state.jid), jlib:jid_to_binary(From)]),
+                  [jid:to_binary(StateData#state.jid), jid:to_binary(From)]),
             add_to_log(room_existence, destroyed, StateData),
             destroy_room(SubEl1, StateData);
         Items ->
@@ -3289,7 +3289,7 @@ get_config(Lang, StateData, From) ->
     Res =
     [#xmlel{name = <<"title">>,
             children = [#xmlcdata{content = <<(translate:translate(Lang, <<"Configuration of room ">>))/binary,
-                                    (jlib:jid_to_binary(StateData#state.jid))/binary>>}]},
+                                    (jid:to_binary(StateData#state.jid))/binary>>}]},
      #xmlel{name = <<"field">>,
             attrs = [{<<"type">>, <<"hidden">>},
           {<<"var">>, <<"FORM_TYPE">>}],
@@ -3297,28 +3297,28 @@ get_config(Lang, StateData, From) ->
                                children = [#xmlcdata{content = <<"http://jabber.org/protocol/muc#roomconfig">>}]}]},
      stringxfield(<<"Room title">>,
                <<"muc#roomconfig_roomname">>,
-               (Config#config.title), Lang),
+                Config#config.title, Lang),
      stringxfield(<<"Room description">>,
                <<"muc#roomconfig_roomdesc">>,
-               (Config#config.description), Lang)
+                Config#config.description, Lang)
     ] ++
      case acl:match_rule(StateData#state.server_host, AccessPersistent, From) of
         allow ->
             [boolxfield(
              <<"Make room persistent">>,
              <<"muc#roomconfig_persistentroom">>,
-             (Config#config.persistent), Lang)];
+              Config#config.persistent, Lang)];
         _ -> []
      end ++ [
      boolxfield(<<"Make room public searchable">>,
              <<"muc#roomconfig_publicroom">>,
-             (Config#config.public), Lang),
+              Config#config.public, Lang),
      boolxfield(<<"Make participants list public">>,
              <<"public_list">>,
-             (Config#config.public_list), Lang),
+              Config#config.public_list, Lang),
      boolxfield(<<"Make room password protected">>,
              <<"muc#roomconfig_passwordprotectedroom">>,
-             (Config#config.password_protected), Lang),
+              Config#config.password_protected, Lang),
      privatexfield(<<"Password">>,
             <<"muc#roomconfig_roomsecret">>,
             case Config#config.password_protected of
@@ -3365,34 +3365,34 @@ get_config(Lang, StateData, From) ->
                                                   children = [#xmlcdata{content = <<"anyone">>}]}]}]},
      boolxfield(<<"Make room members-only">>,
              <<"muc#roomconfig_membersonly">>,
-             (Config#config.members_only), Lang),
+              Config#config.members_only, Lang),
      boolxfield(<<"Make room moderated">>,
              <<"muc#roomconfig_moderatedroom">>,
-             (Config#config.moderated), Lang),
+              Config#config.moderated, Lang),
      boolxfield(<<"Default users as participants">>,
              <<"members_by_default">>,
-             (Config#config.members_by_default), Lang),
+              Config#config.members_by_default, Lang),
      boolxfield(<<"Allow users to change the subject">>,
              <<"muc#roomconfig_changesubject">>,
-             (Config#config.allow_change_subj), Lang),
+              Config#config.allow_change_subj, Lang),
      boolxfield(<<"Allow users to send private messages">>,
              <<"allow_private_messages">>,
-             (Config#config.allow_private_messages), Lang),
+              Config#config.allow_private_messages, Lang),
      boolxfield(<<"Allow users to query other users">>,
              <<"allow_query_users">>,
-             (Config#config.allow_query_users), Lang),
+              Config#config.allow_query_users, Lang),
      boolxfield(<<"Allow users to send invites">>,
              <<"muc#roomconfig_allowinvites">>,
-             (Config#config.allow_user_invites), Lang),
+              Config#config.allow_user_invites, Lang),
      boolxfield(<<"Allow users to enter room with multiple sessions">>,
              <<"muc#roomconfig_allowmultisessions">>,
-             (Config#config.allow_multiple_sessions), Lang),
+              Config#config.allow_multiple_sessions, Lang),
      boolxfield(<<"Allow visitors to send status text in presence updates">>,
              <<"muc#roomconfig_allowvisitorstatus">>,
-             (Config#config.allow_visitor_status), Lang),
+              Config#config.allow_visitor_status, Lang),
      boolxfield(<<"Allow visitors to change nickname">>,
              <<"muc#roomconfig_allowvisitornickchange">>,
-             (Config#config.allow_visitor_nickchange), Lang)
+              Config#config.allow_visitor_nickchange, Lang)
     ] ++
     case mod_muc_log:check_access_log(
            StateData#state.server_host, From) of
@@ -3400,7 +3400,7 @@ get_config(Lang, StateData, From) ->
         [boolxfield(
             <<"Enable logging">>,
             <<"muc#roomconfig_enablelogging">>,
-            (Config#config.logging), Lang)];
+             Config#config.logging, Lang)];
         _ -> []
     end,
     {result, [#xmlel{name = <<"instructions">>,
@@ -3874,7 +3874,7 @@ get_mucroom_disco_items(StateData=#state{jid=RoomJID}) ->
 disco_item(User=#user{nick=Nick}, RoomJID) ->
     #xmlel{
         name = <<"item">>,
-        attrs = [{<<"jid">>, jlib:jid_to_binary(occupant_jid(User, RoomJID))},
+        attrs = [{<<"jid">>, jid:to_binary(occupant_jid(User, RoomJID))},
                  {<<"name">>, Nick}]}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3968,7 +3968,7 @@ unsafe_check_invitation(FromJID, Els, Lang,
                                 children = [#xmlcdata{content = Reason}]},
                   OutInviteEl = #xmlel{
                                    name = <<"invite">>,
-                                   attrs = [{<<"from">>, jlib:jid_to_binary(FromJID)}],
+                                   attrs = [{<<"from">>, jid:to_binary(FromJID)}],
                                    children = [ReasonEl] ++ ContinueEl},
                   PasswdEl = create_password_elem(StateData),
                   BodyEl = invite_body_elem(FromJID, Reason, Lang, StateData),
@@ -3984,7 +3984,7 @@ unsafe_check_invitation(FromJID, Els, Lang,
 
 -spec decode_destination_jid(jlib:xmlel()) -> ejabberd:jid().
 decode_destination_jid(InviteEl) ->
-    case jlib:binary_to_jid(xml:get_tag_attr_s(<<"to">>, InviteEl)) of
+    case jid:from_binary(xml:get_tag_attr_s(<<"to">>, InviteEl)) of
       error -> throw({error, ?ERR_JID_MALFORMED});
       JID   -> JID
     end.
@@ -4043,8 +4043,8 @@ invite_body_text(FromJID, Reason, Lang,
             config=#config{
                 password_protected=IsProtected,
                 password=Password}}) ->
-    BFromJID = jlib:jid_to_binary(FromJID),
-    BRoomJID = jlib:jid_to_binary(RoomJID),
+    BFromJID = jid:to_binary(FromJID),
+    BRoomJID = jid:to_binary(RoomJID),
     ITranslate = translate:translate(Lang, <<" invites you to the room ">>),
     IMessage = <<BFromJID/binary, ITranslate/binary, BRoomJID/binary>>,
     BPassword = case IsProtected of
@@ -4102,7 +4102,7 @@ check_decline_invitation(Packet) ->
     ?NS_MUC_USER = xml:get_tag_attr_s(<<"xmlns">>, XEl),
     DEl = xml:get_subtag(XEl, <<"decline">>),
     ToString = xml:get_tag_attr_s(<<"to">>, DEl),
-    ToJID = jlib:binary_to_jid(ToString),
+    ToJID = jid:from_binary(ToString),
     {true, {Packet, XEl, DEl, ToJID}}.
 
 
@@ -4111,7 +4111,7 @@ check_decline_invitation(Packet) ->
 -spec send_decline_invitation({jlib:xmlel(), jlib:xmlel(), jlib:xmlel(), ejabberd:jid()},
         ejabberd:jid(), ejabberd:simple_jid() | ejabberd:jid()) -> 'ok'.
 send_decline_invitation({Packet, XEl, DEl, ToJID}, RoomJID, FromJID) ->
-    FromString = jlib:jid_to_binary(FromJID),
+    FromString = jid:to_binary(FromJID),
     #xmlel{name = <<"decline">>, attrs = DAttrs, children = DEls} = DEl,
     DAttrs2 = lists:keydelete(<<"to">>, 1, DAttrs),
     DAttrs3 = [{<<"from">>, FromString} | DAttrs2],
@@ -4148,13 +4148,13 @@ add_to_log(Type, Data, StateData)
     %% When logging is disabled, the config change message must be logged:
     mod_muc_log:add_to_log(
       StateData#state.server_host, roomconfig_change, Data,
-      jlib:jid_to_binary(StateData#state.jid), make_opts(StateData));
+      jid:to_binary(StateData#state.jid), make_opts(StateData));
 add_to_log(Type, Data, StateData) ->
     case (StateData#state.config)#config.logging of
     true ->
         mod_muc_log:add_to_log(
           StateData#state.server_host, Type, Data,
-          jlib:jid_to_binary(StateData#state.jid), make_opts(StateData));
+          jid:to_binary(StateData#state.jid), make_opts(StateData));
     false ->
         ok
     end.
@@ -4164,7 +4164,7 @@ add_to_log(Type, Data, StateData) ->
 
 -spec tab_add_online_user(ejabberd:jid(), state()) -> any().
 tab_add_online_user(JID, StateData) ->
-    {LUser, LServer, _} = jlib:jid_tolower(JID),
+    {LUser, LServer, _} = jid:to_lower(JID),
     US = {LUser, LServer},
     Room = StateData#state.room,
     Host = StateData#state.host,
@@ -4175,7 +4175,7 @@ tab_add_online_user(JID, StateData) ->
 
 -spec tab_remove_online_user(ejabberd:simple_jid() | ejabberd:jid(), state()) -> any().
 tab_remove_online_user(JID, StateData) ->
-    {LUser, LServer, _} = jlib:jid_tolower(JID),
+    {LUser, LServer, _} = jid:to_lower(JID),
     US = {LUser, LServer},
     Room = StateData#state.room,
     Host = StateData#state.host,
@@ -4186,7 +4186,7 @@ tab_remove_online_user(JID, StateData) ->
 
 -spec tab_count_user(ejabberd:jid()) -> non_neg_integer().
 tab_count_user(JID) ->
-    {LUser, LServer, _} = jlib:jid_tolower(JID),
+    {LUser, LServer, _} = jid:to_lower(JID),
     US = {LUser, LServer},
     case catch ets:select(
          muc_online_users,
@@ -4327,7 +4327,7 @@ route_message(#routed_message{from = From, packet = Packet, lang = Lang},
 -spec route_error(mod_muc:nick(), ejabberd:jid(), jlib:xmlel(), state()) -> state().
 route_error(Nick, From, Error, StateData) ->
     %% TODO: s/Nick/<<>>/
-    ejabberd_router:route(jlib:jid_replace_resource(StateData#state.jid, Nick),
+    ejabberd_router:route(jid:replace_resource(StateData#state.jid, Nick),
                           From, Error),
     StateData.
 
@@ -4488,9 +4488,9 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
     Err = jlib:make_error_reply(
         Packet, ?ERRT_BAD_REQUEST(Lang, ErrText)),
     ejabberd_router:route(
-        jlib:jid_replace_resource(
-            StateData#state.jid,
-            ToNick),
+        jid:replace_resource(
+       StateData#state.jid,
+       ToNick),
         From, Err),
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
@@ -4500,24 +4500,24 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
     Err = jlib:make_error_reply(
         Packet, ?ERRT_ITEM_NOT_FOUND(Lang, ErrText)),
     ejabberd_router:route(
-        jlib:jid_replace_resource(
-            StateData#state.jid,
-            ToNick),
+        jid:replace_resource(
+       StateData#state.jid,
+       ToNick),
         From, Err),
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From, jid = ToJID}, StateData) ->
-    {ok, #user{nick = FromNick}} = ?DICT:find(jlib:jid_tolower(From),
+    {ok, #user{nick = FromNick}} = ?DICT:find(jid:to_lower(From),
         StateData#state.users),
     ejabberd_router:route(
-        jlib:jid_replace_resource(StateData#state.jid, FromNick), ToJID, Packet),
+        jid:replace_resource(StateData#state.jid, FromNick), ToJID, Packet),
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery,
                                         allow_pm = true,
                                         online = false} = Routed, StateData) ->
     #routed_nick_message{packet = Packet, from = From,
                          lang = Lang, nick = ToNick} = Routed,
-    RoomJID = jlib:jid_replace_resource(StateData#state.jid, ToNick),
+    RoomJID = jid:replace_resource(StateData#state.jid, ToNick),
     send_error_only_occupants(<<"messages">>, Packet, Lang, RoomJID, From),
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = false,
@@ -4527,7 +4527,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = f
     Err = jlib:make_error_reply(
         Packet, ?ERRT_FORBIDDEN(Lang, ErrText)),
     ejabberd_router:route(
-        jlib:jid_replace_resource(StateData#state.jid, ToNick), From, Err),
+        jid:replace_resource(StateData#state.jid, ToNick), From, Err),
     StateData.
 
 
@@ -4541,23 +4541,23 @@ route_nick_iq(#routed_nick_iq{allow_query = true, online = {true, _, _}, jid = f
     Err = jlib:make_error_reply(
         Packet, ?ERRT_ITEM_NOT_FOUND(Lang, ErrText)),
     ejabberd_router:route(
-        jlib:jid_replace_resource(
-            StateData#state.jid, ToNick),
+        jid:replace_resource(
+       StateData#state.jid, ToNick),
         From, Err);
 route_nick_iq(#routed_nick_iq{allow_query = true, online = {true, NewId, FromFull},
     jid = ToJID, packet = Packet, stanza = StanzaId}, StateData) ->
-    {ok, #user{nick = FromNick}} = ?DICT:find(jlib:jid_tolower(FromFull),
+    {ok, #user{nick = FromNick}} = ?DICT:find(jid:to_lower(FromFull),
         StateData#state.users),
     {ToJID2, Packet2} = handle_iq_vcard(FromFull, ToJID,
         StanzaId, NewId,Packet),
     ejabberd_router:route(
-        jlib:jid_replace_resource(StateData#state.jid, FromNick),
+        jid:replace_resource(StateData#state.jid, FromNick),
         ToJID2, Packet2);
 route_nick_iq(#routed_nick_iq{online = {false, _, _}, iq = reply}, _StateData) ->
     ok;
 route_nick_iq(#routed_nick_iq{online = {false, _, _}, from = From, nick = ToNick,
                               packet = Packet, lang = Lang}, StateData) ->
-    RoomJID = jlib:jid_replace_resource(StateData#state.jid, ToNick),
+    RoomJID = jid:replace_resource(StateData#state.jid, ToNick),
     send_error_only_occupants(<<"queries">>, Packet, Lang, RoomJID, From);
 route_nick_iq(#routed_nick_iq{iq = reply}, _StateData) ->
     ok;
@@ -4566,7 +4566,7 @@ route_nick_iq(#routed_nick_iq{packet = Packet, lang = Lang, nick = ToNick,
     ErrText = <<"Queries to the conference members are "
                 "not allowed in this room">>,
     Err = jlib:make_error_reply(Packet, ?ERRT_NOT_ALLOWED(Lang, ErrText)),
-    RouteFrom = jlib:jid_replace_resource(StateData#state.jid, ToNick),
+    RouteFrom = jid:replace_resource(StateData#state.jid, ToNick),
     ejabberd_router:route(RouteFrom, From, Err).
 
 

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -155,7 +155,7 @@ handle_offline_msg(#offline_msg{us=US} = Msg, AccessMaxOfflineMsgs) ->
 
 %% Function copied from ejabberd_sm.erl:
 get_max_user_messages(AccessRule, LUser, Host) ->
-    case acl:match_rule(Host, AccessRule, jlib:make_jid(LUser, Host, <<>>)) of
+    case acl:match_rule(Host, AccessRule, jid:make(LUser, Host, <<>>)) of
 	Max when is_integer(Max) -> Max;
 	infinity -> infinity;
 	_ -> ?MAX_USER_MESSAGES
@@ -426,8 +426,8 @@ pop_offline_messages(Ls, User, Server) ->
     Ls ++ pop_offline_messages(User, Server).
 
 pop_offline_messages(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     case ?BACKEND:pop_messages(LUser, LServer) of
         {ok, Rs} ->
             lists:map(fun(R) ->
@@ -440,8 +440,8 @@ pop_offline_messages(User, Server) ->
     end.
 
 resend_offline_messages(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     case ?BACKEND:pop_messages(LUser, LServer) of
         {ok, Rs} ->
             lists:foreach(fun(R) ->
@@ -471,7 +471,7 @@ add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
     xml:append_subtags(Packet, [TimeStampXML]).
 
 timestamp_xml(Server, Time) ->
-    FromJID = jlib:make_jid(<<>>, Server, <<>>),
+    FromJID = jid:make(<<>>, Server, <<>>),
     jlib:timestamp_to_xml(Time, utc, FromJID, <<"Offline Storage">>).
 
 remove_expired_messages(Host) ->

--- a/apps/ejabberd/src/mod_offline_mnesia.erl
+++ b/apps/ejabberd/src/mod_offline_mnesia.erl
@@ -122,8 +122,8 @@ count_offline_messages(LUser, LServer) ->
     end.
 
 remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     US = {LUser, LServer},
     F = fun() ->
 		mnesia:delete({offline_msg, US})

--- a/apps/ejabberd/src/mod_offline_odbc.erl
+++ b/apps/ejabberd/src/mod_offline_odbc.erl
@@ -44,7 +44,7 @@ init(_Host, _Opts) ->
 
 pop_messages(LUser, LServer) ->
     US = {LUser, LServer},
-    To = jlib:make_jid(LUser, LServer, <<>>),
+    To = jid:make(LUser, LServer, <<>>),
     SUser = ejabberd_odbc:escape(LUser),
     SServer = ejabberd_odbc:escape(LServer),
     TimeStamp = now(),
@@ -64,7 +64,7 @@ rows_to_records(US, To, Rows) ->
 row_to_record(US, To, {STimeStamp, SFrom, SPacket}) ->
     {ok, Packet} = exml:parse(SPacket),
     TimeStamp = microseconds_to_now(list_to_integer(binary_to_list(STimeStamp))),
-    From = jlib:binary_to_jid(SFrom),
+    From = jid:from_binary(SFrom),
     #offline_msg{us = US,
              timestamp = TimeStamp,
              expire = undefined,
@@ -115,7 +115,7 @@ write_all_messages_t(LServer, SUser, SServer, Msgs) ->
 
 record_to_row(SUser, SServer, #offline_msg{
         from = From, packet = Packet, timestamp = TimeStamp, expire = Expire}) ->
-    SFrom = ejabberd_odbc:escape(jlib:jid_to_binary(From)),
+    SFrom = ejabberd_odbc:escape(jid:to_binary(From)),
     SPacket = ejabberd_odbc:escape(exml:to_binary(Packet)),
     STimeStamp = encode_timestamp(TimeStamp),
     SExpire = maybe_encode_timestamp(Expire),

--- a/apps/ejabberd/src/mod_ping.erl
+++ b/apps/ejabberd/src/mod_ping.erl
@@ -183,7 +183,7 @@ handle_info({timeout, _TRef, {ping, JID}},
     F = fun(Response) ->
                 gen_server:cast(Pid, {iq_pong, JID, Response})
         end,
-    From = jlib:make_jid(<<"">>, State#state.host, <<"">>),
+    From = jid:make(<<"">>, State#state.host, <<"">>),
     ejabberd_local:route_iq(From, JID, IQ, F, PingReqTimeout),
     Timers = add_timer(JID, State#state.ping_interval, State#state.timers),
     {noreply, State#state{timers = Timers}};
@@ -220,7 +220,7 @@ user_keep_alive(JID) ->
 %% Internal functions
 %%====================================================================
 add_timer(JID, Interval, Timers) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     NewTimers = case ?DICT:find(LJID, Timers) of
                     {ok, OldTRef} ->
                         cancel_timer(OldTRef),
@@ -232,7 +232,7 @@ add_timer(JID, Interval, Timers) ->
     ?DICT:store(LJID, TRef, NewTimers).
 
 del_timer(JID, Timers) ->
-    LJID = jlib:jid_tolower(JID),
+    LJID = jid:to_lower(JID),
     case ?DICT:find(LJID, Timers) of
         {ok, TRef} ->
             cancel_timer(TRef),

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -300,8 +300,8 @@ is_item_needdb(#listitem{type = group})        -> true;
 is_item_needdb(_)                              -> false.
 
 get_user_list(_, User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     case ?BACKEND:get_default_list(LUser, LServer) of
         {ok, {Default, List}} ->
             NeedDb = is_list_needdb(List),
@@ -323,13 +323,13 @@ check_packet(_, User, Server,
         _ ->
             PType = packet_directed_type(Dir, packet_type(Packet)),
             LJID = case Dir of
-                   in -> jlib:jid_tolower(From);
-                   out -> jlib:jid_tolower(To)
-               end,
+                   in -> jid:to_lower(From);
+                   out -> jid:to_lower(To)
+                   end,
             {Subscription, Groups} =
             case NeedDb of
                 true ->
-                    Host = jlib:nameprep(Server),
+                    Host = jid:nameprep(Server),
                     roster_get_jid_info(Host, User, Server, LJID);
                 false ->
                     {[], []}
@@ -407,8 +407,8 @@ is_type_match(Type, Value, JID, Subscription, Groups) ->
 
 
 remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     ?BACKEND:remove_user(LUser, LServer).
 
 
@@ -502,11 +502,11 @@ set_type_and_value(<<>>, _Value, Item) ->
 set_type_and_value(_Type, <<>>, _Item) ->
     false;
 set_type_and_value(<<"jid">>, Value, Item) ->
-    case jlib:binary_to_jid(Value) of
+    case jid:from_binary(Value) of
         error ->
             false;
         JID ->
-            Item#listitem{type = jid, value = jlib:jid_tolower(JID)}
+            Item#listitem{type = jid, value = jid:to_lower(JID)}
     end;
 set_type_and_value(<<"group">>, Value, Item) ->
     Item#listitem{type = group, value = Value};
@@ -635,7 +635,7 @@ type_to_binary(Type) ->
 
 value_to_binary(Type, Val) ->
     case Type of
-    jid -> jlib:jid_to_binary(Val);
+    jid -> jid:to_binary(Val);
     group -> Val;
     subscription ->
         case Val of
@@ -671,7 +671,7 @@ binary_to_order_s(Order) ->
 %% ------------------------------------------------------------------
 
 broadcast_privacy_list(LUser, LServer, Name, UserList) ->
-    UserJID = jlib:make_jid(LUser, LServer, <<>>),
+    UserJID = jid:make(LUser, LServer, <<>>),
     ejabberd_sm:route(UserJID, UserJID, broadcast_privacy_list_packet(Name, UserList)).
 
 %% TODO this is dirty

--- a/apps/ejabberd/src/mod_privacy_odbc.erl
+++ b/apps/ejabberd/src/mod_privacy_odbc.erl
@@ -204,9 +204,9 @@ raw_to_item({BType, BValue, BAction, BOrder, BMatchAll, BMatchIQ,
         <<"n">> ->
         {none, none};
         <<"j">> ->
-        case jlib:binary_to_jid(BValue) of
+        case jid:from_binary(BValue) of
             #jid{} = JID ->
-            {jid, jlib:jid_tolower(JID)}
+            {jid, jid:to_lower(JID)}
         end;
         <<"g">> ->
         {group, BValue};
@@ -259,7 +259,7 @@ item_to_raw(#listitem{type = Type,
         none ->
         {<<"n">>, <<"">>};
         jid ->
-        {<<"j">>, ejabberd_odbc:escape(jlib:jid_to_binary(Value))};
+        {<<"j">>, ejabberd_odbc:escape(jid:to_binary(Value))};
         group ->
         {<<"g">>, ejabberd_odbc:escape(Value)};
         subscription ->

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -89,8 +89,8 @@ stop(Host) ->
 %% Handlers
 
 remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     ?BACKEND:remove_user(LUser, LServer).
 
 process_sm_iq(

--- a/apps/ejabberd/src/mod_register.erl
+++ b/apps/ejabberd/src/mod_register.erl
@@ -85,12 +85,12 @@ unauthenticated_iq_register(_Acc,
 		 {A, _Port} -> A;
 		  _ -> undefined
 	      end,
-    ResIQ = process_iq(jlib:make_jid(<<>>, <<>>, <<>>),
- 		       jlib:make_jid(<<>>, Server, <<>>),
+    ResIQ = process_iq(jid:make(<<>>, <<>>, <<>>),
+                        jid:make(<<>>, Server, <<>>),
  		       IQ,
 		       Address),
-    Res1 = jlib:replace_from_to(jlib:make_jid(<<>>, Server, <<>>),
- 				jlib:make_jid(<<>>, <<>>, <<>>),
+    Res1 = jlib:replace_from_to(jid:make(<<>>, Server, <<>>),
+                                 jid:make(<<>>, <<>>, <<>>),
  				jlib:iq_to_xml(ResIQ)),
     jlib:remove_attr(<<"to">>, Res1);
 
@@ -98,7 +98,7 @@ unauthenticated_iq_register(Acc, _Server, _IQ, _IP) ->
     Acc.
 
 process_iq(From, To, IQ) ->
-    process_iq(From, To, IQ, jlib:jid_tolower(From)).
+    process_iq(From, To, IQ, jid:to_lower(From)).
 
 process_iq(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl, id = ID} = IQ, Source) ->
     case Type of
@@ -160,8 +160,8 @@ process_iq(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl, id = ID} = IQ
 					id = ID,
 					sub_el = [SubEl]},
 			    ejabberd_router:route(
-			      jlib:make_jid(User, Server, Resource),
-			      jlib:make_jid(User, Server, Resource),
+			      jid:make(User, Server, Resource),
+			      jid:make(User, Server, Resource),
 			      jlib:iq_to_xml(ResIQ)),
 			    ejabberd_auth:remove_user(User, Server),
 			    ignore;
@@ -250,11 +250,11 @@ try_set_password(User, Server, Password, IQ, SubEl, Lang) ->
     end.
 
 try_register(User, Server, Password, SourceRaw, Lang) ->
-    case jlib:is_nodename(User) of
+    case jid:is_nodename(User) of
 	false ->
 	    {error, ?ERR_BAD_REQUEST};
 	_ ->
-	    JID = jlib:make_jid(User, Server, <<>>),
+	    JID = jid:make(User, Server, <<>>),
 	    Access = gen_mod:get_module_opt(Server, ?MODULE, access, all),
 	    IPAccess = get_ip_access(Server),
 	    case {acl:match_rule(Server, Access, JID),
@@ -305,7 +305,7 @@ send_welcome_message(JID) ->
 	    ok;
 	{Subj, Body} ->
 	    ejabberd_router:route(
-	      jlib:make_jid(<<>>, Host, <<>>),
+	      jid:make(<<>>, Host, <<>>),
 	      JID,
 	      #xmlel{name = <<"message">>, attrs = [{<<"type">>, <<"normal">>}],
 	             children = [#xmlel{name = <<"subject">>,
@@ -325,15 +325,15 @@ send_registration_notifications(UJID, Source) ->
 		     io_lib:format(
 		       "[~s] The account ~s was registered from IP address ~s "
 		       "on node ~w using ~p.",
-		       [get_time_string(), jlib:jid_to_binary(UJID),
+		       [get_time_string(), jid:to_binary(UJID),
 			ip_to_string(Source), node(), ?MODULE])),
 	    lists:foreach(
 	      fun(S) ->
-		      case jlib:binary_to_jid(S) of
+		      case jid:from_binary(S) of
 			  error -> ok;
 			  JID ->
 			      ejabberd_router:route(
-				jlib:make_jid(<<>>, Host, <<>>),
+				jid:make(<<>>, Host, <<>>),
 				JID,
 				#xmlel{name = <<"message">>,
 				       attrs = [{<<"type">>, <<"chat">>}],
@@ -452,7 +452,7 @@ write_time({{Y,Mo,D},{H,Mi,S}}) ->
 		  [Y, Mo, D, H, Mi, S]).
 
 is_strong_password(Server, Password) ->
-    LServer = jlib:nameprep(Server),
+    LServer = jid:nameprep(Server),
     case gen_mod:get_module_opt(LServer, ?MODULE, password_strength, 0) of
 	Entropy when is_number(Entropy), Entropy >= 0 ->
 	    if Entropy == 0 ->
@@ -471,7 +471,7 @@ is_strong_password(Server, Password) ->
 %%%
 
 may_remove_resource({_, _, _} = From) ->
-    jlib:jid_remove_resource(From);
+    jid:remove_resource(From);
 may_remove_resource(From) ->
     From.
 

--- a/apps/ejabberd/src/mod_register.erl
+++ b/apps/ejabberd/src/mod_register.erl
@@ -471,7 +471,7 @@ is_strong_password(Server, Password) ->
 %%%
 
 may_remove_resource({_, _, _} = From) ->
-    jid:remove_resource(From);
+    jid:to_bare(From);
 may_remove_resource(From) ->
     From.
 

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -785,13 +785,13 @@ send_unsubscribing_presence(From, Item) ->
                  _ -> false
              end,
     if IsTo ->
-           send_presence_type(jid:remove_resource(From),
+           send_presence_type(jid:to_bare(From),
                               jid:make(Item#roster.jid),
                               <<"unsubscribe">>);
        true -> ok
     end,
     if IsFrom ->
-           send_presence_type(jid:remove_resource(From),
+           send_presence_type(jid:to_bare(From),
                               jid:make(Item#roster.jid),
                               <<"unsubscribed">>);
        true -> ok
@@ -881,7 +881,7 @@ get_jid_info(_, User, Server, JID) ->
     case read_subscription_and_groups(User, Server, LJID) of
         {Subscription, Groups} -> {Subscription, Groups};
         error ->
-            LRJID = jid:to_lower(jid:remove_resource(JID)),
+            LRJID = jid:to_lower(jid:to_bare(JID)),
             if LRJID == LJID -> {none, []};
                true ->
                    case read_subscription_and_groups(User, Server, LRJID)

--- a/apps/ejabberd/src/mod_roster_odbc.erl
+++ b/apps/ejabberd/src/mod_roster_odbc.erl
@@ -92,7 +92,7 @@ get_roster(LUser, LServer) ->
                                                error -> [];
                                                R ->
                                                    SJID =
-                                                   jlib:jid_to_binary(R#roster.jid),
+                                                   jid:to_binary(R#roster.jid),
                                                    Groups = case dict:find(SJID,
                                                                            GroupsDict)
                                                             of
@@ -109,7 +109,7 @@ get_roster(LUser, LServer) ->
 
 get_roster_by_jid_t(LUser, LServer, LJID) ->
     Username = ejabberd_odbc:escape(LUser),
-    SJID = ejabberd_odbc:escape(jlib:jid_to_binary(LJID)),
+    SJID = ejabberd_odbc:escape(jid:to_binary(LJID)),
     {selected,
      [<<"username">>, <<"jid">>, <<"nick">>,
       <<"subscription">>, <<"ask">>, <<"askmessage">>,
@@ -149,13 +149,13 @@ get_subscription_lists(_, LUser, LServer) ->
 roster_subscribe_t(LUser, LServer, LJID, Item) ->
     ItemVals = record_to_string(Item),
     Username = ejabberd_odbc:escape(LUser),
-    SJID = ejabberd_odbc:escape(jlib:jid_to_binary(LJID)),
+    SJID = ejabberd_odbc:escape(jid:to_binary(LJID)),
     odbc_queries:roster_subscribe(LServer, Username, SJID,
                                   ItemVals).
 
 get_roster_by_jid_with_groups_t(LUser, LServer, LJID) ->
     Username = ejabberd_odbc:escape(LUser),
-    SJID = ejabberd_odbc:escape(jlib:jid_to_binary(LJID)),
+    SJID = ejabberd_odbc:escape(jid:to_binary(LJID)),
     case odbc_queries:get_roster_by_jid(LServer, Username,
                                         SJID)
     of
@@ -189,23 +189,23 @@ remove_user(LUser, LServer) ->
 
 update_roster_t(LUser, LServer, LJID, Item) ->
     Username = ejabberd_odbc:escape(LUser),
-    SJID = ejabberd_odbc:escape(jlib:jid_to_binary(LJID)),
+    SJID = ejabberd_odbc:escape(jid:to_binary(LJID)),
     ItemVals = record_to_string(Item),
     ItemGroups = groups_to_string(Item),
     odbc_queries:update_roster(LServer, Username, SJID, ItemVals, ItemGroups).
 
 del_roster_t(LUser, LServer, LJID) ->
     Username = ejabberd_odbc:escape(LUser),
-    SJID = ejabberd_odbc:escape(jlib:jid_to_binary(LJID)),
+    SJID = ejabberd_odbc:escape(jid:to_binary(LJID)),
     odbc_queries:del_roster(LServer, Username, SJID).
 
 raw_to_record(LServer,
               {User, SJID, Nick, SSubscription, SAsk, SAskMessage,
                _SServer, _SSubscribe, _SType}) ->
-    case jlib:binary_to_jid(SJID) of
+    case jid:from_binary(SJID) of
         error -> error;
         JID ->
-            LJID = jlib:jid_tolower(JID),
+            LJID = jid:to_lower(JID),
             Subscription = case SSubscription of
                                <<"B">> -> both;
                                <<"T">> -> to;
@@ -228,7 +228,7 @@ raw_to_record(LServer,
 
 read_subscription_and_groups(LUser, LServer, LJID) ->
     Username = ejabberd_odbc:escape(LUser),
-    SJID = ejabberd_odbc:escape(jlib:jid_to_binary(LJID)),
+    SJID = ejabberd_odbc:escape(jid:to_binary(LJID)),
     case catch odbc_queries:get_subscription(LServer,
                                              Username, SJID)
     of
@@ -260,7 +260,7 @@ record_to_string(#roster{us = {User, _Server},
                          ask = Ask, askmessage = AskMessage}) ->
     Username = ejabberd_odbc:escape(User),
     SJID =
-    ejabberd_odbc:escape(jlib:jid_to_binary(jlib:jid_tolower(JID))),
+    ejabberd_odbc:escape(jid:to_binary(jid:to_lower(JID))),
     Nick = ejabberd_odbc:escape(Name),
     SSubscription = case Subscription of
                         both -> <<"B">>;
@@ -284,7 +284,7 @@ groups_to_string(#roster{us = {User, _Server},
                          jid = JID, groups = Groups}) ->
     Username = ejabberd_odbc:escape(User),
     SJID =
-    ejabberd_odbc:escape(jlib:jid_to_binary(jlib:jid_tolower(JID))),
+    ejabberd_odbc:escape(jid:to_binary(jid:to_lower(JID))),
     lists:foldl(fun (<<"">>, Acc) -> Acc;
                     (Group, Acc) ->
                         G = ejabberd_odbc:escape(Group),

--- a/apps/ejabberd/src/mod_roster_riak.erl
+++ b/apps/ejabberd/src/mod_roster_riak.erl
@@ -62,7 +62,7 @@ transaction(_LServer, F) ->
 %% --------------------- Inside "transactions" --------------------------------
 
 get_roster_by_jid_t(LUser, LServer, LJID) ->
-    case riakc_map:find({jlib:jid_to_binary(LJID), register}, get_t_roster(LUser, LServer)) of
+    case riakc_map:find({jid:to_binary(LJID), register}, get_t_roster(LUser, LServer)) of
         {ok, ItemReg} ->
             UnpackedItem = unpack_item(ItemReg),
             UnpackedItem#roster{ jid = LJID, name = <<>>, groups = [], xs = [] };
@@ -74,7 +74,7 @@ roster_subscribe_t(LUser, LServer, LJID, Item) ->
     set_t_roster(LUser, LServer, LJID, Item).
 
 get_roster_by_jid_with_groups_t(LUser, LServer, LJID) ->
-    case riakc_map:find({jlib:jid_to_binary(LJID), register}, get_t_roster(LUser, LServer)) of
+    case riakc_map:find({jid:to_binary(LJID), register}, get_t_roster(LUser, LServer)) of
         {ok, ItemReg} -> unpack_item(ItemReg);
         error -> #roster{usj = {LUser, LServer, LJID}, us = {LUser, LServer}, jid = LJID}
     end.
@@ -126,7 +126,7 @@ remove_user(LUser, LServer) ->
 read_subscription_and_groups(LUser, LServer, LJID) ->
     try
         {ok, RosterMap} = mongoose_riak:fetch_type(?ROSTER_BUCKET(LServer), LUser),
-        ItemReg = riakc_map:fetch({jlib:jid_to_binary(LJID), register}, RosterMap),
+        ItemReg = riakc_map:fetch({jid:to_binary(LJID), register}, RosterMap),
         #roster{ subscription = Subscription, groups = Groups } = unpack_item(ItemReg),
         {Subscription, Groups}
     catch
@@ -164,7 +164,7 @@ get_t_roster(LUser, LServer) ->
 set_t_roster(LUser, LServer, LJID, Item) ->
     RosterMap1 = get_t_roster(LUser, LServer),
     put({riak_roster_t, {LUser, LServer}},
-        riakc_map:update({jlib:jid_to_binary(LJID), register},
+        riakc_map:update({jid:to_binary(LJID), register},
                          fun(R) -> riakc_register:set(term_to_binary(Item), R) end, RosterMap1)).
 
 -spec del_t_roster(LUser :: ejabberd:luser(),
@@ -172,7 +172,7 @@ set_t_roster(LUser, LServer, LJID, Item) ->
                    LJID :: ejabberd:simple_jid()) -> any().
 del_t_roster(LUser, LServer, LJID) ->
     RosterMap1 = get_t_roster(LUser, LServer),
-    RosterMap = case catch riakc_map:erase({jlib:jid_to_binary(LJID), register}, RosterMap1) of
+    RosterMap = case catch riakc_map:erase({jid:to_binary(LJID), register}, RosterMap1) of
                     context_required -> RosterMap1;
                     RosterMap2 -> RosterMap2
                 end,

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -152,8 +152,8 @@ process_item(RosterItem, _Host) ->
     end.
 
 get_subscription_lists({F, T, P}, User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     US = {LUser, LServer},
     DisplayedGroups = get_user_displayed_groups(US),
     SRUsers = lists:usort(lists:flatmap(fun (Group) ->
@@ -164,10 +164,10 @@ get_subscription_lists({F, T, P}, User, Server) ->
     {lists:usort(SRJIDs ++ F), lists:usort(SRJIDs ++ T), P}.
 
 get_jid_info({Subscription, Groups}, User, Server, JID) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     US = {LUser, LServer},
-    {U1, S1, _} = jlib:jid_tolower(JID),
+    {U1, S1, _} = jid:to_lower(JID),
     US1 = {U1, S1},
     SRUsers = get_user_to_groups_map(US, false),
     case dict:find(US1, SRUsers) of
@@ -186,10 +186,10 @@ out_subscription(User, Server, JID, Type) ->
     process_subscription(out, User, Server, JID, Type, false).
 
 process_subscription(Direction, User, Server, JID, _Type, Acc) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nameprep(Server),
     US = {LUser, LServer},
-    {U1, S1, _} = jlib:jid_tolower(jlib:jid_remove_resource(JID)),
+    {U1, S1, _} = jid:to_lower(jid:remove_resource(JID)),
     US1 = {U1, S1},
     DisplayedGroups = get_user_displayed_groups(US),
     SRUsers = lists:usort(lists:flatmap(
@@ -422,7 +422,7 @@ search_group_info(State, Group) ->
                                            end,
                                   JIDs = lists:foldl(
                                            fun ({ok, UID}, L) ->
-                                                   PUID = jlib:nodeprep(UID),
+                                                   PUID = jid:nodeprep(UID),
                                                    case PUID of
                                                        error ->
                                                            L;

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -189,7 +189,7 @@ process_subscription(Direction, User, Server, JID, _Type, Acc) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
     US = {LUser, LServer},
-    {U1, S1, _} = jid:to_lower(jid:remove_resource(JID)),
+    {U1, S1, _} = jid:to_lower(jid:to_bare(JID)),
     US1 = {U1, S1},
     DisplayedGroups = get_user_displayed_groups(US),
     SRUsers = lists:usort(lists:flatmap(

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -292,8 +292,8 @@ get_local_features(Acc, _From, _To, Node, _Lang) ->
     end.
 
 remove_user(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nodeprep(Server),
+    LUser = jid:nodeprep(User),
+    LServer = jid:nodeprep(Server),
     ?BACKEND:remove_user(LUser,LServer).
 
 %% react to "global" config change
@@ -433,7 +433,7 @@ find_xdata_el1([_ | Els]) ->
 search_result(Lang, JID, VHost, Data) ->
     [#xmlel{name = <<"title">>,
             children = [#xmlcdata{content = [translate:translate(Lang, <<"Search Results for ">>),
-                                             jlib:jid_to_binary(JID)]}]}
+                                             jid:to_binary(JID)]}]}
                                              | ?BACKEND:search(VHost, Data, Lang, get_default_reported_fields(Lang))].
 b2l(Binary) ->
     binary_to_list(Binary).
@@ -464,7 +464,7 @@ prepare_vcard_search_params(User, VHost, VCARD) ->
                 _ -> EMail1
             end,
 
-    LUser     = jlib:nodeprep(User),
+    LUser     = jid:nodeprep(User),
     LFN       = stringprep:tolower(FN),
     LFamily   = stringprep:tolower(Family),
     LGiven    = stringprep:tolower(Given),

--- a/apps/ejabberd/src/mod_vcard_mnesia.erl
+++ b/apps/ejabberd/src/mod_vcard_mnesia.erl
@@ -44,7 +44,7 @@ get_vcard(LUser, LServer) ->
     end.
 
 set_vcard(User, VHost, VCard, VCardSearch) ->
-    LUser = jlib:nodeprep(User),
+    LUser = jid:nodeprep(User),
     F = fun() ->
                 mnesia:write(#vcard{us ={LUser,VHost}, vcard = VCard}),
                 mnesia:write(VCardSearch)

--- a/apps/ejabberd/src/mod_vcard_odbc.erl
+++ b/apps/ejabberd/src/mod_vcard_odbc.erl
@@ -66,7 +66,7 @@ get_vcard(LUser, LServer) ->
     end.
 
 set_vcard(User, VHost, VCard, VCardSearch) ->
-    LUser = jlib:nodeprep(User),
+    LUser = jid:nodeprep(User),
     Username = ejabberd_odbc:escape(User),
     LUsername = ejabberd_odbc:escape(LUser),
     LServer = ejabberd_odbc:escape(VHost),

--- a/apps/ejabberd/src/mod_vcard_riak.erl
+++ b/apps/ejabberd/src/mod_vcard_riak.erl
@@ -40,7 +40,7 @@ remove_user(LUser, LServer) ->
 set_vcard(User, VHost, VCard, _VCardSearch) ->
     BucketType = bucket_type(VHost),
     VCardEncoded = exml:to_binary(VCard),
-    LUser = jlib:nodeprep(User),
+    LUser = jid:nodeprep(User),
     Obj = riakc_obj:new(BucketType, LUser, VCardEncoded, "application/xml"),
     mongoose_riak:put(Obj).
 

--- a/apps/ejabberd/src/scram.erl
+++ b/apps/ejabberd/src/scram.erl
@@ -66,7 +66,7 @@
 
 -spec salted_password(binary(), binary(), non_neg_integer()) -> binary().
 salted_password(Password, Salt, IterationCount) ->
-    hi(jlib:resourceprep(Password), Salt, IterationCount).
+    hi(jid:resourceprep(Password), Salt, IterationCount).
 
 -spec client_key(binary()) -> binary().
 client_key(SaltedPassword) ->

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE.erl
@@ -44,5 +44,5 @@ stop_c2s(C2SPid) when is_pid(C2SPid) ->
     ejabberd_c2s_SUITE_mocks:teardown().
 
 jid(Str) ->
-    jlib:binary_to_jid(Str).
+    jid:from_binary(Str).
 

--- a/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
+++ b/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
@@ -110,7 +110,7 @@ init_per_suite(Config) ->
               end,
 
     AuthMods = auth_modules(),
-    
+
     NewConfig = escalus:init_per_suite([{ctl_path, CtlPath},
                                         {ctl_auth_mods, AuthMods},
                                         {roster_template, TemplatePath} | Config]),
@@ -234,7 +234,7 @@ ban_account(Config) ->
 num_active_users(Config) ->
     {AliceName, Domain, _} = get_user_data(alice, Config),
     {MikeName, Domain, _} = get_user_data(mike, Config),
-    
+
     {Mega, Secs, _} = erlang:now(),
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now),
@@ -246,13 +246,13 @@ delete_old_users(Config) ->
     {BobName, Domain, _} = get_user_data(bob, Config),
     {KateName, Domain, _} = get_user_data(kate, Config),
     {MikeName, Domain, _} = get_user_data(mike, Config),
-    
+
     {Mega, Secs, _} = erlang:now(),
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now),
     set_last(BobName, Domain, Now),
     set_last(MikeName, Domain, Now),
-    
+
     {_, 0} = ejabberdctl("delete_old_users", ["10"], Config),
     {_, 0} = ejabberdctl("check_account", [AliceName, Domain], Config),
     {_, ErrCode} = ejabberdctl("check_account", [KateName, Domain], Config),
@@ -262,7 +262,7 @@ delete_old_users_vhost(Config) ->
     {AliceName, Domain, _} = get_user_data(alice, Config),
     {KateName, Domain, KatePass} = get_user_data(kate, Config),
     SecDomain = escalus_config:get_config(ejabberd_secondary_domain, Config),
-    
+
     {Mega, Secs, _} = erlang:now(),
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now-86400*30),
@@ -340,10 +340,10 @@ sessions_info(Config) ->
 
 set_presence(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
-                Username = escalus_client:username(Alice), 
-                Domain = escalus_client:server(Alice), 
+                Username = escalus_client:username(Alice),
+                Domain = escalus_client:server(Alice),
                 Resource = escalus_client:resource(Alice),
-                
+
                 {_, 0} = ejabberdctl("set_presence", [Username, Domain, Resource,
                                                       "available", "away", "mystatus", "10"], Config),
                 Presence = escalus:wait_for_stanza(Alice),
@@ -358,28 +358,28 @@ set_presence(Config) ->
 
 vcard_rw(Config) ->
     {Username, Domain, _} = get_user_data(alice, Config),
-    
+
     {_, ExitCode} = ejabberdctl("get_vcard", [Username, Domain, "NICKNAME"], Config),
     true = (ExitCode /= 0),
-    
+
     {_, 0} = ejabberdctl("set_vcard", [Username, Domain, "NICKNAME", "SomeNickname"], Config),
     {"SomeNickname\n", 0} = ejabberdctl("get_vcard", [Username, Domain, "NICKNAME"], Config).
 
 vcard2_rw(Config) ->
     {Username, Domain, _} = get_user_data(alice, Config),
-    
+
     {_, ExitCode} = ejabberdctl("get_vcard2", [Username, Domain, "ORG", "ORGNAME"], Config),
     true = (ExitCode /= 0),
-    
+
     {_, 0} = ejabberdctl("set_vcard2", [Username, Domain, "ORG", "ORGNAME", "ESL"], Config),
     {"ESL\n", 0} = ejabberdctl("get_vcard2", [Username, Domain, "ORG", "ORGNAME"], Config).
 
 vcard2_multi_rw(Config) ->
     {Username, Domain, _} = get_user_data(alice, Config),
-    
+
     {_, ExitCode} = ejabberdctl("get_vcard2_multi", [Username, Domain, "ORG", "ORGUNIT"], Config),
     true = (ExitCode /= 0),
-    
+
     {_, 0} = ejabberdctl("set_vcard2_multi", [Username, Domain, "ORG", "ORGUNIT", "'sales;marketing'"], Config),
     {OrgUnits0, 0} = ejabberdctl("get_vcard2_multi", [Username, Domain, "ORG", "ORGUNIT"], Config),
     OrgUnits = string:tokens(OrgUnits0, "\n"),
@@ -395,7 +395,7 @@ rosteritem_rw(Config) ->
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 {BobName, Domain, _} = get_user_data(bob, Config),
                 {MikeName, Domain, _} = get_user_data(mike, Config),
-                
+
                 {_, 0} = ejabberdctl("add_rosteritem", [AliceName, Domain, BobName,
                                                         Domain, "MyBob", "MyGroup", "both"], Config),
                 {_, 0} = ejabberdctl("add_rosteritem", [AliceName, Domain, MikeName,
@@ -418,7 +418,7 @@ rosteritem_rw(Config) ->
                 escalus:assert(roster_contains, [mike], Roster1),
 
                 {_, 0} = ejabberdctl("delete_rosteritem", [AliceName, Domain, BobName, Domain], Config),
-                
+
                 Push3 = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_roster_set, Push3),
                 escalus:assert(roster_contains, [bob], Push3),
@@ -433,13 +433,13 @@ presence_after_add_rosteritem(Config) ->
      escalus:story(Config, [{alice, 1}, {bob,1}], fun(Alice, Bob) ->
                  {AliceName, Domain, _} = get_user_data(alice, Config),
                  {BobName, Domain, _} = get_user_data(bob, Config),
- 
+
                  {_, 0} = ejabberdctl("add_rosteritem", [AliceName, Domain, BobName,
                                                          Domain, "MyBob", "MyGroup", "both"], Config),
 
                  escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
                  escalus:assert(is_presence, escalus:wait_for_stanza(Bob)),
- 
+
                  escalus:send(Alice, escalus_stanza:roster_remove_contact(bob))  % cleanup
          end).
 
@@ -447,7 +447,7 @@ push_roster(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 TemplatePath = escalus_config:get_config(roster_template, Config),
-                
+
                 {_, 0} = ejabberdctl("push_roster", [TemplatePath, AliceName, Domain], Config),
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster1 = escalus:wait_for_stanza(Alice),
@@ -467,7 +467,7 @@ push_roster_all(Config) ->
                 Roster1 = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_roster_result, Roster1),
                 escalus:assert(roster_contains, [bob], Roster1),
-                
+
                 escalus:send(Bob, escalus_stanza:roster_get()),
                 Roster2 = escalus:wait_for_stanza(Bob),
                 escalus:assert(is_roster_result, Roster2),
@@ -485,7 +485,7 @@ push_roster_alltoall(Config) ->
 
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster = escalus:wait_for_stanza(Alice),
-                
+
                 escalus:assert(is_roster_result, Roster),
                 escalus:assert(roster_contains, [bob], Roster),
                 escalus:assert(roster_contains, [mike], Roster),
@@ -500,7 +500,7 @@ set_last(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 {BobName, Domain, _} = get_user_data(bob, Config),
-                
+
                 {_, 0} = ejabberdctl("add_rosteritem", [AliceName, Domain, BobName,
                                                         Domain, "MyBob", "MyGroup", "both"], Config),
                 {_, 0} = ejabberdctl("add_rosteritem", [BobName, Domain, AliceName,
@@ -551,7 +551,7 @@ send_message(Config) ->
                                                            "\"Hi Bob!\""], Config),
                 Stanza1 = escalus:wait_for_stanza(Bob1),
                 escalus:assert(is_chat_message, [<<"Hi Bob!">>], Stanza1),
-                
+
                 {_, 0} = ejabberdctl("send_message_headline", [escalus_client:full_jid(Alice),
                                                                     escalus_client:short_jid(Bob1),
                                                                     "Subj", "\"Hi Bob!!\""], Config),
@@ -585,11 +585,11 @@ stats_global(Config) ->
     escalus:story(Config, [{alice, 1}, {bob,1}], fun(_Alice, _Bob) ->
                 RegisteredCount = length(escalus_config:get_config(escalus_users, Config, [])),
                 Registered = integer_to_list(RegisteredCount) ++ "\n",
-                
+
                 {UpTime, 0} = ejabberdctl("stats", ["uptimeseconds"], Config),
                 _ = list_to_integer(string:strip(UpTime, both, $\n)),
                 {Registered, 0} = ejabberdctl("stats", ["registeredusers"], Config),
-                
+
                 {"2\n", 0} = ejabberdctl("stats", ["onlineusersnode"], Config),
 
                 {"2\n", 0} = ejabberdctl("stats", ["onlineusers"], Config)
@@ -605,7 +605,7 @@ stats_host(Config) ->
 
                 {Registered, 0} = ejabberdctl("stats_host", ["registeredusers", PriDomain], Config),
                 {"0\n", 0} = ejabberdctl("stats_host", ["registeredusers", SecDomain], Config),
-                
+
                 {"2\n", 0} = ejabberdctl("stats_host", ["onlineusers", PriDomain], Config),
                 {"0\n", 0} = ejabberdctl("stats_host", ["onlineusers", SecDomain], Config)
         end).
@@ -718,8 +718,8 @@ remove_old_messages_test(Config) ->
         %% given
         JidA = nick_to_jid(alice, Config),
         JidB = nick_to_jid(bob, Config),
-        JidRecordAlice = rpc_call(jlib, binary_to_jid, [JidA]),
-        JidRecordBob = rpc_call(jlib, binary_to_jid, [JidB]),
+        JidRecordAlice = rpc_call(jid, from_binary, [JidA]),
+        JidRecordBob = rpc_call(jid, from_binary, [JidB]),
         Msg1 = escalus_stanza:chat_to(<<"bob@localhost">>, "Hi, how are you? Its old message!"),
         Msg2 = escalus_stanza:chat_to(<<"bob@localhost">>, "Hello its new message!"),
         OldTimestamp = fallback_timestamp(10, now()),
@@ -739,8 +739,8 @@ remove_expired_messages_test(Config) ->
         %% given
         JidA = nick_to_jid(mike, Config),
         JidB = nick_to_jid(kate, Config),
-        JidRecordMike = rpc_call(jlib, binary_to_jid, [JidA]),
-        JidRecordKate = rpc_call(jlib, binary_to_jid, [JidB]),
+        JidRecordMike = rpc_call(jid, from_binary, [JidA]),
+        JidRecordKate = rpc_call(jid, from_binary, [JidB]),
         Msg1 = escalus_stanza:chat_to(<<"kate@localhost">>, "Rolling stones"),
         Msg2 = escalus_stanza:chat_to(<<"kate@localhost">>, "Arctic monkeys!"),
         Msg3 = escalus_stanza:chat_to(<<"kate@localhost">>, "More wine..."),

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -2245,9 +2245,9 @@ muc_bootstrap_archive(Config) ->
               rpc_apply(mod_mam_muc, archive_id, [Domain, Room])},
     Msgs = generate_msgs_for_days(ArcJID,
                                  [{B, make_jid(<<"bob">>, Host, <<"res1">>),
-                                  rpc_apply(jlib, jid_replace_resource, [RoomJid, nick(bob)])},
+                                  rpc_apply(jid, replace_resource, [RoomJid, nick(bob)])},
                                   {A, make_jid(<<"alice">>, Host, <<"res1">>),
-                                   rpc_apply(jlib, jid_replace_resource, [RoomJid, nick(alice)])}], 16),
+                                   rpc_apply(jid, replace_resource, [RoomJid, nick(alice)])}], 16),
 
     put_muc_msgs(Msgs),
 
@@ -2269,7 +2269,7 @@ nick_to_jid(UserName, Config) when is_atom(UserName) ->
     escalus_utils:jid_to_lower(escalus_users:get_jid(Config, UserSpec)).
 
 make_jid(U, S, R) ->
-    rpc_apply(jlib, make_jid, [U, S, R]).
+    rpc_apply(jid, make, [U, S, R]).
 
 
 is_mam_possible(Host) ->


### PR DESCRIPTION
This PR introduces `jid` module where all jid-specific functions are defined. Previously they were defined in `jlib`, it's still possible to use this module for jid manipulation but this will produce a log message on warning level saying that given function has been deprecated and will be removed.