### PR TITLE
Fix muc_SUITE sometimes fails on RSM disco cases

### DIFF
--- a/apps/ejabberd/src/mod_muc.erl
+++ b/apps/ejabberd/src/mod_muc.erl
@@ -166,8 +166,13 @@ start(Host, Opts) ->
     | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop(Host) ->
     stop_supervisor(Host),
+    stop_gen_server(Host).
+
+stop_gen_server(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
+    %% Proc can still be alive because of a race condition
+    supervisor:terminate_child(ejabberd_sup, Proc),
     supervisor:delete_child(ejabberd_sup, Proc).
 
 

--- a/test.disabled/ejabberd_tests/tests/mongoose_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/mongoose_helper.erl
@@ -18,6 +18,7 @@
          clear_caps_cache/1]).
 
 -export([kick_everyone/0]).
+-export([ensure_muc_clean/0]).
 
 -define(RPC(M, F, A), escalus_ejabberd:rpc(M, F, A)).
 
@@ -195,3 +196,21 @@ get_session_specs() ->
 
 get_session_pids() ->
     [element(2, X) || X <- get_session_specs()].
+
+
+ensure_muc_clean() ->
+    stop_online_rooms(),
+    forget_persistent_rooms().
+
+stop_online_rooms() ->
+    Host = ct:get_config({hosts, mim, domain}),
+    Supervisor = escalus_ejabberd:rpc(gen_mod, get_module_proc,
+                                      [Host, ejabberd_mod_muc_sup]),
+    escalus_ejabberd:rpc(erlang, exit, [Supervisor, kill]),
+    escalus_ejabberd:rpc(mnesia, clear_table, [muc_online_room]),
+    ok.
+
+forget_persistent_rooms() ->
+    escalus_ejabberd:rpc(mnesia, clear_table, [muc_room]),
+    escalus_ejabberd:rpc(mnesia, clear_table, [muc_registered]),
+    ok.

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -257,12 +257,17 @@ suite() ->
 
 
 init_per_suite(Config) ->
+    Config2 = escalus:init_per_suite(Config),
+    Config3 = dynamic_modules:save_modules(domain(), Config2),
     load_muc(muc_host()),
-    escalus:init_per_suite(Config).
+    mongoose_helper:ensure_muc_clean(),
+    Config3.
 
 end_per_suite(Config) ->
-    unload_muc(),
     escalus_fresh:clean(),
+    mongoose_helper:ensure_muc_clean(),
+    unload_muc(),
+    dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_suite(Config).
 
 init_per_group(moderator, Config) ->
@@ -286,6 +291,7 @@ init_per_group(disco, Config) ->
         [{persistent, true}]);
 
 init_per_group(disco_rsm, Config) ->
+    mongoose_helper:ensure_muc_clean(),
     Config1 = escalus:create_users(Config, escalus:get_users([alice, bob])),
     [Alice | _] = ?config(escalus_users, Config1),
     start_rsm_rooms(Config1, Alice, <<"aliceonchat">>);


### PR DESCRIPTION
This PR addresses the error on travis:

```
====== Suite FAILED: muc_SUITE (5 of 119 tests failed)
====== Test name: pagination_empty_rset
====== Reason:    {test_case_failed,"assert_equal( \"i2b ( TotalCount )\", \"Out # rsm_out . count\") failed\n\tExpected <<\"15\">>\n\tValue <<\"16\">>\n"}
====== Test name: pagination_last5
====== Reason:    {test_case_failed,"assert_equal( \"i2b ( TotalCount )\", \"Out # rsm_out . count\") failed\n\tExpected <<\"15\">>\n\tValue <<\"16\">>\n"}
====== Test name: pagination_first5
====== Reason:    {test_case_failed,"assert_equal( \"i2b ( TotalCount )\", \"Out # rsm_out . count\") failed\n\tExpected <<\"15\">>\n\tValue <<\"16\">>\n"}
====== Test name: pagination_before10
====== Reason:    {test_case_failed,"assert_equal( \"i2b ( TotalCount )\", \"Out # rsm_out . count\") failed\n\tExpected <<\"15\">>\n\tValue <<\"16\">>\n"}
====== Test name: pagination_after10
====== Reason:    {test_case_failed,"assert_equal( \"i2b ( TotalCount )\", \"Out # rsm_out . count\") failed\n\tExpected <<\"15\">>\n\tValue <<\"16\">>\n"}
```

Proposed changes include:
* Clean mod_muc module's database state;
* Save and restore modules in init/end_per_suite callbacks;
* terminate before destroying worker in mod_muc:stop/1 (because doc says that process should be dead before terminating it and after returning from the stop call the server still can be running - for example, executing the gen_server's terminate callback).

