### PR TITLE
Add an option to log stanzas in CT tests.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
   {base16, ".*", {git, "git://github.com/goj/base16.git", "1e9dd28bdbcfb"}},
   {cuesport, ".*", {git, "git://github.com/esl/cuesport.git", "d82ff25"}},
   {redo, ".*", {git, "git://github.com/JacobVorreuter/redo.git", "7c7eaef"}},
-  {exml, ".*", {git, "git://github.com/esl/exml.git", "2.2.0"}},
+  {exml, ".*", {git, "git://github.com/esl/exml.git", {branch, "clean_to_iolist"}}},
   {lager, ".*", {git, "git://github.com/basho/lager.git", "3.0.3"}},
   {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", "1.0.4"}},
   {exometer, ".*", {git, "git://github.com/esl/exometer.git", {branch, "1.1-patched"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
   {base16, ".*", {git, "git://github.com/goj/base16.git", "1e9dd28bdbcfb"}},
   {cuesport, ".*", {git, "git://github.com/esl/cuesport.git", "d82ff25"}},
   {redo, ".*", {git, "git://github.com/JacobVorreuter/redo.git", "7c7eaef"}},
-  {exml, ".*", {git, "git://github.com/esl/exml.git", {branch, "clean_to_iolist"}}},
+  {exml, ".*", {git, "git://github.com/esl/exml.git", "2547164950b65a86b79a5a5669821cff9bde17a7"}},
   {lager, ".*", {git, "git://github.com/basho/lager.git", "3.0.3"}},
   {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", "1.0.4"}},
   {exometer, ".*", {git, "git://github.com/esl/exometer.git", {branch, "1.1-patched"}}},

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,8 +4,8 @@
 {require_otp_vsn, "R?1[45678]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "stanza_log"}}},
-        {exml, ".*", {git, "git://github.com/esl/exml.git", {branch, "clean_to_iolist"}}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "07119b4c597872f5ef4b1a47bba86317af909018"}},
+        {exml, ".*", {git, "git://github.com/esl/exml.git", "2547164950b65a86b79a5a5669821cff9bde17a7"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},
         {katt, ".*", {git, "git://github.com/for-GET/katt.git", {tag, "1.3.1-rc"}}},

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,8 +4,8 @@
 {require_otp_vsn, "R?1[45678]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "5bf799a"}},
-        {exml, ".*", {git, "git://github.com/esl/exml.git", "2.2.0"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "stanza_log"}}},
+        {exml, ".*", {git, "git://github.com/esl/exml.git", {branch, "clean_to_iolist"}}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},
         {katt, ".*", {git, "git://github.com/for-GET/katt.git", {tag, "1.3.1-rc"}}},

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -44,6 +44,9 @@
 %% {escalus_user_db, {module, YourModule}}.
 %% {escalus_user_db, {module, YourModule, ListOfOptions}}.
 
+%% Log all stanzas sent and received (consumed) in the test cases
+%% {stanza_log, true}.
+
 {escalus_users, [
     {alice, [
         {username, <<"alicE">>},

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -2058,21 +2058,21 @@ maybe_start_elem(undefined) ->
 maybe_start_elem(BStart) ->
     #xmlel{
         name = <<"start">>,
-        children = #xmlcdata{content = BStart}}.
+        children = [#xmlcdata{content = BStart}]}.
 
 maybe_end_elem(undefined) ->
     undefined;
 maybe_end_elem(BEnd) ->
     #xmlel{
         name = <<"end">>,
-        children = #xmlcdata{content = BEnd}}.
+        children = [#xmlcdata{content = BEnd}]}.
 
 maybe_with_elem(undefined) ->
     undefined;
 maybe_with_elem(BWithJID) ->
     #xmlel{
         name = <<"with">>,
-        children = #xmlcdata{content = BWithJID}}.
+        children = [#xmlcdata{content = BWithJID}]}.
 
 %% An optional 'queryid' attribute allows the client to match results to
 %% a certain query.
@@ -2178,14 +2178,14 @@ stanza_lookup_messages_iq_v02(P, QueryId, BStart, BEnd, BWithJID, RSM) ->
     }]).
 
 maybe_simple_elem(#rsm_in{simple=true}) ->
-    [#xmlel{name = <<"simple">>}];
+    #xmlel{name = <<"simple">>};
 maybe_simple_elem(_) ->
-    [].
+    undefined.
 
 maybe_opt_count_elem(#rsm_in{opt_count=true}) ->
-    [#xmlel{name = <<"opt_count">>}];
+    #xmlel{name = <<"opt_count">>};
 maybe_opt_count_elem(_) ->
-    [].
+    undefined.
 
 border_attributes(undefined) ->
     [];
@@ -2205,29 +2205,29 @@ maybe_rsm_elem(#rsm_in{max=Max, direction=Direction, id=Id, index=Index}) ->
                 maybe_rsm_index(Index),
                 maybe_rsm_direction(Direction, Id)])}.
 
-maybe_rsm_id(undefined) -> [];
-maybe_rsm_id(Id) -> #xmlcdata{content = Id}.
+rsm_id_children(undefined) -> [];
+rsm_id_children(Id) -> [#xmlcdata{content = Id}].
 
 maybe_rsm_direction(undefined, undefined) ->
     undefined;
 maybe_rsm_direction(Direction, Id) ->
     #xmlel{
         name = atom_to_binary(Direction, latin1),
-        children = maybe_rsm_id(Id)}.
+        children = rsm_id_children(Id)}.
 
 maybe_rsm_index(undefined) ->
     undefined;
 maybe_rsm_index(Index) when is_integer(Index) ->
     #xmlel{
         name = <<"index">>,
-        children = #xmlcdata{content = integer_to_list(Index)}}.
+        children = [#xmlcdata{content = integer_to_list(Index)}]}.
 
 maybe_rsm_max(undefined) ->
     undefined;
 maybe_rsm_max(Max) when is_integer(Max) ->
     #xmlel{
         name = <<"max">>,
-        children = #xmlcdata{content = integer_to_list(Max)}}.
+        children = [#xmlcdata{content = integer_to_list(Max)}]}.
 
 add_with_jid(BWithJID,
     IQ=#xmlel{children=[

--- a/test/ejabberd_tests/tests/metrics_c2s_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_c2s_SUITE.erl
@@ -254,7 +254,7 @@ error_presence(Config) ->
         escalus:wait_for_stanza(Bob),
 
         ErrorElt = escalus_stanza:error_element(<<"cancel">>, <<"gone">>),
-        Presence = escalus_stanza:presence_direct(alice, <<"error">>, ErrorElt),
+        Presence = escalus_stanza:presence_direct(alice, <<"error">>, [ErrorElt]),
         escalus:send(Bob, Presence),
         escalus:wait_for_stanza(Alice),
 

--- a/test/ejabberd_tests/tests/mod_time_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_time_SUITE.erl
@@ -99,8 +99,8 @@ time_request_stanza(Server, ID) ->
     #xmlel{name = <<"iq">>,
            attrs = [{<<"type">>, <<"get">>},
                     {<<"id">>, ID}, {<<"to">>, Server}],
-           children = #xmlel{name = <<"time">>,
-                             attrs = [{<<"xmlns">>, ?NS_TIME}]}}.
+           children = [#xmlel{name = <<"time">>,
+                              attrs = [{<<"xmlns">>, ?NS_TIME}]}]}.
 
 check_ns(#xmlel{name = <<"iq">>, attrs = _, children = [Child]}) ->
     case Child of

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3813,29 +3813,29 @@ maybe_rsm_elem(#rsm_in{max=Max, direction=Direction, id=Id, index=Index}) ->
                 maybe_rsm_index(Index),
                 maybe_rsm_direction(Direction, Id)])}.
 
-maybe_rsm_id(undefined) -> [];
-maybe_rsm_id(Id) -> #xmlcdata{content = Id}.
+rsm_id_children(undefined) -> [];
+rsm_id_children(Id) -> [#xmlcdata{content = Id}].
 
 maybe_rsm_direction(undefined, undefined) ->
     undefined;
 maybe_rsm_direction(Direction, Id) ->
     #xmlel{
         name = atom_to_binary(Direction, latin1),
-        children = maybe_rsm_id(Id)}.
+        children = rsm_id_children(Id)}.
 
 maybe_rsm_index(undefined) ->
     undefined;
 maybe_rsm_index(Index) when is_integer(Index) ->
     #xmlel{
         name = <<"index">>,
-        children = #xmlcdata{content = integer_to_list(Index)}}.
+        children = [#xmlcdata{content = integer_to_list(Index)}]}.
 
 maybe_rsm_max(undefined) ->
     undefined;
 maybe_rsm_max(Max) when is_integer(Max) ->
     #xmlel{
         name = <<"max">>,
-        children = #xmlcdata{content = integer_to_list(Max)}}.
+        children = [#xmlcdata{content = integer_to_list(Max)}]}.
 
 skip_undefined(Xs) ->
     [X || X <- Xs, X =/= undefined].
@@ -4165,7 +4165,7 @@ stanza_set_roles(Room, List) ->
         attrs = [{<<"nick">>, Nick}, {<<"role">>, Role}],
         children = [#xmlel{
             name = <<"reason">>,
-            children = #xmlcdata{content = Reason}}
+            children = [#xmlcdata{content = Reason}]}
         ]}
     end, List),
     stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
@@ -4179,7 +4179,7 @@ stanza_set_affiliations(Room, List) ->
         attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}],
         children = [#xmlel{
             name = <<"reason">>,
-            children = #xmlcdata{content = Reason}}
+            children = [#xmlcdata{content = Reason}]}
         ]}
     end, List),
     stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
@@ -4209,10 +4209,10 @@ stanza_ban_user(User, Room, Reason) ->
 
 stanza_join_room(Room, Nick) ->
     stanza_to_room(#xmlel{name = <<"presence">>, children =
-        #xmlel{
+        [#xmlel{
             name = <<"x">>,
             attrs = [{<<"xmlns">>,<<"http://jabber.org/protocol/muc">>}]
-        }
+        }]
     },Room, Nick).
 
 %% stanza with multiple x subelements - empathy send additional x's
@@ -4230,7 +4230,7 @@ stanza_join_room_many_x_elements(Room, Nick) ->
 
 stanza_voice_request_form(Room) ->
     Payload = [ form_field({<<"muc#role">>, <<"participant">>, <<"text-single">>}) ],
-    stanza_message_to_room(Room, stanza_form(Payload, ?NS_MUC_REQUEST)).
+    stanza_message_to_room(Room, [stanza_form(Payload, ?NS_MUC_REQUEST)]).
 
 stanza_voice_request_approval(Room, JID, Nick) ->
     Items = [{<<"muc#role">>, <<"participant">>, <<"text-single">>},
@@ -4238,14 +4238,14 @@ stanza_voice_request_approval(Room, JID, Nick) ->
         {<<"muc#roomnick">>, Nick, <<"text-single">>},
         {<<"muc#request_allow">>, <<"true">>, <<"boolean">>}],
     Payload = [ form_field(El) || El <- Items],
-    stanza_message_to_room(Room, stanza_form(Payload, ?NS_MUC_REQUEST)).
+    stanza_message_to_room(Room, [stanza_form(Payload, ?NS_MUC_REQUEST)]).
 
 stanza_voice_request_approval_nonick(Room, JID) ->
     Items = [{<<"muc#role">>, <<"participant">>, <<"text-single">>},
         {<<"muc#jid">>, JID, <<"jid-single">>},
         {<<"muc#request_allow">>, <<"true">>, <<"boolean">>}],
     Payload = [ form_field(El) || El <- Items],
-    stanza_message_to_room(Room, stanza_form(Payload, ?NS_MUC_REQUEST)).
+    stanza_message_to_room(Room, [stanza_form(Payload, ?NS_MUC_REQUEST)]).
 
 stanza_configuration_form(Room, Params) ->
     DefaultParams = [],
@@ -4256,13 +4256,13 @@ stanza_configuration_form(Room, Params) ->
         DefaultParams, Params) ++ Params,
     Payload = [ form_field(FieldData) || FieldData <- FinalParams ],
     stanza_to_room(escalus_stanza:iq_set(
-          ?NS_MUC_OWNER, stanza_form(Payload, ?NS_MUC_ROOMCONFIG)), Room).
+          ?NS_MUC_OWNER, [stanza_form(Payload, ?NS_MUC_ROOMCONFIG)]), Room).
 
 stanza_cancel(Room) ->
-    Payload = #xmlel{
+    Payload = [#xmlel{
         name = <<"x">>,
         attrs = [{<<"xmlns">>,<<"jabber:x:data">>}, {<<"type">>,<<"cancel">>}]
-    },
+    }],
     stanza_to_room(escalus_stanza:iq_set(
           ?NS_MUC_OWNER, Payload), Room).
 

--- a/test/ejabberd_tests/tests/oauth_SUITE.erl
+++ b/test/ejabberd_tests/tests/oauth_SUITE.erl
@@ -151,7 +151,7 @@ request_tokens_once_logged_in_impl(Config, User) ->
     escalus:story(Config, [{User, 1}], fun(Client) ->
                                                ClientShortJid = escalus_utils:get_short_jid(Client),
                                                R = escalus_stanza:query_el(?NS_ESL_TOKEN_AUTH, []),
-                                               IQ = escalus_stanza:iq(ClientShortJid, <<"get">>, R),
+                                               IQ = escalus_stanza:iq(ClientShortJid, <<"get">>, [R]),
                                                escalus:send(Client, IQ),
                                                Result = escalus:wait_for_stanza(Client),
                                                {AT, RT} = extract_tokens(Result),


### PR DESCRIPTION
To enable it, uncomment the following line:
   `   {stanza_log, true}.`
in test config.

The log contains only stanzas which have JID defined and are:
-  either sent using escalus_connection
-  or received (not peeked) in escalus_client.
