### PR TITLE
Add per_message_flush_time metric

### DIFF
--- a/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_async_pool_writer.erl
@@ -175,7 +175,7 @@ stop_workers(Host) ->
 start_worker(WriterProc, N, Host, Pool, MaxSize) ->
     WriterChildSpec =
     {WriterProc,
-     {gen_server, start_link, [{local, WriterProc}, ?MODULE, [N, Host, Pool, MaxSize], []]},
+     {gen_server, start_link, [{local, WriterProc}, ?MODULE, [Host, N, Pool, MaxSize], []]},
      permanent,
      5000,
      worker,


### PR DESCRIPTION
This PR adds a metric that shows how long it takes for MAM to flush messages, averaged over a message batch.