### PR TITLE
Fix http muc tests

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -3981,7 +3981,7 @@ deny_access_to_http_password_protected_room_service_unavailable(Config1) ->
     Config = given_fresh_room(Config1, AliceSpec, [{password_protected, true}]),
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         escalus:send(Bob, stanza_muc_enter_password_protected_room(?config(room, Config), escalus_utils:get_username(Bob), ?PASSWORD)),
-        escalus_assert:is_error(escalus:wait_for_stanza(Bob), <<"cancel">>, <<"service-unavailable">>)
+        escalus_assert:is_error(escalus:wait_for_stanza(Bob, 6000), <<"cancel">>, <<"service-unavailable">>)
     end),
     destroy_room(Config).
 
@@ -4060,7 +4060,7 @@ deny_creation_of_http_password_protected_room_service_unavailable(Config) ->
         RoomName = fresh_room_name(),
         Presence = stanza_muc_enter_password_protected_room(RoomName, <<"alice-the-owner">>, ?PASSWORD),
         escalus:send(Alice, Presence),
-        escalus_assert:is_error(escalus:wait_for_stanza(Alice), <<"cancel">>, <<"service-unavailable">>),
+        escalus_assert:is_error(escalus:wait_for_stanza(Alice, 6000), <<"cancel">>, <<"service-unavailable">>),
         escalus_assert:has_no_stanzas(Alice)
     end).
 

--- a/src/mongoose_http_client.erl
+++ b/src/mongoose_http_client.erl
@@ -147,6 +147,8 @@ make_request(Pool, Path, Method, Headers, Query) ->
             {ok, {Code, RespBody}};
         {error, timeout} ->
             {error, request_timeout};
+        {'EXIT', Reason} ->
+            {error, {'EXIT', Reason}};
         {error, Reason} ->
             {error, Reason}
     end.


### PR DESCRIPTION
Fixes:

```erlang
2017-07-21 14:53:18.754 [warning] <0.23644.0> ====== SUITE muc_SUITE starting        
2017-07-21 14:53:36.164 [error] <0.20165.0> Supervisor received unexpected message: {'ETS-TRANSFER',mongoose_http_client_pools,<0.24818.0>,<0.24818.0>}
2017-07-21 14:53:37.245 [error] <0.24847.0> gen_fsm <0.24847.0> in state normal_state terminated with reason: no case clause matching {'EXIT',{shutdown,{gen_server,call,[<0.24826.0>,{request,<<"/muc/auth/check_password?from=bO
b16.201532%40localhost%2Fres1&to=room-alice16.199701%40muc.localhost&pass=pa5sw0rd">>,<<"GET">>,[],<<>>,1,2000},infinity]}}} in mongoose_http_client:make_request/5 line 138
2017-07-21 14:53:37.245 [error] <0.24847.0> CRASH REPORT Process <0.24847.0> with 0 neighbours exited with reason: no case clause matching {'EXIT',{shutdown,{gen_server,call,[<0.24826.0>,{request,<<"/muc/auth/check_password?fr
om=bOb16.201532%40localhost%2Fres1&to=room-alice16.199701%40muc.localhost&pass=pa5sw0rd">>,<<"GET">>,[],<<>>,1,2000},infinity]}}} in mongoose_http_client:make_request/5 line 138 in gen_fsm:terminate/7 line 626
2017-07-21 14:53:37.245 [error] <0.24853.0> gen_fsm <0.24853.0> in state initial_state terminated with reason: no case clause matching {'EXIT',{shutdown,{gen_server,call,[<0.24827.0>,{request,<<"/muc/auth/check_password?from=a
licE16.200036%40localhost%2Fres1&to=room-caad6276ad%40muc.localhost&pass=pa5sw0rd">>,<<"GET">>,[],<<>>,1,2000},infinity]}}} in mongoose_http_client:make_request/5 line 138
2017-07-21 14:53:37.245 [error] <0.24834.0> Supervisor ejabberd_mod_muc_sup_localhost had child undefined started with {mod_muc_room,start_link,undefined} at <0.24847.0> exit with reason no case clause matching {'EXIT',{shutdo
wn,{gen_server,call,[<0.24826.0>,{request,<<"/muc/auth/check_password?from=bOb16.201532%40localhost%2Fres1&to=room-alice16.199701%40muc.localhost&pass=pa5sw0rd">>,<<"GET">>,[],<<>>,1,2000},infinity]}}} in mongoose_http_client:
make_request/5 line 138 in context child_terminated                                  
2017-07-21 14:53:37.245 [error] <0.24853.0> CRASH REPORT Process <0.24853.0> with 0 neighbours exited with reason: no case clause matching {'EXIT',{shutdown,{gen_server,call,[<0.24827.0>,{request,<<"/muc/auth/check_password?fr
om=alicE16.200036%40localhost%2Fres1&to=room-caad6276ad%40muc.localhost&pass=pa5sw0rd">>,<<"GET">>,[],<<>>,1,2000},infinity]}}} in mongoose_http_client:make_request/5 line 138 in gen_fsm:terminate/7 line 626
2017-07-21 14:53:37.245 [error] <0.24834.0> Supervisor ejabberd_mod_muc_sup_localhost had child undefined started with {mod_muc_room,start_link,undefined} at <0.24853.0> exit with reason no case clause matching {'EXIT',{shutdown,{gen_server,call,[<0.24827.0>,{request,<<"/muc/auth/check_password?from=alicE16.200036%40localhost%2Fres1&to=room-caad6276ad%40muc.localhost&pass=pa5sw0rd">>,<<"GET">>,[],<<>>,1,2000},infinity]}}} in mongoose_http_client:ma
ke_request/5 line 138 in context child_terminated                                    
 ```

and failing tests deny_access_to_http_password_protected_room_service_unavailable and deny_creation_of_http_password_protected_room_service_unavailable

```erlang
====== Test name: deny_access_to_http_password_protected_room_service_unavailable    
====== Reason:    {timeout_when_waiting_for_stanza,                                  
                      [{escalus_client,wait_for_stanza,                              
                           [{client,<<"bOb16.201532@localhost/res1">>,               
                                escalus_tcp,<0.24482.0>,                             
                                [{event_manager,<0.24471.0>},                        
                                 {server,<<"localhost">>},                           
                                 {username,<<"bOb16.201532">>},                      
                                 {resource,<<"res1">>}],                             
                                [{event_client,                                      
                                     [{event_manager,<0.24471.0>},                   
                                      {server,<<"localhost">>},                      
                                      {username,<<"bOb16.201532">>},                 
                                      {resource,<<"res1">>}]},                       
                                 {resource,<<"res1">>},                              
                                 {username,<<"bOb16.201532">>},                      
                                 {server,<<"localhost">>},                           
                                 {host,<<"localhost">>},                             
                                 {port,5222},                                        
                                 {auth,{escalus_auth,auth_plain}},                   
                                 {wspath,undefined},                                 
                                 {username,<<"bOb16.201532">>},                      
                                 {server,<<"localhost">>},                           
                                 {password,<<"makrolika">>},                         
                                 {stream_id,<<"1804DD034B333CF2">>}]},               
                            1000],                                                   
                           [{file,"src/escalus_client.erl"},{line,141}]},            
                       {muc_SUITE,                                                   
                           '-deny_access_to_http_password_protected_room_service_unavailable/1-fun-0-',
                           2,                                                        
                           [{file,"muc_SUITE.erl"},{line,3784}]}, 
                       {escalus_story,story,3,                                       
                           [{file,"src/escalus_story.erl"},{line,40}]},              
                       {muc_SUITE,                                                   
                           deny_access_to_http_password_protected_room_service_unavailable,
                           1,                                                        
                           [{file,"muc_SUITE.erl"},{line,3782}]},                    
                       {test_server,ts_tc,3,                                         
                           [{file,"test_server.erl"},{line,1533}]},                  
                       {test_server,run_test_case_eval1,6,                           
                           [{file,"test_server.erl"},{line,1053}]},                  
                       {test_server,run_test_case_eval,9,                            
                           [{file,"test_server.erl"},{line,985}]}]}                  
Updating /home/user/erlang/esl/2017/MongooseIM/test.disabled/ejabberd_tests/ct_report/index.html... done
Updating /home/user/erlang/esl/2017/MongooseIM/test.disabled/ejabberd_tests/ct_report/all_runs.html... done
Makefile:45: recipe for target 'quicktest' failed                                    
make: *** [quicktest] Error 1                                                        
make: Leaving directory '/home/user/erlang/esl/2017/MongooseIM/test.disabled/ejabberd_tests'
                                                                                     
                                                                                     
====== Test name: deny_creation_of_http_password_protected_room_service_unavailable  
```