### PR TITLE
Add labels to docker images created on travis

### DIFF
--- a/tools/travis-build-and-push-docker.sh
+++ b/tools/travis-build-and-push-docker.sh
@@ -30,9 +30,8 @@ fi
 
 IMAGE_TAG=${DOCKERHUB_USER}/mongooseim:${DOCKERHUB_TAG}
 
-git clone https://github.com/esl/mongooseim-docker.git
+git clone -b 843558f https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
-git checkout 843558f
 
 cp ../${MONGOOSE_TGZ} member
 
@@ -44,6 +43,6 @@ docker build -f Dockerfile.member -t ${IMAGE_TAG} \
 
 docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
 
-docker push ${DOCKERHUB_USER}/mongooseim:${DOCKERHUB_TAG}
+docker push ${IMAGE_TAG}
 
 fi

--- a/tools/travis-build-and-push-docker.sh
+++ b/tools/travis-build-and-push-docker.sh
@@ -4,12 +4,10 @@
 
 if [ ${TRAVIS_SECURE_ENV_VARS} == 'true' ]; then
 
-
 ./tools/configure with-all
 make rel
 
 MIM_TAR_FULL_NAME=mongooseim-$TRAVIS_BRANCH.OTP-$TRAVIS_OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2
-
 MONGOOSE_TGZ=mongooseim.tar.gz
 
 BUILD_PATH=_build/prod/rel/mongooseim
@@ -21,6 +19,8 @@ export BUILDS=`pwd`
 export MEMBER_TGZ=mongooseim.tar.gz
 
 DOCKERHUB_TAG=${TRAVIS_BRANCH}
+VERSION=`tools/generate_vsn.sh`
+GIT_REF=`git rev-parse --short HEAD`
 
 if [ ${TRAVIS_PULL_REQUEST} != 'false' ]; then
     DOCKERHUB_TAG="PR-${TRAVIS_PULL_REQUEST}"
@@ -28,16 +28,21 @@ elif [ ${TRAVIS_BRANCH} == 'master' ]; then
     DOCKERHUB_TAG="latest";
 fi
 
+IMAGE_TAG=${DOCKERHUB_USER}/mongooseim:${DOCKERHUB_TAG}
+
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
+git checkout 843558f
 
 cp ../${MONGOOSE_TGZ} member
 
-docker build -f Dockerfile.member -t mongooseim .
+docker build -f Dockerfile.member -t ${IMAGE_TAG} \
+             --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+	     --build-arg VCS_REF=${GIT_REF} \
+	     --build-arg VERSION=${VERSION} \
+	     .
 
-docker login -e=${DOCKERHUB_EMAIL} -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
-
-docker tag mongooseim ${DOCKERHUB_USER}/mongooseim:${DOCKERHUB_TAG}
+docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
 
 docker push ${DOCKERHUB_USER}/mongooseim:${DOCKERHUB_TAG}
 


### PR DESCRIPTION
Proposed changes include:
* build time values passed to `docker build` via `--build-args`
* removal of deprecated `--email` parameter to `docker login`
* frozen version of https://github.com/esl/mongooseim-docker/commit/843558fb15ddbde6c0fbb704295208449034b123

