### PR TITLE
Use older image of rslota/fcm-http2-mock-server

### DIFF
--- a/test.disabled/ejabberd_tests/services/mongoose_push-compose.yml
+++ b/test.disabled/ejabberd_tests/services/mongoose_push-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   fcm-mock:
-    image: rslota/fcm-http2-mock-server
+    image: rslota/fcm-http2-mock-server:working
     expose:
       - "443"
     ports:


### PR DESCRIPTION
The latest version was not working (most likely due to some python lib dependencies)
so we try to use older version to check if Travis jobs still fail.