### PR TITLE
Fix BOSH interleaving

### DIFF
--- a/apps/ejabberd/src/mod_bosh_socket.erl
+++ b/apps/ejabberd/src/mod_bosh_socket.erl
@@ -623,36 +623,47 @@ is_acceptable_rid(Rid, ExpectedRid)
 is_acceptable_rid(_, _) ->
     false.
 
-%% @doc Send data to the client if any request handler is available.
+%% @doc Send data to the client if a request handler is available, that matches next RID.
 %% Otherwise, store for sending later.
 -spec send_or_store(_Data, state()) -> state().
 send_or_store(Data, State) when not is_list(Data) ->
     send_or_store([Data], State);
-send_or_store(Data, #state{handlers = []} = S) ->
-    store(Data, S);
 send_or_store(Data, State) ->
-    send_to_handler(Data, State).
+    case send_to_handler(Data, State) of
+        no_valid_handler ->
+            store(Data, State);
+        NewState ->
+            NewState
+    end.
 
 
 %% @doc send_to_handler() assumes that Handlers is not empty!
 %% Be sure that's the case if calling it.
 -spec send_to_handler([any()] | jlib:xmlel(), state()) -> state().
 send_to_handler(Data, State) ->
-    {Handler, NS} = pick_handler(State),
-    send_to_handler(Handler, Data, NS).
+    case pick_handler(State) of
+        {Handler, NS} ->
+            send_to_handler(Handler, Data, NS);
+        false ->
+            no_valid_handler
+    end.
 
 
 %% Return handler and new state if a handler is available
 %% or `false` otherwise.
 -spec pick_handler(state()) -> {{rid(), pid()}, state()} | false.
-pick_handler(#state{handlers = []}) ->
+pick_handler(#state{ handlers = [] }) ->
     false;
-pick_handler(#state{handlers = Handlers} = S) ->
-    [{Rid, TRef, Pid} | HRest] = lists:sort(Handlers),
-    %% The cancellation might fail if the timer already fired.
-    %% Don't worry, it's handled on receiving the timeout message.
-    erlang:cancel_timer(TRef),
-    {{Rid, Pid}, S#state{handlers = HRest}}.
+pick_handler(#state{ handlers = Handlers, rid = Rid } = S) ->
+    case lists:sort(Handlers) of
+        [{HandlerRid, TRef, Pid} | HRest] when HandlerRid =< Rid->
+            %% The cancellation might fail if the timer already fired.
+            %% Don't worry, it's handled on receiving the timeout message.
+            erlang:cancel_timer(TRef),
+            {{HandlerRid, Pid}, S#state{handlers = HRest}};
+        _ ->
+            false
+    end.
 
 
 -spec send_to_handler({_, atom() | pid() | port() | {atom(), atom()}},
@@ -788,12 +799,13 @@ return_surplus_handlers(SName, #state{handlers = [_], pending = []} = State)
     when SName == normal; SName == closing ->
     State;
 return_surplus_handlers(accumulate, #state{handlers = _} = S) ->
-    NS = send_to_handler([], S),
-    return_surplus_handlers(accumulate, NS);
+    case send_to_handler([], S) of
+        no_valid_handler -> S;
+        NS -> return_surplus_handlers(accumulate, NS)
+    end;
 return_surplus_handlers(SName, #state{pending = Pending} = S)
     when SName == normal; SName == closing ->
-    NS = send_or_store(Pending, S#state{pending = []}),
-    return_surplus_handlers(normal, NS).
+    send_or_store(Pending, S#state{pending = []}).
 
 
 -spec bosh_unwrap(EventTag :: mod_bosh:event_type(), jlib:xmlel(), state())

--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -11,7 +11,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "d365533"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "1091afe"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {branch, "fix-bosh-concurrency"}}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},

--- a/test.disabled/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/bosh_SUITE.erl
@@ -357,10 +357,10 @@ cant_send_invalid_rid(Config) ->
         %% mod_bosh:forward_body:265 session not found!
         
         %% NOTICE 3
-	%% We enable quickfail mode, because sometimes request with invalid RID
+        %% We enable quickfail mode, because sometimes request with invalid RID
         %% arrives before empty body req. with valid RID, so server returns an error
-	%% only for the first req. and escalus_bosh in normal mode would get stuck
-	%% since it wants to maintain order according to RIDs
+        %% only for the first req. and escalus_bosh in normal mode would get stuck
+        %% since it wants to maintain order according to RIDs
 
         escalus_bosh:set_quickfail(Carol, true),
 
@@ -627,7 +627,6 @@ server_acks(Config) ->
         timer:sleep(200),
 
         All = recv_all(Carol),
-	ct:pal("Recvall: ~p", [All]),
         ExpectedRid = exml_query:attr(hd(All), <<"ack">>)
 
         end).

--- a/test.disabled/ejabberd_tests/tests/bosh_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/bosh_SUITE.erl
@@ -87,10 +87,12 @@ time_test_cases() ->
     ].
 
 acks_test_cases() ->
-    [server_acks,
+    [
+     server_acks,
      force_report,
      force_retransmission,
-     force_cache_trimming].
+     force_cache_trimming
+    ].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -151,7 +153,7 @@ create_and_terminate_session(Config) ->
     {ok, Conn} = escalus_bosh:connect(CarolSpec),
 
     %% Assert there are no BOSH sessions on the server.
-    0 = length(get_bosh_sessions()),
+    [] = get_bosh_sessions(),
 
     Domain = ct:get_config({hosts, mim, domain}),
     Body = escalus_bosh:session_creation_body(get_bosh_rid(Conn), Domain),
@@ -159,7 +161,7 @@ create_and_terminate_session(Config) ->
     escalus_connection:get_stanza(Conn, session_creation_response),
 
     %% Assert that a BOSH session was created.
-    1 = length(get_bosh_sessions()),
+    [_] = get_bosh_sessions(),
 
     Sid = get_bosh_sid(Conn),
     Terminate = escalus_bosh:session_termination_body(get_bosh_rid(Conn), Sid),
@@ -167,7 +169,7 @@ create_and_terminate_session(Config) ->
 
     timer:sleep(100),
     %% Assert the session was terminated.
-    0 = length(get_bosh_sessions()).
+    [] = get_bosh_sessions().
 
 accept_higher_hold_value(Config) ->
     #xmlel{attrs = RespAttrs} = send_specific_hold(Config, <<"2">>),
@@ -353,6 +355,14 @@ cant_send_invalid_rid(Config) ->
         %% completes. This will leave the following message in the log:
         %%
         %% mod_bosh:forward_body:265 session not found!
+        
+        %% NOTICE 3
+	%% We enable quickfail mode, because sometimes request with invalid RID
+        %% arrives before empty body req. with valid RID, so server returns an error
+	%% only for the first req. and escalus_bosh in normal mode would get stuck
+	%% since it wants to maintain order according to RIDs
+
+        escalus_bosh:set_quickfail(Carol, true),
 
         InvalidRid = get_bosh_rid(Carol) + ?INVALID_RID_OFFSET,
         Sid = get_bosh_sid(Carol),
@@ -617,6 +627,7 @@ server_acks(Config) ->
         timer:sleep(200),
 
         All = recv_all(Carol),
+	ct:pal("Recvall: ~p", [All]),
         ExpectedRid = exml_query:attr(hd(All), <<"ack">>)
 
         end).


### PR DESCRIPTION
This PR addresses a problem with random BOSH fails on Travis

Proposed changes include:
* A fix for `mod_bosh_socket`. Now it maintains strict response order, according to RID.
* A cleanup of `bosh_interleave_reqs`
* New `escalus` version with improved BOSH client
