### PR TITLE
Make auth_jwt more configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,18 @@ $(DEVNODES): certs configure.out rel/vars.config
 	(. ./configure.out && \
 	DEVNODE=true ./rebar3 as $@ release) > $(LOG_SILENCE_COVER)
 
-certs: tools/ssl/ca/cacert.pem tools/ssl/fake_cert.pem \
-       tools/ssl/fake_key.pem tools/ssl/fake_server.pem \
-	   tools/ssl/fake_dh_server.pem
+certs: tools/ssl/ca/cacert.pem \
+       tools/ssl/fake_cert.pem \
+       tools/ssl/fake_key.pem \
+       tools/ssl/fake_pubkey.pem \
+       tools/ssl/fake_server.pem \
+       tools/ssl/fake_dh_server.pem
 
-tools/ssl/ca/cacert.pem tools/ssl/fake_cert.pem \
-tools/ssl/fake_key.pem tools/ssl/fake_server.pem \
+tools/ssl/ca/cacert.pem \
+tools/ssl/fake_cert.pem \
+tools/ssl/fake_key.pem \
+tools/ssl/fake_pubkey.pem \
+tools/ssl/fake_server.pem \
 tools/ssl/fake_dh_server.pem:
 	cd tools/ssl && make
 

--- a/apps/ejabberd/src/ejabberd_auth_jwt.erl
+++ b/apps/ejabberd/src/ejabberd_auth_jwt.erl
@@ -57,7 +57,13 @@
 %%%----------------------------------------------------------------------
 
 -spec start(Host :: ejabberd:server()) -> ok.
-start(_Host) ->
+start(Host) ->
+    UsernameKey = get_auth_opt(Host, jwt_username_key),
+    true = is_atom(UsernameKey) andalso UsernameKey /= undefined,
+
+    JWTSecret = get_jwt_secret(Host),
+    set_auth_opts(Host, [{jwt_secret, JWTSecret},
+                         {jwt_algorithm, list_to_binary(get_auth_opt(Host, jwt_algorithm))}]),
     ok.
 
 -spec stop(Host :: ejabberd:server()) -> ok.
@@ -76,19 +82,14 @@ authorize(Creds) ->
                      LServer :: ejabberd:lserver(),
                      Password :: binary()) -> boolean().
 check_password(LUser, LServer, Password) ->
-    Key = case get_auth_opt(LServer, jwt_key) of
-              Key1 when is_binary(Key1) ->
-                  Key1;
-              Key1 when is_list(Key1) ->
-                  list_to_binary(Key1);
-              {env, Var} ->
-                  list_to_binary(os:getenv(Var))
+    Key = case get_auth_opt(LServer, jwt_secret) of
+              Key1 when is_binary(Key1) -> Key1;
+              {env, Var} -> list_to_binary(os:getenv(Var))
           end,
-    Options = #{key => Key, alg => <<"HS256">>},
+    Options = #{key => Key, alg => get_auth_opt(LServer, jwt_algorithm)},
     case jwerl:verify(Password, Options) of
         {ok, TokenData} ->
-            %% Example: bookingNumber => <<"10857838">>
-            UserKey = get_auth_opt(LServer, token_user_key),
+            UserKey = get_auth_opt(LServer, jwt_username_key),
             case maps:find(UserKey, TokenData) of
                 {ok, LUser} ->
                     %% Login username matches $token_user_key in TokenData
@@ -199,12 +200,29 @@ remove_user(_LUser, _LServer) ->
 remove_user(_LUser, _LServer, _Password) ->
     {error, not_allowed}.
 
+%%%----------------------------------------------------------------------
+%%% Internal helpers
+%%%----------------------------------------------------------------------
 
-%% Internal helper
+% A direct path to a file is read only once during startup,
+% a path in environment variable is read on every auth request.
+get_jwt_secret(Host) ->
+    case {get_auth_opt(Host, jwt_secret_source), get_auth_opt(Host, jwt_secret)} of
+        {undefined, JWTSecret0} when is_list(JWTSecret0) ->
+            list_to_binary(JWTSecret0);
+        {undefined, JWTSecret0} when is_binary(JWTSecret0) ->
+            JWTSecret0;
+        {{env, _} = Env, _} ->
+            Env;
+        {JWTSecretPath, _} when is_list(JWTSecretPath) ->
+            {ok, JWTSecretBin} = file:read_file(JWTSecretPath),
+            JWTSecretBin
+    end.
+
 get_auth_opt(Host, Key) ->
     case ejabberd_config:get_local_option(auth_opts, Host) of
         undefined ->
-            false;
+            undefined;
         AuthOpts ->
             case lists:keyfind(Key, 1, AuthOpts) of
                 {Key, Value} ->
@@ -213,3 +231,17 @@ get_auth_opt(Host, Key) ->
                     undefined
             end
     end.
+
+%% This function will store new auth_opts for specific host.
+%% If auth_opts for Host are fetched from global setting,
+%% the new values will be available for get_local_option calls
+%% but not for get_global_option.
+%% Also, options in `KVs` will get overwritten and the remaining ones are copied.
+%% TODO: Replace with generic functions in ejabberd_auth.
+set_auth_opts(Host, KVs) ->
+    AuthOpts = ejabberd_config:get_local_option(auth_opts, Host),
+    AuthOpts1 = lists:foldl(fun({Key, Value}, Acc) ->
+                                    lists:keystore(Key, 1, Acc, {Key, Value})
+                            end, AuthOpts, KVs),
+    ejabberd_config:add_local_option({auth_opts, Host}, AuthOpts1).
+

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -178,18 +178,18 @@ The tuple order is important, unless the no `host_config` option is set. Retaini
              * **Description:** Path to the authentication script used by the `external` auth module. Script API specification can be found in the [[External authentication script]].
 
         * **jwt_secret_source** (local)
-            * **Description:** A path to a file or environment variable, which contents will be used as JWT secret.
-            * **Warning:** A direct path to a file is read only once during startup, a path in environment variable is read on every auth request.
+            * **Description:** A path to a file or environment variable, which contents will be used as a JWT secret.
+            * **Warning:** A direct path to a file is read only once during startup, a path in the environment variable is read on every auth request.
             * **Value:** string, e.g. `/etc/secrets/jwt` or `{env, "env-variable-name"}`
             * **Default:** none, either `jwt_secret_source` or `jwt_secret` must be set
         
         * **jwt_secret** (local)
-            * **Description:** A binary with JWT secret. This options is ignored and overwritten, if `jwt_secret_source` is defined.
+            * **Description:** A binary with a JWT secret. This options is ignored and overwritten, if `jwt_secret_source` is defined.
             * **Value:** binary
-            * **Default:** none, either `jwt_secret_source` or `jwt_secret` must be set
+            * **Default:** none (either `jwt_secret_source` or `jwt_secret` must be set)
         
         * **jwt_algorithm** (local)
-            * **Description:** A name of algorithm used to sign JWT.
+            * **Description:** A name of the algorithm used to sign JWT.
             * **Valid values:** `"HS256", "RS256", "ES256", "HS386", "RS386", "ES386", "HS512", "RS512", "ES512"`
             * **Default:** none, it's a mandatory option
         

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -158,8 +158,8 @@ The tuple order is important, unless the no `host_config` option is set. Retaini
 
 - **auth_method** (local)
     * **Description:** Chooses an authentication module or a list of modules. Modules from a list are queried one after another until one of them replies positively.
-    * **Valid values:** `internal` (Mnesia), `odbc`, `external`, `anonymous`, `ldap`
-    * **Warning:** `external` and `ldap` limit SASL mechanisms list to `PLAIN` and `ANONYMOUS`.
+    * **Valid values:** `internal` (Mnesia), `odbc`, `external`, `anonymous`, `ldap`, `jwt`, `riak`, `http`
+    * **Warning:** `external`, `jwt` and `ldap` work only with `PLAIN` SASL mechanism.
     * **Examples:** `odbc`, `[internal, anonymous]`
 
 - **auth_opts** (local)
@@ -176,6 +176,27 @@ The tuple order is important, unless the no `host_config` option is set. Retaini
 
         * **ext_auth_script** (local)
              * **Description:** Path to the authentication script used by the `external` auth module. Script API specification can be found in the [[External authentication script]].
+
+        * **jwt_secret_source** (local)
+            * **Description:** A path to a file or environment variable, which contents will be used as JWT secret.
+            * **Warning:** A direct path to a file is read only once during startup, a path in environment variable is read on every auth request.
+            * **Value:** string, e.g. `/etc/secrets/jwt` or `{env, "env-variable-name"}`
+            * **Default:** none, either `jwt_secret_source` or `jwt_secret` must be set
+        
+        * **jwt_secret** (local)
+            * **Description:** A binary with JWT secret. This options is ignored and overwritten, if `jwt_secret_source` is defined.
+            * **Value:** binary
+            * **Default:** none, either `jwt_secret_source` or `jwt_secret` must be set
+        
+        * **jwt_algorithm** (local)
+            * **Description:** A name of algorithm used to sign JWT.
+            * **Valid values:** `"HS256", "RS256", "ES256", "HS386", "RS386", "ES386", "HS512", "RS512", "ES512"`
+            * **Default:** none, it's a mandatory option
+        
+        * **jwt_username_key** (local)
+            * **Description:** A JWT key that contains username to verify.
+            * **Value:** atom
+            * **Default:** none, it's a mandatory option
 
 - **LDAP-related options**
     * **ldap_base:**
@@ -220,9 +241,7 @@ The tuple order is important, unless the no `host_config` option is set. Retaini
                                   {ldap_local_filter, {notequal, {"accountStatus",["disabled"]}}}.
                                   {ldap_local_filter, {equal, {"accountStatus",["enabled"]}}}.
                                   {ldap_local_filter, undefined}.
-
         * **Default:** `undefined`
-
 
 ### Database setup
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -353,8 +353,9 @@
              {{{ext_auth_script}}}
              %%
              %% For auth_jwt
-             %% {jwt_key, "shared_secret"},
-             %% {token_user_key, bookingNumber}
+             %% {jwt_secret_source, "/path/to/file"},
+             %% {jwt_algorithm, "RS256"},
+             %% {jwt_username_key, user}
             ]}.
 
 %%

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -1,7 +1,7 @@
 CA_SUB  = /C=PL/ST=Malopolska/L=Krakow/CN=MongooseIM Fake CA
 SRV_SUB = /C=PL/ST=Malopolska/L=Krakow/CN=MongooseIM Server
 
-all: ca/cacert.pem fake_cert.pem fake_server.pem fake_dh_server.pem
+all: ca/cacert.pem fake_cert.pem fake_pubkey.pem fake_privkey.pem fake_server.pem fake_dh_server.pem
 
 ca/cacert.pem ca/cakey.pem: openssl-ca.cnf
 	mkdir -p ca
@@ -17,6 +17,12 @@ fake_cert.csr: openssl-server.cnf
 fake_cert.pem: fake_cert.csr openssl-ca.cnf ca/cacert.pem ca/cakey.pem ca/index.txt ca/serial.txt
 	yes | openssl ca -config openssl-ca.cnf -policy signing_policy \
 		-extensions signing_req -out $@ -infiles fake_cert.csr
+
+fake_pubkey.pem: fake_cert.pem
+	openssl x509 -pubkey -noout -in fake_cert.pem > fake_pubkey.pem
+
+fake_privkey.pem: fake_key.pem
+	openssl rsa -in fake_key.pem -out fake_privkey.pem
 
 fake_server.pem: fake_cert.pem fake_key.pem
 	cat $^ > $@


### PR DESCRIPTION
This PR adds more configuration options to `ejabberd_auth_jwt` backend, enabling more token types.

Auth docs are updated to match current configuration format, although further docs refactoring is necessary (i.e. extracting auth config options to dedicated page).