### PR TITLE
Carbons in sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,8 +86,10 @@ node2.log
 quick_compile.log
 dialyzer
 configure.out
+ejd-redis.conf
 *.d
 .rebar3
+redis.pid
 test/ejabberd_tests/get-deps.log
 test/ejabberd_tests/quicktest.log
 site

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ apps/ejabberd/include/EJABBERD-MIB.hrl
 apps/ejabberd/priv/mibs/EJABBERD-MIB.bin
 apps/ejabberd/ebin/ejabberd.app
 
+# Compilation/test ephemera
+*.d
 Mnesia.mongooseim@*
 compile.log
 ct.log
@@ -87,7 +89,8 @@ quick_compile.log
 dialyzer
 configure.out
 ejd-redis.conf
-*.d
+fed*.log
+node*.log
 .rebar3
 redis.pid
 test/ejabberd_tests/get-deps.log

--- a/.gitignore
+++ b/.gitignore
@@ -82,15 +82,12 @@ Mnesia.mongooseim@*
 compile.log
 ct.log
 deps.log
-fed1.log
-node1.log
-node2.log
-quick_compile.log
 dialyzer
 configure.out
 ejd-redis.conf
 fed*.log
 node*.log
+quick_compile.log
 .rebar3
 redis.pid
 test/ejabberd_tests/get-deps.log

--- a/apps/ejabberd/src/ejabberd_session.erl
+++ b/apps/ejabberd/src/ejabberd_session.erl
@@ -1,0 +1,15 @@
+-module(ejabberd_session).
+-export([merge_info/2]).
+
+-include("ejabberd.hrl").
+
+-spec merge_info(#session{}, #session{}) -> #session{}.
+merge_info(New, Old) ->
+    NewInfo = orddict:from_list(New#session.info),
+    OldInfo = orddict:from_list(Old#session.info),
+    New#session{info =
+                    orddict:to_list(orddict:merge(fun merger/3,
+                                                  NewInfo, OldInfo))}.
+
+merger(_Key, NewVal, _OldVal) ->
+    NewVal.

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -174,7 +174,7 @@ close_session(SID, User, Server, Resource, Reason) ->
                        [SID, JID, Info, Reason]).
 
 -spec store_info(ejabberd:user(), ejabberd:server(), ejabberd:resource(),
-                 {any(), any()}) -> {ok, {any(), any()}}.
+                 {any(), any()}) -> {ok, {any(), any()}} | {error, offline}.
 store_info(User, Server, Resource, {Key, _Value} = KV) ->
     case get_session(User, Server, Resource) of
         offline -> {error, offline};

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -266,10 +266,8 @@ get_session(User, Server, Resource) ->
     end.
 -spec get_raw_sessions(ejabberd:user(), ejabberd:server()) -> [#session{}].
 get_raw_sessions(User, Server) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
-    clean_session_list(?SM_BACKEND:get_sessions(LUser, LServer)).
-
+    clean_session_list(
+      ?SM_BACKEND:get_sessions(jid:nodeprep(User), jid:nameprep(Server))).
 
 -spec set_presence(SID, User, Server, Resource, Prio, Presence, Info) -> ok when
       SID :: 'undefined' | sid(),
@@ -952,4 +950,3 @@ get_cached_unique_count() ->
         _ ->
             0
     end.
-

--- a/apps/ejabberd/src/ejabberd_sm_mnesia.erl
+++ b/apps/ejabberd/src/ejabberd_sm_mnesia.erl
@@ -77,7 +77,7 @@ create_session(User, Server, Resource, Session) ->
             %% Fix potential race condition during XMPP bind, where
             %% multiple calls (> 2) to ejabberd_sm:open_session
             %% have been made, resulting in >1 sessions for this resource
-            MergedSession = ejabberd_session:merge_info
+            MergedSession = mongoose_session:merge_info
                               (Session, hd(lists:sort(Sessions))),
             mnesia:sync_dirty(fun() -> mnesia:write(MergedSession) end)
     end.

--- a/apps/ejabberd/src/ejabberd_sm_mnesia.erl
+++ b/apps/ejabberd/src/ejabberd_sm_mnesia.erl
@@ -70,11 +70,17 @@ get_sessions(User, Server, Resource) ->
                      _Server :: ejabberd:server(),
                      _Resource :: ejabberd:resource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(_User, _Server, _Resource, Session) ->
-    mnesia:sync_dirty(fun() ->
-                              mnesia:write(Session)
-                      end).
-
+create_session(User, Server, Resource, Session) ->
+    case get_sessions(User, Server, Resource) of
+        [] -> mnesia:sync_dirty(fun() -> mnesia:write(Session) end);
+        Sessions when is_list(Sessions) ->
+            %% Fix potential race condition during XMPP bind, where
+            %% multiple calls (> 2) to ejabberd_sm:open_session
+            %% have been made, resulting in >1 sessions for this resource
+            MergedSession = ejabberd_session:merge_info
+                              (Session, hd(lists:sort(Sessions))),
+            mnesia:sync_dirty(fun() -> mnesia:write(MergedSession) end)
+    end.
 
 -spec delete_session(ejabberd_sm:sid(),
                      _User :: ejabberd:user(),

--- a/apps/ejabberd/src/ejabberd_sm_redis.erl
+++ b/apps/ejabberd/src/ejabberd_sm_redis.erl
@@ -80,7 +80,7 @@ create_session(User, Server, Resource, Session) ->
     OldSessions = get_sessions(User, Server, Resource),
     case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
         {value, OldSession} ->
-            MergedInfoSession = ejabberd_session:merge_info(Session,OldSession),
+            MergedInfoSession = mongoose_session:merge_info(Session,OldSession),
             BOldSession = term_to_binary(OldSession),
             BSession = term_to_binary(MergedInfoSession),
             error_or_ok(

--- a/apps/ejabberd/src/ejabberd_sm_redis.erl
+++ b/apps/ejabberd/src/ejabberd_sm_redis.erl
@@ -78,11 +78,11 @@ get_sessions(User, Server, Resource) ->
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
 create_session(User, Server, Resource, Session) ->
     OldSessions = get_sessions(User, Server, Resource),
-    BSession = term_to_binary(Session),
     case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
         {value, OldSession} ->
+            MergedInfoSession = ejabberd_session:merge_info(Session,OldSession),
             BOldSession = term_to_binary(OldSession),
-
+            BSession = term_to_binary(MergedInfoSession),
             error_or_ok(
               ejabberd_redis:cmd([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
                                   ["SREM", hash(User, Server), BOldSession],
@@ -90,6 +90,7 @@ create_session(User, Server, Resource, Session) ->
                                   ["SADD", hash(User, Server), BSession],
                                   ["SADD", hash(User, Server, Resource), BSession]]));
         false ->
+            BSession = term_to_binary(Session),
             error_or_ok(
               ejabberd_redis:cmd([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
                                   ["SADD", hash(User, Server), BSession],

--- a/apps/ejabberd/src/mod_carboncopy.erl
+++ b/apps/ejabberd/src/mod_carboncopy.erl
@@ -278,9 +278,7 @@ disable(Host, U, R) ->
     case ejabberd_sm:store_info(U, Host, R, KV) of
         {error, offline} -> ok;
         {ok, KV} -> ok;
-        Err -> ?INFO_MSG("Could not disable carbon copies for ~p:~p", 
-                         [{U,Host,R}, Err]),
-               ok
+        Err -> {error, Err}
     end.
 
 complete_packet(From, #xmlel{name = <<"message">>, attrs = OrigAttrs} = Packet, sent) ->

--- a/apps/ejabberd/src/mod_carboncopy.erl
+++ b/apps/ejabberd/src/mod_carboncopy.erl
@@ -211,11 +211,11 @@ is_max_prio(Res, PrioRes) ->
     lists:member({max_prio(PrioRes), Res}, PrioRes).
 
 jids_minus_max_priority_resource(U, S, _R, CCResList, PrioRes) ->
-    [ {jlib:make_jid({U, S, CCRes}), CC_Version}
+    [ {jid:make({U, S, CCRes}), CC_Version}
       || {CC_Version, CCRes} <- CCResList, not is_max_prio(CCRes, PrioRes) ].
 
 jids_minus_specific_resource(U, S, R, CCResList, _PrioRes) ->
-    [ {jlib:make_jid({U, S, CCRes}), CC_Version}
+    [ {jid:make({U, S, CCRes}), CC_Version}
       || {CC_Version, CCRes} <- CCResList, CCRes =/= R ].
 
 %% If the original user is the only resource in the list of targets
@@ -236,9 +236,9 @@ send_copies(JID, To, Packet, Direction) ->
     ?DEBUG("targets ~p from resources ~p and ccenabled ~p",
            [Targets, PrioRes, CCResList]),
     lists:map(fun({Dest,Version}) ->
-                      {_, _, Resource} = jlib:jid_tolower(Dest),
+                      {_, _, Resource} = jid:to_lower(Dest),
                       ?DEBUG("forwarding to ~ts", [Resource]),
-                      Sender = jlib:make_jid({U, S, <<>>}),
+                      Sender = jid:make({U, S, <<>>}),
                       New = build_forward_packet
                               (JID, Packet, Sender, Dest, Direction, Version),
                       ejabberd_router:route(Sender, Dest, New)

--- a/apps/ejabberd/src/mongoose_session.erl
+++ b/apps/ejabberd/src/mongoose_session.erl
@@ -1,4 +1,4 @@
--module(ejabberd_session).
+-module(mongoose_session).
 -export([merge_info/2]).
 
 -include("ejabberd.hrl").

--- a/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
+++ b/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
@@ -5,7 +5,6 @@
          init_per_testcase/2, end_per_testcase/2]).
 -export([cleaner_runs_hook_on_nodedown/1]).
 -export([auth_anonymous/1,
-         carboncopy/1,
          last/1,
          stream_management/1,
          local/1,
@@ -24,7 +23,6 @@ all() ->
     [
      cleaner_runs_hook_on_nodedown,
      auth_anonymous,
-     carboncopy,
      last,
      stream_management,
      local,
@@ -84,14 +82,6 @@ auth_anonymous(_Config) ->
     true = ejabberd_auth_anonymous:anonymous_user_exist(U, S),
     ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),
     false = ejabberd_auth_anonymous:anonymous_user_exist(U, S).
-
-carboncopy(_Config) ->
-    mod_carboncopy:start(?HOST, [{iqdisc, no_queue}]),
-    {U, S, R, _JID, SID} = get_fake_session(),
-    mod_carboncopy:enable(S, U, R, ?NS_CC_2),
-    [{R, ?NS_CC_2}] = mod_carboncopy:resources_to_cc(U, S),
-    ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),
-    [] = mod_carboncopy:resources_to_cc(U, S).
 
 last(_Config) ->
     mod_last:start(?HOST, [{iqdisc, no_queue}]),

--- a/test/ejabberd_tests/src/ct_mongoose_hook.erl
+++ b/test/ejabberd_tests/src/ct_mongoose_hook.erl
@@ -138,8 +138,7 @@ do_check_server_purity(_Suite) ->
         fun check_privacy/0,
         fun check_private/0,
         fun check_vcard/0,
-        fun check_roster/0,
-        fun check_carboncopy/0],
+        fun check_roster/0],
     lists:flatmap(fun(F) -> F() end, Funs).
 
 check_sessions() ->


### PR DESCRIPTION
This PR addresses #[not-assigned]

Per-session carbon copy status (enabled/disabled/version) is stored as part of `#session.info` in the `session` table. This eliminates the need for a separate `carboncopy` table, and reduces the number of lookups made by `mod_carboncopy`, per message route event, from 2 to 1. Additionally, no cleanup phase is necessary when a node goes down, as carbons get cleaned up as part of the `session` table cleanup.

To allow this, the `ejabberd_sm_*` backends must be capable of merging `info` proplists when overwriting a user session with `create_session`. This is conveniently achieved via `ejabberd_session:merge_info(#session{}, #session{}) -> #session{}`

To store information for a given xmpp full jid, use `ejabberd_sm:store_info(user(), server(), resource(), {any(), any()}) -> {'ok', {any(), any()}} | {error, offline}`. 

If a given extension module furnishes a user session with extra info that is only valid for that session, this interface is preferred to holding a separate ets table with *de facto* foreign keys to `session`, and risking synchronization issues. `mod_carboncopy` can be used as a template for this pattern.

The unit test suite has been extended to make sure that `ejabberd_sm:store_info` and `ejabberd_sm:create_session` uphold the properties stated above.

The `rebar` noise suppression mechanism in the `Makefile` has been extracted as a Make macro
