### PR TITLE
Introduce XMPP pipelining.

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -3103,7 +3103,6 @@ sasl_challenge_stanza(Challenge) ->
            children = Challenge}.
 
 handle_sasl_success(State, Creds) ->
-    (State#state.sockmod):reset_stream(State#state.socket),
     ServerOut = mongoose_credentials:get(Creds, sasl_success_response, undefined),
     send_element(State, sasl_success_stanza(ServerOut)),
     User = mongoose_credentials:get(Creds, username),

--- a/apps/ejabberd/src/ejabberd_s2s_in.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_in.erl
@@ -360,8 +360,6 @@ wait_for_feature_request({xmlstreamelement, El}, StateData) ->
                         end,
                     if
                         AuthRes ->
-                            (StateData#state.sockmod):reset_stream(
-                              StateData#state.socket),
                             send_element(StateData,
                                           #xmlel{name = <<"success">>,
                                                  attrs = [{<<"xmlns">>, ?NS_SASL}]}),

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -588,7 +588,6 @@ wait_for_auth_result({xmlstreamelement, El}, StateData) ->
                 ?NS_SASL ->
                     ?DEBUG("auth: ~p", [{StateData#state.myname,
                                          StateData#state.server}]),
-                    ejabberd_socket:reset_stream(StateData#state.socket),
                     send_text(StateData,
                               list_to_binary(
                                 io_lib:format(?STREAM_HEADER,

--- a/apps/ejabberd/src/ejabberd_socket.erl
+++ b/apps/ejabberd/src/ejabberd_socket.erl
@@ -36,7 +36,6 @@
          starttls/2,
          starttls/3,
          compress/3,
-         reset_stream/1,
          send/2,
          send_xml/2,
          change_shaper/2,
@@ -193,15 +192,6 @@ compress(SocketData, InflateSizeLimit, Data) ->
     ejabberd_receiver:compress(SocketData#socket_state.receiver, ZlibSocket),
     send(SocketData, Data),
     SocketData#socket_state{socket = ZlibSocket, sockmod = ejabberd_zlib}.
-
-
--spec reset_stream(socket_state()) -> socket_state().
-reset_stream(SocketData) when is_pid(SocketData#socket_state.receiver) ->
-    ejabberd_receiver:reset_stream(SocketData#socket_state.receiver);
-reset_stream(SocketData) when is_atom(SocketData#socket_state.receiver) ->
-    (SocketData#socket_state.receiver):reset_stream(
-      SocketData#socket_state.socket).
-
 
 %% @doc sockmod=gen_tcp|fast_tls|ejabberd_zlib (ejabberd:sockmod())
 send(SocketData, Data) ->

--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -20,7 +20,6 @@
 %% ejabberd_socket compatibility
 -export([starttls/2, starttls/3,
          compress/1, compress/3,
-         reset_stream/1,
          send/2,
          send_xml/2,
          change_shaper/2,
@@ -367,10 +366,6 @@ handle_info({send, Data}, accumulate = SName, #state{} = S) ->
 handle_info({send, Data}, normal = SName, #state{} = S) ->
     NS = send_or_store(Data, S),
     {next_state, SName, NS};
-handle_info(reset_stream, SName, #state{} = S) ->
-    %% TODO: actually reset the stream once it's stored per bosh session
-    ?DEBUG("Stream reset by c2s~n", []),
-    {next_state, SName, S};
 handle_info(close, _SName, #state{pending = []} = State) ->
     {stop, normal, State};
 handle_info(close, _SName, State) ->
@@ -1004,13 +999,6 @@ compress(SocketData) ->
 -spec compress(mod_bosh:socket(), _, integer()) -> no_return().
 compress(_SocketData, _Data, _InflateSizeLimit) ->
     throw({error, negotiate_compression_on_http_level}).
-
-
-%% @doc TODO: adjust for BOSH
--spec reset_stream(mod_bosh:socket()) -> mod_bosh:socket().
-reset_stream(#bosh_socket{pid = Pid} = SocketData) ->
-    Pid ! reset_stream,
-    SocketData.
 
 
 -spec send_xml(mod_bosh:socket(), mongoose_transport:send_xml_input()) -> ok.

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
   {base16, ".*", {git, "git://github.com/goj/base16.git", "f78918e"}},
   {cuesport, ".*", {git, "git://github.com/esl/cuesport.git", "d82ff25"}},
   {redo, ".*", {git, "git://github.com/Wallapop/redo.git", "35a8d1c"}},
-  {exml, ".*", {git, "git://github.com/esl/exml.git", "2.4.1"}},
+  {exml, ".*", {git, "git://github.com/esl/exml.git", {ref, "d365533"}}},
   {lager, ".*", {git, "git://github.com/basho/lager.git", "3.2.4"}},
   {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", "3.0.3"}},
   {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", "1.1.2"}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -35,13 +35,18 @@
   {git,"git://github.com/uwiger/edown.git",
        {ref,"d864427506cd93a00712b7c3b9a89d793e7e1600"}},
   0},
+ {<<"eini">>,{pkg,<<"eini">>,<<"1.2.4">>},1},
  {<<"epgsql">>,
   {git,"git://github.com/epgsql/epgsql.git",
        {ref,"3652aa9c0a7cb58beb4736cdbdfa0dc4f7eafa20"}},
   0},
+ {<<"erlcloud">>,
+  {git,"git://github.com/erlcloud/erlcloud.git",
+       {ref,"c1196989a8e7a5f45ddd7b4f81bbbc2ffcfc8274"}},
+  0},
  {<<"exml">>,
   {git,"git://github.com/esl/exml.git",
-       {ref,"06e743197a519e86e7faef6b938e09e80cddeaa3"}},
+       {ref,"d365533c193fe61fd211c74518b2136ef71b60ec"}},
   0},
  {<<"exometer">>,
   {git,"git://github.com/esl/exometer.git",
@@ -79,6 +84,7 @@
   {git,"git://github.com/davisp/jiffy.git",
        {ref,"06aaf440e091c9fd5f8aea557ac760a33bd37130"}},
   0},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.0">>},1},
  {<<"lager">>,
   {git,"git://github.com/basho/lager.git",
        {ref,"81eaef0ce98fdbf64ab95665e3bc2ec4b24c7dac"}},
@@ -91,6 +97,7 @@
   {git,"git://github.com/inaka/lasse.git",
        {ref,"692eaec1a226a6247f8450fc23b86b8afc1cee7a"}},
   0},
+ {<<"lhttpc">>,{pkg,<<"lhttpc">>,<<"1.5.1">>},1},
  {<<"lz4">>,
   {git,"https://github.com/szktty/erlang-lz4.git",
        {ref,"30878eafeff35939052c2cafe17d21c95029d3a1"}},
@@ -190,5 +197,8 @@
   0}]}.
 [
 {pkg_hash,[
+ {<<"eini">>, <<"ABD64A0533398A6D714D21219BB85F2D41FDB42665AC4080939B7BFA8E55F386">>},
+ {<<"jsx">>, <<"749BEC6D205C694AE1786D62CEA6CC45A390437E24835FD16D12D74F07097727">>},
+ {<<"lhttpc">>, <<"2137CB82D123751B21CC0461A00734CD32CB470BC6278BA139EE13C1ECC3C2B1">>},
  {<<"p1_utils">>, <<"EF0951DDF38E92B7E479AF4B8DC950DF76AF8C1030432EF68B7FD7AD17C436FE">>}]}
 ].

--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -4,8 +4,6 @@
 {require_otp_vsn, "1[789]"}.
 
 {deps, [
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "3.0.1"}},
-        {exml, ".*", {git, "git://github.com/esl/exml.git", "2.4.1"}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {bbmustache, ".*", {git, "https://github.com/soranoba/bbmustache.git", "v1.4.0"}},
         {katt, ".*", {git, "git://github.com/for-GET/katt.git", {tag, "1.5.2"}}},
@@ -13,7 +11,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", {tag, "1.0.4"}}},
-        {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}}
-
-
+        {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},
+        {exml, ".*", {git, "git://github.com/esl/exml.git", "d365533"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "b9c1dd6"}}
 ]}.

--- a/test.disabled/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/bosh_SUITE.erl
@@ -30,10 +30,10 @@
 -define(INVALID_RID_OFFSET, 999).
 
 all() ->
-    [{group, essential},
+    [
+     {group, essential},
 
      {group, chat},
-
      {group, time},
      {group, acks},
 
@@ -65,7 +65,8 @@ essential_test_cases() ->
      put_request].
 
 chat_test_cases() ->
-    [interleave_requests,
+    [
+     interleave_requests,
      simple_chat,
      cdata_escape_chat,
      escape_attr_chat,


### PR DESCRIPTION
This PR introduces pipelining via updating exml to a version that can self-reset XMPP streams, allowing to parse payloads with <stream:stream> tag and XML declaration in the middle.