### PR TITLE
[skip ci] tree/structure review

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,8 +13,8 @@ pages:
       - 'Release/Installation configuration': 'user-guide/release_config.md'
       - 'High-level Architecture': 'user-guide/MongooseIM-High-level-Architecture.md'
   - 'Basic Configuration Overview': 'Basic-configuration.md'
-  - 'Advanced Configuration Overview': 'Advanced-configuration.md'
   - 'Advanced Configuration':
+      - 'Overview': 'Advanced-configuration.md'
       - 'Database backends configuration': 'advanced-configuration/database-backends-configuration.md'
       - 'Cassandra configuration': 'advanced-configuration/Cassandra.md'
       - 'HTTP Authentication Module': 'advanced-configuration/HTTP-authentication-module.md'


### PR DESCRIPTION
"Advanced Configuration Overview" should be under "Advanced Configuration"