### PR TITLE
Add intermodular dependency mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ TAGS
 *.patch
 
 *.diff
+apps/ejabberd/compile_commands.json

--- a/apps/ejabberd/src/ejabberd_app.erl
+++ b/apps/ejabberd/src/ejabberd_app.erl
@@ -117,10 +117,7 @@ start_modules() ->
                   undefined ->
                       ok;
                   Modules ->
-                      lists:foreach(
-                        fun({Module, Args}) ->
-                                gen_mod:start_module(Host, Module, Args)
-                        end, Modules)
+                      gen_mod_deps:start_modules(Host, Modules)
               end
       end, ?MYHOSTS).
 

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -1050,10 +1050,7 @@ handle_local_hosts_config_add({{ldap, _Host}, _}) ->
     %% ignore ldap section
     ok;
 handle_local_hosts_config_add({{modules, Host}, Modules}) ->
-    lists:foreach(
-      fun({Module, Args}) ->
-              gen_mod:start_module(Host, Module, Args)
-      end, Modules);
+    gen_mod_deps:start_modules(Host, Modules);
 handle_local_hosts_config_add({{Key,_Host}, _} = El) ->
     case can_be_ignored(Key) of
         true ->
@@ -1078,10 +1075,7 @@ handle_local_hosts_config_del({{ldap, _Host}, _I}) ->
     %% ignore ldap section, only appli
     ok;
 handle_local_hosts_config_del({{modules, Host}, Modules}) ->
-    lists:foreach(
-      fun({Module, _Args}) ->
-              gen_mod:stop_module(Host, Module)
-      end, Modules);
+    lists:foreach(fun({Mod, _}) -> gen_mod:stop_module(Host, Mod) end, Modules);
 handle_local_hosts_config_del({{Key,_}, _} =El) ->
     case can_be_ignored(Key) of
         true ->
@@ -1114,8 +1108,7 @@ handle_local_hosts_config_change({{auth, Host}, OldVals, _}) ->
 handle_local_hosts_config_change({{ldap, Host}, _OldConfig, NewConfig}) ->
     ok = ejabberd_hooks:run_fold(host_config_update, Host, ok, [Host, ldap, NewConfig]);
 handle_local_hosts_config_change({{modules,Host}, OldModules, NewModules}) ->
-    Res = compare_modules(OldModules, NewModules),
-    reload_modules(Host, Res);
+    gen_mod_deps:replace_modules(Host, OldModules, NewModules);
 handle_local_hosts_config_change({{Key,_Host},_Old,_New} = El) ->
     case can_be_ignored(Key) of
         true ->
@@ -1162,21 +1155,6 @@ can_be_ignored(Key) when is_atom(Key) ->
 remove_virtual_host(Host) ->
     ?DEBUG("Unregister host :~p", [Host]),
     ejabberd_local:unregister_host(Host).
-
--spec reload_modules(Host :: ejabberd:server(),
-                     ChangedModules :: compare_result()) -> 'ok'.
-reload_modules(Host, #compare_result{to_start = Start, to_stop = Stop,
-                                     to_reload = Reload} = ChangedModules) ->
-    ?DEBUG("reload modules: ~p", [lager:pr(ChangedModules, ?MODULE)]),
-    lists:foreach(fun ({M, _}) ->
-                          gen_mod:stop_module(Host, M)
-                  end, Stop),
-    lists:foreach(fun ({M, Args}) ->
-                          gen_mod:start_module(Host, M, Args)
-                  end, Start),
-    lists:foreach(fun({M, _, Args}) ->
-                          gen_mod:reload_module(Host, M, Args)
-                  end, Reload).
 
 -spec reload_listeners(ChangedListeners :: compare_result()) -> 'ok'.
 reload_listeners(#compare_result{to_start = Add, to_stop = Del,
@@ -1339,4 +1317,3 @@ sort_config(Config) when is_list(Config) ->
                           ConfigItem
                   end, Config),
     lists:sort(L).
-

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -53,8 +53,6 @@
 -include("ejabberd.hrl").
 
 -record(ejabberd_module, {module_host, opts}).
--type ejabberd_module() :: #ejabberd_module{module_host :: {module(), ejabberd:server()},
-                                            opts :: list()}.
 
 %% -export([behaviour_info/1]).
 %% behaviour_info(callbacks) ->
@@ -64,9 +62,18 @@
 %%     undefined.
 -callback start(Host :: ejabberd:server(), Opts :: list()) -> any().
 -callback stop(Host :: ejabberd:server()) -> any().
-% -callback deps(Host :: ejabberd:server(), Opts :: proplists:list()) ->
-%     [{module(), DepOpts :: proplists:list(), soft | hard} |
-%      {module(), soft | hard}].
+
+%% Optional callback specifying module dependencies.
+%% The dependent module can specify parameters with which the dependee should be
+%% started (the parameters will be merged with params given in user config and
+%% by other modules).
+%% The last element of the tuple specifies whether the ordering can be broken in
+%% case of cycle (in that case soft dependency may be started after the
+%% dependent module).
+%%
+%% -callback deps(Host :: ejabberd:server(), Opts :: proplists:list()) ->
+%%     [{module(), DepOpts :: proplists:list(), soft | hard} |
+%%      {module(), soft | hard}].
 
 -spec start() -> 'ok'.
 start() ->

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -47,7 +47,8 @@
          get_hosts/2,
          get_module_proc/2,
          backend_code/3,
-         is_loaded/2]).
+         is_loaded/2,
+         get_deps/3]).
 
 -include("ejabberd.hrl").
 
@@ -63,6 +64,9 @@
 %%     undefined.
 -callback start(Host :: ejabberd:server(), Opts :: list()) -> any().
 -callback stop(Host :: ejabberd:server()) -> any().
+% -callback deps(Host :: ejabberd:server(), Opts :: proplists:list()) ->
+%     [{module(), DepOpts :: proplists:list(), soft | hard} |
+%      {module(), soft | hard}].
 
 -spec start() -> 'ok'.
 start() ->
@@ -124,45 +128,46 @@ backend_code(Module, Backend, TrackedFuncs) when is_atom(Backend) ->
     Callbacks = Module:behaviour_info(callbacks),
     ModuleStr = atom_to_list(Module),
     BackendModuleName = ModuleStr ++ "_backend",
-    RealBackendModule = ModuleStr++"_"++atom_to_list(Backend),
+    RealBackendModule = ModuleStr ++ "_" ++ atom_to_list(Backend),
     BehaviourExports = [generate_export(F, A) || {F, A} <- Callbacks],
 
-    BehaviourImpl = [generate_fun(Module, RealBackendModule, F, A, TrackedFuncs) || {F, A} <- Callbacks],
+    BehaviourImpl = [generate_fun(Module, RealBackendModule, F, A, TrackedFuncs) ||
+                        {F, A} <- Callbacks],
     Code = lists:flatten(
-        ["-module(", BackendModuleName,").\n",
+        ["-module(", BackendModuleName, ").\n",
         "-export([backend/0]).\n",
         BehaviourExports,
 
 
         "-spec backend() -> atom().\n",
-        "backend() ->", RealBackendModule,".\n",
+        "backend() ->", RealBackendModule, ".\n",
         BehaviourImpl
         ]),
     {BackendModuleName, Code}.
 
 generate_export(F, A) ->
-    "-export(["++atom_to_list(F)++"/"++integer_to_list(A)++"]).\n".
+    "-export([" ++ atom_to_list(F) ++ "/" ++ integer_to_list(A) ++ "]).\n".
 
 generate_fun(BaseModule, RealBackendModule, F, A, TrackedFuncs) ->
-    Args = string:join(["A"++integer_to_list(I) || I <- lists:seq(1, A)], ", "),
+    Args = string:join(["A" ++ integer_to_list(I) || I <- lists:seq(1, A)], ", "),
     IsTracked = lists:member(F, TrackedFuncs),
-    [fun_header(F, Args)," ->\n",
+    [fun_header(F, Args), " ->\n",
      generate_fun_body(IsTracked, BaseModule, RealBackendModule, F, Args)].
 
 fun_header(F, Args) ->
-    [atom_to_list(F),"(",Args,")"].
+    [atom_to_list(F), "(", Args, ")"].
 
 -define(METRIC(Module, Op), [backends, Module, Op]).
 
 generate_fun_body(false, _, RealBackendModule, F, Args) ->
-    ["    ",RealBackendModule,":",fun_header(F, Args),".\n"];
+    ["    ", RealBackendModule, ":", fun_header(F, Args), ".\n"];
 generate_fun_body(true, BaseModule, RealBackendModule, F, Args) ->
     FS = atom_to_list(F),
 %%     returned is the following
 %%     {Time, Result} = timer:tc(Backend, F, Args),
 %%     mongoose_metrics:update(global, ?METRIC(Backend, F), Time),
 %%     Result.
-    ["    {Time, Result} = timer:tc(",RealBackendModule,", ",FS,", [",Args,"]),\n",
+    ["    {Time, Result} = timer:tc(", RealBackendModule, ", ", FS, ", [", Args, "]),\n",
      "    mongoose_metrics:update(global, ",
           io_lib:format("~p", [?METRIC(BaseModule, F)]),
           ", Time),\n",
@@ -182,7 +187,7 @@ is_app_running(AppName) ->
 
 
 %% @doc Stop the module in a host, and forget its configuration.
--spec stop_module(ejabberd:server(), module()) -> 'error' | {'aborted',_} | {'atomic',_}.
+-spec stop_module(ejabberd:server(), module()) -> 'error' | {'aborted', _} | {'atomic', _}.
 stop_module(Host, Module) ->
     case stop_module_keep_config(Host, Module) of
         error ->
@@ -220,13 +225,13 @@ reload_module(Host, Module, Opts) ->
     stop_module_keep_config(Host, Module),
     start_module(Host, Module, Opts).
 
--spec wait_for_process(atom() | pid() | {atom(),atom()}) -> 'ok'.
+-spec wait_for_process(atom() | pid() | {atom(), atom()}) -> 'ok'.
 wait_for_process(Process) ->
     MonitorReference = erlang:monitor(process, Process),
     wait_for_stop(Process, MonitorReference).
 
 
--spec wait_for_stop(atom() | pid() | {atom(),atom()},reference()) -> 'ok'.
+-spec wait_for_stop(atom() | pid() | {atom(), atom()}, reference()) -> 'ok'.
 wait_for_stop(Process, MonitorReference) ->
     receive
         {'DOWN', MonitorReference, _Type, _Object, _Info} ->
@@ -271,7 +276,7 @@ get_opt(Opt, Opts, F, Default) ->
             F(Val)
     end.
 
--spec set_opt(_,[tuple()],_) -> [tuple(),...].
+-spec set_opt(_, [tuple()], _) -> [tuple(), ...].
 set_opt(Opt, Opts, Value) ->
     lists:keystore(Opt, 1, Opts, {Opt, Value}).
 
@@ -314,13 +319,13 @@ set_module_opt(Host, Module, Opt, Value) ->
 -spec get_module_opt_host(ejabberd:server(), module(), _) -> ejabberd:server().
 get_module_opt_host(Host, Module, Default) ->
     Val = get_module_opt(Host, Module, host, Default),
-    re:replace(Val, "@HOST@", Host, [global, {return,binary}]).
+    re:replace(Val, "@HOST@", Host, [global, {return, binary}]).
 
 
 -spec get_opt_host(ejabberd:server(), list(), _) -> ejabberd:server().
 get_opt_host(Host, Opts, Default) ->
     Val = get_opt(host, Opts, Default),
-    re:replace(Val, "@HOST@", Host, [global, {return,binary}]).
+    re:replace(Val, "@HOST@", Host, [global, {return, binary}]).
 
 
 -spec loaded_modules(ejabberd:server()) -> [module()].
@@ -341,7 +346,7 @@ loaded_modules_with_opts(Host) ->
 
 
 -spec set_module_opts_mnesia(ejabberd:server(), module(), [any()]
-                            ) -> {'aborted',_} | {'atomic',_}.
+                            ) -> {'aborted', _} | {'atomic', _}.
 set_module_opts_mnesia(Host, Module, Opts) ->
     Modules = case ejabberd_config:get_local_option({modules, Host}) of
         undefined ->
@@ -354,7 +359,7 @@ set_module_opts_mnesia(Host, Module, Opts) ->
     ejabberd_config:add_local_option({modules, Host}, Modules2).
 
 
--spec del_module_mnesia(ejabberd:server(), module()) -> {'aborted',_} | {'atomic',_}.
+-spec del_module_mnesia(ejabberd:server(), module()) -> {'aborted', _} | {'atomic', _}.
 del_module_mnesia(Host, Module) ->
     Modules = case ejabberd_config:get_local_option({modules, Host}) of
                   undefined ->
@@ -409,3 +414,17 @@ clear_opts(Module, Opts0) ->
     end.
 
 
+-spec get_deps(Host :: ejabberd:server(), Module :: module(),
+               Opts :: proplists:proplist()) ->
+                      [{module(), proplists:proplist(), hard | soft} |
+                       {module(), hard | soft}].
+get_deps(Host, Module, Opts) ->
+    %% the module has to be loaded,
+    %% otherwise the erlang:function_exported/3 returns false
+    code:ensure_loaded(Module),
+    case erlang:function_exported(Module, deps, 2) of
+        true ->
+            Module:deps(Host, Opts);
+        _ ->
+            []
+    end.

--- a/apps/ejabberd/src/gen_mod_deps.erl
+++ b/apps/ejabberd/src/gen_mod_deps.erl
@@ -105,7 +105,7 @@ resolve_deps(Host, [{Module, Args} | ModuleQueue], KnownModules) ->
             Deps = lists:map(
                      fun
                          ({Mod, _Hardness}) -> {Mod, []};
-                         ({Mod, Args, _Hardness}) -> {Mod, Args}
+                         ({Mod, ModArgs, _Hardness}) -> {Mod, ModArgs}
                      end,
                      gen_mod:get_deps(Host, Module, NewArgs)),
 

--- a/apps/ejabberd/src/gen_mod_deps.erl
+++ b/apps/ejabberd/src/gen_mod_deps.erl
@@ -1,0 +1,233 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(gen_mod_deps).
+
+-include("ejabberd.hrl").
+
+-type ejd_module_params() :: proplists:proplist().
+-type ejd_modules() :: [{module(), ejd_module_params()}].
+-type ejd_module_map() :: #{module() => ejd_module_params()}.
+
+-export([start_modules/2, replace_modules/3]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec start_modules(Host :: ejabberd:server(), Modules :: ejd_modules()) -> ok.
+start_modules(Host, Modules) ->
+    replace_modules(Host, [], Modules).
+
+
+%% @doc
+%% Replaces OldModules (along with dependencies) with NewModules (along with
+%% dependencies). The dependencies are resolved only for given lists of modules,
+%% so for certain arguments a still-needed dependency might be removed.
+%% Thus, the function is meant to replace all modules on the host.
+%% @end
+-spec replace_modules(Host :: ejabberd:server(), OldModules :: ejd_modules(),
+                      NewModules :: ejd_modules()) -> ok.
+replace_modules(Host, OldModules0, NewModules0) ->
+    OldModulesMap = resolve_deps(Host, OldModules0),
+    NewModules = sort_deps(Host, resolve_deps(Host, NewModules0)),
+
+    ToStop = maps:keys(maps:without(proplists:get_keys(NewModules), OldModulesMap)),
+    lists:foreach(fun(Mod) -> gen_mod:stop_module(Host, Mod) end, ToStop),
+
+    lists:foreach(
+      fun({Mod, Args}) ->
+              case maps:find(Mod, OldModulesMap) of
+                  error -> gen_mod:start_module(Host, Mod, Args);
+                  {ok, Args} -> ok;
+                  {ok, _} -> gen_mod:reload_module(Host, Mod, Args)
+              end
+      end, NewModules).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+%% Resolving dependencies
+
+%% @doc
+%% Determines all modules to start, along with their parameters.
+%%
+%% NOTE: A dependency will not be discarded during resolving, e.g.
+%% if the resolver processes dependencies in order:
+%%
+%% deps(mod_a, []) -> [{mod_b, []}, {mod_c, []}]
+%% deps(mod_parent, []) -> [{mod_a, [param]}]
+%%
+%% then the dependency for mod_a will be reevaluated with new parameters and
+%% might return:
+%%
+%% deps(mod_a, [param]) -> [{mod_c, []}]
+%%
+%% In this case, mod_b will still be started.
+%% @end
+-spec resolve_deps(Host :: ejabberd:server(), Modules :: ejd_modules()) ->
+                          ejd_module_map().
+resolve_deps(Host, ModuleQueue) -> resolve_deps(Host, ModuleQueue, #{}).
+
+-spec resolve_deps(Host :: ejabberd:server(), Modules :: ejd_modules(),
+                   Acc :: ejd_module_map()) -> ejd_module_map().
+resolve_deps(_Host, [], KnownModules) -> KnownModules;
+resolve_deps(Host, [{Module, Args} | ModuleQueue], KnownModules) ->
+    NewArgs =
+        case maps:find(Module, KnownModules) of
+            {ok, PreviousArgs} ->
+                case merge_args(Module, PreviousArgs, Args) of
+                    PreviousArgs -> undefined;
+                    ChangedArgs -> ChangedArgs
+                end;
+
+            error ->
+                Args
+        end,
+
+    case NewArgs of
+        undefined -> resolve_deps(Host, ModuleQueue, KnownModules);
+        _ ->
+            Deps = lists:map(
+                     fun
+                         ({Mod, _Hardness}) -> {Mod, []};
+                         ({Mod, Args, _Hardness}) -> {Mod, Args}
+                     end,
+                     gen_mod:get_deps(Host, Module, NewArgs)),
+
+            UpdatedQueue = Deps ++ ModuleQueue,
+            UpdatedKnownModules = maps:put(Module, NewArgs, KnownModules),
+            resolve_deps(Host, UpdatedQueue, UpdatedKnownModules)
+    end.
+
+%% @doc
+%% Merges proplists prioritizing the new list, and warns on overrides.
+%% @end
+-spec merge_args(Module :: module(), PreviousArgs :: ejd_module_params(),
+                 Args :: ejd_module_params()) -> ejd_module_params().
+merge_args(Module, PreviousArgs, Args) ->
+    lists:foldl(fun(Property, OldProplist) ->
+                        [{Key, Value}] = proplists:unfold([Property]),
+                        case proplists:lookup(Key, OldProplist) of
+                            none ->
+                                [Property | OldProplist];
+
+                            {_, Value} ->
+                                OldProplist;
+
+                            {_, OldValue} ->
+                                ?WARNING_MSG("Overriding argument ~p for module ~p "
+                                             "with ~p.~n", [{Key, OldValue}, Module,
+                                                            {Key, Value}]),
+
+                                [Property | proplists:delete(Key, OldProplist)]
+                        end
+                end, PreviousArgs, Args).
+
+%% Sorting resolved dependencies
+
+-spec sort_deps(Host :: ejabberd:server(), ModuleMap :: ejd_module_map()) ->
+                       ejd_modules().
+sort_deps(Host, ModuleMap) ->
+    DepsGraph = digraph:new([acyclic, private]),
+
+    try
+        maps:fold(
+          fun(Module, Args, _) ->
+                  process_module_dep(Host, Module, Args, DepsGraph)
+          end,
+          undefined, ModuleMap),
+
+        lists:map(fun(Module) -> {Module, maps:get(Module, ModuleMap)} end,
+                  digraph_utils:topsort(DepsGraph))
+    after
+        digraph:delete(DepsGraph)
+    end.
+
+
+-spec process_module_dep(Host :: ejabberd:server(), Module :: module(),
+                         Args :: ejd_module_params(),
+                         DepsGraph :: digraph:graph()) -> ok.
+process_module_dep(Host, Module, Args, DepsGraph) ->
+    digraph:add_vertex(DepsGraph, Module),
+    lists:foreach(
+      fun
+          ({DepModule, _, DepHardness}) ->
+              process_dep(Module, DepModule, DepHardness, DepsGraph);
+          ({DepModule, DepHardness}) ->
+              process_dep(Module, DepModule, DepHardness, DepsGraph)
+      end, gen_mod:get_deps(Host, Module, Args)).
+
+
+-spec process_dep(Module :: module(), DepModule :: module(),
+                  DepHardness :: soft | hard, Graph :: digraph:graph()) -> ok.
+process_dep(Module, DepModule, DepHardness, Graph) ->
+    digraph:add_vertex(Graph, DepModule),
+    case {digraph:add_edge(Graph, DepModule, Module, DepHardness), DepHardness} of
+        {['$e' | _], _} ->
+            ok;
+
+        {{error, {bad_edge, CyclePath}}, soft} ->
+            ?INFO_MSG("Soft module dependency cycle detected: ~p. Dropping "
+                      "edge ~p -> ~p~n", [CyclePath, Module, DepModule]),
+            ok;
+
+        {{error, {bad_edge, CyclePath}}, hard} ->
+            case find_soft_edge(Graph, CyclePath) of
+                false ->
+                    ?CRITICAL_MSG("Aborting resolving dependencies because of "
+                                  "module dependency cycle: ~p.~n", [CyclePath]),
+                    error({dependency_cycle, CyclePath});
+
+                {EdgeId, B, A, _} ->
+                    ?INFO_MSG("Soft module dependency cycle detected: ~p. "
+                              "Dropping edge ~p -> ~p~n", [CyclePath, A, B]),
+
+                    digraph:del_edge(Graph, EdgeId),
+                    ['$e' | _] = digraph:add_edge(Graph, DepModule, Module, hard),
+                    ok
+            end
+    end.
+
+
+-spec find_soft_edge(digraph:graph(), [digraph:vertex()]) ->
+                            {digraph:edge(), digraph:vertex(),
+                             digraph:vertex(), digraph:label()} | false.
+find_soft_edge(Graph, CyclePath) ->
+    VerticePairs = lists:zip(CyclePath, tl(CyclePath) ++ [hd(CyclePath)]),
+    Edges = lists:filtermap(
+              fun({A, B}) ->
+                      case find_edge(Graph, A, B) of
+                          false -> false;
+                          Edge -> {true, digraph:edge(Graph, Edge)}
+                      end
+              end,
+              VerticePairs),
+
+    lists:keyfind(soft, 4, Edges).
+
+
+-spec find_edge(digraph:graph(), digraph:vertex(), digraph:vertex()) ->
+                       digraph:edge() | false.
+find_edge(Graph, A, B) ->
+    OutEdges = ordsets:from_list(digraph:out_edges(Graph, A)),
+    InEdges = ordsets:from_list(digraph:in_edges(Graph, B)),
+
+    case ordsets:intersection(OutEdges, InEdges) of
+        [Edge] -> Edge;
+        [] -> false
+    end.

--- a/apps/ejabberd/src/gen_mod_deps.erl
+++ b/apps/ejabberd/src/gen_mod_deps.erl
@@ -18,9 +18,9 @@
 
 -include("ejabberd.hrl").
 
--type ejd_module_params() :: proplists:proplist().
--type ejd_modules() :: [{module(), ejd_module_params()}].
--type ejd_module_map() :: #{module() => ejd_module_params()}.
+-type gen_mod_params() :: proplists:proplist().
+-type gen_mod_list() :: [{module(), gen_mod_params()}].
+-type gen_mod_map() :: #{module() => gen_mod_params()}.
 
 -export([start_modules/2, replace_modules/3]).
 
@@ -28,7 +28,7 @@
 %% API
 %%--------------------------------------------------------------------
 
--spec start_modules(Host :: ejabberd:server(), Modules :: ejd_modules()) -> ok.
+-spec start_modules(Host :: ejabberd:server(), Modules :: gen_mod_list()) -> ok.
 start_modules(Host, Modules) ->
     replace_modules(Host, [], Modules).
 
@@ -39,8 +39,8 @@ start_modules(Host, Modules) ->
 %% so for certain arguments a still-needed dependency might be removed.
 %% Thus, the function is meant to replace all modules on the host.
 %% @end
--spec replace_modules(Host :: ejabberd:server(), OldModules :: ejd_modules(),
-                      NewModules :: ejd_modules()) -> ok.
+-spec replace_modules(Host :: ejabberd:server(), OldModules :: gen_mod_list(),
+                      NewModules :: gen_mod_list()) -> ok.
 replace_modules(Host, OldModules0, NewModules0) ->
     OldModulesMap = resolve_deps(Host, OldModules0),
     NewModules = sort_deps(Host, resolve_deps(Host, NewModules0)),
@@ -79,12 +79,12 @@ replace_modules(Host, OldModules0, NewModules0) ->
 %%
 %% In this case, mod_b will still be started.
 %% @end
--spec resolve_deps(Host :: ejabberd:server(), Modules :: ejd_modules()) ->
-                          ejd_module_map().
+-spec resolve_deps(Host :: ejabberd:server(), Modules :: gen_mod_list()) ->
+                          gen_mod_map().
 resolve_deps(Host, ModuleQueue) -> resolve_deps(Host, ModuleQueue, #{}).
 
--spec resolve_deps(Host :: ejabberd:server(), Modules :: ejd_modules(),
-                   Acc :: ejd_module_map()) -> ejd_module_map().
+-spec resolve_deps(Host :: ejabberd:server(), Modules :: gen_mod_list(),
+                   Acc :: gen_mod_map()) -> gen_mod_map().
 resolve_deps(_Host, [], KnownModules) -> KnownModules;
 resolve_deps(Host, [{Module, Args} | ModuleQueue], KnownModules) ->
     NewArgs =
@@ -117,31 +117,32 @@ resolve_deps(Host, [{Module, Args} | ModuleQueue], KnownModules) ->
 %% @doc
 %% Merges proplists prioritizing the new list, and warns on overrides.
 %% @end
--spec merge_args(Module :: module(), PreviousArgs :: ejd_module_params(),
-                 Args :: ejd_module_params()) -> ejd_module_params().
+-spec merge_args(Module :: module(), PreviousArgs :: gen_mod_params(),
+                 Args :: gen_mod_params()) -> gen_mod_params().
 merge_args(Module, PreviousArgs, Args) ->
-    lists:foldl(fun(Property, OldProplist) ->
-                        [{Key, Value}] = proplists:unfold([Property]),
-                        case proplists:lookup(Key, OldProplist) of
-                            none ->
-                                [Property | OldProplist];
+    lists:foldl(
+      fun(Property, OldProplist) ->
+              [{Key, Value}] = proplists:unfold([Property]),
+              case proplists:lookup(Key, OldProplist) of
+                  none ->
+                      [Property | OldProplist];
 
-                            {_, Value} ->
-                                OldProplist;
+                  {_, Value} ->
+                      OldProplist;
 
-                            {_, OldValue} ->
-                                ?WARNING_MSG("Overriding argument ~p for module ~p "
-                                             "with ~p.~n", [{Key, OldValue}, Module,
-                                                            {Key, Value}]),
+                  {_, OldValue} ->
+                      ?WARNING_MSG("Overriding argument ~p for module ~p "
+                                   "with ~p.~n", [{Key, OldValue}, Module,
+                                                  {Key, Value}]),
 
-                                [Property | proplists:delete(Key, OldProplist)]
-                        end
-                end, PreviousArgs, Args).
+                      [Property | proplists:delete(Key, OldProplist)]
+              end
+      end, PreviousArgs, Args).
 
 %% Sorting resolved dependencies
 
--spec sort_deps(Host :: ejabberd:server(), ModuleMap :: ejd_module_map()) ->
-                       ejd_modules().
+-spec sort_deps(Host :: ejabberd:server(), ModuleMap :: gen_mod_map()) ->
+                       gen_mod_list().
 sort_deps(Host, ModuleMap) ->
     DepsGraph = digraph:new([acyclic, private]),
 
@@ -160,7 +161,7 @@ sort_deps(Host, ModuleMap) ->
 
 
 -spec process_module_dep(Host :: ejabberd:server(), Module :: module(),
-                         Args :: ejd_module_params(),
+                         Args :: gen_mod_params(),
                          DepsGraph :: digraph:graph()) -> ok.
 process_module_dep(Host, Module, Args, DepsGraph) ->
     digraph:add_vertex(DepsGraph, Module),

--- a/apps/ejabberd/test/gen_mod_deps_SUITE.erl
+++ b/apps/ejabberd/test/gen_mod_deps_SUITE.erl
@@ -55,7 +55,11 @@ starts_dependencies(_Config) ->
 starts_dependency_chain(_Config) ->
     set_deps(#{mod_a => [{mod_b, hard}], mod_b => [{mod_c, hard}]}),
     gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
-    check_started([mod_a, mod_b, mod_c]).
+
+    check_started([mod_a, mod_b, mod_c]),
+
+    StartOrder = [Mod || {_, {_, start_module, [_, Mod, _]}, _} <- meck:history(gen_mod)],
+    ?assertEqual([mod_c, mod_b, mod_a], StartOrder).
 
 
 starts_dependency_dag(_Config) ->

--- a/apps/ejabberd/test/gen_mod_deps_SUITE.erl
+++ b/apps/ejabberd/test/gen_mod_deps_SUITE.erl
@@ -1,0 +1,172 @@
+-module(gen_mod_deps_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MODS, [mod_a, mod_b, mod_c, mod_d]).
+
+all() ->
+    [
+     starts_modules,
+     starts_dependencies,
+     starts_dependency_chain,
+     starts_dependency_dag,
+     fails_on_dependency_cycle,
+     succeeds_on_cycle_with_soft_dep_in_path,
+     succeeds_on_adding_soft_dependency_cycle_edge,
+     forces_dependency_args,
+     appends_dependencies_args,
+     overrides_dependency_args,
+     merges_dependency_args,
+     replaces_modules,
+     reloads_modules_with_changed_args
+    ].
+
+%% Fixtures
+
+init_per_testcase(_, C) ->
+    meck:new(gen_mod, [passthrough]),
+    meck:new(?MODS, [non_strict]),
+    meck:expect(gen_mod, start_module,  fun(_, _, _) -> ok end),
+    meck:expect(gen_mod, stop_module,   fun(_, _)    -> ok end),
+    meck:expect(gen_mod, reload_module, fun(_, _, _) -> ok end),
+    meck:expect(gen_mod, get_deps, fun(Host, Mod, Opts) -> meck:passthrough([Host, Mod, Opts]) end),
+    C.
+
+end_per_testcase(_, C) ->
+    meck:unload(gen_mod),
+    meck:unload(?MODS),
+    C.
+
+%% Tests
+
+starts_modules(_Config) ->
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}, {mod_b, []}]),
+    check_started([mod_a, mod_b]).
+
+
+starts_dependencies(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started([mod_a, mod_b, mod_c]).
+
+
+starts_dependency_chain(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}], mod_b => [{mod_c, hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started([mod_a, mod_b, mod_c]).
+
+
+starts_dependency_dag(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, hard}],
+               mod_b => [{mod_c, hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started([mod_a, mod_b, mod_c]).
+
+
+fails_on_dependency_cycle(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}],
+               mod_b => [{mod_c, hard}],
+               mod_c => [{mod_a, hard}]}),
+    ?assertError(_, gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}])).
+
+
+succeeds_on_cycle_with_soft_dep_in_path(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}],
+               mod_b => [{mod_c, soft}],
+               mod_c => [{mod_a, hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started([mod_a, mod_b, mod_c]).
+
+
+succeeds_on_adding_soft_dependency_cycle_edge(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}], mod_b => [{mod_a, soft}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started([mod_a, mod_b]).
+
+
+forces_dependency_args(_Config) ->
+    set_deps(#{mod_a => [{mod_b, [arg1, arg2], hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started({mod_b, [arg1, arg2]}).
+
+
+appends_dependencies_args(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, [arg1], hard}],
+               mod_b => [{mod_c, [arg2], hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    check_started({mod_c, [arg1, arg2]}).
+
+
+overrides_dependency_args(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, [{arg, a}], hard}],
+               mod_b => [{mod_c, [{arg, b}], hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+
+    ?assert(meck:called(gen_mod, start_module, ['_', mod_c, [{arg, a}]]) orelse
+            meck:called(gen_mod, start_module, ['_', mod_c, [{arg, b}]])).
+
+
+merges_dependency_args(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, [{arg, a}], hard}],
+               mod_b => [{mod_c, [{arg, a}, arg2], hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+
+    check_started({mod_c, [{arg, a}, arg2]}).
+
+
+replaces_modules(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+
+    meck:reset(gen_mod),
+
+    gen_mod_deps:replace_modules(<<"host">>, [{mod_a, []}], [{mod_d, []}, {mod_b, []}]),
+
+    check_stopped(mod_a),
+    ?assertNot(meck:called(gen_mod, replace_module, '_')),
+    check_started(mod_d).
+
+
+reloads_modules_with_changed_args(_Config) ->
+    set_deps(#{mod_a => [{mod_b, hard}]}),
+    gen_mod_deps:start_modules(<<"host">>, [{mod_a, []}]),
+    gen_mod_deps:replace_modules(<<"host">>, [{mod_a, []}], [{mod_b, [arg]}]),
+    check_reloaded({mod_b, [arg]}).
+
+%% Helpers
+
+set_deps(DepsMap) ->
+    maps:fold(fun(Mod, Deps, _) -> meck:expect(Mod, deps, fun(_, _) -> Deps end) end,
+              undefined, DepsMap).
+
+
+check_started([]) -> ok;
+check_started([{Mod, Args} | Mods]) ->
+    ?assert(meck:called(gen_mod, start_module, ['_', Mod, Args])),
+    check_started(Mods);
+check_started([Mod | Mods]) ->
+    ?assert(meck:called(gen_mod, start_module, ['_', Mod, '_'])),
+    check_started(Mods);
+check_started(Mod) ->
+    check_started([Mod]).
+
+
+check_stopped([]) -> ok;
+check_stopped([Mod | Mods]) ->
+    ?assert(meck:called(gen_mod, stop_module, ['_', Mod])),
+    check_stopped(Mods);
+check_stopped(Mod) ->
+    check_stopped([Mod]).
+
+
+check_reloaded([]) -> ok;
+check_reloaded([{Mod, Args} | Mods]) ->
+    ?assert(meck:called(gen_mod, reload_module, ['_', Mod, Args])),
+    check_reloaded(Mods);
+check_reloaded([Mod | Mods]) ->
+    ?assert(meck:called(gen_mod, reload_module, ['_', Mod, '_'])),
+    check_reloaded(Mods);
+check_reloaded(Mod) ->
+    check_reloaded([Mod]).

--- a/elvis.config
+++ b/elvis.config
@@ -1,21 +1,26 @@
-[
- {
-  elvis,
+[{elvis, [{
+  config,
   [
-   {config,
-    [#{dirs => ["apps/*/src", "apps/*/test", "test/ejabberd_tests/tests"],
-       filter => "*.erl",
-       ruleset => erl_files,
-       rules => [{elvis_style, line_length, #{limit => 100,
-                                              skip_comments => false}},
-                 {elvis_style,
-                  variable_naming_convention,
-                  #{regex => "^_{0,2}([A-Z][0-9a-zA-Z]*)$"}},
-		         {elvis_style, dont_repeat_yourself, #{min_complexity => 20}}
-		]
-      }
-    ]
-   }
+    #{
+      dirs => ["apps/*/src"],
+      filter => "*.erl",
+      ruleset => erl_files,
+      rules =>
+      [
+        {elvis_style, line_length, #{limit => 100, skip_comments => false}},
+        {elvis_style, dont_repeat_yourself, #{min_complexity => 20}}
+      ]
+    },
+    #{
+      dirs => ["apps/*/test", "test/ejabberd_tests/tests"],
+      filter => "*.erl",
+      ruleset => erl_files,
+      rules =>
+      [
+        {elvis_style, line_length, #{limit => 100, skip_comments => false}},
+        {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+        {elvis_style, variable_naming_convention, #{regex => "^(_?[A-Z][0-9a-zA-Z]*)$"}}
+      ]
+    }
   ]
- }
-].
+}]}].

--- a/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
@@ -113,7 +113,7 @@ simple_message(Config) ->
            after 2000 ->
                    error(missing_request)
            end,
-    ct:pal("Got request ~p~n", [Body]),
+    % ct:pal("Got request ~p~n", [Body]),
     {_, _} = binary:match(Body, <<"alice">>),
     {_, _} = binary:match(Body, <<"Simple">>).
 

--- a/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_http_notification_SUITE.erl
@@ -58,7 +58,7 @@ init_per_suite(Config0) ->
     escalus:create_users(Config1, escalus:get_users([alice, bob])).
 
 end_per_suite(Config) ->
-    escalus:delete_users(Config, [alice, bob]),
+    escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
 init_per_group(mod_http_notification_tests, Config) ->


### PR DESCRIPTION
This PR introduces a mechanism for inter-modular dependencies. With this PR, a module (`mod_*`) can expose a `deps/2` function:

```erlang
-spec deps(Host :: ejabberd:server(), Opts :: proplists:proplist()) ->
                      [{module(), proplists:proplist(), hard | soft} |
                       {module(), hard | soft}]. 
```

`deps/2` returns a list of dependencies of the module. The dependent module can specify parameters with which the dependee should be started (the parameters will be merged with those given by the user). The last element of the tuple specifies whether the ordering can be broken in case of cycle (in that case `soft` dependency may be started after the dependent module).

A new `gen_mod_deps` module is responsible for resolving the dependencies along with their parameters and topologically sorting the dependency graph to determine starting order.