### PR TITLE
MAM refactoring - part 2

### DIFF
--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -31,6 +31,10 @@ For now `odbc` backend has very limited support for this feature, while `cassand
 * **archive_chat_markers** (boolean, default: `false`) - If set to true, XEP-0333 chat markers will be archived. See more details [here](#archiving-chat-markers)
 * **pm** (list | `false`, default: `[]`) - Override options for archivization of one-to-one messages. If the value of this option is `false`, one-to-one message archive is disabled.
 * **muc** (list | `false`, default: `false`) - Override options for archivization of group chat messages. If the value of this option is `false`, group chat message archive is disabled.
+* **extra_lookup_params** (atom, default: `undefined`) - a module implementing `mam_iq` behaviour.
+ If this option has value other then undefined, function `extra_lookup_params/2` from this module will be called when building MAM lookup parameters.
+ This can be used to extend currently supported MAM query fields by a custom field or fields.
+ This field(s) can be added to lookup params later passed to MAM backend.
 
 **backend**, **add_archived_element**, **no_stanzaid_element** and **is_archivable_message** will be applied to both `pm` and `muc` (if they are enabled), unless overriden explicitly (see example below).
 
@@ -70,9 +74,9 @@ These options will only have effect when the `odbc` backend is used:
 #### Common backend options
 
 * **user_prefs_store** (atom, default: `false`) - Leaving this option as `false` will prevent users from setting their archiving preferences. It will also increase performance. Other possible values are:
-    * `odbc` (ODBC backend only) - User archiving preferences saved in ODBC. Slow and not recommended, but might be used to simplify things and keep everything in ODBC.
-    * `cassandra` (Cassandra backend only) - User archiving preferences are saved in Cassandra.
-    * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of an inconsistent (in a rather harmless way) state of the preferences table.
+  * `odbc` (ODBC backend only) - User archiving preferences saved in ODBC. Slow and not recommended, but might be used for simplicity (keeping everything in ODBC).
+  * `cassandra` (Cassandra backend only) - User archiving preferences are saved in Cassandra.
+  * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of an inconsistent (in a rather harmless way) state of the preferences table.
 * **full_text_search** (boolean, default: `true`) - Enables full text search in message archive (see *Full Text Search* paragraph). Please note that the full text search is currently only implemented for `odbc` and `riak` backends. Also, full text search works only for messages archived while this option is enabled.
 
 #### <a id="is_archivable_message"></a>`is_archivable_message/3` callback

--- a/src/mam_iq.erl
+++ b/src/mam_iq.erl
@@ -53,7 +53,7 @@ action_v02(#iq{type = Action, sub_el = SubEl = #xmlel{name = Category}}) ->
         {get, <<"prefs">>} -> mam_get_prefs;
         {get, <<"query">>} -> mam_lookup_messages;
         {set, <<"purge">>} ->
-            case xml:get_tag_attr_s(<<"id">>, SubEl) of
+            case exml_query:attr(SubEl, <<"id">>, <<>>) of
                 <<>> -> mam_purge_multiple_messages;
                 _    -> mam_purge_single_message
             end

--- a/src/mam_iq.erl
+++ b/src/mam_iq.erl
@@ -2,7 +2,6 @@
 
 -export([action/1]).
 -export([action_type/1]).
--export([wait_shaper/3]).
 
 -export([fix_rsm/1]).
 -export([elem_to_start_microseconds/1]).
@@ -78,25 +77,6 @@ action_type(mam_set_message_form) -> get;
 action_type(mam_get_message_form) -> get;
 action_type(mam_purge_single_message) -> set;
 action_type(mam_purge_multiple_messages) -> set.
-
-
--spec action_to_shaper_name(action()) -> atom().
-action_to_shaper_name(Action) ->
-    list_to_atom(atom_to_list(Action) ++ "_shaper").
-
--spec action_to_global_shaper_name(action()) -> atom().
-action_to_global_shaper_name(Action) -> list_to_atom(atom_to_list(Action) ++ "_global_shaper").
-
-
--spec wait_shaper(ejabberd:server(), action(), ejabberd:jid()) ->
-    'ok' | {'error', 'max_delay_reached'}.
-wait_shaper(Host, Action, From) ->
-    case shaper_srv:wait(Host, action_to_shaper_name(Action), From, 1) of
-        ok ->
-            shaper_srv:wait(Host, action_to_global_shaper_name(Action), global, 1);
-        Err ->
-            Err
-    end.
 
 %% @doc Convert id into internal format.
 -spec fix_rsm('none' | jlib:rsm_in()) -> 'undefined' | jlib:rsm_in().

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -260,7 +260,7 @@ process_mam_iq(From=#jid{lserver=Host}, To, Acc, IQ) ->
     Action = mam_iq:action(IQ),
     Res = case is_action_allowed(Action, From, To) of
         true  ->
-            case mam_iq:wait_shaper(Host, Action, From) of
+            case mod_mam_utils:wait_shaper(Host, Action, From) of
                 ok ->
                     handle_error_iq(Host, To, Action,
                                     handle_mam_iq(Action, From, To, IQ));

--- a/src/mod_mam_meta.erl
+++ b/src/mod_mam_meta.erl
@@ -89,10 +89,11 @@ valid_core_mod_opts(mod_mam) ->
      no_stanzaid_element,
      is_archivable_message,
      archive_chat_markers,
+     extra_lookup_params,
      full_text_search,
      archive_groupchats];
 valid_core_mod_opts(mod_mam_muc) ->
-    [add_archived_element, is_archivable_message, host, full_text_search].
+    [add_archived_element, is_archivable_message, host, extra_lookup_params, full_text_search].
 
 -spec parse_backend_opts(odbc | cassandra | riak, Type :: pm | muc,
                          Opts :: proplists:proplist(), deps()) -> deps().

--- a/src/mod_mam_muc.erl
+++ b/src/mod_mam_muc.erl
@@ -266,7 +266,7 @@ room_process_mam_iq(From = #jid{lserver = Host}, To, Acc, IQ) ->
     Action = mam_iq:action(IQ),
     Res = case is_action_allowed(Action, From, To) of
         true ->
-            case mam_iq:wait_shaper(Host, Action, From) of
+            case mod_mam_utils:wait_shaper(Host, Action, From) of
                 ok ->
                     handle_error_iq(Host, To, Action,
                                     handle_mam_iq(Action, From, To, IQ));

--- a/src/mod_mam_muc.erl
+++ b/src/mod_mam_muc.erl
@@ -110,13 +110,6 @@
 
 %% ----------------------------------------------------------------------
 %% Other types
--type action() :: 'mam_get_prefs'
-                | 'mam_lookup_messages'
-                | 'mam_purge_multiple_messages'
-                | 'mam_purge_single_message'
-                | 'mam_set_prefs'
-                | 'mam_set_message_form'
-                | 'mam_get_message_form'.
 -type packet() :: any().
 -type row_batch() :: {TotalCount :: non_neg_integer(),
                       Offset :: non_neg_integer(),
@@ -268,10 +261,10 @@ archive_room_packet(Packet, FromNick, FromJID=#jid{}, RoomJID=#jid{}, Role, Affi
 -spec room_process_mam_iq(From :: ejabberd:jid(), To :: ejabberd:jid(), Acc :: mongoose_acc:t(),
                           IQ :: ejabberd:iq()) -> {mongoose_acc:t(), ejabberd:iq() | 'ignore'}.
 room_process_mam_iq(From = #jid{lserver = Host}, To, Acc, IQ) ->
-    Action = iq_action(IQ),
+    Action = mam_iq:action(IQ),
     Res = case is_action_allowed(Action, From, To) of
         true ->
-            case wait_shaper(Host, Action, From) of
+            case mam_iq:wait_shaper(Host, Action, From) of
                 ok ->
                     handle_error_iq(Host, To, Action,
                                     handle_mam_iq(Action, From, To, IQ));
@@ -308,16 +301,16 @@ is_action_allowed(Action, From, To = #jid{lserver = Host}) ->
         default -> is_action_allowed_by_default(Action, From, To)
     end.
 
--spec is_action_allowed_by_default(Action :: action(), From :: ejabberd:jid(),
+-spec is_action_allowed_by_default(Action :: mam_iq:action(), From :: ejabberd:jid(),
                                    To :: ejabberd:jid()) -> boolean().
 is_action_allowed_by_default(Action, From, To) ->
     is_room_action_allowed_by_default(Action, From, To).
 
 
--spec is_room_action_allowed_by_default(Action :: action(),
+-spec is_room_action_allowed_by_default(Action :: mam_iq:action(),
                                         From :: ejabberd:jid(), To :: ejabberd:jid()) -> boolean().
 is_room_action_allowed_by_default(Action, From, To) ->
-    case action_type(Action) of
+    case mam_iq:action_type(Action) of
         set -> is_room_owner(From, To);
         get -> can_access_room(From, To)
     end.
@@ -341,26 +334,7 @@ can_access_room(User, Room) ->
     ejabberd_hooks:run_fold(can_access_room, Room#jid.lserver, false, [Room, User]).
 
 
--spec action_type(action()) -> 'get' | 'set'.
-action_type(mam_get_prefs) -> get;
-action_type(mam_set_prefs) -> set;
-action_type(mam_lookup_messages) -> get;
-action_type(mam_set_message_form) -> get;
-action_type(mam_get_message_form) -> get;
-action_type(mam_purge_single_message) -> set;
-action_type(mam_purge_multiple_messages) -> set.
-
-
--spec action_to_shaper_name(action()) -> atom().
-action_to_shaper_name(Action) ->
-    list_to_atom(atom_to_list(Action) ++ "_shaper").
-
-
--spec action_to_global_shaper_name(action()) -> atom().
-action_to_global_shaper_name(Action) -> list_to_atom(atom_to_list(Action) ++ "_global_shaper").
-
-
--spec handle_mam_iq('mam_get_prefs', From :: ejabberd:jid(), ejabberd:jid(),
+-spec handle_mam_iq(mam_iq:action(), From :: ejabberd:jid(), ejabberd:jid(),
                     ejabberd:iq()) ->
                            ejabberd:iq() | {error, any(), ejabberd:iq()}.
 handle_mam_iq(Action, From, To, IQ) ->
@@ -379,39 +353,6 @@ handle_mam_iq(Action, From, To, IQ) ->
             handle_purge_single_message(To, IQ);
         mam_purge_multiple_messages ->
             handle_purge_multiple_messages(To, IQ)
-    end.
-
-
--spec iq_action(ejabberd:iq()) -> action().
-iq_action(IQ = #iq{xmlns = ?NS_MAM}) ->
-    iq_action02(IQ);
-iq_action(IQ = #iq{xmlns = ?NS_MAM_03}) ->
-    iq_action03(IQ);
-iq_action(IQ = #iq{xmlns = ?NS_MAM_04}) ->
-    iq_action03(IQ);
-iq_action(IQ = #iq{xmlns = ?NS_MAM_06}) ->
-    iq_action03(IQ).
-
-iq_action02(#iq{type = Action, sub_el = SubEl = #xmlel{name = Category}}) ->
-    case {Action, Category} of
-        {set, <<"prefs">>} -> mam_set_prefs;
-        {get, <<"prefs">>} -> mam_get_prefs;
-        {get, <<"query">>} -> mam_lookup_messages;
-        {set, <<"purge">>} ->
-            case exml_query:attr(SubEl, <<"id">>) of
-                undefined -> mam_purge_multiple_messages;
-                _ -> mam_purge_single_message
-            end
-    end.
-
-iq_action03(#iq{type = Action, sub_el = #xmlel{name = Category}}) ->
-    case {Action, Category} of
-        {set, <<"prefs">>} -> mam_set_prefs;
-        {get, <<"prefs">>} -> mam_get_prefs;
-        {get, <<"query">>} -> mam_get_message_form;
-        {set, <<"query">>} -> mam_set_message_form
-                              %% Purge is NOT official extention, it is not implemented for
-                              %% XEP-0313 v0.3. Use v0.2 namespace if you really want it.
     end.
 
 -spec handle_set_prefs(ejabberd:jid(), ejabberd:iq()) ->
@@ -694,17 +635,6 @@ purge_multiple_messages(Host, ArcID, ArcJID, Borders,
                         Start, End, Now, WithJID) ->
     ejabberd_hooks:run_fold(mam_muc_purge_multiple_messages, Host, ok,
                             [Host, ArcID, ArcJID, Borders, Start, End, Now, WithJID]).
-
-
--spec wait_shaper(ejabberd:server(), action(), ejabberd:jid())
-                 -> 'ok' | {'error', 'max_delay_reached'}.
-wait_shaper(Host, Action, From) ->
-    case shaper_srv:wait(Host, action_to_shaper_name(Action), From, 1) of
-        ok ->
-            shaper_srv:wait(Host, action_to_global_shaper_name(Action), global, 1);
-        Err ->
-            Err
-    end.
 
 %% ----------------------------------------------------------------------
 %% Helpers

--- a/src/mod_mam_muc.erl
+++ b/src/mod_mam_muc.erl
@@ -471,7 +471,7 @@ send_messages_and_iq_result({TotalCount, Offset, MessageRows}, From,
                             #iq{xmlns = MamNs, sub_el = QueryEl} = IQ,
                             #{owner_jid := ArcJID, page_size := PageSize}) ->
     %% Forward messages
-    QueryID = xml:get_tag_attr_s(<<"queryid">>, QueryEl),
+    QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
     {FirstMessID, LastMessID} = forward_messages(From, ArcJID, MamNs,
                                                  QueryID, MessageRows, true),
 

--- a/src/mod_mam_utils.erl
+++ b/src/mod_mam_utils.erl
@@ -84,6 +84,7 @@
 
 %% Ejabberd
 -export([send_message/3,
+         maybe_set_client_xmlns/2,
          is_jid_in_user_roster/2]).
 
 %-define(MAM_INLINE_UTILS, true).
@@ -983,6 +984,12 @@ is_last_page(_PageSize, _TotalCount, _Offset, _MessageRows) ->
     %%     it's not possible case: the page is bigger then page size.
     %% Otherwise either TotalCount or Offset is undefined because of optimizations.
     false.
+
+-spec maybe_set_client_xmlns(boolean(), exml:element()) -> exml:element().
+maybe_set_client_xmlns(true, Packet) ->
+    xml:replace_tag_attr(<<"xmlns">>, <<"jabber:client">>, Packet);
+maybe_set_client_xmlns(false, Packet) ->
+    Packet.
 
 %% -----------------------------------------------------------------------
 %% Ejabberd

--- a/src/mod_mam_utils.erl
+++ b/src/mod_mam_utils.erl
@@ -80,7 +80,8 @@
          calculate_msg_id_borders/3,
          calculate_msg_id_borders/4,
          maybe_encode_compact_uuid/2,
-         is_last_page/4]).
+         is_last_page/4,
+         wait_shaper/3]).
 
 %% Ejabberd
 -export([send_message/3,
@@ -990,6 +991,25 @@ maybe_set_client_xmlns(true, Packet) ->
     xml:replace_tag_attr(<<"xmlns">>, <<"jabber:client">>, Packet);
 maybe_set_client_xmlns(false, Packet) ->
     Packet.
+
+
+-spec action_to_shaper_name(mam_iq:action()) -> atom().
+action_to_shaper_name(Action) ->
+    list_to_atom(atom_to_list(Action) ++ "_shaper").
+
+-spec action_to_global_shaper_name(mam_iq:action()) -> atom().
+action_to_global_shaper_name(Action) -> list_to_atom(atom_to_list(Action) ++ "_global_shaper").
+
+
+-spec wait_shaper(ejabberd:server(), mam_iq:action(), ejabberd:jid()) ->
+    'ok' | {'error', 'max_delay_reached'}.
+wait_shaper(Host, Action, From) ->
+    case shaper_srv:wait(Host, action_to_shaper_name(Action), From, 1) of
+        ok ->
+            shaper_srv:wait(Host, action_to_global_shaper_name(Action), global, 1);
+        Err ->
+            Err
+    end.
 
 %% -----------------------------------------------------------------------
 %% Ejabberd


### PR DESCRIPTION
Proposed changes include:
* unify message forwarding for different MAM versions
* move `pm` and `muc` duplicated helper function to `mam_iq`
* add possibility to configure a callback module which can add extra lookup params based on custom form fields

