### PR TITLE
a tiny fix - authorize was trying to update a non-existent metric

### DIFF
--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -608,7 +608,7 @@ auth_modules(LServer) ->
     [list_to_atom("ejabberd_auth_" ++ atom_to_list(M)) || M <- Methods].
 
 ensure_metrics(Host) ->
-    Metrics = [check_password, try_register, does_user_exist],
+    Metrics = [authorize, check_password, try_register, does_user_exist],
     [mongoose_metrics:ensure_metric(Host, ?METRIC(Metric), histogram)
      || Metric <- Metrics].
 


### PR DESCRIPTION
This PR doesn't address any particular issue, it'is just a cleanup - the code tries to update an 'authorize' metric which is not created before.


