### PR TITLE
escalus_ejabberd as default escalus_user_db in tests

### DIFF
--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -35,8 +35,8 @@
                  {domain, <<"fed">>},
                  {cluster, fed}]}]}.
 
-%% Use XMPP in-band registration for creating/deleting test users
-{escalus_user_db, xmpp}.
+%% Use RPC and ejabberd_auth API for creating/deleting test users
+{escalus_user_db, {module, escalus_ejabberd}}.
 {escalus_xmpp_server, escalus_mongooseim}.
 
 %% Use modules that implement the escalus_user_db behaviour:
@@ -124,7 +124,7 @@
     {astrid, [
         {username, <<"astrid">>},
         {server, <<"sogndal">>},
-        {host, <<"localhost">>},      
+        {host, <<"localhost">>},
         {password, <<"doctor">>}]},
     {alice2, [
         {username, <<"alice">>},

--- a/test/ejabberd_tests/tests/login_SUITE.erl
+++ b/test/ejabberd_tests/tests/login_SUITE.erl
@@ -86,7 +86,7 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    escalus:init_per_suite(Config).
+    [{escalus_user_db, xmpp} | escalus:init_per_suite(Config)].
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).

--- a/test/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test/ejabberd_tests/tests/s2s_SUITE.erl
@@ -95,7 +95,8 @@ init_per_suite(Config0) ->
                     node2_s2s_use_starttls = Node2S2SUseStartTLS},
 
     Config1 = [{s2s_opts, S2S} | escalus:init_per_suite(Config0)],
-    escalus:create_users(Config1, escalus:get_users([alice2, bob2, alice, bob])).
+    Config2 = [{escalus_user_db, xmpp} | Config1],
+    escalus:create_users(Config2, escalus:get_users([alice2, bob2, alice, bob])).
 
 end_per_suite(Config) ->
     S2SOrig = ?config(s2s_opts, Config),


### PR DESCRIPTION
In most cases it's enough to just register/remove users by doing rpc calls to the server. This will shorten the time required for users registration before the real test case which makes parallel tests with fresh users even more efficient.

