### PR TITLE
Fix MAM+MUC Light

### DIFF
--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -64,8 +64,7 @@
 %% UID
 -import(mod_mam_utils,
         [generate_message_id/0,
-         decode_compact_uuid/1,
-         normalize_search_text/2]).
+         decode_compact_uuid/1]).
 
 %% XML
 -import(mod_mam_utils,
@@ -89,7 +88,6 @@
 %% Forms
 -import(mod_mam_utils,
         [form_field_value_s/2,
-         form_field_value/2,
          message_form/3]).
 
 %% Other
@@ -103,8 +101,8 @@
         [send_message/3]).
 
 
--include_lib("ejabberd/include/ejabberd.hrl").
--include_lib("ejabberd/include/jlib.hrl").
+-include_lib("ejabberd.hrl").
+-include_lib("jlib.hrl").
 -include_lib("exml/include/exml.hrl").
 
 -callback is_complete_message(Module :: atom(), Dir :: atom(), Packet :: any()) ->
@@ -325,22 +323,22 @@ is_room_action_allowed_by_default(Action, From, To) ->
     end.
 
 
--spec is_room_owner(From :: ejabberd:jid(), To :: ejabberd:jid()) -> boolean().
-is_room_owner(From, To) ->
-    ejabberd_hooks:run_fold(is_muc_room_owner, To#jid.lserver, false, [To, From]).
+-spec is_room_owner(User :: ejabberd:jid(), Room :: ejabberd:jid()) -> boolean().
+is_room_owner(User, Room) ->
+    ejabberd_hooks:run_fold(is_muc_room_owner, Room#jid.lserver, false, [Room, User]).
 
 
 %% @doc Return true if user element should be removed from results
--spec is_user_identity_hidden(From :: ejabberd:jid(), ArcJID :: ejabberd:jid()) -> boolean().
-is_user_identity_hidden(From, ArcJID) ->
-    case mod_muc_room:can_access_identity(ArcJID, From) of
-        {error, _} -> true;
-        {ok, CanAccess} -> (not CanAccess)
+-spec is_user_identity_hidden(User :: ejabberd:jid(), Room :: ejabberd:jid()) -> boolean().
+is_user_identity_hidden(User, Room) ->
+    case ejabberd_hooks:run_fold(can_access_identity, Room#jid.lserver, false, [Room, User]) of
+        CanAccess when is_boolean(CanAccess) -> not CanAccess;
+        _ -> true
     end.
 
--spec can_access_room(From :: ejabberd:jid(), To :: ejabberd:jid()) -> boolean().
-can_access_room(From, To) ->
-    ejabberd_hooks:run_fold(can_access_room, To#jid.lserver, false, [From, To]).
+-spec can_access_room(User :: ejabberd:jid(), Room :: ejabberd:jid()) -> boolean().
+can_access_room(User, Room) ->
+    ejabberd_hooks:run_fold(can_access_room, Room#jid.lserver, false, [Room, User]).
 
 
 -spec action_type(action()) -> 'get' | 'set'.

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -71,6 +71,7 @@
          process_iq_set/4,
          is_room_owner/3,
          can_access_room/3,
+         can_access_identity/3,
          muc_room_pid/2]).
 
 %% For Administration API
@@ -139,6 +140,7 @@ start(Host, Opts) ->
     ejabberd_hooks:add(is_muc_room_owner, MUCHost, ?MODULE, is_room_owner, 50),
     ejabberd_hooks:add(muc_room_pid, MUCHost, ?MODULE, muc_room_pid, 50),
     ejabberd_hooks:add(can_access_room, MUCHost, ?MODULE, can_access_room, 50),
+    ejabberd_hooks:add(can_access_identity, MUCHost, ?MODULE, can_access_identity, 50),
 
     %% Prepare config schema
     ConfigSchema = mod_muc_light_utils:make_config_schema(
@@ -164,6 +166,7 @@ stop(Host) ->
     ejabberd_hooks:delete(is_muc_room_owner, MUCHost, ?MODULE, is_room_owner, 50),
     ejabberd_hooks:delete(muc_room_pid, MUCHost, ?MODULE, muc_room_pid, 50),
     ejabberd_hooks:delete(can_access_room, MUCHost, ?MODULE, can_access_room, 50),
+    ejabberd_hooks:delete(can_access_identity, MUCHost, ?MODULE, can_access_identity, 50),
 
     ejabberd_hooks:delete(roster_get, Host, ?MODULE, add_rooms_to_roster, 50),
     ejabberd_hooks:delete(privacy_iq_get, Host, ?MODULE, process_iq_get, 1),
@@ -352,8 +355,15 @@ muc_room_pid(_, _) ->
 
 -spec can_access_room(Acc :: boolean(), Room :: ejabberd:jid(), User :: ejabberd:jid()) ->
     boolean().
-can_access_room(_, User, Room) ->
+can_access_room(_, Room, User) ->
     none =/= get_affiliation(Room, User).
+
+-spec can_access_identity(Acc :: boolean(), Room :: ejabberd:jid(), User :: ejabberd:jid()) ->
+    boolean().
+can_access_identity(_Acc, _Room, _User) ->
+    %% User JIDs are explicit in MUC Light but this hook is about appending
+    %% 0045 MUC element with user identity and we don't want it
+    false.
 
 %%====================================================================
 %% Internal functions

--- a/test.disabled/ejabberd_tests/tests/mam_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_helper.erl
@@ -714,9 +714,10 @@ send_muc_rsm_messages(Config) ->
         escalus:wait_for_stanzas(Alice, 3),
 
         %% Alice sends messages to Bob.
-        [escalus:send(Alice,
-                      escalus_stanza:groupchat_to(RoomAddr, generate_message_text(N)))
-         || N <- lists:seq(1, 15)],
+        lists:foreach(fun(N) ->
+                              escalus:send(Alice, escalus_stanza:groupchat_to(
+                                                    RoomAddr, generate_message_text(N)))
+                      end, lists:seq(1, 15)),
         %% Bob is waiting for 15 messages for 5 seconds.
         escalus:wait_for_stanzas(Bob, 15, 5000),
         escalus:wait_for_stanzas(Alice, 15, 5000),
@@ -746,9 +747,11 @@ send_rsm_messages(Config) ->
     P = ?config(props, Config),
     F = fun(Alice, Bob) ->
         %% Alice sends messages to Bob.
-        [escalus:send(Alice,
-                      escalus_stanza:chat_to(Bob, generate_message_text(N)))
-         || N <- lists:seq(1, 15)],
+        lists:foreach(fun(N) ->
+                              escalus:send(Alice,
+                                           escalus_stanza:chat_to(Bob, generate_message_text(N))),
+                              timer:sleep(1)
+                      end, lists:seq(1, 15)),
         %% Bob is waiting for 15 messages for 5 seconds.
         escalus:wait_for_stanzas(Bob, 15, 5000),
         maybe_wait_for_archive(Config),


### PR DESCRIPTION
This PR addresses #1267 

Proposed changes include:
* A call to `mod_muc_room:can_access_identity` in `mod_mam_muc` has been changed to a hook call. `mod_muc` and `mod_muc_light` have been modified accordingly.
* A short (1ms) sleep has been added in MAM tests, because messages sometimes are stored out of order (because we no longer use strictly monotonic time) on fast machines.

