### PR TITLE
Blocking Commands white spaces fix

### DIFF
--- a/apps/ejabberd/src/mod_blocking.erl
+++ b/apps/ejabberd/src/mod_blocking.erl
@@ -61,9 +61,9 @@ process_iq_get(Val, _, _, _, _) ->
 process_iq_set(_, From, _To, #iq{xmlns = ?NS_BLOCKING, sub_el = SubEl}) ->
     %% collect needed data
     #jid{luser = LUser, lserver = LServer} = From,
-    #xmlel{children = Els, name = BType} = SubEl,
+    #xmlel{name = BType} = SubEl,
     Type = binary_to_existing_atom(BType, latin1),
-    Usrs = [xml:get_tag_attr_s(<<"jid">>, I) || I <- Els],
+    Usrs = exml_query:paths(SubEl, [{element, <<"item">>}, {attr, <<"jid">>}]),
     CurrList = case ?BACKEND:get_privacy_list(LUser, LServer, <<"blocking">>) of
                   {ok, List} ->
                       List;


### PR DESCRIPTION
The problem occured when sending [IQ block request](https://xmpp.org/extensions/xep-0191.html#block) containing some additional white characters like '\n' or indentation inside the `<block>` tag. It was causing some `function_clase` error on the server side which resulted with `not-implemented` response to the client

Proposed changes include:
* test for IQ block set request containing '\n` character in it
* fixed the issue in `mod_blocking`

