### PR TITLE
Properly handle incoming presence of type error by MUC room

### DIFF
--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -1036,8 +1036,7 @@ process_presence_error(From, Packet, Lang, StateData) ->
         true ->
             ErrorText
             = <<"This participant is kicked from the room because he sent an error presence">>,
-            expulse_participant(Packet, From, StateData, translate:translate(Lang, ErrorText)),
-            StateData;
+            expulse_participant(Packet, From, StateData, translate:translate(Lang, ErrorText));
         _ ->
             StateData
     end.


### PR DESCRIPTION
Function expulse_participant updates state, but it's not what the original code expects.

This PR addresses a bug.

Proposed changes include:
* Kicked user is actually kicked
* Room state is properly updated

