### PR TITLE
zlib_drv: use erts_exit() if available

### DIFF
--- a/apps/ejabberd/c_src/ejabberd_zlib_drv.c
+++ b/apps/ejabberd/c_src/ejabberd_zlib_drv.c
@@ -44,7 +44,12 @@ typedef struct {
 
 /* Wrappers around driver_alloc() that check  */
 /* for OOM.                                   */
-void erl_exit(int n, char* v, ...) { abort(); }
+#ifdef HAS_ERTS_EXIT
+void erts_exit(int n, char* v, ...);
+#define erl_exit erts_exit
+#else
+void erl_exit(int n, char* v, ...);
+#endif
 
 void *ejabberd_zlib_drv_alloc(ErlDrvSizeT size);
 ErlDrvBinary *ejabberd_zlib_drv_alloc_binary(ErlDrvSizeT size);

--- a/apps/ejabberd/rebar.config.script
+++ b/apps/ejabberd/rebar.config.script
@@ -1,3 +1,16 @@
+Append = fun(Str, Flag) ->
+    string:join(sets:to_list(sets:add_element(Flag,
+                    sets:from_list(string:tokens(Str, " ")))), " ")
+end,
+
+Setenv = fun(Key, Val) ->
+    Cur = case os:getenv(Key) of
+        false -> "";
+        N -> N
+    end,
+    os:putenv(Key, Append(Cur, Val))
+end,
+
 GetFullVer = fun() ->
     Path = filename:join([code:root_dir(), "releases",
                           erlang:system_info(otp_release),
@@ -11,6 +24,8 @@ GetFullVer = fun() ->
     end
 end,
 
+SysVersion = lists:map(fun erlang:list_to_integer/1,
+               string:tokens(erlang:system_info(version), ".")),
 
 DisableCoverage = fun(Config) ->
     Opts = [{cover_enabled, false},
@@ -49,4 +64,14 @@ MaybeFIPSSupport = fun(Config) ->
     end
 end,
 
-MaybeFIPSSupport(MaybeDisableCoverage(CONFIG)).
+MaybeErtsExitSupport = fun(Config) ->
+    ExitFlag = case SysVersion >= [7, 3] of
+        true -> "-DHAS_ERTS_EXIT";
+        _ -> ""
+    end,
+    true = Setenv("CFLAGS", ExitFlag),
+    CONFIG
+end,
+
+lists:foldl(fun(Fun, Cfg) -> Fun(Cfg) end, CONFIG,
+    [MaybeDisableCoverage, MaybeFIPSSupport, MaybeErtsExitSupport]).


### PR DESCRIPTION
Set CFLAGS in rebar.config.script based on the emulator version as
discussed in:

https://github.com/esl/MongooseIM/pull/1134
