### PR TITLE
Improve PubSub coverage + fixes

### DIFF
--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -1174,7 +1174,7 @@ iq_disco_items(Host, <<>>, From, _RSM) ->
                                    false ->
                                        [{<<"jid">>, Host}
                                         | nodeAttr(SubNode)];
-                                   Title ->
+                                   [Title] ->
                                        [{<<"jid">>, Host},
                                         {<<"name">>, Title}
                                         | nodeAttr(SubNode)]
@@ -1207,7 +1207,7 @@ iq_disco_items(Host, Item, From, RSM) ->
                                                                    false ->
                                                                        [{<<"jid">>, Host}
                                                                         | nodeAttr(SubNode)];
-                                                                   Title ->
+                                                                   [Title] ->
                                                                        [{<<"jid">>, Host},
                                                                         {<<"name">>, Title}
                                                                         | nodeAttr(SubNode)]

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -3711,6 +3711,8 @@ get_configure_xfields(_Type, Options, Lang, Groups) ->
                          send_last_published_item, [never, on_sub, on_sub_and_presence]),
      ?BOOL_CONFIG_FIELD(<<"Only deliver notifications to available users">>,
                         presence_based_delivery),
+     ?STRING_CONFIG_FIELD(<<"Specify the type of payload data to be provided at this node">>,
+                          type),
      ?NLIST_CONFIG_FIELD(<<"The collections with which a node is affiliated">>,
                          collection)].
 
@@ -3742,11 +3744,12 @@ set_configure(Host, Node, From, Els, Lang) ->
                                                                end,
                                                      case set_xoption(Host, XData, OldOpts) of
                                                          NewOpts when is_list(NewOpts) ->
+                                                             NewNode = N#pubsub_node{options = NewOpts},
                                                              case tree_call(Host,
                                                                             set_node,
-                                                                            [N#pubsub_node{options = NewOpts}])
+                                                                            [NewNode])
                                                              of
-                                                                 ok -> {result, ok};
+                                                                 ok -> {result, NewNode};
                                                                  Err -> Err
                                                              end;
                                                          Error ->
@@ -3758,7 +3761,7 @@ set_configure(Host, Node, From, Els, Lang) ->
                                      end
                              end,
                     case transaction(Host, Node, Action, transaction) of
-                        {result, {TNode, ok}} ->
+                        {result, {_OldNode, TNode}} ->
                             Nidx = TNode#pubsub_node.id,
                             Type = TNode#pubsub_node.type,
                             Options = TNode#pubsub_node.options,

--- a/rebar.config
+++ b/rebar.config
@@ -85,13 +85,13 @@
                                  {overlay_vars, "rel/vars.config"},
                                  {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]},
              %% development nodes
-             {mim1,    [{relx, [ {overlay_vars, "rel/mim1.vars.config"},
+             {mim1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim1.vars.config"]},
                                  {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]},
-             {mim2,    [{relx, [ {overlay_vars, "rel/mim2.vars.config"},
+             {mim2,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim2.vars.config"]},
                                  {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]},
-             {mim3,    [{relx, [ {overlay_vars, "rel/mim3.vars.config"},
+             {mim3,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim3.vars.config"]},
                                  {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]},
-             {fed1,    [{relx, [ {overlay_vars, "rel/fed1.vars.config"},
+             {fed1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/fed1.vars.config"]},
                                  {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]} ]}.
 
 {plugins,

--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -23,6 +23,9 @@
 {all_metrics_are_global, false}.
 {c2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 {s2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
+
+{normal_shaper_rate, 1000}.
+
 {mongooseim_runner_user, []}.
 {mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.
 {mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -529,7 +529,7 @@
 %%
 %% The "normal" shaper limits traffic speed to 1000 B/s
 %%
-{shaper, normal, {maxrate, 1000}}.
+{shaper, normal, {maxrate, {{normal_shaper_rate}} }}.
 
 %%
 %% The "fast" shaper limits traffic speed to 50000 B/s

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -56,6 +56,9 @@
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
 {c2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 {s2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
+
+{normal_shaper_rate, 5000}.
+
 {mongooseim_runner_user, []}.
 {mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.
 {mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -46,6 +46,9 @@
 {all_metrics_are_global, true}.
 {c2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 {s2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
+
+{normal_shaper_rate, 1000}.
+
 {mongooseim_runner_user, []}.
 {mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.
 {mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -35,6 +35,9 @@
 {all_metrics_are_global, false}.
 {c2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 {s2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
+
+{normal_shaper_rate, 1000}.
+
 {mongooseim_runner_user, []}.
 {mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.
 {mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -48,6 +48,8 @@
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
 
+{normal_shaper_rate, 1000}.
+
 {all_metrics_are_global, "false"}.
 
 %% Defined in Makefile by appending configure.vars.config

--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -11,7 +11,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "d365533"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "9c9fb51"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "new-pubsub-stuff"}}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},

--- a/test.disabled/ejabberd_tests/tests/pubsub_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/pubsub_SUITE.erl
@@ -15,9 +15,11 @@
 
 -import(pubsub_tools,
         [create_node/3,
+         delete_node/3,
          request_configuration/3,
          configure_node/4,
-         delete_node/3,
+         get_affiliations/3,
+         set_affiliations/4,
          subscribe/3,
          unsubscribe/3,
          publish/4,
@@ -26,10 +28,15 @@
          purge_all_items/3,
          retrieve_user_subscriptions/3,
          retrieve_node_subscriptions/3,
+         submit_subscription_response/5,
+         request_pending_subscriptions/3,
+         request_pending_subscriptions/4,
          modify_node_subscriptions/4,
          discover_nodes/3,
          receive_item_notification/4,
          receive_subscription_notification/4,
+         receive_subscription_request/4,
+         receive_subscription_requests/4,
          receive_node_creation_notification/3,
          receive_subscribe_response/3]).
 
@@ -40,9 +47,12 @@
 all() -> [
           {group, pubsub_tests},
           {group, node_config_tests},
+          {group, service_config_tests},
+          {group, node_affiliations_tests},
           {group, manage_subscriptions_tests},
           {group, collection_tests},
-          {group, collection_config_tests}
+          {group, collection_config_tests},
+          {group, debug_calls_tests}
          ].
 
 groups() -> [{pubsub_tests, [parallel],
@@ -72,10 +82,25 @@ groups() -> [{pubsub_tests, [parallel],
                send_last_published_item_test
               ]
              },
+             {service_config_tests, [parallel],
+              [
+               max_subscriptions_test
+              ]
+             },
+             {node_affiliations_tests, [parallel],
+              [
+               get_affiliations_test,
+               add_publisher_and_member_test,
+               swap_owners_test,
+               deny_no_owner_test
+              ]
+             },
              {manage_subscriptions_tests, [parallel],
               [
                retrieve_node_subscriptions_test,
-               modify_node_subscriptions_test
+               modify_node_subscriptions_test,
+               process_subscription_requests_test,
+               retrieve_pending_subscription_requests_test
               ]
              },
              {collection_tests, [parallel],
@@ -99,6 +124,11 @@ groups() -> [{pubsub_tests, [parallel],
                disable_notifications_leaf_test,
                disable_payload_leaf_test,
                disable_persist_items_leaf_test
+              ]
+             },
+             {debug_calls_tests, [parallel],
+              [
+               debug_get_items_test
               ]
              }
             ].
@@ -143,11 +173,19 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, _Config) ->
     ok.
 
+init_per_testcase(max_subscriptions_test, Config) ->
+    MaxSubs = lookup_service_option(domain(), max_subscriptions_node),
+    set_service_option(domain(), max_subscriptions_node, 1),
+    init_per_testcase(generic, [{max_subscriptions_node, MaxSubs} | Config]);
 init_per_testcase(_TestName, Config) ->
     escalus:init_per_testcase(_TestName, Config).
 
-end_per_testcase(_TestName, Config) ->
-    escalus:end_per_testcase(_TestName, Config).
+end_per_testcase(max_subscriptions_test, Config1) ->
+    {value, {_, OldMaxSubs}, Config2} = lists:keytake(max_subscriptions_node, 1, Config1),
+    set_service_option(domain(), max_subscriptions_node, OldMaxSubs),
+    end_per_testcase(generic, Config2);
+end_per_testcase(TestName, Config) ->
+    escalus:end_per_testcase(TestName, Config).
 
 %%--------------------------------------------------------------------
 %% Test cases for XEP-0060
@@ -262,7 +300,12 @@ notify_test(Config) ->
       [{alice, 1}, {bob, 2}, {geralt, 2}],
       fun(Alice, Bob1, Bob2, Geralt1, Geralt2) ->
               Node = pubsub_node(),
-              create_node(Alice, Node, []),
+
+              % It's a quick win for confirming happy path for this option
+              % TODO: Extract into separate test case
+              NodeConfig = [{<<"pubsub#presence_based_delivery">>, <<"1">>}],
+
+              create_node(Alice, Node, [{config, NodeConfig}]),
               subscribe(Bob1, Node, []),
               subscribe(Geralt1, Node, [{jid_type, bare}]),
               publish(Alice, <<"item1">>, Node, []),
@@ -380,7 +423,7 @@ retrieve_subscriptions_test(Config) ->
               %% Response:     Ex.22 No Subscriptions
               retrieve_user_subscriptions(Bob, node_addr(), [{expected_result, []}]),
 
-              {_, NodeName} = {_, NodeName} = Node = pubsub_node(),
+              {_, NodeName} = Node = pubsub_node(),
               create_node(Alice, Node, []),
               subscribe(Bob, Node, []),
 
@@ -566,6 +609,102 @@ send_last_published_item_test(Config) ->
       end).
 
 %%--------------------------------------------------------------------
+%% Service config
+%%--------------------------------------------------------------------
+
+max_subscriptions_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {bob, 1}],
+      fun(Alice, Bob) ->
+              Node = pubsub_node(),
+              create_node(Alice, Node, []),
+
+              subscribe(Alice, Node, []),
+              IQError = subscribe(Bob, Node, [{expected_error_type, <<"cancel">>}]),
+              is_not_allowed_and_closed(IQError),
+
+              delete_node(Alice, Node, [])
+      end).
+
+%%--------------------------------------------------------------------
+%% Node affiliations management
+%%--------------------------------------------------------------------
+
+get_affiliations_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}],
+      fun(Alice) ->
+              Node = pubsub_node(),
+              create_node(Alice, Node, []),
+
+              verify_affiliations(get_affiliations(Alice, Node, []), [{Alice, <<"owner">>}]),
+
+              delete_node(Alice, Node, [])
+      end).
+
+add_publisher_and_member_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {bob, 1}, {kate, 1}],
+      fun(Alice, Bob, Kate) ->
+              Node = pubsub_node(),
+              NodeConfig = [{<<"pubsub#access_model">>, <<"whitelist">>},
+                            {<<"pubsub#publish_model">>, <<"publishers">>}],
+              create_node(Alice, Node, [{config, NodeConfig}]),
+
+              publish(Bob, <<"item1">>, Node, [{expected_error_type, <<"auth">>}]),
+              IQError = subscribe(Kate, Node, [{expected_error_type, <<"cancel">>}]),
+              is_not_allowed_and_closed(IQError),
+
+              AffChange = [{Bob, <<"publisher">>}, {Kate, <<"member">>}],
+              set_affiliations(Alice, Node, AffChange, []),
+
+              publish(Kate, <<"nope">>, Node, [{expected_error_type, <<"auth">>}]),
+              subscribe(Kate, Node, []),
+              publish(Bob, <<"item1">>, Node, []),
+              receive_item_notification(Kate, <<"item1">>, Node, []),
+
+              delete_node(Alice, Node, [])
+      end).
+
+swap_owners_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {bob, 1}],
+      fun(Alice, Bob) ->
+              Node = pubsub_node(),
+              create_node(Alice, Node, []),
+
+              AffChange = [{Bob, <<"owner">>}, {Alice, <<"none">>}],
+              set_affiliations(Alice, Node, AffChange, []),
+
+              get_affiliations(Alice, Node, [{expected_error_type, <<"auth">>}]),
+              verify_affiliations(get_affiliations(Bob, Node, []), [{Bob, <<"owner">>}]),
+
+              delete_node(Bob, Node, [])
+      end).
+
+deny_no_owner_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}],
+      fun(Alice) ->
+              Node = pubsub_node(),
+              create_node(Alice, Node, []),
+
+              AffChange = [{Alice, <<"member">>}],
+              IQError = set_affiliations(Alice, Node, AffChange,
+                                         [{expected_error_type, <<"modify">>}]),
+              verify_returned_affiliation(IQError, Alice, <<"owner">>),
+
+              verify_affiliations(get_affiliations(Alice, Node, []), [{Alice, <<"owner">>}]),
+
+              delete_node(Alice, Node, [])
+      end).
+
+%%--------------------------------------------------------------------
 %% Subscriptions management
 %%--------------------------------------------------------------------
 
@@ -626,6 +765,57 @@ modify_node_subscriptions_test(Config) ->
 
               ModSubs = [{Geralt, bare, <<"subscribed">>}, {Geralt, full, <<"subscribed">>}],
               retrieve_node_subscriptions(Alice, Node, [{expected_result, ModSubs}]),
+
+              delete_node(Alice, Node, [])
+      end).
+
+process_subscription_requests_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {bob, 1}, {kate, 1}],
+      fun(Alice, Bob, Kate) ->
+              Node = pubsub_node(),
+              NodeConfig = [{<<"pubsub#access_model">>, <<"authorize">>}],
+              create_node(Alice, Node, [{config, NodeConfig}]),
+
+              subscribe(Bob, Node, [{subscription, <<"pending">>}]),
+              BobsRequest = receive_subscription_request(Alice, Bob, Node, []),
+              subscribe(Kate, Node, [{subscription, <<"pending">>}]),
+              KatesRequest = receive_subscription_request(Alice, Kate, Node, []),
+
+              submit_subscription_response(Alice, BobsRequest, Node, true, []),
+              receive_subscription_notification(Bob, <<"subscribed">>, Node, []),
+              submit_subscription_response(Alice, KatesRequest, Node, false, []),
+              receive_subscription_notification(Kate, <<"none">>, Node, []),
+
+              publish(Alice, <<"item1">>, Node, []),
+              receive_item_notification(Bob, <<"item1">>, Node, []),
+              [] = escalus:peek_stanzas(Kate),
+
+              delete_node(Alice, Node, [])
+      end).
+
+retrieve_pending_subscription_requests_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {bob, 1}, {kate, 1}],
+      fun(Alice, Bob, Kate) ->
+              {NodeAddr, NodeName} = Node = pubsub_node(),
+              NodeConfig = [{<<"pubsub#access_model">>, <<"authorize">>}],
+              create_node(Alice, Node, [{config, NodeConfig}]),
+
+              subscribe(Bob, Node, [{subscription, <<"pending">>}]),
+              receive_subscription_request(Alice, Bob, Node, []),
+              subscribe(Kate, Node, [{subscription, <<"pending">>}]),
+              receive_subscription_request(Alice, Kate, Node, []),
+
+              request_pending_subscriptions(Alice, NodeAddr, [NodeName], []),
+
+              %% TODO: XEP requires IQ result to come before the requests
+              Request = request_pending_subscriptions(Alice, Node, [{receive_response, false}]),
+              receive_subscription_requests(Alice, [Bob, Kate], Node, []),
+              IQRes = escalus:wait_for_stanza(Alice),
+              escalus:assert(is_iq_result, [Request], IQRes),
 
               delete_node(Alice, Node, [])
       end).
@@ -1010,6 +1200,27 @@ disable_persist_items_leaf_test(Config) ->
       end).
 
 %%--------------------------------------------------------------------
+%% Debug calls tests
+%%--------------------------------------------------------------------
+
+debug_get_items_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}],
+      fun(Alice) ->
+              {NodeAddr, NodeName} = Node = pubsub_node(),
+              create_node(Alice, Node, []),
+              publish(Alice, <<"item1">>, Node, []),
+              publish(Alice, <<"item2">>, Node, []),
+
+              Items = escalus_ejabberd:rpc(mod_pubsub, get_items, [NodeAddr, NodeName]),
+              % We won't bother with importing records etc...
+              2 = length(Items),
+
+              delete_node(Alice, Node, [])
+      end).
+
+%%--------------------------------------------------------------------
 %% Tests for unsupported features  - excluded from suite
 %%--------------------------------------------------------------------
 
@@ -1144,4 +1355,39 @@ verify_config_values(NodeConfig, ValidConfig) ->
     lists:foreach(fun({Var, Val}) ->
                           {{_, _, Val}, _} = {lists:keyfind(Var, 1, NodeConfig), Var}
                   end, ValidConfig).
+
+verify_affiliations(Affiliations, ValidAffiliations) ->
+    NormalisedValidAffiliations
+    = lists:sort([ {escalus_utils:jid_to_lower(escalus_client:short_jid(Client)), Aff}
+                   || {Client, Aff} <- ValidAffiliations ]),
+    NormalisedValidAffiliations = lists:sort(Affiliations).
+
+verify_returned_affiliation(IQError, User, Aff) ->
+    UserJid = escalus_utils:jid_to_lower(escalus_utils:get_short_jid(User)),
+    QPath = [{element, <<"pubsub">>},
+             {element, <<"affiliations">>},
+             {element, <<"affiliation">>}],
+    [AffEl] = exml_query:paths(IQError, QPath),
+    UserJid = exml_query:attr(AffEl, <<"jid">>),
+    Aff = exml_query:attr(AffEl, <<"affiliation">>).
+
+is_not_allowed_and_closed(IQError) ->
+    ?NS_STANZA_ERRORS = exml_query:path(IQError, [{element, <<"error">>},
+                                                  {element, <<"not-allowed">>},
+                                                  {attr, <<"xmlns">>}]),
+    ?NS_PUBSUB_ERRORS = exml_query:path(IQError, [{element, <<"error">>},
+                                                  {element, <<"closed-node">>},
+                                                  {attr, <<"xmlns">>}]).
+
+%% TODO: Functions below will most probably fail when mod_pubsub gets some nice refactoring!
+
+set_service_option(Host, Key, Val) ->
+    true = escalus_ejabberd:rpc(ets, insert, [service_tab_name(Host), {Key, Val}]).
+
+lookup_service_option(Host, Key) ->
+    [{_, Val}] = escalus_ejabberd:rpc(ets, lookup, [service_tab_name(Host), Key]),
+    Val.
+
+service_tab_name(Host) ->
+    escalus_ejabberd:rpc(gen_mod, get_module_proc, [Host, config]).
 

--- a/test.disabled/ejabberd_tests/tests/pubsub_tools.erl
+++ b/test.disabled/ejabberd_tests/tests/pubsub_tools.erl
@@ -16,9 +16,11 @@
 
 %% Send request, receive (optional) response
 -export([create_node/3,
+         delete_node/3,
          request_configuration/3,
          configure_node/4,
-         delete_node/3,
+         get_affiliations/3,
+         set_affiliations/4,
          subscribe/3,
          unsubscribe/3,
          publish/4,
@@ -27,12 +29,17 @@
          purge_all_items/3,
          retrieve_user_subscriptions/3,
          retrieve_node_subscriptions/3,
+         submit_subscription_response/5,
+         request_pending_subscriptions/3,
+         request_pending_subscriptions/4,
          modify_node_subscriptions/4,
          discover_nodes/3]).
 
 %% Receive notification or response
 -export([receive_item_notification/4,
          receive_subscription_notification/4,
+         receive_subscription_request/4,
+         receive_subscription_requests/4,
          receive_node_creation_notification/3,
          receive_subscribe_response/3,
          receive_unsubscribe_response/3]).
@@ -63,6 +70,11 @@ create_node(User, Node, Options) ->
 
     send_request_and_receive_response(User, Request, Id, Options).
 
+delete_node(User, Node, Options) ->
+    Id = id(User, Node, <<"delete_node">>),
+    Request = escalus_pubsub_stanza:delete_node(User, Id, Node),
+    send_request_and_receive_response(User, Request, Id, Options).
+
 request_configuration(User, Node, Options) ->
     Id = id(User, Node, <<"get_config">>),
     Request = escalus_pubsub_stanza:request_configuration(User, Id, Node),
@@ -73,9 +85,14 @@ configure_node(User, Node, Config, Options) ->
     Request = escalus_pubsub_stanza:configure_node(User, Id, Node, Config),
     send_request_and_receive_response(User, Request, Id, Options).
 
-delete_node(User, Node, Options) ->
-    Id = id(User, Node, <<"delete_node">>),
-    Request = escalus_pubsub_stanza:delete_node(User, Id, Node),
+get_affiliations(User, Node, Options) ->
+    Id = id(User, Node, <<"get_config">>),
+    Request = escalus_pubsub_stanza:request_affiliations(User, Id, Node),
+    decode_affiliations(send_request_and_receive_response(User, Request, Id, Options)).
+
+set_affiliations(User, Node, AffChange, Options) ->
+    Id = id(User, Node, <<"set_affiliations">>),
+    Request = escalus_pubsub_stanza:set_affiliations(User, Id, Node, AffChange),
     send_request_and_receive_response(User, Request, Id, Options).
 
 subscribe(User, Node, Options) ->
@@ -142,6 +159,24 @@ retrieve_node_subscriptions(User, Node, Options) ->
               check_node_subscriptions_response(Response, ExpectedResult, Node)
       end).
 
+submit_subscription_response(User, {MsgId, SubForm}, Node, Allow, Options) ->
+    Key = <<"pubsub#allow">>,
+    NewSubForm = lists:keyreplace(Key, 1, SubForm, {Key, <<"boolean">>, bool2bin(Allow)}),
+    Request = escalus_pubsub_stanza:submit_subscription_response(User, MsgId, Node, NewSubForm),
+    send_request_and_receive_response(User, Request, MsgId, [{receive_response, false} | Options]).
+
+request_pending_subscriptions(User, Node, Options) ->
+    Id = id(User, Node, <<"request_pending_subscriptions">>),
+    Request = escalus_pubsub_stanza:request_pending_subscriptions(User, Id, Node),
+    send_request_and_receive_response(User, Request, Id, Options),
+    Request.
+
+request_pending_subscriptions(User, NodesAddr, NodeNames, Options) ->
+    Id = id(User, {<<>>, <<>>}, <<"request_pending_subscriptions">>),
+    Request = escalus_pubsub_stanza:request_pending_subscriptions(User, Id, NodesAddr),
+    Response = send_request_and_receive_response(User, Request, Id, Options),
+    check_pending_subscriptions(Response, NodeNames).
+
 modify_node_subscriptions(User, ModifiedSubscriptions, Node, Options) ->
     Id = id(User, Node, <<"modify_node_subs">>),
     Subs = fill_subscriptions_jids(ModifiedSubscriptions),
@@ -177,6 +212,24 @@ receive_subscription_notification(User, Subscription, {NodeAddr, NodeName}, Opti
     Stanza = receive_notification(User, NodeAddr, Options),
     check_subscription_notification(User, Stanza, Subscription, NodeName, Options).
 
+receive_subscription_request(User, Requester, {NodeAddr, NodeName}, Options) ->
+    Stanza = receive_notification(User, NodeAddr, Options),
+    check_subscription_request(Stanza, Requester, NodeName, Options).
+
+receive_subscription_requests(User, Requesters, {NodeAddr, NodeName}, Options) ->
+    Stanzas = [ receive_notification(User, NodeAddr, Options) || _ <- Requesters ],
+
+    true =
+    lists:all(
+      fun(Requester) ->
+              lists:any(
+                fun(Stanza) ->
+                        element(1, catch check_subscription_request(
+                                           Stanza, Requester, NodeName, Options))
+                        =/= 'EXIT'
+                end, Stanzas)
+      end, Requesters).
+
 receive_node_creation_notification(User, {NodeAddr, NodeName}, Options) ->
     Stanza = receive_notification(User, NodeAddr, Options),
     check_node_creation_notification(Stanza, NodeName).
@@ -200,7 +253,7 @@ check_subscription_response(Response, User, {_, NodeName}, Options) ->
     Jid = jid(User, proplists:get_value(jid_type, Options, full)),
     Subscription = exml_query:path(Response, [{element, <<"pubsub">>},
                                               {element, <<"subscription">>}]),
-    check_subscription(Subscription, Jid, NodeName),
+    check_subscription(Subscription, Jid, NodeName, Options),
     Response.
 
 check_user_subscriptions_response(User, Response, ExpectedSubscriptions) ->
@@ -243,13 +296,38 @@ check_node_discovery_response(Response, {NodeAddr, NodeName}, ExpectedNodes) ->
     Response.
 
 check_subscription_notification(User, Response, Subscription, NodeName, Options) ->
-    SubscriptionElem = exml_query:path(Response, [{element, <<"pubsub">>},
-                                                {element, <<"subscription">>}]),
+    SubEl =
+    case exml_query:subelement(Response, <<"pubsub">>) of
+        undefined -> exml_query:subelement(Response, <<"event">>);
+        PubSubElem -> PubSubElem
+    end,
+    SubscriptionElem = exml_query:subelement(SubEl, <<"subscription">>),
     Jid = jid(User, proplists:get_value(jid_type, Options, full)),
     assert_ljid_equal(Jid, exml_query:attr(SubscriptionElem, <<"jid">>)),
     Subscription = exml_query:attr(SubscriptionElem, <<"subscription">>),
     NodeName = exml_query:attr(SubscriptionElem, <<"node">>),
     Response.
+
+check_subscription_request(Stanza, Requester, NodeName, Options) ->
+    DecodedForm =
+    [ decode_form_field(F)
+      || F <- exml_query:paths(Stanza, [{element, <<"x">>}, {element, <<"field">>}]) ],
+    
+    RequesterJid = escalus_utils:jid_to_lower(
+                     jid(Requester, proplists:get_value(jid_type, Options, full))),
+    {_, _, RequesterJid} = lists:keyfind(<<"pubsub#subscriber_jid">>, 1, DecodedForm),
+
+    {_, _, NodeName} = lists:keyfind(<<"pubsub#node">>, 1, DecodedForm),
+
+    {exml_query:attr(Stanza, <<"id">>), DecodedForm}.
+
+check_pending_subscriptions(Stanza, Nodes) ->
+    RetrievedNodes =
+    exml_query:paths(Stanza, [{element, <<"command">>}, {element, <<"x">>}, {element, <<"field">>},
+                              {element, <<"option">>}, {element, <<"value">>}, cdata]),
+
+    SortedNodes = lists:sort(Nodes),
+    SortedNodes = lists:sort(RetrievedNodes).
 
 check_node_creation_notification(Response, NodeName) ->
     NodeName = exml_query:path(Response, [{element, <<"event">>},
@@ -327,11 +405,16 @@ receive_stanza(User, Options) ->
             Stanza
     end.
 
-check_subscription(Subscr, Jid, NodeName) ->
+check_subscription(Subscr, Jid, NodeName, Options) ->
     assert_ljid_equal(Jid, exml_query:attr(Subscr, <<"jid">>)),
     NodeName = exml_query:attr(Subscr, <<"node">>),
-    true = exml_query:attr(Subscr, <<"subid">>) =/= undefined,
-    <<"subscribed">> = exml_query:attr(Subscr, <<"subscription">>).
+    case proplists:get_value(subscription, Options) of
+        undefined ->
+            true = exml_query:attr(Subscr, <<"subid">>) =/= undefined,
+            <<"subscribed">> = exml_query:attr(Subscr, <<"subscription">>);
+        <<"pending">> ->
+            <<"pending">> = exml_query:attr(Subscr, <<"subscription">>)
+    end.
 
 check_items(ReceivedItemsElem, ExpectedItemIds, NodeName, WithPayload) ->
     NodeName = exml_query:attr(ReceivedItemsElem, <<"node">>),
@@ -346,6 +429,9 @@ check_item(ExpectedItemId, WithPayload, ReceivedItem) ->
 
 item_content(false) -> undefined;
 item_content(true) -> item_content().
+
+bool2bin(true) -> <<"true">>;
+bool2bin(false) -> <<"false">>.
 
 convert_subscriptions_to_ljids(Subscriptions) ->
     [{escalus_utils:jid_to_lower(Jid), Sub} || {Jid, Sub} <- Subscriptions].
@@ -374,13 +460,22 @@ decode_config_form(IQResult) ->
 
     QPath = [{element, <<"configure">>}, {element, <<"x">>}, {element, <<"field">>}],
     Fields = exml_query:paths(PubSubNode, QPath),
-    lists:map(fun decode_config_field/1, Fields).
+    lists:map(fun decode_form_field/1, Fields).
 
-decode_config_field(F) ->
+decode_form_field(F) ->
     Var = exml_query:attr(F, <<"var">>),
     Type = exml_query:attr(F, <<"type">>),
     case exml_query:paths(F, [{element, <<"value">>}, cdata]) of
         [Value] -> {Var, Type, Value};
         Values -> {Var, Type, Values}
     end.
+
+decode_affiliations(IQResult) ->
+    PubSubNode = exml_query:subelement(IQResult, <<"pubsub">>),
+    ?NS_PUBSUB_OWNER = exml_query:attr(PubSubNode, <<"xmlns">>),
+
+    QPath = [{element, <<"affiliations">>}, {element, <<"affiliation">>}],
+    Fields = exml_query:paths(PubSubNode, QPath),
+
+    [ {exml_query:attr(F, <<"jid">>), exml_query:attr(F, <<"affiliation">>)} || F <- Fields ].
 


### PR DESCRIPTION
This PR adds more tests to `pubsub_SUITE` and `pep_SUITE` to cover `mod_pubsub` parts that have to be refactored, according to Elvis. The goal was not to reach 100% coverage of these fragments but to ensure that these use cases simply work (like getting affiliations list).

The checklist of these fragments and new test scenarios can be found in internal doc.

**TODO:** Refactor tests, as they are a bit ugly now. This PR is meant for early review and to check coverage improvement with coveralls.
