### PR TITLE
Fix syntax error in mongoosectl

### DIFF
--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -208,7 +208,7 @@ ctlexec ()
       -noinput \
       -hidden \
       $COOKIE_ARG \
-      -pa $EJABBERD_EBIN_PATH \
+      -pa "$EJABBERD_EBIN_PATH" \
       -s ejabberd_ctl -extra $NODENAME $COMMAND
 }
 

--- a/test/ejabberd_tests/tests/reload_helper.erl
+++ b/test/ejabberd_tests/tests/reload_helper.erl
@@ -45,15 +45,16 @@ restart_ejabberd_node(Node) ->
 reload_through_ctl(Node, Config) ->
     ReloadCmd = node_ctl(Node, Config) ++ " reload_local",
     OutputStr = rpc(Node, os, cmd, [ReloadCmd]),
-    ok = verify_reload_output(OutputStr).
+    ok = verify_reload_output(ReloadCmd, OutputStr).
 
-verify_reload_output(OutputStr) ->
+verify_reload_output(ReloadCmd, OutputStr) ->
     ExpectedOutput = ?CTL_RELOAD_OUTPUT_PREFIX,
     case lists:sublist(OutputStr, length(ExpectedOutput)) of
         ExpectedOutput ->
             ok;
         _ ->
-            ct:pal("~ts", [OutputStr]),
+            ct:pal("ReloadCmd: ~p", [ReloadCmd]),
+            ct:pal("OutputStr: ~ts", [OutputStr]),
             error(config_reload_failed, [OutputStr])
     end.
 


### PR DESCRIPTION
Because of this some of our tests fail when we reload configuration.
Unescaped $EJABBERD_EBIN_PATH seams to have some different meaning (there shouldn't be any white-spaces, but it seams that erlang expects something escaped. Most likely error is caused by "@" character or something similar in the path).

