### PR TITLE
Add support for <text> tag in auth failures

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2962,10 +2962,17 @@ sasl_success_stanza(ServerOut) ->
            attrs = [{<<"xmlns">>, ?NS_SASL}],
            children = C}.
 
-sasl_failure_stanza(Error) ->
+sasl_failure_stanza(Error) when is_binary(Error) ->
+    sasl_failure_stanza({Error, undefined});
+sasl_failure_stanza({Error, Text}) ->
     #xmlel{name = <<"failure">>,
            attrs = [{<<"xmlns">>, ?NS_SASL}],
-           children = [#xmlel{name = Error}]}.
+           children = [#xmlel{name = Error} | maybe_text_tag(Text)]}.
+
+maybe_text_tag(undefined) -> [];
+maybe_text_tag(Text) ->
+    [#xmlel{name = <<"text">>,
+            children = [#xmlcdata{content = Text}]}].
 
 sasl_challenge_stanza(Challenge) ->
     #xmlel{name = <<"challenge">>,

--- a/test/ejabberd_tests/default.spec
+++ b/test/ejabberd_tests/default.spec
@@ -42,6 +42,7 @@
 {suites, "tests", private_SUITE}.
 {suites, "tests", pubsub_SUITE}.
 {suites, "tests", s2s_SUITE}.
+{suites, "tests", sasl_SUITE}.
 {suites, "tests", shared_roster_SUITE}.
 {suites, "tests", sic_SUITE}.
 {suites, "tests", sm_SUITE}.

--- a/test/ejabberd_tests/tests/sasl_SUITE.erl
+++ b/test/ejabberd_tests/tests/sasl_SUITE.erl
@@ -1,0 +1,117 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(sasl_SUITE).
+-compile(export_all).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("exml/include/exml.hrl").
+
+% Ideally we'd use a custom mechanism here, but escalus
+% hardwires the allowed mechanism in escalus_session.erl, so
+% we're stuck with testing using a mechanism that dosen't
+% get used by any other tests.
+-define(TEST_MECHANISM, <<"EXTERNAL">>).
+-define(TEXT_CONTENT, <<"Call 555-123-1234 for assistance">>).
+
+-behaviour(cyrsasl).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, text_response}].
+
+groups() ->
+    [{text_response, [sequence], all_tests()}].
+
+all_tests() ->
+    [text_response].
+
+suite() ->
+    escalus:suite().
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+init_per_group(_GroupName, Config) ->
+    escalus:create_users(Config, escalus:get_users([alice])).
+
+end_per_group(_GroupName, Config) ->
+    escalus:delete_users(Config, escalus:get_users([alice])).
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+%%--------------------------------------------------------------------
+%% cyrsasl tests
+%%--------------------------------------------------------------------
+
+text_response(Config) ->
+    {Mod, Bin, File} = code:get_object_code(?MODULE),
+    escalus_ejabberd:rpc(code, load_binary, [Mod, File, Bin]),
+    escalus_ejabberd:rpc(
+      cyrsasl, register_mechanism, [?TEST_MECHANISM, ?MODULE, plain]),
+
+    AliceSpec = escalus_users:get_options(Config, alice),
+    {ok, Client, _, _} = escalus_connection:start(AliceSpec,
+                                                  [start_stream,
+                                                   stream_features]),
+    Stanza = escalus_stanza:auth(?TEST_MECHANISM,
+                                 [#xmlcdata{content =
+                                            base64:encode(<<"alice">>)}]),
+    Result = escalus:send_and_wait(Client, Stanza),
+    assert_is_failure_with_text(Result).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+assert_is_failure_with_text(#xmlel{name = <<"failure">>,
+                                   children = Children}) ->
+    assert_has_text(Children);
+assert_is_failure_with_text(Result) ->
+    ct:fail("Result is not a failure stanza: ~p", [Result]).
+
+assert_has_text([]) ->
+    ct:fail("Result has no or incorrect text field");
+assert_has_text([#xmlel{name = <<"text">>,
+                        children = [#xmlcdata{content = ?TEXT_CONTENT}]}
+                 | _]) ->
+    ok;
+assert_has_text([_ | Tail]) ->
+    assert_has_text(Tail).
+
+%%--------------------------------------------------------------------
+%% cyrsasl test callback functions
+%%--------------------------------------------------------------------
+
+mech_new(_Host, _GetPassword, _CheckPassword, _CheckPasswordDigest) ->
+    {ok, {}}.
+
+mech_step(_State, _ClientIn) ->
+    {error, {<<"not-authorized">>, ?TEXT_CONTENT}, <<>>}.

--- a/test/ejabberd_tests/tests/sasl_SUITE.erl
+++ b/test/ejabberd_tests/tests/sasl_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("exml/include/exml.hrl").
 
 % Ideally we'd use a custom mechanism here, but escalus
-% hardwires the allowed mechanism in escalus_session.erl, so
+% hardwires the allowed mechanisms in escalus_session.erl, so
 % we're stuck with testing using a mechanism that dosen't
 % get used by any other tests.
 -define(TEST_MECHANISM, <<"EXTERNAL">>).


### PR DESCRIPTION
This change allows SASL authentication mechanism implementations to optionally supply a value for the `<text>` tag in `<failure>` results (as permitted by https://tools.ietf.org/html/rfc6120#section-6.5). It's backwards-compatible, so shouldn't break anything.