### PR TITLE
Add support for XEP-0363 (HTTP Upload) version 0.3.0.

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -81,7 +81,8 @@
 -define(NS_MAM,         <<"urn:xmpp:mam:tmp">>).
 -define(NS_MAM_03,      <<"urn:xmpp:mam:0">>). % MAM 0.3
 -define(NS_MAM_04,      <<"urn:xmpp:mam:1">>). % MAM 0.4.1 or 0.5
--define(NS_HTTP_UPLOAD, <<"urn:xmpp:http:upload">>).
+-define(NS_HTTP_UPLOAD_025, <<"urn:xmpp:http:upload">>).
+-define(NS_HTTP_UPLOAD_030, <<"urn:xmpp:http:upload:0">>).
 -define(NS_PUSH,        <<"urn:xmpp:push:0">>).
 
 -define(NS_RSM,         <<"http://jabber.org/protocol/rsm">>).

--- a/apps/ejabberd/src/http_upload/mod_http_upload.erl
+++ b/apps/ejabberd/src/http_upload/mod_http_upload.erl
@@ -17,7 +17,8 @@
 -module(mod_http_upload).
 -author('konrad.zemek@erlang-solutions.com').
 -behaviour(gen_mod).
--xep([{xep, 363}, {version, "0.2.4"}]).
+-xep([{xep, 363}, {version, "0.2.5"}]).
+-xep([{xep, 363}, {version, "0.3.0"}]).
 
 -include("jlib.hrl").
 -include("ejabberd.hrl").
@@ -38,7 +39,7 @@
 -callback create_slot(UTCDateTime :: calendar:datetime(), UUID :: binary(),
                       Filename :: unicode:unicode_binary(), ContentType :: binary(),
                       Size :: pos_integer(), Opts :: proplists:proplist()) ->
-    {PUTURL :: binary(), GETURL :: binary()}.
+    {PUTURL :: binary(), GETURL :: binary(), Headers :: #{binary() => binary()}}.
 
 %%--------------------------------------------------------------------
 %% API
@@ -54,7 +55,9 @@ start(Host, Opts) ->
     ejabberd_hooks:add(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
     ejabberd_hooks:add(disco_info, SubHost, ?MODULE, get_disco_info, 90),
     ejabberd_hooks:add(disco_local_items, Host, ?MODULE, get_disco_items, 90),
-    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD, ?MODULE,
+    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_025, ?MODULE,
+                                  iq_handler, IQDisc),
+    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030, ?MODULE,
                                   iq_handler, IQDisc),
     gen_mod:start_backend_module(?MODULE, with_default_backend(Opts), [create_slot]).
 
@@ -62,7 +65,8 @@ start(Host, Opts) ->
 -spec stop(Host :: ejabberd:server()) -> any().
 stop(Host) ->
     SubHost = subhost(Host),
-    gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD),
+    gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030),
+    gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_025),
     ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, get_disco_items, 90),
     ejabberd_hooks:delete(disco_info, SubHost, ?MODULE, get_disco_info, 90),
     ejabberd_hooks:delete(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
@@ -78,7 +82,7 @@ iq_handler(_From, _To, IQ = #iq{type = set, sub_el = SubEl}) ->
 iq_handler(_From, _To = #jid{lserver = SubHost}, IQ = #iq{type = get, sub_el = Request}) ->
     {ok, Host} = mongoose_subhosts:get_host(SubHost),
     case parse_request(Request) of
-        {Filename, Size, ContentType} ->
+        {Filename, Size, ContentType, Namespace} ->
             MaxFileSize = max_file_size(Host),
             case MaxFileSize =:= undefined orelse Size =< MaxFileSize of
                 true ->
@@ -86,13 +90,14 @@ iq_handler(_From, _To = #jid{lserver = SubHost}, IQ = #iq{type = get, sub_el = R
                     Token = generate_token(Host),
                     Opts = module_opts(Host),
 
-                    {PutUrl, GetUrl} = mod_http_upload_backend:create_slot(
-                                         UTCDateTime, Token, Filename, ContentType, Size, Opts),
+                    {PutUrl, GetUrl, Headers} =
+                        mod_http_upload_backend:create_slot(UTCDateTime, Token, Filename,
+                                                            ContentType, Size, Opts),
 
-                    compose_iq_reply(IQ, PutUrl, GetUrl);
+                    compose_iq_reply(IQ, Namespace, PutUrl, GetUrl, Headers);
 
                 false ->
-                    IQ#iq{type = error, sub_el = [file_too_large_error(MaxFileSize)]}
+                    IQ#iq{type = error, sub_el = [file_too_large_error(MaxFileSize, Namespace)]}
             end;
 
         bad_request ->
@@ -126,7 +131,7 @@ get_disco_items(Acc, _From, _To, _Node, _Lang) ->
 -spec get_disco_features(Acc :: term(), From :: ejabberd:jid(), To :: ejabberd:jid(),
                          Node :: binary(), ejabberd:lang()) -> {result, [jlib:xmlel()]} | term().
 get_disco_features({result, Nodes}, _From, _To, _Node = <<>>, _Lang) ->
-    {result, [?NS_HTTP_UPLOAD | Nodes]};
+    {result, [?NS_HTTP_UPLOAD_025, ?NS_HTTP_UPLOAD_030 | Nodes]};
 get_disco_features(empty, From, To, Node, Lang) ->
     get_disco_features({result, []}, From, To, Node, Lang);
 get_disco_features(Acc, _From, _To, _Node, _Lang) ->
@@ -141,10 +146,8 @@ get_disco_info(Acc, SubHost, _Mod, _Node = <<>>, _Lang) ->
         undefined -> Acc;
         MaxFileSize ->
             MaxFileSizeBin = integer_to_binary(MaxFileSize),
-            [#xmlel{name = <<"x">>,
-                    attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"result">>}],
-                    children = [jlib:form_field({<<"FORM_TYPE">>, <<"hidden">>, ?NS_HTTP_UPLOAD}),
-                                jlib:form_field({<<"max-file-size">>, MaxFileSizeBin})]}]
+            [get_disco_info_form(?NS_HTTP_UPLOAD_025, MaxFileSizeBin),
+             get_disco_info_form(?NS_HTTP_UPLOAD_030, MaxFileSizeBin)]
     end;
 get_disco_info(Acc, _Host, _Mod, _Node, _Lang) ->
     Acc.
@@ -163,14 +166,16 @@ my_disco_name(Lang) ->
     translate:translate(Lang, <<"HTTP File Upload">>).
 
 
--spec compose_iq_reply(IQ :: ejabberd:iq(), PutUrl :: binary(), GetUrl :: binary()) ->
+-spec compose_iq_reply(IQ :: ejabberd:iq(), Namespace :: binary(),
+                       PutUrl :: binary(), GetUrl :: binary(),
+                       Headers :: #{binary() => binary()}) ->
                               Reply :: ejabberd:iq().
-compose_iq_reply(IQ, PutUrl, GetUrl) ->
+compose_iq_reply(IQ, Namespace, PutUrl, GetUrl, Headers) ->
     Slot = #xmlel{
-              name = <<"slot">>,
-              attrs = [{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
-              children = [#xmlel{name = <<"put">>, children = [exml:escape_cdata(PutUrl)]},
-                          #xmlel{name = <<"get">>, children = [exml:escape_cdata(GetUrl)]}]},
+              name     = <<"slot">>,
+              attrs    = [{<<"xmlns">>, Namespace}],
+              children = [create_url_xmlel(<<"put">>, PutUrl, Headers, Namespace),
+                          create_url_xmlel(<<"get">>, PutUrl, #{}, Namespace)]},
     IQ#iq{type = result, sub_el =[Slot]}.
 
 
@@ -202,12 +207,12 @@ generate_token(Host) ->
     base16:encode(crypto:strong_rand_bytes(token_bytes(Host))).
 
 
--spec file_too_large_error(MaxFileSize :: non_neg_integer()) -> jlib:exml().
-file_too_large_error(MaxFileSize) ->
+-spec file_too_large_error(MaxFileSize :: non_neg_integer(), Namespace :: binary()) -> jlib:exml().
+file_too_large_error(MaxFileSize, Namespace) ->
     MaxFileSizeBin = integer_to_binary(MaxFileSize),
     MaxSizeEl = #xmlel{name = <<"max-file-size">>, children = [exml:escape_cdata(MaxFileSizeBin)]},
     FileTooLargeEl = #xmlel{name = <<"file-too-large">>,
-                            attrs = [{<<"xmlns">>, ?NS_HTTP_UPLOAD}],
+                            attrs = [{<<"xmlns">>, Namespace}],
                             children = [MaxSizeEl]},
     Error0 = ?ERR_NOT_ACCEPTABLE,
     Error0#xmlel{children = [FileTooLargeEl | Error0#xmlel.children]}.
@@ -215,16 +220,42 @@ file_too_large_error(MaxFileSize) ->
 
 -spec parse_request(Request :: exml:element()) ->
                            {Filename :: binary(), Size :: integer(),
-                            ContentType :: binary() | undefined} |
+                            ContentType :: binary() | undefined, Namespace :: binary()} |
                            bad_request.
 parse_request(Request) ->
-    Filename = exml_query:path(Request, [{element, <<"filename">>}, cdata]),
-    SizeBin = exml_query:path(Request, [{element, <<"size">>}, cdata]),
+    Namespace = exml_query:attr(Request, <<"xmlns">>),
+    Keys = [<<"filename">>, <<"size">>, <<"content-type">>],
+    [Filename, SizeBin, ContentType] =
+        case Namespace of
+            ?NS_HTTP_UPLOAD_025 -> [exml_query:path(Request, [{element, K}, cdata]) || K <- Keys];
+            ?NS_HTTP_UPLOAD_030 -> [exml_query:attr(Request, K) || K <- Keys]
+        end,
     Size = (catch erlang:binary_to_integer(SizeBin)),
-    ContentType = exml_query:path(Request, [{element, <<"content-type">>}, cdata]),
-
-    case is_binary(Filename) andalso <<>> =/= Filename
-        andalso is_integer(Size) andalso Size >= 0 of
+    case is_binary(Filename) andalso <<>> =/= Filename andalso is_integer(Size) andalso Size >= 0 of
         false -> bad_request;
-        true -> {Filename, Size, ContentType}
+        true -> {Filename, Size, ContentType, Namespace}
     end.
+
+
+-spec get_disco_info_form(Namespace :: binary(), MaxFileSizeBin :: binary()) -> exml:element().
+get_disco_info_form(Namespace, MaxFileSizeBin) ->
+    #xmlel{name     = <<"x">>,
+           attrs    = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"result">>}],
+           children = [jlib:form_field({<<"FORM_TYPE">>, <<"hidden">>, Namespace}),
+                       jlib:form_field({<<"max-file-size">>, MaxFileSizeBin})]}.
+
+
+-spec header_to_xmlel({Key :: binary(), Value :: binary()}) -> exml:element().
+header_to_xmlel({Key, Value}) ->
+    #xmlel{name = <<"header">>,
+           attrs = [{<<"name">>, exml:escape_attr(Key)}],
+           children = [exml:escape_cdata(Value)]}.
+
+
+-spec create_url_xmlel(Name :: binary(), Url :: binary(), Headers :: #{binary() => binary()},
+                       Namespace :: binary()) -> exml:element().
+create_url_xmlel(Name, Url, _Headers, ?NS_HTTP_UPLOAD_025) ->
+    #xmlel{name = Name, children = [exml:escape_cdata(Url)]};
+create_url_xmlel(Name, Url, Headers, ?NS_HTTP_UPLOAD_030) ->
+    HeadersXml = [header_to_xmlel(H) || H <- maps:to_list(Headers)],
+    #xmlel{name = Name, attrs = [{<<"url">>, exml:escape_attr(Url)}], children = HeadersXml}.

--- a/apps/ejabberd/src/http_upload/mod_http_upload.erl
+++ b/apps/ejabberd/src/http_upload/mod_http_upload.erl
@@ -231,7 +231,7 @@ parse_request(Request) ->
             ?NS_HTTP_UPLOAD_030 -> [exml_query:attr(Request, K) || K <- Keys]
         end,
     Size = (catch erlang:binary_to_integer(SizeBin)),
-    case is_binary(Filename) andalso <<>> =/= Filename andalso is_integer(Size) andalso Size >= 0 of
+    case is_nonempty_binary(Filename) andalso is_positive_integer(Size) of
         false -> bad_request;
         true -> {Filename, Size, ContentType, Namespace}
     end.
@@ -259,3 +259,13 @@ create_url_xmlel(Name, Url, _Headers, ?NS_HTTP_UPLOAD_025) ->
 create_url_xmlel(Name, Url, Headers, ?NS_HTTP_UPLOAD_030) ->
     HeadersXml = [header_to_xmlel(H) || H <- maps:to_list(Headers)],
     #xmlel{name = Name, attrs = [{<<"url">>, exml:escape_attr(Url)}], children = HeadersXml}.
+
+
+-spec is_nonempty_binary(term()) -> boolean().
+is_nonempty_binary(<<_, _/binary>>) -> true;
+is_nonempty_binary(_) -> false.
+
+
+-spec is_positive_integer(term()) -> boolean().
+is_positive_integer(X) when is_integer(X) -> X > 0;
+is_positive_integer(_) -> false.

--- a/apps/ejabberd/src/http_upload/mod_http_upload_s3.erl
+++ b/apps/ejabberd/src/http_upload/mod_http_upload_s3.erl
@@ -27,7 +27,8 @@
 -spec create_slot(UTCDateTime :: calendar:datetime(), Token :: binary(),
                   Filename :: unicode:unicode_binary(), ContentType :: binary(),
                   Size :: pos_integer(), Opts :: proplists:proplist()) ->
-                         {PUTURL :: binary(), GETURL :: binary()}.
+                         {PUTURL :: binary(), GETURL :: binary(),
+                          Headers :: #{binary() => binary()}}.
 create_slot(UTCDateTime, Token, Filename, ContentType, Size, Opts) ->
     S3Opts = gen_mod:get_opt(s3, Opts),
     ExpirationTime = gen_mod:get_opt(expiration_time, Opts, 60),
@@ -49,7 +50,8 @@ create_slot(UTCDateTime, Token, Filename, ContentType, Size, Opts) ->
 
     {
       compose_url(Scheme, Host, Port, Path, Queries),
-      compose_url(Scheme, Host, Port, Path, #{})
+      compose_url(Scheme, Host, Port, Path, #{}),
+      #{}
     }.
 
 %%--------------------------------------------------------------------

--- a/apps/ejabberd/test/mod_http_upload_s3_SUITE.erl
+++ b/apps/ejabberd/test/mod_http_upload_s3_SUITE.erl
@@ -157,13 +157,14 @@ creates_get_url_to_the_resource(_Config) ->
 %% Helpers
 
 create_slot(Args) ->
-    mod_http_upload_s3:create_slot(
-      maps:get(timestamp, Args, ?TIMESTAMP),
-      maps:get(token, Args, ?TOKEN),
-      maps:get(filename, Args, ?FILENAME),
-      maps:get(content_type, Args, ?CONTENT_TYPE),
-      maps:get(size, Args, ?SIZE),
-      maps:get(opts, Args, ?OPTS)).
+    {PutUrl, GetUrl, #{}} = mod_http_upload_s3:create_slot(
+                              maps:get(timestamp, Args, ?TIMESTAMP),
+                              maps:get(token, Args, ?TOKEN),
+                              maps:get(filename, Args, ?FILENAME),
+                              maps:get(content_type, Args, ?CONTENT_TYPE),
+                              maps:get(size, Args, ?SIZE),
+                              maps:get(opts, Args, ?OPTS)),
+    {PutUrl, GetUrl}.
 
 with_s3_opts(Opts) ->
     [{s3, S3Opts}] = ?OPTS,


### PR DESCRIPTION
This PR adds support for XEP-0363 v 0.3.0 while preserving backwards compatibility with version 0.2.5 (which looks to have conforming client implementations).