### PR TITLE
Create foreign-event IQ handler and verify requests

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -118,6 +118,8 @@
 %% Erlang Solutions custom extension - token based authentication
 -define(NS_ESL_TOKEN_AUTH, <<"erlang-solutions.com:xmpp:token-auth:0">>).
 
+-define(NS_FOREIGN_EVENT, <<"urn:xmpp:foreign_event:0">>).
+
 -define(NS_FOREIGN_EVENT_HTTP, <<"urn:xmpp:foreign_event:http:0">>).
 
 -define(ERR_BAD_REQUEST,

--- a/apps/ejabberd/src/foreign_event/mod_foreign_http.erl
+++ b/apps/ejabberd/src/foreign_event/mod_foreign_http.erl
@@ -28,9 +28,11 @@
 %%--------------------------------------------------------------------
 
 make_request(Request, OnResponse) ->
-    {Host, Path, Method, Headers, Body} = parse(Request),
-    Response = do_make_request(Host, Path, Method, Headers, Body),
-    respond(encode(Response), OnResponse),
+    spawn(fun() ->
+            {Host, Path, Method, Headers, Body} = parse(Request),
+            Response = do_make_request(Host, Path, Method, Headers, Body),
+            respond(encode(Response), OnResponse)
+          end),
     ok.
 
 %%--------------------------------------------------------------------

--- a/test.disabled/ejabberd_tests/tests/mod_foreign_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_foreign_SUITE.erl
@@ -12,7 +12,7 @@
                      {http, [{pool_size, 100}]}
                     ]}
         ]).
-
+-define(NS_FOREIGN_EVENT, <<"urn:xmpp:foreign_event:0">>).
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -23,7 +23,11 @@ all() ->
 
 groups() ->
     [{mod_foreign, [], [
-                        foreign_event_item_discovery
+                        foreign_event_item_discovery,
+                        foreign_event_without_request_node,
+                        foreign_event_without_request_type,
+                        foreign_event_with_unknown_request_type,
+                        foreign_event_http_success
                        ]}].
 
 suite() ->
@@ -67,6 +71,89 @@ foreign_event_item_discovery(Config) ->
               escalus:assert(has_item, [foreign_service(Bob)], Result)
       end).
 
+%%--------------------------------------------------------------------
+%% Bad request tests
+%%--------------------------------------------------------------------
+
+foreign_event_without_request_node(Config) ->
+    escalus:story(Config, [{bob, 1}],
+                  fun(Bob) ->
+                      ForeignEventJID = foreign_service(Bob),
+                      Stanza = foreign_event_iq(ForeignEventJID, []),
+
+                      Result = escalus:send_and_wait(Bob, Stanza),
+
+                      escalus:assert(is_iq_error, Result),
+                      Error = exml_query:subelement(Result, <<"error">>),
+                      ?assertNotEqual(undefined, Error),
+                      ErrorCode = exml_query:attr(Error, <<"code">>),
+                      ErrorType = exml_query:attr(Error, <<"type">>),
+                      ?assertEqual(<<"400">>, ErrorCode),
+                      ?assertEqual(<<"modify">>, ErrorType),
+                      ?assertMatch([_], exml_query:paths(Error, [{element, <<"bad-request">>}]))
+                  end).
+
+foreign_event_without_request_type(Config) ->
+    escalus:story(Config, [{bob, 1}],
+                  fun(Bob) ->
+                      ForeignEventJID = foreign_service(Bob),
+                      Stanza = foreign_event_iq(ForeignEventJID,
+                                                [#xmlel{name = <<"request">>}]),
+
+                      Result = escalus:send_and_wait(Bob, Stanza),
+
+                      escalus:assert(is_iq_error, Result),
+                      Error = exml_query:subelement(Result, <<"error">>),
+                      ?assertNotEqual(undefined, Error),
+                      ErrorCode = exml_query:attr(Error, <<"code">>),
+                      ErrorType = exml_query:attr(Error, <<"type">>),
+                      ?assertEqual(<<"400">>, ErrorCode),
+                      ?assertEqual(<<"modify">>, ErrorType),
+                      ?assertMatch([_], exml_query:paths(Error, [{element, <<"bad-request">>}]))
+                  end).
+
+
+%%--------------------------------------------------------------------
+%% Feature not implemented test
+%%--------------------------------------------------------------------
+
+foreign_event_with_unknown_request_type(Config) ->
+    escalus:story(Config, [{bob, 1}],
+                  fun(Bob) ->
+                      ForeignEventJID = foreign_service(Bob),
+                      Stanza = foreign_event_iq(ForeignEventJID,
+                                                [#xmlel{name = <<"request">>,
+                                                        attrs = [{<<"type">>, <<"amqp">>}]}]),
+
+                      Result = escalus:send_and_wait(Bob, Stanza),
+
+                      escalus:assert(is_iq_error, Result),
+                      Error = exml_query:subelement(Result, <<"error">>),
+                      ?assertNotEqual(undefined, Error),
+                      ErrorCode = exml_query:attr(Error, <<"code">>),
+                      ErrorType = exml_query:attr(Error, <<"type">>),
+                      ?assertEqual(<<"501">>, ErrorCode),
+                      ?assertEqual(<<"cancel">>, ErrorType),
+                      ?assertMatch([_], exml_query:paths(Error, [{element, <<"feature-not-implemented">>}]))
+                  end).
+
+%%--------------------------------------------------------------------
+%% Success HTTP event
+%%--------------------------------------------------------------------
+
+foreign_event_http_success(Config) ->
+    escalus:story(Config, [{bob, 1}],
+                  fun(Bob) ->
+                      ForeignEventJID = foreign_service(Bob),
+                      Stanza = foreign_event_iq(ForeignEventJID,
+                                                [#xmlel{name = <<"request">>,
+                                                        attrs = [{<<"type">>, <<"http">>}]}]),
+
+                      Result = escalus:send_and_wait(Bob, Stanza),
+
+                      escalus:assert(is_iq_result, Result)
+                  end).
+
 
 %%--------------------------------------------------------------------
 %% Test helpers
@@ -77,3 +164,9 @@ foreign_service(Client) ->
 
 host() ->
     ct:get_config({hosts, mim, domain}).
+
+foreign_event_iq(To, Children) ->
+    ForeignEvent = #xmlel{name = <<"foreign-event">>,
+                          attrs = [{<<"xmlns">>, ?NS_FOREIGN_EVENT}],
+                          children = Children},
+    escalus_stanza:iq(To, <<"set">>, [ForeignEvent]).


### PR DESCRIPTION
This PR installs handler for foreign-event IQ stanzas and simple verification of requests format.

