### PR TITLE
Client's REST API doc

### DIFF
--- a/doc/REST-API.md
+++ b/doc/REST-API.md
@@ -1,31 +1,31 @@
 In addition to the regular XMPP connection methods such as TCP (with TLS/STARTTLS),
-WebSockets and BOSH, MongooseIM provides parts of its functionality over REST API.
+WebSockets and BOSH, MongooseIM provides parts of its functionality over a REST API.
 
 ### Assumptions
 
 1. Every request has to be authenticated.
 Please see the [Authentication](#authentication) section for more details.
-1. We advise to serve this API over HTTPS.
-1. User registration has to be done via other methods (f.e using the
+1. We advise that this API is served over HTTPS.
+1. User registration has to be done via other methods (f.e. using the
 [REST API for backend services](http-api/http-administration-api-documentation.md)).
-1. Relevant endpoint has to be configured on the server side.
+1. The relevant endpoint has to be configured on the server side.
 See the [configuration section](#configuration).
-1. List of provided actions is documented in Swagger.
+1. A list of provided actions is documented with Swagger.
 See the documentation at the [bottom](#specification) of this page or under
 [this link](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true).
 
 ### Authentication
 
-The only possible authentication method now is *Basic Authentication*.
-The *userid* part is user's *bare JID* and password is the same as used to
+The only possible authentication method for the time being is *Basic Authentication*.
+The *userid* part is user's *bare JID* and the password is the same as that used to
 register the user's account.
 
 #### Bare JID
 
-To ilustrate what bare JIDs are, let's assume your MongooseIM server's host is
-*wonderland.com* and the user is *alice*
+To ilustrate what bare JIDs are, let's assume your MongooseIM server's hostname is
+*wonderland.com* and the user is *alice*.
 In this case the bare JID for her is just: *alice@wonderland.com*.
-This value should be used as *userid* in the Basic Authentication method for all the REST API calls.
+This value should be used as the *userid* in the Basic Authentication method for all the REST API calls.
 
 ### Configuration
 
@@ -48,10 +48,10 @@ In order to enable the REST API, the following configuration should be added to 
 ```
 
 The most important part of the above example is the *modules* lists where the relevant
-REST API functionalities are enabled and exposed on given path.
+REST API functionalities are enabled and exposed on the given paths.
 By default the REST API is exposed on port 8089 but this can be changed to whatever is more convenient.
 
-For more details about possible `ejabberd_cowboy` configuration parameters plese
+For more details about possible `ejabberd_cowboy` configuration parameters please
 see the relevant documentation in [Listener-modules](../advanced-configuration/Listener-modules/#http-based-services-bosh-websocket-rest-ejabberd_cowboy)
 
 ### Specification

--- a/doc/REST-API.md
+++ b/doc/REST-API.md
@@ -12,7 +12,7 @@ Please see the [Authentication](#authentication) section for more details.
 See the [configuration section](#configuration).
 1. List of provided actions is documented in Swagger.
 See the documentation at the [bottom](#specification) of this page or under
-[this link](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true)
+[this link](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true).
 
 ### Authentication
 
@@ -22,14 +22,14 @@ register the user's account.
 
 #### Bare JID
 
-A word of explanation what is *bare JID*. Provide your MongooseIM servers host
-`wonderland.com` and the user is `alice`, the bare JID for her is just: `alice@wonderland.com`.
-This value should be used as *userid* in the *Basic Authentication* method for
-all the REST API calls.
+To ilustrate what bare JIDs are, let's assume your MongooseIM server's host is
+*wonderland.com* and the user is *alice*
+In this case the bare JID for her is just: *alice@wonderland.com*.
+This value should be used as *userid* in the Basic Authentication method for all the REST API calls.
 
 ### Configuration
 
-In order to enable the REST API, following configuration should be added to the
+In order to enable the REST API, the following configuration should be added to the
 *listen* section in *ejabberd.cfg* file.
 
 ```erlang
@@ -47,10 +47,9 @@ In order to enable the REST API, following configuration should be added to the
   ]}
 ```
 
-The most important part from above example is the *modules* lists where relevant
+The most important part of the above example is the *modules* lists where the relevant
 REST API functionalities are enabled and exposed on given path.
-By default the REST API is exposed on port 8089 but this can be changed to anything
-which is more convenient.
+By default the REST API is exposed on port 8089 but this can be changed to whatever is more convenient.
 
 For more details about possible `ejabberd_cowboy` configuration parameters plese
 see the relevant documentation in [Listener-modules](../advanced-configuration/Listener-modules/#http-based-services-bosh-websocket-rest-ejabberd_cowboy)

--- a/doc/REST-API.md
+++ b/doc/REST-API.md
@@ -1,24 +1,59 @@
-MongooseIM's REST API
----------------------
-
 In addition to the regular XMPP connection methods such as TCP (with TLS/STARTTLS),
 WebSockets and BOSH, MongooseIM provides parts of its functionality over REST API.
 
 ### Assumptions
 
 1. Every request has to be authenticated.
+Please see the [Authentication](#authentication) section for more details.
+1. We advise to serve this API over HTTPS.
 1. User registration has to be done via other methods (f.e using the
 [REST API for backend services](http-api/http-administration-api-documentation.md)).
 1. Relevant endpoint has to be configured on the server side.
+See the [configuration section](#configuration).
 1. List of provided actions is documented in Swagger.
-See the documentation at the bottom of this page or under
+See the documentation at the [bottom](#specification) of this page or under
 [this link](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true)
 
+### Authentication
 
+The only possible authentication method now is *Basic Authentication*.
+The *userid* part is user's *bare JID* and password is the same as used to
+register the user's account.
+
+#### Bare JID
+
+A word of explanation what is *bare JID*. Provide your MongooseIM servers host
+`wonderland.com` and the user is `alice`, the bare JID for her is just: `alice@wonderland.com`.
+This value should be used as *userid* in the *Basic Authentication* method for
+all the REST API calls.
 
 ### Configuration
 
-TODO add endpoint configuration
+In order to enable the REST API, following configuration should be added to the
+*listen* section in *ejabberd.cfg* file.
+
+```erlang
+  { 8089 , ejabberd_cowboy, [
+      {num_acceptors, 10},
+      {max_connections, 1024},
+      {compress, true},
+      {ssl, [{certfile, "priv/ssl/fake_cert.pem"}, {keyfile, "priv/ssl/fake_key.pem"}, {password, ""}]},
+      {modules, [
+          {"_", "/api/messages/[:with]", mongoose_client_api_messages, []},
+          {"_", "/api/rooms/:id/messages",    mongoose_client_api_rooms_messages, []},
+          {"_", "/api/rooms/:id/users/[:user]",    mongoose_client_api_rooms_users, []},
+          {"_", "/api/rooms/[:id]",    mongoose_client_api_rooms, []}
+      ]}
+  ]}
+```
+
+The most important part from above example is the *modules* lists where relevant
+REST API functionalities are enabled and exposed on given path.
+By default the REST API is exposed on port 8089 but this can be changed to anything
+which is more convenient.
+
+For more details about possible `ejabberd_cowboy` configuration parameters plese
+see the relevant documentation in [Listener-modules](../advanced-configuration/Listener-modules/#http-based-services-bosh-websocket-rest-ejabberd_cowboy)
 
 ### Specification
 

--- a/doc/REST-API.md
+++ b/doc/REST-API.md
@@ -1,0 +1,46 @@
+MongooseIM's REST API
+---------------------
+
+In addition to the regular XMPP connection methods such as TCP (with TLS/STARTTLS),
+WebSockets and BOSH, MongooseIM provides parts of its functionality over REST API.
+
+### Assumptions
+
+1. Every request has to be authenticated.
+1. User registration has to be done via other methods (f.e using the
+[REST API for backend services](http-api/http-administration-api-documentation.md)).
+1. Relevant endpoint has to be configured on the server side.
+1. List of provided actions is documented in Swagger.
+See the documentation at the bottom of this page or under
+[this link](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true)
+
+
+
+### Configuration
+
+TODO add endpoint configuration
+
+### Specification
+
+Find the beautiful Swagger documentation below
+
+<iframe src="http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true"
+height="800" width="800" style="margin-left: -45px;" id="swagger-ui-iframe"></iframe>
+
+<script>
+
+$(document).ready(function() {
+  if (window.location.host.match("readthedocs")){
+    path = window.location.pathname.match("(.*)/REST-API/")[1]
+    url = window.location.protocol + "//" + window.location.hostname
+    finalURL = url + path + "/swagger/index.html?client=true"
+    $('a[href$="swagger/index.html?client=true"]').attr('href', finalURL)
+    $('#swagger-ui-iframe').attr('src', finalURL)
+  }
+
+
+})
+
+</script>
+
+

--- a/doc/user-guide/Features-and-supported-standards.md
+++ b/doc/user-guide/Features-and-supported-standards.md
@@ -1,15 +1,21 @@
 Features and supported standards
 --------------------------------
 
-*   XMPP Core: [RFC 3920](https://tools.ietf.org/html/rfc3920),
+* XMPP Core: [RFC 3920](https://tools.ietf.org/html/rfc3920),
+[RFC 6120](https://tools.ietf.org/html/rfc6120)
+* XMPP Instant Messaging and Presence: [RFC 3921](https://tools.ietf.org/html/rfc3921),
+[RFC 6121](https://tools.ietf.org/html/rfc6121)
+* Client connections:
+    * over TCP (with TLS/STARTTLS available) as defined in
     [RFC 6120](https://tools.ietf.org/html/rfc6120)
-*   XMPP Instant Messaging and Presence: [RFC 3921](https://tools.ietf.org/html/rfc3921),
-    [RFC 6121](https://tools.ietf.org/html/rfc6121)
-*   Client connections over TCP (with TLS/STARTTLS available), Websockets,
-    and HTTP(S) long-polling (BOSH).
-*   Configurable database backends: MySQL, Postgres, generic ODBC, Riak KV.
-    Mnesia and Redis for transient data.
-*   Supports XEPs:
+    * over WebsSockets as defined in  [RFC 7395](https://tools.ietf.org/html/rfc7395)
+    * over HTTP(S) long-polling (BOSH) as defined in
+    [XEP-0124](http://xmpp.org/extensions/xep-0124.html) and
+    [XEP-0206](http://xmpp.org/extensions/xep-0206.html)
+    * [REST API](../REST-API.md)
+* Configurable database backends: MySQL, Postgres, generic ODBC, Riak KV.
+Mnesia and Redis for transient data.
+* Supports XEPs:
 
 |||||
 | ------------- | ------------- | ------------- |------------- |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ pages:
   - 'MongooseIM open XMPP extensions':
       - 'MUC light': 'open-extensions/muc_light.md'
       - 'Token-based reconnection': 'open-extensions/token-reconnection.md'
+  - 'REST API': 'REST-API.md'
   - 'Modules':
       - 'mod_adhoc': 'modules/mod_adhoc.md'
       - 'mod_admin_extra': 'modules/mod_admin_extra.md'


### PR DESCRIPTION
Proposed changes include:
* dedicate page for client's REST API
* updated `Features and supported standards` page

The relevant readthedocs page is here: http://mongooseim.readthedocs.io/en/connection-methods-and-endpoints-doc/REST-API/

