### PR TITLE
Fix node name generation in mongooseimctl

### DIFF
--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -155,7 +155,7 @@ ctl ()
 	# concurrent invocations using a bound
 	# number of atoms
 	for N in $(seq 1 $MAXCONNID); do
-	    CTL_CONN="mongooseimctl-$N"
+	    CTL_CONN="mongooseimctl-$N-${NODENAME}"
 	    CTL_LOCKFILE="$CONNLOCKDIR/$CTL_CONN"
 	    (
 		exec 8>"$CTL_LOCKFILE"


### PR DESCRIPTION
The issue manifested with the following crash report:

```
bin/mongooseimctl
2016-11-03 11:24:45 Can't set long node name!
Please check your configuration

2016-11-03 11:24:45 crash_report
    initial_call: {net_kernel,init,['Argument__1']}
    pid: <0.24.0>
    registered_name: []
    error_info: {exit,{error,badarg},[{gen_server,init_it,6,[{file,"gen_server.erl"},{line,344}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
    ancestors: [net_sup,kernel_sup,<0.12.0>]
    messages: []
    links: [<0.21.0>]
    dictionary: [{longnames,true}]
    trap_exit: true
    status: running
    heap_size: 1598
    stack_size: 27
    reductions: 1039
2016-11-03 11:24:45 supervisor_report
    supervisor: {local,net_sup}
    errorContext: start_error
    reason: {'EXIT',nodistribution}
    offender: [{pid,undefined},{id,net_kernel},{mfargs,{net_kernel,start_link,[['mongooseimctl-1',longnames],true]}},{restart_type,permanent},{shutdown,2000},{child_type,worker}]
2016-11-03 11:24:45 supervisor_report
    supervisor: {local,kernel_sup}
    errorContext: start_error
    reason: {shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}
    offender: [{pid,undefined},{id,net_sup},{mfargs,{erl_distribution,start_link,[]}},{restart_type,permanent},{shutdown,infinity},{child_type,supervisor}]
2016-11-03 11:24:45 crash_report
    initial_call: {application_master,init,['Argument__1','Argument__2','Argument__3','Argument__4']}
    pid: <0.11.0>
    registered_name: []
    error_info: {exit,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}},[{application_master,init,4,[{file,"application_master.erl"},{line,134}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
    ancestors: [<0.10.0>]
    messages: [{'EXIT',<0.12.0>,normal}]
    links: [<0.10.0>,<0.9.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 376
    stack_size: 27
    reductions: 153
2016-11-03 11:24:45 std_info
    application: kernel
    exited: {{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}
    type: permanent
{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{kernel,start,[normal,[]]}}}"}

Crash dump is being written to: erl_crash.dump...done
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{{shutdown,{failed_to_start_child,net_sup,{shutdown,{failed_to_start_child,net_kernel,{'EXIT',nodistribution}}}}},{ke
```