### PR TITLE
Simplify MAM configuration

### DIFF
--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -27,6 +27,15 @@
 -module(gen_mod).
 -author('alexey@process-one.net').
 
+-type dep_arguments() :: proplists:proplist().
+-type dep_hardness() :: soft | hard.
+-type deps_list() :: [
+                      {module(), dep_arguments(), dep_hardness()} |
+                      {module(), dep_hardness()}
+                     ].
+
+-export_type([deps_list/0]).
+
 -export([
          % Modules start & stop
          start/0,
@@ -81,8 +90,7 @@
 %% dependent module).
 %%
 %% -callback deps(Host :: ejabberd:server(), Opts :: proplists:list()) ->
-%%     [{module(), DepOpts :: proplists:list(), soft | hard} |
-%%      {module(), soft | hard}].
+%%     deps_list().
 
 -spec start() -> 'ok'.
 start() ->
@@ -428,9 +436,7 @@ clear_opts(Module, Opts0) ->
 
 
 -spec get_deps(Host :: ejabberd:server(), Module :: module(),
-               Opts :: proplists:proplist()) ->
-                      [{module(), proplists:proplist(), hard | soft} |
-                       {module(), hard | soft}].
+               Opts :: proplists:proplist()) -> deps_list().
 get_deps(Host, Module, Opts) ->
     %% the module has to be loaded,
     %% otherwise the erlang:function_exported/3 returns false

--- a/apps/ejabberd/src/mod_mam_meta.erl
+++ b/apps/ejabberd/src/mod_mam_meta.erl
@@ -80,7 +80,7 @@ parse_opts(Type, Opts, Deps) ->
                       Opt -> {true, Opt}
                   end
           end,
-          [add_archived_element, is_complete_message, host]),
+          [add_archived_element, is_archivable_message, host]),
 
     WithCoreDeps = add_dep(CoreMod, CoreModOpts, Deps),
     Backend = proplists:get_value(backend, Opts, odbc),

--- a/apps/ejabberd/src/mod_mam_meta.erl
+++ b/apps/ejabberd/src/mod_mam_meta.erl
@@ -1,0 +1,178 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(mod_mam_meta).
+-behaviour(gen_mod).
+
+-type deps() :: #{module() => proplists:proplist()}.
+
+-export([start/2, stop/1, deps/2]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec start(Host :: ejabberd:server(), Opts :: list()) -> any().
+start(_Host, _Opts) ->
+    ok.
+
+
+-spec stop(Host :: ejabberd:server()) -> any().
+stop(_Host) ->
+    ok.
+
+
+-spec deps(_Host :: ejabberd:server(), Opts :: proplists:proplist()) ->
+                  [{Mod, Args, Hardness} | {Mod, Hardness}] when
+      Mod :: module(),
+      Args :: proplists:proplist(),
+      Hardness :: soft | hard.
+deps(_Host, Opts0) ->
+    Opts = normalize(Opts0),
+
+    DepsWithPm = handle_nested_opts(pm, Opts, [], #{}),
+    DepsWithPmAndMuc = handle_nested_opts(muc, Opts, false, DepsWithPm),
+
+    [{Dep, Args, hard} || {Dep, Args} <- maps:to_list(DepsWithPmAndMuc)].
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+-spec handle_nested_opts(Key :: atom(), RootOpts :: proplists:proplist(),
+                         Default :: term(), deps()) -> deps().
+handle_nested_opts(Key, RootOpts, Default, Deps) ->
+    case proplists:get_value(Key, RootOpts, Default) of
+        false -> Deps;
+        Opts0 ->
+            Opts = normalize(Opts0),
+            FullOpts = lists:ukeymerge(1, Opts, RootOpts),
+            parse_opts(Key, FullOpts, Deps)
+    end.
+
+
+-spec parse_opts(Type :: pm | muc, Opts :: proplists:proplist(), deps()) -> deps().
+parse_opts(Type, Opts, Deps) ->
+    CoreMod =
+        case Type of
+            pm -> mod_mam;
+            muc -> mod_mam_muc
+        end,
+
+    CoreModOpts =
+        lists:filtermap(
+          fun(Key) ->
+                  case proplists:lookup(Key, Opts) of
+                      none -> false;
+                      Opt -> {true, Opt}
+                  end
+          end,
+          [add_archived_element, is_complete_message, host]),
+
+    WithCoreDeps = add_dep(CoreMod, CoreModOpts, Deps),
+    Backend = proplists:get_value(backend, Opts, odbc),
+
+    parse_backend_opts(Backend, Type, Opts, WithCoreDeps).
+
+
+-spec parse_backend_opts(odbc | cassandra | riak, Type :: pm | muc,
+                         Opts :: proplists:proplist(), deps()) -> deps().
+parse_backend_opts(cassandra, Type, Opts, Deps0) ->
+    ModArch =
+        case Type of
+            pm -> mod_mam_cassandra_arch;
+            muc -> mod_mam_muc_cassandra_arch
+        end,
+
+    Deps = add_dep(ModArch, Deps0),
+
+    case proplists:get_value(user_prefs_store, Opts, false) of
+        cassandra -> add_dep(mod_mam_cassandra_prefs, [Type], Deps);
+        mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
+        mnesia_dirty -> add_dep(mod_mam_mnesia_dirty_prefs, [Type], Deps);
+        _ -> Deps
+    end;
+
+parse_backend_opts(riak, Type, Opts, Deps0) ->
+    Deps = add_dep(mod_mam_riak_timed_arch_yz, [Type], Deps0),
+
+    case proplists:get_value(user_prefs_store, Opts, false) of
+        mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
+        mnesia_dirty -> add_dep(mod_mam_mnesia_dirty_prefs, [Type], Deps);
+        _ -> Deps
+    end;
+
+parse_backend_opts(odbc, Type, Opts0, Deps0) ->
+    Opts = add_default_odbc_opts(Opts0),
+
+    {ModODBCArch, ModAsyncWriter} =
+        case Type of
+            pm -> {mod_mam_odbc_arch, mod_mam_odbc_async_pool_writer};
+            muc -> {mod_mam_muc_odbc_arch, mod_mam_muc_odbc_async_pool_writer}
+        end,
+
+    Deps1 = add_dep(ModODBCArch, [Type], Deps0),
+    Deps = add_dep(mod_mam_odbc_user, [Type], Deps1),
+
+    lists:foldl(
+      fun
+          ({cache_users, true}, Acc) ->
+              add_dep(mod_mam_cache_user, [Type], Acc);
+          ({user_prefs_store, odbc}, Acc) ->
+              add_dep(mod_mam_odbc_prefs, [Type], Acc);
+          ({user_prefs_store, mnesia}, Acc) ->
+              add_dep(mod_mam_mnesia_prefs, [Type], Acc);
+          ({user_prefs_store, mnesia_dirty}, Acc) ->
+              add_dep(mod_mam_mnesia_dirty_prefs, [Type], Acc);
+          ({odbc_message_format, simple}, Acc) ->
+              add_dep(ModODBCArch, [simple], Acc);
+          ({async_writer, true}, Acc) ->
+              AccWithNoWriter = add_dep(ModODBCArch, [no_writer], Acc),
+              add_dep(ModAsyncWriter, [Type], AccWithNoWriter);
+          (_, Acc) -> Acc
+      end,
+      Deps,
+      Opts).
+
+
+-spec normalize(proplists:proplist()) -> [{atom(), term()}].
+normalize(Opts) ->
+    lists:ukeysort(1, proplists:unfold(Opts)).
+
+
+-spec add_dep(Dep :: module(), deps()) -> deps().
+add_dep(Dep, Deps) ->
+    add_dep(Dep, [], Deps).
+
+
+-spec add_dep(Dep :: module(), Args :: proplists:proplist(), deps()) -> deps().
+add_dep(Dep, Args, Deps) ->
+    PrevArgs = maps:get(Dep, Deps, []),
+    NewArgs = Args ++ PrevArgs,
+    maps:put(Dep, NewArgs, Deps).
+
+
+-spec add_default_odbc_opts(Opts :: proplists:proplist()) -> proplists:proplist().
+add_default_odbc_opts(Opts) ->
+    lists:foldl(
+    fun({Key, _} = DefaultOpt, Acc) ->
+        case proplists:lookup(Key, Opts) of
+            none -> [DefaultOpt | Acc];
+            _ -> Acc
+        end
+    end,
+    Opts,
+    [{cache_users, true}, {async_writer, true}]).

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -207,8 +207,8 @@ stop(Host) ->
 -spec filter_room_packet(Packet :: packet(), EventData :: list()) -> packet().
 filter_room_packet(Packet, EventData) ->
     ?DEBUG("Incoming room packet.", []),
-    IsComplete = call_is_complete_message(?MODULE, incoming, Packet),
-    case IsComplete of
+    IsArchivable = mod_mam_muc_params:is_archivable_message(?MODULE, incoming, Packet),
+    case IsArchivable of
         true ->
             {_, FromNick}    = lists:keyfind(from_nick, 1, EventData),
             {_, FromJID}     = lists:keyfind(from_jid, 1, EventData),
@@ -927,20 +927,27 @@ compile_params_module(Params) ->
     code:load_binary(Mod, "mod_mam_muc_params.erl", Code).
 
 params_helper(Params) ->
+    %% Try is_complete_message opt for backwards compatibility
+    {IsArchivableModule, IsArchivableFunction} =
+        case proplists:get_value(is_archivable_message, Params) of
+            undefined ->
+                case proplists:get_value(is_complete_message, Params) of
+                    undefined -> {mod_mam_utils, is_archivable_message};
+                    OldStyleMod -> {OldStyleMod, is_complete_message}
+                end;
+
+            Mod -> {Mod, is_archivable_message}
+        end,
+
     binary_to_list(iolist_to_binary(io_lib:format(
         "-module(mod_mam_muc_params).~n"
         "-compile(export_all).~n"
         "add_archived_element() -> ~p.~n"
-        "is_complete_message() -> ~p.~n",
+        "is_archivable_message(Mod, Dir, Packet) -> ~p:~p(Mod, Dir, Packet).~n",
         [proplists:get_bool(add_archived_element, Params),
-         proplists:get_value(is_complete_message, Params, mod_mam_utils)]))).
+         IsArchivableModule, IsArchivableFunction]))).
 
 %% @doc Enable support for `<archived/>' element from MAM v0.2
 -spec add_archived_element() -> boolean().
 add_archived_element() ->
     mod_mam_muc_params:add_archived_element().
-
-call_is_complete_message(Module, Dir, Packet) ->
-    M = mod_mam_muc_params:is_complete_message(),
-    M:is_complete_message(Module, Dir, Packet).
-

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -29,7 +29,7 @@
          packet_to_x_user_jid/1,
          get_one_of_path/2,
          get_one_of_path/3,
-         is_complete_message/3,
+         is_archivable_message/3,
          wrap_message/6,
          result_set/4,
          result_query/2,
@@ -300,13 +300,13 @@ get_one_of_path(_Elem, [], Def) ->
 %% From v0.3: it is expected that all messages that hold meaningful content,
 %% rather than state changes such as Chat State Notifications, would be archived.
 %% @end
--spec is_complete_message(Mod :: module(), Dir :: incoming | outgoing,
+-spec is_archivable_message(Mod :: module(), Dir :: incoming | outgoing,
                           Packet :: jlib:xmlel()) -> boolean().
-is_complete_message(Mod, Dir, Packet=#xmlel{name = <<"message">>}) ->
+is_archivable_message(Mod, Dir, Packet=#xmlel{name = <<"message">>}) ->
     Type = xml:get_tag_attr_s(<<"type">>, Packet),
     is_valid_message_type(Mod, Dir, Type) andalso
     is_valid_message(Mod, Dir, Packet);
-is_complete_message(_, _, _) ->
+is_archivable_message(_, _, _) ->
     false.
 
 is_valid_message_type(_, _, <<"">>)          -> true;
@@ -884,4 +884,3 @@ success_sql_query(Host, Query) ->
         Result ->
             Result
     end.
-

--- a/apps/ejabberd/test/mod_mam_meta_SUITE.erl
+++ b/apps/ejabberd/test/mod_mam_meta_SUITE.erl
@@ -1,0 +1,174 @@
+-module(mod_mam_meta_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() -> [
+          overrides_general_options,
+          sets_odbc_as_default_backend,
+          assumes_pm_by_default,
+          handles_disabled_pm,
+          disables_sync_writer_on_async_writer,
+          disables_sync_muc_writer_on_async_writer,
+          produces_valid_configurations,
+          handles_riak_config,
+          handles_cassandra_config,
+          example_muc_only_no_pref_good_performance,
+          example_pm_only_good_performance
+         ].
+
+%% Tests
+
+overrides_general_options(_Config) ->
+    Deps = deps([{backend, odbc}, {pm, [{backend, cassandra}]}, {muc, []}]),
+
+    ?assert(lists:keymember(mod_mam_cassandra_arch, 1, Deps)),
+    ?assert(lists:keymember(mod_mam_muc_odbc_arch, 1, Deps)),
+    ?assertNot(lists:keymember(mod_mam_odbc_arch, 1, Deps)).
+
+
+sets_odbc_as_default_backend(_Config) ->
+    Deps = deps([{pm, []}]),
+    ?assert(lists:keymember(mod_mam_odbc_arch, 1, Deps)).
+
+
+assumes_pm_by_default(_Config) ->
+    Deps = deps([]),
+    ?assert(lists:keymember(mod_mam, 1, Deps)).
+
+
+handles_disabled_pm(_Config) ->
+    Deps = deps([{pm, false}, {muc, []}]),
+    ?assertNot(lists:keymember(mod_mam, 1, Deps)).
+
+
+disables_sync_writer_on_async_writer(_Config) ->
+    Deps = deps([{pm, [async_writer]}]),
+    {_, Args, _} = lists:keyfind(mod_mam_odbc_arch, 1, Deps),
+    ?assert(lists:member(no_writer, Args)).
+
+
+disables_sync_muc_writer_on_async_writer(_Config) ->
+    Deps = deps([{pm, false}, {muc, [async_writer]}]),
+    {_, Args, _} = lists:keyfind(mod_mam_muc_odbc_arch, 1, Deps),
+    ?assert(lists:member(no_writer, Args)).
+
+
+produces_valid_configurations(_Config) ->
+    Deps = deps([
+                 {backend, odbc},
+                 cache_users,
+                 add_archived_element,
+
+                 {pm, [{user_prefs_store, odbc}, {async_writer, false}]},
+                 {muc, [
+                        {host, <<"host">>},
+                        {odbc_message_format, simple},
+                        {user_prefs_store, mnesia}
+                       ]}
+                ]),
+
+    check_has_args(mod_mam, [{add_archived_element, true}], Deps),
+    check_has_args(mod_mam_muc, [{host, <<"host">>}], Deps),
+    check_has_args(mod_mam_odbc_arch, [pm], Deps),
+    check_has_args(mod_mam_muc_odbc_arch, [no_writer, simple], Deps),
+    check_has_args(mod_mam_odbc_user, [pm, muc], Deps),
+    check_has_args(mod_mam_cache_user, [pm, muc], Deps),
+    check_has_args(mod_mam_mnesia_prefs, [muc], Deps),
+    check_has_args(mod_mam_odbc_prefs, [pm], Deps),
+    check_has_args(mod_mam_muc_odbc_async_pool_writer, [], Deps),
+
+    check_has_no_args(mod_mam_odbc_arch, [muc, simple, no_writer], Deps),
+    check_has_no_args(mod_mam_mnesia_prefs, [pm], Deps),
+    check_has_no_args(mod_mam_odbc_prefs, [muc], Deps),
+    ?assertNot(lists:keymember(mod_mam_odbc_async_pool_writer, 1, Deps)).
+
+
+handles_riak_config(_Config) ->
+    Deps = deps([{backend, riak}, {pm, [{user_prefs_store, mnesia}]}, {muc, []}]),
+
+    ?assert(lists:keymember(mod_mam, 1, Deps)),
+    ?assert(lists:keymember(mod_mam_muc, 1, Deps)),
+    check_has_args(mod_mam_riak_timed_arch_yz, [pm, muc], Deps),
+    check_has_args(mod_mam_mnesia_prefs, [pm], Deps),
+    check_has_no_args(mod_mam_mnesia_prefs, [muc], Deps).
+
+
+handles_cassandra_config(_Config) ->
+    Deps = deps([
+                 {backend, cassandra},
+                 {pm, [{user_prefs_store, cassandra}]},
+                 {muc, [{user_prefs_store, mnesia}]}
+                ]),
+
+    ?assert(lists:keymember(mod_mam_cassandra_arch, 1, Deps)),
+    ?assert(lists:keymember(mod_mam_muc_cassandra_arch, 1, Deps)),
+    check_has_args(mod_mam_mnesia_prefs, [muc], Deps),
+    check_has_args(mod_mam_cassandra_prefs, [pm], Deps).
+
+
+example_muc_only_no_pref_good_performance(_Config) ->
+    Deps = deps([
+                 cache_users,
+                 async_writer,
+                 {pm, false},
+                 {muc, [{host, "muc.@HOST@"}]}
+                ]),
+
+    check_equal_deps([
+                      {mod_mam_odbc_user, [muc]},
+                      {mod_mam_cache_user, [muc]},
+                      %% 'muc' argument is ignored by the module
+                      {mod_mam_muc_odbc_arch, [muc, no_writer]},
+                      %% 'muc' argument is ignored by the module
+                      {mod_mam_muc_odbc_async_pool_writer, [muc]},
+                      {mod_mam_muc, [{host, "muc.@HOST@"}]}
+                     ], Deps).
+
+
+example_pm_only_good_performance(_Config) ->
+    Deps = deps([
+                 cache_users,
+                 async_writer,
+                 {user_prefs_store, mnesia_dirty}
+                ]),
+
+    check_equal_deps([
+                      {mod_mam_odbc_user, [pm]},
+                      {mod_mam_cache_user, [pm]},
+                      {mod_mam_mnesia_dirty_prefs, [pm]},
+                      {mod_mam_odbc_arch, [pm, no_writer]},
+                      {mod_mam_odbc_async_pool_writer, [pm]},
+                      {mod_mam, []}
+                     ], Deps).
+
+%% Helpers
+
+
+check_equal_deps(A, B) ->
+    ?assertEqual(sort_deps(A), sort_deps(B)).
+
+
+sort_deps(Deps) ->
+    lists:map(
+      fun
+          ({Mod, ArgsOrHardness}) -> {Mod, lists:sort(ArgsOrHardness)};
+          ({Mod, Args, _Hardness}) -> {Mod, lists:sort(Args)}
+      end,
+      lists:keysort(1, Deps)).
+
+
+check_has_no_args(Mod, Args, Deps) ->
+    {_, ActualArgs, _} = lists:keyfind(Mod, 1, Deps),
+    ?assertEqual([], ordsets:intersection(
+                       ordsets:from_list(Args), ordsets:from_list(ActualArgs))).
+
+check_has_args(Mod, Args, Deps) ->
+    {_, ActualArgs, _} = lists:keyfind(Mod, 1, Deps),
+    ?assert(ordsets:is_subset(
+              ordsets:from_list(Args), ordsets:from_list(ActualArgs))).
+
+
+deps(Args) ->
+    mod_mam_meta:deps(<<"host">>, Args).

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -6,93 +6,61 @@ Configure MAM with different storage backends:
 * ODBC (RDBMS, like MySQL, PostgreSQL, MS SQL Server)
 * Riak KV (NOSQL)
 
-### Configure MAM with ODBC backend
 
-#### Options
-* `mod_mam_odbc_prefs`, `mod_mam_mnesia_prefs`:
-Consider the process as a kind of recipe. For each step you can enable none ("optional"), one ("single") or more ("multi") modules, according to instructions. Provided there are any, please use the options described in a specific step. All config parameters are boolean, so you can enable them by adding an atom to the configuration list, e.g. `{mod_mam_odbc_arch, [pm, no_writer]}`.
+`mod_mam_meta` is a meta-module that ensures all relevant `mod_mam_*` modules are loaded and properly configured.
 
-##### Step 1 (multi)
-* `*mod_mam` + `mod_mam_odbc_arch`: Enables support for one-to-one messages archive.
-* `mod_mam_muc` + `mod_mam_muc_odbc_arch`: Enables support for group chat messages archive.
+### Options
 
-If you haven't chosen any of the above, skip the next part.
+* **backend** (atom, default: `odbc`) - Database backend to use. `odbc`, `riak` and `cassandra` are supported.
+* **add_archived_element** (atom, default: `false`) - Add `<archived/>` element from MAM v0.2.
+* **is_complete_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_complete_message/3` callback](#is_complete_message) that determines if the message should be archived.
+* **host** (string, default: `"conference.@HOST@"`) - MUC host that will be archived if MUC archiving is enabled. **Warning**: if you are using MUC Light, make sure this option is set to MUC Light domain.
+* **pm** (list | `false`, default: `[]`) - Override options for archivization of one-to-one messages. If the value of this option is `false`, one-to-one message archive is disabled.
+* **muc** (list | `false`, default: `false`) - Override options for archivization of group chat messages. If the value of this option is `false`, group chat message archive is disabled.
 
-**Options:**
-
-* `mod_mam_muc`:
-    * `host` (optional, default: `"conference.@HOST@"`): MUC host that will be archived; **Warning:** If you are using MUC Light, make sure this option is set to MUC Light domain.
-* `mod_mam_odbc_arch`:
-    * `pm` (mandatory when `mod_mam` enabled): Enable archiving one-to-one messages
-    * `muc` (optional): Enable group chat archive, mutually exclusive with `mod_mam_muc_odbc_arch`. **Not recommended**, `mod_mam_muc_odbc_arch` is more efficient.
-    * `simple`: Same as `{simple, true}`
-    * `{simple, true}`: Store messages in XML and full JIDs. Archive MUST be empty to change this option.
-    * `{simple, false} (default)`: Store messages and JIDs in internal format.
-* `mod_mam_odbc_arch`, `mod_mam_muc_odbc_arch`:
-    * `no_writer`: Disables default synchronous, slow writer and uses async one (step 5 & 6) instead.
-    * `{simple, true}`: Store messages in XML and full JIDs. Archive MUST be empty to change this option.
-    * `{simple, false} (default)`: Store messages and JIDs in internal format.
-
-##### Step 2 (mandatory)
-* `mod_mam_odbc_user`: Maps archive ID to integer.
-
-**Options**
-
-* `pm`: Mandatory when `mod_mam` enabled.
-* `muc`: Mandatory when `mod_mam_muc` enabled.
-
-##### Step 3 (optional, recommended)
-* `mod_mam_cache_user`: Enables Archive ID to integer mappings cache.
-
-**Options**
-
-* `pm`: Optional, enables cache for one-to-one messaging, works only with `mod_mam` enabled.
-* `muc`: Optional, enables cache for group chat messaging, works only with `mod_mam_muc` enabled.
-
-##### Step 4 (single, optional)
-Skipping this step will make `mod_mam` archive all the messages and users will not be able to set their archiving preferences. It will also increase performance.
-
-* `mod_mam_odbc_prefs`: User archiving preferences saved in ODBC. Slow and not recommended, but might be used to simplify things and keep everything in ODBC.
-* `mod_mam_mnesia_prefs`: User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of inconsistent (in a rather harmless way) state of preferences table. Provides best performance.
-
-**Options:** (common for all three modules)
-
-* `pm`: Optional, enables MAM preferences for user-to-user messaging, works only with `mod_mam` enabled.
-* `muc`: Optional, enables MAM preferences for group chat messaging, works only with `mod_mam_muc` enabled.
-
-##### Step 5 (single, optional, recommended, requires `mod_mam` module enabled and `no_writer` option set in `mod_mam_odbc_arch`)
-
-Enabling asynchronous writers will make debugging more difficult.
-
-* `mod_mam_odbc_async_pool_writer`: Asynchronous writer, will insert batches of messages, grouped by archive ID.
-
-**Options:** (common for both modules)
-
-* `pm`: Optional, enables the chosen writer for one-to-one messaging, works only with `mod_mam` enabled.
-* `muc`: Optional, enables the chosen writer for group chat messaging, use only when `mod_mam_odbc_arch` has `muc` enabled. **Not recommended**.
-
-##### Step 6 (single, optional, recommended, requires `mod_mam_muc` module enabled and `no_writer` option set in `mod_mam_muc_odbc_arch`)
-
-Enabling asynchronous writers will make debugging more difficult.
-
-* `mod_mam_muc_odbc_async_pool_writer`: Asychronous writer, will insert batches of messages, grouped by archive ID.
-
-### Configure MAM with Riak KV backend
-
-In order to use Riak KV as the backend for one-to-one archives, the following configuration must be used:
+All options described in this document can be overriden for specific type of messages through `pm` and `muc` options, e.g.:
 
 ```erlang
-{mod_mam, []}.
-{mod_mam_riak_timed_arch_yz, [pm]}.
+{mod_mam_meta, [
+  {backend, odbc},
+  {async_writer, true}, %% this option enables async writer for ODBC backend
+  {muc, [
+    {async_writer, false} %% disable async writer for MUC archive only
+  ]}
+]}
 ```
 
-To archive both one-to-one and group chat (MUC, Multi-User Chat) messages use this configuration instead:
+#### ODBC backend options
+
+These options will only have effect when `odbc` backend is used:
+
+* [**user_prefs_store**](#user_prefs_store)
+* **cache_users** (boolean, default: `true`) - Enables Archive ID to integer mappings cache.
+* **odbc_message_format** (atom, default: `internal`) - When set to `simple`, stores messages in XML and full JIDs. When set to `internal`, stores messages and JIDs in internal format. **Warning**: Archive MUST be empty to change this option.
+* **async_writer** (boolean, default: `true`) - Enables asynchronous writer that is faster than synchronous but harder to debug.
+
+#### Common backend options
+
+* **user_prefs_store** (atom, default: `false`) - Leaving this option as `false` will prevent users from setting their archiving preferences. It will also increase performance. Other possible values are:
+  * `odbc` (ODBC backend only) - User archiving preferences saved in ODBC. Slow and not recommended, but might be used to simplify things and keep everything in ODBC.
+  * `cassandra` (Cassandra backend only) - User archiving preferences are saved in Cassandra.
+  * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of inconsistent (in a rather harmless way) state of preferences table.
+  * `mnesia_dirty` - like `mnesia`, but dirty synchronous writes are enabled.
+
+#### <a id="is_complete_message"></a>`is_complete_message/3` callback
+
+`is_complete_message` option has to name a module exporting `is_complete_message/3` function conforming to the spec:
 
 ```erlang
-{mod_mam, []}.
-{mod_mam_muc, []}.
-{mod_mam_riak_timed_arch_yz, [pm, muc]}.
+-spec is_complete_message(Mod :: module(), Dir :: incoming | outgoing,
+                          Packet :: jlib:xmlel()) -> boolean().
 ```
+
+Servers SHOULD NOT archive messages that do not have a `<body/>` child tag. Servers SHOULD NOT archive delayed messages.
+
+From MAM v0.3 onwards it is expected that all messages that hold meaningful content, rather than state changes such as Chat State Notifications, would be archived.
+
+### Riak backend
 
 The Riak KV backend for MAM stores messages in weekly buckets so it's easier to remove old buckets.
 Archive querying is done using Riak KV 2.0 [search mechanism](http://docs.basho.com/riak/2.1.1/dev/using/search/)
@@ -100,23 +68,21 @@ called Yokozuna. Your instance of Riak KV must be configured with Yokozuna enabl
 
 This backend works with Riak KV 2.0 and above, but we recommend version 2.1.1.
 
-### `mod_mam` options
-
-- `add_archived_element`: add `<archived/>` element from MAM v0.2
-- `is_complete_message`: module name implementing is_complete_message/3 callback.
-  This callback returns true if message should be archived.
-
 ### Example configuration
 
-Default configuration for `mod_mam`:
-
 ```erlang
-{mod_mam, []}.
-```
+{mod_mam_meta, [
+        {backend, odbc},
 
-It's expanded to:
+        cache_users,
+        add_archived_element,
 
-```erlang
-{mod_mam, [{add_archived_element, false},
-           {is_complete_message, mod_mam_utils}]}
+        {pm, [{user_prefs_store, odbc}]},
+        {muc, [
+               {host, "muc.example.com"},
+               {odbc_message_format, simple},
+               async_writer,
+               {user_prefs_store, mnesia}
+              ]}
+       ]}.
 ```

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -74,14 +74,13 @@ This backend works with Riak KV 2.0 and above, but we recommend version 2.1.1.
 {mod_mam_meta, [
         {backend, odbc},
 
-        cache_users,
         add_archived_element,
 
         {pm, [{user_prefs_store, odbc}]},
         {muc, [
                {host, "muc.example.com"},
                {odbc_message_format, simple},
-               async_writer,
+               {async_writer, false}
                {user_prefs_store, mnesia}
               ]}
        ]}.

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -13,7 +13,7 @@ Configure MAM with different storage backends:
 
 * **backend** (atom, default: `odbc`) - Database backend to use. `odbc`, `riak` and `cassandra` are supported.
 * **add_archived_element** (atom, default: `false`) - Add `<archived/>` element from MAM v0.2.
-* **is_complete_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_complete_message/3` callback](#is_complete_message) that determines if the message should be archived.
+* **is_archivable_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_archivable_message/3` callback](#is_archivable_message) that determines if the message should be archived.
 * **host** (string, default: `"conference.@HOST@"`) - MUC host that will be archived if MUC archiving is enabled. **Warning**: if you are using MUC Light, make sure this option is set to MUC Light domain.
 * **pm** (list | `false`, default: `[]`) - Override options for archivization of one-to-one messages. If the value of this option is `false`, one-to-one message archive is disabled.
 * **muc** (list | `false`, default: `false`) - Override options for archivization of group chat messages. If the value of this option is `false`, group chat message archive is disabled.
@@ -47,12 +47,12 @@ These options will only have effect when `odbc` backend is used:
   * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of inconsistent (in a rather harmless way) state of preferences table.
   * `mnesia_dirty` - like `mnesia`, but dirty synchronous writes are enabled.
 
-#### <a id="is_complete_message"></a>`is_complete_message/3` callback
+#### <a id="is_archivable_message"></a>`is_archivable_message/3` callback
 
-`is_complete_message` option has to name a module exporting `is_complete_message/3` function conforming to the spec:
+`is_archivable_message` option has to name a module exporting `is_archivable_message/3` function conforming to the spec:
 
 ```erlang
--spec is_complete_message(Mod :: module(), Dir :: incoming | outgoing,
+-spec is_archivable_message(Mod :: module(), Dir :: incoming | outgoing,
                           Packet :: jlib:xmlel()) -> boolean().
 ```
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -764,70 +764,47 @@
   {mod_carboncopy, []}
 
   %%
-  %% Message Archive Management (MAM) for registered users.
+  %% Message Archive Management (MAM, XEP-0313) for registered users and
+  %% Multi-User chats (MUCs).
   %%
 
-  %% A module for storing preferences in RDBMS (used by default).
-  %% Enable for private message archives.
-% {mod_mam_odbc_prefs, [pm]},
-  %% Enable for multiuser message archives.
-% {mod_mam_odbc_prefs, [muc]},
-  %% Enable for both private and multiuser message archives.
-% {mod_mam_odbc_prefs, [pm, muc]},
+% {mod_mam_meta, [
+    %% Use ODBC backend (default)
+%   {backend, odbc},
 
-  %% A module for storing preferences in Mnesia (recommended).
-  %% This module will be called each time, as a message is routed.
-  %% That is why, Mnesia is better for this job.
-% {mod_mam_mnesia_prefs, [pm, muc]},
+    %% Do not store user preferences (default)
+%   {user_prefs_store, false},
+    %% Store user preferences in RDBMS
+%   {user_prefs_store, odbc},
+    %% Store user preferences in Mnesia (recommended).
+    %% The preferences store will be called each time, as a message is routed.
+    %% That is why Mnesia is better suited for this job.
+%   {user_prefs_store, mnesia},
+    %% Mnesia back-end with optimized writes and dirty synchronious writes.
+%   {user_prefs_store, mnesia_dirty},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
+    %% Enables a pool of asynchronous writers. (default)
+    %% Messages will be grouped together based on archive id.
+%   {async_writer, true},
 
-  %% A back-end for storing messages.
-  %% Synchronious writer (used by default).
-  %% This writer is easy to debug, but writing performance is low.
-% {mod_mam_odbc_arch, [pm]},
+    %% Cache information about users (default)
+%   {cache_users, true},
 
-  %% Enable the module with a custom writer.
-% {mod_mam_odbc_arch, [no_writer, pm]},
+    %% Enable archivization for private messages (default)
+%   {pm, [
+      %% Top-level options can be overriden here if needed, for example:
+%     {async_writer, false}
+%   ]},
 
-  %% A pool of asynchronious writers (recommended).
-  %% Messages will be grouped together based on archive id.
-% {mod_mam_odbc_async_pool_writer, [pm]},
-
-  %% A module for converting an archive id to an integer.
-  %% Extract information using ODBC.
-% {mod_mam_odbc_user, [pm, muc]},
-
-  %% Cache information about users (recommended).
-  %% Requires mod_mam_odbc_user or alternative.
-% {mod_mam_cache_user, [pm, muc]},
-
-  %% Enable MAM.
-% {mod_mam, []},
-
-
-  %%
-  %% Message Archive Management (MAM) for multi-user chats (MUC).
-  %% Enable XEP-0313 for "muc.@HOST@".
-  %%
-
-  %% A back-end for storing messages (default for MUC).
-  %% Modules mod_mam_muc_* are optimized for MUC.
-  %%
-  %% Synchronious writer (used by default for MUC).
-  %% This module is easy to debug, but performance is low.
-% {mod_mam_muc_odbc_arch, []},
-% {mod_mam_muc_odbc_arch, [no_writer]},
-
-  %% Asynchronious writer for RDBMS (recommended for MUC).
-  %% Messages will be grouped and inserted all at once.
-% {mod_mam_muc_odbc_async_pool_writer, []},
-
-  %% Load mod_mam_odbc_user too.
-
-  %% Enable MAM for MUC
-% {mod_mam_muc, [{host, "muc.@HOST@"}]}
+    %%
+    %% Message Archive Management (MAM) for multi-user chats (MUC).
+    %% Enable XEP-0313 for "muc.@HOST@".
+    %%
+%   {muc, [
+%     {host, "muc.@HOST@"}
+      %% As with pm, top-level options can be overriden for MUC archive
+%   ]}
+% ]},
 
 
   %%
@@ -835,41 +812,37 @@
   %%
 
   %% Only MUC, no user-defined preferences, good performance.
-% {mod_mam_odbc_user, [muc]},
-% {mod_mam_cache_user, [muc]},
-% {mod_mam_muc_odbc_arch, [no_writer]},
-% {mod_mam_muc_odbc_async_pool_writer, []},
-% {mod_mam_muc, [{host, "muc.@HOST@"}]}
+% {mod_mam_meta, [
+%   {backend, odbc},
+%   {pm, false},
+%   {muc, [
+%     {host, "muc.@HOST@"}
+%   ]}
+% ]},
 
   %% Only archives for c2c messages, good performance.
-% {mod_mam_odbc_user, [pm]},
-% {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
-% {mod_mam_odbc_arch, [pm, no_writer]},
-% {mod_mam_odbc_async_pool_writer, [pm]},
-% {mod_mam, []}
+% {mod_mam_meta, [
+%   {backend, odbc},
+%   {pm, [
+%     {user_prefs_store, mnesia_dirty}
+%   ]}
+% ]},
 
   %% Basic configuration for c2c messages, bad performance, easy to debug.
-% {mod_mam_odbc_user, [pm]},
-% {mod_mam_odbc_prefs, [pm]},
-% {mod_mam_odbc_arch, [pm]},
-% {mod_mam, []}
+% {mod_mam_meta, [
+%   {backend, odbc},
+%   {async_writer, false},
+%   {cache_users, false}
+% ]},
 
-  %% Cassandra c2c conversations.
+  %% Cassandra archive for c2c and MUC conversations.
   %% All queries MUST contain "with" element.
   %% No custom settings supported (always archive).
-% {mod_mam_odbc_user, [pm]},
-% {mod_mam_cache_user, [pm]},
-% {mod_mam_con_ca_arch, [pm]},
-% {mod_mam, []}
-
-  %% Cassandra muc conversations.
-  %% No custom settings supported (always archive).
-% {mod_mam_odbc_user, [muc]},
-% {mod_mam_cache_user, [muc]},
-% {mod_mam_muc_ca_arch, []},
-% {mod_mam_muc, [{host, "muc.@HOST@"}]},
-
+% {mod_mam_meta, [
+%   {backend, cassandra},
+%   {user_prefs_store, cassandra},
+%   {muc, [{host, "muc.@HOST@"}]}
+% ]}
 
  ]}.
 


### PR DESCRIPTION
 Configuration is simplified by introducing a new module, mod_mam_meta, that only parses its arguments and pulls in relevant MAM modules using deps/2 callback introduced in #1103. This way a unified configuration may be introduced without disrupting existing modules and providing full backwards compatibility with old configs.