### PR TITLE
Rocked mongoose_* + new behaviour: mongoose_packet_handler

### DIFF
--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -70,6 +70,9 @@
 
 -type scram() :: #scram{}.
 
--record(route, {domain, handler}).
+-record(route, {
+          domain :: binary(),
+          handler :: mongoose_packet_handler:t()
+         }).
 
 -record(external_component, {domain, handler, node}).

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -62,11 +62,6 @@
 
 -type domain() :: binary().
 
--type route() :: #route{
-                    domain :: domain(),
-                    handler :: mongoose_packet_handler:t()
-                   }.
-
 -type external_component() :: #external_component{domain :: domain(),
                                                   handler :: mongoose_packet_handler:t()}.
 

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -31,17 +31,16 @@
 %% API
 -export([route/3,
          route_error/4,
-         register_route/1,
          register_route/2,
-         register_routes/1,
+         register_routes/2,
          unregister_route/1,
          unregister_routes/1,
          dirty_get_all_routes/0,
          dirty_get_all_domains/0,
-         register_components/1,
          register_components/2,
-         register_component/1,
+         register_components/3,
          register_component/2,
+         register_component/3,
          lookup_component/1,
          lookup_component/2,
          unregister_component/1,
@@ -61,15 +60,15 @@
 
 -record(state, {}).
 
--type handler() :: undefined
-                 | {apply_fun, fun((_, _, _) -> any())}
-                 | {apply, M::atom(), F::atom()}.
 -type domain() :: binary().
 
--type route() :: #route{domain :: domain(),
-                        handler :: handler()}.
+-type route() :: #route{
+                    domain :: domain(),
+                    handler :: mongoose_packet_handler:t()
+                   }.
+
 -type external_component() :: #external_component{domain :: domain(),
-                                                  handler :: handler()}.
+                                                  handler :: mongoose_packet_handler:t()}.
 
 
 %%====================================================================
@@ -122,14 +121,16 @@ route_error(From, To, ErrPacket, OrigPacket) ->
             ok
     end.
 
--spec register_components([Domain :: domain()]) -> ok | {error, any()}.
-register_components(Domains) ->
-    register_components(Domains, node()).
+-spec register_components([Domain :: domain()],
+                          Handler :: mongoose_packet_handler:t()) -> ok | {error, any()}.
+register_components(Domains, Handler) ->
+    register_components(Domains, node(), Handler).
 
--spec register_components([Domain :: domain()], Node :: node()) -> ok | {error, any()}.
-register_components(Domains, Node) ->
+-spec register_components([Domain :: domain()],
+                          Node :: node(),
+                          Handler :: mongoose_packet_handler:t()) -> ok | {error, any()}.
+register_components(Domains, Node, Handler) ->
     LDomains = [{jid:nameprep(Domain), Domain} || Domain <- Domains],
-    Handler = make_handler(undefined),
     F = fun() ->
             [do_register_component(LDomain, Handler, Node) || LDomain <- LDomains],
             ok
@@ -144,13 +145,16 @@ register_components(Domains, Node) ->
 %% and external_components_global as globals. Registration should be done by register_component/1
 %% or register_components/1, which registers them for current node; the arity 2 funcs are
 %% here for testing.
--spec register_component(Domain :: domain()) -> ok | {error, any()}.
-register_component(Domain) ->
-    register_components([Domain], node()).
+-spec register_component(Domain :: domain(),
+                         Handler :: mongoose_packet_handler:t()) -> ok | {error, any()}.
+register_component(Domain, Handler) ->
+    register_components([Domain], node(), Handler).
 
--spec register_component(Domain :: domain(), Node :: node()) -> ok | {error, any()}.
-register_component(Domain, Node) ->
-    register_components([Domain], Node).
+-spec register_component(Domain :: domain(),
+                         Node :: node(),
+                         Handler :: mongoose_packet_handler:t()) -> ok | {error, any()}.
+register_component(Domain, Node, Handler) ->
+    register_components([Domain], Node, Handler).
 
 do_register_component({error, Domain}, _Handler, _Node) ->
     error({invalid_domain, Domain});
@@ -170,12 +174,12 @@ do_register_component({LDomain, _}, Handler, Node) ->
 %% true and false are there because that's how orelse works.
 -spec check_component(binary(), Node :: node()) -> ok | true | false.
 check_component(LDomain, Node) ->
-    check_component_route(LDomain, Node)
+    check_component_route(LDomain)
         orelse check_component_local(LDomain, Node)
         orelse check_component_global(LDomain, Node).
 
 
-check_component_route(LDomain, Node) ->
+check_component_route(LDomain) ->
     %% check that route for this domain is not already registered
     case mnesia:read(route, LDomain) of
         [] ->
@@ -260,41 +264,23 @@ lookup_component(Domain) ->
 lookup_component(Domain, Node) ->
     mnesia:dirty_read(external_component, {Domain, Node}).
 
--spec register_route(Domain :: domain()) -> any().
-register_route(Domain) ->
-    register_route(Domain, undefined).
-
 -spec register_route(Domain :: domain(),
-                     Handler :: handler()) -> any().
+                     Handler :: mongoose_packet_handler:t()) -> any().
 register_route(Domain, Handler) ->
     register_route_to_ldomain(jid:nameprep(Domain), Domain, Handler).
 
--spec register_routes([domain()]) -> 'ok'.
-register_routes(Domains) ->
+-spec register_routes([domain()], mongoose_packet_handler:t()) -> 'ok'.
+register_routes(Domains, Handler) ->
     lists:foreach(fun(Domain) ->
-                      register_route(Domain)
+                      register_route(Domain, Handler)
                   end,
                   Domains).
 
--spec register_route_to_ldomain(binary(), domain(), handler()) -> any().
+-spec register_route_to_ldomain(binary(), domain(), mongoose_packet_handler:t()) -> any().
 register_route_to_ldomain(error, Domain, _) ->
     erlang:error({invalid_domain, Domain});
-register_route_to_ldomain(LDomain, _, HandlerOrUndef) ->
-    Handler = make_handler(HandlerOrUndef),
+register_route_to_ldomain(LDomain, _, Handler) ->
     mnesia:dirty_write(#route{domain = LDomain, handler = Handler}).
-
--spec make_handler(handler()) -> handler().
-make_handler(undefined) ->
-    Pid = self(),
-    {apply_fun, fun(From, To, Packet) ->
-                    Pid ! {route, From, To, Packet}
-                end};
-make_handler({apply_fun, Fun} = Handler) when is_function(Fun, 3) ->
-    Handler;
-make_handler({apply, Module, Function} = Handler)
-    when is_atom(Module),
-         is_atom(Function) ->
-    Handler.
 
 unregister_route(Domain) ->
     case jid:nameprep(Domain) of

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -45,6 +45,7 @@
 -author('piotr.nosek@erlang-solutions.com').
 
 -behaviour(gen_mod).
+-behaviour(mongoose_packet_handler).
 
 %% API
 -export([standard_config_schema/0, standard_default_config/0, default_host/0]).
@@ -53,8 +54,8 @@
 %% gen_mod callbacks
 -export([start/2, stop/1]).
 
-%% Router export
--export([route/3]).
+%% Packet handler export
+-export([process_packet/4]).
 
 %% Hook handlers
 -export([prevent_service_unavailable/4,
@@ -133,7 +134,7 @@ start(Host, Opts) ->
     MUCHost = gen_mod:get_opt_subhost(Host, Opts, default_host()),
     mod_muc_light_db_backend:start(Host, MUCHost),
     mongoose_subhosts:register(Host, MUCHost),
-    ejabberd_router:register_route(MUCHost, {apply, ?MODULE, route}),
+    ejabberd_router:register_route(MUCHost, mongoose_packet_handler:new(?MODULE)),
 
     ejabberd_hooks:add(is_muc_room_owner, MUCHost, ?MODULE, is_room_owner, 50),
     ejabberd_hooks:add(muc_room_pid, MUCHost, ?MODULE, muc_room_pid, 50),
@@ -177,14 +178,14 @@ stop(Host) ->
 %% Routing
 %%====================================================================
 
--spec route(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) -> any().
-route(From, To, Packet) ->
-    process_packet(From, To, mod_muc_light_codec_backend:decode(From, To, Packet), Packet).
+-spec process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Extra :: any()) -> any().
+process_packet(From, To, Packet, _Extra) ->
+    process_decoded_packet(From, To, mod_muc_light_codec_backend:decode(From, To, Packet), Packet).
 
--spec process_packet(From :: ejabberd:jid(), To :: ejabberd:jid(),
+-spec process_decoded_packet(From :: ejabberd:jid(), To :: ejabberd:jid(),
                      DecodedPacket :: mod_muc_light_codec:decode_result(),
                      OrigPacket :: jlib:xmlel()) -> any().
-process_packet(From, To, {ok, {set, #create{} = Create}}, OrigPacket) ->
+process_decoded_packet(From, To, {ok, {set, #create{} = Create}}, OrigPacket) ->
     FromUS = jid:to_lus(From),
     case not mod_muc_light_utils:room_limit_reached(FromUS, To#jid.lserver) of
         true ->
@@ -193,11 +194,11 @@ process_packet(From, To, {ok, {set, #create{} = Create}}, OrigPacket) ->
             mod_muc_light_codec_backend:encode_error(
               {error, bad_request}, From, To, OrigPacket, fun ejabberd_router:route/3)
     end;
-process_packet(From, To, {ok, {get, #disco_info{} = DI}}, _OrigPacket) ->
+process_decoded_packet(From, To, {ok, {get, #disco_info{} = DI}}, _OrigPacket) ->
     handle_disco_info_get(From, To, DI);
-process_packet(From, To, {ok, {get, #disco_items{} = DI}}, OrigPacket) ->
+process_decoded_packet(From, To, {ok, {get, #disco_items{} = DI}}, OrigPacket) ->
     handle_disco_items_get(From, To, DI, OrigPacket);
-process_packet(From, To, {ok, {_, #blocking{}} = Blocking}, OrigPacket) ->
+process_decoded_packet(From, To, {ok, {_, #blocking{}} = Blocking}, OrigPacket) ->
     RouteFun = fun ejabberd_router:route/3,
     case gen_mod:get_module_opt_by_subhost(To#jid.lserver, ?MODULE, blocking, ?DEFAULT_BLOCKING) of
         true ->
@@ -210,7 +211,7 @@ process_packet(From, To, {ok, {_, #blocking{}} = Blocking}, OrigPacket) ->
         false -> mod_muc_light_codec_backend:encode_error(
                    {error, bad_request}, From, To, OrigPacket, fun ejabberd_router:route/3)
     end;
-process_packet(From, To, {ok, #iq{} = IQ}, OrigPacket) ->
+process_decoded_packet(From, To, {ok, #iq{} = IQ}, OrigPacket) ->
     case mod_muc_iq:process_iq(To#jid.lserver, From, To, IQ) of
         ignore -> ok;
         error ->
@@ -219,19 +220,19 @@ process_packet(From, To, {ok, #iq{} = IQ}, OrigPacket) ->
         ResIQ ->
             ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ))
     end;
-process_packet(From, #jid{ luser = RoomU } = To, {ok, RequestToRoom}, OrigPacket)
+process_decoded_packet(From, #jid{ luser = RoomU } = To, {ok, RequestToRoom}, OrigPacket)
   when RoomU =/= <<>> ->
     case mod_muc_light_db_backend:room_exists(jid:to_lus(To)) of
         true -> mod_muc_light_room:handle_request(From, To, OrigPacket, RequestToRoom);
         false -> mod_muc_light_codec_backend:encode_error(
                    {error, item_not_found}, From, To, OrigPacket, fun ejabberd_router:route/3)
     end;
-process_packet(From, To, {error, _} = Err, OrigPacket) ->
+process_decoded_packet(From, To, {error, _} = Err, OrigPacket) ->
     mod_muc_light_codec_backend:encode_error(
       Err, From, To, OrigPacket, fun ejabberd_router:route/3);
-process_packet(_From, _To, ignore, _OrigPacket) ->
+process_decoded_packet(_From, _To, ignore, _OrigPacket) ->
      ok;
-process_packet(From, To, _InvalidReq, OrigPacket) ->
+process_decoded_packet(From, To, _InvalidReq, OrigPacket) ->
     mod_muc_light_codec_backend:encode_error(
       {error, bad_request}, From, To, OrigPacket, fun ejabberd_router:route/3).
 

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -46,6 +46,7 @@
 -module(mod_pubsub).
 -behaviour(gen_mod).
 -behaviour(gen_server).
+-behaviour(mongoose_packet_handler).
 -author('christophe.romain@process-one.net').
 
 -xep([{xep, 60}, {version, "1.13-1"}]).
@@ -92,6 +93,9 @@
          handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 -export([default_host/0]).
+
+%% packet handler export
+-export([process_packet/4]).
 
 -export([send_loop/1]).
 
@@ -240,6 +244,10 @@ stop(Host) ->
 default_host() ->
     <<"pubsub.@HOST@">>.
 
+-spec process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Pid :: pid()) -> any().
+process_packet(From, To, Packet, Pid) ->
+    Pid ! {route, From, To, Packet}.
+
 %%====================================================================
 %% gen_server callbacks
 %%====================================================================
@@ -329,7 +337,7 @@ init([ServerHost, Opts]) ->
         false ->
             ok
     end,
-    ejabberd_router:register_route(Host),
+    ejabberd_router:register_route(Host, mongoose_packet_handler:new(?MODULE, self())),
     {_, State} = init_send_loop(ServerHost),
     {ok, State}.
 

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -53,6 +53,9 @@
          terminate/2,
          code_change/3]).
 
+%% mongoose_packet_handler export
+-export([process_packet/4]).
+
 %% Hook handlers
 -export([process_local_iq/3,
          process_sm_iq/3,
@@ -165,6 +168,14 @@ stop(VHost) ->
     supervisor:delete_child(ejabberd_sup, Proc).
 
 %%--------------------------------------------------------------------
+%% mongoose_packet_handler callbacks
+%%--------------------------------------------------------------------
+
+-spec process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Pid :: pid()) -> any().
+process_packet(From, To, Packet, Pid) ->
+    Pid ! {route, From, To, Packet}.
+
+%%--------------------------------------------------------------------
 %% gen_server callbacks
 %%--------------------------------------------------------------------
 start_link(VHost, Opts) ->
@@ -185,7 +196,8 @@ init([VHost, Opts]) ->
     Search = gen_mod:get_opt(search, Opts, true),
     case Search of
         true ->
-            ejabberd_router:register_route(DirectoryHost);
+            ejabberd_router:register_route(
+              DirectoryHost, mongoose_packet_handler:new(?MODULE, self()));
         _ ->
             ok
     end,

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -31,8 +31,13 @@
 -include("mongoose_api.hrl").
 -include("ejabberd.hrl").
 
--import(mongoose_api_common, [error_response/3, error_response/4, action_to_method/1, method_to_action/1, error_code/1,
-                              process_request/4, parse_request_body/1]).
+-import(mongoose_api_common, [error_response/3,
+                              error_response/4,
+                              action_to_method/1,
+                              method_to_action/1,
+                              error_code/1,
+                              process_request/4,
+                              parse_request_body/1]).
 
 %%--------------------------------------------------------------------
 %% ejabberd_cowboy callbacks

--- a/apps/ejabberd/src/mongoose_api_client.erl
+++ b/apps/ejabberd/src/mongoose_api_client.erl
@@ -28,8 +28,12 @@
          rest_terminate/2,
          delete_resource/2]).
 
--import(mongoose_api_common, [action_to_method/1, method_to_action/1, error_code/1, process_request/4,
-                              error_response/4, parse_request_body/1]).
+-import(mongoose_api_common, [action_to_method/1,
+                              method_to_action/1,
+                              error_code/1,
+                              process_request/4,
+                              error_response/4,
+                              parse_request_body/1]).
 
 %%--------------------------------------------------------------------
 %% ejabberd_cowboy callbacks
@@ -75,7 +79,8 @@ rest_init(Req, Opts) ->
 
 allowed_methods(Req, #http_api_state{command_category = Name} = State) ->
     CommandList = mongoose_commands:list(user, Name),
-    AllowedMethods = [action_to_method(mongoose_commands:action(Command)) || Command <- CommandList],
+    AllowedMethods = [action_to_method(mongoose_commands:action(Command))
+                      || Command <- CommandList],
     {AllowedMethods, Req, State}.
 
 content_types_provided(Req, State) ->
@@ -135,7 +140,8 @@ from_json(Req, #http_api_state{command_category = Category, bindings = B} = Stat
     end.
 
 arity(C) ->
-    % we don't have caller in bindings (we know it from authorisation), so it doesn't count when checking arity
+    % we don't have caller in bindings (we know it from authorisation),
+    % so it doesn't count when checking arity
     Args = mongoose_commands:args(C),
     length([N || {N, _} <- Args, N =/= caller]).
 

--- a/apps/ejabberd/src/mongoose_local_delivery.erl
+++ b/apps/ejabberd/src/mongoose_local_delivery.erl
@@ -18,12 +18,7 @@ do_route(OrigFrom, OrigTo, OrigPacket, LDstDomain, Handler) ->
     case ejabberd_hooks:run_fold(filter_local_packet, LDstDomain,
         {OrigFrom, OrigTo, OrigPacket}, []) of
         {From, To, Packet} ->
-            case Handler of
-                {apply_fun, Fun} ->
-                    Fun(From, To, Packet);
-                {apply, Module, Function} ->
-                    Module:Function(From, To, Packet)
-            end;
+            mongoose_packet_handler:process(Handler, From, To, Packet);
         drop ->
             ejabberd_hooks:run(xmpp_stanza_dropped,
                 OrigFrom#jid.lserver,

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -34,7 +34,7 @@
          privacy_iq_set/4,
          privacy_check_packet/6,
          user_ping_timeout/2,
-         privacy_list_push/5,
+         privacy_list_push/5
         ]).
 
 -type hook() :: [atom() | ejabberd:server() | integer(), ...].

--- a/apps/ejabberd/src/mongoose_metrics_mam_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_mam_hooks.erl
@@ -1,0 +1,231 @@
+%%%-------------------------------------------------------------------
+%%% @author Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% @doc MAM hooks for general metrics
+%%%
+%%% @end
+%%% Created : 13 Feb 2017 by Piotr Nosek
+%%%-------------------------------------------------------------------
+-module(mongoose_metrics_mam_hooks).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+
+-export([get_hooks/1]).
+
+%%-------------------
+%% Internal exports
+%%-------------------
+-export([mam_get_prefs/4,
+         mam_set_prefs/7,
+         mam_remove_archive/4,
+         mam_lookup_messages/14,
+         mam_archive_message/9,
+         mam_flush_messages/3,
+         mam_drop_message/2,
+         mam_drop_iq/6,
+         mam_drop_messages/3,
+         mam_purge_single_message/6,
+         mam_purge_multiple_messages/9,
+         mam_muc_get_prefs/4,
+         mam_muc_set_prefs/7,
+         mam_muc_remove_archive/4,
+         mam_muc_lookup_messages/14,
+         mam_muc_archive_message/9,
+         mam_muc_flush_messages/3,
+         mam_muc_drop_message/1,
+         mam_muc_drop_iq/6,
+         mam_muc_drop_messages/2,
+         mam_muc_purge_single_message/6,
+         mam_muc_purge_multiple_messages/9
+        ]).
+
+-type metrics_notify_return() :: mongoose_metrics_hooks:metrics_notify_return().
+
+%%-------------------
+%% Implementation
+%%-------------------
+
+%% @doc Here will be declared which hooks should be registered
+-spec get_hooks(_) -> [mongoose_metrics_hooks:t(), ...].
+get_hooks(Host) ->
+    [[mam_set_prefs, Host, ?MODULE, mam_set_prefs, 50],
+     [mam_get_prefs, Host, ?MODULE, mam_get_prefs, 50],
+     [mam_archive_message, Host, ?MODULE, mam_archive_message, 50],
+     [mam_flush_messages, Host, ?MODULE, mam_flush_messages, 50],
+     [mam_drop_message, Host, ?MODULE, mam_drop_message, 50],
+     [mam_drop_iq, Host, ?MODULE, mam_drop_iq, 50],
+     [mam_drop_messages, Host, ?MODULE, mam_drop_messages, 50],
+     [mam_remove_archive, Host, ?MODULE, mam_remove_archive, 50],
+     [mam_lookup_messages, Host, ?MODULE, mam_lookup_messages, 100],
+     [mam_purge_single_message, Host, ?MODULE, mam_purge_single_message, 50],
+     [mam_purge_multiple_messages, Host, ?MODULE, mam_purge_multiple_messages, 50],
+     [mam_muc_set_prefs, Host, ?MODULE, mam_muc_set_prefs, 50],
+     [mam_muc_get_prefs, Host, ?MODULE, mam_muc_get_prefs, 50],
+     [mam_muc_archive_message, Host, ?MODULE, mam_muc_archive_message, 50],
+     [mam_muc_remove_archive, Host, ?MODULE, mam_muc_remove_archive, 50],
+     [mam_muc_lookup_messages, Host, ?MODULE, mam_muc_lookup_messages, 100],
+     [mam_muc_purge_single_message, Host, ?MODULE, mam_muc_purge_single_message, 50],
+     [mam_muc_purge_multiple_messages, Host, ?MODULE, mam_muc_purge_multiple_messages, 50]].
+
+
+-spec mam_get_prefs(Result :: any(),
+                    Host :: ejabberd:server(),
+                    _ArcID :: mod_mam:archive_id(),
+                    _ArcJID :: ejabberd:jid()) -> any().
+mam_get_prefs(Result, Host, _ArcID, _ArcJID) ->
+    mongoose_metrics:update(Host, modMamPrefsGets, 1),
+    Result.
+
+-spec mam_set_prefs(Result :: any(), Host :: ejabberd:server(),
+    _ArcID :: mod_mam:archive_id(), _ArcJID :: ejabberd:jid(),
+    _DefaultMode :: any(), _AlwaysJIDs :: [ejabberd:literal_jid()],
+    _NeverJIDs :: [ejabberd:literal_jid()]) -> any().
+mam_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJIDs) ->
+    mongoose_metrics:update(Host, modMamPrefsSets, 1),
+    Result.
+
+-spec mam_remove_archive(Acc :: map(),
+                         Host :: ejabberd:server(),
+                         _ArcID :: mod_mam:archive_id(),
+                         _ArcJID :: ejabberd:jid()) -> metrics_notify_return().
+mam_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
+    mongoose_metrics:update(Host, modMamArchiveRemoved, 1),
+    Acc.
+
+mam_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
+    Host, _ArcID, _ArcJID,
+    _RSM, _Borders,
+    _Start, _End, _Now, _WithJID,
+    _PageSize, _LimitPassed, _MaxResultLimit, IsSimple) ->
+    mongoose_metrics:update(Host, modMamForwarded, length(MessageRows)),
+    mongoose_metrics:update(Host, modMamLookups, 1),
+    case IsSimple of
+        true ->
+            mongoose_metrics:update(Host, [modMamLookups, simple], 1);
+        _ ->
+            ok
+    end,
+    Result;
+mam_lookup_messages(Result = {error, _},
+    _Host, _ArcID, _ArcJID,
+    _RSM, _Borders,
+    _Start, _End, _Now, _WithJID,
+    _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+    Result.
+
+-spec mam_archive_message(Result :: any(), Host :: ejabberd:server(),
+    _MessId :: mod_mam:message_id(), _ArcID :: mod_mam:archive_id(),
+    _LocJID :: ejabberd:jid(), _RemJID :: ejabberd:jid(),
+    _SrcJID :: ejabberd:jid(), _Dir :: atom(), _Packet :: jlib:xmlel()) -> any().
+mam_archive_message(Result, Host,
+    _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
+    mongoose_metrics:update(Host, modMamArchived, 1),
+    Result.
+
+-spec mam_flush_messages(Acc :: map(),
+                         Host :: ejabberd:server(),
+                         MessageCount :: integer()) -> metrics_notify_return().
+mam_flush_messages(Acc, Host, MessageCount) ->
+    mongoose_metrics:update(Host, modMamFlushed, MessageCount),
+    Acc.
+
+%% #rh
+-spec mam_drop_message(Acc :: map(), Host :: ejabberd:server()) -> metrics_notify_return().
+mam_drop_message(Acc, Host) ->
+    mongoose_metrics:update(Host, modMamDropped, 1),
+    Acc.
+
+%% #rh
+-spec mam_drop_iq(Acc :: map(), Host :: ejabberd:server(), _To :: ejabberd:jid(),
+    _IQ :: ejabberd:iq(), _Action :: any(), _Reason :: any()) -> metrics_notify_return().
+mam_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
+    mongoose_metrics:update(Host, modMamDroppedIQ, 1),
+    Acc.
+
+%% #rh
+-spec mam_drop_messages(Acc :: map(),
+                        Host :: ejabberd:server(),
+                        Count :: integer()) -> metrics_notify_return().
+mam_drop_messages(Acc, Host, Count) ->
+    mongoose_metrics:update(Host, modMamDropped2, Count),
+    Acc.
+
+mam_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
+    mongoose_metrics:update(Host, modMamSinglePurges, 1),
+    Result.
+
+mam_purge_multiple_messages(Result, Host,
+    _ArcID, _ArcJID, _Borders, _Start, _End, _Now, _WithJID) ->
+    mongoose_metrics:update(Host, modMamMultiplePurges, 1),
+    Result.
+
+
+%% ----------------------------------------------------------------------------
+%% mod_mam_muc
+
+mam_muc_get_prefs(Result, Host, _ArcID, _ArcJID) ->
+    mongoose_metrics:update(Host, modMucMamPrefsGets, 1),
+    Result.
+
+mam_muc_set_prefs(Result, Host, _ArcID, _ArcJID, _DefaultMode, _AlwaysJIDs, _NeverJIDs) ->
+    mongoose_metrics:update(Host, modMucMamPrefsSets, 1),
+    Result.
+
+mam_muc_remove_archive(Acc, Host, _ArcID, _ArcJID) ->
+    mongoose_metrics:update(Host, modMucMamArchiveRemoved, 1),
+    Acc.
+
+mam_muc_lookup_messages(Result = {ok, {_TotalCount, _Offset, MessageRows}},
+    Host, _ArcID, _ArcJID,
+    _RSM, _Borders,
+    _Start, _End, _Now, _WithJID,
+    _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+    mongoose_metrics:update(Host, modMucMamForwarded, length(MessageRows)),
+    mongoose_metrics:update(Host, modMucMamLookups, 1),
+    Result;
+mam_muc_lookup_messages(Result = {error, _},
+    _Host, _ArcID, _ArcJID,
+    _RSM, _Borders,
+    _Start, _End, _Now, _WithJID,
+    _PageSize, _LimitPassed, _MaxResultLimit, _IsSimple) ->
+    Result.
+
+
+mam_muc_archive_message(Result, Host,
+    _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
+    mongoose_metrics:update(Host, modMucMamArchived, 1),
+    Result.
+
+%% #rh
+mam_muc_flush_messages(Acc, Host, MessageCount) ->
+    mongoose_metrics:update(Host, modMucMamFlushed, MessageCount),
+    Acc.
+
+mam_muc_drop_message(Host) ->
+    mongoose_metrics:update(Host, modMucMamDropped, 1).
+
+%% #rh
+mam_muc_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
+    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1),
+    Acc.
+
+mam_muc_drop_messages(Host, Count) ->
+    mongoose_metrics:update(Host, modMucMamDropped2, Count).
+
+-spec mam_muc_purge_single_message(Result :: any(), Host :: ejabberd:server(),
+    _MessID :: mod_mam:message_id(), _ArcID :: mod_mam:archive_id(),
+    _ArcJID :: ejabberd:jid(), _Now :: mod_mam:unix_timestamp()) -> any().
+mam_muc_purge_single_message(Result, Host, _MessID, _ArcID, _ArcJID, _Now) ->
+    mongoose_metrics:update(Host, modMucMamSinglePurges, 1),
+    Result.
+
+-spec mam_muc_purge_multiple_messages(Result :: any(),
+    Host :: ejabberd:server(), _ArcID :: mod_mam:archive_id(),
+    _ArcJID :: ejabberd:jid(), _Borders :: any(), _Start :: any(),
+    _End :: any(), _Now :: mod_mam:unix_timestamp(), _WithJID :: any()) -> any().
+mam_muc_purge_multiple_messages(Result, Host,
+    _ArcID, _ArcJID, _Borders, _Start, _End, _Now, _WithJID) ->
+    mongoose_metrics:update(Host, modMucMamMultiplePurges, 1),
+    Result.
+
+%%% vim: set sts=4 ts=4 sw=4 et filetype=erlang foldmarker=%%%',%%%. foldmethod=marker:

--- a/apps/ejabberd/src/mongoose_packet_handler.erl
+++ b/apps/ejabberd/src/mongoose_packet_handler.erl
@@ -1,0 +1,50 @@
+%%%----------------------------------------------------------------------
+%%% File    : mongoose_packet_handler.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : Packet handler behaviour
+%%% Created : 24 Jan 2017
+%%%----------------------------------------------------------------------
+
+-module(mongoose_packet_handler).
+-author('piotr.nosek@erlang-solutions.com').
+
+-include("jlib.hrl").
+
+%%----------------------------------------------------------------------
+%% Types
+%%----------------------------------------------------------------------
+
+-record(packet_handler, { module, extra }).
+
+-type t() :: #packet_handler{
+                module :: module(),
+                extra :: any()
+               }.
+
+-export_type([t/0]).
+
+%%----------------------------------------------------------------------
+%% Callback declarations
+%%----------------------------------------------------------------------
+
+-callback process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Extra :: any()) ->
+    any().
+
+%%----------------------------------------------------------------------
+%% API
+%%----------------------------------------------------------------------
+
+-export([new/1, new/2, process/4]).
+
+-spec new(Module :: module()) -> t().
+new(Module) ->
+    new(Module, undefined).
+
+-spec new(Module :: module(), Extra :: any()) -> t().
+new(Module, Extra) when is_atom(Module) ->
+    #packet_handler{ module = Module, extra = Extra }.
+
+-spec process(Handler :: t(), From :: jid(), To :: jid(), Packet :: exml:element()) -> any().
+process(#packet_handler{ module = Module, extra = Extra }, From, To, Packet) ->
+    Module:process_packet(From, To, Packet, Extra).
+

--- a/apps/ejabberd/src/mongoose_riak.erl
+++ b/apps/ejabberd/src/mongoose_riak.erl
@@ -163,9 +163,12 @@ search(Index, Query, Opts) ->
 get_index(BucketType, Index, Value, Opts) ->
     ?CALL(get_index_eq, [BucketType, Index, Value, Opts]).
 
--spec get_index_range(riakc_obj:bucket(), binary() | secondary_index_id(), key() | integer() | list(),
-                key() | integer() | list(), [term()]) ->
-                       {ok, index_results()} | {error, term()}.
+-spec get_index_range(Bucket :: riakc_obj:bucket(),
+                      Index :: binary() | secondary_index_id(),
+                      StartKey :: key() | integer() | list(),
+                      EndKey :: key() | integer() | list(),
+                      Opts :: [term()]) ->
+    {ok, index_results()} | {error, term()}.
 get_index_range(Bucket, Index, StartKey, EndKey, Opts) ->
     ?CALL(get_index_range, [Bucket, Index, StartKey, EndKey, Opts]).
 

--- a/apps/ejabberd/src/mongoose_riak_sup.erl
+++ b/apps/ejabberd/src/mongoose_riak_sup.erl
@@ -88,9 +88,8 @@ child_spec(Workers, RiakOpts) ->
     ChildMF = {mongoose_riak, start_worker},
     RiakPoolName = mongoose_riak:pool_name(),
     ChildArgs = {for_all, RiakOpts},
-    AChild = {RiakPoolName, {cuesport, start_link, [RiakPoolName, Workers, ChildMods, ChildMF, ChildArgs]},
-        Restart, Shutdown, Type, ChildMods},
-    AChild.
+    PoolMFA = {cuesport, start_link, [RiakPoolName, Workers, ChildMods, ChildMF, ChildArgs]},
+    {RiakPoolName, PoolMFA, Restart, Shutdown, Type, ChildMods}.
 
 %%%===================================================================
 %%% Internal functions

--- a/apps/ejabberd/test/component_reg_SUITE.erl
+++ b/apps/ejabberd/test/component_reg_SUITE.erl
@@ -32,7 +32,7 @@ end_per_suite(_C) ->
 
 registering(_C) ->
     Dom = <<"aaa.bbb.com">>,
-    ejabberd_router:register_component(Dom),
+    ejabberd_router:register_component(Dom, mongoose_packet_handler:new(?MODULE)),
     Lookup = ejabberd_router:lookup_component(Dom),
     ?assertMatch([#external_component{}], Lookup),
     ejabberd_router:unregister_component(Dom),
@@ -43,7 +43,8 @@ registering_with_local(_C) ->
     Dom = <<"aaa.bbb.com">>,
     ThisNode = node(),
     AnotherNode = 'another@nohost',
-    ejabberd_router:register_component(Dom),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    ejabberd_router:register_component(Dom, Handler),
     %% we can find it globally
     ?assertMatch([#external_component{node = ThisNode}], ejabberd_router:lookup_component(Dom)),
     %% and for this node
@@ -56,8 +57,8 @@ registering_with_local(_C) ->
     ?assertMatch([], ejabberd_router:lookup_component(Dom, ThisNode)),
     ?assertMatch([], ejabberd_router:lookup_component(Dom, AnotherNode)),
     %% we can register from both nodes
-    ejabberd_router:register_component(Dom, ThisNode),
-    ejabberd_router:register_component(Dom, AnotherNode), %% passing node here is only for testing
+    ejabberd_router:register_component(Dom, ThisNode, Handler),
+    ejabberd_router:register_component(Dom, AnotherNode, Handler), %% passing node here is only for testing
     %% both are reachable locally
     ?assertMatch([#external_component{node = ThisNode}], ejabberd_router:lookup_component(Dom, ThisNode)),
     ?assertMatch([#external_component{node = AnotherNode}], ejabberd_router:lookup_component(Dom, AnotherNode)),
@@ -70,4 +71,6 @@ registering_with_local(_C) ->
     ?assertMatch([#external_component{node = AnotherNode}], ejabberd_router:lookup_component(Dom, AnotherNode)),
     ok.
 
+process_packet(_From, _To, _Packet, _Extra) ->
+    exit(process_packet_called).
 

--- a/apps/ejabberd/test/component_reg_SUITE.erl
+++ b/apps/ejabberd/test/component_reg_SUITE.erl
@@ -43,12 +43,13 @@ registering_with_local(_C) ->
     Dom = <<"aaa.bbb.com">>,
     ThisNode = node(),
     AnotherNode = 'another@nohost',
-    Handler = mongoose_packet_handler:new(?MODULE),
+    Handler = mongoose_packet_handler:new(?MODULE), %% This handler is only for testing!
     ejabberd_router:register_component(Dom, Handler),
     %% we can find it globally
     ?assertMatch([#external_component{node = ThisNode}], ejabberd_router:lookup_component(Dom)),
     %% and for this node
-    ?assertMatch([#external_component{node = ThisNode}], ejabberd_router:lookup_component(Dom, ThisNode)),
+    ?assertMatch([#external_component{node = ThisNode}],
+                 ejabberd_router:lookup_component(Dom, ThisNode)),
     %% but not for another node
     ?assertMatch([], ejabberd_router:lookup_component(Dom, AnotherNode)),
     %% once we unregister it is not available
@@ -58,17 +59,22 @@ registering_with_local(_C) ->
     ?assertMatch([], ejabberd_router:lookup_component(Dom, AnotherNode)),
     %% we can register from both nodes
     ejabberd_router:register_component(Dom, ThisNode, Handler),
-    ejabberd_router:register_component(Dom, AnotherNode, Handler), %% passing node here is only for testing
+    %% passing node here is only for testing
+    ejabberd_router:register_component(Dom, AnotherNode, Handler),
     %% both are reachable locally
-    ?assertMatch([#external_component{node = ThisNode}], ejabberd_router:lookup_component(Dom, ThisNode)),
-    ?assertMatch([#external_component{node = AnotherNode}], ejabberd_router:lookup_component(Dom, AnotherNode)),
+    ?assertMatch([#external_component{node = ThisNode}],
+                 ejabberd_router:lookup_component(Dom, ThisNode)),
+    ?assertMatch([#external_component{node = AnotherNode}],
+                 ejabberd_router:lookup_component(Dom, AnotherNode)),
     %% if we try global lookup we get two handlers
     ?assertMatch([_, _], ejabberd_router:lookup_component(Dom)),
     %% we unregister one and the result is:
     ejabberd_router:unregister_component(Dom),
     ?assertMatch([], ejabberd_router:lookup_component(Dom, ThisNode)),
-    ?assertMatch([#external_component{node = AnotherNode}], ejabberd_router:lookup_component(Dom)),
-    ?assertMatch([#external_component{node = AnotherNode}], ejabberd_router:lookup_component(Dom, AnotherNode)),
+    ?assertMatch([#external_component{node = AnotherNode}],
+                 ejabberd_router:lookup_component(Dom)),
+    ?assertMatch([#external_component{node = AnotherNode}],
+                 ejabberd_router:lookup_component(Dom, AnotherNode)),
     ok.
 
 process_packet(_From, _To, _Packet, _Extra) ->


### PR DESCRIPTION
Proposed changes include:
* Refactored `mongoose_*` modules, according to Elvis' suggestions
* Introduced `mongoose_packet_handler` behaviour for modules that are called during local routing
* Handler modules are responsible for creating a handle for `register_route` and `register_component`.