### PR TITLE
Eradicate now() calls

### DIFF
--- a/apps/ejabberd/src/cyrsasl_anonymous.erl
+++ b/apps/ejabberd/src/cyrsasl_anonymous.erl
@@ -42,14 +42,15 @@ stop() ->
 
 -spec mech_new(Host :: ejabberd:server(),
                Creds :: mongoose_credentials:t()) -> {ok, tuple()}.
-mech_new(Host, Creds) ->
+mech_new(_Host, Creds) ->
     {ok, #state{creds = Creds}}.
 
 -spec mech_step(State :: tuple(), ClientIn :: binary()) -> R when
       R :: {ok, mongoose_credentials:t()} | {error, binary()}.
 mech_step(#state{creds = Creds}, _ClientIn) ->
     %% We generate a random username:
-    User = list_to_binary(lists:concat([randoms:get_string() | tuple_to_list(now())])),
+    User = <<(list_to_binary(randoms:get_string()))/binary,
+             (integer_to_binary(p1_time_compat:unique_integer([positive])))/binary>>,
     %% Checks that the username is available
     case ejabberd_auth:is_user_exists(User, mongoose_credentials:lserver(Creds)) of
         true  -> {error, <<"not-authorized">>};

--- a/apps/ejabberd/src/ejabberd_auth_external.erl
+++ b/apps/ejabberd/src/ejabberd_auth_external.erl
@@ -359,7 +359,7 @@ set_password_internal(LUser, LServer, Password) ->
 -spec is_fresh_enough(TimeLast :: integer(),
                       CacheTime :: integer()) -> boolean().
 is_fresh_enough(TimeStampLast, CacheTime) ->
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = p1_time_compat:timestamp(),
     Now = MegaSecs * 1000000 + Secs,
     (TimeStampLast + CacheTime > Now).
 

--- a/apps/ejabberd/src/ejabberd_config.erl
+++ b/apps/ejabberd/src/ejabberd_config.erl
@@ -154,7 +154,7 @@ start() ->
     Config = get_ejabberd_config_path(),
     ejabberd_config:load_file(Config),
     %% This start time is used by mod_last:
-    add_local_option(node_start, now()),
+    add_local_option(node_start, p1_time_compat:timestamp()),
     ok.
 
 

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -1111,8 +1111,7 @@ get_addr_port(Server) ->
         {ok, #hostent{h_addr_list = AddrList}} ->
             %% Probabilities are not exactly proportional to weights
             %% for simplicity (higher weigths are overvalued)
-            {A1, A2, A3} = now(),
-            random:seed(A1, A2, A3),
+            random:seed(randoms:good_seed()),
             case (catch lists:map(
                           fun({Priority, Weight, Port, Host}) ->
                                   N = case Weight of
@@ -1286,7 +1285,7 @@ wait_before_reconnect(StateData) ->
                 undefined_delay ->
                     %% The initial delay is random between 1 and 15 seconds
                     %% Return a random integer between 1000 and 15000
-                    {_, _, MicroSecs} = now(),
+                    {_, _, MicroSecs} = p1_time_compat:timestamp(),
                     (MicroSecs rem 14000) + 1000;
                 D1 ->
                     %% Duplicate the delay with each successive failed

--- a/apps/ejabberd/src/extauth.erl
+++ b/apps/ejabberd/src/extauth.erl
@@ -134,8 +134,7 @@ call_port(Server, Msg) ->
 
 -spec random_instance(pos_integer()) -> non_neg_integer().
 random_instance(MaxNum) ->
-    {A1, A2, A3} = now(),
-    random:seed(A1, A2, A3),
+    random:seed(randoms:good_seed()),
     random:uniform(MaxNum) - 1.
 
 

--- a/apps/ejabberd/src/gen_iq_handler.erl
+++ b/apps/ejabberd/src/gen_iq_handler.erl
@@ -125,7 +125,7 @@ handle(Host, Module, Function, Opts, From, To, IQ) ->
         {one_queue, Pid} ->
             Pid ! {process_iq, From, To, IQ};
         {queues, Pids} ->
-            Pid = lists:nth(erlang:phash(now(), length(Pids)), Pids),
+            Pid = lists:nth(erlang:phash(p1_time_compat:unique_integer(), length(Pids)), Pids),
             Pid ! {process_iq, From, To, IQ};
         parallel ->
             spawn(?MODULE, process_iq, [Host, Module, Function, From, To, IQ]);

--- a/apps/ejabberd/src/mod_admin_extra_accounts.erl
+++ b/apps/ejabberd/src/mod_admin_extra_accounts.erl
@@ -170,7 +170,7 @@ get_sha(AccountPass) ->
 
 -spec num_active_users(ejabberd:server(), integer()) -> non_neg_integer().
 num_active_users(Host, Days) ->
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = p1_time_compat:timestamp(),
     TimeStamp = MegaSecs * 1000000 + Secs,
     TS = TimeStamp - Days * 86400,
     case catch mod_last:count_active_users(Host, TS) of
@@ -206,7 +206,7 @@ delete_old_users(Days, Users) ->
     SecOlder = Days*24*60*60,
 
     %% Get current time
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = p1_time_compat:timestamp(),
     TimeStampNow = MegaSecs * 1000000 + Secs,
 
     %% Apply the remove function to every user in the list

--- a/apps/ejabberd/src/mod_bosh.erl
+++ b/apps/ejabberd/src/mod_bosh.erl
@@ -346,8 +346,7 @@ store_session(Sid, Socket) ->
 
 -spec make_sid() -> binary().
 make_sid() ->
-    %% TODO: now() skews system timer and ref() is unique enough as is
-    sha:sha1_hex(term_to_binary({now(), make_ref()})).
+    sha:sha1_hex(term_to_binary(make_ref())).
 
 %%--------------------------------------------------------------------
 %% HTTP errors

--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -549,10 +549,8 @@ maybe_trim_cache(Ack, S) ->
 schedule_report(Ack, #state{sent = Sent} = S) ->
     ReportRid = Ack + 1,
     try
-        {resp,
-         {ReportRid, TimeSent, _}} = {resp, lists:keyfind(ReportRid, 1, Sent)},
-        ElapsedTimeMillis = erlang:round(timer:now_diff(now(), TimeSent)
-                                         / 1000),
+        {ReportRid, TimeSent, _} = lists:keyfind(ReportRid, 1, Sent),
+        ElapsedTimeMillis = p1_time_compat:monotonic_time(milli_seconds) - TimeSent,
         Report = {ReportRid, ElapsedTimeMillis},
         case S#state.report of
             false ->
@@ -667,7 +665,7 @@ send_to_handler({_, Pid}, #xmlel{name = <<"body">>} = Wrapped, State) ->
     send_wrapped_to_handler(Pid, Wrapped, State);
 send_to_handler({Rid, Pid}, Data, State) ->
     {Wrapped, NS} = bosh_wrap(Data, Rid, State),
-    NS2 = cache_response({Rid, now(), Wrapped}, NS),
+    NS2 = cache_response({Rid, p1_time_compat:monotonic_time(milli_seconds), Wrapped}, NS),
     send_wrapped_to_handler(Pid, Wrapped, NS2).
 
 

--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -50,7 +50,7 @@
 -define(DEFAULT_MAXPAUSE, 120).
 -define(DEFAULT_CLIENT_ACKS, false).
 
--type cached_response() :: {rid(), erlang:timestamp(), jlib:xmlel()}.
+-type cached_response() :: {rid(), TStamp :: integer(), jlib:xmlel()}.
 -type rid() :: pos_integer().
 
 -record(state, {from            :: binary() | undefined,
@@ -465,10 +465,7 @@ maybe_diff(_, undefined) -> undefined;
 maybe_diff(Rid, Expected) -> abs(Rid-Expected).
 
 
--spec resend_cached({Rid :: pos_integer(),
-                     {non_neg_integer(), non_neg_integer(), non_neg_integer()},
-                     CachedBody :: jlib:xmlel()},
-                    state()) -> state().
+-spec resend_cached(cached_response(), state()) -> state().
 resend_cached({_Rid, _, CachedBody}, S) ->
     send_to_handler(CachedBody, S).
 
@@ -703,7 +700,7 @@ maybe_report(#state{report = Report} = S) ->
     {NewAttrs, S#state{report = false}}.
 
 
--spec cache_response({rid(), erlang:timestamp(), jlib:xmlel()}, state()) -> state().
+-spec cache_response(cached_response(), state()) -> state().
 cache_response({Rid, _, _} = Response, #state{sent = Sent} = S) ->
     NewSent = lists:keymerge(1, [Response], Sent),
     CacheUpTo = case S#state.client_acks of

--- a/apps/ejabberd/src/mod_commands.erl
+++ b/apps/ejabberd/src/mod_commands.erl
@@ -202,7 +202,7 @@ get_recent_messages(Caller, Before, Limit) ->
     get_recent_messages(Caller, undefined, Before, Limit).
 
 get_recent_messages(Caller, With, 0, Limit) ->
-    {MegaSecs, Secs, _} = now(),
+    {MegaSecs, Secs, _} = os:timestamp(),
     Future = (MegaSecs + 1) * 1000000 + Secs, % to make sure we return all messages
     get_recent_messages(Caller, With, Future, Limit);
 get_recent_messages(Caller, With, Before, Limit) ->

--- a/apps/ejabberd/src/mod_last.erl
+++ b/apps/ejabberd/src/mod_last.erl
@@ -131,7 +131,7 @@ process_local_iq(_From, _To,
 get_node_uptime() ->
     case ejabberd_config:get_local_option(node_start) of
         {_, _, _} = StartNow ->
-            now_to_seconds(now()) - now_to_seconds(StartNow);
+            now_to_seconds(p1_time_compat:timestamp()) - now_to_seconds(StartNow);
         _Undefined ->
             trunc(element(1, erlang:statistics(wall_clock))/1000)
     end.
@@ -189,7 +189,7 @@ make_response(IQ, SubEl, LUser, LServer, allow) ->
                     IQ#iq{type = error,
                         sub_el = [SubEl, ?ERR_SERVICE_UNAVAILABLE]};
                 {ok, TimeStamp, Status} ->
-                    TimeStamp2 = now_to_seconds(now()),
+                    TimeStamp2 = now_to_seconds(p1_time_compat:timestamp()),
                     Sec = TimeStamp2 - TimeStamp,
                     IQ#iq{type = result,
                         sub_el =
@@ -220,7 +220,7 @@ count_active_users(LServer, Timestamp) ->
 -spec on_presence_update(map(), ejabberd:user(), ejabberd:server(), ejabberd:resource(),
                          Status :: binary()) -> map() | {error, term()}.
 on_presence_update(Acc, LUser, LServer, _Resource, Status) ->
-    TimeStamp = now_to_seconds(os:timestamp()),
+    TimeStamp = now_to_seconds(p1_time_compat:timestamp()),
     case store_last_info(LUser, LServer, TimeStamp, Status) of
         ok -> Acc;
         E -> E

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -22,7 +22,7 @@
 %%% Message identifiers (or UIDs in the spec) are generated based on:
 %%%
 %%% <ul>
-%%% <li>date (using `now()');</li>
+%%% <li>date (using `timestamp()');</li>
 %%% <li>node number (using {@link ejabberd_node_id}).</li>
 %%% </ul>
 %%% @end

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -22,7 +22,7 @@
 %%% Message identifiers (or UIDs in the spec) are generated based on:
 %%%
 %%% <ul>
-%%% <li>date (using `now()');</li>
+%%% <li>date (using `timestamp()');</li>
 %%% <li>node number (using {@link ejabberd_node_id}).</li>
 %%% </ul>
 %%% @end

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -152,7 +152,7 @@ microseconds_to_now(MicroSeconds) when is_integer(MicroSeconds) ->
     {Seconds div 1000000, Seconds rem 1000000, MicroSeconds rem 1000000}.
 
 
-%% @doc Returns time in `now()' format.
+%% @doc Returns time in `timestamp()' format.
 -spec iso8601_datetime_binary_to_timestamp(iso8601_datetime_binary())
         -> erlang:timestamp() | undefined.
 iso8601_datetime_binary_to_timestamp(DateTime) when is_binary(DateTime) ->
@@ -178,7 +178,7 @@ microseconds_to_datetime(MicroSeconds) when is_integer(MicroSeconds) ->
 generate_message_id() ->
     {ok, NodeId} = ejabberd_node_id:node_id(),
     %% Use monotone function here.
-    encode_compact_uuid(now_to_microseconds(now()), NodeId).
+    encode_compact_uuid(now_to_microseconds(p1_time_compat:timestamp()), NodeId).
 
 
 %% @doc Create a message ID (UID).

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -177,8 +177,11 @@ microseconds_to_datetime(MicroSeconds) when is_integer(MicroSeconds) ->
 -spec generate_message_id() -> integer().
 generate_message_id() ->
     {ok, NodeId} = ejabberd_node_id:node_id(),
-    %% Use monotone function here.
-    encode_compact_uuid(now_to_microseconds(p1_time_compat:timestamp()), NodeId).
+    %% Unique enough
+    {T1, T2, T3} = p1_time_compat:timestamp(),
+    ImprovedTS = {T1, T2,
+                  (T3 div 1000) * 1000 + p1_time_compat:unique_integer([positive]) rem 1000 },
+    encode_compact_uuid(now_to_microseconds(ImprovedTS), NodeId).
 
 
 %% @doc Create a message ID (UID).

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -901,7 +901,8 @@ xfield(Type, Label, Var, Val, Lang) ->
 %%       http://xmpp.org/extensions/xep-0045.html#createroom-unique
 -spec iq_get_unique(ejabberd:jid()) -> jlib:xmlcdata().
 iq_get_unique(From) ->
-        #xmlcdata{content = sha:sha1_hex(term_to_binary([From, now(), randoms:get_string()]))}.
+        #xmlcdata{content = sha:sha1_hex(term_to_binary([From, p1_time_compat:unique_integer(),
+                                                         randoms:get_string()]))}.
 
 
 -spec iq_get_register_info('undefined' | ejabberd:server(),

--- a/apps/ejabberd/src/mod_muc_log.erl
+++ b/apps/ejabberd/src/mod_muc_log.erl
@@ -407,7 +407,7 @@ add_message_to_log(Nick1, Message, RoomJID, Opts, State) ->
     Room = get_room_info(RoomJID, Opts),
     Nick = htmlize(Nick1, FileFormat),
     Nick2 = htmlize(<<"<", Nick1/binary, ">">>, FileFormat),
-    Now = now(),
+    Now = p1_time_compat:timestamp(),
     TimeStamp = case Timezone of
                     local -> calendar:now_to_local_time(Now);
                     universal -> calendar:now_to_universal_time(Now)
@@ -874,7 +874,7 @@ put_header_script(F) ->
 put_room_config(_F, _RoomConfig, _Lang, plaintext) ->
     ok;
 put_room_config(F, RoomConfig, Lang, _FileFormat) ->
-    {Now1, Now2, Now3} = now(),
+    {Now1, Now2, Now3} = p1_time_compat:timestamp(),
     NowBin = list_to_binary(lists:flatten(io_lib:format("~p~p~p", [Now1, Now2, Now3]))),
     fw(F, <<"<div class=\"rc\">">>),
     fw(F, <<"<div class=\"rct\" onclick=\"sh('a", NowBin/binary, "');return false;\">",
@@ -889,7 +889,7 @@ put_room_config(F, RoomConfig, Lang, _FileFormat) ->
 put_room_occupants(_F, _RoomOccupants, _Lang, plaintext) ->
     ok;
 put_room_occupants(F, RoomOccupants, Lang, _FileFormat) ->
-    {Now1, Now2, Now3} = now(),
+    {Now1, Now2, Now3} = p1_time_compat:timestamp(),
     NowBin = list_to_binary(lists:flatten(io_lib:format("~p~p~p", [Now1, Now2, Now3]))),
     fw(F, <<"<div class=\"rc\">">>),
     fw(F, <<"<div class=\"rct\" onclick=\"sh('o", NowBin/binary, "');return false;\">",
@@ -1094,7 +1094,7 @@ get_proc_name(Host) -> gen_mod:get_module_proc(Host, ?PROCNAME).
 
 -spec calc_hour_offset(calendar:datetime()) -> integer().
 calc_hour_offset(TimeHere) ->
-    TimeZero = calendar:now_to_universal_time(now()),
+    TimeZero = calendar:now_to_universal_time(p1_time_compat:timestamp()),
     TimeHereHour = calendar:datetime_to_gregorian_seconds(TimeHere) div 3600,
     TimeZeroHour = calendar:datetime_to_gregorian_seconds(TimeZero) div 3600,
     TimeHereHour - TimeZeroHour.

--- a/apps/ejabberd/src/mod_offline.erl
+++ b/apps/ejabberd/src/mod_offline.erl
@@ -376,11 +376,11 @@ store_packet(From, To = #jid{luser = LUser, lserver = LServer},
     TimeStamp =
     case exml_query:subelement(Packet, <<"delay">>) of
         undefined ->
-            now();
+            p1_time_compat:timestamp();
         #xmlel{name = <<"delay">>} = DelayEl ->
             case exml_query:attr(DelayEl, <<"stamp">>, <<>>) of
                 <<"">> ->
-                    now();
+                    p1_time_compat:timestamp();
                 Stamp ->
                     jlib:datetime_binary_to_timestamp(Stamp)
             end

--- a/apps/ejabberd/src/mod_offline_mnesia.erl
+++ b/apps/ejabberd/src/mod_offline_mnesia.erl
@@ -109,7 +109,7 @@ remove_user(User, Server) ->
 -spec remove_expired_messages(ejabberd:lserver()) -> {error, term()} | {ok, HowManyRemoved} when
     HowManyRemoved :: integer().
 remove_expired_messages(_Host) ->
-    TimeStamp = now(),
+    TimeStamp = p1_time_compat:timestamp(),
     F = fun() ->
                 mnesia:write_lock_table(offline_msg),
                 mnesia:foldl(

--- a/apps/ejabberd/src/mod_register.erl
+++ b/apps/ejabberd/src/mod_register.erl
@@ -355,12 +355,12 @@ check_timeout(undefined) ->
     true;
 check_timeout(Source) ->
     Timeout = case ejabberd_config:get_local_option(registration_timeout) of
-                  undefined ->  600;
+                  undefined -> 600;
                   TO -> TO
               end,
-    if
-        is_integer(Timeout) ->
-            {MSec, Sec, _USec} = now(),
+    case is_integer(Timeout) of
+        true ->
+            {MSec, Sec, _USec} = p1_time_compat:timestamp(),
             Priority = -(MSec * 1000000 + Sec),
             CleanPriority = Priority + Timeout,
             F = fun() ->
@@ -391,7 +391,7 @@ check_timeout(Source) ->
                                [Reason]),
                     true
             end;
-        true ->
+        false ->
             true
     end.
 

--- a/apps/ejabberd/src/mod_time.erl
+++ b/apps/ejabberd/src/mod_time.erl
@@ -44,7 +44,7 @@ process_local_iq(_From, _To, #iq{type = get} = IQ) ->
 
 %% Internals
 calculate_time() ->
-    Now = now(),
+    Now = p1_time_compat:timestamp(),
     Now_universal = calendar:now_to_universal_time(Now),
     Now_local = calendar:now_to_local_time(Now),
     {UTC_time, UTC_diff} = jlib:timestamp_to_iso(Now_universal, utc),

--- a/apps/ejabberd/src/randoms.erl
+++ b/apps/ejabberd/src/randoms.erl
@@ -1,7 +1,7 @@
 %%%----------------------------------------------------------------------
 %%% File    : randoms.erl
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
-%%% Purpose : Random generation number wrapper
+%%% Purpose : Random generation utils
 %%% Created : 13 Dec 2002 by Alexey Shchepin <alexey@process-one.net>
 %%%
 %%%
@@ -27,8 +27,15 @@
 -author('alexey@process-one.net').
 
 -export([get_string/0]).
+-export([good_seed/0]).
 
 -spec get_string() -> string().
 get_string() ->
     R = crypto:rand_uniform(0, 16#10000000000000000),
     integer_to_list(R, 16).
+
+-spec good_seed() -> {integer(), integer(), integer()}.
+good_seed() ->
+    % Good seed, according to random:seed/3 documentation
+    {erlang:phash2([node()]), p1_time_compat:monotonic_time(), p1_time_compat:unique_integer()}.
+

--- a/apps/ejabberd/src/shaper_srv.erl
+++ b/apps/ejabberd/src/shaper_srv.erl
@@ -6,7 +6,7 @@
 %%%-------------------------------------------------------------------
 -module(shaper_srv).
 -behaviour(gen_server).
--include_lib("ejabberd/include/ejabberd.hrl").
+-include_lib("ejabberd.hrl").
 -define(SERVER, ?MODULE).
 
 %% ------------------------------------------------------------------
@@ -126,7 +126,7 @@ handle_call({wait, Host, Action, FromJID, Size},
             From, State=#state{max_delay=MaxDelayMs}) ->
     Key = new_key(Host, Action, FromJID),
     Shaper = find_or_create_shaper(Key, State),
-    State1 = update_access_time(Key, now(), State),
+    State1 = update_access_time(Key, p1_time_compat:timestamp(), State),
     case shaper:update(Shaper, Size) of
         {UpdatedShaper, 0} ->
             {reply, ok, save_shaper(Key, UpdatedShaper, State1)};
@@ -189,7 +189,7 @@ init_dicts(State) ->
 
 -spec delete_old_shapers(state()) -> state().
 delete_old_shapers(State=#state{shapers=Shapers, a_times=Times, ttl=TTL}) ->
-    Min = subtract_seconds(now(), TTL),
+    Min = subtract_seconds(p1_time_compat:timestamp(), TTL),
     %% Copy recently modified shapers
     dict:fold(fun
         (_, ATime, Acc) when ATime < Min -> Acc; %% skip too old

--- a/apps/ejabberd/src/supervisor2.erl
+++ b/apps/ejabberd/src/supervisor2.erl
@@ -1484,7 +1484,7 @@ add_restart(State) ->
     I = State#state.intensity,
     P = State#state.period,
     R = State#state.restarts,
-    Now = erlang:now(),
+    Now = p1_time_compat:timestamp(),
     R1 = add_restart([Now|R], Now, P),
     State1 = State#state{restarts = R1},
     case length(R1) of

--- a/apps/ejabberd/test/ejabberd_sm_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_sm_SUITE.erl
@@ -216,7 +216,7 @@ cannot_reproduce_race_condition_in_store_info(C) ->
     ok = try_to_reproduce_race_condition(C).
 
 store_info_sends_message_to_the_session_owner(C) ->
-    SID = {now(), self()},
+    SID = {p1_time_compat:timestamp(), self()},
     U = <<"alice2">>,
     S = <<"localhost">>,
     R = <<"res1">>,
@@ -350,7 +350,7 @@ get_fun_for_unique_count(ejabberd_sm_redis) ->
     end.
 
 make_sid() ->
-    {now(), self()}.
+    {p1_time_compat:timestamp(), self()}.
 
 given_session_opened(Sid, USR) ->
     given_session_opened(Sid, USR, 1).
@@ -464,7 +464,7 @@ is_redis_running() ->
 
 
 try_to_reproduce_race_condition(Config) ->
-    SID = {now(), self()},
+    SID = {p1_time_compat:timestamp(), self()},
     U = <<"alice">>,
     S = <<"localhost">>,
     R = <<"res1">>,

--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -188,7 +188,7 @@ store_packet(From, To, Packet) ->
             case check_event_chatstates(From, To, Packet) of
                 true ->
                     #jid{luser = LUser, lserver = LServer} = To,
-                    TimeStamp = now(),
+                    TimeStamp = erlang:timestamp(),
                     {xmlelement, _Name, _Attrs, Els} = Packet,
                     Expire = find_x_expire(TimeStamp, Els),
                     gen_mod:get_module_proc(To#jid.lserver, ?PROCNAME)

--- a/test.disabled/ejabberd_tests/src/ct_tty_hook.erl
+++ b/test.disabled/ejabberd_tests/src/ct_tty_hook.erl
@@ -80,13 +80,13 @@ post_end_per_group(Group,_Config,Return,State) ->
 %% @doc Called before each test case.
 pre_init_per_testcase(TC,Config,State) ->
     print_case_enter(TC, State, "Starting"),
-    {Config, State#state{ ts = now(), total = State#state.suite_total + 1 } }.
+    {Config, State#state{ ts = os:timestamp(), total = State#state.suite_total + 1 } }.
 
 %% @doc Called after each test case.
 post_end_per_testcase(TC, _Config, Return, State) ->
     ParallelTestDiffOverride = 1,
     %%% this fails when running in parallel:
-    %%% timer:now_diff(now(), State#state.ts),
+    %%% timer:now_diff(os:timestamp(), State#state.ts),
     TCInfo = {testcase, TC, Return, ParallelTestDiffOverride},
     print_case_enter(TC, State, "Finished"),
     {Return, State#state{ts = undefined, tcs = [TCInfo | State#state.tcs]}}.

--- a/test.disabled/ejabberd_tests/tests/ejabberdctl_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/ejabberdctl_SUITE.erl
@@ -248,7 +248,7 @@ num_active_users(Config) ->
     {AliceName, Domain, _} = get_user_data(alice, Config),
     {MikeName, Domain, _} = get_user_data(mike, Config),
 
-    {Mega, Secs, _} = erlang:now(),
+    {Mega, Secs, _} = os:timestamp(),
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now),
     {Result, _} = ejabberdctl("num_active_users", [Domain, "5"], Config),
@@ -263,7 +263,7 @@ delete_old_users(Config) ->
     {KateName, Domain, _} = get_user_data(kate, Config),
     {MikeName, Domain, _} = get_user_data(mike, Config),
 
-    {Mega, Secs, _} = erlang:now(),
+    {Mega, Secs, _} = os:timestamp(),
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now),
     set_last(BobName, Domain, Now),
@@ -280,7 +280,7 @@ delete_old_users_vhost(Config) ->
     {KateName, Domain, KatePass} = get_user_data(kate, Config),
     SecDomain = ct:get_config({hosts, mim, secondary_domain}),
 
-    {Mega, Secs, _} = erlang:now(),
+    {Mega, Secs, _} = os:timestamp(),
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now-86400*30),
 
@@ -715,7 +715,7 @@ set_last(Config) ->
 
                 escalus:wait_for_stanza(Alice), % ignore push
 
-                Now = usec:to_sec(usec:from_now(erlang:now())),
+                Now = usec:to_sec(usec:from_now(os:timestamp())),
                 TS = integer_to_list(Now - 7200),
                 {_, 0} = ejabberdctl("set_last", [BobName, Domain, TS, "Status"], Config),
                 escalus:send(Alice, escalus_stanza:last_activity(BobJid)),
@@ -984,9 +984,9 @@ remove_old_messages_test(Config) ->
                                       "Hi, how are you? Its old message!"),
         Msg2 = escalus_stanza:chat_to(<<"bob@", Domain/binary>>,
                                       "Hello its new message!"),
-        OldTimestamp = fallback_timestamp(10, now()),
+        OldTimestamp = fallback_timestamp(10, os:timestamp()),
         OfflineOld = generate_offline_message(JidRecordAlice, JidRecordBob, Msg1, OldTimestamp),
-        OfflineNew = generate_offline_message(JidRecordAlice, JidRecordBob, Msg2, now()),
+        OfflineNew = generate_offline_message(JidRecordAlice, JidRecordBob, Msg2, os:timestamp()),
         {jid, _, _, _, LUser, LServer, _} = JidRecordBob,
         rpc_call(mod_offline_backend, write_messages, [LUser, LServer, [OfflineOld, OfflineNew]]),
         %% when
@@ -1012,17 +1012,17 @@ remove_expired_messages_test(Config) ->
                                       "More wine..."),
         Msg4 = escalus_stanza:chat_to(<<"kate@", Domain/binary>>,
                                       "kings of leon"),
-        OldTimestamp = fallback_timestamp(10, now()),
-        ExpirationTime = fallback_timestamp(2, now()),
-        ExpirationTimeFuture= fallback_timestamp(-5, now()),
+        OldTimestamp = fallback_timestamp(10, os:timestamp()),
+        ExpirationTime = fallback_timestamp(2, os:timestamp()),
+        ExpirationTimeFuture= fallback_timestamp(-5, os:timestamp()),
         OfflineOld = generate_offline_expired_message(JidRecordMike,
                                                       JidRecordKate, Msg1,
                                                       OldTimestamp,
                                                       ExpirationTime),
         OfflineNow = generate_offline_expired_message(JidRecordMike,
-                             JidRecordKate, Msg2, now(), ExpirationTime),
+                             JidRecordKate, Msg2, os:timestamp(), ExpirationTime),
         OfflineFuture = generate_offline_expired_message(JidRecordMike,
-                             JidRecordKate, Msg3, now(), ExpirationTimeFuture),
+                             JidRecordKate, Msg3, os:timestamp(), ExpirationTimeFuture),
         OfflineFuture2 = generate_offline_expired_message(JidRecordMike,
                                                           JidRecordKate, Msg4,
                                                           OldTimestamp,

--- a/test.disabled/ejabberd_tests/tests/mam_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_helper.erl
@@ -920,7 +920,7 @@ parse_messages(Messages) ->
     end.
 
 bootstrap_archive(Config) ->
-    random:seed(now()),
+    random:seed(os:timestamp()),
     Users = escalus_ct:get_config(escalus_users),
     AliceJID    = escalus_users:get_jid(Config, alice),
     BobJID      = escalus_users:get_jid(Config, bob),
@@ -1217,7 +1217,7 @@ run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate,
     escalus:send(Alice, IqSet),
     _ReplySet = escalus:wait_for_stanza(Alice),
     Messages = [iolist_to_binary(io_lib:format("n=~p, prefs=~p, now=~p",
-                                               [N, PrefsState, now()]))
+                                               [N, PrefsState, os:timestamp()]))
                 || N <- [1, 2, 3, 4]],
     %% Messages:
     %% 1. Bob sends a message to Alice

--- a/test.disabled/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -270,7 +270,7 @@ multiparty_multiprotocol(Config) ->
 %%--------------------------------------------------------------------
 
 make_distinct_name(Prefix) ->
-    {_, S, US} = erlang:now(),
+    {_, S, US} = os:timestamp(),
     L = lists:flatten([integer_to_list(S rem 100), ".", integer_to_list(US)]),
     Suffix = list_to_binary(L),
     %% The bove is adapted from `escalus_fresh'.

--- a/test.disabled/ejabberd_tests/tsung/mam_con.xml
+++ b/test.disabled/ejabberd_tests/tsung/mam_con.xml
@@ -58,7 +58,7 @@
       <!-- Returns a random message id of 24 hours age -->
       <![CDATA[
         fun() ->
-            Now = now_to_microseconds(now()),
+            Now = now_to_microseconds(os:timestamp()),
             Microseconds = Now - random:uniform(86400000000),
             NodeId = random:uniform(255),
             MessId = (Microseconds bsl 8) + NodeId,

--- a/test.disabled/ejabberd_tests/tsung/mam_con_big.xml
+++ b/test.disabled/ejabberd_tests/tsung/mam_con_big.xml
@@ -58,7 +58,7 @@
       <!-- Returns a random message id of 10 minutes age -->
       <![CDATA[
         fun() ->
-            Now = now_to_microseconds(now()),
+            Now = now_to_microseconds(os:timestamp()),
             Microseconds = Now - random:uniform(600000000),
             NodeId = random:uniform(255),
             MessId = (Microseconds bsl 8) + NodeId,

--- a/test.disabled/ejabberd_tests/tsung/mam_muc.xml
+++ b/test.disabled/ejabberd_tests/tsung/mam_muc.xml
@@ -41,7 +41,7 @@
       <!-- Returns a random message id of 10 minutes age -->
       <![CDATA[
         fun() ->
-            Now = now_to_microseconds(now()),
+            Now = now_to_microseconds(os:timestamp()),
             Microseconds = Now - random:uniform(600000000),
             NodeId = random:uniform(255),
             MessId = (Microseconds bsl 8) + NodeId,

--- a/test.disabled/ejabberd_tests/tsung/mam_muc_big.xml
+++ b/test.disabled/ejabberd_tests/tsung/mam_muc_big.xml
@@ -50,7 +50,7 @@
       <!-- Returns a random message id of 10 minutes age -->
       <![CDATA[
         fun() ->
-            Now = now_to_microseconds(now()),
+            Now = now_to_microseconds(os:timestamp()),
             Microseconds = Now - random:uniform(600000000),
             NodeId = random:uniform(255),
             MessId = (Microseconds bsl 8) + NodeId,

--- a/test.disabled/ejabberd_tests/tsung/mam_muc_v2.xml
+++ b/test.disabled/ejabberd_tests/tsung/mam_muc_v2.xml
@@ -50,7 +50,7 @@
       <!-- Returns a random message id of 10 minutes age -->
       <![CDATA[
         fun() ->
-            Now = now_to_microseconds(now()),
+            Now = now_to_microseconds(os:timestamp()),
             Microseconds = Now - random:uniform(600000000),
             NodeId = random:uniform(255),
             MessId = (Microseconds bsl 8) + NodeId,


### PR DESCRIPTION
Proposed changes include:

* Replacement of all `now()` calls with proper equivalents from `p1_time_compat` (that will be eventually replaced with `erlang` module in the future).
* Replacement of `now()` calls in integration tests with `os:timestamp()`.

Some explanations:

* Whenever I was sure that `now()` was used to generate unique values or was hashed, I have replaced it with `unique_integer`, since it is recommended by OTP docs.
* `timestamp()` was my default choice where I wasn't sure if it's safe to use any other function.
* `mod_bosh_socket` now uses `monotonic_time/1`, because it used `now()` for time difference calculation, so I've chosen function recommended by OTP docs.
* I've used `os:timestamp()` in `mod_commands` because its output is used later together with `p1_time_compat:os_system_time(micro_seconds)`, so I considered it appropriate to stick to OS time.
* I've used `os:timestamp()` in integration tests in order not to introduce new dependency here. This function is good enough in tests, as they do not have as strict time "quality" requirements, as server code does.