### PR TITLE
Extend Makefile with qtest task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ apps/ejabberd/priv/mibs/EJABBERD-MIB.bin
 apps/ejabberd/ebin/ejabberd.app
 rel/configure.vars.config
 rel/vars.config
+test/ejabberd_tests/qtest.spec
 
 # Compilation/test ephemera
 *.d

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test: test_node_stopped test_deps
 
 # $ make qtest SUITE=mam_SUITE
 # $ make qtest SUITE="[mam_SUITE,metrics_api_SUITE]"
-qtest: test_node_stopped
+qtest: test_node_stopped check_cfg_backup
 	cp test/ejabberd_tests/qtest.spec.template test/ejabberd_tests/qtest.spec
 	echo "{suites, \"tests\", $(SUITE)}." >> test/ejabberd_tests/qtest.spec
 	cd test/ejabberd_tests;
@@ -121,7 +121,7 @@ configure.out rel/configure.vars.config:
 
 devrel: certs $(DEVNODES)
 
-$(DEVNODES): rebar deps compile deps_dev configure.out rel/vars.config
+$(DEVNODES): rebar deps compile deps_dev configure.out rel/vars.config remove_config_backups
 	@echo "building $@"
 	(. ./configure.out && \
 	 cd rel && \
@@ -166,5 +166,11 @@ test_deps:
 
 install: configure.out rel
 	@. ./configure.out && tools/install
+
+check_cfg_backup:
+	./tools/check_cfg_backup.sh
+
+remove_config_backups:
+	-@rm -rf dev/*/etc/ejabberd.cfg.bak > /dev/null 2>&1
 
 include tools/cd_tools/cd-targets

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,15 @@ qct:
 test: test_deps
 	cd test/ejabberd_tests; make test
 
+# $ make qtest SUITE=mam_SUITE
+qtest:
+	cp test/ejabberd_tests/qtest.spec.template test/ejabberd_tests/qtest.spec
+	echo "{suites, \"tests\", $(SUITE)}." >> test/ejabberd_tests/qtest.spec
+	cd test/ejabberd_tests;
+	@(if [ "$(SUITE)" ]; \
+		then make quicktest TESTSPEC=qtest.spec; \
+		else make quicktest; fi)
+
 test_preset: test_deps
 	cd test/ejabberd_tests; make test_preset
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ test: test_node_stopped test_deps
 	cd test/ejabberd_tests; make test
 
 # $ make qtest SUITE=mam_SUITE
+# $ make qtest SUITE="[mam_SUITE,metrics_api_SUITE]"
 qtest: test_node_stopped
 	cp test/ejabberd_tests/qtest.spec.template test/ejabberd_tests/qtest.spec
 	echo "{suites, \"tests\", $(SUITE)}." >> test/ejabberd_tests/qtest.spec

--- a/test/ejabberd_tests/qtest.spec.template
+++ b/test/ejabberd_tests/qtest.spec.template
@@ -1,0 +1,25 @@
+%% Spec examples:
+%%
+%%   {suites, "tests", amp_SUITE}.
+%%   {groups, "tests", amp_SUITE, [discovery]}.
+%%   {groups, "tests", amp_SUITE, [discovery], {cases, [stream_feature_test]}}.
+%%   {cases, "tests", amp_SUITE, [stream_feature_test]}.
+%%
+%% For more info see:
+%% http://www.erlang.org/doc/apps/common_test/run_test_chapter.html#test_specifications
+
+%% do not remove below SUITE if testing mongoose
+{suites, "tests", mongoose_sanity_checks_SUITE}.
+
+{config, ["test.config"]}.
+{logdir, "ct_report"}.
+
+%% ct_tty_hook will log CT failures to TTY verbosely
+%% ct_mongoose_hook will:
+%% * log suite start/end events in the MongooseIM console
+%% * ensure preset value is passed to ct Config
+%% * check server's purity after SUITE
+{ct_hooks, [ct_tty_hook, ct_mongoose_hook, ct_progress_hook]}.
+
+%% To enable printing group and case enters on server side
+%%{ct_hooks, [{ct_mongoose_hook, [print_group, print_case]}]}.

--- a/tools/check_cfg_backup.sh
+++ b/tools/check_cfg_backup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if ls dev/mongooseim_*/etc/ejabberd.cfg.bak 1> /dev/null 2>&1; then
+    echo "Unrestored config exists. Your actions:"
+    echo "1. Stop nodes"
+    echo "2. Run \"make devrel\" again to restore original configs"
+    echo "3. Start nodes"
+    echo "4. Run the test again"
+    exit 1
+fi


### PR DESCRIPTION
This feature adds:
- Adds "make qtest SUITE=mam_SUITE" that prepares CT config for you and runs specified feature tests only. 
- Ensures that Common Test node is down when start a new test (allows to restart tests fast on dev machine), see test_node_stopped;
- Ensures that there is no config backups. Config backups are created when we reload configuration. If the backup is still here when we run another test, than we can be sure that something is wrong with configuration and our tests will fail (so, just restart mongoose nodes by hand). Useless on CI, helps a lot on dev environment against many types of errors related with configuration.
