### PR TITLE
Configurable routing mech

### DIFF
--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -70,14 +70,6 @@
 
 -type scram() :: #scram{}.
 
--type handler() :: 'undefined'
-| {'apply_fun',fun((_,_,_) -> any())}
-| {'apply', M::atom(), F::atom()}.
--type domain() :: binary().
+-record(route, {domain, handler}).
 
--record(route, {domain :: domain(),
-    handler :: handler()
-}).
-
--record(external_component, {domain  :: domain(),
-    handler :: handler()}).
+-record(external_component, {domain, handler}).

--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -70,3 +70,14 @@
 
 -type scram() :: #scram{}.
 
+-type handler() :: 'undefined'
+| {'apply_fun',fun((_,_,_) -> any())}
+| {'apply', M::atom(), F::atom()}.
+-type domain() :: binary().
+
+-record(route, {domain :: domain(),
+    handler :: handler()
+}).
+
+-record(external_component, {domain  :: domain(),
+    handler :: handler()}).

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -567,6 +567,8 @@ process_term(Term, State) ->
             add_option(registration_timeout, Timeout, State);
         {mongooseimctl_access_commands, ACs} ->
             add_option(mongooseimctl_access_commands, ACs, State);
+        {routing_modules, Mods} ->
+            add_option(routing_modules, Mods, State);
         {loglevel, Loglevel} ->
             ejabberd_loglevel:set(Loglevel),
             State;

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -151,7 +151,7 @@ route(From, To, Packet) ->
                 [jid:to_binary(From), jid:to_binary(To),
                     ?MODULE, Reason, exml:to_binary(Packet),
                     erlang:get_stacktrace()]);
-        Res -> Res
+        _ -> ok
     end.
 
 filter(From, To, Packet) ->

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -145,7 +145,14 @@ process_iq_reply(From, To, #iq{id = ID} = IQ) ->
             To :: ejabberd:jid(),
             Packet :: jlib:xmlel()) -> 'ok' | {'error','lager_not_running'}.
 route(From, To, Packet) ->
-    xmpp_router:route_wrap(?MODULE, From, To, Packet).
+    case (catch do_route(From, To, Packet)) of
+        {'EXIT', Reason} ->
+            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
+                [jid:to_binary(From), jid:to_binary(To),
+                    ?MODULE, Reason, exml:to_binary(Packet),
+                    erlang:get_stacktrace()]);
+        Res -> Res
+    end.
 
 filter(From, To, Packet) ->
     {From, To, Packet}.

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -34,6 +34,7 @@
 -export([start_link/0]).
 
 -export([route/3,
+         filter/3,
          route_iq/4,
          route_iq/5,
          process_iq_reply/3,
@@ -144,7 +145,10 @@ process_iq_reply(From, To, #iq{id = ID} = IQ) ->
             To :: ejabberd:jid(),
             Packet :: jlib:xmlel()) -> 'ok' | {'error','lager_not_running'}.
 route(From, To, Packet) ->
-    xmpp_router:route(?MODULE, From, To, Packet).
+    xmpp_router:route_wrap(?MODULE, From, To, Packet).
+
+filter(From, To, Packet) ->
+    {From, To, Packet}.
 
 -spec route_iq(From :: ejabberd:jid(),
                To :: ejabberd:jid(),

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -28,13 +28,11 @@
 -author('alexey@process-one.net').
 
 -behaviour(gen_server).
--behaviour(xmpp_router).
 
 %% API
 -export([start_link/0]).
 
 -export([route/3,
-         filter/3,
          route_iq/4,
          route_iq/5,
          process_iq_reply/3,
@@ -153,9 +151,6 @@ route(From, To, Packet) ->
                     erlang:get_stacktrace()]);
         _ -> ok
     end.
-
-filter(From, To, Packet) ->
-    {From, To, Packet}.
 
 -spec route_iq(From :: ejabberd:jid(),
                To :: ejabberd:jid(),

--- a/apps/ejabberd/src/ejabberd_local_delivery.erl
+++ b/apps/ejabberd/src/ejabberd_local_delivery.erl
@@ -1,0 +1,34 @@
+%%%-------------------------------------------------------------------
+%%% @author bartek
+%%% @copyright (C) 2016, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 21. Mar 2016 12:24
+%%%-------------------------------------------------------------------
+-module(ejabberd_local_delivery).
+-author("bartek").
+
+-include("jlib.hrl").
+
+%% API
+-export([do_local_route/5]).
+
+
+do_local_route(OrigFrom, OrigTo, OrigPacket, LDstDomain, Handler) ->
+    %% Filter locally
+    case ejabberd_hooks:run_fold(filter_local_packet, LDstDomain,
+        {OrigFrom, OrigTo, OrigPacket}, []) of
+        {From, To, Packet} ->
+            case Handler of
+                {apply_fun, Fun} ->
+                    Fun(From, To, Packet);
+                {apply, Module, Function} ->
+                    Module:Function(From, To, Packet)
+            end;
+        drop ->
+            ejabberd_hooks:run(xmpp_stanza_dropped,
+                OrigFrom#jid.lserver,
+                [OrigFrom, OrigTo, OrigPacket]),
+            ok
+    end.

--- a/apps/ejabberd/src/ejabberd_local_delivery.erl
+++ b/apps/ejabberd/src/ejabberd_local_delivery.erl
@@ -12,10 +12,10 @@
 -include("jlib.hrl").
 
 %% API
--export([do_local_route/5]).
+-export([do_route/5]).
 
 
-do_local_route(OrigFrom, OrigTo, OrigPacket, LDstDomain, Handler) ->
+do_route(OrigFrom, OrigTo, OrigPacket, LDstDomain, Handler) ->
     %% Filter locally
     case ejabberd_hooks:run_fold(filter_local_packet, LDstDomain,
         {OrigFrom, OrigTo, OrigPacket}, []) of

--- a/apps/ejabberd/src/ejabberd_local_delivery.erl
+++ b/apps/ejabberd/src/ejabberd_local_delivery.erl
@@ -1,10 +1,8 @@
 %%%-------------------------------------------------------------------
-%%% @author bartek
-%%% @copyright (C) 2016, <COMPANY>
 %%% @doc
-%%%
+%%% Completes delivery to local recipient or a component; called by
+%%% main routing chain if it finds a handler to direct the message to.
 %%% @end
-%%% Created : 21. Mar 2016 12:24
 %%%-------------------------------------------------------------------
 -module(ejabberd_local_delivery).
 -author("bartek").

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -98,7 +98,7 @@ start_link() ->
     Packet :: jlib:xmlel()) -> ok.
 route(From, To, Packet) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
-        [From, To, Packet]),
+           [From, To, Packet]),
     route(From, To, Packet, routing_modules_list()).
 
 %% Route the error packet only if the originating packet is not an error itself.

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -118,7 +118,7 @@ route_error(From, To, ErrPacket, OrigPacket) ->
 
 -spec register_components([Domain :: domain()]) -> ok | {error, any()}.
 register_components(Domains) ->
-    LDomains = [{jlib:nameprep(Domain), Domain} || Domain <- Domains],
+    LDomains = [{jid:nameprep(Domain), Domain} || Domain <- Domains],
     Handler = make_handler(undefined),
     F = fun() ->
             [do_register_component(LDomain, Handler) || LDomain <- LDomains],
@@ -147,7 +147,7 @@ do_register_component({LDomain, _}, Handler) ->
 
 -spec unregister_components([Domains :: domain()]) -> {atomic, ok}.
 unregister_components(Domains) ->
-    LDomains = [{jlib:nameprep(Domain), Domain} || Domain <- Domains],
+    LDomains = [{jid:nameprep(Domain), Domain} || Domain <- Domains],
     F = fun() ->
             [do_unregister_component(LDomain) || LDomain <- LDomains],
             ok

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -337,33 +337,33 @@ route(_, _, _, []) ->
     ok; %% shouldn't we raise error here? If we get here means we don't know
     %% how to route this message...
 route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
-    ?DEBUG({using, M}),
+    ?DEBUG("Using module ~p", [M]),
     case (catch M:filter(OrigFrom, OrigTo, OrigPacket)) of
         {'EXIT', Reason} ->
-            ?DEBUG({filtering, error}),
+            ?DEBUG("Filtering error", []),
             ?ERROR_MSG("error when filtering from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
                 [jid:to_binary(OrigFrom), jid:to_binary(OrigTo),
                     M, Reason, exml:to_binary(OrigPacket),
                     erlang:get_stacktrace()]),
             ok;
         drop ->
-            ?DEBUG({filter, dropped}),
+            ?DEBUG("filter dropped packet", []),
             ok;
         {OrigFrom, OrigTo, OrigPacket} ->
-            ?DEBUG({filter, passed}),
+            ?DEBUG("filter passed", []),
             case catch(M:route(OrigFrom, OrigTo, OrigPacket)) of
                 {'EXIT', Reason} ->
                     ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
                         [jid:to_binary(OrigFrom), jid:to_binary(OrigTo),
                             M, Reason, exml:to_binary(OrigPacket),
                             erlang:get_stacktrace()]),
-                    ?DEBUG({routing, error}),
+                    ?DEBUG("routing error", []),
                     ok;
                 done ->
-                    ?DEBUG({routing, done}),
+                    ?DEBUG("routing done", []),
                     ok;
                 {From, To, Packet} ->
-                    ?DEBUG({routing, skipped}),
+                    ?DEBUG("routing skipped", []),
                     route(From, To, Packet, Tail)
             end
     end.

--- a/apps/ejabberd/src/ejabberd_router_external.erl
+++ b/apps/ejabberd/src/ejabberd_router_external.erl
@@ -1,10 +1,9 @@
 %%%-------------------------------------------------------------------
-%%% @author bartek
-%%% @copyright (C) 2016, <COMPANY>
 %%% @doc
-%%%
+%%% Part of a routing chain; checks if there is an external component
+%%% registered for the domain and directs the message there if there is,
+%%% otherwise just passes it on.
 %%% @end
-%%% Created : 21. Mar 2016 12:30
 %%%-------------------------------------------------------------------
 -module(ejabberd_router_external).
 -author("bartek").

--- a/apps/ejabberd/src/ejabberd_router_external.erl
+++ b/apps/ejabberd/src/ejabberd_router_external.erl
@@ -1,0 +1,39 @@
+%%%-------------------------------------------------------------------
+%%% @author bartek
+%%% @copyright (C) 2016, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 21. Mar 2016 12:30
+%%%-------------------------------------------------------------------
+-module(ejabberd_router_external).
+-author("bartek").
+
+-behaviour(xmpp_router).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+
+%% API
+-export([filter/3, route/3]).
+%% xmpp_router callback
+-export([do_filter/3, do_route/3]).
+
+filter(From, To, Packet) ->
+    xmpp_router:filter(?MODULE, From, To, Packet).
+route(From, To, Packet) ->
+    xmpp_router:route(?MODULE, From, To, Packet).
+
+do_filter(OrigFrom, OrigTo, OrigPacket) ->
+    {OrigFrom, OrigTo, OrigPacket}.
+
+do_route(From, To, Packet) ->
+    LDstDomain = To#jid.lserver,
+    case mnesia:dirty_read(external_component, LDstDomain) of
+        [] ->
+            {From, To, Packet};
+        [#external_component{handler = Handler}] ->
+            ejabberd_local_delivery:do_local_route(From, To, Packet,
+                LDstDomain, Handler),
+            done
+    end.

--- a/apps/ejabberd/src/ejabberd_router_external.erl
+++ b/apps/ejabberd/src/ejabberd_router_external.erl
@@ -14,20 +14,13 @@
 -include("ejabberd.hrl").
 -include("jlib.hrl").
 
-%% API
--export([filter/3, route/3]).
 %% xmpp_router callback
--export([do_filter/3, do_route/3]).
+-export([filter/3, route/3]).
 
-filter(From, To, Packet) ->
-    xmpp_router:filter(?MODULE, From, To, Packet).
-route(From, To, Packet) ->
-    xmpp_router:route(?MODULE, From, To, Packet).
-
-do_filter(OrigFrom, OrigTo, OrigPacket) ->
+filter(OrigFrom, OrigTo, OrigPacket) ->
     {OrigFrom, OrigTo, OrigPacket}.
 
-do_route(From, To, Packet) ->
+route(From, To, Packet) ->
     LDstDomain = To#jid.lserver,
     case mnesia:dirty_read(external_component, LDstDomain) of
         [] ->

--- a/apps/ejabberd/src/ejabberd_router_external.erl
+++ b/apps/ejabberd/src/ejabberd_router_external.erl
@@ -26,7 +26,7 @@ route(From, To, Packet) ->
         [] ->
             {From, To, Packet};
         [#external_component{handler = Handler}] ->
-            ejabberd_local_delivery:do_local_route(From, To, Packet,
+            ejabberd_local_delivery:do_route(From, To, Packet,
                 LDstDomain, Handler),
             done
     end.

--- a/apps/ejabberd/src/ejabberd_router_global.erl
+++ b/apps/ejabberd/src/ejabberd_router_global.erl
@@ -1,10 +1,9 @@
 %%%-------------------------------------------------------------------
-%%% @author bartek
-%%% @copyright (C) 2016, <COMPANY>
 %%% @doc
-%%%
+%%% Part of a routing chain; does only filtering - uses hooks to check
+%%% if the message should be routed at all. This one should be the first
+%%% module in chain.
 %%% @end
-%%% Created : 21. Mar 2016 12:30
 %%%-------------------------------------------------------------------
 -module(ejabberd_router_global).
 -author("bartek").

--- a/apps/ejabberd/src/ejabberd_router_global.erl
+++ b/apps/ejabberd/src/ejabberd_router_global.erl
@@ -1,0 +1,37 @@
+%%%-------------------------------------------------------------------
+%%% @author bartek
+%%% @copyright (C) 2016, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 21. Mar 2016 12:30
+%%%-------------------------------------------------------------------
+-module(ejabberd_router_global).
+-author("bartek").
+
+-behaviour(xmpp_router).
+
+-include("ejabberd.hrl").
+
+%% API
+-export([filter/3, route/3]).
+%% xmpp_router callback
+-export([do_filter/3, do_route/3]).
+
+filter(From, To, Packet) ->
+    xmpp_router:filter(?MODULE, From, To, Packet).
+route(From, To, Packet) ->
+    xmpp_router:route(?MODULE, From, To, Packet).
+
+do_filter(OrigFrom, OrigTo, OrigPacket) ->
+    %% Filter globally
+    case ejabberd_hooks:run_fold(filter_packet,
+        {OrigFrom, OrigTo, OrigPacket}, []) of
+        {From, To, Packet} ->
+            {From, To, Packet};
+        drop ->
+            drop
+    end.
+
+do_route(From, To, Packet) ->
+    {From, To, Packet}.

--- a/apps/ejabberd/src/ejabberd_router_global.erl
+++ b/apps/ejabberd/src/ejabberd_router_global.erl
@@ -13,17 +13,10 @@
 
 -include("ejabberd.hrl").
 
-%% API
--export([filter/3, route/3]).
 %% xmpp_router callback
--export([do_filter/3, do_route/3]).
+-export([filter/3, route/3]).
 
-filter(From, To, Packet) ->
-    xmpp_router:filter(?MODULE, From, To, Packet).
-route(From, To, Packet) ->
-    xmpp_router:route(?MODULE, From, To, Packet).
-
-do_filter(OrigFrom, OrigTo, OrigPacket) ->
+filter(OrigFrom, OrigTo, OrigPacket) ->
     %% Filter globally
     case ejabberd_hooks:run_fold(filter_packet,
         {OrigFrom, OrigTo, OrigPacket}, []) of
@@ -33,5 +26,5 @@ do_filter(OrigFrom, OrigTo, OrigPacket) ->
             drop
     end.
 
-do_route(From, To, Packet) ->
+route(From, To, Packet) ->
     {From, To, Packet}.

--- a/apps/ejabberd/src/ejabberd_router_localdomain.erl
+++ b/apps/ejabberd/src/ejabberd_router_localdomain.erl
@@ -27,7 +27,7 @@ route(From, To, Packet) ->
         [] ->
             {From, To, Packet};
         [#route{handler=Handler}] ->
-            ejabberd_local_delivery:do_local_route(From, To, Packet,
+            ejabberd_local_delivery:do_route(From, To, Packet,
                 LDstDomain, Handler),
             done
     end.

--- a/apps/ejabberd/src/ejabberd_router_localdomain.erl
+++ b/apps/ejabberd/src/ejabberd_router_localdomain.erl
@@ -15,19 +15,13 @@
 -include("jlib.hrl").
 
 %% API
--export([filter/3, route/3]).
 %% xmpp_router callback
--export([do_filter/3, do_route/3]).
+-export([filter/3, route/3]).
 
 filter(From, To, Packet) ->
-    xmpp_router:filter(?MODULE, From, To, Packet).
-route(From, To, Packet) ->
-    xmpp_router:route(?MODULE, From, To, Packet).
-
-do_filter(From, To, Packet) ->
     {From, To, Packet}.
 
-do_route(From, To, Packet) ->
+route(From, To, Packet) ->
     LDstDomain = To#jid.lserver,
     case mnesia:dirty_read(route, LDstDomain) of
         [] ->

--- a/apps/ejabberd/src/ejabberd_router_localdomain.erl
+++ b/apps/ejabberd/src/ejabberd_router_localdomain.erl
@@ -1,0 +1,39 @@
+%%%-------------------------------------------------------------------
+%%% @author bartek
+%%% @copyright (C) 2016, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 21. Mar 2016 12:30
+%%%-------------------------------------------------------------------
+-module(ejabberd_router_localdomain).
+-author("bartek").
+
+-behaviour(xmpp_router).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+
+%% API
+-export([filter/3, route/3]).
+%% xmpp_router callback
+-export([do_filter/3, do_route/3]).
+
+filter(From, To, Packet) ->
+    xmpp_router:filter(?MODULE, From, To, Packet).
+route(From, To, Packet) ->
+    xmpp_router:route(?MODULE, From, To, Packet).
+
+do_filter(From, To, Packet) ->
+    {From, To, Packet}.
+
+do_route(From, To, Packet) ->
+    LDstDomain = To#jid.lserver,
+    case mnesia:dirty_read(route, LDstDomain) of
+        [] ->
+            {From, To, Packet};
+        [#route{handler=Handler}] ->
+            ejabberd_local_delivery:do_local_route(From, To, Packet,
+                LDstDomain, Handler),
+            done
+    end.

--- a/apps/ejabberd/src/ejabberd_router_localdomain.erl
+++ b/apps/ejabberd/src/ejabberd_router_localdomain.erl
@@ -1,10 +1,8 @@
 %%%-------------------------------------------------------------------
-%%% @author bartek
-%%% @copyright (C) 2016, <COMPANY>
 %%% @doc
-%%%
+%%% Part of a routing chain: searches for a route registered for the domain,
+%%% forwards the messge there, or passes on.
 %%% @end
-%%% Created : 21. Mar 2016 12:30
 %%%-------------------------------------------------------------------
 -module(ejabberd_router_localdomain).
 -author("bartek").

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -90,9 +90,6 @@ start_link() ->
 filter(From, To, Packet) ->
     {From, To, Packet}.
 
--spec route(From :: ejabberd:jid(),
-            To :: ejabberd:jid(),
-            Packet :: jlib:xmlel()) -> 'ok' | {'error','lager_not_running'}.
 route(From, To, Packet) ->
     do_route(From, To, Packet).
 

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -55,8 +55,6 @@
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
-%% xmpp_router callback
--export([do_route/3, do_filter/3]).
 
 %% ejabberd API
 -export([get_info_s2s_connections/1]).
@@ -90,13 +88,13 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 filter(From, To, Packet) ->
-    xmpp_router:filter(?MODULE, From, To, Packet).
+    {From, To, Packet}.
 
 -spec route(From :: ejabberd:jid(),
             To :: ejabberd:jid(),
             Packet :: jlib:xmlel()) -> 'ok' | {'error','lager_not_running'}.
 route(From, To, Packet) ->
-    xmpp_router:route(?MODULE, From, To, Packet).
+    do_route(From, To, Packet).
 
 -spec remove_connection(_, pid()) -> 'ok' | {'aborted',_} | {'atomic',_}.
 remove_connection(FromTo, Pid) ->
@@ -292,13 +290,6 @@ do_route(From, To, Packet) ->
             end,
             done
     end.
-
--spec do_filter(From :: ejabberd:jid(),
-    To :: ejabberd:jid(),
-    Packet :: jlib:xmlel()) ->
-    drop | done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
-do_filter(From, To, Packet) ->
-    {From, To, Packet}.
 
 -spec find_connection(From :: ejabberd:jid(),
                       To :: ejabberd:jid()) -> {'aborted',_} | {'atomic',_}.

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -215,7 +215,8 @@ wait_for_handshake({xmlstreamelement, El}, StateData) ->
                         ok ->
                             send_text(StateData, <<"<handshake/>">>),
                             {next_state, stream_established, StateData};
-                        {error, _Reason} ->
+                        {error, Reason} ->
+                            ?ERROR_MSG("Error in component handshake: ~p", [Reason]),
                             send_text(StateData, ?CONFLICT_ERR),
                             {stop, normal, StateData}
                     end;

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -129,7 +129,14 @@ start_link() ->
       To :: ejabberd:jid(),
       Packet :: jlib:xmlel() | ejabberd_c2s:broadcast().
 route(From, To, Packet) ->
-    xmpp_router:route_wrap(?MODULE, From, To, Packet).
+    case (catch do_route(From, To, Packet)) of
+        {'EXIT', Reason} ->
+            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
+                [jid:to_binary(From), jid:to_binary(To),
+                    ?MODULE, Reason, exml:to_binary(Packet),
+                    erlang:get_stacktrace()]);
+        Res -> Res
+    end.
 
 filter(From, To, Packet) ->
     {From, To, Packet}.

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -68,6 +68,7 @@
          terminate/2, code_change/3]).
 
 %% xmpp_router callback
+-export([do_filter/3]).
 -export([do_route/3]).
 
 -include("ejabberd.hrl").
@@ -519,6 +520,9 @@ set_session(SID, User, Server, Resource, Priority, Info) ->
     ?SM_BACKEND:create_session(LUser, LServer, LResource, Session).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+do_filter(From, To, Packet) ->
+    {From, To, Packet}.
 
 -spec do_route(From, To, Packet) -> ok when
       From :: ejabberd:jid(),

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -27,12 +27,10 @@
 -author('alexey@process-one.net').
 
 -behaviour(gen_server).
--behaviour(xmpp_router).
 
 %% API
 -export([start_link/0,
          route/3,
-         filter/3,
          open_session/5, open_session/6,
          close_session/5,
          store_info/4,
@@ -137,9 +135,6 @@ route(From, To, Packet) ->
                     erlang:get_stacktrace()]);
         _ -> ok
     end.
-
-filter(From, To, Packet) ->
-    {From, To, Packet}.
 
 -spec open_session(SID, User, Server, Resource, Info) -> ok when
       SID :: 'undefined' | sid(),

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -467,7 +467,7 @@ handle_cast(_Msg, State) ->
 %%--------------------------------------------------------------------
 -spec handle_info(_,_) -> {'noreply',_}.
 handle_info({route, From, To, Packet}, State) ->
-    xmpp_router:route(?MODULE,From,To,Packet),
+    route(From, To, Packet),
     {noreply, State};
 handle_info({register_iq_handler, Host, XMLNS, Module, Function}, State) ->
     ets:insert(sm_iqtable, {{XMLNS, Host}, Module, Function}),

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -32,6 +32,7 @@
 %% API
 -export([start_link/0,
          route/3,
+         filter/3,
          open_session/5, open_session/6,
          close_session/5,
          store_info/4,
@@ -128,7 +129,10 @@ start_link() ->
       To :: ejabberd:jid(),
       Packet :: jlib:xmlel() | ejabberd_c2s:broadcast().
 route(From, To, Packet) ->
-    xmpp_router:route(?MODULE, From, To, Packet).
+    xmpp_router:route_wrap(?MODULE, From, To, Packet).
+
+filter(From, To, Packet) ->
+    {From, To, Packet}.
 
 -spec open_session(SID, User, Server, Resource, Info) -> ok when
       SID :: 'undefined' | sid(),

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -135,7 +135,7 @@ route(From, To, Packet) ->
                 [jid:to_binary(From), jid:to_binary(To),
                     ?MODULE, Reason, exml:to_binary(Packet),
                     erlang:get_stacktrace()]);
-        Res -> Res
+        _ -> ok
     end.
 
 filter(From, To, Packet) ->

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -1,13 +1,17 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% A behaviour which should be used by all modules being used in a
+%%% routing pipeline. The pipeline, manage by ejabberd_router:route
+%%% func, calls filter and route for each successful module.
+%%%
+%%% Module has to implement both functions, can be a no-op just returning
+%%% a tuple of its args.
+%%% @end
+%%%-------------------------------------------------------------------
 -module(xmpp_router).
 
 -include("ejabberd.hrl").
 
-%%A behaviour which should be used by all modules being used in a
-%%routing pipeline. The pipeline, manage by ejabberd_router:route
-%%func, calls filter and route for each successful module.
-%%
-%%Module has to implement both functions, can be a no-op just returning
-%%a tuple of its args.
 
 -callback route(From :: ejabberd:jid(), To :: ejabberd:jid(),
                    Packet :: jlib:xmlel()) ->

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -1,23 +1,44 @@
 -module(xmpp_router).
 -export([route/4]).
+-export([filter/4]).
 
 -include("ejabberd.hrl").
 
 
 -callback do_route(From :: ejabberd:jid(), To :: ejabberd:jid(),
-                   Packet :: jlib:xmlel()) -> ok.
+                   Packet :: jlib:xmlel()) ->
+    done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
+
+-callback do_filter(From :: ejabberd:jid(), To :: ejabberd:jid(),
+    Packet :: jlib:xmlel()) ->
+    drop | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
 
 -spec route(Module :: module(),
             From :: ejabberd:jid(),
             To :: ejabberd:jid(),
-            Packet :: jlib:xmlel() | ejabberd_c2s:broadcast()) -> ok.
-route(Module,From,To,Packet) ->
-    case (catch Module:do_route(From,To,Packet)) of
+            Packet :: jlib:xmlel() | ejabberd_c2s:broadcast()) ->
+                done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
+route(Module, From, To, Packet) ->
+    case (catch Module:do_route(From, To, Packet)) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
                        [jid:to_binary(From), jid:to_binary(To),
                         Module, Reason, exml:to_binary(Packet),
                         erlang:get_stacktrace()]);
-        _ -> ok
+        Res -> Res
     end.
 
+-spec filter(Module :: module(),
+    From :: ejabberd:jid(),
+    To :: ejabberd:jid(),
+    Packet :: jlib:xmlel() | ejabberd_c2s:broadcast()) ->
+    drop | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
+filter(Module, From, To, Packet) ->
+    case (catch Module:do_filter(From, To, Packet)) of
+        {'EXIT', Reason} ->
+            ?ERROR_MSG("error when filtering from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
+                [jid:to_binary(From), jid:to_binary(To),
+                    Module, Reason, exml:to_binary(Packet),
+                    erlang:get_stacktrace()]);
+        Res -> Res
+    end.

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -3,6 +3,12 @@
 
 -include("ejabberd.hrl").
 
+%%A behaviour which should be used by all modules being used in a
+%%routing pipeline. The pipeline, manage by ejabberd_router:route
+%%func, calls filter and route for each successful module.
+%%
+%%Module has to implement both functions, can be a no-op just returning
+%%a tuple of its args.
 
 -callback route(From :: ejabberd:jid(), To :: ejabberd:jid(),
                    Packet :: jlib:xmlel()) ->
@@ -14,6 +20,8 @@
 
 
 
+%% @doc This does what previously was done by xmpp_router:route function,
+%% i.e. wraps the callers do_route function in an exception handler.
 -spec route_wrap(Module :: module(),
             From :: ejabberd:jid(),
             To :: ejabberd:jid(),

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -1,24 +1,25 @@
 -module(xmpp_router).
--export([route/4]).
--export([filter/4]).
+-export([route_wrap/4]).
 
 -include("ejabberd.hrl").
 
 
--callback do_route(From :: ejabberd:jid(), To :: ejabberd:jid(),
+-callback route(From :: ejabberd:jid(), To :: ejabberd:jid(),
                    Packet :: jlib:xmlel()) ->
     done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
 
--callback do_filter(From :: ejabberd:jid(), To :: ejabberd:jid(),
+-callback filter(From :: ejabberd:jid(), To :: ejabberd:jid(),
     Packet :: jlib:xmlel()) ->
     drop | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
 
--spec route(Module :: module(),
+
+
+-spec route_wrap(Module :: module(),
             From :: ejabberd:jid(),
             To :: ejabberd:jid(),
             Packet :: jlib:xmlel() | ejabberd_c2s:broadcast()) ->
                 done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
-route(Module, From, To, Packet) ->
+route_wrap(Module, From, To, Packet) ->
     case (catch Module:do_route(From, To, Packet)) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
@@ -28,17 +29,4 @@ route(Module, From, To, Packet) ->
         Res -> Res
     end.
 
--spec filter(Module :: module(),
-    From :: ejabberd:jid(),
-    To :: ejabberd:jid(),
-    Packet :: jlib:xmlel() | ejabberd_c2s:broadcast()) ->
-    drop | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
-filter(Module, From, To, Packet) ->
-    case (catch Module:do_filter(From, To, Packet)) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("error when filtering from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
-                [jid:to_binary(From), jid:to_binary(To),
-                    Module, Reason, exml:to_binary(Packet),
-                    erlang:get_stacktrace()]);
-        Res -> Res
-    end.
+

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -1,5 +1,4 @@
 -module(xmpp_router).
--export([route_wrap/4]).
 
 -include("ejabberd.hrl").
 
@@ -18,23 +17,5 @@
     Packet :: jlib:xmlel()) ->
     drop | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
 
-
-
-%% @doc This does what previously was done by xmpp_router:route function,
-%% i.e. wraps the callers do_route function in an exception handler.
--spec route_wrap(Module :: module(),
-            From :: ejabberd:jid(),
-            To :: ejabberd:jid(),
-            Packet :: jlib:xmlel() | ejabberd_c2s:broadcast()) ->
-                done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
-route_wrap(Module, From, To, Packet) ->
-    case (catch Module:do_route(From, To, Packet)) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
-                       [jid:to_binary(From), jid:to_binary(To),
-                        Module, Reason, exml:to_binary(Packet),
-                        erlang:get_stacktrace()]);
-        Res -> Res
-    end.
 
 

--- a/apps/ejabberd/test/translate_SUITE.erl
+++ b/apps/ejabberd/test/translate_SUITE.erl
@@ -11,6 +11,10 @@ all() ->
     ].
 
 
+end_per_testcase(_, C) ->
+    catch meck:unload(ejabberd_config),
+    C.
+
 test_undefined_translation(_Config) ->
     %% given - if undefined it should be english(pass through)
     given_default_language(undefined),

--- a/apps/ejabberd/test/xmpp_route_SUITE.erl
+++ b/apps/ejabberd/test/xmpp_route_SUITE.erl
@@ -2,64 +2,101 @@
 -compile([export_all]).
 
 -include_lib("exml/include/exml.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 
 all() ->
-    [ success_with_module_implementing_behaviour,
-      fail_with_module_not_implementing_behaviour,
-      fail_when_do_route_crashes
-    ].
+    [ basic_routing ].
 
 init_per_suite(C) ->
     application:start(stringprep),
     application:ensure_all_started(lager),
+    mnesia:start(),
+    mnesia:create_schema([node()]),
+    meck:new(ejabberd_config),
+    meck:expect(ejabberd_config, get_local_option,
+        fun(routing_modules) ->
+            [xmpp_router_a, xmpp_router_b, xmpp_router_c]
+        end),
+    ejabberd_router:start_link(),
     C.
 
 end_per_suite(_C) ->
     ok.
 
-success_with_module_implementing_behaviour(_C) ->
-    meck:new(xmpp_router_correct, [non_strict]),
-    meck:expect(xmpp_router_correct, do_route,
-                fun(_From, _To, _Packet) -> ok end),
-    ok = xmpp_router:route(xmpp_router_correct,
-                           jid:from_binary(<<"ala@localhost">>),
-                           jid:from_binary(<<"bob@localhost">>),
-                           message()),
-    meck:validate(xmpp_router_correct),
-    meck:unload(xmpp_router_correct),
+basic_routing(_C) ->
+    %% module 'a' drops message 1, routes message 2, passes on everything else
+    Self = self(),
+    meck:new(xmpp_router_a, [non_strict]),
+    meck:expect(xmpp_router_a, filter,
+                fun(From, To, Packet) ->
+                    case Packet of
+                        1 -> drop;
+                        _ -> {From, To, Packet}
+                    end
+                end),
+    meck:expect(xmpp_router_a, route,
+        fun(From, To, Packet) ->
+            case Packet of
+                2 ->
+                    Self ! {a, Packet},
+                    done;
+                _ -> {From, To, Packet}
+            end
+        end),
+    %% module 'b' drops message 3, routes message 4, passes on everything else
+    meck:new(xmpp_router_b, [non_strict]),
+    meck:expect(xmpp_router_b, filter,
+        fun(From, To, Packet) ->
+            case Packet of
+                3 -> drop;
+                _ -> {From, To, Packet}
+            end
+        end),
+    meck:expect(xmpp_router_b, route,
+        fun(From, To, Packet) ->
+            case Packet of
+                4 ->
+                    Self ! {b, Packet},
+                    done;
+                _ -> {From, To, Packet}
+            end
+        end),
+    %% module 'c' routes everything
+    meck:new(xmpp_router_c, [non_strict]),
+    meck:expect(xmpp_router_c, filter,
+        fun(From, To, Packet) ->
+            {From, To, Packet}
+        end),
+    meck:expect(xmpp_router_c, route,
+        fun(_From, _To, Packet) ->
+            Self ! {c, Packet},
+            done
+        end),
+    %% send messages from 1 to 5
+    lists:map(fun(I) -> route(I) end, [1,2,3,4,5]),
+    meck:validate(xmpp_router_a),
+    meck:unload(xmpp_router_a),
+    meck:validate(xmpp_router_b),
+    meck:unload(xmpp_router_b),
+    meck:validate(xmpp_router_c),
+    meck:unload(xmpp_router_c),
+    %% we know that 1 and 3 should be dropped, and 2, 4 and 5 handled by a, b and c respectively
+    verify([{a, 2}, {b, 4}, {c, 5}]),
     ok.
 
-fail_with_module_not_implementing_behaviour(_C) ->
-    meck:new(xmpp_router_incorrect, [non_strict]),
-    meck:expect(xmpp_router_incorrect, no_do_route,
-                fun(_From, _To, _Packet) -> ok end),
-    meck:new(lager, [unstick, passthrough]),
-    ok = xmpp_router:route(xmpp_router_incorrect,
-                           jid:from_binary(<<"ala@localhost">>),
-                           jid:from_binary(<<"bob@localhost">>),
-                           message()),
-    meck:validate(lager),
-    meck:unload(xmpp_router_incorrect),
-    meck:unload(lager),
-    ok.
+route(I) ->
+    ok = ejabberd_router:route(jid:from_binary(<<"ala@localhost">>),
+        jid:from_binary(<<"bob@localhost">>),
+        I).
 
-
-fail_when_do_route_crashes(_C) ->
-    meck:new(xmpp_router_crashing, [non_strict]),
-    meck:expect(xmpp_router_crashing, do_route,
-                fun(_From, _To, _Packet) -> meck:exception(error, sth_wrong) end),
-    meck:new(lager, [unstick, passthrough]),
-    ok = xmpp_router:route(xmpp_router_crashing,
-                           jid:from_binary(<<"ala@localhost">>),
-                           jid:from_binary(<<"bob@localhost">>),
-                           message()),
-    meck:validate(xmpp_router_crashing),
-    meck:validate(lager),
-    meck:unload(xmpp_router_crashing),
-    meck:unload(lager),
-    ok.
-
-message() ->
-    #xmlel{name = <<"message">>}.
+verify(L) ->
+    receive
+        X ->
+            ?assert(lists:member(X, L)),
+            verify(lists:delete(X, L))
+    after 1000 ->
+        ?assertEqual(L, []),
+        ct:pal("all messages routed correctly")
+    end.
 

--- a/apps/ejabberd/test/xmpp_route_SUITE.erl
+++ b/apps/ejabberd/test/xmpp_route_SUITE.erl
@@ -9,7 +9,7 @@ all() ->
     [ basic_routing ].
 
 init_per_suite(C) ->
-    application:start(stringprep),
+    application:ensure_started(stringprep),
     application:ensure_all_started(lager),
     mnesia:start(),
     mnesia:create_schema([node()]),

--- a/apps/ejabberd/test/xmpp_route_SUITE.erl
+++ b/apps/ejabberd/test/xmpp_route_SUITE.erl
@@ -18,6 +18,7 @@ init_per_suite(C) ->
         fun(routing_modules) ->
             [xmpp_router_a, xmpp_router_b, xmpp_router_c]
         end),
+    application:start(exometer),
     ejabberd_router:start_link(),
     C.
 


### PR DESCRIPTION
This PR addresses issue #696, and goes a bit beyond that.
The routing system is reworked, so that there is a chain of modules, each implementing xmpp_router behaviour. Each of those modules can filter out a message, route it or pass it on. The ejabberd_router module is sort of a "routing controller". There is a default chain, and config file can specify a different one.
The engine is tested by xmpp_router_SUITE.

