### PR TITLE
Remove `configure` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,6 @@ eunit: rebar deps
 	./rebar compile
 	./rebar skip_deps=true eunit
 
-configure:
-	./tools/configure $(filter-out $@,$(MAKECMDGOALS))
-
 rel: certs rebar deps configure.out rel/vars.config
 	. ./configure.out && ./rebar compile generate -f
 
@@ -141,9 +138,6 @@ xeplist: escript
 
 test_deps:
 	cd test/ejabberd_tests; make get-deps
-
-%:
-	@:
 
 install: configure.out rel
 	@. ./configure.out && tools/install

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -75,9 +75,10 @@ Microsoft SQL Server, sometimes called MSSQL, or Azure SQL Database.
 
 **Setup**
 
-MSSQL can be used from MongooseIM through the ODBC layer, so you need to
-have it installed in your system. Moreover, an Erlang/OTP release must be
-built with the support for ODBC as well as MongooseIM itself.
+MSSQL can be used from MongooseIM through the ODBC layer,
+so you need to have it installed in your system.
+Moreover, your Erlang/OTP as well as MongooseIM
+must be built with support for ODBC.
 
 You can configure MongooseIM appropriately by using the following command
 (assuming you're in the top-level directory of the checked out repository):

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -79,7 +79,12 @@ MSSQL can be used from MongooseIM through the ODBC layer, so you need to
 have it installed in your system. Moreover, an Erlang/OTP release must be
 built with the support for ODBC as well as MongooseIM itself.
 
-You can configure MongooseIM appropriately by using the following command: ``make configure with-odbc``.
+You can configure MongooseIM appropriately by using the following command
+(assuming you're in the top-level directory of the checked out repository):
+
+```sh
+./tools/configure with-odbc
+```
 
 You also need FreeTDS (an ODBC driver for MSSQL) installed in your
 system.

--- a/doc/user-guide/release_config.md
+++ b/doc/user-guide/release_config.md
@@ -53,9 +53,9 @@ This script is also accessible via make `configure` target.
 For example if only `mysql` and `redis` drivers should be included in the
 release, following command has to be run before `make rel`:
 
-        $ make configure with-mysql with-redis
+    $ ./tools/configure with-mysql with-redis
 
-The `make configure` command has to be run only once (unless one needs to 
+The `./tools/configure` command has to be run only once (unless one needs to
 change the release's config and include some other dependencies).
 
 ### System install

--- a/tools/travis-build-and-push-docker.sh
+++ b/tools/travis-build-and-push-docker.sh
@@ -5,7 +5,7 @@
 if [ ${TRAVIS_SECURE_ENV_VARS} == 'true' ]; then
 
 
-make configure with-all
+./tools/configure with-all
 make rel
 
 MIM_TAR_FULL_NAME=mongooseim-$TRAVIS_BRANCH.OTP-$TRAVIS_OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2

--- a/tools/travis-build.sh
+++ b/tools/travis-build.sh
@@ -6,7 +6,7 @@ TRAVIS_DB_PASSWORD=$(cat /tmp/travis_db_password)
 
 ${TOOLS}/set-odbc-password vars ${TRAVIS_DB_PASSWORD}
 
-make configure $REL_CONFIG
+./tools/configure $REL_CONFIG
 
 cat configure.out
 echo ""


### PR DESCRIPTION
(The following is copied from commit description)

This target requires another one:

    %:
        @:

which drastically affects how make handles undefined targets.
A single typo in the CLI or dependency chain can cause silent errors.
With the above target, this works:

    $ make zxczxczxc && echo a
    a

While the default make behaviour is:

    $ make zxczxczxc && echo a
    make: *** No rule to make target `zxczxczxc'.  Stop.

Fail fast and loud, don't let silent errors sneak into the build process.