### PR TITLE
rename is_user_exists to does_user_exist

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -472,7 +472,7 @@ do_does_user_exist_in_other_modules(Module, LUser, LServer) ->
 does_user_exist_in_other_modules_loop([], _User, _Server) ->
     false;
 does_user_exist_in_other_modules_loop([AuthModule|AuthModules], User, Server) ->
-    case AuthModule:is_user_exists(User, Server) of
+    case AuthModule:does_user_exist(User, Server) of
         true ->
             true;
         false ->


### PR DESCRIPTION
This PR addresses #862 

* renames an instance of is_user_exists() to do_user_exist that was missed in commit e4ca38c8e622be5dae3f0bb5b4c1ff682a5afecc

