### PR TITLE
Fix muclight hook call

### DIFF
--- a/apps/ejabberd/include/mod_muc_light.hrl
+++ b/apps/ejabberd/include/mod_muc_light.hrl
@@ -121,3 +121,5 @@
                                   | {set, #config{}, AffUsers :: aff_users()}
                                   | {error, bad_request}.
 
+-type msg() :: #msg{}.
+

--- a/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
+++ b/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
@@ -107,7 +107,7 @@ decode_message(#xmlel{ attrs = Attrs, children = Children }) ->
 -spec decode_message_by_type(Type :: {binary(), binary()} | false,
                              Id :: {binary(), binary()} | false,
                              Children :: [jlib:xmlch()]) ->
-    {ok, #msg{} | {set, #config{}}} | {error, bad_request} | ignore.
+    {ok, msg() | {set, config()}} | {error, bad_request} | ignore.
 decode_message_by_type({_, <<"groupchat">>}, _, [#xmlel{ name = <<"subject">> } = SubjectEl]) ->
     {ok, {set, #config{ raw_config = [{<<"subject">>, exml_query:cdata(SubjectEl)}] }}};
 decode_message_by_type({_, <<"groupchat">>}, Id, Children) ->
@@ -463,7 +463,7 @@ make_query_el(_, undefined) ->
 make_query_el(XMLNS, Els) ->
     [#xmlel{ name = <<"query">>, attrs = [{<<"xmlns">>, XMLNS}], children = Els }].
 
--spec status(Code :: binary()) -> #xmlel{}.
+-spec status(Code :: binary()) -> xmlel().
 status(Code) -> #xmlel{ name = <<"status">>, attrs = [{<<"code">>, Code}] }.
 
 %%====================================================================

--- a/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
+++ b/apps/ejabberd/src/mod_muc_light_codec_legacy.erl
@@ -46,6 +46,8 @@ decode(_, _, _) ->
              RoomUS :: ejabberd:simple_bare_jid(),
              HandleFun :: mod_muc_light_codec:encoded_packet_handler()) -> any().
 encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
+    US = jid:to_lus(Sender),
+    Aff = get_sender_aff(AffUsers, US),
     FromNick = jid:to_binary(jid:to_lus(Sender)),
     {RoomJID, RoomBin} = jids_from_room_with_resource(RoomUS, FromNick),
     Attrs = [
@@ -54,9 +56,15 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
              {<<"from">>, RoomBin}
             ],
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs, children = Msg#msg.children },
+    EventData = [{from_nick, FromNick},
+                 {from_jid, Sender},
+                 {room_jid, jid:make_noprep({RoomU, RoomS, <<>>})},
+                 {affiliation, Aff},
+                 {role, Aff}
+    ],
     #xmlel{ children = Children }
     = ejabberd_hooks:run_fold(filter_room_packet, RoomS, MsgForArch,
-                              [FromNick, Sender, jid:make_noprep({RoomU, RoomS, <<>>})]),
+                              [EventData]),
     lists:foreach(
       fun({{U, S}, _}) ->
               send_to_aff_user(RoomJID, U, S, <<"message">>, Attrs, Children, HandleFun)
@@ -469,4 +477,10 @@ b2action(<<"deny">>) -> deny.
 -spec action2b(Action :: atom()) -> binary().
 action2b(allow) -> <<"allow">>;
 action2b(deny) -> <<"deny">>.
+
+get_sender_aff(Users, US) ->
+    case lists:keyfind(US, 1, Users) of
+        {US, Aff} -> Aff;
+        _ -> undefined
+    end.
 

--- a/apps/ejabberd/src/mod_muc_light_codec_modern.erl
+++ b/apps/ejabberd/src/mod_muc_light_codec_modern.erl
@@ -396,9 +396,14 @@ encode_iq({set, #config{} = Config, AffUsers}, RoomJID, RoomBin, HandleFun) ->
                     | ConfigEls ],
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_CONFIGURATION, ConfigNotif) },
+    EventData = [{from_nick, <<>>},
+                 {from_jid, RoomJID},
+                 {room_jid, RoomJID},
+                 {role, owner},
+                 {affiliation, owner}],
     #xmlel{ children = FinalConfigNotif }
     = ejabberd_hooks:run_fold(filter_room_packet, RoomJID#jid.lserver, MsgForArch,
-                              [<<>>, RoomJID, RoomJID]),
+                              [EventData]),
 
     lists:foreach(
       fun({{U, S}, _}) ->

--- a/apps/ejabberd/src/mod_muc_light_codec_modern.erl
+++ b/apps/ejabberd/src/mod_muc_light_codec_modern.erl
@@ -99,7 +99,7 @@ decode_message(#xmlel{ attrs = Attrs, children = Children }) ->
 -spec decode_message_by_type(Type :: {binary(), binary()} | false,
                              Id :: {binary(), binary()} | false,
                              Children :: [jlib:xmlch()]) ->
-    {ok, #msg{}} | {error, bad_request} | ignore.
+    {ok, msg()} | {error, bad_request} | ignore.
 decode_message_by_type({_, <<"groupchat">>}, Id, Children) ->
     {ok, #msg{ children = Children, id = ensure_id(Id) }};
 decode_message_by_type({_, <<"error">>}, _, _) ->
@@ -317,14 +317,9 @@ encode_iq({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers}, RoomJID, Room
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_AFFILIATIONS,
                                                  NotifForCurrentNoPrevVersion) },
-    EventData = [{from_nick, <<>>},
-                 {from_jid, RoomJID},
-                 {room_jid, RoomJID},
-                 {role, owner},
-                 {affiliation, owner}],
     #xmlel{ children = FinalChildrenForCurrentNoPrevVersion }
     = ejabberd_hooks:run_fold(filter_room_packet, RoomJID#jid.lserver, MsgForArch,
-                              [EventData]),
+                              [room_event(RoomJID)]),
     FinalChildrenForCurrent = inject_prev_version(FinalChildrenForCurrentNoPrevVersion,
                                                   Affs#affiliations.prev_version),
     bcast_aff_messages(RoomJID, OldAffUsers, NewAffUsers, Attrs, VersionEl,
@@ -349,13 +344,8 @@ encode_iq({set, #create{} = Create, UniqueRequested}, RoomJID, RoomBin, HandleFu
     AllAffsEls = [ aff_user_to_el(AffUser) || AffUser <- Create#create.aff_users ],
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_AFFILIATIONS, AllAffsEls) },
-    EventData = [{from_nick, <<>>},
-                 {from_jid, RoomJID},
-                 {room_jid, RoomJID},
-                 {role, owner},
-                 {affiliation, owner}],
     ejabberd_hooks:run_fold(filter_room_packet, RoomJID#jid.lserver, MsgForArch,
-                              [EventData]),
+                              [room_event(RoomJID)]),
 
     %% IQ reply "from"
     %% Sent from service JID when unique room was requested
@@ -396,14 +386,9 @@ encode_iq({set, #config{} = Config, AffUsers}, RoomJID, RoomBin, HandleFun) ->
                     | ConfigEls ],
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_CONFIGURATION, ConfigNotif) },
-    EventData = [{from_nick, <<>>},
-                 {from_jid, RoomJID},
-                 {room_jid, RoomJID},
-                 {role, owner},
-                 {affiliation, owner}],
     #xmlel{ children = FinalConfigNotif }
     = ejabberd_hooks:run_fold(filter_room_packet, RoomJID#jid.lserver, MsgForArch,
-                              [EventData]),
+                              [room_event(RoomJID)]),
 
     lists:foreach(
       fun({{U, S}, _}) ->
@@ -532,3 +517,9 @@ b2what(<<"room">>) -> room.
 what2b(user) -> <<"user">>;
 what2b(room) -> <<"room">>.
 
+room_event(RoomJID) ->
+    [{from_nick, <<>>},
+     {from_jid, RoomJID},
+     {room_jid, RoomJID},
+     {role, owner},
+     {affiliation, owner}].


### PR DESCRIPTION
Fixed invalid call to `filter_room_packet` hook - handlers for that hook have different arity.

The call never really makes it to handlers because it is made from muc_light, while the only handler for this hook is added by mam, but still it should be done right.

