### PR TITLE
Hunt BOSH interleave requests issue

### DIFF
--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -417,7 +417,7 @@ handle_stream_event({EventTag, Body, Rid} = Event, Handler,
                 is_expected_rid(Rid, ExpectedRid),
                 is_acceptable_rid(Rid, ExpectedRid)}
     of
-        {_, {true, CachedResponse}, _, _} ->
+        {_, {true, CachedResponse}, _, _} when Handler /= none ->
             case CachedResponse of
                 none ->
                     NS;

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -11,7 +11,7 @@
         {katt, ".*", {git, "git://github.com/for-GET/katt.git", {tag, "1.5.2"}}},
         {erlsh, ".*", {git, "git://github.com/proger/erlsh.git", "2fce513"}},
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
-        {proper, ".*", {git, "https://github.com/manopapad/proper.git", "20e62bc32f9bd43fe2ff52944a4ef99eb71d1399"}},
+        {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", {tag, "1.0.4"}}}
 ]}.
 

--- a/test/ejabberd_tests/src/ct_tty_hook.erl
+++ b/test/ejabberd_tests/src/ct_tty_hook.erl
@@ -93,7 +93,8 @@ post_end_per_testcase(TC, _Config, Return, State) ->
 
 %% @doc Called after post_init_per_suite, post_end_per_suite, post_init_per_group,
 %% post_end_per_group and post_end_per_testcase if the suite, group or test case failed.
-on_tc_fail(_TC, _Reason, State) ->
+on_tc_fail(TC, Reason, State) ->
+    ct:print("~p~n~p", [TC, Reason]),
     State.
 
 %% @doc Called when a test case is skipped by either user action

--- a/test/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test/ejabberd_tests/tests/bosh_SUITE.erl
@@ -309,7 +309,10 @@ interleave_requests_raw(Config) ->
         Msg3 = <<"3rd!">>,
         Msg4 = <<"4th!">>,
 
+        escalus:send(Geralt, escalus_stanza:chat_to(Carol, <<"Hi, Carol">>)),
         send_message_with_rid(Carol, Geralt, Rid + 1, Sid, Msg2),
+        escalus:assert(is_chat_message, [<<"Hi, Carol">>],
+                       escalus_client:wait_for_stanza(Carol)),
         send_message_with_rid(Carol2, Geralt, Rid, Sid, Msg1),
 
         send_message_with_rid(Carol2, Geralt, Rid + 2,   Sid, Msg3),

--- a/test/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test/ejabberd_tests/tests/bosh_SUITE.erl
@@ -69,7 +69,8 @@ chat_test_cases() ->
      cant_send_invalid_rid,
      multiple_stanzas,
      namespace,
-     stream_error].
+     stream_error
+    ].
 
 time_test_cases() ->
     [disconnect_inactive,
@@ -268,22 +269,71 @@ interleave_requests(Config) ->
         Rid = get_bosh_rid(Carol),
         Sid = get_bosh_sid(Carol),
 
-        Empty2 = escalus_bosh:empty_body(Rid + 1, Sid),
-        Chat2 = Empty2#xmlel{
-                children = [escalus_stanza:chat_to(Geralt, <<"2nd!">>)]},
-        escalus_bosh:send_raw(Carol, Chat2),
+        Msg1 = <<"1st!">>,
+        Msg2 = <<"2nd!">>,
+        Msg3 = <<"3rd!">>,
+        Msg4 = <<"4th!">>,
 
-        Empty1 = escalus_bosh:empty_body(Rid, Sid),
-        Chat1 = Empty1#xmlel{
-                children = [escalus_stanza:chat_to(Geralt, <<"1st!">>)]},
-        escalus_bosh:send_raw(Carol, Chat1),
+        send_message_with_rid(Carol, Geralt, Rid + 1, Sid, Msg2),
+        send_message_with_rid(Carol, Geralt, Rid, Sid, Msg1),
 
-        escalus:assert(is_chat_message, [<<"1st!">>],
+        send_message_with_rid(Carol, Geralt, Rid + 2,   Sid, Msg3),
+        send_message_with_rid(Carol, Geralt, Rid + 3,   Sid, Msg4),
+
+        escalus:assert(is_chat_message, [Msg1],
                        escalus_client:wait_for_stanza(Geralt)),
-        escalus:assert(is_chat_message, [<<"2nd!">>],
-                       escalus_client:wait_for_stanza(Geralt))
+        escalus:assert(is_chat_message, [Msg2],
+                       escalus_client:wait_for_stanza(Geralt)),
+        escalus:assert(is_chat_message, [Msg3],
+                       escalus_client:wait_for_stanza(Geralt)),
+        escalus:assert(is_chat_message, [Msg4],
+                       escalus_client:wait_for_stanza(Geralt)),
 
+        true = escalus_bosh:is_connected(Carol)
     end).
+
+interleave_requests_raw(Config) ->
+    escalus:story(Config, [{geralt, 1}], fun(Geralt) ->
+        User = ?config(user, Config),
+        Carol = start_client(Config, User, <<"bosh">>),
+        Rid = get_bosh_rid(Carol),
+        Sid = get_bosh_sid(Carol),
+
+        NamedSpecs = escalus_config:get_config(escalus_users, Config),
+        UserSpec = [{keepalive, false} | proplists:get_value(User, NamedSpecs)],
+
+        {ok, Carol2} = escalus_bosh:connect(UserSpec),
+
+        Msg1 = <<"1st!">>,
+        Msg2 = <<"2nd!">>,
+        Msg3 = <<"3rd!">>,
+        Msg4 = <<"4th!">>,
+
+        send_message_with_rid(Carol, Geralt, Rid + 1, Sid, Msg2),
+        send_message_with_rid(Carol2, Geralt, Rid, Sid, Msg1),
+
+        send_message_with_rid(Carol2, Geralt, Rid + 2,   Sid, Msg3),
+        send_message_with_rid(Carol, Geralt, Rid + 3,   Sid, Msg4),
+
+        escalus:assert(is_chat_message, [Msg1],
+                       escalus_client:wait_for_stanza(Geralt)),
+        escalus:assert(is_chat_message, [Msg2],
+                       escalus_client:wait_for_stanza(Geralt)),
+        escalus:assert(is_chat_message, [Msg3],
+                       escalus_client:wait_for_stanza(Geralt)),
+        escalus:assert(is_chat_message, [Msg4],
+                       escalus_client:wait_for_stanza(Geralt)),
+
+        true = escalus_bosh:is_connected(Carol),
+        escalus_bosh:kill(Carol),
+        escalus_bosh:kill(Carol2)
+    end).
+
+send_message_with_rid(From, To, Rid, Sid, Msg) ->
+    Empty = escalus_bosh:empty_body(Rid, Sid),
+    Chat = Empty#xmlel{
+             children = [escalus_stanza:chat_to(To, Msg)]},
+    escalus_bosh:send_raw(From, Chat).
 
 
 simple_chat(Config) ->

--- a/test/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test/ejabberd_tests/tests/bosh_SUITE.erl
@@ -63,6 +63,7 @@ essential_test_cases() ->
 
 chat_test_cases() ->
     [interleave_requests,
+     interleave_requests_statem,
      simple_chat,
      cdata_escape_chat,
      escape_attr_chat,
@@ -292,7 +293,10 @@ interleave_requests(Config) ->
         true = escalus_bosh:is_connected(Carol)
     end).
 
-interleave_requests_raw(Config) ->
+interleave_requests_statem(Config) ->
+    true = bosh_interleave_reqs:test(Config).
+
+interleave_requests_escalus(Config) ->
     escalus:story(Config, [{geralt, 1}], fun(Geralt) ->
         User = ?config(user, Config),
         Carol = start_client(Config, User, <<"bosh">>),

--- a/test/ejabberd_tests/tests/bosh_interleave_reqs.erl
+++ b/test/ejabberd_tests/tests/bosh_interleave_reqs.erl
@@ -1,0 +1,173 @@
+-module(bosh_interleave_reqs).
+
+-behaviour(proper_statem).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("escalus/include/escalus.hrl").
+
+-export([test/1, sample/0, prop/1]).
+
+-export([initial_state/0, command/1, precondition/2, postcondition/3,
+		 next_state/3]).
+
+-export([read_config/0,
+         connect_carol/0,
+         connect_geralt/0,
+         send_from_carol/2,
+         send_from_geralt/2,
+         wait_for_msgs_carol/2,
+         wait_for_msgs_geralt/2]).
+
+-export([ct_config_giver/1]).
+
+-record(state, {carol,
+				geralt,
+                msgs_to_carol,
+                msgs_to_geralt}).
+
+test(Config) ->
+    proper:quickcheck(?MODULE:prop(Config)).
+
+sample() ->
+    proper_gen:pick(commands(?MODULE)).
+
+prop(Config) ->
+    spawn_link(?MODULE, ct_config_giver, [Config]),
+	?FORALL(Cmds, commands(?MODULE),
+			?TRAPEXIT(
+			   begin
+                   ct:pal("commands: ~p", [Cmds]),
+				   {History,State,Result} = run_commands(?MODULE, Cmds),
+                   maybe_stop_client(State#state.carol),
+                   maybe_stop_client(State#state.geralt),
+                   escalus_fresh:clean(),
+				   ?WHENFAIL(ct:pal(error, "History: ~p~nState: ~p\nResult: ~p~n",
+									[History,State,Result]),
+							 aggregate(command_names(Cmds), Result =:= ok))
+			   end)).
+
+ct_config_giver(Config) ->
+    register(ct_config_giver, self()),
+    wait_for_request(Config).
+
+wait_for_request(Config) ->
+    receive
+        {give_me_config, Pid} ->
+            Pid ! {ok, Config},
+            wait_for_request(Config)
+    end.
+
+maybe_stop_client(undefined) -> ok;
+maybe_stop_client(Client) ->
+    escalus_client:stop(Client).
+
+initial_state() ->
+	#state{carol = undefined,
+		   geralt = undefined,
+           msgs_to_carol = [],
+           msgs_to_geralt = []}.
+
+command(S) ->
+    Cmds = possible_commands(S),
+    oneof(Cmds).
+
+possible_commands(S) ->
+    Carol = (S#state.carol /= undefined),
+    Geralt = (S#state.geralt /= undefined),
+    Users = Carol andalso Geralt,
+    MsgsToCarol = (S#state.msgs_to_carol /= []),
+    MsgsToGeralt = (S#state.msgs_to_geralt /= []),
+    [{call, ?MODULE, connect_carol, []} || not Carol] ++
+    [{call, ?MODULE, connect_geralt, []} || not Geralt] ++
+    [{call, ?MODULE, send_from_carol, [S#state.carol, S#state.geralt]} || Users] ++
+    [{call, ?MODULE, send_from_geralt, [S#state.geralt, S#state.carol]} || Users] ++
+    [{call, ?MODULE, wait_for_msgs_carol, [S#state.carol, S#state.msgs_to_carol]}
+     || MsgsToCarol] ++
+    [{call, ?MODULE, wait_for_msgs_geralt, [S#state.geralt, S#state.msgs_to_geralt]}
+     || MsgsToGeralt].
+
+
+precondition(_, _) -> true.
+postcondition(_, _, _) -> true.
+
+next_state(S, V, {call, _, connect_carol, []}) ->
+    S#state{carol = V};
+next_state(S, V, {call, _, connect_geralt, []}) ->
+    S#state{geralt = V};
+next_state(#state{msgs_to_geralt = Msgs} = S, V, {call, _, send_from_carol, _}) ->
+    % ct:pal("msgs to geralt: ~p", [[V | Msgs]]),
+    S#state{msgs_to_geralt = [V | Msgs]};
+next_state(#state{msgs_to_carol = Msgs} = S, V, {call, _, send_from_geralt, _}) ->
+    % ct:pal("msgs to carol: ~p", [[V | Msgs]]),
+    S#state{msgs_to_carol = [V | Msgs]};
+next_state(S, _, {call, _, wait_for_msgs_carol, _}) ->
+    % ct:pal("msgs to carol2: ~p", [S#state.msgs_to_carol]),
+    S#state{msgs_to_carol = []};
+next_state(S, _, {call, _, wait_for_msgs_geralt, _}) ->
+    % ct:pal("msgs to geralt2: ~p", [S#state.msgs_to_geralt]),
+    S#state{msgs_to_geralt = []};
+next_state(S, _, _) ->
+    S.
+
+read_config() ->
+    ct_config_giver ! {give_me_config, self()},
+    receive
+        {ok, Config} ->
+            Config
+    after 100 ->
+          error
+    end.
+
+connect_carol() ->
+    Spec = given_fresh_spec(read_config(), carol),
+    connect_user([{keepalive, true} | Spec]).
+
+connect_geralt() ->
+    Spec = given_fresh_spec(read_config(), geralt),
+    connect_user(Spec).
+
+given_fresh_spec(Config, User) ->
+    NewConfig = escalus_fresh:create_users(Config, [{User, 1}]),
+    escalus_users:get_userspec(NewConfig, User).
+
+connect_user(Spec) ->
+    Res = base64:encode(crypto:rand_bytes(4)),
+    {ok, Conn, Props, _} = escalus_connection:start([{resource, Res} | Spec]),
+    JID = make_jid(Props),
+    escalus:send(Conn, escalus_stanza:presence(<<"available">>)),
+    escalus:wait_for_stanza(Conn),
+    Conn#client{jid = JID}.
+
+make_jid(Proplist) ->
+    {username, U} = lists:keyfind(username, 1, Proplist),
+    {server, S} = lists:keyfind(server, 1, Proplist),
+    {resource, R} = lists:keyfind(resource, 1, Proplist),
+    <<U/binary, "@", S/binary, "/", R/binary>>.
+
+send_from_carol(Carol, Geralt) ->
+    Msg = gen_msg(),
+    escalus:send(Carol, escalus_stanza:chat_to(Geralt, Msg)),
+    Msg.
+
+send_from_geralt(Geralt, Carol) ->
+    Msg = gen_msg(),
+    escalus:send(Geralt, escalus_stanza:chat_to(Carol, Msg)),
+    Msg.
+
+gen_msg() ->
+    Msg = base64:encode(crypto:rand_bytes(15)),
+    Msg.
+
+wait_for_msgs_carol(Carol, Msgs) ->
+    wait_for_msgs(Carol, lists:reverse(Msgs)).
+
+wait_for_msgs_geralt(Geralt, Msgs) ->
+    wait_for_msgs(Geralt, lists:reverse(Msgs)).
+
+wait_for_msgs(_Client, []) ->
+    ok;
+wait_for_msgs(Client, [Msg | Rest]) ->
+    escalus:assert(is_chat_message, [Msg],
+                   escalus_client:wait_for_stanza(Client)),
+    wait_for_msgs(Client, Rest).
+

--- a/test/ejabberd_tests/tests/bosh_interleave_reqs.erl
+++ b/test/ejabberd_tests/tests/bosh_interleave_reqs.erl
@@ -11,7 +11,7 @@
 -export([test/1, sample/0, prop/1]).
 
 -export([initial_state/1, command/1, precondition/2, postcondition/3,
-		 next_state/3]).
+         next_state/3]).
 
 -export([read_config/1,
          connect_carol/1,
@@ -24,7 +24,7 @@
 -export([ct_config_giver/1]).
 
 -record(state, {carol,
-				geralt,
+                geralt,
                 msgs_to_carol,
                 msgs_to_geralt,
                 config_pid}).
@@ -37,16 +37,16 @@ sample() ->
 
 prop(Config) ->
     Pid = spawn_link(?MODULE, ct_config_giver, [Config]),
-	?FORALL(Cmds, commands(?MODULE, initial_state(Pid)),
-			?TRAPEXIT(
-			   begin
-				   {History,State,Result} = run_commands(?MODULE, Cmds),
+    ?FORALL(Cmds, commands(?MODULE, initial_state(Pid)),
+            ?TRAPEXIT(
+               begin
+                   {History, State, Result} = run_commands(?MODULE, Cmds),
                    maybe_stop_client(State#state.carol),
                    maybe_stop_client(State#state.geralt),
-				   ?WHENFAIL(ct:pal(error, "History: ~p~nState: ~p\nResult: ~p~n",
-									[History,State,Result]),
-							 aggregate(command_names(Cmds), Result =:= ok))
-			   end)).
+                   ?WHENFAIL(ct:log(error, "History: ~p~nState: ~p\nResult: ~p~n",
+                                    [History, State, Result]),
+                             aggregate(command_names(Cmds), Result =:= ok))
+               end)).
 
 ct_config_giver(Config) ->
     receive
@@ -60,8 +60,8 @@ maybe_stop_client(Client) ->
     escalus_client:stop(Client).
 
 initial_state(Pid) ->
-	#state{carol = undefined,
-		   geralt = undefined,
+    #state{carol = undefined,
+           geralt = undefined,
            msgs_to_carol = [],
            msgs_to_geralt = [],
            config_pid = Pid}.
@@ -95,16 +95,12 @@ next_state(S, V, {call, _, connect_carol, [_]}) ->
 next_state(S, V, {call, _, connect_geralt, [_]}) ->
     S#state{geralt = V};
 next_state(#state{msgs_to_geralt = Msgs} = S, V, {call, _, send_from_carol, _}) ->
-    % ct:pal("msgs to geralt: ~p", [[V | Msgs]]),
     S#state{msgs_to_geralt = [V | Msgs]};
 next_state(#state{msgs_to_carol = Msgs} = S, V, {call, _, send_from_geralt, _}) ->
-    % ct:pal("msgs to carol: ~p", [[V | Msgs]]),
     S#state{msgs_to_carol = [V | Msgs]};
 next_state(S, _, {call, _, wait_for_msgs_carol, _}) ->
-    % ct:pal("msgs to carol2: ~p", [S#state.msgs_to_carol]),
     S#state{msgs_to_carol = []};
 next_state(S, _, {call, _, wait_for_msgs_geralt, _}) ->
-    % ct:pal("msgs to geralt2: ~p", [S#state.msgs_to_geralt]),
     S#state{msgs_to_geralt = []};
 next_state(S, _, _) ->
     S.
@@ -115,7 +111,7 @@ read_config(Pid) ->
         {ok, Config} ->
             Config
     after 100 ->
-          error
+              error
     end.
 
 connect_carol(Pid) ->
@@ -168,7 +164,6 @@ wait_for_msgs_carol(Carol, Msgs) ->
     RMsgs = [exml_query:path(E, [{element, <<"body">>}, cdata])
              || E <- Stanzas],
     SortedMsgs = lists:sort([Msg || {_, Msg} <- Msgs]),
-    ct:pal("waiting for: ~p~nreceived: ~p", [SortedMsgs, RMsgs]),
     SortedMsgs = lists:sort(RMsgs),
     ok.
 


### PR DESCRIPTION
Proposed changes include:
* fix for wrong deferred `rid` processing when there was a response delivered to the hendler which send bigger `rid` then expected
* fix for missing `xmlns:stream` attr in `<body>` when stream features arrives in their own message
* PopEr tests for message sending/receiving over BOSH

Detailed description of the deferred rids processing.

Assume expected `rid` has value `X`
This bug happens when MongooseIM processes a request with `rid` `X+1` before `X` **and** there is a pending response to the client. In this situation Mongoose puts the request into deferred list which is expected. Also it sends the pending response to the client using this deferred connection which  results in adding the `X+1` `rid` to cached responses list (used to track retransmissions). Later when the deferred `rid` `X+1` is process because the prev arrived, MongooseIM treats it as a retransmission (because the `rid` `X+1` is on the cached responses list). Because of that the main `rid` is not updated correctly and expects `X+1` whereas it should expect now `X+2`. As a result the end the session is terminated upon receiving `rid` `X+3`