### PR TITLE
Fix count and index types in rsm_out

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -345,8 +345,8 @@
                       to_id     :: non_neg_integer() | undefined
                      }).
 
--record(rsm_out, {count :: pos_integer(),
-                  index :: pos_integer(),
+-record(rsm_out, {count :: non_neg_integer(),
+                  index :: non_neg_integer(),
                   first :: binary(),
                   last :: binary()
                  }).


### PR DESCRIPTION
Both `index` and `count` in `rsm_out` can, by my reading of the XEP-0059, have 0 as a value. The existing `pos_integer()` type, however, causes dialyzer warnings for this case.

