### PR TITLE
Lager init

### DIFF
--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -223,5 +223,10 @@ load_drivers([Driver | Rest]) ->
 
 init_log() ->
     ejabberd_loglevel:init(),
-    ejabberd_loglevel:set(4).
+    case application:get_env(ejabberd, keep_lager_intact, false) of
+        true ->
+            skip;
+        false ->
+            ejabberd_loglevel:set(4)
+    end.
 

--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -39,8 +39,7 @@
 %%%
 
 start(normal, _Args) ->
-    ejabberd_loglevel:init(),
-    ejabberd_loglevel:set(4),
+    init_log(),
     mongoose_fips:notify(),
     write_pid_file(),
     db_init(),
@@ -221,3 +220,8 @@ load_drivers([Driver | Rest]) ->
                           [erl_ddll:format_error(Reason)]),
             exit({driver_loading_failed, Driver, Reason})
     end.
+
+init_log() ->
+    ejabberd_loglevel:init(),
+    ejabberd_loglevel:set(4).
+

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -243,6 +243,11 @@ By default only following applications can be found there:
     Here you can change logs location and file names (`file`), rotation strategy (`size` and `count`) 
    and date formatting (`date`). Ignore log level parameters - they are overridden with the value in `ejabberd.cfg`.
 
+* `ejabberd` - set `keep_lager_intact` parameter to `true` when you want
+    use `lager` log level parameters from `app.config`. Missing value or
+    `false` for this parameter means override log levels with the value
+    in `ejabberd.cfg`.
+
 * `ssl` only `session_lifetime` parameter is specified in
     this file. Its default value is **600s**. This parameter says for how
     long ssl session should remain in the cache for further re-use,


### PR DESCRIPTION
Do not change lager loglevel when the parameter is specified in the env.

When the ejabberd app is started all lager handlers are set to the same loglevel,
either from config or default. Sometimes it is necessary to keep different handlers at
different loglevels. In this case the loglevels are set for the lager app and
a particular parameter is set in the ejabberd env so ejabberd doesn't changes
the lager loglevels on start.