### PR TITLE
Fix for issue #1036 - Make travis-test.sh usable from the command line

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -29,7 +29,7 @@ done
 source tools/travis-common-vars.sh
 source tools/travis-helpers.sh
 
-if [ $TRAVIS_SECURE_ENV_VARS == 'true' ]; then
+if [ "$TRAVIS_SECURE_ENV_VARS" == 'true' ]; then
   CT_REPORTS=$(ct_reports_dir)
 
   echo "Test results will be uploaded to:"
@@ -39,8 +39,9 @@ fi
 echo "" > /tmp/progress
 tail -f /tmp/progress &
 
-# Kill children
-trap "trap - SIGTERM && kill -- -$$ 2> /dev/null" SIGINT SIGTERM EXIT
+# Kill children on exit, but do not kill self on normal exit
+trap "trap - SIGTERM && kill -- -$$ 2> /dev/null" SIGINT SIGTERM
+trap "trap '' SIGTERM && kill -- -$$ 2> /dev/null" EXIT
 
 echo ${BASE}
 


### PR DESCRIPTION
This PR addresses #1036 

Proposed changes include:
* protect against unset environment variable
* ignore SIGTERM on EXIT trap, so that killing the process group does not kill bash itself
