### PR TITLE
uncommented registration of hook and handler calls in mongoose_acc

### DIFF
--- a/apps/ejabberd/src/ejabberd_hooks.erl
+++ b/apps/ejabberd/src/ejabberd_hooks.erl
@@ -129,17 +129,16 @@ run_fold(Hook, Host, Val, Args) ->
     end,
     record(Hook, Res).
 
-record(_Hook, Acc) ->
-    Acc.
+record(Hook, Acc) ->
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
     % unless load tests show that the impact on performance is negligible
-%%    case mongoose_acc:is_acc(Acc) of % this check will go away some day
-%%        true ->
-%%            mongoose_acc:append(hooks_run, Hook, Acc);
-%%        false ->
-%%            Acc
-%%    end.
+    case mongoose_acc:is_acc(Acc) of % this check will go away some day
+        true ->
+            mongoose_acc:append(hooks_run, Hook, Acc);
+        false ->
+            Acc
+    end.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_server
@@ -259,14 +258,13 @@ hook_apply_function(Module, Function, Hook, Val, Args) ->
     record(Hook, Module, Function, Result).
 
 
-record(_Hook, _Module, _Function, Acc) ->
-    Acc.
+record(Hook, Module, Function, Acc) ->
     % just to show some nice things we can do now
     % this should probably be protected by a compilation flag
     % unless load tests show that the impact on performance is negligible
-%%    case mongoose_acc:is_acc(Acc) of % this check will go away some day
-%%        true ->
-%%            mongoose_acc:append(handlers_run, {Hook, Module, Function}, Acc);
-%%        false ->
-%%            Acc
-%%    end.
+    case mongoose_acc:is_acc(Acc) of % this check will go away some day
+        true ->
+            mongoose_acc:append(handlers_run, {Hook, Module, Function}, Acc);
+        false ->
+            Acc
+    end.

--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -13,7 +13,7 @@
         {exml, ".*", {git, "git://github.com/esl/exml.git", "d365533"}},
         {escalus, ".*", {git, "git://github.com/esl/escalus.git", "868afbb"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
-        {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
+        {cowboy, ".*", {git, "git://github.com/bartekgorny/cowboy.git", {branch, "quickfix"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},
         {chatterbox, ".*", {git, "https://github.com/joedevivo/chatterbox.git", {tag, "0.4.1"}}}
 ]}.


### PR DESCRIPTION
This PR is for load-testing - here all calls to hooks and handlers are recorded in the accumulator, for tracing and debugging. We want to see whether it has an impact on performance.

