### PR TITLE
Stop hibernated room

### DIFF
--- a/apps/ejabberd/include/mod_muc_room.hrl
+++ b/apps/ejabberd/include/mod_muc_room.hrl
@@ -88,7 +88,9 @@
                 room_shaper              :: shaper:shaper(),
                 room_queue = queue:new(),
                 http_auth_pool = none :: none | mongoose_http_client:pool(),
-                http_auth_pids = [] :: [pid()]
+                http_auth_pids = [] :: [pid()],
+                hibernate_timeout = 2000 :: timeout()
+
                }).
 
 -record(muc_online_users, {

--- a/apps/ejabberd/include/mod_muc_room.hrl
+++ b/apps/ejabberd/include/mod_muc_room.hrl
@@ -21,9 +21,6 @@
 
 -define(MAX_USERS_DEFAULT, 200).
 
--define(SETS, gb_sets).
--define(DICT, dict).
-
 -record(lqueue, {queue,
                  len :: non_neg_integer(),
                  max :: non_neg_integer()
@@ -76,10 +73,10 @@
                 access              :: mod_muc:access(),
                 jid                 :: ejabberd:jid(),
                 config = #config{}  :: mod_muc_room:config(),
-                users = ?DICT:new(),
-                sessions = ?DICT:new(),
-                robots = ?DICT:new(),
-                affiliations = ?DICT:new(),
+                users = dict:new(),
+                sessions = dict:new(),
+                robots = dict:new(),
+                affiliations = dict:new(),
                 history,
                 subject = <<>>,
                 subject_author = <<>>,

--- a/apps/ejabberd/include/mod_muc_room.hrl
+++ b/apps/ejabberd/include/mod_muc_room.hrl
@@ -89,8 +89,7 @@
                 room_queue = queue:new(),
                 http_auth_pool = none :: none | mongoose_http_client:pool(),
                 http_auth_pids = [] :: [pid()],
-                hibernate_timeout = 2000 :: timeout()
-
+                hibernate_timeout = 90000 :: timeout()
                }).
 
 -record(muc_online_users, {

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -49,6 +49,8 @@
          room_process_mam_iq/3,
          forget_room/2]).
 
+-export([server_host/1]).
+
 %% private
 -export([archive_message/8]).
 -export([lookup_messages/13]).

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -1241,6 +1241,8 @@ count_hibernated_rooms(Pid, Count) ->
 
 -define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}], [value]}).
 ensure_metrics(_Host) ->
+    mongoose_metrics:ensure_metric(global, [mod_muc, deep_hibernations], spiral),
+    mongoose_metrics:ensure_metric(global, [mod_muc, process_recreations], spiral),
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernations], spiral),
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernated_rooms],
                                    {function, mod_muc, hibernated_rooms_number, [],

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -529,8 +529,7 @@ route_to_room(Room, {From,To,Packet} = Routed, #state{host=Host} = State) ->
 
 
 -spec route_to_nonexistent_room(room(), from_to_packet(), state()) -> 'ok'.
-route_to_nonexistent_room(Room, {From, To, Packet},
-                          #state{host = Host} = State) ->
+route_to_nonexistent_room(Room, {From, To, Packet}, State) ->
     #xmlel{name = Name, attrs = Attrs} = Packet,
     Type = xml:get_attr_s(<<"type">>, Attrs),
     case {Name, Type} of
@@ -593,7 +592,7 @@ route_packet_to_nonexistent_room(Room, From, To, Packet,
     end.
 
 -spec route_by_nick(room(), from_to_packet(), state()) -> 'ok' | pid().
-route_by_nick(<<>>, {_,_,Packet} = Routed, State) ->
+route_by_nick(<<>>, {_, _, Packet} = Routed, State) ->
     #xmlel{name = Name} = Packet,
     route_by_type(Name, Routed, State);
 route_by_nick(_Nick, {From, To, Packet}, _State) ->

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -141,8 +141,8 @@ start_link(Host, Opts) ->
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
 
--spec start(ejabberd:server(),_) -> {'error',_}
-            | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+-spec start(ejabberd:server(), _) ->
+    {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(Host, Opts) ->
     ensure_metrics(Host),
     start_supervisor(Host),
@@ -1171,7 +1171,7 @@ count_hibernated_rooms(Pid, Count) ->
             Count
     end.
 
--define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}],[value]}).
+-define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}], [value]}).
 ensure_metrics(_Host) ->
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernations], spiral),
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernated_rooms],

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -292,6 +292,7 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opt
                                   hibernate_timeout = read_hibernate_timeout(ServerHost)
                                  }),
     add_to_log(room_existence, started, State),
+    mongoose_metrics:update(global, [mod_muc, process_recreations], 1),
     {ok, normal_state, State, State#state.hibernate_timeout}.
 
 read_hibernate_timeout(Host) ->
@@ -715,6 +716,7 @@ stop_if_only_owner_is_online(_, _, State) ->
 
 do_stop_persistent_room(RoomName, State) ->
     ?INFO_MSG("Stopping persistent room's process, ~p ~p", [self(), RoomName]),
+    mongoose_metrics:update(global, [mod_muc, deep_hibernations], 1),
     {stop, normal, State}.
 
 %% @doc Purpose: Shutdown the fsm

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -524,7 +524,8 @@ normal_state({http_auth, AuthPid, Result, From, Nick, Packet, Role}, StateData) 
     StateDataWithoutPid = StateData#state{http_auth_pids = lists:delete(AuthPid, AuthPids)},
     NewStateData = handle_http_auth_result(Result, From, Nick, Packet, Role, StateDataWithoutPid),
     destroy_temporary_room_if_empty(NewStateData, normal_state);
-normal_state(timeout, StateData) ->
+normal_state(timeout, #state{server_host = Host} = StateData) ->
+    mongoose_metrics:update(global, [mod_muc, hibernations], 1),
     {next_state, normal_state, StateData, hibernate};
 normal_state(_Event, StateData) ->
     next_normal_state(StateData).

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -102,6 +102,7 @@
 
 -type statename() :: 'locked_state' | 'normal_state'.
 -type fsm_return() :: {'next_state', statename(), state()}
+                    | {'next_state', statename(), state(), timeout()}
                     | {'stop', any(), state()}.
 
 -type lqueue() :: #lqueue{}.
@@ -244,7 +245,8 @@ can_access_identity(RoomJID, UserJID) ->
 %% @doc A room is created. Depending on request type (MUC/groupchat 1.0) the
 %% next state is determined accordingly (a locked room for MUC or an instant
 %% one for groupchat).
--spec init([any(),...]) -> {'ok',statename(), state()}.
+-spec init([any(), ...]) ->
+    {ok, statename(), state()} | {ok, statename(), state(), timeout()}.
 init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
       Creator, _Nick, DefRoomOpts]) ->
     process_flag(trap_exit, true),

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -102,7 +102,7 @@
 
 -type statename() :: 'locked_state' | 'normal_state'.
 -type fsm_return() :: {'next_state', statename(), state()}
-                    | {'next_state', statename(), state(), timeout()}
+                    | {'next_state', statename(), state(), timeout() | hibernate}
                     | {'stop', any(), state()}.
 
 -type lqueue() :: #lqueue{}.

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -258,7 +258,9 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
                                    jid = jid:make(Room, Host, <<>>),
                                    just_created = true,
                                    room_shaper = Shaper,
-                                   http_auth_pool = HttpAuthPool}),
+                                   http_auth_pool = HttpAuthPool,
+                                   hibernate_timeout = read_hibernate_timeout(ServerHost)
+                                  }),
     State1 = set_opts(DefRoomOpts, State),
     ?INFO_MSG("Created MUC room ~s@~s by ~s",
               [Room, Host, jid:to_binary(Creator)]),
@@ -283,10 +285,14 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opt
                                   history = lqueue_new(HistorySize),
                                   jid = jid:make(Room, Host, <<>>),
                                   room_shaper = Shaper,
-                                  http_auth_pool = HttpAuthPool}),
+                                  http_auth_pool = HttpAuthPool,
+                                  hibernate_timeout = read_hibernate_timeout(ServerHost)
+                                 }),
     add_to_log(room_existence, started, State),
     {ok, normal_state, State, State#state.hibernate_timeout}.
 
+read_hibernate_timeout(Host) ->
+    gen_mod:get_module_opt(Host, mod_muc, hibernate_timeout, timer:seconds(90)).
 
 %%----------------------------------------------------------------------
 %% Func: StateName/2

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -677,14 +677,14 @@ handle_info(process_room_queue, normal_state = StateName, StateData) ->
         StateData3 = prepare_room_queue(StateData2),
         process_presence(From, Nick, Packet, StateData3);
     {empty, _} ->
-        {next_state, StateName, StateData}
+            next_normal_state(StateData)
     end;
 handle_info({'EXIT', FromPid, _Reason}, StateName, StateData) ->
     AuthPids = StateData#state.http_auth_pids,
     StateWithoutPid = StateData#state{http_auth_pids = lists:delete(FromPid, AuthPids)},
     destroy_temporary_room_if_empty(StateWithoutPid, StateName);
-handle_info(_Info, StateName, StateData) ->
-    {next_state, StateName, StateData}.
+handle_info(_Info, StateName, #state{hibernate_timeout = Timeout} = StateData) ->
+    {next_state, StateName, StateData, Timeout}.
 
 
 %% @doc Purpose: Shutdown the fsm

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -418,6 +418,8 @@ locked_state({route, From, ToNick,
         _ ->
             locked_error(Call, locked_state, StateData)
     end;
+locked_state(timeout, StateData) ->
+    {next_state, locked_state, StateData};
 locked_state(Call, StateData) ->
     locked_error(Call, locked_state, StateData).
 

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -20,6 +20,7 @@ This module implements [XEP-0045: Multi-User Chat)](http://xmpp.org/extensions/x
 * `user_presence_shaper` (atom, default: `none`): Shaper for user presences processed by a room (global for the room).
 * `max_user_conferences` (non-negative, default: 10): Specifies the number of rooms that a user can occupy simultaneously.
 * `http_auth_pool` (atom, default: `none`): If an external HTTP service is chosen to check passwords for password-protected rooms, this option specifies the HTTP pool name to use (see [External HTTP Authentication](#external-http-authentication) below).
+* `hibernate_timeout` (timeout, default: `90000`): Timeout (in milliseconds) defining the inactivity period after which the room's process should be hibernated.
 * `default_room_options` (list of key-value tuples, default: `[]`): List of room configuration options to be overridden in initial state.
     * `title` (binary, default: `<<>>`): Room title, short free text.
     * `description` (binary, default: `<<>>`): Room description, long free text.

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -21,6 +21,8 @@ This module implements [XEP-0045: Multi-User Chat)](http://xmpp.org/extensions/x
 * `max_user_conferences` (non-negative, default: 10): Specifies the number of rooms that a user can occupy simultaneously.
 * `http_auth_pool` (atom, default: `none`): If an external HTTP service is chosen to check passwords for password-protected rooms, this option specifies the HTTP pool name to use (see [External HTTP Authentication](#external-http-authentication) below).
 * `hibernate_timeout` (timeout, default: `90000`): Timeout (in milliseconds) defining the inactivity period after which the room's process should be hibernated.
+* `hibernated_room_check_interval` (timeout, default: `infinity`): Interval defining how often hibernated rooms will be checked.
+* `hibernated_room_timeout` (timeout, default: `inifitniy`): A time after which a hibernated room is stopped (deeply hibernated). See [MUC performance optimisation]().
 * `default_room_options` (list of key-value tuples, default: `[]`): List of room configuration options to be overridden in initial state.
     * `title` (binary, default: `<<>>`): Room title, short free text.
     * `description` (binary, default: `<<>>`): Room description, long free text.
@@ -51,6 +53,29 @@ This module implements [XEP-0045: Multi-User Chat)](http://xmpp.org/extensions/x
              {access_create, muc_create}
             ]},
 ```
+
+### Performance optimisations
+
+In large installation with many rooms there might be issues with memory consumption.
+Each room is represented by erlang process with it's own state which can be big.
+In MongooseIM there 2 levels for MUC rooms memory optimisations.
+
+#### Room's process hibernation
+
+By default the room's process is hibernated by the Erlang VM after 90s since last activity.
+This timeout can be modified by `hibernate_timeout` option.
+
+#### Room deep hibernation
+
+In addition to the process hibernation there is also room's deep hibernation.
+This optimisation works only for persistent rooms as only such rooms can be restored on demand.
+The improvement works as follows:
+1. Every `hibernated_room_check_interval` all room processes are traversed.
+1. If a process is hibernated for longer time then `hibernated_room_timeout` a "stop" signal is sent to it.
+1. The room's process can be stopped only if there is no online users or the only one is its owner.
+In case the owner is online, a presence with type unavailable is sent to it indicating that the room's process is being terminated.
+
+In future the room's process can be recreated on demand, for example when there is presence sent to it, or owner wants to add more users to the room.
 
 ### External HTTP Authentication
 

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3903,6 +3903,8 @@ hibernated_room_is_stopped_and_restored_by_presence(Config) ->
 
         escalus:send(Bob, JoinRoom),
         escalus:wait_for_stanza(Bob),
+        Message = escalus:wait_for_stanza(Bob),
+        true = is_subject_message(Message, <<"Restorable">>),
 
         {ok, _Pid2} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
         ok

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3836,7 +3836,8 @@ hibernation_metrics_are_updated(Config) ->
 
         OnlineRooms = escalus_ejabberd:rpc(mod_muc, online_rooms_number, []),
         true = OnlineRooms > 0,
-        Hibernations = escalus_ejabberd:rpc(mongoose_metrics, get_metric_value, [global, [mod_muc, hibernations]]),
+        Hibernations = escalus_ejabberd:rpc(mongoose_metrics, get_metric_value,
+                                            [global, [mod_muc, hibernations]]),
         {ok, [{count, HibernationsCnt}, {one, _}]} = Hibernations,
         true = HibernationsCnt > 0,
         HibernatedRooms = escalus_ejabberd:rpc(mod_muc, hibernated_rooms_number, []),
@@ -3857,7 +3858,8 @@ room_with_participants_and_messages_is_hibernated(Config) ->
 hibernated_room_can_be_queried_for_archive(Config) ->
     RoomName = fresh_room_name(),
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        {Msg, {ok, _, Pid}} = given_fresh_room_with_messages_is_hibernated(Alice, RoomName, [], Bob),
+        Result = given_fresh_room_with_messages_is_hibernated(Alice, RoomName, [], Bob),
+        {Msg, {ok, _, Pid}} = Result,
         Props = [{mam_ns, mam_helper:mam_ns_binary_v04()},
                  {data_form, true}],
         QueryStanza = mam_helper:stanza_archive_request(Props, <<"q1">>),
@@ -3884,8 +3886,10 @@ given_fresh_room_for_user(Owner, RoomName, Opts) ->
     Username = escalus_client:username(Owner),
     Server = escalus_client:server(Owner),
     Resource = escalus_client:resource(Owner),
-    JID = {jid, Username, Server, Resource, escalus_utils:jid_to_lower(Username), Server, Resource},
-    RoomJID = {jid, RoomName, muc_host(), <<>>, escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
+    JID = {jid, Username, Server, Resource,
+           escalus_utils:jid_to_lower(Username), Server, Resource},
+    RoomJID = {jid, RoomName, muc_host(), <<>>,
+               escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
     Nick = <<"a-nick">>,
     ok =  create_instant_room(domain(), RoomName, JID, Nick, Opts),
     JoinRoom = stanza_join_room(RoomName, <<"a-nick">>),

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -83,7 +83,7 @@ all() -> [
         {group, room_management},
         {group, http_auth_no_server},
         {group, http_auth},
-          {group, hibernation}
+        {group, hibernation}
         ].
 
 groups() -> [

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -91,7 +91,8 @@ groups() -> [
                                         room_with_participants_is_hibernated,
                                         hibernation_metrics_are_updated,
                                         room_with_participants_and_messages_is_hibernated,
-                                        hibernated_room_can_be_queried_for_archive]},
+                                        hibernated_room_can_be_queried_for_archive,
+                                        hibernated_room_is_stopped]},
         {disco, [parallel], [
                 disco_service,
                 disco_features,
@@ -3873,6 +3874,15 @@ hibernated_room_can_be_queried_for_archive(Config) ->
         escalus:wait_for_stanza(Bob),
         true = wait_for_hibernation(Pid, 10)
 
+    end),
+
+    destroy_room(muc_host(), RoomName).
+
+hibernated_room_is_stopped(Config) ->
+    RoomName = fresh_room_name(),
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        {ok, Pid} = given_fresh_room_is_hibernated(Alice, RoomName, [{persistent, true}]),
+        true = wait_for_room_to_be_stopped(Pid, timer:seconds(5))
     end),
 
     destroy_room(muc_host(), RoomName).

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3786,20 +3786,21 @@ deny_creation_of_http_password_protected_room_service_unavailable(Config) ->
 room_is_hibernated(Config) ->
     RoomName = fresh_room_name(),
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        Username = escalus_client:username(Alice),
-        Server = escalus_client:server(Alice),
-        Resource = escalus_client:resource(Alice),
-        JID = {jid, Username, Server, Resource, escalus_utils:jid_to_lower(Username), Server, Resource},
-        RoomJID = {jid, RoomName, muc_host(), <<>>, escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
-        Nick = <<"a-nick">>,
-        ok =  create_instant_room(domain(), RoomName, JID, Nick, []),
-        {ok, RoomPid} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
-        true = wait_for_hibernation(RoomPid, 10),
-
-        ok
+        {ok, RoomPid} = given_fresh_room_for_user(Alice, RoomName, []),
+        true = wait_for_hibernation(RoomPid, 10)
     end),
 
     destroy_room(muc_host(), RoomName).
+
+given_fresh_room_for_user(Owner, RoomName, Opts) ->
+    Username = escalus_client:username(Owner),
+    Server = escalus_client:server(Owner),
+    Resource = escalus_client:resource(Owner),
+    JID = {jid, Username, Server, Resource, escalus_utils:jid_to_lower(Username), Server, Resource},
+    RoomJID = {jid, RoomName, muc_host(), <<>>, escalus_utils:jid_to_lower(RoomName), muc_host(), <<>>},
+    Nick = <<"a-nick">>,
+    ok =  create_instant_room(domain(), RoomName, JID, Nick, Opts),
+    escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]).
 
 wait_for_hibernation(Pid, 0) ->
     is_hibernated(Pid);

--- a/test/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_SUITE.erl
@@ -3949,7 +3949,8 @@ stopped_members_only_room_process_invitations_correctly(Config) ->
 
         true = wait_for_room_to_be_stopped(Pid, timer:seconds(8)),
 
-        Stanza2 = stanza_set_affiliations(RoomName, [{escalus_client:short_jid(Kate), <<"member">>}]),
+        Stanza2 = stanza_set_affiliations(RoomName,
+                                          [{escalus_client:short_jid(Kate), <<"member">>}]),
         escalus:send(Alice, Stanza2),
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
         is_invitation(escalus:wait_for_stanza(Kate)),
@@ -3979,7 +3980,7 @@ room_with_only_owner_is_stopped(Config) ->
         true = wait_for_room_to_be_stopped(Pid, timer:seconds(8)),
 
         Unavailable = escalus:wait_for_stanza(Alice),
-	    escalus:assert(is_presence_with_type, [<<"unavailable">>], Unavailable)
+        escalus:assert(is_presence_with_type, [<<"unavailable">>], Unavailable)
     end),
 
     destroy_room(muc_host(), RoomName),
@@ -3995,7 +3996,7 @@ deep_hibernation_metrics_are_updated(Config) ->
         true = DeepHibernations > 0,
 
         Unavailable = escalus:wait_for_stanza(Alice),
-	    escalus:assert(is_presence_with_type, [<<"unavailable">>], Unavailable),
+        escalus:assert(is_presence_with_type, [<<"unavailable">>], Unavailable),
 
         escalus:send(Bob, stanza_join_room(RoomName, <<"bob">>)),
         escalus:wait_for_stanzas(Bob, 2),
@@ -4040,7 +4041,7 @@ maybe_configure(Owner, RoomName, Opts) ->
 
     Result = escalus:wait_for_stanza(Owner),
     escalus:assert(is_iq_result, Result),
-    escalus:assert(is_stanza_from, [<<RoomName/binary,"@muc.localhost">>], Result).
+    escalus:assert(is_stanza_from, [<<RoomName/binary, "@muc.localhost">>], Result).
 
 opt_to_room_config({Name, Value}) when is_atom(Value) ->
     NameBin = atom_to_binary(Name, utf8),

--- a/test/ejabberd_tests/tests/muc_helper.erl
+++ b/test/ejabberd_tests/tests/muc_helper.erl
@@ -42,12 +42,12 @@ foreach_recipient(Users, VerifyFun) ->
 
 load_muc(Host) ->
     dynamic_modules:start(<<"localhost">>, mod_muc,
-        [{host, binary_to_list(Host)},
-            {access, muc},
-            {access_create, muc_create}]),
+                          [{host, binary_to_list(Host)},
+                           {access, muc},
+                           {access_create, muc_create}]),
     dynamic_modules:start(<<"localhost">>, mod_muc_log,
-        [{outdir, "/tmp/muclogs"},
-            {access_log, muc}]).
+                          [{outdir, "/tmp/muclogs"},
+                           {access_log, muc}]).
 
 unload_muc() ->
     dynamic_modules:stop(<<"localhost">>, mod_muc),

--- a/test/ejabberd_tests/tests/muc_helper.erl
+++ b/test/ejabberd_tests/tests/muc_helper.erl
@@ -43,6 +43,7 @@ foreach_recipient(Users, VerifyFun) ->
 load_muc(Host) ->
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},
+                           {hibernate_timeout, 2000},
                            {access, muc},
                            {access_create, muc_create}]),
     dynamic_modules:start(<<"localhost">>, mod_muc_log,

--- a/test/ejabberd_tests/tests/muc_helper.erl
+++ b/test/ejabberd_tests/tests/muc_helper.erl
@@ -44,6 +44,8 @@ load_muc(Host) ->
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},
                            {hibernate_timeout, 2000},
+                           {hibernated_room_check_interval, 1000},
+                           {hibernated_room_timeout, 2000},
                            {access, muc},
                            {access_create, muc_create}]),
     dynamic_modules:start(<<"localhost">>, mod_muc_log,


### PR DESCRIPTION
This PR introduces deep hibernation of room's process.
The optimisation works only for persistent rooms for which the process can be stopped and recreated later on demand.

Goes on top of #1086
