### PR TITLE
Pass ServerHost to mod_pubsub's publish_item callback

### DIFF
--- a/apps/ejabberd/src/gen_pubsub_node.erl
+++ b/apps/ejabberd/src/gen_pubsub_node.erl
@@ -110,7 +110,8 @@
     {result, default} |
     {error, xmlel()}.
 
--callback publish_item(NodeId :: nodeIdx(),
+-callback publish_item(ServerHost :: ejabberd:server(),
+        NodeId :: nodeIdx(),
         Publisher :: jid(),
         PublishModel :: publishModel(),
         Max_Items :: non_neg_integer(),

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -2182,7 +2182,7 @@ publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, Access, Publish
                         {error, Reason};
                     false ->
                         node_call(Host, Type, publish_item,
-                                  [Nidx, Publisher, PublishModel, MaxItems, ItemId,
+                                  [ServerHost, Nidx, Publisher, PublishModel, MaxItems, ItemId,
                                    ItemPublisher, Payload, PublishOptions])
                 end
         end,

--- a/apps/ejabberd/src/node_dag.erl
+++ b/apps/ejabberd/src/node_dag.erl
@@ -27,7 +27,7 @@
 -export([init/3, terminate/2, options/0, features/0,
          create_node_permission/6, create_node/2, delete_node/1,
          purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/8, delete_item/4, remove_extra_items/3,
+         publish_item/9, delete_item/4, remove_extra_items/3,
          get_entity_affiliations/2, get_node_affiliations/1,
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -66,7 +66,8 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_hometree:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload, PublishOptions) ->
+publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
+             PublishOptions) ->
     case nodetree_dag:get_node(Nidx) of
         #pubsub_node{options = Options} ->
             case find_opt(node_type, Options) of

--- a/apps/ejabberd/src/node_dag.erl
+++ b/apps/ejabberd/src/node_dag.erl
@@ -66,7 +66,7 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_hometree:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
+publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
              PublishOptions) ->
     case nodetree_dag:get_node(Nidx) of
         #pubsub_node{options = Options} ->
@@ -75,7 +75,7 @@ publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublishe
                     {error,
                         ?ERR_EXTENDED((?ERR_NOT_ALLOWED), <<"publish">>)};
                 _ ->
-                    node_hometree:publish_item(Nidx, Publisher, Model, MaxItems,
+                    node_hometree:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems,
                                                ItemId, ItemPublisher, Payload, PublishOptions)
             end;
         Err -> Err

--- a/apps/ejabberd/src/node_flat.erl
+++ b/apps/ejabberd/src/node_flat.erl
@@ -40,7 +40,7 @@
 -export([init/3, terminate/2, options/0, features/0,
          create_node_permission/6, create_node/2, delete_node/1,
          purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/8, delete_item/4, remove_extra_items/3,
+         publish_item/9, delete_item/4, remove_extra_items/3,
          get_entity_affiliations/2, get_node_affiliations/1,
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -344,7 +344,7 @@ delete_subscriptions(SubKey, Nidx, Subscriptions, SubState) ->
 %%   to completly disable persistance.</li></ul>
 %% </p>
 %% <p>In the default plugin module, the record is unchanged.</p>
-publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, ItemPublisher,
+publish_item(_ServerHost, Nidx, Publisher, PublishModel, MaxItems, ItemId, ItemPublisher,
              Payload, _PublishOptions) ->
     SubKey = jid:to_lower(Publisher),
     GenKey = jid:to_bare(SubKey),

--- a/apps/ejabberd/src/node_hometree.erl
+++ b/apps/ejabberd/src/node_hometree.erl
@@ -35,7 +35,7 @@
 -export([init/3, terminate/2, options/0, features/0,
          create_node_permission/6, create_node/2, delete_node/1,
          purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/8, delete_item/4, remove_extra_items/3,
+         publish_item/9, delete_item/4, remove_extra_items/3,
          get_entity_affiliations/2, get_node_affiliations/1,
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -101,7 +101,8 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload, PublishOptions) ->
+publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
+             PublishOptions) ->
     node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
                            Payload, PublishOptions).
 

--- a/apps/ejabberd/src/node_hometree.erl
+++ b/apps/ejabberd/src/node_hometree.erl
@@ -101,9 +101,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
+publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
              PublishOptions) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
+    node_flat:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
                            Payload, PublishOptions).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->

--- a/apps/ejabberd/src/node_pep.erl
+++ b/apps/ejabberd/src/node_pep.erl
@@ -130,9 +130,9 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
         {result, _} -> {result, []}
     end.
 
-publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
+publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
              PublishOptions) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
+    node_flat:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
                            Payload, PublishOptions).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->

--- a/apps/ejabberd/src/node_pep.erl
+++ b/apps/ejabberd/src/node_pep.erl
@@ -38,7 +38,7 @@
 -export([init/3, terminate/2, options/0, features/0,
          create_node_permission/6, create_node/2, delete_node/1,
          purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/8, delete_item/4, remove_extra_items/3,
+         publish_item/9, delete_item/4, remove_extra_items/3,
          get_entity_affiliations/2, get_node_affiliations/1,
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -130,7 +130,8 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
         {result, _} -> {result, []}
     end.
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload, PublishOptions) ->
+publish_item(_ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
+             PublishOptions) ->
     node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
                            Payload, PublishOptions).
 


### PR DESCRIPTION
This PR fixes `node_push` behaviour when used with multiple virtual hosts. This fix required passing `ServerHost` variable to `publish_item` callback. Without It, it would be possible to fetch from `ets` pubsub's host in form of 'pubsub.somehost.com', but that would require getting the host prefix from configuration in order to strip it before running callback. Therefore passing the original `ServerHost` seemed to be better idea, although it's not as pretty as I would like it to be.