### PR TITLE
Add `import_users` command to mongooseimctl

### DIFF
--- a/apps/ejabberd/src/ejabberd.app.src
+++ b/apps/ejabberd/src/ejabberd.app.src
@@ -13,6 +13,7 @@
                   cache_tab,
                   cowboy,
                   crypto,
+                  csv,
                   cuesport,
                   exml,
                   exometer,

--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -411,7 +411,10 @@ do_register([User, Host, Password]) ->
     end;
 
 do_register(List) ->
-    Info = list_to_binary(lists:join(<<",">>, List)),
+    JoinBinary = fun(Elem, <<"">>) -> Elem;
+                    (Elem, Acc) -> <<Elem/binary, ",", Acc/binary>>
+                 end,
+    Info = lists:foldr(JoinBinary, <<"">>, List),
     {bad_csv, Info}.
 
 get_loglevel() ->

--- a/apps/ejabberd/src/ejabberd_admin.erl
+++ b/apps/ejabberd/src/ejabberd_admin.erl
@@ -27,6 +27,8 @@
 -module(ejabberd_admin).
 -author('mickael.remond@process-one.net').
 
+-define(REGISTER_WORKERS_NUM, 10).
+
 -export([start/0, stop/0,
          %% Server
          status/0,
@@ -34,6 +36,7 @@
          %% Accounts
          register/3, unregister/2,
          registered_users/1,
+         import_users/1,
          %% Purge DB
          delete_expired_messages/0, delete_old_messages/1,
          %% Mnesia
@@ -47,6 +50,8 @@
          get_loglevel/0,
          join_cluster/1, leave_cluster/0,
          remove_from_cluster/1]).
+
+-export([register_worker/1]).
 
 -include("ejabberd.hrl").
 -include("ejabberd_commands.hrl").
@@ -94,6 +99,13 @@ commands() ->
                         module = ?MODULE, function = registered_users,
                         args = [{host, binary}],
                         result = {users, {list, {username, binary}}}},
+     #ejabberd_commands{name = import_users, tags = [accounts],
+                        desc = "Import users from CSV file",
+                        module = ?MODULE, function = import_users,
+                        args = [{file, string}],
+                        result = {users, {list, {res, {tuple,
+                                                       [{result, atom},
+                                                        {user, binary}]}}}}},
      #ejabberd_commands{name = delete_expired_messages, tags = [purge],
                         desc = "Delete expired offline messages from database",
                         module = ?MODULE, function = delete_expired_messages,
@@ -324,6 +336,83 @@ registered_users(Host) ->
     Users = ejabberd_auth:get_vh_registered_users(Host),
     SUsers = lists:sort(Users),
     lists:map(fun({U, _S}) -> U end, SUsers).
+
+-spec import_users(Filename :: string()) -> [{ok, ejabberd:user()} |
+                                             {exists, ejabberd:user()} |
+                                             {not_allowed, ejabberd:user()} |
+                                             {invalid_jid, ejabberd:user()} |
+                                             {null_password, ejabberd:user()} |
+                                             {bad_csv, binary()}].
+import_users(File) ->
+    FileStream = stdio:file(File),
+    CsvStream = csv:stream(FileStream),
+    Workers = spawn_link_workers(),
+    WorkersQueue = queue:from_list(Workers),
+    do_import(CsvStream, WorkersQueue).
+
+-spec do_import(CsvStream :: stdio:stream(), Workers :: queue:queue()) ->
+    [{ok, ejabberd:user()} |
+     {exists, ejabberd:user()} |
+     {not_allowed, ejabberd:user()} |
+     {invalid_jid, ejabberd:user()} |
+     {null_password, ejabberd:user()} |
+     {bad_csv, binary()}].
+do_import({}, WorkersQueue) ->
+    Workers = queue:to_list(WorkersQueue),
+    lists:flatmap(fun get_result/1, Workers);
+
+
+do_import({s, UserData, TailFun}, WorkersQueue) ->
+    {{value, Worker}, Q1} = queue:out(WorkersQueue),
+    Worker ! {proccess, UserData},
+    Q2 = queue:in(Worker, Q1),
+    do_import(TailFun(), Q2).
+
+-spec spawn_link_workers() -> [pid()].
+spawn_link_workers() ->
+    [ spawn_link(?MODULE, register_worker, [self()]) ||
+      _ <- lists:seq(1, ?REGISTER_WORKERS_NUM)].
+
+-spec get_result(Worker :: pid()) -> [{ok, ejabberd:user()} |
+                                      {exists, ejabberd:user()} |
+                                      {not_allowed, ejabberd:user()} |
+                                      {invalid_jid, ejabberd:user()} |
+                                      {null_password, ejabberd:user()} |
+                                      {bad_csv, binary()}].
+get_result(Pid) ->
+    Pid ! get_result,
+    receive
+        {result, Result} -> Result
+    end.
+
+-spec register_worker(Manager :: pid()) -> ok.
+register_worker(Manager) ->
+    register_worker(Manager, []).
+
+-spec register_worker(Manager :: pid(), any()) -> ok.
+register_worker(Manager, Result) ->
+    receive
+        {proccess, Data} -> RegisterResult = do_register(Data),
+                            register_worker(Manager, [RegisterResult | Result]);
+        get_result -> Manager ! {result, Result}
+    end,
+    ok.
+
+-spec do_register([binary()]) -> {ok, ejabberd:user()} |
+                                 {exists, ejabberd:user()} |
+                                 {not_allowed, ejabberd:user()} |
+                                 {invalid_jid, ejabberd:user()} |
+                                 {null_password, ejabberd:user()} |
+                                 {bad_csv, binary()}.
+do_register([User, Host, Password]) ->
+    case ejabberd_auth:try_register(User, Host, Password) of
+        {error, Reason} -> {Reason, User};
+        _ -> {ok, User}
+    end;
+
+do_register(List) ->
+    Info = list_to_binary(lists:join(<<",">>, List)),
+    {bad_csv, Info}.
 
 get_loglevel() ->
     BackendList = ejabberd_loglevel:get(),

--- a/apps/ejabberd/test/ejabberd_admin_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_admin_SUITE.erl
@@ -56,14 +56,13 @@ import_users_from_valid_csv(Config) ->
     % when
     Result = ejabberd_admin:import_users(ValidCsvPath),
     % then
-    ?assertEqual(Result,
-                 [{ok, <<"user">>},
+    ?assertEqual([{ok, <<"user">>},
                   {exists, <<"existing_user">>},
                   {null_password, <<"null_password_user">>},
                   {not_allowed, <<"bad_domain_user">>},
                   {invalid_jid, <<"invalid_jid_user">>},
-                  {bad_csv, <<"wrong,number,of,fields,line">>}
-                 ]).
+                  {bad_csv, <<"wrong,number,of,fields,line">>}],
+                 Result).
 
 import_users_from_valid_csv_with_quoted_fields(Config) ->
     % given
@@ -71,8 +70,8 @@ import_users_from_valid_csv_with_quoted_fields(Config) ->
     % when
     Result = ejabberd_admin:import_users(ValidCsvPath),
     % then
-    ?assertEqual(Result,
-                 [{ok, <<"username,with,commas">>}]).
+    ?assertEqual([{ok, <<"username,with,commas">>}],
+                 Result).
 
 import_from_invalid_csv(Config) ->
     % given

--- a/apps/ejabberd/test/ejabberd_admin_SUITE.erl
+++ b/apps/ejabberd/test/ejabberd_admin_SUITE.erl
@@ -1,0 +1,82 @@
+-module(ejabberd_admin_SUITE).
+-compile([export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-import(ejabberd_helper, [data/2]).
+
+
+all() ->
+    [{group, import_users}].
+
+groups() ->
+    [{import_users, [], [import_users_from_valid_csv,
+                         import_users_from_valid_csv_with_quoted_fields,
+                         import_from_invalid_csv]}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_, Config) ->
+    meck:new(ejabberd_auth, [no_link]),
+    meck:expect(ejabberd_auth, try_register,
+                fun(<<"existing_user">>, _, _) -> {error, exists};
+                   (<<"null_password_user">>, _, _) -> {error, null_password};
+                   (_, <<"not_allowed_domain">>, _) -> {error, not_allowed};
+                   (<<"invalid_jid_user">>, _, _) -> {error, invalid_jid};
+                   (_, _, _) -> ok
+                end),
+    Config;
+
+init_per_group(_, Config) -> Config.
+
+end_per_group(_, _Config) ->
+    meck:unload(ejabberd_auth),
+    ok;
+
+end_per_group(_, _) -> ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%
+%% Tests
+%%
+
+import_users_from_valid_csv(Config) ->
+    % given
+    ValidCsvPath = data(Config, "valid.csv"),
+    % when
+    Result = ejabberd_admin:import_users(ValidCsvPath),
+    % then
+    ?assertEqual(Result,
+                 [{ok, <<"user">>},
+                  {exists, <<"existing_user">>},
+                  {null_password, <<"null_password_user">>},
+                  {not_allowed, <<"bad_domain_user">>},
+                  {invalid_jid, <<"invalid_jid_user">>},
+                  {bad_csv, <<"wrong,number,of,fields,line">>}
+                 ]).
+
+import_users_from_valid_csv_with_quoted_fields(Config) ->
+    % given
+    ValidCsvPath = data(Config, "valid_quoted.csv"),
+    % when
+    Result = ejabberd_admin:import_users(ValidCsvPath),
+    % then
+    ?assertEqual(Result,
+                 [{ok, <<"username,with,commas">>}]).
+
+import_from_invalid_csv(Config) ->
+    % given
+    NonExistingPath = "",
+    % then
+    ?assertError({badmatch, {error, enoent}},
+                 ejabberd_admin:import_users(NonExistingPath)).

--- a/apps/ejabberd/test/ejabberd_admin_SUITE_data/valid.csv
+++ b/apps/ejabberd/test/ejabberd_admin_SUITE_data/valid.csv
@@ -1,0 +1,6 @@
+user,localhost,password
+existing_user,localhost,password
+null_password_user,localhost,
+bad_domain_user,not_allowed_domain,password
+invalid_jid_user,localhost,password
+wrong,number,of,fields,line

--- a/apps/ejabberd/test/ejabberd_admin_SUITE_data/valid_quoted.csv
+++ b/apps/ejabberd/test/ejabberd_admin_SUITE_data/valid_quoted.csv
@@ -1,0 +1,1 @@
+"username,with,commas",localhost,"password_with_quote_and_comma"","

--- a/rebar.config
+++ b/rebar.config
@@ -43,6 +43,7 @@
   {erlcloud, ".*", {git, "git://github.com/erlcloud/erlcloud.git", "c119698"}},
   {worker_pool, ".*", {git, "git://github.com/inaka/worker_pool.git", {tag, "2.2.2"}}},
   {jwerl, ".*", {git, "git://github.com/emedia-project/jwerl.git", "3f365d1"}},
+  {csv, ".*", {git, "https://github.com/bszaf/csv.git", {ref, "b0b854d"}}},
 
   %% TODO: Remove this override of an exometer_core dependency
   %%       once it bundles a new enough (i.e. with verify_directories=false) version.


### PR DESCRIPTION
This allows to register users specified in CSV file in following
format: `user,domain,password`

- Proposed change is adding new command `import_users` to mongooseimctl.
  - It expects one parameter which is path to CSV file containing user accounts to register. They are expected to be formatted in following order - `user,host,password`. 
  - File reading is lazy, so we are not loading whole file into memory at once.
  - The `ejabberd_admin:import_users/1` function returns list of tuples `{Result, Binary}`, where `Result :: ok | exists | not_allowed | invalid_jid | null_password | bad_csv `, and `Binary :: ejabberd:user() | binary()`.
  - Library `csv` is added as dependency. It is used for parsing csv files.
- describe new or updated tests
  - add suite for this functionality.