### PR TITLE
Muc light disco#items fix + room confuguration fix

### DIFF
--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -433,6 +433,8 @@ apply_rsm(_RoomsInfo, _RoomsInfoLen, #rsm_in{ max = Max }) when Max < 0 ->
     {error, item_not_found};
 apply_rsm(_RoomsInfo, RoomsInfoLen, #rsm_in{ max = 0 }) ->
     {ok, [], #rsm_out{ count = RoomsInfoLen }};
+apply_rsm([], 0, #rsm_in{ direction = undefined, id = undefined, index = undefined } = _RSMIn) ->
+    {ok, [], none};
 apply_rsm(RoomsInfo, RoomsInfoLen, #rsm_in{ direction = undefined, id = undefined,
                                             index = undefined } = RSMIn) ->
     apply_rsm(RoomsInfo, RoomsInfoLen, RSMIn#rsm_in{ index = 0 });

--- a/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
@@ -331,7 +331,7 @@ set_config_transaction(RoomUS, ConfigChanges, Version) ->
         [] ->
             {error, not_exists};
         [#?ROOM_TAB{ config = Config } = Rec] ->
-            NewConfig = lists:umerge(ConfigChanges, Config),
+            NewConfig = lists:ukeymerge(1, ConfigChanges, Config),
             mnesia:write(Rec#?ROOM_TAB{ config = NewConfig, version = Version }),
             {ok, Rec#?ROOM_TAB.version}
     end.

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -401,7 +401,7 @@ change_subject(Config) ->
         end).
 
 change_roomname(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
         %% change room name
         ConfigChange = [{<<"roomname">>, <<"new_test_room">>}],
         Stanza = stanza_config_set(?ROOM, ConfigChange),


### PR DESCRIPTION
This PR addresses https://github.com/esl/MongooseIM/issues/838 and #839

Proposed changes include:
For #838:
 added tests with four cases:
- set `{rooms_per_page, infinity}` and empty room list
- set `{rooms_per_page, infinity}` and not empty room list
- set `{rooms_per_page, 1}` and not empty room list
- set `{rooms_per_page, 1}` and empty room list <-- this test hasn't passed

Fixed the issue in module `mod_muc_light`
 ---
For #839 :
- added test for changing room name configuration
- fixed the issue with replacing the room configuration in mnesia backend

