### PR TITLE
[#17433] Saving unicode messages in Mysql

### DIFF
--- a/apps/ejabberd/priv/mysql.sql
+++ b/apps/ejabberd/priv/mysql.sql
@@ -212,7 +212,8 @@ CREATE TABLE mam_message(
   search_body text,
   PRIMARY KEY (user_id, id),
   INDEX i_mam_message_rem USING BTREE (user_id, remote_bare_jid, id)
-)  ENGINE=InnoDB
+)  CHARACTER SET utf8
+   ENGINE=InnoDB
    PARTITION BY HASH(user_id)
    PARTITIONS 32;
 -- Partition is selected based on MOD(user_id, 32)
@@ -300,4 +301,3 @@ CREATE TABLE muc_light_blocking(
 );
 
 CREATE INDEX i_muc_light_blocking USING HASH ON muc_light_blocking(luser, lserver);
-

--- a/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_muc_odbc_arch.erl
@@ -151,7 +151,8 @@ archive_message_unsafe(Host, MessID, RoomID, FromNick, Packet) ->
     SMessID = integer_to_list(MessID),
     TextBody = mod_mam_utils:packet_to_search_body(mod_mam_muc, Host, Packet),
     STextBody = mongoose_rdbms:escape(TextBody),
-    write_message(Host, SMessID, SRoomID, SFromNick, SData, STextBody).
+    BTextBody = unicode:characters_to_binary(STextBody),
+    write_message(Host, SMessID, SRoomID, SFromNick, SData, BTextBody).
 
 
 -spec write_message(ejabberd:server(), string(),
@@ -645,4 +646,3 @@ stored_binary_to_packet(Host, Bin) ->
 -spec db_message_codec(Host :: ejabberd:server()) -> module().
 db_message_codec(Host) ->
     gen_mod:get_module_opt(Host, ?MODULE, db_message_format, mam_message_compressed_eterm).
-

--- a/apps/ejabberd/src/mod_mam_odbc_arch.erl
+++ b/apps/ejabberd/src/mod_mam_odbc_arch.erl
@@ -257,7 +257,8 @@ prepare_message(Host, MessID, UserID, LocJID = #jid{}, RemJID = #jid{lresource =
     SSrcJID = jid_to_stored_binary(Host, LocJID, SrcJID),
     SDir = encode_direction(Dir),
     Data = packet_to_stored_binary(Host, Packet),
-    TextBody = mod_mam_utils:packet_to_search_body(mod_mam, Host, Packet),
+    TextBody0 = mod_mam_utils:packet_to_search_body(mod_mam, Host, Packet),
+    TextBody = unicode:characters_to_binary(TextBody0),
     [MessID, UserID, SBareRemJID, RemLResource, SDir, SSrcJID, Data, TextBody].
 
 -spec prepare_insert(Name :: atom(), NumRows :: pos_integer()) -> ok.
@@ -757,4 +758,3 @@ db_jid_codec(Host) ->
 -spec db_message_codec(ejabberd:server()) -> module().
 db_message_codec(Host) ->
     gen_mod:get_module_opt(Host, ?MODULE, db_message_format, mam_message_compressed_eterm).
-

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -734,7 +734,8 @@ normalize_search_text(Text, WordSeparator) ->
     ReOpts = [{return, list}, global, unicode, ucp],
     Re0 = re:replace(LowerBody, "[, .:;-?!]+", " ", ReOpts),
     Re1 = re:replace(Re0, "([^\\w ]+)|(^\\s+)|(\\s+$)", "", ReOpts),
-    re:replace(Re1, "\s+", WordSeparator, ReOpts).
+    Re2 = re:replace(Re1, "\s+", WordSeparator, ReOpts),
+    unicode:characters_to_binary(Re2).
 
 -spec packet_to_search_body(Module :: mod_mam | mod_mam_muc, Host :: ejabberd:server(),
                             Packet :: xmlel()) -> string().

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -92,7 +92,8 @@
          metric_incremented_on_archive_request/1,
          metric_incremented_when_store_message/1,
          archive_chat_markers/1,
-         dont_archive_chat_markers/1]).
+         dont_archive_chat_markers/1,
+         save_unicode_messages/1]).
 
 -import(muc_helper,
         [muc_host/0,
@@ -312,7 +313,8 @@ text_search_cases() ->
     [
      simple_text_search_request,
      long_text_search_request,
-     text_search_is_available
+     text_search_is_available,
+     save_unicode_messages
     ].
 
 disabled_text_search_cases() ->
@@ -870,6 +872,8 @@ init_per_testcase(C=archive_chat_markers, Config) ->
 init_per_testcase(C=dont_archive_chat_markers, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, Config1);
+init_per_testcase(C=save_unicode_messages, Config) ->
+    skip_if_cassandra(Config, fun() -> escalus:init_per_testcase(C, Config) end);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
@@ -2025,6 +2029,38 @@ dont_archive_chat_markers(Config) ->
         end,
     escalus:story(Config, [{alice, 1}, {bob, 1}], F).
 
+save_unicode_messages(Config) ->
+  P = ?config(props, Config),
+  F = fun(Alice, Bob) ->
+      escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi! this is an unicode character ȥ"/utf8>>)),
+      escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"this is another one ȸ"/utf8>>)),
+      escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"This is the same again ȥ"/utf8>>)),
+      maybe_wait_for_archive(Config),
+
+      %% 'ȥ' query
+      escalus:send(Alice, stanza_text_search_archive_request(P, <<"q1">>, <<"ȥ"/utf8>>)),
+      Res1 = wait_archive_respond(P, Alice),
+      assert_respond_size(2, Res1),
+      assert_respond_query_id(P, <<"q1">>, parse_result_iq(P, Res1)),
+      [Msg1, Msg2] = respond_messages(Res1),
+      #forwarded_message{message_body = Body1} = parse_forwarded_message(Msg1),
+      #forwarded_message{message_body = Body2} = parse_forwarded_message(Msg2),
+      ?assert_equal(<<"Hi! this is an unicode character ȥ"/utf8>>, Body1),
+      ?assert_equal(<<"This is the same again ȥ"/utf8>>, Body2),
+
+      %% 'ȸ' query
+      escalus:send(Alice, stanza_text_search_archive_request(P, <<"q2">>, <<"ȸ"/utf8>>)),
+      Res2 = wait_archive_respond(P, Alice),
+      assert_respond_size(1, Res2),
+      assert_respond_query_id(P, <<"q2">>, parse_result_iq(P, Res2)),
+      [Msg3] = respond_messages(Res2),
+      #forwarded_message{message_body = Body3} = parse_forwarded_message(Msg3),
+      ?assert_equal(<<"this is another one ȸ"/utf8>>, Body3),
+
+      ok
+      end,
+  escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
+
 pagination_empty_rset(Config) ->
     P = ?config(props, Config),
     F = fun(Alice) ->
@@ -2508,5 +2544,3 @@ when_pm_message_is_sent(Sender, Receiver, Body) ->
 
 then_pm_message_is_received(Receiver, Body) ->
     escalus:assert(is_chat_message, [Body], escalus:wait_for_stanza(Receiver)).
-
-


### PR DESCRIPTION
This PR addresses #17433. It saves messages with unicode characteres in MySql. It also allows to search by them when MAM is enabled.

