### PR TITLE
Feature odbc backend for mod muc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
         - odbc-postgresql
         - slapd
         - ldap-utils
+    hosts:
+        - muc.localhost
 before_install:
         - curl -L https://github.com/docker/compose/releases/download/1.11.2/docker-compose-`uname -s`-`uname -m` > docker-compose
         - chmod +x docker-compose

--- a/apps/ejabberd/include/mod_muc.hrl
+++ b/apps/ejabberd/include/mod_muc.hrl
@@ -1,0 +1,13 @@
+-record(muc_room, {
+          name_host,
+          opts
+         }).
+
+-record(muc_online_room, {name_host,
+                          pid
+                         }).
+
+-record(muc_registered, {
+          us_host,
+          nick
+         }).

--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -301,3 +301,21 @@ CREATE TABLE muc_light_blocking(
 
 CREATE INDEX i_muc_light_blocking USING HASH ON muc_light_blocking(luser, lserver);
 
+CREATE TABLE muc_room (
+    name text NOT NULL,
+    host text NOT NULL,
+    opts mediumtext NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX i_muc_room_name_host USING BTREE ON muc_room(name(75), host(75));
+
+CREATE TABLE muc_registered (
+    jid text NOT NULL,
+    host text NOT NULL,
+    nick text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE INDEX i_muc_registered_nick USING BTREE ON muc_registered(nick(75));
+CREATE UNIQUE INDEX i_muc_registered_jid_host USING BTREE ON muc_registered(jid(75), host(75));

--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -302,20 +302,18 @@ CREATE TABLE muc_light_blocking(
 CREATE INDEX i_muc_light_blocking USING HASH ON muc_light_blocking(luser, lserver);
 
 CREATE TABLE muc_room (
-    name text NOT NULL,
-    host text NOT NULL,
-    opts mediumtext NOT NULL,
-    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+    name        VARCHAR(250) NOT NULL,
+    host        VARCHAR(250) NOT NULL,
+    opts        mediumtext   NOT NULL,
+    created_at  timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(host, name)
+)  ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE muc_registered(
+    jid        VARCHAR(250) NOT NULL,
+    host       VARCHAR(250) NOT NULL,
+    nick       VARCHAR(250) NOT NULL,
+    created_at timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(host, jid)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
-CREATE UNIQUE INDEX i_muc_room_name_host USING BTREE ON muc_room(name(75), host(75));
-
-CREATE TABLE muc_registered (
-    jid text NOT NULL,
-    host text NOT NULL,
-    nick text NOT NULL,
-    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
-CREATE INDEX i_muc_registered_nick USING BTREE ON muc_registered(nick(75));
-CREATE UNIQUE INDEX i_muc_registered_jid_host USING BTREE ON muc_registered(jid(75), host(75));
+CREATE UNIQUE INDEX i_muc_registered_host_nick USING BTREE ON muc_registered(host(75), nick(75));

--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -303,7 +303,8 @@ CREATE INDEX i_muc_light_blocking USING HASH ON muc_light_blocking(luser, lserve
 
 CREATE TABLE muc_room (
     name        VARCHAR(250) NOT NULL,
-    host        VARCHAR(250) NOT NULL,
+    -- According to RFC 1035 the length of a FQDN is limited to 255 characters
+    host        VARCHAR(250) CHARACTER SET ASCII NOT NULL,
     opts        mediumtext   NOT NULL,
     created_at  timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY(host, name)

--- a/apps/ejabberd/priv/pg.sql
+++ b/apps/ejabberd/priv/pg.sql
@@ -286,3 +286,20 @@ CREATE TABLE muc_light_blocking(
 );
 
 CREATE INDEX i_muc_light_blocking ON muc_light_blocking (luser, lserver);
+
+CREATE TABLE muc_room (
+    name VARCHAR(250) NOT NULL,
+    host VARCHAR(250) NOT NULL,
+    opts text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(host, name)
+);
+
+CREATE TABLE muc_registered (
+    jid text NOT NULL,
+    host text NOT NULL,
+    nick text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(host, jid)
+);
+CREATE UNIQUE INDEX i_muc_registered_host_nick ON muc_registered(host, nick);

--- a/apps/ejabberd/src/jlib.erl
+++ b/apps/ejabberd/src/jlib.erl
@@ -59,7 +59,9 @@
          stanza_errort/5,
          stream_error/1,
          stream_errort/3,
-         remove_delay_tags/1]).
+         remove_delay_tags/1,
+         expr_to_term/1,
+         term_to_expr/1]).
 
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl"). % only used to define stream types
@@ -875,3 +877,12 @@ remove_delay_tags(#xmlel{children = Els} = Packet) ->
                               El ++ [R]
                 end, [], Els),
     Packet#xmlel{children=NEl}.
+
+expr_to_term(Expr) ->
+    Str = binary_to_list(<<Expr/binary, ".">>),
+    {ok, Tokens, _} = erl_scan:string(Str),
+    {ok, Term} = erl_parse:parse_term(Tokens),
+    Term.
+
+term_to_expr(Term) ->
+    list_to_binary(io_lib:print(Term)).

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -85,7 +85,7 @@
         {From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: packet()}.
 -type access() :: {_AccessRoute, _AccessCreate, _AccessAdmin, _AccessPersistent}.
 
--include_lib("ejabberd/include/mod_muc.hrl").
+-include("mod_muc.hrl").
 
 -type muc_room() :: #muc_room{
                        name_host    :: room_host(),

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -287,11 +287,11 @@ init([Host, Opts]) ->
 
     case gen_mod:get_module_opt(Host, mod_muc, load_permanent_rooms_at_startup, false) of
         false ->
-            ?ERROR_MSG("issue=load_permanent_rooms_at_startup, skip=true, "
-                       "details=\"each room is loaded when someone access the room\"", []);
+            ?INFO_MSG("issue=load_permanent_rooms_at_startup, skip=true, "
+                      "details=\"each room is loaded when someone access the room\"", []);
         true ->
-            ?ERROR_MSG("issue=load_permanent_rooms_at_startup, skip=false, "
-                       "details=\"it can take some time\"", []),
+            ?INFO_MSG("issue=load_permanent_rooms_at_startup, skip=false, "
+                      "details=\"it can take some time\"", []),
             load_permanent_rooms(MyHost, Host,
                                  {Access, AccessCreate, AccessAdmin, AccessPersistent},
                                  HistorySize, RoomShaper, HttpAuthPool)

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -538,13 +538,13 @@ route_packet_to_nonexistent_room(Room, From, To, Packet,
                                         access = Access} = State) ->
 
     case restore_room(ServerHost, Host, Room) of
-        error ->
+        {error, _} ->
             Lang = exml_query:attr(Packet, <<"xml:lang">>, <<>>),
             ErrText = <<"Conference room does not exist">>,
             Err = jlib:make_error_reply(
                     Packet, ?ERRT_ITEM_NOT_FOUND(Lang, ErrText)),
             ejabberd_router:route(To, From, Err);
-        Opts ->
+        {ok, Opts} ->
             ?DEBUG("MUC: restore room '~s'~n", [Room]),
             #state{history_size = HistorySize,
                    room_shaper = RoomShaper,
@@ -708,13 +708,13 @@ start_new_room(Host, ServerHost, Access, Room,
                HistorySize, RoomShaper, HttpAuthPool, From,
                Nick, DefRoomOpts) ->
     case mod_muc_db_backend:restore_room(ServerHost, Host, Room) of
-        error ->
+        {error, _} ->
             ?DEBUG("MUC: open new room '~s'~n", [Room]),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
                                RoomShaper, HttpAuthPool, From,
                                Nick, DefRoomOpts);
-        Opts ->
+        {ok, Opts} ->
             ?DEBUG("MUC: restore room '~s'~n", [Room]),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
@@ -891,9 +891,9 @@ iq_get_register_info(ServerHost, Host, From, Lang) ->
         case catch get_nick(ServerHost, Host, From) of
             {'EXIT', _Reason} ->
                 {<<>>, []};
-            error ->
+            {error, _} ->
                 {<<>>, []};
-            N ->
+            {ok, N} ->
                 {N, [#xmlel{name = <<"registered">>}]}
         end,
     ClientReqText = translate:translate(

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -286,9 +286,17 @@ init([Host, Opts]) ->
     ejabberd_router:register_route(MyHost, mongoose_packet_handler:new(?MODULE, State)),
     mongoose_subhosts:register(Host, MyHost),
 
-    load_permanent_rooms(MyHost, Host,
-                         {Access, AccessCreate, AccessAdmin, AccessPersistent},
-                         HistorySize, RoomShaper, HttpAuthPool),
+    case gen_mod:get_module_opt(Host, mod_muc, load_permanent_rooms_at_startup, false) of
+        false ->
+            ?ERROR_MSG("issue=load_permanent_rooms_at_startup, skip=true, "
+                       "details=\"each room is loaded when someone access the room\"", []);
+        true ->
+            ?ERROR_MSG("issue=load_permanent_rooms_at_startup, skip=false, "
+                       "details=\"it can take some time\"", []),
+            load_permanent_rooms(MyHost, Host,
+                                 {Access, AccessCreate, AccessAdmin, AccessPersistent},
+                                 HistorySize, RoomShaper, HttpAuthPool)
+    end,
     set_persistent_rooms_timer(State),
     {ok, State}.
 

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -139,7 +139,7 @@ start_link(Host, Opts) ->
 start(Host, Opts) ->
     ensure_metrics(Host),
     TrackedDBFuns = [store_room, restore_room, forget_room, get_rooms,
-                     can_use_nick, get_nick, set_nick],
+                     can_use_nick, get_nick, set_nick, unset_nick],
     gen_mod:start_backend_module(mod_muc_db, Opts, TrackedDBFuns),
     start_supervisor(Host),
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
@@ -228,6 +228,9 @@ can_use_nick(ServerHost, Host, JID, Nick) ->
 
 set_nick(LServer, Host, From, Nick) ->
     mod_muc_db_backend:set_nick(LServer, Host, From, Nick).
+
+unset_nick(LServer, Host, From) ->
+    mod_muc_db_backend:unset_nick(LServer, Host, From).
 
 get_nick(LServer, Host, From) ->
     mod_muc_db_backend:get_nick(LServer, Host, From).
@@ -586,16 +589,17 @@ route_by_type(<<"iq">>, {From, To, Packet}, #state{host = Host} = State) ->
         #iq{type = get, xmlns = ?NS_DISCO_ITEMS} = IQ ->
             spawn(?MODULE, process_iq_disco_items, [Host, From, To, IQ]);
         #iq{type = get, xmlns = ?NS_REGISTER = XMLNS, lang = Lang} = IQ ->
+            Result = iq_get_register_info(ServerHost, Host, From, Lang),
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = [{<<"xmlns">>, XMLNS}],
-                                         children = iq_get_register_info(Host, From, Lang)}]},
+                                         children = Result}]},
             ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{type = set,
             xmlns = ?NS_REGISTER = XMLNS,
             lang = Lang,
             sub_el = SubEl} = IQ ->
-            case process_iq_register_set(Host, From, SubEl, Lang) of
+            case process_iq_register_set(ServerHost, Host, From, SubEl, Lang) of
                 {result, IQRes} ->
                     Res = IQ#iq{type = result,
                                 sub_el = [#xmlel{name = <<"query">>,
@@ -879,13 +883,12 @@ iq_get_unique(From) ->
                                                          randoms:get_string()]))}.
 
 
--spec iq_get_register_info('undefined' | ejabberd:server(),
+-spec iq_get_register_info(ejabberd:server(), ejabberd:server(),
         ejabberd:simple_jid() | ejabberd:jid(), ejabberd:lang())
             -> [jlib:xmlel(), ...].
-iq_get_register_info(Host, From, Lang) ->
-    {_LUser, LServer, _} = jid:to_lower(From),
+iq_get_register_info(ServerHost, Host, From, Lang) ->
     {Nick, Registered} =
-        case catch get_nick(LServer, Host, From) of
+        case catch get_nick(ServerHost, Host, From) of
             {'EXIT', _Reason} ->
                 {<<>>, []};
             error ->
@@ -911,25 +914,44 @@ iq_get_register_info(Host, From, Lang) ->
                         xfield(<<"text-single">>, <<"Nickname">>, <<"nick">>, Nick, Lang)]}].
 
 
--spec iq_set_register_info(ejabberd:server(),
+-spec iq_set_register_info(ejabberd:server(), ejabberd:server(),
         ejabberd:simple_jid() | ejabberd:jid(), nick(), ejabberd:lang())
             -> {'error', jlib:xmlel()} | {'result', []}.
-iq_set_register_info(Host, From, Nick, Lang) ->
-    {_LUser, LServer, _} = jid:to_lower(From),
-    case set_nick(LServer, Host, From, Nick) of
-        {atomic, ok} ->
+iq_set_register_info(ServerHost, Host, From, Nick, Lang) ->
+    case set_nick(ServerHost, Host, From, Nick) of
+        ok ->
             {result, []};
-        {atomic, false} ->
+        {error, conflict} ->
             ErrText = <<"That nickname is registered by another person">>,
             {error, ?ERRT_CONFLICT(Lang, ErrText)};
-        _ ->
+        {error, should_not_be_empty} ->
+            ErrText = <<"You must fill in field \"Nickname\" in the form">>,
+            {error, ?ERRT_NOT_ACCEPTABLE(Lang, ErrText)};
+        {error, ErrorReason} ->
+            ?ERROR_MSG("issue=iq_set_register_info_failed, "
+                        "jid=~ts, nick=~p, reason=~p",
+                       [jid:to_binary(From), Nick, ErrorReason]),
             {error, ?ERR_INTERNAL_SERVER_ERROR}
     end.
 
--spec process_iq_register_set(ejabberd:server(), ejabberd:jid(),
-        jlib:xmlel(), ejabberd:lang())
+-spec iq_set_unregister_info(ejabberd:server(), ejabberd:server(),
+        ejabberd:simple_jid() | ejabberd:jid(), ejabberd:lang())
             -> {'error', jlib:xmlel()} | {'result', []}.
-process_iq_register_set(Host, From, SubEl, Lang) ->
+iq_set_unregister_info(ServerHost, Host, From, _Lang) ->
+    case unset_nick(ServerHost, Host, From) of
+        ok ->
+            {result, []};
+        {error, ErrorReason} ->
+            ?ERROR_MSG("issue=iq_set_unregister_info_failed, "
+                        "jid=~ts, reason=~p",
+                       [jid:to_binary(From), ErrorReason]),
+            {error, ?ERR_INTERNAL_SERVER_ERROR}
+    end.
+
+-spec process_iq_register_set(ejabberd:server(), ejabberd:server(),
+                              ejabberd:jid(), jlib:xmlel(), ejabberd:lang())
+            -> {'error', jlib:xmlel()} | {'result', []}.
+process_iq_register_set(ServerHost, Host, From, SubEl, Lang) ->
     #xmlel{children = Els} = SubEl,
     case xml:get_subtag(SubEl, <<"remove">>) of
         false ->
@@ -937,20 +959,21 @@ process_iq_register_set(Host, From, SubEl, Lang) ->
                 [#xmlel{name = <<"x">>} = XEl] ->
                     process_register(xml:get_tag_attr_s(<<"xmlns">>, XEl),
                                      xml:get_tag_attr_s(<<"type">>, XEl),
-                                     Host, From, Lang, XEl);
+                                     ServerHost, Host, From, Lang, XEl);
                 _ ->
                     {error, ?ERR_BAD_REQUEST}
             end;
         _ ->
-            iq_set_register_info(Host, From, <<>>, Lang)
+            iq_set_unregister_info(ServerHost, Host, From, Lang)
     end.
 
--spec process_register(XMLNS :: binary(), Type :: binary(), Host :: ejabberd:server(),
+-spec process_register(XMLNS :: binary(), Type :: binary(),
+                       ServerHost :: ejabberd:server(), Host :: ejabberd:server(),
                        From :: jid(), Lang :: ejabberd:lang(), XEl :: exml:element()) ->
     {error, exml:element()} | {result, []}.
-process_register(?NS_XDATA, <<"cancel">>, _Host, _From, _Lang, _XEl) ->
+process_register(?NS_XDATA, <<"cancel">>, _ServerHost, _Host, _From, _Lang, _XEl) ->
     {result, []};
-process_register(?NS_XDATA, <<"submit">>, Host, From, Lang, XEl) ->
+process_register(?NS_XDATA, <<"submit">>, ServerHost, Host, From, Lang, XEl) ->
     XData = jlib:parse_xdata_submit(XEl),
     case XData of
         invalid ->
@@ -958,13 +981,13 @@ process_register(?NS_XDATA, <<"submit">>, Host, From, Lang, XEl) ->
         _ ->
             case lists:keysearch(<<"nick">>, 1, XData) of
                 {value, {_, [Nick]}} when Nick /= <<>> ->
-                    iq_set_register_info(Host, From, Nick, Lang);
+                    iq_set_register_info(ServerHost, Host, From, Nick, Lang);
                 _ ->
                     ErrText = <<"You must fill in field \"Nickname\" in the form">>,
                     {error, ?ERRT_NOT_ACCEPTABLE(Lang, ErrText)}
             end
     end;
-process_register(_, _, _Host, _From, _Lang, _XEl) ->
+process_register(_, _, _ServerHost, _Host, _From, _Lang, _XEl) ->
     {error, ?ERR_BAD_REQUEST}.
 
 -spec iq_get_vcard(ejabberd:lang()) -> [jlib:xmlel(), ...].

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -197,7 +197,7 @@ store_room(ServerHost, Host, Name, Opts) ->
 
 
 -spec restore_room(ejabberd:server(), ejabberd:server(), room())
-                                    -> 'error' | 'undefined' | [any()].
+                                    -> {error, _} | {ok, _}.
 restore_room(ServerHost, Host, Name) ->
     mod_muc_db_backend:restore_room(ServerHost, Host, Name).
 

--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -928,7 +928,7 @@ iq_set_register_info(Host, From, Nick, Lang) ->
 
 -spec process_iq_register_set(ejabberd:server(), ejabberd:jid(),
         jlib:xmlel(), ejabberd:lang())
-            -> {'error', jlib:xmlel()} | {'result',[]}.
+            -> {'error', jlib:xmlel()} | {'result', []}.
 process_iq_register_set(Host, From, SubEl, Lang) ->
     #xmlel{children = Els} = SubEl,
     case xml:get_subtag(SubEl, <<"remove">>) of

--- a/apps/ejabberd/src/mod_muc_db.erl
+++ b/apps/ejabberd/src/mod_muc_db.erl
@@ -1,0 +1,12 @@
+-module(mod_muc_db).
+
+-callback init(ejabberd:server(), list()) -> ok.
+-callback store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
+            -> {'aborted',_} | {'atomic',_}.
+-callback restore_room(ejabberd:server(), ejabberd:server(), mod_muc:room())
+                                    -> 'error' | 'undefined' | [any()].
+-callback forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) -> 'ok'.
+-callback can_use_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid(), mod_muc:nick()) -> boolean().
+-callback get_rooms(ejabberd:server(), ejabberd:server()) -> list().
+-callback get_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid()) -> error | mod_muc:nick().
+-callback set_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid(), mod_muc:nick()) -> term().

--- a/apps/ejabberd/src/mod_muc_db.erl
+++ b/apps/ejabberd/src/mod_muc_db.erl
@@ -1,12 +1,17 @@
 -module(mod_muc_db).
 
 -callback init(ejabberd:server(), list()) -> ok.
--callback store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
-            -> {'aborted',_} | {'atomic',_}.
--callback restore_room(ejabberd:server(), ejabberd:server(), mod_muc:room())
-                                    -> 'error' | 'undefined' | [any()].
--callback forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) -> 'ok'.
--callback can_use_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid(), mod_muc:nick()) -> boolean().
+-callback store_room(ejabberd:server(), ejabberd:server(),
+                     mod_muc:room(), list()) ->
+    {'aborted', _} | {'atomic', _}.
+-callback restore_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) ->
+    'error' | 'undefined' | [any()].
+-callback forget_room(ejabberd:server(), ejabberd:server(),
+                      mod_muc:room()) -> 'ok'.
+-callback can_use_nick(ejabberd:server(), ejabberd:server(),
+                       ejabberd:jid(), mod_muc:nick()) -> boolean().
 -callback get_rooms(ejabberd:server(), ejabberd:server()) -> list().
--callback get_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid()) -> error | mod_muc:nick().
--callback set_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid(), mod_muc:nick()) -> term().
+-callback get_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid()) ->
+    error | mod_muc:nick().
+-callback set_nick(ejabberd:server(), ejabberd:server(),
+                   ejabberd:jid(), mod_muc:nick()) -> term().

--- a/apps/ejabberd/src/mod_muc_db.erl
+++ b/apps/ejabberd/src/mod_muc_db.erl
@@ -11,7 +11,53 @@
 -callback can_use_nick(ejabberd:server(), ejabberd:server(),
                        ejabberd:jid(), mod_muc:nick()) -> boolean().
 -callback get_rooms(ejabberd:server(), ejabberd:server()) -> list().
--callback get_nick(ejabberd:server(), ejabberd:server(), ejabberd:jid()) ->
-    error | mod_muc:nick().
--callback set_nick(ejabberd:server(), ejabberd:server(),
-                   ejabberd:jid(), mod_muc:nick()) -> term().
+
+%% Get nick associated with jid From across MucHost domain
+-callback get_nick(LServer, MucHost, From) ->
+    error | Nick
+      when
+      %% Defines which ODBC pool to use
+      %% Parent host of the MUC service
+      LServer :: ejabberd:server(),
+      %% Host of MUC service
+      MucHost :: ejabberd:server(),
+      %% User's JID. Can be on another domain accessable over FED.
+      %% Only bare part (user@host) is important.
+      From :: ejabberd:jid(),
+      %% Nick to register
+      %% Only one nick can be registred for each unique bare From.
+      %% Nick is registered per MUC-host (not per room).
+      %% Registered nicks are not available to register.
+      Nick :: mod_muc:nick().
+
+%% Register nick
+-callback set_nick(LServer, MucHost, From, Nick) ->
+    ok | {error, conflict} | {error, should_not_be_empty} | {error, term()}
+      when
+      %% Defines which ODBC pool to use
+      %% Parent host of the MUC service
+      LServer :: ejabberd:server(),
+      %% Host of MUC service
+      MucHost :: ejabberd:server(),
+      %% User's JID. Can be on another domain accessable over FED.
+      %% Only bare part (user@host) is important.
+      From :: ejabberd:jid(),
+      %% Nick to register
+      %% Only one nick can be registred for each unique bare From.
+      %% Nick is registered per MUC-host (not per room).
+      %% Registered nicks are not available to register.
+      Nick :: mod_muc:nick().
+
+%% Unregister nick
+%% Unregistered nicks can be used by someone else
+-callback unset_nick(LServer, MucHost, From) ->
+    ok | {error, term()}
+      when
+      %% Defines which ODBC pool to use
+      %% Parent host of the MUC service
+      LServer :: ejabberd:server(),
+      %% Host of MUC service
+      MucHost :: ejabberd:server(),
+      %% User's JID. Can be on another domain accessable over FED.
+      %% Only bare part (user@host) is important.
+      From :: ejabberd:jid().

--- a/apps/ejabberd/src/mod_muc_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_db_mnesia.erl
@@ -123,7 +123,7 @@ can_use_nick_internal(Host, Nick, LUS) ->
         catch Class:Reason ->
             ?ERROR_MSG("issue=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
                        [jid:to_binary(LUS), Nick, Class, Reason]),
-            true
+            false
     end.
 
 get_nick(_LServer, Host, From) ->

--- a/apps/ejabberd/src/mod_muc_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_db_mnesia.erl
@@ -1,8 +1,10 @@
 %%%----------------------------------------------------------------------
-%%% File    : mod_muc.erl
+%%% Based on file mod_muc.
+%%%
+%%% Original header and copyright notice:
+%%%
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
 %%% Purpose : MUC support (XEP-0045)
-%%% Created : 19 Mar 2003 by Alexey Shchepin <alexey@process-one.net>
 %%%
 %%%
 %%% ejabberd, Copyright (C) 2002-2011   ProcessOne

--- a/apps/ejabberd/src/mod_muc_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_db_mnesia.erl
@@ -62,7 +62,7 @@ store_room(_LServer, Host, Name, Opts) ->
         end,
     Result = mnesia:transaction(F),
     case Result of
-        {atomic,_} ->
+        {atomic, _} ->
             ok;
         _ ->
             ?ERROR_MSG("issue=store_room_failed room=~ts", [Name])
@@ -91,7 +91,7 @@ forget_room(_LServer, Host, Name) ->
         end,
     Result = mnesia:transaction(F),
     case Result of
-        {atomic,_} ->
+        {atomic, _} ->
             ejabberd_hooks:run(forget_room, Host, [Host, Name]),
             ok;
         _ ->
@@ -133,7 +133,7 @@ get_nick(_LServer, Host, From) ->
             error;
         [#muc_registered{nick = Nick}] ->
             Nick
-        catch Class:Reason -> 
+        catch Class:Reason ->
             ?ERROR_MSG("issue=get_nick_failed jid=~ts reason=~p:~p",
                        [jid:to_binary(From), Class, Reason]),
             error
@@ -155,7 +155,7 @@ set_nick(_LServer, Host, From, Nick) ->
         end,
     Result = mnesia:transaction(F),
     case Result of
-        {atomic,_} ->
+        {atomic, _} ->
             ok;
         _ ->
             ?ERROR_MSG("issue=set_nick_failed jid=~ts nick=~ts",
@@ -170,7 +170,7 @@ unset_nick(Host, From) ->
         end,
     Result = mnesia:transaction(F),
     case Result of
-        {atomic,_} ->
+        {atomic, _} ->
             ok;
         _ ->
             ?ERROR_MSG("issue=unset_nick_failed jid=~ts",

--- a/apps/ejabberd/src/mod_muc_db_mnesia.erl
+++ b/apps/ejabberd/src/mod_muc_db_mnesia.erl
@@ -1,0 +1,239 @@
+%%%----------------------------------------------------------------------
+%%% File    : mod_muc.erl
+%%% Author  : Alexey Shchepin <alexey@process-one.net>
+%%% Purpose : MUC support (XEP-0045)
+%%% Created : 19 Mar 2003 by Alexey Shchepin <alexey@process-one.net>
+%%%
+%%%
+%%% ejabberd, Copyright (C) 2002-2011   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with this program; if not, write to the Free Software
+%%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+%%% 02111-1307 USA
+%%%
+%%%----------------------------------------------------------------------
+
+-module(mod_muc_db_mnesia).
+-behaviour(mod_muc_db).
+-export([init/2,
+         store_room/4,
+         restore_room/3,
+         forget_room/3,
+         get_rooms/2,
+         can_use_nick/4,
+         get_nick/3,
+         set_nick/4]).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+-include_lib("ejabberd/include/mod_muc.hrl").
+
+init(Host, Opts) ->
+    mnesia:create_table(muc_room,
+                        [{disc_copies, [node()]},
+                         {attributes, record_info(fields, muc_room)}]),
+    mnesia:create_table(muc_registered,
+                        [{disc_copies, [node()]},
+                         {attributes, record_info(fields, muc_registered)}]),
+    mnesia:add_table_copy(muc_room, node(), disc_copies),
+    mnesia:add_table_copy(muc_registered, node(), disc_copies),
+    MyHost = gen_mod:get_opt_subhost(Host, Opts, <<"conference.@HOST@">>),
+    update_tables(MyHost),
+    mnesia:add_table_index(muc_registered, nick),
+    ok.
+
+-spec store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
+            -> {'aborted',_} | {'atomic',_}.
+store_room(_LServer, Host, Name, Opts) ->
+    F = fun() ->
+                mnesia:write(#muc_room{name_host = {Name, Host},
+                                       opts = Opts})
+        end,
+    mnesia:transaction(F).
+
+
+-spec restore_room(ejabberd:server(), ejabberd:server(), mod_muc:room())
+                                    -> 'error' | 'undefined' | [any()].
+restore_room(_LServer, Host, Name) ->
+    case catch mnesia:dirty_read(muc_room, {Name, Host}) of
+        [#muc_room{opts = Opts}] ->
+            Opts;
+        _ ->
+            error
+    end.
+
+-spec forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) -> 'ok'.
+forget_room(_LServer, Host, Name) ->
+    F = fun() ->
+                mnesia:delete({muc_room, {Name, Host}})
+        end,
+    mnesia:transaction(F),
+    ejabberd_hooks:run(forget_room, Host, [Host, Name]),
+    ok.
+
+get_rooms(_Lserver, Host) ->
+    mnesia:dirty_select(
+                 muc_room, [{#muc_room{name_host = {'_', Host}, _ = '_'},
+                             [],
+                             ['$_']}]).
+
+-spec can_use_nick(ejabberd:server(), ejabberd:server(),
+                   ejabberd:jid(), mod_muc:nick()) -> boolean().
+can_use_nick(_LServer, Host, JID, Nick) ->
+    {LUser, LServer, _} = jid:to_lower(JID),
+    LUS = {LUser, LServer},
+    case catch mnesia:dirty_select(
+                 muc_registered,
+                 [{#muc_registered{us_host = '$1',
+                                   nick = Nick,
+                                   _ = '_'},
+                   [{'==', {element, 2, '$1'}, Host}],
+                   ['$_']}]) of
+        {'EXIT', _Reason} ->
+            true;
+        [] ->
+            true;
+        [#muc_registered{us_host = {U, _Host}}] ->
+            U == LUS
+    end.
+
+get_nick(_LServer, Host, From) ->
+    {LUser, LServer, _} = jid:to_lower(From),
+    LUS = {LUser, LServer},
+    case mnesia:dirty_read(muc_registered, {LUS, Host}) of
+    [] -> error;
+    [#muc_registered{nick = Nick}] -> Nick
+    end.
+
+set_nick(_LServer, Host, From, Nick) ->
+    {LUser, LServer, _} = jid:to_lower(From),
+    LUS = {LUser, LServer},
+    F = fun () ->
+        case Nick of
+            <<"">> ->
+            mnesia:delete({muc_registered, {LUS, Host}}),
+            ok;
+            _ ->
+            Allow = case mnesia:select(
+                       muc_registered,
+                       [{#muc_registered{us_host =
+                                 '$1',
+                             nick = Nick,
+                             _ = '_'},
+                     [{'==', {element, 2, '$1'},
+                       Host}],
+                     ['$_']}]) of
+                    [] -> true;
+                    [#muc_registered{us_host = {U, _Host}}] ->
+                    U == LUS
+                end,
+            if Allow ->
+                mnesia:write(#muc_registered{
+                        us_host = {LUS, Host},
+                        nick = Nick}),
+                ok;
+               true ->
+                false
+            end
+        end
+    end,
+    mnesia:transaction(F).
+
+-spec update_tables(ejabberd:server()) -> any().
+update_tables(Host) ->
+    update_muc_room_table(Host),
+    update_muc_registered_table(Host).
+
+-spec update_muc_room_table(ejabberd:server()) -> any().
+update_muc_room_table(Host) ->
+    Fields = record_info(fields, muc_room),
+    case mnesia:table_info(muc_room, attributes) of
+        Fields ->
+            ok;
+        [name, opts] ->
+            ?INFO_MSG("Converting muc_room table from {name, opts} format", []),
+            {atomic, ok} = mnesia:create_table(
+                             mod_muc_tmp_table,
+                             [{disc_only_copies, [node()]},
+                              {type, bag},
+                              {local_content, true},
+                              {record_name, muc_room},
+                              {attributes, record_info(fields, muc_room)}]),
+            mnesia:transform_table(muc_room, ignore, Fields),
+            F1 = fun() ->
+                         mnesia:write_lock_table(mod_muc_tmp_table),
+                         mnesia:foldl(
+                           fun(#muc_room{name_host = Name} = R, _) ->
+                                   mnesia:dirty_write(
+                                     mod_muc_tmp_table,
+                                     R#muc_room{name_host = {Name, Host}})
+                           end, ok, muc_room)
+                 end,
+            mnesia:transaction(F1),
+            mnesia:clear_table(muc_room),
+            F2 = fun() ->
+                         mnesia:write_lock_table(muc_room),
+                         mnesia:foldl(
+                           fun(R, _) ->
+                                   mnesia:dirty_write(R)
+                           end, ok, mod_muc_tmp_table)
+                 end,
+            mnesia:transaction(F2),
+            mnesia:delete_table(mod_muc_tmp_table);
+        _ ->
+            ?INFO_MSG("Recreating muc_room table", []),
+            mnesia:transform_table(muc_room, ignore, Fields)
+    end.
+
+-spec update_muc_registered_table(ejabberd:server()) -> any().
+update_muc_registered_table(Host) ->
+    Fields = record_info(fields, muc_registered),
+    case mnesia:table_info(muc_registered, attributes) of
+        Fields ->
+            ok;
+        [user, nick] ->
+            ?INFO_MSG("Converting muc_registered table from {user, nick} format", []),
+            {atomic, ok} = mnesia:create_table(
+                             mod_muc_tmp_table,
+                             [{disc_only_copies, [node()]},
+                              {type, bag},
+                              {local_content, true},
+                              {record_name, muc_registered},
+                              {attributes, record_info(fields, muc_registered)}]),
+            mnesia:del_table_index(muc_registered, nick),
+            mnesia:transform_table(muc_registered, ignore, Fields),
+            F1 = fun() ->
+                         mnesia:write_lock_table(mod_muc_tmp_table),
+                         mnesia:foldl(
+                           fun(#muc_registered{us_host = US} = R, _) ->
+                                   mnesia:dirty_write(
+                                     mod_muc_tmp_table,
+                                     R#muc_registered{us_host = {US, Host}})
+                           end, ok, muc_registered)
+                 end,
+            mnesia:transaction(F1),
+            mnesia:clear_table(muc_registered),
+            F2 = fun() ->
+                         mnesia:write_lock_table(muc_registered),
+                         mnesia:foldl(
+                           fun(R, _) ->
+                                   mnesia:dirty_write(R)
+                           end, ok, mod_muc_tmp_table)
+                 end,
+            mnesia:transaction(F2),
+            mnesia:delete_table(mod_muc_tmp_table);
+        _ ->
+            ?INFO_MSG("Recreating muc_registered table", []),
+            mnesia:transform_table(muc_registered, ignore, Fields)
+    end.

--- a/apps/ejabberd/src/mod_muc_db_odbc.erl
+++ b/apps/ejabberd/src/mod_muc_db_odbc.erl
@@ -94,7 +94,7 @@ can_use_nick(LServer, Host, JID, Nick) ->
         Error ->
             ?ERROR_MSG("issue=can_use_nick_failed jid=~ts nick=~ts reason=~1000p",
                        [BinJID, Nick, Error]),
-            true
+            false
     end.
 
 get_rooms(LServer, Host) ->

--- a/apps/ejabberd/src/mod_muc_db_odbc.erl
+++ b/apps/ejabberd/src/mod_muc_db_odbc.erl
@@ -21,26 +21,26 @@ init(_Host, _Opts) ->
     ok.
 
 store_room(LServer, Host, Name, Opts) ->
-    SHost = ejabberd_odbc:escape(Host),
-    SName = ejabberd_odbc:escape(Name),
+    SHost = mongoose_rdbms:escape(Host),
+    SName = mongoose_rdbms:escape(Name),
     BinOpts = jlib:term_to_expr(Opts),
-    SBinOpts = ejabberd_odbc:escape(BinOpts),
-    ejabberd_odbc:sql_transaction(
+    SBinOpts = mongoose_rdbms:escape(BinOpts),
+    mongoose_rdbms:sql_transaction(
       LServer,
       fun() ->
-          odbc_queries:update_t(<<"muc_room">>,
+          rdbms_queries:update_t(<<"muc_room">>,
                [<<"name">>, <<"host">>, <<"opts">>],
                [SName, SHost, SBinOpts],
                [<<"name='">>, SName, <<"' AND host='">>, SHost, <<"'">>])
       end).
 
 restore_room(LServer, Host, Name) ->
-    SHost = ejabberd_odbc:escape(Host),
-    SName = ejabberd_odbc:escape(Name),
+    SHost = mongoose_rdbms:escape(Host),
+    SName = mongoose_rdbms:escape(Name),
     Query = ["select opts from muc_room "
               "where name='", SName, "' "
                 "and host='", SHost, "'"],
-    case (catch ejabberd_odbc:sql_query(LServer, Query)) of
+    case (catch mongoose_rdbms:sql_query(LServer, Query)) of
     {selected, _, [{Opts}]} ->
             jlib:expr_to_term(Opts);
     _ ->
@@ -48,33 +48,33 @@ restore_room(LServer, Host, Name) ->
     end.
 
 forget_room(LServer, Host, Name) ->
-    SHost = ejabberd_odbc:escape(Host),
-    SName = ejabberd_odbc:escape(Name),
+    SHost = mongoose_rdbms:escape(Host),
+    SName = mongoose_rdbms:escape(Name),
     Query = ["delete from muc_room "
               "where name='", SName, "' "
                 "and host='", SHost, "'"],
     F = fun () ->
-        ejabberd_odbc:sql_query_t(Query)
+        mongoose_rdbms:sql_query_t(Query)
     end,
-    ejabberd_odbc:sql_transaction(LServer, F).
+    mongoose_rdbms:sql_transaction(LServer, F).
 
 can_use_nick(LServer, Host, JID, Nick) ->
     BinJID = jid:to_binary(jid:to_lower(jid:to_bare(JID))),
-    SHost = ejabberd_odbc:escape(Host),
-    SNick = ejabberd_odbc:escape(Nick),
+    SHost = mongoose_rdbms:escape(Host),
+    SNick = mongoose_rdbms:escape(Nick),
     Query = ["select jid from muc_registered "
               "where nick='", SNick, "' "
                 "and host='", SHost, "'"],
-    case catch ejabberd_odbc:sql_query(LServer, Query) of
+    case catch mongoose_rdbms:sql_query(LServer, Query) of
     {selected, _, [{DbBinJID}]} -> BinJID == DbBinJID;
     _ -> true
     end.
 
 get_rooms(LServer, Host) ->
-    SHost = ejabberd_odbc:escape(Host),
+    SHost = mongoose_rdbms:escape(Host),
     Query = ["select name, opts from muc_room"
               " where host='", SHost, "'"],
-    case catch ejabberd_odbc:sql_query(LServer, Query) of
+    case catch mongoose_rdbms:sql_query(LServer, Query) of
     {selected, _, RoomOpts} ->
         lists:map(
           fun({Room, Opts}) ->
@@ -87,12 +87,12 @@ get_rooms(LServer, Host) ->
     end.
 
 get_nick(LServer, Host, From) ->
-    SHost = ejabberd_odbc:escape(Host),
+    SHost = mongoose_rdbms:escape(Host),
     BinJID = jid:to_binary(jid:to_lower(jid:to_bare(From))),
-    SBinJID = ejabberd_odbc:escape(BinJID),
+    SBinJID = mongoose_rdbms:escape(BinJID),
     Query = ["select nick from muc_registered where"
               " jid='", SBinJID, "' and host='", SHost, "'"],
-    case catch ejabberd_odbc:sql_query(LServer, Query) of
+    case catch mongoose_rdbms:sql_query(LServer, Query) of
     {selected, _, [{Nick}]} -> Nick;
     _ -> error
     end.
@@ -100,15 +100,15 @@ get_nick(LServer, Host, From) ->
 set_nick(LServer, Host, From, <<>>) ->
     unset_nick(LServer, Host, From);
 set_nick(LServer, Host, From, Nick) ->
-    SHost = ejabberd_odbc:escape(Host),
-    SNick = ejabberd_odbc:escape(Nick),
+    SHost = mongoose_rdbms:escape(Host),
+    SNick = mongoose_rdbms:escape(Nick),
     BinJID = jid:to_binary(jid:to_lower(jid:to_bare(From))),
     JidQuery = ["select jid from muc_registered "
                    " where nick='", SNick, "'"
                      " and host='", SHost, "'"],
 
     F = fun () ->
-        case ejabberd_odbc:sql_query_t(JidQuery) of
+        case mongoose_rdbms:sql_query_t(JidQuery) of
             {selected, _, [{J}]} when J == BinJID ->
                 %% Already inserted
                 ok;
@@ -117,27 +117,27 @@ set_nick(LServer, Host, From, Nick) ->
                 false;
             {selected, _, []} ->
                 %% Available nick
-                SBinJID = ejabberd_odbc:escape(BinJID),
+                SBinJID = mongoose_rdbms:escape(BinJID),
                 InsQuery = ["insert into muc_registered (jid, host, nick) "
                              " values ('", SBinJID, "', "
                                       "'", SHost, "', "
                                       "'", SNick, "')"],
-                ejabberd_odbc:sql_query_t(InsQuery),
+                mongoose_rdbms:sql_query_t(InsQuery),
                 ok
         end
     end,
-    ejabberd_odbc:sql_transaction(LServer, F).
+    mongoose_rdbms:sql_transaction(LServer, F).
 
 
 unset_nick(LServer, Host, From) ->
-    SHost = ejabberd_odbc:escape(Host),
+    SHost = mongoose_rdbms:escape(Host),
     BinJID = jid:to_binary(jid:to_lower(jid:to_bare(From))),
-    SBinJID = ejabberd_odbc:escape(BinJID),
+    SBinJID = mongoose_rdbms:escape(BinJID),
     Query = ["delete from muc_registered "
               "where jid='", SBinJID, "' "
                 "and host='", SHost, "'"],
     F = fun () ->
-            ejabberd_odbc:sql_query_t(Query),
+            mongoose_rdbms:sql_query_t(Query),
             ok
     end,
-    ejabberd_odbc:sql_transaction(LServer, F).
+    mongoose_rdbms:sql_transaction(LServer, F).

--- a/apps/ejabberd/src/mod_muc_db_odbc.erl
+++ b/apps/ejabberd/src/mod_muc_db_odbc.erl
@@ -77,7 +77,7 @@ forget_room(ServerHost, MucHost, RoomName) ->
             ?ERROR_MSG("issue=forget_room_failed room=~ts reason=~1000p",
                        [RoomName, Result])
     end,
-    Result.
+    ok.
 
 can_use_nick(ServerHost, MucHost, JID, Nick) ->
     BinJID = jid:to_binary(jid:to_lower(jid:to_bare(JID))),

--- a/apps/ejabberd/src/mod_muc_db_odbc.erl
+++ b/apps/ejabberd/src/mod_muc_db_odbc.erl
@@ -1,0 +1,143 @@
+-module(mod_muc_db_odbc).
+-behaviour(mod_muc_db).
+-export([init/2,
+         store_room/4,
+         restore_room/3,
+         forget_room/3,
+         get_rooms/2,
+         can_use_nick/4,
+         get_nick/3,
+         set_nick/4]).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+-include_lib("ejabberd/include/mod_muc.hrl").
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+init(_Host, _Opts) ->
+    ok.
+
+store_room(LServer, Host, Name, Opts) ->
+    SHost = ejabberd_odbc:escape(Host),
+    SName = ejabberd_odbc:escape(Name),
+    BinOpts = jlib:term_to_expr(Opts),
+    SBinOpts = ejabberd_odbc:escape(BinOpts),
+    ejabberd_odbc:sql_transaction(
+      LServer,
+      fun() ->
+          odbc_queries:update_t(<<"muc_room">>,
+               [<<"name">>, <<"host">>, <<"opts">>],
+               [SName, SHost, SBinOpts],
+               [<<"name='">>, SName, <<"' AND host='">>, SHost, <<"'">>])
+      end).
+
+restore_room(LServer, Host, Name) ->
+    SHost = ejabberd_odbc:escape(Host),
+    SName = ejabberd_odbc:escape(Name),
+    Query = ["select opts from muc_room "
+              "where name='", SName, "' "
+                "and host='", SHost, "'"],
+    case (catch ejabberd_odbc:sql_query(LServer, Query)) of
+    {selected, _, [{Opts}]} ->
+            jlib:expr_to_term(Opts);
+    _ ->
+        error
+    end.
+
+forget_room(LServer, Host, Name) ->
+    SHost = ejabberd_odbc:escape(Host),
+    SName = ejabberd_odbc:escape(Name),
+    Query = ["delete from muc_room "
+              "where name='", SName, "' "
+                "and host='", SHost, "'"],
+    F = fun () ->
+        ejabberd_odbc:sql_query_t(Query)
+    end,
+    ejabberd_odbc:sql_transaction(LServer, F).
+
+can_use_nick(LServer, Host, JID, Nick) ->
+    BinJID = jid:to_binary(jid:to_lower(jid:to_bare(JID))),
+    SHost = ejabberd_odbc:escape(Host),
+    SNick = ejabberd_odbc:escape(Nick),
+    Query = ["select jid from muc_registered "
+              "where nick='", SNick, "' "
+                "and host='", SHost, "'"],
+    case catch ejabberd_odbc:sql_query(LServer, Query) of
+    {selected, _, [{DbBinJID}]} -> BinJID == DbBinJID;
+    _ -> true
+    end.
+
+get_rooms(LServer, Host) ->
+    SHost = ejabberd_odbc:escape(Host),
+    Query = ["select name, opts from muc_room"
+              " where host='", SHost, "'"],
+    case catch ejabberd_odbc:sql_query(LServer, Query) of
+    {selected, _, RoomOpts} ->
+        lists:map(
+          fun({Room, Opts}) ->
+              #muc_room{name_host = {Room, Host},
+                opts = jlib:expr_to_term(Opts)}
+          end, RoomOpts);
+    Err ->
+        ?ERROR_MSG("failed to get rooms: ~p", [Err]),
+        []
+    end.
+
+get_nick(LServer, Host, From) ->
+    SHost = ejabberd_odbc:escape(Host),
+    BinJID = jid:to_binary(jid:to_lower(jid:to_bare(From))),
+    SBinJID = ejabberd_odbc:escape(BinJID),
+    Query = ["select nick from muc_registered where"
+              " jid='", SBinJID, "' and host='", SHost, "'"],
+    case catch ejabberd_odbc:sql_query(LServer, Query) of
+    {selected, _, [{Nick}]} -> Nick;
+    _ -> error
+    end.
+
+set_nick(LServer, Host, From, <<>>) ->
+    unset_nick(LServer, Host, From);
+set_nick(LServer, Host, From, Nick) ->
+    SHost = ejabberd_odbc:escape(Host),
+    SNick = ejabberd_odbc:escape(Nick),
+    BinJID = jid:to_binary(jid:to_lower(jid:to_bare(From))),
+    JidQuery = ["select jid from muc_registered "
+                   " where nick='", SNick, "'"
+                     " and host='", SHost, "'"],
+
+    F = fun () ->
+        case ejabberd_odbc:sql_query_t(JidQuery) of
+            {selected, _, [{J}]} when J == BinJID ->
+                %% Already inserted
+                ok;
+            {selected, _, [{_}]} ->
+                %% Busy nick
+                false;
+            {selected, _, []} ->
+                %% Available nick
+                SBinJID = ejabberd_odbc:escape(BinJID),
+                InsQuery = ["insert into muc_registered (jid, host, nick) "
+                             " values ('", SBinJID, "', "
+                                      "'", SHost, "', "
+                                      "'", SNick, "')"],
+                ejabberd_odbc:sql_query_t(InsQuery),
+                ok
+        end
+    end,
+    ejabberd_odbc:sql_transaction(LServer, F).
+
+
+unset_nick(LServer, Host, From) ->
+    SHost = ejabberd_odbc:escape(Host),
+    BinJID = jid:to_binary(jid:to_lower(jid:to_bare(From))),
+    SBinJID = ejabberd_odbc:escape(BinJID),
+    Query = ["delete from muc_registered "
+              "where jid='", SBinJID, "' "
+                "and host='", SHost, "'"],
+    F = fun () ->
+            ejabberd_odbc:sql_query_t(Query),
+            ok
+    end,
+    ejabberd_odbc:sql_transaction(LServer, F).

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -170,19 +170,22 @@ start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
             Opts :: list()) -> {'error', _}
                                    | {'ok', 'undefined' | pid()}
                                    | {'ok', 'undefined' | pid(), _}.
-start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opts) ->
+start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opts)
+    when is_list(Opts) ->
     Supervisor = gen_mod:get_module_proc(ServerHost, ejabberd_mod_muc_sup),
     supervisor:start_child(Supervisor, [Host, ServerHost, Access, Room,
                                         HistorySize, RoomShaper, HttpAuthPool, Opts]).
 
 start_link(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
-       Creator, Nick, DefRoomOpts) ->
+       Creator, Nick, DefRoomOpts)
+    when is_list(DefRoomOpts) ->
     gen_fsm:start_link(?MODULE,
                        [Host, ServerHost, Access, Room, HistorySize,
                         RoomShaper, HttpAuthPool, Creator, Nick, DefRoomOpts],
                        ?FSMOPTS).
 
-start_link(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opts) ->
+start_link(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opts)
+    when is_list(Opts) ->
     gen_fsm:start_link(?MODULE,
                        [Host, ServerHost, Access, Room, HistorySize,
                         RoomShaper, HttpAuthPool, Opts],
@@ -248,7 +251,7 @@ can_access_identity(RoomJID, UserJID) ->
 -spec init([any(), ...]) ->
     {ok, statename(), state()} | {ok, statename(), state(), timeout()}.
 init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
-      Creator, _Nick, DefRoomOpts]) ->
+      Creator, _Nick, DefRoomOpts]) when is_list(DefRoomOpts) ->
     process_flag(trap_exit, true),
     Shaper = shaper:new(RoomShaper),
     State = set_affiliation(Creator, owner,

--- a/apps/ejabberd/src/mod_muc_room.erl
+++ b/apps/ejabberd/src/mod_muc_room.erl
@@ -3830,7 +3830,9 @@ destroy_room(DestroyEl, StateData) ->
     remove_each_occupant_from_room(DestroyEl, StateData),
     case (StateData#state.config)#config.persistent of
         true ->
-            mod_muc:forget_room(StateData#state.server_host, StateData#state.host, StateData#state.room);
+            mod_muc:forget_room(StateData#state.server_host,
+                                StateData#state.host,
+                                StateData#state.room);
         false ->
             ok
     end,

--- a/apps/ejabberd/src/rdbms/rdbms_queries.erl
+++ b/apps/ejabberd/src/rdbms/rdbms_queries.erl
@@ -104,6 +104,8 @@
          remove_offline_messages/3,
          create_bulk_insert_query/3]).
 
+-export([update_t/4]).
+
 %% We have only two compile time options for db queries:
 %%-define(generic, true).
 %%-define(mssql, true).

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -8,6 +8,8 @@ Also `mod_muc_log` is a logging submodule.
 ### Options
 * `host` (string, default: `"conference.@HOST@"`): Subdomain for MUC service to reside under. 
  `@HOST@` is replaced with each served domain.
+* `backend` (atom, default: `mnesia`): Storage backend. Currently `mnesia` and `odbc`
+  are supported.
 * `access` (atom, default: `all`): Access Rule to determine who is allowed to use the MUC service.
 * `access_create` (atom, default: `all`): Who is allowed to create rooms.
 * `access_admin` (atom, default: `none`): Who is the administrator in all rooms.

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -29,7 +29,7 @@ Also `mod_muc_log` is a logging submodule.
 * `user_presence_shaper` (atom, default: `none`): Shaper for user presences processed by a room (global for the room).
 * `max_user_conferences` (non-negative, default: 10): Specifies the number of rooms that a user can occupy simultaneously.
 * `http_auth_pool` (atom, default: `none`): If an external HTTP service is chosen to check passwords for password-protected rooms, this option specifies the HTTP pool name to use (see [External HTTP Authentication](#external-http-authentication) below).
-* `load_permanent_rooms_at_startup` (boolean, default: false) - Load all rooms at startup (can be not safe with a lot of rooms, that's why disabled).
+* `load_permanent_rooms_at_startup` (boolean, default: false) - Load all rooms at startup (can be unsafe when there are many rooms, that's why disabled).
 * `hibernate_timeout` (timeout, default: `90000`): Timeout (in milliseconds) defining the inactivity period after which the room's process should be hibernated.
 * `hibernated_room_check_interval` (timeout, default: `infinity`): Interval defining how often the hibernated rooms will be checked (a timer is global for a node).
 * `hibernated_room_timeout` (timeout, default: `inifitniy`): A time after which a hibernated room is stopped (deeply hibernated).

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -27,6 +27,7 @@ Also `mod_muc_log` is a logging submodule.
 * `user_presence_shaper` (atom, default: `none`): Shaper for user presences processed by a room (global for the room).
 * `max_user_conferences` (non-negative, default: 10): Specifies the number of rooms that a user can occupy simultaneously.
 * `http_auth_pool` (atom, default: `none`): If an external HTTP service is chosen to check passwords for password-protected rooms, this option specifies the HTTP pool name to use (see [External HTTP Authentication](#external-http-authentication) below).
+* `load_permanent_rooms_at_startup` (boolean, default: false) - Load all rooms at startup (can be not safe with a lot of rooms, that's why disabled).
 * `hibernate_timeout` (timeout, default: `90000`): Timeout (in milliseconds) defining the inactivity period after which the room's process should be hibernated.
 * `hibernated_room_check_interval` (timeout, default: `infinity`): Interval defining how often the hibernated rooms will be checked (a timer is global for a node).
 * `hibernated_room_timeout` (timeout, default: `inifitniy`): A time after which a hibernated room is stopped (deeply hibernated).

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -261,7 +261,7 @@ rsm_cases() ->
        pagination_empty_rset].
 
 suite() ->
-    escalus:suite().
+    s2s_helper:suite(escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -334,10 +334,11 @@ init_per_group(hibernation, Config) ->
     end,
     Config;
 init_per_group(register_over_s2s, Config) ->
-    Config1 = [{escalus_user_db, xmpp}|Config],
+    Config1 = s2s_helper:init_s2s(Config),
+    Config2 = s2s_helper:configure_s2s(both_plain, Config1),
     [{_,AliceSpec2}|Others] = escalus:get_users([alice2, bob, kate]),
     Users = [{alice,AliceSpec2}|Others],
-    escalus:create_users(Config1, Users);
+    escalus:create_users(Config2, Users);
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob, kate])).
 
@@ -394,6 +395,7 @@ end_per_group(hibernation, Config) ->
     end,
     Config;
 end_per_group(register_over_s2s, Config) ->
+    s2s_helper:end_s2s(Config),
     escalus:delete_users(Config, escalus:get_users([alice2, bob, kate]));
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob, kate])).

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -393,6 +393,8 @@ end_per_group(hibernation, Config) ->
             ok
     end,
     Config;
+end_per_group(register_over_s2s, Config) ->
+    escalus:delete_users(Config, escalus:get_users([alice2, bob, kate]));
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob, kate])).
 

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -83,7 +83,9 @@ all() -> [
         {group, room_management},
         {group, http_auth_no_server},
         {group, http_auth},
-        {group, hibernation}
+        {group, hibernation},
+        {group, register},
+        {group, register_over_s2s}
         ].
 
 groups() -> [
@@ -238,8 +240,18 @@ groups() -> [
                 create_instant_http_password_protected_room,
                 deny_creation_of_http_password_protected_room,
                 deny_creation_of_http_password_protected_room_wrong_password
-                ]}
+                ]},
+        {register, [parallel], register_cases()},
+        {register_over_s2s, [parallel], register_cases()}
         ].
+
+register_cases() ->
+    [user_asks_for_registration_form,
+     user_submits_registration_form,
+     user_submits_registration_form_twice,
+     user_changes_nick,
+     user_unregisters_nick,
+     user_unregisters_nick_twice].
 
 rsm_cases() ->
       [pagination_first5,
@@ -321,6 +333,11 @@ init_per_group(hibernation, Config) ->
             ok
     end,
     Config;
+init_per_group(register_over_s2s, Config) ->
+    Config1 = [{escalus_user_db, xmpp}|Config],
+    [{_,AliceSpec2}|Others] = escalus:get_users([alice2, bob, kate]),
+    Users = [{alice,AliceSpec2}|Others],
+    escalus:create_users(Config1, Users);
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob, kate])).
 
@@ -2600,6 +2617,83 @@ one2one_chat_to_muc(Config) ->
     end).
 
 
+%%--------------------------------------------------------------------
+%% Registration at a server
+%%--------------------------------------------------------------------
+
+%% You send the register IQ to room jid "muc@host/room".
+%% But in MongooseIM you need to send it to "muc@host".
+user_asks_for_registration_form(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+		?assert_equal(<<>>, get_nick(Alice))
+    end).
+
+%% Example 71. User Submits Registration Form
+%% You send the register IQ to room jid "muc@host/room".
+%% But in MongooseIM you need to send it to "muc@host".
+user_submits_registration_form(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Nick = fresh_nick_name(<<"thirdwitch">>),
+		set_nick(Alice, Nick),
+		?assert_equal(Nick, get_nick(Alice))
+    end).
+
+user_submits_registration_form_over_s2s(Config) ->
+    escalus:fresh_story(Config, [{alice2, 1}], fun(Alice) ->
+        Nick = fresh_nick_name(<<"thirdwitch">>),
+		set_nick(Alice, Nick),
+		?assert_equal(Nick, get_nick(Alice))
+    end).
+
+user_submits_registration_form_twice(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Nick = fresh_nick_name(<<"thirdwitch">>),
+		set_nick(Alice, Nick),
+		?assert_equal(Nick, get_nick(Alice)),
+
+		set_nick(Alice, Nick),
+		?assert_equal(Nick, get_nick(Alice))
+    end).
+
+user_changes_nick(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Nick1 = fresh_nick_name(<<"thirdwitch1">>),
+        Nick2 = fresh_nick_name(<<"thirdwitch2">>),
+		set_nick(Alice, Nick1),
+		?assert_equal(Nick1, get_nick(Alice)),
+
+		set_nick(Alice, Nick2),
+		?assert_equal(Nick2, get_nick(Alice))
+    end).
+
+user_unregisters_nick(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Nick = fresh_nick_name(<<"thirdwitch1">>),
+		set_nick(Alice, Nick),
+		?assert_equal(Nick, get_nick(Alice)),
+
+		unset_nick(Alice),
+		?assert_equal(<<>>, get_nick(Alice))
+    end).
+
+user_unregisters_nick_twice(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Nick = fresh_nick_name(<<"thirdwitch1">>),
+		set_nick(Alice, Nick),
+		?assert_equal(Nick, get_nick(Alice)),
+
+		unset_nick(Alice),
+		?assert_equal(<<>>, get_nick(Alice)),
+
+		unset_nick(Alice),
+		?assert_equal(<<>>, get_nick(Alice))
+    end).
+
+
+%%--------------------------------------------------------------------
+%% Registration in a room
+%%--------------------------------------------------------------------
+
 %%Examples 66-76
 %%Registartion feature is not implemented
 %%TODO: create a differend goruop for the registration test cases (they will fail)
@@ -4684,6 +4778,41 @@ stanza_get_services(Config) ->
     escalus_stanza:setattr(escalus_stanza:iq_get(?NS_DISCO_ITEMS, []), <<"to">>,
         ct:get_config({hosts, mim, domain})).
 
+get_nick_form_iq() ->
+    NS = <<"jabber:iq:register">>,
+    GetIQ = escalus_stanza:iq_get(<<"jabber:iq:register">>, []),
+    escalus_stanza:to(GetIQ, ?MUC_HOST).
+
+change_nick_form_iq(Nick) ->
+    NS = <<"jabber:iq:register">>,
+    NickField = form_field({<<"nick">>, Nick, <<"text-single">>}),
+    Form = stanza_form([NickField], NS),
+    SetIQ = escalus_stanza:iq_set(NS, [Form]),
+    escalus_stanza:to(SetIQ, ?MUC_HOST).
+
+remove_nick_form_iq() ->
+    NS = <<"jabber:iq:register">>,
+    RemoveEl = #xmlel{name = <<"remove">>},
+    SetIQ = escalus_stanza:iq_set(NS, [RemoveEl]),
+    escalus_stanza:to(SetIQ, ?MUC_HOST).
+
+set_nick(User, Nick) ->
+	escalus:send(User, change_nick_form_iq(Nick)),
+	ResultIQ = escalus:wait_for_stanza(User),
+	escalus:assert(is_iq_result, ResultIQ).
+
+unset_nick(User) ->
+	escalus:send(User, remove_nick_form_iq()),
+	ResultIQ = escalus:wait_for_stanza(User),
+	escalus:assert(is_iq_result, ResultIQ).
+
+get_nick(User) ->
+    escalus:send(User, get_nick_form_iq()),
+    ResultIQ = escalus:wait_for_stanza(User),
+    escalus:assert(is_iq_result, ResultIQ),
+    true = form_has_field(<<"nick">>, ResultIQ),
+    form_field_value(<<"nick">>, ResultIQ).
+
 %%--------------------------------------------------------------------
 %% Helpers (assertions)
 %%--------------------------------------------------------------------
@@ -4702,6 +4831,23 @@ is_message_form(Stanza) ->
 is_form(Stanza) ->
     exml_query:path(Stanza,[{element, <<"query">>}, {element,<<"x">>},
         {attr, <<"xmlns">>}]) =:= ?NS_DATA_FORMS.
+
+form_has_field(VarName, Stanza) ->
+    Path = [{element, <<"query">>},
+            {element, <<"x">>},
+            {element, <<"field">>},
+            {attr, <<"var">>}],
+    Vars = exml_query:paths(Stanza, Path),
+    lists:member(VarName, Vars).
+
+form_field_value(VarName, Stanza) ->
+    Path = [{element, <<"query">>},
+            {element, <<"x">>},
+            {element, <<"field">>}],
+    Fields = exml_query:paths(Stanza, Path),
+    hd([exml_query:path(Field, [{element, <<"value">>}, cdata])
+        || Field <- Fields,
+        exml_query:attr(Field, <<"var">>) == VarName]).
 
 is_groupchat_message(Stanza) ->
     escalus_pred:is_message(Stanza) andalso
@@ -4953,3 +5099,9 @@ fresh_room_name(Username) ->
 
 fresh_room_name() ->
     fresh_room_name(base16:encode(crypto:strong_rand_bytes(5))).
+
+fresh_nick_name(Prefix) ->
+    <<Prefix/binary, (fresh_nick_name())/binary>>.
+
+fresh_nick_name() ->
+    fresh_room_name(base16:encode(crypto:rand_bytes(5))).

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -42,6 +42,7 @@
 -define(PASSWORD, <<"pa5sw0rd">>).
 -define(SUBJECT, <<"subject">>).
 -define(WAIT_TIME, 1500).
+-define(WAIT_TIMEOUT, 10000).
 
 -define(NS_MUC_REQUEST, <<"http://jabber.org/protocol/muc#request">>).
 -define(NS_MUC_ROOMCONFIG, <<"http://jabber.org/protocol/muc#roomconfig">>).
@@ -4042,7 +4043,7 @@ hibernated_room_is_stopped_and_restored_by_presence(Config) ->
         ct:sleep(timer:seconds(1)),
 
         escalus:send(Bob, stanza_join_room(RoomName, <<"bob">>)),
-        Presence = escalus:wait_for_stanza(Bob),
+        Presence = escalus:wait_for_stanza(Bob, ?WAIT_TIMEOUT),
         ct:print("~p", [Presence]),
         MessageWithSubject = escalus:wait_for_stanza(Bob),
         ct:print("~p", [MessageWithSubject]),
@@ -4096,7 +4097,7 @@ stopped_members_only_room_process_invitations_correctly(Config) ->
         Stanza2 = stanza_set_affiliations(RoomName,
                                           [{escalus_client:short_jid(Kate), <<"member">>}]),
         escalus:send(Alice, Stanza2),
-        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice, ?WAIT_TIMEOUT)),
         is_invitation(escalus:wait_for_stanza(Kate)),
 
         ok
@@ -4265,7 +4266,7 @@ wait_for_mam_result(RoomName, Client, Msg) ->
              {data_form, true}],
     QueryStanza = mam_helper:stanza_archive_request(Props, <<"q1">>),
     escalus:send(Client, muc_helper:stanza_to_room(QueryStanza, RoomName)),
-    S = escalus:wait_for_stanza(Client),
+    S = escalus:wait_for_stanza(Client, ?WAIT_TIMEOUT),
     M = exml_query:path(S, [{element, <<"result">>},
                             {element, <<"forwarded">>},
                             {element, <<"message">>}]),

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -334,7 +334,7 @@ init_per_group(hibernation, Config) ->
     end,
     Config;
 init_per_group(register_over_s2s, Config) ->
-    Config1 = s2s_helper:init_s2s(Config),
+    Config1 = s2s_helper:init_s2s(Config, false),
     Config2 = s2s_helper:configure_s2s(both_plain, Config1),
     [{_,AliceSpec2}|Others] = escalus:get_users([alice2, bob, kate]),
     Users = [{alice,AliceSpec2}|Others],

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -2626,7 +2626,7 @@ one2one_chat_to_muc(Config) ->
 %% Registration at a server
 %%--------------------------------------------------------------------
 
-%% You send the register IQ to room jid "muc@host/room".
+%% You send the register IQ to room jid.
 %% But in MongooseIM you need to send it to "muc@host".
 user_asks_for_registration_form(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->

--- a/test.disabled/ejabberd_tests/tests/muc_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_helper.erl
@@ -41,8 +41,14 @@ foreach_recipient(Users, VerifyFun) ->
       end, Users).
 
 load_muc(Host) ->
+    Backend = case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
+                  true -> odbc;
+                  false -> mnesia
+              end,
+    ct:pal("mod_muc backend=~p", [Backend]),
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},
+                           {backend, Backend},
                            {hibernate_timeout, 2000},
                            {hibernated_room_check_interval, 1000},
                            {hibernated_room_timeout, 2000},

--- a/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
@@ -77,7 +77,7 @@ suite() ->
 %%%===================================================================
 
 init_per_suite(Config) ->
-    Config1 = s2s_helper:init_s2s(escalus:init_per_suite(Config)),
+    Config1 = s2s_helper:init_s2s(escalus:init_per_suite(Config), true),
     escalus:create_users(Config1, escalus:get_users([alice2, alice, bob])).
 
 end_per_suite(Config) ->

--- a/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
@@ -70,85 +70,23 @@ negative() ->
     [timeout_waiting_for_message].
 
 suite() ->
-    require_s2s_nodes() ++
-    escalus:suite().
-
-require_s2s_nodes() ->
-    [{require, mim_node, {hosts, mim, node}},
-     {require, fed_node, {hosts, fed, node}}].
+    s2s_helper:suite(escalus:suite()).
 
 %%%===================================================================
 %%% Init & teardown
 %%%===================================================================
 
-init_per_suite(Config0) ->
-    Node1S2SCertfile = rpc(mim(), ejabberd_config, get_local_option, [s2s_certfile]),
-    Node1S2SUseStartTLS = rpc(mim(), ejabberd_config, get_local_option, [s2s_use_starttls]),
-
-    rpc(fed(), mongoose_cover_helper, start, [[ejabberd]]),
-
-    Node2S2SCertfile = rpc(fed(), ejabberd_config, get_local_option, [s2s_certfile]),
-    Node2S2SUseStartTLS = rpc(fed(), ejabberd_config, get_local_option, [s2s_use_starttls]),
-    S2S = #s2s_opts{node1_s2s_certfile = Node1S2SCertfile,
-                    node1_s2s_use_starttls = Node1S2SUseStartTLS,
-                    node2_s2s_certfile = Node2S2SCertfile,
-                    node2_s2s_use_starttls = Node2S2SUseStartTLS},
-
-    Config1 = [{s2s_opts, S2S} | escalus:init_per_suite(Config0)],
-    Config2 = [{escalus_user_db, xmpp} | Config1],
-    escalus:create_users(Config2, escalus:get_users([alice2, alice, bob])).
+init_per_suite(Config) ->
+    Config1 = s2s_helper:init_s2s(escalus:init_per_suite(Config)),
+    escalus:create_users(Config1, escalus:get_users([alice2, alice, bob])).
 
 end_per_suite(Config) ->
-    S2SOrig = ?config(s2s_opts, Config),
-    configure_s2s(S2SOrig),
-    rpc(fed(), mongoose_cover_helper, analyze, []),
+    s2s_helper:end_s2s(Config),
     escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
-init_per_group(both_plain, Config) ->
-    configure_s2s(#s2s_opts{}),
-    Config;
-init_per_group(both_tls_optional, Config) ->
-    S2S = ?config(s2s_opts, Config), %The initial config assumes that both nodes are configured to use encrypted s2s
-    configure_s2s(S2S),
-    Config;
-init_per_group(both_tls_required, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required,
-                               node2_s2s_use_starttls = required}),
-    Config;
-init_per_group(node1_tls_optional_node2_tls_required, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = required}),
-    Config;
-init_per_group(node1_tls_required_node2_tls_optional, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required}),
-    Config;
-init_per_group(node1_tls_required_trusted_node2_tls_optional, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required_trusted}),
-    Config;
-init_per_group(node1_tls_false_node2_tls_optional, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = false}),
-    Config;
-init_per_group(node1_tls_optional_node2_tls_false, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = false}),
-    Config;
-init_per_group(node1_tls_false_node2_tls_required, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = false,
-                               node2_s2s_use_starttls = required}),
-    Config;
-init_per_group(node1_tls_required_node2_tls_false, Config) ->
-    S2S = ?config(s2s_opts, Config),
-    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required,
-                               node2_s2s_use_starttls = false}),
-    Config;
-init_per_group(_GroupName, Config) ->
-    Config.
+init_per_group(GroupName, Config) ->
+    s2s_helper:configure_s2s(GroupName, Config).
 
 end_per_group(_GroupName, _Config) ->
     ok.
@@ -238,39 +176,3 @@ nonascii_addr(Config) ->
         escalus:assert(is_chat_message, [<<"Miło Cię poznać">>], Stanza2)
 
     end).
-
-configure_s2s(#s2s_opts{node1_s2s_certfile = Certfile1,
-                        node1_s2s_use_starttls = StartTLS1,
-                        node2_s2s_certfile = Certfile2,
-                        node2_s2s_use_starttls = StartTLS2}) ->
-    configure_s2s(mim(), Certfile1, StartTLS1),
-    configure_s2s(fed(), Certfile2, StartTLS2),
-    restart_s2s().
-
-configure_s2s(Node, Certfile, StartTLS) ->
-    rpc(Node, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
-    rpc(Node, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
-
-restart_s2s() ->
-    restart_s2s(mim()),
-    restart_s2s(fed()).
-
-restart_s2s(Node) ->
-    Children = rpc(Node, supervisor, which_children, [ejabberd_s2s_out_sup]),
-    [rpc(Node, ejabberd_s2s_out, stop_connection, [Pid]) ||
-     {_, Pid, _, _} <- Children],
-
-    ChildrenIn = rpc(Node, supervisor, which_children, [ejabberd_s2s_in_sup]),
-    [rpc(Node, erlang, exit, [Pid, kill]) ||
-     {_, Pid, _, _} <- ChildrenIn].
-
-mim() ->
-    get_or_fail(mim_node).
-
-fed() ->
-    get_or_fail(fed_node).
-
-get_or_fail(Key) ->
-    Val = ct:get_config(Key),
-    Val == undefined andalso error({undefined, Key}),
-    Val.

--- a/test.disabled/ejabberd_tests/tests/s2s_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/s2s_helper.erl
@@ -1,0 +1,123 @@
+-module(s2s_helper).
+-export([suite/1]).
+-export([init_s2s/1]).
+-export([end_s2s/1]).
+-export([configure_s2s/2]).
+
+-import(distributed_helper, [rpc/4, rpc/5]).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-record(s2s_opts, {
+          node1_s2s_certfile = undefined,
+          node1_s2s_use_starttls = undefined,
+          node2_s2s_certfile = undefined,
+          node2_s2s_use_starttls = undefined
+         }).
+
+
+suite(Config) ->
+    require_s2s_nodes() ++ Config.
+
+require_s2s_nodes() ->
+    [{require, mim_node, {hosts, mim, node}},
+     {require, fed_node, {hosts, fed, node}}].
+
+init_s2s(Config) ->
+    Node1S2SCertfile = rpc(mim(), ejabberd_config, get_local_option, [s2s_certfile]),
+    Node1S2SUseStartTLS = rpc(mim(), ejabberd_config, get_local_option, [s2s_use_starttls]),
+
+    rpc(fed(), mongoose_cover_helper, start, [[ejabberd]]),
+
+    Node2S2SCertfile = rpc(fed(), ejabberd_config, get_local_option, [s2s_certfile]),
+    Node2S2SUseStartTLS = rpc(fed(), ejabberd_config, get_local_option, [s2s_use_starttls]),
+    S2S = #s2s_opts{node1_s2s_certfile = Node1S2SCertfile,
+                    node1_s2s_use_starttls = Node1S2SUseStartTLS,
+                    node2_s2s_certfile = Node2S2SCertfile,
+                    node2_s2s_use_starttls = Node2S2SUseStartTLS},
+
+    [{s2s_opts, S2S}, {escalus_user_db, xmpp} | Config].
+
+end_s2s(Config) ->
+    S2SOrig = ?config(s2s_opts, Config),
+    configure_s2s(S2SOrig),
+    rpc(fed(), mongoose_cover_helper, analyze, []).
+
+configure_s2s(both_plain, Config) ->
+    configure_s2s(#s2s_opts{}),
+    Config;
+configure_s2s(both_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config), %The initial config assumes that both nodes are configured to use encrypted s2s
+    configure_s2s(S2S),
+    Config;
+configure_s2s(both_tls_required, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required,
+                               node2_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_optional_node2_tls_required, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_required_node2_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_required_trusted_node2_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required_trusted}),
+    Config;
+configure_s2s(node1_tls_false_node2_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = false}),
+    Config;
+configure_s2s(node1_tls_optional_node2_tls_false, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = false}),
+    Config;
+configure_s2s(node1_tls_false_node2_tls_required, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = false,
+                               node2_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_required_node2_tls_false, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required,
+                               node2_s2s_use_starttls = false}),
+    Config.
+
+configure_s2s(#s2s_opts{node1_s2s_certfile = Certfile1,
+                        node1_s2s_use_starttls = StartTLS1,
+                        node2_s2s_certfile = Certfile2,
+                        node2_s2s_use_starttls = StartTLS2}) ->
+    configure_s2s(mim(), Certfile1, StartTLS1),
+    configure_s2s(fed(), Certfile2, StartTLS2),
+    restart_s2s().
+
+configure_s2s(Node, Certfile, StartTLS) ->
+    rpc(Node, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
+    rpc(Node, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
+
+restart_s2s() ->
+    restart_s2s(mim()),
+    restart_s2s(fed()).
+
+restart_s2s(Node) ->
+    Children = rpc(Node, supervisor, which_children, [ejabberd_s2s_out_sup]),
+    [rpc(Node, ejabberd_s2s_out, stop_connection, [Pid]) ||
+     {_, Pid, _, _} <- Children],
+
+    ChildrenIn = rpc(Node, supervisor, which_children, [ejabberd_s2s_in_sup]),
+    [rpc(Node, erlang, exit, [Pid, kill]) ||
+     {_, Pid, _, _} <- ChildrenIn].
+
+mim() ->
+    get_or_fail(mim_node).
+
+fed() ->
+    get_or_fail(fed_node).
+
+get_or_fail(Key) ->
+    Val = ct:get_config(Key),
+    Val == undefined andalso error({undefined, Key}),
+    Val.


### PR DESCRIPTION
This PR adds SQL backend for mod_muc.

Proposed changes include:
* Separate query logic into separate Mnesia backend
* Add ODBC backend
* New option load_permanent_rooms_at_startup option that keep rooms hibernated after whole cluster restart.
