### PR TITLE
Add observer_cli dependency.

### DIFF
--- a/apps/ejabberd/src/ejabberd.app.src
+++ b/apps/ejabberd/src/ejabberd.app.src
@@ -28,6 +28,7 @@
                   lasse,
                   mnesia,
                   mochijson2,
+                  observer_cli,
                   pa,
                   poolboy,
                   public_key,

--- a/rebar.config
+++ b/rebar.config
@@ -44,6 +44,7 @@
   {worker_pool, ".*", {git, "git://github.com/inaka/worker_pool.git", {tag, "2.2.2"}}},
   {jwerl, ".*", {git, "git://github.com/emedia-project/jwerl.git", "3f365d1"}},
   {csv, ".*", {git, "https://github.com/bszaf/csv.git", {ref, "b0b854d"}}},
+  {observer_cli, "1.1.0"},
 
   %% TODO: Remove this override of an exometer_core dependency
   %%       once it bundles a new enough (i.e. with verify_directories=false) version.

--- a/rebar.lock
+++ b/rebar.lock
@@ -125,6 +125,7 @@
   {git,"git://github.com/mysql-otp/mysql-otp.git",
        {ref,"43336aee3ae785638c4e82577351c37ec2b51323"}},
   0},
+ {<<"observer_cli">>,{pkg,<<"observer_cli">>,<<"1.1.0">>},0},
  {<<"p1_utils">>,{pkg,<<"p1_utils">>,<<"1.0.6">>},1},
  {<<"pa">>,
   {git,"git://github.com/erszcz/pa.git",
@@ -210,5 +211,6 @@
 {pkg_hash,[
  {<<"eini">>, <<"ABD64A0533398A6D714D21219BB85F2D41FDB42665AC4080939B7BFA8E55F386">>},
  {<<"lhttpc">>, <<"2137CB82D123751B21CC0461A00734CD32CB470BC6278BA139EE13C1ECC3C2B1">>},
+ {<<"observer_cli">>, <<"F3A47C22327424291758167DF3C4600DCF8BF34795A3787612019AA5B86A5C21">>},
  {<<"p1_utils">>, <<"EF0951DDF38E92B7E479AF4B8DC950DF76AF8C1030432EF68B7FD7AD17C436FE">>}]}
 ].


### PR DESCRIPTION
[observer_cli](https://github.com/zhongwencool/observer_cli) increases our ability to perform runtime diagnostics of the system.