### PR TITLE
Update MongooseIM URI

### DIFF
--- a/apps/ejabberd/include/ejabberd.hrl
+++ b/apps/ejabberd/include/ejabberd.hrl
@@ -31,7 +31,7 @@
 -define(CONFIG_PATH, "etc/ejabberd.cfg").
 
 -define(EJABBERD_URI, "http://www.process-one.net/en/ejabberd/").
--define(MONGOOSE_URI, <<"https://www.erlang-solutions.com/products/mongooseim-massively-scalable-ejabberd-platform">>).
+-define(MONGOOSE_URI, <<"https://www.erlang-solutions.com/products/mongooseim.html">>).
 
 -define(S2STIMEOUT, 600000).
 


### PR DESCRIPTION
Use new product page instead of the old one which unavailable.

