### PR TITLE
If username is empty return immediately

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -422,6 +422,8 @@ do_get_password_with_authmodule(LUser, LServer) ->
 %% logged under the given name
 -spec is_user_exists(User :: ejabberd:user(),
                      Server :: ejabberd:server()) -> boolean().
+is_user_exists(<<"">>, _) ->
+    false;
 is_user_exists(User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),


### PR DESCRIPTION
This PR addresses #856 
It is just a simple one-liner - some client implementation call this function with empty username, which might be a bug, but still - since you can't register a user with an empty username we don't have to check backends here, can return immediately and save on resources.


