### PR TITLE
HTTP Upload size limits

### DIFF
--- a/apps/ejabberd/src/http_upload/mod_http_upload.erl
+++ b/apps/ejabberd/src/http_upload/mod_http_upload.erl
@@ -168,9 +168,9 @@ my_disco_name(Lang) ->
 compose_iq_reply(IQ, PutUrl, GetUrl) ->
     Slot = #xmlel{
               name = <<"slot">>,
-              attrs=[{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
-              children =[#xmlel{name = <<"put">>, children = [exml:escape_cdata(PutUrl)]},
-                         #xmlel{name = <<"get">>, children = [exml:escape_cdata(GetUrl)]}]},
+              attrs = [{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
+              children = [#xmlel{name = <<"put">>, children = [exml:escape_cdata(PutUrl)]},
+                          #xmlel{name = <<"get">>, children = [exml:escape_cdata(GetUrl)]}]},
     IQ#iq{type = result, sub_el =[Slot]}.
 
 
@@ -205,17 +205,12 @@ generate_token(Host) ->
 -spec file_too_large_error(MaxFileSize :: non_neg_integer()) -> jlib:exml().
 file_too_large_error(MaxFileSize) ->
     MaxFileSizeBin = integer_to_binary(MaxFileSize),
+    MaxSizeEl = #xmlel{name = <<"max-file-size">>, children = [exml:escape_cdata(MaxFileSizeBin)]},
+    FileTooLargeEl = #xmlel{name = <<"file-too-large">>,
+                            attrs = [{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
+                            children = [MaxSizeEl]},
     Error0 = ?ERR_NOT_ACCEPTABLE,
-    Error0#xmlel{
-      children =
-          [
-           #xmlel{name = <<"file-too-large">>,
-                  attrs = [{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
-                  children =
-                      [#xmlel{name = <<"max-file-size">>,
-                              children = [exml:escape_cdata(MaxFileSizeBin)]}]}
-           | Error0#xmlel.children
-          ]}.
+    Error0#xmlel{children = [FileTooLargeEl | Error0#xmlel.children]}.
 
 
 -spec parse_request(Request :: exml:element()) ->

--- a/apps/ejabberd/src/http_upload/mod_http_upload.erl
+++ b/apps/ejabberd/src/http_upload/mod_http_upload.erl
@@ -22,7 +22,14 @@
 -include("jlib.hrl").
 -include("ejabberd.hrl").
 
+-define(DEFAULT_TOKEN_BYTES, 32).
+-define(DEFAULT_MAX_FILE_SIZE, 10 * 1024 * 1024). % 10 MB
+-define(DEFAULT_SUBHOST, <<"upload.@HOST@">>).
+
 -export([start/2, stop/1, iq_handler/3]).
+
+%% Hook implementations
+-export([get_disco_identity/5, get_disco_items/5, get_disco_features/5]).
 
 %%--------------------------------------------------------------------
 %% Callbacks
@@ -40,16 +47,26 @@
 -spec start(Host :: ejabberd:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
-    mod_disco:register_feature(Host, ?NS_HTTP_UPLOAD),
-    gen_iq_handler:add_iq_handler(ejabberd_local, Host, ?NS_HTTP_UPLOAD, ?MODULE,
+    SubHost = subhost(Host),
+    mod_disco:register_subhost(Host, SubHost),
+    mongoose_subhosts:register(Host, SubHost),
+    ejabberd_hooks:add(disco_local_features, SubHost, ?MODULE, get_disco_features, 90),
+    ejabberd_hooks:add(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
+    ejabberd_hooks:add(disco_local_items, Host, ?MODULE, get_disco_items, 90),
+    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD, ?MODULE,
                                   iq_handler, IQDisc),
     gen_mod:start_backend_module(?MODULE, with_default_backend(Opts), [create_slot]).
 
 
 -spec stop(Host :: ejabberd:server()) -> any().
 stop(Host) ->
-    gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_HTTP_UPLOAD),
-    mod_disco:unregister_feature(Host, ?NS_HTTP_UPLOAD).
+    SubHost = subhost(Host),
+    gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD),
+    ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, get_disco_items, 90),
+    ejabberd_hooks:delete(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
+    ejabberd_hooks:delete(disco_local_features, SubHost, ?MODULE, get_disco_features, 90),
+    mongoose_subhosts:unregister(SubHost),
+    mod_disco:unregister_subhost(Host, SubHost).
 
 
 -spec iq_handler(From :: ejabberd:jid(), To :: ejabberd:jid(), IQ :: ejabberd:iq()) ->
@@ -59,22 +76,83 @@ iq_handler(_From, _To, IQ = #iq{type = set, sub_el = SubEl}) ->
 iq_handler(_From, _To, IQ = #iq{type = get, sub_el = Request}) ->
     case parse_request(Request) of
         {Filename, Size, ContentType} ->
-            UTCDateTime = calendar:universal_time(),
-            Token = generate_token(),
-            Opts = module_opts(),
+            case max_file_size =:= undefined orelse Size =< max_file_size() of
+                true ->
+                    UTCDateTime = calendar:universal_time(),
+                    Token = generate_token(),
+                    Opts = module_opts(),
 
-            {PutUrl, GetUrl} = mod_http_upload_backend:create_slot(
-                                 UTCDateTime, Token, Filename, ContentType, Size, Opts),
+                    {PutUrl, GetUrl} = mod_http_upload_backend:create_slot(
+                                         UTCDateTime, Token, Filename, ContentType, Size, Opts),
 
-            compose_iq_reply(IQ, PutUrl, GetUrl);
+                    compose_iq_reply(IQ, PutUrl, GetUrl);
+
+                false ->
+                    MaxFileSizeBin = integer_to_binary(max_file_size()),
+                    Error0 = ?ERR_NOT_ACCEPTABLE,
+                    Error = Error0#xmlel{
+                              children =
+                                  [
+                                   #xmlel{name = <<"file-too-large">>,
+                                          attrs = [{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
+                                          children =
+                                              [#xmlel{name = <<"max-file-size">>,
+                                                      children = [exml:escape_cdata(MaxFileSizeBin)]}]}
+                                   | Error0#xmlel.children
+                                  ]},
+                    IQ#iq{type = error, sub_el = [Error]}
+            end;
 
         bad_request ->
             IQ#iq{type = error, sub_el = [Request, ?ERR_BAD_REQUEST]}
     end.
 
+
+-spec get_disco_identity(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
+                         Node :: binary(), ejabberd:lang()) -> [jlib:xmlel()] | term().
+get_disco_identity(Acc, _From, _To, _Node, Lang) ->
+    [#xmlel{name = <<"identity">>,
+            attrs = [{<<"category">>, <<"store">>},
+                     {<<"type">>, <<"file">>},
+                     {<<"name">>, my_disco_name(Lang)}]} | Acc];
+get_disco_identity(Acc, _From, _To, _Node, _Lang) ->
+    Acc.
+
+
+-spec get_disco_items(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
+                      Node :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]} | term().
+get_disco_items({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, Lang) ->
+    Item = #xmlel{name = <<"item">>,
+                  attrs = [{<<"jid">>, subhost(LServer)}, {<<"name">>, my_disco_name(Lang)}]},
+    {result, [Item | Nodes]};
+get_disco_items(empty, From, To, Node, Lang) ->
+    get_disco_items({result, []}, From, To, Node, Lang);
+get_disco_items(Acc, _From, _To, _Node, _Lang) ->
+    Acc.
+
+
+-spec get_disco_features(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
+                         Node :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]} | term().
+get_disco_features({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, Lang) ->
+    {result, [?NS_HTTP_UPLOAD | Nodes]};
+get_disco_features(empty, From, To, Node, Lang) ->
+    get_disco_features({result, []}, From, To, Node, Lang);
+get_disco_features(Acc, _From, _To, _Node, _Lang) ->
+    Acc.
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
+
+-spec subhost(Host :: ejabberd:server()) -> binary().
+subhost(Host) ->
+    gen_mod:get_module_opt_subhost(Host, ?MODULE, ?DEFAULT_SUBHOST).
+
+
+-spec my_disco_name(ejabberd:lang()) -> binary().
+my_disco_name(Lang) ->
+    translate:translate(Lang, <<"HTTP File Upload">>).
+
 
 -spec compose_iq_reply(IQ :: ejabberd:iq(), PutUrl :: binary(), GetUrl :: binary()) ->
                               Reply :: ejabberd:iq().
@@ -82,17 +160,19 @@ compose_iq_reply(IQ, PutUrl, GetUrl) ->
     Slot = #xmlel{
               name = <<"slot">>,
               attrs=[{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
-              children =[
-                         #xmlel{name = <<"put">>, children = [exml:escape_cdata(PutUrl)]},
-                         #xmlel{name = <<"get">>, children = [exml:escape_cdata(GetUrl)]}
-                        ]},
-
+              children =[#xmlel{name = <<"put">>, children = [exml:escape_cdata(PutUrl)]},
+                         #xmlel{name = <<"get">>, children = [exml:escape_cdata(GetUrl)]}]},
     IQ#iq{type = result, sub_el =[Slot]}.
 
 
 -spec token_bytes() -> pos_integer().
 token_bytes() ->
-    gen_mod:get_module_opt(?MYNAME, ?MODULE, token_bytes, 32).
+    gen_mod:get_module_opt(?MYNAME, ?MODULE, token_bytes, ?DEFAULT_TOKEN_BYTES).
+
+
+-spec max_file_size() -> pos_integer() | undefined.
+max_file_size() ->
+    gen_mod:get_module_opt(?MYNAME, ?MODULE, max_file_size, ?DEFAULT_MAX_FILE_SIZE).
 
 
 -spec with_default_backend(Opts :: proplists:proplist()) -> proplists:proplist().

--- a/apps/ejabberd/src/http_upload/mod_http_upload.erl
+++ b/apps/ejabberd/src/http_upload/mod_http_upload.erl
@@ -29,7 +29,7 @@
 -export([start/2, stop/1, iq_handler/3]).
 
 %% Hook implementations
--export([get_disco_identity/5, get_disco_items/5, get_disco_features/5]).
+-export([get_disco_identity/5, get_disco_items/5, get_disco_features/5, get_disco_info/5]).
 
 %%--------------------------------------------------------------------
 %% Callbacks
@@ -52,6 +52,7 @@ start(Host, Opts) ->
     mongoose_subhosts:register(Host, SubHost),
     ejabberd_hooks:add(disco_local_features, SubHost, ?MODULE, get_disco_features, 90),
     ejabberd_hooks:add(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
+    ejabberd_hooks:add(disco_info, SubHost, ?MODULE, get_disco_info, 90),
     ejabberd_hooks:add(disco_local_items, Host, ?MODULE, get_disco_items, 90),
     gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD, ?MODULE,
                                   iq_handler, IQDisc),
@@ -63,6 +64,7 @@ stop(Host) ->
     SubHost = subhost(Host),
     gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD),
     ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, get_disco_items, 90),
+    ejabberd_hooks:delete(disco_info, SubHost, ?MODULE, get_disco_info, 90),
     ejabberd_hooks:delete(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
     ejabberd_hooks:delete(disco_local_features, SubHost, ?MODULE, get_disco_features, 90),
     mongoose_subhosts:unregister(SubHost),
@@ -73,14 +75,16 @@ stop(Host) ->
                         ejabberd:iq() | ignore.
 iq_handler(_From, _To, IQ = #iq{type = set, sub_el = SubEl}) ->
     IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
-iq_handler(_From, _To, IQ = #iq{type = get, sub_el = Request}) ->
+iq_handler(_From, _To = #jid{lserver = SubHost}, IQ = #iq{type = get, sub_el = Request}) ->
+    {ok, Host} = mongoose_subhosts:get_host(SubHost),
     case parse_request(Request) of
         {Filename, Size, ContentType} ->
-            case max_file_size() =:= undefined orelse Size =< max_file_size() of
+            MaxFileSize = max_file_size(Host),
+            case MaxFileSize =:= undefined orelse Size =< MaxFileSize of
                 true ->
                     UTCDateTime = calendar:universal_time(),
-                    Token = generate_token(),
-                    Opts = module_opts(),
+                    Token = generate_token(Host),
+                    Opts = module_opts(Host),
 
                     {PutUrl, GetUrl} = mod_http_upload_backend:create_slot(
                                          UTCDateTime, Token, Filename, ContentType, Size, Opts),
@@ -88,7 +92,6 @@ iq_handler(_From, _To, IQ = #iq{type = get, sub_el = Request}) ->
                     compose_iq_reply(IQ, PutUrl, GetUrl);
 
                 false ->
-                    MaxFileSize = max_file_size(),
                     IQ#iq{type = error, sub_el = [file_too_large_error(MaxFileSize)]}
             end;
 
@@ -99,7 +102,7 @@ iq_handler(_From, _To, IQ = #iq{type = get, sub_el = Request}) ->
 
 -spec get_disco_identity(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
                          Node :: binary(), ejabberd:lang()) -> [jlib:xmlel()] | term().
-get_disco_identity(Acc, _From, _To, _Node, Lang) ->
+get_disco_identity(Acc, _From, _To, _Node = <<>>, Lang) ->
     [#xmlel{name = <<"identity">>,
             attrs = [{<<"category">>, <<"store">>},
                      {<<"type">>, <<"file">>},
@@ -110,9 +113,9 @@ get_disco_identity(Acc, _From, _To, _Node, _Lang) ->
 
 -spec get_disco_items(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
                       Node :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]} | term().
-get_disco_items({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, Lang) ->
-    Item = #xmlel{name = <<"item">>,
-                  attrs = [{<<"jid">>, subhost(LServer)}, {<<"name">>, my_disco_name(Lang)}]},
+get_disco_items({result, Nodes}, _From, #jid{lserver = Host} = _To, <<"">>, Lang) ->
+    Item = #xmlel{name  = <<"item">>,
+                  attrs = [{<<"jid">>, subhost(Host)}, {<<"name">>, my_disco_name(Lang)}]},
     {result, [Item | Nodes]};
 get_disco_items(empty, From, To, Node, Lang) ->
     get_disco_items({result, []}, From, To, Node, Lang);
@@ -122,11 +125,28 @@ get_disco_items(Acc, _From, _To, _Node, _Lang) ->
 
 -spec get_disco_features(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
                          Node :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]} | term().
-get_disco_features({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, Lang) ->
+get_disco_features({result, Nodes}, _From, _To, _Node = <<>>, _Lang) ->
     {result, [?NS_HTTP_UPLOAD | Nodes]};
 get_disco_features(empty, From, To, Node, Lang) ->
     get_disco_features({result, []}, From, To, Node, Lang);
 get_disco_features(Acc, _From, _To, _Node, _Lang) ->
+    Acc.
+
+
+-spec get_disco_info(Acc :: [jlib:xmlel()], ejabberd:server(), module(), Node :: binary(),
+                     Lang :: ejabberd:lang()) -> [jlib:xmlel()].
+get_disco_info(Acc, SubHost, _Mod, _Node = <<>>, _Lang) ->
+    {ok, Host} = mongoose_subhosts:get_host(SubHost),
+    case max_file_size(Host) of
+        undefined -> Acc;
+        MaxFileSize ->
+            MaxFileSizeBin = integer_to_binary(MaxFileSize),
+            [#xmlel{name = <<"x">>,
+                    attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"result">>}],
+                    children = [jlib:form_field({<<"FORM_TYPE">>, <<"hidden">>, ?NS_HTTP_UPLOAD}),
+                                jlib:form_field({<<"max-file-size">>, MaxFileSizeBin})]}]
+    end;
+get_disco_info(Acc, _Host, _Mod, _Node, _Lang) ->
     Acc.
 
 %%--------------------------------------------------------------------
@@ -154,14 +174,14 @@ compose_iq_reply(IQ, PutUrl, GetUrl) ->
     IQ#iq{type = result, sub_el =[Slot]}.
 
 
--spec token_bytes() -> pos_integer().
-token_bytes() ->
-    gen_mod:get_module_opt(?MYNAME, ?MODULE, token_bytes, ?DEFAULT_TOKEN_BYTES).
+-spec token_bytes(ejabberd:server()) -> pos_integer().
+token_bytes(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, token_bytes, ?DEFAULT_TOKEN_BYTES).
 
 
--spec max_file_size() -> pos_integer() | undefined.
-max_file_size() ->
-    gen_mod:get_module_opt(?MYNAME, ?MODULE, max_file_size, ?DEFAULT_MAX_FILE_SIZE).
+-spec max_file_size(ejabberd:server()) -> pos_integer() | undefined.
+max_file_size(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, max_file_size, ?DEFAULT_MAX_FILE_SIZE).
 
 
 -spec with_default_backend(Opts :: proplists:proplist()) -> proplists:proplist().
@@ -172,14 +192,14 @@ with_default_backend(Opts) ->
     end.
 
 
--spec module_opts() -> proplists:proplist().
-module_opts() ->
-    gen_mod:get_module_opts(?MYNAME, ?MODULE).
+-spec module_opts(ejabberd:server()) -> proplists:proplist().
+module_opts(Host) ->
+    gen_mod:get_module_opts(Host, ?MODULE).
 
 
--spec generate_token() -> binary().
-generate_token() ->
-    base16:encode(crypto:strong_rand_bytes(token_bytes())).
+-spec generate_token(ejabberd:server()) -> binary().
+generate_token(Host) ->
+    base16:encode(crypto:strong_rand_bytes(token_bytes(Host))).
 
 
 -spec file_too_large_error(MaxFileSize :: non_neg_integer()) -> jlib:exml().

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -191,17 +191,18 @@ make_invitation(From, Password, Reason) ->
 
 
 -spec form_field({binary(), binary(), binary()}
+               | {binary(), binary()}
                | {binary(), binary(), binary(), binary()}) -> xmlel().
 form_field({Var, Type, Value, Label}) ->
-    #xmlel{name = <<"field">>,
-           attrs = [{<<"var">>, Var}, {<<"type">>, Type}, {<<"label">>, Label}],
-           children = [#xmlel{name = <<"value">>,
-                              children = [#xmlcdata{content = Value}]}]};
+    Field = form_field({Var, Type, Value}),
+    Field#xmlel{attrs = [{<<"label">>, Label} | Field#xmlel.attrs]};
 form_field({Var, Type, Value}) ->
+    Field = form_field({Var, Value}),
+    Field#xmlel{attrs = [{<<"type">>, Type} | Field#xmlel.attrs]};
+form_field({Var, Value}) ->
     #xmlel{name = <<"field">>,
-           attrs = [{<<"var">>, Var}, {<<"type">>, Type}],
-           children = [#xmlel{name = <<"value">>,
-                              children = [#xmlcdata{content = Value}]}]}.
+           attrs = [{<<"var">>, Var}],
+           children = [#xmlel{name = <<"value">>, children = [#xmlcdata{content = Value}]}]}.
 
 
 -spec make_voice_approval_form(From :: ejabberd:simple_jid() | ejabberd:jid(),

--- a/apps/ejabberd/src/mod_disco.erl
+++ b/apps/ejabberd/src/mod_disco.erl
@@ -46,7 +46,9 @@
          register_feature/2,
          unregister_feature/2,
          register_extra_domain/2,
-         unregister_extra_domain/2]).
+         unregister_extra_domain/2,
+         register_subhost/2,
+         unregister_subhost/2]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -55,6 +57,32 @@
 
 -spec start(ejabberd:server(), list()) -> 'ok'.
 start(Host, Opts) ->
+    [catch ets:new(Name, [named_table, ordered_set, public]) || Name <-
+        [disco_features, disco_extra_domains, disco_sm_features, disco_sm_nodes, disco_subhosts]],
+
+    register_host(Host, Opts),
+    register_feature(Host, <<"iq">>),
+    register_feature(Host, <<"presence">>),
+    register_feature(Host, <<"presence-invisible">>),
+    ejabberd_hooks:add(disco_local_identity, Host, ?MODULE, get_local_identity, 100),
+    ExtraDomains = gen_mod:get_opt(extra_domains, Opts, []),
+    lists:foreach(fun(Domain) -> register_extra_domain(Host, Domain) end, ExtraDomains).
+
+
+-spec stop(ejabberd:server()) -> ok.
+stop(Host) ->
+    unregister_host(Host),
+    ejabberd_hooks:delete(disco_local_identity, Host, ?MODULE, get_local_identity, 100).
+
+
+register_subhost(Host, Subhost) ->
+    case gen_mod:is_loaded(Host, ?MODULE) of
+        false -> ok;
+        true ->
+            register_host(Subhost, gen_mod:get_module_opts(Host, ?MODULE)),
+            ets:insert(disco_subhosts, {{Subhost, Host}})
+    end.
+register_host(Host, Opts) ->
     ejabberd_local:refresh_iq_handlers(),
 
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
@@ -67,29 +95,22 @@ start(Host, Opts) ->
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_DISCO_INFO,
                                   ?MODULE, process_sm_iq_info, IQDisc),
 
-    catch ets:new(disco_features, [named_table, ordered_set, public]),
-    register_feature(Host, <<"iq">>),
-    register_feature(Host, <<"presence">>),
-    register_feature(Host, <<"presence-invisible">>),
-
-    catch ets:new(disco_extra_domains, [named_table, ordered_set, public]),
-    ExtraDomains = gen_mod:get_opt(extra_domains, Opts, []),
-    lists:foreach(fun(Domain) -> register_extra_domain(Host, Domain) end,
-                  ExtraDomains),
-    catch ets:new(disco_sm_features, [named_table, ordered_set, public]),
-    catch ets:new(disco_sm_nodes, [named_table, ordered_set, public]),
     ejabberd_hooks:add(disco_local_items, Host, ?MODULE, get_local_services, 100),
     ejabberd_hooks:add(disco_local_features, Host, ?MODULE, get_local_features, 100),
-    ejabberd_hooks:add(disco_local_identity, Host, ?MODULE, get_local_identity, 100),
     ejabberd_hooks:add(disco_sm_items, Host, ?MODULE, get_sm_items, 100),
     ejabberd_hooks:add(disco_sm_features, Host, ?MODULE, get_sm_features, 100),
     ejabberd_hooks:add(disco_sm_identity, Host, ?MODULE, get_sm_identity, 100),
     ejabberd_hooks:add(disco_info, Host, ?MODULE, get_info, 100),
     ok.
 
-
--spec stop(ejabberd:server()) -> ok.
-stop(Host) ->
+unregister_subhost(Host, Subhost) ->
+    case gen_mod:is_loaded(Host, ?MODULE) of
+        false -> ok;
+        true ->
+            unregister_host(Subhost),
+            ets:delete(disco_subhosts, {Subhost, Host})
+    end.
+unregister_host(Host) ->
     ejabberd_hooks:delete(disco_sm_identity, Host, ?MODULE, get_sm_identity, 100),
     ejabberd_hooks:delete(disco_sm_features, Host, ?MODULE, get_sm_features, 100),
     ejabberd_hooks:delete(disco_sm_items, Host, ?MODULE, get_sm_items, 100),
@@ -103,8 +124,9 @@ stop(Host) ->
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_DISCO_INFO),
     catch ets:match_delete(disco_features, {{'_', Host}}),
     catch ets:match_delete(disco_extra_domains, {{'_', Host}}),
+    lists:foreach(fun([{Subhost, _}]) -> unregister_subhost(Host, Subhost) end,
+                  ets:match(disco_subhosts, {{'_', Host}})),
     ok.
-
 
 -spec register_feature(ejabberd:server(), feature()) -> 'true'.
 register_feature(Host, Feature) ->

--- a/doc/modules/mod_http_upload.md
+++ b/doc/modules/mod_http_upload.md
@@ -8,6 +8,7 @@ Currently, the module supports only S3 backend using [AWS Signature Version 4](h
 * **backend** (atom, default: `s3`) - Backend to use for generating slots. Currently only `s3` can be used.
 * **expiration_time** (integer, default: `60`) - Duration (in seconds) after which the generated `PUT` URL will become invalid.
 * **token_bytes** (integer, default: `32`) - Number of random bytes of a token that will be used in a generated URL. The text representation of the token will be twice as long as the number of bytes, e.g. for the default value the token in URL will be 64 characters long.
+* **max_file_size** (integer, default: 10 MB) - Maximum file size (in bytes) accepted by the module. Disabled if set to `undefined`.
 * **s3** (list, default: unset) - Options specific to S3 backend.
 
 #### S3 backend options

--- a/doc/modules/mod_http_upload.md
+++ b/doc/modules/mod_http_upload.md
@@ -5,6 +5,7 @@ Currently, the module supports only S3 backend using [AWS Signature Version 4](h
 
 ### Options
 
+* **host** (string, default: `"upload.@HOST@"`): Subdomain for upload service to reside under. `@HOST@` is replaced with each served domain.
 * **backend** (atom, default: `s3`) - Backend to use for generating slots. Currently only `s3` can be used.
 * **expiration_time** (integer, default: `60`) - Duration (in seconds) after which the generated `PUT` URL will become invalid.
 * **token_bytes** (integer, default: `32`) - Number of random bytes of a token that will be used in a generated URL. The text representation of the token will be twice as long as the number of bytes, e.g. for the default value the token in URL will be 64 characters long.
@@ -26,6 +27,7 @@ Currently, the module supports only S3 backend using [AWS Signature Version 4](h
 
 ```Erlang
 {mod_http_upload, [
+        {host, "upload.@HOST@"},
         {backend, s3},
         {expiration_time, 120},
         {s3, [

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -713,6 +713,9 @@
   %                              roster, last, private, stanza, stats]}]},
 
 % {mod_http_upload, [
+    %% Set max file size in bytes. Defaults to 10 MB.
+    %% Disabled if value is `undefined`.
+%   {max_file_size, 1024},
     %% Use S3 storage backend
 %   {backend, s3},
     %% Set options for S3 backend

--- a/test.disabled/ejabberd_tests/tests/mod_http_upload_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_http_upload_SUITE.erl
@@ -57,15 +57,14 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(unset_size, Config) ->
-    dynamic_modules:start(<<"localhost">>, mod_http_upload,
-                          [{max_file_size, undefined} | ?S3_OPTS]),
+    dynamic_modules:start(host(), mod_http_upload, [{max_file_size, undefined} | ?S3_OPTS]),
     escalus:create_users(Config, escalus:get_users([bob]));
 init_per_group(_, Config) ->
-    dynamic_modules:start(<<"localhost">>, mod_http_upload, ?S3_OPTS),
+    dynamic_modules:start(host(), mod_http_upload, ?S3_OPTS),
     escalus:create_users(Config, escalus:get_users([bob])).
 
 end_per_group(_, Config) ->
-    dynamic_modules:stop(<<"localhost">>, mod_http_upload),
+    dynamic_modules:stop(host(), mod_http_upload),
     escalus:delete_users(Config, escalus:get_users([bob])).
 
 init_per_testcase(CaseName, Config) ->
@@ -298,3 +297,6 @@ has_field(Var, Type, Value, Form) ->
         end,
     lists:any(fun(Item) -> VarFits(Item) andalso TypeFits(Item) andalso ValueFits(Item) end,
               Fields).
+
+host() ->
+    ct:get_config({hosts, mim, domain}).


### PR DESCRIPTION
This PR introduces `max_file_size` configuration option for mod_http_upload, and moves the upload service to its own subhost. mod_disco has also been tweaked to allow registering subhost services.