### PR TITLE
Fix escalus warnings

### DIFF
--- a/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
+++ b/test/ejabberd_tests/tests/ejabberdctl_SUITE.erl
@@ -401,6 +401,9 @@ vcard2_multi_rw(Config) ->
 
 rosteritem_rw(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
+                BobJid = escalus_users:get_jid(Config, bob),
+                MikeJid = escalus_users:get_jid(Config, mike),
+
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 {BobName, Domain, _} = get_user_data(bob, Config),
                 {MikeName, Domain, _} = get_user_data(mike, Config),
@@ -412,9 +415,9 @@ rosteritem_rw(Config) ->
 
                 [Push1, Push2] = escalus:wait_for_stanzas(Alice, 2), % Check roster broadcasts
                 escalus:assert(is_roster_set, Push1),
-                escalus:assert(roster_contains, [bob], Push1),
+                escalus:assert(roster_contains, [BobJid], Push1),
                 escalus:assert(is_roster_set, Push2),
-                escalus:assert(roster_contains, [mike], Push2),
+                escalus:assert(roster_contains, [MikeJid], Push2),
 
                 {Items1, 0} = ejabberdctl("get_roster", [AliceName, Domain], Config),
                 match_roster([{BobName, Domain, "MyBob", "MyGroup", "both"},
@@ -423,23 +426,24 @@ rosteritem_rw(Config) ->
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster1 = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_roster_result, Roster1),
-                escalus:assert(roster_contains, [bob], Roster1),
-                escalus:assert(roster_contains, [mike], Roster1),
+                escalus:assert(roster_contains, [BobJid], Roster1),
+                escalus:assert(roster_contains, [MikeJid], Roster1),
 
                 {_, 0} = ejabberdctl("delete_rosteritem", [AliceName, Domain, BobName, Domain], Config),
 
                 Push3 = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_roster_set, Push3),
-                escalus:assert(roster_contains, [bob], Push3),
+                escalus:assert(roster_contains, [BobJid], Push3),
 
                 {Items2, 0} = ejabberdctl("get_roster", [AliceName, Domain], Config),
                 match_roster([{MikeName, Domain, "MyMike", "MyGroup", "both"}], Items2),
 
-                escalus:send(Alice, escalus_stanza:roster_remove_contact(mike))  % cleanup
+                escalus:send(Alice, escalus_stanza:roster_remove_contact(MikeJid))  % cleanup
         end).
 
 presence_after_add_rosteritem(Config) ->
      escalus:story(Config, [{alice, 1}, {bob,1}], fun(Alice, Bob) ->
+                 BobJid = escalus_users:get_jid(Config, bob),
                  {AliceName, Domain, _} = get_user_data(alice, Config),
                  {BobName, Domain, _} = get_user_data(bob, Config),
 
@@ -449,11 +453,12 @@ presence_after_add_rosteritem(Config) ->
                  escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
                  escalus:assert(is_presence, escalus:wait_for_stanza(Bob)),
 
-                 escalus:send(Alice, escalus_stanza:roster_remove_contact(bob))  % cleanup
+                 escalus:send(Alice, escalus_stanza:roster_remove_contact(BobJid))  % cleanup
          end).
 
 push_roster(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
+                BobJid = escalus_users:get_jid(Config, bob),
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 TemplatePath = escalus_config:get_config(roster_template, Config),
 
@@ -461,9 +466,9 @@ push_roster(Config) ->
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster1 = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_roster_result, Roster1),
-                escalus:assert(roster_contains, [bob], Roster1),
+                escalus:assert(roster_contains, [BobJid], Roster1),
 
-                escalus:send(Alice, escalus_stanza:roster_remove_contact(bob)) % cleanup
+                escalus:send(Alice, escalus_stanza:roster_remove_contact(BobJid)) % cleanup
         end).
 
 process_rosteritems_list_simple(Config) ->
@@ -644,6 +649,9 @@ push_roster_all(Config) ->
 
 push_roster_alltoall(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
+                BobJid = escalus_users:get_jid(Config, bob),
+                MikeJid = escalus_users:get_jid(Config, mike),
+                KateJid = escalus_users:get_jid(Config, kate),
                 {_, Domain, _} = get_user_data(alice, Config),
 
                 {_, 0} = ejabberdctl("push_roster_alltoall", [Domain, "MyGroup"], Config),
@@ -652,9 +660,9 @@ push_roster_alltoall(Config) ->
                 Roster = escalus:wait_for_stanza(Alice),
 
                 escalus:assert(is_roster_result, Roster),
-                escalus:assert(roster_contains, [bob], Roster),
-                escalus:assert(roster_contains, [mike], Roster),
-                escalus:assert(roster_contains, [kate], Roster)
+                escalus:assert(roster_contains, [BobJid], Roster),
+                escalus:assert(roster_contains, [MikeJid], Roster),
+                escalus:assert(roster_contains, [KateJid], Roster)
         end).
 
 %%--------------------------------------------------------------------
@@ -663,6 +671,7 @@ push_roster_alltoall(Config) ->
 
 set_last(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
+                BobJid = escalus_users:get_jid(Config, bob),
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 {BobName, Domain, _} = get_user_data(bob, Config),
 
@@ -676,7 +685,7 @@ set_last(Config) ->
                 Now = usec:to_sec(usec:from_now(erlang:now())),
                 TS = integer_to_list(Now - 7200),
                 {_, 0} = ejabberdctl("set_last", [BobName, Domain, TS, "Status"], Config),
-                escalus:send(Alice, escalus_stanza:last_activity(bob)),
+                escalus:send(Alice, escalus_stanza:last_activity(BobJid)),
                 LastAct = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_last_result, LastAct),
                 Seconds = list_to_integer(binary_to_list(

--- a/test/ejabberd_tests/tests/metrics_c2s_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_c2s_SUITE.erl
@@ -133,7 +133,7 @@ presence_direct_one(Config) ->
         {value, StanzaSent} = get_counter_value(xmppStanzaSent),
         {value, StanzaReceived} = get_counter_value(xmppStanzaReceived),
 
-        Presence = escalus_stanza:presence_direct(bob, <<"available">>),
+        Presence = escalus_stanza:presence_direct(escalus_client:short_jid(Bob), <<"available">>),
         escalus:send(Alice, Presence),
         escalus:wait_for_stanza(Bob),
 
@@ -250,11 +250,13 @@ error_presence(Config) ->
     {value, Errors} = get_counter_value(xmppErrorPresence),
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"available">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(
+                              escalus_client:short_jid(Bob), <<"available">>)),
         escalus:wait_for_stanza(Bob),
 
         ErrorElt = escalus_stanza:error_element(<<"cancel">>, <<"gone">>),
-        Presence = escalus_stanza:presence_direct(alice, <<"error">>, [ErrorElt]),
+        Presence = escalus_stanza:presence_direct(escalus_client:short_jid(Alice),
+                                                  <<"error">>, [ErrorElt]),
         escalus:send(Bob, Presence),
         escalus:wait_for_stanza(Alice),
 
@@ -265,7 +267,8 @@ error_presence(Config) ->
 error_iq(Config) ->
     {value, Errors} = get_counter_value(xmppErrorIq),
 
-    Alice = escalus_users:get_user_by_name(alice),
+    Users = escalus_config:get_config(escalus_users, Config),
+    Alice = escalus_users:get_user_by_name(alice, Users),
     escalus_users:create_user(Config, Alice),
 
     timer:sleep(?WAIT_TIME),

--- a/test/ejabberd_tests/tests/metrics_roster_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_roster_SUITE.erl
@@ -163,12 +163,14 @@ subscribe(ConfigIn) ->
     Config = mongoose_metrics(ConfigIn, [{['_', modPresenceSubscriptions], 1}]),
 
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_client:short_jid(Bob),
+        AliceJid = escalus_client:short_jid(Alice),
 
         %% add contact
         add_sample_contact(Alice, Bob),
 
         %% subscribe
-        escalus_client:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus_client:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus_client:wait_for_stanza(Alice),
         escalus_client:send(Alice, escalus_stanza:iq_result(PushReq)),
 
@@ -185,7 +187,7 @@ subscribe(ConfigIn) ->
         escalus_client:wait_for_stanza(Bob),
 
         %% Bob sends subscribed presence
-        escalus_client:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribed">>)),
+        escalus_client:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
         escalus_client:wait_for_stanzas(Alice, 3),
@@ -200,12 +202,14 @@ decline_subscription(ConfigIn) ->
     Config = mongoose_metrics(ConfigIn, [{['_', modPresenceUnsubscriptions], 1}]),
 
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_client:short_jid(Bob),
+        AliceJid = escalus_client:short_jid(Alice),
 
         %% add contact
         add_sample_contact(Alice, Bob),
 
         %% subscribe
-        escalus_client:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus_client:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus_client:wait_for_stanza(Alice),
         escalus_client:send(Alice, escalus_stanza:iq_result(PushReq)),
 
@@ -213,7 +217,7 @@ decline_subscription(ConfigIn) ->
         escalus_client:wait_for_stanza(Bob),
 
         %% Bob refuses subscription
-        escalus_client:send(Bob, escalus_stanza:presence_direct(alice, <<"unsubscribed">>)),
+        escalus_client:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"unsubscribed">>)),
 
         %% Alice receives subscribed
         escalus_client:wait_for_stanzas(Alice, 2)
@@ -225,10 +229,13 @@ unsubscribe(ConfigIn) ->
     Config = mongoose_metrics(ConfigIn, [{['_', modPresenceUnsubscriptions], 1}]),
 
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_client:short_jid(Bob),
+        AliceJid = escalus_client:short_jid(Alice),
+
         %% add contact
         add_sample_contact(Alice, Bob),
         %% subscribe
-        escalus_client:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus_client:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus_client:wait_for_stanza(Alice),
 
         escalus_client:send(Alice, escalus_stanza:iq_result(PushReq)),
@@ -245,7 +252,7 @@ unsubscribe(ConfigIn) ->
         escalus_client:wait_for_stanza(Bob),
 
         %% Bob sends subscribed presence
-        escalus_client:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribed">>)),
+        escalus_client:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
         escalus_client:wait_for_stanzas(Alice, 2),
@@ -257,7 +264,7 @@ unsubscribe(ConfigIn) ->
         escalus_assert:is_roster_set(PushReqB1),
 
         %% Alice sends unsubscribe
-        escalus_client:send(Alice, escalus_stanza:presence_direct(bob, <<"unsubscribe">>)),
+        escalus_client:send(Alice, escalus_stanza:presence_direct(BobJid, <<"unsubscribe">>)),
 
         PushReqA2 = escalus_client:wait_for_stanza(Alice),
         escalus_client:send(Alice, escalus_stanza:iq_result(PushReqA2)),

--- a/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
@@ -55,10 +55,10 @@ host() -> <<"localhost">>.
 
 init_per_suite(Config0) ->
     Config1 = escalus:init_per_suite(Config0),
-    escalus:create_users(Config1, escalus:get_users({by_name, [alice, bob]})).
+    escalus:create_users(Config1, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
-    escalus:delete_users(Config, {by_name, [alice, bob]}),
+    escalus:delete_users(Config, [alice, bob]),
     escalus:end_per_suite(Config).
 
 init_per_group(mod_http_notification_tests, Config) ->
@@ -124,9 +124,11 @@ simple_message_failing_listener(Config) ->
     do_simple_message(Config, <<"Hi, Failing!">>).
 
 do_simple_message(Config, Msg) ->
+    BobJid = escalus_users:get_jid(Config, bob),
+
     %% Alice sends a message to Bob, who is offline
     escalus:story(Config, [{alice, 1}],
-        fun(Alice) -> escalus:send(Alice, escalus_stanza:chat_to(bob, Msg)) end),
+        fun(Alice) -> escalus:send(Alice, escalus_stanza:chat_to(BobJid, Msg)) end),
 
     %% Bob logs in
     Bob = login_send_presence(Config, bob),

--- a/test/ejabberd_tests/tests/presence_SUITE.erl
+++ b/test/ejabberd_tests/tests/presence_SUITE.erl
@@ -117,7 +117,8 @@ available(Config) ->
 available_direct(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
 
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"available">>)),
+        BobJid = escalus_users:get_jid(Config, bob),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"available">>)),
         Received = escalus:wait_for_stanza(Bob),
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Alice, Received)
@@ -132,7 +133,8 @@ additions(Config) ->
             {<<"priority">>, <<"1">>},
             {<<"status">>, <<"Short break">>}
         ]),
-        Presence = escalus_stanza:presence_direct(bob, <<"available">>, Tags),
+        BobJid = escalus_users:get_jid(Config, bob),
+        Presence = escalus_stanza:presence_direct(BobJid, <<"available">>, Tags),
         escalus:send(Alice, Presence),
 
         Received = escalus:wait_for_stanza(Bob),
@@ -172,12 +174,14 @@ negative_priority_presence(Config) ->
 
 invisible_presence(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_users:get_jid(Config, bob),
+        AliceJid = escalus_users:get_jid(Config, alice),
 
         %% Alice adds Bob as a contact
         add_sample_contact(Alice, Bob),
 
         %% She subscribes to his presences
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus:wait_for_stanza(Alice),
         escalus:assert(is_roster_set, PushReq),
         escalus:send(Alice, escalus_stanza:iq_result(PushReq)),
@@ -196,7 +200,7 @@ invisible_presence(Config) ->
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
-        escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribed">>)),
+        escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
         Stanzas = escalus:wait_for_stanzas(Alice, 2),
@@ -249,7 +253,8 @@ add_contact(Config) ->
         Received2 = escalus:wait_for_stanza(Alice),
 
         escalus:assert(is_roster_result, Received2),
-        escalus:assert(roster_contains, [bob], Received2)
+        BobJid = escalus_users:get_jid(Config, bob),
+        escalus:assert(roster_contains, [BobJid], Received2)
 
         end).
 
@@ -307,7 +312,8 @@ versioning(Config) ->
         Received2 = escalus:wait_for_stanza(Alice),
 
         escalus:assert(is_roster_result, Received2),
-        escalus:assert(roster_contains, [bob], Received2),
+        BobJid = escalus_users:get_jid(Config, bob),
+        escalus:assert(roster_contains, [BobJid], Received2),
 
         %% check version
 
@@ -331,12 +337,14 @@ versioning_no_store(Config) ->
 
 subscribe(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        BobJid = escalus_users:get_jid(Config, bob),
+        AliceJid = escalus_users:get_jid(Config, alice),
 
         %% Alice adds Bob as a contact
         add_sample_contact(Alice, Bob),
 
         %% She subscribes to his presences
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus:wait_for_stanza(Alice),
         escalus:assert(is_roster_set, PushReq),
         escalus:send(Alice, escalus_stanza:iq_result(PushReq)),
@@ -355,7 +363,7 @@ subscribe(Config) ->
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
-        escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribed">>)),
+        escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
         Stanzas = escalus:wait_for_stanzas(Alice, 2),
@@ -380,12 +388,14 @@ subscribe(Config) ->
 
 subscribe_decline(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_users:get_jid(Config, bob),
+        AliceJid = escalus_users:get_jid(Config, alice),
 
         %% add contact
         add_sample_contact(Alice, Bob),
 
         %% subscribe
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus:wait_for_stanza(Alice),
         escalus_assert:is_roster_set(PushReq),
         escalus:send(Alice, escalus_stanza:iq_result(PushReq)),
@@ -395,7 +405,7 @@ subscribe_decline(Config) ->
         escalus:assert(is_presence_with_type, [<<"subscribe">>], Received),
 
         %% Bob refuses subscription
-        escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"unsubscribed">>)),
+        escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"unsubscribed">>)),
 
         %% Alice receives subscribed
         Stanzas = escalus:wait_for_stanzas(Alice, 2),
@@ -406,12 +416,14 @@ subscribe_decline(Config) ->
 
 subscribe_relog(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        BobJid = escalus_users:get_jid(Config, bob),
+        AliceJid = escalus_users:get_jid(Config, alice),
 
         %% Alice adds Bob as a contact
         add_sample_contact(Alice, Bob),
 
         %% She subscribes to his presences
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus:wait_for_stanza(Alice),
         escalus:assert(is_roster_set, PushReq),
         escalus:send(Alice, escalus_stanza:iq_result(PushReq)),
@@ -442,24 +454,26 @@ subscribe_relog(Config) ->
                 end,
                 fun(S) ->
                     escalus_pred:is_presence_with_type(<<"subscribe">>, S)
-                    andalso escalus_pred:is_stanza_from(alice, S)
+                    andalso escalus_pred:is_stanza_from(AliceJid, S)
                 end
             ], Stanzas),
 
         escalus_client:stop(NewBob),
 
-        escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"unsubscribed">>))
+        escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"unsubscribed">>))
 
         end).
 
 unsubscribe(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_users:get_jid(Config, bob),
+        AliceJid = escalus_users:get_jid(Config, alice),
 
         %% add contact
         add_sample_contact(Alice, Bob),
 
         %% subscribe
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus:wait_for_stanza(Alice),
         escalus:send(Alice, escalus_stanza:iq_result(PushReq)),
 
@@ -475,7 +489,7 @@ unsubscribe(Config) ->
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
-        escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribed">>)),
+        escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
         Stanzas = escalus:wait_for_stanzas(Alice, 2),
@@ -488,7 +502,7 @@ unsubscribe(Config) ->
         escalus_assert:is_roster_set(PushReqB1),
 
         %% Alice sends unsubscribe
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"unsubscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"unsubscribe">>)),
 
         PushReqA2 = escalus:wait_for_stanza(Alice),
         escalus_assert:is_roster_set(PushReqA2),
@@ -507,11 +521,14 @@ unsubscribe(Config) ->
 
 remove_unsubscribe(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice,Bob) ->
+        BobJid = escalus_users:get_jid(Config, bob),
+        AliceJid = escalus_users:get_jid(Config, alice),
+
         %% add contact
         add_sample_contact(Alice, Bob),
 
         %% subscribe
-        escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribe">>)),
+        escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"subscribe">>)),
         PushReq = escalus:wait_for_stanza(Alice),
         escalus:send(Alice, escalus_stanza:iq_result(PushReq)),
 
@@ -527,7 +544,7 @@ remove_unsubscribe(Config) ->
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
-        escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribed">>)),
+        escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
         Stanzas = [escalus:wait_for_stanza(Alice),

--- a/test/ejabberd_tests/tests/private_SUITE.erl
+++ b/test/ejabberd_tests/tests/private_SUITE.erl
@@ -102,7 +102,7 @@ get_other_user(Config) ->
 
                           %% Alice asks for Bob's private data
                           GetIQ = escalus_stanza:private_get(NS, <<"my_element">>),
-                          IQ = escalus_stanza:to(GetIQ, bob),
+                          IQ = escalus_stanza:to(GetIQ, escalus_users:get_jid(Config, bob)),
                           escalus_client:send(Alice, IQ),
 
                           %% Alice gets an error
@@ -117,7 +117,8 @@ set_other_user(Config) ->
                           NS = <<"bob:private:ns">>,
 
                           %% Alice asks for Bob's private data
-                          IQ = escalus_stanza:to(escalus_stanza:private_set(my_banana(NS)), bob),
+                          IQ = escalus_stanza:to(escalus_stanza:private_set(my_banana(NS)),
+                                                 escalus_users:get_jid(Config, bob)),
                           escalus_client:send(Alice, IQ),
 
                           %% Alice gets a forbidden error

--- a/test/ejabberd_tests/tests/sic_SUITE.erl
+++ b/test/ejabberd_tests/tests/sic_SUITE.erl
@@ -76,7 +76,7 @@ user_sic(Config) ->
 forbidden_user_sic(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
         %% Alice sends a SIC IQ stanza to get Bob's IP
-        escalus:send(Alice, sic_iq_get(bob)),
+        escalus:send(Alice, sic_iq_get(escalus_users:get_jid(Config, bob))),
         %% Alice should get <forbidden/> error
         Stanza = escalus:wait_for_stanza(Alice),
         escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Stanza)


### PR DESCRIPTION
Not all of them fixed. Privacy suite requires some extra refactoring.
So, far I want this first bunch of fixes to be merged, it will simplify our work with travis (less noise when test fails).
No other changes in the test, just passing Config in testcases where it's trivial to do..