### PR TITLE
Fix race condition in ejabberd_sm

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -42,7 +42,7 @@
          get_subscribed/1,
          send_filtered/5,
          broadcast/4,
-         store_info/5]).
+         store_session_info/5]).
 
 %% gen_fsm callbacks
 -export([init/1,
@@ -140,8 +140,8 @@ broadcast(FsmRef, Type, From, Packet) ->
 stop(FsmRef) ->
     ?GEN_FSM:send_event(FsmRef, closed).
 
-store_info(FsmRef, User, Server, Resource, KV) ->
-    FsmRef ! {store_info, User, Server, Resource, KV, self()}.
+store_session_info(FsmRef, User, Server, Resource, KV) ->
+    FsmRef ! {store_session_info, User, Server, Resource, KV, self()}.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm
@@ -1203,7 +1203,7 @@ handle_info(check_buffer_full, StateName, StateData) ->
             fsm_next_state(StateName,
                            StateData#state{stream_mgmt_constraint_check_tref = undefined})
     end;
-handle_info({store_info, User, Server, Resource, KV, _FromPid}, StateName, StateData) ->
+handle_info({store_session_info, User, Server, Resource, KV, _FromPid}, StateName, StateData) ->
     ejabberd_sm:store_info(User, Server, Resource, KV),
     fsm_next_state(StateName, StateData);
 handle_info(Info, StateName, StateData) ->
@@ -2404,7 +2404,7 @@ bounce_messages() ->
         {route, From, To, El} ->
             ejabberd_router:route(From, To, El),
             bounce_messages();
-        {store_info, User, Server, Resource, KV, _FromPid} ->
+        {store_session_info, User, Server, Resource, KV, _FromPid} ->
             ejabberd_sm:store_info(User, Server, Resource, KV)
     after 0 ->
               ok

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -41,7 +41,8 @@
          get_subscription/2,
          get_subscribed/1,
          send_filtered/5,
-         broadcast/4]).
+         broadcast/4,
+         store_info/5]).
 
 %% gen_fsm callbacks
 -export([init/1,
@@ -138,6 +139,9 @@ broadcast(FsmRef, Type, From, Packet) ->
 
 stop(FsmRef) ->
     ?GEN_FSM:send_event(FsmRef, closed).
+
+store_info(FsmRef, User, Server, Resource, KV) ->
+    FsmRef ! {store_info, User, Server, Resource, KV, self()}.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm
@@ -1199,6 +1203,9 @@ handle_info(check_buffer_full, StateName, StateData) ->
             fsm_next_state(StateName,
                            StateData#state{stream_mgmt_constraint_check_tref = undefined})
     end;
+handle_info({store_info, User, Server, Resource, KV, _FromPid}, StateName, StateData) ->
+    ejabberd_sm:store_info(User, Server, Resource, KV),
+    fsm_next_state(StateName, StateData);
 handle_info(Info, StateName, StateData) ->
     ?ERROR_MSG("Unexpected info: ~p", [Info]),
     fsm_next_state(StateName, StateData).
@@ -2396,7 +2403,9 @@ bounce_messages() ->
     receive
         {route, From, To, El} ->
             ejabberd_router:route(From, To, El),
-            bounce_messages()
+            bounce_messages();
+        {store_info, User, Server, Resource, KV, _FromPid} ->
+            ejabberd_sm:store_info(User, Server, Resource, KV)
     after 0 ->
               ok
     end.

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -186,9 +186,18 @@ store_info(User, Server, Resource, {Key, _Value} = KV) ->
     case get_session(User, Server, Resource) of
         offline -> {error, offline};
         {_SUser,SID,SPriority,SInfo} ->
-            set_session(SID, User, Server, Resource, SPriority,
-                        lists:keystore(Key, 1, SInfo, KV)),
-            {ok, KV}
+            case SID of
+                {_, Pid} when self() =:= Pid ->
+                    %% It's safe to allow process update it's own record
+                    set_session(SID, User, Server, Resource, SPriority,
+                                lists:keystore(Key, 1, SInfo, KV)),
+                    {ok, KV};
+                {_, Pid} ->
+                    %% Ask the process to update it's record itself
+                    %% Async operation
+                    ejabberd_c2s:store_info(Pid, User, Server, Resource, KV),
+                    {ok, KV}
+            end
     end.
 
 -spec check_in_subscription(Acc, User, Server, JID, Type, Reason) -> any() | {stop, false} when

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -195,7 +195,7 @@ store_info(User, Server, Resource, {Key, _Value} = KV) ->
                 {_, Pid} ->
                     %% Ask the process to update it's record itself
                     %% Async operation
-                    ejabberd_c2s:store_info(Pid, User, Server, Resource, KV),
+                    ejabberd_c2s:store_session_info(Pid, User, Server, Resource, KV),
                     {ok, KV}
             end
     end.

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -185,7 +185,7 @@ close_session(SID, User, Server, Resource, Reason) ->
 store_info(User, Server, Resource, {Key, _Value} = KV) ->
     case get_session(User, Server, Resource) of
         offline -> {error, offline};
-        {_SUser,SID,SPriority,SInfo} ->
+        {_SUser, SID, SPriority, SInfo} ->
             case SID of
                 {_, Pid} when self() =:= Pid ->
                     %% It's safe to allow process update it's own record

--- a/apps/ejabberd/src/mod_carboncopy.erl
+++ b/apps/ejabberd/src/mod_carboncopy.erl
@@ -70,7 +70,8 @@ is_carbon_copy(Packet) ->
     end.
 
 start(Host, Opts) ->
-    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
+    %% execute disable/enable actions in the c2s process itself
+    IQDisc = gen_mod:get_opt(iqdisc, Opts, no_queue),
     mod_disco:register_feature(Host, ?NS_CC_1),
     mod_disco:register_feature(Host, ?NS_CC_2),
     ejabberd_hooks:add(unset_presence_hook, Host, ?MODULE, remove_connection, 10),

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -205,7 +205,7 @@ kv_can_be_updated_for_session(C) ->
     when_session_info_stored(U, S, R, {key2, override}),
 
     [#session{sid = Sid, info = [{key1, val1}, {key2, override}]}]
-     = ?B(C):get_sessions(U,S).
+     = ?B(C):get_sessions(U, S).
 
 cannot_reproduce_race_condition_in_store_info(C) ->
     ok = try_to_reproduce_race_condition(10000).
@@ -215,7 +215,7 @@ store_info_sends_message_to_the_session_owner(C) ->
     U = <<"alice2">>,
     S = <<"localhost">>,
     R = <<"res1">>,
-    Session = #session{sid = SID,usr = {U,S,R},us = {U,S}, priority = 1,info = []},
+    Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = []},
     %% Create session in one process
     ?B(C):create_session(U, S, R, Session),
     %% but call store_info from another process
@@ -465,7 +465,7 @@ try_to_reproduce_race_condition(Retries) when Retries > 0 ->
     U = <<"alice">>,
     S = <<"localhost">>,
     R = <<"res1">>,
-    Session = #session{sid = SID,usr = {U,S,R},us = {U,S}, priority = 1,info = []},
+    Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = []},
     ejabberd_sm_mnesia:create_session(U, S, R, Session),
     Parent = self(),
     %% Add some instrumentation to simulate race conditions
@@ -480,7 +480,7 @@ try_to_reproduce_race_condition(Retries) when Retries > 0 ->
                             end),
     SetterPid = spawn_link(fun() ->
                                    receive start -> ok end,
-                                   ejabberd_sm:store_info(U, S, R, {cc,undefined}),
+                                   ejabberd_sm:store_info(U, S, R, {cc, undefined}),
                                    Parent ! p2_done
                            end),
     %% Step2 setup mocking for some ejabbers_sm_mnesia functions
@@ -508,7 +508,7 @@ try_to_reproduce_race_condition(Retries) when Retries > 0 ->
     receive p2_done -> ok end,
     meck:unload(ejabberd_sm_mnesia),
     %% Session should not exist
-    case ejabberd_sm_mnesia:get_sessions(U,S,R) of
+    case ejabberd_sm_mnesia:get_sessions(U, S, R) of
         [] ->
             ok;
         Other ->

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -34,7 +34,7 @@ end_per_suite(C) ->
 
 groups() ->
     [{mnesia, [],
-      [cannot_reproduce_race_condition_in_store_info]},
+      tests() ++ [cannot_reproduce_race_condition_in_store_info]},
      {redis, [], tests()}].
 
 tests() ->
@@ -221,7 +221,7 @@ store_info_sends_message_to_the_session_owner(C) ->
     %% but call store_info from another process
     spawn_link(fun() -> ejabberd_sm:store_info(U, S, R, {cc, undefined}) end),
     %% The original process receives a message
-    receive {store_info, User, Server, Resource, KV, _FromPid} ->
+    receive {store_session_info, User, Server, Resource, KV, _FromPid} ->
         ?eq(U, User),
         ?eq(S, Server),
         ?eq(R, Resource),

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -33,8 +33,7 @@ end_per_suite(C) ->
     application:stop(exometer_core).
 
 groups() ->
-    [{mnesia, [],
-      tests() ++ [cannot_reproduce_race_condition_in_store_info]},
+    [{mnesia, [], tests()},
      {redis, [], tests()}].
 
 tests() ->
@@ -55,7 +54,8 @@ tests() ->
      session_info_keys_not_truncated_if_session_opened_with_empty_infolist,
      kv_can_be_stored_for_session,
      kv_can_be_updated_for_session,
-     store_info_sends_message_to_the_session_owner
+     store_info_sends_message_to_the_session_owner,
+     cannot_reproduce_race_condition_in_store_info
     ].
 
 init_per_group(mnesia, Config) ->
@@ -208,7 +208,7 @@ kv_can_be_updated_for_session(C) ->
      = ?B(C):get_sessions(U, S).
 
 cannot_reproduce_race_condition_in_store_info(C) ->
-    ok = try_to_reproduce_race_condition(10000).
+    ok = try_to_reproduce_race_condition(C).
 
 store_info_sends_message_to_the_session_owner(C) ->
     SID = {now(), self()},
@@ -458,15 +458,13 @@ is_redis_running() ->
     [] =/= os:cmd("ps aux | grep '[r]edis'").
 
 
-try_to_reproduce_race_condition(0) ->
-    ok; %% no more retries
-try_to_reproduce_race_condition(Retries) when Retries > 0 ->
+try_to_reproduce_race_condition(Config) ->
     SID = {now(), self()},
     U = <<"alice">>,
     S = <<"localhost">>,
     R = <<"res1">>,
     Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = []},
-    ejabberd_sm_mnesia:create_session(U, S, R, Session),
+    ?B(Config):create_session(U, S, R, Session),
     Parent = self(),
     %% Add some instrumentation to simulate race conditions
     %% The goal is to delete the session after other process reads it
@@ -475,7 +473,7 @@ try_to_reproduce_race_condition(Retries) when Retries > 0 ->
     %% Step1 prepare concurrent processes
     DeleterPid = spawn_link(fun() ->
                                     receive start -> ok end,
-                                    ejabberd_sm_mnesia:delete_session(SID, U, S, R),
+                                    ?B(Config):delete_session(SID, U, S, R),
                                     Parent ! p1_done
                             end),
     SetterPid = spawn_link(fun() ->
@@ -484,35 +482,35 @@ try_to_reproduce_race_condition(Retries) when Retries > 0 ->
                                    Parent ! p2_done
                            end),
     %% Step2 setup mocking for some ejabbers_sm_mnesia functions
-    meck:new(ejabberd_sm_mnesia, []),
+    meck:new(?B(Config), []),
     %% When the first get_sessions (run from ejabberd_sm:store_info)
     %% is executed, the start msg is sent to Deleter process
     %% Thanks to that, setter will get not empty list of sessions
     PassThrough3 = fun(A, B, C) ->
                            DeleterPid ! start,
                            meck:passthrough([A, B, C]) end,
-    meck:expect(ejabberd_sm_mnesia, get_sessions, PassThrough3),
+    meck:expect(?B(Config), get_sessions, PassThrough3),
     %% Wait some time before setting the sessions
     %% so we are sure delete operation finishes
-    meck:expect(ejabberd_sm_mnesia, create_session,
+    meck:expect(?B(Config), create_session,
                 fun(U1, S1, R1, Session1) ->
                         timer:sleep(100),
                         meck:passthrough([U1, S1, R1, Session1])
                 end),
     PassThrough4 = fun(A, B, C, D) -> meck:passthrough([A, B, C, D]) end,
-    meck:expect(ejabberd_sm_mnesia, delete_session, PassThrough4),
+    meck:expect(?B(Config), delete_session, PassThrough4),
     %% Start the play from setter process
     SetterPid ! start,
     %% Wait for both process to finish
     receive p1_done -> ok end,
     receive p2_done -> ok end,
-    meck:unload(ejabberd_sm_mnesia),
+    meck:unload(?B(Config)),
     %% Session should not exist
-    case ejabberd_sm_mnesia:get_sessions(U, S, R) of
+    case ?B(Config):get_sessions(U, S, R) of
         [] ->
             ok;
         Other ->
-            error_logger:error_msg("issue=reproduced, sid=~p, other=~1000p, retries_left=~p",
-                                   [SID, Other, Retries]),
+            error_logger:error_msg("issue=reproduced, sid=~p, other=~1000p",
+                                   [SID, Other]),
             {error, reproduced}
     end.

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -33,7 +33,8 @@ end_per_suite(C) ->
     application:stop(exometer_core).
 
 groups() ->
-    [{mnesia, [], tests()},
+    [{mnesia, [],
+      tests() ++ [cannot_reproduce_race_condition_in_store_info]},
      {redis, [], tests()}].
 
 tests() ->
@@ -54,7 +55,6 @@ tests() ->
      session_info_keys_not_truncated_if_session_opened_with_empty_infolist,
      kv_can_be_stored_for_session,
      kv_can_be_updated_for_session,
-     cannot_reproduce_race_condition_in_store_info,
      store_info_sends_message_to_the_session_owner
     ].
 
@@ -217,8 +217,7 @@ store_info_sends_message_to_the_session_owner(C) ->
     R = <<"res1">>,
     Session = #session{sid = SID,usr = {U,S,R},us = {U,S}, priority = 1,info = []},
     %% Create session in one process
-    ejabberd_sm_mnesia:create_session(U, S, R, Session),
-    Parent = self(),
+    ?B(C):create_session(U, S, R, Session),
     %% but call store_info from another process
     spawn_link(fun() -> ejabberd_sm:store_info(U, S, R, {cc, undefined}) end),
     %% The original process receives a message


### PR DESCRIPTION
This PR addresses #1082

When the race condition could happen? Two processes (f.e. `c2s` and process `A` ) operates on the same `user`'s session. At the same time, process `A` updates `user`'s session info and `c2s` deletes the info because the `user` disconnected. Function `ejabberd_sm:store_info` (called by `A`) first checks if there is any record for given `user` and only then updates (sets new value). It's possible that the record is deleted by `c2s` just after the get returns to `A` but set is not yet started. In this situation the info about the `user` will remain in the table, even though the `user` disconnected.

Following PR fixes this bug by running all session updates in the context of c2s process.

It was found and fixed by @arcusfelis.