### PR TITLE
[skip ci] rename "howto" articles

### DIFF
--- a/doc/user-guide/How-to-build.md
+++ b/doc/user-guide/How-to-build.md
@@ -1,4 +1,4 @@
-# How to build
+# How to build MongooseIM
 
 ## Requirements
 

--- a/doc/user-guide/ICE_tutorial.md
+++ b/doc/user-guide/ICE_tutorial.md
@@ -1,4 +1,4 @@
-## How to: Set up Fennec (TURN/STUN server) and see that it works (a.k.a ICE demo)
+## How to set up MongooseICE (ICE/TURN/STUN server)
 
 ### Introduction
 #### Who is this document for?

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -1,4 +1,4 @@
-## How to setup Push Notifications with MongoosePush
+## How to set up Push Notifications with MongoosePush
 
 MongooseIM server supports push notifications using FCM (**F**irebase **C**loud **M**essaging)
 and APNS (**A**pple **P**ush **N**otification **S**ervice) providers. Server side push

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -1,4 +1,4 @@
-## Push Notifications
+## How to setup Push Notifications with MongoosePush
 
 MongooseIM server supports push notifications using FCM (**F**irebase **C**loud **M**essaging)
 and APNS (**A**pple **P**ush **N**otification **S**ervice) providers. Server side push

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ pages:
       - 'Release/Installation configuration': 'user-guide/release_config.md'
       - 'High-level Architecture': 'user-guide/MongooseIM-High-level-Architecture.md'
       - 'How to build MongooseIM':  'user-guide/How-to-build.md'
-      - 'How to setup Push Notifications with MongoosePush': 'user-guide/Push-notifications.md'
+      - 'How to set up Push Notifications with MongoosePush': 'user-guide/Push-notifications.md'
       - 'How to set up MongooseICE (ICE/TURN/STUN server)': 'user-guide/ICE_tutorial.md'
   - Platform:
       - 'Roadmap': 'Roadmap.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,9 +14,9 @@ pages:
       - 'Getting started': 'user-guide/Getting-started.md'
       - 'Release/Installation configuration': 'user-guide/release_config.md'
       - 'High-level Architecture': 'user-guide/MongooseIM-High-level-Architecture.md'
-      - 'How to build':  'user-guide/How-to-build.md'
-      - 'Setting up Push Notifications': 'user-guide/Push-notifications.md'
-      - 'How to: Set up Fennec (TURN/STUN server) and see how it works (a.k.a. ICE demo)': 'user-guide/ICE_tutorial.md'
+      - 'How to build MongooseIM':  'user-guide/How-to-build.md'
+      - 'How to setup Push Notifications with MongoosePush': 'user-guide/Push-notifications.md'
+      - 'How to set up MongooseICE (ICE/TURN/STUN server)': 'user-guide/ICE_tutorial.md'
   - Platform:
       - 'Roadmap': 'Roadmap.md'
       - 'Contributions to ecosystem': 'Contributions.md'


### PR DESCRIPTION
for consistency
