### PR TITLE
Ditch support for R16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ branches:
                 - /\d+\.\d+\.\d+(\-[a-z,0-9])*/
 
 otp_release:
-        - 17.5
+        - 18.3
 env:
         - PRESET=internal_redis DB=mnesia REL_CONFIG=with-redis
         - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all
@@ -59,9 +59,7 @@ env:
 
 matrix:
     include:
-        - otp_release: R16B03
-          env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none
-        - otp_release: 18.1
+        - otp_release: 17.5
           env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ How to build
     *   GNU Make,
     *   GCC,
     *   Libexpat 1.95 or higher,
-    *   Erlang/OTP R16B03-1 or higher,
-    *   Reltool 0.6.4.1 or higher,
+    *   Erlang/OTP 17.5 or higher,
+    *   Reltool 0.6.6 or higher,
     *   OpenSSL 0.9.8 or higher, for STARTTLS, SASL and SSL encryption,
     *   Zlib 1.2.3 or higher for Stream Compression support (XEP-0138). Optional.
 

--- a/apps/ejabberd/rebar.config
+++ b/apps/ejabberd/rebar.config
@@ -1,8 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]},
             {d, xml_nif},
-            {parse_transform, lager_transform},
-            {platform_define, "^R1[6]", only_builtin_types}]}. %% Ref: OTP commit b66e75c
+            {parse_transform, lager_transform}]}.
 
 {require_otp_vsn, "R?1[678]"}.
 

--- a/apps/ejabberd/rebar.config
+++ b/apps/ejabberd/rebar.config
@@ -2,7 +2,6 @@
             {i, ["include"]},
             {d, xml_nif},
             {parse_transform, lager_transform},
-            {platform_define, "^R1[6]", latin1_characters},
             {platform_define, "^R1[6]", only_builtin_types}]}. %% Ref: OTP commit b66e75c
 
 {require_otp_vsn, "R?1[678]"}.

--- a/apps/ejabberd/src/ejabberd.erl
+++ b/apps/ejabberd/src/ejabberd.erl
@@ -76,18 +76,6 @@
               literal_jid/0
              ]).
 
--ifdef(only_builtin_types).
--type dict_t() :: dict().
--type queue_t() :: queue().
--type set_t() :: set().
--else.
--type dict_t() :: dict:dict().
--type queue_t() :: queue:queue().
--type set_t() :: sets:set().
--endif.
-
--export_type([dict_t/0, queue_t/0, set_t/0]).
-
 start() ->
     application:ensure_all_started(ejabberd).
 

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -267,13 +267,8 @@ normalize_hosts([Host|Hosts], PrepHosts) ->
             normalize_hosts(Hosts, [PrepHost|PrepHosts])
     end.
 
--ifdef(latin1_characters).
-host_to_binary(Host) ->
-    list_to_binary(Host).
--else.
 host_to_binary(Host) ->
     unicode:characters_to_binary(Host).
--endif.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Errors reading the config file

--- a/apps/ejabberd/src/ejabberd_sm_mnesia.erl
+++ b/apps/ejabberd/src/ejabberd_sm_mnesia.erl
@@ -119,7 +119,7 @@ unique_count() ->
     compute_unique(mnesia:dirty_first(session),
                    sets:new()).
 
--spec compute_unique(term(), ejabberd:set_t()) -> integer().
+-spec compute_unique(term(), set:set()) -> integer().
 compute_unique('$end_of_table', Set) ->
     sets:size(Set);
 compute_unique(Key, Set) ->

--- a/apps/ejabberd/src/eldap.erl
+++ b/apps/ejabberd/src/eldap.erl
@@ -153,8 +153,8 @@
          passwd = <<"">>         :: binary(),
          id = 0                  :: non_neg_integer(),
          bind_timer = make_ref() :: reference(),
-	     dict = dict:new()       :: ejabberd:dict_t(),
-         req_q = queue:new()     :: ejabberd:queue_t()}).
+	     dict = dict:new()       :: dict:dict(),
+         req_q = queue:new()     :: queue:queue()}).
 
 -type eldap() :: #eldap{}.
 -type eldap_config() :: #eldap_config{}.

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -2478,7 +2478,7 @@ lqueue_in(Item, #lqueue{queue = Q1, len = Len, max = Max}) ->
     end.
 
 
--spec lqueue_cut(ejabberd:queue_t(), non_neg_integer()) -> ejabberd:queue_t().
+-spec lqueue_cut(queue:queue(), non_neg_integer()) -> ejabberd:queue_t().
 lqueue_cut(Q, 0) ->
     Q;
 lqueue_cut(Q, N) ->

--- a/apps/ejabberd/src/shaper_srv.erl
+++ b/apps/ejabberd/src/shaper_srv.erl
@@ -28,8 +28,8 @@
         max_delay :: non_neg_integer(),
         %% How many seconds to store each shaper
         ttl :: non_neg_integer(),
-        shapers :: ejabberd:dict_t(),
-        a_times :: ejabberd:dict_t()
+        shapers :: dict:dict(),
+        a_times :: dict:dict()
     }).
 -type state() :: #state{}.
 

--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -1,4 +1,4 @@
-## Installation 
+## Installation
 
 ### Getting started with MongooseIM on Mac OS X
 
@@ -8,11 +8,11 @@ This short guide will show you how to compile MongooseIM from source code or ins
 
 ##### Prerequisites for source code installation
 
-MongooseIM is supported on Mac OS X 10.6.8 and later. Before you can compile and run MongooseIM, you also need the following to be installed on your system: 
+MongooseIM is supported on Mac OS X 10.6.8 and later. Before you can compile and run MongooseIM, you also need the following to be installed on your system:
 
 * GNU Make and GCC (the GNU Compiler Collection). To ensure that these are installed, you can install the Command Line Tools for Xcode, available via Xcode or from the Apple Developer website.
 * Git – `brew install git`
-* Erlang/OTP R16B03-1 or higher – `brew install erlang`
+* Erlang/OTP 17.5 or higher – `brew install erlang`
 
 An easy way to install some of the packages is by using a package manager, such as [Homebrew](http://brew.sh) – the Homebrew commands are provided here.
 
@@ -44,10 +44,10 @@ Go to the [donwloads](https://www.erlang-solutions.com/downloads/) page of Erlan
 
 The default XMPP domain served by MongooseIM right after installation is `localhost`. Users on a different computer can register using the server’s IP address.
 
-You can register a user with the `mongooseimctl` utility:  
+You can register a user with the `mongooseimctl` utility:
 `mongooseimctl register user domain password`
 
-For example:  
+For example:
 `mongooseimctl register user1 localhost GJ9TuHq8`
 
 
@@ -71,7 +71,7 @@ Registered users wishing to add an existing account to Adium should enter the Mo
 
 To use your system’s domain name instead of localhost, edit the following MongooseIM configuration file: `$REPO/rel/mongooseim/etc/ejabberd.cfg` (where `$REPO` is the repository root). Find the line that contains the following: `{hosts ["localhost"] }.` Replace localhost with your domain name, for example: `{hosts, ["example.org"] }.` Save the configuration file and restart the MongooseIM server. A user’s Jabber ID will then use the domain instead of localhost, for example: `user1@example.org`
 
-You can also configure multiple domains for one server:  
+You can also configure multiple domains for one server:
 `{hosts, ["example1.org", "example2.org"] }.`
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]}]}.
 
-{require_otp_vsn, "R?1[678]"}.
+{require_otp_vsn, "1[78]"}.
 
 {sub_dirs, [
     "apps/ejabberd",

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]}]}.
 
-{require_otp_vsn, "R?1[45678]"}.
+{require_otp_vsn, "1[78]"}.
 
 {deps, [
         {amoc, ".*", {git, "git://github.com/esl/amoc.git", "9acfdc4b57cd37e8030831a4493847d2e01d1ec9"}},


### PR DESCRIPTION
This PR addresses #785

Proposed changes include:
* removed workaround for utf8 characters in host name
* removed workaround for prefixed types like `dict:dict()`

