### PR TITLE
Rename MongoosePush docker image to mongoose-push

### DIFF
--- a/test.disabled/ejabberd_tests/services/mongoose_push-compose.yml
+++ b/test.disabled/ejabberd_tests/services/mongoose_push-compose.yml
@@ -14,8 +14,8 @@ services:
     ports:
       - "${APNS_MOCK_PORT:-12992}:2197"
 
-  mongoose_push:
-    image: mongooseim/mongoose_push:latest
+  mongoose-push:
+    image: mongooseim/mongoose-push:latest
     command: foreground
     depends_on:
       - apns-mock


### PR DESCRIPTION
Use new, renamed version of MongoosePush docker image - `mongoose-push`.
