### PR TITLE
Remove deprecated functions from jlib

### DIFF
--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -38,19 +38,6 @@
          replace_from_to_attrs/3,
          replace_from_to/3,
          remove_attr/2,
-         make_jid/3,
-         make_jid/1,
-         are_equal_jids/2,
-         binary_to_jid/1,
-         jid_to_binary/1,
-         is_nodename/1,
-         nodeprep/1,
-         nameprep/1,
-         resourceprep/1,
-         jid_to_lower/1,
-         jid_tolower/1,
-         jid_remove_resource/1,
-         jid_replace_resource/2,
          iq_query_info/1,
          iq_query_or_response_info/1,
          iq_to_xml/1,
@@ -264,85 +251,6 @@ replace_from_to(From, To, XE = #xmlel{attrs = Attrs}) ->
 remove_attr(Attr, XE = #xmlel{attrs = Attrs}) ->
     NewAttrs = lists:keydelete(Attr, 1, Attrs),
     XE#xmlel{attrs = NewAttrs}.
-
-
--spec make_jid(User     :: ejabberd:user(),
-               Server   :: ejabberd:server(),
-               Resource :: ejabberd:resource()) -> ejabberd:jid() | error.
-make_jid(User, Server, Resource) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:make(User, Server, Resource).
-
--spec make_jid(ejabberd:simple_jid()) -> ejabberd:jid() | error.
-make_jid({User, Server, Resource}) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    make_jid(User, Server, Resource).
-
--spec are_equal_jids(ejabberd:jid(), ejabberd:jid()) -> boolean().
-are_equal_jids(JID1, JID2) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:are_equal(JID1, JID2).
-
-
--spec binary_to_jid(binary()) -> 'error' | ejabberd:jid().
-binary_to_jid(J) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:from_binary(J).
-
-
--spec jid_to_binary(ejabberd:simple_jid() | ejabberd:jid()) -> binary().
-jid_to_binary(JID) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:to_binary(JID).
-
--spec is_nodename(<<>> | binary()) -> boolean().
-is_nodename(J) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:is_nodename(J).
-
--spec nodeprep(ejabberd:user()) -> 'error' | ejabberd:lserver().
-nodeprep(S) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:nodeprep(S).
-
-
--spec nameprep(ejabberd:server()) -> 'error' | ejabberd:luser().
-nameprep(S) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:nameprep(S).
-
--spec resourceprep(ejabberd:resource()) ->
-    'error' | ejabberd:lresource().
-resourceprep(S) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:resourceprep(S).
-
-
-%% @doc You are a bad person if you use this function.
--spec jid_tolower(JID :: ejabberd:simple_jid() | ejabberd:jid()) -> error | ejabberd:simple_jid().
-jid_tolower(Any) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:to_lower(Any).
-
--spec jid_to_lower(JID :: ejabberd:simple_jid() | ejabberd:jid()
-                 ) -> error | ejabberd:simple_jid().
-jid_to_lower(JID) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:to_lower(JID).
-
--spec jid_remove_resource(ejabberd:simple_jid() | ejabberd:jid()) ->
-                          ejabberd:simple_jid() | ejabberd:jid().
-jid_remove_resource(JID) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:to_bare(JID).
-
-
--spec jid_replace_resource(ejabberd:jid(), ejabberd:resource()) ->
-                                                  'error' | ejabberd:jid().
-jid_replace_resource(JID, Resource) ->
-    ?WARNING_MSG("This function has been deprecated in MongooseIM 1.6.1 and will be removed in 1.7.0", []),
-    jid:replace_resource(JID, Resource).
-
 
 -spec iq_query_info(xmlel()) -> 'invalid' | 'not_iq' | 'reply' | ejabberd:iq().
 iq_query_info(El) ->

--- a/apps/ejabberd/src/mongoose_cassandra_worker.erl
+++ b/apps/ejabberd/src/mongoose_cassandra_worker.erl
@@ -217,7 +217,7 @@ test_query(PoolName, UserJID) ->
 %% Don't use these queries in production. Just for testing.
 
 total_count_query(PoolName, Table) ->
-    UserJID = jlib:make_jid(<<"mongooseim">>, ?MYNAME, <<>>),
+    UserJID = jid:make(<<"mongooseim">>, ?MYNAME, <<>>),
     Res = cql_query_pool(PoolName, UserJID, ?MODULE, {total_count_query, Table}, []),
     {ok, [[Count]]} = Res,
     Count.

--- a/apps/ejabberd/test/acl_SUITE.erl
+++ b/apps/ejabberd/test/acl_SUITE.erl
@@ -38,21 +38,21 @@ end_per_testcase(_TC, _Config) ->
     ok.
 
 all_rule_returns_allow(_Config) ->
-    JID = jlib:make_jid(<<"pawel">>, <<"phost">>, <<"test">>),
+    JID = jid:make(<<"pawel">>, <<"phost">>, <<"test">>),
     ?assertEqual(allow, acl:match_rule(global, all, JID)),
     ?assertEqual(allow, acl:match_rule(<<"phost">>, all, JID)),
     ?assertEqual(allow, acl:match_rule(<<"localhost">>, all, JID)),
     ok.
 
 none_rule_returns_deny(_Config) ->
-    JID = jlib:make_jid(<<"gawel">>, <<"phost">>, <<"test">>),
+    JID = jid:make(<<"gawel">>, <<"phost">>, <<"test">>),
     ?assertEqual(deny, acl:match_rule(global, none, JID)),
     ?assertEqual(deny, acl:match_rule(<<"phosty">>, none, JID)),
     ?assertEqual(deny, acl:match_rule(<<"localhosty">>, none, JID)),
     ok.
 
 basic_access_rules(_Config) ->
-    JID = jlib:make_jid(<<"pawel">>, <<"phost">>, <<"test">>),
+    JID = jid:make(<<"pawel">>, <<"phost">>, <<"test">>),
 
     %% rule is not defined deny by default - deny
     ?assertEqual(deny, (acl:match_rule(global, single_rule, JID))),
@@ -77,8 +77,8 @@ basic_access_rules(_Config) ->
 host_sepcific_access_rules(_Config) ->
     given_registered_domains([<<"poznan">>, <<"wroclaw">>]),
 
-    PozAdmin = jlib:make_jid(<<"gawel">>, <<"poznan">>, <<"test">>),
-    Pawel = jlib:make_jid(<<"pawel">>, <<"wroclaw">>, <<"test">>),
+    PozAdmin = jid:make(<<"gawel">>, <<"poznan">>, <<"test">>),
+    Pawel = jid:make(<<"pawel">>, <<"wroclaw">>, <<"test">>),
 
     acl:add(global, admin_poz, {user, <<"gawel">>, <<"poznan">>}),
 
@@ -95,8 +95,8 @@ host_sepcific_access_rules(_Config) ->
 compound_access_rules(_Config) ->
     given_registered_domains([<<"krakow">>]),
 
-    KrkAdmin = jlib:make_jid(<<"gawel">>, <<"krakow">>, <<"test">>),
-    KrkNormal = jlib:make_jid(<<"pawel">>, <<"krakow">>, <<"test">>),
+    KrkAdmin = jid:make(<<"gawel">>, <<"krakow">>, <<"test">>),
+    KrkNormal = jid:make(<<"pawel">>, <<"krakow">>, <<"test">>),
 
     %% add admin user rule
     acl:add(global, admin_wawa, {user, <<"gawel">>, <<"wawa">>}),
@@ -115,7 +115,7 @@ compound_access_rules(_Config) ->
 global_host_priority(_Config) ->
     given_registered_domains([<<"rzeszow">>, <<"lublin">>]),
 
-    RzeAdmin = jlib:make_jid(<<"pawel">>, <<"rzeszow">>, <<"test">>),
+    RzeAdmin = jid:make(<<"pawel">>, <<"rzeszow">>, <<"test">>),
 
     %% add admin user rule
     acl:add(<<"rzeszow">>, admin, {user, <<"pawel">>, <<"rzeszow">>}),
@@ -140,7 +140,7 @@ global_host_priority(_Config) ->
 all_and_none_specs(_Config) ->
     given_registered_domains([<<"zakopane">>]),
 
-    User = jlib:make_jid(<<"pawel">>, <<"zakopane">>, <<"test">>),
+    User = jid:make(<<"pawel">>, <<"zakopane">>, <<"test">>),
     acl:add(global, a_users, all),
     acl:add(global, n_users, none),
 
@@ -154,7 +154,7 @@ all_and_none_specs(_Config) ->
 invalid_spec(_Config) ->
     given_registered_domains([<<"bialystok">>]),
 
-    User = jlib:make_jid(<<"pawel">>, <<"bialystok">>, <<"test">>),
+    User = jid:make(<<"pawel">>, <<"bialystok">>, <<"test">>),
     acl:add(global, invalid, {non_existing_spec, "lalala"}),
 
     set_global_rule(invalid, [{allow, invalid}, {deny, all}]),
@@ -164,8 +164,8 @@ invalid_spec(_Config) ->
 different_specs_matching_the_same_user(_Config) ->
     given_registered_domains([<<"gdansk">>, <<"koszalin">>]),
 
-    UserGd = jlib:make_jid(<<"pawel">>, <<"gdansk">>,  <<"res">>),
-    UserKo = jlib:make_jid(<<"pawel">>, <<"koszalin">>,<<"res1">>),
+    UserGd = jid:make(<<"pawel">>, <<"gdansk">>,  <<"res">>),
+    UserKo = jid:make(<<"pawel">>, <<"koszalin">>,<<"res1">>),
 
     %% invariand we are going to change admin acl only
     set_global_rule(allow_admin, [{allow, admin}, {deny, all}]),

--- a/apps/ejabberd/test/auth_tokens_SUITE.erl
+++ b/apps/ejabberd/test/auth_tokens_SUITE.erl
@@ -153,7 +153,7 @@ validity_period_test(_) ->
 
 choose_key_by_token_type(_) ->
     %% given mocked keystore (see init_per_testcase)
-    JID = jlib:binary_to_jid(<<"alice@localhost">>),
+    JID = jid:from_binary(<<"alice@localhost">>),
     %% when mod_auth_token asks for key for given token type
     %% then the correct key is returned
     ?ae(<<"access_or_refresh">>, ?TESTED:get_key_for_user(access, JID)),
@@ -197,7 +197,7 @@ revoked_token_is_not_valid(_) ->
     self() ! {valid_seq_no, ValidSeqNo},
     T = #token{type = refresh,
                expiry_datetime = ?TESTED:seconds_to_datetime(utc_now_as_seconds() + 10),
-               user_jid = jlib:binary_to_jid(<<"alice@localhost">>),
+               user_jid = jid:from_binary(<<"alice@localhost">>),
                sequence_no = RevokedSeqNo},
     Revoked = ?TESTED:serialize(?TESTED:token_with_mac(T)),
     %% when
@@ -356,7 +356,7 @@ token() ->
 make_token({Type, Expiry, JID, SeqNo, VCard}) ->
     T = #token{type = Type,
                expiry_datetime = Expiry,
-               user_jid = jlib:binary_to_jid(JID)},
+               user_jid = jid:from_binary(JID)},
     case Type of
         access ->
             ?TESTED:token_with_mac(T);

--- a/apps/ejabberd/test/jid_SUITE.erl
+++ b/apps/ejabberd/test/jid_SUITE.erl
@@ -1,0 +1,142 @@
+-module(jid_SUITE).
+-include_lib("exml/include/exml.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
+-include_lib("common_test/include/ct.hrl").
+-compile([export_all]).
+
+-import(prop_helper, [prop/2]).
+
+all() -> [
+          binary_to_jid_succeeds_with_valid_binaries,
+          binary_to_jid_fails_with_invalid_binaries,
+          binary_to_jid_fails_with_empty_binary,
+          make_jid_fails_on_binaries_that_are_too_long,
+          jid_to_lower_fails_if_any_binary_is_invalid,
+          jid_replace_resource_failes_for_invalid_resource,
+          nodeprep_fails_with_too_long_username,
+          nameprep_fails_with_too_long_domain,
+          resourceprep_fails_with_too_long_resource,
+          nodeprep_fails_with_incorrect_username,
+          resourceprep_fails_with_incorrect_resource,
+          nameprep_fails_with_incorrect_domain,
+          is_nodename_fails_for_empty_binary,
+          compare_bare_jids
+         ].
+
+init_per_suite(C) ->
+    application:start(stringprep),
+    C.
+
+end_per_suite(C) ->
+    C.
+
+
+binary_to_jid_succeeds_with_valid_binaries(_C) ->
+    Prop = ?FORALL(BinJid, (jid_gen:jid()),
+                   (is_record(jid:from_binary(BinJid), jid))),
+    prop(binary_to_jid_succeeds_with_valid_binaries, Prop).
+
+
+binary_to_jid_fails_with_invalid_binaries(_C) ->
+    Prop = ?FORALL(BinJid, jid_gen:invalid_jid(),
+                   error == jid:from_binary(BinJid)),
+    run_property(Prop, 100, 1, 42).
+
+binary_to_jid_fails_with_empty_binary(_) ->
+    error = jid:from_binary(<<>>).
+
+make_jid_fails_on_binaries_that_are_too_long(_) ->
+    Prop = ?FORALL({U, S, R},
+                   {jid_gen:username(), jid_gen:domain(), jid_gen:resource()},
+                   case element_length_is_too_big([U,S,R]) of
+                        true -> error == jid:make(U,S,R);
+                        false -> is_record(jid:make(U,S,R), jid)
+                   end),
+    run_property(Prop, 100, 500, 1500).
+
+element_length_is_too_big(Els) ->
+    lists:any(fun(El) -> size(El) >= 1024 end, Els).
+
+jid_to_lower_fails_if_any_binary_is_invalid(_) ->
+    Prop = ?FORALL({U, S, R},
+                   {jid_gen:maybe_valid_username(), jid_gen:maybe_valid_domain(), jid_gen:maybe_valid_resource()},
+                   case jid:to_lower({U, S, R}) of
+                       {LU, LS, LR} ->
+                           jid:nodeprep(U) == LU andalso
+                           jid:nameprep(S) == LS andalso
+                           jid:resourceprep(R) == LR;
+                       error ->
+                           jid:nodeprep(U) == error orelse
+                           jid:nameprep(S) == error orelse
+                           jid:resourceprep(R) == error
+                   end),
+
+    run_property(Prop, 150, 1, 42).
+
+nodeprep_fails_with_too_long_username(_C) ->
+    Prop = ?FORALL(Bin, jid_gen:username(),
+                   error == jid:nodeprep(Bin)),
+    run_property(Prop, 5, 1024, 2048).
+
+nameprep_fails_with_too_long_domain(_C) ->
+    Prop = ?FORALL(Bin, jid_gen:domain(),
+                   error == jid:nameprep(Bin)),
+    run_property(Prop, 5, 1024, 2048).
+
+resourceprep_fails_with_too_long_resource(_C) ->
+    Prop = ?FORALL(Bin, jid_gen:resource(),
+                   error == jid:resourceprep(Bin)),
+    run_property(Prop, 5, 1024, 2048).
+
+jid_replace_resource_failes_for_invalid_resource(_) ->
+    Prop = ?FORALL({BinJid, MaybeCorrectRes},
+                   {jid_gen:bare_jid(), jid_gen:maybe_valid_resource()},
+                   jid_replace_resource(BinJid, MaybeCorrectRes)),
+    prop(jid_replace_resource, Prop).
+
+jid_replace_resource(BinJid, Res) ->
+    Jid = jid:from_binary(BinJid),
+    Jid2 = jid:replace_resource(Jid, Res),
+    check_jid_replace_resource_output(Res, Jid2).
+
+check_jid_replace_resource_output(Resource, error) ->
+    jid:resourceprep(Resource) == error;
+check_jid_replace_resource_output(Resource, #jid{}) ->
+    jid:resourceprep(Resource) =/= error.
+
+
+run_property(Prop, NumTest, StartSize, StopSize) ->
+    ?assert(proper:quickcheck(Prop, [verbose, long_result,
+                                     {numtests, NumTest},
+                                     {start_size, StartSize},
+                                     {max_size, StopSize}])).
+
+nodeprep_fails_with_incorrect_username(_) ->
+    prop(incorrect_username_property,
+         ?FORALL(Bin, jid_gen:invalid_username(),
+                 error == jid:nodeprep(Bin))).
+
+resourceprep_fails_with_incorrect_resource(_) ->
+    prop(incorrect_resource_property,
+         ?FORALL(Bin, jid_gen:invalid_resource(),
+                 error == jid:resourceprep(Bin))).
+
+nameprep_fails_with_incorrect_domain(_) ->
+    prop(incorrect_domain_property,
+         ?FORALL(Bin, jid_gen:invalid_domain(),
+                 error == jid:nameprep(Bin))).
+
+is_nodename_fails_for_empty_binary(_) ->
+    false = jid:is_nodename(<<>>).
+
+compare_bare_jids(_) ->
+    prop(compare_bare_jids,
+         ?FORALL({A, B}, {jid_gen:jid(), jid_gen:jid()},
+                 begin
+                    AA = jid:from_binary(A),
+                    BB = jid:from_binary(B),
+                    equals(jid:are_equal(jid:to_bare(AA), jid:to_bare(BB)),
+                           jid:are_bare_equal(AA, BB))
+                 end)).

--- a/apps/ejabberd/test/jlib_SUITE.erl
+++ b/apps/ejabberd/test/jlib_SUITE.erl
@@ -8,24 +8,12 @@
 
 -import(prop_helper, [prop/2]).
 
-all() -> [make_iq_reply_changes_type_to_result,
+all() -> [
+          make_iq_reply_changes_type_to_result,
           make_iq_reply_changes_to_to_from,
           make_iq_reply_switches_from_to_to,
-          make_iq_reply_switches_to_and_from_attrs,
-          binary_to_jid_succeeds_with_valid_binaries,
-          binary_to_jid_fails_with_invalid_binaries,
-          binary_to_jid_fails_with_empty_binary,
-          make_jid_fails_on_binaries_that_are_too_long,
-          jid_to_lower_fails_if_any_binary_is_invalid,
-          jid_replace_resource_failes_for_invalid_resource,
-          nodeprep_fails_with_too_long_username,
-          nameprep_fails_with_too_long_domain,
-          resourceprep_fails_with_too_long_resource,
-          nodeprep_fails_with_incorrect_username,
-          resourceprep_fails_with_incorrect_resource,
-          nameprep_fails_with_incorrect_domain,
-          is_nodename_fails_for_empty_binary,
-          compare_bare_jids].
+          make_iq_reply_switches_to_and_from_attrs
+         ].
 
 init_per_suite(C) ->
     application:start(stringprep),
@@ -82,79 +70,8 @@ base_iq() ->
                               attrs = [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-session">>}]}
                       ]}.
 
-binary_to_jid_succeeds_with_valid_binaries(_C) ->
-    Prop = ?FORALL(BinJid, (jid_gen:jid()),
-                   (is_record(jlib:binary_to_jid(BinJid), jid))),
-    prop(binary_to_jid_succeeds_with_valid_binaries, Prop).
-
-
-binary_to_jid_fails_with_invalid_binaries(_C) ->
-    Prop = ?FORALL(BinJid, jid_gen:invalid_jid(),
-                   error == jlib:binary_to_jid(BinJid)),
-    run_property(Prop, 100, 1, 42).
-
-binary_to_jid_fails_with_empty_binary(_) ->
-    error = jlib:binary_to_jid(<<>>).
-
-make_jid_fails_on_binaries_that_are_too_long(_) ->
-    Prop = ?FORALL({U, S, R},
-                   {jid_gen:username(), jid_gen:domain(), jid_gen:resource()},
-                   case element_length_is_too_big([U,S,R]) of
-                        true -> error == jlib:make_jid(U,S,R);
-                        false -> is_record(jlib:make_jid(U,S,R), jid)
-                   end),
-    run_property(Prop, 100, 500, 1500).
-
 element_length_is_too_big(Els) ->
     lists:any(fun(El) -> size(El) >= 1024 end, Els).
-
-jid_to_lower_fails_if_any_binary_is_invalid(_) ->
-    Prop = ?FORALL({U, S, R},
-                   {jid_gen:maybe_valid_username(), jid_gen:maybe_valid_domain(), jid_gen:maybe_valid_resource()},
-                   case jlib:jid_to_lower({U, S, R}) of
-                       {LU, LS, LR} ->
-                           jlib:nodeprep(U) == LU andalso
-                           jlib:nameprep(S) == LS andalso
-                           jlib:resourceprep(R) == LR;
-                       error ->
-                           jlib:nodeprep(U) == error orelse
-                           jlib:nameprep(S) == error orelse
-                           jlib:resourceprep(R) == error
-                   end),
-
-    run_property(Prop, 150, 1, 42).
-
-nodeprep_fails_with_too_long_username(_C) ->
-    Prop = ?FORALL(Bin, jid_gen:username(),
-                   error == jlib:nodeprep(Bin)),
-    run_property(Prop, 5, 1024, 2048).
-
-nameprep_fails_with_too_long_domain(_C) ->
-    Prop = ?FORALL(Bin, jid_gen:domain(),
-                   error == jlib:nameprep(Bin)),
-    run_property(Prop, 5, 1024, 2048).
-
-resourceprep_fails_with_too_long_resource(_C) ->
-    Prop = ?FORALL(Bin, jid_gen:resource(),
-                   error == jlib:resourceprep(Bin)),
-    run_property(Prop, 5, 1024, 2048).
-
-jid_replace_resource_failes_for_invalid_resource(_) ->
-    Prop = ?FORALL({BinJid, MaybeCorrectRes},
-                   {jid_gen:bare_jid(), jid_gen:maybe_valid_resource()},
-                   jid_replace_resource(BinJid, MaybeCorrectRes)),
-    prop(jid_replace_resource, Prop).
-
-jid_replace_resource(BinJid, Res) ->
-    Jid = jlib:binary_to_jid(BinJid),
-    Jid2 = jlib:jid_replace_resource(Jid, Res),
-    check_jid_replace_resource_output(Res, Jid2).
-
-check_jid_replace_resource_output(Resource, error) ->
-    jlib:resourceprep(Resource) == error;
-check_jid_replace_resource_output(Resource, #jid{}) ->
-    jlib:resourceprep(Resource) =/= error.
-
 
 run_property(Prop, NumTest, StartSize, StopSize) ->
     ?assert(proper:quickcheck(Prop, [verbose, long_result,
@@ -162,30 +79,3 @@ run_property(Prop, NumTest, StartSize, StopSize) ->
                                      {start_size, StartSize},
                                      {max_size, StopSize}])).
 
-nodeprep_fails_with_incorrect_username(_) ->
-    prop(incorrect_username_property,
-         ?FORALL(Bin, jid_gen:invalid_username(),
-                 error == jlib:nodeprep(Bin))).
-
-resourceprep_fails_with_incorrect_resource(_) ->
-    prop(incorrect_resource_property,
-         ?FORALL(Bin, jid_gen:invalid_resource(),
-                 error == jlib:resourceprep(Bin))).
-
-nameprep_fails_with_incorrect_domain(_) ->
-    prop(incorrect_domain_property,
-         ?FORALL(Bin, jid_gen:invalid_domain(),
-                 error == jlib:nameprep(Bin))).
-
-is_nodename_fails_for_empty_binary(_) ->
-    false = jlib:is_nodename(<<>>).
-
-compare_bare_jids(_) ->
-    prop(compare_bare_jids,
-         ?FORALL({A, B}, {jid_gen:jid(), jid_gen:jid()},
-                 begin
-                    AA = jid:from_binary(A),
-                    BB = jid:from_binary(B),
-                    equals(jid:are_equal(jid:to_bare(AA), jid:to_bare(BB)),
-                           jid:are_bare_equal(AA, BB))
-                 end)).

--- a/apps/ejabberd/test/muc_light_SUITE.erl
+++ b/apps/ejabberd/test/muc_light_SUITE.erl
@@ -4,8 +4,8 @@
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include("mod_muc_light.hrl").
--include("jlib.hrl").
+-include_lib("ejabberd/include/mod_muc_light.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
 
 -define(DOMAIN, <<"localhost">>).
 
@@ -32,7 +32,7 @@ groups() ->
     ].
 
 init_per_group(rsm_disco, Config) ->
-    application:start(p1_stringprep),
+    application:start(stringprep),
     Config;
 init_per_group(_, Config) ->
     Config.
@@ -115,8 +115,8 @@ prop_rsm_disco_success() ->
                         FirstIndex = RSMOut#rsm_out.index,
                         {FirstRoom, _, _} = hd(ProperSlice),
                         {LastRoom, _, _} = lists:last(ProperSlice),
-                        RSMFirst = jlib:jid_to_binary(FirstRoom),
-                        RSMLast = jlib:jid_to_binary(LastRoom),
+                        RSMFirst = jid:to_binary(FirstRoom),
+                        RSMLast = jid:to_binary(LastRoom),
                         true
                 end
             end).
@@ -250,7 +250,7 @@ make_rsm_in(aft, ProperSlice, _FirstIndex, BeforeL, _AfterL) ->
     #rsm_in{
        max = length(ProperSlice),
        direction = aft,
-       id = jlib:jid_to_binary(element(1, lists:last(BeforeL)))
+       id = jid:to_binary(element(1, lists:last(BeforeL)))
       };
 make_rsm_in(before, ProperSlice, _FirstIndex, _BeforeL, AfterL) ->
     #rsm_in{
@@ -258,7 +258,7 @@ make_rsm_in(before, ProperSlice, _FirstIndex, _BeforeL, AfterL) ->
        direction = before,
        id = case AfterL of
                 [] -> <<>>;
-                _ -> jlib:jid_to_binary(element(1, hd(AfterL)))
+                _ -> jid:to_binary(element(1, hd(AfterL)))
             end
       }.
 
@@ -275,7 +275,7 @@ make_invalid_rsm_in(Direction, _RoomsInfo, Nonexistent) ->
     #rsm_in{
        max = 10,
        direction = Direction,
-       id = jlib:jid_to_binary(Nonexistent)
+       id = jid:to_binary(Nonexistent)
       }.
 
 %% ------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses #615 

Proposed changes include:
* Deprecated functions have been removed
* Fixed a call to `jlib:make_jid` in `mongoose_cassandra_worker`


