### PR TITLE
fix for #1218, with regression test

### DIFF
--- a/apps/ejabberd/test/acc_SUITE.erl
+++ b/apps/ejabberd/test/acc_SUITE.erl
@@ -21,7 +21,8 @@ all() ->
 groups() ->
     [
      {basic, [sequence],
-      [store_and_retrieve, init_from_element, get_and_require ]
+      [store_and_retrieve, init_from_element, get_and_require,
+          parse_with_cdata]
      }
     ].
 
@@ -58,6 +59,11 @@ get_and_require(_C) ->
     ?assertEqual(mongoose_acc:get(xmlns, Acc2), <<"urn:xmpp:blocking">>),
     ok.
 
+parse_with_cdata(_C) ->
+    Acc = mongoose_acc:from_element(stanza_with_cdata()),
+    Acc1 = mongoose_acc:require(xmlns, Acc),
+    ?assertEqual(mongoose_acc:get(xmlns, Acc1), <<"jabber:iq:roster">>).
+
 
 sample_stanza() ->
     {xmlel, <<"iq">>,
@@ -67,5 +73,10 @@ sample_stanza() ->
             [{xmlel, <<"item">>,
                 [{<<"jid">>, <<"bob37.814302@localhost">>}],
                 []}]}]}.
+
+stanza_with_cdata() ->
+    Txt = <<"<iq type=\"get\" id=\"aab9a\"><query xmlns=\"jabber:iq:roster\"/>\" </iq>\">">>,
+    {ok, X} = exml:parse(Txt),
+    X.
 
 


### PR DESCRIPTION
This PR addresses #1218 

Proposed changes include:
* improvement to mongoose_acc:read_children, so that it doesn't try to process cdata, plus stops when it finds xmlns
* test for the fix (failed in the old version)

