### PR TITLE
Accum stage one

### DIFF
--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -80,6 +80,15 @@
 -define(DEPRECATED,
     ok).
 %%    lager:error("Deprecated call", [])).
+%% Not to break things, we often change a function arity or pattern but keep the old one
+%% so that parts of the code not yet rewritten still work. Eventually all those things
+%% will go away. This macro denotes a function called in a deprecated way.
+
+-define(TEMPORARY, ok).
+%% just a marker - oftentimes we create a mongoose_acc just because we call a hook
+%% while the 'real' accumulator doesn't yet reach this point, so for compatibility
+%% we have to mock it. This macro is to mark such places in the code.
+
 
 -define(DUMP(Acc),
     mongoose_acc:dump(Acc)).

--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -76,3 +76,16 @@
          }).
 
 -record(external_component, {domain, handler, node}).
+
+-define(DEPRECATED,
+    ok).
+%%    lager:error("Deprecated call", [])).
+
+-define(INITIALISE(Elem),
+    mongoose_acc:initialise(Elem, ?FILE, ?LINE)).
+
+-define(TERMINATE(Acc),
+    mongoose_acc:terminate(Acc, ?FILE, ?LINE)).
+
+-define(DUMP(Acc),
+    mongoose_acc:dump(Acc)).

--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -81,11 +81,5 @@
     ok).
 %%    lager:error("Deprecated call", [])).
 
--define(INITIALISE(Elem),
-    mongoose_acc:initialise(Elem, ?FILE, ?LINE)).
-
--define(TERMINATE(Acc),
-    mongoose_acc:terminate(Acc, ?FILE, ?LINE)).
-
 -define(DUMP(Acc),
     mongoose_acc:dump(Acc)).

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -921,7 +921,7 @@ session_established(closed, StateData) ->
 -spec process_outgoing_stanza(El :: jlib:xmlel(), state()) -> fsm_return().
 process_outgoing_stanza(El, StateData) ->
     % initialise accumulator, fill with data
-    Acc = ?INITIALISE(El),
+    Acc = mongoose_acc:initialise(El, ?FILE, ?LINE),
     User = StateData#state.user,
     Server = StateData#state.server,
     FromJID = StateData#state.jid,
@@ -960,7 +960,7 @@ process_outgoing_stanza(El, StateData) ->
             process_outgoing_stanza(ToJID, Name, {Attrs, Acc, FromJID, StateData, Server, User});
         _ ->
             % unpack and proceed as before
-            NewElement = ?TERMINATE(Acc2),
+            NewElement = mongoose_acc:terminate(Acc2, ?FILE, ?LINE),
             process_outgoing_stanza(ToJID, Name, {Attrs, NewElement, FromJID, StateData, Server, User})
     end,
     ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, El}]),
@@ -989,7 +989,7 @@ process_outgoing_stanza(ToJID, <<"presence">>, Args) ->
                                    Res,
                                    [FromJID, ToJID, El]),
     ?DUMP(Res1),
-    PresenceEl = ?TERMINATE(Res1),
+    PresenceEl = mongoose_acc:terminate(Res1, ?FILE, ?LINE),
     case ToJID of
         #jid{user = User,
              server = Server,

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -961,7 +961,9 @@ process_outgoing_stanza(El, StateData) ->
         _ ->
             % unpack and proceed as before
             NewElement = mongoose_acc:terminate(Acc2, ?FILE, ?LINE),
-            process_outgoing_stanza(ToJID, Name, {Attrs, NewElement, FromJID, StateData, Server, User})
+            process_outgoing_stanza(ToJID,
+                                    Name,
+                                    {Attrs, NewElement, FromJID, StateData, Server, User})
     end,
     ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, El}]),
     fsm_next_state(session_established, NState).
@@ -988,17 +990,14 @@ process_outgoing_stanza(ToJID, <<"presence">>, Args) ->
                                    Server,
                                    Res,
                                    [FromJID, ToJID, El]),
-    ?DUMP(Res1),
-    PresenceEl = mongoose_acc:terminate(Res1, ?FILE, ?LINE),
     case ToJID of
         #jid{user = User,
              server = Server,
              resource = <<>>} ->
-             ?DEBUG("presence_update(~p, ~n\t~p, ~n\t~p)",
-                 [FromJID, PresenceEl, StateData]),
-             presence_update(FromJID, PresenceEl,
+             presence_update(FromJID, Res1,
                              StateData);
         _ ->
+             PresenceEl = mongoose_acc:terminate(Res1, ?FILE, ?LINE),
              presence_track(FromJID, ToJID, PresenceEl,
                             StateData)
     end;
@@ -1169,8 +1168,9 @@ handle_info({force_update_presence, LUser}, StateName,
                            StateData#state.pres_last,
                            [LUser, LServer]),
             StateData2 = StateData#state{pres_last = PresenceEl},
+            Acc = mongoose_acc:initialise(PresenceEl, ?FILE, ?LINE),
             presence_update(StateData2#state.jid,
-                            PresenceEl,
+                            Acc,
                             StateData2),
             StateData2;
         _ ->
@@ -1487,6 +1487,7 @@ terminate(_Reason, StateName, StateData) ->
             Packet = #xmlel{name = <<"presence">>,
                             attrs = [{<<"type">>, <<"unavailable">>}],
                             children = [StatusEl]},
+            Acc = mongoose_acc:from_element(Packet),
             ejabberd_sm:close_session_unset_presence(
               StateData#state.sid,
               StateData#state.user,
@@ -1495,9 +1496,9 @@ terminate(_Reason, StateName, StateData) ->
               <<"Replaced by new connection">>,
               replaced),
             presence_broadcast(
-              StateData, From, StateData#state.pres_a, Packet),
+              StateData, From, StateData#state.pres_a, Acc),
             presence_broadcast(
-              StateData, From, StateData#state.pres_i, Packet),
+              StateData, From, StateData#state.pres_i, Acc),
             reroute_unacked_messages(StateData);
         {_, resumed} ->
             ?INFO_MSG("(~w) Stream ~p resumed for ~s",
@@ -1524,6 +1525,7 @@ terminate(_Reason, StateName, StateData) ->
                     From = StateData#state.jid,
                     Packet = #xmlel{name = <<"presence">>,
                                     attrs = [{<<"type">>, <<"unavailable">>}]},
+                    Acc = mongoose_acc:from_element(Packet),
                     ejabberd_sm:close_session_unset_presence(
                       StateData#state.sid,
                       StateData#state.user,
@@ -1532,9 +1534,9 @@ terminate(_Reason, StateName, StateData) ->
                       <<"">>,
                       normal),
                     presence_broadcast(
-                      StateData, From, StateData#state.pres_a, Packet),
+                      StateData, From, StateData#state.pres_a, Acc),
                     presence_broadcast(
-                      StateData, From, StateData#state.pres_i, Packet)
+                      StateData, From, StateData#state.pres_i, Acc)
             end,
             reroute_unacked_messages(StateData)
     end,
@@ -1814,11 +1816,11 @@ specifically_visible_to(LFrom, #state{pres_invis = Invisible} = S) ->
 
 %% @doc User updates his presence (non-directed presence packet)
 -spec presence_update(From :: 'undefined' | ejabberd:jid(),
-                      Pkt :: jlib:xmlel(),
+                      Acc :: mongoose_acc:t(),
                       State :: state()) -> state().
-presence_update(From, Packet, StateData) ->
-    #xmlel{attrs = Attrs} = Packet,
-    case xml:get_attr_s(<<"type">>, Attrs) of
+presence_update(From, Acc, StateData) ->
+    Packet = mongoose_acc:get(element, Acc),
+    case mongoose_acc:get(type, Acc) of
         <<"unavailable">> ->
             Status = case xml:get_subtag(Packet, <<"status">>) of
                          false ->
@@ -1828,14 +1830,15 @@ presence_update(From, Packet, StateData) ->
                      end,
             Info = [{ip, StateData#state.ip}, {conn, StateData#state.conn},
                     {auth_module, StateData#state.auth_module}],
-            ejabberd_sm:unset_presence(StateData#state.sid,
-                                       StateData#state.user,
-                                       StateData#state.server,
-                                       StateData#state.resource,
-                                       Status,
-                                       Info),
-            presence_broadcast(StateData, From, StateData#state.pres_a, Packet),
-            presence_broadcast(StateData, From, StateData#state.pres_i, Packet),
+            Acc1 = ejabberd_sm:unset_presence(Acc, StateData#state.sid,
+                                              StateData#state.user,
+                                              StateData#state.server,
+                                              StateData#state.resource,
+                                              Status,
+                                              Info),
+            Acc2 = presence_broadcast(StateData, From, StateData#state.pres_a, Acc1),
+            presence_broadcast(StateData, From, StateData#state.pres_i, Acc2),
+            % and here we reach the end
             StateData#state{pres_last = undefined,
                             pres_timestamp = undefined,
                             pres_a = gb_sets:new(),
@@ -1843,21 +1846,22 @@ presence_update(From, Packet, StateData) ->
                             pres_invis = false};
         <<"invisible">> ->
             NewPriority = get_priority_from_presence(Packet),
-            update_priority(NewPriority, Packet, StateData),
+            Acc0 = update_priority(Acc, NewPriority, Packet, StateData),
             NewState =
             case StateData#state.pres_invis of
                 false ->
-                    presence_broadcast(StateData, From,
-                                       StateData#state.pres_a,
-                                       Packet),
-                    presence_broadcast(StateData, From,
-                                       StateData#state.pres_i,
-                                       Packet),
+                    Acc1 = presence_broadcast(StateData, From,
+                                              StateData#state.pres_a,
+                                              Acc0),
+                    Acc2 = presence_broadcast(StateData, From,
+                                              StateData#state.pres_i,
+                                              Acc1),
                     S1 = StateData#state{pres_last = undefined,
                                          pres_timestamp = undefined,
                                          pres_a = gb_sets:new(),
                                          pres_i = gb_sets:new(),
                                          pres_invis = true},
+                    mongoose_acc:terminate(Acc2, ?FILE, ?LINE),
                     presence_broadcast_first(From, S1, Packet);
                 true ->
                     StateData
@@ -1876,6 +1880,7 @@ presence_update(From, Packet, StateData) ->
         <<"unsubscribed">> ->
             StateData;
         _ ->
+            mongoose_acc:terminate(Acc, ?FILE, ?LINE),
             presence_update_to_available(StateData, From, Packet)
     end.
 
@@ -2018,21 +2023,26 @@ check_privacy_and_route(From, StateData, FromRoute, To, Packet) ->
             ejabberd_router:route(FromRoute, To, Packet)
     end.
 
+privacy_check_packet(StateData, From, To, Packet, Dir) ->
+    ?DEPRECATED,
+    Res = privacy_check_packet(mongoose_acc:new(), StateData, From, To, Packet, Dir),
+    mongoose_acc:get(privacy_check, Res, allow).
 
--spec privacy_check_packet(StateData :: state(),
+-spec privacy_check_packet(Acc :: mongoose_acc:t(),
+                           StateData :: state(),
                            From :: ejabberd:jid(),
                            To :: ejabberd:jid(),
                            Packet :: jlib:xmlel(),
                            Dir :: 'in' | 'out') -> any().
-privacy_check_packet(StateData, From, To, Packet, Dir) ->
-    ejabberd_hooks:run_fold(
-      privacy_check_packet, StateData#state.server,
-      allow,
-      [StateData#state.user,
-       StateData#state.server,
-       StateData#state.privacy_list,
-       {From, To, Packet},
-       Dir]).
+privacy_check_packet(Acc, StateData, From, To, Packet, Dir) ->
+    ejabberd_hooks:run_fold(privacy_check_packet,
+                            StateData#state.server,
+                            Acc,
+                            [StateData#state.user,
+                             StateData#state.server,
+                             StateData#state.privacy_list,
+                             {From, To, Packet},
+                             Dir]).
 
 
 %% @doc Check if privacy rules allow this delivery
@@ -2051,17 +2061,20 @@ is_privacy_allow(StateData, From, To, Packet, Dir) ->
 -spec presence_broadcast(State :: state(),
                          From :: 'undefined' | ejabberd:jid(),
                          JIDSet :: jid_set(),
-                         Packet :: jlib:xmlel()) -> 'ok'.
-presence_broadcast(StateData, From, JIDSet, Packet) ->
-    lists:foreach(fun(JID) ->
+                         Acc :: mongoose_acc:t()) -> mongoose_acc:t().
+presence_broadcast(StateData, From, JIDSet, Acc) ->
+    Packet = mongoose_acc:get(element, Acc),
+    lists:foldl(fun(JID, A) ->
                           FJID = jid:make(JID),
-                          case privacy_check_packet(StateData, From, FJID, Packet, out) of
+                          Res = privacy_check_packet(A, StateData, From, FJID, Packet, out),
+                          case mongoose_acc:get(privacy_check, Res, allow) of
                               allow ->
-                                  ejabberd_router:route(From, FJID, Packet);
+                                  ejabberd_router:route(From, FJID, Packet),
+                                  Res;
                               _ ->
-                                  ok
+                                  Res
                           end
-                  end, gb_sets:to_list(JIDSet)).
+                  end, Acc, gb_sets:to_list(JIDSet)).
 
 
 -spec presence_broadcast_to_trusted(State :: state(),
@@ -2171,14 +2184,19 @@ roster_change(IJID, ISubscription, StateData) ->
             end
     end.
 
-
--spec update_priority(Priority :: integer(),
-                      Packet :: jlib:xmlel(),
-                      State :: state()) -> 'ok'.
 update_priority(Priority, Packet, StateData) ->
+    ?DEPRECATED,
+    update_priority(mongoose_acc:from_element(Packet), Priority, Packet, StateData).
+
+-spec update_priority(Acc :: mongoose_acc:t(),
+                      Priority :: integer(),
+                      Packet :: jlib:xmlel(),
+                      State :: state()) -> mongoose_acc:t().
+update_priority(Acc, Priority, Packet, StateData) ->
     Info = [{ip, StateData#state.ip}, {conn, StateData#state.conn},
             {auth_module, StateData#state.auth_module}],
-    ejabberd_sm:set_presence(StateData#state.sid,
+    ejabberd_sm:set_presence(Acc,
+                             StateData#state.sid,
                              StateData#state.user,
                              StateData#state.server,
                              StateData#state.resource,

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -254,7 +254,8 @@ run_fold1([{_Seq, Module, Function} | Ls], Hook, Val, Args) ->
 hook_apply_function(_Module, Function, _Hook, Val, Args) when is_function(Function) ->
     safely:apply(Function, [Val | Args]);
 hook_apply_function(Module, Function, Hook, Val, Args) ->
-    record(Hook, Module, Function, safely:apply(Module, Function, [Val | Args])).
+    Result = safely:apply(Module, Function, [Val | Args]),
+    record(Hook, Module, Function, Result).
 
 
 record(Hook, Module, Function, Acc) ->

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -132,7 +132,8 @@ run_fold(Hook, Host, Val, Args) ->
 record(Hook, Acc) ->
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
-    case mongoose_acc:is_acc(Acc) of
+    % unless load tests show that the impact on performance is negligible
+    case mongoose_acc:is_acc(Acc) of % this check will go away some day
         true ->
             mongoose_acc:append(hooks_run, Hook, Acc);
         false ->
@@ -257,7 +258,8 @@ run_fold1([{_Seq, Module, Function} | Ls], Hook, Val, Args) ->
 record(Hook, Module, Function, Acc) ->
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
-    case mongoose_acc:is_acc(Acc) of
+    % unless load tests show that the impact on performance is negligible
+    case mongoose_acc:is_acc(Acc) of % this check will go away some day
         true ->
             mongoose_acc:append(handlers_run, {Hook, Module, Function}, Acc);
         false ->

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -164,15 +164,17 @@ process_sm_iq(From, To,
                 UserListRecord =
                     ejabberd_hooks:run_fold(privacy_get_user_list, Server,
                         #userlist{}, [User, Server]),
-                case ejabberd_hooks:run_fold(privacy_check_packet,
-                    Server, allow,
-                    [User, Server, UserListRecord,
-                        {To, From,
-                            #xmlel{name = <<"presence">>,
-                                attrs = [],
-                                children = []}},
-                        out])
-                of
+                ?TEMPORARY,
+                Acc = mongoose_acc:new(),
+                Res = ejabberd_hooks:run_fold(privacy_check_packet,
+                                              Server, Acc,
+                                              [User, Server, UserListRecord,
+                                               {To, From,
+                                               #xmlel{name = <<"presence">>,
+                                                      attrs = [],
+                                                      children = []}},
+                                               out]),
+                case mongoose_acc:get(privacy_check, Res, allow) of
                     allow -> get_last_iq(IQ, SubEl, User, Server);
                     deny ->
                         IQ#iq{type = error, sub_el = [SubEl, ?ERR_FORBIDDEN]}

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -134,7 +134,7 @@ get_node_uptime() ->
     case ejabberd_config:get_local_option(node_start) of
         {_, _, _} = StartNow ->
             now_to_seconds(now()) - now_to_seconds(StartNow);
-        _undefined ->
+        _Undefined ->
             trunc(element(1, erlang:statistics(wall_clock))/1000)
     end.
 
@@ -158,35 +158,35 @@ process_sm_iq(From, To,
             {Subscription, _Groups} =
                 ejabberd_hooks:run_fold(roster_get_jid_info, Server,
                     {none, []}, [User, Server, From]),
-            if (Subscription == both) or (Subscription == from) or
-                (From#jid.luser == To#jid.luser) and
-                    (From#jid.lserver == To#jid.lserver) ->
-                UserListRecord =
-                    ejabberd_hooks:run_fold(privacy_get_user_list, Server,
-                        #userlist{}, [User, Server]),
-                ?TEMPORARY,
-                Acc = mongoose_acc:new(),
-                Res = ejabberd_hooks:run_fold(privacy_check_packet,
-                                              Server, Acc,
-                                              [User, Server, UserListRecord,
-                                               {To, From,
-                                               #xmlel{name = <<"presence">>,
-                                                      attrs = [],
-                                                      children = []}},
-                                               out]),
-                case mongoose_acc:get(privacy_check, Res, allow) of
-                    allow -> get_last_iq(IQ, SubEl, User, Server);
-                    deny ->
+                case (Subscription == both) or (Subscription == from) or
+                     (From#jid.luser == To#jid.luser) and
+                     (From#jid.lserver == To#jid.lserver) of
+                    true ->
+                        UserListRecord =
+                        ejabberd_hooks:run_fold(privacy_get_user_list, Server,
+                                                #userlist{}, [User, Server]),
+                        ?TEMPORARY,
+                        Acc = mongoose_acc:new(),
+                        Res = ejabberd_hooks:run_fold(privacy_check_packet,
+                                                      Server, Acc,
+                                                      [User, Server, UserListRecord,
+                                                       {To, From,
+                                                        #xmlel{name = <<"presence">>,
+                                                               attrs = [],
+                                                               children = []}},
+                                                       out]),
+                        make_response(IQ, SubEl, User, Server,
+                                      mongoose_acc:get(privacy_check, Res, allow));
+                    false ->
                         IQ#iq{type = error, sub_el = [SubEl, ?ERR_FORBIDDEN]}
-                end;
-                true ->
-                    IQ#iq{type = error, sub_el = [SubEl, ?ERR_FORBIDDEN]}
-            end
+                end
     end.
 
--spec get_last_iq(ejabberd:iq(), SubEl :: 'undefined' | [jlib:xmlel()],
-                  ejabberd:luser(), ejabberd:lserver()) -> ejabberd:iq().
-get_last_iq(IQ, SubEl, LUser, LServer) ->
+-spec make_response(ejabberd:iq(), SubEl :: 'undefined' | [jlib:xmlel()],
+                    ejabberd:luser(), ejabberd:lserver(), allow | deny) -> ejabberd:iq().
+make_response(IQ, SubEl, _, _, deny) ->
+    IQ#iq{type = error, sub_el = [SubEl, ?ERR_FORBIDDEN]};
+make_response(IQ, SubEl, LUser, LServer, allow) ->
     case ejabberd_sm:get_user_resources(LUser, LServer) of
         [] ->
             case get_last(LUser, LServer) of

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -312,11 +312,11 @@ get_user_list(_, User, Server) ->
 %% From is the sender, To is the destination.
 %% If Dir = out, User@Server is the sender account (From).
 %% If Dir = in, User@Server is the destination account (To).
-check_packet(_, User, Server,
+check_packet(Acc, User, Server,
          #userlist{list = List, needdb = NeedDb},
          {From, To, Packet},
          Dir) ->
-    case List of
+    CheckResult = case List of
         [] ->
             allow;
         _ ->
@@ -335,7 +335,8 @@ check_packet(_, User, Server,
             end,
             Type = xml:get_attr_s(<<"type">>, Packet#xmlel.attrs),
             check_packet_aux(List, PType, Type, LJID, Subscription, Groups)
-    end.
+    end,
+    mongoose_acc:put(privacy_check, CheckResult, Acc).
 
 %% allow error messages
 check_packet_aux(_, message, <<"error">>, _JID, _Subscription, _Groups) ->

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -32,12 +32,12 @@
 %%% the code which is executed between them is rewritten. We will proceed by moving
 %%% both points further apart until they reach their respective ends of processing chain.
 
-initialise(El, F, L) ->
-    ?ERROR_MSG("AAA initialise accumulator ~p ~p", [F, L]),
+initialise(El, _F, _L) ->
+%%    ?ERROR_MSG("AAA initialise accumulator ~p ~p", [F, L]),
     from_element(El).
 
-terminate(M, F, L) ->
-    ?ERROR_MSG("ZZZ terminate accumulator ~p ~p", [F, L]),
+terminate(M, _F, _L) ->
+%%    ?ERROR_MSG("ZZZ terminate accumulator ~p ~p", [F, L]),
     get(element, M).
 
 dump(Acc) ->

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -20,7 +20,17 @@
 %% if it is defined as -opaque then dialyzer fails
 -type t() :: map().
 
+%%% This module encapsulates implementation of mongoose_acc
+%%% its interface is map-like but implementation might change
+%%% it is passed along many times, and relatively rarely read or written to
+%%% might be worth reimplementing as binary
+
 %%%%% devel API %%%%%
+
+%%% Eventually, we'll call initialise when a stanza enters MongooseIM and terminate
+%%% when it leaves. During development we can call both in arbitrary places, provided that
+%%% the code which is executed between them is rewritten. We will proceed by moving
+%%% both points further apart until they reach their respective ends of processing chain.
 
 initialise(El, F, L) ->
     ?ERROR_MSG("AAA initialise accumulator ~p ~p", [F, L]),
@@ -30,16 +40,17 @@ terminate(M, F, L) ->
     ?ERROR_MSG("ZZZ terminate accumulator ~p ~p", [F, L]),
     get(element, M).
 
-
 dump(Acc) ->
     dump(Acc, lists:sort(maps:keys(Acc))).
 
-%%%%% API %%%%%
-
+%% This function is for transitional period, eventually all hooks will use accumulator
+%% and we will not have to check
 is_acc(A) when is_map(A) ->
     maps:get(mongoose_acc, A, false);
 is_acc(_) ->
     false.
+
+%%%%% API %%%%%
 
 -spec new() -> t().
 new() ->

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -1,0 +1,112 @@
+%%%-------------------------------------------------------------------
+%%%
+%%% This module encapsulates a data type which will initially be passed to
+%%% hookhandlers as accumulator, and later will be passed all the way along
+%%% processing chain.
+%%%
+%%%-------------------------------------------------------------------
+-module(mongoose_acc).
+-author("bartek").
+
+-include("jlib.hrl").
+-include("ejabberd.hrl").
+
+%% API
+-export([new/0, from_kv/2, put/3, get/2, get/3, append/3, to_map/1]).
+-export([from_element/1, from_map/1, update/2, is_acc/1]).
+-export([initialise/3, terminate/3, dump/1]).
+-export_type([t/0]).
+
+%% if it is defined as -opaque then dialyzer fails
+-type t() :: map().
+
+%%%%% devel API %%%%%
+
+initialise(El, F, L) ->
+    ?ERROR_MSG("AAA initialise accumulator ~p ~p", [F, L]),
+    from_element(El).
+
+terminate(M, F, L) ->
+    ?ERROR_MSG("ZZZ terminate accumulator ~p ~p", [F, L]),
+    get(element, M).
+
+
+dump(Acc) ->
+    dump(Acc, lists:sort(maps:keys(Acc))).
+
+%%%%% API %%%%%
+
+is_acc(A) when is_map(A) ->
+    maps:get(mongoose_acc, A, false);
+is_acc(_) ->
+    false.
+
+-spec new() -> t().
+new() ->
+    #{mongoose_acc => true}.
+
+-spec from_kv(atom(), any()) -> t().
+from_kv(K, V) ->
+    M = maps:put(K, V, #{}),
+    maps:put(mongoose_acc, true, M).
+
+-spec from_element(xmlel()) -> t().
+from_element(El) ->
+    #xmlel{name = Name, attrs = Attrs} = El,
+    Type = xml:get_attr_s(<<"type">>, Attrs),
+    #{element => El, mongoose_acc => true, name => Name, attrs => Attrs, type => Type}.
+
+-spec from_map(map()) -> t().
+from_map(M) ->
+    maps:put(mongoose_acc, true, M).
+
+-spec update(t(), map() | t()) -> t().
+update(Acc, M) ->
+    maps:merge(Acc, M).
+
+%% @doc convert to map so that we can pattern-match on it
+-spec to_map(t()) -> map()|{error, cant_convert_to_map}.
+to_map(P) when is_map(P) ->
+    P;
+to_map(_) ->
+    {error, cant_convert_to_map}.
+
+-spec put(atom(), any(), t()) -> t().
+put(Key, Val, P) ->
+    maps:put(Key, Val, P).
+
+-spec get(atom()|[atom()], t()) -> any().
+get([], _) ->
+    undefined;
+get([Key|Keys], P) ->
+    case maps:is_key(Key, P) of
+        true ->
+            maps:get(Key, P);
+        _ ->
+            get(Keys, P)
+    end;
+get(Key, P) ->
+    maps:get(Key, P).
+
+-spec get(atom(), t(), any()) -> any().
+get(Key, P, Default) ->
+    maps:get(Key, P, Default).
+
+-spec append(atom(), any(), t()) -> t().
+append(Key, Val, P) ->
+    L = get(Key, P, []),
+    maps:put(Key, append(Val, L), P).
+
+
+%%%%% internal %%%%%
+
+append(Val, L) when is_list(L), is_list(Val) ->
+    L ++ Val;
+append(Val, L) when is_list(L) ->
+    [Val | L].
+
+dump(_, []) ->
+    ok;
+dump(Acc, [K|Tail]) ->
+    ?ERROR_MSG("~p = ~p", [K, maps:get(K, Acc)]),
+    dump(Acc, Tail).

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -234,13 +234,13 @@ privacy_list_push(Acc, _From, #jid{server = Server} = _To, _Broadcast, SessionCo
 user_ping_timeout(Acc, _JID) ->
     Acc.
 
--spec privacy_check_packet(Acc :: allow | deny | block,
+-spec privacy_check_packet(Acc :: mongoose_acc:t(),
                           binary(),
                           Server :: ejabberd:server(),
-                          term(), term(), term()) -> allow | deny | block.
+                          term(), term(), term()) -> mongoose_acc:t().
 privacy_check_packet(Acc, _, Server, _, _, _) ->
     mongoose_metrics:update(Server, modPrivacyStanzaAll, 1),
-    case Acc of
+    case mongoose_acc:get(privacy_check, Acc) of
         deny ->
             mongoose_metrics:update(Server, modPrivacyStanzaDenied, 1);
         block ->

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -240,7 +240,7 @@ user_ping_timeout(Acc, _JID) ->
                           term(), term(), term()) -> mongoose_acc:t().
 privacy_check_packet(Acc, _, Server, _, _, _) ->
     mongoose_metrics:update(Server, modPrivacyStanzaAll, 1),
-    case mongoose_acc:get(privacy_check, Acc) of
+    case mongoose_acc:get(privacy_check, Acc, allow) of
         deny ->
             mongoose_metrics:update(Server, modPrivacyStanzaDenied, 1);
         block ->


### PR DESCRIPTION
This is a rewrite of a very small part of the whole processing chain - early stages of processing outgoing presence. The idea is to eventually create a mongoose_acc:t() from xmlel when a stanza enters the system, pass it along and terminate when it is about to leave. We start with a very small part, then we'll move initialisation and termination points further apart, untill they reach both ends.

Being an intermediate PR, it contains lots of utilities, comments, commented-out code which will eventually go away. Also, in `ejabberd_hooks` there are some useful things which show cool things we can do - those may stay or go, it depends.

