### PR TITLE
mod_vcard: implement search Result Set Management support

### DIFF
--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -42,6 +42,7 @@
          iq_query_or_response_info/1,
          iq_to_xml/1,
          parse_xdata_submit/1,
+         parse_xdata_fields/1,
          timestamp_to_xml/4,
          timestamp_to_mam_xml/4,
          timestamp_to_iso/2,
@@ -361,11 +362,16 @@ parse_xdata_submit(El) ->
     #xmlel{attrs = Attrs, children = Els} = El,
     case xml:get_attr_s(<<"type">>, Attrs) of
         <<"submit">> ->
-            lists:reverse(parse_xdata_fields(Els, []));
+            parse_xdata_fields(Els);
         _ ->
             invalid
     end.
 
+
+-spec parse_xdata_fields([xmlcdata() | xmlel()]) ->
+    [{binary(), [binary()]}].
+parse_xdata_fields(Els) ->
+    lists:reverse(parse_xdata_fields(Els, [])).
 
 -spec parse_xdata_fields([xmlcdata() | xmlel()], [{binary(), [binary()]}]) ->
     [{binary(), [binary()]}].

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -133,7 +133,7 @@ default_search_fields() ->
      {<<"Organization Name">>, <<"orgname">>},
      {<<"Organization Unit">>, <<"orgunit">>}].
 
--spec get_results_limit(ejabberd:lserver()) -> non_neg_integer() | inifinity.
+-spec get_results_limit(ejabberd:lserver()) -> non_neg_integer() | infinity.
 get_results_limit(LServer) ->
     case gen_mod:get_module_opt(LServer, mod_vcard, matches, ?JUD_MATCHES) of
         infinity ->
@@ -385,6 +385,7 @@ do_route(VHost, From, To, Packet, #iq{type = set,
                                       sub_el = SubEl} = IQ) ->
 
     XDataEl = find_xdata_el(SubEl),
+    RSMIn = jlib:rsm_decode(IQ),
     case XDataEl of
         false ->
             Err = jlib:make_error_reply(Packet, ?ERR_BAD_REQUEST),
@@ -396,7 +397,7 @@ do_route(VHost, From, To, Packet, #iq{type = set,
                     Err = jlib:make_error_reply(Packet, ?ERR_BAD_REQUEST),
                     ejabberd_router:route(To, From, Err);
                 _ ->
-                    SearchResult = search_result(Lang, To, VHost, XData),
+                    {SearchResult, RSMOutEls} = search_result(Lang, To, VHost, XData, RSMIn),
                     ResIQ = IQ#iq{
                               type = result,
                               sub_el = [#xmlel{name = <<"query">>,
@@ -404,7 +405,9 @@ do_route(VHost, From, To, Packet, #iq{type = set,
                                                children = [#xmlel{name = <<"x">>,
                                                                attrs = [{<<"xmlns">>, ?NS_XDATA},
                                                                         {<<"type">>, <<"result">>}],
-                                                               children = SearchResult}]}]},
+                                                               children = SearchResult}
+                                                          ] ++ RSMOutEls}
+                                       ]},
                     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ))
             end
     end;
@@ -489,13 +492,129 @@ find_xdata_el1([XE = #xmlel{attrs = Attrs} | Els]) ->
 find_xdata_el1([_ | Els]) ->
     find_xdata_el1(Els).
 
-search_result(Lang, JID, VHost, Data) ->
+search_result(Lang, JID, VHost, Data, RSMIn) ->
     Text = translate:translate(Lang, <<"Search Results for ">>),
     TitleEl = #xmlel{name = <<"title">>,
                      children = [#xmlcdata{content = [Text, jid:to_binary(JID)]}]},
     ReportedFields = mod_vcard_backend:search_reported_fields(VHost, Lang),
-    [TitleEl, ReportedFields
-     | mod_vcard_backend:search(VHost, Data)].
+    Results1 = mod_vcard_backend:search(VHost, Data),
+    Results2 = lists:filtermap(
+                 fun(Result) ->
+                         case search_result_get_jid(Result) of
+                             {ok, ResultJID} ->
+                                 {true, {ResultJID, Result}};
+                             undefined ->
+                                 false
+                         end
+                 end,
+                 Results1),
+    %% mnesia does not guarantee sorting order
+    Results3 = lists:sort(Results2),
+    {Results4, RSMOutEls} =
+        apply_rsm_to_search_results(Results3, RSMIn, none),
+    Results5 = [Result
+                || {_, Result} <- Results4],
+
+    {[TitleEl, ReportedFields
+      | Results5],
+     RSMOutEls}.
+
+%% No RSM input, create empty
+apply_rsm_to_search_results(Results, none, RSMOut) ->
+    apply_rsm_to_search_results(Results, #rsm_in{}, RSMOut);
+
+%% Create RSM output
+apply_rsm_to_search_results(Results, #rsm_in{} = RSMIn, none) ->
+    RSMOut = #rsm_out{count = length(Results)},
+    apply_rsm_to_search_results(Results, RSMIn, RSMOut);
+
+%% Skip by <after>$id</after>
+apply_rsm_to_search_results(Results1, #rsm_in{direction = aft,
+                                              id = After} = RSMIn, RSMOut)
+  when is_binary(After) ->
+    Results2 = lists:dropwhile(
+                 fun({JID, _Result}) ->
+                         JID == After
+                 end,
+                 lists:dropwhile(
+                   fun({JID, _Result}) ->
+                           JID =/= After
+                   end,
+                   Results1
+                  )),
+    Index = length(Results1) - length(Results2),
+    apply_rsm_to_search_results(
+      Results2,
+      RSMIn#rsm_in{direction = undefined, id = undefined},
+      RSMOut#rsm_out{index = Index}
+     );
+
+%% Seek by <before>$id</before>
+apply_rsm_to_search_results(Results1, #rsm_in{max = Max,
+                                              direction = before,
+                                              id = Before} = RSMIn, RSMOut)
+  when is_binary(Before) ->
+    Results2 = lists:takewhile(
+                 fun({JID, _Result}) ->
+                         JID =/= Before
+                 end, Results1),
+    if
+        is_integer(Max) ->
+            Index = max(0, length(Results2) - Max),
+            Results3 = lists:nthtail(Index, Results2);
+        true ->
+            Index = 0,
+            Results3 = Results2
+    end,
+    apply_rsm_to_search_results(
+      Results3,
+      RSMIn#rsm_in{direction = undefined, id = undefined},
+      RSMOut#rsm_out{index = Index}
+     );
+
+%% Skip by page number <index>371</index>
+apply_rsm_to_search_results(Results1,
+                            #rsm_in{max = Max,
+                                    index = Index} = RSMIn1,
+                            RSMOut)
+  when is_integer(Max), is_integer(Index) ->
+    Results2 = lists:nthtail(min(Index, length(Results1)), Results1),
+    RSMIn2 = RSMIn1#rsm_in{index = undefined},
+    apply_rsm_to_search_results(
+      Results2,
+      RSMIn2,
+      RSMOut#rsm_out{index = Index}
+     );
+
+%% Limit to <max>10</max> items
+apply_rsm_to_search_results(Results1, #rsm_in{max = Max} = RSMIn, RSMOut)
+  when is_integer(Max)  ->
+    Results2 = lists:sublist(Results1, Max),
+    apply_rsm_to_search_results(Results2,
+                                RSMIn#rsm_in{max = undefined}, RSMOut);
+
+%% Encode RSM output
+apply_rsm_to_search_results([_ | _] = Results, _, #rsm_out{} = RSMOut1) ->
+    {FirstJID, _} = hd(Results),
+    {LastJID, _} = lists:last(Results),
+    RSMOut2 = RSMOut1#rsm_out{first = FirstJID,
+                              last = LastJID},
+    {Results, jlib:rsm_encode(RSMOut2)};
+
+apply_rsm_to_search_results([], _, #rsm_out{} = RSMOut1) ->
+    %% clear `index' without `after'
+    RSMOut2 = RSMOut1#rsm_out{index = undefined},
+    {[], jlib:rsm_encode(RSMOut2)}.
+
+search_result_get_jid(#xmlel{name = <<"item">>,
+                             children = Children}) ->
+    Fields = jlib:parse_xdata_fields(Children),
+    case lists:keysearch(<<"jid">>, 1, Fields) of
+        {value, {<<"jid">>, JID}} ->
+            {ok, list_to_binary(JID)};
+        false ->
+            undefined
+    end.
 
 b2l(Binary) ->
     binary_to_list(Binary).

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -424,7 +424,7 @@ search_rsm_pages(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Client) ->
-                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                Domain = ct:get_config({hosts, mim, secondary_domain}),
                 DirJID = <<"vjud.", Domain/binary>>,
                 Fields = [{get_full_name_search_field(),
                            <<"Doe*">>}],
@@ -490,7 +490,7 @@ search_rsm_forward(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Client) ->
-                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                Domain = ct:get_config({hosts, mim, secondary_domain}),
                 DirJID = <<"vjud.", Domain/binary>>,
                 Fields = [{get_full_name_search_field(),
                            <<"Doe*">>}],
@@ -581,7 +581,7 @@ search_rsm_backward(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Client) ->
-                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                Domain = ct:get_config({hosts, mim, secondary_domain}),
                 DirJID = <<"vjud.", Domain/binary>>,
                 Fields = [{get_full_name_search_field(),
                            <<"Doe*">>}],
@@ -673,7 +673,7 @@ search_rsm_count(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Client) ->
-                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                Domain = ct:get_config({hosts, mim, secondary_domain}),
                 DirJID = <<"vjud.", Domain/binary>>,
                 Fields = [{get_full_name_search_field(),
                            <<"Doe*">>}],
@@ -705,22 +705,22 @@ search_rsm_count(Config) ->
         end).
 
 get_rsm_count(El) ->
-    exml_query:path(Res1, [{element, <<"query">>},
-                           {element, <<"set">>},
-                           {element, <<"count">>},
-                           cdata]).
+    exml_query:path(El, [{element, <<"query">>},
+                         {element, <<"set">>},
+                         {element, <<"count">>},
+                         cdata]).
 
 get_rsm_first(El) ->
-    exml_query:path(Res1, [{element, <<"query">>},
-                           {element, <<"set">>},
-                           {element, <<"first">>},
-                           cdata]).
+    exml_query:path(El, [{element, <<"query">>},
+                         {element, <<"set">>},
+                         {element, <<"first">>},
+                         cdata]).
 
 get_rsm_last(El) ->
-    exml_query:path(Res1, [{element, <<"query">>},
-                           {element, <<"set">>},
-                           {element, <<"last">>},
-                           cdata]).
+    exml_query:path(El, [{element, <<"query">>},
+                         {element, <<"set">>},
+                         {element, <<"last">>},
+                         cdata]).
 
 append_to_query(#xmlel{name = <<"iq">>,
                        children = IqChildren} = Iq,

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -671,8 +671,8 @@ search_rsm_count(Config) ->
         fun(Client) ->
                 Domain = escalus_ct:get_config(ejabberd_secondary_domain),
                 DirJID = <<"vjud.", Domain/binary>>,
-                Fields = [{get_nickname_field(),
-                           <<"*">>}],
+                Fields = [{get_full_name_search_field(),
+                           <<"Doe*">>}],
                 Iq1 = escalus_stanza:search_iq(
                         DirJID,
                         escalus_stanza:search_fields(Fields)

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -436,11 +436,12 @@ search_rsm_pages(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          }
+                                   ]}
                        ),
 
                 Res1 = escalus:send_and_wait(Client, Iq2),
@@ -454,15 +455,16 @@ search_rsm_pages(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 },
-                                           #xmlel{name = "index",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          },
+                                    #xmlel{name = "index",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          }
+                                   ]}
                        ),
 
                 Res2 = escalus:send_and_wait(Client, Iq3),
@@ -500,11 +502,12 @@ search_rsm_forward(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          }
+                                   ]}
                        ),
 
                 Res1 = escalus:send_and_wait(Client, Iq2),
@@ -519,15 +522,16 @@ search_rsm_forward(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 },
-                                           #xmlel{name = "after",
-                                                  children =
-                                                      [#xmlcdata{content = RSMLast1}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          },
+                                    #xmlel{name = "after",
+                                           children =
+                                               [#xmlcdata{content = RSMLast1}]
+                                          }
+                                   ]}
                        ),
 
                 Res2 = escalus:send_and_wait(Client, Iq3),
@@ -553,15 +557,16 @@ search_rsm_forward(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 },
-                                           #xmlel{name = "after",
-                                                  children =
-                                                      [#xmlcdata{content = RSMLast2}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          },
+                                    #xmlel{name = "after",
+                                           children =
+                                               [#xmlcdata{content = RSMLast2}]
+                                          }
+                                   ]}
                        ),
 
                 Res3 = escalus:send_and_wait(Client, Iq4),
@@ -588,12 +593,13 @@ search_rsm_backward(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 },
-                                           #xmlel{name = "before"}
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          },
+                                    #xmlel{name = "before"}
+                                   ]}
                        ),
 
                 Res1 = escalus:send_and_wait(Client, Iq2),
@@ -608,15 +614,16 @@ search_rsm_backward(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 },
-                                           #xmlel{name = "before",
-                                                  children =
-                                                      [#xmlcdata{content = RSMFirst1}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          },
+                                    #xmlel{name = "before",
+                                           children =
+                                               [#xmlcdata{content = RSMFirst1}]
+                                          }
+                                   ]}
                        ),
 
                 Res2 = escalus:send_and_wait(Client, Iq3),
@@ -642,15 +649,16 @@ search_rsm_backward(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"1">>}]
-                                                 },
-                                           #xmlel{name = "before",
-                                                  children =
-                                                      [#xmlcdata{content = RSMFirst2}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"1">>}]
+                                          },
+                                    #xmlel{name = "before",
+                                           children =
+                                               [#xmlcdata{content = RSMFirst2}]
+                                          }
+                                   ]}
                        ),
 
                 Res3 = escalus:send_and_wait(Client, Iq4),
@@ -677,11 +685,12 @@ search_rsm_count(Config) ->
                         Iq1,
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
-                               children = [#xmlel{name = "max",
-                                                  children =
-                                                      [#xmlcdata{content = <<"0">>}]
-                                                 }
-                                          ]}
+                               children =
+                                   [#xmlel{name = "max",
+                                           children =
+                                               [#xmlcdata{content = <<"0">>}]
+                                          }
+                                   ]}
                        ),
 
                 Res = escalus:send_and_wait(Client, Iq2),

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -437,17 +437,16 @@ search_rsm_pages(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]}
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 }
                                           ]}
                        ),
 
                 Res1 = escalus:send_and_wait(Client, Iq2),
                 escalus:assert(is_iq_result, Res1),
 
-                RSMCount1 = exml_query:path(Res1, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount1 = get_rsm_count(Res1),
                 <<"2">> = RSMCount1,
                 ItemTups1 = search_result_item_tuples(Res1),
 
@@ -456,29 +455,32 @@ search_rsm_pages(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 },
                                            #xmlel{name = "index",
-                                                  children = [#xmlcdata{content = <<"1">>}]}
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 }
                                           ]}
                        ),
 
                 Res2 = escalus:send_and_wait(Client, Iq3),
                 escalus:assert(is_iq_result, Res2),
 
-                RSMCount2 = exml_query:path(Res2, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount2 = get_rsm_count(Res2),
                 <<"2">> = RSMCount2,
                 ItemTups2 = search_result_item_tuples(Res2),
-                ExpectedItemTups = get_search_results(Config,
-                                                      [<<"bobb@localhost.bis">>,
-                                                       <<"aliceb@localhost.bis">>]),
+                ExpectedItemTups = get_search_results(
+                                     Config,
+                                     [<<"bobb@localhost.bis">>,
+                                      <<"aliceb@localhost.bis">>]),
                 case vcard_simple_SUITE:is_vcard_ldap() of
                     true ->
                         ignore;
                     _ ->
-                        list_unordered_key_match2(ExpectedItemTups, ItemTups1 ++ ItemTups2)
+                        list_unordered_key_match2(ExpectedItemTups,
+                                                  ItemTups1 ++ ItemTups2)
                 end
         end).
 
@@ -499,22 +501,18 @@ search_rsm_forward(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]}
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 }
                                           ]}
                        ),
 
                 Res1 = escalus:send_and_wait(Client, Iq2),
                 escalus:assert(is_iq_result, Res1),
 
-                RSMCount1 = exml_query:path(Res1, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount1 = get_rsm_count(Res1),
                 <<"2">> = RSMCount1,
-                RSMLast1 = exml_query:path(Res1, [{element, <<"query">>},
-                                                  {element, <<"set">>},
-                                                  {element, <<"last">>},
-                                                  cdata]),
+                RSMLast1 = get_rsm_last(Res1),
                 ItemTups1 = search_result_item_tuples(Res1),
 
                 Iq3 = append_to_query(
@@ -522,33 +520,33 @@ search_rsm_forward(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 },
                                            #xmlel{name = "after",
-                                                  children = [#xmlcdata{content = RSMLast1}]}
+                                                  children =
+                                                      [#xmlcdata{content = RSMLast1}]
+                                                 }
                                           ]}
                        ),
 
                 Res2 = escalus:send_and_wait(Client, Iq3),
                 escalus:assert(is_iq_result, Res2),
 
-                RSMCount2 = exml_query:path(Res2, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount2 = get_rsm_count(Res2),
                 <<"2">> = RSMCount2,
-                RSMLast2 = exml_query:path(Res2, [{element, <<"query">>},
-                                                  {element, <<"set">>},
-                                                  {element, <<"last">>},
-                                                  cdata]),
+                RSMLast2 = get_rsm_last(Res2),
                 ItemTups2 = search_result_item_tuples(Res2),
-                ExpectedItemTups = get_search_results(Config,
-                                                      [<<"bobb@localhost.bis">>,
-                                                       <<"aliceb@localhost.bis">>]),
+                ExpectedItemTups = get_search_results(
+                                     Config,
+                                     [<<"bobb@localhost.bis">>,
+                                      <<"aliceb@localhost.bis">>]),
                 case vcard_simple_SUITE:is_vcard_ldap() of
                     true ->
                         ignore;
                     _ ->
-                        list_unordered_key_match2(ExpectedItemTups, ItemTups1 ++ ItemTups2)
+                        list_unordered_key_match2(ExpectedItemTups,
+                                                  ItemTups1 ++ ItemTups2)
                 end,
 
                 Iq4 = append_to_query(
@@ -556,19 +554,20 @@ search_rsm_forward(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 },
                                            #xmlel{name = "after",
-                                                  children = [#xmlcdata{content = RSMLast2}]}
+                                                  children =
+                                                      [#xmlcdata{content = RSMLast2}]
+                                                 }
                                           ]}
                        ),
 
                 Res3 = escalus:send_and_wait(Client, Iq4),
                 escalus:assert(is_iq_result, Res3),
 
-                RSMCount2 = exml_query:path(Res3, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount2 = get_rsm_count(Res3),
                 <<"2">> = RSMCount2,
                 [] = search_result_item_tuples(Res3)
         end).
@@ -590,7 +589,9 @@ search_rsm_backward(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 },
                                            #xmlel{name = "before"}
                                           ]}
                        ),
@@ -598,15 +599,9 @@ search_rsm_backward(Config) ->
                 Res1 = escalus:send_and_wait(Client, Iq2),
                 escalus:assert(is_iq_result, Res1),
 
-                RSMCount1 = exml_query:path(Res1, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount1 = get_rsm_count(Res1),
                 <<"2">> = RSMCount1,
-                RSMFirst1 = exml_query:path(Res1, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"first">>},
-                                                   cdata]),
+                RSMFirst1 = get_rsm_first(Res1),
                 ItemTups1 = search_result_item_tuples(Res1),
 
                 Iq3 = append_to_query(
@@ -614,33 +609,33 @@ search_rsm_backward(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 },
                                            #xmlel{name = "before",
-                                                  children = [#xmlcdata{content = RSMFirst1}]}
+                                                  children =
+                                                      [#xmlcdata{content = RSMFirst1}]
+                                                 }
                                           ]}
                        ),
 
                 Res2 = escalus:send_and_wait(Client, Iq3),
                 escalus:assert(is_iq_result, Res2),
 
-                RSMCount2 = exml_query:path(Res2, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount2 = get_rsm_count(Res2),
                 <<"2">> = RSMCount2,
-                RSMFirst2 = exml_query:path(Res2, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"first">>},
-                                                   cdata]),
+                RSMFirst2 = get_rsm_first(Res2),
                 ItemTups2 = search_result_item_tuples(Res2),
-                ExpectedItemTups = get_search_results(Config,
-                                                      [<<"bobb@localhost.bis">>,
-                                                       <<"aliceb@localhost.bis">>]),
+                ExpectedItemTups = get_search_results(
+                                     Config,
+                                     [<<"bobb@localhost.bis">>,
+                                      <<"aliceb@localhost.bis">>]),
                 case vcard_simple_SUITE:is_vcard_ldap() of
                     true ->
                         ignore;
                     _ ->
-                        list_unordered_key_match2(ExpectedItemTups, ItemTups1 ++ ItemTups2)
+                        list_unordered_key_match2(ExpectedItemTups,
+                                                  ItemTups1 ++ ItemTups2)
                 end,
 
                 Iq4 = append_to_query(
@@ -648,19 +643,20 @@ search_rsm_backward(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                                  children =
+                                                      [#xmlcdata{content = <<"1">>}]
+                                                 },
                                            #xmlel{name = "before",
-                                                  children = [#xmlcdata{content = RSMFirst2}]}
+                                                  children =
+                                                      [#xmlcdata{content = RSMFirst2}]
+                                                 }
                                           ]}
                        ),
 
                 Res3 = escalus:send_and_wait(Client, Iq4),
                 escalus:assert(is_iq_result, Res3),
 
-                RSMCount2 = exml_query:path(Res3, [{element, <<"query">>},
-                                                   {element, <<"set">>},
-                                                   {element, <<"count">>},
-                                                   cdata]),
+                RSMCount2 = get_rsm_count(Res3),
                 <<"2">> = RSMCount2,
                 [] = search_result_item_tuples(Res3)
         end).
@@ -682,7 +678,9 @@ search_rsm_count(Config) ->
                         #xmlel{name = <<"set">>,
                                attrs = [{<<"xmlns">>, ?NS_RSM}],
                                children = [#xmlel{name = "max",
-                                                  children = [#xmlcdata{content = <<"0">>}]}
+                                                  children =
+                                                      [#xmlcdata{content = <<"0">>}]
+                                                 }
                                           ]}
                        ),
 
@@ -692,13 +690,28 @@ search_rsm_count(Config) ->
                 ItemTups = search_result_item_tuples(Res),
                 0 = length(ItemTups),
 
-                RSMCount = exml_query:path(Res, [{element, <<"query">>},
-                                                 {element, <<"set">>},
-                                                 {element, <<"count">>},
-                                                 cdata]),
+                RSMCount = get_rsm_count(Res),
                 <<"2">> = RSMCount
 
         end).
+
+get_rsm_count(El) ->
+    exml_query:path(Res1, [{element, <<"query">>},
+                           {element, <<"set">>},
+                           {element, <<"count">>},
+                           cdata]).
+
+get_rsm_first(El) ->
+    exml_query:path(Res1, [{element, <<"query">>},
+                           {element, <<"set">>},
+                           {element, <<"first">>},
+                           cdata]).
+
+get_rsm_last(El) ->
+    exml_query:path(Res1, [{element, <<"query">>},
+                           {element, <<"set">>},
+                           {element, <<"last">>},
+                           cdata]).
 
 append_to_query(#xmlel{name = <<"iq">>,
                        children = IqChildren} = Iq,

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -448,7 +448,12 @@ search_rsm_pages(Config) ->
                 escalus:assert(is_iq_result, Res1),
 
                 RSMCount1 = get_rsm_count(Res1),
-                <<"2">> = RSMCount1,
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount1;
+                    false ->
+                        <<"2">> = RSMCount1
+                end,
                 ItemTups1 = search_result_item_tuples(Res1),
 
                 Iq3 = append_to_query(
@@ -471,7 +476,12 @@ search_rsm_pages(Config) ->
                 escalus:assert(is_iq_result, Res2),
 
                 RSMCount2 = get_rsm_count(Res2),
-                <<"2">> = RSMCount2,
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount2;
+                    false ->
+                        <<"2">> = RSMCount2
+                end,
                 ItemTups2 = search_result_item_tuples(Res2),
                 ExpectedItemTups = get_search_results(
                                      Config,
@@ -514,7 +524,12 @@ search_rsm_forward(Config) ->
                 escalus:assert(is_iq_result, Res1),
 
                 RSMCount1 = get_rsm_count(Res1),
-                <<"2">> = RSMCount1,
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount1;
+                    false ->
+                        <<"2">> = RSMCount1
+                end,
                 RSMLast1 = get_rsm_last(Res1),
                 ItemTups1 = search_result_item_tuples(Res1),
 
@@ -538,7 +553,12 @@ search_rsm_forward(Config) ->
                 escalus:assert(is_iq_result, Res2),
 
                 RSMCount2 = get_rsm_count(Res2),
-                <<"2">> = RSMCount2,
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount2;
+                    false ->
+                        <<"2">> = RSMCount2
+                end,
                 RSMLast2 = get_rsm_last(Res2),
                 ItemTups2 = search_result_item_tuples(Res2),
                 ExpectedItemTups = get_search_results(
@@ -573,8 +593,14 @@ search_rsm_forward(Config) ->
                 escalus:assert(is_iq_result, Res3),
 
                 RSMCount2 = get_rsm_count(Res3),
-                <<"2">> = RSMCount2,
-                [] = search_result_item_tuples(Res3)
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount2,
+                        [_] = search_result_item_tuples(Res3);
+                    false ->
+                        <<"2">> = RSMCount2,
+                        [] = search_result_item_tuples(Res3)
+                end
         end).
 
 search_rsm_backward(Config) ->
@@ -606,7 +632,12 @@ search_rsm_backward(Config) ->
                 escalus:assert(is_iq_result, Res1),
 
                 RSMCount1 = get_rsm_count(Res1),
-                <<"2">> = RSMCount1,
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount1;
+                    false ->
+                        <<"2">> = RSMCount1
+                end,
                 RSMFirst1 = get_rsm_first(Res1),
                 ItemTups1 = search_result_item_tuples(Res1),
 
@@ -630,7 +661,12 @@ search_rsm_backward(Config) ->
                 escalus:assert(is_iq_result, Res2),
 
                 RSMCount2 = get_rsm_count(Res2),
-                <<"2">> = RSMCount2,
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount2;
+                    false ->
+                        <<"2">> = RSMCount2
+                end,
                 RSMFirst2 = get_rsm_first(Res2),
                 ItemTups2 = search_result_item_tuples(Res2),
                 ExpectedItemTups = get_search_results(
@@ -665,8 +701,14 @@ search_rsm_backward(Config) ->
                 escalus:assert(is_iq_result, Res3),
 
                 RSMCount2 = get_rsm_count(Res3),
-                <<"2">> = RSMCount2,
-                [] = search_result_item_tuples(Res3)
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount2,
+                        [_] = search_result_item_tuples(Res3);
+                    false ->
+                        <<"2">> = RSMCount2,
+                        [] = search_result_item_tuples(Res3)
+                end
         end).
 
 search_rsm_count(Config) ->
@@ -700,8 +742,12 @@ search_rsm_count(Config) ->
                 0 = length(ItemTups),
 
                 RSMCount = get_rsm_count(Res),
-                <<"2">> = RSMCount
-
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        <<"3">> = RSMCount;
+                    false ->
+                        <<"2">> = RSMCount
+                end
         end).
 
 get_rsm_count(El) ->

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -28,10 +28,8 @@
 -module(vcard_SUITE).
 -compile(export_all).
 
--include_lib("escalus/include/escalus_xmlns.hrl").
--include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
--include_lib("exml/include/exml.hrl").
+-include_lib("../../../apps/ejabberd/include/jlib.hrl").
 
 %% Element CData
 -define(EL(Element, Name), exml_query:path(Element, [{element, Name}])).
@@ -81,7 +79,11 @@ ro_full_search_tests() ->
      search_empty,
      search_some,
      search_some_many_fields,
-     search_wildcard
+     search_wildcard,
+     search_rsm_count,
+     search_rsm_forward,
+     search_rsm_backward,
+     search_rsm_pages
     ].
 
 ro_limited_search_tests() ->
@@ -417,6 +419,301 @@ search_wildcard(Config) ->
                         list_unordered_key_match2(ExpectedItemTups, ItemTups)
                 end
         end).
+
+search_rsm_pages(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Client) ->
+                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                DirJID = <<"vjud.", Domain/binary>>,
+                Fields = [{get_full_name_search_field(),
+                           <<"Doe*">>}],
+                Iq1 = escalus_stanza:search_iq(
+                        DirJID,
+                        escalus_stanza:search_fields(Fields)
+                       ),
+                Iq2 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]}
+                                          ]}
+                       ),
+
+                Res1 = escalus:send_and_wait(Client, Iq2),
+                escalus:assert(is_iq_result, Res1),
+
+                RSMCount1 = exml_query:path(Res1, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount1,
+                ItemTups1 = search_result_item_tuples(Res1),
+
+                Iq3 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                           #xmlel{name = "index",
+                                                  children = [#xmlcdata{content = <<"1">>}]}
+                                          ]}
+                       ),
+
+                Res2 = escalus:send_and_wait(Client, Iq3),
+                escalus:assert(is_iq_result, Res2),
+
+                RSMCount2 = exml_query:path(Res2, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount2,
+                ItemTups2 = search_result_item_tuples(Res2),
+                ExpectedItemTups = get_search_results(Config,
+                                                      [<<"bobb@localhost.bis">>,
+                                                       <<"aliceb@localhost.bis">>]),
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        ignore;
+                    _ ->
+                        list_unordered_key_match2(ExpectedItemTups, ItemTups1 ++ ItemTups2)
+                end
+        end).
+
+search_rsm_forward(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Client) ->
+                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                DirJID = <<"vjud.", Domain/binary>>,
+                Fields = [{get_full_name_search_field(),
+                           <<"Doe*">>}],
+                Iq1 = escalus_stanza:search_iq(
+                        DirJID,
+                        escalus_stanza:search_fields(Fields)
+                       ),
+                Iq2 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]}
+                                          ]}
+                       ),
+
+                Res1 = escalus:send_and_wait(Client, Iq2),
+                escalus:assert(is_iq_result, Res1),
+
+                RSMCount1 = exml_query:path(Res1, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount1,
+                RSMLast1 = exml_query:path(Res1, [{element, <<"query">>},
+                                                  {element, <<"set">>},
+                                                  {element, <<"last">>},
+                                                  cdata]),
+                ItemTups1 = search_result_item_tuples(Res1),
+
+                Iq3 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                           #xmlel{name = "after",
+                                                  children = [#xmlcdata{content = RSMLast1}]}
+                                          ]}
+                       ),
+
+                Res2 = escalus:send_and_wait(Client, Iq3),
+                escalus:assert(is_iq_result, Res2),
+
+                RSMCount2 = exml_query:path(Res2, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount2,
+                RSMLast2 = exml_query:path(Res2, [{element, <<"query">>},
+                                                  {element, <<"set">>},
+                                                  {element, <<"last">>},
+                                                  cdata]),
+                ItemTups2 = search_result_item_tuples(Res2),
+                ExpectedItemTups = get_search_results(Config,
+                                                      [<<"bobb@localhost.bis">>,
+                                                       <<"aliceb@localhost.bis">>]),
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        ignore;
+                    _ ->
+                        list_unordered_key_match2(ExpectedItemTups, ItemTups1 ++ ItemTups2)
+                end,
+
+                Iq4 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                           #xmlel{name = "after",
+                                                  children = [#xmlcdata{content = RSMLast2}]}
+                                          ]}
+                       ),
+
+                Res3 = escalus:send_and_wait(Client, Iq4),
+                escalus:assert(is_iq_result, Res3),
+
+                RSMCount2 = exml_query:path(Res3, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount2,
+                [] = search_result_item_tuples(Res3)
+        end).
+
+search_rsm_backward(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Client) ->
+                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                DirJID = <<"vjud.", Domain/binary>>,
+                Fields = [{get_full_name_search_field(),
+                           <<"Doe*">>}],
+                Iq1 = escalus_stanza:search_iq(
+                        DirJID,
+                        escalus_stanza:search_fields(Fields)
+                       ),
+                Iq2 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                           #xmlel{name = "before"}
+                                          ]}
+                       ),
+
+                Res1 = escalus:send_and_wait(Client, Iq2),
+                escalus:assert(is_iq_result, Res1),
+
+                RSMCount1 = exml_query:path(Res1, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount1,
+                RSMFirst1 = exml_query:path(Res1, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"first">>},
+                                                   cdata]),
+                ItemTups1 = search_result_item_tuples(Res1),
+
+                Iq3 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                           #xmlel{name = "before",
+                                                  children = [#xmlcdata{content = RSMFirst1}]}
+                                          ]}
+                       ),
+
+                Res2 = escalus:send_and_wait(Client, Iq3),
+                escalus:assert(is_iq_result, Res2),
+
+                RSMCount2 = exml_query:path(Res2, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount2,
+                RSMFirst2 = exml_query:path(Res2, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"first">>},
+                                                   cdata]),
+                ItemTups2 = search_result_item_tuples(Res2),
+                ExpectedItemTups = get_search_results(Config,
+                                                      [<<"bobb@localhost.bis">>,
+                                                       <<"aliceb@localhost.bis">>]),
+                case vcard_simple_SUITE:is_vcard_ldap() of
+                    true ->
+                        ignore;
+                    _ ->
+                        list_unordered_key_match2(ExpectedItemTups, ItemTups1 ++ ItemTups2)
+                end,
+
+                Iq4 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"1">>}]},
+                                           #xmlel{name = "before",
+                                                  children = [#xmlcdata{content = RSMFirst2}]}
+                                          ]}
+                       ),
+
+                Res3 = escalus:send_and_wait(Client, Iq4),
+                escalus:assert(is_iq_result, Res3),
+
+                RSMCount2 = exml_query:path(Res3, [{element, <<"query">>},
+                                                   {element, <<"set">>},
+                                                   {element, <<"count">>},
+                                                   cdata]),
+                <<"2">> = RSMCount2,
+                [] = search_result_item_tuples(Res3)
+        end).
+
+search_rsm_count(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Client) ->
+                Domain = escalus_ct:get_config(ejabberd_secondary_domain),
+                DirJID = <<"vjud.", Domain/binary>>,
+                Fields = [{get_nickname_field(),
+                           <<"*">>}],
+                Iq1 = escalus_stanza:search_iq(
+                        DirJID,
+                        escalus_stanza:search_fields(Fields)
+                       ),
+                Iq2 = append_to_query(
+                        Iq1,
+                        #xmlel{name = <<"set">>,
+                               attrs = [{<<"xmlns">>, ?NS_RSM}],
+                               children = [#xmlel{name = "max",
+                                                  children = [#xmlcdata{content = <<"0">>}]}
+                                          ]}
+                       ),
+
+                Res = escalus:send_and_wait(Client, Iq2),
+                escalus:assert(is_iq_result, Res),
+
+                ItemTups = search_result_item_tuples(Res),
+                0 = length(ItemTups),
+
+                RSMCount = exml_query:path(Res, [{element, <<"query">>},
+                                                 {element, <<"set">>},
+                                                 {element, <<"count">>},
+                                                 cdata]),
+                <<"2">> = RSMCount
+
+        end).
+
+append_to_query(#xmlel{name = <<"iq">>,
+                       children = IqChildren} = Iq,
+                NewChild) ->
+    Iq#xmlel{
+      children =
+          lists:map(
+            fun(#xmlel{
+                   name = <<"query">>,
+                   children = QueryChildren
+                  } = Query) ->
+                    Query#xmlel{children = QueryChildren ++ [NewChild]};
+               (El) ->
+                    El
+            end, IqChildren)}.
 
 search_some_many_fields(Config) ->
     escalus:story(
@@ -886,7 +1183,7 @@ list_unordered_key_match(Expected, Actual) ->
 
 list_unordered_key_match2([], _) ->
     ok;
-list_unordered_key_match2([{User, ExpectedTup} | Rest], ActualTuples) ->
+list_unordered_key_match2([{User, ExpectedTup} | _Rest], ActualTuples) ->
 
     case lists:keyfind(User, 1, ActualTuples) of
         {User, ReceivedTuple} ->


### PR DESCRIPTION
This augments the vCard user directory results with [XEP-0059](http://www.xmpp.org/extensions/xep-0059.html) support.

Of course, it would be more efficient to handle this in the backend modules. For a start, it provides support regardless of specific database backends.
