### PR TITLE
Improved subdomain handling

### DIFF
--- a/apps/ejabberd/include/mod_muc_light.hrl
+++ b/apps/ejabberd/include/mod_muc_light.hrl
@@ -18,7 +18,6 @@
 -define(DEFAULT_MAX_OCCUPANTS, infinity).
 -define(DEFAULT_ROOMS_PER_PAGE, 10).
 -define(DEFAULT_ROOMS_IN_ROSTERS, false).
--define(DEFAULT_HOST, <<"muclight.@HOST@">>).
 
 -type schema_value_type() :: binary | integer | float.
 -type schema_item() :: {FormFieldName :: binary(), OptionName :: atom(),

--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -283,9 +283,8 @@ status() ->
 send_service_message_all_mucs(Subject, AnnouncementText) ->
     Message = io_lib:format("~s~n~s", [Subject, AnnouncementText]),
     lists:foreach(
-      fun(ServerHost) ->
-              MUCHost = gen_mod:get_module_opt_host(
-                          ServerHost, mod_muc, "conference.@HOST@"),
+      fun(Host) ->
+              MUCHost = gen_mod:get_module_subhost(Host, mod_muc),
               mod_muc:broadcast_service_message(MUCHost, Message)
       end,
       ?MYHOSTS).

--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -284,7 +284,7 @@ send_service_message_all_mucs(Subject, AnnouncementText) ->
     Message = io_lib:format("~s~n~s", [Subject, AnnouncementText]),
     lists:foreach(
       fun(Host) ->
-              MUCHost = gen_mod:get_module_subhost(Host, mod_muc),
+              {ok, MUCHost} = gen_mod:get_module_subhost(Host, mod_muc),
               mod_muc:broadcast_service_message(MUCHost, Message)
       end,
       ?MYHOSTS).

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -53,9 +53,8 @@
 
 -include("ejabberd.hrl").
 
--record(ejabberd_module, {module_host, module_subhost, opts}).
+-record(ejabberd_module, {module_host, opts}).
 -type ejabberd_module() :: #ejabberd_module{module_host :: {module(), ejabberd:server()},
-                                            module_subhost :: {module(), ejabberd:server()},
                                             opts :: list()}.
 
 -record(ejabberd_module_subhost, {subhost, module, host}).

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -37,23 +37,32 @@
          get_opt/2,
          get_opt/3,
          get_opt/4,
-         get_opt_host/3,
+         get_opt_subhost/2,
          set_opt/3,
          get_module_opt/4,
-         get_module_opt_host/3,
+         get_module_opt_by_subhost/4,
          set_module_opt/4,
+         set_module_opt_by_subhost/4,
+         get_module_subhost/2,
+         get_module_and_host_by_subhost/1,
          loaded_modules/1,
          loaded_modules_with_opts/1,
-         get_hosts/2,
          get_module_proc/2,
          backend_code/3,
          is_loaded/2]).
 
 -include("ejabberd.hrl").
 
--record(ejabberd_module, {module_host, opts}).
+-record(ejabberd_module, {module_host, module_subhost, opts}).
 -type ejabberd_module() :: #ejabberd_module{module_host :: {module(), ejabberd:server()},
+                                            module_subhost :: {module(), ejabberd:server()},
                                             opts :: list()}.
+
+-record(ejabberd_module_subhost, {subhost, module, host}).
+-type ejabberd_module_subhost() :: #ejabberd_module_subhost{
+                                      subhost :: ejabberd:server(),
+                                      module :: module(),
+                                      host :: ejabberd:server()}.
 
 %% -export([behaviour_info/1]).
 %% behaviour_info(callbacks) ->
@@ -66,10 +75,10 @@
 
 -spec start() -> 'ok'.
 start() ->
-    ets:new(ejabberd_modules,
-            [named_table,
-             public,
-             {keypos, #ejabberd_module.module_host}]),
+    ets:new(ejabberd_modules, [named_table, public, {keypos, #ejabberd_module.module_host},
+                               {read_concurrency, true}]),
+    ets:new(ejabberd_modules_subhosts, [named_table, public, {read_concurrency, true},
+                                        {keypos, #ejabberd_module_subhost.subhost}]),
     ok.
 
 
@@ -79,11 +88,16 @@ start() ->
 start_module(Host, Module, Opts0) ->
     Opts = clear_opts(Module, Opts0),
     set_module_opts_mnesia(Host, Module, Opts),
-    ets:insert(ejabberd_modules,
-               #ejabberd_module{module_host = {Module, Host},
-                                opts = Opts}),
+    ets:insert(ejabberd_modules, #ejabberd_module{module_host = {Module, Host}, opts = Opts}),
     try
         Res = Module:start(Host, Opts),
+        case catch get_opt_subhost(Host, Opts) of
+            SubHost when is_binary(SubHost) ->
+                ets:insert(ejabberd_modules_subhosts,
+                           #ejabberd_module_subhost{ subhost = SubHost, module = Module,
+                                                     host = Host });
+            _ -> ok
+        end,
         ?DEBUG("Module ~p started for ~p.", [Module, Host]),
         Res
     catch
@@ -189,10 +203,12 @@ is_app_running(AppName) ->
 %% @doc Stop the module in a host, and forget its configuration.
 -spec stop_module(ejabberd:server(), module()) -> 'error' | {'aborted',_} | {'atomic',_}.
 stop_module(Host, Module) ->
+    SubHost = get_module_subhost(Host, Module),
     case stop_module_keep_config(Host, Module) of
         error ->
             error;
         ok ->
+            ets:delete(ejabberd_modules_subhosts, {Module, SubHost}),
             del_module_mnesia(Host, Module)
     end.
 
@@ -300,6 +316,11 @@ get_module_opt(Host, Module, Opt, Default) ->
             get_opt(Opt, Opts, Default)
     end.
 
+-spec get_module_opt_by_subhost(SubHost :: ejabberd:server(), Module :: module(),
+                                Opt :: term(), Default :: term()) -> term().
+get_module_opt_by_subhost(SubHost, Module, Opt, Default) ->
+    {Module, Host} = get_module_and_host_by_subhost(SubHost),
+    get_module_opt(Host, Module, Opt, Default).
 
 %% @doc Non-atomic! You have been warned.
 -spec set_module_opt(ejabberd:server(), module(), _Opt, _Value) -> boolean().
@@ -315,18 +336,32 @@ set_module_opt(Host, Module, Opt, Value) ->
                                {#ejabberd_module.opts, Updated})
     end.
 
+-spec set_module_opt_by_subhost(SubHost :: ejabberd:server(), Module :: module(),
+                                Opt :: term(), Value :: term()) -> boolean().
+set_module_opt_by_subhost(SubHost, Module, Opt, Value) ->
+    {Module, Host} = get_module_and_host_by_subhost(SubHost),
+    set_module_opt(Host, Module, Opt, Value).
 
--spec get_module_opt_host(ejabberd:server(), module(), _) -> ejabberd:server().
-get_module_opt_host(Host, Module, Default) ->
-    Val = get_module_opt(Host, Module, host, Default),
+
+-spec get_opt_subhost(ejabberd:server(), list()) -> ejabberd:server().
+get_opt_subhost(Host, Opts) ->
+    Val = get_opt(host, Opts),
     re:replace(Val, "@HOST@", Host, [global, {return,binary}]).
 
+-spec get_module_subhost(Host :: ejabberd:server(), Module :: module()) -> ejabberd:server().
+get_module_subhost(Host, Module) ->
+    case ets:match(ejabberd_modules_subhosts,
+                   #ejabberd_module_subhost{module = Module, host = Host, subhost = '$1'}) of
+        [[SubHost]] -> SubHost;
+        _ -> undefined
+    end.
 
--spec get_opt_host(ejabberd:server(), list(), _) -> ejabberd:server().
-get_opt_host(Host, Opts, Default) ->
-    Val = get_opt(host, Opts, Default),
-    re:replace(Val, "@HOST@", Host, [global, {return,binary}]).
-
+-spec get_module_and_host_by_subhost(SubHost :: ejabberd:server()) -> {module(), ejabberd:server()}.
+get_module_and_host_by_subhost(SubHost) ->
+    case ets:lookup(ejabberd_modules_subhosts, SubHost) of
+        [#ejabberd_module_subhost{ host = Host, module = Module }] -> {Module, Host};
+        _ -> undefined
+    end.
 
 -spec loaded_modules(ejabberd:server()) -> [module()].
 loaded_modules(Host) ->
@@ -373,20 +408,6 @@ del_module_mnesia(Host, Module) ->
         OtherModules ->
             ejabberd_config:add_local_option({modules, Host}, OtherModules)
     end.
-
-get_hosts(Opts, Prefix) ->
-    case catch gen_mod:get_opt(hosts, Opts) of
-        {'EXIT', _Error1} ->
-            case catch gen_mod:get_opt(host, Opts) of
-                {'EXIT', _Error2} ->
-                    [Prefix ++ Host || Host <- ?MYHOSTS];
-                Host ->
-                    [Host]
-            end;
-        Hosts ->
-            Hosts
-    end.
-
 
 -spec get_module_proc(binary() | string(), module()) -> atom().
 get_module_proc(Host, Base) when is_binary(Host) ->

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -40,9 +40,9 @@
          get_opt_subhost/2,
          set_opt/3,
          get_module_opt/4,
-         get_module_opt_by_subhost/4,
+         get_module_opt_by_subhost/3,
          set_module_opt/4,
-         set_module_opt_by_subhost/4,
+         set_module_opt_by_subhost/3,
          get_module_subhost/2,
          get_module_and_host_by_subhost/1,
          loaded_modules/1,
@@ -203,12 +203,10 @@ is_app_running(AppName) ->
 %% @doc Stop the module in a host, and forget its configuration.
 -spec stop_module(ejabberd:server(), module()) -> 'error' | {'aborted',_} | {'atomic',_}.
 stop_module(Host, Module) ->
-    SubHost = get_module_subhost(Host, Module),
     case stop_module_keep_config(Host, Module) of
         error ->
             error;
         ok ->
-            ets:delete(ejabberd_modules_subhosts, {Module, SubHost}),
             del_module_mnesia(Host, Module)
     end.
 
@@ -232,6 +230,7 @@ stop_module_keep_config(Host, Module) ->
             ets:delete(ejabberd_modules, {Module, Host}),
             ok;
         _ ->
+            ets:delete(ejabberd_modules_subhosts, get_module_subhost(Host, Module)),
             ets:delete(ejabberd_modules, {Module, Host}),
             ok
     end.
@@ -316,9 +315,9 @@ get_module_opt(Host, Module, Opt, Default) ->
             get_opt(Opt, Opts, Default)
     end.
 
--spec get_module_opt_by_subhost(SubHost :: ejabberd:server(), Module :: module(),
-                                Opt :: term(), Default :: term()) -> term().
-get_module_opt_by_subhost(SubHost, Module, Opt, Default) ->
+-spec get_module_opt_by_subhost(
+        SubHost :: ejabberd:server(), Opt :: term(), Default :: term()) -> term().
+get_module_opt_by_subhost(SubHost, Opt, Default) ->
     {Module, Host} = get_module_and_host_by_subhost(SubHost),
     get_module_opt(Host, Module, Opt, Default).
 
@@ -336,9 +335,9 @@ set_module_opt(Host, Module, Opt, Value) ->
                                {#ejabberd_module.opts, Updated})
     end.
 
--spec set_module_opt_by_subhost(SubHost :: ejabberd:server(), Module :: module(),
-                                Opt :: term(), Value :: term()) -> boolean().
-set_module_opt_by_subhost(SubHost, Module, Opt, Value) ->
+-spec set_module_opt_by_subhost(
+        SubHost :: ejabberd:server(), Opt :: term(), Value :: term()) -> boolean().
+set_module_opt_by_subhost(SubHost, Opt, Value) ->
     {Module, Host} = get_module_and_host_by_subhost(SubHost),
     set_module_opt(Host, Module, Opt, Value).
 

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -276,7 +276,7 @@ init([Host, Opts]) ->
     mnesia:add_table_copy(muc_room, node(), disc_copies),
     mnesia:add_table_copy(muc_registered, node(), disc_copies),
     catch ets:new(muc_online_users, [bag, named_table, public, {keypos, 2}]),
-    MyHost = gen_mod:get_opt_host(Host, Opts, <<"conference.@HOST@">>),
+    MyHost = gen_mod:get_opt_subhost(Host, Opts),
     update_tables(MyHost),
     clean_table_from_bad_node(node(), MyHost),
     mnesia:add_table_index(muc_registered, nick),

--- a/apps/ejabberd/src/mod_muc_admin.erl
+++ b/apps/ejabberd/src/mod_muc_admin.erl
@@ -110,7 +110,7 @@ create_instant_room(Host, Name, Owner, Nick) ->
     %% the HTTP API, they will certainly recieve stanzas as a
     %% consequence, even if their client(s) did not initiate this.
     OwnerJID = jid:binary_to_bare(Owner),
-    MUCHost = gen_mod:get_module_opt_host(Host, mod_muc, <<"muc.@HOST@">>),
+    MUCHost = gen_mod:get_module_subhost(Host, mod_muc),
     UserRoomJID = jid:make(Name, MUCHost, Nick),
     BareRoomJID = jid:make(Name, MUCHost, <<"">>),
     %% Send presence to create a room.
@@ -171,7 +171,7 @@ kick_user_from_room(Host, Name, Nick) ->
 %%--------------------------------------------------------------------
 
 room_address(Name, Host) ->
-    MUCHost = gen_mod:get_module_opt_host(Host, mod_muc, <<"muc.@HOST@">>),
+    MUCHost = gen_mod:get_module_subhost(Host, mod_muc),
     <<Name/binary, $@, MUCHost/binary>>.
 
 room_address(Name, Host, Nick) ->

--- a/apps/ejabberd/src/mod_muc_admin.erl
+++ b/apps/ejabberd/src/mod_muc_admin.erl
@@ -110,7 +110,7 @@ create_instant_room(Host, Name, Owner, Nick) ->
     %% the HTTP API, they will certainly recieve stanzas as a
     %% consequence, even if their client(s) did not initiate this.
     OwnerJID = jid:binary_to_bare(Owner),
-    MUCHost = gen_mod:get_module_subhost(Host, mod_muc),
+    {ok, MUCHost} = gen_mod:get_module_subhost(Host, mod_muc),
     UserRoomJID = jid:make(Name, MUCHost, Nick),
     BareRoomJID = jid:make(Name, MUCHost, <<"">>),
     %% Send presence to create a room.
@@ -171,12 +171,8 @@ kick_user_from_room(Host, Name, Nick) ->
 %%--------------------------------------------------------------------
 
 room_address(Name, Host) ->
-    MUCHost = gen_mod:get_module_subhost(Host, mod_muc),
+    {ok, MUCHost} = gen_mod:get_module_subhost(Host, mod_muc),
     <<Name/binary, $@, MUCHost/binary>>.
-
-room_address(Name, Host, Nick) ->
-    MUCRoomAddress = room_address(Name, Host),
-    <<MUCRoomAddress/binary, $/, Nick/binary>>.
 
 iq(Type, Sender, Recipient, Children)
   when is_binary(Type), is_list(Children) ->

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -147,7 +147,7 @@ start(Host, Opts) ->
 
 -spec stop(Host :: ejabberd:server()) -> ok.
 stop(Host) ->
-    MyDomain = gen_mod:get_module_subhost(Host, ?MODULE),
+    {ok, MyDomain} = gen_mod:get_module_subhost(Host, ?MODULE),
     ejabberd_router:unregister_route(MyDomain),
 
     ?BACKEND:stop(Host, MyDomain),
@@ -245,7 +245,7 @@ get_muc_service({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, _
                 true -> ?NS_MUC;
                 false -> ?NS_MUC_LIGHT
             end,
-    SubHost = gen_mod:get_module_subhost(LServer, ?MODULE),
+    {ok, SubHost} = gen_mod:get_module_subhost(LServer, ?MODULE),
     Item = [#xmlel{name = <<"item">>,
                    attrs = [{<<"jid">>, SubHost},
                             {<<"node">>, XMLNS}]}],
@@ -283,7 +283,7 @@ add_rooms_to_roster(Acc, UserUS) ->
                      IQ :: #iq{}, ActiveList :: binary()) ->
     {stop, {result, [jlib:xmlel()]}} | {error, #xmlel{}}.
 process_iq_get(_Acc, #jid{ lserver = FromS } = From, To, #iq{} = IQ, _ActiveList) ->
-    MUCHost = gen_mod:get_module_subhost(FromS, ?MODULE),
+    {ok, MUCHost} = gen_mod:get_module_subhost(FromS, ?MODULE),
     case {?CODEC:decode(From, To, IQ), gen_mod:get_module_opt_by_subhost(
                                          MUCHost, blocking, ?DEFAULT_BLOCKING)} of
         {{ok, {get, #blocking{} = Blocking}}, true} ->
@@ -301,7 +301,7 @@ process_iq_get(_Acc, #jid{ lserver = FromS } = From, To, #iq{} = IQ, _ActiveList
 -spec process_iq_set(Acc :: any(), From :: #jid{}, To :: #jid{}, IQ :: #iq{}) ->
     {stop, {result, [jlib:xmlel()]}} | {error, #xmlel{}}.
 process_iq_set(_Acc, #jid{ lserver = FromS } = From, To, #iq{} = IQ) ->
-    MUCHost = gen_mod:get_module_subhost(FromS, ?MODULE),
+    {ok, MUCHost} = gen_mod:get_module_subhost(FromS, ?MODULE),
     case {?CODEC:decode(From, To, IQ), gen_mod:get_module_opt_by_subhost(
                                          MUCHost, blocking, ?DEFAULT_BLOCKING)} of
         {{ok, {set, #blocking{ items = Items }} = Blocking}, true} ->

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -49,7 +49,6 @@
 %% API
 -export([standard_config_schema/0, standard_default_config/0]).
 -export([config_schema/1, default_config/1]).
--export([get_opt/3, set_opt/3]).
 
 %% gen_mod callbacks
 -export([start/2, stop/1]).
@@ -79,8 +78,6 @@
 -include("mod_muc_light.hrl").
 -include("mod_roster.hrl").
 
--define(CONFIG_TAB, muc_light_config).
-
 %%====================================================================
 %% API
 %%====================================================================
@@ -92,23 +89,10 @@ standard_config_schema() -> ["roomname", "subject"].
 standard_default_config() -> [{"roomname", "Untitled"}, {"subject", ""}].
 
 -spec default_config(MUCServer :: ejabberd:lserver()) -> config().
-default_config(MUCServer) -> get_opt(MUCServer, default_config, []).
+default_config(MUCServer) -> gen_mod:get_module_opt_by_subhost(MUCServer, default_config, []).
 
 -spec config_schema(MUCServer :: ejabberd:lserver()) -> config_schema().
-config_schema(MUCServer) -> get_opt(MUCServer, config_schema, undefined).
-
--spec get_opt(MUCServer :: ejabberd:lserver(), OptName :: atom(), Default :: any()) -> any().
-get_opt(MUCServer, OptName, Default) ->
-    [{_, Opts}] = ets:lookup(?CONFIG_TAB, MUCServer),
-    case lists:keyfind(OptName, 1, Opts) of
-        false -> Default;
-        {_, Val} -> Val
-    end.
-
--spec set_opt(MUCServer :: ejabberd:lserver(), OptName :: atom(), Value :: any()) -> any().
-set_opt(MUCServer, OptName, Value) ->
-    [{_, Opts}] = ets:lookup(?CONFIG_TAB, MUCServer),
-    ets:insert(?CONFIG_TAB, {MUCServer, lists:keystore(OptName, 1, Opts, {OptName, Value})}).
+config_schema(MUCServer) -> get_mod:get_module_opt_by_subhost(MUCServer, config_schema, undefined).
 
 %%====================================================================
 %% gen_mod callbacks
@@ -148,24 +132,16 @@ start(Host, Opts) ->
     ejabberd_hooks:add(muc_room_pid, MyDomain, ?MODULE, muc_room_pid, 50),
     ejabberd_hooks:add(can_access_room, MyDomain, ?MODULE, can_access_room, 50),
 
-    EjdSupPid = whereis(ejabberd_sup),
-    HeirOpt = case self() =:= EjdSupPid of
-                  true -> [];
-                  false -> [{heir, EjdSupPid, testing}] % for dynamic start from tests
-              end,
-    catch ets:new(?CONFIG_TAB, [set, public, named_table, {read_concurrency, true} | HeirOpt]),
-    ets:insert(?CONFIG_TAB, {MyDomain, Opts}),
-
     %% Prepare config schema
     ConfigSchema = mod_muc_light_utils:make_config_schema(
                      gen_mod:get_opt(config_schema, Opts, standard_config_schema())),
-    set_opt(MyDomain, config_schema, ConfigSchema),
+    gen_mod:set_module_opt(Host, ?MODULE, config_schema, ConfigSchema),
 
     %% Prepare default config
     DefaultConfig = mod_muc_light_utils:make_default_config(
                       gen_mod:get_opt(default_config, Opts, standard_default_config()),
                       ConfigSchema),
-    set_opt(MyDomain, default_config, DefaultConfig),
+    gen_mod:set_module_opt(Host, ?MODULE, default_config, DefaultConfig),
 
     ok.
 
@@ -173,8 +149,6 @@ start(Host, Opts) ->
 stop(Host) ->
     MyDomain = gen_mod:get_module_subhost(Host, ?MODULE),
     ejabberd_router:unregister_route(MyDomain),
-
-    ets:delete(?CONFIG_TAB, MyDomain),
 
     ?BACKEND:stop(Host, MyDomain),
 
@@ -203,7 +177,8 @@ route(From, To, Packet) ->
                      DecodedPacket :: mod_muc_light_codec:decode_result(),
                      OrigPacket :: jlib:xmlel()) -> any().
 process_packet(From, To, {ok, {set, #create{} = Create}}, OrigPacket) ->
-    RoomsPerUser = get_opt(To#jid.lserver, rooms_per_user, ?DEFAULT_ROOMS_PER_USER),
+    RoomsPerUser = gen_mod:get_module_opt_by_subhost(
+                     To#jid.lserver, ?MODULE, rooms_per_user, ?DEFAULT_ROOMS_PER_USER),
     FromUS = jid:to_lus(From),
     case RoomsPerUser == infinity orelse length(?BACKEND:get_user_rooms(FromUS)) < RoomsPerUser of
         true ->
@@ -217,7 +192,7 @@ process_packet(From, To, {ok, {get, #disco_info{} = DI}}, _OrigPacket) ->
 process_packet(From, To, {ok, {get, #disco_items{} = DI}}, OrigPacket) ->
     handle_disco_items_get(From, To, DI, OrigPacket);
 process_packet(From, To, {ok, {_, #blocking{}} = Blocking}, OrigPacket) ->
-    case get_opt(To#jid.lserver, blocking, ?DEFAULT_BLOCKING) of
+    case gen_mod:get_module_opt_by_subhost(To#jid.lserver, ?MODULE, blocking, ?DEFAULT_BLOCKING) of
         true ->
             case handle_blocking(From, To, Blocking) of
                 ok ->
@@ -265,7 +240,8 @@ prevent_service_unavailable(_From, _To, Packet) ->
 -spec get_muc_service(Acc :: {result, [jlib:xmlel()]}, From :: ejabberd:jid(), To :: ejabberd:jid(),
                       NS :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]}.
 get_muc_service({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, _Lang) ->
-    XMLNS = case get_opt(LServer, legacy_mode, ?DEFAULT_LEGACY_MODE) of
+    XMLNS = case gen_mod:get_module_opt_by_subhost(
+                   LServer, ?MODULE, legacy_mode, ?DEFAULT_LEGACY_MODE) of
                 true -> ?NS_MUC;
                 false -> ?NS_MUC_LIGHT
             end,
@@ -308,7 +284,8 @@ add_rooms_to_roster(Acc, UserUS) ->
     {stop, {result, [jlib:xmlel()]}} | {error, #xmlel{}}.
 process_iq_get(_Acc, #jid{ lserver = FromS } = From, To, #iq{} = IQ, _ActiveList) ->
     MUCHost = gen_mod:get_module_subhost(FromS, ?MODULE),
-    case {?CODEC:decode(From, To, IQ), get_opt(MUCHost, blocking, ?DEFAULT_BLOCKING)} of
+    case {?CODEC:decode(From, To, IQ), gen_mod:get_module_opt_by_subhost(
+                                         MUCHost, ?MODULE, blocking, ?DEFAULT_BLOCKING)} of
         {{ok, {get, #blocking{} = Blocking}}, true} ->
             Items = ?BACKEND:get_blocking(jid:to_lus(From)),
             ?CODEC:encode({get, Blocking#blocking{ items = Items }}, From, jid:to_lus(To),
@@ -325,7 +302,8 @@ process_iq_get(_Acc, #jid{ lserver = FromS } = From, To, #iq{} = IQ, _ActiveList
     {stop, {result, [jlib:xmlel()]}} | {error, #xmlel{}}.
 process_iq_set(_Acc, #jid{ lserver = FromS } = From, To, #iq{} = IQ) ->
     MUCHost = gen_mod:get_module_subhost(FromS, ?MODULE),
-    case {?CODEC:decode(From, To, IQ), get_opt(MUCHost, blocking, ?DEFAULT_BLOCKING)} of
+    case {?CODEC:decode(From, To, IQ), gen_mod:get_module_opt_by_subhost(
+                                         MUCHost, ?MODULE, blocking, ?DEFAULT_BLOCKING)} of
         {{ok, {set, #blocking{ items = Items }} = Blocking}, true} ->
             case lists:any(fun({_, _, {WhoU, WhoS}}) ->
                                    WhoU =:= <<>> orelse WhoS =:= <<>>
@@ -401,7 +379,8 @@ try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = Creatio
     {_RoomU, RoomS} = RoomUS = jid:to_lus(RoomJID),
     InitialAffUsers = mod_muc_light_utils:filter_out_prevented(
                         CreatorUS, RoomUS, CreationCfg#create.aff_users),
-    MaxOccupants = get_opt(RoomJID#jid.lserver, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
+    MaxOccupants = gen_mod:get_module_opt_by_subhost(
+                     RoomJID#jid.lserver, ?MODULE, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
     case {mod_muc_light_utils:process_raw_config(
             RawConfig, default_config(RoomS), config_schema(RoomS)),
           process_create_aff_users_if_valid(RoomS, CreatorUS, InitialAffUsers)} of
@@ -429,7 +408,8 @@ process_create_aff_users_if_valid(MUCServer, Creator, AffUsers) ->
                        ({_, Aff}) -> Aff =:= none end, AffUsers) of
         false ->
             process_create_aff_users(
-              Creator, AffUsers, get_opt(MUCServer, equal_occupants, ?DEFAULT_EQUAL_OCCUPANTS));
+              Creator, AffUsers, gen_mod:get_module_opt_by_subhost(
+                                   MUCServer, ?MODULE, equal_occupants, ?DEFAULT_EQUAL_OCCUPANTS));
         true ->
             {error, bad_request}
     end.
@@ -461,7 +441,8 @@ handle_disco_items_get(From, To, DiscoItems0, OrigPacket) ->
                                 fun ejabberd_router:route/3);
         Rooms ->
             RoomsInfo = get_rooms_info(lists:sort(Rooms)),
-            RoomsPerPage = get_opt(To#jid.lserver, rooms_per_page, ?DEFAULT_ROOMS_PER_PAGE),
+            RoomsPerPage = gen_mod:get_module_opt_by_subhost(
+                             To#jid.lserver, ?MODULE, rooms_per_page, ?DEFAULT_ROOMS_PER_PAGE),
             case apply_rsm(RoomsInfo, length(RoomsInfo),
                            page_service_limit(DiscoItems0#disco_items.rsm, RoomsPerPage)) of
                 {ok, RoomsInfoSlice, RSMOut} ->

--- a/apps/ejabberd/src/mod_muc_light_admin.erl
+++ b/apps/ejabberd/src/mod_muc_light_admin.erl
@@ -106,8 +106,7 @@ commands() ->
 
 create_unique_room(Domain, RoomName, Creator, Subject) ->
     C = jid:to_lus(jid:from_binary(Creator)),
-    MUCLightDomain = gen_mod:get_module_opt_host(Domain, mod_muc,
-                                            <<"muclight.@HOST@">>),
+    MUCLightDomain = gen_mod:get_module_subhost(Domain, mod_muc_light),
     MUCService = jid:make(<<>>, MUCLightDomain, <<>>),
     Config = make_room_config(RoomName, Subject),
     case mod_muc_light:try_to_create_room(C, MUCService, Config) of

--- a/apps/ejabberd/src/mod_muc_light_admin.erl
+++ b/apps/ejabberd/src/mod_muc_light_admin.erl
@@ -106,7 +106,7 @@ commands() ->
 
 create_unique_room(Domain, RoomName, Creator, Subject) ->
     C = jid:to_lus(jid:from_binary(Creator)),
-    MUCLightDomain = gen_mod:get_module_subhost(Domain, mod_muc_light),
+    {ok, MUCLightDomain} = gen_mod:get_module_subhost(Domain, mod_muc_light),
     MUCService = jid:make(<<>>, MUCLightDomain, <<>>),
     Config = make_room_config(RoomName, Subject),
     case mod_muc_light:try_to_create_room(C, MUCService, Config) of

--- a/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
+++ b/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
@@ -265,7 +265,7 @@ encode_meta({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers},
                        Affs#affiliations.aff_users, HandleFun),
     {iq_reply, Affs#affiliations.id};
 encode_meta({get, #blocking{} = Blocking}, SenderBareJID, _SenderJID, _HandleFun) ->
-    MUCHost = gen_mod:get_module_opt_host(SenderBareJID#jid.lserver, mod_muc_light, ?DEFAULT_HOST),
+    MUCHost = gen_mod:get_module_subhost(SenderBareJID#jid.lserver, mod_muc_light),
     BlockingEls = [ blocking_to_el(BlockingItem, MUCHost)
                     || BlockingItem <- Blocking#blocking.items ],
     Blocklist = #xmlel{ name = <<"list">>, attrs = [{<<"name">>, ?NS_MUC_LIGHT}],

--- a/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
+++ b/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
@@ -265,7 +265,7 @@ encode_meta({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers},
                        Affs#affiliations.aff_users, HandleFun),
     {iq_reply, Affs#affiliations.id};
 encode_meta({get, #blocking{} = Blocking}, SenderBareJID, _SenderJID, _HandleFun) ->
-    MUCHost = gen_mod:get_module_subhost(SenderBareJID#jid.lserver, mod_muc_light),
+    {ok, MUCHost} = gen_mod:get_module_subhost(SenderBareJID#jid.lserver, mod_muc_light),
     BlockingEls = [ blocking_to_el(BlockingItem, MUCHost)
                     || BlockingItem <- Blocking#blocking.items ],
     Blocklist = #xmlel{ name = <<"list">>, attrs = [{<<"name">>, ?NS_MUC_LIGHT}],

--- a/apps/ejabberd/src/mod_muc_light_room.erl
+++ b/apps/ejabberd/src/mod_muc_light_room.erl
@@ -56,7 +56,8 @@ handle_request(From, To, OrigPacket, Request) ->
                               NewAffUsers :: aff_users()) ->
     ok | {error, occupant_limit_exceeded}.
 participant_limit_check({_, MUCServer} = _RoomUS, NewAffUsers) ->
-    MaxOccupants = mod_muc_light:get_opt(MUCServer, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
+    MaxOccupants = gen_mod:get_module_opt_by_subhost(
+                     MUCServer, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
     case length(NewAffUsers) > MaxOccupants of
         true -> {error, occupant_limit_exceeded};
         false -> ok
@@ -106,7 +107,7 @@ process_request({get, #info{} = InfoReq}, _From, _UserUS, {_, RoomS} = RoomUS, _
                         raw_config = RawConfig }};
 process_request({set, #config{} = ConfigReq}, _From, _UserUS, {_, MUCServer} = RoomUS,
                 {_, UserAff}, AffUsers) ->
-    AllCanConfigure = mod_muc_light:get_opt(
+    AllCanConfigure = gen_mod:get_module_opt_by_subhost(
                         MUCServer, all_can_configure, ?DEFAULT_ALL_CAN_CONFIGURE),
     process_config_set(ConfigReq, RoomUS, UserAff, AffUsers, AllCanConfigure);
 process_request({set, #affiliations{} = AffReq}, _From, UserUS, {_, MUCServer} = RoomUS,
@@ -121,7 +122,7 @@ process_request({set, #affiliations{} = AffReq}, _From, UserUS, {_, MUCServer} =
               {ok, mod_muc_light_utils:filter_out_prevented(
                      UserUS, RoomUS, AffReq#affiliations.aff_users)};
           member ->
-              AllCanInvite = mod_muc_light:get_opt(
+              AllCanInvite = gen_mod:get_module_opt_by_subhost(
                                MUCServer, all_can_invite, ?DEFAULT_ALL_CAN_INVITE),
               validate_aff_changes_by_member(
                 AffReq#affiliations.aff_users, [], UserUS, OwnerUS, RoomUS, AllCanInvite)

--- a/apps/ejabberd/src/mod_muc_light_utils.erl
+++ b/apps/ejabberd/src/mod_muc_light_utils.erl
@@ -139,8 +139,10 @@ bin_ts() ->
                           RoomUS :: ejabberd:simple_bare_jid(),
                           AffUsers :: aff_users()) -> aff_users().
 filter_out_prevented(FromUS, {RoomU, MUCServer} = RoomUS, AffUsers) ->
-    RoomsPerUser = mod_muc_light:get_opt(MUCServer, rooms_per_user, ?DEFAULT_ROOMS_PER_USER),
-    BlockingQuery = case mod_muc_light:get_opt(MUCServer, blocking, ?DEFAULT_BLOCKING) of
+    RoomsPerUser = gen_mod:get_module_opt_by_subhost(
+                     MUCServer, rooms_per_user, ?DEFAULT_ROOMS_PER_USER),
+    BlockingQuery = case gen_mod:get_module_opt_by_subhost(
+                           MUCServer, blocking, ?DEFAULT_BLOCKING) of
                         true ->
                             [{user, FromUS}
                              | if

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -254,7 +254,7 @@ stop(Host) ->
 
 init([ServerHost, Opts]) ->
     ?DEBUG("pubsub init ~p ~p", [ServerHost, Opts]),
-    Host = gen_mod:get_opt_host(ServerHost, Opts, <<"pubsub.@HOST@">>),
+    Host = gen_mod:get_opt_subhost(ServerHost, Opts),
     Access = gen_mod:get_opt(access_createnode, Opts,
                              fun(A) when is_atom(A) -> A end, all),
     PepOffline = gen_mod:get_opt(ignore_pep_from_offline, Opts,

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -175,7 +175,7 @@ init([VHost, Opts]) ->
                                   ?MODULE,process_sm_iq, IQDisc),
     gen_iq_handler:add_iq_handler(ejabberd_local, VHost, ?NS_VCARD,
                                   ?MODULE,process_local_iq, IQDisc),
-    DirectoryHost = gen_mod:get_opt_host(VHost, Opts, "vjud.@HOST@"),
+    DirectoryHost = gen_mod:get_opt_subhost(VHost, Opts),
     Search = gen_mod:get_opt(search, Opts, true),
     case Search of
         true ->

--- a/apps/ejabberd/src/mod_vcard_ldap.erl
+++ b/apps/ejabberd/src/mod_vcard_ldap.erl
@@ -461,8 +461,7 @@ process_pattern(Str, {User, Domain}, AttrValues) ->
 			  [{<<"%s">>, V, 1} || V <- AttrValues]).
 
 parse_options(Host, Opts) ->
-    MyHost = gen_mod:get_opt_host(Host, Opts,
-				  <<"vjud.@HOST@">>),
+    MyHost = gen_mod:get_opt_subhost(Host, Opts),
     Matches = eldap_utils:get_mod_opt(matches, Opts,
                               fun(infinity) -> 0;
                                  (I) when is_integer(I), I>0 -> I

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -22,7 +22,7 @@ If you haven't chosen any of the above, skip the next part.
 **Options:**
 
 * `mod_mam_muc`:
-    * `host` (optional, default: `"conference.@HOST@"`): MUC host that will be archived; **Warning:** If you are using MUC Light, make sure this option is set to MUC Light domain.
+    * `muc_module` (optional, default: `mod_muc`): MUC module the MAM service will attach to; **Warning:** If you are using MUC Light, make sure this option is set to `mod_muc_light`.
 * `mod_mam_odbc_arch`:
     * `pm` (mandatory when `mod_mam` enabled): Enable archiving one-to-one messages
     * `muc` (optional): Enable group chat archive, mutually exclusive with `mod_mam_muc_odbc_arch`. **Not recommended**, `mod_mam_muc_odbc_arch` is more efficient.

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -2,7 +2,7 @@
 This module implements [XEP-0045: Multi-User Chat)](http://xmpp.org/extensions/xep-0045.html) (MUC). It's a common XMPP group chat solution. This extension consists of two Erlang modules: `mod_muc` and `mod_muc_room`, the latter being the room code itself. Only `mod_muc` needs to be enabled in configuration file though. Also  `mod_muc_log` is a logging submodule.
 
 ### Options
-* `host` (string, default: `"conference.@HOST@"`): Subdomain for MUC service to reside under. `@HOST@` is replaced with each served domain.
+* `host` (string, mandatory, default in config example: `"muc.@HOST@"`): Subdomain for MUC service to reside under. `@HOST@` is replaced with each served domain.
 * `access` (atom, default: `all`): Access Rule to determine who is allowed to use the MUC service.
 * `access_create` (atom, default: `all`): Who is allowed to create rooms.
 * `access_admin` (atom, default: `none`): Who is the administrator in all rooms.
@@ -14,7 +14,7 @@ This module implements [XEP-0045: Multi-User Chat)](http://xmpp.org/extensions/x
 * `max_room_desc` (atom or positive integer, default: `infinite`): Maximum room description length.
 * `min_message_interval` (non-negative integer, default: 0): Minimal interval (in seconds) between messages processed by the room.
 * `min_presence_interval` (non-negative integer, default: 0): Minimal interval (in seconds) between presences processed by the room.
-* `max_user` (positive integer, default: 200): Absolute maximum user count per room on the node.
+* `max_user` (positivmuc default: 200): Absolute maximum user count per room on the node.
 * `max_users_admin_threshold` (positive integer, default: 5): Absolute maximum administrator count per room on the node.
 * `user_message_shaper` (atom, default: `none`): Shaper for user messages processed by a room (global for the room).
 * `user_presence_shaper` (atom, default: `none`): Shaper for user presences processed by a room (global for the room).

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -4,7 +4,7 @@ This module implements [XEP Multi-User Chat Light](https://github.com/xsf/xeps/p
 
 ### Options
 
-* **host** (string, default: `"muclight.@HOST@"`) - Domain for MUC Light service to reside under. `@HOST@` is replaced with each served domain.
+* **host** (string, mandatory, default in config example: `"muclight.@HOST@"`) - Domain for MUC Light service to reside under. `@HOST@` is replaced with each served domain.
 * **backend** (atom, default: `mnesia`) - Database backend to use. Currently only `mnesia` is supported.
 * **equal_occupants** (boolean, default: `false`) - When enabled, MUC Light rooms won't have owners. It means that every occupant will be a `member`, even the room creator. **Warning:** This option does not implicitly set `all_can_invite` to `true`. If that option is set to `false`, nobody will be able to join the room after initial creation request.
 * **legacy_mode** (boolean, default: `false`) - Enables XEP-0045 compatibility mode. It allows to use subset of classic MUC stanzas with some MUC Light functions limited.

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -13,8 +13,7 @@ It's all about fitting PubSub to your needs!
 
 ### Options
 
-* `host` (string, default: `"pubsub.@HOST@"`): Subdomain for Pubsub service to reside under.
-`@HOST@` is replaced with each served domain.
+* `host` (string, mandatory, recommended: `"pubsub.@HOST@"`): Subdomain for Pubsub service to reside under. `@HOST@` is replaced with each served domain.
 * `access_create` (atom, default: `all`): Who is allowed to create pubsub nodes.
 * `max_items_node` (integer, default: `10`): Define the maximum number of items that can be stored in a node.
 * `max_subscriptions_node` (integer, default: `undefined` - no limitation): The maximum number of subscriptions managed by a node.

--- a/doc/modules/mod_vcard.md
+++ b/doc/modules/mod_vcard.md
@@ -4,7 +4,7 @@ This module provides support for vCards, as specified in [XEP-0054: vcard-temp](
 ### Options
 
 * `iqdisc`
-* `host` (string, default: `"vjud.@HOST@"`): Domain of vCard User Directory. Used for searching. `@HOST@` is replaced with domain(s) supported by the cluster.
+* `host` (string, mandatory, default in config: `"vjud.@HOST@"`): Domain of vCard User Directory. Used for searching. `@HOST@` is replaced with domain(s) supported by the cluster.
 * `search` (boolean, default: `true`): Enables/disables the domain set in previous option. `false` makes searching for users impossible.
 * `backend` (atom, default: `mnesia`): vCard storage backend. Valid values are `ldap`, `odbc`, `riak` and `mnesia`. **Warning:** LDAP backend is read-only.
 * `matches` (`inifnity` or positive integer, default: 30): Maxmimum search results to be returned to the user.

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -816,7 +816,7 @@
   %% Load mod_mam_odbc_user too.
 
   %% Enable MAM for MUC
-% {mod_mam_muc, [{host, "muc.@HOST@"}]}
+% {mod_mam_muc, [{muc_module, mod_muc}]}
 
 
   %%
@@ -828,7 +828,7 @@
 % {mod_mam_cache_user, [muc]},
 % {mod_mam_muc_odbc_arch, [no_writer]},
 % {mod_mam_muc_odbc_async_pool_writer, []},
-% {mod_mam_muc, [{host, "muc.@HOST@"}]}
+% {mod_mam_muc, [{muc_module, mod_muc}]}
 
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
@@ -857,7 +857,7 @@
 % {mod_mam_odbc_user, [muc]},
 % {mod_mam_cache_user, [muc]},
 % {mod_mam_muc_ca_arch, []},
-% {mod_mam_muc, [{host, "muc.@HOST@"}]},
+% {mod_mam_muc, [{muc_module, mod_muc}]},
 
 
  ]}.

--- a/rel/reltool_vars/node1_vars.config
+++ b/rel/reltool_vars/node1_vars.config
@@ -37,7 +37,7 @@
 {mod_roster, "{mod_roster, []},"}.
 {mod_vcard, "{mod_vcard, [ %{matches, 1},\n"
                 "%{search, true},\n"
-                "%{host, directory.@HOST@}\n"
+                "{host, \"vjud.@HOST@\"}\n"
                 "]},"}.
 {cowboy_port, 5280}.
 {cowboy_port_secure, 5285}.

--- a/rel/reltool_vars/node2_vars.config
+++ b/rel/reltool_vars/node2_vars.config
@@ -19,7 +19,7 @@
 {mod_roster, "{mod_roster, []},"}.
 {mod_vcard, "{mod_vcard, [ %{matches, 1},\n"
                 "%{search, true},\n"
-                "%{host, directory.@HOST@}\n"
+                "{host, \"vjud.@HOST@\"}\n"
                 "]},"}.
 {http_api_old_endpoint, "{5289, \"127.0.0.1\"}"}.
 {http_api_endpoint, "{8090, \"127.0.0.1\"}"}.

--- a/rel/reltool_vars/node3_vars.config
+++ b/rel/reltool_vars/node3_vars.config
@@ -21,7 +21,7 @@
 {http_api_endpoint, "{5296, \"127.0.0.1\"}"}.
 {mod_vcard, "{mod_vcard, [ %{matches, 1},\n"
                 "%{search, true},\n"
-                "%{host, directory.@HOST@}\n"
+                "{host, \"vjud.@HOST@\"}\n"
                 "]},"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -29,7 +29,7 @@
                 "%{ldap_search_operator, 'or'}, %% either 'or' or 'and'\n"
                 "%{ldap_binary_search_fields, [<<\"PHOTO\">>]},\n"
                 "%% list of binary search fields (as in vcard after mapping)\n"
-                "%{host, directory.@HOST@}\n"
+                "{host, \"vjud.@HOST@\"}\n"
                 "]},"}.
 
 {sm_backend, "{mnesia, []}"}.

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -189,7 +189,7 @@
       {mod_privacy, "{mod_privacy, [{backend, odbc}]},"},
       {mod_private, "{mod_private, [{backend, odbc}]},"},
       {mod_offline, "{mod_offline, [{backend, odbc}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, odbc}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, odbc}, {host, \"vjud.@HOST@\"}]},"},
       {mod_roster, "{mod_roster, [{backend, odbc}]},"}]},
     {odbc_pgsql_mnesia,
      [{sm_backend, "{mnesia, []}"},
@@ -200,7 +200,7 @@
       {mod_privacy, "{mod_privacy, [{backend, odbc}]},"},
       {mod_private, "{mod_private, [{backend, odbc}]},"},
       {mod_offline, "{mod_offline, [{backend, odbc}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, odbc}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, odbc}, {host, \"vjud.@HOST@\"}]},"},
       {mod_roster, "{mod_roster, [{backend, odbc}]},"}]},
     {mysql_mnesia,
      [{sm_backend, "{mnesia, []}"},
@@ -210,7 +210,7 @@
       {mod_privacy, "{mod_privacy, [{backend, odbc}]},"},
       {mod_private, "{mod_private, [{backend, mysql}]},"},
       {mod_offline, "{mod_offline, [{backend, odbc}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, odbc}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, odbc}, {host, \"vjud.@HOST@\"}]},"},
       {mod_roster, "{mod_roster, [{backend, odbc}]},"}]},
     {mysql_redis,
      [{sm_backend, "{redis, [{pool_size, 3}, {worker_config, [{host, \"localhost\"}, {port, 6379}]}]}"},
@@ -220,7 +220,7 @@
       {mod_privacy, "{mod_privacy, [{backend, odbc}]},"},
       {mod_private, "{mod_private, [{backend, odbc}]},"},
       {mod_offline, "{mod_offline, [{backend, odbc}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, odbc}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, odbc}, {host, \"vjud.@HOST@\"}]},"},
       {mod_roster, "{mod_roster, [{backend, odbc}]},"}]},
     {external_mnesia,
      [{sm_backend, "{mnesia, []}"},
@@ -235,7 +235,7 @@
                   "{ldap_base, \"ou=Users,dc=esl,dc=com\"}.\n"
                   "{ldap_filter, \"(objectClass=inetOrgPerson)\"}.\n"
       },
-      {mod_vcard,"{mod_vcard, [{backend, ldap},\n"
+      {mod_vcard,"{mod_vcard, [{backend, ldap}, {host, \"vjud.@HOST@\"},\n"
                                "{ldap_filter,\"(objectClass=inetOrgPerson)\"},\n"
                                "{ldap_base, \"ou=Users,dc=esl,dc=com\"}\n"
                                "]},"}
@@ -247,7 +247,7 @@
       {riak_server, "{riak_server, [{pool_size, 5}, {address, \"127.0.0.1\"},{port, 8087}]}."},
       {mod_roster, "{mod_roster, [{backend, riak}]},"},
       {mod_private, "{mod_private, [{backend, riak}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, riak}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, riak}, {host, \"vjud.@HOST@\"}]},"},
       {mod_offline, "{mod_offline, [{backend, riak}]},"},
       {mod_last, "{mod_last, [{backend, riak}]},"},
       {mod_privacy, "{mod_privacy, [{backend, riak}]},"}

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -448,7 +448,7 @@ init_modules(C, muc_light, Config) ->
     dynamic_modules:start(host(), mod_muc_light, [{host, binary_to_list(muc_light_host())}]),
     Config1 = init_modules(C, muc, Config),
     stop_module(host(), mod_mam_muc),
-    init_module(host(), mod_mam_muc, [{host, binary_to_list(muc_light_host())}]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc_light}]),
     Config1;
 
 init_modules(ca, muc_with_pm, Config) ->
@@ -456,7 +456,7 @@ init_modules(ca, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_ca_arch, []),
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc, muc_with_pm, Config) ->
     %% TODO test both mod_mam_muc_odbc_arch and mod_mam_odbc_arch
@@ -464,14 +464,14 @@ init_modules(odbc, muc_with_pm, Config) ->
     init_module(host(), mod_mam_odbc_prefs, [muc, pm]),
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_simple, muc_with_pm, Config) ->
     init_module(host(), mod_mam_odbc_arch, [muc, pm, simple]),
     init_module(host(), mod_mam_odbc_prefs, [muc, pm]),
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_async_pool, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [no_writer]),
@@ -481,7 +481,7 @@ init_modules(odbc_async_pool, muc_with_pm, Config) ->
     init_module(host(), mod_mam_odbc_prefs, [muc, pm]),
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
@@ -489,7 +489,7 @@ init_modules(odbc_mnesia, muc_with_pm, Config) ->
     init_module(host(), mod_mam_mnesia_prefs, [muc, pm]),
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
@@ -498,7 +498,7 @@ init_modules(odbc_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam_cache_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_async_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [no_writer]),
@@ -509,7 +509,7 @@ init_modules(odbc_async_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam_cache_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia_muc_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
@@ -519,7 +519,7 @@ init_modules(odbc_mnesia_muc_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_cache_user, [pm]),
     init_module(host(), mod_mam_muc_cache_user, []),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
@@ -528,46 +528,46 @@ init_modules(odbc_mnesia_cache, muc_with_pm, Config) ->
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam_cache_user, [muc, pm]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 
 init_modules(ca, muc, Config) ->
     init_module(host(), mod_mam_muc_ca_arch, []),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc, muc, Config) ->
     %% TODO test both mod_mam_muc_odbc_arch and mod_mam_odbc_arch
     init_module(host(), mod_mam_odbc_arch, [muc]),
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_simple, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [muc, simple]),
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_async_pool, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [no_writer]),
     init_module(host(), mod_mam_muc_odbc_async_pool_writer, [{flush_interval, 1}]), %% 1ms
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_cache, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_async_cache, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [no_writer]),
@@ -575,21 +575,21 @@ init_modules(odbc_async_cache, muc, Config) ->
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia_muc_cache, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_muc_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia_cache, muc, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc, _, Config) ->
     init_module(host(), mod_mam, [add_archived_element]),
@@ -620,7 +620,7 @@ init_modules(riak_timed_yz_buckets, _, Config) ->
     init_module(host(), mod_mam_riak_timed_arch_yz, [pm, muc]),
     init_module(host(), mod_mam_mnesia_prefs, [pm, muc]),
     init_module(host(), mod_mam, [add_archived_element]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{muc_module, mod_muc}, add_archived_element]),
     Config;
 init_modules(odbc_async_pool, _, Config) ->
     init_module(host(), mod_mam, [add_archived_element]),

--- a/test/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test/ejabberd_tests/tests/mam_SUITE.erl
@@ -661,8 +661,9 @@ init_modules(odbc_mnesia_cache, _, Config) ->
     Config.
 
 end_modules(C, muc_light, Config) ->
+    end_modules(C, generic, Config),
     dynamic_modules:stop(host(), mod_muc_light),
-    end_modules(C, generic, Config);
+    Config;
 end_modules(_, _, Config) ->
     [stop_module(host(), M) || M <- mam_modules()],
     Config.

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -246,8 +246,8 @@ init_per_suite(Config) ->
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
-    escalus_fresh:clean(),
     unload_muc(),
+    escalus_fresh:clean(),
     escalus:end_per_suite(Config).
 
 init_per_group(moderator, Config) ->

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -1166,7 +1166,7 @@ set_custom_config(RawSchema, RawDefaultConfig) ->
 
 -spec set_mod_config(K :: atom(), V :: any()) -> ok.
 set_mod_config(K, V) ->
-    true = rpc(gen_mod, set_module_opt_by_subhost, [?MUCHOST, mod_muc_light, K, V]).
+    true = rpc(gen_mod, set_module_opt_by_subhost, [?MUCHOST, K, V]).
 
 -spec ns_muc_light_affiliations() -> binary().
 ns_muc_light_affiliations() ->

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -197,8 +197,8 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     clear_db(),
-    dynamic_modules:stop(<<"localhost">>, mod_muc_light),
     Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
+    dynamic_modules:stop(<<"localhost">>, mod_muc_light),
     escalus:end_per_suite(Config1).
 
 init_per_group(_GroupName, Config) ->

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -1166,7 +1166,7 @@ set_custom_config(RawSchema, RawDefaultConfig) ->
 
 -spec set_mod_config(K :: atom(), V :: any()) -> ok.
 set_mod_config(K, V) ->
-    true = rpc(mod_muc_light, set_opt, [?MUCHOST, K, V]).
+    true = rpc(gen_mod, set_module_opt_by_subhost, [?MUCHOST, mod_muc_light, K, V]).
 
 -spec ns_muc_light_affiliations() -> binary().
 ns_muc_light_affiliations() ->

--- a/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
@@ -848,5 +848,5 @@ set_default_mod_config() ->
 
 -spec set_mod_config(K :: atom(), V :: any()) -> ok.
 set_mod_config(K, V) ->
-    true = rpc(mod_muc_light, set_opt, [?MUCHOST, K, V]).
+    true = rpc(gen_mod, set_module_opt_by_subhost, [?MUCHOST, mod_muc_light, K, V]).
 

--- a/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
@@ -848,5 +848,5 @@ set_default_mod_config() ->
 
 -spec set_mod_config(K :: atom(), V :: any()) -> ok.
 set_mod_config(K, V) ->
-    true = rpc(gen_mod, set_module_opt_by_subhost, [?MUCHOST, mod_muc_light, K, V]).
+    true = rpc(gen_mod, set_module_opt_by_subhost, [?MUCHOST, K, V]).
 

--- a/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
@@ -134,8 +134,8 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     clear_db(),
-    dynamic_modules:stop(<<"localhost">>, mod_muc_light),
     Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
+    dynamic_modules:stop(<<"localhost">>, mod_muc_light),
     escalus:end_per_suite(Config1).
 
 init_per_group(_GroupName, Config) ->

--- a/test/ejabberd_tests/tests/pep_SUITE.erl
+++ b/test/ejabberd_tests/tests/pep_SUITE.erl
@@ -137,7 +137,8 @@ required_modules() ->
      {mod_pubsub, [
                    {plugins,[<<"dag">>,<<"pep">>]},
                    {nodetree,<<"dag">>},
-                   {pep_mapping,[]}
+                   {pep_mapping,[]},
+                   {host, "pubsub.@HOST@"}
                   ]}].
 
 send_initial_presence_with_caps(User) ->

--- a/test/ejabberd_tests/tests/pubsub_SUITE.erl
+++ b/test/ejabberd_tests/tests/pubsub_SUITE.erl
@@ -874,5 +874,6 @@ disable_delivery_test(Config) ->
 required_modules() ->
     [{mod_pubsub, [
                    {plugins,[<<"dag">>]},
-                   {nodetree,<<"dag">>}
+                   {nodetree,<<"dag">>},
+                   {host, "pubsub.@HOST@"}
                   ]}].

--- a/test/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_SUITE.erl
@@ -87,7 +87,7 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    rest_helper:maybe_disable_mam(proplists:get_value(mam_enabled, Config), host()),
+    rest_helper:maybe_disable_mam(mam_helper:backend(), host()),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->

--- a/test/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -20,7 +20,7 @@ init_per_suite(C) ->
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     Host = ct:get_config({hosts, mim, domain}),
-    rest_helper:maybe_disable_mam(proplists:get_value(mam_enabled, Config), Host),
+    rest_helper:maybe_disable_mam(mam_helper:backend(), Host),
     escalus:end_per_suite(Config).
 
 init_per_group(_GN, C) ->

--- a/test/ejabberd_tests/tests/rest_helper.erl
+++ b/test/ejabberd_tests/tests/rest_helper.erl
@@ -166,13 +166,13 @@ maybe_enable_mam(odbc, Host, Config) ->
     init_module(Host, mod_mam_odbc_prefs, [muc, pm]),
     init_module(Host, mod_mam_odbc_user, [muc, pm]),
     init_module(Host, mod_mam, []),
-    init_module(Host, mod_mam_muc, [{host, "muc.@HOST@"}]),
+    init_module(Host, mod_mam_muc, [{muc_module, mod_muc}]),
     [{mam_backend, odbc} | Config];
 maybe_enable_mam(riak, Host,  Config) ->
     init_module(Host, mod_mam_riak_timed_arch_yz, [pm, muc]),
     init_module(Host, mod_mam_mnesia_prefs, [pm, muc]),
     init_module(Host, mod_mam, []),
-    init_module(Host, mod_mam_muc, [{host, "muc.@HOST@"}]),
+    init_module(Host, mod_mam_muc, [{muc_module, mod_muc}]),
     [{mam_backend, riak}, {yz_wait, 2500} | Config];
 maybe_enable_mam(_, _, C) ->
     [{mam_backend, disabled} | C].

--- a/test/ejabberd_tests/tests/rest_helper.erl
+++ b/test/ejabberd_tests/tests/rest_helper.erl
@@ -166,12 +166,14 @@ maybe_enable_mam(odbc, Host, Config) ->
     init_module(Host, mod_mam_odbc_prefs, [muc, pm]),
     init_module(Host, mod_mam_odbc_user, [muc, pm]),
     init_module(Host, mod_mam, []),
+    init_module(Host, mod_muc, [{host, "muc.@HOST@"}]),
     init_module(Host, mod_mam_muc, [{muc_module, mod_muc}]),
     [{mam_backend, odbc} | Config];
 maybe_enable_mam(riak, Host,  Config) ->
     init_module(Host, mod_mam_riak_timed_arch_yz, [pm, muc]),
     init_module(Host, mod_mam_mnesia_prefs, [pm, muc]),
     init_module(Host, mod_mam, []),
+    init_module(Host, mod_muc, [{host, "muc.@HOST@"}]),
     init_module(Host, mod_mam_muc, [{muc_module, mod_muc}]),
     [{mam_backend, riak}, {yz_wait, 2500} | Config];
 maybe_enable_mam(_, _, C) ->
@@ -185,12 +187,14 @@ maybe_disable_mam(odbc, Host) ->
     stop_module(Host, mod_mam_odbc_prefs),
     stop_module(Host, mod_mam_odbc_user),
     stop_module(Host, mod_mam),
-    stop_module(Host, mod_mam_muc);
+    stop_module(Host, mod_mam_muc),
+    stop_module(Host, mod_muc);
 maybe_disable_mam(riak, Host) ->
     stop_module(Host, mod_mam_riak_timed_arch_yz),
     stop_module(Host, mod_mam_mnesia_prefs),
     stop_module(Host, mod_mam),
-    stop_module(Host, mod_mam_muc);
+    stop_module(Host, mod_mam_muc),
+    stop_module(Host, mod_muc);
 maybe_disable_mam(_, _) ->
     ok.
 

--- a/test/ejabberd_tests/tests/vcard_simple_SUITE.erl
+++ b/test/ejabberd_tests/tests/vcard_simple_SUITE.erl
@@ -450,7 +450,7 @@ configure_ldap_vcards(Config) ->
     CurrentConfigs = escalus_ejabberd:rpc(gen_mod, loaded_modules_with_opts, [Domain]),
     {mod_vcard, CurrentVcardConfig} = lists:keyfind(mod_vcard, 1, CurrentConfigs),
     dynamic_modules:stop(Domain, mod_vcard),
-    Cfg = [{backend,ldap},
+    Cfg = [{backend,ldap}, {host, "vjud.@HOST@"},
            {ldap_filter,"(objectClass=inetOrgPerson)"},
            {ldap_base,"ou=Users,dc=esl,dc=com"},
            {ldap_search_fields, [{"Full Name","cn"},{"User","uid"}]},


### PR DESCRIPTION
This PR partially addresses #911

Proposed changes include:
- `gen_mod` maintains a table of subdomain->domain mappings for modules that register themselves under these subdomains.
- Entries are automatically added/removed
- API is provided to manipulate module options by subdomain
- When any module uses `host` option, it is mandatory now (makes it easier to update mappings table)
- Main module table is now created with `read_concurrency` enabled
- Clarified naming convention in some places (Host/ServerHost/Server vs. Host/SubHost/MUCHost/etc.)
- Updated docs about `host` becoming mandatory
- `mod_mam_muc` is now configured with MUC module name, not domain; it also uses new registry instead of custom, private table
- `mod_muc_light` uses new registry instead of own, private table
