### PR TITLE
Fix Elvis's complains re missing space after colon

### DIFF
--- a/apps/ejabberd/src/acl.erl
+++ b/apps/ejabberd/src/acl.erl
@@ -198,7 +198,7 @@ match(all, _LJID, _Host) ->
     true;
 match({user, U}, {User, Server, _Resource}, Host) ->
     U == User andalso is_server_valid(Host, Server);
-match({user, U, S}, {User, Server ,_Resource}, _Host) ->
+match({user, U, S}, {User, Server, _Resource}, _Host) ->
     U == User andalso S == Server;
 match({server, S}, {_User, Server, _Resource}, _Host) ->
     S == Server;

--- a/apps/ejabberd/src/amp.erl
+++ b/apps/ejabberd/src/amp.erl
@@ -24,22 +24,22 @@
 
 
 -spec binaries_to_rule(binary(), binary(), binary()) -> amp_rule() | amp_invalid_rule().
-binaries_to_rule(<<"deliver">> = Condition, Value,Action) ->
-    case are_valid_deliver_params(Value,Action) of
+binaries_to_rule(<<"deliver">> = Condition, Value, Action) ->
+    case are_valid_deliver_params(Value, Action) of
         true -> mk_amp_rule('deliver', from_bin_(Value), from_bin_(Action));
         false -> mk_amp_invalid_rule(Condition, Value, Action)
     end;
-binaries_to_rule(<<"match-resource">> = Condition, Value,Action) ->
-    case are_valid_match_resource_params(Value,Action) of
+binaries_to_rule(<<"match-resource">> = Condition, Value, Action) ->
+    case are_valid_match_resource_params(Value, Action) of
         true -> mk_amp_rule('match-resource', from_bin_(Value), from_bin_(Action));
         false -> mk_amp_invalid_rule(Condition, Value, Action)
     end;
-binaries_to_rule(<<"expire-at">> = Condition, Value,Action) ->
-    case are_valid_expire_at_params(Value,Action) of
+binaries_to_rule(<<"expire-at">> = Condition, Value, Action) ->
+    case are_valid_expire_at_params(Value, Action) of
         true -> mk_amp_rule('expire-at', Value, from_bin_(Action)); %% Value is binary here!
         false -> mk_amp_invalid_rule(Condition, Value, Action)
     end;
-binaries_to_rule(Condition,Value,Action) ->
+binaries_to_rule(Condition, Value, Action) ->
     mk_amp_invalid_rule(Condition, Value, Action).
 
 
@@ -82,9 +82,9 @@ make_error_response([E|_] = Errors, [_|_] = Rules, User, Packet) ->
            attrs = [{<<"id">>, OriginalId},
                     {<<"type">>, <<"error">>}],
            children = [Error, Amp]};
-make_error_response(Errors,Rules,User,Packet) ->
+make_error_response(Errors, Rules, User, Packet) ->
     ?ERROR_MSG("amp:make_error_response/4 got invalid data: ~p",
-               [Errors,Rules,User,Packet]),
+               [Errors, Rules, User, Packet]),
     error(invalid_data).
 
 error_amp_attrs('undefined-condition', User, Packet) ->
@@ -93,12 +93,12 @@ error_amp_attrs('undefined-condition', User, Packet) ->
     [{<<"status">>, <<"error">>},
      {<<"to">>, OriginalRecipient},
      {<<"from">>, OriginalSender}];
-error_amp_attrs(_,_,_) -> [].
+error_amp_attrs(_, _, _) -> [].
 
 
 %% The lists are guaranteed to be non-empty and of equal
 %% length by make_error_message/4
--spec make_error_el([amp_error()],[amp_any_rule()]) -> #xmlel{}.
+-spec make_error_el([amp_error()], [amp_any_rule()]) -> #xmlel{}.
 make_error_el(Errors, Rules) ->
     ErrorMarker = #xmlel{name = error_marker_name(hd(Errors)),
                          attrs = [{<<"xmlns">>, ?NS_STANZAS}]},
@@ -119,7 +119,7 @@ rule_to_xmlel(#amp_rule{condition=C, value=V, action=A}) ->
 rule_to_xmlel(#amp_invalid_rule{condition=C, value=V, action=A}) ->
     #xmlel{name = <<"rule">>,
            attrs = [{<<"condition">>, C},
-                    {<<"value">>,V},
+                    {<<"value">>, V},
                     {<<"action">>, A}]}.
 
 -spec strip_amp_el(#xmlel{}) -> #xmlel{}.
@@ -161,8 +161,8 @@ parse_rules(Stanza) ->
 
 -spec parse_rule(#xmlel{}) -> amp_rule() | amp_invalid_rule().
 parse_rule(#xmlel{attrs = Attrs}) ->
-    GetF = fun(Value) -> proplists:get_value(Value,Attrs, <<"attribute-missing">>) end,
-    {C,V,A} = {GetF(<<"condition">>),
+    GetF = fun(Value) -> proplists:get_value(Value, Attrs, <<"attribute-missing">>) end,
+    {C, V, A} = {GetF(<<"condition">>),
                GetF(<<"value">>),
                GetF(<<"action">>)},
     binaries_to_rule(C, V, A).
@@ -186,9 +186,9 @@ are_valid_expire_at_params(_Value, Action) ->
     %% We may check the value with a regexp for a proper date in the future.
     is_valid_action(Action).
 
-mk_amp_rule(C,V,A) ->
+mk_amp_rule(C, V, A) ->
     #amp_rule{condition = C, value = V, action = A}.
-mk_amp_invalid_rule(C,V,A) ->
+mk_amp_invalid_rule(C, V, A) ->
     #amp_invalid_rule{condition = C, value = V, action = A}.
 
 error_code('not-acceptable')      -> <<"405">>;

--- a/apps/ejabberd/src/amp_strategy.erl
+++ b/apps/ejabberd/src/amp_strategy.erl
@@ -34,7 +34,7 @@ null_strategy() ->
 
 %% Internals
 get_target_resources(MessageTarget) ->
-    {User,Server,Resource} = jid:to_lower(MessageTarget),
+    {User, Server, Resource} = jid:to_lower(MessageTarget),
     ResourceSession = ejabberd_sm:get_session(User, Server, Resource),
     UserResources = ejabberd_sm:get_user_resources(User, Server),
     {ResourceSession, UserResources}.

--- a/apps/ejabberd/src/cyrsasl.erl
+++ b/apps/ejabberd/src/cyrsasl.erl
@@ -119,7 +119,7 @@ listmech(Host) ->
                                  [{'==', '$2', plain}];
                              scram ->
                                  [{'/=', '$2', digest}];
-                             {'EXIT',{undef,[{Module,store_type,[]} | _]}} ->
+                             {'EXIT', {undef, [{Module, store_type, []} | _]}} ->
                                  ?WARNING_MSG("~p doesn't implement the function store_type/0", [Module]),
                                  [];
                              _Else ->
@@ -144,8 +144,8 @@ server_new(Service, ServerFQDN, UserRealm, _SecFlags, Creds) ->
                  ClientIn :: binary()) -> {ok, _}
                                         | {ok, term(), term()}
                                         | {error, binary()}
-                                        | {'continue',_,sasl_state()}
-                                        | {'error',binary(),ejabberd:user()}.
+                                        | {'continue', _, sasl_state()}
+                                        | {'error', binary(), ejabberd:user()}.
 server_start(State, Mech, ClientIn) ->
     case lists:member(Mech, listmech(State#sasl_state.myname)) of
         true ->

--- a/apps/ejabberd/src/cyrsasl_digest.erl
+++ b/apps/ejabberd/src/cyrsasl_digest.erl
@@ -65,7 +65,7 @@ mech_new(Host, Creds) ->
 mech_step(#state{step = 1, nonce = Nonce} = State, _) ->
     {continue,
      list_to_binary("nonce=\"" ++ Nonce ++
-     "\", qop=\"auth\", charset=utf-8, algorithm=md5-sess"),
+     "\",qop=\"auth\",charset=utf-8,algorithm=md5-sess"),
      State#state{step = 3}};
 mech_step(#state{step = 3, nonce = Nonce} = State, ClientIn) ->
     case parse(ClientIn) of

--- a/apps/ejabberd/src/cyrsasl_digest.erl
+++ b/apps/ejabberd/src/cyrsasl_digest.erl
@@ -65,7 +65,7 @@ mech_new(Host, Creds) ->
 mech_step(#state{step = 1, nonce = Nonce} = State, _) ->
     {continue,
      list_to_binary("nonce=\"" ++ Nonce ++
-     "\",qop=\"auth\",charset=utf-8,algorithm=md5-sess"),
+     "\", qop=\"auth\", charset=utf-8, algorithm=md5-sess"),
      State#state{step = 3}};
 mech_step(#state{step = 3, nonce = Nonce} = State, ClientIn) ->
     case parse(ClientIn) of
@@ -124,11 +124,11 @@ mech_step(#state{step = 5,
                                              {authzid, AuthzId},
                                              {auth_module, AuthModule}])};
 mech_step(A, B) ->
-    ?DEBUG("SASL DIGEST: A ~p B ~p", [A,B]),
+    ?DEBUG("SASL DIGEST: A ~p B ~p", [A, B]),
     {error, <<"bad-protocol">>}.
 
 
--spec parse(binary()) -> 'bad' | [{binary(),binary()}].
+-spec parse(binary()) -> 'bad' | [{binary(), binary()}].
 parse(S) ->
     parse1(S, <<>>, []).
 
@@ -164,8 +164,8 @@ parse3(<<>>, _, _, _) ->
 -spec parse4(binary(),
     Key :: binary(),
     Val :: binary(),
-    Ts :: [{binary(),binary()}]) -> 'bad' | [{K :: binary(), V :: binary()}].
-parse4(<<$, , Cs/binary>>, Key, Val, Ts) ->
+    Ts :: [{binary(), binary()}]) -> 'bad' | [{K :: binary(), V :: binary()}].
+parse4(<<$,, Cs/binary>>, Key, Val, Ts) ->
     parse1(Cs, <<>>, [{Key, binary_reverse(Val)} | Ts]);
 parse4(<<$\s, Cs/binary>>, Key, Val, Ts) ->
     parse4(Cs, Key, Val, Ts);
@@ -176,8 +176,8 @@ parse4(<<>>, Key, Val, Ts) ->
 
 binary_reverse(<<>>) ->
     <<>>;
-binary_reverse(<<H,T/binary>>) ->
-    <<(binary_reverse(T))/binary,H>>.
+binary_reverse(<<H, T/binary>>) ->
+    <<(binary_reverse(T))/binary, H>>.
 
 %% @doc Check if the digest-uri is valid.
 %% RFC-2831 allows to provide the IP address in Host,
@@ -210,7 +210,7 @@ digit_to_xchar(D) ->
 hex(S) ->
     hex(S, <<>>).
 
--spec hex(binary(),binary()) -> binary().
+-spec hex(binary(), binary()) -> binary().
 hex(<<>>, Res) ->
     binary_reverse(Res);
 hex(<<N, Ns/binary>>, Res) ->
@@ -219,7 +219,7 @@ hex(<<N, Ns/binary>>, Res) ->
     hex(Ns, <<D1, D2, Res/binary>>).
 
 
--spec response(KeyVals :: [{binary(),binary()}],
+-spec response(KeyVals :: [{binary(), binary()}],
                User :: ejabberd:user(),
                Passwd :: binary(),
                Nonce :: binary(),

--- a/apps/ejabberd/src/cyrsasl_plain.erl
+++ b/apps/ejabberd/src/cyrsasl_plain.erl
@@ -68,7 +68,7 @@ mech_step(Creds, ClientIn) ->
             {error, <<"bad-protocol">>}
     end.
 
--spec prepare(binary()) -> 'error' | [binary(),...].
+-spec prepare(binary()) -> 'error' | [binary(), ...].
 prepare(ClientIn) ->
     case parse(ClientIn) of
         [<<>>, UserMaybeDomain, Password] ->
@@ -90,11 +90,11 @@ prepare(ClientIn) ->
     end.
 
 
--spec parse(binary()) -> [binary(),...].
+-spec parse(binary()) -> [binary(), ...].
 parse(S) ->
     parse1(S, <<>>, []).
 
--spec parse1(binary(),binary(),[binary()]) -> [binary(),...].
+-spec parse1(binary(), binary(), [binary()]) -> [binary(), ...].
 parse1(<<0, Cs/binary>>, S, T) ->
     parse1(Cs, <<>>, [binary_reverse(S)| T]);
 parse1(<<C, Cs/binary>>, S, T) ->
@@ -105,11 +105,11 @@ parse1(<<>>, S, T) ->
     lists:reverse([binary_reverse(S)| T]).
 
 
--spec parse_domain(binary()) -> [binary(),...].
+-spec parse_domain(binary()) -> [binary(), ...].
 parse_domain(S) ->
     parse_domain1(S, <<>>, []).
 
--spec parse_domain1(binary(),binary(),[binary()]) -> [binary(),...].
+-spec parse_domain1(binary(), binary(), [binary()]) -> [binary(), ...].
 parse_domain1(<<$@, Cs/binary>>, S, T) ->
     parse_domain1(Cs, <<>>, [binary_reverse(S) | T]);
 parse_domain1(<<C, Cs/binary>>, S, T) ->
@@ -121,5 +121,5 @@ parse_domain1(<<>>, S, T) ->
 -spec binary_reverse(binary()) -> binary().
 binary_reverse(<<>>) ->
     <<>>;
-binary_reverse(<<H,T/binary>>) ->
-    <<(binary_reverse(T))/binary,H>>.
+binary_reverse(<<H, T/binary>>) ->
+    <<(binary_reverse(T))/binary, H>>.

--- a/apps/ejabberd/src/cyrsasl_scram.erl
+++ b/apps/ejabberd/src/cyrsasl_scram.erl
@@ -61,7 +61,7 @@ mech_new(_Host, Creds) ->
     {ok, #state{step = 2, creds = Creds}}.
 
 mech_step(#state{step = 2} = State, ClientIn) ->
-    case re:split(ClientIn, <<", ">>, [{return, binary}]) of
+    case re:split(ClientIn, <<",">>, [{return, binary}]) of
         [_CBind, _AuthorizationIdentity, _UserNameAttribute, _ClientNonceAttribute, ExtensionAttribute | _]
           when ExtensionAttribute /= [] ->
             {error, <<"protocol-error-extension-not-supported">>};
@@ -105,16 +105,16 @@ mech_step(#state{step = 2} = State, ClientIn) ->
                                               [<<"r=">>,
                                                ClientNonce,
                                                ServerNonce,
-                                               <<", s=">>,
+                                               <<",s=">>,
                                                jlib:encode_base64(Salt),
-                                               <<", i=">>,
+                                               <<",i=">>,
                                                integer_to_list(IterationCount)]),
                                             {continue, ServerFirstMessage,
                                              State#state{step = 4, stored_key = StoredKey,
                                                          server_key = ServerKey,
                                                          auth_message =
                                                          <<ClientFirstMessageBare/binary,
-                                                           ", ", ServerFirstMessage/binary>>,
+                                                           ",", ServerFirstMessage/binary>>,
                                                          client_nonce = ClientNonce,
                                                          server_nonce = ServerNonce,
                                                          username = UserName,
@@ -127,7 +127,7 @@ mech_step(#state{step = 2} = State, ClientIn) ->
         _Else -> {error, <<"bad-protocol">>}
     end;
 mech_step(#state{step = 4} = State, ClientIn) ->
-    case re:split(ClientIn, <<", ">>) of
+    case re:split(ClientIn, <<",">>) of
         [GS2ChannelBindingAttribute, NonceAttribute,
          ClientProofAttribute] ->
             case parse_attribute(GS2ChannelBindingAttribute) of
@@ -142,10 +142,10 @@ mech_step(#state{step = 4} = State, ClientIn) ->
                                    case parse_attribute(ClientProofAttribute) of
                                        {$p, ClientProofB64} ->
                                            ClientProof = jlib:decode_base64(ClientProofB64),
-                                           {PStart, _} = binary:match(ClientIn, <<", p=">>),
+                                           {PStart, _} = binary:match(ClientIn, <<",p=">>),
                                            AuthMessage = iolist_to_binary(
                                                            [State#state.auth_message,
-                                                            ", ",
+                                                            ",",
                                                             binary:part(ClientIn, 0, PStart)
                                                            ]),
                                            ClientSignature =
@@ -212,7 +212,7 @@ unescape_username(UnescapedUsername) ->
                                 binary:replace(UnescapedUsername,
                                                <<"=3D">>, <<"=">>,
                                                [global]),
-                                <<"=2C">>, <<", ">>, [global]),
+                                <<"=2C">>, <<",">>, [global]),
             case binary:match(EscapedUsername, <<"=">>) of
                 nomatch ->
                     EscapedUsername;

--- a/apps/ejabberd/src/cyrsasl_scram.erl
+++ b/apps/ejabberd/src/cyrsasl_scram.erl
@@ -61,7 +61,7 @@ mech_new(_Host, Creds) ->
     {ok, #state{step = 2, creds = Creds}}.
 
 mech_step(#state{step = 2} = State, ClientIn) ->
-    case re:split(ClientIn, <<",">>, [{return, binary}]) of
+    case re:split(ClientIn, <<", ">>, [{return, binary}]) of
         [_CBind, _AuthorizationIdentity, _UserNameAttribute, _ClientNonceAttribute, ExtensionAttribute | _]
           when ExtensionAttribute /= [] ->
             {error, <<"protocol-error-extension-not-supported">>};
@@ -105,16 +105,16 @@ mech_step(#state{step = 2} = State, ClientIn) ->
                                               [<<"r=">>,
                                                ClientNonce,
                                                ServerNonce,
-                                               <<",s=">>,
+                                               <<", s=">>,
                                                jlib:encode_base64(Salt),
-                                               <<",i=">>,
+                                               <<", i=">>,
                                                integer_to_list(IterationCount)]),
                                             {continue, ServerFirstMessage,
                                              State#state{step = 4, stored_key = StoredKey,
                                                          server_key = ServerKey,
                                                          auth_message =
                                                          <<ClientFirstMessageBare/binary,
-                                                           ",", ServerFirstMessage/binary>>,
+                                                           ", ", ServerFirstMessage/binary>>,
                                                          client_nonce = ClientNonce,
                                                          server_nonce = ServerNonce,
                                                          username = UserName,
@@ -127,7 +127,7 @@ mech_step(#state{step = 2} = State, ClientIn) ->
         _Else -> {error, <<"bad-protocol">>}
     end;
 mech_step(#state{step = 4} = State, ClientIn) ->
-    case re:split(ClientIn, <<",">>) of
+    case re:split(ClientIn, <<", ">>) of
         [GS2ChannelBindingAttribute, NonceAttribute,
          ClientProofAttribute] ->
             case parse_attribute(GS2ChannelBindingAttribute) of
@@ -142,10 +142,10 @@ mech_step(#state{step = 4} = State, ClientIn) ->
                                    case parse_attribute(ClientProofAttribute) of
                                        {$p, ClientProofB64} ->
                                            ClientProof = jlib:decode_base64(ClientProofB64),
-                                           {PStart, _} = binary:match(ClientIn, <<",p=">>),
+                                           {PStart, _} = binary:match(ClientIn, <<", p=">>),
                                            AuthMessage = iolist_to_binary(
                                                            [State#state.auth_message,
-                                                            ",",
+                                                            ", ",
                                                             binary:part(ClientIn, 0, PStart)
                                                            ]),
                                            ClientSignature =
@@ -212,7 +212,7 @@ unescape_username(UnescapedUsername) ->
                                 binary:replace(UnescapedUsername,
                                                <<"=3D">>, <<"=">>,
                                                [global]),
-                                <<"=2C">>, <<",">>, [global]),
+                                <<"=2C">>, <<", ">>, [global]),
             case binary:match(EscapedUsername, <<"=">>) of
                 nomatch ->
                     EscapedUsername;

--- a/apps/ejabberd/src/dynamic_compile.erl
+++ b/apps/ejabberd/src/dynamic_compile.erl
@@ -53,12 +53,12 @@
 
 %% @doc Returns a binary that can be used with
 %% code:load_binary(Module, ModuleFilenameForInternalRecords, Binary).
--spec from_string('eof' | string()) -> {_,binary()}.
+-spec from_string('eof' | string()) -> {_, binary()}.
 from_string(CodeStr) ->
     from_string(CodeStr, []).
 
 %% @doc takes Options as for compile:forms/2
--spec from_string('eof' | string(),[any()]) -> {_,binary()}.
+-spec from_string('eof' | string(), [any()]) -> {_, binary()}.
 from_string(CodeStr, CompileFormsOptions) ->
     %% Initialise the macro dictionary with the default predefined macros,
     %% (adapted from epp.erl:predef_macros/1
@@ -108,7 +108,7 @@ from_string(CodeStr, CompileFormsOptions) ->
 %% @private
 -spec scan_and_parse('eof' | string(),
                     _CurrFilename :: file:name(),
-                    _CurrLine :: integer() | {integer(),pos_integer()},
+                    _CurrLine :: integer() | {integer(), pos_integer()},
                     RevForms :: [any()],
                     MacroDict :: macro_dict(),
                     _IncludeSearchPath :: [file:name()]) -> {[any()], macro_dict()}.
@@ -120,19 +120,19 @@ scan_and_parse(RemainingText, CurrFilename, CurrLine, RevForms, MacroDict, Inclu
                 {ok, Form} = erl_parse:parse_form(Toks),
                 scan_and_parse(NRemainingText, CurrFilename, NLine, [Form | RevForms], MacroDict, IncludeSearchPath);
             {macro, NLine, NRemainingText, NMacroDict} ->
-                scan_and_parse(NRemainingText, CurrFilename, NLine, RevForms,NMacroDict, IncludeSearchPath);
+                scan_and_parse(NRemainingText, CurrFilename, NLine, RevForms, NMacroDict, IncludeSearchPath);
         {include, NLine, NRemainingText, IncludeFilename} ->
             IncludeFileRemainingTextents = read_include_file(IncludeFilename, IncludeSearchPath),
-            %%io:format("include file ~p contents: ~n~p~nRemainingText = ~p~n", [IncludeFilename,IncludeFileRemainingTextents, RemainingText]),
+            %%io:format("include file ~p contents: ~n~p~nRemainingText = ~p~n", [IncludeFilename, IncludeFileRemainingTextents, RemainingText]),
             %% Modify the FILE macro to reflect the filename
-            %%IncludeMacroDict = dict:store('FILE', {[],IncludeFilename}, MacroDict),
+            %%IncludeMacroDict = dict:store('FILE', {[], IncludeFilename}, MacroDict),
             IncludeMacroDict = MacroDict,
 
             %% Process the header file (inc. any nested header files)
             {RevIncludeForms, IncludedMacroDict} = scan_and_parse(IncludeFileRemainingTextents, IncludeFilename, 1, [], IncludeMacroDict, IncludeSearchPath),
             %io:format("include file results = ~p~n", [R]),
             %% Restore the FILE macro in the NEW MacroDict (so we keep any macros defined in the header file)
-            %%NMacroDict = dict:store('FILE', {[],CurrFilename}, IncludedMacroDict),
+            %%NMacroDict = dict:store('FILE', {[], CurrFilename}, IncludedMacroDict),
             NMacroDict = IncludedMacroDict,
 
             %% Continue with the original file
@@ -143,15 +143,15 @@ scan_and_parse(RemainingText, CurrFilename, CurrLine, RevForms, MacroDict, Inclu
 
 %% @private
 -spec scanner(Text :: 'eof' | string(),
-              Line :: integer() | {integer(),pos_integer()},
+              Line :: integer() | {integer(), pos_integer()},
               MacroDict :: macro_dict()) ->
       'done'
-      | {'include',integer() | {integer(),pos_integer()},'eof' | string(),_}
-      | {'macro',integer() | {integer(),pos_integer()},'eof' | string(), macro_dict()}
-      | {'tokens',integer() | {integer(),pos_integer()},'eof' | string(),[any()]}.
+      | {'include', integer() | {integer(), pos_integer()}, 'eof' | string(), _}
+      | {'macro', integer() | {integer(), pos_integer()}, 'eof' | string(), macro_dict()}
+      | {'tokens', integer() | {integer(), pos_integer()}, 'eof' | string(), [any()]}.
 scanner(Text, Line, MacroDict) ->
-    case erl_scan:tokens([],Text,Line) of
-        {done, {ok,Toks,NLine}, LeftOverChars} ->
+    case erl_scan:tokens([], Text, Line) of
+        {done, {ok, Toks, NLine}, LeftOverChars} ->
             case pre_proc(Toks, MacroDict) of
                 {tokens,  NToks}      -> {tokens,  NLine, LeftOverChars, NToks};
                 {macro,   NMacroDict} -> {macro,   NLine, LeftOverChars, NMacroDict};
@@ -175,7 +175,7 @@ scanner(Text, Line, MacroDict) ->
 is_only_comments(Text) -> is_only_comments(Text, not_in_comment).
 
 %% @private
--spec is_only_comments('eof' | string(),'in_comment' | 'not_in_comment') -> boolean().
+-spec is_only_comments('eof' | string(), 'in_comment' | 'not_in_comment') -> boolean().
 is_only_comments([],       _)              -> true;
 is_only_comments([$   |T], not_in_comment) -> is_only_comments(T, not_in_comment); % skipping whitspace outside of comment
 is_only_comments([$\t |T], not_in_comment) -> is_only_comments(T, not_in_comment); % skipping whitspace outside of comment
@@ -190,44 +190,44 @@ is_only_comments([_   |T], in_comment)     -> is_only_comments(T, in_comment).  
 %% have to implement a subset of the pre-processor, since epp insists
 %% on running on a file. Only handles 2 cases;
 %% -define(MACRO, something).
-%% -define(MACRO(VAR1,VARN),{stuff,VAR1,more,stuff,VARN,extra,stuff}).
+%% -define(MACRO(VAR1, VARN), {stuff, VAR1, more, stuff, VARN, extra, stuff}).
 %% @private
--spec pre_proc([{_,_} | {_,_,_}], macro_dict()) -> {'include',_} | {'macro', macro_dict()} | {'tokens',[any()]}.
-pre_proc([{'-',_},{atom,_,define},{'(',_},{_,_,Name}|DefToks],MacroDict) ->
+-spec pre_proc([{_, _} | {_, _, _}], macro_dict()) -> {'include', _} | {'macro', macro_dict()} | {'tokens', [any()]}.
+pre_proc([{'-', _}, {atom, _, define}, {'(', _}, {_, _, Name}|DefToks], MacroDict) ->
     false = dict:is_key(Name, MacroDict),
     case DefToks of
-        [{',',_} | Macro] ->
+        [{', ', _} | Macro] ->
             {macro, dict:store(Name, {[], macro_body_def(Macro, [])},  MacroDict)};
-        [{'(',_} | Macro] ->
+        [{'(', _} | Macro] ->
             {macro, dict:store(Name, macro_params_body_def(Macro, []), MacroDict)}
     end;
-pre_proc([{'-',_}, {atom,_,include}, {'(',_}, {string,_,Filename}, {')',_}, {dot,_}], _MacroDict) ->
+pre_proc([{'-', _}, {atom, _, include}, {'(', _}, {string, _, Filename}, {')', _}, {dot, _}], _MacroDict) ->
     {include, Filename};
-pre_proc(Toks,MacroDict) ->
+pre_proc(Toks, MacroDict) ->
     {tokens, subst_macros(Toks, MacroDict)}.
 
 %% @private
--spec macro_params_body_def(Tokens :: [{_,_} | {_,_,_},...],
+-spec macro_params_body_def(Tokens :: [{_, _} | {_, _, _}, ...],
                             RevParams :: [any()]
-                            ) -> {[any()],[{_,_} | {_,_,_}]}.
-macro_params_body_def([{')',_},{',',_} | Toks], RevParams) ->
+                            ) -> {[any()], [{_, _} | {_, _, _}]}.
+macro_params_body_def([{')', _}, {', ', _} | Toks], RevParams) ->
     {reverse(RevParams), macro_body_def(Toks, [])};
-macro_params_body_def([{var,_,Param} | Toks], RevParams) ->
+macro_params_body_def([{var, _, Param} | Toks], RevParams) ->
     macro_params_body_def(Toks, [Param | RevParams]);
-macro_params_body_def([{',',_}, {var,_,Param} | Toks], RevParams) ->
+macro_params_body_def([{', ', _}, {var, _, Param} | Toks], RevParams) ->
     macro_params_body_def(Toks, [Param | RevParams]).
 
 %% @private
--spec macro_body_def(Tokens :: [{_,_} | {_,_,_},...],
-                     RevMacroBodyTokens :: [{_,_} | {_,_,_}]
-                     ) -> [{_,_} | {_,_,_}].
-macro_body_def([{')',_}, {dot,_}], RevMacroBodyToks) ->
+-spec macro_body_def(Tokens :: [{_, _} | {_, _, _}, ...],
+                     RevMacroBodyTokens :: [{_, _} | {_, _, _}]
+                     ) -> [{_, _} | {_, _, _}].
+macro_body_def([{')', _}, {dot, _}], RevMacroBodyToks) ->
     reverse(RevMacroBodyToks);
 macro_body_def([Tok|Toks], RevMacroBodyToks) ->
     macro_body_def(Toks, [Tok | RevMacroBodyToks]).
 
 %% @private
--spec subst_macros(Toks :: [{_,_} | {_,_,_}], MacroDict :: macro_dict()) -> [any()].
+-spec subst_macros(Toks :: [{_, _} | {_, _, _}], MacroDict :: macro_dict()) -> [any()].
 subst_macros(Toks, MacroDict) ->
     reverse(subst_macros_rev(Toks, MacroDict, [])).
 
@@ -236,10 +236,10 @@ subst_macros(Toks, MacroDict) ->
 -spec subst_macros_rev(Tokens :: maybe_improper_list(),
                        MacroDict :: macro_dict(),
                        RevOutToks :: [any()]) -> [any()].
-subst_macros_rev([{'?',_}, {_,LineNum,'LINE'} | Toks], MacroDict, RevOutToks) ->
+subst_macros_rev([{'?', _}, {_, LineNum, 'LINE'} | Toks], MacroDict, RevOutToks) ->
     %% special-case for ?LINE, to avoid creating a new MacroDict for every line in the source file
-    subst_macros_rev(Toks, MacroDict, [{integer,LineNum,LineNum}] ++ RevOutToks);
-subst_macros_rev([{'?',_}, {_,_,Name}, {'(',_} = Paren | Toks], MacroDict, RevOutToks) ->
+    subst_macros_rev(Toks, MacroDict, [{integer, LineNum, LineNum}] ++ RevOutToks);
+subst_macros_rev([{'?', _}, {_, _, Name}, {'(', _} = Paren | Toks], MacroDict, RevOutToks) ->
     case dict:fetch(Name, MacroDict) of
         {[], MacroValue} ->
             %% This macro does not have any vars, so ignore the fact that the invocation is followed by "(...stuff"
@@ -258,7 +258,7 @@ subst_macros_rev([{'?',_}, {_,_,Name}, {'(',_} = Paren | Toks], MacroDict, RevOu
             RevExpandedOtherMacrosToks = subst_macros_rev(ExpandedParamsToks, MacroDict, []),
             subst_macros_rev(NToks, MacroDict, RevExpandedOtherMacrosToks ++ RevOutToks)
     end;
-subst_macros_rev([{'?',_}, {_,_,Name} | Toks], MacroDict, RevOutToks) ->
+subst_macros_rev([{'?', _}, {_, _, Name} | Toks], MacroDict, RevOutToks) ->
     %% This macro invocation does not have arguments.
     %% Therefore the definition should not have parameters
     {[], MacroValue} = dict:fetch(Name, MacroDict),
@@ -273,25 +273,25 @@ subst_macros_rev([], _MacroDict, RevOutToks) -> RevOutToks.
 
 %% @private
 -spec subst_macros_get_args(Toks :: nonempty_maybe_improper_list(),
-                            RevArgs :: [any()]) -> {_,[any()]}.
-subst_macros_get_args([{')',_} | Toks], RevArgs) ->
+                            RevArgs :: [any()]) -> {_, [any()]}.
+subst_macros_get_args([{')', _} | Toks], RevArgs) ->
     {Toks, reverse(RevArgs)};
-subst_macros_get_args([{',',_}, {var,_,ArgName} | Toks], RevArgs) ->
+subst_macros_get_args([{', ', _}, {var, _, ArgName} | Toks], RevArgs) ->
     subst_macros_get_args(Toks, [ArgName| RevArgs]);
-subst_macros_get_args([{var,_,ArgName} | Toks], RevArgs) ->
+subst_macros_get_args([{var, _, ArgName} | Toks], RevArgs) ->
     subst_macros_get_args(Toks, [ArgName | RevArgs]).
 
 %% @private
--spec subst_macros_subst_args_for_vars({[any()],_},[any()]) -> any().
+-spec subst_macros_subst_args_for_vars({[any()], _}, [any()]) -> any().
 subst_macros_subst_args_for_vars({[], BodyToks}, []) ->
     BodyToks;
 subst_macros_subst_args_for_vars({[Param | Params], BodyToks}, [Arg|Args]) ->
-    NBodyToks = keyreplace(Param, 3, BodyToks, {var,1,Arg}),
+    NBodyToks = keyreplace(Param, 3, BodyToks, {var, 1, Arg}),
     subst_macros_subst_args_for_vars({Params, NBodyToks}, Args).
 
 %% @private
 -spec read_include_file(Filename :: file:name(),
-                        IncludeSearchPath :: [file:name(),...]
+                        IncludeSearchPath :: [file:name(), ...]
                         ) -> [byte()].
 read_include_file(Filename, IncludeSearchPath) ->
     case file:path_open(IncludeSearchPath, Filename, [read, raw, binary]) of

--- a/apps/ejabberd/src/ejabberd.erl
+++ b/apps/ejabberd/src/ejabberd.erl
@@ -62,8 +62,8 @@
 -type xml_stream_item() :: 'closed'
                           | 'timeout'
                           | {'xmlstreamelement', jlib:xmlel()}
-                          | {'xmlstreamend',_}
-                          | {'xmlstreamerror',_}
+                          | {'xmlstreamend', _}
+                          | {'xmlstreamerror', _}
                           | {'xmlstreamstart', Name :: any(), Attrs :: list()}.
 
 -export_type([lang/0,

--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -363,7 +363,7 @@ delete_old_messages(Days) ->
 %%% Mnesia management
 %%%
 
--spec set_master(Node :: atom() | string()) -> {'error', io_lib:chars()} | {'ok',[]}.
+-spec set_master(Node :: atom() | string()) -> {'error', io_lib:chars()} | {'ok', []}.
 set_master("self") ->
     set_master(node());
 set_master(NodeString) when is_list(NodeString) ->
@@ -378,7 +378,7 @@ set_master(Node) when is_atom(Node) ->
             {error, String}
     end.
 
--spec backup_mnesia(file:name()) -> {'cannot_backup', io_lib:chars()} | {'ok',[]}.
+-spec backup_mnesia(file:name()) -> {'cannot_backup', io_lib:chars()} | {'ok', []}.
 backup_mnesia(Path) ->
     case mnesia:backup(Path) of
         ok ->
@@ -391,7 +391,7 @@ backup_mnesia(Path) ->
 
 -spec restore_mnesia(file:name()) -> {'cannot_restore', io_lib:chars()}
                                    | {'file_not_found', io_lib:chars()}
-                                   | {'ok',[]}
+                                   | {'ok', []}
                                    | {'table_not_exists', io_lib:chars()}.
 restore_mnesia(Path) ->
     case ejabberd_admin:restore(Path) of
@@ -401,11 +401,11 @@ restore_mnesia(Path) ->
             String = io_lib:format("Can't restore backup from ~p at node ~p: ~p",
                                    [filename:absname(Path), node(), Reason]),
             {cannot_restore, String};
-        {aborted,{no_exists,Table}} ->
+        {aborted, {no_exists, Table}} ->
             String = io_lib:format("Can't restore backup from ~p at node ~p: Table ~p does not exist.",
                                    [filename:absname(Path), node(), Table]),
             {table_not_exists, String};
-        {aborted,enoent} ->
+        {aborted, enoent} ->
             String = io_lib:format("Can't restore backup from ~p at node ~p: File not found.",
                                    [filename:absname(Path), node()]),
             {file_not_found, String}
@@ -415,7 +415,7 @@ restore_mnesia(Path) ->
 %% This function is called from ejabberd_ctl, ejabberd_web_admin and
 %% mod_configure/adhoc
 restore(Path) ->
-    mnesia:restore(Path, [{keep_tables,keep_tables()},
+    mnesia:restore(Path, [{keep_tables, keep_tables()},
                           {default_op, skip_tables}]).
 
 %% @doc This function return a list of tables that should be kept from a
@@ -486,19 +486,19 @@ dump_tables(Path, Tables) ->
             {cannot_dump, String}
     end.
 
--spec dump_to_textfile(file:name()) -> 'ok' | {'error',atom()}.
+-spec dump_to_textfile(file:name()) -> 'ok' | {'error', atom()}.
 dump_to_textfile(File) ->
     Tabs = get_local_tables(),
     dump_to_textfile(File, Tabs).
 
--spec dump_to_textfile(file:name(), Tabs :: list()) -> 'ok' | {'error',atom()}.
+-spec dump_to_textfile(file:name(), Tabs :: list()) -> 'ok' | {'error', atom()}.
 dump_to_textfile(File, Tabs) ->
     dump_to_textfile(mnesia:system_info(is_running), Tabs, file:open(File, [write])).
 
 -spec dump_to_textfile(any(),
                       any(),
-                      {'error',atom()} | {'ok',pid() | {'file_descriptor',atom() | tuple(),_}}
-                      ) -> 'ok' | {'error',atom()}.
+                      {'error', atom()} | {'ok', pid() | {'file_descriptor', atom() | tuple(), _}}
+                      ) -> 'ok' | {'error', atom()}.
 dump_to_textfile(yes, Tabs, {ok, F}) ->
     Defs = lists:map(
              fun(T) -> {T, [{record_name, mnesia:table_info(T, record_name)},
@@ -514,13 +514,13 @@ dump_to_textfile(_, _, {ok, F}) ->
 dump_to_textfile(_, _, {error, Reason}) ->
     {error, Reason}.
 
--spec dump_tab(pid(),atom()) -> 'ok'.
+-spec dump_tab(pid(), atom()) -> 'ok'.
 dump_tab(F, T) ->
     W = mnesia:table_info(T, wild_pattern),
-    {atomic,All} = mnesia:transaction(
+    {atomic, All} = mnesia:transaction(
                      fun() -> mnesia:match_object(T, W, read) end),
     lists:foreach(
-      fun(Term) -> io:format(F,"~p.~n", [setelement(1, Term, T)]) end, All).
+      fun(Term) -> io:format(F, "~p.~n", [setelement(1, Term, T)]) end, All).
 
 -spec load_mnesia(file:name()) -> {'cannot_load', io_lib:chars()} | {'ok', []}.
 load_mnesia(Path) ->
@@ -534,7 +534,7 @@ load_mnesia(Path) ->
     end.
 
 -spec install_fallback_mnesia(file:name()) ->
-                        {'cannot_fallback', io_lib:chars()} | {'ok',[]}.
+                        {'cannot_fallback', io_lib:chars()} | {'ok', []}.
 install_fallback_mnesia(Path) ->
     case mnesia:install_fallback(Path) of
         ok ->
@@ -545,7 +545,7 @@ install_fallback_mnesia(Path) ->
             {cannot_fallback, String}
     end.
 
--spec mnesia_change_nodename(string(),string(),_,_) -> {ok,_} | {error,_}.
+-spec mnesia_change_nodename(string(), string(), _, _) -> {ok, _} | {error, _}.
 mnesia_change_nodename(FromString, ToString, Source, Target) ->
     From = list_to_atom(FromString),
     To = list_to_atom(ToString),
@@ -566,7 +566,7 @@ mnesia_change_nodename(FromString, ToString, Source, Target) ->
         fun
             ({schema, db_nodes, Nodes}, Acc) ->
                 io:format(" +++ db_nodes ~p~n", [Nodes]),
-                {[{schema, db_nodes, lists:map(Switch,Nodes)}], Acc};
+                {[{schema, db_nodes, lists:map(Switch, Nodes)}], Acc};
             ({schema, version, Version}, Acc) ->
                 io:format(" +++ version: ~p~n", [Version]),
                 {[{schema, version, Version}], Acc};

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -173,7 +173,7 @@ check_password(User, Server, Password, Digest, DigestGen) ->
                      Password :: binary(),
                      Digest :: binary(),
                      DigestGen :: fun()) -> boolean().
-do_check_password(LUser, LServer, _,_,_)
+do_check_password(LUser, LServer, _, _, _)
     when LUser =:= error; LServer =:= error ->
     false;
 do_check_password(LUser, LServer, Password, Digest, DigestGen) ->
@@ -229,7 +229,7 @@ do_check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen) -
                                                Digest, DigestGen]).
 
 -spec check_password_loop(AuthModules :: [authmodule()],
-                          Args :: [any(),...]
+                          Args :: [any(), ...]
                           ) -> 'false' | {'true', authmodule()}.
 check_password_loop([], _Args) ->
     false;
@@ -256,7 +256,7 @@ check_digest(Digest, DigestGen, _Password, Passwd) ->
                    Server :: ejabberd:server(),
                    Password :: binary()
                   ) -> ok | {error, empty_password | not_allowed | invalid_jid}.
-set_password(_,_, <<"">>) ->
+set_password(_, _, <<"">>) ->
     {error, empty_password};
 set_password(User, Server, Password) ->
     LUser = jid:nodeprep(User),
@@ -278,19 +278,19 @@ do_set_password(LUser, LServer, Password) ->
                    Server :: ejabberd:server(),
                    Password :: binary()
                    ) -> ok | {error, exists | not_allowed | invalid_jid | null_password}.
-try_register(_,_,<<"">>) ->
+try_register(_, _, <<"">>) ->
     {error, null_password};
 try_register(User, Server, Password) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nodeprep(Server),
     do_try_register(LUser, LServer, Password).
 
--spec do_try_register(ejabberd:luser(), ejabberd:lserver(),binary())
+-spec do_try_register(ejabberd:luser(), ejabberd:lserver(), binary())
         -> ok | {error, exists | not_allowed | invalid_jid}.
 do_try_register(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
     {error, invalid_jid};
 do_try_register(LUser, LServer, Password) ->
-    Exists = is_user_exists(LUser,LServer),
+    Exists = is_user_exists(LUser, LServer),
     do_try_register_if_does_not_exist(Exists, LUser, LServer, Password).
 
 do_try_register_if_does_not_exist(true, _, _, _) ->

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -78,7 +78,7 @@ start(Host) ->
     mnesia:create_table(passwd, [{disc_copies, [node()]},
                                  {attributes, record_info(fields, passwd)},
                                  {storage_properties,
-                                  [{ets, [{read_concurrency,true}]}]}
+                                  [{ets, [{read_concurrency, true}]}]}
                                   ]),
     mnesia:create_table(reg_users_counter,
 			[{ram_copies, [node()]},
@@ -235,7 +235,7 @@ get_vh_registered_users(LServer, [{limit, Limit}, {offset, Offset}])
     end;
 get_vh_registered_users(LServer, [{prefix, Prefix}])
         when is_binary(Prefix) ->
-    Set = [{U,S} || {U, S} <- get_vh_registered_users(LServer),
+    Set = [{U, S} || {U, S} <- get_vh_registered_users(LServer),
                     binary:part(U, 0, bit_size(Prefix)) =:= Prefix],
     lists:keysort(1, Set);
 get_vh_registered_users(LServer, [{prefix, Prefix}, {from, Start}, {to, End}])
@@ -243,7 +243,7 @@ get_vh_registered_users(LServer, [{prefix, Prefix}, {from, Start}, {to, End}])
     get_vh_registered_users(LServer, [{prefix, Prefix}, {limit, End-Start+1}, {offset, Start}]);
 get_vh_registered_users(LServer, [{prefix, Prefix}, {limit, Limit}, {offset, Offset}])
         when is_binary(Prefix) and is_integer(Limit) and is_integer(Offset) ->
-    case [{U,S} || {U, S} <- get_vh_registered_users(LServer),
+    case [{U, S} || {U, S} <- get_vh_registered_users(LServer),
                    binary:part(U, 0, bit_size(Prefix)) =:= Prefix] of
     [] ->
         [];

--- a/apps/ejabberd/src/ejabberd_auth_riak.erl
+++ b/apps/ejabberd/src/ejabberd_auth_riak.erl
@@ -59,7 +59,7 @@ store_type(Host) ->
         true -> scram
     end.
 
--spec set_password(ejabberd:luser(),ejabberd:lserver(), binary())
+-spec set_password(ejabberd:luser(), ejabberd:lserver(), binary())
         -> ok | {error, not_allowed | invalid_jid}.
 set_password(LUser, LServer, Password) ->
     case prepare_password(LServer, Password) of

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -74,7 +74,7 @@
 %%%----------------------------------------------------------------------
 
 -spec start(_, list())
--> {'error',_} | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+-> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(SockData, Opts) ->
     ?SUPERVISOR_START.
 
@@ -912,7 +912,7 @@ session_established({xmlstreamerror, _}, StateData) ->
     send_trailer(StateData),
     {stop, normal, StateData};
 session_established(closed, StateData) ->
-    ?DEBUG("Session established closed - trying to enter resume_session",[]),
+    ?DEBUG("Session established closed - trying to enter resume_session", []),
     maybe_enter_resume_session(StateData#state.stream_mgmt_id, StateData).
 
 %% @doc Process packets sent by user (coming from user on c2s XMPP
@@ -969,7 +969,7 @@ process_outgoing_stanza(ToJID, <<"presence">>, Args) ->
         #jid{user = User,
              server = Server,
              resource = <<>>} ->
-             ?DEBUG("presence_update(~p,~n\t~p,~n\t~p)",
+             ?DEBUG("presence_update(~p, ~n\t~p, ~n\t~p)",
                  [FromJID, PresenceEl, StateData]),
              presence_update(FromJID, PresenceEl,
                              StateData);
@@ -1021,7 +1021,7 @@ resume_session(closed, StateData) ->
 resume_session(timeout, StateData) ->
     {next_state, resume_session, StateData, hibernate};
 resume_session(Msg, StateData) ->
-    ?WARNING_MSG("unexpected message ~p",[Msg]),
+    ?WARNING_MSG("unexpected message ~p", [Msg]),
     {next_state, resume_session, StateData, hibernate}.
 
 
@@ -2209,7 +2209,7 @@ process_privacy_iq(From, To,
 
 -spec resend_offline_messages(state()) -> ok.
 resend_offline_messages(StateData) ->
-    ?DEBUG("resend offline messages~n",[]),
+    ?DEBUG("resend offline messages~n", []),
     case ejabberd_hooks:run_fold(
            resend_offline_messages_hook, StateData#state.server,
            [],
@@ -2350,7 +2350,7 @@ fsm_reply(Reply, StateName, StateData) ->
                        ) -> boolean().
 is_ip_blacklisted(undefined) ->
     false;
-is_ip_blacklisted({IP,_Port}) ->
+is_ip_blacklisted({IP, _Port}) ->
     ejabberd_hooks:run_fold(check_bl_c2s, false, [IP]).
 
 
@@ -2496,7 +2496,7 @@ blocking_presence_to_contacts(Action, [Jid|JIDs], StateData) ->
     Pres = case Action of
                block ->
                    #xmlel{name = <<"presence">>,
-                       attrs = [{<<"xml:lang">>,<<"en">>},{<<"type">>,<<"unavailable">>}]
+                       attrs = [{<<"xml:lang">>, <<"en">>}, {<<"type">>, <<"unavailable">>}]
                    };
                unblock ->
                    StateData#state.pres_last
@@ -2542,10 +2542,10 @@ pack_jid_set(Set, Pack) ->
     {?SETS:from_list(PackedJids), NewPack}.
 
 
--spec pack_jids([{_,_,_}], Pack :: pack_tree(), Acc :: [ejabberd:simple_jid()]) ->
-    {[ejabberd:simple_jid()],pack_tree()}.
+-spec pack_jids([{_, _, _}], Pack :: pack_tree(), Acc :: [ejabberd:simple_jid()]) ->
+    {[ejabberd:simple_jid()], pack_tree()}.
 pack_jids([], Pack, Acc) -> {Acc, Pack};
-pack_jids([{U,S,R}=Jid | Jids], Pack, Acc) ->
+pack_jids([{U, S, R}=Jid | Jids], Pack, Acc) ->
     case gb_trees:lookup(Jid, Pack) of
         {value, PackedJid} ->
             pack_jids(Jids, Pack, [PackedJid | Acc]);
@@ -2899,7 +2899,7 @@ do_resume_session(SMID, El, [{_, Pid}], StateData) ->
                                                   NSD#state.stream_mgmt_in),
                     send_element(NSD, Resumed),
                     [send_element(NSD, Packet)
-                     || {_, _,Packet} <- lists:reverse(NSD#state.stream_mgmt_buffer)],
+                     || {_, _, Packet} <- lists:reverse(NSD#state.stream_mgmt_buffer)],
 
                     NSD2 = flush_csi_buffer(NSD),
 
@@ -2907,7 +2907,7 @@ do_resume_session(SMID, El, [{_, Pid}], StateData) ->
                 catch
                     %% errors from send_element
                     _:_ ->
-                        ?INFO_MSG("resumption error while resending old stanzas entering resume state again smid: ~p~n",[SMID]),
+                        ?INFO_MSG("resumption error while resending old stanzas entering resume state again smid: ~p~n", [SMID]),
                         maybe_enter_resume_session(SMID, NSD)
                 end
         end
@@ -2984,14 +2984,14 @@ maybe_add_timestamp({F, T, #xmlel{name= <<"message">>}=Packet}=PacketTuple, Time
         <<"headline">> ->
             PacketTuple;
         _ ->
-            {F, T, add_timestamp(Timestamp,<<"localhost">>, Packet)}
+            {F, T, add_timestamp(Timestamp, <<"localhost">>, Packet)}
     end;
 maybe_add_timestamp(Packet, _Timestamp) ->
     Packet.
 
-add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
-    {D,{H,M,S}} = calendar:now_to_universal_time(TimeStamp),
-    Time = {D,{H,M,S, Micro}},
+add_timestamp({_, _, Micro} = TimeStamp, Server, Packet) ->
+    {D, {H, M, S}} = calendar:now_to_universal_time(TimeStamp),
+    Time = {D, {H, M, S, Micro}},
     case xml:get_subtag(Packet, <<"delay">>) of
         false ->
             TimeStampXML = timestamp_xml(Server, Time),

--- a/apps/ejabberd/src/ejabberd_commands.erl
+++ b/apps/ejabberd/src/ejabberd_commands.erl
@@ -124,11 +124,11 @@
 %%%
 %%% When your module is initialized or started, register your commands:
 %%%
-%%% <pre>ejabberd_commands:register_commands(commands()),</pre>
+%%% <pre>ejabberd_commands:register_commands(commands()), </pre>
 %%%
 %%% And when your module is stopped, unregister your commands:
 %%%
-%%% <pre>ejabberd_commands:unregister_commands(commands()),</pre>
+%%% <pre>ejabberd_commands:unregister_commands(commands()), </pre>
 %%%
 %%% That's all! Now when your module is started, the command will be
 %%% registered and any frontend can access it. For example:
@@ -448,7 +448,7 @@ check_access(Access, Auth) ->
     end.
 
 
--spec check_access_command(_,tuple(),_,_,_) -> boolean().
+-spec check_access_command(_, tuple(), _, _, _) -> boolean().
 check_access_command(Commands, Command, ArgumentRestrictions, Method, Arguments) ->
     case Commands==all orelse lists:member(Method, Commands) of
         true -> check_access_arguments(Command, ArgumentRestrictions, Arguments);
@@ -471,8 +471,8 @@ check_access_arguments(Command, ArgumentRestrictions, Arguments) ->
       end, ArgumentRestrictions).
 
 
--spec tag_arguments(ArgsDefs :: [{atom(), integer() | string() | {_,_}}],
-                    Args :: [any()] ) -> [{_,_}].
+-spec tag_arguments(ArgsDefs :: [{atom(), integer() | string() | {_, _}}],
+                    Args :: [any()] ) -> [{_, _}].
 tag_arguments(ArgsDefs, Args) ->
     lists:zipwith(
       fun({ArgName, _ArgType}, ArgValue) ->

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -670,7 +670,7 @@ set_opts(State) ->
             ?ERROR_MSG("Error reading Mnesia database spool files:~n"
                        "The Mnesia database couldn't read the spool file for the table '~p'.~n"
                        "ejabberd needs read and write access in the directory:~n   ~s~n"
-                       "Maybe the problem is a change in the computer hostname,~n"
+                       "Maybe the problem is a change in the computer hostname, ~n"
                        "or a change in the Erlang node name, which is currently:~n   ~p~n"
                        "Check the ejabberd guide for details about changing the~n"
                        "computer hostname or Erlang node name.~n",
@@ -1054,7 +1054,7 @@ handle_local_hosts_config_add({{ldap, _Host}, _}) ->
     ok;
 handle_local_hosts_config_add({{modules, Host}, Modules}) ->
     gen_mod_deps:start_modules(Host, Modules);
-handle_local_hosts_config_add({{Key,_Host}, _} = El) ->
+handle_local_hosts_config_add({{Key, _Host}, _} = El) ->
     case can_be_ignored(Key) of
         true ->
             ok;
@@ -1079,7 +1079,7 @@ handle_local_hosts_config_del({{ldap, _Host}, _I}) ->
     ok;
 handle_local_hosts_config_del({{modules, Host}, Modules}) ->
     lists:foreach(fun({Mod, _}) -> gen_mod:stop_module(Host, Mod) end, Modules);
-handle_local_hosts_config_del({{Key,_}, _} =El) ->
+handle_local_hosts_config_del({{Key, _}, _} =El) ->
     case can_be_ignored(Key) of
         true ->
             ok;
@@ -1110,9 +1110,9 @@ handle_local_hosts_config_change({{auth, Host}, OldVals, _}) ->
     ejabberd_auth:start(Host);
 handle_local_hosts_config_change({{ldap, Host}, _OldConfig, NewConfig}) ->
     ok = ejabberd_hooks:run_fold(host_config_update, Host, ok, [Host, ldap, NewConfig]);
-handle_local_hosts_config_change({{modules,Host}, OldModules, NewModules}) ->
+handle_local_hosts_config_change({{modules, Host}, OldModules, NewModules}) ->
     gen_mod_deps:replace_modules(Host, OldModules, NewModules);
-handle_local_hosts_config_change({{Key,_Host},_Old,_New} = El) ->
+handle_local_hosts_config_change({{Key, _Host}, _Old, _New} = El) ->
     case can_be_ignored(Key) of
         true ->
             ok;

--- a/apps/ejabberd/src/ejabberd_cowboy.erl
+++ b/apps/ejabberd/src/ejabberd_cowboy.erl
@@ -70,7 +70,7 @@ reload_dispatch(Ref) ->
     gen_server:call(Ref, reload_dispatch).
 
 %% @doc gen_server for handling shutdown when started via ejabberd_listener
--spec start_link(_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(_) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(State) ->
     gen_server:start_link(?MODULE, State, []).
 

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -314,7 +314,7 @@ call_command([CmdString | Args], Auth, AccessCommands) ->
 		    Result = ejabberd_commands:execute_command(AccessCommands, Auth, Command,
 							       ArgsFormatted),
 		    format_result(Result, ResultFormat);
-		{'EXIT', {function_clause,[{lists,zip,[A1, A2], _FileInfo} | _]}} ->
+		{'EXIT', {function_clause, [{lists, zip, [A1, A2], _FileInfo} | _]}} ->
 		    {NumCompa, TextCompa} =
 			case {length(A1), length(A2)} of
 			    {L1, L2} when L1 < L2 -> {L2-L1, "less argument"};
@@ -454,7 +454,7 @@ format_result([FirstElement | Elements], {_Name, {list, ElementsDef}}) ->
                ["\n" | format_result(Element, ElementsDef)]
        end,
        Elements)];
-%% The result is a tuple with several elements: {something1(), something2(),...}
+%% The result is a tuple with several elements: {something1(), something2(), ...}
 %% NOTE: the elements in the tuple are separated with tabular characters,
 %% if a string is empty, it will be difficult to notice in the shell,
 %% maybe a different separation character should be used, like ;;?
@@ -481,7 +481,7 @@ get_list_commands() ->
     try ejabberd_commands:list_commands() of
         Commands ->
             [tuple_command_help(Command)
-             || {N,_,_}=Command <- Commands,
+             || {N, _, _}=Command <- Commands,
                 %% Don't show again those commands, because they are already
                 %% announced by ejabberd_ctl itself
                 N /= status, N /= stop, N /= restart]
@@ -516,7 +516,7 @@ format_status([{node, Node}, {internal_status, IS}, {provided_status, PS},
                           {running, Version} -> Version;
                           not_running -> "unavailable - mongooseim app not running"
                         end, "\n",
-       "    uptime: ", io_lib:format(?TIME_HMS_FORMAT, UptimeHMS) ,"\n"] ++
+       "    uptime: ", io_lib:format(?TIME_HMS_FORMAT, UptimeHMS), "\n"] ++
       ["    logs: none - maybe enable logging to a file in app.config?\n" || LogFiles == [] ] ++
       ["    logs:\n" || LogFiles /= [] ] ++ [
       ["        ", LogFile, "\n"] || LogFile <- LogFiles ] ).
@@ -541,8 +541,8 @@ print_usage() ->
 
 
 -spec print_usage('dual' | 'long'
-                 , MaxC :: integer()
-                 , ShCode :: boolean()) -> 'ok'.
+                , MaxC :: integer()
+                , ShCode :: boolean()) -> 'ok'.
 print_usage(HelpMode, MaxC, ShCode) ->
     AllCommands =
         [
@@ -572,7 +572,7 @@ print_usage(HelpMode, MaxC, ShCode) ->
 -spec print_usage_commands(HelpMode :: 'dual' | 'long',
                            MaxC :: integer(),
                            ShCode :: boolean(),
-                           Commands :: [cmd(),...]) -> 'ok'.
+                           Commands :: [cmd(), ...]) -> 'ok'.
 print_usage_commands(HelpMode, MaxC, ShCode, Commands) ->
     CmdDescsSorted = lists:keysort(1, Commands),
 
@@ -605,7 +605,7 @@ print_usage_commands(HelpMode, MaxC, ShCode, Commands) ->
 
 %% @doc Get some info about the shell: how many columns of width and guess if
 %% it supports text formatting codes.
--spec get_shell_info() -> {integer(),boolean()}.
+-spec get_shell_info() -> {integer(), boolean()}.
 get_shell_info() ->
     case io:columns() of
         {ok, C} -> {C-2, true};
@@ -616,7 +616,7 @@ get_shell_info() ->
 %% @doc Split this command description in several lines of proper length
 -spec prepare_description(DescInit :: non_neg_integer(),
                           MaxC :: integer(),
-                          Desc :: string()) -> [[[any()]],...].
+                          Desc :: string()) -> [[[any()]], ...].
 prepare_description(DescInit, MaxC, Desc) ->
     Words = string:tokens(Desc, " "),
     prepare_long_line(DescInit, MaxC, Words).
@@ -625,7 +625,7 @@ prepare_description(DescInit, MaxC, Desc) ->
 -spec prepare_long_line(DescInit :: non_neg_integer(),
                         MaxC :: integer(),
                         Words :: [nonempty_string()]
-                        ) -> [[[any()]],...].
+                        ) -> [[[any()]], ...].
 prepare_long_line(DescInit, MaxC, Words) ->
     MaxSegmentLen = MaxC - DescInit,
     MarginString = lists:duplicate(DescInit, ?ASCII_SPACE_CHARACTER), % Put spaces
@@ -635,7 +635,7 @@ prepare_long_line(DescInit, MaxC, Words) ->
 
 
 -spec mix_desc_segments(MarginStr :: [any()],
-                        Segments :: [[[any(),...]]]) -> [[[any()],...]].
+                        Segments :: [[[any(), ...]]]) -> [[[any()], ...]].
 mix_desc_segments(MarginString, Segments) ->
     [["\n", MarginString, Segment] || Segment <- Segments].
 
@@ -645,7 +645,7 @@ split_desc_segments(MaxL, Words) ->
 
 %% @doc Join words in a segment, but stop adding to a segment if adding this
 %% word would pass L
--spec join(L :: number(), Words :: [nonempty_string()]) -> [[[any(),...]],...].
+-spec join(L :: number(), Words :: [nonempty_string()]) -> [[[any(), ...]], ...].
 join(L, Words) ->
     join(L, Words, 0, [], []).
 
@@ -654,7 +654,7 @@ join(L, Words) ->
            Words :: [nonempty_string()],
            LenLastSeg :: non_neg_integer(),
            LastSeg :: [nonempty_string()],
-           ResSeg :: [[[any(),...]]] ) -> [[[any(),...]],...].
+           ResSeg :: [[[any(), ...]]] ) -> [[[any(), ...]], ...].
 join(_L, [], _LenLastSeg, LastSeg, ResSeg) ->
     ResSeg2 = [lists:reverse(LastSeg) | ResSeg],
     lists:reverse(ResSeg2);
@@ -675,11 +675,11 @@ join(L, [Word | Words], LenLastSeg, LastSeg, ResSeg) ->
     end.
 
 
--spec format_command_lines(CALD :: [{[any()],[any()],number(),_},...],
+-spec format_command_lines(CALD :: [{[any()], [any()], number(), _}, ...],
                            MaxCmdLen :: integer(),
                            MaxC :: integer(),
                            ShCode :: boolean(),
-                           'dual' | 'long') -> [[any(),...],...].
+                           'dual' | 'long') -> [[any(), ...], ...].
 format_command_lines(CALD, MaxCmdLen, MaxC, ShCode, dual)
   when MaxC - MaxCmdLen < 40 ->
     %% If the space available for descriptions is too narrow, enforce long help mode
@@ -748,11 +748,11 @@ print_usage_help(MaxC, ShCode) ->
         ["The special 'help' mongooseimctl command provides help of MongooseIM commands.\n\n"
          "The format is:\n  ", ?B("mongooseimctl"), " ", ?B("help"), " [", ?B("--tags"), " ", ?U("[tag]"), " | ", ?U("com?*"), "]\n\n"
          "The optional arguments:\n"
-         "  ",?B("--tags"),"      Show all tags and the names of commands in each tag\n"
-         "  ",?B("--tags"), " ", ?U("tag"),"  Show description of commands in this tag\n"
-         "  ",?U("command"),"     Show detailed description of the command\n"
-         "  ",?U("com?*"),"       Show detailed description of commands that match this glob.\n"
-         "              You can use ? to match a simple character,\n"
+         "  ", ?B("--tags"), "      Show all tags and the names of commands in each tag\n"
+         "  ", ?B("--tags"), " ", ?U("tag"), "  Show description of commands in this tag\n"
+         "  ", ?U("command"), "     Show detailed description of the command\n"
+         "  ", ?U("com?*"), "       Show detailed description of commands that match this glob.\n"
+         "              You can use ? to match a simple character, \n"
          "              and * to match several characters.\n"
          "\n",
          "Some example usages:\n",
@@ -762,7 +762,7 @@ print_usage_help(MaxC, ShCode) ->
          " mongooseimctl help register\n",
          " mongooseimctl help regist*\n",
          "\n",
-         "Please note that 'mongooseimctl help' shows all MongooseIM commands,\n",
+         "Please note that 'mongooseimctl help' shows all MongooseIM commands, \n",
          "even those that cannot be used in the shell with mongooseimctl.\n",
          "Those commands can be identified because the description starts with: *"],
     ArgsDef = [],
@@ -860,11 +860,11 @@ print_usage_command(Cmd, C, MaxC, ShCode) ->
 
     %% Initial indentation of result is 11 = length("  Returns: ")
     ResultFmt = format_usage_ctype(ResultDef, 11),
-    ReturnsFmt = ["  ",?B("Returns"),": ", ResultFmt],
+    ReturnsFmt = ["  ", ?B("Returns"), ": ", ResultFmt],
 
-    TagsFmt = ["  ",?B("Tags"),": ", prepare_long_line(8, MaxC, [atom_to_list(TagA) || TagA <- TagsAtoms])],
+    TagsFmt = ["  ", ?B("Tags"), ": ", prepare_long_line(8, MaxC, [atom_to_list(TagA) || TagA <- TagsAtoms])],
 
-    DescFmt = ["  ",?B("Description"),": ", prepare_description(15, MaxC, Desc)],
+    DescFmt = ["  ", ?B("Description"), ": ", prepare_description(15, MaxC, Desc)],
 
     LongDescFmt = case LongDesc of
                       "" -> "";
@@ -895,11 +895,11 @@ format_usage_ctype({Name, {tuple, ElementsDef}}, Indentation) ->
 format_usage_tuple([], _Indentation) ->
     [];
 format_usage_tuple([ElementDef], Indentation) ->
-    [format_usage_ctype(ElementDef, Indentation) , " }"];
+    [format_usage_ctype(ElementDef, Indentation), " }"];
 format_usage_tuple([ElementDef | ElementsDef], Indentation) ->
     ElementFmt = format_usage_ctype(ElementDef, Indentation),
     MarginString = lists:duplicate(Indentation, ?ASCII_SPACE_CHARACTER), % Put spaces
-    [ElementFmt, ",\n", MarginString, format_usage_tuple(ElementsDef, Indentation)].
+    [ElementFmt, ", \n", MarginString, format_usage_tuple(ElementsDef, Indentation)].
 
 get_mongoose_status() ->
     case lists:keyfind(mongooseim, 1, application:which_applications()) of

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -146,7 +146,7 @@ run_fold(Hook, Host, Val, Args) ->
 %%          {stop, Reason}
 %%----------------------------------------------------------------------
 init([]) ->
-    ets:new(hooks, [named_table, {read_concurrency,true}]),
+    ets:new(hooks, [named_table, {read_concurrency, true}]),
     {ok, #state{}}.
 
 %%----------------------------------------------------------------------

--- a/apps/ejabberd/src/ejabberd_listener.erl
+++ b/apps/ejabberd/src/ejabberd_listener.erl
@@ -51,7 +51,7 @@
 -type portnum() :: inet:port_number().
 -type port_ip_proto() :: portnum() | {portnum(), addr() | proto()} | {portnum(), addr(), proto()}.
 
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     supervisor:start_link({local, ejabberd_listeners}, ?MODULE, []).
 
@@ -61,7 +61,7 @@ init(_) ->
     {ok, {{one_for_one, 10, 1}, []}}.
 
 
--spec start_listeners() -> 'ignore' | {'ok',{{_,_,_},[any()]}}.
+-spec start_listeners() -> 'ignore' | {'ok', {{_, _, _}, [any()]}}.
 start_listeners() ->
     case ejabberd_config:get_local_option(listen) of
         undefined ->
@@ -132,7 +132,7 @@ init(PortIP, Module, RawOpts) ->
                            | {port, inet:port_number()}.
 -spec init_udp(PortIPProto :: port_ip_proto(),
                Module :: atom(),
-               Opts :: [any(),...],
+               Opts :: [any(), ...],
                SockOpts :: [udp_listen_option()],
                Port :: inet:port_number(),
                IPS :: [any()]) -> no_return().
@@ -151,7 +151,7 @@ init_udp(PortIPProto, Module, Opts, SockOpts, Port, IPS) ->
 
 -spec init_tcp(PortIPProto :: port_ip_proto(),
                Module :: atom(),
-               Opts :: [any(),...],
+               Opts :: [any(), ...],
                SockOpts :: [gen_tcp:listen_option()],
                Port :: inet:port_number(),
                IPS :: [any()]) -> no_return().
@@ -260,7 +260,7 @@ parse_listener_portip(PortIPProto, Opts) ->
 
 -spec prepare_opts(IPT :: tuple(),
                    IPV :: 'inet' | 'inet6',
-                   OptsClean :: [any()]) -> {[any(),...],[any()]}.
+                   OptsClean :: [any()]) -> {[any(), ...], [any()]}.
 prepare_opts(IPT, IPV, OptsClean) ->
     %% The first inet|inet6 and the last {ip, _} work,
     %% so overriding those in Opts
@@ -313,7 +313,7 @@ get_ip_tuple(IPOpt, _IPVOpt) ->
 
 -spec accept(Socket :: port(),
              Module :: atom(),
-             Opts :: [any(),...]) -> no_return().
+             Opts :: [any(), ...]) -> no_return().
 accept(ListenSocket, Module, Opts) ->
     case gen_tcp:accept(ListenSocket) of
         {ok, Socket} ->
@@ -334,7 +334,7 @@ accept(ListenSocket, Module, Opts) ->
 
 -spec udp_recv(Socket :: port(),
                Module :: atom(),
-               Opts :: [any(),...]) -> no_return().
+               Opts :: [any(), ...]) -> no_return().
 udp_recv(Socket, Module, Opts) ->
     case gen_udp:recv(Socket, 0) of
         {ok, {Addr, Port, Packet}} ->
@@ -355,7 +355,7 @@ udp_recv(Socket, Module, Opts) ->
 
 -spec start_listener(PortIPProto :: port_ip_proto(),
                      Module :: atom(),
-                     Opts :: [any()]) -> {'error', pid()} | {'ok',_}.
+                     Opts :: [any()]) -> {'error', pid()} | {'ok', _}.
 start_listener(Port, Module, Opts) ->
     case start_listener2(Port, Module, Opts) of
         {ok, _Pid} = R -> R;
@@ -378,7 +378,7 @@ start_listener2(Port, Module, Opts) ->
     start_listener_sup(Port, Module, Opts).
 
 -spec start_module_sup(_, Module :: module())
-      -> {'error',_} | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+      -> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start_module_sup(_PortIPProto, Module) ->
     Proc1 = gen_mod:get_module_proc("sup", Module),
     ChildSpec1 =
@@ -391,7 +391,7 @@ start_module_sup(_PortIPProto, Module) ->
     supervisor:start_child(ejabberd_sup, ChildSpec1).
 
 -spec start_listener_sup(port_ip_proto(), Module :: atom(), Opts :: [any()])
-      -> {'error',_} | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+      -> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start_listener_sup(PortIPProto, Module, Opts) ->
     case Module:socket_type() of
         independent ->
@@ -418,7 +418,7 @@ stop_listeners() ->
 
 -spec stop_listener(PortIPProto :: port_ip_proto(),
                     Module :: atom())
-      -> 'ok' | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+      -> 'ok' | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_listener(PortIPProto, Module) ->
     supervisor:terminate_child(ejabberd_listeners, PortIPProto),
     supervisor:delete_child(ejabberd_listeners, PortIPProto).
@@ -428,7 +428,7 @@ stop_listener(PortIPProto, Module) ->
 -spec add_listener(PortIPProto :: port_ip_proto(),
                    Module :: atom(),
                    Opts :: [listener_option()]
-                   ) -> 'ok' | {'error',_}.
+                   ) -> 'ok' | {'error', _}.
 add_listener(PortIPProto, Module, Opts) ->
     {Port, IPT, _, _, Proto, _} = parse_listener_portip(PortIPProto, Opts),
     PortIP1 = {Port, IPT, Proto},
@@ -450,14 +450,14 @@ add_listener(PortIPProto, Module, Opts) ->
 
 -spec delete_listener(PortIPProto :: port_ip_proto(),
                       Module :: atom())
-      -> 'ok' | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+      -> 'ok' | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 delete_listener(PortIPProto, Module) ->
     delete_listener(PortIPProto, Module, []).
 
 -spec delete_listener(PortIPProto :: port_ip_proto(),
                       Module :: atom(),
                       Opts :: [listener_option()])
-      -> 'ok' | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+      -> 'ok' | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 delete_listener(PortIPProto, Module, Opts) ->
 %%    this one stops a listener and deletes it from configuration, used while reloading config
     {Port, IPT, _, _, Proto, _} = parse_listener_portip(PortIPProto, Opts),
@@ -506,7 +506,7 @@ includes_deprecated_ssl_option(Opts) ->
             lists:member(ssl, Opts)
     end.
 
--spec certfile_readable([any()]) -> 'true' | {'false',string()}.
+-spec certfile_readable([any()]) -> 'true' | {'false', string()}.
 certfile_readable(Opts) ->
     case proplists:lookup(certfile, Opts) of
         none -> true;

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -79,10 +79,10 @@
 %% API
 %%====================================================================
 %%--------------------------------------------------------------------
-%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
+%% Function: start_link() -> {ok, Pid} | ignore | {error, Error}
 %% Description: Starts the server
 %%--------------------------------------------------------------------
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
@@ -90,7 +90,7 @@ start_link() ->
                  To :: ejabberd:jid(),
                  Packet :: jlib:xmlel()
                  ) -> 'nothing' | 'ok' | 'todo' | pid()
-                    | {'error','lager_not_running'} | {'process_iq',_,_,_}.
+                    | {'error', 'lager_not_running'} | {'process_iq', _, _, _}.
 process_iq(From, To, Packet) ->
     IQ = jlib:iq_query_info(Packet),
     case IQ of
@@ -141,7 +141,7 @@ process_iq_reply(From, To, #iq{id = ID} = IQ) ->
 
 -spec route(From :: ejabberd:jid(),
             To :: ejabberd:jid(),
-            Packet :: jlib:xmlel()) -> 'ok' | {'error','lager_not_running'}.
+            Packet :: jlib:xmlel()) -> 'ok' | {'error', 'lager_not_running'}.
 route(From, To, Packet) ->
     case (catch do_route(From, To, Packet)) of
         {'EXIT', Reason} ->
@@ -200,7 +200,7 @@ register_iq_response_handler(_Host, ID, Module, Function, Timeout0) ->
 -spec register_iq_handler(Host :: ejabberd:server(),
                           XMLNS :: binary(),
                           Module :: atom(),
-                          Function :: fun()) -> {register_iq_handler,_,_,_,_}.
+                          Function :: fun()) -> {register_iq_handler, _, _, _, _}.
 register_iq_handler(Host, XMLNS, Module, Fun) ->
     ejabberd_local ! {register_iq_handler, Host, XMLNS, Module, Fun}.
 
@@ -208,7 +208,7 @@ register_iq_handler(Host, XMLNS, Module, Fun) ->
                           XMLNS :: binary(),
                           Module :: atom(),
                           Function :: fun(),
-                          Opts :: [any()]) -> {register_iq_handler,_,_,_,_,_}.
+                          Opts :: [any()]) -> {register_iq_handler, _, _, _, _, _}.
 register_iq_handler(Host, XMLNS, Module, Fun, Opts) ->
     ejabberd_local ! {register_iq_handler, Host, XMLNS, Module, Fun, Opts}.
 
@@ -219,7 +219,7 @@ unregister_iq_response_handler(_Host, ID) ->
     ok.
 
 -spec unregister_iq_handler(Host :: ejabberd:server(),
-                           XMLNS :: binary()) -> {unregister_iq_handler,_,_}.
+                           XMLNS :: binary()) -> {unregister_iq_handler, _, _}.
 unregister_iq_handler(Host, XMLNS) ->
     ejabberd_local ! {unregister_iq_handler, Host, XMLNS}.
 
@@ -236,11 +236,11 @@ bounce_resource_packet(From, To, Packet) ->
 
 -spec register_host(Host :: ejabberd:server()) -> ok.
 register_host(Host) ->
-    gen_server:call(?MODULE,{register_host,Host}).
+    gen_server:call(?MODULE, {register_host, Host}).
 
 -spec unregister_host(Host :: ejabberd:server()) -> ok.
 unregister_host(Host) ->
-    gen_server:call(?MODULE,{unregister_host,Host}).
+    gen_server:call(?MODULE, {unregister_host, Host}).
 
 %%====================================================================
 %% API
@@ -413,7 +413,7 @@ do_route(From, To, Packet) ->
             end
         end.
 
--spec update_table() -> ok | {atomic|aborted,_}.
+-spec update_table() -> ok | {atomic|aborted, _}.
 update_table() ->
     case catch mnesia:table_info(iq_response, attributes) of
         [id, module, function] ->

--- a/apps/ejabberd/src/ejabberd_node_id.erl
+++ b/apps/ejabberd/src/ejabberd_node_id.erl
@@ -62,7 +62,7 @@ max_node_id() ->
     mnesia:foldl(fun(#node{id=Id}, Max) -> max(Id, Max) end, 0, node).
 
 -spec select_node_id(NodeName :: atom()
-                    ) -> {'error','not_found'} | {'ok',nodeid()}.
+                    ) -> {'error', 'not_found'} | {'ok', nodeid()}.
 select_node_id(NodeName) ->
     case mnesia:dirty_read(node, NodeName) of
         [#node{id=Id}] -> {ok, Id};

--- a/apps/ejabberd/src/ejabberd_odbc_sup.erl
+++ b/apps/ejabberd/src/ejabberd_odbc_sup.erl
@@ -50,7 +50,7 @@
                    pid :: pid()
                   }).
 
--spec start_link(binary() | string()) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(binary() | string()) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Host) ->
     mnesia:create_table(sql_pool,
                         [{ram_copies, [node()]},
@@ -66,7 +66,7 @@ start_link(Host) ->
                           ?MODULE, [Host]).
 
 -spec get_dedicated_connection(Host :: ejabberd:server())
-      -> 'ignore' | {'error',_} | {'ok',{Host :: atom(), pid()}}.
+      -> 'ignore' | {'error', _} | {'ok', {Host :: atom(), pid()}}.
 get_dedicated_connection(Host) ->
     StartInterval = start_interval(Host)*1000,
     case ejabberd_odbc:start_link(Host, StartInterval, true) of
@@ -76,7 +76,7 @@ get_dedicated_connection(Host) ->
             Other
     end.
 
--spec init([ejabberd:server(),...]) -> {'ok',{{_,_,_},[any()]}}.
+-spec init([ejabberd:server(), ...]) -> {'ok', {{_, _, _}, [any()]}}.
 init([Host]) ->
     PoolSize = pool_size(Host),
     StartInterval = start_interval(Host)*1000,

--- a/apps/ejabberd/src/ejabberd_rdbms.erl
+++ b/apps/ejabberd/src/ejabberd_rdbms.erl
@@ -30,12 +30,12 @@
 -export([start/0, start/1, stop/1, stop_odbc/1]).
 -include("ejabberd.hrl").
 
--spec start() -> 'ok' | {'error','lager_not_running'}.
+-spec start() -> 'ok' | {'error', 'lager_not_running'}.
 start() ->
     compile_odbc_type_helper(),
     %% Check if ejabberd has been compiled with ODBC
     case catch ejabberd_odbc_sup:module_info() of
-        {'EXIT',{undef,_}} ->
+        {'EXIT', {undef, _}} ->
             ?INFO_MSG("ejabberd has not been compiled with relational database support. Skipping database startup.", []);
         _ ->
             %% If compiled with ODBC, start ODBC on the needed host

--- a/apps/ejabberd/src/ejabberd_receiver.erl
+++ b/apps/ejabberd/src/ejabberd_receiver.erl
@@ -62,16 +62,16 @@
 %% API
 %%====================================================================
 %%--------------------------------------------------------------------
-%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
+%% Function: start_link() -> {ok, Pid} | ignore | {error, Error}
 %% Description: Starts the server
 %%--------------------------------------------------------------------
--spec start_link(_,_,_,_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(_, _, _, _) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Socket, SockMod, Shaper, MaxStanzaSize) ->
     gen_server:start_link(
       ?MODULE, [Socket, SockMod, Shaper, MaxStanzaSize], []).
 
 %%--------------------------------------------------------------------
-%% Function: start() -> {ok,Pid} | ignore | {error,Error}
+%% Function: start() -> {ok, Pid} | ignore | {error, Error}
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 start(Socket, SockMod, Shaper) ->
@@ -83,7 +83,7 @@ start(Socket, SockMod, Shaper, MaxStanzaSize) ->
                   [Socket, SockMod, Shaper, MaxStanzaSize]),
     Pid.
 
--spec change_shaper(atom() | pid() | {atom(),_} | {'via',_,_},_) -> 'ok'.
+-spec change_shaper(atom() | pid() | {atom(), _} | {'via', _, _}, _) -> 'ok'.
 change_shaper(Pid, Shaper) ->
     gen_server:cast(Pid, {change_shaper, Shaper}).
 
@@ -99,7 +99,7 @@ compress(Pid, ZlibSocket) ->
 become_controller(Pid, C2SPid) ->
     gen_server:call(Pid, {become_controller, C2SPid}).
 
--spec close(atom() | pid() | {atom(),_} | {'via',_,_}) -> 'ok'.
+-spec close(atom() | pid() | {atom(), _} | {'via', _, _}) -> 'ok'.
 close(Pid) ->
     gen_server:cast(Pid, close).
 
@@ -114,7 +114,7 @@ close(Pid) ->
 %%                         {stop, Reason}
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
--spec init([any(),...]) -> {'ok',state()}.
+-spec init([any(), ...]) -> {'ok', state()}.
 init([Socket, SockMod, Shaper, MaxStanzaSize]) ->
     ShaperState = shaper:new(Shaper),
     Timeout = case SockMod of
@@ -279,7 +279,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%--------------------------------------------------------------------
 
--spec activate_socket(state()) -> 'ok' | {'tcp_closed',_}.
+-spec activate_socket(state()) -> 'ok' | {'tcp_closed', _}.
 activate_socket(#state{socket = Socket,
                        sock_mod = SockMod}) ->
     PeerName =

--- a/apps/ejabberd/src/ejabberd_redis.erl
+++ b/apps/ejabberd/src/ejabberd_redis.erl
@@ -28,15 +28,15 @@ start_link(Opts) ->
                             transient, 2000, supervisor, [cuesport | ChildMods]}).
 
 -spec cmd(iolist()) -> undefined | binary()
-                | [binary() | [binary() | integer()] | integer() | {'error',_}]
+                | [binary() | [binary() | integer()] | integer() | {'error', _}]
                 | integer()
-                | {'error',_}.
+                | {'error', _}.
 cmd(Cmd) ->
     redo:cmd(cuesport:get_worker(?POOL_NAME), Cmd).
 
 -spec cmd(iolist(), integer()) -> undefined | binary()
-              | [binary() | [binary() | integer()] | integer() | {'error',_}]
+              | [binary() | [binary() | integer()] | integer() | {'error', _}]
               | integer()
-              | {'error',_}.
+              | {'error', _}.
 cmd(Cmd, Timeout) ->
     redo:cmd(cuesport:get_worker(?POOL_NAME), Cmd, Timeout).

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -62,7 +62,7 @@
 -record(state, {}).
 
 -type handler() :: undefined
-                 | {apply_fun,fun((_,_,_) -> any())}
+                 | {apply_fun, fun((_, _, _) -> any())}
                  | {apply, M::atom(), F::atom()}.
 -type domain() :: binary().
 
@@ -80,7 +80,7 @@
 %%--------------------------------------------------------------------
 
 
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -83,7 +83,7 @@
 %%--------------------------------------------------------------------
 %% Description: Starts the server
 %%--------------------------------------------------------------------
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
@@ -93,7 +93,7 @@ filter(From, To, Packet) ->
 route(From, To, Packet) ->
     do_route(From, To, Packet).
 
--spec remove_connection(_, pid()) -> 'ok' | {'aborted',_} | {'atomic',_}.
+-spec remove_connection(_, pid()) -> 'ok' | {'aborted', _} | {'atomic', _}.
 remove_connection(FromTo, Pid) ->
     case catch mnesia:dirty_match_object(s2s, #s2s{fromto = FromTo,
                                                    pid = Pid}) of
@@ -289,7 +289,7 @@ do_route(From, To, Packet) ->
     end.
 
 -spec find_connection(From :: ejabberd:jid(),
-                      To :: ejabberd:jid()) -> {'aborted',_} | {'atomic',_}.
+                      To :: ejabberd:jid()) -> {'aborted', _} | {'atomic', _}.
 find_connection(From, To) ->
     #jid{lserver = MyServer} = From,
     #jid{lserver = Server} = To,
@@ -373,7 +373,7 @@ choose_pid(From, Pids) ->
 -spec open_several_connections(N :: pos_integer(), MyServer :: ejabberd:server(),
     Server :: ejabberd:server(), From :: ejabberd:jid(), FromTo :: fromto(),
     MaxS2S :: pos_integer(), MaxS2SPerNode :: pos_integer())
-      -> {'aborted',_} | {'atomic',_}.
+      -> {'aborted', _} | {'atomic', _}.
 open_several_connections(N, MyServer, Server, From, FromTo,
                          MaxS2SConnectionsNumber,
                          MaxS2SConnectionsNumberPerNode) ->
@@ -390,7 +390,7 @@ open_several_connections(N, MyServer, Server, From, FromTo,
 
 -spec new_connection(MyServer :: ejabberd:server(), Server :: ejabberd:server(),
     From :: ejabberd:jid(), FromTo :: fromto(), MaxS2S :: pos_integer(),
-    MaxS2SPerNode :: pos_integer()) -> {'aborted',_} | {'atomic',_}.
+    MaxS2SPerNode :: pos_integer()) -> {'aborted', _} | {'atomic', _}.
 new_connection(MyServer, Server, From, FromTo,
                MaxS2SConnectionsNumber, MaxS2SConnectionsNumberPerNode) ->
     {ok, Pid} = ejabberd_s2s_out:start(
@@ -460,11 +460,11 @@ is_service(From, To) ->
             lists:any(P, parent_domains(To#jid.lserver))
     end.
 
--spec parent_domains(binary()) -> [binary(),...].
+-spec parent_domains(binary()) -> [binary(), ...].
 parent_domains(Domain) ->
     parent_domains(Domain, [Domain]).
 
--spec parent_domains(binary(),[binary(),...]) -> [binary(),...].
+-spec parent_domains(binary(), [binary(), ...]) -> [binary(), ...].
 parent_domains(<<>>, Acc) ->
     lists:reverse(Acc);
 parent_domains(<<$., Rest/binary>>, Acc) ->
@@ -492,7 +492,7 @@ domain_utf8_to_ascii(Domain) ->
 %%%----------------------------------------------------------------------
 %%% ejabberd commands
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
      #ejabberd_commands{name = incoming_s2s_number,
@@ -584,33 +584,33 @@ get_info_s2s_connections(Type) ->
                     out -> ejabberd_s2s_out_sup
                 end,
     Connections = supervisor:which_children(ChildType),
-    get_s2s_info(Connections,Type).
+    get_s2s_info(Connections, Type).
 
 -type connstate() :: 'restarting' | 'undefined' | pid().
 -type conn() :: { any(), connstate(), 'supervisor' | 'worker', 'dynamic' | [_] }.
 -spec get_s2s_info(Connections :: [conn()],
                   Type :: 'in' | 'out'
-                  ) -> [[{any(), any()},...]]. % list of lists
-get_s2s_info(Connections,Type)->
-    complete_s2s_info(Connections,Type,[]).
+                  ) -> [[{any(), any()}, ...]]. % list of lists
+get_s2s_info(Connections, Type)->
+    complete_s2s_info(Connections, Type, []).
 
 -spec complete_s2s_info(Connections :: [conn()],
                         Type :: 'in' | 'out',
-                        Result :: [[{any(), any()},...]] % list of lists
-                        ) -> [[{any(), any()},...]]. % list of lists
-complete_s2s_info([],_,Result)->
+                        Result :: [[{any(), any()}, ...]] % list of lists
+                        ) -> [[{any(), any()}, ...]]. % list of lists
+complete_s2s_info([], _, Result)->
     Result;
-complete_s2s_info([Connection|T],Type,Result)->
-    {_,PID,_,_}=Connection,
+complete_s2s_info([Connection|T], Type, Result)->
+    {_, PID, _, _}=Connection,
     State = get_s2s_state(PID),
-    complete_s2s_info(T,Type,[State|Result]).
+    complete_s2s_info(T, Type, [State|Result]).
 
--spec get_s2s_state(connstate()) -> [{atom(), any()},...].
+-spec get_s2s_state(connstate()) -> [{atom(), any()}, ...].
 get_s2s_state(S2sPid)->
-    Infos = case gen_fsm:sync_send_all_state_event(S2sPid,get_state_infos) of
+    Infos = case gen_fsm:sync_send_all_state_event(S2sPid, get_state_infos) of
                 {state_infos, Is} -> [{status, open} | Is];
-                {noproc,_} -> [{status, closed}]; %% Connection closed
-                {badrpc,_} -> [{status, error}]
+                {noproc, _} -> [{status, closed}]; %% Connection closed
+                {badrpc, _} -> [{status, error}]
             end,
     [{s2s_pid, S2sPid} | Infos].
 

--- a/apps/ejabberd/src/ejabberd_s2s_in.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_in.erl
@@ -62,7 +62,7 @@
                 tls_enabled = false   :: boolean(),
                 tls_required = false  :: boolean(),
                 tls_certverify = false :: boolean(),
-                tls_options = []      :: [{_,_}],
+                tls_options = []      :: [{_, _}],
                 server                :: ejabberd:server(),
                 authenticated = false :: boolean(),
                 auth_domain           :: binary(),
@@ -119,14 +119,14 @@
 %%%----------------------------------------------------------------------
 %%% API
 %%%----------------------------------------------------------------------
--spec start(_,_) -> {'error',_}
-                  | {'ok','undefined' | pid()}
-                  | {'ok','undefined' | pid(),_}.
+-spec start(_, _) -> {'error', _}
+                  | {'ok', 'undefined' | pid()}
+                  | {'ok', 'undefined' | pid(), _}.
 start(SockData, Opts) ->
     ?SUPERVISOR_START.
 
 
--spec start_link(_,_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(_, _) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(SockData, Opts) ->
     gen_fsm:start_link(ejabberd_s2s_in, [SockData, Opts], ?FSMOPTS).
 
@@ -145,7 +145,7 @@ socket_type() ->
 %%          ignore                              |
 %%          {stop, StopReason}
 %%----------------------------------------------------------------------
--spec init(_) -> {'ok','wait_for_stream',state()}.
+-spec init(_) -> {'ok', 'wait_for_stream', state()}.
 init([{SockMod, Socket}, Opts]) ->
     ?DEBUG("started: ~p", [{SockMod, Socket}]),
     Shaper = case lists:keysearch(shaper, 1, Opts) of
@@ -570,14 +570,14 @@ handle_event(_Event, StateName, StateData) ->
 %%   Reply = {state_infos, [{InfoName::atom(), InfoValue::any()]
 %%----------------------------------------------------------------------
 -spec handle_sync_event(any(), any(), statename(), state()
-                       ) -> {'reply','ok' | {'state_infos',[any(),...]}, atom(), state()}.
+                       ) -> {'reply', 'ok' | {'state_infos', [any(), ...]}, atom(), state()}.
 handle_sync_event(get_state_infos, _From, StateName, StateData) ->
     SockMod = StateData#state.sockmod,
-    {Addr,Port} = try SockMod:peername(StateData#state.socket) of
-                      {ok, {A,P}} ->  {A,P};
-                      {error, _} -> {unknown,unknown}
+    {Addr, Port} = try SockMod:peername(StateData#state.socket) of
+                      {ok, {A, P}} ->  {A, P};
+                      {error, _} -> {unknown, unknown}
                   catch
-                      _:_ -> {unknown,unknown}
+                      _:_ -> {unknown, unknown}
                   end,
     Domains =   case StateData#state.authenticated of
                     true ->
@@ -602,7 +602,7 @@ handle_sync_event(get_state_infos, _From, StateName, StateData) ->
              {domains, Domains}
             ],
     Reply = {state_infos, Infos},
-    {reply,Reply,StateName,StateData};
+    {reply, Reply, StateName, StateData};
 
 %%----------------------------------------------------------------------
 %% Func: handle_sync_event/4
@@ -627,7 +627,7 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%          {next_state, NextStateName, NextStateData, Timeout} |
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
--spec handle_info(_,_,_) -> {next_state, atom(), state()} | {stop, normal, state()}.
+-spec handle_info(_, _, _) -> {next_state, atom(), state()} | {stop, normal, state()}.
 handle_info({send_text, Text}, StateName, StateData) ->
     send_text(StateData, Text),
     {next_state, StateName, StateData};
@@ -685,8 +685,8 @@ cancel_timer(Timer) ->
     end.
 
 
--spec is_key_packet(jlib:xmlel()) -> 'false' | {'key',_,_,_,binary()}
-                                  | {'verify',_,_,_,binary()}.
+-spec is_key_packet(jlib:xmlel()) -> 'false' | {'key', _, _, _, binary()}
+                                  | {'verify', _, _, _, binary()}.
 is_key_packet(#xmlel{name = Name, attrs = Attrs,
                      children = Els}) when Name == <<"db:result">> ->
     {key,
@@ -803,7 +803,7 @@ match_domain(Domain, Pattern) ->
     match_labels(DLabels, PLabels).
 
 
--spec match_labels([binary()],[binary()]) -> boolean().
+-spec match_labels([binary()], [binary()]) -> boolean().
 match_labels([], []) ->
     true;
 match_labels([], [_ | _]) ->

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -144,12 +144,12 @@
 %%%----------------------------------------------------------------------
 %%% API
 %%%----------------------------------------------------------------------
--spec start(_,_,_) -> {'error',_} | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+-spec start(_, _, _) -> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(From, Host, Type) ->
     ?SUPERVISOR_START.
 
 
--spec start_link(_,_,_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(_, _, _) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(From, Host, Type) ->
     p1_fsm:start_link(ejabberd_s2s_out, [From, Host, Type],
                       fsm_limit_opts() ++ ?FSMOPTS).
@@ -173,7 +173,7 @@ stop_connection(Pid) ->
 %%          ignore                              |
 %%          {stop, StopReason}
 %%----------------------------------------------------------------------
--spec init([any(),...]) -> {'ok','open_socket',state()}.
+-spec init([any(), ...]) -> {'ok', 'open_socket', state()}.
 init([From, Server, Type]) ->
     process_flag(trap_exit, true),
     ?DEBUG("started: ~p", [{From, Server, Type}]),
@@ -294,11 +294,11 @@ open_socket(_, StateData) ->
 %%----------------------------------------------------------------------
 %% IPv4
 -spec open_socket1(Host :: binary() | inet:ip_address(),
-                   Port :: inet:port_number()) -> {'error',_} | {'ok',_}.
-open_socket1({_,_,_,_} = Addr, Port) ->
+                   Port :: inet:port_number()) -> {'error', _} | {'ok', _}.
+open_socket1({_, _, _, _} = Addr, Port) ->
     open_socket2(inet, Addr, Port);
 %% IPv6
-open_socket1({_,_,_,_,_,_,_,_} = Addr, Port) ->
+open_socket1({_, _, _, _, _, _, _, _} = Addr, Port) ->
     open_socket2(inet6, Addr, Port);
 %% Hostname
 open_socket1(Host, Port) ->
@@ -316,7 +316,7 @@ open_socket1(Host, Port) ->
 
 -spec open_socket2(Type :: 'inet' | 'inet6',
                    Addr :: inet:ip_address(),
-                   Port :: inet:port_number()) -> {'error',_} | {'ok',_}.
+                   Port :: inet:port_number()) -> {'error', _} | {'ok', _}.
 open_socket2(Type, Addr, Port) ->
     ?DEBUG("s2s_out: connecting to ~p:~p~n", [Addr, Port]),
     Timeout = outgoing_s2s_timeout(),
@@ -371,7 +371,7 @@ wait_for_stream({xmlstreamerror, _}, StateData) ->
     ?INFO_MSG("Closing s2s connection: ~s -> ~s (invalid xml)",
               [StateData#state.myname, StateData#state.server]),
     {stop, normal, StateData};
-wait_for_stream({xmlstreamend,_Name}, StateData) ->
+wait_for_stream({xmlstreamend, _Name}, StateData) ->
     ?INFO_MSG("Closing s2s connection: ~s -> ~s (xmlstreamend)",
               [StateData#state.myname, StateData#state.server]),
     {stop, normal, StateData};
@@ -821,12 +821,12 @@ handle_event(_Event, StateName, StateData) ->
 %%   Reply = {state_infos, [{InfoName::atom(), InfoValue::any()]
 %%----------------------------------------------------------------------
 handle_sync_event(get_state_infos, _From, StateName, StateData) ->
-    {Addr,Port} = try ejabberd_socket:peername(StateData#state.socket) of
-                      {ok, {A,P}} ->  {A,P};
-                      {error, _} -> {unknown,unknown}
+    {Addr, Port} = try ejabberd_socket:peername(StateData#state.socket) of
+                      {ok, {A, P}} ->  {A, P};
+                      {error, _} -> {unknown, unknown}
                   catch
                       _:_ ->
-                          {unknown,unknown}
+                          {unknown, unknown}
                   end,
     Infos = [
              {direction, out},
@@ -848,7 +848,7 @@ handle_sync_event(get_state_infos, _From, StateName, StateData) ->
              {verify, StateData#state.verify}
             ],
     Reply = {state_infos, Infos},
-    {reply,Reply,StateName,StateData};
+    {reply, Reply, StateName, StateData};
 
 %%----------------------------------------------------------------------
 %% Func: handle_sync_event/4
@@ -1078,7 +1078,7 @@ send_db_request(StateData) ->
     end.
 
 
--spec is_verify_res(jlib:xmlel()) -> 'false' | {'result',_,_,_,_} | {'verify',_,_,_,_}.
+-spec is_verify_res(jlib:xmlel()) -> 'false' | {'result', _, _, _, _} | {'verify', _, _, _, _}.
 is_verify_res(#xmlel{name = Name,
                      attrs = Attrs}) when Name == <<"db:result">> ->
     {result,
@@ -1135,7 +1135,7 @@ get_addr_port(Server) ->
     end.
 
 
--spec srv_lookup(ejabberd:server()) -> {'error',atom()} | {'ok', inet:hostent()}.
+-spec srv_lookup(ejabberd:server()) -> {'error', atom()} | {'ok', inet:hostent()}.
 srv_lookup(Server) ->
     Options = case ejabberd_config:get_local_option(s2s_dns_options) of
                   L when is_list(L) -> L;
@@ -1153,7 +1153,7 @@ srv_lookup(Server) ->
 -spec srv_lookup(ejabberd:server(),
                  Timeout :: non_neg_integer(),
                  Retries :: pos_integer()
-                 ) -> {'error',atom()} | {'ok', inet:hostent()}.
+                 ) -> {'error', atom()} | {'ok', inet:hostent()}.
 srv_lookup(_Server, _Timeout, Retries) when Retries < 1 ->
     {error, timeout};
 srv_lookup(Server, Timeout, Retries) ->
@@ -1217,7 +1217,7 @@ outgoing_s2s_port() ->
     end.
 
 
--spec outgoing_s2s_families() -> ['ipv4' | 'ipv6',...].
+-spec outgoing_s2s_families() -> ['ipv4' | 'ipv6', ...].
 outgoing_s2s_families() ->
     case ejabberd_config:get_local_option(outgoing_s2s_options) of
         {Families, _} when is_list(Families) ->
@@ -1323,7 +1323,7 @@ terminate_if_waiting_delay(From, To) ->
       Pids).
 
 
--spec fsm_limit_opts() -> [{'max_queue',integer()}].
+-spec fsm_limit_opts() -> [{'max_queue', integer()}].
 fsm_limit_opts() ->
     case ejabberd_config:get_local_option(max_fsm_queue) of
         N when is_integer(N) ->
@@ -1339,12 +1339,12 @@ get_predefined_addresses(Server) ->
     case ejabberd_config:get_local_option({s2s_addr, Server}) of
         undefined ->
             [];
-        {{_,_,_,_}, Port} = IP4Port when is_integer(Port) ->
+        {{_, _, _, _}, Port} = IP4Port when is_integer(Port) ->
             [IP4Port];
-        {{_,_,_,_,_,_,_,_}, Port} = IP6Port when is_integer(Port) ->
+        {{_, _, _, _, _, _, _, _}, Port} = IP6Port when is_integer(Port) ->
             [IP6Port];
-        {_,_,_,_} = IP4 ->
+        {_, _, _, _} = IP4 ->
             [{IP4, outgoing_s2s_port()}];
-        {_,_,_,_,_,_,_,_} = IP6 ->
+        {_, _, _, _, _, _, _, _} = IP6 ->
             [{IP6, outgoing_s2s_port()}]
     end.

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -115,12 +115,12 @@
 %%%----------------------------------------------------------------------
 %%% API
 %%%----------------------------------------------------------------------
--spec start(_,_) -> {'error',_} | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+-spec start(_, _) -> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(SockData, Opts) ->
     supervisor:start_child(ejabberd_service_sup, [SockData, Opts]).
 
 
--spec start_link(_, list()) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(_, list()) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(SockData, Opts) ->
     ?GEN_FSM:start_link(ejabberd_service, [SockData, Opts],
                         fsm_limit_opts(Opts) ++ ?FSMOPTS).
@@ -140,7 +140,7 @@ socket_type() ->
 %%          ignore                              |
 %%          {stop, StopReason}
 %%----------------------------------------------------------------------
--spec init([list() | {atom() | tuple(),_},...]) -> {'ok','wait_for_stream',state()}.
+-spec init([list() | {atom() | tuple(), _}, ...]) -> {'ok', 'wait_for_stream', state()}.
 init([{SockMod, Socket}, Opts]) ->
     ?INFO_MSG("(~w) External service connected", [Socket]),
     Access = case lists:keysearch(access, 1, Opts) of
@@ -199,8 +199,8 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
 wait_for_stream({xmlstreamerror, _}, StateData) ->
     Header = io_lib:format(?STREAM_HEADER,
                            [<<"none">>, ?MYNAME]),
-    send_text(StateData,<<(iolist_to_binary(Header))/binary,
-                           (?INVALID_XML_ERR)/binary,(?STREAM_TRAILER)/binary>>),
+    send_text(StateData, <<(iolist_to_binary(Header))/binary,
+                           (?INVALID_XML_ERR)/binary, (?STREAM_TRAILER)/binary>>),
     {stop, normal, StateData};
 wait_for_stream(closed, StateData) ->
     {stop, normal, StateData}.
@@ -233,7 +233,7 @@ wait_for_handshake({xmlstreamelement, El}, StateData) ->
 wait_for_handshake({xmlstreamend, _Name}, StateData) ->
     {stop, normal, StateData};
 wait_for_handshake({xmlstreamerror, _}, StateData) ->
-    send_text(StateData,<<(?INVALID_XML_ERR)/binary,(?STREAM_TRAILER)/binary>>),
+    send_text(StateData, <<(?INVALID_XML_ERR)/binary, (?STREAM_TRAILER)/binary>>),
     {stop, normal, StateData};
 wait_for_handshake(closed, StateData) ->
     {stop, normal, StateData}.
@@ -282,7 +282,7 @@ stream_established({xmlstreamend, _Name}, StateData) ->
     % TODO ??
     {stop, normal, StateData};
 stream_established({xmlstreamerror, _}, StateData) ->
-    send_text(StateData, <<(?INVALID_XML_ERR)/binary,(?STREAM_TRAILER)/binary>>),
+    send_text(StateData, <<(?INVALID_XML_ERR)/binary, (?STREAM_TRAILER)/binary>>),
     {stop, normal, StateData};
 stream_established(closed, StateData) ->
     % TODO ??
@@ -343,7 +343,7 @@ handle_info({send_element, El}, StateName, StateData) ->
 handle_info({route, From, To, Packet}, StateName, StateData) ->
     case acl:match_rule(global, StateData#state.access, From) of
         allow ->
-           #xmlel{name =Name, attrs = Attrs,children = Els} = Packet,
+           #xmlel{name =Name, attrs = Attrs, children = Els} = Packet,
            Attrs2 = jlib:replace_from_to_attrs(jid:to_binary(From),
                                                jid:to_binary(To),
                                                Attrs),
@@ -405,7 +405,7 @@ new_id() ->
     randoms:get_string().
 
 
--spec fsm_limit_opts(maybe_improper_list()) -> [{'max_queue',integer()}].
+-spec fsm_limit_opts(maybe_improper_list()) -> [{'max_queue', integer()}].
 fsm_limit_opts(Opts) ->
     case lists:keysearch(max_fsm_queue, 1, Opts) of
         {value, {_, N}} when is_integer(N) ->

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -113,10 +113,10 @@
 %% API
 %%====================================================================
 %%--------------------------------------------------------------------
-%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
+%% Function: start_link() -> {ok, Pid} | ignore | {error, Error}
 %% Description: Starts the server
 %%--------------------------------------------------------------------
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     mongoose_metrics:ensure_metric(global, ?UNIQUE_COUNT_CACHE, gauge),
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -470,7 +470,7 @@ handle_cast(_Msg, State) ->
 %%                                       {stop, Reason, State}
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
--spec handle_info(_,_) -> {'noreply',_}.
+-spec handle_info(_, _) -> {'noreply', _}.
 handle_info({route, From, To, Packet}, State) ->
     route(From, To, Packet),
     {noreply, State};
@@ -499,7 +499,7 @@ handle_info(_Info, State) ->
 %% cleaning up. When it returns, the gen_server terminates with Reason.
 %% The return value is ignored.
 %%--------------------------------------------------------------------
--spec terminate(_,state()) -> 'ok'.
+-spec terminate(_, state()) -> 'ok'.
 terminate(_Reason, _State) ->
     ejabberd_commands:unregister_commands(commands()),
     ok.
@@ -545,7 +545,7 @@ do_filter(From, To, Packet) ->
       To :: ejabberd:jid(),
       Packet :: jlib:xmlel() | ejabberd_c2s:broadcast().
 do_route(From, To, {broadcast, _} = Broadcast) ->
-    ?DEBUG("from=~p,to=~p,broadcast=~p", [From, To, Broadcast]),
+    ?DEBUG("from=~p, to=~p, broadcast=~p", [From, To, Broadcast]),
     #jid{ luser = LUser, lserver = LServer, lresource = LResource} = To,
     case LResource of
         <<>> ->
@@ -593,7 +593,7 @@ do_route(From, To, Packet) ->
       Packet :: jlib:xmlel(),
       Type :: 'subscribe' | 'subscribed' | 'unsubscribe' | 'unsubscribed',
       Reason :: any().
-do_route_no_resource_presence_prv(From,To,Packet,Type,Reason) ->
+do_route_no_resource_presence_prv(From, To, Packet, Type, Reason) ->
     is_privacy_allow(From, To, Packet) andalso ejabberd_hooks:run_fold(
         roster_in_subscription,
         To#jid.lserver,
@@ -726,7 +726,7 @@ is_privacy_allow(From, To, Packet, PrivacyList) ->
 route_message(From, To, Packet) ->
     LUser = To#jid.luser,
     LServer = To#jid.lserver,
-    PrioPid = get_user_present_pids(LUser,LServer),
+    PrioPid = get_user_present_pids(LUser, LServer),
     case catch lists:max(PrioPid) of
         {Priority, _} when is_integer(Priority), Priority >= 0 ->
             lists:foreach(
@@ -778,7 +778,7 @@ clean_session_list(Ss) ->
     clean_session_list(lists:keysort(#session.usr, Ss), []).
 
 
--spec clean_session_list([sid()],[sid()]) -> [sid()].
+-spec clean_session_list([sid()], [sid()]) -> [sid()].
 clean_session_list([], Res) ->
     Res;
 clean_session_list([S], Res) ->
@@ -804,7 +804,7 @@ clean_session_list([S1, S2 | Rest], Res) ->
       LServer :: ejabberd:lserver().
 get_user_present_pids(LUser, LServer) ->
     Ss = clean_session_list(?SM_BACKEND:get_sessions(LUser, LServer)),
-    [{S#session.priority, element(2,S#session.sid)} || S <- Ss, is_integer(S#session.priority)].
+    [{S#session.priority, element(2, S#session.sid)} || S <- Ss, is_integer(S#session.priority)].
 
 -spec get_user_present_resources(LUser :: ejabberd:user(),
                                  LServer :: ejabberd:server()

--- a/apps/ejabberd/src/ejabberd_sm_backend_sup.erl
+++ b/apps/ejabberd/src/ejabberd_sm_backend_sup.erl
@@ -39,7 +39,7 @@ start_link() ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% Whenever a supervisor is started using supervisor:start_link/[2,3],
+%% Whenever a supervisor is started using supervisor:start_link/[2, 3],
 %% this function is called by the new process to find out about
 %% restart strategy, maximum restart frequency and child
 %% specifications.

--- a/apps/ejabberd/src/ejabberd_sm_redis.erl
+++ b/apps/ejabberd/src/ejabberd_sm_redis.erl
@@ -83,7 +83,7 @@ create_session(User, Server, Resource, Session) ->
     OldSessions = get_sessions(User, Server, Resource),
     case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
         {value, OldSession} ->
-            MergedInfoSession = mongoose_session:merge_info(Session,OldSession),
+            MergedInfoSession = mongoose_session:merge_info(Session, OldSession),
             BOldSession = term_to_binary(OldSession),
             BSession = term_to_binary(MergedInfoSession),
             error_or_ok(

--- a/apps/ejabberd/src/ejabberd_socket.erl
+++ b/apps/ejabberd/src/ejabberd_socket.erl
@@ -61,7 +61,7 @@
 %% Description:
 %%--------------------------------------------------------------------
 -spec start(atom() | tuple(), ejabberd:sockmod(),
-    Socket :: port(), Opts :: [{atom(),_}]) -> ok.
+    Socket :: port(), Opts :: [{atom(), _}]) -> ok.
 start(Module, SockMod, Socket, Opts) ->
     case Module:socket_type() of
         xml_stream ->
@@ -122,10 +122,10 @@ start(Module, SockMod, Socket, Opts) ->
                       | integer() | inet:ip_address().
 -type option() :: 'binary' | 'inet' | 'inet6' | 'list'
                 | {atom(), option_value()}
-                | {'raw',non_neg_integer(),non_neg_integer(),binary()}.
+                | {'raw', non_neg_integer(), non_neg_integer(), binary()}.
 -spec connect(Addr :: atom() | string() | inet:ip_address(),
               Port :: inet:port_number(),
-              Opts :: [option()]) -> {'error',atom()} | {'ok',socket_state()}.
+              Opts :: [option()]) -> {'error', atom()} | {'ok', socket_state()}.
 connect(Addr, Port, Opts) ->
     connect(Addr, Port, Opts, infinity).
 
@@ -134,7 +134,7 @@ connect(Addr, Port, Opts) ->
               Port :: inet:port_number(),
               Opts :: [option()],
               Timeout :: non_neg_integer() | infinity
-              ) -> {'error',atom()} | {'ok',socket_state()}.
+              ) -> {'error', atom()} | {'ok', socket_state()}.
 connect(Addr, Port, Opts, Timeout) ->
     case gen_tcp:connect(Addr, Port, Opts, Timeout) of
         {ok, Socket} ->
@@ -195,10 +195,10 @@ send(SocketData, Data) ->
              SocketData#socket_state.socket, Data) of
         ok -> ok;
         {error, timeout} ->
-            ?INFO_MSG("Timeout on ~p:send",[SocketData#socket_state.sockmod]),
+            ?INFO_MSG("Timeout on ~p:send", [SocketData#socket_state.sockmod]),
             exit(normal);
         Error ->
-            ?DEBUG("Error in ~p:send: ~p",[SocketData#socket_state.sockmod, Error]),
+            ?DEBUG("Error in ~p:send: ~p", [SocketData#socket_state.sockmod, Error]),
             exit(normal)
     end.
 
@@ -212,7 +212,7 @@ send_xml(SocketData, Data) ->
             SocketData#socket_state.socket, Data).
 
 
--spec change_shaper(#socket_state{receiver::atom() | pid() | tuple()},_) -> any().
+-spec change_shaper(#socket_state{receiver::atom() | pid() | tuple()}, _) -> any().
 change_shaper(SocketData, Shaper)
   when is_pid(SocketData#socket_state.receiver) ->
     ejabberd_receiver:change_shaper(SocketData#socket_state.receiver, Shaper);

--- a/apps/ejabberd/src/ejabberd_users.erl
+++ b/apps/ejabberd/src/ejabberd_users.erl
@@ -63,7 +63,7 @@ stop(Host) ->
 
 -spec start_link(ProcName :: atom(),
                  Host :: ejabberd:server())
-      -> 'ignore' | {'error',_} | {'ok',pid()}.
+      -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(ProcName, Host) ->
     gen_server:start_link({local, ProcName}, ?MODULE, [Host], []).
 
@@ -104,7 +104,7 @@ remove_user(LUser, LServer) ->
 %%                         {stop, Reason}
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
--spec init([ejabberd:server() | string(),...]) -> {'ok',#state{}}.
+-spec init([ejabberd:server() | string(), ...]) -> {'ok', #state{}}.
 init([Host]) ->
     Tab = tbl_name(Host),
     TabOpts = [named_table, public, set,

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -81,7 +81,7 @@ recv_data2(ZlibSock, Packet) ->
             Res
     end.
 
--spec recv_data1(zlibsock(), iolist()) -> {'error',string()} | {'ok',binary()}.
+-spec recv_data1(zlibsock(), iolist()) -> {'error', string()} | {'ok', binary()}.
 recv_data1(#zlibsock{zlibport = Port, inflate_size_limit = SizeLimit} = _ZlibSock, Packet) ->
     case port_control(Port, SizeLimit bsl 2 + ?INFLATE, Packet) of
 	<<0, In/binary>> ->

--- a/apps/ejabberd/src/eldap.erl
+++ b/apps/ejabberd/src/eldap.erl
@@ -123,15 +123,15 @@
 
 -type statename() :: 'active' | 'active_bind' | 'connecting'.
 -type fsm_return() :: {'next_state', statename(), _}
-                    | {'stop','normal',_}.
+                    | {'stop', 'normal', _}.
 
--type eldap_cmd() :: {'delete',_}
+-type eldap_cmd() :: {'delete', _}
                    | {'search', eldap_search()}
-                   | {'add',_,_}
-                   | {'bind',_,_}
-                   | {'modify',_,_}
-                   | {'modify_passwd',_,_}
-                   | {'modify_dn',_,_,_,_}.
+                   | {'add', _, _}
+                   | {'bind', _, _}
+                   | {'modify', _, _}
+                   | {'modify_passwd', _, _}
+                   | {'modify_dn', _, _, _, _}.
 
 -type eldap_req_tag() :: 'addRequest' | 'bindRequest' | 'delRequest'
                        | 'extendedReq' | 'modDNRequest' | 'modifyRequest'
@@ -170,16 +170,16 @@
 %%% API
 %%%----------------------------------------------------------------------
 
--spec start_link(binary()) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(binary()) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Name) ->
-    Reg_name = binary_to_atom(<<"eldap_",Name/binary>>,utf8),
+    Reg_name = binary_to_atom(<<"eldap_", Name/binary>>, utf8),
     gen_fsm:start_link({local, Reg_name}, ?MODULE, [], []).
 
 
 -spec start_link(binary(), [binary()], inet:port_number(), binary(),
                  binary(), tlsopts()) -> any().
 start_link(Name, Hosts, Port, Rootdn, Passwd, Opts) ->
-    Reg_name = binary_to_atom(<<"eldap_",Name/binary>>,utf8),
+    Reg_name = binary_to_atom(<<"eldap_", Name/binary>>, utf8),
     gen_fsm:start_link({local, Reg_name}, ?MODULE,
                        [Hosts, Port, Rootdn, Passwd, Opts], []).
 
@@ -283,7 +283,7 @@ mod_replace(Type, Values) ->
     m(replace, Type, Values).
 
 
--spec m('add' | 'delete' | 'replace',_,_) -> #'ModifyRequest_modification_SEQOF'{}.
+-spec m('add' | 'delete' | 'replace', _, _) -> #'ModifyRequest_modification_SEQOF'{}.
 m(Operation, Type, Values) ->
     #'ModifyRequest_modification_SEQOF'{operation =
                                             Operation,
@@ -345,22 +345,22 @@ optional(Value) -> Value.
 %%%
 %%%  Example:
 %%%
-%%%     Filter = eldap:substrings("sn", [{any,"o"}]),
+%%%     Filter = eldap:substrings("sn", [{any, "o"}]),
 %%%     eldap:search(S, [{base, "dc=bluetail, dc=com"},
 %%%                      {filter, Filter},
-%%%                      {attributes,["cn"]}])),
+%%%                      {attributes, ["cn"]}])),
 %%%
 %%% Returned result:  {ok, #eldap_search_result{}}
 %%%
 %%% Example:
 %%%
-%%%  {ok,{eldap_search_result,
+%%%  {ok, {eldap_search_result,
 %%%        [{eldap_entry,
 %%%           "cn=Magnus Froberg, dc=bluetail, dc=com",
-%%%           [{"cn",["Magnus Froberg"]}]},
+%%%           [{"cn", ["Magnus Froberg"]}]},
 %%%         {eldap_entry,
 %%%           "cn=Torbjorn Tornkvist, dc=bluetail, dc=com",
-%%%           [{"cn",["Torbjorn Tornkvist"]}]}],
+%%%           [{"cn", ["Torbjorn Tornkvist"]}]}],
 %%%        []}}
 %%%
 %%% --------------------------------------------------------------------
@@ -451,7 +451,7 @@ wholeSubtree() -> wholeSubtree.
 
 %%%
 %%% The following Filter parameters consist of an attribute
-%%% and an attribute value. Example: F("uid","tobbe")
+%%% and an attribute value. Example: F("uid", "tobbe")
 %%%
 -type 'and'() :: {'and', [filter()]}.
 -spec 'and'([filter()]) -> 'and'().
@@ -520,9 +520,9 @@ av_assert(Desc, Value) ->
 %%% to substrings/2 looks like this:
 %%%
 %%% Type   ::= string( <attribute> )
-%%% SubStr ::= listof( {initial,Value} | {any,Value}, {final,Value})
+%%% SubStr ::= listof( {initial, Value} | {any, Value}, {final, Value})
 %%%
-%%% Example: substrings("sn",[{initial,"To"},{any,"kv"},{final,"st"}])
+%%% Example: substrings("sn", [{initial, "To"}, {any, "kv"}, {final, "st"}])
 %%% will match entries containing:  'sn: Tornkvist'
 %%%
 present(Attribute) ->
@@ -582,7 +582,7 @@ extensibleMatch_opts([], MRA) -> MRA.
 get_handle(Pid) when is_pid(Pid) -> Pid;
 get_handle(Atom) when is_atom(Atom) -> Atom;
 get_handle(Name) when is_binary(Name) ->
-    binary_to_atom(<<"eldap_",Name/binary>>,utf8).
+    binary_to_atom(<<"eldap_", Name/binary>>, utf8).
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm
@@ -664,7 +664,7 @@ init([Hosts, Port, Rootdn, Passwd, Opts]) ->
 
 %%----------------------------------------------------------------------
 %% Func: StateName/2
-%% Called when gen_fsm:send_event/2,3 is invoked (async)
+%% Called when gen_fsm:send_event/2, 3 is invoked (async)
 %% Returns: {next_state, NextStateName, NextStateData}          |
 %%          {next_state, NextStateName, NextStateData, Timeout} |
 %%          {stop, Reason, NewStateData}
@@ -675,7 +675,7 @@ connecting(timeout, S) ->
 
 %%----------------------------------------------------------------------
 %% Func: StateName/3
-%% Called when gen_fsm:sync_send_event/2,3 is invoked.
+%% Called when gen_fsm:sync_send_event/2, 3 is invoked.
 %% Returns: {next_state, NextStateName, NextStateData}            |
 %%          {next_state, NextStateName, NextStateData, Timeout}   |
 %%          {reply, Reply, NextStateName, NextStateData}          |
@@ -713,7 +713,7 @@ handle_event(_Event, StateName, S) ->
 
 %%----------------------------------------------------------------------
 %% Func: handle_sync_event/4
-%% Called when gen_fsm:sync_send_all_state_event/2,3 is invoked
+%% Called when gen_fsm:sync_send_all_state_event/2, 3 is invoked
 %% Returns: {next_state, NextStateName, NextStateData}            |
 %%          {next_state, NextStateName, NextStateData, Timeout}   |
 %%          {reply, Reply, NextStateName, NextStateData}          |
@@ -1017,7 +1017,7 @@ check_bind_reply(Other, _From) -> {error, Other}.
 
 %% @doc TODO: process reply depending on requestName:
 %% this requires BER-decoding of #'ExtendedResponse'.response
--spec check_extended_reply(_,_) -> 'ok' | {'error',_}.
+-spec check_extended_reply(_, _) -> 'ok' | {'error', _}.
 check_extended_reply(#'ExtendedResponse'{resultCode = success}, _From) ->
   ok;
 check_extended_reply(#'ExtendedResponse'{resultCode = Reason}, _From) ->
@@ -1026,7 +1026,7 @@ check_extended_reply(Other, _From) ->
   {error, Other}.
 
 
--spec get_op_rec(_, dict:dict(non_neg_integer(), [tuple()])) -> {_,_,_,_}.
+-spec get_op_rec(_, dict:dict(non_neg_integer(), [tuple()])) -> {_, _, _, _}.
 get_op_rec(Id, Dict) ->
     case dict:find(Id, Dict) of
       {ok, [{Timer, _Command, From, Name} | Res]} ->
@@ -1043,7 +1043,7 @@ get_op_rec(Id, Dict) ->
 %%  {error, Reason}
 %%  {'EXIT', Reason} - Broken packet
 %%-----------------------------------------------------------------------
--spec recvd_wait_bind_response(binary(), eldap()) -> 'bound' | {'fail_bind',_}.
+-spec recvd_wait_bind_response(binary(), eldap()) -> 'bound' | {'fail_bind', _}.
 recvd_wait_bind_response(Pkt, S) ->
     case 'ELDAPv3':decode('LDAPMessage', Pkt) of
       {ok, Msg} ->
@@ -1060,7 +1060,7 @@ recvd_wait_bind_response(Pkt, S) ->
     end.
 
 
--spec check_id(non_neg_integer(),non_neg_integer()) -> 'ok' | none().
+-spec check_id(non_neg_integer(), non_neg_integer()) -> 'ok' | none().
 check_id(Id, Id) -> ok;
 check_id(_, _) -> throw({error, wrong_bind_id}).
 
@@ -1103,10 +1103,10 @@ report_bind_failure(Host, Port, Reason) ->
 %% Sort out timed out commands
 %%-----------------------------------------------------------------------
 -spec cmd_timeout(reference(), _, eldap()
-                  ) -> {'error','timed_out_cmd_not_in_dict'}
+                  ) -> {'error', 'timed_out_cmd_not_in_dict'}
                      | {'reply',
                         any(),
-                        {'error','timeout'} | {'timeout', #eldap_search_result{}},
+                        {'error', 'timeout'} | {'timeout', #eldap_search_result{}},
                         eldap()}.
 cmd_timeout(Timer, Id, S) ->
     Dict = S#eldap.dict,
@@ -1144,7 +1144,7 @@ str_to_bin(L) ->
 polish(Entries) -> polish(Entries, [], []).
 
 
--spec polish([any()], Res :: [eldap_entry()], Ref :: [any()]) -> {[{_,_,_}],[any()]}.
+-spec polish([any()], Res :: [eldap_entry()], Ref :: [any()]) -> {[{_, _, _}], [any()]}.
 polish([H | T], Res, Ref)
     when is_record(H, 'SearchResultEntry') ->
     ObjectName = H#'SearchResultEntry'.objectName,
@@ -1163,7 +1163,7 @@ polish([], Res, Ref) -> {Res, Ref}.
 %%-----------------------------------------------------------------------
 %% Connect to next server in list and attempt to bind to it.
 %%-----------------------------------------------------------------------
--spec connect_bind(eldap()) -> {'ok','connecting' | 'wait_bind_response',eldap()}.
+-spec connect_bind(eldap()) -> {'ok', 'connecting' | 'wait_bind_response', eldap()}.
 connect_bind(S) ->
     Host = next_host(S#eldap.host, S#eldap.hosts),
     ?INFO_MSG("LDAP connection on ~s:~p",
@@ -1208,7 +1208,7 @@ connect_bind(S) ->
     end.
 
 
--spec bind_request(port() | {'sslsocket',_,_}, eldap()) -> any().
+-spec bind_request(port() | {'sslsocket', _, _}, eldap()) -> any().
 bind_request(Socket, S) ->
     Id = bump_id(S),
     Req = #'BindRequest'{version = S#eldap.version,
@@ -1225,7 +1225,7 @@ bind_request(Socket, S) ->
 
 
 %% @doc Given last tried Server, find next one to try
--spec next_host('undefined' | binary(),[binary()]) -> binary().
+-spec next_host('undefined' | binary(), [binary()]) -> binary().
 next_host(undefined, [H | _]) ->
     H;                    % First time, take first
 next_host(Host,
@@ -1251,7 +1251,7 @@ next_host(Host,
 %%% Other Stuff
 %%% --------------------------------------------------------------------
 
--spec next_host('undefined' | binary(),[binary()],[binary()]) -> binary().
+-spec next_host('undefined' | binary(), [binary()], [binary()]) -> binary().
 next_host(Host, [Host], Hosts) ->
     hd(Hosts);    % Wrap back to first
 next_host(Host, [Host | Tail], _Hosts) ->

--- a/apps/ejabberd/src/eldap_filter.erl
+++ b/apps/ejabberd/src/eldap_filter.erl
@@ -45,8 +45,8 @@
 %%% Example:
 %%%   > eldap_filter:parse("(&(!(uid<=100))(mail=*))").
 %%%
-%%%   {ok,{'and',[{'not',{lessOrEqual,{'AttributeValueAssertion',"uid","100"}}},
-%%%           {present,"mail"}]}}
+%%%   {ok, {'and', [{'not', {lessOrEqual, {'AttributeValueAssertion', "uid", "100"}}},
+%%%           {present, "mail"}]}}
 %%%-------------------------------------------------------------------
 -spec parse(binary()) -> {error, any()} | {ok, eldap:filter()}.
 parse(L) ->
@@ -70,12 +70,12 @@ parse(L) ->
 %%% Example:
 %%%    > eldap_filter:parse(
 %%%            "(|(mail=%u@%d)(jid=%u@%d))",
-%%%            [{"%u", "xramtsov"},{"%d","gmail.com"}]).
+%%%            [{"%u", "xramtsov"}, {"%d", "gmail.com"}]).
 %%%
-%%%    {ok,{'or',[{equalityMatch,{'AttributeValueAssertion',
+%%%    {ok, {'or', [{equalityMatch, {'AttributeValueAssertion',
 %%%                              "mail",
 %%%                              "xramtsov@gmail.com"}},
-%%%           {equalityMatch,{'AttributeValueAssertion',
+%%%           {equalityMatch, {'AttributeValueAssertion',
 %%%                              "jid",
 %%%                              "xramtsov@gmail.com"}}]}}
 %%%-------------------------------------------------------------------
@@ -101,13 +101,13 @@ parse(L, SList) ->
 -define(do_scan(L), scan(Rest, <<>>, [{L, 1} | check(Buf, S) ++ Result], L, S)).
 
 
--spec scan([byte()],_) -> [{atom(),1} | {'str',1,[any()]}].
+-spec scan([byte()], _) -> [{atom(), 1} | {'str', 1, [any()]}].
 scan(L, SList) ->
     scan(L, <<"">>, [], undefined, SList).
 
 
--spec scan([byte()], Buf :: binary(), Result :: [{atom(),1} | {'str',1,[any()]}],
-    atom(), S :: any()) -> [{atom(),1} | {'str',1,[any()]}].
+-spec scan([byte()], Buf :: binary(), Result :: [{atom(), 1} | {'str', 1, [any()]}],
+    atom(), S :: any()) -> [{atom(), 1} | {'str', 1, [any()]}].
 scan("=*)" ++ Rest, Buf, Result, '(', S) ->
     scan(Rest, <<>>, [{')', 1}, {'=*', 1} | check(Buf, S) ++ Result], ')', S);
 scan(":dn" ++ Rest, Buf, Result, '(', S) -> ?do_scan(':dn');
@@ -133,7 +133,7 @@ scan([], Buf, Result, _, S) ->
     lists:reverse(check(Buf, S) ++ Result).
 
 
--spec check(binary(),_) -> [{'str',1,[byte()]}].
+-spec check(binary(), _) -> [{'str', 1, [byte()]}].
 check(<<>>, _) ->
     [];
 check(Buf, S) ->

--- a/apps/ejabberd/src/eldap_pool.erl
+++ b/apps/ejabberd/src/eldap_pool.erl
@@ -29,7 +29,7 @@
 -author('xram@jabber.ru').
 
 %% API
--export([start_link/7,stop/1, bind/3, search/2, delete/2, add/3,
+-export([start_link/7, stop/1, bind/3, search/2, delete/2, add/3,
          modify_passwd/3]).
 
 -include("ejabberd.hrl").
@@ -38,35 +38,35 @@
 %% API
 %%====================================================================
 
--spec bind(binary(),_,_) -> any().
+-spec bind(binary(), _, _) -> any().
 bind(PoolName, DN, Passwd) ->
     do_request(PoolName, {bind, [DN, Passwd]}).
 
 
--spec search(binary(),_) -> any().
+-spec search(binary(), _) -> any().
 search(PoolName, Opts) ->
     do_request(PoolName, {search, [Opts]}).
 
 
--spec modify_passwd(binary(),_,_) -> any().
+-spec modify_passwd(binary(), _, _) -> any().
 modify_passwd(PoolName, DN, Passwd) ->
     do_request(PoolName, {modify_passwd, [DN, Passwd]}).
 
 
--spec delete(binary(),_) -> any().
-delete(PoolName,DN) ->
+-spec delete(binary(), _) -> any().
+delete(PoolName, DN) ->
     case do_request(PoolName, {delete, [DN]}) of
         false -> not_exists;
         R -> R
     end.
 
 
--spec add(binary(),_,_) -> any().
-add(PoolName,DN,Attrs) ->
-    do_request(PoolName, {add,[DN,Attrs]}).
+-spec add(binary(), _, _) -> any().
+add(PoolName, DN, Attrs) ->
+    do_request(PoolName, {add, [DN, Attrs]}).
 
 
--spec start_link(Name :: binary(), Hosts :: [any()],_,_,_,_,_) -> 'ok'.
+-spec start_link(Name :: binary(), Hosts :: [any()], _, _, _, _, _) -> 'ok'.
 start_link(Name, Hosts, Backups, Port, Rootdn, Passwd, Opts) ->
     PoolName = make_id(Name),
     pg2:create(PoolName),
@@ -89,9 +89,9 @@ start_link(Name, Hosts, Backups, Port, Rootdn, Passwd, Opts) ->
 stop(Name) ->
     Pids = pg2:get_local_members(make_id(Name)),
     lists:foreach(fun (P) ->
-                          ok = pg2:leave(make_id(Name),P),
+                          ok = pg2:leave(make_id(Name), P),
                           eldap:close(P)
-                  end,Pids).
+                  end, Pids).
 
 
 %%====================================================================
@@ -99,7 +99,7 @@ stop(Name) ->
 %%====================================================================
 
 -type f() :: add | bind | delete | modify_passwd | search.
--spec do_request(Name :: binary(), {f() ,[any(),...]}) -> any().
+-spec do_request(Name :: binary(), {f(), [any(), ...]}) -> any().
 do_request(Name, {F, Args}) ->
     case pg2:get_closest_pid(make_id(Name)) of
       Pid when is_pid(Pid) ->
@@ -118,4 +118,4 @@ do_request(Name, {F, Args}) ->
 
 -spec make_id(binary()) -> atom().
 make_id(Name) ->
-    binary_to_atom(<<"eldap_pool_", Name/binary>>,utf8).
+    binary_to_atom(<<"eldap_pool_", Name/binary>>, utf8).

--- a/apps/ejabberd/src/extauth.erl
+++ b/apps/ejabberd/src/extauth.erl
@@ -43,7 +43,7 @@
 -define(CALL_TIMEOUT, 10000). % Timeout is in milliseconds: 10 seconds == 10000
 
 
--spec start(atom() | binary(),_) -> 'ok'.
+-spec start(atom() | binary(), _) -> 'ok'.
 start(Host, ExtPrg) ->
     lists:foreach(
         fun(This) ->
@@ -53,22 +53,22 @@ start(Host, ExtPrg) ->
     ).
 
 
--spec start_instance(atom(),_) -> pid().
+-spec start_instance(atom(), _) -> pid().
 start_instance(ProcessName, ExtPrg) ->
     spawn(?MODULE, init, [ProcessName, ExtPrg]).
 
 
--spec restart_instance(atom(),_) -> pid().
+-spec restart_instance(atom(), _) -> pid().
 restart_instance(ProcessName, ExtPrg) ->
     unregister(ProcessName),
     start_instance(ProcessName, ExtPrg).
 
 
--spec init(atom(),string()) -> no_return().
+-spec init(atom(), string()) -> no_return().
 init(ProcessName, ExtPrg) ->
     register(ProcessName, self()),
-    process_flag(trap_exit,true),
-    Port = open_port({spawn, ExtPrg}, [{packet,2}]),
+    process_flag(trap_exit, true),
+    Port = open_port({spawn, ExtPrg}, [{packet, 2}]),
     loop(Port, ?INIT_TIMEOUT, ProcessName, ExtPrg).
 
 
@@ -82,7 +82,7 @@ stop(Host) ->
     ).
 
 
--spec get_process_name(binary(),integer()) -> atom().
+-spec get_process_name(binary(), integer()) -> atom().
 get_process_name(Host, Integer) ->
     gen_mod:get_module_proc(lists:append([erlang:binary_to_list(Host), integer_to_list(Integer)]), eauth).
 
@@ -121,20 +121,20 @@ remove_user(User, Server, Password) ->
     call_port(Server, [<<"removeuser3">>, User, Server, Password]).
 
 
--spec call_port(ejabberd:server(), [any(),...]) -> any().
+-spec call_port(ejabberd:server(), [any(), ...]) -> any().
 call_port(Server, Msg) ->
     LServer = jid:nameprep(Server),
     ProcessName = get_process_name(LServer, random_instance(get_instances(LServer))),
     ProcessName ! {call, self(), Msg},
     receive
-        {eauth,Result} ->
+        {eauth, Result} ->
             Result
     end.
 
 
 -spec random_instance(pos_integer()) -> non_neg_integer().
 random_instance(MaxNum) ->
-    {A1,A2,A3} = now(),
+    {A1, A2, A3} = now(),
     random:seed(A1, A2, A3),
     random:uniform(MaxNum) - 1.
 
@@ -203,10 +203,10 @@ join(List, Sep) ->
 
 -spec encode([binary()]) -> [byte()].
 encode(L) ->
-    erlang:binary_to_list(join(L,<<":">>)).
+    erlang:binary_to_list(join(L, <<":">>)).
 
 
--spec decode([0 | 1,...]) -> boolean().
-decode([0,0]) -> false;
-decode([0,1]) -> true.
+-spec decode([0 | 1, ...]) -> boolean().
+decode([0, 0]) -> false;
+decode([0, 1]) -> true.
 

--- a/apps/ejabberd/src/gen_iq_handler.erl
+++ b/apps/ejabberd/src/gen_iq_handler.erl
@@ -51,7 +51,7 @@
 -type state()     :: #state{}.
 -type component() :: atom() | tuple().
 -type ns()        :: binary().
--type type()      :: 'no_queue' | 'one_queue' | 'parallel' | {'queues',integer()}.
+-type type()      :: 'no_queue' | 'one_queue' | 'parallel' | {'queues', integer()}.
 -type options()   :: atom() | {one_queue | queues, pid() | [pid()]}.
 
 %%====================================================================
@@ -60,7 +60,7 @@
 
 %% @doc Starts the server
 -spec start_link(ejabberd:server(), atom(), atom()
-                ) -> 'ignore' | {'error',_} | {'ok',pid()}.
+                ) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Host, Module, Function) ->
     gen_server:start_link(?MODULE, [Host, Module, Function], []).
 
@@ -116,8 +116,8 @@ stop_iq_handler(_Module, _Function, Opts) ->
 -spec handle(Host :: ejabberd:server(), Module :: atom(), Function :: atom(),
              Opts :: options(), From :: ejabberd:jid(), To :: ejabberd:jid(),
              IQ :: ejabberd:iq()) -> 'ok' | 'todo' | pid()
-                                  | {'error','lager_not_running'}
-                                  | {'process_iq',_,_,_}.
+                                  | {'error', 'lager_not_running'}
+                                  | {'process_iq', _, _, _}.
 handle(Host, Module, Function, Opts, From, To, IQ) ->
     case Opts of
         no_queue ->
@@ -136,7 +136,7 @@ handle(Host, Module, Function, Opts, From, To, IQ) ->
 
 -spec process_iq(Host :: ejabberd:server(), Module :: atom(), Function :: atom(),
                  From :: ejabberd:jid(), To :: ejabberd:jid(),
-                 IQ :: ejabberd:iq()) -> 'ok' | {'error','lager_not_running'}.
+                 IQ :: ejabberd:iq()) -> 'ok' | {'error', 'lager_not_running'}.
 process_iq(_Host, Module, Function, From, To, IQ) ->
     case catch Module:Function(From, To, IQ) of
         {'EXIT', Reason} ->
@@ -163,7 +163,7 @@ check_type(parallel) -> parallel.
 %%====================================================================
 
 %% @doc Initiates the server
--spec init([atom() | binary(),...]) -> {'ok', state()}.
+-spec init([atom() | binary(), ...]) -> {'ok', state()}.
 init([Host, Module, Function]) ->
     {ok, #state{host = Host,
                 module = Module,

--- a/apps/ejabberd/src/gen_mod.erl
+++ b/apps/ejabberd/src/gen_mod.erl
@@ -187,10 +187,10 @@ generate_fun_body(true, BaseModule, RealBackendModule, F, Args) ->
 %%     {Time, Result} = timer:tc(Backend, F, Args),
 %%     mongoose_metrics:update(global, ?METRIC(Backend, F), Time),
 %%     Result.
-    ["    {Time, Result} = timer:tc(", RealBackendModule, ", ", FS, ", [", Args, "]),\n",
+    ["    {Time, Result} = timer:tc(", RealBackendModule, ", ", FS, ", [", Args, "]), \n",
      "    mongoose_metrics:update(global, ",
           io_lib:format("~p", [?METRIC(BaseModule, F)]),
-          ", Time),\n",
+          ", Time), \n",
      "    Result.\n"].
 
 ensure_backend_metrics(Module, Ops) ->

--- a/apps/ejabberd/src/gen_pubsub_node.erl
+++ b/apps/ejabberd/src/gen_pubsub_node.erl
@@ -69,18 +69,18 @@
         Owner   :: jid()) ->
     {result, {default, broadcast}}.
 
--callback delete_node(Nodes :: [pubsubNode(),...]) ->
+-callback delete_node(Nodes :: [pubsubNode(), ...]) ->
     {result,
         {default, broadcast,
             [{pubsubNode(),
-                    [{ljid(), [{subscription(), subId()}]},...]},...]
+                    [{ljid(), [{subscription(), subId()}]}, ...]}, ...]
             }
         }
     |
     {result,
         {[],
             [{pubsubNode(),
-                    [{ljid(), [{subscription(), subId()}]},...]},...]
+                    [{ljid(), [{subscription(), subId()}]}, ...]}, ...]
             }
         }.
 
@@ -152,7 +152,7 @@
 -callback get_node_subscriptions(NodeIdx :: nodeIdx()) ->
     {result,
         [{ljid(), subscription(), subId()}] |
-        [{ljid(), none},...]
+        [{ljid(), none}, ...]
         }.
 
 -callback get_entity_subscriptions(Host :: host(),

--- a/apps/ejabberd/src/gen_pubsub_nodetree.erl
+++ b/apps/ejabberd/src/gen_pubsub_nodetree.erl
@@ -80,7 +80,7 @@
 -callback get_parentnodes_tree(Host :: host(),
         NodeId :: nodeId(),
         From :: jid()) ->
-    [{0, [pubsubNode(),...]}].
+    [{0, [pubsubNode(), ...]}].
 
 -callback get_subnodes(Host :: host(),
         NodeId :: nodeId(),

--- a/apps/ejabberd/src/jid.erl
+++ b/apps/ejabberd/src/jid.erl
@@ -121,7 +121,7 @@ binary_to_jid1(<<>>, N) ->
 
 
 %% @doc Only one "@" is admitted per JID
--spec binary_to_jid2(binary(),[byte()],[byte()]) -> 'error' | ejabberd:jid().
+-spec binary_to_jid2(binary(), [byte()], [byte()]) -> 'error' | ejabberd:jid().
 binary_to_jid2(<<$@, _J/binary>>, _N, _S) ->
     error;
 binary_to_jid2(<<$/, _J/binary>>, _N, []) ->
@@ -136,7 +136,7 @@ binary_to_jid2(<<>>, N, S) ->
     make(list_to_binary(N), list_to_binary(lists:reverse(S)), <<>>).
 
 
--spec binary_to_jid3(binary(),[byte()],[byte()],[byte()]) -> 'error' | ejabberd:jid().
+-spec binary_to_jid3(binary(), [byte()], [byte()], [byte()]) -> 'error' | ejabberd:jid().
 binary_to_jid3(<<C, J/binary>>, N, S, R) ->
     binary_to_jid3(J, N, S, [C | R]);
 binary_to_jid3(<<>>, N, S, R) ->

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -93,7 +93,7 @@
                       'false' | integer()
                       }.
 %% Timezone format where all or some elements may be 'false' or integer()
--type maybe_tz() :: {'false' | non_neg_integer(),'false' | non_neg_integer()}.
+-type maybe_tz() :: {'false' | non_neg_integer(), 'false' | non_neg_integer()}.
 
 %% Time format where all or some elements may be 'false' or integer()
 -type maybe_time() :: {'false' | non_neg_integer(),
@@ -107,7 +107,7 @@ make_result_iq_reply(XE = #xmlel{attrs = Attrs}) ->
     XE#xmlel{attrs = NewAttrs}.
 
 
--spec make_result_iq_reply_attrs([binary_pair()]) -> [binary_pair(),...].
+-spec make_result_iq_reply_attrs([binary_pair()]) -> [binary_pair(), ...].
 make_result_iq_reply_attrs(Attrs) ->
     To = xml:get_attr(<<"to">>, Attrs),
     From = xml:get_attr(<<"from">>, Attrs),
@@ -136,7 +136,7 @@ make_error_reply(#xmlel{name = Name, attrs = Attrs,
     #xmlel{name = Name, attrs = NewAttrs, children = SubTags ++ [Error]}.
 
 
--spec make_error_reply_attrs([binary_pair()]) -> [binary_pair(),...].
+-spec make_error_reply_attrs([binary_pair()]) -> [binary_pair(), ...].
 make_error_reply_attrs(Attrs) ->
     To = xml:get_attr(<<"to">>, Attrs),
     From = xml:get_attr(<<"from">>, Attrs),
@@ -409,7 +409,7 @@ parse_xdata_values([_ | Els], Res) ->
 rsm_decode(#iq{sub_el=SubEl})->
     rsm_decode(SubEl);
 rsm_decode(#xmlel{}=SubEl) ->
-    case xml:get_subtag(SubEl,<<"set">>) of
+    case xml:get_subtag(SubEl, <<"set">>) of
         false ->
             none;
         #xmlel{name = <<"set">>, children = SubEls} ->
@@ -448,7 +448,7 @@ rsm_encode(RsmOut)->
 -spec rsm_encode_out(rsm_out()) -> [xmlel()].
 rsm_encode_out(#rsm_out{count=Count, index=Index, first=First, last=Last})->
     El = rsm_encode_first(First, Index, []),
-    El2 = rsm_encode_last(Last,El),
+    El2 = rsm_encode_last(Last, El),
     rsm_encode_count(Count, El2).
 
 
@@ -506,7 +506,7 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second, Micro}}, Timezone) 
                            true -> "+";
                            false -> "-"
                        end,
-                io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh),TZm])
+                io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh), TZm])
         end,
     {Timestamp_string, Timezone_string};
 timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
@@ -524,7 +524,7 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
                            true -> "+";
                            false -> "-"
                        end,
-                io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh),TZm])
+                io_lib:format("~s~2..0w:~2..0w", [Sign, abs(TZh), TZm])
         end,
     {Timestamp_string, Timezone_string}.
 
@@ -630,7 +630,7 @@ parse_time_with_timezone(Time) ->
 
 
 -spec parse_time_with_timezone(nonempty_string(),
-                               Delim :: [43 | 45,...]) -> maybe_datetime().
+                               Delim :: [43 | 45, ...]) -> maybe_datetime().
 parse_time_with_timezone(Time, Delim) ->
     [T, TZ] = string:tokens(Time, Delim),
     {TZH, TZM} = parse_timezone(TZ),
@@ -664,8 +664,8 @@ parse_time1(Time) ->
     {{H1, M1, S1}, MS}.
 
 
--spec check_list([{nonempty_string(), 12 | 24 | 60},...]) ->
-                                  {['false' | non_neg_integer(),...],_}.
+-spec check_list([{nonempty_string(), 12 | 24 | 60}, ...]) ->
+                                  {['false' | non_neg_integer(), ...], _}.
 check_list(List) ->
     lists:mapfoldl(
       fun({L, N}, B)->
@@ -698,21 +698,21 @@ decode_base64(S) ->
 -spec decode1_base64(string()) -> string().
 decode1_base64([]) ->
     [];
-decode1_base64([Sextet1,Sextet2,$=,$=|Rest]) ->
+decode1_base64([Sextet1, Sextet2, $=, $=|Rest]) ->
     Bits2x6=
         (d(Sextet1) bsl 18) bor
         (d(Sextet2) bsl 12),
     Octet1=Bits2x6 bsr 16,
     [Octet1|decode1_base64(Rest)];
-decode1_base64([Sextet1,Sextet2,Sextet3,$=|Rest]) ->
+decode1_base64([Sextet1, Sextet2, Sextet3, $=|Rest]) ->
     Bits3x6=
         (d(Sextet1) bsl 18) bor
         (d(Sextet2) bsl 12) bor
         (d(Sextet3) bsl 6),
     Octet1=Bits3x6 bsr 16,
     Octet2=(Bits3x6 bsr 8) band 16#ff,
-    [Octet1,Octet2|decode1_base64(Rest)];
-decode1_base64([Sextet1,Sextet2,Sextet3,Sextet4|Rest]) ->
+    [Octet1, Octet2|decode1_base64(Rest)];
+decode1_base64([Sextet1, Sextet2, Sextet3, Sextet4|Rest]) ->
     Bits4x6=
         (d(Sextet1) bsl 18) bor
         (d(Sextet2) bsl 12) bor
@@ -721,7 +721,7 @@ decode1_base64([Sextet1,Sextet2,Sextet3,Sextet4|Rest]) ->
     Octet1=Bits4x6 bsr 16,
     Octet2=(Bits4x6 bsr 8) band 16#ff,
     Octet3=Bits4x6 band 16#ff,
-    [Octet1,Octet2,Octet3|decode1_base64(Rest)];
+    [Octet1, Octet2, Octet3|decode1_base64(Rest)];
 decode1_base64(_CatchAll) ->
     "".
 
@@ -746,11 +746,11 @@ encode_base64([]) ->
     [];
 encode_base64([A]) ->
     [e(A bsr 2), e((A band 3) bsl 4), $=, $=];
-encode_base64([A,B]) ->
+encode_base64([A, B]) ->
     [e(A bsr 2), e(((A band 3) bsl 4) bor (B bsr 4)), e((B band 15) bsl 2), $=];
-encode_base64([A,B,C|Ls]) ->
-    encode_base64_do(A,B,C, Ls).
-encode_base64_do(A,B,C, Rest) ->
+encode_base64([A, B, C|Ls]) ->
+    encode_base64_do(A, B, C, Ls).
+encode_base64_do(A, B, C, Rest) ->
     BB = (A bsl 16) bor (B bsl 8) bor C,
     [e(BB bsr 18), e((BB bsr 12) band 63),
      e((BB bsr 6) band 63), e(BB band 63)|encode_base64(Rest)].
@@ -770,20 +770,20 @@ e(X) ->                     exit({bad_encode_base64_token, X}).
                 ) -> string().
 ip_to_list({IP, _Port}) ->
     ip_to_list(IP);
-ip_to_list({_,_,_,_,_,_,_,_} = Ipv6Address) ->
+ip_to_list({_, _, _, _, _, _, _, _} = Ipv6Address) ->
     inet_parse:ntoa(Ipv6Address);
 %% This function clause could use inet_parse too:
-ip_to_list({A,B,C,D}) ->
-    lists:flatten(io_lib:format("~w.~w.~w.~w",[A,B,C,D]));
+ip_to_list({A, B, C, D}) ->
+    lists:flatten(io_lib:format("~w.~w.~w.~w", [A, B, C, D]));
 ip_to_list(IP) ->
     lists:flatten(io_lib:format("~w", [IP])).
 
 
 -spec stanza_error( Code :: binary()
-    , Type :: binary()
-    , Condition :: binary()
-    , SpecTag :: binary()
-    , SpecNs :: binary() | undefined) -> #xmlel{}.
+   , Type :: binary()
+   , Condition :: binary()
+   , SpecTag :: binary()
+   , SpecNs :: binary() | undefined) -> #xmlel{}.
 stanza_error(Code, Type, Condition, SpecTag, SpecNs) ->
     Er = stanza_error(Code, Type, Condition),
     Spec = #xmlel{ name = SpecTag, attrs = [{<<"xmlns">>, SpecNs}]},
@@ -792,55 +792,55 @@ stanza_error(Code, Type, Condition, SpecTag, SpecNs) ->
 
 %% TODO: remove<<"code" attribute (currently it used for backward-compatibility)
 -spec stanza_error( Code :: binary()
-                  , Type :: binary()
-                  , Condition :: binary() | undefined) -> #xmlel{}.
+                 , Type :: binary()
+                 , Condition :: binary() | undefined) -> #xmlel{}.
 stanza_error(Code, Type, Condition) ->
   #xmlel{ name = <<"error">>
-        , attrs = [{<<"code">>, Code}, {<<"type">>, Type}]
-        , children = [ #xmlel{ name = Condition
-                             , attrs = [{<<"xmlns">>, ?NS_STANZAS}]
+       , attrs = [{<<"code">>, Code}, {<<"type">>, Type}]
+       , children = [ #xmlel{ name = Condition
+                            , attrs = [{<<"xmlns">>, ?NS_STANZAS}]
                              }]
         }.
 
 -spec stanza_errort( Code :: binary()
-                   , Type :: binary()
-                   , Condition :: binary()
-                   , Lang :: ejabberd:lang()
-                   , Text :: binary()) -> #xmlel{}.
+                  , Type :: binary()
+                  , Condition :: binary()
+                  , Lang :: ejabberd:lang()
+                  , Text :: binary()) -> #xmlel{}.
 stanza_errort(Code, Type, Condition, Lang, Text) ->
   Txt = translate:translate(Lang, Text),
   #xmlel{ name = <<"error">>
-        , attrs = [{<<"code">>, Code}, {<<"type">>, Type}]
-        , children = [ #xmlel{ name = Condition
-                             , attrs = [{<<"xmlns">>, ?NS_STANZAS}]
+       , attrs = [{<<"code">>, Code}, {<<"type">>, Type}]
+       , children = [ #xmlel{ name = Condition
+                            , attrs = [{<<"xmlns">>, ?NS_STANZAS}]
                              }
-                     , #xmlel{ name = <<"text">>
-                             , attrs = [{<<"xmlns">>, ?NS_STANZAS}]
-                             , children = [#xmlcdata{ content = Txt }]
+                    , #xmlel{ name = <<"text">>
+                            , attrs = [{<<"xmlns">>, ?NS_STANZAS}]
+                            , children = [#xmlcdata{ content = Txt }]
                              }]
         }.
 
 -spec stream_error(Condition :: binary()) -> #xmlel{}.
 stream_error(Condition) ->
   #xmlel{ name = <<"stream:error">>
-        , children = [ #xmlel{ name = Condition
-                             , attrs = [{<<"xmlns">>, ?NS_STREAMS}]
+       , children = [ #xmlel{ name = Condition
+                            , attrs = [{<<"xmlns">>, ?NS_STREAMS}]
                              }
                      ]
         }.
 
 -spec stream_errort( Condition :: binary()
-                   , Lang :: ejabberd:lang()
-                   , Text :: binary()) -> #xmlel{}.
+                  , Lang :: ejabberd:lang()
+                  , Text :: binary()) -> #xmlel{}.
 stream_errort(Condition, Lang, Text) ->
   Txt = translate:translate(Lang, Text),
   #xmlel{ name = <<"stream:error">>
-        , children = [ #xmlel{ name = Condition
-                             , attrs = [{<<"xmlns">>, ?NS_STREAMS}] }
-                     , #xmlel{ name = <<"text">>
-                             , attrs = [ {<<"xml:lang">>, Lang}
-                                       , {<<"xmlns">>, ?NS_STREAMS}]
-                             , children = [ #xmlcdata{ content = Txt} ]}
+       , children = [ #xmlel{ name = Condition
+                            , attrs = [{<<"xmlns">>, ?NS_STREAMS}] }
+                    , #xmlel{ name = <<"text">>
+                            , attrs = [ {<<"xml:lang">>, Lang}
+                                      , {<<"xmlns">>, ?NS_STREAMS}]
+                            , children = [ #xmlcdata{ content = Txt} ]}
                      ]
         }.
 
@@ -853,7 +853,7 @@ remove_delay_tags(#xmlel{children = Els} = Packet) ->
                                   _ ->
                                     El ++ [R]
                               end;
-                (#xmlel{name= <<"x">> , attrs = Attrs } = R, El) ->
+                (#xmlel{name= <<"x">>, attrs = Attrs } = R, El) ->
                               case xml:get_attr_s(<<"xmlns">>, Attrs) of
                                   ?NS_DELAY91 ->
                                       El;
@@ -862,5 +862,5 @@ remove_delay_tags(#xmlel{children = Els} = Packet) ->
                               end;
                 (R, El) ->
                               El ++ [R]
-                end, [],Els),
+                end, [], Els),
     Packet#xmlel{children=NEl}.

--- a/apps/ejabberd/src/mod_admin_extra.erl
+++ b/apps/ejabberd/src/mod_admin_extra.erl
@@ -33,7 +33,7 @@
 
 -define(SUBMODS, [node, accounts, sessions, vcard, roster, last,
                   private, stanza, stats
-                  %,srg %% Disabled until we add mod_shared_roster
+                  %, srg %% Disabled until we add mod_shared_roster
                  ]).
 
 %%%

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -47,7 +47,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = change_password, tags = [accounts],
@@ -258,7 +258,7 @@ ban_account(User, Host, ReasonText) ->
     kick_sessions(User, Host, Reason),
     case set_random_password(User, Host, Reason) of
         ok ->
-            {ok, io_lib:format("User ~s@~s successfully banned with reason: ~s",[User, Host, ReasonText])};
+            {ok, io_lib:format("User ~s@~s successfully banned with reason: ~s", [User, Host, ReasonText])};
         {error, ErrorReason} ->
             {error, ErrorReason}
     end.
@@ -284,7 +284,7 @@ set_random_password(User, Server, Reason) ->
 
 -spec build_random_password(Reason :: binary()) -> binary().
 build_random_password(Reason) ->
-    {{Year,Month,Day},{Hour,Minute,Second}} = calendar:universal_time(),
+    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:universal_time(),
     Date = list_to_binary(
              lists:flatten(
                io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0wZ",

--- a/apps/ejabberd/src/mod_admin_extra_last.erl
+++ b/apps/ejabberd/src/mod_admin_extra_last.erl
@@ -44,7 +44,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
      #ejabberd_commands{name = set_last, tags = [last],

--- a/apps/ejabberd/src/mod_admin_extra_node.erl
+++ b/apps/ejabberd/src/mod_admin_extra_node.erl
@@ -42,7 +42,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = load_config, tags = [server],

--- a/apps/ejabberd/src/mod_admin_extra_private.erl
+++ b/apps/ejabberd/src/mod_admin_extra_private.erl
@@ -42,7 +42,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = private_get, tags = [private],
@@ -81,11 +81,11 @@ do_private_get(Username, Host, Element, Ns) ->
     To = jid:make(Username, Host, <<"">>),
     IQ = {iq, <<"">>, get, ?NS_PRIVATE, <<"">>,
           #xmlel{ name = <<"query">>,
-                  attrs = [{<<"xmlns">>,?NS_PRIVATE}],
+                  attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
                   children = [#xmlel{ name = Element, attrs = [{<<"xmlns">>, Ns}]}] } },
     ResIq = mod_private:process_sm_iq(From, To, IQ),
     [#xmlel{ name = <<"query">>,
-             attrs = [{<<"xmlns">>,<<"jabber:iq:private">>}],
+             attrs = [{<<"xmlns">>, <<"jabber:iq:private">>}],
              children = [SubEl] }] = ResIq#iq.sub_el,
     exml:to_binary(SubEl).
 
@@ -118,7 +118,7 @@ do_private_set2(Username, Host, Xml) ->
             To = jid:make(Username, Host, <<"">>),
             IQ = {iq, <<"">>, set, ?NS_PRIVATE, <<"">>,
                   #xmlel{ name = <<"query">>,
-                          attrs = [{<<"xmlns">>,?NS_PRIVATE}],
+                          attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
                           children = [Xml]}},
             mod_private:process_sm_iq(From, To, IQ),
             {ok, ""};

--- a/apps/ejabberd/src/mod_admin_extra_roster.erl
+++ b/apps/ejabberd/src/mod_admin_extra_roster.erl
@@ -69,7 +69,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = add_rosteritem, tags = [roster],
@@ -198,12 +198,12 @@ do_add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
                 _Xattrs :: [jlib:binary_pair()]) -> any().
  subscribe(LU, LS, User, Server, Nick, Group, SubscriptionS, _Xattrs) ->
     ItemEl = build_roster_item(User, Server, {add, Nick, SubscriptionS, Group}),
-    case loaded_module(LS,[mod_roster_odbc,mod_roster]) of
+    case loaded_module(LS, [mod_roster_odbc, mod_roster]) of
         {ok, M} ->
             M:set_items(
                 LU, LS,
                 #xmlel{ name = <<"query">>,
-                        attrs = [{<<"xmlns">>,<<"jabber:iq:roster">>}],
+                        attrs = [{<<"xmlns">>, <<"jabber:iq:roster">>}],
                         children = [ItemEl]});
         {error, not_found} ->
             unknown_server
@@ -239,12 +239,12 @@ delete_rosteritem(LocalUser, LocalServer, User, Server) ->
                   Server :: ejabberd:server()) -> any().
 unsubscribe(LU, LS, User, Server) ->
     ItemEl = build_roster_item(User, Server, remove),
-    case loaded_module(LS,[mod_roster_odbc,mod_roster]) of
+    case loaded_module(LS, [mod_roster_odbc, mod_roster]) of
         {ok, M} ->
             M:set_items(
                 LU, LS,
                 #xmlel{ name = <<"query">>,
-                        attrs = [{<<"xmlns">>,<<"jabber:iq:roster">>}],
+                        attrs = [{<<"xmlns">>, <<"jabber:iq:roster">>}],
                         children = [ItemEl]});
         {error, not_found} ->
             unknown_server
@@ -253,15 +253,15 @@ unsubscribe(LU, LS, User, Server) ->
 
 
 -spec loaded_module(Domain :: binary(),
-                    Options :: ['mod_roster' | 'mod_roster_odbc',...])
-            -> {'error','not_found'} | {'ok','mod_roster' | 'mod_roster_odbc'}.
-loaded_module(Domain,Options) ->
+                    Options :: ['mod_roster' | 'mod_roster_odbc', ...])
+            -> {'error', 'not_found'} | {'ok', 'mod_roster' | 'mod_roster_odbc'}.
+loaded_module(Domain, Options) ->
     LoadedModules = gen_mod:loaded_modules(Domain),
     case lists:filter(fun(Module) ->
                     lists:member(Module, LoadedModules)
             end, Options) of
         [M|_] -> {ok, M};
-        [] -> {error,not_found}
+        [] -> {error, not_found}
     end.
 
 %% -----------------------------
@@ -462,7 +462,7 @@ process_rosteritems(ActionS, SubsS, AsksS, UsersS, ContactsS) ->
     rosteritem_purge({Action, Subs, Asks, Users, Contacts}),
     ok.
 
--spec rosteritem_purge(delete_action() | list_action()) -> {'atomic','ok'}.
+-spec rosteritem_purge(delete_action() | list_action()) -> {'atomic', 'ok'}.
 rosteritem_purge(Options) ->
     Num_rosteritems = mnesia:table_info(roster, size),
     case Num_rosteritems of
@@ -549,7 +549,7 @@ is_regexp_match(String, RegExp) ->
             false;
         {match, List} ->
             Size = length(binary_to_list(String)),
-            case lists:member({0,Size}, List) of
+            case lists:member({0, Size}, List) of
                 true ->
                     true;
                 false ->

--- a/apps/ejabberd/src/mod_admin_extra_sessions.erl
+++ b/apps/ejabberd/src/mod_admin_extra_sessions.erl
@@ -72,7 +72,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     SessionDisplay = {list,
                       {sessions, {tuple,

--- a/apps/ejabberd/src/mod_admin_extra_srg.erl
+++ b/apps/ejabberd/src/mod_admin_extra_srg.erl
@@ -49,13 +49,13 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = srg_create, tags = [shared_roster_group],
                            desc = "Create a Shared Roster Group",
                            longdesc = "If you want to specify several group "
-                           "identifiers in the Display argument,\n"
+                           "identifiers in the Display argument, \n"
                            "put  \\ \" around the argument and\nseparate the "
                            "identifiers with \\ \\ n\n"
                            "For example:\n"
@@ -129,14 +129,14 @@ srg_list(Host) ->
 
 -spec srg_get_info(group(), ejabberd:server()) -> [{string(), string()}].
 srg_get_info(Group, Host) ->
-    Opts = mod_shared_roster:get_group_opts(Host,Group),
+    Opts = mod_shared_roster:get_group_opts(Host, Group),
     [{io_lib:format("~p", [Title]),
       io_lib:format("~p", [Value])} || {Title, Value} <- Opts].
 
 
 -spec srg_get_members(group(), ejabberd:server()) -> [binary()].
 srg_get_members(Group, Host) ->
-    Members = mod_shared_roster:get_group_explicit_users(Host,Group),
+    Members = mod_shared_roster:get_group_explicit_users(Host, Group),
     [jid:to_binary(jid:make(MUser, MServer, <<"">>))
      || {MUser, MServer} <- Members].
 

--- a/apps/ejabberd/src/mod_admin_extra_stanza.erl
+++ b/apps/ejabberd/src/mod_admin_extra_stanza.erl
@@ -44,7 +44,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = send_message_chat, tags = [stanza],
@@ -113,7 +113,7 @@ send_packet_all_resources(FromJIDString, ToJIDString, Packet) ->
                 Res ->
                     send_packet_all_resources(FromJID, ToUser, ToServer, Res, Packet)
             end,
-            {ok,""}
+            {ok, ""}
     end.
 
 
@@ -144,7 +144,7 @@ send_packet_all_resources(FromJID, ToU, ToS, ToR, Packet) ->
 
 
 -spec build_packet('message_chat' | 'message_headline',
-                  Subject_Body :: [binary() | string(),...]) -> jlib:xmlel().
+                  Subject_Body :: [binary() | string(), ...]) -> jlib:xmlel().
 build_packet(message_chat, [Body]) ->
     #xmlel{ name = <<"message">>,
            attrs = [{<<"type">>, <<"chat">>}, {<<"id">>, list_to_binary(randoms:get_string())}],
@@ -166,7 +166,7 @@ send_stanza_c2s(Username, Host, Resource, Stanza) ->
     C2sPid = ejabberd_sm:get_session_pid(Username, Host, Resource),
     case C2sPid of
         none ->
-            {user_does_not_exist, io_lib:format("User ~s@~s/~s does not exist",[Username, Host, Resource])};
+            {user_does_not_exist, io_lib:format("User ~s@~s/~s does not exist", [Username, Host, Resource])};
         _ ->
             case exml:parse(Stanza) of
                 {ok, XmlEl} ->

--- a/apps/ejabberd/src/mod_admin_extra_stats.erl
+++ b/apps/ejabberd/src/mod_admin_extra_stats.erl
@@ -41,7 +41,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     [
         #ejabberd_commands{name = stats, tags = [stats],

--- a/apps/ejabberd/src/mod_admin_extra_vcard.erl
+++ b/apps/ejabberd/src/mod_admin_extra_vcard.erl
@@ -47,7 +47,7 @@
 %%% Register commands
 %%%
 
--spec commands() -> [ejabberd_commands:cmd(),...].
+-spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     Vcard1FieldsString = "Some vcard field names in get/set_vcard are:\n"
                          " FN		- Full Name\n"
@@ -226,7 +226,7 @@ set_vcard_content(User, Server, Data, ContentList) ->
     Module:Function(JID, JID, IQ2),
     {ok, ""}.
 
--spec update_vcard_els(Data :: [binary(),...],
+-spec update_vcard_els(Data :: [binary(), ...],
                        ContentList :: [binary() | string()],
                        Els :: [jlib:xmlcdata() | jlib:xmlel()]
                       ) -> [jlib:xmlcdata() | jlib:xmlel()].

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -88,16 +88,16 @@ strip_amp_el_from_request(Packet) ->
 %% @doc This may eventually be configurable, but for now we return a constant list.
 amp_features() ->
     [<<"http://jabber.org/protocol/amp">>
-    ,<<"http://jabber.org/protocol/amp?action=notify">>
-    ,<<"http://jabber.org/protocol/amp?action=error">>
-    ,<<"http://jabber.org/protocol/amp?condition=deliver">>
-    ,<<"http://jabber.org/protocol/amp?condition=match-resource">>
+   , <<"http://jabber.org/protocol/amp?action=notify">>
+   , <<"http://jabber.org/protocol/amp?action=error">>
+   , <<"http://jabber.org/protocol/amp?condition=deliver">>
+   , <<"http://jabber.org/protocol/amp?condition=match-resource">>
     ].
 
 -spec process_amp_rules(#xmlel{}, jid(), amp_event(), amp_rules()) -> #xmlel{} | drop.
 process_amp_rules(Packet, From, Event, Rules) ->
     VerifiedRules = verify_support(host(From), Rules),
-    {Good,Bad} = lists:partition(fun is_supported_rule/1, VerifiedRules),
+    {Good, Bad} = lists:partition(fun is_supported_rule/1, VerifiedRules),
     ValidRules = [ Rule || {supported, Rule} <- Good ],
     case Bad of
         [{error, ValidationError, InvalidRule} | _] ->
@@ -163,7 +163,7 @@ reply_to_sender(MatchedRule, ServerJid, OriginalSender, OriginalPacket) ->
 send_error_and_drop(Packet, From, AmpError, MatchedRule) ->
     send_errors_and_drop(Packet, From, [{AmpError, MatchedRule}]).
 
--spec send_errors_and_drop(#xmlel{}, jid(), [{amp_error(),amp_rule()}]) -> drop.
+-spec send_errors_and_drop(#xmlel{}, jid(), [{amp_error(), amp_rule()}]) -> drop.
 send_errors_and_drop(Packet, From, []) ->
     ?ERROR_MSG("~p from ~p generated an empty list of errors. This shouldn't happen!",
                [Packet, From]),
@@ -183,7 +183,7 @@ update_metric_and_drop(Packet, From) ->
     drop.
 
 %% Internal
-result_or({result, I},_) -> I;
+result_or({result, I}, _) -> I;
 result_or(_, Or)         -> Or.
 
 -spec is_supported_rule(amp_rule_support()) -> boolean().

--- a/apps/ejabberd/src/mod_auth_token.erl
+++ b/apps/ejabberd/src/mod_auth_token.erl
@@ -175,7 +175,7 @@ revoke(Owner) ->
     try
         ?BACKEND:revoke(Owner)
     catch
-        E:R -> ?ERROR_MSG("backend error! ~p",[{E,R}]),
+        E:R -> ?ERROR_MSG("backend error! ~p", [{E, R}]),
                error
     end.
 
@@ -244,7 +244,7 @@ is_revoked(#token{type = refresh, sequence_no = TokenSeqNo} = T) ->
         ValidSeqNo = ?BACKEND:get_valid_sequence_number(T#token.user_jid),
         TokenSeqNo < ValidSeqNo
     catch
-        E:R -> ?ERROR_MSG("error checking revocation status: ~p", [{E,R}]),
+        E:R -> ?ERROR_MSG("error checking revocation status: ~p", [{E, R}]),
                true
     end.
 
@@ -276,7 +276,7 @@ create_token_response(From, IQ) ->
                                    attrs = [{<<"xmlns">>, ?NS_ESL_TOKEN_AUTH}],
                                    children = [token_to_xmlel(AccessToken),
                                                token_to_xmlel(RefreshToken)]}]};
-        {_,_} -> {error, ?ERR_INTERNAL_SERVER_ERROR}
+        {_, _} -> {error, ?ERR_INTERNAL_SERVER_ERROR}
     end.
 
 -spec datetime_to_seconds(calendar:datetime()) -> non_neg_integer().
@@ -303,8 +303,8 @@ token(Type, User) ->
                                T#token{sequence_no = ValidSeqNo}
                        end)
     catch
-        E:R -> ?ERROR_MSG("error creating token sequence number ~p", [{E,R}]),
-               {error, {E,R}}
+        E:R -> ?ERROR_MSG("error creating token sequence number ~p", [{E, R}]),
+               {error, {E, R}}
     end.
 
 %% {modules, [

--- a/apps/ejabberd/src/mod_blocking.erl
+++ b/apps/ejabberd/src/mod_blocking.erl
@@ -138,7 +138,7 @@ blocking_list_modify(block, Change, Old) ->
 blocking_list_modify(unblock, [], Old) ->
     %% unblock with empty list means unblocking all contacts
     Rem = [jid:to_binary(J#listitem.value) || J <- Old],
-    {unblock_all, Rem,[]};
+    {unblock_all, Rem, []};
 blocking_list_modify(unblock, Change, Old) ->
     {Removed, O} = remove_from(Change, Old),
     {unblock, Removed, O}.

--- a/apps/ejabberd/src/mod_bosh.erl
+++ b/apps/ejabberd/src/mod_bosh.erl
@@ -72,8 +72,8 @@
               | 'no_body'
               | 'policy_violation'
               | {'bosh_reply', jlib:xmlel()}
-              | {'close',_}
-              | {'wrong_method',_}.
+              | {'close', _}
+              | {'wrong_method', _}.
 
 %%--------------------------------------------------------------------
 %% API
@@ -171,7 +171,7 @@ init(_Transport, Req, _Opts) ->
     {loop, NewReq, #rstate{}}.
 
 
--spec info(info(), req(), rstate()) -> {'ok',req(),_}.
+-spec info(info(), req(), rstate()) -> {'ok', req(), _}.
 info(accept_options, Req, State) ->
     {Origin, Req2} = cowboy_req:header(<<"origin">>, Req),
     Headers = ac_all(Origin),
@@ -267,7 +267,7 @@ event_type(Body) ->
 
 
 -spec forward_body(req(), jlib:xmlel(), rstate())
-            -> {'loop',_,rstate()} | {'ok',req(),rstate()}.
+            -> {'loop', _, rstate()} | {'ok', req(), rstate()}.
 forward_body(Req, #xmlel{} = Body, S) ->
     try
         case Type = event_type(Body) of
@@ -359,7 +359,7 @@ method_not_allowed_error(Req) ->
     strip_ok(cowboy_req:reply(405, ac_all(?DEFAULT_ALLOW_ORIGIN),
                               <<"Use POST request method">>, Req)).
 
--spec strip_ok({'ok',cowboy_req:req()}) -> cowboy_req:req().
+-spec strip_ok({'ok', cowboy_req:req()}) -> cowboy_req:req().
 strip_ok({ok, Req}) ->
     Req.
 
@@ -422,7 +422,7 @@ ac_max_age() ->
     {<<"Access-Control-Max-Age">>, integer_to_binary(?DEFAULT_MAX_AGE)}.
 
 
--spec ac_all('undefined' | binary()) -> [{binary(),_},...].
+-spec ac_all('undefined' | binary()) -> [{binary(), _}, ...].
 ac_all(Origin) ->
     [ac_allow_origin(Origin),
      ac_allow_methods(),

--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -89,12 +89,12 @@
 %%--------------------------------------------------------------------
 
 -spec start(mod_bosh:sid(), _) ->
-    {'error',_} | {'ok','undefined' | pid()} | {'ok','undefined' | pid(),_}.
+    {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(Sid, Peer) ->
     supervisor:start_child(?BOSH_SOCKET_SUP, [Sid, Peer]).
 
 
--spec start_link(mod_bosh:sid(),_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(mod_bosh:sid(), _) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Sid, Peer) ->
     gen_fsm:start_link(?MODULE, [Sid, Peer], []).
 
@@ -235,7 +235,7 @@ closing(Event, State) ->
 %% @doc
 %% There should be one instance of this function for each possible
 %% state name. Whenever a gen_fsm receives an event sent using
-%% gen_fsm:sync_send_event/[2,3], the instance of this function with
+%% gen_fsm:sync_send_event/[2, 3], the instance of this function with
 %% the same name as the current state name StateName is called to
 %% handle the event.
 %%
@@ -310,7 +310,7 @@ determine_next_state(EventTag, SName, NNS) ->
 %% @private
 %% @doc
 %% Whenever a gen_fsm receives an event sent using
-%% gen_fsm:sync_send_all_state_event/[2,3], this function is called
+%% gen_fsm:sync_send_all_state_event/[2, 3], this function is called
 %% to handle the event.
 %%
 %% @spec handle_sync_event(Event, From, StateName, State) ->
@@ -350,7 +350,7 @@ handle_sync_event(Event, _From, StateName, State) ->
 %% message other than a synchronous or asynchronous event
 %% (or a system message).
 %%
-%% @spec handle_info(Info,StateName,State)->
+%% @spec handle_info(Info, StateName, State)->
 %%                   {next_state, NextStateName, NextState} |
 %%                   {next_state, NextStateName, NextState, Timeout} |
 %%                   {stop, Reason, NewState}
@@ -435,7 +435,7 @@ handle_stream_event({EventTag, Body, Rid} = Event, Handler,
         {_, _, false, false} ->
 
             ?ERROR_MSG("invalid rid ~p, expected ~p, difference ~p:~n~p~n",
-                       [Rid, ExpectedRid, maybe_diff(Rid,ExpectedRid),
+                       [Rid, ExpectedRid, maybe_diff(Rid, ExpectedRid),
                         {EventTag, Body}]),
             [Pid ! item_not_found
              || {_, _, Pid} <- lists:sort(NS#state.handlers)],
@@ -470,7 +470,7 @@ maybe_diff(Rid, Expected) -> abs(Rid-Expected).
 
 
 -spec resend_cached({Rid :: pos_integer(),
-                     {non_neg_integer(),non_neg_integer(),non_neg_integer()},
+                     {non_neg_integer(), non_neg_integer(), non_neg_integer()},
                      CachedBody :: jlib:xmlel()},
                     state()) -> state().
 resend_cached({_Rid, _, CachedBody}, S) ->
@@ -505,7 +505,7 @@ rid(#state{} = S, Rid) when is_integer(Rid), Rid > 0 ->
                               boolean(),
                               Rid :: rid(),
                               LastProcessed :: 'undefined' | pos_integer()
-                            ) -> {'noreport',_} | {'report',_}.
+                            ) -> {'noreport', _} | {'report', _}.
 determine_report_action(undefined, false, _, _) ->
     {noreport, undefined};
 determine_report_action(undefined, true, Rid, LastProcessed) ->
@@ -540,7 +540,7 @@ is_valid_ack(_, _) ->
 maybe_trim_cache(undefined, S) ->
     S;
 maybe_trim_cache(Ack, S) ->
-    UpToAck = fun({R,_,_}) when R =< Ack ->
+    UpToAck = fun({R, _, _}) when R =< Ack ->
                     true;
                  (_) ->
                     false
@@ -664,7 +664,7 @@ pick_handler(#state{handlers = Handlers} = S) ->
     {{Rid, Pid}, S#state{handlers = HRest}}.
 
 
--spec send_to_handler({_, atom() | pid() | port() | {atom(),atom()}},
+-spec send_to_handler({_, atom() | pid() | port() | {atom(), atom()}},
                       Wrapped :: [any()] | jlib:xmlel(),
                       State :: state() ) -> state().
 send_to_handler({_, Pid}, #xmlel{name = <<"body">>} = Wrapped, State) ->
@@ -678,7 +678,7 @@ send_to_handler({Rid, Pid}, Data, State) ->
 %% @doc This is the most specific variant of send_to_handler()
 %% and the *only one* actually performing a send
 %% to the cowboy_loop_handler serving a HTTP request.
--spec send_wrapped_to_handler(atom() | pid() | port() | {atom(),atom()},
+-spec send_wrapped_to_handler(atom() | pid() | port() | {atom(), atom()},
                               Wrapped :: jlib:xmlel(),
                               State :: state()) -> state().
 send_wrapped_to_handler(Pid, Wrapped, #state{handlers = []} = State) ->
@@ -689,7 +689,7 @@ send_wrapped_to_handler(Pid, Wrapped, State) ->
     State.
 
 
--spec maybe_ack(rid(), state()) -> [{binary(),_}].
+-spec maybe_ack(rid(), state()) -> [{binary(), _}].
 maybe_ack(HandlerRid, #state{rid = Rid} = S) ->
     if
         Rid > HandlerRid ->
@@ -699,7 +699,7 @@ maybe_ack(HandlerRid, #state{rid = Rid} = S) ->
     end.
 
 
--spec maybe_report(state()) -> {[{binary(),_}], state()}.
+-spec maybe_report(state()) -> {[{binary(), _}], state()}.
 maybe_report(#state{report = false} = S) ->
     {[], S};
 maybe_report(#state{report = Report} = S) ->
@@ -710,7 +710,7 @@ maybe_report(#state{report = Report} = S) ->
 
 
 -spec cache_response({rid(), erlang:timestamp(), jlib:xmlel()}, state()) -> state().
-cache_response({Rid,_,_} = Response, #state{sent = Sent} = S) ->
+cache_response({Rid, _, _} = Response, #state{sent = Sent} = S) ->
     NewSent = lists:keymerge(1, [Response], Sent),
     CacheUpTo = case S#state.client_acks of
         true ->
@@ -733,7 +733,7 @@ cache_up_to(N, Responses) ->
     lists:nthtail(max(0, length(Responses) - N), Responses).
 
 
--spec last_processed(rid(),'undefined' | pos_integer()) -> rid().
+-spec last_processed(rid(), 'undefined' | pos_integer()) -> rid().
 last_processed(Rid, undefined) ->
     Rid;
 last_processed(Rid1, Rid2) ->
@@ -920,7 +920,7 @@ bosh_stream_start_body(#xmlstreamstart{attrs = Attrs}, #state{} = S) ->
                     {<<"hold">>, integer_to_binary(S#state.hold)},
                     {<<"from">>, proplists:get_value(<<"from">>, Attrs)},
                     %% TODO: how to support these with cowboy?
-                    {<<"accept">>, <<"deflate,gzip">>},
+                    {<<"accept">>, <<"deflate, gzip">>},
                     {<<"sid">>, S#state.sid},
                     {<<"xmpp:restartlogic">>, <<"true">>},
                     {<<"xmpp:version">>, <<"1.0">>},
@@ -934,18 +934,18 @@ bosh_stream_start_body(#xmlstreamstart{attrs = Attrs}, #state{} = S) ->
            children = []}.
 
 
--spec inactivity('infinity' | 'undefined' | pos_integer()) -> [{binary(),_}].
+-spec inactivity('infinity' | 'undefined' | pos_integer()) -> [{binary(), _}].
 inactivity(I) ->
     [{<<"inactivity">>, integer_to_binary(I)} || is_integer(I)].
 
 
--spec maxpause('undefined' | pos_integer()) -> [{binary(),_}].
+-spec maxpause('undefined' | pos_integer()) -> [{binary(), _}].
 maxpause(MP) ->
     [{<<"maxpause">>, integer_to_binary(MP)} || is_integer(MP)].
 
 
--spec server_ack('false' | 'true' | 'undefined','undefined' | rid())
-            -> [{binary(),_}].
+-spec server_ack('false' | 'true' | 'undefined', 'undefined' | rid())
+            -> [{binary(), _}].
 server_ack(ServerAcks, Rid) ->
     [{<<"ack">>, integer_to_binary(Rid)} || ServerAcks =:= true].
 
@@ -1057,7 +1057,7 @@ peername(#bosh_socket{peer = Peer}) ->
 
 %% @doc Set Fields of the Record to Values,
 %% when {Field, Value} <- FieldValues (in list comprehension syntax).
--spec record_set(state(), [{pos_integer(), _},...]) -> state().
+-spec record_set(state(), [{pos_integer(), _}, ...]) -> state().
 record_set(Record, FieldValues) ->
     F = fun({Field, Value}, Rec) ->
             setelement(Field, Rec, Value)
@@ -1088,6 +1088,6 @@ maybe_add_default_ns(El) ->
 -include_lib("eunit/include/eunit.hrl").
 
 cache_up_to_test_() ->
-    [?_test(?assertEqual( [4,5], cache_up_to(2, [1,2,3,4,5]) ))].
+    [?_test(?assertEqual( [4, 5], cache_up_to(2, [1, 2, 3, 4, 5]) ))].
 
 -endif.

--- a/apps/ejabberd/src/mod_caps.erl
+++ b/apps/ejabberd/src/mod_caps.erl
@@ -509,7 +509,7 @@ make_disco_hash(DiscoEls, Algo) ->
                              concat_features(DiscoEls), concat_info(DiscoEls)]),
     jlib:encode_base64(case Algo of
                            md5 -> erlang:md5(Concat);
-                           sha1 -> crypto:hash(sha,Concat);
+                           sha1 -> crypto:hash(sha, Concat);
                            sha224 -> crypto:hash(sha224, Concat);
                            sha256 -> crypto:hash(sha256, Concat);
                            sha384 -> crypto:hash(sha384, Concat);

--- a/apps/ejabberd/src/mod_disco.erl
+++ b/apps/ejabberd/src/mod_disco.erl
@@ -210,11 +210,11 @@ get_local_identity(Acc, _From, _To, Node, _Lang) when is_binary(Node) ->
     Acc.
 
 
--spec get_local_features(Acc :: 'empty' | {'error',_} | {'result',_},
+-spec get_local_features(Acc :: 'empty' | {'error', _} | {'result', _},
                         From :: ejabberd:jid(),
                         To :: ejabberd:jid(),
                         Node :: binary(),
-                        Lang :: ejabberd:lang()) -> {'error',_} | {'result',_}.
+                        Lang :: ejabberd:lang()) -> {'error', _} | {'result', _}.
 get_local_features({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_local_features(Acc, _From, To, <<>>, _Lang) ->
@@ -255,11 +255,11 @@ domain_to_xml(Domain) ->
     #xmlel{name = <<"item">>, attrs = [{<<"jid">>, Domain}]}.
 
 
--spec get_local_services(Acc :: 'empty' | {'error',_} | {'result',_},
+-spec get_local_services(Acc :: 'empty' | {'error', _} | {'result', _},
                          From :: ejabberd:jid(),
                          To :: ejabberd:jid(),
                          Node :: binary(),
-                         Lang :: ejabberd:lang()) -> {'error',_} | {'result',_}.
+                         Lang :: ejabberd:lang()) -> {'error', _} | {'result', _}.
 get_local_services({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_local_services(Acc, _From, To, <<>>, _Lang) ->
@@ -333,11 +333,11 @@ process_sm_iq_items(From, To, #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ
     end.
 
 
--spec get_sm_items(Acc :: 'empty' | {'error',_} | {'result',_},
+-spec get_sm_items(Acc :: 'empty' | {'error', _} | {'result', _},
                    From :: ejabberd:jid(),
                    To :: ejabberd:jid(),
                    Node :: binary(),
-                   Lang :: ejabberd:lang()) -> {'error',_} | {'result',_}.
+                   Lang :: ejabberd:lang()) -> {'error', _} | {'result', _}.
 get_sm_items({error, _Error} = Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_sm_items(Acc, From,

--- a/apps/ejabberd/src/mod_keystore.erl
+++ b/apps/ejabberd/src/mod_keystore.erl
@@ -153,7 +153,7 @@ init_key({KeyName, ram}, Domain, Opts) ->
     {ok, _ActualKey} = ?BACKEND:init_ram_key(KeyRecord),
     ok.
 
-%% It's easier to trace these than ets:{insert,lookup} - much less noise.
+%% It's easier to trace these than ets:{insert, lookup} - much less noise.
 ets_get_key(KeyID) ->
     ets:lookup(keystore, KeyID).
 

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -235,7 +235,7 @@ store_last_info(LUser, LServer, TimeStamp, Status) ->
     ?BACKEND:set_last_info(LUser, LServer, TimeStamp, Status).
 
 -spec get_last_info(ejabberd:luser(), ejabberd:lserver())
-        -> 'not_found' | {'ok',integer(),string()}.
+        -> 'not_found' | {'ok', integer(), string()}.
 get_last_info(LUser, LServer) ->
     case get_last(LUser, LServer) of
         {error, _Reason} -> not_found;

--- a/apps/ejabberd/src/mod_last_mnesia.erl
+++ b/apps/ejabberd/src/mod_last_mnesia.erl
@@ -45,8 +45,8 @@ get_last(LUser, LServer) ->
 
 -spec count_active_users(ejabberd:lserver(), non_neg_integer()) -> non_neg_integer().
 count_active_users(LServer, TimeStamp) ->
-    MS = [{{last_activity,{'_',LServer},'$1','_'},
-        [{'>','$1',TimeStamp}],
+    MS = [{{last_activity, {'_', LServer}, '$1', '_'},
+        [{'>', '$1', TimeStamp}],
         [true]}],
     ets:select_count(last_activity, MS).
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -131,7 +131,7 @@
                           MessageRows :: [{message_id(), jid(), jlib:xmlel()}]}.
 
 %% Internal types
--type iterator_fun() :: fun(() -> {'ok',{_,_}}).
+-type iterator_fun() :: fun(() -> {'ok', {_, _}}).
 -type rewriter_fun() :: fun((JID :: ejabberd:literal_jid())
                                                     -> ejabberd:literal_jid()).
 -type restore_option() :: {rewrite_jids, rewriter_fun() | [{binary(), binary()}]}
@@ -800,7 +800,7 @@ purge_multiple_messages(Host, ArcID, ArcJID, Borders, Start, End, Now, WithJID) 
 
 
 -spec wait_shaper(ejabberd:server(), action(), ejabberd:jid()
-                  ) -> 'ok' | {'error','max_delay_reached'}.
+                  ) -> 'ok' | {'error', 'max_delay_reached'}.
 wait_shaper(Host, Action, From) ->
     case shaper_srv:wait(Host, action_to_shaper_name(Action), From, 1) of
         ok ->
@@ -816,17 +816,17 @@ wait_shaper(Host, Action, From) ->
                               SrcJID :: ejabberd:jid(),
                               Packet :: jlib:xmlel()}.
 -spec message_row_to_xml(binary(), messid_jid_packet(), QueryId :: binary()) -> jlib:xmlel().
-message_row_to_xml(MamNs, {MessID,SrcJID,Packet}, QueryID) ->
+message_row_to_xml(MamNs, {MessID, SrcJID, Packet}, QueryID) ->
     {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
     DateTime = calendar:now_to_universal_time(microseconds_to_now(Microseconds)),
     BExtMessID = mess_id_to_external_binary(MessID),
     wrap_message(MamNs, Packet, QueryID, BExtMessID, DateTime, SrcJID).
 
-set_client_xmlns_for_row({MessID,SrcJID,Packet}) ->
-    {MessID,SrcJID,set_client_xmlns(Packet)}.
+set_client_xmlns_for_row({MessID, SrcJID, Packet}) ->
+    {MessID, SrcJID, set_client_xmlns(Packet)}.
 
 -spec message_row_to_ext_id(messid_jid_packet()) -> binary().
-message_row_to_ext_id({MessID,_,_}) ->
+message_row_to_ext_id({MessID, _, _}) ->
     mess_id_to_external_binary(MessID).
 
 set_client_xmlns(M) ->
@@ -945,7 +945,7 @@ return_max_delay_reached_error_iq(IQ) ->
 
 
 -spec return_error_iq(ejabberd:iq(), Reason :: term()) -> {error, term(), ejabberd:iq()}.
-return_error_iq(IQ, {Reason,{stacktrace,_Stacktrace}}) ->
+return_error_iq(IQ, {Reason, {stacktrace, _Stacktrace}}) ->
     return_error_iq(IQ, Reason);
 return_error_iq(IQ, timeout) ->
     {error, timeout, IQ#iq{type = error, sub_el = [?ERR_SERVICE_UNAVAILABLE]}};
@@ -957,7 +957,7 @@ return_error_iq(IQ, Reason) ->
 return_message_form_iq(IQ) ->
     IQ#iq{type = result, sub_el = [message_form(IQ#iq.xmlns)]}.
 
-report_issue({Reason,{stacktrace,Stacktrace}}, Issue, ArcJID, IQ) ->
+report_issue({Reason, {stacktrace, Stacktrace}}, Issue, ArcJID, IQ) ->
     report_issue(Reason, Stacktrace, Issue, ArcJID, IQ);
 report_issue(Reason, Issue, ArcJID, IQ) ->
     report_issue(Reason, [], Issue, ArcJID, IQ).

--- a/apps/ejabberd/src/mod_mam_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_cache_user.erl
@@ -144,7 +144,7 @@ stop_muc(Host) ->
 %% API
 %%====================================================================
 
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     gen_server:start_link({local, srv_name()}, ?MODULE, [], []).
 

--- a/apps/ejabberd/src/mod_mam_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_arch.erl
@@ -149,7 +149,7 @@ archive_size(Size, Host, _UserID, UserJID) when is_integer(Size) ->
 insert_query_cql() ->
     "INSERT INTO mam_message "
         "(id, user_jid, from_jid, remote_jid, with_jid, message) "
-        "VALUES (?,?,?,?,?,?)".
+        "VALUES (?, ?, ?, ?, ?, ?)".
 
 archive_message(Result, Host, MessID, _UserID,
                 LocJID, RemJID, SrcJID, Dir, Packet) ->
@@ -305,7 +305,7 @@ lookup_messages2(PoolName, Host,
                  PageSize, LimitPassed, MaxResultLimit,
                  _IsSimple) ->
     %% Query with offset calculation
-    %% We cannot just use ODBC code because "LIMIT X,Y" is not supported by cassandra
+    %% We cannot just use ODBC code because "LIMIT X, Y" is not supported by cassandra
     %% Not all queries are optimal. You would like to disable something for production
     %% once you know how you will call bd
     Strategy = rsm_to_strategy(RSM),
@@ -559,8 +559,8 @@ purge_multiple_messages(_Result, Host, UserID, UserJID, Borders,
 
 %% Offset is not supported
 %% Each record is a tuple of form
-%% `{<<"13663125233">>,<<"bob@localhost">>,<<"res1">>,<<binary>>}'.
-%% Columns are `["id","from_jid","message"]'.
+%% `{<<"13663125233">>, <<"bob@localhost">>, <<"res1">>, <<binary>>}'.
+%% Columns are `["id", "from_jid", "message"]'.
 -spec extract_messages(PoolName, UserJID, Host, Filter, IMax, ReverseLimit) ->
                               [Row] when
       PoolName :: mongoose_cassandra:pool_name(),

--- a/apps/ejabberd/src/mod_mam_muc_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cache_user.erl
@@ -136,7 +136,7 @@ maybe_cache_archive_id(ArcJID, UserID) ->
 %% @private
 cache_archive_id(ArcJID, UserID) ->
     case room_pid(ArcJID) of
-        {error,not_found} ->
+        {error, not_found} ->
             ok;
         RoomPid ->
             gen_server:call(srv_name(), {cache_archive_id, ArcJID, UserID, RoomPid})

--- a/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
@@ -150,7 +150,7 @@ archive_size(Size, Host, _RoomID, RoomJID) when is_integer(Size) ->
 insert_query_cql() ->
     "INSERT INTO mam_muc_message "
         "(id, room_jid, nick_name, with_nick, message) "
-        "VALUES (?,?,?,?,?)".
+        "VALUES (?, ?, ?, ?, ?)".
 
 archive_message(Result, Host, MessID, _RoomID,
                 LocJID, NickName, NickName, Dir, Packet) ->
@@ -306,7 +306,7 @@ lookup_messages2(PoolName, Host,
                  PageSize, LimitPassed, MaxResultLimit,
                  _IsSimple) ->
     %% Query with offset calculation
-    %% We cannot just use ODBC code because "LIMIT X,Y" is not supported by cassandra
+    %% We cannot just use ODBC code because "LIMIT X, Y" is not supported by cassandra
     %% Not all queries are optimal. You would like to disable something for production
     %% once you know how you will call bd
     Strategy = rsm_to_strategy(RSM),
@@ -555,8 +555,8 @@ purge_multiple_messages(_Result, Host, RoomID, RoomJID, Borders,
 
 %% Offset is not supported
 %% Each record is a tuple of form
-%% `{<<"13663125233">>,<<"bob@localhost">>,<<"res1">>,<<binary>>}'.
-%% Columns are `["id","nick_name","message"]'.
+%% `{<<"13663125233">>, <<"bob@localhost">>, <<"res1">>, <<binary>>}'.
+%% Columns are `["id", "nick_name", "message"]'.
 -spec extract_messages(PoolName, RoomJID, Host, Filter, IMax, ReverseLimit) ->
                               [Row] when
       PoolName :: mongoose_cassandra:pool_name(),

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -59,7 +59,7 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(ejabberd:server(),_) -> 'ok'.
+-spec start(ejabberd:server(), _) -> 'ok'.
 start(Host, Opts) ->
     compile_params_module(Opts),
     start_muc(Host, Opts).
@@ -73,7 +73,7 @@ stop(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam_muc
 
--spec start_muc(ejabberd:server(),_) -> 'ok'.
+-spec start_muc(ejabberd:server(), _) -> 'ok'.
 start_muc(Host, _Opts) ->
     case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
         true ->
@@ -177,7 +177,7 @@ prepare_message_1(Host, MessID, RoomID, FromNick, Packet) ->
     [SMessID, SRoomID, SFromNick, SData].
 
 
--spec archive_messages(ejabberd:lserver(), Acc :: [[any(),...]]) -> any().
+-spec archive_messages(ejabberd:lserver(), Acc :: [[any(), ...]]) -> any().
 archive_messages(LServer, Acc) ->
     mod_mam_utils:success_sql_query(
       LServer,
@@ -185,7 +185,7 @@ archive_messages(LServer, Acc) ->
        "VALUES ", tuples(Acc)]).
 
 
--spec archive_messages(ejabberd:lserver(), Acc :: [[any(),...]],
+-spec archive_messages(ejabberd:lserver(), Acc :: [[any(), ...]],
                        N :: any()) -> any().
 archive_messages(LServer, Acc, N) ->
     mod_mam_utils:success_sql_query(
@@ -377,13 +377,13 @@ lookup_messages(Host, RoomID, RoomJID = #jid{},
     end.
 
 
--spec after_id(integer(), [[binary()],...]) -> [[binary()],...].
+-spec after_id(integer(), [[binary()], ...]) -> [[binary()], ...].
 after_id(ID, Filter) ->
     SID = escape_message_id(ID),
     [Filter, " AND id > '", SID, "'"].
 
 
--spec before_id('undefined' | integer(), [[binary()],...]) -> [[binary()],...].
+-spec before_id('undefined' | integer(), [[binary()], ...]) -> [[binary()], ...].
 before_id(undefined, Filter) ->
     Filter;
 before_id(ID, Filter) ->
@@ -400,7 +400,7 @@ rows_to_uniform_format(MessageRows, Host, RoomJID) ->
 
 
 -spec row_to_uniform_format(atom(), atom(), raw_row(), ejabberd:jid()) -> mod_mam_muc:row().
-row_to_uniform_format(DbEngine, EscFormat, {BMessID,BNick,SDataRaw}, RoomJID) ->
+row_to_uniform_format(DbEngine, EscFormat, {BMessID, BNick, SDataRaw}, RoomJID) ->
     MessID = list_to_integer(binary_to_list(BMessID)),
     SrcJID = jid:replace_resource(RoomJID, BNick),
     SData = ejabberd_odbc:unescape_odbc_binary(DbEngine, SDataRaw),
@@ -409,8 +409,8 @@ row_to_uniform_format(DbEngine, EscFormat, {BMessID,BNick,SDataRaw}, RoomJID) ->
     {MessID, SrcJID, Packet}.
 
 
--spec row_to_message_id({binary(),_,_}) -> integer().
-row_to_message_id({BMessID,_,_}) ->
+-spec row_to_message_id({binary(), _, _}) -> integer().
+row_to_message_id({BMessID, _, _}) ->
     list_to_integer(binary_to_list(BMessID)).
 
 
@@ -462,7 +462,7 @@ purge_multiple_messages(_Result, Host, RoomID, _RoomJID, Borders,
     ok.
 
 
-%% @doc Columns are `["id","nick_name","message"]'.
+%% @doc Columns are `["id", "nick_name", "message"]'.
 -spec extract_messages(Host :: ejabberd:server(), RoomID :: mod_mam:archive_id(),
         Filter :: filter(), IOffset :: non_neg_integer(), IMax :: pos_integer(),
         ReverseLimit :: boolean()) -> [raw_row()].
@@ -623,17 +623,17 @@ maybe_jid_to_escaped_resource(#jid{lresource = WithLResource}) ->
     ejabberd_odbc:escape(WithLResource).
 
 
--spec join([[any(),...],...]) -> [[any()],...].
+-spec join([[any(), ...], ...]) -> [[any()], ...].
 join([H|T]) ->
     [H, [", " ++ X || X <- T]].
 
 
--spec tuples([[any(),...]]) -> [[any()],...].
+-spec tuples([[any(), ...]]) -> [[any()], ...].
 tuples(Rows) ->
     join([tuple(Row) || Row <- Rows]).
 
 
--spec tuple([any(),...]) -> [any(),...].
+-spec tuple([any(), ...]) -> [any(), ...].
 tuple([H|T]) ->
     ["('", H, "'", [[", '", X, "'"] || X <- T], ")"].
 
@@ -684,7 +684,7 @@ compile_params_module(Params) ->
 
 expand_simple_param(Params) ->
     lists:flatmap(fun(simple) -> simple_params();
-                     ({simple,true}) -> simple_params();
+                     ({simple, true}) -> simple_params();
                      (Param) -> [Param]
                   end, Params).
 

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -66,7 +66,7 @@ worker_count(Host) ->
     gen_mod:get_module_opt(Host, ?MODULE, pool_size, ?DEFAULT_POOL_SIZE).
 
 
--spec worker_names(ejabberd:server()) -> [{integer(),atom()}].
+-spec worker_names(ejabberd:server()) -> [{integer(), atom()}].
 worker_names(Host) ->
     [{N, worker_name(Host, N)} || N <- lists:seq(0, worker_count(Host) - 1)].
 
@@ -91,13 +91,13 @@ worker_number(Host, ArcID) ->
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(ejabberd:server(),_) -> 'ok'.
+-spec start(ejabberd:server(), _) -> 'ok'.
 start(Host, Opts) ->
     start_workers(Host),
     start_muc(Host, Opts).
 
 
--spec stop(ejabberd:server()) -> ['ok' | {'error','not_found' | 'restarting'
+-spec stop(ejabberd:server()) -> ['ok' | {'error', 'not_found' | 'restarting'
                                   | 'running' | 'simple_one_for_one'}].
 stop(Host) ->
     stop_muc(Host),
@@ -106,7 +106,7 @@ stop(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam_muc
 
--spec start_muc(ejabberd:server(),_) -> 'ok'.
+-spec start_muc(ejabberd:server(), _) -> 'ok'.
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_archive_message, Host, ?MODULE, archive_message, 50),
     ejabberd_hooks:add(mam_muc_archive_size, Host, ?MODULE, archive_size, 30),
@@ -131,24 +131,24 @@ stop_muc(Host) ->
 %% API
 %%====================================================================
 
--spec start_workers(ejabberd:server()) -> [{'error',_}
-                                        | {'ok','undefined' | pid()}
-                                        | {'ok','undefined' | pid(),_}].
+-spec start_workers(ejabberd:server()) -> [{'error', _}
+                                        | {'ok', 'undefined' | pid()}
+                                        | {'ok', 'undefined' | pid(), _}].
 start_workers(Host) ->
     [start_worker(WriterProc, N, Host)
      || {N, WriterProc} <- worker_names(Host)].
 
 
 -spec stop_workers(ejabberd:server()) -> ['ok'
-    | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}].
+    | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}].
 stop_workers(Host) ->
     [stop_worker(WriterProc) ||  {_, WriterProc} <- worker_names(Host)].
 
 
 -spec start_worker(atom(), integer(), ejabberd:server())
       -> {'error', _}
-         | {'ok','undefined' | pid()}
-         | {'ok','undefined' | pid(), _}.
+         | {'ok', 'undefined' | pid()}
+         | {'ok', 'undefined' | pid(), _}.
 start_worker(WriterProc, N, Host) ->
     WriterChildSpec =
     {WriterProc,
@@ -161,13 +161,13 @@ start_worker(WriterProc, N, Host) ->
 
 
 -spec stop_worker(atom()) -> 'ok'
-        | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+        | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_worker(Proc) ->
     supervisor:terminate_child(mod_mam_sup, Proc),
     supervisor:delete_child(mod_mam_sup, Proc).
 
 
--spec start_link(atom(),_,_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(atom(), _, _) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(ProcName, N, Host) ->
     gen_server:start_link({local, ProcName}, ?MODULE, [Host, N], []).
 
@@ -207,7 +207,7 @@ is_overloaded(Pid) ->
 
 
 %% @doc For metrics.
--spec queue_length(ejabberd:server()) -> {'ok',number()}.
+-spec queue_length(ejabberd:server()) -> {'ok', number()}.
 queue_length(Host) ->
     Len = lists:sum(queue_lengths(Host)),
     {ok, Len}.
@@ -380,7 +380,7 @@ init([Host, N]) ->
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
 -spec handle_call('wait_flushing', _, state())
-      -> {'noreply', state()} | {'reply','ok',state()}.
+      -> {'noreply', state()} | {'reply', 'ok', state()}.
 handle_call(get_connection, _From, State=#state{conn = Conn}) ->
     {reply, Conn, State};
 handle_call(wait_flushing, _From, State=#state{acc=[]}) ->
@@ -426,7 +426,7 @@ handle_cast(Msg, State) ->
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 
--spec handle_info('flush',state()) -> {'noreply',state()}.
+-spec handle_info('flush', state()) -> {'noreply', state()}.
 handle_info(flush, State) ->
     {noreply, run_flush(State#state{flush_interval_tref=undefined})}.
 

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -98,7 +98,7 @@ stop(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam
 
--spec start_pm(ejabberd:server(),_) -> 'ok'.
+-spec start_pm(ejabberd:server(), _) -> 'ok'.
 start_pm(Host, _Opts) ->
     case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
         true ->
@@ -133,7 +133,7 @@ stop_pm(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam_muc
 
--spec start_muc(ejabberd:server(),_) -> 'ok'.
+-spec start_muc(ejabberd:server(), _) -> 'ok'.
 start_muc(Host, _Opts) ->
     case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
         true ->
@@ -509,7 +509,7 @@ rows_to_uniform_format(Host, UserJID, MessageRows) ->
     DbEngine = ejabberd_odbc:db_engine(Host),
     [row_to_uniform_format(DbEngine, UserJID, EscFormat, Row) || Row <- MessageRows].
 
-row_to_uniform_format(DbEngine, UserJID, EscFormat, {BMessID,BSrcJID,SDataRaw}) ->
+row_to_uniform_format(DbEngine, UserJID, EscFormat, {BMessID, BSrcJID, SDataRaw}) ->
     MessID = list_to_integer(binary_to_list(BMessID)),
     SrcJID = stored_binary_to_jid(UserJID, BSrcJID),
     SData = ejabberd_odbc:unescape_odbc_binary(DbEngine, SDataRaw),
@@ -517,7 +517,7 @@ row_to_uniform_format(DbEngine, UserJID, EscFormat, {BMessID,BSrcJID,SDataRaw}) 
     Packet = stored_binary_to_packet(Data),
     {MessID, SrcJID, Packet}.
 
-row_to_message_id({BMessID,_,_}) ->
+row_to_message_id({BMessID, _, _}) ->
     list_to_integer(binary_to_list(BMessID)).
 
 
@@ -571,8 +571,8 @@ purge_multiple_messages(_Result, Host, UserID, UserJID, Borders,
 
 
 %% @doc Each record is a tuple of form
-%% `{<<"13663125233">>,<<"bob@localhost">>,<<binary>>}'.
-%% Columns are `["id","from_jid","message"]'.
+%% `{<<"13663125233">>, <<"bob@localhost">>, <<binary>>}'.
+%% Columns are `["id", "from_jid", "message"]'.
 -type msg() :: {binary(), ejabberd:literal_jid(), binary()}.
 -spec extract_messages(Host :: ejabberd:server(), _UserID :: mod_mam:archive_id(),
         Filter :: filter(), IOffset :: non_neg_integer(), IMax :: pos_integer(),
@@ -594,11 +594,11 @@ do_extract_messages(Host, UserID, Filter, 0, IMax, Order) ->
     {LimitSQL, LimitMSSQL} = odbc_queries:get_db_specific_limits(IMax),
     mod_mam_utils:success_sql_query(
         Host,
-        ["SELECT ", LimitMSSQL," id, from_jid, message "
+        ["SELECT ", LimitMSSQL, " id, from_jid, message "
         "FROM ", select_table(UserID), " ",
             Filter,
             Order,
-            " ",LimitSQL]);
+            " ", LimitSQL]);
 do_extract_messages(Host, UserID, Filter, IOffset, IMax, Order) ->
     {LimitSQL, _LimitMSSQL} = odbc_queries:get_db_specific_limits(IMax),
     Offset = odbc_queries:get_db_specific_offset(IOffset, IMax),
@@ -804,7 +804,7 @@ compile_params_module(Params) ->
 
 expand_simple_param(Params) ->
     lists:flatmap(fun(simple) -> simple_params();
-                     ({simple,true}) -> simple_params();
+                     ({simple, true}) -> simple_params();
                      (Param) -> [Param]
                   end, Params).
 

--- a/apps/ejabberd/src/mod_mam_odbc_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_prefs.erl
@@ -28,7 +28,7 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(ejabberd:server(),_) -> 'ok'.
+-spec start(ejabberd:server(), _) -> 'ok'.
 start(Host, Opts) ->
     case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
         true ->
@@ -63,7 +63,7 @@ stop(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam
 
--spec start_pm(ejabberd:server(),_) -> 'ok'.
+-spec start_pm(ejabberd:server(), _) -> 'ok'.
 start_pm(Host, _Opts) ->
     ejabberd_hooks:add(mam_get_behaviour, Host, ?MODULE, get_behaviour, 50),
     ejabberd_hooks:add(mam_get_prefs, Host, ?MODULE, get_prefs, 50),
@@ -84,7 +84,7 @@ stop_pm(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam_muc_muc
 
--spec start_muc(ejabberd:server(),_) -> 'ok'.
+-spec start_muc(ejabberd:server(), _) -> 'ok'.
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_get_behaviour, Host, ?MODULE, get_behaviour, 50),
     ejabberd_hooks:add(mam_muc_get_prefs, Host, ?MODULE, get_prefs, 50),
@@ -210,7 +210,7 @@ query_behaviour(Host, SUserID, SRemLJID, SRemLBareJID) ->
     Result =
     mod_mam_utils:success_sql_query(
       Host,
-      ["SELECT ", LimitMSSQL," behaviour "
+      ["SELECT ", LimitMSSQL, " behaviour "
        "FROM mam_config "
        "WHERE user_id='", SUserID, "' "
          "AND (remote_jid='' OR remote_jid='", SRemLJID, "'",
@@ -227,7 +227,7 @@ query_behaviour(Host, SUserID, SRemLJID, SRemLBareJID) ->
 %% ----------------------------------------------------------------------
 %% Helpers
 
--spec encode_behaviour('always' | 'never' | 'roster') -> [65|78|82,...].
+-spec encode_behaviour('always' | 'never' | 'roster') -> [65|78|82, ...].
 encode_behaviour(roster) -> "R";
 encode_behaviour(always) -> "A";
 encode_behaviour(never)  -> "N".
@@ -244,19 +244,19 @@ esc_jid(JID) ->
     ejabberd_odbc:escape(jid:to_binary(JID)).
 
 
--spec encode_first_config_row(SUserID :: string(), SBehaviour :: [65|78|82,...],
-    SJID :: string()) -> [string(),...].
+-spec encode_first_config_row(SUserID :: string(), SBehaviour :: [65|78|82, ...],
+    SJID :: string()) -> [string(), ...].
 encode_first_config_row(SUserID, SBehavour, SJID) ->
     ["('", SUserID, "', '", SBehavour, "', '", SJID, "')"].
 
 
--spec encode_config_row(SUserID :: string(), SBehaviour :: [65 | 78,...],
-        SJID :: binary() | string()) -> [binary() | string(),...].
+-spec encode_config_row(SUserID :: string(), SBehaviour :: [65 | 78, ...],
+        SJID :: binary() | string()) -> [binary() | string(), ...].
 encode_config_row(SUserID, SBehavour, SJID) ->
     [", ('", SUserID, "', '", SBehavour, "', '", SJID, "')"].
 
 
--spec sql_transaction_map(ejabberd:server(), [iolist(),...]) -> any().
+-spec sql_transaction_map(ejabberd:server(), [iolist(), ...]) -> any().
 sql_transaction_map(LServer, Queries) ->
     AtomicF = fun() ->
         [mod_mam_utils:success_sql_query(LServer, Query) || Query <- Queries]
@@ -268,7 +268,7 @@ sql_transaction_map(LServer, Queries) ->
         DefaultMode :: mod_mam:archive_behaviour(),
         AlwaysJIDs :: [ejabberd:literal_jid()],
         NeverJIDs :: [ejabberd:literal_jid()]) ->
-    {mod_mam:archive_behaviour(),[ejabberd:literal_jid()],[ejabberd:literal_jid()]}.
+    {mod_mam:archive_behaviour(), [ejabberd:literal_jid()], [ejabberd:literal_jid()]}.
 decode_prefs_rows([{<<>>, Behavour}|Rows], _DefaultMode, AlwaysJIDs, NeverJIDs) ->
     decode_prefs_rows(Rows, decode_behaviour(Behavour), AlwaysJIDs, NeverJIDs);
 decode_prefs_rows([{JID, <<"A">>}|Rows], DefaultMode, AlwaysJIDs, NeverJIDs) ->

--- a/apps/ejabberd/src/mod_mam_odbc_user.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_user.erl
@@ -24,7 +24,7 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(ejabberd:server(),_) -> 'ok'.
+-spec start(ejabberd:server(), _) -> 'ok'.
 start(Host, Opts) ->
     case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
         true ->
@@ -59,7 +59,7 @@ stop(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam
 
--spec start_pm(ejabberd:server(),_) -> 'ok'.
+-spec start_pm(ejabberd:server(), _) -> 'ok'.
 start_pm(Host, _Opts) ->
     ejabberd_hooks:add(mam_archive_id, Host, ?MODULE, archive_id, 50),
     case gen_mod:get_module_opt(Host, ?MODULE, auto_remove, false) of
@@ -88,7 +88,7 @@ stop_pm(Host) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam_muc
 
--spec start_muc(ejabberd:server(),_) -> 'ok'.
+-spec start_muc(ejabberd:server(), _) -> 'ok'.
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_archive_id, Host, ?MODULE, archive_id, 50),
     case gen_mod:get_module_opt(Host, ?MODULE, auto_remove, false) of
@@ -172,7 +172,7 @@ create_user_archive(Host, Server, UserName) ->
             ok;
         %% Ignore the race condition
         %% Duplicate entry ... for key 'uc_mam_server_user_name'
-        {error,"#23000" ++ _} ->
+        {error, "#23000" ++ _} ->
             ok
         %% TODO duplicate entry and postgres?
     end.

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -201,7 +201,7 @@ bucket({_, _, _} = Date) ->
 bucket({Year, Week}) ->
     YearBin = integer_to_binary(Year),
     WeekNumBin = integer_to_binary(Week),
-    {?MAM_BUCKET_TYPE, <<"mam_",YearBin/binary, "_", WeekNumBin/binary>>};
+    {?MAM_BUCKET_TYPE, <<"mam_", YearBin/binary, "_", WeekNumBin/binary>>};
 bucket(_) ->
     undefined.
 
@@ -406,12 +406,12 @@ do_fold_archive(Fun, BucketKeys, InitialAcc) ->
     lists:foldl(fun({_Index, Props}, Acc) ->
         {_, Bucket} = lists:keyfind(<<"_yz_rb">>, 1, Props),
         {_, Type} = lists:keyfind(<<"_yz_rt">>, 1, Props),
-        {_ , Key} = lists:keyfind(<<"_yz_rk">>, 1, Props),
+        {_, Key} = lists:keyfind(<<"_yz_rk">>, 1, Props),
         Fun({Type, Bucket}, Key, Acc)
     end, InitialAcc, BucketKeys).
 
 key_filters(Jid) ->
-    <<"_yz_rk:",Jid/binary,"*">>.
+    <<"_yz_rk:", Jid/binary, "*">>.
 
 key_filters(LocalJid, undefined) ->
     key_filters(LocalJid);
@@ -420,7 +420,7 @@ key_filters(LocalJid, MsgId) when is_integer(MsgId) ->
     MsgIdBin = integer_to_binary(MsgId),
     <<StartsWith/binary, " AND msg_id_register:", MsgIdBin/binary>>;
 key_filters(LocalJid, RemoteJid) ->
-    <<"_yz_rk:",LocalJid/binary,"/", RemoteJid/binary,"*">>.
+    <<"_yz_rk:", LocalJid/binary, "/", RemoteJid/binary, "*">>.
 
 key_filters(LocalJid, RemoteJid, undefined, undefined) ->
     key_filters(LocalJid, RemoteJid);
@@ -437,7 +437,7 @@ id_filters(StartInt, EndInt) ->
     solr_id_filters(integer_to_binary(StartInt), integer_to_binary(EndInt)).
 
 solr_id_filters(Start, End) ->
-    <<"msg_id_register:[",Start/binary," TO ", End/binary," ]">>.
+    <<"msg_id_register:[", Start/binary, " TO ", End/binary, " ]">>.
 
 calculate_msg_id_borders(#rsm_in{id = undefined}, Borders, Start, End) ->
     calculate_msg_id_borders(undefined, Borders, Start, End);

--- a/apps/ejabberd/src/mod_mam_sup.erl
+++ b/apps/ejabberd/src/mod_mam_sup.erl
@@ -48,7 +48,7 @@ start_link() ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% Whenever a supervisor is started using supervisor:start_link/[2,3],
+%% Whenever a supervisor is started using supervisor:start_link/[2, 3],
 %% this function is called by the new process to find out about
 %% restart strategy, maximum restart frequency and child
 %% specifications.

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -102,7 +102,7 @@ rsm_ns_binary() -> <<"http://jabber.org/protocol/rsm">>.
 
 %% ----------------------------------------------------------------------
 %% Datetime types
--type ne_binary() :: <<_:8,_:_*8>>.
+-type ne_binary() :: <<_:8, _:_*8>>.
 -type iso8601_datetime_binary() :: ne_binary().
 %% Microseconds from 01.01.1970
 -type unix_timestamp() :: mod_mam:unix_timestamp().
@@ -147,7 +147,7 @@ iso8601_datetime_binary_to_timestamp(DateTime) when is_binary(DateTime) ->
 
 
 -spec datetime_to_microseconds(calendar:datetime()) -> integer().
-datetime_to_microseconds({{_,_,_}, {_,_,_}} = DateTime) ->
+datetime_to_microseconds({{_, _, _}, {_, _, _}} = DateTime) ->
     S1 = calendar:datetime_to_gregorian_seconds(DateTime),
     S0 = calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}),
     Seconds = S1 - S0,
@@ -172,7 +172,7 @@ generate_message_id() ->
 %%
 %% It removes a leading 0 from 64-bit binary representation.
 %% It puts node id as a last byte.
-%% The maximum date, that can be encoded is `{{4253,5,31},{22,20,37}}'.
+%% The maximum date, that can be encoded is `{{4253, 5, 31}, {22, 20, 37}}'.
 -spec encode_compact_uuid(integer(), integer()) -> integer().
 encode_compact_uuid(Microseconds, NodeId)
     when is_integer(Microseconds), is_integer(NodeId) ->
@@ -180,7 +180,7 @@ encode_compact_uuid(Microseconds, NodeId)
 
 
 %% @doc Extract date and node id from a message id.
--spec decode_compact_uuid(integer()) -> {integer(),byte()}.
+-spec decode_compact_uuid(integer()) -> {integer(), byte()}.
 decode_compact_uuid(Id) ->
     Microseconds = Id bsr 8,
     NodeId = Id band 255,
@@ -247,7 +247,7 @@ append_x_user_element(FromJID, Role, Affiliation, Packet) ->
     ItemElem = x_user_item(FromJID, Role, Affiliation),
     X = #xmlel{
         name = <<"x">>,
-        attrs = [{<<"xmlns">>,?NS_MUC_USER}],
+        attrs = [{<<"xmlns">>, ?NS_MUC_USER}],
         children = [ItemElem]},
     xml:append_subtags(Packet, [X]).
 
@@ -367,7 +367,7 @@ replace_from_attribute(From, Packet=#xmlel{attrs = Attrs}) ->
 
 %% @doc Generates tag `<result />'.
 %% This element will be added in each forwarded message.
--spec result(binary(), _, MessageUID :: binary(), Children :: [jlib:xmlel(),...])
+-spec result(binary(), _, MessageUID :: binary(), Children :: [jlib:xmlel(), ...])
             -> jlib:xmlel().
 result(MamNs, QueryID, MessageUID, Children) when is_list(Children) ->
     %% <result xmlns='urn:xmpp:mam:tmp' queryid='f27' id='28482-98726-73623' />
@@ -704,7 +704,7 @@ expand_minified_jid(UserJID, Encoded) ->
     Part = binary:match(Encoded, [<<$@>>, <<$/>>, <<$:>>]),
     expand_minified_jid_2(Part, UserJID, Encoded).
 
--spec expand_minified_jid_2('nomatch' | {non_neg_integer(),1},
+-spec expand_minified_jid_2('nomatch' | {non_neg_integer(), 1},
             ejabberd:jid(), Encoded :: ejabberd:luser() | binary()) -> binary().
 expand_minified_jid_2(nomatch,  #jid{lserver=ThisServer}, LUser) ->
     <<LUser/binary, $@, ThisServer/binary>>;
@@ -846,7 +846,7 @@ is_last_page(_PageSize, _TotalCount, _Offset, _MessageRows) ->
 %% Ejabberd
 
 -spec send_message(ejabberd:jid(), ejabberd:jid(), jlib:xmlel()
-                  ) -> 'ok' | {'error','lager_not_running'}.
+                  ) -> 'ok' | {'error', 'lager_not_running'}.
 
 -ifdef(MAM_COMPACT_FORWARDED).
 

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -134,11 +134,11 @@
 %% API
 %%====================================================================
 %%--------------------------------------------------------------------
-%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
+%% Function: start_link() -> {ok, Pid} | ignore | {error, Error}
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 -spec start_link(ejabberd:server(), list())
-            -> 'ignore' | {'error',_} | {'ok',pid()}.
+            -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
@@ -161,7 +161,7 @@ start(Host, Opts) ->
 
 
 -spec stop(ejabberd:server()) -> 'ok'
-    | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+    | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop(Host) ->
     stop_supervisor(Host),
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
@@ -194,7 +194,7 @@ create_instant_room(Host, Name, From, Nick, Opts) ->
 
 
 -spec store_room(ejabberd:server(), room(), list())
-            -> {'aborted',_} | {'atomic',_}.
+            -> {'aborted', _} | {'atomic', _}.
 store_room(Host, Name, Opts) ->
     F = fun() ->
                 mnesia:write(#muc_room{name_host = {Name, Host},
@@ -269,7 +269,7 @@ can_use_nick(Host, JID, Nick) ->
 %%                         {stop, Reason}
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
--spec init([ejabberd:server() | list(),...]) -> {'ok',state()}.
+-spec init([ejabberd:server() | list(), ...]) -> {'ok', state()}.
 init([Host, Opts]) ->
     mnesia:create_table(muc_room,
                         [{disc_copies, [node()]},
@@ -463,9 +463,9 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 %%% Internal functions
 %%--------------------------------------------------------------------
--spec start_supervisor(ejabberd:server()) -> {'error',_}
-                                           | {'ok','undefined' | pid()}
-                                           | {'ok','undefined' | pid(),_}.
+-spec start_supervisor(ejabberd:server()) -> {'error', _}
+                                           | {'ok', 'undefined' | pid()}
+                                           | {'ok', 'undefined' | pid(), _}.
 start_supervisor(Host) ->
     Proc = gen_mod:get_module_proc(Host, ejabberd_mod_muc_sup),
     ChildSpec =
@@ -480,7 +480,7 @@ start_supervisor(Host) ->
 
 
 -spec stop_supervisor(ejabberd:server()) -> 'ok'
-    | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+    | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_supervisor(Host) ->
     Proc = gen_mod:get_module_proc(Host, ejabberd_mod_muc_sup),
     supervisor:terminate_child(ejabberd_sup, Proc),
@@ -498,7 +498,7 @@ route(Routed, State) ->
     To :: ejabberd:simple_jid() | ejabberd:jid(), Packet :: any()},
         state()) -> 'ok' | pid().
 route_by_privilege({From, To, Packet} = Routed,
-                   #state{access={AccessRoute,_,_,_},
+                   #state{access={AccessRoute, _, _, _},
                           server_host=ServerHost} = State) ->
     case acl:match_rule(ServerHost, AccessRoute, From) of
         allow ->
@@ -515,10 +515,10 @@ route_by_privilege({From, To, Packet} = Routed,
 
 
 -spec route_to_room(room(), from_to_packet(), state()) -> 'ok' | pid().
-route_to_room(<<>>, {_,To,_} = Routed, State) ->
+route_to_room(<<>>, {_, To, _} = Routed, State) ->
     {_, _, Nick} = jid:to_lower(To),
     route_by_nick(Nick, Routed, State);
-route_to_room(Room, {From,To,Packet} = Routed, #state{host=Host} = State) ->
+route_to_room(Room, {From, To, Packet} = Routed, #state{host=Host} = State) ->
     case mnesia:dirty_read(muc_online_room, {Room, Host}) of
         [] ->
             route_to_nonexistent_room(Room, Routed, State);
@@ -666,7 +666,7 @@ route_by_type(<<"iq">>, {From, To, Packet}, #state{host = Host} = State) ->
     end;
 route_by_type(<<"message">>, {From, To, Packet},
               #state{host = Host, server_host = ServerHost,
-                     access = {_,_,AccessAdmin,_}}) ->
+                     access = {_, _, AccessAdmin, _}}) ->
     #xmlel{attrs = Attrs} = Packet,
     case xml:get_attr_s(<<"type">>, Attrs) of
         <<"error">> ->
@@ -739,9 +739,9 @@ load_permanent_rooms(Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuth
         HistorySize :: 'undefined' | integer(), RoomShaper :: shaper:shaper(),
         HttpAuthPool :: none | mongoose_http_client:pool(), From :: ejabberd:jid(), nick(),
         DefRoomOpts :: 'undefined' | [any()])
-            -> {'error',_}
-             | {'ok','undefined' | pid()}
-             | {'ok','undefined' | pid(),_}.
+            -> {'error', _}
+             | {'ok', 'undefined' | pid()}
+             | {'ok', 'undefined' | pid(), _}.
 start_new_room(Host, ServerHost, Access, Room,
                HistorySize, RoomShaper, HttpAuthPool, From,
                Nick, DefRoomOpts) ->
@@ -761,7 +761,7 @@ start_new_room(Host, ServerHost, Access, Room,
 
 
 -spec register_room('undefined' | ejabberd:server(), room(),
-                    'undefined' | pid()) -> {'aborted',_} | {'atomic',_}.
+                    'undefined' | pid()) -> {'aborted', _} | {'atomic', _}.
 register_room(Host, Room, Pid) ->
     F = fun() ->
                 mnesia:write(#muc_online_room{name_host = {Room, Host},
@@ -922,7 +922,7 @@ iq_get_unique(From) ->
 
 -spec iq_get_register_info('undefined' | ejabberd:server(),
         ejabberd:simple_jid() | ejabberd:jid(), ejabberd:lang())
-            -> [jlib:xmlel(),...].
+            -> [jlib:xmlel(), ...].
 iq_get_register_info(Host, From, Lang) ->
     {LUser, LServer, _} = jid:to_lower(From),
     LUS = {LUser, LServer},
@@ -951,7 +951,7 @@ iq_get_register_info(Host, From, Lang) ->
 
 -spec iq_set_register_info(ejabberd:server(),
         ejabberd:simple_jid() | ejabberd:jid(), nick(), ejabberd:lang())
-            -> {'error',jlib:xmlel()} | {'result',[]}.
+            -> {'error', jlib:xmlel()} | {'result', []}.
 iq_set_register_info(Host, From, Nick, Lang) ->
     {LUser, LServer, _} = jid:to_lower(From),
     LUS = {LUser, LServer},
@@ -998,7 +998,7 @@ iq_set_register_info(Host, From, Nick, Lang) ->
 
 -spec process_iq_register_set(ejabberd:server(), ejabberd:jid(),
         jlib:xmlel(), ejabberd:lang())
-            -> {'error', jlib:xmlel()} | {'result',[]}.
+            -> {'error', jlib:xmlel()} | {'result', []}.
 process_iq_register_set(Host, From, SubEl, Lang) ->
     #xmlel{children = Els} = SubEl,
     case xml:get_subtag(SubEl, <<"remove">>) of
@@ -1034,7 +1034,7 @@ process_iq_register_set(Host, From, SubEl, Lang) ->
     end.
 
 
--spec iq_get_vcard(ejabberd:lang()) -> [jlib:xmlel(),...].
+-spec iq_get_vcard(ejabberd:lang()) -> [jlib:xmlel(), ...].
 iq_get_vcard(Lang) ->
     [#xmlel{name = <<"FN">>,
             children = [#xmlcdata{content = <<"ejabberd/mod_muc">>}]},

--- a/apps/ejabberd/src/mod_muc_commands.erl
+++ b/apps/ejabberd/src/mod_muc_commands.erl
@@ -135,7 +135,7 @@ invite_to_room(Host, Name, Sender, Recipient, Reason) ->
     %% Direct invitation: i.e. not mediated by MUC room. See XEP 0249.
     X = #xmlel{name = <<"x">>,
                attrs = [{<<"xmlns">>, ?NS_CONFERENCE},
-                        {<<"jid">> , room_address(Name, Host)},
+                        {<<"jid">>, room_address(Name, Host)},
                         {<<"reason">>, Reason}]
               },
     Invite = message(S, R, <<>>, [ X ]),

--- a/apps/ejabberd/src/mod_muc_iq.erl
+++ b/apps/ejabberd/src/mod_muc_iq.erl
@@ -28,7 +28,7 @@ tbl_name() ->
 %% API
 %%====================================================================
 
--spec start_link() -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     gen_server:start_link({local, srv_name()}, ?MODULE, [], []).
 

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -268,7 +268,7 @@ remove_user(User, Server) ->
     Version = mod_muc_light_utils:bin_ts(),
     case mod_muc_light_db_backend:remove_user(UserUS, Version) of
         {error, _} = Err ->
-            ?ERROR_MSG("hook=remove_user,error=~p", [Err]);
+            ?ERROR_MSG("hook=remove_user, error=~p", [Err]);
         AffectedRooms ->
             bcast_removed_user(UserUS, AffectedRooms, Version),
             maybe_forget_rooms(AffectedRooms)

--- a/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_light_db_mnesia.erl
@@ -337,7 +337,7 @@ remove_user_transaction(UserUS, Version) ->
     lists:map(
       fun(#?USER_ROOM_TAB{ room = RoomUS }) ->
               {RoomUS, modify_aff_users_transaction(
-                         RoomUS, [{UserUS, none}], fun(_,_) -> ok end, Version)}
+                         RoomUS, [{UserUS, none}], fun(_, _) -> ok end, Version)}
       end, mnesia:read(?USER_ROOM_TAB, UserUS)).
 
 %% ------------------------ Configuration manipulation ------------------------

--- a/apps/ejabberd/src/mod_muc_log.erl
+++ b/apps/ejabberd/src/mod_muc_log.erl
@@ -83,15 +83,15 @@
 %%====================================================================
 
 %% @doc Starts the server
--spec start_link(ejabberd:server(),_) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(ejabberd:server(), _) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
 
--spec start(ejabberd:server(),_) -> {'error',_}
-                                  | {'ok','undefined' | pid()}
-                                  | {'ok','undefined' | pid(),_}.
+-spec start(ejabberd:server(), _) -> {'error', _}
+                                  | {'ok', 'undefined' | pid()}
+                                  | {'ok', 'undefined' | pid(), _}.
 start(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     ChildSpec =
@@ -105,7 +105,7 @@ start(Host, Opts) ->
 
 
 -spec stop(ejabberd:server()) -> 'ok'
-    | {'error','not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
+    | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
@@ -140,7 +140,7 @@ check_access_log(Host, From) ->
 %%                         {stop, Reason}
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
--spec init([list() | ejabberd:server(),...]) -> {'ok',logstate()}.
+-spec init([list() | ejabberd:server(), ...]) -> {'ok', logstate()}.
 init([Host, Opts]) ->
     OutDir = list_to_binary(gen_mod:get_opt(outdir, Opts, "www/muc")),
     DirType = gen_mod:get_opt(dirtype, Opts, subdirs),
@@ -182,9 +182,9 @@ init([Host, Opts]) ->
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
 -spec handle_call('stop'
-            | {'check_access_log','global' | ejabberd:server(), ejabberd:jid()},
-        From :: any(), logstate()) -> {'reply','allow' | 'deny',logstate()}
-                                    | {'stop','normal','ok',_}.
+            | {'check_access_log', 'global' | ejabberd:server(), ejabberd:jid()},
+        From :: any(), logstate()) -> {'reply', 'allow' | 'deny', logstate()}
+                                    | {'stop', 'normal', 'ok', _}.
 handle_call({check_access_log, ServerHost, FromJID}, _From, State) ->
     Reply = acl:match_rule(ServerHost, State#logstate.access, FromJID),
     {reply, Reply, State};
@@ -325,7 +325,7 @@ get_timestamp_daydiff(TimeStamp, Daydiff) ->
 
 
 %% @doc Try to close the previous day log, if it exists
--spec close_previous_log(binary(), any(), file_format()) -> 'ok' | {'error',atom()}.
+-spec close_previous_log(binary(), any(), file_format()) -> 'ok' | {'error', atom()}.
 close_previous_log(Fn, Images_dir, FileFormat) ->
     case file:read_file_info(Fn) of
         {ok, _} ->
@@ -363,7 +363,7 @@ add_message_to_log(Nick1, Message, RoomJID, Opts, State) ->
            top_link = TopLink} = State,
     Room = get_room_info(RoomJID, Opts),
     Nick = htmlize(Nick1, FileFormat),
-    Nick2 = htmlize(<<"<",Nick1/binary,">">>, FileFormat),
+    Nick2 = htmlize(<<"<", Nick1/binary, ">">>, FileFormat),
     Now = now(),
     TimeStamp = case Timezone of
                     local -> calendar:now_to_local_time(Now);
@@ -423,17 +423,17 @@ add_message_to_log(Nick1, Message, RoomJID, Opts, State) ->
                        <<"<font class=\"mj\">", Nick/binary, " ", (?T(<<"leaves the room">>))/binary, "</font><br/>">>;
                {leave, Reason} ->
                        <<"<font class=\"ml\">", Nick/binary, " ", (?T(<<"leaves the room">>))/binary, ": ",
-                            (htmlize(Reason,NoFollow,FileFormat))/binary, ": ~s</font><br/>">>;
+                            (htmlize(Reason, NoFollow, FileFormat))/binary, ": ~s</font><br/>">>;
                {kickban, "301", ""} ->
                        <<"<font class=\"mb\">", Nick/binary, " ", (?T(<<"has been banned">>))/binary, "</font><br/>">>;
                {kickban, "301", Reason} ->
                        <<"<font class=\"mb\">", Nick/binary, " ", (?T(<<"has been banned">>))/binary, ": ",
-                            (htmlize(Reason,FileFormat))/binary, "</font><br/>">>;
+                            (htmlize(Reason, FileFormat))/binary, "</font><br/>">>;
                {kickban, "307", ""} ->
                        <<"<font class=\"mk\">", Nick/binary, " ", (?T(<<"has been kicked">>))/binary, "</font><br/>">>;
                {kickban, "307", Reason} ->
                        <<"<font class=\"mk\">", Nick/binary, " ", (?T(<<"has been kicked">>))/binary, ": ",
-                            (htmlize(Reason,FileFormat))/binary, "</font><br/>">>;
+                            (htmlize(Reason, FileFormat))/binary, "</font><br/>">>;
                {kickban, "321", ""} ->
                        <<"<font class=\"mk\">", Nick/binary, " ",
                             (?T(<<"has been kicked because of an affiliation change">>))/binary, "</font><br/>">>;
@@ -444,22 +444,22 @@ add_message_to_log(Nick1, Message, RoomJID, Opts, State) ->
                        <<"<font class=\"mk\">", Nick/binary, " ",
                             (?T(<<"has been kicked because of a system shutdown">>))/binary, "</font><br/>">>;
                {nickchange, OldNick} ->
-                       <<"<font class=\"mnc\">", (htmlize(OldNick,FileFormat))/binary, " ",
+                       <<"<font class=\"mnc\">", (htmlize(OldNick, FileFormat))/binary, " ",
                             (?T(<<"is now known as">>))/binary, " ", Nick/binary, "</font><br/>">>;
                {subject, T} ->
                       <<"<font class=\"msc\">", Nick/binary, (?T(<<" has set the subject to: ">>))/binary,
-                            (htmlize(T,NoFollow,FileFormat))/binary, "</font><br/>">>;
+                            (htmlize(T, NoFollow, FileFormat))/binary, "</font><br/>">>;
                {body, T} ->
                        case {re:run(T, <<"^/me\s">>, [{capture, none}]), Nick} of
                            {_, ""} ->
-                                   <<"<font class=\"msm\">", (htmlize(T,NoFollow,FileFormat))/binary, "</font><br/>">>;
+                                   <<"<font class=\"msm\">", (htmlize(T, NoFollow, FileFormat))/binary, "</font><br/>">>;
                            {match, _} ->
                        %% Delete "/me " from the beginning.
-                               <<_Pref:32, SubStr/binary>> = htmlize(T,FileFormat),
+                               <<_Pref:32, SubStr/binary>> = htmlize(T, FileFormat),
                                    <<"<font class=\"mne\">", Nick/binary, " ", SubStr/binary, "</font><br/>">>;
                            {nomatch, _} ->
                                    <<"<font class=\"mn\">", Nick2/binary, "</font> ",
-                                        (htmlize(T,NoFollow,FileFormat))/binary, "<br/>">>
+                                        (htmlize(T, NoFollow, FileFormat))/binary, "<br/>">>
                        end;
                {room_existence, RoomNewExistence} ->
                        <<"<font class=\"mrcm\">", (get_room_existence_string(RoomNewExistence, Lang))/binary, "</font><br/>">>
@@ -527,7 +527,7 @@ get_dateweek(Date, Lang) ->
     end.
 
 
--spec make_dir_rec(binary()) -> 'ok' | {'error',atom()}.
+-spec make_dir_rec(binary()) -> 'ok' | {'error', atom()}.
 make_dir_rec(Dir) ->
     case file:read_file_info(Dir) of
         {ok, _} ->
@@ -673,7 +673,7 @@ image_base64(<<"powered-by-ejabberd.png">>) ->
         "AElFTkSuQmCC">>.
 
 
--spec create_image_files(<<_:8,_:_*8>>) -> 'ok'.
+-spec create_image_files(<<_:8, _:_*8>>) -> 'ok'.
 create_image_files(Images_dir) ->
     Filenames = [<<"powered-by-ejabberd.png">>,
                  <<"powered-by-erlang.png">>,
@@ -797,7 +797,7 @@ put_room_config(_F, _RoomConfig, _Lang, plaintext) ->
     ok;
 put_room_config(F, RoomConfig, Lang, _FileFormat) ->
     {Now1, Now2, Now3} = now(),
-    NowBin = list_to_binary(lists:flatten(io_lib:format("~p~p~p", [Now1,Now2,Now3]))),
+    NowBin = list_to_binary(lists:flatten(io_lib:format("~p~p~p", [Now1, Now2, Now3]))),
     fw(F, <<"<div class=\"rc\">">>),
     fw(F,   <<"<div class=\"rct\" onclick=\"sh('a", NowBin/binary, "');return false;\">", (?T(<<"Room Configuration">>))/binary, "</div>">>),
     fw(F,   <<"<div class=\"rcos\" id=\"a", NowBin/binary, "\" style=\"display: none;\" ><br/>", RoomConfig/binary, "</div>">>),
@@ -810,7 +810,7 @@ put_room_occupants(_F, _RoomOccupants, _Lang, plaintext) ->
     ok;
 put_room_occupants(F, RoomOccupants, Lang, _FileFormat) ->
     {Now1, Now2, Now3} = now(),
-    NowBin = list_to_binary(lists:flatten(io_lib:format("~p~p~p", [Now1,Now2,Now3]))),
+    NowBin = list_to_binary(lists:flatten(io_lib:format("~p~p~p", [Now1, Now2, Now3]))),
     fw(F, <<"<div class=\"rc\">">>),
     fw(F,   <<"<div class=\"rct\" onclick=\"sh('o", NowBin/binary, "');return false;\">", (?T(<<"Room Occupants">>))/binary, "</div>">>),
     fw(F,   <<"<div class=\"rcos\" id=\"o", NowBin/binary, "\" style=\"display: none;\" ><br/>", RoomOccupants/binary, "</div>">>),
@@ -857,7 +857,7 @@ htmlize2(S1, NoFollow) ->
          {<<"((http|https|ftp)://|(mailto|xmpp):)[^] )\'\"}]+">>, link_regexp(NoFollow)},
          {<<"  ">>, <<"\\&nbsp;\\&nbsp;">>},
          {<<"\\t">>, <<"\\&nbsp;\\&nbsp;\\&nbsp;\\&nbsp;">>},
-         {<<226,128,174>>, <<"[RLO]">>}],
+         {<<226, 128, 174>>, <<"[RLO]">>}],
     lists:foldl(fun({RegExp, Replace}, Acc) ->
                         re:replace(Acc, RegExp, Replace, [global, {return, binary}])
                 end, S1, ReplacementRules).
@@ -991,7 +991,7 @@ group_by_role(Users) ->
 
 
 %% Users = [{JID, Nick}]
--spec role_users_to_string(string(), [jid_nick()]) -> [string(),...].
+-spec role_users_to_string(string(), [jid_nick()]) -> [string(), ...].
 role_users_to_string(RoleS, Users) ->
     SortedUsers = lists:keysort(2, Users),
     UsersString = [[Nick, "<br/>"] || {_JID, Nick} <- SortedUsers],

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -156,9 +156,9 @@
             Access :: _, Room :: mod_muc:room(), HistorySize :: integer(),
             RoomShaper :: shaper:shaper(), HttpAuthPool :: none | mongoose_http_client:pool(),
             Creator :: ejabberd:jid(), Nick :: mod_muc:nick(),
-            DefRoomOpts :: list()) -> {'error',_}
-                                          | {'ok','undefined' | pid()}
-                                          | {'ok','undefined' | pid(),_}.
+            DefRoomOpts :: list()) -> {'error', _}
+                                          | {'ok', 'undefined' | pid()}
+                                          | {'ok', 'undefined' | pid(), _}.
 start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
       Creator, Nick, DefRoomOpts) ->
     ?SUPERVISOR_START.
@@ -167,9 +167,9 @@ start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
 -spec start(Host :: ejabberd:server(), ServerHost :: ejabberd:server(),
             Access :: _, Room :: mod_muc:room(), HistorySize :: integer(),
             RoomShaper :: shaper:shaper(), HttpAuthPool :: none | mongoose_http_client:pool(),
-            Opts :: list()) -> {'error',_}
-                                   | {'ok','undefined' | pid()}
-                                   | {'ok','undefined' | pid(),_}.
+            Opts :: list()) -> {'error', _}
+                                   | {'ok', 'undefined' | pid()}
+                                   | {'ok', 'undefined' | pid(), _}.
 start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opts) ->
     Supervisor = gen_mod:get_module_proc(ServerHost, ejabberd_mod_muc_sup),
     supervisor:start_child(Supervisor, [Host, ServerHost, Access, Room,
@@ -308,7 +308,7 @@ read_hibernate_timeout(Host) ->
 %% @doc In the locked state StateData contains the same settings it previously
 %% held for the normal_state. The fsm awaits either a confirmation or a
 %% configuration form from the creator. Responds with error to any other queries.
--spec locked_error({'route',ejabberd:jid(),_,jlib:xmlel()},
+-spec locked_error({'route', ejabberd:jid(), _, jlib:xmlel()},
                    statename(), state()) -> fsm_return().
 locked_error({route, From, ToNick, #xmlel{attrs = Attrs} = Packet},
              NextState, StateData) ->
@@ -354,7 +354,7 @@ is_query_allowed(Query) ->
 
 
 -spec locked_state_process_owner_iq(ejabberd:jid(), jlib:xmlel(),
-        ejabberd:lang(), 'error' | 'get' | 'invalid' | 'result',_)
+        ejabberd:lang(), 'error' | 'get' | 'invalid' | 'result', _)
             -> {{'error', jlib:xmlel()}, statename()}
                | {result, [jlib:xmlel() | jlib:xmlcdata()], state() | stop}.
 locked_state_process_owner_iq(From, Query, Lang, set, StateData) ->
@@ -372,7 +372,7 @@ locked_state_process_owner_iq(_From, _Query, Lang, _Type, _StateData) ->
 
 
 %% @doc Destroy room / confirm instant room / configure room
--spec locked_state({'route',From :: ejabberd:jid(), To :: mod_muc:nick(),
+-spec locked_state({'route', From :: ejabberd:jid(), To :: mod_muc:nick(),
                    Packet :: jlib:xmlel()}, state()) -> fsm_return().
 locked_state({route, From, _ToNick,
               #xmlel{name = <<"iq">>} = Packet}, StateData) ->
@@ -771,7 +771,7 @@ occupant_jid(#user{nick=Nick}, RoomJID) ->
     jid:replace_resource(RoomJID, Nick).
 
 
--spec route(atom() | pid() | port() | {atom(),_} | {'via',_,_},
+-spec route(atom() | pid() | port() | {atom(), _} | {'via', _, _},
     From :: ejabberd:jid(), To :: mod_muc:nick(), Pkt :: jlib:xmlel()) -> 'ok'.
 route(Pid, From, ToNick, Packet) ->
     gen_fsm:send_event(Pid, {route, From, ToNick, Packet}).
@@ -1121,7 +1121,7 @@ check_and_strip_visitor_status(From, Packet, StateData) ->
 
 
 -spec handle_new_user(ejabberd:jid(), mod_muc:nick(), jlib:xmlel(), state(),
-                      [{binary(),binary()}]) -> state().
+                      [{binary(), binary()}]) -> state().
 handle_new_user(From, Nick = <<>>, _Packet, StateData, Attrs) ->
     Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
     ErrText = <<"No nickname">>,
@@ -1156,7 +1156,7 @@ is_occupant_or_admin(JID, StateData) ->
 %%%
 
 -spec is_user_online_iq(_, ejabberd:jid(), state())
-            -> {'false',_,ejabberd:jid()} | {'true',_,ejabberd:jid()}.
+            -> {'false', _, ejabberd:jid()} | {'true', _, ejabberd:jid()}.
 is_user_online_iq(StanzaId, JID, StateData) when JID#jid.lresource /= <<>> ->
     {is_user_online(JID, StateData), StanzaId, JID};
 is_user_online_iq(StanzaId, JID, StateData) when JID#jid.lresource == <<>> ->
@@ -1587,7 +1587,7 @@ store_user_activity(JID, UserActivity, StateData) ->
     StateData1.
 
 
--spec clean_treap(treap:treap(), {1,integer()}) -> treap:treap().
+-spec clean_treap(treap:treap(), {1, integer()}) -> treap:treap().
 clean_treap(Treap, CleanPriority) ->
     case treap:is_empty(Treap) of
     true ->
@@ -2053,7 +2053,7 @@ count_stanza_shift(Nick, Els, StateData) ->
     lists:max([Shift0, Shift1, Shift2, Shift3]).
 
 
--spec count_seconds_shift(integer(),[any()]) -> number().
+-spec count_seconds_shift(integer(), [any()]) -> number().
 count_seconds_shift(Seconds, HistoryList) ->
     lists:sum(
       lists:map(
@@ -2068,7 +2068,7 @@ count_seconds_shift(Seconds, HistoryList) ->
     end, HistoryList)).
 
 
--spec count_maxstanzas_shift(non_neg_integer(),[any()]) -> integer().
+-spec count_maxstanzas_shift(non_neg_integer(), [any()]) -> integer().
 count_maxstanzas_shift(MaxStanzas, HistoryList) ->
     S = length(HistoryList) - MaxStanzas,
     max(0, S).
@@ -2893,7 +2893,7 @@ process_admin_items_set(UJID, Items, Lang, StateData) ->
                     'affiliation' | 'role', any(), any()}.
 -spec find_changed_items(ejabberd:jid(), mod_muc:affiliation(), mod_muc:role(),
         [jlib:xmlel()], ejabberd:lang(), state(), [res_row()])
-            -> {'error', jlib:xmlel()} | {'result',[res_row()]}.
+            -> {'error', jlib:xmlel()} | {'result', [res_row()]}.
 find_changed_items(_UJID, _UAffiliation, _URole, [], _Lang, _StateData, Res) ->
     {result, Res};
 find_changed_items(UJID, UAffiliation, URole, [#xmlcdata{} | Items],
@@ -3431,7 +3431,7 @@ is_password_settings_correct(XEl, StateData) ->
         false;
     {true, undefined, _, <<>>} ->
         false;
-    {_, true , <<>>, undefined} ->
+    {_, true, <<>>, undefined} ->
         false;
     {_, true, _, <<>>} ->
         false;
@@ -3448,7 +3448,7 @@ get_default_room_maxusers(RoomState) ->
 
 
 -spec get_config(ejabberd:lang(), state(), ejabberd:jid())
-            -> {'result',[jlib:xmlel(),...], state()}.
+            -> {'result', [jlib:xmlel(), ...], state()}.
 get_config(Lang, StateData, From) ->
     AccessPersistent = access_persistent(StateData),
     ServiceMaxUsers = get_service_max_users(StateData),
@@ -3744,7 +3744,7 @@ set_xoption([_ | _Opts], _Config) ->
     {error, ?ERR_BAD_REQUEST}.
 
 
--spec change_config(config(), state()) -> {'result',[],state()}.
+-spec change_config(config(), state()) -> {'result', [], state()}.
 change_config(Config, StateData) ->
     NSD = StateData#state{config = Config},
     case {(StateData#state.config)#config.persistent,
@@ -3844,7 +3844,7 @@ set_opts([{Opt, Val} | Opts], SD=#state{config = C = #config{}}) ->
 
 -define(MAKE_CONFIG_OPT(Opt), {Opt, Config#config.Opt}).
 
--spec make_opts(state()) -> [{atom(),_},...].
+-spec make_opts(state()) -> [{atom(), _}, ...].
 make_opts(StateData) ->
     Config = StateData#state.config,
     [
@@ -3945,7 +3945,7 @@ config_opt_to_feature(Opt, Fiftrue, Fiffalse) ->
 
 -spec process_iq_disco_info(ejabberd:jid(), 'get' | 'set', ejabberd:lang(),
                             state()) -> {'error', jlib:xmlel()}
-                                      | {'result',[jlib:xmlel(),...],state()}.
+                                      | {'result', [jlib:xmlel(), ...], state()}.
 process_iq_disco_info(_From, set, _Lang, _StateData) ->
     {error, ?ERR_NOT_ALLOWED};
 process_iq_disco_info(_From, get, Lang, StateData) ->
@@ -4003,8 +4003,8 @@ iq_disco_info_extras(Lang, StateData) ->
 
 
 -spec process_iq_disco_items(ejabberd:jid(), 'get' | 'set', ejabberd:lang(),
-                            state()) -> {'error',jlib:xmlel()}
-                                      | {'result',[jlib:xmlel()],state()}.
+                            state()) -> {'error', jlib:xmlel()}
+                                      | {'result', [jlib:xmlel()], state()}.
 process_iq_disco_items(_From, set, _Lang, _StateData) ->
     {error, ?ERR_NOT_ALLOWED};
 process_iq_disco_items(From, get, _Lang, StateData) ->
@@ -4032,7 +4032,7 @@ get_title(StateData) ->
 
 
 -spec get_roomdesc_reply(ejabberd:jid(), state(), Tail :: binary()
-                        ) -> 'false' | {'item',_}.
+                        ) -> 'false' | {'item', _}.
 get_roomdesc_reply(JID, StateData, Tail) ->
     IsOccupantOrAdmin = is_occupant_or_admin(JID, StateData),
     if (StateData#state.config)#config.public or IsOccupantOrAdmin ->
@@ -4126,7 +4126,7 @@ get_field(_Var, []) ->
 
 -spec check_invitation(ejabberd:simple_jid() | ejabberd:jid(),
         [jlib:xmlcdata() | jlib:xmlel()], ejabberd:lang(), state())
-            -> {'error',_} | {'ok',ejabberd:jid()}.
+            -> {'error', _} | {'ok', ejabberd:jid()}.
 check_invitation(FromJID, Els, Lang, StateData) ->
     try
         unsafe_check_invitation(FromJID, Els, Lang, StateData)
@@ -4291,7 +4291,7 @@ handle_roommessage_from_nonparticipant(Packet, Lang, StateData, From) ->
 %% packet. This function must be catched, because it crashes when the packet
 %% is not a decline message.
 -spec check_decline_invitation(jlib:xmlel()) ->
-    {'true',{jlib:xmlel(), jlib:xmlel(), jlib:xmlel(), 'error' | ejabberd:jid()}}.
+    {'true', {jlib:xmlel(), jlib:xmlel(), jlib:xmlel(), 'error' | ejabberd:jid()}}.
 check_decline_invitation(Packet) ->
     #xmlel{name = <<"message">>} = Packet,
     XEl = xml:get_subtag(Packet, <<"x">>),
@@ -4463,7 +4463,7 @@ route_message(#routed_message{allowed = true, type = <<"groupchat">>,
             MessageInterval =
                 (Activity#activity.message_time +
                 MinMessageInterval - Now) div 1000,
-                Interval = lists:max([MessageInterval,MessageShaperInterval]),
+                Interval = lists:max([MessageInterval, MessageShaperInterval]),
                 erlang:send_after(
                     Interval, self(), {process_user_message, From}),
                 NewActivity = Activity#activity{
@@ -4528,7 +4528,7 @@ route_error(Nick, From, Error, StateData) ->
     StateData.
 
 
--spec route_voice_approval('ok' | {'error',jlib:xmlel()} | {'form',binary()}
+-spec route_voice_approval('ok' | {'error', jlib:xmlel()} | {'form', binary()}
         | {'role', binary(), binary()}, ejabberd:jid(), jlib:xmlel(),
         ejabberd:lang(), state()) -> state().
 route_voice_approval({error, ErrType}, From, Packet, _Lang, StateData) ->

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -516,9 +516,9 @@ resend_offline_message_packet(Server,
 
 add_timestamp(undefined, _Server, Packet) ->
     Packet;
-add_timestamp({_,_,Micro} = TimeStamp, Server, Packet) ->
-    {D,{H,M,S}} = calendar:now_to_universal_time(TimeStamp),
-    Time = {D,{H,M,S, Micro}},
+add_timestamp({_, _, Micro} = TimeStamp, Server, Packet) ->
+    {D, {H, M, S}} = calendar:now_to_universal_time(TimeStamp),
+    Time = {D, {H, M, S, Micro}},
     TimeStampXML = timestamp_xml(Server, Time),
     xml:append_subtags(Packet, [TimeStampXML]).
 

--- a/apps/ejabberd/src/mod_offline_odbc.erl
+++ b/apps/ejabberd/src/mod_offline_odbc.erl
@@ -51,7 +51,7 @@ pop_messages(LUser, LServer) ->
     TimeStamp = now(),
     STimeStamp = encode_timestamp(TimeStamp),
     case odbc_queries:pop_offline_messages(LServer, SUser, SServer, STimeStamp) of
-        {atomic, {selected, [<<"timestamp">>,<<"from_jid">>,<<"packet">>], Rows}} ->
+        {atomic, {selected, [<<"timestamp">>, <<"from_jid">>, <<"packet">>], Rows}} ->
             {ok, rows_to_records(US, To, Rows)};
         {aborted, Reason} ->
             {error, Reason};

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -117,7 +117,7 @@
 %% ------------------------------------------------------------------
 
 start(Host, Opts) ->
-    gen_mod:start_backend_module(?MODULE, Opts, [get_privacy_list,get_list_names,
+    gen_mod:start_backend_module(?MODULE, Opts, [get_privacy_list, get_list_names,
                                                  set_default_list, forget_default_list,
                                                  remove_privacy_list, replace_privacy_list,
                                                  get_default_list]),

--- a/apps/ejabberd/src/mod_privacy_riak.erl
+++ b/apps/ejabberd/src/mod_privacy_riak.erl
@@ -18,7 +18,7 @@
 % NOTES:
 %   user default privacy is stored in bucket {<<"privacy_defaults">>, LServer}, key LUser
 %   user privacy lists names are stored in set {<<"privacy_lists_names">>, <<"LServer">>}, key LUser
-%   user privace lists content are stored in bucket {<<"privacy_lists">>, LServer}, key <<LUser,$/,ListName>>
+%   user privace lists content are stored in bucket {<<"privacy_lists">>, LServer}, key <<LUser, $/, ListName>>
 
 -module(mod_privacy_riak).
 -author('guillaume@bour.cc').

--- a/apps/ejabberd/src/mod_private_riak.erl
+++ b/apps/ejabberd/src/mod_private_riak.erl
@@ -46,7 +46,7 @@ multi_get_data(LUser, LServer, NS2Def) ->
 
 -spec remove_user(ejabberd:luser(), ejabberd:lserver()) -> ok.
 remove_user(LUser, LServer) ->
-    KeyFilter = [[<<"starts_with">>,LUser]],
+    KeyFilter = [[<<"starts_with">>, LUser]],
     Bucket = bucket_type(LServer),
     case mongoose_riak:mapred([{Bucket, KeyFilter}], []) of
         {ok, []} ->

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -102,7 +102,7 @@
 %% API
 %%====================================================================
 %%--------------------------------------------------------------------
-%% Function: start_link() -> {ok,Pid} | ignore | {error,Error}
+%% Function: start_link() -> {ok, Pid} | ignore | {error, Error}
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 
@@ -130,7 +130,7 @@
 
 %% -type payload() defined here because the -type xmlel() is not accessible
 %% from pubsub.hrl
--type(payload() :: [] | [xmlel(),...]).
+-type(payload() :: [] | [xmlel(), ...]).
 
 -export_type([
               pubsubNode/0,
@@ -146,7 +146,7 @@
            id      :: Nidx::mod_pubsub:nodeIdx(),
            parents :: [Node::mod_pubsub:nodeId()],
            type    :: Type::binary(),
-           owners  :: [Owner::ljid(),...],
+           owners  :: [Owner::ljid(), ...],
            options :: Opts::mod_pubsub:nodeOptions()
           }
         ).
@@ -213,7 +213,7 @@
            max_subscriptions_node  :: non_neg_integer()|undefined,
            default_node_config     :: [{atom(), binary()|boolean()|integer()|atom()}],
            nodetree                :: binary(),
-           plugins                 :: [binary(),...],
+           plugins                 :: [binary(), ...],
            db_type                 :: atom()
           }
 
@@ -252,8 +252,8 @@ default_host() ->
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
 -spec init(
-        [binary() | [{_,_}],...])
-        -> {'ok',state()}.
+        [binary() | [{_, _}], ...])
+        -> {'ok', state()}.
 
 init([ServerHost, Opts]) ->
     ?DEBUG("pubsub init ~p ~p", [ServerHost, Opts]),
@@ -520,7 +520,7 @@ disco_local_identity(Acc, _From, _To, _Node, _Lang) ->
           To     :: jid(),
           Node   :: <<>> | mod_pubsub:nodeId(),
           Lang   :: binary())
-        -> [binary(),...].
+        -> [binary(), ...].
 disco_local_features(Acc, _From, To, <<>>, _Lang) ->
     Host = To#jid.lserver,
     Feats = case Acc of
@@ -910,7 +910,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 -spec do_route(
         ServerHost :: binary(),
           Access     :: atom(),
-          Plugins    :: [binary(),...],
+          Plugins    :: [binary(), ...],
           Host       :: mod_pubsub:hostPubsub(),
           From       :: jid(),
           To         :: jid(),
@@ -1218,7 +1218,7 @@ iq_pubsub(Host, ServerHost, From, IQType, SubEl, Lang) ->
           SubEl      :: xmlel(),
           Lang       :: binary(),
           Access     :: atom(),
-          Plugins    :: [binary(),...])
+          Plugins    :: [binary(), ...])
         -> {result, [xmlel()]}
 %%%
                | {error, xmlel()}.
@@ -1751,7 +1751,7 @@ update_auth(Host, Node, Type, Nidx, Subscriber, Allow, Subs) ->
           Type          :: binary(),
           Access        :: atom(),
           Configuration :: [xmlel()])
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 create_node(Host, ServerHost, Node, Owner, Type) ->
@@ -1870,7 +1870,7 @@ create_node(Host, ServerHost, Node, Owner, GivenType, Access, Configuration) ->
         Host  :: mod_pubsub:host(),
           Node  :: mod_pubsub:nodeId(),
           Owner :: jid())
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 delete_node(_Host, <<>>, _Owner) ->
@@ -1954,7 +1954,7 @@ delete_node(Host, Node, Owner) ->
           From          :: jid(),
           JID           :: binary(),
           Configuration :: [xmlel()])
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 subscribe_node(Host, Node, From, JID, Configuration) ->
@@ -2101,7 +2101,7 @@ unsubscribe_node(Host, Node, From, Subscriber, SubId) ->
           Publisher  :: jid(),
           ItemId     :: <<>> | mod_pubsub:itemId(),
           Payload    :: mod_pubsub:payload())
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload) ->
@@ -2343,7 +2343,7 @@ purge_node(Host, Node, Owner) ->
           SMaxItems :: binary(),
           ItemIds   :: [mod_pubsub:itemId()],
           Rsm       :: none | rsm_in())
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 get_items(Host, Node, From, SubId, SMaxItems, ItemIds, RSM) ->
@@ -2501,7 +2501,7 @@ dispatch_items(From, To, _Node, Options, Stanza) ->
           Node    :: mod_pubsub:nodeId(),
           JID     :: jid(),
           Plugins :: [binary()])
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 get_affiliations(Host, Node, JID, Plugins) when is_list(Plugins) ->
@@ -2551,7 +2551,7 @@ get_affiliations(Host, Node, JID, Plugins) when is_list(Plugins) ->
         Host :: mod_pubsub:host(),
           Node :: mod_pubsub:nodeId(),
           JID  :: jid())
-        -> {result, [xmlel(),...]}
+        -> {result, [xmlel(), ...]}
 %%%
                | {error, xmlel()}.
 get_affiliations(Host, Node, JID) ->
@@ -2984,7 +2984,7 @@ set_subscriptions(Host, Node, From, EntitiesEls) ->
 -spec get_presence_and_roster_permissions(
         Host          :: mod_pubsub:host(),
           From          :: ljid(),
-          Owners        :: [ljid(),...],
+          Owners        :: [ljid(), ...],
           AccessModel   :: mod_pubsub:accessModel(),
           AllowedGroups :: [binary()])
         -> {PresenceSubscription::boolean(), RosterGroup::boolean()}.
@@ -3890,8 +3890,8 @@ serverhost({_U, Server, _R})->
     Server;
 serverhost(Host) ->
     case binary:match(Host, <<"pubsub.">>) of
-        {0,7} ->
-            [_,ServerHost] = binary:split(Host, <<".">>),
+        {0, 7} ->
+            [_, ServerHost] = binary:split(Host, <<".">>),
             ServerHost;
         _ ->
             Host
@@ -4130,7 +4130,7 @@ itemsEls(Items) ->
             attrs    = itemAttr(ItemId, Publisher),
             children = Payload}
      || #pubsub_item{itemid    = {ItemId, _},
-                     publisher = Publisher  ,
+                     publisher = Publisher ,
                      payload   = Payload    } <- Items].
 
 -spec add_message_type(
@@ -4215,7 +4215,7 @@ purge_offline(LJID) ->
             lists:foreach(
               fun ({Node, Affiliation}) ->
                       Options = Node#pubsub_node.options,
-                      Publisher = lists:member(Affiliation, [owner,publisher,publish_only]),
+                      Publisher = lists:member(Affiliation, [owner, publisher, publish_only]),
                       Open = (get_option(Options, publish_model) == open),
                       Purge = (get_option(Options, purge_offline)
                                andalso get_option(Options, persist_items)),

--- a/apps/ejabberd/src/mod_register.erl
+++ b/apps/ejabberd/src/mod_register.erl
@@ -415,7 +415,7 @@ ip_to_string(_) -> "unknown".
 
 get_time_string() -> write_time(erlang:localtime()).
 %% Function copied from ejabberd_logger_h.erl and customized
-write_time({{Y,Mo,D},{H,Mi,S}}) ->
+write_time({{Y, Mo, D}, {H, Mi, S}}) ->
     io_lib:format("~w-~.2.0w-~.2.0w ~.2.0w:~.2.0w:~.2.0w",
                   [Y, Mo, D, H, Mi, S]).
 

--- a/apps/ejabberd/src/mod_revproxy.erl
+++ b/apps/ejabberd/src/mod_revproxy.erl
@@ -140,7 +140,7 @@ request_body(Req, #state{length=Length}) ->
     end.
 
 remove_confusing_headers(List) ->
-    [Header || {Field,_}=Header <- List,
+    [Header || {Field, _}=Header <- List,
                not is_header_confusing(cowboy_bstr:to_lower(Field))].
 
 is_header_confusing(<<"transfer-encoding">>) -> true;
@@ -154,7 +154,7 @@ upstream_uri(#match{upstream=Upstream, remainder=Remainder,
               host=UpHost,
               path=UpPath} = Upstream,
     BoundHost = upstream_bindings(UpHost, $., Bindings, <<>>),
-    PathSegments = case {Type,Path} of
+    PathSegments = case {Type, Path} of
         {uri, _} -> UpPath ++ Remainder;
         {_, '_'} -> UpPath ++ Remainder;
         _        -> UpPath ++ Path ++ Remainder
@@ -268,7 +268,7 @@ compile_routes([], Acc) ->
     lists:reverse(Acc);
 compile_routes([{Host, Method, Upstream}|Tail], Acc) ->
     compile_routes([{Host, '_', Method, Upstream}|Tail], Acc);
-compile_routes([{HostMatch,PathMatch,MethodMatch,UpstreamMatch}|Tail], Acc) ->
+compile_routes([{HostMatch, PathMatch, MethodMatch, UpstreamMatch}|Tail], Acc) ->
     HostRule = compile_host(HostMatch),
     Method = compile_method(MethodMatch),
     Upstream = compile_upstream(UpstreamMatch),

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -213,8 +213,8 @@ process_subscription(Direction, User, Server, JID, _Type, Acc) ->
 config_change(Acc, Host, ldap, _NewConfig) ->
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
     Mods = ejabberd_config:get_local_option({modules, Host}),
-    Opts = proplists:get_value(?MODULE,Mods,[]),
-    ok = gen_server:call(Proc,{new_config, Host, Opts}),
+    Opts = proplists:get_value(?MODULE, Mods, []),
+    ok = gen_server:call(Proc, {new_config, Host, Opts}),
     Acc;
 config_change(Acc, _, _, _) ->
     Acc.
@@ -225,7 +225,7 @@ config_change(Acc, _, _, _) ->
 %%====================================================================
 init([Host, Opts]) ->
     State = parse_options(Host, Opts),
-    process_flag(trap_exit,true),
+    process_flag(trap_exit, true),
     cache_tab:new(shared_roster_ldap_user,
                   [{max_size, State#state.user_cache_size}, {lru, false},
                    {life_time, State#state.user_cache_validity}]),
@@ -476,7 +476,7 @@ get_user_part_re(String, Pattern) ->
     end.
 
 parse_options(Host, Opts) ->
-    Eldap_ID = atom_to_binary(gen_mod:get_module_proc(Host, ?MODULE),utf8),
+    Eldap_ID = atom_to_binary(gen_mod:get_module_proc(Host, ?MODULE), utf8),
     Cfg = eldap_utils:get_config(Host, Opts),
     GroupAttr = eldap_utils:get_mod_opt(ldap_groupattr, Opts,
                                         fun iolist_to_binary/1,
@@ -557,7 +557,7 @@ parse_options(Host, Opts) ->
     GroupFilter = case ConfigFilter of
                       <<"">> -> GroupSubFilter;
                       _ ->
-                          <<"(&", GroupSubFilter/binary, ConfigFilter/binary,")">>
+                          <<"(&", GroupSubFilter/binary, ConfigFilter/binary, ")">>
                   end,
     #state{host = Host, eldap_id = Eldap_ID,
            servers = Cfg#eldap_config.servers,

--- a/apps/ejabberd/src/mod_time.erl
+++ b/apps/ejabberd/src/mod_time.erl
@@ -10,8 +10,8 @@
 -export([start/2, stop/1, process_local_iq/3]).
 -include("ejabberd.hrl").
 -include("jlib.hrl").
--xep([{xep, 202}, {version,"2.0"}]).
--xep([{xep, 82}, {version,"1.1"}]).
+-xep([{xep, 202}, {version, "2.0"}]).
+-xep([{xep, 82}, {version, "1.1"}]).
 start(Host, Opts) ->
     mod_disco:register_feature(Host, ?NS_TIME),
     IQDisc = gen_mod:get_opt(iqdisc, Opts,

--- a/apps/ejabberd/src/mod_vcard_ldap.erl
+++ b/apps/ejabberd/src/mod_vcard_ldap.erl
@@ -135,7 +135,7 @@
 %%--------------------------------------------------------------------
 
 init(VHost, Options) ->
-    start_link(VHost,Options),
+    start_link(VHost, Options),
     ok.
 
 remove_user(_LUser, _LServer) ->
@@ -145,15 +145,15 @@ remove_user(_LUser, _LServer) ->
 
 get_vcard(LUser, LServer) ->
     Proc = gen_mod:get_module_proc(LServer, ?PROCNAME),
-    {ok,State} = gen_server:call(Proc, get_state),
+    {ok, State} = gen_server:call(Proc, get_state),
     LServer = State#state.serverhost,
     case ejabberd_auth:is_user_exists(LUser, LServer) of
         true ->
             VCardMap = State#state.vcard_map,
-            case find_ldap_user(LUser,State) of
+            case find_ldap_user(LUser, State) of
                 #eldap_entry{attributes = Attributes} ->
-                    Vcard = ldap_attributes_to_vcard(Attributes, VCardMap,{LUser, LServer}),
-                    {ok,Vcard};
+                    Vcard = ldap_attributes_to_vcard(Attributes, VCardMap, {LUser, LServer}),
+                    {ok, Vcard};
                 _ ->
                     {ok, []}
             end;
@@ -166,17 +166,17 @@ set_vcard(_User, _VHost, _VCard, _VCardSearch) ->
 
 search(LServer, Data) ->
     Proc = gen_mod:get_module_proc(LServer, ?PROCNAME),
-    {ok,State} = gen_server:call(Proc, get_state),
+    {ok, State} = gen_server:call(Proc, get_state),
     search_internal(State, Data).
 
 search_fields(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
-    {ok,State} = gen_server:call(Proc, get_state),
+    {ok, State} = gen_server:call(Proc, get_state),
     State#state.search_fields.
 
 search_reported_fields(Host, Lang) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
-    {ok,State} = gen_server:call(Proc, get_state),
+    {ok, State} = gen_server:call(Proc, get_state),
     SearchReported = State#state.search_reported,
     #xmlel{name = <<"reported">>, attrs = [],
            children =
@@ -417,7 +417,7 @@ search_items(Entries, State) ->
 							       LServer/binary>>)]
 						       ++
 						       [?FIELD(Name,
-                                       search_item_value(Name,Value,BinFields))
+                                       search_item_value(Name, Value, BinFields))
 							|| {Name, Value}
 							       <- RFields],
 					    [#xmlel{name = <<"item">>,
@@ -466,7 +466,7 @@ parse_options(Host, Opts) ->
                               fun(infinity) -> 0;
                                  (I) when is_integer(I), I>0 -> I
                               end, 30),
-    Eldap_ID = atom_to_binary(gen_mod:get_module_proc(Host, ?PROCNAME),utf8),
+    Eldap_ID = atom_to_binary(gen_mod:get_module_proc(Host, ?PROCNAME), utf8),
     Cfg = eldap_utils:get_config(Host, Opts),
     UIDsTemp = eldap_utils:get_opt(
                  {ldap_uids, Host}, Opts,

--- a/apps/ejabberd/src/mod_vcard_mnesia.erl
+++ b/apps/ejabberd/src/mod_vcard_mnesia.erl
@@ -58,17 +58,17 @@ get_vcard(LUser, LServer) ->
 set_vcard(User, VHost, VCard, VCardSearch) ->
     LUser = jid:nodeprep(User),
     F = fun() ->
-                mnesia:write(#vcard{us ={LUser,VHost}, vcard = VCard}),
+                mnesia:write(#vcard{us ={LUser, VHost}, vcard = VCard}),
                 mnesia:write(VCardSearch)
         end,
     {atomic, _} = mnesia:transaction(F),
-    ejabberd_hooks:run(vcard_set, VHost,[LUser,VHost, VCard]),
+    ejabberd_hooks:run(vcard_set, VHost, [LUser, VHost, VCard]),
     ok.
 
 search(VHost, Data) ->
     MatchHead = make_matchhead(VHost, Data),
     R = do_search(VHost, MatchHead),
-    lists:map(fun record_to_item/1,R).
+    lists:map(fun record_to_item/1, R).
 
 do_search(_, #vcard_search{_ = '_'}) ->
     [];
@@ -187,10 +187,10 @@ update_vcard_search_table() ->
          given,    lgiven,
          middle,   lmiddle,
          nickname, lnickname,
-         bday,	   lbday,
-         ctry,	   lctry,
+         bday, 	   lbday,
+         ctry, 	   lctry,
          locality, llocality,
-         email,	   lemail,
+         email, 	   lemail,
          orgname,  lorgname,
          orgunit,  lorgunit] ->
             ?INFO_MSG("Converting vcard_search table from "
@@ -251,10 +251,10 @@ update_vcard_search_table() ->
 						given,    lgiven,
 						middle,   lmiddle,
 						nickname, lnickname,
-						bday,	   lbday,
-						ctry,	   lctry,
+						bday, 	   lbday,
+						ctry, 	   lctry,
 						locality, llocality,
-						email,	   lemail,
+						email, 	   lemail,
 						orgname,  lorgname,
 						orgunit,  lorgunit}))
 			  end, mnesia:table_info(vcard_search, index)),

--- a/apps/ejabberd/src/mod_vcard_odbc.erl
+++ b/apps/ejabberd/src/mod_vcard_odbc.erl
@@ -58,16 +58,16 @@ remove_user(LUser, LServer) ->
 get_vcard(LUser, LServer) ->
     U = ejabberd_odbc:escape(LUser),
     S = ejabberd_odbc:escape(LServer),
-    case odbc_queries:get_vcard(S,U) of
+    case odbc_queries:get_vcard(S, U) of
         {selected, [<<"vcard">>], [{SVCARD}]} ->
             case exml:parse(SVCARD) of
                 {error, Reason} ->
-                    ?WARNING_MSG("not sending bad vcard xml ~p~n~p",[Reason,SVCARD]),
+                    ?WARNING_MSG("not sending bad vcard xml ~p~n~p", [Reason, SVCARD]),
                     {error, ?ERR_SERVICE_UNAVAILABLE};
 		{ok, VCARD} ->
                     {ok, [VCARD]}
             end;
-        {selected, [<<"vcard">>],[]} ->
+        {selected, [<<"vcard">>], []} ->
             {error, ?ERR_SERVICE_UNAVAILABLE}
     end.
 
@@ -115,7 +115,7 @@ set_vcard(User, VHost, VCard, VCardSearch) ->
 search(LServer, Data) ->
     RestrictionSQL = make_restriction_sql(LServer, Data),
     R = do_search(LServer, RestrictionSQL),
-    lists:map(fun(I) -> record_to_item(LServer,I) end, R).
+    lists:map(fun(I) -> record_to_item(LServer, I) end, R).
 
 do_search(_LServer, "") ->
     [];
@@ -148,7 +148,7 @@ filter_fields([], RestrictionSQLIn, LServer) ->
         "" ->
             "";
         _ ->
-            [" where ", [RestrictionSQLIn, " and ", ["server = '", ejabberd_odbc:escape(LServer),"'"]]]
+            [" where ", [RestrictionSQLIn, " and ", ["server = '", ejabberd_odbc:escape(LServer), "'"]]]
     end;
 filter_fields([{SVar, [Val]} | Ds], RestrictionSQL, LServer)
   when is_binary(Val) and (Val /= <<"">>) ->
@@ -171,7 +171,7 @@ filter_fields([{SVar, [Val]} | Ds], RestrictionSQL, LServer)
         end,
     filter_fields(Ds, NewRestrictionSQL, LServer);
 filter_fields([_ | Ds], RestrictionSQL, LServer) ->
-    filter_fields(Ds,RestrictionSQL , LServer).
+    filter_fields(Ds, RestrictionSQL, LServer).
 
 -spec make_val(RestrictionSQL, Field, Val) -> Result when
     RestrictionSQL :: iolist(),

--- a/apps/ejabberd/src/mod_vcard_riak.erl
+++ b/apps/ejabberd/src/mod_vcard_riak.erl
@@ -61,7 +61,7 @@ get_vcard(LUser, LServer) ->
                 {ok, XMLEl} ->
                     {ok, [XMLEl]};
                 {error, Reason} ->
-                    ?WARNING_MSG("not sending bad vcard reason=~p, xml=~n~p",[Reason,XMLBin]),
+                    ?WARNING_MSG("not sending bad vcard reason=~p, xml=~n~p", [Reason, XMLBin]),
                     {error, ?ERR_SERVICE_UNAVAILABLE}
             end;
         {error, notfound} ->

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -122,7 +122,7 @@ from_json(Req, #http_api_state{command_category = Category,
                                bindings = B} = State) ->
     case parse_request_body(Req) of
         {error, _R}->
-            error_response(bad_request, ?BODY_MALFORMED , Req, State);
+            error_response(bad_request, ?BODY_MALFORMED, Req, State);
         {Params, _} ->
             {Method, _} = cowboy_req:method(Req),
             Cmds = mongoose_commands:list(admin, Category, method_to_action(Method), SubCategory),

--- a/apps/ejabberd/src/mongoose_api_client.erl
+++ b/apps/ejabberd/src/mongoose_api_client.erl
@@ -122,7 +122,7 @@ from_json(Req, #http_api_state{command_category = Category, bindings = B} = Stat
     {Method, _} = cowboy_req:method(Req),
     case parse_request_body(Req) of
         {error, _R}->
-            error_response(bad_request, ?BODY_MALFORMED , Req, State);
+            error_response(bad_request, ?BODY_MALFORMED, Req, State);
         {Params, _} ->
         Arity = length(B) + length(Params),
         Cmds = mongoose_commands:list(user, Category, method_to_action(Method)),

--- a/apps/ejabberd/src/mongoose_api_metrics.erl
+++ b/apps/ejabberd/src/mongoose_api_metrics.erl
@@ -136,7 +136,7 @@ get_available_hosts() ->
 get_available_metrics(Host) ->
     mongoose_metrics:get_host_metric_names(Host).
 
--spec get_available_hosts_metrics() -> {[any(),...], [any()]}.
+-spec get_available_hosts_metrics() -> {[any(), ...], [any()]}.
 get_available_hosts_metrics() ->
     Hosts = get_available_hosts(),
     Metrics = [Metric || [Metric] <- get_available_metrics(hd(Hosts))],
@@ -145,16 +145,16 @@ get_available_hosts_metrics() ->
 get_available_global_metrics() ->
     [Metric || [Metric] <- mongoose_metrics:get_global_metric_names()].
 
--spec get_sum_metrics() -> [{_,_}].
+-spec get_sum_metrics() -> [{_, _}].
 get_sum_metrics() ->
     {_Hosts, Metrics} = get_available_hosts_metrics(),
     [{Metric, get_sum_metric(Metric)} || Metric <- Metrics].
 
--spec get_sum_metric(atom()) -> [{_,_}].
+-spec get_sum_metric(atom()) -> [{_, _}].
 get_sum_metric(Metric) ->
     mongoose_metrics:get_aggregated_values(Metric).
 
--spec get_host_metrics(undefined | global | ejabberd:server()) -> [{_,_}].
+-spec get_host_metrics(undefined | global | ejabberd:server()) -> [{_, _}].
 get_host_metrics(Host) ->
     Metrics = mongoose_metrics:get_metric_values(Host),
     [{prep_name(NameParts), Value} || {[_Host | NameParts], Value} <- Metrics].

--- a/apps/ejabberd/src/mongoose_cleaner.erl
+++ b/apps/ejabberd/src/mongoose_cleaner.erl
@@ -71,7 +71,7 @@ cleanup_modules(Node) ->
     Retries = 1,
     case global:trans(LockRequest, C, Nodes, Retries) of
         aborted ->
-            ?DEBUG("could not get ~p~n" , [?NODE_CLEANUP_LOCK(Node)]),
+            ?DEBUG("could not get ~p~n", [?NODE_CLEANUP_LOCK(Node)]),
             {ok, aborted};
         Result ->
             ?WARNING_MSG("cleanup result: ~p~n", [Result]),

--- a/apps/ejabberd/src/mongoose_cluster.erl
+++ b/apps/ejabberd/src/mongoose_cluster.erl
@@ -117,7 +117,7 @@ table_type(ClusterMember, T) ->
                   Type =:= ram_copies;
                   Type =:= disc_only_copies -> Type
     catch
-        E:R -> error({cant_get_storage_type, {T,E,R}}, [T])
+        E:R -> error({cant_get_storage_type, {T, E, R}}, [T])
     end.
 
 %% This will remove all your Mnesia data!

--- a/apps/ejabberd/src/mongoose_commands.erl
+++ b/apps/ejabberd/src/mongoose_commands.erl
@@ -70,7 +70,7 @@
 %% a list of arbitrary length, of a given type
 %% [integer]                        []
 %% [integer]                        [1]
-%% [integer]                        [1,2,3,4]
+%% [integer]                        [1, 2, 3, 4]
 %% a list of anything
 %% []
 %% a named argument (name is only for clarity)

--- a/apps/ejabberd/src/mongoose_metrics.erl
+++ b/apps/ejabberd/src/mongoose_metrics.erl
@@ -116,7 +116,7 @@ get_global_metric_names() ->
     get_host_metric_names(global).
 
 get_aggregated_values(Metric) ->
-    exometer:aggregate([{{['_',Metric],'_','_'},[],[true]}], [one, count, value]).
+    exometer:aggregate([{{['_', Metric], '_', '_'}, [], [true]}], [one, count, value]).
 
 -spec increment_generic_hook_metric(ejabberd:lserver(), atom()) -> ok | {error, any()}.
 increment_generic_hook_metric(Host, Hook) ->

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -59,17 +59,17 @@
          mam_muc_purge_multiple_messages/9
         ]).
 
--type hook() :: [atom() | ejabberd:server() | integer(),...].
+-type hook() :: [atom() | ejabberd:server() | integer(), ...].
 -type metrics_notify_return() ::
                 'ok'
-                | {'error',_,'nonexistent_metric' | 'unsupported_metric_type'}.
+                | {'error', _, 'nonexistent_metric' | 'unsupported_metric_type'}.
 
 %%-------------------
 %% Implementation
 %%-------------------
 
 %% @doc Here will be declared which hooks should be registered
--spec get_hooks(_) -> [hook(),...].
+-spec get_hooks(_) -> [hook(), ...].
 get_hooks(Host) ->
     [[sm_register_connection_hook, Host, ?MODULE, sm_register_connection_hook, 50],
      [sm_remove_connection_hook, Host, ?MODULE, sm_remove_connection_hook, 50],
@@ -112,24 +112,24 @@ get_hooks(Host) ->
 
 -spec sm_register_connection_hook(tuple(), ejabberd:jid(), term()
                                  ) -> metrics_notify_return().
-sm_register_connection_hook(_,#jid{server = Server}, _) ->
+sm_register_connection_hook(_, #jid{server = Server}, _) ->
     mongoose_metrics:update(Server, sessionSuccessfulLogins, 1),
     mongoose_metrics:update(Server, sessionCount, 1).
 
 -spec sm_remove_connection_hook(tuple(), ejabberd:jid(),
                                 term(), ejabberd_sm:close_reason()
                                ) -> metrics_notify_return().
-sm_remove_connection_hook(_,#jid{server = Server},_, _Reason) ->
+sm_remove_connection_hook(_, #jid{server = Server}, _, _Reason) ->
     mongoose_metrics:update(Server, sessionLogouts, 1),
     mongoose_metrics:update(Server, sessionCount, -1).
 
 -spec auth_failed(binary(), binary()) -> metrics_notify_return().
-auth_failed(_,Server) ->
+auth_failed(_, Server) ->
     mongoose_metrics:update(Server, sessionAuthFails, 1).
 
 -spec user_send_packet(ejabberd:jid(), tuple(), tuple()
                       ) -> metrics_notify_return().
-user_send_packet(#jid{server = Server},_,Packet) ->
+user_send_packet(#jid{server = Server}, _, Packet) ->
     mongoose_metrics:update(Server, xmppStanzaSent, 1),
     user_send_packet_type(Server, Packet).
 
@@ -143,7 +143,7 @@ user_send_packet_type(Server, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(Server, xmppPresenceSent, 1).
 
 -spec user_receive_packet(ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
-user_receive_packet(#jid{server = Server} ,_,_,Packet) ->
+user_receive_packet(#jid{server = Server}, _, _, Packet) ->
     mongoose_metrics:update(Server, xmppStanzaReceived, 1),
     user_receive_packet_type(Server, Packet).
 
@@ -162,7 +162,7 @@ xmpp_bounce_message(Server, _) ->
     mongoose_metrics:update(Server, xmppMessageBounced, 1).
 
 -spec xmpp_stanza_dropped(ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
-xmpp_stanza_dropped(#jid{server = Server} ,_,_) ->
+xmpp_stanza_dropped(#jid{server = Server}, _, _) ->
    mongoose_metrics:update(Server, xmppStanzaDropped, 1).
 
 -spec xmpp_send_element(Server :: ejabberd:server(),
@@ -194,31 +194,31 @@ roster_get(Acc, {_, Server}) ->
     Acc.
 
 -spec roster_set(JID :: ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
-roster_set(#jid{server = Server},_,_) ->
+roster_set(#jid{server = Server}, _, _) ->
     mongoose_metrics:update(Server, modRosterSets, 1).
 
 -spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
-roster_in_subscription(Acc,_,Server,_,subscribed,_) ->
+roster_in_subscription(Acc, _, Server, _, subscribed, _) ->
     mongoose_metrics:update(Server, modPresenceSubscriptions, 1),
     Acc;
-roster_in_subscription(Acc,_,Server,_,unsubscribed,_) ->
+roster_in_subscription(Acc, _, Server, _, unsubscribed, _) ->
     mongoose_metrics:update(Server, modPresenceUnsubscriptions, 1),
     Acc;
-roster_in_subscription(Acc,_,_,_,_,_) ->
+roster_in_subscription(Acc, _, _, _, _, _) ->
     Acc.
 
--spec roster_push(ejabberd:jid(),term()) -> metrics_notify_return().
-roster_push(#jid{server = Server},_) ->
+-spec roster_push(ejabberd:jid(), term()) -> metrics_notify_return().
+roster_push(#jid{server = Server}, _) ->
     mongoose_metrics:update(Server, modRosterPush, 1).
 
 %% Register
 
 -spec register_user(binary(), ejabberd:server()) -> metrics_notify_return().
-register_user(_,Server) ->
+register_user(_, Server) ->
     mongoose_metrics:update(Server, modRegisterCount, 1).
 
 -spec remove_user(binary(), ejabberd:server()) -> metrics_notify_return().
-remove_user(_,Server) ->
+remove_user(_, Server) ->
     mongoose_metrics:update(Server, modUnregisterCount, 1).
 
 %% Privacy
@@ -419,4 +419,4 @@ mam_muc_purge_multiple_messages(Result, Host,
     Result.
 
 
-%%% vim: set sts=4 ts=4 sw=4 et filetype=erlang foldmarker=%%%',%%%. foldmethod=marker:
+%%% vim: set sts=4 ts=4 sw=4 et filetype=erlang foldmarker=%%%', %%%. foldmethod=marker:

--- a/apps/ejabberd/src/mongoose_riak.erl
+++ b/apps/ejabberd/src/mongoose_riak.erl
@@ -42,7 +42,7 @@
 
 -export([pool_name/0]).
 
--compile({no_auto_import,[put/2]}).
+-compile({no_auto_import, [put/2]}).
 
 -define(CALL(F, Args), call_riak(F, Args)).
 

--- a/apps/ejabberd/src/mongoose_riak_sup.erl
+++ b/apps/ejabberd/src/mongoose_riak_sup.erl
@@ -60,7 +60,7 @@ stop() ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% Whenever a supervisor is started using supervisor:start_link/[2,3],
+%% Whenever a supervisor is started using supervisor:start_link/[2, 3],
 %% this function is called by the new process to find out about
 %% restart strategy, maximum restart frequency and child
 %% specifications.

--- a/apps/ejabberd/src/nodetree_dag.erl
+++ b/apps/ejabberd/src/nodetree_dag.erl
@@ -190,8 +190,8 @@ find_opt(Key, Default, Options) ->
         Pred    :: fun(),
         Tr      :: fun(),
         Host    :: mod_pubsub:hostPubsub(),
-        Nodes :: [mod_pubsub:nodeId(),...])
-        -> [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(),...]}].
+        Nodes :: [mod_pubsub:nodeId(), ...])
+        -> [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(), ...]}].
 traversal_helper(Pred, Tr, Host, Nodes) ->
     traversal_helper(Pred, Tr, 0, Host, Nodes, []).
 
@@ -218,7 +218,7 @@ remove_config_parent(Node, [H | T], Acc) ->
 
 -spec validate_parentage(
         Key            :: mod_pubsub:hostPubsub(),
-        Owners         :: [ljid(),...],
+        Owners         :: [ljid(), ...],
         Parent_Nodes :: [mod_pubsub:nodeId()])
     -> true
     %%%

--- a/apps/ejabberd/src/odbc_queries.erl
+++ b/apps/ejabberd/src/odbc_queries.erl
@@ -187,10 +187,10 @@ update_set_t(Table, FieldsVals, Where) ->
 	       <<") values ('">>, join(Vals, "', '"), "');"])
     end.
 
-odds([X,_|T]) -> [X|odds(T)];
+odds([X, _|T]) -> [X|odds(T)];
 odds([])      -> [].
 
-evens([_,X|T]) -> [X|evens(T)];
+evens([_, X|T]) -> [X|evens(T)];
 evens([])      -> [].
 
 join_field_and_values([Field, Val|FieldsVals]) ->
@@ -270,7 +270,7 @@ set_password_t(LServer, Username, {Pass, PassDetails}) ->
       fun() ->
 	      update_t(<<"users">>, [<<"password">>, <<"pass_details">>],
 		       [Pass, PassDetails],
-		       [<<"username='">>, Username ,<<"'">>])
+		       [<<"username='">>, Username, <<"'">>])
       end);
 set_password_t(LServer, Username, Pass) ->
     ejabberd_odbc:sql_transaction(
@@ -278,7 +278,7 @@ set_password_t(LServer, Username, Pass) ->
       fun() ->
 	      update_t(<<"users">>, [<<"username">>, <<"password">>],
 		       [Username, Pass],
-		       [<<"username='">>, Username ,<<"'">>])
+		       [<<"username='">>, Username, <<"'">>])
       end).
 
 add_user(LServer, Username, {Pass, PassDetails}) ->
@@ -295,7 +295,7 @@ add_user(LServer, Username, Pass) ->
 del_user(LServer, Username) ->
     ejabberd_odbc:sql_query(
       LServer,
-      [<<"delete from users where username='">>, Username ,"';"]).
+      [<<"delete from users where username='">>, Username, "';"]).
 
 del_user_return_password(_LServer, Username, Pass) ->
     P = ejabberd_odbc:sql_query_t(
@@ -725,7 +725,7 @@ set_privacy_list(ID, RItems) ->
 del_privacy_lists(LServer, _Server, Username) ->
     ejabberd_odbc:sql_query(
       LServer,
-      [<<"delete from privacy_list_data where id in ( select id from privacy_list as pl where pl.username='">>,Username,<<"');">>]),
+      [<<"delete from privacy_list_data where id in ( select id from privacy_list as pl where pl.username='">>, Username, <<"');">>]),
     ejabberd_odbc:sql_query(
       LServer,
       [<<"delete from privacy_list where username='">>, Username, "';"]),

--- a/apps/ejabberd/src/odbc_queries_mssql.erl
+++ b/apps/ejabberd/src/odbc_queries_mssql.erl
@@ -40,7 +40,7 @@ search_vcard(LServer, RestrictionSQL, infinity) ->
     do_search_vcard(LServer, RestrictionSQL, <<"">>);
 search_vcard(LServer, RestrictionSQL, Limit) when is_integer(Limit) ->
     LimitBin = integer_to_binary(Limit),
-    do_search_vcard(LServer, RestrictionSQL, <<" TOP ", LimitBin/binary," ">>).
+    do_search_vcard(LServer, RestrictionSQL, <<" TOP ", LimitBin/binary, " ">>).
 
 do_search_vcard(LServer, RestrictionSQL, Limit) ->
     ejabberd_odbc:sql_query(
@@ -55,7 +55,7 @@ query_archive_id(Host, SServer, SUserName) ->
         Host,
         ["SELECT TOP 1 id "
         "FROM mam_server_user "
-        "WHERE server='",SServer, "' AND user_name='", SUserName, "'"]).
+        "WHERE server='", SServer, "' AND user_name='", SUserName, "'"]).
 
 count_offline_messages(LServer, SUser, SServer, Limit) ->
     ejabberd_odbc:sql_query(

--- a/apps/ejabberd/src/p1_fsm_old.erl
+++ b/apps/ejabberd/src/p1_fsm_old.erl
@@ -133,7 +133,7 @@
          system_code_change/4,
          format_status/2]).
 
--import(error_logger , [format/2]).
+-import(error_logger, [format/2]).
 
 %%% Internal gen_fsm state
 %%% This state is used to defined resource control values:
@@ -214,17 +214,17 @@ send_event(Name, Event) ->
 
 sync_send_event(Name, Event) ->
     case catch gen:call(Name, '$gen_sync_event', Event) of
-	{ok,Res} ->
+	{ok, Res} ->
 	    Res;
-	{'EXIT',Reason} ->
+	{'EXIT', Reason} ->
 	    exit({Reason, {?MODULE, sync_send_event, [Name, Event]}})
     end.
 
 sync_send_event(Name, Event, Timeout) ->
     case catch gen:call(Name, '$gen_sync_event', Event, Timeout) of
-	{ok,Res} ->
+	{ok, Res} ->
 	    Res;
-	{'EXIT',Reason} ->
+	{'EXIT', Reason} ->
 	    exit({Reason, {?MODULE, sync_send_event, [Name, Event, Timeout]}})
     end.
 
@@ -237,17 +237,17 @@ send_all_state_event(Name, Event) ->
 
 sync_send_all_state_event(Name, Event) ->
     case catch gen:call(Name, '$gen_sync_all_state_event', Event) of
-	{ok,Res} ->
+	{ok, Res} ->
 	    Res;
-	{'EXIT',Reason} ->
+	{'EXIT', Reason} ->
 	    exit({Reason, {?MODULE, sync_send_all_state_event, [Name, Event]}})
     end.
 
 sync_send_all_state_event(Name, Event, Timeout) ->
     case catch gen:call(Name, '$gen_sync_all_state_event', Event, Timeout) of
-	{ok,Res} ->
+	{ok, Res} ->
 	    Res;
-	{'EXIT',Reason} ->
+	{'EXIT', Reason} ->
 	    exit({Reason, {?MODULE, sync_send_all_state_event,
 			   [Name, Event, Timeout]}})
     end.
@@ -258,7 +258,7 @@ sync_send_all_state_event(Name, Event, Timeout) ->
 %% e.g. when straddling a failover, or turn up in a restarted
 %% instance of the process.
 
-%% Returns Ref, sends event {timeout,Ref,Msg} after Time
+%% Returns Ref, sends event {timeout, Ref, Msg} after Time
 %% to the (then) current state.
 start_timer(Time, Msg) ->
     erlang:start_timer(Time, self(), {'$gen_timer', Msg}).
@@ -279,7 +279,7 @@ cancel_timer(Ref) ->
 	    RemainingTime
     end.
 
-%% enter_loop/4,5,6
+%% enter_loop/4, 5, 6
 %% Makes an existing process into a gen_fsm.
 %% The calling process will enter the gen_fsm receive loop and become a
 %% gen_fsm process.
@@ -290,8 +290,8 @@ cancel_timer(Ref) ->
 enter_loop(Mod, Options, StateName, StateData) ->
     enter_loop(Mod, Options, StateName, StateData, self(), infinity).
 
-enter_loop(Mod, Options, StateName, StateData, ServerName = {_,_}) ->
-    enter_loop(Mod, Options, StateName, StateData, ServerName,infinity);
+enter_loop(Mod, Options, StateName, StateData, ServerName = {_, _}) ->
+    enter_loop(Mod, Options, StateName, StateData, ServerName, infinity);
 enter_loop(Mod, Options, StateName, StateData, Timeout) ->
     enter_loop(Mod, Options, StateName, StateData, self(), Timeout).
 
@@ -307,7 +307,7 @@ enter_loop(Mod, Options, StateName, StateData, ServerName, Timeout) ->
 
 maybe_debug_options(Opts) ->
     case lists:keyfind(debug, 1, Opts) of
-        {_,Options} ->
+        {_, Options} ->
             sys:debug_options(Options);
         false ->
             []
@@ -394,8 +394,8 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	    exit(Error)
     end.
 
-name({local,Name}) -> Name;
-name({global,Name}) -> Name;
+name({local, Name}) -> Name;
+name({global, Name}) -> Name;
 name(Pid) when is_pid(Pid) -> Pid.
 
 %%-----------------------------------------------------------------
@@ -415,7 +415,7 @@ loop(Parent, Name, StateName, StateData, Mod, hibernate, Debug,
     end;
 loop(Parent, Name, StateName, StateData, Mod, hibernate, Debug,
      Limits, _Queue, _QueueLen) ->
-    proc_lib:hibernate(?MODULE,wake_hib,
+    proc_lib:hibernate(?MODULE, wake_hib,
 		       [Parent, Name, StateName, StateData, Mod,
 			Debug, Limits]);
 %% First we test if we have reach a defined limit ...
@@ -436,7 +436,7 @@ loop(Parent, Name, StateName, StateData, Mod, Time, Debug,
 process_message(Parent, Name, StateName, StateData, Mod, Time, Debug,
 		Limits, Queue, QueueLen) ->
     {Msg, Queue1, QueueLen1} = collect_messages(Queue, QueueLen, Time),
-    decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time,
+    decode_msg(Msg, Parent, Name, StateName, StateData, Mod, Time,
 	       Debug, Limits, Queue1, QueueLen1, false).
 
 collect_messages(Queue, QueueLen, Time) ->
@@ -475,7 +475,7 @@ wake_hib(Parent, Name, StateName, StateData, Mod, Debug,
     decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate,
 	       Debug, Limits, Queue, QueueLen, true).
 
-decode_msg(Msg,Parent, Name, StateName, StateData, Mod, Time, Debug,
+decode_msg(Msg, Parent, Name, StateName, StateData, Mod, Time, Debug,
 	   Limits, Queue, QueueLen, Hib) ->
     put('$internal_queue_len', QueueLen),
     case Msg of
@@ -733,16 +733,16 @@ terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug) ->
 error_info(Mod, Reason, Name, Msg, StateName, StateData, Debug) ->
     Reason1 =
 	case Reason of
-	    {undef,[{M,F,A}|MFAs]} ->
+	    {undef, [{M, F, A}|MFAs]} ->
 		case code:is_loaded(M) of
 		    false ->
-			{'module could not be loaded',[{M,F,A}|MFAs]};
+			{'module could not be loaded', [{M, F, A}|MFAs]};
 		    _ ->
 			case erlang:function_exported(M, F, length(A)) of
 			    true ->
 				Reason;
 			    false ->
-				{'function not exported',[{M,F,A}|MFAs]}
+				{'function not exported', [{M, F, A}|MFAs]}
 			end
 		end;
 	    _ ->
@@ -800,7 +800,7 @@ format_status(Opt, StatusData) ->
     Specfic =
 	case erlang:function_exported(Mod, format_status, 2) of
 	    true ->
-		case catch Mod:format_status(Opt,[PDict,StateData]) of
+		case catch Mod:format_status(Opt, [PDict, StateData]) of
 		    {'EXIT', _} -> [{data, [{"StateData", StateData}]}];
 		    Else -> Else
 		end;
@@ -823,7 +823,7 @@ limit_options(Options) ->
 limit_options([], Limits) ->
     Limits;
 %% Maximum number of messages allowed in the process message queue
-limit_options([{max_queue,N}|Options], Limits)
+limit_options([{max_queue, N}|Options], Limits)
   when is_integer(N) ->
     NewLimits = Limits#limits{max_queue=N},
     limit_options(Options, NewLimits);

--- a/apps/ejabberd/src/scram.erl
+++ b/apps/ejabberd/src/scram.erl
@@ -62,7 +62,7 @@
 
 -define(SALT_LENGTH, 16).
 -define(SCRAM_DEFAULT_ITERATION_COUNT, 4096).
--define(SCRAM_SERIAL_PREFIX, "==SCRAM==, ").
+-define(SCRAM_SERIAL_PREFIX, "==SCRAM==,").
 
 -spec salted_password(binary(), binary(), non_neg_integer()) -> binary().
 salted_password(Password, Salt, IterationCount) ->
@@ -161,7 +161,7 @@ serialize(#scram{storedkey = StoredKey, serverkey = ServerKey,
        $,,Salt/binary, $,,IterationCountBin/binary>>.
 
 deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
-    case catch binary:split(Serialized, <<", ">>, [global]) of
+    case catch binary:split(Serialized, <<",">>, [global]) of
         [StoredKey, ServerKey, Salt, IterationCount] ->
             {ok, #scram{storedkey = StoredKey,
                         serverkey = ServerKey,

--- a/apps/ejabberd/src/scram.erl
+++ b/apps/ejabberd/src/scram.erl
@@ -62,7 +62,7 @@
 
 -define(SALT_LENGTH, 16).
 -define(SCRAM_DEFAULT_ITERATION_COUNT, 4096).
--define(SCRAM_SERIAL_PREFIX, "==SCRAM==,").
+-define(SCRAM_SERIAL_PREFIX, "==SCRAM==, ").
 
 -spec salted_password(binary(), binary(), non_neg_integer()) -> binary().
 salted_password(Password, Salt, IterationCount) ->
@@ -157,12 +157,12 @@ serialize(#scram{storedkey = StoredKey, serverkey = ServerKey,
                      salt = Salt, iterationcount = IterationCount})->
     IterationCountBin = integer_to_binary(IterationCount),
     << <<?SCRAM_SERIAL_PREFIX>>/binary,
-       StoredKey/binary,$,,ServerKey/binary,
-       $,,Salt/binary,$,,IterationCountBin/binary>>.
+       StoredKey/binary, $,,ServerKey/binary,
+       $,,Salt/binary, $,,IterationCountBin/binary>>.
 
 deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
-    case catch binary:split(Serialized, <<",">>, [global]) of
-        [StoredKey, ServerKey,Salt,IterationCount] ->
+    case catch binary:split(Serialized, <<", ">>, [global]) of
+        [StoredKey, ServerKey, Salt, IterationCount] ->
             {ok, #scram{storedkey = StoredKey,
                         serverkey = ServerKey,
                         salt = Salt,

--- a/apps/ejabberd/src/shaper_srv.erl
+++ b/apps/ejabberd/src/shaper_srv.erl
@@ -59,7 +59,7 @@ child_spec(ProcName) ->
      [?MODULE]}.
 
 
--spec start_link(atom()) -> 'ignore' | {'error',_} | {'ok',pid()}.
+-spec start_link(atom()) -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link(ProcName) ->
     gen_server:start_link({local, ProcName}, ?MODULE, [], []).
 
@@ -88,7 +88,7 @@ select_worker(Host, Tag) ->
     worker_name(Host, N).
 
 
--spec worker_number(ejabberd:server(),_) -> non_neg_integer().
+-spec worker_number(ejabberd:server(), _) -> non_neg_integer().
 worker_number(Host, Tag) ->
     erlang:phash2(Tag, worker_count(Host)).
 
@@ -198,7 +198,7 @@ delete_old_shapers(State=#state{shapers=Shapers, a_times=Times, ttl=TTL}) ->
         end, init_dicts(State), Times).
 
 
--spec create_shaper(key()) -> 'none' | {'maxrate',_,0,non_neg_integer()}.
+-spec create_shaper(key()) -> 'none' | {'maxrate', _, 0, non_neg_integer()}.
 create_shaper(Key) ->
     shaper:new(request_shaper_name(Key)).
 
@@ -225,7 +225,7 @@ get_shaper_name(Host, Action, FromJID, Default) ->
 %% @doc It is a small hack
 %% This function calls this in more efficient way:
 %% timer:apply_after(DelayMs, gen_server, reply, [From, Reply]).
--spec reply_after(pos_integer(),{atom() | pid(),_},'ok') -> reference().
+-spec reply_after(pos_integer(), {atom() | pid(), _}, 'ok') -> reference().
 reply_after(DelayMs, {Pid, Tag}, Reply) ->
     erlang:send_after(DelayMs, Pid, {Tag, Reply}).
 


### PR DESCRIPTION
This PR adds space (` `) after colon (`,`) if there is missing one. This PR aims to fix Elvis's complains about missing space.

To do the job I used following bash magic:
```bash
git ls-files "apps/ejabberd/src/*.erl" | xargs gsed -i -E 's/,([^ ])/, \1/g'
``` 

What it does?
1. Lists all tracked files ending with `.erl` inside `apps/ejabberd/src` and runs following sed command for each file
2. The `sed` (gnu sed) command replaces all occurrences of a `,` without ` ` after it. The `\1` makes sure that the matched character other than space is preserved. 