### PR TITLE
Hibernate MUC processes

### DIFF
--- a/apps/ejabberd/include/mod_muc_room.hrl
+++ b/apps/ejabberd/include/mod_muc_room.hrl
@@ -88,7 +88,9 @@
                 room_shaper              :: shaper:shaper(),
                 room_queue = queue:new(),
                 http_auth_pool = none :: none | mongoose_http_client:pool(),
-                http_auth_pids = [] :: [pid()]
+                http_auth_pids = [] :: [pid()],
+                hibernate_timeout = 2000 :: timeout()
+
                }).
 
 -record(muc_online_users, {

--- a/apps/ejabberd/include/mod_muc_room.hrl
+++ b/apps/ejabberd/include/mod_muc_room.hrl
@@ -89,8 +89,7 @@
                 room_queue = queue:new(),
                 http_auth_pool = none :: none | mongoose_http_client:pool(),
                 http_auth_pids = [] :: [pid()],
-                hibernate_timeout = 2000 :: timeout()
-
+                hibernate_timeout = 90000 :: timeout()
                }).
 
 -record(muc_online_users, {

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -141,8 +141,8 @@ start_link(Host, Opts) ->
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
 
--spec start(ejabberd:server(),_) -> {'error',_}
-            | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+-spec start(ejabberd:server(), _) ->
+    {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(Host, Opts) ->
     ensure_metrics(Host),
     start_supervisor(Host),
@@ -1171,7 +1171,7 @@ count_hibernated_rooms(Pid, Count) ->
             Count
     end.
 
--define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}],[value]}).
+-define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}], [value]}).
 ensure_metrics(_Host) ->
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernations], spiral),
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernated_rooms],

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -524,7 +524,8 @@ normal_state({http_auth, AuthPid, Result, From, Nick, Packet, Role}, StateData) 
     StateDataWithoutPid = StateData#state{http_auth_pids = lists:delete(AuthPid, AuthPids)},
     NewStateData = handle_http_auth_result(Result, From, Nick, Packet, Role, StateDataWithoutPid),
     destroy_temporary_room_if_empty(NewStateData, normal_state);
-normal_state(timeout, StateData) ->
+normal_state(timeout, #state{server_host = Host} = StateData) ->
+    mongoose_metrics:update(global, [mod_muc, hibernations], 1),
     {next_state, normal_state, StateData, hibernate};
 normal_state(_Event, StateData) ->
     next_normal_state(StateData).

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -102,6 +102,7 @@
 
 -type statename() :: 'locked_state' | 'normal_state'.
 -type fsm_return() :: {'next_state', statename(), state()}
+                    | {'next_state', statename(), state(), timeout()}
                     | {'stop', any(), state()}.
 
 -type lqueue() :: #lqueue{}.
@@ -244,7 +245,8 @@ can_access_identity(RoomJID, UserJID) ->
 %% @doc A room is created. Depending on request type (MUC/groupchat 1.0) the
 %% next state is determined accordingly (a locked room for MUC or an instant
 %% one for groupchat).
--spec init([any(),...]) -> {'ok',statename(), state()}.
+-spec init([any(), ...]) ->
+    {ok, statename(), state()} | {ok, statename(), state(), timeout()}.
 init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
       Creator, _Nick, DefRoomOpts]) ->
     process_flag(trap_exit, true),

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -258,7 +258,9 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
                                    jid = jid:make(Room, Host, <<>>),
                                    just_created = true,
                                    room_shaper = Shaper,
-                                   http_auth_pool = HttpAuthPool}),
+                                   http_auth_pool = HttpAuthPool,
+                                   hibernate_timeout = read_hibernate_timeout(ServerHost)
+                                  }),
     State1 = set_opts(DefRoomOpts, State),
     ?INFO_MSG("Created MUC room ~s@~s by ~s",
               [Room, Host, jid:to_binary(Creator)]),
@@ -283,10 +285,14 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opt
                                   history = lqueue_new(HistorySize),
                                   jid = jid:make(Room, Host, <<>>),
                                   room_shaper = Shaper,
-                                  http_auth_pool = HttpAuthPool}),
+                                  http_auth_pool = HttpAuthPool,
+                                  hibernate_timeout = read_hibernate_timeout(ServerHost)
+                                 }),
     add_to_log(room_existence, started, State),
     {ok, normal_state, State, State#state.hibernate_timeout}.
 
+read_hibernate_timeout(Host) ->
+    gen_mod:get_module_opt(Host, mod_muc, hibernate_timeout, timer:seconds(90)).
 
 %%----------------------------------------------------------------------
 %% Func: StateName/2

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -677,14 +677,14 @@ handle_info(process_room_queue, normal_state = StateName, StateData) ->
         StateData3 = prepare_room_queue(StateData2),
         process_presence(From, Nick, Packet, StateData3);
     {empty, _} ->
-        {next_state, StateName, StateData}
+            next_normal_state(StateData)
     end;
 handle_info({'EXIT', FromPid, _Reason}, StateName, StateData) ->
     AuthPids = StateData#state.http_auth_pids,
     StateWithoutPid = StateData#state{http_auth_pids = lists:delete(FromPid, AuthPids)},
     destroy_temporary_room_if_empty(StateWithoutPid, StateName);
-handle_info(_Info, StateName, StateData) ->
-    {next_state, StateName, StateData}.
+handle_info(_Info, StateName, #state{hibernate_timeout = Timeout} = StateData) ->
+    {next_state, StateName, StateData, Timeout}.
 
 
 %% @doc Purpose: Shutdown the fsm

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -418,6 +418,8 @@ locked_state({route, From, ToNick,
         _ ->
             locked_error(Call, locked_state, StateData)
     end;
+locked_state(timeout, StateData) ->
+    {next_state, locked_state, StateData};
 locked_state(Call, StateData) ->
     locked_error(Call, locked_state, StateData).
 

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -20,6 +20,7 @@ This module implements [XEP-0045: Multi-User Chat)](http://xmpp.org/extensions/x
 * `user_presence_shaper` (atom, default: `none`): Shaper for user presences processed by a room (global for the room).
 * `max_user_conferences` (non-negative, default: 10): Specifies the number of rooms that a user can occupy simultaneously.
 * `http_auth_pool` (atom, default: `none`): If an external HTTP service is chosen to check passwords for password-protected rooms, this option specifies the HTTP pool name to use (see [External HTTP Authentication](#external-http-authentication) below).
+* `hibernate_timeout` (timeout, default: `90000`): Timeout (in milliseconds) defining the inactivity period after which the room's process should be hibernated.
 * `default_room_options` (list of key-value tuples, default: `[]`): List of room configuration options to be overridden in initial state.
     * `title` (binary, default: `<<>>`): Room title, short free text.
     * `description` (binary, default: `<<>>`): Room description, long free text.

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3836,7 +3836,8 @@ hibernation_metrics_are_updated(Config) ->
 
         OnlineRooms = escalus_ejabberd:rpc(mod_muc, online_rooms_number, []),
         true = OnlineRooms > 0,
-        Hibernations = escalus_ejabberd:rpc(mongoose_metrics, get_metric_value, [global, [mod_muc, hibernations]]),
+        Hibernations = escalus_ejabberd:rpc(mongoose_metrics, get_metric_value,
+                                            [global, [mod_muc, hibernations]]),
         {ok, [{count, HibernationsCnt}, {one, _}]} = Hibernations,
         true = HibernationsCnt > 0,
         HibernatedRooms = escalus_ejabberd:rpc(mod_muc, hibernated_rooms_number, []),
@@ -3857,7 +3858,8 @@ room_with_participants_and_messages_is_hibernated(Config) ->
 hibernated_room_can_be_queried_for_archive(Config) ->
     RoomName = fresh_room_name(),
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        {Msg, {ok, _, Pid}} = given_fresh_room_with_messages_is_hibernated(Alice, RoomName, [], Bob),
+        Result = given_fresh_room_with_messages_is_hibernated(Alice, RoomName, [], Bob),
+        {Msg, {ok, _, Pid}} = Result,
         Props = [{mam_ns, mam_helper:mam_ns_binary_v04()},
                  {data_form, true}],
         QueryStanza = mam_helper:stanza_archive_request(Props, <<"q1">>),
@@ -3884,8 +3886,10 @@ given_fresh_room_for_user(Owner, RoomName, Opts) ->
     Username = escalus_client:username(Owner),
     Server = escalus_client:server(Owner),
     Resource = escalus_client:resource(Owner),
-    JID = {jid, Username, Server, Resource, escalus_utils:jid_to_lower(Username), Server, Resource},
-    RoomJID = {jid, RoomName, muc_host(), <<>>, escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
+    JID = {jid, Username, Server, Resource,
+           escalus_utils:jid_to_lower(Username), Server, Resource},
+    RoomJID = {jid, RoomName, muc_host(), <<>>,
+               escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
     Nick = <<"a-nick">>,
     ok =  create_instant_room(domain(), RoomName, JID, Nick, Opts),
     JoinRoom = stanza_join_room(RoomName, <<"a-nick">>),

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3786,20 +3786,21 @@ deny_creation_of_http_password_protected_room_service_unavailable(Config) ->
 room_is_hibernated(Config) ->
     RoomName = fresh_room_name(),
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        Username = escalus_client:username(Alice),
-        Server = escalus_client:server(Alice),
-        Resource = escalus_client:resource(Alice),
-        JID = {jid, Username, Server, Resource, escalus_utils:jid_to_lower(Username), Server, Resource},
-        RoomJID = {jid, RoomName, muc_host(), <<>>, escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
-        Nick = <<"a-nick">>,
-        ok =  create_instant_room(domain(), RoomName, JID, Nick, []),
-        {ok, RoomPid} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
-        true = wait_for_hibernation(RoomPid, 10),
-
-        ok
+        {ok, RoomPid} = given_fresh_room_for_user(Alice, RoomName, []),
+        true = wait_for_hibernation(RoomPid, 10)
     end),
 
     destroy_room(muc_host(), RoomName).
+
+given_fresh_room_for_user(Owner, RoomName, Opts) ->
+    Username = escalus_client:username(Owner),
+    Server = escalus_client:server(Owner),
+    Resource = escalus_client:resource(Owner),
+    JID = {jid, Username, Server, Resource, escalus_utils:jid_to_lower(Username), Server, Resource},
+    RoomJID = {jid, RoomName, muc_host(), <<>>, escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
+    Nick = <<"a-nick">>,
+    ok =  create_instant_room(domain(), RoomName, JID, Nick, Opts),
+    escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]).
 
 wait_for_hibernation(Pid, 0) ->
     is_hibernated(Pid);

--- a/test/ejabberd_tests/tests/muc_helper.erl
+++ b/test/ejabberd_tests/tests/muc_helper.erl
@@ -42,12 +42,12 @@ foreach_recipient(Users, VerifyFun) ->
 
 load_muc(Host) ->
     dynamic_modules:start(<<"localhost">>, mod_muc,
-        [{host, binary_to_list(Host)},
-            {access, muc},
-            {access_create, muc_create}]),
+                          [{host, binary_to_list(Host)},
+                           {access, muc},
+                           {access_create, muc_create}]),
     dynamic_modules:start(<<"localhost">>, mod_muc_log,
-        [{outdir, "/tmp/muclogs"},
-            {access_log, muc}]).
+                          [{outdir, "/tmp/muclogs"},
+                           {access_log, muc}]).
 
 unload_muc() ->
     dynamic_modules:stop(<<"localhost">>, mod_muc),

--- a/test/ejabberd_tests/tests/muc_helper.erl
+++ b/test/ejabberd_tests/tests/muc_helper.erl
@@ -43,6 +43,7 @@ foreach_recipient(Users, VerifyFun) ->
 load_muc(Host) ->
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},
+                           {hibernate_timeout, 2000},
                            {access, muc},
                            {access_create, muc_create}]),
     dynamic_modules:start(<<"localhost">>, mod_muc_log,


### PR DESCRIPTION
This PR hibernates the MUC process after configurable period of inactivity. This is very similar to what we already have for c2s process.

The timeout is configurable and default value is 90s.