### PR TITLE
fixed packet_to_search_body for unicode strings

### DIFF
--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -241,7 +241,8 @@ create_obj(Host, MsgId, SourceJID, Packet, Type) ->
             pm -> mod_mam;
             muc -> mod_mam_muc
         end,
-    BodyValue = unicode:characters_to_binary(mod_mam_utils:packet_to_search_body(ModMAM, Host, Packet)),
+    BodyChars = mod_mam_utils:packet_to_search_body(ModMAM, Host, Packet),
+    BodyValue = unicode:characters_to_binary(BodyChars),
     Ops = [
            {{<<"msg_id">>, register},
             fun(R) -> riakc_register:set(MsgId, R) end},

--- a/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
+++ b/apps/ejabberd/src/mod_mam_riak_timed_arch_yz.erl
@@ -241,7 +241,7 @@ create_obj(Host, MsgId, SourceJID, Packet, Type) ->
             pm -> mod_mam;
             muc -> mod_mam_muc
         end,
-    BodyValue = list_to_binary(mod_mam_utils:packet_to_search_body(ModMAM, Host, Packet)),
+    BodyValue = unicode:characters_to_binary(mod_mam_utils:packet_to_search_body(ModMAM, Host, Packet)),
     Ops = [
            {{<<"msg_id">>, register},
             fun(R) -> riakc_register:set(MsgId, R) end},


### PR DESCRIPTION
Problem with saving unicode message to riakkv mam with exception badarg in list_to_binary function

