### PR TITLE
Catch noproc error in ejabberd_receiver

### DIFF
--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -92,7 +92,7 @@ reset_stream(Pid) ->
     gen_server_call_or_noproc(Pid, reset_stream).
 
 starttls(Pid, TLSSocket) ->
-    gen_server:call(Pid, {starttls, TLSSocket}).
+    gen_server_call_or_noproc(Pid, {starttls, TLSSocket}).
 
 compress(Pid, ZlibSocket) ->
     gen_server:call(Pid, {compress, ZlibSocket}).

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -89,7 +89,7 @@ change_shaper(Pid, Shaper) ->
     gen_server:cast(Pid, {change_shaper, Shaper}).
 
 reset_stream(Pid) ->
-    gen_server:call(Pid, reset_stream).
+    gen_server_call_or_noproc(Pid, reset_stream).
 
 starttls(Pid, TLSSocket) ->
     gen_server:call(Pid, {starttls, TLSSocket}).
@@ -387,3 +387,10 @@ free_parser(undefined) ->
     ok;
 free_parser(Parser) ->
     exml_stream:free_parser(Parser).
+
+gen_server_call_or_noproc(Pid, Message) ->
+    try
+        gen_server:call(Pid, Message)
+    catch exit:{noproc,Extra} ->
+        {error, {noproc,Extra}}
+    end.

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -95,7 +95,7 @@ starttls(Pid, TLSSocket) ->
     gen_server_call_or_noproc(Pid, {starttls, TLSSocket}).
 
 compress(Pid, ZlibSocket) ->
-    gen_server:call(Pid, {compress, ZlibSocket}).
+    gen_server_call_or_noproc(Pid, {compress, ZlibSocket}).
 
 become_controller(Pid, C2SPid) ->
     gen_server:call(Pid, {become_controller, C2SPid}).


### PR DESCRIPTION
Fixes #411 
Fixes #626 
Contains a regular test reproducing the issue.
About tests. I used sys:suspend/1 to prepare c2s process to "crash properly" :)

I tried to use "build-in" tests for Mongoose (in apps/ejabberd/tests) but we actually want to test change in ejabberd_receiver, not ejabberd_c2s. And each time I end up with mocked ejabberd_receiver. :)

I understand that ejabberd_receiver:starttls/2, compress/2 and become_controller/2 could also crash.
But I don't have a test for them yet. And I never saw them crashing :)