### PR TITLE
Reimplement shaper as a token bucket.

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -831,7 +831,20 @@ do_open_session_common(JID, #state{user = U, resource = R} = NewStateData0) ->
     Conn = get_conn_type(NewStateData0),
     Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
             {auth_module, NewStateData0#state.auth_module}],
-    ejabberd_sm:open_session(SID, U, NewStateData0#state.server, R, Info),
+    ReplacedPids = ejabberd_sm:open_session(SID, U, NewStateData0#state.server, R, Info),
+
+    MonitorRefs = ordsets:from_list([{monitor(process, PID), PID} || PID <- ReplacedPids]),
+    lists:foreach(
+        fun({MonitorRef, PID}) ->
+            receive
+                {'DOWN', MonitorRef, _, _, _} -> ok
+            after 100 ->
+                ?WARNING_MSG("C2S process ~p for ~s replaced by ~p has not stopped before timeout",
+                             [PID, jid:to_binary(NewStateData0#state.jid), self()])
+            end
+        end,
+        MonitorRefs),
+
     NewStateData =
     NewStateData0#state{sid = SID,
                         conn = Conn,
@@ -1126,7 +1139,12 @@ handle_info({route, From, To, Packet}, StateName, StateData) ->
     ejabberd_hooks:run(c2s_loop_debug, [{route, From, To, Packet}]),
     Name = Packet#xmlel.name,
     process_incoming_stanza(Name, From, To, Packet, StateName, StateData);
-
+handle_info(new_offline_messages, session_established,
+            #state{pres_last = Presence, pres_invis = Invisible} = StateData)
+  when Presence =/= undefined orelse Invisible ->
+    From = StateData#state.jid,
+    resend_offline_messages(mongoose_acc:new(), StateData),
+    {next_state, session_established, StateData};
 handle_info({'DOWN', Monitor, _Type, _Object, _Info}, _StateName, StateData)
   when Monitor == StateData#state.socket_monitor ->
     maybe_enter_resume_session(StateData#state.stream_mgmt_id, StateData);
@@ -2282,11 +2300,9 @@ resend_offline_messages(Acc, StateData) ->
                                    Acc,
                                    [StateData#state.user, StateData#state.server]),
     Rs = mongoose_acc:get(offline_messages, Acc1, []),
-    Acc2 = lists:foldl(fun({route, From, To, #xmlel{} = Packet}, A) ->
-                           check_privacy_and_route_or_ignore(A, StateData, From, To, Packet, in)
-                       end,
-                       Acc1, Rs),
-    mongoose_acc:remove(offline_messages, Acc2). % they are gone from db backend and sent
+    [check_privacy_and_route_or_ignore(StateData, From, To, Packet, in)
+     || {route, From, To, #xmlel{} = Packet} <- Rs],
+    mongoose_acc:remove(offline_messages, Acc1). % they are gone from db backend and sent
 
 
 -spec check_privacy_and_route_or_ignore(StateData :: state(),
@@ -3169,4 +3185,3 @@ terminate_when_tls_required_but_not_enabled(true, false, StateData, _El) ->
 terminate_when_tls_required_but_not_enabled(_, _, StateData, El) ->
     process_unauthenticated_stanza(StateData, El),
     fsm_next_state(wait_for_feature_before_auth, StateData).
-

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -1142,7 +1142,6 @@ handle_info({route, From, To, Packet}, StateName, StateData) ->
 handle_info(new_offline_messages, session_established,
             #state{pres_last = Presence, pres_invis = Invisible} = StateData)
   when Presence =/= undefined orelse Invisible ->
-    From = StateData#state.jid,
     resend_offline_messages(mongoose_acc:new(), StateData),
     {next_state, session_established, StateData};
 handle_info({'DOWN', Monitor, _Type, _Object, _Info}, _StateName, StateData)

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -744,8 +744,7 @@ terminate(Reason, _StateName, StateData) ->
               tab_remove_online_user(LJID, StateData)
       end, [], StateData#state.users),
     add_to_log(room_existence, stopped, StateData),
-    mod_muc:room_destroyed(StateData#state.host, StateData#state.room, self(),
-               StateData#state.server_host),
+    mod_muc:room_destroyed(StateData#state.host, StateData#state.room, self()),
     ok.
 
 %%%----------------------------------------------------------------------

--- a/apps/ejabberd/src/mongoose_client_api_sse.erl
+++ b/apps/ejabberd/src/mongoose_client_api_sse.erl
@@ -23,7 +23,7 @@ maybe_init(true, Req, #{jid := JID} = State) ->
     UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
     Resource = <<"sse-", UUID/binary>>,
 
-    ok = ejabberd_sm:open_session(SID, User, Server, Resource, 1, []),
+    ejabberd_sm:open_session(SID, User, Server, Resource, 1, []),
 
     {ok, Req, State#{sid => SID, jid => jid:replace_resource(JID, Resource)}};
 maybe_init(true, Req, State) ->
@@ -66,4 +66,3 @@ maybe_send_message_event(<<"groupchat">>, Packet, Timestamp, #{id := ID} = State
     {send, Event, State#{id := ID + 1}};
 maybe_send_message_event(_, _, _, State) ->
     {nosend, State}.
-

--- a/apps/ejabberd/src/monitored_map.erl
+++ b/apps/ejabberd/src/monitored_map.erl
@@ -1,0 +1,97 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(monitored_map).
+-author('konrad.zemek@erlang-solutions.com').
+
+-export([new/0, put/4, remove/2, find/2, get/2, get/3, handle_info/2]).
+
+-record(monitored_map, {
+          map = #{} :: #{term() => {term(), pid(), reference()}},
+          monitors = #{} :: #{reference() => term()}
+         }).
+
+-type t() :: #monitored_map{}.
+-type t(KeyT, ValueT) :: #monitored_map{map :: #{KeyT => {ValueT, pid(), reference()}},
+                                        monitors :: #{reference() => KeyT}}.
+
+-export_type([t/0, t/2]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec new() -> t().
+new() ->
+    #monitored_map{}.
+
+-spec put(Key :: term(), Value :: term(), Pid :: pid(), MonMap :: t()) -> t().
+put(Key, Value, Pid, #monitored_map{map = Map, monitors = Monitors} = MonMap) ->
+    case maps:get(Key, Map, {undefined, undefined, make_ref()}) of
+        {_, Pid, Ref} ->
+            NewMap = maps:put(Key, {Value, Pid, Ref}, Map),
+            MonMap#monitored_map{map = NewMap};
+
+        {_, _, OldRef} ->
+            demonitor(OldRef),
+            Ref = monitor(process, Pid),
+            NewMonitors = maps:put(Ref, Key, maps:remove(Ref, Monitors)),
+            NewMap = maps:put(Key, {Value, Pid, Ref}, Map),
+            MonMap#monitored_map{map = NewMap, monitors = NewMonitors}
+    end.
+
+-spec remove(Key :: term(), MonMap :: t()) -> t().
+remove(Key, #monitored_map{map = Map, monitors = Monitors} = MonMap) ->
+    case maps:find(Key, Map) of
+        {ok, {_Value, _Pid, Ref}} ->
+            demonitor(Ref),
+            NewMap = maps:remove(Key, Map),
+            NewMonitors = maps:remove(Ref, Monitors),
+            MonMap#monitored_map{map = NewMap, monitors = NewMonitors};
+        _ ->
+            MonMap
+    end.
+
+-spec find(Key :: term(), MonMap :: t()) -> {ok, term()} | error.
+find(Key, #monitored_map{map = Map}) ->
+    case maps:find(Key, Map) of
+        {ok, {Value, _, _}} -> {ok, Value};
+        Other -> Other
+    end.
+
+-spec get(Key :: term(), MonMap :: t()) -> term() | no_return().
+get(Key, #monitored_map{map = Map}) ->
+    {Value, _, _} = maps:get(Key, Map),
+    Value.
+
+-spec get(Key :: term(), MonMap :: t(), Default :: term()) -> term().
+get(Key, #monitored_map{map = Map}, Default) ->
+    {Value, _, _} = maps:get(Key, Map, {Default, undefined, undefined}),
+    Value.
+
+-spec handle_info(Message :: term(), MonMap :: t()) -> t().
+handle_info({'DOWN', MonitorRef, _Type, _Object, _Info},
+            #monitored_map{map = Map, monitors = Monitors} = MonMap) ->
+    case maps:find(MonitorRef, Monitors) of
+        {ok, Key} ->
+            NewMap = maps:remove(Key, Map),
+            NewMonitors = maps:remove(MonitorRef, Monitors),
+            MonMap#monitored_map{map = NewMap, monitors = NewMonitors};
+        error ->
+            MonMap
+    end;
+handle_info(_, MonMap) ->
+    MonMap.

--- a/apps/ejabberd/src/shaper.erl
+++ b/apps/ejabberd/src/shaper.erl
@@ -25,23 +25,23 @@
     last_update = p1_time_compat:monotonic_time() :: integer()
 }).
 
--type shaper() :: #shaper{}.
+-type shaper() :: #shaper{} | none.
 
 -export_type([shaper/0]).
 
 -spec new(atom()) -> shaper().
 new(Name) ->
     case ejabberd_config:get_global_option({shaper, Name, global}) of
-        undefined -> #shaper{};
-        none -> #shaper{};
+        undefined -> none;
+        none -> none;
         {maxrate, MaxRate} -> #shaper{max_rate = MaxRate, tokens = MaxRate}
     end.
 
 %% @doc Update shaper.
 %% `Delay' is how many milliseconds to wait.
 -spec update(shaper(), Size :: pos_integer()) -> {shaper(), Delay :: non_neg_integer()}.
-update(#shaper{max_rate = undefined} = Shaper, _Size) ->
-    {Shaper, 0};
+update(none, _Size) ->
+    {none, 0};
 update(Shaper, Size) ->
     Now = p1_time_compat:monotonic_time(),
     Second = p1_time_compat:convert_time_unit(1, seconds, native),

--- a/apps/ejabberd/src/shaper.erl
+++ b/apps/ejabberd/src/shaper.erl
@@ -1,89 +1,62 @@
-%%%----------------------------------------------------------------------
-%%% File    : shaper.erl
-%%% Author  : Alexey Shchepin <alexey@process-one.net>
-%%% Purpose : Functions to control connections traffic
-%%% Created :  9 Feb 2003 by Alexey Shchepin <alexey@process-one.net>
-%%%
-%%%
-%%% ejabberd, Copyright (C) 2002-2011   ProcessOne
-%%%
-%%% This program is free software; you can redistribute it and/or
-%%% modify it under the terms of the GNU General Public License as
-%%% published by the Free Software Foundation; either version 2 of the
-%%% License, or (at your option) any later version.
-%%%
-%%% This program is distributed in the hope that it will be useful,
-%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
-%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-%%% General Public License for more details.
-%%%
-%%% You should have received a copy of the GNU General Public License
-%%% along with this program; if not, write to the Free Software
-%%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-%%% 02111-1307 USA
-%%%
-%%%----------------------------------------------------------------------
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
 
 -module(shaper).
--author('alexey@process-one.net').
+-author('konrad.zemek@erlang-solutions.com').
 
--export([new/1, new1/1, update/2]).
+-export([new/1, update/2]).
 
--include("ejabberd.hrl").
+-record(shaper, {
+    max_rate :: undefined | pos_integer(),
+    tokens = 0 :: non_neg_integer(),
+    last_update = p1_time_compat:monotonic_time() :: integer()
+}).
 
--record(maxrate, {maxrate, lastrate, lasttime}).
-
--type shaper() :: none | #maxrate{}.
+-type shaper() :: #shaper{}.
 
 -export_type([shaper/0]).
 
 -spec new(atom()) -> shaper().
 new(Name) ->
-    Data = case ejabberd_config:get_global_option({shaper, Name, global}) of
-               undefined ->
-                   none;
-               D ->
-                   D
-           end,
-    new1(Data).
-
-
--spec new1(shaper()) -> shaper().
-new1(none) ->
-    none;
-new1({maxrate, MaxRate}) ->
-    #maxrate{maxrate = MaxRate,
-             lastrate = 0,
-             lasttime = now_to_usec(now())}.
-
+    case ejabberd_config:get_global_option({shaper, Name, global}) of
+        undefined -> #shaper{};
+        none -> #shaper{};
+        {maxrate, MaxRate} -> #shaper{max_rate = MaxRate, tokens = MaxRate}
+    end.
 
 %% @doc Update shaper.
 %% `Delay' is how many milliseconds to wait.
--spec update(shaper(), Size :: non_neg_integer()) ->
-                                      {shaper(), Delay :: non_neg_integer()}.
-update(none, _Size) ->
-    {none, 0};
-update(#maxrate{} = State, Size) ->
-    MinInterv = 1000 * Size /
-        (2 * State#maxrate.maxrate - State#maxrate.lastrate),
-    Now = now_to_usec(now()),
-    Interv = (Now - State#maxrate.lasttime) / 1000,
-    ?DEBUG("State: ~p, Size=~p~nM=~p, I=~p~n",
-              [State, Size, MinInterv, Interv]),
-    Pause = if
-                MinInterv > Interv ->
-                    1 + trunc(MinInterv - Interv);
-                true ->
-                    0
-            end,
-    NextNow = Now + Pause * 1000,
-    {State#maxrate{
-       lastrate = (State#maxrate.lastrate +
-                   1000000 * Size / (NextNow - State#maxrate.lasttime))/2,
-       lasttime = NextNow},
-     Pause}.
+-spec update(shaper(), Size :: pos_integer()) -> {shaper(), Delay :: non_neg_integer()}.
+update(#shaper{max_rate = undefined} = Shaper, _Size) ->
+    {Shaper, 0};
+update(Shaper, Size) ->
+    Now = p1_time_compat:monotonic_time(),
+    Second = p1_time_compat:convert_time_unit(1, seconds, native),
 
+    SecondsSinceLastUpdate = (Now - Shaper#shaper.last_update) / Second,
+    TokenGrowth = round(Shaper#shaper.max_rate * SecondsSinceLastUpdate),
+    Tokens = min(Shaper#shaper.max_rate, Shaper#shaper.tokens + TokenGrowth),
 
--spec now_to_usec(erlang:timestamp()) -> non_neg_integer().
-now_to_usec({MSec, Sec, USec}) ->
-    (MSec*1000000 + Sec)*1000000 + USec.
+    TokensLeft = max(0, Tokens - Size),
+    AdditionalTokensNeeded = max(0, Size - Tokens),
+
+    TimeNeededForTokensToGrow = round(AdditionalTokensNeeded / Shaper#shaper.max_rate * Second),
+    Delay = p1_time_compat:convert_time_unit(TimeNeededForTokensToGrow, native, milli_seconds),
+    LastUpdate = Now + TimeNeededForTokensToGrow,
+
+    lager:debug("Tokens: ~p (+~p,-~p), delay: ~p ms", [TokensLeft, TokenGrowth, Size, Delay]),
+
+    {Shaper#shaper{last_update = LastUpdate, tokens = TokensLeft}, Delay}.

--- a/apps/ejabberd/test/monitored_map_SUITE.erl
+++ b/apps/ejabberd/test/monitored_map_SUITE.erl
@@ -45,7 +45,7 @@ all() ->
 
 no_key_test(_Config) ->
     Map = monitored_map:new(),
-    ?assertError({badkey, key}, monitored_map:get(key, Map)).
+    ?assertError(_, monitored_map:get(key, Map)).
 
 put_monitors_test(_Config) ->
     Map0 = monitored_map:new(),
@@ -62,7 +62,7 @@ remove_test(_Config) ->
     Map0 = monitored_map:new(),
     Map1 = monitored_map:put(key, value, self(), Map0),
     Map2 = monitored_map:remove(key, Map1),
-    ?assertError({badkey, key}, monitored_map:get(key, Map2)),
+    ?assertError(_, monitored_map:get(key, Map2)),
     assert_monitors([]).
 
 expire_entries_on_process_death_test(_Config) ->
@@ -80,9 +80,9 @@ expire_entries_on_process_death_test(_Config) ->
              fun(_, Map) -> receive DownMsg1 -> monitored_map:handle_info(DownMsg1, Map) end end,
              Map1, lists:seq(1, 3)),
 
-    ?assertError({badkey, key1}, monitored_map:get(key1, Map2)),
-    ?assertError({badkey, key2}, monitored_map:get(key2, Map2)),
-    ?assertError({badkey, key3}, monitored_map:get(key3, Map2)),
+    ?assertError(_, monitored_map:get(key1, Map2)),
+    ?assertError(_, monitored_map:get(key2, Map2)),
+    ?assertError(_, monitored_map:get(key3, Map2)),
     ?assertEqual(value4, monitored_map:get(key4, Map2)),
     assert_monitors([Pid3]).
 

--- a/apps/ejabberd/test/monitored_map_SUITE.erl
+++ b/apps/ejabberd/test/monitored_map_SUITE.erl
@@ -1,0 +1,136 @@
+%%==============================================================================
+%% Copyright 2017 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(monitored_map_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     no_key_test,
+     put_monitors_test,
+     get_test,
+     remove_test,
+     expire_entries_on_process_death_test,
+     overwrite_entry_test,
+     overwrite_entry_same_pid_test,
+     find_test,
+     get_default_test,
+     remove_nonexistent_element_test,
+     ignore_nonrelevant_info_test
+    ].
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+no_key_test(_Config) ->
+    Map = monitored_map:new(),
+    ?assertError({badkey, key}, monitored_map:get(key, Map)).
+
+put_monitors_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Pid = new_process(),
+    _Map1 = monitored_map:put(key, value, Pid, Map0),
+    assert_monitors([Pid]).
+
+get_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Map1 = monitored_map:put(key, value, self(), Map0),
+    ?assertEqual(value, monitored_map:get(key, Map1)).
+
+remove_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Map1 = monitored_map:put(key, value, self(), Map0),
+    Map2 = monitored_map:remove(key, Map1),
+    ?assertError({badkey, key}, monitored_map:get(key, Map2)),
+    assert_monitors([]).
+
+expire_entries_on_process_death_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Pid1 = spawn(fun() -> ok end),
+    Pid2 = spawn(fun() -> ok end),
+    Pid3 = new_process(),
+
+    Map1 = lists:foldl(fun({Key, Value, Pid}, M) -> monitored_map:put(Key, Value, Pid, M) end,
+                       Map0, [{key1, value1, Pid1}, {key2, value2, Pid1},
+                              {key3, value3, Pid2}, {key4, value4, Pid3}]),
+
+    %% Receive 3 expiration messages: two from first process, one from second
+    Map2 = lists:foldl(
+             fun(_, Map) -> receive DownMsg1 -> monitored_map:handle_info(DownMsg1, Map) end end,
+             Map1, lists:seq(1, 3)),
+
+    ?assertError({badkey, key1}, monitored_map:get(key1, Map2)),
+    ?assertError({badkey, key2}, monitored_map:get(key2, Map2)),
+    ?assertError({badkey, key3}, monitored_map:get(key3, Map2)),
+    ?assertEqual(value4, monitored_map:get(key4, Map2)),
+    assert_monitors([Pid3]).
+
+overwrite_entry_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Pid = new_process(),
+    Map1 = monitored_map:put(key, value1, self(), Map0),
+    Map2 = monitored_map:put(key, value2, Pid, Map1),
+    ?assertEqual(value2, monitored_map:get(key, Map2)),
+    assert_monitors([Pid]).
+
+overwrite_entry_same_pid_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Map1 = monitored_map:put(key, value1, self(), Map0),
+    Map2 = monitored_map:put(key, value2, self(), Map1),
+    ?assertEqual(value2, monitored_map:get(key, Map2)).
+
+find_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Map1 = monitored_map:put(key, value, self(), Map0),
+    ?assertEqual({ok, value}, monitored_map:find(key, Map1)),
+    ?assertEqual(error, monitored_map:find(key2, Map1)).
+
+get_default_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Map1 = monitored_map:put(key, value, self(), Map0),
+    ?assertEqual(value, monitored_map:get(key, Map1, default_value)),
+    ?assertEqual(default_value, monitored_map:get(key2, Map1, default_value)).
+
+remove_nonexistent_element_test(_Config) ->
+    Map = monitored_map:new(),
+    ?assertEqual(Map, monitored_map:remove(key, Map)).
+
+ignore_nonrelevant_info_test(_Config) ->
+    Map0 = monitored_map:new(),
+    Map1 = monitored_map:put(key, value, self(), Map0),
+    DownMsg = {'DOWN', make_ref(), process, self(), error},
+    ?assertEqual(Map1, monitored_map:handle_info(DownMsg, Map1)),
+    ?assertEqual(Map1, monitored_map:handle_info(any_other_msg, Map1)).
+
+%%--------------------------------------------------------------------
+%% Test helpers
+%%--------------------------------------------------------------------
+
+assert_monitors(Expected) ->
+    {monitors, All} = process_info(self(), monitors),
+    MonitoredPids = [Pid || {process, Pid} <- All],
+    ?assertEqual(ordsets:from_list(Expected), ordsets:from_list(MonitoredPids)).
+
+new_process() ->
+    spawn_link(fun() -> receive Anything -> Anything end end).

--- a/test.disabled/ejabberd_tests/test.config
+++ b/test.disabled/ejabberd_tests/test.config
@@ -168,10 +168,12 @@
 {ejabberd_presets, [
     {internal_mnesia,
      [{sm_backend, "{mnesia, []}"},
-      {auth_method, "internal"}]},
+      {auth_method, "internal"},
+      {mod_offline, "{mod_offline, []},"}]},
     {internal_redis,
      [{sm_backend, "{redis, [{pool_size, 3}, {worker_config, [{host, \"localhost\"}, {port, 6379}]}]}"},
-      {auth_method, "internal"}]},
+      {auth_method, "internal"},
+      {mod_offline, "{mod_offline, []},"}]},
     {pgsql_mnesia,
      [{sm_backend, "{mnesia, []}"},
       {auth_method, "odbc"},
@@ -216,10 +218,12 @@
     {external_mnesia,
      [{sm_backend, "{mnesia, []}"},
       {auth_method, "external"},
-      {ext_auth_script, "{extauth_program, \"priv/sample_external_auth.py\"}"}]},
+      {ext_auth_script, "{extauth_program, \"priv/sample_external_auth.py\"}"},
+      {mod_offline, "{mod_offline, []},"}]},
     {ldap_mnesia,
      [{sm_backend, "{mnesia, []}"},
       {auth_method, "ldap"},
+      {mod_offline, "{mod_offline, []},"},
       {auth_ldap, "{ldap_servers,[\"localhost\"]}.\n"
                   "{ldap_rootdn,\"cn=admin,dc=esl,dc=com\"}.\n"
                   "{ldap_password, \"%ODBC_PASSWORD%\"}.\n"
@@ -246,7 +250,8 @@
     {cassandra_mnesia,
      [{sm_backend, "{mnesia, []}"},
       {cassandra_servers, "{cassandra_servers, [{default, []}]}."},
-      {auth_method, "internal"}
+      {auth_method, "internal"},
+      {mod_offline, "{mod_offline, []},"}
      ]}
 ]}.
 

--- a/test.disabled/ejabberd_tests/tests/sm_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/sm_SUITE.erl
@@ -614,7 +614,7 @@ resume_session_with_wrong_h_does_not_leak_sessions(Config) ->
 
         [] = get_user_resources(AliceSpec),
         [] = get_sid_by_stream_id(SMID),
-        false = escalus_connection:is_connected(Alice)
+        escalus_connection:wait_for_close(Alice, timer:seconds(5))
     end).
 
 resume_session_with_wrong_sid_returns_item_not_found(Config) ->


### PR DESCRIPTION
The previous shaper implementation penalized users for sending
several small packets in burst, causing connection/reconnection
to be greatly delayed. To change this behaviour, this  commit
reimplements the shaper as a token bucket:
https://en.wikipedia.org/wiki/Token_bucket .

The PR also fixes several issues that came to light with un-delaying packets:
* Fixes/reduces severity of stanza racing to SM buffer / mod_offline when recipient "flickers" on and off
  * enables mod_offline for all presets
  * adds `monitored_map` module for recurring usecase of storing data bound to peer-process lifetime
* Splits test for notifying unavailable pubsub subscribers and disables the part that never really worked
* Ensures MUC room won't be routed to after its process stops