### PR TITLE
Muc light loop fix

### DIFF
--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -229,6 +229,8 @@ process_packet(From, #jid{ luser = RoomU } = To, {ok, RequestToRoom}, OrigPacket
 process_packet(From, To, {error, _} = Err, OrigPacket) ->
     mod_muc_light_codec_backend:encode_error(
       Err, From, To, OrigPacket, fun ejabberd_router:route/3);
+process_packet(_From, _To, ignore, _OrigPacket) ->
+     ok;
 process_packet(From, To, _InvalidReq, OrigPacket) ->
     mod_muc_light_codec_backend:encode_error(
       {error, bad_request}, From, To, OrigPacket, fun ejabberd_router:route/3).

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -730,8 +730,11 @@ adding_wrongly_named_user_triggers_infinite_loop(Config)->
             Username = <<"buggyuser">>,
             escalus:send(Alice, generate_buggy_aff_staza(BuggyRoomName, Username)),
             timer:sleep(300),
-            [SessionRecPid] = rpc(ets, tab2list, [session]),
-            {session, {_, Pid}, _, _, _, _} = SessionRecPid,
+            AUsername = lbin(escalus_users:get_username(Config, alice)),
+            Host = lbin(escalus_users:get_host(Config, alice)),
+            Resource = <<"res1">>,
+            SessionRecPid = rpc(ejabberd_sm, get_session, [AUsername, Host, Resource]),
+            {{AUsername, Host, Resource}, {_, Pid}, _, _} = SessionRecPid,
             %% maybe throws exception
             assert_process_memory_not_growing(Pid, 0, 2),
             escalus:wait_for_stanzas(Alice, 2)

--- a/test/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -51,7 +51,8 @@
          remove_and_add_users/1,
          explicit_owner_change/1,
          implicit_owner_change/1,
-         edge_case_owner_change/1
+         edge_case_owner_change/1,
+         adding_wrongly_named_user_triggers_infinite_loop/1
         ]).
 -export([ % limits
          rooms_per_user/1,
@@ -170,7 +171,8 @@ groups() ->
                           remove_and_add_users,
                           explicit_owner_change,
                           implicit_owner_change,
-                          edge_case_owner_change
+                          edge_case_owner_change,
+                          adding_wrongly_named_user_triggers_infinite_loop
                          ]},
      {limits, [sequence], [
                            rooms_per_user,
@@ -722,6 +724,19 @@ edge_case_owner_change(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice))
         end).
 
+adding_wrongly_named_user_triggers_infinite_loop(Config)->
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
+            BuggyRoomName = <<"buggyroom">>,
+            Username = <<"buggyuser">>,
+            escalus:send(Alice, generate_buggy_aff_staza(BuggyRoomName, Username)),
+            timer:sleep(300),
+            [SessionRecPid] = rpc(ets, tab2list, [session]),
+            {session, {_, Pid}, _, _, _, _} = SessionRecPid,
+            %% maybe throws exception
+            assert_process_memory_not_growing(Pid, 0, 2),
+            escalus:wait_for_stanzas(Alice, 2)
+    end).
+
 %% ---------------------- limits ----------------------
 
 rooms_per_user(Config) ->
@@ -875,6 +890,12 @@ get_disco_rooms(User) ->
     true = lists:member(?NS_DISCO_ITEMS, XNamespaces),
     escalus:assert(is_stanza_from, [?MUCHOST], Stanza),
     exml_query:paths(Stanza, [{element, <<"query">>}, {element, <<"item">>}]).
+
+-spec generate_buggy_aff_staza(RoomName :: binary(), Username :: binary()) -> xmlel().
+generate_buggy_aff_staza(RoomName, Username) ->
+    BuggyJid = <<Username/binary, "@muclight.localhost">>,
+    BuggyUser = #client{jid = BuggyJid},
+    stanza_create_room(RoomName, [], [{BuggyUser, member}]).
 
 %%--------------------------------------------------------------------
 %% IQ getters
@@ -1153,6 +1174,22 @@ to_lus(UserAtom, Config) ->
 
 -spec lbin(Bin :: binary()) -> binary().
 lbin(Bin) -> list_to_binary(string:to_lower(binary_to_list(Bin))).
+
+-spec assert_process_memory_not_growing(pid(), integer(), integer()) -> any().
+assert_process_memory_not_growing(_, _, Counter) when Counter > 4 ->
+    throw({memory_consumption_is_growing});
+assert_process_memory_not_growing(_, _, Counter) when Counter == 0 ->
+    ok;
+assert_process_memory_not_growing(Pid, OldMemory, Counter) ->
+    {memory, Memory} = rpc(erlang, process_info, [Pid, memory]),
+    timer:sleep(1000),
+    NewCounter = case Memory =< OldMemory of
+                   true ->
+                     Counter - 1;
+                   _ ->
+                     Counter + 1
+                 end,
+  assert_process_memory_not_growing(Pid, Memory, NewCounter).
 
 -spec default_config() -> list().
 default_config() -> rpc(mod_muc_light, default_config, [?MUCHOST]).


### PR DESCRIPTION
This PR fixes infinite route loop triggered by muc_light.
Essentially, when someone tried to invite a user who contained domain reserved for the muclight service in his JID (by default its "muclight.HOST"), there was triggered infinite loop of function `ejabberd_router:route/3`. This was happening because muc_light processing didn't ignore error message

Proposed changes include:
* test that checks if memory of c2s process is not growing when the loop is triggered by special affiliation change stanza
* fix for the issue in the `mod_muc_light`

