### PR TITLE
Make's default target does not build MongooseIM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ XEP_TOOL = tools/xep_tool
 EJD_EBIN = $(EJABBERD_DIR)/ebin
 DEVNODES = node1 node2
 
-include tools/cd_tools/cd-targets
-
 all: deps compile
 
 compile: rebar
@@ -162,3 +160,5 @@ test_deps:
 
 %:
 	@:
+
+include tools/cd_tools/cd-targets


### PR DESCRIPTION
Either the the documentation (i.e. README.md) is out of date, or someone has introduced a mistake in the `Makefile`.

According to the documentation,  one should be able to compile `MongooseIM` by simply running `make`.  However, this does not seem to hold true anymore. This [commit](https://github.com/esl/MongooseIM/blob/7682033c3744990671cb93c16071a6b2d158fb96/Makefile#L10), injects some targets before the `all` target.