### PR TITLE
Missing "value" tag while retrieving form fields

### DIFF
--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -643,7 +643,8 @@ form_type_field(MamNs) when is_binary(MamNs) ->
     #xmlel{name = <<"field">>,
            attrs = [{<<"type">>, <<"hidden">>},
                     {<<"var">>, <<"FORM_TYPE">>}],
-           children = [#xmlcdata{content = MamNs}]}.
+           children = [#xmlel{name = <<"value">>,
+                              children = [#xmlcdata{content = MamNs}]}]}.
 
 form_field(Type, VarName) ->
     #xmlel{name = <<"field">>,

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -44,6 +44,7 @@
          prefs_set_request/1,
          retrive_form_fields/1,
          prefs_set_cdata_request/1,
+         query_get_request/1,
          pagination_first5/1,
          pagination_last5/1,
          pagination_before10/1,
@@ -350,6 +351,7 @@ rsm_cases() ->
 prefs_cases() ->
     [prefs_set_request,
      prefs_set_cdata_request,
+     query_get_request,
      run_prefs_cases,
      run_set_and_get_prefs_cases].
 
@@ -2037,6 +2039,21 @@ prefs_set_request(Config) ->
         end,
     escalus:story(Config, [{alice, 1}], F).
 
+query_get_request(Config) ->
+    F = fun(Alice) ->
+        QueryXmlns = mam_ns_binary_v04(),
+        escalus:send(Alice, stanza_query_get_request(QueryXmlns)),
+        ReplyFields = escalus:wait_for_stanza(Alice),
+        ResponseXmlns = exml_query:path(ReplyFields,
+            [{element, <<"query">>},
+             {element, <<"x">>},
+             {element, <<"field">>},
+             {element, <<"value">>},
+              cdata]),
+        ?assert_equal(QueryXmlns, ResponseXmlns)
+        end,
+    escalus:story(Config, [{alice, 1}], F).
+
 %% Test reproducing https://github.com/esl/MongooseIM/issues/263
 %% The idea is this: in a "perfect" world jid elements are put together
 %% without whitespaces. In the real world it is not true.
@@ -2379,6 +2396,12 @@ stanza_prefs_get_request(Namespace) ->
     escalus_stanza:iq(<<"get">>, [#xmlel{
        name = <<"prefs">>,
        attrs = [{<<"xmlns">>, Namespace}]
+    }]).
+
+stanza_query_get_request(Namespace) ->
+    escalus_stanza:iq(<<"get">>, [#xmlel{
+        name = <<"query">>,
+        attrs = [{<<"xmlns">>, Namespace}]
     }]).
 
 %% Allows to cdata to be put as it is


### PR DESCRIPTION
Due to [XEP-0313 section Retrieving form fields](http://xmpp.org/extensions/xep-0313.html#query-form) in order to get form fields I sent IQ:

```xml
<iq id='z6WRz-20' type='get'>
<query xmlns='urn:xmpp:mam:1' queryid='3bd9571e-6fe6-4341-8589-a3f5d5371404'>
</query>
</iq>
```

and got Response:

``` xml
<iq from='ludwik.bukowski@erlang-solutions.com' to='ludwik.bukowski@erlang-solutions.com/9bb69f6dacb33248' id='z6WRz-20' type='result'>
<query xmlns='urn:xmpp:mam:1'>
<x xmlns='jabber:x:data' type='form'>
<field type='hidden' var='FORM_TYPE'>urn:xmpp:mam:1</field>
<field type='jid-single' var='with'/>
<field type='text-single' var='start'/>
<field type='text-single' var='end'/>
</x>
</query>
</iq>
```

At the first field, the *urn:xmpp:mam:1* should be between `<value>`
tags.

Proposed changes include:
* test for retrieving field form in `mam_SUITE`
* fixed the issue in `mod_mam_utils`

