### PR TITLE
Fix uncleaned resumed sessions

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -2876,20 +2876,20 @@ do_resume_session(SMID, El, [{_, Pid}], StateData) ->
         Conn = get_conn_type(StateData),
         MergedState = merge_state(OldState,
                                   StateData#state{sid = SID, conn = Conn}),
-        Priority = get_priority_from_presence(MergedState#state.pres_last),
-        Info = [{ip, MergedState#state.ip},
-                {conn, MergedState#state.conn},
-                {auth_module, MergedState#state.auth_module}],
-        ejabberd_sm:open_session(SID,
-                                 MergedState#state.user,
-                                 MergedState#state.server,
-                                 MergedState#state.resource,
-                                 Priority, Info),
-        ok = mod_stream_management:register_smid(SMID, SID),
         case stream_mgmt_handle_ack(session_established, El, MergedState) of
             {stop, _, _} = Stop ->
                 Stop;
             {next_state, session_established, NSD, _} ->
+                Priority = get_priority_from_presence(NSD#state.pres_last),
+                Info = [{ip, NSD#state.ip},
+                        {conn, NSD#state.conn},
+                        {auth_module, NSD#state.auth_module}],
+                ejabberd_sm:open_session(SID,
+                                         NSD#state.user,
+                                         NSD#state.server,
+                                         NSD#state.resource,
+                                         Priority, Info),
+                ok = mod_stream_management:register_smid(SMID, SID),
                 try
                     Resumed = stream_mgmt_resumed(NSD#state.stream_mgmt_id,
                                                   NSD#state.stream_mgmt_in),

--- a/test.disabled/ejabberd_tests/tests/sm_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/sm_SUITE.erl
@@ -611,6 +611,7 @@ resume_session_with_wrong_h_does_not_leak_sessions(Config) ->
                                          <<"h attribute too big">>], Resumed),
 
         [] = get_user_resources(AliceSpec),
+        [] = get_sid_by_stream_id(SMID),
         false = escalus_connection:is_connected(Alice)
     end).
 
@@ -775,6 +776,9 @@ get_session_pid(UserSpec, Resource) ->
 get_user_resources(UserSpec) ->
     {U, S} = get_us_from_spec(UserSpec),
     escalus_ejabberd:rpc(ejabberd_sm, get_user_present_resources, [U, S]).
+
+get_sid_by_stream_id(SMID) ->
+    escalus_ejabberd:rpc(mod_stream_management, get_sid, [SMID]).
 
 get_us_from_spec(UserSpec) ->
     ConfigUS = [proplists:get_value(username, UserSpec),


### PR DESCRIPTION
This PR addresses #843

The issue is very well described in this comment: https://github.com/esl/MongooseIM/issues/843#issuecomment-279312597

Basically if the stream resumption fails, there was session entry remaining after stopped `c2s` process. This entry would only be removed in users connects with the same resource, otherwise it may remain in the session table for ever.

Proposed changes include:
* moved session item creation after checking the `h` parameter
* regression test
