### PR TITLE
Retrieve rooms after room destruction (muc_light)

### DIFF
--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -564,8 +564,7 @@ destroy_room_get_disco_items_empty(Config) ->
         % Send disco#items request
         DiscoStanza = escalus_stanza:to(escalus_stanza:iq_get(?NS_DISCO_ITEMS, []), ?MUCHOST),
         foreach_occupant([Alice, Bob, Kate], DiscoStanza, disco_items_verify_fun([]))
-
-                                                             end).
+     end).
 
 destroy_room_get_disco_items_one_left(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
@@ -579,7 +578,7 @@ destroy_room_get_disco_items_one_left(Config) ->
         % Send disco#items request. Shoul be one room created by kate
         DiscoStanza = escalus_stanza:to(escalus_stanza:iq_get(?NS_DISCO_ITEMS, []), ?MUCHOST),
         foreach_occupant([Alice, Bob, Kate], DiscoStanza, disco_items_verify_fun([ProperJID]))
-                                                             end).
+     end).
 
 set_config(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -35,6 +35,8 @@
          create_room_with_equal_occupants/1,
          create_existing_room_deny/1,
          destroy_room/1,
+         destroy_room_get_disco_items_empty/1,
+         destroy_room_get_disco_items_one_left/1,
          set_config/1,
          remove_and_add_users/1,
          explicit_owner_change/1,
@@ -143,6 +145,8 @@ groups() ->
                           create_room_with_equal_occupants,
                           create_existing_room_deny,
                           destroy_room,
+                          destroy_room_get_disco_items_empty,
+                          destroy_room_get_disco_items_one_left,
                           set_config,
                           remove_and_add_users,
                           explicit_owner_change,
@@ -551,6 +555,32 @@ destroy_room(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice))
         end).
 
+destroy_room_get_disco_items_empty(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+        escalus:send(Alice, stanza_destroy_room(?ROOM)),
+        AffUsersChanges = [{Bob, none}, {Alice, none}, {Kate, none}],
+        verify_aff_bcast([], AffUsersChanges, [?NS_MUC_LIGHT_DESTROY]),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+        % Send disco#items request
+        DiscoStanza = escalus_stanza:to(escalus_stanza:iq_get(?NS_DISCO_ITEMS, []), ?MUCHOST),
+        foreach_occupant([Alice, Bob, Kate], DiscoStanza, disco_items_verify_fun([]))
+
+                                                             end).
+
+destroy_room_get_disco_items_one_left(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+        {ok, {?ROOM2, ?MUCHOST}} = create_room(?ROOM2, ?MUCHOST, kate, [bob, alice], Config, ver(0)),
+        ProperJID = room_bin_jid(?ROOM2),
+        %% alie destroy her room
+        escalus:send(Alice, stanza_destroy_room(?ROOM)),
+        AffUsersChanges = [{Bob, none}, {Alice, none}, {Kate, none}],
+        verify_aff_bcast([], AffUsersChanges, [?NS_MUC_LIGHT_DESTROY]),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+        % Send disco#items request. Shoul be one room created by kate
+        DiscoStanza = escalus_stanza:to(escalus_stanza:iq_get(?NS_DISCO_ITEMS, []), ?MUCHOST),
+        foreach_occupant([Alice, Bob, Kate], DiscoStanza, disco_items_verify_fun([ProperJID]))
+                                                             end).
+
 set_config(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
             ConfigChange = [{<<"roomname">>, <<"The Coven">>}],
@@ -822,6 +852,15 @@ verify_blocklist(Query, ProperBlocklist) ->
     ProperBlocklistLen = length(ProperBlocklist),
     ProperBlocklistLen = length(BlockedItems),
     [] = lists:foldl(fun lists:delete/2, BlockedItems, ProperBlocklist).
+
+-spec disco_items_verify_fun(list(Jid :: binary())) -> verify_fun().
+disco_items_verify_fun(JidList) ->
+    fun(Incomming) ->
+        ResultItemList = exml_query:paths(Incomming, [{element, <<"query">>}, {element, <<"item">>}]),
+        ResultJids = [exml_query:attr(ResultItem, <<"jid">>) || ResultItem <- ResultItemList],
+        {SortedResult, SortedExptected} = {lists:sort(JidList), lists:sort(ResultJids)},
+        SortedResult = SortedExptected
+    end.
 
 verify_aff_bcast(CurrentOccupants, AffUsersChanges) ->
     verify_aff_bcast(CurrentOccupants, AffUsersChanges, []).


### PR DESCRIPTION
It was not possible for client to [retrive room list](https://xmpp.org/extensions/inbox/muc-light.html#disco-occupied-rooms) after[ destroying any room](https://xmpp.org/extensions/inbox/muc-light.html#destroying-a-room) in Muc Light because of a timeout. 

The reason lies in `mod_muc_light_db_mnesia:destroy_room_transaction/1` [1]. 
The room is removed from `muc_light_room` table but it's still untouched in the user's room list in `muc_light_user_room`. Then, the _disco#items_ request looks through this table and tries to obtain unexistent room's information[2] which results with `{error, not_exists}`[3] and client get no response


Proposed changes include:
* tests for destrying room and retriving a room list
* fixed the issue in `mod_muc_light_db_mnesia`

[1] https://github.com/esl/MongooseIM/blob/master/apps/ejabberd/src/mod_muc_light_db_mnesia.erl#L307
[2] https://github.com/esl/MongooseIM/blob/master/apps/ejabberd/src/mod_muc_light.erl#L399
[3] https://github.com/esl/MongooseIM/blob/master/apps/ejabberd/src/mod_muc_light_db_mnesia.erl#L222