### PR TITLE
Mod_keystore clearing the table

### DIFF
--- a/apps/ejabberd/src/mod_keystore.erl
+++ b/apps/ejabberd/src/mod_keystore.erl
@@ -74,7 +74,7 @@ start(Domain, Opts) ->
 stop(Domain) ->
     [ ejabberd_hooks:delete(Hook, Domain, ?MODULE, Handler, Priority)
       || {Hook, Handler, Priority} <- hook_handlers() ],
-    delete_keystore_ets(),
+    clear_keystore_ets(Domain),
     ok.
 
 %%
@@ -119,9 +119,9 @@ create_keystore_ets() ->
             ok
     end.
 
-delete_keystore_ets() ->
-    ets:delete(keystore).
-
+clear_keystore_ets(Domain) ->
+    Pattern = {{'_', Domain}, '$1'},
+    ets:match_delete(keystore, Pattern).
 does_table_exist(NameOrTID) ->
     ets:info(NameOrTID, name) /= undefined.
 


### PR DESCRIPTION
This PR addresses https://github.com/esl/MongooseIM/issues/723

Proposed changes include:
* Clearing ets table `keystore` for appropriate domain when module stops instead of deleting the whole table.
* Added test in `keystore_SUITE` which checks `mod_keystore` functionality for multiple domains when the module stops for one of them