### PR TITLE
Hooks streamlined

### DIFF
--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -52,8 +52,18 @@
 -define(ERROR_MSG(Format, Args),
     lager:error(Format, Args)).
 
+-define(DEPRECATED,
+    ok).
+%%    lager:error("Deprecated call", [])).
+
 -define(CRITICAL_MSG(Format, Args),
     lager:critical(Format, Args)).
+
+-define(INITIALISE(Map),
+    mongoose_stanza:initialise(Map, ?FILE, ?LINE)).
+
+-define(TERMINATE(Stanza),
+    mongoose_stanza:terminate(Stanza, ?FILE, ?LINE)).
 
 -record(session, {sid,
                   usr,

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -47,19 +47,26 @@ stop(Host) ->
 
 -spec check_packet(xmlel(), amp_event()) -> xmlel() | drop.
 check_packet(Packet = #xmlel{attrs = Attrs}, Event) ->
+    ?DEPRECATED,
     case xml:get_attr(<<"from">>, Attrs) of
         {value, From} ->
             check_packet(Packet, jid:from_binary(From), Event);
         _ ->
             Packet
-    end.
+    end;
+check_packet(Stanza, Event) ->
+    Host = mongoose_stanza:get(lserver, Stanza),
+    From = mongoose_stanza:get(from_jid, Stanza),
+    ejabberd_hooks:run_fold(amp_check_packet, Host, Stanza, [From, Event]).
 
 -spec check_packet(xmlel(), jid(), amp_event()) -> xmlel() | drop.
 check_packet(Packet = #xmlel{name = <<"message">>}, #jid{lserver = Host} = From, Event) ->
+    ?DEPRECATED,
     Stanza = mongoose_stanza:from_element(Packet),
     NStanza = ejabberd_hooks:run_fold(amp_check_packet, Host, Stanza, [From, Event]),
     mongoose_stanza:get(element, NStanza);
 check_packet(Packet, _, _) ->
+    ?DEPRECATED,
     Packet.
 
 add_local_features(Acc, _From, _To, ?NS_AMP, _Lang) ->
@@ -74,7 +81,7 @@ add_stream_feature(Feat, _Host) ->
 amp_check_packet(Acc, From, Event) ->
     Packet = mongoose_stanza:get(element, Acc),
     case do_amp_check_packet(Packet, From, Event) of
-        drop -> mongoose_stanza:put(element, drop, Acc);
+        drop -> mongoose_stanza:put(amp_check, drop, Acc);
         NPacket -> mongoose_stanza:put(element, NPacket, Acc)
     end.
 
@@ -85,7 +92,8 @@ do_amp_check_packet(#xmlel{name = <<"message">>} = Packet, From, Event) ->
         {rules, Rules}          -> process_amp_rules(Packet, From, Event, Rules);
         {errors, Errors}        -> send_errors_and_drop(Packet, From, Errors)
     end;
-do_amp_check_packet(Packet, _From, _Event) -> Packet.
+do_amp_check_packet(Packet, _From, _Event) ->
+    Packet.
 
 strip_amp_el_from_request(Packet) ->
     case amp:is_amp_request(Packet) of

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -294,8 +294,8 @@ user_send_packet(Acc, From, To, Packet) ->
 -spec filter_packet(mongoose_stanza:t()) -> mongoose_stanza:t().
 filter_packet(Acc) ->
     Packet = mongoose_stanza:get(element, Acc),
-    From = mongoose_stanza:get(from, Acc),
-    To = mongoose_stanza:get(to, Acc),
+    From = mongoose_stanza:get(from_jid, Acc),
+    To = mongoose_stanza:get(to_jid, Acc),
     #jid{luser=LUser, lserver=LServer} = To,
     ?DEBUG("Receive packet~n    from ~p ~n    to ~p~n    packet ~p.",
            [From, To, Packet]),
@@ -315,8 +315,8 @@ filter_packet(Acc) ->
                         {archived, replace_archived_elem(BareTo, MessID, Packet)}
                 end
         end,
-    PacketAfterAmp = mod_amp:check_packet(PacketAfterArchive, From, AmpEvent),
-    mongoose_stanza:put(element, PacketAfterAmp, Acc).
+    StanzaAfterArchive = mongoose_stanza:put(element, PacketAfterArchive, Acc),
+    mod_amp:check_packet(StanzaAfterArchive, AmpEvent). % we return stanza with packet after amp
 
 process_incoming_packet(From, To, Packet) ->
     handle_package(incoming, true, To, From, From, Packet).

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -163,11 +163,8 @@ stop(Host) ->
 %% Server side functions
 %% ------------------------------------------------------------------
 
-amp_failed_event(#xmlel{} = Packet, From) ->
-    amp_failed_event(mongoose_stanza:from_element(Packet), From);
-amp_failed_event(Acc, From) ->
-    mod_amp:check_packet(mongoose_stanza:get(element, Acc), From, offline_failed),
-    Acc.
+amp_failed_event(Packet, From) ->
+    mod_amp:check_packet(Packet, From, offline_failed).
 
 handle_offline_msg(#offline_msg{us=US} = Msg, AccessMaxOfflineMsgs) ->
     {LUser, LServer} = US,

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -515,7 +515,10 @@ get_subscription_lists(Acc, User, Server) ->
     LServer = jid:nameprep(Server),
     Items = ?BACKEND:get_subscription_lists(Acc, LUser, LServer),
     JID = jid:make(User, Server, <<>>),
-    fill_subscription_lists(JID, LServer, Items, [], [], []).
+    {F, T, P} = fill_subscription_lists(JID, LServer, Items, [], [], []),
+    A1 = mongoose_stanza:append(from, F, Acc),
+    A2 = mongoose_stanza:append(to, T, A1),
+    mongoose_stanza:append(pending, P, A2).
 
 
 fill_subscription_lists(JID, LServer, [#roster{} = I | Is], F, T, P) ->

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -151,7 +151,10 @@ process_item(RosterItem, _Host) ->
         _ -> RosterItem#roster{subscription = both, ask = none}
     end.
 
-get_subscription_lists({F, T, P}, User, Server) ->
+get_subscription_lists(Acc, User, Server) ->
+    F = mongoose_stanza:get(from, Acc, []),
+    T = mongoose_stanza:get(to, Acc, []),
+    P = mongoose_stanza:get(pending, Acc, []),
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
     US = {LUser, LServer},
@@ -161,7 +164,8 @@ get_subscription_lists({F, T, P}, User, Server) ->
                                         end,
                                         DisplayedGroups)),
     SRJIDs = [{U1, S1, <<"">>} || {U1, S1} <- SRUsers],
-    {lists:usort(SRJIDs ++ F), lists:usort(SRJIDs ++ T), P}.
+    {F1, T1, P1} = {lists:usort(SRJIDs ++ F), lists:usort(SRJIDs ++ T), P},
+    mongoose_stanza:update(Acc, #{from=>F1, to=>T1, pending=>P1}).
 
 get_jid_info({Subscription, Groups}, User, Server, JID) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mongoose_local_delivery.erl
+++ b/apps/ejabberd/src/mongoose_local_delivery.erl
@@ -15,9 +15,10 @@
 
 do_route(From, To, OrigPacket, LDstDomain, Handler) ->
     Acc = mongoose_stanza:from_element(OrigPacket),
-    Acc1 = mongoose_stanza:put(from, From, Acc),
-    Acc2 = mongoose_stanza:put(to, To, Acc1),
-    Acc3 = mongoose_stanza:put(routing_decision, send, Acc2),
+    Acc1 = mongoose_stanza:put(from_jid, From, Acc),
+    Acc2 = mongoose_stanza:put(to_jid, To, Acc1),
+    #jid{lserver=LServer} = To,
+    Acc3 = mongoose_stanza:put(routing_decision, send, mongoose_stanza:put(lserver, LServer, Acc2)),
     %% Filter locally
     Acc4 = ejabberd_hooks:run_fold(filter_local_packet, LDstDomain, Acc3, []),
     case mongoose_stanza:get(routing_decision, Acc4) of

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -285,8 +285,15 @@ user_ping_timeout(Acc, _JID) ->
                           Server :: ejabberd:server(),
                           term(), term(), term()) -> allow | deny | block | mongoose_stanza:t().
 privacy_check_packet(Acc, _, Server, _, _, _) ->
+    Res = case mongoose_stanza:is_stanza(Acc) of
+        true ->
+            mongoose_stanza:get(privacy_check, Acc, allow);
+        false ->
+            ?DEPRECATED,
+            Acc
+    end,
     mongoose_metrics:update(Server, modPrivacyStanzaAll, 1),
-    case Acc of
+    case Res of
         deny ->
             mongoose_metrics:update(Server, modPrivacyStanzaDenied, 1);
         block ->

--- a/apps/ejabberd/src/mongoose_privacy.erl
+++ b/apps/ejabberd/src/mongoose_privacy.erl
@@ -1,0 +1,56 @@
+%%%-------------------------------------------------------------------
+%%% @author bartek
+%%% @copyright (C) 2017, <COMPANY>
+%%% @doc
+%%%
+%%% Shared library of privacy-related functions
+%%%
+%%% @end
+%%% Created : 05. Jan 2017 12:01
+%%%-------------------------------------------------------------------
+-module(mongoose_privacy).
+-author("bartek").
+
+-include_lib("ejabberd/include/jlib.hrl").
+
+%% API
+-export([privacy_check_packet/6, check_result/2]).
+
+%% @doc A shared function to check privacy on a packet; check results are attached to the
+%% stanza as `privacy_check` field, but they are also cached per recipient (a stanza can be)
+%% checked multiple times against many recipients, if it is a broadcast)
+-spec privacy_check_packet(
+    User :: binary(),
+    Server :: binary(),
+    PrivList :: list(any()),
+    Stanza :: map(),
+    To :: ejabberd:jid(),
+    Dir :: 'in' | 'out') -> map().
+privacy_check_packet(User, Server, PrivList, Stanza, To, Dir) ->
+    From = mongoose_stanza:get(from_jid, Stanza),
+    Stanza1 = case check_result(To, Stanza) of
+        undefined ->
+            Packet = mongoose_stanza:get(element, Stanza),
+            S1 = ejabberd_hooks:run_fold(
+                                    privacy_check_packet, Server,
+                                    Stanza,
+                                    [User,
+                                     Server,
+                                     PrivList,
+                                     {From, To, Packet},
+                                     Dir]),
+            Res = mongoose_stanza:get(privacy_check, S1, allow),
+            Key = {To#jid.user, To#jid.server},
+            mongoose_stanza:append(privacy_check_cache, {Key, Res}, S1);
+        {ok, Res} ->
+            mongoose_stanza:put(privacy_check, Res, Stanza)
+    end,
+    {ok, Stanza1, Res}.
+
+check_result(To, Stanza) ->
+    Key = {To#jid.user, To#jid.server},
+    PCheck = mongoose_stanza:get(privacy_check_cache, Stanza, []),
+    case proplists:lookup(Key, PCheck) of
+        none -> undefined;
+        {Key, Res} -> {ok, Res}
+    end.

--- a/apps/ejabberd/src/mongoose_stanza.erl
+++ b/apps/ejabberd/src/mongoose_stanza.erl
@@ -8,27 +8,58 @@
 -module(mongoose_stanza).
 -author("bartek").
 
+-include("ejabberd.hrl").
 -include("jlib.hrl").
 
 %% API
--export([new/0, from_kv/2, put/3, get/2, get/3, append/3, to_map/1]).
--export([from_element/1]).
+-export([new/0, from_kv/2, put/3, get/2, get/3, append/3, to_map/1, update/2]).
+-export([from_element/1, from_map/1, is_stanza/1]).
+-export([initialise/3, terminate/3, dump/1]).
 -export_type([t/0]).
 
 %% if it is defined as -opaque then dialyzer fails
 -type t() :: map().
 
+%% development only
+initialise(Map, F, L) ->
+%%    ?ERROR_MSG("AAA Initialize stanza ~p ~p", [F, L]),
+    % we call it at the entry
+    maps:put(mongoose_stanza, true, Map).
+terminate(Stanza, F, L) ->
+%%    ?ERROR_MSG("AAA Terminate stanza ~p ~p", [F, L]),
+    % here we stop using stanza and revert to original xmlel
+    maps:get(element, Stanza).
+dump(Stanza) ->
+    Keys = lists:sort(maps:keys(Stanza)),
+    ?ERROR_MSG("------", []),
+    lists:map(fun(K) -> ?ERROR_MSG("~p = ~p", [K, maps:get(K, Stanza)]) end, Keys).
+
+-spec is_stanza(any()) -> boolean().
+is_stanza(M) when not is_map(M) ->
+    false;
+is_stanza(M) ->
+    maps:get(mongoose_stanza, M, false).
+
 -spec new() -> t().
 new() ->
-    #{}.
+    #{mongoose_stanza=>true}.
+
+-spec update(t(), t()) -> t().
+update(Stanza, M) ->
+    maps:merge(Stanza, M).
+
+-spec from_map(map()) -> t().
+from_map(M) ->
+    maps:put(mongoose_stanza, true, M).
 
 -spec from_kv(atom(), any()) -> t().
 from_kv(K, V) ->
-    maps:put(K, V, #{}).
+    M = maps:put(K, V, #{}),
+    maps:put(mongoose_stanza, true, M).
 
 -spec from_element(xmlel()) -> t().
 from_element(El) ->
-    #{element => El}.
+    #{element => El, mongoose_stanza=>true}.
 
 %% @doc convert to map so that we can pattern-match on it
 -spec to_map(t()) -> map()|{error, cant_convert_to_map}.
@@ -41,6 +72,7 @@ to_map(_) ->
 put(Key, Val, P) ->
     maps:put(Key, Val, P).
 
+%% @doc a version of get specyfying multiple keys, we check all of them until we find something
 -spec get(atom()|[atom()], t()) -> any().
 get([], _) ->
     undefined;

--- a/apps/ejabberd/test/privacy_SUITE.erl
+++ b/apps/ejabberd/test/privacy_SUITE.erl
@@ -1,0 +1,99 @@
+%% @doc This suite tests both old ejabberd_commands module, which is slowly getting deprecated,
+%% and the new mongoose_commands implementation.
+-module(privacy_SUITE).
+-compile([export_all]).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("ejabberd/include/ejabberd_commands.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
+
+-define(PRT(X, Y), ct:pal("~p: ~p", [X, Y])).
+
+dump(Stanza) ->
+    Keys = lists:sort(maps:keys(Stanza)),
+    ct:pal("------", []),
+    lists:map(fun(K) -> ct:pal("~p = ~p", [K, maps:get(K, Stanza)]) end, Keys).
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%% suite configuration
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+all() ->
+    [
+     {group, privacy_check}
+    ].
+
+groups() ->
+    [
+     {privacy_check, [sequence],
+      [check_repeatable ]
+     }
+    ].
+
+
+init_per_suite(C) ->
+    catch application:ensure_all_started(stringprep),
+    mnesia:create_schema([node()]),
+    mnesia:start(),
+    C.
+
+init_per_testcase(T, Config) ->
+    application:ensure_all_started(exometer),
+    {ok, _HooksServer} = ejabberd_hooks:start_link(),
+    ets:new(local_config, [named_table]),
+    ejabberd_hooks:add(privacy_check_packet, <<"localhost">>,
+        ?MODULE, check_packet, 50),
+    Config.
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%% test methods
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+check_repeatable(_C) ->
+    To1 = {jid,<<"bob">>,<<"localhost">>,<<>>,<<"bob">>,<<"localhost">>,<<>>},
+    To2 = {jid,<<"geralt">>,<<"localhost">>,<<>>,<<"geralt">>,<<"localhost">>,<<>>},
+    From = {jid,<<"alice">>,<<"localhost">>,<<>>,<<"alice">>,<<"localhost">>,<<>>},
+    Res = check(From, To1),
+    ?assertEqual(allow, mongoose_stanza:get(privacy_check, Res)),
+    Res_o = check(From, To2),
+    ?assertEqual(deny, mongoose_stanza:get(privacy_check, Res_o)),
+    Res_o2 = check(Res, From, To2),
+    ?assertEqual(deny, mongoose_stanza:get(privacy_check, Res_o2)),
+    Res_o3 = check(Res_o2, From, To2),
+    ?assertEqual(deny, mongoose_stanza:get(privacy_check, Res_o3)),
+    Res_o4 = check(Res_o3, From, To1),
+    ?assertEqual(allow, mongoose_stanza:get(privacy_check, Res_o4)),
+    ok.
+
+check(From, To) ->
+    Packet = {xmlel,<<"presence">>,[{<<"type">>,<<"unsubscribed">>}],[]},
+    Stanza = mongoose_stanza:from_map(#{element=>Packet, from_jid=>From, to_jid=>To,
+        type=><<"presence">>}),
+    check(Stanza, From, To).
+
+check(Stanza, _From, To) ->
+    List = [{listitem,jid,{<<"geralt">>,<<"localhost">>,<<>>},deny,1,true,false,false,false,false}],
+    NeedDb = false,
+    User = <<"alice">>,
+    Server = <<"localhost">>,
+    PList = {List, NeedDb},
+    mongoose_privacy:privacy_check_packet(
+        User,
+        Server,
+        PList,
+        Stanza,
+        To,
+        out
+    ).
+
+check_packet(Acc, _, _, _, {_From, To, _}, _) ->
+    Res = check_packet(To#jid.luser),
+    mongoose_stanza:put(privacy_check, Res, Acc).
+
+check_packet(<<"bob">>) ->
+    allow;
+check_packet(<<"geralt">>) ->
+    deny.


### PR DESCRIPTION
This PR is meant to contain a rewrite of the whole processing chain, so that a stanza entering the system is stored in an accumulator which is then passed to subseqent stages, processed and return by hooks and handlers, routed, shipped between c2s and sm, and used to store all useful information (e.g. results of a privacy check). When we are ready to ship something out, this 'something' is also store in the accumulator, and then the very last thing is to read it from there and send over the wire.