### PR TITLE
Log cleanup duration on start

### DIFF
--- a/apps/ejabberd/src/ejabberd_sm_redis.erl
+++ b/apps/ejabberd/src/ejabberd_sm_redis.erl
@@ -26,7 +26,10 @@
 start(Opts) ->
     ejabberd_redis:start_link(Opts),
     %% Clean current node's sessions from previous life
-    cleanup(node()).
+    {Elapsed, RetVal} = timer:tc(fun() -> cleanup(node()) end),
+    ?WARNING_MSG("cleanup on start took=~pms~n",
+                 [erlang:round(Elapsed / 1000)]),
+    RetVal.
 
 
 -spec get_sessions() -> [ejabberd_sm:ses_tuple()].

--- a/apps/ejabberd/src/ejabberd_sm_redis.erl
+++ b/apps/ejabberd/src/ejabberd_sm_redis.erl
@@ -26,7 +26,7 @@
 start(Opts) ->
     ejabberd_redis:start_link(Opts),
     %% Clean current node's sessions from previous life
-    {Elapsed, RetVal} = timer:tc(fun() -> cleanup(node()) end),
+    {Elapsed, RetVal} = timer:tc(?MODULE, cleanup, [node()]),
     ?WARNING_MSG("cleanup on start took=~pms~n",
                  [erlang:round(Elapsed / 1000)]),
     RetVal.


### PR DESCRIPTION
This PR addresses missing logging for one of cleanup calls.

Proposed changes include:
* log duration of a cleanup on start

The duration of the cleanup is logged during the normal operations when the other node
goes down in `mongoose_cleaner:run_node_cleanup/1`. Let's log it on start as well.

