### PR TITLE
Go back to old now()-like behaviour for generating MAM ids.

### DIFF
--- a/apps/ejabberd/c_src/mongoose_mam_id.cpp
+++ b/apps/ejabberd/c_src/mongoose_mam_id.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file mongoose_mam_id.cpp
+ * @author konrad.zemek@erlang-solutions.com
+ * @copyright 2017 Erlang Solutions Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <erl_nif.h>
+
+#include <atomic>
+#include <cstdint>
+
+static std::atomic<std::uint_fast64_t> counter{ 0 };
+
+extern "C" {
+static ERL_NIF_TERM next_unique(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    unsigned long long_candidate;
+    if (!enif_get_uint64(env, argv[0], &long_candidate))
+        return enif_make_badarg(env);
+
+    std::uint_fast64_t candidate = long_candidate;
+    std::uint_fast64_t current = candidate - 1;
+
+    while (!counter.compare_exchange_weak(current, candidate, std::memory_order_relaxed))
+        {
+            if (current >= candidate)
+                candidate = current + 1;
+        }
+
+    return enif_make_uint64(env, candidate);
+}
+
+static ErlNifFunc nif_funcs[] = { { "next_unique", 1, next_unique } };
+
+ERL_NIF_INIT(mongoose_mam_id, nif_funcs, nullptr, nullptr, nullptr, nullptr)
+}

--- a/apps/ejabberd/rebar.config
+++ b/apps/ejabberd/rebar.config
@@ -12,8 +12,10 @@
 ]}.
 
 {port_specs,
- [{".*", "priv/lib/ejabberd_zlib_drv.so", ["c_src/ejabberd_zlib_drv.c"], [{env, [{"LDFLAGS", "$LDFLAGS -lz"}]}]}]
- }.
+ [
+  {".*", "priv/lib/ejabberd_zlib_drv.so", ["c_src/ejabberd_zlib_drv.c"], [{env, [{"LDFLAGS", "$LDFLAGS -lz"}]}]},
+  {".*", "priv/lib/mongoose_mam_id.so", ["c_src/mongoose_mam_id.cpp"], [{env, [{"CXXFLAGS", "$CXXFLAGS -std=c++11"}]}]}
+ ]}.
 
 {xref_checks, [undefined_function_calls,
                undefined_functions,

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -177,7 +177,7 @@ microseconds_to_datetime(MicroSeconds) when is_integer(MicroSeconds) ->
 -spec generate_message_id() -> integer().
 generate_message_id() ->
     {ok, NodeId} = ejabberd_node_id:node_id(),
-    CandidateStamp = p1_time_compat:system_time(micro_seconds),
+    CandidateStamp = p1_time_compat:os_system_time(micro_seconds),
     UniqueStamp = mongoose_mam_id:next_unique(CandidateStamp),
     encode_compact_uuid(UniqueStamp, NodeId).
 

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -177,11 +177,9 @@ microseconds_to_datetime(MicroSeconds) when is_integer(MicroSeconds) ->
 -spec generate_message_id() -> integer().
 generate_message_id() ->
     {ok, NodeId} = ejabberd_node_id:node_id(),
-    %% Unique enough
-    {T1, T2, T3} = p1_time_compat:timestamp(),
-    ImprovedTS = {T1, T2,
-                  (T3 div 1000) * 1000 + p1_time_compat:unique_integer([positive]) rem 1000 },
-    encode_compact_uuid(now_to_microseconds(ImprovedTS), NodeId).
+    CandidateStamp = p1_time_compat:system_time(micro_seconds),
+    UniqueStamp = mongoose_mam_id:next_unique(CandidateStamp),
+    encode_compact_uuid(UniqueStamp, NodeId).
 
 
 %% @doc Create a message ID (UID).

--- a/apps/ejabberd/src/mongoose_mam_id.erl
+++ b/apps/ejabberd/src/mongoose_mam_id.erl
@@ -1,0 +1,28 @@
+%%==============================================================================
+%% Copyright 2017 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(mongoose_mam_id).
+-author('konrad.zemek@erlang-solutions.com').
+
+-export([next_unique/1]).
+-on_load(load/0).
+
+load() ->
+    Path = filename:join(ejabberd:get_so_path(), ?MODULE_STRING),
+    erlang:load_nif(Path, 0).
+
+next_unique(_Candidate) ->
+    erlang:nif_error(not_loaded).


### PR DESCRIPTION
The difference is that the underlying implementation ensuring
unique microsecond timestamps is now based on atomic operations,
optimized for speed and should not be any kind of bottleneck.