### PR TITLE
Add unavailable presence after blocking contact

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2420,11 +2420,16 @@ flush_messages(N, Acc) ->
 %%%----------------------------------------------------------------------
 
 maybe_update_presence(StateData = #state{jid = JID, pres_f = Froms}, NewList) ->
+    % Our own jid is added to pres_f, even though we're not a "contact", so for
+    % the purposes of this check we don't want it:
+    SelfJID = jid:to_lower(jid:to_bare(JID)),
+    FromsExceptSelf = ?SETS:del_element(SelfJID, Froms),
+
     ?SETS:fold(
       fun(T, _) ->
               send_unavail_if_newly_blocked(StateData, jid:make(T), NewList),
               ok
-      end, ok, Froms).
+      end, ok, FromsExceptSelf).
 
 send_unavail_if_newly_blocked(StateData = #state{jid = JID},
                               ContactJID, NewList) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2419,16 +2419,12 @@ flush_messages(N, Acc) ->
 %%% XEP-0016
 %%%----------------------------------------------------------------------
 
-maybe_update_presence(StateData = #state{jid = JID}, NewList) ->
-    {Froms, _Tos, _Pending} = ejabberd_hooks:run_fold(
-                                 roster_get_subscription_lists,
-                                 JID#jid.lserver, {[], [], []},
-                                 [JID#jid.luser, JID#jid.lserver]),
-    lists:foreach(
-      fun(T) ->
-              send_unavail_if_newly_blocked(StateData, jid:make(T), NewList)
-      end, Froms),
-    ok.
+maybe_update_presence(StateData = #state{jid = JID, pres_f = Froms}, NewList) ->
+    ?SETS:fold(
+      fun(T, _) ->
+              send_unavail_if_newly_blocked(StateData, jid:make(T), NewList),
+              ok
+      end, ok, Froms).
 
 send_unavail_if_newly_blocked(StateData = #state{jid = JID},
                               ContactJID, NewList) ->

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -70,7 +70,8 @@ blocking_test_cases() ->
      block_jid_all,
      block_jid_message_but_not_presence,
      newly_blocked_presense_jid_by_new_list,
-     newly_blocked_presense_jid_by_list_change
+     newly_blocked_presense_jid_by_list_change,
+     newly_blocked_presence_not_notify_self
     ].
 
 allowing_test_cases() ->
@@ -716,7 +717,7 @@ newly_blocked_presense_jid_by_new_list(Config) ->
         add_sample_contact(Alice, Bob, [<<"My Friends">>], <<"Bobbie">>),
         subscribe(Bob, Alice),
 
-        % Alice gets notification that a roster contact is now subscribed
+        %% Alice gets notification that a roster contact is now subscribed
         escalus:assert(is_roster_set, escalus_client:wait_for_stanza(Alice)),
 
         %% Bob should receive presence in
@@ -746,10 +747,10 @@ newly_blocked_presense_jid_by_list_change(Config) ->
         add_sample_contact(Alice, Bob, [<<"My Friends">>], <<"Bobbie">>),
         subscribe(Bob, Alice),
 
-        % Alice gets notification that a roster contact is now subscribed
+        %% Alice gets notification that a roster contact is now subscribed
         escalus:assert(is_roster_set, escalus_client:wait_for_stanza(Alice)),
 
-        % Alice sets up an initially empty privacy list
+        %% Alice sets up an initially empty privacy list
         privacy_helper:set_and_activate(Alice, <<"noop_list">>),
 
         %% Bob should receive presence in
@@ -770,6 +771,19 @@ newly_blocked_presense_jid_by_list_change(Config) ->
         Received2 = escalus_client:wait_for_stanza(Bob),
         escalus:assert(is_presence_with_type, [<<"unavailable">>], Received2),
         escalus_assert:is_stanza_from(Alice, Received2)
+
+        end).
+
+newly_blocked_presence_not_notify_self(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        %% Alice sets up an initially empty privacy list
+        privacy_helper:set_and_activate(Alice,
+                                        <<"deny_not_both_presence_out">>),
+
+        %% Alice should not receive an 'unavailable' because she's not a
+        %% contact of herself.
+        timer:sleep(?SLEEP_TIME),
+        escalus_assert:has_no_stanzas(Alice)
 
         end).
 

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -778,28 +778,29 @@ add_sample_contact(Who, Whom, Groups, Nick) ->
     escalus:assert(is_iq_result, escalus:wait_for_stanza(Who)).
 
 subscribe(Who, Whom) ->
+    % 'Who' sends a subscribe request to 'Whom'
     escalus:send(Who, escalus_stanza:presence_direct(Whom, <<"subscribe">>)),
     PushReq = escalus:wait_for_stanza(Who),
     escalus:assert(is_roster_set, PushReq),
     escalus:send(Who, escalus_stanza:iq_result(PushReq)),
 
-    %% Bob receives subscription reqest
+    %% 'Whom' receives subscription reqest
     Received = escalus:wait_for_stanza(Whom),
     escalus:assert(is_presence_with_type, [<<"subscribe">>], Received),
 
-    %% Bob adds new contact to his roster
+    %% 'Whom' adds new contact to their roster
     escalus:send(Whom, escalus_stanza:roster_add_contact(Who,
                                                         [<<"enemies">>],
                                                         <<"Alice">>)),
-    PushReqB = escalus:wait_for_stanza(Whom),
-    escalus:assert(is_roster_set, PushReqB),
-    escalus:send(Whom, escalus_stanza:iq_result(PushReqB)),
+    PushReq2 = escalus:wait_for_stanza(Whom),
+    escalus:assert(is_roster_set, PushReq2),
+    escalus:send(Whom, escalus_stanza:iq_result(PushReq2)),
     escalus:assert(is_iq_result, escalus:wait_for_stanza(Whom)),
 
-    %% Bob sends subscribed presence
+    %% 'Whom' sends subscribed presence
     escalus:send(Whom, escalus_stanza:presence_direct(Who, <<"subscribed">>)),
 
-    %% Alice receives subscribed
+    %% 'Who' receives subscribed
     Stanzas = escalus:wait_for_stanzas(Who, 2),
 
     check_subscription_stanzas(Stanzas, <<"subscribed">>),

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -9,7 +9,7 @@
 
 -export([set_and_activate/2,
          set_list/2,
-         modify_list/3,
+         set_list/3,
          send_set_list/2,
          activate_list/2,
          set_default_list/2,
@@ -42,7 +42,7 @@ set_list(Client, ListName) ->
     verify_set_list_response(Client),
     verify_list(Client, ListName, Stanza).
 
-modify_list(Client, ListName, NewItems) ->
+set_list(Client, ListName, NewItems) ->
     PrivacyList = escalus_stanza:privacy_list(ListName, NewItems),
     Stanza = escalus_stanza:privacy_set_list(PrivacyList),
     escalus:send(Client, Stanza),

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -152,7 +152,11 @@ list_content(<<"deny_all_message_but_subscription_both">>) -> [
         escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>, <<"both">>, [<<"message">>]),
         escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, [<<"message">>])
     ];
-
+list_content(<<"deny_not_both_presence_out">>) -> [
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"from">>, [<<"presence-out">>]),
+        escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, <<"subscription">>, <<"to">>, [<<"presence-out">>]),
+        escalus_stanza:privacy_list_item(<<"3">>, <<"deny">>, <<"subscription">>, <<"none">>, [<<"presence-out">>])
+    ];
 list_content(<<"deny_bob_presence_in">>) -> [
         escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, bob, [<<"presence-in">>])
     ];

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -117,6 +117,8 @@ is_presence_error(Stanza) ->
 privacy_list(Name) ->
     escalus_stanza:privacy_list(Name, list_content(Name)).
 
+% Geralt is not used by the privacy tests, but lists have to have
+% at least one element so we use him for a no-op.
 list_content(<<"noop_list">>) -> [
         escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, geralt, [])
     ];

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -9,6 +9,7 @@
 
 -export([set_and_activate/2,
          set_list/2,
+         modify_list/3,
          send_set_list/2,
          activate_list/2,
          set_default_list/2,
@@ -38,8 +39,21 @@ send_set_list(Client, ListName) ->
 %% Sets the list on server.
 set_list(Client, ListName) ->
     Stanza = send_set_list(Client, ListName),
+    verify_set_list_response(Client),
+    verify_list(Client, ListName, Stanza).
+
+modify_list(Client, ListName, NewItems) ->
+    PrivacyList = escalus_stanza:privacy_list(ListName, NewItems),
+    Stanza = escalus_stanza:privacy_set_list(PrivacyList),
+    escalus:send(Client, Stanza),
+    verify_set_list_response(Client),
+    verify_list(Client, ListName, Stanza).
+
+verify_set_list_response(Client) ->
     Responses = escalus:wait_for_stanzas(Client, 2),
-    escalus:assert_many([is_iq_result, is_privacy_set], Responses),
+    escalus:assert_many([is_iq_result, is_privacy_set], Responses).
+
+verify_list(Client, ListName, Stanza) ->
     GetStanza = escalus_stanza:privacy_get_lists([ListName]),
     escalus:send(Client, GetStanza),
     GetResultStanza = escalus:wait_for_stanza(Client),
@@ -103,6 +117,9 @@ is_presence_error(Stanza) ->
 privacy_list(Name) ->
     escalus_stanza:privacy_list(Name, list_content(Name)).
 
+list_content(<<"noop_list">>) -> [
+        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, geralt, [])
+    ];
 list_content(<<"deny_bob">>) -> [
         escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, bob, [])
     ];


### PR DESCRIPTION
XEP-0016 section 2.11 contains the following requirement:

> When a user blocks outbound presence to a contact, the user's server MUST send unavailable presence information to the contact (but only if the contact is allowed to receive presence notifications from the user in accordance with the rules defined in RFC 6121).

However for this case no unavailable message was being sent. This patch adds this behaviour, sending an "unavailable" from A to B when all the following conditions are met:
* B is subscribed to receive presence information from A (and is therefore a contact)
* A has changed their active privacy list or modified their currently active list
* The change means that where presence notifications were previously sent from A to B, they are now blocked

This covers the unambiguous case described in the XEP. It's not clear to me whether an 'unavailable' is also required to be sent when some second-order condition changes the blocking state. For example, if A has an existing privacy list that blocks all presence information to group X, and A adds B to group X, should that trigger an unavailable message? XE-0016 isn't really explcit on the matter. For now I've left those other cases out.