### PR TITLE
Run hooks with a default (empty) accumulator

### DIFF
--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -300,8 +300,6 @@ send_service_message_all_mucs(Subject, AnnouncementText) ->
                                       | {'ok', io_lib:chars()}.
 register(User, Host, Password) ->
     case ejabberd_auth:try_register(User, Host, Password) of
-        ok ->
-            {ok, io_lib:format("User ~s@~s successfully registered", [User, Host])};
         {error, exists} ->
             String = io_lib:format("User ~s@~s already registered at node ~p",
                                    [User, Host, node()]),
@@ -309,7 +307,9 @@ register(User, Host, Password) ->
         {error, Reason} ->
             String = io_lib:format("Can't register user ~s@~s at node ~p: ~p",
                                    [User, Host, node(), Reason]),
-            {cannot_register, String}
+            {cannot_register, String};
+        _ ->
+            {ok, io_lib:format("User ~s@~s successfully registered", [User, Host])}
     end.
 
 

--- a/apps/ejabberd/src/ejabberd_gen_mam_archive.erl
+++ b/apps/ejabberd/src/ejabberd_gen_mam_archive.erl
@@ -19,8 +19,8 @@
         IsSimple :: boolean()) -> {ok, mod_mam:lookup_result()}
                                 | {error, 'policy-violation'}.
 
--callback remove_archive(Host :: ejabberd:server(),
-    ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid()) -> 'ok'.
+-callback remove_archive(Acc :: map(), Host :: ejabberd:server(),
+    ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid()) -> map().
 
 -callback purge_single_message(Result :: purge_single_message_result(), Host :: ejabberd:server(),
         MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -102,19 +102,13 @@ delete(Hook, Host, Module, Function, Seq) ->
 -spec run(Hook :: atom(),
           Args :: [any()]) -> ok.
 run(Hook, Args) ->
-    run(Hook, global, Args).
+    run_fold(Hook, global, #{}, Args).
 
 -spec run(Hook :: atom(),
           Host :: ejabberd:server() | global,
           Args :: [any()]) -> ok.
 run(Hook, Host, Args) ->
-    case ets:lookup(hooks, {Hook, Host}) of
-        [{_, Ls}] ->
-            mongoose_metrics:increment_generic_hook_metric(Host, Hook),
-            run1(Ls, Hook, #{}, Args); % run with empty map as accumulator
-        [] ->
-            ok
-    end.
+    run_fold(Hook, Host, #{}, Args).
 
 %% @spec (Hook::atom(), Val, Args) -> Val | stopped | NewVal
 %% @doc Run the calls of this hook in order.
@@ -227,27 +221,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%%----------------------------------------------------------------------
 %%% Internal functions
 %%%----------------------------------------------------------------------
-
-run1([], _Hook, Acc, _Args) ->
-    Acc;
-run1([{_Seq, Module, Function} | Ls], Hook, Acc, Args) ->
-    Res = if is_function(Function) ->
-                  safely:apply(Function, [Acc|Args]);
-             true ->
-                  safely:apply(Module, Function, [Acc|Args])
-          end,
-    case Res of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("~p~n    Running hook: ~p~n    Callback: ~p:~p",
-                       [Reason, {Hook, Args}, Module, Function]),
-            run1(Ls, Hook, Acc, Args);
-        stop ->
-            stopped;
-        {stop, NAcc} ->
-            NAcc;
-        NewAcc ->
-            run1(Ls, Hook, NewAcc, Args)
-    end.
 
 run_fold1([], _Hook, Val, _Args) ->
     Val;

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -111,7 +111,7 @@ run(Hook, Host, Args) ->
     case ets:lookup(hooks, {Hook, Host}) of
         [{_, Ls}] ->
             mongoose_metrics:increment_generic_hook_metric(Host, Hook),
-            run1(Ls, Hook, Args);
+            run1(Ls, Hook, #{}, Args); % run with empty map as accumulator
         [] ->
             ok
     end.
@@ -228,23 +228,25 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%----------------------------------------------------------------------
 
-run1([], _Hook, _Args) ->
-    ok;
-run1([{_Seq, Module, Function} | Ls], Hook, Args) ->
+run1([], _Hook, Acc, _Args) ->
+    Acc;
+run1([{_Seq, Module, Function} | Ls], Hook, Acc, Args) ->
     Res = if is_function(Function) ->
-                  safely:apply(Function, Args);
+                  safely:apply(Function, [Acc|Args]);
              true ->
-                  safely:apply(Module, Function, Args)
+                  safely:apply(Module, Function, [Acc|Args])
           end,
     case Res of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p~n    Running hook: ~p~n    Callback: ~p:~p",
                        [Reason, {Hook, Args}, Module, Function]),
-            run1(Ls, Hook, Args);
+            run1(Ls, Hook, Acc, Args);
         stop ->
-            ok;
-        _ ->
-            run1(Ls, Hook, Args)
+            stopped;
+        {stop, NAcc} ->
+            NAcc;
+        NewAcc ->
+            run1(Ls, Hook, NewAcc, Args)
     end.
 
 run_fold1([], _Hook, Val, _Args) ->

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -45,12 +45,13 @@
          unregister_host/1,
          unregister_iq_response_handler/2,
          refresh_iq_handlers/0,
-         bounce_resource_packet/3
+         bounce_resource_packet/3,
+         bounce_resource_packet/4
         ]).
 
 %% Hooks callbacks
 
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -226,6 +227,14 @@ unregister_iq_handler(Host, XMLNS) ->
 refresh_iq_handlers() ->
     ejabberd_local ! refresh_iq_handlers.
 
+%% #rh
+-spec bounce_resource_packet(Acc:: map(), From :: ejabberd:jid(),
+    To :: ejabberd:jid(),
+    Packet :: jlib:xmlel()) -> {'stop', map()}.
+bounce_resource_packet(Acc, From, To, Packet) ->
+    bounce_resource_packet(From, To, Packet),
+    {stop, Acc}.
+
 -spec bounce_resource_packet(From :: ejabberd:jid(),
                              To :: ejabberd:jid(),
                              Packet :: jlib:xmlel()) -> 'stop'.
@@ -246,7 +255,7 @@ unregister_host(Host) ->
 %% API
 %%====================================================================
 
-node_cleanup(Node) ->
+node_cleanup(Acc, Node) ->
     F = fun() ->
                 Keys = mnesia:select(
                          iq_response,
@@ -257,7 +266,8 @@ node_cleanup(Node) ->
                                       mnesia:delete({iq_response, Key})
                               end, Keys)
         end,
-    mnesia:async_dirty(F).
+    Res = mnesia:async_dirty(F),
+    maps:put(cleanup_result, Res, Acc).
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -266,8 +266,8 @@ node_cleanup(Acc, Node) ->
                                       mnesia:delete({iq_response, Key})
                               end, Keys)
         end,
-    Res = mnesia:async_dirty(F),
-    maps:put(cleanup_result, Res, Acc).
+    mnesia:async_dirty(F),
+    Acc.
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -50,7 +50,7 @@
         ]).
 
 %% Hooks callbacks
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -157,7 +157,7 @@ dirty_get_connections() ->
 %% Hooks callbacks
 %%====================================================================
 
-node_cleanup(Node) ->
+node_cleanup(Acc, Node) ->
     F = fun() ->
                 Es = mnesia:select(
                        s2s,
@@ -168,7 +168,8 @@ node_cleanup(Node) ->
                                       mnesia:delete_object(E)
                               end, Es)
         end,
-    mnesia:async_dirty(F).
+    Res = mnesia:async_dirty(F),
+    maps:put(cleanup_result, Res, Acc).
 
 -spec key({ejabberd:lserver(), ejabberd:lserver()}, binary()) ->
     binary().

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -157,7 +157,8 @@ open_session(SID, User, Server, Resource, Priority, Info) ->
     check_for_sessions_to_replace(User, Server, Resource),
     JID = jid:make(User, Server, Resource),
     ejabberd_hooks:run(sm_register_connection_hook, JID#jid.lserver,
-                       [SID, JID, Info]).
+                       [SID, JID, Info]),
+    ok.
 
 -spec close_session(SID, User, Server, Resource, Reason) -> ok when
     SID :: 'undefined' | sid(),

--- a/apps/ejabberd/src/ejabberd_users.erl
+++ b/apps/ejabberd/src/ejabberd_users.erl
@@ -7,7 +7,7 @@
          does_user_exist/2]).
 
 %% Hooks.
--export([remove_user/2]).
+-export([remove_user/3]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -87,11 +87,12 @@ does_user_exist(LUser, LServer) ->
 %% Hooks
 %%====================================================================
 
--spec remove_user(LUser :: ejabberd:luser(),
-                  LServer :: ejabberd:lserver() | string()) -> ok.
-remove_user(LUser, LServer) ->
+-spec remove_user(Acc :: map(),
+                  LUser :: ejabberd:luser(),
+                  LServer :: ejabberd:lserver() | string()) -> map().
+remove_user(Acc, LUser, LServer) ->
     delete_user(LUser, LServer),
-    ok.
+    Acc.
 
 %%====================================================================
 %% gen_server callbacks

--- a/apps/ejabberd/src/mod_bosh.erl
+++ b/apps/ejabberd/src/mod_bosh.erl
@@ -26,7 +26,7 @@
          terminate/3]).
 
 %% Hooks callbacks
--export([node_cleanup/1]).
+-export([node_cleanup/2]).
 
 %% For testing and debugging
 -export([get_session_socket/1, store_session/2]).
@@ -135,8 +135,9 @@ stop(_Host) ->
 %% Hooks handlers
 %%--------------------------------------------------------------------
 
-node_cleanup(Node) ->
-    ?BOSH_BACKEND:node_cleanup(Node).
+node_cleanup(Acc, Node) ->
+    Res = ?BOSH_BACKEND:node_cleanup(Node),
+    maps:put(cleanup_result, Res, Acc).
 
 %%--------------------------------------------------------------------
 %% cowboy_loop_handler callbacks

--- a/apps/ejabberd/src/mod_caps.erl
+++ b/apps/ejabberd/src/mod_caps.erl
@@ -46,7 +46,7 @@
 -export([init/1, handle_info/2, handle_call/3,
          handle_cast/2, terminate/2, code_change/3]).
 
--export([user_send_packet/3, user_receive_packet/4,
+-export([user_send_packet/4, user_receive_packet/5,
          c2s_presence_in/2, c2s_filter_packet/6,
          c2s_broadcast_recipients/6]).
 
@@ -144,11 +144,12 @@ read_caps([_ | Tail], Result) ->
     read_caps(Tail, Result);
 read_caps([], Result) -> Result.
 
-user_send_packet(#jid{luser = User, lserver = Server} = From,
+user_send_packet(Acc,
+                 #jid{luser = User, lserver = Server} = From,
                  #jid{luser = User, lserver = Server,
                       lresource = <<"">>},
                  #xmlel{name = <<"presence">>, attrs = Attrs,
-                        children = Els} = Pkt) ->
+                        children = Els}) ->
     Type = xml:get_attr_s(<<"type">>, Attrs),
     if Type == <<"">>; Type == <<"available">> ->
             case read_caps(Els) of
@@ -158,13 +159,13 @@ user_send_packet(#jid{luser = User, lserver = Server} = From,
             end;
        true -> ok
     end,
-    Pkt;
-user_send_packet(_From, _To, Pkt) ->
-    Pkt.
+    Acc;
+user_send_packet(Acc, _From, _To, _Pkt) ->
+    Acc.
 
-user_receive_packet(#jid{lserver = Server}, From, _To,
+user_receive_packet(Acc, #jid{lserver = Server}, From, _To,
                     #xmlel{name = <<"presence">>, attrs = Attrs,
-                           children = Els} = Pkt) ->
+                           children = Els}) ->
     Type = xml:get_attr_s(<<"type">>, Attrs),
     IsRemote = not lists:member(From#jid.lserver, ?MYHOSTS),
     if IsRemote and
@@ -176,9 +177,9 @@ user_receive_packet(#jid{lserver = Server}, From, _To,
             end;
        true -> ok
     end,
-    Pkt;
-user_receive_packet(_JID, _From, _To, Pkt) ->
-    Pkt.
+    Acc;
+user_receive_packet(Acc, _JID, _From, _To, _Pkt) ->
+    Acc.
 
 -spec caps_stream_features([xmlel()], binary()) -> [xmlel()].
 

--- a/apps/ejabberd/src/mod_carboncopy.erl
+++ b/apps/ejabberd/src/mod_carboncopy.erl
@@ -36,11 +36,11 @@
          classify_packet/1]).
 
 %% Hooks
--export([user_send_packet/3,
-         user_receive_packet/4,
+-export([user_send_packet/4,
+         user_receive_packet/5,
          iq_handler2/3,
          iq_handler1/3,
-         remove_connection/4
+         remove_connection/5
         ]).
 
 %% For testing and debugging
@@ -117,11 +117,13 @@ iq_handler(From, _To,  #iq{type = set, sub_el = #xmlel{name = Operation, childre
 iq_handler(_From, _To, IQ, _CC) ->
     IQ#iq{type=error, sub_el = [?ERR_NOT_ALLOWED]}.
 
-user_send_packet(From, To, Packet) ->
-    check_and_forward(From, To, Packet, sent).
+user_send_packet(Acc, From, To, Packet) ->
+    check_and_forward(From, To, Packet, sent),
+    Acc.
 
-user_receive_packet(JID, _From, To, Packet) ->
-    check_and_forward(JID, To, Packet, received).
+user_receive_packet(Acc, JID, _From, To, Packet) ->
+    check_and_forward(JID, To, Packet, received),
+    Acc.
 
 % Check if the traffic is local.
 % Modified from original version:
@@ -182,15 +184,15 @@ is_forwarded(SubTag) ->
         _ -> ignore
     end.
 
-remove_connection(User, Server, Resource, _Status) ->
+remove_connection(Acc, User, Server, Resource, _Status) ->
     disable(Server, User, Resource),
-    ok.
+    Acc.
 
 
 %%
 %% Internal
 %%
-is_bare_to(Direction, To, PrioRes) ->
+is_bare_to(Direction, To, _PrioRes) ->
     case {Direction, To} of
         {received, #jid{lresource = <<>>}} -> true;
         _ -> false

--- a/apps/ejabberd/src/mod_commands.erl
+++ b/apps/ejabberd/src/mod_commands.erl
@@ -163,8 +163,6 @@ registered_users(Host) ->
 
 register(Host, User, Password) ->
     case ejabberd_auth:try_register(User, Host, Password) of
-        #{} ->
-            list_to_binary(io_lib:format("User ~s@~s successfully registered", [User, Host]));
         {error, exists} ->
             String = io_lib:format("User ~s@~s already registered at node ~p",
                                    [User, Host, node()]),
@@ -172,7 +170,9 @@ register(Host, User, Password) ->
         {error, Reason} ->
             String = io_lib:format("Can't register user ~s@~s at node ~p: ~p",
                                    [User, Host, node(), Reason]),
-            throw({error, String})
+            throw({error, String});
+        _ ->
+            list_to_binary(io_lib:format("User ~s@~s successfully registered", [User, Host]))
     end.
 
 unregister(Host, User) ->

--- a/apps/ejabberd/src/mod_commands.erl
+++ b/apps/ejabberd/src/mod_commands.erl
@@ -163,7 +163,7 @@ registered_users(Host) ->
 
 register(Host, User, Password) ->
     case ejabberd_auth:try_register(User, Host, Password) of
-        ok ->
+        #{} ->
             list_to_binary(io_lib:format("User ~s@~s successfully registered", [User, Host]));
         {error, exists} ->
             String = io_lib:format("User ~s@~s already registered at node ~p",

--- a/apps/ejabberd/src/mod_http_notification.erl
+++ b/apps/ejabberd/src/mod_http_notification.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_mod).
 
 %% API
--export([start/2, stop/1, on_user_send_packet/3, should_make_req/3]).
+-export([start/2, stop/1, on_user_send_packet/4, should_make_req/3]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -31,7 +31,7 @@ stop(Host) ->
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, on_user_send_packet, 100),
     ok.
 
-on_user_send_packet(From, To, Packet) ->
+on_user_send_packet(Acc, From, To, Packet) ->
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
     Mod = get_callback_module(),
     case Mod:should_make_req(Packet, From, To) of
@@ -39,7 +39,8 @@ on_user_send_packet(From, To, Packet) ->
             make_req(From#jid.lserver, From#jid.luser, To#jid.luser, Body);
         _ ->
             ok
-    end.
+    end,
+    Acc.
 
 %%%===================================================================
 %%% Internal functions

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -258,8 +258,5 @@ remove_user(Acc, User, Server) ->
 -spec session_cleanup(Acc :: map(), LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
                       LResource :: ejabberd:lresource(), SID :: ejabberd_sm:sid()) -> any().
 session_cleanup(Acc, LUser, LServer, LResource, _SID) ->
-    case on_presence_update(Acc, LUser, LServer, LResource, <<>>) of
-        Acc when is_map(Acc) -> Acc;
-        E -> E
-    end.
+    on_presence_update(Acc, LUser, LServer, LResource, <<>>).
 

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -36,12 +36,12 @@
          stop/1,
          process_local_iq/3,
          process_sm_iq/3,
-         on_presence_update/4,
+         on_presence_update/5,
          store_last_info/4,
          get_last_info/2,
          count_active_users/2,
-         remove_user/2,
-         session_cleanup/4
+         remove_user/3,
+         session_cleanup/5
         ]).
 
 -include("ejabberd.hrl").
@@ -223,11 +223,14 @@ get_last(LUser, LServer) ->
 count_active_users(LServer, Timestamp) ->
     ?BACKEND:count_active_users(LServer, Timestamp).
 
--spec on_presence_update(ejabberd:user(), ejabberd:server(), ejabberd:resource(),
-                         Status :: binary()) -> ok | {error, term()}.
-on_presence_update(LUser, LServer, _Resource, Status) ->
+-spec on_presence_update(map(), ejabberd:user(), ejabberd:server(), ejabberd:resource(),
+                         Status :: binary()) -> map() | {error, term()}.
+on_presence_update(Acc, LUser, LServer, _Resource, Status) ->
     TimeStamp = now_to_seconds(os:timestamp()),
-    store_last_info(LUser, LServer, TimeStamp, Status).
+    case store_last_info(LUser, LServer, TimeStamp, Status) of
+        ok -> Acc;
+        E -> E
+    end.
 
 -spec store_last_info(ejabberd:user(), ejabberd:server(), non_neg_integer(),
                       Status :: binary()) -> ok | {error, term()}.
@@ -242,14 +245,21 @@ get_last_info(LUser, LServer) ->
         Res -> Res
     end.
 
--spec remove_user(ejabberd:user(), ejabberd:server()) -> ok | {error, term()}.
-remove_user(User, Server) ->
+%% #rh
+-spec remove_user(map(), ejabberd:user(), ejabberd:server()) -> map() | {error, term()}.
+remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    ?BACKEND:remove_user(LUser, LServer).
+    case ?BACKEND:remove_user(LUser, LServer) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec session_cleanup(LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
+-spec session_cleanup(Acc :: map(), LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
                       LResource :: ejabberd:lresource(), SID :: ejabberd_sm:sid()) -> any().
-session_cleanup(LUser, LServer, LResource, _SID) ->
-    on_presence_update(LUser, LServer, LResource, <<>>).
+session_cleanup(Acc, LUser, LServer, LResource, _SID) ->
+    case on_presence_update(Acc, LUser, LServer, LResource, <<>>) of
+        Acc when is_map(Acc) -> Acc;
+        E -> E
+    end.
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -46,8 +46,8 @@
 
 %% ejabberd handlers
 -export([process_mam_iq/3,
-         user_send_packet/3,
-         remove_user/2,
+         user_send_packet/4,
+         remove_user/3,
          filter_packet/1,
          determine_amp_strategy/5,
          sm_filter_offline_message/4]).
@@ -274,13 +274,14 @@ process_mam_iq(From=#jid{lserver=Host}, To, IQ) ->
 %%
 %% Note: for outgoing messages, the server MUST use the value of the 'to'
 %%       attribute as the target JID.
--spec user_send_packet(From :: ejabberd:jid(), To :: ejabberd:jid(),
-                       Packet :: jlib:xmlel()) -> 'ok'.
-user_send_packet(From, To, Packet) ->
+-spec user_send_packet(Acc :: map(), From :: ejabberd:jid(),
+                       To :: ejabberd:jid(),
+                       Packet :: jlib:xmlel()) -> map().
+user_send_packet(Acc, From, To, Packet) ->
     ?DEBUG("Send packet~n    from ~p ~n    to ~p~n    packet ~p.",
               [From, To, Packet]),
     handle_package(outgoing, false, From, To, From, Packet),
-    ok.
+    Acc.
 
 
 %% @doc Handle an incoming message.
@@ -322,9 +323,11 @@ process_incoming_packet(From, To, Packet) ->
     handle_package(incoming, true, To, From, From, Packet).
 
 %% @doc A ejabberd's callback with diferent order of arguments.
--spec remove_user(ejabberd:user(), ejabberd:server()) -> 'ok'.
-remove_user(User, Server) ->
-    delete_archive(Server, User).
+%% #rh
+-spec remove_user(map(), ejabberd:user(), ejabberd:server()) -> map().
+remove_user(Acc, User, Server) ->
+    delete_archive(Server, User),
+    Acc.
 
 sm_filter_offline_message(_Drop=false, _From, _To, Packet) ->
     %% If ...

--- a/apps/ejabberd/src/mod_mam_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_cache_user.erl
@@ -19,7 +19,7 @@
 %% ejabberd handlers
 -export([cached_archive_id/3,
          store_archive_id/3,
-         remove_archive/3]).
+         remove_archive/4]).
 
 %% API
 -export([clean_cache/1]).
@@ -168,10 +168,13 @@ store_archive_id(UserID, _Host, ArcJID) ->
     UserID.
 
 
--spec remove_archive(_Host :: ejabberd:server(), _UserID :: ejabberd:user(),
-                    ArcJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(_Host, _UserID, ArcJID) ->
-    clean_cache(ArcJID).
+%% #rh
+-spec remove_archive(Acc :: map(), _Host :: ejabberd:server(),
+                     _UserID :: ejabberd:user(),
+                     ArcJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, _Host, _UserID, ArcJID) ->
+    clean_cache(ArcJID),
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_mam_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_arch.erl
@@ -17,7 +17,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -234,7 +234,7 @@ remove_archive_offsets_query_cql() ->
 select_for_removal_query_cql() ->
     "SELECT DISTINCT user_jid, with_jid FROM mam_message WHERE user_jid = ?".
 
-remove_archive(_Host, _UserID, UserJID) ->
+remove_archive(Acc, _Host, _UserID, UserJID) ->
     BUserJID = bare_jid(UserJID),
     PoolName = pool_name(UserJID),
     Params = #{user_jid => BUserJID},
@@ -250,8 +250,7 @@ remove_archive(_Host, _UserID, UserJID) ->
 
     mongoose_cassandra:cql_foldl(PoolName, UserJID, ?MODULE,
                                  select_for_removal_query, Params, DeleteFun, []),
-    ok.
-
+    Acc.
 
 
 %% ----------------------------------------------------------------------

--- a/apps/ejabberd/src/mod_mam_cassandra_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_prefs.erl
@@ -18,7 +18,7 @@
 -export([get_behaviour/5,
          get_prefs/4,
          set_prefs/7,
-         remove_archive/3]).
+         remove_archive/4]).
 
 -export([prepared_queries/0]).
 
@@ -200,13 +200,13 @@ get_prefs({GlobalDefaultMode, _, _}, _Host, _UserID, UserJID) ->
 
 -spec remove_archive(ejabberd:server(), mod_mam:archive_id(),
                      ejabberd:jid()) -> 'ok'.
-remove_archive(_Host, _UserID, UserJID) ->
+remove_archive(Acc, _Host, _UserID, UserJID) ->
     PoolName = pool_name(UserJID),
     BUserJID = bare_jid(UserJID),
     Now = mongoose_cassandra:now_timestamp(),
     Params = #{'[timestamp]' => Now, user_jid => BUserJID},
     mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, del_prefs_ts_query, [Params]),
-    ok.
+    Acc.
 
 
 -spec query_behaviour(ejabberd:server(), UserJID :: ejabberd:jid(), BUserJID :: binary() | string(),

--- a/apps/ejabberd/src/mod_mam_cassandra_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_cassandra_prefs.erl
@@ -198,8 +198,8 @@ get_prefs({GlobalDefaultMode, _, _}, _Host, _UserID, UserJID) ->
     decode_prefs_rows(Rows, GlobalDefaultMode, [], []).
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(),
-                     ejabberd:jid()) -> 'ok'.
+-spec remove_archive(any(), ejabberd:server(), mod_mam:archive_id(),
+                     ejabberd:jid()) -> any().
 remove_archive(Acc, _Host, _UserID, UserJID) ->
     PoolName = pool_name(UserJID),
     BUserJID = bare_jid(UserJID),

--- a/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_mnesia_prefs.erl
@@ -20,6 +20,7 @@
 -export([get_behaviour/5,
          get_prefs/4,
          set_prefs/7,
+         remove_archive/4,
          remove_archive/3]).
 
 -include_lib("ejabberd/include/ejabberd.hrl").
@@ -204,13 +205,16 @@ get_prefs({GlobalDefaultMode, _, _}, _Host, _ArcID, ArcJID) ->
             {DefaultMode, AlwaysJIDs, NeverJIDs}
     end.
 
+%% #rh
+remove_archive(Host, ArcID, ArcJID) ->
+    remove_archive(ok, Host, ArcID, ArcJID).
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> any().
-remove_archive(_Host, _ArcID, ArcJID) ->
+remove_archive(Acc, _Host, _ArcID, ArcJID) ->
     SU = su_key(ArcJID),
     mnesia:sync_dirty(fun() ->
             mnesia:delete(mam_prefs, SU, write)
-        end).
+        end),
+    Acc.
 
 %% ----------------------------------------------------------------------
 %% Helpers

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -47,7 +47,8 @@
 %% ejabberd room handlers
 -export([filter_room_packet/2,
          room_process_mam_iq/3,
-         forget_room/2]).
+         forget_room/2,
+         forget_room/3]).
 
 %% private
 -export([archive_message/8]).
@@ -283,6 +284,13 @@ room_process_mam_iq(From = #jid{lserver = Host}, To, IQ) ->
         false -> return_action_not_allowed_error_iq(IQ)
     end.
 
+
+%% #rh
+%% @doc This hook is called from `mod_muc:forget_room(Host, Name)'.
+-spec forget_room(map(), ejabberd:lserver(), binary()) -> map().
+forget_room(Acc, LServer, RoomName) ->
+    forget_room(LServer, RoomName),
+    Acc.
 
 %% @doc This hook is called from `mod_muc:forget_room(Host, Name)'.
 -spec forget_room(ejabberd:lserver(), binary()) -> 'ok'.

--- a/apps/ejabberd/src/mod_mam_muc_cache_user.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cache_user.erl
@@ -21,7 +21,7 @@
 %% ejabberd handlers
 -export([cached_archive_id/3,
          store_archive_id/3,
-         remove_archive/3]).
+         remove_archive/4]).
 
 %% API
 -export([clean_cache/1]).
@@ -117,8 +117,10 @@ store_archive_id(UserID, _Host, ArcJID) ->
     maybe_cache_archive_id(ArcJID, UserID),
     UserID.
 
-remove_archive(_Host, _UserID, ArcJID) ->
-    clean_cache(ArcJID).
+%% #rh
+remove_archive(Acc, _Host, _UserID, ArcJID) ->
+    clean_cache(ArcJID),
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_cassandra_arch.erl
@@ -14,7 +14,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -230,7 +230,7 @@ remove_archive_offsets_query_cql() ->
 select_for_removal_query_cql() ->
     "SELECT DISTINCT room_jid, with_nick FROM mam_muc_message WHERE room_jid = ?".
 
-remove_archive(_Host, _RoomID, RoomJID) ->
+remove_archive(Acc, _Host, _RoomID, RoomJID) ->
     BRoomJID = bare_jid(RoomJID),
     PoolName = pool_name(RoomJID),
     Params = #{room_jid => BRoomJID},
@@ -246,7 +246,7 @@ remove_archive(_Host, _RoomID, RoomJID) ->
 
     mongoose_cassandra:cql_foldl(PoolName, RoomJID, ?MODULE,
                                  select_for_removal_query, Params, DeleteFun, []),
-    ok.
+    Acc.
 
 %% ----------------------------------------------------------------------
 %% GET NICK NAME

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -19,6 +19,7 @@
          archive_message/9,
          lookup_messages/14,
          remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -194,13 +195,13 @@ archive_messages(LServer, Acc, N) ->
            "(id, room_id, nick_name, message) "
        "VALUES ", tuples(Acc)]).
 
-lookup_messages({error, Reason}=Result, _Host,
+lookup_messages({error, _Reason}=Result, _Host,
                 _UserID, _UserJID, _RSM, _Borders,
                 _Start, _End, _Now, _WithJID,
                 _PageSize, _LimitPassed, _MaxResultLimit,
                 _IsSimple) ->
     Result;
-lookup_messages(Result, Host,
+lookup_messages(_Result, Host,
                 UserID, UserJID, RSM, Borders,
                 Start, End, Now, WithJID,
                 PageSize, LimitPassed, MaxResultLimit,
@@ -415,15 +416,17 @@ row_to_message_id({BMessID, _, _}) ->
     mongoose_rdbms:result_to_integer(BMessID).
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> 'ok'.
-remove_archive(Host, RoomID, _RoomJID) ->
+-spec remove_archive(map(), ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> map().
+remove_archive(Acc, Host, RoomID, _RoomJID) ->
     {updated, _} =
     mod_mam_utils:success_sql_query(
       Host,
       ["DELETE FROM ", select_table(RoomID), " "
        "WHERE room_id = '", escape_room_id(RoomID), "'"]),
-    ok.
+    Acc.
 
+remove_archive(Host, RoomID, RoomJID) ->
+    remove_archive(ok, Host, RoomID, RoomJID).
 
 -spec purge_single_message(_Result, Host :: ejabberd:server(),
                            MessID :: mod_mam:message_id(),

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -18,7 +18,6 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -424,9 +423,6 @@ remove_archive(Acc, Host, RoomID, _RoomJID) ->
       ["DELETE FROM ", select_table(RoomID), " "
        "WHERE room_id = '", escape_room_id(RoomID), "'"]),
     Acc.
-
-remove_archive(Host, RoomID, RoomJID) ->
-    remove_archive(ok, Host, RoomID, RoomJID).
 
 -spec purge_single_message(_Result, Host :: ejabberd:server(),
                            MessID :: mod_mam:message_id(),

--- a/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -17,7 +17,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -255,10 +255,11 @@ archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size) ->
     Result.
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> 'ok'.
-remove_archive(Host, ArcID, _ArcJID) ->
+%% #rh
+-spec remove_archive(map(), ejabberd:server(), mod_mam:archive_id(), ejabberd:jid()) -> map().
+remove_archive(Acc, Host, ArcID, _ArcJID) ->
     wait_flushing(Host, ArcID),
-    ok.
+    Acc.
 
 
 -spec purge_single_message(ejabberd_gen_mam_archive:purge_single_message_result(),

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -23,7 +23,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -521,15 +521,17 @@ row_to_message_id({BMessID, _, _}) ->
     mongoose_rdbms:result_to_integer(BMessID).
 
 
--spec remove_archive(Host :: ejabberd:server(), ArchiveID :: mod_mam:archive_id(),
-        RoomJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(Host, UserID, _UserJID) ->
+%% #rh
+-spec remove_archive(Acc :: map(), Host :: ejabberd:server(),
+                     ArchiveID :: mod_mam:archive_id(),
+                     RoomJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, Host, UserID, _UserJID) ->
     {updated, _} =
     mod_mam_utils:success_sql_query(
       Host,
       ["DELETE FROM ", select_table(UserID), " "
        "WHERE user_id = '", escape_user_id(UserID), "'"]),
-    ok.
+    Acc.
 
 -spec purge_single_message(Result :: any(), Host :: ejabberd:server(),
                            MessID :: mod_mam:message_id(),

--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -18,6 +18,7 @@
          archive_message/9,
          lookup_messages/14,
          remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -262,12 +263,16 @@ lookup_messages(Result, Host, ArcID, _ArcJID,
     Result.
 
 
--spec remove_archive(Host :: ejabberd:server(),
-        RoomId :: mod_mam:archive_id(), RoomJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(Host, ArcID, _ArcJID) ->
+%% #rh
+-spec remove_archive(Acc :: map(), Host :: ejabberd:server(),
+                     RoomId :: mod_mam:archive_id(),
+                     RoomJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, Host, ArcID, _ArcJID) ->
     wait_flushing(Host, ArcID),
-    ok.
+    Acc.
 
+remove_archive(Host, ArcID, _ArcJID) ->
+    wait_flushing(Host, ArcID).
 
 -spec purge_single_message(Result :: any(), Host :: ejabberd:server(),
         MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),

--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -17,7 +17,6 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/14,
-         remove_archive/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
@@ -270,9 +269,6 @@ lookup_messages(Result, Host, ArcID, _ArcJID,
 remove_archive(Acc, Host, ArcID, _ArcJID) ->
     wait_flushing(Host, ArcID),
     Acc.
-
-remove_archive(Host, ArcID, _ArcJID) ->
-    wait_flushing(Host, ArcID).
 
 -spec purge_single_message(Result :: any(), Host :: ejabberd:server(),
         MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),

--- a/apps/ejabberd/src/mod_mam_odbc_prefs.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_prefs.erl
@@ -17,7 +17,7 @@
 -export([get_behaviour/5,
          get_prefs/4,
          set_prefs/7,
-         remove_archive/3]).
+         remove_archive/4]).
 
 -include_lib("ejabberd/include/ejabberd.hrl").
 -include_lib("ejabberd/include/jlib.hrl").
@@ -188,9 +188,10 @@ get_prefs({GlobalDefaultMode, _, _}, Host, UserID, _ArcJID) ->
     decode_prefs_rows(Rows, GlobalDefaultMode, [], []).
 
 
--spec remove_archive(ejabberd:server(), mod_mam:archive_id(),
-                     ejabberd:jid()) -> 'ok'.
-remove_archive(Host, UserID, _ArcJID) ->
+%% #rh
+-spec remove_archive(map(), ejabberd:server(), mod_mam:archive_id(),
+                     ejabberd:jid()) -> map().
+remove_archive(Acc, Host, UserID, _ArcJID) ->
     SUserID = integer_to_list(UserID),
     {updated, _} =
     mod_mam_utils:success_sql_query(
@@ -198,7 +199,7 @@ remove_archive(Host, UserID, _ArcJID) ->
       ["DELETE "
        "FROM mam_config "
        "WHERE user_id='", SUserID, "'"]),
-    ok.
+    Acc.
 
 
 -spec query_behaviour(ejabberd:server(), SUserID :: string(),

--- a/apps/ejabberd/src/mod_mam_odbc_user.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_user.erl
@@ -15,7 +15,7 @@
 
 %% ejabberd handlers
 -export([archive_id/3,
-         remove_archive/3]).
+         remove_archive/4]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -124,9 +124,10 @@ archive_id(undefined, Host, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
 archive_id(ArcID, _Host, _ArcJID) ->
     ArcID.
 
--spec remove_archive(Host :: ejabberd:server(),
-    ArchiveID :: mod_mam:archive_id(), ArchiveJID :: ejabberd:jid()) -> 'ok'.
-remove_archive(Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
+-spec remove_archive(Acc :: map(), Host :: ejabberd:server(),
+                     ArchiveID :: mod_mam:archive_id(),
+                     ArchiveJID :: ejabberd:jid()) -> map().
+remove_archive(Acc, Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
     SUserName = mongoose_rdbms:escape(UserName),
     SServer   = mongoose_rdbms:escape(Server),
     {updated, _} =
@@ -134,7 +135,7 @@ remove_archive(Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) -
       Host,
       ["DELETE FROM mam_server_user "
        "WHERE server = '", SServer, "' AND user_name = '", SUserName, "'"]),
-    ok.
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -26,7 +26,6 @@
          stop/1,
          archive_size/4,
          lookup_messages/10,
-         remove_archive/3,
          remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -27,6 +27,7 @@
          archive_size/4,
          lookup_messages/10,
          remove_archive/3,
+         remove_archive/4,
          purge_single_message/6,
          purge_multiple_messages/9]).
 
@@ -313,6 +314,10 @@ get_message2(MsgId, Bucket, Key) ->
         _ ->
             []
     end.
+
+remove_archive(Acc, Host, ArchiveID, ArchiveJID) ->
+    remove_archive(Host, ArchiveID, ArchiveJID),
+    Acc.
 
 remove_archive(Host, _ArchiveID, ArchiveJID) ->
     {ok, TotalCount, _, _} = R = remove_chunk(Host, ArchiveJID, 0),

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -634,7 +634,7 @@ find_field([#xmlel{name = <<"field">>, attrs = Attrs}=Field|Fields], Name) ->
     end;
 find_field([_|Fields], Name) -> %% skip whitespaces
     find_field(Fields, Name);
-find_field([], Name) ->
+find_field([], _Name) ->
     undefined.
 
 -spec field_to_value(jlib:xmlel()) -> binary().
@@ -821,7 +821,7 @@ maybe_previous_id(X) ->
     TotalCount  :: non_neg_integer()|undefined,
     Offset      :: non_neg_integer()|undefined,
     MessageRows :: list().
-is_last_page(PageSize, TotalCount, Offset, MessageRows)
+is_last_page(PageSize, _TotalCount, _Offset, MessageRows)
     when length(MessageRows) < PageSize ->
     true;
 is_last_page(PageSize, TotalCount, Offset, MessageRows)

--- a/apps/ejabberd/src/mod_offline_riak.erl
+++ b/apps/ejabberd/src/mod_offline_riak.erl
@@ -145,7 +145,6 @@ pop_msg(Key, LUser, LServer, To) ->
         MD = riakc_obj:get_update_metadata(Obj),
         [Timestamp] = riakc_obj:get_secondary_index(MD, ?TIMESTAMP_IDX),
         [Expire] = riakc_obj:get_secondary_index(MD, ?EXPIRE_IDX),
-%%        User = riakc_obj:get_secondary_index(MD, ?USER_IDX),
         From = riakc_obj:get_user_metadata_entry(MD, <<"from">>),
 
         mongoose_riak:delete(bucket_type(LServer), Key),

--- a/apps/ejabberd/src/mod_offline_riak.erl
+++ b/apps/ejabberd/src/mod_offline_riak.erl
@@ -145,7 +145,7 @@ pop_msg(Key, LUser, LServer, To) ->
         MD = riakc_obj:get_update_metadata(Obj),
         [Timestamp] = riakc_obj:get_secondary_index(MD, ?TIMESTAMP_IDX),
         [Expire] = riakc_obj:get_secondary_index(MD, ?EXPIRE_IDX),
-        User = riakc_obj:get_secondary_index(MD, ?USER_IDX),
+%%        User = riakc_obj:get_secondary_index(MD, ?USER_IDX),
         From = riakc_obj:get_user_metadata_entry(MD, <<"from">>),
 
         mongoose_riak:delete(bucket_type(LServer), Key),

--- a/apps/ejabberd/src/mod_offline_stub.erl
+++ b/apps/ejabberd/src/mod_offline_stub.erl
@@ -30,7 +30,7 @@
          stop/1]).
 
 %% Hook handlers
--export([stop_hook_processing/3]).
+-export([stop_hook_processing/4]).
 
 -spec start(any(), any()) -> 'ok'.
 start(Host, _Opts) ->
@@ -48,6 +48,6 @@ stop(Host) ->
 handlers() ->
     [{offline_message_hook, ?MODULE, stop_hook_processing, 75}].
 
--spec stop_hook_processing(any(), any(), any()) -> stop.
-stop_hook_processing(_From, _To, _Packet) ->
-    stop.
+-spec stop_hook_processing(map(), any(), any(), any()) -> {stop, map()}.
+stop_hook_processing(Acc, _From, _To, _Packet) ->
+    {stop, Acc}.

--- a/apps/ejabberd/src/mod_ping.erl
+++ b/apps/ejabberd/src/mod_ping.erl
@@ -52,10 +52,10 @@
 
 %% Hook callbacks
 -export([iq_ping/3,
-         user_online/3,
-         user_offline/4,
-         user_send/3,
-         user_keep_alive/1]).
+         user_online/4,
+         user_offline/5,
+         user_send/4,
+         user_keep_alive/2]).
 
 -record(state, {host = <<"">>,
                 send_pings = ?DEFAULT_SEND_PINGS,
@@ -204,17 +204,21 @@ iq_ping(_From, _To, #iq{type = Type, sub_el = SubEl} = IQ) ->
             IQ#iq{type = error, sub_el = [SubEl, ?ERR_FEATURE_NOT_IMPLEMENTED]}
     end.
 
-user_online(_SID, JID, _Info) ->
-    start_ping(JID#jid.lserver, JID).
+user_online(Acc, _SID, JID, _Info) ->
+    start_ping(JID#jid.lserver, JID),
+    Acc.
 
-user_offline(_SID, JID, _Info, _Reason) ->
-    stop_ping(JID#jid.lserver, JID).
+user_offline(Acc, _SID, JID, _Info, _Reason) ->
+    stop_ping(JID#jid.lserver, JID),
+    Acc.
 
-user_send(JID, _From, _Packet) ->
-    start_ping(JID#jid.lserver, JID).
+user_send(Acc, JID, _From, _Packet) ->
+    start_ping(JID#jid.lserver, JID),
+    Acc.
 
-user_keep_alive(JID) ->
-    start_ping(JID#jid.lserver, JID).
+user_keep_alive(Acc, JID) ->
+    start_ping(JID#jid.lserver, JID),
+    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -37,6 +37,7 @@
          get_user_list/3,
          check_packet/6,
          remove_user/2,
+         remove_user/3,
          updated_list/3]).
 
 -include("ejabberd.hrl").
@@ -122,7 +123,7 @@ start(Host, Opts) ->
                                                  remove_privacy_list, replace_privacy_list,
                                                  get_default_list]),
     ?BACKEND:init(Host, Opts),
-    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
+%%    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     ejabberd_hooks:add(privacy_iq_get, Host,
                ?MODULE, process_iq_get, 50),
     ejabberd_hooks:add(privacy_iq_set, Host,
@@ -423,6 +424,12 @@ is_type_match(Type, Value, JID, Subscription, Groups) ->
             lists:member(Value, Groups)
     end.
 
+%% #rh
+remove_user(Acc, User, Server) ->
+    case remove_user(User, Server) of
+        ok -> Acc;
+        E -> E
+    end.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -123,7 +123,6 @@ start(Host, Opts) ->
                                                  remove_privacy_list, replace_privacy_list,
                                                  get_default_list]),
     ?BACKEND:init(Host, Opts),
-%%    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     ejabberd_hooks:add(privacy_iq_get, Host,
                ?MODULE, process_iq_get, 50),
     ejabberd_hooks:add(privacy_iq_set, Host,

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -32,6 +32,7 @@
 -export([start/2,
          stop/1,
          process_sm_iq/3,
+         remove_user/3,
          remove_user/2]).
 
 -include("ejabberd.hrl").
@@ -87,6 +88,14 @@ stop(Host) ->
 
 %% ------------------------------------------------------------------
 %% Handlers
+
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    case remove_user(User, Server) of
+        ok -> Acc;
+        E -> E
+    end.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -64,7 +64,7 @@
 
 %% exports for hooks
 -export([presence_probe/4, caps_change/4, caps_change/5,
-         in_subscription/7, out_subscription/5,
+         in_subscription/6, out_subscription/5,
          on_user_offline/5, remove_user/2, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
          disco_local_items/5, disco_sm_identity/5,
@@ -677,7 +677,6 @@ disco_items(Host, Node, From) ->
 %% presence hooks handling functions
 %%
 
-%% #rh
 caps_change(Acc, FromJID, ToJID, Pid, Features) ->
     caps_change(FromJID, ToJID, Pid, Features),
     Acc.
@@ -688,7 +687,6 @@ caps_change(#jid{luser = _U, lserver = S, lresource = _R} = FromJID, ToJID, Pid,
         false -> ok
     end.
 
-%% #rh
 presence_probe(Acc, #jid{luser = _U, lserver = S, lresource = _R} = JID, JID, _Pid) ->
     notify_send_loop(S, {send_last_pubsub_items, _Recipient = JID}),
     Acc;
@@ -718,11 +716,11 @@ out_subscription(Acc, User, Server, JID, subscribed) ->
 out_subscription(Acc, _, _, _, _) ->
     Acc.
 
-in_subscription(Acc, _, User, Server, Owner, unsubscribed, _) ->
+in_subscription(_, User, Server, Owner, unsubscribed, _) ->
     unsubscribe_user(jid:make(User, Server, <<>>), Owner),
-    Acc;
-in_subscription(Acc, _, _, _, _, _, _) ->
-    Acc.
+    true;
+in_subscription(_, _, _, _, _, _) ->
+    true.
 
 unsubscribe_user(Entity, Owner) ->
     spawn(fun () ->
@@ -766,7 +764,6 @@ unsubscribe_user(Host, Entity, Owner) ->
 %% user remove hook handling function
 %%
 
-%% #rh
 remove_user(Acc, User, Server) ->
     remove_user(User, Server),
     Acc.

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -63,9 +63,9 @@
 -define(PEPNODE, <<"pep">>).
 
 %% exports for hooks
--export([presence_probe/3, caps_change/4,
-         in_subscription/6, out_subscription/4,
-         on_user_offline/4, remove_user/2,
+-export([presence_probe/4, caps_change/4, caps_change/5,
+         in_subscription/7, out_subscription/5,
+         on_user_offline/5, remove_user/2, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
          disco_local_items/5, disco_sm_identity/5,
          disco_sm_features/5, disco_sm_items/5]).
@@ -677,16 +677,23 @@ disco_items(Host, Node, From) ->
 %% presence hooks handling functions
 %%
 
+%% #rh
+caps_change(Acc, FromJID, ToJID, Pid, Features) ->
+    caps_change(FromJID, ToJID, Pid, Features),
+    Acc.
+
 caps_change(#jid{luser = _U, lserver = S, lresource = _R} = FromJID, ToJID, Pid, _Features) ->
     case jid:to_lower(FromJID) == jid:to_lower(ToJID) of
         true -> notify_send_loop(S, {send_last_pep_items, ToJID, Pid});
         false -> ok
     end.
 
-presence_probe(#jid{luser = _U, lserver = S, lresource = _R} = JID, JID, _Pid) ->
-    notify_send_loop(S, {send_last_pubsub_items, _Recipient = JID});
-presence_probe(_Host, _JID, _Pid) ->
-    ok.
+%% #rh
+presence_probe(Acc, #jid{luser = _U, lserver = S, lresource = _R} = JID, JID, _Pid) ->
+    notify_send_loop(S, {send_last_pubsub_items, _Recipient = JID}),
+    Acc;
+presence_probe(Acc, _Host, _JID, _Pid) ->
+    Acc.
 
 notify_send_loop(ServerHost, Action) ->
     {SendLoop, _} = case whereis(gen_mod:get_module_proc(ServerHost, ?LOOPNAME)) of
@@ -699,7 +706,7 @@ notify_send_loop(ServerHost, Action) ->
 %% subscription hooks handling functions
 %%
 
-out_subscription(User, Server, JID, subscribed) ->
+out_subscription(Acc, User, Server, JID, subscribed) ->
     Owner = jid:make(User, Server, <<>>),
     {PUser, PServer, PResource} = jid:to_lower(JID),
     PResources = case PResource of
@@ -707,15 +714,15 @@ out_subscription(User, Server, JID, subscribed) ->
                      _ -> [PResource]
                  end,
     notify_send_loop(Server, {send_last_items_from_owner, Owner, {PUser, PServer, PResources}}),
-    true;
-out_subscription(_, _, _, _) ->
-    true.
+    Acc;
+out_subscription(Acc, _, _, _, _) ->
+    Acc.
 
-in_subscription(_, User, Server, Owner, unsubscribed, _) ->
+in_subscription(Acc, _, User, Server, Owner, unsubscribed, _) ->
     unsubscribe_user(jid:make(User, Server, <<>>), Owner),
-    true;
-in_subscription(_, _, _, _, _, _) ->
-    true.
+    Acc;
+in_subscription(Acc, _, _, _, _, _, _) ->
+    Acc.
 
 unsubscribe_user(Entity, Owner) ->
     spawn(fun () ->
@@ -758,6 +765,11 @@ unsubscribe_user(Host, Entity, Owner) ->
 %% -------
 %% user remove hook handling function
 %%
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),
@@ -4178,12 +4190,13 @@ extended_headers(Jids) ->
             attrs = [{<<"type">>, <<"replyto">>}, {<<"jid">>, Jid}]}
      || Jid <- Jids].
 
-on_user_offline(_, JID, _, _) ->
+on_user_offline(Acc, _, JID, _, _) ->
     {User, Server, Resource} = jid:to_lower(JID),
     case user_resources(User, Server) of
         [] -> purge_offline({User, Server, Resource});
         _ -> true
-    end.
+    end,
+    Acc.
 
 purge_offline(LJID) ->
     Host = host(element(2, LJID)),

--- a/apps/ejabberd/src/mod_register.erl
+++ b/apps/ejabberd/src/mod_register.erl
@@ -281,21 +281,21 @@ try_register(User, Server, Password, SourceRaw, Lang) ->
                         true ->
                             case ejabberd_auth:try_register(
                                    User, Server, Password) of
-                                ok ->
+                                {error, Error} ->
+                                    case Error of
+                                        exists ->
+                                            {error, ?ERR_CONFLICT};
+                                        invalid_jid ->
+                                            {error, ?ERR_JID_MALFORMED};
+                                        not_allowed ->
+                                            {error, ?ERR_NOT_ALLOWED};
+                                        null_password ->
+                                            {error, ?ERR_NOT_ACCEPTABLE}
+                                    end;
+                                _ ->
                                     send_welcome_message(JID),
                                     send_registration_notifications(JID, SourceRaw),
-                                    ok;
-                                Error ->
-                                    case Error of
-                                        {error, exists} ->
-                                            {error, ?ERR_CONFLICT};
-                                        {error, invalid_jid} ->
-                                            {error, ?ERR_JID_MALFORMED};
-                                        {error, not_allowed} ->
-                                            {error, ?ERR_NOT_ALLOWED};
-                                        {error, null_password} ->
-                                            {error, ?ERR_NOT_ACCEPTABLE}
-                                    end
+                                    ok
                             end;
                         false ->
                             ErrText = <<"The password is too weak">>,

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -48,7 +48,6 @@
          get_subscription_lists/3,
          get_roster/2,
          in_subscription/6,
-         in_subscription/7,
          out_subscription/5,
          set_items/3,
          remove_user/2,
@@ -570,19 +569,13 @@ roster_subscribe_t(LUser, LServer, LJID, Item) ->
 transaction(LServer, F) ->
     ?BACKEND:transaction(LServer, F).
 
-in_subscription(Acc, _, User, Server, JID, Type, Reason) ->
+in_subscription(_, User, Server, JID, Type, Reason) ->
     process_subscription(in, User, Server, JID, Type,
-        Reason),
-    Acc.
+        Reason).
 
 out_subscription(Acc, User, Server, JID, Type) ->
     process_subscription(out, User, Server, JID, Type, <<"">>),
     Acc.
-
-%% temporary - for folds
-in_subscription(_, User, Server, JID, Type, Reason) ->
-    process_subscription(in, User, Server, JID, Type,
-                         Reason).
 
 get_roster_by_jid_with_groups_t(LUser, LServer, LJID) ->
     ?BACKEND:get_roster_by_jid_with_groups_t(LUser, LServer, LJID).

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -48,9 +48,11 @@
          get_subscription_lists/3,
          get_roster/2,
          in_subscription/6,
-         out_subscription/4,
+         in_subscription/7,
+         out_subscription/5,
          set_items/3,
          remove_user/2,
+         remove_user/3,
          get_jid_info/4,
          item_to_xml/1,
          get_versioning_feature/2,
@@ -568,12 +570,19 @@ roster_subscribe_t(LUser, LServer, LJID, Item) ->
 transaction(LServer, F) ->
     ?BACKEND:transaction(LServer, F).
 
+in_subscription(Acc, _, User, Server, JID, Type, Reason) ->
+    process_subscription(in, User, Server, JID, Type,
+        Reason),
+    Acc.
+
+out_subscription(Acc, User, Server, JID, Type) ->
+    process_subscription(out, User, Server, JID, Type, <<"">>),
+    Acc.
+
+%% temporary - for folds
 in_subscription(_, User, Server, JID, Type, Reason) ->
     process_subscription(in, User, Server, JID, Type,
                          Reason).
-
-out_subscription(User, Server, JID, Type) ->
-    process_subscription(out, User, Server, JID, Type, <<"">>).
 
 get_roster_by_jid_with_groups_t(LUser, LServer, LJID) ->
     ?BACKEND:get_roster_by_jid_with_groups_t(LUser, LServer, LJID).
@@ -754,6 +763,11 @@ in_auto_reply(from, none, unsubscribe) -> unsubscribed;
 in_auto_reply(from, out, unsubscribe) -> unsubscribed;
 in_auto_reply(both, none, unsubscribe) -> unsubscribed;
 in_auto_reply(_, _, _) -> none.
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -39,7 +39,7 @@
          handle_info/2, terminate/2, code_change/3]).
 
 -export([get_user_roster/2, get_subscription_lists/3,
-         get_jid_info/4, process_item/2, in_subscription/7,
+         get_jid_info/4, process_item/2, in_subscription/6,
          out_subscription/5]).
 
 -export([config_change/4]).
@@ -179,12 +179,12 @@ get_jid_info({Subscription, Groups}, User, Server, JID) ->
         error -> {Subscription, Groups}
     end.
 
-in_subscription(Acc, _, User, Server, JID, Type, _Reason) ->
+in_subscription(Acc, User, Server, JID, Type, _Reason) ->
     case process_subscription(in, User, Server, JID, Type) of
         stop ->
             {stop, Acc};
         {stop, false} ->
-            {stop, acc};
+            {stop, false};
         _ -> Acc
     end.
 
@@ -193,7 +193,7 @@ out_subscription(Acc, User, Server, JID, Type) ->
         stop ->
             {stop, Acc};
         {stop, false} ->
-            {stop, acc};
+            {stop, Acc};
         _ -> Acc
     end.
 

--- a/apps/ejabberd/src/mod_shared_roster_ldap.erl
+++ b/apps/ejabberd/src/mod_shared_roster_ldap.erl
@@ -39,8 +39,8 @@
          handle_info/2, terminate/2, code_change/3]).
 
 -export([get_user_roster/2, get_subscription_lists/3,
-         get_jid_info/4, process_item/2, in_subscription/6,
-         out_subscription/4]).
+         get_jid_info/4, process_item/2, in_subscription/7,
+         out_subscription/5]).
 
 -export([config_change/4]).
 
@@ -179,13 +179,25 @@ get_jid_info({Subscription, Groups}, User, Server, JID) ->
         error -> {Subscription, Groups}
     end.
 
-in_subscription(Acc, User, Server, JID, Type, _Reason) ->
-    process_subscription(in, User, Server, JID, Type, Acc).
+in_subscription(Acc, _, User, Server, JID, Type, _Reason) ->
+    case process_subscription(in, User, Server, JID, Type) of
+        stop ->
+            {stop, Acc};
+        {stop, false} ->
+            {stop, acc};
+        _ -> Acc
+    end.
 
-out_subscription(User, Server, JID, Type) ->
-    process_subscription(out, User, Server, JID, Type, false).
+out_subscription(Acc, User, Server, JID, Type) ->
+    case process_subscription(out, User, Server, JID, Type) of
+        stop ->
+            {stop, Acc};
+        {stop, false} ->
+            {stop, acc};
+        _ -> Acc
+    end.
 
-process_subscription(Direction, User, Server, JID, _Type, Acc) ->
+process_subscription(Direction, User, Server, JID, _Type) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
     US = {LUser, LServer},
@@ -203,7 +215,7 @@ process_subscription(Direction, User, Server, JID, _Type, Acc) ->
                 in -> {stop, false};
                 out -> stop
             end;
-        false -> Acc
+        false -> false
     end.
 
 %%====================================================================

--- a/apps/ejabberd/src/mod_stream_management.erl
+++ b/apps/ejabberd/src/mod_stream_management.erl
@@ -8,8 +8,8 @@
 
 %% `ejabberd_hooks' handlers
 -export([add_sm_feature/2,
-         remove_smid/4,
-         session_cleanup/4]).
+         remove_smid/5,
+         session_cleanup/5]).
 
 %% `ejabberd.cfg' options (don't use outside of tests)
 -export([get_buffer_max/1,
@@ -59,18 +59,19 @@ sm() ->
     #xmlel{name = <<"sm">>,
            attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]}.
 
-remove_smid(SID, _JID, _Info, _Reason) ->
+remove_smid(Acc, SID, _JID, _Info, _Reason) ->
     case mnesia:dirty_index_read(sm_session, SID, #sm_session.sid) of
         [] ->
             ok;
         [#sm_session{} = SMSession] ->
             mnesia:sync_dirty(fun mnesia:delete_object/1, [SMSession])
-    end.
+    end,
+    Acc.
 
--spec session_cleanup(LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
+-spec session_cleanup(Acc :: map(), LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
                       LResource :: ejabberd:lresource(), SID :: ejabberd_sm:sid()) -> any().
-session_cleanup(_LUser, _LServer, _LResource, SID) ->
-    remove_smid(SID, undefined, undefined, undefined).
+session_cleanup(Acc, _LUser, _LServer, _LResource, SID) ->
+    remove_smid(Acc, SID, undefined, undefined, undefined).
 
 %%
 %% `ejabberd.cfg' options (don't use outside of tests)

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -58,6 +58,7 @@
          process_sm_iq/3,
          get_local_features/5,
          remove_user/2,
+         remove_user/3,
          set_vcard/3]).
 
 -export([start_link/2]).
@@ -241,7 +242,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 process_local_iq(_From, _To, #iq{type = set, sub_el = SubEl} = IQ) ->
     IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
-process_local_iq(_From, _To, #iq{type = get, lang = Lang} = IQ) ->
+process_local_iq(_From,_To,#iq{type = get} = IQ) ->
     IQ#iq{type = result,
           sub_el = [#xmlel{name = <<"vCard">>, attrs = [{<<"xmlns">>, ?NS_VCARD}],
                            children = [#xmlel{name = <<"FN">>,
@@ -331,6 +332,11 @@ get_local_features(Acc, _From, _To, Node, _Lang) ->
         _ ->
             Acc
     end.
+
+%% #rh
+remove_user(Acc, User, Server) ->
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mongoose_api_users.erl
+++ b/apps/ejabberd/src/mongoose_api_users.erl
@@ -98,7 +98,7 @@ maybe_register_user(Username, Host, Password) ->
             ?ERROR;
         {error, exists} ->
             maybe_change_password(Username, Host, Password);
-        ok ->
+        _ ->
             ok
     end.
 

--- a/apps/ejabberd/src/mongoose_cleaner.erl
+++ b/apps/ejabberd/src/mongoose_cleaner.erl
@@ -74,12 +74,12 @@ cleanup_modules(Node) ->
             ?DEBUG("could not get ~p~n", [?NODE_CLEANUP_LOCK(Node)]),
             {ok, aborted};
         Result ->
-            ?WARNING_MSG("cleanup result: ~p~n", [Result]),
+            ?WARNING_MSG("cleanup result: ~p~n", [maps:get(cleanup_result, Result, none)]),
             {ok, Result}
     end.
 
 run_node_cleanup(Node) ->
     {Elapsed, RetVal} = timer:tc(ejabberd_hooks, run, [node_cleanup, [Node]]),
     ?WARNING_MSG("cleanup took=~pms, result: ~p~n",
-                 [erlang:round(Elapsed / 1000), RetVal]),
+                 [erlang:round(Elapsed / 1000), maps:get(cleanup_result, RetVal, none)]),
     RetVal.

--- a/apps/ejabberd/src/mongoose_commands.erl
+++ b/apps/ejabberd/src/mongoose_commands.erl
@@ -373,6 +373,7 @@ check_and_execute(Caller, Command, Args) when is_map(Args) ->
     check_and_execute(Caller, Command, ArgList);
 check_and_execute(Caller, Command, Args) ->
     % check permissions
+    Av = is_available_for(Caller, Command),
     case is_available_for(Caller, Command) of
         true ->
             ok;

--- a/apps/ejabberd/src/mongoose_commands.erl
+++ b/apps/ejabberd/src/mongoose_commands.erl
@@ -373,7 +373,6 @@ check_and_execute(Caller, Command, Args) when is_map(Args) ->
     check_and_execute(Caller, Command, ArgList);
 check_and_execute(Caller, Command, Args) ->
     % check permissions
-    Av = is_available_for(Caller, Command),
     case is_available_for(Caller, Command) of
         true ->
             ok;

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -138,7 +138,7 @@ user_send_packet(Acc, #jid{server = Server},_,Packet) ->
     Acc.
 
 -spec user_send_packet_type(Server :: ejabberd:server(),
-                            Packet :: jlib:xmlel()) -> metrics_notify_return().
+                            Packet :: jlib:xmlel()) -> ok | {error, not_found}.
 user_send_packet_type(Server, #xmlel{name = <<"message">>}) ->
     mongoose_metrics:update(Server, xmppMessageSent, 1);
 user_send_packet_type(Server, #xmlel{name = <<"iq">>}) ->
@@ -153,7 +153,7 @@ user_receive_packet(Acc, #jid{server = Server} ,_,_,Packet) ->
     Acc.
 
 -spec user_receive_packet_type(Server :: ejabberd:server(),
-                               Packet :: jlib:xmlel()) -> metrics_notify_return().
+                               Packet :: jlib:xmlel()) -> ok | {error, not_found}.
 user_receive_packet_type(Server, #xmlel{name = <<"message">>}) ->
     mongoose_metrics:update(Server, xmppMessageReceived, 1);
 user_receive_packet_type(Server, #xmlel{name = <<"iq">>}) ->
@@ -164,17 +164,13 @@ user_receive_packet_type(Server, #xmlel{name = <<"presence">>}) ->
 -spec xmpp_bounce_message(Acc :: map(), Server :: ejabberd:server(),
                           tuple()) -> metrics_notify_return().
 xmpp_bounce_message(Acc, Server, _) ->
-    case mongoose_metrics:update(Server, xmppMessageBounced, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Server, xmppMessageBounced, 1),
+    Acc.
 
 -spec xmpp_stanza_dropped(map(), ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
 xmpp_stanza_dropped(Acc, #jid{server = Server} ,_,_) ->
-   case mongoose_metrics:update(Server, xmppStanzaDropped, 1) of
-       ok -> Acc;
-       E -> E
-   end.
+    mongoose_metrics:update(Server, xmppStanzaDropped, 1),
+    Acc.
 
 -spec xmpp_send_element(Acc :: map(), Server :: ejabberd:server(),
                         Packet :: jlib:xmlel()) -> ok | metrics_notify_return().
@@ -208,10 +204,8 @@ roster_get(Acc, {_, Server}) ->
 -spec roster_set(Acc :: map(), JID :: ejabberd:jid(), tuple(), tuple()) ->
     metrics_notify_return().
 roster_set(Acc, #jid{server = Server},_,_) ->
-    case mongoose_metrics:update(Server, modRosterSets, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Server, modRosterSets, 1),
+    Acc.
 
 -spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
 roster_in_subscription(Acc, _, Server, _, subscribed, _) ->
@@ -225,20 +219,16 @@ roster_in_subscription(Acc, _, _, _, _, _) ->
 
 -spec roster_push(map(), ejabberd:jid(), term()) -> metrics_notify_return().
 roster_push(Acc, #jid{server = Server},_) ->
-    case mongoose_metrics:update(Server, modRosterPush, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Server, modRosterPush, 1),
+    Acc.
 
 %% Register
 
 %% #rh
 -spec register_user(map(), binary(), ejabberd:server()) -> metrics_notify_return().
 register_user(Acc, _,Server) ->
-    case mongoose_metrics:update(Server, modRegisterCount, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Server, modRegisterCount, 1),
+    Acc.
 
 -spec remove_user(map(), binary(), ejabberd:server()) -> metrics_notify_return().
 remove_user(Acc, _,Server) ->
@@ -275,10 +265,8 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
                         Broadcast :: ejabberd_c2s:broadcast(),
                         SessionCount :: non_neg_integer()) -> ok | metrics_notify_return().
 privacy_list_push(Acc, _From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
-    case mongoose_metrics:update(Server, modPrivacyPush, SessionCount) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Server, modPrivacyPush, SessionCount),
+    Acc.
 
 user_ping_timeout(Acc, _JID) ->
     Acc.
@@ -360,37 +348,29 @@ mam_archive_message(Result, Host,
                          Host :: ejabberd:server(),
                          MessageCount :: integer()) -> metrics_notify_return().
 mam_flush_messages(Acc, Host, MessageCount) ->
-    case mongoose_metrics:update(Host, modMamFlushed, MessageCount) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMamFlushed, MessageCount),
+    Acc.
 
 %% #rh
 -spec mam_drop_message(Acc :: map(), Host :: ejabberd:server()) -> metrics_notify_return().
 mam_drop_message(Acc, Host) ->
-    case mongoose_metrics:update(Host, modMamDropped, 1)of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMamDropped, 1),
+    Acc.
 
 %% #rh
 -spec mam_drop_iq(Acc :: map(), Host :: ejabberd:server(), _To :: ejabberd:jid(),
     _IQ :: ejabberd:iq(), _Action :: any(), _Reason :: any()) -> metrics_notify_return().
 mam_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
-    case mongoose_metrics:update(Host, modMamDroppedIQ, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMamDroppedIQ, 1),
+    Acc.
 
 %% #rh
 -spec mam_drop_messages(Acc :: map(),
                         Host :: ejabberd:server(),
                         Count :: integer()) -> metrics_notify_return().
 mam_drop_messages(Acc, Host, Count) ->
-    case mongoose_metrics:update(Host, modMamDropped2, Count) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMamDropped2, Count),
+    Acc.
 
 mam_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
     mongoose_metrics:update(Host, modMamSinglePurges, 1),
@@ -414,10 +394,8 @@ mam_muc_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _Nev
     Result.
 
 mam_muc_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
-    case mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1),
+    Acc.
 
 mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
@@ -442,20 +420,16 @@ mam_muc_archive_message(Result, Host,
 
 %% #rh
 mam_muc_flush_messages(Acc, Host, MessageCount) ->
-    case mongoose_metrics:update(Host, modMucMamFlushed, MessageCount) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMucMamFlushed, MessageCount),
+    Acc.
 
 mam_muc_drop_message(Host) ->
     mongoose_metrics:update(Host, modMucMamDropped, 1).
 
 %% #rh
 mam_muc_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
-    case mongoose_metrics:update(Host, modMucMamDroppedIQ, 1) of
-        ok -> Acc;
-        E -> E
-    end.
+    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1),
+    Acc.
 
 mam_muc_drop_messages(Host, Count) ->
     mongoose_metrics:update(Host, modMucMamDropped2, Count).

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -16,44 +16,44 @@
 %%-------------------
 %% Internal exports
 %%-------------------
--export([sm_register_connection_hook/3,
-         sm_remove_connection_hook/4,
-         auth_failed/2,
-         user_send_packet/3,
-         user_receive_packet/4,
-         xmpp_bounce_message/2,
-         xmpp_stanza_dropped/3,
-         xmpp_send_element/2,
+-export([sm_register_connection_hook/4,
+         sm_remove_connection_hook/5,
+         auth_failed/3,
+         user_send_packet/4,
+         user_receive_packet/5,
+         xmpp_bounce_message/3,
+         xmpp_stanza_dropped/4,
+         xmpp_send_element/3,
          roster_get/2,
-         roster_set/3,
-         roster_push/2,
+         roster_set/4,
+         roster_push/3,
          roster_in_subscription/6,
-         register_user/2,
-         remove_user/2,
+         register_user/3,
+         remove_user/3,
          privacy_iq_get/5,
          privacy_iq_set/4,
          privacy_check_packet/6,
-         user_ping_timeout/1,
-         privacy_list_push/4,
+         user_ping_timeout/2,
+         privacy_list_push/5,
          mam_get_prefs/4,
          mam_set_prefs/7,
-         mam_remove_archive/3,
+         mam_remove_archive/4,
          mam_lookup_messages/14,
          mam_archive_message/9,
-         mam_flush_messages/2,
-         mam_drop_message/1,
-         mam_drop_iq/5,
-         mam_drop_messages/2,
+         mam_flush_messages/3,
+         mam_drop_message/2,
+         mam_drop_iq/6,
+         mam_drop_messages/3,
          mam_purge_single_message/6,
          mam_purge_multiple_messages/9,
          mam_muc_get_prefs/4,
          mam_muc_set_prefs/7,
-         mam_muc_remove_archive/3,
+         mam_muc_remove_archive/4,
          mam_muc_lookup_messages/14,
          mam_muc_archive_message/9,
-         mam_muc_flush_messages/2,
+         mam_muc_flush_messages/3,
          mam_muc_drop_message/1,
-         mam_muc_drop_iq/5,
+         mam_muc_drop_iq/6,
          mam_muc_drop_messages/2,
          mam_muc_purge_single_message/6,
          mam_muc_purge_multiple_messages/9
@@ -61,8 +61,8 @@
 
 -type hook() :: [atom() | ejabberd:server() | integer(), ...].
 -type metrics_notify_return() ::
-                'ok'
-                | {'error', _, 'nonexistent_metric' | 'unsupported_metric_type'}.
+                map()
+                | {'error',_,'nonexistent_metric' | 'unsupported_metric_type'}.
 
 %%-------------------
 %% Implementation
@@ -110,28 +110,32 @@ get_hooks(Host) ->
      [mam_muc_purge_multiple_messages, Host, ?MODULE, mam_muc_purge_multiple_messages, 50]].
 
 
--spec sm_register_connection_hook(tuple(), ejabberd:jid(), term()
+-spec sm_register_connection_hook(map(), tuple(), ejabberd:jid(), term()
                                  ) -> metrics_notify_return().
-sm_register_connection_hook(_, #jid{server = Server}, _) ->
+sm_register_connection_hook(Acc, _,#jid{server = Server}, _) ->
     mongoose_metrics:update(Server, sessionSuccessfulLogins, 1),
-    mongoose_metrics:update(Server, sessionCount, 1).
+    mongoose_metrics:update(Server, sessionCount, 1),
+    Acc.
 
--spec sm_remove_connection_hook(tuple(), ejabberd:jid(),
+-spec sm_remove_connection_hook(map(), tuple(), ejabberd:jid(),
                                 term(), ejabberd_sm:close_reason()
                                ) -> metrics_notify_return().
-sm_remove_connection_hook(_, #jid{server = Server}, _, _Reason) ->
+sm_remove_connection_hook(Acc, _,#jid{server = Server},_, _Reason) ->
     mongoose_metrics:update(Server, sessionLogouts, 1),
-    mongoose_metrics:update(Server, sessionCount, -1).
+    mongoose_metrics:update(Server, sessionCount, -1),
+    Acc.
 
--spec auth_failed(binary(), binary()) -> metrics_notify_return().
-auth_failed(_, Server) ->
-    mongoose_metrics:update(Server, sessionAuthFails, 1).
+-spec auth_failed(map(), binary(), binary()) -> metrics_notify_return().
+auth_failed(Acc, _,Server) ->
+    mongoose_metrics:update(Server, sessionAuthFails, 1),
+    Acc.
 
--spec user_send_packet(ejabberd:jid(), tuple(), tuple()
+-spec user_send_packet(map(), ejabberd:jid(), tuple(), tuple()
                       ) -> metrics_notify_return().
-user_send_packet(#jid{server = Server}, _, Packet) ->
+user_send_packet(Acc, #jid{server = Server},_,Packet) ->
     mongoose_metrics:update(Server, xmppStanzaSent, 1),
-    user_send_packet_type(Server, Packet).
+    user_send_packet_type(Server, Packet),
+    Acc.
 
 -spec user_send_packet_type(Server :: ejabberd:server(),
                             Packet :: jlib:xmlel()) -> metrics_notify_return().
@@ -142,10 +146,11 @@ user_send_packet_type(Server, #xmlel{name = <<"iq">>}) ->
 user_send_packet_type(Server, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(Server, xmppPresenceSent, 1).
 
--spec user_receive_packet(ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
-user_receive_packet(#jid{server = Server}, _, _, Packet) ->
+-spec user_receive_packet(map(), ejabberd:jid(), tuple(), tuple(), tuple()) -> term().
+user_receive_packet(Acc, #jid{server = Server} ,_,_,Packet) ->
     mongoose_metrics:update(Server, xmppStanzaReceived, 1),
-    user_receive_packet_type(Server, Packet).
+    user_receive_packet_type(Server, Packet),
+    Acc.
 
 -spec user_receive_packet_type(Server :: ejabberd:server(),
                                Packet :: jlib:xmlel()) -> metrics_notify_return().
@@ -156,18 +161,24 @@ user_receive_packet_type(Server, #xmlel{name = <<"iq">>}) ->
 user_receive_packet_type(Server, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(Server, xmppPresenceReceived, 1).
 
--spec xmpp_bounce_message(Server :: ejabberd:server(),
+-spec xmpp_bounce_message(Acc :: map(), Server :: ejabberd:server(),
                           tuple()) -> metrics_notify_return().
-xmpp_bounce_message(Server, _) ->
-    mongoose_metrics:update(Server, xmppMessageBounced, 1).
+xmpp_bounce_message(Acc, Server, _) ->
+    case mongoose_metrics:update(Server, xmppMessageBounced, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec xmpp_stanza_dropped(ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
-xmpp_stanza_dropped(#jid{server = Server}, _, _) ->
-   mongoose_metrics:update(Server, xmppStanzaDropped, 1).
+-spec xmpp_stanza_dropped(map(), ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
+xmpp_stanza_dropped(Acc, #jid{server = Server} ,_,_) ->
+   case mongoose_metrics:update(Server, xmppStanzaDropped, 1) of
+       ok -> Acc;
+       E -> E
+   end.
 
--spec xmpp_send_element(Server :: ejabberd:server(),
+-spec xmpp_send_element(Acc :: map(), Server :: ejabberd:server(),
                         Packet :: jlib:xmlel()) -> ok | metrics_notify_return().
-xmpp_send_element(Server, #xmlel{name = Name, attrs = Attrs}) ->
+xmpp_send_element(Acc, Server, #xmlel{name = Name, attrs = Attrs}) ->
     mongoose_metrics:update(Server, xmppStanzaCount, 1),
     case lists:keyfind(<<"type">>, 1, Attrs) of
         {<<"type">>, <<"error">>} ->
@@ -181,9 +192,10 @@ xmpp_send_element(Server, #xmlel{name = Name, attrs = Attrs}) ->
                     mongoose_metrics:update(Server, xmppErrorPresence, 1)
             end;
         _ -> ok
-    end;
-xmpp_send_element(_, _) ->
-    ok.
+    end,
+    Acc;
+xmpp_send_element(Acc, _, _) ->
+    Acc.
 
 
 %% Roster
@@ -193,9 +205,13 @@ roster_get(Acc, {_, Server}) ->
     mongoose_metrics:update(Server, modRosterGets, 1),
     Acc.
 
--spec roster_set(JID :: ejabberd:jid(), tuple(), tuple()) -> metrics_notify_return().
-roster_set(#jid{server = Server}, _, _) ->
-    mongoose_metrics:update(Server, modRosterSets, 1).
+-spec roster_set(Acc :: map(), JID :: ejabberd:jid(), tuple(), tuple()) ->
+    metrics_notify_return().
+roster_set(Acc, #jid{server = Server},_,_) ->
+    case mongoose_metrics:update(Server, modRosterSets, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 -spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
 roster_in_subscription(Acc, _, Server, _, subscribed, _) ->
@@ -207,19 +223,27 @@ roster_in_subscription(Acc, _, Server, _, unsubscribed, _) ->
 roster_in_subscription(Acc, _, _, _, _, _) ->
     Acc.
 
--spec roster_push(ejabberd:jid(), term()) -> metrics_notify_return().
-roster_push(#jid{server = Server}, _) ->
-    mongoose_metrics:update(Server, modRosterPush, 1).
+-spec roster_push(map(), ejabberd:jid(), term()) -> metrics_notify_return().
+roster_push(Acc, #jid{server = Server},_) ->
+    case mongoose_metrics:update(Server, modRosterPush, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 %% Register
 
--spec register_user(binary(), ejabberd:server()) -> metrics_notify_return().
-register_user(_, Server) ->
-    mongoose_metrics:update(Server, modRegisterCount, 1).
+%% #rh
+-spec register_user(map(), binary(), ejabberd:server()) -> metrics_notify_return().
+register_user(Acc, _,Server) ->
+    case mongoose_metrics:update(Server, modRegisterCount, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec remove_user(binary(), ejabberd:server()) -> metrics_notify_return().
-remove_user(_, Server) ->
-    mongoose_metrics:update(Server, modUnregisterCount, 1).
+-spec remove_user(map(), binary(), ejabberd:server()) -> metrics_notify_return().
+remove_user(Acc, _,Server) ->
+    mongoose_metrics:update(Server, modUnregisterCount, 1),
+    Acc.
 
 %% Privacy
 
@@ -245,15 +269,19 @@ privacy_iq_set(Acc, #jid{server = Server}, _To, #iq{sub_el = SubEl}) ->
     mongoose_metrics:update(Server, modPrivacySets, 1),
     Acc.
 
--spec privacy_list_push(_From :: ejabberd:jid(),
+-spec privacy_list_push(Acc :: map(),
+                        _From :: ejabberd:jid(),
                         To :: ejabberd:jid(),
                         Broadcast :: ejabberd_c2s:broadcast(),
                         SessionCount :: non_neg_integer()) -> ok | metrics_notify_return().
-privacy_list_push(_From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
-    mongoose_metrics:update(Server, modPrivacyPush, SessionCount).
+privacy_list_push(Acc, _From, #jid{server = Server} = _To, _Broadcast, SessionCount) ->
+    case mongoose_metrics:update(Server, modPrivacyPush, SessionCount) of
+        ok -> Acc;
+        E -> E
+    end.
 
-user_ping_timeout(_JID) ->
-    ok.
+user_ping_timeout(Acc, _JID) ->
+    Acc.
 
 -spec privacy_check_packet(Acc :: allow | deny | block,
                           binary(),
@@ -290,11 +318,13 @@ mam_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJI
     mongoose_metrics:update(Host, modMamPrefsSets, 1),
     Result.
 
--spec mam_remove_archive(Host :: ejabberd:server(),
+-spec mam_remove_archive(Acc :: map(),
+                         Host :: ejabberd:server(),
                          _ArcID :: mod_mam:archive_id(),
                          _ArcJID :: ejabberd:jid()) -> metrics_notify_return().
-mam_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update(Host, modMamArchiveRemoved, 1).
+mam_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
+    mongoose_metrics:update(Host, modMamArchiveRemoved, 1),
+    Acc.
 
 mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
@@ -326,24 +356,41 @@ mam_archive_message(Result, Host,
     mongoose_metrics:update(Host, modMamArchived, 1),
     Result.
 
--spec mam_flush_messages(Host :: ejabberd:server(),
+-spec mam_flush_messages(Acc :: map(),
+                         Host :: ejabberd:server(),
                          MessageCount :: integer()) -> metrics_notify_return().
-mam_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update(Host, modMamFlushed, MessageCount).
+mam_flush_messages(Acc, Host, MessageCount) ->
+    case mongoose_metrics:update(Host, modMamFlushed, MessageCount) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec mam_drop_message(Host :: ejabberd:server()) -> metrics_notify_return().
-mam_drop_message(Host) ->
-    mongoose_metrics:update(Host, modMamDropped, 1).
+%% #rh
+-spec mam_drop_message(Acc :: map(), Host :: ejabberd:server()) -> metrics_notify_return().
+mam_drop_message(Acc, Host) ->
+    case mongoose_metrics:update(Host, modMamDropped, 1)of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec mam_drop_iq(Host :: ejabberd:server(), _To :: ejabberd:jid(),
+%% #rh
+-spec mam_drop_iq(Acc :: map(), Host :: ejabberd:server(), _To :: ejabberd:jid(),
     _IQ :: ejabberd:iq(), _Action :: any(), _Reason :: any()) -> metrics_notify_return().
-mam_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update(Host, modMamDroppedIQ, 1).
+mam_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
+    case mongoose_metrics:update(Host, modMamDroppedIQ, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
--spec mam_drop_messages(Host :: ejabberd:server(),
+%% #rh
+-spec mam_drop_messages(Acc :: map(),
+                        Host :: ejabberd:server(),
                         Count :: integer()) -> metrics_notify_return().
-mam_drop_messages(Host, Count) ->
-    mongoose_metrics:update(Host, modMamDropped2, Count).
+mam_drop_messages(Acc, Host, Count) ->
+    case mongoose_metrics:update(Host, modMamDropped2, Count) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
     mongoose_metrics:update(Host, modMamSinglePurges, 1),
@@ -366,8 +413,11 @@ mam_muc_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _Nev
     mongoose_metrics:update(Host, modMucMamPrefsSets, 1),
     Result.
 
-mam_muc_remove_archive(Host, _ArcID, _ArcJID) ->
-    mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1).
+mam_muc_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
+    case mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
     Host, _ArcID, _ArcJID,
@@ -390,14 +440,22 @@ mam_muc_archive_message(Result, Host,
     mongoose_metrics:update(Host, modMucMamArchived, 1),
     Result.
 
-mam_muc_flush_messages(Host, MessageCount) ->
-    mongoose_metrics:update(Host, modMucMamFlushed, MessageCount).
+%% #rh
+mam_muc_flush_messages(Acc, Host, MessageCount) ->
+    case mongoose_metrics:update(Host, modMucMamFlushed, MessageCount) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_muc_drop_message(Host) ->
     mongoose_metrics:update(Host, modMucMamDropped, 1).
 
-mam_muc_drop_iq(Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1).
+%% #rh
+mam_muc_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
+    case mongoose_metrics:update(Host, modMucMamDroppedIQ, 1) of
+        ok -> Acc;
+        E -> E
+    end.
 
 mam_muc_drop_messages(Host, Count) ->
     mongoose_metrics:update(Host, modMucMamDropped2, Count).

--- a/apps/ejabberd/test/ejabberd_hooks_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_hooks_SUITE.erl
@@ -35,7 +35,7 @@ end_per_suite(_C) ->
 
 init_per_testcase(_, C) ->
     ejabberd_hooks:start_link(),
-    ets:new(local_config, [named_table]),
+    catch ets:new(local_config, [named_table]),
     C.
 
 a_fun_can_be_added(_) ->

--- a/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
+++ b/apps/ejabberd/test/mongoose_cleanup_SUITE.erl
@@ -62,7 +62,7 @@ meck_mods(_) -> [exometer, ejabberd_sm, ejabberd_local, ejabberd_config].
 cleaner_runs_hook_on_nodedown(_Config) ->
     {ok, Cleaner} = mongoose_cleaner:start_link(),
     Self = self(),
-    NotifySelf = fun (Node) -> Self ! {got_nodedown, Node} end,
+    NotifySelf = fun (_Acc, Node) -> Self ! {got_nodedown, Node} end,
     ejabberd_hooks:add(node_cleanup, global, undefined, NotifySelf, 50),
 
     FakeNode = fakename@fakehost,
@@ -78,7 +78,7 @@ auth_anonymous(_Config) ->
     ejabberd_auth_anonymous:start(?HOST),
     {U, S, R, JID, SID} = get_fake_session(),
     Info = [{auth_module, ejabberd_auth_anonymous}],
-    ejabberd_auth_anonymous:register_connection(SID, JID, Info),
+    ejabberd_auth_anonymous:register_connection(#{}, SID, JID, Info),
     true = ejabberd_auth_anonymous:anonymous_user_exist(U, S),
     ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),
     false = ejabberd_auth_anonymous:anonymous_user_exist(U, S).
@@ -89,7 +89,7 @@ last(_Config) ->
     {U, S, R, _JID, SID} = get_fake_session(),
     not_found = mod_last:get_last_info(U, S),
     Status1 = <<"status1">>,
-    ok = mod_last:on_presence_update(U, S, R, Status1),
+    #{} = mod_last:on_presence_update(#{}, U, S, R, Status1),
     {ok, TS1, Status1} = mod_last:get_last_info(U, S),
     timer:sleep(2000),
     ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),

--- a/test.disabled/ejabberd_tests/tests/login_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/login_SUITE.erl
@@ -120,8 +120,8 @@ init_per_group(GroupName, Config) when
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
-end_per_group(register, _Config) ->
-    ok;
+end_per_group(register, Config) ->
+    escalus:delete_users(Config, escalus:get_users([admin, alice, bob]));
 end_per_group(change_account_details, Config) ->
     ok;
 end_per_group(bad_registration, _Config) ->
@@ -213,11 +213,11 @@ end_per_testcase(CaseName, Config) ->
 register(Config) ->
     [{Name1, UserSpec1}, {Name2, UserSpec2}] = escalus_users:get_users([alice, bob]),
     [{_, AdminSpec}] = escalus_users:get_users([admin]),
-    [Username1, Server1, _Pass1] = escalus_users:get_usp(Config, UserSpec1),
-    [Username2, Server2, _Pass2] = escalus_users:get_usp(Config, UserSpec2),
+    [Username1, _Server1, _Pass1] = escalus_users:get_usp(Config, UserSpec1),
+    [Username2, _Server2, _Pass2] = escalus_users:get_usp(Config, UserSpec2),
     [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
 
-    ok = escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+    escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
 
     escalus:story(Config, [{admin, 1}], fun(Admin) ->
             escalus:create_users(Config, escalus:get_users([Name1, Name2])),

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -2068,7 +2068,7 @@ check_user_exist(Config) ->
   %% when
   [{_, AdminSpec}] = escalus_users:get_users([admin]),
   [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
-  ok = escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+  #{} = escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
   %% admin user already registered
   true = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, AdminS]),
   false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),


### PR DESCRIPTION
Simple modification resulting in plenty of code changes: all hook handers which were runned before (not run_folded) are now prepared to accept an accumulator, and return it, mostly unchanged. If called by 'run', the accumulator is an empty map, and return value is ignored.

By doing this, we make all handlers ready to switch to run_fold with a map-like accumulator, which will be subject of further PRs.

