### PR TITLE
Customisable MUC Light room config schemas

### DIFF
--- a/apps/ejabberd/include/mod_muc_light.hrl
+++ b/apps/ejabberd/include/mod_muc_light.hrl
@@ -20,8 +20,14 @@
 -define(DEFAULT_ROOMS_IN_ROSTERS, false).
 -define(DEFAULT_HOST, <<"muclight.@HOST@">>).
 
+-type schema_value_type() :: binary | integer | float.
+-type schema_item() :: {FormFieldName :: binary(), OptionName :: atom(),
+                        ValueType :: schema_value_type()}.
+-type config_schema() :: [schema_item()].
+
 -type config() :: [{Key :: atom(), Value :: term()}].
 -type raw_config() :: [{Key :: binary(), Value :: binary()}].
+
 -type aff() :: owner | member | none.
 -type aff_user() :: {ejabberd:simple_bare_jid(), aff()}.
 -type aff_users() :: [aff_user()].

--- a/apps/ejabberd/include/mod_muc_light.hrl
+++ b/apps/ejabberd/include/mod_muc_light.hrl
@@ -25,7 +25,8 @@
                         ValueType :: schema_value_type()}.
 -type config_schema() :: [schema_item()].
 
--type config() :: [{Key :: atom(), Value :: term()}].
+-type config_item() :: {Key :: atom(), Value :: term()}.
+-type config() :: [config_item()].
 -type raw_config() :: [{Key :: binary(), Value :: binary()}].
 
 -type aff() :: owner | member | none.

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -30,7 +30,7 @@
 %%% Allowed `config_schema` list items (may be mixed):
 %%% * Just field name: "field" - will be expanded to "field" of type 'binary'
 %%% * Field name and type: {"field", integer}
-%%% * Field binary name, atom and the type: {"field", field, float} - useful only for debugging
+%%% * Field name, atom and the type: {"field", field, float} - useful only for debugging
 %%%                 or unusual applications
 %%% Sample valid list: `["roomname", {"subject", binary}, {"priority", priority, integer}]`
 %%%

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -17,9 +17,15 @@
 %%% * rooms_per_page (10) - Maximal room count per result page in room disco
 %%% * rooms_in_rosters (false) - If enabled, rooms that user occupies will be included in
 %%%                              user's roster
-%%% * config_schema (undefined) - Custom list of configuration options for a room;
+%%% * config_schema (["roomname", "subject"]) - Custom list of configuration options for a room;
 %%%                               WARNING! Lack of `roomname` field will cause room names in
-%%%                               Disco results and Roster items be set to empty string.
+%%%                               Disco results and Roster items be set to room username.
+%%% * default_config ([{"roomname, "Untitled"}, {"subject", ""}]) -
+%%%                                Custom default room configuration; must be a subset of
+%%%                                config schema. It's a list of KV tuples with string keys
+%%%                                and values of appriopriate type. String values will be
+%%%                                converted to binary automatically.
+%%%        Example: [{"roomname", "The room"}, {"subject", "Chit-chat"}, {"security", 10}]
 %%%
 %%% Allowed `config_schema` list items (may be mixed):
 %%% * Just field name: "field" - will be expanded to "field" of type 'binary'
@@ -41,7 +47,8 @@
 -behaviour(gen_mod).
 
 %% API
--export([config_schema/1, default_config/0]).
+-export([standard_config_schema/0, standard_default_config/0]).
+-export([config_schema/1, default_config/1]).
 -export([get_opt/3, set_opt/3]).
 
 %% gen_mod callbacks
@@ -78,12 +85,14 @@
 %% API
 %%====================================================================
 
--spec default_config() -> config().
-default_config() ->
-    [
-     {roomname, <<"Untitled">>},
-     {subject, <<>>}
-    ].
+-spec standard_config_schema() -> config_schema().
+standard_config_schema() -> ["roomname", "subject"].
+
+-spec standard_default_config() -> config().
+standard_default_config() -> [{"roomname", "Untitled"}, {"subject", ""}].
+
+-spec default_config(MUCServer :: ejabberd:lserver()) -> config().
+default_config(MUCServer) -> get_opt(MUCServer, default_config, []).
 
 -spec config_schema(MUCServer :: ejabberd:lserver()) -> config_schema().
 config_schema(MUCServer) -> get_opt(MUCServer, config_schema, undefined).
@@ -149,8 +158,14 @@ start(Host, Opts) ->
 
     %% Prepare config schema
     ConfigSchema = mod_muc_light_utils:make_config_schema(
-                     gen_mod:get_opt(config_schema, Opts, undefined)),
+                     gen_mod:get_opt(config_schema, Opts, standard_config_schema())),
     set_opt(MyDomain, config_schema, ConfigSchema),
+
+    %% Prepare default config
+    DefaultConfig = mod_muc_light_utils:make_default_config(
+                      gen_mod:get_opt(default_config, Opts, standard_default_config()),
+                      ConfigSchema),
+    set_opt(MyDomain, default_config, DefaultConfig),
 
     ok.
 
@@ -386,13 +401,15 @@ try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = Creatio
     InitialAffUsers = mod_muc_light_utils:filter_out_prevented(
                         CreatorUS, RoomUS, CreationCfg#create.aff_users),
     MaxOccupants = get_opt(RoomJID#jid.lserver, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
-    case {mod_muc_light_utils:process_raw_config(RawConfig, default_config(), config_schema(RoomS)),
-          process_create_aff_users_if_valid(RoomJID#jid.lserver, CreatorUS, InitialAffUsers)} of
+    case {mod_muc_light_utils:process_raw_config(
+            RawConfig, default_config(RoomS), config_schema(RoomS)),
+          process_create_aff_users_if_valid(RoomS, CreatorUS, InitialAffUsers)} of
         {{ok, Config0}, {ok, FinalAffUsers}} when length(FinalAffUsers) =< MaxOccupants ->
             Version = mod_muc_light_utils:bin_ts(),
             case ?BACKEND:create_room(RoomUS, lists:sort(Config0), FinalAffUsers, Version) of
                 {ok, FinalRoomUS} ->
-                    {ok, FinalRoomUS, CreationCfg#create{aff_users = FinalAffUsers, version = Version}};
+                    {ok, FinalRoomUS, CreationCfg#create{
+                                        aff_users = FinalAffUsers, version = Version}};
                 Other ->
                     Other
             end;
@@ -458,10 +475,10 @@ handle_disco_items_get(From, To, DiscoItems0, OrigPacket) ->
 -spec get_rooms_info(Rooms :: [ejabberd:simple_bare_jid()]) -> [disco_room_info()].
 get_rooms_info([]) ->
     [];
-get_rooms_info([RoomUS | RRooms]) ->
+get_rooms_info([{RoomU, _} = RoomUS | RRooms]) ->
     {ok, Config, Version} = ?BACKEND:get_config(RoomUS),
     RoomName = case lists:keyfind(roomname, 1, Config) of
-                   false -> <<>>;
+                   false -> RoomU;
                    {_, RoomName0} -> RoomName0
                end,
     [{RoomUS, RoomName, Version} | get_rooms_info(RRooms)].

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -85,10 +85,10 @@
 %% API
 %%====================================================================
 
--spec standard_config_schema() -> config_schema().
+-spec standard_config_schema() -> [Field :: string()].
 standard_config_schema() -> ["roomname", "subject"].
 
--spec standard_default_config() -> config().
+-spec standard_default_config() -> [{K :: string(), V :: string()}].
 standard_default_config() -> [{"roomname", "Untitled"}, {"subject", ""}].
 
 -spec default_config(MUCServer :: ejabberd:lserver()) -> config().

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -19,7 +19,7 @@
 %%%                              user's roster
 %%% * config_schema (undefined) - Custom list of configuration options for a room;
 %%%                               WARNING! Lack of `roomname` field will cause room names in
-%%%                               Disco results and Roster items be set to null string.
+%%%                               Disco results and Roster items be set to empty string.
 %%%
 %%% Allowed `config_schema` list items (may be mixed):
 %%% * Just field name: "field" - will be expanded to "field" of type 'binary'
@@ -459,7 +459,11 @@ handle_disco_items_get(From, To, DiscoItems0, OrigPacket) ->
 get_rooms_info([]) ->
     [];
 get_rooms_info([RoomUS | RRooms]) ->
-    {ok, RoomName, Version} = ?BACKEND:get_config(RoomUS, roomname),
+    {ok, Config, Version} = ?BACKEND:get_config(RoomUS),
+    RoomName = case lists:keyfind(roomname, 1, Config) of
+                   false -> <<>>;
+                   {_, RoomName0} -> RoomName0
+               end,
     [{RoomUS, RoomName, Version} | get_rooms_info(RRooms)].
 
 -spec apply_rsm(RoomsInfo :: [disco_room_info()], RoomsInfoLen :: non_neg_integer(),

--- a/apps/ejabberd/src/mod_muc_light_room.erl
+++ b/apps/ejabberd/src/mod_muc_light_room.erl
@@ -140,7 +140,7 @@ process_request(_UnknownReq, _From, _UserUS, _RoomUS, _Auth, _AffUsers) ->
 
 -spec process_config_set(ConfigReq :: #config{}, RoomUS :: ejabberd:simple_bare_jid(),
                          UserAff :: member | owner, AffUsers :: aff_users(),
-                         AllCanConfigure :: boolean()) ->
+                         UserAllowedToConfigure :: boolean()) ->
     {set, #config{}} | {error, not_allowed} | validation_error().
 process_config_set(#config{ raw_config = [{<<"subject">>, _}] } = ConfigReq, RoomUS, UserAff,
                    AffUsers, false) ->

--- a/doc/developers-guide/mod_muc_light_developers_guide.md
+++ b/doc/developers-guide/mod_muc_light_developers_guide.md
@@ -75,12 +75,13 @@ Advantages and drawbacks (compared to classic MUC)
 
 New MUC implementation has following benefits:
 
-* Fully distributed - does not have SPOF, concurrent senders do not block each other, especially in large rooms. Message broadcasting is being done in sender c2s context.
-* Doesn't use presences - much less traffic and stable membership information, especially on mobile networks.
+* Fully distributed - Does not have SPOF, concurrent senders do not block each other, especially in large rooms. Message broadcasting is being done in sender c2s context.
+* Doesn't use presences - Much less traffic and stable membership information, especially on mobile networks.
 * Built-in blocking support - Instead of blocking traffic like Privacy Lists do, it handles blocklists internally, preventing the blocker from being added to or by blocked entities.
 * Less round-trips - Room can be created and configured with initial list of occupants with single request.
-* Versioning - reduces traffic and allows clients to detect reliably and early that room state has changed.
+* Versioning - Reduces traffic and allows clients to detect reliably and early that room state has changed.
 * Isolation - Any processing error is contained in sender context, not affecting other room occupants.
+* Fully customisable room configuration - Your users can store any meta room information you allow.
 
 Drawbacks are:
 
@@ -107,7 +108,6 @@ Ideas for Further Development
 
 ### Easy
 
-  * Make default room configuration configurable
   * ODBC backend
   * Add more tests for negative cases
 
@@ -116,6 +116,7 @@ Ideas for Further Development
   * Add optional per-room processes to avoid the need of DB transactions and ensure message ordering (maybe "hard"?).
   * Riak backend
   * Redis backend
+  * Extract per service subdomain config tab as separate, generic module (maybe "easy"?).
 
 ### Hard
 

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -1,4 +1,5 @@
 ### Module Description
+
 This module implements [XEP Multi-User Chat Light](https://github.com/xsf/xeps/pull/118) (still being reviewed by XMPP community). It's an experimental XMPP group chat solution. This extension consists of several modules but only `mod_muc_light` needs to be enabled in config file.
 
 ### Options
@@ -14,8 +15,27 @@ This module implements [XEP Multi-User Chat Light](https://github.com/xsf/xeps/p
 * **max_occupants** (positive integer or `infinity`, default: `infinity`) - Specifies a cap on occupant count per room.
 * **rooms_per_page** (positive integer or `infinity`, default: 10) - Specifies maximal number of rooms returned for single Disco request.
 * **rooms_in_rosters** (boolean, default: `false`) - When enabled, rooms the user occupies are included in its roster.
+* **config_schema** (list; see below, default: `["roomname", "subject"]`) - A list of fields allowed in room configuration. Field type may be specified but the default is "binary", i.e. effectively a string. **WARNING!** Lack of `roomname` field will cause room names in Disco results and Roster items be set to room username.
+* **default_config** (list, default: `[{"roomname, "Untitled"}, {"subject", ""}]`) - Custom default room configuration; must be a subset of config schema. It's a list of KV tuples with string keys and values of appriopriate type. String values will be converted to binary automatically.
+
+### Config schema
+
+Allowed `config_schema` list items are (may be mixed):
+
+* Just field name: `"field"` - will be expanded to "field" of a type `binary`
+* Field name and a type: `{"field", integer}`
+* Field name, an atom and a type: `{"field", field, float}` - useful only for debugging or unusual applications
+
+Example of such list: `["roomname", {"subject", binary}, {"priority", priority, integer}]`
+
+Valid config field types are:
+
+* `binary` (i.e. any valid XML CDATA)
+* `integer`
+* `float`
 
 ### Example Configuration
+
 ```
 {mod_muc_light, [
              {host, "muclight.example.com"},
@@ -27,6 +47,8 @@ This module implements [XEP Multi-User Chat Light](https://github.com/xsf/xeps/p
              {all_can_invite, true},
              {max_occupants, 50},
              {rooms_per_page, 5},
-             {rooms_in_rosters, true}
+             {rooms_in_rosters, true},
+             {config_schema, ["roomname", {"display-lines", integer}]},
+             {default_config, [{"roomname", "The Room"}, {"display-lines", 30}]}
             ]},
 ```

--- a/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
@@ -830,7 +830,7 @@ lbin(Bin) ->
 
 -spec default_config() -> list().
 default_config() ->
-    rpc(mod_muc_light, default_config, []).
+    rpc(mod_muc_light, default_config, [?MUCHOST]).
 
 -spec set_default_mod_config() -> ok.
 set_default_mod_config() ->


### PR DESCRIPTION
This PR allows to set custom room config schema in `mod_muc_light` options. In extreme case even all parameters may be replaced (i.e. default `roomname` and `subject`).

I will also make possible to set custom default values for these fields.

**TODOs:**
- [x] Handle a case with missing `roomname` in schema.
- [x] Setting default values for custom schema.
- [x] Tests.
- [x] Docs.