### PR TITLE
Check for unsupervised links in gen_mod

### DIFF
--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -77,6 +77,7 @@ start() ->
                    Module :: module(),
                    Opts :: [any()]) -> any().
 start_module(Host, Module, Opts0) ->
+    {links, LinksBefore} = erlang:process_info(self(), links),
     Opts = clear_opts(Module, Opts0),
     set_module_opts_mnesia(Host, Module, Opts),
     ets:insert(ejabberd_modules,
@@ -84,6 +85,17 @@ start_module(Host, Module, Opts0) ->
                                 opts = Opts}),
     try
         Res = Module:start(Host, Opts),
+        {links, LinksAfter} = erlang:process_info(self(), links),
+        case lists:sort(LinksBefore) =:= lists:sort(LinksAfter) of
+            true -> ok;
+            false ->
+                %% Note for programmers:
+                %% Never call start_link directory in module:start function!
+                %% The process will be killed if we start modules remotely or in shell
+                ?ERROR_MSG("issue=unexpected_links, cause_travis_build_failure=true,"
+                            " links_before=~p, links_after=~p",
+                           [LinksBefore, LinksAfter])
+        end,
         ?DEBUG("Module ~p started for ~p.", [Module, Host]),
         Res
     catch

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -84,7 +84,12 @@ run_tests() {
 	echo
 	echo "All tests done."
 
-	if [ $SMALL_STATUS -eq 0 -a $BIG_STATUS -eq 0 ]
+	grep "cause_travis_build_failure=true" ${BASE}/dev/mongooseim_*/log/ejabberd.log
+    # If phrase found than exit with code 1
+    test $? -eq 1
+    LOG_STATUS=$?
+
+	if [ $SMALL_STATUS -eq 0 -a $BIG_STATUS -eq 0 -a $LOG_STATUS -eq 0 ]
 	then
 		RESULT=0
 		echo "Build succeeded"
@@ -93,6 +98,7 @@ run_tests() {
 		echo "Build failed:"
 		[ $SMALL_STATUS -ne 0 ] && echo "    small tests failed"
 		[ $BIG_STATUS -ne 0 ]   && echo "    big tests failed"
+		[ $LOG_STATUS -ne 0 ]   && echo "    log contains errors"
 	fi
 
 	exit ${RESULT}


### PR DESCRIPTION
This PR contains two features:
- Allow for some log messages to trigger CI failure
- Warn about links added inside start_module callback.

Bad-written modules can link to the caller process in start_module callback
It works without errors until we try to start modules in the shell or using RPC
