### PR TITLE
Use MongooseIM version from git to tag builds form cron

### DIFF
--- a/tools/travis-build-and-push-docker.sh
+++ b/tools/travis-build-and-push-docker.sh
@@ -27,6 +27,12 @@ elif [ ${TRAVIS_BRANCH} == 'master' ]; then
     DOCKERHUB_TAG="latest";
 fi
 
+if [ ${TRAVIS_EVENT_TYPE} == 'cron' ]; then
+    DOCKERHUB_TAG=${VERSION};
+fi
+
+echo "Tag: ${DOCKERHUB_TAG}"
+
 IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git


### PR DESCRIPTION
I'm going to enable weekly builds on travis. Such builds will produce docker images with tag which equals current version of MongooseIM, f.e `2.1.0beta1-665-gcb0a666`. These weekly builds will help us better monitor performance changes.

