### PR TITLE
Rel 1.7 mongoose cluster

### DIFF
--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -44,7 +44,8 @@
          dump_to_textfile/1, dump_to_textfile/2,
          mnesia_change_nodename/4,
          restore/1, % Still used by some modules%%
-         get_loglevel/0]).
+         get_loglevel/0,
+         join_cluster/1, leave_cluster/0]).
 
 -include("ejabberd.hrl").
 -include("ejabberd_commands.hrl").
@@ -147,13 +148,74 @@ commands() ->
      #ejabberd_commands{name = reload_cluster, tags = [server],
                         desc = "Reload configuration file in the cluster",
                         module = ejabberd_config, function = reload_cluster,
-                        args = [], result = {res, restuple}}
+                        args = [], result = {res, restuple}},
+     #ejabberd_commands{name = join_cluster, tags = [server],
+                        desc = "Join the node to the cluster",
+                        module = ?MODULE, function = join_cluster,
+                        args = [{node, string}],
+                        result = {res, restuple}},
+     #ejabberd_commands{name = leave_cluster, tags = [server],
+                        desc = "Leave a node from the cluster",
+                        module = ?MODULE, function = leave_cluster,
+                        args = [],
+                        result = {res, restuple}}
     ].
 
 
 %%%
 %%% Server management
 %%%
+
+-spec join_cluster(string()) -> {ok, string()} | {pang, string()} | {mnesia_error, string()} | {error, string()}.
+join_cluster(NodeString) ->
+  NodeAtom = list_to_atom(NodeString),
+  NodeList = mnesia:system_info(running_db_nodes),
+  case lists:member(NodeAtom, NodeList) of
+    true ->
+      String = io_lib:format("The node ~s has already joined the cluster~n", [NodeString]),
+      {ok, String};
+    _ ->
+      do_join_cluster(NodeAtom)
+  end.
+
+do_join_cluster(Node) ->
+    try mongoose_cluster:join(Node) of
+        ok ->
+            String = io_lib:format("You have successfully joined the node ~p to the cluster with node member ~p~n", [node(), Node]),
+            {ok, String}
+    catch
+        error:pang ->
+            String = io_lib:format("Timeout while attempting to connect to node ~s~n", [Node]),
+            {pang, String};
+        error:{cant_get_storage_type, {T, E, R}} ->
+            String = io_lib:format("Cannot get storage type for table ~p~n. Reason: ~p:~p", [T, E, R]),
+            {mnesia_error, String};
+        E:R ->
+            {error, {E, R}}
+    end.
+
+-spec leave_cluster() -> {ok, string()} | {error, term()} | {not_in_cluster, string()}.
+leave_cluster() ->
+  NodeList = mnesia:system_info(running_db_nodes),
+  case NodeList of
+    [] ->
+      String = io_lib:format("The node ~p is not in the cluster~n", [node()]),
+      {not_in_cluster, String};
+    _ ->
+      do_leave_cluster()
+  end.
+
+do_leave_cluster() ->
+  try mongoose_cluster:leave() of
+    ok ->
+      String = io_lib:format("You have successfully left the node ~p from
+      the cluster~n", [node()]),
+      {ok, String}
+  catch
+    E:R ->
+      {error, {E, R}}
+  end.
+
 
 -spec status() -> {'ejabberd_not_running', io_lib:chars()} | {'ok', io_lib:chars()}.
 status() ->

--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -166,17 +166,18 @@ commands() ->
 %%% Server management
 %%%
 
--spec join_cluster(string()) -> {ok, string()} | {pang, string()} | {mnesia_error, string()} | {error, string()}.
+-spec join_cluster(string()) -> {ok, string()} | {pang, string()} | {alread_joined, string()} |
+                                {mnesia_error, string()} | {error, string()}.
 join_cluster(NodeString) ->
-  NodeAtom = list_to_atom(NodeString),
-  NodeList = mnesia:system_info(running_db_nodes),
-  case lists:member(NodeAtom, NodeList) of
-    true ->
-      String = io_lib:format("The node ~s has already joined the cluster~n", [NodeString]),
-      {ok, String};
-    _ ->
-      do_join_cluster(NodeAtom)
-  end.
+    NodeAtom = list_to_atom(NodeString),
+    NodeList = mnesia:system_info(running_db_nodes),
+    case lists:member(NodeAtom, NodeList) of
+        true ->
+            String = io_lib:format("The node ~s has already joined the cluster~n", [NodeString]),
+            {alread_joined, String};
+        _ ->
+            do_join_cluster(NodeAtom)
+    end.
 
 do_join_cluster(Node) ->
     try mongoose_cluster:join(Node) of
@@ -196,25 +197,25 @@ do_join_cluster(Node) ->
 
 -spec leave_cluster() -> {ok, string()} | {error, term()} | {not_in_cluster, string()}.
 leave_cluster() ->
-  NodeList = mnesia:system_info(running_db_nodes),
-  case NodeList of
-    [] ->
-      String = io_lib:format("The node ~p is not in the cluster~n", [node()]),
-      {not_in_cluster, String};
-    _ ->
-      do_leave_cluster()
-  end.
+    NodeList = mnesia:system_info(running_db_nodes),
+    ThisNode = node(),
+    case NodeList of
+        [ThisNode] ->
+            String = io_lib:format("The node ~p is not in the cluster~n", [node()]),
+            {not_in_cluster, String};
+        _ ->
+            do_leave_cluster()
+    end.
 
 do_leave_cluster() ->
-  try mongoose_cluster:leave() of
-    ok ->
-      String = io_lib:format("You have successfully left the node ~p from
-      the cluster~n", [node()]),
-      {ok, String}
-  catch
-    E:R ->
-      {error, {E, R}}
-  end.
+    try mongoose_cluster:leave() of
+        ok ->
+            String = io_lib:format("You have successfully left the node ~p from the cluster~n", [node()]),
+            {ok, String}
+    catch
+        E:R ->
+            {error, {E, R}}
+    end.
 
 
 -spec status() -> {'ejabberd_not_running', io_lib:chars()} | {'ok', io_lib:chars()}.

--- a/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
+++ b/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
@@ -84,7 +84,19 @@ Just start MongooseIM using `mongooseim start` or `mongooseim live`
 
 ### New node
 
-#### MongooseIM 1.5.0 and newer
+#### MongooseIM 1.7.0 and newer
+Cluster management commands since MongooseIM 1.7.0 have been a bit changed. We call them now from a running node that is going
+to leave or join the cluster.
+
+```bash
+mongooseimctl join_cluster ClusterMember
+```
+
+`ClusterMember` is the name of running node set in `vm.args` file, for example `mongooseim@localhost`. This node
+has to be part of the cluster we'd like to join.
+The successful output from above command starts with `You have successfully joined the node to the cluster`.
+
+#### MongooseIM 1.5.0 - 1.7.0
 Since MongooseIM 1.5.0 adding new node to a cluster is as simple as executing following command:
 
 ```bash
@@ -115,7 +127,18 @@ Exit shell and start MongooseIM using `mongooseim start/live`
 
 ### Remove node
 
-#### MongooseIM 1.5.0 and newer
+#### MongooseIM 1.7.0 and newer
+
+In case to remove a node from the cluster call:
+
+```bash
+mongooseimctl leave_cluster
+```
+
+It makes sense only if the node is the part of any cluster, e.g called `join_cluster` from that node before.
+The successful output from above command starts with `You have successfully left the node`.
+
+#### MongooseIM 1.5.0 - 1.7.0
 
 To remove a node, connect to a different one and execute enter:
 

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -98,40 +98,6 @@ case "$1" in
             sleep 1
         done
         ;;
-    add_to_cluster)
-        NAME_TYPE=$(echo $NAME | sed 's/^\-//')
-
-        TARGETNODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME $2 $COOKIE_ARG"
-        ADD_TO_CLUSTER_CMD="$ERTS_PATH/escript $ERTS_PATH/nodetool -exact_$NAME_TYPE $NODE $COOKIE_ARG add_to_cluster $2"
-
-        RES=`$NODETOOL ping`
-        if [ "$RES" = "pong" ]; then
-            echo "Error: Node is already running! Stop the node and delete Mnesia database directory ($MNESIA_DIR)."
-            exit 1
-        fi
-
-        if [ -d "$MNESIA_DIR" ]; then
-            echo "Error: $MNESIA_DIR already exists. Please remove whole directory before continuing."
-            exit 1
-        fi
-        RES2=`$TARGETNODETOOL ping`
-        if [ "$RES2" = "pong" ]; then
-            RES3=`$ADD_TO_CLUSTER_CMD`
-            if [ "$RES3" = "ok" ]; then
-                echo "Node added to cluster. Run mongooseimctl live or mongooseimctl start."
-            else
-                echo "Adding Node to cluster failed:  $RES3"
-                exit 1
-            fi
-        else
-            echo "Error: Node $2 is not reachable."
-            exit 1
-        fi
-        ;;
-    remove_from_cluster)
-        ## See if the VM is alive
-        $NODETOOL remove_from_cluster $2
-        ;;
     restart)
         ## Restart the VM without exiting the process
         $NODETOOL restart

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -233,7 +233,7 @@ case "$1" in
         fi
         ;;
     *)
-        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|live|console|console_clean|attach|debug|version|add_to_cluster|remove_from_cluster}"
+        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|live|console|console_clean|attach|debug|version|join_cluster|leave_cluster}"
         exit 1
         ;;
 esac

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -35,14 +35,34 @@ fi
 NAME_TYPE="${NODENAME_ARG% *}"
 NODENAME="${NODENAME_ARG#* }"
 
-add_to_cluster()
+join_cluster()
 {
-    $RUNNER_SCRIPT_DIR/mongooseim $ARGS
+    echo "Warning. This will drop all current connections and will discard all persistent data from Mnesia.
+            Do you want to continue? (yes/no)"
+            read GUARD
+
+            if [ $GUARD =  "yes" ]; then
+                echo "Joining the cluster..."
+                ctl $QUOTED_ARGS
+            else
+                echo "Operation discarded by user"
+                exit 1
+            fi
 }
 
-remove_from_cluster()
+leave_cluster()
 {
-    $RUNNER_SCRIPT_DIR/mongooseim $ARGS
+        echo "Warning. This will drop all current connections and will discard all persistent data from Mnesia.
+                Do you want to continue? (yes/no)"
+                read GUARD
+
+                if [ $GUARD =  "yes" ]; then
+                    echo "Leaving the cluster..."
+                    ctl $QUOTED_ARGS
+                else
+                    echo "Operation discarded by user"
+                    exit 1
+                fi
 }
 
 start ()
@@ -70,8 +90,8 @@ help ()
     echo "  debug  Attach an interactive Erlang shell to a running MongooseIM node"
     echo "  live   Start MongooseIM node in live (interactive) mode"
     echo "MongooseIM cluster management commads:"
-    echo "  add_to_cluster other_node_name       Add current node to cluster"
-    echo "  remove_from_cluster dead_node_name   Remove other node from cluster"
+    echo "  join_cluster other_node_name       Add current node to cluster"
+    echo "  leave_cluster                      Leave current node from the cluster"
     echo ""
 }
 
@@ -219,8 +239,8 @@ done
 
 case $1 in
     'start') start;;
-    'add_to_cluster') add_to_cluster;;
-    'remove_from_cluster') remove_from_cluster;;
+    'join_cluster') join_cluster;;
+    'leave_cluster') leave_cluster;;
     'debug') debug;;
     'live') live;;
     'started') wait_for_status 0 30 2;; # wait 30x2s before timeout

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -32,7 +32,8 @@
                  {vars, "node2_vars.config"},
                  {cluster, mim}]},
          {fed,  [{node, fed1@localhost},
-                 {domain, <<"fed">>},
+                 {domain, <<"fed1">>},
+                 {vars, "fed1_vars.config"},
                  {cluster, fed}]}]}.
 
 %% Use XMPP in-band registration for creating/deleting test users

--- a/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -20,7 +20,7 @@
 -import(distributed_helper, [add_node_to_cluster/1,
                              remove_node_from_cluster/1,
                              is_sm_distributed/0]).
--import(ejabberdctl_helper, [ejabberdctl/3, rpc_call/3]).
+-import(ejabberdctl_helper, [ejabberdctl/3, rpc_call/3, verify_result/1]).
 
 
 -include_lib("common_test/include/ct.hrl").

--- a/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -17,14 +17,16 @@
 -module(cluster_commands_SUITE).
 -compile(export_all).
 
--import(distributed_helper, [add_node_to_cluster/1,
-remove_node_from_cluster/1, is_sm_distributed/0, verify_result/1]).
+-import(distributed_helper, [add_node_to_cluster/1, mim/0, mim2/0, fed/0, rpc/5,
+        remove_node_from_cluster/1, is_sm_distributed/0]).
 -import(ejabberdctl_helper, [ejabberdctl/3, rpc_call/3]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-define(LOCAL_NODE, mim()).
 -define(eq(Expected, Actual), ?assertEqual(Expected, Actual)).
 -define(ne(A, B), ?assertNot(A == B)).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -32,39 +34,65 @@ remove_node_from_cluster/1, is_sm_distributed/0, verify_result/1]).
 all() ->
     [{group, clustered},
         {group, ejabberdctl},
-        {group, clustering}].
+        {group, clustering_two},
+        {group, clustering_theree}].
 groups() ->
     [{clustered, [], [one_to_one_message]},
-        {clustering, [], [join_successful, leave_successful,
-            join_unsuccessful, leave_unsuccessful, leave_but_no_cluster, join_twice, leave_twice]},
+        {clustering_two, [],
+            [join_successful,
+            leave_successful,
+            join_unsuccessful,
+            leave_unsuccessful,
+            leave_but_no_cluster,
+            join_twice,
+            leave_twice]},
+        {clustering_theree, [shuffle],
+            [cluster_of_theree,
+             leave_the_theree]},
         {ejabberdctl, [], [set_master_test]}].
 suite() ->
+    require_all_nodes() ++
     escalus:suite().
+
+require_all_nodes() ->
+    [{require, mim_node, {hosts, mim, node}},
+        {require, mim_node2, {hosts, mim2, node}},
+        {require, fed_node, {hosts, fed, node}}].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    Config1 = escalus:init_per_suite(Config),
-    Node = ct:get_config(ejabberd2_node),
-    Config2 = ejabberd_node_utils:init(Node, Config1),
-    ejabberd_node_utils:backup_config_file(Node, Config2),
-    MainDomain = ct:get_config(ejabberd_domain),
+    Node1 = mim(),
+    Node2 = mim2(),
+    Node3 = fed(),
+    Config1 = ejabberd_node_utils:init(Node1, Config),
+    Config2 = ejabberd_node_utils:init(Node2, Config1),
+    Config3 = ejabberd_node_utils:init(Node3, Config2),
+    ejabberd_node_utils:backup_config_file(Node2, Config3),
+    ejabberd_node_utils:backup_config_file(Node3, Config3),
+    MainDomain = ct:get_config({hosts, mim, domain}),
     Ch = [{hosts, "[\"" ++ binary_to_list(MainDomain) ++ "\"]"}],
-    ejabberd_node_utils:modify_config_file(Node, "reltool_vars/node2_vars.config", Ch, Config2),
-    ejabberd_node_utils:call_ctl(Node, reload_local, Config2),
-    {ok, EjdWD} = escalus_ejabberd:rpc(file, get_cwd, []),
-    CtlPath = case filelib:is_file(EjdWD ++ "/bin/ejabberdctl") of
-                  true -> EjdWD ++ "/bin/ejabberdctl";
-                  false -> EjdWD ++ "/bin/mongooseimctl"
-              end,
-    escalus:init_per_suite([{ctl_path, CtlPath} | Config2]).
+    ejabberd_node_utils:modify_config_file(Node2, "reltool_vars/node2_vars.config", Ch, Config3),
+    ejabberd_node_utils:call_ctl(Node2, reload_local, Config2),
+    ejabberd_node_utils:modify_config_file(Node3, "reltool_vars/fed1_vars.config", Ch, Config3),
+    ejabberd_node_utils:call_ctl(Node3, reload_local, Config2),
+    NodeCtlPath = distributed_helper:ctl_path(Node1, Config3),
+    Node2CtlPath = distributed_helper:ctl_path(Node2, Config3),
+    Node3CtlPath = distributed_helper:ctl_path(Node3, Config3),
+    escalus:init_per_suite([{ctl_path_atom(Node1), NodeCtlPath},
+        {ctl_path_atom(Node2), Node2CtlPath},
+        {ctl_path_atom(Node3), Node3CtlPath}]
+    ++ Config3).
 
 end_per_suite(Config) ->
-    Node = ct:get_config(ejabberd2_node),
-    ejabberd_node_utils:restore_config_file(Node, Config),
-    ejabberd_node_utils:restart_application(Node, ejabberd),
+    Node2 = mim2(),
+    Node3 = fed(),
+    ejabberd_node_utils:restore_config_file(Node2, Config),
+    ejabberd_node_utils:restore_config_file(Node3, Config),
+    ejabberd_node_utils:restart_application(Node2, ejabberd),
+    ejabberd_node_utils:restart_application(Node3, ejabberd),
     escalus:end_per_suite(Config).
 
 init_per_group(Group, Config) when Group == clustered orelse Group == ejabberdctl ->
@@ -78,7 +106,7 @@ init_per_group(Group, Config) when Group == clustered orelse Group == ejabberdct
             {skip, nondistributed_sm}
     end;
 
-init_per_group(clustering, _Config) ->
+init_per_group(Group, _Config) when Group == clustering_two orelse Group == clustering_theree ->
     case is_sm_distributed() of
         true ->
             ok;
@@ -96,7 +124,7 @@ end_per_group(Group, Config) when Group == clustered orelse Group == ejabberdctl
 
 %% Users are gone after mnesia cleaning
 %% hence there is no need to delete them manually
-end_per_group(clustering, _Config) ->
+end_per_group(Group, _Config) when Group == clustering_two orelse Group == clustering_theree ->
     ok;
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config).
@@ -104,10 +132,19 @@ end_per_group(_GroupName, Config) ->
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
-end_per_testcase(CaseName, Config) when CaseName == leave_unsuccessful orelse CaseName == join_twice ->
-    remove_node_from_cluster(Config),
-    escalus:end_per_testcase(leave_unsuccessful, Config);
+end_per_testcase(cluster_of_theree, Config) ->
+    Timeout = timer:seconds(60),
+    Node2 = mim2(),
+    Node3 = fed(),
+    ok = rpc(Node2, mongoose_cluster, leave, [], Timeout),
+    ok = rpc(Node3, mongoose_cluster, leave, [], Timeout),
+    escalus:end_per_testcase(cluster_of_theree, Config);
 
+end_per_testcase(CaseName, Config) when CaseName == join_successful
+                                   orelse CaseName == leave_unsuccessful
+                                   orelse CaseName == join_twice ->
+    remove_node_from_cluster(Config),
+    escalus:end_per_testcase(CaseName, Config);
 
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
@@ -121,20 +158,20 @@ one_to_one_message(ConfigIn) ->
     Metrics = [{[data, dist], [{recv_oct, '>'}, {send_oct, '>'}]}],
     Config = [{mongoose_metrics, Metrics} | ConfigIn],
     escalus:story(Config, [{alice, 1}, {clusterguy, 1}], fun(Alice, ClusterGuy) ->
-                %% When Alice sends a message to ClusterGuy
-                Msg1 = escalus_stanza:chat_to(ClusterGuy, <<"Hi!">>),
-                escalus:send(Alice, Msg1),
-                %% Then he receives it
-                Stanza1 = escalus:wait_for_stanza(ClusterGuy, 5000),
-                escalus:assert(is_chat_message, [<<"Hi!">>], Stanza1),
+        %% When Alice sends a message to ClusterGuy
+        Msg1 = escalus_stanza:chat_to(ClusterGuy, <<"Hi!">>),
+        escalus:send(Alice, Msg1),
+        %% Then he receives it
+        Stanza1 = escalus:wait_for_stanza(ClusterGuy, 5000),
+        escalus:assert(is_chat_message, [<<"Hi!">>], Stanza1),
 
-                %% When ClusterGuy sends a response
-                Msg2 = escalus_stanza:chat_to(Alice, <<"Oh hi!">>),
-                escalus:send(ClusterGuy, Msg2),
-                %% Then Alice also receives it
-                Stanza2 = escalus:wait_for_stanza(Alice, 5000),
-                escalus:assert(is_chat_message, [<<"Oh hi!">>], Stanza2)
-        end).
+        %% When ClusterGuy sends a response
+        Msg2 = escalus_stanza:chat_to(Alice, <<"Oh hi!">>),
+        escalus:send(ClusterGuy, Msg2),
+        %% Then Alice also receives it
+        Stanza2 = escalus:wait_for_stanza(Alice, 5000),
+        escalus:assert(is_chat_message, [<<"Oh hi!">>], Stanza2)
+                                                         end).
 %%--------------------------------------------------------------------
 %% Ejabberdctl tests
 %%--------------------------------------------------------------------
@@ -153,54 +190,114 @@ set_master_test(ConfigIn) ->
     [MasterNode] = rpc_call(mnesia, table_info, [TableName, master_nodes]).
 
 join_successful(Config) ->
-    Node2 = ct:get_config(ejabberd2_node),
+    %% given
+    Node2 = mim2(),
+    %% when
     {_, OpCode} = ejabberdctl_interactive("join_cluster", [atom_to_list(Node2)], "yes\n", Config),
-    verify_result(add),
+    %% then
+    distributed_helper:verify_result(add),
     ?eq(0, OpCode).
 
 leave_successful(Config) ->
+    %% given
+    add_node_to_cluster(Config),
+    %% when
     {_, OpCode} = ejabberdctl_interactive("leave_cluster", [], "yes\n", Config),
-    verify_result(remove),
+    %% then
+    distributed_helper:verify_result(remove),
     ?eq(0, OpCode).
 
 join_unsuccessful(Config) ->
+    %% when
     {_, OpCode} = ejabberdctl_interactive("join_cluster", [], "no\n", Config),
-    verify_result(remove),
+    %% then
+    distributed_helper:verify_result(remove),
     ?ne(0, OpCode).
 
 leave_unsuccessful(Config) ->
+    %% given
     add_node_to_cluster(Config),
+    %% when
     {_, OpCode} = ejabberdctl_interactive("leave_cluster", [], "no\n", Config),
-    verify_result(add),
+    %% then
+    distributed_helper:verify_result(add),
     ?ne(0, OpCode).
 
 leave_but_no_cluster(Config) ->
-    {_, OpCode} = ejabberdctl_interactive("leave_cluster", [], "no\n", Config),
-    verify_result(remove),
+    %% when
+    {_, OpCode} = ejabberdctl_interactive("leave_cluster", [], "yes\n", Config),
+    %% then
+    distributed_helper:verify_result(remove),
     ?ne(0, OpCode).
 
 join_twice(Config) ->
-    Node2 = ct:get_config(ejabberd2_node),
+    %% given
+    Node2 = mim2(),
+    %% when
     {_, OpCode1} = ejabberdctl_interactive("join_cluster", [atom_to_list(Node2)], "yes\n", Config),
     {_, OpCode2} = ejabberdctl_interactive("join_cluster", [atom_to_list(Node2)], "yes\n", Config),
-    verify_result(add),
+    %% then
+    distributed_helper:verify_result(add),
     ?eq(0, OpCode1),
     ?ne(0, OpCode2).
 
 leave_twice(Config) ->
+    %% given
     add_node_to_cluster(Config),
+    %% when
     {_, OpCode1} = ejabberdctl_interactive("leave_cluster", [], "yes\n", Config),
     {_, OpCode2} = ejabberdctl_interactive("leave_cluster", [], "yes\n", Config),
-    verify_result(remove),
+    %% then
+    distributed_helper:verify_result(remove),
     ?eq(0, OpCode1),
     ?ne(0, OpCode2).
 
+cluster_of_theree(Config) ->
+    %% given
+    ClusterMember = mim(),
+    Node2 = mim2(),
+    Node3 = fed(),
+    %% when
+    {_, OpCode1} = ejabberdctl_interactive(Node2, "join_cluster", [atom_to_list(ClusterMember)], "yes\n", Config),
+    {_, OpCode2} = ejabberdctl_interactive(Node3, "join_cluster", [atom_to_list(ClusterMember)], "yes\n", Config),
+    %% then
+    ?eq(0, OpCode1),
+    ?eq(0, OpCode2),
+    nodes_clustered(Node2, ClusterMember, true),
+    nodes_clustered(Node3, ClusterMember, true),
+    nodes_clustered(Node2, Node3, true).
+
+leave_the_theree(Config) ->
+    %% given
+    Timeout = timer:seconds(60),
+    ClusterMember = mim(),
+    Node2 = mim2(),
+    Node3 = fed(),
+    ok = rpc(Node2, mongoose_cluster, join, [ClusterMember], Timeout),
+    ok = rpc(Node3, mongoose_cluster, join, [ClusterMember], Timeout),
+    %% when
+    {_, OpCode1} = ejabberdctl_interactive(Node2, "leave_cluster", [], "yes\n", Config),
+    nodes_clustered(Node2, ClusterMember, false),
+    nodes_clustered(Node3, ClusterMember, true),
+    {_, OpCode2} = ejabberdctl_interactive(Node3, "leave_cluster", [], "yes\n", Config),
+    %% then
+    nodes_clustered(Node3, ClusterMember, false),
+    nodes_clustered(Node2, Node3, false),
+    ?eq(0, OpCode1),
+    ?eq(0, OpCode2).
+
 
 %% Helpers
-ejabberdctl_interactive(Cmd, Args, Response, Config) ->
-    CtlCmd = escalus_config:get_config(ctl_path, Config),
+ejabberdctl_interactive(C, A, R, Config) ->
+    DefaultNode = mim(),
+    ejabberdctl_interactive(DefaultNode, C, A, R, Config).
+ejabberdctl_interactive(Node, Cmd, Args, Response, Config) ->
+    CtlCmd = escalus_config:get_config(ctl_path_atom(Node), Config),
     run_interactive(string:join([CtlCmd, Cmd | normalize_args(Args)], " "), Response).
 
+ctl_path_atom(NodeName) ->
+    CtlString = atom_to_list(NodeName) ++ "_ctl",
+    list_to_atom(CtlString).
 normalize_args(Args) ->
     lists:map(fun
                   (Arg) when is_binary(Arg) ->
@@ -226,4 +323,14 @@ loop(Port, Data, Timeout) ->
     after Timeout ->
         throw(timeout)
     end.
+
+nodes_clustered(Node1, Node2, ShouldBe) ->
+    DbNodes1 = distributed_helper:rpc(Node1, mnesia, system_info, [running_db_nodes]),
+    DbNodes2 = distributed_helper:rpc(Node2, mnesia, system_info, [running_db_nodes]),
+    Pairs = [{Node1, DbNodes2, ShouldBe},
+        {Node2, DbNodes1, ShouldBe},
+        {Node1, DbNodes1, true},
+        {Node2, DbNodes2, true}],
+    [?assertEqual(ShouldBelong, lists:member(Element, List))
+        || {Element, List, ShouldBelong} <- Pairs].
 

--- a/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -17,9 +17,10 @@
 -module(cluster_commands_SUITE).
 -compile(export_all).
 
--import(distributed_helper, [add_node_to_cluster/1, mim/0, mim2/0, fed/0, rpc/5,
+-import(distributed_helper, [add_node_to_cluster/1, rpc/5,
         remove_node_from_cluster/1, is_sm_distributed/0]).
 -import(ejabberdctl_helper, [ejabberdctl/3, rpc_call/3]).
+-import(ejabberd_node_utils, [mim/0, mim2/0, fed/0]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").

--- a/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -47,8 +47,7 @@ groups() ->
             join_twice,
             leave_twice]},
         {clustering_theree, [shuffle],
-            [cluster_of_theree,
-             leave_the_theree]},
+            [cluster_of_theree, leave_the_theree]},
         {ejabberdctl, [], [set_master_test]}].
 suite() ->
     require_all_nodes() ++
@@ -56,8 +55,8 @@ suite() ->
 
 require_all_nodes() ->
     [{require, mim_node, {hosts, mim, node}},
-        {require, mim_node2, {hosts, mim2, node}},
-        {require, fed_node, {hosts, fed, node}}].
+     {require, mim_node2, {hosts, mim2, node}},
+     {require, fed_node, {hosts, fed, node}}].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -171,7 +170,7 @@ one_to_one_message(ConfigIn) ->
         %% Then Alice also receives it
         Stanza2 = escalus:wait_for_stanza(Alice, 5000),
         escalus:assert(is_chat_message, [<<"Oh hi!">>], Stanza2)
-                                                         end).
+    end).
 %%--------------------------------------------------------------------
 %% Ejabberdctl tests
 %%--------------------------------------------------------------------

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -74,7 +74,7 @@ should_belong(remove) -> false.
 
 cluster_op_timeout() ->
     %% This timeout is deliberately a long one.
-    timer:seconds(15).
+    timer:seconds(25).
 
 rpc(Node, M, F, A) ->
     rpc(Node, M, F, A, timer:seconds(5)).

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -3,7 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--import(ejabberd_node_utils, [get_cwd/2]).
+-import(ejabberd_node_utils, [get_cwd/2, mim/0, mim2/0, fed/0]).
 
 -compile(export_all).
 
@@ -81,19 +81,3 @@ rpc(Node, M, F, A) ->
 rpc(Node, M, F, A, TimeOut) ->
     Cookie = ct:get_config(ejabberd_cookie),
     escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie).
-
-get_or_fail(Key) ->
-    Val = ct:get_config(Key),
-    Val == undefined andalso error({undefined, Key}),
-    Val.
-
-
-%% MongooseIM node names
-mim() ->
-    get_or_fail({hosts, mim, node}).
-
-mim2() ->
-    get_or_fail({hosts, mim2, node}).
-
-fed() ->
-    get_or_fail({hosts, fed, node}).

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -73,7 +73,7 @@ should_belong(remove) -> false.
 
 cluster_op_timeout() ->
     %% This timeout is deliberately a long one.
-    timer:seconds(25).
+    timer:seconds(30).
 
 rpc(Node, M, F, A) ->
     rpc(Node, M, F, A, timer:seconds(5)).

--- a/test/ejabberd_tests/tests/distributed_helper.erl
+++ b/test/ejabberd_tests/tests/distributed_helper.erl
@@ -12,18 +12,17 @@ is_sm_distributed() ->
     is_sm_backend_distributed(Backend).
 
 is_sm_backend_distributed(ejabberd_sm_mnesia) -> true;
-is_sm_backend_distributed(Other)              -> {false, Other}.
+is_sm_backend_distributed(Other) -> {false, Other}.
 
 add_node_to_cluster(Config) ->
-    %% TODO: nodes should be described in a uniform fashion, not with adhoc names
-    Node = ct:get_config(ejabberd_node),
-    Node2 = ct:get_config(ejabberd2_node),
+    Node = mim(),
+    Node2 = mim2(),
     ok = rpc(Node2, mongoose_cluster, join, [Node], cluster_op_timeout()),
     verify_result(add),
     Config.
 
-remove_node_from_cluster(Config) ->
-    Node2 = ct:get_config(ejabberd2_node),
+remove_node_from_cluster(_Config) ->
+    Node2 = mim2(),
     ok = rpc(Node2, mongoose_cluster, leave, [], cluster_op_timeout()),
     verify_result(remove),
     ok.
@@ -43,33 +42,33 @@ wait_until_started(Cmd, Retries) ->
             ok;
         _ ->
             timer:sleep(1000),
-            wait_until_started(Cmd, Retries-1)
+            wait_until_started(Cmd, Retries - 1)
     end.
 
 wait_until_stopped(_, 0) ->
     erlang:error({timeout, stopping_node});
 wait_until_stopped(Cmd, Retries) ->
     case os:cmd(Cmd) of
-        "pong" ++ _->
+        "pong" ++ _ ->
             timer:sleep(1000),
-            wait_until_stopped(Cmd, Retries-1);
+            wait_until_stopped(Cmd, Retries - 1);
         _ ->
             ok
     end.
 
 verify_result(Op) ->
-    Node1 = ct:get_config(ejabberd_node),
-    Node2 = ct:get_config(ejabberd2_node),
+    Node1 = mim(),
+    Node2 = mim2(),
     DbNodes1 = rpc(Node1, mnesia, system_info, [running_db_nodes]),
     DbNodes2 = rpc(Node2, mnesia, system_info, [running_db_nodes]),
     Pairs = [{Node1, DbNodes2, should_belong(Op)},
-             {Node2, DbNodes1, should_belong(Op)},
-             {Node1, DbNodes1, true},
-             {Node2, DbNodes2, true}],
+        {Node2, DbNodes1, should_belong(Op)},
+        {Node1, DbNodes1, true},
+        {Node2, DbNodes2, true}],
     [?assertEqual(ShouldBelong, lists:member(Element, List))
-     || {Element, List, ShouldBelong} <- Pairs].
+        || {Element, List, ShouldBelong} <- Pairs].
 
-should_belong(add)    -> true;
+should_belong(add) -> true;
 should_belong(remove) -> false.
 
 cluster_op_timeout() ->
@@ -82,3 +81,19 @@ rpc(Node, M, F, A) ->
 rpc(Node, M, F, A, TimeOut) ->
     Cookie = ct:get_config(ejabberd_cookie),
     escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie).
+
+get_or_fail(Key) ->
+    Val = ct:get_config(Key),
+    Val == undefined andalso error({undefined, Key}),
+    Val.
+
+
+%% MongooseIM node names
+mim() ->
+    get_or_fail({hosts, mim, node}).
+
+mim2() ->
+    get_or_fail({hosts, mim2, node}).
+
+fed() ->
+    get_or_fail({hosts, fed, node}).

--- a/test/ejabberd_tests/tests/ejabberd_node_utils.erl
+++ b/test/ejabberd_tests/tests/ejabberd_node_utils.erl
@@ -17,15 +17,15 @@
 -module(ejabberd_node_utils).
 
 -export([init/1, init/2,
-         restart_application/1, restart_application/2,
-         call_fun/3, call_fun/4,
-         call_ctl/2, call_ctl/3,
-         call_ctl_with_args/3,
-         file_exists/1, file_exists/2,
-         backup_config_file/1, backup_config_file/2,
-         restore_config_file/1, restore_config_file/2,
-         modify_config_file/2, modify_config_file/4,
-         get_cwd/2]).
+    restart_application/1, restart_application/2,
+    call_fun/3, call_fun/4,
+    call_ctl/2, call_ctl/3,
+    call_ctl_with_args/3,
+    file_exists/1, file_exists/2,
+    backup_config_file/1, backup_config_file/2,
+    restore_config_file/1, restore_config_file/2,
+    modify_config_file/2, modify_config_file/4,
+    get_cwd/2, mim/0, mim2/0, fed/0]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -184,6 +184,19 @@ modify_config_file(Node, VarsFile, CfgVarsToChange, Config) ->
 get_cwd(Node, Config) ->
     ?CWD(Node, Config).
 
+%% MongooseIM node names
+-spec mim() -> node() | no_return().
+mim() ->
+    get_or_fail({hosts, mim, node}).
+
+-spec mim2() -> node() | no_return().
+mim2() ->
+    get_or_fail({hosts, mim2, node}).
+
+-spec fed() -> node() | no_return().
+fed() ->
+    get_or_fail({hosts, fed, node}).
+
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
@@ -196,3 +209,8 @@ update_config_variables(CfgVarsToChange, CfgVars) ->
     lists:foldl(fun({Var, Val}, Acc) ->
                         lists:keystore(Var, 1, Acc,{Var, Val})
                 end, CfgVars, CfgVarsToChange).
+
+get_or_fail(Key) ->
+    Val = ct:get_config(Key),
+    Val == undefined andalso error({undefined, Key}),
+    Val.

--- a/test/ejabberd_tests/tests/ejabberd_node_utils.erl
+++ b/test/ejabberd_tests/tests/ejabberd_node_utils.erl
@@ -56,7 +56,7 @@
 
 -spec init(ct_config()) -> ct_config().
 init(Config) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     init(Node, Config).
 
 init(Node, Config) ->
@@ -64,7 +64,7 @@ init(Node, Config) ->
 
 -spec restart_application(atom()) -> ok.
 restart_application(ApplicationName) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     restart_application(Node, ApplicationName).
 
 -spec restart_application(node(), atom()) -> ok.
@@ -75,7 +75,7 @@ restart_application(Node, ApplicationName) ->
 
 -spec backup_config_file(ct_config()) -> ct_config().
 backup_config_file(Config) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     backup_config_file(Node, Config).
 
 -spec backup_config_file(node(), ct_config()) -> ct_config().
@@ -85,7 +85,7 @@ backup_config_file(Node, Config) ->
 
 -spec restore_config_file(ct_config()) -> ct_config().
 restore_config_file(Config) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     restore_config_file(Node, Config).
 
 -spec restore_config_file(node(), ct_config()) -> ct_config().
@@ -95,7 +95,7 @@ restore_config_file(Node, Config) ->
 
 -spec call_fun(module(), atom(), []) -> term() | {badrpc, term()}.
 call_fun(M, F, A) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     call_fun(Node, M, F, A).
 
 -spec call_fun(node(), module(), atom(), []) -> term() | {badrpc, term()}.
@@ -107,7 +107,7 @@ call_fun(Node, M, F, A) ->
 %% For example to restart mongooseim call `call_ctl(restart, Config).'.
 -spec call_ctl(atom(), ct_config()) -> term() | term().
 call_ctl(Cmd, Config) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     call_ctl(Node, Cmd, Config).
 
 -spec call_ctl(node(), atom(), ct_config()) -> term() | term().
@@ -142,7 +142,7 @@ file_exists(Node, Filename) ->
       ConfigVariable :: atom(),
       Value :: string().
 modify_config_file(CfgVarsToChange, Config) ->
-    Node = ct:get_config(ejabberd_node),
+    Node = ct:get_config({hosts, mim, node}),
     modify_config_file(Node, "vars.config", CfgVarsToChange, Config).
 
 -spec modify_config_file(node(), string(), [{ConfigVariable, Value}], ct_config()) -> ok when

--- a/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
+++ b/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
@@ -23,6 +23,7 @@
 
 -import(ejabberdctl_helper, [ejabberdctl/3, rpc_call/3]).
 -import(mongoose_helper, [auth_modules/0]).
+-import(ejabberd_node_utils, [mim/0]).
 
 -define(SINGLE_QUOTE_CHAR, $\').
 -define(DOUBLE_QUOTE_CHAR, $\").
@@ -114,7 +115,7 @@ init_per_suite(Config) ->
     TemplatePath = Cwd ++ "/roster.template",
     start_mod_admin_extra(),
     AuthMods = auth_modules(),
-    Node = distributed_helper:mim(),
+    Node = mim(),
     Config1 = ejabberd_node_utils:init(Node, Config),
     Config2 = escalus:init_per_suite([{ctl_auth_mods, AuthMods},
                                         {roster_template, TemplatePath} | Config1]),

--- a/test/ejabberd_tests/tests/ejabberdctl_helper.erl
+++ b/test/ejabberd_tests/tests/ejabberdctl_helper.erl
@@ -13,7 +13,8 @@
 -export([ejabberdctl/3, rpc_call/3]).
 
 ejabberdctl(Cmd, Args, Config) ->
-    CtlCmd = escalus_config:get_config(ctl_path, Config),
+    Node = distributed_helper:mim(),
+    CtlCmd = distributed_helper:ctl_path(Node, Config),
     run(string:join([CtlCmd, Cmd | normalize_args(Args)], " ")).
 
 rpc_call(M, F, Args) ->

--- a/test/ejabberd_tests/tests/ejabberdctl_helper.erl
+++ b/test/ejabberd_tests/tests/ejabberdctl_helper.erl
@@ -9,11 +9,12 @@
 -module(ejabberdctl_helper).
 -author("ludwikbukowski").
 -include_lib("escalus/include/escalus.hrl").
+-import(ejabberd_node_utils, [mim/0]).
 %% API
 -export([ejabberdctl/3, rpc_call/3]).
 
 ejabberdctl(Cmd, Args, Config) ->
-    Node = distributed_helper:mim(),
+    Node = mim(),
     CtlCmd = distributed_helper:ctl_path(Node, Config),
     run(string:join([CtlCmd, Cmd | normalize_args(Args)], " ")).
 


### PR DESCRIPTION
This PR addresses https://github.com/esl/MongooseIM/issues/685

Proposed changes include:
* Replacing commands `add_to_cluster` and `remove_from_cluster` with brand-new
`join_cluster` and `leave_cluster` in _ejabberd_admin_ module. The commands use module _mongoose_cluster_ for the cluster management hence it's done completely at the Erlang level
* updated tests in _cluster_commands_SUITE_

