### PR TITLE
Use cqerl as cassandra client library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: erlang
+dist: trusty
 sudo: required
 addons:
     apt:

--- a/apps/ejabberd/src/mod_mam_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_arch.erl
@@ -21,7 +21,7 @@
          purge_single_message/6,
          purge_multiple_messages/9]).
 
-%% mongoose_cassandra_worker callbacks
+%% mongoose_cassandra callbacks
 -export([prepared_queries/0]).
 
 %% ----------------------------------------------------------------------
@@ -63,11 +63,9 @@
           user_jid :: binary(),
           remote_jid :: binary(),
           from_jid :: binary(),
-          with_jid :: binary(),
+          with_jid = <<>> :: binary(),
           message :: binary()
          }).
-
--type worker() :: pid() | atom().
 
 %% ----------------------------------------------------------------------
 %% Types
@@ -136,20 +134,13 @@ prepared_queries() ->
         ++ list_message_ids_queries().
 
 %% ----------------------------------------------------------------------
-%% Helpers
-
-select_worker(UserJID) ->
-    PoolName = pool_name(UserJID),
-    mongoose_cassandra_sup:select_worker(PoolName, UserJID).
-
-%% ----------------------------------------------------------------------
 %% Internal functions and callbacks
 
 archive_size(Size, Host, _UserID, UserJID) when is_integer(Size) ->
-    Worker = select_worker(UserJID),
+    PoolName = pool_name(UserJID),
     Borders = Start = End = WithJID = undefined,
     Filter = prepare_filter(UserJID, Borders, Start, End, WithJID),
-    calc_count(Worker, UserJID, Host, Filter).
+    calc_count(PoolName, UserJID, Host, Filter).
 
 
 %% ----------------------------------------------------------------------
@@ -192,8 +183,7 @@ archive_message2(_Result, _Host, MessID,
 write_messages(UserJID, Messages) ->
     PoolName = pool_name(UserJID),
     MultiParams = [message_to_params(M) || M <- Messages],
-    mongoose_cassandra_worker:cql_query_pool_multi_async(PoolName, UserJID, ?MODULE, insert_query,
-                                                         MultiParams).
+    mongoose_cassandra:cql_write_async(PoolName, UserJID, ?MODULE, insert_query, MultiParams).
 
 message_to_params(#mam_message{
                      id         = MessID,
@@ -203,7 +193,8 @@ message_to_params(#mam_message{
                      with_jid   = BWithJID,
                      message    = BPacket
                     }) ->
-    [MessID, BLocJID, BSrcJID, BRemJID, BWithJID, BPacket].
+    [{id, MessID}, {user_jid, BLocJID}, {from_jid, BSrcJID},
+     {remote_jid, BRemJID}, {with_jid, BWithJID}, {message, BPacket}].
 
 
 %% ----------------------------------------------------------------------
@@ -213,17 +204,17 @@ delete_query_cql() ->
     "DELETE FROM mam_message "
         "WHERE user_jid = ? AND with_jid = ? AND id = ?".
 
-delete_messages(Worker, UserJID, Messages) ->
+delete_messages(PoolName, UserJID, Messages) ->
     MultiParams = [delete_message_to_params(M) || M <- Messages],
-    mongoose_cassandra_worker:cql_query_multi_async(Worker, UserJID, ?MODULE, delete_query,
-                                                    MultiParams).
+    mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, delete_query,
+                                 MultiParams).
 
 delete_message_to_params(#mam_message{
                             id       = MessID,
                             user_jid = BLocJID,
                             with_jid = BWithJID
                            }) ->
-    [BLocJID, BWithJID, MessID].
+    [{user_jid, BLocJID}, {with_jid, BWithJID}, {id, MessID}].
 
 
 %% ----------------------------------------------------------------------
@@ -235,10 +226,10 @@ remove_archive_query_cql() ->
 remove_archive(_Host, _UserID, UserJID) ->
     BUserJID = bare_jid(UserJID),
     PoolName = pool_name(UserJID),
-    Params = [BUserJID],
+    Params = [{user_jid, BUserJID}],
     %% Wait until deleted
-    mongoose_cassandra_worker:cql_query_pool(PoolName, UserJID, ?MODULE, remove_archive_query,
-                                             Params),
+
+    mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, remove_archive_query, [Params]),
     ok.
 
 
@@ -249,15 +240,15 @@ message_id_to_remote_jid_cql() ->
     "SELECT remote_jid FROM mam_message "
         "WHERE user_jid = ? AND with_jid = '' AND id = ?".
 
-message_id_to_remote_jid(Worker, UserJID, BUserJID, MessID) ->
-    Params = [BUserJID, MessID],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query(Worker, UserJID, ?MODULE,
-                                                     message_id_to_remote_jid_query, Params),
+message_id_to_remote_jid(PoolName, UserJID, BUserJID, MessID) ->
+    Params = [{user_jid, BUserJID}, {id, MessID}, {with_jid, <<>>}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE,
+                                             message_id_to_remote_jid_query, Params),
     case Rows of
         [] ->
             {error, not_found};
-        [[BRemFullJID]] ->
-            {ok, BRemFullJID}
+        [Row] ->
+            {ok, proplists:get_value(remote_jid, Row)}
     end.
 
 
@@ -289,8 +280,8 @@ lookup_messages(_Result, Host,
                 PageSize, LimitPassed, MaxResultLimit,
                 IsSimple) ->
     try
-        Worker = select_worker(UserJID),
-        lookup_messages2(Worker, Host,
+        PoolName = pool_name(UserJID),
+        lookup_messages2(PoolName, Host,
                          UserJID, RSM, Borders,
                          Start, End, WithJID,
                          PageSize, LimitPassed, MaxResultLimit,
@@ -300,15 +291,15 @@ lookup_messages(_Result, Host,
             {error, {Reason, S}}
     end.
 
-lookup_messages2(Worker, Host,
+lookup_messages2(PoolName, Host,
                  UserJID = #jid{}, RSM, Borders,
                  Start, End, WithJID,
                  PageSize, _LimitPassed, _MaxResultLimit,
                  _IsSimple = true) ->
     %% Simple query without calculating offset and total count
     Filter = prepare_filter(UserJID, Borders, Start, End, WithJID),
-    lookup_messages_simple(Worker, Host, UserJID, RSM, PageSize, Filter);
-lookup_messages2(Worker, Host,
+    lookup_messages_simple(PoolName, Host, UserJID, RSM, PageSize, Filter);
+lookup_messages2(PoolName, Host,
                  UserJID = #jid{}, RSM, Borders,
                  Start, End, WithJID,
                  PageSize, LimitPassed, MaxResultLimit,
@@ -322,15 +313,15 @@ lookup_messages2(Worker, Host,
     Result =
         case Strategy of
             last_page ->
-                lookup_messages_last_page(Worker, Host, UserJID, RSM, PageSize, Filter);
+                lookup_messages_last_page(PoolName, Host, UserJID, RSM, PageSize, Filter);
             by_offset ->
-                lookup_messages_by_offset(Worker, Host, UserJID, RSM, PageSize, Filter);
+                lookup_messages_by_offset(PoolName, Host, UserJID, RSM, PageSize, Filter);
             first_page ->
-                lookup_messages_first_page(Worker, Host, UserJID, RSM, PageSize, Filter);
+                lookup_messages_first_page(PoolName, Host, UserJID, RSM, PageSize, Filter);
             before_id ->
-                lookup_messages_before_id(Worker, Host, UserJID, RSM, PageSize, Filter);
+                lookup_messages_before_id(PoolName, Host, UserJID, RSM, PageSize, Filter);
             after_id ->
-                lookup_messages_after_id(Worker, Host, UserJID, RSM, PageSize, Filter)
+                lookup_messages_after_id(PoolName, Host, UserJID, RSM, PageSize, Filter)
         end,
     check_result_for_policy_violation(Result, MaxResultLimit, LimitPassed).
 
@@ -349,43 +340,43 @@ rsm_to_strategy(#rsm_in{}) ->
 rsm_to_strategy(undefined) ->
     first_page.
 
-lookup_messages_simple(Worker, Host, UserJID,
+lookup_messages_simple(PoolName, Host, UserJID,
                        #rsm_in{direction = aft, id = ID},
                        PageSize, Filter) ->
     %% Get last rows from result set
-    MessageRows = extract_messages(Worker, UserJID, Host, after_id(ID, Filter), PageSize, false),
+    MessageRows = extract_messages(PoolName, UserJID, Host, after_id(ID, Filter), PageSize, false),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows)}};
-lookup_messages_simple(Worker, Host, UserJID,
+lookup_messages_simple(PoolName, Host, UserJID,
                        #rsm_in{direction = before, id = ID},
                        PageSize, Filter) ->
-    MessageRows = extract_messages(Worker, UserJID, Host, before_id(ID, Filter), PageSize, true),
+    MessageRows = extract_messages(PoolName, UserJID, Host, before_id(ID, Filter), PageSize, true),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows)}};
-lookup_messages_simple(Worker, Host, UserJID,
+lookup_messages_simple(PoolName, Host, UserJID,
                        #rsm_in{direction = undefined, index = Offset},
                        PageSize, Filter) ->
     %% Apply offset
-    StartId = offset_to_start_id(Worker, UserJID, Filter,
+    StartId = offset_to_start_id(PoolName, UserJID, Filter,
                                  Offset), %% POTENTIALLY SLOW AND NOT SIMPLE :)
-    MessageRows = extract_messages(Worker, UserJID, Host, from_id(StartId, Filter), PageSize,
+    MessageRows = extract_messages(PoolName, UserJID, Host, from_id(StartId, Filter), PageSize,
                                    false),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows)}};
-lookup_messages_simple(Worker, Host, UserJID,
+lookup_messages_simple(PoolName, Host, UserJID,
                        _,
                        PageSize, Filter) ->
-    MessageRows = extract_messages(Worker, UserJID, Host, Filter, PageSize, false),
+    MessageRows = extract_messages(PoolName, UserJID, Host, Filter, PageSize, false),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows)}}.
 
-lookup_messages_last_page(Worker, Host, UserJID,
+lookup_messages_last_page(PoolName, Host, UserJID,
                           #rsm_in{direction = before, id = undefined},
                           0, Filter) ->
     %% Last page
-    TotalCount = calc_count(Worker, UserJID, Host, Filter),
+    TotalCount = calc_count(PoolName, UserJID, Host, Filter),
     {ok, {TotalCount, TotalCount, []}};
-lookup_messages_last_page(Worker, Host, UserJID,
+lookup_messages_last_page(PoolName, Host, UserJID,
                           #rsm_in{direction = before, id = undefined},
                           PageSize, Filter) ->
     %% Last page
-    MessageRows = extract_messages(Worker, UserJID, Host, Filter, PageSize, true),
+    MessageRows = extract_messages(PoolName, UserJID, Host, Filter, PageSize, true),
     MessageRowsCount = length(MessageRows),
     case MessageRowsCount < PageSize of
         true ->
@@ -393,23 +384,23 @@ lookup_messages_last_page(Worker, Host, UserJID,
                   rows_to_uniform_format(MessageRows)}};
         false ->
             FirstID = row_to_message_id(hd(MessageRows)),
-            Offset = calc_count(Worker, UserJID, Host, before_id(FirstID, Filter)),
+            Offset = calc_count(PoolName, UserJID, Host, before_id(FirstID, Filter)),
             {ok, {Offset + MessageRowsCount, Offset,
                   rows_to_uniform_format(MessageRows)}}
     end.
 
-lookup_messages_by_offset(Worker, Host, UserJID,
+lookup_messages_by_offset(PoolName, Host, UserJID,
                           #rsm_in{direction = undefined, index = Offset},
                           0, Filter) when is_integer(Offset) ->
     %% By offset
-    TotalCount = calc_count(Worker, UserJID, Host, Filter),
+    TotalCount = calc_count(PoolName, UserJID, Host, Filter),
     {ok, {TotalCount, Offset, []}};
-lookup_messages_by_offset(Worker, Host, UserJID,
+lookup_messages_by_offset(PoolName, Host, UserJID,
                           #rsm_in{direction = undefined, index = Offset},
                           PageSize, Filter) when is_integer(Offset) ->
     %% By offset
-    StartId = offset_to_start_id(Worker, UserJID, Filter, Offset), %% POTENTIALLY SLOW
-    MessageRows = extract_messages(Worker, UserJID, Host, from_id(StartId, Filter), PageSize,
+    StartId = offset_to_start_id(PoolName, UserJID, Filter, Offset), %% POTENTIALLY SLOW
+    MessageRows = extract_messages(PoolName, UserJID, Host, from_id(StartId, Filter), PageSize,
                                    false),
     MessageRowsCount = length(MessageRows),
     case MessageRowsCount < PageSize of
@@ -418,22 +409,22 @@ lookup_messages_by_offset(Worker, Host, UserJID,
                   rows_to_uniform_format(MessageRows)}};
         false ->
             LastID = row_to_message_id(lists:last(MessageRows)),
-            CountAfterLastID = calc_count(Worker, UserJID, Host, after_id(LastID, Filter)),
+            CountAfterLastID = calc_count(PoolName, UserJID, Host, after_id(LastID, Filter)),
             {ok, {Offset + MessageRowsCount + CountAfterLastID, Offset,
                   rows_to_uniform_format(MessageRows)}}
     end.
 
-lookup_messages_first_page(Worker, Host, UserJID,
+lookup_messages_first_page(PoolName, Host, UserJID,
                            _,
                            0, Filter) ->
     %% First page, just count
-    TotalCount = calc_count(Worker, UserJID, Host, Filter),
+    TotalCount = calc_count(PoolName, UserJID, Host, Filter),
     {ok, {TotalCount, 0, []}};
-lookup_messages_first_page(Worker, Host, UserJID,
+lookup_messages_first_page(PoolName, Host, UserJID,
                            _,
                            PageSize, Filter) ->
     %% First page
-    MessageRows = extract_messages(Worker, UserJID, Host, Filter, PageSize, false),
+    MessageRows = extract_messages(PoolName, UserJID, Host, Filter, PageSize, false),
     MessageRowsCount = length(MessageRows),
     case MessageRowsCount < PageSize of
         true ->
@@ -442,25 +433,25 @@ lookup_messages_first_page(Worker, Host, UserJID,
                   rows_to_uniform_format(MessageRows)}};
         false ->
             LastID = row_to_message_id(lists:last(MessageRows)),
-            CountAfterLastID = calc_count(Worker, UserJID, Host, after_id(LastID, Filter)),
+            CountAfterLastID = calc_count(PoolName, UserJID, Host, after_id(LastID, Filter)),
             {ok, {MessageRowsCount + CountAfterLastID, 0,
                   rows_to_uniform_format(MessageRows)}}
     end.
 
-lookup_messages_before_id(Worker, Host, UserJID,
+lookup_messages_before_id(PoolName, Host, UserJID,
                           RSM = #rsm_in{direction = before, id = ID},
                           PageSize, Filter) ->
-    TotalCount = calc_count(Worker, UserJID, Host, Filter),
-    Offset = calc_offset(Worker, UserJID, Host, Filter, PageSize, TotalCount, RSM),
-    MessageRows = extract_messages(Worker, UserJID, Host, before_id(ID, Filter), PageSize, true),
+    TotalCount = calc_count(PoolName, UserJID, Host, Filter),
+    Offset = calc_offset(PoolName, UserJID, Host, Filter, PageSize, TotalCount, RSM),
+    MessageRows = extract_messages(PoolName, UserJID, Host, before_id(ID, Filter), PageSize, true),
     {ok, {TotalCount, Offset, rows_to_uniform_format(MessageRows)}}.
 
-lookup_messages_after_id(Worker, Host, UserJID,
+lookup_messages_after_id(PoolName, Host, UserJID,
                          RSM = #rsm_in{direction = aft, id = ID},
                          PageSize, Filter) ->
-    TotalCount = calc_count(Worker, UserJID, Host, Filter),
-    Offset = calc_offset(Worker, UserJID, Host, Filter, PageSize, TotalCount, RSM),
-    MessageRows = extract_messages(Worker, UserJID, Host, after_id(ID, Filter), PageSize, false),
+    TotalCount = calc_count(PoolName, UserJID, Host, Filter),
+    Offset = calc_offset(PoolName, UserJID, Host, Filter, PageSize, TotalCount, RSM),
+    MessageRows = extract_messages(PoolName, UserJID, Host, after_id(ID, Filter), PageSize, false),
     {ok, {TotalCount, Offset, rows_to_uniform_format(MessageRows)}}.
 
 
@@ -501,13 +492,14 @@ from_id(ID, Filter = #mam_ca_filter{start_id = AfterID}) ->
 rows_to_uniform_format(MessageRows) ->
     [row_to_uniform_format(Row) || Row <- MessageRows].
 
-row_to_uniform_format([MessID, BSrcJID, Data]) ->
-    SrcJID = unserialize_jid(BSrcJID),
-    Packet = stored_binary_to_packet(Data),
-    {MessID, SrcJID, Packet}.
+row_to_uniform_format(Row) ->
+    SrcJID = unserialize_jid(proplists:get_value(from_jid, Row)),
+    Packet = stored_binary_to_packet(proplists:get_value(message, Row)),
+    MsgID = proplists:get_value(id, Row),
+    {MsgID, SrcJID, Packet}.
 
-row_to_message_id([MessID, _, _]) ->
-    MessID.
+row_to_message_id(Row) ->
+    proplists:get_value(id, Row).
 
 -spec purge_single_message(_Result, Host, MessID, _UserID, UserJID,
                            Now) ->
@@ -516,9 +508,9 @@ row_to_message_id([MessID, _, _]) ->
       _UserID :: user_id(), UserJID :: jid(),
       Now :: unix_timestamp().
 purge_single_message(_Result, _Host, MessID, _UserID, UserJID, _Now) ->
-    Worker = select_worker(UserJID),
+    PoolName = pool_name(UserJID),
     BUserJID = bare_jid(UserJID),
-    Result = message_id_to_remote_jid(Worker, UserJID, BUserJID, MessID),
+    Result = message_id_to_remote_jid(PoolName, UserJID, BUserJID, MessID),
     case Result of
         {ok, BRemFullJID} ->
             RemFullJID = unserialize_jid(BRemFullJID),
@@ -534,7 +526,7 @@ purge_single_message(_Result, _Host, MessID, _UserID, UserJID, _Now) ->
                            remote_jid = BRemFullJID, %% set the field for debugging
                            with_jid   = BWithJID
                           }           || BWithJID <- BWithJIDs],
-            delete_messages(Worker, UserJID, Messages),
+            delete_messages(PoolName, UserJID, Messages),
             ok;
         {error, _} ->
             ok
@@ -556,12 +548,13 @@ purge_multiple_messages(_Result, Host, UserID, UserJID, Borders,
     PoolName = pool_name(UserJID),
     Limit = 500, %% TODO something smarter
     QueryName = {list_message_ids_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [Limit],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query_pool(PoolName, UserJID, ?MODULE, QueryName,
-                                                          Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', Limit}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, QueryName,
+                                             Params),
     %% TODO can be faster
     %% TODO rate limiting
-    [purge_single_message(ok, Host, MessID, UserID, UserJID, Now) || [MessID] <- Rows],
+    [purge_single_message(ok, Host, proplists:get_value(id, Row), UserID, UserJID, Now)
+     || Row <- Rows],
     ok.
 
 
@@ -569,9 +562,9 @@ purge_multiple_messages(_Result, Host, UserID, UserJID, Borders,
 %% Each record is a tuple of form
 %% `{<<"13663125233">>,<<"bob@localhost">>,<<"res1">>,<<binary>>}'.
 %% Columns are `["id","from_jid","message"]'.
--spec extract_messages(Worker, UserJID, Host, Filter, IMax, ReverseLimit) ->
+-spec extract_messages(PoolName, UserJID, Host, Filter, IMax, ReverseLimit) ->
                               [Row] when
-      Worker :: worker(),
+      PoolName :: mongoose_cassandra:pool_name(),
       UserJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
@@ -580,15 +573,15 @@ purge_multiple_messages(_Result, Host, UserID, UserJID, Borders,
       Row :: list().
 extract_messages(_Worker, _UserJID, _Host, _Filter, 0, _) ->
     [];
-extract_messages(Worker, UserJID, _Host, Filter, IMax, false) ->
+extract_messages(PoolName, UserJID, _Host, Filter, IMax, false) ->
     QueryName = {extract_messages_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [IMax],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query(Worker, UserJID, ?MODULE, QueryName, Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', IMax}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, QueryName, Params),
     Rows;
-extract_messages(Worker, UserJID, _Host, Filter, IMax, true) ->
+extract_messages(PoolName, UserJID, _Host, Filter, IMax, true) ->
     QueryName = {extract_messages_r_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [IMax],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query(Worker, UserJID, ?MODULE, QueryName, Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', IMax}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, QueryName, Params),
     lists:reverse(Rows).
 
 
@@ -597,66 +590,65 @@ extract_messages(Worker, UserJID, _Host, Filter, IMax, true) ->
 %% If the element does not exists, the ID of the next element will
 %% be returned instead.
 %% @end
--spec calc_index(Worker, UserJID, Host, Filter, MessID) -> Count
-                                                               when
-      Worker :: worker(),
+-spec calc_index(PoolName, UserJID, Host, Filter, MessID) -> Count
+                                                                 when
+      PoolName :: mongoose_cassandra:pool_name(),
       UserJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
       MessID :: message_id(),
       Count :: non_neg_integer().
-calc_index(Worker, UserJID, Host, Filter, MessID) ->
-    calc_count(Worker, UserJID, Host, to_id(MessID, Filter)).
+calc_index(PoolName, UserJID, Host, Filter, MessID) ->
+    calc_count(PoolName, UserJID, Host, to_id(MessID, Filter)).
 
 %% @doc Count of elements in RSet before the passed element.
 %%
 %% The element with the passed UID can be already deleted.
 %% @end
--spec calc_before(Worker, UserJID, Host, Filter, MessID) -> Count
-                                                                when
-      Worker :: worker(),
+-spec calc_before(PoolName, UserJID, Host, Filter, MessID) -> Count
+                                                                  when
+      PoolName :: mongoose_cassandra:pool_name(),
       UserJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
       MessID :: message_id(),
       Count :: non_neg_integer().
-calc_before(Worker, UserJID, Host, Filter, MessID) ->
-    calc_count(Worker, UserJID, Host, before_id(MessID, Filter)).
+calc_before(PoolName, UserJID, Host, Filter, MessID) ->
+    calc_count(PoolName, UserJID, Host, before_id(MessID, Filter)).
 
 
 %% @doc Get the total result set size.
 %% "SELECT COUNT(*) as "count" FROM mam_message WHERE "
--spec calc_count(Worker, UserJID, Host, Filter) -> Count
-                                                       when
-      Worker :: worker(),
+-spec calc_count(PoolName, UserJID, Host, Filter) -> Count
+                                                         when
+      PoolName :: mongoose_cassandra:pool_name(),
       UserJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
       Count :: non_neg_integer().
-calc_count(Worker, UserJID, _Host, Filter) ->
+calc_count(PoolName, UserJID, _Host, Filter) ->
     QueryName = {calc_count_query, select_filter(Filter)},
     Params = eval_filter_params(Filter),
-    {ok, [[Count]]} = mongoose_cassandra_worker:cql_query(Worker, UserJID, ?MODULE, QueryName,
-                                                          Params),
-    Count.
+    {ok, [Row]} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, QueryName,
+                                              Params),
+    proplists:get_value(count, Row).
 
 %% @doc Convert offset to index of the first entry
 %% Returns undefined if not there are not enough rows
--spec offset_to_start_id(Worker, UserJID, Filter, Offset) -> Id
-                                                                 when
-      Worker :: worker(),
-      UserJID :: jlib:jid(),
-      Offset :: non_neg_integer(),
-      Filter :: filter(),
-      Id :: non_neg_integer() | undefined.
-offset_to_start_id(Worker, UserJID, Filter, Offset) when is_integer(Offset), Offset >= 0 ->
+-spec offset_to_start_id(PoolName, UserJID, Filter, Offset) -> Id when
+    PoolName :: mongoose_cassandra:pool_name(),
+    UserJID :: jlib:jid(),
+    Offset :: non_neg_integer(),
+    Filter :: filter(),
+    Id :: non_neg_integer() | undefined.
+offset_to_start_id(PoolName, UserJID, Filter, Offset) when is_integer(Offset), Offset >= 0 ->
     QueryName = {list_message_ids_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [Offset + 1],
-    {ok, RowsIds} = mongoose_cassandra_worker:cql_query(Worker, UserJID, ?MODULE, QueryName,
-                                                        Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', Offset + 1}],
+    {ok, RowsIds} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, QueryName, Params),
     case RowsIds of
-        [] -> unfefined;
-        [_ | _] -> [StartId] = lists:last(RowsIds), StartId
+        [] -> undefined;
+        [_ | _] ->
+            proplists:get_value(id, lists:last(RowsIds))
     end.
 
 prepare_filter(UserJID, Borders, Start, End, WithJID) ->
@@ -682,8 +674,9 @@ eval_filter_params(#mam_ca_filter{
                       start_id = StartID,
                       end_id   = EndID
                      }) ->
-    Optional = [Value || Value <- [StartID, EndID], Value =/= undefined],
-    [BUserJID, BWithJID | Optional].
+    Optional = [Value || {_, ID} = Value <- [{start_id, StartID}, {end_id, EndID}], ID =/=
+                             undefined],
+    [{user_jid, BUserJID}, {with_jid, BWithJID} | Optional].
 
 select_filter(#mam_ca_filter{
                  start_id = StartID,
@@ -708,20 +701,20 @@ select_filter(_, _) ->
 prepare_filter_cql(StartID, EndID) ->
     case StartID of
         undefined -> "";
-        _ -> " AND id >= ?"
+        _ -> " AND id >= :start_id"
     end ++
         case EndID of
             undefined -> "";
-            _ -> " AND id <= ?"
+            _ -> " AND id <= :end_id"
         end.
 
 filter_to_cql() ->
     [{select_filter(StartID, EndID), prepare_filter_cql(StartID, EndID)}
      || StartID <- [undefined, 0], EndID <- [undefined, 0]].
 
--spec calc_offset(Worker, UserJID, Host, Filter, PageSize, TotalCount, RSM) -> Offset
-                                                                                   when
-      Worker :: worker(),
+-spec calc_offset(PoolName, UserJID, Host, Filter, PageSize, TotalCount, RSM) -> Offset
+                                                                                     when
+      PoolName :: mongoose_cassandra:pool_name(),
       UserJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
@@ -732,12 +725,12 @@ filter_to_cql() ->
 %% Requesting the Last Page in a Result Set
 calc_offset(_W, _UserJID, _LS, _F, PS, TC, #rsm_in{direction = before, id = undefined}) ->
     max(0, TC - PS);
-calc_offset(Worker, UserJID, Host, F, PS, _TC, #rsm_in{direction = before, id = ID})
+calc_offset(PoolName, UserJID, Host, F, PS, _TC, #rsm_in{direction = before, id = ID})
   when is_integer(ID) ->
-    max(0, calc_before(Worker, UserJID, Host, F, ID) - PS);
-calc_offset(Worker, UserJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = ID})
+    max(0, calc_before(PoolName, UserJID, Host, F, ID) - PS);
+calc_offset(PoolName, UserJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = ID})
   when is_integer(ID) ->
-    calc_index(Worker, UserJID, Host, F, ID);
+    calc_index(PoolName, UserJID, Host, F, ID);
 calc_offset(_W, _UserJID, _LS, _F, _PS, _TC, _RSM) ->
     0.
 

--- a/apps/ejabberd/src/mod_mam_cassandra_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_prefs.erl
@@ -117,7 +117,7 @@ prepared_queries() ->
       "SELECT remote_jid, behaviour FROM mam_config WHERE user_jid = ? AND remote_jid IN ('', ?)"},
      {get_behaviour_full_query,
       "SELECT remote_jid, behaviour FROM mam_config WHERE user_jid = ? AND remote_jid "
-      "IN ('', ?, ?)"},
+      "IN ('', :start_remote_jid, :end_remote_jid)"},
      {del_prefs_ts_query,
       "DELETE FROM mam_config USING TIMESTAMP ? WHERE user_jid = ?"}
     ].
@@ -137,8 +137,8 @@ get_behaviour(DefaultBehaviour, Host, _UserID, LocJID, RemJID) ->
             DefaultBehaviour;
         {ok, [_ | _] = Rows} ->
             %% After sort <<>>, <<"a">>, <<"a/b">>
-            [_, Behavour] = lists:last(lists:sort(Rows)),
-            decode_behaviour(Behavour)
+            LastRow = lists:last(lists:sort(Rows)),
+            decode_behaviour(proplists:get_value(behaviour, LastRow))
     end.
 
 
@@ -164,16 +164,21 @@ set_prefs1(_Host, UserJID, DefaultMode, AlwaysJIDs, NeverJIDs) ->
     %% http://stackoverflow.com/questions/30317877/cassandra-batch-statement-execution-order
     Now = mongoose_cassandra:now_timestamp(),
     Next = Now + 1,
-    DelParams = [Now, BUserJID],
-    MultiParams = [[BUserJID, <<>>, encode_behaviour(DefaultMode), Next]]
-        ++ [[BUserJID, BinJID, <<"A">>, Next] || BinJID <- AlwaysJIDs]
-        ++ [[BUserJID, BinJID, <<"N">>, Next] || BinJID <- NeverJIDs],
-    DelQuery = {del_prefs_ts_query, DelParams},
-    SetQuries = [{set_prefs_ts_query, Params} || Params <- MultiParams],
-    Queries = [DelQuery | SetQuries],
-    Res = mongoose_cassandra_worker:cql_batch_pool(PoolName, UserJID, ?MODULE, Queries),
+    DelParams = [{'[timestamp]', Now}, {user_jid, BUserJID}],
+    MultiParams = [encode_row(BUserJID, <<>>, encode_behaviour(DefaultMode), Next)]
+        ++ [encode_row(BUserJID, BinJID, <<"A">>, Next) || BinJID <- AlwaysJIDs]
+        ++ [encode_row(BUserJID, BinJID, <<"N">>, Next) || BinJID <- NeverJIDs],
+    DelQuery = {del_prefs_ts_query, [DelParams]},
+    SetQuery = {set_prefs_ts_query, MultiParams},
+    Queries = [DelQuery, SetQuery],
+    Res = [mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, Query, Params)
+           || {Query, Params} <- Queries],
     ?DEBUG("issue=set_prefs1, result=~p", [Res]),
     ok.
+
+encode_row(BUserJID, BRemoteJID, Behaviour, Timestamp) ->
+    [{user_jid, BUserJID}, {remote_jid, BRemoteJID},
+     {behaviour, Behaviour}, {'[timestamp]', Timestamp}].
 
 
 -spec get_prefs(mod_mam:preference(), _Host :: ejabberd:server(),
@@ -182,9 +187,9 @@ set_prefs1(_Host, UserJID, DefaultMode, AlwaysJIDs, NeverJIDs) ->
 get_prefs({GlobalDefaultMode, _, _}, _Host, _UserID, UserJID) ->
     BUserJID = bare_jid(UserJID),
     PoolName = pool_name(UserJID),
-    Params = [BUserJID],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query_pool(PoolName, UserJID, ?MODULE,
-                                                          get_prefs_query, Params),
+    Params = [{user_jid, BUserJID}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE,
+                                             get_prefs_query, Params),
     decode_prefs_rows(Rows, GlobalDefaultMode, [], []).
 
 
@@ -194,9 +199,8 @@ remove_archive(_Host, _UserID, UserJID) ->
     PoolName = pool_name(UserJID),
     BUserJID = bare_jid(UserJID),
     Now = mongoose_cassandra:now_timestamp(),
-    Params = [Now, BUserJID],
-    mongoose_cassandra_worker:cql_query_pool(PoolName, UserJID, ?MODULE, del_prefs_ts_query,
-                                             Params),
+    Params = [{'[timestamp]', Now}, {user_jid, BUserJID}],
+    mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, del_prefs_ts_query, [Params]),
     ok.
 
 
@@ -206,13 +210,14 @@ query_behaviour(_Host, UserJID, BUserJID, BRemJID, BRemBareJID) ->
     PoolName = pool_name(UserJID),
     case BRemJID of
         BRemBareJID ->
-            Params = [BUserJID, BRemBareJID],
-            mongoose_cassandra_worker:cql_query_pool(PoolName, UserJID, ?MODULE,
-                                                     get_behaviour_bare_query, Params);
+            Params = [{user_jid, BUserJID}, {remote_jid, BRemBareJID}],
+            mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE,
+                                        get_behaviour_bare_query, Params);
         _ ->
-            Params = [BUserJID, BRemJID, BRemBareJID],
-            mongoose_cassandra_worker:cql_query_pool(PoolName, UserJID, ?MODULE,
-                                                     get_behaviour_full_query, Params)
+            Params = [{user_jid, BUserJID},
+                      {start_remote_jid, BRemJID}, {end_remote_jid, BRemBareJID}],
+            mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE,
+                                        get_behaviour_full_query, Params)
     end.
 
 %% ----------------------------------------------------------------------
@@ -245,14 +250,19 @@ full_jid(JID) ->
                          [ejabberd:literal_jid()],
                          [ejabberd:literal_jid()]
                         }.
-decode_prefs_rows([[<<>>, Behavour] | Rows], _DefaultMode, AlwaysJIDs, NeverJIDs) ->
-    decode_prefs_rows(Rows, decode_behaviour(Behavour), AlwaysJIDs, NeverJIDs);
-decode_prefs_rows([[JID, <<"A">>] | Rows], DefaultMode, AlwaysJIDs, NeverJIDs) ->
-    decode_prefs_rows(Rows, DefaultMode, [JID | AlwaysJIDs], NeverJIDs);
-decode_prefs_rows([[JID, <<"N">>] | Rows], DefaultMode, AlwaysJIDs, NeverJIDs) ->
-    decode_prefs_rows(Rows, DefaultMode, AlwaysJIDs, [JID | NeverJIDs]);
 decode_prefs_rows([], DefaultMode, AlwaysJIDs, NeverJIDs) ->
-    {DefaultMode, AlwaysJIDs, NeverJIDs}.
+    {DefaultMode, AlwaysJIDs, NeverJIDs};
+decode_prefs_rows([Row | Rows], DefaultMode, AlwaysJIDs, NeverJIDs) ->
+    JID = proplists:get_value(remote_jid, Row),
+    Behaviour = proplists:get_value(behaviour, Row),
+    case {JID, Behaviour} of
+        {<<>>, Behaviour} ->
+            decode_prefs_rows(Rows, decode_behaviour(Behaviour), AlwaysJIDs, NeverJIDs);
+        {JID, <<"A">>} ->
+            decode_prefs_rows(Rows, DefaultMode, [JID | AlwaysJIDs], NeverJIDs);
+        {JID, <<"N">>} ->
+            decode_prefs_rows(Rows, DefaultMode, AlwaysJIDs, [JID | NeverJIDs])
+    end.
 
 
 %% ----------------------------------------------------------------------

--- a/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
@@ -18,7 +18,7 @@
          purge_single_message/6,
          purge_multiple_messages/9]).
 
-%% mongoose_cassandra_worker callbacks
+%% mongoose_cassandra callbacks
 -export([prepared_queries/0]).
 
 %% ----------------------------------------------------------------------
@@ -59,8 +59,6 @@
           with_nick :: binary(),
           message :: binary()
          }).
-
--type worker() :: pid() | atom().
 
 -callback encode(binary()) -> binary().
 -callback decode(binary()) -> binary().
@@ -132,13 +130,6 @@ prepared_queries() ->
         ++ calc_count_queries()
         ++ list_message_ids_queries().
 
-%% ----------------------------------------------------------------------
-%% Helpers
-
-select_worker(UserJID) ->
-    PoolName = pool_name(UserJID),
-    mongoose_cassandra_sup:select_worker(PoolName, UserJID).
-
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -147,10 +138,10 @@ select_worker(UserJID) ->
 %% Internal functions and callbacks
 
 archive_size(Size, Host, _RoomID, RoomJID) when is_integer(Size) ->
-    Worker = select_worker(RoomJID),
+    PoolName = pool_name(RoomJID),
     Borders = Start = End = WithNick = undefined,
     Filter = prepare_filter(RoomJID, Borders, Start, End, WithNick),
-    calc_count(Worker, RoomJID, Host, Filter).
+    calc_count(PoolName, RoomJID, Host, Filter).
 
 
 %% ----------------------------------------------------------------------
@@ -184,14 +175,13 @@ archive_message2(_Result, _Host, MessID,
                 },
     WithNicks = [<<>>, BNick],
     Messages = [Message#mam_muc_message{with_nick = BWithNick} || BWithNick <- WithNicks],
-    Worker = select_worker(LocJID),
-    write_messages(Worker, Messages).
+    PoolName = pool_name(LocJID),
+    write_messages(PoolName, Messages).
 
 write_messages(RoomJID, Messages) ->
     PoolName = pool_name(RoomJID),
     MultiParams = [message_to_params(M) || M <- Messages],
-    mongoose_cassandra_worker:cql_query_pool_multi_async(PoolName, RoomJID, ?MODULE, insert_query,
-                                                         MultiParams).
+    mongoose_cassandra:cql_write_async(PoolName, RoomJID, ?MODULE, insert_query, MultiParams).
 
 message_to_params(#mam_muc_message{
                      id        = MessID,
@@ -200,7 +190,8 @@ message_to_params(#mam_muc_message{
                      with_nick = BWithNick,
                      message   = BPacket
                     }) ->
-    [MessID, BLocJID, BNick, BWithNick, BPacket].
+    [{id, MessID}, {room_jid, BLocJID}, {nick_name, BNick}, {with_nick, BWithNick},
+     {message, BPacket}].
 
 
 %% ----------------------------------------------------------------------
@@ -210,17 +201,17 @@ delete_query_cql() ->
     "DELETE FROM mam_muc_message "
         "WHERE room_jid = ? AND with_nick = ? AND id = ?".
 
-delete_messages(Worker, RoomJID, Messages) ->
+delete_messages(PoolName, RoomJID, Messages) ->
     MultiParams = [delete_message_to_params(M) || M <- Messages],
-    mongoose_cassandra_worker:cql_query_multi_async(Worker, RoomJID, ?MODULE, delete_query,
-                                                    MultiParams).
+    mongoose_cassandra:cql_write(PoolName, RoomJID, ?MODULE, delete_query,
+                                 MultiParams).
 
 delete_message_to_params(#mam_muc_message{
                             id        = MessID,
                             room_jid  = BLocJID,
                             with_nick = BWithNick
                            }) ->
-    [BLocJID, BWithNick, MessID].
+    [{room_jid, BLocJID}, {with_nick, BWithNick}, {id, MessID}].
 
 
 %% ----------------------------------------------------------------------
@@ -232,12 +223,11 @@ remove_archive_query_cql() ->
 remove_archive(_Host, _RoomID, RoomJID) ->
     BRoomJID = bare_jid(RoomJID),
     PoolName = pool_name(RoomJID),
-    Params = [BRoomJID],
+    Params = [{room_jid, BRoomJID}],
     %% Wait until deleted
-    mongoose_cassandra_worker:cql_query_pool(PoolName, RoomJID, ?MODULE, remove_archive_query,
-                                             Params),
-    ok.
 
+    mongoose_cassandra:cql_write(PoolName, RoomJID, ?MODULE, remove_archive_query, [Params]),
+    ok.
 
 %% ----------------------------------------------------------------------
 %% GET NICK NAME
@@ -246,15 +236,15 @@ message_id_to_nick_name_cql() ->
     "SELECT nick_name FROM mam_muc_message "
         "WHERE room_jid = ? AND with_nick = '' AND id = ?".
 
-message_id_to_nick_name(Worker, RoomJID, BRoomJID, MessID) ->
-    Params = [BRoomJID, MessID],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query(Worker, RoomJID, ?MODULE,
-                                                     message_id_to_nick_name_query, Params),
+message_id_to_nick_name(PoolName, RoomJID, BRoomJID, MessID) ->
+    Params = [{room_jid, BRoomJID}, {id, MessID}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, RoomJID, ?MODULE,
+                                             message_id_to_nick_name_query, Params),
     case Rows of
         [] ->
             {error, not_found};
-        [[BNickName]] ->
-            {ok, BNickName}
+        [Row] ->
+            {ok, proplists:get_value(nick_name, Row)}
     end.
 
 
@@ -287,8 +277,8 @@ lookup_messages(_Result, Host,
                 IsSimple) ->
     try
         WithNick = maybe_jid_to_nick(WithJID),
-        Worker = select_worker(RoomJID),
-        lookup_messages2(Worker, Host,
+        PoolName = pool_name(RoomJID),
+        lookup_messages2(PoolName, Host,
                          RoomJID, RSM, Borders,
                          Start, End, WithNick,
                          PageSize, LimitPassed, MaxResultLimit,
@@ -302,15 +292,15 @@ maybe_jid_to_nick(#jid{lresource = BNick}) -> BNick;
 maybe_jid_to_nick(undefined) -> undefined.
 
 
-lookup_messages2(Worker, Host,
+lookup_messages2(PoolName, Host,
                  RoomJID = #jid{}, RSM, Borders,
                  Start, End, WithNick,
                  PageSize, _LimitPassed, _MaxResultLimit,
                  _IsSimple = true) ->
     %% Simple query without calculating offset and total count
     Filter = prepare_filter(RoomJID, Borders, Start, End, WithNick),
-    lookup_messages_simple(Worker, Host, RoomJID, RSM, PageSize, Filter);
-lookup_messages2(Worker, Host,
+    lookup_messages_simple(PoolName, Host, RoomJID, RSM, PageSize, Filter);
+lookup_messages2(PoolName, Host,
                  RoomJID = #jid{}, RSM, Borders,
                  Start, End, WithNick,
                  PageSize, LimitPassed, MaxResultLimit,
@@ -324,15 +314,15 @@ lookup_messages2(Worker, Host,
     Result =
         case Strategy of
             last_page ->
-                lookup_messages_last_page(Worker, Host, RoomJID, RSM, PageSize, Filter);
+                lookup_messages_last_page(PoolName, Host, RoomJID, RSM, PageSize, Filter);
             by_offset ->
-                lookup_messages_by_offset(Worker, Host, RoomJID, RSM, PageSize, Filter);
+                lookup_messages_by_offset(PoolName, Host, RoomJID, RSM, PageSize, Filter);
             first_page ->
-                lookup_messages_first_page(Worker, Host, RoomJID, RSM, PageSize, Filter);
+                lookup_messages_first_page(PoolName, Host, RoomJID, RSM, PageSize, Filter);
             before_id ->
-                lookup_messages_before_id(Worker, Host, RoomJID, RSM, PageSize, Filter);
+                lookup_messages_before_id(PoolName, Host, RoomJID, RSM, PageSize, Filter);
             after_id ->
-                lookup_messages_after_id(Worker, Host, RoomJID, RSM, PageSize, Filter)
+                lookup_messages_after_id(PoolName, Host, RoomJID, RSM, PageSize, Filter)
         end,
     check_result_for_policy_violation(Result, MaxResultLimit, LimitPassed).
 
@@ -351,43 +341,43 @@ rsm_to_strategy(#rsm_in{}) ->
 rsm_to_strategy(undefined) ->
     first_page.
 
-lookup_messages_simple(Worker, Host, RoomJID,
+lookup_messages_simple(PoolName, Host, RoomJID,
                        #rsm_in{direction = aft, id = ID},
                        PageSize, Filter) ->
     %% Get last rows from result set
-    MessageRows = extract_messages(Worker, RoomJID, Host, after_id(ID, Filter), PageSize, false),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, after_id(ID, Filter), PageSize, false),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows, RoomJID)}};
-lookup_messages_simple(Worker, Host, RoomJID,
+lookup_messages_simple(PoolName, Host, RoomJID,
                        #rsm_in{direction = before, id = ID},
                        PageSize, Filter) ->
-    MessageRows = extract_messages(Worker, RoomJID, Host, before_id(ID, Filter), PageSize, true),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, before_id(ID, Filter), PageSize, true),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows, RoomJID)}};
-lookup_messages_simple(Worker, Host, RoomJID,
+lookup_messages_simple(PoolName, Host, RoomJID,
                        #rsm_in{direction = undefined, index = Offset},
                        PageSize, Filter) ->
     %% Apply offset
-    StartId = offset_to_start_id(Worker, RoomJID, Filter,
+    StartId = offset_to_start_id(PoolName, RoomJID, Filter,
                                  Offset), %% POTENTIALLY SLOW AND NOT SIMPLE :)
-    MessageRows = extract_messages(Worker, RoomJID, Host, from_id(StartId, Filter), PageSize,
+    MessageRows = extract_messages(PoolName, RoomJID, Host, from_id(StartId, Filter), PageSize,
                                    false),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows, RoomJID)}};
-lookup_messages_simple(Worker, Host, RoomJID,
+lookup_messages_simple(PoolName, Host, RoomJID,
                        _,
                        PageSize, Filter) ->
-    MessageRows = extract_messages(Worker, RoomJID, Host, Filter, PageSize, false),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, Filter, PageSize, false),
     {ok, {undefined, undefined, rows_to_uniform_format(MessageRows, RoomJID)}}.
 
-lookup_messages_last_page(Worker, Host, RoomJID,
+lookup_messages_last_page(PoolName, Host, RoomJID,
                           #rsm_in{direction = before, id = undefined},
                           0, Filter) ->
     %% Last page
-    TotalCount = calc_count(Worker, RoomJID, Host, Filter),
+    TotalCount = calc_count(PoolName, RoomJID, Host, Filter),
     {ok, {TotalCount, TotalCount, []}};
-lookup_messages_last_page(Worker, Host, RoomJID,
+lookup_messages_last_page(PoolName, Host, RoomJID,
                           #rsm_in{direction = before, id = undefined},
                           PageSize, Filter) ->
     %% Last page
-    MessageRows = extract_messages(Worker, RoomJID, Host, Filter, PageSize, true),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, Filter, PageSize, true),
     MessageRowsCount = length(MessageRows),
     case MessageRowsCount < PageSize of
         true ->
@@ -395,23 +385,23 @@ lookup_messages_last_page(Worker, Host, RoomJID,
                   rows_to_uniform_format(MessageRows, RoomJID)}};
         false ->
             FirstID = row_to_message_id(hd(MessageRows)),
-            Offset = calc_count(Worker, RoomJID, Host, before_id(FirstID, Filter)),
+            Offset = calc_count(PoolName, RoomJID, Host, before_id(FirstID, Filter)),
             {ok, {Offset + MessageRowsCount, Offset,
                   rows_to_uniform_format(MessageRows, RoomJID)}}
     end.
 
-lookup_messages_by_offset(Worker, Host, RoomJID,
+lookup_messages_by_offset(PoolName, Host, RoomJID,
                           #rsm_in{direction = undefined, index = Offset},
                           0, Filter) when is_integer(Offset) ->
     %% By offset
-    TotalCount = calc_count(Worker, RoomJID, Host, Filter),
+    TotalCount = calc_count(PoolName, RoomJID, Host, Filter),
     {ok, {TotalCount, Offset, []}};
-lookup_messages_by_offset(Worker, Host, RoomJID,
+lookup_messages_by_offset(PoolName, Host, RoomJID,
                           #rsm_in{direction = undefined, index = Offset},
                           PageSize, Filter) when is_integer(Offset) ->
     %% By offset
-    StartId = offset_to_start_id(Worker, RoomJID, Filter, Offset), %% POTENTIALLY SLOW
-    MessageRows = extract_messages(Worker, RoomJID, Host, from_id(StartId, Filter), PageSize,
+    StartId = offset_to_start_id(PoolName, RoomJID, Filter, Offset), %% POTENTIALLY SLOW
+    MessageRows = extract_messages(PoolName, RoomJID, Host, from_id(StartId, Filter), PageSize,
                                    false),
     MessageRowsCount = length(MessageRows),
     case MessageRowsCount < PageSize of
@@ -420,22 +410,22 @@ lookup_messages_by_offset(Worker, Host, RoomJID,
                   rows_to_uniform_format(MessageRows, RoomJID)}};
         false ->
             LastID = row_to_message_id(lists:last(MessageRows)),
-            CountAfterLastID = calc_count(Worker, RoomJID, Host, after_id(LastID, Filter)),
+            CountAfterLastID = calc_count(PoolName, RoomJID, Host, after_id(LastID, Filter)),
             {ok, {Offset + MessageRowsCount + CountAfterLastID, Offset,
                   rows_to_uniform_format(MessageRows, RoomJID)}}
     end.
 
-lookup_messages_first_page(Worker, Host, RoomJID,
+lookup_messages_first_page(PoolName, Host, RoomJID,
                            _,
                            0, Filter) ->
     %% First page, just count
-    TotalCount = calc_count(Worker, RoomJID, Host, Filter),
+    TotalCount = calc_count(PoolName, RoomJID, Host, Filter),
     {ok, {TotalCount, 0, []}};
-lookup_messages_first_page(Worker, Host, RoomJID,
+lookup_messages_first_page(PoolName, Host, RoomJID,
                            _,
                            PageSize, Filter) ->
     %% First page
-    MessageRows = extract_messages(Worker, RoomJID, Host, Filter, PageSize, false),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, Filter, PageSize, false),
     MessageRowsCount = length(MessageRows),
     case MessageRowsCount < PageSize of
         true ->
@@ -443,26 +433,26 @@ lookup_messages_first_page(Worker, Host, RoomJID,
                   rows_to_uniform_format(MessageRows, RoomJID)}};
         false ->
             LastID = row_to_message_id(lists:last(MessageRows)),
-            CountAfterLastID = calc_count(Worker, RoomJID, Host, after_id(LastID, Filter)),
+            CountAfterLastID = calc_count(PoolName, RoomJID, Host, after_id(LastID, Filter)),
             {ok, {MessageRowsCount + CountAfterLastID, 0,
                   rows_to_uniform_format(MessageRows, RoomJID)}}
     end.
 
-lookup_messages_before_id(Worker, Host, RoomJID,
+lookup_messages_before_id(PoolName, Host, RoomJID,
                           RSM = #rsm_in{direction = before, id = ID},
                           PageSize, Filter) ->
-    TotalCount = calc_count(Worker, RoomJID, Host, Filter),
-    Offset = calc_offset(Worker, RoomJID, Host, Filter, PageSize, TotalCount, RSM),
-    MessageRows = extract_messages(Worker, RoomJID, Host, before_id(ID, Filter), PageSize, true),
+    TotalCount = calc_count(PoolName, RoomJID, Host, Filter),
+    Offset = calc_offset(PoolName, RoomJID, Host, Filter, PageSize, TotalCount, RSM),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, before_id(ID, Filter), PageSize, true),
     {ok, {TotalCount, Offset, rows_to_uniform_format(MessageRows, RoomJID)}}.
 
-lookup_messages_after_id(Worker, Host, RoomJID,
+lookup_messages_after_id(PoolName, Host, RoomJID,
                          RSM = #rsm_in{direction = aft, id = ID},
                          PageSize, Filter) ->
-    Worker = select_worker(RoomJID),
-    TotalCount = calc_count(Worker, RoomJID, Host, Filter),
-    Offset = calc_offset(Worker, RoomJID, Host, Filter, PageSize, TotalCount, RSM),
-    MessageRows = extract_messages(Worker, RoomJID, Host, after_id(ID, Filter), PageSize, false),
+    PoolName = pool_name(RoomJID),
+    TotalCount = calc_count(PoolName, RoomJID, Host, Filter),
+    Offset = calc_offset(PoolName, RoomJID, Host, Filter, PageSize, TotalCount, RSM),
+    MessageRows = extract_messages(PoolName, RoomJID, Host, after_id(ID, Filter), PageSize, false),
     {ok, {TotalCount, Offset, rows_to_uniform_format(MessageRows, RoomJID)}}.
 
 check_result_for_policy_violation(Result = {ok, {TotalCount, Offset, _}},
@@ -502,13 +492,16 @@ from_id(ID, Filter = #mam_muc_ca_filter{start_id = AfterID}) ->
 rows_to_uniform_format(MessageRows, RoomJID) ->
     [row_to_uniform_format(Row, RoomJID) || Row <- MessageRows].
 
-row_to_uniform_format([MessID, BNick, Data], RoomJID) ->
+row_to_uniform_format(Row, RoomJID) ->
+    BNick = proplists:get_value(nick_name, Row),
+    Data = proplists:get_value(message, Row),
+    MessID = proplists:get_value(id, Row),
     SrcJID = jid:replace_resource(RoomJID, BNick),
     Packet = stored_binary_to_packet(Data),
     {MessID, SrcJID, Packet}.
 
-row_to_message_id([MessID, _, _]) ->
-    MessID.
+row_to_message_id(Row) ->
+    proplists:get_value(id, Row).
 
 -spec purge_single_message(_Result, Host, MessID, _RoomID, RoomJID,
                            Now) ->
@@ -517,9 +510,9 @@ row_to_message_id([MessID, _, _]) ->
       _RoomID :: user_id(), RoomJID :: jid(),
       Now :: unix_timestamp().
 purge_single_message(_Result, _Host, MessID, _RoomID, RoomJID, _Now) ->
-    Worker = select_worker(RoomJID),
+    PoolName = pool_name(RoomJID),
     BRoomJID = bare_jid(RoomJID),
-    Result = message_id_to_nick_name(Worker, RoomJID, BRoomJID, MessID),
+    Result = message_id_to_nick_name(PoolName, RoomJID, BRoomJID, MessID),
     case Result of
         {ok, BNick} ->
             BWithNicks = lists:usort([BNick, <<>>]),
@@ -531,7 +524,7 @@ purge_single_message(_Result, _Host, MessID, _RoomID, RoomJID, _Now) ->
                            nick_name = BNick, %% set the field for debugging
                            with_nick = BWithNick
                           }           || BWithNick <- BWithNicks],
-            delete_messages(Worker, RoomJID, Messages),
+            delete_messages(PoolName, RoomJID, Messages),
             ok;
         {error, _} ->
             ok
@@ -551,14 +544,15 @@ purge_multiple_messages(_Result, Host, RoomID, RoomJID, Borders,
     %% Simple query without calculating offset and total count
     Filter = prepare_filter(RoomJID, Borders, Start, End, WithNick),
     PoolName = pool_name(RoomJID),
-    Limit = 500, %% TODO something smarter
+    Limit = 100, %% TODO something smarter
     QueryName = {list_message_ids_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [Limit],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query_pool(PoolName, RoomJID, ?MODULE, QueryName,
-                                                          Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', Limit}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, RoomJID, ?MODULE, QueryName,
+                                             Params),
     %% TODO can be faster
     %% TODO rate limiting
-    [purge_single_message(ok, Host, MessID, RoomID, RoomJID, Now) || [MessID] <- Rows],
+    [purge_single_message(ok, Host, proplists:get_value(id, Row), RoomID, RoomJID, Now)
+     || Row <- Rows],
     ok.
 
 
@@ -566,9 +560,9 @@ purge_multiple_messages(_Result, Host, RoomID, RoomJID, Borders,
 %% Each record is a tuple of form
 %% `{<<"13663125233">>,<<"bob@localhost">>,<<"res1">>,<<binary>>}'.
 %% Columns are `["id","nick_name","message"]'.
--spec extract_messages(Worker, RoomJID, Host, Filter, IMax, ReverseLimit) ->
+-spec extract_messages(PoolName, RoomJID, Host, Filter, IMax, ReverseLimit) ->
                               [Row] when
-      Worker :: worker(),
+      PoolName :: mongoose_cassandra:pool_name(),
       RoomJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
@@ -577,15 +571,15 @@ purge_multiple_messages(_Result, Host, RoomID, RoomJID, Borders,
       Row :: list().
 extract_messages(_Worker, _RoomJID, _Host, _Filter, 0, _) ->
     [];
-extract_messages(Worker, RoomJID, _Host, Filter, IMax, false) ->
+extract_messages(PoolName, RoomJID, _Host, Filter, IMax, false) ->
     QueryName = {extract_messages_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [IMax],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query(Worker, RoomJID, ?MODULE, QueryName, Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', IMax}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, RoomJID, ?MODULE, QueryName, Params),
     Rows;
-extract_messages(Worker, RoomJID, _Host, Filter, IMax, true) ->
+extract_messages(PoolName, RoomJID, _Host, Filter, IMax, true) ->
     QueryName = {extract_messages_r_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [IMax],
-    {ok, Rows} = mongoose_cassandra_worker:cql_query(Worker, RoomJID, ?MODULE, QueryName, Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', IMax}],
+    {ok, Rows} = mongoose_cassandra:cql_read(PoolName, RoomJID, ?MODULE, QueryName, Params),
     lists:reverse(Rows).
 
 
@@ -594,66 +588,65 @@ extract_messages(Worker, RoomJID, _Host, Filter, IMax, true) ->
 %% If the element does not exists, the ID of the next element will
 %% be returned instead.
 %% @end
--spec calc_index(Worker, RoomJID, Host, Filter, MessID) -> Count
-                                                               when
-      Worker :: worker(),
+-spec calc_index(PoolName, RoomJID, Host, Filter, MessID) -> Count
+                                                                 when
+      PoolName :: mongoose_cassandra:pool_name(),
       RoomJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
       MessID :: message_id(),
       Count :: non_neg_integer().
-calc_index(Worker, RoomJID, Host, Filter, MessID) ->
-    calc_count(Worker, RoomJID, Host, to_id(MessID, Filter)).
+calc_index(PoolName, RoomJID, Host, Filter, MessID) ->
+    calc_count(PoolName, RoomJID, Host, to_id(MessID, Filter)).
 
 %% @doc Count of elements in RSet before the passed element.
 %%
 %% The element with the passed UID can be already deleted.
 %% @end
--spec calc_before(Worker, RoomJID, Host, Filter, MessID) -> Count
-                                                                when
-      Worker :: worker(),
+-spec calc_before(PoolName, RoomJID, Host, Filter, MessID) -> Count
+                                                                  when
+      PoolName :: mongoose_cassandra:pool_name(),
       RoomJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
       MessID :: message_id(),
       Count :: non_neg_integer().
-calc_before(Worker, RoomJID, Host, Filter, MessID) ->
-    calc_count(Worker, RoomJID, Host, before_id(MessID, Filter)).
+calc_before(PoolName, RoomJID, Host, Filter, MessID) ->
+    calc_count(PoolName, RoomJID, Host, before_id(MessID, Filter)).
 
 
 %% @doc Get the total result set size.
 %% "SELECT COUNT(*) as "count" FROM mam_muc_message WHERE "
--spec calc_count(Worker, RoomJID, Host, Filter) -> Count
-                                                       when
-      Worker :: worker(),
+-spec calc_count(PoolName, RoomJID, Host, Filter) -> Count
+                                                         when
+      PoolName :: mongoose_cassandra:pool_name(),
       RoomJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
       Count :: non_neg_integer().
-calc_count(Worker, RoomJID, _Host, Filter) ->
+calc_count(PoolName, RoomJID, _Host, Filter) ->
     QueryName = {calc_count_query, select_filter(Filter)},
     Params = eval_filter_params(Filter),
-    {ok, [[Count]]} = mongoose_cassandra_worker:cql_query(Worker, RoomJID, ?MODULE, QueryName,
-                                                          Params),
-    Count.
+    {ok, [Row]} = mongoose_cassandra:cql_read(PoolName, RoomJID, ?MODULE, QueryName,
+                                              Params),
+    proplists:get_value(count, Row).
 
 %% @doc Convert offset to index of the first entry
 %% Returns undefined if not there are not enough rows
--spec offset_to_start_id(Worker, RoomJID, Filter, Offset) -> Id
-                                                                 when
-      Worker :: worker(),
-      RoomJID :: jlib:jid(),
-      Offset :: non_neg_integer(),
-      Filter :: filter(),
-      Id :: non_neg_integer() | undefined.
-offset_to_start_id(Worker, RoomJID, Filter, Offset) when is_integer(Offset), Offset >= 0 ->
+-spec offset_to_start_id(PoolName, RoomJID, Filter, Offset) -> Id when
+    PoolName :: mongoose_cassandra:pool_name(),
+    RoomJID :: jlib:jid(),
+    Offset :: non_neg_integer(),
+    Filter :: filter(),
+    Id :: non_neg_integer() | undefined.
+offset_to_start_id(PoolName, RoomJID, Filter, Offset) when is_integer(Offset), Offset >= 0 ->
     QueryName = {list_message_ids_query, select_filter(Filter)},
-    Params = eval_filter_params(Filter) ++ [Offset + 1],
-    {ok, RowsIds} = mongoose_cassandra_worker:cql_query(Worker, RoomJID, ?MODULE, QueryName,
-                                                        Params),
+    Params = eval_filter_params(Filter) ++ [{'[limit]', Offset + 1}],
+    {ok, RowsIds} = mongoose_cassandra:cql_read(PoolName, RoomJID, ?MODULE, QueryName, Params),
     case RowsIds of
-        [] -> unfefined;
-        [_ | _] -> [StartId] = lists:last(RowsIds), StartId
+        [] -> undefined;
+        [_ | _] ->
+            proplists:get_value(id, lists:last(RowsIds))
     end.
 
 prepare_filter(RoomJID, Borders, Start, End, WithNick) ->
@@ -679,8 +672,9 @@ eval_filter_params(#mam_muc_ca_filter{
                       start_id  = StartID,
                       end_id    = EndID
                      }) ->
-    Optional = [Value || Value <- [StartID, EndID], Value =/= undefined],
-    [BRoomJID, BWithNick | Optional].
+    Optional = [Value || {_, ID} = Value <- [{start_id, StartID}, {end_id, EndID}], ID =/=
+                             undefined],
+    [{room_jid, BRoomJID}, {with_nick, BWithNick} | Optional].
 
 select_filter(#mam_muc_ca_filter{
                  start_id = StartID,
@@ -705,11 +699,11 @@ select_filter(_, _) ->
 prepare_filter_cql(StartID, EndID) ->
     case StartID of
         undefined -> "";
-        _ -> " AND id >= ?"
+        _ -> " AND id >= :start_id"
     end ++
         case EndID of
             undefined -> "";
-            _ -> " AND id <= ?"
+            _ -> " AND id <= :end_id"
         end.
 
 filter_to_cql() ->
@@ -718,9 +712,9 @@ filter_to_cql() ->
      || StartID <- [undefined, 0],
         EndID <- [undefined, 0]].
 
--spec calc_offset(Worker, RoomJID, Host, Filter, PageSize, TotalCount, RSM) -> Offset
-                                                                                   when
-      Worker :: worker(),
+-spec calc_offset(PoolName, RoomJID, Host, Filter, PageSize, TotalCount, RSM) -> Offset
+                                                                                     when
+      PoolName :: mongoose_cassandra:pool_name(),
       RoomJID :: jlib:jid(),
       Host :: server_hostname(),
       Filter :: filter(),
@@ -731,12 +725,12 @@ filter_to_cql() ->
 %% Requesting the Last Page in a Result Set
 calc_offset(_W, _RoomJID, _LS, _F, PS, TC, #rsm_in{direction = before, id = undefined}) ->
     max(0, TC - PS);
-calc_offset(Worker, RoomJID, Host, F, PS, _TC, #rsm_in{direction = before, id = ID})
+calc_offset(PoolName, RoomJID, Host, F, PS, _TC, #rsm_in{direction = before, id = ID})
   when is_integer(ID) ->
-    max(0, calc_before(Worker, RoomJID, Host, F, ID) - PS);
-calc_offset(Worker, RoomJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = ID})
+    max(0, calc_before(PoolName, RoomJID, Host, F, ID) - PS);
+calc_offset(PoolName, RoomJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = ID})
   when is_integer(ID) ->
-    calc_index(Worker, RoomJID, Host, F, ID);
+    calc_index(PoolName, RoomJID, Host, F, ID);
 calc_offset(_W, _RoomJID, _LS, _F, _PS, _TC, _RSM) ->
     0.
 

--- a/apps/ejabberd/src/mongoose_cassandra.erl
+++ b/apps/ejabberd/src/mongoose_cassandra.erl
@@ -1,30 +1,101 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
 -module(mongoose_cassandra).
+-author("Rafal Slota").
+
+-include_lib("ejabberd/include/ejabberd.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
+-include_lib("cqerl/include/cqerl.hrl").
+
+-define(READ_TIMEOUT, timer:minutes(1)).
+
+%% ====================================================================
+%% Types
+%% ====================================================================
+
+-type row() :: proplists:proplist().
+-type row_fold_fun() :: fun((Page :: [row()], AccIn :: term()) -> AccOut :: term()).
+-type pool_name() :: atom().
+-type cql_query() :: #cql_query{}.
+-type query_name() :: atom() | {atom(), atom()}.
+
+%% ====================================================================
+%% Exports
+%% ====================================================================
+
+%% Module callbacks
 -export([start/0, stop/0]).
+
+%% API
+-export([cql_read/5, cql_foldl/7, cql_write/5, cql_write_async/5]).
 -export([now_timestamp/0]).
 
+%% Test queries
+-export([prepared_queries/0, total_count_query_cql/1, test_query_sql/0]).
+-export([test_query/1, test_query/2, total_count_query/2]).
+
+%% Types
+-export_type([pool_name/0, row/0, query_name/0]).
+
+%% Callbacks definitions
 -callback prepared_queries() -> list({term(), string()}).
 
+
+%% ====================================================================
+%% Module API
+%% ====================================================================
+
+-spec start() -> ignore | ok | no_return().
 start() ->
     case ejabberd_config:get_local_option(cassandra_servers) of
         undefined ->
             ignore;
         Pools ->
-            [start_pool(Pool) || Pool <- Pools]
+            cqerl_app:start(normal, []),
+            [init_pool(Pool) || Pool <- Pools]
     end.
-
-start_pool({PoolName, PoolConfig}) ->
-    mongoose_cassandra_sup:start(PoolName, extend_config(PoolConfig)).
-
-extend_config(PoolConfig) ->
-    PoolConfig
-        ++ [{servers, [{"localhost", 9042, 1}]},
-            {socket_options, [{connect_timeout, 4000}]},
-            {keyspace, "mongooseim"},
-            {credentials, undefined}].
 
 -spec stop() -> _.
 stop() ->
-    mongoose_cassandra_sup:stop().
+    mongoose_cassandra_sup:stop(),
+    cqerl_app:stop(undefined).
+
+%% Module helpers
+-spec init_pool({pool_name(), proplists:proplist()} |
+                {pool_name(), PoolSize :: non_neg_integer(), proplists:proplist()}) ->
+                       ok | no_return().
+init_pool({PoolName, PoolConfig}) ->
+    init_pool({PoolName, 20, PoolConfig});
+init_pool({PoolName, PoolSize, PoolConfig}) ->
+    ExtConfig = extend_config(PoolConfig),
+    application:set_env(cqerl, num_clients, PoolSize),
+    ok = cqerl_cluster:add_nodes(PoolName, proplists:get_value(servers, ExtConfig), ExtConfig),
+    {ok, _} = mongoose_cassandra_sup:start(PoolName, PoolSize * 4),
+    ok.
+
+extend_config(PoolConfig) ->
+    PoolConfig
+        ++ [{servers, [{"localhost", 9042}]},
+            %%            {tcp_opts, [{connect_timeout, 4000}]},
+            {keyspace, mongooseim}].
+
+
+%% ====================================================================
+%% Cassandra API
+%% ====================================================================
 
 %% @doc Return timestamp in nanoseconds
 now_timestamp() ->
@@ -33,3 +104,219 @@ now_timestamp() ->
 -spec now_to_usec(erlang:timestamp()) -> non_neg_integer().
 now_to_usec({MSec, Sec, USec}) ->
     (MSec*1000000 + Sec)*1000000 + USec.
+
+
+%% --------------------------------------------------------
+%% @doc Execute batch write query to cassandra (insert, update or delete).
+%% Note that Cassandra doesn't like big batches, therefore this function will try to
+%% split given rows into batches of 50 rows and will fall back to smaller batches if
+%% Cassandra rejects the query due to its size being to big.
+%% --------------------------------------------------------
+-spec cql_write(PoolName :: pool_name(), UserJID :: jid(), Module :: atom(),
+                QueryName :: query_name(), Rows :: [proplists:proplist()]) ->
+                       ok | {error, Reason :: any()}.
+cql_write(PoolName, _UserJID, Module, QueryName, Rows)  ->
+    QueryStr = proplists:get_value(QueryName, Module:prepared_queries()),
+    Query = #cql_query{statement = QueryStr},
+
+    {ok, Client} = cqerl:get_client(PoolName),
+    cql_write_rows(Client, Query, Rows, 50, 3).
+
+%% --------------------------------------------------------
+%% @doc Execute async batch write query to cassandra (insert, update or delete).
+%% Note that Cassandra doesn't like big batches and there's not retry login when query size will
+%% be exceeded like in cql_write/5.
+%% --------------------------------------------------------
+-spec cql_write_async(PoolName :: pool_name(), UserJID :: jid(), Module :: atom(),
+                      QueryName :: query_name(), Rows :: [proplists:proplist()]) ->
+                             ok | {error, Reason :: any()}.
+cql_write_async(PoolName, UserJID, Module, QueryName, Rows)  ->
+    QueryStr = proplists:get_value(QueryName, Module:prepared_queries()),
+    Query = #cql_query{statement = QueryStr},
+
+    {ok, Client} = cqerl:get_client(PoolName),
+    BatchQuery =
+        #cql_query_batch{
+           mode = unlogged,
+           queries = [Query#cql_query{values = Row}
+                      || Row <- Rows]
+          },
+
+    QueryExecutor =
+        fun() ->
+                cqerl:send_query(Client, BatchQuery)
+        end,
+
+    Worker = mongoose_cassandra_sup:select_worker(PoolName, UserJID),
+    gen_server:cast(Worker, {cql_write, QueryExecutor}).
+
+
+%% --------------------------------------------------------
+%% @doc Execute read query to cassandra (select).
+%% Returns all rows at once even if there are several query pages.
+%% --------------------------------------------------------
+-spec cql_read(PoolName :: pool_name(), UserJID :: jid() | undefined, Module :: atom(),
+               QueryName :: query_name(), Params :: proplists:proplist()) ->
+                      {ok, Rows :: [proplists:proplist()]} | {error, Reason :: any()}.
+cql_read(PoolName, UserJID, Module, QueryName, Params)  ->
+    Fun = fun(Page, Acc) -> [Page | Acc] end,
+    case cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, []) of
+        {ok, Rows} ->
+            {ok, lists:append(lists:reverse(Rows))};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+
+%% --------------------------------------------------------
+%% @doc Execute read query to cassandra (select).
+%% This functions behaves much like the lists:foldl/3 but the input are pages from result of given
+%% query. Therefore each execution of given fun gets list of several result rows (by default 100 at
+%% most).
+%% --------------------------------------------------------
+-spec cql_foldl(PoolName :: pool_name(), UserJID :: jid() | undefined, Module :: atom(),
+                QueryName :: query_name(), Params :: proplists:proplist(),
+                row_fold_fun(), AccIn :: term()) ->
+                       {ok, AccOut :: term()} | {error, Reason :: any()}.
+cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn)  ->
+    cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn, 3).
+
+-spec cql_foldl(PoolName :: pool_name(), UserJID :: jid() | undefined, Module :: atom(),
+                QueryName :: query_name(), Params :: proplists:proplist(),
+                row_fold_fun(), AccIn :: term(), TryCount :: non_neg_integer()) ->
+                   {ok, AccOut :: term()} | {error, Reason :: any()}.
+cql_foldl(_PoolName, _UserJID, _Module, QueryName, Params, _Fun, _AccIn, 0)  ->
+    {error, {query_timeout, QueryName, Params}};
+cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn, TryCount)  ->
+    QueryStr = proplists:get_value(QueryName, Module:prepared_queries()),
+    Query = #cql_query{statement = QueryStr, values = Params},
+
+    {ok, Client} = cqerl:get_client(PoolName),
+    Tag = cqerl:send_query(Client, Query),
+    receive
+        {result, Tag, Result} ->
+            cql_read_pages(Result, Fun, AccIn, TryCount);
+        {error, Tag, {16#1200, _, _}} ->
+            cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn, TryCount - 1);
+        {error, Tag, Reason} ->
+            {error, Reason}
+    after ?READ_TIMEOUT ->
+            cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn, TryCount - 1)
+    end.
+
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+
+-spec cql_read_pages(ResultHandle :: term(), row_fold_fun(), AccIn :: term(),
+                     TryCount :: non_neg_integer()) ->
+                            {ok, AccOut :: term()} | {error, Reason :: any()}.
+cql_read_pages(Result, _Fun, _AccIn, 0) ->
+    {error, {query_page_timeout, Result}};
+cql_read_pages(Result, Fun, AccIn, Retry) ->
+    NextAcc = Fun(cqerl:all_rows(Result), AccIn),
+    case cqerl:has_more_pages(Result) of
+        true ->
+            Tag = cqerl:fetch_more_async(Result),
+            receive
+                {result, Tag, NextResult} ->
+                    cql_read_pages(NextResult, Fun, NextAcc, Retry);
+                {error, Tag, {16#1200, _, _}} ->
+                    timer:sleep(crypto:rand_uniform(50, 500)),
+                    cql_read_pages(Result, Fun, NextAcc, Retry - 1);
+                {error, Tag, Reason} ->
+                    {error, Reason}
+            after ?READ_TIMEOUT ->
+                    cql_read_pages(Result, Fun, NextAcc, Retry - 1)
+            end;
+        false ->
+            {ok, NextAcc}
+    end.
+
+-spec cql_write_rows(Client :: cqerl:client(), WriteQuery :: cql_query(), Rows :: [row()],
+                     BatchSize :: non_neg_integer(), TryCount :: non_neg_integer()) ->
+                            ok | {error, Reason :: term()}.
+cql_write_rows(_, _, [], _, _) ->
+    ok;
+
+cql_write_rows(_, WriteQuery, _, _, 0) ->
+    error({query_batch_timeout, WriteQuery});
+cql_write_rows(Client, WriteQuery, Rows, BatchSize, TryCount) ->
+    {NewRows, Tail} = lists:split(min(BatchSize, length(Rows)), Rows),
+    Tag = cqerl:send_query(Client, #cql_query_batch{
+                                      mode = unlogged,
+                                      queries = [WriteQuery#cql_query{values = NewRow}
+                                                 || NewRow <- NewRows]
+                                     }),
+    WriteTimeout = timer:minutes(1),
+    receive
+        {result, _, void} ->
+            cql_write_rows(Client, WriteQuery, Tail, BatchSize, TryCount);
+        {error, Tag, {16#2200, _, _}} ->
+            NewBatchSize = max(1, round(BatchSize * 0.75)),
+            cql_write_rows(Client, WriteQuery, Rows, NewBatchSize, TryCount);
+        {error, Tag, {16#1100, _, _}} ->
+            timer:sleep(crypto:rand_uniform(10, 50)),
+            cql_write_rows(Client, WriteQuery, Rows, BatchSize, TryCount - 1);
+        {error, Tag, Reason} ->
+            {error, Reason}
+    after WriteTimeout ->
+            cql_write_rows(Client, WriteQuery, Tail, BatchSize, 0)
+    end.
+
+%% ====================================================================
+%% Queries
+%% ====================================================================
+
+prepared_queries() ->
+    [{test_query, test_query_sql()}] ++
+        total_count_queries().
+
+test_query_sql() ->
+    "SELECT now() FROM system.local". %% "SELECT 1" for cassandra
+
+total_count_query_cql(T) when is_atom(T) ->
+    "SELECT COUNT(*) FROM " ++ atom_to_list(T).
+
+
+%% ====================================================================
+%% Diagnostic utilities
+%% ====================================================================
+
+-spec test_query(pool_name()) -> ok | {error, Reason :: term()}.
+test_query(PoolName) ->
+    test_query(PoolName, undefined).
+
+test_query(PoolName, UserJID) ->
+    try  mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, test_query, []) of
+         {ok, _} -> ok
+    catch
+        Class:Reason ->
+            {error, {Class, Reason}}
+    end.
+
+-spec total_count_query(pool_name(), Table :: atom()) ->
+    non_neg_integer().
+total_count_query(PoolName, Table) ->
+    UserJID = undefined,
+    Res = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, {total_count_query, Table}, []),
+    {ok, [Row]} = Res,
+    proplists:get_value(count, Row).
+
+total_count_queries() ->
+    [{{total_count_query, T}, total_count_query_cql(T)} || T <- tables()].
+
+
+tables() ->
+    [
+     mam_message,
+     mam_muc_message,
+     mam_config
+     %%     private_storage,
+     %%     privacy_default_list,
+     %%     privacy_list,
+     %%     privacy_item,
+     %%     rosterusers,
+     %%     roster_version
+    ].

--- a/apps/ejabberd/src/mongoose_cassandra_worker.erl
+++ b/apps/ejabberd/src/mongoose_cassandra_worker.erl
@@ -9,39 +9,16 @@
 %% ----------------------------------------------------------------------
 %% Exports
 
-%% API
--export([cql_query/5,
-         cql_query_pool/5,
-         cql_query_async/5,
-         cql_query_pool_async/5,
-         cql_query_multi_async/5,
-         cql_query_pool_multi_async/5,
-         cql_batch/4,
-         cql_batch_pool/4,
-         cql_batch/5,
-         cql_batch_pool/5]).
-
-%% Helpers for debugging
--export([test_query/1,
-         test_query/2,
-         queue_length/1,
-         queue_lengths/1,
-         total_count_query/2]).
 
 %% Internal exports
--export([start_link/4]).
-
-%% mongoose_cassandra_worker callbacks
--export([prepared_queries/0]).
+-export([start_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
+-export([queue_length/1]).
 
 -behaviour(gen_server).
--behaviour(mongoose_cassandra).
-
--callback prepared_queries() -> proplists:proplist().
 
 %% ----------------------------------------------------------------------
 %% Imports
@@ -52,140 +29,15 @@
 
 -record(state, {
           pool_name,
-          conn,
-          prepared_queries,
-          query_refs,
-          query_refs_count}).
-
--record(prepared_query, {
-          query_id,
-          query_types}).
+          query_refs = #{}
+         }).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
 
-start_link(PoolName, Addr, Port, ClientOptions) ->
-    gen_server:start_link(?MODULE, [PoolName, Addr, Port, ClientOptions], []).
-
-%% @doc Do CQL query
-%%
-%% UserJID is used for rate-limiting, statistics and debugging
-cql_query(Worker, _UserJID, Module, QueryName, Params) when is_pid(Worker) ->
-    ResultF = gen_server:call(Worker, {cql_query, Module, QueryName, Params}),
-    {ok, Result} = ResultF(),
-    case Result of
-        void ->
-            {ok, []};
-        _ ->
-            {ok, seestar_result:rows(Result)}
-    end.
-
-cql_query_async(Worker, _UserJID, Module, QueryName, Params) when is_pid(Worker) ->
-    gen_server:cast(Worker, {async_cql_query, Module, QueryName, Params}).
-
-cql_query_multi_async(Worker, _UserJID, Module, QueryName, MultiParams) when is_pid(Worker) ->
-    gen_server:cast(Worker, {multi_async_cql_query, Module, QueryName, MultiParams}).
-
-cql_batch(Worker, UserJID, Module, Queries, not_batch) ->
-    cql_query_multi(Worker, UserJID, Module, Queries);
-cql_batch(Worker, _UserJID, Module, Queries, BatchType) ->
-    ResultF = gen_server:call(Worker, {cql_batch, Module, BatchType, Queries}),
-    {ok, Result} = ResultF(),
-    case Result of
-        void ->
-            {ok, []};
-        _ ->
-            {ok, seestar_result:rows(Result)}
-    end.
-
-%% @doc Run queries, abort if an error. No rollback
-cql_query_multi(Worker, UserJID, Module, Queries) ->
-    cql_query_multi(Worker, UserJID, Module, Queries, []).
-
-cql_query_multi(Worker, UserJID, Module, [{QueryName, Params} | Queries], Results) ->
-    case catch cql_query(Worker, UserJID, Module, QueryName, Params) of
-        {ok, Result} ->
-            cql_query_multi(Worker, UserJID, Module, Queries, [Result | Results]);
-        Reason ->
-            {error, [{reason, Reason}, {results, Results}]}
-    end;
-cql_query_multi(_Worker, _UserJID, _Module, [], Results) ->
-    {ok, lists:reverse(Results)}.
-
-cql_batch_pool(PoolName, UserJID, Module, Queries, BatchType) ->
-    Worker = mongoose_cassandra_sup:select_worker(PoolName, UserJID),
-    cql_batch(Worker, UserJID, Module, Queries, BatchType).
-
-cql_batch(Worker, UserJID, Module, Queries) ->
-    cql_batch(Worker, UserJID, Module, Queries, unlogged).
-
-cql_batch_pool(PoolName, UserJID, Module, Queries) ->
-    cql_batch_pool(PoolName, UserJID, Module, Queries, unlogged).
-
-%% @doc Select worker and do cql query
-cql_query_pool(PoolName, UserJID, Module, QueryName, Params) ->
-    Worker = mongoose_cassandra_sup:select_worker(PoolName, UserJID),
-    cql_query(Worker, UserJID, Module, QueryName, Params).
-
-cql_query_pool_async(PoolName, UserJID, Module, QueryName, Params) ->
-    Worker = mongoose_cassandra_sup:select_worker(PoolName, UserJID),
-    cql_query_async(Worker, UserJID, Module, QueryName, Params).
-
-cql_query_pool_multi_async(PoolName, UserJID, Module, QueryName, MultiParams) ->
-    Worker = mongoose_cassandra_sup:select_worker(PoolName, UserJID),
-    cql_query_multi_async(Worker, UserJID, Module, QueryName, MultiParams).
-
-%% ----------------------------------------------------------------------
-%% mongoose_cassandra_worker behaviour callbacks
-
-prepared_queries() ->
-    [{test_query, test_query_sql()}] ++
-        total_count_queries().
-
-tables() ->
-    [mam_message,
-     mam_muc_message,
-     mam_config,
-     private_storage,
-     privacy_default_list,
-     privacy_list,
-     privacy_item,
-     rosterusers,
-     roster_version].
-
-%% ----------------------------------------------------------------------
-%% TEST CONNECTION
-
-test_query_sql() ->
-    "SELECT now() FROM system.local". %% "SELECT 1" for cassandra
-
-test_query(PoolName) ->
-    test_query(PoolName, undefined).
-
-test_query(PoolName, UserJID) ->
-    Workers = mongoose_cassandra_sup:get_all_workers(PoolName),
-    [{Worker, try cql_query(Worker, UserJID, ?MODULE, test_query, []) of
-                  {ok, [[_Now]]} -> ok;
-                  Other -> {error, Other}
-              catch Class:Reason -> {error, {Class, Reason}}
-              end} || Worker <- Workers].
-
-%% ----------------------------------------------------------------------
-%% COUNT OBJECTS
-%% Don't use these queries in production. Just for testing.
-
-total_count_query(PoolName, Table) ->
-    UserJID = undefined,
-    Res = cql_query_pool(PoolName, UserJID, ?MODULE, {total_count_query, Table}, []),
-    {ok, [[Count]]} = Res,
-    Count.
-
-total_count_queries() ->
-    [{{total_count_query, T}, total_count_query_cql(T)} || T <- tables()].
-
-total_count_query_cql(T) when is_atom(T) ->
-    "SELECT COUNT(*) FROM " ++ atom_to_list(T).
+start_link(PoolName) ->
+    gen_server:start_link(?MODULE, [PoolName], []).
 
 
 %% ----------------------------------------------------------------------
@@ -214,104 +66,6 @@ worker_queue_length(Worker) ->
     end.
 
 %%====================================================================
-%% Internal SQL part
-%%====================================================================
-
-get_prepared_query(Conn, Module, QueryName, State = #state{prepared_queries = PreparedQueries}) ->
-    Key = {Module, QueryName},
-    case dict:find(Key, PreparedQueries) of
-        {ok, Query} ->
-            {ok, Query, State};
-        error ->
-            get_prepared_query_first_time(Conn, Module, QueryName, State)
-    end.
-
-get_prepared_query_first_time(Conn, Module, QueryName,
-                              State = #state{prepared_queries = PreparedQueries}) ->
-    Key = {Module, QueryName},
-    case get_query_cql(Module, QueryName) of
-        {ok, Cql} ->
-            case prepare_query(Conn, Cql, Module, QueryName) of
-                {ok, PreparedQuery} ->
-                    PreparedQueries2 = dict:store(Key, PreparedQuery, PreparedQueries),
-                    State2 = State#state{prepared_queries = PreparedQueries2},
-                    {ok, PreparedQuery, State2};
-                {error, Reason} ->
-                    {error, Reason}
-            end;
-        {error, Reason} ->
-            {error, Reason}
-    end.
-
-get_query_cql(Module, QueryName) ->
-    try get_query_cql_unsafe(Module, QueryName)
-    catch Class:Error ->
-            Stacktrace = erlang:get_stacktrace(),
-            ?ERROR_MSG("issue=get_query_cql_failed, query_module=~p, query_name=~p,
-reason=~p:~p, stacktrace=~1000p",
-[Module, QueryName, Class, Error, Stacktrace]),
-            {error, get_query_cql_failed}
-    end.
-
-get_query_cql_unsafe(Module, QueryName) ->
-    List = Module:prepared_queries(),
-    {QueryName, Cql} = lists:keyfind(QueryName, 1, List),
-    {ok, Cql}.
-
-prepare_query(Conn, Query, Module, QueryName) ->
-    case seestar_session:prepare(Conn, Query) of
-        {ok, Res} ->
-            Types = seestar_result:types(Res),
-            QueryID = seestar_result:query_id(Res),
-            {ok, #prepared_query{query_id = QueryID, query_types = Types}};
-        {error, Reason} ->
-            ?ERROR_MSG("issue=preparing_query_failed, query_module=~p, query_name=~p, reason=~p",
-                       [Module, QueryName, Reason]),
-            {error, Reason}
-    end.
-
-execute_prepared_query(Conn, #prepared_query{query_id = QueryID, query_types = Types}, Params) ->
-    seestar_session:execute_async(Conn, QueryID, Types, Params, one).
-
-new_prepared_query(#prepared_query{query_id = QueryID, query_types = Types}, Params) ->
-    seestar_session:new_batch_execute(QueryID, Types, Params).
-
-new_batch_queries(Conn, Module, Queries, State) ->
-    new_batch_queries(Conn, Module, Queries, [], State).
-
-new_batch_queries(Conn, Module, [{QueryName, Params} | Queries], BatchQueries, State) ->
-    case get_prepared_query(Conn, Module, QueryName, State) of
-        {ok, PreparedQuery, State2} ->
-            BatchQuery = new_prepared_query(PreparedQuery, Params),
-            new_batch_queries(Conn, Module, Queries, [BatchQuery | BatchQueries], State2);
-        {error, Reason} ->
-            {error, Reason, State}
-    end;
-new_batch_queries(_Conn, _Module, [], BatchQueries, State) ->
-    {ok, lists:reverse(BatchQueries), State}.
-
-run_batch(Conn, BatchType, BatchQueries) ->
-    seestar_session:batch_async(Conn, BatchType, BatchQueries, one).
-
-save_query_ref(From, QueryRef, State = #state{query_refs = Refs, query_refs_count = RefsCount}) ->
-    Refs2 = dict:store(QueryRef, From, Refs),
-    put(query_refs_count, RefsCount + 1),
-    State#state{query_refs = Refs2, query_refs_count = RefsCount + 1}.
-
-forward_query_respond(ResultF, QueryRef,
-                      State = #state{query_refs = Refs, query_refs_count = RefsCount}) ->
-    case dict:find(QueryRef, Refs) of
-        {ok, From} ->
-            Refs2 = dict:erase(QueryRef, Refs),
-            gen_server:reply(From, ResultF),
-            put(query_refs_count, RefsCount - 1),
-            State#state{query_refs = Refs2, query_refs_count = RefsCount - 1};
-        error -> % lager:warning("Ignore response ~p ~p", [QueryRef, ResultF()]),
-            State
-    end.
-
-
-%%====================================================================
 %% gen_server callbacks
 %%====================================================================
 
@@ -322,20 +76,9 @@ forward_query_respond(ResultF, QueryRef,
 %%                         {stop, Reason}
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
-init([PoolName, Addr, Port, ClientOptions]) ->
-    async_spawn(Addr, Port, ClientOptions),
-    State = #state{pool_name = PoolName},
-    {ok, State}.
-
-init_connection(ConnPid, Conn, State = #state{pool_name = PoolName}) ->
-    erlang:monitor(process, ConnPid),
+init([PoolName]) ->
     mongoose_cassandra_sup:register_worker(PoolName, self()),
-    put(query_refs_count, 0),
-    State#state{
-      conn             = Conn,
-      query_refs       = dict:new(),
-      query_refs_count = 0,
-      prepared_queries = dict:new()}.
+    {ok, #state{pool_name = PoolName}}.
 
 %%--------------------------------------------------------------------
 %% Function: %% handle_call(Request, From, State) -> {reply, Reply, State} |
@@ -346,26 +89,6 @@ init_connection(ConnPid, Conn, State = #state{pool_name = PoolName}) ->
 %%                                      {stop, Reason, State}
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
-handle_call(_, _From, State = #state{conn = undefined}) ->
-    {reply, no_connection, State};
-handle_call({cql_query, Module, QueryName, Params}, From,
-            State = #state{conn = Conn}) ->
-    case get_prepared_query(Conn, Module, QueryName, State) of
-        {ok, PreparedQuery, State2} ->
-            QueryRef = execute_prepared_query(Conn, PreparedQuery, Params),
-            {noreply, save_query_ref(From, QueryRef, State2)};
-        {error, Reason} ->
-            {reply, {error, Reason}, State}
-    end;
-handle_call({cql_batch, Module, BatchType, Queries}, From,
-            State = #state{conn = Conn}) ->
-    case new_batch_queries(Conn, Module, Queries, State) of
-        {ok, BatchQueries, State2} ->
-            QueryRef = run_batch(Conn, BatchType, BatchQueries),
-            {noreply, save_query_ref(From, QueryRef, State2)};
-        {error, Reason, State2} ->
-            {reply, {error, Reason}, State2}
-    end;
 handle_call(_, _From, State = #state{}) ->
     {reply, ok, State}.
 
@@ -377,28 +100,12 @@ handle_call(_, _From, State = #state{}) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 
-handle_cast(_, State = #state{conn = undefined}) ->
-    {noreply, State};
-handle_cast({async_cql_query, Module, QueryName, Params},
-            State = #state{conn = Conn}) ->
-    case get_prepared_query(Conn, Module, QueryName, State) of
-        {ok, PreparedQuery, State2} ->
-            execute_prepared_query(Conn, PreparedQuery, Params),
-            {noreply, State2};
-        {error, _Reason} ->
-            {noreply, State}
-    end;
-handle_cast({multi_async_cql_query, Module, QueryName, MultiParams},
-            State = #state{conn = Conn}) ->
-    case get_prepared_query(Conn, Module, QueryName, State) of
-        {ok, PreparedQuery, State2} ->
-            [execute_prepared_query(Conn, PreparedQuery, Params) || Params <- MultiParams],
-            {noreply, State2};
-        {error, _Reason} ->
-            {noreply, State}
-    end;
+handle_cast({cql_write, QueryExecutor}, State = #state{query_refs = Refs}) ->
+    QueryRef = QueryExecutor(),
+    NewRefs = maps:put(QueryRef, QueryExecutor, Refs),
+    {noreply, State#state{query_refs = NewRefs}};
 handle_cast(Msg, State) ->
-    ?WARNING_MSG("Strange cast message ~p.", [Msg]),
+    ?WARNING_MSG("Unknown cast message ~p", [Msg]),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -409,21 +116,17 @@ handle_cast(Msg, State) ->
 %%--------------------------------------------------------------------
 
 
-handle_info({connection_result, {ok, ConnPid, Conn}}, State = #state{conn = undefined}) ->
-    State2 = init_connection(ConnPid, Conn, State),
-    {noreply, State2};
-handle_info({connection_result, Reason}, State = #state{conn = undefined}) ->
-    ?ERROR_MSG("issue=\"Fail to connect to Cassandra\", reason=~1000p", [Reason]),
-    {stop, {connection_result, Reason}, State};
-handle_info(_, State = #state{conn = undefined}) ->
-    {noreply, State};
-handle_info({seestar_response, QueryRef, ResultF}, State) ->
-    {noreply, forward_query_respond(ResultF, QueryRef, State)};
-handle_info({'DOWN', _, process, Pid, Reason}, State = #state{conn = Pid}) ->
-    ?ERROR_MSG("issue=\"Cassandra connection closed\", reason=~1000p", [Reason]),
-    {stop, {dead_connection, Pid, Reason}, State};
+handle_info({result, Tag, _}, State = #state{query_refs = Refs}) ->
+    {noreply, State#state{query_refs = maps:remove(Tag, Refs)}};
+handle_info({error, Tag, {16#1100, _, _}}, State = #state{query_refs = Refs}) ->
+    QueryExecutor = maps:get(Tag, Refs),
+    NewRefs1 = maps:remove(Tag, Refs),
+    NewRefs2 = maps:put(QueryExecutor(), QueryExecutor, NewRefs1),
+    {noreply, State#state{query_refs = NewRefs2}};
+handle_info({error, Tag, _}, State = #state{query_refs = Refs}) ->
+    {noreply, State#state{query_refs = maps:remove(Tag, Refs)}};
 handle_info(Msg, State) ->
-    ?WARNING_MSG("Strange info message ~p.", [Msg]),
+    ?WARNING_MSG("Unknown info message ~p.", [Msg]),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -442,35 +145,3 @@ terminate(_Reason, _State) ->
 %%--------------------------------------------------------------------
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-%% Helpers
-%%--------------------------------------------------------------------
-
-async_spawn(Addr, Port, ClientOptions) ->
-    ?INFO_MSG("issue=\"Connecting to Cassandra\", address=~p, port=~p", [Addr, Port]),
-    Parent = self(),
-    proc_lib:spawn_link(
-      fun() ->
-          ConnectOptions = proplists:get_value(socket_options, ClientOptions, []),
-          ?DEBUG("issue=\"seestar_session:start_link\", address=~p, port=~p, "
-                 "client_options=~p, connect_options=~p",
-                 [Addr, Port, ClientOptions, ConnectOptions]),
-          Res = (catch seestar_session:start_link(Addr, Port, ClientOptions, ConnectOptions)),
-          ?DEBUG("issue=\"seestar_session:start_link result\", result=~p",
-                 [Res]),
-          Parent ! {connection_result, Res},
-          maybe_waitfor(Res)
-      end).
-
--spec maybe_waitfor({ok, pid()} | term()) -> ok.
-maybe_waitfor(Res) ->
-    case Res of
-        {ok, Pid} ->
-            Mon = erlang:monitor(process, Pid),
-            receive
-                {'DOWN', Mon, process, Pid, _} -> ok
-            end;
-        _ ->
-            ok
-    end.
-

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
   {lasse, ".*", {git, "git://github.com/inaka/lasse.git", "692eaec"}},
 
   {riakc, ".*", {git, "https://github.com/basho/riak-erlang-client", "2.4.2"}},
-  {seestar, ".*", {git, "git://github.com/arcusfelis/seestar.git", "e9700e1e7e8226173ad76d22be9d3a4e0ef77310"}},
+  {cqerl, ".*", {git, "https://github.com/matehat/cqerl.git", "v1.0.4"}},
 
   {cache_tab, ".*", {git, "git://github.com/processone/cache_tab", {tag, "1.0.4"}}},
   {stringprep, ".*", {git, "git://github.com/processone/stringprep.git", {tag, "1.0.6"}}},

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -503,19 +503,19 @@
 %%{cassandra_servers, [{default, []}]}.
 
 %% ALTERNATIVE CONFIGURATION: Custom server address
-%% - Five connections to each of four Cassandra servers
+%% - 100 connections to all four Cassandra servers in total
 %% - Keyspace "big_mongooseim"
 %%
 %%{cassandra_servers,
 %% [
-%%  {default,
+%%  {default, 100,
 %%   [
 %%    {servers,
 %%     [
-%%      {"cassandra_server1.example.com", 9042, 5},
-%%      {"cassandra_server2.example.com", 9042, 5},
-%%      {"cassandra_server3.example.com", 9042, 5},
-%%      {"cassandra_server4.example.com", 9042, 5}
+%%      {"cassandra_server1.example.com", 9042},
+%%      {"cassandra_server2.example.com", 9042},
+%%      {"cassandra_server3.example.com", 9042},
+%%      {"cassandra_server4.example.com", 9042}
 %%     ]
 %%    },
 %%    {keyspace, "big_mongooseim"}

--- a/tools/configure
+++ b/tools/configure
@@ -40,11 +40,12 @@ app_opts() ->
      {"all",       [],                  "include all drivers"},
      {"mysql",     ["p1_mysql"],        include_driver("mysql")},
      {"odbc",      ["odbc"],            "include standard ODBC driver shipped with Erlang/OTP"},
-     {"pgsql",     ["p1_pgsql"],           include_driver("pgsql")},
+     {"pgsql",     ["p1_pgsql"],        include_driver("pgsql")},
      {"redis",     ["redo"],            include_driver("redis")},
      {"riak",      ["riakc", "riak_pb", "protobuffs"],
                                         include_driver("riak")},
-     {"cassandra", ["seestar"],         include_driver("cassandra")}].
+     {"cassandra", ["cqerl", "pooler", "re2", "semver", "snappy", "lz4", "uuid"],
+                                        include_driver("cassandra")}].
 
 opts() ->
     [{"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},


### PR DESCRIPTION
This PR changes Cassandra backend to use cqerl client library instead seestar. 
