### PR TITLE
Showcase how Vim formats Erlang

### DIFF
--- a/apps/ejabberd/src/ejabberd_s2s_in.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_in.erl
@@ -68,14 +68,14 @@
                 auth_domain           :: binary(),
                 connections = ?DICT:new(),
                 timer                 :: reference()
-              }).
+               }).
 -type state() :: #state{}.
 
 -type statename() :: 'stream_established' | 'wait_for_feature_request'.
 %% FSM handler return value
 -type fsm_return() :: {'stop', Reason :: 'normal', state()}
-                    | {'next_state', statename(), state()}
-                    | {'next_state', statename(), state(), Timeout :: integer()}.
+| {'next_state', statename(), state()}
+| {'next_state', statename(), state(), Timeout :: integer()}.
 %-define(DBGFSM, true).
 
 -ifdef(DBGFSM).
@@ -95,11 +95,11 @@
 
 -define(STREAM_HEADER(Version),
         (<<"<?xml version='1.0'?>"
-         "<stream:stream "
-         "xmlns:stream='http://etherx.jabber.org/streams' "
-         "xmlns='jabber:server' "
-         "xmlns:db='jabber:server:dialback' "
-         "id='", (StateData#state.streamid)/binary, "'", Version/binary, ">">>)
+           "<stream:stream "
+           "xmlns:stream='http://etherx.jabber.org/streams' "
+           "xmlns='jabber:server' "
+           "xmlns:db='jabber:server:dialback' "
+           "id='", (StateData#state.streamid)/binary, "'", Version/binary, ">">>)
        ).
 
 -define(STREAM_TRAILER, <<"</stream:stream>">>).
@@ -120,8 +120,8 @@
 %%% API
 %%%----------------------------------------------------------------------
 -spec start(_,_) -> {'error',_}
-                  | {'ok','undefined' | pid()}
-                  | {'ok','undefined' | pid(),_}.
+                    | {'ok','undefined' | pid()}
+                    | {'ok','undefined' | pid(),_}.
 start(SockData, Opts) ->
     ?SUPERVISOR_START.
 
@@ -153,21 +153,21 @@ init([{SockMod, Socket}, Opts]) ->
                  _ -> none
              end,
     {StartTLS, TLSRequired, TLSCertverify} = case ejabberd_config:get_local_option(s2s_use_starttls) of
-             UseTls when (UseTls==undefined) or (UseTls==false) ->
-                 {false, false, false};
-             UseTls when (UseTls==true) or (UseTls==optional) ->
-                 {true, false, false};
-             required ->
-                 {true, true, false};
-             required_trusted ->
-                 {true, true, true}
-         end,
+                                                 UseTls when (UseTls==undefined) or (UseTls==false) ->
+                                                     {false, false, false};
+                                                 UseTls when (UseTls==true) or (UseTls==optional) ->
+                                                     {true, false, false};
+                                                 required ->
+                                                     {true, true, false};
+                                                 required_trusted ->
+                                                     {true, true, true}
+                                             end,
     TLSOpts1 = case ejabberd_config:get_local_option(s2s_certfile) of
-                  undefined ->
-                      [];
-                  CertFile ->
-                      [{certfile, CertFile}]
-              end,
+                   undefined ->
+                       [];
+                   CertFile ->
+                       [{certfile, CertFile}]
+               end,
     TLSOpts2 = lists:filter(fun({protocol_options, _}) -> true;
                                ({dhfile, _}) -> true;
                                (_) -> false
@@ -203,48 +203,48 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
               StateData#state.tls and (not StateData#state.authenticated) ->
             send_text(StateData, ?STREAM_HEADER(<<" version='1.0'">>)),
             SASL =
-                if
-                    StateData#state.tls_enabled ->
-                        case (StateData#state.sockmod):get_peer_certificate(
-                               StateData#state.socket) of
-                            {ok, Cert} ->
-                                case (StateData#state.sockmod):get_verify_result(StateData#state.socket) of
-                                    0 ->
-                                        [#xmlel{name = <<"mechanisms">>,
-                                                attrs = [{<<"xmlns">>, ?NS_SASL}],
-                                                children = [#xmlel{name = <<"mechanism">>,
-                                                                   children = [#xmlcdata{content = <<"EXTERNAL">>}]}]}];
-                                    CertVerifyRes ->
-                                        case StateData#state.tls_certverify of
-                                            true -> {error_cert_verif, CertVerifyRes, Cert};
-                                            false -> []
-                                        end
-                                end;
-                            error ->
-                                []
-                        end;
-                    true ->
-                        []
-                end,
+            if
+                StateData#state.tls_enabled ->
+                    case (StateData#state.sockmod):get_peer_certificate(
+                                                     StateData#state.socket) of
+                        {ok, Cert} ->
+                            case (StateData#state.sockmod):get_verify_result(StateData#state.socket) of
+                                0 ->
+                                    [#xmlel{name = <<"mechanisms">>,
+                                            attrs = [{<<"xmlns">>, ?NS_SASL}],
+                                            children = [#xmlel{name = <<"mechanism">>,
+                                                               children = [#xmlcdata{content = <<"EXTERNAL">>}]}]}];
+                                CertVerifyRes ->
+                                    case StateData#state.tls_certverify of
+                                        true -> {error_cert_verif, CertVerifyRes, Cert};
+                                        false -> []
+                                    end
+                            end;
+                        error ->
+                            []
+                    end;
+                true ->
+                    []
+            end,
             StartTLS = if
                            StateData#state.tls_enabled ->
                                [];
                            (not StateData#state.tls_enabled) and (not StateData#state.tls_required) ->
-                              [#xmlel{name = <<"starttls">>,
-                                      attrs = [{<<"xmlns">>, ?NS_TLS}]}];
+                               [#xmlel{name = <<"starttls">>,
+                                       attrs = [{<<"xmlns">>, ?NS_TLS}]}];
                            (not StateData#state.tls_enabled) and StateData#state.tls_required ->
-                              [#xmlel{name = <<"starttls">>,
-                                      attrs = [{<<"xmlns">>, ?NS_TLS}],
-                                      children = [#xmlel{name = <<"required">>}]}]
+                               [#xmlel{name = <<"starttls">>,
+                                       attrs = [{<<"xmlns">>, ?NS_TLS}],
+                                       children = [#xmlel{name = <<"required">>}]}]
                        end,
             case SASL of
                 {error_cert_verif, CertVerifyResult, Certificate} ->
                     CertError = fast_tls:get_cert_verify_string(CertVerifyResult, Certificate),
                     RemoteServer = xml:get_attr_s(<<"from">>, Attrs),
                     ?INFO_MSG("Closing s2s connection: ~s <--> ~s (~s)",
-                      [StateData#state.server, RemoteServer, CertError]),
+                              [StateData#state.server, RemoteServer, CertError]),
                     send_text(StateData, exml:to_binary(
-                                ?SERRT_POLICY_VIOLATION(<<"en">>, CertError))),
+                                           ?SERRT_POLICY_VIOLATION(<<"en">>, CertError))),
                     {atomic, Pid} = ejabberd_s2s:find_connection(
                                       jid:make(<<"">>, Server, <<"">>),
                                       jid:make(<<"">>, RemoteServer, <<"">>)),
@@ -255,10 +255,10 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
                     send_element(StateData,
                                  #xmlel{name = <<"stream:features">>,
                                         children = SASL ++ StartTLS ++
-                                                   ejabberd_hooks:run_fold(
-                                                     s2s_stream_features,
-                                                     Server,
-                                                     [], [Server])}),
+                                        ejabberd_hooks:run_fold(
+                                          s2s_stream_features,
+                                          Server,
+                                          [], [Server])}),
                     {next_state, wait_for_feature_request, StateData#state{server = Server}}
             end;
         {<<"jabber:server">>, _, Server, true} when
@@ -297,8 +297,8 @@ wait_for_feature_request({xmlstreamelement, El}, StateData) ->
     SockMod = (StateData#state.sockmod):get_sockmod(StateData#state.socket),
     case {xml:get_attr_s(<<"xmlns">>, Attrs), Name} of
         {?NS_TLS, <<"starttls">>} when TLS == true,
-                                   TLSEnabled == false,
-                                   SockMod == gen_tcp ->
+                                       TLSEnabled == false,
+                                       SockMod == gen_tcp ->
             ?DEBUG(<<"starttls">>, []),
             Socket = StateData#state.socket,
             TLSOpts = case ejabberd_config:get_local_option(
@@ -313,10 +313,10 @@ wait_for_feature_request({xmlstreamelement, El}, StateData) ->
                                  StateData#state.tls_options)]
                       end,
             TLSSocket = (StateData#state.sockmod):starttls(
-                          Socket, TLSOpts,
-                          exml:to_binary(
-                            #xmlel{name = <<"proceed">>,
-                                   attrs = [{<<"xmlns">>, ?NS_TLS}]})),
+                                                    Socket, TLSOpts,
+                                                    exml:to_binary(
+                                                      #xmlel{name = <<"proceed">>,
+                                                             attrs = [{<<"xmlns">>, ?NS_TLS}]})),
             {next_state, wait_for_stream,
              StateData#state{socket = TLSSocket,
                              streamid = new_id(),
@@ -330,47 +330,47 @@ wait_for_feature_request({xmlstreamelement, El}, StateData) ->
                     Auth = jlib:decode_base64(xml:get_cdata(Els)),
                     AuthDomain = jid:nameprep(Auth),
                     AuthRes =
-                        case (StateData#state.sockmod):get_peer_certificate(
-                               StateData#state.socket) of
-                            {ok, Cert} ->
-                                case (StateData#state.sockmod):get_verify_result(
-                                       StateData#state.socket) of
-                                    0 ->
-                                        case AuthDomain of
-                                            error ->
-                                                false;
-                                            _ ->
-                                                case ejabberd_s2s:domain_utf8_to_ascii(AuthDomain) of
-                                                    false ->
-                                                        false;
-                                                    PCAuthDomain ->
-                                                        lists:any(
-                                                          fun(D) ->
-                                                                  match_domain(
-                                                                    PCAuthDomain, D)
-                                                          end, get_cert_domains(Cert))
-                                                end
-                                        end;
-                                    _ ->
-                                        false
-                                end;
-                            error ->
-                                false
-                        end,
+                    case (StateData#state.sockmod):get_peer_certificate(
+                                                     StateData#state.socket) of
+                        {ok, Cert} ->
+                            case (StateData#state.sockmod):get_verify_result(
+                                                             StateData#state.socket) of
+                                0 ->
+                                    case AuthDomain of
+                                        error ->
+                                            false;
+                                        _ ->
+                                            case ejabberd_s2s:domain_utf8_to_ascii(AuthDomain) of
+                                                false ->
+                                                    false;
+                                                PCAuthDomain ->
+                                                    lists:any(
+                                                      fun(D) ->
+                                                              match_domain(
+                                                                PCAuthDomain, D)
+                                                      end, get_cert_domains(Cert))
+                                            end
+                                    end;
+                                _ ->
+                                    false
+                            end;
+                        error ->
+                            false
+                    end,
                     if
                         AuthRes ->
                             (StateData#state.sockmod):reset_stream(
-                              StateData#state.socket),
+                                                        StateData#state.socket),
                             send_element(StateData,
-                                          #xmlel{name = <<"success">>,
-                                                 attrs = [{<<"xmlns">>, ?NS_SASL}]}),
-                             ?DEBUG("(~w) Accepted s2s authentication for ~s",
-                                       [StateData#state.socket, AuthDomain]),
-                             {next_state, wait_for_stream,
-                              StateData#state{streamid = new_id(),
-                                              authenticated = true,
-                                              auth_domain = AuthDomain
-                                             }};
+                                         #xmlel{name = <<"success">>,
+                                                attrs = [{<<"xmlns">>, ?NS_SASL}]}),
+                            ?DEBUG("(~w) Accepted s2s authentication for ~s",
+                                   [StateData#state.socket, AuthDomain]),
+                            {next_state, wait_for_stream,
+                             StateData#state{streamid = new_id(),
+                                             authenticated = true,
+                                             auth_domain = AuthDomain
+                                            }};
                         true ->
                             send_element(StateData,
                                          #xmlel{name = <<"failure">>,
@@ -459,22 +459,22 @@ stream_established({xmlstreamelement, El}, StateData) ->
                     if
                         StateData#state.authenticated ->
                             case (LFrom == StateData#state.auth_domain)
-                                andalso
-                                lists:member(
-                                  LTo,
-                                  ejabberd_router:dirty_get_all_domains()) of
+                                 andalso
+                                 lists:member(
+                                   LTo,
+                                   ejabberd_router:dirty_get_all_domains()) of
                                 true ->
                                     if ((Name == <<"iq">>) or
                                         (Name == <<"message">>) or
                                         (Name == <<"presence">>)) ->
-                                            ejabberd_hooks:run(
-                                              s2s_receive_packet,
-                                              LTo,
-                                              [From, To, NewEl]),
-                                            ejabberd_router:route(
-                                              From, To, NewEl);
+                                           ejabberd_hooks:run(
+                                             s2s_receive_packet,
+                                             LTo,
+                                             [From, To, NewEl]),
+                                           ejabberd_router:route(
+                                             From, To, NewEl);
                                        true ->
-                                            error
+                                           error
                                     end;
                                 false ->
                                     error
@@ -486,14 +486,14 @@ stream_established({xmlstreamelement, El}, StateData) ->
                                     if ((Name == <<"iq">>) or
                                         (Name == <<"message">>) or
                                         (Name == <<"presence">>)) ->
-                                            ejabberd_hooks:run(
-                                              s2s_receive_packet,
-                                              LTo,
-                                              [From, To, NewEl]),
-                                            ejabberd_router:route(
-                                              From, To, NewEl);
+                                           ejabberd_hooks:run(
+                                             s2s_receive_packet,
+                                             LTo,
+                                             [From, To, NewEl]),
+                                           ejabberd_router:route(
+                                             From, To, NewEl);
                                        true ->
-                                            error
+                                           error
                                     end;
                                 _ ->
                                     error
@@ -585,7 +585,7 @@ handle_sync_event(get_state_infos, _From, StateName, StateData) ->
                     false ->
                         Connections = StateData#state.connections,
                         [D || {{D, _}, established} <-
-                            dict:to_list(Connections)]
+                              dict:to_list(Connections)]
                 end,
     Infos = [
              {direction, in},
@@ -681,12 +681,12 @@ cancel_timer(Timer) ->
         {timeout, Timer, _} ->
             ok
     after 0 ->
-            ok
+              ok
     end.
 
 
 -spec is_key_packet(jlib:xmlel()) -> 'false' | {'key',_,_,_,binary()}
-                                  | {'verify',_,_,_,binary()}.
+                                     | {'verify',_,_,_,binary()}.
 is_key_packet(#xmlel{name = Name, attrs = Attrs,
                      children = Els}) when Name == <<"db:result">> ->
     {key,
@@ -708,9 +708,9 @@ is_key_packet(_) ->
 -spec get_cert_domains(#'Certificate'{}) ->  [any()].
 get_cert_domains(Cert) ->
     {rdnSequence, Subject} =
-        (Cert#'Certificate'.tbsCertificate)#'TBSCertificate'.subject,
+    (Cert#'Certificate'.tbsCertificate)#'TBSCertificate'.subject,
     Extensions =
-        (Cert#'Certificate'.tbsCertificate)#'TBSCertificate'.extensions,
+    (Cert#'Certificate'.tbsCertificate)#'TBSCertificate'.extensions,
     lists:flatmap(
       fun(#'AttributeTypeAndValue'{type = ?'id-at-commonName',
                                    value = Val}) ->
@@ -740,58 +740,58 @@ get_cert_domains(Cert) ->
          (_) ->
               []
       end, lists:flatten(Subject)) ++
-        lists:flatmap(
-          fun(#'Extension'{extnID = ?'id-ce-subjectAltName',
-                           extnValue = Val}) ->
-                  BVal = if
-                             is_list(Val) -> list_to_binary(Val);
-                             is_binary(Val) -> Val;
-                             true -> Val
-                         end,
-                  case ?PKIXIMPLICIT:decode('SubjectAltName', BVal) of
-                      {ok, SANs} ->
-                          lists:flatmap(
-                            fun({otherName,
-                                 #'AnotherName'{'type-id' = ?'id-on-xmppAddr',
-                                                value = XmppAddr
-                                               }}) ->
-                                    case 'XmppAddr':decode(
-                                           'XmppAddr', XmppAddr) of
-                                        {ok, D} when is_binary(D) ->
-                                            case jid:from_binary(D) of
-                                                #jid{luser = <<"">>,
-                                                     lserver = LD,
-                                                     lresource = <<"">>} ->
-                                                    case ejabberd_s2s:domain_utf8_to_ascii(LD) of
-                                                        false ->
-                                                            [];
-                                                        PCLD ->
-                                                            [PCLD]
-                                                    end;
-                                                _ ->
-                                                    []
-                                            end;
-                                        _ ->
-                                            []
-                                    end;
-                               ({dNSName, D}) when is_list(D) ->
-                                    case jid:from_binary(list_to_binary(D)) of
-                                        #jid{luser = <<"">>,
-                                             lserver = LD,
-                                             lresource = <<"">>} ->
-                                            [LD];
-                                        _ ->
-                                            []
-                                    end;
-                               (_) ->
-                                    []
-                            end, SANs);
-                      _ ->
-                          []
-                  end;
-             (_) ->
-                  []
-          end, Extensions).
+    lists:flatmap(
+      fun(#'Extension'{extnID = ?'id-ce-subjectAltName',
+                       extnValue = Val}) ->
+              BVal = if
+                         is_list(Val) -> list_to_binary(Val);
+                         is_binary(Val) -> Val;
+                         true -> Val
+                     end,
+              case ?PKIXIMPLICIT:decode('SubjectAltName', BVal) of
+                  {ok, SANs} ->
+                      lists:flatmap(
+                        fun({otherName,
+                             #'AnotherName'{'type-id' = ?'id-on-xmppAddr',
+                                            value = XmppAddr
+                                           }}) ->
+                                case 'XmppAddr':decode(
+                                                  'XmppAddr', XmppAddr) of
+                                    {ok, D} when is_binary(D) ->
+                                        case jid:from_binary(D) of
+                                            #jid{luser = <<"">>,
+                                                 lserver = LD,
+                                                 lresource = <<"">>} ->
+                                                case ejabberd_s2s:domain_utf8_to_ascii(LD) of
+                                                    false ->
+                                                        [];
+                                                    PCLD ->
+                                                        [PCLD]
+                                                end;
+                                            _ ->
+                                                []
+                                        end;
+                                    _ ->
+                                        []
+                                end;
+                           ({dNSName, D}) when is_list(D) ->
+                                case jid:from_binary(list_to_binary(D)) of
+                                    #jid{luser = <<"">>,
+                                         lserver = LD,
+                                         lresource = <<"">>} ->
+                                        [LD];
+                                    _ ->
+                                        []
+                                end;
+                           (_) ->
+                                []
+                        end, SANs);
+                  _ ->
+                      []
+              end;
+         (_) ->
+              []
+      end, Extensions).
 
 
 -spec match_domain(binary(), binary()) -> boolean().
@@ -813,8 +813,8 @@ match_labels([_ | _], []) ->
 match_labels([DL | DLabels], [PL | PLabels]) ->
     PLlist = binary_to_list(PL),
     case lists:all(fun(C) -> (($a =< C) andalso (C =< $z))
-                                 orelse (($0 =< C) andalso (C =< $9))
-                                 orelse (C == $-) orelse (C == $*)
+                             orelse (($0 =< C) andalso (C =< $9))
+                             orelse (C == $-) orelse (C == $*)
                    end, PLlist) of
         true ->
             Regexp = xmerl_regexp:sh_to_awk(PLlist),

--- a/tools/vim-reindent
+++ b/tools/vim-reindent
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+pushd /
+HERE=`popd`
+popd > /dev/null 2>&1
+
+vim -u $HERE/tools/vim-reindent.rc -f +'bufdo execute "normal gg=G" | update' +qall $@
+

--- a/tools/vim-reindent.rc
+++ b/tools/vim-reindent.rc
@@ -1,0 +1,7 @@
+filetype plugin indent on
+
+" don't use tabs
+set expandtab
+
+" 4 spaces for indentation level
+set shiftwidth=4 tabstop=4 softtabstop=4


### PR DESCRIPTION
Prerequisite: Vim 7.4 (older might work, not sure, only tested with this one)

This shows the default Vim formatting on `ejabberd_c2s` and `ejabberd_s2s_in`.
This formatting approach can be easily scripted, e.g. in a git pre-commit hook. Let's compare this with the default Emacs formatting and see which looks better / has fewer problem cases remaining when we format the code.

Issues:
- [] `++ maybe_sasl_mechanisms(Server)` doesn't get an extra level of indentation / extra alignment
- [] `| {'next_state', statename(), state()}` in multiline `-type`/`-spec` attributes gets zero alignment

Please comment if you see more problems.