### PR TITLE
Explicitly pass specs to escalus:create_users/2

### DIFF
--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,7 +4,7 @@
 {require_otp_vsn, "R?1[45678]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "get_users-accept-list"}}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "5bf799a"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "2.2.0"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},

--- a/test/ejabberd_tests/tests/adhoc_SUITE.erl
+++ b/test/ejabberd_tests/tests/adhoc_SUITE.erl
@@ -38,10 +38,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/amp_SUITE.erl
+++ b/test/ejabberd_tests/tests/amp_SUITE.erl
@@ -48,10 +48,10 @@ groups() ->
 
 init_per_suite(Config) ->
     escalus:init_per_suite(Config),
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}),
+    escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
 init_per_testcase(CaseName,Config) ->

--- a/test/ejabberd_tests/tests/anonymous_SUITE.erl
+++ b/test/ejabberd_tests/tests/anonymous_SUITE.erl
@@ -46,10 +46,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice]}).
+    escalus:create_users(Config, escalus:get_users([alice])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice]}).
+    escalus:delete_users(Config, escalus:get_users([alice])).
 
 init_per_testcase(CaseName, Config0) ->
     NewUsers = proplists:get_value(escalus_users, Config0) ++ escalus_ct:get_config(escalus_anon_users),

--- a/test/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test/ejabberd_tests/tests/bosh_SUITE.erl
@@ -102,17 +102,17 @@ init_per_group(essential, Config) ->
 init_per_group(essential_https, Config) ->
     [{user, carol_s} | Config];
 init_per_group(chat_https, Config) ->
-    Config1 = escalus_users:create_users(Config, {by_name, [carol, carol_s, geralt, alice]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([carol, carol_s, geralt, alice])),
     [{user, carol_s} | Config1];
 init_per_group(_GroupName, Config) ->
-    Config1 = escalus_users:create_users(Config, {by_name, [carol, carol_s, geralt, alice]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([carol, carol_s, geralt, alice])),
     [{user, carol} | Config1].
 
 end_per_group(GroupName, Config)
     when GroupName =:= essential; GroupName =:= essential_https ->
     Config;
 end_per_group(_GroupName, Config) ->
-    R = escalus_users:delete_users(Config, {by_name, [carol, carol_s, geralt, alice]}),
+    R = escalus:delete_users(Config, escalus:get_users([carol, carol_s, geralt, alice])),
     mongoose_helper:clear_last_activity(Config, carol),
     R.
 

--- a/test/ejabberd_tests/tests/carboncopy_SUITE.erl
+++ b/test/ejabberd_tests/tests/carboncopy_SUITE.erl
@@ -35,10 +35,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName,Config) ->
     escalus:init_per_testcase(CaseName,Config).

--- a/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -73,7 +73,7 @@ init_per_group(Group, Config) when Group == clustered orelse Group == ejabberdct
 
     case is_sm_distributed() of
         true ->
-            escalus:create_users(Config1, {by_name, [alice, clusterguy]});
+            escalus:create_users(Config1, escalus:get_users([alice, clusterguy]));
         {false, Backend} ->
             ct:pal("Backend ~p doesn't support distributed tests", [Backend]),
             remove_node_from_cluster(Config1),
@@ -83,7 +83,7 @@ init_per_group(_GroupName, Config) ->
     escalus:create_users(Config).
 
 end_per_group(Group, Config) when Group == clustered orelse Group == ejabberdctl ->
-    escalus:delete_users(Config, {by_name, [alice, clusterguy]}),
+    escalus:delete_users(Config, escalus:get_users([alice, clusterguy])),
     remove_node_from_cluster(Config);
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config).

--- a/test/ejabberd_tests/tests/conf_reload_SUITE.erl
+++ b/test/ejabberd_tests/tests/conf_reload_SUITE.erl
@@ -175,10 +175,10 @@ run_config_file_modification_fun(Config) ->
     Fun(Config).
 
 create_user_in_initial_domain(User, Config) ->
-    escalus:create_users(Config, {by_name, [User]}).
+    escalus:create_users(Config, escalus:get_users([User])).
 
 delete_user_in_initial_domain(User, Config) ->
-    escalus:delete_users(Config, {by_name, [User]}).
+    escalus:delete_users(Config, escalus:get_users([User])).
 
 connect_user(User, Config) ->
     UserSpec = escalus_users:get_userspec(Config, User),

--- a/test/ejabberd_tests/tests/connect_SUITE.erl
+++ b/test/ejabberd_tests/tests/connect_SUITE.erl
@@ -79,10 +79,10 @@ init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(Config0),
     ejabberd_node_utils:backup_config_file(Config1),
     assert_cert_file_exists(),
-    escalus:create_users(Config1, {by_name, [?SECURE_USER, alice]}).
+    escalus:create_users(Config1, escalus:get_users([?SECURE_USER, alice])).
 
 end_per_suite(Config) ->
-    escalus:delete_users(Config, {by_name, [?SECURE_USER, alice]}),
+    escalus:delete_users(Config, escalus:get_users([?SECURE_USER, alice])),
     restore_ejabberd_node(Config),
     escalus:end_per_suite(Config).
 

--- a/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
+++ b/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
@@ -124,7 +124,7 @@ init_per_suite(Config) ->
     NewConfig = escalus:init_per_suite([{ctl_path, CtlPath},
                                         {ctl_auth_mods, AuthMods},
                                         {roster_template, TemplatePath} | Config]),
-    escalus:create_users(NewConfig, {by_name, [alice, mike, bob, kate]}).
+    escalus:create_users(NewConfig, escalus:get_users([alice, mike, bob, kate])).
 
 end_per_suite(Config) ->
     Config1 = lists:keydelete(ctl_auth_mods, 1, Config),
@@ -195,7 +195,7 @@ init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
 end_per_testcase(delete_old_users, Config) ->
-    Users = escalus_users:get_users({by_name, [alice, bob, kate, mike]}),
+    Users = escalus_users:get_users([alice, bob, kate, mike]),
     lists:foreach(fun({_User, UserSpec}) ->
                 {Username, Domain, Pass} = get_user_data(UserSpec, Config),
                 escalus_ejabberd:rpc(ejabberd_auth, try_register, [Username, Domain, Pass])
@@ -1023,7 +1023,7 @@ set_last(User, Domain, TStamp) ->
     escalus_ejabberd:rpc(Mod, Fun, [escalus_utils:jid_to_lower(User), Domain, TStamp, <<>>]).
 
 delete_users(Config) ->
-    Users = escalus_users:get_users({by_name, [alice, bob, kate, mike]}),
+    Users = escalus_users:get_users([alice, bob, kate, mike]),
     lists:foreach(fun({_User, UserSpec}) ->
                 {Username, Domain, _Pass} = get_user_data(UserSpec, Config),
                 escalus_ejabberd:rpc(ejabberd_auth, remove_user, [Username, Domain])

--- a/test/ejabberd_tests/tests/last_SUITE.erl
+++ b/test/ejabberd_tests/tests/last_SUITE.erl
@@ -42,13 +42,13 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config0) ->
-    Config1 = escalus:create_users(Config0, {by_name, [alice, bob]}),
+    Config1 = escalus:create_users(Config0, escalus:get_users([alice, bob])),
     Config2 = escalus:make_everyone_friends(Config1),
     escalus_ejabberd:wait_for_session_count(Config2, 0),
     Config2.
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/ldap_helper.erl
+++ b/test/ejabberd_tests/tests/ldap_helper.erl
@@ -27,6 +27,8 @@
          create_users/2,
          delete_users/2]).
 
+-type user_spec() :: escalus_users:user_spec().
+
 -spec start(any()) -> ok.
 start(_) ->
     ok.
@@ -35,15 +37,13 @@ start(_) ->
 stop(_) ->
     ok.
 
--spec create_users(escalus:config(), escalus_users:who()) -> escalus:config().
-create_users(Config, Who) ->
-    Users = escalus_users:get_users(Who),
+-spec create_users(escalus:config(), [user_spec()]) -> escalus:config().
+create_users(Config, Users) ->
     lists:foreach(fun create_user/1, Users),
     lists:keystore(escalus_users, 1, Config, {escalus_users, Users}).
 
--spec delete_users(escalus:config(), escalus_users:who()) -> escalus:config().
-delete_users(Config, Who) ->
-    Users = escalus_users:get_users(Who),
+-spec delete_users(escalus:config(), [user_spec()]) -> escalus:config().
+delete_users(Config, Users) ->
     lists:foreach(fun delete_user/1, Users),
     Config.
 

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -289,10 +289,10 @@ user_names() ->
     [alice, bob].
 
 create_users(Config) ->
-    escalus:create_users(Config, {by_name, user_names()}).
+    escalus:create_users(Config, escalus:get_users(user_names())).
 
 delete_users(Config) ->
-    escalus:delete_users(Config, {by_name, user_names()}).
+    escalus:delete_users(Config, escalus:get_users(user_names())).
 
 init_per_group(Group, ConfigIn) ->
    C = configuration(Group),

--- a/test/ejabberd_tests/tests/metrics_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_api_SUITE.erl
@@ -53,10 +53,10 @@ end_per_suite(Config) ->
     dynamic_modules:start_running(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/metrics_c2s_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_c2s_SUITE.erl
@@ -67,10 +67,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/metrics_roster_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_roster_SUITE.erl
@@ -73,10 +73,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/metrics_session_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_session_SUITE.erl
@@ -56,10 +56,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/mod_ping_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_ping_SUITE.erl
@@ -50,23 +50,23 @@ end_per_suite(Config) ->
 
 init_per_group(client_ping, Config) ->
     start_mod_ping([]),
-    escalus:create_users(Config, {by_name, [alice]});
+    escalus:create_users(Config, escalus:get_users([alice]));
 init_per_group(server_ping, Config) ->
     start_mod_ping([{send_pings, true},
                     {ping_interval, 8},
                     {ping_req_timeout, 4}]),
-    escalus:create_users(Config, {by_name, [alice]});
+    escalus:create_users(Config, escalus:get_users([alice]));
 init_per_group(server_ping_kill, Config) ->
     start_mod_ping([{send_pings, true},
                     {ping_interval, 8},
                     {ping_req_timeout, 4},
                     {timeout_action, kill}]),
-    [{timeout_action, kill} | escalus:create_users(Config, {by_name, [alice]})].
+    [{timeout_action, kill} | escalus:create_users(Config, escalus:get_users([alice]))].
 
 end_per_group(_GroupName, Config) ->
     Domain = ct:get_config(ejabberd_domain),
     dynamic_modules:stop(Domain, mod_ping),
-    escalus:delete_users(Config, {by_name, [alice]}).
+    escalus:delete_users(Config, escalus:get_users([alice])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/mod_time_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_time_SUITE.erl
@@ -47,10 +47,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(mod_time, Config) ->
-    escalus:create_users(Config, {by_name, [alice]}).
+    escalus:create_users(Config, escalus:get_users([alice])).
 
 end_per_group(mod_time, Config) ->
-    escalus:delete_users(Config, {by_name, [alice]}).
+    escalus:delete_users(Config, escalus:get_users([alice])).
 
 
 init_per_testcase(CaseName, Config) ->

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -1299,7 +1299,7 @@ admin_ban_list(Config) ->
     end).
 
 admin_get_form(Config) ->
-    escalus:story(Config, [1,1,1], fun(Alice, _Bob, _Kate) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, _Bob, _Kate) ->
         timer:sleep(?WAIT_TIME),
         %%%% Bootstrap:
         %% Alice is admin
@@ -1552,7 +1552,7 @@ check_rolelist(LoginData, no, Config) ->
 
 %% This one tests a roomconfig_getmemberlist setting
 admin_member_list_allowed(Config) ->
-    escalus:story(Config, [1,1,1], fun(Alice, Bob, Kate) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
         timer:sleep(?WAIT_TIME),
         %%%% Bootstrap:
         %% Alice is admin
@@ -2849,7 +2849,7 @@ disco_items(Config) ->
                                  end).
 
 disco_items_nonpublic(Config) ->
-    escalus:story(Config, [1,1], fun(Alice, Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         escalus:send(Alice, stanza_join_room(<<"alicesroom">>, <<"nicenick">>)),
         _Stanza = escalus:wait_for_stanza(Alice),
 

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -217,7 +217,7 @@ end_per_suite(Config) ->
 init_per_group(moderator, Config) ->
     RoomName = <<"alicesroom">>,
     RoomNick = <<"alicesnick">>,
-    Config1 = escalus:create_users(Config, {by_name, [alice, bob, kate]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, bob, kate])),
     [Alice | _] = ?config(escalus_users, Config1),
     start_room(Config1, Alice, RoomName, RoomNick,
         [{persistent, true}, {allow_change_subj, false}, {moderated, true},
@@ -226,54 +226,54 @@ init_per_group(moderator, Config) ->
 init_per_group(admin, Config) ->
     RoomName = <<"alicesroom">>,
     RoomNick = <<"alicesnick">>,
-    Config1 = escalus:create_users(Config, {by_name, [alice, bob, kate]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, bob, kate])),
     [Alice | _] = ?config(escalus_users, Config1),
     start_room(Config1, Alice, RoomName, RoomNick, [{persistent, true}]);
 
 init_per_group(admin_membersonly, Config) ->
     RoomName = <<"alicesroom">>,
     RoomNick = <<"alicesnick">>,
-    Config1 = escalus:create_users(Config, {by_name, [alice, bob, kate]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, bob, kate])),
     [Alice | _] = ?config(escalus_users, Config1),
     start_room(Config1, Alice, RoomName, RoomNick, [{persistent, true},
         {members_only, true}]);
 
 init_per_group(disco, Config) ->
-    Config1 = escalus:create_users(Config, {by_name, [alice, bob]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, bob])),
     [Alice | _] = ?config(escalus_users, Config1),
     start_room(Config1, Alice, <<"alicesroom">>, <<"aliceonchat">>,
         [{persistent, true}]);
 
 init_per_group(disco_rsm, Config) ->
-    Config1 = escalus:create_users(Config, {by_name, [alice, bob]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, bob])),
     [Alice | _] = ?config(escalus_users, Config1),
     start_rsm_rooms(Config1, Alice, <<"aliceonchat">>);
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob, kate]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob, kate])).
 
 end_per_group(moderator, Config) ->
     destroy_room(Config),
-    escalus:delete_users(Config, {by_name, [alice, bob, kate]});
+    escalus:delete_users(Config, escalus:get_users([alice, bob, kate]));
 
 end_per_group(admin, Config) ->
     destroy_room(Config),
-    escalus:delete_users(Config, {by_name, [alice, bob, kate]});
+    escalus:delete_users(Config, escalus:get_users([alice, bob, kate]));
 
 end_per_group(admin_membersonly, Config) ->
     destroy_room(Config),
-    escalus:delete_users(Config, {by_name, [alice, bob, kate]});
+    escalus:delete_users(Config, escalus:get_users([alice, bob, kate]));
 
 end_per_group(disco, Config) ->
     destroy_room(Config),
-    escalus:delete_users(Config, {by_name, [alice, bob]});
+    escalus:delete_users(Config, escalus:get_users([alice, bob]));
 
 end_per_group(disco_rsm, Config) ->
     destroy_rsm_rooms(Config),
-    escalus:delete_users(Config, {by_name, [alice, bob]});
+    escalus:delete_users(Config, escalus:get_users([alice, bob]));
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob, kate]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob, kate])).
 
 init_per_testcase(CaseName = configure_anonymous, Config) ->
     [Alice | _] = ?config(escalus_users, Config),

--- a/test/ejabberd_tests/tests/offline_SUITE.erl
+++ b/test/ejabberd_tests/tests/offline_SUITE.erl
@@ -40,10 +40,10 @@ suite() ->
 
 init_per_suite(Config0) ->
     Config1 = escalus:init_per_suite(Config0),
-    escalus:create_users(Config1, {by_name, [alice, bob]}).
+    escalus:create_users(Config1, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}),
+    escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->

--- a/test/ejabberd_tests/tests/presence_SUITE.erl
+++ b/test/ejabberd_tests/tests/presence_SUITE.erl
@@ -62,10 +62,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(versioning, ConfigIn) ->
     Config = set_versioning(true, true, ConfigIn),

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -82,10 +82,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/private_SUITE.erl
+++ b/test/ejabberd_tests/tests/private_SUITE.erl
@@ -48,10 +48,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, {by_name, [alice, bob]}).
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}).
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/test/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test/ejabberd_tests/tests/s2s_SUITE.erl
@@ -89,13 +89,13 @@ init_per_suite(Config0) ->
                     node2_s2s_use_starttls = Node2S2SUseStartTLS},
 
     Config1 = [{s2s_opts, S2S} | escalus:init_per_suite(Config0)],
-    escalus_users:create_users(Config1, {by_name, [alice2, bob2, alice, bob]}).
+    escalus:create_users(Config1, escalus:get_users([alice2, bob2, alice, bob])).
 
 end_per_suite(Config) ->
     S2SOrig = ?config(s2s_opts, Config),
     configure_s2s(S2SOrig),
     node2_rpccall(mongoose_cover_helper, analyze, []),
-    escalus:delete_users(Config, {by_name, [alice, bob]}),
+    escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
 init_per_group(both_plain, Config) ->

--- a/test/ejabberd_tests/tests/shared_roster_SUITE.erl
+++ b/test/ejabberd_tests/tests/shared_roster_SUITE.erl
@@ -56,10 +56,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_, Config) ->
-    escalus:create_users(Config, ?USERS).
+    escalus:create_users(Config, escalus:get_users(?USERS)).
 
 end_per_group(_, Config) ->
-    escalus:delete_users(Config, ?USERS).
+    escalus:delete_users(Config, escalus:get_users(?USERS)).
 
 init_per_testcase(CaseName,Config) ->
     case proplists:get_value(ldap_auth, Config) of

--- a/test/ejabberd_tests/tests/shared_roster_SUITE.erl
+++ b/test/ejabberd_tests/tests/shared_roster_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
 
--define(USERS, {by_name, [alice, bob]}).
+-define(USERS, [alice, bob]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -108,7 +108,7 @@ delete_user(Config) ->
     NumOfOtherUsers = length(escalus_users:get_users(?USERS))-2,
     %% wait to invalidate the roster group cache
     timer:sleep(1200),
-    escalus_users:delete_users(Config,{by_name, [bob]}),
+    escalus:delete_users(Config,escalus:get_users([bob])),
     escalus:story(Config,[{alice, 1}],fun(Alice) ->
         escalus_client:send(Alice, escalus_stanza:roster_get()),
         Roster=escalus_client:wait_for_stanza(Alice),
@@ -118,7 +118,7 @@ delete_user(Config) ->
     end).
 
 add_user(Config) ->
-    escalus_users:create_users(Config,{by_name, [bob]}),
+    escalus:create_users(Config,escalus:get_users([bob])),
     timer:sleep(1200),
     escalus:story(Config,[{alice, 1}],fun(Alice) ->
         NumOfOtherUsers = length(escalus_users:get_users(?USERS))-1,

--- a/test/ejabberd_tests/tests/shared_roster_SUITE.erl
+++ b/test/ejabberd_tests/tests/shared_roster_SUITE.erl
@@ -105,29 +105,29 @@ get_contacts(Config) ->
     end).
 
 delete_user(Config) ->
-    NumOfOtherUsers = length(escalus_users:get_users(?USERS))-2,
+    NumOfOtherUsers = length(escalus_users:get_users(?USERS)) - 2,
     %% wait to invalidate the roster group cache
     timer:sleep(1200),
-    escalus:delete_users(Config,escalus:get_users([bob])),
-    escalus:story(Config,[{alice, 1}],fun(Alice) ->
+    escalus:delete_users(Config, escalus:get_users([bob])),
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
         escalus_client:send(Alice, escalus_stanza:roster_get()),
         Roster=escalus_client:wait_for_stanza(Alice),
 
-        escalus:assert(is_roster_result,Roster),
-        escalus:assert(count_roster_items,[NumOfOtherUsers],Roster)
+        escalus:assert(is_roster_result, Roster),
+        escalus:assert(count_roster_items, [NumOfOtherUsers], Roster)
     end).
 
 add_user(Config) ->
-    escalus:create_users(Config,escalus:get_users([bob])),
+    escalus:create_users(Config, escalus:get_users([bob])),
     timer:sleep(1200),
-    escalus:story(Config,[{alice, 1}],fun(Alice) ->
-        NumOfOtherUsers = length(escalus_users:get_users(?USERS))-1,
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
+        NumOfOtherUsers = length(escalus_users:get_users(?USERS)) - 1,
 
         escalus_client:send(Alice, escalus_stanza:roster_get()),
         Roster=escalus_client:wait_for_stanza(Alice),
 
-        escalus:assert(is_roster_result,Roster),
-        escalus:assert(count_roster_items,[NumOfOtherUsers],Roster)
+        escalus:assert(is_roster_result, Roster),
+        escalus:assert(count_roster_items, [NumOfOtherUsers], Roster)
     end).
 
 %%--------------------------------------------------------------------

--- a/test/ejabberd_tests/tests/sic_SUITE.erl
+++ b/test/ejabberd_tests/tests/sic_SUITE.erl
@@ -35,10 +35,10 @@ suite() ->
 
 init_per_suite(Config0) ->
     Config1 = escalus:init_per_suite(Config0),
-    escalus:create_users(Config1, {by_name, [alice, bob]}).
+    escalus:create_users(Config1, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}),
+    escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
 init_per_group(mod_offline_tests, Config) ->

--- a/test/ejabberd_tests/tests/sm_SUITE.erl
+++ b/test/ejabberd_tests/tests/sm_SUITE.erl
@@ -67,11 +67,11 @@ suite() ->
 init_per_suite(Config) ->
     NewConfig = escalus_ejabberd:setup_option(ack_freq(never), Config),
     Config1 = escalus:init_per_suite(NewConfig),
-    escalus:create_users(Config1, {by_name, [alice, bob]}).
+    escalus:create_users(Config1, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
     NewConfig = escalus_ejabberd:reset_option(ack_freq(never), Config),
-    NewConfig1 = escalus:delete_users(NewConfig, {by_name, [alice, bob]}),
+    NewConfig1 = escalus:delete_users(NewConfig, escalus:get_users([alice, bob])),
     escalus:end_per_suite(NewConfig1).
 
 init_per_group(client_acking, Config) ->

--- a/test/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test/ejabberd_tests/tests/vcard_SUITE.erl
@@ -105,7 +105,7 @@ init_per_suite(Config) ->
     NewConfig = escalus:init_per_suite(Config),
     NewConfig1 = vcard_config(NewConfig),
     NewConfig2 = stop_running_vcard_mod(NewConfig1),
-    AliceAndBob = escalus_users:get_users({by_name, [alice, bob]}),
+    AliceAndBob = escalus_users:get_users([alice, bob]),
     BisUsers = [{aliceb,[{username,<<"aliceb">>},
                         {server,<<"localhost.bis">>},
                         {host, <<"localhost">>},

--- a/test/ejabberd_tests/tests/vcard_simple_SUITE.erl
+++ b/test/ejabberd_tests/tests/vcard_simple_SUITE.erl
@@ -71,10 +71,10 @@ init_per_suite(Config) ->
         _ ->
             NewConfig0
     end,
-    escalus:create_users(NewConfig, {by_name, [alice, bob]}).
+    escalus:create_users(NewConfig, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
-    NewConfig = escalus:delete_users(Config, {by_name, [alice, bob]}),
+    NewConfig = escalus:delete_users(Config, escalus:get_users([alice, bob])),
     case is_vcard_ldap() of
         true ->
             restore_ldap_vcards_config(Config);

--- a/test/ejabberd_tests/tests/websockets_SUITE.erl
+++ b/test/ejabberd_tests/tests/websockets_SUITE.erl
@@ -54,7 +54,7 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(GroupName, Config) ->
-    Config1 = escalus:create_users(Config, {by_name, [alice, geralt, geralt_s, oldie]}),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, geralt, geralt_s, oldie])),
     case GroupName of
         wss_chat ->
             [{user, geralt_s} | Config1];
@@ -64,7 +64,7 @@ init_per_group(GroupName, Config) ->
 
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, {by_name, [alice, geralt, geralt_s, oldie]}).
+    escalus:delete_users(Config, escalus:get_users([alice, geralt, geralt_s, oldie])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).


### PR DESCRIPTION
Use a slightly narrower, but simple to reimplement interface for `escalus:create_users/2`. See esl/escalus#95 for reasons why I think it's a good change.