### PR TITLE
Add ByteaAsLongVarBinary option to odbc.ini for Travis

### DIFF
--- a/apps/ejabberd/src/mod_auth_token_odbc.erl
+++ b/apps/ejabberd/src/mod_auth_token_odbc.erl
@@ -16,10 +16,10 @@ get_valid_sequence_number(#jid{lserver = LServer} = JID) ->
     BBareJID = jid:to_binary(jid:to_bare(JID)),
     EBareJID = ejabberd_odbc:escape(BBareJID),
     Q = valid_sequence_number_query(EBareJID),
-    [{updated, undefined},
+    [{updated, _},
      {updated, _},
      {selected, _, [{BSeqNo}]},
-     {updated, undefined}] = ejabberd_odbc:sql_query(LServer, Q),
+     {updated, _}] = ejabberd_odbc:sql_query(LServer, Q),
     binary_to_integer(BSeqNo).
 
 valid_sequence_number_query(EOwner) when is_binary(EOwner) ->

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -25,14 +25,15 @@ elif [ $DB = 'pgsql' ]; then
     psql -U postgres -q -d ejabberd -f ${SQLDIR}/pg.sql
     cat > ~/.odbc.ini << EOL
 [ejabberd-pgsql]
-Driver      = PostgreSQL Unicode
-ServerName  = localhost
-Port        = 5432
-Database    = ejabberd
-Username    = ejabberd
-Password    = ${TRAVIS_DB_PASSWORD}
-Protocol    = 9.3.5
-Debug       = 1
+Driver               = PostgreSQL Unicode
+ServerName           = localhost
+Port                 = 5432
+Database             = ejabberd
+Username             = ejabberd
+Password             = ${TRAVIS_DB_PASSWORD}
+Protocol             = 9.3.5
+Debug                = 1
+ByteaAsLongVarBinary = 1
 EOL
 
 elif [ $DB = 'riak' ]; then


### PR DESCRIPTION
Proposed changes include:
* odbc settings for the Travis build now include the ``ByteaAsLongVarBinary`` setting to make sure that columns containing binary data are fetched as such, not as strings


