### PR TITLE
change `make rel` default configuration to `full`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,19 +34,19 @@ otp_release:
         - 17.5
 env:
         - PRESET=internal_redis DB=mnesia REL_CONFIG=with-redis
-        - PRESET=internal_mnesia DB=mnesia
+        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal
         - PRESET=mysql_mnesia DB=mysql REL_CONFIG=with-mysql
         - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
         - PRESET=pgsql_mnesia DB=pgsql REL_CONFIG=with-pgsql
-        - PRESET=ldap_mnesia DB=mnesia
+        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=minimal
         - PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
-        - PRESET=external_mnesia DB=mnesia
+        - PRESET=external_mnesia DB=mnesia REL_CONFIG=minimal
 
 matrix:
     include:
         - otp_release: R15B03
-          env: PRESET=internal_mnesia DB=mnesia
+          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal
         - otp_release: R16B03
-          env: PRESET=internal_mnesia DB=mnesia
+          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal
         - otp_release: 18.0
-          env: PRESET=internal_mnesia DB=mnesia
+          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,11 @@ eunit: rebar deps
 configure:
 	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
 
-rel: certs rebar deps
+rel: certs rebar deps configure.out
 	./rebar compile generate -f
+
+configure.out:
+	./tools/configure full
 
 devrel: certs $(DEVNODES)
 

--- a/tools/configure
+++ b/tools/configure
@@ -45,4 +45,6 @@ usage() ->
     io:format("specifies which 3rd party deps will be included in release~n"),
     io:format("possible options:~n"),
     [io:format("~s\t~s~n", [Opt, Desc]) || {Opt, Desc} <- all_opts_with_desc()],
-    io:format("~s\t\t~s~n", ["full", "include all above deps"]).
+    io:format("~s\t\t~s~n", ["full", "include all above deps"]),
+    io:format("~s\t\t~s~n", ["minimal", "does not include any of above deps"]).
+    


### PR DESCRIPTION
Current default configuration which is `mnesia-only` is error-prone. This PR changes that so the default config is full now. This approach will be easier for most people trying new features like f.e. Riak backends. 