### PR TITLE
Default to 'submit' form type in node_push

### DIFF
--- a/apps/ejabberd/src/node_push.erl
+++ b/apps/ejabberd/src/node_push.erl
@@ -208,7 +208,7 @@ parse_form(undefined) ->
     #{};
 parse_form(Form) ->
     IsForm = ?NS_XDATA == exml_query:attr(Form, <<"xmlns">>),
-    IsSubmit = <<"submit">> == exml_query:attr(Form, <<"type">>),
+    IsSubmit = <<"submit">> == exml_query:attr(Form, <<"type">>, <<"submit">>),
 
     FieldsXML = exml_query:subelements(Form, <<"field">>),
     Fields = [{exml_query:attr(Field, <<"var">>),


### PR DESCRIPTION
This PR makes xform validation in `node_push` less strict. This will allow to process forms that are not valid considering [XEP-0004](https://xmpp.org/extensions/xep-0004.html) standard, but since some examples in [XEP-0357](https://xmpp.org/extensions/xep-0357.html) contain mistake when comes to xfrom `type` attribute, we may need to skip this check to be complaint with some existing clients. 
