### PR TITLE
Fix bugs in mod_mam_odbc_prefs

### DIFF
--- a/apps/ejabberd/src/mod_mam_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_cache_user.erl
@@ -109,6 +109,7 @@ stop_server(_Host) ->
 start_pm(Host, _Opts) ->
     ejabberd_hooks:add(mam_archive_id, Host, ?MODULE, cached_archive_id, 30),
     ejabberd_hooks:add(mam_archive_id, Host, ?MODULE, store_archive_id, 70),
+    ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 
@@ -116,6 +117,7 @@ start_pm(Host, _Opts) ->
 stop_pm(Host) ->
     ejabberd_hooks:delete(mam_archive_id, Host, ?MODULE, cached_archive_id, 30),
     ejabberd_hooks:delete(mam_archive_id, Host, ?MODULE, store_archive_id, 70),
+    ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 
@@ -126,6 +128,7 @@ stop_pm(Host) ->
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_archive_id, Host, ?MODULE, cached_archive_id, 30),
     ejabberd_hooks:add(mam_muc_archive_id, Host, ?MODULE, store_archive_id, 70),
+    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 
@@ -133,6 +136,7 @@ start_muc(Host, _Opts) ->
 stop_muc(Host) ->
     ejabberd_hooks:delete(mam_muc_archive_id, Host, ?MODULE, cached_archive_id, 30),
     ejabberd_hooks:delete(mam_muc_archive_id, Host, ?MODULE, store_archive_id, 70),
+    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 

--- a/apps/ejabberd/src/mod_mam_mnesia_dirty_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_dirty_prefs.erl
@@ -186,8 +186,8 @@ set_prefs(Result, _Host, ArcID, ArcJID, DefaultMode, AlwaysJIDs, NeverJIDs) ->
 -spec get_prefs(mod_mam:preference(), _Host :: ejabberd:server(),
                 _ArcId :: mod_mam:archive_id(), ArcJID :: ejabberd:jid()
                 ) -> mod_mam:preference().
-get_prefs({GlobalDefaultMode, _, _}, _Host, _ArcID, ArcJID) ->
-    case mnesia:dirty_read(mam_prefs, su_key(ArcJID)) of
+get_prefs({GlobalDefaultMode, _, _}, _Host, ArcID, ArcJID) ->
+    case mnesia:dirty_read(mam_prefs, ArcID) of
         [] ->
             {GlobalDefaultMode, [], []};
         [#mam_prefs{default_mode=DefaultMode,

--- a/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
@@ -193,12 +193,14 @@ get_prefs({GlobalDefaultMode, _, _}, _Host, _ArcID, ArcJID) ->
                      ArcJID :: ejabberd:jid()) -> 'ok'.
 remove_archive(_Host, _ArcID, ArcJID) ->
     {atomic, ok} = mnesia:transaction(fun() ->
-        case mnesia:read(mam_prefs_user, su_key(ArcJID)) of
+        SU = su_key(ArcJID),
+        case mnesia:read(mam_prefs_user, SU) of
             [] -> ok; %% already deleted
             [#mam_prefs_user{always_rules=ARules, never_rules=NRules}] ->
-                Rules = [key3(ArcJID)] ++ ARules ++ NRules,
-                Keys = [key(ArcJID, Rule) || Rule <- Rules],
+                Rules =  ARules ++ NRules,
+                Keys = [key3(ArcJID)] ++ [key(ArcJID, Rule) || Rule <- Rules],
                 [mnesia:delete(mam_prefs_rule, Key, write) || Key <- Keys],
+                mnesia:delete(mam_prefs_user, SU, write),
                 ok
         end
     end),

--- a/apps/ejabberd/src/mod_mam_muc_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cache_user.erl
@@ -88,11 +88,13 @@ stop_server(_Host) ->
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_archive_id, Host, ?MODULE, cached_archive_id, 30),
     ejabberd_hooks:add(mam_muc_archive_id, Host, ?MODULE, store_archive_id, 70),
+    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 stop_muc(Host) ->
     ejabberd_hooks:delete(mam_muc_archive_id, Host, ?MODULE, cached_archive_id, 30),
     ejabberd_hooks:delete(mam_muc_archive_id, Host, ?MODULE, store_archive_id, 70),
+    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 

--- a/apps/ejabberd/src/mod_mam_odbc_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_prefs.erl
@@ -111,12 +111,13 @@ stop_muc(Host) ->
 get_behaviour(DefaultBehaviour, Host, UserID, _LocJID, RemJID) ->
     RemLJID      = jid:to_lower(RemJID),
     SRemLBareJID = esc_jid(jid:to_bare(RemLJID)),
-    SRemLJID     = esc_jid(jid:to_lower(RemJID)),
+    SRemLJID     = esc_jid(RemLJID),
     SUserID      = integer_to_list(UserID),
     case query_behaviour(Host, SUserID, SRemLJID, SRemLBareJID) of
-        {selected, ["behaviour"], [{Behavour}]} ->
+        {selected, [<<"behaviour">>], [{Behavour}]} ->
             decode_behaviour(Behavour);
-        _ -> DefaultBehaviour
+        {selected, [<<"behaviour">>], []} ->
+            DefaultBehaviour
     end.
 
 

--- a/apps/ejabberd/src/mod_mam_odbc_user.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_user.erl
@@ -62,12 +62,14 @@ stop(Host) ->
 -spec start_pm(ejabberd:server(),_) -> 'ok'.
 start_pm(Host, _Opts) ->
     ejabberd_hooks:add(mam_archive_id, Host, ?MODULE, archive_id, 50),
+    ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 90),
     ok.
 
 
 -spec stop_pm(ejabberd:server()) -> 'ok'.
 stop_pm(Host) ->
     ejabberd_hooks:delete(mam_archive_id, Host, ?MODULE, archive_id, 50),
+    ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 90),
     ok.
 
 
@@ -77,12 +79,14 @@ stop_pm(Host) ->
 -spec start_muc(ejabberd:server(),_) -> 'ok'.
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_archive_id, Host, ?MODULE, archive_id, 50),
+    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 90),
     ok.
 
 
 -spec stop_muc(ejabberd:server()) -> 'ok'.
 stop_muc(Host) ->
     ejabberd_hooks:delete(mam_muc_archive_id, Host, ?MODULE, archive_id, 50),
+    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 90),
     ok.
 
 

--- a/apps/ejabberd/src/shaper_srv.erl
+++ b/apps/ejabberd/src/shaper_srv.erl
@@ -15,7 +15,9 @@
 
 -export([start_link/1,
          child_specs/0,
-         wait/4]).
+         wait/4,
+         reset_shapers/1,
+         reset_all_shapers/1]).
 
 %% ------------------------------------------------------------------
 %% Record definitions
@@ -98,6 +100,14 @@ worker_number(Host, Tag) ->
 wait(Host, Action, FromJID, Size) ->
     gen_server:call(select_worker(Host, FromJID), {wait, Host, Action, FromJID, Size}).
 
+%% @doc Ask all shaper servers to forget current shapers and read settings again
+reset_all_shapers(Host) ->
+    [reset_shapers(ProcName) || ProcName <- worker_names(Host)].
+
+%% @doc Ask server to forget its shapers
+reset_shapers(ProcName) ->
+    gen_server:call(ProcName, reset_shapers).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
@@ -124,7 +134,9 @@ handle_call({wait, Host, Action, FromJID, Size},
             {noreply, save_shaper(Key, UpdatedShaper, State1)};
         {_, _} ->
             {reply, {error, max_delay_reached}, State1}
-    end.
+    end;
+handle_call(reset_shapers, _From, State=#state{}) ->
+    {reply, ok, init_dicts(State)}.
 
 handle_cast(_Msg, State) ->
     {noreply, State}.

--- a/apps/ejabberd/src/shaper_srv.erl
+++ b/apps/ejabberd/src/shaper_srv.erl
@@ -203,7 +203,7 @@ create_shaper(Key) ->
     shaper:new(request_shaper_name(Key)).
 
 
--spec request_shaper_name(key()) -> 'allow' | 'none'.
+-spec request_shaper_name(key()) -> atom().
 request_shaper_name({Host, Action, FromJID}) ->
     get_shaper_name(Host, Action, FromJID, default_shaper()).
 

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -2481,7 +2481,7 @@ run_set_and_get_prefs_cases(Config) ->
 run_set_and_get_prefs_case({PrefsState, _ExpectedMessageStates}, Alice, Config) ->
     IqSet = stanza_prefs_set_request(PrefsState, Config),
     escalus:send(Alice, IqSet),
-    ReplySet = escalus:wait_for_stanza(Alice),
+    ReplySet = escalus:wait_for_stanza(Alice, 5000),
 
     escalus:send(Alice, stanza_prefs_get_request()),
     ReplyGet = escalus:wait_for_stanza(Alice),

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -2463,6 +2463,6 @@ users_to_jids(Users, Config) ->
     [escalus_users:get_jid(Config, User) || User <- Users].
 
 print_configuration_not_supported(C, B) ->
-    I = iolib:format("issue=configuration_not_supported, "
-                      "configuration=~p, basic_group=~p", [C, B]),
+    I = io_lib:format("issue=configuration_not_supported, "
+                       "configuration=~p, basic_group=~p", [C, B]),
      binary_to_list(iolist_to_binary(I)).

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -517,6 +517,7 @@ init_modules(odbc_async, _, Config) ->
     Config;
 init_modules(riak_timed_yz_buckets, _, Config) ->
     init_module(host(), mod_mam_riak_timed_arch_yz, [pm, muc]),
+    init_module(host(), mod_mam_mnesia_prefs, [pm, muc]),
     init_module(host(), mod_mam, []),
     init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
     Config;

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -149,6 +149,7 @@ odbc_configs(true) ->
     [odbc,
      odbc_async_pool,
      odbc_mnesia,
+     odbc_dirty_mnesia,
      odbc_async_cache,
      odbc_cache,
      odbc_mnesia_cache,
@@ -367,6 +368,14 @@ init_modules(odbc_mnesia, muc_with_pm, Config) ->
     init_module(host(), mod_mam, []),
     init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
     Config;
+init_modules(odbc_dirty_mnesia, muc_with_pm, Config) ->
+    init_module(host(), mod_mam_muc_odbc_arch, []),
+    init_module(host(), mod_mam_odbc_arch, [pm]),
+    init_module(host(), mod_mam_mnesia_dirty_prefs, [muc, pm]),
+    init_module(host(), mod_mam_odbc_user, [muc, pm]),
+    init_module(host(), mod_mam, []),
+    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
+    Config;
 init_modules(odbc_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_odbc_arch, [pm]),
@@ -429,6 +438,12 @@ init_modules(odbc_async_pool, muc, Config) ->
 init_modules(odbc_mnesia, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
+    init_module(host(), mod_mam_odbc_user, [muc]),
+    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
+    Config;
+init_modules(odbc_dirty_mnesia, muc, Config) ->
+    init_module(host(), mod_mam_muc_odbc_arch, []),
+    init_module(host(), mod_mam_mnesia_dirty_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}]),
     Config;
@@ -496,6 +511,12 @@ init_modules(odbc_mnesia, _, Config) ->
     init_module(host(), mod_mam, []),
     init_module(host(), mod_mam_odbc_arch, [pm]),
     init_module(host(), mod_mam_mnesia_prefs, [pm]),
+    init_module(host(), mod_mam_odbc_user, [pm]),
+    Config;
+init_modules(odbc_dirty_mnesia, _, Config) ->
+    init_module(host(), mod_mam, []),
+    init_module(host(), mod_mam_odbc_arch, [pm]),
+    init_module(host(), mod_mam_mnesia_dirty_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
     Config;
 init_modules(odbc_cache, _, Config) ->

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -309,7 +309,7 @@ init_per_group(Group, ConfigIn) ->
    B = basic_group(Group),
    case init_modules(C, B, ConfigIn) of
         skip ->
-            {skip, {init_modules, C, B, ConfigIn}};
+            {skip, print_configuration_not_supported(C, B)};
         Config0 ->
             ct:pal("Init per group ~p; configuration ~p; basic group ~p",
                    [Group, C, B]),
@@ -2461,3 +2461,8 @@ stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers}, Config) ->
 
 users_to_jids(Users, Config) ->
     [escalus_users:get_jid(Config, User) || User <- Users].
+
+print_configuration_not_supported(C, B) ->
+    I = iolib:format("issue=configuration_not_supported, "
+                      "configuration=~p, basic_group=~p", [C, B]),
+     binary_to_list(iolist_to_binary(I)).


### PR DESCRIPTION
Add tests for MAM preferences
Bug 1: JIDs are not normalized before stored in preferences
Bug 2: Result from SQL query never matches in get_behaviour