### PR TITLE
Check for unsupervised links in gen_mod

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -167,7 +167,12 @@ run_tests() {
   echo
   echo "All tests done."
 
-  if [ $SMALL_STATUS -eq 0 -a $BIG_STATUS -eq 0 -a $BIG_STATUS_BY_SUMMARY -eq 0 ]
+  grep "fail_ci_build=true" ${BASE}/dev/mongooseim_*/log/ejabberd.log
+  # If phrase found than exit with code 1
+  test $? -eq 1
+  LOG_STATUS=$?
+
+  if [ $SMALL_STATUS -eq 0 -a $BIG_STATUS -eq 0 -a $BIG_STATUS_BY_SUMMARY -eq 0 -a $LOG_STATUS -eq 0 ]
   then
     RESULT=0
     echo "Build succeeded"
@@ -177,6 +182,7 @@ run_tests() {
     [ $SMALL_STATUS -ne 0 ] && echo "    small tests failed"
     [ $BIG_STATUS_BY_SUMMARY -ne 0 ]   && echo "    big tests failed"
     [ $BIG_STATUS -ne 0 ]   && echo "    big tests failed - missing suites"
+    [ $LOG_STATUS -ne 0 ]   && echo "    log contains errors"
   fi
 
   exit ${RESULT}

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -167,7 +167,7 @@ run_tests() {
   echo
   echo "All tests done."
 
-  grep "fail_ci_build=true" ${BASE}/dev/mongooseim_*/log/ejabberd.log
+  grep "fail_ci_build=true" ${BASE}/_build/mim*/rel/mongooseim/log/ejabberd.log
   # If phrase found than exit with code 1
   test $? -eq 1
   LOG_STATUS=$?


### PR DESCRIPTION
This is a rebased version of #971

------------------
Copied description from #971:

This PR contains two features:

    Allow for some log messages to trigger CI failure
    Warn about links added inside start_module callback.

Bad-written modules can link to the caller process in start_module callback
It works without errors until we try to start modules in the shell or using RPC

-------------

Changes:
- Allow for some log messages to trigger CI failure
- Bad-written modules can link to the caller process in start_module callback
- It works without errors until we try to start modules in the shell or using RPC
- Use Heroku's logfmt for log message format

