### PR TITLE
Fix broken MUC Light room destruction

### DIFF
--- a/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
@@ -314,9 +314,9 @@ destroy_room_transaction(RoomUS) ->
             AffUsers = Rec#?ROOM_TAB.aff_users,
             lists:foreach(
                 fun({User, _}) ->
-                    ok = mnesia:delete_object(#?USER_ROOM_TAB{user = User, room = RoomUS}),
-                    mnesia:delete({?ROOM_TAB, RoomUS})
-                end, AffUsers)
+                    ok = mnesia:delete_object(#?USER_ROOM_TAB{user = User, room = RoomUS})
+                end, AffUsers),
+            mnesia:delete({?ROOM_TAB, RoomUS})
     end.
 
 -spec remove_user_transaction(UserUS :: ejabberd:simple_bare_jid(), Version :: binary()) ->

--- a/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_legacy_SUITE.erl
@@ -134,8 +134,8 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     clear_db(),
-    dynamic_modules:stop(<<"localhost">>, mod_muc_light),
     Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
+    dynamic_modules:stop(<<"localhost">>, mod_muc_light),
     escalus:end_per_suite(Config1).
 
 init_per_group(_GroupName, Config) ->


### PR DESCRIPTION
This PR addresses #955 

Proposed changes include:
* Room destruction now may be triggered by user removal.
* Room removal is now working correctly when affiliation list is empty.
* New test case for user removal.
* Added a check in `leave_room` test case, whether the room gets removed.


