### PR TITLE
[skip ci] precisions, unification on mod_mam doc

### DIFF
--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -8,8 +8,8 @@ This module implements revision 0.2 of [XEP-0313 (Message Archive Management)](h
 Consider the process as a kind of recipe. For each step you can enable none ("optional"), one ("single") or more ("multi") modules, according to instructions. Provided there are any, please use the options described in a specific step. All config parameters are boolean, so you can enable them by adding an atom to the configuration list, e.g. `{mod_mam_odbc_arch, [pm, no_writer]}`
 
 ##### Step 1 (multi)
-* **mod_mam** + **mod_mam_odbc_arch** - Enables support for client-to-client archive.
-* **mod_mam_muc** + **mod_mam_muc_odbc_arch** - Enables support for groupchats archive.
+* **mod_mam** + **mod_mam_odbc_arch** - Enables support for one-to-one messages archive.
+* **mod_mam_muc** + **mod_mam_muc_odbc_arch** - Enables support for group chat messages archive.
 
 If you haven't chosen any of the above, skip the next part.
 
@@ -18,16 +18,16 @@ If you haven't chosen any of the above, skip the next part.
 * **mod_mam_muc**
     * `host` (optional, default: `"conference.@HOST@"`) - MUC host that will be archived
 * **mod_mam_odbc_arch**
-    * `pm` (mandatory when `mod_mam` enabled) - Enable archiving user-to-user messages
+    * `pm` (mandatory when `mod_mam` enabled) - Enable archiving one-to-one messages
     * `muc` (optional) - Enable group chat archive, mutually exclusive with `mod_mam_muc_odbc_arch`. **Not recommended**, `mod_mam_muc_odbc_arch` is more efficient.
     * `simple` - Same as `{simple, true}`
     * `{simple, true}` - Store messages in XML and full JIDs. Archive MUST be empty to change this option.
-    * `{simple, false} (default)` - Store messages and JIDs in internal format
+    * `{simple, false} (default)` - Store messages and JIDs in internal format.
 
 * **mod_mam_odbc_arch**, **mod_mam_muc_odbc_arch**
     * `no_writer` - Disables default synchronous, slow writer and uses async one (step 5 & 6) instead.
     * `{simple, true}` - Store messages in XML and full JIDs. Archive MUST be empty to change this option.
-    * `{simple, false} (default)` - Store messages and JIDs in internal format
+    * `{simple, false} (default)` - Store messages and JIDs in internal format.
 
 ##### Step 2 (mandatory)
 * **mod_mam_odbc_user** - Maps archive ID to integer.
@@ -38,11 +38,11 @@ If you haven't chosen any of the above, skip the next part.
 * `muc` - Mandatory when `mod_mam_muc` enabled.
 
 ##### Step 3 (optional, recommended)
-* **mod_mam_cache_user** - Enables Archive ID -> integer mappings cache.
+* **mod_mam_cache_user** - Enables Archive ID to integer mappings cache.
 
 **Options**
 
-* `pm` - Optional, enables cache for user-to-user messaging, works only with `mod_mam` enabled.
+* `pm` - Optional, enables cache for one-to-one messaging, works only with `mod_mam` enabled.
 * `muc` - Optional, enables cache for group chat messaging, works only with `mod_mam_muc` enabled.
 
 ##### Step 4 (single, optional)
@@ -64,7 +64,7 @@ Enabling asynchronous writers will make debugging more difficult.
 
 **Options:** (common for both modules)
 
-* `pm` - Optional, enables the chosen writer for user-to-user messaging, works only with `mod_mam` enabled.
+* `pm` - Optional, enables the chosen writer for one-to-one messaging, works only with `mod_mam` enabled.
 * `muc` - Optional, enables the chosen writer for group chat messaging, use only when `mod_mam_odbc_arch` has `muc` enabled. **Not recommended**.
 
 ##### Step 6 (single, optional, recommended, requires `mod_mam_muc` module enabled and `no_writer` option set in `mod_mam_muc_odbc_arch`)
@@ -73,16 +73,16 @@ Enabling asynchronous writers will make debugging more difficult.
 
 * **mod_mam_muc_odbc_async_pool_writer** - Asychronous writer, will insert batches of messages, grouped by archive ID.
 
-## Configuring MAM with Riak backend
+## Configuring MAM with Riak KV backend
 
-In order to use Riak as the backend for one-to-one archives, the following configuration must be used:
+In order to use Riak KV as the backend for one-to-one archives, the following configuration must be used:
 
 ```erlang
 {mod_mam, []}.
 {mod_mam_riak_timed_arch_yz, [pm]}.
 ```
 
-To archive both one-to-one and multichat messages use this configuration instead:
+To archive both one-to-one and group chat messages use this configuration instead:
 
 ```erlang
 {mod_mam, []}.
@@ -90,19 +90,17 @@ To archive both one-to-one and multichat messages use this configuration instead
 {mod_mam_riak_timed_arch_yz, [pm, muc]}.
 ```
 
-The Riak backend for MAM stores messages in weekly buckets so it's easier to remove old buckets.
-Archive querying is done using Riak 2.0 [search mechanism](http://docs.basho.com/riak/2.1.1/dev/using/search/)
-called Yokozuna. Your instance of Riak must be configured with Yokozuna enabled.
+The Riak KV backend for MAM stores messages in weekly buckets so it's easier to remove old buckets.
+Archive querying is done using Riak KV 2.0 [search mechanism](http://docs.basho.com/riak/2.1.1/dev/using/search/)
+called Yokozuna. Your instance of Riak KV must be configured with Yokozuna enabled.
 
-This backend works with Riak 2.0 and above, but the recommend version is 2.1.1
-
-
+This backend works with Riak KV 2.0 and above, but the recommend version is 2.1.1.
 
 ## Configure MAM with Cassandra backend
 
 There are two Cassandra modules:
 - mod_mam_con_ca_arch - for one-to-one messages
-- mod_mam_muc_ca_arch - for groupchat messages
+- mod_mam_muc_ca_arch - for group chat messages
 
 They can be used together.
 
@@ -110,7 +108,7 @@ They can be used together.
 
 Module to store conversations (con in the module's name) in Cassandra.
 
-This module uses keyspace "mam" in Cassadra (keyspace is simular to database in relational databasas).
+This module uses keyspace "mam" in Cassadra (keyspace is simular to database in relational databases).
 Has configuration parameter "servers". It is a list of Cassandra servers.
 If you have 4 Cassandra servers with IP adresses from 10.0.0.1 to 10.0.0.4, then pass:
 
@@ -137,7 +135,7 @@ Default value is `[{"localhost", 9042, 1}]` (one connection to localhost).
 
 It is different from mod_mam_odbc_arch:
 
-- This module does not use archive integer ids. It stores JIDs for each message instead
+- This module does not use archive integer IDs. It stores JIDs for each message instead
 (it means, that for minimal configuration you do not need mod_mam_odbc_user);
 - It stores not two copies, but one copy of an unique message (between two users);
 - User is not allowed to purge (delete) messages.
@@ -156,10 +154,9 @@ Configuration example:
 {mod_mam, []}
 ```
 
-
 ### mod_mam_muc_ca_arch
 
-Module to store room chat history in Cassandra.
+Module to store group chat history in Cassandra.
 
 It has the same configuration parameter `servers` as module `mod_mam_con_ca_arch`.
 
@@ -167,7 +164,6 @@ It is different from mod_mam_muc_odbc_arch:
 
 - User is not allowed to purge. Purging is a feature not described in
   XEP that allows user to delete messages.
-
 
 Configuration example:
 
@@ -183,7 +179,6 @@ Configuration example:
 {mod_mam_odbc_user, [muc]},
 {mod_mam_muc, []}
 ```
-
 
 Configuration example with both modules enabled:
 
@@ -222,14 +217,12 @@ Custom credentials:
 {credentials, [{"username", "cassandra"}, {"password", "secret"}]}
 ```
 
-
 mod_mam options
 ---------------
 
 - add_archived_element - add `<archived/>` element from MAM v0.2
 - is_complete_message - module name implementing is_complete_message/3 callback.
   This callback returns true if message should be archived.
-
 
 Default configuration for mod_mam:
 


### PR DESCRIPTION
From user-to-user to one-to-one, from client-to-client to one-to-one, form groupchat to group chat, from Riak to Riak KV, some more typos...