### PR TITLE
Increase timeout for cleanup

### DIFF
--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -388,7 +388,8 @@ unregister_iq_handler(Host, XMLNS) ->
 %%====================================================================
 
 node_cleanup(Node) ->
-    gen_server:call(?MODULE, {node_cleanup, Node}).
+    Timeout = timer:minutes(1),
+    gen_server:call(?MODULE, {node_cleanup, Node}, Timeout).
 
 %%====================================================================
 %% gen_server callbacks


### PR DESCRIPTION
This PR addresses possible timeout for a cleanup call

Proposed changes include:
* increase timeout for cleanup call from 5 seconds to 1 minute

I have a 3 node mongooseIM cluster with a redis sm backend. When one node goes down,
the other do a cleanup. The cleanup takes more than 5 seconds and crashes 
```
2016-08-04 14:25:03.186 [error] <0.306.0>@ejabberd_hooks:run1:240 {timeout,{gen_server,call,[ejabberd_sm,{node_cleanup,'n3@172.12.2.202'}]}}
    Running hook: {node_cleanup,['n3@172.12.2.202']}
    Callback: ejabberd_sm:node_cleanup
2016-08-04 14:25:03.187 [warning] <0.306.0>@mongoose_cleaner:run_node_cleanup:83 cleanup took=5001ms, result: ok
2016-08-04 14:25:03.193 [warning] <0.306.0>@mongoose_cleaner:cleanup_modules:77 cleanup result: ok
```