### PR TITLE
Simplify adding and deleting hooks from modules

### DIFF
--- a/apps/ejabberd/src/mod_adhoc.erl
+++ b/apps/ejabberd/src/mod_adhoc.erl
@@ -52,29 +52,23 @@ start(Host, Opts) ->
                                   ?MODULE, process_local_iq, IQDisc),
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_COMMANDS,
                                   ?MODULE, process_sm_iq, IQDisc),
-
-    ejabberd_hooks:add(disco_local_identity, Host, ?MODULE, get_local_identity, 99),
-    ejabberd_hooks:add(disco_local_features, Host, ?MODULE, get_local_features, 99),
-    ejabberd_hooks:add(disco_local_items, Host, ?MODULE, get_local_commands, 99),
-    ejabberd_hooks:add(disco_sm_identity, Host, ?MODULE, get_sm_identity, 99),
-    ejabberd_hooks:add(disco_sm_features, Host, ?MODULE, get_sm_features, 99),
-    ejabberd_hooks:add(disco_sm_items, Host, ?MODULE, get_sm_commands, 99),
-    ejabberd_hooks:add(adhoc_local_items, Host, ?MODULE, ping_item, 100),
-    ejabberd_hooks:add(adhoc_local_commands, Host, ?MODULE, ping_command, 100).
+    ejabberd_hooks:add(hooks(Host)).
 
 stop(Host) ->
-    ejabberd_hooks:delete(adhoc_local_commands, Host, ?MODULE, ping_command, 100),
-    ejabberd_hooks:delete(adhoc_local_items, Host, ?MODULE, ping_item, 100),
-    ejabberd_hooks:delete(disco_sm_items, Host, ?MODULE, get_sm_commands, 99),
-    ejabberd_hooks:delete(disco_sm_features, Host, ?MODULE, get_sm_features, 99),
-    ejabberd_hooks:delete(disco_sm_identity, Host, ?MODULE, get_sm_identity, 99),
-    ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, get_local_commands, 99),
-    ejabberd_hooks:delete(disco_local_features, Host, ?MODULE, get_local_features, 99),
-    ejabberd_hooks:delete(disco_local_identity, Host, ?MODULE, get_local_identity, 99),
+    ejabberd_hooks:delete(hooks(Host)),
 
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_COMMANDS),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_COMMANDS).
 
+hooks(Host) ->
+    [{disco_local_identity, Host, ?MODULE, get_local_identity, 99},
+     {disco_local_features, Host, ?MODULE, get_local_features, 99},
+     {disco_local_items, Host, ?MODULE, get_local_commands, 99},
+     {disco_sm_identity, Host, ?MODULE, get_sm_identity, 99},
+     {disco_sm_features, Host, ?MODULE, get_sm_features, 99},
+     {disco_sm_items, Host, ?MODULE, get_sm_commands, 99},
+     {adhoc_local_items, Host, ?MODULE, ping_item, 100},
+     {adhoc_local_commands, Host, ?MODULE, ping_command, 100}].
 %%-------------------------------------------------------------------------
 
 -spec get_local_commands(Acc :: [jlib:xmlel()],

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -27,22 +27,19 @@
 
 start(Host, _Opts) ->
     mod_disco:register_feature(Host, ?NS_AMP),
-    ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE, add_stream_feature, 50),
-    ejabberd_hooks:add(disco_local_features, Host, ?MODULE, add_local_features, 99),
-    ejabberd_hooks:add(amp_check_packet, Host, ?MODULE, amp_check_packet, 10),
-    ejabberd_hooks:add(amp_verify_support, Host, ?AMP_RESOLVER, verify_support, 10),
-    ejabberd_hooks:add(amp_check_condition, Host, ?AMP_RESOLVER, check_condition, 10),
-    ejabberd_hooks:add(amp_determine_strategy, Host, ?AMP_STRATEGY, determine_strategy, 10).
+    ejabberd_hooks:add(hooks(Host)).
 
 stop(Host) ->
-    ejabberd_hooks:delete(amp_determine_strategy, Host, ?AMP_STRATEGY, determine_strategy, 10),
-    ejabberd_hooks:delete(amp_check_condition, Host, ?AMP_RESOLVER, check_condition, 10),
-    ejabberd_hooks:delete(amp_verify_support, Host, ?AMP_RESOLVER, verify_support, 10),
-    ejabberd_hooks:delete(amp_check_packet, Host, ?MODULE, amp_check_packet, 10),
-    ejabberd_hooks:delete(disco_local_features, Host, ?MODULE, add_local_features, 99),
-    ejabberd_hooks:delete(c2s_stream_features, Host, ?MODULE, add_stream_feature, 50),
+    ejabberd_hooks:delete(hooks(Host)),
     mod_disco:unregister_feature(Host, ?NS_AMP).
 
+hooks(Host) ->
+    [{c2s_stream_features, Host, ?MODULE, add_stream_feature, 50},
+     {disco_local_features, Host, ?MODULE, add_local_features, 99},
+     {amp_check_packet, Host, ?MODULE, amp_check_packet, 10},
+     {amp_verify_support, Host, ?AMP_RESOLVER, verify_support, 10},
+     {amp_check_condition, Host, ?AMP_RESOLVER, check_condition, 10},
+     {amp_determine_strategy, Host, ?AMP_STRATEGY, determine_strategy, 10}].
 %% Business API
 
 -spec check_packet(mongoose_acc:t() | exml:element(), amp_event()) ->

--- a/apps/ejabberd/src/mod_roster.erl
+++ b/apps/ejabberd/src/mod_roster.erl
@@ -171,43 +171,24 @@ start(Host, Opts) ->
     gen_mod:start_backend_module(?MODULE, Opts, TrackedFuns),
     mod_roster_backend:init(Host, Opts),
 
-    ejabberd_hooks:add(roster_get, Host,
-                       ?MODULE, get_user_roster, 50),
-    ejabberd_hooks:add(roster_in_subscription, Host,
-                       ?MODULE, in_subscription, 50),
-    ejabberd_hooks:add(roster_out_subscription, Host,
-                       ?MODULE, out_subscription, 50),
-    ejabberd_hooks:add(roster_get_subscription_lists, Host,
-                       ?MODULE, get_subscription_lists, 50),
-    ejabberd_hooks:add(roster_get_jid_info, Host,
-                       ?MODULE, get_jid_info, 50),
-    ejabberd_hooks:add(remove_user, Host,
-                       ?MODULE, remove_user, 50),
-    ejabberd_hooks:add(anonymous_purge_hook, Host,
-                       ?MODULE, remove_user, 50),
-    ejabberd_hooks:add(roster_get_versioning_feature, Host,
-                       ?MODULE, get_versioning_feature, 50),
+    ejabberd_hooks:add(hooks(Host)),
+
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_ROSTER,
                                   ?MODULE, process_iq, IQDisc).
 
 stop(Host) ->
-    ejabberd_hooks:delete(roster_get, Host,
-                          ?MODULE, get_user_roster, 50),
-    ejabberd_hooks:delete(roster_in_subscription, Host,
-                          ?MODULE, in_subscription, 50),
-    ejabberd_hooks:delete(roster_out_subscription, Host,
-                          ?MODULE, out_subscription, 50),
-    ejabberd_hooks:delete(roster_get_subscription_lists, Host,
-                          ?MODULE, get_subscription_lists, 50),
-    ejabberd_hooks:delete(roster_get_jid_info, Host,
-                          ?MODULE, get_jid_info, 50),
-    ejabberd_hooks:delete(remove_user, Host,
-                          ?MODULE, remove_user, 50),
-    ejabberd_hooks:delete(anonymous_purge_hook, Host,
-                          ?MODULE, remove_user, 50),
-    ejabberd_hooks:delete(roster_get_versioning_feature, Host,
-                          ?MODULE, get_versioning_feature, 50),
+    ejabberd_hooks:delete(hooks(Host)),
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_ROSTER).
+
+hooks(Host) ->
+    [{roster_get, Host, ?MODULE, get_user_roster, 50},
+     {roster_in_subscription, Host, ?MODULE, in_subscription, 50},
+     {roster_out_subscription, Host, ?MODULE, out_subscription, 50},
+     {roster_get_subscription_lists, Host, ?MODULE, get_subscription_lists, 50},
+     {roster_get_jid_info, Host, ?MODULE, get_jid_info, 50},
+     {remove_user, Host, ?MODULE, remove_user, 50},
+     {anonymous_purge_hook, Host, ?MODULE, remove_user, 50},
+     {roster_get_versioning_feature, Host, ?MODULE, get_versioning_feature, 50}].
 
 get_roster_entry(LUser, LServer, Jid) ->
     mod_roster_backend:get_roster_entry(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid)).


### PR DESCRIPTION
Proposed changes include:
* `ejabberd_hooks:add/1` - accepting list of hooks to add
* `ejabberd_hooks:delete/1` - accepting lit of hooks to delete
* changed some modules showing how above new functions can be used

This is basically to simplify adding/deleting hooks from modules and reducing code duplication.

