### PR TITLE
Stabilize riak job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,6 @@ env:
         - PRESET=dialyzer_only
 
 matrix:
-    allow_failures:
-        - env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
-    fast_finish: true
     include:
         - otp_release: R16B03
           env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none

--- a/apps/ejabberd/src/mod_keystore.erl
+++ b/apps/ejabberd/src/mod_keystore.erl
@@ -114,10 +114,17 @@ create_keystore_ets() ->
     case does_table_exist(keystore) of
         true -> ok;
         false ->
-            keystore = ets:new(keystore, [named_table, public,
-                                          {read_concurrency, true}]),
+            BaseOpts = [named_table, public,
+                        {read_concurrency, true}],
+            Opts = maybe_add_heir(whereis(ejabberd_sup), self(), BaseOpts),
+            keystore = ets:new(keystore, Opts),
             ok
     end.
+
+maybe_add_heir(EjdSupPid, _Self, BaseOpts) when is_pid(EjdSupPid) ->
+    [{heir, EjdSupPid, testing} | BaseOpts];
+maybe_add_heir(_, _, BaseOpts) ->
+    BaseOpts.
 
 clear_keystore_ets(Domain) ->
     Pattern = {{'_', Domain}, '$1'},

--- a/apps/ejabberd/src/mod_keystore.erl
+++ b/apps/ejabberd/src/mod_keystore.erl
@@ -121,10 +121,16 @@ create_keystore_ets() ->
             ok
     end.
 
+%% In tests or when module is started in run-time, we need to set heir to the
+%% ETS table, otherwise it will be destroy when the creator's process finishes.
+%% When started normally during node start up, self() =:= EjdSupPid and there
+%% is no need for setting heir
+maybe_add_heir(EjdSupPid, EjdSupPid, BaseOpts) when is_pid(EjdSupPid) ->
+     BaseOpts;
 maybe_add_heir(EjdSupPid, _Self, BaseOpts) when is_pid(EjdSupPid) ->
-    [{heir, EjdSupPid, testing} | BaseOpts];
+      [{heir, EjdSupPid, testing} | BaseOpts];
 maybe_add_heir(_, _, BaseOpts) ->
-    BaseOpts.
+      BaseOpts.
 
 clear_keystore_ets(Domain) ->
     Pattern = {{'_', Domain}, '$1'},

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -715,7 +715,7 @@
   {{mod_vcard}}
   {mod_bosh, []},
   {mod_websockets, []},
-  {mod_carboncopy, []},
+  {mod_carboncopy, []}
 
   %%
   %% Message Archive Management (MAM) for registered users.
@@ -824,21 +824,6 @@
 % {mod_mam_muc_ca_arch, []},
 % {mod_mam_muc, [{host, "muc.@HOST@"}]},
 
-  %% Ephemeral / persistent key storage
-  {mod_keystore, [{keys, [
-                          {token_secret, ram},
-                          %% This is a hack for tests! As the name implies,
-                          %% a pre-shared key should be read from a file stored
-                          %% on disk. This way it can be shared with trusted 3rd
-                          %% parties who can use it to sign tokens for users
-                          %% to authenticate with and MongooseIM to verify.
-                          {provision_pre_shared, ram}
-                         ]}]},
-
-  %% Token based authentication, requires mod_keystore
-  {mod_auth_token, [{ {validity_period, access}, {60, minutes} },
-                    { {validity_period, refresh}, {1, days} }]
-  }
 
  ]}.
 

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -1035,6 +1035,8 @@ muc_light_simple(Config) ->
             muc_light_SUITE:verify_aff_bcast([{Alice, owner}, {Bob, member}], [{Bob, member}]),
 
             P = ?config(props, Config),
+            maybe_wait_for_yz(Config),
+
             ArchiveReqStanza = escalus_stanza:to(stanza_archive_request(P, <<"mlight">>), Room2BinJID),
             escalus:send(Bob, ArchiveReqStanza),
             [CreateEvent, Msg1, Msg2, BobAdd] = respond_messages(assert_respond_size(

--- a/test/ejabberd_tests/tests/oauth_SUITE.erl
+++ b/test/ejabberd_tests/tests/oauth_SUITE.erl
@@ -72,13 +72,30 @@ init_per_suite(Config0) ->
     case is_pgsql_available(Config0) of
         true ->
             Config = dynamic_modules:stop_running(mod_last, Config0),
+            Host = ct:get_config({hosts, mim, domain}),
+            KeyStoreOpts = [{keys, [
+                                    {token_secret, ram},
+                                    %% This is a hack for tests! As the name implies,
+                                    %% a pre-shared key should be read from a file stored
+                                    %% on disk. This way it can be shared with trusted 3rd
+                                    %% parties who can use it to sign tokens for users
+                                    %% to authenticate with and MongooseIM to verify.
+                                    {provision_pre_shared, ram}
+                                   ]}],
+            AuthOpts = [{ {validity_period, access}, {60, minutes} },
+                        { {validity_period, refresh}, {1, days} }],
+            dynamic_modules:start(Host, mod_keystore, KeyStoreOpts),
+            dynamic_modules:start(Host, mod_auth_token, AuthOpts),
             escalus:init_per_suite(Config);
         false ->
             {skip, "PostgreSQL not available - check env configuration"}
     end.
 
 end_per_suite(Config) ->
+    Host = ct:get_config({hosts, mim, domain}),
     dynamic_modules:start_running(Config),
+    dynamic_modules:stop(Host, mod_auth_token),
+    dynamic_modules:stop(Host, mod_keystore),
     escalus:end_per_suite(Config).
 
 init_per_group(GroupName, Config0) ->

--- a/tools/setup_riak
+++ b/tools/setup_riak
@@ -1,26 +1,26 @@
 #!/bin/bash
 
-
+sleep 20
 
 RIAK_HOST="http://localhost:8098"
 
-curl -XPUT $RIAK_HOST/search/schema/vcard \
+curl -v -XPUT $RIAK_HOST/search/schema/vcard \
     -H 'Content-Type:application/xml' \
     --data-binary @tools/vcard_search_schema.xml
 
-curl $RIAK_HOST/search/schema/vcard
+curl -v $RIAK_HOST/search/schema/vcard
 
-curl -XPUT $RIAK_HOST/search/index/vcard \
+curl -v -XPUT $RIAK_HOST/search/index/vcard \
     -H 'Content-Type: application/json' \
     -d '{"schema":"vcard"}'
 
-curl -XPUT $RIAK_HOST/search/schema/mam \
+curl -v -XPUT $RIAK_HOST/search/schema/mam \
     -H 'Content-Type:application/xml' \
     --data-binary @tools/mam_search_schema.xml
 
-curl $RIAK_HOST/search/schema/mam
+curl -v $RIAK_HOST/search/schema/mam
 
-curl -XPUT $RIAK_HOST/search/index/mam \
+curl -v -XPUT $RIAK_HOST/search/index/mam \
     -H 'Content-Type: application/json' \
     -d '{"schema":"mam"}'
 


### PR DESCRIPTION
Proposed changes include:
* start `mod_keystore` and `mod_auth_token` only for tests
* stable riak job on travis
