### PR TITLE
MAM documentation fixes

### DIFF
--- a/apps/ejabberd/src/mod_mam_meta.erl
+++ b/apps/ejabberd/src/mod_mam_meta.erl
@@ -107,7 +107,6 @@ parse_backend_opts(cassandra, Type, Opts, Deps0) ->
     case proplists:get_value(user_prefs_store, Opts, false) of
         cassandra -> add_dep(mod_mam_cassandra_prefs, [Type], Deps);
         mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        mnesia_dirty -> add_dep(mod_mam_mnesia_dirty_prefs, [Type], Deps);
         _ -> Deps
     end;
 
@@ -116,7 +115,6 @@ parse_backend_opts(riak, Type, Opts, Deps0) ->
 
     case proplists:get_value(user_prefs_store, Opts, false) of
         mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        mnesia_dirty -> add_dep(mod_mam_mnesia_dirty_prefs, [Type], Deps);
         _ -> Deps
     end;
 
@@ -177,8 +175,6 @@ parse_backend_opt(Type, ModODBCArch, ModAsyncWriter, Option, Deps) ->
             add_dep(mod_mam_odbc_prefs, [Type], Deps);
         {user_prefs_store, mnesia} ->
             add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        {user_prefs_store, mnesia_dirty} ->
-            add_dep(mod_mam_mnesia_dirty_prefs, [Type], Deps);
         {odbc_message_format, simple} ->
             add_dep(ModODBCArch, odbc_simple_opts(), Deps);
         {async_writer, true} ->
@@ -191,4 +187,3 @@ parse_backend_opt(Type, ModODBCArch, ModAsyncWriter, Option, Deps) ->
 
 -spec odbc_simple_opts() -> list().
 odbc_simple_opts() -> [{db_jid_format, mam_jid_rfc}, {db_message_format, mam_message_xml}].
-

--- a/apps/ejabberd/test/cowboy_SUITE_data/ejabberd.onlyhttp.cfg
+++ b/apps/ejabberd/test/cowboy_SUITE_data/ejabberd.onlyhttp.cfg
@@ -646,9 +646,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -715,7 +712,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/cowboy_SUITE_data/ejabberd.onlyws.cfg
+++ b/apps/ejabberd/test/cowboy_SUITE_data/ejabberd.onlyws.cfg
@@ -646,9 +646,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -715,7 +712,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.default.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.default.cfg
@@ -626,9 +626,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -690,7 +687,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.split.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.split.cfg
@@ -643,9 +643,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -707,7 +704,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.cfg
@@ -627,9 +627,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -691,7 +688,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.different_opts.cfg
+++ b/apps/ejabberd/test/ejabberd_config_SUITE_data/ejabberd.with_mod_offline.different_opts.cfg
@@ -627,9 +627,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -691,7 +688,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/mod_mam_meta_SUITE.erl
+++ b/apps/ejabberd/test/mod_mam_meta_SUITE.erl
@@ -133,13 +133,13 @@ example_pm_only_good_performance(_Config) ->
     Deps = deps([
                  cache_users,
                  async_writer,
-                 {user_prefs_store, mnesia_dirty}
+                 {user_prefs_store, mnesia}
                 ]),
 
     check_equal_deps([
                       {mod_mam_odbc_user, [pm]},
                       {mod_mam_cache_user, [pm]},
-                      {mod_mam_mnesia_dirty_prefs, [pm]},
+                      {mod_mam_mnesia_prefs, [pm]},
                       {mod_mam_odbc_arch, [pm, no_writer]},
                       {mod_mam_odbc_async_pool_writer, [pm]},
                       {mod_mam, []}

--- a/apps/ejabberd/test/revproxy_SUITE_data/ejabberd.norules.cfg
+++ b/apps/ejabberd/test/revproxy_SUITE_data/ejabberd.norules.cfg
@@ -646,9 +646,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -715,7 +712,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/apps/ejabberd/test/revproxy_SUITE_data/ejabberd.onerule.cfg
+++ b/apps/ejabberd/test/revproxy_SUITE_data/ejabberd.onerule.cfg
@@ -649,9 +649,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -718,7 +715,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -70,9 +70,9 @@ These options will only have effect when the `odbc` backend is used:
 #### Common backend options
 
 * **user_prefs_store** (atom, default: `false`) - Leaving this option as `false` will prevent users from setting their archiving preferences. It will also increase performance. Other possible values are:
-  * `odbc` (ODBC backend only) - User archiving preferences saved in ODBC. Slow and not recommended, but might be used to simplify things and keep everything in ODBC.
-  * `cassandra` (Cassandra backend only) - User archiving preferences are saved in Cassandra.
-  * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of an inconsistent (in a rather harmless way) state of the preferences table.
+    * `odbc` (ODBC backend only) - User archiving preferences saved in ODBC. Slow and not recommended, but might be used to simplify things and keep everything in ODBC.
+    * `cassandra` (Cassandra backend only) - User archiving preferences are saved in Cassandra.
+    * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of an inconsistent (in a rather harmless way) state of the preferences table.
 * **full_text_search** (boolean, default: `true`) - Enables full text search in message archive (see *Full Text Search* paragraph). Please note that the full text search is currently only implemented for `odbc` and `riak` backends. Also, full text search works only for messages archived while this option is enabled.
 
 #### <a id="is_archivable_message"></a>`is_archivable_message/3` callback
@@ -114,10 +114,10 @@ Edit main config section adding:
 MongooseIM will create one pool with one worker to connect to localhost:9042.
 
 You can change the default settings using extra parameters:
-- 5 connections to each server with addresses from 10.0.0.1 to 10.0.0.4;
-- Keyspace "mongooseim";
-- Custom connect timeout in milliseconds;
-- Custom credentials.
+* 5 connections to each server with addresses from 10.0.0.1 to 10.0.0.4;
+* Keyspace "mongooseim";
+* Custom connect timeout in milliseconds;
+* Custom credentials.
 
 ```erlang
 {cassandra_servers,

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -1,7 +1,7 @@
 ### Module Description
-This module implements [XEP-0313 (Message Archive Management)](http://xmpp.org/extensions/attic/xep-0313.html). 
-It enables a service to store all user messages for one-to-one chats as well as group chats (MUC, MultiUser Chat). 
-It uses [XEP-0059: Result Set Management](http://xmpp.org/extensions/xep-0059.html) for paging. 
+This module implements [XEP-0313 (Message Archive Management)](https://xmpp.org/extensions/xep-0313.html).
+It enables a service to store all user messages for one-to-one chats as well as group chats (MUC, MultiUser Chat).
+It uses [XEP-0059: Result Set Management](http://xmpp.org/extensions/xep-0059.html) for paging.
 It is a highly customizable module, that requires some skill and knowledge to operate properly and efficiently.
 
 Configure MAM with different storage backends:
@@ -14,12 +14,12 @@ Configure MAM with different storage backends:
 `mod_mam_meta` is a meta-module that ensures all relevant `mod_mam_*` modules are loaded and properly configured.
 
 #### Full Text Search
-This module allows message filtering by their text body (if enabled, see *Common backend options*). 
-This means that an XMPP client, while requesting messages from the archive may not only specify standard form fields (`with`, `start`, `end`), but also `full-text-search` (of type `text-single`). 
+This module allows message filtering by their text body (if enabled, see *Common backend options*).
+This means that an XMPP client, while requesting messages from the archive may not only specify standard form fields (`with`, `start`, `end`), but also `full-text-search` (of type `text-single`).
 If this happens, the client will receive only messages that contain words specified in the request.
 
-The exact behaviour, like whether word ordering matters, may depend on the storage backend in use. 
-For now `odbc` backend has very limited support for this feature, while `cassandra` does not support it at all. 
+The exact behaviour, like whether word ordering matters, may depend on the storage backend in use.
+For now `odbc` backend has very limited support for this feature, while `cassandra` does not support it at all.
 `riak` backend on the other hand should provide you with the best results when it comes to text filtering.
 
 ### Options
@@ -41,7 +41,7 @@ MongooseIM will print a warning on startup if `pm` MAM is enabled without `archi
 
 #### MUC-specific options
 
-* **host** (string, default: `"conference.@HOST@"`) - MUC host that will be archived if MUC archiving is enabled. 
+* **host** (string, default: `"conference.@HOST@"`) - MUC host that will be archived if MUC archiving is enabled.
 
 #### Example
 
@@ -62,8 +62,8 @@ The example below presents how to override common option for `muc` module specif
 These options will only have effect when the `odbc` backend is used:
 
 * **cache_users** (boolean, default: `true`) - Enables Archive ID to integer mappings cache.
-* **odbc_message_format** (atom, default: `internal`) - When set to `simple`, stores messages in XML and full JIDs. 
- When set to `internal`, stores messages and JIDs in internal format. 
+* **odbc_message_format** (atom, default: `internal`) - When set to `simple`, stores messages in XML and full JIDs.
+ When set to `internal`, stores messages and JIDs in internal format.
  **Warning**: Archive MUST be empty to change this option.
 * **async_writer** (boolean, default: `true`) - Enables asynchronous writer that is faster than synchronous but harder to debug.
 
@@ -99,7 +99,7 @@ When performing full text search chat markers are treated as if they had empty m
 ### Riak backend
 
 The Riak KV backend for MAM stores messages in weekly buckets so it's easier to remove old buckets.
-Archive querying is done using Riak KV 2.0 [search mechanism](http://docs.basho.com/riak/2.1.1/dev/using/search/) called Yokozuna. 
+Archive querying is done using Riak KV 2.0 [search mechanism](http://docs.basho.com/riak/2.1.1/dev/using/search/) called Yokozuna.
 Your instance of Riak KV must be configured with Yokozuna enabled.
 
 This backend works with Riak KV 2.0 and above, but we recommend version 2.1.1.

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -147,7 +147,7 @@ You can change the default settings using extra parameters:
 {mod_mam_meta, [
         {backend, odbc},
 
-        add_archived_element,
+        {add_archived_element, true},
 
         {pm, [{user_prefs_store, odbc}]},
         {muc, [

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -73,7 +73,6 @@ These options will only have effect when the `odbc` backend is used:
   * `odbc` (ODBC backend only) - User archiving preferences saved in ODBC. Slow and not recommended, but might be used to simplify things and keep everything in ODBC.
   * `cassandra` (Cassandra backend only) - User archiving preferences are saved in Cassandra.
   * `mnesia` (recommended) - User archiving preferences saved in Mnesia and accessed without transactions. Recommended in most deployments, could be overloaded with lots of users updating their preferences at once. There's a small risk of an inconsistent (in a rather harmless way) state of the preferences table.
-  * `mnesia_dirty` - like `mnesia`, but dirty synchronous writes are enabled.
 * **full_text_search** (boolean, default: `true`) - Enables full text search in message archive (see *Full Text Search* paragraph). Please note that the full text search is currently only implemented for `odbc` and `riak` backends. Also, full text search works only for messages archived while this option is enabled.
 
 #### <a id="is_archivable_message"></a>`is_archivable_message/3` callback

--- a/doc/user-guide/ICE_tutorial/ejabberd.cfg
+++ b/doc/user-guide/ICE_tutorial/ejabberd.cfg
@@ -833,8 +833,6 @@
     %% The preferences store will be called each time, as a message is routed.
     %% That is why Mnesia is better suited for this job.
 %   {user_prefs_store, mnesia},
-    %% Mnesia back-end with optimized writes and dirty synchronious writes.
-%   {user_prefs_store, mnesia_dirty},
 
     %% Enables a pool of asynchronous writers. (default)
     %% Messages will be grouped together based on archive id.
@@ -877,7 +875,7 @@
 % {mod_mam_meta, [
 %   {backend, odbc},
 %   {pm, [
-%     {user_prefs_store, mnesia_dirty}
+%     {user_prefs_store, mnesia}
 %   ]}
 % ]},
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -819,8 +819,6 @@
     %% The preferences store will be called each time, as a message is routed.
     %% That is why Mnesia is better suited for this job.
 %   {user_prefs_store, mnesia},
-    %% Mnesia back-end with optimized writes and dirty synchronious writes.
-%   {user_prefs_store, mnesia_dirty},
 
     %% Enables a pool of asynchronous writers. (default)
     %% Messages will be grouped together based on archive id.
@@ -863,7 +861,7 @@
 % {mod_mam_meta, [
 %   {backend, odbc},
 %   {pm, [
-%     {user_prefs_store, mnesia_dirty}
+%     {user_prefs_store, mnesia}
 %   ]}
 % ]},
 

--- a/rel/files/ejabberd.cfg.token-support
+++ b/rel/files/ejabberd.cfg.token-support
@@ -296,9 +296,9 @@
              %% Store the plain passwords or hashed for SCRAM:
              %% {password_format, plain} % default
              %% {password_format, scram}
-             
+
              %% {scram_iterations, 4096} % default
-             
+
              %%
              %% For auth_http:
              %% {host, IP | Hostname}
@@ -686,9 +686,6 @@
   %% That is why, Mnesia is better for this job.
 % {mod_mam_mnesia_prefs, [pm, muc]},
 
-  %% Mnesia back-end with optimized writes and dirty synchronious writes.
-% {mod_mam_mnesia_dirty_prefs, [pm, muc]},
-
   %% A back-end for storing messages.
   %% Synchronious writer (used by default).
   %% This writer is easy to debug, but writing performance is low.
@@ -750,7 +747,7 @@
   %% Only archives for c2c messages, good performance.
 % {mod_mam_odbc_user, [pm]},
 % {mod_mam_cache_user, [pm]},
-% {mod_mam_mnesia_dirty_prefs, [pm]},
+% {mod_mam_mnesia_prefs, [pm]},
 % {mod_mam_odbc_arch, [pm, no_writer]},
 % {mod_mam_odbc_async_pool_writer, [pm]},
 % {mod_mam, []}


### PR DESCRIPTION
The main change of this PR is a removal of `mnesia_dirty` prefs store from documentation **and** `mod_mam_meta` module. I've also fixed the link to MAM XEP (it points to 0.6 though) and took a chance to improve rendering of bullet points (4 spaces make a nested bullet point! 👍 )

