### PR TITLE
Add Foreign-Event related metrics

### DIFF
--- a/snippets.erl
+++ b/snippets.erl
@@ -52,4 +52,13 @@ recon_trace:calls({mod_foreign, parse_foreign_event, fun(_) -> return_trace() en
 recon_trace:calls({mod_foreign_http, encode, fun(_) -> return_trace() end},100,[{scope, local}]).
 
 
+%% mod_foreign global metrics
 
+mongoose_metrics:get_metric_value([<<"localhost">>, mod_foreign, failed_requests]).
+mongoose_metrics:get_metric_value([<<"localhost">>, mod_foreign, successful_requests]).
+mongoose_metrics:get_metric_value([<<"localhost">>, mod_foreign, response_time]).
+
+%% mod_foreign_http metrics
+mongoose_metrics:get_metric_value([<<"localhost">>, mod_foreign_http, failed_http_requests]).
+mongoose_metrics:get_metric_value([<<"localhost">>, mod_foreign_http, successful_http_requests]).
+mongoose_metrics:get_metric_value([<<"localhost">>, mod_foreign_http, http_request_time]).


### PR DESCRIPTION
There're 3 mod_foreign global metrics:
[HOST, mod_foreign, failed_requests]
[HOST, mod_foreign, successful_requests]
[HOST, mod_foreign, response_time]

There're 3 mod_foreign_http metrics:
[HOST, mod_foreign_http, failed_http_requests]
[HOST, mod_foreign_http, successful_http_requests]
[HOST, mod_foreign_http, http_request_time]

This PR addresses #

Proposed changes include:
* describe the functionality changes
* describe new or updated tests
* describe changes to the documentation

