### PR TITLE
Global metrics only switch

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -70,8 +70,7 @@
 %% TODO: TBH this name smells.
 -type passwordlike() :: binary() | scram:scram_tuple().
 
--define(METRIC(Host, Name), [backends, auth, Host, Name]).
--define(METRIC_GLOBAL(Name), ?METRIC(global, Name)).
+-define(METRIC(Name), [backends, auth, Name]).
 
 %%%----------------------------------------------------------------------
 %%% API
@@ -610,13 +609,13 @@ auth_modules(LServer) ->
 
 ensure_metrics(Host) ->
     Metrics = [check_password, try_register, does_user_exist],
-    [mongoose_metrics:ensure_metric(?METRIC(Host, Metric), ?METRIC_GLOBAL(Metric), histogram)
+    [mongoose_metrics:ensure_metric(Host, ?METRIC(Metric), histogram)
      || Metric <- Metrics].
 
 -spec timed_call(ejabberd:lserver(), term(), fun(), list()) -> term().
 timed_call(LServer, Metric, Fun, Args) ->
     {Time, Result} = timer:tc(Fun, Args),
-    mongoose_metrics:update(?METRIC(LServer, Metric), ?METRIC_GLOBAL(Metric), Time),
+    mongoose_metrics:update(LServer, ?METRIC(Metric), Time),
     Result.
 
 %% Library functions for reuse in ejabberd_auth_* modules

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -71,6 +71,8 @@
 -type passwordlike() :: binary() | scram:scram_tuple().
 
 -define(METRIC(Host, Name), [backends, auth, Host, Name]).
+-define(METRIC_GLOBAL(Name), ?METRIC(global, Name)).
+
 %%%----------------------------------------------------------------------
 %%% API
 %%%----------------------------------------------------------------------
@@ -608,13 +610,13 @@ auth_modules(LServer) ->
 
 ensure_metrics(Host) ->
     Metrics = [check_password, try_register, does_user_exist],
-    [mongoose_metrics:ensure_metric(?METRIC(Host, Metric), histogram)
+    [mongoose_metrics:ensure_metric(?METRIC(Host, Metric), ?METRIC_GLOBAL(Metric), histogram)
      || Metric <- Metrics].
 
 -spec timed_call(ejabberd:lserver(), term(), fun(), list()) -> term().
 timed_call(LServer, Metric, Fun, Args) ->
     {Time, Result} = timer:tc(Fun, Args),
-    mongoose_metrics:update(?METRIC(LServer, Metric), Time),
+    mongoose_metrics:update(?METRIC(LServer, Metric), ?METRIC_GLOBAL(Metric), Time),
     Result.
 
 %% Library functions for reuse in ejabberd_auth_* modules

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -867,13 +867,13 @@ session_established({xmlstreamelement,
                       session_established, StateData);
 session_established({xmlstreamelement,
                      #xmlel{name = <<"inactive">>} = El}, State) ->
-    mongoose_metrics:update([State#state.server, modCSIInactive], 1),
+    mongoose_metrics:update([State#state.server, modCSIInactive], [global, modCSIInactive], 1),
 
     maybe_inactivate_session(xml:get_tag_attr_s(<<"xmlns">>, El), State);
 
 session_established({xmlstreamelement,
                      #xmlel{name = <<"active">>} = El}, State) ->
-    mongoose_metrics:update([State#state.server, modCSIActive], 1),
+    mongoose_metrics:update([State#state.server, modCSIActive], [global, modCSIActive], 1),
 
     maybe_activate_session(xml:get_tag_attr_s(<<"xmlns">>, El), State);
 
@@ -1526,7 +1526,7 @@ change_shaper(StateData, JID) ->
 send_text(StateData, Text) ->
     ?DEBUG("Send XML on stream = ~p", [Text]),
     Size = size(Text),
-    mongoose_metrics:update([data, xmpp, sent, xml_stanza_size], Size),
+    mongoose_metrics:update(undefined, [data, xmpp, sent, xml_stanza_size], Size),
     (StateData#state.sockmod):send(StateData#state.socket, Text).
 
 -spec maybe_send_element_safe(state(), El :: jlib:xmlel()) -> any().

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -867,13 +867,13 @@ session_established({xmlstreamelement,
                       session_established, StateData);
 session_established({xmlstreamelement,
                      #xmlel{name = <<"inactive">>} = El}, State) ->
-    mongoose_metrics:update([State#state.server, modCSIInactive], [global, modCSIInactive], 1),
+    mongoose_metrics:update(State#state.server, modCSIInactive, 1),
 
     maybe_inactivate_session(xml:get_tag_attr_s(<<"xmlns">>, El), State);
 
 session_established({xmlstreamelement,
                      #xmlel{name = <<"active">>} = El}, State) ->
-    mongoose_metrics:update([State#state.server, modCSIActive], [global, modCSIActive], 1),
+    mongoose_metrics:update(State#state.server, modCSIActive, 1),
 
     maybe_activate_session(xml:get_tag_attr_s(<<"xmlns">>, El), State);
 
@@ -1526,7 +1526,7 @@ change_shaper(StateData, JID) ->
 send_text(StateData, Text) ->
     ?DEBUG("Send XML on stream = ~p", [Text]),
     Size = size(Text),
-    mongoose_metrics:update(undefined, [data, xmpp, sent, xml_stanza_size], Size),
+    mongoose_metrics:update(global, [data, xmpp, sent, xml_stanza_size], Size),
     (StateData#state.sockmod):send(StateData#state.socket, Text).
 
 -spec maybe_send_element_safe(state(), El :: jlib:xmlel()) -> any().

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -1011,7 +1011,7 @@ handle_local_config_add(#local_config{key = {cassandra_server,_,_}}) ->
     mongoose_cassandra:stop(),
     mongoose_cassandra:start();
 handle_local_config_add(#local_config{key=Key} = El) ->
-    case Key of
+    case can_be_ignored(Key) of
         true ->
             ok;
         false ->
@@ -1170,7 +1170,7 @@ add_virtual_host(Host) ->
 
 -spec can_be_ignored(Key :: atom()) -> boolean().
 can_be_ignored(Key) when is_atom(Key) ->
-    L = [domain_certfile, s2s],
+    L = [domain_certfile, s2s, all_metrics_are_global],
     lists:member(Key,L).
 
 -spec remove_virtual_host(ejabberd:server()) -> any().

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -574,6 +574,8 @@ process_term(Term, State) ->
             add_option(sasl_mechanisms, Mechanisms, State);
         {http_connections, HttpConnections} ->
             add_option(http_connections, HttpConnections, State);
+        {all_metrics_are_global, Value} ->
+            add_option(all_metrics_are_global, Value, State);
         {_Opt, _Val} ->
             lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
                         State, State#state.hosts)

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -204,7 +204,7 @@ handle_info({Tag, _TCPSocket, Data},
   when (Tag == tcp) or (Tag == ssl) ->
     case SockMod of
 	ejabberd_tls ->
-        mongoose_metrics:update([data, xmpp, received, encrypted_size], size(Data)),
+        mongoose_metrics:update(undefined, [data, xmpp, received, encrypted_size], size(Data)),
 	    case ejabberd_tls:recv_data(Socket, Data) of
 		{ok, TLSData} ->
 		    {noreply, process_data(TLSData, State),
@@ -213,7 +213,7 @@ handle_info({Tag, _TCPSocket, Data},
 		    {stop, normal, State}
 	    end;
 	ejabberd_zlib ->
-        mongoose_metrics:update([data, xmpp, received, compressed_size], size(Data)),
+        mongoose_metrics:update(undefined, [data, xmpp, received, compressed_size], size(Data)),
 	    case ejabberd_zlib:recv_data(Socket, Data) of
 		{ok, ZlibData} ->
 		    {noreply, process_data(ZlibData, State),
@@ -322,7 +322,7 @@ process_data(Data, #state{parser = Parser,
                           c2s_pid = C2SPid} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
     Size = size(Data),
-    mongoose_metrics:update([data, xmpp, received, xml_stanza_size], Size),
+    mongoose_metrics:update(undefined, [data, xmpp, received, xml_stanza_size], Size),
 
     maybe_run_keep_alive_hook(Size, State),
     case exml_stream:parse(Parser, Data) of

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -204,7 +204,7 @@ handle_info({Tag, _TCPSocket, Data},
   when (Tag == tcp) or (Tag == ssl) ->
     case SockMod of
 	ejabberd_tls ->
-        mongoose_metrics:update(undefined, [data, xmpp, received, encrypted_size], size(Data)),
+        mongoose_metrics:update(global, [data, xmpp, received, encrypted_size], size(Data)),
 	    case ejabberd_tls:recv_data(Socket, Data) of
 		{ok, TLSData} ->
 		    {noreply, process_data(TLSData, State),
@@ -213,7 +213,7 @@ handle_info({Tag, _TCPSocket, Data},
 		    {stop, normal, State}
 	    end;
 	ejabberd_zlib ->
-        mongoose_metrics:update(undefined, [data, xmpp, received, compressed_size], size(Data)),
+        mongoose_metrics:update(global, [data, xmpp, received, compressed_size], size(Data)),
 	    case ejabberd_zlib:recv_data(Socket, Data) of
 		{ok, ZlibData} ->
 		    {noreply, process_data(ZlibData, State),
@@ -322,7 +322,7 @@ process_data(Data, #state{parser = Parser,
                           c2s_pid = C2SPid} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
     Size = size(Data),
-    mongoose_metrics:update(undefined, [data, xmpp, received, xml_stanza_size], Size),
+    mongoose_metrics:update(global, [data, xmpp, received, xml_stanza_size], Size),
 
     maybe_run_keep_alive_hook(Size, State),
     case exml_stream:parse(Parser, Data) of

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -349,7 +349,7 @@ init([]) ->
                          {record_name, external_component}]),
     mnesia:add_table_copy(external_component_global, node(), ram_copies),
     compile_routing_module(),
-    mongoose_metrics:ensure_metric(undefined, [global, routingErrors], spiral),
+    mongoose_metrics:ensure_metric(global, routingErrors, spiral),
 
     {ok, #state{}}.
 
@@ -440,7 +440,7 @@ route(From, To, Packet, []) ->
     ?ERROR_MSG("error routing from=~ts to=~ts, packet=~ts, reason: no more routing modules",
                [jid:to_binary(From), jid:to_binary(To),
                 exml:to_binary(Packet)]),
-    mongoose_metrics:update(undefined, [global, routingErrors], 1),
+    mongoose_metrics:update(global, routingErrors, 1),
     ok;
 route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
     ?DEBUG("Using module ~p", [M]),

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -349,7 +349,7 @@ init([]) ->
                          {record_name, external_component}]),
     mnesia:add_table_copy(external_component_global, node(), ram_copies),
     compile_routing_module(),
-    mongoose_metrics:ensure_metric([global, routingErrors], spiral),
+    mongoose_metrics:ensure_metric(undefined, [global, routingErrors], spiral),
 
     {ok, #state{}}.
 
@@ -440,7 +440,7 @@ route(From, To, Packet, []) ->
     ?ERROR_MSG("error routing from=~ts to=~ts, packet=~ts, reason: no more routing modules",
                [jid:to_binary(From), jid:to_binary(To),
                 exml:to_binary(Packet)]),
-    mongoose_metrics:update([global, routingErrors], 1),
+    mongoose_metrics:update(undefined, [global, routingErrors], 1),
     ok;
 route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
     ?DEBUG("Using module ~p", [M]),

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -118,7 +118,7 @@
 %%--------------------------------------------------------------------
 -spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
 start_link() ->
-    mongoose_metrics:ensure_metric(undefined, ?UNIQUE_COUNT_CACHE, gauge),
+    mongoose_metrics:ensure_metric(global, ?UNIQUE_COUNT_CACHE, gauge),
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 
@@ -338,7 +338,7 @@ get_session_pid(User, Server, Resource) ->
 get_unique_sessions_number() ->
     try
         C = ?SM_BACKEND:unique_count(),
-        mongoose_metrics:update(undefined, ?UNIQUE_COUNT_CACHE, C),
+        mongoose_metrics:update(global, ?UNIQUE_COUNT_CACHE, C),
         C
     catch
         _:_ ->
@@ -958,7 +958,7 @@ sm_backend(Backend) ->
 
 -spec get_cached_unique_count() -> non_neg_integer().
 get_cached_unique_count() ->
-    case mongoose_metrics:get_metric_value(?UNIQUE_COUNT_CACHE) of
+    case mongoose_metrics:get_metric_value(global, ?UNIQUE_COUNT_CACHE) of
         {ok, DataPoints} ->
             proplists:get_value(value, DataPoints);
         _ ->

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -118,7 +118,7 @@
 %%--------------------------------------------------------------------
 -spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
 start_link() ->
-    mongoose_metrics:ensure_metric(?UNIQUE_COUNT_CACHE, gauge),
+    mongoose_metrics:ensure_metric(undefined, ?UNIQUE_COUNT_CACHE, gauge),
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 
@@ -338,7 +338,7 @@ get_session_pid(User, Server, Resource) ->
 get_unique_sessions_number() ->
     try
         C = ?SM_BACKEND:unique_count(),
-        mongoose_metrics:update(?UNIQUE_COUNT_CACHE, C),
+        mongoose_metrics:update(undefined, ?UNIQUE_COUNT_CACHE, C),
         C
     catch
         _:_ ->

--- a/apps/ejabberd/src/ejabberd_tls.erl
+++ b/apps/ejabberd/src/ejabberd_tls.erl
@@ -141,7 +141,7 @@ send(#tlssock{tcpsock = TCPSocket, tlsport = Port} = TLSSock, Packet) ->
             case port_control(Port, ?GET_ENCRYPTED_OUTPUT, []) of
                 <<0, Out/binary>> ->
                     mongoose_metrics:update(
-                      undefined, [data, xmpp, sent, encrypted_size], size(Out)),
+                      global, [data, xmpp, sent, encrypted_size], size(Out)),
                     gen_tcp:send(TCPSocket, Out);
                 <<1, Error/binary>> ->
                     {error, binary_to_list(Error)}

--- a/apps/ejabberd/src/ejabberd_tls.erl
+++ b/apps/ejabberd/src/ejabberd_tls.erl
@@ -140,7 +140,8 @@ send(#tlssock{tcpsock = TCPSocket, tlsport = Port} = TLSSock, Packet) ->
             %?PRINT("OUT: ~p~n", [{TCPSocket, lists:flatten(Packet)}]),
             case port_control(Port, ?GET_ENCRYPTED_OUTPUT, []) of
                 <<0, Out/binary>> ->
-                    mongoose_metrics:update([data, xmpp, sent, encrypted_size], size(Out)),
+                    mongoose_metrics:update(
+                      undefined, [data, xmpp, sent, encrypted_size], size(Out)),
                     gen_tcp:send(TCPSocket, Out);
                 <<1, Error/binary>> ->
                     {error, binary_to_list(Error)}

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -95,7 +95,7 @@ send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of
 	<<0, Out/binary>> ->
-        mongoose_metrics:update([data, xmpp, sent, compressed_size], size(Out)),
+        mongoose_metrics:update(undefined, [data, xmpp, sent, compressed_size], size(Out)),
 	    SockMod:send(Socket, Out);
 	<<1, Error/binary>> ->
 	    {error, erlang:binary_to_existing_atom(Error, utf8)};

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -95,7 +95,7 @@ send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of
 	<<0, Out/binary>> ->
-        mongoose_metrics:update(undefined, [data, xmpp, sent, compressed_size], size(Out)),
+        mongoose_metrics:update(global, [data, xmpp, sent, compressed_size], size(Out)),
 	    SockMod:send(Socket, Out);
 	<<1, Error/binary>> ->
 	    {error, erlang:binary_to_existing_atom(Error, utf8)};

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -160,23 +160,18 @@ generate_fun_body(true, BaseModule, RealBackendModule, F, Args) ->
     FS = atom_to_list(F),
 %%     returned is the following
 %%     {Time, Result} = timer:tc(Backend, F, Args),
-%%     mongoose_metrics:update(undefined, ?METRIC(Backend, F), Time),
+%%     mongoose_metrics:update(global, ?METRIC(Backend, F), Time),
 %%     Result.
     ["    {Time, Result} = timer:tc(",RealBackendModule,", ",FS,", [",Args,"]),\n",
-     "    mongoose_metrics:update(undefined, ",
+     "    mongoose_metrics:update(global, ",
           io_lib:format("~p", [?METRIC(BaseModule, F)]),
           ", Time),\n",
      "    Result.\n"].
 
 ensure_backend_metrics(Module, Ops) ->
     EnsureFun = fun(Op) ->
-        case exometer:info(?METRIC(Module, Op), type) of
-            undefined ->
-                exometer:new(?METRIC(Module, Op), histogram);
-            _ ->
-                ok
-        end
-    end,
+                        mongoose_metrics:ensure_metric(global, ?METRIC(Module, Op), histogram)
+                end,
     lists:foreach(EnsureFun, Ops).
 
 -spec is_app_running(_) -> boolean().

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -160,10 +160,10 @@ generate_fun_body(true, BaseModule, RealBackendModule, F, Args) ->
     FS = atom_to_list(F),
 %%     returned is the following
 %%     {Time, Result} = timer:tc(Backend, F, Args),
-%%     mongoose_metrics:update(?METRIC(Backend, F), Time),
+%%     mongoose_metrics:update(undefined, ?METRIC(Backend, F), Time),
 %%     Result.
     ["    {Time, Result} = timer:tc(",RealBackendModule,", ",FS,", [",Args,"]),\n",
-     "    mongoose_metrics:update(",
+     "    mongoose_metrics:update(undefined, ",
           io_lib:format("~p", [?METRIC(BaseModule, F)]),
           ", Time),\n",
      "    Result.\n"].

--- a/apps/ejabberd/src/mod_http_notification.erl
+++ b/apps/ejabberd/src/mod_http_notification.erl
@@ -18,9 +18,9 @@
 -define(DEFAULT_POOL_NAME, http_pool).
 -define(DEFAULT_PATH, "").
 
--define(SENT_METRIC(Host), [Host, mod_http_notifications, sent]).
--define(FAILED_METRIC(Host), [Host, mod_http_notifications, failed]).
--define(RESPONSE_METRIC(Host), [Host, mod_http_notifications, response_time]).
+-define(SENT_METRIC, [mod_http_notifications, sent]).
+-define(FAILED_METRIC, [mod_http_notifications, failed]).
+-define(RESPONSE_METRIC, [mod_http_notifications, response_time]).
 
 start(Host, _Opts) ->
     ensure_metrics(Host),
@@ -81,16 +81,16 @@ make_req(Host, Sender, Receiver, Message) ->
     ok.
 
 ensure_metrics(Host) ->
-    mongoose_metrics:ensure_metric(?SENT_METRIC(Host), ?SENT_METRIC(global), spiral),
-    mongoose_metrics:ensure_metric(?FAILED_METRIC(Host), ?FAILED_METRIC(global), spiral),
-    mongoose_metrics:ensure_metric(?RESPONSE_METRIC(Host), ?RESPONSE_METRIC(global), histogram),
+    mongoose_metrics:ensure_metric(Host, ?SENT_METRIC, spiral),
+    mongoose_metrics:ensure_metric(Host, ?FAILED_METRIC, spiral),
+    mongoose_metrics:ensure_metric(Host, ?RESPONSE_METRIC, histogram),
     ok.
 record_result(Host, ok, Elapsed) ->
-    mongoose_metrics:update(?SENT_METRIC(Host), ?SENT_METRIC(global), 1),
-    mongoose_metrics:update(?RESPONSE_METRIC(Host), ?RESPONSE_METRIC(global), Elapsed),
+    mongoose_metrics:update(Host, ?SENT_METRIC, 1),
+    mongoose_metrics:update(Host, ?RESPONSE_METRIC, Elapsed),
     ok;
 record_result(Host, {error, Reason}, _) ->
-    mongoose_metrics:update(?FAILED_METRIC(Host), ?FAILED_METRIC(global), 1),
+    mongoose_metrics:update(Host, ?FAILED_METRIC, 1),
     ?WARNING_MSG("Sending http notification failed: ~p", [Reason]),
     ok.
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -205,10 +205,9 @@ start(Host, Opts) ->
     ejabberd_hooks:add(remove_user, Host, ?MODULE, remove_user, 50),
     ejabberd_hooks:add(anonymous_purge_hook, Host, ?MODULE, remove_user, 50),
     ejabberd_hooks:add(amp_determine_strategy, Host, ?MODULE, determine_amp_strategy, 20),
-    mongoose_metrics:ensure_metric(undefined, [backends, ?MODULE, lookup], histogram),
-    mongoose_metrics:ensure_metric(
-      [Host, modMamLookups, simple], [global, modMamLookups, simple], spiral),
-    mongoose_metrics:ensure_metric(undefined, [backends, ?MODULE, archive], histogram),
+    mongoose_metrics:ensure_metric(global, [backends, ?MODULE, lookup], histogram),
+    mongoose_metrics:ensure_metric(Host, [modMamLookups, simple], spiral),
+    mongoose_metrics:ensure_metric(global, [backends, ?MODULE, archive], histogram),
     ok.
 
 
@@ -743,7 +742,7 @@ lookup_messages(Host, ArcID, ArcJID, RSM, Borders, Start, End, Now,
          Start, End, Now, WithJID,
          PageSize, LimitPassed, MaxResultLimit, IsSimple]),
     Diff = timer:now_diff(os:timestamp(), StartT),
-    mongoose_metrics:update(undefined, [backends, ?MODULE, lookup], Diff),
+    mongoose_metrics:update(global, [backends, ?MODULE, lookup], Diff),
     R.
 
 
@@ -756,7 +755,7 @@ archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
     R = ejabberd_hooks:run_fold(mam_archive_message, Host, ok,
         [Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet]),
     Diff = timer:now_diff(os:timestamp(), StartT),
-    mongoose_metrics:update(undefined, [backends, ?MODULE, archive], Diff),
+    mongoose_metrics:update(global, [backends, ?MODULE, archive], Diff),
     R.
 
 -spec purge_single_message(Host :: ejabberd:server(),

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -205,9 +205,10 @@ start(Host, Opts) ->
     ejabberd_hooks:add(remove_user, Host, ?MODULE, remove_user, 50),
     ejabberd_hooks:add(anonymous_purge_hook, Host, ?MODULE, remove_user, 50),
     ejabberd_hooks:add(amp_determine_strategy, Host, ?MODULE, determine_amp_strategy, 20),
-    mongoose_metrics:create([backends, ?MODULE, lookup], histogram),
-    mongoose_metrics:create([Host, modMamLookups, simple], spiral),
-    mongoose_metrics:create([backends, ?MODULE, archive], histogram),
+    mongoose_metrics:ensure_metric(undefined, [backends, ?MODULE, lookup], histogram),
+    mongoose_metrics:ensure_metric(
+      [Host, modMamLookups, simple], [global, modMamLookups, simple], spiral),
+    mongoose_metrics:ensure_metric(undefined, [backends, ?MODULE, archive], histogram),
     ok.
 
 
@@ -742,7 +743,7 @@ lookup_messages(Host, ArcID, ArcJID, RSM, Borders, Start, End, Now,
          Start, End, Now, WithJID,
          PageSize, LimitPassed, MaxResultLimit, IsSimple]),
     Diff = timer:now_diff(os:timestamp(), StartT),
-    mongoose_metrics:update([backends, ?MODULE, lookup], Diff),
+    mongoose_metrics:update(undefined, [backends, ?MODULE, lookup], Diff),
     R.
 
 
@@ -755,7 +756,7 @@ archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
     R = ejabberd_hooks:run_fold(mam_archive_message, Host, ok,
         [Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet]),
     Diff = timer:now_diff(os:timestamp(), StartT),
-    mongoose_metrics:update([backends, ?MODULE, archive], Diff),
+    mongoose_metrics:update(undefined, [backends, ?MODULE, archive], Diff),
     R.
 
 -spec purge_single_message(Host :: ejabberd:server(),

--- a/apps/ejabberd/src/mongoose_api_json.erl
+++ b/apps/ejabberd/src/mongoose_api_json.erl
@@ -52,6 +52,8 @@ do_serialize(Data) ->
 
 prepare_struct({Key, Value}) ->
     {struct, [{Key, prepare_struct(Value)}]};
+prepare_struct([]) ->
+    [];
 prepare_struct(List) when is_list(List) ->
     case is_proplist(List) of
         true  ->

--- a/apps/ejabberd/src/mongoose_api_metrics.erl
+++ b/apps/ejabberd/src/mongoose_api_metrics.erl
@@ -91,7 +91,7 @@ host_metric(Bindings) ->
     {metric, Metric} = lists:keyfind(metric, 1, Bindings),
     try
         MetricAtom = binary_to_existing_atom(Metric, utf8),
-        {ok, Value} = mongoose_metrics:get_metric_value({Host, MetricAtom}),
+        {ok, Value} = mongoose_metrics:get_metric_value([Host, MetricAtom]),
         {ok, {metric, Value}}
     catch error:badarg ->
         {error, not_found}
@@ -109,7 +109,7 @@ host_metrics(Bindings) ->
 global_metric(Bindings) ->
     {metric, Metric} = lists:keyfind(metric, 1, Bindings),
     MetricAtom = binary_to_existing_atom(Metric, utf8),
-    case mongoose_metrics:get_metric_value({global, MetricAtom}) of
+    case mongoose_metrics:get_metric_value(global, MetricAtom) of
         {ok, Value} ->
             {ok, {metric, Value}};
         _Other ->
@@ -161,4 +161,4 @@ get_host_metrics(Host) ->
 
 prep_name(NameParts) ->
     ToStrings = [atom_to_list(NamePart) || NamePart <- NameParts],
-    string:join(ToStrings, "_").
+    string:join(ToStrings, ".").

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -19,7 +19,10 @@
 
 %% API
 -export([init/0,
+         create_global_metrics/0,
+         init_predefined_host_metrics/1,
          init_subscriptions/0,
+         create_generic_hook_metric/2,
          update/2,
          create/2,
          ensure_metric/2,
@@ -33,9 +36,6 @@
          get_host_metric_names/1,
          get_global_metric_names/0,
          get_aggregated_values/1,
-         init_predefined_host_metrics/1,
-         create_global_metrics/0,
-         create_generic_hook_metric/2,
          increment_generic_hook_metric/2,
          get_odbc_data_stats/0,
          get_odbc_mam_async_stats/0,
@@ -46,6 +46,9 @@
 
 -define(DEFAULT_REPORT_INTERVAL, 60000). %%60s
 
+%% ---------------------------------------------------------------------
+%% API
+%% ---------------------------------------------------------------------
 
 -spec init() -> ok.
 init() ->
@@ -53,8 +56,23 @@ init() ->
     lists:foreach(
         fun(Host) ->
             mongoose_metrics:init_predefined_host_metrics(Host)
-        end, ?MYHOSTS),
+        end, ?HOSTS),
     init_subscriptions().
+
+create_global_metrics() ->
+    lists:foreach(fun({Metric, FunSpec, DataPoints}) ->
+        FunSpecTuple = list_to_tuple(FunSpec ++ [DataPoints]),
+        catch exometer:new(Metric, FunSpecTuple)
+    end, get_vm_stats()),
+    lists:foreach(fun({Metric, Spec}) -> create(Metric, Spec) end,
+                  ?GLOBAL_COUNTERS),
+    create_data_metrics().
+
+-spec init_predefined_host_metrics(ejabberd:lserver()) -> ok.
+init_predefined_host_metrics(Host) ->
+    create_metrics(Host),
+    metrics_hooks(add, Host),
+    ok.
 
 init_subscriptions() ->
     Reporters = exometer_report:list_reporters(),
@@ -64,9 +82,9 @@ init_subscriptions() ->
                 subscribe_to_all(Name, Interval)
         end, Reporters).
 
-get_report_interval() ->
-    application:get_env(exometer, mongooseim_report_interval,
-                        ?DEFAULT_REPORT_INTERVAL).
+-spec create_generic_hook_metric(ejabberd:lserver(), atom()) -> ok | {ok, already_present}.
+create_generic_hook_metric(Host, Hook) ->
+    do_create_generic_hook_metric([Host, filter_hook(Hook)]).
 
 -spec update({term(), term()} | list(), term()) -> any().
 update(Name, Change) when is_tuple(Name)->
@@ -77,6 +95,11 @@ update(Name, Change) ->
 -spec create(list(), term()) -> ok | {error, term()}.
 create(Metric, Spec) ->
     ensure_metric(Metric, Spec).
+
+ensure_metric(Metric, Type) when is_tuple(Type) ->
+    ensure_metric(Metric, Type, element(1, Type));
+ensure_metric(Metric, Type) ->
+    ensure_metric(Metric, Type, Type).
 
 start_host_metrics_subscriptions(Reporter, Host, Interval) ->
     do_start_metrics_subscriptions(Reporter, Interval, [Host]).
@@ -93,12 +116,6 @@ start_data_metrics_subscriptions(Reporter, Interval) ->
 start_backend_metrics_subscriptions(Reporter, Interval) ->
     do_start_metrics_subscriptions(Reporter, Interval, [backends]).
 
-get_host_metric_names(Host) ->
-    [MetricName || {[_Host | MetricName], _, _} <- exometer:find_entries([Host])].
-
-get_global_metric_names() ->
-    get_host_metric_names(global).
-
 get_metric_value({Host, Name}) ->
     get_metric_value([Host, Name]);
 get_metric_value(Metric) ->
@@ -109,43 +126,18 @@ get_metric_values(Metric) when is_list(Metric) ->
 get_metric_values(Host) ->
     exometer:get_values([Host]).
 
+get_host_metric_names(Host) ->
+    [MetricName || {[_Host | MetricName], _, _} <- exometer:find_entries([Host])].
+
+get_global_metric_names() ->
+    get_host_metric_names(global).
 
 get_aggregated_values(Metric) ->
     exometer:aggregate([{{['_',Metric],'_','_'},[],[true]}], [one, count, value]).
 
--spec init_predefined_host_metrics(ejabberd:lserver()) -> ok.
-init_predefined_host_metrics(Host) ->
-    create_metrics(Host),
-    metrics_hooks(add, Host),
-    ok.
-
--spec create_generic_hook_metric(ejabberd:lserver(), atom()) -> ok | {ok, already_present}.
-create_generic_hook_metric(Host, Hook) ->
-    do_create_generic_hook_metric([Host, filter_hook(Hook)]).
-
 -spec increment_generic_hook_metric(ejabberd:lserver(), atom()) -> ok | {error, any()}.
 increment_generic_hook_metric(Host, Hook) ->
     do_increment_generic_hook_metric([Host, filter_hook(Hook)]).
-
--spec get_up_time() -> {value, integer()}.
-get_up_time() ->
-    {value, erlang:round(element(1, erlang:statistics(wall_clock))/1000)}.
-
--spec do_create_generic_hook_metric(list()) -> ok | {ok, already_present}.
-do_create_generic_hook_metric([_, skip]) ->
-    ok;
-do_create_generic_hook_metric(MetricName) ->
-    ensure_metric(MetricName, spiral).
-
--spec do_increment_generic_hook_metric(list()) -> ok | {error, any()}.
-do_increment_generic_hook_metric([_, skip]) ->
-    ok;
-do_increment_generic_hook_metric(MetricName) ->
-    update(MetricName, 1).
-
-get_dist_data_stats() ->
-    DistStats = [inet_stats(Port) || {_, Port} <- erlang:system_info(dist_ctrl)],
-    [{connections, length(DistStats)} | merge_stats(DistStats)].
 
 get_odbc_data_stats() ->
     RegularODBCWorkers = [catch ejabberd_odbc_sup:get_pids(Host) || Host <- ?MYHOSTS],
@@ -156,63 +148,13 @@ get_odbc_mam_async_stats() ->
     MamAsynODBCWorkers = [catch element(2, gen_server:call(Pid, get_connection, 1000)) || {_, Pid, worker, _} <- supervisor:which_children(mod_mam_sup)],
     get_odbc_stats(MamAsynODBCWorkers).
 
-get_odbc_stats(ODBCWorkers) ->
-    ODBCConnections = [catch ejabberd_odbc:get_db_info(Pid) || Pid <- ODBCWorkers],
-    Ports = [get_port_from_odbc_connection(Conn) || Conn <- ODBCConnections],
-    PortStats = [inet_stats(Port) || Port <- lists:flatten(Ports)],
-    [{workers, length(ODBCConnections)} | merge_stats(PortStats)].
-%%
+get_dist_data_stats() ->
+    DistStats = [inet_stats(Port) || {_, Port} <- erlang:system_info(dist_ctrl)],
+    [{connections, length(DistStats)} | merge_stats(DistStats)].
 
-get_port_from_odbc_connection({ok, DbType, Pid}) when DbType =:= mysql; DbType =:= pgsql ->
-    %% Pid of mysql_conn process
-    {links, [MySQLRecv]} = erlang:process_info(Pid, links),
-    %% Port is hold by mysql_recv process which is linked to the mysql_conn
-    {links, Links} = erlang:process_info(MySQLRecv, links),
-    [Port || Port <- Links, is_port(Port)];
-get_port_from_odbc_connection({ok, odbc, Pid}) ->
-    {links, Links} = erlang:process_info(Pid, links),
-    [Port || Port <- Links, is_port(Port), {name, "tcp_inet"} == erlang:port_info(Port, name)];
-get_port_from_odbc_connection(_) ->
-    undefined.
-
--define (INET_STATS, [recv_oct,
-                      recv_cnt,
-                      recv_max,
-                      send_oct,
-                      send_max,
-                      send_cnt,
-                      send_pend
-                     ]).
--define(EMPTY_INET_STATS, [{recv_oct,0},
-                           {recv_cnt,0},
-                           {recv_max,0},
-                           {send_oct,0},
-                           {send_max,0},
-                           {send_cnt,0},
-                           {send_pend,0}
-                          ]).
-
-merge_stats(Stats) ->
-    OrdDict = lists:foldl(fun(Stat, Acc) ->
-        StatDict = orddict:from_list(Stat),
-        orddict:merge(fun merge_stats_fun/3, Acc, StatDict)
-    end, orddict:from_list(?EMPTY_INET_STATS), Stats),
-
-    orddict:to_list(OrdDict).
-
-merge_stats_fun(recv_max, V1, V2) ->
-    erlang:max(V1, V2);
-merge_stats_fun(send_max, V1, V2) ->
-    erlang:max(V1, V2);
-merge_stats_fun(_, V1, V2) ->
-    V1 + V2.
-
-
-inet_stats(Port) when is_port(Port) ->
-    {ok, Stats} = inet:getstat(Port, ?INET_STATS),
-    Stats;
-inet_stats(_) ->
-    ?EMPTY_INET_STATS.
+-spec get_up_time() -> {value, integer()}.
+get_up_time() ->
+    {value, erlang:round(element(1, erlang:statistics(wall_clock))/1000)}.
 
 remove_host_metrics(Host) ->
     lists:foreach(fun remove_metric/1,
@@ -222,80 +164,11 @@ remove_all_metrics() ->
     lists:foreach(fun remove_metric/1,
                   exometer:find_entries([])).
 
-remove_metric({Name, _, _}) ->
-    exometer_admin:delete_entry(Name).
+%% ---------------------------------------------------------------------
+%% Metrics definitions
+%% ---------------------------------------------------------------------
 
-%% decided whether to use a metric for given hook or not
-filter_hook(sm_register_connection_hook) -> skip;
-filter_hook(sm_remove_connection_hook) -> skip;
-filter_hook(auth_failed) -> skip;
-filter_hook(user_send_packet) -> skip;
-filter_hook(user_receive_packet) -> skip;
-filter_hook(xmpp_bounce_message) -> skip;
-filter_hook(xmpp_stanza_dropped) -> skip;
-filter_hook(xmpp_send_element) -> skip;
-filter_hook(roster_get) -> skip;
-filter_hook(roster_set) -> skip;
-filter_hook(roster_push) -> skip;
-filter_hook(register_user) -> skip;
-filter_hook(remove_user) -> skip;
-filter_hook(privacy_iq_get) -> skip;
-filter_hook(privacy_iq_set) -> skip;
-filter_hook(privacy_check_packet) -> skip;
-filter_hook(mam_get_prefs) -> skip;
-filter_hook(mam_set_prefs) -> skip;
-filter_hook(mam_remove_archive) -> skip;
-filter_hook(mam_archive_message) -> skip;
-filter_hook(mam_flush_messages) -> skip;
-filter_hook(mam_drop_message) -> skip;
-filter_hook(mam_drop_iq) -> skip;
-filter_hook(mam_drop_messages) -> skip;
-filter_hook(mam_purge_single_message) -> skip;
-filter_hook(mam_purge_multiple_messages) -> skip;
-filter_hook(mam_muc_get_prefs) -> skip;
-filter_hook(mam_muc_set_prefs) -> skip;
-filter_hook(mam_muc_remove_archive) -> skip;
-filter_hook(mam_muc_lookup_messages) -> skip;
-filter_hook(mam_muc_archive_message) -> skip;
-filter_hook(mam_muc_flush_messages) -> skip;
-filter_hook(mam_muc_drop_message) -> skip;
-filter_hook(mam_muc_drop_iq) -> skip;
-filter_hook(mam_muc_drop_messages) -> skip;
-filter_hook(mam_muc_purge_single_message) -> skip;
-filter_hook(mam_muc_purge_multiple_messages) -> skip;
-
-filter_hook(Hook) -> Hook.
-
-
-
--spec create_metrics(ejabberd:server()) -> 'ok'.
-create_metrics(Host) ->
-    lists:foreach(fun(Name) -> ensure_metric(Name, spiral) end,
-                  get_general_counters(Host)),
-
-    lists:foreach(fun(Name) -> ensure_metric(Name, counter) end,
-                  get_total_counters(Host)).
-
-ensure_metric(Metric, Type) when is_tuple(Type) ->
-    ensure_metric(Metric, Type, element(1, Type));
-ensure_metric(Metric, Type) ->
-    ensure_metric(Metric, Type, Type).
-
-ensure_metric(Metric, Type, ShortType) when is_list(Metric) ->
-    %% the split into ShortType and Type is needed because function metrics are
-    %% defined as tuples (that is Type), while exometer:info returns only 'function'
-    case exometer:info(Metric, type) of
-        ShortType -> {ok, already_present};
-        undefined -> exometer:new(Metric, Type)
-    end.
-
--spec metrics_hooks('add' | 'delete', ejabberd:server()) -> 'ok'.
-metrics_hooks(Op, Host) ->
-    lists:foreach(fun(Hook) ->
-        apply(ejabberd_hooks, Op, Hook)
-    end, mongoose_metrics_hooks:get_hooks(Host)).
-
--define (GENERAL_COUNTERS, [
+-define(GENERAL_COUNTERS, [
     sessionSuccessfulLogins,
     sessionAuthAnonymous,
     sessionAuthFails,
@@ -354,21 +227,12 @@ metrics_hooks(Op, Host) ->
     modCSIActive
 ]).
 
-
--spec get_general_counters(ejabberd:server()) -> [[ejabberd:server() | atom(), ...]].
-get_general_counters(Host) ->
-    get_counters(Host, ?GENERAL_COUNTERS).
-
--define (TOTAL_COUNTERS, [
+-define(TOTAL_COUNTERS, [
     sessionCount
 ]).
 
-
--spec get_total_counters(ejabberd:server()) -> [[ejabberd:server() | atom(), ...]].
-get_total_counters(Host) ->
-    get_counters(Host, ?TOTAL_COUNTERS).
-
 -define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}],[value]}).
+
 -define(GLOBAL_COUNTERS,
         [{[global, totalSessionCount],
           {function, ejabberd_sm, get_total_sessions_number, [],
@@ -400,27 +264,171 @@ get_total_counters(Host) ->
          {[data, dist],
           {function, mongoose_metrics, get_dist_data_stats, [], proplist, [connections | ?INET_STATS]}}]).
 
-create_global_metrics() ->
-    lists:foreach(fun({Metric, FunSpec, DataPoints}) ->
-        FunSpecTuple = list_to_tuple(FunSpec ++ [DataPoints]),
-        catch exometer:new(Metric, FunSpecTuple)
-    end, get_vm_stats()),
-    lists:foreach(fun({Metric, Spec}) -> create(Metric, Spec) end,
-                  ?GLOBAL_COUNTERS),
-    create_data_metrics().
 
-create_data_metrics() ->
-    lists:foreach(fun(Metric) -> exometer:new(Metric, histogram) end,
-        ?GLOBAL_HISTOGRAMS),
-    lists:foreach(fun({Metric, Spec}) -> exometer:new(Metric, Spec) end,
-        ?DATA_FUN_METRICS).
+-define(INET_STATS, [recv_oct,
+                     recv_cnt,
+                     recv_max,
+                     send_oct,
+                     send_max,
+                     send_cnt,
+                     send_pend
+                    ]).
 
+-define(EMPTY_INET_STATS, [{recv_oct,0},
+                           {recv_cnt,0},
+                           {recv_max,0},
+                           {send_oct,0},
+                           {send_max,0},
+                           {send_cnt,0},
+                           {send_pend,0}
+                          ]).
 
 get_vm_stats() ->
     [{[erlang, system_info], [function, erlang, system_info, ['$dp'], value],
         [port_count, port_limit, process_count, process_limit, ets_limit]},
      {[erlang, memory], [function, erlang, memory, ['$dp'], value],
       [total, processes_used, atom_used, binary, ets, system]}].
+
+%% ---------------------------------------------------------------------
+%% Internal functions
+%% ---------------------------------------------------------------------
+
+get_report_interval() ->
+    application:get_env(exometer, mongooseim_report_interval,
+                        ?DEFAULT_REPORT_INTERVAL).
+
+-spec do_create_generic_hook_metric(list()) -> ok | {ok, already_present}.
+do_create_generic_hook_metric([_, skip]) ->
+    ok;
+do_create_generic_hook_metric(MetricName) ->
+    ensure_metric(MetricName, spiral).
+
+-spec do_increment_generic_hook_metric(list()) -> ok | {error, any()}.
+do_increment_generic_hook_metric([_, skip]) ->
+    ok;
+do_increment_generic_hook_metric(MetricName) ->
+    update(MetricName, 1).
+
+get_odbc_stats(ODBCWorkers) ->
+    ODBCConnections = [catch ejabberd_odbc:get_db_info(Pid) || Pid <- ODBCWorkers],
+    Ports = [get_port_from_odbc_connection(Conn) || Conn <- ODBCConnections],
+    PortStats = [inet_stats(Port) || Port <- lists:flatten(Ports)],
+    [{workers, length(ODBCConnections)} | merge_stats(PortStats)].
+
+get_port_from_odbc_connection({ok, DbType, Pid}) when DbType =:= mysql; DbType =:= pgsql ->
+    %% Pid of mysql_conn process
+    {links, [MySQLRecv]} = erlang:process_info(Pid, links),
+    %% Port is hold by mysql_recv process which is linked to the mysql_conn
+    {links, Links} = erlang:process_info(MySQLRecv, links),
+    [Port || Port <- Links, is_port(Port)];
+get_port_from_odbc_connection({ok, odbc, Pid}) ->
+    {links, Links} = erlang:process_info(Pid, links),
+    [Port || Port <- Links, is_port(Port), {name, "tcp_inet"} == erlang:port_info(Port, name)];
+get_port_from_odbc_connection(_) ->
+    undefined.
+
+merge_stats(Stats) ->
+    OrdDict = lists:foldl(fun(Stat, Acc) ->
+        StatDict = orddict:from_list(Stat),
+        orddict:merge(fun merge_stats_fun/3, Acc, StatDict)
+    end, orddict:from_list(?EMPTY_INET_STATS), Stats),
+
+    orddict:to_list(OrdDict).
+
+merge_stats_fun(recv_max, V1, V2) ->
+    erlang:max(V1, V2);
+merge_stats_fun(send_max, V1, V2) ->
+    erlang:max(V1, V2);
+merge_stats_fun(_, V1, V2) ->
+    V1 + V2.
+
+inet_stats(Port) when is_port(Port) ->
+    {ok, Stats} = inet:getstat(Port, ?INET_STATS),
+    Stats;
+inet_stats(_) ->
+    ?EMPTY_INET_STATS.
+
+remove_metric({Name, _, _}) ->
+    exometer_admin:delete_entry(Name).
+
+%% decided whether to use a metric for given hook or not
+filter_hook(sm_register_connection_hook) -> skip;
+filter_hook(sm_remove_connection_hook) -> skip;
+filter_hook(auth_failed) -> skip;
+filter_hook(user_send_packet) -> skip;
+filter_hook(user_receive_packet) -> skip;
+filter_hook(xmpp_bounce_message) -> skip;
+filter_hook(xmpp_stanza_dropped) -> skip;
+filter_hook(xmpp_send_element) -> skip;
+filter_hook(roster_get) -> skip;
+filter_hook(roster_set) -> skip;
+filter_hook(roster_push) -> skip;
+filter_hook(register_user) -> skip;
+filter_hook(remove_user) -> skip;
+filter_hook(privacy_iq_get) -> skip;
+filter_hook(privacy_iq_set) -> skip;
+filter_hook(privacy_check_packet) -> skip;
+filter_hook(mam_get_prefs) -> skip;
+filter_hook(mam_set_prefs) -> skip;
+filter_hook(mam_remove_archive) -> skip;
+filter_hook(mam_archive_message) -> skip;
+filter_hook(mam_flush_messages) -> skip;
+filter_hook(mam_drop_message) -> skip;
+filter_hook(mam_drop_iq) -> skip;
+filter_hook(mam_drop_messages) -> skip;
+filter_hook(mam_purge_single_message) -> skip;
+filter_hook(mam_purge_multiple_messages) -> skip;
+filter_hook(mam_muc_get_prefs) -> skip;
+filter_hook(mam_muc_set_prefs) -> skip;
+filter_hook(mam_muc_remove_archive) -> skip;
+filter_hook(mam_muc_lookup_messages) -> skip;
+filter_hook(mam_muc_archive_message) -> skip;
+filter_hook(mam_muc_flush_messages) -> skip;
+filter_hook(mam_muc_drop_message) -> skip;
+filter_hook(mam_muc_drop_iq) -> skip;
+filter_hook(mam_muc_drop_messages) -> skip;
+filter_hook(mam_muc_purge_single_message) -> skip;
+filter_hook(mam_muc_purge_multiple_messages) -> skip;
+
+filter_hook(Hook) -> Hook.
+
+
+
+-spec create_metrics(ejabberd:server()) -> 'ok'.
+create_metrics(Host) ->
+    lists:foreach(fun(Name) -> ensure_metric(Name, spiral) end,
+                  get_general_counters(Host)),
+
+    lists:foreach(fun(Name) -> ensure_metric(Name, counter) end,
+                  get_total_counters(Host)).
+
+ensure_metric(Metric, Type, ShortType) when is_list(Metric) ->
+    %% the split into ShortType and Type is needed because function metrics are
+    %% defined as tuples (that is Type), while exometer:info returns only 'function'
+    case exometer:info(Metric, type) of
+        ShortType -> {ok, already_present};
+        undefined -> exometer:new(Metric, Type)
+    end.
+
+-spec metrics_hooks('add' | 'delete', ejabberd:server()) -> 'ok'.
+metrics_hooks(Op, Host) ->
+    lists:foreach(fun(Hook) ->
+        apply(ejabberd_hooks, Op, Hook)
+    end, mongoose_metrics_hooks:get_hooks(Host)).
+
+-spec get_general_counters(ejabberd:server()) -> [[ejabberd:server() | atom(), ...]].
+get_general_counters(Host) ->
+    get_counters(Host, ?GENERAL_COUNTERS).
+
+-spec get_total_counters(ejabberd:server()) -> [[ejabberd:server() | atom(), ...]].
+get_total_counters(Host) ->
+    get_counters(Host, ?TOTAL_COUNTERS).
+
+create_data_metrics() ->
+    lists:foreach(fun(Metric) -> exometer:new(Metric, histogram) end,
+        ?GLOBAL_HISTOGRAMS),
+    lists:foreach(fun({Metric, Spec}) -> exometer:new(Metric, Spec) end,
+        ?DATA_FUN_METRICS).
 
 get_counters(Host, Counters) ->
     [[Host, Counter] || Counter <- Counters].

--- a/apps/ejabberd/src/mongoose_metrics_definitions.hrl
+++ b/apps/ejabberd/src/mongoose_metrics_definitions.hrl
@@ -1,0 +1,120 @@
+-define(GENERAL_COUNTERS, [
+    sessionSuccessfulLogins,
+    sessionAuthAnonymous,
+    sessionAuthFails,
+    sessionLogouts,
+    xmppMessageSent,
+    xmppMessageReceived,
+    xmppMessageBounced,
+    xmppPresenceSent,
+    xmppPresenceReceived,
+    xmppIqSent,
+    xmppIqReceived,
+    xmppStanzaSent,
+    xmppStanzaReceived,
+    xmppStanzaDropped,
+    xmppStanzaCount,
+    xmppErrorTotal,
+    xmppErrorIq,
+    xmppErrorMessage,
+    xmppErrorPresence,
+    modRosterSets,
+    modRosterGets,
+    modPresenceSubscriptions,
+    modPresenceUnsubscriptions,
+    modRosterPush,
+    modRegisterCount,
+    modUnregisterCount,
+    modPrivacySets,
+    modPrivacySetsActive,
+    modPrivacySetsDefault,
+    modPrivacyPush,
+    modPrivacyGets,
+    modPrivacyStanzaDenied,
+    modPrivacyStanzaBlocked,
+    modPrivacyStanzaAll,
+    modMamPrefsSets,
+    modMamPrefsGets,
+    modMamArchiveRemoved,
+    modMamLookups,
+    modMamForwarded,
+    modMamArchived,
+    modMamFlushed,
+    modMamDropped,
+    modMamDropped2,
+    modMamDroppedIQ,
+    modMamSinglePurges,
+    modMamMultiplePurges,
+    modMucMamPrefsSets,
+    modMucMamPrefsGets,
+    modMucMamArchiveRemoved,
+    modMucMamLookups,
+    modMucMamForwarded,
+    modMucMamArchived,
+    modMucMamSinglePurges,
+    modMucMamMultiplePurges,
+    modCSIInactive,
+    modCSIActive
+]).
+
+-define(TOTAL_COUNTERS, [
+    sessionCount
+]).
+
+-define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}],[value]}).
+
+-define(GLOBAL_COUNTERS,
+        [{[global, totalSessionCount],
+          {function, ejabberd_sm, get_total_sessions_number, [],
+           eval, ?EX_EVAL_SINGLE_VALUE}},
+         {[global, uniqueSessionCount],
+          {function, ejabberd_sm, get_unique_sessions_number, [],
+           eval, ?EX_EVAL_SINGLE_VALUE}},
+         {[global, nodeSessionCount],
+          {function, ejabberd_sm, get_node_sessions_number, [],
+           eval, ?EX_EVAL_SINGLE_VALUE}},
+         {[global, nodeUpTime],
+          {function, mongoose_metrics, get_up_time, [],
+           tagged, [value]}}
+        ]
+).
+
+-define(VM_STATS, [{[erlang, system_info], [function, erlang, system_info, ['$dp'], value],
+                    [port_count, port_limit, process_count, process_limit, ets_limit]},
+                   {[erlang, memory], [function, erlang, memory, ['$dp'], value],
+                    [total, processes_used, atom_used, binary, ets, system]}]).
+
+-define(GLOBAL_HISTOGRAMS, [[data, xmpp, received, encrypted_size],
+                            [data, xmpp, received, compressed_size],
+                            [data, xmpp, received, xml_stanza_size],
+                            [data, xmpp, sent, encrypted_size],
+                            [data, xmpp, sent, compressed_size],
+                            [data, xmpp, sent, xml_stanza_size]]).
+
+-define(DATA_FUN_METRICS,
+        [{[data, odbc, regular],
+          {function, mongoose_metrics, get_odbc_data_stats, [], proplist, [workers | ?INET_STATS]}},
+         {[data, odbc, mam_async],
+          {function, mongoose_metrics, get_odbc_mam_async_stats, [], proplist, [workers | ?INET_STATS]}},
+         {[data, dist],
+          {function, mongoose_metrics, get_dist_data_stats, [], proplist, [connections | ?INET_STATS]}}]).
+
+
+-define(INET_STATS, [recv_oct,
+                     recv_cnt,
+                     recv_max,
+                     send_oct,
+                     send_max,
+                     send_cnt,
+                     send_pend
+                    ]).
+
+-define(EMPTY_INET_STATS, [{recv_oct,0},
+                           {recv_cnt,0},
+                           {recv_max,0},
+                           {send_oct,0},
+                           {send_max,0},
+                           {send_cnt,0},
+                           {send_pend,0}
+                          ]).
+

--- a/apps/ejabberd/src/mongoose_metrics_definitions.hrl
+++ b/apps/ejabberd/src/mongoose_metrics_definitions.hrl
@@ -1,4 +1,4 @@
--define(GENERAL_COUNTERS, [
+-define(GENERAL_SPIRALS, [
     sessionSuccessfulLogins,
     sessionAuthAnonymous,
     sessionAuthFails,
@@ -64,16 +64,16 @@
 -define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}],[value]}).
 
 -define(GLOBAL_COUNTERS,
-        [{[global, totalSessionCount],
+        [{totalSessionCount,
           {function, ejabberd_sm, get_total_sessions_number, [],
            eval, ?EX_EVAL_SINGLE_VALUE}},
-         {[global, uniqueSessionCount],
+         {uniqueSessionCount,
           {function, ejabberd_sm, get_unique_sessions_number, [],
            eval, ?EX_EVAL_SINGLE_VALUE}},
-         {[global, nodeSessionCount],
+         {nodeSessionCount,
           {function, ejabberd_sm, get_node_sessions_number, [],
            eval, ?EX_EVAL_SINGLE_VALUE}},
-         {[global, nodeUpTime],
+         {nodeUpTime,
           {function, mongoose_metrics, get_up_time, [],
            tagged, [value]}}
         ]

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -113,72 +113,74 @@ get_hooks(Host) ->
 -spec sm_register_connection_hook(tuple(), ejabberd:jid(), term()
                                  ) -> metrics_notify_return().
 sm_register_connection_hook(_,#jid{server = Server}, _) ->
-    mongoose_metrics:update({Server, sessionSuccessfulLogins}, 1),
-    mongoose_metrics:update({Server, sessionCount}, 1).
+    mongoose_metrics:update({Server, sessionSuccessfulLogins}, {global, sessionSuccessfulLogins}, 1),
+    mongoose_metrics:update({Server, sessionCount}, {global, sessionCount}, 1).
 
 -spec sm_remove_connection_hook(tuple(), ejabberd:jid(),
                                 term(), ejabberd_sm:close_reason()
                                ) -> metrics_notify_return().
 sm_remove_connection_hook(_,#jid{server = Server},_, _Reason) ->
-    mongoose_metrics:update({Server, sessionLogouts}, 1),
-    mongoose_metrics:update({Server, sessionCount}, -1).
+    mongoose_metrics:update({Server, sessionLogouts}, {global, sessionLogouts}, 1),
+    mongoose_metrics:update({Server, sessionCount}, {global, sessionCount}, -1).
 
 -spec auth_failed(binary(), binary()) -> metrics_notify_return().
 auth_failed(_,Server) ->
-    mongoose_metrics:update({Server, sessionAuthFails},1).
+    mongoose_metrics:update({Server, sessionAuthFails}, {global, sessionAuthFails}, 1).
 
 -spec user_send_packet(ejabberd:jid(), tuple(), tuple()
                       ) -> metrics_notify_return().
 user_send_packet(#jid{server = Server},_,Packet) ->
-    mongoose_metrics:update({Server, xmppStanzaSent}, 1),
+    mongoose_metrics:update({Server, xmppStanzaSent}, {global, xmppStanzaSent}, 1),
     user_send_packet_type(Server, Packet).
 
 -spec user_send_packet_type(Server :: ejabberd:server(),
                             Packet :: jlib:xmlel()) -> metrics_notify_return().
 user_send_packet_type(Server, #xmlel{name = <<"message">>}) ->
-    mongoose_metrics:update({Server, xmppMessageSent}, 1);
+    mongoose_metrics:update({Server, xmppMessageSent}, {global, xmppMessageSent}, 1);
 user_send_packet_type(Server, #xmlel{name = <<"iq">>}) ->
-    mongoose_metrics:update({Server, xmppIqSent}, 1);
+    mongoose_metrics:update({Server, xmppIqSent}, {global, xmppIqSent}, 1);
 user_send_packet_type(Server, #xmlel{name = <<"presence">>}) ->
-    mongoose_metrics:update({Server, xmppPresenceSent}, 1).
+    mongoose_metrics:update({Server, xmppPresenceSent}, {global, xmppPresenceSent}, 1).
 
 -spec user_receive_packet(ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
 user_receive_packet(#jid{server = Server} ,_,_,Packet) ->
-    mongoose_metrics:update({Server, xmppStanzaReceived},1),
+    mongoose_metrics:update({Server, xmppStanzaReceived}, {global, xmppStanzaReceived}, 1),
     user_receive_packet_type(Server, Packet).
 
 -spec user_receive_packet_type(Server :: ejabberd:server(),
                                Packet :: jlib:xmlel()) -> metrics_notify_return().
 user_receive_packet_type(Server, #xmlel{name = <<"message">>}) ->
-    mongoose_metrics:update({Server, xmppMessageReceived}, 1);
+    mongoose_metrics:update({Server, xmppMessageReceived}, {global, xmppMessageReceived}, 1);
 user_receive_packet_type(Server, #xmlel{name = <<"iq">>}) ->
-    mongoose_metrics:update({Server, xmppIqReceived}, 1);
+    mongoose_metrics:update({Server, xmppIqReceived}, {global, xmppIqReceived}, 1);
 user_receive_packet_type(Server, #xmlel{name = <<"presence">>}) ->
-    mongoose_metrics:update({Server, xmppPresenceReceived}, 1).
+    mongoose_metrics:update({Server, xmppPresenceReceived}, {global, xmppPresenceReceived}, 1).
 
 -spec xmpp_bounce_message(Server :: ejabberd:server(),
                           tuple()) -> metrics_notify_return().
 xmpp_bounce_message(Server, _) ->
-    mongoose_metrics:update({Server, xmppMessageBounced}, 1).
+    mongoose_metrics:update({Server, xmppMessageBounced}, {global, xmppMessageBounced}, 1).
 
 -spec xmpp_stanza_dropped(ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
 xmpp_stanza_dropped(#jid{server = Server} ,_,_) ->
-   mongoose_metrics:update({Server, xmppStanzaDropped}, 1).
+   mongoose_metrics:update({Server, xmppStanzaDropped}, {global, xmppStanzaDropped}, 1).
 
 -spec xmpp_send_element(Server :: ejabberd:server(),
                         Packet :: jlib:xmlel()) -> ok | metrics_notify_return().
 xmpp_send_element(Server, #xmlel{name = Name, attrs = Attrs}) ->
-    mongoose_metrics:update({Server, xmppStanzaCount}, 1),
+    mongoose_metrics:update({Server, xmppStanzaCount}, {global, xmppStanzaCount}, 1),
     case lists:keyfind(<<"type">>, 1, Attrs) of
         {<<"type">>, <<"error">>} ->
-            mongoose_metrics:update({Server, xmppErrorTotal}, 1),
+            mongoose_metrics:update({Server, xmppErrorTotal}, {global, xmppErrorTotal}, 1),
             case Name of
                 <<"iq">> ->
-                    mongoose_metrics:update({Server, xmppErrorIq},1);
+                    mongoose_metrics:update({Server, xmppErrorIq}, {global, xmppErrorIq}, 1);
                 <<"message">> ->
-                    mongoose_metrics:update({Server, xmppErrorMessage},1);
+                    mongoose_metrics:update({Server, xmppErrorMessage},
+                                            {global, xmppErrorMessage}, 1);
                 <<"presence">> ->
-                    mongoose_metrics:update({Server, xmppErrorPresence}, 1)
+                    mongoose_metrics:update({Server, xmppErrorPresence},
+                                            {global, xmppErrorPresence}, 1)
             end;
         _ -> ok
     end;
@@ -190,42 +192,44 @@ xmpp_send_element(_, _) ->
 
 -spec roster_get(list(), {_, ejabberd:server()}) -> list().
 roster_get(Acc, {_, Server}) ->
-    mongoose_metrics:update({Server, modRosterGets}, 1),
+    mongoose_metrics:update({Server, modRosterGets}, {global, modRosterGets}, 1),
     Acc.
 
 -spec roster_set(JID :: ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
 roster_set(#jid{server = Server},_,_) ->
-    mongoose_metrics:update({Server, modRosterSets}, 1).
+    mongoose_metrics:update({Server, modRosterSets}, {global, modRosterSets}, 1).
 
 -spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
 roster_in_subscription(Acc,_,Server,_,subscribed,_) ->
-    mongoose_metrics:update({Server, modPresenceSubscriptions}, 1),
+    mongoose_metrics:update({Server, modPresenceSubscriptions},
+                            {global, modPresenceSubscriptions}, 1),
     Acc;
 roster_in_subscription(Acc,_,Server,_,unsubscribed,_) ->
-    mongoose_metrics:update({Server, modPresenceUnsubscriptions}, 1),
+    mongoose_metrics:update({Server, modPresenceUnsubscriptions},
+                            {global, modPresenceUnsubscriptions}, 1),
     Acc;
 roster_in_subscription(Acc,_,_,_,_,_) ->
     Acc.
 
 -spec roster_push(ejabberd:jid(),term()) -> metrics_notify_return().
 roster_push(#jid{server = Server},_) ->
-    mongoose_metrics:update({Server, modRosterPush}, 1).
+    mongoose_metrics:update({Server, modRosterPush}, {global, modRosterPush}, 1).
 
 %% Register
 
 -spec register_user(binary(), ejabberd:server()) -> metrics_notify_return().
 register_user(_,Server) ->
-    mongoose_metrics:update({Server, modRegisterCount}, 1).
+    mongoose_metrics:update({Server, modRegisterCount}, {global, modRegisterCount}, 1).
 
 -spec remove_user(binary(), ejabberd:server()) -> metrics_notify_return().
 remove_user(_,Server) ->
-    mongoose_metrics:update({Server, modUnregisterCount}, 1).
+    mongoose_metrics:update({Server, modUnregisterCount}, {global, modUnregisterCount}, 1).
 
 %% Privacy
 
 -spec privacy_iq_get(term(), ejabberd:jid(), ejabberd:jid(), term(), term()) -> term().
 privacy_iq_get(Acc, #jid{server  = Server}, _, _, _) ->
-    mongoose_metrics:update({Server, modPrivacyGets}, 1),
+    mongoose_metrics:update({Server, modPrivacyGets}, {global, modPrivacyGets}, 1),
     Acc.
 
 -spec privacy_iq_set(Acc :: term(),
@@ -236,13 +240,15 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
     #xmlel{children = Els} = SubEl,
     case xml:remove_cdata(Els) of
         [#xmlel{name = <<"active">>}] ->
-            mongoose_metrics:update({Server, modPrivacySetsActive}, 1);
+            mongoose_metrics:update({Server, modPrivacySetsActive},
+                                    {global, modPrivacySetsActive}, 1);
         [#xmlel{name = <<"default">>}] ->
-            mongoose_metrics:update({Server, modPrivacySetsDefault}, 1);
+            mongoose_metrics:update({Server, modPrivacySetsDefault},
+                                    {global, modPrivacySetsDefault}, 1);
         _ ->
             ok
     end,
-    mongoose_metrics:update({Server, modPrivacySets}, 1),
+    mongoose_metrics:update({Server, modPrivacySets}, {global, modPrivacySets}, 1),
     Acc.
 
 -spec privacy_list_push(_From :: ejabberd:jid(),
@@ -250,7 +256,7 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
                         Broadcast :: ejabberd_c2s:broadcast(),
                         SessionCount :: non_neg_integer()) -> ok | metrics_notify_return().
 privacy_list_push(_From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
-    mongoose_metrics:update({Server, modPrivacyPush}, SessionCount).
+    mongoose_metrics:update({Server, modPrivacyPush}, {global, modPrivacyPush}, SessionCount).
 
 user_ping_timeout(_JID) ->
     ok.
@@ -260,12 +266,14 @@ user_ping_timeout(_JID) ->
                           Server :: ejabberd:server(),
                           term(), term(), term()) -> allow | deny | block.
 privacy_check_packet(Acc, _, Server, _, _, _) ->
-    mongoose_metrics:update({Server, modPrivacyStanzaAll}, 1),
+    mongoose_metrics:update({Server, modPrivacyStanzaAll}, {global, modPrivacyStanzaAll}, 1),
     case Acc of
         deny ->
-            mongoose_metrics:update({Server, modPrivacyStanzaDenied}, 1);
+            mongoose_metrics:update({Server, modPrivacyStanzaDenied},
+                                    {global, modPrivacyStanzaDenied}, 1);
         block ->
-            mongoose_metrics:update({Server, modPrivacyStanzaBlocked}, 1);
+            mongoose_metrics:update({Server, modPrivacyStanzaBlocked},
+                                    {global, modPrivacyStanzaBlocked}, 1);
         allow ->
             ok
     end,
@@ -279,7 +287,7 @@ privacy_check_packet(Acc, _, Server, _, _, _) ->
                     _ArcID :: mod_mam:archive_id(),
                     _ArcJID :: ejabberd:jid()) -> any().
 mam_get_prefs(Result, Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMamPrefsGets}, 1),
+    mongoose_metrics:update({Host, modMamPrefsGets}, {global, modMamPrefsGets}, 1),
     Result.
 
 -spec mam_set_prefs(Result :: any(), Host :: ejabberd:server(),
@@ -287,25 +295,26 @@ mam_get_prefs(Result, Host, _ArcID, _ArcJID) ->
     _DefaultMode :: any(), _AlwaysJIDs :: [ejabberd:literal_jid()],
     _NeverJIDs :: [ejabberd:literal_jid()]) -> any().
 mam_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJIDs) ->
-    mongoose_metrics:update({Host, modMamPrefsSets}, 1),
+    mongoose_metrics:update({Host, modMamPrefsSets}, {global, modMamPrefsSets}, 1),
     Result.
 
 -spec mam_remove_archive(Host :: ejabberd:server(),
                          _ArcID :: mod_mam:archive_id(),
                          _ArcJID :: ejabberd:jid()) -> metrics_notify_return().
 mam_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMamArchiveRemoved}, 1).
+    mongoose_metrics:update({Host, modMamArchiveRemoved}, {global, modMamArchiveRemoved}, 1).
 
 mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
     _RSM, _Borders,
     _Start, _End, _Now, _WithJID,
     _PageSize, _LimitPassed, _MaxResultLimit, IsSimple) ->
-    mongoose_metrics:update({Host, modMamForwarded}, length(MessageRows)),
-    mongoose_metrics:update({Host, modMamLookups}, 1),
+    mongoose_metrics:update({Host, modMamForwarded}, {global, modMamForwarded}, length(MessageRows)),
+    mongoose_metrics:update({Host, modMamLookups}, {globl, modMamLookups}, 1),
     case IsSimple of
         true ->
-            mongoose_metrics:update([Host, modMamLookups, simple], 1);
+            mongoose_metrics:update([Host, modMamLookups, simple],
+                                    [global, modMamLookups, simple], 1);
         _ ->
             ok
     end,
@@ -323,35 +332,35 @@ mam_lookup_messages(Result = {error, _},
     _SrcJID :: ejabberd:jid(), _Dir :: atom(), _Packet :: jlib:xmlel()) -> any().
 mam_archive_message(Result, Host,
     _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
-    mongoose_metrics:update({Host, modMamArchived}, 1),
+    mongoose_metrics:update({Host, modMamArchived}, {global, modMamArchived}, 1),
     Result.
 
 -spec mam_flush_messages(Host :: ejabberd:server(),
                          MessageCount :: integer()) -> metrics_notify_return().
 mam_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update({Host, modMamFlushed}, MessageCount).
+    mongoose_metrics:update({Host, modMamFlushed}, {global, modMamFlushed}, MessageCount).
 
 -spec mam_drop_message(Host :: ejabberd:server()) -> metrics_notify_return().
 mam_drop_message(Host) ->
-    mongoose_metrics:update({Host, modMamDropped}, 1).
+    mongoose_metrics:update({Host, modMamDropped}, {global, modMamDropped}, 1).
 
 -spec mam_drop_iq(Host :: ejabberd:server(), _To :: ejabberd:jid(),
     _IQ :: ejabberd:iq(), _Action :: any(), _Reason :: any()) -> metrics_notify_return().
 mam_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update({Host, modMamDroppedIQ}, 1).
+    mongoose_metrics:update({Host, modMamDroppedIQ}, {global, modMamDroppedIQ}, 1).
 
 -spec mam_drop_messages(Host :: ejabberd:server(),
                         Count :: integer()) -> metrics_notify_return().
 mam_drop_messages(Host, Count) ->
-    mongoose_metrics:update({Host, modMamDropped2}, Count).
+    mongoose_metrics:update({Host, modMamDropped2}, {global, modMamDropped2}, Count).
 
 mam_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
-    mongoose_metrics:update({Host, modMamSinglePurges}, 1),
+    mongoose_metrics:update({Host, modMamSinglePurges}, {global, modMamSinglePurges}, 1),
     Result.
 
 mam_purge_multiple_messages(Result, Host,
     _ArcID, _ArcJID, _Borders, _Start, _End, _Now, _WithJID) ->
-    mongoose_metrics:update({Host, modMamMultiplePurges}, 1),
+    mongoose_metrics:update({Host, modMamMultiplePurges}, {global, modMamMultiplePurges}, 1),
     Result.
 
 
@@ -359,23 +368,24 @@ mam_purge_multiple_messages(Result, Host,
 %% mod_mam_muc
 
 mam_muc_get_prefs(Result, Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMucMamPrefsGets}, 1),
+    mongoose_metrics:update({Host, modMucMamPrefsGets}, {global, modMucMamPrefsGets}, 1),
     Result.
 
 mam_muc_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJIDs) ->
-    mongoose_metrics:update({Host, modMucMamPrefsSets}, 1),
+    mongoose_metrics:update({Host, modMucMamPrefsSets}, {global, modMucMamPrefsSets}, 1),
     Result.
 
 mam_muc_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMucMamArchiveRemoved}, 1).
+    mongoose_metrics:update({Host, modMucMamArchiveRemoved}, {global, modMucMamArchiveRemoved}, 1).
 
 mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
     _RSM, _Borders,
     _Start, _End, _Now, _WithJID,
     _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
-    mongoose_metrics:update({Host, modMucMamForwarded}, length(MessageRows)),
-    mongoose_metrics:update({Host, modMucMamLookups}, 1),
+    mongoose_metrics:update({Host, modMucMamForwarded}, {global, modMucMamForwarded},
+                            length(MessageRows)),
+    mongoose_metrics:update({Host, modMucMamLookups}, {global, modMucMamLookups}, 1),
     Result;
 mam_muc_lookup_messages(Result = {error, _},
     _Host, _ArcID, _ArcJID,
@@ -387,26 +397,26 @@ mam_muc_lookup_messages(Result = {error, _},
 
 mam_muc_archive_message(Result, Host,
     _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
-    mongoose_metrics:update({Host, modMucMamArchived}, 1),
+    mongoose_metrics:update({Host, modMucMamArchived}, {global, modMucMamArchived}, 1),
     Result.
 
 mam_muc_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update({Host, modMucMamFlushed}, MessageCount).
+    mongoose_metrics:update({Host, modMucMamFlushed}, {global, modMucMamFlushed}, MessageCount).
 
 mam_muc_drop_message(Host) ->
-    mongoose_metrics:update({Host, modMucMamDropped}, 1).
+    mongoose_metrics:update({Host, modMucMamDropped}, {global, modMucMamDropped}, 1).
 
 mam_muc_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update({Host, modMucMamDroppedIQ}, 1).
+    mongoose_metrics:update({Host, modMucMamDroppedIQ}, {global, modMucMamDroppedIQ}, 1).
 
 mam_muc_drop_messages(Host, Count) ->
-    mongoose_metrics:update({Host, modMucMamDropped2}, Count).
+    mongoose_metrics:update({Host, modMucMamDropped2}, {global, modMucMamDropped2}, Count).
 
 -spec mam_muc_purge_single_message(Result :: any(), Host :: ejabberd:server(),
     _MessID :: mod_mam:message_id(), _ArcID :: mod_mam:archive_id(),
     _ArcJID :: ejabberd:jid(), _Now :: mod_mam:unix_timestamp()) -> any().
 mam_muc_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
-    mongoose_metrics:update({Host, modMucMamSinglePurges}, 1),
+    mongoose_metrics:update({Host, modMucMamSinglePurges}, {global, modMucMamSinglePurges}, 1),
     Result.
 
 -spec mam_muc_purge_multiple_messages(Result :: any(),
@@ -415,9 +425,8 @@ mam_muc_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
     _End :: any(), _Now :: mod_mam:unix_timestamp(), _WithJID :: any()) -> any().
 mam_muc_purge_multiple_messages(Result, Host,
     _ArcID, _ArcJID, _Borders, _Start, _End, _Now, _WithJID) ->
-    mongoose_metrics:update({Host, modMucMamMultiplePurges}, 1),
+    mongoose_metrics:update({Host, modMucMamMultiplePurges}, {global, modMucMamMultiplePurges}, 1),
     Result.
-
 
 
 %%% vim: set sts=4 ts=4 sw=4 et filetype=erlang foldmarker=%%%',%%%. foldmethod=marker:

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -113,74 +113,72 @@ get_hooks(Host) ->
 -spec sm_register_connection_hook(tuple(), ejabberd:jid(), term()
                                  ) -> metrics_notify_return().
 sm_register_connection_hook(_,#jid{server = Server}, _) ->
-    mongoose_metrics:update({Server, sessionSuccessfulLogins}, {global, sessionSuccessfulLogins}, 1),
-    mongoose_metrics:update({Server, sessionCount}, {global, sessionCount}, 1).
+    mongoose_metrics:update(Server, sessionSuccessfulLogins, 1),
+    mongoose_metrics:update(Server, sessionCount, 1).
 
 -spec sm_remove_connection_hook(tuple(), ejabberd:jid(),
                                 term(), ejabberd_sm:close_reason()
                                ) -> metrics_notify_return().
 sm_remove_connection_hook(_,#jid{server = Server},_, _Reason) ->
-    mongoose_metrics:update({Server, sessionLogouts}, {global, sessionLogouts}, 1),
-    mongoose_metrics:update({Server, sessionCount}, {global, sessionCount}, -1).
+    mongoose_metrics:update(Server, sessionLogouts, 1),
+    mongoose_metrics:update(Server, sessionCount, -1).
 
 -spec auth_failed(binary(), binary()) -> metrics_notify_return().
 auth_failed(_,Server) ->
-    mongoose_metrics:update({Server, sessionAuthFails}, {global, sessionAuthFails}, 1).
+    mongoose_metrics:update(Server, sessionAuthFails, 1).
 
 -spec user_send_packet(ejabberd:jid(), tuple(), tuple()
                       ) -> metrics_notify_return().
 user_send_packet(#jid{server = Server},_,Packet) ->
-    mongoose_metrics:update({Server, xmppStanzaSent}, {global, xmppStanzaSent}, 1),
+    mongoose_metrics:update(Server, xmppStanzaSent, 1),
     user_send_packet_type(Server, Packet).
 
 -spec user_send_packet_type(Server :: ejabberd:server(),
                             Packet :: jlib:xmlel()) -> metrics_notify_return().
 user_send_packet_type(Server, #xmlel{name = <<"message">>}) ->
-    mongoose_metrics:update({Server, xmppMessageSent}, {global, xmppMessageSent}, 1);
+    mongoose_metrics:update(Server, xmppMessageSent, 1);
 user_send_packet_type(Server, #xmlel{name = <<"iq">>}) ->
-    mongoose_metrics:update({Server, xmppIqSent}, {global, xmppIqSent}, 1);
+    mongoose_metrics:update(Server, xmppIqSent, 1);
 user_send_packet_type(Server, #xmlel{name = <<"presence">>}) ->
-    mongoose_metrics:update({Server, xmppPresenceSent}, {global, xmppPresenceSent}, 1).
+    mongoose_metrics:update(Server, xmppPresenceSent, 1).
 
 -spec user_receive_packet(ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
 user_receive_packet(#jid{server = Server} ,_,_,Packet) ->
-    mongoose_metrics:update({Server, xmppStanzaReceived}, {global, xmppStanzaReceived}, 1),
+    mongoose_metrics:update(Server, xmppStanzaReceived, 1),
     user_receive_packet_type(Server, Packet).
 
 -spec user_receive_packet_type(Server :: ejabberd:server(),
                                Packet :: jlib:xmlel()) -> metrics_notify_return().
 user_receive_packet_type(Server, #xmlel{name = <<"message">>}) ->
-    mongoose_metrics:update({Server, xmppMessageReceived}, {global, xmppMessageReceived}, 1);
+    mongoose_metrics:update(Server, xmppMessageReceived, 1);
 user_receive_packet_type(Server, #xmlel{name = <<"iq">>}) ->
-    mongoose_metrics:update({Server, xmppIqReceived}, {global, xmppIqReceived}, 1);
+    mongoose_metrics:update(Server, xmppIqReceived, 1);
 user_receive_packet_type(Server, #xmlel{name = <<"presence">>}) ->
-    mongoose_metrics:update({Server, xmppPresenceReceived}, {global, xmppPresenceReceived}, 1).
+    mongoose_metrics:update(Server, xmppPresenceReceived, 1).
 
 -spec xmpp_bounce_message(Server :: ejabberd:server(),
                           tuple()) -> metrics_notify_return().
 xmpp_bounce_message(Server, _) ->
-    mongoose_metrics:update({Server, xmppMessageBounced}, {global, xmppMessageBounced}, 1).
+    mongoose_metrics:update(Server, xmppMessageBounced, 1).
 
 -spec xmpp_stanza_dropped(ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
 xmpp_stanza_dropped(#jid{server = Server} ,_,_) ->
-   mongoose_metrics:update({Server, xmppStanzaDropped}, {global, xmppStanzaDropped}, 1).
+   mongoose_metrics:update(Server, xmppStanzaDropped, 1).
 
 -spec xmpp_send_element(Server :: ejabberd:server(),
                         Packet :: jlib:xmlel()) -> ok | metrics_notify_return().
 xmpp_send_element(Server, #xmlel{name = Name, attrs = Attrs}) ->
-    mongoose_metrics:update({Server, xmppStanzaCount}, {global, xmppStanzaCount}, 1),
+    mongoose_metrics:update(Server, xmppStanzaCount, 1),
     case lists:keyfind(<<"type">>, 1, Attrs) of
         {<<"type">>, <<"error">>} ->
-            mongoose_metrics:update({Server, xmppErrorTotal}, {global, xmppErrorTotal}, 1),
+            mongoose_metrics:update(Server, xmppErrorTotal, 1),
             case Name of
                 <<"iq">> ->
-                    mongoose_metrics:update({Server, xmppErrorIq}, {global, xmppErrorIq}, 1);
+                    mongoose_metrics:update(Server, xmppErrorIq, 1);
                 <<"message">> ->
-                    mongoose_metrics:update({Server, xmppErrorMessage},
-                                            {global, xmppErrorMessage}, 1);
+                    mongoose_metrics:update(Server, xmppErrorMessage, 1);
                 <<"presence">> ->
-                    mongoose_metrics:update({Server, xmppErrorPresence},
-                                            {global, xmppErrorPresence}, 1)
+                    mongoose_metrics:update(Server, xmppErrorPresence, 1)
             end;
         _ -> ok
     end;
@@ -192,44 +190,42 @@ xmpp_send_element(_, _) ->
 
 -spec roster_get(list(), {_, ejabberd:server()}) -> list().
 roster_get(Acc, {_, Server}) ->
-    mongoose_metrics:update({Server, modRosterGets}, {global, modRosterGets}, 1),
+    mongoose_metrics:update(Server, modRosterGets, 1),
     Acc.
 
 -spec roster_set(JID :: ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
 roster_set(#jid{server = Server},_,_) ->
-    mongoose_metrics:update({Server, modRosterSets}, {global, modRosterSets}, 1).
+    mongoose_metrics:update(Server, modRosterSets, 1).
 
 -spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
 roster_in_subscription(Acc,_,Server,_,subscribed,_) ->
-    mongoose_metrics:update({Server, modPresenceSubscriptions},
-                            {global, modPresenceSubscriptions}, 1),
+    mongoose_metrics:update(Server, modPresenceSubscriptions, 1),
     Acc;
 roster_in_subscription(Acc,_,Server,_,unsubscribed,_) ->
-    mongoose_metrics:update({Server, modPresenceUnsubscriptions},
-                            {global, modPresenceUnsubscriptions}, 1),
+    mongoose_metrics:update(Server, modPresenceUnsubscriptions, 1),
     Acc;
 roster_in_subscription(Acc,_,_,_,_,_) ->
     Acc.
 
 -spec roster_push(ejabberd:jid(),term()) -> metrics_notify_return().
 roster_push(#jid{server = Server},_) ->
-    mongoose_metrics:update({Server, modRosterPush}, {global, modRosterPush}, 1).
+    mongoose_metrics:update(Server, modRosterPush, 1).
 
 %% Register
 
 -spec register_user(binary(), ejabberd:server()) -> metrics_notify_return().
 register_user(_,Server) ->
-    mongoose_metrics:update({Server, modRegisterCount}, {global, modRegisterCount}, 1).
+    mongoose_metrics:update(Server, modRegisterCount, 1).
 
 -spec remove_user(binary(), ejabberd:server()) -> metrics_notify_return().
 remove_user(_,Server) ->
-    mongoose_metrics:update({Server, modUnregisterCount}, {global, modUnregisterCount}, 1).
+    mongoose_metrics:update(Server, modUnregisterCount, 1).
 
 %% Privacy
 
 -spec privacy_iq_get(term(), ejabberd:jid(), ejabberd:jid(), term(), term()) -> term().
 privacy_iq_get(Acc, #jid{server  = Server}, _, _, _) ->
-    mongoose_metrics:update({Server, modPrivacyGets}, {global, modPrivacyGets}, 1),
+    mongoose_metrics:update(Server, modPrivacyGets, 1),
     Acc.
 
 -spec privacy_iq_set(Acc :: term(),
@@ -240,15 +236,13 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
     #xmlel{children = Els} = SubEl,
     case xml:remove_cdata(Els) of
         [#xmlel{name = <<"active">>}] ->
-            mongoose_metrics:update({Server, modPrivacySetsActive},
-                                    {global, modPrivacySetsActive}, 1);
+            mongoose_metrics:update(Server, modPrivacySetsActive, 1);
         [#xmlel{name = <<"default">>}] ->
-            mongoose_metrics:update({Server, modPrivacySetsDefault},
-                                    {global, modPrivacySetsDefault}, 1);
+            mongoose_metrics:update(Server, modPrivacySetsDefault, 1);
         _ ->
             ok
     end,
-    mongoose_metrics:update({Server, modPrivacySets}, {global, modPrivacySets}, 1),
+    mongoose_metrics:update(Server, modPrivacySets, 1),
     Acc.
 
 -spec privacy_list_push(_From :: ejabberd:jid(),
@@ -256,7 +250,7 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
                         Broadcast :: ejabberd_c2s:broadcast(),
                         SessionCount :: non_neg_integer()) -> ok | metrics_notify_return().
 privacy_list_push(_From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
-    mongoose_metrics:update({Server, modPrivacyPush}, {global, modPrivacyPush}, SessionCount).
+    mongoose_metrics:update(Server, modPrivacyPush, SessionCount).
 
 user_ping_timeout(_JID) ->
     ok.
@@ -266,14 +260,12 @@ user_ping_timeout(_JID) ->
                           Server :: ejabberd:server(),
                           term(), term(), term()) -> allow | deny | block.
 privacy_check_packet(Acc, _, Server, _, _, _) ->
-    mongoose_metrics:update({Server, modPrivacyStanzaAll}, {global, modPrivacyStanzaAll}, 1),
+    mongoose_metrics:update(Server, modPrivacyStanzaAll, 1),
     case Acc of
         deny ->
-            mongoose_metrics:update({Server, modPrivacyStanzaDenied},
-                                    {global, modPrivacyStanzaDenied}, 1);
+            mongoose_metrics:update(Server, modPrivacyStanzaDenied, 1);
         block ->
-            mongoose_metrics:update({Server, modPrivacyStanzaBlocked},
-                                    {global, modPrivacyStanzaBlocked}, 1);
+            mongoose_metrics:update(Server, modPrivacyStanzaBlocked, 1);
         allow ->
             ok
     end,
@@ -287,7 +279,7 @@ privacy_check_packet(Acc, _, Server, _, _, _) ->
                     _ArcID :: mod_mam:archive_id(),
                     _ArcJID :: ejabberd:jid()) -> any().
 mam_get_prefs(Result, Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMamPrefsGets}, {global, modMamPrefsGets}, 1),
+    mongoose_metrics:update(Host, modMamPrefsGets, 1),
     Result.
 
 -spec mam_set_prefs(Result :: any(), Host :: ejabberd:server(),
@@ -295,26 +287,25 @@ mam_get_prefs(Result, Host, _ArcID, _ArcJID) ->
     _DefaultMode :: any(), _AlwaysJIDs :: [ejabberd:literal_jid()],
     _NeverJIDs :: [ejabberd:literal_jid()]) -> any().
 mam_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJIDs) ->
-    mongoose_metrics:update({Host, modMamPrefsSets}, {global, modMamPrefsSets}, 1),
+    mongoose_metrics:update(Host, modMamPrefsSets, 1),
     Result.
 
 -spec mam_remove_archive(Host :: ejabberd:server(),
                          _ArcID :: mod_mam:archive_id(),
                          _ArcJID :: ejabberd:jid()) -> metrics_notify_return().
 mam_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMamArchiveRemoved}, {global, modMamArchiveRemoved}, 1).
+    mongoose_metrics:update(Host, modMamArchiveRemoved, 1).
 
 mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
     _RSM, _Borders,
     _Start, _End, _Now, _WithJID,
     _PageSize, _LimitPassed, _MaxResultLimit, IsSimple) ->
-    mongoose_metrics:update({Host, modMamForwarded}, {global, modMamForwarded}, length(MessageRows)),
-    mongoose_metrics:update({Host, modMamLookups}, {globl, modMamLookups}, 1),
+    mongoose_metrics:update(Host, modMamForwarded, length(MessageRows)),
+    mongoose_metrics:update(Host, modMamLookups, 1),
     case IsSimple of
         true ->
-            mongoose_metrics:update([Host, modMamLookups, simple],
-                                    [global, modMamLookups, simple], 1);
+            mongoose_metrics:update(Host, [modMamLookups, simple], 1);
         _ ->
             ok
     end,
@@ -332,35 +323,35 @@ mam_lookup_messages(Result = {error, _},
     _SrcJID :: ejabberd:jid(), _Dir :: atom(), _Packet :: jlib:xmlel()) -> any().
 mam_archive_message(Result, Host,
     _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
-    mongoose_metrics:update({Host, modMamArchived}, {global, modMamArchived}, 1),
+    mongoose_metrics:update(Host, modMamArchived, 1),
     Result.
 
 -spec mam_flush_messages(Host :: ejabberd:server(),
                          MessageCount :: integer()) -> metrics_notify_return().
 mam_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update({Host, modMamFlushed}, {global, modMamFlushed}, MessageCount).
+    mongoose_metrics:update(Host, modMamFlushed, MessageCount).
 
 -spec mam_drop_message(Host :: ejabberd:server()) -> metrics_notify_return().
 mam_drop_message(Host) ->
-    mongoose_metrics:update({Host, modMamDropped}, {global, modMamDropped}, 1).
+    mongoose_metrics:update(Host, modMamDropped, 1).
 
 -spec mam_drop_iq(Host :: ejabberd:server(), _To :: ejabberd:jid(),
     _IQ :: ejabberd:iq(), _Action :: any(), _Reason :: any()) -> metrics_notify_return().
 mam_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update({Host, modMamDroppedIQ}, {global, modMamDroppedIQ}, 1).
+    mongoose_metrics:update(Host, modMamDroppedIQ, 1).
 
 -spec mam_drop_messages(Host :: ejabberd:server(),
                         Count :: integer()) -> metrics_notify_return().
 mam_drop_messages(Host, Count) ->
-    mongoose_metrics:update({Host, modMamDropped2}, {global, modMamDropped2}, Count).
+    mongoose_metrics:update(Host, modMamDropped2, Count).
 
 mam_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
-    mongoose_metrics:update({Host, modMamSinglePurges}, {global, modMamSinglePurges}, 1),
+    mongoose_metrics:update(Host, modMamSinglePurges, 1),
     Result.
 
 mam_purge_multiple_messages(Result, Host,
     _ArcID, _ArcJID, _Borders, _Start, _End, _Now, _WithJID) ->
-    mongoose_metrics:update({Host, modMamMultiplePurges}, {global, modMamMultiplePurges}, 1),
+    mongoose_metrics:update(Host, modMamMultiplePurges, 1),
     Result.
 
 
@@ -368,24 +359,23 @@ mam_purge_multiple_messages(Result, Host,
 %% mod_mam_muc
 
 mam_muc_get_prefs(Result, Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMucMamPrefsGets}, {global, modMucMamPrefsGets}, 1),
+    mongoose_metrics:update(Host, modMucMamPrefsGets, 1),
     Result.
 
 mam_muc_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJIDs) ->
-    mongoose_metrics:update({Host, modMucMamPrefsSets}, {global, modMucMamPrefsSets}, 1),
+    mongoose_metrics:update(Host, modMucMamPrefsSets, 1),
     Result.
 
 mam_muc_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update({Host, modMucMamArchiveRemoved}, {global, modMucMamArchiveRemoved}, 1).
+    mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1).
 
 mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
     _RSM, _Borders,
     _Start, _End, _Now, _WithJID,
     _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
-    mongoose_metrics:update({Host, modMucMamForwarded}, {global, modMucMamForwarded},
-                            length(MessageRows)),
-    mongoose_metrics:update({Host, modMucMamLookups}, {global, modMucMamLookups}, 1),
+    mongoose_metrics:update(Host, modMucMamForwarded, length(MessageRows)),
+    mongoose_metrics:update(Host, modMucMamLookups, 1),
     Result;
 mam_muc_lookup_messages(Result = {error, _},
     _Host, _ArcID, _ArcJID,
@@ -397,26 +387,26 @@ mam_muc_lookup_messages(Result = {error, _},
 
 mam_muc_archive_message(Result, Host,
     _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
-    mongoose_metrics:update({Host, modMucMamArchived}, {global, modMucMamArchived}, 1),
+    mongoose_metrics:update(Host, modMucMamArchived, 1),
     Result.
 
 mam_muc_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update({Host, modMucMamFlushed}, {global, modMucMamFlushed}, MessageCount).
+    mongoose_metrics:update(Host, modMucMamFlushed, MessageCount).
 
 mam_muc_drop_message(Host) ->
-    mongoose_metrics:update({Host, modMucMamDropped}, {global, modMucMamDropped}, 1).
+    mongoose_metrics:update(Host, modMucMamDropped, 1).
 
 mam_muc_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update({Host, modMucMamDroppedIQ}, {global, modMucMamDroppedIQ}, 1).
+    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1).
 
 mam_muc_drop_messages(Host, Count) ->
-    mongoose_metrics:update({Host, modMucMamDropped2}, {global, modMucMamDropped2}, Count).
+    mongoose_metrics:update(Host, modMucMamDropped2, Count).
 
 -spec mam_muc_purge_single_message(Result :: any(), Host :: ejabberd:server(),
     _MessID :: mod_mam:message_id(), _ArcID :: mod_mam:archive_id(),
     _ArcJID :: ejabberd:jid(), _Now :: mod_mam:unix_timestamp()) -> any().
 mam_muc_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
-    mongoose_metrics:update({Host, modMucMamSinglePurges}, {global, modMucMamSinglePurges}, 1),
+    mongoose_metrics:update(Host, modMucMamSinglePurges, 1),
     Result.
 
 -spec mam_muc_purge_multiple_messages(Result :: any(),
@@ -425,7 +415,7 @@ mam_muc_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
     _End :: any(), _Now :: mod_mam:unix_timestamp(), _WithJID :: any()) -> any().
 mam_muc_purge_multiple_messages(Result, Host,
     _ArcID, _ArcJID, _Borders, _Start, _End, _Now, _WithJID) ->
-    mongoose_metrics:update({Host, modMucMamMultiplePurges}, {global, modMucMamMultiplePurges}, 1),
+    mongoose_metrics:update(Host, modMucMamMultiplePurges, 1),
     Result.
 
 

--- a/apps/ejabberd/test/component_reg_SUITE.erl
+++ b/apps/ejabberd/test/component_reg_SUITE.erl
@@ -17,7 +17,9 @@ init_per_suite(C) ->
     meck:new(ejabberd_config),
     meck:expect(ejabberd_config, get_local_option,
         fun(routing_modules) ->
-            [xmpp_router_a, xmpp_router_b, xmpp_router_c]
+                [xmpp_router_a, xmpp_router_b, xmpp_router_c];
+           (_) ->
+                undefined
         end),
     application:ensure_all_started(exometer),
     ejabberd_router:start_link(),

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -34,7 +34,7 @@ setup() ->
                 fun() -> "57" end),
 
     meck:new(mongoose_metrics),
-    meck:expect(mongoose_metrics, update, fun (_,_) -> ok end).
+    meck:expect(mongoose_metrics, update, fun (_,_,_) -> ok end).
 
 teardown() ->
     meck:unload().

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -87,6 +87,7 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, Config) ->
     clean_sessions(Config),
     meck:unload(acl),
+    meck:unload(ejabberd_config),
     meck:unload(ejabberd_hooks),
     Config.
 
@@ -273,6 +274,7 @@ unique_count_while_removing_entries(C) ->
     USDict = get_unique_us_dict(UsersWithManyResources),
     %% Check if unique count equals prev cached value
     UniqueCount = ejabberd_sm:get_unique_sessions_number(),
+    meck:unload(?B(C)),
     true = UniqueCount /= dict:size(USDict) + UniqueCount.
 
 set_meck(SMBackend) ->
@@ -280,6 +282,7 @@ set_meck(SMBackend) ->
     meck:expect(ejabberd_config, get_global_option,
                 fun(sm_backend) -> SMBackend;
                     (hosts) -> [<<"localhost">>] end),
+    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
 
     meck:new(ejabberd_hooks, []),
     meck:expect(ejabberd_hooks, add, fun(_, _, _, _, _) -> ok end),
@@ -295,6 +298,8 @@ unload_meck() ->
     meck:unload(ejabberd_commands).
 
 set_test_case_meck(MaxUserSessions) ->
+    meck:new(ejabberd_config, []),
+    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     meck:new(acl, []),
     meck:expect(acl, match_rule, fun(_, _, _) -> MaxUserSessions end),
     meck:new(ejabberd_hooks, []),

--- a/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
+++ b/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
@@ -50,10 +50,10 @@ end_per_testcase(T, Config) ->
     unload_meck(meck_mods(T)),
     Config.
 
-meck_mods(bosh) -> [exometer, mod_bosh_socket];
+meck_mods(bosh) -> [exometer, mod_bosh_socket, ejabberd_config];
 meck_mods(s2s) -> [exometer, ejabberd_commands, randoms, ejabberd_config];
 meck_mods(local) -> [exometer, ejabberd_config];
-meck_mods(_) -> [exometer, ejabberd_sm, ejabberd_local].
+meck_mods(_) -> [exometer, ejabberd_sm, ejabberd_local, ejabberd_config].
 
 %% -----------------------------------------------------
 %% Tests
@@ -172,6 +172,7 @@ setup_meck([ejabberd_config | R]) ->
                     (hosts) -> [];
                     (_) -> undefined
                 end),
+    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     setup_meck(R);
 setup_meck([ejabberd_commands | R]) ->
     meck:new(ejabberd_commands),

--- a/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
+++ b/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
@@ -8,9 +8,27 @@
 
 -compile([export_all]).
 
-all() -> [no_skip_metric, subscriptions_initialised].
+all() ->
+    [
+     {group, ordinary_mode},
+     {group, all_metrics_are_global}
+    ].
+
+-define(ALL_CASES, [no_skip_metric, subscriptions_initialised]).
+
+groups() ->
+    [
+     {ordinary_mode, [], ?ALL_CASES},
+     {all_metrics_are_global, [], ?ALL_CASES}
+    ].
 
 init_per_suite(C) ->
+    C.
+
+end_per_suite(C) ->
+    C.
+
+init_per_group(Group, C) ->
     application:load(exometer),
     application:set_env(exometer, mongooseim_report_interval, 1000),
     {Port, Socket} = carbon_cache_server:start(1, 0),
@@ -41,11 +59,11 @@ init_per_suite(C) ->
     application:set_env(exometer, report, Reporters),
     PortServer = carbon_cache_server:wait_for_accepting(),
     {ok, _Apps} = application:ensure_all_started(exometer),
-    setup_meck(),
+    setup_meck(Group),
     exometer:new([carbon, packets], spiral),
     [{carbon_port, Port}, {test_sup, Sup}, {carbon_server, PortServer}, {carbon_socket, Socket} | C].
 
-end_per_suite(C) ->
+end_per_group(Name, C) ->
     Sup = ?config(test_sup, C),
     Sup ! stop,
     CarbonServer = ?config(carbon_server, C),
@@ -74,10 +92,13 @@ wait_for_update({ok, [{count,0}]}, N) ->
     timer:sleep(1000),
     wait_for_update(exometer:get_value([carbon, packets], count), N-1).
 
-setup_meck() ->
+setup_meck(Group) ->
     meck:new(ejabberd_config, [no_link]),
     meck:expect(ejabberd_config, get_global_option, fun(hosts) -> [<<"localhost">>] end),
-    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
+    meck:expect(ejabberd_config, get_local_option,
+                fun (all_metrics_are_global) -> Group =:= all_metrics_are_global;
+                    (_) -> undefined
+                end),
     ok.
 
 get_reporters_cfg(Port) ->

--- a/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
+++ b/apps/ejabberd/test/mongooseim_metrics_SUITE.erl
@@ -77,6 +77,7 @@ wait_for_update({ok, [{count,0}]}, N) ->
 setup_meck() ->
     meck:new(ejabberd_config, [no_link]),
     meck:expect(ejabberd_config, get_global_option, fun(hosts) -> [<<"localhost">>] end),
+    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     ok.
 
 get_reporters_cfg(Port) ->

--- a/apps/ejabberd/test/muc_light_SUITE.erl
+++ b/apps/ejabberd/test/muc_light_SUITE.erl
@@ -4,8 +4,8 @@
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include("mod_muc_light.hrl").
--include("jlib.hrl").
+-include_lib("ejabberd/include/mod_muc_light.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
 
 -define(DOMAIN, <<"localhost">>).
 
@@ -32,7 +32,7 @@ groups() ->
     ].
 
 init_per_group(rsm_disco, Config) ->
-    application:start(p1_stringprep),
+    application:start(stringprep),
     Config;
 init_per_group(_, Config) ->
     Config.

--- a/apps/ejabberd/test/xmpp_route_SUITE.erl
+++ b/apps/ejabberd/test/xmpp_route_SUITE.erl
@@ -16,7 +16,9 @@ init_per_suite(C) ->
     meck:new(ejabberd_config),
     meck:expect(ejabberd_config, get_local_option,
         fun(routing_modules) ->
-            [xmpp_router_a, xmpp_router_b, xmpp_router_c]
+            [xmpp_router_a, xmpp_router_b, xmpp_router_c];
+           (_) ->
+            undefined
         end),
     {ok, _} = application:ensure_all_started(exometer),
     ejabberd_router:start_link(),

--- a/apps/ejabberd/test/zlib_driver_SUITE.erl
+++ b/apps/ejabberd/test/zlib_driver_SUITE.erl
@@ -11,9 +11,10 @@ stanza_1024(_)->
     %% Just random 1024 bytes data
     Data = <<"iGzHvZgQbX6oTJYViq9Xy3MncZtDlypeFWNF61owolz8boGSqsr5wxtfT42QSJIMShM6MZInMHBUh9unSYpuwqfzlLIZ3ZNfjje7YsLhaITQzXXNABsXdvjUMU437FJppLeLVob9M4ZcUpAOdMSpCB1t6KKgWBmNEdkbo9VL2seDdpYT3AcZlGOsy73pk7og3KirclNJM6NFI2wARifUdE9ShEJhlncjOQnG3ExCnjGsRSGcJl8eh6Vjsq8pavfhOTYyE6z4xBPG4jKtZCiqVO1uaWQjeTOPZnhPdnVThcrpVS1GiB33xZz9p6pRw2ricGbsbZoUNIQQqBsL5VGZeNQhRLAoiNsT1S3kJl43Mm6rvIy8rM5Jm9y4NXvkZcjgPpmfySmgXSygWshbjGbaUlwub2ZCe7C5Z1vQL7n5DutDefQcFXJScMWiOW11ye9UIx9u29qVp2HhzhJ1dtAheBBk6unVNTVkQJoyMcdVAFSQ4yob66WKm33xkrtxgvyAFesdWwXFc6VNGxtXjBYu2Hd8jyDSAzl9wK3CRF9rraKSLSv3ycTFty16noELhJwzQQ2zjkQerms7MR98nmmGFLA1DgaZXSwQnWl4A3k8mTvxsWfhVgZDdkcvwqmFB3JHJsKfUuakt921dJ3uXI5ywsV3nVi3Skpuj3OiV9mfZzNp2J8mE7zxX5RtgV3phcfIEA52gBb8TngbL8hnPPkJy1tTaYYtNCcZEHaLd8XKUPa2aAr7rMdLzqhiaGPY6JWIncDWKGW8EOCOXXKVIgXtFEhAjZlc6e7LSOvkBbJTkh3hoS9Ow9daLJrnIGIMDRT1NxhHX9iYzvUAs9c78zZjTA7CWFWRhj5Ui7koQrMXzIszmVDTGe3y5Ml6bNMMUtZUT2eK7QSnU4wFwFqeviN56XN4qugVMW9J6YbVY5bZA77fpUW92TUHXA2jhXldNpFL8cc82p5XNNQERaqBDA15EHuotqaVDZGCYPkvPLqXlx9UjOLJltDAAKYlifQQonPW">>,
 
-    case erl_ddll:load_driver("../../../ejabberd/priv/lib", ejabberd_zlib_drv) of
-	ok -> ok;
-	{error, already_loaded} -> ok
+    case erl_ddll:load_driver(filename:join(code:priv_dir(ejabberd), "lib"), ejabberd_zlib_drv) of
+        ok -> ok;
+        {error, already_loaded} -> ok;
+        {error, ErrorDesc} -> error(erl_ddll:format_error(ErrorDesc))
     end,
 
     Port = open_port({spawn, ejabberd_zlib_drv}, [binary]),

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -202,6 +202,12 @@ See [Database backends configuration](./advanced-configuration/database-backends
     * **Description:** Default language for messages sent by server to users. You can get a full list of supported codes by executing `cd [MongooseIM root] ; ls apps/ejabberd/priv/*.msg | awk '{split($0,a,"/"); split(a[4],b,"."); print b[1]}'` (`en` is not listed there)
     * **Default:** `en`
 
+### Miscellaneous
+
+* **all_metrics_are_global** (local)
+    * **Description:** When enabled, all per-host metrics are merged into global equivalents. It means it is no longer possible to view individual host1, host2, host3, ... metrics, only sums are available. This option significantly reduces CPU and (especially) memory footprint in setups with exceptionally many domains (thousands, tens of thousands).
+    * **Default:** `false`
+
 ### Modules
 
 For specific configuration, please refer to [Modules](advanced-configuration/Modules.md) page.

--- a/doc/Basic-configuration.md
+++ b/doc/Basic-configuration.md
@@ -45,6 +45,9 @@ There are 2 types of options: params and features. Unlike params, features can b
 * **auth_ldap** - feature
     * **Description:** Put [[LDAP configuration]] here.
 
+* **all_metrics_are_global** - param
+    * **Description:** When set to 'true', per-host metrics are replaced with global equivalents. For more info consult [Advanced configuration](Advanced-configuration.md)
+
 * **s2s_addr** - feature
     * **Description:** Override DNS lookup for specific non-local XMPP domain and use predefined server IP and port for S2S connection (server-to-server).
     * **Syntax:** `"{ {s2s_addr, \"some-domain\"}, { {10,20,30,40}, 7890 } }."`

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -5,7 +5,7 @@ They are managed by [Feuerlabs's exometer](https://github.com/Feuerlabs/exometer
  
 All metrics are divided into following groups:
 
-* host metrics: organized by XMPP hosts, meaning if MongooseIM servers host `a.com` and `b.com` metrics for specific host only can be obtained. 
+* host metrics: organized by XMPP hosts, meaning if MongooseIM servers host `a.com` and `b.com` metrics for specific host only can be obtained. **Warning:** They can become a performance issue when cluster supports many (thousands or more) domains. In such case it is recommended to replace them with global equivalents with `all_metrics_are_global` config option.
 * global metrics: metrics common for all XMPP hosts 
 * backend metrics: these are mainly metrics specific for backend modules
 * data metrics: various metrics related to data sizes (e.g. sent and received stanza size statistics)
@@ -101,7 +101,6 @@ All metrics are divided into following groups:
 | xmppStanzaDropped | spiral | host, XMPP | Number of dropped stanzas |
 | xmppStanzaReceived | spiral | host, XMPP | Number of stanzas received by the server|
 | xmppStanzaSent | spiral | host, XMPP | Numb of stanzas sent to clients|
-
 
 Metrics assgined to group `hook` are generic metrics updated when given hook is run. In case of these metric, their names are the same as corresponding hook name.
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -649,6 +649,10 @@
 %% [{language, "ru"}]
 %%}.
 
+%%%.   ================
+%%%'   MISCELLANEOUS
+
+{all_metrics_are_global, {{all_metrics_are_global}} }.
 
 %%%.   =======
 %%%'   MODULES

--- a/rel/reltool_vars/fed1_vars.config
+++ b/rel/reltool_vars/fed1_vars.config
@@ -18,3 +18,4 @@
 {http_api_old_endpoint, "{5293, \"127.0.0.1\"}"}.
 {http_api_endpoint, "{8094, \"127.0.0.1\"}"}.
 {http_api_client_endpoint, "8095"}.
+{all_metrics_are_global, false}.

--- a/rel/reltool_vars/node1_vars.config
+++ b/rel/reltool_vars/node1_vars.config
@@ -44,6 +44,7 @@
 { {s2s_addr, "localhost2"}, {127,0,0,1} }.
 { {s2s_addr, "michał"}, {127,0,0,1} }.
 {module_host_config, ""}.
+{all_metrics_are_global, false}.
 {registration_watchers, "{registration_watchers, [\"admin@localhost\"]},"}.
 {tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls,"}.
 {https_config, "{ssl, [{certfile, \"priv/ssl/fake_cert.pem\"}, {keyfile, \"priv/ssl/fake_key.pem\"}, {password, \"\"}]},"}.

--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -42,3 +42,6 @@
     "                {ip, {127, 0, 0, 1}},\n"
     "                {password, \"secret\"}\n"
     "           ]}"}.
+
+{all_metrics_are_global, true}.
+

--- a/rel/reltool_vars/node3_vars.config
+++ b/rel/reltool_vars/node3_vars.config
@@ -30,3 +30,4 @@
 {http_api_old_endpoint, "{5292, \"127.0.0.1\"}"}.
 {http_api_endpoint, "{8092, \"127.0.0.1\"}"}.
 {http_api_client_endpoint, "8093"}.
+{all_metrics_are_global, false}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -48,6 +48,8 @@
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
 
+{all_metrics_are_global, "false"}.
+
 %% Defined in Makefile by appending configure.vars.config
 %% Uncomment for manual release generation.
 %{mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -16,6 +16,7 @@
 {ejabberd_secondary_domain, <<"localhost.bis">>}.
 {ejabberd_reloaded_domain, <<"sogndal">>}.
 {ejabberd_metrics_rest_port, 5288}.
+{ejabberd2_metrics_rest_port, 5289}.
 {ejabberd_string_format, bin}.
 
 %% TODO: in every new use case this should be used instead
@@ -152,6 +153,12 @@
         {server, <<"localhost">>},
         {host, <<"localhost">>},
         {password, <<"distributionftw">>},
+        {port, 5232}]},
+    {clusterbuddy, [
+        {username, <<"clusterbuddy">>},
+        {server, <<"localhost">>},
+        {host, <<"localhost">>},
+        {password, <<"wasssssssup">>},
         {port, 5232}]}
 ]}.
 

--- a/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -163,7 +163,7 @@ end_per_testcase(CaseName, Config) ->
 
 one_to_one_message(ConfigIn) ->
     %% Given Alice connected to node one and ClusterGuy connected to node two
-    Metrics = [{[data, dist], [{recv_oct, '>'}, {send_oct, '>'}]}],
+    Metrics = [{[global, data, dist], [{recv_oct, '>'}, {send_oct, '>'}]}],
     Config = [{mongoose_metrics, Metrics} | ConfigIn],
     escalus:story(Config, [{alice, 1}, {clusterguy, 1}], fun(Alice, ClusterGuy) ->
         %% When Alice sends a message to ClusterGuy

--- a/test/ejabberd_tests/tests/conf_reload_SUITE.erl
+++ b/test/ejabberd_tests/tests/conf_reload_SUITE.erl
@@ -38,10 +38,12 @@ all() ->
 
 groups() ->
     [{xmpp_domain_local_reload, [],
-      [domain_should_change,
+      [
+       domain_should_change,
        user_should_be_registered_and_unregistered_via_ctl,
        user_should_be_registered_and_unregistered_via_xmpp,
-       user_should_be_disconnected_from_removed_domain]}].
+       user_should_be_disconnected_from_removed_domain
+       ]}].
 
 suite() ->
     [{required, ejabberd_reloaded_domain} | escalus:suite()].

--- a/test/ejabberd_tests/tests/katt_helper.erl
+++ b/test/ejabberd_tests/tests/katt_helper.erl
@@ -42,7 +42,7 @@ run(BlueprintName, Config, Params) ->
     Blueprint = blueprint(BlueprintName, Config),
     Params1 = [{hostname, "localhost"},
                {port, ct:get_config(ejabberd_metrics_rest_port)}],
-    Params2 = Params ++ Params1,
+    Params2 = lists:ukeymerge(1, lists:keysort(1, Params), lists:keysort(1, Params1)),
     {TestResult, _, _, _, TransResults} = Result = katt:run(Blueprint, Params2),
     case TestResult of
         pass ->

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -737,7 +737,7 @@ init_per_testcase(C=archived, ConfigIn) ->
     Config = case ?config(configuration, ConfigIn) of
                  odbc_async_pool ->
                      MongooseMetrics = [
-                                        {[data, odbc, mam_async],
+                                        {[global, data, odbc, mam_async],
                                          [{recv_oct, '>'}, {send_oct, '>'}]}
                                        ],
                      [{mongoose_metrics, MongooseMetrics} | ConfigIn];
@@ -937,8 +937,8 @@ simple_archive_request(ConfigIn) ->
         assert_respond_query_id(P, <<"q1">>, parse_result_iq(P, Res)),
         ok
         end,
-    MongooseMetrics = [{[backends, mod_mam, archive], changed},
-                       {[backends, mod_mam, lookup], changed}
+    MongooseMetrics = [{[global, backends, mod_mam, archive], changed},
+                       {[global, backends, mod_mam, lookup], changed}
                       ],
     Config = [{mongoose_metrics, MongooseMetrics} | ConfigIn],
     escalus:story(Config, [{alice, 1}, {bob, 1}], F).

--- a/test/ejabberd_tests/tests/metrics_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_api_SUITE.erl
@@ -34,7 +34,8 @@
 %% Suite configuration
 %%--------------------------------------------------------------------
 all() ->
-    [{group, metrics},
+    [
+     {group, metrics},
      {group, stories},
      {group, global}
     ].

--- a/test/ejabberd_tests/tests/metrics_api_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_api_SUITE.erl
@@ -244,9 +244,13 @@ find(CounterName, CounterList) ->
         {CounterName, Val} -> Val end.
 
 fetch_counter_value(Counter, Config) ->
-    Params = [{host, ct:get_config(ejabberd_domain)},
-              {metric, atom_to_list(Counter)}],
-    {_, _, _, Vars, _} = katt_helper:run(metric, Config, Params),
+    {Blueprint, ParamsTail}
+    = case metrics_helper:all_metrics_are_global() of
+               true -> {global, []};
+               _ -> {metric, [{host, ct:get_config(ejabberd_domain)}]}
+           end,
+    Params = [{metric, atom_to_list(Counter)} | ParamsTail],
+    {_, _, _, Vars, _} = katt_helper:run(Blueprint, Config, Params),
     HostValue = proplists:get_value("value_host", Vars),
     HostValueList = proplists:get_value("value_host_list", Vars),
     TotalValue = proplists:get_value("value_total", Vars),

--- a/test/ejabberd_tests/tests/metrics_api_SUITE_data/global_gauge.apib
+++ b/test/ejabberd_tests/tests/metrics_api_SUITE_data/global_gauge.apib
@@ -7,7 +7,9 @@ GET /api/metrics/global/{{<metric}}
 < 200
 < Content-Type: application/json
 {
-    "metric": {"value": "{{>value}}"},
+    "metric": {
+            "value": "{{>value}}"
+        },
     "{{_}}": "{{unexpected}}"
 }
 
@@ -21,7 +23,9 @@ GET /api/metrics/global
 < Content-Type: application/json
 {
     "metrics": {
-            "{{<metric}}": {"value": "{{>value_list}}"},
+            "{{<metric}}": {
+                    "value": "{{>value_list}}"
+                },
     },
     "{{_}}": "{{unexpected}}"
 }

--- a/test/ejabberd_tests/tests/metrics_api_SUITE_data/global_spiral.apib
+++ b/test/ejabberd_tests/tests/metrics_api_SUITE_data/global_spiral.apib
@@ -1,0 +1,33 @@
+# 1. Fetch a global metric
+
+GET /api/metrics/global/{{<metric}}
+> Accept: application/json
+> User-Agent: katt
+> Host: {{<hostname}}:{{<port}}
+< 200
+< Content-Type: application/json
+{
+    "metric": {
+            "one": "{{_}}",
+            "count": "{{>value}}"
+        },
+    "{{_}}": "{{unexpected}}"
+}
+
+# 2. Fetch a global metric value from list
+
+GET /api/metrics/global
+> Accept: application/json
+> User-Agent: katt
+> Host: {{<hostname}}:{{<port}}
+< 200
+< Content-Type: application/json
+{
+    "metrics": {
+            "{{<metric}}": {
+                    "one": "{{_}}",
+                    "count": "{{>value_list}}"
+                },
+    },
+    "{{_}}": "{{unexpected}}"
+}

--- a/test/ejabberd_tests/tests/metrics_api_SUITE_data/metrics_only_global.apib
+++ b/test/ejabberd_tests/tests/metrics_api_SUITE_data/metrics_only_global.apib
@@ -1,0 +1,49 @@
+# 0. GET is the only implemented allowed method
+#    (both OPTIONS and HEAD are for free then)
+
+OPTIONS /api/metrics/
+> User-Agent: katt
+> Host: {{<hostname}}:{{<port}}
+< 200
+< Allow: OPTIONS, HEAD, GET
+
+# 1. List of hosts and metrics
+
+GET /api/metrics/
+> Accept: application/json
+> User-Agent: katt
+> Host: {{<hostname}}:{{<port}}
+< 200
+< Content-Type: application/json
+{
+    "hosts":   ["{{>example_host}}"],
+    "metrics": [],
+    "global": ["{{>example_global}}"],
+    "{{_}}":   "{{unexpected}}"
+}
+
+# 2a. All global metric
+
+GET /api/metrics/global
+> Accept: application/json
+> User-Agent: katt
+> Host: {{<hostname}}:{{<port}}
+< 200
+< Content-Type: application/json
+{
+    "metrics": "{{_}}",
+    "{{_}}": "{{unexpected}}"
+}
+
+# 2b. An example global metric
+
+GET /api/metrics/global/{{<example_global}}
+> Accept: application/json
+> User-Agent: katt
+> Host: {{<hostname}}:{{<port}}
+< 200
+< Content-Type: application/json
+{
+    "metric": "{{_}}",
+    "{{_}}": "{{unexpected}}"
+}

--- a/test/ejabberd_tests/tests/metrics_helper.erl
+++ b/test/ejabberd_tests/tests/metrics_helper.erl
@@ -4,12 +4,9 @@
 
 -compile(export_all).
 
-
-get_counter_value({_, _} = Counter) ->
-    Result = rpc:call(ct:get_config(ejabberd_node),
-                      mongoose_metrics,
-                      get_metric_value,
-                      [Counter]),
+get_counter_value({Host, Metric}) ->
+    Result = rpc:call(ct:get_config(ejabberd_node), mongoose_metrics,
+                      get_metric_value, [make_metric_name(Host, Metric)]),
     case Result of
         {ok, [{count, Total}, {one, _}]} ->
             {value, Total};
@@ -25,6 +22,16 @@ get_counter_value([Host, Metric | _ ]) ->
 get_counter_value(CounterName) ->
     get_counter_value({ct:get_config(ejabberd_domain), CounterName}).
 
-
 assert_counter(Value, CounterName) ->
     {value, Value} = get_counter_value(CounterName).
+
+make_metric_name(Host, Metric) ->
+    case all_metrics_are_global() of
+        true -> [global, Metric];
+        _ -> [Host, Metric]
+    end.
+
+all_metrics_are_global() ->
+    rpc:call(ct:get_config(ejabberd_node), ejabberd_config,
+             get_local_option, [all_metrics_are_global]).
+

--- a/test/ejabberd_tests/tests/metrics_helper.erl
+++ b/test/ejabberd_tests/tests/metrics_helper.erl
@@ -4,6 +4,11 @@
 
 -compile(export_all).
 
+%% We introduce a convention, where metrics-related suites use only 2 accounts
+%% but it depends on `all_metrics_are_global` flag, which duet it will be.
+-define(METRICS_GROUP_USERS, [alice, bob]).
+-define(ONLY_GLOBAL_METRICS_GROUP_USERS, [clusterguy, clusterbuddy]).
+
 get_counter_value(CounterName) ->
     get_counter_value(ct:get_config(ejabberd_domain), CounterName).
 
@@ -28,22 +33,22 @@ assert_counter(Host, Value, CounterName) ->
 -spec prepare_by_all_metrics_are_global(Config :: list(), UseAllMetricsAreGlobal :: boolean()) ->
     list().
 prepare_by_all_metrics_are_global(Config, false) ->
-    escalus:create_users(Config, escalus:get_users([alice, bob]));
+    escalus:create_users(Config, escalus:get_users(?METRICS_GROUP_USERS));
 prepare_by_all_metrics_are_global(Config, true) ->
     Config1 = [{all_metrics_are_global, true} | Config],
     %% TODO: Refactor once escalus becomes compatible with multiple nodes RPC
     Config2 = distributed_helper:add_node_to_cluster(ejabberd_node_utils:mim2(), Config1),
-    escalus:create_users(Config2, escalus:get_users([clusterguy, clusterbuddy])).
+    escalus:create_users(Config2, escalus:get_users(?ONLY_GLOBAL_METRICS_GROUP_USERS)).
 
 -spec finalise_by_all_metrics_are_global(Config :: list(), UseAllMetricsAreGlobal :: boolean()) ->
     list().
 finalise_by_all_metrics_are_global(Config, false) ->
-    escalus:delete_users(Config, escalus:get_users([alice, bob]));
+    escalus:delete_users(Config, escalus:get_users(?METRICS_GROUP_USERS));
 finalise_by_all_metrics_are_global(Config, true) ->
     Config1 = lists:keydelete(all_metrics_are_global, 1, Config),
     %% TODO: Refactor once escalus becomes compatible with multiple nodes RPC
     Config2 = distributed_helper:remove_node_from_cluster(ejabberd_node_utils:mim2(), Config1),
-    escalus:delete_users(Config2, escalus:get_users([clusterguy, clusterbuddy])).
+    escalus:delete_users(Config2, escalus:get_users(?ONLY_GLOBAL_METRICS_GROUP_USERS)).
 
 all_metrics_are_global(Config) ->
     case lists:keyfind(all_metrics_are_global, 1, Config) of
@@ -60,14 +65,22 @@ make_global_groups_names(GroupsNames) ->
 make_global_groups(Groups) ->
     [{make_global_group_name(GN), Opts, Cases} || {GN, Opts, Cases} <- Groups].
 
+%% Converts legacy userspec format to the new one. In order for this function to work 100%
+%% correctly, the suite has to use (prepare|finalise)_by_all_metrics_are_global.
+%% This function is an abstraction over `all_metrics_are_global` true/false distinction.
+%% It automaticaly picks proper users and the suite provides only a number of resources
+%% for user 1 and user 2.
 userspec(User1Count, Config) ->
-    [User1ID | _] = user_ids(Config),
+    [User1ID, _] = user_ids(Config),
     [{User1ID, User1Count}].
 
 userspec(User1Count, User2Count, Config) ->
-    [User1ID, User2ID | _] = user_ids(Config),
+    [User1ID, User2ID] = user_ids(Config),
     [{User1ID, User1Count}, {User2ID, User2Count}].
 
 user_ids(Config) ->
-    [ UserID || {UserID, _Otps} <- proplists:get_value(escalus_users, Config, []) ].
+    case all_metrics_are_global(Config) of
+        true -> ?ONLY_GLOBAL_METRICS_GROUP_USERS;
+        _ -> ?METRICS_GROUP_USERS
+    end.
 

--- a/test/ejabberd_tests/tests/metrics_helper.erl
+++ b/test/ejabberd_tests/tests/metrics_helper.erl
@@ -4,10 +4,27 @@
 
 -compile(export_all).
 
-get_counter_value({Host, Metric}) ->
-    Result = rpc:call(ct:get_config(ejabberd_node), mongoose_metrics,
-                      get_metric_value, [make_metric_name(Host, Metric)]),
-    case Result of
+get_counter_value(CounterName) ->
+    get_counter_value(CounterName, []).
+
+get_counter_value(CounterName, Config) ->
+    get_counter_value(ct:get_config(ejabberd_domain), CounterName, Config).
+
+get_counter_value(Host, Metric, Config) ->
+    RPCFun = case all_metrics_are_global(Config) of
+               true ->
+                     fun() ->
+                             with_rpc_to_node_2(
+                               escalus_ejabberd, rpc,
+                               [mongoose_metrics, get_metric_value, [Host, Metric]])
+                     end;
+               false ->
+                     fun() ->
+                             escalus_ejabberd:rpc(
+                               mongoose_metrics, get_metric_value, [Host, Metric])
+                     end
+           end,
+    case RPCFun() of
         {ok, [{count, Total}, {one, _}]} ->
             {value, Total};
         {ok, [{value, Value} | _]} when is_integer(Value) ->
@@ -16,22 +33,63 @@ get_counter_value({Host, Metric}) ->
             {value, Value};
         _ ->
             {error, unknown_counter}
-    end;
-get_counter_value([Host, Metric | _ ]) ->
-    get_counter_value({Host, Metric});
-get_counter_value(CounterName) ->
-    get_counter_value({ct:get_config(ejabberd_domain), CounterName}).
-
-assert_counter(Value, CounterName) ->
-    {value, Value} = get_counter_value(CounterName).
-
-make_metric_name(Host, Metric) ->
-    case all_metrics_are_global() of
-        true -> [global, Metric];
-        _ -> [Host, Metric]
     end.
 
-all_metrics_are_global() ->
-    rpc:call(ct:get_config(ejabberd_node), ejabberd_config,
-             get_local_option, [all_metrics_are_global]).
+assert_counter(Value, CounterName) ->
+    assert_counter(Value, CounterName, []).
+
+assert_counter(Value, CounterName, Config) ->
+    {value, Value} = get_counter_value(CounterName, Config).
+
+-spec prepare_by_all_metrics_are_global(Config :: list(), UseAllMetricsAreGlobal :: boolean()) ->
+    list().
+prepare_by_all_metrics_are_global(Config, false) ->
+    escalus:create_users(Config, escalus:get_users([alice, bob]));
+prepare_by_all_metrics_are_global(Config, true) ->
+    Config1 = [{all_metrics_are_global, true} | Config],
+    escalus:create_users(Config1, escalus:get_users([clusterguy, clusterbuddy])).
+
+-spec finalise_by_all_metrics_are_global(Config :: list(), UseAllMetricsAreGlobal :: boolean()) ->
+    list().
+finalise_by_all_metrics_are_global(Config, false) ->
+    escalus:delete_users(Config, escalus:get_users([alice, bob]));
+finalise_by_all_metrics_are_global(Config, true) ->
+    Config1 = lists:keydelete(all_metrics_are_global, 1, Config),
+    escalus:delete_users(Config1, escalus:get_users([clusterguy, clusterbuddy])).
+
+all_metrics_are_global(Config) ->
+    case lists:keyfind(all_metrics_are_global, 1, Config) of
+        {_, Value} -> Value;
+        _ -> escalus_ejabberd:rpc(ejabberd_config, get_local_option, [all_metrics_are_global])
+    end.
+
+make_global_group_name(GN) ->
+    list_to_atom(atom_to_list(GN) ++ "_all_metrics_are_global").
+
+make_global_groups_names(GroupsNames) ->
+    [{group, make_global_group_name(GN)} || GN <- GroupsNames].
+
+make_global_groups(Groups) ->
+    [{make_global_group_name(GN), Opts, Cases} || {GN, Opts, Cases} <- Groups].
+
+userspec(User1Count, Config) ->
+    [User1ID | _] = user_ids(Config),
+    [{User1ID, User1Count}].
+
+userspec(User1Count, User2Count, Config) ->
+    [User1ID, User2ID | _] = user_ids(Config),
+    [{User1ID, User1Count}, {User2ID, User2Count}].
+
+user_ids(Config) ->
+    [ UserID || {UserID, _Otps} <- proplists:get_value(escalus_users, Config, []) ].
+
+%% TODO: Remove this and refactor functions using it to use hosts option instead
+%%       as soon as escalus_ejabberd supports it
+with_rpc_to_node_2(M, F, A) ->
+    Node = ct:get_config(ejabberd_node),
+    Node2 = ct:get_config(ejabberd2_node),
+    ct_config:update_config(ejabberd_node, Node2),
+    Result = apply(M, F, A),
+    ct_config:update_config(ejabberd_node, Node),
+    Result.
 

--- a/test/ejabberd_tests/tests/metrics_roster_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_roster_SUITE.erl
@@ -61,11 +61,11 @@ subscription_tests() -> [unsubscribe,
 
 init_per_suite(Config) ->
 
-    MongooseMetrics = [{[data, xmpp, received, xml_stanza_size], changed},
-                       {[data, xmpp, sent, xml_stanza_size], changed},
-                       {fun roster_odbc_precondition/0, [data, odbc, regular],
+    MongooseMetrics = [{[global, data, xmpp, received, xml_stanza_size], changed},
+                       {[global, data, xmpp, sent, xml_stanza_size], changed},
+                       {fun roster_odbc_precondition/0, [global, data, odbc, regular],
                         [{recv_oct, '>'}, {send_oct, '>'}]},
-                       {[backends, mod_roster, get_subscription_lists], changed}
+                       {[global, backends, mod_roster, get_subscription_lists], changed}
                        ],
     [{mongoose_metrics, MongooseMetrics} | escalus:init_per_suite(Config)].
 
@@ -112,7 +112,7 @@ end_rosters_remove(Config) ->
 get_roster(ConfigIn) ->
     Metrics =
         [{['_', modRosterGets], 1},
-         {[backends, mod_roster, get_roster], changed}
+         {[global, backends, mod_roster, get_roster], changed}
         ],
     Config = mongoose_metrics(ConfigIn, Metrics),
 

--- a/test/ejabberd_tests/tests/metrics_session_SUITE.erl
+++ b/test/ejabberd_tests/tests/metrics_session_SUITE.erl
@@ -25,7 +25,8 @@
 -define(RT_WINDOW, 3).  % seconds
 
 -import(metrics_helper, [assert_counter/2,
-                      get_counter_value/1]).
+                         assert_counter/3,
+                         get_counter_value/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -112,7 +113,7 @@ session_global(Config) ->
     escalus:story(Config, [{alice, 1}], fun(_Alice) ->
 
         timer:sleep(?GLOBAL_WAIT_TIME),
-        assert_counter(1, [global, totalSessionCount])
+        assert_counter(global, 1, totalSessionCount)
 
         end).
 
@@ -120,7 +121,7 @@ session_unique(Config) ->
     escalus:story(Config, [{alice, 2}], fun(_Alice1, _Alice2) ->
 
         timer:sleep(?GLOBAL_WAIT_TIME),
-        assert_counter(1, [global, uniqueSessionCount]),
-        assert_counter(2, [global, totalSessionCount])
+        assert_counter(global, 1, uniqueSessionCount),
+        assert_counter(global, 2, totalSessionCount)
 
         end).

--- a/test/ejabberd_tests/tests/mod_ping_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_ping_SUITE.erl
@@ -107,7 +107,6 @@ active(Config) ->
 active_keep_alive(Config) ->
     escalus:story(Config, [{alice, 1}],
         fun(Alice) ->
-                Domain = ct:get_config(ejabberd_domain),
                 ct:sleep(timer:seconds(6)), % wait 6s (ping_interval is 8)
                 Socket = Alice#client.socket,
                 gen_tcp:send(Socket, <<"\n">>),
@@ -126,7 +125,7 @@ server_ping_pong(Config) ->
 
 server_ping_pang(ConfigIn) ->
     Domain = ct:get_config(ejabberd_domain),
-    Metrics = [{metrics_helper:make_metric_name(Domain, user_ping_timeout), 1}],
+    Metrics = [{[Domain, user_ping_timeout], 1}],
     Config = [{mongoose_metrics, Metrics} | ConfigIn],
     escalus:story(Config, [{alice, 1}],
         fun(Alice) ->

--- a/test/ejabberd_tests/tests/mod_ping_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_ping_SUITE.erl
@@ -126,7 +126,7 @@ server_ping_pong(Config) ->
 
 server_ping_pang(ConfigIn) ->
     Domain = ct:get_config(ejabberd_domain),
-    Metrics = [{[Domain, user_ping_timeout], 1}],
+    Metrics = [{metrics_helper:make_metric_name(Domain, user_ping_timeout), 1}],
     Config = [{mongoose_metrics, Metrics} | ConfigIn],
     escalus:story(Config, [{alice, 1}],
         fun(Alice) ->


### PR DESCRIPTION
This PR adds `all_metrics_are_global` switch.

Proposed changes include:
* `mongoose_metrics` got some serious refactoring.
* New option, when enabled, merges all per-host metrics into global equivalents, effectively reducing CPU and memory footprint in clusters with lots of XMPP domains supported.
* A side effect is an unification of metrics names. Host part (or `global` atom) always comes first now.
* Only unit tests and metrics_api suite are updated, because remaining metrics test cases rely heavily on RPC, which doesn't offer nice and consistent way of making calls to more than one node. The new switch is enabled on dev node 2 to avoid restarts or introducing yet another test configuration
* Updated documentation, including a note about performance problem the new switch solves.

Not all metrics test suites are modified to verify both nodes (with switch enabled and disabled) because they rely on many RPC calls and this mechanism is not ready yet for flexible calls to any node.
