### PR TITLE
Erlang 19.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,9 @@ env:
 
 matrix:
     include:
-        - otp_release: 19.2
+        - otp_release: 19.3
           env: PRESET=dialyzer_only
-        - otp_release: 19.2
+        - otp_release: 19.3
           env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG=with-pgsql
         - otp_release: 17.5
           env: PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-none

--- a/apps/ejabberd/test/ejabberd_listener_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_listener_SUITE.erl
@@ -37,6 +37,9 @@ end_per_testcase(_T, C) ->
     meck:unload(gen_tcp),
     C.
 
+init_per_suite(C) ->
+   C.
+
 end_per_suite(_C) ->
     mnesia:stop(),
     mnesia:delete_schema([node()]).

--- a/apps/ejabberd/test/mod_aws_sns_SUITE.erl
+++ b/apps/ejabberd/test/mod_aws_sns_SUITE.erl
@@ -123,6 +123,9 @@ init_per_suite(Config) ->
     stringprep:start(),
     Config.
 
+end_per_suite(_) ->
+    ok.
+
 init_per_testcase(_, Config) ->
     meck:new([gen_mod, erlcloud_sns, wpool], [non_strict, passthrough]),
     meck:expect(erlcloud_sns, new, fun(_, _, _) -> mod_aws_sns_SUITE_erlcloud_sns_new end),


### PR DESCRIPTION
This PR runs one preset and dialyzer jobs on travis with Erlang/OTP 19.3

Also implements missing init or end per_suite when the opposite is defined. See commit message for more details.

