### PR TITLE
Fix #904 - broken MUC light config update due to invalid sanitisation

### DIFF
--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -344,7 +344,7 @@ create_room(From, FromUS, To, #create{ raw_config = RawConfig } = Create0, OrigP
           process_create_aff_users_if_valid(To#jid.lserver, FromUS, InitialAffUsers)} of
         {{ok, Config0}, {ok, FinalAffUsers}} when length(FinalAffUsers) =< MaxOccupants ->
             Version = mod_muc_light_utils:bin_ts(),
-            case ?BACKEND:create_room(RoomUS, lists:sort(Config0), FinalAffUsers, Version) of
+            case ?BACKEND:create_room(RoomUS, Config0, FinalAffUsers, Version) of
                 {ok, FinalRoomUS} ->
                     Create = Create0#create{ version = Version, aff_users = FinalAffUsers },
                     ?CODEC:encode({set, Create, RoomU == <<>>}, From,

--- a/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
@@ -270,6 +270,7 @@ create_table(Name, TabDef) ->
 
 %% ------------------------ General room management ------------------------
 
+%% Expects config to have unique fields!
 -spec create_room_transaction(RoomUS :: ejabberd:simple_bare_jid(),
                               Config :: config(), AffUsers :: aff_users(),
                               Version :: binary()) ->
@@ -288,7 +289,7 @@ create_room_transaction(RoomUS, Config, AffUsers, Version) ->
         [] ->
             RoomRecord = #?ROOM_TAB{
                              room = RoomUS,
-                             config = Config,
+                             config = lists:sort(Config),
                              aff_users = AffUsers,
                              version = Version
                             },
@@ -329,6 +330,7 @@ remove_user_transaction(UserUS, Version) ->
 
 %% ------------------------ Configuration manipulation ------------------------
 
+%% Expects config changes to have unique fields!
 -spec set_config_transaction(RoomUS :: ejabberd:simple_bare_jid(),
                              ConfigChanges :: config(),
                              Version :: binary()) ->
@@ -338,7 +340,7 @@ set_config_transaction(RoomUS, ConfigChanges, Version) ->
         [] ->
             {error, not_exists};
         [#?ROOM_TAB{ config = Config } = Rec] ->
-            NewConfig = lists:ukeymerge(1, ConfigChanges, Config),
+            NewConfig = lists:ukeymerge(1, lists:sort(ConfigChanges), Config),
             mnesia:write(Rec#?ROOM_TAB{ config = NewConfig, version = Version }),
             {ok, Rec#?ROOM_TAB.version}
     end.

--- a/apps/ejabberd/src/mod_muc_light_utils.erl
+++ b/apps/ejabberd/src/mod_muc_light_utils.erl
@@ -51,6 +51,7 @@
 %% API
 %%====================================================================
 
+%% Guarantees that config will have unique fields
 -spec process_raw_config(RawConfig :: raw_config(), Config :: config()) ->
     {ok, config()} | validation_error().
 process_raw_config([], Config) ->


### PR DESCRIPTION
This PR addresses #904 

* Config changes in MUC Light are now properly applied.
* Separation of responsibilities: main MUC Light code ensures config fields uniqueness after parsing the requests, the backend ensures the order of fields.