### PR TITLE
Fix race condition between caps and PEP

### DIFF
--- a/apps/ejabberd/src/mod_pubsub.erl
+++ b/apps/ejabberd/src/mod_pubsub.erl
@@ -65,7 +65,7 @@
 -define(PUSHNODE, <<"push">>).
 
 %% exports for hooks
--export([presence_probe/4, caps_change/4, caps_change/5,
+-export([presence_probe/4, caps_recognised/4,
          in_subscription/6, out_subscription/5,
          on_user_offline/5, remove_user/2, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
@@ -324,10 +324,8 @@ init([ServerHost, Opts]) ->
 
     case lists:member(?PEPNODE, Plugins) of
         true ->
-            ejabberd_hooks:add(caps_add, ServerHost,
-                               ?MODULE, caps_change, 80),
-            ejabberd_hooks:add(caps_update, ServerHost,
-                               ?MODULE, caps_change, 80),
+            ejabberd_hooks:add(caps_recognised, ServerHost,
+                               ?MODULE, caps_recognised, 80),
             ejabberd_hooks:add(disco_sm_identity, ServerHost,
                                ?MODULE, disco_sm_identity, 75),
             ejabberd_hooks:add(disco_sm_features, ServerHost,
@@ -725,15 +723,9 @@ handle_pep_authorization_response(Acc) ->
 %% presence hooks handling functions
 %%
 
-caps_change(Acc, FromJID, ToJID, Pid, Features) ->
-    caps_change(FromJID, ToJID, Pid, Features),
+caps_recognised(Acc, #jid{ lserver = S } = JID, Pid, _Features) ->
+    notify_send_loop(S, {send_last_pep_items, JID, Pid}),
     Acc.
-
-caps_change(#jid{luser = _U, lserver = S, lresource = _R} = FromJID, ToJID, Pid, _Features) ->
-    case jid:to_lower(FromJID) == jid:to_lower(ToJID) of
-        true -> notify_send_loop(S, {send_last_pep_items, ToJID, Pid});
-        false -> ok
-    end.
 
 presence_probe(Acc, #jid{luser = _U, lserver = S, lresource = _R} = JID, JID, _Pid) ->
     notify_send_loop(S, {send_last_pubsub_items, _Recipient = JID}),
@@ -898,10 +890,8 @@ terminate(_Reason, #state{host = Host, server_host = ServerHost,
     ejabberd_router:unregister_route(Host),
     case lists:member(?PEPNODE, Plugins) of
         true ->
-            ejabberd_hooks:delete(caps_add, ServerHost,
-                                  ?MODULE, caps_change, 80),
-            ejabberd_hooks:delete(caps_update, ServerHost,
-                                  ?MODULE, caps_change, 80),
+            ejabberd_hooks:delete(caps_recognised, ServerHost,
+                                  ?MODULE, caps_recognised, 80),
             ejabberd_hooks:delete(disco_sm_identity, ServerHost,
                                   ?MODULE, disco_sm_identity, 75),
             ejabberd_hooks:delete(disco_sm_features, ServerHost,


### PR DESCRIPTION
This PR addresses random `pep_SUITE` failures on Travis.

Before this change, a scenario was possible when a check for supported features in cache (when about to send PEP message) was performed before processing feature response from a client. This PR moves "PEP last item resend" trigger to a place when it's 100% certain we have the features stored in cache.

Unfortunately it may lead to duplicated notifications in federation but it's because `mod_caps` should subscribe not to `user_receive_packet` but to some hook in s2s. I think it is a separate matter to investigate (that requires new test case). It's out of scope of fixing failures on Travis.

It's difficult to reproduce with a dedicated integration test, because it would require ensuring that feature request is sent after PEP resend is processed. I don't like the idea of introducing crude `timer:sleep` here and I don't like the one I've added but the only way to avoid it is to introduce something like `wait_for_pubsub_loop`.