### PR TITLE
Fix for #1252 - if MongooseIM fails to send message while replying to an

### DIFF
--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -812,8 +812,8 @@ do_open_session(El, JID, StateData) ->
     case send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm) of
         {_, _, NStateData, _} ->
             do_open_session_common(JID, NStateData);
-        {_, _, _} -> % error, resume not possible
-            c2s_stream_error(?SERR_INTERNAL_SERVER_ERROR, StateData)
+        {_, _, NStateData} -> % error, resume not possible
+            c2s_stream_error(?SERR_INTERNAL_SERVER_ERROR, NStateData)
     end.
 
 do_open_session_common(JID, #state{user = U, resource = R} = NewStateData0) ->

--- a/apps/ejabberd/src/ejabberd_c2s.erl
+++ b/apps/ejabberd/src/ejabberd_c2s.erl
@@ -809,8 +809,12 @@ do_open_session(El, JID, StateData) ->
     ?INFO_MSG("(~w) Opened session for ~s", [StateData#state.socket, jid:to_binary(JID)]),
     Res = jlib:make_result_iq_reply(El),
     Packet = {jid:to_bare(StateData#state.jid), StateData#state.jid, Res},
-    {_, _, NStateData, _} = send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm),
-    do_open_session_common(JID, NStateData).
+    case send_and_maybe_buffer_stanza(Packet, StateData, wait_for_session_or_sm) of
+        {_, _, NStateData, _} ->
+            do_open_session_common(JID, NStateData);
+        {_, _, _} -> % error, resume not possible
+            c2s_stream_error(?SERR_INTERNAL_SERVER_ERROR, StateData)
+    end.
 
 do_open_session_common(JID, #state{user = U, resource = R} = NewStateData0) ->
     change_shaper(NewStateData0, JID),

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -13,10 +13,10 @@ setup() ->
     meck:expect(ejabberd_socket, send, fun(_, _) -> ok end),
     meck:expect(ejabberd_socket, get_sockmod, fun(_) -> gen_tcp end),
     meck:expect(ejabberd_socket, peername,
-                fun(_) -> {ok, {{127,0,0,0}, 50001}}  end),
+                fun(_) -> {ok, {{127, 0, 0, 0}, 50001}}  end),
     meck:expect(ejabberd_socket, monitor,
                 fun(_) -> ok  end),
-    meck:expect(ejabberd_socket, change_shaper, fun(_,_) -> ok end),
+    meck:expect(ejabberd_socket, change_shaper, fun(_, _) -> ok end),
 
     meck:new(cyrsasl),
     meck:expect(cyrsasl, server_new, fun(_, _, _, _, _) -> saslstate end),
@@ -25,26 +25,30 @@ setup() ->
 
     meck:new(mongoose_credentials),
     meck:expect(mongoose_credentials, new, fun(_) -> ok end),
-    meck:expect(mongoose_credentials, get, fun(dummy_creds, sasl_success_response, undefined) -> undefined end),
+    meck:expect(mongoose_credentials, get,
+                fun(dummy_creds, sasl_success_response, undefined) ->
+                    undefined end),
     meck:expect(mongoose_credentials, get, fun mcred_get/2),
 
     meck:new(ejabberd_hooks),
-    meck:expect(ejabberd_hooks, run, fun(_,_) -> ok end),
-    meck:expect(ejabberd_hooks, run, fun(_,_,_) -> ok end),
+    meck:expect(ejabberd_hooks, run, fun(_, _) -> ok end),
+    meck:expect(ejabberd_hooks, run, fun(_, _, _) -> ok end),
     meck:expect(ejabberd_hooks, run_fold, fun hookfold/3),
     meck:expect(ejabberd_hooks, run_fold, fun hookfold/4),
 
     meck:new(ejabberd_config),
-    meck:expect(ejabberd_config, get_local_option, fun default_local_option/1),
-    meck:expect(ejabberd_config, get_global_option, fun default_global_option/1),
-    meck:expect(acl, match_rule, fun(_,_,_) -> allow end),
+    meck:expect(ejabberd_config, get_local_option,
+                fun default_local_option/1),
+    meck:expect(ejabberd_config, get_global_option,
+                fun default_global_option/1),
+    meck:expect(acl, match_rule, fun(_, _, _) -> allow end),
 
     meck:new(randoms),
     meck:expect(randoms, get_string,
                 fun() -> "57" end),
 
     meck:new(mongoose_metrics),
-    meck:expect(mongoose_metrics, update, fun (_,_,_) -> ok end).
+    meck:expect(mongoose_metrics, update, fun (_, _, _) -> ok end).
 
 
 teardown() ->
@@ -53,7 +57,7 @@ teardown() ->
 default_local_option(max_fsm_queue) -> 100.
 
 default_global_option(hosts) ->  [<<"localhost">>];
-default_global_option({access,c2s_shaper,global}) ->  [];
+default_global_option({access, c2s_shaper, global}) ->  [];
 default_global_option(language) ->  [<<"en">>].
 
 mcred_get(dummy_creds, username) -> <<"cosmic_hippo">>;

--- a/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/apps/ejabberd/test/ejabberd_c2s_SUITE_mocks.erl
@@ -5,24 +5,34 @@ setup() ->
     meck:new(ejabberd_sm),
     meck:expect(ejabberd_sm, close_session,
                 fun(_SID, _User, _Server, _Resource, _Reason) -> ok end),
+    meck:expect(ejabberd_sm, open_session, fun(_, _, _, _, _) -> [] end),
 
     meck:new(ejabberd_socket),
     meck:expect(ejabberd_socket, close,
                 fun(_) -> ok end),
-    meck:expect(ejabberd_socket, send, fun(_,_) -> ok end),
+    meck:expect(ejabberd_socket, send, fun(_, _) -> ok end),
+    meck:expect(ejabberd_socket, get_sockmod, fun(_) -> gen_tcp end),
     meck:expect(ejabberd_socket, peername,
                 fun(_) -> {ok, {{127,0,0,0}, 50001}}  end),
     meck:expect(ejabberd_socket, monitor,
                 fun(_) -> ok  end),
     meck:expect(ejabberd_socket, change_shaper, fun(_,_) -> ok end),
 
+    meck:new(cyrsasl),
+    meck:expect(cyrsasl, server_new, fun(_, _, _, _, _) -> saslstate end),
+    meck:expect(cyrsasl, server_start, fun(_, _, _) -> {ok, dummy_creds} end),
+    meck:expect(cyrsasl, listmech, fun(_) -> [] end),
+
+    meck:new(mongoose_credentials),
+    meck:expect(mongoose_credentials, new, fun(_) -> ok end),
+    meck:expect(mongoose_credentials, get, fun(dummy_creds, sasl_success_response, undefined) -> undefined end),
+    meck:expect(mongoose_credentials, get, fun mcred_get/2),
+
     meck:new(ejabberd_hooks),
     meck:expect(ejabberd_hooks, run, fun(_,_) -> ok end),
     meck:expect(ejabberd_hooks, run, fun(_,_,_) -> ok end),
-    meck:expect(ejabberd_hooks, run_fold,
-                fun(privacy_check_packet, _, _, _) -> allow end),
-    meck:expect(ejabberd_hooks, run_fold,
-                fun(check_bl_c2s, _, _) -> false end),
+    meck:expect(ejabberd_hooks, run_fold, fun hookfold/3),
+    meck:expect(ejabberd_hooks, run_fold, fun hookfold/4),
 
     meck:new(ejabberd_config),
     meck:expect(ejabberd_config, get_local_option, fun default_local_option/1),
@@ -36,6 +46,7 @@ setup() ->
     meck:new(mongoose_metrics),
     meck:expect(mongoose_metrics, update, fun (_,_,_) -> ok end).
 
+
 teardown() ->
     meck:unload().
 
@@ -44,3 +55,15 @@ default_local_option(max_fsm_queue) -> 100.
 default_global_option(hosts) ->  [<<"localhost">>];
 default_global_option({access,c2s_shaper,global}) ->  [];
 default_global_option(language) ->  [<<"en">>].
+
+mcred_get(dummy_creds, username) -> <<"cosmic_hippo">>;
+mcred_get(dummy_creds, auth_module) -> auuuthmodule.
+
+hookfold(check_bl_c2s, _, _) -> false.
+
+hookfold(roster_get_versioning_feature, _, _, _) -> [];
+hookfold(roster_get_subscription_lists, _, _, _) -> mongoose_acc:new();
+hookfold(privacy_get_user_list, _, A, _) -> A;
+hookfold(session_opening_allowed_for_user, _, _, _) -> allow;
+hookfold(c2s_stream_features, _, _, _) -> [];
+hookfold(privacy_check_packet, _, _, _) -> allow.


### PR DESCRIPTION
attempt to set session, it should send an error and close the stream

This PR addresses #1252 

Proposed changes include:
* when c2s is waiting for stanza which would establish session, receives it and fails to reply (for whatever reason), it is an unrecoverable stream error - it tries to send back error message and stream termination and then exit (previously it just crashed)
* two new tests in common test suite - one establishes a session on bare c2s, the other replicates the above problem and asserts c2s replied with error and stream end


