### PR TITLE
Fix return type of xml:get_path_s

### DIFF
--- a/apps/ejabberd/src/xml.erl
+++ b/apps/ejabberd/src/xml.erl
@@ -121,7 +121,8 @@ append_subtags(XE = #xmlel{children = SubTags1}, SubTags2) ->
     XE#xmlel{children = SubTags1 ++ SubTags2}.
 
 
--spec get_path_s(jlib:xmlel(), [{elem, binary()} | {attr, binary()} | cdata]) -> binary().
+-spec get_path_s(jlib:xmlel(), [{elem, binary()} | {attr, binary()} | cdata]) ->
+    iodata() | jlib:xmlel().
 get_path_s(El, []) ->
     El;
 get_path_s(El, [{elem, Name} | Path]) ->


### PR DESCRIPTION
A tiny fix to broaden the return type of `xml:get_path_s` so that it includes `iodata()` (the permitted type for cdata and a superset of `binary()`) and `jlib:xmlel()` which is returned if you request an `elem`.