### PR TITLE
[MUCLight][Doc] fix documentation regarding default_config [skip ci]

### DIFF
--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -20,12 +20,12 @@
 %%% * config_schema (["roomname", "subject"]) - Custom list of configuration options for a room;
 %%%                               WARNING! Lack of `roomname` field will cause room names in
 %%%                               Disco results and Roster items be set to room username.
-%%% * default_config ([{"roomname, "Untitled"}, {"subject", ""}]) -
+%%% * default_config ([{roomname, "Untitled"}, {subject, ""}]) -
 %%%                                Custom default room configuration; must be a subset of
 %%%                                config schema. It's a list of KV tuples with string keys
 %%%                                and values of appriopriate type. String values will be
 %%%                                converted to binary automatically.
-%%%        Example: [{"roomname", "The room"}, {"subject", "Chit-chat"}, {"security", 10}]
+%%%        Example: [{roomname, "The room"}, {subject, "Chit-chat"}, {security, 10}]
 %%%
 %%% Allowed `config_schema` list items (may be mixed):
 %%% * Just field name: "field" - will be expanded to "field" of type 'binary'

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -6,20 +6,20 @@ This extension consists of several modules but only `mod_muc_light` needs to be 
 
 ### Options
 
-* **host** (string, default: `"muclight.@HOST@"`) - Domain for the MUC Light service to reside under. 
+* **host** (string, default: `"muclight.@HOST@"`) - Domain for the MUC Light service to reside under.
  `@HOST@` is replaced with each served domain.
-* **backend** (atom, default: `mnesia`) - Database backend to use. 
+* **backend** (atom, default: `mnesia`) - Database backend to use.
  `mnesia` and `odbc` are supported.
-* **equal_occupants** (boolean, default: `false`) - When enabled, MUC Light rooms won't have owners. 
- It means that every occupant will be a `member`, even the room creator. 
- **Warning:** This option does not implicitly set `all_can_invite` to `true`. 
+* **equal_occupants** (boolean, default: `false`) - When enabled, MUC Light rooms won't have owners.
+ It means that every occupant will be a `member`, even the room creator.
+ **Warning:** This option does not implicitly set `all_can_invite` to `true`.
  If that option is set to `false`, nobody will be able to join the room after the initial creation request.
-* **legacy_mode** (boolean, default: `false`) - Enables XEP-0045 compatibility mode. 
+* **legacy_mode** (boolean, default: `false`) - Enables XEP-0045 compatibility mode.
  It allows using a subset of classic MUC stanzas with some MUC Light functions limited.
-* **rooms_per_user** (positive integer or `infinity`, default: `infinity`) - Specifies a cap on a number of rooms a user can occupy. 
+* **rooms_per_user** (positive integer or `infinity`, default: `infinity`) - Specifies a cap on a number of rooms a user can occupy.
  **Warning:** Setting such a limit may trigger expensive DB queries for every occupant addition.
 * **blocking** (boolean, default: `true`) - Blocking feature enabled/disabled.
-* **all_can_configure** (boolean, default: `false`) - When enabled, all room occupants can change all configuration options. 
+* **all_can_configure** (boolean, default: `false`) - When enabled, all room occupants can change all configuration options.
  If disabled, everyone can still the change room subject.
 * **all_can_invite** (boolean, default: `false`) - When enabled, all room occupants can add new occupants to the room.
  Occupants added by `members` become `members` as well.
@@ -27,11 +27,12 @@ This extension consists of several modules but only `mod_muc_light` needs to be 
 * **rooms_per_page** (positive integer or `infinity`, default: 10) - Specifies maximal number of rooms returned for a single Disco request.
 * **rooms_in_rosters** (boolean, default: `false`) - When enabled, rooms the user occupies are included in their roster.
 * **config_schema** (list; see below, default: `["roomname", "subject"]`) - A list of fields allowed in the room configuration.
- The field type may be specified but the default is "binary", i.e. effectively a string. 
+ The field type may be specified but the default is "binary", i.e. effectively a string.
  **WARNING!** Lack of the `roomname` field will cause room names in Disco results and Roster items be set to the room username.
-* **default_config** (list, default: `[{"roomname, "Untitled"}, {"subject", ""}]`) - Custom default room configuration; must be a subset of config schema. 
- It's a list of KV tuples with string keys and values of appriopriate type. 
- String values will be converted to binary automatically.
+* **default_config** (list, default: `[{roomname, "Untitled"}, {subject, ""}]`)
+ - Custom default room configuration; must be a subset of config schema.
+ It's a list of KV tuples with atom keys and values of appriopriate type.
+ String values will be converted to binaries automatically.
 
 ### Config schema
 
@@ -51,7 +52,7 @@ Valid config field types are:
 
 ### Example Configuration
 
-```
+```erlang
 {mod_muc_light, [
              {host, "muclight.example.com"},
              {equal_occupants, true},
@@ -64,6 +65,6 @@ Valid config field types are:
              {rooms_per_page, 5},
              {rooms_in_rosters, true},
              {config_schema, ["roomname", {"display-lines", integer}]},
-             {default_config, [{"roomname", "The Room"}, {"display-lines", 30}]}
+             {default_config, [{roomname, "The Room"}, {display-lines, 30}]}
             ]},
 ```


### PR DESCRIPTION
Keys in default config has to be atoms, otherwise the key will not be found in the `config schema` list.