### PR TITLE
Remove mam index duplicates

### DIFF
--- a/apps/ejabberd/priv/mysql-part.sql
+++ b/apps/ejabberd/priv/mysql-part.sql
@@ -17,8 +17,7 @@ CREATE TABLE mam_message_00(
   -- Term-encoded message packet
   message blob NOT NULL,
   PRIMARY KEY (user_id, id),
-  INDEX i_mam_message_rem USING BTREE (user_id, remote_bare_jid, id),
-  INDEX i_mam_message_uid USING BTREE (user_id, id)
+  INDEX i_mam_message_rem USING BTREE (user_id, remote_bare_jid, id)
 )  ENGINE=InnoDB;
 
 CREATE TABLE mam_message_01 LIKE mam_message_00;

--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -231,10 +231,8 @@ CREATE TABLE mam_server_user(
   server    varchar(250) CHARACTER SET binary NOT NULL,
   user_name varchar(250) CHARACTER SET binary NOT NULL,
   PRIMARY KEY(id) USING HASH,
-  CONSTRAINT uc_mam_server_user_name UNIQUE (server, user_name)
+  CONSTRAINT uc_mam_server_user_name UNIQUE USING HASH (server, user_name)
 );
-CREATE INDEX i_mam_server_user_name USING HASH ON mam_server_user(server, user_name);
-
 
 CREATE TABLE mam_muc_message(
   -- Message UID

--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -206,8 +206,7 @@ CREATE TABLE mam_message(
   -- Don't try to decode it using MySQL tools
   message blob NOT NULL,
   PRIMARY KEY (user_id, id),
-  INDEX i_mam_message_rem USING BTREE (user_id, remote_bare_jid, id),
-  INDEX i_mam_message_uid USING BTREE (user_id, id)
+  INDEX i_mam_message_rem USING BTREE (user_id, remote_bare_jid, id)
 )  ENGINE=InnoDB
    PARTITION BY HASH(user_id)
    PARTITIONS 32;
@@ -240,15 +239,14 @@ CREATE INDEX i_mam_server_user_name USING HASH ON mam_server_user(server, user_n
 CREATE TABLE mam_muc_message(
   -- Message UID
   -- A server-assigned UID that MUST be unique within the archive.
-  id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+  id BIGINT UNSIGNED NOT NULL,
   room_id INT UNSIGNED NOT NULL,
   -- A nick of the message's originator
   nick_name varchar(250) NOT NULL,
   -- Term-encoded message packet
-  message blob NOT NULL
+  message blob NOT NULL,
+  PRIMARY KEY (room_id, id)
 );
-CREATE INDEX i_mam_muc_message_room_name_added_at USING BTREE ON mam_muc_message(room_id, id);
-
 
 CREATE TABLE offline_message(
   id BIGINT UNSIGNED        NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/apps/ejabberd/priv/pg.sql
+++ b/apps/ejabberd/priv/pg.sql
@@ -171,7 +171,7 @@ CREATE TYPE mam_direction AS ENUM('I','O');
 CREATE TABLE mam_message(
   -- Message UID (64 bits)
   -- A server-assigned UID that MUST be unique within the archive.
-  id BIGINT NOT NULL PRIMARY KEY,
+  id BIGINT NOT NULL,
   user_id INT NOT NULL,
   -- FromJID used to form a message without looking into stanza.
   -- This value will be send to the client "as is".
@@ -185,12 +185,9 @@ CREATE TABLE mam_message(
   -- Has no meaning for MUC-rooms.
   direction mam_direction NOT NULL,
   -- Term-encoded message packet
-  message bytea NOT NULL
+  message bytea NOT NULL,
+  PRIMARY KEY(user_id, id)
 );
-CREATE INDEX i_mam_message_username_id
-    ON mam_message
-    USING BTREE
-    (user_id, id);
 CREATE INDEX i_mam_message_username_jid_id
     ON mam_message
     USING BTREE

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -190,7 +190,7 @@ archive_size(Size, Host, UserID, _UserJID) when is_integer(Size) ->
 index_hint_sql(Host) ->
     case ejabberd_odbc:db_engine(Host) of
         mysql ->
-            "USE INDEX(i_mam_message_uid, i_mam_message_rem) ";
+            "USE INDEX(PRIMARY, i_mam_message_rem) ";
         _ ->
             ""
     end.


### PR DESCRIPTION
Use this query under the root mysql user to check which indexes are created:

```sql
select database_name, table_name, index_name, stat_value*@@innodb_page_size
from mysql.innodb_index_stats where stat_name='size';
```

Basically,

```sql
... PRIMARY KEY (my_key) ... // create BTREE with data in leafs
CREATE INDEX another_index (my_key); // create BTREE with pointers on data in leafs
```

creates two indexes.
This second index can affect performance.

So, the pull request removes unwanted index duplicates.
