### PR TITLE
Test redis backend with mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,8 @@ branches:
 otp_release:
         - 18.3
 env:
-        - PRESET=internal_redis DB=mnesia REL_CONFIG=with-redis
         - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all
-        - PRESET=mysql_mnesia DB=mysql REL_CONFIG=with-mysql
+        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
         - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
         - PRESET=pgsql_mnesia DB=pgsql REL_CONFIG=with-pgsql
         - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -225,7 +225,7 @@
       {odbc_server, "{odbc_server, {mysql, \"localhost\", \"ejabberd\", \"ejabberd\", \"%ODBC_PASSWORD%\"}}."},
       {mod_last, "{mod_last, [{backend, odbc}]},"},
       {mod_privacy, "{mod_privacy, [{backend, odbc}]},"},
-      {mod_private, "{mod_private, [{backend, odbc}]},"},
+      {mod_private, "{mod_private, [{backend, mysql}]},"},
       {mod_offline, "{mod_offline, [{backend, odbc}]},"},
       {mod_vcard, "{mod_vcard, [{backend, odbc}]},"},
       {mod_roster, "{mod_roster, [{backend, odbc}]},"}]},


### PR DESCRIPTION
This PR merges 2 jobs on travis `interl_redis` and `mysql_mnesia` into 1 - `mysql_redis`. This reduces the total time of a build by around 30 minutes and keeps the code coverage at the same level. 