### PR TITLE
Admin http auth

### DIFF
--- a/apps/ejabberd/include/mongoose_api.hrl
+++ b/apps/ejabberd/include/mongoose_api.hrl
@@ -5,6 +5,7 @@
                          command_category,
                          command_subcategory,
                          entity = admin,
+			 auth = {any, any},
                          opts = []}).
 %% Error messages
 -define(ARGS_LEN_ERROR, <<"Bad parameters length.">>).

--- a/apps/ejabberd/include/mongoose_api.hrl
+++ b/apps/ejabberd/include/mongoose_api.hrl
@@ -5,7 +5,7 @@
                          command_category,
                          command_subcategory,
                          entity = admin,
-			 auth = {any, any},
+			 auth = any,
                          opts = []}).
 %% Error messages
 -define(ARGS_LEN_ERROR, <<"Bad parameters length.">>).

--- a/apps/ejabberd/include/mongoose_api.hrl
+++ b/apps/ejabberd/include/mongoose_api.hrl
@@ -5,7 +5,7 @@
                          command_category,
                          command_subcategory,
                          entity = admin,
-			 auth = any,
+                         auth = any,
                          opts = []}).
 %% Error messages
 -define(ARGS_LEN_ERROR, <<"Bad parameters length.">>).

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -24,7 +24,8 @@
          rest_init/2,
          options/2,
          content_types_accepted/2,
-         delete_resource/2]).
+         delete_resource/2,
+	 is_authorized/2]).
 
 %% local callbacks
 -export([to_json/2, from_json/2]).

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -120,7 +120,7 @@ is_authorized(Req, State) ->
     ControlCreds = get_control_creds(State),
     Creds = mongoose_api_common:get_creds(Req),
     AuthMethod = mongoose_api_common:get_auth_method(Req),
-    case compare_creds(ControlCreds, PassCreds) andalso
+    case compare_creds(ControlCreds, Creds) andalso
 	 mongoose_api_common:is_known_auth_method(AuthMethod) of
 	true ->
 	    {true, Req, State};
@@ -130,11 +130,11 @@ is_authorized(Req, State) ->
 
 compare_creds({UserControl, PassControl}, {User, Pass}) ->
     compare_single_cred(UserControl, User) andalso
-	 compare_simple_cred(PassControl, Pass).
+	 compare_single_cred(PassControl, Pass).
 
-compare_users(any, _) -> true;
-compare_users(Control, Control) -> true;
-compare_users(_Control, _User) -> false.
+compare_single_cred(any, _) -> true;
+compare_single_cred(Control, Control) -> true;
+compare_single_cred(_Control, _User) -> false.
 
 
 get_control_creds(#http_api_state{opts = Opts}) ->

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -122,17 +122,18 @@ delete_resource(Req, #http_api_state{command_category = Category, bindings = B} 
 % @doc Cowboy callback
 is_authorized(Req, State) ->
     ControlCreds = get_control_creds(State),
-    {ok, {AuthMethod, Creds}, Req2} = mongoose_api_common:get_auth_details(Req),
-    case authorize(ControlCreds, Creds, AuthMethod) of
+    {ok, AuthDetails, Req2} = mongoose_api_common:get_auth_details(Req),
+    case authorize(ControlCreds, AuthDetails) of
         true ->
             {true, Req2, State};
         false ->
             mongoose_api_common:make_unauthorized_response(Req2, State)
     end.
 
--spec authorize(credentials(), credentials(), binary()) -> boolean().
-authorize(any, _, _) -> true;
-authorize(ControlCreds, Creds, AuthMethod) ->
+-spec authorize(credentials(), {credentials(), binary()}) -> boolean().
+authorize(any, _) -> true;
+authorize(_, undefined) -> false;
+authorize(ControlCreds, {AuthMethod, Creds}) ->
     compare_creds(ControlCreds, Creds) andalso
         mongoose_api_common:is_known_auth_method(AuthMethod).
 
@@ -140,13 +141,10 @@ authorize(ControlCreds, Creds, AuthMethod) ->
 % it is equal to everything).
 -spec compare_creds(credentials(), credentials() | undefined) -> boolean().
 compare_creds({UserControl, PassControl}, {User, Pass}) ->
-    compare_single_cred(UserControl, User) andalso
-        compare_single_cred(PassControl, Pass);
+    UserControl == User andalso
+    PassControl == Pass;
 compare_creds(any, undefined) -> true;
 compare_creds(_, _) -> false.
-
-compare_single_cred(Creds, Creds) -> true;
-compare_single_cred(_Control, _User) -> false.
 
 get_control_creds(#http_api_state{auth = Creds}) ->
     Creds.

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -180,8 +180,8 @@ from_json(Req, #http_api_state{command_category = Category,
             end
     end.
 
--spec handler_path(ejabberd_cowboy:path(), mongoose_commands:t(), [{atom(), term()}])
-      -> ejabberd_cowboy:route().
+-spec handler_path(ejabberd_cowboy:path(), mongoose_commands:t(), [{atom(), term()}]) -> 
+    ejabberd_cowboy:route().
 handler_path(Base, Command, ExtraOpts) ->
     {[Base, mongoose_api_common:create_admin_url_path(Command)],
         ?MODULE, [{command_category, mongoose_commands:category(Command)},

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -25,7 +25,7 @@
          options/2,
          content_types_accepted/2,
          delete_resource/2,
-	 is_authorized/2]).
+         is_authorized/2]).
 %% local callbacks
 -export([to_json/2, from_json/2]).
 -include("mongoose_api.hrl").
@@ -78,7 +78,7 @@ rest_init(Req, Opts) ->
                             bindings = Bindings,
                             command_category = CommandCategory,
                             command_subcategory = CommandSubCategory,
-			    auth = Auth},
+                            auth = Auth},
     options(Req1, State).
 
 options(Req, State) ->
@@ -125,24 +125,24 @@ is_authorized(Req, State) ->
     Creds = mongoose_api_common:get_creds(Req),
     AuthMethod = mongoose_api_common:get_auth_method(Req),
     case authorize(ControlCreds, Creds, AuthMethod) of
-	true ->
-	    {true, Req, State};
-	false ->
-	    mongoose_api_common:make_unauthorized_response(Req, State)
+        true ->
+            {true, Req, State};
+        false ->
+            mongoose_api_common:make_unauthorized_response(Req, State)
     end.
 
 -spec authorize(credentials(), credentials(), binary()) -> boolean().
 authorize({any, any}, _, _) -> true;
 authorize(ControlCreds, Creds, AuthMethod) ->
     compare_creds(ControlCreds, Creds) andalso
-	 mongoose_api_common:is_known_auth_method(AuthMethod).
+        mongoose_api_common:is_known_auth_method(AuthMethod).
 
 % @doc Checks if credentials are the same (if control creds are 'any'
 % it is equal to everything).
 -spec compare_creds(credentials(), credentials()) -> boolean().
 compare_creds({UserControl, PassControl}, {User, Pass}) ->
     compare_single_cred(UserControl, User) andalso
-	 compare_single_cred(PassControl, Pass);
+        compare_single_cred(PassControl, Pass);
 compare_creds({any, any}, undefined) -> true;
 compare_creds(_, _) -> false.
 
@@ -184,7 +184,8 @@ from_json(Req, #http_api_state{command_category = Category,
             end
     end.
 
--spec handler_path(ejabberd_cowboy:path(), mongoose_commands:t(), [{atom(), term()}]) -> ejabberd_cowboy:route().
+-spec handler_path(ejabberd_cowboy:path(), mongoose_commands:t(), [{atom(), term()}])
+      -> ejabberd_cowboy:route().
 handler_path(Base, Command, ExtraOpts) ->
     {[Base, mongoose_api_common:create_admin_url_path(Command)],
         ?MODULE, [{command_category, mongoose_commands:category(Command)},

--- a/apps/ejabberd/src/mongoose_api_admin.erl
+++ b/apps/ejabberd/src/mongoose_api_admin.erl
@@ -180,7 +180,7 @@ from_json(Req, #http_api_state{command_category = Category,
             end
     end.
 
--spec handler_path(ejabberd_cowboy:path(), mongoose_commands:t(), [{atom(), term()}]) -> 
+-spec handler_path(ejabberd_cowboy:path(), mongoose_commands:t(), [{atom(), term()}]) ->
     ejabberd_cowboy:route().
 handler_path(Base, Command, ExtraOpts) ->
     {[Base, mongoose_api_common:create_admin_url_path(Command)],

--- a/apps/ejabberd/src/mongoose_api_common.erl
+++ b/apps/ejabberd/src/mongoose_api_common.erl
@@ -351,3 +351,35 @@ method_to_action(<<"POST">>) -> create;
 method_to_action(<<"PUT">>) -> update;
 method_to_action(<<"DELETE">>) -> delete.
 
+%%--------------------------------------------------------------------
+%% Authorization
+%%--------------------------------------------------------------------
+
+get_creds(Req) ->
+    case get_auth_details(Req) of
+	{ok, undefined, _} ->
+	    undefined,
+	{ok, {_AuthMethod, Creds}, _Req2} ->
+	   Creds
+    end.
+
+get_auth_method(Req) ->
+    case get_auth_details(Req) of
+	{ok, undefined, _} ->
+	    undefined,
+	{ok, {AuthMethod, _Creds}, _Req2} ->
+	   AuthMethod
+    end.
+
+get_http_method(Req) ->
+    {M, _} = cowboy_req:method(Req),
+    M.
+
+get_auth_details(Req) ->
+    cowboy_req:parse_header(<<"authorization">>, Req).
+
+is_known_auth_method(<<"basic">>) -> true;
+is_known_auth_method(_) -> false.
+
+make_unauthorized_response(Req, State) ->
+        {{false, <<"Basic realm=\"mongooseim\"">>}, Req, State}.

--- a/apps/ejabberd/src/mongoose_api_common.erl
+++ b/apps/ejabberd/src/mongoose_api_common.erl
@@ -76,7 +76,13 @@
          parse_request_body/1,
          get_allowed_methods/1,
          process_request/4,
-         reload_dispatches/1]).
+         reload_dispatches/1,
+	 get_creds/1,
+	 get_auth_method/1,
+	 get_http_method/1,
+         get_auth_details/1,
+	 is_known_auth_method/1,
+	 make_unauthorized_response/2]).
 
 
 %% @doc Reload all ejabberd_cowboy listeners.
@@ -358,7 +364,7 @@ method_to_action(<<"DELETE">>) -> delete.
 get_creds(Req) ->
     case get_auth_details(Req) of
 	{ok, undefined, _} ->
-	    undefined,
+	    undefined;
 	{ok, {_AuthMethod, Creds}, _Req2} ->
 	   Creds
     end.
@@ -366,7 +372,7 @@ get_creds(Req) ->
 get_auth_method(Req) ->
     case get_auth_details(Req) of
 	{ok, undefined, _} ->
-	    undefined,
+	    undefined;
 	{ok, {AuthMethod, _Creds}, _Req2} ->
 	   AuthMethod
     end.

--- a/apps/ejabberd/src/mongoose_api_common.erl
+++ b/apps/ejabberd/src/mongoose_api_common.erl
@@ -77,12 +77,12 @@
          get_allowed_methods/1,
          process_request/4,
          reload_dispatches/1,
-	 get_creds/1,
-	 get_auth_method/1,
-	 get_http_method/1,
+         get_creds/1,
+         get_auth_method/1,
+         get_http_method/1,
          get_auth_details/1,
-	 is_known_auth_method/1,
-	 make_unauthorized_response/2]).
+         is_known_auth_method/1,
+         make_unauthorized_response/2]).
 
 
 %% @doc Reload all ejabberd_cowboy listeners.
@@ -363,18 +363,18 @@ method_to_action(<<"DELETE">>) -> delete.
 
 get_creds(Req) ->
     case get_auth_details(Req) of
-	{ok, undefined, _} ->
-	    undefined;
-	{ok, {_AuthMethod, Creds}, _Req2} ->
-	   Creds
+        {ok, undefined, _} ->
+           undefined;
+        {ok, {_AuthMethod, Creds}, _Req2} ->
+           Creds
     end.
 
 get_auth_method(Req) ->
     case get_auth_details(Req) of
-	{ok, undefined, _} ->
-	    undefined;
-	{ok, {AuthMethod, _Creds}, _Req2} ->
-	   AuthMethod
+        {ok, undefined, _} ->
+           undefined;
+        {ok, {AuthMethod, _Creds}, _Req2} ->
+           AuthMethod
     end.
 
 get_http_method(Req) ->

--- a/apps/ejabberd/src/mongoose_api_common.erl
+++ b/apps/ejabberd/src/mongoose_api_common.erl
@@ -77,9 +77,6 @@
          get_allowed_methods/1,
          process_request/4,
          reload_dispatches/1,
-         get_creds/1,
-         get_auth_method/1,
-         get_http_method/1,
          get_auth_details/1,
          is_known_auth_method/1,
          make_unauthorized_response/2]).
@@ -361,28 +358,8 @@ method_to_action(<<"DELETE">>) -> delete.
 %% Authorization
 %%--------------------------------------------------------------------
 
-get_creds(Req) ->
-    case get_auth_details(Req) of
-        {ok, undefined, _} ->
-           undefined;
-        {ok, {_AuthMethod, Creds}, _Req2} ->
-           Creds
-    end.
-
-get_auth_method(Req) ->
-    case get_auth_details(Req) of
-        {ok, undefined, _} ->
-           undefined;
-        {ok, {AuthMethod, _Creds}, _Req2} ->
-           AuthMethod
-    end.
-
-get_http_method(Req) ->
-    {M, _} = cowboy_req:method(Req),
-    M.
-
 get_auth_details(Req) ->
-    cowboy_req:parse_header(<<"authorization">>, Req).
+    cowboy_req:parse_header(<<"authorization">>, Req, {undefined, any}).
 
 is_known_auth_method(<<"basic">>) -> true;
 is_known_auth_method(_) -> false.

--- a/apps/ejabberd/src/mongoose_api_common.erl
+++ b/apps/ejabberd/src/mongoose_api_common.erl
@@ -365,4 +365,4 @@ is_known_auth_method(<<"basic">>) -> true;
 is_known_auth_method(_) -> false.
 
 make_unauthorized_response(Req, State) ->
-        {{false, <<"Basic realm=\"mongooseim\"">>}, Req, State}.
+    {{false, <<"Basic realm=\"mongooseim\"">>}, Req, State}.

--- a/apps/ejabberd/src/mongoose_api_common.erl
+++ b/apps/ejabberd/src/mongoose_api_common.erl
@@ -359,7 +359,7 @@ method_to_action(<<"DELETE">>) -> delete.
 %%--------------------------------------------------------------------
 
 get_auth_details(Req) ->
-    cowboy_req:parse_header(<<"authorization">>, Req, {undefined, any}).
+    cowboy_req:parse_header(<<"authorization">>, Req).
 
 is_known_auth_method(<<"basic">>) -> true;
 is_known_auth_method(_) -> false.

--- a/apps/ejabberd/src/mongoose_client_api.erl
+++ b/apps/ejabberd/src/mongoose_client_api.erl
@@ -61,17 +61,18 @@ is_authorized(Req, State) ->
     Creds = mongoose_api_common:get_creds(Req),
     AuthMethod = mongoose_api_common:get_auth_method(Req),
     case check_password(Creds) andalso
-	 mongoose_api_common:is_known_auth_method(AuthMethod) andalso
+	 mongoose_api_common:is_known_auth_method(AuthMethod) orelse
 	 is_noauth_http_method(HTTPMethod) of
 	true ->
 	    {User, _} = Creds,
-            {true, Req, State#{user => User, jid => jlib:from_binary(User)}};
+            {true, Req, State#{user => User, jid => jid:from_binary(User)}};
 	false ->
 	    mongoose_api_common:make_unauthorized_response(Req, State)
     end.
 
+check_password(undefined) -> false;
 check_password({User, Password}) ->
-    #jid{luser = RawUser, lserver = Server} = jlib:from_binary(User),
+    #jid{luser = RawUser, lserver = Server} = jid:from_binary(User),
     Creds0 = mongoose_credentials:new(Server),
     Creds1 = mongoose_credentials:set(Creds0, username, RawUser),
     Creds2 = mongoose_credentials:set(Creds1, password, Password),

--- a/apps/ejabberd/src/mongoose_client_api.erl
+++ b/apps/ejabberd/src/mongoose_client_api.erl
@@ -61,13 +61,13 @@ is_authorized(Req, State) ->
     Creds = mongoose_api_common:get_creds(Req),
     AuthMethod = mongoose_api_common:get_auth_method(Req),
     case check_password(Creds) andalso
-	 mongoose_api_common:is_known_auth_method(AuthMethod) orelse
-	 is_noauth_http_method(HTTPMethod) of
-	true ->
-	    {User, _} = Creds,
+         mongoose_api_common:is_known_auth_method(AuthMethod) orelse
+         is_noauth_http_method(HTTPMethod) of
+        true ->
+            {User, _} = Creds,
             {true, Req, State#{user => User, jid => jid:from_binary(User)}};
-	false ->
-	    mongoose_api_common:make_unauthorized_response(Req, State)
+        false ->
+            mongoose_api_common:make_unauthorized_response(Req, State)
     end.
 
 check_password(undefined) -> false;
@@ -77,8 +77,8 @@ check_password({User, Password}) ->
     Creds1 = mongoose_credentials:set(Creds0, username, RawUser),
     Creds2 = mongoose_credentials:set(Creds1, password, Password),
     case ejabberd_auth:authorize(Creds2) of
-	{ok, _} -> true;
-	_ -> false
+        {ok, _} -> true;
+        _ -> false
     end.
 
 % Constraints

--- a/apps/ejabberd/src/mongoose_client_api.erl
+++ b/apps/ejabberd/src/mongoose_client_api.erl
@@ -67,13 +67,15 @@ is_authorized(Req, State) ->
     end.
 
 authorize({AuthMethod, Creds}, HTTPMethod, Req, State) ->
-    case check_password(Creds) andalso
-         mongoose_api_common:is_known_auth_method(AuthMethod) orelse
-         is_noauth_http_method(HTTPMethod) of
-                true ->
+    case {check_password(Creds) andalso
+         mongoose_api_common:is_known_auth_method(AuthMethod),
+         is_noauth_http_method(HTTPMethod)} of
+                {_, true} ->
+                    {true, Req, State};
+                {true, _} ->
                     {User, _} = Creds,
                     {true, Req, State#{user => User, jid => jid:from_binary(User)}};
-                false ->
+                {false, _} ->
                     mongoose_api_common:make_unauthorized_response(Req, State)
     end.
 

--- a/apps/ejabberd/src/mongoose_client_api.erl
+++ b/apps/ejabberd/src/mongoose_client_api.erl
@@ -57,17 +57,16 @@ to_json(Req, User) ->
 
 % @doc cowboy callback
 is_authorized(Req, State) ->
-    HTTPMethod = mongoose_api_common:get_http_method(Req),
-    Creds = mongoose_api_common:get_creds(Req),
-    AuthMethod = mongoose_api_common:get_auth_method(Req),
+    {HTTPMethod, Req2} = cowboy_req:method(Req),
+    {ok, {AuthMethod, Creds}, Req3} = mongoose_api_common:get_auth_details(Req2),
     case check_password(Creds) andalso
          mongoose_api_common:is_known_auth_method(AuthMethod) orelse
          is_noauth_http_method(HTTPMethod) of
         true ->
             {User, _} = Creds,
-            {true, Req, State#{user => User, jid => jid:from_binary(User)}};
+            {true, Req3, State#{user => User, jid => jid:from_binary(User)}};
         false ->
-            mongoose_api_common:make_unauthorized_response(Req, State)
+            mongoose_api_common:make_unauthorized_response(Req3, State)
     end.
 
 check_password(undefined) -> false;

--- a/apps/ejabberd/src/mongoose_client_api_contacts.erl
+++ b/apps/ejabberd/src/mongoose_client_api_contacts.erl
@@ -112,7 +112,7 @@ handle_request_and_respond(Method, Jid, Action, CJid, Req, State) ->
         not_found ->
             {ok, Req2} = cowboy_req:reply(404, Req),
             {halt, Req2, State}
-    end
+    end.
 
 serve_failure(not_implemented, Req, State) ->
     {ok, Req2} = cowboy_req:reply(501, Req),

--- a/apps/ejabberd/src/mongoose_client_api_contacts.erl
+++ b/apps/ejabberd/src/mongoose_client_api_contacts.erl
@@ -70,30 +70,24 @@ from_json(Req, #{jid := Caller} = State) ->
               J -> J
           end,
     Action = maps:get(<<"action">>, JSONData, undefined),
-    case handle_request(Method, to_binary(Jid), Action, CJid) of
-        ok ->
-            {true, Req2, State};
-        not_implemented ->
-            {ok, Req3} = cowboy_req:reply(501, Req2),
-            {halt, Req3, State};
-        not_found ->
-            {ok, Req3} = cowboy_req:reply(404, Req2),
-            {halt, Req3, State}
-    end.
+    handle_request_and_respond(Method, Jid, Action, CJid, Req2, State).
 
 %% @doc Called for a method of type "DELETE"
 delete_resource(Req, #{jid := Caller} = State) ->
     {Jid, Req2} = cowboy_req:binding(jid, Req),
     CJid = jid:to_binary(Caller),
-    case handle_request(<<"DELETE">>, Jid, undefined, CJid) of
+    handle_request_and_respond(<<"DELETE">>, Jid, undefined, CJid, Req2, State).
+
+handle_request_and_respond(Method, Jid, Action, CJid, Req, State) ->
+    case handle_request(Method, to_binary(Jid), Action, CJid) of
         ok ->
-            {true, Req2, State};
+            {true, Req, State};
         not_implemented ->
-            {ok, Req3} = cowboy_req:reply(501, Req2),
-            {halt, Req3, State};
+            {ok, Req2} = cowboy_req:reply(501, Req),
+            {halt, Req2, State};
         not_found ->
-            {ok, Req3} = cowboy_req:reply(404, Req2),
-            {halt, Req3, State}
+            {ok, Req2} = cowboy_req:reply(404, Req),
+            {halt, Req2, State}
     end.
 
 

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -88,11 +88,13 @@ Unlike `ejabberd_c2s`, it doesn't use `ejabberd_receiver` or `ejabberd_listener`
 
             `{"localhost", "/api", mongoose_api, [{handlers, [mongoose_api_metrics]}]}`
 
-  * `mongoose_api_admin` -  REST API for admin commands. It expects credentials in the form of {Username, Password}
-    in module options. If they're not provided, authorization is disabled.
-        Example:
-            `{"localhost", "/api", mongoose_api_admin, [{"ala", "makotaipsa"}]}`
-   Exposes all mongoose_commands.
+  * `mongoose_api_admin` -  REST API for admin commands. Exposes all mongoose_commands. 
+    			    It expects one optional argument:  
+      * Credentials: `{auth, {Username, Password}}`.  
+        If they're not provided, authorization is disabled.  
+        Example:  
+            `{"localhost", "/api", mongoose_api_admin, [{auth, {"ala", "makotaipsa"}}]}`
+   
     `mongoose_api_client` - REST API for client side commands.
      Exposes all mongoose_commands marked as "user".
         Example declaration:

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -88,13 +88,16 @@ Unlike `ejabberd_c2s`, it doesn't use `ejabberd_receiver` or `ejabberd_listener`
 
             `{"localhost", "/api", mongoose_api, [{handlers, [mongoose_api_metrics]}]}`
 
-  * `mongoose_api_admin` -  REST API for admin commands.
+  * `mongoose_api_admin` -  REST API for admin commands. It expects credentials in the form of {Username, Password}
+    in module options. If they're not provided, authorization is disabled.
+        Example:
+            `{"localhost", "/api", mongoose_api_admin, [{"ala", "makotaipsa"}]}`
    Exposes all mongoose_commands.
     `mongoose_api_client` - REST API for client side commands.
      Exposes all mongoose_commands marked as "user".
         Example declaration:
 
-            `{"localhost", "/api", mongoose_api_admin, []}`
+            `{"localhost", "/api/contacts/{:jid}", mongoose_api_client_contacts, []}`
 
 ### HTTP module: `mod_cowboy`
 

--- a/test.disabled/ejabberd_tests/tests/ejabberd_node_utils.erl
+++ b/test.disabled/ejabberd_tests/tests/ejabberd_node_utils.erl
@@ -82,12 +82,12 @@ backup_config_file(Node, Config) ->
     {ok, _} = call_fun(Node, file, copy, [current_config_path(Node, Config),
                                           backup_config_path(Node, Config)]).
 
--spec restore_config_file(ct_config()) -> ct_config().
+-spec restore_config_file(ct_config()) -> 'ok'.
 restore_config_file(Config) ->
     Node = ct:get_config({hosts, mim, node}),
     restore_config_file(Node, Config).
 
--spec restore_config_file(node(), ct_config()) -> ct_config().
+-spec restore_config_file(node(), ct_config()) -> 'ok'.
 restore_config_file(Node, Config) ->
     ok = call_fun(Node, file, rename, [backup_config_path(Node, Config),
                                        current_config_path(Node, Config)]).

--- a/test.disabled/ejabberd_tests/tests/muc_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_http_api_SUITE.erl
@@ -92,7 +92,7 @@ create_room(Config) ->
         Body = #{name => Name,
                  owner => escalus_client:short_jid(Alice),
                  nick => <<"ali">>},
-        {{<<"201">>, _}, Name} = rest_helper:post(Path, Body),
+        {{<<"201">>, _}, Name} = rest_helper:post(admin, Path, Body),
         %% Service acknowledges room creation (10.1.1 Ex. 154), then
         %% (presumably 7.2.16) sends room subject, finally the IQ
         %% result of the IQ request (10.1.2) for an instant room. The
@@ -112,7 +112,7 @@ invite_online_user_to_room(Config) ->
         Body = #{sender => escalus_client:short_jid(Alice),
                  recipient => escalus_client:short_jid(Bob),
                  reason => Reason},
-        {{<<"204">>, _}, <<"">>} = rest_helper:post(Path, Body),
+        {{<<"204">>, _}, <<"">>} = rest_helper:post(admin, Path, Body),
         Stanza = escalus:wait_for_stanza(Bob),
         is_direct_invitation(Stanza),
         direct_invite_has_reason(Stanza, Reason)
@@ -137,7 +137,7 @@ send_message_to_room(Config) ->
                  body => Message},
         %% The HTTP call in question. Notice: status 200 because no
         %% resource is created.
-        {{<<"204">>, _}, <<"">>} = rest_helper:post(Path, Body),
+        {{<<"204">>, _}, <<"">>} = rest_helper:post(admin, Path, Body),
         Got = escalus:wait_for_stanza(Bob),
         escalus:assert(is_message, Got),
         Message = exml_query:path(Got, [{element, <<"body">>}, cdata])
@@ -176,7 +176,7 @@ kick_user_from_room(Config) ->
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
         %% The HTTP call in question.
-        {{<<"204">>, _}, <<"">>} = rest_helper:delete(Path),
+        {{<<"204">>, _}, <<"">>} = rest_helper:delete(admin, Path),
         BobRoomAddress = muc_helper:room_address(Name, <<"bobcat">>),
         %% Bob finds out he's been kicked.
         KickedStanza = escalus:wait_for_stanza(Bob),
@@ -207,7 +207,7 @@ multiparty_multiprotocol(Config) ->
             false = user_sees_room(Bob, Room),
             %% HTTP: create a room on Alice's behalf.
             {{<<"201">>, _}, Room} =
-                rest_helper:post(MUCPath,
+                rest_helper:post(admin, MUCPath,
                                  #{name => Room,
                                    owner => escalus_client:short_jid(Alice),
                                    nick => <<"ali">>}),
@@ -217,13 +217,13 @@ multiparty_multiprotocol(Config) ->
             true = user_sees_room(Kate, Room),
             %% HTTP: Alice invites Bob to the MUC room.
             {{<<"204">>, _}, <<"">>} =
-                rest_helper:post(RoomInvitePath,
+                rest_helper:post(admin, RoomInvitePath,
                                  invite_body(Alice, Bob, Reason)),
             %% XMPP: Bob recieves the invite to the MUC room.
             Room = wait_for_invite(Bob, Reason),
             %% HTTP: Alice invites Kate to the MUC room.
             {{<<"204">>, _}, <<"">>} =
-                rest_helper:post(RoomInvitePath,
+                rest_helper:post(admin, RoomInvitePath,
                                  invite_body(Alice, Kate, Reason)),
             %% XMPP: kate recieves the invite to the MUC room.
             Room = wait_for_invite(Kate, Reason),
@@ -248,7 +248,7 @@ multiparty_multiprotocol(Config) ->
             [ escalus:wait_for_stanza(User) || User <- [Alice, Bob] ],
             %% HTTP: Alice sends a message to the room.
             {{<<"204">>, _}, <<"">>} =
-                rest_helper:post(MessagePath,
+                rest_helper:post(admin, MessagePath,
                                  #{from => escalus_client:short_jid(Alice),
                                    body => Message}),
             %% XMPP: All three recieve the message sent to the MUC room.

--- a/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
@@ -264,7 +264,7 @@ check_delete_room(Config, RoomNameToCreate, RoomNameToDelete, RoomOwner,
     ShortJID = escalus_client:short_jid(UserToExecuteDelete),
     Path = <<"/muc-lights",$/,Domain/binary,$/,
              RoomNameToDelete/binary,$/,ShortJID/binary,$/,"management">>,
-    rest_helper:delete(Path).
+    rest_helper:delete(admin, Path).
 
 %%--------------------------------------------------------------------
 %% Constants

--- a/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
@@ -94,7 +94,7 @@ create_unique_room(Config) ->
                   owner => escalus_client:short_jid(Alice),
                   subject => <<"Lewis Carol">>
                 },
-        {{<<"201">>, _}, _} = rest_helper:post(Path, Body),
+        {{<<"201">>, _}, _} = rest_helper:post(admin, Path, Body),
         [Item] = get_disco_rooms(Alice),
         MUCLightDomain = muc_light_domain(),
         true = is_room_name(Name, Item),
@@ -113,7 +113,7 @@ create_identifiable_room(Config) ->
                 },
         {{<<"201">>, _},
          <<"just_some_id", $@, MUCLightDomain/binary>>
-        } = rest_helper:putt(Path, Body),
+        } = rest_helper:putt(admin, Path, Body),
         [Item] = get_disco_rooms(Alice),
         MUCLightDomain = muc_light_domain(),
         true = is_room_name(Name, Item),
@@ -140,7 +140,7 @@ invite_to_room(Config) ->
         Body = #{ sender => escalus_client:short_jid(Alice),
                   recipient => escalus_client:short_jid(Bob)
                 },
-        {{<<"204">>, _}, <<"">>} = rest_helper:post(Path, Body),
+        {{<<"204">>, _}, <<"">>} = rest_helper:post(admin, Path, Body),
         %% XMPP: Bob recieves his affiliation information.
         member_is_affiliated(escalus:wait_for_stanza(Bob), Bob),
         %% XMPP: Alice recieves Bob's affiliation infromation.
@@ -168,7 +168,7 @@ send_message_to_room(Config) ->
         Body = #{ from => escalus_client:short_jid(Alice),
                   body => Text
                 },
-        {{<<"204">>, _}, <<"">>} = rest_helper:post(Path, Body),
+        {{<<"204">>, _}, <<"">>} = rest_helper:post(admin, Path, Body),
         %% XMPP: Both Bob and Kate see the message.
         [ see_message_from_user(U, Alice, Text) || U <- [Bob, Kate] ]
     end).

--- a/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
@@ -100,14 +100,14 @@ host() ->
 init_per_suite(Config) ->
     Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host(), Config),
     Config2 = ejabberd_node_utils:init(Config1),
-    ejabberd_node_utils:backup_config_file(Config2),
+    %ejabberd_node_utils:backup_config_file(Config2),
     % Set username and password for blank
     escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     rest_helper:maybe_disable_mam(mam_helper:backend(), host()),
-    ok = ejabberd_node_utils:restore_config_file(Config),
+    %ok = ejabberd_node_utils:restore_config_file(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(auth, Config) ->

--- a/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
@@ -100,14 +100,12 @@ host() ->
 init_per_suite(Config) ->
     Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host(), Config),
     Config2 = ejabberd_node_utils:init(Config1),
-    %ejabberd_node_utils:backup_config_file(Config2),
     % Set username and password for blank
     escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     rest_helper:maybe_disable_mam(mam_helper:backend(), host()),
-    %ok = ejabberd_node_utils:restore_config_file(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(auth, Config) ->

--- a/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
@@ -25,11 +25,11 @@
         [assert_inlist/2,
          assert_notinlist/2,
          decode_maplist/1,
-         gett/1,
+         gett/2,
          post/2,
          putt/2,
          delete/1,
-         gett/2,
+         gett/3,
          post/3,
          putt/3,
          delete/2]
@@ -41,6 +41,7 @@
 -define(NOCONTENT, {<<"204">>, <<"No Content">>}).
 -define(ERROR, {<<"500">>, _}).
 -define(NOT_FOUND, {<<"404">>, _}).
+-define(NOT_AUTHORIZED, {<<"401">>, _}).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -52,16 +53,27 @@
 all() ->
     [
      {group, admin},
-     {group, dynamic_module}
+     {group, dynamic_module},
+     {group, auth},
+     {group, blank_auth}
     ].
 
 groups() ->
     [{admin, [parallel], test_cases()},
+     {auth, [parallel], auth_test_cases()},
+     {blank_auth, [parallel], blank_auth_testcases()},
      {roster, [parallel], [list_contacts,
                              befriend_and_alienate,
                              befriend_and_alienate_auto]},
      {dynamic_module, [], [stop_start_command_module]}
     ].
+
+auth_test_cases() ->
+    [auth_passes_correct_creds,
+     auth_fails_incorrect_creds].
+
+blank_auth_testcases() ->
+    [auth_always_passes_blank_creds].
 
 test_cases() ->
     [commands_are_listed,
@@ -87,16 +99,27 @@ host() ->
 
 init_per_suite(Config) ->
     Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host(), Config),
-    escalus:init_per_suite(Config1).
+    Config2 = ejabberd_node_utils:init(Config1),
+    ejabberd_node_utils:backup_config_file(Config2),
+    % Set username and password for blank
+    escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     rest_helper:maybe_disable_mam(mam_helper:backend(), host()),
     escalus:end_per_suite(Config).
 
+init_per_group(auth, Config) ->
+    rest_helper:change_admin_creds({<<"ala">>, <<"makota">>}),
+    Config;
+init_per_group(blank_auth, Config) ->
+    rest_helper:change_admin_creds(any),
+    Config;
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
+end_per_group(auth, Config) ->
+    rest_helper:change_admin_creds(any);
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob, mike])).
 
@@ -111,48 +134,65 @@ end_per_testcase(CaseName, Config) ->
 %% Tests
 %%--------------------------------------------------------------------
 
+% Authorization
+auth_passes_correct_creds(Config) ->
+    % try to login with the same creds
+    {?OK, _Lcmds} = gett(admin, <<"/commands">>, {<<"ala">>, <<"makota">>}).
+
+auth_fails_incorrect_creds(Config) ->
+    % try to login with different creds
+    {?NOT_AUTHORIZED, _} = gett(admin, <<"/commands">>, {<<"ola">>, <<"mapsa">>}).
+
+auth_always_passes_blank_creds(Config) ->
+    % we set control creds for blank
+    rest_helper:change_admin_creds(any),
+    % try with any auth
+    {?OK, _Lcmds} = gett(admin, <<"/commands">>, {<<"aaaa">>, <<"bbbb">>}),
+    % try with no auth
+    {?OK, _Lcmds} = gett(admin, <<"/commands">>).
+
 commands_are_listed(_C) ->
-    {?OK, Lcmds} = gett(<<"/commands">>),
+    {?OK, Lcmds} = gett(admin, <<"/commands">>),
     DecCmds = decode_maplist(Lcmds),
     assert_inlist(#{name => <<"list_methods">>}, DecCmds).
 
 non_existent_command_returns404(_C) ->
-    {?NOT_FOUND, _} = gett(<<"/isitthereornot">>).
+    {?NOT_FOUND, _} = gett(admin, <<"/isitthereornot">>).
 
 user_can_be_registered_and_removed(_Config) ->
     % list users
-    {?OK, Lusers} = gett(<<"/users/localhost">>),
+    {?OK, Lusers} = gett(admin, <<"/users/localhost">>),
     Domain = domain(),
     assert_inlist(<<"alice@", Domain/binary>>, Lusers),
     % create user
     CrUser = #{username => <<"mike">>, password => <<"nicniema">>},
-    {?CREATED, _} = post(<<"/users/localhost">>, CrUser),
-    {?OK, Lusers1} = gett(<<"/users/localhost">>),
+    {?CREATED, _} = post(admin, <<"/users/localhost">>, CrUser),
+    {?OK, Lusers1} = gett(admin, <<"/users/localhost">>),
     assert_inlist(<<"mike@", Domain/binary>>, Lusers1),
     % try to create the same user
-    {?ERROR, _} = post(<<"/users/localhost">>, CrUser),
+    {?ERROR, _} = post(admin, <<"/users/localhost">>, CrUser),
     % delete user
-    {?NOCONTENT, _} = delete(<<"/users/localhost/mike">>),
-    {?OK, Lusers2} = gett(<<"/users/localhost">>),
+    {?NOCONTENT, _} = delete(admin, <<"/users/localhost/mike">>),
+    {?OK, Lusers2} = gett(admin, <<"/users/localhost">>),
     assert_notinlist(<<"mike@", Domain/binary>>, Lusers2),
     ok.
 
 sessions_are_listed(_) ->
     % no session
-    {?OK, Sessions} = gett("/sessions/localhost"),
+    {?OK, Sessions} = gett(admin, "/sessions/localhost"),
     true = is_list(Sessions).
 
 session_can_be_kicked(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
         % Alice is connected
         Domain = domain(),
-        {?OK, Sessions1} = gett("/sessions/localhost"),
+        {?OK, Sessions1} = gett(admin, "/sessions/localhost"),
         assert_inlist(<<"alice@", Domain/binary, "/res1">>, Sessions1),
         % kick alice
-        {?NOCONTENT, _} = delete("/sessions/localhost/alice/res1"),
+        {?NOCONTENT, _} = delete(admin, "/sessions/localhost/alice/res1"),
         escalus:wait_for_stanza(Alice),
         true = escalus_connection:wait_for_close(Alice, timer:seconds(1)),
-        {?OK, Sessions2} = gett("/sessions/localhost"),
+        {?OK, Sessions2} = gett(admin, "/sessions/localhost"),
         assert_notinlist(<<"alice@", Domain/binary, "/res1">>, Sessions2)
     end).
 
@@ -169,9 +209,9 @@ send_messages(Alice, Bob) ->
         AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
         BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
         M = #{caller => BobJID, to => AliceJID, body => <<"hello from Bob">>},
-        {?NOCONTENT, _} = post(<<"/messages">>, M),
+        {?NOCONTENT, _} = post(admin, <<"/messages">>, M),
         M1 = #{caller => AliceJID, to => BobJID, body => <<"hello from Alice">>},
-        {?NOCONTENT, _} = post(<<"/messages">>, M1),
+        {?NOCONTENT, _} = post(admin, <<"/messages">>, M1),
         {M, M1}.
 
 messages_are_archived(Config) ->
@@ -184,7 +224,7 @@ messages_are_archived(Config) ->
                                  "/", binary_to_list(BobJID),
                                  "?limit=10"]),
         mam_helper:maybe_wait_for_archive(Config),
-        {?OK, Msgs} = gett(GetPath),
+        {?OK, Msgs} = gett(admin, GetPath),
         [Last, Previous|_] = lists:reverse(decode_maplist(Msgs)),
         <<"hello from Alice">> = maps:get(body, Last),
         AliceJID = maps:get(sender, Last),
@@ -195,7 +235,7 @@ messages_are_archived(Config) ->
                                   "/", binary_to_list(AliceJID),
                                   "/", binary_to_list(BobJID)]),
         mam_helper:maybe_wait_for_archive(Config),
-        {?OK, Msgs1} = gett(GetPath1),
+        {?OK, Msgs1} = gett(admin, GetPath1),
         [Last1, Previous1|_] = lists:reverse(decode_maplist(Msgs1)),
         <<"hello from Alice">> = maps:get(body, Last1),
         AliceJID = maps:get(sender, Last1),
@@ -204,7 +244,7 @@ messages_are_archived(Config) ->
         % and we can do the same without specifying contact
         GetPath2 = lists:flatten(["/messages/", binary_to_list(AliceJID)]),
         mam_helper:maybe_wait_for_archive(Config),
-        {?OK, Msgs2} = gett(GetPath2),
+        {?OK, Msgs2} = gett(admin, GetPath2),
         [Last2, Previous2|_] = lists:reverse(decode_maplist(Msgs2)),
         <<"hello from Alice">> = maps:get(body, Last2),
         AliceJID = maps:get(sender, Last2),
@@ -243,7 +283,7 @@ password_can_be_changed(Config) ->
         skip
     end),
     % we change password
-    {?NOCONTENT, _} = putt("/users/localhost/bob",
+    {?NOCONTENT, _} = putt(admin, "/users/localhost/bob",
                            #{newpass => <<"niemakrolika">>}),
     % he logs with his alternative password
     escalus:story(Config, [{bob_altpass, 1}], fun(_Bob) ->
@@ -256,7 +296,7 @@ password_can_be_changed(Config) ->
         ok
     end,
     % we change it back
-    {?NOCONTENT, _} = putt("/users/localhost/bob",
+    {?NOCONTENT, _} = putt(admin, "/users/localhost/bob",
                            #{newpass => <<"makrolika">>}),
     % now he logs again with the regular one
     escalus:story(Config, [{bob, 1}], fun(_Bob) ->
@@ -273,7 +313,7 @@ list_contacts(Config) ->
             BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
             add_sample_contact(Bob, Alice),
             % list bob's contacts
-            {?OK, R} = gett(lists:flatten(["/contacts/",
+            {?OK, R} = gett(client, lists:flatten(["/contacts/",
                                            binary_to_list(BobJID)])),
             [R1] =  decode_maplist(R),
             #{jid := AliceJID, subscription := <<"none">>,
@@ -298,28 +338,28 @@ befriend_and_alienate(Config) ->
             check_roster_empty(AlicePath),
             check_roster_empty(BobPath),
             % adds them to rosters
-            {?NOCONTENT, _} = post(AlicePath, #{jid => BobJID}),
-            {?NOCONTENT, _} = post(BobPath, #{jid => AliceJID}),
+            {?NOCONTENT, _} = post(admin, AlicePath, #{jid => BobJID}),
+            {?NOCONTENT, _} = post(admin, BobPath, #{jid => AliceJID}),
             check_roster(BobPath, AliceJID, none, none),
             check_roster(AlicePath, BobJID, none, none),
             % now do the subscription sequence
             PutPathA = lists:flatten([AlicePath, "/", BobS]),
-            {?NOCONTENT, _} = putt(PutPathA, #{action => <<"subscribe">>}),
+            {?NOCONTENT, _} = putt(admin, PutPathA, #{action => <<"subscribe">>}),
             check_roster(AlicePath, BobJID, none, out),
             PutPathB = lists:flatten([BobPath, "/", AliceS]),
-            {?NOCONTENT, _} = putt(PutPathB, #{action => <<"subscribed">>}),
+            {?NOCONTENT, _} = putt(admin, PutPathB, #{action => <<"subscribed">>}),
             check_roster(AlicePath, BobJID, to, none),
             check_roster(BobPath, AliceJID, from, none),
-            {?NOCONTENT, _} = putt(PutPathB, #{action => <<"subscribe">>}),
+            {?NOCONTENT, _} = putt(admin, PutPathB, #{action => <<"subscribe">>}),
             check_roster(BobPath, AliceJID, from, out),
-            {?NOCONTENT, _} = putt(PutPathA, #{action => <<"subscribed">>}),
+            {?NOCONTENT, _} = putt(admin, PutPathA, #{action => <<"subscribed">>}),
             check_roster(AlicePath, BobJID, both, none),
             check_roster(BobPath, AliceJID, both, none),
             % now remove
-            {?NOCONTENT, _} = delete(PutPathA),
+            {?NOCONTENT, _} = delete(admin, PutPathA),
             check_roster_empty(AlicePath),
             check_roster(BobPath, AliceJID, none, none),
-            {?NOCONTENT, _} = delete(PutPathB),
+            {?NOCONTENT, _} = delete(admin, PutPathB),
             check_roster_empty(BobPath),
             APushes = lists:filter(fun escalus_pred:is_roster_set/1,
                                     escalus:wait_for_stanzas(Alice, 20)),
@@ -364,10 +404,10 @@ befriend_and_alienate_auto(Config) ->
                                      BobS,
                                      "/manage"
             ]),
-            {?NOCONTENT, _} = putt(ManagePath, #{action => <<"connect">>}),
+            {?NOCONTENT, _} = putt(admin, ManagePath, #{action => <<"connect">>}),
             check_roster(AlicePath, BobJID, both, none),
             check_roster(BobPath, AliceJID, both, none),
-            {?NOCONTENT, _} = putt(ManagePath, #{action => <<"disconnect">>}),
+            {?NOCONTENT, _} = putt(admin, ManagePath, #{action => <<"disconnect">>}),
             check_roster_empty(AlicePath),
             check_roster_empty(BobPath),
             APushes = lists:filter(fun escalus_pred:is_roster_set/1,
@@ -394,14 +434,14 @@ befriend_and_alienate_auto(Config) ->
 %%--------------------------------------------------------------------
 
 check_roster(Path, Jid, Subs, Ask) ->
-    {?OK, R} = gett(Path),
+    {?OK, R} = gett(admin, Path),
     S = atom_to_binary(Subs, latin1),
     A = atom_to_binary(Ask, latin1),
     Res = decode_maplist(R),
     [#{jid := Jid, subscription := S, ask := A}] = Res.
 
 check_roster_empty(Path) ->
-    {?OK, R} = gett(Path),
+    {?OK, R} = gett(admin, Path),
     [] = decode_maplist(R).
 
 get_messages(Me, Other, Count) ->
@@ -409,7 +449,7 @@ get_messages(Me, Other, Count) ->
                              binary_to_list(Me),
                              "/", binary_to_list(Other),
                              "?limit=", integer_to_list(Count)]),
-    {?OK, Msgs} = gett(GetPath),
+    {?OK, Msgs} = gett(admin, GetPath),
     Msgs.
 
 get_messages(Me, Other, Before, Count) ->
@@ -418,7 +458,7 @@ get_messages(Me, Other, Before, Count) ->
                              "/", binary_to_list(Other),
                              "?before=", integer_to_list(Before),
                              "&limit=", integer_to_list(Count)]),
-    {?OK, Msgs} = gett(GetPath),
+    {?OK, Msgs} = gett(admin, GetPath),
     Msgs.
 
 stop_start_command_module(_) ->
@@ -428,12 +468,12 @@ stop_start_command_module(_) ->
     %% resource then the same test will succeed. With the precondition
     %% described above we test both transition from `started' to
     %% `stopped' and from `stopped' to `started'.
-    {?OK, _} = gett(<<"/commands">>),
+    {?OK, _} = gett(admin, <<"/commands">>),
     {atomic, ok} = dynamic_modules:stop(host(), mod_commands),
-    {?NOT_FOUND, _} = gett(<<"/commands">>),
+    {?NOT_FOUND, _} = gett(admin, <<"/commands">>),
     ok = dynamic_modules:start(host(), mod_commands, []),
     timer:sleep(200), %% give the server some time to build the paths again
-    {?OK, _} = gett(<<"/commands">>).
+    {?OK, _} = gett(admin, <<"/commands">>).
 
 to_list(V) when is_binary(V) ->
     binary_to_list(V);

--- a/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
@@ -107,6 +107,7 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     rest_helper:maybe_disable_mam(mam_helper:backend(), host()),
+    ok = ejabberd_node_utils:restore_config_file(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(auth, Config) ->
@@ -129,6 +130,7 @@ init_per_testcase(CaseName, Config) ->
 
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
+
 
 %%--------------------------------------------------------------------
 %% Tests

--- a/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_SUITE.erl
@@ -100,7 +100,6 @@ host() ->
 init_per_suite(Config) ->
     Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host(), Config),
     Config2 = ejabberd_node_utils:init(Config1),
-    % Set username and password for blank
     escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->

--- a/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -10,14 +10,14 @@
         [assert_inlist/2,
          assert_notinlist/2,
          decode_maplist/1,
-         gett/1,
-         post/2,
-         putt/2,
-         delete/1,
-         gett/2,
+         gett/3,
          post/3,
          putt/3,
-         delete/2]
+         delete/2,
+         gett/3,
+         post/4,
+         putt/4,
+         delete/3]
          ).
 
 -define(PRT(X, Y), ct:pal("~p: ~p", [X, Y])).
@@ -172,7 +172,7 @@ all_messages_are_archived(Config) ->
         AliceJID = maps:get(to, M1),
         AliceCreds = {AliceJID, user_password(alice)},
         GetPath = lists:flatten("/messages/"),
-        {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(GetPath, AliceCreds),
+        {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(client, GetPath, AliceCreds),
         Received = [_Msg1, _Msg2, _Msg3] = rest_helper:decode_maplist(Msgs),
         assert_messages(Sent, Received)
 
@@ -185,7 +185,7 @@ messages_with_user_are_archived(Config) ->
         KateJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Kate)),
         AliceCreds = {AliceJID, user_password(alice)},
         GetPath = lists:flatten(["/messages/", binary_to_list(KateJID)]),
-        {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(GetPath, AliceCreds),
+        {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(client, GetPath, AliceCreds),
         Recv = [_Msg2] = rest_helper:decode_maplist(Msgs),
         assert_messages([M3], Recv)
 
@@ -316,7 +316,7 @@ only_room_participant_can_read_messages(Config) ->
 get_room_messages(Caller, RoomID) ->
     Path = <<"/rooms/", RoomID/binary, "/messages">>,
     Creds = credentials(Caller),
-    rest_helper:gett(Path, Creds).
+    rest_helper:gett(client, Path, Creds).
 
 messages_can_be_paginated_in_room(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
@@ -390,7 +390,7 @@ assert_room_messages(RecvMsg, {_ID, _GenFrom, GenMsg}) ->
 
 get_room_info(User, RoomID) ->
     Creds = credentials(User),
-    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:gett(<<"/rooms/", RoomID/binary>>,
+    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:gett(client, <<"/rooms/", RoomID/binary>>,
                                                          Creds),
     Result.
 
@@ -414,7 +414,7 @@ given_message_sent_to_room(RoomID, Sender) ->
     {UserJID, _} = Creds = credentials(Sender),
     Path = <<"/rooms/", RoomID/binary, "/messages">>,
     Body = #{body => <<"Hi all!">>},
-    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:post(Path, Body, Creds),
+    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:post(client, Path, Body, Creds),
     MsgId = proplists:get_value(<<"id">>, Result),
     true = is_binary(MsgId),
 
@@ -450,13 +450,13 @@ maybe_wait_for_aff_stanza(_, _) ->
 invite_to_room(Inviter, RoomID, Invitee) ->
     Body = #{user => Invitee},
     Creds = credentials(Inviter),
-    rest_helper:post(<<"/rooms/", RoomID/binary, "/users">>, Body, Creds).
+    rest_helper:post(client, <<"/rooms/", RoomID/binary, "/users">>, Body, Creds).
 
 remove_user_from_a_room(Inviter, RoomID, Invitee) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Invitee)),
     Creds = credentials(Inviter),
     Path = <<"/rooms/", RoomID/binary, "/users/", JID/binary>>,
-    rest_helper:delete(Path, Creds).
+    rest_helper:delete(client, Path, Creds).
 
 credentials({User, ClientOrSpec}) ->
     {user_jid(ClientOrSpec), user_password(User)}.
@@ -477,7 +477,7 @@ send_message(User, From, To) ->
     BobJID = user_jid(To),
     M = #{to => BobJID, body => <<"hello, ", BobJID/binary, " it's me">>},
     Cred = credentials({User, From}),
-    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:post(<<"/messages">>, M, Cred),
+    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:post(client, <<"/messages">>, M, Cred),
     ID = proplists:get_value(<<"id">>, Result),
     M#{id => ID, from => AliceJID}.
 
@@ -488,7 +488,7 @@ get_messages(MeCreds, Other, Count) ->
     get_messages(GetPath, MeCreds).
 
 get_messages(Path, Creds) ->
-    {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(Path, Creds),
+    {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(client, Path, Creds),
     rest_helper:decode_maplist(Msgs).
 
 get_messages(MeCreds, Other, Before, Count) ->
@@ -512,7 +512,7 @@ get_room_messages(Client, RoomID, Count, Before) ->
 create_room({_AliceJID, _} = Creds, RoomName, Subject) ->
     Room = #{name => RoomName,
              subject => Subject},
-    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:post(<<"/rooms">>, Room, Creds),
+    {{<<"200">>, <<"OK">>}, {Result}} = rest_helper:post(client, <<"/rooms">>, Room, Creds),
     proplists:get_value(<<"id">>, Result).
 
 create_room_with_id({_AliceJID, _} = Creds, RoomName, Subject, RoomID) ->
@@ -524,11 +524,11 @@ create_room_with_id_request(Creds, RoomName, Subject, RoomID) ->
     Room = #{name => RoomName,
              subject => Subject},
     Path = <<"/rooms/", RoomID/binary>>,
-    rest_helper:putt(Path, Room, Creds).
+    rest_helper:putt(client, Path, Room, Creds).
 
 get_my_rooms(User) ->
     Creds = credentials(User),
-    {{<<"200">>, <<"OK">>}, Rooms} = rest_helper:gett(<<"/rooms">>, Creds),
+    {{<<"200">>, <<"OK">>}, Rooms} = rest_helper:gett(client, <<"/rooms">>, Creds),
     Rooms.
 
 assert_messages([], []) ->
@@ -644,15 +644,15 @@ add_contact_and_invite(Config) ->
                             escalus_client:short_jid(Alice)),
             BCred = credentials({bob, Bob}),
             % bob has empty roster
-            {?OK, R} = gett("/contacts", BCred),
+            {?OK, R} = gett(client, "/contacts", BCred),
             Res = decode_maplist(R),
             [] = Res,
             % adds Alice
             AddContact = #{jid => AliceJID},
-            {?NOCONTENT, _} = post(<<"/contacts">>, AddContact,
+            {?NOCONTENT, _} = post(client, <<"/contacts">>, AddContact,
                                    BCred),
             % and she is in his roster, with empty status
-            {?OK, R2} = gett("/contacts", BCred),
+            {?OK, R2} = gett(client, "/contacts", BCred),
             Result = decode_maplist(R2),
             [Res2] = Result,
             #{jid := AliceJID, subscription := <<"none">>,
@@ -662,7 +662,7 @@ add_contact_and_invite(Config) ->
             escalus:assert(is_roster_set, Push),
             % he invites her
             PutPath = lists:flatten(["/contacts/", binary_to_list(AliceJID)]),
-            {?NOCONTENT, _} = putt(PutPath,
+            {?NOCONTENT, _} = putt(client, PutPath,
                                    #{action => <<"invite">>},
                                    BCred),
             % another roster push
@@ -673,7 +673,7 @@ add_contact_and_invite(Config) ->
             Sub = escalus:wait_for_stanza(Alice),
             escalus:assert(is_presence_with_type, [<<"subscribe">>], Sub),
             % in his roster she has a changed 'ask' status
-            {?OK, R3} = gett("/contacts", BCred),
+            {?OK, R3} = gett(client, "/contacts", BCred),
             Result3 = decode_maplist(R3),
             [Res3] = Result3,
             #{jid := AliceJID, subscription := <<"none">>,
@@ -692,7 +692,7 @@ add_contact_and_invite(Config) ->
                              <<"subscribed">>)),
             % now check Bob's roster
             timer:sleep(100),
-            {?OK, R4} = gett("/contacts", BCred),
+            {?OK, R4} = gett(client, "/contacts", BCred),
             Result4 = decode_maplist(R4),
             [Res4] = Result4,
             #{jid := AliceJID, subscription := <<"to">>,
@@ -710,15 +710,15 @@ add_contact_and_be_invited(Config) ->
                 escalus_client:short_jid(Alice)),
             BCred = credentials({bob, Bob}),
             % bob has empty roster
-            {?OK, R} = gett("/contacts", BCred),
+            {?OK, R} = gett(client, "/contacts", BCred),
             Res = decode_maplist(R),
             [] = Res,
             % adds Alice
             AddContact = #{jid => AliceJID},
-            {?NOCONTENT, _} = post(<<"/contacts">>, AddContact,
+            {?NOCONTENT, _} = post(client, <<"/contacts">>, AddContact,
                                    BCred),
             % and she is in his roster, with empty status
-            {?OK, R2} = gett("/contacts", BCred),
+            {?OK, R2} = gett(client, "/contacts", BCred),
             Result = decode_maplist(R2),
             [Res2] = Result,
             #{jid := AliceJID, subscription := <<"none">>,
@@ -740,7 +740,7 @@ add_contact_and_be_invited(Config) ->
             escalus:assert(is_presence_with_type, [<<"subscribe">>],
                            escalus:wait_for_stanza(Bob)),
             % now check Bob's roster, and it is the same...
-            {?OK, R4} = gett("/contacts", BCred),
+            {?OK, R4} = gett(client, "/contacts", BCred),
             [Res4] = decode_maplist(R4),
             #{jid := AliceJID, subscription := <<"none">>,
                 ask := <<"in">>} = Res4,
@@ -748,7 +748,7 @@ add_contact_and_be_invited(Config) ->
             % should be hidden from user, we changed it in REST API
             % he accepts
             PutPath = lists:flatten(["/contacts/", binary_to_list(AliceJID)]),
-            {?NOCONTENT, _} = putt(PutPath,
+            {?NOCONTENT, _} = putt(client, PutPath,
                                    #{action => <<"accept">>},
                                    BCred),
             escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob)),
@@ -773,21 +773,21 @@ add_and_remove(Config) ->
             BCred = credentials({bob, Bob}),
             % adds Alice
             AddContact = #{jid => AliceJID},
-            {?NOCONTENT, _} = post(<<"/contacts">>, AddContact,
+            {?NOCONTENT, _} = post(client, <<"/contacts">>, AddContact,
                 BCred),
             Push = escalus:wait_for_stanza(Bob),
             escalus:assert(is_roster_set, Push),
             % and she is in his roster, with empty status
-            {?OK, R2} = gett("/contacts", BCred),
+            {?OK, R2} = gett(client, "/contacts", BCred),
             Result = decode_maplist(R2),
             [Res2] = Result,
             #{jid := AliceJID, subscription := <<"none">>,
               ask := <<"none">>} = Res2,
             % delete user
             DelPath = lists:flatten(["/contacts/", binary_to_list(AliceJID)]),
-            {?NOCONTENT, _} = delete(DelPath, BCred),
+            {?NOCONTENT, _} = delete(client, DelPath, BCred),
             % Bob's roster is empty again
-            {?OK, R3} = gett("/contacts", BCred),
+            {?OK, R3} = gett(client, "/contacts", BCred),
             [] = decode_maplist(R3),
             IsSubscriptionRemove = fun(El) ->
                 Sub = exml_query:paths(El, [{element, <<"query">>},
@@ -810,18 +810,18 @@ break_stuff(Config) ->
                 escalus_client:short_jid(Alice)),
             BCred = credentials({bob, Bob}),
             AddContact = #{jid => AliceJID},
-            {?NOCONTENT, _} = post(<<"/contacts">>, AddContact,
+            {?NOCONTENT, _} = post(client, <<"/contacts">>, AddContact,
                 BCred),
             PutPath = lists:flatten(["/contacts/", binary_to_list(AliceJID)]),
-            {?NOT_IMPLEMENTED, _} = putt(PutPath,
+            {?NOT_IMPLEMENTED, _} = putt(client, PutPath,
                                          #{action => <<"nosuchaction">>},
                                          BCred),
             BadPutPath = "/contacts/zorro@localhost",
-            {?NOT_FOUND, _} = putt(BadPutPath,
+            {?NOT_FOUND, _} = putt(client, BadPutPath,
                                    #{action => <<"invite">>},
                                    BCred),
             BadGetPath = "/contacts/zorro@localhost",
-            {?NOT_FOUND, _} = gett(BadGetPath, BCred),
+            {?NOT_FOUND, _} = gett(client, BadGetPath, BCred),
             ok
         end
     ),

--- a/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_client_SUITE.erl
@@ -18,7 +18,7 @@
          putt/4,
          delete/2,
          delete/3,
-         delete/4,
+         delete/4]
          ).
 
 -define(PRT(X, Y), ct:pal("~p: ~p", [X, Y])).
@@ -777,7 +777,7 @@ add_and_remove(Config) ->
             % adds Alice
             add_contact_check_roster_push(Alice, {bob, Bob}),
             % Check if Contact is in Bob's roster
-            {?OK, R2} = gett("/contacts", BCred),
+            {?OK, R2} = gett(client, "/contacts", BCred),
             Result = decode_maplist(R2),
             [Res2] = Result,
             #{jid := AliceJID, subscription := <<"none">>,
@@ -815,9 +815,9 @@ add_and_remove_some_contacts_properly(Config) ->
             CarolContact = create_contact(CarolJID),
             % delete Alice and Kate
             Body = jiffy:encode(#{<<"to_delete">> => [AliceJID, KateJID]}),
-            {?OK, {[{<<"not_deleted">>,[]}]}} = delete("/contacts", BCred, Body),
+            {?OK, {[{<<"not_deleted">>,[]}]}} = delete(client, "/contacts", BCred, Body),
             % Bob's roster consists now of only Carol
-            {?OK, R4} = gett("/contacts", BCred),
+            {?OK, R4} = gett(client, "/contacts", BCred),
             [CarolContact] = decode_maplist(R4),
             is_subscription_remove(Bob),
             ok
@@ -846,9 +846,9 @@ add_and_remove_some_contacts_with_nonexisting(Config) ->
             CarolContact = create_contact(CarolJID),
             % delete Alice, Kate and Carol (who is absent)
             Body = jiffy:encode(#{<<"to_delete">> => [AliceJID, KateJID, CarolJID]}),
-            {?OK, {[{<<"not_deleted">>,[CarolJID]}]}} = delete("/contacts", BCred, Body),
+            {?OK, {[{<<"not_deleted">>,[CarolJID]}]}} = delete(client, "/contacts", BCred, Body),
             % Bob's roster is empty now
-            {?OK, R4} = gett("/contacts", BCred),
+            {?OK, R4} = gett(client, "/contacts", BCred),
             [] = decode_maplist(R4),
             is_subscription_remove(Bob),
             ok
@@ -864,7 +864,7 @@ add_contact_check_roster_push(Contact, {_, RosterOwnerSpec} = RosterOwner) ->
     ContactJID = escalus_utils:jid_to_lower(
                 escalus_client:short_jid(Contact)),
     RosterOwnerCreds = credentials(RosterOwner),
-    {?NOCONTENT, _} = post(<<"/contacts">>, #{jid => ContactJID},
+    {?NOCONTENT, _} = post(client, <<"/contacts">>, #{jid => ContactJID},
                             RosterOwnerCreds),
     Push = escalus:wait_for_stanza(RosterOwnerSpec),
     escalus:assert(is_roster_set, Push),

--- a/test.disabled/ejabberd_tests/tests/rest_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_helper.erl
@@ -24,6 +24,9 @@
 
 -define(PATHPREFIX, <<"/api">>).
 
+
+-type role() :: admin | client.
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
@@ -89,7 +92,7 @@ putt(Role, Path, Body) ->
 delete(Role, Path) ->
     make_request(Role, <<"DELETE">>, Path).
 
--spec gett(Path :: string()|binary(), Cred :: {Username :: binary(), Password :: binary()}) -> term().
+-spec gett(role(), Path :: string()|binary(), Cred :: {Username :: binary(), Password :: binary()}) -> term().
 gett(Role, Path, Cred) ->
     io:format("in gett: role-~p, path-~p, cred-~p~n", [Role, Path, Cred]),
     make_request(Role, {<<"GET">>, Cred}, Path).
@@ -149,13 +152,12 @@ fusco_request(Method, Path, Body, HeadersIn, Port, SSL) ->
     fusco_cp:stop(Client),
     Result.
 
-% TODO: make a role() type as it is all over the file
--spec get_port(Role :: admin | client) -> Port :: atom().
+-spec get_port(role()) -> Port :: atom().
 get_port(admin) -> 8088;
 get_port(client) -> 8089.
 
-% TODO: Should be fetched from ejabberd.cfg ?!? (Ask Piotr about the SSL staff generally)
--spec get_ssl_status(Role :: admin | client) -> boolean().
+% TODO: Should be fetched from ejabberd.cfg ?!?
+-spec get_ssl_status(role()) -> boolean().
 get_ssl_status(admin) -> false;
 get_ssl_status(client) -> true.
 

--- a/test.disabled/ejabberd_tests/tests/rest_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_helper.erl
@@ -171,10 +171,7 @@ get_ssl_status(Role) ->
 -spec change_admin_creds({User :: binary(), Password :: binary()}) -> 'ok' | 'error'.
 change_admin_creds(Creds) ->
     stop_listener(admin),
-    case start_admin_listener(Creds) of
-	{error, _} -> error;
-	{ok, _} -> ok
-    end.
+    {ok, _} =  start_admin_listener(Creds).
 
 -spec stop_listener(role()) -> 'ok' | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_listener(Role) ->

--- a/test.disabled/ejabberd_tests/tests/rest_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/rest_helper.erl
@@ -155,8 +155,10 @@ get_port(admin) -> 8088;
 get_port(client) -> 8089.
 
 -spec get_ssl_status(role()) -> boolean().
-get_ssl_status(admin) -> false;
-get_ssl_status(client) -> true.
+get_ssl_status(Role) ->
+    Listeners = apply_on_mim1(ejabberd_config, get_local_option, [listen]),
+    [{_PortIpNet, _Module, Opts}] = lists:filter(fun (Opts) -> is_roles_port_ip_net(Opts, Role) end, Listeners),
+    lists:keymember(ssl, 1, Opts).
 
 % @doc Changes the control credentials for admin by restarting the listener
 % with new options.
@@ -170,16 +172,14 @@ change_admin_creds(Creds) ->
 
 -spec stop_listener(role()) -> 'ok' | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_listener(Role) ->
-    Port = get_port(Role),
     Listeners = apply_on_mim1(ejabberd_config, get_local_option, [listen]),
-    [{PortIpNet, Module, _Opts}] = lists:filter(fun is_admin_port_ip_net/1, Listeners),
+    [{PortIpNet, Module, _Opts}] = lists:filter(fun (Opts) -> is_roles_port_ip_net(Opts, Role) end, Listeners),
     apply_on_mim1(ejabberd_listener, stop_listener, [PortIpNet, Module]).
 
 -spec start_admin_listener(Creds :: {binary(), binary()}) -> {'error', pid()} | {'ok', _}.
 start_admin_listener(Creds) ->
-    Port = get_port(admin),
     Listeners = apply_on_mim1(ejabberd_config, get_local_option, [listen]),
-    [{PortIpNet, Module, Opts}] = lists:filter(fun is_admin_port_ip_net/1, Listeners),
+    [{PortIpNet, Module, Opts}] = lists:filter(fun (Opts) -> is_roles_port_ip_net(Opts, admin) end, Listeners),
     NewOpts = insert_creds(Opts, Creds),
     apply_on_mim1(ejabberd_listener, start_listener, [PortIpNet, Module, NewOpts]).
 
@@ -191,8 +191,6 @@ insert_creds(Opts, Creds) ->
     lists:keyreplace(modules, 1, Opts, {modules, NewModules}).
 
 inject_creds_to_opts(PathOpts, any) ->
-    inject_creds_to_opts(PathOpts, {any, any});
-inject_creds_to_opts(PathOpts, {any, any}) ->
     lists:keydelete(auth, 1, PathOpts);
 inject_creds_to_opts(PathOpts, Creds) ->
     case lists:keymember(auth, 1, PathOpts) of
@@ -204,9 +202,9 @@ inject_creds_to_opts(PathOpts, Creds) ->
 
 % @doc Checks whether a tuple is a tuple of {Port, Ip, Net} and
 % port belongs to the admin http api listener.
-is_admin_port_ip_net({{Port, _, _}, ejabberd_cowboy, _opts}) ->
-    Port == get_port(admin);
-is_admin_port_ip_net(_) -> false.
+is_roles_port_ip_net({{Port, _, _}, ejabberd_cowboy, _opts}, Role) ->
+    Port == get_port(Role);
+is_roles_port_ip_net(_, _) -> false.
 
 % @doc Applies a function on a mim1. Waits 5000 ms for response.
 apply_on_mim1(M, F, A) ->


### PR DESCRIPTION
This PR addresses introduces admin http api authorization. 

Changes include:
* Implementing cowboy callback `is_authorized` for mongoose_api_admin
* Extracting common part for client and admin authorization
* Implementing tests for newly implemented feature
* refactoring rest_helper so that it is more general and can be helpful for new tests
