### PR TITLE
Riak MAM for muc

### DIFF
--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -537,9 +537,6 @@ get_prefs(Host, ArcID, ArcJID, GlobalDefaultMode) ->
 
 -spec remove_archive(ejabberd:server(), mod_mam:archive_id() | undefined,
                      ejabberd:jid()) -> 'ok'.
-remove_archive(_Host, undefined, #jid{user=User, server=Server}) ->
-    ?WARNING_MSG("Archive ~ts@~ts does not exist.", [User, Server]),
-    ok;
 remove_archive(Host, ArcID, ArcJID=#jid{}) ->
     ejabberd_hooks:run(mam_muc_remove_archive, Host, [Host, ArcID, ArcJID]),
     ok.

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -45,9 +45,26 @@
 -define(YZ_SEARCH_INDEX, <<"mam">>).
 -define(MAM_BUCKET_TYPE, <<"mam_yz">>).
 
+%% @doc Start module
+%%
+%% Options:
+%% - `pm' option starts one-to-one chat archives
+%% - `muc' option starts multichat archives
+%%
+%% Use both options `pm, muc' to archive both MUC and private messages
 start(Host, Opts) ->
-    start_chat_archive(Host, Opts),
-    start_muc_archive(Host, Opts).
+    case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
+        true ->
+            start_chat_archive(Host, Opts);
+        false ->
+            ok
+    end,
+    case gen_mod:get_module_opt(Host, ?MODULE, muc, false) of
+        true ->
+            start_muc_archive(Host, Opts);
+        false ->
+            ok
+    end.
 
 start_chat_archive(Host, _Opts) ->
     ejabberd_hooks:add(mam_archive_message, Host, ?MODULE, safe_archive_message, 50),
@@ -66,8 +83,18 @@ start_muc_archive(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_purge_multiple_messages, Host, ?MODULE, purge_multiple_messages, 50).
 
 stop(Host) ->
-    stop_chat_archive(Host),
-    stop_muc_archive(Host).
+    case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
+        true ->
+            stop_chat_archive(Host);
+        false ->
+            ok
+    end,
+    case gen_mod:get_module_opt(Host, ?MODULE, muc, false) of
+        true ->
+            stop_muc_archive(Host);
+        false ->
+            ok
+    end.
 
 stop_chat_archive(Host) ->
     ejabberd_hooks:delete(mam_archive_message, Host, ?MODULE, safe_archive_message_muc, 50),

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -32,7 +32,9 @@
          purge_multiple_messages/9]).
 
 -export([safe_archive_message/9,
-         lookup_messages/14]).
+         safe_archive_message_muc/9,
+         lookup_messages/14,
+         lookup_messages_muc/14]).
 
 -export([key/3]).
 
@@ -44,36 +46,45 @@
 -define(MAM_BUCKET_TYPE, <<"mam_yz">>).
 
 start(Host, Opts) ->
-    start_chat_archive(Host, Opts).
+    start_chat_archive(Host, Opts),
+    start_muc_archive(Host, Opts).
 
 start_chat_archive(Host, _Opts) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
-        true ->
-            ok;
-        false ->
-            ejabberd_hooks:add(mam_archive_message, Host, ?MODULE, safe_archive_message, 50)
-    end,
+    ejabberd_hooks:add(mam_archive_message, Host, ?MODULE, safe_archive_message, 50),
     ejabberd_hooks:add(mam_archive_size, Host, ?MODULE, archive_size, 50),
     ejabberd_hooks:add(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
     ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
     ejabberd_hooks:add(mam_purge_single_message, Host, ?MODULE, purge_single_message, 50),
     ejabberd_hooks:add(mam_purge_multiple_messages, Host, ?MODULE, purge_multiple_messages, 50).
 
+start_muc_archive(Host, _Opts) ->
+    ejabberd_hooks:add(mam_muc_archive_message, Host, ?MODULE, safe_archive_message_muc, 50),
+    ejabberd_hooks:add(mam_muc_archive_size, Host, ?MODULE, archive_size, 50),
+    ejabberd_hooks:add(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages_muc, 50),
+    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50),
+    ejabberd_hooks:add(mam_muc_purge_single_message, Host, ?MODULE, purge_single_message, 50),
+    ejabberd_hooks:add(mam_muc_purge_multiple_messages, Host, ?MODULE, purge_multiple_messages, 50).
+
 stop(Host) ->
-    stop_chat_archive(Host).
+    stop_chat_archive(Host),
+    stop_muc_archive(Host).
 
 stop_chat_archive(Host) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
-        true ->
-            ok;
-        false ->
-            ejabberd_hooks:delete(mam_archive_message, Host, ?MODULE, safe_archive_message, 50)
-    end,
+    ejabberd_hooks:delete(mam_archive_message, Host, ?MODULE, safe_archive_message_muc, 50),
     ejabberd_hooks:delete(mam_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:delete(mam_lookup_messages, Host, ?MODULE, safe_lookup_messages, 50),
+    ejabberd_hooks:delete(mam_lookup_messages, Host, ?MODULE, lookup_messages_muc, 50),
     ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
     ejabberd_hooks:delete(mam_purge_single_message, Host, ?MODULE, purge_single_message, 50),
     ejabberd_hooks:delete(mam_purge_multiple_messages, Host, ?MODULE, purge_multiple_messages, 50),
+    ok.
+
+stop_muc_archive(Host) ->
+    ejabberd_hooks:delete(mam_muc_archive_message, Host, ?MODULE, safe_archive_message, 50),
+    ejabberd_hooks:delete(mam_muc_archive_size, Host, ?MODULE, archive_size, 50),
+    ejabberd_hooks:delete(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 50),
+    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50),
+    ejabberd_hooks:delete(mam_muc_purge_single_message, Host, ?MODULE, purge_single_message, 50),
+    ejabberd_hooks:delete(mam_muc_purge_multiple_messages, Host, ?MODULE, purge_multiple_messages, 50),
     ok.
 
 safe_archive_message(Result, Host, MessID, UserID,
@@ -94,6 +105,16 @@ safe_archive_message(Result, Host, MessID, UserID,
         {error, Reason}
     end.
 
+safe_archive_message_muc(Result, Host, MessId, UserID, LocJID, RemJID, SrcJID, Dir, Packet) ->
+    RemJIDMuc = maybe_muc_jid(RemJID),
+    safe_archive_message(Result, Host, MessId, UserID, LocJID, RemJIDMuc, SrcJID, Dir, Packet).
+
+maybe_muc_jid(#jid{lresource = RemRes}) ->
+    {<<>>, RemRes, <<>>};
+maybe_muc_jid(Other) ->
+    Other.
+
+
 lookup_messages({error, _Reason} = Result, _Host,
                      _UserID, _UserJID, _RSM, _Borders,
                      _Start, _End, _Now, _WithJID,
@@ -113,6 +134,19 @@ lookup_messages(_Result, _Host,
     catch _Type:Reason ->
         {error, Reason}
     end.
+
+lookup_messages_muc(Result, Host,
+                    UserID, UserJID, RSM, Borders,
+                    Start, End, _Now, WithJID,
+                    PageSize, LimitPassed, MaxResultLimit,
+                    IsSimple) ->
+    WithJIDMuc = maybe_muc_jid(WithJID),
+    lookup_messages(Result, Host,
+                    UserID, UserJID, RSM, Borders,
+                    Start, End, _Now, WithJIDMuc,
+                    PageSize, LimitPassed, MaxResultLimit,
+                    IsSimple).
+
 
 archive_size(Size, _Host, _ArchiveID, _ArchiveJID) ->
     Size.

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -73,7 +73,15 @@ In order to use Riak as the backend for one-to-one archives, the following confi
 
 ```erlang
 {mod_mam, []}.
-{mod_mam_riak_timed_arch_yz, []}.
+{mod_mam_riak_timed_arch_yz, [pm]}.
+```
+
+To archive both one-to-one and multichat messages use this configuration instead:
+
+```erlang
+{mod_mam, []}.
+{mod_mam_muc, []}.
+{mod_mam_riak_timed_arch_yz, [pm, muc]}.
 ```
 
 The Riak backend for MAM stores messages in weekly buckets so it's easier to remove old buckets.

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -472,7 +472,7 @@ init_modules(odbc_async, _, Config) ->
     init_module(host(), mod_mam_odbc_user, [pm]),
     Config;
 init_modules(riak_timed_yz_buckets, _, Config) ->
-    init_module(host(), mod_mam_riak_timed_arch_yz, [pm]),
+    init_module(host(), mod_mam_riak_timed_arch_yz, [pm, muc]),
     init_module(host(), mod_mam, []),
     init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
     Config;

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -192,8 +192,6 @@ groups() ->
      || C <- configurations(), {G, Props, Tests} <- basic_groups(),
         not is_skipped(C, G)].
 
-is_skipped(riak_timed_yz_buckets, G) ->
-    lists:member(G, [muc, muc_with_pm, muc_rsm]);
 is_skipped(_, _) ->
     false.
 
@@ -476,6 +474,7 @@ init_modules(odbc_async, _, Config) ->
 init_modules(riak_timed_yz_buckets, _, Config) ->
     init_module(host(), mod_mam_riak_timed_arch_yz, [pm]),
     init_module(host(), mod_mam, []),
+    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
     Config;
 init_modules(odbc_async_pool, _, Config) ->
     init_module(host(), mod_mam, []),
@@ -1053,6 +1052,7 @@ muc_archive_request(Config) ->
         %% Attribute giving the message's UID within the archive.
         Id  = exml_query:attr(Arc, <<"id">>),
 
+        maybe_wait_for_yz(Config),
 
         %% Bob requests the room's archive.
         escalus:send(Bob, stanza_to_room(stanza_archive_request(<<"q1">>), Room)),
@@ -1094,6 +1094,7 @@ muc_archive_purge(Config) ->
         escalus:send(Alice, stanza_to_room(stanza_purge_multiple_messages(
            undefined, undefined, undefined), Room)),
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+        maybe_wait_for_yz(Config),
         ok
     end,
     escalus:story(Config, [1, 1], F).
@@ -1150,6 +1151,9 @@ muc_multiple_devices(Config) ->
         ?assert_equal(Alice1Arc, Arc),
 
         %% Bob requests the room's archive.
+
+        maybe_wait_for_yz(Config),
+
         escalus:send(Bob, stanza_to_room(stanza_archive_request(<<"q1">>), Room)),
         [_ArcRes, ArcMsg] = assert_respond_size(1, wait_archive_respond_iq_first(Bob)),
         #forwarded_message{result_id=ArcId, message_body=ArcMsgBody} =
@@ -2074,6 +2078,7 @@ clean_room_archive(Config) ->
     Room = ?config(room, Config),
     delete_room_archive(muc_host(), Room),
     timer:sleep(500),
+    maybe_wait_for_yz(Config),
     assert_empty_room_archive(muc_host(), Room),
     Config.
 
@@ -2250,6 +2255,8 @@ muc_bootstrap_archive(Config) ->
                                    rpc_apply(jid, replace_resource, [RoomJid, nick(alice)])}], 16),
 
     put_muc_msgs(Msgs),
+
+    maybe_wait_for_yz(Config),
 
     [{pre_generated_muc_msgs, sort_msgs(Msgs)} | Config].
 


### PR DESCRIPTION
This PR introduces simplest MAM MUC archive in Riak. MUC archives are kept in the same buckets as regular one-to-one archives. The archive is "owned" by the room only - this means:
* the message is stored only once despite the number of occupants
* everyone can read the history, even if joined after a message was archived