### PR TITLE
Fix for`is_cached_user_exists` function crash

### DIFF
--- a/apps/ejabberd/src/ejabberd_users.erl
+++ b/apps/ejabberd/src/ejabberd_users.erl
@@ -4,7 +4,7 @@
 -export([start/1,
          stop/1,
          start_link/2,
-         is_user_exists/2]).
+         does_user_exist/2]).
 
 %% Hooks.
 -export([remove_user/2]).
@@ -68,13 +68,13 @@ start_link(ProcName, Host) ->
     gen_server:start_link({local, ProcName}, ?MODULE, [Host], []).
 
 
--spec is_user_exists(LUser :: ejabberd:luser(),
+-spec does_user_exist(LUser :: ejabberd:luser(),
                      LServer :: ejabberd:lserver() | string()) -> boolean().
-is_user_exists(LUser, LServer) ->
-    case is_cached_user_exists(LUser, LServer) of
+does_user_exist(LUser, LServer) ->
+    case does_cached_user_exist(LUser, LServer) of
         true -> true;
         false ->
-            case is_stored_user_exists(LUser, LServer) of
+            case does_stored_user_exist(LUser, LServer) of
                 true ->
                     put_user_into_cache(LUser, LServer),
                     true;
@@ -168,8 +168,8 @@ code_change(_OldVsn, State, _Extra) ->
 %% Helpers
 %%====================================================================
 
--spec is_stored_user_exists(ejabberd:luser(), ejabberd:lserver()) -> boolean().
-is_stored_user_exists(LUser, LServer) ->
+-spec does_stored_user_exist(ejabberd:luser(), ejabberd:lserver()) -> boolean().
+does_stored_user_exist(LUser, LServer) ->
     ejabberd_auth:is_user_exists(LUser, LServer)
     andalso not is_anonymous_user(LUser, LServer).
 
@@ -184,8 +184,8 @@ is_anonymous_user(LUser, LServer) ->
     end.
 
 
--spec is_cached_user_exists(ejabberd:luser(), ejabberd:lserver() | string()) -> boolean().
-is_cached_user_exists(LUser, LServer) ->
+-spec does_cached_user_exist(ejabberd:luser(), ejabberd:lserver() | string()) -> boolean().
+does_cached_user_exist(LUser, LServer) ->
     Key = key(LUser, LServer),
     Tab = tbl_name(LServer),
     ets:info(Tab) =/= undefined andalso ets:member(Tab, Key).

--- a/apps/ejabberd/src/ejabberd_users.erl
+++ b/apps/ejabberd/src/ejabberd_users.erl
@@ -188,7 +188,7 @@ is_anonymous_user(LUser, LServer) ->
 is_cached_user_exists(LUser, LServer) ->
     Key = key(LUser, LServer),
     Tab = tbl_name(LServer),
-    ets:member(Tab, Key).
+    ets:info(Tab) =/= undefined andalso ets:member(Tab, Key).
 
 
 -spec put_user_into_cache(ejabberd:luser(), ejabberd:lserver()) -> 'ok'.

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -287,7 +287,7 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Packet}) ->
     ?DEBUG("Receive packet~n    from ~p ~n    to ~p~n    packet ~p.",
            [From, To, Packet]),
     {AmpEvent, PacketAfterArchive} =
-        case ejabberd_users:is_user_exists(LUser, LServer) of
+        case ejabberd_users:does_user_exist(LUser, LServer) of
             false ->
                 {mam_failed, Packet};
             true ->

--- a/test/ejabberd_tests/tests/login_SUITE.erl
+++ b/test/ejabberd_tests/tests/login_SUITE.erl
@@ -224,13 +224,10 @@ check_user_exist(Config) ->
   %% when
   [{_, AdminSpec}] = escalus_users:get_users([admin]),
   [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
-  ok = escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
-  %% then
+  %% admin user already registered
   true = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, AdminS]),
   false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
-  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
-  %% cleanup
-  ok = escalus_ejabberd:rpc(ejabberd_auth, remove_user, [AdminU, AdminS]).
+  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]).
 
 register(Config) ->
     [{Name1, UserSpec1}, {Name2, UserSpec2}] = escalus_users:get_users([alice, bob]),

--- a/test/ejabberd_tests/tests/login_SUITE.erl
+++ b/test/ejabberd_tests/tests/login_SUITE.erl
@@ -47,7 +47,6 @@ all() ->
 
 groups() ->
     [{register, [sequence], [register,
-                             check_user_exist,
                              already_registered,
                              check_unregistered]},
      {bad_registration, [no_sequence], [null_password]},
@@ -220,14 +219,6 @@ end_per_testcase(CaseName, Config) ->
 %% Message tests
 %%--------------------------------------------------------------------
 
-check_user_exist(Config) ->
-  %% when
-  [{_, AdminSpec}] = escalus_users:get_users([admin]),
-  [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
-  %% admin user already registered
-  true = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, AdminS]),
-  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
-  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]).
 
 register(Config) ->
     [{Name1, UserSpec1}, {Name2, UserSpec2}] = escalus_users:get_users([alice, bob]),

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -73,7 +73,8 @@
          muc_querying_for_all_messages_with_jid/1,
          muc_light_simple/1,
          run_prefs_cases/1,
-         run_set_and_get_prefs_cases/1]).
+         run_set_and_get_prefs_cases/1,
+         check_user_exist/1]).
 
 -import(muc_helper,
         [muc_host/0,
@@ -213,7 +214,8 @@ basic_group_names() ->
      archived,
      policy_violation,
      nostore,
-     prefs_cases
+     prefs_cases,
+     impl_specific
     ].
 
 all() ->
@@ -266,7 +268,9 @@ basic_groups() ->
      {with_rsm,         [], with_rsm_cases()},
      {with_rsm03,       [], with_rsm_cases()},
      {with_rsm04,       [], with_rsm_cases()},
-     {prefs_cases,      [], prefs_cases()}].
+     {prefs_cases,      [], prefs_cases()},
+     {impl_specific,    [], impl_specific()}
+    ].
 
 bootstrapped_cases() ->
      [purge_old_single_message,
@@ -351,6 +355,9 @@ prefs_cases() ->
      query_get_request,
      run_prefs_cases,
      run_set_and_get_prefs_cases].
+
+impl_specific() ->
+  [check_user_exist].
 
 suite() ->
     escalus:suite().
@@ -2002,3 +2009,16 @@ run_set_and_get_prefs_cases(Config) ->
                                                                        Namespace <- namespaces()]
         end,
     escalus:story(Config, [{alice, 1}], F).
+
+%% MAM's implementation specific test
+check_user_exist(Config) ->
+  %% when
+  [{_, AdminSpec}] = escalus_users:get_users([admin]),
+  [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
+  ok = escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+  %% admin user already registered
+  true = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, AdminS]),
+  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
+  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
+  %% cleanup
+  ok = escalus_ejabberd:rpc(ejabberd_auth, remove_user, [AdminU, AdminS]).


### PR DESCRIPTION
This PR initially addressed https://github.com/esl/MongooseIM/issues/890
but then it turned out that cassandra backend has been temporary removed so
now, it's not possible to reproduce this particular issue. 
However, I introduce the fix for that bug in case to avoid similar problems in future.

When function `ejabberd_users:is_chached_user_exists/2` was called with an unexistent domain name the crash occurred instead of returning `false` value. 
