### PR TITLE
Make calls to accept/3 and udp_recv/3 fully qualified

### DIFF
--- a/apps/ejabberd/src/ejabberd_listener.erl
+++ b/apps/ejabberd/src/ejabberd_listener.erl
@@ -29,6 +29,8 @@
 
 -export([start_link/0, init/1, start/3,
          init/3,
+         accept/3,
+         udp_recv/3,
          start_listeners/0,
          start_listener/3,
          stop_listeners/0,
@@ -143,7 +145,7 @@ init_udp(PortIPProto, Module, Opts, SockOpts, Port, IPS) ->
         {ok, Socket} ->
             %% Inform my parent that this port was opened succesfully
             proc_lib:init_ack({ok, self()}),
-            udp_recv(Socket, Module, Opts);
+            ?MODULE:udp_recv(Socket, Module, Opts);
         {error, Reason} ->
             socket_error(Reason, PortIPProto, Module, SockOpts, Port, IPS)
     end.
@@ -159,7 +161,7 @@ init_tcp(PortIPProto, Module, Opts, SockOpts, Port, IPS) ->
     %% Inform my parent that this port was opened succesfully
     proc_lib:init_ack({ok, self()}),
     %% And now start accepting connection attempts
-    accept(ListenSocket, Module, Opts).
+    ?MODULE:accept(ListenSocket, Module, Opts).
 
 -spec listen_tcp(PortIPPRoto :: port_ip_proto(),
                  Module :: atom(),
@@ -319,11 +321,11 @@ accept(ListenSocket, Module, Opts) ->
                     ok
             end,
             ejabberd_socket:start(Module, gen_tcp, Socket, Opts),
-            accept(ListenSocket, Module, Opts);
+            ?MODULE:accept(ListenSocket, Module, Opts);
         {error, Reason} ->
             ?INFO_MSG("(~w) Failed TCP accept: ~w",
                       [ListenSocket, Reason]),
-            accept(ListenSocket, Module, Opts)
+            ?MODULE:accept(ListenSocket, Module, Opts)
     end.
 
 -spec udp_recv(Socket :: port(),
@@ -341,7 +343,7 @@ udp_recv(Socket, Module, Opts) ->
                 _ ->
                     ok
             end,
-            udp_recv(Socket, Module, Opts);
+            ?MODULE:udp_recv(Socket, Module, Opts);
         {error, Reason} ->
             ?ERROR_MSG("unexpected UDP error: ~s", [format_error(Reason)]),
             throw({error, Reason})

--- a/apps/ejabberd/test/ejabberd_listener_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_listener_SUITE.erl
@@ -4,8 +4,15 @@
 
 all() ->
     [tcp_socket_is_started_with_default_backlog,
-     tcp_socket_is_started_with_options].
+     tcp_socket_is_started_with_options,
+     udp_socket_is_started_with_defaults].
 
+init_per_testcase(udp_socket_is_started_with_defaults, C) ->
+    meck:new(gen_udp, [unstick, passthrough]),
+    meck:expect(gen_udp, open, fun(Port, Opts) ->
+                                       meck:passthrough([Port, Opts])
+                               end),
+    C;
 init_per_testcase(_T, C) ->
     meck:new(gen_tcp, [unstick, passthrough]),
     meck:expect(gen_tcp, listen, fun(Port, Opts) ->
@@ -13,6 +20,9 @@ init_per_testcase(_T, C) ->
                                  end),
     C.
 
+end_per_testcase(udp_socket_is_started_with_defaults, C) ->
+    meck:unload(gen_udp),
+    C;
 end_per_testcase(_T, C) ->
     meck:unload(gen_tcp),
     C.
@@ -35,9 +45,23 @@ tcp_socket_is_started_with_options(_C) ->
     50 = proplists:get_value(backlog, Opts).
 
 
+udp_socket_is_started_with_defaults(_C) ->
+    {ok, _Pid} = receiver_started([]),
+
+    [{_Pid, {gen_udp, open, [_, Opts]}, _Result}] =  meck:history(gen_udp),
+
+    {0,0,0,0} = proplists:get_value(ip, Opts).
+
 listener_started(Opts) ->
     ets:new(listen_sockets, [named_table, public]),
     proc_lib:start_link(ejabberd_listener, init, [tcp_port_ip(), ?MODULE, Opts]).
+
+receiver_started(Opts) ->
+    ets:new(listen_sockets, [named_table, public]),
+    proc_lib:start_link(ejabberd_listener, init, [udp_port_ip(), ?MODULE, Opts]).
+
+udp_port_ip() ->
+    {1805, {0,0,0,0}, udp}.
 
 tcp_port_ip() ->
     {1805, {0,0,0,0}, tcp}.


### PR DESCRIPTION
Calls to accept/3 and udp_recv/3 are local. This results in the ejabberd_listener keeping
the old version of code. The manual code reloading forces the listener process to crash.
With fully qualified calls the manual code reloading would not
crash the listener process.