### PR TITLE
Finalize MVP for the MUC HTTP Administration API

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -25,6 +25,7 @@
 -include_lib("exml/include/exml.hrl").
 
 -define(NS_CLIENT,       <<"jabber:client">>).
+-define(NS_CONFERENCE,   <<"jabber:x:conference">>).
 -define(NS_DISCO_ITEMS,  <<"http://jabber.org/protocol/disco#items">>).
 -define(NS_DISCO_INFO,   <<"http://jabber.org/protocol/disco#info">>).
 -define(NS_VCARD,        <<"vcard-temp">>).

--- a/apps/ejabberd/src/jid.erl
+++ b/apps/ejabberd/src/jid.erl
@@ -31,6 +31,7 @@
 -export([to_lus/1]).
 -export([to_bare/1]).
 -export([replace_resource/2]).
+-export([binary_to_bare/1]).
 
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl"). % only used to define stream types
@@ -241,4 +242,13 @@ replace_resource(JID, Resource) ->
         error -> error;
         LResource ->
             JID#jid{resource = Resource, lresource = LResource}
+    end.
+
+-spec binary_to_bare(binary()) -> error | ejabberd:jid().
+binary_to_bare(JID) when is_binary(JID) ->
+    case from_binary(JID) of
+        error ->
+            error;
+        #jid{} = Result ->
+            to_bare(Result)
     end.

--- a/apps/ejabberd/src/mod_muc_admin.erl
+++ b/apps/ejabberd/src/mod_muc_admin.erl
@@ -38,17 +38,17 @@ stop(_) ->
 commands() ->
     [
      [{name, create_muc_room},
-      {category, muc},
+      {category, mucs},
       {desc, "Create a MUC room."},
       {module, ?MODULE},
       {function, create_room},
       {action, create},
-      {identifiers, [domain]},
+      {identifiers, [host]},
       {args,
-       %% The argument `domain' is what we normally term the XMPP
+       %% The argument `host' is what we normally term the XMPP
        %% host, `name' is the room name, `owner' is the XMPP entity
        %% that would normally request an instant MUC room.
-       [{domain, binary},
+       [{host, binary},
         {name, binary},
         {owner, binary},
         {nick, binary}]},
@@ -74,6 +74,7 @@ commands() ->
      %% with the same URL and method.
      [{name, send_message_to_room},
       {category, mucs},
+      {subcategory, <<"messages">>},
       {desc, "Send a message to a MUC room from a given user."},
       {module, ?MODULE},
       {function, send_message_to_room},

--- a/apps/ejabberd/src/mod_muc_admin.erl
+++ b/apps/ejabberd/src/mod_muc_admin.erl
@@ -91,10 +91,10 @@ commands() ->
     ].
 
 create_instant_room(Host, Name, Owner, Nick) ->
-    %% Because these stanzas are sent on the owner's behalf, they will
-    %% certainly recieve stanzas as a consequence, even if their
-    %% client(s) did not initiate anything.
-    OwnerJID = jid:from_binary(Owner),
+    %% Because these stanzas are sent on the owner's behalf through
+    %% the HTTP API, they will certainly recieve stanzas as a
+    %% consequence, even if their client(s) did not initiate this.
+    OwnerJID = binary_to_bare(Owner),
     MUCHost = gen_mod:get_module_opt_host(Host, mod_muc, <<"muc.@HOST@">>),
     UserRoomJID = jid:make(Name, MUCHost, Nick),
     BareRoomJID = jid:make(Name, MUCHost, <<"">>),
@@ -112,8 +112,8 @@ create_instant_room(Host, Name, Owner, Nick) ->
     end.
 
 invite_to_room(Host, Name, Sender, Recipient, Reason) ->
-    S = jid:from_binary(Sender),
-    R = jid:from_binary(Recipient),
+    S = binary_to_bare(Sender),
+    R = binary_to_bare(Recipient),
     %% Direct invitation: i.e. not mediated by MUC room. See XEP 0249.
     X = #xmlel{name = <<"x">>,
                attrs = [{<<"xmlns">>, ?NS_CONFERENCE},
@@ -124,7 +124,7 @@ invite_to_room(Host, Name, Sender, Recipient, Reason) ->
     ejabberd_router:route(S, R, Invite).
 
 send_message_to_room(Host, Name, Sender, Message) ->
-    S = jid:from_binary(Sender),
+    S = binary_to_bare(Sender),
     Room = jid:from_binary(room_jid(Name, Host)),
     X = #xmlel{name = <<"body">>,
                children = [ #xmlcdata{ content = Message } ]
@@ -163,3 +163,6 @@ data_submission() ->
                               attrs = [{<<"xmlns">>, ?NS_XDATA},
                                        {<<"type">>, <<"submit">>}]}]
           }.
+
+binary_to_bare(JID) ->
+    jid:to_bare(jid:from_binary(JID)).

--- a/apps/ejabberd/src/mod_muc_admin.erl
+++ b/apps/ejabberd/src/mod_muc_admin.erl
@@ -94,7 +94,7 @@ create_instant_room(Host, Name, Owner, Nick) ->
     %% Because these stanzas are sent on the owner's behalf through
     %% the HTTP API, they will certainly recieve stanzas as a
     %% consequence, even if their client(s) did not initiate this.
-    OwnerJID = binary_to_bare(Owner),
+    OwnerJID = jid:binary_to_bare(Owner),
     MUCHost = gen_mod:get_module_opt_host(Host, mod_muc, <<"muc.@HOST@">>),
     UserRoomJID = jid:make(Name, MUCHost, Nick),
     BareRoomJID = jid:make(Name, MUCHost, <<"">>),
@@ -112,8 +112,8 @@ create_instant_room(Host, Name, Owner, Nick) ->
     end.
 
 invite_to_room(Host, Name, Sender, Recipient, Reason) ->
-    S = binary_to_bare(Sender),
-    R = binary_to_bare(Recipient),
+    S = jid:binary_to_bare(Sender),
+    R = jid:binary_to_bare(Recipient),
     %% Direct invitation: i.e. not mediated by MUC room. See XEP 0249.
     X = #xmlel{name = <<"x">>,
                attrs = [{<<"xmlns">>, ?NS_CONFERENCE},
@@ -124,7 +124,7 @@ invite_to_room(Host, Name, Sender, Recipient, Reason) ->
     ejabberd_router:route(S, R, Invite).
 
 send_message_to_room(Host, Name, Sender, Message) ->
-    S = binary_to_bare(Sender),
+    S = jid:binary_to_bare(Sender),
     Room = jid:from_binary(room_jid(Name, Host)),
     X = #xmlel{name = <<"body">>,
                children = [ #xmlcdata{ content = Message } ]
@@ -163,6 +163,3 @@ data_submission() ->
                               attrs = [{<<"xmlns">>, ?NS_XDATA},
                                        {<<"type">>, <<"submit">>}]}]
           }.
-
-binary_to_bare(JID) ->
-    jid:to_bare(jid:from_binary(JID)).

--- a/apps/ejabberd/src/mod_muc_admin.erl
+++ b/apps/ejabberd/src/mod_muc_admin.erl
@@ -95,8 +95,7 @@ create_instant_room(Host, Name, Owner, Nick) ->
     %% certainly recieve stanzas as a consequence, even if their
     %% client(s) did not initiate anything.
     OwnerJID = jid:from_binary(Owner),
-    MUCHost = gen_mod:get_module_opt_host(Host, mod_muc,
-                                            <<"muc.@HOST@">>),
+    MUCHost = gen_mod:get_module_opt_host(Host, mod_muc, <<"muc.@HOST@">>),
     UserRoomJID = jid:make(Name, MUCHost, Nick),
     BareRoomJID = jid:make(Name, MUCHost, <<"">>),
     %% Send presence to create a room.
@@ -116,29 +115,24 @@ invite_to_room(Host, Name, Sender, Recipient, Reason) ->
     S = jid:from_binary(Sender),
     R = jid:from_binary(Recipient),
     %% Direct invitation: i.e. not mediated by MUC room. See XEP 0249.
-    X = #xmlel{
-           name = <<"x">>,
-           attrs =
-               [ {<<"xmlns">>, ?NS_CONFERENCE},
-                 {<<"jid">> , room_jid(Name, Host)},
-                 {<<"reason">>, Reason}
-               ]
-          },
+    X = #xmlel{name = <<"x">>,
+               attrs = [{<<"xmlns">>, ?NS_CONFERENCE},
+                        {<<"jid">> , room_jid(Name, Host)},
+                        {<<"reason">>, Reason}]
+              },
     Invite = #xmlel{name = <<"message">>, children = [ X ]},
     ejabberd_router:route(S, R, Invite).
 
 send_message_to_room(Host, Name, Sender, Message) ->
     S = jid:from_binary(Sender),
-    Room = jid:from_binary(room_jid(Name, Host)), %% Go for jid:make/3 instead.
-    X = #xmlel{
-           name = <<"body">>,
-           children =
-               [ #xmlcdata{ content = Message } ]
-          },
-    Stanza = #xmlel{
-                 name = <<"message">>, 
-                 attrs = [{<<"type">>, <<"groupchat">>}],
-                 children = [ X ]},
+    Room = jid:from_binary(room_jid(Name, Host)),
+    X = #xmlel{name = <<"body">>,
+               children = [ #xmlcdata{ content = Message } ]
+              },
+    Stanza = #xmlel{name = <<"message">>,
+                    attrs = [{<<"type">>, <<"groupchat">>}],
+                    children = [ X ]
+                   },
     ejabberd_router:route(S, Room, Stanza).
 
 
@@ -147,28 +141,25 @@ send_message_to_room(Host, Name, Sender, Message) ->
 %%--------------------------------------------------------------------
 
 room_jid(Name, Host) ->
-    MUCHost = gen_mod:get_module_opt_host(Host, mod_muc,
-                                            <<"muc.@HOST@">>),
+    MUCHost = gen_mod:get_module_opt_host(Host, mod_muc, <<"muc.@HOST@">>),
     <<Name/binary, $@, MUCHost/binary>>.
 
 presence() ->
-    #xmlel{
-       name = <<"presence">>,
-       children = [ #xmlel{
-                       name = <<"x">>,
-                       attrs = [{<<"xmlns">>, ?NS_MUC}]} ]}.
+    #xmlel{name = <<"presence">>,
+           children = [#xmlel{name = <<"x">>,
+                              attrs = [{<<"xmlns">>, ?NS_MUC}]}]
+          }.
 
 declination() ->
-    #xmlel{
-       name = <<"iq">>,
-       attrs = [{<<"type">>, <<"set">>}],
-       children = [ data_submission() ]}.
+    #xmlel{name = <<"iq">>,
+           attrs = [{<<"type">>, <<"set">>}],
+           children = [ data_submission() ]
+          }.
 
 data_submission() ->
-    #xmlel{
-       name = <<"query">>,
-       attrs = [{<<"xmlns">>, ?NS_MUC_OWNER}],
-       children = [ #xmlel{
-                       name = <<"x">>,
-                       attrs = [{<<"xmlns">>, ?NS_XDATA},
-                                {<<"type">>, <<"submit">>}]} ]}.
+    #xmlel{name = <<"query">>,
+           attrs = [{<<"xmlns">>, ?NS_MUC_OWNER}],
+           children = [#xmlel{name = <<"x">>,
+                              attrs = [{<<"xmlns">>, ?NS_XDATA},
+                                       {<<"type">>, <<"submit">>}]}]
+          }.

--- a/apps/ejabberd/src/muc_admin.erl
+++ b/apps/ejabberd/src/muc_admin.erl
@@ -1,0 +1,60 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% Author: Joseph Yiasemides <joseph.yiasemides@erlang-solutions.com>
+%% Description: Administration commands for Mult-user Chat (MUC)
+%%==============================================================================
+
+-module(muc_admin).
+
+-behaviour(gen_mod).
+-export([start/2, stop/1]).
+
+-export([create_room/4]).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+
+start(_, _) ->
+    mongoose_commands:register(commands()).
+
+stop(_) ->
+    mongoose_commands:unregister(commands()).
+
+commands() ->
+    [
+     [{name, create_muc_room},
+      {category, muc},
+      {desc, "Create a MUC room."},
+      {module, ?MODULE},
+      {function, create_room},
+      {action, create},
+      {args,
+       %% The argument `domain' is what we normally term the XMPP
+       %% host, `name' is the room name, `owner' is the XMPP entity
+       %% that would normally request an instant MUC room.
+       [{domain, binary},
+        {name, binary},
+        {owner, binary},
+        {nick, binary}]},
+      {result, {name, binary}}]
+    ].
+
+create_room(Domain, Name, Owner, Nick) ->
+    try mod_muc:create_instant_room(Domain, Name, jid:from_binary(Owner), Nick, default) of
+        ok -> Name
+    catch
+        Kind:Reason -> {error, {Kind, Reason}}
+    end.

--- a/apps/ejabberd/src/muc_admin.erl
+++ b/apps/ejabberd/src/muc_admin.erl
@@ -24,6 +24,7 @@
 
 -export([create_room/4]).
 -export([invite_to_room/5]).
+-export([send_message_to_room/4]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -67,6 +68,23 @@ commands() ->
         {recipient, binary},
         {reason, binary}
        ]},
+      {result, ok}],
+
+     %% This breaks the module because we have two HTTP end-points
+     %% with the same URL and method.
+     [{name, send_message_to_room},
+      {category, muc},
+      {desc, "Send a message to a MUC room from a given user."},
+      {module, ?MODULE},
+      {function, send_message_to_room},
+      {action, create},
+      {identifiers, [domain, name]},
+      {args,
+       [{domain, binary},
+        {name, binary},
+        {sender, binary},
+        {message, binary}
+       ]},
       {result, ok}]
 
     ].
@@ -93,6 +111,25 @@ invite_to_room(Domain, Name, Sender, Recipient, Reason) ->
           },
     Invite = #xmlel{name = <<"message">>, children = [ X ]},
     ejabberd_router:route(S, R, Invite).
+
+send_message_to_room(Domain, Name, Sender, Message) ->
+    S = jid:from_binary(Sender),
+    Room = jid:from_binary(room_jid(Name, Domain)),
+    X = #xmlel{
+           name = <<"body">>,
+           children =
+               [ #xmlcdata{ content = Message } ]
+          },
+    Stanza = #xmlel{
+                 name = <<"message">>, 
+                 attrs = [{<<"type">>, <<"groupchat">>}],
+                 children = [ X ]},
+    ejabberd_router:route(S, Room, Stanza).
+
+
+%%--------------------------------------------------------------------
+%% Ancillary
+%%--------------------------------------------------------------------
 
 room_jid(Name, Domain) ->
     MUCDomain = gen_mod:get_module_opt_host(Domain, mod_muc,

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -669,6 +669,7 @@
   {{mod_amp}}
   {mod_disco, []},
   {mongoose_admin, []},
+  {muc_admin, []},
   {{mod_last}}
   {mod_stream_management, [
                            % default 100

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -669,7 +669,7 @@
   {{mod_amp}}
   {mod_disco, []},
   {mongoose_admin, []},
-  {muc_admin, []},
+  {mod_muc_admin, []},
   {{mod_last}}
   {mod_stream_management, [
                            % default 100

--- a/test/ejabberd_tests/default.spec
+++ b/test/ejabberd_tests/default.spec
@@ -37,6 +37,7 @@
 {suites, "tests", muc_SUITE}.
 {suites, "tests", muc_light_SUITE}.
 {suites, "tests", muc_light_legacy_SUITE}.
+{suites, "tests", muc_http_api_SUITE}.
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
 {suites, "tests", pep_SUITE}.

--- a/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -116,7 +116,7 @@ send_message_to_room(Config) ->
         %% Parameters for this test.
         Host = <<"localhost">>,
         Name = <<"wonderland">>,
-        Path = <<"/mucs", $/, Host/binary, $/, Name/binary>>,
+        Path = <<"/mucs",$/,Host/binary,$/,Name/binary,$/,"messages">>,
         Message = <<"Greetings!">>,
         Body = #{sender => escalus_utils:get_jid(Bob),
                  message => Message},

--- a/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -77,8 +77,8 @@ end_per_testcase(CaseName, Config) ->
 
 create_room(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        Domain = <<"localhost">>,
-        Path = <<"/muc/", Domain/binary>>,
+        Host = <<"localhost">>,
+        Path = <<"/mucs/", Host/binary>>,
         Name = <<"wonderland">>,
         Body = #{name => Name,
                  owner => escalus_utils:get_jid(Alice),
@@ -92,7 +92,7 @@ create_room(Config) ->
 
 invite_online_user_to_room(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        Path = <<"/muc/localhost/wonderland">>,
+        Path = <<"/mucs/localhost/wonderland">>,
         Reason = <<"I think you'll like this room!">>,
         Body = #{sender => escalus_utils:get_jid(Alice),
                  recipient => escalus_utils:get_jid(Bob),
@@ -114,9 +114,9 @@ send_message_to_room(Config) ->
                                                       <<"bobcat">>)),
         escalus:wait_for_stanzas(Bob, 2),
         %% Parameters for this test.
-        Domain = <<"localhost">>,
+        Host = <<"localhost">>,
         Name = <<"wonderland">>,
-        Path = <<"/muc", $/, Domain/binary, $/, Name/binary>>,
+        Path = <<"/mucs", $/, Host/binary, $/, Name/binary>>,
         Message = <<"Greetings!">>,
         Body = #{sender => escalus_utils:get_jid(Bob),
                  message => Message},
@@ -127,6 +127,7 @@ send_message_to_room(Config) ->
         escalus:assert(is_message, Got),
         Message = exml_query:path(Got, [{element, <<"body">>}, cdata])
     end).
+
 
 %%--------------------------------------------------------------------
 %% Ancillary (adapted from the MUC suite)

--- a/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -40,7 +40,9 @@ groups() ->
 success_response() ->
     [
      create_room,
-     invite_to_room
+     invite_online_user_to_room,
+     %% invite_offline_user_to_room, %% TO DO.
+     send_message_to_room
     ].
 
 
@@ -88,25 +90,46 @@ create_room(Config) ->
         escalus:assert(is_stanza_from, [muc_helper:muc_host()], Stanza)
     end).
 
-invite_to_room(Config) ->
+invite_online_user_to_room(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-
         Path = <<"/muc/localhost/wonderland">>,
         Reason = <<"I think you'll like this room!">>,
         Body = #{sender => escalus_utils:get_jid(Alice),
                  recipient => escalus_utils:get_jid(Bob),
                  reason => Reason},
-
         {{<<"200">>, _}, <<"">>} = rest_helper:putt(Path, Body),
-
         Stanza = escalus:wait_for_stanza(Bob),
         is_direct_invitation(Stanza),
         direct_invite_has_reason(Stanza, Reason)
     end).
 
+send_message_to_room(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        %% Alice creates a MUC room.
+        muc_helper:start_room([], escalus_users:get_user_by_name(alice),
+                              <<"wonderland">>, <<"ali">>, []),
+        %% Bob enters the room.
+        escalus:send(Bob,
+                     muc_helper:stanza_muc_enter_room(<<"wonderland">>,
+                                                      <<"bobcat">>)),
+        escalus:wait_for_stanzas(Bob, 2),
+        %% Parameters for this test.
+        Domain = <<"localhost">>,
+        Name = <<"wonderland">>,
+        Path = <<"/muc", $/, Domain/binary, $/, Name/binary>>,
+        Message = <<"Greetings!">>,
+        Body = #{sender => escalus_utils:get_jid(Bob),
+                 message => Message},
+        %% The HTTP call in question. Notice: status 200 because no
+        %% resource is created.
+        {{<<"200">>, _}, <<"">>} = rest_helper:post(Path, Body),
+        Got = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_message, Got),
+        Message = exml_query:path(Got, [{element, <<"body">>}, cdata])
+    end).
 
 %%--------------------------------------------------------------------
-%% Ancillary (these are borrowed from the MUC suite)
+%% Ancillary (adapted from the MUC suite)
 %%--------------------------------------------------------------------
 
 stanza_get_rooms() ->

--- a/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -89,7 +89,7 @@ create_room(Config) ->
         Path = <<"/mucs/", Host/binary>>,
         Name = ?config(room_name, Config),
         Body = #{name => Name,
-                 owner => escalus_utils:get_jid(Alice),
+                 owner => escalus_client:short_jid(Alice),
                  nick => <<"ali">>},
         {{<<"201">>, _}, <<"">>} = rest_helper:post(Path, Body),
         %% Service acknowledges room creation (10.1.1 Ex. 154), then
@@ -108,8 +108,8 @@ invite_online_user_to_room(Config) ->
         Name = ?config(room_name, Config),
         Path = <<"/mucs/localhost/", Name/binary>>,
         Reason = <<"I think you'll like this room!">>,
-        Body = #{sender => escalus_utils:get_jid(Alice),
-                 recipient => escalus_utils:get_jid(Bob),
+        Body = #{sender => escalus_client:short_jid(Alice),
+                 recipient => escalus_client:short_jid(Bob),
                  reason => Reason},
         {{<<"200">>, _}, <<"">>} = rest_helper:putt(Path, Body),
         Stanza = escalus:wait_for_stanza(Bob),
@@ -132,7 +132,7 @@ send_message_to_room(Config) ->
         Host = <<"localhost">>,
         Path = <<"/mucs",$/,Host/binary,$/,Name/binary,$/,"messages">>,
         Message = <<"Greetings!">>,
-        Body = #{sender => escalus_utils:get_jid(Bob),
+        Body = #{sender => escalus_client:short_jid(Bob),
                  message => Message},
         %% The HTTP call in question. Notice: status 200 because no
         %% resource is created.
@@ -158,7 +158,7 @@ multiparty_multiprotocol(Config) ->
             {{<<"201">>, _}, <<"">>} =
                 rest_helper:post(MUCPath,
                                  #{name => Room,
-                                   owner => escalus_utils:get_jid(Alice),
+                                   owner => escalus_client:short_jid(Alice),
                                    nick => <<"ali">>}),
             %% See comments under the create room test case.
             escalus:wait_for_stanzas(Alice, 3),
@@ -198,7 +198,7 @@ multiparty_multiprotocol(Config) ->
             %% HTTP: Alice sends a message to the room.
             {{<<"200">>, _}, <<"">>} =
                 rest_helper:post(MessagePath,
-                                 #{sender => escalus_utils:get_jid(Alice),
+                                 #{sender => escalus_client:short_jid(Alice),
                                    message => Message}),
             %% XMPP: All three recieve the message sent to the MUC room.
             [ Message = wait_for_group_message(User) || User <- [Alice, Bob, Kate] ],
@@ -240,8 +240,8 @@ direct_invite_has_reason(Stanza, Reason) ->
     Reason = exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"reason">>}]).
 
 invite_body(Sender, Recipient, Reason) ->
-    #{sender => escalus_utils:get_jid(Sender),
-      recipient => escalus_utils:get_jid(Recipient),
+    #{sender => escalus_client:short_jid(Sender),
+      recipient => escalus_client:short_jid(Recipient),
       reason => Reason}.
 
 wait_for_invite(Recipient, Reason) ->

--- a/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -1,0 +1,101 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% Author: Joseph Yiasemides <joseph.yiasemides@erlang-solutions.com>
+%% Description: Test HTTP Administration API for Mult-user Chat (MUC)
+%%==============================================================================
+
+-module(muc_http_api_SUITE).
+-compile(export_all).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, positive}].
+
+groups() ->
+    [{positive, [shuffle], success_response()}].
+
+success_response() ->
+    [create_room].
+
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    muc_helper:load_muc(muc_helper:muc_host()),
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    muc_helper:unload_muc(),
+    escalus:end_per_suite(Config).
+
+init_per_group(_GroupName, Config) ->
+    escalus:create_users(Config, escalus:get_users([alice, bob])).
+
+end_per_group(_GroupName, Config) ->
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+create_room(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Domain = <<"localhost">>,
+        Path = <<"/muc/", Domain/binary>>,
+        Name = <<"wonderland">>,
+        Body = #{name => Name,
+                 owner => escalus_utils:get_jid(Alice),
+                 nick => <<"ali">>},
+        {{<<"201">>, _}, <<"">>} = rest_helper:post(Path, Body),
+        escalus:send(Alice, stanza_get_rooms()),
+        Stanza = escalus:wait_for_stanza(Alice),
+        has_room(muc_helper:room_address(<<"wonderland">>), Stanza),
+        escalus:assert(is_stanza_from, [muc_helper:muc_host()], Stanza)
+    end).
+
+
+%%--------------------------------------------------------------------
+%% Ancillary
+%%--------------------------------------------------------------------
+
+stanza_get_rooms() ->
+    escalus_stanza:setattr(escalus_stanza:iq_get(?NS_DISCO_ITEMS, []), <<"to">>,
+        muc_helper:muc_host()).
+
+has_room(JID, #xmlel{children = [ #xmlel{children = Rooms} ]}) ->
+    RoomPred = fun(Item) ->
+        exml_query:attr(Item, <<"jid">>) == JID
+    end,
+    true = lists:any(RoomPred, Rooms).


### PR DESCRIPTION
Introduce MVP for the MUC HTTP API:

- [x] Create room
- [x] Invite to room
- [x] Send message to room
- [x] Refactor & improve source (following a review)
- [x] Improve & expand tests

This cherry-picks the commits off of what was PR #903. 