### PR TITLE
Fix #1410

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -76,7 +76,11 @@
                    {template, "rel/files/mongooseimctl",    "bin/mongooseimctl"},
                    {template, "rel/files/app.config",       "etc/app.config"},
                    {template, "rel/files/vm.args",          "etc/vm.args"},
-                   {template, "rel/files/vm.dist.args",     "etc/vm.dist.args"}
+                   {template, "rel/files/vm.dist.args",     "etc/vm.dist.args"},
+
+		   {mkdir, "version"},
+		   {copy, "priv/logo.txt", "version/logo.txt"},
+		   {copy, "VERSION", "version/VERSION"}
                   ]}
 
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -79,7 +79,7 @@
                    {template, "rel/files/vm.dist.args",     "etc/vm.dist.args"},
 
                    {copy, "priv/logo.txt", "priv/logo.txt"},
-		   {copy, "VERSION", "priv/VERSION"}
+                   {copy, "VERSION", "priv/VERSION"}
                   ]}
 
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -78,9 +78,8 @@
                    {template, "rel/files/vm.args",          "etc/vm.args"},
                    {template, "rel/files/vm.dist.args",     "etc/vm.dist.args"},
 
-		   {mkdir, "version"},
-		   {copy, "priv/logo.txt", "version/logo.txt"},
-		   {copy, "VERSION", "version/VERSION"}
+                   {copy, "priv/logo.txt", "priv/logo.txt"},
+		           {copy, "VERSION", "priv/VERSION"}
                   ]}
 
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -79,7 +79,7 @@
                    {template, "rel/files/vm.dist.args",     "etc/vm.dist.args"},
 
                    {copy, "priv/logo.txt", "priv/logo.txt"},
-		           {copy, "VERSION", "priv/VERSION"}
+		   {copy, "VERSION", "priv/VERSION"}
                   ]}
 
        ]}.

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -188,7 +188,6 @@ case "$1" in
         ;;
 
     version)
-        MIM=`ls $RUNNER_BASE_DIR/lib/mongooseim*/ebin/mongooseim.app | head -1`
         if [ $# == 2 ] && [ $2 == '--simple' ]
         then
             cat $RUNNER_BASE_DIR/priv/VERSION

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -191,11 +191,13 @@ case "$1" in
         MIM=`ls $RUNNER_BASE_DIR/lib/mongooseim*/ebin/mongooseim.app | head -1`
         if [ $# == 2 ] && [ $2 == '--simple' ]
         then
-            $NODETOOL version $MIM
+	    cat $RUNNER_BASE_DIR/version/VERSION
+            # $NODETOOL version $MIM
         else
-            cat $RUNNER_BASE_DIR/lib/mongooseim*/priv/logo.txt
+            cat $RUNNER_BASE_DIR/version/logo.txt
             echo -n "MongooseIM version "
-            $NODETOOL version $MIM
+	    cat $RUNNER_BASE_DIR/version/VERSION
+            # $NODETOOL version $MIM
         fi
         ;;
     *)

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -191,11 +191,11 @@ case "$1" in
         MIM=`ls $RUNNER_BASE_DIR/lib/mongooseim*/ebin/mongooseim.app | head -1`
         if [ $# == 2 ] && [ $2 == '--simple' ]
         then
-	    cat $RUNNER_BASE_DIR/priv/VERSION
+            cat $RUNNER_BASE_DIR/priv/VERSION
         else
             cat $RUNNER_BASE_DIR/priv/logo.txt
             echo -n "MongooseIM version "
-	    cat $RUNNER_BASE_DIR/priv/VERSION
+            cat $RUNNER_BASE_DIR/priv/VERSION
         fi
         ;;
     *)

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -191,12 +191,12 @@ case "$1" in
         MIM=`ls $RUNNER_BASE_DIR/lib/mongooseim*/ebin/mongooseim.app | head -1`
         if [ $# == 2 ] && [ $2 == '--simple' ]
         then
-	    cat $RUNNER_BASE_DIR/version/VERSION
+	    cat $RUNNER_BASE_DIR/priv/VERSION
             # $NODETOOL version $MIM
         else
-            cat $RUNNER_BASE_DIR/version/logo.txt
+            cat $RUNNER_BASE_DIR/priv/logo.txt
             echo -n "MongooseIM version "
-	    cat $RUNNER_BASE_DIR/version/VERSION
+	    cat $RUNNER_BASE_DIR/priv/VERSION
             # $NODETOOL version $MIM
         fi
         ;;

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -192,12 +192,10 @@ case "$1" in
         if [ $# == 2 ] && [ $2 == '--simple' ]
         then
 	    cat $RUNNER_BASE_DIR/priv/VERSION
-            # $NODETOOL version $MIM
         else
             cat $RUNNER_BASE_DIR/priv/logo.txt
             echo -n "MongooseIM version "
 	    cat $RUNNER_BASE_DIR/priv/VERSION
-            # $NODETOOL version $MIM
         fi
         ;;
     *)


### PR DESCRIPTION
This PR refactors the way `mongooseim version` command fetches a version and mongoose logo. It is now added to the release under `./priv` folder.