### PR TITLE
Fix node push discovery in mod_pubsub

### DIFF
--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -4025,8 +4025,8 @@ host(ServerHost) ->
 serverhost({_U, Server, _R})->
     Server;
 serverhost(Host) ->
-    case binary:match(Host, <<"pubsub.">>) of
-        {0, 7} ->
+    case config(Host, host, undefined) of
+        undefined ->
             [_, ServerHost] = binary:split(Host, <<".">>),
             ServerHost;
         _ ->

--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -514,8 +514,11 @@ is_subscribed(Recipient, NodeOwner, NodeOptions) ->
           Node   :: <<>> | mod_pubsub:nodeId(),
           Lang   :: binary())
         -> [xmlel()].
-disco_local_identity(Acc, _From, To, <<>>, _Lang) ->
+disco_local_identity(Acc, _From, To, Node, Lang) ->
     LServer = To#jid.lserver,
+    disco_local_identity(Acc, LServer, Node, Lang).
+
+disco_local_identity(Acc, Host, <<>>, _Lang) ->
     PepIdentity =
     #xmlel{name = <<"identity">>,
            attrs = [{<<"category">>, <<"pubsub">>},
@@ -524,8 +527,8 @@ disco_local_identity(Acc, _From, To, <<>>, _Lang) ->
     #xmlel{name = <<"identity">>,
            attrs = [{<<"category">>, <<"pubsub">>},
                     {<<"type">>, ?PUSHNODE}]},
-    HasPep = lists:member(?PEPNODE, plugins(LServer)),
-    HasPush = lists:member(?PUSHNODE, plugins(LServer)),
+    HasPep = lists:member(?PEPNODE, plugins(Host)),
+    HasPush = lists:member(?PUSHNODE, plugins(Host)),
     Plugins = [{HasPep, PepIdentity}, {HasPush, PushIdentity}],
     lists:foldl(
         fun
@@ -534,7 +537,7 @@ disco_local_identity(Acc, _From, To, <<>>, _Lang) ->
             ({false, _}, AccIn) ->
                 AccIn
         end, Acc, Plugins);
-disco_local_identity(Acc, _From, _To, _Node, _Lang) ->
+disco_local_identity(Acc, _Host, _Node, _Lang) ->
     Acc.
 
 -spec disco_local_features(
@@ -1115,12 +1118,15 @@ iq_disco_info(Host, SNode, From, Lang) ->
                                                 %   Node = string_to_node(RealSNode),
     case Node of
         <<>> ->
-            {result, [#xmlel{name = <<"identity">>,
-                             attrs = [{<<"category">>, <<"pubsub">>},
-                                      {<<"type">>, <<"service">>},
-                                      {<<"name">>, translate:translate(
-                                                     Lang, <<"Publish-Subscribe">>)}]},
-                      #xmlel{name = <<"feature">>,
+            InitAcc =
+                [#xmlel{name = <<"identity">>,
+                        attrs = [{<<"category">>, <<"pubsub">>},
+                                 {<<"type">>, <<"service">>},
+                                 {<<"name">>,
+                                  translate:translate(Lang, <<"Publish-Subscribe">>)}]}],
+            Identities = disco_local_identity(InitAcc, Host, Node, Lang),
+            {result, Identities ++
+                     [#xmlel{name = <<"feature">>,
                              attrs = [{<<"var">>, ?NS_DISCO_INFO}]},
                       #xmlel{name = <<"feature">>,
                              attrs = [{<<"var">>, ?NS_DISCO_ITEMS}]},

--- a/test.disabled/ejabberd_tests/tests/push_pubsub_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_pubsub_SUITE.erl
@@ -11,6 +11,8 @@
 -define(NS_PUBSUB_PUB_OPTIONS,  <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(PUSH_FORM_TYPE,         <<"urn:xmpp:push:summary">>).
 
+-define(PUBSUB_SUB_DOMAIN, "pubsub").
+
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -96,7 +98,7 @@ has_disco_identity(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Server = escalus_client:server(Alice),
+            Server = node_addr(),
             escalus:send(Alice, escalus_stanza:disco_info(Server)),
             Stanza = escalus:wait_for_stanza(Alice),
             escalus:assert(has_identity, [<<"pubsub">>, <<"push">>], Stanza)
@@ -336,7 +338,7 @@ domain() ->
 
 node_addr() ->
     Domain = domain(),
-    <<"pubsub.", Domain/binary>>.
+    <<?PUBSUB_SUB_DOMAIN, ".", Domain/binary>>.
 
 rand_name(Prefix) ->
     Suffix = base64:encode(crypto:rand_bytes(5)),
@@ -390,12 +392,15 @@ next_rest_req() ->
         throw(rest_mock_timeout)
     end.
 
+pubsub_host(Host) ->
+    ?PUBSUB_SUB_DOMAIN ++ "." ++ Host.
+
 %% Module config
 required_modules() ->
     [{mod_pubsub, [
         {plugins, [<<"dag">>, <<"push">>]},
         {nodetree, <<"dag">>},
-        {host, "pubsub.@HOST@"}
+        {host, ?PUBSUB_SUB_DOMAIN ++ ".@HOST@"}
     ]},
      {mod_push_service_mongoosepush, [
          {pool_name, mongoose_push_http},

--- a/test.disabled/ejabberd_tests/tests/push_pubsub_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_pubsub_SUITE.erl
@@ -11,7 +11,7 @@
 -define(NS_PUBSUB_PUB_OPTIONS,  <<"http://jabber.org/protocol/pubsub#publish-options">>).
 -define(PUSH_FORM_TYPE,         <<"urn:xmpp:push:summary">>).
 
--define(PUBSUB_SUB_DOMAIN, "pubsub").
+-define(PUBSUB_SUB_DOMAIN, "push").
 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses the following issues:
- node `push` disco info shall be visible under pubsub's sub domain, instead of the main server's domain
- `mod_pubsub` should allow for running on custom sub-domain

Please note that the second fix only allows to run pubsub on custom, non "pubsub.*" sub-domain. You can still run only one pubsub at a time. This is another issue which is much more complicated to fix, because the `mod_pubsub` internally holds its state on the main domain of the server. Therefore starting second `mod_pubsub` will always conflict with the first one. 
