### PR TITLE
[#17558]: Implement the REST API to delete a MUC Light room.

### DIFF
--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -56,6 +56,9 @@
 -export([standard_config_schema/0, standard_default_config/0, default_host/0]).
 -export([config_schema/1, default_config/1]).
 
+%% For Administration API
+-export([try_to_create_room/3, delete_room/1]).
+
 %% gen_mod callbacks
 -export([start/2, stop/1]).
 
@@ -72,11 +75,7 @@
          is_room_owner/3,
          can_access_room/3,
          can_access_identity/3,
-         muc_room_pid/2,
-         delete_room/1]).
-
-%% For Administration API
--export([try_to_create_room/3]).
+         muc_room_pid/2]).
 
 %% For propEr
 -export([apply_rsm/3]).
@@ -102,6 +101,43 @@ default_config(MUCServer) ->
 -spec config_schema(MUCServer :: ejabberd:lserver()) -> config_schema().
 config_schema(MUCServer) ->
     gen_mod:get_module_opt_by_subhost(MUCServer, ?MODULE, config_schema, undefined).
+
+%%====================================================================
+%% Administration API
+%%====================================================================
+
+-spec try_to_create_room(CreatorUS :: ejabberd:simple_bare_jid(), RoomJID :: ejabberd:jid(),
+                         CreationCfg :: create_req_props()) ->
+    {ok, ejabberd:simple_bare_jid(), create_req_props()}
+    | {error, validation_error() | bad_request | exists}.
+try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = CreationCfg) ->
+    {_RoomU, RoomS} = RoomUS = jid:to_lus(RoomJID),
+    InitialAffUsers = mod_muc_light_utils:filter_out_prevented(
+                        CreatorUS, RoomUS, CreationCfg#create.aff_users),
+    MaxOccupants = gen_mod:get_module_opt_by_subhost(
+                     RoomJID#jid.lserver, ?MODULE, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
+    case {mod_muc_light_utils:process_raw_config(
+            RawConfig, default_config(RoomS), config_schema(RoomS)),
+          process_create_aff_users_if_valid(RoomS, CreatorUS, InitialAffUsers)} of
+        {{ok, Config0}, {ok, FinalAffUsers}} when length(FinalAffUsers) =< MaxOccupants ->
+            Version = mod_muc_light_utils:bin_ts(),
+            case mod_muc_light_db_backend:create_room(
+                   RoomUS, lists:sort(Config0), FinalAffUsers, Version) of
+                {ok, FinalRoomUS} ->
+                    {ok, FinalRoomUS, CreationCfg#create{
+                                        aff_users = FinalAffUsers, version = Version}};
+                Other ->
+                    Other
+            end;
+        {{error, _} = Error, _} ->
+            Error;
+        _ ->
+            {error, bad_request}
+    end.
+
+-spec delete_room(RoomUS :: ejabberd:simple_bare_jid()) -> ok | {error, not_exists}.
+delete_room(RoomUS) ->
+    mod_muc_light_db_backend:destroy_room(RoomUS).
 
 %%====================================================================
 %% gen_mod callbacks
@@ -374,10 +410,6 @@ can_access_identity(_Acc, _Room, _User) ->
     %% 0045 MUC element with user identity and we don't want it
     false.
 
--spec delete_room(RoomUS :: ejabberd:simple_bare_jid()) -> ok | {error, not_exists}.
-delete_room(RoomUS) ->
-    mod_muc_light_db_backend:destroy_room(RoomUS).
-
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -411,35 +443,6 @@ create_room(From, FromUS, To, Create0, OrigPacket) ->
             ErrorText = io_lib:format("~s:~p", tuple_to_list(Error)),
             mod_muc_light_codec_backend:encode_error(
               {error, bad_request, ErrorText}, From, To, OrigPacket, fun ejabberd_router:route/3)
-    end.
-
--spec try_to_create_room(CreatorUS :: ejabberd:simple_bare_jid(), RoomJID :: ejabberd:jid(),
-                         CreationCfg :: create_req_props()) ->
-    {ok, ejabberd:simple_bare_jid(), create_req_props()}
-    | {error, validation_error() | bad_request | exists}.
-try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = CreationCfg) ->
-    {_RoomU, RoomS} = RoomUS = jid:to_lus(RoomJID),
-    InitialAffUsers = mod_muc_light_utils:filter_out_prevented(
-                        CreatorUS, RoomUS, CreationCfg#create.aff_users),
-    MaxOccupants = gen_mod:get_module_opt_by_subhost(
-                     RoomJID#jid.lserver, ?MODULE, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
-    case {mod_muc_light_utils:process_raw_config(
-            RawConfig, default_config(RoomS), config_schema(RoomS)),
-          process_create_aff_users_if_valid(RoomS, CreatorUS, InitialAffUsers)} of
-        {{ok, Config0}, {ok, FinalAffUsers}} when length(FinalAffUsers) =< MaxOccupants ->
-            Version = mod_muc_light_utils:bin_ts(),
-            case mod_muc_light_db_backend:create_room(
-                   RoomUS, lists:sort(Config0), FinalAffUsers, Version) of
-                {ok, FinalRoomUS} ->
-                    {ok, FinalRoomUS, CreationCfg#create{
-                                        aff_users = FinalAffUsers, version = Version}};
-                Other ->
-                    Other
-            end;
-        {{error, _} = Error, _} ->
-            Error;
-        _ ->
-            {error, bad_request}
     end.
 
 -spec process_create_aff_users_if_valid(MUCServer :: ejabberd:lserver(),

--- a/apps/ejabberd/src/mod_muc_light.erl
+++ b/apps/ejabberd/src/mod_muc_light.erl
@@ -72,7 +72,8 @@
          is_room_owner/3,
          can_access_room/3,
          can_access_identity/3,
-         muc_room_pid/2]).
+         muc_room_pid/2,
+         delete_room/1]).
 
 %% For Administration API
 -export([try_to_create_room/3]).
@@ -372,6 +373,10 @@ can_access_identity(_Acc, _Room, _User) ->
     %% User JIDs are explicit in MUC Light but this hook is about appending
     %% 0045 MUC element with user identity and we don't want it
     false.
+
+-spec delete_room(RoomUS :: ejabberd:simple_bare_jid()) -> ok | {error, not_exists}.
+delete_room(RoomUS) ->
+    mod_muc_light_db_backend:destroy_room(RoomUS).
 
 %%====================================================================
 %% Internal functions

--- a/apps/ejabberd/src/mod_muc_light_commands.erl
+++ b/apps/ejabberd/src/mod_muc_light_commands.erl
@@ -185,7 +185,7 @@ send_message(Domain, RoomName, Sender, Message) ->
     end.
 
 -spec delete_room(DomainName :: binary(), RoomName :: binary(),
-                  Sender :: binary()) ->
+                  Owner :: binary()) ->
                          ok | {error, not_exists} | {error, not_allowed}.
 delete_room(DomainName, RoomName, Owner) ->
     OwnerJID = jid:binary_to_bare(Owner),

--- a/apps/ejabberd/src/mod_muc_light_commands.erl
+++ b/apps/ejabberd/src/mod_muc_light_commands.erl
@@ -120,8 +120,7 @@ commands() ->
 
      [{name, delete_room},
       {category, <<"muc-lights">>},
-      {subcategory, <<"messages">>},
-      {desc, <<"Delete a MUC room.">>},
+      {desc, <<"Delete a MUC Light room.">>},
       {module, ?MODULE},
       {function, delete_room},
       {action, delete},

--- a/apps/ejabberd/src/mod_muc_light_commands.erl
+++ b/apps/ejabberd/src/mod_muc_light_commands.erl
@@ -120,6 +120,7 @@ commands() ->
 
      [{name, delete_room},
       {category, <<"muc-lights">>},
+      {subcategory, <<"management">>},
       {desc, <<"Delete a MUC Light room.">>},
       {module, ?MODULE},
       {function, delete_room},

--- a/apps/ejabberd/src/mongoose_commands.erl
+++ b/apps/ejabberd/src/mongoose_commands.erl
@@ -397,6 +397,8 @@ check_and_execute(Caller, Command, Args) ->
     % run command
     Res = apply(Command#mongoose_command.module, Command#mongoose_command.function, Args),
     case Res of
+        {error, not_allowed} ->
+            throw(permission_denied);
         {error, E} ->
             throw({func_returned_error, E});
         _ ->

--- a/doc/http-api/backend_swagger.yml
+++ b/doc/http-api/backend_swagger.yml
@@ -513,6 +513,23 @@ paths:
       responses:
         204:
           description: Message was sent to the MUC Light room
+  /muc-lights/{XMPPHost}/{roomName}/{user}/management:
+    parameters:
+      - $ref: '#/parameters/hostName'
+      - $ref: '#/parameters/roomName'
+      - user: owner
+          in: path
+          description: User's JID (f.e. alice@wonderland.lit)
+          required: true
+          type: string
+          format: JID
+    delete:
+      tags:
+        - "MUC-light management"
+      description: Delete a MUC-light room.
+      responses:
+        204:
+          description: The MUC-light room was deleted.
   /mucs/{XMPPHost}:
     parameters:
       - $ref: '#/parameters/hostName'

--- a/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
@@ -32,22 +32,26 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    [{group, positive}].
+    [{group, positive},
+     {group, negative}].
 
 groups() ->
-    [{positive, [parallel], success_response()}].
+    [{positive, [parallel], success_response()},
+     {negative, [parallel], negative_response()}].
 
 success_response() ->
-    [%create_unique_room,
-     %create_identifiable_room,
-     invite_to_room
-     %send_message_to_room,
-     %delete_room_by_owner,
-     %delete_room_by_non_owner,
-     %delete_non_existent_room,
-     %delete_room_without_having_a_membership
+    [create_unique_room,
+     create_identifiable_room,
+     invite_to_room,
+     send_message_to_room,
+     delete_room_by_owner
     ].
 
+negative_response() ->
+    [delete_room_by_non_owner,
+     delete_non_existent_room,
+     delete_room_without_having_a_membership
+    ].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -259,7 +263,7 @@ check_delete_room(Config, RoomNameToCreate, RoomNameToDelete, RoomOwner,
     [escalus:wait_for_stanza(Member) || Member <- [RoomOwner] ++ RoomMembers],
     ShortJID = escalus_client:short_jid(UserToExecuteDelete),
     Path = <<"/muc-lights",$/,Domain/binary,$/,
-             RoomNameToDelete/binary,$/,ShortJID/binary>>,
+             RoomNameToDelete/binary,$/,ShortJID/binary,$/,"management">>,
     rest_helper:delete(Path).
 
 %%--------------------------------------------------------------------

--- a/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
@@ -32,19 +32,21 @@
 %%--------------------------------------------------------------------
 
 all() ->
-
     [{group, positive}].
 
 groups() ->
-
     [{positive, [parallel], success_response()}].
 
 success_response() ->
-
     [create_unique_room,
      create_identifiable_room,
      invite_to_room,
-     send_message_to_room].
+     send_message_to_room,
+     delete_room_by_owner,
+     delete_room_by_non_owner,
+     delete_non_existent_room,
+     delete_room_without_having_a_membership
+    ].
 
 
 %%--------------------------------------------------------------------
@@ -167,6 +169,47 @@ send_message_to_room(Config) ->
         [ see_message_from_user(U, Alice, Text) || U <- [Bob, Kate] ]
     end).
 
+delete_room_by_owner(Config) ->
+    RoomName = <<"wonderland">>,
+    escalus:fresh_story(Config,
+                        [{alice, 1}, {bob, 1}, {kate, 1}],
+                        fun(Alice, Bob, Kate)->
+                                {{<<"204">>, <<"No Content">>}, <<"">>} =
+                                    check_delete_room(Config, RoomName, RoomName,
+                                                      Alice, [Bob, Kate], Alice)
+                        end).
+
+delete_room_by_non_owner(Config) ->
+    RoomName = <<"wonderland">>,
+    escalus:fresh_story(Config,
+                        [{alice, 1}, {bob, 1}, {kate, 1}],
+                        fun(Alice, Bob, Kate)->
+                                {{<<"403">>, <<"Forbidden">>},
+                                 <<"Command not available for this user">>} = 
+                                    check_delete_room(Config, RoomName, RoomName,
+                                                      Alice, [Bob, Kate], Bob)
+                        end).
+
+delete_non_existent_room(Config) ->
+    RoomName = <<"wonderland">>,
+    escalus:fresh_story(Config,
+                        [{alice, 1}, {bob, 1}, {kate, 1}],
+                        fun(Alice, Bob, Kate)->
+                                {{<<"500">>, _}, _} =
+                                    check_delete_room(Config, RoomName, <<"some_non_existent_room">>,
+                                                      Alice, [Bob, Kate], Alice)
+                        end).
+
+delete_room_without_having_a_membership(Config) ->
+    RoomName = <<"wonderland">>,
+    escalus:fresh_story(Config,
+                        [{alice, 1}, {bob, 1}, {kate, 1}],
+                        fun(Alice, Bob, Kate)->
+                                {{<<"500">>, _}, _} =
+                                    check_delete_room(Config, RoomName, RoomName,
+                                                      Alice, [Bob], Kate)
+                        end).
+
 
 %%--------------------------------------------------------------------
 %% Ancillary (borrowed and adapted from the MUC and MUC Light suites)
@@ -206,6 +249,19 @@ member_is_affiliated(Stanza, User) ->
     MemberJID = escalus_utils:jid_to_lower(escalus_utils:get_short_jid(User)),
     Data = exml_query:path(Stanza, [{element, <<"x">>}, {element, <<"user">>}, cdata]),
     MemberJID == Data.
+
+check_delete_room(Config, RoomNameToCreate, RoomNameToDelete, RoomOwner,
+                  RoomMembers, UserToExecuteDelete) ->
+    Domain = <<"localhost">>,
+    escalus:send(RoomOwner, stanza_create_room(undefined,
+                                           [{<<"roomname">>, RoomNameToCreate}],
+                                           [{Member, member} || Member <- RoomMembers])),
+    [escalus:wait_for_stanza(Member) || Member <- [RoomOwner] ++ RoomMembers],
+    ShortJID = escalus_client:short_jid(UserToExecuteDelete),
+    Path = <<"/muc-lights",$/,Domain/binary,$/,
+             RoomNameToDelete/binary,$/,ShortJID/binary,$/,
+             "messages">>,
+    rest_helper:delete(Path).
 
 %%--------------------------------------------------------------------
 %% Constants

--- a/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_light_http_api_SUITE.erl
@@ -38,14 +38,14 @@ groups() ->
     [{positive, [parallel], success_response()}].
 
 success_response() ->
-    [create_unique_room,
-     create_identifiable_room,
-     invite_to_room,
-     send_message_to_room,
-     delete_room_by_owner,
-     delete_room_by_non_owner,
-     delete_non_existent_room,
-     delete_room_without_having_a_membership
+    [%create_unique_room,
+     %create_identifiable_room,
+     invite_to_room
+     %send_message_to_room,
+     %delete_room_by_owner,
+     %delete_room_by_non_owner,
+     %delete_non_existent_room,
+     %delete_room_without_having_a_membership
     ].
 
 
@@ -259,8 +259,7 @@ check_delete_room(Config, RoomNameToCreate, RoomNameToDelete, RoomOwner,
     [escalus:wait_for_stanza(Member) || Member <- [RoomOwner] ++ RoomMembers],
     ShortJID = escalus_client:short_jid(UserToExecuteDelete),
     Path = <<"/muc-lights",$/,Domain/binary,$/,
-             RoomNameToDelete/binary,$/,ShortJID/binary,$/,
-             "messages">>,
+             RoomNameToDelete/binary,$/,ShortJID/binary>>,
     rest_helper:delete(Path).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses the feature to delete a MUC room via REST API.

Proposed changes include:
* The module ```mod_muc_light_commands.erl``` and ```mod_muc_light.erl``` have been updated with a function to delete a MUC light room.
* New tests have been added to the ```muc_light_http_api_SUITE.erl```

