### PR TITLE
HTTP client API - improve room users API

### DIFF
--- a/apps/ejabberd/src/mod_muc_light_admin.erl
+++ b/apps/ejabberd/src/mod_muc_light_admin.erl
@@ -208,21 +208,20 @@ is_subdomain(Child, Parent) ->
         {_, _} -> true
     end.
 
-iq(S, R, T, C) when is_binary(S),
-                    is_binary(R), is_binary(T), is_list(C) ->
+iq(To, From, Type, Children) ->
     UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
     #xmlel{name = <<"iq">>,
-           attrs = [{<<"from">>, S},
-                    {<<"to">>, R},
-                    {<<"type">>, T},
+           attrs = [{<<"from">>, From},
+                    {<<"to">>, To},
+                    {<<"type">>, Type},
                     {<<"id">>, UUID}],
-           children = C
+           children = Children
           }.
 
-query(NS, C) when is_binary(NS), is_list(C) ->
+query(NS, Children) when is_binary(NS), is_list(Children) ->
     #xmlel{name = <<"query">>,
            attrs = [{<<"xmlns">>, NS}],
-           children = C
+           children = Children
           }.
 
 affiliate(JID, Kind) when is_binary(JID), is_binary(Kind) ->

--- a/apps/ejabberd/src/mod_muc_light_admin.erl
+++ b/apps/ejabberd/src/mod_muc_light_admin.erl
@@ -210,10 +210,12 @@ is_subdomain(Child, Parent) ->
 
 iq(S, R, T, C) when is_binary(S),
                     is_binary(R), is_binary(T), is_list(C) ->
+    UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
     #xmlel{name = <<"iq">>,
            attrs = [{<<"from">>, S},
                     {<<"to">>, R},
-                    {<<"type">>, T}],
+                    {<<"type">>, T},
+                    {<<"id">>, UUID}],
            children = C
           }.
 

--- a/apps/ejabberd/src/mod_muc_light_admin.erl
+++ b/apps/ejabberd/src/mod_muc_light_admin.erl
@@ -25,7 +25,7 @@
 -export([create_unique_room/4]).
 -export([send_message/4]).
 -export([invite_to_room/4]).
--export([invite_to_room_id/4]).
+-export([change_affiliation/5]).
 
 -include("mod_muc_light.hrl").
 -include("ejabberd.hrl").
@@ -127,14 +127,14 @@ invite_to_room(Domain, RoomName, Sender, Recipient0) ->
     ejabberd_router:route(S, R, iq(jid:to_binary(S), jid:to_binary(R),
                                    <<"set">>, [Changes])).
 
-invite_to_room_id(Domain, RoomID, Sender, Recipient0) ->
+change_affiliation(Domain, RoomID, Sender, Recipient0, Affiliation) ->
     Recipient1 = jid:binary_to_bare(Recipient0),
     MUCLightDomain = gen_mod:get_module_opt_host(Domain, mod_muc_light,
                                                  <<"muclight.@HOST@">>),
     R = jid:make(RoomID, MUCLightDomain, <<>>),
     S = jid:binary_to_bare(Sender),
     Changes = query(?NS_MUC_LIGHT_AFFILIATIONS,
-                    [affiliate(jid:to_binary(Recipient1), <<"member">>)]),
+                    [affiliate(jid:to_binary(Recipient1), Affiliation)]),
     ejabberd_router:route(S, R, iq(jid:to_binary(S), jid:to_binary(R),
                                    <<"set">>, [Changes])).
 

--- a/apps/ejabberd/src/mongoose_client_api_rooms.erl
+++ b/apps/ejabberd/src/mongoose_client_api_rooms.erl
@@ -37,7 +37,7 @@ content_types_accepted(Req, State) ->
      ], Req, State}.
 
 allowed_methods(Req, State) ->
-    {[<<"GET">>, <<"POST">>, <<"PUT">>], Req, State}.
+    {[<<"GET">>, <<"POST">>], Req, State}.
 
 resource_exists(Req, #{jid := #jid{lserver = Server}} = State) ->
     {RoomID, Req2} = cowboy_req:binding(id, Req),
@@ -100,15 +100,7 @@ handle_request(<<"POST">>, JSONData, Req,
             RespBody = #{<<"id">> => RoomJID#jid.luser},
             RespReq = cowboy_req:set_resp_body(jiffy:encode(RespBody), Req),
             {true, RespReq, State}
-    end;
-handle_request(<<"PUT">>, _, Req, #{role_in_room := none} = State) ->
-    forbidden_request(Req, State);
-handle_request(<<"PUT">>, JSONData, Req,
-               #{user := User, jid := #jid{lserver = Server}} = State) ->
-    #{<<"user">> := UserToInvite} = JSONData,
-    {RoomId, Req2} = cowboy_req:binding(id, Req),
-    mod_muc_light_admin:invite_to_room_id(Server, RoomId, User, UserToInvite),
-    {true, Req2, State}.
+    end.
 
 user_to_json({UserServer, Role}) ->
     #{user => jid:to_binary(UserServer),

--- a/apps/ejabberd/src/mongoose_client_api_rooms_users.erl
+++ b/apps/ejabberd/src/mongoose_client_api_rooms_users.erl
@@ -1,0 +1,51 @@
+-module(mongoose_client_api_rooms_users).
+
+-export([init/3]).
+-export([rest_init/2]).
+-export([content_types_provided/2]).
+-export([content_types_accepted/2]).
+-export([is_authorized/2]).
+-export([allowed_methods/2]).
+-export([resource_exists/2]).
+-export([allow_missing_post/2]).
+
+-export([from_json/2]).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+-include_lib("exml/include/exml.hrl").
+
+init(_Transport, _Req, _Opts) ->
+    {upgrade, protocol, cowboy_rest}.
+
+rest_init(Req, HandlerOpts) ->
+    mongoose_client_api:rest_init(Req, HandlerOpts).
+
+is_authorized(Req, State) ->
+    mongoose_client_api:is_authorized(Req, State).
+
+content_types_provided(Req, State) ->
+    mongoose_client_api_rooms:content_types_provided(Req, State).
+
+content_types_accepted(Req, State) ->
+    mongoose_client_api_rooms:content_types_accepted(Req, State).
+
+allowed_methods(Req, State) ->
+    {[<<"POST">>], Req, State}.
+
+resource_exists(Req, State) ->
+    mongoose_client_api_rooms:resource_exists(Req, State).
+
+allow_missing_post(Req, State) ->
+    {false, Req, State}.
+
+from_json(Req, #{role_in_room := none} = State) ->
+    mongoose_client_api_rooms:forbidden_request(Req, State);
+from_json(Req, #{user := User, jid := #jid{lserver = Server}} = State) ->
+    {ok, Body, Req2} = cowboy_req:body(Req),
+    JSONData = jiffy:decode(Body, [return_maps]),
+    #{<<"user">> := UserToInvite} = JSONData,
+    {RoomId, Req3} = cowboy_req:binding(id, Req2),
+    mod_muc_light_admin:invite_to_room_id(Server, RoomId, User, UserToInvite),
+    {true, Req3, State}.
+

--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -299,6 +299,10 @@ definitions:
       id:
         type: string
         description: The ID of a message.
+      timestamp:
+        type: integer
+        format: int64
+        description: Unix timestamp in miliseconds.
       body:
         type: string
         description: |
@@ -309,7 +313,7 @@ definitions:
         description: |
           JID of a user, whom affiliation changed.
           Present only if the type is "affiliation".
-      affiliations:
+      affiliation:
         type: string
         description: |
           The new affiliation of a user in the room.
@@ -319,5 +323,4 @@ definitions:
     description: |
       This is user's JID (Jabber ID) which consist of username and server.
       Example: alice@wonderland.com
-
 

--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -119,7 +119,7 @@ paths:
           description: |
             When authenticated user is not allowed to read room's deatails.
   /rooms/{id}/users:
-    put:
+    post:
       description: "Adds a user to a room."
       parameters:
         - in: path

--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -118,8 +118,9 @@ paths:
         403:
           description: |
             When authenticated user is not allowed to read room's deatails.
+  /rooms/{id}/users:
     put:
-      description: "Adds users to a room."
+      description: "Adds a user to a room."
       parameters:
         - in: path
           name: id

--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -142,7 +142,10 @@ paths:
             When authenticated user is not allowed to add users to the room.
   /rooms/{id}/users/{user}:
     delete:
-      description: Removes a user from the room.
+      description: |
+        Removes a user from the room.
+        Owner can remove any user.
+        Occupant can also use this method, but can only remove itself.
       parameters:
         - in: path
           name: id

--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -140,6 +140,29 @@ paths:
         403:
           description: |
             When authenticated user is not allowed to add users to the room.
+  /rooms/{id}/users/{user}:
+    delete:
+      description: Removes a user from the room.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          type: string
+          description: The ID of a room.
+        - in: path
+          name: user
+          required: true
+          type: string
+          description: |
+            The JID (ex: alice@wonderalnd.com) of user to remove
+      responses:
+        204:
+          description: User was successfully removed form the room.
+        404:
+          description: When there is no room with given id.
+        403:
+          description: |
+            When authenticated user is not allowed to add users to the room.
   /rooms/{id}/messages:
     post:
       description: Send a message to a room.
@@ -293,4 +316,5 @@ definitions:
     description: |
       This is user's JID (Jabber ID) which consist of username and server.
       Example: alice@wonderland.com
+
 

--- a/elvis.config
+++ b/elvis.config
@@ -1,0 +1,16 @@
+[
+ {
+  elvis,
+  [
+   {config,
+    [#{dirs => ["apps/*/src", "apps/*/test", "test/ejabberd_tests/tests"],
+       filter => "*.erl",
+       ruleset => erl_files,
+       rules => [{elvis_style, line_length, #{limit => 100,
+                                              skip_comments => false}}]
+      }
+    ]
+   }
+  ]
+ }
+].

--- a/elvis.config
+++ b/elvis.config
@@ -7,7 +7,9 @@
        filter => "*.erl",
        ruleset => erl_files,
        rules => [{elvis_style, line_length, #{limit => 100,
-                                              skip_comments => false}}]
+                                              skip_comments => false}},
+		 {elvis_style, dont_repeat_yourself, #{min_complexity => 15}}
+		]
       }
     ]
    }

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -214,6 +214,7 @@
       {modules, [
           {"_", "/api/messages/[:with]", mongoose_client_api_messages, []},
           {"_", "/api/rooms/[:id]",    mongoose_client_api_rooms, []},
+          {"_", "/api/rooms/:id/users/[:user]",    mongoose_client_api_rooms_users, []},
           {"_", "/api/rooms/[:id]/messages",    mongoose_client_api_rooms_messages, []}
       ]}
   ]},

--- a/test/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -338,7 +338,7 @@ send_messages(Config, Alice, Bob, Kate) ->
 assert_aff_change_stanza(Stanza, Target, Change) ->
     TargetJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Target)),
     ID = exml_query:attr(Stanza, <<"id">>),
-    %true = is_binary(ID) andalso ID /= <<>>,
+    true = is_binary(ID) andalso ID /= <<>>,
     User = exml_query:path(Stanza, [{element, <<"x">>}, {element, <<"user">>}]),
     Change = exml_query:attr(User, <<"affiliation">>),
     TargetJID = exml_query:cdata(User).

--- a/test/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -247,9 +247,9 @@ given_user_invited({_, Inviter} = Owner, RoomID, Invitee) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Invitee)),
     {{<<"204">>, <<"No Content">>}, _} = invite_to_room(Owner, RoomID, JID),
     Stanza = escalus:wait_for_stanza(Invitee),
-    ct:pal("Invitee ~p", [Stanza]),
+    assert_aff_change_stanza(Stanza, Invitee, <<"member">>),
     Stanza2 = escalus:wait_for_stanza(Inviter),
-    ct:pal("Inviter ~p", [Stanza2]).
+    assert_aff_change_stanza(Stanza2, Invitee, <<"member">>).
 
 invite_to_room(Inviter, RoomID, Invitee) ->
     Body = #{user => Invitee},

--- a/test/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -240,7 +240,7 @@ given_user_invited({_, Inviter} = Owner, RoomID, Invitee) ->
 invite_to_room(Inviter, RoomID, Invitee) ->
     Body = #{user => Invitee},
     Creds = credentials(Inviter),
-    rest_helper:putt(<<"/rooms/", RoomID/binary>>, Body, Creds).
+    rest_helper:post(<<"/rooms/", RoomID/binary, "/users">>, Body, Creds).
 
 credentials({User, UserClient}) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(UserClient)),

--- a/test/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -148,7 +148,6 @@ owner_can_leave_a_room_and_auto_select_owner(Config) ->
         RoomID = given_new_room_with_users({alice, Alice}, [{bob, Bob}]),
         {{<<"204">>, _}, _} = remove_user_from_a_room({alice, Alice}, RoomID, Alice),
         Stanza = escalus:wait_for_stanza(Bob),
-        ct:pal("~p", [Stanza]),
         assert_aff_change_stanza(Stanza, Alice, <<"none">>),
         assert_aff_change_stanza(Stanza, Bob, <<"owner">>)
     end).


### PR DESCRIPTION
This PR goes on top of #973 

Proposed changes include:
* user's management move to path /room/:id/users
* id attribute to affiliation change messages initiated by the API
