### PR TITLE
Add traffic stanza hooks

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.hrl
+++ b/apps/ejabberd/src/ejabberd_c2s.hrl
@@ -61,7 +61,7 @@
                 privacy_list = #userlist{} :: mod_privacy:userlist(),
                 conn = unknown,
                 auth_module     :: ejabberd_auth:authmodule(),
-                ip              :: inet:ip_address(),
+                ip              :: {inet:ip_address(), inet:port_number()},
                 aux_fields = [] :: [{aux_key(), aux_value()}],
                 lang            :: ejabberd:lang(),
                 stream_mgmt = false,


### PR DESCRIPTION
This change adds two hooks as close as possible to the incoming/outgoing stanza points which include the IP/port of the client. We use these for logging traffic at a low level (just above the XML encoding/decoding) to diagnose errors that may cause the packets not to make it to the higher level hooks.

There's also a fix for a related type error in ejabberd_c2s.hrl.

