### PR TITLE
Allow creating rooms with specific JID via API

### DIFF
--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -8,6 +8,9 @@ info:
     Please keep in mind that:
     * All users are represented by **bare JIDs** (Jabber Identifiers such as **alice@wonderland.com**).
      This is to ensure integration between the **REST API** users and regular **XMPP** users.
+    * All requests which require room ID (i.e. most of the requests fired at `/room` endpoint) accept either
+      a bare room ID (e.g. `656c6f656c6f`) or a room JID (e.g. `656c6f656c6f@muclight.somedomain.com`).
+      The host part of the room JID must be the host name of MUC light service running in user's domain.
     * All requests require authentication.
     This is to make sure the server can identify who sent the request and if it comes from an authorized user.
     Currently the only supported method is **Basic Auth**.

--- a/doc/http-api/client_swagger.yml
+++ b/doc/http-api/client_swagger.yml
@@ -8,9 +8,9 @@ info:
     Please keep in mind that:
     * All users are represented by **bare JIDs** (Jabber Identifiers such as **alice@wonderland.com**).
      This is to ensure integration between the **REST API** users and regular **XMPP** users.
-    * All requests which require room ID (i.e. most of the requests fired at `/room` endpoint) accept either
-      a bare room ID (e.g. `656c6f656c6f`) or a room JID (e.g. `656c6f656c6f@muclight.somedomain.com`).
-      The host part of the room JID must be the host name of MUC light service running in user's domain.
+    * All requests requiring a room ID (i.e. most of the requests fired at `/room` endpoint) accept either
+     a bare room ID (e.g. `656c6f656c6f`) or a room JID (e.g. `656c6f656c6f@muclight.somedomain.com`).
+     The host part of the room JID must be the host name of a MUC light service running in user's domain.
     * All requests require authentication.
     This is to make sure the server can identify who sent the request and if it comes from an authorized user.
     Currently the only supported method is **Basic Auth**.

--- a/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -371,6 +371,7 @@ messages_can_be_sent_and_fetched_by_room_jid(Config) ->
         RoomID = given_new_room({alice, Alice}),
         RoomJID = room_jid(RoomID, Config),
         given_message_sent_to_room(RoomJID, {alice, Alice}),
+        mam_helper:maybe_wait_for_archive(Config),
         [_] = get_room_messages({alice, Alice}, RoomJID, 10)
     end).
 

--- a/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -102,7 +102,8 @@ init_per_testcase(TC, Config) ->
                     messages_can_be_paginated,
                     messages_are_archived_in_room,
                     only_room_participant_can_read_messages,
-                    messages_can_be_paginated_in_room
+                    messages_can_be_paginated_in_room,
+                    messages_can_be_sent_and_fetched_by_room_jid
                    ],
     rest_helper:maybe_skip_mam_test_cases(TC, MAMTestCases, Config).
 


### PR DESCRIPTION
This PR allows creating rooms with specific JID via API.

Before, we could only do:

`PUT /api/rooms/some_id`

and after this PR:

`PUT /api/rooms/some_id@muclight.localhost`

