### PR TITLE
allow filtering moduels return modified packet in ejabberd_router:rou…

### DIFF
--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -455,13 +455,13 @@ route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
         drop ->
             ?DEBUG("filter dropped packet", []),
             ok;
-        {OrigFrom, OrigTo, OrigPacket} ->
+        {OrigFrom, OrigTo, OrigPacketFiltered} ->
             ?DEBUG("filter passed", []),
-            case catch(M:route(OrigFrom, OrigTo, OrigPacket)) of
+            case catch(M:route(OrigFrom, OrigTo, OrigPacketFiltered)) of
                 {'EXIT', Reason} ->
                     ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
                                [jid:to_binary(OrigFrom), jid:to_binary(OrigTo),
-                                M, Reason, exml:to_binary(OrigPacket),
+                                M, Reason, exml:to_binary(OrigPacketFiltered),
                                 erlang:get_stacktrace()]),
                     ?DEBUG("routing error", []),
                     ok;


### PR DESCRIPTION
This PR addresses https://github.com/esl/MongooseIM/issues/1075

Proposed changes include:
* Change in `ejabberd_router:route/4` function so that it allows filtering modules change the packet and route it further