### PR TITLE
[skip ci] Update name of username field in request

### DIFF
--- a/doc/http-api/backend_swagger.yml
+++ b/doc/http-api/backend_swagger.yml
@@ -65,7 +65,7 @@ paths:
             title: Credentials
             type: object
             properties:
-              username:
+              user:
                 type: string
               password:
                 type: string


### PR DESCRIPTION
This PR addresses #958 

Proposed changes include:
1. Change name of the field `username` to `user` to work with the REST API


