### PR TITLE
Add archive_groupchats option to mod_mam

### DIFF
--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -195,6 +195,15 @@ archive_id(Server, User)
 -spec start(Host :: ejabberd:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
     ?DEBUG("mod_mam starting", []),
+    case gen_mod:get_opt(archive_groupchats, Opts, undefined) of
+        undefined ->
+            ?WARNING_MSG("mod_mam is enabled without explicit archive_groupchats option value."
+                         " It will default to `false` in one of future releases."
+                         " Please check the mod_mam documentation for more details.", []);
+        _ ->
+            ok
+    end,
+
     compile_params_module(Opts),
     ejabberd_users:start(Host),
     %% `parallel' is the only one recommended here.
@@ -687,7 +696,7 @@ handle_package(Dir, ReturnMessID,
     end.
 
 should_archive_if_groupchat(Host, <<"groupchat">>) ->
-    gen_mod:get_module_opt(Host, ?MODULE, archive_groupchats, false);
+    gen_mod:get_module_opt(Host, ?MODULE, archive_groupchats, true);
 should_archive_if_groupchat(_, _) ->
     true.
 

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -322,12 +322,12 @@ is_archivable_message(Mod, Dir, Packet=#xmlel{name = <<"message">>}) ->
 is_archivable_message(_, _, _) ->
     false.
 
-is_valid_message_type(_, _, <<"">>)          -> true;
-is_valid_message_type(_, _, <<"normal">>)    -> true;
-is_valid_message_type(_, _, <<"chat">>)      -> true;
-is_valid_message_type(_, _, <<"groupchat">>) -> true;
-is_valid_message_type(_, _, <<"error">>)     -> false;
-is_valid_message_type(_, _, _)               -> false.
+is_valid_message_type(_, _, <<"">>) -> true;
+is_valid_message_type(_, _, <<"normal">>) -> true;
+is_valid_message_type(_, _, <<"chat">>) -> true;
+is_valid_message_type(_, incoming, <<"groupchat">>) -> true;
+is_valid_message_type(_, _, <<"error">>) -> false;
+is_valid_message_type(_, _, _) -> false.
 
 is_valid_message(_Mod, _Dir, Packet) ->
     Body     = xml:get_subtag(Packet, <<"body">>),

--- a/apps/ejabberd/test/mod_mam_meta_SUITE.erl
+++ b/apps/ejabberd/test/mod_mam_meta_SUITE.erl
@@ -61,7 +61,7 @@ produces_valid_configurations(_Config) ->
                  cache_users,
                  add_archived_element,
 
-                 {pm, [{user_prefs_store, odbc}, {async_writer, false}]},
+                 {pm, [{user_prefs_store, odbc}, archive_groupchats, {async_writer, false}]},
                  {muc, [
                         {host, <<"host">>},
                         {odbc_message_format, simple},
@@ -71,7 +71,7 @@ produces_valid_configurations(_Config) ->
 
     ExpandedSimpleOpts = [{db_jid_format, mam_jid_rfc}, {db_message_format, mam_message_xml}],
 
-    check_has_args(mod_mam, [{add_archived_element, true}], Deps),
+    check_has_args(mod_mam, [{add_archived_element, true}, {archive_groupchats, true}], Deps),
     check_has_args(mod_mam_muc, [{host, <<"host">>}], Deps),
     check_has_args(mod_mam_odbc_arch, [pm], Deps),
     check_has_args(mod_mam_muc_odbc_arch, [no_writer | ExpandedSimpleOpts], Deps),

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -35,7 +35,8 @@ For now `odbc` backend has very limited support for this feature, while `cassand
 
 #### PM-specific options
 
-* **archive_groupchats** (boolean, default: `false`) - When enabled, MAM will store groupchat messages in recipients' individual archives. **USE WITH CAUTION!** May increase archive size significantly. Disabling this option for existing installation will neither remove such messages from MAM storage, nor will filter out them from search results.
+* **archive_groupchats** (boolean, default: `true`) - When enabled, MAM will store groupchat messages in recipients' individual archives. **USE WITH CAUTION!** May increase archive size significantly. Disabling this option for existing installation will neither remove such messages from MAM storage, nor will filter out them from search results.
+MongooseIM will print a warning on startup if `pm` MAM is enabled without `archive_groupchats` being explicitly set to a specific value. In one of the future MongooseIM releases this option will default to `false` (as it's more common use case and less DB-consuming) and the warning message will be removed.
 
 #### MUC-specific options
 

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -25,14 +25,25 @@ For now `odbc` backend has very limited support for this feature, while `cassand
 ### Options
 
 * **backend** (atom, default: `odbc`) - Database backend to use. `odbc`, `riak` and `cassandra` are supported.
-* **add_archived_element** (atom, default: `false`) - Add `<archived/>` element from MAM v0.2.
+* **add_archived_element** (boolean, default: `false`) - Add `<archived/>` element from MAM v0.2.
 * **is_archivable_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_archivable_message/3` callback](#is_archivable_message) that determines if the message should be archived.
-* **host** (string, default: `"conference.@HOST@"`) - MUC host that will be archived if MUC archiving is enabled. 
  **Warning**: if you are using MUC Light, make sure this option is set to the MUC Light domain.
 * **pm** (list | `false`, default: `[]`) - Override options for archivization of one-to-one messages. If the value of this option is `false`, one-to-one message archive is disabled.
 * **muc** (list | `false`, default: `false`) - Override options for archivization of group chat messages. If the value of this option is `false`, group chat message archive is disabled.
 
-All options described in this document can be overriden for a specific type of messages through `pm` and `muc` options, e.g.:
+**backend**, **add_archived_element** and **is_archivable_message** will be applied to both `pm` and `muc` (if they are enabled), unless overriden explicitly (see example below).
+
+#### PM-specific options
+
+* **archive_groupchats** (boolean, default: `false`) - When enabled, MAM will store groupchat messages in recipients' individual archives. **USE WITH CAUTION!** May increase archive size significantly. Disabling this option for existing installation will neither remove such messages from MAM storage, nor will filter out them from search results.
+
+#### MUC-specific options
+
+* **host** (string, default: `"conference.@HOST@"`) - MUC host that will be archived if MUC archiving is enabled. 
+
+#### Example
+
+The example below presents how to override common option for `muc` module specifically.
 
 ```erlang
 {mod_mam_meta, [

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -625,13 +625,13 @@ init_modules(odbc_mnesia_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm]),
     init_module(host(), mod_mam_odbc_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
     Config;
 init_modules(odbc_simple, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm, simple]),
     init_module(host(), mod_mam_odbc_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
@@ -640,44 +640,44 @@ init_modules(riak_timed_yz_buckets, C, Config) ->
     init_module(host(), mod_mam_riak_timed_arch_yz, [pm, muc]),
     init_module(host(), mod_mam_mnesia_prefs, [pm, muc,
                                                {archive_key, mam_archive_key_server_user}]),
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_muc,
-                [{host, muc_domain(Config)}, add_archived_element] ++ addin_mam_options(C)),
+                [{host, muc_domain(Config)}, add_archived_element] ++ addin_mam_options(C, Config)),
     Config;
 init_modules(cassandra, C, Config) ->
     init_module(host(), mod_mam_cassandra_arch, [pm]),
     init_module(host(), mod_mam_cassandra_prefs, [pm]),
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     Config;
 init_modules(odbc_async, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm, no_writer]),
     init_module(host(), mod_mam_odbc_async_writer, [pm, {flush_interval, 1}]), % 1ms
     init_module(host(), mod_mam_odbc_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
     Config;
 init_modules(odbc_async_pool, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm, no_writer]),
     init_module(host(), mod_mam_odbc_async_pool_writer, [pm, {flush_interval, 1}]), %% 1ms
     init_module(host(), mod_mam_odbc_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
     Config;
 init_modules(odbc_mnesia, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm]),
     init_module(host(), mod_mam_mnesia_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
     Config;
 init_modules(odbc_cache, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm]),
     init_module(host(), mod_mam_odbc_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
     init_module(host(), mod_mam_cache_user, [pm]),
     Config;
 init_modules(odbc_async_cache, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm, no_writer]),
     init_module(host(), mod_mam_odbc_async_pool_writer, [pm, {flush_interval, 1}]), %% 1ms
     init_module(host(), mod_mam_odbc_prefs, [pm]),
@@ -687,7 +687,7 @@ init_modules(odbc_async_cache, C, Config) ->
 init_modules(odbc_mnesia_muc_cache, _, _Config) ->
     skip;
 init_modules(odbc_mnesia_cache, C, Config) ->
-    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
+    init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm]),
     init_module(host(), mod_mam_mnesia_prefs, [pm]),
     init_module(host(), mod_mam_odbc_user, [pm]),
@@ -697,7 +697,7 @@ init_modules(odbc_mnesia_cache, C, Config) ->
 init_modules_for_muc_light(BackendType, Config) ->
     dynamic_modules:start(host(), mod_muc_light, [{host, binary_to_list(muc_light_host())}]),
     Config1 = init_modules(BackendType, muc_all, [{muc_domain, "muclight.@HOST@"} | Config]),
-    init_modules(BackendType, pm, Config1).
+    init_modules(BackendType, pm, [{archive_groupchats, false} | Config1]).
 
 end_modules(C, muc_light, Config) ->
     end_modules(C, generic, Config),
@@ -710,10 +710,13 @@ end_modules(_, _, Config) ->
 muc_domain(Config) ->
     proplists:get_value(muc_domain, Config, "muc.@HOST@").
 
-addin_mam_options(disabled_text_search) ->
-    [{full_text_search, false}];
-addin_mam_options(_) ->
-    [].
+addin_mam_options(disabled_text_search, Config) ->
+    [{full_text_search, false} | addin_mam_options(Config)];
+addin_mam_options(_BasicGroup, Config) ->
+    addin_mam_options(Config).
+
+addin_mam_options(Config) ->
+    [{archive_groupchats, proplists:get_value(archive_groupchats, Config, false)}].
 
 mam_modules() ->
     [mod_mam,

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -1246,9 +1246,9 @@ muc_light_shouldnt_modify_pm_archive(Config) ->
             then_pm_message_is_received(Bob, <<"private hi!">>),
 
             maybe_wait_for_archive(Config),
-            when_archive_query_is_sent(Alice, <<>>, Config),
+            when_archive_query_is_sent(Alice, undefined, Config),
             then_archive_response_is(Alice, [{message, Alice, <<"private hi!">>}], Config),
-            when_archive_query_is_sent(Bob, <<>>, Config),
+            when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [{message, Alice, <<"private hi!">>}], Config),
 
             M1 = when_muc_light_message_is_sent(Alice, Room,
@@ -1260,9 +1260,9 @@ muc_light_shouldnt_modify_pm_archive(Config) ->
             then_archive_response_is(Alice, [{create, [{Alice, owner}, {Bob, member}]},
                                              {muc_message, Room, Alice, <<"Msg 1">>}], Config),
 
-            when_archive_query_is_sent(Alice, <<>>, Config),
+            when_archive_query_is_sent(Alice, undefined, Config),
             then_archive_response_is(Alice, [{message, Alice, <<"private hi!">>}], Config),
-            when_archive_query_is_sent(Bob, <<>>, Config),
+            when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [{message, Alice, <<"private hi!">>}], Config)
         end).
 
@@ -1273,10 +1273,10 @@ muc_light_stored_in_pm_if_allowed_to(Config) ->
 
             maybe_wait_for_archive(Config),
             AliceAffEvent = {affiliations, [{Alice, owner}]},
-            when_archive_query_is_sent(Alice, <<>>, Config),
+            when_archive_query_is_sent(Alice, undefined, Config),
             then_archive_response_is(Alice, [AliceAffEvent], Config),
             BobAffEvent = {affiliations, [{Bob, member}]},
-            when_archive_query_is_sent(Bob, <<>>, Config),
+            when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [BobAffEvent], Config),
 
             M1 = when_muc_light_message_is_sent(Alice, Room, <<"Msg 1">>, <<"Id 1">>),
@@ -1284,9 +1284,9 @@ muc_light_stored_in_pm_if_allowed_to(Config) ->
 
             maybe_wait_for_archive(Config),
             MessageEvent = {muc_message, Room, Alice, <<"Msg 1">>},
-            when_archive_query_is_sent(Alice, <<>>, Config),
+            when_archive_query_is_sent(Alice, undefined, Config),
             then_archive_response_is(Alice, [AliceAffEvent, MessageEvent], Config),
-            when_archive_query_is_sent(Bob, <<>>, Config),
+            when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [BobAffEvent, MessageEvent], Config)
         end).
 
@@ -2455,7 +2455,10 @@ then_muc_light_affiliations_are_received_by(Users, {_Room, Affiliations}) ->
 
 when_archive_query_is_sent(Sender, RecipientJid, Config) ->
 	P = ?config(props, Config),
-    Request = escalus_stanza:to(stanza_archive_request(P, <<"q">>), RecipientJid),
+    Request = case RecipientJid of
+                  undefined -> stanza_archive_request(P, <<"q">>);
+                  _ -> escalus_stanza:to(stanza_archive_request(P, <<"q">>), RecipientJid)
+              end,
     escalus:send(Sender, Request).
 
 then_archive_response_is(Receiver, Expected, Config) ->

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -557,8 +557,10 @@ init_modules(odbc, muc_light, Config) ->
     init_module(host(), mod_mam_odbc_user, [muc, pm]),
     init_module(host(), mod_mam_odbc_arch, [muc, pm]),
     Config1;
-init_modules(cassandra, muc_light, Config) ->
-    init_modules_for_muc_light(cassandra, Config);
+init_modules(BT = riak_timed_yz_buckets, muc_light, config) ->
+    init_modules_for_muc_light(BT, config);
+init_modules(BT = cassandra, muc_light, config) ->
+    init_modules_for_muc_light(BT, config);
 init_modules(BackendType, muc_light, Config) ->
     Config1 = init_modules_for_muc_light(BackendType, Config),
     init_module(host(), mod_mam_odbc_user, [muc, pm]),

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -82,6 +82,7 @@
          muc_querying_for_all_messages/1,
          muc_querying_for_all_messages_with_jid/1,
          muc_light_simple/1,
+         muc_light_shouldnt_modify_pm_archive/1,
          messages_filtered_when_prefs_default_policy_is_always/1,
          messages_filtered_when_prefs_default_policy_is_never/1,
          messages_filtered_when_prefs_default_policy_is_roster/1,
@@ -98,7 +99,6 @@
 
 -import(mam_helper,
         [rpc_apply/3,
-         rpc_call/3,
          is_riak_enabled/1,
          is_cassandra_enabled/1,
          is_mam_possible/1,
@@ -162,7 +162,6 @@
          run_prefs_case/6,
          prefs_cases2/0,
          default_policy/1,
-         namespaces/0,
          get_all_messages/2,
          parse_messages/1,
          run_set_and_get_prefs_case/4,
@@ -347,7 +346,10 @@ muc_cases() ->
      ].
 
 muc_light_cases() ->
-    [muc_light_simple].
+    [
+     muc_light_simple,
+     muc_light_shouldnt_modify_pm_archive
+    ].
 
 muc_rsm_cases() ->
     rsm_cases().
@@ -548,49 +550,52 @@ end_per_group(Group, Config) ->
     escalus_fresh:clean(),
     delete_users(Config2).
 
-init_modules(C, muc_light, Config) ->
-    dynamic_modules:start(host(), mod_muc_light, [{host, binary_to_list(muc_light_host())}]),
-    Config1 = init_modules(C, muc_all, Config), %% Init more modules!
-    stop_module(host(), mod_mam_muc),
-    init_module(host(), mod_mam_muc, [{host, "muclight.@HOST@"}]),
+init_modules(odbc, muc_light, Config) ->
+    Config1 = init_modules_for_muc_light(odbc, Config),
+    init_module(host(), mod_mam_odbc_user, [muc, pm]),
+    init_module(host(), mod_mam_odbc_arch, [muc, pm]),
     Config1;
-
-
+init_modules(cassandra, muc_light, Config) ->
+    init_modules_for_muc_light(cassandra, Config);
+init_modules(BackendType, muc_light, Config) ->
+    Config1 = init_modules_for_muc_light(BackendType, Config),
+    init_module(host(), mod_mam_odbc_user, [muc, pm]),
+    Config1;
 init_modules(cassandra, muc_all, Config) ->
     init_module(host(), mod_mam_muc_cassandra_arch, []),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc, muc_all, Config) ->
     init_module(host(), mod_mam_odbc_arch, [muc]),
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_simple, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [muc, simple]),
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_async_pool, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [no_writer]),
     init_module(host(), mod_mam_muc_odbc_async_pool_writer, [{flush_interval, 1}]), %% 1ms
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_async_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, [no_writer]),
@@ -598,21 +603,21 @@ init_modules(odbc_async_cache, muc_all, Config) ->
     init_module(host(), mod_mam_odbc_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia_muc_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_muc_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc_mnesia_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
     init_module(host(), mod_mam_odbc_user, [muc]),
     init_module(host(), mod_mam_cache_user, [muc]),
-    init_module(host(), mod_mam_muc, [{host, "muc.@HOST@"}, add_archived_element]),
+    init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
 init_modules(odbc, C, Config) ->
     init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
@@ -632,7 +637,7 @@ init_modules(riak_timed_yz_buckets, C, Config) ->
                                                {archive_key, mam_archive_key_server_user}]),
     init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C)),
     init_module(host(), mod_mam_muc,
-                [{host, "muc.@HOST@"}, add_archived_element] ++ addin_mam_options(C)),
+                [{host, muc_domain(Config)}, add_archived_element] ++ addin_mam_options(C)),
     Config;
 init_modules(cassandra, C, Config) ->
     init_module(host(), mod_mam_cassandra_arch, [pm]),
@@ -684,6 +689,11 @@ init_modules(odbc_mnesia_cache, C, Config) ->
     init_module(host(), mod_mam_cache_user, [pm]),
     Config.
 
+init_modules_for_muc_light(BackendType, Config) ->
+    dynamic_modules:start(host(), mod_muc_light, [{host, binary_to_list(muc_light_host())}]),
+    Config1 = init_modules(BackendType, muc_all, [{muc_domain, "muclight.@HOST@"} | Config]),
+    init_modules(BackendType, pm, Config1).
+
 end_modules(C, muc_light, Config) ->
     end_modules(C, generic, Config),
     dynamic_modules:stop(host(), mod_muc_light),
@@ -691,6 +701,9 @@ end_modules(C, muc_light, Config) ->
 end_modules(_, _, Config) ->
     [stop_module(host(), M) || M <- mam_modules()],
     Config.
+
+muc_domain(Config) ->
+    proplists:get_value(muc_domain, Config, "muc.@HOST@").
 
 addin_mam_options(disabled_text_search) ->
     [{full_text_search, false}];
@@ -717,10 +730,11 @@ mam_modules() ->
 init_state(_, muc_all, Config) ->
     Config;
 init_state(C, muc_light, Config) ->
+    clean_archives(Config),
     init_state(C, muc04, Config);
-init_state(C, prefs_cases, Config) ->
+init_state(_C, prefs_cases, Config) ->
     Config;
-init_state(C, policy_violation, Config) ->
+init_state(_C, policy_violation, Config) ->
     rpc_apply(mod_mam, set_params,
               [ [{max_result_limit, 5}] ]),
     Config;
@@ -1180,44 +1194,63 @@ muc_querying_for_all_messages_with_jid(Config) ->
 
 muc_light_simple(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-            Room2 = muc_light_SUITE:room2(),
-            escalus:send(Alice, muc_light_SUITE:stanza_create_room(Room2, [], [])),
-            muc_light_SUITE:verify_aff_bcast([{Alice, owner}], [{Alice, owner}]),
-            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+            Room = <<"testroom">>,
+            given_muc_light_room(Room, Alice, []),
 
-            Room2BinJID = muc_light_SUITE:room_bin_jid(Room2),
-            MsgBody1 = <<"Message 1">>,
-            Id1 = <<"MyID1">>,
-            Stanza1 = escalus_stanza:set_id(
-                        escalus_stanza:groupchat_to(Room2BinJID, MsgBody1), Id1),
-            muc_helper:foreach_occupant(
-              [Alice], Stanza1, muc_light_SUITE:gc_message_verify_fun(Room2, MsgBody1, Id1)),
-            MsgBody2 = <<"Message 2">>,
-            Id2 = <<"MyID2">>,
-            Stanza2 = escalus_stanza:set_id(
-                        escalus_stanza:groupchat_to(Room2BinJID, MsgBody2), Id2),
-            muc_helper:foreach_occupant(
-              [Alice], Stanza2, muc_light_SUITE:gc_message_verify_fun(Room2, MsgBody2, Id2)),
-            escalus:send(Alice, muc_light_SUITE:stanza_aff_set(Room2, [{Bob, member}])),
-            muc_light_SUITE:verify_aff_bcast([{Alice, owner}, {Bob, member}], [{Bob, member}]),
+            M1 = when_muc_light_message_is_sent(Alice, Room,
+                                                <<"Msg 1">>, <<"Id1">>),
+            then_muc_light_message_is_received_by([Alice], M1),
 
-            P = ?config(props, Config),
-            maybe_wait_for_archive(Config),
+            M2 = when_muc_light_message_is_sent(Alice, Room,
+                                                <<"Message 2">>, <<"MyID2">>),
+            then_muc_light_message_is_received_by([Alice], M2),
 
-            ArchiveReqStanza = escalus_stanza:to(stanza_archive_request(P, <<"mlight">>),
-                                                 Room2BinJID),
-            escalus:send(Bob, ArchiveReqStanza),
-            [CreateEvent, Msg1, Msg2, BobAdd] = respond_messages(assert_respond_size(
-                                                          4, wait_archive_respond(P, Bob))),
+            Aff = when_muc_light_affiliations_are_set(Alice, Room, [{Bob, member}]),
+            then_muc_light_affiliations_are_received_by([Alice, Bob], Aff),
 
-            #forwarded_message{message_body = MsgBody1} = parse_forwarded_message(Msg1),
-            #forwarded_message{message_body = MsgBody2} = parse_forwarded_message(Msg2),
-
-            verify_archived_muc_light_aff_msg(parse_forwarded_message(CreateEvent),
-                                              [{Alice, owner}], true),
-            verify_archived_muc_light_aff_msg(parse_forwarded_message(BobAdd),
-                                              [{Bob, member}], false)
+            when_archive_query_is_sent(Bob, muc_light_SUITE:room_bin_jid(Room), Config),
+            ExpectedResponse = [{create, [{Alice, owner}]},
+                                {muc_message, Room, Alice, <<"Msg 1">>},
+                                {muc_message, Room, Alice, <<"Message 2">>},
+                                {affiliations, [{Bob, member}]}],
+            then_archive_response_is(Bob, ExpectedResponse, Config)
         end).
+
+muc_light_shouldnt_modify_pm_archive(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+            Room = <<"testroom2">>,
+            given_muc_light_room(Room, Alice, [{Bob, member}]),
+
+            when_pm_message_is_sent(Alice, Bob, <<"private hi!">>),
+            then_pm_message_is_received(Bob, <<"private hi!">>),
+
+            when_archive_query_is_sent(Alice, <<>>, Config),
+            then_archive_response_is(Alice, [{message, Alice, <<"private hi!">>}], Config),
+            when_archive_query_is_sent(Bob, <<>>, Config),
+            then_archive_response_is(Bob, [{message, Alice, <<"private hi!">>}], Config),
+
+            M1 = when_muc_light_message_is_sent(Alice, Room,
+                                                <<"Msg 1">>, <<"Id 1">>),
+            then_muc_light_message_is_received_by([Alice, Bob], M1),
+
+            when_archive_query_is_sent(Alice, muc_light_SUITE:room_bin_jid(Room), Config),
+            then_archive_response_is(Alice, [{create, [{Alice, owner}, {Bob, member}]},
+                                             {muc_message, Room, Alice, <<"Msg 1">>}], Config),
+
+            when_archive_query_is_sent(Alice, <<>>, Config),
+            then_archive_response_is(Alice, [{message, Alice, <<"private hi!">>}], Config),
+            when_archive_query_is_sent(Bob, <<>>, Config),
+            then_archive_response_is(Bob, [{message, Alice, <<"private hi!">>}], Config),
+            when_archive_query_is_sent(Bob, <<>>, Config),
+
+            ok
+        end).
+
+muc_light_room_jid(Room, User) ->
+    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    UserJid = escalus_utils:get_short_jid(User),
+    <<RoomJid/binary, $/, UserJid/binary>>.
+
 
 retrieve_form_fields(ConfigIn) ->
     escalus_fresh:story(ConfigIn, [{alice, 1}], fun(Alice) ->
@@ -2340,3 +2373,66 @@ text_search_messages() ->
        "pig officia.">>,
      <<"Spare ribs landjaeger pork belly, chuck aliquip turducken beef culpa nostrud.">>
     ].
+
+%% --------- MUC Light stories helpers ----------
+
+when_pm_message_is_sent(Sender, Receiver, Body) ->
+    escalus:send(Sender, escalus_stanza:chat_to(Receiver, Body)).
+
+then_pm_message_is_received(Receiver, Body) ->
+    escalus:assert(is_chat_message, [Body], escalus:wait_for_stanza(Receiver)).
+
+given_muc_light_room(Name, Creator, InitOccupants) ->
+    CreateStanza = muc_light_SUITE:stanza_create_room(Name, [], InitOccupants),
+    escalus:send(Creator, CreateStanza),
+    Affiliations = [{Creator, owner} | InitOccupants],
+    muc_light_SUITE:verify_aff_bcast(Affiliations, Affiliations),
+    escalus:assert(is_iq_result, escalus:wait_for_stanza(Creator)).
+
+when_muc_light_message_is_sent(Sender, Room, Body, Id) ->
+    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    Stanza = escalus_stanza:set_id(
+               escalus_stanza:groupchat_to(RoomJid, Body), Id),
+    escalus:send(Sender, Stanza),
+    {Room, Body, Id}.
+
+then_muc_light_message_is_received_by(Users, {Room, Body, Id}) ->
+    F = muc_light_SUITE:gc_message_verify_fun(Room, Body, Id),
+    [ F(escalus:wait_for_stanza(User)) || User <- Users ].
+
+when_muc_light_affiliations_are_set(Sender, Room, Affiliations) ->
+    Stanza = muc_light_SUITE:stanza_aff_set(Room, Affiliations),
+    escalus:send(Sender, Stanza),
+    {Room, Affiliations}.
+
+then_muc_light_affiliations_are_received_by(Users, {_Room, Affiliations}) ->
+    F = muc_light_SUITE:aff_msg_verify_fun(Affiliations),
+    [ F(escalus:wait_for_stanza(User)) || User <- Users ].
+
+when_archive_query_is_sent(Sender, RecipientJid, Config) ->
+	P = ?config(props, Config),
+    Request = escalus_stanza:to(stanza_archive_request(P, <<"q">>), RecipientJid),
+    escalus:send(Sender, Request).
+
+then_archive_response_is(Receiver, Expected, Config) ->
+	P = ?config(props, Config),
+    Response = wait_archive_respond(P, Receiver),
+    Stanzas = respond_messages(assert_respond_size(length(Expected), Response)),
+    ParsedStanzas = [ parse_forwarded_message(Stanza) || Stanza <- Stanzas ],
+    [ assert_archive_element(Element)
+      || Element <- lists:zip(Expected, ParsedStanzas) ].
+
+assert_archive_element({{create, Affiliations}, Stanza}) ->
+    verify_archived_muc_light_aff_msg(Stanza, Affiliations, _IsCreate = true);
+assert_archive_element({{affiliations, Affiliations}, Stanza}) ->
+    verify_archived_muc_light_aff_msg(Stanza, Affiliations, _IsCreate = false);
+assert_archive_element({{muc_message, Room, Sender, Body}, Stanza}) ->
+    FromJid = escalus_utils:jid_to_lower(muc_light_room_jid(Room, Sender)),
+    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    #forwarded_message{message_body = Body,
+                       from = RoomJid,
+                       delay_from = FromJid} = Stanza;
+assert_archive_element({{message, Sender, Body}, Stanza}) ->
+    FromJid = escalus_utils:jid_to_lower(escalus_utils:get_jid(Sender)),
+    #forwarded_message{message_body = Body, delay_from = FromJid} = Stanza.
+

--- a/test.disabled/ejabberd_tests/tests/mam_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_helper.erl
@@ -750,7 +750,7 @@ send_rsm_messages(Config) ->
         lists:foreach(fun(N) ->
                               escalus:send(Alice,
                                            escalus_stanza:chat_to(Bob, generate_message_text(N))),
-                              timer:sleep(1)
+                              timer:sleep(5)
                       end, lists:seq(1, 15)),
         %% Bob is waiting for 15 messages for 5 seconds.
         escalus:wait_for_stanzas(Bob, 15, 5000),

--- a/test.disabled/ejabberd_tests/tests/mongoose_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/mongoose_helper.erl
@@ -129,6 +129,7 @@ generic_count_backend(mod_last_odbc) -> count_odbc(<<"last">>);
 generic_count_backend(mod_last_riak) -> count_riak(<<"last">>);
 generic_count_backend(mod_privacy_mnesia) -> count_wildpattern(privacy);
 generic_count_backend(mod_privacy_odbc) -> count_odbc(<<"privacy_list">>);
+generic_count_backend(mod_privacy_riak) -> count_riak(<<"privacy_lists">>);
 generic_count_backend(mod_private_mnesia) -> count_wildpattern(private_storage);
 generic_count_backend(mod_private_odbc) -> count_odbc(<<"private_storage">>);
 generic_count_backend(mod_private_mysql) -> count_odbc(<<"private_storage">>);

--- a/test.disabled/ejabberd_tests/tests/muc_light_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_SUITE.erl
@@ -72,6 +72,7 @@
          verify_aff_bcast/2,
          room_bin_jid/1,
          gc_message_verify_fun/3,
+         aff_msg_verify_fun/1,
          stanza_aff_set/2,
          bin_aff_users/1,
          verify_aff_users/2,


### PR DESCRIPTION
This PR addresses #827 and #1231

Proposed changes include:
* When there is incoming groupchat message to a user, `mod_mam` stores it in individual archive only when `archive_groupchats` flag is enabled

BTW: Thanks @studzien for test case!

**TODO:**

- [x] Add positive testcase for new flag
- [x] ~Add test case for `mod_muc` integration (if it's affected as well)~ I can't see a way of starting PM+MUC `mod_mam` for MUC cases without making `init_modules` function even longer. I think I'd like to refactor `mam_SUITE` first as a separate task.