### PR TITLE
Enable configure, make, make install procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,21 +42,21 @@ otp_release:
         - 17.5
 env:
         - PRESET=internal_redis DB=mnesia REL_CONFIG=with-redis
-        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal
+        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none
         - PRESET=mysql_mnesia DB=mysql REL_CONFIG=with-mysql
         - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
         - PRESET=pgsql_mnesia DB=pgsql REL_CONFIG=with-pgsql
-        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=minimal
+        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
         - PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
-        - PRESET=external_mnesia DB=mnesia REL_CONFIG=minimal
+        - PRESET=external_mnesia DB=mnesia REL_CONFIG=with-none
         - PRESET=dialyzer_only
 
 matrix:
     include:
         - otp_release: R16B03
-          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal
+          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none
         - otp_release: 18.1
-          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=minimal
+          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none
 
 after_failure:
         - tools/travis-upload-ct-reports.sh

--- a/Makefile
+++ b/Makefile
@@ -139,4 +139,7 @@ test_deps:
 %:
 	@:
 
+install: configure.out
+	@source configure.out && tools/install
+
 include tools/cd_tools/cd-targets

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ configure:
 	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
 
 rel: certs rebar deps configure.out
-	source configure.out && \
+	source ./configure.out && \
 	./rebar compile generate -f
 
 configure.out:
@@ -140,6 +140,6 @@ test_deps:
 	@:
 
 install: configure.out
-	@source configure.out && tools/install
+	@source ./configure.out && tools/install
 
 include tools/cd_tools/cd-targets

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ devrel: certs $(DEVNODES)
 
 $(DEVNODES): rebar deps compile deps_dev configure.out
 	@echo "building $@"
-	(source configure.out && \
+	(source ./configure.out && \
 	 cd rel && \
 	 ../rebar generate -f target_dir=../dev/mongooseim_$@ overlay_vars=./reltool_vars/$@_vars.config)
 	cp -R `dirname $(shell ./readlink.sh $(shell which erl))`/../lib/tools-* dev/mongooseim_$@/lib/

--- a/Makefile
+++ b/Makefile
@@ -86,16 +86,19 @@ configure:
 	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
 
 rel: certs rebar deps configure.out
+	source configure.out && \
 	./rebar compile generate -f
 
 configure.out:
-	./tools/configure full
+	./tools/configure with-all
 
 devrel: certs $(DEVNODES)
 
-$(DEVNODES): rebar deps compile deps_dev
+$(DEVNODES): rebar deps compile deps_dev configure.out
 	@echo "building $@"
-	(cd rel && ../rebar generate -f target_dir=../dev/mongooseim_$@ overlay_vars=./reltool_vars/$@_vars.config)
+	(source configure.out && \
+	 cd rel && \
+	 ../rebar generate -f target_dir=../dev/mongooseim_$@ overlay_vars=./reltool_vars/$@_vars.config)
 	cp -R `dirname $(shell ./readlink.sh $(shell which erl))`/../lib/tools-* dev/mongooseim_$@/lib/
 
 deps_dev:

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ eunit: rebar deps
 configure:
 	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
 
-rel: certs rebar deps rel/vars.config
-	./rebar compile generate -f
+rel: certs rebar deps configure.out rel/vars.config
+	source ./configure.out && ./rebar compile generate -f
 
 rel/vars.config: rel/vars.config.in rel/configure.vars.config
 	cat $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ configure.out rel/configure.vars.config:
 
 devrel: certs $(DEVNODES)
 
-$(DEVNODES): rebar deps compile deps_dev configure.out
+$(DEVNODES): rebar deps compile deps_dev configure.out rel/vars.config
 	@echo "building $@"
 	(source ./configure.out && \
 	 cd rel && \

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ rel: certs rebar deps rel/vars.config
 rel/vars.config: rel/vars.config.in rel/configure.vars.config
 	cat $^ > $@
 
+## Don't allow these files to go out of sync!
 configure.out rel/configure.vars.config:
 	./tools/configure with-all
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ configure:
 	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
 
 rel: certs rebar deps configure.out rel/vars.config
-	source ./configure.out && ./rebar compile generate -f
+	. ./configure.out && ./rebar compile generate -f
 
 rel/vars.config: rel/vars.config.in rel/configure.vars.config
 	cat $^ > $@
@@ -99,7 +99,7 @@ devrel: certs $(DEVNODES)
 
 $(DEVNODES): rebar deps compile deps_dev configure.out rel/vars.config
 	@echo "building $@"
-	(source ./configure.out && \
+	(. ./configure.out && \
 	 cd rel && \
 	 ../rebar generate -f target_dir=../dev/mongooseim_$@ overlay_vars=./reltool_vars/$@_vars.config)
 	cp -R `dirname $(shell ./readlink.sh $(shell which erl))`/../lib/tools-* dev/mongooseim_$@/lib/
@@ -143,6 +143,6 @@ test_deps:
 	@:
 
 install: configure.out rel
-	@source ./configure.out && tools/install
+	@. ./configure.out && tools/install
 
 include tools/cd_tools/cd-targets

--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,13 @@ eunit: rebar deps
 configure:
 	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
 
-rel: certs rebar deps configure.out
-	source ./configure.out && \
+rel: certs rebar deps rel/vars.config
 	./rebar compile generate -f
 
-configure.out:
+rel/vars.config: rel/vars.config.in rel/configure.vars.config
+	cat $^ > $@
+
+configure.out rel/configure.vars.config:
 	./tools/configure with-all
 
 devrel: certs $(DEVNODES)
@@ -139,7 +141,7 @@ test_deps:
 %:
 	@:
 
-install: configure.out
+install: configure.out rel
 	@source ./configure.out && tools/install
 
 include tools/cd_tools/cd-targets

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ MongooseIM  [![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=mas
 ============
 <img align="left" src="doc/MongooseIM_logo.png"</img>
 
-MongooseIM is Erlang Solutions' robust and efficient XMPP server aimed at large installations. Specifically designed for enterprise purposes, it is fault-tolerant, can utilize resources of multiple clustered machines and easily scale in need of more capacity (by just adding a box/VM). 
+MongooseIM is Erlang Solutions' robust and efficient XMPP server aimed at large installations. Specifically designed for enterprise purposes, it is fault-tolerant, can utilize resources of multiple clustered machines and easily scale in need of more capacity (by just adding a box/VM).
 
 MongooseIM can accept client sessions over vanilla XMPP, Websockets, and HTTP long-polling (a.k.a. BOSH).
 
@@ -66,14 +66,14 @@ Features and supported standards
     and HTTP(S) (BOSH).
 *   Configurable database backends: MySQL, Postgres, generic ODBC. Mnesia
     and Redis for transient data.
-*   Supports XEPs: 
+*   Supports XEPs:
 
 |||||
 | ------------- | ------------- | ------------- |------------- |
 | [0004 - Data Forms](http://xmpp.org/extensions/xep-0004.html) | [0012 - Last Activity](http://xmpp.org/extensions/xep-0012.html) | [0016 - Privacy Lists](http://xmpp.org/extensions/xep-0016.html)|[0018 - Invisible Presence](http://xmpp.org/extensions/xep-0018.html)|
 |[0022 - Message Events](http://xmpp.org/extensions/xep-0022.html)| [0023 - Message Expiration](http://xmpp.org/extensions/xep-0023.html)|[0030 - Service Discovery](http://xmpp.org/extensions/xep-0030.html)| [0045 - Multi-User Chat](http://xmpp.org/extensions/xep-0045.html)|
 |[0049 - Private XML Storage](http://xmpp.org/extensions/xep-0049.html)| [0050 - Ad-Hoc Commands](http://xmpp.org/extensions/xep-0050.html)| [0054 - vcard-temp](http://xmpp.org/extensions/xep-0054.html)| [0055 - Jabber Search](http://xmpp.org/extensions/xep-0055.html)
-|[0059 - Result Set Management](http://xmpp.org/extensions/xep-0059.html)|[0068 - Field Standardization for Data Forms](http://xmpp.org/extensions/xep-0068.html)| [0073 - Basic IM Protocol Suite](http://xmpp.org/extensions/xep-0073.html)| [0077 - In-Band Registration](http://xmpp.org/extensions/xep-0077.html)| 
+|[0059 - Result Set Management](http://xmpp.org/extensions/xep-0059.html)|[0068 - Field Standardization for Data Forms](http://xmpp.org/extensions/xep-0068.html)| [0073 - Basic IM Protocol Suite](http://xmpp.org/extensions/xep-0073.html)| [0077 - In-Band Registration](http://xmpp.org/extensions/xep-0077.html)|
 |[0078 - Non-SASL Authentication](http://xmpp.org/extensions/xep-0078.html)|[0079 partial - Advanced Message Processin](http://xmpp.org/extensions/xep-0079.html)| [0082 - XMPP Date and Time Profiles](http://xmpp.org/extensions/xep-0082.html)| [0083 - Nested Roster Groups](http://xmpp.org/extensions/xep-0083.html)|
 |[0085 - Chat State Notifications](http://xmpp.org/extensions/xep-0085.html)|[0086 - Error Condition Mappings](http://xmpp.org/extensions/xep-0086.html) | [0093 -  Roster Item Exchange](http://xmpp.org/extensions/xep-0093.html)| [0114 - Jabber Component Protocol](http://xmpp.org/extensions/xep-0114.html)|
 |[0124 - Bidirectional-streams Over Synchronous HTTP (BOSH)](http://xmpp.org/extensions/xep-0124.html)|[0126 - Invisibility](http://xmpp.org/extensions/xep-0126.html)| [0138 - Stream Compression](http://xmpp.org/extensions/xep-0138.html) | [0153 - vCard-Based Avatars](http://xmpp.org/extensions/xep-0153.html)|
@@ -112,35 +112,13 @@ How to build
 
         $ make rel
 
-    or
+    If more advanced release is required (with some specific db support only,
+    f.e. mysql or pgsql) or you want to set `prefix` or `user` for the
+    installation script please refer to the
+    [release configuration](doc/user-guide/release_config.md)
+    page in our documentation
 
-        $ ./rebar generate
-
-
-    If more advanced release is required (with some specifyc db support only, f.e. mysql or pgsql) a `make configure` script with appropirate option(s) can be run before `make rel` or `./rebar generate`. `make configure` without any option will print following help message.
-
-    ```
-specifies which 3rd party deps will be included in release
-possible options:
-with-mysql	include mysql driver
-with-pgsql	include pgsql driver
-with-odbc	include standard ODBC driver shipped with Erlang/OTP
-with-redis	include redis driver
-with-riak      include riak driver
-with-cassandra	include cassandra driver
-full		include all above deps
-    ```
-
-    For example if mysql and redis support has to be added to the release, following command has to be run before `make rel`:
-
-        $ make configure with-mysql with-redis
-
-    The `make configure` command has to be run only once (unless one need to change the relase config and include some other dependecies).
-
-    Take a look [here](http://mongooseim.readthedocs.org/en/latest/advanced-configuration/database-backends-configuration/)
-    for instructions how to setup the external databases.
-
-    `make rel` or `./rebar generate` commands will generate a self-contained OTP system image in the
+    `make rel` commands will generate a self-contained OTP system image in the
     project's `rel/mongooseim` subdirectory. The contents of that directory are as
     follows:
     *   `rel/mongooseim/bin` - startup/administration scripts,
@@ -170,8 +148,14 @@ full		include all above deps
     operations on a running instance, e.g.:
 
         $ bin/mongooseimctl status
-        The node mongooseim@localhost is started with status: started
-        MongooseIM version 1.3.1 is running on that node
+        MongooseIM node mongooseim@localhost:
+          operating system pid: 86026
+          Erlang VM status: started (of: starting | started | stopping)
+          boot script status: started
+          version: 1.6.2-61-g48b8332
+          uptime: 1:12:46
+          logs:
+            log/ejabberd.log
 
 4.  Building the testing target and running tests.
 
@@ -184,7 +168,8 @@ full		include all above deps
 
     To run the tests (from project's root directory, i.e. `$REPO`):
 
-        $ cd test
+        $ dev/mongooseim_node1/bin/mongooseim start
+        $ dev/mongooseim_node2/bin/mongooseim start
         $ make quicktest
 
     The test results will show up in the console`.
@@ -229,7 +214,3 @@ We recommend following client libraries:
 * iOS, Objective-C: [XMPPframework](https://github.com/robbiehanson/XMPPFramework)
 * Android, Java: [Smack](https://github.com/igniterealtime/Smack)
 * Web, JavaScript: [Stanza.io](https://github.com/otalk/stanza.io)
-
-
-
-

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -160,8 +160,8 @@ process(["status"]) ->
             end,
             ?STATUS_ERROR;
         {_, _, Version} ->
-            ?PRINT("MongooseIM version ~s is running on this node~n",
-                   [Version]),
+            ?PRINT("MongooseIM version ~s is running on this node with pid ~s~n",
+                   [Version, os:getpid()]),
             ?STATUS_SUCCESS
     end;
 process(["stop"]) ->

--- a/doc/user-guide/release_config.md
+++ b/doc/user-guide/release_config.md
@@ -1,0 +1,158 @@
+## Advanced release configuration
+
+It's now possible to install MongooseIM from source in two modes:
+
+* `system` - it's internally used to generate RPM packages
+* `user`  - which is the default mode and used for testing on travis and
+    in development
+
+An environment for building (as of now RPM) packages is accessible by
+cloning ESL-internal
+[command line interface](https://gitlab.erlang-solutions.com/current-projects/necromancer-cli).
+
+### Configure script
+
+The `tools/configure` script can be used to specify which 3rd party
+dependencies should be included in the final release or set installation
+prefix and installation mode. More details can found in the tool's help.
+The help is printed when the script is run without any parameters
+`tools/configure`:
+
+```
+configure: OPTIONS
+
+Specifies which 3rd party deps will be included in the release.
+Writes configure.out file as output - this file can be sourced with:
+
+    . configure.out
+
+Writes rel/configure.vars.config which can be used as Reltool input.
+
+3rd party apps:
+
+    with-none           include no 3rd party drivers
+    with-all            include all drivers
+    with-cassandra      include cassandra driver
+    with-mysql          include mysql driver
+    with-odbc           include standard ODBC driver shipped with Erlang/OTP
+    with-pgsql          include pgsql driver
+    with-redis          include redis driver
+    with-riak           include riak driver
+
+Options:
+
+    prefix    Installation PREFIX directory. Default: /usr/local
+    system    Install files into $PREFIX/{bin, etc, ...} instead of a completely self contained release. Default: no
+    user      System user to run the server as. Default:
+```
+
+This script is also accessible via make `configure` target.
+
+### Example
+
+For example if only `mysql` and `redis` drivers should be included in the
+release, following command has to be run before `make rel`:
+
+        $ make configure with-mysql with-redis
+
+The `make configure` command has to be run only once (unless one needs to 
+change the release's config and include some other dependencies).
+
+### System install
+
+To manually test the installation one can run `tools/test-install.sh`.
+This script is intended for careful inspection by a human user, not for automation.
+Results should be similar to those described below.
+
+On Mac:
+
+```sh
+./tools/configure with-all user=erszcz prefix=/tmp/mim-sandbox-system system=yes
+cat configure.out rel/configure.vars.config
+RUNNER_GROUP=staff make install
+```
+
+Overriding `RUNNER_GROUP` on a Mac is necessary, as user's by default don't
+have private groups of the same name as their usernames.
+
+Generated build configs:
+
+```sh
+$ cat configure.out rel/configure.vars.config
+export MONGOOSEIM_CONFIGURED="yes"
+export APPS="seestar mysql odbc pgsql redo riakc riak_pb protobuffs"
+export PREFIX="/tmp/mim-sandbox-system"
+export RELTOOL_VARS="rel/configure.vars.config"
+export RUNNER_USER="erszcz"
+export SYSTEM="yes"
+export BIN_DIR="$PREFIX/usr/bin"
+export ETC_DIR="$PREFIX/etc/mongooseim"
+export LIB_DIR="$PREFIX/usr/lib/mongooseim"
+export LOG_DIR="$PREFIX/var/log/mongooseim"
+export MDB_DIR="$PREFIX/var/lib/mongooseim"
+export LOCK_DIR="$PREFIX/var/lock/mongooseim"
+{mongooseim_runner_user, "erszcz"}.
+{mongooseim_script_dir, "/tmp/mim-sandbox-system/usr/lib/mongooseim/bin"}.
+{mongooseim_etc_dir, "/tmp/mim-sandbox-system/etc/mongooseim"}.
+{mongooseim_log_dir, "/tmp/mim-sandbox-system/var/log/mongooseim"}.
+{mongooseim_mdb_dir, "/tmp/mim-sandbox-system/var/lib/mongooseim"}.
+{mongooseim_mdb_dir_toggle, []}.
+{mongooseim_lock_dir, "/tmp/mim-sandbox-system/var/lock/mongooseim"}.
+```
+
+Installed tree:
+
+```
+$ tree mim-sandbox-system/ -L 3
+mim-sandbox-system/
+├── etc
+│   └── mongooseim
+│       ├── app.config
+│       ├── ejabberd.cfg
+│       └── vm.args
+├── usr
+│   ├── bin
+│   │   └── mongooseimctl
+│   └── lib
+│       └── mongooseim
+└── var
+    ├── lib
+    │   └── mongooseim
+    ├── lock
+    │   └── mongooseim
+    └── log
+        └── mongooseim
+
+13 directories, 4 files
+```
+
+Files which change after starting and stopping such an installation:
+
+```
+var/lib/mongooseim/DECISION_TAB.LOG
+var/lib/mongooseim/LATEST.LOG
+var/lib/mongooseim/last_activity.DCD
+var/lib/mongooseim/muc_registered.DCD
+var/lib/mongooseim/muc_room.DCD
+var/lib/mongooseim/offline_msg.DAT
+var/lib/mongooseim/passwd.DCD
+var/lib/mongooseim/privacy.DCD
+var/lib/mongooseim/private_storage.DAT
+var/lib/mongooseim/roster.DCD
+var/lib/mongooseim/roster_version.DCD
+var/lib/mongooseim/schema.DAT
+var/lib/mongooseim/vcard.DAT
+var/lib/mongooseim/vcard_search.DCD
+var/log/mongooseim/crash.log
+var/log/mongooseim/ejabberd.log
+var/log/mongooseim/erlang.log.1
+var/log/mongooseim/run_erl.log
+```
+
+
+### Caveats
+
+* Running `make install` will blindly overwrite any configs it encounters on its way.
+  Mnesia database and log files are preserved only due to the fact that they're
+  not build process artifacts.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ pages:
       - 'Features and supported standards': 'user-guide/Features-and-supported-standards.md'
       - 'Get to know MongooseIM': 'user-guide/Get-to-know-MongooseIM.md'
       - 'Getting started': 'user-guide/Getting-started.md'
+      - 'Release/Installation configuration': 'user-guide/release_config.md'
   - 'Basic Configuration Overview': 'Basic-configuration.md'
   - 'Advanced Configuration Overview': 'Advanced-configuration.md'
   - 'Advanced Configuration':

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -1,7 +1,7 @@
 [
  {ssl, [{session_lifetime, 600}]}, %% 10 minutes
  {lager, [
-    {log_root, {{app_config_lager_log_dir}} },
+    {log_root, "{{mongooseim_log_dir}}"},
     {crash_log, "crash.log"},
     {handlers, [
         {lager_console_backend, [info, {lager_default_formatter,[{eol, "\r\n"}]}]},

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -1,4 +1,5 @@
 [
+ {{mongooseim_mdb_dir_toggle}}{mnesia, [{dir, "{{mongooseim_mdb_dir}}"}]},
  {ssl, [{session_lifetime, 600}]}, %% 10 minutes
  {lager, [
     {log_root, "{{mongooseim_log_dir}}"},

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -9,7 +9,7 @@ RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc
 RUNNER_LOG_DIR={{mongooseim_log_dir}}
 # Note the trailing slash on $PIPE_DIR/
 PIPE_DIR=/tmp/mongooseim_pipe_`whoami`/
-RUNNER_USER=
+RUNNER_USER={{mongooseim_runner_user}}
 
 EJABBERD_SO_PATH=`ls -dt $RUNNER_BASE_DIR/lib/ejabberd-2.1.8*/priv/lib | head -1`
 EJABBERD_CONFIG_PATH=$RUNNER_ETC_DIR/ejabberd.cfg

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -2,7 +2,7 @@
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 
-RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
+RUNNER_SCRIPT_DIR={{mongooseim_script_dir}}
 
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
 RUNNER_ETC_DIR={{mongooseim_etc_dir}}

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -5,7 +5,7 @@
 RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
 
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
-RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc
+RUNNER_ETC_DIR={{mongooseim_etc_dir}}
 RUNNER_LOG_DIR={{mongooseim_log_dir}}
 # Note the trailing slash on $PIPE_DIR/
 PIPE_DIR=/tmp/mongooseim_pipe_`whoami`/

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -35,7 +35,7 @@ if [ -z "$NAME_ARG" ]; then
 fi
 NAME=$(echo $NAME_ARG | awk '{print $1}')
 NODE=$(echo $NAME_ARG | awk '{print $2}')
-MNESIA_DIR="$RUNNER_BASE_DIR/Mnesia.$NODE"
+MNESIA_DIR={{mongooseim_mdb_dir}}
 
 # Extract the target cookie
 COOKIE_ARG=`grep -e '^-setcookie' $RUNNER_ETC_DIR/vm.args`

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -33,6 +33,9 @@ if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1
 fi
+NAME=$(echo $NAME_ARG | awk '{print $1}')
+NODE=$(echo $NAME_ARG | awk '{print $2}')
+MNESIA_DIR="$RUNNER_BASE_DIR/Mnesia.$NODE"
 
 # Extract the target cookie
 COOKIE_ARG=`grep -e '^-setcookie' $RUNNER_ETC_DIR/vm.args`
@@ -96,8 +99,6 @@ case "$1" in
         done
         ;;
     add_to_cluster)
-        NAME=$(echo $NAME_ARG | awk '{print $1}')
-        NODE=$(echo $NAME_ARG | awk '{print $2}')
         NAME_TYPE=$(echo $NAME | sed 's/^\-//')
 
         TARGETNODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME $2 $COOKIE_ARG"
@@ -109,7 +110,6 @@ case "$1" in
             exit 1
         fi
 
-        MNESIA_DIR="$RUNNER_BASE_DIR/Mnesia.$NODE"
         if [ -d "$MNESIA_DIR" ]; then
             echo "Error: $MNESIA_DIR already exists. Please remove whole directory before continuing."
             exit 1

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -6,7 +6,7 @@ RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
 
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
 RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc
-RUNNER_LOG_DIR={{mongooseim_runner_log_dir}}
+RUNNER_LOG_DIR={{mongooseim_log_dir}}
 # Note the trailing slash on $PIPE_DIR/
 PIPE_DIR=/tmp/mongooseim_pipe_`whoami`/
 RUNNER_USER=

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -77,7 +77,7 @@ ctl ()
     # using flock if available. Expects a linux-style
     # flock that can lock a file descriptor.
     MAXCONNID=100
-    CONNLOCKDIR=/var/lock/mongooseimctl
+    CONNLOCKDIR={{mongooseim_lock_dir}}/ctl
     mkdir -p $CONNLOCKDIR
     FLOCK='/usr/bin/flock'
     if [ ! -x "$FLOCK" ] || [ ! -d "$CONNLOCKDIR" ] ; then

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -17,6 +17,7 @@ START_ERL=`cat $EJABBERD_DIR/releases/start_erl.data`
 ERTS_VSN=${START_ERL% *}
 ERTS_PATH=$EJABBERD_DIR/erts-$ERTS_VSN/bin
 ERL=$ERTS_PATH/erl
+EPMD=$ERTS_PATH/epmd
 EJABBERD_EBIN_PATH=$EJABBERD_DIR/lib/ejabberd-*/ebin/
 
 COOKIE_ARG=`grep -e '^-setcookie' $EJABBERD_VMARGS_PATH`
@@ -174,7 +175,7 @@ usage ()
 # stop epmd if there is no other running node
 stop_epmd()
 {
-    epmd -names | grep -q name || epmd -kill
+    $EPMD -names | grep -q name || $EPMD -kill
 }
 
 # allow sync calls

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
+RUNNER_SCRIPT_DIR={{mongooseim_script_dir}}
+RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
+## Depending on build time config RUNNER_ETC_DIR may depend on RUNNER_BASE_DIR.
+RUNNER_ETC_DIR={{mongooseim_etc_dir}}
+
 EJABBERD_DIR=${RUNNER_SCRIPT_DIR%/*}
-EJABBERD_VMARGS_PATH=$EJABBERD_DIR/etc/vm.args
+EJABBERD_VMARGS_PATH=${RUNNER_ETC_DIR}/vm.args
 START_ERL=`cat $EJABBERD_DIR/releases/start_erl.data`
 ERTS_VSN=${START_ERL% *}
 ERTS_PATH=$EJABBERD_DIR/erts-$ERTS_VSN/bin
@@ -73,7 +77,7 @@ ctl ()
     # using flock if available. Expects a linux-style
     # flock that can lock a file descriptor.
     MAXCONNID=100
-    CONNLOCKDIR=$EJABBERD_DIR/var/lock/mongooseimctl
+    CONNLOCKDIR=/var/lock/mongooseimctl
     mkdir -p $CONNLOCKDIR
     FLOCK='/usr/bin/flock'
     if [ ! -x "$FLOCK" ] || [ ! -d "$CONNLOCKDIR" ] ; then

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -4,6 +4,12 @@ RUNNER_SCRIPT_DIR={{mongooseim_script_dir}}
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
 ## Depending on build time config RUNNER_ETC_DIR may depend on RUNNER_BASE_DIR.
 RUNNER_ETC_DIR={{mongooseim_etc_dir}}
+RUNNER_USER={{mongooseim_runner_user}}
+
+# Make sure this script is running as the appropriate user
+if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
+    exec sudo -u $RUNNER_USER -i $0 $@
+fi
 
 EJABBERD_DIR=${RUNNER_SCRIPT_DIR%/*}
 EJABBERD_VMARGS_PATH=${RUNNER_ETC_DIR}/vm.args

--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -82,6 +82,7 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
            {copy, "files/mongooseimctl", "bin/mongooseimctl"},
 
            {template, "files/mongooseim", "bin/mongooseim"},
+           {template, "files/mongooseimctl", "bin/mongooseimctl"},
            {template, "files/app.config", "etc/app.config"},
            {template, "files/vm.args", "etc/vm.args"},
            {template, "files/ejabberd.cfg", "etc/ejabberd.cfg"}

--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -68,11 +68,14 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
 
 {overlay_vars, "vars.config"},
 
-{overlay, [{mkdir, "log/sasl"},
-           {mkdir, "var"},
-           {mkdir, "var/log"},
+{overlay, [
            {mkdir, "priv"},
+           {copy, "files/sample_external_auth.py", "priv/sample_external_auth.py"},
+
            {mkdir, "priv/ssl"},
+           {copy, "../fake_cert.pem", "priv/ssl/fake_cert.pem"},
+           {copy, "../fake_key.pem", "priv/ssl/fake_key.pem"},
+           {copy, "../fake_server.pem", "priv/ssl/fake_server.pem"},
 
            {copy, "files/erl", "\{\{erts_vsn\}\}/bin/erl"},
            {copy, "files/nodetool", "\{\{erts_vsn\}\}/bin/nodetool"},
@@ -81,11 +84,6 @@ IncludeApps = lists:map(fun(App) -> {app, App, [{incl_cond, include}]} end, Apps
            {template, "files/mongooseim", "bin/mongooseim"},
            {template, "files/app.config", "etc/app.config"},
            {template, "files/vm.args", "etc/vm.args"},
-           {template, "files/ejabberd.cfg", "etc/ejabberd.cfg"},
-
-           {copy, "../fake_cert.pem", "priv/ssl/fake_cert.pem"},
-           {copy, "../fake_key.pem", "priv/ssl/fake_key.pem"},
-           {copy, "../fake_server.pem", "priv/ssl/fake_server.pem"},
-           {copy, "files/sample_external_auth.py", "priv/sample_external_auth.py"}
+           {template, "files/ejabberd.cfg", "etc/ejabberd.cfg"}
           ]}
 ].

--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -1,30 +1,25 @@
 {ok, Path} = file:get_cwd(),
 ConfigureOut = Path ++ "/../configure.out",
-Conf = case file:consult(ConfigureOut) of
-            {ok, Terms} -> Terms;
-            E -> io:format("WARN: error ~p reading file: ~p - using default rel config~n", [E, ConfigureOut]), []
-       end,
-
-BaseAppsToRun = [compiler,
-                 lager,
-                 kernel,
-                 mnesia,
-                 sasl,
-                 ssl,
-                 stdlib,
-                 ejabberd,
-                 inets,
-                 syntax_tools,
-                 p1_stringprep,
-                 xmerl,
-                 exml,
-                 cowboy,
-                 fusco,
-                 exometer],
-
-AppsToRunIn = BaseAppsToRun ++ proplists:get_value(apps_to_run, Conf, []),
-
-AppsToRun = ordsets:to_list(ordsets:from_list(AppsToRunIn)),
+EnvApps = os:getenv("APPS"),
+EnvApps =/= false orelse error("APPS not defined"),
+EnvAppsToInclude = [ list_to_atom(App)
+                     || App <- string:tokens(EnvApps, " \n\r") ],
+AppsToRun = [compiler,
+             lager,
+             kernel,
+             mnesia,
+             sasl,
+             ssl,
+             stdlib,
+             ejabberd,
+             inets,
+             syntax_tools,
+             p1_stringprep,
+             xmerl,
+             exml,
+             cowboy,
+             fusco,
+             exometer],
 
 BaseAppsToInclude = AppsToRun ++
                     [asn1,
@@ -51,7 +46,7 @@ BaseAppsToInclude = AppsToRun ++
 
 RemovedApps = [mysql,pgsql,redo,seestar,odbc],
 
-AppsToIncludeIn = BaseAppsToInclude ++ proplists:get_value(apps_to_include, Conf, []),
+AppsToIncludeIn = BaseAppsToInclude ++ EnvAppsToInclude,
 
 AppsToInclude = ordsets:to_list(ordsets:from_list(AppsToIncludeIn)),
 

--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -40,11 +40,7 @@ BaseAppsToInclude = AppsToRun ++
                      alarms,
                      idna,
                      recon,
-                     setup
-                     ],
-
-
-RemovedApps = [mysql,pgsql,redo,seestar,odbc],
+                     setup],
 
 AppsToIncludeIn = BaseAppsToInclude ++ EnvAppsToInclude,
 

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -31,6 +31,7 @@
 {registration_watchers, "%{registration_watchers, [\"admin@localhost\"]},"}.
 {riak_server, "%%{riak_server, [{pool_size, 20}, {address, \"127.0.0.1\"}, {port, 8087}, {riak_pb_socket_opts, []}]}."}.
 
+{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
 {mongooseim_log_dir, "log"}.
 {mongooseim_runner_user, ""}.
 {http_api_endpoint, "{5288, \"127.0.0.1\"}"}.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -32,6 +32,7 @@
 {riak_server, "%%{riak_server, [{pool_size, 20}, {address, \"127.0.0.1\"}, {port, 8087}, {riak_pb_socket_opts, []}]}."}.
 
 {mongooseim_log_dir, "log"}.
+{mongooseim_runner_user, ""}.
 {http_api_endpoint, "{5288, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -31,10 +31,7 @@
 {registration_watchers, "%{registration_watchers, [\"admin@localhost\"]},"}.
 {riak_server, "%%{riak_server, [{pool_size, 20}, {address, \"127.0.0.1\"}, {port, 8087}, {riak_pb_socket_opts, []}]}."}.
 
-% These have to be the same to gather all
-% (bin/mongooseim - the script - and lager) log files in one place.
-{app_config_lager_log_dir, "\"log\""}.
-{mongooseim_runner_log_dir, "log"}.
+{mongooseim_log_dir, "log"}.
 {http_api_endpoint, "{5288, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -31,6 +31,7 @@
 {registration_watchers, "%{registration_watchers, [\"admin@localhost\"]},"}.
 {riak_server, "%%{riak_server, [{pool_size, 20}, {address, \"127.0.0.1\"}, {port, 8087}, {riak_pb_socket_opts, []}]}."}.
 
+%% TODO: export from tools/configure
 {mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
 {mongooseim_log_dir, "log"}.
 {mongooseim_runner_user, ""}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -42,4 +42,5 @@
 %{mongooseim_log_dir, "log"}.
 %{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 %{mongooseim_mdb_dir_toggle, "%"}.
+%{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
 %{mongooseim_runner_user, ""}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -37,6 +37,7 @@
 
 %% Defined in Makefile by appending configure.vars.config
 %% Uncomment for manual release generation.
+%{mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.
 %{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
 %{mongooseim_log_dir, "log"}.
 %{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -37,6 +37,6 @@
 
 %% Defined in Makefile by appending configure.vars.config
 %% Uncomment for manual release generation.
-%{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
+{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
 %{mongooseim_log_dir, "log"}.
 %{mongooseim_runner_user, ""}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -37,6 +37,8 @@
 
 %% Defined in Makefile by appending configure.vars.config
 %% Uncomment for manual release generation.
-{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
+%{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
 %{mongooseim_log_dir, "log"}.
+%{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
+%{mongooseim_mdb_dir_toggle, "%"}.
 %{mongooseim_runner_user, ""}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -31,10 +31,12 @@
 {registration_watchers, "%{registration_watchers, [\"admin@localhost\"]},"}.
 {riak_server, "%%{riak_server, [{pool_size, 20}, {address, \"127.0.0.1\"}, {port, 8087}, {riak_pb_socket_opts, []}]}."}.
 
-%% TODO: export from tools/configure
-{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
-{mongooseim_log_dir, "log"}.
-{mongooseim_runner_user, ""}.
 {http_api_endpoint, "{5288, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
+
+%% Defined in Makefile by appending configure.vars.config
+%% Uncomment for manual release generation.
+%{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
+%{mongooseim_log_dir, "log"}.
+%{mongooseim_runner_user, ""}.

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -24,7 +24,9 @@ add_node_to_cluster(ConfigIn) ->
     Node2Ctl = ctl_path(Node2, Config),
 
     StartCmd = Node2Ctl ++ " start",
+    StartedCmd = Node2Ctl ++ " started",
     StopCmd = Node2Ctl  ++ " stop",
+    StoppedCmd = Node2Ctl ++ " stopped",
     StatusCmd = Node2Ctl ++ " status",
 
 
@@ -35,6 +37,7 @@ add_node_to_cluster(ConfigIn) ->
 
     Res1 = call_fun(Node, os, cmd, [StopCmd]),
     ?assertEqual("", Res1),
+    call_fun(Node, os, cmd, [StoppedCmd]),
     wait_until_stopped(StatusCmd, 120),
 
     Res2 = call_fun(Node, os, cmd, [MnesiaCmd]),
@@ -45,6 +48,7 @@ add_node_to_cluster(ConfigIn) ->
 
     Res4 = call_fun(Node, os, cmd, [StartCmd]),
     ?assertEqual("", Res4),
+    call_fun(Node, os, cmd, [StartedCmd]),
     wait_until_started(StatusCmd, 120),
 
     verify_result(add),
@@ -56,7 +60,9 @@ remove_node_from_cluster(Config) ->
     Node2 = ct:get_config(ejabberd2_node),
     Node2Ctl = ctl_path(Node2, Config),
     StartCmd = Node2Ctl ++ " start",
+    StartedCmd = Node2Ctl ++ " started",
     StopCmd = Node2Ctl ++ " stop",
+    StoppedCmd = Node2Ctl ++ " stopped",
     StatusCmd = Node2Ctl ++ " status",
     RemoveCmd = ctl_path(Node, Config) ++ " remove_from_cluster " ++ atom_to_list(Node2),
 
@@ -64,6 +70,7 @@ remove_node_from_cluster(Config) ->
     MnesiaCmd = "rm -rf " ++ MnesiaDir,
 
     Res1 = call_fun(Node, os, cmd, [StopCmd]),
+    call_fun(Node, os, cmd, [StoppedCmd]),
     ?assertEqual(Res1, ""),
     wait_until_stopped(StatusCmd, 120),
 
@@ -74,8 +81,9 @@ remove_node_from_cluster(Config) ->
     ?assertEqual(Res3, ""),
 
     Res4 = call_fun(Node, os, cmd, [StartCmd]),
-    wait_until_started(StatusCmd, 120),
     ?assertEqual(Res4, ""),
+    call_fun(Node, os, cmd, [StartedCmd]),
+    wait_until_started(StatusCmd, 120),
 
     verify_result(remove),
 

--- a/tools/configure
+++ b/tools/configure
@@ -13,7 +13,7 @@
                prefix         = "/usr/local",
                reltool_vars   = "rel/configure.vars.config",
                system         = "no",
-               user           = "mongooseim",
+               user           = "",
                script_dir     = "$(cd ${0%/*} && pwd)",
                bin_dir        = undefined,
                etc_dir        = "$RUNNER_BASE_DIR/etc",
@@ -156,8 +156,8 @@ write(shell, FileName, Opts) ->
               sh_var("APPS", validate_apps(Opts#opts.apps)),
               sh_var("PREFIX", [Opts#opts.prefix]),
               sh_var("RELTOOL_VARS", [Opts#opts.reltool_vars]),
-              sh_var("RUNNER_USER", [Opts#opts.user]),
               sh_var("SYSTEM", [Opts#opts.system])] ++
+             [sh_var("RUNNER_USER", [Opts#opts.user])|| Opts#opts.user /= ""] ++
              [sh_var("BIN_DIR", [Opts#opts.bin_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("ETC_DIR", [Opts#opts.etc_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("LIB_DIR", [Opts#opts.lib_dir]) || Opts#opts.system == "yes"] ++

--- a/tools/configure
+++ b/tools/configure
@@ -1,14 +1,25 @@
 #!/usr/bin/env escript
+-module(configure).
+-compile([export_all]).
+-mode(compile).
+
+-define(b2l(B), binary_to_list(B)).
+-define(l2b(L), list_to_binary(L)).
 
 -define(NO_ODBC_WARN, "WARNING! There is no odbc module in your Erlang/OTP installation! "
                       "It will not be included in the release!").
 
--record(opts, {apps         = [],
-               log_dir      = "log",
-               prefix       = "/usr/local",
-               reltool_vars = "rel/configure.vars.config",
-               user         = "mongooseim",
-               system       = "no"}).
+-record(opts, {apps             = [],
+               prefix           = "/usr/local",
+               reltool_vars     = "rel/configure.vars.config",
+               system           = "no",
+               user             = "mongooseim",
+               bin_dir          = undefined,
+               etc_dir          = "$RUNNER_BASE_DIR/etc",
+               lib_dir          = undefined,
+               log_dir          = "log",
+               mdb_dir          = "$RUNNER_BASE_DIR/Mnesia.$NODE",
+               mdb_dir_toggle   = "%"}).
 
 main([]) ->
     usage();
@@ -16,7 +27,7 @@ main(Args) ->
     case catch process_args(Args, #opts{}) of
         {ok, Opts} ->
             ok = write(shell, "configure.out", Opts),
-            ok = write(reltool, Opts#opts.reltool_vars, Opts);
+            ok = write(reltool, Opts#opts.reltool_vars, expand_prefix(Opts));
         error ->
             ok
     end.
@@ -34,11 +45,10 @@ app_opts() ->
                                         include_driver("riak")}].
 
 opts() ->
-    [{"log-dir", (#opts{})#opts.log_dir, "Log directory. If relative, will be relative to $PREFIX/mongooseim"},
-     {"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},
-     {"user",    (#opts{})#opts.user,    "System user to run the server as"},
+    [{"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},
      {"system",  (#opts{})#opts.system,  "Install files into $PREFIX/{bin, etc, ...} instead of "
-                                         "a completely self contained release"}].
+                                         "a completely self contained release"},
+     {"user",    (#opts{})#opts.user,    "System user to run the server as"}].
 
 include_driver(DB) ->
     ["include ", DB, " driver"].
@@ -49,20 +59,18 @@ all_apps() ->
 process_args(["with-" ++ App | Args], #opts{apps = Apps} = Opts) ->
     process_args(Args, Opts#opts{apps = process_app(App, Apps)});
 
-process_args(["log-dir=" ++ LogDir | Args], #opts{} = Opts) ->
-    process_args(Args, Opts#opts{log_dir = LogDir});
-process_args(["log-dir", LogDir | Args], #opts{} = Opts) ->
-    process_args(Args, Opts#opts{log_dir = LogDir});
-
 process_args(["prefix=" ++ Prefix | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{prefix = Prefix});
 process_args(["prefix", Prefix | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{prefix = Prefix});
 
 process_args(["system=" ++ System | Args], #opts{} = Opts) ->
-    process_args(Args, Opts#opts{system = System});
+    case is_true(System) of
+        true  -> process_args(Args, system_install(Opts));
+        false -> process_args(Args, Opts)
+    end;
 process_args(["system" | Args], #opts{} = Opts) ->
-    process_args(Args, Opts#opts{system = "yes"});
+    process_args(Args, system_install(Opts));
 
 process_args(["user=" ++ User | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{user = User});
@@ -74,6 +82,15 @@ process_args([Unknown | _Args], #opts{} = _Opts) ->
     throw(error);
 
 process_args([], Opts) -> {ok, Opts}.
+
+system_install(Opts) ->
+    Opts#opts{system  = "yes",
+              bin_dir = "$PREFIX/usr/bin",
+              etc_dir = "$PREFIX/etc/mongooseim",
+              lib_dir = "$PREFIX/usr/lib/mongooseim",
+              log_dir = "$PREFIX/var/log/mongooseim",
+              mdb_dir = "$PREFIX/var/lib/mongooseim",
+              mdb_dir_toggle = ""}.
 
 process_app("none", _Apps) -> [];
 process_app("all", _Apps)  -> all_apps();
@@ -98,10 +115,11 @@ usage() ->
           "~s: OPTIONS\n"
           "\n"
           "Specifies which 3rd party deps will be included in the release.\n"
-          "Allows to configure LOG_DIR or installation PREFIX.\n"
-          "Writes configure.out file as output. This file can be sourced with:\n"
+          "Writes configure.out file as output - this file can be sourced with:\n"
           "\n"
           "    . configure.out\n"
+          "\n"
+          "Writes rel/configure.vars.config which can be used as Reltool input.\n"
           "\n"
           "3rd party apps:\n\n~s\n"
           "Options:\n\n~s\n",
@@ -117,6 +135,8 @@ print(Handle, Fmt, Args) ->
 progname() ->
     filename:basename(hd(init:get_plain_arguments())).
 
+is_true(Opt) -> lists:member(Opt, ["yes", "true", "1"]).
+
 sh_var(Name, Value) -> ["export ", Name, "=\"", value(Value), "\"\n"].
 
 value([]) -> [];
@@ -126,15 +146,40 @@ value([H | T]) -> [H, " "] ++ value(T).
 rt_var(Name, Value) -> io_lib:format("{~s, ~p}.\n", [Name, Value]).
 
 write(shell, FileName, Opts) ->
-    Data = [sh_var("MONGOOSEIM_CONFIGURED", ["yes"]),
-            sh_var("APPS", validate_apps(Opts#opts.apps)),
-            sh_var("PREFIX", [Opts#opts.prefix]),
-            sh_var("RELTOOL_VARS", [Opts#opts.reltool_vars]),
-            sh_var("RUNNER_USER", [Opts#opts.user]),
-            sh_var("SYSTEM", [Opts#opts.system])],
+    Data = ( [sh_var("MONGOOSEIM_CONFIGURED", ["yes"]),
+              sh_var("APPS", validate_apps(Opts#opts.apps)),
+              sh_var("PREFIX", [Opts#opts.prefix]),
+              sh_var("RELTOOL_VARS", [Opts#opts.reltool_vars]),
+              sh_var("RUNNER_USER", [Opts#opts.user]),
+              sh_var("SYSTEM", [Opts#opts.system])] ++
+             [sh_var("BIN_DIR", [Opts#opts.bin_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("ETC_DIR", [Opts#opts.etc_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("LIB_DIR", [Opts#opts.lib_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("LOG_DIR", [Opts#opts.log_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("MDB_DIR", [Opts#opts.mdb_dir]) || Opts#opts.system == "yes"] ),
     file:write_file(FileName, Data);
 
 write(reltool, FileName, Opts) ->
-    Data = [rt_var(mongooseim_log_dir, Opts#opts.log_dir),
-            rt_var(mongooseim_runner_user, Opts#opts.user)],
+    Data = ( [rt_var(mongooseim_runner_user, Opts#opts.user)] ++
+             [rt_var(mongooseim_etc_dir, Opts#opts.etc_dir)] ++
+             [rt_var(mongooseim_log_dir, Opts#opts.log_dir)] ++
+             [rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir)] ++
+             [rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle)] ),
     file:write_file(FileName, Data).
+
+expand_prefix(Opts) when Opts#opts.system /= "yes" -> Opts;
+expand_prefix(Opts) ->
+    {NOpts, _} = lists:foldl(fun ?MODULE:expand_prefix/2, {Opts, Opts#opts.prefix},
+                             [#opts.bin_dir,
+                              #opts.etc_dir,
+                              #opts.lib_dir,
+                              #opts.log_dir,
+                              #opts.mdb_dir]),
+    NOpts.
+
+expand_prefix(Index, {Opts, Prefix}) ->
+    {setelement(Index, Opts, expand_env("$PREFIX", Prefix, element(Index, Opts))),
+     Prefix}.
+
+expand_env(Name, Value, String) ->
+    ?b2l(binary:replace(?l2b(String), ?l2b(Name), ?l2b(Value))).

--- a/tools/configure
+++ b/tools/configure
@@ -3,17 +3,20 @@
 -define(NO_ODBC_WARN, "WARNING! There is no odbc module in your Erlang/OTP installation! "
                       "It will not be included in the release!").
 
--record(opts, {apps     = [],
-               log_dir  = "log",
-               prefix   = "/usr/local"}).
+-record(opts, {apps    = [],
+               log_dir = "log",
+               prefix  = "/usr/local",
+               system  = "no"}).
 
 main([]) ->
     usage();
 main(Args) ->
     Opts = process_args(Args, #opts{}),
-    Data = [var("APPS", validate_apps(Opts#opts.apps)),
+    Data = [var("MONGOOSEIM_CONFIGURED", ["yes"]),
+            var("APPS", validate_apps(Opts#opts.apps)),
             var("LOG_DIR", [Opts#opts.log_dir]),
-            var("PREFIX", [Opts#opts.prefix])],
+            var("PREFIX", [Opts#opts.prefix]),
+            var("INSTALL_SBIN", [Opts#opts.system])],
     ok = file:write_file("configure.out", Data).
 
 app_opts() ->
@@ -30,7 +33,8 @@ app_opts() ->
 
 opts() ->
     [{"log-dir", (#opts{})#opts.log_dir, "Log directory. If relative, will be relative to $PREFIX/mongooseim"},
-     {"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"}].
+     {"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},
+     {"system",  (#opts{})#opts.system,  "Install mongooseimctl into $PREFIX/sbin"}].
 
 include_driver(DB) ->
     ["include ", DB, " driver"].
@@ -50,6 +54,11 @@ process_args(["prefix=" ++ Prefix | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{prefix = Prefix});
 process_args(["prefix", Prefix | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{prefix = Prefix});
+
+process_args(["system=" ++ System | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{system = System});
+process_args(["system" | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{system = "yes"});
 
 process_args([Unknown | Args], #opts{} = Opts) ->
     print(standard_error, "~s: unknown option: ~s~n", [progname(), Unknown]),

--- a/tools/configure
+++ b/tools/configure
@@ -16,7 +16,7 @@ main(Args) ->
             var("APPS", validate_apps(Opts#opts.apps)),
             var("LOG_DIR", [Opts#opts.log_dir]),
             var("PREFIX", [Opts#opts.prefix]),
-            var("INSTALL_SBIN", [Opts#opts.system])],
+            var("SYSTEM", [Opts#opts.system])],
     ok = file:write_file("configure.out", Data).
 
 app_opts() ->
@@ -34,7 +34,8 @@ app_opts() ->
 opts() ->
     [{"log-dir", (#opts{})#opts.log_dir, "Log directory. If relative, will be relative to $PREFIX/mongooseim"},
      {"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},
-     {"system",  (#opts{})#opts.system,  "Install mongooseimctl into $PREFIX/sbin"}].
+     {"system",  (#opts{})#opts.system,  "Install files into $PREFIX/{bin, etc, ...} instead of "
+                                         "a completely self contained release"}].
 
 include_driver(DB) ->
     ["include ", DB, " driver"].

--- a/tools/configure
+++ b/tools/configure
@@ -51,6 +51,10 @@ process_args(["prefix=" ++ Prefix | Args], #opts{} = Opts) ->
 process_args(["prefix", Prefix | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{prefix = Prefix});
 
+process_args([Unknown | Args], #opts{} = Opts) ->
+    print(standard_error, "~s: unknown option: ~s~n", [progname(), Unknown]),
+    process_args(Args, Opts);
+
 process_args([], Opts) -> Opts.
 
 process_app("none", _Apps) -> [];
@@ -72,21 +76,25 @@ is_odbc_available() ->
     {module, odbc} == code:ensure_loaded(odbc).
 
 usage() ->
-    io:format("~s: OPTIONS\n"
-              "\n"
-              "Specifies which 3rd party deps will be included in the release.\n"
-              "Allows to configure LOG_DIR or installation PREFIX.\n"
-              "Writes configure.out file as output. This file can be sourced with:\n"
-              "\n"
-              "    . configure.out\n"
-              "\n"
-              "3rd party apps:\n\n~s\n"
-              "Options:\n\n~s\n",
-              [progname(),
-               [ io_lib:format("    with-~.15s~s\n", [Opt, Desc])
-                 || {Opt, _, Desc} <- app_opts() ],
-               [ io_lib:format("    ~.10s~s. Default: ~s\n", [Opt, Desc, Default])
-                 || {Opt, Default, Desc} <- opts() ]]).
+    print(standard_error,
+          "~s: OPTIONS\n"
+          "\n"
+          "Specifies which 3rd party deps will be included in the release.\n"
+          "Allows to configure LOG_DIR or installation PREFIX.\n"
+          "Writes configure.out file as output. This file can be sourced with:\n"
+          "\n"
+          "    . configure.out\n"
+          "\n"
+          "3rd party apps:\n\n~s\n"
+          "Options:\n\n~s\n",
+          [progname(),
+           [ io_lib:format("    with-~.15s~s\n", [Opt, Desc])
+             || {Opt, _, Desc} <- app_opts() ],
+           [ io_lib:format("    ~.10s~s. Default: ~s\n", [Opt, Desc, Default])
+             || {Opt, Default, Desc} <- opts() ]]).
+
+print(Handle, Fmt, Args) ->
+    io:format(Handle, Fmt, Args).
 
 progname() ->
     filename:basename(hd(init:get_plain_arguments())).

--- a/tools/configure
+++ b/tools/configure
@@ -1,72 +1,98 @@
 #!/usr/bin/env escript
 
--define(NO_ODBC_WARN, "WARNING! There is no odbc module in your Erlang/OTP installation! It will not be included in the release!").
+-define(NO_ODBC_WARN, "WARNING! There is no odbc module in your Erlang/OTP installation! "
+                      "It will not be included in the release!").
+
+-record(opts, {apps     = [],
+               log_dir  = "log",
+               prefix   = "/usr/local"}).
 
 main([]) ->
     usage();
-main(OptsIn) ->
-    Opts = case lists:member("full", OptsIn) of
-        false ->
+main(Args) ->
+    Opts = process_args(Args, #opts{}),
+    Data = [var("APPS", validate_apps(Opts#opts.apps)),
+            var("LOG_DIR", [Opts#opts.log_dir]),
+            var("PREFIX", [Opts#opts.prefix])],
+    ok = file:write_file("configure.out", Data).
 
-            OptsIn;
-        _ ->
-            all_opts()
-    end,
-    {AppsToRun, AppsToInclude} = lists:foldl(fun(O, Acc) -> analyze_opt(O, Acc) end,
-                                             {[], []}, Opts),
-    Data = io_lib:fwrite("~p.~n~p.", [{apps_to_run, AppsToRun}, {apps_to_include, AppsToInclude}]),
-    file:write_file("configure.out", Data).
+app_opts() ->
+    %% Opt         Apps                 Desc
+    [{"none",      [],                  "include no 3rd party drivers"},
+     {"all",       [],                  "include all drivers"},
+     {"cassandra", ["seestar"],         include_driver("cassandra")},
+     {"mysql",     ["mysql"],           include_driver("mysql")},
+     {"odbc",      ["odbc"],            "include standard ODBC driver shipped with Erlang/OTP"},
+     {"pgsql",     ["pgsql"],           include_driver("pgsql")},
+     {"redis",     ["redo"],            include_driver("redis")},
+     {"riak",      ["riakc", "riak_pb", "protobuffs"],
+                                        include_driver("riak")}].
 
-analyze_opt("with-mysql", {AppsToInclude, AppsToRun}) ->
-    {[mysql | AppsToInclude], AppsToRun};
-analyze_opt("with-pgsql", {AppsToInclude, AppsToRun}) ->
-    {[pgsql | AppsToInclude], AppsToRun};
-analyze_opt("with-odbc", {AppsToInclude, AppsToRun} = Acc) ->
+opts() ->
+    [{"log-dir", (#opts{})#opts.log_dir, "Log directory. If relative, will be relative to $PREFIX/mongooseim"},
+     {"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"}].
+
+include_driver(DB) ->
+    ["include ", DB, " driver"].
+
+all_apps() ->
+    lists:flatmap(fun ({_, Apps, _}) -> Apps end, app_opts()).
+
+process_args(["with-" ++ App | Args], #opts{apps = Apps} = Opts) ->
+    process_args(Args, Opts#opts{apps = process_app(App, Apps)});
+
+process_args(["log-dir=" ++ LogDir | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{log_dir = LogDir});
+process_args(["log-dir", LogDir | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{log_dir = LogDir});
+
+process_args(["prefix=" ++ Prefix | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{prefix = Prefix});
+process_args(["prefix", Prefix | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{prefix = Prefix});
+
+process_args([], Opts) -> Opts.
+
+process_app("none", _Apps) -> [];
+process_app("all", _Apps)  -> all_apps();
+process_app(App, Apps)     -> [App | Apps].
+
+validate_apps(Apps) -> validate_apps(Apps, []).
+
+validate_apps(["odbc" = App | Apps], Acc) ->
     case is_odbc_available() of
-        true ->
-            {[odbc | AppsToInclude], AppsToRun};
-        _ ->
-            io:format("~s~n", [?NO_ODBC_WARN]),
-            Acc
+        false -> io:format(standard_error, "~s~n", [?NO_ODBC_WARN]),
+                 validate_apps(Apps, Acc);
+        true  -> validate_apps(Apps, [App | Acc])
     end;
-analyze_opt("with-riak", {AppsToInclude, AppsToRun}) ->
-    {[riakc, riak_pb, protobuffs | AppsToInclude], AppsToRun};
-analyze_opt("with-redis", {AppsToInclude, AppsToRun}) ->
-    {[redo | AppsToInclude], AppsToRun};
-analyze_opt("with-cassandra", {AppsToInclude, AppsToRun}) ->
-    {[seestar | AppsToInclude], AppsToRun};
-analyze_opt("minimal", Acc) ->
-    Acc;
-analyze_opt(Opt, Acc) ->
-    io:format("WARNING! Unknown option ~s~n", [Opt]),
-    Acc.
-
-all_opts() ->
-    [Opt || {Opt, _} <- all_opts_with_desc()].
-
-all_opts_with_desc() ->
-    [{"with-mysql", "include mysql driver"},
-     {"with-pgsql", "include pgsql driver"},
-     {"with-riak", "include riak client"},
-     {"with-redis", "include redis driver"},
-     {"with-cassandra", "include cassandra driver"},
-     maybe_odbc()].
-
-maybe_odbc() ->
-    case is_odbc_available() of
-        true ->
-            {"with-odbc", "include standard ODBC driver shipped with Erlang/OTP"};
-        _ ->
-            {"with-odbc", "include standard ODBC driver shipped with Erlang/OTP. " ++ ?NO_ODBC_WARN}
-    end.
+validate_apps([App | Apps], Acc) -> validate_apps(Apps, [App | Acc]);
+validate_apps([], Acc) -> lists:reverse(Acc).
 
 is_odbc_available() ->
     {module, odbc} == code:ensure_loaded(odbc).
 
 usage() ->
-    io:format("specifies which 3rd party deps will be included in release~n"),
-    io:format("possible options:~n"),
-    [io:format("~s\t~s~n", [Opt, Desc]) || {Opt, Desc} <- all_opts_with_desc()],
-    io:format("~s\t\t~s~n", ["full", "include all above deps"]),
-    io:format("~s\t\t~s~n", ["minimal", "does not include any of above deps"]).
+    io:format("~s: OPTIONS\n"
+              "\n"
+              "Specifies which 3rd party deps will be included in the release.\n"
+              "Allows to configure LOG_DIR or installation PREFIX.\n"
+              "Writes configure.out file as output. This file can be sourced with:\n"
+              "\n"
+              "    . configure.out\n"
+              "\n"
+              "3rd party apps:\n\n~s\n"
+              "Options:\n\n~s\n",
+              [progname(),
+               [ io_lib:format("    with-~.15s~s\n", [Opt, Desc])
+                 || {Opt, _, Desc} <- app_opts() ],
+               [ io_lib:format("    ~.10s~s. Default: ~s\n", [Opt, Desc, Default])
+                 || {Opt, Default, Desc} <- opts() ]]).
 
+progname() ->
+    filename:basename(hd(init:get_plain_arguments())).
+
+var(Name, Value) -> ["export ", Name, "=\"", value(Value), "\"\n"].
+
+value([]) -> [];
+value([V]) -> [V];
+value([H | T]) -> [H, " "] ++ value(T).

--- a/tools/configure
+++ b/tools/configure
@@ -162,12 +162,12 @@ write(shell, FileName, Opts) ->
     file:write_file(FileName, Data);
 
 write(reltool, FileName, Opts) ->
-    Data = ( [rt_var(mongooseim_runner_user, Opts#opts.user)] ++
-             [rt_var(mongooseim_script_dir, Opts#opts.script_dir)] ++
-             [rt_var(mongooseim_etc_dir, Opts#opts.etc_dir)] ++
-             [rt_var(mongooseim_log_dir, Opts#opts.log_dir)] ++
-             [rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir)] ++
-             [rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle)] ),
+    Data = [rt_var(mongooseim_runner_user, Opts#opts.user),
+            rt_var(mongooseim_script_dir, Opts#opts.script_dir),
+            rt_var(mongooseim_etc_dir, Opts#opts.etc_dir),
+            rt_var(mongooseim_log_dir, Opts#opts.log_dir),
+            rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir),
+            rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle)],
     file:write_file(FileName, Data).
 
 expand_prefix(Opts) when Opts#opts.system /= "yes" -> Opts;

--- a/tools/configure
+++ b/tools/configure
@@ -20,7 +20,8 @@
                lib_dir        = undefined,
                log_dir        = "log",
                mdb_dir        = "$RUNNER_BASE_DIR/Mnesia.$NODE",
-               mdb_dir_toggle = "%"}).
+               mdb_dir_toggle = "%",
+               lock_dir       = "$EJABBERD_DIR/var/lock"}).
 
 main([]) ->
     usage();
@@ -92,7 +93,8 @@ system_install(Opts) ->
               lib_dir        = "$PREFIX/usr/lib/mongooseim",
               log_dir        = "$PREFIX/var/log/mongooseim",
               mdb_dir        = "$PREFIX/var/lib/mongooseim",
-              mdb_dir_toggle = ""}.
+              mdb_dir_toggle = "",
+              lock_dir       = "$PREFIX/var/lock/mongooseim"}.
 
 process_app("none", _Apps) -> [];
 process_app("all", _Apps)  -> all_apps();
@@ -158,7 +160,8 @@ write(shell, FileName, Opts) ->
              [sh_var("ETC_DIR", [Opts#opts.etc_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("LIB_DIR", [Opts#opts.lib_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("LOG_DIR", [Opts#opts.log_dir]) || Opts#opts.system == "yes"] ++
-             [sh_var("MDB_DIR", [Opts#opts.mdb_dir]) || Opts#opts.system == "yes"] ),
+             [sh_var("MDB_DIR", [Opts#opts.mdb_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("LOCK_DIR", [Opts#opts.lock_dir]) || Opts#opts.system == "yes"] ),
     file:write_file(FileName, Data);
 
 write(reltool, FileName, Opts) ->
@@ -167,7 +170,8 @@ write(reltool, FileName, Opts) ->
             rt_var(mongooseim_etc_dir, Opts#opts.etc_dir),
             rt_var(mongooseim_log_dir, Opts#opts.log_dir),
             rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir),
-            rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle)],
+            rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle),
+            rt_var(mongooseim_lock_dir, Opts#opts.lock_dir)],
     file:write_file(FileName, Data).
 
 expand_prefix(Opts) when Opts#opts.system /= "yes" -> Opts;
@@ -178,7 +182,8 @@ expand_prefix(Opts) ->
                               #opts.etc_dir,
                               #opts.lib_dir,
                               #opts.log_dir,
-                              #opts.mdb_dir]),
+                              #opts.mdb_dir,
+                              #opts.lock_dir]),
     NOpts.
 
 expand_prefix(Index, {Opts, Prefix}) ->

--- a/tools/configure
+++ b/tools/configure
@@ -97,8 +97,10 @@ system_install(Opts) ->
               lock_dir       = "$PREFIX/var/lock/mongooseim"}.
 
 process_app("none", _Apps) -> [];
-process_app("all", _Apps)  -> all_apps();
-process_app(App, Apps)     -> [App | Apps].
+process_app("all", _Apps) -> all_apps();
+process_app(App, Apps) ->
+    {App, AppDeps, _} = lists:keyfind(App, 1, app_opts()),
+    AppDeps ++ Apps.
 
 validate_apps(Apps) -> validate_apps(Apps, []).
 

--- a/tools/configure
+++ b/tools/configure
@@ -3,22 +3,20 @@
 -define(NO_ODBC_WARN, "WARNING! There is no odbc module in your Erlang/OTP installation! "
                       "It will not be included in the release!").
 
--record(opts, {apps    = [],
-               log_dir = "log",
-               prefix  = "/usr/local",
-               system  = "no"}).
+-record(opts, {apps         = [],
+               log_dir      = "log",
+               prefix       = "/usr/local",
+               reltool_vars = "rel/configure.vars.config",
+               user         = "mongooseim",
+               system       = "no"}).
 
 main([]) ->
     usage();
 main(Args) ->
     case catch process_args(Args, #opts{}) of
         {ok, Opts} ->
-            Data = [var("MONGOOSEIM_CONFIGURED", ["yes"]),
-                    var("APPS", validate_apps(Opts#opts.apps)),
-                    var("LOG_DIR", [Opts#opts.log_dir]),
-                    var("PREFIX", [Opts#opts.prefix]),
-                    var("SYSTEM", [Opts#opts.system])],
-            ok = file:write_file("configure.out", Data);
+            ok = write(shell, "configure.out", Opts),
+            ok = write(reltool, Opts#opts.reltool_vars, Opts);
         error ->
             ok
     end.
@@ -38,6 +36,7 @@ app_opts() ->
 opts() ->
     [{"log-dir", (#opts{})#opts.log_dir, "Log directory. If relative, will be relative to $PREFIX/mongooseim"},
      {"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},
+     {"user",    (#opts{})#opts.user,    "System user to run the server as"},
      {"system",  (#opts{})#opts.system,  "Install files into $PREFIX/{bin, etc, ...} instead of "
                                          "a completely self contained release"}].
 
@@ -64,6 +63,11 @@ process_args(["system=" ++ System | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{system = System});
 process_args(["system" | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{system = "yes"});
+
+process_args(["user=" ++ User | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{user = User});
+process_args(["user", User | Args], #opts{} = Opts) ->
+    process_args(Args, Opts#opts{user = User});
 
 process_args([Unknown | _Args], #opts{} = _Opts) ->
     print(standard_error, "~s: unknown option: ~s~n", [progname(), Unknown]),
@@ -113,8 +117,24 @@ print(Handle, Fmt, Args) ->
 progname() ->
     filename:basename(hd(init:get_plain_arguments())).
 
-var(Name, Value) -> ["export ", Name, "=\"", value(Value), "\"\n"].
+sh_var(Name, Value) -> ["export ", Name, "=\"", value(Value), "\"\n"].
 
 value([]) -> [];
 value([V]) -> [V];
 value([H | T]) -> [H, " "] ++ value(T).
+
+rt_var(Name, Value) -> io_lib:format("{~s, ~p}.\n", [Name, Value]).
+
+write(shell, FileName, Opts) ->
+    Data = [sh_var("MONGOOSEIM_CONFIGURED", ["yes"]),
+            sh_var("APPS", validate_apps(Opts#opts.apps)),
+            sh_var("PREFIX", [Opts#opts.prefix]),
+            sh_var("RELTOOL_VARS", [Opts#opts.reltool_vars]),
+            sh_var("RUNNER_USER", [Opts#opts.user]),
+            sh_var("SYSTEM", [Opts#opts.system])],
+    file:write_file(FileName, Data);
+
+write(reltool, FileName, Opts) ->
+    Data = [rt_var(mongooseim_log_dir, Opts#opts.log_dir),
+            rt_var(mongooseim_runner_user, Opts#opts.user)],
+    file:write_file(FileName, Data).

--- a/tools/configure
+++ b/tools/configure
@@ -9,17 +9,18 @@
 -define(NO_ODBC_WARN, "WARNING! There is no odbc module in your Erlang/OTP installation! "
                       "It will not be included in the release!").
 
--record(opts, {apps             = [],
-               prefix           = "/usr/local",
-               reltool_vars     = "rel/configure.vars.config",
-               system           = "no",
-               user             = "mongooseim",
-               bin_dir          = undefined,
-               etc_dir          = "$RUNNER_BASE_DIR/etc",
-               lib_dir          = undefined,
-               log_dir          = "log",
-               mdb_dir          = "$RUNNER_BASE_DIR/Mnesia.$NODE",
-               mdb_dir_toggle   = "%"}).
+-record(opts, {apps           = [],
+               prefix         = "/usr/local",
+               reltool_vars   = "rel/configure.vars.config",
+               system         = "no",
+               user           = "mongooseim",
+               script_dir     = "$(cd ${0%/*} && pwd)",
+               bin_dir        = undefined,
+               etc_dir        = "$RUNNER_BASE_DIR/etc",
+               lib_dir        = undefined,
+               log_dir        = "log",
+               mdb_dir        = "$RUNNER_BASE_DIR/Mnesia.$NODE",
+               mdb_dir_toggle = "%"}).
 
 main([]) ->
     usage();
@@ -84,12 +85,13 @@ process_args([Unknown | _Args], #opts{} = _Opts) ->
 process_args([], Opts) -> {ok, Opts}.
 
 system_install(Opts) ->
-    Opts#opts{system  = "yes",
-              bin_dir = "$PREFIX/usr/bin",
-              etc_dir = "$PREFIX/etc/mongooseim",
-              lib_dir = "$PREFIX/usr/lib/mongooseim",
-              log_dir = "$PREFIX/var/log/mongooseim",
-              mdb_dir = "$PREFIX/var/lib/mongooseim",
+    Opts#opts{system         = "yes",
+              script_dir     = "$PREFIX/usr/lib/mongooseim/bin",
+              bin_dir        = "$PREFIX/usr/bin",
+              etc_dir        = "$PREFIX/etc/mongooseim",
+              lib_dir        = "$PREFIX/usr/lib/mongooseim",
+              log_dir        = "$PREFIX/var/log/mongooseim",
+              mdb_dir        = "$PREFIX/var/lib/mongooseim",
               mdb_dir_toggle = ""}.
 
 process_app("none", _Apps) -> [];
@@ -161,6 +163,7 @@ write(shell, FileName, Opts) ->
 
 write(reltool, FileName, Opts) ->
     Data = ( [rt_var(mongooseim_runner_user, Opts#opts.user)] ++
+             [rt_var(mongooseim_script_dir, Opts#opts.script_dir)] ++
              [rt_var(mongooseim_etc_dir, Opts#opts.etc_dir)] ++
              [rt_var(mongooseim_log_dir, Opts#opts.log_dir)] ++
              [rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir)] ++
@@ -170,7 +173,8 @@ write(reltool, FileName, Opts) ->
 expand_prefix(Opts) when Opts#opts.system /= "yes" -> Opts;
 expand_prefix(Opts) ->
     {NOpts, _} = lists:foldl(fun ?MODULE:expand_prefix/2, {Opts, Opts#opts.prefix},
-                             [#opts.bin_dir,
+                             [#opts.script_dir,
+                              #opts.bin_dir,
                               #opts.etc_dir,
                               #opts.lib_dir,
                               #opts.log_dir,

--- a/tools/configure
+++ b/tools/configure
@@ -11,13 +11,17 @@
 main([]) ->
     usage();
 main(Args) ->
-    Opts = process_args(Args, #opts{}),
-    Data = [var("MONGOOSEIM_CONFIGURED", ["yes"]),
-            var("APPS", validate_apps(Opts#opts.apps)),
-            var("LOG_DIR", [Opts#opts.log_dir]),
-            var("PREFIX", [Opts#opts.prefix]),
-            var("SYSTEM", [Opts#opts.system])],
-    ok = file:write_file("configure.out", Data).
+    case catch process_args(Args, #opts{}) of
+        {ok, Opts} ->
+            Data = [var("MONGOOSEIM_CONFIGURED", ["yes"]),
+                    var("APPS", validate_apps(Opts#opts.apps)),
+                    var("LOG_DIR", [Opts#opts.log_dir]),
+                    var("PREFIX", [Opts#opts.prefix]),
+                    var("SYSTEM", [Opts#opts.system])],
+            ok = file:write_file("configure.out", Data);
+        error ->
+            ok
+    end.
 
 app_opts() ->
     %% Opt         Apps                 Desc
@@ -61,11 +65,11 @@ process_args(["system=" ++ System | Args], #opts{} = Opts) ->
 process_args(["system" | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{system = "yes"});
 
-process_args([Unknown | Args], #opts{} = Opts) ->
+process_args([Unknown | _Args], #opts{} = _Opts) ->
     print(standard_error, "~s: unknown option: ~s~n", [progname(), Unknown]),
-    process_args(Args, Opts);
+    throw(error);
 
-process_args([], Opts) -> Opts.
+process_args([], Opts) -> {ok, Opts}.
 
 process_app("none", _Apps) -> [];
 process_app("all", _Apps)  -> all_apps();

--- a/tools/install
+++ b/tools/install
@@ -43,6 +43,7 @@ chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${LIB_DIR}
 }
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${LOG_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${MDB_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${LOCK_DIR}
 
 ## Do the bookkeeping.
 ## TODO: How to automate this? If done manually, there's always space for a cock-up.
@@ -61,6 +62,7 @@ log () {
 find ${LIB_DIR} >> $LOG
 [ x"$SYSTEM" == x"yes" ] && log ${LOG_DIR}
 [ x"$SYSTEM" == x"yes" ] && log ${MDB_DIR}
+[ x"$SYSTEM" == x"yes" ] && log ${LOCK_DIR}
 
 ## Voila!
 echo MongooseIM successfully installed to ${LIB_DIR} > /dev/stderr

--- a/tools/install
+++ b/tools/install
@@ -65,4 +65,4 @@ find ${LIB_DIR} >> $LOG
 [ x"$SYSTEM" == x"yes" ] && log ${LOCK_DIR}
 
 ## Voila!
-echo MongooseIM successfully installed to ${LIB_DIR} > /dev/stderr
+echo MongooseIM successfully installed to ${LIB_DIR} >&2

--- a/tools/install
+++ b/tools/install
@@ -13,10 +13,10 @@ if [ -z "${MONGOOSEIM_CONFIGURED}" ]; then
 fi
 
 INSTALL_DIR=${PREFIX}/mongooseim
-if [ "${INSTALL_SBIN}" == "yes" ]; then
-    SBIN_DIR=${PREFIX}/sbin
+if [ "${SYSTEM}" == "yes" ]; then
+    BIN_DIR=${PREFIX}/bin
 else
-    SBIN_DIR=
+    BIN_DIR=
 fi
 if [ -z "${RUNNER_USER}" ]; then
     RUNNER_USER=mongooseim
@@ -27,23 +27,27 @@ if [ -z "${RUNNER_GROUP}" ]; then
     RUNNER_GROUP=${RUNNER_USER}
 fi
 
+## Install!
 INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
 install $INSTALL_OPTS -d ${INSTALL_DIR}
 cp -R rel/mongooseim/* ${INSTALL_DIR}
 chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${INSTALL_DIR}
-if [ -n ${SBIN_DIR} ]; then
-    install $INSTALL_OPTS -d ${SBIN_DIR}
-    install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${SBIN_DIR}/mongooseimctl
+if [ -n ${BIN_DIR} ]; then
+    install $INSTALL_OPTS -d ${BIN_DIR}
+    install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${BIN_DIR}/mongooseimctl
     ## TODO: these sed lines will become redundant once reltool is capable of putting correct values in
     sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${INSTALL_DIR}"'/bin*' \
-        rel/mongooseim/bin/mongooseimctl > ${SBIN_DIR}/mongooseimctl
+        rel/mongooseim/bin/mongooseimctl > ${BIN_DIR}/mongooseimctl
     sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \
         rel/mongooseim/bin/mongooseim > ${INSTALL_DIR}/bin/mongooseim
-    chmod 550 ${SBIN_DIR}/mongooseimctl
+    chmod 550 ${BIN_DIR}/mongooseimctl
 fi
+
+## Do the bookkeeping.
+## TODO: How to automate this? If done manually, there's always space for a cock-up.
 find ${INSTALL_DIR} > install.log
-if [ "${INSTALL_SBIN}" == "yes" ]; then
-    echo ${SBIN_DIR} >> install.log
-    echo ${SBIN_DIR}/mongooseimctl >> install.log
+if [ "${SYSTEM}" == "yes" ]; then
+    echo ${BIN_DIR} >> install.log
+    echo ${BIN_DIR}/mongooseimctl >> install.log
 fi
 echo \# MongooseIM successfully installed to ${INSTALL_DIR} | tee -a install.log > /dev/fd/2

--- a/tools/install
+++ b/tools/install
@@ -29,10 +29,6 @@ fi
 INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${BIN_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 555 rel/mongooseim/bin/mongooseimctl ${BIN_DIR}
-## TODO: this sed line will become redundant once reltool is capable of putting correct values in
-[ x"$SYSTEM" == x"yes" ] && chmod u+w ${BIN_DIR}/mongooseimctl
-[ x"$SYSTEM" == x"yes" ] && sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${LIB_DIR}"'/bin*' \
-    rel/mongooseim/bin/mongooseimctl > ${BIN_DIR}/mongooseimctl
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${ETC_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 rel/mongooseim/etc/app.config ${ETC_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 rel/mongooseim/etc/ejabberd.cfg ${ETC_DIR}
@@ -40,9 +36,11 @@ INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
 install $INSTALL_OPTS -d ${LIB_DIR}
 cp -R rel/mongooseim/* ${LIB_DIR}
 chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${LIB_DIR}
-## TODO: this sed line will become redundant once reltool is capable of putting correct values in
-sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \
-    rel/mongooseim/bin/mongooseim > ${LIB_DIR}/bin/mongooseim
+[ x"$SYSTEM" == x"yes" ] && {
+    mv ${LIB_DIR}/etc/app.config   ${LIB_DIR}/etc/app.config.example
+    mv ${LIB_DIR}/etc/ejabberd.cfg ${LIB_DIR}/etc/ejabberd.cfg.example
+    mv ${LIB_DIR}/etc/vm.args      ${LIB_DIR}/etc/vm.args.example
+}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${LOG_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${MDB_DIR}
 

--- a/tools/install
+++ b/tools/install
@@ -32,14 +32,15 @@ INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
 install $INSTALL_OPTS -d ${INSTALL_DIR}
 cp -R rel/mongooseim/* ${INSTALL_DIR}
 chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${INSTALL_DIR}
+## TODO: this sed line will become redundant once reltool is capable of putting correct values in
+sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \
+    rel/mongooseim/bin/mongooseim > ${INSTALL_DIR}/bin/mongooseim
 if [ -n "${BIN_DIR}" ]; then
     install $INSTALL_OPTS -d ${BIN_DIR}
     install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${BIN_DIR}/mongooseimctl
-    ## TODO: these sed lines will become redundant once reltool is capable of putting correct values in
+    ## TODO: this sed line will become redundant once reltool is capable of putting correct values in
     sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${INSTALL_DIR}"'/bin*' \
         rel/mongooseim/bin/mongooseimctl > ${BIN_DIR}/mongooseimctl
-    sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \
-        rel/mongooseim/bin/mongooseim > ${INSTALL_DIR}/bin/mongooseim
     chmod 550 ${BIN_DIR}/mongooseimctl
 fi
 

--- a/tools/install
+++ b/tools/install
@@ -18,9 +18,6 @@ if [ "${SYSTEM}" == "yes" ]; then
 else
     BIN_DIR=
 fi
-if [ -z "${RUNNER_USER}" ]; then
-    RUNNER_USER=mongooseim
-fi
 # A separate RUNNER_GROUP is handy for testing on a Mac,
 # where users don't have a group of the same name by default.
 if [ -z "${RUNNER_GROUP}" ]; then

--- a/tools/install
+++ b/tools/install
@@ -32,7 +32,7 @@ INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
 install $INSTALL_OPTS -d ${INSTALL_DIR}
 cp -R rel/mongooseim/* ${INSTALL_DIR}
 chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${INSTALL_DIR}
-if [ -n ${BIN_DIR} ]; then
+if [ -n "${BIN_DIR}" ]; then
     install $INSTALL_OPTS -d ${BIN_DIR}
     install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${BIN_DIR}/mongooseimctl
     ## TODO: these sed lines will become redundant once reltool is capable of putting correct values in

--- a/tools/install
+++ b/tools/install
@@ -63,4 +63,4 @@ find ${LIB_DIR} >> $LOG
 [ x"$SYSTEM" == x"yes" ] && log ${MDB_DIR}
 
 ## Voila!
-echo MongooseIM successfully installed to ${LIB_DIR} > /dev/fd/2
+echo MongooseIM successfully installed to ${LIB_DIR} > /dev/stderr

--- a/tools/install
+++ b/tools/install
@@ -34,6 +34,7 @@ chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${INSTALL_DIR}
 if [ -n ${SBIN_DIR} ]; then
     install $INSTALL_OPTS -d ${SBIN_DIR}
     install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${SBIN_DIR}/mongooseimctl
+    ## TODO: these sed lines will become redundant once reltool is capable of putting correct values in
     sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${INSTALL_DIR}"'/bin*' \
         rel/mongooseim/bin/mongooseimctl > ${SBIN_DIR}/mongooseimctl
     sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \

--- a/tools/install
+++ b/tools/install
@@ -12,6 +12,11 @@ if [ -z "${MONGOOSEIM_CONFIGURED}" ]; then
     exit 1
 fi
 
+## We assume that current user will be the owner if not specified
+if [ -z "${RUNNER_USER}" ]; then
+    RUNNER_USER=`whoami`
+fi
+
 # A separate RUNNER_GROUP is handy for testing on a Mac,
 # where users don't have a group of the same name by default.
 if [ -z "${RUNNER_GROUP}" ]; then

--- a/tools/install
+++ b/tools/install
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+## Debug?
+set -x
+
+## Fail if any of the steps fails.
+set -e
+
+## We assume configure.out is sourced already.
+if [ -z "${MONGOOSEIM_CONFIGURED}" ]; then
+    echo "Is configure.out sourced?" > /dev/fd/2
+    exit 1
+fi
+
+INSTALL_DIR=${PREFIX}/mongooseim
+if [ "${INSTALL_SBIN}" == "yes" ]; then
+    SBIN_DIR=${PREFIX}/sbin
+else
+    SBIN_DIR=
+fi
+if [ -z "${RUNNER_USER}" ]; then
+    RUNNER_USER=mongooseim
+fi
+# A separate RUNNER_GROUP is handy for testing on a Mac,
+# where users don't have a group of the same name by default.
+if [ -z "${RUNNER_GROUP}" ]; then
+    RUNNER_GROUP=${RUNNER_USER}
+fi
+
+INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
+install $INSTALL_OPTS -d ${INSTALL_DIR}
+cp -R rel/mongooseim/* ${INSTALL_DIR}
+chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${INSTALL_DIR}
+if [ -n ${SBIN_DIR} ]; then
+    install $INSTALL_OPTS -d ${SBIN_DIR}
+    install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${SBIN_DIR}/mongooseimctl
+    sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${INSTALL_DIR}"'/bin*' \
+        rel/mongooseim/bin/mongooseimctl > ${SBIN_DIR}/mongooseimctl
+    sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \
+        rel/mongooseim/bin/mongooseim > ${INSTALL_DIR}/bin/mongooseim
+    chmod 550 ${SBIN_DIR}/mongooseimctl
+fi
+find ${INSTALL_DIR} > install.log
+if [ "${INSTALL_SBIN}" == "yes" ]; then
+    echo ${SBIN_DIR} >> install.log
+    echo ${SBIN_DIR}/mongooseimctl >> install.log
+fi
+echo \# MongooseIM successfully installed to ${INSTALL_DIR} | tee -a install.log > /dev/fd/2

--- a/tools/install
+++ b/tools/install
@@ -12,40 +12,57 @@ if [ -z "${MONGOOSEIM_CONFIGURED}" ]; then
     exit 1
 fi
 
-INSTALL_DIR=${PREFIX}/mongooseim
-if [ "${SYSTEM}" == "yes" ]; then
-    BIN_DIR=${PREFIX}/bin
-else
-    BIN_DIR=
-fi
 # A separate RUNNER_GROUP is handy for testing on a Mac,
 # where users don't have a group of the same name by default.
 if [ -z "${RUNNER_GROUP}" ]; then
     RUNNER_GROUP=${RUNNER_USER}
 fi
 
+if [ "${SYSTEM}" == "yes" ]; then
+    ## we are good, sourcing configure.out has already set everything up
+    :
+else
+    LIB_DIR=$PREFIX/mongooseim
+fi
+
 ## Install!
 INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
-install $INSTALL_OPTS -d ${INSTALL_DIR}
-cp -R rel/mongooseim/* ${INSTALL_DIR}
-chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${INSTALL_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${BIN_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 555 rel/mongooseim/bin/mongooseimctl ${BIN_DIR}
+## TODO: this sed line will become redundant once reltool is capable of putting correct values in
+[ x"$SYSTEM" == x"yes" ] && chmod u+w ${BIN_DIR}/mongooseimctl
+[ x"$SYSTEM" == x"yes" ] && sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${LIB_DIR}"'/bin*' \
+    rel/mongooseim/bin/mongooseimctl > ${BIN_DIR}/mongooseimctl
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${ETC_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 rel/mongooseim/etc/app.config ${ETC_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 rel/mongooseim/etc/ejabberd.cfg ${ETC_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 rel/mongooseim/etc/vm.args ${ETC_DIR}
+install $INSTALL_OPTS -d ${LIB_DIR}
+cp -R rel/mongooseim/* ${LIB_DIR}
+chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${LIB_DIR}
 ## TODO: this sed line will become redundant once reltool is capable of putting correct values in
 sed -e 's*\(RUNNER_USER=\).\**\1'"${RUNNER_USER}"'*' \
-    rel/mongooseim/bin/mongooseim > ${INSTALL_DIR}/bin/mongooseim
-if [ -n "${BIN_DIR}" ]; then
-    install $INSTALL_OPTS -d ${BIN_DIR}
-    install $INSTALL_OPTS rel/mongooseim/bin/mongooseimctl ${BIN_DIR}/mongooseimctl
-    ## TODO: this sed line will become redundant once reltool is capable of putting correct values in
-    sed -e 's*\(RUNNER_SCRIPT_DIR=\).\**\1'"${INSTALL_DIR}"'/bin*' \
-        rel/mongooseim/bin/mongooseimctl > ${BIN_DIR}/mongooseimctl
-    chmod 550 ${BIN_DIR}/mongooseimctl
-fi
+    rel/mongooseim/bin/mongooseim > ${LIB_DIR}/bin/mongooseim
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${LOG_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${MDB_DIR}
 
 ## Do the bookkeeping.
 ## TODO: How to automate this? If done manually, there's always space for a cock-up.
-find ${INSTALL_DIR} > install.log
-if [ "${SYSTEM}" == "yes" ]; then
-    echo ${BIN_DIR} >> install.log
-    echo ${BIN_DIR}/mongooseimctl >> install.log
-fi
-echo \# MongooseIM successfully installed to ${INSTALL_DIR} | tee -a install.log > /dev/fd/2
+LOG=install.log
+echo > $LOG
+log () {
+    local file=$1
+    echo $file >> $LOG
+}
+[ x"$SYSTEM" == x"yes" ] && log ${BIN_DIR}
+[ x"$SYSTEM" == x"yes" ] && log ${BIN_DIR}/mongooseimctl
+[ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}
+[ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/app.config
+[ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/ejabberd.cfg
+[ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/vm.args
+find ${LIB_DIR} >> $LOG
+[ x"$SYSTEM" == x"yes" ] && log ${LOG_DIR}
+[ x"$SYSTEM" == x"yes" ] && log ${MDB_DIR}
+
+## Voila!
+echo MongooseIM successfully installed to ${LIB_DIR} > /dev/fd/2

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -11,21 +11,16 @@ rm configure.out rel/configure.vars.config rel/vars.config
 rm -rf rel/mongooseim; RUNNER_GROUP=staff make install
 cd $TARGET
 git init
-git commit --allow-empty -m "first empty"
+git commit --allow-empty -m "1st empty"
 git add .
-git commit -m "first non-empty"
+git commit -m "1st non-empty"
 $TARGET/usr/bin/mongooseimctl start
-$TARGET/usr/bin/mongooseimctl started
+$TARGET/usr/bin/mongooseimctl started && echo node: started
 $TARGET/usr/bin/mongooseimctl status
 $TARGET/usr/bin/mongooseimctl stop
-$TARGET/usr/bin/mongooseimctl stopped
-$TARGET/usr/bin/mongooseimctl status || echo node down: ok, this is expected
-ps aux | grep 'bea[m]'
-running=$?
-if [ $running -eq 0 ];  then
-	echo node still running, but should not
-	exit 1
-fi
+$TARGET/usr/bin/mongooseimctl stopped && echo node: stopped
+$TARGET/usr/bin/mongooseimctl status || echo status failed: this might be ok
+ps aux | grep 'bea[m]' && { echo "node still running, but should not"; exit 1; }
 git status
 tree $TARGET -L 3
 echo $0: all ok

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -5,8 +5,8 @@ set -e
 
 TARGET=/tmp/mim-sandbox-system
 
-rm -rf $TARGET
-rm configure.out rel/configure.vars.config rel/vars.config
+rm -rf $TARGET || :
+rm configure.out rel/configure.vars.config rel/vars.config || :
 ./tools/configure with-all user=erszcz prefix=$TARGET \
     system=yes && cat configure.out rel/configure.vars.config
 rm -rf rel/mongooseim; RUNNER_GROUP=staff make install

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+## Propagate failures
 set -e
 
 TARGET=/tmp/mim-sandbox-system
@@ -28,6 +29,6 @@ done
 ps aux | grep 'bea[m]' && { echo "node still running, but should not"; exit 1; }
 git add .
 git commit -m "2nd non-empty"
-git --no-pager show --format= --name-only
-tree $TARGET -L 3
+echo changed files: && git --no-pager show --format= --name-only
+echo -n "tree: " && tree $TARGET -L 3
 echo $0: all ok

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -21,6 +21,8 @@ $TARGET/usr/bin/mongooseimctl stop
 $TARGET/usr/bin/mongooseimctl stopped && echo node: stopped
 $TARGET/usr/bin/mongooseimctl status || echo status failed: this might be ok
 ps aux | grep 'bea[m]' && { echo "node still running, but should not"; exit 1; }
-git status
+git add .
+git commit -m "2nd non-empty"
+git --no-pager show --format= --name-only
 tree $TARGET -L 3
 echo $0: all ok

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -20,6 +20,11 @@ $TARGET/usr/bin/mongooseimctl status
 $TARGET/usr/bin/mongooseimctl stop
 $TARGET/usr/bin/mongooseimctl stopped && echo node: stopped
 $TARGET/usr/bin/mongooseimctl status || echo status failed: this might be ok
+retries=10
+while ps aux | grep 'bea[m]' && [ $retries -gt 0 ]; do
+    retries=$(expr $retries - 1)
+    sleep 0.5s
+done
 ps aux | grep 'bea[m]' && { echo "node still running, but should not"; exit 1; }
 git add .
 git commit -m "2nd non-empty"

--- a/tools/test-install.sh
+++ b/tools/test-install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+set -e
+
+TARGET=/tmp/mim-sandbox-system
+
+rm -rf $TARGET
+rm configure.out rel/configure.vars.config rel/vars.config
+./tools/configure with-all user=erszcz prefix=$TARGET \
+    system=yes && cat configure.out rel/configure.vars.config
+rm -rf rel/mongooseim; RUNNER_GROUP=staff make install
+cd $TARGET
+git init
+git commit --allow-empty -m "first empty"
+git add .
+git commit -m "first non-empty"
+$TARGET/usr/bin/mongooseimctl start
+$TARGET/usr/bin/mongooseimctl started
+$TARGET/usr/bin/mongooseimctl status
+$TARGET/usr/bin/mongooseimctl stop
+$TARGET/usr/bin/mongooseimctl stopped
+$TARGET/usr/bin/mongooseimctl status || echo node down: ok, this is expected
+ps aux | grep 'bea[m]'
+running=$?
+if [ $running -eq 0 ];  then
+	echo node still running, but should not
+	exit 1
+fi
+git status
+tree $TARGET -L 3
+echo $0: all ok


### PR DESCRIPTION
This PR partially addresses #689 and issues mentioned therein.

It's now possible to install MongooseIM from source in two modes: so called `system` and unnamed, but let's say, `user` mode. The better tested mode is `system` as it's internally used to generate RPM packages.

An environment for building (as of now RPM) packages is accessible by cloning ESL-internal [command line interface](https://gitlab.erlang-solutions.com/current-projects/necromancer-cli).

### System install

To manually test the installation one can run `tools/test-install.sh`. This script is intended for careful inspection by a human user, not for automation. Results should be similar to those described below.

On Mac:

```sh
./tools/configure with-all user=erszcz prefix=/tmp/mim-sandbox-system system=yes
cat configure.out rel/configure.vars.config
RUNNER_GROUP=staff make install
```

Overriding `RUNNER_GROUP` on a Mac is necessary, as user's by default don't have private groups of the same name as their usernames.

Generated build configs:

```sh
$ cat configure.out rel/configure.vars.config
export MONGOOSEIM_CONFIGURED="yes"
export APPS="seestar mysql odbc pgsql redo riakc riak_pb protobuffs"
export PREFIX="/tmp/mim-sandbox-system"
export RELTOOL_VARS="rel/configure.vars.config"
export RUNNER_USER="erszcz"
export SYSTEM="yes"
export BIN_DIR="$PREFIX/usr/bin"
export ETC_DIR="$PREFIX/etc/mongooseim"
export LIB_DIR="$PREFIX/usr/lib/mongooseim"
export LOG_DIR="$PREFIX/var/log/mongooseim"
export MDB_DIR="$PREFIX/var/lib/mongooseim"
export LOCK_DIR="$PREFIX/var/lock/mongooseim"
{mongooseim_runner_user, "erszcz"}.
{mongooseim_script_dir, "/tmp/mim-sandbox-system/usr/lib/mongooseim/bin"}.
{mongooseim_etc_dir, "/tmp/mim-sandbox-system/etc/mongooseim"}.
{mongooseim_log_dir, "/tmp/mim-sandbox-system/var/log/mongooseim"}.
{mongooseim_mdb_dir, "/tmp/mim-sandbox-system/var/lib/mongooseim"}.
{mongooseim_mdb_dir_toggle, []}.
{mongooseim_lock_dir, "/tmp/mim-sandbox-system/var/lock/mongooseim"}.
```

Installed tree:

```
$ tree mim-sandbox-system/ -L 3
mim-sandbox-system/
├── etc
│   └── mongooseim
│       ├── app.config
│       ├── ejabberd.cfg
│       └── vm.args
├── usr
│   ├── bin
│   │   └── mongooseimctl
│   └── lib
│       └── mongooseim
└── var
    ├── lib
    │   └── mongooseim
    ├── lock
    │   └── mongooseim
    └── log
        └── mongooseim

13 directories, 4 files
```

Files which change after starting and stopping such an installation:

```
var/lib/mongooseim/DECISION_TAB.LOG
var/lib/mongooseim/LATEST.LOG
var/lib/mongooseim/last_activity.DCD
var/lib/mongooseim/muc_registered.DCD
var/lib/mongooseim/muc_room.DCD
var/lib/mongooseim/offline_msg.DAT
var/lib/mongooseim/passwd.DCD
var/lib/mongooseim/privacy.DCD
var/lib/mongooseim/private_storage.DAT
var/lib/mongooseim/roster.DCD
var/lib/mongooseim/roster_version.DCD
var/lib/mongooseim/schema.DAT
var/lib/mongooseim/vcard.DAT
var/lib/mongooseim/vcard_search.DCD
var/log/mongooseim/crash.log
var/log/mongooseim/ejabberd.log
var/log/mongooseim/erlang.log.1
var/log/mongooseim/run_erl.log
```


### Breaking changes

- `rel/vars.config` is now a generated file. Tests **will** break if it's missing. AFAIK some tests use it to restart / reconfigure nodes on the fly - I have a hunch these tests go too far, that is assume too much about the environment they are run in.

- Format of `mongooseimctl status` is now different - it should be easier to parse and more human-readable, but might break scripts.


### Caveats

- Running `make install` will blindly overwrite any configs it encounters on its way. Mnesia database and log files are preserved only due to the fact that they're not build process artifacts.