### PR TITLE
Accum stage four

### DIFF
--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -52,9 +52,6 @@
 -define(ERROR_MSG(Format, Args),
     lager:error(Format, Args)).
 
--define(OK_OR_LOG(E),
-    case E of ok -> ok; {atomic, _} -> ok; _ -> lager:error("Error - expected ok, got '~p'", [E]) end).
-
 -define(CRITICAL_MSG(Format, Args),
     lager:critical(Format, Args)).
 

--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -52,6 +52,9 @@
 -define(ERROR_MSG(Format, Args),
     lager:error(Format, Args)).
 
+-define(OK_OR_LOG(E),
+    case E of ok -> ok; _ -> lager:error("Error - expected ok, got '~p'", [E]) end).
+
 -define(CRITICAL_MSG(Format, Args),
     lager:critical(Format, Args)).
 

--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -53,7 +53,7 @@
     lager:error(Format, Args)).
 
 -define(OK_OR_LOG(E),
-    case E of ok -> ok; _ -> lager:error("Error - expected ok, got '~p'", [E]) end).
+    case E of ok -> ok; {atomic, _} -> ok; _ -> lager:error("Error - expected ok, got '~p'", [E]) end).
 
 -define(CRITICAL_MSG(Format, Args),
     lager:critical(Format, Args)).

--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -70,6 +70,8 @@
 
 -type scram() :: #scram{}.
 
+-type sm_session() :: #session{}.
+
 -record(route, {
           domain :: binary(),
           handler :: mongoose_packet_handler:t()

--- a/apps/ejabberd/src/amp.erl
+++ b/apps/ejabberd/src/amp.erl
@@ -133,7 +133,7 @@ strip_amp_el(#xmlel{children = Children} = Elem) ->
 %%      but filter out server->client AMPed responses.
 %%      We can distinguish them by the fact that s2c messages MUST have
 %%      a 'status' attr on the <amp> element.
--spec is_amp_request(#xmlel{}) -> boolean().
+-spec is_amp_request(xmlel()) -> boolean().
 is_amp_request(Stanza) ->
     Amp = exml_query:subelement(Stanza, <<"amp">>),
     (undefined =/= Amp)

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -3158,7 +3158,7 @@ sasl_success_stanza(ServerOut) ->
            attrs = [{<<"xmlns">>, ?NS_SASL}],
            children = C}.
 
--spec sasl_failure_stanza(any()) -> xmlel().
+-spec sasl_failure_stanza(binary() | {binary(), iodata() | undefined}) -> xmlel().
 sasl_failure_stanza(Error) when is_binary(Error) ->
     sasl_failure_stanza({Error, undefined});
 sasl_failure_stanza({Error, Text}) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1211,7 +1211,7 @@ maybe_terminate(Acc) ->
     % instead of this, we will pass on the accumulator, only replacing
     % 'element' with 'to_send', if present
     case mongoose_acc:is_acc(Acc) of
-        true -> 
+        true ->
             mongoose_acc:terminate(Acc, received, ?FILE, ?LINE);
         false ->
             ?ERROR_MSG("Hey, it should be accumulator here! ~p", [Acc]),

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -64,6 +64,7 @@
 -include("ejabberd.hrl").
 -include("ejabberd_c2s.hrl").
 -include("jlib.hrl").
+-include_lib("exml/include/exml.hrl").
 -xep([{xep, 18}, {version, "0.2"}]).
 -behaviour(p1_fsm_old).
 
@@ -1274,9 +1275,10 @@ handle_incoming_message(Info, StateName, StateData) ->
     ?ERROR_MSG("Unexpected info: ~p", [Info]),
     fsm_next_state(StateName, StateData).
 
-process_incoming_stanza(<<"broadcast">>, _From, _To, Packet, StateName, StateData) ->
-    self() ! legacy_packet_to_broadcast(Packet),
-    fsm_next_state(StateName, StateData);
+%% do we still need this?
+%%process_incoming_stanza(<<"broadcast">>, _From, _To, Packet, StateName, StateData) ->
+%%    self() ! legacy_packet_to_broadcast(Packet),
+%%    fsm_next_state(StateName, StateData);
 process_incoming_stanza(Name, From, To, Acc, StateName, StateData) ->
     case handle_routed(Name, From, To, Acc, StateData) of
         {allow, NewAcc, NewState} ->
@@ -1320,12 +1322,13 @@ send_back_error(Etype, From, To, Packet) ->
     Err = jlib:make_error_reply(Packet, Etype),
     ejabberd_router:route(To, From, Err).
 
--spec legacy_packet_to_broadcast({xmlel, any(), any(), list()}) -> {broadcast, broadcast_type()}.
-legacy_packet_to_broadcast({xmlel, _, _, [Child]}) ->
-    {broadcast, Child};
-legacy_packet_to_broadcast(InvalidBroadcast) ->
-    ?WARNING_MSG("invalid_broadcast=~p", [InvalidBroadcast]),
-    {broadcast, unknown}.
+% do we still need this?
+%%-spec legacy_packet_to_broadcast(jlib:xmlel()) -> {broadcast, broadcast_type()}.
+%%legacy_packet_to_broadcast(#xmlel{children = [Child]}) ->
+%%    {broadcast, Child};
+%%legacy_packet_to_broadcast(InvalidBroadcast) ->
+%%    ?WARNING_MSG("invalid_broadcast=~p", [InvalidBroadcast]),
+%%    {broadcast, unknown}.
 
 handle_routed(<<"presence">>, From, To, Acc, StateData) ->
     handle_routed_presence(From, To, Acc, StateData);
@@ -1346,7 +1349,7 @@ handle_routed(_, _From, _To, Acc, StateData) ->
 
 -spec handle_routed_iq(From :: ejabberd:jid(),
                        To :: ejabberd:jid(),
-                       Packet :: exml:element(),
+                       Acc :: mongoose_acc:t(),
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc, StateData) ->
     Qi = jlib:iq_query_info(mongoose_acc:get(to_send, Acc)), % could be done via 'require'
@@ -1354,7 +1357,7 @@ handle_routed_iq(From, To, Acc, StateData) ->
 
 -spec handle_routed_iq(From :: ejabberd:jid(),
                        To :: ejabberd:jid(),
-                       Packet :: exml:element(),
+                       Acc :: mongoose_acc:t(),
                        IQ :: invalid | not_iq | reply | ejabberd:iq(),
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc, #iq{ xmlns = ?NS_LAST }, StateData) ->
@@ -1438,7 +1441,7 @@ privacy_list_push_iq(PrivListName) ->
                                             attrs = [{<<"name">>, PrivListName}]}]}]}.
 
 -spec handle_routed_presence(From :: ejabberd:jid(), To :: ejabberd:jid(),
-                             Packet :: mongoose_acc:t(), StateData :: state()) -> routing_result().
+                             Acc0 :: mongoose_acc:t(), StateData :: state()) -> routing_result().
 handle_routed_presence(From, To, Acc0, StateData) ->
     Packet = mongoose_acc:get(to_send, Acc0),
     % a rare exception - hook which modifies state, can we treat #state as accumulator here?
@@ -1484,7 +1487,7 @@ handle_routed_presence(From, To, Acc0, StateData) ->
 -spec handle_routed_available_presence(State :: state(),
                                        From :: ejabberd:jid(),
                                        To :: ejabberd:jid(),
-                                       Packet :: exml:element()) -> routing_result().
+                                       Acc :: mongoose_acc:t()) -> routing_result().
 handle_routed_available_presence(State, From, To, Acc) ->
     {Acc1, Res} = privacy_check_packet(Acc, To, in, State),
     case Res of

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -973,14 +973,14 @@ process_outgoing_stanza(Acc, StateData) ->
     fsm_next_state(session_established, NState).
 
 process_outgoing_stanza(Acc, error, _Name, StateData) ->
-    Attrs = mongoose_acc:get(attrs, Acc),
     NewEl = mongoose_acc:terminate(Acc, ?FILE, ?LINE),
-    case xml:get_attr_s(<<"type">>, Attrs) of
+    case mongoose_acc:get(type, Acc) of
         <<"error">> -> StateData;
         <<"result">> -> StateData;
         _ ->
             Err = jlib:make_error_reply(NewEl, ?ERR_JID_MALFORMED),
-            send_element(StateData, Err),
+            NAcc = mongoose_acc:put(to_send, Err, Acc),
+            send_element(NAcc, StateData),
             StateData
     end;
 process_outgoing_stanza(Acc, ToJID, <<"presence">>, StateData) ->
@@ -1593,12 +1593,26 @@ maybe_send_element_safe(State, El) ->
         _ -> error
     end.
 
-send_element(#state{server = Server, sockmod = SockMod} = StateData, El)
-  when StateData#state.xml_socket ->
-    ejabberd_hooks:run(xmpp_send_element, Server, [Server, El]),
+%% @doc This is the termination point - from here stanza is sent to the user
+%% We sent the original stanza ('element') unless there is a different thing
+%% keyed 'to_send'
+send_element(StateData, #xmlel{} = El) ->
+    ?DEPRECATED,
+    send_element(mongoose_acc:from_element(El), StateData),
+    ok;
+send_element(Acc, #state{server = Server} = StateData) ->
+    Acc1 = ejabberd_hooks:run_fold(xmpp_send_element, Server, Acc, [Server]),
+    El = case mongoose_acc:get(to_send, Acc1, undefined) of
+             undefined -> mongoose_acc:get(element, Acc1);
+             OutStanza -> OutStanza
+         end,
+    % we might put send result into accumulator
+    do_send_element(El, StateData),
+    Acc1.
+
+do_send_element(El, #state{sockmod = SockMod} = StateData) when StateData#state.xml_socket ->
     mongoose_transport:send_xml(SockMod, StateData#state.socket, {xmlstreamelement, El});
-send_element(#state{server = Server} = StateData, El) ->
-    ejabberd_hooks:run(xmpp_send_element, Server, [Server, El]),
+do_send_element(El, StateData) ->
     send_text(StateData, exml:to_binary(El)).
 
 
@@ -1655,6 +1669,7 @@ send_trailer(StateData) ->
 
 
 send_and_maybe_buffer_stanza({J1, J2, El}, State, StateName)->
+    % this is coming in, no rewrite yet
     {SendResult, BufferedStateData} =
         send_and_maybe_buffer_stanza({J1, J2, mod_amp:strip_amp_el_from_request(El)}, State),
     mod_amp:check_packet(El, send_result_to_amp_event(SendResult)),
@@ -2340,18 +2355,18 @@ check_privacy_and_route_or_ignore(Acc, StateData, From, To, Packet, Dir) ->
 
 -spec resend_subscription_requests(mongoose_acc:t(), state()) -> {mongoose_acc:t(), state()}.
 resend_subscription_requests(Acc, #state{pending_invitations = Pending} = StateData) ->
-    % this seems to be one of the final function calls - or nearly final, depending on where
-    % do we want to terminate accumulator - on send_element or earlier
-    NewState = lists:foldl(
-                 fun(XMLPacket, #state{} = State) ->
-                         send_element(State, XMLPacket),
+    {NewAcc, NewState} = lists:foldl(
+                 fun(XMLPacket, {A, #state{} = State}) ->
+                         A1 = mongoose_acc:put(to_send, XMLPacket, A),
+                         A2 = send_element(A1, State),
                          {value, From} =  xml:get_tag_attr(<<"from">>, XMLPacket),
                          {value, To} = xml:get_tag_attr(<<"to">>, XMLPacket),
                          BufferedStateData = buffer_out_stanza({From, To, XMLPacket}, State),
+                         % this one will be next to tackle
                          maybe_send_ack_request(BufferedStateData),
-                         BufferedStateData
-                 end, StateData, Pending),
-    {Acc, NewState#state{pending_invitations = []}}.
+                         {A2, BufferedStateData}
+                 end, {Acc, StateData}, Pending),
+    {NewAcc, NewState#state{pending_invitations = []}}.
 
 
 get_showtag(undefined) ->
@@ -2684,6 +2699,7 @@ resend_csi_buffer(State) ->
     fsm_next_state(session_established, NewState#state{csi_state=active}).
 
 ship_to_local_user(Packet, State, StateName) ->
+    % this is coming in, no rewrite yet
     maybe_csi_inactive_optimisation(Packet, State, StateName).
 
 maybe_csi_inactive_optimisation(Packet, #state{csi_state = active} = State,

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1137,16 +1137,6 @@ handle_info(replaced, _StateName, StateData) ->
                             ?SERRT_CONFLICT(Lang, <<"Replaced by new connection">>)),
     maybe_send_trailer_safe(StateData),
     {stop, normal, StateData#state{authenticated = replaced}};
-%% Process Packets that are to be sent to the user
-handle_info({broadcast, Broadcast}, StateName, StateData) ->
-    ejabberd_hooks:run(c2s_loop_debug, [{broadcast, Broadcast}]),
-    ?DEBUG("broadcast=~p", [Broadcast]),
-    Res = handle_routed_broadcast(Broadcast, StateData),
-    handle_broadcast_result(Res, StateName, StateData);
-handle_info({route, From, To, Packet}, StateName, StateData) ->
-    ejabberd_hooks:run(c2s_loop_debug, [{route, From, To, Packet}]),
-    Name = Packet#xmlel.name,
-    process_incoming_stanza(Name, From, To, Packet, StateName, StateData);
 handle_info(new_offline_messages, session_established,
             #state{pres_last = Presence, pres_invis = Invisible} = StateData)
   when Presence =/= undefined orelse Invisible ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1241,7 +1241,7 @@ handle_incoming_message({route, From, To, Acc0}, StateName, StateData) ->
     Name = mongoose_acc:get(name, Acc1),
     process_incoming_stanza(Name, From, To, Acc1, StateName, StateData);
 handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
-    ?ERROR_MSG("{send_filtered, Packet}: ~p~n", [{send_filtered, Packet}]), % is it ever called?
+    % this is used by pubsub and should be rewritten when someone rewrites pubsub module
     Drop = ejabberd_hooks:run_fold(c2s_filter_packet, StateData#state.server,
         true, [StateData#state.server, StateData,
             Feature, To, Packet]),
@@ -1343,8 +1343,9 @@ handle_routed(_, _From, _To, Acc, StateData) ->
                        Acc :: mongoose_acc:t(),
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc, StateData) ->
-    Qi = jlib:iq_query_info(mongoose_acc:get(to_send, Acc)), % could be done via 'require'
-    handle_routed_iq(From, To, Acc, Qi, StateData).
+    Acc1 = mongoose_acc:require(iq_query_info, Acc),
+    Qi = mongoose_acc:get(iq_query_info, Acc1),
+    handle_routed_iq(From, To, Acc1, Qi, StateData).
 
 -spec handle_routed_iq(From :: ejabberd:jid(),
                        To :: ejabberd:jid(),
@@ -2306,9 +2307,9 @@ get_priority_from_presence(PresencePacket) ->
 -spec process_privacy_iq(Acc :: mongoose_acc:t(),
                          To :: ejabberd:jid(),
                          StateData :: state()) -> {mongoose_acc:t(), state()}.
-process_privacy_iq(Acc, To, StateData) ->
-    El = mongoose_acc:get(element, Acc),
-    IQ = jlib:iq_query_info(El),
+process_privacy_iq(Acc0, To, StateData) ->
+    Acc = mongoose_acc:require(iq_query_info, Acc0),
+    IQ = mongoose_acc:get(iq_query_info, Acc),
     Acc1 = mongoose_acc:put(iq, IQ, Acc),
     From = mongoose_acc:get(from_jid, Acc1),
     #iq{type = Type, sub_el = SubEl} = IQ,

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -897,9 +897,27 @@ session_established({xmlstreamelement, El}, StateData) ->
         _NewEl ->
             NewState = maybe_increment_sm_incoming(StateData#state.stream_mgmt,
                                                    StateData),
-            case mod_amp:check_packet(El, FromJID, initial_check) of
+            % initialise accumulator, fill with data
+            Acc0 = mongoose_acc:initialise(El, ?FILE, ?LINE),
+            User = NewState#state.user,
+            Server = NewState#state.server,
+            Attrs = mongoose_acc:get(attrs, Acc0),
+            To = xml:get_attr_s(<<"to">>, Attrs),
+            ToJID = case To of
+                        <<>> ->
+                            jid:make(User, Server, <<>>);
+                        _ ->
+                            jid:from_binary(To)
+                    end,
+            Acc = mongoose_acc:update(Acc0, #{user => User,
+                                              server => Server,
+                                              from_jid => FromJID,
+                                              to_jid => ToJID,
+                                              to => To}),
+            Acc1 = mod_amp:check_packet(Acc, initial_check),
+            case mongoose_acc:get(amp_check_result, Acc1, ok) of
                 drop -> fsm_next_state(session_established, NewState);
-                NewEl -> process_outgoing_stanza(NewEl, NewState)
+                _ -> process_outgoing_stanza(Acc1, NewState)
             end
     end;
 
@@ -929,28 +947,14 @@ session_established(closed, StateData) ->
 
 %% @doc Process packets sent by user (coming from user on c2s XMPP
 %% connection)
--spec process_outgoing_stanza(El :: jlib:xmlel(), state()) -> fsm_return().
-process_outgoing_stanza(El, StateData) ->
-    % initialise accumulator, fill with data
-    Acc = mongoose_acc:initialise(El, ?FILE, ?LINE),
-    User = StateData#state.user,
-    Server = StateData#state.server,
-    FromJID = StateData#state.jid,
+%% eventually it should return {mongoose_acc:t(), fsm_return()} so that the accumulator
+%% comes back whence it originated
+-spec process_outgoing_stanza(mongoose_acc:t(), state()) -> fsm_return().
+process_outgoing_stanza(Acc, StateData) ->
+    El0 = mongoose_acc:get(element, Acc),
     Attrs = mongoose_acc:get(attrs, Acc),
-    To = xml:get_attr_s(<<"to">>, Attrs),
-    ToJID = case To of
-                <<>> ->
-                    jid:make(User, Server, <<>>);
-                _ ->
-                    jid:from_binary(To)
-            end,
-    Acc1 = mongoose_acc:update(Acc, #{user => User,
-                                      server => Server,
-                                      from_jid => FromJID,
-                                      to_jid => ToJID,
-                                      to => To}),
+    ToJID = mongoose_acc:get(to_jid, Acc),
     % do some cryptic preparation on xmlel
-    El0 = mongoose_acc:get(element, Acc1),
     NewEl1 = jlib:remove_attr(<<"xmlns">>, jlib:remove_delay_tags(El0)),
     NewEl = case xml:get_attr_s(<<"xml:lang">>, Attrs) of
                 <<>> ->
@@ -962,10 +966,10 @@ process_outgoing_stanza(El, StateData) ->
                 _ ->
                     NewEl1
             end,
-    Acc2 = mongoose_acc:put(element, NewEl, Acc1),
+    Acc2 = mongoose_acc:put(element, NewEl, Acc),
     Name = mongoose_acc:get(name, Acc2),
     NState = process_outgoing_stanza(Acc2, ToJID, Name, StateData),
-    ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, El}]),
+    ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, NewEl}]),
     fsm_next_state(session_established, NState).
 
 process_outgoing_stanza(Acc, error, _Name, StateData) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1230,7 +1230,13 @@ handle_incoming_message({broadcast, Acc}, StateName, StateData) ->
     ?DEBUG("broadcast=~p", [Broadcast]),
     Res = handle_routed_broadcast(Broadcast, StateData),
     handle_broadcast_result(Res, StateName, StateData);
-handle_incoming_message({route, From, To, Acc}, StateName, StateData) ->
+handle_incoming_message({route, From, To, Acc0}, StateName, StateData) ->
+    % since we are now in the other user's session some cached data are not valid
+    % anymore (e.g. privacy_check), they have to be removed somewher between
+    % sender and recipient. One might argue, possibly rightly, that it should be
+    % stripped before sending; the reason I do it here is that when we send
+    % an acc out of c2s it returns and we might still use the cached data.
+    Acc = mongoose_acc:flush(Acc0),
     Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [{route, From, To}]),
     Name = mongoose_acc:get(name, Acc1),
     process_incoming_stanza(Name, From, To, Acc1, StateName, StateData);
@@ -1272,9 +1278,9 @@ process_incoming_stanza(<<"broadcast">>, _From, _To, Packet, StateName, StateDat
     self() ! legacy_packet_to_broadcast(Packet),
     fsm_next_state(StateName, StateData);
 process_incoming_stanza(Name, From, To, Acc, StateName, StateData) ->
-    Packet = mongoose_acc:get(to_send, Acc),
     case handle_routed(Name, From, To, Acc, StateData) of
         {allow, NewAcc, NewState} ->
+            Packet = mongoose_acc:get(to_send, NewAcc),
             #xmlel{attrs = Attrs} = Packet,
             Attrs2 = jlib:replace_from_to_attrs(jid:to_binary(From),
                 jid:to_binary(To),
@@ -1286,7 +1292,8 @@ process_incoming_stanza(Name, From, To, Acc, StateName, StateData) ->
                 Acc2,
                 [StateData#state.jid, From, To, FixedPacket]),
             ship_to_local_user({From, To, FixedPacket}, NewState, StateName);
-        {Reason, _NewAcc, NewState} ->
+        {Reason, NewAcc, NewState} ->
+            Packet = mongoose_acc:get(to_send, NewAcc),
             response_negative(Name, Reason, From, To, Packet),
             fsm_next_state(StateName, NewState)
     end.
@@ -1342,7 +1349,7 @@ handle_routed(_, _From, _To, Acc, StateData) ->
                        Packet :: exml:element(),
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc, StateData) ->
-    Qi = jlib:iq_query_info(mongoose_acc:get(to_send, Acc)),
+    Qi = jlib:iq_query_info(mongoose_acc:get(to_send, Acc)), % could be done via 'require'
     handle_routed_iq(From, To, Acc, Qi, StateData).
 
 -spec handle_routed_iq(From :: ejabberd:jid(),
@@ -1430,9 +1437,11 @@ privacy_list_push_iq(PrivListName) ->
                          children = [#xmlel{name = <<"list">>,
                                             attrs = [{<<"name">>, PrivListName}]}]}]}.
 
--spec handle_routed_presence(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel(),
-                            StateData :: state()) -> routing_result().
-handle_routed_presence(From, To, Acc0, State) ->
+-spec handle_routed_presence(From :: ejabberd:jid(), To :: ejabberd:jid(),
+                             Packet :: mongoose_acc:t(), StateData :: state()) -> routing_result().
+handle_routed_presence(From, To, Acc0, StateData) ->
+    Packet = mongoose_acc:get(to_send, Acc0),
+    % a rare exception - hook which modifies state, can we treat #state as accumulator here?
     State = ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
                                     StateData, [{From, To, Packet}]),
     Acc = mongoose_acc:require(send_type, Acc0),
@@ -1451,7 +1460,8 @@ handle_routed_presence(From, To, Acc0, State) ->
         <<"invisible">> ->
             El = mongoose_acc:get(element, Acc),
             #xmlel{attrs = Attrs} = El,
-            Attrs2 = [{<<"type">>, <<"unavailable">>} | Attrs],
+            Attrs1 = lists:keydelete(<<"type">>, 1, Attrs),
+            Attrs2 = [{<<"type">>, <<"unavailable">>} | Attrs1],
             NEl = El#xmlel{attrs = Attrs2},
             Acc1 = mongoose_acc:put(to_send, NEl, Acc),
             {allow, Acc1, State};

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1220,6 +1220,7 @@ maybe_terminate(Acc) ->
 
 %%% incoming messages
 handle_incoming_message({send_text, Text}, StateName, StateData) ->
+    ?ERROR_MSG("{c2s:send_text, Text}: ~p~n", [{send_text, Text}]), % is it ever called?
     send_text(StateData, Text),
     ejabberd_hooks:run(c2s_loop_debug, [Text]),
     fsm_next_state(StateName, StateData);
@@ -1230,11 +1231,11 @@ handle_incoming_message({broadcast, Acc}, StateName, StateData) ->
     Res = handle_routed_broadcast(Broadcast, StateData),
     handle_broadcast_result(Res, StateName, StateData);
 handle_incoming_message({route, From, To, Acc}, StateName, StateData) ->
-    Packet = maybe_terminate(Acc),
-    ejabberd_hooks:run(c2s_loop_debug, [{route, From, To, Packet}]),
-    Name = Packet#xmlel.name,
-    process_incoming_stanza(Name, From, To, Packet, StateName, StateData);
+    Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [{route, From, To}]),
+    Name = mongoose_acc:get(name, Acc1),
+    process_incoming_stanza(Name, From, To, Acc1, StateName, StateData);
 handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
+    ?ERROR_MSG("{send_filtered, Packet}: ~p~n", [{send_filtered, Packet}]), % is it ever called?
     Drop = ejabberd_hooks:run_fold(c2s_filter_packet, StateData#state.server,
         true, [StateData#state.server, StateData,
             Feature, To, Packet]),
@@ -1270,18 +1271,22 @@ handle_incoming_message(Info, StateName, StateData) ->
 process_incoming_stanza(<<"broadcast">>, _From, _To, Packet, StateName, StateData) ->
     self() ! legacy_packet_to_broadcast(Packet),
     fsm_next_state(StateName, StateData);
-process_incoming_stanza(Name, From, To, Packet, StateName, StateData) ->
-    case handle_routed(Name, From, To, Packet, StateData) of
-        {allow, NewAttrs, NewState} ->
+process_incoming_stanza(Name, From, To, Acc, StateName, StateData) ->
+    Packet = mongoose_acc:get(to_send, Acc),
+    case handle_routed(Name, From, To, Acc, StateData) of
+        {allow, NewAcc, NewState} ->
+            #xmlel{attrs = Attrs} = Packet,
             Attrs2 = jlib:replace_from_to_attrs(jid:to_binary(From),
                 jid:to_binary(To),
-                NewAttrs),
+                Attrs),
             FixedPacket = Packet#xmlel{attrs = Attrs2},
-            ejabberd_hooks:run(user_receive_packet,
+            Acc2 = mongoose_acc:put(to_send, FixedPacket, NewAcc),
+            _Acc3 = ejabberd_hooks:run_fold(user_receive_packet,
                 StateData#state.server,
+                Acc2,
                 [StateData#state.jid, From, To, FixedPacket]),
             ship_to_local_user({From, To, FixedPacket}, NewState, StateName);
-        {Reason, _NewAttrs, NewState} ->
+        {Reason, _NewAcc, NewState} ->
             response_negative(Name, Reason, From, To, Packet),
             fsm_next_state(StateName, NewState)
     end.
@@ -1315,35 +1320,37 @@ legacy_packet_to_broadcast(InvalidBroadcast) ->
     ?WARNING_MSG("invalid_broadcast=~p", [InvalidBroadcast]),
     {broadcast, unknown}.
 
-handle_routed(<<"presence">>, From, To, Packet, StateData) ->
-    handle_routed_presence(From, To, Packet, StateData);
-handle_routed(<<"iq">>, From, To, Packet, StateData) ->
-    handle_routed_iq(From, To, Packet, StateData);
-handle_routed(<<"message">>, From, To, Packet, StateData) ->
-    case privacy_check_packet(StateData, From, To, Packet, in) of
+handle_routed(<<"presence">>, From, To, Acc, StateData) ->
+    handle_routed_presence(From, To, Acc, StateData);
+handle_routed(<<"iq">>, From, To, Acc, StateData) ->
+    handle_routed_iq(From, To, Acc, StateData);
+handle_routed(<<"message">>, _From, To, Acc, StateData) ->
+    {Acc1, Res} = privacy_check_packet(Acc, To, in, StateData),
+    case Res of
         allow ->
-            {allow, Packet#xmlel.attrs, StateData};
+            {allow, Acc1, StateData};
         deny ->
-            {deny, Packet#xmlel.attrs, StateData};
+            {deny, Acc1, StateData};
         block ->
-            {deny, Packet#xmlel.attrs, StateData}
+            {deny, Acc1, StateData}
     end;
-handle_routed(_, _From, _To, Packet, StateData) ->
-    {true, Packet#xmlel.attrs, StateData}.
+handle_routed(_, _From, _To, Acc, StateData) ->
+    {ignore, Acc, StateData}.
 
 -spec handle_routed_iq(From :: ejabberd:jid(),
                        To :: ejabberd:jid(),
                        Packet :: exml:element(),
                        StateData :: state()) -> routing_result().
-handle_routed_iq(From, To, Packet, StateData) ->
-    handle_routed_iq(From, To, Packet, jlib:iq_query_info(Packet), StateData).
+handle_routed_iq(From, To, Acc, StateData) ->
+    Qi = jlib:iq_query_info(mongoose_acc:get(to_send, Acc)),
+    handle_routed_iq(From, To, Acc, Qi, StateData).
 
 -spec handle_routed_iq(From :: ejabberd:jid(),
                        To :: ejabberd:jid(),
                        Packet :: exml:element(),
                        IQ :: invalid | not_iq | reply | ejabberd:iq(),
                        StateData :: state()) -> routing_result().
-handle_routed_iq(From, To, Packet = #xmlel{attrs = Attrs}, #iq{ xmlns = ?NS_LAST }, StateData) ->
+handle_routed_iq(From, To, Acc, #iq{ xmlns = ?NS_LAST }, StateData) ->
     %% TODO: Support for mod_last / XEP-0012. Can we move it to the respective module?
     %%   Thanks to add_iq_handler(ejabberd_sm, ...)?
     HasFromSub = ( is_subscribed_to_my_presence(From, StateData)
@@ -1351,29 +1358,31 @@ handle_routed_iq(From, To, Packet = #xmlel{attrs = Attrs}, #iq{ xmlns = ?NS_LAST
                                             #xmlel{name = <<"presence">>}, out) ),
     case HasFromSub of
         true ->
-            case privacy_check_packet(StateData, From, To, Packet, in) of
+            {Acc1, Res} = privacy_check_packet(Acc, To, in, StateData),
+            case Res of
                 allow ->
-                    {allow, Attrs, StateData};
+                    {allow, Acc1, StateData};
                 _ ->
-                    {deny, Attrs, StateData}
+                    {deny, Acc1, StateData}
             end;
         _ ->
-            {forbidden, Attrs, StateData}
+            {forbidden, Acc, StateData}
     end;
-handle_routed_iq(From, To, Packet = #xmlel{attrs = Attrs}, IQ, StateData)
+handle_routed_iq(_From, To, Acc, IQ, StateData)
   when (is_record(IQ, iq)) orelse (IQ == reply) ->
-    case privacy_check_packet(StateData, From, To, Packet, in) of
+    {Acc1, Res} = privacy_check_packet(Acc, To, in, StateData),
+    case Res of
         allow ->
-            {allow, Attrs, StateData};
+            {allow, Acc1, StateData};
         deny when is_record(IQ, iq) ->
-            {deny, Attrs, StateData};
+            {deny, Acc1, StateData};
         deny when IQ == reply ->
             %% ???
-            {deny, Attrs, StateData}
+            {deny, Acc1, StateData}
     end;
-handle_routed_iq(_From, _To, #xmlel{attrs = Attrs}, IQ, StateData)
+handle_routed_iq(_From, _To, Acc, IQ, StateData)
   when (IQ == invalid) or (IQ == not_iq) ->
-    {invalid, Attrs, StateData}.
+    {invalid, Acc, StateData}.
 
 -spec handle_routed_broadcast(Broadcast :: broadcast_type(), StateData :: state()) ->
     broadcast_result().
@@ -1423,10 +1432,11 @@ privacy_list_push_iq(PrivListName) ->
 
 -spec handle_routed_presence(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel(),
                             StateData :: state()) -> routing_result().
-handle_routed_presence(From, To, Packet = #xmlel{attrs = Attrs}, StateData) ->
+handle_routed_presence(From, To, Acc0, State) ->
     State = ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
                                     StateData, [{From, To, Packet}]),
-    case xml:get_attr_s(<<"type">>, Attrs) of
+    Acc = mongoose_acc:require(send_type, Acc0),
+    case mongoose_acc:get(send_type, Acc) of
         <<"probe">> ->
             {LFrom, LBFrom} = lowcase_and_bare(From),
             NewState = case am_i_available_to(LFrom, LBFrom, State) of
@@ -1434,43 +1444,48 @@ handle_routed_presence(From, To, Packet = #xmlel{attrs = Attrs}, StateData) ->
                            false -> make_available_to(LFrom, LBFrom, State)
                        end,
             process_presence_probe(From, To, NewState),
-            {probe, Attrs, NewState};
+            {probe, Acc, NewState};
         <<"error">> ->
             NewA = gb_sets:del_element(jid:to_lower(From), State#state.pres_a),
-            {allow, Attrs, State#state{pres_a = NewA}};
+            {allow, Acc, State#state{pres_a = NewA}};
         <<"invisible">> ->
-            Attrs1 = lists:keydelete(<<"type">>, 1, Attrs),
-            {allow, [{<<"type">>, <<"unavailable">>} | Attrs1], State};
+            El = mongoose_acc:get(element, Acc),
+            #xmlel{attrs = Attrs} = El,
+            Attrs2 = [{<<"type">>, <<"unavailable">>} | Attrs],
+            NEl = El#xmlel{attrs = Attrs2},
+            Acc1 = mongoose_acc:put(to_send, NEl, Acc),
+            {allow, Acc1, State};
         <<"subscribe">> ->
-            SRes = privacy_check_packet(State, From, To, Packet, in),
-            {SRes, Attrs, State};
+            {Acc1, SRes} = privacy_check_packet(Acc, To, in, State),
+            {SRes, Acc1, State};
         <<"subscribed">> ->
-            SRes = privacy_check_packet(State, From, To, Packet, in),
-            {SRes, Attrs, State};
+            {Acc1, SRes} = privacy_check_packet(Acc, To, in, State),
+            {SRes, Acc1, State};
         <<"unsubscribe">> ->
-            SRes = privacy_check_packet(State, From, To, Packet, in),
-            {SRes, Attrs, State};
+            {Acc1, SRes} = privacy_check_packet(Acc, To, in, State),
+            {SRes, Acc1, State};
         <<"unsubscribed">> ->
-            SRes = privacy_check_packet(State, From, To, Packet, in),
-            {SRes, Attrs, State};
+            {Acc1, SRes} = privacy_check_packet(Acc, To, in, State),
+            {SRes, Acc1, State};
         _ ->
-            handle_routed_available_presence(State, From, To, Packet)
+            handle_routed_available_presence(State, From, To, Acc)
     end.
 
 -spec handle_routed_available_presence(State :: state(),
                                        From :: ejabberd:jid(),
                                        To :: ejabberd:jid(),
                                        Packet :: exml:element()) -> routing_result().
-handle_routed_available_presence(State, From, To, #xmlel{ attrs = Attrs } = Packet) ->
-    case privacy_check_packet(State, From, To, Packet, in) of
+handle_routed_available_presence(State, From, To, Acc) ->
+    {Acc1, Res} = privacy_check_packet(Acc, To, in, State),
+    case Res of
         allow ->
             {LFrom, LBFrom} = lowcase_and_bare(From),
             case am_i_available_to(LFrom, LBFrom, State) of
-                true -> {allow, Attrs, State};
-                false -> {allow, Attrs, make_available_to(LFrom, LBFrom, State)}
+                true -> {allow, Acc1, State};
+                false -> {allow, Acc1, make_available_to(LFrom, LBFrom, State)}
             end;
         _ ->
-            {deny, Attrs, State}
+            {deny, Acc1, State}
     end.
 
 am_i_available_to(LFrom, LBFrom, State) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1230,13 +1230,7 @@ handle_incoming_message({broadcast, Acc}, StateName, StateData) ->
     ?DEBUG("broadcast=~p", [Broadcast]),
     Res = handle_routed_broadcast(Broadcast, StateData),
     handle_broadcast_result(Res, StateName, StateData);
-handle_incoming_message({route, From, To, Acc0}, StateName, StateData) ->
-    % since we are now in the other user's session some cached data are not valid
-    % anymore (e.g. privacy_check), they have to be removed somewher between
-    % sender and recipient. One might argue, possibly rightly, that it should be
-    % stripped before sending; the reason I do it here is that when we send
-    % an acc out of c2s it returns and we might still use the cached data.
-    Acc = mongoose_acc:flush(Acc0),
+handle_incoming_message({route, From, To, Acc}, StateName, StateData) ->
     Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [{route, From, To}]),
     Name = mongoose_acc:get(name, Acc1),
     process_incoming_stanza(Name, From, To, Acc1, StateName, StateData);

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -912,6 +912,7 @@ session_established({xmlstreamelement, El}, StateData) ->
             Acc = mongoose_acc:update(Acc0, #{user => User,
                                               server => Server,
                                               from_jid => FromJID,
+                                              from => jid:to_binary(FromJID),
                                               to_jid => ToJID,
                                               to => To}),
             Acc1 = mod_amp:check_packet(Acc, initial_check),
@@ -1127,10 +1128,9 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%          {next_state, NextStateName, NextStateData, Timeout} |
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
-handle_info({send_text, Text}, StateName, StateData) ->
-    send_text(StateData, Text),
-    ejabberd_hooks:run(c2s_loop_debug, [Text]),
-    fsm_next_state(StateName, StateData);
+
+
+%%% system events
 handle_info(replaced, _StateName, StateData) ->
     Lang = StateData#state.lang,
     maybe_send_element_safe(StateData,
@@ -1186,34 +1186,6 @@ handle_info({force_update_presence, LUser}, StateName,
             StateData
     end,
     {next_state, StateName, NewStateData};
-handle_info({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
-    Drop = ejabberd_hooks:run_fold(c2s_filter_packet, StateData#state.server,
-                                   true, [StateData#state.server, StateData,
-                                          Feature, To, Packet]),
-    case {Drop, StateData#state.jid} of
-        {true, _} ->
-            ?DEBUG("Dropping packet from ~p to ~p", [jid:to_binary(From), jid:to_binary(To)]),
-            fsm_next_state(StateName, StateData);
-        {_, To} ->
-            FinalPacket = jlib:replace_from_to(From, To, Packet),
-            case privacy_check_packet(StateData, From, To, FinalPacket, in) of
-                allow ->
-                    send_and_maybe_buffer_stanza({From, To, FinalPacket}, StateData, StateName);
-                _ ->
-                    fsm_next_state(StateName, StateData)
-            end;
-        _ ->
-            FinalPacket = jlib:replace_from_to(From, To, Packet),
-            ejabberd_router:route(From, To, FinalPacket),
-            fsm_next_state(StateName, StateData)
-    end;
-handle_info({broadcast, Type, From, Packet}, StateName, StateData) ->
-    Recipients = ejabberd_hooks:run_fold(
-                   c2s_broadcast_recipients, StateData#state.server,
-                   [], [StateData#state.server, StateData, Type, From, Packet]),
-    lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,
-                  lists:usort(Recipients)),
-    fsm_next_state(StateName, StateData);
 handle_info(resume_timeout, resume_session, StateData) ->
     {stop, normal, StateData};
 handle_info(check_buffer_full, StateName, StateData) ->
@@ -1233,6 +1205,65 @@ handle_info({store_session_info, User, Server, Resource, KV, _FromPid}, StateNam
     ejabberd_sm:store_info(User, Server, Resource, KV),
     fsm_next_state(StateName, StateData);
 handle_info(Info, StateName, StateData) ->
+    handle_incoming_message(Info, StateName, StateData).
+
+maybe_terminate(Acc) ->
+    % instead of this, we will pass on the accumulator, only replacing
+    % 'element' with 'to_send', if present
+    case mongoose_acc:is_acc(Acc) of
+        true -> 
+            mongoose_acc:terminate(Acc, received, ?FILE, ?LINE);
+        false ->
+            ?ERROR_MSG("Hey, it should be accumulator here! ~p", [Acc]),
+            Acc
+    end.
+
+%%% incoming messages
+handle_incoming_message({send_text, Text}, StateName, StateData) ->
+    send_text(StateData, Text),
+    ejabberd_hooks:run(c2s_loop_debug, [Text]),
+    fsm_next_state(StateName, StateData);
+handle_incoming_message({broadcast, Acc}, StateName, StateData) ->
+    Broadcast = maybe_terminate(Acc),
+    ejabberd_hooks:run(c2s_loop_debug, [{broadcast, Broadcast}]),
+    ?DEBUG("broadcast=~p", [Broadcast]),
+    Res = handle_routed_broadcast(Broadcast, StateData),
+    handle_broadcast_result(Res, StateName, StateData);
+handle_incoming_message({route, From, To, Acc}, StateName, StateData) ->
+    Packet = maybe_terminate(Acc),
+    ejabberd_hooks:run(c2s_loop_debug, [{route, From, To, Packet}]),
+    Name = Packet#xmlel.name,
+    process_incoming_stanza(Name, From, To, Packet, StateName, StateData);
+handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
+    Drop = ejabberd_hooks:run_fold(c2s_filter_packet, StateData#state.server,
+        true, [StateData#state.server, StateData,
+            Feature, To, Packet]),
+    case {Drop, StateData#state.jid} of
+        {true, _} ->
+            ?DEBUG("Dropping packet from ~p to ~p", [jid:to_binary(From), jid:to_binary(To)]),
+            fsm_next_state(StateName, StateData);
+        {_, To} ->
+            FinalPacket = jlib:replace_from_to(From, To, Packet),
+            case privacy_check_packet(StateData, From, To, FinalPacket, in) of
+                allow ->
+                    send_and_maybe_buffer_stanza({From, To, FinalPacket}, StateData, StateName);
+                _ ->
+                    fsm_next_state(StateName, StateData)
+            end;
+        _ ->
+            FinalPacket = jlib:replace_from_to(From, To, Packet),
+            ejabberd_router:route(From, To, FinalPacket),
+            fsm_next_state(StateName, StateData)
+    end;
+handle_incoming_message({broadcast, Type, From, Acc}, StateName, StateData) ->
+    Packet = maybe_terminate(Acc),
+    Recipients = ejabberd_hooks:run_fold(
+        c2s_broadcast_recipients, StateData#state.server,
+        [], [StateData#state.server, StateData, Type, From, Packet]),
+    lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,
+        lists:usort(Recipients)),
+    fsm_next_state(StateName, StateData);
+handle_incoming_message(Info, StateName, StateData) ->
     ?ERROR_MSG("Unexpected info: ~p", [Info]),
     fsm_next_state(StateName, StateData).
 
@@ -1595,17 +1626,15 @@ maybe_send_element_safe(State, El) ->
 
 %% @doc This is the termination point - from here stanza is sent to the user
 %% We sent the original stanza ('element') unless there is a different thing
-%% keyed 'to_send'
-send_element(StateData, #xmlel{} = El) ->
+% keyed 'to_send'
+-spec send_element(mongoose_acc:t() | state(), state() | xmlel()) -> mongoose_acc:t() | ok.
+send_element(#state{} = StateData, #xmlel{} = El) ->
     ?DEPRECATED,
     send_element(mongoose_acc:from_element(El), StateData),
     ok;
 send_element(Acc, #state{server = Server} = StateData) ->
     Acc1 = ejabberd_hooks:run_fold(xmpp_send_element, Server, Acc, [Server]),
-    El = case mongoose_acc:get(to_send, Acc1, undefined) of
-             undefined -> mongoose_acc:get(element, Acc1);
-             OutStanza -> OutStanza
-         end,
+    El = mongoose_acc:get(to_send, Acc1),
     % we might put send result into accumulator
     do_send_element(El, StateData),
     Acc1.
@@ -2047,20 +2076,18 @@ check_privacy_and_route(Acc, FromRoute, StateData) ->
     From = mongoose_acc:get(from_jid, Acc),
     To = mongoose_acc:get(to_jid, Acc),
     {Acc1, Res} = privacy_check_packet(Acc, To, out, StateData),
-    Packet = mongoose_acc:terminate(Acc1, ?FILE, ?LINE),
-    case Res of
-        deny ->
-            Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_CANCEL),
-            ejabberd_router:route(To, From, Err),
-            ok;
-        block ->
-            Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_BLOCKED),
-            ejabberd_router:route(To, From, Err),
-            ok;
-        allow ->
-            ejabberd_router:route(FromRoute, To, Packet)
-    end,
-    Acc1.
+    Packet = mongoose_acc:get(element, Acc1),
+    NAcc = case Res of
+               deny ->
+                   Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_CANCEL),
+                   ejabberd_router:route(To, From, mongoose_acc:put(to_send, Err, Acc1));
+               block ->
+                   Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_BLOCKED),
+                   ejabberd_router:route(To, From, mongoose_acc:put(to_send, Err, Acc1));
+               allow ->
+                   ejabberd_router:route(FromRoute, To, Acc1)
+           end,
+    NAcc.
 
 
 -spec privacy_check_packet(StateData :: state(),
@@ -2106,7 +2133,6 @@ is_privacy_allow(StateData, From, To, Packet, Dir) ->
                          JIDSet :: jid_set(),
                          State :: state()) -> mongoose_acc:t().
 presence_broadcast(Acc, JIDSet, StateData) ->
-    Packet = mongoose_acc:get(element, Acc),
     From = mongoose_acc:get(from_jid, Acc),
     lists:foldl(fun(JID, A) ->
                           FJID = jid:make(JID),
@@ -2114,8 +2140,7 @@ presence_broadcast(Acc, JIDSet, StateData) ->
                           case Res of
                               allow ->
                                   % here we sort of mongoose_acc:terminate
-                                  ejabberd_router:route(From, FJID, Packet),
-                                  A1;
+                                  ejabberd_router:route(From, FJID, A1);
                               _ ->
                                   A1
                           end
@@ -2143,17 +2168,14 @@ presence_broadcast_to_trusted(Acc, StateData, From, T, A, Packet) ->
                                From :: 'undefined' | ejabberd:jid(),
                                State :: state(),
                                Packet :: jlib:xmlel()) -> {mongoose_acc:t(), state()}.
-presence_broadcast_first(Acc, From, StateData, Packet) ->
-    gb_sets:fold(fun(JID, X) -> % X is just a placeholder, we don't accumulate anything
-                                % so it works like map
-                       ejabberd_router:route(
-                         From,
-                         jid:make(JID),
-                         #xmlel{name = <<"presence">>,
-                                attrs = [{<<"type">>, <<"probe">>}]}),
-                       X
-               end,
-               [],
+presence_broadcast_first(Acc0, From, StateData, Packet) ->
+    Acc = gb_sets:fold(fun(JID, A) ->
+                           Stanza = #xmlel{name = <<"presence">>,
+                                           attrs = [{<<"type">>, <<"probe">>}]},
+                           A1 = mongoose_acc:put(to_send, Stanza, A),
+                           ejabberd_router:route(From, jid:make(JID), A1)
+                       end,
+               Acc0,
                StateData#state.pres_t),
     case StateData#state.pres_invis of
         true ->
@@ -2283,8 +2305,8 @@ process_privacy_iq(Acc, To, StateData) ->
                 {error, Error} ->
                     IQ#iq{type = error, sub_el = [SubEl, Error]}
             end,
-    ejabberd_router:route(To, From, jlib:iq_to_xml(IQRes)),
-    {Acc2, NewStateData}.
+    Acc3 = ejabberd_router:route(To, From, mongoose_acc:put(to_send, jlib:iq_to_xml(IQRes), Acc2)),
+    {Acc3, NewStateData}.
 
 -spec process_privacy_iq(Acc :: mongoose_acc:t(),
                          Type :: get | set,
@@ -2346,12 +2368,12 @@ check_privacy_and_route_or_ignore(StateData, From, To, Packet, Dir) ->
                                         Packet :: exml:element(),
                                         Dir :: in | out) -> any().
 check_privacy_and_route_or_ignore(Acc, StateData, From, To, Packet, Dir) ->
-    {Acc1, Res} = privacy_check_packet(Acc, To, Dir, StateData),
+    Acc1 = mongoose_acc:put(to_send, Packet, Acc),
+    {Acc2, Res} = privacy_check_packet(Acc1, To, Dir, StateData),
     case Res of
-        allow -> ejabberd_router:route(From, To, Packet);
-        _ -> ok
-    end,
-    Acc1.
+        allow -> ejabberd_router:route(From, To, Acc2);
+        _ -> Acc2
+    end.
 
 -spec resend_subscription_requests(mongoose_acc:t(), state()) -> {mongoose_acc:t(), state()}.
 resend_subscription_requests(Acc, #state{pending_invitations = Pending} = StateData) ->
@@ -3126,6 +3148,7 @@ defer_resource_constraint_check(#state{stream_mgmt_constraint_check_tref = undef
 defer_resource_constraint_check(State)->
     State.
 
+-spec sasl_success_stanza(any()) -> xmlel().
 sasl_success_stanza(ServerOut) ->
     C = case ServerOut of
             undefined -> [];
@@ -3135,6 +3158,7 @@ sasl_success_stanza(ServerOut) ->
            attrs = [{<<"xmlns">>, ?NS_SASL}],
            children = C}.
 
+-spec sasl_failure_stanza(any()) -> xmlel().
 sasl_failure_stanza(Error) when is_binary(Error) ->
     sasl_failure_stanza({Error, undefined});
 sasl_failure_stanza({Error, Text}) ->
@@ -3147,6 +3171,7 @@ maybe_text_tag(Text) ->
     [#xmlel{name = <<"text">>,
             children = [#xmlcdata{content = Text}]}].
 
+-spec sasl_challenge_stanza(any()) -> xmlel().
 sasl_challenge_stanza(Challenge) ->
     #xmlel{name = <<"challenge">>,
            attrs = [{<<"xmlns">>, ?NS_SASL}],

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -902,10 +902,9 @@ session_established({xmlstreamelement, El}, StateData) ->
             Acc0 = mongoose_acc:initialise(El, ?FILE, ?LINE),
             User = NewState#state.user,
             Server = NewState#state.server,
-            Attrs = mongoose_acc:get(attrs, Acc0),
-            To = xml:get_attr_s(<<"to">>, Attrs),
+            To = exml_query:attr(El, <<"to">>),
             ToJID = case To of
-                        <<>> ->
+                        undefined ->
                             jid:make(User, Server, <<>>);
                         _ ->
                             jid:from_binary(To)
@@ -1208,7 +1207,7 @@ handle_info({store_session_info, User, Server, Resource, KV, _FromPid}, StateNam
 handle_info(Info, StateName, StateData) ->
     handle_incoming_message(Info, StateName, StateData).
 
-maybe_terminate(Acc) ->
+convert_to_stanza(Acc) ->
     % instead of this, we will pass on the accumulator, only replacing
     % 'element' with 'to_send', if present
     case mongoose_acc:is_acc(Acc) of
@@ -1226,7 +1225,7 @@ handle_incoming_message({send_text, Text}, StateName, StateData) ->
     ejabberd_hooks:run(c2s_loop_debug, [Text]),
     fsm_next_state(StateName, StateData);
 handle_incoming_message({broadcast, Acc}, StateName, StateData) ->
-    Broadcast = maybe_terminate(Acc),
+    Broadcast = convert_to_stanza(Acc),
     ejabberd_hooks:run(c2s_loop_debug, [{broadcast, Broadcast}]),
     ?DEBUG("broadcast=~p", [Broadcast]),
     Res = handle_routed_broadcast(Broadcast, StateData),
@@ -1264,7 +1263,7 @@ handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, S
             fsm_next_state(StateName, StateData)
     end;
 handle_incoming_message({broadcast, Type, From, Acc}, StateName, StateData) ->
-    Packet = maybe_terminate(Acc),
+    Packet = convert_to_stanza(Acc),
     Recipients = ejabberd_hooks:run_fold(
         c2s_broadcast_recipients, StateData#state.server,
         [], [StateData#state.server, StateData, Type, From, Packet]),
@@ -1321,14 +1320,6 @@ response_iq_deny(_, _, _, _) ->
 send_back_error(Etype, From, To, Packet) ->
     Err = jlib:make_error_reply(Packet, Etype),
     ejabberd_router:route(To, From, Err).
-
-% do we still need this?
-%%-spec legacy_packet_to_broadcast(jlib:xmlel()) -> {broadcast, broadcast_type()}.
-%%legacy_packet_to_broadcast(#xmlel{children = [Child]}) ->
-%%    {broadcast, Child};
-%%legacy_packet_to_broadcast(InvalidBroadcast) ->
-%%    ?WARNING_MSG("invalid_broadcast=~p", [InvalidBroadcast]),
-%%    {broadcast, unknown}.
 
 handle_routed(<<"presence">>, From, To, Acc, StateData) ->
     handle_routed_presence(From, To, Acc, StateData);
@@ -1444,7 +1435,6 @@ privacy_list_push_iq(PrivListName) ->
                              Acc0 :: mongoose_acc:t(), StateData :: state()) -> routing_result().
 handle_routed_presence(From, To, Acc0, StateData) ->
     Packet = mongoose_acc:get(to_send, Acc0),
-    % a rare exception - hook which modifies state, can we treat #state as accumulator here?
     State = ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
                                     StateData, [{From, To, Packet}]),
     Acc = mongoose_acc:require(send_type, Acc0),
@@ -2105,17 +2095,16 @@ check_privacy_and_route(Acc, FromRoute, StateData) ->
     To = mongoose_acc:get(to_jid, Acc),
     {Acc1, Res} = privacy_check_packet(Acc, To, out, StateData),
     Packet = mongoose_acc:get(element, Acc1),
-    NAcc = case Res of
-               deny ->
-                   Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_CANCEL),
-                   ejabberd_router:route(To, From, mongoose_acc:put(to_send, Err, Acc1));
-               block ->
-                   Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_BLOCKED),
-                   ejabberd_router:route(To, From, mongoose_acc:put(to_send, Err, Acc1));
-               allow ->
-                   ejabberd_router:route(FromRoute, To, Acc1)
-           end,
-    NAcc.
+    case Res of
+       deny ->
+           Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_CANCEL),
+           ejabberd_router:route(To, From, mongoose_acc:put(to_send, Err, Acc1));
+       block ->
+           Err = jlib:make_error_reply(Packet, ?ERR_NOT_ACCEPTABLE_BLOCKED),
+           ejabberd_router:route(To, From, mongoose_acc:put(to_send, Err, Acc1));
+       allow ->
+           ejabberd_router:route(FromRoute, To, Acc1)
+   end.
 
 
 -spec privacy_check_packet(StateData :: state(),
@@ -2197,9 +2186,9 @@ presence_broadcast_to_trusted(Acc, StateData, From, T, A, Packet) ->
                                State :: state(),
                                Packet :: jlib:xmlel()) -> {mongoose_acc:t(), state()}.
 presence_broadcast_first(Acc0, From, StateData, Packet) ->
+    Stanza = #xmlel{name = <<"presence">>,
+        attrs = [{<<"type">>, <<"probe">>}]},
     Acc = gb_sets:fold(fun(JID, A) ->
-                           Stanza = #xmlel{name = <<"presence">>,
-                                           attrs = [{<<"type">>, <<"probe">>}]},
                            A1 = mongoose_acc:put(to_send, Stanza, A),
                            ejabberd_router:route(From, jid:make(JID), A1)
                        end,

--- a/apps/ejabberd/src/ejabberd_c2s.hrl
+++ b/apps/ejabberd/src/ejabberd_c2s.hrl
@@ -103,7 +103,7 @@
                                      [binary()]}
                         | unknown.
 
--type broadcast() :: {broadcast, broadcast_type()}.
+-type broadcast() :: {broadcast, broadcast_type() | mongoose_acc:t()}.
 
 -type broadcast_result() :: {new_state, NewState :: state()}
                           | {exit, Reason :: binary()}

--- a/apps/ejabberd/src/ejabberd_c2s.hrl
+++ b/apps/ejabberd/src/ejabberd_c2s.hrl
@@ -111,7 +111,7 @@
                              Packet :: jlib:xmlel(),
                              NewState :: state()}.
 
--type routing_result() :: {DoRoute :: allow | atom(), NewAttrs :: [{binary(), binary()}],
+-type routing_result() :: {DoRoute :: allow | atom(), NewAcc :: mongoose_acc:t(),
                            NewState :: state()}.
 
 %-define(DBGFSM, true).

--- a/apps/ejabberd/src/ejabberd_gen_sm.erl
+++ b/apps/ejabberd/src/ejabberd_gen_sm.erl
@@ -3,20 +3,77 @@
 -callback start(list()) -> any().
 -callback get_sessions() -> [ejabberd_sm:ses_tuple()].
 -callback get_sessions(ejabberd:server()) -> [ejabberd_sm:ses_tuple()].
--callback get_sessions(ejabberd:user(), ejabberd:server()) -> [ejabberd_sm:session()].
+-callback get_sessions(ejabberd:user(), ejabberd:server()) ->
+    [ejabberd_sm:session()].
 -callback get_sessions(ejabberd:user(), ejabberd:server(), ejabberd:resource()
                       ) -> [ejabberd_sm:session()].
 -callback create_session(_User :: ejabberd:user(),
                          _Server :: ejabberd:server(),
                          _Resource :: ejabberd:resource(),
-                         Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+                         Session :: ejabberd_sm:session()) ->
+    ok | {error, term()}.
 -callback delete_session(ejabberd_sm:sid(),
                          _User :: ejabberd:user(),
                          _Server :: ejabberd:server(),
                          _Resource :: ejabberd:resource()) -> ok.
--callback cleanup(atom()) -> any().
+-callback cleanup(Node :: atom()) -> any().
 -callback total_count() -> integer().
 -callback unique_count() -> integer().
+
+-export([start/2, get_sessions/1, get_sessions/2, get_sessions/3,
+         get_sessions/4, create_session/5, delete_session/5, cleanup/2,
+         total_count/1, unique_count/1]).
+
+-spec start(module(), list()) -> any().
+start(Mod, Opts) ->
+    Mod:start(Opts).
+
+-spec get_sessions(module()) -> [ejabberd_sm:ses_tuple()].
+get_sessions(Mod) ->
+    Mod:get_sessions().
+
+-spec get_sessions(module(), ejabberd:server()) -> [ejabberd_sm:ses_tuple()].
+get_sessions(Mod, Server) ->
+    Mod:get_sessions(Server).
+
+-spec get_sessions(module(), ejabberd:user(), ejabberd:server()) ->
+    [ejabberd_sm:session()].
+get_sessions(Mod, User, Server) ->
+    Mod:get_sessions(User, Server).
+
+-spec get_sessions(module(),
+                   ejabberd:user(),
+                   ejabberd:server(),
+                   ejabberd:resource()) ->
+    [ejabberd_sm:session()].
+get_sessions(Mod, User, Server, Resource) ->
+    Mod:get_sessions(User, Server, Resource).
+
+-spec create_session(Mod :: module(), User :: ejabberd:user(),
+                     Server :: ejabberd:server(),
+                     Resource :: ejabberd:resource(),
+                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+create_session(Mod, User, Server, Resource, Session) ->
+    Mod:create_session(User, Server, Resource, Session).
+
+-spec delete_session(Mod :: module(), Sid :: ejabberd_sm:sid(),
+                     User :: ejabberd:user(),
+                     Server :: ejabberd:server(),
+                     Resource :: ejabberd:resource()) -> ok.
+delete_session(Mod, Sid, User, Server, Resource) ->
+    Mod:delete_session(Sid, User, Server, Resource).
+
+-spec cleanup(Mod :: module(), Node :: atom()) -> any().
+cleanup(Mod, Node) ->
+    Mod:cleanup(Node).
+
+-spec total_count(module()) -> integer().
+total_count(Mod) ->
+    Mod:total_count().
+
+-spec unique_count(module()) -> integer().
+unique_count(Mod) ->
+    Mod:unique_count().
 
 %% -export([behaviour_info/1]).
 %% -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -108,7 +108,7 @@ run(Hook, Args) ->
           Host :: ejabberd:server() | global,
           Args :: [any()]) -> ok.
 run(Hook, Host, Args) ->
-    run_fold(Hook, Host, #{}, Args).
+    run_fold(Hook, Host, mongoose_acc:new(), Args).
 
 %% @spec (Hook::atom(), Val, Args) -> Val | stopped | NewVal
 %% @doc Run the calls of this hook in order.

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -130,15 +130,16 @@ run_fold(Hook, Host, Val, Args) ->
     record(Hook, Res).
 
 record(Hook, Acc) ->
+    Acc.
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
     % unless load tests show that the impact on performance is negligible
-    case mongoose_acc:is_acc(Acc) of % this check will go away some day
-        true ->
-            mongoose_acc:append(hooks_run, Hook, Acc);
-        false ->
-            Acc
-    end.
+%%    case mongoose_acc:is_acc(Acc) of % this check will go away some day
+%%        true ->
+%%            mongoose_acc:append(hooks_run, Hook, Acc);
+%%        false ->
+%%            Acc
+%%    end.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_server
@@ -259,12 +260,13 @@ hook_apply_function(Module, Function, Hook, Val, Args) ->
 
 
 record(Hook, Module, Function, Acc) ->
+    Acc.
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
     % unless load tests show that the impact on performance is negligible
-    case mongoose_acc:is_acc(Acc) of % this check will go away some day
-        true ->
-            mongoose_acc:append(handlers_run, {Hook, Module, Function}, Acc);
-        false ->
-            Acc
-    end.
+%%    case mongoose_acc:is_acc(Acc) of % this check will go away some day
+%%        true ->
+%%            mongoose_acc:append(handlers_run, {Hook, Module, Function}, Acc);
+%%        false ->
+%%            Acc
+%%    end.

--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -129,7 +129,7 @@ run_fold(Hook, Host, Val, Args) ->
     end,
     record(Hook, Res).
 
-record(Hook, Acc) ->
+record(_Hook, Acc) ->
     Acc.
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
@@ -259,7 +259,7 @@ hook_apply_function(Module, Function, Hook, Val, Args) ->
     record(Hook, Module, Function, Result).
 
 
-record(Hook, Module, Function, Acc) ->
+record(_Hook, _Module, _Function, Acc) ->
     Acc.
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -90,7 +90,7 @@ start_link() ->
 
 -spec process_iq(From :: ejabberd:jid(),
                  To :: ejabberd:jid(),
-                 Packet :: mongoose_acc:t()
+                 Acc :: mongoose_acc:t()
                  ) -> 'nothing' | 'ok' | 'todo' | pid()
                     | {'error', 'lager_not_running'} | {'process_iq', _, _, _}.
 process_iq(From, To, Packet) ->

--- a/apps/ejabberd/src/ejabberd_local.erl
+++ b/apps/ejabberd/src/ejabberd_local.erl
@@ -149,8 +149,8 @@ process_iq_reply(From, To, #iq{id = ID} = IQ) ->
 process_packet(From, To, Packet, _Extra) ->
     case (catch do_route(From, To, Packet)) of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p~n~nreason=~p~n~n"
-                       " packet=~ts~n~nstack_trace=~p~n",
+            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p "
+                       "reason=~p packet=~ts stack_trace=~p",
                        [jid:to_binary(From), jid:to_binary(To),
                         ?MODULE, Reason, mongoose_acc:to_binary(Packet),
                         erlang:get_stacktrace()]);

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -98,7 +98,7 @@ start_link() ->
     Packet :: mongoose_acc:t()|jlib:xmlel()) -> mongoose_acc:t().
 route(From, To, #xmlel{} = Packet) ->
 %%    ?ERROR_MSG("Deprecated - it should be Acc: ~p", [Packet]),
-    route(From, To, mongoose_acc:from_element(Packet));
+    route(From, To, mongoose_acc:from_element(Packet, From, To));
 route(From, To, Packet) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
            [From, To, Packet]),

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -437,10 +437,10 @@ route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
                        [jid:to_binary(OrigFrom), jid:to_binary(OrigTo),
                         M, Reason, mongoose_acc:to_binary(OrigPacket),
                         erlang:get_stacktrace()]),
-            ok;
+            OrigPacket;
         drop ->
             ?DEBUG("filter dropped packet", []),
-            ok;
+            OrigPacket;
         {OrigFrom, OrigTo, OrigPacketFiltered} ->
             ?DEBUG("filter passed", []),
             case catch(M:route(OrigFrom, OrigTo, OrigPacketFiltered)) of

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -99,11 +99,11 @@ start_link() ->
 route(From, To, #xmlel{} = Packet) ->
 %%    ?ERROR_MSG("Deprecated - it should be Acc: ~p", [Packet]),
     route(From, To, mongoose_acc:from_element(Packet, From, To));
-route(From, To, Packet) ->
+route(From, To, Acc) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
-           [From, To, Packet]),
-    P2 = route(From, To, Packet, routing_modules_list()),
-    mongoose_acc:remove(to_send, P2).
+           [From, To, Acc]),
+    Acc1 = route(From, To, Acc, routing_modules_list()),
+    mongoose_acc:remove(to_send, Acc1).
 
 %% Route the error packet only if the originating packet is not an error itself.
 %% RFC3920 9.3.1

--- a/apps/ejabberd/src/ejabberd_router.erl
+++ b/apps/ejabberd/src/ejabberd_router.erl
@@ -429,7 +429,7 @@ route(From, To, Packet, []) ->
     Packet;
 route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
     ?DEBUG("Using module ~p", [M]),
-    case (catch M:filter(OrigFrom, OrigTo, OrigPacket)) of
+    case (catch xmpp_router:call_filter(M, OrigFrom, OrigTo, OrigPacket)) of
         {'EXIT', Reason} ->
             ?DEBUG("Filtering error", []),
             ?ERROR_MSG("error when filtering from=~ts to=~ts in module=~p~n~nreason=~p~n~n"
@@ -443,7 +443,7 @@ route(OrigFrom, OrigTo, OrigPacket, [M|Tail]) ->
             OrigPacket;
         {OrigFrom, OrigTo, OrigPacketFiltered} ->
             ?DEBUG("filter passed", []),
-            case catch(M:route(OrigFrom, OrigTo, OrigPacketFiltered)) of
+            case catch(xmpp_router:call_route(M, OrigFrom, OrigTo, OrigPacketFiltered)) of
                 {'EXIT', Reason} ->
                     ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p~n~nreason=~p~n~n"
                                "packet=~ts~n~nstack_trace=~p~n",

--- a/apps/ejabberd/src/ejabberd_s2s_in.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_in.erl
@@ -628,6 +628,7 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%----------------------------------------------------------------------
 -spec handle_info(_, _, _) -> {next_state, atom(), state()} | {stop, normal, state()}.
 handle_info({send_text, Text}, StateName, StateData) ->
+    ?ERROR_MSG("{s2s_in:send_text, Text}: ~p~n", [{send_text, Text}]), % is it ever called?
     send_text(StateData, Text),
     {next_state, StateName, StateData};
 handle_info({timeout, Timer, _}, _StateName,

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -873,6 +873,7 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
 handle_info({send_text, Text}, StateName, StateData) ->
+    ?ERROR_MSG("{s2s_out:send_text, Text}: ~p~n", [{send_text, Text}]), % is it ever called?
     send_text(StateData, Text),
     cancel_timer(StateData#state.timer),
     Timer = erlang:start_timer(?S2STIMEOUT, self(), []),

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -970,7 +970,7 @@ send_element(StateData, #xmlel{} = El) ->
     ?DEPRECATED,
     send_text(StateData, exml:to_binary(El));
 send_element(StateData, Acc) ->
-    El = mongoose_acc:get(to_send, Acc, undefined),
+    El = mongoose_acc:get(to_send, Acc),
     send_text(StateData, exml:to_binary(El)).
 
 

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -348,9 +348,11 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
 handle_info({send_text, Text}, StateName, StateData) ->
+    ?ERROR_MSG("{service:send_text, Text}: ~p~n", [{send_text, Text}]), % is it ever called?
     send_text(StateData, Text),
     {next_state, StateName, StateData};
 handle_info({send_element, El}, StateName, StateData) ->
+    ?ERROR_MSG("{service:send_element, El}: ~p~n", [{send_text, El}]), % is it ever called?
     send_element(StateData, El),
     {next_state, StateName, StateData};
 handle_info({route, From, To, Acc}, StateName, StateData) ->

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -353,7 +353,8 @@ handle_info({send_text, Text}, StateName, StateData) ->
 handle_info({send_element, El}, StateName, StateData) ->
     send_element(StateData, El),
     {next_state, StateName, StateData};
-handle_info({route, From, To, Packet}, StateName, StateData) ->
+handle_info({route, From, To, Acc}, StateName, StateData) ->
+    Packet = mongoose_acc:get(to_send, Acc),
     case acl:match_rule(global, StateData#state.access, From) of
         allow ->
            #xmlel{name =Name, attrs = Attrs, children = Els} = Packet,

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -137,9 +137,9 @@ socket_type() ->
 %%% mongoose_packet_handler callback
 %%%----------------------------------------------------------------------
 
--spec process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Pid :: pid()) -> any().
-process_packet(From, To, Packet, Pid) ->
-    Pid ! {route, From, To, Packet}.
+-spec process_packet(From :: jid(), To :: jid(), Acc :: mongoose_acc:t(), Pid :: pid()) -> any().
+process_packet(From, To, Acc, Pid) ->
+    Pid ! {route, From, To, mongoose_acc:strip(Acc)}.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm

--- a/apps/ejabberd/src/ejabberd_service.erl
+++ b/apps/ejabberd/src/ejabberd_service.erl
@@ -348,11 +348,13 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
 handle_info({send_text, Text}, StateName, StateData) ->
-    ?ERROR_MSG("{service:send_text, Text}: ~p~n", [{send_text, Text}]), % is it ever called?
+    % is it ever called?
+    ?ERROR_MSG("{service:send_text, Text}: ~p", [{send_text, Text}]),
     send_text(StateData, Text),
     {next_state, StateName, StateData};
 handle_info({send_element, El}, StateName, StateData) ->
-    ?ERROR_MSG("{service:send_element, El}: ~p~n", [{send_text, El}]), % is it ever called?
+    % is it ever called?
+    ?ERROR_MSG("{service:send_element, El}: ~p~n", [{send_text, El}]),
     send_element(StateData, El),
     {next_state, StateName, StateData};
 handle_info({route, From, To, Acc}, StateName, StateData) ->

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -130,7 +130,7 @@ start_link() ->
       Acc :: mongoose_acc:t().
 route(From, To, #xmlel{} = Packet) ->
 %%    ?ERROR_MSG("Deprecated - it should be Acc: ~p", [Packet]),
-    route(From, To, mongoose_acc:from_element(Packet));
+    route(From, To, mongoose_acc:from_element(Packet, From, To));
 route(From, To, {broadcast, Payload} = Packet) ->
     NPayload = case mongoose_acc:is_acc(Payload) of
                    false ->

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -148,15 +148,15 @@ route(From, To, {broadcast, Payload} = Packet) ->
                     erlang:get_stacktrace()]);
         Acc -> Acc
     end;
-route(From, To, Packet) ->
-    case (catch do_route(From, To, Packet)) of
+route(From, To, Acc) ->
+    case (catch do_route(From, To, Acc)) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p~n~nreason=~p~n~n"
                        "packet=~ts~n~nstack_trace=~p~n",
                        [jid:to_binary(From), jid:to_binary(To),
-                        ?MODULE, Reason, mongoose_acc:to_binary(Packet),
+                        ?MODULE, Reason, mongoose_acc:to_binary(Acc),
                         erlang:get_stacktrace()]);
-        Acc -> Acc
+        Acc1 -> Acc1
     end.
 
 -spec open_session(SID, User, Server, Resource, Info) -> ReplacedPids when

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -756,7 +756,7 @@ is_privacy_allow(From, To, Packet) ->
       From :: ejabberd:jid(),
       To :: ejabberd:jid(),
       Packet :: jlib:xmlel() | mongoose_acc:t(),
-      PrivacyList :: #userlist{}.
+      PrivacyList :: mongoose_privacy:userlist().
 is_privacy_allow(From, To, Packet, PrivacyList) ->
     User = To#jid.user,
     Server = To#jid.server,

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -310,7 +310,7 @@ get_session(User, Server, Resource) ->
              Session#session.priority,
              Session#session.info}
     end.
--spec get_raw_sessions(ejabberd:user(), ejabberd:server()) -> [#session{}].
+-spec get_raw_sessions(ejabberd:user(), ejabberd:server()) -> [sm_session()].
 get_raw_sessions(User, Server) ->
     clean_session_list(
       sm_backend():get_sessions(jid:nodeprep(User), jid:nameprep(Server))).

--- a/apps/ejabberd/src/ejabberd_users.erl
+++ b/apps/ejabberd/src/ejabberd_users.erl
@@ -87,9 +87,9 @@ does_user_exist(LUser, LServer) ->
 %% Hooks
 %%====================================================================
 
--spec remove_user(Acc :: map(),
+-spec remove_user(Acc :: mongoose_acc:t(),
                   LUser :: ejabberd:luser(),
-                  LServer :: ejabberd:lserver() | string()) -> map().
+                  LServer :: ejabberd:lserver() | string()) -> mongoose_acc:t().
 remove_user(Acc, LUser, LServer) ->
     delete_user(LUser, LServer),
     Acc.

--- a/apps/ejabberd/src/jid.erl
+++ b/apps/ejabberd/src/jid.erl
@@ -144,6 +144,9 @@ binary_to_jid3(<<>>, N, S, R) ->
 
 
 -spec to_binary(ejabberd:simple_jid() | ejabberd:simple_bare_jid() | ejabberd:jid()) ->  binary().
+to_binary(Jid) when is_binary(Jid) ->
+    % sometimes it is used to format error messages
+    Jid;
 to_binary(#jid{user = User, server = Server, resource = Resource}) ->
     to_binary({User, Server, Resource});
 to_binary({User, Server}) ->

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -130,11 +130,15 @@ make_result_iq_reply_attrs(Attrs) ->
     [{<<"type">>, <<"result">>} | Attrs5].
 
 
--spec make_error_reply(xmlel(), xmlcdata() | xmlel()) -> xmlel().
+-spec make_error_reply(xmlel() | mongoose_acc:t(),
+                       xmlcdata() | xmlel()) ->
+    xmlel() | mongoose_acc:t().
 make_error_reply(#xmlel{name = Name, attrs = Attrs,
                         children = SubTags}, Error) ->
     NewAttrs = make_error_reply_attrs(Attrs),
-    #xmlel{name = Name, attrs = NewAttrs, children = SubTags ++ [Error]}.
+    #xmlel{name = Name, attrs = NewAttrs, children = SubTags ++ [Error]};
+make_error_reply(Acc, Error) ->
+    make_error_reply(mongoose_acc:get(to_send, Acc), Error).
 
 
 -spec make_error_reply_attrs([binary_pair()]) -> [binary_pair(), ...].

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -263,7 +263,7 @@ ban_account(User, Host, ReasonText) ->
             {error, ErrorReason}
     end.
 
--spec kick_sessions(ejabberd:user(), ejabberd:server(), binary()) -> [ok].
+-spec kick_sessions(ejabberd:user(), ejabberd:server(), binary()) -> [mongoose_acc:t()].
 kick_sessions(User, Server, Reason) ->
     lists:map(
         fun(Resource) ->

--- a/apps/ejabberd/src/mod_admin_extra_roster.erl
+++ b/apps/ejabberd/src/mod_admin_extra_roster.erl
@@ -354,7 +354,7 @@ push_roster_item(LU, LS, U, S, Action) ->
 
 
 -spec push_roster_item(ejabberd:luser(), ejabberd:lserver(), ejabberd:user(),
-        ejabberd:user(), ejabberd:server(), Action :: push_action()) -> 'ok'.
+        ejabberd:user(), ejabberd:server(), Action :: push_action()) -> mongoose_acc:t().
 push_roster_item(LU, LS, R, U, S, Action) ->
     LJID = jid:make(LU, LS, R),
     BroadcastEl = build_broadcast(U, S, Action),

--- a/apps/ejabberd/src/mod_admin_extra_sessions.erl
+++ b/apps/ejabberd/src/mod_admin_extra_sessions.erl
@@ -188,14 +188,14 @@ resource_num(User, Host, Num) ->
 
 
 -spec kick_session(ejabberd:user(), ejabberd:server(), ejabberd:resource(),
-        ReasonText :: binary()) -> ok.
+        ReasonText :: binary()) -> 'ok'.
 kick_session(User, Server, Resource, ReasonText) ->
     kick_this_session(User, Server, Resource, prepare_reason(ReasonText)),
     ok.
 
 
 -spec kick_this_session(ejabberd:user(), ejabberd:server(), ejabberd:resource(),
-        Reason :: binary()) -> ok | {error, lager_not_started}.
+        Reason :: binary()) -> mongoose_acc:t().
 kick_this_session(User, Server, Resource, Reason) ->
     ejabberd_sm:route(
         jid:make(<<"">>, <<"">>, <<"">>),

--- a/apps/ejabberd/src/mod_admin_extra_stanza.erl
+++ b/apps/ejabberd/src/mod_admin_extra_stanza.erl
@@ -138,7 +138,7 @@ send_packet_all_resources(FromJID, ToUser, ToServer, Packet) ->
 
 
 -spec send_packet_all_resources(ejabberd:jid(), ToU :: binary(), ToS :: binary(),
-                                ToR :: binary(), jlib:xmlel()) -> 'ok'.
+                                ToR :: binary(), jlib:xmlel()) -> mongoose_acc:t().
 send_packet_all_resources(FromJID, ToU, ToS, ToR, Packet) ->
     ToJID = jid:make(ToU, ToS, ToR),
     ejabberd_router:route(FromJID, ToJID, Packet).

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -189,7 +189,7 @@ take_action_for_matched_rule(Packet, From, #amp_rule{action = error} = Rule) ->
 take_action_for_matched_rule(Packet, From, #amp_rule{action = drop}) ->
     update_metric_and_drop(Packet, From).
 
--spec reply_to_sender(amp_rule(), jid(), jid(), exml:element()) -> ok.
+-spec reply_to_sender(amp_rule(), jid(), jid(), exml:element()) -> mongoose_acc:t().
 reply_to_sender(MatchedRule, ServerJid, OriginalSender, OriginalPacket) ->
     Response = amp:make_response(MatchedRule, OriginalSender, OriginalPacket),
     ejabberd_router:route(ServerJid, OriginalSender, Response).

--- a/apps/ejabberd/src/mod_caps.erl
+++ b/apps/ejabberd/src/mod_caps.erl
@@ -227,11 +227,6 @@ disco_info(Acc, Host, Module, Node, Lang) ->
 
 c2s_presence_in(C2SState,
                 {From, To, {_, _, Attrs, Els}}) ->
-    % XXX it is never called, it appears, the only call has a different
-    % signature:
-    % ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
-    %    StateData, [{From, To, Packet}]),
-    % where Packet is #xmlel
     ?DEBUG("Presence to ~p from ~p with Els ~p", [To, From, Els]),
     Type = xml:get_attr_s(<<"type">>, Attrs),
     Subscription = ejabberd_c2s:get_subscription(From,

--- a/apps/ejabberd/src/mod_caps.erl
+++ b/apps/ejabberd/src/mod_caps.erl
@@ -227,6 +227,11 @@ disco_info(Acc, Host, Module, Node, Lang) ->
 
 c2s_presence_in(C2SState,
                 {From, To, {_, _, Attrs, Els}}) ->
+    % XXX it is never called, it appears, the only call has a different
+    % signature:
+    % ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
+    %    StateData, [{From, To, Packet}]),
+    % where Packet is #xmlel
     ?DEBUG("Presence to ~p from ~p with Els ~p", [To, From, Els]),
     Type = xml:get_attr_s(<<"type">>, Attrs),
     Subscription = ejabberd_c2s:get_subscription(From,

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -239,16 +239,18 @@ get_last_info(LUser, LServer) ->
         Res -> Res
     end.
 
-%% #rh
--spec remove_user(map(), ejabberd:user(), ejabberd:server()) -> map() | {error, term()}.
+-spec remove_user(mongoose_acc:t(), ejabberd:user(), ejabberd:server()) -> mongoose_acc:t().
 remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    case mod_last_backend:remove_user(LUser, LServer) of
-        ok -> Acc;
-        E -> E
-    end.
+    % XXX we should handle errors somehow - previously the code returned something else
+    % but it is ignored anyway because the hook is run (not folded) so errors were not
+    % handled anyway
+    % same for many other handlers of 'remove_user' hook
+    mod_last_backend:remove_user(LUser, LServer),
+    Acc.
 
+%% TODO fix
 -spec session_cleanup(Acc :: map(), LUser :: ejabberd:luser(), LServer :: ejabberd:lserver(),
                       LResource :: ejabberd:lresource(), SID :: ejabberd_sm:sid()) -> any().
 session_cleanup(Acc, LUser, LServer, LResource, _SID) ->

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -247,7 +247,8 @@ remove_user(Acc, User, Server) ->
     % but it is ignored anyway because the hook is run (not folded) so errors were not
     % handled anyway
     % same for many other handlers of 'remove_user' hook
-    mod_last_backend:remove_user(LUser, LServer),
+    Res = mod_last_backend:remove_user(LUser, LServer),
+    ?OK_OR_LOG(Res),
     Acc.
 
 %% TODO fix

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -243,12 +243,8 @@ get_last_info(LUser, LServer) ->
 remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    % XXX we should handle errors somehow - previously the code returned something else
-    % but it is ignored anyway because the hook is run (not folded) so errors were not
-    % handled anyway
-    % same for many other handlers of 'remove_user' hook
     Res = mod_last_backend:remove_user(LUser, LServer),
-    ?OK_OR_LOG(Res),
+    mongoose_lib:log_if_backend_error(Res),
     Acc.
 
 %% TODO fix

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -243,8 +243,8 @@ get_last_info(LUser, LServer) ->
 remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    Res = mod_last_backend:remove_user(LUser, LServer),
-    mongoose_lib:log_if_backend_error(Res),
+    R = mod_last_backend:remove_user(LUser, LServer),
+    mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {Acc, User, Server}),
     Acc.
 
 %% TODO fix

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -324,8 +324,7 @@ process_incoming_packet(From, To, Packet) ->
     handle_package(incoming, true, To, From, From, Packet).
 
 %% @doc A ejabberd's callback with diferent order of arguments.
-%% #rh
--spec remove_user(map(), ejabberd:user(), ejabberd:server()) -> map().
+-spec remove_user(mongoose_acc:t(), ejabberd:user(), ejabberd:server()) -> mongoose_acc:t().
 remove_user(Acc, User, Server) ->
     delete_archive(Server, User),
     Acc.

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -294,11 +294,13 @@ user_send_packet(Acc, From, To, Packet) ->
 %% From and To are jid records.
 -type fpacket() :: {From :: ejabberd:jid(),
                     To :: ejabberd:jid(),
-                    Packet :: jlib:xmlel()}.
+                    Acc :: mongoose_acc:t()}.
 -spec filter_packet(Value :: fpacket() | drop) -> fpacket() | drop.
 filter_packet(drop) ->
     drop;
-filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Packet}) ->
+filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Acc}) ->
+    % let them to their amp-related mambo jumbo on stanza
+    Packet = mongoose_acc:get(to_send, Acc),
     ?DEBUG("Receive packet~n    from ~p ~n    to ~p~n    packet ~p.",
            [From, To, Packet]),
     {AmpEvent, PacketAfterArchive} =
@@ -318,7 +320,7 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Packet}) ->
                 end
         end,
     PacketAfterAmp = mod_amp:check_packet(PacketAfterArchive, From, AmpEvent),
-    {From, To, PacketAfterAmp}.
+    {From, To, mongoose_acc:put(to_send, PacketAfterAmp, Acc)}.
 
 process_incoming_packet(From, To, Packet) ->
     handle_package(incoming, true, To, From, From, Packet).

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -902,7 +902,7 @@ is_last_page(_PageSize, _TotalCount, _Offset, _MessageRows) ->
 %% Ejabberd
 
 -spec send_message(ejabberd:jid(), ejabberd:jid(), jlib:xmlel()
-                  ) -> 'ok' | {'error', 'lager_not_running'}.
+                  ) -> mongoose_acc:t().
 
 -ifdef(MAM_COMPACT_FORWARDED).
 

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -226,7 +226,7 @@ forget_room(Host, Name) ->
 
 
 -spec process_iq_disco_items(Host :: ejabberd:server(), From :: ejabberd:jid(),
-        To :: ejabberd:jid(), ejabberd:iq()) -> ok | {error, lager_not_started}.
+        To :: ejabberd:jid(), ejabberd:iq()) -> mongoose_acc:t().
 process_iq_disco_items(Host, From, To, #iq{lang = Lang} = IQ) ->
     Rsm = jlib:rsm_decode(IQ),
     Res = IQ#iq{type = result,

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -483,9 +483,10 @@ stop_supervisor(Host) ->
                      To :: ejabberd:simple_jid() | ejabberd:jid(),
                      Packet :: any(),
                      State :: state()) -> ok | pid().
-process_packet(From, To, Packet, #state{
+process_packet(From, To, PacketOrAcc, #state{
                                     access = {AccessRoute, _, _, _},
                                     server_host = ServerHost} = State) ->
+    Packet = mongoose_acc:to_element(PacketOrAcc),
     case acl:match_rule(ServerHost, AccessRoute, From) of
         allow ->
             {Room, _, _} = jid:to_lower(To),

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -181,8 +181,10 @@ stop(Host) ->
 %% Routing
 %%====================================================================
 
--spec process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Extra :: any()) -> any().
-process_packet(From, To, Packet, _Extra) ->
+-spec process_packet(From :: jid(), To :: jid(), Acc :: mongoose_acc:t(), Extra :: any()) ->
+    any().
+process_packet(From, To, Acc, _Extra) ->
+    Packet = mongoose_acc:to_element(Acc),
     process_decoded_packet(From, To, mod_muc_light_codec_backend:decode(From, To, Packet), Packet).
 
 -spec process_decoded_packet(From :: ejabberd:jid(), To :: ejabberd:jid(),
@@ -205,11 +207,13 @@ process_decoded_packet(From, To, {ok, {_, #blocking{}} = Blocking}, OrigPacket) 
     RouteFun = fun ejabberd_router:route/3,
     case gen_mod:get_module_opt_by_subhost(To#jid.lserver, ?MODULE, blocking, ?DEFAULT_BLOCKING) of
         true ->
-            case handle_blocking(From, To, Blocking) of
-                ok ->
+            ?TEMPORARY,
+            Res = handle_blocking(From, To, Blocking),
+            case (mongoose_acc:is_acc(Res) or (Res == ok)) of
+                true ->
                     ok;
-                Error ->
-                    mod_muc_light_codec_backend:encode_error(Error, From, To, OrigPacket, RouteFun)
+                false ->
+                    mod_muc_light_codec_backend:encode_error(Res, From, To, OrigPacket, RouteFun)
             end;
         false -> mod_muc_light_codec_backend:encode_error(
                    {error, bad_request}, From, To, OrigPacket, fun ejabberd_router:route/3)
@@ -265,7 +269,8 @@ get_muc_service({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, _
 get_muc_service(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
--spec remove_user(Acc :: map(), User :: binary(), Server :: binary()) -> ok.
+-spec remove_user(Acc :: mongoose_acc:t(), User :: binary(), Server :: binary()) ->
+    mongoose_acc:t().
 remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -2323,7 +2323,7 @@ send_existing_presences(ToJID, StateData) ->
         end, dict:to_list(StateData#state.users)).
 
 -spec send_existing_presence({ejabberd:simple_jid(), mod_muc_room_user()}, mod_muc:role(),
-                             jid(), state()) -> ok.
+                             jid(), state()) -> mongoose_acc:t().
 send_existing_presence({_LJID, #user{jid = FromJID, nick = FromNick,
                                     role = FromRole, last_presence = Presence}},
                        Role, RealToJID, StateData) ->

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -2365,10 +2365,10 @@ send_config_update(Type, StateData) ->
         end, dict:to_list(StateData#state.users)).
 
 
--spec send_invitation(ejabberd:jid(), ejabberd:jid(), binary(), state()) -> 'ok'.
-send_invitation(From, To, Reason, StateData = #state{host = Host,
-                                                     server_host = ServerHost,
-                                                     jid = RoomJID}) ->
+-spec send_invitation(ejabberd:jid(), ejabberd:jid(), binary(), state()) -> mongoose_acc:t().
+send_invitation(From, To, Reason, StateData=#state{host=Host,
+                                                   server_host=ServerHost,
+                                                   jid=RoomJID}) ->
     ejabberd_hooks:run(invitation_sent, Host, [Host, ServerHost, RoomJID, From, To, Reason]),
     Config = StateData#state.config,
     Password = case Config#config.password_protected of
@@ -2589,7 +2589,7 @@ send_history(JID, Shift, StateData) ->
       end, false, lists:nthtail(Shift, lqueue_to_list(StateData#state.history))).
 
 
--spec send_subject(ejabberd:jid(), ejabberd:lang(), state()) -> 'ok'.
+-spec send_subject(ejabberd:jid(), ejabberd:lang(), state()) -> mongoose_acc:t().
 send_subject(JID, _Lang, StateData = #state{subject = <<>>, subject_author = <<>>}) ->
     Packet = #xmlel{name = <<"message">>,
                     attrs = [{<<"type">>, <<"groupchat">>}],
@@ -4226,7 +4226,7 @@ create_invite_message_elem(InviteEl, BodyEl, PasswdEl, Reason)
 %% If it is a decline, send to the inviter.
 %% Otherwise, an error message is sent to the sender.
 -spec handle_roommessage_from_nonparticipant(jlib:xmlel(), ejabberd:lang(),
-                    state(), ejabberd:simple_jid() | ejabberd:jid()) -> 'ok'.
+                    state(), ejabberd:simple_jid() | ejabberd:jid()) -> mongoose_acc:t().
 handle_roommessage_from_nonparticipant(Packet, Lang, StateData, From) ->
     case catch check_decline_invitation(Packet) of
         {true, DeclineData} ->
@@ -4254,7 +4254,7 @@ check_decline_invitation(Packet) ->
 %% @doc Send the decline to the inviter user.
 %% The original stanza must be slightly modified.
 -spec send_decline_invitation({jlib:xmlel(), jlib:xmlel(), jlib:xmlel(), ejabberd:jid()},
-        ejabberd:jid(), ejabberd:simple_jid() | ejabberd:jid()) -> 'ok'.
+        ejabberd:jid(), ejabberd:simple_jid() | ejabberd:jid()) -> mongoose_acc:t().
 send_decline_invitation({Packet, XEl, DEl, ToJID}, RoomJID, FromJID) ->
     FromString = jid:to_binary(FromJID),
     #xmlel{name = <<"decline">>, attrs = DAttrs, children = DEls} = DEl,
@@ -4275,7 +4275,7 @@ replace_subelement(XE = #xmlel{children = SubEls}, NewSubEl) ->
 
 -spec send_error_only_occupants(binary(), jlib:xmlel(),
                                 binary() | nonempty_string(),
-                                ejabberd:jid(), ejabberd:jid()) -> 'ok'.
+                                ejabberd:jid(), ejabberd:jid()) -> mongoose_acc:t().
 send_error_only_occupants(What, Packet, Lang, RoomJID, From)
   when is_binary(What) ->
     ErrText = <<"Only occupants are allowed to send ",

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -543,7 +543,7 @@ remove_old_messages(Host, Days) ->
 %% #rh
 remove_user(Acc, User, Server) ->
     R = remove_user(User, Server),
-    ?OK_OR_LOG(R),
+    mongoose_lib:log_if_backend_error(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -542,7 +542,8 @@ remove_old_messages(Host, Days) ->
 
 %% #rh
 remove_user(Acc, User, Server) ->
-    remove_user(User, Server),
+    R = remove_user(User, Server),
+    ?OK_OR_LOG(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -543,7 +543,7 @@ remove_old_messages(Host, Days) ->
 %% #rh
 remove_user(Acc, User, Server) ->
     R = remove_user(User, Server),
-    mongoose_lib:log_if_backend_error(R),
+    mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {Acc, User, Server}),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -416,12 +416,9 @@ is_type_match(subscription, Value, _JID, Subscription, _Groups) ->
 is_type_match(group, Value, _JID, _Subscription, Groups) ->
     lists:member(Value, Groups).
 
-%% #rh
 remove_user(Acc, User, Server) ->
-    case remove_user(User, Server) of
-        ok -> Acc;
-        E -> E
-    end.
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -418,7 +418,7 @@ is_type_match(group, Value, _JID, _Subscription, Groups) ->
 
 remove_user(Acc, User, Server) ->
     R = remove_user(User, Server),
-    ?OK_OR_LOG(R),
+    mongoose_lib:log_if_backend_error(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -417,7 +417,8 @@ is_type_match(group, Value, _JID, _Subscription, Groups) ->
     lists:member(Value, Groups).
 
 remove_user(Acc, User, Server) ->
-    remove_user(User, Server),
+    R = remove_user(User, Server),
+    ?OK_OR_LOG(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_privacy.erl
+++ b/apps/ejabberd/src/mod_privacy.erl
@@ -418,7 +418,7 @@ is_type_match(group, Value, _JID, _Subscription, Groups) ->
 
 remove_user(Acc, User, Server) ->
     R = remove_user(User, Server),
-    mongoose_lib:log_if_backend_error(R),
+    mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {Acc, User, Server}),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -88,13 +88,9 @@ stop(Host) ->
 %% ------------------------------------------------------------------
 %% Handlers
 
-
-%% #rh
 remove_user(Acc, User, Server) ->
-    case remove_user(User, Server) of
-        ok -> Acc;
-        E -> E
-    end.
+    remove_user(User, Server),
+    Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -89,7 +89,8 @@ stop(Host) ->
 %% Handlers
 
 remove_user(Acc, User, Server) ->
-    remove_user(User, Server),
+    R = remove_user(User, Server),
+    ?OK_OR_LOG(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -90,7 +90,7 @@ stop(Host) ->
 
 remove_user(Acc, User, Server) ->
     R = remove_user(User, Server),
-    ?OK_OR_LOG(R),
+    mongoose_lib:log_if_backend_error(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_private.erl
+++ b/apps/ejabberd/src/mod_private.erl
@@ -90,7 +90,7 @@ stop(Host) ->
 
 remove_user(Acc, User, Server) ->
     R = remove_user(User, Server),
-    mongoose_lib:log_if_backend_error(R),
+    mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {Acc, User, Server}),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -875,8 +875,9 @@ handle_cast(_Msg, State) -> {noreply, State}.
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 %% @private
-handle_info({route, From, To, Packet},
+handle_info({route, From, To, Acc},
             #state{server_host = ServerHost, access = Access, plugins = Plugins} = State) ->
+    Packet = mongoose_acc:to_element(Acc),
     case catch do_route(ServerHost, Access, Plugins, To#jid.lserver, From, To, Packet) of
         {'EXIT', Reason} -> ?ERROR_MSG("~p", [Reason]);
         _ -> ok

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -704,22 +704,25 @@ disco_items(Host, Node, From) ->
 %% callback that prevents routing subscribe authorizations back to the sender
 %%
 
-handle_pep_authorization_response({From, To, #xmlel{ name = <<"message">> } = Packet} = Acc)
+handle_pep_authorization_response({From, To, Acc}) ->
+    Name = mongoose_acc:get(name, Acc),
+    Type = mongoose_acc:get(type, Acc),
+    handle_pep_authorization_response(Name, Type, From, To, Acc).
+
+handle_pep_authorization_response(_, <<"error">>, From, To, Acc) ->
+    {From, To, Acc};
+handle_pep_authorization_response(<<"message">>, _, From, To, Acc)
   when From#jid.luser == To#jid.luser, From#jid.lserver == To#jid.lserver ->
-    case exml_query:attr(Packet, <<"type">>) of
-        <<"error">> ->
-            Acc;
-        _ ->
-            case find_authorization_response(Packet) of
-                none -> Acc;
-                invalid -> Acc;
-                XFields ->
-                    handle_authorization_response(jid:to_lower(To), From, To, Packet, XFields),
-                    drop
-            end
-    end;
-handle_pep_authorization_response(Acc) ->
-    Acc.
+        Packet = mongoose_acc:get(to_send, Acc),
+        case find_authorization_response(Packet) of
+            none -> {From, To, Acc};
+            invalid -> {From, To, Acc};
+            XFields ->
+                handle_authorization_response(jid:to_lower(To), From, To, Packet, XFields),
+                drop
+        end;
+handle_pep_authorization_response(_, _, From, To, Acc) ->
+    {From, To, Acc}.
 
 %% -------
 %% presence hooks handling functions

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -98,7 +98,8 @@ stop(Host) ->
 %%--------------------------------------------------------------------
 
 %% Hook 'remove_user'
--spec remove_user(Acc :: map(), LUser :: binary(), LServer :: binary()) -> ok.
+-spec remove_user(Acc :: mongoose_acc:t(), LUser :: binary(), LServer :: binary()) ->
+    mongoose_acc:t().
 remove_user(Acc, LUser, LServer) ->
     mod_push_backend:disable(jid:make_noprep(LUser, LServer, <<>>), undefined, undefined),
     Acc.

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -102,7 +102,7 @@ stop(Host) ->
     mongoose_acc:t().
 remove_user(Acc, LUser, LServer) ->
     R = mod_push_backend:disable(jid:make_noprep(LUser, LServer, <<>>), undefined, undefined),
-    ?OK_OR_LOG(R),
+    mongoose_lib:log_if_backend_error(R),
     Acc.
 
 %% Hook 'filter_packet'

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -101,7 +101,8 @@ stop(Host) ->
 -spec remove_user(Acc :: mongoose_acc:t(), LUser :: binary(), LServer :: binary()) ->
     mongoose_acc:t().
 remove_user(Acc, LUser, LServer) ->
-    mod_push_backend:disable(jid:make_noprep(LUser, LServer, <<>>), undefined, undefined),
+    R = mod_push_backend:disable(jid:make_noprep(LUser, LServer, <<>>), undefined, undefined),
+    ?OK_OR_LOG(R),
     Acc.
 
 %% Hook 'filter_packet'

--- a/apps/ejabberd/src/mod_push.erl
+++ b/apps/ejabberd/src/mod_push.erl
@@ -102,7 +102,7 @@ stop(Host) ->
     mongoose_acc:t().
 remove_user(Acc, LUser, LServer) ->
     R = mod_push_backend:disable(jid:make_noprep(LUser, LServer, <<>>), undefined, undefined),
-    mongoose_lib:log_if_backend_error(R),
+    mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {Acc, LUser, LServer}),
     Acc.
 
 %% Hook 'filter_packet'

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -762,7 +762,7 @@ remove_user(User, Server) ->
     LServer = jid:nameprep(Server),
     send_unsubscription_to_rosteritems(LUser, LServer),
     R = mod_roster_backend:remove_user(LUser, LServer),
-    mongoose_lib:log_if_backend_error(R),
+    mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {User, Server}),
     ok.
 
 %% For each contact with Subscription:

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -754,7 +754,8 @@ in_auto_reply(_, _, _) -> none.
 
 %% #rh
 remove_user(Acc, User, Server) ->
-    remove_user(User, Server),
+    R = remove_user(User, Server),
+    ?OK_OR_LOG(R),
     Acc.
 
 remove_user(User, Server) ->

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -762,7 +762,7 @@ remove_user(User, Server) ->
     LServer = jid:nameprep(Server),
     send_unsubscription_to_rosteritems(LUser, LServer),
     R = mod_roster_backend:remove_user(LUser, LServer),
-    ?OK_OR_LOG(R),
+    mongoose_lib:log_if_backend_error(R),
     ok.
 
 %% For each contact with Subscription:

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -754,15 +754,16 @@ in_auto_reply(_, _, _) -> none.
 
 %% #rh
 remove_user(Acc, User, Server) ->
-    R = remove_user(User, Server),
-    ?OK_OR_LOG(R),
+    remove_user(User, Server),
     Acc.
 
 remove_user(User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
     send_unsubscription_to_rosteritems(LUser, LServer),
-    mod_roster_backend:remove_user(LUser, LServer).
+    R = mod_roster_backend:remove_user(LUser, LServer),
+    ?OK_OR_LOG(R),
+    ok.
 
 %% For each contact with Subscription:
 %% Both or From, send a "unsubscribed" presence stanza;

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -230,7 +230,8 @@ handle_call(stop, _From, State) ->
 handle_call(_Request, _From, State) ->
     {reply, bad_request, State}.
 
-handle_info({route, From, To, Packet}, State) ->
+handle_info({route, From, To, Acc}, State) ->
+    Packet = mongoose_acc:to_element(Acc),
     IQ = jlib:iq_query_info(Packet),
     case catch do_route(State#state.host, From, To, Packet, IQ) of
         {'EXIT', Reason} ->

--- a/apps/ejabberd/src/mod_vcard.erl
+++ b/apps/ejabberd/src/mod_vcard.erl
@@ -231,9 +231,9 @@ handle_call(_Request, _From, State) ->
     {reply, bad_request, State}.
 
 handle_info({route, From, To, Acc}, State) ->
-    Packet = mongoose_acc:to_element(Acc),
-    IQ = jlib:iq_query_info(Packet),
-    case catch do_route(State#state.host, From, To, Packet, IQ) of
+    Acc1 = mongoose_acc:require(iq_query_info, Acc),
+    IQ = mongoose_acc:get(iq_query_info, Acc1),
+    case catch do_route(State#state.host, From, To, Acc1, IQ) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p", [Reason]);
         _ ->
@@ -376,11 +376,11 @@ config_change(Acc, _, _, _) ->
 %% Internal
 %% ------------------------------------------------------------------
 do_route(_VHost, From, #jid{user = User,
-                            resource =Resource} = To, Packet, _IQ)
+                            resource =Resource} = To, Acc, _IQ)
   when (User /= <<"">>) or (Resource /= <<"">>) ->
-    Err = jlib:make_error_reply(Packet, ?ERR_SERVICE_UNAVAILABLE),
+    Err = jlib:make_error_reply(Acc, ?ERR_SERVICE_UNAVAILABLE),
     ejabberd_router:route(To, From, Err);
-do_route(VHost, From, To, Packet, #iq{type = set,
+do_route(VHost, From, To, Acc, #iq{type = set,
                                       xmlns = ?NS_SEARCH,
                                       lang = Lang,
                                       sub_el = SubEl} = IQ) ->
@@ -389,13 +389,13 @@ do_route(VHost, From, To, Packet, #iq{type = set,
     RSMIn = jlib:rsm_decode(IQ),
     case XDataEl of
         false ->
-            Err = jlib:make_error_reply(Packet, ?ERR_BAD_REQUEST),
+            Err = jlib:make_error_reply(Acc, ?ERR_BAD_REQUEST),
             ejabberd_router:route(To, From, Err);
         _ ->
             XData = jlib:parse_xdata_submit(XDataEl),
             case XData of
                 invalid ->
-                    Err = jlib:make_error_reply(Packet, ?ERR_BAD_REQUEST),
+                    Err = jlib:make_error_reply(Acc, ?ERR_BAD_REQUEST),
                     ejabberd_router:route(To, From, Err);
                 _ ->
                     {SearchResult, RSMOutEls} = search_result(Lang, To, VHost, XData, RSMIn),
@@ -412,7 +412,7 @@ do_route(VHost, From, To, Packet, #iq{type = set,
                     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ))
             end
     end;
-do_route(VHost, From, To, _Packet, #iq{type = get,
+do_route(VHost, From, To, _Acc, #iq{type = get,
                                         xmlns = ?NS_SEARCH,
                                         lang = Lang} = IQ) ->
     ResIQ =
@@ -422,11 +422,11 @@ do_route(VHost, From, To, _Packet, #iq{type = get,
                            children = ?FORM(To, mod_vcard_backend:search_fields(VHost), Lang)
                           }]},
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
-do_route(_VHost, From, To, Packet, #iq{type = set,
+do_route(_VHost, From, To, Acc, #iq{type = set,
                                        xmlns = ?NS_DISCO_INFO}) ->
-    Err = jlib:make_error_reply(Packet, ?ERR_NOT_ALLOWED),
+    Err = jlib:make_error_reply(Acc, ?ERR_NOT_ALLOWED),
     ejabberd_router:route(To, From, Err);
-do_route(VHost, From, To, _Packet, #iq{type = get,
+do_route(VHost, From, To, _Acc, #iq{type = get,
                                        xmlns = ?NS_DISCO_INFO,
                                        lang = Lang} = IQ) ->
     Info = ejabberd_hooks:run_fold(disco_info, VHost, [],
@@ -447,18 +447,18 @@ do_route(VHost, From, To, _Packet, #iq{type = get,
                                                       attrs = [{<<"var">>, ?NS_VCARD}]}
                                               ] ++ Info}]},
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
-do_route(_VHost, From, To, Packet, #iq{type=set,
+do_route(_VHost, From, To, Acc, #iq{type=set,
                                        xmlns = ?NS_DISCO_ITEMS}) ->
-    Err = jlib:make_error_reply(Packet, ?ERR_NOT_ALLOWED),
+    Err = jlib:make_error_reply(Acc, ?ERR_NOT_ALLOWED),
     ejabberd_router:route(To, From, Err);
-do_route(_VHost, From, To, _Packet, #iq{ type = get,
+do_route(_VHost, From, To, _Acc, #iq{ type = get,
                                          xmlns = ?NS_DISCO_ITEMS} = IQ) ->
     ResIQ =
         IQ#iq{type = result,
               sub_el = [#xmlel{name = <<"query">>,
                                attrs = [{<<"xmlns">>, ?NS_DISCO_ITEMS}]}]},
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
-do_route(_VHost, From, To, _Packet, #iq{ type = get,
+do_route(_VHost, From, To, _Acc, #iq{ type = get,
                                          xmlns = ?NS_VCARD,
                                          lang = Lang} = IQ) ->
     ResIQ =
@@ -467,8 +467,8 @@ do_route(_VHost, From, To, _Packet, #iq{ type = get,
                                attrs = [{<<"xmlns">>, ?NS_VCARD}],
                                children = iq_get_vcard(Lang)}]},
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
-do_route(_VHost, From, To, Packet, _IQ) ->
-    Err = jlib:make_error_reply(Packet, ?ERR_SERVICE_UNAVAILABLE),
+do_route(_VHost, From, To, Acc, _IQ) ->
+    Err = jlib:make_error_reply(Acc, ?ERR_SERVICE_UNAVAILABLE),
     ejabberd_router:route(To, From, Err).
 
 iq_get_vcard(_Lang) ->

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -14,6 +14,7 @@
 %% API
 -export([new/0, from_kv/2, put/3, get/2, get/3, append/3, to_map/1, remove/2]).
 -export([from_element/1, from_map/1, update/2, is_acc/1, require/2]).
+-export([flush/1]).
 -export([initialise/3, terminate/3, terminate/4, dump/1, to_binary/1]).
 -export([to_element/1]).
 -export_type([t/0]).
@@ -176,6 +177,13 @@ require([Key|Tail], Acc) ->
     require(Tail, Acc1);
 require(Key, Acc) ->
     require([Key], Acc).
+
+%% @doc Remove all data we cached
+%% Personally I think we should consider a more flexible implementation of
+%% in-accumulator cache, so that attrs are not hardcoded here.
+-spec flush(t()) -> t().
+flush(Acc) ->
+    remove(privacy_check, Acc).
 
 %%%%% internal %%%%%
 

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -60,7 +60,12 @@ to_binary({broadcast, Payload}) ->
     end;
 to_binary(Acc) ->
     % replacement to exml:to_binary, for error logging
-    exml:to_binary(mongoose_acc:get(element, Acc)).
+    case mongoose_acc:is_acc(Acc) of
+        true ->
+            exml:to_binary(mongoose_acc:get(element, Acc));
+        false ->
+            list_to_binary(io_lib:format("~p", [Acc]))
+    end.
 
 %% This function is for transitional period, eventually all hooks will use accumulator
 %% and we will not have to check

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -205,6 +205,9 @@ produce(send_type, Acc) ->
     El = mongoose_acc:get(to_send, Acc),
     SType = exml_query:attr(El, <<"type">>, undefined),
     mongoose_acc:put(send_type, SType, Acc);
+produce(iq_query_info, Acc) ->
+    Iq = jlib:iq_query_info(mongoose_acc:get(element, Acc)), % it doesn't change
+    mongoose_acc:put(iq_query_info, Iq, Acc);
 produce(xmlns, Acc) ->
     read_children(Acc);
 produce(command, Acc) ->

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -119,6 +119,7 @@ put(Key, Val, P) ->
 get(to_send, Acc) ->
     get(to_send, Acc, get(element, Acc));
 get([], _) ->
+
     undefined;
 get([Key|Keys], P) ->
     case maps:is_key(Key, P) of

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -190,28 +190,20 @@ strip(Acc) ->
     El = get(to_send, Acc),
     Acc1 = from_element(El),
 %%    Ats = [name, type, attrs, from, from_jid, to, to_jid, ref, timestamp],
-    Ats = [from, from_jid, ref, timestamp],
-    NAcc = lists:foldl(fun(Atr, AccIn) ->
-                           Nval = mongoose_acc:get(Atr, Acc),
-                           mongoose_acc:put(Atr, Nval, AccIn)
+    Attributes = [from, from_jid, ref, timestamp],
+    NewAcc = lists:foldl(fun(Attrib, AccIn) ->
+                           Val = mongoose_acc:get(Attrib, Acc),
+                           mongoose_acc:put(Attrib, Val, AccIn)
                        end,
-                       Acc1, Ats),
-    OptAts = [to, to_jid],
-    lists:foldl(fun(Atr, AccIn) ->
-                    case mongoose_acc:get(Atr, Acc, undefined) of
+                       Acc1, Attributes),
+    OptionalAttributes = [to, to_jid],
+    lists:foldl(fun(Attrib, AccIn) ->
+                    case mongoose_acc:get(Attrib, Acc, undefined) of
                         undefined -> AccIn;
-                        Nval -> mongoose_acc:put(Atr, Nval, AccIn)
+                        Val -> mongoose_acc:put(Attrib, Val, AccIn)
                     end
                 end,
-                NAcc, OptAts).
-%%    mongoose_acc:put(element, mongoose_acc:get(to_send, Acc), NAcc1).
-%%    case mongoose_acc:get(send_type, Acc, undefined) of
-%%        undefined ->
-%%            NAcc1;
-%%        SType ->
-%%            mongoose_acc:put(type, SType, NAcc2)
-%%    end.
-
+        NewAcc, OptionalAttributes).
 
 %%%%% internal %%%%%
 

--- a/apps/ejabberd/src/mongoose_client_api_sse.erl
+++ b/apps/ejabberd/src/mongoose_client_api_sse.erl
@@ -36,12 +36,16 @@ maybe_init({false, Value}, Req, State) ->
 handle_notify(_Msg, State) ->
     {nosend, State}.
 
-handle_info({route, _From, _To, #xmlel{name = <<"message">>} = Packet}, State) ->
-    Timestamp = usec:from_now(os:timestamp()),
-    Type = exml_query:attr(Packet, <<"type">>),
-    maybe_send_message_event(Type, Packet, Timestamp, State);
+handle_info({route, _From, _To, Acc}, State) ->
+    handle_msg(mongoose_acc:get(name, Acc), Acc, State);
 handle_info(_Msg, State) ->
     {nosend, State}.
+
+handle_msg(<<"message">>, Acc, State) ->
+    Timestamp = usec:from_now(os:timestamp()),
+    Type = mongoose_acc:get(type, Acc),
+    Packet = mongoose_acc:get(to_send, Acc),
+    maybe_send_message_event(Type, Packet, Timestamp, State).
 
 handle_error(_Msg, _Reson, State) ->
     {nosend, State}.

--- a/apps/ejabberd/src/mongoose_lib.erl
+++ b/apps/ejabberd/src/mongoose_lib.erl
@@ -1,5 +1,7 @@
 -module(mongoose_lib).
--export([bin_to_int/1]).
+-export([bin_to_int/1, log_if_backend_error/1]).
+
+-include("ejabberd.hrl").
 
 %% @doc string:to_integer/1 for binaries
 bin_to_int(Bin) ->
@@ -9,3 +11,18 @@ bin_to_int(<<H, T/binary>>, X) when $0 =< H, H =< $9 ->
     bin_to_int(T, (X*10)+(H-$0));
 bin_to_int(Bin, X) ->
     {X, Bin}.
+
+
+%% @doc Database backends for various modules return ok, {atomic, ok}
+%% or {atomic, []} on success, and usually {error, ...} on failure.
+%% All we need is to log an error if such occurred, and proceed normally.
+-spec log_if_backend_error(any()) -> ok.
+log_if_backend_error(V) ->
+    case V of
+        ok -> ok;
+        {atomic, _} -> ok;
+        {error, E} -> ?ERROR_MSG("Error calling backend - got '~p'", [E]);
+        E -> ?ERROR_MSG("Unexpected return from backend - got '~p'", [E])
+    end,
+    ok.
+

--- a/apps/ejabberd/src/mongoose_lib.erl
+++ b/apps/ejabberd/src/mongoose_lib.erl
@@ -32,5 +32,5 @@ log_if_backend_error(V, Module, Line, Args) ->
     ok.
 
 make_msg(Msg, Error, Module, Line, Args) ->
-    ?ERROR_MSG("~p: ~p~nBackend called in ~p:~p~nwith arguments~n~p",
+    ?ERROR_MSG("~p:~p module=~p line=~p arguments=~p",
                   [Msg, Error, Module, Line, Args]).

--- a/apps/ejabberd/src/mongoose_metrics_hooks.erl
+++ b/apps/ejabberd/src/mongoose_metrics_hooks.erl
@@ -23,7 +23,7 @@
          user_receive_packet/5,
          xmpp_bounce_message/3,
          xmpp_stanza_dropped/4,
-         xmpp_send_element/3,
+         xmpp_send_element/2,
          roster_get/2,
          roster_set/4,
          roster_push/3,
@@ -135,14 +135,13 @@ xmpp_stanza_dropped(Acc, #jid{server = Server} , _, _) ->
     mongoose_metrics:update(Server, xmppStanzaDropped, 1),
     Acc.
 
--spec xmpp_send_element(Acc :: map(), Server :: ejabberd:server(),
-                        Packet :: jlib:xmlel()) -> ok | metrics_notify_return().
-xmpp_send_element(Acc, Server, #xmlel{name = Name, attrs = Attrs}) ->
+-spec xmpp_send_element(Acc :: map(), Server :: ejabberd:server()) -> ok | metrics_notify_return().
+xmpp_send_element(Acc, Server) ->
     mongoose_metrics:update(Server, xmppStanzaCount, 1),
-    case lists:keyfind(<<"type">>, 1, Attrs) of
-        {<<"type">>, <<"error">>} ->
+    case mongoose_acc:get(type, Acc) of
+        <<"error">> ->
             mongoose_metrics:update(Server, xmppErrorTotal, 1),
-            case Name of
+            case mongoose_acc:get(name, Acc) of
                 <<"iq">> ->
                     mongoose_metrics:update(Server, xmppErrorIq, 1);
                 <<"message">> ->
@@ -152,8 +151,6 @@ xmpp_send_element(Acc, Server, #xmlel{name = Name, attrs = Attrs}) ->
             end;
         _ -> ok
     end,
-    Acc;
-xmpp_send_element(Acc, _, _) ->
     Acc.
 
 

--- a/apps/ejabberd/src/mongoose_packet_handler.erl
+++ b/apps/ejabberd/src/mongoose_packet_handler.erl
@@ -27,8 +27,8 @@
 %% Callback declarations
 %%----------------------------------------------------------------------
 
--callback process_packet(From :: jid(), To :: jid(), Packet :: exml:element(), Extra :: any()) ->
-    any().
+-callback process_packet(From :: jid(), To :: jid(), Packet :: exml:element() | mongoose_acc:t(),
+    Extra :: any()) -> any().
 
 %%----------------------------------------------------------------------
 %% API
@@ -44,7 +44,8 @@ new(Module) ->
 new(Module, Extra) when is_atom(Module) ->
     #packet_handler{ module = Module, extra = Extra }.
 
--spec process(Handler :: t(), From :: jid(), To :: jid(), Packet :: exml:element()) -> any().
+-spec process(Handler :: t(), From :: jid(), To :: jid(),
+    Packet :: exml:element() | mongoose_acc:t()) -> any().
 process(#packet_handler{ module = Module, extra = Extra }, From, To, Packet) ->
     Module:process_packet(From, To, Packet, Extra).
 

--- a/apps/ejabberd/src/mongoose_privacy.erl
+++ b/apps/ejabberd/src/mongoose_privacy.erl
@@ -45,7 +45,7 @@ privacy_check_packet(Acc, Server, User, PrivacyList, From, To, Dir) ->
     % check if it is there, if not then set default and run a hook
     case mongoose_acc:get(privacy_check, Acc, undefined) of
         undefined ->
-            Packet = mongoose_acc:get(element, Acc),
+            Packet = mongoose_acc:get(to_send, Acc),
             Acc1 = ejabberd_hooks:run_fold(privacy_check_packet,
                                            Server,
                                            mongoose_acc:put(privacy_check, allow, Acc),

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -14,12 +14,12 @@
 
 
 -callback route(From :: ejabberd:jid(), To :: ejabberd:jid(),
-                   Packet :: jlib:xmlel()) ->
-    done | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
+                   Packet :: mongoose_acc:t()) ->
+    done | {ejabberd:jid(), ejabberd:jid(), mongoose_acc:t()}.
 
 -callback filter(From :: ejabberd:jid(), To :: ejabberd:jid(),
-    Packet :: jlib:xmlel()) ->
-    drop | {ejabberd:jid(), ejabberd:jid(), jlib:xmlel()}.
+    Packet :: mongoose_acc:t()) ->
+    drop | {ejabberd:jid(), ejabberd:jid(), mongoose_acc:t()}.
 
 
 

--- a/apps/ejabberd/src/xmpp_router.erl
+++ b/apps/ejabberd/src/xmpp_router.erl
@@ -22,4 +22,17 @@
     drop | {ejabberd:jid(), ejabberd:jid(), mongoose_acc:t()}.
 
 
+-export([call_route/4, call_filter/4]).
 
+-spec call_route(Module :: module(), From :: ejabberd:jid(),
+    To :: ejabberd:jid(), Packet :: mongoose_acc:t()) ->
+    done | {ejabberd:jid(), ejabberd:jid(), mongoose_acc:t()}.
+call_route(Module, From, To, Packet) ->
+    Module:route(From, To, Packet).
+
+
+-spec call_filter(Module :: module(), From :: ejabberd:jid(),
+    To :: ejabberd:jid(), Packet :: mongoose_acc:t()) ->
+    drop | {ejabberd:jid(), ejabberd:jid(), mongoose_acc:t()}.
+call_filter(Module, From, To, Packet) ->
+    Module:filter(From, To, Packet).

--- a/apps/ejabberd/test/acc_SUITE.erl
+++ b/apps/ejabberd/test/acc_SUITE.erl
@@ -57,6 +57,12 @@ get_and_require(_C) ->
     ?assertEqual(mongoose_acc:get(xmlns, Acc, nope), nope),
     Acc2 = mongoose_acc:require([command, xmlns], Acc),
     ?assertEqual(mongoose_acc:get(xmlns, Acc2), <<"urn:xmpp:blocking">>),
+    ?assertEqual(mongoose_acc:get(iq_query_info, Acc2, nope), nope),
+    Iq = mongoose_acc:from_element(iq_stanza()),
+    Iq1 = mongoose_acc:require([iq_query_info], Iq),
+    IqData = mongoose_acc:get(iq_query_info, Iq1),
+    ?assertEqual(IqData#iq.type, set),
+    ?assertEqual(IqData#iq.xmlns, <<"urn:ietf:params:xml:ns:xmpp-session">>),
     ok.
 
 parse_with_cdata(_C) ->
@@ -79,4 +85,12 @@ stanza_with_cdata() ->
     {ok, X} = exml:parse(Txt),
     X.
 
+
+iq_stanza() ->
+    {xmlel,<<"iq">>,
+        [{<<"type">>,<<"set">>},
+            {<<"id">>,<<"a31baa4c478896af19b76bac799b65ed">>}],
+        [{xmlel,<<"session">>,
+            [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-session">>}],
+            []}]}.
 

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -70,4 +70,5 @@ hookfold(roster_get_subscription_lists, _, _, _) -> mongoose_acc:new();
 hookfold(privacy_get_user_list, _, A, _) -> A;
 hookfold(session_opening_allowed_for_user, _, _, _) -> allow;
 hookfold(c2s_stream_features, _, _, _) -> [];
+hookfold(xmpp_send_element, _, A, _, _) -> A;
 hookfold(privacy_check_packet, _, _, _) -> allow.

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -70,5 +70,5 @@ hookfold(roster_get_subscription_lists, _, _, _) -> mongoose_acc:new();
 hookfold(privacy_get_user_list, _, A, _) -> A;
 hookfold(session_opening_allowed_for_user, _, _, _) -> allow;
 hookfold(c2s_stream_features, _, _, _) -> [];
-hookfold(xmpp_send_element, _, A, _, _) -> A;
+hookfold(xmpp_send_element, _, A, _) -> A;
 hookfold(privacy_check_packet, _, _, _) -> allow.

--- a/test.disabled/ejabberd_tests/tests/push_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_SUITE.erl
@@ -376,7 +376,8 @@ pm_msg_notify_if_user_offline(Config) ->
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = RealPubsubJID, packet = Packet} = Published,
+            #route{to = RealPubsubJID, packet = Acc} = Published,
+            Packet = rpc(mongoose_acc, get, [to_send, Acc]),
             ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                              {element, <<"publish">>},
@@ -408,7 +409,8 @@ pm_msg_notify_if_user_offline_with_publish_options(Config) ->
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = RealPubsubJID, packet = Packet} = Published,
+            #route{to = RealPubsubJID, packet = Acc} = Published,
+            Packet = rpc(mongoose_acc, get, [to_send, Acc]),
             ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                             {element, <<"publish-options">>},
@@ -504,7 +506,8 @@ muclight_msg_notify_if_user_offline(Config) ->
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = RealPubsubJID, packet = Packet} = Published,
+            #route{to = RealPubsubJID, packet = Acc} = Published,
+            Packet = rpc(mongoose_acc, get, [to_send, Acc]),
             ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                             {element, <<"publish">>},
@@ -540,7 +543,8 @@ muclight_msg_notify_if_user_offline_with_publish_options(Config) ->
 
             Published = received_route(),
             ?assertMatch(#route{}, Published),
-            #route{to = RealPubsubJID, packet = Packet} = Published,
+            #route{to = RealPubsubJID, packet = Acc} = Published,
+            Packet = rpc(mongoose_acc, get, [to_send, Acc]),
             ?assertMatch(PubsubJID, rpc(jid, to_binary, [RealPubsubJID])),
             Form = exml_query:path(Packet, [{element, <<"pubsub">>},
                                             {element, <<"publish-options">>},

--- a/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
@@ -164,7 +164,7 @@ end_per_testcase(CaseName, Config) ->
 %%%===================================================================
 
 simple_message(Config) ->
-    escalus:story(Config, [{alice2, 1}, {alice, 1}], fun(Alice2, Alice1) ->
+    escalus:fresh_story(Config, [{alice2, 1}, {alice, 1}], fun(Alice2, Alice1) ->
 
         %% User on the main server sends a message to a user on a federated server
         escalus:send(Alice1, escalus_stanza:chat_to(Alice2, <<"Hi, foreign Alice!">>)),
@@ -192,7 +192,7 @@ timeout_waiting_for_message(Config) ->
     end.
 
 nonexistent_user(Config) ->
-    escalus:story(Config, [{alice, 1}, {alice2, 1}], fun(Alice1, Alice2) ->
+    escalus:fresh_story(Config, [{alice, 1}, {alice2, 1}], fun(Alice1, Alice2) ->
 
         %% Alice@localhost1 sends message to Xyz@localhost2
         RemoteServer = escalus_client:server(Alice2),
@@ -207,7 +207,7 @@ nonexistent_user(Config) ->
     end).
 
 unknown_domain(Config) ->
-    escalus:story(Config, [{alice, 1}], fun(Alice1) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice1) ->
 
         %% Alice@localhost1 sends message to Xyz@localhost3
         escalus:send(Alice1, escalus_stanza:chat_to(
@@ -221,7 +221,7 @@ unknown_domain(Config) ->
     end).
 
 nonascii_addr(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob2, 1}], fun(Alice, Bob) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob2, 1}], fun(Alice, Bob) ->
 
         %% Bob@localhost2 sends message to Alice@localhost1
         escalus:send(Bob, escalus_stanza:chat_to(Alice, <<"Cześć Alice!">>)),

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -1006,7 +1006,7 @@ prepare_vcard(ldap, JID, Fields) ->
 prepare_vcard(_, JID, Fields) ->
     RJID = get_jid_record(JID),
     VCard = escalus_stanza:vcard_update(JID, Fields),
-    ok = vcard_rpc(RJID, VCard).
+    vcard_rpc(RJID, VCard).
 
 insert_alice_photo(Config) ->
     User = <<"alice">>,


### PR DESCRIPTION
This PR makes a big step by introducing accumulators to interprocess communication: ejabberd:route now sends out accumulators instead of stanzas. c2s receives them and converts back to stanzas, same for s2s. Doesn't sound like much, but there is lots of code changes. Follow-up will be to move termination point from c2s:handle_info further down the chain, until we reach send_element again.

