### PR TITLE
Remove escalus warnings in privacy_SUITE

### DIFF
--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -219,8 +219,8 @@ get_existing_list(Config) ->
         Response = escalus:wait_for_stanza(Alice),
 
         <<"deny_client">> = exml_query:path(Response, [{element, <<"query">>},
-                                                    {element, <<"list">>},
-                                                    {attr, <<"name">>}])
+                                                       {element, <<"list">>},
+                                                       {attr, <<"name">>}])
 
         end).
 
@@ -358,7 +358,7 @@ remove_list(Config) ->
 
         %% Request list deletion by sending an empty list.
         RemoveRequest = escalus_stanza:privacy_set_list(
-                escalus_stanza:privacy_list(<<"someList">>, [])),
+                          escalus_stanza:privacy_list(<<"someList">>, [])),
         escalus_client:send(Alice, RemoveRequest),
 
         %% These too are the pushed notification and iq result.
@@ -400,7 +400,7 @@ block_jid_message(Config) ->
         escalus_client:send(Alice, escalus_stanza:chat_to(
                                      Bob, <<"Hi, Bobbb!">>)),
         escalus_assert:is_chat_message(<<"Hi, Bobbb!">>,
-            escalus_client:wait_for_stanza(Bob))
+                                       escalus_client:wait_for_stanza(Bob))
 
         end).
 
@@ -435,9 +435,9 @@ block_subscription_message(Config) ->
             escalus_client:wait_for_stanza(Alice)),
 
         %% Alice sends unsubscribe
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(Bob),
-                <<"unsubscribe">>)),
+        Stanza = escalus_stanza:presence_direct(escalus_utils:get_short_jid(Bob),
+                                                <<"unsubscribe">>),
+        escalus_client:send(Alice, Stanza),
 
         %% set the list on server and make it active
         privacy_helper:set_and_activate(Alice, <<"deny_unsubscribed_message">>),
@@ -470,16 +470,16 @@ allow_subscription_to_from_message(Config) ->
         escalus_assert:has_no_stanzas(Bob),
 
         %% Alice subscribes to Bob
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(Bob),
-                <<"subscribe">>)),
+        SubStanza = escalus_stanza:presence_direct(escalus_utils:get_short_jid(Bob),
+                                                   <<"subscribe">>),
+        escalus_client:send(Alice, SubStanza),
         escalus_client:wait_for_stanza(Alice),
         escalus_client:wait_for_stanza(Bob),
 
+        SubConfirmStanza = escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
+                                                          <<"subscribed">>),
         %% Bob accepts Alice
-        escalus_client:send(Bob,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
-                <<"subscribed">>)),
+        escalus_client:send(Bob, SubConfirmStanza),
         escalus_client:wait_for_stanza(Bob),
         escalus_client:wait_for_stanzas(Alice, 3),
 
@@ -488,11 +488,11 @@ allow_subscription_to_from_message(Config) ->
 
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice XYZ!">>)),
         escalus_assert:is_chat_message(<<"Hi, Alice XYZ!">>,
-            escalus_client:wait_for_stanza(Alice)),
+                                       escalus_client:wait_for_stanza(Alice)),
 
         escalus_client:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi, Bob XYZ!">>)),
         escalus_assert:is_chat_message(<<"Hi, Bob XYZ!">>,
-            escalus_client:wait_for_stanza(Bob))
+                                       escalus_client:wait_for_stanza(Bob))
 
     end).
 
@@ -528,27 +528,27 @@ allow_subscription_both_message(Config) ->
         escalus_assert:has_no_stanzas(Bob),
 
         %% Alice subscribes to Bob
-        escalus_client:send(Bob,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
-                <<"subscribe">>)),
+        SubStanza = escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
+                                                   <<"subscribe">>),
+        escalus_client:send(Bob, SubStanza),
         escalus_client:wait_for_stanza(Alice),
         escalus_client:wait_for_stanza(Bob),
 
         %% Bob accepts Alice
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(BobBareJID,
-                <<"subscribed">>)),
+        SubConfirmStanza = escalus_stanza:presence_direct(BobBareJID,
+                                                          <<"subscribed">>),
+        escalus_client:send(Alice, SubConfirmStanza),
         escalus_client:wait_for_stanzas(Alice, 2),
         escalus_client:wait_for_stanzas(Bob, 3),
 
         %% Now their subscription is in state "both"
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice XYZ!">>)),
         escalus_assert:is_chat_message(<<"Hi, Alice XYZ!">>,
-            escalus_client:wait_for_stanza(Alice)),
+                                       escalus_client:wait_for_stanza(Alice)),
 
         escalus_client:send(Alice, escalus_stanza:chat_to(BobBareJID, <<"Hi, Bob XYZ! 2">>)),
         escalus_assert:is_chat_message(<<"Hi, Bob XYZ! 2">>,
-            escalus_client:wait_for_stanza(Bob))
+                                       escalus_client:wait_for_stanza(Bob))
 
     end).
 
@@ -558,7 +558,7 @@ block_all_message(Config) ->
         %% Alice should receive message
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi!">>)),
         escalus_assert:is_chat_message(<<"Hi!">>,
-            escalus_client:wait_for_stanza(Alice)),
+                                       escalus_client:wait_for_stanza(Alice)),
 
         %% set the list on server and make it active
         privacy_helper:set_and_activate(Alice, <<"deny_all_message">>),
@@ -575,9 +575,9 @@ block_jid_presence_in(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
         %% Alice should receive presence in
-        escalus_client:send(Bob,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(alice),
-                <<"available">>)),
+        Presence1 =  escalus_stanza:presence_direct(escalus_utils:get_short_jid(alice),
+                                                    <<"available">>),
+        escalus_client:send(Bob, Presence1),
         Received = escalus_client:wait_for_stanza(Alice),
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Bob, Received),
@@ -585,9 +585,9 @@ block_jid_presence_in(Config) ->
         privacy_helper:set_and_activate(Alice, {<<"deny_client_presence_in">>, Bob}),
 
         %% Alice should NOT receive presence in
-        escalus_client:send(Bob,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
-                <<"available">>)),
+        Presence2 = escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
+                                                   <<"available">>),
+        escalus_client:send(Bob, Presence2),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Alice),
         %% and Bob should NOT receive any response
@@ -602,9 +602,9 @@ block_jid_presence_out(Config) ->
         BobBareJID = escalus_utils:get_short_jid(Bob),
 
         %% Bob should receive presence in
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(BobBareJID,
-                <<"available">>)),
+        Presence1 = escalus_stanza:presence_direct(BobBareJID, <<"available">>),
+        escalus_client:send(Alice, Presence1),
+
         Received = escalus_client:wait_for_stanza(Bob),
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Alice, Received),
@@ -612,12 +612,12 @@ block_jid_presence_out(Config) ->
         privacy_helper:set_and_activate(Alice, {<<"deny_client_presence_out">>, Bob}),
 
         %% Bob should NOT receive presence in
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(BobBareJID, <<"available">>)),
+        Presence2 = escalus_stanza:presence_direct(BobBareJID, <<"available">>),
+        escalus_client:send(Alice, Presence2),
 
         %% Alice gets an error back from mod_privacy
-        Presence = escalus_client:wait_for_stanza(Alice),
-        escalus:assert(is_presence_with_type, [<<"error">>], Presence),
+        ErrorPresence = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_presence_with_type, [<<"error">>], ErrorPresence),
 
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Bob)
@@ -635,9 +635,10 @@ block_jid_iq(Config) ->
 
         privacy_helper:set_list(Alice, <<"deny_localhost_iq">>),
         %% activate it
-        escalus_client:send(Alice,
-            escalus_stanza:privacy_activate(<<"deny_localhost_iq">>)),
+        Stanza = escalus_stanza:privacy_activate(<<"deny_localhost_iq">>),
+        escalus_client:send(Alice, Stanza),
         timer:sleep(500), %% we must let it sink in
+
         %% bob queries for version and gets an error, Alice doesn't receive the query
         escalus_client:send(Bob, version_iq(<<"get">>, Bob, Alice)),
         timer:sleep(?SLEEP_TIME),
@@ -662,8 +663,9 @@ block_jid_all(Config) ->
         privacy_helper:set_list(Alice, {<<"deny_jid_all">>, Bob}),
 
         %% Alice blocks Bob
-        escalus_client:send(Alice,
-            escalus_stanza:privacy_activate(<<"deny_jid_all">>)),
+        Stanza = escalus_stanza:privacy_activate(<<"deny_jid_all">>),
+        escalus_client:send(Alice, Stanza),
+
         %% IQ response is blocked;
         %% do magic wait for the request to take effect
         timer:sleep(200),
@@ -675,16 +677,17 @@ block_jid_all(Config) ->
         privacy_helper:gets_error(Bob, <<"service-unavailable">>),
 
         %% Alice should NOT receive presence-in from Bob, no err msg
-        escalus_client:send(Bob,
-            escalus_stanza:presence_direct(escalus_utils:get_short_jid(Alice),
-                <<"available">>)),
+        AliceBareJID = escalus_utils:get_short_jid(Alice),
+        Presence1 = escalus_stanza:presence_direct(AliceBareJID,
+                                                   <<"available">>),
+        escalus_client:send(Bob, Presence1),
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Bob),
 
         %% Bob should NOT receive presence-in from Alice, Alice receives err msg
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(
-                escalus_utils:get_short_jid(Bob), <<"available">>)),
+        BobBareJID = escalus_utils:get_short_jid(Bob),
+        Presence2 = escalus_stanza:presence_direct(BobBareJID, <<"available">>),
+        escalus_client:send(Alice, Presence2),
         timer:sleep(?SLEEP_TIME),
         privacy_helper:gets_error(Alice, <<"not-acceptable">>),
 
@@ -708,10 +711,10 @@ block_jid_message_but_not_presence(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
         %% Alice should receive message
-        escalus_client:send(Bob,
-            escalus_stanza:chat_to(Alice, <<"Hi! What's your name?">>)),
+        Msg =  escalus_stanza:chat_to(Alice, <<"Hi! What's your name?">>),
+        escalus_client:send(Bob, Msg),
         escalus_assert:is_chat_message(<<"Hi! What's your name?">>,
-            escalus_client:wait_for_stanza(Alice)),
+                                       escalus_client:wait_for_stanza(Alice)),
 
         %% set the list on server and make it active
         privacy_helper:set_and_activate(Alice, {<<"deny_client_message">>, Bob}),
@@ -724,7 +727,7 @@ block_jid_message_but_not_presence(Config) ->
 
         %% ...but should receive presence in
         escalus_client:send(Bob,
-            escalus_stanza:presence_direct(Alice, <<"available">>)),
+                            escalus_stanza:presence_direct(Alice, <<"available">>)),
         Received = escalus_client:wait_for_stanza(Alice),
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Bob, Received)
@@ -740,9 +743,9 @@ newly_blocked_presense_jid_by_new_list(Config) ->
         escalus:assert(is_roster_set, escalus_client:wait_for_stanza(Alice)),
 
         %% Bob should receive presence in
-        escalus_client:send(Alice,
-            escalus_stanza:presence_direct(escalus_client:short_jid(Bob),
-                                           <<"available">>)),
+        Presence = escalus_stanza:presence_direct(escalus_client:short_jid(Bob),
+                                                  <<"available">>),
+        escalus_client:send(Alice, Presence),
         Received = escalus_client:wait_for_stanza(Bob),
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Alice, Received),

--- a/test/ejabberd_tests/tests/privacy_SUITE.erl
+++ b/test/ejabberd_tests/tests/privacy_SUITE.erl
@@ -167,22 +167,22 @@ get_all_lists(Config) ->
         end).
 
 get_all_lists_with_active(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:set_and_activate(Alice, <<"deny_bob">>),
+        privacy_helper:set_and_activate(Alice, {<<"deny_client">>, Bob}),
 
         escalus:send(Alice, escalus_stanza:privacy_get_all()),
-        escalus:assert(is_privacy_result_with_active, [<<"deny_bob">>],
+        escalus:assert(is_privacy_result_with_active, [<<"deny_client">>],
                        escalus:wait_for_stanza(Alice))
 
         end).
 
 get_all_lists_with_default(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:set_list(Alice, <<"deny_bob">>),
-        privacy_helper:set_list(Alice, <<"allow_bob">>),
-        privacy_helper:set_default_list(Alice, <<"allow_bob">>),
+        privacy_helper:set_list(Alice, {<<"deny_client">>, Bob}),
+        privacy_helper:set_list(Alice, {<<"allow_client">>, Bob}),
+        privacy_helper:set_default_list(Alice, <<"allow_client">>),
 
         escalus:send(Alice, escalus_stanza:privacy_get_all()),
         escalus:assert(is_privacy_result_with_default,
@@ -211,25 +211,25 @@ get_many_lists(Config) ->
         end).
 
 get_existing_list(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:set_list(Alice, <<"deny_bob">>),
+        privacy_helper:set_list(Alice, {<<"deny_client">>, Bob}),
 
-        escalus:send(Alice, escalus_stanza:privacy_get_lists([<<"deny_bob">>])),
+        escalus:send(Alice, escalus_stanza:privacy_get_lists([<<"deny_client">>])),
         Response = escalus:wait_for_stanza(Alice),
 
-        <<"deny_bob">> = exml_query:path(Response, [{element, <<"query">>},
+        <<"deny_client">> = exml_query:path(Response, [{element, <<"query">>},
                                                     {element, <<"list">>},
                                                     {attr, <<"name">>}])
 
         end).
 
 activate(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:set_list(Alice, <<"deny_bob">>),
+        privacy_helper:set_list(Alice, {<<"deny_client">>, Bob}),
 
-        Request = escalus_stanza:privacy_activate(<<"deny_bob">>),
+        Request = escalus_stanza:privacy_activate(<<"deny_client">>),
         escalus_client:send(Alice, Request),
 
         Response = escalus_client:wait_for_stanza(Alice),
@@ -260,11 +260,11 @@ deactivate(Config) ->
         end).
 
 default(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:set_list(Alice, <<"deny_bob">>),
+        privacy_helper:set_list(Alice, {<<"deny_client">>, Bob}),
 
-        Request = escalus_stanza:privacy_set_default(<<"deny_bob">>),
+        Request = escalus_stanza:privacy_set_default(<<"deny_client">>),
         escalus_client:send(Alice, Request),
 
         Response = escalus_client:wait_for_stanza(Alice),
@@ -273,22 +273,22 @@ default(Config) ->
         end).
 
 default_conflict(Config) ->
-    escalus:story(Config, [{alice, 2}, {bob, 1}], fun(Alice, Alice2, _Bob) ->
+    escalus:story(Config, [{alice, 2}, {bob, 1}], fun(Alice, Alice2, Bob) ->
 
         %% testcase setup
         %% setup list on server
-        privacy_helper:send_set_list(Alice, <<"deny_bob">>),
-        privacy_helper:send_set_list(Alice, <<"allow_bob">>),
+        privacy_helper:send_set_list(Alice, {<<"deny_client">>, Bob}),
+        privacy_helper:send_set_list(Alice, {<<"allow_client">>, Bob}),
         %% skip responses
         escalus_client:wait_for_stanzas(Alice, 4),
         %% make a default list for Alice2
-        R1 = escalus_stanza:privacy_set_default(Alice2, <<"deny_bob">>),
+        R1 = escalus_stanza:privacy_set_default(Alice2, <<"deny_client">>),
         escalus_client:send(Alice2, R1),
         escalus:assert_many([is_privacy_set, is_privacy_set, is_iq_result],
                             escalus_client:wait_for_stanzas(Alice2, 3)),
         %% setup done
 
-        Request = escalus_stanza:privacy_set_default(<<"allow_bob">>),
+        Request = escalus_stanza:privacy_set_default(<<"allow_client">>),
         escalus_client:send(Alice, Request),
 
         Response = escalus_client:wait_for_stanza(Alice),
@@ -323,9 +323,9 @@ no_default(Config) ->
         end).
 
 set_list(Config) ->
-    escalus:story(Config, [{alice, 3}, {bob, 1}], fun(Alice, Alice2, Alice3, _Bob) ->
+    escalus:story(Config, [{alice, 3}, {bob, 1}], fun(Alice, Alice2, Alice3, Bob) ->
 
-        privacy_helper:send_set_list(Alice, <<"deny_bob">>),
+        privacy_helper:send_set_list(Alice, {<<"deny_client">>, Bob}),
 
         %% Verify that original Alice gets iq result and notification.
         %% It's a bit quirky as these come in undefined order
@@ -349,9 +349,9 @@ set_list(Config) ->
         end).
 
 remove_list(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, _Bob) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:send_set_list(Alice, <<"deny_bob">>),
+        privacy_helper:send_set_list(Alice, {<<"deny_client">>, Bob}),
 
         %% These are the pushed notification and iq result.
         escalus_client:wait_for_stanzas(Alice, 2),
@@ -386,7 +386,7 @@ block_jid_message(Config) ->
             escalus_client:wait_for_stanza(Alice)),
 
         %% set the list on server and make it active
-        privacy_helper:set_and_activate(Alice, <<"deny_bob_message">>),
+        privacy_helper:set_and_activate(Alice, {<<"deny_client_message">>, Bob}),
 
         %% Alice should NOT receive message, while Bob gets error message
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice!">>)),
@@ -436,7 +436,7 @@ block_subscription_message(Config) ->
 
         %% Alice sends unsubscribe
         escalus_client:send(Alice,
-            escalus_stanza:presence_direct(bob, <<"unsubscribe">>)),
+            escalus_stanza:presence_direct(Bob, <<"unsubscribe">>)),
 
         %% set the list on server and make it active
         privacy_helper:set_and_activate(Alice, <<"deny_unsubscribed_message">>),
@@ -572,7 +572,7 @@ block_jid_presence_in(Config) ->
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Bob, Received),
 
-        privacy_helper:set_and_activate(Alice, <<"deny_bob_presence_in">>),
+        privacy_helper:set_and_activate(Alice, {<<"deny_client_presence_in">>, Bob}),
 
         %% Alice should NOT receive presence in
         escalus_client:send(Bob,
@@ -595,7 +595,7 @@ block_jid_presence_out(Config) ->
         escalus:assert(is_presence, Received),
         escalus_assert:is_stanza_from(Alice, Received),
 
-        privacy_helper:set_and_activate(Alice, <<"deny_bob_presence_out">>),
+        privacy_helper:set_and_activate(Alice, {<<"deny_client_presence_out">>, Bob}),
 
         %% Bob should NOT receive presence in
         escalus_client:send(Alice,
@@ -645,7 +645,7 @@ block_jid_iq(Config) ->
 block_jid_all(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
-        privacy_helper:set_list(Alice, <<"deny_jid_all">>),
+        privacy_helper:set_list(Alice, {<<"deny_jid_all">>, Bob}),
 
         %% Alice blocks Bob
         escalus_client:send(Alice,
@@ -672,9 +672,9 @@ block_jid_all(Config) ->
         timer:sleep(?SLEEP_TIME),
         privacy_helper:gets_error(Alice, <<"not-acceptable">>),
 
-        %% Just set the toy list and ensure that only
+        %% Just set the toy list and en~sure that only
         %% the notification push comes back.
-        privacy_helper:send_set_list(Alice, <<"deny_bob">>),
+        privacy_helper:send_set_list(Alice, {<<"deny_client">>, Bob}),
 
         %% verify
         timer:sleep(?SLEEP_TIME),
@@ -698,7 +698,7 @@ block_jid_message_but_not_presence(Config) ->
             escalus_client:wait_for_stanza(Alice)),
 
         %% set the list on server and make it active
-        privacy_helper:set_and_activate(Alice, <<"deny_bob_message">>),
+        privacy_helper:set_and_activate(Alice, {<<"deny_client_message">>, Bob}),
 
         %% Alice should NOT receive message
         escalus_client:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi, Alice!">>)),

--- a/test/ejabberd_tests/tests/privacy_helper.erl
+++ b/test/ejabberd_tests/tests/privacy_helper.erl
@@ -131,66 +131,84 @@ privacy_list(Name) ->
 % Geralt is not used by the privacy tests, but lists have to have
 % at least one element so we use him for a no-op.
 list_content(<<"noop_list">>) -> [
-        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, <<"geralt@localhost">>, [])
+        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>,
+                                             <<"geralt@localhost">>, [])
     ];
 list_content(<<"deny_group_message">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>, <<"ignored">>, [<<"message">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>,
+                                         <<"ignored">>, [<<"message">>])
     ];
 list_content(<<"deny_unsubscribed_message">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"none">>, [<<"message">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>,
+                                         <<"none">>, [<<"message">>])
     ];
 list_content(<<"deny_all_message">>) -> [
         escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, [<<"message">>])
     ];
 list_content(<<"deny_all_message_but_subscription_from">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>, <<"from">>, [<<"message">>]),
+        escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>,
+                                         <<"from">>, [<<"message">>]),
         escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, [<<"message">>])
     ];
 list_content(<<"deny_all_message_but_subscription_to">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>, <<"to">>, [<<"message">>]),
+        escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>,
+                                         <<"to">>, [<<"message">>]),
         escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, [<<"message">>])
     ];
 list_content(<<"deny_all_message_but_subscription_both">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>, <<"both">>, [<<"message">>]),
+        escalus_stanza:privacy_list_item(<<"1">>, <<"allow">>, <<"subscription">>,
+                                         <<"both">>, [<<"message">>]),
         escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, [<<"message">>])
     ];
 list_content(<<"deny_not_both_presence_out">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"from">>, [<<"presence-out">>]),
-        escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, <<"subscription">>, <<"to">>, [<<"presence-out">>]),
-        escalus_stanza:privacy_list_item(<<"3">>, <<"deny">>, <<"subscription">>, <<"none">>, [<<"presence-out">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>,
+                                         <<"from">>, [<<"presence-out">>]),
+        escalus_stanza:privacy_list_item(<<"2">>, <<"deny">>, <<"subscription">>,
+                                         <<"to">>, [<<"presence-out">>]),
+        escalus_stanza:privacy_list_item(<<"3">>, <<"deny">>, <<"subscription">>,
+                                         <<"none">>, [<<"presence-out">>])
     ];
 list_content(<<"deny_unsubscribed_presence_in">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"none">>, [<<"presence-in">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>,
+                                         <<"none">>, [<<"presence-in">>])
     ];
 list_content(<<"deny_all_presence_in">>) -> [
         escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, [<<"presence-in">>])
     ];
 list_content(<<"deny_group_presence_in">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>, <<"ignored">>, [<<"presence-in">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>,
+                                         <<"ignored">>, [<<"presence-in">>])
     ];
 list_content(<<"deny_unsubscribed_presence_out">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"none">>, [<<"presence-out">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>,
+                                         <<"none">>, [<<"presence-out">>])
     ];
 list_content(<<"deny_all_presence_out">>) -> [
         escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, [<<"presence-out">>])
     ];
 list_content(<<"deny_localhost_iq">>) -> [
-        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, <<"localhost">>, [<<"iq">>])
+        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>,
+                                             <<"localhost">>, [<<"iq">>])
     ];
 list_content(<<"deny_group_iq">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>, <<"ignored">>, [<<"iq">>])
-                                     ];
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>,
+                                         <<"ignored">>, [<<"iq">>])
+    ];
 list_content(<<"deny_unsubscribed_iq">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"none">>, [<<"iq">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>,
+                                         <<"none">>, [<<"iq">>])
     ];
 list_content(<<"deny_group_presence_out">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>, <<"ignored">>, [<<"presence-out">>])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>,
+                                         <<"ignored">>, [<<"presence-out">>])
     ];
 list_content(<<"deny_group_all">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>, <<"ignored">>, [])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"group">>,
+                                         <<"ignored">>, [])
     ];
 list_content(<<"deny_unsubscribed_all">>) -> [
-        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>, <<"none">>, [])
+        escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, <<"subscription">>,
+                                         <<"none">>, [])
     ];
 list_content(<<"deny_all_all">>) -> [
         escalus_stanza:privacy_list_item(<<"1">>, <<"deny">>, [])
@@ -206,20 +224,26 @@ list_content(<<"allow_client">>, JID) -> [
         escalus_stanza:privacy_list_jid_item(<<"1">>, <<"allow">>, JID, [])
     ];
 list_content(<<"deny_client_message">>, JID) -> [
-        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, JID, [<<"message">>])
+        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>,
+                                             JID, [<<"message">>])
     ];
 list_content(<<"deny_client_presence_in">>, JID) -> [
-        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, JID, [<<"presence-in">>])
+        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>,
+                                             JID, [<<"presence-in">>])
     ];
 list_content(<<"deny_client_presence_out">>, JID) -> [
-        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, JID, [<<"presence-out">>])
+        escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>,
+                                             JID, [<<"presence-out">>])
     ];
 list_content(<<"deny_jid_all">>, JID) -> [
         escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, JID, []),
-        escalus_stanza:privacy_list_jid_item(<<"2">>, <<"deny">>, <<"localhost">>, [])
+        escalus_stanza:privacy_list_jid_item(<<"2">>, <<"deny">>,
+                                             <<"localhost">>, [])
     ];
 list_content(<<"deny_3_items">>, JID) -> [
         escalus_stanza:privacy_list_jid_item(<<"1">>, <<"deny">>, JID, []),
-        escalus_stanza:privacy_list_jid_item(<<"2">>, <<"deny">>, <<"steve@localhost">>, []),
-        escalus_stanza:privacy_list_jid_item(<<"3">>, <<"deny">>, <<"john@localhost">>, [])
+        escalus_stanza:privacy_list_jid_item(<<"2">>, <<"deny">>,
+                                             <<"steve@localhost">>, []),
+        escalus_stanza:privacy_list_jid_item(<<"3">>, <<"deny">>,
+                                             <<"john@localhost">>, [])
     ].


### PR DESCRIPTION
This PR removes warnings emitted by escalus when running privacy_SUITE.

Since [this commit](https://github.com/esl/escalus/commit/93ee6eef1cce80ae7d1213c62b31cfebe301b11f) escalus prints warning whenever we try to lookup JID by atom representing user in config file.

Proposed changes include:
* removed sending stanzas to recipients defined by atoms in `privacy_SUITE`
* removed setting privacy lists' targets  as atoms in `privacy_helpers` module
