### PR TITLE
fix typo in `listener-modules.md` [skip ci]

### DIFF
--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -86,7 +86,7 @@ As for now, all WebSockets connections with the `Sec-WebSocket-Protocol: xmpp`
 header, will go through the mod_websockets connection.
 This is the MongooseIM's regular websocket connection handler.
 
-## Server-to-server (S2S): `ejabberd_s2s_in
+## Server-to-server (S2S): `ejabberd_s2s_in`
 
 Handles incoming server-to-server (S2S) connections (federation). Relies on `ejabberd_listener` and `ejabberd_receiver` just like `ejabberd_c2s`.
 


### PR DESCRIPTION
Fixed typo in listener-modules.md

