### PR TITLE
External component adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
-script: tools/travis-test.sh
+script: tools/travis-test.sh $PRESET
 
 after_success:
         - make cover_report

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EJD_INCLUDE = $(EJABBERD_DIR)/include
 EJD_PRIV = $(EJABBERD_DIR)/priv
 XEP_TOOL = tools/xep_tool
 EJD_EBIN = $(EJABBERD_DIR)/ebin
-DEVNODES = node1 node2
+DEVNODES = node1 node2 fed1
 
 all: deps compile
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,10 @@ reload: quick_compile
 	rsync -uW ./apps/ejabberd/ebin/*beam ./rel/mongooseim/lib/$$E/ebin/ ;\
 
 reload_dev: quick_compile
-	@E=`ls ./dev/mongooseim_node1/lib/ | grep ejabberd-2 | sort -r | head -n 1` ;\
-	rsync -uW ./apps/ejabberd/ebin/*beam ./dev/mongooseim_node1/lib/$$E/ebin/ ;\
+	@for NODE in $(DEVNODES); do \
+		E=`ls ./dev/mongooseim_$$NODE/lib/ | grep ejabberd-2 | sort -r | head -n 1` ;\
+		rsync -uW ./apps/ejabberd/ebin/*beam ./dev/mongooseim_$$NODE/lib/$$E/ebin/ ;\
+	done
 
 ct: deps quick_compile
 	@(if [ "$(SUITE)" ]; then ./rebar ct suite=$(SUITE) skip_deps=true;\

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -38,7 +38,11 @@
          unregister_route/1,
          unregister_routes/1,
          dirty_get_all_routes/0,
-         dirty_get_all_domains/0
+         dirty_get_all_domains/0,
+         register_components/1,
+         register_component/1,
+         unregister_component/1,
+         unregister_components/1
         ]).
 
 -export([start_link/0]).
@@ -61,6 +65,10 @@
 -record(route, {domain :: domain(),
                 handler :: handler()
                }).
+
+-record(external_component, {domain  :: domain(),
+                             handler :: handler()}).
+
 -record(state, {}).
 
 %%====================================================================
@@ -93,6 +101,44 @@ route_error(From, To, ErrPacket, OrigPacket) ->
         true ->
             ok
     end.
+
+-spec register_components([Domain :: domain()]) -> {atomic, ok}.
+register_components(Domains) ->
+    LDomains = [{jlib:nameprep(Domain), Domain} || Domain <- Domains],
+    Handler = make_handler(undefined),
+    F = fun() ->
+            [do_register_component(LDomain, Handler) || LDomain <- LDomains],
+            ok
+    end,
+    {atomic, ok} = mnesia:transaction(F).
+
+-spec register_component(Domain :: domain()) -> {atomic, ok}.
+register_component(Domain) ->
+    register_components([Domain]).
+
+do_register_component({error, Domain}, _Handler) ->
+    error({invalid_domain, Domain});
+do_register_component({LDomain, _}, Handler) ->
+    Component = #external_component{domain = LDomain, handler = Handler},
+    ok = mnesia:write(Component).
+
+-spec unregister_components([Domains :: domain()]) -> {atomic, ok}.
+unregister_components(Domains) ->
+    LDomains = [{jlib:nameprep(Domain), Domain} || Domain <- Domains],
+    F = fun() ->
+            [do_unregister_component(LDomain) || LDomain <- LDomains],
+            ok
+    end,
+    {atomic, ok} = mnesia:transaction(F).
+
+do_unregister_component({error, Domain}) ->
+    error({invalid_domain, Domain});
+do_unregister_component({LDomain, _}) ->
+    ok = mnesia:delete({external_component, LDomain}).
+
+-spec unregister_component(Domain :: domain()) -> {atomic, ok}.
+unregister_component(Domain) ->
+    unregister_components([Domain]).
 
 -spec register_route(Domain :: domain()) -> any().
 register_route(Domain) ->
@@ -146,10 +192,13 @@ unregister_routes(Domains) ->
 
 
 dirty_get_all_routes() ->
-    lists:usort(mnesia:dirty_all_keys(route)) -- ?MYHOSTS.
+    lists:usort(all_routes()) -- ?MYHOSTS.
 
 dirty_get_all_domains() ->
-    lists:usort(mnesia:dirty_all_keys(route)).
+    lists:usort(all_routes()).
+
+all_routes() ->
+    mnesia:dirty_all_keys(route) ++ mnesia:dirty_all_keys(external_component).
 
 
 %%====================================================================
@@ -171,6 +220,14 @@ init([]) ->
                          {attributes, record_info(fields, route)},
                          {local_content, true}]),
     mnesia:add_table_copy(route, node(), ram_copies),
+
+    %% add distributed service_component routes
+    mnesia:create_table(external_component,
+                        [{ram_copies, [node()]},
+                         {attributes, record_info(fields, external_component)},
+                         {type, set}]),
+    mnesia:add_table_copy(external_component, node(), ram_copies),
+
     {ok, #state{}}.
 
 %%--------------------------------------------------------------------
@@ -237,11 +294,18 @@ do_route(OrigFrom, OrigTo, OrigPacket) ->
                                  {OrigFrom, OrigTo, OrigPacket}, []) of
         {From, To, Packet} ->
             LDstDomain = To#jid.lserver,
-            case mnesia:dirty_read(route, LDstDomain) of
+            case mnesia:dirty_read(external_component, LDstDomain) of
                 [] ->
-                    ejabberd_s2s:route(From, To, Packet);
-                [#route{handler=Handler}] ->
-                    do_local_route(OrigFrom, OrigTo, OrigPacket, LDstDomain, Handler)
+                    case mnesia:dirty_read(route, LDstDomain) of
+                        [] ->
+                            ejabberd_s2s:route(From, To, Packet);
+                        [#route{handler=Handler}] ->
+                            do_local_route(OrigFrom, OrigTo, OrigPacket,
+                                           LDstDomain, Handler)
+                    end;
+                [#external_component{handler = Handler}] ->
+                    do_local_route(OrigFrom, OrigTo, OrigPacket,
+                                   LDstDomain, Handler)
             end;
         drop ->
             ejabberd_hooks:run(xmpp_stanza_dropped, 

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -411,20 +411,19 @@ fsm_limit_opts(Opts) ->
 -spec register_routes(state()) -> any().
 register_routes(#state{host=Subdomain, is_subdomain=true}) ->
     Hosts = ejabberd_config:get_global_option(hosts),
-    [register_route(<<Subdomain/binary, ".", Host/binary>>) || Host <- Hosts];
+    Routes = component_routes(Subdomain, Hosts),
+    ejabberd_router:register_components(Routes);
 register_routes(#state{host=Host}) ->
-    register_route(Host).
-
-register_route(Host) ->
-    ejabberd_router:register_route(Host),
-    ?INFO_MSG("Route registered for service ~p~n", [Host]).
+    ejabberd_router:register_component(Host).
 
 -spec unregister_routes(state()) -> any().
 unregister_routes(#state{host=Subdomain, is_subdomain=true}) ->
     Hosts = ejabberd_config:get_global_option(hosts),
-    [unregister_route(<<Subdomain/binary,".",Host/binary>>) || Host <- Hosts];
+    Routes = component_routes(Subdomain, Hosts),
+    ejabberd_router:unregister_components(Routes);
 unregister_routes(#state{host=Host}) ->
-    unregister_route(Host).
+    ejabberd_router:unregister_component(Host).
 
-unregister_route(Host) ->
-    ejabberd_router:unregister_route(Host).
+-spec component_routes(binary(), [binary()]) -> [binary()].
+component_routes(Subdomain, Hosts) ->
+    [<<Subdomain/binary, ".", Host/binary>> || Host <- Hosts].

--- a/apps/ejabberd/src/mod_websockets.erl
+++ b/apps/ejabberd/src/mod_websockets.erl
@@ -51,15 +51,17 @@
 -define(LISTENER, ?MODULE).
 -define(GEN_FSM, p1_fsm).
 -define(NS_FRAMING, <<"urn:ietf:params:xml:ns:xmpp-framing">>).
+-define(NS_COMPONENT, <<"jabber:component:accept">>).
 
 -record(websocket, {
           pid :: pid(),
           peername :: {inet:ip_address(), inet:port_number()}
          }).
 -record(ws_state, {
-          c2s_pid :: pid(),
+          fsm_pid :: pid(),
           open_tag :: stream | open,
           parser :: exml_stream:parser(),
+          opts :: proplists:proplist(),
           ping_rate :: integer()
          }).
 
@@ -155,10 +157,10 @@ init(Transport, Req, Opts) ->
     {upgrade, protocol, cowboy_websocket}.
 
 handle(Req, State) ->
-        {ok, Req, State}.
+    {ok, Req, State}.
 
 terminate(_Reason, _Req, _State) ->
-        ok.
+    ok.
 
 %%--------------------------------------------------------------------
 %% cowboy_http_websocket_handler callbacks
@@ -167,36 +169,18 @@ terminate(_Reason, _Req, _State) ->
 % Called for every new websocket connection.
 websocket_init(Transport, Req, Opts) ->
     ?DEBUG("websocket_init: ~p~n", [{Transport, Req, Opts}]),
-    {Peer, NewReq} = cowboy_req:peer(Req),
-    NewReq2 = cowboy_req:set_resp_header(<<"Sec-WebSocket-Protocol">>, <<"xmpp">>, NewReq),
-    SocketData = #websocket{pid=self(),
-                            peername = Peer},
-    C2SOpts = [{xml_socket, true} | Opts],
-    case ejabberd_c2s:start({?MODULE, SocketData}, C2SOpts) of
-        {ok, Pid} ->
-            ?DEBUG("started c2s via websockets: ~p", [Pid]),
-            State = #ws_state{c2s_pid = Pid},
-            Timeout = gen_mod:get_opt(timeout, Opts, infinity),
-            PingRate = gen_mod:get_opt(ping_rate, Opts, none),
-            ?DEBUG("ping rate is ~p", [PingRate]),
-            maybe_send_ping_request(PingRate),
-            NewState = State#ws_state{ping_rate = PingRate},
-            {ok, NewReq2, NewState, Timeout};
-        {error, Reason} ->
-            ?WARNING_MSG("c2s start failed: ~p", [Reason]),
-            {shutdown, NewReq2}
-    end.
+    Req1 = cowboy_req:set_resp_header(<<"Sec-WebSocket-Protocol">>, <<"xmpp">>, Req),
+    State = #ws_state{opts = Opts},
+    {ok, Req1, State}.
 
 % Called when a text message arrives.
 websocket_handle({text, Msg}, Req, State) ->
     ?DEBUG("Received: ~p", [Msg]),
-    {ok, NewState} = handle_text(Msg, State),
-    {ok, Req, NewState};
+    handle_text(Msg, Req, State);
 
 websocket_handle({binary, Msg}, Req, State) ->
     ?DEBUG("Received binary: ~p", [Msg]),
-    {ok, NewState} = handle_text(Msg, State),
-    {ok, Req, NewState};
+    handle_text(Msg, Req, State);
 
 websocket_handle({pong, Payload}, Req, State) ->
     ?DEBUG("Received pong frame: ~p", [Payload]),
@@ -250,22 +234,66 @@ websocket_terminate(_Reason, _Req, _State) ->
 %% Callbacks implementation
 %%--------------------------------------------------------------------
 
-handle_text(Text, #ws_state{ parser = undefined } = State) ->
+handle_text(Text, Req, #ws_state{ parser = undefined } = State) ->
     ParserOpts = get_parser_opts(Text),
     {ok, Parser} = exml_stream:new_parser(ParserOpts),
-    handle_text(Text, State#ws_state{ parser = Parser });
-handle_text(Text, #ws_state{c2s_pid = C2S, parser = Parser} = State) ->
+    handle_text(Text, Req, State#ws_state{ parser = Parser });
+handle_text(Text, Req, #ws_state{parser = Parser} = State) ->
     {ok, NewParser, Elements} = exml_stream:parse(Parser, Text),
     State1 = State#ws_state{ parser = NewParser },
-    {Elements1, State2} = process_client_stream_start(Elements, State1),
-    [send_to_c2s(C2S, process_client_stream_end(
-                        replace_stream_ns(Elem, State2), State2)) || Elem <- Elements1],
-    {ok, State2}.
+    case maybe_start_fsm(Elements, Req, State1) of
+        {ok, Req1, State2} ->
+            process_client_elements(Elements, Req1, State2);
+        {shutdown, _, _} = Shutdown ->
+            Shutdown
+    end.
 
-send_to_c2s(C2S, #xmlel{} = Element) ->
-    send_to_c2s(C2S, {xmlstreamelement, Element});
-send_to_c2s(C2S, StreamElement) ->
-    ?GEN_FSM:send_event(C2S, StreamElement).
+process_client_elements(Elements, Req, #ws_state{fsm_pid = FSM} = State) ->
+    {Elements1, State1} = process_client_stream_start(Elements, State),
+    [send_to_fsm(FSM, process_client_stream_end(
+                replace_stream_ns(Elem, State1), State1)) || Elem <- Elements1],
+    {ok, Req, State1}.
+
+send_to_fsm(FSM, #xmlel{} = Element) ->
+    send_to_fsm(FSM, {xmlstreamelement, Element});
+send_to_fsm(FSM, StreamElement) ->
+    ?GEN_FSM:send_event(FSM, StreamElement).
+
+maybe_start_fsm([#xmlstreamstart{ name = <<"stream", _/binary>>, attrs = Attrs}
+                 | _], Req,
+                #ws_state{fsm_pid = undefined, opts = Opts}=State) ->
+    {FSMModule, FSMOpts} = case lists:keyfind(<<"xmlns">>, 1, Attrs) of
+        {<<"xmlns">>, ?NS_COMPONENT} ->
+            ServiceOpts = gen_mod:get_opt(ejabberd_service, Opts, []),
+            {ejabberd_service, ServiceOpts};
+        _ ->
+            {ejabberd_c2s, Opts}
+    end,
+    do_start_fsm(FSMModule, FSMOpts, Req, State);
+maybe_start_fsm([#xmlel{ name = <<"open">> }],
+                Req, #ws_state{fsm_pid = undefined, opts = Opts}=State) ->
+    do_start_fsm(ejabberd_c2s, Opts, Req, State);
+maybe_start_fsm(_Els, Req, State) ->
+    {ok, Req, State}.
+
+do_start_fsm(FSMModule, Opts, Req, State) ->
+    {Peer, NewReq} = cowboy_req:peer(Req),
+    SocketData = #websocket{pid = self(),
+                            peername = Peer},
+    Opts1 = [{xml_socket, true} | Opts],
+    case FSMModule:start({?MODULE, SocketData}, Opts1) of
+        {ok, Pid} ->
+            ?DEBUG("started ~p via websockets: ~p", [FSMModule, Pid]),
+            Timeout = gen_mod:get_opt(timeout, Opts, infinity),
+            PingRate = gen_mod:get_opt(ping_rate, Opts, none),
+            ?DEBUG("ping rate is ~p", [PingRate]),
+            maybe_send_ping_request(PingRate),
+            NewState = State#ws_state{fsm_pid = Pid, ping_rate = PingRate},
+            {ok, NewReq, NewState, Timeout};
+        {error, Reason} ->
+            ?WARNING_MSG("~p start failed: ~p", [FSMModule, Reason]),
+            {shutdown, NewReq, State}
+    end.
 
 %%--------------------------------------------------------------------
 %% ejabberd_socket compatibility
@@ -338,8 +366,8 @@ process_client_stream_start([#xmlel{ name = <<"open">>, attrs = Attrs }], State)
     Attrs2 = [{<<"xmlns:stream">>, ?NS_STREAM} | Attrs1],
     NewStart = #xmlstreamstart{ name = <<"stream:stream">>, attrs = Attrs2 },
     {[NewStart], State#ws_state{ open_tag = open }};
-process_client_stream_start(_, #ws_state{ c2s_pid = C2SPid } = State) ->
-    send_to_c2s(C2SPid, {xmlstreamerror, <<"Unknown opening tag">>}),
+process_client_stream_start(_, #ws_state{ fsm_pid = FSMPid } = State) ->
+    send_to_fsm(FSMPid, {xmlstreamerror, <<"Unknown opening tag">>}),
     {[], State}.
 
 process_client_stream_end(#xmlel{ name = <<"close">> }, #ws_state{ open_tag = open }) ->

--- a/apps/ejabberd/src/mongoose_cover_helper.erl
+++ b/apps/ejabberd/src/mongoose_cover_helper.erl
@@ -34,7 +34,7 @@ cover_compile_app(App) ->
 
 do_cover_compile_app(App, {error, Error}) ->
     [{error, App, Error}];
-do_cover_compile_app(_App, AppPath) ->
+do_cover_compile_app(App, AppPath) ->
     EbinDir = filename:join(AppPath, "ebin"),
     BeamFilter = fun
         %% modules not compatible with cover
@@ -50,7 +50,7 @@ do_cover_compile_app(_App, AppPath) ->
         {ok, Files} ->
             BeamFileNames = lists:filter(BeamFilter, Files),
             BeamFiles = [filename:join(EbinDir, File) || File <- BeamFileNames],
-            compile_beams(BeamFiles, []);
+            [{App, compile_beams(BeamFiles, [])}];
         Error ->
             [{error, EbinDir, Error}]
     end.

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -37,13 +37,28 @@ Manages all HTTP-based services. Unlike `ejabberd_c2s`, it doesn't use `ejabberd
 * `key` (string, optional, no default value) - Path to the SSL private key in X509 format.
 * `key_pass` (string, optional, default: `undefined`) - Password to a private key, `undefined` for no password.
 * `modules` (list of tuples: `{Host, Path, Modules}`) - List of enabled HTTP-based modules. `"_"` equals any host.
-    * `mod_bosh` - BOSH connections handler. Default declaration: `{"_", "/http-bind", mod_bosh}`
+    * `mod_bosh` - BOSH connections handler. Default declaration:
+
+            `{"_", "/http-bind", mod_bosh}`
+
     * `mod_websockets` - Websocket connections, both [old](http://xmpp.org/extensions/xep-0206.html) and [new](http://datatracker.ietf.org/doc/draft-ietf-xmpp-websocket/?include_text=1) type. You can pass optional
-    parameters: `{timeout, Val}` and `{ping_rate, Val}`. The first one is the time after which an inactive user is
-    disconnected. The Ping rate points to the time between pings sent by server. By declaring this field you enable
-    server-side pinging. Default declaration:
-     `{"_", "/ws-xmpp", mod_websockets, []}`.
-    * `mongoose_api` - REST API for accessing internal MongooseIM metrics. Please refer to [REST interface to metrics](../developers-guide/REST-interface-to-metrics.md) for more information. Default declaration: `{"localhost", "/api", mongoose_api, [{handlers, [mongoose_api_metrics]}]}`.
+    parameters:
+        * `{timeout, Val}` - the time after which an inactive user is disconnected.
+        * `{ping_rate, Val}` - the Ping rate points to the time between pings sent by server. By declaring this field you enable server-side pinging.
+        * `{ejabberd_service, Params}` - this enables external component
+            connections over WebSockets. See [ejabberd_service](#ejabberd_service)
+            section for more details how to configure it.
+
+        Default declaration:
+
+            `{"_", "/ws-xmpp", mod_websockets, []}`
+
+    * `mongoose_api` - REST API for accessing internal MongooseIM metrics.
+        Please refer to [REST interface to metrics](../developers-guide/REST-interface-to-metrics.md)
+        for more information. Default declaration:
+
+            `{"localhost", "/api", mongoose_api, [{handlers, [mongoose_api_metrics]}]}`
+
 
 ### mod_cowboy
 
@@ -98,4 +113,11 @@ Interface for external [XMPP components](http://xmpp.org/extensions/xep-0114.htm
 * `shaper_rule` (atom, default: `fast`) - Connection shaper to use for incoming component traffic.
 * `service_check_from` (boolean, default: `true`) - Checks whether the server should verify the "from" field in stanzas from component
 
+### Custom extension to the protocol
+
+In order to register a component for all virtual hosts served by the
+server, the component must add attribute `is_subdomain="true"`to the opening stream element.
+This maybe helpful if someone wants to have a single instance of a
+component serving multiple virtual hosts. The `is_subdomain` attribute
+is optional and the default behaviour is as described in the XEP.
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -234,17 +234,12 @@
   { {{ejabberd_s2s_in_port}}, ejabberd_s2s_in, [
 			   {shaper, s2s_shaper},
 			   {max_stanza_size, 131072}
-			  ]},
+			  ]}
 
   %%
   %% ejabberd_service: Interact with external components (transports, ...)
   %%
-  {8888, ejabberd_service, [
-                              {access, all},
-                              {shaper_rule, fast},
-                              {ip, {127, 0, 0, 1}},
-                              {password, "secret"}
-                             ]}
+  {{ejabberd_service}}
 
   %%
   %% ejabberd_stun: Handles STUN Binding requests

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -243,9 +243,7 @@
   %%			    {access, all},
   %%			    {shaper_rule, fast},
   %%			    {ip, {127, 0, 0, 1}},
-  %%			    {hosts, ["icq.example.org", "sms.example.org"],
-  %%			     [{password, "secret"}]
-  %%			    }
+  %%		            {password, "secret"}
   %%			   ]},
 
   %%

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -234,17 +234,17 @@
   { {{ejabberd_s2s_in_port}}, ejabberd_s2s_in, [
 			   {shaper, s2s_shaper},
 			   {max_stanza_size, 131072}
-			  ]}
+			  ]},
 
   %%
   %% ejabberd_service: Interact with external components (transports, ...)
   %%
-  %%{8888, ejabberd_service, [
-  %%			    {access, all},
-  %%			    {shaper_rule, fast},
-  %%			    {ip, {127, 0, 0, 1}},
-  %%		            {password, "secret"}
-  %%			   ]},
+  {8888, ejabberd_service, [
+                              {access, all},
+                              {shaper_rule, fast},
+                              {ip, {127, 0, 0, 1}},
+                              {password, "secret"}
+                             ]}
 
   %%
   %% ejabberd_stun: Handles STUN Binding requests

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -138,7 +138,11 @@
       {modules, [
 
           {"_", "/http-bind", mod_bosh},
-          {"_", "/ws-xmpp", mod_websockets, [
+          {"_", "/ws-xmpp", mod_websockets, [{ejabberd_service, [
+                                        {access, all},
+                                        {shaper_rule, fast},
+                                        {ip, {127, 0, 0, 1}},
+                                        {password, "secret"}]}
           %% Uncomment to enable connection dropping or/and server-side pings
           %{timeout, 600000}, {ping_rate, 2000}
           ]}

--- a/rel/reltool_vars/fed1_vars.config
+++ b/rel/reltool_vars/fed1_vars.config
@@ -1,0 +1,17 @@
+{hosts, "[ \"fed1\", \"michał\" ]"}.
+{outgoing_s2s_port, 5269}.
+{odbc_server, ""}.
+{s2s_addr, "{ {s2s_addr, \"localhost\"}, {127,0,0,1} }."}.
+{s2s_default_policy, allow}.
+{node_name, "fed1@localhost"}.
+{ejabberd_c2s_port, 5242}.
+{ejabberd_s2s_in_port, 5299}.
+{cowboy_port, 5282}.
+{cowboy_port_secure, 5287}.
+{ejabberd_service, ""}.
+{mod_roster, "{mod_roster, []},"}.
+{http_api_endpoint, "{5389, \"127.0.0.1\"}"}.
+{s2s_use_starttls, "{s2s_use_starttls, optional}."}.
+{s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
+{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"DHE-RSA-AES256-SHA\"},"}.
+{secondary_c2s, ""}.

--- a/rel/reltool_vars/node1_vars.config
+++ b/rel/reltool_vars/node1_vars.config
@@ -22,6 +22,12 @@
     ]},"}.
 {ejabberd_s2s_in_port, 5269}.
 {mod_amp, "{mod_amp, []},"}.
+{ejabberd_service, ",{8888, ejabberd_service, [\n"
+                 "                {access, all},\n"
+                 "                {shaper_rule, fast},\n"
+                 "                {ip, {127, 0, 0, 1}},\n"
+                 "                {password, \"secret\"}\n"
+                 "           ]}"}.
 {mod_last, "{mod_last, []},"}.
 {mod_offline, "{mod_offline, [{access_max_user_messages, max_user_offline_messages}]},"}.
 {mod_privacy, "{mod_privacy, []},"}.

--- a/rel/reltool_vars/node1_vars.config
+++ b/rel/reltool_vars/node1_vars.config
@@ -6,10 +6,10 @@
 "{host_config, \"anonymous.localhost\", [{auth_method, anonymous},
                                         {allow_multiple_connections, true},
                                         {anonymous_protocol, both}]}." }.
-{outgoing_s2s_port, 5279}.
+{outgoing_s2s_port, 5299}.
 {odbc_server, ""}.
 {auth_ldap,""}.
-{s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
+{s2s_addr, "{ {s2s_addr, \"fed1\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {node_name, "mongooseim@localhost"}.
 {ejabberd_c2s_port, 5222}.

--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -1,4 +1,7 @@
-{hosts, "[ \"localhost2\", \"michal\", \"localhost\"]"}.
+{hosts, "[\"localhost\",
+          \"anonymous.localhost\",
+          \"localhost.bis\"
+         ]"}.
 {outgoing_s2s_port, 5269}.
 {odbc_server, ""}.
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.

--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -1,4 +1,4 @@
-{hosts, "[ \"localhost2\", \"michał\"]"}.
+{hosts, "[ \"localhost2\", \"michal\", \"localhost\"]"}.
 {outgoing_s2s_port, 5269}.
 {odbc_server, ""}.
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
@@ -8,6 +8,7 @@
 {ejabberd_s2s_in_port, 5279}.
 {cowboy_port, 5281}.
 {cowboy_port_secure, 5286}.
+{ejabberd_service, ""}.
 {mod_last, "{mod_last, []},"}.
 {mod_privacy, "{mod_privacy, []},"}.
 {mod_private, "{mod_private, []},"}.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -12,6 +12,12 @@
 {cowboy_port, 5280}.
 {cowboy_port_secure, 5285}.
 {mod_amp, ""}.
+{ejabberd_service, ",{8888, ejabberd_service, [\n"
+                 "                {access, all},\n"
+                 "                {shaper_rule, fast},\n"
+                 "                {ip, {127, 0, 0, 1}},\n"
+                 "                {password, \"secret\"}\n"
+                 "           ]}"}.
 {mod_last, "{mod_last, []},"}.
 {mod_offline, "{mod_offline, [{access_max_user_messages, max_user_offline_messages}]},"}.
 {mod_privacy, "{mod_privacy, []},"}.

--- a/test/ejabberd_tests/default.spec
+++ b/test/ejabberd_tests/default.spec
@@ -19,6 +19,7 @@
 {suites, "tests", cluster_commands_SUITE}.
 {suites, "tests", conf_reload_SUITE}.
 {suites, "tests", connect_SUITE}.
+{suites, "tests", component_SUITE}.
 {suites, "tests", ejabberdctl_SUITE}.
 {suites, "tests", last_SUITE}.
 {suites, "tests", login_SUITE}.

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -1,6 +1,10 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% coding: utf-8
 
+%% DEPRECATED!
+%% TODO: This entire block assumes there's just one node in the tests which is false.
+%%       Stop using it as soon as possible (i.e. convert suites to use `hosts` defined below).
+%%       See s2s_SUITE for example on using `hosts` to RPC into nodes (uses CT "require").
 %% the Erlang node name of tested ejabberd/MongooseIM
 {ejabberd_node, 'mongooseim@localhost'}.
 {ejabberd2_node, 'ejabberd2@localhost'}.
@@ -14,10 +18,22 @@
 {ejabberd_metrics_rest_port, 5288}.
 {ejabberd_string_format, bin}.
 
-{hosts, [{mim, [{node, mongooseim@localhost},
-                {domain, <<"localhost">>}]},
-         {fed, [{node, fed1@localhost},
-                {domain, <<"fed">>}]}]}.
+%% TODO: in every new use case this should be used instead
+%%       of ejabberd_node, ejabberd2_node, ejabberd_domain,
+%%       ejabberd_secondary_domain, ...
+%% TODO: introduce host option verification ASAP,
+%%       so that we rein the "bag of things" approach
+{hosts, [{mim,  [{node, mongooseim@localhost},
+                 {domain, <<"localhost">>},
+                 {vars, "node1_vars.config"},
+                 {cluster, mim}]},
+         {mim2, [{node, ejabberd2@localhost},
+                 {domain, <<"localhost">>},
+                 {vars, "node2_vars.config"},
+                 {cluster, mim}]},
+         {fed,  [{node, fed1@localhost},
+                 {domain, <<"fed">>},
+                 {cluster, fed}]}]}.
 
 %% Use XMPP in-band registration for creating/deleting test users
 {escalus_user_db, xmpp}.

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -107,24 +107,6 @@
         {server, <<"sogndal">>},
         {host, <<"localhost">>},      
         {password, <<"doctor">>}]},
-    {component1, [
-        {server, <<"localhost">>},
-        {host, <<"localhost">>},
-        {password, <<"secret">>},
-        {component, <<"test_service">>},
-        {port, 8888}]},
-    {component2, [
-        {server, <<"localhost">>},
-        {host, <<"localhost">>},
-        {password, <<"secret">>},
-        {component, <<"another_service">>},
-        {port, 8888}]},
-    {muc_component, [
-        {server, <<"localhost">>},
-        {host, <<"localhost">>},
-        {password, <<"secret">>},
-        {component, <<"muc">>},
-        {port, 8888}]},
     {alice2, [
         {username, <<"alice">>},
         {server, <<"fed1">>},

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -14,6 +14,11 @@
 {ejabberd_metrics_rest_port, 5288}.
 {ejabberd_string_format, bin}.
 
+{hosts, [{mim, [{node, mongooseim@localhost},
+                {domain, <<"localhost">>}]},
+         {fed, [{node, fed1@localhost},
+                {domain, <<"fed">>}]}]}.
+
 %% Use XMPP in-band registration for creating/deleting test users
 {escalus_user_db, xmpp}.
 {escalus_xmpp_server, escalus_mongooseim}.
@@ -122,15 +127,15 @@
         {port, 8888}]},
     {alice2, [
         {username, <<"alice">>},
-        {server, <<"localhost2">>},
+        {server, <<"fed1">>},
         {host, <<"localhost">>},
-        {port, 5232},
+        {port, 5242},
         {password, <<"makota2">>}]},
     {bob2, [
         {username, <<"bob">>},
         {server, <<109,105,99,104,97,197,130>>}, %% <<"michał"/utf8>>
         {host, <<"localhost">>},
-        {port, 5232},
+        {port, 5242},
         {password, <<"makota3">>}]},
     {clusterguy, [
         {username, <<"clusterguy">>},

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -114,6 +114,12 @@
         {password, <<"secret">>},
         {component, <<"another_service">>},
         {port, 8888}]},
+    {muc_component, [
+        {server, <<"localhost">>},
+        {host, <<"localhost">>},
+        {password, <<"secret">>},
+        {component, <<"muc">>},
+        {port, 8888}]},
     {alice2, [
         {username, <<"alice">>},
         {server, <<"localhost2">>},

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -100,8 +100,20 @@
     {astrid, [
         {username, <<"astrid">>},
         {server, <<"sogndal">>},
-        {host, <<"localhost">>},
+        {host, <<"localhost">>},      
         {password, <<"doctor">>}]},
+    {component1, [
+        {server, <<"localhost">>},
+        {host, <<"localhost">>},
+        {password, <<"secret">>},
+        {component, <<"test_service">>},
+        {port, 8888}]},
+    {component2, [
+        {server, <<"localhost">>},
+        {host, <<"localhost">>},
+        {password, <<"secret">>},
+        {component, <<"another_service">>},
+        {port, 8888}]},
     {alice2, [
         {username, <<"alice">>},
         {server, <<"localhost2">>},

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -111,7 +111,7 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 register_one_component(Config) ->
     %% Given one connected component
-    CompOpts = ?config(component1, Config),
+    CompOpts = spec(component1, Config),
     {Component, ComponentAddr, _} = connect_component(CompOpts),
 
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
@@ -136,8 +136,8 @@ register_one_component(Config) ->
 
 register_two_components(Config) ->
     %% Given two connected components
-    CompOpts1 = ?config(component1, Config),
-    CompOpts2 = ?config(component2, Config),
+    CompOpts1 = spec(component1, Config),
+    CompOpts2 = spec(component2, Config),
     {Comp1, CompAddr1, _} = connect_component(CompOpts1),
     {Comp2, CompAddr2, _} = connect_component(CompOpts2),
 
@@ -178,7 +178,7 @@ register_two_components(Config) ->
 
 try_registering_with_wrong_password(Config) ->
     %% Given a component with a wrong password
-    CompOpts1 = ?config(component1, Config),
+    CompOpts1 = spec(component1, Config),
     CompOpts2 = lists:keyreplace(password, 1, CompOpts1,
                                  {password, <<"wrong_one">>}),
 
@@ -194,7 +194,7 @@ try_registering_with_wrong_password(Config) ->
 
 try_registering_component_twice(Config) ->
     %% Given two components with the same name
-    CompOpts1 = ?config(component1, Config),
+    CompOpts1 = spec(component1, Config),
     {Comp1, Addr, _} = connect_component(CompOpts1),
 
     try
@@ -211,7 +211,7 @@ try_registering_component_twice(Config) ->
 
 try_registering_existing_host(Config) ->
     %% Given a external muc component
-    Component = ?config(muc_component, Config),
+    Component = spec(muc_component, Config),
 
     try
         %% When trying to connect it to the server
@@ -225,8 +225,8 @@ try_registering_existing_host(Config) ->
 
 disco_components(Config) ->
     %% Given two connected components
-    CompOpts1 = ?config(component1, Config),
-    CompOpts2 = ?config(component2, Config),
+    CompOpts1 = spec(component1, Config),
+    CompOpts2 = spec(component2, Config),
     {Comp1, Addr1, _} = connect_component(CompOpts1),
     {Comp2, Addr2, _} = connect_component(CompOpts2),
 
@@ -247,7 +247,7 @@ disco_components(Config) ->
 
 register_subdomain(Config) ->
     %% Given one connected component
-    CompOpts1 = ?config(component1, Config),
+    CompOpts1 = spec(component1, Config),
     {Comp, _Addr, Name} = connect_component_subdomain(CompOpts1),
 
     escalus:story(Config, [{alice, 1}, {astrid, 1}], fun(Alice, Astrid) ->
@@ -279,7 +279,7 @@ register_subdomain(Config) ->
 
 register_in_cluster(Config) ->
     %% Given one component connected to the cluster
-    CompOpts1 = ?config(component1, Config),
+    CompOpts1 = spec(component1, Config),
     {Comp, Addr, Name} = connect_component(CompOpts1),
 
     escalus:story(Config, [{alice, 1}, {clusterguy, 1}], fun(Alice, ClusterGuy) ->
@@ -448,3 +448,16 @@ default_node(Config) ->
     Node = escalus_config:get_config(ejabberd_node, Config),
     Node == undefined andalso error(node_undefined, [Config]),
     Node.
+
+spec(component1, Config) ->
+    [{component, <<"test_service">>}] ++ common(Config);
+spec(component2, Config) ->
+    [{component, <<"another_service">>}] ++ common(Config);
+spec(muc_component, Config) ->
+    [{component, <<"muc">>}] ++ common(Config).
+
+common(Config) ->
+    [{server, ?config(ejabberd_domain, Config)},
+     {host, ?config(ejabberd_addr, Config)},
+     {password, <<"secret">>},
+     {port, 8888}].

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -114,7 +114,7 @@ register_one_component(Config) ->
     CompOpts = ?config(component1, Config),
     {Component, ComponentAddr, _} = connect_component(CompOpts),
 
-    escalus:story(Config, [1], fun(Alice) ->
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
                 %% When Alice sends a message to the component
                 Msg1 = escalus_stanza:chat_to(ComponentAddr, <<"Hi!">>),
                 escalus:send(Alice, Msg1),
@@ -141,7 +141,7 @@ register_two_components(Config) ->
     {Comp1, CompAddr1, _} = connect_component(CompOpts1),
     {Comp2, CompAddr2, _} = connect_component(CompOpts2),
 
-    escalus:story(Config, [1,1], fun(Alice, Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
                 %% When Alice sends a message to the first component
                 Msg1 = escalus_stanza:chat_to(Alice, <<"abc">>),
                 escalus:send(Comp1, escalus_stanza:from(Msg1, CompAddr1)),
@@ -230,7 +230,7 @@ disco_components(Config) ->
     {Comp1, Addr1, _} = connect_component(CompOpts1),
     {Comp2, Addr2, _} = connect_component(CompOpts2),
 
-    escalus:story(Config, [1], fun(Alice) ->
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
                 %% When server asked for the disco features
                 Server = escalus_client:server(Alice),
                 Disco = escalus_stanza:service_discovery(Server),
@@ -250,7 +250,7 @@ register_subdomain(Config) ->
     CompOpts1 = ?config(component1, Config),
     {Comp, _Addr, Name} = connect_component_subdomain(CompOpts1),
 
-    escalus:story(Config, [1,1], fun(Alice, Astrid) ->
+    escalus:story(Config, [{alice, 1}, {astrid, 1}], fun(Alice, Astrid) ->
                 %% When Alice asks for service discovery on the server
                 Server1 = escalus_client:server(Alice),
                 Disco1 = escalus_stanza:service_discovery(Server1),
@@ -282,7 +282,7 @@ register_in_cluster(Config) ->
     CompOpts1 = ?config(component1, Config),
     {Comp, Addr, Name} = connect_component(CompOpts1),
 
-    escalus:story(Config, [1,1], fun(Alice, Astrid) ->
+    escalus:story(Config, [{alice, 1}, {astrid, 1}], fun(Alice, Astrid) ->
                 %% When Alice sends a message to the component
                 Msg1 = escalus_stanza:chat_to(Addr, <<"Hi!">>),
                 escalus:send(Alice, Msg1),

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -30,8 +30,7 @@
                         set_ejabberd_node_cwd/1]).
 
 -import(distributed_helper, [add_node_to_cluster/1,
-                             remove_node_from_cluster/1,
-                             cluster_users/0]).
+                             remove_node_from_cluster/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -439,3 +438,7 @@ component_handshake(SID, Password) ->
     Handshake = crypto:hash(sha, <<SID/binary, Password/binary>>),
     #xmlel{name = <<"handshake">>,
            children = [#xmlcdata{content = base16:encode(Handshake)}]}.
+
+cluster_users() ->
+    AllUsers = ct:get_config(escalus_users),
+    [proplists:lookup(alice, AllUsers), proplists:lookup(clusterguy, AllUsers)].

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -71,33 +71,33 @@ end_per_suite(Config) ->
 
 init_per_group(xep0114_tcp, Config) ->
     Config1 = get_components([], Config),
-    escalus:create_users(Config1, {by_name, [alice, bob]});
+    escalus:create_users(Config1, escalus:get_users([alice, bob]));
 init_per_group(xep0114_ws, Config) ->
     WSOpts = [{transport, ws},
               {wspath, <<"/ws-xmpp">>},
               {wslegacy, true},
               {port, 5280}],
     Config1 = get_components(WSOpts, Config),
-    escalus:create_users(Config1, {by_name, [alice, bob]});
+    escalus:create_users(Config1, escalus:get_users([alice, bob]));
 init_per_group(subdomain, Config) ->
     Config1 = get_components([], Config),
     Config2 = add_domain(Config1),
-    escalus:create_users(Config2, {by_name, [alice, astrid]});
+    escalus:create_users(Config2, escalus:get_users([alice, astrid]));
 init_per_group(distributed, Config) ->
     Config1 = get_components([], Config),
     Config2 = add_node_to_cluster(Config1),
     escalus:create_users(Config2, cluster_users());
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(subdomain, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, astrid]}),
+    escalus:delete_users(Config, escalus:get_users([alice, astrid])),
     restore_domain(Config);
 end_per_group(distributed, Config) ->
     escalus:delete_users(Config, ?config(escalus_users, Config)),
     remove_node_from_cluster(Config);
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -342,12 +342,10 @@ register_in_cluster(Config) ->
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
+
 get_components(Opts, Config) ->
     Components = [component1, component2, muc_component],
-    lists:foldl(fun(Name, Acc) ->
-                {_, ComponentOpts} = escalus_users:get_user_by_name(Name),
-                [{Name, Opts ++ ComponentOpts}|Acc]
-        end, [], Components) ++ Config.
+    [ {C, Opts ++ spec(C, Config)} || C <- Components ] ++ Config.
 
 connect_component(Component) ->
     connect_component(Component, component_start_stream).
@@ -457,7 +455,7 @@ spec(muc_component, Config) ->
     [{component, <<"muc">>}] ++ common(Config).
 
 common(Config) ->
-    [{server, ?config(ejabberd_domain, Config)},
-     {host, ?config(ejabberd_addr, Config)},
+    [{server, ct:get_config(ejabberd_domain, Config)},
+     {host, ct:get_config(ejabberd_domain, Config)},
      {password, <<"secret">>},
      {port, 8888}].

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -1,0 +1,277 @@
+%%==============================================================================
+%% Copyright 2014 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(component_SUITE).
+-compile(export_all).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("exml/include/exml_stream.hrl").
+
+-import(conf_reload_SUITE, [modify_config_file/2,
+                            bacup_ejabberd_config_file/1,
+                            restore_ejabberd_config_file/1,
+                            reload_through_ctl/1,
+                            restart_ejabberd_node/0,
+                            set_ejabberd_node_cwd/1]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, xep0114},
+     {group, subdomain}].
+
+groups() ->
+    [{xep0114, [], [register_one_component,
+                    register_two_components,
+                    disco_components]},
+     {subdomain, [], [register_subdomain]}].
+
+suite() ->
+    escalus:suite().
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+init_per_group(subdomain, Config) ->
+    Config1 = add_domain(Config),
+    escalus:create_users(Config1, {by_name, [alice, astrid]});
+init_per_group(_GroupName, Config) ->
+    escalus:create_users(Config, {by_name, [alice, bob]}).
+
+end_per_group(subdomain, Config) ->
+    escalus:delete_users(Config, {by_name, [alice, astrid]}),
+    restore_domain(Config);
+end_per_group(_GroupName, Config) ->
+    escalus:delete_users(Config, {by_name, [alice, bob]}).
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+register_one_component(Config) ->
+    %% Given one connected component
+    {Component, ComponentAddr, _} = connect_component(component1),
+
+    escalus:story(Config, [1], fun(Alice) ->
+                %% When Alice sends a message to the component
+                Msg1 = escalus_stanza:chat_to(ComponentAddr, <<"Hi!">>),
+                escalus:send(Alice, Msg1),
+                %% Then component receives it
+                Reply1 = escalus:wait_for_stanza(Component),
+                escalus:assert(is_chat_message, [<<"Hi!">>], Reply1),
+
+                %% When component sends a reply
+                Msg2 = escalus_stanza:chat_to(Alice, <<"Oh hi!">>),
+                escalus:send(Component, escalus_stanza:from(Msg2, ComponentAddr)),
+
+                %% Then Alice receives it
+                Reply2 = escalus:wait_for_stanza(Alice),
+                escalus:assert(is_chat_message, [<<"Oh hi!">>], Reply2),
+                escalus:assert(is_stanza_from, [ComponentAddr], Reply2)
+        end).
+
+register_two_components(Config) ->
+    %% Given two connected components
+    {Comp1, CompAddr1, _} = connect_component(component1),
+    {Comp2, CompAddr2, _} = connect_component(component2),
+
+    escalus:story(Config, [1,1], fun(Alice, Bob) ->
+                %% When Alice sends a message to the first component
+                Msg1 = escalus_stanza:chat_to(Alice, <<"abc">>),
+                escalus:send(Comp1, escalus_stanza:from(Msg1, CompAddr1)),
+                %% Then component receives it
+                Reply1 = escalus:wait_for_stanza(Alice),
+                escalus:assert(is_chat_message, [<<"abc">>], Reply1),
+                escalus:assert(is_stanza_from, [CompAddr1], Reply1),
+
+                %% When Bob sends a message to the second component
+                Msg2 = escalus_stanza:chat_to(Bob, <<"def">>),
+                escalus:send(Comp2, escalus_stanza:from(Msg2, CompAddr2)),
+                %% Then it also receives it
+                Reply2 = escalus:wait_for_stanza(Bob),
+                escalus:assert(is_chat_message, [<<"def">>], Reply2),
+                escalus:assert(is_stanza_from, [CompAddr2], Reply2),
+
+                %% When the second component sends a reply to Bob
+                Msg3 = escalus_stanza:chat_to(CompAddr2, <<"ghi">>),
+                escalus:send(Bob, Msg3),
+                %% Then he receives it
+                Reply3 = escalus:wait_for_stanza(Comp2),
+                escalus:assert(is_chat_message, [<<"ghi">>], Reply3),
+
+                %% WHen the first component sends a reply to Alice
+                Msg4 = escalus_stanza:chat_to(CompAddr1, <<"jkl">>),
+                escalus:send(Alice, Msg4),
+                %% Then she receives it
+                Reply4 = escalus:wait_for_stanza(Comp1),
+                escalus:assert(is_chat_message, [<<"jkl">>], Reply4)
+        end).
+
+disco_components(Config) ->
+    %% Given two connected components
+    {_Comp1, Addr1, _} = connect_component(component1),
+    {_Comp2, Addr2, _} = connect_component(component2),
+
+    escalus:story(Config, [1], fun(Alice) ->
+                %% When server asked for the disco features
+                Server = escalus_client:server(Alice),
+                Disco = escalus_stanza:service_discovery(Server),
+                escalus:send(Alice, Disco),
+
+                %% Then it contains hosts of 2 components
+                DiscoReply = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_service, [Addr1], DiscoReply),
+                escalus:assert(has_service, [Addr2], DiscoReply)
+        end).
+
+register_subdomain(Config) ->
+    %% Given one connected component
+    {_Comp, _Addr, Name} = connect_component_subdomain(component1),
+
+    escalus:story(Config, [1,1], fun(Alice, Astrid) ->
+                %% When Alice asks for service discovery on the server
+                Server1 = escalus_client:server(Alice),
+                Disco1 = escalus_stanza:service_discovery(Server1),
+                escalus:send(Alice, Disco1),
+
+                %% Then it contains the registered route
+                DiscoReply1 = escalus:wait_for_stanza(Alice),
+                ComponentHost1 = <<Name/binary, ".", Server1/binary>>,
+                escalus:assert(has_service, [ComponentHost1], DiscoReply1),
+
+                %% When Astrid ask for service discovery on her server
+                Server2 = escalus_client:server(Astrid),
+                false = (Server1 =:= Server2),
+                Disco2 = escalus_stanza:service_discovery(Server2),
+                escalus:send(Astrid, Disco2),
+
+                %% Then it also contains the registered route
+                DiscoReply2 = escalus:wait_for_stanza(Astrid),
+                ComponentHost2 = <<Name/binary, ".", Server2/binary>>,
+                escalus:assert(has_service, [ComponentHost2], DiscoReply2)
+
+        end).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+connect_component(Name) ->
+    connect_component(Name, component_start_stream).
+
+connect_component_subdomain(Name) ->
+    connect_component(Name, component_start_stream_subdomain).
+
+connect_component(Name, StartStep) ->
+    {_, ComponentOpts} = escalus_users:get_user_by_name(Name),
+    {ok, Component, _, _} = escalus_connection:start(ComponentOpts,
+                                                     [{?MODULE, StartStep},
+                                                      {?MODULE, component_handshake}]),
+    {component, ComponentName} = lists:keyfind(component, 1, ComponentOpts),
+    {host, ComponentHost} = lists:keyfind(host, 1, ComponentOpts),
+    ComponentAddr = <<ComponentName/binary, ".", ComponentHost/binary>>,
+    {Component, ComponentAddr, ComponentName}.
+
+add_domain(Config) ->
+    Hosts = {hosts, "[\"localhost\", \"sogndal\"]"},
+    Config1 = set_ejabberd_node_cwd(Config),
+    bacup_ejabberd_config_file(Config1),
+    modify_config_file([Hosts], Config1),
+    reload_through_ctl(Config1),
+    Config1.
+
+restore_domain(Config) ->
+    restore_ejabberd_config_file(Config),
+    restart_ejabberd_node(),
+    Config.
+
+%%--------------------------------------------------------------------
+%% Escalus connection steps
+%%--------------------------------------------------------------------
+component_start_stream(Conn, Props, []) ->
+    {server, Server} = lists:keyfind(server, 1, Props),
+    {component, Component} = lists:keyfind(component, 1, Props),
+
+    ComponentHost = <<Component/binary, ".", Server/binary>>,
+    StreamStart = component_stream_start(ComponentHost, false),
+    ok = escalus_connection:send(Conn, StreamStart),
+    StreamStartRep = escalus_connection:get_stanza(Conn, wait_for_stream),
+
+    #xmlstreamstart{attrs = Attrs} = StreamStartRep,
+    Id = proplists:get_value(<<"id">>, Attrs),
+
+    {Conn, [{sid, Id}|Props], []}.
+
+component_start_stream_subdomain(Conn, Props, []) ->
+    {component, Component} = lists:keyfind(component, 1, Props),
+
+    StreamStart = component_stream_start(Component, true),
+    ok = escalus_connection:send(Conn, StreamStart),
+    StreamStartRep = escalus_connection:get_stanza(Conn, wait_for_stream),
+
+    #xmlstreamstart{attrs = Attrs} = StreamStartRep,
+    Id = proplists:get_value(<<"id">>, Attrs),
+
+    {Conn, [{sid, Id}|Props], []}.
+
+component_handshake(Conn, Props, []) ->
+    {password, Password} = lists:keyfind(password, 1, Props),
+    {sid, SID} = lists:keyfind(sid, 1, Props),
+
+    Handshake = component_handshake(SID, Password),
+    ok = escalus_connection:send(Conn, Handshake),
+
+    HandshakeRep = escalus_connection:get_stanza(Conn, handshake),
+    #xmlel{name = <<"handshake">>, children = []} = HandshakeRep,
+
+    {Conn, Props, []}.
+
+%%--------------------------------------------------------------------
+%% Stanzas
+%%--------------------------------------------------------------------
+component_stream_start(Component, IsSubdomain) ->
+    Attrs1 = [{<<"to">>, Component},
+              {<<"xmlns">>, <<"jabber:component:accept">>},
+              {<<"xmlns:stream">>,
+               <<"http://etherx.jabber.org/streams">>}],
+    Attrs2 = case IsSubdomain of
+        false ->
+            Attrs1;
+        true ->
+            [{<<"is_subdomain">>, <<"true">>}|Attrs1]
+    end,
+    #xmlstreamstart{name = <<"stream:stream">>, attrs = Attrs2}.
+
+component_handshake(SID, Password) ->
+    Handshake = crypto:hash(sha, <<SID/binary, Password/binary>>),
+    #xmlel{name = <<"handshake">>,
+           children = [#xmlcdata{content = base16:encode(Handshake)}]}.

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -184,7 +184,7 @@ try_registering_with_wrong_password(Config) ->
 
     try
         %% When trying to connect it
-        {Comp, Addr, _} = connect_component(CompOpts2),
+        {Comp, _Addr, _} = connect_component(CompOpts2),
         ok = escalus_connection:stop(Comp),
         ct:fail("component connected successfully with wrong password")
     catch error:{badmatch, _} ->
@@ -215,7 +215,7 @@ try_registering_existing_host(Config) ->
 
     try
         %% When trying to connect it to the server
-        {Comp, Addr, _} = connect_component(Component),
+        {Comp, _Addr, _} = connect_component(Component),
         ok = escalus_connection:stop(Comp),
         ct:fail("muc component connected successfully")
     catch error:{badmatch, _} ->

--- a/test/ejabberd_tests/tests/conf_reload_SUITE.erl
+++ b/test/ejabberd_tests/tests/conf_reload_SUITE.erl
@@ -146,20 +146,6 @@ user_should_be_disconnected_from_removed_domain(Config) ->
 get_ejabberd_hosts() ->
     ejabberd_node_utils:call_fun(ejabberd_config, get_global_option, [hosts]).
 
-reload_through_ctl(Config) ->
-    OutputStr = ejabberd_node_utils:call_ctl(reload_local, Config),
-    ok = verify_reload_output(OutputStr).
-
-verify_reload_output(OutputStr) ->
-    ExpectedOutput = ?CTL_RELOAD_OUTPUT_PREFIX,
-    case lists:sublist(OutputStr, length(ExpectedOutput)) of
-        ExpectedOutput ->
-            ok;
-        _ ->
-            ct:pal("~ts", [OutputStr]),
-            error(config_reload_failed, [OutputStr])
-    end.
-
 register_user_by_ejabberd_admin(User, Host) ->
     ejabberd_node_utils:call_fun(ejabberd_admin, register,
                                  [User, Host, <<"doctor">>]).

--- a/test/ejabberd_tests/tests/conf_reload_SUITE.erl
+++ b/test/ejabberd_tests/tests/conf_reload_SUITE.erl
@@ -21,14 +21,18 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-import(reload_helper, [modify_config_file/2,
+                        bacup_ejabberd_config_file/1,
+                        restore_ejabberd_config_file/1,
+                        reload_through_ctl/1,
+                        restart_ejabberd_node/0,
+                        set_ejabberd_node_cwd/1]).
+
 -define(RELOADED_DOMAIN, ct:get_config(ejabberd_reloaded_domain)).
 
 -define(SAMPLE_USERNAME, <<"astrid">>).
 -define(RELOADED_DOMAIN_USER, astrid).
 -define(INITIAL_DOMAIN_USER, alice).
-
--define(CTL_RELOAD_OUTPUT_PREFIX,
-        "# Reloaded: " ++ atom_to_list(ct:get_config(ejabberd_node))).
 
 %%--------------------------------------------------------------------
 %% Suite configuration

--- a/test/ejabberd_tests/tests/conf_reload_SUITE.erl
+++ b/test/ejabberd_tests/tests/conf_reload_SUITE.erl
@@ -139,14 +139,13 @@ user_should_be_disconnected_from_removed_domain(Config) ->
 %%--------------------------------------------------------------------
 
 get_ejabberd_hosts() ->
-    ejabberd_node_utils:call_fun(ejabberd_config, get_global_option, [hosts]).
+    escalus_ejabberd:rpc(ejabberd_config, get_global_option, [hosts]).
 
 register_user_by_ejabberd_admin(User, Host) ->
-    ejabberd_node_utils:call_fun(ejabberd_admin, register,
-                                 [User, Host, <<"doctor">>]).
+    escalus_ejabberd:rpc(ejabberd_admin, register, [User, Host, <<"doctor">>]).
 
 unregister_user_by_ejabberd_admin(User, Host) ->
-    ejabberd_node_utils:call_fun(ejabberd_admin, unregister, [User, Host]).
+    escalus_ejabberd:rpc(ejabberd_admin, unregister, [User, Host]).
 
 change_domain_in_config_file(Config) ->
     ejabberd_node_utils:modify_config_file(

--- a/test/ejabberd_tests/tests/conf_reload_SUITE.erl
+++ b/test/ejabberd_tests/tests/conf_reload_SUITE.erl
@@ -98,17 +98,17 @@ domain_should_change(Config) ->
 user_should_be_registered_and_unregistered_via_ctl(Config) ->
     %% GIVEN
     [NewHost] = ?config(new_hosts_value, Config),
-    ?assertMatch({cannot_register, _}, register_user_by_ejabberd_admin(
-                                         ?SAMPLE_USERNAME, NewHost)),
+    ?assertMatch({cannot_register, _},
+                 register_user_by_ejabberd_admin(?SAMPLE_USERNAME, NewHost)),
 
     %% WHEN
     reload_through_ctl(default_node(Config), Config),
 
     %% THEN
-    ?assertMatch({ok, _}, register_user_by_ejabberd_admin(
-                            ?SAMPLE_USERNAME, NewHost)),
-    ?assertMatch({ok, _}, unregister_user_by_ejabberd_admin(
-                            ?SAMPLE_USERNAME, NewHost)).
+    ?assertMatch({ok, _},
+                 register_user_by_ejabberd_admin(?SAMPLE_USERNAME, NewHost)),
+    ?assertMatch({ok, _},
+                 unregister_user_by_ejabberd_admin(?SAMPLE_USERNAME, NewHost)).
 
 user_should_be_registered_and_unregistered_via_xmpp(Config) ->
     %% GIVEN

--- a/test/ejabberd_tests/tests/connect_SUITE.erl
+++ b/test/ejabberd_tests/tests/connect_SUITE.erl
@@ -110,14 +110,10 @@ init_per_group(ciphers_default, Config) ->
     ejabberd_node_utils:restart_application(ejabberd),
     [{c2s_port, 5222} | Config];
 init_per_group('node2_supports_DHE-RSA-AES256-SHA_only', Config) ->
-     node2_rpccall(mongoose_cover_helper, start, [[ejabberd]]),
     [{c2s_port, 5233} | Config];
 init_per_group(_, Config) ->
     Config.
 
-end_per_group('node2_supports_DHE-RSA-AES256-SHA_only', Config) ->
-    node2_rpccall(mongoose_cover_helper, analyze, []),
-    Config;
 end_per_group(_, Config) ->
     Config.
 
@@ -431,11 +427,6 @@ default_context(To) ->
     [{version, <<"version='1.0'">>},
      {to, To},
      {stream_ns, ?NS_XMPP}].
-
-node2_rpccall(Module, Function, Args) ->
-    Node = ct:get_config(ejabberd2_node),
-    rpc:call(Node, Module, Function, Args).
-
 
 children_specs_to_pids(Children) ->
     [Pid || {_, Pid, _, _} <- Children].

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -3,8 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--import(ejabberd_node_utils, [get_cwd/2,
-                              call_fun/4]).
+-import(ejabberd_node_utils, [get_cwd/2]).
 
 -compile(export_all).
 

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -465,7 +465,7 @@ allow_subscription_to_from_message(Config) ->
 allow_subscription_both_message(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
 
-        [{_, Spec}] = escalus_users:get_users({by_name, [bob]}),
+        [{_, Spec}] = escalus_users:get_users([bob]),
         {ok, Bob, _Spec2, _Features} = escalus_connection:start(Spec),
         %escalus_story:send_initial_presence(Alice),
         escalus_story:send_initial_presence(Bob),

--- a/test/ejabberd_tests/tests/reload_helper.erl
+++ b/test/ejabberd_tests/tests/reload_helper.erl
@@ -1,0 +1,98 @@
+%%==============================================================================
+%% Copyright 2014 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(reload_helper).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([modify_config_file/2,
+         bacup_ejabberd_config_file/1,
+         restore_ejabberd_config_file/1,
+         reload_through_ctl/1,
+         restart_ejabberd_node/0,
+         set_ejabberd_node_cwd/1]).
+
+-define(CWD(Config), ?config(ejabberd_node_cwd, Config)).
+-define(CURRENT_CFG_PATH(Config),
+        filename:join([?CWD(Config), "etc", "ejabberd.cfg"])).
+-define(BACKUP_CFG_PATH(Config),
+        filename:join([?CWD(Config), "etc","ejabberd.cfg.bak"])).
+-define(CFG_TEMPLATE_PATH(Config),
+        filename:join([?CWD(Config), "..", "..", "rel", "files",
+                       "ejabberd.cfg"])).
+-define(CFG_VARS_PATH(Config),
+        filename:join([?CWD(Config), "..", "..", "rel",
+                       "vars.config"])).
+-define(CTL_PATH(Config),
+        filename:join([?CWD(Config), "bin", "mongooseimctl"])).
+
+-define(CTL_RELOAD_OUTPUT_PREFIX,
+        "# Reloaded: " ++ atom_to_list(ct:get_config(ejabberd_node))).
+
+
+call_ejabberd(M, F, A) ->
+    Node = ct:get_config(ejabberd_node),
+    rpc:call(Node, M, F, A).
+
+set_ejabberd_node_cwd(Config) ->
+    {ok, Cwd} = call_ejabberd(file, get_cwd, []),
+    [{ejabberd_node_cwd, Cwd} | Config].
+
+bacup_ejabberd_config_file(Config) ->
+    {ok, _} = call_ejabberd(file, copy, [?CURRENT_CFG_PATH(Config),
+                                         ?BACKUP_CFG_PATH(Config)]).
+
+restore_ejabberd_config_file(Config) ->
+    ok = call_ejabberd(file, rename, [?BACKUP_CFG_PATH(Config),
+                                      ?CURRENT_CFG_PATH(Config)]).
+
+restart_ejabberd_node() ->
+    ok = call_ejabberd(application, stop, [ejabberd]),
+    ok = call_ejabberd(application, start, [ejabberd]).
+
+reload_through_ctl(Config) ->
+    ReloadCmd = ?CTL_PATH(Config) ++ " reload_local",
+    OutputStr = call_ejabberd(os, cmd, [ReloadCmd]),
+    ok = verify_reload_output(OutputStr).
+
+verify_reload_output(OutputStr) ->
+    ExpectedOutput = ?CTL_RELOAD_OUTPUT_PREFIX,
+    case lists:sublist(OutputStr, length(ExpectedOutput)) of
+        ExpectedOutput ->
+            ok;
+        _ ->
+            ct:pal("~ts", [OutputStr]),
+            error(config_reload_failed, [OutputStr])
+    end.
+    
+
+modify_config_file(CfgVarsToChange, Config) ->
+    CurrentCfgPath = ?CURRENT_CFG_PATH(Config),
+    {ok, CfgTemplate} = call_ejabberd(file, read_file,
+                                      [?CFG_TEMPLATE_PATH(Config)]),
+    {ok, CfgVars} = call_ejabberd(file, consult,
+                                  [?CFG_VARS_PATH(Config)]),
+    UpdatedCfgVars = update_config_variables(CfgVarsToChange, CfgVars),
+    CfgTemplateList = binary_to_list(CfgTemplate),
+    UpdatedCfgFile = mustache:render(CfgTemplateList,
+                                     dict:from_list(UpdatedCfgVars)),
+    ok = call_ejabberd(file, write_file, [CurrentCfgPath,
+                                          UpdatedCfgFile]).
+
+update_config_variables(CfgVarsToChange, CfgVars) ->
+    lists:foldl(fun({Var, Val}, Acc) ->
+                        lists:keystore(Var, 1, Acc,{Var, Val})
+                end, CfgVars, CfgVarsToChange).

--- a/test/ejabberd_tests/tests/reload_helper.erl
+++ b/test/ejabberd_tests/tests/reload_helper.erl
@@ -24,39 +24,26 @@
          reload_through_ctl/2,
          restart_ejabberd_node/1]).
 
--import(distributed_helper, [rpc/4]).
-
--define(CWD(Config), ?config(ejabberd_node_cwd, Config)).
--define(CURRENT_CFG_PATH(Config),
-        filename:join([?CWD(Config), "etc", "ejabberd.cfg"])).
--define(BACKUP_CFG_PATH(Config),
-        filename:join([?CWD(Config), "etc","ejabberd.cfg.bak"])).
--define(CFG_TEMPLATE_PATH(Config),
-        filename:join([?CWD(Config), "..", "..", "rel", "files",
-                       "ejabberd.cfg"])).
--define(CFG_VARS_PATH(Config),
-        filename:join([?CWD(Config), "..", "..", "rel",
-                       "vars.config"])).
--define(CTL_PATH(Config),
-        filename:join([?CWD(Config), "bin", "mongooseimctl"])).
+-import(distributed_helper, [rpc/4, rpc/5]).
 
 -define(CTL_RELOAD_OUTPUT_PREFIX,
         "# Reloaded: " ++ atom_to_list(ct:get_config(ejabberd_node))).
 
 backup_ejabberd_config_file(Node, Config) ->
-    {ok, _} = rpc(Node, file, copy, [?CURRENT_CFG_PATH(Config),
-                                     ?BACKUP_CFG_PATH(Config)]).
+    {ok, _} = rpc(Node, file, copy, [node_cfg(Node, current, Config),
+                                     node_cfg(Node, backup, Config)]).
 
 restore_ejabberd_config_file(Node, Config) ->
-    ok = rpc(Node, file, rename, [?BACKUP_CFG_PATH(Config),
-                                  ?CURRENT_CFG_PATH(Config)]).
+    ok = rpc(Node, file, rename, [node_cfg(Node, backup, Config),
+                                  node_cfg(Node, current, Config)]).
 
 restart_ejabberd_node(Node) ->
-    ok = rpc(Node, application, stop, [ejabberd]),
-    ok = rpc(Node, application, start, [ejabberd]).
+    %% Node restarts might take a long time -> long timeout.
+    ok = rpc(Node, application, stop, [ejabberd], timer:seconds(10)),
+    ok = rpc(Node, application, start, [ejabberd], timer:seconds(10)).
 
 reload_through_ctl(Node, Config) ->
-    ReloadCmd = ?CTL_PATH(Config) ++ " reload_local",
+    ReloadCmd = node_ctl(Node, Config) ++ " reload_local",
     OutputStr = rpc(Node, os, cmd, [ReloadCmd]),
     ok = verify_reload_output(OutputStr).
 
@@ -69,12 +56,11 @@ verify_reload_output(OutputStr) ->
             ct:pal("~ts", [OutputStr]),
             error(config_reload_failed, [OutputStr])
     end.
-    
 
 modify_config_file(Node, CfgVarsToChange, Config) ->
-    CurrentCfgPath = ?CURRENT_CFG_PATH(Config),
-    {ok, CfgTemplate} = rpc(Node, file, read_file, [?CFG_TEMPLATE_PATH(Config)]),
-    {ok, CfgVars} = rpc(Node, file, consult, [?CFG_VARS_PATH(Config)]),
+    CurrentCfgPath = node_cfg(Node, current, Config),
+    {ok, CfgTemplate} = rpc(Node, file, read_file, [node_cfg(Node, template, Config)]),
+    {ok, CfgVars} = rpc(Node, file, consult, [node_cfg(Node, vars, Config)]),
     UpdatedCfgVars = update_config_variables(CfgVarsToChange, CfgVars),
     CfgTemplateList = binary_to_list(CfgTemplate),
     UpdatedCfgFile = mustache:render(CfgTemplateList,
@@ -85,3 +71,17 @@ update_config_variables(CfgVarsToChange, CfgVars) ->
     lists:foldl(fun({Var, Val}, Acc) ->
                         lists:keystore(Var, 1, Acc,{Var, Val})
                 end, CfgVars, CfgVarsToChange).
+
+node_cfg(N, current, C)  -> flat([node_cwd(N, C), "etc", "ejabberd.cfg"]);
+node_cfg(N, backup, C)   -> flat([node_cwd(N, C), "etc", "ejabberd.cfg.bak"]);
+node_cfg(N, template, C) -> flat([node_cwd(N, C), "..", "..", "rel", "files", "ejabberd.cfg"]);
+node_cfg(N, vars, C)     -> flat([node_cwd(N, C), "..", "..", "rel", "vars.config"]).
+
+node_ctl(N, C) -> flat([node_cwd(N, C), "bin", "mongooseimctl"]).
+
+flat(PathComponents) -> filename:join(PathComponents).
+
+node_cwd(Node, Config) ->
+    CWD = escalus_config:get_config({ejabberd_cwd, Node}, Config),
+    CWD == undefined andalso error({{ejabberd_cwd, Node}, undefined}, [Node, Config]),
+    CWD.

--- a/test/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test/ejabberd_tests/tests/s2s_SUITE.erl
@@ -7,6 +7,8 @@
 -module(s2s_SUITE).
 -compile(export_all).
 
+-import(distributed_helper, [rpc/4, rpc/5]).
+
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
 
@@ -16,7 +18,6 @@
           node2_s2s_certfile = undefined,
           node2_s2s_use_starttls = undefined
          }).
-
 
 %%%===================================================================
 %%% Suite configuration
@@ -69,20 +70,25 @@ negative() ->
     [timeout_waiting_for_message].
 
 suite() ->
+    require_s2s_nodes() ++
     escalus:suite().
+
+require_s2s_nodes() ->
+    [{require, mim_node, {hosts, mim, node}},
+     {require, fed_node, {hosts, fed, node}}].
 
 %%%===================================================================
 %%% Init & teardown
 %%%===================================================================
 
 init_per_suite(Config0) ->
-    Node1S2SCertfile = escalus_ejabberd:rpc(ejabberd_config, get_local_option, [s2s_certfile]),
-    Node1S2SUseStartTLS = escalus_ejabberd:rpc(ejabberd_config, get_local_option, [s2s_use_starttls]),
+    Node1S2SCertfile = rpc(mim(), ejabberd_config, get_local_option, [s2s_certfile]),
+    Node1S2SUseStartTLS = rpc(mim(), ejabberd_config, get_local_option, [s2s_use_starttls]),
 
-    node2_rpccall(mongoose_cover_helper, start, [[ejabberd]]),
+    rpc(fed(), mongoose_cover_helper, start, [[ejabberd]]),
 
-    Node2S2SCertfile = node2_rpccall(ejabberd_config, get_local_option, [s2s_certfile]),
-    Node2S2SUseStartTLS = node2_rpccall(ejabberd_config, get_local_option, [s2s_use_starttls]),
+    Node2S2SCertfile = rpc(fed(), ejabberd_config, get_local_option, [s2s_certfile]),
+    Node2S2SUseStartTLS = rpc(fed(), ejabberd_config, get_local_option, [s2s_use_starttls]),
     S2S = #s2s_opts{node1_s2s_certfile = Node1S2SCertfile,
                     node1_s2s_use_starttls = Node1S2SUseStartTLS,
                     node2_s2s_certfile = Node2S2SCertfile,
@@ -94,7 +100,7 @@ init_per_suite(Config0) ->
 end_per_suite(Config) ->
     S2SOrig = ?config(s2s_opts, Config),
     configure_s2s(S2SOrig),
-    node2_rpccall(mongoose_cover_helper, analyze, []),
+    rpc(fed(), mongoose_cover_helper, analyze, []),
     escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
@@ -159,17 +165,17 @@ end_per_testcase(CaseName, Config) ->
 simple_message(Config) ->
     escalus:story(Config, [{alice2, 1}, {alice, 1}], fun(Alice2, Alice1) ->
 
-        %% Alice@localhost1 sends message to Alice@localhost2
+        %% User on the main server sends a message to a user on a federated server
         escalus:send(Alice1, escalus_stanza:chat_to(Alice2, <<"Hi, foreign Alice!">>)),
 
-        %% Alice@localhost2 receives message from Alice@localhost1
+        %% User on the federated server receives the message
         Stanza = escalus:wait_for_stanza(Alice2, 10000),
         escalus:assert(is_chat_message, [<<"Hi, foreign Alice!">>], Stanza),
 
-        %% Alice@localhost2 sends message to Alice@localhost1
+        %% User on the federated server sends a message to the main server
         escalus:send(Alice2, escalus_stanza:chat_to(Alice1, <<"Nice to meet you!">>)),
 
-        %% Alice@localhost1 receives message from Alice@localhost2
+        %% User on the main server receives the message
         Stanza2 = escalus:wait_for_stanza(Alice1, 10000),
         escalus:assert(is_chat_message, [<<"Nice to meet you!">>], Stanza2)
 
@@ -232,33 +238,38 @@ nonascii_addr(Config) ->
 
     end).
 
-node2_rpccall(Module, Function, Args) ->
-    Node = ct:get_config(ejabberd2_node),
-    rpc:call(Node, Module, Function, Args).
-
 configure_s2s(#s2s_opts{node1_s2s_certfile = Certfile1,
                         node1_s2s_use_starttls = StartTLS1,
                         node2_s2s_certfile = Certfile2,
                         node2_s2s_use_starttls = StartTLS2}) ->
-    configure_s2s(ct:get_config(ejabberd_node), Certfile1, StartTLS1),
-    configure_s2s(ct:get_config(ejabberd2_node), Certfile2, StartTLS2),
+    configure_s2s(mim(), Certfile1, StartTLS1),
+    configure_s2s(fed(), Certfile2, StartTLS2),
     restart_s2s().
 
 configure_s2s(Node, Certfile, StartTLS) ->
-    rpc:call(Node, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
-    rpc:call(Node, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
+    rpc(Node, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
+    rpc(Node, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
 
 restart_s2s() ->
-    restart_s2s(ct:get_config(ejabberd_node)),
-    restart_s2s(ct:get_config(ejabberd2_node)).
-
+    restart_s2s(mim()),
+    restart_s2s(fed()).
 
 restart_s2s(Node) ->
-    Children = rpc:call(Node, supervisor, which_children, [ejabberd_s2s_out_sup]),
-    [rpc:call(Node, ejabberd_s2s_out, stop_connection, [Pid]) ||
+    Children = rpc(Node, supervisor, which_children, [ejabberd_s2s_out_sup]),
+    [rpc(Node, ejabberd_s2s_out, stop_connection, [Pid]) ||
      {_, Pid, _, _} <- Children],
 
-    ChildrenIn = rpc:call(Node, supervisor, which_children, [ejabberd_s2s_in_sup]),
-    [rpc:call(Node, erlang, exit, [Pid, kill]) ||
+    ChildrenIn = rpc(Node, supervisor, which_children, [ejabberd_s2s_in_sup]),
+    [rpc(Node, erlang, exit, [Pid, kill]) ||
      {_, Pid, _, _} <- ChildrenIn].
 
+mim() ->
+    get_or_fail(mim_node).
+
+fed() ->
+    get_or_fail(fed_node).
+
+get_or_fail(Key) ->
+    Val = ct:get_config(Key),
+    Val == undefined andalso error({undefined, Key}),
+    Val.

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -8,7 +8,3 @@ else
     BASE=`readlink -f ${TOOLS}/..`
 fi
 
-EJD1=${BASE}/dev/mongooseim_node1
-EJD2=${BASE}/dev/mongooseim_node2
-EJD1CTL=${EJD1}/bin/mongooseim
-EJD2CTL=${EJD2}/bin/mongooseim

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
+PRESET=$1
+
 source tools/travis-common-vars.sh
 
 echo ${BASE}
+
+EJD1=${BASE}/dev/mongooseim_node1
+EJD2=${BASE}/dev/mongooseim_node2
+FED1=${BASE}/dev/mongooseim_fed1
+EJD1CTL=${EJD1}/bin/mongooseim
+EJD2CTL=${EJD2}/bin/mongooseim
+FED1CTL=${FED1}/bin/mongooseim
+
+NODES=(${EJD1CTL} ${EJD2CTL} ${FED1CTL})
 
 SUMMARIES_DIRS=${BASE}'/test/ejabberd_tests/ct_report/ct_run*'
 
@@ -17,15 +28,27 @@ echo "############################"
 echo "Running ejabberd_tests"
 echo "############################"
 
-echo -n "starting MongooseIM node 1: "
-${EJD1CTL} start && echo ok || echo failed
-echo -n "starting MongooseIM node 2: "
-${EJD2CTL} start && echo ok || echo failed
-sleep 1
-echo -n "pinging MongooseIM node 1: "
-${EJD1CTL} ping
-echo -n "pinging MongooseIM node 2: "
-${EJD2CTL} ping
+start_node() {
+	echo -n "${1} start: "
+	${1} start && echo ok || echo failed
+}
+
+ping_node() {
+	echo -n "${1} ping: "
+	${1} ping
+}
+
+stop_node() {
+	echo -n "${1} stop: "
+	${1} stop
+}
+
+for node in ${NODES[@]}; do
+	echo $node;
+	start_node $node;
+	sleep 1;
+	ping_node $node;
+done
 
 tools/print-dots.sh start
 make cover_test_preset TESTSPEC=default.spec PRESET=$PRESET
@@ -33,10 +56,9 @@ tools/print-dots.sh stop
 
 RAN_TESTS=`cat /tmp/ct_count`
 
-echo -n "stopping MongooseIM node 1: "
-${EJD1CTL} stop
-echo -n "stopping MongooseIM node 2: "
-${EJD2CTL} stop
+for node in ${NODES[@]}; do
+	stop_node $node;
+done
 
 if [ `uname` = "Darwin" ]; then
     SUMMARIES_DIR=`ls -dt ${SUMMARIES_DIRS} | head -n ${RAN_TESTS}`


### PR DESCRIPTION
This PR:
* changes the routing mechanism - the new `external_component` table is checked firstly
* allows to use external_component registered on different node in the cluster
* allows to expose `ejabberd_service` over WebSockets
* includes changes to tests:
    * new dev node for federation
    * old node2 is now meant to be used only for clustering with node2
    * new `component_SUITE` testing ejabberd_service interface
    * `reload_helper` module to be used whenever a node reload is required

Todo:
- [x] fix tests :smile: 
- [x] fix warnings :smile:
- [ ] make ``is_subdomain`` feature configurable (default disabled)
- [ ] make the component routing via additional routing table (``external_component``) optional
- [ ] modify the component routing so that first it's checked if the component is registered locally, route to an externally registered service as a last resort (allow to register the same component on different nodes)