### PR TITLE
rebar.config.script: return updated config

### DIFF
--- a/apps/ejabberd/rebar.config.script
+++ b/apps/ejabberd/rebar.config.script
@@ -70,7 +70,7 @@ MaybeErtsExitSupport = fun(Config) ->
         _ -> ""
     end,
     true = Setenv("CFLAGS", ExitFlag),
-    CONFIG
+    Config
 end,
 
 lists:foldl(fun(Fun, Cfg) -> Fun(Cfg) end, CONFIG,


### PR DESCRIPTION
Fix copy/paste error in rebar.config.script from commit da78e183b:
the initial config was returned instead of the modified config.

