### PR TITLE
Mam fixes

### DIFF
--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -73,8 +73,8 @@
          get_one_of_path/2,
          wrap_message/6,
          result_set/4,
-         result_query/1,
-         result_prefs/3,
+         result_query/2,
+         result_prefs/4,
          make_fin_message/5,
          make_fin_element/4,
          parse_prefs/1,
@@ -448,7 +448,7 @@ handle_set_prefs(ArcJID=#jid{},
     handle_set_prefs_result(Res, DefaultMode, AlwaysJIDs, NeverJIDs, IQ).
 
 handle_set_prefs_result(ok, DefaultMode, AlwaysJIDs, NeverJIDs, IQ) ->
-    ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs),
+    ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};
 handle_set_prefs_result({error, Reason},
                         _DefaultMode, _AlwaysJIDs, _NeverJIDs, IQ) ->
@@ -466,7 +466,7 @@ handle_get_prefs(ArcJID=#jid{}, IQ=#iq{}) ->
 handle_get_prefs_result({DefaultMode, AlwaysJIDs, NeverJIDs}, IQ) ->
     ?DEBUG("Extracted data~n\tDefaultMode ~p~n\tAlwaysJIDs ~p~n\tNeverJIDS ~p~n",
               [DefaultMode, AlwaysJIDs, NeverJIDs]),
-    ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs),
+    ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};
 handle_get_prefs_result({error, Reason}, IQ) ->
     return_error_iq(IQ, Reason).
@@ -518,7 +518,7 @@ handle_lookup_messages(
         [send_message(ArcJID, From, message_row_to_xml(MamNs, From, HideUser, SetClientNs, Row, QueryID))
          || Row <- MessageRows],
         ResultSetEl = result_set(FirstMessID, LastMessID, Offset, TotalCount),
-        ResultQueryEl = result_query(ResultSetEl),
+        ResultQueryEl = result_query(ResultSetEl, MamNs),
         %% On receiving the query, the server pushes to the client a series of
         %% messages from the archive that match the client's given criteria,
         %% and finally returns the <iq/> result.

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -421,7 +421,7 @@ result_set(FirstId, LastId, FirstIndexI, CountI)
         children = FirstEl ++ LastEl ++ [CountEl]}.
 
 
--spec result_query(jlib:xmlcdata() | jlib:xmlel()) -> jlib:xmlel().
+-spec result_query(jlib:xmlcdata() | jlib:xmlel(), binary()) -> jlib:xmlel().
 result_query(SetEl, Namespace) ->
      #xmlel{
         name = <<"query">>,
@@ -627,10 +627,11 @@ field_to_value(FieldEl) ->
 
 -spec message_form(binary()) -> jlib:xmlel().
 message_form(MamNs) ->
-    #xmlel{name = <<"x">>,
+    SubEl = #xmlel{name = <<"x">>,
            attrs = [{<<"xmlns">>, <<"jabber:x:data">>},
                     {<<"type">>, <<"form">>}],
-           children = message_form_fields(MamNs)}.
+           children = message_form_fields(MamNs)},
+    result_query(SubEl, MamNs).
 
 message_form_fields(MamNs) ->
     [form_type_field(MamNs),

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -32,8 +32,8 @@
          is_complete_message/3,
          wrap_message/6,
          result_set/4,
-         result_query/1,
-         result_prefs/3,
+         result_query/2,
+         result_prefs/4,
          make_fin_message/5,
          make_fin_element/4,
          parse_prefs/1,
@@ -98,7 +98,6 @@
 
 %% Constants
 rsm_ns_binary() -> <<"http://jabber.org/protocol/rsm">>.
-mam_ns_binary() -> <<"urn:xmpp:mam:tmp">>.
 
 %% ----------------------------------------------------------------------
 %% Datetime types
@@ -423,23 +422,24 @@ result_set(FirstId, LastId, FirstIndexI, CountI)
 
 
 -spec result_query(jlib:xmlcdata() | jlib:xmlel()) -> jlib:xmlel().
-result_query(SetEl) ->
+result_query(SetEl, Namespace) ->
      #xmlel{
         name = <<"query">>,
-        attrs = [{<<"xmlns">>, mam_ns_binary()}],
+        attrs = [{<<"xmlns">>, Namespace}],
         children = [SetEl]}.
 
 -spec result_prefs(DefaultMode :: archive_behaviour(),
                    AlwaysJIDs :: [ejabberd:literal_jid()],
-                   NeverJIDs :: [ejabberd:literal_jid()]) -> jlib:xmlel().
-result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs) ->
+                   NeverJIDs :: [ejabberd:literal_jid()],
+                   Namespace :: binary()) -> jlib:xmlel().
+result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, Namespace) ->
     AlwaysEl = #xmlel{name = <<"always">>,
                       children = encode_jids(AlwaysJIDs)},
     NeverEl  = #xmlel{name = <<"never">>,
                       children = encode_jids(NeverJIDs)},
     #xmlel{
        name = <<"prefs">>,
-       attrs = [{<<"xmlns">>,mam_ns_binary()},
+       attrs = [{<<"xmlns">>, Namespace},
                 {<<"default">>, atom_to_binary(DefaultMode, utf8)}],
        children = [AlwaysEl, NeverEl]
     }.

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -2006,10 +2006,10 @@ prefs_set_request(Config) ->
         %% </iq>
         escalus:send(Alice, stanza_prefs_set_request(<<"roster">>,
                                                      [<<"romeo@montague.net">>],
-                                                     [<<"montague@montague.net">>])),
+                                                     [<<"montague@montague.net">>], mam_ns_binary())),
         ReplySet = escalus:wait_for_stanza(Alice),
 
-        escalus:send(Alice, stanza_prefs_get_request()),
+        escalus:send(Alice, stanza_prefs_get_request(mam_ns_binary())),
         ReplyGet = escalus:wait_for_stanza(Alice),
 
         ResultIQ1 = parse_prefs_result_iq(ReplySet),
@@ -2039,10 +2039,10 @@ prefs_set_cdata_request(Config) ->
         escalus:send(Alice, stanza_prefs_set_request(<<"roster">>,
                                                      [<<"romeo@montague.net">>,
                                                       {xmlcdata, <<"\n">>}, %% Put as it is
-                                                      <<"montague@montague.net">>], [])),
+                                                      <<"montague@montague.net">>], [], mam_ns_binary_v03())),
         ReplySet = escalus:wait_for_stanza(Alice),
 
-        escalus:send(Alice, stanza_prefs_get_request()),
+        escalus:send(Alice, stanza_prefs_get_request(mam_ns_binary_v03())),
         ReplyGet = escalus:wait_for_stanza(Alice),
 
         ResultIQ1 = parse_prefs_result_iq(ReplySet),
@@ -2093,6 +2093,7 @@ nick(User) -> escalus_utils:get_username(User).
 mam_ns_binary() -> <<"urn:xmpp:mam:tmp">>.
 mam_ns_binary_v03() -> <<"urn:xmpp:mam:0">>.
 mam_ns_binary_v04() -> <<"urn:xmpp:mam:1">>.
+namespaces() -> [mam_ns_binary(), mam_ns_binary_v03(), mam_ns_binary_v04()].
 muc_ns_binary() -> <<"http://jabber.org/protocol/muc">>.
 
 stanza_purge_single_message(MessId) ->
@@ -2336,22 +2337,22 @@ verify_archived_muc_light_aff_msg(Msg, AffUsersChanges, IsCreate) ->
 %% ----------------------------------------------------------------------
 %% PREFERENCE QUERIES
 
-stanza_prefs_set_request(DefaultMode, AlwaysJIDs, NeverJIDs) ->
+stanza_prefs_set_request(DefaultMode, AlwaysJIDs, NeverJIDs, Namespace) ->
     AlwaysEl = #xmlel{name = <<"always">>,
                       children = encode_jids(AlwaysJIDs)},
     NeverEl  = #xmlel{name = <<"never">>,
                       children = encode_jids(NeverJIDs)},
     escalus_stanza:iq(<<"set">>, [#xmlel{
        name = <<"prefs">>,
-       attrs = [{<<"xmlns">>,mam_ns_binary()}]
+       attrs = [{<<"xmlns">>, Namespace}]
                ++ [{<<"default">>, DefaultMode} || is_def(DefaultMode)],
        children = [AlwaysEl, NeverEl]
     }]).
 
-stanza_prefs_get_request() ->
+stanza_prefs_get_request(Namespace) ->
     escalus_stanza:iq(<<"get">>, [#xmlel{
        name = <<"prefs">>,
-       attrs = [{<<"xmlns">>,mam_ns_binary()}]
+       attrs = [{<<"xmlns">>, Namespace}]
     }]).
 
 %% Allows to cdata to be put as it is
@@ -3040,7 +3041,8 @@ run_prefs_cases(Config) ->
     F = fun(Alice, Bob, Kate) ->
         make_alice_and_bob_friends(Alice, Bob),
         %% Just send messages for each prefs configuration
-        Funs = [run_prefs_case(Case, Alice, Bob, Kate, Config) || Case <- prefs_cases2()],
+        Funs = [run_prefs_case(Case, Namespace, Alice, Bob, Kate, Config) || Case <- prefs_cases2(),
+                                                                             Namespace <- namespaces()],
 
         maybe_wait_for_yz(Config),
 
@@ -3074,8 +3076,9 @@ make_alice_and_bob_friends(Alice, Bob) ->
         escalus:wait_for_stanzas(Bob, 3, 5000), % iq set subscription=both, presence subscribed, presence
         ok.
 
-run_prefs_case({PrefsState, ExpectedMessageStates}, Alice, Bob, Kate, Config) ->
-    IqSet = stanza_prefs_set_request(PrefsState, Config),
+run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate, Config) ->
+    {DefaultMode, AlwaysUsers, NeverUsers} = PrefsState,
+    IqSet = stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config),
     escalus:send(Alice, IqSet),
     ReplySet = escalus:wait_for_stanza(Alice),
     Messages = [iolist_to_binary(io_lib:format("n=~p, prefs=~p, now=~p",
@@ -3122,11 +3125,11 @@ get_all_messages(P, Alice, Id) ->
             PageMessages ++ get_all_messages(P, Alice, LastId)
     end.
 
-stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers}, Config) ->
+stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config) ->
     DefaultModeBin = atom_to_binary(DefaultMode, utf8),
     AlwaysJIDs = users_to_jids(AlwaysUsers, Config),
     NeverJIDs  = users_to_jids(NeverUsers, Config),
-    stanza_prefs_set_request(DefaultModeBin, AlwaysJIDs, NeverJIDs).
+    stanza_prefs_set_request(DefaultModeBin, AlwaysJIDs, NeverJIDs, Namespace).
 
 users_to_jids(Users, Config) ->
     [escalus_users:get_jid(Config, User) || User <- Users].
@@ -3140,19 +3143,23 @@ print_configuration_not_supported(C, B) ->
 run_set_and_get_prefs_cases(Config) ->
     P = ?config(props, Config),
     F = fun(Alice) ->
-        [run_set_and_get_prefs_case(Case, Alice, Config) || Case <- prefs_cases2()]
+        [run_set_and_get_prefs_case(Case, Namespace, Alice, Config) || Case <- prefs_cases2(),
+                                                                       Namespace <- namespaces()]
         end,
     escalus:story(Config, [{alice, 1}], F).
 
 %% Alice sets and gets her preferences
-run_set_and_get_prefs_case({PrefsState, _ExpectedMessageStates}, Alice, Config) ->
-    IqSet = stanza_prefs_set_request(PrefsState, Config),
+run_set_and_get_prefs_case({PrefsState, _ExpectedMessageStates}, Namespace, Alice, Config) ->
+    {DefaultMode, AlwaysUsers, NeverUsers} = PrefsState,
+    IqSet = stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config),
     escalus:send(Alice, IqSet),
     ReplySet = escalus:wait_for_stanza(Alice, 5000),
-
-    escalus:send(Alice, stanza_prefs_get_request()),
+    ReplySetNS = exml_query:path(ReplySet, [{element, <<"prefs">>}, {attr, <<"xmlns">>}]),
+    ?assert_equal(ReplySetNS, Namespace),
+    escalus:send(Alice, stanza_prefs_get_request(Namespace)),
     ReplyGet = escalus:wait_for_stanza(Alice),
-
+    ReplyGetNS = exml_query:path(ReplyGet, [{element, <<"prefs">>}, {attr, <<"xmlns">>}]),
+    ?assert_equal(ReplyGetNS, Namespace),
     ResultIQ1 = parse_prefs_result_iq(ReplySet),
     ResultIQ2 = parse_prefs_result_iq(ReplyGet),
     ?assert_equal(ResultIQ1, ResultIQ2),

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -1065,7 +1065,7 @@ retrive_form_fields(ConfigIn) ->
         escalus:send(Alice, stanza_retrive_form_fields(<<"q">>, Namespace)),
         Res = escalus:wait_for_stanza(Alice),
         escalus:assert(is_iq_with_ns, [Namespace], Res)
-                                          end).
+    end).
 
 archived(Config) ->
     P = ?config(props, Config),


### PR DESCRIPTION
This PR fixes two issues:

**1.When sending mam prefs stanza request we get wrong namespace in resposnse**

Send:
```xml
<iq id='7rWGj-19' type='get'>
<prefs xmlns='urn:xmpp:mam:1'> <!--- REQUEST NAMESPACE -->
</prefs>
</iq>
```
Received:
```` xml
<iq from='test.user@erlang-solutions.com' 
to='test.user@erlang-solutions.com/9bb69f6dacb33248' id='7rWGj-19'
type='result'>
<prefs xmlns='urn:xmpp:mam:tmp' default='always'>   <!--- RESPONSE NAMESPACE -->
<always/>
<never/>
</prefs>
</iq>
````
`urn:xmpp:mam:tmp` should be `urn:xmpp:mam:1`


Proposed changes include:
* updated tests `run_set_and_get_prefs_cases` in `mam_SUITE` so that namespace is checked
* fixed the problem in `mod_mam`

--
**2.Missing query tag while retrieving form fields**
Send:
``` xml
<iq id='lKJrJ-19' type='get'>
<query xmlns='urn:xmpp:mam:1' 
queryid='0d3c9b95-6c06-4edd-b554-e04f02c63006'>
</query>
</iq>
```

Received:
``` xml
<iq from='test.user@erlang-solutions.com'
 to='test.user@erlang-solutions.com/9bb69f6dacb33248' id='lKJrJ-19' 
type='result'>
<x xmlns='jabber:x:data' type='form'>  <!--- MISSING QUERY NAMESPACE -->
<field type='hidden' var='FORM_TYPE'>urn:xmpp:mam:1</field>
<field type='jid-single' var='with'/>
<field type='text-single' var='start'/>
<field type='text-single' var='end'/>
</x>
</iq>
```

The `x` tag should be inside a `query` tag in response stanza

Proposed changes include:
* added test `retrive_form_fields` in `mam_SUITE` for both `mam:1` and `mam:0` namespaces
* fixed the problem in `mod_mam`

