### PR TITLE
Join/leave cluster completely at the Erlang level

### DIFF
--- a/apps/ejabberd/src/mongoose_cluster.erl
+++ b/apps/ejabberd/src/mongoose_cluster.erl
@@ -1,0 +1,140 @@
+-module(mongoose_cluster).
+
+%% This is a library module for cluster management: joining / leaving a cluster.
+
+%% TODO: it might make sense to expose this stuff as mod_admin_extra_cluster
+
+-export([join/1,
+         leave/0]).
+
+-include("ejabberd.hrl").
+
+%%
+%% API
+%%
+
+%% @doc Join a cluster designated by ClusterMember.
+%% This drops all current connections and discards all persistent
+%% data from Mnesia. Use with caution!
+%% Next time the node starts, it will connect to other members automatically.
+%% TODO: when/if exposing through ejabberd_admin make sure it's guarded
+%%       by an interactive yes/no question or some flag
+-spec join(node()) -> ok.
+join(ClusterMember) ->
+    ?INFO_MSG("join ~p", [ClusterMember]),
+    with_app_stopped(ejabberd,
+                     fun () ->
+                             check_networking(ClusterMember),
+                             unsafe_join(node(), ClusterMember)
+                     end).
+
+%% @doc Leave cluster.
+%% This drops all current connections and discards all persistent
+%% data from Mnesia. Use with caution!
+%% Next time the node starts, it will NOT connect to previous members.
+%% Remaining members will remove this node from the cluster Mnesia schema.
+%% TODO: when/if exposing through ejabberd_admin make sure it's guarded
+%%       by an interactive yes/no question or some flag
+-spec leave() -> ok.
+leave() ->
+    ?INFO_MSG("leave", []),
+    with_app_stopped(ejabberd,
+                     fun () ->
+                             catch mnesia:stop(),
+                             detach_nodes(mnesia_nodes()),
+                             delete_mnesia(),
+                             ok = mnesia:start()
+                     end).
+
+%%
+%% Helpers
+%%
+
+is_app_running(App) ->
+    lists:keymember(App, 1, application:which_applications()).
+
+check_networking(ClusterMember) ->
+    ok == wait_for_pong(ClusterMember) orelse error(pang, [ClusterMember]).
+
+unsafe_join(Node, ClusterMember) ->
+    delete_mnesia(),
+    ok = mnesia:start(),
+    {ok, [ClusterMember]} = mnesia:change_config(extra_db_nodes, [ClusterMember]),
+    true = lists:member(ClusterMember, mnesia:system_info(running_db_nodes)),
+    {atomic, ok} = mnesia:change_table_copy_type(schema, Node, disc_copies),
+    Tables = [ {T, table_type(ClusterMember, T)}
+               || T <- mnesia:system_info(tables),
+                  T /= schema ],
+    Copied = [ {Table, mnesia:add_table_copy(T, Node, Type)}
+               || {T, Type} = Table <- Tables ],
+    Expected = lists:zip(Tables, repeat(length(Tables), {atomic, ok})),
+    Expected = Copied,
+    ok.
+
+table_type(ClusterMember, T) ->
+    try rpc:call(ClusterMember, mnesia, table_info, [T, storage_type]) of
+        Type when Type =:= disc_copies;
+                  Type =:= ram_copies;
+                  Type =:= disc_only_copies -> Type
+    catch
+        E:R -> error({cant_get_storage_type, {E,R}}, [T])
+    end.
+
+%% This will remove all your Mnesia data!
+%% You've been warned.
+delete_mnesia() ->
+    catch mnesia:stop(),
+    catch mnesia:delete_schema(),
+    Dir = mnesia:system_info(directory),
+    case application:get_env(mnesia, dir, undefined) of
+        undefined -> ok;
+        Dir ->
+            %% Both settings match, OK!
+            ok;
+        _NotDir ->
+            error(mnesia_dir_inconsistent)
+    end,
+    ok = rmrf(Dir),
+    ?WARNING_MSG("Mnesia schema and files deleted", []),
+    ok.
+
+repeat(N, El) ->
+    [ El || _ <- lists:seq(1, N) ].
+
+wait_for_pong(Node) ->
+    wait_for_pong(net_adm:ping(Node), Node, 5, 100).
+
+wait_for_pong(pong, _Node, _Retries, _Interval) ->
+    ok;
+wait_for_pong(pang, _Node, 0, _Interval) ->
+    timeout;
+wait_for_pong(pang, Node, Retries, Interval) ->
+    timer:sleep(Interval),
+    wait_for_pong(net_adm:ping(Node), Node, Retries - 1, Interval).
+
+rmrf(Dir) ->
+    case file:list_dir(Dir) of
+        {error, enoent} -> ok;
+        {error, enotdir} ->
+            ok = file:delete(Dir);
+        {ok, Dirs} ->
+            [ ok = rmrf(filename:join(Dir, Sub)) || Sub <- Dirs],
+            ok = file:del_dir(Dir),
+            ok
+    end.
+
+detach_nodes(Nodes) ->
+    Node = node(),
+    {_, []} = rpc:multicall(Nodes, mnesia, del_table_copy, [schema, Node]).
+
+mnesia_nodes() ->
+    mnesia:system_info(db_nodes) -- [node()].
+
+with_app_stopped(App, F) ->
+    Running = is_app_running(App),
+    Running andalso application:stop(App),
+    try
+        F()
+    after
+        Running andalso application:start(App)
+    end.

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -118,7 +118,7 @@ case "$1" in
         if [ "$RES2" = "pong" ]; then
             RES3=`$ADD_TO_CLUSTER_CMD`
             if [ "$RES3" = "ok" ]; then
-                echo "Node added to cluster. Run mongooseimctl live or mongooseimclt start."
+                echo "Node added to cluster. Run mongooseimctl live or mongooseimctl start."
             else
                 echo "Adding Node to cluster failed:  $RES3"
                 exit 1

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -15,69 +15,19 @@ is_sm_distributed() ->
 is_sm_backend_distributed(ejabberd_sm_mnesia) -> true;
 is_sm_backend_distributed(Other)              -> {false, Other}.
 
-add_node_to_cluster(ConfigIn) ->
+add_node_to_cluster(Config) ->
+    %% TODO: nodes should be described in a uniform fashion, not with adhoc names
     Node = ct:get_config(ejabberd_node),
     Node2 = ct:get_config(ejabberd2_node),
-    Config = ejabberd_node_utils:init(Node2,
-                                      ejabberd_node_utils:init(Node, ConfigIn)),
-
-    Node2Ctl = ctl_path(Node2, Config),
-
-    StartCmd = Node2Ctl ++ " start",
-    StopCmd = Node2Ctl  ++ " stop",
-    StatusCmd = Node2Ctl ++ " status",
-
-
-    AddToClusterCmd = ctl_path(Node2, Config) ++ " add_to_cluster " ++ atom_to_list(Node),
-
-    MnesiaDir = filename:join([get_cwd(Node2, Config), "Mnesia*"]),
-    MnesiaCmd = "rm -rf " ++ MnesiaDir,
-
-    Res1 = call_fun(Node, os, cmd, [StopCmd]),
-    ?assertEqual("", Res1),
-    wait_until_stopped(StatusCmd, 120),
-    Res2 = call_fun(Node, os, cmd, [MnesiaCmd]),
-    ?assertEqual("", Res2),
-
-    Res3 = call_fun(Node, os, cmd, [AddToClusterCmd]),
-    ?assertMatch("Node added to cluster" ++ _, Res3),
-    Res4 = call_fun(Node, os, cmd, [StartCmd]),
-    ?assertEqual("", Res4),
-    wait_until_started(StatusCmd, 120),
-
+    ok = rpc(Node2, mongoose_cluster, join, [Node], cluster_op_timeout()),
     verify_result(add),
-
     Config.
 
 remove_node_from_cluster(Config) ->
-    Node = ct:get_config(ejabberd_node),
     Node2 = ct:get_config(ejabberd2_node),
-    Node2Ctl = ctl_path(Node2, Config),
-    StartCmd = Node2Ctl ++ " start",
-    StopCmd = Node2Ctl ++ " stop",
-    StatusCmd = Node2Ctl ++ " status",
-    RemoveCmd = ctl_path(Node, Config) ++ " remove_from_cluster " ++ atom_to_list(Node2),
-
-    MnesiaDir = filename:join([get_cwd(Node2, Config), "Mnesia*"]),
-    MnesiaCmd = "rm -rf " ++ MnesiaDir,
-
-    Res1 = call_fun(Node, os, cmd, [StopCmd]),
-    wait_until_stopped(StatusCmd, 120),
-
-    Res2 = call_fun(Node, os, cmd, [RemoveCmd]),
-    Res3 = call_fun(Node, os, cmd, [MnesiaCmd]),
-    Res4 = call_fun(Node, os, cmd, [StartCmd]),
-    wait_until_started(StatusCmd, 120),
-
-    ?assertEqual(Res1, ""),
-    ?assertEqual(Res2, "{atomic,ok}\n"),
-    ?assertEqual(Res3, ""),
-    ?assertEqual(Res4, ""),
-
+    ok = rpc(Node2, mongoose_cluster, leave, [], cluster_op_timeout()),
     verify_result(remove),
-
     ok.
-
 
 ctl_path(Node, Config) ->
     filename:join([get_cwd(Node, Config), "bin", "mongooseimctl"]).
@@ -108,20 +58,25 @@ wait_until_stopped(Cmd, Retries) ->
 verify_result(Op) ->
     Node1 = ct:get_config(ejabberd_node),
     Node2 = ct:get_config(ejabberd2_node),
-    Nodes1 = call_fun(Node1, erlang, nodes, []),
-    Nodes2 = call_fun(Node2, erlang, nodes, []),
-    DbNodes1 = call_fun(Node1, mnesia, system_info, [running_db_nodes]),
-    DbNodes2 = call_fun(Node2, mnesia, system_info, [running_db_nodes]),
-
-    Pairs = [{Node2, Nodes1,   should_belong(Op)},
-             {Node1, Nodes2,   should_belong(Op)},
-             {Node1, DbNodes2, should_belong(Op)},
+    DbNodes1 = rpc(Node1, mnesia, system_info, [running_db_nodes]),
+    DbNodes2 = rpc(Node2, mnesia, system_info, [running_db_nodes]),
+    Pairs = [{Node1, DbNodes2, should_belong(Op)},
              {Node2, DbNodes1, should_belong(Op)},
              {Node1, DbNodes1, true},
              {Node2, DbNodes2, true}],
-
     [?assertEqual(ShouldBelong, lists:member(Element, List))
      || {Element, List, ShouldBelong} <- Pairs].
 
 should_belong(add)    -> true;
 should_belong(remove) -> false.
+
+cluster_op_timeout() ->
+    %% This timeout is deliberately a long one.
+    timer:seconds(15).
+
+rpc(Node, M, F, A) ->
+    rpc(Node, M, F, A, timer:seconds(5)).
+
+rpc(Node, M, F, A, TimeOut) ->
+    Cookie = ct:get_config(ejabberd_cookie),
+    escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie).


### PR DESCRIPTION
Apart from the rationale in 20d40e8 description, there's one more reason: using just RPC (instead of a shell-out) to cluster/disband nodes makes it possible to keep cover-compiled modules loaded through the whole cluster life cycle. This is required to make rel-1.7-service tests finally pass.