### PR TITLE
Upgrade escalus for tests 2.7.0 => 2.7.1

### DIFF
--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -5,7 +5,7 @@
 
 {deps, [
         {amoc, ".*", {git, "git://github.com/esl/amoc.git", "9acfdc4b57cd37e8030831a4493847d2e01d1ec9"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "2.7.0"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "2.7.1"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "2.3.0"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},


### PR DESCRIPTION
Includes https://github.com/esl/wsecli/pull/9
Fix race conditions in wsecli library when reading stanzas from server