### PR TITLE
Fix external component disconnect over websocket

### DIFF
--- a/test/ejabberd_tests/rebar.config
+++ b/test/ejabberd_tests/rebar.config
@@ -4,7 +4,7 @@
 {require_otp_vsn, "1[789]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "3.0.0"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "e1eca08218c21f1ac9d45431194e4463119efff6"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "2.4.0"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},

--- a/test/ejabberd_tests/tests/component_SUITE.erl
+++ b/test/ejabberd_tests/tests/component_SUITE.erl
@@ -52,6 +52,7 @@ suite() ->
 
 xep0114_tests() ->
     [register_one_component,
+     dirty_disconnect,
      register_two_components,
      try_registering_with_wrong_password,
      try_registering_component_twice,
@@ -109,6 +110,14 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 %% Tests
 %%--------------------------------------------------------------------
+dirty_disconnect(Config) ->
+    %% Given one connected component, kill the connection and reconnect
+    CompOpts = ?config(component1, Config),
+    {Component, _, _} = connect_component(CompOpts),
+    escalus_connection:kill(Component),
+    {Component1, _, _} = connect_component(CompOpts),
+    ok = escalus_connection:stop(Component1).
+
 register_one_component(Config) ->
     %% Given one connected component
     CompOpts = ?config(component1, Config),


### PR DESCRIPTION
This PR addresses #1104

Proposed changes include:
* ejabberd_service now monitors the (cowboy web)socket process and terminates itself when the monitor is triggered. This causes the route to be unregistered so the external component will be accepted without conflict when it connects again.

This is effectively equivalent to ejabberd_c2s behavior - it also uses the monitor to detect that web socket is closed.