### PR TITLE
Fix types on #rsm_out structure

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -350,9 +350,9 @@
                      }).
 
 -record(rsm_out, {count :: non_neg_integer(),
-                  index :: non_neg_integer(),
-                  first :: binary(),
-                  last :: binary()
+                  index :: non_neg_integer() | undefined,
+                  first :: binary() | undefined,
+                  last  :: binary() | undefined
                  }).
 
 -type iq() :: #iq{}.


### PR DESCRIPTION
The 'index', 'first' and 'last' fields of rsm_out are permitted to have
'undefined' as a value, per jlib:rsm_encode_[first|last].