### PR TITLE
make status ctl working for uptime longer than one day

### DIFF
--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -64,7 +64,7 @@
 
 -define(ASCII_SPACE_CHARACTER, $\s).
 -define(PRINT(Format, Args), io:format(lists:flatten(Format), Args)).
--define(TIME_HMS_FORMAT, "~B:~2.10.0B:~2.10.0B").
+-define(TIME_HMS_FORMAT, "~B days ~B hours ~B minutes ~B secs").
 -define(a2l(A), atom_to_list(A)).
 
 %%-----------------------------
@@ -909,8 +909,8 @@ get_mongoose_status() ->
 
 get_uptime() ->
     {MilliSeconds, _} = erlang:statistics(wall_clock),
-    {H, M, S} = calendar:seconds_to_time(MilliSeconds div 1000),
-    {uptime, [H, M, S]}.
+    {D, {H, M, S}} = calendar:seconds_to_daystime(MilliSeconds div 1000),
+    {uptime, [D, H, M, S]}.
 
 %%-----------------------------
 %% Lager specific helpers

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -64,7 +64,7 @@
 
 -define(ASCII_SPACE_CHARACTER, $\s).
 -define(PRINT(Format, Args), io:format(lists:flatten(Format), Args)).
--define(TIME_HMS_FORMAT, "~B days ~B hours ~B minutes ~B secs").
+-define(TIME_HMS_FORMAT, "~B days ~2.10.0B:~2.10.0B:~2.10.0B").
 -define(a2l(A), atom_to_list(A)).
 
 %%-----------------------------


### PR DESCRIPTION
This PR addresses https://github.com/esl/MongooseIM/issues/853

Proposed changes include:
* add `days` to uptime statistics in `mongooseimctl status` command

Before, it was `seconds_to_time/1` fun used. What Erlang documentation says about it:

> Computes the time from the specified number of seconds. Seconds must be less than the number of seconds per day (86400).

so the call was crashing every time uptime was longer than one day because it was called with
seconds returned by `erlang:statistics(wall_clock)` [1]

[1] https://github.com/esl/MongooseIM/blob/master/apps/ejabberd/src/ejabberd_ctl.erl#L911