### PR TITLE
[do not merge] Refactor C2S / SASL / auth interface

### DIFF
--- a/apps/ejabberd/src/cyrsasl.erl
+++ b/apps/ejabberd/src/cyrsasl.erl
@@ -102,11 +102,8 @@ start() ->
     ets:new(sasl_mechanism, [named_table,
                              public,
                              {keypos, #sasl_mechanism.mechanism}]),
-    cyrsasl_plain:start([]),
-    cyrsasl_digest:start([]),
-    cyrsasl_scram:start([]),
-    cyrsasl_anonymous:start([]),
-    cyrsasl_oauth:start([]), %%todo: consider moving it somewhere else....
+    MechOpts = [],
+    [ Mech:start(MechOpts) || Mech <- get_mechanisms() ],
     ok.
 
 -spec register_mechanism(Mechanism :: mechanism(),
@@ -238,3 +235,11 @@ filter_anonymous(Host, Mechs) ->
         true  -> Mechs;
         false -> Mechs -- [<<"ANONYMOUS">>]
     end.
+
+get_mechanisms() ->
+    Default = [cyrsasl_plain,
+               cyrsasl_digest,
+               cyrsasl_scram,
+               cyrsasl_anonymous,
+               cyrsasl_oauth],
+    ejabberd_config:get_local_option_or_default(sasl_mechanisms, Default).

--- a/apps/ejabberd/src/cyrsasl.erl
+++ b/apps/ejabberd/src/cyrsasl.erl
@@ -90,6 +90,7 @@
                    CheckPassword :: check_password_fun(),
                    CheckPasswordDigest :: check_pass_digest_fun()
                    ) -> {ok, tuple()}.
+
 -callback mech_step(State :: tuple(),
                     ClientIn :: binary()
                     ) -> {ok, proplists:proplist()}
@@ -209,27 +210,27 @@ server_step(State, ClientIn) ->
     Module = State#sasl_state.mech_mod,
     MechState = State#sasl_state.mech_state,
     case Module:mech_step(MechState, ClientIn) of
-	{ok, Props} ->
-	    case check_credentials(State, Props) of
-		ok ->
-		    {ok, Props};
-		{error, Error} ->
-		    {error, Error}
-	    end;
-	{ok, Props, ServerOut} ->
-	    case check_credentials(State, Props) of
-		ok ->
-		    {ok, Props, ServerOut};
-		{error, Error} ->
-		    {error, Error}
-	    end;
-	{continue, ServerOut, NewMechState} ->
-	    {continue, ServerOut,
-	     State#sasl_state{mech_state = NewMechState}};
-	{error, Error, Username} ->
-	    {error, Error, Username};
-	{error, Error} ->
-	    {error, Error}
+        {ok, Props} ->
+            case check_credentials(State, Props) of
+                ok ->
+                    {ok, Props};
+                {error, Error} ->
+                    {error, Error}
+            end;
+        {ok, Props, ServerOut} ->
+            case check_credentials(State, Props) of
+                ok ->
+                    {ok, Props, ServerOut};
+                {error, Error} ->
+                    {error, Error}
+            end;
+        {continue, ServerOut, NewMechState} ->
+            {continue, ServerOut,
+             State#sasl_state{mech_state = NewMechState}};
+        {error, Error, Username} ->
+            {error, Error, Username};
+        {error, Error} ->
+            {error, Error}
     end.
 
 %% @doc Remove the anonymous mechanism from the list if not enabled for the

--- a/apps/ejabberd/src/cyrsasl_oauth.erl
+++ b/apps/ejabberd/src/cyrsasl_oauth.erl
@@ -1,11 +1,11 @@
 -module(cyrsasl_oauth).
 -author('adrian.stachurski@erlang-solutions.com').
 
--export([start/1, stop/0, mech_new/4, mech_step/2]).
+-export([start/1, stop/0, mech_new/2, mech_step/2]).
 
 -behaviour(cyrsasl).
 
--record(state, {check_password}).
+-record(state, {creds}).
 
 start(_Opts) ->
     cyrsasl:register_mechanism(<<"X-OAUTH">>, ?MODULE, plain),
@@ -15,28 +15,27 @@ stop() ->
     ok.
 
 -spec mech_new(Host :: ejabberd:server(),
-               GetPassword :: cyrsasl:get_password_fun(),
-               CheckPassword :: cyrsasl:check_password_fun(),
-               CheckPasswordDigest :: cyrsasl:check_pass_digest_fun()
-               ) -> {ok, tuple()}.
-mech_new(Host, GetPassword, CheckPassword, CheckPasswordDigest) ->
-    {ok, #state{check_password = CheckPassword}}.
+               Creds :: mongoose_credentials:t()) -> {ok, tuple()}.
+mech_new(Host, Creds) ->
+    {ok, #state{creds = Creds}}.
 
 -spec mech_step(State :: tuple(),
-                ClientIn :: binary()
-                ) -> {ok, proplists:proplist()} | {error, binary()}.
-mech_step(State, SerializedToken) ->
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(#state{creds = Creds}, SerializedToken) ->
     %% SerializedToken is a token decoded from CDATA <auth/> body sent by client
     case mod_auth_token:authenticate(SerializedToken) of
         % Validating access token
         {ok, AuthModule, User} ->
-            {ok,[{username, User},
-                 {auth_module, AuthModule}]};
+            {ok, mongoose_credentials:extend(Creds,
+                                             [{username, User},
+                                              {auth_module, AuthModule}])};
         % Validating refresh token and returning new tokens
         {ok, AuthModule, User, AccessToken} ->
-            {ok,[{username, User},
-                 {auth_module, AuthModule}],
-             AccessToken};
+            {ok, mongoose_credentials:extend(Creds,
+                                             [{username, User},
+                                              {auth_module, AuthModule},
+                                              {sasl_success_response, AccessToken}])};
         {error, {Username, _}} ->
             {error, <<"not-authorized">>, Username};
         {error, _Reason} ->

--- a/apps/ejabberd/src/cyrsasl_plain.erl
+++ b/apps/ejabberd/src/cyrsasl_plain.erl
@@ -27,11 +27,11 @@
 -module(cyrsasl_plain).
 -author('alexey@process-one.net').
 
--export([start/1, stop/0, mech_new/4, mech_step/2, parse/1]).
+-export([start/1, stop/0, mech_new/2, mech_step/2, parse/1]).
 -xep([{xep, 78}, {version, "2.5"}]).
 -behaviour(cyrsasl).
 
--record(state, {check_password}).
+-include("ejabberd.hrl").
 
 start(_Opts) ->
     cyrsasl:register_mechanism(<<"PLAIN">>, ?MODULE, plain),
@@ -41,25 +41,28 @@ stop() ->
     ok.
 
 -spec mech_new(Host :: ejabberd:server(),
-               GetPassword :: cyrsasl:get_password_fun(),
-               CheckPassword :: cyrsasl:check_password_fun(),
-               CheckPasswordDigest :: cyrsasl:check_pass_digest_fun()
-               ) -> {ok, tuple()}.
-mech_new(_Host, _GetPassword, CheckPassword, _CheckPasswordDigest) ->
-    {ok, #state{check_password = CheckPassword}}.
+               Creds :: mongoose_credentials:t()) -> {ok, tuple()}.
+mech_new(_Host, Creds) ->
+    {ok, Creds}.
 
--spec mech_step(State :: tuple(),
-                ClientIn :: binary()
-                ) -> {ok, proplists:proplist()} | {error, binary()}.
-mech_step(State, ClientIn) ->
+-spec mech_step(Creds :: mongoose_credentials:t(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(Creds, ClientIn) ->
     case prepare(ClientIn) of
         [AuthzId, User, Password] ->
-            case (State#state.check_password)(User, Password) of
-                {true, AuthModule} ->
-                    {ok, [{username, User}, {authzid, AuthzId},
-                          {auth_module, AuthModule}]};
-                _ ->
-                    {error, <<"not-authorized">>, User}
+            Request = mongoose_credentials:extend(Creds,
+                                                  [{username, User},
+                                                   {password, Password},
+                                                   {authzid, AuthzId}]),
+            case ejabberd_auth:authorize(Request) of
+                {ok, Result} ->
+                    {ok, Result};
+                {error, not_authorized} ->
+                    {error, <<"not-authorized">>, User};
+                {error, R} ->
+                    ?DEBUG("authorize error: ~p", [R]),
+                    {error, <<"internal-error">>}
             end;
         _ ->
             {error, <<"bad-protocol">>}

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -313,7 +313,6 @@ stream_start_features_before_auth(#state{server = Server} = S) ->
                                    mk_check_password3_with_authmodule(Server),
                                    mk_check_password5_with_authmodule(Server)),
     SockMod = (S#state.sockmod):get_sockmod(S#state.socket),
-
     send_element(S, stream_features(determine_features(SockMod, S))),
     fsm_next_state(wait_for_feature_before_auth,
                    S#state{sasl_state = SASLState}).
@@ -321,12 +320,12 @@ stream_start_features_before_auth(#state{server = Server} = S) ->
 stream_start_features_after_auth(#state{server = Server} = S) ->
     SockMod = (S#state.sockmod):get_sockmod(S#state.socket),
     Features = (maybe_compress_feature(SockMod, S)
-            ++ [#xmlel{name = <<"bind">>,
-                         attrs = [{<<"xmlns">>, ?NS_BIND}]},
-                  #xmlel{name = <<"session">>,
-                         attrs = [{<<"xmlns">>, ?NS_SESSION}]}]
-                 ++ maybe_roster_versioning_feature(Server)
-                 ++ hook_enabled_features(Server) ),
+                ++ [#xmlel{name = <<"bind">>,
+                           attrs = [{<<"xmlns">>, ?NS_BIND}]},
+                    #xmlel{name = <<"session">>,
+                           attrs = [{<<"xmlns">>, ?NS_SESSION}]}]
+                ++ maybe_roster_versioning_feature(Server)
+                ++ hook_enabled_features(Server) ),
     send_element(S, stream_features(Features)),
     fsm_next_state(wait_for_feature_after_auth, S).
 
@@ -457,8 +456,7 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
                          _ ->
                              [#xmlcdata{content = U}]
                      end,
-            Res = case ejabberd_auth:plain_password_required(
-                         StateData#state.server) of
+            Res = case ejabberd_auth:plain_password_required(StateData#state.server) of
                       false ->
                           XE#xmlel{children = [#xmlel{name = <<"query">>,
                                                       attrs = [{<<"xmlns">>,
@@ -480,18 +478,16 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
             send_element(StateData, Res),
             fsm_next_state(wait_for_auth, StateData);
         {auth, _ID, set, {_U, _P, _D, <<>>}} ->
-            Err = jlib:make_error_reply(
-                    El,
-                    ?ERR_AUTH_NO_RESOURCE_PROVIDED(StateData#state.lang)),
+            Err = jlib:make_error_reply(El, ?ERR_AUTH_NO_RESOURCE_PROVIDED(StateData#state.lang)),
             send_element(StateData, Err),
             fsm_next_state(wait_for_auth, StateData);
         {auth, _ID, set, {U, P, D, R}} ->
             JID = jid:make(U, StateData#state.server, R),
             maybe_legacy_auth(JID, El, StateData, U, P, D, R);
-                        _ ->
+        _ ->
             process_unauthenticated_stanza(StateData, El),
-                            fsm_next_state(wait_for_auth, StateData)
-                    end;
+            fsm_next_state(wait_for_auth, StateData)
+    end;
 wait_for_auth(timeout, StateData) ->
     {stop, normal, StateData};
 wait_for_auth({xmlstreamend, _Name}, StateData) ->
@@ -505,26 +501,22 @@ wait_for_auth(closed, StateData) ->
     {stop, normal, StateData}.
 
 maybe_legacy_auth(error, El, StateData, U, _P, _D, R) ->
-                            ?INFO_MSG(
-                               "(~w) Forbidden legacy authentication for "
-                               "username '~s' with resource '~s'",
-                               [StateData#state.socket, U, R]),
-                            Err = jlib:make_error_reply(El, ?ERR_JID_MALFORMED),
-                            send_element(StateData, Err),
-                            fsm_next_state(wait_for_auth, StateData);
+    ?INFO_MSG("(~w) Forbidden legacy authentication for "
+              "username '~s' with resource '~s'",
+              [StateData#state.socket, U, R]),
+    Err = jlib:make_error_reply(El, ?ERR_JID_MALFORMED),
+    send_element(StateData, Err),
+    fsm_next_state(wait_for_auth, StateData);
 maybe_legacy_auth(JID, El, StateData, U, P, D, R) ->
     case user_allowed(JID, StateData) of
-                        true ->
+        true ->
             do_legacy_auth(JID, El, StateData, U, P, D, R);
         _ ->
-
-                            ?INFO_MSG(
-                               "(~w) Forbidden legacy authentication for ~s",
-                               [StateData#state.socket,
-                                jid:to_binary(JID)]),
-                            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
-                            send_element(StateData, Err),
-                            fsm_next_state(wait_for_auth, StateData)
+            ?INFO_MSG("(~w) Forbidden legacy authentication for ~s",
+                      [StateData#state.socket, jid:to_binary(JID)]),
+            Err = jlib:make_error_reply(El, ?ERR_NOT_ALLOWED),
+            send_element(StateData, Err),
+            fsm_next_state(wait_for_auth, StateData)
     end.
 
 do_legacy_auth(JID, El, StateData, U, P, D, R) ->
@@ -534,12 +526,10 @@ do_legacy_auth(JID, El, StateData, U, P, D, R) ->
                                    AuthModule);
         _ ->
             IP = peerip(StateData#state.sockmod, StateData#state.socket),
-            ?INFO_MSG(
-               "(~w) Failed legacy authentication for ~s from IP ~s (~w)",
-               [StateData#state.socket,
-                jid:to_binary(JID), jlib:ip_to_list(IP), IP]),
-            Err = jlib:make_error_reply(
-                    El, ?ERR_NOT_AUTHORIZED),
+            ?INFO_MSG("(~w) Failed legacy authentication for ~s from IP ~s (~w)",
+                      [StateData#state.socket,
+                       jid:to_binary(JID), jlib:ip_to_list(IP), IP]),
+            Err = jlib:make_error_reply(El, ?ERR_NOT_AUTHORIZED),
             ejabberd_hooks:run(auth_failed, StateData#state.server,
                                [U, StateData#state.server]),
             send_element(StateData, Err),
@@ -558,18 +548,15 @@ check_password_with_auth_module(User, StateData, _, Digest) ->
                                                  <<>>, Digest, DGen).
 
 do_open_legacy_session(El, StateData, U, R, JID, AuthModule) ->
-    ?INFO_MSG(
-       "(~w) Accepted legacy authentication for ~s by ~p",
-       [StateData#state.socket,
-        jid:to_binary(JID), AuthModule]),
+    ?INFO_MSG("(~w) Accepted legacy authentication for ~s by ~p",
+              [StateData#state.socket, jid:to_binary(JID), AuthModule]),
     Res1 = jlib:make_result_iq_reply(El),
     Res = Res1#xmlel{children = []},
     send_element(StateData, Res),
-    NewStateData = StateData#state{
-                     user = U,
-                     resource = R,
-                     jid = JID,
-                     auth_module = AuthModule},
+    NewStateData = StateData#state{ user = U,
+                                    resource = R,
+                                    jid = JID,
+                                    auth_module = AuthModule },
     do_open_session_common(JID, NewStateData).
 
 -spec wait_for_feature_before_auth(Item :: ejabberd:xml_stream_item(),
@@ -3010,14 +2997,13 @@ handle_sasl_success(State, Props, ServerOut) ->
     AuthModule = proplists:get_value(auth_module, Props, <<>>),
     ?INFO_MSG("(~w) Accepted authentication for ~s by ~p",
               [State#state.socket, U, AuthModule]),
-    NewState = State#state{
-                 streamid = new_id(),
-                 authenticated = true,
-                 auth_module = AuthModule,
-                 user = U},
+    NewState = State#state{ streamid = new_id(),
+                            authenticated = true,
+                            auth_module = AuthModule,
+                            user = U },
     {wait_for_stream, NewState}.
 
-handle_sasl_step(#state{server = Server, socket= Sock} = State, StepRes) ->
+handle_sasl_step(#state{server = Server, socket = Sock} = State, StepRes) ->
     case StepRes of
         {ok, Props} ->
             handle_sasl_success(State, Props);

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -122,6 +122,7 @@
                     | {mongooseimctl_access_commands, list()}
                     | {loglevel, _}
                     | {max_fsm_queue, _}
+                    | {sasl_mechanisms, _}
                     | host_term().
 
 -type host_term() :: {acl, _, _}
@@ -574,6 +575,8 @@ process_term(Term, State) ->
             State;
         {max_fsm_queue, N} ->
             add_option(max_fsm_queue, N, State);
+        {sasl_mechanisms, Mechanisms} ->
+            add_option(sasl_mechanisms, Mechanisms, State);
         {_Opt, _Val} ->
             lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
                         State, State#state.hosts)

--- a/apps/ejabberd/src/ejabberd_gen_auth.erl
+++ b/apps/ejabberd/src/ejabberd_gen_auth.erl
@@ -18,15 +18,8 @@
                        Password :: binary()
                       ) -> ok | {error, not_allowed | invalid_jid}.
 
--callback check_password(User :: ejabberd:luser(),
-                         Server :: ejabberd:lserver(),
-                         Password :: binary()) -> boolean().
-
--callback check_password(User :: ejabberd:luser(),
-                         Server :: ejabberd:lserver(),
-                         Password :: binary(),
-                         Digest :: binary(),
-                         DigestGen :: fun()) -> boolean().
+-callback authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
+                                               | {error, any()}.
 
 -callback try_register(User :: ejabberd:luser(),
                        Server :: ejabberd:lserver(),
@@ -63,3 +56,6 @@
                       Password :: binary()
                       ) -> ok | {error, not_exists | not_allowed | bad_request}.
 
+-export_type([t/0]).
+
+-type t() :: module().

--- a/apps/ejabberd/src/mongoose_credentials.erl
+++ b/apps/ejabberd/src/mongoose_credentials.erl
@@ -1,0 +1,75 @@
+-module(mongoose_credentials).
+
+-export([new/1,
+         lserver/1,
+         get/2, get/3,
+         set/3,
+         extend/2,
+         register/3]).
+
+-export_type([t/0]).
+
+-record(mongoose_credentials, {lserver, registry = [], extra = []}).
+
+-type auth_event() :: any().
+
+-opaque t() ::
+    #mongoose_credentials{ %% These values are always present.
+                           lserver :: ejabberd:lserver(),
+                           %% Authorization success / failure registry.
+                           registry :: [{ejabberd_gen_auth:t(), auth_event()}],
+                           %% These values are dependent on the ejabberd_auth backend in use.
+                           %% Each backend may require different values to be present.
+                           extra :: [proplists:property()] }.
+
+-spec new(ejabberd:server()) -> mongoose_credentials:t().
+new(Server) ->
+    case jid:nameprep(Server) of
+        error -> error(nameprep_failed, [Server]);
+        LServer when is_binary(LServer) ->
+            #mongoose_credentials{lserver = LServer}
+    end.
+
+-spec lserver(t()) -> ejabberd:lserver().
+lserver(#mongoose_credentials{lserver = S}) -> S.
+
+%% @doc Calls erlang:error/2 when Key is not found!
+-spec get(t(), Key) -> Value when
+      Key :: any(),
+      Value :: any().
+get(#mongoose_credentials{extra = Extra} = C, Key) ->
+    case lists:keyfind(Key, 1, Extra) of
+        false -> error({not_found, Key}, [C, Key]);
+        {Key, Value} -> Value
+    end.
+
+%% @doc Returns Default when Key is not found.
+-spec get(t(), Key, Default) -> Value when
+      Key :: any(),
+      Default :: any(),
+      Value :: any().
+get(#mongoose_credentials{extra = Extra}, Key, Default) ->
+    case lists:keyfind(Key, 1, Extra) of
+        false -> Default;
+        {Key, Value} -> Value
+    end.
+
+-spec set(t(), Key, Value) -> ok when
+      Key :: any(),
+      Value :: any().
+set(#mongoose_credentials{extra = Extra} = C, Key, Value) ->
+    NewExtra = lists:keystore(Key, 1, Extra, {Key, Value}),
+    C#mongoose_credentials{extra = NewExtra}.
+
+-spec extend(t(), [{Key, Value}]) -> ok when
+      Key :: any(),
+      Value :: any().
+extend(#mongoose_credentials{} = C, KVPairs) ->
+    lists:foldl(fun ({K, V}, Creds) ->
+                        ?MODULE:set(Creds, K, V)
+                end, C, KVPairs).
+
+-spec register(t(), ejabberd_gen_auth:t(), auth_event()) -> t().
+register(#mongoose_credentials{} = C, Mod, Event) ->
+    #mongoose_credentials{registry = R} = C,
+    C#mongoose_credentials{registry = [{Mod, Event} | R]}.


### PR DESCRIPTION
This PR introduces a `mongoose_credentials` type. A single instance corresponds to a single authentication/authorization request.
The datatype is instantiated in `ejabberd_c2s` when the session is initially authenticated.
It gathers all information obtained by the chosen SASL mechanism, which is later consumed by the auth backend(s).
The auth backends might add more information (like session capabilities, validity period, etc.) when returning the credentials back to C2S - this information can e.g. come from decrypting an authorization token or from an external authorization service.
The idea is to have all the bits and pieces of information in one place in order to enable extending the authentication process through hooks (no such hook is introduced in this PR yet).

This is not intended for merging yet, as auth backends other than `internal` aren't ready. I just want to get feedback from Travis.