### PR TITLE
Archive chat markers

### DIFF
--- a/apps/ejabberd/include/jlib.hrl
+++ b/apps/ejabberd/include/jlib.hrl
@@ -115,6 +115,8 @@
 
 -define(NS_CSI, <<"urn:xmpp:csi:0">>).
 
+-define(NS_CHAT_MARKERS, <<"urn:xmpp:chat-markers:0">>).
+
 %% Erlang Solutions custom extension - token based authentication
 -define(NS_ESL_TOKEN_AUTH, <<"erlang-solutions.com:xmpp:token-auth:0">>).
 

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -1037,17 +1037,20 @@ params_helper(Params) ->
 
             Mod -> {Mod, is_archivable_message}
         end,
+
     Format =
         io_lib:format(
           "-module(mod_mam_params).~n"
           "-compile(export_all).~n"
           "add_archived_element() -> ~p.~n"
           "is_archivable_message(Mod, Dir, Packet) -> ~p:~p(Mod, Dir, Packet).~n"
+          "archive_chat_markers() -> ~p.~n"
           "default_result_limit() -> ~p.~n"
           "max_result_limit() -> ~p.~n"
           "params() -> ~p.~n",
           [proplists:get_bool(add_archived_element, Params),
            IsArchivableModule, IsArchivableFunction,
+           proplists:get_bool(archive_chat_markers, Params),
            proplists:get_value(default_result_limit, Params, 50),
            proplists:get_value(max_result_limit, Params, 50),
            Params

--- a/apps/ejabberd/src/mod_mam_meta.erl
+++ b/apps/ejabberd/src/mod_mam_meta.erl
@@ -85,7 +85,11 @@ mam_type_to_core_mod(muc) -> mod_mam_muc.
 
 -spec valid_core_mod_opts(module()) -> [atom()].
 valid_core_mod_opts(mod_mam) ->
-    [add_archived_element, is_archivable_message, full_text_search, archive_groupchats];
+    [add_archived_element,
+     is_archivable_message,
+     archive_chat_markers,
+     full_text_search,
+     archive_groupchats];
 valid_core_mod_opts(mod_mam_muc) ->
     [add_archived_element, is_archivable_message, host, full_text_search].
 

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -355,15 +355,12 @@ is_chat_marker(Packet) ->
     end.
 
 do_check_markers(Packet) ->
-    MarkerTags = [<<"received">>, <<"displayed">>, <<"acknowledged">>],
-    HasSubtag = fun(Tag) ->
-                    case xml:get_subtag(Packet, Tag) of
-                        #xmlel{} -> true;
-                        _        -> false
-                    end
-                end,
-            lists:any(fun(P) -> P end,
-                      lists:map(HasSubtag, MarkerTags)).
+    case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS) of
+        #xmlel{name = <<"received">>}     -> true;
+        #xmlel{name = <<"displayed">>}    -> true;
+        #xmlel{name = <<"acknowledged">>} -> true;
+        _                                 -> false
+    end.
 
 %% @doc Forms `<forwarded/>' element, according to the XEP.
 -spec wrap_message(MamNs :: binary(), Packet :: jlib:xmlel(), QueryID :: binary(),
@@ -748,8 +745,8 @@ normalize_search_text(Text, WordSeparator) ->
 packet_to_search_body(Module, Host, Packet) ->
     case has_full_text_search(Module, Host) of
         true ->
-            BodyValue = case xml:get_subtag(Packet, <<"body">>) of
-                                false ->
+            BodyValue = case exml_query:subelement(Packet, <<"body">>) of
+                                undefined ->
                                         <<"">>;
                                 Body ->
                                     xml:get_tag_cdata(Body)

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -318,7 +318,7 @@ get_one_of_path(_Elem, [], Def) ->
 is_archivable_message(Mod, Dir, Packet=#xmlel{name = <<"message">>}) ->
     Type = xml:get_tag_attr_s(<<"type">>, Packet),
     is_valid_message_type(Mod, Dir, Type) andalso
-        (is_valid_message(Mod, Dir, Packet) orelse is_chat_marker(Packet));
+        is_valid_message(Mod, Dir, Packet);
 is_archivable_message(_, _, _) ->
     false.
 
@@ -330,31 +330,27 @@ is_valid_message_type(_, _, <<"error">>) -> false;
 is_valid_message_type(_, _, _) -> false.
 
 is_valid_message(_Mod, _Dir, Packet) ->
-    Body     = xml:get_subtag(Packet, <<"body">>),
+    Body       = xml:get_subtag(Packet, <<"body">>),
+    ChatMarker = should_check_chat_markers() andalso has_chat_marker(Packet),
     %% Used in MAM
-    Result   = xml:get_subtag(Packet, <<"result">>),
+    Result     = xml:get_subtag(Packet, <<"result">>),
     %% Used in mod_offline
-    Delay    = xml:get_subtag(Packet, <<"delay">>),
+    Delay      = xml:get_subtag(Packet, <<"delay">>),
     %% Message Processing Hints (XEP-0334)
-    NoStore  = xml:get_subtag(Packet, <<"no-store">>),
-    is_valid_message_children(Body, Result, Delay, NoStore).
+    NoStore    = xml:get_subtag(Packet, <<"no-store">>),
+    is_valid_message_children(Body, ChatMarker, Result, Delay, NoStore).
 
-%% Forwarded by MAM message or just a message without body
-is_valid_message_children(false, _,     _,     _    ) -> false;
-is_valid_message_children(_,     false, false, false) -> true;
+%% Forwarded by MAM message, or just a message without body or chat marker
+is_valid_message_children(false, false, _,     _,     _    ) -> false;
+is_valid_message_children(_,     _,     false, false, false) -> true;
 %% Forwarded by MAM message or delivered by mod_offline
 %% See mam_SUITE:offline_message for a test case
-is_valid_message_children(_,      _,    _,     _    ) -> false.
+is_valid_message_children(_,     _,     _,    _,     _    ) -> false.
 
-is_chat_marker(Packet) ->
-    case mod_mam_params:archive_chat_markers() of
-        true ->
-            do_check_markers(Packet);
-        false ->
-            false
-    end.
+should_check_chat_markers() ->
+    mod_mam_params:archive_chat_markers().
 
-do_check_markers(Packet) ->
+has_chat_marker(Packet) ->
     case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS) of
         #xmlel{name = <<"received">>}     -> true;
         #xmlel{name = <<"displayed">>}    -> true;

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -729,7 +729,12 @@ normalize_search_text(Text, WordSeparator) ->
 packet_to_search_body(Module, Host, Packet) ->
     case has_full_text_search(Module, Host) of
         true ->
-            BodyValue = xml:get_tag_cdata(xml:get_subtag(Packet, <<"body">>)),
+            BodyValue = case xml:get_subtag(Packet, <<"body">>) of
+                                false ->
+                                        <<"">>;
+                                Body ->
+                                    xml:get_tag_cdata(Body)
+                        end,
             mod_mam_utils:normalize_search_text(BodyValue, " ");
         false -> ""
     end.

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -745,12 +745,8 @@ normalize_search_text(Text, WordSeparator) ->
 packet_to_search_body(Module, Host, Packet) ->
     case has_full_text_search(Module, Host) of
         true ->
-            BodyValue = case exml_query:subelement(Packet, <<"body">>) of
-                                undefined ->
-                                        <<"">>;
-                                Body ->
-                                    xml:get_tag_cdata(Body)
-                        end,
+            BodyValue = exml_query:path(Packet, [{element, <<"body">>}, cdata],
+                                        <<"">>),
             mod_mam_utils:normalize_search_text(BodyValue, " ");
         false -> ""
     end.

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -28,6 +28,7 @@ For now `odbc` backend has very limited support for this feature, while `cassand
 * **add_archived_element** (boolean, default: `false`) - Add `<archived/>` element from MAM v0.2.
 * **is_archivable_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_archivable_message/3` callback](#is_archivable_message) that determines if the message should be archived.
  **Warning**: if you are using MUC Light, make sure this option is set to the MUC Light domain.
+* **archive_chat_markers** (boolean, default: `false`) - If set to true, XEP-0333 chat markers will be archived. See more details [here](#archiving-chat-markers)
 * **pm** (list | `false`, default: `[]`) - Override options for archivization of one-to-one messages. If the value of this option is `false`, one-to-one message archive is disabled.
 * **muc** (list | `false`, default: `false`) - Override options for archivization of group chat messages. If the value of this option is `false`, group chat message archive is disabled.
 
@@ -87,6 +88,13 @@ These options will only have effect when the `odbc` backend is used:
 Servers SHOULD NOT archive messages that do not have a `<body/>` child tag. Servers SHOULD NOT archive delayed messages.
 
 From MAM v0.3 onwards it is expected that all messages that hold meaningful content, rather than state changes such as Chat State Notifications, are archived.
+
+#### Archiving chat markers
+
+Archiving chat markers can be enabled by setting `archive_chat_markers` option to `true`. However it only works if
+`is_archivable_message` callback module is set to `mod_mam_utils` or isn't set at all.
+
+When performing full text search chat markers are treated as if they had empty message body.
 
 ### Riak backend
 

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
   {base16, ".*", {git, "git://github.com/goj/base16.git", "f78918e"}},
   {cuesport, ".*", {git, "git://github.com/esl/cuesport.git", "d82ff25"}},
   {redo, ".*", {git, "git://github.com/Wallapop/redo.git", "35a8d1c"}},
-  {exml, ".*", {git, "git://github.com/esl/exml.git", {ref, "f45f215"}}},
+  {exml, ".*", {git, "git://github.com/esl/exml.git", {ref, "013fc58"}}},
   {lager, ".*", {git, "git://github.com/basho/lager.git", "3.2.4"}},
   {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", "3.0.3"}},
   {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", "1.1.2"}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -50,7 +50,7 @@
   0},
  {<<"exml">>,
   {git,"git://github.com/esl/exml.git",
-       {ref,"f45f2158108a312aa74f5ea1896a0abe6aa101d9"}},
+       {ref,"013fc58a64fa5bbd6736127cc1da078d4570c537"}},
   0},
  {<<"exometer">>,
   {git,"git://github.com/esl/exometer.git",

--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -9,7 +9,7 @@
         {erlsh, ".*", {git, "git://github.com/proger/erlsh.git", "2fce513"}},
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
-        {exml, ".*", {git, "git://github.com/esl/exml.git", "d365533"}},
+        {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
         {escalus, ".*", {git, "git://github.com/esl/escalus.git", "a0dae9569dcb1ddf7d9453f0f3ccb674b0f80902"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -1974,10 +1974,9 @@ archive_chat_markers(Config) ->
             escalus:wait_for_stanzas(Alice, 3),
 
             %% Alice queries MAM
+            maybe_wait_for_archive(Config),
             escalus:send(Alice, stanza_archive_request(P, <<"q1">>)),
             Result = wait_archive_respond(P, Alice),
-
-            ct:pal("~p~n", [Result]),
 
             %% archived message + 3 markers
             assert_respond_size(1 + 3, Result),

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -90,7 +90,8 @@
          run_set_and_get_prefs_cases/1,
          check_user_exist/1,
          metric_incremented_on_archive_request/1,
-         metric_incremented_when_store_message/1]).
+         metric_incremented_when_store_message/1,
+         archive_chat_markers/1]).
 
 -import(muc_helper,
         [muc_host/0,
@@ -213,6 +214,7 @@ cassandra_configs(_) ->
 basic_group_names() ->
     [
      mam_all,
+     chat_markers,
      muc_all,
      muc_light,
      policy_violation,
@@ -264,6 +266,7 @@ basic_groups() ->
               {with_rsm02, [parallel], with_rsm_cases()},
               {with_rsm03, [parallel], with_rsm_cases()},
               {with_rsm04, [parallel], with_rsm_cases()}]}]},
+     {chat_markers, [parallel], [archive_chat_markers]},
      {muc_all, [parallel],
            [{muc02, [parallel], muc_cases()},
             {muc03, [parallel], muc_cases() ++ muc_text_search_cases()},
@@ -712,6 +715,8 @@ muc_domain(Config) ->
 
 addin_mam_options(disabled_text_search, Config) ->
     [{full_text_search, false} | addin_mam_options(Config)];
+addin_mam_options(chat_markers, Config) ->
+    [{archive_chat_markers, true} | addin_mam_options(Config)];
 addin_mam_options(_BasicGroup, Config) ->
     addin_mam_options(Config).
 
@@ -849,6 +854,9 @@ init_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config) ->
                                 [host(), mod_mam, archive_groupchats, true]),
     clean_archives(Config),
     escalus:init_per_testcase(C, [{archive_groupchats_backup, OrigVal} | Config]);
+init_per_testcase(C=archive_chat_markers, Config) ->
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, Config1);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
@@ -1941,6 +1949,41 @@ limit_archive_request(Config) ->
         end,
     %% Made fresh in init_per_testcase
     escalus:story(Config, [{alice, 1}], F).
+
+archive_chat_markers(Config) ->
+    P = ?config(props, Config),
+    F = fun(Alice, Bob) ->
+            %% Alice sends markable message to Bob
+            Message  = escalus_stanza:markable(
+                          escalus_stanza:chat_to(Bob, <<"Hello, Bob!">>)
+                       ),
+            MessageID = escalus_stanza:id(),
+            escalus:send(Alice, escalus_stanza:set_id(Message, MessageID)),
+            escalus:wait_for_stanza(Bob),
+
+            %% Bob sends 3 chat markers
+            Marker1 = escalus_stanza:chat_marker(Alice, <<"received">>,
+                                                 MessageID),
+            Marker2 = escalus_stanza:chat_marker(Alice, <<"displayed">>,
+                                                 MessageID),
+            Marker3 = escalus_stanza:chat_marker(Alice, <<"acknowledged">>,
+                                                 MessageID),
+            escalus:send(Bob, Marker1),
+            escalus:send(Bob, Marker2),
+            escalus:send(Bob, Marker3),
+            escalus:wait_for_stanzas(Alice, 3),
+
+            %% Alice queries MAM
+            escalus:send(Alice, stanza_archive_request(P, <<"q1">>)),
+            Result = wait_archive_respond(P, Alice),
+
+            ct:pal("~p~n", [Result]),
+
+            %% archived message + 3 markers
+            assert_respond_size(1 + 3, Result),
+            assert_respond_query_id(P, <<"q1">>, parse_result_iq(P, Result))
+        end,
+    escalus:story(Config, [{alice, 1}, {bob, 1}], F).
 
 pagination_empty_rset(Config) ->
     P = ?config(props, Config),


### PR DESCRIPTION
This PR addresses #1354

Proposed changes include:
* archiving chat markers when `mod_mam_utils` is used as `is_archivable_message` callback when `{archive_chat_markers, true}` option is set
