### PR TITLE
Stabilise tests on travis

### DIFF
--- a/apps/ejabberd/test/cowboy_SUITE.erl
+++ b/apps/ejabberd/test/cowboy_SUITE.erl
@@ -32,6 +32,7 @@
 
 all() ->
     [{group, routing},
+     start_cowboy_returns_error_eaddrinuse,
      conf_reload].
 
 groups() ->
@@ -201,6 +202,12 @@ mixed_requests(_Config) ->
 
     %% Then
     Responses = lists:duplicate(50, {TextPong, true, TextPong, true}).
+
+start_cowboy_returns_error_eaddrinuse(_C) ->
+    Opts = [{port, 8088}, {ip, {127, 0, 0, 1}}, {modules, []}, {retires, {2, 10}}],
+    {ok, _Pid} = ejabberd_cowboy:start_cowboy(a_ref, Opts),
+    Result = ejabberd_cowboy:start_cowboy(a_ref_2, Opts),
+    {error, eaddrinuse} = Result.
 
 conf_reload(Config) ->
     %% Given initial configuration

--- a/test/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test/ejabberd_tests/tests/bosh_SUITE.erl
@@ -258,7 +258,7 @@ stream_error(Config) ->
               escalus:assert(is_stream_error, [<<"invalid-from">>, <<>>],
                              escalus_client:wait_for_stanza(Carol)),
               %% connection should be closed, let's wait
-              true = wait_for_close(Carol, 10)
+              true = escalus_connection:wait_for_close(Carol, timer:seconds(1))
       end).
 
 interleave_requests(Config) ->
@@ -336,7 +336,7 @@ cant_send_invalid_rid(Config) ->
         escalus_bosh:send_raw(Carol, Empty),
 
         escalus:assert(is_stream_end, escalus:wait_for_stanza(Carol)),
-        true = wait_for_close(Carol, 10),
+        true = escalus_connection:wait_for_close(Carol, timer:seconds(1)),
         true = wait_for_session_close(Sid, 10)
         end).
 
@@ -773,17 +773,6 @@ wait_for_stanzas(Client, Count) ->
 
 wait_for_stanza(Client) ->
     escalus_client:wait_for_stanza(Client).
-
-wait_for_close(Client, 0) ->
-    false == escalus_connection:is_connected(Client);
-wait_for_close(Client, N) ->
-    case escalus_connection:is_connected(Client) of
-        false ->
-            true;
-        _ ->
-            timer:sleep(100),
-            wait_for_close(Client, N-1)
-    end.
 
 ack_body(Body, Rid) ->
     Attrs = Body#xmlel.attrs,

--- a/test/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test/ejabberd_tests/tests/rest_SUITE.erl
@@ -146,6 +146,7 @@ session_can_be_kicked(Config) ->
         % kick alice
         {?NOCONTENT, _} = delete("/sessions/localhost/alice/res1"),
         escalus:wait_for_stanza(Alice),
+        true = escalus_connection:wait_for_close(Alice, timer:seconds(1)),
         {?OK, Sessions2} = gett("/sessions/localhost"),
         assert_notinlist(<<"alice@localhost/res1">>, Sessions2)
     end).


### PR DESCRIPTION
This PR aims to stabilize randomly failing tests on travis.

Proposed changes include:
* allow empty list in `rest_helper:assert_notinlist`
* wait for connection to be closed in `rest_SUITE.erl`
* try starting cowboy listener if it failed due to `{error, eaddrinuse}`



