### PR TITLE
Stabilise and clean tests

### DIFF
--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -675,7 +675,6 @@
   {{mod_offline}}
   {{mod_privacy}}
   {{mod_private}}
-  {{mod_http_notification}}
 % {mod_private, [{backend, mnesia}]},
 % {mod_private, [{backend, odbc}]},
   {mod_register, [

--- a/rel/reltool_vars/node1_vars.config
+++ b/rel/reltool_vars/node1_vars.config
@@ -37,7 +37,6 @@
                 "%{search, true},\n"
                 "%{host, directory.@HOST@}\n"
                 "]},"}.
-{mod_http_notification, "{mod_http_notification, [{pool_size, 5}, {host, \"http://localhost:8000\"}]},"}.
 {cowboy_port, 5280}.
 {cowboy_port_secure, 5285}.
 { {s2s_addr, "localhost2"}, {127,0,0,1} }.

--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -20,7 +20,6 @@
                 "%{search, true},\n"
                 "%{host, directory.@HOST@}\n"
                 "]},"}.
-{mod_http_notification, "{mod_http_notification, []},"}.
 {http_api_endpoint, "{5289, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -9,6 +9,7 @@
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},
         {katt, ".*", {git, "git://github.com/for-GET/katt.git", {tag, "1.3.1-rc"}}},
+        {erlsh, ".*", {git, "git://github.com/proger/erlsh.git", "2fce513"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "20e62bc32f9bd43fe2ff52944a4ef99eb71d1399"}}
 ]}.
 

--- a/test/ejabberd_tests/tests/connect_SUITE.erl
+++ b/test/ejabberd_tests/tests/connect_SUITE.erl
@@ -257,6 +257,9 @@ clients_can_connect_with_advertised_ciphers(Config) ->
                          ciphers_working_with_ssl_clients(Config))).
 
 'clients_can_connect_with_DHE-RSA-AES256-SHA_only'(Config) ->
+    CiphersStr = os:cmd("openssl ciphers 'DHE-RSA-AES256-SHA'"),
+    ct:pal("Available cipher suites for : ~s", [CiphersStr]),
+    ct:pal("Openssl version: ~s", [os:cmd("openssl version")]),
     ?assertEqual(["DHE-RSA-AES256-SHA"],
                  ciphers_working_with_ssl_clients(Config)).
 

--- a/test/ejabberd_tests/tests/connect_SUITE.erl
+++ b/test/ejabberd_tests/tests/connect_SUITE.erl
@@ -492,9 +492,9 @@ ciphers_working_with_ssl_clients(Config) ->
 openssl_client_can_use_cipher(Cipher, Port) ->
     PortStr = integer_to_list(Port),
     Cmd = "echo '' | openssl s_client -connect localhost:" ++ PortStr ++
-        " -cipher " "\"" ++ Cipher ++ "\" 2>&1"
-        " | grep 'Cipher is " ++ Cipher ++ "'",
-    [] =/= os:cmd(Cmd).
+          " -cipher " "\"" ++ Cipher ++ "\" 2>&1",
+    {done, ReturnCode, _Result} = erlsh:oneliner(Cmd),
+    0 == ReturnCode.
 
 restore_ejabberd_node(Config) ->
     ejabberd_node_utils:restore_config_file(Config),

--- a/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
@@ -32,7 +32,7 @@ suite() ->
     escalus:suite().
 
 set_worker_timeout() ->
-    dynamic_modules:restart(host(), mod_http_notification, [{worker_timeout, 500}, {host, "http://localhost:8000"}]),
+    dynamic_modules:start(host(), mod_http_notification, [{worker_timeout, 500}, {host, "http://localhost:8000"}]),
     ok.
 
 host() -> <<"localhost">>.
@@ -43,6 +43,7 @@ init_per_suite(Config0) ->
     escalus:create_users(Config1, escalus:get_users({by_name, [alice, bob]})).
 
 end_per_suite(Config) ->
+    dynamic_modules:stop(host(), mod_http_notification),
     escalus:delete_users(Config, {by_name, [alice, bob]}),
     escalus:end_per_suite(Config).
 


### PR DESCRIPTION
Proposed changes include:
* module used by mod_http_notification_SUITE is started only for the suite
* optimised connect_SUITE (by running more test cases in parallel)
* uses [proger/erlsh](https://github.com/proger/erlsh) to run `opnessl s_client` command to get status code - fixes strange and random failures of `node2_supports_DHE-RSA-AES256-SHA_only'}]
    end.
` test case
