### PR TITLE
Delete leftover configuration item ejabberd_addr

### DIFF
--- a/test/ejabberd_tests/test.config
+++ b/test/ejabberd_tests/test.config
@@ -11,8 +11,6 @@
 {ejabberd_cookie, ejabberd}.
 %% the main XMPP domain served by the tested ejabberd/MongooseIM
 {ejabberd_domain, <<"localhost">>}.
-%% the server host name or ip addres
-{ejabberd_addr, <<"127.0.0.1">>}.
 {ejabberd_secondary_domain, <<"localhost.bis">>}.
 {ejabberd_reloaded_domain, <<"sogndal">>}.
 {ejabberd_metrics_rest_port, 5288}.


### PR DESCRIPTION
This PR addresses no known tracked issue.

Proposed changes include:
* No functionality changes
* No new or updated tests
* No changes to the documentation

This commit aims at avoiding misleading the reader of the test config re how to target the tests at MongooseIM machine distinct from localhost.
