### PR TITLE
Disable DNS lookup for S2S hosts with predefined addresses.

### DIFF
--- a/apps/ejabberd/src/ejabberd_s2s.erl
+++ b/apps/ejabberd/src/ejabberd_s2s.erl
@@ -570,12 +570,8 @@ allow_host1(MyHost, S2SHost) ->
             case ejabberd_config:get_local_option({s2s_default_policy, MyHost}) of
                 deny -> false;
                 _ ->
-                    case ejabberd_hooks:run_fold(s2s_allow_host, MyHost,
-                                                 allow, [MyHost, S2SHost]) of
-                        deny -> false;
-                        allow -> true;
-                        _ -> true
-                    end
+                    ejabberd_hooks:run_fold(s2s_allow_host, MyHost,
+                                            allow, [MyHost, S2SHost]) /= deny
             end
     end.
 

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -233,13 +233,7 @@ open_socket(init, StateData) ->
                                 StateData#state.server,
                                 StateData#state.new,
                                 StateData#state.verify}]),
-    AddrList = get_predefined_addresses(StateData#state.server) ++
-               case ejabberd_s2s:domain_utf8_to_ascii(StateData#state.server) of
-                   false ->
-                       [];
-                   ASCIIAddr ->
-                       get_addr_port(ASCIIAddr)
-               end,
+    AddrList = get_addr_list(StateData#state.server),
     case lists:foldl(fun({Addr, Port}, Acc) ->
                              case Acc of
                                  {ok, Socket} ->
@@ -1334,6 +1328,20 @@ fsm_limit_opts() ->
             [{max_queue, N}];
         _ ->
             []
+    end.
+
+
+-spec get_addr_list(ejabberd:server()) -> [{inet:ip_address(), inet:port_number()}].
+get_addr_list(Server) ->
+    case get_predefined_addresses(Server) of
+        [] ->
+            case ejabberd_s2s:domain_utf8_to_ascii(Server) of
+                false -> [];
+                ASCIIAddr -> get_addr_port(ASCIIAddr)
+            end;
+
+        Addrs ->
+            Addrs
     end.
 
 

--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -234,20 +234,15 @@ open_socket(init, StateData) ->
                                 StateData#state.new,
                                 StateData#state.verify}]),
     AddrList = get_addr_list(StateData#state.server),
-    case lists:foldl(fun({Addr, Port}, Acc) ->
-                             case Acc of
-                                 {ok, Socket} ->
-                                     {ok, Socket};
-                                 _ ->
-                                     open_socket1(Addr, Port)
-                             end
+    case lists:foldl(fun({_Addr, _Port}, {ok, Socket}) ->
+                             {ok, Socket};
+                        ({Addr, Port}, _Acc) ->
+                             open_socket1(Addr, Port)
                      end, ?SOCKET_DEFAULT_RESULT, AddrList) of
         {ok, Socket} ->
-            Version = if
-                          StateData#state.use_v10 ->
-                              <<" version='1.0'">>;
-                          true ->
-                              <<"">>
+            Version = case StateData#state.use_v10 of
+                          true -> <<" version='1.0'">>;
+                          false -> <<"">>
                       end,
             NewStateData = StateData#state{socket = Socket,
                                            tls_enabled = false,
@@ -1346,7 +1341,7 @@ get_addr_list(Server) ->
 
 
 %% @doc Get IPs predefined for a given s2s domain in the configuration
--spec get_predefined_addresses(atom()) -> [{inet:ip_address(), inet:port_number()}].
+-spec get_predefined_addresses(ejabberd:server()) -> [{inet:ip_address(), inet:port_number()}].
 get_predefined_addresses(Server) ->
     S2SAddr = ejabberd_config:get_local_option({s2s_addr, Server}),
     do_get_predefined_addresses(S2SAddr).


### PR DESCRIPTION
When addresses are set in the configuration file via s2s_addr tuple,
it's a confusing behaviour to additionaly perform a DNS lookup of
the peer host and use its results alongside the preconfigured ones.