### PR TITLE
preserve resume timeout when a session is resumed

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2752,6 +2752,7 @@ merge_state(OldSD, SD) ->
                 #state.stream_mgmt_buffer,
                 #state.stream_mgmt_buffer_size,
                 #state.stream_mgmt_buffer_max,
+                #state.stream_mgmt_resume_timeout,
                 #state.stream_mgmt_ack_freq],
     Copy = fun(Index, {Stale, Acc}) ->
                    {Stale, setelement(Index, Acc, element(Index, Stale))}


### PR DESCRIPTION
In a resumption, resume timeout is not merged, so it will get the default resume timeout instead of the timeout of the configuration file.