### PR TITLE
Remove support for legacy WebSockets

### DIFF
--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -83,7 +83,6 @@ prep_stop(State) ->
     ejabberd_listener:stop_listeners(),
     stop_modules(),
     broadcast_c2s_shutdown(),
-    mod_websockets:stop(),
     timer:sleep(5000),
     mongoose_metrics:remove_all_metrics(),
     State.

--- a/apps/ejabberd/src/ejabberd_cowboy.erl
+++ b/apps/ejabberd/src/ejabberd_cowboy.erl
@@ -152,6 +152,7 @@ get_routes(Modules) ->
     Final = Merged ++ [{'_', WildcardPaths}],
     ?DEBUG("Configured Cowboy Routes: ~p", [Final]),
     Final.
+
 get_routes([], Routes) ->
     Routes;
 get_routes([{Host, BasePath, Module} | Tail], Routes) ->

--- a/apps/ejabberd/src/mod_websockets.erl
+++ b/apps/ejabberd/src/mod_websockets.erl
@@ -1,16 +1,11 @@
 %%%===================================================================
-%%% @copyright (C) 2013, Erlang Solutions Ltd.
-%%% @doc Module providing support for websockets in ejabberd
+%%% @copyright (C) 2016, Erlang Solutions Ltd.
+%%% @doc Module providing support for websockets in MongooseIM
 %%% @end
 %%%===================================================================
 -module(mod_websockets).
--behaviour(gen_mod).
 -behaviour(cowboy_http_handler).
 -behaviour(cowboy_websocket_handler).
-
-%% gen_mod callbacks
--export([start/2,
-         stop/1]).
 
 %% cowboy_http_handler callbacks
 -export([init/3,
@@ -37,13 +32,6 @@
          set_ping/2,
          disable_ping/1]).
 
-%% ejabberd_listener compatibility
--export([socket_type/0,
-         start_listener/2]).
-
--export([stop/0]).
-
-
 -include("ejabberd.hrl").
 -include("jlib.hrl").
 -include_lib("exml/include/exml_stream.hrl").
@@ -64,89 +52,6 @@
           opts :: proplists:proplist(),
           ping_rate :: integer() | none
          }).
-
-%%--------------------------------------------------------------------
-%% ejabberd_listener compatibility
-%%--------------------------------------------------------------------
--spec socket_type() -> independent.
-socket_type() ->
-    independent.
-
-% -spec start_listener(list())
-start_listener({Port, IP, ws}, Opts) ->
-    Dispatch = get_dispatch(Opts),
-    NumAcceptors = gen_mod:get_opt(num_acceptors, Opts, 100),
-    start_ws(NumAcceptors, Port, IP, Dispatch);
-
-start_listener({Port, IP, wss}, Opts) ->
-    Dispatch = get_dispatch(Opts),
-    NumAcceptors = gen_mod:get_opt(num_acceptors, Opts, 100),
-    SSLPort = gen_mod:get_opt(ssl_port, Opts, Port),
-    SSLCert = gen_mod:get_opt(cert, Opts, undefined),
-    SSLKey = gen_mod:get_opt(key, Opts, undefined),
-    SSLKeyPass = gen_mod:get_opt(key_pass, Opts, undefined),
-    start_wss(NumAcceptors, SSLPort, IP, SSLCert, SSLKey, SSLKeyPass, Dispatch).
-
-%%--------------------------------------------------------------------
-%% gen_mod callbacks
-%%--------------------------------------------------------------------
-
-start(_Host, Opts) ->
-    NumAcceptors = gen_mod:get_opt(num_acceptors, Opts, 100),
-    Port = gen_mod:get_opt(port, Opts, undefined),
-    IP = gen_mod:get_opt(ip, Opts, {0,0,0,0}),
-    SSLPort = gen_mod:get_opt(ssl_port, Opts, undefined),
-    SSLCert = gen_mod:get_opt(cert, Opts, undefined),
-    SSLKey = gen_mod:get_opt(key, Opts, undefined),
-    SSLKeyPass = gen_mod:get_opt(key_pass, Opts, undefined),
-    Dispatch = get_dispatch(Opts),
-    {ok, _} = start_ws(NumAcceptors, Port, IP, Dispatch),
-    {ok, _} = start_wss(NumAcceptors, SSLPort, IP, SSLCert, SSLKey,
-                        SSLKeyPass, Dispatch).
-
-start_ws(_, undefined, _, _) ->
-    {ok, not_started};
-start_ws(NumAcceptors, Port, IP, Dispatch) ->
-    case cowboy:start_http(?LISTENER, NumAcceptors,
-                                [{port, Port}, {ip, IP}],
-                                [{env, [{dispatch, Dispatch}]}]) of
-% Uncomment when cowboy 1.1.0 is released with fixed spec
-%        {error, {already_started, Pid}} ->
-%            {ok, Pid};
-        {ok, Pid} ->
-            {ok, Pid};
-        {error, Reason} ->
-            {error, Reason}
-    end.
-
-start_wss(_, _, _, undefined, undefined, undefined, _) ->
-    {ok, not_started};
-start_wss(NumAcceptors, Port, IP, Cert, Key, Pass, Dispatch) ->
-    case cowboy:start_https({?LISTENER, secure}, NumAcceptors,
-                                [
-                                    {certfile, Cert},
-                                    {keyfile, Key},
-                                    {password, Pass},
-                                    {ip, IP},
-                                    {port, Port}
-                                ],
-                                [{env, [{dispatch, Dispatch}]}]) of
-% Uncomment when cowboy 1.1.0 is released with fixed spec
-%        {error, {already_started, Pid}} ->
-%            {ok, Pid};
-        {ok, Pid} ->
-            {ok, Pid};
-        {error, Reason} ->
-            {error, Reason}
-    end.
-
-stop() ->
-    stop(any).
-
-stop(_Host) ->
-    cowboy:stop_listener({?LISTENER, secure}),
-    cowboy:stop_listener(?LISTENER),
-    ok.
 
 %%--------------------------------------------------------------------
 %% cowboy_http_handler callbacks

--- a/apps/ejabberd/src/mod_websockets.erl
+++ b/apps/ejabberd/src/mod_websockets.erl
@@ -317,12 +317,6 @@ should_have_jabber_client(#xmlel{name = <<"message">>}) -> true;
 should_have_jabber_client(#xmlel{name = <<"presence">>}) -> true;
 should_have_jabber_client(_) -> false.
 
-
-get_dispatch(Opts) ->
-    WSHost = gen_mod:get_opt(host, Opts, '_'), %% default to any
-    WSPrefix = gen_mod:get_opt(prefix, Opts, "/ws-xmpp"),
-    cowboy_router:compile([{WSHost, [{WSPrefix, ?MODULE, Opts}] }]).
-
 send_ping_request(PingRate) ->
     Dest = self(),
     ?DEBUG("Sending websocket ping request to ~p", [Dest]),

--- a/apps/ejabberd/src/mod_websockets.erl
+++ b/apps/ejabberd/src/mod_websockets.erl
@@ -171,14 +171,13 @@ send_to_fsm(FSM, StreamElement) ->
 maybe_start_fsm([#xmlstreamstart{ name = <<"stream", _/binary>>, attrs = Attrs}
                  | _], Req,
                 #ws_state{fsm_pid = undefined, opts = Opts}=State) ->
-    {FSMModule, FSMOpts} = case lists:keyfind(<<"xmlns">>, 1, Attrs) of
+    case lists:keyfind(<<"xmlns">>, 1, Attrs) of
         {<<"xmlns">>, ?NS_COMPONENT} ->
             ServiceOpts = gen_mod:get_opt(ejabberd_service, Opts, []),
-            {ejabberd_service, ServiceOpts};
+            do_start_fsm(ejabberd_service, ServiceOpts, Req, State);
         _ ->
-            {ejabberd_c2s, Opts}
-    end,
-    do_start_fsm(FSMModule, FSMOpts, Req, State);
+            {shutdown, Req, State}
+    end;
 maybe_start_fsm([#xmlel{ name = <<"open">> }],
                 Req, #ws_state{fsm_pid = undefined, opts = Opts}=State) ->
     do_start_fsm(ejabberd_c2s, Opts, Req, State);

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.default.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.default.cfg
@@ -163,7 +163,7 @@
 			{max_stanza_size, 65536}
 		       ]},
 
-  
+
 
   %%
   %% To enable the old SSL connection method on port 5223:
@@ -624,10 +624,9 @@
 %{search, true},
 %{host, directory.@HOST@}
 ]},
-  {mod_bosh, []},
-  {mod_websockets, []}
+  {mod_bosh, []}
 
-  %% 
+  %%
   %% Message Archive Management (MAM) for registered users.
   %%
 

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.split.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.split.cfg
@@ -163,7 +163,7 @@
 			{max_stanza_size, 65536}
 		       ]},
 
-  
+
 
   %%
   %% To enable the old SSL connection method on port 5223:
@@ -624,10 +624,9 @@
 %{search, true},
 %{host, directory.@HOST@}
 ]},
-  {mod_bosh, []},
-  {mod_websockets, []}
+  {mod_bosh, []}
 
-  %% 
+  %%
   %% Message Archive Management (MAM) for registered users.
   %%
 

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.cfg
@@ -163,7 +163,7 @@
 			{max_stanza_size, 65536}
 		       ]},
 
-  
+
 
   %%
   %% To enable the old SSL connection method on port 5223:
@@ -625,8 +625,7 @@
 %{search, true},
 %{host, directory.@HOST@}
 ]},
-  {mod_bosh, []},
-  {mod_websockets, []}
+  {mod_bosh, []}
 
   %%
   %% Message Archive Management (MAM) for registered users.

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.different_opts.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.different_opts.cfg
@@ -163,7 +163,7 @@
 			{max_stanza_size, 65536}
 		       ]},
 
-  
+
 
   %%
   %% To enable the old SSL connection method on port 5223:
@@ -625,10 +625,9 @@
 %{search, true},
 %{host, directory.@HOST@}
 ]},
-  {mod_bosh, []},
-  {mod_websockets, []}
+  {mod_bosh, []}
 
-  %% 
+  %%
   %% Message Archive Management (MAM) for registered users.
   %%
 

--- a/apps/ejabberd/test/ejabberd_listener_SUITE_data/ejabberd.alt.cfg
+++ b/apps/ejabberd/test/ejabberd_listener_SUITE_data/ejabberd.alt.cfg
@@ -120,8 +120,7 @@
   {mod_vcard, [ {allow_return_all, true},
                 {search_all_hosts, true}
               ]},
-  {mod_bosh, []},
-  {mod_websockets, []}
+  {mod_bosh, []}
 
  ]}.
 

--- a/apps/ejabberd/test/ejabberd_listener_SUITE_data/ejabberd.basic.cfg
+++ b/apps/ejabberd/test/ejabberd_listener_SUITE_data/ejabberd.basic.cfg
@@ -120,8 +120,7 @@
   {mod_vcard, [ {allow_return_all, true},
                 {search_all_hosts, true}
               ]},
-  {mod_bosh, []},
-  {mod_websockets, []}
+  {mod_bosh, []}
 
  ]}.
 

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -1,6 +1,6 @@
 Some of MongooseIM modules are specialised in handling user connections. They can be used in the `listen` clause in `ejabberd.cfg` file. See this section for their description and configuration options.
 
-Options described with a value type (e.g. string, integer) are key-value tuples. 
+Options described with a value type (e.g. string, integer) are key-value tuples.
 Other options are enabled by being added as atoms. E.g. a tuple option might be: `{access, c2s}` while other options are added as: `starttls`.
 
 ## Client-to-server (C2S): `ejabberd_c2s`
@@ -49,10 +49,11 @@ Manages all HTTP-based services, such as BOSH (HTTP long-polling) and WebSocket.
 
             `{"_", "/http-bind", mod_bosh}`
 
-    * `mod_websockets` - Websocket connections, both [old](http://xmpp.org/extensions/xep-0206.html) and [new](http://datatracker.ietf.org/doc/draft-ietf-xmpp-websocket/?include_text=1) type. You can pass optional
-    parameters:
+    * `mod_websockets` - Websocket connections as defined in  [RFC 7395](https://tools.ietf.org/html/rfc7395).
+    You can pass optional parameters:
         * `{timeout, Val}` - the time after which an inactive user is disconnected.
-        * `{ping_rate, Val}` - the Ping rate points to the time between pings sent by server. By declaring this field you enable server-side pinging.
+        * `{ping_rate, Val}` - the Ping rate points to the time between pings sent by server.
+	By declaring this field you enable server-side pinging.
         * `{ejabberd_service, Params}` - this enables external component
             connections over WebSockets. See [ejabberd_service](#ejabberd_service)
             section for more details how to configure it.

--- a/doc/modules/mod_websockets.md
+++ b/doc/modules/mod_websockets.md
@@ -1,7 +1,8 @@
 ### Module Description
 
 If you'd like clients to connect over Websocket connections, you must enable
-this module both in the [`listen` section of `ejabberd.cfg`](../advanced-configuration/Listener-modules.md) and as a module. Websockets are enabled by default.
+this module in the [`listen` section of `ejabberd.cfg`](../advanced-configuration/Listener-modules.md).
+WebSockets are enabled by default.
 
 ### Options
 
@@ -17,12 +18,8 @@ In the listener section:
       {num_acceptors, 10},
       {max_connections, 1024},
       {modules, [
-          {"_", "/ws-xmpp", mod_websockets}
+          {"_", "/ws-xmpp", mod_websockets, []}
       ]}
   ]}
 ```
 
-In the module section:
-```
-  {mod_websockets, []}
-```

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -757,7 +757,6 @@
   {mod_sic, []},
   {{mod_vcard}}
   {mod_bosh, []},
-  {mod_websockets, []},
   {mod_carboncopy, []}
 
   %%

--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,7 +4,7 @@
 {require_otp_vsn, "1[789]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "3169334"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "1d7d3b7"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "2.3.0"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},

--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -110,15 +110,6 @@
         {password, <<"bringdowntheserver">>},
         {compression, <<"zlib">>},
         {port, 5223}]},
-    {oldie, [
-        {username, <<"oldie">>},
-        {server, <<"localhost">>},
-        {password, <<"legacy">>},
-        {transport, escalus_ws},
-        {port, 5280},
-        {wspath, <<"/ws-xmpp">>},
-        {wslegacy, true}
-      ]},
     {admin, [
         {username, <<"admin">>},
         {server, <<"localhost">>},

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -181,8 +181,6 @@ try_registering_with_wrong_password(Config) ->
     CompOpts1 = ?config(component1, Config),
     CompOpts2 = lists:keyreplace(password, 1, CompOpts1,
                                  {password, <<"wrong_one">>}),
-    ct:print("~p", [CompOpts2]),
-
     try
         %% When trying to connect it
         {Comp, _Addr, _} = connect_component(CompOpts2),
@@ -249,7 +247,6 @@ disco_components(Config) ->
 register_subdomain(Config) ->
     %% Given one connected component
     CompOpts1 = ?config(component1, Config),
-    ct:print("~p", [CompOpts1]),
     {Comp, _Addr, Name} = connect_component_subdomain(CompOpts1),
 
     escalus:story(Config, [{alice, 1}, {astrid, 1}], fun(Alice, Astrid) ->

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -56,7 +56,8 @@ xep0114_tests() ->
      try_registering_with_wrong_password,
      try_registering_component_twice,
      try_registering_existing_host,
-     disco_components].
+     disco_components
+     ].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -70,21 +71,20 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(xep0114_tcp, Config) ->
-    Config1 = get_components([], Config),
+    Config1 = get_components(common(Config), Config),
     escalus:create_users(Config1, escalus:get_users([alice, bob]));
 init_per_group(xep0114_ws, Config) ->
-    WSOpts = [{transport, ws},
+    WSOpts = [{transport, escalus_ws},
               {wspath, <<"/ws-xmpp">>},
-              {wslegacy, true},
-              {port, 5280}],
+              {wslegacy, true} | common(Config, 5280)],
     Config1 = get_components(WSOpts, Config),
     escalus:create_users(Config1, escalus:get_users([alice, bob]));
 init_per_group(subdomain, Config) ->
-    Config1 = get_components([], Config),
+    Config1 = get_components(common(Config), Config),
     add_domain(Config1),
     escalus:create_users(Config1, escalus:get_users([alice, astrid]));
 init_per_group(distributed, Config) ->
-    Config1 = get_components([], Config),
+    Config1 = get_components(common(Config), Config),
     Config2 = add_node_to_cluster(Config1),
     escalus:create_users(Config2, escalus:get_users([alice, clusterguy]));
 init_per_group(_GroupName, Config) ->
@@ -111,7 +111,7 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 register_one_component(Config) ->
     %% Given one connected component
-    CompOpts = spec(component1, Config),
+    CompOpts = ?config(component1, Config),
     {Component, ComponentAddr, _} = connect_component(CompOpts),
 
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
@@ -136,8 +136,8 @@ register_one_component(Config) ->
 
 register_two_components(Config) ->
     %% Given two connected components
-    CompOpts1 = spec(component1, Config),
-    CompOpts2 = spec(component2, Config),
+    CompOpts1 = ?config(component1, Config),
+    CompOpts2 = ?config(component2, Config),
     {Comp1, CompAddr1, _} = connect_component(CompOpts1),
     {Comp2, CompAddr2, _} = connect_component(CompOpts2),
 
@@ -178,9 +178,10 @@ register_two_components(Config) ->
 
 try_registering_with_wrong_password(Config) ->
     %% Given a component with a wrong password
-    CompOpts1 = spec(component1, Config),
+    CompOpts1 = ?config(component1, Config),
     CompOpts2 = lists:keyreplace(password, 1, CompOpts1,
                                  {password, <<"wrong_one">>}),
+    ct:print("~p", [CompOpts2]),
 
     try
         %% When trying to connect it
@@ -194,7 +195,7 @@ try_registering_with_wrong_password(Config) ->
 
 try_registering_component_twice(Config) ->
     %% Given two components with the same name
-    CompOpts1 = spec(component1, Config),
+    CompOpts1 = ?config(component1, Config),
     {Comp1, Addr, _} = connect_component(CompOpts1),
 
     try
@@ -211,7 +212,7 @@ try_registering_component_twice(Config) ->
 
 try_registering_existing_host(Config) ->
     %% Given a external vjud component
-    Component = spec(vjud_component, Config),
+    Component = ?config(vjud_component, Config),
 
     try
         %% When trying to connect it to the server
@@ -225,8 +226,8 @@ try_registering_existing_host(Config) ->
 
 disco_components(Config) ->
     %% Given two connected components
-    CompOpts1 = spec(component1, Config),
-    CompOpts2 = spec(component2, Config),
+    CompOpts1 = ?config(component1, Config),
+    CompOpts2 = ?config(component2, Config),
     {Comp1, Addr1, _} = connect_component(CompOpts1),
     {Comp2, Addr2, _} = connect_component(CompOpts2),
 
@@ -247,7 +248,8 @@ disco_components(Config) ->
 
 register_subdomain(Config) ->
     %% Given one connected component
-    CompOpts1 = spec(component1, Config),
+    CompOpts1 = ?config(component1, Config),
+    ct:print("~p", [CompOpts1]),
     {Comp, _Addr, Name} = connect_component_subdomain(CompOpts1),
 
     escalus:story(Config, [{alice, 1}, {astrid, 1}], fun(Alice, Astrid) ->
@@ -279,10 +281,10 @@ register_subdomain(Config) ->
 
 register_in_cluster(Config) ->
     %% Given one component connected to the cluster
-    CompOpts1 = spec(component1, Config),
+    CompOpts1 = ?config(component1, Config),
     Component1 = connect_component(CompOpts1),
     {Comp1, _, _} = Component1,
-    CompOpts2 = spec(component2, Config),
+    CompOpts2 = ?config(component2, Config),
     Component2 = connect_component(CompOpts2),
     {Comp2, _, _} = Component2,
     CompOpts_on_2 = spec(component_on_2, Config),
@@ -361,19 +363,16 @@ register_same_on_both(Config) ->
     %% but not on the same host
     %% we should be able to register
     %% and we get two components having the same name and address
-    CompOpts2 = spec(component2, Config),
+    CompOpts2 = ?config(component2, Config),
     Component2 = connect_component(CompOpts2),
-    ct:pal("~p", [Component2]),
     {Comp2, Addr, Name} = Component2,
     CompOpts_d = spec(component_duplicate, Config),
     Component_d = connect_component(CompOpts_d),
-    ct:pal("~p", [Component_d]),
     {Comp_d, Addr, Name} = Component_d,
 
     escalus:story(Config, [{alice, 1}, {clusterguy, 1}], fun(Alice, ClusterGuy) ->
         %% When Alice sends a message to the component
         Msg1 = escalus_stanza:chat_to(Addr, <<"Hi!">>),
-        ct:pal("~p", [Msg1]),
         escalus:send(Alice, Msg1),
         %% Then component receives it (on the same node)
         Reply1 = escalus:wait_for_stanza(Comp2),
@@ -444,8 +443,8 @@ connect_component_subdomain(Component) ->
 
 connect_component(ComponentOpts, StartStep) ->
     Res = escalus_connection:start(ComponentOpts,
-                                                     [{?MODULE, StartStep},
-                                                      {?MODULE, component_handshake}]),
+                                   [{?MODULE, StartStep},
+                                    {?MODULE, component_handshake}]),
     case Res of
     {ok, Component, _, _} ->
         {component, ComponentName} = lists:keyfind(component, 1, ComponentOpts),
@@ -551,16 +550,19 @@ default_node(Config) ->
     Node == undefined andalso error(node_undefined, [Config]),
     Node.
 
-spec(component1, Config) ->
-    [{component, <<"test_service">>}] ++ common(Config);
-spec(component2, Config) ->
-    [{component, <<"another_service">>}] ++ common(Config);
 spec(component_on_2, Config) ->
     [{component, <<"yet_another_service">>}] ++ common(Config, 8899);
 spec(component_duplicate, Config) ->
     [{component, <<"another_service">>}] ++ common(Config, 8899);
-spec(vjud_component, Config) ->
-    [{component, <<"vjud">>}] ++ common(Config).
+spec(Other, Config) ->
+    [name(Other) | proplists:get_value(Other, Config, [])].
+
+name(component1) ->
+    {component, <<"test_service">>};
+name(component2) ->
+    {component, <<"another_service">>};
+name(vjud_component) ->
+    {component, <<"vjud">>}.
 
 common(Config) ->
     common(Config, 8888).

--- a/test/ejabberd_tests/tests/websockets_SUITE.erl
+++ b/test/ejabberd_tests/tests/websockets_SUITE.erl
@@ -54,7 +54,7 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(GroupName, Config) ->
-    Config1 = escalus:create_users(Config, escalus:get_users([alice, geralt, geralt_s, oldie])),
+    Config1 = escalus:create_users(Config, escalus:get_users([alice, geralt, geralt_s, carol])),
     case GroupName of
         wss_chat ->
             [{user, geralt_s} | Config1];
@@ -64,7 +64,7 @@ init_per_group(GroupName, Config) ->
 
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, escalus:get_users([alice, geralt, geralt_s, oldie])).
+    escalus:delete_users(Config, escalus:get_users([alice, geralt, geralt_s, carol])).
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -77,7 +77,8 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 
 chat_msg(Config) ->
-    escalus:story(Config, [{alice, 1}, {?config(user, Config), 1}, {oldie, 1}], fun(Alice, Geralt, Oldie) ->
+    escalus:story(Config, [{alice, 1}, {?config(user, Config), 1}, {carol, 1}],
+                  fun(Alice, Geralt, Carol) ->
 
         escalus_client:send(Alice, escalus_stanza:chat_to(Geralt, <<"Hi!">>)),
         FromAlice = escalus_client:wait_for_stanza(Geralt),
@@ -87,28 +88,26 @@ chat_msg(Config) ->
         escalus_client:send(Geralt, escalus_stanza:chat_to(Alice, <<"Hello!">>)),
         escalus:assert(is_chat_message, [<<"Hello!">>], escalus_client:wait_for_stanza(Alice)),
 
-        escalus_client:send(Geralt, escalus_stanza:chat_to(Oldie, <<"Hey!">>)),
-        escalus_assert:is_chat_message(<<"Hey!">>, escalus_client:wait_for_stanza(Oldie))
+        escalus_client:send(Geralt, escalus_stanza:chat_to(Carol, <<"Hey!">>)),
+        escalus_assert:is_chat_message(<<"Hey!">>, escalus_client:wait_for_stanza(Carol))
 
         end).
 
 escape_chat_msg(Config) ->
-    escalus:story(Config, [{alice, 1}, {?config(user, Config), 1}, {oldie, 1}], fun(Alice, Geralt, Oldie) ->
+    escalus:story(Config, [{alice, 1}, {?config(user, Config), 1}, {carol, 1}],
+                  fun(Alice, Geralt, Carol) ->
         special_chars_helper:check_cdata_from_to(Alice, Geralt, <<"Hi! & < >">>),
         special_chars_helper:check_cdata_from_to(Geralt, Alice, <<"Hello! & < >">>),
-        special_chars_helper:check_cdata_from_to(Geralt, Oldie, <<"Hey! & < >">>)
+        special_chars_helper:check_cdata_from_to(Geralt, Carol, <<"Hey! & < >">>)
 
     end).
 
 escape_attrs(Config) ->
-    escalus:story(Config, [{alice, 1}, {?config(user, Config), 1}, {oldie, 1}], fun(Alice, Geralt, Oldie) ->
+    escalus:story(Config, [{alice, 1}, {?config(user, Config), 1}, {carol, 1}],
+                  fun(Alice, Geralt, Carol) ->
         special_chars_helper:check_attr_from_to(Alice, Geralt),
         special_chars_helper:check_attr_from_to(Geralt, Alice),
-        special_chars_helper:check_attr_from_to(Geralt, Oldie)
+        special_chars_helper:check_attr_from_to(Geralt, Carol)
 
     end).
-
-%%--------------------------------------------------------------------
-%% Helpers
-%%--------------------------------------------------------------------
 


### PR DESCRIPTION
The only supported XMPP over WebSockets is the one defined in  [RFC 7395](https://tools.ietf.org/html/rfc7395)

Also following changes has been made:
* removed unnecessary code from `mod_websockets`
* `component_SUITE` now truly uses WebSocket connection in the `xep_0114_ws` group

