### PR TITLE
[skip ci] added support for build dashboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,8 @@ matrix:
 
 after_failure:
         - tools/travis-upload-ct-reports.sh
+
+notifications:
+    webhooks:
+        # trigger Buildtime Trend Service to parse Travis CI log
+        - https://buildtimetrend.herokuapp.com/travis

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-MongooseIM  [![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM) [![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](http://mongooseim.readthedocs.org/en/latest/?badge=latest) [![Coverage Status](https://img.shields.io/coveralls/esl/MongooseIM.svg)](https://coveralls.io/r/esl/MongooseIM?branch=master)
+MongooseIM  [![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM) [![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](http://mongooseim.readthedocs.org/en/latest/?badge=latest) [![Coverage Status](https://img.shields.io/coveralls/esl/MongooseIM.svg)](https://coveralls.io/r/esl/MongooseIM?branch=master) [![Buildtime trend](https://buildtimetrend.herokuapp.com/badge/esl/MongooseIM/latest)](https://buildtimetrend.herokuapp.com/dashboard/esl/MongooseIM>/)
+
 ============
 <img align="left" src="https://www.erlang-solutions.com/sites/all/themes/erlang/img/mongoose/MongooseIM_blue.png"</img>
 
@@ -228,3 +229,7 @@ We recommend following client libraries:
 * iOS, Objective-C: [XMPPframework](https://github.com/robbiehanson/XMPPFramework)
 * Android, Java: [Smack](https://github.com/igniterealtime/Smack)
 * Web, JavaScript: [Stanza.io](https://github.com/otalk/stanza.io)
+
+
+
+


### PR DESCRIPTION
[Squashed commits]
Added basic integration with buildtimetrend service for easy and nice inspection of various build parameters.
More info on the service is available at: http://buildtimetrend.herokuapp.com
Other projects are available in dashboard/projects section. Not much can be said about quality of this service as it's a new thing. But looks as nice complement to travis and coveralls. More badges and better resolution (inter-test-suite statistics) will be added over time as we find more about this service.