### PR TITLE
Make privacy list message blocking incoming only

### DIFF
--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -339,6 +339,8 @@ check_packet(_, User, Server,
 
 check_packet_aux(_, message, <<"error">>, _JID, _Subscription, _Groups) ->
     allow;
+check_packet_aux(_, message_out, _Type, _JID, _Subscription, _Groups) ->
+    allow;
 check_packet_aux([], _PType, _Type, _JID, _Subscription, _Groups) ->
     allow;
 check_packet_aux([Item | List], PType, MType, JID, Subscription, Groups) ->
@@ -429,7 +431,8 @@ updated_list(_,
 
 packet_directed_type(Dir, Type) ->
     case {Type, Dir} of
-         {message, _} -> message;
+         {message, out} -> message_out;
+         {message, in} -> message;
          {iq, in} -> iq;
          {presence, in} -> presence_in;
          {presence, out} -> presence_out;

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -394,12 +394,13 @@ block_jid_message(Config) ->
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
 
-        %% now Alice try to send a msg to Bob, whom she had blocked, and gets error
+        %% Blocking only applies to incoming messages, so Alice can still send
+        %% Bob a message
         %% and Bob gets nothing
-        escalus_client:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi, Bobbb!">>)),
-        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
-        timer:sleep(?SLEEP_TIME),
-        escalus_assert:has_no_stanzas(Bob)
+        escalus_client:send(Alice, escalus_stanza:chat_to(
+                                     Bob, <<"Hi, Bobbb!">>)),
+        escalus_assert:is_chat_message(<<"Hi, Bobbb!">>,
+            escalus_client:wait_for_stanza(Bob))
 
         end).
 
@@ -462,9 +463,9 @@ allow_subscription_to_from_message(Config) ->
 
         ct:sleep(?SLEEP_TIME),
         %% they received just rejection msgs
-        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
+        privacy_helper:gets_error(Alice, <<"service-unavailable">>),
         escalus_assert:has_no_stanzas(Alice),
-        privacy_helper:gets_error(Bob, <<"not-acceptable">>),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
         escalus_assert:has_no_stanzas(Bob),
 
         %% Alice subscribes to Bob
@@ -509,12 +510,14 @@ allow_subscription_both_message(Config) ->
 
         %% Bob and Alice cannot sent to each other now
         %% Even though they are in subscription "to" and "from" respectively
-        escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice XYZ!">>)),
-        escalus_client:send(Alice, escalus_stanza:chat_to(bob, <<"Hi, Bob XYZ!">>)),
+        escalus_client:send(Bob, escalus_stanza:chat_to(
+                                   Alice, <<"Hi, Alice XYZ!">>)),
+        escalus_client:send(Alice, escalus_stanza:chat_to(
+                                     bob, <<"Hi, Bob XYZ!">>)),
 
         ct:sleep(?SLEEP_TIME),
-        privacy_helper:gets_error(Alice, <<"not-acceptable">>),
-        privacy_helper:gets_error(Bob, <<"not-acceptable">>),
+        privacy_helper:gets_error(Alice, <<"service-unavailable">>),
+        privacy_helper:gets_error(Bob, <<"service-unavailable">>),
         escalus_assert:has_no_stanzas(Alice),
         escalus_assert:has_no_stanzas(Bob),
 


### PR DESCRIPTION
XEP-0016 s2.9 describes the `<message>` blocking system only in terms of
incoming messages, however the existing implementation also blocks
matching outgoing messages. This change alters the behaviour so that
only incoming messages that match `message` privacy list entries are
blocked.

The reasoning for this is twofold:
* First, it brings the behaviour in to line with that described in the XEP, and
* Second, the previous behaviour precluded any kind of privacy list based asymmetric messaging (eg a follower/followed relationship where messages can only be sent in one direction).