### PR TITLE
Tests muc light helper

### DIFF
--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -127,7 +127,6 @@
          nick/1,
          respond_messages/1,
          parse_forwarded_message/1,
-         verify_archived_muc_light_aff_msg/3,
          append_subelem/2,
          archived_elem/2,
          generate_message_text/1,
@@ -169,6 +168,15 @@
          muc_light_host/0,
          host/0
         ]).
+
+-import(muc_light_helper,
+        [given_muc_light_room/3,
+         when_muc_light_message_is_sent/4,
+         then_muc_light_message_is_received_by/2,
+         when_muc_light_affiliations_are_set/3,
+         then_muc_light_affiliations_are_received_by/2,
+         when_archive_query_is_sent/3,
+         then_archive_response_is/3]).
 
 -include("mam_helper.hrl").
 -include_lib("escalus/include/escalus.hrl").
@@ -1289,12 +1297,6 @@ muc_light_stored_in_pm_if_allowed_to(Config) ->
             when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [BobAffEvent, MessageEvent], Config)
         end).
-
-muc_light_room_jid(Room, User) ->
-    RoomJid = muc_light_SUITE:room_bin_jid(Room),
-    UserJid = escalus_utils:get_short_jid(User),
-    <<RoomJid/binary, $/, UserJid/binary>>.
-
 
 retrieve_form_fields(ConfigIn) ->
     escalus_fresh:story(ConfigIn, [{alice, 1}], fun(Alice) ->
@@ -2426,58 +2428,4 @@ when_pm_message_is_sent(Sender, Receiver, Body) ->
 then_pm_message_is_received(Receiver, Body) ->
     escalus:assert(is_chat_message, [Body], escalus:wait_for_stanza(Receiver)).
 
-given_muc_light_room(Name, Creator, InitOccupants) ->
-    CreateStanza = muc_light_SUITE:stanza_create_room(Name, [], InitOccupants),
-    escalus:send(Creator, CreateStanza),
-    Affiliations = [{Creator, owner} | InitOccupants],
-    muc_light_SUITE:verify_aff_bcast(Affiliations, Affiliations),
-    escalus:assert(is_iq_result, escalus:wait_for_stanza(Creator)).
-
-when_muc_light_message_is_sent(Sender, Room, Body, Id) ->
-    RoomJid = muc_light_SUITE:room_bin_jid(Room),
-    Stanza = escalus_stanza:set_id(
-               escalus_stanza:groupchat_to(RoomJid, Body), Id),
-    escalus:send(Sender, Stanza),
-    {Room, Body, Id}.
-
-then_muc_light_message_is_received_by(Users, {Room, Body, Id}) ->
-    F = muc_light_SUITE:gc_message_verify_fun(Room, Body, Id),
-    [ F(escalus:wait_for_stanza(User)) || User <- Users ].
-
-when_muc_light_affiliations_are_set(Sender, Room, Affiliations) ->
-    Stanza = muc_light_SUITE:stanza_aff_set(Room, Affiliations),
-    escalus:send(Sender, Stanza),
-    {Room, Affiliations}.
-
-then_muc_light_affiliations_are_received_by(Users, {_Room, Affiliations}) ->
-    F = muc_light_SUITE:aff_msg_verify_fun(Affiliations),
-    [ F(escalus:wait_for_stanza(User)) || User <- Users ].
-
-when_archive_query_is_sent(Sender, RecipientJid, Config) ->
-	P = ?config(props, Config),
-    Request = case RecipientJid of
-                  undefined -> stanza_archive_request(P, <<"q">>);
-                  _ -> escalus_stanza:to(stanza_archive_request(P, <<"q">>), RecipientJid)
-              end,
-    escalus:send(Sender, Request).
-
-then_archive_response_is(Receiver, Expected, Config) ->
-	P = ?config(props, Config),
-    Response = wait_archive_respond(P, Receiver),
-    Stanzas = respond_messages(assert_respond_size(length(Expected), Response)),
-    ParsedStanzas = [ parse_forwarded_message(Stanza) || Stanza <- Stanzas ],
-    [ assert_archive_element(Element)
-      || Element <- lists:zip(Expected, ParsedStanzas) ].
-
-assert_archive_element({{create, Affiliations}, Stanza}) ->
-    verify_archived_muc_light_aff_msg(Stanza, Affiliations, _IsCreate = true);
-assert_archive_element({{affiliations, Affiliations}, Stanza}) ->
-    verify_archived_muc_light_aff_msg(Stanza, Affiliations, _IsCreate = false);
-assert_archive_element({{muc_message, Room, Sender, Body}, Stanza}) ->
-    FromJid = escalus_utils:jid_to_lower(muc_light_room_jid(Room, Sender)),
-    #forwarded_message{message_body = Body,
-                       delay_from = FromJid} = Stanza;
-assert_archive_element({{message, Sender, Body}, Stanza}) ->
-    FromJid = escalus_utils:jid_to_lower(escalus_utils:get_jid(Sender)),
-    #forwarded_message{message_body = Body, delay_from = FromJid} = Stanza.
 

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -758,7 +758,7 @@ init_state(_, _, Config) ->
     clean_archives(Config).
 
 end_state(C, muc_light, Config) ->
-    muc_light_SUITE:clear_db(),
+    muc_light_helper:clear_db(),
     end_state(C, generic, Config);
 end_state(_, _, Config) ->
     Config.
@@ -1237,7 +1237,7 @@ muc_light_simple(Config) ->
             then_muc_light_affiliations_are_received_by([Alice, Bob], Aff),
 
             maybe_wait_for_archive(Config),
-            when_archive_query_is_sent(Bob, muc_light_SUITE:room_bin_jid(Room), Config),
+            when_archive_query_is_sent(Bob, muc_light_helper:room_bin_jid(Room), Config),
             ExpectedResponse = [{create, [{Alice, owner}]},
                                 {muc_message, Room, Alice, <<"Msg 1">>},
                                 {muc_message, Room, Alice, <<"Message 2">>},
@@ -1264,7 +1264,7 @@ muc_light_shouldnt_modify_pm_archive(Config) ->
             then_muc_light_message_is_received_by([Alice, Bob], M1),
 
             maybe_wait_for_archive(Config),
-            when_archive_query_is_sent(Alice, muc_light_SUITE:room_bin_jid(Room), Config),
+            when_archive_query_is_sent(Alice, muc_light_helper:room_bin_jid(Room), Config),
             then_archive_response_is(Alice, [{create, [{Alice, owner}, {Bob, member}]},
                                              {muc_message, Room, Alice, <<"Msg 1">>}], Config),
 

--- a/test.disabled/ejabberd_tests/tests/mam_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_helper.erl
@@ -433,15 +433,15 @@ is_same_message_text(Stanza, Raw) ->
         Msg :: #forwarded_message{}, AffUsersChanges :: [{escalus:client(), binary()}],
         IsCreate :: boolean()) -> [].
 verify_archived_muc_light_aff_msg(Msg, AffUsersChanges, IsCreate) ->
-    BinAffUsersChanges = muc_light_SUITE:bin_aff_users(AffUsersChanges),
+    BinAffUsersChanges = muc_light_helper:bin_aff_users(AffUsersChanges),
     [X] = Msg#forwarded_message.message_xs,
-    ProperNS = muc_light_SUITE:ns_muc_light_affiliations(),
+    ProperNS = muc_light_helper:ns_muc_light_affiliations(),
     ProperNS = exml_query:attr(X, <<"xmlns">>),
     undefined = exml_query:subelement(X, <<"prev-version">>),
     Version = exml_query:path(X, [{element, <<"version">>}, cdata]),
     true = IsCreate orelse is_binary(Version),
     Items = exml_query:subelements(X, <<"user">>),
-    muc_light_SUITE:verify_aff_users(Items, BinAffUsersChanges).
+    muc_light_helper:verify_aff_users(Items, BinAffUsersChanges).
 
 %% ----------------------------------------------------------------------
 %% PREFERENCE QUERIES

--- a/test.disabled/ejabberd_tests/tests/muc_light.hrl
+++ b/test.disabled/ejabberd_tests/tests/muc_light.hrl
@@ -1,0 +1,9 @@
+
+-define(NS_MUC_LIGHT, <<"urn:xmpp:muclight:0">>).
+-define(NS_MUC_LIGHT_CONFIGURATION, <<"urn:xmpp:muclight:0#configuration">>).
+-define(NS_MUC_LIGHT_AFFILIATIONS, <<"urn:xmpp:muclight:0#affiliations">>).
+-define(NS_MUC_LIGHT_INFO, <<"urn:xmpp:muclight:0#info">>).
+-define(NS_MUC_LIGHT_BLOCKING, <<"urn:xmpp:muclight:0#blocking">>).
+-define(NS_MUC_LIGHT_CREATE, <<"urn:xmpp:muclight:0#create">>).
+-define(NS_MUC_LIGHT_DESTROY, <<"urn:xmpp:muclight:0#destroy">>).
+

--- a/test.disabled/ejabberd_tests/tests/muc_light_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_helper.erl
@@ -3,33 +3,63 @@
 -compile([export_all]).
 
 -include("mam_helper.hrl").
+-include("muc_light.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("exml/include/exml.hrl").
+
+-type ct_aff_user() :: {EscalusClient :: escalus:client(), Aff :: atom()}.
+-type ct_aff_users() :: [ct_aff_user()].
+
+-spec room_bin_jid(Room :: binary()) -> binary().
+room_bin_jid(Room) ->
+    <<Room/binary, $@, (muc_host())/binary>>.
+
+muc_host() ->
+    Host = ct:get_config({hosts, mim, domain}),
+    <<"muclight.", Host/binary>>.
+
+create_room(RoomU, MUCHost, Owner, Members, Config, Version) ->
+    DefaultConfig = default_config(),
+    RoomUS = {RoomU, MUCHost},
+    AffUsers = [{to_lus(Owner, Config), owner}
+                | [ {to_lus(Member, Config), member} || Member <- Members ]],
+    {ok, _RoomUS} = escalus_ejabberd:rpc(mod_muc_light_db_backend, create_room,
+                                         [RoomUS, DefaultConfig, AffUsers, Version]).
+
+-spec default_config() -> list().
+default_config() -> escalus_ejabberd:rpc(mod_muc_light, default_config, [muc_host()]).
+
+-spec ns_muc_light_affiliations() -> binary().
+ns_muc_light_affiliations() ->
+    ?NS_MUC_LIGHT_AFFILIATIONS.
 
 given_muc_light_room(Name, Creator, InitOccupants) ->
-    CreateStanza = muc_light_SUITE:stanza_create_room(Name, [], InitOccupants),
+    CreateStanza = stanza_create_room(Name, [], InitOccupants),
     escalus:send(Creator, CreateStanza),
     Affiliations = [{Creator, owner} | InitOccupants],
-    muc_light_SUITE:verify_aff_bcast(Affiliations, Affiliations),
-    escalus:assert(is_iq_result, escalus:wait_for_stanza(Creator)).
+    verify_aff_bcast(Affiliations, Affiliations),
+    IQResult = escalus:wait_for_stanza(Creator),
+    escalus:assert(is_iq_result, IQResult),
+    exml_query:attr(IQResult, <<"from">>).
 
 when_muc_light_message_is_sent(Sender, Room, Body, Id) ->
-    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    RoomJid = room_bin_jid(Room),
     Stanza = escalus_stanza:set_id(
                escalus_stanza:groupchat_to(RoomJid, Body), Id),
     escalus:send(Sender, Stanza),
     {Room, Body, Id}.
 
 then_muc_light_message_is_received_by(Users, {Room, Body, Id}) ->
-    F = muc_light_SUITE:gc_message_verify_fun(Room, Body, Id),
+    F = gc_message_verify_fun(Room, Body, Id),
     [ F(escalus:wait_for_stanza(User)) || User <- Users ].
 
 when_muc_light_affiliations_are_set(Sender, Room, Affiliations) ->
-    Stanza = muc_light_SUITE:stanza_aff_set(Room, Affiliations),
+    Stanza = stanza_aff_set(Room, Affiliations),
     escalus:send(Sender, Stanza),
     {Room, Affiliations}.
 
 then_muc_light_affiliations_are_received_by(Users, {_Room, Affiliations}) ->
-    F = muc_light_SUITE:aff_msg_verify_fun(Affiliations),
+    F = aff_msg_verify_fun(Affiliations),
     [ F(escalus:wait_for_stanza(User)) || User <- Users ].
 
 when_archive_query_is_sent(Sender, RecipientJid, Config) ->
@@ -62,6 +92,130 @@ assert_archive_element({{message, Sender, Body}, Stanza}) ->
 
 
 muc_light_room_jid(Room, User) ->
-    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    RoomJid = room_bin_jid(Room),
     UserJid = escalus_utils:get_short_jid(User),
     <<RoomJid/binary, $/, UserJid/binary>>.
+
+verify_aff_bcast(CurrentOccupants, AffUsersChanges) ->
+    verify_aff_bcast(CurrentOccupants, AffUsersChanges, []).
+
+verify_aff_bcast(CurrentOccupants, AffUsersChanges, ExtraNSs) ->
+    muc_helper:foreach_recipient(
+      [ User || {User, _} <- CurrentOccupants ], aff_msg_verify_fun(AffUsersChanges)),
+    lists:foreach(
+      fun({Leaver, none}) ->
+              Incoming = escalus:wait_for_stanza(Leaver),
+              %% This notification must come from the room bare JID
+              MUCHost = muc_host(),
+              [_, MUCHost] = binary:split(exml_query:attr(Incoming, <<"from">>), <<"@">>),
+              {[X], []} = lists:foldl(
+                            fun(XEl, {XAcc, NSAcc}) ->
+                                    XMLNS = exml_query:attr(XEl, <<"xmlns">>),
+                                    case lists:member(XMLNS, NSAcc) of
+                                        true -> {XAcc, lists:delete(XMLNS, NSAcc)};
+                                        false -> {[XEl | XAcc], NSAcc}
+                                    end
+                            end, {[], ExtraNSs}, exml_query:subelements(Incoming, <<"x">>)),
+              ?NS_MUC_LIGHT_AFFILIATIONS = exml_query:attr(X, <<"xmlns">>),
+              [Item] = exml_query:subelements(X, <<"user">>),
+              <<"none">> = exml_query:attr(Item, <<"affiliation">>),
+              LeaverJIDBin = lbin(escalus_client:short_jid(Leaver)),
+              LeaverJIDBin = exml_query:cdata(Item);
+         (_) ->
+              ignore
+      end, AffUsersChanges).
+
+-spec aff_msg_verify_fun(AffUsersChanges :: ct_aff_users()) -> muc_helper:verify_fun().
+aff_msg_verify_fun(AffUsersChanges) ->
+    BinAffUsersChanges = bin_aff_users(AffUsersChanges),
+    fun(Incoming) ->
+            [X] = exml_query:subelements(Incoming, <<"x">>),
+            ?NS_MUC_LIGHT_AFFILIATIONS = exml_query:attr(X, <<"xmlns">>),
+            PrevVersion = exml_query:path(X, [{element, <<"prev-version">>}, cdata]),
+            Version = exml_query:path(X, [{element, <<"version">>}, cdata]),
+            [Item | RItems] = Items = exml_query:subelements(X, <<"user">>),
+            [ToBin | _] = binary:split(exml_query:attr(Incoming, <<"to">>), <<"/">>),
+            true = is_binary(Version),
+            true = Version =/= PrevVersion,
+            case {ToBin == exml_query:cdata(Item), RItems} of
+                {true, []} ->
+                    {_, ProperAff} = lists:keyfind(ToBin, 1, BinAffUsersChanges),
+                    ProperAff = exml_query:attr(Item, <<"affiliation">>);
+                _ ->
+                    true = is_binary(PrevVersion),
+                    verify_aff_users(Items, BinAffUsersChanges)
+            end
+    end.
+
+-spec lbin(Bin :: binary()) -> binary().
+lbin(Bin) -> list_to_binary(string:to_lower(binary_to_list(Bin))).
+
+
+-spec bin_aff_users(AffUsers :: ct_aff_users()) -> [{LBinJID :: binary(), AffBin :: binary()}].
+bin_aff_users(AffUsers) ->
+    [ {lbin(escalus_client:short_jid(User)), list_to_binary(atom_to_list(Aff))}
+      || {User, Aff} <- AffUsers ].
+
+-spec verify_aff_users(Items :: [exml:element()], BinAffUsers :: [{binary(), binary()}]) -> [].
+verify_aff_users(Items, BinAffUsers) ->
+    true = (length(Items) == length(BinAffUsers)),
+    [] = lists:foldl(
+           fun(Item, AffAcc) ->
+                   JID = exml_query:cdata(Item),
+                   Aff = exml_query:attr(Item, <<"affiliation">>),
+                   verify_keytake(lists:keytake(JID, 1, AffAcc), JID, Aff, AffAcc)
+           end, BinAffUsers, Items).
+
+-spec verify_keytake(Result :: {value, Item :: tuple(), Acc :: list()}, JID :: binary(),
+                     Aff :: binary(), AffAcc :: list()) -> list().
+verify_keytake({value, {_, Aff}, NewAffAcc}, _JID, Aff, _AffAcc) -> NewAffAcc.
+
+-spec stanza_create_room(RoomNode :: binary() | undefined, InitConfig :: [{binary(), binary()}],
+                         InitOccupants :: ct_aff_users()) -> exml:element().
+stanza_create_room(RoomNode, InitConfig, InitOccupants) ->
+    Host = muc_host(),
+    ToBinJID = case RoomNode of
+                     undefined -> Host;
+                     _ -> <<RoomNode/binary, $@, Host/binary>>
+                 end,
+    ConfigItem = #xmlel{ name = <<"configuration">>,
+                         children = [ kv_el(K, V) || {K, V} <- InitConfig ] },
+    OccupantsItems = [ #xmlel{ name = <<"user">>,
+                               attrs = [{<<"affiliation">>, BinAff}],
+                               children = [#xmlcdata{ content = BinJID }] }
+                       || {BinJID, BinAff} <- bin_aff_users(InitOccupants) ],
+    OccupantsItem = #xmlel{ name = <<"occupants">>, children = OccupantsItems },
+    escalus_stanza:to(escalus_stanza:iq_set(
+                        ?NS_MUC_LIGHT_CREATE, [ConfigItem, OccupantsItem]), ToBinJID).
+
+-spec kv_el(K :: binary(), V :: binary()) -> exml:element().
+kv_el(K, V) ->
+    #xmlel{ name = K, children = [ #xmlcdata{ content = V } ] }.
+
+-spec to_lus(Config :: list(), UserAtom :: atom()) -> {binary(), binary()}.
+to_lus(UserAtom, Config) ->
+    {lbin(escalus_users:get_username(Config, UserAtom)),
+     lbin(escalus_users:get_server(Config, UserAtom))}.
+
+-spec gc_message_verify_fun(Room :: binary(), MsgText :: binary(), Id :: binary()) -> muc_helper:verify_fun().
+gc_message_verify_fun(Room, MsgText, Id) ->
+    Host = muc_host(),
+    fun(Incoming) ->
+            escalus:assert(is_groupchat_message, [MsgText], Incoming),
+            [RoomBareJID, FromNick] = binary:split(exml_query:attr(Incoming, <<"from">>), <<"/">>),
+            [Room, Host] = binary:split(RoomBareJID, <<"@">>),
+            [_] = binary:split(FromNick, <<"/">>), % nick is bare JID
+            Id = exml_query:attr(Incoming, <<"id">>)
+    end.
+
+
+-spec stanza_aff_set(Room :: binary(), AffUsers :: ct_aff_users()) -> exml:element().
+stanza_aff_set(Room, AffUsers) ->
+    Items = [#xmlel{ name = <<"user">>, attrs = [{<<"affiliation">>, AffBin}],
+                     children = [#xmlcdata{ content = UserBin }] }
+             || {UserBin, AffBin} <- bin_aff_users(AffUsers)],
+    escalus_stanza:to(escalus_stanza:iq_set(?NS_MUC_LIGHT_AFFILIATIONS, Items), room_bin_jid(Room)).
+
+clear_db() ->
+    escalus_ejabberd:rpc(mod_muc_light_db_backend, force_clear, []).
+

--- a/test.disabled/ejabberd_tests/tests/muc_light_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_helper.erl
@@ -1,0 +1,67 @@
+-module(muc_light_helper).
+
+-compile([export_all]).
+
+-include("mam_helper.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+given_muc_light_room(Name, Creator, InitOccupants) ->
+    CreateStanza = muc_light_SUITE:stanza_create_room(Name, [], InitOccupants),
+    escalus:send(Creator, CreateStanza),
+    Affiliations = [{Creator, owner} | InitOccupants],
+    muc_light_SUITE:verify_aff_bcast(Affiliations, Affiliations),
+    escalus:assert(is_iq_result, escalus:wait_for_stanza(Creator)).
+
+when_muc_light_message_is_sent(Sender, Room, Body, Id) ->
+    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    Stanza = escalus_stanza:set_id(
+               escalus_stanza:groupchat_to(RoomJid, Body), Id),
+    escalus:send(Sender, Stanza),
+    {Room, Body, Id}.
+
+then_muc_light_message_is_received_by(Users, {Room, Body, Id}) ->
+    F = muc_light_SUITE:gc_message_verify_fun(Room, Body, Id),
+    [ F(escalus:wait_for_stanza(User)) || User <- Users ].
+
+when_muc_light_affiliations_are_set(Sender, Room, Affiliations) ->
+    Stanza = muc_light_SUITE:stanza_aff_set(Room, Affiliations),
+    escalus:send(Sender, Stanza),
+    {Room, Affiliations}.
+
+then_muc_light_affiliations_are_received_by(Users, {_Room, Affiliations}) ->
+    F = muc_light_SUITE:aff_msg_verify_fun(Affiliations),
+    [ F(escalus:wait_for_stanza(User)) || User <- Users ].
+
+when_archive_query_is_sent(Sender, RecipientJid, Config) ->
+	P = ?config(props, Config),
+    Request = case RecipientJid of
+                  undefined -> mam_helper:stanza_archive_request(P, <<"q">>);
+                  _ -> escalus_stanza:to(mam_helper:stanza_archive_request(P, <<"q">>), RecipientJid)
+              end,
+    escalus:send(Sender, Request).
+
+then_archive_response_is(Receiver, Expected, Config) ->
+	P = ?config(props, Config),
+    Response = mam_helper:wait_archive_respond(P, Receiver),
+    Stanzas = mam_helper:respond_messages(mam_helper:assert_respond_size(length(Expected), Response)),
+    ParsedStanzas = [ mam_helper:parse_forwarded_message(Stanza) || Stanza <- Stanzas ],
+    [ assert_archive_element(Element)
+      || Element <- lists:zip(Expected, ParsedStanzas) ].
+
+assert_archive_element({{create, Affiliations}, Stanza}) ->
+    mam_helper:verify_archived_muc_light_aff_msg(Stanza, Affiliations, _IsCreate = true);
+assert_archive_element({{affiliations, Affiliations}, Stanza}) ->
+    mam_helper:verify_archived_muc_light_aff_msg(Stanza, Affiliations, _IsCreate = false);
+assert_archive_element({{muc_message, Room, Sender, Body}, Stanza}) ->
+    FromJid = escalus_utils:jid_to_lower(muc_light_room_jid(Room, Sender)),
+    #forwarded_message{message_body = Body,
+                       delay_from = FromJid} = Stanza;
+assert_archive_element({{message, Sender, Body}, Stanza}) ->
+    FromJid = escalus_utils:jid_to_lower(escalus_utils:get_jid(Sender)),
+    #forwarded_message{message_body = Body, delay_from = FromJid} = Stanza.
+
+
+muc_light_room_jid(Room, User) ->
+    RoomJid = muc_light_SUITE:room_bin_jid(Room),
+    UserJid = escalus_utils:get_short_jid(User),
+    <<RoomJid/binary, $/, UserJid/binary>>.

--- a/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
@@ -194,7 +194,7 @@ stanza_create_room(RoomNode, InitConfig, InitOccupants) ->
     OccupantsItems = [ #xmlel{ name = <<"user">>,
         attrs = [{<<"affiliation">>, BinAff}],
         children = [#xmlcdata{ content = BinJID }] }
-        || {BinJID, BinAff} <- bin_aff_users(InitOccupants) ],
+        || {BinJID, BinAff} <- muc_light_helper:bin_aff_users(InitOccupants) ],
     OccupantsItem = #xmlel{ name = <<"occupants">>, children = OccupantsItems },
     escalus_stanza:to(escalus_stanza:iq_set(<<"urn:xmpp:muclight:0#create">>,
                                             [ConfigItem, OccupantsItem]),
@@ -203,8 +203,3 @@ stanza_create_room(RoomNode, InitConfig, InitOccupants) ->
 kv_el(K, V) ->
     #xmlel{ name = K, children = [ #xmlcdata{ content = V } ] }.
 
-bin_aff_users(AffUsers) ->
-    [ {lbin(escalus_client:short_jid(User)), list_to_binary(atom_to_list(Aff))}
-        || {User, Aff} <- AffUsers ].
-
-lbin(Bin) -> list_to_binary(string:to_lower(binary_to_list(Bin))).

--- a/test.disabled/ejabberd_tests/tests/push_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_SUITE.erl
@@ -17,7 +17,7 @@
         {backend, mnesia}
     ]).
 
--import(muc_light_SUITE,
+-import(muc_light_helper,
     [
         room_bin_jid/1,
         create_room/6

--- a/test.disabled/ejabberd_tests/tests/push_integration_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_integration_SUITE.erl
@@ -12,7 +12,7 @@
 -define(DEFAULT_MONGOOSE_PUSH_PORT,     "12993").
 
 
--import(muc_light_SUITE,
+-import(muc_light_helper,
     [
         room_bin_jid/1,
         create_room/6
@@ -397,18 +397,18 @@ get_push_logs(Service, DeviceToken, _Config) ->
         PushMock = connect_to(Service),
         {ok, 200, Body} = h2_req(PushMock, get, <<"/activity">>),
         #{<<"logs">> := Logs} = jiffy:decode(Body, [return_maps]),
-                                    
+
         DeviceLogs = lists:filter(
             fun(#{<<"device_token">> := Token}) ->
                 DeviceToken =:= Token
             end, Logs),
 
-        case length(DeviceLogs) > 0 of 
-            true -> 
+        case length(DeviceLogs) > 0 of
+            true ->
                 DeviceLogs;
             false ->
                 throw({no_push_messages, DeviceToken})
-        end             
+        end
      end).
 
 %% ----------------------------------


### PR DESCRIPTION
This PR introduces `muc_light_helper` for test. This makes reusing existing parts related to MUC light tests easier.
