### PR TITLE
Replace all tabs with spaces.

### DIFF
--- a/apps/ejabberd/src/cyrsasl_digest.erl
+++ b/apps/ejabberd/src/cyrsasl_digest.erl
@@ -232,26 +232,23 @@ response(KeyVals, User, Passwd, Nonce, AuthzId, A2Prefix) ->
     NC = xml:get_attr_s(<<"nc">>, KeyVals),
     QOP = xml:get_attr_s(<<"qop">>, KeyVals),
     A1 = case AuthzId of
-	     <<>> ->
-		 list_to_binary(
-		   [crypto:hash(md5, [User, <<":">>, Realm, <<":">>, Passwd]),
-		     <<":">>, Nonce, <<":">>, CNonce]);
-	     _ ->
-		 list_to_binary(
-		   [crypto:hash(md5, [User, <<":">>, Realm, <<":">>, Passwd]),
-		     <<":">>, Nonce, <<":">>, CNonce, <<":">>, AuthzId])
-	 end,
+             <<>> ->
+                 list_to_binary(
+                   [crypto:hash(md5, [User, <<":">>, Realm, <<":">>, Passwd]),
+                     <<":">>, Nonce, <<":">>, CNonce]);
+             _ ->
+                 list_to_binary(
+                   [crypto:hash(md5, [User, <<":">>, Realm, <<":">>, Passwd]),
+                     <<":">>, Nonce, <<":">>, CNonce, <<":">>, AuthzId])
+         end,
     A2 = case QOP of
-	     <<"auth">> ->
-		 [A2Prefix, <<":">>, DigestURI];
-	     _ ->
-		 [A2Prefix, <<":">>, DigestURI,
-		     <<":00000000000000000000000000000000">>]
-	 end,
+             <<"auth">> ->
+                 [A2Prefix, <<":">>, DigestURI];
+             _ ->
+                 [A2Prefix, <<":">>, DigestURI,
+                     <<":00000000000000000000000000000000">>]
+         end,
     T = [hex(crypto:hash(md5, A1)), <<":">>, Nonce, <<":">>,
-	NC, <<":">>, CNonce, <<":">>, QOP, <<":">>,
-	hex(crypto:hash(md5, A2))],
+        NC, <<":">>, CNonce, <<":">>, QOP, <<":">>,
+        hex(crypto:hash(md5, A2))],
     hex(crypto:hash(md5, T)).
-
-
-

--- a/apps/ejabberd/src/ejabberd_auth_internal.erl
+++ b/apps/ejabberd/src/ejabberd_auth_internal.erl
@@ -81,8 +81,8 @@ start(Host) ->
                                   [{ets, [{read_concurrency, true}]}]}
                                   ]),
     mnesia:create_table(reg_users_counter,
-			[{ram_copies, [node()]},
-			 {attributes, record_info(fields, reg_users_counter)}]),
+                        [{ram_copies, [node()]},
+                         {attributes, record_info(fields, reg_users_counter)}]),
     mnesia:add_table_copy(passwd, node(), disc_copies),
     mnesia:add_table_copy(reg_users_counter, node(), ram_copies),
     update_reg_users_counter_table(Host),
@@ -136,10 +136,10 @@ check_password(LUser, LServer, Password) ->
 check_password(LUser, LServer, Password, Digest, DigestGen) ->
     US = {LUser, LServer},
     case catch dirty_read_passwd(US) of
-	[#passwd{password = Scram}] when is_record(Scram, scram) ->
+        [#passwd{password = Scram}] when is_record(Scram, scram) ->
             Passwd = base64:decode(Scram#scram.storedkey),
             ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
-	[#passwd{password = Passwd}] ->
+        [#passwd{password = Passwd}] ->
             ejabberd_auth:check_digest(Digest, DigestGen, Password, Passwd);
         _ ->
             false
@@ -207,8 +207,8 @@ get_vh_registered_users(LServer) ->
     mnesia:dirty_select(
       passwd,
       [{#passwd{us = '$1', _ = '_'},
-	[{'==', {element, 2, '$1'}, LServer}],
-	['$1']}]).
+        [{'==', {element, 2, '$1'}, LServer}],
+        ['$1']}]).
 
 
 -type query_keyword() :: from | to | limit | offset | prefix.
@@ -291,15 +291,15 @@ get_vh_registered_users_number(LServer, _) ->
 get_password(LUser, LServer) ->
     US = {LUser, LServer},
     case catch dirty_read_passwd(US) of
-	[#passwd{password = Scram}] when is_record(Scram, scram) ->
-	    {base64:decode(Scram#scram.storedkey),
-	     base64:decode(Scram#scram.serverkey),
-	     base64:decode(Scram#scram.salt),
-	     Scram#scram.iterationcount};
-	[#passwd{password = Password}] ->
-	    Password;
-	_ ->
-	    false
+        [#passwd{password = Scram}] when is_record(Scram, scram) ->
+            {base64:decode(Scram#scram.storedkey),
+             base64:decode(Scram#scram.serverkey),
+             base64:decode(Scram#scram.salt),
+             Scram#scram.iterationcount};
+        [#passwd{password = Password}] ->
+            Password;
+        _ ->
+            false
     end.
 
 -spec get_password_s(LUser :: ejabberd:luser(),
@@ -307,12 +307,12 @@ get_password(LUser, LServer) ->
 get_password_s(LUser, LServer) ->
     US = {LUser, LServer},
     case catch dirty_read_passwd(US) of
-	[#passwd{password = Scram}] when is_record(Scram, scram) ->
-	    <<"">>;
-	[#passwd{password = Password}] ->
-	    Password;
-	_ ->
-	    <<"">>
+        [#passwd{password = Scram}] when is_record(Scram, scram) ->
+            <<"">>;
+        [#passwd{password = Password}] ->
+            Password;
+        _ ->
+            <<"">>
     end.
 
 -spec does_user_exist(LUser :: ejabberd:luser(),
@@ -412,4 +412,3 @@ write_passwd(#passwd{} = Passwd) ->
 -spec write_counter(users_counter()) -> ok.
 write_counter(#reg_users_counter{} = Counter) ->
     mnesia:write(Counter).
-

--- a/apps/ejabberd/src/ejabberd_commands.erl
+++ b/apps/ejabberd/src/ejabberd_commands.erl
@@ -431,7 +431,7 @@ check_auth({User, Server, Password}) ->
 -spec get_md5(iodata()) -> string().
 get_md5(AccountPass) ->
     lists:flatten([io_lib:format("~.16B", [X])
-		           || X <- binary_to_list(crypto:hash(md5, AccountPass))]).
+                   || X <- binary_to_list(crypto:hash(md5, AccountPass))]).
 
 
 -spec check_access(Access :: acl:rule(), Auth :: auth()) -> boolean().

--- a/apps/ejabberd/src/ejabberd_ctl.erl
+++ b/apps/ejabberd/src/ejabberd_ctl.erl
@@ -306,24 +306,24 @@ call_command([CmdString | Args], Auth, AccessCommands) ->
     CmdStringU = re:replace(CmdString, "-", "_", [global, {return, list}]),
     Command = list_to_atom(CmdStringU),
     case ejabberd_commands:get_command_format(Command) of
-	{error, command_unknown} ->
-	    {error, command_unknown};
-	{ArgsFormat, ResultFormat} ->
-	    case (catch format_args(Args, ArgsFormat)) of
-		ArgsFormatted when is_list(ArgsFormatted) ->
-		    Result = ejabberd_commands:execute_command(AccessCommands, Auth, Command,
-							       ArgsFormatted),
-		    format_result(Result, ResultFormat);
-		{'EXIT', {function_clause, [{lists, zip, [A1, A2], _FileInfo} | _]}} ->
-		    {NumCompa, TextCompa} =
-			case {length(A1), length(A2)} of
-			    {L1, L2} when L1 < L2 -> {L2-L1, "less argument"};
-			    {L1, L2} when L1 > L2 -> {L1-L2, "more argument"}
-			end,
-		    {io_lib:format("Error: the command ~p requires ~p ~s.",
-				   [CmdString, NumCompa, TextCompa]),
-		     wrong_command_arguments}
-	    end
+        {error, command_unknown} ->
+            {error, command_unknown};
+        {ArgsFormat, ResultFormat} ->
+            case (catch format_args(Args, ArgsFormat)) of
+                ArgsFormatted when is_list(ArgsFormatted) ->
+                    Result = ejabberd_commands:execute_command(AccessCommands, Auth, Command,
+                                                               ArgsFormatted),
+                    format_result(Result, ResultFormat);
+                {'EXIT', {function_clause, [{lists, zip, [A1, A2], _FileInfo} | _]}} ->
+                    {NumCompa, TextCompa} =
+                        case {length(A1), length(A2)} of
+                            {L1, L2} when L1 < L2 -> {L2-L1, "less argument"};
+                            {L1, L2} when L1 > L2 -> {L1-L2, "more argument"}
+                        end,
+                    {io_lib:format("Error: the command ~p requires ~p ~s.",
+                                   [CmdString, NumCompa, TextCompa]),
+                     wrong_command_arguments}
+            end
     end.
 
 

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -187,17 +187,17 @@ init([From, Server, Type]) ->
           end,
     UseV10 = TLS,
     TLSOpts = case ejabberd_config:get_local_option(s2s_certfile) of
-		  undefined ->
-		      [connect];
-		  CertFile ->
-		      [{certfile, CertFile}, connect]
-	      end,
+                  undefined ->
+                      [connect];
+                  CertFile ->
+                      [{certfile, CertFile}, connect]
+              end,
     TLSOpts2 = case ejabberd_config:get_local_option(s2s_ciphers) of
-		       undefined ->
-			       TLSOpts;
-		       Ciphers ->
-			       [{ciphers, Ciphers} | TLSOpts]
-	       end,
+                       undefined ->
+                               TLSOpts;
+                       Ciphers ->
+                               [{ciphers, Ciphers} | TLSOpts]
+               end,
     {New, Verify} = case Type of
                         new ->
                             {true, false};
@@ -207,15 +207,15 @@ init([From, Server, Type]) ->
                     end,
     Timer = erlang:start_timer(?S2STIMEOUT, self(), []),
     {ok, open_socket, #state{use_v10 = UseV10,
-			     tls = TLS,
-			     tls_required = TLSRequired,
-			     tls_options = TLSOpts2,
-			     queue = queue:new(),
-			     myname = From,
-			     server = Server,
-			     new = New,
-			     verify = Verify,
-			     timer = Timer}}.
+                             tls = TLS,
+                             tls_required = TLSRequired,
+                             tls_options = TLSOpts2,
+                             queue = queue:new(),
+                             myname = From,
+                             server = Server,
+                             new = New,
+                             verify = Verify,
+                             timer = Timer}}.
 
 %%----------------------------------------------------------------------
 %% Func: StateName/2
@@ -649,53 +649,53 @@ wait_for_auth_result(closed, StateData) ->
 -spec wait_for_starttls_proceed(ejabberd:xml_stream_item(), state()) -> fsm_return().
 wait_for_starttls_proceed({xmlstreamelement, El}, StateData) ->
     case El of
-	#xmlel{name = <<"proceed">>, attrs = Attrs} ->
-	    case xml:get_attr_s(<<"xmlns">>, Attrs) of
-		?NS_TLS ->
-		    ?DEBUG("starttls: ~p", [{StateData#state.myname,
-					     StateData#state.server}]),
-		    Socket = StateData#state.socket,
-		    TLSOpts = case ejabberd_config:get_local_option(
-				     {domain_certfile,
-				      binary_to_list(StateData#state.myname)}) of
-				  undefined ->
-				      StateData#state.tls_options;
-				  CertFile ->
-				      [{certfile, CertFile} |
-				       lists:keydelete(
-					 certfile, 1,
-					 StateData#state.tls_options)]
-			      end,
-		    TLSOpts2 = case ejabberd_config:get_local_option(s2s_ciphers) of
-				       undefined ->
-					       TLSOpts;
-				       Ciphers ->
-					       [{ciphers, Ciphers} | TLSOpts]
-			       end,
-		    TLSSocket = ejabberd_socket:starttls(Socket, TLSOpts2),
-		    NewStateData = StateData#state{socket = TLSSocket,
-						   streamid = new_id(),
-						   tls_enabled = true,
-						   tls_options = TLSOpts2
-						  },
-		    send_text(NewStateData,
+        #xmlel{name = <<"proceed">>, attrs = Attrs} ->
+            case xml:get_attr_s(<<"xmlns">>, Attrs) of
+                ?NS_TLS ->
+                    ?DEBUG("starttls: ~p", [{StateData#state.myname,
+                                             StateData#state.server}]),
+                    Socket = StateData#state.socket,
+                    TLSOpts = case ejabberd_config:get_local_option(
+                                     {domain_certfile,
+                                      binary_to_list(StateData#state.myname)}) of
+                                  undefined ->
+                                      StateData#state.tls_options;
+                                  CertFile ->
+                                      [{certfile, CertFile} |
+                                       lists:keydelete(
+                                         certfile, 1,
+                                         StateData#state.tls_options)]
+                              end,
+                    TLSOpts2 = case ejabberd_config:get_local_option(s2s_ciphers) of
+                                       undefined ->
+                                               TLSOpts;
+                                       Ciphers ->
+                                               [{ciphers, Ciphers} | TLSOpts]
+                               end,
+                    TLSSocket = ejabberd_socket:starttls(Socket, TLSOpts2),
+                    NewStateData = StateData#state{socket = TLSSocket,
+                                                   streamid = new_id(),
+                                                   tls_enabled = true,
+                                                   tls_options = TLSOpts2
+                                                  },
+                    send_text(NewStateData,
                       list_to_binary(
                         io_lib:format(?STREAM_HEADER,
                                       [StateData#state.myname, StateData#state.server,
                                        <<" version='1.0'">>]))),
-		    {next_state, wait_for_stream, NewStateData, ?FSMTIMEOUT};
-		_ ->
-		    send_text(StateData,
-			      <<(exml:to_binary(?SERR_BAD_FORMAT))/binary,
-			      (?STREAM_TRAILER)/binary>>),
-		    ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-			      [StateData#state.myname, StateData#state.server]),
-		    {stop, normal, StateData}
-	    end;
-	_ ->
-	    ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-		      [StateData#state.myname, StateData#state.server]),
-	    {stop, normal, StateData}
+                    {next_state, wait_for_stream, NewStateData, ?FSMTIMEOUT};
+                _ ->
+                    send_text(StateData,
+                              <<(exml:to_binary(?SERR_BAD_FORMAT))/binary,
+                              (?STREAM_TRAILER)/binary>>),
+                    ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
+                              [StateData#state.myname, StateData#state.server]),
+                    {stop, normal, StateData}
+            end;
+        _ ->
+            ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
+                      [StateData#state.myname, StateData#state.server]),
+            {stop, normal, StateData}
     end;
 wait_for_starttls_proceed({xmlstreamend, _Name}, StateData) ->
     ?INFO_MSG("wait for starttls proceed: xmlstreamend", []),

--- a/apps/ejabberd/src/ejabberd_socket.erl
+++ b/apps/ejabberd/src/ejabberd_socket.erl
@@ -175,9 +175,9 @@ starttls(SocketData, TLSOpts, Data) ->
 -spec compress(socket_state(), integer(), _) -> socket_state().
 compress(SocketData, InflateSizeLimit, Data) ->
     {ok, ZlibSocket} = ejabberd_zlib:enable_zlib(
-			 SocketData#socket_state.sockmod,
-			 SocketData#socket_state.socket,
-			 InflateSizeLimit),
+                         SocketData#socket_state.sockmod,
+                         SocketData#socket_state.socket,
+                         InflateSizeLimit),
     ejabberd_receiver:compress(SocketData#socket_state.receiver, ZlibSocket),
     send(SocketData, Data),
     SocketData#socket_state{socket = ZlibSocket, sockmod = ejabberd_zlib}.

--- a/apps/ejabberd/src/ejabberd_tmp_sup.erl
+++ b/apps/ejabberd/src/ejabberd_tmp_sup.erl
@@ -35,5 +35,5 @@ start_link(Name, Module) ->
 
 init(Module) ->
     {ok, {{simple_one_for_one, 10, 1},
-	  [{undefined, {Module, start_link, []},
-	    temporary, brutal_kill, worker, [Module]}]}}.
+          [{undefined, {Module, start_link, []},
+            temporary, brutal_kill, worker, [Module]}]}}.

--- a/apps/ejabberd/src/ejabberd_zlib.erl
+++ b/apps/ejabberd/src/ejabberd_zlib.erl
@@ -45,10 +45,10 @@
 -spec enable_zlib(ejabberd:sockmod(), zlibsock(), integer()) -> {ok, zlibsock()}.
 enable_zlib(SockMod, Socket, InflateSizeLimit) ->
     case erl_ddll:load_driver(ejabberd:get_so_path(), ejabberd_zlib_drv) of
-	ok -> ok;
-	{error, already_loaded} -> ok;
-	{error, OtherError} ->
-	    erlang:error({cannot_load_ejabberd_zlib_drv, erl_ddll:format_error(OtherError)})
+        ok -> ok;
+        {error, already_loaded} -> ok;
+        {error, OtherError} ->
+            erlang:error({cannot_load_ejabberd_zlib_drv, erl_ddll:format_error(OtherError)})
     end,
     Port = open_port({spawn_driver, "ejabberd_zlib_drv"}, [binary]),
     {ok, #zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port,
@@ -84,23 +84,23 @@ recv_data2(ZlibSock, Packet) ->
 -spec recv_data1(zlibsock(), iolist()) -> {'error', string()} | {'ok', binary()}.
 recv_data1(#zlibsock{zlibport = Port, inflate_size_limit = SizeLimit} = _ZlibSock, Packet) ->
     case port_control(Port, SizeLimit bsl 2 + ?INFLATE, Packet) of
-	<<0, In/binary>> ->
-	    {ok, In};
-	<<1, Error/binary>> ->
-	    {error, erlang:binary_to_existing_atom(Error, utf8)}
+        <<0, In/binary>> ->
+            {ok, In};
+        <<1, Error/binary>> ->
+            {error, erlang:binary_to_existing_atom(Error, utf8)}
     end.
 
 -spec send(zlibsock(), iolist()) -> ok | {error, string()}.
 send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of
-	<<0, Out/binary>> ->
+        <<0, Out/binary>> ->
         mongoose_metrics:update(global, [data, xmpp, sent, compressed_size], size(Out)),
-	    SockMod:send(Socket, Out);
-	<<1, Error/binary>> ->
-	    {error, erlang:binary_to_existing_atom(Error, utf8)};
-	_ ->
-	    {error, deflate_error}
+            SockMod:send(Socket, Out);
+        <<1, Error/binary>> ->
+            {error, erlang:binary_to_existing_atom(Error, utf8)};
+        _ ->
+            {error, deflate_error}
     end.
 
 
@@ -137,5 +137,3 @@ controlling_process(#zlibsock{sockmod = SockMod, socket = Socket}, Pid) ->
 close(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port}) ->
     SockMod:close(Socket),
     port_close(Port).
-
-

--- a/apps/ejabberd/src/eldap.erl
+++ b/apps/ejabberd/src/eldap.erl
@@ -153,7 +153,7 @@
          passwd = <<"">>         :: binary(),
          id = 0                  :: non_neg_integer(),
          bind_timer = make_ref() :: reference(),
-	     dict = dict:new()       :: dict:dict(),
+         dict = dict:new()       :: dict:dict(),
          req_q = queue:new()     :: queue:queue()}).
 
 -type eldap() :: #eldap{}.
@@ -912,10 +912,10 @@ gen_req({modify_dn, Entry, NewRDN, DelOldRDN,
                         deleteoldrdn = DelOldRDN, newSuperior = NewSup}};
 gen_req({modify_passwd, DN, Passwd}) ->
     {ok, ReqVal} = 'ELDAPv3':encode(
-				 'PasswdModifyRequestValue',
-				 #'PasswdModifyRequestValue'{userIdentity = DN,
-							     newPasswd =
-								 Passwd}),
+                                'PasswdModifyRequestValue',
+                                #'PasswdModifyRequestValue'{userIdentity = DN,
+                                                            newPasswd =
+                                                                Passwd}),
     {extendedReq,
      #'ExtendedRequest'{requestName = ?passwdModifyOID,
                         requestValue = iolist_to_binary(ReqVal)}};

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -847,7 +847,7 @@ stream_errort(Condition, Lang, Text) ->
 remove_delay_tags(#xmlel{children = Els} = Packet) ->
     NEl = lists:foldl(
              fun(#xmlel{name= <<"delay">>, attrs = Attrs} = R, El)->
-			      case xml:get_attr_s(<<"xmlns">>, Attrs) of
+                              case xml:get_attr_s(<<"xmlns">>, Attrs) of
                                   ?NS_DELAY ->
                                       El;
                                   _ ->

--- a/apps/ejabberd/src/mod_admin_extra_vcard.erl
+++ b/apps/ejabberd/src/mod_admin_extra_vcard.erl
@@ -50,21 +50,21 @@
 -spec commands() -> [ejabberd_commands:cmd(), ...].
 commands() ->
     Vcard1FieldsString = "Some vcard field names in get/set_vcard are:\n"
-                         " FN		- Full Name\n"
-                         " NICKNAME	- Nickname\n"
-                         " BDAY		- Birthday\n"
-                         " TITLE		- Work: Position\n"
-                         " ROLE		- Work: Role",
+                         " FN\t\t- Full Name\n"
+                         " NICKNAME\t- Nickname\n"
+                         " BDAY\t\t- Birthday\n"
+                         " TITLE\t\t- Work: Position\n"
+                         " ROLE\t\t- Work: Role",
 
     Vcard2FieldsString = "Some vcard field names and subnames in get/set_vcard2 are:\n"
-                         " N FAMILY	- Family name\n"
-                         " N GIVEN	- Given name\n"
-                         " N MIDDLE	- Middle name\n"
-                         " ADR CTRY	- Address: Country\n"
-                         " ADR LOCALITY	- Address: City\n"
-                         " EMAIL USERID	- E-Mail Address\n"
-                         " ORG ORGNAME	- Work: Company\n"
-                         " ORG ORGUNIT	- Work: Department",
+                         " N FAMILY\t- Family name\n"
+                         " N GIVEN\t- Given name\n"
+                         " N MIDDLE\t- Middle name\n"
+                         " ADR CTRY\t- Address: Country\n"
+                         " ADR LOCALITY\t- Address: City\n"
+                         " EMAIL USERID\t- E-Mail Address\n"
+                         " ORG ORGNAME\t- Work: Company\n"
+                         " ORG ORGUNIT\t- Work: Department",
 
     VcardXEP = "For a full list of vCard fields check XEP-0054: vcard-temp at "
                "http://www.xmpp.org/extensions/xep-0054.html",

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -123,17 +123,17 @@ start(Host, Opts) ->
     ?BACKEND:init(Host, Opts),
     start_worker(Host, AccessMaxOfflineMsgs),
     ejabberd_hooks:add(offline_message_hook, Host,
-		       ?MODULE, inspect_packet, 50),
+                       ?MODULE, inspect_packet, 50),
     ejabberd_hooks:add(resend_offline_messages_hook, Host,
-		       ?MODULE, pop_offline_messages, 50),
+                       ?MODULE, pop_offline_messages, 50),
     ejabberd_hooks:add(remove_user, Host,
-		       ?MODULE, remove_user, 50),
+                       ?MODULE, remove_user, 50),
     ejabberd_hooks:add(anonymous_purge_hook, Host,
-		       ?MODULE, remove_user, 50),
+                       ?MODULE, remove_user, 50),
     ejabberd_hooks:add(disco_sm_features, Host,
-		       ?MODULE, get_sm_features, 50),
+                       ?MODULE, get_sm_features, 50),
     ejabberd_hooks:add(disco_local_features, Host,
-		       ?MODULE, get_sm_features, 50),
+                       ?MODULE, get_sm_features, 50),
     ejabberd_hooks:add(amp_determine_strategy, Host,
                        ?MODULE, determine_amp_strategy, 30),
     ejabberd_hooks:add(failed_to_store_message, Host,
@@ -142,13 +142,13 @@ start(Host, Opts) ->
 
 stop(Host) ->
     ejabberd_hooks:delete(offline_message_hook, Host,
-			  ?MODULE, inspect_packet, 50),
+                          ?MODULE, inspect_packet, 50),
     ejabberd_hooks:delete(resend_offline_messages_hook, Host,
-			  ?MODULE, pop_offline_messages, 50),
+                          ?MODULE, pop_offline_messages, 50),
     ejabberd_hooks:delete(remove_user, Host,
-			  ?MODULE, remove_user, 50),
+                          ?MODULE, remove_user, 50),
     ejabberd_hooks:delete(anonymous_purge_hook, Host,
-			  ?MODULE, remove_user, 50),
+                          ?MODULE, remove_user, 50),
     ejabberd_hooks:delete(disco_sm_features, Host, ?MODULE, get_sm_features, 50),
     ejabberd_hooks:delete(disco_local_features, Host, ?MODULE, get_sm_features, 50),
     ejabberd_hooks:delete(amp_determine_strategy, Host,
@@ -393,30 +393,30 @@ store_packet(
 check_event_chatstates(From, To, Packet) ->
     #xmlel{children = Els} = Packet,
     case find_x_event_chatstates(Els, {false, false, false}) of
-	%% There wasn't any x:event or chatstates subelements
-	{false, false, _} ->
-	    true;
-	%% There a chatstates subelement and other stuff, but no x:event
-	{false, CEl, true} when CEl /= false ->
-	    true;
-	%% There was only a subelement: a chatstates
-	{false, CEl, false} when CEl /= false ->
-	    %% Don't allow offline storage
-	    false;
-	%% There was an x:event element, and maybe also other stuff
-	{El, _, _} when El /= false ->
-	    case xml:get_subtag(El, <<"id">>) of
-		false ->
-		    case xml:get_subtag(El, <<"offline">>) of
-			false ->
-			    true;
-			_ ->
+        %% There wasn't any x:event or chatstates subelements
+        {false, false, _} ->
+            true;
+        %% There a chatstates subelement and other stuff, but no x:event
+        {false, CEl, true} when CEl /= false ->
+            true;
+        %% There was only a subelement: a chatstates
+        {false, CEl, false} when CEl /= false ->
+            %% Don't allow offline storage
+            false;
+        %% There was an x:event element, and maybe also other stuff
+        {El, _, _} when El /= false ->
+            case xml:get_subtag(El, <<"id">>) of
+                false ->
+                    case xml:get_subtag(El, <<"offline">>) of
+                        false ->
+                            true;
+                        _ ->
                 ejabberd_router:route(To, From, patch_offline_message(Packet)),
-			    true
-		    end;
-		_ ->
-		    false
-	    end
+                            true
+                    end;
+                _ ->
+                    false
+            end
     end.
 
 patch_offline_message(Packet) ->
@@ -442,12 +442,12 @@ find_x_event_chatstates([#xmlcdata{} | Els], Res) ->
     find_x_event_chatstates(Els, Res);
 find_x_event_chatstates([El | Els], {A, B, C}) ->
     case xml:get_tag_attr_s(<<"xmlns">>, El) of
-	?NS_EVENT ->
-	    find_x_event_chatstates(Els, {El, B, C});
-	?NS_CHATSTATES ->
-	    find_x_event_chatstates(Els, {A, El, C});
-	_ ->
-	    find_x_event_chatstates(Els, {A, B, true})
+        ?NS_EVENT ->
+            find_x_event_chatstates(Els, {El, B, C});
+        ?NS_CHATSTATES ->
+            find_x_event_chatstates(Els, {A, El, C});
+        _ ->
+            find_x_event_chatstates(Els, {A, B, true})
     end.
 
 find_x_expire(_, []) ->
@@ -456,22 +456,22 @@ find_x_expire(TimeStamp, [#xmlcdata{} | Els]) ->
     find_x_expire(TimeStamp, Els);
 find_x_expire(TimeStamp, [El | Els]) ->
     case xml:get_tag_attr_s(<<"xmlns">>, El) of
-	?NS_EXPIRE ->
-	    Val = xml:get_tag_attr_s(<<"seconds">>, El),
-	    case catch list_to_integer(binary_to_list(Val)) of
-		{'EXIT', _} ->
-		    never;
-		Int when Int > 0 ->
-		    {MegaSecs, Secs, MicroSecs} = TimeStamp,
-		    S = MegaSecs * 1000000 + Secs + Int,
-		    MegaSecs1 = S div 1000000,
-		    Secs1 = S rem 1000000,
-		    {MegaSecs1, Secs1, MicroSecs};
-		_ ->
-		    never
-	    end;
-	_ ->
-	    find_x_expire(TimeStamp, Els)
+        ?NS_EXPIRE ->
+            Val = xml:get_tag_attr_s(<<"seconds">>, El),
+            case catch list_to_integer(binary_to_list(Val)) of
+                {'EXIT', _} ->
+                    never;
+                Int when Int > 0 ->
+                    {MegaSecs, Secs, MicroSecs} = TimeStamp,
+                    S = MegaSecs * 1000000 + Secs + Int,
+                    MegaSecs1 = S div 1000000,
+                    Secs1 = S rem 1000000,
+                    {MegaSecs1, Secs1, MicroSecs};
+                _ ->
+                    never
+            end;
+        _ ->
+            find_x_expire(TimeStamp, Els)
     end.
 
 pop_offline_messages(Ls, User, Server) ->
@@ -560,4 +560,3 @@ fallback_timestamp(Days, {MegaSecs, Secs, _MicroSecs}) ->
     MegaSecs1 = S div 1000000,
     Secs1 = S rem 1000000,
     {MegaSecs1, Secs1, 0}.
-

--- a/apps/ejabberd/src/mod_offline_mnesia.erl
+++ b/apps/ejabberd/src/mod_offline_mnesia.erl
@@ -45,19 +45,19 @@
 
 init(_Host, _Opts) ->
     mnesia:create_table(offline_msg,
-			[{disc_only_copies, [node()]},
-			 {type, bag},
-			 {attributes, record_info(fields, offline_msg)}]),
+                        [{disc_only_copies, [node()]},
+                         {type, bag},
+                         {attributes, record_info(fields, offline_msg)}]),
     mnesia:add_table_copy(offline_msg, node(), disc_only_copies),
     ok.
 
 pop_messages(LUser, LServer) ->
     US = {LUser, LServer},
     F = fun() ->
-		Rs = mnesia:wread({offline_msg, US}),
-		mnesia:delete({offline_msg, US}),
-		Rs
-	end,
+                Rs = mnesia:wread({offline_msg, US}),
+                mnesia:delete({offline_msg, US}),
+                Rs
+        end,
     case mnesia:transaction(F) of
         {atomic, Rs} ->
             {ok, Rs};
@@ -104,8 +104,8 @@ remove_user(User, Server) ->
     LServer = jid:nameprep(Server),
     US = {LUser, LServer},
     F = fun() ->
-		mnesia:delete({offline_msg, US})
-	end,
+                mnesia:delete({offline_msg, US})
+        end,
     mnesia:transaction(F).
 
 -spec remove_expired_messages(ejabberd:lserver()) -> {error, term()} | {ok, HowManyRemoved} when
@@ -113,12 +113,12 @@ remove_user(User, Server) ->
 remove_expired_messages(_Host) ->
     TimeStamp = now(),
     F = fun() ->
-		mnesia:write_lock_table(offline_msg),
-		mnesia:foldl(
-		  fun(Rec, Acc) ->
+                mnesia:write_lock_table(offline_msg),
+                mnesia:foldl(
+                  fun(Rec, Acc) ->
               Acc + remove_expired_message(TimeStamp, Rec)
-		  end, 0, offline_msg)
-	end,
+                  end, 0, offline_msg)
+        end,
     case mnesia:transaction(F) of
         {aborted, Reason} ->
             {error, Reason};
@@ -172,4 +172,3 @@ remove_old_message(TimeStamp, Rec) ->
 
 is_old_message(MaxAllowedTimeStamp, #offline_msg{timestamp=TimeStamp}) ->
     TimeStamp < MaxAllowedTimeStamp.
-

--- a/apps/ejabberd/src/mod_private_mnesia.erl
+++ b/apps/ejabberd/src/mod_private_mnesia.erl
@@ -43,8 +43,8 @@
 
 init(_Host, _Opts) ->
     mnesia:create_table(private_storage,
-			[{disc_only_copies, [node()]},
-			 {attributes, record_info(fields, private_storage)}]),
+                        [{disc_only_copies, [node()]},
+                         {attributes, record_info(fields, private_storage)}]),
 
     mnesia:add_table_copy(private_storage, node(), disc_only_copies),
     ok.
@@ -75,7 +75,7 @@ get_data(LUser, LServer, NS, Default) ->
 
 remove_user(LUser, LServer) ->
     F = fun() ->
-		NSs = select_namespaces_t(LUser, LServer),
+                NSs = select_namespaces_t(LUser, LServer),
         [delete_record_t(LUser, LServer, NS) || NS <- NSs]
         end,
     mnesia:transaction(F).
@@ -90,4 +90,3 @@ select_namespaces_t(LUser, LServer) ->
 
 delete_record_t(LUser, LServer, NS) ->
     mnesia:delete({private_storage, {LUser, LServer, NS}}).
-

--- a/apps/ejabberd/src/mod_private_mysql.erl
+++ b/apps/ejabberd/src/mod_private_mysql.erl
@@ -44,8 +44,8 @@ multi_get_data(LUser, LServer, NS2Def) ->
 select_value({NS, Def}, RowsDict) ->
     case dict:find(NS, RowsDict) of
         {ok, SData} ->
-	    {ok, Elem} = exml:parse(SData),
-	    Elem;
+            {ok, Elem} = exml:parse(SData),
+            Elem;
         error ->
             Def
     end.

--- a/apps/ejabberd/src/mod_private_odbc.erl
+++ b/apps/ejabberd/src/mod_private_odbc.erl
@@ -69,8 +69,8 @@ get_data(LUser, LServer, NS, Default) ->
     SNS = mongoose_rdbms:escape(NS),
     case catch rdbms_queries:get_private_data(LServer, SLUser, SNS) of
         {selected, [{SData}]} ->
-	    {ok, Elem} = exml:parse(SData),
-	    Elem;
+            {ok, Elem} = exml:parse(SData),
+            Elem;
         _ ->
             Default
     end.

--- a/apps/ejabberd/src/mod_sic.erl
+++ b/apps/ejabberd/src/mod_sic.erl
@@ -30,10 +30,10 @@
 -behaviour(gen_mod).
 
 -export([start/2,
-	 stop/1,
-	 process_local_iq/3,
-	 process_sm_iq/3
-	]).
+         stop/1,
+         process_local_iq/3,
+         process_sm_iq/3
+        ]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -43,9 +43,9 @@
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host,
-				  ?NS_SIC, ?MODULE, process_local_iq, IQDisc),
+                                  ?NS_SIC, ?MODULE, process_local_iq, IQDisc),
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host,
-				  ?NS_SIC, ?MODULE, process_sm_iq, IQDisc).
+                                  ?NS_SIC, ?MODULE, process_sm_iq, IQDisc).
 
 stop(Host) ->
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_SIC),
@@ -53,7 +53,7 @@ stop(Host) ->
 
 
 process_local_iq(#jid{user = User, server = Server, resource = Resource}, _To,
-		 #iq{type = 'get', sub_el = _SubEl} = IQ) ->
+                 #iq{type = 'get', sub_el = _SubEl} = IQ) ->
     get_ip({User, Server, Resource}, IQ);
 
 process_local_iq(_From, _To, #iq{type = 'set', sub_el = SubEl} = IQ) ->
@@ -61,8 +61,8 @@ process_local_iq(_From, _To, #iq{type = 'set', sub_el = SubEl} = IQ) ->
 
 
 process_sm_iq(#jid{user = User, server = Server, resource = Resource},
-	      #jid{user = User, server = Server},
-	      #iq{type = 'get', sub_el = _SubEl} = IQ) ->
+              #jid{user = User, server = Server},
+              #iq{type = 'get', sub_el = _SubEl} = IQ) ->
     get_ip({User, Server, Resource}, IQ);
 
 process_sm_iq(_From, _To, #iq{type = 'get', sub_el = SubEl} = IQ) ->
@@ -74,21 +74,21 @@ process_sm_iq(_From, _To, #iq{type = 'set', sub_el = SubEl} = IQ) ->
 get_ip({User, Server, Resource},
        #iq{sub_el = #xmlel{} = SubEl} = IQ) ->
     case ejabberd_sm:get_session_ip(User, Server, Resource) of
-	{IP, Port} when is_tuple(IP) ->
-	    IQ#iq{
-	      type = 'result',
-	      sub_el = [
-			SubEl#xmlel{
+        {IP, Port} when is_tuple(IP) ->
+            IQ#iq{
+              type = 'result',
+              sub_el = [
+                SubEl#xmlel{
                 children = [
                     #xmlel{name = <<"ip">>,
                         children = [#xmlcdata{content = list_to_binary(inet_parse:ntoa(IP))}]},
                     #xmlel{name = <<"port">>,
                         children = [#xmlcdata{content = integer_to_binary(Port)}]}
-		       ]
-	        }]};
-	_ ->
-	    IQ#iq{
-	      type = 'error',
-	      sub_el = [SubEl, ?ERR_INTERNAL_SERVER_ERROR]
-	     }
+                ]
+                }]};
+        _ ->
+            IQ#iq{
+              type = 'error',
+              sub_el = [SubEl, ?ERR_INTERNAL_SERVER_ERROR]
+             }
     end.

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -467,10 +467,10 @@ find_xdata_el1([]) ->
     false;
 find_xdata_el1([XE = #xmlel{attrs = Attrs} | Els]) ->
     case xml:get_attr_s(<<"xmlns">>, Attrs) of
-	?NS_XDATA ->
-	    XE;
-	_ ->
-	    find_xdata_el1(Els)
+        ?NS_XDATA ->
+            XE;
+        _ ->
+            find_xdata_el1(Els)
     end;
 find_xdata_el1([_ | Els]) ->
     find_xdata_el1(Els).

--- a/apps/ejabberd/src/mod_vcard_ldap.erl
+++ b/apps/ejabberd/src/mod_vcard_ldap.erl
@@ -35,7 +35,7 @@
 
 %% gen_server callbacks.
 -export([init/1, handle_info/2, handle_call/3,
-	 handle_cast/2,  code_change/3, terminate/2]).
+         handle_cast/2,  code_change/3, terminate/2]).
 
 -export([start_link/2,  transform_module_options/1]).
 
@@ -81,52 +81,52 @@
          matches = 0                :: non_neg_integer()}).
 
 -define(VCARD_MAP,
-	[{<<"NICKNAME">>, <<"%u">>, []},
-	 {<<"FN">>, <<"%s">>, [<<"displayName">>]},
-	 {<<"FAMILY">>, <<"%s">>, [<<"sn">>]},
-	 {<<"GIVEN">>, <<"%s">>, [<<"givenName">>]},
-	 {<<"MIDDLE">>, <<"%s">>, [<<"initials">>]},
-	 {<<"ORGNAME">>, <<"%s">>, [<<"o">>]},
-	 {<<"ORGUNIT">>, <<"%s">>, [<<"ou">>]},
-	 {<<"CTRY">>, <<"%s">>, [<<"c">>]},
-	 {<<"LOCALITY">>, <<"%s">>, [<<"l">>]},
-	 {<<"STREET">>, <<"%s">>, [<<"street">>]},
-	 {<<"REGION">>, <<"%s">>, [<<"st">>]},
-	 {<<"PCODE">>, <<"%s">>, [<<"postalCode">>]},
-	 {<<"TITLE">>, <<"%s">>, [<<"title">>]},
-	 {<<"URL">>, <<"%s">>, [<<"labeleduri">>]},
-	 {<<"DESC">>, <<"%s">>, [<<"description">>]},
-	 {<<"TEL">>, <<"%s">>, [<<"telephoneNumber">>]},
-	 {<<"EMAIL">>, <<"%s">>, [<<"mail">>]},
-	 {<<"BDAY">>, <<"%s">>, [<<"birthDay">>]},
-	 {<<"ROLE">>, <<"%s">>, [<<"employeeType">>]},
-	 {<<"PHOTO">>, <<"%s">>, [<<"jpegPhoto">>]}]).
+        [{<<"NICKNAME">>, <<"%u">>, []},
+         {<<"FN">>, <<"%s">>, [<<"displayName">>]},
+         {<<"FAMILY">>, <<"%s">>, [<<"sn">>]},
+         {<<"GIVEN">>, <<"%s">>, [<<"givenName">>]},
+         {<<"MIDDLE">>, <<"%s">>, [<<"initials">>]},
+         {<<"ORGNAME">>, <<"%s">>, [<<"o">>]},
+         {<<"ORGUNIT">>, <<"%s">>, [<<"ou">>]},
+         {<<"CTRY">>, <<"%s">>, [<<"c">>]},
+         {<<"LOCALITY">>, <<"%s">>, [<<"l">>]},
+         {<<"STREET">>, <<"%s">>, [<<"street">>]},
+         {<<"REGION">>, <<"%s">>, [<<"st">>]},
+         {<<"PCODE">>, <<"%s">>, [<<"postalCode">>]},
+         {<<"TITLE">>, <<"%s">>, [<<"title">>]},
+         {<<"URL">>, <<"%s">>, [<<"labeleduri">>]},
+         {<<"DESC">>, <<"%s">>, [<<"description">>]},
+         {<<"TEL">>, <<"%s">>, [<<"telephoneNumber">>]},
+         {<<"EMAIL">>, <<"%s">>, [<<"mail">>]},
+         {<<"BDAY">>, <<"%s">>, [<<"birthDay">>]},
+         {<<"ROLE">>, <<"%s">>, [<<"employeeType">>]},
+         {<<"PHOTO">>, <<"%s">>, [<<"jpegPhoto">>]}]).
 
 -define(SEARCH_FIELDS,
-	[{<<"User">>, <<"%u">>},
-	 {<<"Full Name">>, <<"displayName">>},
-	 {<<"Given Name">>, <<"givenName">>},
-	 {<<"Middle Name">>, <<"initials">>},
-	 {<<"Family Name">>, <<"sn">>},
-	 {<<"Nickname">>, <<"%u">>},
-	 {<<"Birthday">>, <<"birthDay">>},
-	 {<<"Country">>, <<"c">>}, {<<"City">>, <<"l">>},
-	 {<<"Email">>, <<"mail">>},
-	 {<<"Organization Name">>, <<"o">>},
-	 {<<"Organization Unit">>, <<"ou">>}]).
+        [{<<"User">>, <<"%u">>},
+         {<<"Full Name">>, <<"displayName">>},
+         {<<"Given Name">>, <<"givenName">>},
+         {<<"Middle Name">>, <<"initials">>},
+         {<<"Family Name">>, <<"sn">>},
+         {<<"Nickname">>, <<"%u">>},
+         {<<"Birthday">>, <<"birthDay">>},
+         {<<"Country">>, <<"c">>}, {<<"City">>, <<"l">>},
+         {<<"Email">>, <<"mail">>},
+         {<<"Organization Name">>, <<"o">>},
+         {<<"Organization Unit">>, <<"ou">>}]).
 
 -define(SEARCH_REPORTED,
-	[{<<"Full Name">>, <<"FN">>},
-	 {<<"Given Name">>, <<"FIRST">>},
-	 {<<"Middle Name">>, <<"MIDDLE">>},
-	 {<<"Family Name">>, <<"LAST">>},
-	 {<<"Nickname">>, <<"NICK">>},
-	 {<<"Birthday">>, <<"BDAY">>},
-	 {<<"Country">>, <<"CTRY">>},
-	 {<<"City">>, <<"LOCALITY">>},
-	 {<<"Email">>, <<"EMAIL">>},
-	 {<<"Organization Name">>, <<"ORGNAME">>},
-	 {<<"Organization Unit">>, <<"ORGUNIT">>}]).
+        [{<<"Full Name">>, <<"FN">>},
+         {<<"Given Name">>, <<"FIRST">>},
+         {<<"Middle Name">>, <<"MIDDLE">>},
+         {<<"Family Name">>, <<"LAST">>},
+         {<<"Nickname">>, <<"NICK">>},
+         {<<"Birthday">>, <<"BDAY">>},
+         {<<"Country">>, <<"CTRY">>},
+         {<<"City">>, <<"LOCALITY">>},
+         {<<"Email">>, <<"EMAIL">>},
+         {<<"Organization Name">>, <<"ORGNAME">>},
+         {<<"Organization Unit">>, <<"ORGUNIT">>}]).
 
 
 
@@ -197,15 +197,15 @@ search_reported_fields(Host, Lang) ->
 start_link(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:start_link({local, Proc}, ?MODULE,
-			  [Host, Opts], []).
+                          [Host, Opts], []).
 
 init([Host, Opts]) ->
     process_flag(trap_exit, true),
     State = parse_options(Host, Opts),
     eldap_pool:start_link(State#state.eldap_id,
-			  State#state.servers, State#state.backups,
-			  State#state.port, State#state.dn,
-			  State#state.password, State#state.tls_options),
+                          State#state.servers, State#state.backups,
+                          State#state.port, State#state.dn,
+                          State#state.password, State#state.tls_options),
     {ok, State}.
 
 handle_info(_Info, State) ->
@@ -234,128 +234,128 @@ find_ldap_user(User, State) ->
     Eldap_ID = State#state.eldap_id,
     VCardAttrs = State#state.vcard_map_attrs,
     case eldap_filter:parse(RFC2254_Filter,
-			    [{<<"%u">>, User}])
-	of
+                            [{<<"%u">>, User}])
+        of
       {ok, EldapFilter} ->
-	  case eldap_pool:search(Eldap_ID,
-				 [{base, Base}, {filter, EldapFilter},
-				  {deref_aliases, State#state.deref_aliases},
-				  {attributes, VCardAttrs}])
-	      of
-	    #eldap_search_result{entries = [E | _]} -> E;
-	    _ -> false
-	  end;
+          case eldap_pool:search(Eldap_ID,
+                                 [{base, Base}, {filter, EldapFilter},
+                                  {deref_aliases, State#state.deref_aliases},
+                                  {attributes, VCardAttrs}])
+              of
+            #eldap_search_result{entries = [E | _]} -> E;
+            _ -> false
+          end;
       _ -> false
     end.
 
 ldap_attributes_to_vcard(Attributes, VCardMap, UD) ->
     Attrs = lists:map(fun ({VCardName, _, _}) ->
-			      {stringprep:tolower(VCardName),
-			       map_vcard_attr(VCardName, Attributes, VCardMap,
-					      UD)}
-		      end,
-		      VCardMap),
+                              {stringprep:tolower(VCardName),
+                               map_vcard_attr(VCardName, Attributes, VCardMap,
+                                              UD)}
+                      end,
+                      VCardMap),
     Elts = [ldap_attribute_to_vcard(vCard, Attr)
-	    || Attr <- Attrs],
+            || Attr <- Attrs],
     NElts = [ldap_attribute_to_vcard(vCardN, Attr)
-	     || Attr <- Attrs],
+             || Attr <- Attrs],
     OElts = [ldap_attribute_to_vcard(vCardO, Attr)
-	     || Attr <- Attrs],
+             || Attr <- Attrs],
     AElts = [ldap_attribute_to_vcard(vCardA, Attr)
-	     || Attr <- Attrs],
+             || Attr <- Attrs],
     [#xmlel{name = <<"vCard">>,
-	    attrs = [{<<"xmlns">>, ?NS_VCARD}],
-	    children =
-		lists:append([X || X <- Elts, X /= none],
-			     [#xmlel{name = <<"N">>, attrs = [],
-				     children = [X || X <- NElts, X /= none]},
-			      #xmlel{name = <<"ORG">>, attrs = [],
-				     children = [X || X <- OElts, X /= none]},
-			      #xmlel{name = <<"ADR">>, attrs = [],
-				     children =
-					 [X || X <- AElts, X /= none]}])}].
+            attrs = [{<<"xmlns">>, ?NS_VCARD}],
+            children =
+                lists:append([X || X <- Elts, X /= none],
+                             [#xmlel{name = <<"N">>, attrs = [],
+                                     children = [X || X <- NElts, X /= none]},
+                              #xmlel{name = <<"ORG">>, attrs = [],
+                                     children = [X || X <- OElts, X /= none]},
+                              #xmlel{name = <<"ADR">>, attrs = [],
+                                     children =
+                                         [X || X <- AElts, X /= none]}])}].
 
 ldap_attribute_to_vcard(vCard, {<<"fn">>, Value}) ->
     #xmlel{name = <<"FN">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard,
-			{<<"nickname">>, Value}) ->
+                        {<<"nickname">>, Value}) ->
     #xmlel{name = <<"NICKNAME">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard, {<<"title">>, Value}) ->
     #xmlel{name = <<"TITLE">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard, {<<"bday">>, Value}) ->
     #xmlel{name = <<"BDAY">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard, {<<"url">>, Value}) ->
     #xmlel{name = <<"URL">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard, {<<"desc">>, Value}) ->
     #xmlel{name = <<"DESC">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard, {<<"role">>, Value}) ->
     #xmlel{name = <<"ROLE">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCard, {<<"tel">>, Value}) ->
     #xmlel{name = <<"TEL">>, attrs = [],
-	   children =
-	       [#xmlel{name = <<"VOICE">>, attrs = [], children = []},
-		#xmlel{name = <<"WORK">>, attrs = [], children = []},
-		#xmlel{name = <<"NUMBER">>, attrs = [],
-		       children = [{xmlcdata, Value}]}]};
+           children =
+               [#xmlel{name = <<"VOICE">>, attrs = [], children = []},
+                #xmlel{name = <<"WORK">>, attrs = [], children = []},
+                #xmlel{name = <<"NUMBER">>, attrs = [],
+                       children = [{xmlcdata, Value}]}]};
 ldap_attribute_to_vcard(vCard, {<<"email">>, Value}) ->
     #xmlel{name = <<"EMAIL">>, attrs = [],
-	   children =
-	       [#xmlel{name = <<"INTERNET">>, attrs = [],
-		       children = []},
-		#xmlel{name = <<"PREF">>, attrs = [], children = []},
-		#xmlel{name = <<"USERID">>, attrs = [],
-		       children = [{xmlcdata, Value}]}]};
+           children =
+               [#xmlel{name = <<"INTERNET">>, attrs = [],
+                       children = []},
+                #xmlel{name = <<"PREF">>, attrs = [], children = []},
+                #xmlel{name = <<"USERID">>, attrs = [],
+                       children = [{xmlcdata, Value}]}]};
 ldap_attribute_to_vcard(vCard, {<<"photo">>, Value}) ->
     #xmlel{name = <<"PHOTO">>, attrs = [],
-	   children =
-	       [#xmlel{name = <<"TYPE">>, attrs = [],
-		       children = [{xmlcdata, <<"image/jpeg">>}]},
-		#xmlel{name = <<"BINVAL">>, attrs = [],
-		       children = [{xmlcdata, jlib:encode_base64(Value)}]}]};
+           children =
+               [#xmlel{name = <<"TYPE">>, attrs = [],
+                       children = [{xmlcdata, <<"image/jpeg">>}]},
+                #xmlel{name = <<"BINVAL">>, attrs = [],
+                       children = [{xmlcdata, jlib:encode_base64(Value)}]}]};
 ldap_attribute_to_vcard(vCardN,
-			{<<"family">>, Value}) ->
+                        {<<"family">>, Value}) ->
     #xmlel{name = <<"FAMILY">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardN, {<<"given">>, Value}) ->
     #xmlel{name = <<"GIVEN">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardN,
-			{<<"middle">>, Value}) ->
+                        {<<"middle">>, Value}) ->
     #xmlel{name = <<"MIDDLE">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardO,
-			{<<"orgname">>, Value}) ->
+                        {<<"orgname">>, Value}) ->
     #xmlel{name = <<"ORGNAME">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardO,
-			{<<"orgunit">>, Value}) ->
+                        {<<"orgunit">>, Value}) ->
     #xmlel{name = <<"ORGUNIT">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardA,
-			{<<"locality">>, Value}) ->
+                        {<<"locality">>, Value}) ->
     #xmlel{name = <<"LOCALITY">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardA,
-			{<<"street">>, Value}) ->
+                        {<<"street">>, Value}) ->
     #xmlel{name = <<"STREET">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardA, {<<"ctry">>, Value}) ->
     #xmlel{name = <<"CTRY">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardA,
-			{<<"region">>, Value}) ->
+                        {<<"region">>, Value}) ->
     #xmlel{name = <<"REGION">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(vCardA, {<<"pcode">>, Value}) ->
     #xmlel{name = <<"PCODE">>, attrs = [],
-	   children = [{xmlcdata, Value}]};
+           children = [{xmlcdata, Value}]};
 ldap_attribute_to_vcard(_, _) -> none.
 
 search_internal(_, []) ->
@@ -371,12 +371,12 @@ search_internal(State, Data) ->
     Filter = eldap:'and'([SearchFilter,
                           eldap_utils:make_filter(Data, UIDs, Op)]),
     case eldap_pool:search(Eldap_ID,
-			   [{base, Base}, {filter, Filter}, {limit, Limit},
-			    {deref_aliases, State#state.deref_aliases},
-			    {attributes, ReportedAttrs}])
-	of
+                           [{base, Base}, {filter, Filter}, {limit, Limit},
+                            {deref_aliases, State#state.deref_aliases},
+                            {attributes, ReportedAttrs}])
+        of
       #eldap_search_result{entries = E} ->
-	  search_items(E, State);
+          search_items(E, State);
       _ -> error
     end.
 
@@ -387,50 +387,50 @@ search_items(Entries, State) ->
     UIDs = State#state.uids,
     BinFields = State#state.binary_search_fields,
     Attributes = lists:map(fun (E) ->
-				   #eldap_entry{attributes = Attrs} = E, Attrs
-			   end,
-			   Entries),
+                                   #eldap_entry{attributes = Attrs} = E, Attrs
+                           end,
+                           Entries),
     lists:flatmap(fun (Attrs) ->
-			  case eldap_utils:find_ldap_attrs(UIDs, Attrs) of
-			    {U, UIDAttrFormat} ->
-				case eldap_utils:get_user_part(U, UIDAttrFormat)
-				    of
-				  {ok, Username} ->
-				      case
-					ejabberd_auth:is_user_exists(Username,
-								     LServer)
-					  of
-					true ->
-					    RFields = lists:map(fun ({_,
-								      VCardName}) ->
-									{VCardName,
-									 map_vcard_attr(VCardName,
-											Attrs,
-											VCardMap,
-											{Username,
-											 ?MYNAME})}
-								end,
-								SearchReported),
-					    Result = [?FIELD(<<"jid">>,
-							     <<Username/binary,
-							       "@",
-							       LServer/binary>>)]
-						       ++
-						       [?FIELD(Name,
+                          case eldap_utils:find_ldap_attrs(UIDs, Attrs) of
+                            {U, UIDAttrFormat} ->
+                                case eldap_utils:get_user_part(U, UIDAttrFormat)
+                                    of
+                                  {ok, Username} ->
+                                      case
+                                        ejabberd_auth:is_user_exists(Username,
+                                                                     LServer)
+                                          of
+                                        true ->
+                                            RFields = lists:map(fun ({_,
+                                                                      VCardName}) ->
+                                                                        {VCardName,
+                                                                         map_vcard_attr(VCardName,
+                                                                                        Attrs,
+                                                                                        VCardMap,
+                                                                                        {Username,
+                                                                                         ?MYNAME})}
+                                                                end,
+                                                                SearchReported),
+                                            Result = [?FIELD(<<"jid">>,
+                                                             <<Username/binary,
+                                                               "@",
+                                                               LServer/binary>>)]
+                                                       ++
+                                                       [?FIELD(Name,
                                        search_item_value(Name, Value, BinFields))
-							|| {Name, Value}
-							       <- RFields],
-					    [#xmlel{name = <<"item">>,
-						    attrs = [],
-						    children = Result}];
-					_ -> []
-				      end;
-				  _ -> []
-				end;
-			    <<"">> -> []
-			  end
-		  end,
-		  Attributes).
+                                                        || {Name, Value}
+                                                               <- RFields],
+                                            [#xmlel{name = <<"item">>,
+                                                    attrs = [],
+                                                    children = Result}];
+                                        _ -> []
+                                      end;
+                                  _ -> []
+                                end;
+                            <<"">> -> []
+                          end
+                  end,
+                  Attributes).
 
 %%%-----------------------
 %%% Auxiliary functions.
@@ -443,15 +443,15 @@ search_item_value(Name, Value, BinaryFields) ->
 
 map_vcard_attr(VCardName, Attributes, Pattern, UD) ->
     Res = lists:filter(fun ({Name, _, _}) ->
-			       eldap_utils:case_insensitive_match(Name,
-								  VCardName)
-		       end,
-		       Pattern),
+                               eldap_utils:case_insensitive_match(Name,
+                                                                  VCardName)
+                       end,
+                       Pattern),
     case Res of
       [{_, Str, Attrs}] ->
-	  process_pattern(Str, UD,
-			  [eldap_utils:get_ldap_attr(X, Attributes)
-			   || X <- Attrs]);
+          process_pattern(Str, UD,
+                          [eldap_utils:get_ldap_attr(X, Attributes)
+                           || X <- Attrs]);
       _ -> <<"">>
     end.
 
@@ -485,13 +485,13 @@ parse_options(Host, Opts) ->
                         {ldap_filter, Host}, Opts,
                         fun check_filter/1, <<"">>) of
                      <<"">> ->
-			 SubFilter;
+                         SubFilter;
                      F ->
                          <<"(&", SubFilter/binary, F/binary, ")">>
                  end,
     {ok, SearchFilter} =
-	eldap_filter:parse(eldap_filter:do_sub(UserFilter,
-					       [{<<"%u">>, <<"*">>}])),
+        eldap_filter:parse(eldap_filter:do_sub(UserFilter,
+                                               [{<<"%u">>, <<"*">>}])),
     VCardMap = eldap_utils:get_mod_opt(ldap_vcard_map, Opts,
                                fun(Ls) ->
                                        lists:map(
@@ -516,23 +516,23 @@ parse_options(Host, Opts) ->
                                      end, ?SEARCH_REPORTED),
     UIDAttrs = [UAttr || {UAttr, _} <- UIDs],
     VCardMapAttrs = lists:usort(lists:append([A
-					      || {_, _, A} <- VCardMap])
-				  ++ UIDAttrs),
+                                              || {_, _, A} <- VCardMap])
+                                  ++ UIDAttrs),
     SearchReportedAttrs = lists:usort(lists:flatmap(fun ({_,
-							  N}) ->
-							    case
-							      lists:keysearch(N,
-									      1,
-									      VCardMap)
-								of
-							      {value,
-							       {_, _, L}} ->
-								  L;
-							      _ -> []
-							    end
-						    end,
-						    SearchReported)
-					++ UIDAttrs),
+                                                          N}) ->
+                                                            case
+                                                              lists:keysearch(N,
+                                                                              1,
+                                                                              VCardMap)
+                                                                of
+                                                              {value,
+                                                               {_, _, L}} ->
+                                                                  L;
+                                                              _ -> []
+                                                            end
+                                                    end,
+                                                    SearchReported)
+                                        ++ UIDAttrs),
     SearchOperatorFun = fun
         ('or') -> 'or';
         (_)    -> 'and'

--- a/apps/ejabberd/src/mod_vcard_mnesia.erl
+++ b/apps/ejabberd/src/mod_vcard_mnesia.erl
@@ -187,10 +187,10 @@ update_vcard_search_table() ->
          given,    lgiven,
          middle,   lmiddle,
          nickname, lnickname,
-         bday, 	   lbday,
-         ctry, 	   lctry,
+         bday,     lbday,
+         ctry,     lctry,
          locality, llocality,
-         email, 	   lemail,
+         email,    lemail,
          orgname,  lorgname,
          orgunit,  lorgunit] ->
             ?INFO_MSG("Converting vcard_search table from "
@@ -234,44 +234,44 @@ update_vcard_search_table() ->
                                         bday      = BDay,     lbday      = LBDay,
                                         ctry      = CTRY,     lctry      = LCTRY,
                                         locality  = Locality, llocality  = LLocality,
-				       email     = EMail,    lemail     = LEMail,
-				       orgname   = OrgName,  lorgname   = LOrgName,
-				       orgunit   = OrgUnit,  lorgunit   = LOrgUnit
-				      })
-			   end, ok, vcard_search)
-		 end,
-	    mnesia:transaction(F1),
-	    lists:foreach(fun(I) ->
-				  mnesia:del_table_index(
-				    vcard_search,
-				    element(I, {vcard_search,
-						user,     luser,
-						fn,       lfn,
-						family,   lfamily,
-						given,    lgiven,
-						middle,   lmiddle,
-						nickname, lnickname,
-						bday, 	   lbday,
-						ctry, 	   lctry,
-						locality, llocality,
-						email, 	   lemail,
-						orgname,  lorgname,
-						orgunit,  lorgunit}))
-			  end, mnesia:table_info(vcard_search, index)),
-	    mnesia:clear_table(vcard_search),
-	    mnesia:transform_table(vcard_search, ignore, Fields),
-	    F2 = fun() ->
-	        	 mnesia:write_lock_table(vcard_search),
-	        	 mnesia:foldl(
-	        	   fun(R, _) ->
-	        		   mnesia:dirty_write(R)
-	        	   end, ok, mod_vcard_tmp_table)
-	         end,
-	    mnesia:transaction(F2),
-	    mnesia:delete_table(mod_vcard_tmp_table);
-	_ ->
-	    ?INFO_MSG("Recreating vcard_search table", []),
-	    mnesia:transform_table(vcard_search, ignore, Fields)
+                                       email     = EMail,    lemail     = LEMail,
+                                       orgname   = OrgName,  lorgname   = LOrgName,
+                                       orgunit   = OrgUnit,  lorgunit   = LOrgUnit
+                                      })
+                           end, ok, vcard_search)
+                 end,
+            mnesia:transaction(F1),
+            lists:foreach(fun(I) ->
+                                  mnesia:del_table_index(
+                                    vcard_search,
+                                    element(I, {vcard_search,
+                                                user,     luser,
+                                                fn,       lfn,
+                                                family,   lfamily,
+                                                given,    lgiven,
+                                                middle,   lmiddle,
+                                                nickname, lnickname,
+                                                bday,     lbday,
+                                                ctry,     lctry,
+                                                locality, llocality,
+                                                email,    lemail,
+                                                orgname,  lorgname,
+                                                orgunit,  lorgunit}))
+                          end, mnesia:table_info(vcard_search, index)),
+            mnesia:clear_table(vcard_search),
+            mnesia:transform_table(vcard_search, ignore, Fields),
+            F2 = fun() ->
+                         mnesia:write_lock_table(vcard_search),
+                         mnesia:foldl(
+                           fun(R, _) ->
+                                   mnesia:dirty_write(R)
+                           end, ok, mod_vcard_tmp_table)
+                 end,
+            mnesia:transaction(F2),
+            mnesia:delete_table(mod_vcard_tmp_table);
+        _ ->
+            ?INFO_MSG("Recreating vcard_search table", []),
+            mnesia:transform_table(vcard_search, ignore, Fields)
     end.
 
 make_matchhead(VHost, Data) ->
@@ -332,4 +332,3 @@ record_to_item(R) ->
                        ?FIELD(<<"orgname">>, (R#vcard_search.orgname)),
                        ?FIELD(<<"orgunit">>, (R#vcard_search.orgunit))
                       ]}.
-

--- a/apps/ejabberd/src/mod_vcard_odbc.erl
+++ b/apps/ejabberd/src/mod_vcard_odbc.erl
@@ -64,7 +64,7 @@ get_vcard(LUser, LServer) ->
                 {error, Reason} ->
                     ?WARNING_MSG("not sending bad vcard xml ~p~n~p", [Reason, SVCARD]),
                     {error, ?ERR_SERVICE_UNAVAILABLE};
-		{ok, VCARD} ->
+                {ok, VCARD} ->
                     {ok, [VCARD]}
             end;
         {selected, []} ->
@@ -178,20 +178,20 @@ filter_fields([_ | Ds], RestrictionSQL, LServer) ->
     Result :: iolist().
 make_val(RestrictionSQL, Field, Val) ->
     Condition =
-	case binary:last(Val) of
-	    $* ->
-		Val1 = binary:part(Val, 0, byte_size(Val)-1),
-		SVal = mongoose_rdbms:escape_like(Val1),
-		[Field, " LIKE '", SVal, "%'"];
-	    _ ->
-		SVal = mongoose_rdbms:escape(Val),
-		[Field, " = '", SVal, "'"]
-	end,
+        case binary:last(Val) of
+            $* ->
+                Val1 = binary:part(Val, 0, byte_size(Val)-1),
+                SVal = mongoose_rdbms:escape_like(Val1),
+                [Field, " LIKE '", SVal, "%'"];
+            _ ->
+                SVal = mongoose_rdbms:escape(Val),
+                [Field, " = '", SVal, "'"]
+        end,
     case RestrictionSQL of
-	"" ->
-	    Condition;
-	_ ->
-	    [RestrictionSQL, " and ", Condition]
+        "" ->
+            Condition;
+        _ ->
+            [RestrictionSQL, " and ", Condition]
     end.
 
 record_to_item(_CallerVHost, {Username, VCardVHost, FN, Family, Given, Middle,

--- a/apps/ejabberd/src/p1_fsm_old.erl
+++ b/apps/ejabberd/src/p1_fsm_old.erl
@@ -214,18 +214,18 @@ send_event(Name, Event) ->
 
 sync_send_event(Name, Event) ->
     case catch gen:call(Name, '$gen_sync_event', Event) of
-	{ok, Res} ->
-	    Res;
-	{'EXIT', Reason} ->
-	    exit({Reason, {?MODULE, sync_send_event, [Name, Event]}})
+        {ok, Res} ->
+            Res;
+        {'EXIT', Reason} ->
+            exit({Reason, {?MODULE, sync_send_event, [Name, Event]}})
     end.
 
 sync_send_event(Name, Event, Timeout) ->
     case catch gen:call(Name, '$gen_sync_event', Event, Timeout) of
-	{ok, Res} ->
-	    Res;
-	{'EXIT', Reason} ->
-	    exit({Reason, {?MODULE, sync_send_event, [Name, Event, Timeout]}})
+        {ok, Res} ->
+            Res;
+        {'EXIT', Reason} ->
+            exit({Reason, {?MODULE, sync_send_event, [Name, Event, Timeout]}})
     end.
 
 send_all_state_event({global, Name}, Event) ->
@@ -237,19 +237,19 @@ send_all_state_event(Name, Event) ->
 
 sync_send_all_state_event(Name, Event) ->
     case catch gen:call(Name, '$gen_sync_all_state_event', Event) of
-	{ok, Res} ->
-	    Res;
-	{'EXIT', Reason} ->
-	    exit({Reason, {?MODULE, sync_send_all_state_event, [Name, Event]}})
+        {ok, Res} ->
+            Res;
+        {'EXIT', Reason} ->
+            exit({Reason, {?MODULE, sync_send_all_state_event, [Name, Event]}})
     end.
 
 sync_send_all_state_event(Name, Event, Timeout) ->
     case catch gen:call(Name, '$gen_sync_all_state_event', Event, Timeout) of
-	{ok, Res} ->
-	    Res;
-	{'EXIT', Reason} ->
-	    exit({Reason, {?MODULE, sync_send_all_state_event,
-			   [Name, Event, Timeout]}})
+        {ok, Res} ->
+            Res;
+        {'EXIT', Reason} ->
+            exit({Reason, {?MODULE, sync_send_all_state_event,
+                           [Name, Event, Timeout]}})
     end.
 
 %% Designed to be only callable within one of the callbacks
@@ -271,12 +271,12 @@ send_event_after(Time, Event) ->
 %% an active timer/send_event_after, false otherwise.
 cancel_timer(Ref) ->
     case erlang:cancel_timer(Ref) of
-	false ->
-	    receive {timeout, Ref, _} -> 0
-	    after 0 -> false
-	    end;
-	RemainingTime ->
-	    RemainingTime
+        false ->
+            receive {timeout, Ref, _} -> 0
+            after 0 -> false
+            end;
+        RemainingTime ->
+            RemainingTime
     end.
 
 %% enter_loop/4, 5, 6
@@ -303,7 +303,7 @@ enter_loop(Mod, Options, StateName, StateData, ServerName, Timeout) ->
     Queue = queue:new(),
     QueueLen = 0,
     loop(Parent, Name, StateName, StateData, Mod, Timeout, Debug,
-	 Limits, Queue, QueueLen).
+         Limits, Queue, QueueLen).
 
 maybe_debug_options(Opts) ->
     case lists:keyfind(debug, 1, Opts) of
@@ -317,44 +317,44 @@ get_proc_name(Pid) when is_pid(Pid) ->
     Pid;
 get_proc_name({local, Name}) ->
     case process_info(self(), registered_name) of
-	{registered_name, Name} ->
-	    Name;
-	{registered_name, _Name} ->
-	    exit(process_not_registered);
-	[] ->
-	    exit(process_not_registered)
+        {registered_name, Name} ->
+            Name;
+        {registered_name, _Name} ->
+            exit(process_not_registered);
+        [] ->
+            exit(process_not_registered)
     end;
 get_proc_name({global, Name}) ->
     case global:whereis_name(Name) of
-	undefined ->
-	    exit(process_not_registered_globally);
-	Pid when Pid==self() ->
-	    Name;
-	_Pid ->
-	    exit(process_not_registered_globally)
+        undefined ->
+            exit(process_not_registered_globally);
+        Pid when Pid==self() ->
+            Name;
+        _Pid ->
+            exit(process_not_registered_globally)
     end.
 
 get_parent() ->
     case get('$ancestors') of
-	[Parent | _] when is_pid(Parent) ->
-	    Parent;
-	[Parent | _] when is_atom(Parent) ->
-	    name_to_pid(Parent);
-	_ ->
-	    exit(process_was_not_started_by_proc_lib)
+        [Parent | _] when is_pid(Parent) ->
+            Parent;
+        [Parent | _] when is_atom(Parent) ->
+            name_to_pid(Parent);
+        _ ->
+            exit(process_was_not_started_by_proc_lib)
     end.
 
 name_to_pid(Name) ->
     case whereis(Name) of
-	undefined ->
-	    case global:whereis_name(Name) of
-		undefined ->
-		    exit(could_not_find_registerd_name);
-		Pid ->
-		    Pid
-	    end;
-	Pid ->
-	    Pid
+        undefined ->
+            case global:whereis_name(Name) of
+                undefined ->
+                    exit(could_not_find_registerd_name);
+                Pid ->
+                    Pid
+            end;
+        Pid ->
+            Pid
     end.
 
 %%% ---------------------------------------------------
@@ -373,25 +373,25 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
     Queue = queue:new(),
     QueueLen = 0,
     case catch Mod:init(Args) of
-	{ok, StateName, StateData} ->
-	    proc_lib:init_ack(Starter, {ok, self()}),
-	    loop(Parent, Name, StateName, StateData, Mod, infinity, Debug, Limits, Queue, QueueLen);
-	{ok, StateName, StateData, Timeout} ->
-	    proc_lib:init_ack(Starter, {ok, self()}),
-	    loop(Parent, Name, StateName, StateData, Mod, Timeout, Debug, Limits, Queue, QueueLen);
-	{stop, Reason} ->
-	    proc_lib:init_ack(Starter, {error, Reason}),
-	    exit(Reason);
-	ignore ->
-	    proc_lib:init_ack(Starter, ignore),
-	    exit(normal);
-	{'EXIT', Reason} ->
-	    proc_lib:init_ack(Starter, {error, Reason}),
-	    exit(Reason);
-	Else ->
-	    Error = {bad_return_value, Else},
-	    proc_lib:init_ack(Starter, {error, Error}),
-	    exit(Error)
+        {ok, StateName, StateData} ->
+            proc_lib:init_ack(Starter, {ok, self()}),
+            loop(Parent, Name, StateName, StateData, Mod, infinity, Debug, Limits, Queue, QueueLen);
+        {ok, StateName, StateData, Timeout} ->
+            proc_lib:init_ack(Starter, {ok, self()}),
+            loop(Parent, Name, StateName, StateData, Mod, Timeout, Debug, Limits, Queue, QueueLen);
+        {stop, Reason} ->
+            proc_lib:init_ack(Starter, {error, Reason}),
+            exit(Reason);
+        ignore ->
+            proc_lib:init_ack(Starter, ignore),
+            exit(normal);
+        {'EXIT', Reason} ->
+            proc_lib:init_ack(Starter, {error, Reason}),
+            exit(Reason);
+        Else ->
+            Error = {bad_return_value, Else},
+            proc_lib:init_ack(Starter, {error, Error}),
+            exit(Error)
     end.
 
 name({local, Name}) -> Name;
@@ -405,94 +405,94 @@ loop(Parent, Name, StateName, StateData, Mod, hibernate, Debug,
      Limits, Queue, QueueLen)
   when QueueLen > 0 ->
     case queue:out(Queue) of
-	{{value, Msg}, Queue1} ->
-	    decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate,
-		       Debug, Limits, Queue1, QueueLen - 1, false);
-	{empty, _} ->
-	    Reason = internal_queue_error,
-	    error_info(Mod, Reason, Name, hibernate, StateName, StateData, Debug),
-	    exit(Reason)
+        {{value, Msg}, Queue1} ->
+            decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate,
+                       Debug, Limits, Queue1, QueueLen - 1, false);
+        {empty, _} ->
+            Reason = internal_queue_error,
+            error_info(Mod, Reason, Name, hibernate, StateName, StateData, Debug),
+            exit(Reason)
     end;
 loop(Parent, Name, StateName, StateData, Mod, hibernate, Debug,
      Limits, _Queue, _QueueLen) ->
     proc_lib:hibernate(?MODULE, wake_hib,
-		       [Parent, Name, StateName, StateData, Mod,
-			Debug, Limits]);
+                       [Parent, Name, StateName, StateData, Mod,
+                        Debug, Limits]);
 %% First we test if we have reach a defined limit ...
 loop(Parent, Name, StateName, StateData, Mod, Time, Debug,
      Limits, Queue, QueueLen) ->
     try
-	message_queue_len(Limits, QueueLen)
-	%% TODO: We can add more limit checking here...
+        message_queue_len(Limits, QueueLen)
+        %% TODO: We can add more limit checking here...
     catch
-	{process_limit, Limit} ->
-	    Reason = {process_limit, Limit},
-	    Msg = {'EXIT', Parent, {error, {process_limit, Limit}}},
-	    terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug)
+        {process_limit, Limit} ->
+            Reason = {process_limit, Limit},
+            Msg = {'EXIT', Parent, {error, {process_limit, Limit}}},
+            terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug)
     end,
     process_message(Parent, Name, StateName, StateData,
-		    Mod, Time, Debug, Limits, Queue, QueueLen).
+                    Mod, Time, Debug, Limits, Queue, QueueLen).
 %% ... then we can process a new message:
 process_message(Parent, Name, StateName, StateData, Mod, Time, Debug,
-		Limits, Queue, QueueLen) ->
+                Limits, Queue, QueueLen) ->
     {Msg, Queue1, QueueLen1} = collect_messages(Queue, QueueLen, Time),
     decode_msg(Msg, Parent, Name, StateName, StateData, Mod, Time,
-	       Debug, Limits, Queue1, QueueLen1, false).
+               Debug, Limits, Queue1, QueueLen1, false).
 
 collect_messages(Queue, QueueLen, Time) ->
     receive
-	Input ->
-	    case Input of
-		{'EXIT', _Parent, priority_shutdown} ->
-		    {Input, Queue, QueueLen};
-		_ ->
-		    collect_messages(
-		      queue:in(Input, Queue), QueueLen + 1, Time)
-	    end
+        Input ->
+            case Input of
+                {'EXIT', _Parent, priority_shutdown} ->
+                    {Input, Queue, QueueLen};
+                _ ->
+                    collect_messages(
+                      queue:in(Input, Queue), QueueLen + 1, Time)
+            end
     after 0 ->
-	    case queue:out(Queue) of
-		{{value, Msg}, Queue1} ->
-		    {Msg, Queue1, QueueLen - 1};
-		{empty, _} ->
-		    receive
-			Input ->
-			    {Input, Queue, QueueLen}
-		    after Time ->
-			    {{'$gen_event', timeout}, Queue, QueueLen}
-		    end
-	    end
+            case queue:out(Queue) of
+                {{value, Msg}, Queue1} ->
+                    {Msg, Queue1, QueueLen - 1};
+                {empty, _} ->
+                    receive
+                        Input ->
+                            {Input, Queue, QueueLen}
+                    after Time ->
+                            {{'$gen_event', timeout}, Queue, QueueLen}
+                    end
+            end
     end.
 
 
 wake_hib(Parent, Name, StateName, StateData, Mod, Debug,
-	 Limits) ->
+         Limits) ->
     Msg = receive
-	      Input ->
-		  Input
-	  end,
+              Input ->
+                  Input
+          end,
     Queue = queue:new(),
     QueueLen = 0,
     decode_msg(Msg, Parent, Name, StateName, StateData, Mod, hibernate,
-	       Debug, Limits, Queue, QueueLen, true).
+               Debug, Limits, Queue, QueueLen, true).
 
 decode_msg(Msg, Parent, Name, StateName, StateData, Mod, Time, Debug,
-	   Limits, Queue, QueueLen, Hib) ->
+           Limits, Queue, QueueLen, Hib) ->
     put('$internal_queue_len', QueueLen),
     case Msg of
         {system, From, Req} ->
-	    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
-				  [Name, StateName, StateData,
-				   Mod, Time, Limits, Queue, QueueLen], Hib);
-	{'EXIT', Parent, Reason} ->
-	    terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug);
-	_Msg when Debug == [] ->
-	    handle_msg(Msg, Parent, Name, StateName, StateData,
-		       Mod, Time, Limits, Queue, QueueLen);
-	_Msg ->
-	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
-				      {Name, StateName}, {in, Msg}),
-	    handle_msg(Msg, Parent, Name, StateName, StateData,
-		       Mod, Time, Debug1, Limits, Queue, QueueLen)
+            sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug,
+                                  [Name, StateName, StateData,
+                                   Mod, Time, Limits, Queue, QueueLen], Hib);
+        {'EXIT', Parent, Reason} ->
+            terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug);
+        _Msg when Debug == [] ->
+            handle_msg(Msg, Parent, Name, StateName, StateData,
+                       Mod, Time, Limits, Queue, QueueLen);
+        _Msg ->
+            Debug1 = sys:handle_debug(Debug, fun print_event/3,
+                                      {Name, StateName}, {in, Msg}),
+            handle_msg(Msg, Parent, Name, StateName, StateData,
+                       Mod, Time, Debug1, Limits, Queue, QueueLen)
     end.
 
 %%-----------------------------------------------------------------
@@ -509,13 +509,13 @@ system_terminate(Reason, _Parent, Debug,
     terminate(Reason, Name, [], Mod, StateName, StateData, Debug).
 
 system_code_change([Name, StateName, StateData, Mod, Time,
-		    Limits, Queue, QueueLen],
-		   _Module, OldVsn, Extra) ->
+                    Limits, Queue, QueueLen],
+                   _Module, OldVsn, Extra) ->
     case catch Mod:code_change(OldVsn, StateName, StateData, Extra) of
-	{ok, NewStateName, NewStateData} ->
-	    {ok, [Name, NewStateName, NewStateData, Mod, Time,
-		  Limits, Queue, QueueLen]};
-	Else -> Else
+        {ok, NewStateName, NewStateData} ->
+            {ok, [Name, NewStateName, NewStateData, Mod, Time,
+                  Limits, Queue, QueueLen]};
+        Else -> Else
     end.
 
 %%-----------------------------------------------------------------
@@ -524,32 +524,32 @@ system_code_change([Name, StateName, StateData, Mod, Time,
 %%-----------------------------------------------------------------
 print_event(Dev, {in, Msg}, {Name, StateName}) ->
     case Msg of
-	{'$gen_event', Event} ->
-	    io:format(Dev, "*DBG* ~p got event ~p in state ~w~n",
-		      [Name, Event, StateName]);
-	{'$gen_all_state_event', Event} ->
-	    io:format(Dev,
-		      "*DBG* ~p got all_state_event ~p in state ~w~n",
-		      [Name, Event, StateName]);
-	{timeout, Ref, {'$gen_timer', Message}} ->
-	    io:format(Dev,
-		      "*DBG* ~p got timer ~p in state ~w~n",
-		      [Name, {timeout, Ref, Message}, StateName]);
-	{timeout, _Ref, {'$gen_event', Event}} ->
-	    io:format(Dev,
-		      "*DBG* ~p got timer ~p in state ~w~n",
-		      [Name, Event, StateName]);
-	_ ->
-	    io:format(Dev, "*DBG* ~p got ~p in state ~w~n",
-		      [Name, Msg, StateName])
+        {'$gen_event', Event} ->
+            io:format(Dev, "*DBG* ~p got event ~p in state ~w~n",
+                      [Name, Event, StateName]);
+        {'$gen_all_state_event', Event} ->
+            io:format(Dev,
+                      "*DBG* ~p got all_state_event ~p in state ~w~n",
+                      [Name, Event, StateName]);
+        {timeout, Ref, {'$gen_timer', Message}} ->
+            io:format(Dev,
+                      "*DBG* ~p got timer ~p in state ~w~n",
+                      [Name, {timeout, Ref, Message}, StateName]);
+        {timeout, _Ref, {'$gen_event', Event}} ->
+            io:format(Dev,
+                      "*DBG* ~p got timer ~p in state ~w~n",
+                      [Name, Event, StateName]);
+        _ ->
+            io:format(Dev, "*DBG* ~p got ~p in state ~w~n",
+                      [Name, Msg, StateName])
     end;
 print_event(Dev, {out, Msg, To, StateName}, Name) ->
     io:format(Dev, "*DBG* ~p sent ~p to ~w~n"
-	           "      and switched to state ~w~n",
-	      [Name, Msg, To, StateName]);
+                   "      and switched to state ~w~n",
+              [Name, Msg, To, StateName]);
 print_event(Dev, return, {Name, StateName}) ->
     io:format(Dev, "*DBG* ~p switched to state ~w~n",
-	      [Name, StateName]).
+              [Name, StateName]).
 
 relay_messages(MRef, TRef, Clone, Queue) ->
     lists:foreach(
@@ -559,117 +559,117 @@ relay_messages(MRef, TRef, Clone, Queue) ->
 
 relay_messages(MRef, TRef, Clone) ->
     receive
-	{'DOWN', MRef, process, Clone, Reason} ->
-	    Reason;
-	{'EXIT', _Parent, _Reason} ->
-	    {migrated, Clone};
-	{timeout, TRef, timeout} ->
-	    {migrated, Clone};
-	Msg ->
-	    Clone ! Msg,
-	    relay_messages(MRef, TRef, Clone)
+        {'DOWN', MRef, process, Clone, Reason} ->
+            Reason;
+        {'EXIT', _Parent, _Reason} ->
+            {migrated, Clone};
+        {timeout, TRef, timeout} ->
+            {migrated, Clone};
+        Msg ->
+            Clone ! Msg,
+            relay_messages(MRef, TRef, Clone)
     end.
 
 handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time,
-	   Limits, Queue, QueueLen) -> %No debug here
+           Limits, Queue, QueueLen) -> %No debug here
     From = from(Msg),
     case catch dispatch(Msg, Mod, StateName, StateData) of
-	{next_state, NStateName, NStateData} ->
-	    loop(Parent, Name, NStateName, NStateData,
-		 Mod, infinity, [], Limits, Queue, QueueLen);
-	{next_state, NStateName, NStateData, Time1} ->
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, [],
-		 Limits, Queue, QueueLen);
+        {next_state, NStateName, NStateData} ->
+            loop(Parent, Name, NStateName, NStateData,
+                 Mod, infinity, [], Limits, Queue, QueueLen);
+        {next_state, NStateName, NStateData, Time1} ->
+            loop(Parent, Name, NStateName, NStateData, Mod, Time1, [],
+                 Limits, Queue, QueueLen);
         {reply, Reply, NStateName, NStateData} when From =/= undefined ->
-	    reply(From, Reply),
-	    loop(Parent, Name, NStateName, NStateData,
-		 Mod, infinity, [], Limits, Queue, QueueLen);
+            reply(From, Reply),
+            loop(Parent, Name, NStateName, NStateData,
+                 Mod, infinity, [], Limits, Queue, QueueLen);
         {reply, Reply, NStateName, NStateData, Time1} when From =/= undefined ->
-	    reply(From, Reply),
-	    loop(Parent, Name, NStateName, NStateData, Mod, Time1, [],
-		 Limits, Queue, QueueLen);
-	{migrate, NStateData, {Node, M, F, A}, Time1} ->
-	    Reason = case catch rpc:call(Node, M, F, A, 5000) of
-			 {badrpc, _} = Err ->
-			     {migration_error, Err};
-			 {'EXIT', _} = Err ->
-			     {migration_error, Err};
-			 {error, _} = Err ->
-			     {migration_error, Err};
-			 {ok, Clone} ->
-			     process_flag(trap_exit, true),
-			     MRef = erlang:monitor(process, Clone),
-			     TRef = erlang:start_timer(Time1, self(), timeout),
-			     relay_messages(MRef, TRef, Clone, Queue);
-			 Reply ->
-			     {migration_error, {bad_reply, Reply}}
-		     end,
-	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, []);
-	{stop, Reason, NStateData} ->
-	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, []);
-	{stop, Reason, Reply, NStateData} when From =/= undefined ->
-	    {'EXIT', R} = (catch terminate(Reason, Name, Msg, Mod,
-					   StateName, NStateData, [])),
-	    reply(From, Reply),
-	    exit(R);
-	{'EXIT', What} ->
-	    terminate(What, Name, Msg, Mod, StateName, StateData, []);
-	Reply ->
-	    terminate({bad_return_value, Reply},
-		      Name, Msg, Mod, StateName, StateData, [])
+            reply(From, Reply),
+            loop(Parent, Name, NStateName, NStateData, Mod, Time1, [],
+                 Limits, Queue, QueueLen);
+        {migrate, NStateData, {Node, M, F, A}, Time1} ->
+            Reason = case catch rpc:call(Node, M, F, A, 5000) of
+                         {badrpc, _} = Err ->
+                             {migration_error, Err};
+                         {'EXIT', _} = Err ->
+                             {migration_error, Err};
+                         {error, _} = Err ->
+                             {migration_error, Err};
+                         {ok, Clone} ->
+                             process_flag(trap_exit, true),
+                             MRef = erlang:monitor(process, Clone),
+                             TRef = erlang:start_timer(Time1, self(), timeout),
+                             relay_messages(MRef, TRef, Clone, Queue);
+                         Reply ->
+                             {migration_error, {bad_reply, Reply}}
+                     end,
+            terminate(Reason, Name, Msg, Mod, StateName, NStateData, []);
+        {stop, Reason, NStateData} ->
+            terminate(Reason, Name, Msg, Mod, StateName, NStateData, []);
+        {stop, Reason, Reply, NStateData} when From =/= undefined ->
+            {'EXIT', R} = (catch terminate(Reason, Name, Msg, Mod,
+                                           StateName, NStateData, [])),
+            reply(From, Reply),
+            exit(R);
+        {'EXIT', What} ->
+            terminate(What, Name, Msg, Mod, StateName, StateData, []);
+        Reply ->
+            terminate({bad_return_value, Reply},
+                      Name, Msg, Mod, StateName, StateData, [])
     end.
 
 handle_msg(Msg, Parent, Name, StateName, StateData,
-	   Mod, _Time, Debug, Limits, Queue, QueueLen) ->
+           Mod, _Time, Debug, Limits, Queue, QueueLen) ->
     From = from(Msg),
     case catch dispatch(Msg, Mod, StateName, StateData) of
-	{next_state, NStateName, NStateData} ->
-	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
-				      {Name, NStateName}, return),
-	    loop(Parent, Name, NStateName, NStateData,
-		 Mod, infinity, Debug1, Limits, Queue, QueueLen);
-	{next_state, NStateName, NStateData, Time1} ->
-	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
-				      {Name, NStateName}, return),
-	    loop(Parent, Name, NStateName, NStateData,
-		 Mod, Time1, Debug1, Limits, Queue, QueueLen);
+        {next_state, NStateName, NStateData} ->
+            Debug1 = sys:handle_debug(Debug, fun print_event/3,
+                                      {Name, NStateName}, return),
+            loop(Parent, Name, NStateName, NStateData,
+                 Mod, infinity, Debug1, Limits, Queue, QueueLen);
+        {next_state, NStateName, NStateData, Time1} ->
+            Debug1 = sys:handle_debug(Debug, fun print_event/3,
+                                      {Name, NStateName}, return),
+            loop(Parent, Name, NStateName, NStateData,
+                 Mod, Time1, Debug1, Limits, Queue, QueueLen);
         {reply, Reply, NStateName, NStateData} when From =/= undefined ->
-	    Debug1 = reply(Name, From, Reply, Debug, NStateName),
-	    loop(Parent, Name, NStateName, NStateData,
-		 Mod, infinity, Debug1, Limits, Queue, QueueLen);
+            Debug1 = reply(Name, From, Reply, Debug, NStateName),
+            loop(Parent, Name, NStateName, NStateData,
+                 Mod, infinity, Debug1, Limits, Queue, QueueLen);
         {reply, Reply, NStateName, NStateData, Time1} when From =/= undefined ->
-	    Debug1 = reply(Name, From, Reply, Debug, NStateName),
-	    loop(Parent, Name, NStateName, NStateData,
-		 Mod, Time1, Debug1, Limits, Queue, QueueLen);
-	{migrate, NStateData, {Node, M, F, A}, Time1} ->
-	    Reason = case catch rpc:call(Node, M, F, A, Time1) of
-			 {badrpc, R} ->
-			     {migration_error, R};
-			 {'EXIT', R} ->
-			     {migration_error, R};
-			 {error, R} ->
-			     {migration_error, R};
-			 {ok, Clone} ->
-			     process_flag(trap_exit, true),
-			     MRef = erlang:monitor(process, Clone),
-			     TRef = erlang:start_timer(Time1, self(), timeout),
-			     relay_messages(MRef, TRef, Clone, Queue);
-			 Reply ->
-			     {migration_error, {bad_reply, Reply}}
-		     end,
-	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, Debug);
-	{stop, Reason, NStateData} ->
-	    terminate(Reason, Name, Msg, Mod, StateName, NStateData, Debug);
-	{stop, Reason, Reply, NStateData} when From =/= undefined ->
-	    {'EXIT', R} = (catch terminate(Reason, Name, Msg, Mod,
-					   StateName, NStateData, Debug)),
-	    reply(Name, From, Reply, Debug, StateName),
-	    exit(R);
-	{'EXIT', What} ->
-	    terminate(What, Name, Msg, Mod, StateName, StateData, Debug);
-	Reply ->
-	    terminate({bad_return_value, Reply},
-		      Name, Msg, Mod, StateName, StateData, Debug)
+            Debug1 = reply(Name, From, Reply, Debug, NStateName),
+            loop(Parent, Name, NStateName, NStateData,
+                 Mod, Time1, Debug1, Limits, Queue, QueueLen);
+        {migrate, NStateData, {Node, M, F, A}, Time1} ->
+            Reason = case catch rpc:call(Node, M, F, A, Time1) of
+                         {badrpc, R} ->
+                             {migration_error, R};
+                         {'EXIT', R} ->
+                             {migration_error, R};
+                         {error, R} ->
+                             {migration_error, R};
+                         {ok, Clone} ->
+                             process_flag(trap_exit, true),
+                             MRef = erlang:monitor(process, Clone),
+                             TRef = erlang:start_timer(Time1, self(), timeout),
+                             relay_messages(MRef, TRef, Clone, Queue);
+                         Reply ->
+                             {migration_error, {bad_reply, Reply}}
+                     end,
+            terminate(Reason, Name, Msg, Mod, StateName, NStateData, Debug);
+        {stop, Reason, NStateData} ->
+            terminate(Reason, Name, Msg, Mod, StateName, NStateData, Debug);
+        {stop, Reason, Reply, NStateData} when From =/= undefined ->
+            {'EXIT', R} = (catch terminate(Reason, Name, Msg, Mod,
+                                           StateName, NStateData, Debug)),
+            reply(Name, From, Reply, Debug, StateName),
+            exit(R);
+        {'EXIT', What} ->
+            terminate(What, Name, Msg, Mod, StateName, StateData, Debug);
+        Reply ->
+            terminate({bad_return_value, Reply},
+                      Name, Msg, Mod, StateName, StateData, Debug)
     end.
 
 dispatch({'$gen_event', Event}, Mod, StateName, StateData) ->
@@ -679,7 +679,7 @@ dispatch({'$gen_all_state_event', Event}, Mod, StateName, StateData) ->
 dispatch({'$gen_sync_event', From, Event}, Mod, StateName, StateData) ->
     Mod:StateName(Event, From, StateData);
 dispatch({'$gen_sync_all_state_event', From, Event},
-	 Mod, StateName, StateData) ->
+         Mod, StateName, StateData) ->
     Mod:handle_sync_event(Event, From, StateName, StateData);
 dispatch({timeout, Ref, {'$gen_timer', Msg}}, Mod, StateName, StateData) ->
     Mod:StateName({timeout, Ref, Msg}, StateData);
@@ -699,7 +699,7 @@ reply({To, Tag}, Reply) ->
 reply(Name, {To, Tag}, Reply, Debug, StateName) ->
     reply({To, Tag}, Reply),
     sys:handle_debug(Debug, fun print_event/3, Name,
-		     {out, Reply, To, StateName}).
+                     {out, Reply, To, StateName}).
 
 %%% ---------------------------------------------------
 %%% Terminate the server.
@@ -707,54 +707,54 @@ reply(Name, {To, Tag}, Reply, Debug, StateName) ->
 
 terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug) ->
     case catch Mod:terminate(Reason, StateName, StateData) of
-	{'EXIT', R} ->
-	    error_info(Mod, R, Name, Msg, StateName, StateData, Debug),
-	    exit(R);
-	_ ->
-	    case Reason of
-		normal ->
-		    exit(normal);
-		shutdown ->
-		    exit(shutdown);
-		priority_shutdown ->
-		    %% Priority shutdown should be considered as
-		    %% shutdown by SASL
-		    exit(shutdown);
-		{process_limit, _Limit} ->
-		    exit(Reason);
-		{migrated, _Clone} ->
-		    exit(normal);
-		_ ->
-		    error_info(Mod, Reason, Name, Msg, StateName, StateData, Debug),
-		    exit(Reason)
-	    end
+        {'EXIT', R} ->
+            error_info(Mod, R, Name, Msg, StateName, StateData, Debug),
+            exit(R);
+        _ ->
+            case Reason of
+                normal ->
+                    exit(normal);
+                shutdown ->
+                    exit(shutdown);
+                priority_shutdown ->
+                    %% Priority shutdown should be considered as
+                    %% shutdown by SASL
+                    exit(shutdown);
+                {process_limit, _Limit} ->
+                    exit(Reason);
+                {migrated, _Clone} ->
+                    exit(normal);
+                _ ->
+                    error_info(Mod, Reason, Name, Msg, StateName, StateData, Debug),
+                    exit(Reason)
+            end
     end.
 
 error_info(Mod, Reason, Name, Msg, StateName, StateData, Debug) ->
     Reason1 =
-	case Reason of
-	    {undef, [{M, F, A}|MFAs]} ->
-		case code:is_loaded(M) of
-		    false ->
-			{'module could not be loaded', [{M, F, A}|MFAs]};
-		    _ ->
-			case erlang:function_exported(M, F, length(A)) of
-			    true ->
-				Reason;
-			    false ->
-				{'function not exported', [{M, F, A}|MFAs]}
-			end
-		end;
-	    _ ->
-		Reason
-	end,
+        case Reason of
+            {undef, [{M, F, A}|MFAs]} ->
+                case code:is_loaded(M) of
+                    false ->
+                        {'module could not be loaded', [{M, F, A}|MFAs]};
+                    _ ->
+                        case erlang:function_exported(M, F, length(A)) of
+                            true ->
+                                Reason;
+                            false ->
+                                {'function not exported', [{M, F, A}|MFAs]}
+                        end
+                end;
+            _ ->
+                Reason
+        end,
     StateToPrint = case erlang:function_exported(Mod, print_state, 1) of
       true -> (catch Mod:print_state(StateData));
       false -> StateData
     end,
     Str = "** State machine ~p terminating \n" ++
-	get_msg_str(Msg) ++
-	"** When State == ~p~n"
+        get_msg_str(Msg) ++
+        "** When State == ~p~n"
         "**      Data  == ~p~n"
         "** Reason for termination = ~n** ~p~n",
     format(Str, [Name, get_msg(Msg), StateName, StateToPrint, Reason1]),
@@ -789,29 +789,29 @@ get_msg(Msg) -> Msg.
 %%-----------------------------------------------------------------
 format_status(Opt, StatusData) ->
     [PDict, SysState, Parent, Debug, [Name, StateName, StateData, Mod, _Time | _]] =
-	StatusData,
+        StatusData,
     NameTag = if is_pid(Name) ->
-		      pid_to_list(Name);
-		 is_atom(Name) ->
-		      Name
-	      end,
+                      pid_to_list(Name);
+                 is_atom(Name) ->
+                      Name
+              end,
     Header = lists:concat(["Status for state machine ", NameTag]),
     Log = sys:get_debug(log, Debug, []),
     Specfic =
-	case erlang:function_exported(Mod, format_status, 2) of
-	    true ->
-		case catch Mod:format_status(Opt, [PDict, StateData]) of
-		    {'EXIT', _} -> [{data, [{"StateData", StateData}]}];
-		    Else -> Else
-		end;
-	    _ ->
-		[{data, [{"StateData", StateData}]}]
-	end,
+        case erlang:function_exported(Mod, format_status, 2) of
+            true ->
+                case catch Mod:format_status(Opt, [PDict, StateData]) of
+                    {'EXIT', _} -> [{data, [{"StateData", StateData}]}];
+                    Else -> Else
+                end;
+            _ ->
+                [{data, [{"StateData", StateData}]}]
+        end,
     [{header, Header},
      {data, [{"Status", SysState},
-	     {"Parent", Parent},
-	     {"Logged events", Log},
-	     {"StateName", StateName}]} |
+             {"Parent", Parent},
+             {"Logged events", Log},
+             {"StateName", StateName}]} |
      Specfic].
 
 %%-----------------------------------------------------------------
@@ -838,7 +838,7 @@ message_queue_len(#limits{max_queue = MaxQueue}, QueueLen) ->
     Pid = self(),
     case process_info(Pid, message_queue_len) of
         {message_queue_len, N} when N + QueueLen > MaxQueue ->
-	    throw({process_limit, {max_queue, N + QueueLen}});
-	_ ->
-	    ok
+            throw({process_limit, {max_queue, N + QueueLen}});
+        _ ->
+            ok
     end.

--- a/apps/ejabberd/src/rdbms/rdbms_queries.erl
+++ b/apps/ejabberd/src/rdbms/rdbms_queries.erl
@@ -31,74 +31,74 @@
          begin_trans/0,
          get_db_specific_limits/1,
          get_db_specific_offset/2,
-	     sql_transaction/2,
-	     get_last/2,
-	     select_last/3,
-	     set_last_t/4,
-	     del_last/2,
-	     get_password/2,
-	     set_password_t/3,
-	     add_user/3,
-	     del_user/2,
-	     del_user_return_password/3,
-	     list_users/1,
+         sql_transaction/2,
+         get_last/2,
+         select_last/3,
+         set_last_t/4,
+         del_last/2,
+         get_password/2,
+         set_password_t/3,
+         add_user/3,
+         del_user/2,
+         del_user_return_password/3,
+         list_users/1,
          list_users/2,
-	     users_number/1,
+         users_number/1,
          users_number/2,
-	     get_users_without_scram/2,
-	     get_users_without_scram_count/1,
+         get_users_without_scram/2,
+         get_users_without_scram_count/1,
          get_average_roster_size/1,
          get_average_rostergroup_size/1,
          clear_rosters/1,
-	     get_roster/2,
-	     get_roster_jid_groups/2,
-	     get_roster_groups/3,
-	     del_user_roster_t/2,
-	     get_roster_by_jid/3,
-	     get_rostergroup_by_jid/3,
-	     del_roster/3,
-	     del_roster_sql/2,
-	     update_roster/5,
-	     update_roster_sql/4,
-	     roster_subscribe/4,
-	     get_subscription/3,
-	     set_private_data/4,
-	     set_private_data_sql/3,
-	     get_private_data/3,
-	     multi_get_private_data/3,
-	     multi_set_private_data/3,
-	     del_user_private_storage/2,
-	     get_default_privacy_list/2,
-	     get_default_privacy_list_t/1,
+         get_roster/2,
+         get_roster_jid_groups/2,
+         get_roster_groups/3,
+         del_user_roster_t/2,
+         get_roster_by_jid/3,
+         get_rostergroup_by_jid/3,
+         del_roster/3,
+         del_roster_sql/2,
+         update_roster/5,
+         update_roster_sql/4,
+         roster_subscribe/4,
+         get_subscription/3,
+         set_private_data/4,
+         set_private_data_sql/3,
+         get_private_data/3,
+         multi_get_private_data/3,
+         multi_set_private_data/3,
+         del_user_private_storage/2,
+         get_default_privacy_list/2,
+         get_default_privacy_list_t/1,
          count_privacy_lists/1,
          clear_privacy_lists/1,
-	     get_privacy_list_names/2,
-	     get_privacy_list_names_t/1,
-	     get_privacy_list_id/3,
-	     get_privacy_list_id_t/2,
-	     get_privacy_list_data/3,
-	     get_privacy_list_data_by_id/2,
-	     set_default_privacy_list/2,
-	     unset_default_privacy_list/2,
-	     remove_privacy_list/2,
-	     add_privacy_list/2,
-	     set_privacy_list/2,
-	     del_privacy_lists/3,
-	     set_vcard/26,
-	     get_vcard/2,
+         get_privacy_list_names/2,
+         get_privacy_list_names_t/1,
+         get_privacy_list_id/3,
+         get_privacy_list_id_t/2,
+         get_privacy_list_data/3,
+         get_privacy_list_data_by_id/2,
+         set_default_privacy_list/2,
+         unset_default_privacy_list/2,
+         remove_privacy_list/2,
+         add_privacy_list/2,
+         set_privacy_list/2,
+         del_privacy_lists/3,
+         set_vcard/26,
+         get_vcard/2,
          search_vcard/3,
-	     escape_string/1,
-	     escape_like_string/1,
-	     count_records_where/3,
-	     get_roster_version/2,
-	     set_roster_version/2,
-	     prepare_offline_message/6,
-	     push_offline_messages/2,
-	     pop_offline_messages/4,
-	     count_offline_messages/4,
-	     remove_old_offline_messages/2,
-	     remove_expired_offline_messages/2,
-	     remove_offline_messages/3]).
+         escape_string/1,
+         escape_like_string/1,
+         count_records_where/3,
+         get_roster_version/2,
+         set_roster_version/2,
+         prepare_offline_message/6,
+         push_offline_messages/2,
+         pop_offline_messages/4,
+         count_offline_messages/4,
+         remove_old_offline_messages/2,
+         remove_expired_offline_messages/2,
+         remove_offline_messages/3]).
 
 %% We have only two compile time options for db queries:
 %%-define(generic, true).
@@ -154,17 +154,17 @@ get_db_type() ->
 %% Safe atomic update.
 update_t(Table, Fields, Vals, Where) ->
     UPairs = lists:zipwith(fun(A, B) -> [A, "='", B, "'"] end,
-			   Fields, Vals),
+                           Fields, Vals),
     case mongoose_rdbms:sql_query_t(
-	   [<<"update ">>, Table, <<" set ">>,
-	    join(UPairs, ", "),
-	    <<" where ">>, Where, ";"]) of
-	{updated, 1} ->
-	    ok;
-	_ ->
-	    mongoose_rdbms:sql_query_t(
-	      [<<"insert into ">>, Table, "(", join(Fields, ", "),
-	       <<") values ('">>, join(Vals, "', '"), "');"])
+           [<<"update ">>, Table, <<" set ">>,
+            join(UPairs, ", "),
+            <<" where ">>, Where, ";"]) of
+        {updated, 1} ->
+            ok;
+        _ ->
+            mongoose_rdbms:sql_query_t(
+              [<<"insert into ">>, Table, "(", join(Fields, ", "),
+               <<") values ('">>, join(Vals, "', '"), "');"])
     end.
 
 %% Safe atomic update.
@@ -174,17 +174,17 @@ update_t(Table, Fields, Vals, Where) ->
 %% This function is useful, when there are a lot of fields to update.
 update_set_t(Table, FieldsVals, Where) ->
     case mongoose_rdbms:sql_query_t(
-	   [<<"update ">>, Table, <<" set ">>,
+           [<<"update ">>, Table, <<" set ">>,
         join_field_and_values(FieldsVals),
-	    <<" where ">>, Where, ";"]) of
-	{updated, 1} ->
-	    ok;
-	_ ->
+            <<" where ">>, Where, ";"]) of
+        {updated, 1} ->
+            ok;
+        _ ->
         Fields = odds(FieldsVals),
         Vals = evens(FieldsVals),
-	    mongoose_rdbms:sql_query_t(
-	      [<<"insert into ">>, Table, "(", join(Fields, ", "),
-	       <<") values ('">>, join(Vals, "', '"), "');"])
+            mongoose_rdbms:sql_query_t(
+              [<<"insert into ">>, Table, "(", join(Fields, ", "),
+               <<") values ('">>, join(Vals, "', '"), "');"])
     end.
 
 odds([X, _|T]) -> [X|odds(T)];
@@ -206,19 +206,19 @@ join_field_and_values_1([]) ->
 
 update(LServer, Table, Fields, Vals, Where) ->
     UPairs = lists:zipwith(fun(A, B) -> [A, "='", B, "'"] end,
-			   Fields, Vals),
+                           Fields, Vals),
     case mongoose_rdbms:sql_query(
-	   LServer,
-	   [<<"update ">>, Table, <<" set ">>,
-	    join(UPairs, ", "),
-	    <<" where ">>, Where, ";"]) of
-	{updated, 1} ->
-	    ok;
-	_ ->
-	    mongoose_rdbms:sql_query(
-	      LServer,
-	      [<<"insert into ">>, Table, "(", join(Fields, ", "),
-	       <<") values ('">>, join(Vals, "', '"), "');"])
+           LServer,
+           [<<"update ">>, Table, <<" set ">>,
+            join(UPairs, ", "),
+            <<" where ">>, Where, ";"]) of
+        {updated, 1} ->
+            ok;
+        _ ->
+            mongoose_rdbms:sql_query(
+              LServer,
+              [<<"insert into ">>, Table, "(", join(Fields, ", "),
+               <<") values ('">>, join(Vals, "', '"), "');"])
     end.
 
 %% F can be either a fun or a list of queries
@@ -250,8 +250,8 @@ select_last(LServer, TStamp, Comparator) ->
 
 set_last_t(LServer, Username, Seconds, State) ->
     update(LServer, "last", ["username", "seconds", "state"],
-	   [Username, Seconds, State],
-	   [<<"username='">>, Username, "'"]).
+           [Username, Seconds, State],
+           [<<"username='">>, Username, "'"]).
 
 del_last(LServer, Username) ->
     mongoose_rdbms:sql_query(
@@ -268,17 +268,17 @@ set_password_t(LServer, Username, {Pass, PassDetails}) ->
     mongoose_rdbms:sql_transaction(
       LServer,
       fun() ->
-	      update_t(<<"users">>, [<<"password">>, <<"pass_details">>],
-		       [Pass, PassDetails],
-		       [<<"username='">>, Username, <<"'">>])
+              update_t(<<"users">>, [<<"password">>, <<"pass_details">>],
+                       [Pass, PassDetails],
+                       [<<"username='">>, Username, <<"'">>])
       end);
 set_password_t(LServer, Username, Pass) ->
     mongoose_rdbms:sql_transaction(
       LServer,
       fun() ->
-	      update_t(<<"users">>, [<<"username">>, <<"password">>],
-		       [Username, Pass],
-		       [<<"username='">>, Username, <<"'">>])
+              update_t(<<"users">>, [<<"username">>, <<"password">>],
+                       [Username, Pass],
+                       [<<"username='">>, Username, <<"'">>])
       end).
 
 add_user(LServer, Username, {Pass, PassDetails}) ->
@@ -299,11 +299,11 @@ del_user(LServer, Username) ->
 
 del_user_return_password(_LServer, Username, Pass) ->
     P = mongoose_rdbms:sql_query_t(
-	  [<<"select password from users where username='">>,
-	   Username, "';"]),
+          [<<"select password from users where username='">>,
+           Username, "';"]),
     mongoose_rdbms:sql_query_t([<<"delete from users "
-			       "where username='">>, Username,
-			       <<"' and password='">>, Pass, "';"]),
+                               "where username='">>, Username,
+                               <<"' and password='">>, Pass, "';"]),
     P.
 
 list_users(LServer) ->
@@ -400,10 +400,10 @@ clear_rosters(Server) ->
     mongoose_rdbms:sql_transaction(
       Server,
       fun() ->
-	      mongoose_rdbms:sql_query_t(
-		[<<"delete from rosterusers;">>]),
-	      mongoose_rdbms:sql_query_t(
-		[<<"delete from rostergroups;">>])
+              mongoose_rdbms:sql_query_t(
+                [<<"delete from rosterusers;">>]),
+              mongoose_rdbms:sql_query_t(
+                [<<"delete from rostergroups;">>])
       end).
 
 get_roster(LServer, Username) ->
@@ -429,12 +429,12 @@ del_user_roster_t(LServer, Username) ->
     mongoose_rdbms:sql_transaction(
       LServer,
       fun() ->
-	      mongoose_rdbms:sql_query_t(
-		[<<"delete from rosterusers "
-		   "where username='">>, Username, "';"]),
-	      mongoose_rdbms:sql_query_t(
-		[<<"delete from rostergroups "
-		   "where username='">>, Username, "';"])
+              mongoose_rdbms:sql_query_t(
+                [<<"delete from rosterusers "
+                   "where username='">>, Username, "';"]),
+              mongoose_rdbms:sql_query_t(
+                [<<"delete from rostergroups "
+                   "where username='">>, Username, "';"])
       end).
 
 get_roster_by_jid(_LServer, Username, SJID) ->
@@ -471,20 +471,20 @@ del_roster_sql(Username, SJID) ->
 
 update_roster(_LServer, Username, SJID, ItemVals, ItemGroups) ->
     update_t(<<"rosterusers">>,
-	     [<<"username">>, <<"jid">>, <<"nick">>, <<"subscription">>, <<"ask">>,
-	      <<"askmessage">>, <<"server">>, <<"subscribe">>, <<"type">>],
-	     ItemVals,
-	     [<<"username='">>, Username, <<"' and jid='">>, SJID, "'"]),
+             [<<"username">>, <<"jid">>, <<"nick">>, <<"subscription">>, <<"ask">>,
+              <<"askmessage">>, <<"server">>, <<"subscribe">>, <<"type">>],
+             ItemVals,
+             [<<"username='">>, Username, <<"' and jid='">>, SJID, "'"]),
     mongoose_rdbms:sql_query_t(
       [<<"delete from rostergroups "
          "where username='">>, Username, <<"' "
          "and jid='">>, SJID, "';"]),
     lists:foreach(fun(ItemGroup) ->
-			  mongoose_rdbms:sql_query_t(
-			    [<<"insert into rostergroups(username, jid, grp) "
-			       "values ('">>, join(ItemGroup, "', '"), "');"])
-		  end,
-		  ItemGroups).
+                          mongoose_rdbms:sql_query_t(
+                            [<<"insert into rostergroups(username, jid, grp) "
+                               "values ('">>, join(ItemGroup, "', '"), "');"])
+                  end,
+                  ItemGroups).
 
 update_roster_sql(Username, SJID, ItemVals, ItemGroups) ->
     [[<<"delete from rosterusers "
@@ -504,10 +504,10 @@ update_roster_sql(Username, SJID, ItemVals, ItemGroups) ->
 
 roster_subscribe(_LServer, Username, SJID, ItemVals) ->
     update_t(<<"rosterusers">>,
-	     [<<"username">>, <<"jid">>, <<"nick">>, <<"subscription">>, <<"ask">>,
-	      <<"askmessage">>, <<"server">>, <<"subscribe">>, <<"type">>],
-	     ItemVals,
-	     [<<"username='">>, Username, <<"' and jid='">>, SJID, "'"]).
+             [<<"username">>, <<"jid">>, <<"nick">>, <<"subscription">>, <<"ask">>,
+              <<"askmessage">>, <<"server">>, <<"subscribe">>, <<"type">>],
+             ItemVals,
+             [<<"username='">>, Username, <<"' and jid='">>, SJID, "'"]).
 
 get_subscription(LServer, Username, SJID) ->
     mongoose_rdbms:sql_query(
@@ -518,9 +518,9 @@ get_subscription(LServer, Username, SJID) ->
 
 set_private_data(_LServer, Username, LXMLNS, SData) ->
     update_t(<<"private_storage">>,
-	     [<<"username">>, <<"namespace">>, <<"data">>],
-	     [Username, LXMLNS, SData],
-	     [<<"username='">>, Username, <<"' and namespace='">>, LXMLNS, "'"]).
+             [<<"username">>, <<"namespace">>, <<"data">>],
+             [Username, LXMLNS, SData],
+             [<<"username='">>, Username, <<"' and namespace='">>, LXMLNS, "'"]).
 
 set_private_data_sql(Username, LXMLNS, SData) ->
     [[<<"delete from private_storage "
@@ -560,9 +560,9 @@ del_user_private_storage(LServer, Username) ->
       [<<"delete from private_storage where username='">>, Username, "';"]).
 
 set_vcard(LServer, LUsername, SBDay, SCTRY, SEMail, SFN, SFamily, SGiven,
-	  SLBDay, SLCTRY, SLEMail, SLFN, SLFamily, SLGiven, SLLocality,
-	  SLMiddle, SLNickname, SLOrgName, SLOrgUnit, SLocality, SMiddle,
-	  SNickname, SOrgName, SOrgUnit, SVCARD, Username) ->
+          SLBDay, SLCTRY, SLEMail, SLFN, SLFamily, SLGiven, SLLocality,
+          SLMiddle, SLNickname, SLOrgName, SLOrgUnit, SLocality, SMiddle,
+          SNickname, SOrgName, SOrgUnit, SVCARD, Username) ->
     mongoose_rdbms:sql_transaction(
       LServer,
       fun() ->
@@ -689,7 +689,7 @@ get_privacy_list_data_by_id(LServer, ID) ->
 
 set_default_privacy_list(Username, SName) ->
     update_t(<<"privacy_default_list">>, [<<"username">>, <<"name">>],
-	     [Username, SName], [<<"username='">>, Username, "'"]).
+             [Username, SName], [<<"username='">>, Username, "'"]).
 
 unset_default_privacy_list(LServer, Username) ->
     mongoose_rdbms:sql_query(
@@ -712,15 +712,15 @@ set_privacy_list(ID, RItems) ->
       [<<"delete from privacy_list_data "
          "where id='">>, ID, "';"]),
     lists:foreach(fun(Items) ->
-			  mongoose_rdbms:sql_query_t(
-			    [<<"insert into privacy_list_data("
-			       "id, t, value, action, ord, match_all, match_iq, "
-			       "match_message, match_presence_in, "
-			       "match_presence_out "
-			       ") "
-			       "values ('">>, ID, "', '",
-			     join(Items, "', '"), "');"])
-		  end, RItems).
+                          mongoose_rdbms:sql_query_t(
+                            [<<"insert into privacy_list_data("
+                               "id, t, value, action, ord, match_all, match_iq, "
+                               "match_message, match_presence_in, "
+                               "match_presence_out "
+                               ") "
+                               "values ('">>, ID, "', '",
+                             join(Items, "', '"), "');"])
+                  end, RItems).
 
 del_privacy_lists(LServer, _Server, Username) ->
     mongoose_rdbms:sql_query(
@@ -768,7 +768,7 @@ pop_offline_messages(LServer, SUser, SServer, STimeStamp) ->
     SelectSQL = select_offline_messages_sql(SUser, SServer, STimeStamp),
     DeleteSQL = delete_offline_messages_sql(SUser, SServer),
     F = fun() ->
-	      Res = mongoose_rdbms:sql_query_t(SelectSQL),
+              Res = mongoose_rdbms:sql_query_t(SelectSQL),
           mongoose_rdbms:sql_query_t(DeleteSQL),
           Res
         end,
@@ -855,5 +855,3 @@ do_get_db_specific_offset(mssql, Offset, Limit) ->
     " FETCH NEXT ", Limit, " ROWS ONLY"];
 do_get_db_specific_offset(_, Offset, _Limit) ->
     [" OFFSET ", Offset].
-
-

--- a/apps/ejabberd/src/scram.erl
+++ b/apps/ejabberd/src/scram.erl
@@ -86,8 +86,8 @@ client_signature(StoredKey, AuthMessage) ->
 -spec client_key(binary(), binary()) -> binary().
 client_key(ClientProof, ClientSignature) ->
     list_to_binary(lists:zipwith(fun (X, Y) -> X bxor Y end,
-				 binary_to_list(ClientProof),
-				 binary_to_list(ClientSignature))).
+                                 binary_to_list(ClientProof),
+                                 binary_to_list(ClientSignature))).
 
 -spec server_signature(binary(), binary()) -> binary().
 server_signature(ServerKey, AuthMessage) ->
@@ -96,18 +96,18 @@ server_signature(ServerKey, AuthMessage) ->
 hi(Password, Salt, IterationCount) ->
     U1 = crypto:hmac(sha, Password, <<Salt/binary, 0, 0, 0, 1>>),
     list_to_binary(lists:zipwith(fun (X, Y) -> X bxor Y end,
-				 binary_to_list(U1),
-				 binary_to_list(hi_round(Password, U1,
-							 IterationCount - 1)))).
+                                 binary_to_list(U1),
+                                 binary_to_list(hi_round(Password, U1,
+                                                         IterationCount - 1)))).
 
 hi_round(Password, UPrev, 1) ->
     crypto:hmac(sha, Password, UPrev);
 hi_round(Password, UPrev, IterationCount) ->
     U = crypto:hmac(sha, Password, UPrev),
     list_to_binary(lists:zipwith(fun (X, Y) -> X bxor Y end,
-				 binary_to_list(U),
-				 binary_to_list(hi_round(Password, U,
-							 IterationCount - 1)))).
+                                 binary_to_list(U),
+                                 binary_to_list(hi_round(Password, U,
+                                                         IterationCount - 1)))).
 
 
 enabled(Host) ->

--- a/apps/ejabberd/src/supervisor2.erl
+++ b/apps/ejabberd/src/supervisor2.erl
@@ -73,14 +73,14 @@
 
 %% External exports
 -export([start_link/2, start_link/3,
-	 start_child/2, restart_child/2,
-	 delete_child/2, terminate_child/2,
-	 which_children/1, count_children/1,
-	 find_child/2, check_childspecs/1]).
+         start_child/2, restart_child/2,
+         delete_child/2, terminate_child/2,
+         which_children/1, count_children/1,
+         find_child/2, check_childspecs/1]).
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-	 terminate/2, code_change/3]).
+         terminate/2, code_change/3]).
 -export([try_again_restart/3]).
 
 %%--------------------------------------------------------------------------
@@ -118,23 +118,23 @@
 
 -ifdef(use_specs).
 -record(child, {% pid is undefined when child is not running
-	        pid = undefined :: child() | {restarting, pid()} | [pid()],
-		name            :: child_id(),
-		mfargs          :: mfargs(),
-		restart_type    :: restart(),
-		shutdown        :: shutdown(),
-		child_type      :: worker(),
-		modules = []    :: modules()}).
+                pid = undefined :: child() | {restarting, pid()} | [pid()],
+                name            :: child_id(),
+                mfargs          :: mfargs(),
+                restart_type    :: restart(),
+                shutdown        :: shutdown(),
+                child_type      :: worker(),
+                modules = []    :: modules()}).
 -type child_rec() :: #child{}.
 -else.
 -record(child, {
-	        pid = undefined,
-		name,
-		mfargs,
-		restart_type,
-		shutdown,
-		child_type,
-		modules = []}).
+                pid = undefined,
+                name,
+                mfargs,
+                restart_type,
+                shutdown,
+                child_type,
+                modules = []}).
 -endif.
 
 -define(DICT, dict).
@@ -143,25 +143,25 @@
 
 -ifdef(use_specs).
 -record(state, {name,
-		strategy               :: strategy(),
-		children = []          :: [child_rec()],
-		dynamics               :: ?DICT() | ?SET(),
-		intensity              :: non_neg_integer(),
-		period                 :: pos_integer(),
-		restarts = [],
-	        module,
-	        args}).
+                strategy               :: strategy(),
+                children = []          :: [child_rec()],
+                dynamics               :: ?DICT() | ?SET(),
+                intensity              :: non_neg_integer(),
+                period                 :: pos_integer(),
+                restarts = [],
+                module,
+                args}).
 -type state() :: #state{}.
 -else.
 -record(state, {name,
-		strategy,
-		children = [],
-		dynamics,
-		intensity,
-		period,
-		restarts = [],
-	        module,
-	        args}).
+                strategy,
+                children = [],
+                dynamics,
+                intensity,
+                period,
+                restarts = [],
+                module,
+                args}).
 -endif.
 
 -define(is_simple(State), State#state.strategy =:= simple_one_for_one).
@@ -200,7 +200,7 @@
 -endif.
 start_link(Mod, Args) ->
     gen_server:start_link(?MODULE, {self, Mod, Args}, []).
- 
+
 -ifdef(use_specs).
 -spec start_link(SupName, Module, Args) -> startlink_ret() when
       SupName :: sup_name(),
@@ -209,16 +209,16 @@ start_link(Mod, Args) ->
 -endif.
 start_link(SupName, Mod, Args) ->
     gen_server:start_link(SupName, ?MODULE, {SupName, Mod, Args}, []).
- 
+
 %%% ---------------------------------------------------
 %%% Interface functions.
 %%% ---------------------------------------------------
 -ifdef(use_specs).
 -type startchild_err() :: 'already_present'
-			| {'already_started', Child :: child()} | term().
+                        | {'already_started', Child :: child()} | term().
 -type startchild_ret() :: {'ok', Child :: child()}
                         | {'ok', Child :: child(), Info :: term()}
-			| {'error', startchild_err()}.
+                        | {'error', startchild_err()}.
 
 -spec start_child(SupRef, ChildSpec) -> startchild_ret() when
       SupRef :: sup_ref(),
@@ -235,7 +235,7 @@ start_child(Supervisor, ChildSpec) ->
               | {'ok', Child :: child(), Info :: term()}
               | {'error', Error},
       Error :: 'running' | 'restarting' | 'not_found' | 'simple_one_for_one' |
-	       term().
+               term().
 -endif.
 restart_child(Supervisor, Name) ->
     call(Supervisor, {restart_child, Name}).
@@ -308,8 +308,8 @@ call(Supervisor, Req) ->
 -endif.
 check_childspecs(ChildSpecs) when is_list(ChildSpecs) ->
     case check_startspec(ChildSpecs) of
-	{ok, _} -> ok;
-	Error -> {error, Error}
+        {ok, _} -> ok;
+        Error -> {error, Error}
     end;
 check_childspecs(X) -> {error, {badarg, X}}.
 
@@ -328,9 +328,9 @@ cast(Supervisor, Req) ->
     gen_server:cast(Supervisor, Req).
 
 %%% ---------------------------------------------------
-%%% 
+%%%
 %%% Initialize the supervisor.
-%%% 
+%%%
 %%% ---------------------------------------------------
 -ifdef(use_specs).
 -type init_sup_name() :: sup_name() | 'self'.
@@ -347,19 +347,19 @@ cast(Supervisor, Req) ->
 init({SupName, Mod, Args}) ->
     process_flag(trap_exit, true),
     case Mod:init(Args) of
-	{ok, {SupFlags, StartSpec}} ->
-	    case init_state(SupName, SupFlags, Mod, Args) of
-		{ok, State} when ?is_simple(State) ->
-		    init_dynamic(State, StartSpec);
-		{ok, State} ->
-		    init_children(State, StartSpec);
-		Error ->
-		    {stop, {supervisor_data, Error}}
-	    end;
-	ignore ->
-	    ignore;
-	Error ->
-	    {stop, {bad_return, {Mod, init, Error}}}
+        {ok, {SupFlags, StartSpec}} ->
+            case init_state(SupName, SupFlags, Mod, Args) of
+                {ok, State} when ?is_simple(State) ->
+                    init_dynamic(State, StartSpec);
+                {ok, State} ->
+                    init_children(State, StartSpec);
+                Error ->
+                    {stop, {supervisor_data, Error}}
+            end;
+        ignore ->
+            ignore;
+        Error ->
+            {stop, {bad_return, {Mod, init, Error}}}
     end.
 
 init_children(State, StartSpec) ->
@@ -380,7 +380,7 @@ init_children(State, StartSpec) ->
 init_dynamic(State, [StartSpec]) ->
     case check_startspec([StartSpec]) of
         {ok, Children} ->
-	    {ok, State#state{children = Children}};
+            {ok, State#state{children = Children}};
         Error ->
             {stop, {start_spec, Error}}
     end;
@@ -401,16 +401,16 @@ start_children(Children, SupName) -> start_children(Children, [], SupName).
 
 start_children([Child|Chs], NChildren, SupName) ->
     case do_start_child(SupName, Child) of
-	{ok, undefined} when Child#child.restart_type =:= temporary ->
-	    start_children(Chs, NChildren, SupName);
-	{ok, Pid} ->
-	    start_children(Chs, [Child#child{pid = Pid}|NChildren], SupName);
-	{ok, Pid, _Extra} ->
-	    start_children(Chs, [Child#child{pid = Pid}|NChildren], SupName);
-	{error, Reason} ->
-	    report_error(start_error, Reason, Child, SupName),
-	    {error, lists:reverse(Chs) ++ [Child | NChildren],
-	     {failed_to_start_child, Child#child.name, Reason}}
+        {ok, undefined} when Child#child.restart_type =:= temporary ->
+            start_children(Chs, NChildren, SupName);
+        {ok, Pid} ->
+            start_children(Chs, [Child#child{pid = Pid}|NChildren], SupName);
+        {ok, Pid, _Extra} ->
+            start_children(Chs, [Child#child{pid = Pid}|NChildren], SupName);
+        {error, Reason} ->
+            report_error(start_error, Reason, Child, SupName),
+            {error, lists:reverse(Chs) ++ [Child | NChildren],
+             {failed_to_start_child, Child#child.name, Reason}}
     end;
 start_children([], NChildren, _SupName) ->
     {ok, NChildren}.
@@ -418,41 +418,41 @@ start_children([], NChildren, _SupName) ->
 do_start_child(SupName, Child) ->
     #child{mfargs = {M, F, Args}} = Child,
     case catch apply(M, F, Args) of
-	{ok, Pid} when is_pid(Pid) ->
-	    NChild = Child#child{pid = Pid},
-	    report_progress(NChild, SupName),
-	    {ok, Pid};
-	{ok, Pid, Extra} when is_pid(Pid) ->
-	    NChild = Child#child{pid = Pid},
-	    report_progress(NChild, SupName),
-	    {ok, Pid, Extra};
-	ignore ->
-	    {ok, undefined};
-	{error, What} -> {error, What};
-	What -> {error, What}
+        {ok, Pid} when is_pid(Pid) ->
+            NChild = Child#child{pid = Pid},
+            report_progress(NChild, SupName),
+            {ok, Pid};
+        {ok, Pid, Extra} when is_pid(Pid) ->
+            NChild = Child#child{pid = Pid},
+            report_progress(NChild, SupName),
+            {ok, Pid, Extra};
+        ignore ->
+            {ok, undefined};
+        {error, What} -> {error, What};
+        What -> {error, What}
     end.
 
 do_start_child_i(M, F, A) ->
     case catch apply(M, F, A) of
-	{ok, Pid} when is_pid(Pid) ->
-	    {ok, Pid};
-	{ok, Pid, Extra} when is_pid(Pid) ->
-	    {ok, Pid, Extra};
-	ignore ->
-	    {ok, undefined};
-	{error, Error} ->
-	    {error, Error};
-	What ->
-	    {error, What}
+        {ok, Pid} when is_pid(Pid) ->
+            {ok, Pid};
+        {ok, Pid, Extra} when is_pid(Pid) ->
+            {ok, Pid, Extra};
+        ignore ->
+            {ok, undefined};
+        {error, Error} ->
+            {error, Error};
+        What ->
+            {error, What}
     end.
 
 %%% ---------------------------------------------------
-%%% 
+%%%
 %%% Callback functions.
-%%% 
+%%%
 %%% ---------------------------------------------------
 -ifdef(use_specs).
--type call() :: 'which_children' | 'count_children' | {_, _}.	% XXX: refine
+-type call() :: 'which_children' | 'count_children' | {_, _}.        % XXX: refine
 -spec handle_call(call(), term(), state()) -> {'reply', term(), state()}.
 -endif.
 handle_call({start_child, EArgs}, _From, State) when ?is_simple(State) ->
@@ -460,34 +460,34 @@ handle_call({start_child, EArgs}, _From, State) when ?is_simple(State) ->
     #child{mfargs = {M, F, A}} = Child,
     Args = A ++ EArgs,
     case do_start_child_i(M, F, Args) of
-	{ok, undefined} when Child#child.restart_type =:= temporary ->
-	    {reply, {ok, undefined}, State};
-	{ok, Pid} ->
-	    NState = save_dynamic_child(Child#child.restart_type, Pid, Args, State),
-	    {reply, {ok, Pid}, NState};
-	{ok, Pid, Extra} ->
-	    NState = save_dynamic_child(Child#child.restart_type, Pid, Args, State),
-	    {reply, {ok, Pid, Extra}, NState};
-	What ->
-	    {reply, What, State}
+        {ok, undefined} when Child#child.restart_type =:= temporary ->
+            {reply, {ok, undefined}, State};
+        {ok, Pid} ->
+            NState = save_dynamic_child(Child#child.restart_type, Pid, Args, State),
+            {reply, {ok, Pid}, NState};
+        {ok, Pid, Extra} ->
+            NState = save_dynamic_child(Child#child.restart_type, Pid, Args, State),
+            {reply, {ok, Pid, Extra}, NState};
+        What ->
+            {reply, What, State}
     end;
 
 %% terminate_child for simple_one_for_one can only be done with pid
 handle_call({terminate_child, Name}, _From, State) when not is_pid(Name),
-							?is_simple(State) ->
+                                                        ?is_simple(State) ->
     {reply, {error, simple_one_for_one}, State};
 
 handle_call({terminate_child, Name}, _From, State) ->
     case get_child(Name, State, ?is_simple(State)) of
-	{value, Child} ->
-	    case do_terminate(Child, State#state.name) of
-		#child{restart_type=RT} when RT=:=temporary; ?is_simple(State) ->
-		    {reply, ok, state_del_child(Child, State)};
-		NChild ->
-		    {reply, ok, replace_child(NChild, State)}
-		end;
-	false ->
-	    {reply, {error, not_found}, State}
+        {value, Child} ->
+            case do_terminate(Child, State#state.name) of
+                #child{restart_type=RT} when RT=:=temporary; ?is_simple(State) ->
+                    {reply, ok, state_del_child(Child, State)};
+                NChild ->
+                    {reply, ok, replace_child(NChild, State)}
+                end;
+        false ->
+            {reply, {error, not_found}, State}
     end;
 
 %%% The requests delete_child and restart_child are invalid for
@@ -497,140 +497,140 @@ handle_call({_Req, _Data}, _From, State) when ?is_simple(State) ->
 
 handle_call({start_child, ChildSpec}, _From, State) ->
     case check_childspec(ChildSpec) of
-	{ok, Child} ->
-	    {Resp, NState} = handle_start_child(Child, State),
-	    {reply, Resp, NState};
-	What ->
-	    {reply, {error, What}, State}
+        {ok, Child} ->
+            {Resp, NState} = handle_start_child(Child, State),
+            {reply, Resp, NState};
+        What ->
+            {reply, {error, What}, State}
     end;
 
 handle_call({restart_child, Name}, _From, State) ->
     case get_child(Name, State) of
-	{value, Child} when Child#child.pid =:= undefined ->
-	    case do_start_child(State#state.name, Child) of
-		{ok, Pid} ->
-		    NState = replace_child(Child#child{pid = Pid}, State),
-		    {reply, {ok, Pid}, NState};
-		{ok, Pid, Extra} ->
-		    NState = replace_child(Child#child{pid = Pid}, State),
-		    {reply, {ok, Pid, Extra}, NState};
-		Error ->
-		    {reply, Error, State}
-	    end;
-	{value, #child{pid=?restarting(_)}} ->
-	    {reply, {error, restarting}, State};
-	{value, _} ->
-	    {reply, {error, running}, State};
-	_ ->
-	    {reply, {error, not_found}, State}
+        {value, Child} when Child#child.pid =:= undefined ->
+            case do_start_child(State#state.name, Child) of
+                {ok, Pid} ->
+                    NState = replace_child(Child#child{pid = Pid}, State),
+                    {reply, {ok, Pid}, NState};
+                {ok, Pid, Extra} ->
+                    NState = replace_child(Child#child{pid = Pid}, State),
+                    {reply, {ok, Pid, Extra}, NState};
+                Error ->
+                    {reply, Error, State}
+            end;
+        {value, #child{pid=?restarting(_)}} ->
+            {reply, {error, restarting}, State};
+        {value, _} ->
+            {reply, {error, running}, State};
+        _ ->
+            {reply, {error, not_found}, State}
     end;
 
 handle_call({delete_child, Name}, _From, State) ->
     case get_child(Name, State) of
-	{value, Child} when Child#child.pid =:= undefined ->
-	    NState = remove_child(Child, State),
-	    {reply, ok, NState};
-	{value, #child{pid=?restarting(_)}} ->
-	    {reply, {error, restarting}, State};
-	{value, _} ->
-	    {reply, {error, running}, State};
-	_ ->
-	    {reply, {error, not_found}, State}
+        {value, Child} when Child#child.pid =:= undefined ->
+            NState = remove_child(Child, State),
+            {reply, ok, NState};
+        {value, #child{pid=?restarting(_)}} ->
+            {reply, {error, restarting}, State};
+        {value, _} ->
+            {reply, {error, running}, State};
+        _ ->
+            {reply, {error, not_found}, State}
     end;
 
 handle_call(which_children, _From, #state{children = [#child{restart_type = temporary,
-							     child_type = CT,
-							     modules = Mods}]} =
-		State) when ?is_simple(State) ->
+                                                             child_type = CT,
+                                                             modules = Mods}]} =
+                State) when ?is_simple(State) ->
     Reply = lists:map(fun(Pid) -> {undefined, Pid, CT, Mods} end,
                       ?SETS:to_list(dynamics_db(temporary, State#state.dynamics))),
     {reply, Reply, State};
 
 handle_call(which_children, _From, #state{children = [#child{restart_type = RType,
-							 child_type = CT,
-							 modules = Mods}]} =
-		State) when ?is_simple(State) ->
+                                                         child_type = CT,
+                                                         modules = Mods}]} =
+                State) when ?is_simple(State) ->
     Reply = lists:map(fun({?restarting(_), _}) -> {undefined, restarting, CT, Mods};
-			 ({Pid, _}) -> {undefined, Pid, CT, Mods} end,
-		      ?DICT:to_list(dynamics_db(RType, State#state.dynamics))),
+                         ({Pid, _}) -> {undefined, Pid, CT, Mods} end,
+                      ?DICT:to_list(dynamics_db(RType, State#state.dynamics))),
     {reply, Reply, State};
 
 handle_call(which_children, _From, State) ->
     Resp =
-	lists:map(fun(#child{pid = ?restarting(_), name = Name,
-			     child_type = ChildType, modules = Mods}) ->
-			  {Name, restarting, ChildType, Mods};
-		     (#child{pid = Pid, name = Name,
-			     child_type = ChildType, modules = Mods}) ->
-			  {Name, Pid, ChildType, Mods}
-		  end,
-		  State#state.children),
+        lists:map(fun(#child{pid = ?restarting(_), name = Name,
+                             child_type = ChildType, modules = Mods}) ->
+                          {Name, restarting, ChildType, Mods};
+                     (#child{pid = Pid, name = Name,
+                             child_type = ChildType, modules = Mods}) ->
+                          {Name, Pid, ChildType, Mods}
+                  end,
+                  State#state.children),
     {reply, Resp, State};
 
 
 handle_call(count_children, _From, #state{children = [#child{restart_type = temporary,
-							     child_type = CT}]} = State)
+                                                             child_type = CT}]} = State)
   when ?is_simple(State) ->
     {Active, Count} =
-	?SETS:fold(fun(Pid, {Alive, Tot}) ->
-			   case is_pid(Pid) andalso is_process_alive(Pid) of
-			       true ->{Alive+1, Tot +1};
-			       false ->
-				   {Alive, Tot + 1}
-			   end
-		   end, {0, 0}, dynamics_db(temporary, State#state.dynamics)),
+        ?SETS:fold(fun(Pid, {Alive, Tot}) ->
+                           case is_pid(Pid) andalso is_process_alive(Pid) of
+                               true ->{Alive+1, Tot +1};
+                               false ->
+                                   {Alive, Tot + 1}
+                           end
+                   end, {0, 0}, dynamics_db(temporary, State#state.dynamics)),
     Reply = case CT of
-		supervisor -> [{specs, 1}, {active, Active},
-			       {supervisors, Count}, {workers, 0}];
-		worker -> [{specs, 1}, {active, Active},
-			   {supervisors, 0}, {workers, Count}]
-	    end,
+                supervisor -> [{specs, 1}, {active, Active},
+                               {supervisors, Count}, {workers, 0}];
+                worker -> [{specs, 1}, {active, Active},
+                           {supervisors, 0}, {workers, Count}]
+            end,
     {reply, Reply, State};
 
 handle_call(count_children, _From,  #state{children = [#child{restart_type = RType,
-							      child_type = CT}]} = State)
+                                                              child_type = CT}]} = State)
   when ?is_simple(State) ->
     {Active, Count} =
-	?DICT:fold(fun(Pid, _Val, {Alive, Tot}) ->
-			   case is_pid(Pid) andalso is_process_alive(Pid) of
-			       true ->
-				   {Alive+1, Tot +1};
-			       false ->
-				   {Alive, Tot + 1}
-			   end
-		   end, {0, 0}, dynamics_db(RType, State#state.dynamics)),
+        ?DICT:fold(fun(Pid, _Val, {Alive, Tot}) ->
+                           case is_pid(Pid) andalso is_process_alive(Pid) of
+                               true ->
+                                   {Alive+1, Tot +1};
+                               false ->
+                                   {Alive, Tot + 1}
+                           end
+                   end, {0, 0}, dynamics_db(RType, State#state.dynamics)),
     Reply = case CT of
-		supervisor -> [{specs, 1}, {active, Active},
-			       {supervisors, Count}, {workers, 0}];
-		worker -> [{specs, 1}, {active, Active},
-			   {supervisors, 0}, {workers, Count}]
-	    end,
+                supervisor -> [{specs, 1}, {active, Active},
+                               {supervisors, Count}, {workers, 0}];
+                worker -> [{specs, 1}, {active, Active},
+                           {supervisors, 0}, {workers, Count}]
+            end,
     {reply, Reply, State};
 
 handle_call(count_children, _From, State) ->
     %% Specs and children are together on the children list...
     {Specs, Active, Supers, Workers} =
-	lists:foldl(fun(Child, Counts) ->
-			   count_child(Child, Counts)
-		   end, {0, 0, 0, 0}, State#state.children),
+        lists:foldl(fun(Child, Counts) ->
+                           count_child(Child, Counts)
+                   end, {0, 0, 0, 0}, State#state.children),
 
     %% Reformat counts to a property list.
     Reply = [{specs, Specs}, {active, Active},
-	     {supervisors, Supers}, {workers, Workers}],
+             {supervisors, Supers}, {workers, Workers}],
     {reply, Reply, State}.
 
 
 count_child(#child{pid = Pid, child_type = worker},
-	    {Specs, Active, Supers, Workers}) ->
+            {Specs, Active, Supers, Workers}) ->
     case is_pid(Pid) andalso is_process_alive(Pid) of
-	true ->  {Specs+1, Active+1, Supers, Workers+1};
-	false -> {Specs+1, Active, Supers, Workers+1}
+        true ->  {Specs+1, Active+1, Supers, Workers+1};
+        false -> {Specs+1, Active, Supers, Workers+1}
     end;
 count_child(#child{pid = Pid, child_type = supervisor},
-	    {Specs, Active, Supers, Workers}) ->
+            {Specs, Active, Supers, Workers}) ->
     case is_pid(Pid) andalso is_process_alive(Pid) of
-	true ->  {Specs+1, Active+1, Supers+1, Workers};
-	false -> {Specs+1, Active, Supers+1, Workers}
+        true ->  {Specs+1, Active+1, Supers+1, Workers};
+        false -> {Specs+1, Active, Supers+1, Workers}
     end.
 
 
@@ -639,28 +639,28 @@ count_child(#child{pid = Pid, child_type = supervisor},
 %%% check it's inbox before trying again.
 -ifdef(use_specs).
 -spec handle_cast({try_again_restart, child_id() | pid(), term()}, state()) ->
-			 {'noreply', state()} | {stop, shutdown, state()}.
+                         {'noreply', state()} | {stop, shutdown, state()}.
 -endif.
 handle_cast({try_again_restart, Pid, Reason}, #state{children=[Child]}=State)
   when ?is_simple(State) ->
     RT = Child#child.restart_type,
     RPid = restarting(Pid),
     case dynamic_child_args(RPid, dynamics_db(RT, State#state.dynamics)) of
-	{ok, Args} ->
-	    {M, F, _} = Child#child.mfargs,
-	    NChild = Child#child{pid = RPid, mfargs = {M, F, Args}},
+        {ok, Args} ->
+            {M, F, _} = Child#child.mfargs,
+            NChild = Child#child{pid = RPid, mfargs = {M, F, Args}},
             try_restart(Child#child.restart_type, Reason, NChild, State);
-	error ->
+        error ->
             {noreply, State}
     end;
 
 handle_cast({try_again_restart, Name, Reason}, State) ->
     %% we still support >= R12-B3 in which lists:keyfind/3 doesn't exist
     case lists:keysearch(Name, #child.name, State#state.children) of
-	{value, Child = #child{pid=?restarting(_), restart_type=RestartType}} ->
+        {value, Child = #child{pid=?restarting(_), restart_type=RestartType}} ->
             try_restart(RestartType, Reason, Child, State);
-	_ ->
-	    {noreply, State}
+        _ ->
+            {noreply, State}
     end.
 
 %%
@@ -672,10 +672,10 @@ handle_cast({try_again_restart, Name, Reason}, State) ->
 -endif.
 handle_info({'EXIT', Pid, Reason}, State) ->
     case restart_child(Pid, Reason, State) of
-	{ok, State1} ->
-	    {noreply, State1};
-	{shutdown, State1} ->
-	    {stop, shutdown, State1}
+        {ok, State1} ->
+            {noreply, State1};
+        {shutdown, State1} ->
+            {stop, shutdown, State1}
     end;
 
 handle_info({delayed_restart, {RestartType, Reason, Child}}, State)
@@ -690,8 +690,8 @@ handle_info({delayed_restart, {RestartType, Reason, Child}}, State) ->
     end;
 
 handle_info(Msg, State) ->
-    error_logger:error_msg("Supervisor received unexpected message: ~p~n", 
-			   [Msg]),
+    error_logger:error_msg("Supervisor received unexpected message: ~p~n",
+                           [Msg]),
     {noreply, State}.
 
 %%
@@ -722,21 +722,21 @@ terminate(_Reason, State) ->
 -endif.
 code_change(_, State, _) ->
     case (State#state.module):init(State#state.args) of
-	{ok, {SupFlags, StartSpec}} ->
-	    case catch check_flags(SupFlags) of
-		ok ->
-		    {Strategy, MaxIntensity, Period} = SupFlags,
+        {ok, {SupFlags, StartSpec}} ->
+            case catch check_flags(SupFlags) of
+                ok ->
+                    {Strategy, MaxIntensity, Period} = SupFlags,
                     update_childspec(State#state{strategy = Strategy,
                                                  intensity = MaxIntensity,
                                                  period = Period},
                                      StartSpec);
-		Error ->
-		    {error, Error}
-	    end;
-	ignore ->
-	    {ok, State};
-	Error ->
-	    Error
+                Error ->
+                    {error, Error}
+            end;
+        ignore ->
+            {ok, State};
+        Error ->
+            Error
     end.
 
 check_flags({Strategy, MaxIntensity, Period}) ->
@@ -756,20 +756,20 @@ update_childspec(State, StartSpec) when ?is_simple(State) ->
     end;
 update_childspec(State, StartSpec) ->
     case check_startspec(StartSpec) of
-	{ok, Children} ->
-	    OldC = State#state.children, % In reverse start order !
-	    NewC = update_childspec1(OldC, Children, []),
-	    {ok, State#state{children = NewC}};
+        {ok, Children} ->
+            OldC = State#state.children, % In reverse start order !
+            NewC = update_childspec1(OldC, Children, []),
+            {ok, State#state{children = NewC}};
         Error ->
-	    {error, Error}
+            {error, Error}
     end.
 
 update_childspec1([Child|OldC], Children, KeepOld) ->
     case update_chsp(Child, Children) of
-	{ok, NewChildren} ->
-	    update_childspec1(OldC, NewChildren, KeepOld);
-	false ->
-	    update_childspec1(OldC, Children, [Child|KeepOld])
+        {ok, NewChildren} ->
+            update_childspec1(OldC, NewChildren, KeepOld);
+        false ->
+            update_childspec1(OldC, Children, [Child|KeepOld])
     end;
 update_childspec1([], Children, KeepOld) ->
     %% Return them in (kept) reverse start order.
@@ -777,38 +777,38 @@ update_childspec1([], Children, KeepOld) ->
 
 update_chsp(OldCh, Children) ->
     case lists:map(fun(Ch) when OldCh#child.name =:= Ch#child.name ->
-			   Ch#child{pid = OldCh#child.pid};
-		      (Ch) ->
-			   Ch
-		   end,
-		   Children) of
-	Children ->
-	    false;  % OldCh not found in new spec.
-	NewC ->
-	    {ok, NewC}
+                           Ch#child{pid = OldCh#child.pid};
+                      (Ch) ->
+                           Ch
+                   end,
+                   Children) of
+        Children ->
+            false;  % OldCh not found in new spec.
+        NewC ->
+            {ok, NewC}
     end.
-    
+
 %%% ---------------------------------------------------
 %%% Start a new child.
 %%% ---------------------------------------------------
 
 handle_start_child(Child, State) ->
     case get_child(Child#child.name, State) of
-	false ->
-	    case do_start_child(State#state.name, Child) of
-		{ok, undefined} when Child#child.restart_type =:= temporary ->
-		    {{ok, undefined}, State};
-		{ok, Pid} ->
-		    {{ok, Pid}, save_child(Child#child{pid = Pid}, State)};
-		{ok, Pid, Extra} ->
-		    {{ok, Pid, Extra}, save_child(Child#child{pid = Pid}, State)};
-		{error, What} ->
-		    {{error, {What, Child}}, State}
-	    end;
-	{value, OldChild} when is_pid(OldChild#child.pid) ->
-	    {{error, {already_started, OldChild#child.pid}}, State};
-	{value, _OldChild} ->
-	    {{error, already_present}, State}
+        false ->
+            case do_start_child(State#state.name, Child) of
+                {ok, undefined} when Child#child.restart_type =:= temporary ->
+                    {{ok, undefined}, State};
+                {ok, Pid} ->
+                    {{ok, Pid}, save_child(Child#child{pid = Pid}, State)};
+                {ok, Pid, Extra} ->
+                    {{ok, Pid, Extra}, save_child(Child#child{pid = Pid}, State)};
+                {error, What} ->
+                    {{error, {What, Child}}, State}
+            end;
+        {value, OldChild} when is_pid(OldChild#child.pid) ->
+            {{error, {already_started, OldChild#child.pid}}, State};
+        {value, _OldChild} ->
+            {{error, already_present}, State}
     end.
 
 %%% ---------------------------------------------------
@@ -819,11 +819,11 @@ handle_start_child(Child, State) ->
 restart_child(Pid, Reason, #state{children = [Child]} = State) when ?is_simple(State) ->
     RestartType = Child#child.restart_type,
     case dynamic_child_args(Pid, dynamics_db(RestartType, State#state.dynamics)) of
-	{ok, Args} ->
-	    {M, F, _} = Child#child.mfargs,
-	    NChild = Child#child{pid = Pid, mfargs = {M, F, Args}},
-	    do_restart(RestartType, Reason, NChild, State);
-	error ->
+        {ok, Args} ->
+            {M, F, _} = Child#child.mfargs,
+            NChild = Child#child{pid = Pid, mfargs = {M, F, Args}},
+            do_restart(RestartType, Reason, NChild, State);
+        error ->
             {ok, State}
     end;
 
@@ -831,10 +831,10 @@ restart_child(Pid, Reason, State) ->
     Children = State#state.children,
     %% we still support >= R12-B3 in which lists:keyfind/3 doesn't exist
     case lists:keysearch(Pid, #child.pid, Children) of
-	{value, #child{restart_type = RestartType} = Child} ->
-	    do_restart(RestartType, Reason, Child, State);
-	false ->
-	    {ok, State}
+        {value, #child{restart_type = RestartType} = Child} ->
+            do_restart(RestartType, Reason, Child, State);
+        false ->
+            {ok, State}
     end.
 
 try_restart(RestartType, Reason, Child, State) ->
@@ -922,12 +922,12 @@ do_restart_delay({RestartType, Delay}, Reason, Child, State) ->
 
 restart(Child, State) ->
     case add_restart(State) of
-	{ok, NState} ->
-	    maybe_restart(NState#state.strategy, Child, NState);
-	{terminate, NState} ->
-	    report_error(shutdown, reached_max_restart_intensity,
-			 Child, State#state.name),
-	    {shutdown, remove_child(Child, NState)}
+        {ok, NState} ->
+            maybe_restart(NState#state.strategy, Child, NState);
+        {terminate, NState} ->
+            report_error(shutdown, reached_max_restart_intensity,
+                         Child, State#state.name),
+            {shutdown, remove_child(Child, NState)}
     end.
 
 maybe_restart(Strategy, Child, State) ->
@@ -950,55 +950,55 @@ maybe_restart(Strategy, Child, State) ->
 restart(simple_one_for_one, Child, State) ->
     #child{pid = OldPid, mfargs = {M, F, A}} = Child,
     Dynamics = ?DICT:erase(OldPid, dynamics_db(Child#child.restart_type,
-					       State#state.dynamics)),
+                                               State#state.dynamics)),
     case do_start_child_i(M, F, A) of
-	{ok, Pid} ->
-	    NState = State#state{dynamics = ?DICT:store(Pid, A, Dynamics)},
-	    {ok, NState};
-	{ok, Pid, _Extra} ->
-	    NState = State#state{dynamics = ?DICT:store(Pid, A, Dynamics)},
-	    {ok, NState};
-	{error, Error} ->
-	    NState = State#state{dynamics = ?DICT:store(restarting(OldPid), A,
-							Dynamics)},
-	    report_error(start_error, Error, Child, State#state.name),
-	    {try_again, Error, NState}
+        {ok, Pid} ->
+            NState = State#state{dynamics = ?DICT:store(Pid, A, Dynamics)},
+            {ok, NState};
+        {ok, Pid, _Extra} ->
+            NState = State#state{dynamics = ?DICT:store(Pid, A, Dynamics)},
+            {ok, NState};
+        {error, Error} ->
+            NState = State#state{dynamics = ?DICT:store(restarting(OldPid), A,
+                                                        Dynamics)},
+            report_error(start_error, Error, Child, State#state.name),
+            {try_again, Error, NState}
     end;
 restart(one_for_one, Child, State) ->
     OldPid = Child#child.pid,
     case do_start_child(State#state.name, Child) of
-	{ok, Pid} ->
-	    NState = replace_child(Child#child{pid = Pid}, State),
-	    {ok, NState};
-	{ok, Pid, _Extra} ->
-	    NState = replace_child(Child#child{pid = Pid}, State),
-	    {ok, NState};
-	{error, Reason} ->
-	    NState = replace_child(Child#child{pid = restarting(OldPid)}, State),
-	    report_error(start_error, Reason, Child, State#state.name),
-	    {try_again, Reason, NState}
+        {ok, Pid} ->
+            NState = replace_child(Child#child{pid = Pid}, State),
+            {ok, NState};
+        {ok, Pid, _Extra} ->
+            NState = replace_child(Child#child{pid = Pid}, State),
+            {ok, NState};
+        {error, Reason} ->
+            NState = replace_child(Child#child{pid = restarting(OldPid)}, State),
+            report_error(start_error, Reason, Child, State#state.name),
+            {try_again, Reason, NState}
     end;
 restart(rest_for_one, Child, State) ->
     {ChAfter, ChBefore} = split_child(Child#child.pid, State#state.children),
     ChAfter2 = terminate_children(ChAfter, State#state.name),
     case start_children(ChAfter2, State#state.name) of
-	{ok, ChAfter3} ->
-	    {ok, State#state{children = ChAfter3 ++ ChBefore}};
-	{error, ChAfter3, Reason} ->
-	    NChild = Child#child{pid=restarting(Child#child.pid)},
-	    NState = State#state{children = ChAfter3 ++ ChBefore},
-	    {try_again, Reason, replace_child(NChild, NState)}
+        {ok, ChAfter3} ->
+            {ok, State#state{children = ChAfter3 ++ ChBefore}};
+        {error, ChAfter3, Reason} ->
+            NChild = Child#child{pid=restarting(Child#child.pid)},
+            NState = State#state{children = ChAfter3 ++ ChBefore},
+            {try_again, Reason, replace_child(NChild, NState)}
     end;
 restart(one_for_all, Child, State) ->
     Children1 = del_child(Child#child.pid, State#state.children),
     Children2 = terminate_children(Children1, State#state.name),
     case start_children(Children2, State#state.name) of
-	{ok, NChs} ->
-	    {ok, State#state{children = NChs}};
-	{error, NChs, Reason} ->
-	    NChild = Child#child{pid=restarting(Child#child.pid)},
-	    NState = State#state{children = NChs},
-	    {try_again, Reason, replace_child(NChild, NState)}
+        {ok, NChs} ->
+            {ok, State#state{children = NChs}};
+        {error, NChs, Reason} ->
+            NChild = Child#child{pid=restarting(Child#child.pid)},
+            NState = State#state{children = NChs},
+            {try_again, Reason, replace_child(NChild, NState)}
     end.
 
 restarting(Pid) when is_pid(Pid) -> ?restarting(Pid);
@@ -1041,52 +1041,52 @@ do_terminate(Child, _SupName) ->
     Child#child{pid = undefined}.
 
 %%-----------------------------------------------------------------
-%% Shutdowns a child. We must check the EXIT value 
+%% Shutdowns a child. We must check the EXIT value
 %% of the child, because it might have died with another reason than
-%% the wanted. In that case we want to report the error. We put a 
-%% monitor on the child an check for the 'DOWN' message instead of 
-%% checking for the 'EXIT' message, because if we check the 'EXIT' 
-%% message a "naughty" child, who does unlink(Sup), could hang the 
-%% supervisor. 
+%% the wanted. In that case we want to report the error. We put a
+%% monitor on the child an check for the 'DOWN' message instead of
+%% checking for the 'EXIT' message, because if we check the 'EXIT'
+%% message a "naughty" child, who does unlink(Sup), could hang the
+%% supervisor.
 %% Returns: ok | {error, OtherReason}  (this should be reported)
 %%-----------------------------------------------------------------
 shutdown(Pid, brutal_kill) ->
     case monitor_child(Pid) of
-	ok ->
-	    exit(Pid, kill),
-	    receive
-		{'DOWN', _MRef, process, Pid, killed} ->
-		    ok;
-		{'DOWN', _MRef, process, Pid, OtherReason} ->
-		    {error, OtherReason}
-	    end;
-	{error, Reason} ->      
-	    {error, Reason}
+        ok ->
+            exit(Pid, kill),
+            receive
+                {'DOWN', _MRef, process, Pid, killed} ->
+                    ok;
+                {'DOWN', _MRef, process, Pid, OtherReason} ->
+                    {error, OtherReason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end;
 shutdown(Pid, Time) ->
     case monitor_child(Pid) of
-	ok ->
-	    exit(Pid, shutdown), %% Try to shutdown gracefully
-	    receive 
-		{'DOWN', _MRef, process, Pid, shutdown} ->
-		    ok;
-		{'DOWN', _MRef, process, Pid, OtherReason} ->
-		    {error, OtherReason}
-	    after Time ->
-		    exit(Pid, kill),  %% Force termination.
-		    receive
-			{'DOWN', _MRef, process, Pid, OtherReason} ->
-			    {error, OtherReason}
-		    end
-	    end;
-	{error, Reason} ->      
-	    {error, Reason}
+        ok ->
+            exit(Pid, shutdown), %% Try to shutdown gracefully
+            receive
+                {'DOWN', _MRef, process, Pid, shutdown} ->
+                    ok;
+                {'DOWN', _MRef, process, Pid, OtherReason} ->
+                    {error, OtherReason}
+            after Time ->
+                    exit(Pid, kill),  %% Force termination.
+                    receive
+                        {'DOWN', _MRef, process, Pid, OtherReason} ->
+                            {error, OtherReason}
+                    end
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% Help function to shutdown/2 switches from link to monitor approach
 monitor_child(Pid) ->
-    
-    %% Do the monitor operation first so that if the child dies 
+
+    %% Do the monitor operation first so that if the child dies
     %% before the monitoring is done causing a 'DOWN'-message with
     %% reason noproc, we will get the real reason in the 'EXIT'-message
     %% unless a naughty child has already done unlink...
@@ -1094,21 +1094,21 @@ monitor_child(Pid) ->
     unlink(Pid),
 
     receive
-	%% If the child dies before the unlik we must empty
-	%% the mail-box of the 'EXIT'-message and the 'DOWN'-message.
-	{'EXIT', Pid, Reason} -> 
-	    receive 
-		{'DOWN', _, process, Pid, _} ->
-		    {error, Reason}
-	    end
-    after 0 -> 
-	    %% If a naughty child did unlink and the child dies before
-	    %% monitor the result will be that shutdown/2 receives a 
-	    %% 'DOWN'-message with reason noproc.
-	    %% If the child should die after the unlink there
-	    %% will be a 'DOWN'-message with a correct reason
-	    %% that will be handled in shutdown/2. 
-	    ok   
+        %% If the child dies before the unlik we must empty
+        %% the mail-box of the 'EXIT'-message and the 'DOWN'-message.
+        {'EXIT', Pid, Reason} ->
+            receive
+                {'DOWN', _, process, Pid, _} ->
+                    {error, Reason}
+            end
+    after 0 ->
+            %% If a naughty child did unlink and the child dies before
+            %% monitor the result will be that shutdown/2 receives a
+            %% 'DOWN'-message with reason noproc.
+            %% If the child should die after the unlink there
+            %% will be a 'DOWN'-message with a correct reason
+            %% that will be handled in shutdown/2.
+            ok
     end.
 
 
@@ -1167,15 +1167,15 @@ monitor_dynamic_children(#child{restart_type=RType}, Dynamics) ->
                            {error, Reason} ->
                                {Pids, ?DICT:append(Reason, P, EStack)}
                        end;
-		  (?restarting(_), _, {Pids, EStack}) ->
-		       {Pids, EStack}
+                  (?restarting(_), _, {Pids, EStack}) ->
+                       {Pids, EStack}
                end, {?SETS:new(), ?DICT:new()}, Dynamics).
 
 wait_dynamic_children(_Child, _Pids, 0, undefined, EStack) ->
     EStack;
 wait_dynamic_children(_Child, _Pids, 0, TRef, EStack) ->
-	%% If the timer has expired before its cancellation, we must empty the
-	%% mail-box of the 'timeout'-message.
+        %% If the timer has expired before its cancellation, we must empty the
+        %% mail-box of the 'timeout'-message.
     erlang:cancel_timer(TRef),
     receive
         {timeout, TRef, kill} ->
@@ -1224,7 +1224,7 @@ wait_dynamic_children(#child{restart_type=RType} = Child, Pids, Sz,
 %% it could become very costly as it is not uncommon to spawn
 %% very many such processes.
 save_child(#child{restart_type = temporary,
-		  mfargs = {M, F, _}} = Child, #state{children = Children} = State) ->
+                  mfargs = {M, F, _}} = Child, #state{children = Children} = State) ->
     State#state{children = [Child#child{mfargs = {M, F, undefined}} |Children]};
 save_child(Child, #state{children = Children} = State) ->
     State#state{children = [Child |Children]}.
@@ -1298,27 +1298,27 @@ get_child(Name, State, _) ->
 get_dynamic_child(Pid, #state{children=[Child], dynamics=Dynamics}) ->
     DynamicsDb = dynamics_db(Child#child.restart_type, Dynamics),
     case is_dynamic_pid(Pid, DynamicsDb) of
-	true ->
-	    {value, Child#child{pid=Pid}};
-	false ->
-	    RPid = restarting(Pid),
-	    case is_dynamic_pid(RPid, DynamicsDb) of
-		true ->
-		    {value, Child#child{pid=RPid}};
-		false ->
-		    case erlang:is_process_alive(Pid) of
-			true -> false;
-			false -> {value, Child}
-		    end
-	    end
+        true ->
+            {value, Child#child{pid=Pid}};
+        false ->
+            RPid = restarting(Pid),
+            case is_dynamic_pid(RPid, DynamicsDb) of
+                true ->
+                    {value, Child#child{pid=RPid}};
+                false ->
+                    case erlang:is_process_alive(Pid) of
+                        true -> false;
+                        false -> {value, Child}
+                    end
+            end
     end.
 
 is_dynamic_pid(Pid, Dynamics) ->
     case ?SETS:is_set(Dynamics) of
-	true ->
-	    ?SETS:is_element(Pid, Dynamics);
-	false ->
-	    ?DICT:is_key(Pid, Dynamics)
+        true ->
+            ?SETS:is_element(Pid, Dynamics);
+        false ->
+            ?DICT:is_key(Pid, Dynamics)
     end.
 
 replace_child(Child, State) ->
@@ -1349,10 +1349,10 @@ remove_child(Child, State) ->
 %%-----------------------------------------------------------------
 init_state(SupName, Type, Mod, Args) ->
     case catch init_state1(SupName, Type, Mod, Args) of
-	{ok, State} ->
-	    {ok, State};
-	Error ->
-	    Error
+        {ok, State} ->
+            {ok, State};
+        Error ->
+            Error
     end.
 
 init_state1(SupName, {Strategy, MaxIntensity, Period}, Mod, Args) ->
@@ -1360,11 +1360,11 @@ init_state1(SupName, {Strategy, MaxIntensity, Period}, Mod, Args) ->
     validIntensity(MaxIntensity),
     validPeriod(Period),
     {ok, #state{name = supname(SupName, Mod),
-		strategy = Strategy,
-		intensity = MaxIntensity,
-		period = Period,
-		module = Mod,
-		args = Args}};
+                strategy = Strategy,
+                intensity = MaxIntensity,
+                period = Period,
+                module = Mod,
+                args = Args}};
 init_state1(_SupName, Type, _, _) ->
     {invalid_type, Type}.
 
@@ -1405,12 +1405,12 @@ check_startspec(Children) -> check_startspec(Children, []).
 
 check_startspec([ChildSpec|T], Res) ->
     case check_childspec(ChildSpec) of
-	{ok, Child} ->
-	    case lists:keymember(Child#child.name, #child.name, Res) of
-		true -> {duplicate_child_name, Child#child.name};
-		false -> check_startspec(T, [Child | Res])
-	    end;
-	Error -> Error
+        {ok, Child} ->
+            case lists:keymember(Child#child.name, #child.name, Res) of
+                true -> {duplicate_child_name, Child#child.name};
+                false -> check_startspec(T, [Child | Res])
+            end;
+        Error -> Error
     end;
 check_startspec([], Res) ->
     {ok, lists:reverse(Res)}.
@@ -1427,7 +1427,7 @@ check_childspec(Name, Func, RestartType, Shutdown, ChildType, Mods) ->
     validShutdown(Shutdown, ChildType),
     validMods(Mods),
     {ok, #child{name = Name, mfargs = Func, restart_type = RestartType,
-		shutdown = Shutdown, child_type = ChildType, modules = Mods}}.
+                shutdown = Shutdown, child_type = ChildType, modules = Mods}}.
 
 validChildType(supervisor) -> true;
 validChildType(worker) -> true;
@@ -1435,8 +1435,8 @@ validChildType(What) -> throw({invalid_child_type, What}).
 
 validName(_Name) -> true.
 
-validFunc({M, F, A}) when is_atom(M), 
-                          is_atom(F), 
+validFunc({M, F, A}) when is_atom(M),
+                          is_atom(F),
                           is_list(A) -> true;
 validFunc(Func)                      -> throw({invalid_mfa, Func}).
 
@@ -1454,7 +1454,7 @@ validDelay(Delay) when is_number(Delay),
                        Delay >= 0 -> true;
 validDelay(What)                  -> throw({invalid_delay, What}).
 
-validShutdown(Shutdown, _) 
+validShutdown(Shutdown, _)
   when is_integer(Shutdown), Shutdown > 0 -> true;
 validShutdown(infinity, _)             -> true;
 validShutdown(brutal_kill, _)          -> true;
@@ -1463,12 +1463,12 @@ validShutdown(Shutdown, _)             -> throw({invalid_shutdown, Shutdown}).
 validMods(dynamic) -> true;
 validMods(Mods) when is_list(Mods) ->
     lists:foreach(fun(Mod) ->
-		    if
-			is_atom(Mod) -> ok;
-			true -> throw({invalid_module, Mod})
-		    end
-		  end,
-		  Mods);
+                    if
+                        is_atom(Mod) -> ok;
+                        true -> throw({invalid_module, Mod})
+                    end
+                  end,
+                  Mods);
 validMods(Mods) -> throw({invalid_modules, Mods}).
 
 %%% ------------------------------------------------------
@@ -1480,7 +1480,7 @@ validMods(Mods) -> throw({invalid_modules, Mods}).
 %%% Returns: {ok, State'} | {terminate, State'}
 %%% ------------------------------------------------------
 
-add_restart(State) ->  
+add_restart(State) ->
     I = State#state.intensity,
     P = State#state.period,
     R = State#state.restarts,
@@ -1488,28 +1488,28 @@ add_restart(State) ->
     R1 = add_restart([Now|R], Now, P),
     State1 = State#state{restarts = R1},
     case length(R1) of
-	CurI when CurI  =< I ->
-	    {ok, State1};
-	_ ->
-	    {terminate, State1}
+        CurI when CurI  =< I ->
+            {ok, State1};
+        _ ->
+            {terminate, State1}
     end.
 
 add_restart([R|Restarts], Now, Period) ->
     case inPeriod(R, Now, Period) of
-	true ->
-	    [R|add_restart(Restarts, Now, Period)];
-	_ ->
-	    []
+        true ->
+            [R|add_restart(Restarts, Now, Period)];
+        _ ->
+            []
     end;
 add_restart([], _, _) ->
     [].
 
 inPeriod(Time, Now, Period) ->
     case difference(Time, Now) of
-	T when T > Period ->
-	    false;
-	_ ->
-	    true
+        T when T > Period ->
+            false;
+        _ ->
+            true
     end.
 
 %%
@@ -1531,9 +1531,9 @@ difference({_, TimeS, _}, {_, CurS, _}) ->
 
 report_error(Error, Reason, Child, SupName) ->
     ErrorMsg = [{supervisor, SupName},
-		{errorContext, Error},
-		{reason, Reason},
-		{offender, extract_child(Child)}],
+                {errorContext, Error},
+                {reason, Reason},
+                {offender, extract_child(Child)}],
     error_logger:error_report(supervisor_report, ErrorMsg).
 
 
@@ -1554,5 +1554,5 @@ extract_child(Child) ->
 
 report_progress(Child, SupName) ->
     Progress = [{supervisor, SupName},
-		{started, extract_child(Child)}],
+                {started, extract_child(Child)}],
     error_logger:info_report(progress, Progress).

--- a/apps/ejabberd/test/carboncopy_proper_tests_SUITE.erl
+++ b/apps/ejabberd/test/carboncopy_proper_tests_SUITE.erl
@@ -19,49 +19,49 @@ all() ->
     [{group, mod_message_carbons_proper_tests}].
 
 all_tests() ->
-    [chat_type_test, private_message_test, no_copy_type_test, 
-          received_type_test, sent_forwarded_type_test, sent_message_test, 
+    [chat_type_test, private_message_test, no_copy_type_test,
+          received_type_test, sent_forwarded_type_test, sent_message_test,
           simple_chat_message_test, simple_badarg_test].
 
 groups() ->
     [{mod_message_carbons_proper_tests, [sequence], all_tests()}].
 
 private_message_test(_) ->
-	property(private_message_test, ?FORALL(Msg, private_carbon_message(),
+    property(private_message_test, ?FORALL(Msg, private_carbon_message(),
           ignore == mod_carboncopy:classify_packet(Msg))).
 
 chat_type_test(_) ->
-	property(chat_type_test, ?FORALL(Msg, non_chat_message(),
+    property(chat_type_test, ?FORALL(Msg, non_chat_message(),
           ignore == mod_carboncopy:classify_packet(Msg))).
 
 no_copy_type_test(_) ->
-	property(no_copy_type_test, ?FORALL(Msg, no_copy_message(),
+    property(no_copy_type_test, ?FORALL(Msg, no_copy_message(),
           ignore == mod_carboncopy:classify_packet(Msg))).
 
 received_type_test(_) ->
-	property(received_type_test, ?FORALL(Msg, received_message(),
+    property(received_type_test, ?FORALL(Msg, received_message(),
           ignore == mod_carboncopy:classify_packet(Msg))).
 
 sent_forwarded_type_test(_) ->
-	property(sent_forwarded_type_test, ?FORALL(Msg, sent_forwarded_message(),
+    property(sent_forwarded_type_test, ?FORALL(Msg, sent_forwarded_message(),
           ignore == mod_carboncopy:classify_packet(Msg))).
 
 sent_message_test(_) ->
-	property(sent_message_test, ?FORALL(Msg, sent_message(),
+    property(sent_message_test, ?FORALL(Msg, sent_message(),
           forward == mod_carboncopy:classify_packet(Msg))).
 
 simple_chat_message_test(_) ->
-	property(simple_chat_message_test, ?FORALL(Msg, simple_chat_message(),
+    property(simple_chat_message_test, ?FORALL(Msg, simple_chat_message(),
           forward == mod_carboncopy:classify_packet(Msg))).
 
 simple_badarg_test(_) ->
-	property(simple_badarg_test, ?FORALL(Msg, badarg_message(),
+    property(simple_badarg_test, ?FORALL(Msg, badarg_message(),
           ignore == mod_carboncopy:classify_packet(Msg))).
 
 property(Name, Prop) ->
     Props = proper:conjunction([{Name, Prop}]),
     true = proper:quickcheck(Props, [verbose, long_result, {numtests, 50}]).
-	
+
 
 
 %%
@@ -69,35 +69,35 @@ property(Name, Prop) ->
 %%
 
 non_chat_message() ->
-	xmlel("message",[],[]).
+    xmlel("message",[],[]).
 
 private_carbon_message() ->
-	xmlel("message", 
+    xmlel("message",
           [{<<"type">>,<<"chat">>}],
           [xmlel("private",[{<<"xmlns">>, <<"urn:xmpp:carbons:2">>}],[])]).
 
 no_copy_message() ->
-	xmlel("message", 
+    xmlel("message",
           [{<<"type">>,<<"chat">>}],
           [xmlel("no-copy",[{<<"xmlns">>, <<"urn:xmpp:carbons:2">>}],[])]).
 
 received_message() ->
-	xmlel("message", 
+    xmlel("message",
           [{<<"type">>,<<"chat">>}],
           [xmlel("received",[{<<"xmlns">>, <<"urn:xmpp:carbons:2">>}],[])]).
 
 sent_forwarded_message() ->
-	xmlel("message", 
+    xmlel("message",
           [{<<"type">>,<<"chat">>}],
           [xmlel("sent",[{<<"xmlns">>, <<"urn:xmpp:carbons:2">>}],[xmlel("forwarded",[],[])])]).
 
 sent_message() ->
-	xmlel("message", 
+    xmlel("message",
           [{<<"type">>,<<"chat">>}],
           [xmlel("sent",[{<<"xmlns">>, <<"urn:xmpp:carbons:2">>}],[])]).
 
 simple_chat_message() ->
-	xmlel("message", [{<<"type">>,<<"chat">>}],[]).
+    xmlel("message", [{<<"type">>,<<"chat">>}],[]).
 
 badarg_message() ->
-	xmlel("message", [{<<"type">>,<<"123">>}],[]).
+    xmlel("message", [{<<"type">>,<<"123">>}],[]).

--- a/apps/ejabberd/test/commands_SUITE.erl
+++ b/apps/ejabberd/test/commands_SUITE.erl
@@ -559,9 +559,9 @@ the_same_types(_, _) ->
     <<"wrong response">>.
 
 different_types(10, <<"binary">>) ->
-	<<"response2">>;
+    <<"response2">>;
 different_types(_, _) ->
-	<<"wrong content">>.
+    <<"wrong content">>.
 
 cmd_concat(A, B) ->
     <<A/binary, B/binary>>.


### PR DESCRIPTION
In most files tabs were replaced with 8 spaces, but some files required
4-space replacements. Some whitespace misformats were corrected
manually. Other whitespace errors in modified files were corrected
automatically by Atom.