### PR TITLE
Muc test fix

### DIFF
--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -662,18 +662,15 @@
                            % default: 600 seconds
                            % {resume_timeout, 600}
                           ]},
-%  {mod_muc_light, [
-%                   {host, "muclight.@HOST@"}
-%                  ]},
-  %{mod_muc, [
-             %{host, "muc.@HOST@"},
-             %{access, muc},
-             %{access_create, muc_create}
-            %]},
-  %{mod_muc_log, [
-                 %{outdir, "/tmp/muclogs"},
-                 %{access_log, muc}
-                %]},
+  %% {mod_muc_light, [{host, "muclight.@HOST@"}]},
+  %% {mod_muc, [{host, "muc.@HOST@"},
+  %%            {access, muc},
+  %%            {access_create, muc_create}
+  %%           ]},
+  %% {mod_muc_log, [
+  %%                {outdir, "/tmp/muclogs"},
+  %%                {access_log, muc}
+  %%               ]},
   {{mod_offline}}
   {{mod_privacy}}
   {{mod_private}}

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -665,15 +665,15 @@
 %  {mod_muc_light, [
 %                   {host, "muclight.@HOST@"}
 %                  ]},
-  {mod_muc, [
-             {host, "muc.@HOST@"},
-             {access, muc},
-             {access_create, muc_create}
-            ]},
-  {mod_muc_log, [
-                 {outdir, "/tmp/muclogs"},
-                 {access_log, muc}
-                ]},
+  %{mod_muc, [
+             %{host, "muc.@HOST@"},
+             %{access, muc},
+             %{access_create, muc_create}
+            %]},
+  %{mod_muc_log, [
+                 %{outdir, "/tmp/muclogs"},
+                 %{access_log, muc}
+                %]},
   {{mod_offline}}
   {{mod_privacy}}
   {{mod_private}}

--- a/rel/files/ejabberd.cfg.token-support
+++ b/rel/files/ejabberd.cfg.token-support
@@ -630,16 +630,16 @@
                            % default: 600 seconds
                            % {resume_timeout, 600}
                           ]},
-  {mod_muc, [
-             {host, "muc.@HOST@"},
-             {access, muc},
-             {access_create, muc_create}
-            ]},
-  {mod_muc_log,
-        [
-        {outdir, "/tmp/muclogs"},
-        {access_log, muc}
-        ]},
+  %{mod_muc, [
+             %{host, "muc.@HOST@"},
+             %{access, muc},
+             %{access_create, muc_create}
+            %]},
+  %{mod_muc_log,
+        %[
+        %{outdir, "/tmp/muclogs"},
+        %{access_log, muc}
+        %]},
   {mod_offline, [{access_max_user_messages, max_user_offline_messages}]},
   {mod_privacy, []},
   {mod_private, []},

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -210,16 +210,16 @@ try_registering_component_twice(Config) ->
     ok = escalus_connection:stop(Comp1).
 
 try_registering_existing_host(Config) ->
-    %% Given a external muc component
-    Component = spec(muc_component, Config),
+    %% Given a external vjud component
+    Component = spec(vjud_component, Config),
 
     try
         %% When trying to connect it to the server
         {Comp, _Addr, _} = connect_component(Component),
         ok = escalus_connection:stop(Comp),
-        ct:fail("muc component connected successfully")
+        ct:fail("vjud component connected successfully")
     catch {stream_error, _} ->
-        %% Then it should fail since muc service already exists on the server
+        %% Then it should fail since vjud service already exists on the server
         ok
     end.
 
@@ -433,7 +433,7 @@ register_same_on_both(Config) ->
 %%--------------------------------------------------------------------
 
 get_components(Opts, Config) ->
-    Components = [component1, component2, muc_component],
+    Components = [component1, component2, vjud_component],
     [ {C, Opts ++ spec(C, Config)} || C <- Components ] ++ Config.
 
 connect_component(Component) ->
@@ -559,8 +559,8 @@ spec(component_on_2, Config) ->
     [{component, <<"yet_another_service">>}] ++ common(Config, 8899);
 spec(component_duplicate, Config) ->
     [{component, <<"another_service">>}] ++ common(Config, 8899);
-spec(muc_component, Config) ->
-    [{component, <<"muc">>}] ++ common(Config).
+spec(vjud_component, Config) ->
+    [{component, <<"vjud">>}] ++ common(Config).
 
 common(Config) ->
     common(Config, 8888).

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -350,11 +350,13 @@ suite() ->
     escalus:suite().
 
 init_per_suite(Config) ->
+    muc_helper:load_muc(muc_host()),
     disable_shaping(
       delete_users([{escalus_user_db, {module, escalus_ejabberd}}
                   | escalus:init_per_suite(Config)])).
 
 end_per_suite(Config) ->
+    muc_helper:unload_muc(),
     escalus:end_per_suite(restore_shaping(Config)).
 
 user_names() ->

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -211,22 +211,14 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
--define(MUCHOST, <<"muc.localhost">>).
 
 init_per_suite(Config) ->
-    dynamic_modules:start(<<"localhost">>, mod_muc,
-            [{host, binary_to_list(?MUCHOST)},
-             {access, muc},
-             {access_create, muc_create}]),
-    dynamic_modules:start(<<"localhost">>, mod_muc_log,
-            [{outdir, "/tmp/muclogs"},
-             {access_log, muc}]),
+    muc_helper:load_muc(?MUC_HOST),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    dynamic_modules:stop(<<"localhost">>, mod_muc),
-    dynamic_modules:stop(<<"localhost">>, mod_muc_log),
+    muc_helper:unload_muc(),
     escalus:end_per_suite(Config).
 
 init_per_group(moderator, Config) ->

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -215,14 +215,12 @@ suite() ->
 
 init_per_suite(Config) ->
     dynamic_modules:start(<<"localhost">>, mod_muc,
-        [{host, binary_to_list(?MUCHOST)},
-            {access, muc},
-            {access_create, muc_create}]),
+            [{host, binary_to_list(?MUCHOST)},
+             {access, muc},
+             {access_create, muc_create}]),
     dynamic_modules:start(<<"localhost">>, mod_muc_log,
-        [
-            {outdir, "/tmp/muclogs"},
-            {access_log, muc}
-            ]),
+            [{outdir, "/tmp/muclogs"},
+             {access_log, muc}]),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -211,11 +211,24 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
+-define(MUCHOST, <<"muc.localhost">>).
+
 init_per_suite(Config) ->
+    dynamic_modules:start(<<"localhost">>, mod_muc,
+        [{host, binary_to_list(?MUCHOST)},
+            {access, muc},
+            {access_create, muc_create}]),
+    dynamic_modules:start(<<"localhost">>, mod_muc_log,
+        [
+            {outdir, "/tmp/muclogs"},
+            {access_log, muc}
+            ]),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
+    dynamic_modules:stop(<<"localhost">>, mod_muc),
+    dynamic_modules:stop(<<"localhost">>, mod_muc_log),
     escalus:end_per_suite(Config).
 
 init_per_group(moderator, Config) ->

--- a/test/ejabberd_tests/tests/muc_helper.erl
+++ b/test/ejabberd_tests/tests/muc_helper.erl
@@ -3,7 +3,9 @@
 -include_lib("exml/include/exml.hrl").
 
 -export([foreach_occupant/3,
-        foreach_recipient/2]).
+        foreach_recipient/2,
+        load_muc/1,
+        unload_muc/0]).
 
 -type verify_fun() :: fun((Incoming :: #xmlel{}) -> any()).
 
@@ -37,3 +39,16 @@ foreach_recipient(Users, VerifyFun) ->
       fun(Recipient) ->
               VerifyFun(escalus:wait_for_stanza(Recipient))
       end, Users).
+
+load_muc(Host) ->
+    dynamic_modules:start(<<"localhost">>, mod_muc,
+        [{host, binary_to_list(Host)},
+            {access, muc},
+            {access_create, muc_create}]),
+    dynamic_modules:start(<<"localhost">>, mod_muc_log,
+        [{outdir, "/tmp/muclogs"},
+            {access_log, muc}]).
+
+unload_muc() ->
+    dynamic_modules:stop(<<"localhost">>, mod_muc),
+    dynamic_modules:stop(<<"localhost">>, mod_muc_log).


### PR DESCRIPTION
As it was, if muc_light_legacy_SUITE was run before muc_SUITE then the latter failed. The reason was that muc was loaded statically at startup, and registered itself under muc.localhost in local routing table. muc_light was loaded dynamically, registered itself under the same domain, and then was unloaded.

