### PR TITLE
Blocking cmds fix

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1106,7 +1106,8 @@ handle_info(replaced, _StateName, StateData) ->
 handle_info({broadcast, Broadcast}, StateName, StateData) ->
     ejabberd_hooks:run(c2s_loop_debug, [{broadcast, Broadcast}]),
     ?DEBUG("broadcast=~p", [Broadcast]),
-    handle_broadcast_result(handle_routed_broadcast(Broadcast, StateData), StateName, StateData);
+    Res = handle_routed_broadcast(Broadcast, StateData),
+    handle_broadcast_result(Res, StateName, StateData);
 handle_info({route, From, To, Packet}, StateName, StateData) ->
     ejabberd_hooks:run(c2s_loop_debug, [{route, From, To, Packet}]),
     Name = Packet#xmlel.name,
@@ -1313,10 +1314,10 @@ handle_routed_broadcast({privacy_list, PrivList, PrivListName}, StateData) ->
             maybe_update_presence(StateData, NewPL),
             {send_new, F, T, PrivPushEl, StateData#state{privacy_list = NewPL}}
     end;
-handle_routed_broadcast({blocking, Action, JIDs}, StateData) ->
+handle_routed_broadcast({blocking, UserList, Action, JIDs}, StateData) ->
     blocking_push_to_resources(Action, JIDs, StateData),
     blocking_presence_to_contacts(Action, JIDs, StateData),
-    {new_state, StateData};
+    {new_state, StateData#state{privacy_list = UserList}};
 handle_routed_broadcast(_, StateData) ->
     {new_state, StateData}.
 

--- a/apps/ejabberd/src/ejabberd_c2s.hrl
+++ b/apps/ejabberd/src/ejabberd_c2s.hrl
@@ -103,7 +103,8 @@
                            ISubscription :: from | to | both | none | remove}
                         | {privacy_list, PrivList :: mod_privacy:userlist(),
                            PrivListName :: binary()}
-                        | {blocking, What :: blocking_type(), [binary()]}
+                        | {blocking, UserList :: mod_privacy:userlist(), What :: blocking_type(),
+                                     [binary()]}
                         | unknown.
 
 -type broadcast() :: {broadcast, broadcast_type()}.

--- a/apps/ejabberd/src/mod_blocking.erl
+++ b/apps/ejabberd/src/mod_blocking.erl
@@ -118,9 +118,11 @@ process_blocking_iq_set(Type, LUser, LServer, CurrList, Usrs) ->
 complete_iq_set(blocking_command, _, _, {error, Reason}) ->
     {error, Reason};
 complete_iq_set(blocking_command, LUser, LServer, {ok, Changed, List, Type}) ->
-    broadcast_blocking_command(LUser, LServer, Changed, Type),
-    %% build a response here so that c2s sets the list in its state
-    {result, [], #userlist{name = <<"blocking">>, list = List, needdb = false}}.
+    UserList = #userlist{name = <<"blocking">>, list = List, needdb = false},
+    % send the list to all users c2s processes (resources) to make it effective immediately
+    broadcast_blocking_command(LUser, LServer, UserList, Changed, Type),
+    % return a response here so that c2s sets the list in its state
+    {result, [], UserList}.
 %%complete_iq_set(blocking_command, _, _, _) ->
 %%    {result, []}.
 
@@ -190,14 +192,14 @@ make_blocking_list_entry(J) ->
 
 %% @doc send iq confirmation to all of the user's resources
 %% if we unblock all contacts then we don't list who's been unblocked
-broadcast_blocking_command(LUser, LServer, _Changed, unblock_all) ->
-    broadcast_blocking_command(LUser, LServer, [], unblock);
-broadcast_blocking_command(LUser, LServer, Changed, Type) ->
+broadcast_blocking_command(LUser, LServer, UserList, _Changed, unblock_all) ->
+    broadcast_blocking_command(LUser, LServer, UserList, [], unblock);
+broadcast_blocking_command(LUser, LServer, UserList, Changed, Type) ->
     case jid:make(LUser, LServer, <<>>) of
         error ->
             ok;
         UserJID ->
-            ejabberd_sm:route(UserJID, UserJID, {broadcast, {blocking, Type, Changed}})
+            ejabberd_sm:route(UserJID, UserJID, {broadcast, {blocking, UserList, Type, Changed}})
     end.
 
 blocking_query_response(Lst) ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -337,13 +337,25 @@ check_packet(_, User, Server,
             check_packet_aux(List, PType, Type, LJID, Subscription, Groups)
     end.
 
+%% allow error messages
 check_packet_aux(_, message, <<"error">>, _JID, _Subscription, _Groups) ->
     allow;
-check_packet_aux(_, message_out, _Type, _JID, _Subscription, _Groups) ->
+%% if we run of of list items then it is allowed
+check_packet_aux([], PType, MType, _JID, _Subscription, _Groups) ->
     allow;
-check_packet_aux([], _PType, _Type, _JID, _Subscription, _Groups) ->
-    allow;
+%% check packet against next privacy list item
 check_packet_aux([Item | List], PType, MType, JID, Subscription, Groups) ->
+    #listitem{type = Type, value = Value, action = Action} = Item,
+    do_check_packet_aux(Type, Action, PType, Value, JID, MType, Subscription, Groups, Item, List).
+
+%% list set by blocking commands (XEP-0191) block all communication, both in and out,
+%% for a given JID
+do_check_packet_aux(jid, block, message, JID, JID, _, _, _, _, _) ->
+    block;
+do_check_packet_aux(jid, block, message_out, JID, JID, _, _, _, _, _) ->
+    block;
+%% then we do more complicated checking
+do_check_packet_aux(Type, Action, PType, Value, JID, MType, Subscription, Groups, Item, List) ->
     #listitem{type = Type, value = Value, action = Action} = Item,
     case is_ptype_match(Item, PType) of
         true ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -382,6 +382,9 @@ is_ptype_match(Item, PType) ->
             case PType of
                 message ->
                     Item#listitem.match_message;
+                message_out ->
+                    false; % according to xep-0016, privacy lists do not stop outgoing
+                           % messages (so they say)
                 iq ->
                     Item#listitem.match_iq;
                 presence_in ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -341,7 +341,7 @@ check_packet(_, User, Server,
 check_packet_aux(_, message, <<"error">>, _JID, _Subscription, _Groups) ->
     allow;
 %% if we run of of list items then it is allowed
-check_packet_aux([], PType, MType, _JID, _Subscription, _Groups) ->
+check_packet_aux([], _PType, _MType, _JID, _Subscription, _Groups) ->
     allow;
 %% check packet against next privacy list item
 check_packet_aux([Item | List], PType, MType, JID, Subscription, Groups) ->

--- a/test/ejabberd_tests/tests/mod_blocking_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_blocking_SUITE.erl
@@ -283,7 +283,7 @@ blocking_propagates_to_resources(Config) ->
             client_gets_blocking_error(User1b),
             % Bob can't send to any of Alice's resources
             message_is_not_delivered(User2, [User1a], <<"hau!">>),
-            message_is_not_delivered(User2, [User1b], <<"miau!">>),
+            message_is_not_delivered(User2, [User1b], <<"miau!">>)
         end).
 
 messages_after_relogin(Config) ->

--- a/test/ejabberd_tests/tests/mod_blocking_SUITE.erl
+++ b/test/ejabberd_tests/tests/mod_blocking_SUITE.erl
@@ -174,7 +174,7 @@ add_another_user_to_blocklist(Config) ->
 
 add_many_users_to_blocklist(Config) ->
     escalus:fresh_story(
-        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike,1}],
+        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike, 1}],
         fun(User1, User2, User3, User4) ->
             user_blocks(User1, [User2, User3, User4]),
             BlockList = get_blocklist(User1),
@@ -316,23 +316,20 @@ messages_arrive_after_unblock_and_relogin(Config) ->
 
 blocking_and_relogin_many(Config) ->
     %% given
-    escalus:story(
-        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike, 1}, {geralt, 1}],
+    simple_story(Config,
         fun(User1, User2, User3, User4, _) ->
             user_blocks(User1, [User2, User3]),
             user_blocks(User1, [User3, User4])
         end),
     %% when
-    escalus:story(
-        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike, 1}, {geralt, 1}],
+    simple_story(Config,
         fun(User1, User2, _, User4, User5) ->
             user_unblocks(User1,  [User4]),
             user_unblocks(User1,  [User4, User5]),
             user_unblocks(User1,  [User2, User5])
         end),
     %% then
-    escalus:story(
-        Config, [{alice, 1}, {bob, 1}, {carol, 1},  {mike, 1}, {geralt, 1}],
+    simple_story(Config,
         fun(User1, User2, User3, User4, _) ->
             message_is_delivered(User1, [User4], <<"Under the bridge!">>),
             message_is_not_delivered(User1, [User3], <<"Cant stop">>),
@@ -341,6 +338,12 @@ blocking_and_relogin_many(Config) ->
             BlockList = get_blocklist(User1),
             blocklist_contains_jid(BlockList, User3)
         end).
+
+simple_story(Config, Fun) ->
+    escalus:story(
+        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike, 1}, {geralt, 1}],
+        Fun
+    ).
 
 clear_list_relogin(Config) ->
     escalus:story(
@@ -385,12 +388,16 @@ notify_blockee(Config) ->
             %% make sure they're friends and Bob receives Alice's presences
             subscribe(Bob, Alice),
             escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
-            escalus:assert(is_presence_with_type, [<<"available">>], escalus:wait_for_stanza(Alice)),
-            escalus:assert(is_presence_with_type, [<<"available">>], escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_presence_with_type, [<<"available">>],
+                           escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_presence_with_type, [<<"available">>],
+                           escalus:wait_for_stanza(Bob)),
             user_blocks(Alice, [Bob]),
-            escalus:assert(is_presence_with_type, [<<"unavailable">>], escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_presence_with_type, [<<"unavailable">>],
+                           escalus:wait_for_stanza(Bob)),
             user_unblocks(Alice, [Bob]),
-            escalus:assert(is_presence_with_type, [<<"available">>], escalus:wait_for_stanza(Bob))
+            escalus:assert(is_presence_with_type, [<<"available">>],
+                           escalus:wait_for_stanza(Bob))
         end).
 
 %% common
@@ -508,7 +515,7 @@ blocklist_result_has(ExpectedUser, Stanza) ->
     Children = Blocklist#xmlel.children,
     <<"blocklist">> = Blocklist#xmlel.name,
     {<<"xmlns">>, ?NS_BLOCKING} = lists:keyfind(<<"xmlns">>, 1, Attrs),
-    true == lists:member(ExpectedUser,get_blocklist_items(Children)).
+    true == lists:member(ExpectedUser, get_blocklist_items(Children)).
 
 is_xep191_push(Type, #xmlel{attrs = A, children = [#xmlel{name = Type,
     attrs = Attrs}]}=Stanza) ->
@@ -520,7 +527,6 @@ is_xep191_push(Type, #xmlel{attrs = A, children = [#xmlel{name = Type,
 is_xep191_push(Type, [], #xmlel{children = [#xmlel{name = Type, children = []}]}=Stanza) ->
     is_xep191_push(Type, Stanza);
 is_xep191_push(Type, [], #xmlel{children = [#xmlel{name = Type, children = Items}]}) ->
-    ct:pal("JIDs: should be empty contains, ~p", [Items]),
     false;
 is_xep191_push(Type, JIDs, #xmlel{attrs = A, children = [#xmlel{name = Type,
     attrs = Attrs, children = Items}]}=Stanza) ->
@@ -553,7 +559,7 @@ user_blocks(Blocker, Blockees) when is_list(Blockees) ->
     escalus_client:send(Blocker, AddStanza),
     Res = escalus:wait_for_stanzas(Blocker, 2),
     CheckPush = fun(E) -> is_xep191_push(<<"block">>, BlockeeJIDs, E) end,
-    Preds = [is_iq_result, CheckPush], %% why it sends additional presence from alice to alice, I don't know
+    Preds = [is_iq_result, CheckPush],
     escalus:assert_many(Preds, Res).
 
 blocklist_is_empty(BlockList) ->


### PR DESCRIPTION
This PR addresses an issue with blocking commands - according to XEP-0191:

"If the user attempts to send an outbound stanza to the JID, the user's server MUST NOT route the stanza to the JID"

therefore, we should block outgoing messages. Also, a block should be propagated to all user's resources, which is not explicitly required by the XEP, but suggested by common sense, plus required if we want to effectively block via REST API.