### PR TITLE
Xep 0092

### DIFF
--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -1,0 +1,15 @@
+-module(mod_version).
+-behaviour(gen_mod).
+-export([start/2, stop/1]).
+-include("jlib.hrl").
+-include("ejabberd.hrl").
+
+start(Host, Opts) ->
+    mod_disco:register_feature(Host, ?NS_VERSION),
+    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
+    gen_iq_handler:add_iq_handler(ejabberd_local, Host,
+                                  ?NS_VERSION, ?MODULE, process_local_iq, IQDisc).
+
+stop(Host) ->
+    mod_disco:unregister_feature(Host, ?NS_VERSION),
+    gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_VERSION).

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -1,6 +1,6 @@
 -module(mod_version).
 -behaviour(gen_mod).
--export([start/2, stop/1, process_local_iq/3]).
+-export([start/2, stop/1, process_iq/3, process_iq_with_os/3]).
 -include("jlib.hrl").
 -include("ejabberd.hrl").
 -xep([{xep, 92}, {version, "1.1"}]).
@@ -9,16 +9,22 @@ start(Host, Opts) ->
     mod_disco:register_feature(Host, ?NS_VERSION),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host,
-                                  ?NS_VERSION, ?MODULE, process_local_iq, IQDisc).
+                                  ?NS_VERSION, ?MODULE, get_iq_handler(Host), IQDisc).
 
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_VERSION),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_VERSION).
 
-process_local_iq(_From, _To, #iq{type = set, sub_el = SubEl} = IQ) ->
-    IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
+get_iq_handler(Host) ->
+    case gen_mod:get_module_opt(Host, ?MODULE, os_info, false) of
+        true -> process_iq_with_os;
+        false -> process_iq
+    end.
 
-process_local_iq(_From, _To, #iq{type = get} = IQ) ->
+process_iq(_From, _To, #iq{type = set} = IQ) ->
+    not_allowed(IQ);
+
+process_iq(_From, _To, #iq{type = get} = IQ) ->
     {Name, Version} = mongoose_info(),
     IQ#iq{type = result,
           sub_el =
@@ -29,6 +35,27 @@ process_local_iq(_From, _To, #iq{type = get} = IQ) ->
                                   children =[#xmlcdata{content = Name}]},
                            #xmlel{name = <<"version">>, attrs = [],
                                   children =[#xmlcdata{content = Version}]}]}]}.
+
+process_iq_with_os(_From, _To, #iq{type = set} = IQ) ->
+    not_allowed(IQ);
+
+process_iq_with_os(_From, _To, #iq{type = get} = IQ) ->
+    {Name, Version} = mongoose_info(),
+    OsInfo = os_info(),
+    IQ#iq{type = result,
+          sub_el =
+              [#xmlel{name = <<"query">>,
+                      attrs = [{<<"xmlns">>, ?NS_VERSION}],
+                      children =
+                          [#xmlel{name = <<"name">>, attrs = [],
+                                  children =[#xmlcdata{content = Name}]},
+                           #xmlel{name = <<"version">>, attrs = [],
+                                  children =[#xmlcdata{content = Version}]},
+                           #xmlel{name = <<"os">>, attrs = [],
+                                  children =[#xmlcdata{content = OsInfo}]}]}]}.
+
+not_allowed(#iq{sub_el = SubEl} = IQ) ->
+    IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]}.
 
 mongoose_info() ->
     {ok, Version} = application:get_key(mongooseim, vsn),

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -22,9 +22,8 @@ process_local_iq(_From, _To, #iq{type = get} = IQ) ->
     System = os_info().
 
 mongoose_info() ->
-    [{Name, Version}] =
-      [{N, V} || {mongooseim, N, V} <- application:which_applications()],
-    {Name, Version}.
+    {:ok, Version} = application:get_key(mongooseim, vsn),
+    {"MongooseIM", Version}.
 
 os_info() ->
     {Family, Name} = os:type(),
@@ -36,3 +35,9 @@ os_info() ->
         integer_to_list(Minor) ++ "." ++
         integer_to_list(Release)
     ).
+
+
+% TODO
+% Actually return a response
+% Get more specific system name (lsb_realease, /etc/issue etc.)
+% Include system name in reponse only if specified in options

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -35,7 +35,7 @@ process_iq(From, _To, #iq{type = get} = IQ) ->
 add_os_info(Host) ->
     case gen_mod:get_module_opt(Host, ?MODULE, os_info, false) of
 	true ->
-	    [#xmlel{name="os", attrs = [],
+	    [#xmlel{name = <<"os">>, attrs = [],
 		    children = [#xmlcdata{content = os_info()}]}];
 	_ ->
 	    []

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -5,16 +5,19 @@
 -include("ejabberd.hrl").
 -xep([{xep, 92}, {version, "1.1"}]).
 
+-spec start(ejabberd:server(), list()) -> any()
 start(Host, Opts) ->
     mod_disco:register_feature(Host, ?NS_VERSION),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host,
                                   ?NS_VERSION, ?MODULE, process_iq, IQDisc).
 
+-spec stop(ejabberd:server()) -> any()
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_VERSION),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_VERSION).
 
+-spec process_iq(#jid{}, #jid{}, #iq{}) -> #iq{}
 process_iq(_From, _To, #iq{type = set, sub_el = SubEl} = IQ) ->
     IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
 
@@ -32,6 +35,7 @@ process_iq(From, _To, #iq{type = get} = IQ) ->
                                   children =[#xmlcdata{content = Version}]}
 			  ] ++ add_os_info(Host)}]}.
 
+-spec add_os_info(binary()) -> [#xmlel{}] | []
 add_os_info(Host) ->
     case gen_mod:get_module_opt(Host, ?MODULE, os_info, false) of
 	true ->
@@ -41,11 +45,13 @@ add_os_info(Host) ->
 	    []
     end.   
 
+-spec mongoose_info() -> {binary(), binary()}
 mongoose_info() ->
     {ok, Version} = application:get_key(mongooseim, vsn),
     {ok, Name} = application:get_key(mongooseim, description),
     {list_to_binary(Name), list_to_binary(Version)}.
 
+-spec os_info() -> binary()
 os_info() ->
     {Family, Name} = os:type(),
     {Major, Minor, Release} = os:version(),

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -13,3 +13,26 @@ start(Host, Opts) ->
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_VERSION),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_VERSION).
+
+process_local_iq(_From, _To, #iq{type = set, sub_el = SubEl} = IQ) ->
+    IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
+
+process_local_iq(_From, _To, #iq{type = get} = IQ) ->
+    {Name, Version} = mongoose_info(),
+    System = os_info().
+
+mongoose_info() ->
+    [{Name, Version}] =
+      [{N, V} || {mongooseim, N, V} <- application:which_applications()],
+    {Name, Version}.
+
+os_info() ->
+    {Family, Name} = os:type(),
+    {Major, Minor, Release} = os:version(),
+    list_to_binary(
+        atom_to_list(Family) ++ " " ++
+        atom_to_list(Name) ++ " " ++
+        integer_to_list(Major) ++ "." ++
+        integer_to_list(Minor) ++ "." ++
+        integer_to_list(Release)
+    ).

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -1,6 +1,6 @@
 -module(mod_version).
 -behaviour(gen_mod).
--export([start/2, stop/1, process_iq/3, process_iq_with_os/3]).
+-export([start/2, stop/1, process_iq/3]).
 -include("jlib.hrl").
 -include("ejabberd.hrl").
 -xep([{xep, 92}, {version, "1.1"}]).
@@ -9,53 +9,37 @@ start(Host, Opts) ->
     mod_disco:register_feature(Host, ?NS_VERSION),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host,
-                                  ?NS_VERSION, ?MODULE, get_iq_handler(Host), IQDisc).
+                                  ?NS_VERSION, ?MODULE, process_iq, IQDisc).
 
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_VERSION),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_VERSION).
 
-get_iq_handler(Host) ->
+process_iq(_From, _To, #iq{type = set, sub_el = SubEl} = IQ) ->
+    IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
+
+process_iq(From, _To, #iq{type = get} = IQ) ->
+    {Name, Version} = mongoose_info(),
+    Host = From#jid.lserver,
+    IQ#iq{type = result,
+          sub_el =
+              [#xmlel{name = <<"query">>,
+                      attrs = [{<<"xmlns">>, ?NS_VERSION}],
+                      children =
+                          [#xmlel{name = <<"name">>, attrs = [],
+                                  children =[#xmlcdata{content = Name}]},
+                           #xmlel{name = <<"version">>, attrs = [],
+                                  children =[#xmlcdata{content = Version}]}
+			  ] ++ add_os_info(Host)}]}.
+
+add_os_info(Host) ->
     case gen_mod:get_module_opt(Host, ?MODULE, os_info, false) of
-        true -> process_iq_with_os;
-        false -> process_iq
-    end.
-
-process_iq(_From, _To, #iq{type = set} = IQ) ->
-    not_allowed(IQ);
-
-process_iq(_From, _To, #iq{type = get} = IQ) ->
-    {Name, Version} = mongoose_info(),
-    IQ#iq{type = result,
-          sub_el =
-              [#xmlel{name = <<"query">>,
-                      attrs = [{<<"xmlns">>, ?NS_VERSION}],
-                      children =
-                          [#xmlel{name = <<"name">>, attrs = [],
-                                  children =[#xmlcdata{content = Name}]},
-                           #xmlel{name = <<"version">>, attrs = [],
-                                  children =[#xmlcdata{content = Version}]}]}]}.
-
-process_iq_with_os(_From, _To, #iq{type = set} = IQ) ->
-    not_allowed(IQ);
-
-process_iq_with_os(_From, _To, #iq{type = get} = IQ) ->
-    {Name, Version} = mongoose_info(),
-    OsInfo = os_info(),
-    IQ#iq{type = result,
-          sub_el =
-              [#xmlel{name = <<"query">>,
-                      attrs = [{<<"xmlns">>, ?NS_VERSION}],
-                      children =
-                          [#xmlel{name = <<"name">>, attrs = [],
-                                  children =[#xmlcdata{content = Name}]},
-                           #xmlel{name = <<"version">>, attrs = [],
-                                  children =[#xmlcdata{content = Version}]},
-                           #xmlel{name = <<"os">>, attrs = [],
-                                  children =[#xmlcdata{content = OsInfo}]}]}]}.
-
-not_allowed(#iq{sub_el = SubEl} = IQ) ->
-    IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]}.
+	true ->
+	    [#xmlel{name="os", attrs = [],
+		    children = [#xmlcdata{content = os_info()}]}];
+	_ ->
+	    []
+    end.   
 
 mongoose_info() ->
     {ok, Version} = application:get_key(mongooseim, vsn),

--- a/apps/ejabberd/src/mod_version.erl
+++ b/apps/ejabberd/src/mod_version.erl
@@ -5,19 +5,19 @@
 -include("ejabberd.hrl").
 -xep([{xep, 92}, {version, "1.1"}]).
 
--spec start(ejabberd:server(), list()) -> any()
+-spec start(ejabberd:server(), list()) -> any().
 start(Host, Opts) ->
     mod_disco:register_feature(Host, ?NS_VERSION),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host,
                                   ?NS_VERSION, ?MODULE, process_iq, IQDisc).
 
--spec stop(ejabberd:server()) -> any()
+-spec stop(ejabberd:server()) -> any().
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_VERSION),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_VERSION).
 
--spec process_iq(#jid{}, #jid{}, #iq{}) -> #iq{}
+-spec process_iq(#jid{}, #jid{}, #iq{}) -> #iq{}.
 process_iq(_From, _To, #iq{type = set, sub_el = SubEl} = IQ) ->
     IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
 
@@ -35,7 +35,7 @@ process_iq(From, _To, #iq{type = get} = IQ) ->
                                   children =[#xmlcdata{content = Version}]}
 			  ] ++ add_os_info(Host)}]}.
 
--spec add_os_info(binary()) -> [#xmlel{}] | []
+-spec add_os_info(binary()) -> [#xmlel{}] | [].
 add_os_info(Host) ->
     case gen_mod:get_module_opt(Host, ?MODULE, os_info, false) of
 	true ->
@@ -45,13 +45,13 @@ add_os_info(Host) ->
 	    []
     end.   
 
--spec mongoose_info() -> {binary(), binary()}
+-spec mongoose_info() -> {binary(), binary()}.
 mongoose_info() ->
     {ok, Version} = application:get_key(mongooseim, vsn),
     {ok, Name} = application:get_key(mongooseim, description),
     {list_to_binary(Name), list_to_binary(Version)}.
 
--spec os_info() -> binary()
+-spec os_info() -> binary().
 os_info() ->
     {Family, Name} = os:type(),
     {Major, Minor, Release} = os:version(),
@@ -62,3 +62,4 @@ os_info() ->
         integer_to_list(Minor) ++ "." ++
         integer_to_list(Release)
     ).
+

--- a/doc/modules/mod_version.md
+++ b/doc/modules/mod_version.md
@@ -1,0 +1,14 @@
+### Module description
+
+This module provides functionality specified in [XEP-0092: Software Version](https://xmpp.org/extensions/xep-0092.html).
+
+
+### Options
+
+* **iqdisc**
+* **os_info** (boolean, default: `false`) - Determines wheter information about operating system will be included.
+
+### Example configuration 
+```
+{mod_version, []}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ pages:
       - 'mod_stream_management': 'modules/mod_stream_management.md'
       - 'mod_time': 'modules/mod_time.md'
       - 'mod_vcard': 'modules/mod_vcard.md'
+      - 'mod_version': 'modules/mod_version.md'
       - 'mod_websockets': 'modules/mod_websockets.md'
   - 'Operation and maintenance':
       - 'Cluster configuration and node management': 'operation-and-maintenance/Cluster-configuration-and-node-management.md'

--- a/test/ejabberd_tests/default.spec
+++ b/test/ejabberd_tests/default.spec
@@ -32,6 +32,7 @@
 {suites, "tests", mod_http_notification_SUITE}.
 {suites, "tests", mod_ping_SUITE}.
 {suites, "tests", mod_time_SUITE}.
+{suites, "tests", mod_version_SUITE}.
 {suites, "tests", muc_SUITE}.
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.

--- a/test/ejabberd_tests/tests/mod_version_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_version_SUITE.erl
@@ -58,7 +58,7 @@ version_service_discovery(Config) ->
 
 ask_for_version(Config) ->
     escalus:story(Config, [{bob, 1}], fun(Bob) ->
-        Server = escalus_users:get_server(Config, alice),
+        Server = escalus_users:get_server(Config, bob),
         ID = escalus_stanza:id(),
         SoftStanza = soft_version_stanza(Server, ID),
         escalus_client:send(Bob, SoftStanza),

--- a/test/ejabberd_tests/tests/mod_version_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_version_SUITE.erl
@@ -80,19 +80,28 @@ check_namespace(#xmlel{name = <<"iq">>, attrs = _, children = [Child]}) ->
     case Child of
         #xmlel{name = <<"query">>,
                attrs = [{<<"xmlns">>, ?NS_SOFT_VERSION}],
-               children = _}
-            -> true;
-        _   -> false
+               children = _} ->
+            true;
+        _ ->
+            false
     end;
 
 check_namespace(_) -> false.
 
-check_name_and_version_presence(#xmlel{name = <<"iq">>, attrs = _, children = Children}) ->
-    case Children of
-        [#xmlel{name = <<"name">>, attrs = [], children = [#xmlcdata{content = _}]},
-         #xmlel{name = <<"version">>, attrs = [], children = [#xmlcdata{content = _}]}]
-            -> true;
-        _   -> false
+check_name_and_version_presence(#xmlel{name = <<"iq">>, attrs = _, children = [Child]}) ->
+    case Child of
+        #xmlel{name = <<"query">>,
+               attrs = [{<<"xmlns">>, ?NS_SOFT_VERSION}],
+               children = Children} ->
+                   case Children of
+                       [#xmlel{name = <<"name">>, attrs = [], children = [#xmlcdata{content = _}]},
+                        #xmlel{name = <<"version">>, attrs = [], children = [#xmlcdata{content = _}]}] ->
+                            true;
+                        _ ->
+                            false
+                   end;
+        _ ->
+            false
     end;
 
 check_name_and_version_presence(_) -> false.

--- a/test/ejabberd_tests/tests/mod_version_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_version_SUITE.erl
@@ -13,7 +13,7 @@ all() ->
     [{group, mod_version}].
 
 groups() ->
-    [{mod_version, [], [version_service_discovery]}].
+    [{mod_version, [], [version_service_discovery, ask_for_version]}].
 
 suite() ->
     escalus:suite().
@@ -31,10 +31,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(mod_version, Config) ->
-    escalus:create_users(Config, escalus:get_users([alice])).
+    escalus:create_users(Config, escalus:get_users([bob])).
 
 end_per_group(mod_version, Config) ->
-    escalus:delete_users(Config, escalus:get_users([alice])).
+    escalus:delete_users(Config, escalus:get_users([bob])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -47,11 +47,52 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 
 version_service_discovery(Config) ->
-    escalus:story(Config, [{alice, 1}],
-        fun(Alice) ->
-            ServJID = escalus_client:server(Alice),
-            Result = escalus:send_and_wait(Alice,
+    escalus:story(Config, [{bob, 1}],
+        fun(Bob) ->
+            ServJID = escalus_client:server(Bob),
+            Result = escalus:send_and_wait(Bob,
                                            escalus_stanza:disco_info(ServJID)),
             escalus:assert(is_iq_result, Result),
             escalus:assert(has_feature, [?NS_SOFT_VERSION], Result)
         end).
+
+ask_for_version(Config) ->
+    escalus:story(Config, [{bob, 1}], fun(Bob) ->
+        Server = escalus_users:get_server(Config, alice),
+        ID = escalus_stanza:id(),
+        SoftStanza = soft_version_stanza(Server, ID),
+        escalus_client:send(Bob, SoftStanza),
+        Reply = escalus:wait_for_stanza(Bob, 5000),
+        escalus:assert(is_iq_result, Reply),
+        escalus:assert(fun check_namespace/1, Reply),
+        escalus:assert(fun check_name_and_version_presence/1, Reply)
+    end).
+
+soft_version_stanza(Server, ID) ->
+    #xmlel{name = <<"iq">>,
+           attrs = [{<<"type">>, <<"get">>},
+                    {<<"to">>, Server},
+                    {<<"id">>, ID}],
+           children = [#xmlel{name = <<"query">>,
+                              attrs = [{<<"xmlns">>, ?NS_SOFT_VERSION}]}]}.
+
+check_namespace(#xmlel{name = <<"iq">>, attrs = _, children = [Child]}) ->
+    case Child of
+        #xmlel{name = <<"query">>,
+               attrs = [{<<"xmlns">>, ?NS_SOFT_VERSION}],
+               children = _}
+            -> true;
+        _   -> false
+    end;
+
+check_namespace(_) -> false.
+
+check_name_and_version_presence(#xmlel{name = <<"iq">>, attrs = _, children = Children}) ->
+    case Children of
+        [#xmlel{name = <<"name">>, attrs = [], children = [#xmlcdata{content = _}]},
+         #xmlel{name = <<"version">>, attrs = [], children = [#xmlcdata{content = _}]}]
+            -> true;
+        _   -> false
+    end;
+
+check_name_and_version_presence(_) -> false.

--- a/test/ejabberd_tests/tests/mod_version_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_version_SUITE.erl
@@ -1,0 +1,57 @@
+-module(mod_version_SUITE).
+-compile(export_all).
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("exml/include/exml.hrl").
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, mod_version}].
+
+groups() ->
+    [{mod_version, [], [version_service_discovery]}].
+
+suite() ->
+    escalus:suite().
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    dynamic_modules:start(<<"localhost">>, mod_version, []),
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    dynamic_modules:stop(<<"localhost">>, mod_version),
+    escalus:end_per_suite(Config).
+
+init_per_group(mod_version, Config) ->
+    escalus:create_users(Config, escalus:get_users([alice])).
+
+end_per_group(mod_version, Config) ->
+    escalus:delete_users(Config, escalus:get_users([alice])).
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+%%--------------------------------------------------------------------
+%% Service discovery test
+%%--------------------------------------------------------------------
+
+version_service_discovery(Config) ->
+    escalus:story(Config, [{alice, 1}],
+        fun(Alice) ->
+            ServJID = escalus_client:server(Alice),
+            Result = escalus:send_and_wait(Alice,
+                                           escalus_stanza:disco_info(ServJID)),
+            escalus:assert(is_iq_result, Result),
+            escalus:assert(has_feature, [?NS_SOFT_VERSION], Result)
+        end).


### PR DESCRIPTION
This PR addresses #678 

Proposed changes include:
* response with software name and version (currently name is taken from mongoose configuration)
* tests cover service discovery and checking wheter version and name are included in a response

I would also like to return operating system info and  software name based on user's configuration.
Is there a way to keep configuration options during module lifetime, or should I register different functions for processing iqs based on different options passed to `start/1` ? 

