### PR TITLE
Allow to specify Cowboy options in configuration file

### DIFF
--- a/apps/ejabberd/test/cowboy_SUITE.erl
+++ b/apps/ejabberd/test/cowboy_SUITE.erl
@@ -209,7 +209,7 @@ start_cowboy_returns_error_eaddrinuse(_C) ->
     Opts = [{transport_options, [{port, 8088},
                                  {ip, {127, 0, 0, 1}}]},
             {modules, []},
-            {retires, {2, 10}}],
+            {retries, {2, 10}}],
     {ok, _Pid} = ejabberd_cowboy:start_cowboy(a_ref, Opts),
     Result = ejabberd_cowboy:start_cowboy(a_ref_2, Opts),
     {error, eaddrinuse} = Result.

--- a/apps/ejabberd/test/cowboy_SUITE.erl
+++ b/apps/ejabberd/test/cowboy_SUITE.erl
@@ -206,7 +206,10 @@ mixed_requests(_Config) ->
     Responses = lists:duplicate(50, {TextPong, true, TextPong, true}).
 
 start_cowboy_returns_error_eaddrinuse(_C) ->
-    Opts = [{port, 8088}, {ip, {127, 0, 0, 1}}, {modules, []}, {retires, {2, 10}}],
+    Opts = [{transport_options, [{port, 8088},
+                                 {ip, {127, 0, 0, 1}}]},
+            {modules, []},
+            {retires, {2, 10}}],
     {ok, _Pid} = ejabberd_cowboy:start_cowboy(a_ref, Opts),
     Result = ejabberd_cowboy:start_cowboy(a_ref_2, Opts),
     {error, eaddrinuse} = Result.

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -34,7 +34,8 @@ Manages all HTTP-based services, such as BOSH (HTTP long-polling) and WebSocket.
 
 * `ip` (IP tuple, optional, default: `{0,0,0,0}`) - IP address to bind to.
 * `num_acceptors` (positive integer, optional, default: 100) - Number of acceptors.
-* `max_connections` (positive integer, optional, default: 1024) - Maximum total number of HTTP(S) connections.
+* `transport_options` (proplist, optional, default: []) - Ranch-specific transport options. See [ranch:opt()](https://ninenines.eu/docs/en/ranch/1.2/manual/ranch/#_opt).
+* `protocol_options` (proplist, optional, default: []) - Protocol configuration options for Cowboy. See [Cowboy protocol manual](https://ninenines.eu/docs/en/cowboy/1.0/manual/cowboy_protocol/)
 * `ssl` (list of ssl options, required for https, no default value) - If specified, https will be used. Accepts all ranch_ssl options that don't take fun() parameters. Only `certfile` and `keyfile` are mandatory. See [ranch_ssl documentation](https://github.com/ninenines/ranch/blob/master/doc/src/manual/ranch_ssl.asciidoc) for details. A minimal usage would be as follows:
 
         {ssl, [

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -116,7 +116,7 @@
   %% BOSH and WS endpoints over HTTP
   { {{{cowboy_port}}}, ejabberd_cowboy, [
       {num_acceptors, 10},
-      {max_connections, 1024},
+      {transport_options, [{max_connections, 1024}]},
       {modules, [
 
           {"_", "/http-bind", mod_bosh},
@@ -161,7 +161,7 @@
   %% BOSH and WS endpoints over HTTPS
   { {{{cowboy_port_secure}}}, ejabberd_cowboy, [
         {num_acceptors, 10},
-        {max_connections, 1024},
+        {transport_options, [{max_connections, 1024}]},
         {{{https_config}}}
         {modules, [
             {"_", "/http-bind", mod_bosh},
@@ -182,7 +182,7 @@
 
   { {{{http_api_endpoint}}} , ejabberd_cowboy, [
       {num_acceptors, 10},
-      {max_connections, 1024},
+      {transport_options, [{max_connections, 1024}]},
       {modules, [
           {"localhost", "/api", mongoose_api_admin, []}
       ]}
@@ -190,8 +190,8 @@
 
   { {{{http_api_client_endpoint}}} , ejabberd_cowboy, [
       {num_acceptors, 10},
-      {max_connections, 1024},
-      {compress, true},
+      {transport_options, [{max_connections, 1024}]},
+      {protocol_options, [{compress, true}]},
       {{{https_config}}}
       {modules, [
           {"_", "/api/sse", lasse_handler, [mongoose_client_api_sse]},
@@ -206,7 +206,7 @@
 
   { {{{http_api_old_endpoint}}} , ejabberd_cowboy, [
       {num_acceptors, 10},
-      {max_connections, 1024},
+      {transport_options, [{max_connections, 1024}]},
       {modules, [
           {"localhost", "/api", mongoose_api, [{handlers, [mongoose_api_metrics,
                                                            mongoose_api_users]}]}


### PR DESCRIPTION
This PR addresses #

Proposed changes include:
* describe the functionality changes:
  Change way of providing configuration options in ejabberd.cfg file. Instead of providing only arbitrary options, we can provide all options now.
* describe new or updated tests
  Adapted one test case to new configuration.
* docs:
  Add info about cowboy endpoint cofiguration

