### PR TITLE
Feature/xep 357 push notifications

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -74,6 +74,7 @@
 -define(NS_PUBSUB_PUB_OPTIONS,  <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(NS_PUBSUB_SUB_AUTH,<<"http://jabber.org/protocol/pubsub#subscribe_authorization">>).
 -define(NS_PUBSUB_GET_PENDING, <<"http://jabber.org/protocol/pubsub#get-pending">>).
+-define(NS_PUBSUB_PUB_OPTIONS, <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(NS_COMMANDS,    <<"http://jabber.org/protocol/commands">>).
 -define(NS_BYTESTREAMS, <<"http://jabber.org/protocol/bytestreams">>).
 -define(NS_ADMIN,       <<"http://jabber.org/protocol/admin">>).

--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -71,10 +71,9 @@
 -define(NS_PUBSUB_ERRORS, <<"http://jabber.org/protocol/pubsub#errors">>).
 -define(NS_PUBSUB_NODE_CONFIG,<<"http://jabber.org/protocol/pubsub#node_config">>).
 -define(NS_PUBSUB_SUB_OPTIONS,<<"http://jabber.org/protocol/pubsub#subscribe_options">>).
--define(NS_PUBSUB_PUB_OPTIONS,  <<"http://jabber.org/protocol/pubsub#publish-options">>).
+-define(NS_PUBSUB_PUB_OPTIONS, <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(NS_PUBSUB_SUB_AUTH,<<"http://jabber.org/protocol/pubsub#subscribe_authorization">>).
 -define(NS_PUBSUB_GET_PENDING, <<"http://jabber.org/protocol/pubsub#get-pending">>).
--define(NS_PUBSUB_PUB_OPTIONS, <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(NS_COMMANDS,    <<"http://jabber.org/protocol/commands">>).
 -define(NS_BYTESTREAMS, <<"http://jabber.org/protocol/bytestreams">>).
 -define(NS_ADMIN,       <<"http://jabber.org/protocol/admin">>).

--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -83,7 +83,7 @@
 -define(NS_MAM_04,      <<"urn:xmpp:mam:1">>). % MAM 0.4.1 or 0.5
 -define(NS_HTTP_UPLOAD_025, <<"urn:xmpp:http:upload">>).
 -define(NS_HTTP_UPLOAD_030, <<"urn:xmpp:http:upload:0">>).
--define(NS_PUSH,        <<"urn:xmpp:push:0">>).
+-define(NS_PUSH,        <<"urn:xmpp:push:0">>). % Push Notifications v0.2.1
 
 -define(NS_RSM,         <<"http://jabber.org/protocol/rsm">>).
 -define(NS_EJABBERD_CONFIG,<<"ejabberd:config">>).

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -130,7 +130,8 @@ start_link() ->
 route(From, To, Packet) ->
     case (catch do_route(From, To, Packet)) of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
+            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, "
+                       "packet=~ts, stack_trace=~p",
                        [jid:to_binary(From), jid:to_binary(To),
                         ?MODULE, Reason, exml:to_binary(Packet),
                         erlang:get_stacktrace()]);

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -103,7 +103,7 @@
               ses_tuple/0,
               backend/0,
               close_reason/0
-            ]).
+             ]).
 
 %% default value for the maximum number of user connections
 -define(MAX_USER_SESSIONS, 100).
@@ -131,9 +131,9 @@ route(From, To, Packet) ->
     case (catch do_route(From, To, Packet)) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p, reason=~p, packet=~ts, stack_trace=~p",
-                [jid:to_binary(From), jid:to_binary(To),
-                    ?MODULE, Reason, exml:to_binary(Packet),
-                    erlang:get_stacktrace()]);
+                       [jid:to_binary(From), jid:to_binary(To),
+                        ?MODULE, Reason, exml:to_binary(Packet),
+                        erlang:get_stacktrace()]);
         _ -> ok
     end.
 
@@ -162,11 +162,11 @@ open_session(SID, User, Server, Resource, Priority, Info) ->
     ok.
 
 -spec close_session(SID, User, Server, Resource, Reason) -> ok when
-    SID :: 'undefined' | sid(),
-    User :: ejabberd:user(),
-    Server :: ejabberd:server(),
-    Resource :: ejabberd:resource(),
-    Reason :: close_reason().
+      SID :: 'undefined' | sid(),
+      User :: ejabberd:user(),
+      Server :: ejabberd:server(),
+      Resource :: ejabberd:resource(),
+      Reason :: close_reason().
 close_session(SID, User, Server, Resource, Reason) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
@@ -607,10 +607,10 @@ do_route(From, To, Packet) ->
       Reason :: any().
 do_route_no_resource_presence_prv(From, To, Packet, Type, Reason) ->
     is_privacy_allow(From, To, Packet) andalso ejabberd_hooks:run_fold(
-        roster_in_subscription,
-        To#jid.lserver,
-        false,
-        [To#jid.user, To#jid.server, From, Type, Reason]).
+                                                 roster_in_subscription,
+                                                 To#jid.lserver,
+                                                 false,
+                                                 [To#jid.user, To#jid.server, From, Type, Reason]).
 
 
 -spec do_route_no_resource_presence(Type, From, To, Packet) -> boolean() when
@@ -619,16 +619,16 @@ do_route_no_resource_presence_prv(From, To, Packet, Type, Reason) ->
       To :: ejabberd:jid(),
       Packet :: jlib:xmlel().
 do_route_no_resource_presence(<<"subscribe">>, From, To, Packet) ->
-        Reason = xml:get_path_s(Packet, [{elem, <<"status">>}, cdata]),
-        do_route_no_resource_presence_prv(From, To, Packet, subscribe, Reason);
+    Reason = xml:get_path_s(Packet, [{elem, <<"status">>}, cdata]),
+    do_route_no_resource_presence_prv(From, To, Packet, subscribe, Reason);
 do_route_no_resource_presence(<<"subscribed">>, From, To, Packet) ->
-        do_route_no_resource_presence_prv(From, To, Packet, subscribed, <<>>);
+    do_route_no_resource_presence_prv(From, To, Packet, subscribed, <<>>);
 do_route_no_resource_presence(<<"unsubscribe">>, From, To, Packet) ->
-        do_route_no_resource_presence_prv(From, To, Packet, unsubscribe, <<>>);
+    do_route_no_resource_presence_prv(From, To, Packet, unsubscribe, <<>>);
 do_route_no_resource_presence(<<"unsubscribed">>, From, To, Packet) ->
-        do_route_no_resource_presence_prv(From, To, Packet, unsubscribed, <<>>);
+    do_route_no_resource_presence_prv(From, To, Packet, unsubscribed, <<>>);
 do_route_no_resource_presence(_, _, _, _) ->
-        true.
+    true.
 
 
 -spec do_route_no_resource(Name, Type, From, To, Packet) -> Result when
@@ -639,26 +639,26 @@ do_route_no_resource_presence(_, _, _, _) ->
       Packet :: jlib:xmlel(),
       Result ::ok | stop | todo | pid() | {error, lager_not_running} | {process_iq, _, _, _}.
 do_route_no_resource(<<"presence">>, Type, From, To, Packet) ->
-        case do_route_no_resource_presence(Type, From, To, Packet) of
-            true ->
+    case do_route_no_resource_presence(Type, From, To, Packet) of
+        true ->
             PResources = get_user_present_resources(To#jid.luser, To#jid.lserver),
-                    lists:foreach(
-                      fun({_, R}) ->
-      do_route(From, jid:replace_resource(To, R), Packet)
+            lists:foreach(
+              fun({_, R}) ->
+                      do_route(From, jid:replace_resource(To, R), Packet)
               end, PResources);
-            false ->
-                ok
-        end;
+        false ->
+            ok
+    end;
 do_route_no_resource(<<"message">>, _, From, To, Packet) ->
-        route_message(From, To, Packet);
+    route_message(From, To, Packet);
 do_route_no_resource(<<"iq">>, _, From, To, Packet) ->
-        process_iq(From, To, Packet);
+    process_iq(From, To, Packet);
 do_route_no_resource(<<"broadcast">>, _, From, To, Packet) ->
-    % Backward compatibility
+                                                % Backward compatibility
     ejabberd_hooks:run(sm_broadcast, To#jid.lserver, [From, To, Packet]),
     broadcast_packet(From, To, Packet);
 do_route_no_resource(_, _, _, _, _) ->
-        ok.
+    ok.
 
 -spec do_route_offline(Name, Type, From, To, Packet) -> ok | stop when
       Name :: 'undefined' | binary(),
@@ -668,7 +668,7 @@ do_route_no_resource(_, _, _, _, _) ->
       Packet :: jlib:xmlel().
 do_route_offline(<<"message">>, _, From, To, Packet)  ->
     Drop = ejabberd_hooks:run_fold(sm_filter_offline_message, To#jid.lserver,
-                   false, [From, To, Packet]),
+                                   false, [From, To, Packet]),
     case Drop of
         false ->
             route_message(From, To, Packet);
@@ -677,17 +677,17 @@ do_route_offline(<<"message">>, _, From, To, Packet)  ->
             ok
     end;
 do_route_offline(<<"iq">>, <<"error">>, _From, _To, _Packet) ->
-        ok;
+    ok;
 do_route_offline(<<"iq">>, <<"result">>, _From, _To, _Packet) ->
-        ok;
+    ok;
 do_route_offline(<<"iq">>, _, From, To, Packet) ->
-        Err = jlib:make_error_reply(Packet, ?ERR_SERVICE_UNAVAILABLE),
-        ejabberd_router:route(To, From, Err);
+    Err = jlib:make_error_reply(Packet, ?ERR_SERVICE_UNAVAILABLE),
+    ejabberd_router:route(To, From, Err);
 do_route_offline(_, _, _, _, _) ->
-        ?DEBUG("packet droped~n", []),
-        ok.
+    ?DEBUG("packet droped~n", []),
+    ok.
 
-% Backward compatibility
+                                                % Backward compatibility
 -spec broadcast_packet(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) -> ok.
 broadcast_packet(From, To, Packet) ->
     #jid{user = User, server = Server} = To,
@@ -745,7 +745,7 @@ route_message(From, To, Packet) ->
               %% Route messages to all priority that equals the max, if
               %% positive
               fun({Prio, Pid}) when Prio == Priority ->
-                      % we will lose message if PID is not alive
+                                                % we will lose message if PID is not alive
                       Pid ! {route, From, To, Packet};
                  %% Ignore other priority:
                  ({_Prio, _Pid}) ->
@@ -820,7 +820,7 @@ get_user_present_pids(LUser, LServer) ->
 
 -spec get_user_present_resources(LUser :: ejabberd:user(),
                                  LServer :: ejabberd:server()
-                                 ) -> [{priority(), binary()}].
+                                ) -> [{priority(), binary()}].
 get_user_present_resources(LUser, LServer) ->
     Ss = ?SM_BACKEND:get_sessions(LUser, LServer),
     [{S#session.priority, element(3, S#session.usr)} ||
@@ -945,7 +945,7 @@ force_update_presence({LUser, LServer}) ->
 
 -spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
-        [
+    [
      %% TODO: Implement following API functions with pluggable backends architcture
      %% #ejabberd_commands{name = connected_users,
      %%                    tags = [session],
@@ -965,7 +965,7 @@ commands() ->
                         module = ?MODULE, function = user_resources,
                         args = [{user, string}, {host, string}],
                         result = {resources, {list, {resource, binary}}}}
-        ].
+    ].
 
 
 -spec user_resources(UserStr :: string(), ServerStr :: string()) -> [binary()].
@@ -977,19 +977,19 @@ user_resources(UserStr, ServerStr) ->
 sm_backend(Backend) ->
     lists:flatten(
       ["-module(ejabberd_sm_backend).
-        -export([backend/0]).
+-export([backend/0]).
 
-        -spec backend() -> atom().
-        backend() ->
-            ejabberd_sm_",
-       atom_to_list(Backend),
-       ".\n"]).
+-spec backend() -> atom().
+backend() ->
+    ejabberd_sm_",
+atom_to_list(Backend),
+    ".\n"]).
 
 -spec get_cached_unique_count() -> non_neg_integer().
 get_cached_unique_count() ->
-    case mongoose_metrics:get_metric_value(global, ?UNIQUE_COUNT_CACHE) of
-        {ok, DataPoints} ->
-            proplists:get_value(value, DataPoints);
-        _ ->
-            0
-    end.
+case mongoose_metrics:get_metric_value(global, ?UNIQUE_COUNT_CACHE) of
+{ok, DataPoints} ->
+proplists:get_value(value, DataPoints);
+_ ->
+0
+end.

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -608,10 +608,10 @@ do_route(From, To, Packet) ->
       Reason :: any().
 do_route_no_resource_presence_prv(From, To, Packet, Type, Reason) ->
     is_privacy_allow(From, To, Packet) andalso ejabberd_hooks:run_fold(
-                                                 roster_in_subscription,
-                                                 To#jid.lserver,
-                                                 false,
-                                                 [To#jid.user, To#jid.server, From, Type, Reason]).
+        roster_in_subscription,
+        To#jid.lserver,
+        false,
+        [To#jid.user, To#jid.server, From, Type, Reason]).
 
 
 -spec do_route_no_resource_presence(Type, From, To, Packet) -> boolean() when
@@ -655,7 +655,7 @@ do_route_no_resource(<<"message">>, _, From, To, Packet) ->
 do_route_no_resource(<<"iq">>, _, From, To, Packet) ->
     process_iq(From, To, Packet);
 do_route_no_resource(<<"broadcast">>, _, From, To, Packet) ->
-                                                % Backward compatibility
+    %% Backward compatibility
     ejabberd_hooks:run(sm_broadcast, To#jid.lserver, [From, To, Packet]),
     broadcast_packet(From, To, Packet);
 do_route_no_resource(_, _, _, _, _) ->
@@ -669,7 +669,7 @@ do_route_no_resource(_, _, _, _, _) ->
       Packet :: jlib:xmlel().
 do_route_offline(<<"message">>, _, From, To, Packet)  ->
     Drop = ejabberd_hooks:run_fold(sm_filter_offline_message, To#jid.lserver,
-                                   false, [From, To, Packet]),
+                   false, [From, To, Packet]),
     case Drop of
         false ->
             route_message(From, To, Packet);
@@ -688,7 +688,7 @@ do_route_offline(_, _, _, _, _) ->
     ?DEBUG("packet droped~n", []),
     ok.
 
-                                                % Backward compatibility
+%% Backward compatibility
 -spec broadcast_packet(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) -> ok.
 broadcast_packet(From, To, Packet) ->
     #jid{user = User, server = Server} = To,
@@ -746,7 +746,7 @@ route_message(From, To, Packet) ->
               %% Route messages to all priority that equals the max, if
               %% positive
               fun({Prio, Pid}) when Prio == Priority ->
-                                                % we will lose message if PID is not alive
+                 %% we will lose message if PID is not alive
                       Pid ! {route, From, To, Packet};
                  %% Ignore other priority:
                  ({_Prio, _Pid}) ->
@@ -946,7 +946,7 @@ force_update_presence({LUser, LServer}) ->
 
 -spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
-    [
+        [
      %% TODO: Implement following API functions with pluggable backends architcture
      %% #ejabberd_commands{name = connected_users,
      %%                    tags = [session],
@@ -966,7 +966,7 @@ commands() ->
                         module = ?MODULE, function = user_resources,
                         args = [{user, string}, {host, string}],
                         result = {resources, {list, {resource, binary}}}}
-    ].
+        ].
 
 
 -spec user_resources(UserStr :: string(), ServerStr :: string()) -> [binary()].
@@ -978,19 +978,19 @@ user_resources(UserStr, ServerStr) ->
 sm_backend(Backend) ->
     lists:flatten(
       ["-module(ejabberd_sm_backend).
--export([backend/0]).
+        -export([backend/0]).
 
--spec backend() -> atom().
-backend() ->
-    ejabberd_sm_",
-atom_to_list(Backend),
-    ".\n"]).
+        -spec backend() -> atom().
+        backend() ->
+            ejabberd_sm_",
+       atom_to_list(Backend),
+       ".\n"]).
 
 -spec get_cached_unique_count() -> non_neg_integer().
 get_cached_unique_count() ->
-case mongoose_metrics:get_metric_value(global, ?UNIQUE_COUNT_CACHE) of
-{ok, DataPoints} ->
-proplists:get_value(value, DataPoints);
-_ ->
-0
-end.
+    case mongoose_metrics:get_metric_value(global, ?UNIQUE_COUNT_CACHE) of
+        {ok, DataPoints} ->
+            proplists:get_value(value, DataPoints);
+        _ ->
+            0
+    end.

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -56,7 +56,8 @@
          get_session/3,
          get_session_ip/3,
          get_user_present_resources/2,
-         get_raw_sessions/2
+         get_raw_sessions/2,
+         get_user_present_pids/2
         ]).
 
 %% Hook handlers

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -1,0 +1,111 @@
+%%%-------------------------------------------------------------------
+%%% @author Rafal Slota
+%%% @copyright (C) 2017 Erlang Solutions Ltd.
+%%% This software is released under the Apache License, Version 2.0
+%%% cited in 'LICENSE.txt'.
+%%% @end
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% @todo: write me!
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mod_push).
+-author("Rafal Slota").
+-behavior(gen_mod).
+-xep([{xep, 357}, {version, "0.2.1"}]).
+
+-include_lib("ejabberd/include/ejabberd.hrl").
+-include_lib("ejabberd/include/jlib.hrl").
+
+%% gen_mod handlers
+-export([start/2, stop/1]).
+
+%% Hooks and IQ handlers
+-export([handle_offline_message/3, iq_handler/3]).
+
+-callback init(Host :: ejabberd:server(), Opts :: list()) -> ok.
+-callback enable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(),
+                 Node :: binary(), Forms :: any()) -> ok.
+-callback disable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(), Node :: binary()) -> ok.
+-callback get_publish_services(User :: ejabberd:jid()) ->
+    [{PubSub :: ejabberd:jid(), Node :: binary()}].
+
+
+-spec start(Host :: ejabberd:server(), Opts :: list()) -> any().
+start(Host, Opts) ->
+    ?DEBUG("mod_push starting on host ~p", [Host]),
+
+    gen_mod:start_backend_module(?MODULE, Opts, []),
+
+    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
+    mod_disco:register_feature(Host, ?NS_PUSH),
+    gen_iq_handler:add_iq_handler(ejabberd_local, Host, ?NS_PUSH, ?MODULE,
+                                  iq_handler, IQDisc),
+
+    ejabberd_hooks:add(offline_groupchat_message_hook, Host, ?MODULE, handle_offline_message, 1),
+    ejabberd_hooks:add(offline_message_hook, Host, ?MODULE, handle_offline_message, 1),
+
+    ok.
+
+stop(Host) ->
+
+    ejabberd_hooks:delete(offline_message_hook, Host, ?MODULE, handle_offline_message, 1),
+    ejabberd_hooks:delete(offline_groupchat_message_hook, Host, ?MODULE, handle_offline_message, 1),
+
+    ok.
+
+
+-spec handle_offline_message(From :: ejabberd:jid(),
+                             To :: ejabberd:jid(),
+                             Packet :: jlib:xmlel()) -> ok.
+handle_offline_message(From, To, Packet) ->
+
+
+
+
+    ok.
+
+-spec iq_handler(From :: ejabberd:jid(), To :: ejabberd:jid(), IQ :: ejabberd:iq()) ->
+    ejabberd:iq() | ignore.
+iq_handler(_From, _To, IQ = #iq{type = get, sub_el = SubEl}) ->
+    IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
+iq_handler(_From, _To, IQ = #iq{type = set, sub_el = Request}) ->
+    case parse_request(Request) of
+        {enable, BareJID, Node, Form} ->
+
+
+            IQ#iq{type = result, sub_el = []};
+        {disable, BareJID, Node} ->
+            IQ#iq{type = result, sub_el = []};
+        bad_request ->
+            IQ#iq{type = error, sub_el = [Request, ?ERR_BAD_REQUEST]}
+    end.
+
+
+-spec parse_request(Request :: exml:element()) ->
+    bad_request.
+parse_request(#xmlel{name = <<"enable">>} = Request) ->
+    JID = jid:from_binary(exml_query:attr(Request, <<"jid">>, <<>>)),
+    Node = exml_query:attr(Request, <<"node">>, <<>>), %% Treat unset node as empty - both forbidden
+    Form = exml_query:subelement(Request, <<"x">>),
+
+    case {JID, Node} of
+        {_, <<>>}               -> bad_request;
+        {#jid{luser = <<>>}}    -> bad_request;
+        {#jid{lserver = <<>>}}  -> bad_request;
+        {JID, Node} ->
+            {enable, JID, Node, Form}
+    end;
+parse_request(#xmlel{name = <<"disable">>} = Request) ->
+    JID = jid:from_binary(exml_query:attr(Request, <<"jid">>, <<>>)),
+    Node = exml_query:attr(Request, <<"node">>, undefined),
+
+    case {jid:to_bare(JID), Node} of
+        {_, <<>>}               -> bad_request; %% Node may not be set, but shouldn't be empty
+        {#jid{luser = <<>>}}    -> bad_request;
+        {#jid{lserver = <<>>}}  -> bad_request;
+        {BareJID, Node} ->
+            {disable, BareJID, Node}
+    end;
+parse_request(_) ->
+    bad_request.

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -196,7 +196,6 @@ parse_request(#xmlel{name = <<"enable">>} = Request) ->
         {_, _, invalid_form}            -> bad_request;
         {_, <<>>, _}                    -> bad_request;
         {error, _, _}                   -> bad_request;
-        {#jid{luser = <<>>}, _, _}      -> bad_request;
         {#jid{lserver = <<>>}, _, _}    -> bad_request;
         {JID, Node, FormFields} ->
             {enable, jid:to_bare(JID), Node, FormFields}

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -108,13 +108,13 @@ remove_user(LUser, LServer) ->
 -spec filter_packet(Value :: fpacket() | drop) -> fpacket() | drop.
 filter_packet(drop) ->
     drop;
-filter_packet({From, To, Packet}) ->
+filter_packet({From = #jid{lserver = Host}, To, Packet}) ->
     ?DEBUG("Receive packet~n    from ~p ~n    to ~p~n    packet ~p.",
            [From, To, Packet]),
     PacketType = exml_query:attr(Packet, <<"type">>),
     case lists:member(PacketType, [<<"chat">>, <<"groupchat">>]) of
         true ->
-            case catch mod_push_plugin:should_publish(From, To, Packet) of
+            case mod_push_plugin:should_publish(Host, From, To, Packet) of
                 true ->
                     publish_message(From, To, Packet);
                 false ->

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -221,10 +221,11 @@ parse_form(undefined) ->
     [];
 parse_form(Form) ->
     IsForm = ?NS_XDATA == exml_query:attr(Form, <<"xmlns">>),
-    IsSubmit = <<"submit">> == exml_query:attr(Form, <<"type">>),
+    IsSubmit = <<"submit">> == exml_query:attr(Form, <<"type">>, <<"submit">>),
 
     FieldsXML = exml_query:subelements(Form, <<"field">>),
-    Fields = [{exml_query:attr(Field, <<"var">>), exml_query:cdata(Field)} || Field <- FieldsXML],
+    Fields = [{exml_query:attr(Field, <<"var">>),
+               exml_query:path(Field, [{element, <<"value">>}, cdata])} || Field <- FieldsXML],
     {[{_, FormType}], CustomFields} = lists:partition(
                                         fun({Name, _}) ->
                                                 Name == <<"FORM_TYPE">>
@@ -278,7 +279,7 @@ make_form(Fields) ->
 make_form_field({Name, Value}) ->
     #xmlel{name = <<"field">>,
            attrs = [{<<"var">>, Name}],
-           children = [#xmlcdata{content = Value}]}.
+           children = [#xmlel{name = <<"value">>, children = [#xmlcdata{content = Value}]}]}.
 
 -spec cast(F :: atom(), A :: [any()]) -> any().
 cast(F, A) ->

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -28,18 +28,23 @@
                  Node :: binary(), Forms :: any()) -> ok.
 -callback disable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(), Node :: binary()) -> ok.
 -callback get_publish_services(User :: ejabberd:jid()) ->
-    [{PubSub :: ejabberd:jid(), Node :: binary()}].
+    [{PubSub :: ejabberd:jid(), Node :: binary(), Form :: any()}].
+
+-define(PUSH_FORM_TYPE, <<"urn:xmpp:push:summary">>).
 
 
 -spec start(Host :: ejabberd:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
-    ?DEBUG("mod_push starting on host ~p", [Host]),
+    ?INFO_MSG("mod_push starting on host ~p", [Host]),
 
     gen_mod:start_backend_module(?MODULE, Opts, []),
+    mod_push_backend:init(Host, Opts),
 
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     mod_disco:register_feature(Host, ?NS_PUSH),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host, ?NS_PUSH, ?MODULE,
+                                  iq_handler, IQDisc),
+    gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_PUSH, ?MODULE,
                                   iq_handler, IQDisc),
 
     ejabberd_hooks:add(offline_groupchat_message_hook, Host, ?MODULE, handle_offline_message, 1),
@@ -59,9 +64,15 @@ stop(Host) ->
                              To :: ejabberd:jid(),
                              Packet :: jlib:xmlel()) -> ok.
 handle_offline_message(From, To, Packet) ->
+    ?INFO_MSG("handle_offline_message ~p", [{From, To, Packet}]),
 
-
-
+    BareRecipient = jid:to_bare(To),
+    Services = mod_push_backend:get_publish_services(BareRecipient),
+    lists:foreach(
+        fun(PubsubJID, Node, Form) ->
+            Stanza = push_notification_stanza(From, BareRecipient, Packet, PubsubJID, Node, Form),
+            ejabberd_router:route(To, PubsubJID, Stanza)
+        end, Services),
 
     ok.
 
@@ -69,13 +80,13 @@ handle_offline_message(From, To, Packet) ->
     ejabberd:iq() | ignore.
 iq_handler(_From, _To, IQ = #iq{type = get, sub_el = SubEl}) ->
     IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
-iq_handler(_From, _To, IQ = #iq{type = set, sub_el = Request}) ->
+iq_handler(From, _To, IQ = #iq{type = set, sub_el = Request}) ->
     case parse_request(Request) of
-        {enable, BareJID, Node, Form} ->
-
-
+        {enable, BarePubsubJID, Node, FormFields} ->
+            ok = mod_push_backend:enable(jid:to_bare(From), BarePubsubJID, Node, FormFields),
             IQ#iq{type = result, sub_el = []};
-        {disable, BareJID, Node} ->
+        {disable, BarePubsubJID, Node} ->
+            ok = mod_push_backend:disable(jid:to_bare(From), BarePubsubJID, Node),
             IQ#iq{type = result, sub_el = []};
         bad_request ->
             IQ#iq{type = error, sub_el = [Request, ?ERR_BAD_REQUEST]}
@@ -89,23 +100,82 @@ parse_request(#xmlel{name = <<"enable">>} = Request) ->
     Node = exml_query:attr(Request, <<"node">>, <<>>), %% Treat unset node as empty - both forbidden
     Form = exml_query:subelement(Request, <<"x">>),
 
-    case {JID, Node} of
-        {_, <<>>}               -> bad_request;
-        {#jid{luser = <<>>}}    -> bad_request;
-        {#jid{lserver = <<>>}}  -> bad_request;
-        {JID, Node} ->
-            {enable, JID, Node, Form}
+    case {JID, Node, parse_form(Form)} of
+        {_, _, invalid_form}            -> bad_request;
+        {_, <<>>, _}                    -> bad_request;
+        {error, _, _}                   -> bad_request;
+        {#jid{luser = <<>>}, _, _}      -> bad_request;
+        {#jid{lserver = <<>>}, _, _}    -> bad_request;
+        {JID, Node, FormFields} ->
+            {enable, jid:to_bare(JID), Node, FormFields}
     end;
 parse_request(#xmlel{name = <<"disable">>} = Request) ->
     JID = jid:from_binary(exml_query:attr(Request, <<"jid">>, <<>>)),
     Node = exml_query:attr(Request, <<"node">>, undefined),
 
-    case {jid:to_bare(JID), Node} of
-        {_, <<>>}               -> bad_request; %% Node may not be set, but shouldn't be empty
-        {#jid{luser = <<>>}}    -> bad_request;
-        {#jid{lserver = <<>>}}  -> bad_request;
-        {BareJID, Node} ->
-            {disable, BareJID, Node}
+    case {JID, Node} of
+        {error, _}                  -> bad_request;
+        {_, <<>>}                   -> bad_request; %% Node may not be set, but shouldn't be empty
+        {#jid{luser = <<>>}, _}     -> bad_request;
+        {#jid{lserver = <<>>}, _}   -> bad_request;
+        {JID, Node} ->
+            {disable, jid:to_bare(JID), Node}
     end;
 parse_request(_) ->
     bad_request.
+
+parse_form(undefined) ->
+    [];
+parse_form(Form) ->
+    IsForm = ?NS_XDATA == exml_query:attr(Form, <<"xmlns">>),
+    IsSubmit = <<"submit">> == exml_query:attr(Form, <<"type">>),
+
+    FieldsXML = exml_query:subelements(Form, <<"field">>),
+    Fields = [{exml_query:attr(Field, <<"var">>), exml_query:cdata(Field)} || Field <- FieldsXML],
+    {[{_, FormType}], CustomFields} = lists:partition(
+        fun({Name, _}) ->
+            Name == <<"FORM_TYPE">>
+        end, Fields),
+    IsFormTypeCorrect = ?NS_PUBSUB_PUB_OPTIONS == FormType,
+
+    case IsForm andalso IsSubmit andalso IsFormTypeCorrect of
+        true ->
+            CustomFields;
+        false ->
+            invalid_form
+    end.
+
+
+push_notification_stanza(From, To, Packet, PubsubJID, Node, FormFields) ->
+    ContentFields = [
+        {<<"FORM_TYPE">>, ?PUSH_FORM_TYPE},
+        {<<"message-count">>, <<"1">>},
+        {<<"last-message-sender">>, jid:to_binary(From)},
+        {<<"last-message-body">>, exml_query:cdata(exml_query:subelement(Packet, <<"body">>))}
+    ],
+
+    AlmostStanza = jlib:iq_to_xml(#iq{type = set, sub_el = [
+        #xmlel{name = <<"pubsub">>, attrs = [{<<"xmlns">>, ?NS_PUBSUB}], children = [
+            #xmlel{name = <<"publish">>, attrs = [{<<"node">>, Node}], children = [
+                #xmlel{name = <<"item">>, children = [
+                    #xmlel{name = <<"notification">>,
+                           attrs = [{<<"xmlns">>, ?NS_PUSH}], children = [make_form(ContentFields)]}
+                ]}
+            ]},
+            #xmlel{name = <<"publish-options">>, children = [
+                make_form([{<<"FORM_TYPE">>, ?NS_PUBSUB_PUB_OPTIONS}] ++ FormFields)
+            ]}
+        ]}
+    ]}),
+
+    jlib:replace_from_to(To, PubsubJID, AlmostStanza).
+
+
+make_form(Fields) ->
+    #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"submit">>}],
+           children = [make_form_field(Name, Value) || {Name, Value} <- Fields]}.
+
+make_form_field(Name, Value) ->
+    #xmlel{name = <<"field">>,
+           attrs = [{<<"var">>, Name}],
+           children = [#xmlcdata{content = Value}]}.

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -98,7 +98,7 @@ stop(Host) ->
 %% Hook 'remove_user'
 -spec remove_user(LUser :: binary(), LServer :: binary()) -> ok.
 remove_user(LUser, LServer) ->
-    mod_push_backend:disable(jid:make_noprep(LUser, LServer, undefined), undefined),
+    mod_push_backend:disable(jid:make_noprep(LUser, LServer, <<>>), undefined),
     ok.
 
 %% Hook 'filter_packet'
@@ -186,7 +186,9 @@ publish_message(From, To, Packet) ->
 %%--------------------------------------------------------------------
 
 -spec parse_request(Request :: exml:element()) ->
-                           bad_request.
+    {enable, ejabberd:jid(), pubsub_node(), form()} |
+    {disable, ejabberd:jid(), pubsub_node()} |
+    bad_request.
 parse_request(#xmlel{name = <<"enable">>} = Request) ->
     JID = jid:from_binary(exml_query:attr(Request, <<"jid">>, <<>>)),
     Node = exml_query:attr(Request, <<"node">>, <<>>), %% Treat unset node as empty - both forbidden

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -173,7 +173,7 @@ publish_message(From, To = #jid{lserver = Host}, Packet) ->
     {ok, Services} = mod_push_backend:get_publish_services(BareRecipient),
     lists:foreach(
       fun({PubsubJID, Node, Form}) ->
-              Stanza = push_notification_iq(From, Packet, Node, Form),
+              Stanza = push_notification_iq(Host, From, Packet, Node, Form),
               ResponseHandler =
                   fun(Response) ->
                           cast(Host, handle_publish_response,
@@ -244,14 +244,14 @@ parse_form(Form) ->
             invalid_form
     end.
 
--spec push_notification_iq(From :: ejabberd:jid(), Packet :: jlib:xmlel(),
-                           Node :: pubsub_node(), Form :: form()) -> iq().
-push_notification_iq(From, Packet, Node, Form) ->
+-spec push_notification_iq(Host :: ejabberd:server(), From :: ejabberd:jid(),
+                           Packet :: jlib:xmlel(), Node :: pubsub_node(), Form :: form()) -> iq().
+push_notification_iq(Host, From, Packet, Node, Form) ->
     ContentFields =
         [
          {<<"FORM_TYPE">>, ?PUSH_FORM_TYPE},
          {<<"message-count">>, <<"1">>},
-         {<<"last-message-sender">>, mod_push_plugin:sender_id(From, Packet)},
+         {<<"last-message-sender">>, mod_push_plugin:sender_id(Host, From, Packet)},
          {<<"last-message-body">>, exml_query:cdata(exml_query:subelement(Packet, <<"body">>))}
         ],
 

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -13,60 +13,121 @@
 -author("Rafal Slota").
 -behavior(mod_push).
 
--export([init/2, enable/4, disable/3, get_publish_services/1]).
+%%--------------------------------------------------------------------
+%% Exports
+%%--------------------------------------------------------------------
 
--record(push_subscription, {user_jid, pubsub_jid, pubsub_node, forms}).
+-export([init/2]).
+-export([enable/4, disable/3, get_publish_services/1]).
 
+%%--------------------------------------------------------------------
+%% Definitions
+%%--------------------------------------------------------------------
+
+-record(push_subscription, {
+    user_jid    :: key() | undefined,
+    pubsub_jid  :: ejabberd:jid(),
+    pubsub_node :: mod_push:pubsub_node(),
+    form        :: mod_push:form()
+}).
+
+-type key()     :: ejabberd:simple_bare_jid().
+-type record()  :: #push_subscription{}.
+
+%%--------------------------------------------------------------------
+%% Backend callbacks
+%%--------------------------------------------------------------------
 
 -spec init(Host :: ejabberd:server(), Opts :: list()) -> ok.
 init(_Host, _Opts) ->
     mnesia:create_table(push_subscription,
-                        [{disc_only_copies, [node()]},
+                        [{disc_copies, [node()]},
                          {type, bag},
                          {attributes, record_info(fields, push_subscription)}]),
-    mnesia:add_table_copy(push_subscription, node(), disc_only_copies),
+    mnesia:add_table_copy(push_subscription, node(), disc_copies),
     ok.
 
 
--spec enable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(),
-                 Node :: binary(), Forms :: any()) -> ok.
+-spec enable(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
+                 Node :: mod_push:pubsub_node(), Form :: mod_push:form()) ->
+    ok | {error, Reason :: term()}.
 enable(User, PubSub, Node, Forms) ->
-    write(make_record(User, PubSub, Node, Forms)),
-    ok.
+    write(make_record(User, PubSub, Node, Forms)).
 
 
--spec disable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(), Node :: binary()) -> ok.
-
+-spec disable(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
+                  Node :: mod_push:pubsub_node()) -> ok | {error, Reason :: term()}.
 disable(User, undefined, undefined) ->
     delete(key(User));
-disable(User, PubSub, Node) ->
-    ok.
+disable(User, undefined, undefined) ->
+    delete(key(User));
+disable(User, PubsubJID, Node) ->
+    Result =
+        transaction(
+            fun() ->
+                PubsubFiltered =
+                    [Record ||
+                        #push_subscription{pubsub_jid = RecPubsubJID} = Record <- read(key(User)),
+                     PubsubJID == undefined orelse RecPubsubJID == PubsubJID],
+
+                NodeFiltered =
+                    [Record || #push_subscription{pubsub_node = RecNode} = Record <- PubsubFiltered,
+                     Node == undefined orelse RecNode == Node],
+
+                [mnesia:delete_object(Record) || Record <- NodeFiltered]
+            end),
+
+    case Result of
+        {error, _} = E ->
+            E;
+        _ ->
+            ok
+    end.
 
 
 -spec get_publish_services(User :: ejabberd:jid()) ->
-    [{PubSub :: ejabberd:jid(), Node :: binary()}].
+    {ok, [{PubSub :: ejabberd:jid(), Node :: mod_push:node(), Form :: mod_push:form()}]} |
+    {error, Reason :: term()}.
 get_publish_services(User) ->
-    [{PubsubJID, Node, Forms} ||
-        #push_subscription{pubsub_jid = PubsubJID,
-                           pubsub_node = Node,
-                           forms = Forms} <- read(key(User))].
+    case safe_read(key(User)) of
+        {ok, Records} ->
+            [{PubsubJID, Node, Forms} ||
+                #push_subscription{pubsub_jid = PubsubJID,
+                                   pubsub_node = Node,
+                                   form = Forms} <- Records];
+        {error, _} = E ->
+            E
+    end.
 
+%%--------------------------------------------------------------------
+%% Helper functions
+%%--------------------------------------------------------------------
 
+-spec read(key()) -> [record()] | no_return().
 read(Key) ->
     F = fun() -> mnesia:read({push_subscription, Key}) end,
     mnesia:async_dirty(F).
 
+-spec safe_read(key()) -> {ok, [record()]} | {error, Reason :: term()}.
+safe_read(Key) ->
+    try read(Key)
+    catch
+        _:Reason ->
+            {error, Reason}
+    end.
+
+-spec write(record()) -> ok | {error, Reason :: term()}.
 write(Record) ->
     F = fun() -> mnesia:write(Record) end,
-    case mnesia:transaction(F) of
-        {atomic, Result} ->
-            Result;
-        {aborted, Reason} ->
-            {error, {aborted, Reason}}
-    end.
+    transaction(F).
 
+-spec delete(key()) -> ok | {error, Reason :: term()}.
 delete(Key) ->
     F = fun() -> mnesia:delete({push_subscription, Key}) end,
+    transaction(F).
+
+-spec transaction(fun(() -> any())) -> Result :: any().
+transaction(F) ->
     case mnesia:transaction(F) of
         {atomic, Result} ->
             Result;
@@ -74,14 +135,21 @@ delete(Key) ->
             {error, {aborted, Reason}}
     end.
 
-make_record(User, PubSub, Node, Forms) ->
+-spec make_record(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
+                  Node :: mod_push:pubsub_node(), Form :: mod_push:form()) -> record().
+make_record(UserJID, PubsubJID, Node, Form) ->
     #push_subscription{
-        user_jid = key(User),
-        pubsub_jid = PubSub,
+        user_jid = key(UserJID),
+        pubsub_jid = PubsubJID,
         pubsub_node = Node,
-        forms = Forms
+        form = Form
     }.
 
-
+-spec key(ejabberd:jid()) -> key() | no_return().
 key(JID) ->
-    jid:to_lus(JID).
+    case jid:to_lus(JID) of
+        error ->
+            throw({invalid_jid, JID});
+        SimpleBareJID ->
+            SimpleBareJID
+    end.

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -6,7 +6,7 @@
 %%% @end
 %%%-------------------------------------------------------------------
 %%% @doc
-%%% @todo: write me!
+%%% Mnesia backend for mod_push.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(mod_push_mnesia).
@@ -25,11 +25,11 @@
 %%--------------------------------------------------------------------
 
 -record(push_subscription, {
-    user_jid    :: key() | undefined,
-    pubsub_jid  :: ejabberd:jid(),
-    pubsub_node :: mod_push:pubsub_node(),
-    form        :: mod_push:form()
-}).
+          user_jid    :: key() | undefined,
+          pubsub_jid  :: ejabberd:jid(),
+          pubsub_node :: mod_push:pubsub_node(),
+          form        :: mod_push:form()
+         }).
 
 -type key()     :: ejabberd:simple_bare_jid().
 -type record()  :: #push_subscription{}.
@@ -49,14 +49,14 @@ init(_Host, _Opts) ->
 
 
 -spec enable(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
-                 Node :: mod_push:pubsub_node(), Form :: mod_push:form()) ->
-    ok | {error, Reason :: term()}.
+             Node :: mod_push:pubsub_node(), Form :: mod_push:form()) ->
+                    ok | {error, Reason :: term()}.
 enable(User, PubSub, Node, Forms) ->
     write(make_record(User, PubSub, Node, Forms)).
 
 
 -spec disable(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
-                  Node :: mod_push:pubsub_node()) -> ok | {error, Reason :: term()}.
+              Node :: mod_push:pubsub_node()) -> ok | {error, Reason :: term()}.
 disable(User, undefined, undefined) ->
     delete(key(User));
 disable(User, undefined, undefined) ->
@@ -64,18 +64,19 @@ disable(User, undefined, undefined) ->
 disable(User, PubsubJID, Node) ->
     Result =
         transaction(
-            fun() ->
-                PubsubFiltered =
-                    [Record ||
-                        #push_subscription{pubsub_jid = RecPubsubJID} = Record <- read(key(User)),
-                     PubsubJID == undefined orelse RecPubsubJID == PubsubJID],
+          fun() ->
+                  PubsubFiltered =
+                      [Record ||
+                          #push_subscription{pubsub_jid = RecPubsubJID} = Record <- read(key(User)),
+                          PubsubJID == undefined orelse RecPubsubJID == PubsubJID],
 
-                NodeFiltered =
-                    [Record || #push_subscription{pubsub_node = RecNode} = Record <- PubsubFiltered,
-                     Node == undefined orelse RecNode == Node],
+                  NodeFiltered =
+                      [Record ||
+                          #push_subscription{pubsub_node = RecNode} = Record <- PubsubFiltered,
+                          Node == undefined orelse RecNode == Node],
 
-                [mnesia:delete_object(Record) || Record <- NodeFiltered]
-            end),
+                  [mnesia:delete_object(Record) || Record <- NodeFiltered]
+          end),
 
     case Result of
         {error, _} = E ->
@@ -86,8 +87,9 @@ disable(User, PubsubJID, Node) ->
 
 
 -spec get_publish_services(User :: ejabberd:jid()) ->
-    {ok, [{PubSub :: ejabberd:jid(), Node :: mod_push:node(), Form :: mod_push:form()}]} |
-    {error, Reason :: term()}.
+                                  {ok, [{PubSub :: ejabberd:jid(), Node :: mod_push:node(),
+                                         Form :: mod_push:form()}]} |
+                                  {error, Reason :: term()}.
 get_publish_services(User) ->
     case safe_read(key(User)) of
         {ok, Records} ->
@@ -139,11 +141,11 @@ transaction(F) ->
                   Node :: mod_push:pubsub_node(), Form :: mod_push:form()) -> record().
 make_record(UserJID, PubsubJID, Node, Form) ->
     #push_subscription{
-        user_jid = key(UserJID),
-        pubsub_jid = PubsubJID,
-        pubsub_node = Node,
-        form = Form
-    }.
+       user_jid = key(UserJID),
+       pubsub_jid = PubsubJID,
+       pubsub_node = Node,
+       form = Form
+      }.
 
 -spec key(ejabberd:jid()) -> key() | no_return().
 key(JID) ->

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -1,0 +1,38 @@
+%%%-------------------------------------------------------------------
+%%% @author Rafal Slota
+%%% @copyright (C) 2017 Erlang Solutions Ltd.
+%%% This software is released under the Apache License, Version 2.0
+%%% cited in 'LICENSE.txt'.
+%%% @end
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% @todo: write me!
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mod_push_mnesia).
+-author("Rafal Slota").
+-behavior(mod_push).
+
+-export([init/2, enable/4, disable/3, get_publish_services/1]).
+
+
+-spec init(Host :: ejabberd:server(), Opts :: list()) -> ok.
+init(Host, Opts) ->
+    ok.
+
+
+-spec enable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(),
+                 Node :: binary(), Forms :: any()) -> ok.
+enable(User, PubSub, Node, Forms) ->
+    ok.
+
+
+-spec disable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(), Node :: binary()) -> ok.
+disable(User, PubSub, Node) ->
+    ok.
+
+
+-spec get_publish_services(User :: ejabberd:jid()) ->
+    [{PubSub :: ejabberd:jid(), Node :: binary()}].
+get_publish_services(User) ->
+    [].

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -32,7 +32,7 @@
          }).
 
 -type key()     :: ejabberd:simple_bare_jid().
--type record()  :: #push_subscription{}.
+-type sub_record()  :: #push_subscription{}.
 
 %%--------------------------------------------------------------------
 %% Backend callbacks
@@ -104,12 +104,12 @@ get_publish_services(User) ->
 %% Helper functions
 %%--------------------------------------------------------------------
 
--spec read(key()) -> [record()] | no_return().
+-spec read(key()) -> [sub_record()] | no_return().
 read(Key) ->
     F = fun() -> mnesia:read({push_subscription, Key}) end,
     mnesia:async_dirty(F).
 
--spec safe_read(key()) -> {ok, [record()]} | {error, Reason :: term()}.
+-spec safe_read(key()) -> {ok, [sub_record()]} | {error, Reason :: term()}.
 safe_read(Key) ->
     try read(Key) of
         Records ->
@@ -119,7 +119,7 @@ safe_read(Key) ->
             {error, Reason}
     end.
 
--spec write(record()) -> ok | {error, Reason :: term()}.
+-spec write(sub_record()) -> ok | {error, Reason :: term()}.
 write(Record) ->
     F = fun() -> mnesia:write(Record) end,
     transaction(F).
@@ -139,7 +139,7 @@ transaction(F) ->
     end.
 
 -spec make_record(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
-                  Node :: mod_push:pubsub_node(), Form :: mod_push:form()) -> record().
+                  Node :: mod_push:pubsub_node(), Form :: mod_push:form()) -> sub_record().
 make_record(UserJID, PubsubJID, Node, Form) ->
     #push_subscription{
        user_jid = key(UserJID),
@@ -150,9 +150,4 @@ make_record(UserJID, PubsubJID, Node, Form) ->
 
 -spec key(ejabberd:jid()) -> key() | no_return().
 key(JID) ->
-    case jid:to_lus(JID) of
-        error ->
-            throw({invalid_jid, JID});
-        SimpleBareJID ->
-            SimpleBareJID
-    end.
+    jid:to_lus(JID).

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -15,9 +15,16 @@
 
 -export([init/2, enable/4, disable/3, get_publish_services/1]).
 
+-record(subscription, {user_jid, pubsub_jid, pubsub_node, forms}).
+
 
 -spec init(Host :: ejabberd:server(), Opts :: list()) -> ok.
-init(Host, Opts) ->
+init(_Host, _Opts) ->
+    mnesia:create_table(push_subscription,
+                        [{disc_only_copies, [node()]},
+                         {type, bag},
+                         {attributes, record_info(fields, push_subscription)}]),
+    mnesia:add_table_copy(offline_msg, node(), disc_only_copies),
     ok.
 
 

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -52,13 +52,12 @@ init(_Host, _Opts) ->
              Node :: mod_push:pubsub_node(), Form :: mod_push:form()) ->
                     ok | {error, Reason :: term()}.
 enable(User, PubSub, Node, Forms) ->
+    disable(User, PubSub, Node),
     write(make_record(User, PubSub, Node, Forms)).
 
 
 -spec disable(UserJID :: ejabberd:jid(), PubsubJID :: ejabberd:jid(),
               Node :: mod_push:pubsub_node()) -> ok | {error, Reason :: term()}.
-disable(User, undefined, undefined) ->
-    delete(key(User));
 disable(User, undefined, undefined) ->
     delete(key(User));
 disable(User, PubsubJID, Node) ->

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -15,7 +15,7 @@
 
 -export([init/2, enable/4, disable/3, get_publish_services/1]).
 
--record(subscription, {user_jid, pubsub_jid, pubsub_node, forms}).
+-record(push_subscription, {user_jid, pubsub_jid, pubsub_node, forms}).
 
 
 -spec init(Host :: ejabberd:server(), Opts :: list()) -> ok.
@@ -24,13 +24,14 @@ init(_Host, _Opts) ->
                         [{disc_only_copies, [node()]},
                          {type, bag},
                          {attributes, record_info(fields, push_subscription)}]),
-    mnesia:add_table_copy(offline_msg, node(), disc_only_copies),
+    mnesia:add_table_copy(push_subscription, node(), disc_only_copies),
     ok.
 
 
 -spec enable(User :: ejabberd:jid(), PubSub :: ejabberd:jid(),
                  Node :: binary(), Forms :: any()) -> ok.
 enable(User, PubSub, Node, Forms) ->
+    write(make_record(User, PubSub, Node, Forms)),
     ok.
 
 
@@ -42,4 +43,30 @@ disable(User, PubSub, Node) ->
 -spec get_publish_services(User :: ejabberd:jid()) ->
     [{PubSub :: ejabberd:jid(), Node :: binary()}].
 get_publish_services(User) ->
-    [].
+    read(key(User)).
+
+
+read(Key) ->
+    F = fun() -> mnesia:read({push_subscription, Key}) end,
+    mnesia:async_dirty(F).
+
+write(Record) ->
+    F = fun() -> mnesia:write(Record) end,
+    case mnesia:transaction(F) of
+        {atomic, Result} ->
+            Result;
+        {aborted, Reason} ->
+            {error, {aborted, Reason}}
+    end.
+
+make_record(User, PubSub, Node, Forms) ->
+    #push_subscription{
+        user_jid = key(User),
+        pubsub_jid = PubSub,
+        pubsub_node = Node,
+        forms = Forms
+    }.
+
+
+key(JID) ->
+    jid:to_lus(JID).

--- a/apps/ejabberd/src/mod_push_mnesia.erl
+++ b/apps/ejabberd/src/mod_push_mnesia.erl
@@ -93,10 +93,10 @@ disable(User, PubsubJID, Node) ->
 get_publish_services(User) ->
     case safe_read(key(User)) of
         {ok, Records} ->
-            [{PubsubJID, Node, Forms} ||
+            {ok, [{PubsubJID, Node, Forms} ||
                 #push_subscription{pubsub_jid = PubsubJID,
                                    pubsub_node = Node,
-                                   form = Forms} <- Records];
+                                   form = Forms} <- Records]};
         {error, _} = E ->
             E
     end.
@@ -112,7 +112,9 @@ read(Key) ->
 
 -spec safe_read(key()) -> {ok, [record()]} | {error, Reason :: term()}.
 safe_read(Key) ->
-    try read(Key)
+    try read(Key) of
+        Records ->
+            {ok, Records}
     catch
         _:Reason ->
             {error, Reason}

--- a/apps/ejabberd/src/mod_push_plugin.erl
+++ b/apps/ejabberd/src/mod_push_plugin.erl
@@ -6,7 +6,7 @@
 %%% @end
 %%%-------------------------------------------------------------------
 %%% @doc
-%%% @todo: write me!
+%%% Default plugin module for mod_push. This module allows for some dynamic customizations.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(mod_push_plugin).
@@ -24,7 +24,7 @@
 
 
 -spec should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) ->
-    boolean().
+                            boolean().
 should_publish(_From, To = #jid{luser = LUser, lserver = LServer}, _Packet) ->
     try ejabberd_users:does_user_exist(LUser, LServer) of
         false ->

--- a/apps/ejabberd/src/mod_push_plugin.erl
+++ b/apps/ejabberd/src/mod_push_plugin.erl
@@ -1,0 +1,51 @@
+%%%-------------------------------------------------------------------
+%%% @author Rafal Slota
+%%% @copyright (C) 2017 Erlang Solutions Ltd.
+%%% This software is released under the Apache License, Version 2.0
+%%% cited in 'LICENSE.txt'.
+%%% @end
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% @todo: write me!
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mod_push_plugin).
+-behavior(mod_push_plugin).
+-author('rafal.slota@erlang-solutions.com').
+
+-include_lib("ejabberd/include/jlib.hrl").
+-include_lib("ejabberd/include/ejabberd.hrl").
+
+%% API
+-export([should_publish/3]).
+
+-callback should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) ->
+    boolean().
+
+
+-spec should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) ->
+    boolean().
+should_publish(_From, To = #jid{luser = LUser, lserver = LServer}, _Packet) ->
+    try ejabberd_users:does_user_exist(LUser, LServer) of
+        false ->
+            false;
+        true ->
+            case catch lists:max(ejabberd_sm:get_user_present_pids(LUser, LServer)) of
+                {Priority, _} when Priority >= 0 ->
+                    false;
+                _ ->
+                    is_offline(To)
+            end
+    catch
+        _:_ ->
+            is_offline(To)
+    end.
+
+
+is_offline(#jid{luser = LUser, lserver = LServer}) ->
+    case catch lists:max(ejabberd_sm:get_user_present_pids(LUser, LServer)) of
+        {Priority, _} when is_integer(Priority), Priority >= 0 ->
+            false;
+        _ ->
+            true
+    end.

--- a/apps/ejabberd/src/mod_push_plugin.erl
+++ b/apps/ejabberd/src/mod_push_plugin.erl
@@ -54,12 +54,7 @@ should_publish(_From, To = #jid{luser = LUser, lserver = LServer}, _Packet) ->
         false ->
             false;
         true ->
-            case catch lists:max(ejabberd_sm:get_user_present_pids(LUser, LServer)) of
-                {Priority, _} when Priority >= 0 ->
-                    false;
-                _ ->
-                    is_offline(To)
-            end
+            is_offline(To)
     catch
         _:_ ->
             is_offline(To)
@@ -75,12 +70,12 @@ is_offline(#jid{luser = LUser, lserver = LServer}) ->
 
 %% Callback 'sender_id'
 -spec sender_id(From :: ejabberd:jid(), Packet :: jlib:xmlel()) -> SenderId :: binary().
-sender_id(From = #jid{lresource = LResource, luser = LUser}, Packet) ->
+sender_id(From, Packet) ->
     case exml_query:attr(Packet, <<"type">>) of
         <<"chat">> ->
             jid:to_binary(jid:to_bare(jid:to_lower(From)));
         <<"groupchat">> ->
-            <<LResource/binary, " (room: ", LUser/binary, ")">>
+            jid:to_binary(jid:to_lower(From))
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/ejabberd/src/mod_push_plugin.erl
+++ b/apps/ejabberd/src/mod_push_plugin.erl
@@ -6,11 +6,10 @@
 %%% @end
 %%%-------------------------------------------------------------------
 %%% @doc
-%%% Default plugin module for mod_push. This module allows for some dynamic customizations.
+%%% Plugin behaviour module for mod_push. This module defines API for some dynamic customizations.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(mod_push_plugin).
--behavior(mod_push_plugin).
 -author('rafal.slota@erlang-solutions.com').
 
 -include_lib("ejabberd/include/jlib.hrl").
@@ -19,8 +18,6 @@
 %% API
 -export([should_publish/4, sender_id/3]).
 
-%% Callback API
--export([should_publish/3, sender_id/2]).
 
 -callback should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) ->
     boolean().
@@ -43,45 +40,9 @@ sender_id(Host, From, Packet) ->
     PluginModule:sender_id(From, Packet).
 
 %%--------------------------------------------------------------------
-%% Callbacks
-%%--------------------------------------------------------------------
-
-%% Callback 'should_publish'
--spec should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) ->
-                            boolean().
-should_publish(_From, To = #jid{luser = LUser, lserver = LServer}, _Packet) ->
-    try ejabberd_users:does_user_exist(LUser, LServer) of
-        false ->
-            false;
-        true ->
-            is_offline(To)
-    catch
-        _:_ ->
-            is_offline(To)
-    end.
-
-is_offline(#jid{luser = LUser, lserver = LServer}) ->
-    case catch lists:max(ejabberd_sm:get_user_present_pids(LUser, LServer)) of
-        {Priority, _} when is_integer(Priority), Priority >= 0 ->
-            false;
-        _ ->
-            true
-    end.
-
-%% Callback 'sender_id'
--spec sender_id(From :: ejabberd:jid(), Packet :: jlib:xmlel()) -> SenderId :: binary().
-sender_id(From, Packet) ->
-    case exml_query:attr(Packet, <<"type">>) of
-        <<"chat">> ->
-            jid:to_binary(jid:to_bare(jid:to_lower(From)));
-        <<"groupchat">> ->
-            jid:to_binary(jid:to_lower(From))
-    end.
-
-%%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
 
 -spec plugin_module(Host :: ejabberd:server()) -> Module :: atom().
 plugin_module(Host) ->
-    gen_mod:get_module_opt(Host, mod_push, plugin_module, ?MODULE).
+    gen_mod:get_module_opt(Host, mod_push, plugin_module, mod_push_plugin_default).

--- a/apps/ejabberd/src/mod_push_plugin.erl
+++ b/apps/ejabberd/src/mod_push_plugin.erl
@@ -75,12 +75,12 @@ is_offline(#jid{luser = LUser, lserver = LServer}) ->
 
 %% Callback 'sender_id'
 -spec sender_id(From :: ejabberd:jid(), Packet :: jlib:xmlel()) -> SenderId :: binary().
-sender_id(From = #jid{lresource = LResource}, Packet) ->
+sender_id(From = #jid{lresource = LResource, luser = LUser}, Packet) ->
     case exml_query:attr(Packet, <<"type">>) of
         <<"chat">> ->
             jid:to_binary(jid:to_bare(jid:to_lower(From)));
         <<"groupchat">> ->
-            LResource
+            <<LResource/binary, " (room: ", LUser/binary, ")">>
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/ejabberd/src/mod_push_plugin_default.erl
+++ b/apps/ejabberd/src/mod_push_plugin_default.erl
@@ -1,0 +1,56 @@
+%%%-------------------------------------------------------------------
+%%% @author Rafal Slota
+%%% @copyright (C) 2017 Erlang Solutions Ltd.
+%%% This software is released under the Apache License, Version 2.0
+%%% cited in 'LICENSE.txt'.
+%%% @end
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% Default plugin module for mod_push. This module allows for some dynamic customizations.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mod_push_plugin_default).
+-behavior(mod_push_plugin).
+-author('rafal.slota@erlang-solutions.com').
+
+-include_lib("ejabberd/include/jlib.hrl").
+-include_lib("ejabberd/include/ejabberd.hrl").
+
+%% Callback API
+-export([should_publish/3, sender_id/2]).
+
+%%--------------------------------------------------------------------
+%% Callbacks
+%%--------------------------------------------------------------------
+
+%% Callback 'should_publish'
+-spec should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) ->
+                            boolean().
+should_publish(_From, To = #jid{luser = LUser, lserver = LServer}, _Packet) ->
+    try ejabberd_users:does_user_exist(LUser, LServer) of
+        false ->
+            false;
+        true ->
+            is_offline(To)
+    catch
+        _:_ ->
+            is_offline(To)
+    end.
+
+is_offline(#jid{luser = LUser, lserver = LServer}) ->
+    case catch lists:max(ejabberd_sm:get_user_present_pids(LUser, LServer)) of
+        {Priority, _} when is_integer(Priority), Priority >= 0 ->
+            false;
+        _ ->
+            true
+    end.
+
+%% Callback 'sender_id'
+-spec sender_id(From :: ejabberd:jid(), Packet :: jlib:xmlel()) -> SenderId :: binary().
+sender_id(From, Packet) ->
+    case exml_query:attr(Packet, <<"type">>) of
+        <<"chat">> ->
+            jid:to_binary(jid:to_bare(jid:to_lower(From)));
+        <<"groupchat">> ->
+            jid:to_binary(jid:to_lower(From))
+    end.

--- a/apps/ejabberd/src/mongoose_cassandra.erl
+++ b/apps/ejabberd/src/mongoose_cassandra.erl
@@ -186,7 +186,7 @@ cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn)  ->
 -spec cql_foldl(PoolName :: pool_name(), UserJID :: jid() | undefined, Module :: atom(),
                 QueryName :: query_name(), Params :: parameters(),
                 row_fold_fun(), AccIn :: term(), TryCount :: non_neg_integer()) ->
-                   {ok, AccOut :: term()} | {error, Reason :: any()}.
+                       {ok, AccOut :: term()} | {error, Reason :: any()}.
 cql_foldl(_PoolName, _UserJID, _Module, QueryName, Params, _Fun, _AccIn, 0)  ->
     {error, {query_timeout, QueryName, Params}};
 cql_foldl(PoolName, UserJID, Module, QueryName, Params, Fun, AccIn, TryCount)  ->
@@ -299,7 +299,7 @@ test_query(PoolName, UserJID) ->
     end.
 
 -spec total_count_query(pool_name(), Table :: atom()) ->
-    non_neg_integer().
+                               non_neg_integer().
 total_count_query(PoolName, Table) ->
     UserJID = undefined,
     Res = mongoose_cassandra:cql_read(PoolName, UserJID, ?MODULE, {total_count_query, Table}, []),

--- a/apps/ejabberd/src/mongoose_cassandra.erl
+++ b/apps/ejabberd/src/mongoose_cassandra.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%==============================================================================
 -module(mongoose_cassandra).
--author("Rafal Slota").
+-author('rafal.slota@erlang-solutions.com').
 
 -include_lib("ejabberd/include/ejabberd.hrl").
 -include_lib("ejabberd/include/jlib.hrl").

--- a/doc/modules/mod_push.md
+++ b/doc/modules/mod_push.md
@@ -1,0 +1,34 @@
+### Module Description
+This module implements [XEP-0357: Push Notifications](https://xmpp.org/extensions/xep-0357.html).
+ It enables a service that notifies `PubSub` of user's choice about every message that he could 
+ miss while being offline. There are two control stanzas that clinet may send to this module: 
+ `enable` and `disable`. `enable` stanza enables push notifications and forwards them to 
+ specified `PubSub` node. This stanza also may contain optional `Data Form` that will be added to
+  each and every notification to `PubSub` node as `publish-options`. Please be sure to provide 
+  all form fields that are required by specified `PubSub` node. Any publish error may result in 
+  disabling push notifications to this node.  
+
+### Options
+
+* **backend** (atom, default: `mnesia`) - Backend to use for storing registrations. Currently 
+only `mnesia` may be used.
+* **wpool** (list, default: []) - List of options that will be passed to `worker_pool` library 
+that handles all the requests. Please refer to [Project Site](https://github.com/inaka/worker_pool) for more details.
+* **plugin_module** (atom, default: mod_push_plugin) - Plugin module that implements some dynamic
+ configurations. Currently this module allow configuration of parsing message `sender id` and can
+  filter messages that shall not be published to `PubSub` node.
+
+
+[aws-virtual-host]: https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
+[aws-region]: https://docs.aws.amazon.com/general/latest/gr/rande.html?shortFooter=true#s3_region
+[aws-keys]: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html?shortFooter=true#access-keys-and-secret-access-keys
+
+### Example configuration
+
+```Erlang
+{mod_push, [
+    {backend, mnesia},
+    {wpool, [{workers, 200}]},
+    {plugin_module, mod_push_plugin}
+]}.
+```

--- a/doc/modules/mod_push.md
+++ b/doc/modules/mod_push.md
@@ -12,9 +12,9 @@ This module implements [XEP-0357: Push Notifications](https://xmpp.org/extension
 
 * **backend** (atom, default: `mnesia`) - Backend to use for storing registrations. Currently 
 only `mnesia` may be used.
-* **wpool** (list, default: []) - List of options that will be passed to `worker_pool` library 
+* **wpool** (list, default: `[]`) - List of options that will be passed to `worker_pool` library
 that handles all the requests. Please refer to [Project Site](https://github.com/inaka/worker_pool) for more details.
-* **plugin_module** (atom, default: mod_push_plugin) - Plugin module that implements some dynamic
+* **plugin_module** (atom, default: `mod_push_plugin_default`) - Plugin module that implements some dynamic
  configurations. Currently this module allow configuration of parsing message `sender id` and can
   filter messages that shall not be published to `PubSub` node.
 
@@ -25,6 +25,6 @@ that handles all the requests. Please refer to [Project Site](https://github.com
 {mod_push, [
     {backend, mnesia},
     {wpool, [{workers, 200}]},
-    {plugin_module, mod_push_plugin}
+    {plugin_module, mod_push_plugin_default}
 ]}.
 ```

--- a/doc/modules/mod_push.md
+++ b/doc/modules/mod_push.md
@@ -1,7 +1,7 @@
 ### Module Description
 This module implements [XEP-0357: Push Notifications](https://xmpp.org/extensions/xep-0357.html).
  It enables a service that notifies `PubSub` of user's choice about every message that he could 
- miss while being offline. There are two control stanzas that clinet may send to this module: 
+ miss while being offline. There are two control stanzas that client may send to this module:
  `enable` and `disable`. `enable` stanza enables push notifications and forwards them to 
  specified `PubSub` node. This stanza also may contain optional `Data Form` that will be added to
   each and every notification to `PubSub` node as `publish-options`. Please be sure to provide 
@@ -18,10 +18,6 @@ that handles all the requests. Please refer to [Project Site](https://github.com
  configurations. Currently this module allow configuration of parsing message `sender id` and can
   filter messages that shall not be published to `PubSub` node.
 
-
-[aws-virtual-host]: https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
-[aws-region]: https://docs.aws.amazon.com/general/latest/gr/rande.html?shortFooter=true#s3_region
-[aws-keys]: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html?shortFooter=true#access-keys-and-secret-access-keys
 
 ### Example configuration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ pages:
       - 'mod_privacy': 'modules/mod_privacy.md'
       - 'mod_private': 'modules/mod_private.md'
       - 'mod_pubsub': 'modules/mod_pubsub.md'
+      - 'mod_push': 'modules/mod_push.md'
       - 'mod_push_service_mongoosepush': 'modules/mod_push_service_mongoosepush.md'
       - 'mod_register': 'modules/mod_register.md'
       - 'mod_revproxy': 'modules/mod_revproxy.md'

--- a/test.disabled/ejabberd_tests/default.spec
+++ b/test.disabled/ejabberd_tests/default.spec
@@ -49,6 +49,7 @@
 {suites, "tests", privacy_SUITE}.
 {suites, "tests", private_SUITE}.
 {suites, "tests", pubsub_SUITE}.
+{suites, "tests", push_SUITE}.
 {suites, "tests", push_pubsub_SUITE}.
 {suites, "tests", rest_SUITE}.
 {suites, "tests", rest_client_SUITE}.

--- a/test.disabled/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -74,7 +74,8 @@
          gc_message_verify_fun/3,
          stanza_aff_set/2,
          bin_aff_users/1,
-         verify_aff_users/2
+         verify_aff_users/2,
+         create_room/6
         ]).
 
 -export([all/0, groups/0, suite/0,

--- a/test.disabled/ejabberd_tests/tests/push_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_SUITE.erl
@@ -1,0 +1,485 @@
+-module(push_SUITE).
+-compile(export_all).
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("exml/include/exml.hrl").
+
+-define(NS_XDATA,        <<"jabber:x:data">>).
+-define(NS_PUBSUB_PUB_OPTIONS, <<"http://jabber.org/protocol/pubsub#publish-options">>).
+
+-define(MUC_HOST, <<"muc.localhost">>).
+-define(NS_HTTP_UPLOAD, <<"urn:xmpp:http:upload">>).
+-define(S3_HOSTNAME, "http://bucket.s3-eu-east-25.example.com").
+-define(PUSH_OPTS,
+    [
+        {backend, mnesia}
+    ]).
+
+
+-define(assertReceivedMatch(Expect), ?assertReceivedMatch(Expect, 0)).
+
+-define(assertReceivedMatch(Expect, Timeout),
+    ((fun() ->
+        receive
+            Expect = __Result__ -> __Result__
+        after
+            Timeout ->
+                __Reason__ =
+                receive
+                    __Result__ -> __Result__
+                after
+                    0 -> timeout
+                end,
+
+                __Args__ = [{module, ?MODULE},
+                            {line, ?LINE},
+                            {expected, (??Expect)},
+                            {value, __Reason__}],
+                ct:print("assertReceivedMatch_failed: ~p~n", [__Args__]),
+                erlang:error({assertReceivedMatch_failed, __Args__})
+        end
+      end)())).
+
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+        {group, toggling}
+    ].
+
+groups() ->
+    [
+        {toggling, [], [
+            enable_should_fail_with_missing_attributes,
+            enable_should_fail_with_invalid_attributes,
+            enable_should_succeed_without_form,
+            enable_with_form_should_fail_with_incorrect_from,
+            enable_should_accept_correct_from,
+            disable_should_fail_with_missing_attributes,
+            disable_should_fail_with_invalid_attributes,
+            disable_all,
+            disable_node
+        ]}
+    ].
+
+suite() ->
+    escalus:suite().
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    %% For mocking with unnamed functions
+    {_Module, Binary, Filename} = code:get_object_code(?MODULE),
+    rpc(code, load_binary, [?MODULE, Filename, Binary]),
+
+    muc_helper:load_muc(muc_host()),
+    escalus:init_per_suite(Config).
+end_per_suite(Config) ->
+    muc_helper:unload_muc(),
+    escalus:end_per_suite(Config).
+
+init_per_group(_, Config0) ->
+    Config = [{push_config, ?PUSH_OPTS} | Config0],
+    Host = ct:get_config({hosts, mim, domain}),
+    dynamic_modules:start(Host, mod_push, ?PUSH_OPTS),
+    escalus:create_users(Config, escalus:get_users([bob, alice])).
+
+end_per_group(_, Config) ->
+    Host = ct:get_config({hosts, mim, domain}),
+    dynamic_modules:stop(Host, mod_push),
+    escalus:delete_users(Config, escalus:get_users([bob, alice])).
+
+init_per_testcase(muc_messages = C, Config) ->
+    start_publish_listener(Config),
+    [User | _] = ?config(escalus_users, Config),
+    Config2 = muc_helper:start_room(Config, User, <<"muc_publish">>, <<"user_nick">>,
+                                    [{persistent, true},
+                                     {anonymous, false}]),
+    escalus:init_per_testcase(C, Config2);
+init_per_testcase(CaseName, Config) ->
+    start_publish_listener(Config),
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(muc_messages, Config) ->
+    muc_helper:destroy_room(Config),
+    escalus:delete_users(Config),
+    end_per_testcase(any, Config);
+end_per_testcase(CaseName, Config) ->
+    rpc(meck, unload, []),
+    escalus:end_per_testcase(CaseName, Config).
+
+
+%%--------------------------------------------------------------------
+%% GROUP presence_status_publish
+%%--------------------------------------------------------------------
+
+enable_should_fail_with_missing_attributes(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            BobJID = escalus_utils:get_jid(Bob),
+
+            escalus:send(Bob, escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"enable">>}])),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+
+            CorrectAttrs = [{<<"xmlns">>, <<"urn:xmpp:push:0">>},
+                            {<<"jid">>, BobJID},
+                            {<<"node">>, <<"NodeKey">>}],
+
+            %% Sending only one attribute should fail
+            lists:foreach(
+                fun(Attr) ->
+                    escalus:send(Bob, escalus_stanza:iq(<<"set">>,
+                                                        [#xmlel{name = <<"enable">>,
+                                                                attrs = [Attr]}])),
+                    escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                                   escalus:wait_for_stanza(Bob))
+                end, CorrectAttrs),
+
+            %% Sending all but one attribute should fail
+            lists:foreach(
+                fun(Attr) ->
+                    escalus:send(Bob, escalus_stanza:iq(<<"set">>,
+                                                        [#xmlel{name = <<"enable">>,
+                                                                attrs = CorrectAttrs -- [Attr]}])),
+                    escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                                   escalus:wait_for_stanza(Bob))
+                end, CorrectAttrs),
+
+            ok
+        end).
+
+enable_should_fail_with_invalid_attributes(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            %% Empty JID
+            escalus:send(Bob, enable_stanza(<<>>, <<"nodeId">>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+
+            %% Invalid JID
+            escalus:send(Bob, enable_stanza(<<"this_is_not_a_valid_jid">>, <<"nodeId">>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+
+            %% Empty node
+            escalus:send(Bob, enable_stanza(<<"pubsub@localhost">>, <<>>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+            ok
+        end).
+
+
+enable_should_succeed_without_form(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            escalus:send(Bob, enable_stanza(<<"pubsub@localhost">>, <<"NodeId">>)),
+            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+
+            ok
+        end).
+
+enable_with_form_should_fail_with_incorrect_from(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            escalus:send(Bob, enable_stanza(<<"pubsub@localhost">>, <<"NodeId">>, [], <<"wrong">>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+            ok
+        end).
+
+enable_should_accept_correct_from(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            escalus:send(Bob, enable_stanza(<<"pubsub@localhost">>, <<"NodeId">>, [])),
+            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+
+            escalus:send(Bob, enable_stanza(<<"pubsub@localhost">>, <<"NodeId">>, [
+                {<<"secret1">>, <<"token1">>},
+                {<<"secret2">>, <<"token2">>}
+            ])),
+            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+
+            ok
+        end).
+
+disable_should_fail_with_missing_attributes(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            BobJID = escalus_utils:get_jid(Bob),
+
+            escalus:send(Bob, escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"disable">>}])),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+
+            CorrectAttrs = [{<<"xmlns">>, <<"urn:xmpp:push:0">>}, {<<"jid">>, BobJID}],
+
+            %% Sending only one attribute should fail
+            lists:foreach(
+                fun(Attr) ->
+                    escalus:send(Bob, escalus_stanza:iq(<<"set">>,
+                                                        [#xmlel{name = <<"disable">>,
+                                                                attrs = [Attr]}])),
+                    escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                                   escalus:wait_for_stanza(Bob))
+                end, CorrectAttrs),
+            ok
+        end).
+
+disable_should_fail_with_invalid_attributes(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            %% Empty JID
+            escalus:send(Bob, disable_stanza(<<>>, <<"nodeId">>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+            escalus:send(Bob, disable_stanza(<<>>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+
+            %% Invalid JID
+            escalus:send(Bob, disable_stanza(<<"this_is_not_a_valid_jid">>, <<"nodeId">>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+            escalus:send(Bob, disable_stanza(<<"this_is_not_a_valid_jid">>)),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
+            ok
+        end).
+
+disable_all(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            escalus:send(Bob, disable_stanza(<<"pubsub@localhost">>)),
+            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+
+            ok
+        end).
+
+disable_node(Config) ->
+    escalus:story(
+        Config, [{bob, 1}],
+        fun(Bob) ->
+            escalus:send(Bob, disable_stanza(<<"pubsub@localhost">>, <<"NodeId">>)),
+            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+
+            ok
+        end).
+
+disable_stanza(JID, undefined) ->
+    disable_stanza([
+        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
+        {<<"jid">>, JID}
+    ]);
+disable_stanza(JID, Node) ->
+    disable_stanza([
+        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
+        {<<"jid">>, JID},
+        {<<"node">>, Node}
+    ]).
+disable_stanza(JID) when is_binary(JID) ->
+    disable_stanza(JID, undefined);
+disable_stanza(Attrs) when is_list(Attrs) ->
+    escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"disable">>, attrs = Attrs}]).
+
+enable_stanza(JID, Node) ->
+    enable_stanza(JID, Node, undefined).
+enable_stanza(JID, Node, FormFields) ->
+    enable_stanza(JID, Node, FormFields, ?NS_PUBSUB_PUB_OPTIONS).
+enable_stanza(JID, Node, FormFields, FormType) ->
+    escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"enable">>, attrs = [
+        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
+        {<<"jid">>, JID},
+        {<<"node">>, Node}
+    ], children = maybe_form(FormFields, FormType)}]).
+
+maybe_form(undefined, _FormType) ->
+    [];
+maybe_form(FormFields, FormType) ->
+    [make_form([{<<"FORM_TYPE">>, FormType} | FormFields])].
+
+make_form(Fields) ->
+    #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"submit">>}],
+           children = [make_form_field(Name, Value) || {Name, Value} <- Fields]}.
+
+make_form_field(Name, Value) ->
+    #xmlel{name = <<"field">>,
+           attrs = [{<<"var">>, Name}],
+           children = [#xmlcdata{content = Value}]}.
+
+%%disconnected_user_becomes_unavailable(Config) ->
+%%    escalus:story(
+%%        Config, [{bob, 1}, {alice, 1}],
+%%        fun(_Bob, _Alice) ->
+%%            %% Presences
+%%            ?assertReceivedMatch(#publish{}),
+%%            ?assertReceivedMatch(#publish{})
+%%        end),
+%%
+%%    BobJID = nick_to_jid(bob, Config),
+%%    AliceJID = nick_to_jid(alice, Config),
+%%    ?assertReceivedMatch(#publish{
+%%        message = #{<<"user_id">> := BobJID, <<"present">> := false}
+%%    }, timer:seconds(5)),
+%%    ?assertReceivedMatch(#publish{
+%%        message = #{<<"user_id">> := AliceJID, <<"present">> := false}
+%%    }, timer:seconds(5)).
+%%
+%%%%--------------------------------------------------------------------
+%%%% GROUP message_publish
+%%%%--------------------------------------------------------------------
+%%
+%%pm_messages(Config) ->
+%%    escalus:story(
+%%        Config, [{bob, 1}, {alice, 1}],
+%%        fun(Bob, Alice) ->
+%%            Topic = make_topic_arn(Config, pm_messages_topic),
+%%            BobJID = nick_to_jid(bob, Config),
+%%            AliceJID = nick_to_jid(alice, Config),
+%%
+%%            %% Presences
+%%            ?assertReceivedMatch(#publish{}),
+%%            ?assertReceivedMatch(#publish{}),
+%%
+%%            escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
+%%            ?assertReceivedMatch(#publish{
+%%                topic_arn = Topic,
+%%                message = #{<<"from_user_id">> := AliceJID,
+%%                            <<"to_user_id">> := BobJID,
+%%                            <<"message">> := <<"OH, HAI!">>}
+%%            }, timer:seconds(5)),
+%%
+%%            escalus:send(Bob, escalus_stanza:chat_to(Alice, <<"Hi there!">>)),
+%%            escalus:send(Bob, escalus_stanza:chat_to(Alice, <<"How are you?">>)),
+%%            ?assertReceivedMatch(#publish{
+%%                topic_arn = Topic,
+%%                message = #{<<"from_user_id">> := BobJID,
+%%                            <<"to_user_id">> := AliceJID,
+%%                            <<"message">> := <<"Hi there!">>}
+%%            }, timer:seconds(5)),
+%%            ?assertReceivedMatch(#publish{
+%%                topic_arn = Topic,
+%%                message = #{<<"from_user_id">> := BobJID,
+%%                            <<"to_user_id">> := AliceJID,
+%%                            <<"message">> := <<"How are you?">>}
+%%            }, timer:seconds(5)),
+%%
+%%            ok
+%%        end).
+%%
+%%muc_messages(Config) ->
+%%    escalus:story(
+%%        Config, [{bob, 1}, {alice, 1}],
+%%        fun(Bob, Alice) ->
+%%            Topic = make_topic_arn(Config, muc_messages_topic),
+%%            Room = ?config(room, Config),
+%%            RoomAddr = room_address(Room),
+%%            BobJID = nick_to_jid(bob, Config),
+%%
+%%            %% Presences
+%%            ?assertReceivedMatch(#publish{}),
+%%            ?assertReceivedMatch(#publish{}),
+%%
+%%            escalus:send(Alice, stanza_muc_enter_room(Room, nick(Alice))),
+%%            escalus:send(Bob, stanza_muc_enter_room(Room, nick(Bob))),
+%%
+%%            escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddr, <<"Hi there!">>)),
+%%
+%%            %% 2x presence, topic and message
+%%            escalus:wait_for_stanzas(Bob, 4),
+%%            escalus:wait_for_stanzas(Alice, 4),
+%%
+%%            ?assertReceivedMatch(#publish{
+%%                topic_arn = Topic,
+%%                message = #{<<"from_user_id">> := BobJID,
+%%                            <<"to_user_id">> := RoomAddr,
+%%                            <<"message">> := <<"Hi there!">>}
+%%            }, timer:seconds(5)),
+%%
+%%            ok
+%%        end).
+
+
+%%--------------------------------------------------------------------
+%% Test helpers
+%%--------------------------------------------------------------------
+
+%% @doc Forwards all erlcloud_sns:publish calls to local PID as messages
+start_publish_listener(Config) ->
+    TestCasePid = self(),
+%%    rpc(meck, new, [erlcloud_sns, [no_link, passthrough]]),
+%%    rpc(meck, expect,
+%%        [erlcloud_sns, publish,
+%%         fun(topic, RecipientArn, Message, Subject, Attributes, AWSConfig) ->
+%%             TestCasePid ! #publish{topic_arn = RecipientArn,
+%%                                    message = jiffy:decode(Message, [return_maps]),
+%%                                    subject = Subject,
+%%                                    attributes = Attributes,
+%%                                    config = AWSConfig},
+%%             uuid:uuid_to_string(uuid:get_v4())
+%%         end]),
+    Config.
+
+-spec rpc(M :: atom(), F :: atom(), A :: [term()]) -> term().
+rpc(M, F, A) ->
+    Node = ct:get_config({hosts, mim, node}),
+    Cookie = escalus_ct:get_config(ejabberd_cookie),
+    escalus_ct:rpc_call(Node, M, F, A, 10000, Cookie).
+
+make_topic_arn(Config, TopicVar) ->
+    SNSConfig = proplists:get_value(sns_config, Config),
+    string:join(["arn", "aws", "sns",
+                 proplists:get_value(region, SNSConfig),
+                 proplists:get_value(account_id, SNSConfig),
+                 proplists:get_value(TopicVar, SNSConfig)], ":").
+
+%% @doc Get a binary jid of the user, that tagged with `UserName' in the config.
+nick_to_jid(UserName, Config) when is_atom(UserName) ->
+    UserSpec = escalus_users:get_userspec(Config, UserName),
+    escalus_utils:jid_to_lower(escalus_users:get_jid(Config, UserSpec)).
+
+stanza_muc_enter_room(Room, Nick) ->
+    stanza_to_room(
+        escalus_stanza:presence(<<"available">>,
+                                [#xmlel{name = <<"x">>,
+                                        attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}
+                                ]),
+        Room, Nick).
+
+stanza_default_muc_room(Room, Nick) ->
+    Form = escalus_stanza:x_data_form(<<"submit">>, []),
+    Query = escalus_stanza:query_el(?NS_MUC_OWNER, [Form]),
+    IQSet = escalus_stanza:iq(<<"set">>, [Query]),
+    stanza_to_room(IQSet, Room, Nick).
+
+stanza_to_room(Stanza, Room) ->
+    escalus_stanza:to(Stanza, room_address(Room)).
+
+stanza_to_room(Stanza, Room, Nick) ->
+    escalus_stanza:to(Stanza, room_address(Room, Nick)).
+
+room_address(Room) ->
+    <<Room/binary, "@", ?MUC_HOST/binary>>.
+
+room_address(Room, Nick) ->
+    <<Room/binary, "@", ?MUC_HOST/binary, "/", Nick/binary>>.
+
+nick(User) -> escalus_utils:get_username(User).
+
+muc_host() ->
+    ?MUC_HOST.

--- a/test.disabled/ejabberd_tests/tests/push_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_SUITE.erl
@@ -10,7 +10,7 @@
 -define(NS_XDATA,               <<"jabber:x:data">>).
 -define(NS_PUBSUB_PUB_OPTIONS,  <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(PUSH_FORM_TYPE,         <<"urn:xmpp:push:summary">>).
--define(MUCHOST,                <<"muclight.localhost">>).
+-define(MUCHOST,                <<"muclight.@HOST@">>).
 
 -define(PUSH_OPTS,
     [
@@ -25,7 +25,6 @@
 -import(escalus_ejabberd, [rpc/3]).
 
 -record(route, {from, to, packet}).
--define(PUBSUB_JID, <<"pubsub@", (atom_to_binary(?FUNCTION_NAME, utf8))/binary>>).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -97,6 +96,7 @@ init_per_group(muclight_msg_notifications, Config) ->
                           [{host, binary_to_list(?MUCHOST)},
                            {backend, mnesia},
                            {rooms_in_rosters, true}]),
+    rpc(mod_muc_light_db_backend, force_clear, []),
     Config;
 init_per_group(_, Config0) ->
     Config = [{push_config, ?PUSH_OPTS} | Config0],
@@ -105,7 +105,7 @@ init_per_group(_, Config0) ->
     Config.
 
 end_per_group(disco, Config) ->
-    escalus:delete_users(Config, escalus:get_users([alice]));
+    Config;
 end_per_group(muclight_msg_notifications, _Config) ->
     Host = ct:get_config({hosts, mim, domain}),
     dynamic_modules:stop(Host, mod_push),
@@ -113,7 +113,7 @@ end_per_group(muclight_msg_notifications, _Config) ->
 end_per_group(_, Config) ->
     Host = ct:get_config({hosts, mim, domain}),
     dynamic_modules:stop(Host, mod_push),
-    escalus:delete_users(Config, escalus:get_users([bob, alice])).
+    Config.
 
 init_per_testcase(CaseName = push_notifications_listed_disco_when_available, Config) ->
     Host = ct:get_config({hosts, mim, domain}),
@@ -123,8 +123,8 @@ init_per_testcase(CaseName = push_notifications_not_listed_disco_when_not_availa
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config0) ->
     start_publish_listener(CaseName, Config0),
-    rpc(mod_muc_light_db_backend, force_clear, []),
-    Config = escalus_fresh:create_users(Config0, [{bob, 1}, {alice, 1}, {kate, 1}]),
+    Config1 = escalus_fresh:create_users(Config0, [{bob, 1}, {alice, 1}, {kate, 1}]),
+    Config = [{case_name, CaseName} | Config1],
     escalus:init_per_testcase(CaseName, Config).
 
 
@@ -135,7 +135,6 @@ end_per_testcase(CaseName = push_notifications_listed_disco_when_available, Conf
 end_per_testcase(CaseName = push_notifications_not_listed_disco_when_not_available, Config) ->
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName, Config) ->
-    escalus:delete_users(Config),
     rpc(ejabberd_router, unregister_route, [atom_to_binary(CaseName, utf8)]),
     escalus:end_per_testcase(CaseName, Config).
 
@@ -213,6 +212,8 @@ enable_should_fail_with_invalid_attributes(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Bob) ->
+            PubsubJID = pubsub_jid(Config),
+
             %% Empty JID
             escalus:send(Bob, enable_stanza(<<>>, <<"nodeId">>)),
             escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
@@ -224,7 +225,7 @@ enable_should_fail_with_invalid_attributes(Config) ->
                            escalus:wait_for_stanza(Bob)),
 
             %% Empty node
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<>>)),
+            escalus:send(Bob, enable_stanza(PubsubJID, <<>>)),
             escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
                            escalus:wait_for_stanza(Bob)),
             ok
@@ -235,7 +236,9 @@ enable_should_succeed_without_form(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Bob) ->
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
 
             ok
@@ -245,7 +248,9 @@ enable_with_form_should_fail_with_incorrect_from(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Bob) ->
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>, [], <<"wrong">>)),
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [], <<"wrong">>)),
             escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
                            escalus:wait_for_stanza(Bob)),
             ok
@@ -255,10 +260,12 @@ enable_should_accept_correct_from(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Bob) ->
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>, [])),
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [])),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
 
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>, [
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [
                 {<<"secret1">>, <<"token1">>},
                 {<<"secret2">>, <<"token2">>}
             ])),
@@ -317,7 +324,9 @@ disable_all(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Bob) ->
-            escalus:send(Bob, disable_stanza(?PUBSUB_JID)),
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, disable_stanza(PubsubJID)),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
 
             ok
@@ -327,7 +336,9 @@ disable_node(Config) ->
     escalus:story(
         Config, [{bob, 1}],
         fun(Bob) ->
-            escalus:send(Bob, disable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, disable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
 
             ok
@@ -341,7 +352,7 @@ pm_no_msg_notifications_if_not_enabled(Config) ->
     escalus:story(
         Config, [{bob, 1}, {alice, 1}],
         fun(Bob, Alice) ->
-            escalus:send(Bob, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Bob),
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
 
             ?assert(not truly(received_route())),
@@ -352,7 +363,9 @@ pm_no_msg_notifications_if_user_online(Config) ->
     escalus:story(
         Config, [{bob, 1}, {alice, 1}],
         fun(Bob, Alice) ->
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
@@ -365,24 +378,24 @@ pm_msg_notify_if_user_offline(Config) ->
     escalus:story(
         Config, [{bob, 1}, {alice, 1}],
         fun(Bob, Alice) ->
-            ToPubsubJID = ?PUBSUB_JID,
+            PubsubJID = pubsub_jid(Config),
+
             AliceJID = bare_jid(Alice),
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
-            escalus:send(Bob, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Bob),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = PubsubJID, packet = Packet} = Published,
-            ?assertMatch(ToPubsubJID, rpc(jid, to_binary, [PubsubJID])),
+            #route{to = RealPubsubJID, packet = Packet} = Published,
+            ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                              {element, <<"publish">>},
                                              {element, <<"item">>},
                                              {element, <<"notification">>},
                                              {element, <<"x">>}]),
-            ct:pal("OMG ~p", [Form]),
             Fields = parse_form(Form),
             ?assertMatch(?PUSH_FORM_TYPE, proplists:get_value(<<"FORM_TYPE">>, Fields)),
             ?assertMatch(<<"OH, HAI!">>, proplists:get_value(<<"last-message-body">>, Fields)),
@@ -396,19 +409,20 @@ pm_msg_notify_if_user_offline_with_publish_options(Config) ->
     escalus:story(
         Config, [{bob, 1}, {alice, 1}],
         fun(Bob, Alice) ->
-            ToPubsubJID = ?PUBSUB_JID,
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>,
+            PubsubJID = pubsub_jid(Config),
+
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>,
                                             [{<<"field1">>, <<"value1">>},
                                              {<<"field2">>, <<"value2">>}])),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
-            escalus:send(Bob, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Bob),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = PubsubJID, packet = Packet} = Published,
-            ?assertMatch(ToPubsubJID, rpc(jid, to_binary, [PubsubJID])),
+            #route{to = RealPubsubJID, packet = Packet} = Published,
+            ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                             {element, <<"publish-options">>},
                                             {element, <<"x">>}]),
@@ -423,14 +437,16 @@ pm_msg_notify_stops_after_disabling(Config) ->
     escalus:story(
         Config, [{bob, 1}, {alice, 1}],
         fun(Bob, Alice) ->
+            PubsubJID = pubsub_jid(Config),
+
             %% Enable
-            escalus:send(Bob, enable_stanza(?PUBSUB_JID, <<"NodeId">>, [])),
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [])),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
-            escalus:send(Bob, escalus_stanza:presence(<<"unavailable">>)),
 
             %% Disable
-            escalus:send(Bob, disable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            escalus:send(Bob, disable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            become_unavailable(Bob),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
 
@@ -447,10 +463,10 @@ muclight_no_msg_notifications_if_not_enabled(Config) ->
     escalus:story(
         Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(Alice, Bob, Kate) ->
-            Room = atom_to_binary(?FUNCTION_NAME, utf8),
+            Room = room_name(Config),
             create_room(Room, [bob, alice, kate], Config),
-            escalus:send(Alice, escalus_stanza:presence(<<"unavailable">>)),
-            escalus:send(Kate, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Alice),
+            become_unavailable(Kate),
 
             Msg = <<"Heyah!">>,
             Stanza = escalus_stanza:groupchat_to(room_bin_jid(Room), Msg),
@@ -466,11 +482,13 @@ muclight_no_msg_notifications_if_user_online(Config) ->
     escalus:story(
         Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(Alice, Bob, Kate) ->
-            Room = atom_to_binary(?FUNCTION_NAME, utf8),
+            Room = room_name(Config),
+            PubsubJID = pubsub_jid(Config),
+
             create_room(Room, [bob, alice, kate], Config),
-            escalus:send(Alice, enable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
-            escalus:send(Kate, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Kate),
 
             Msg = <<"Heyah!">>,
             Stanza = escalus_stanza:groupchat_to(room_bin_jid(Room), Msg),
@@ -484,13 +502,14 @@ muclight_msg_notify_if_user_offline(Config) ->
     escalus:story(
         Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(Alice, Bob, _Kate) ->
-            ToPubsubJID = ?PUBSUB_JID,
-            Room = atom_to_binary(?FUNCTION_NAME, utf8),
+            PubsubJID = pubsub_jid(Config),
+            Room = room_name(Config),
             BobJID = bare_jid(Bob),
+
             create_room(Room, [bob, alice, kate], Config),
-            escalus:send(Alice, enable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
-            escalus:send(Alice, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Alice),
 
             Msg = <<"Heyah!">>,
             Stanza = escalus_stanza:groupchat_to(room_bin_jid(Room), Msg),
@@ -498,8 +517,8 @@ muclight_msg_notify_if_user_offline(Config) ->
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = PubsubJID, packet = Packet} = Published,
-            ?assertMatch(ToPubsubJID, rpc(jid, to_binary, [PubsubJID])),
+            #route{to = RealPubsubJID, packet = Packet} = Published,
+            ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                             {element, <<"publish">>},
                                             {element, <<"item">>},
@@ -508,7 +527,7 @@ muclight_msg_notify_if_user_offline(Config) ->
             Fields = parse_form(Form),
             ?assertMatch(?PUSH_FORM_TYPE, proplists:get_value(<<"FORM_TYPE">>, Fields)),
             ?assertMatch(Msg, proplists:get_value(<<"last-message-body">>, Fields)),
-            SenderId = <<BobJID/binary, " (room: ", Room/binary, ")">>,
+            SenderId = <<(room_bin_jid(Room))/binary, "/" ,BobJID/binary>>,
             ?assertMatch(SenderId,
                          proplists:get_value(<<"last-message-sender">>, Fields)),
             ok
@@ -518,14 +537,15 @@ muclight_msg_notify_if_user_offline_with_publish_options(Config) ->
     escalus:story(
         Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(Alice, Bob, _Kate) ->
-            ToPubsubJID = ?PUBSUB_JID,
-            Room = atom_to_binary(?FUNCTION_NAME, utf8),
+            PubsubJID = pubsub_jid(Config),
+            Room = room_name(Config),
+
             create_room(Room, [bob, alice, kate], Config),
-            escalus:send(Alice, enable_stanza(?PUBSUB_JID, <<"NodeId">>,
+            escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>,
                                             [{<<"field1">>, <<"value1">>},
                                              {<<"field2">>, <<"value2">>}])),
             escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
-            escalus:send(Alice, escalus_stanza:presence(<<"unavailable">>)),
+            become_unavailable(Alice),
 
             Msg = <<"Heyah!">>,
             Stanza = escalus_stanza:groupchat_to(room_bin_jid(Room), Msg),
@@ -533,8 +553,8 @@ muclight_msg_notify_if_user_offline_with_publish_options(Config) ->
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = PubsubJID, packet = Packet} = Published,
-            ?assertMatch(ToPubsubJID, rpc(jid, to_binary, [PubsubJID])),
+            #route{to = RealPubsubJID, packet = Packet} = Published,
+            ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                             {element, <<"publish-options">>},
                                             {element, <<"x">>}]),
@@ -549,17 +569,18 @@ muclight_msg_notify_stops_after_disabling(Config) ->
     escalus:story(
         Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(Alice, Bob, _Kate) ->
-            Room = atom_to_binary(?FUNCTION_NAME, utf8),
+            Room = room_name(Config),
+            PubsubJID = pubsub_jid(Config),
             create_room(Room, [bob, alice, kate], Config),
 
             %% Enable
-            escalus:send(Alice, enable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
-            escalus:send(Alice, escalus_stanza:presence(<<"unavailable">>)),
 
             %% Disable
-            escalus:send(Alice, disable_stanza(?PUBSUB_JID, <<"NodeId">>)),
+            escalus:send(Alice, disable_stanza(PubsubJID, <<"NodeId">>)),
             escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            become_unavailable(Alice),
 
             Msg = <<"Heyah!">>,
             Stanza = escalus_stanza:groupchat_to(room_bin_jid(Room), Msg),
@@ -636,13 +657,13 @@ parse_form(Fields) when is_list(Fields) ->
 
 start_publish_listener(CaseName, Config) ->
     TestCasePid = self(),
-    RouteFun = fun(From, To, Packet) ->
-                    TestCasePid ! #route{from = From, to = To, packet = Packet}
-               end,
-    ok = rpc(ejabberd_router, register_route, [atom_to_binary(CaseName, utf8),
-                                               {apply_fun, RouteFun}]),
+    Handler = rpc(mongoose_packet_handler, new, [?MODULE, TestCasePid]),
+    ok = rpc(ejabberd_router, register_route, [atom_to_binary(CaseName, utf8), Handler]),
 
     Config.
+
+process_packet(From, To, Packet, TestCasePid) ->
+    TestCasePid ! #route{from = From, to = To, packet = Packet}.
 
 create_room(Room, [Owner | Members], Config) ->
     Domain = ct:get_config({hosts, mim, domain}),
@@ -667,3 +688,40 @@ truly(_) ->
 bare_jid(JIDOrClient) ->
     ShortJID = escalus_client:short_jid(JIDOrClient),
     list_to_binary(string:to_lower(binary_to_list(ShortJID))).
+
+pubsub_jid(Config) ->
+    CaseName = proplists:get_value(case_name, Config),
+    <<"pubsub@", (atom_to_binary(CaseName, utf8))/binary>>.
+
+room_name(Config) ->
+    CaseName = proplists:get_value(case_name, Config),
+    <<"room_", (atom_to_binary(CaseName, utf8))/binary>>.
+
+is_offline(LUser, LServer) ->
+    case catch lists:max(rpc(ejabberd_sm, get_user_present_pids, [LUser, LServer])) of
+        {Priority, _} when is_integer(Priority), Priority >= 0 ->
+            false;
+        _ ->
+            true
+    end.
+
+become_unavailable(Client) ->
+    escalus:send(Client, escalus_stanza:presence(<<"unavailable">>)),
+    ok = wait_for(timer:seconds(20), fun() ->
+        is_offline(lower(escalus_client:username(Client)), lower(escalus_client:server(Client)))
+    end). %% There is no ACK for unavailable status
+
+wait_for(TimeLeft, _Fun) when TimeLeft < 0 ->
+    timeout;
+wait_for(TimeLeft, Fun) ->
+    Step = 500,
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(Step),
+            wait_for(TimeLeft - Step, Fun)
+    end.
+
+lower(Bin) when is_binary(Bin) ->
+    list_to_binary(string:to_lower(binary_to_list(Bin))).

--- a/test.disabled/ejabberd_tests/tests/push_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_SUITE.erl
@@ -647,7 +647,7 @@ make_form(Fields) ->
 make_form_field(Name, Value) ->
     #xmlel{name = <<"field">>,
            attrs = [{<<"var">>, Name}],
-           children = [#xmlcdata{content = Value}]}.
+           children = [#xmlel{name = <<"value">>, children = [#xmlcdata{content = Value}]}]}.
 
 
 
@@ -660,7 +660,8 @@ parse_form(#xmlel{name = <<"x">>} = Form) ->
 parse_form(Fields) when is_list(Fields) ->
     lists:map(
         fun(Field) ->
-            {exml_query:attr(Field, <<"var">>), exml_query:cdata(Field)}
+            {exml_query:attr(Field, <<"var">>),
+             exml_query:path(Field, [{element, <<"value">>, cdata}])}
         end, Fields).
 
 %% @doc Forwards all erlcloud_sns:publish calls to local PID as messages


### PR DESCRIPTION
This PR features XEP-0357 implementation. All needed informations can be found in `mod_push.md`. Right now only PM and MUCLight messages are supported. 
Also pleas note that this code requires a custom PubSub node that will handle notifications from this module and pass them to external Push Notifications Service.

Tis PR also adds `worker_pool` as pooler used in `mod_push`. This pooler is faster and more configurable than others like `poolboy`. There are several pending PRs that use this pooler, so maybe someday we are gonna switch fully to `worker_pool`. 
