### PR TITLE
Fix shebang of tools/install

### DIFF
--- a/tools/install
+++ b/tools/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Debug?
 set -x

--- a/tools/install
+++ b/tools/install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ## Debug?
 set -x


### PR DESCRIPTION
With /bin/sh, the following comparison is unsupported:
[ x"$SYSTEM" == x"yes" ]

Tested on Debian and Ubuntu
