### PR TITLE
Add special mongoose_acc case for getting to_send with default.

### DIFF
--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -135,6 +135,8 @@ get(Key, P) ->
     maps:get(Key, P).
 
 -spec get(any(), t(), any()) -> any().
+get(to_send, P, Default) ->
+    maps:get(to_send, P, maps:get(element, P, Default));
 get(Key, P, Default) ->
     maps:get(Key, P, Default).
 


### PR DESCRIPTION
Rationale: modules should use `to_send` to inspect the packet that
will be sent. There are cases of logic paths in the system, though, that
do not set `element`, so with no `to_send` field a simple get/2 is not
sufficient and a default is needed.
