### PR TITLE
TCP backlog improvements

### DIFF
--- a/apps/ejabberd/src/ejabberd_listener.erl
+++ b/apps/ejabberd/src/ejabberd_listener.erl
@@ -116,6 +116,7 @@ start_dependent(Port, Module, Opts) ->
 init(PortIP, Module, RawOpts) ->
     {Port, IPT, IPS, IPV, Proto, OptsClean} = parse_listener_portip(PortIP, RawOpts),
     {Opts, SockOpts} = prepare_opts(IPT, IPV, OptsClean),
+
     if Proto == udp ->
             init_udp(PortIP, Module, Opts, SockOpts, Port, IPS);
        true ->
@@ -173,13 +174,14 @@ listen_tcp(PortIPProto, Module, SockOpts, Port, IPS) ->
             ListenSocket;
         _ ->
             Res = gen_tcp:listen(Port, [binary,
+                                        {backlog, 100},
                                         {packet, 0},
                                         {active, false},
                                         {reuseaddr, true},
                                         {nodelay, true},
                                         {send_timeout, ?TCP_SEND_TIMEOUT},
                                         {keepalive, true},
-                                        {send_timeout_close, true}]),
+                                        {send_timeout_close, true} | SockOpts]),
             case Res of
                 {ok, ListenSocket} ->
                     ListenSocket;
@@ -187,6 +189,7 @@ listen_tcp(PortIPProto, Module, SockOpts, Port, IPS) ->
                     socket_error(Reason, PortIPProto, Module, SockOpts, Port, IPS)
             end
     end.
+
 
 %% @spec (PortIP, Opts) -> {Port, IPT, IPS, IPV, OptsClean}
 %% where

--- a/apps/ejabberd/test/ejabberd_listener_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_listener_SUITE.erl
@@ -1,0 +1,31 @@
+-module(ejabberd_listener_SUITE).
+
+-compile([export_all]).
+
+all() ->
+    [tcp_socket_is_started_with_options].
+
+
+tcp_socket_is_started_with_options(_C) ->
+
+    meck:new(gen_tcp, [unstick, passthrough]),
+    meck:expect(gen_tcp, listen, fun(Port, Opts) ->
+                                         meck:passthrough([Port, Opts])
+                                 end),
+
+    OverrideBacklog = {backlog, 50},
+    {ok, _Pid} = listener_started([OverrideBacklog]),
+
+    [{_Pid, {gen_tcp, listen, [_, Opts]}, _Result}] =  meck:history(gen_tcp),
+
+    DefaultBacklog = {backlog, 100},
+    [DefaultBacklog, OverrideBacklog] = proplists:lookup_all(backlog, Opts),
+
+    meck:unload(gen_tcp).
+
+listener_started(Opts) ->
+    ets:new(listen_sockets, [named_table, public]),
+    proc_lib:start_link(ejabberd_listener, init, [tcp_port_ip(), ?MODULE, Opts]).
+
+tcp_port_ip() ->
+    {1805, {0,0,0,0}, tcp}.

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -19,6 +19,7 @@ Handles pure XMPP connections, relies on `ejabberd_listener` for listening. It p
 * `access` (atom, default: `c2s`) - Access Rule to use for C2S connections.
 * `c2s_shaper` (atom, default: `c2s_shaper`) - Connection shaper to use for incoming C2S stanzas.
 * `max_stanza_size` (positive integer, default: 65536) - Maximum allowed incoming stanza size. **Warning:** this limit is checked **after** input data parsing, so it does not limit the input data size itself.
+* `backlog` (positive integer, default 100) - overrides default tcp backlog value
 
 ## ejabberd_cowboy
 

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -86,7 +86,7 @@ run_tests() {
 	exit ${RESULT}
 }
 
-if [ $PRESET = "dialyzer_only" ]; then
+if [ $PRESET == "dialyzer_only" ]; then
 	make dialyzer
 
 else


### PR DESCRIPTION
Proposed changes include:
* increased tcp backlog for ejabberd_listeners
* fix passing tcp opts from config file
* test for default and passed backlog parameter

Also this PR is important to allow running parallel tests, introduced in #706, on MacOS X. Together with @pzel we discovered (mainly based on blogpost [1]) that the backlog queue implementation on MacOS X is less efficient than on linux. Too low backlog on MongooseIM side for port 5222 manifests by strange `{error,econnreset}`

[1]. http://veithen.github.io/2014/01/01/how-tcp-backlog-works-in-linux.html
