### PR TITLE
Privacy fixes and a bit of cleanup

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -132,6 +132,8 @@
         jlib:stanza_error(<<"400">>,<<"modify">>,<<"jid-malformed">>)).
 -define(ERR_NOT_ACCEPTABLE,
         jlib:stanza_error(<<"406">>,<<"modify">>,<<"not-acceptable">>)).
+-define(ERR_NOT_ACCEPTABLE_CANCEL,
+        jlib:stanza_error(<<"406">>,<<"cancel">>,<<"not-acceptable">>)).
 -define(ERR_NOT_ALLOWED,
         jlib:stanza_error(<<"405">>,<<"cancel">>,<<"not-allowed">>)).
 -define(ERR_NOT_AUTHORIZED,

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1938,8 +1938,6 @@ presence_track(From, To, Packet, StateData) ->
 check_privacy_and_route(From, StateData, FromRoute, To, Packet) ->
     case privacy_check_packet(StateData, From, To, Packet, out) of
         deny ->
-            Lang = StateData#state.lang,
-            ErrText = <<"Your active privacy list has denied the routing of this stanza.">>,
             Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_CANCEL),
             ejabberd_router:route(To, From, Err),
             ok;

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -987,26 +987,24 @@ process_outgoing_stanza(error, _Name, Args) ->
     end;
 process_outgoing_stanza(ToJID, <<"presence">>, Args) ->
     {_Attrs, NewEl, FromJID, StateData, Server, User} = Args,
-    PresenceEl = ejabberd_hooks:run_fold(
-        c2s_update_presence,
-        Server,
-        NewEl,
-        [User, Server]),
-    ejabberd_hooks:run(
-        user_send_packet,
-        Server,
-        [FromJID, ToJID, PresenceEl]),
+    PresenceEl = ejabberd_hooks:run_fold(c2s_update_presence,
+                                         Server,
+                                         NewEl,
+                                         [User, Server]),
+    ejabberd_hooks:run(user_send_packet,
+                       Server,
+                       [FromJID, ToJID, PresenceEl]),
     case ToJID of
         #jid{user = User,
-            server = Server,
-            resource = <<>>} ->
-            ?DEBUG("presence_update(~p,~n\t~p,~n\t~p)",
-                [FromJID, PresenceEl, StateData]),
-            presence_update(FromJID, PresenceEl,
-                StateData);
+             server = Server,
+             resource = <<>>} ->
+             ?DEBUG("presence_update(~p,~n\t~p,~n\t~p)",
+                 [FromJID, PresenceEl, StateData]),
+             presence_update(FromJID, PresenceEl,
+                             StateData);
         _ ->
-            presence_track(FromJID, ToJID, PresenceEl,
-                StateData)
+             presence_track(FromJID, ToJID, PresenceEl,
+                            StateData)
     end;
 process_outgoing_stanza(ToJID, <<"iq">>, Args) ->
     {_Attrs, NewEl, FromJID, StateData, Server, _User} = Args,
@@ -1014,23 +1012,21 @@ process_outgoing_stanza(ToJID, <<"iq">>, Args) ->
         #iq{xmlns = Xmlns} = IQ
             when Xmlns == ?NS_PRIVACY;
             Xmlns == ?NS_BLOCKING ->
-            process_privacy_iq(
-                FromJID, ToJID, IQ, StateData);
+            process_privacy_iq(FromJID, ToJID, IQ, StateData);
         _ ->
-            ejabberd_hooks:run(
-                user_send_packet,
-                Server,
-                [FromJID, ToJID, NewEl]),
+            ejabberd_hooks:run(user_send_packet,
+                               Server,
+                               [FromJID, ToJID, NewEl]),
             check_privacy_and_route(FromJID, StateData, FromJID, ToJID, NewEl),
             StateData
     end;
 process_outgoing_stanza(ToJID, <<"message">>, Args) ->
     {_Attrs, NewEl, FromJID, StateData, Server, _User} = Args,
     ejabberd_hooks:run(user_send_packet,
-        Server,
-        [FromJID, ToJID, NewEl]),
+                       Server,
+                       [FromJID, ToJID, NewEl]),
     check_privacy_and_route(FromJID, StateData, FromJID,
-        ToJID, NewEl),
+                            ToJID, NewEl),
     StateData;
 process_outgoing_stanza(_ToJID, _Name, Args) ->
     {_Attrs, _NewEl, _FromJID, StateData, _Server, _User} = Args,
@@ -1892,28 +1888,28 @@ presence_track(From, To, Packet, StateData) ->
                                Server,
                                [User, Server, To, subscribe]),
             check_privacy_and_route(From, StateData, jid:to_bare(From),
-                                To, Packet),
+                                    To, Packet),
             StateData;
         <<"subscribed">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, subscribed]),
             check_privacy_and_route(From, StateData, jid:to_bare(From),
-                                To, Packet),
+                                    To, Packet),
             StateData;
         <<"unsubscribe">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, unsubscribe]),
             check_privacy_and_route(From, StateData, jid:to_bare(From),
-                                To, Packet),
+                                    To, Packet),
             StateData;
         <<"unsubscribed">> ->
             ejabberd_hooks:run(roster_out_subscription,
                                Server,
                                [User, Server, To, unsubscribed]),
             check_privacy_and_route(From, StateData, jid:to_bare(From),
-                                To, Packet),
+                                    To, Packet),
             StateData;
         <<"error">> ->
             check_privacy_and_route(From, StateData, From, To, Packet),
@@ -1931,10 +1927,10 @@ presence_track(From, To, Packet, StateData) ->
 
 
 -spec check_privacy_and_route(From :: 'undefined' | ejabberd:jid(),
-                          StateData :: state(),
-                          FromRoute :: ejabberd:jid(),
-                          To :: ejabberd:jid(),
-                          Packet :: jlib:xmlel()) -> 'ok'.
+                              StateData :: state(),
+                              FromRoute :: ejabberd:jid(),
+                              To :: ejabberd:jid(),
+                              Packet :: jlib:xmlel()) -> 'ok'.
 check_privacy_and_route(From, StateData, FromRoute, To, Packet) ->
     case privacy_check_packet(StateData, From, To, Packet, out) of
         deny ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1224,13 +1224,15 @@ process_incoming_stanza(Name, From, To, Packet, StateName, StateData) ->
     end.
 
 response_negative(<<"iq">>, forbidden, From, To, Packet) ->
-    Err = jlib:make_error_reply(Packet, ?ERR_FORBIDDEN),
-    ejabberd_router:route(To, From, Err);
+    send_back_error(?ERR_FORBIDDEN, From, To, Packet);
 response_negative(<<"iq">>, deny, From, To, Packet) ->
-    Err = jlib:make_error_reply(Packet, ?ERR_SERVICE_UNAVAILABLE),
-    ejabberd_router:route(To, From, Err);
+    send_back_error(?ERR_SERVICE_UNAVAILABLE, From, To, Packet);
 response_negative(_, _, _, _, _) ->
     ok.
+
+send_back_error(Etype, From, To, Packet) ->
+    Err = jlib:make_error_reply(Packet, Etype),
+    ejabberd_router:route(To, From, Err).
 
 -spec legacy_packet_to_broadcast({xmlel, any(), any(), list()}) -> {broadcast, broadcast_type()}.
 legacy_packet_to_broadcast({xmlel, _, _, [Child]}) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1940,7 +1940,7 @@ check_privacy_and_route(From, StateData, FromRoute, To, Packet) ->
         deny ->
             Lang = StateData#state.lang,
             ErrText = <<"Your active privacy list has denied the routing of this stanza.">>,
-            Err = jlib:make_error_reply(Packet, ?ERRT_NOT_ACCEPTABLE(Lang, ErrText)),
+            Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_CANCEL),
             ejabberd_router:route(To, From, Err),
             ok;
         allow ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -349,8 +349,7 @@ check_packet_aux([Item | List], PType, MType, JID, Subscription, Groups) ->
                         true ->
                             Action;
                         false ->
-                            check_packet_aux(
-                                List, PType, MType, JID, Subscription, Groups)
+                            check_packet_aux(List, PType, MType, JID, Subscription, Groups)
                     end
             end;
         false ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -329,12 +329,15 @@ check_packet(_, User, Server,
                 false ->
                     {[], []}
             end,
-            check_packet_aux(List, PType, LJID, Subscription, Groups)
+            Type = xml:get_attr_s(<<"type">>, Packet#xmlel.attrs),
+            check_packet_aux(List, PType, Type, LJID, Subscription, Groups)
     end.
 
-check_packet_aux([], _PType, _JID, _Subscription, _Groups) ->
+check_packet_aux(_, message, <<"error">>, _JID, _Subscription, _Groups) ->
     allow;
-check_packet_aux([Item | List], PType, JID, Subscription, Groups) ->
+check_packet_aux([], _PType, _Type, _JID, _Subscription, _Groups) ->
+    allow;
+check_packet_aux([Item | List], PType, MType, JID, Subscription, Groups) ->
     #listitem{type = Type, value = Value, action = Action} = Item,
     case is_ptype_match(Item, PType) of
         true ->
@@ -347,11 +350,11 @@ check_packet_aux([Item | List], PType, JID, Subscription, Groups) ->
                             Action;
                         false ->
                             check_packet_aux(
-                                List, PType, JID, Subscription, Groups)
+                                List, PType, MType, JID, Subscription, Groups)
                     end
             end;
         false ->
-            check_packet_aux(List, PType, JID, Subscription, Groups)
+            check_packet_aux(List, PType, MType, JID, Subscription, Groups)
     end.
 
 is_ptype_match(Item, PType) ->
@@ -423,7 +426,7 @@ updated_list(_,
 
 packet_directed_type(Dir, Type) ->
     case {Type, Dir} of
-         {message, in} -> message;
+         {message, _} -> message;
          {iq, in} -> iq;
          {presence, in} -> presence_in;
          {presence, out} -> presence_out;

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -386,14 +386,14 @@ block_jid_message(Config) ->
 
         %% Alice should NOT receive message, while Bob gets error message
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice!">>)),
-        privacy_helper:gets_error(Bob, su),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
 
         %% now Alice try to send a msg to Bob, whom she had blocked, and gets error
         %% and Bob gets nothing
         escalus_client:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi, Bobbb!">>)),
-        privacy_helper:gets_error(Alice, na),
+        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Bob)
 
@@ -417,7 +417,7 @@ block_group_message(Config) ->
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, blocked group!">>)),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, su)
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>)
 
         end).
 
@@ -440,7 +440,7 @@ block_subscription_message(Config) ->
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi!">>)),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, su)
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>)
 
         end).
 
@@ -458,9 +458,9 @@ allow_subscription_to_from_message(Config) ->
 
         ct:sleep(?SLEEP_TIME),
         %% they received just rejection msgs
-        privacy_helper:gets_error(Alice, na),
+        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, na),
+        privacy_helper:gets_error(Bob, <<"not-acceptable">>),
         escalus_assert:has_no_stanzas(Bob),
 
         %% Alice subscribes to Bob
@@ -509,8 +509,8 @@ allow_subscription_both_message(Config) ->
         escalus_client:send(Alice, escalus_stanza:chat_to(bob, <<"Hi, Bob XYZ!">>)),
 
         ct:sleep(?SLEEP_TIME),
-        privacy_helper:gets_error(Alice, na),
-        privacy_helper:gets_error(Bob, na),
+        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
+        privacy_helper:gets_error(Bob, <<"not-acceptable">>),
         escalus_assert:has_no_stanzas(Alice),
         escalus_assert:has_no_stanzas(Bob),
 
@@ -551,7 +551,7 @@ block_all_message(Config) ->
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi!">>)),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, su)
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>)
 
         end).
 
@@ -621,12 +621,12 @@ block_jid_iq(Config) ->
         escalus_client:send(Bob, version_iq(<<"get">>, Bob, Alice)),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, su),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
         %% this stanza does not make much sense, but is routed and rejected correctly
         escalus_client:send(Bob, version_iq(<<"set">>, Bob, Alice)),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, su),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
         %% but another type, like result, is silently dropped
         escalus_client:send(Bob, version_iq(<<"result">>, Bob, Alice)),
         timer:sleep(?SLEEP_TIME),
@@ -651,7 +651,7 @@ block_jid_all(Config) ->
 
         %% Alice should NOT receive message, Bob receives err msg
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi!">>)),
-        privacy_helper:gets_error(Bob, su),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
 
         %% Alice should NOT receive presence-in from Bob, no err msg
         escalus_client:send(Bob,
@@ -663,7 +663,7 @@ block_jid_all(Config) ->
         escalus_client:send(Alice,
             escalus_stanza:presence_direct(bob, <<"available">>)),
         timer:sleep(?SLEEP_TIME),
-        privacy_helper:gets_error(Alice, na),
+        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
 
         %% Just set the toy list and ensure that only
         %% the notification push comes back.
@@ -697,7 +697,7 @@ block_jid_message_but_not_presence(Config) ->
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice!">>)),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, su),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
 
         %% ...but should receive presence in
         escalus_client:send(Bob,

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -376,7 +376,16 @@ block_jid_message(Config) ->
         Response = escalus_client:wait_for_stanza(Bob),
         escalus_assert:is_error(Response, <<"cancel">>, <<"service-unavailable">>),
         timer:sleep(?SLEEP_TIME),
-        escalus_assert:has_no_stanzas(Alice)
+        escalus_assert:has_no_stanzas(Alice),
+
+        %% now Alice try to send a msg to Bob, whom she had blocked, and gets error
+        %% and Bob gets nothing
+        escalus_client:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi, Bobbb!">>)),
+        Response1 = escalus_client:wait_for_stanza(Alice),
+        ct:pal("~p", [Response1]),
+        escalus_assert:is_error(Response1, <<"cancel">>, <<"not-acceptable">>),
+        timer:sleep(?SLEEP_TIME),
+        escalus_assert:has_no_stanzas(Bob)
 
         end).
 

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -52,9 +52,8 @@ management_test_cases() ->
      default_nonexistent,
      no_default,
      remove_list,
-     get_all_lists_with_active
-     %get_all_lists_with_default
-     % not implemented (see testcase)
+     get_all_lists_with_active,
+     get_all_lists_with_default
     ].
 
 blocking_test_cases() ->
@@ -165,7 +164,8 @@ get_all_lists_with_default(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
 
         privacy_helper:set_list(Alice, <<"deny_bob">>),
-        privacy_helper:set_and_activate(Alice, <<"allow_bob">>),
+        privacy_helper:set_list(Alice, <<"allow_bob">>),
+        privacy_helper:set_default_list(Alice, <<"allow_bob">>),
 
         escalus:send(Alice, escalus_stanza:privacy_get_all()),
         escalus:assert(is_privacy_result_with_default,

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -13,8 +13,17 @@
          activate_list/2,
          set_default_list/2,
          privacy_list/1,
+         gets_error/2,
          is_privacy_list_push/1,
          is_presence_error/1]).
+
+gets_error(Who, su) ->
+    gets_error(Who, <<"service-unavailable">>);
+gets_error(Who, na) ->
+    gets_error(Who, <<"not-acceptable">>);
+gets_error(Who, Type) ->
+    Response = escalus_client:wait_for_stanza(Who),
+    escalus_assert:is_error(Response, <<"cancel">>, Type).
 
 %% Sets the list on server and makes it the active one.
 set_and_activate(Client, ListName) ->

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -17,10 +17,6 @@
          is_privacy_list_push/1,
          is_presence_error/1]).
 
-gets_error(Who, su) ->
-    gets_error(Who, <<"service-unavailable">>);
-gets_error(Who, na) ->
-    gets_error(Who, <<"not-acceptable">>);
 gets_error(Who, Type) ->
     Response = escalus_client:wait_for_stanza(Who),
     escalus_assert:is_error(Response, <<"cancel">>, Type).


### PR DESCRIPTION
This PR is the first step towards addressing #718.
Blocking commands are a simplified api to privacy lists, and some minor things were missing in current implementation of privacy lists, so here they are.
It also introduces some changes in c2s to make it a bit more readable.

