### PR TITLE
Improve travis test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
-script: tools/travis-test.sh $PRESET
+script: tools/travis-test.sh -p $PRESET
 
 after_failure:
         - cat `ls -1 -d -t apps/ejabberd/logs/ct_run* | head -1`/apps.ejabberd.logs/run.*/suite.log


### PR DESCRIPTION
This PR improves the travis-test.sh script by adding following options:
* `-p` to specify the PREST, default is `internal_mnesia`
* `-s` to specify if small tests should be run, default is `true`
* `-c` to specify is cover should be enabled on MongooseIM, default is `true`.

Example, in order to run only big tests without cover, following option can be used:

```bash
tools/travis-test.sh -p mysql_redis -s false -c false
```

