### PR TITLE
MUCLight - add read only fields to room's configuration

### DIFF
--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -6,20 +6,20 @@ This extension consists of several modules but only `mod_muc_light` needs to be 
 
 ### Options
 
-* **host** (string, default: `"muclight.@HOST@"`) - Domain for the MUC Light service to reside under. 
+* **host** (string, default: `"muclight.@HOST@"`) - Domain for the MUC Light service to reside under.
  `@HOST@` is replaced with each served domain.
-* **backend** (atom, default: `mnesia`) - Database backend to use. 
+* **backend** (atom, default: `mnesia`) - Database backend to use.
  `mnesia` and `odbc` are supported.
-* **equal_occupants** (boolean, default: `false`) - When enabled, MUC Light rooms won't have owners. 
- It means that every occupant will be a `member`, even the room creator. 
- **Warning:** This option does not implicitly set `all_can_invite` to `true`. 
+* **equal_occupants** (boolean, default: `false`) - When enabled, MUC Light rooms won't have owners.
+ It means that every occupant will be a `member`, even the room creator.
+ **Warning:** This option does not implicitly set `all_can_invite` to `true`.
  If that option is set to `false`, nobody will be able to join the room after the initial creation request.
-* **legacy_mode** (boolean, default: `false`) - Enables XEP-0045 compatibility mode. 
+* **legacy_mode** (boolean, default: `false`) - Enables XEP-0045 compatibility mode.
  It allows using a subset of classic MUC stanzas with some MUC Light functions limited.
-* **rooms_per_user** (positive integer or `infinity`, default: `infinity`) - Specifies a cap on a number of rooms a user can occupy. 
+* **rooms_per_user** (positive integer or `infinity`, default: `infinity`) - Specifies a cap on a number of rooms a user can occupy.
  **Warning:** Setting such a limit may trigger expensive DB queries for every occupant addition.
 * **blocking** (boolean, default: `true`) - Blocking feature enabled/disabled.
-* **all_can_configure** (boolean, default: `false`) - When enabled, all room occupants can change all configuration options. 
+* **all_can_configure** (boolean, default: `false`) - When enabled, all room occupants can change all configuration options.
  If disabled, everyone can still the change room subject.
 * **all_can_invite** (boolean, default: `false`) - When enabled, all room occupants can add new occupants to the room.
  Occupants added by `members` become `members` as well.
@@ -27,11 +27,13 @@ This extension consists of several modules but only `mod_muc_light` needs to be 
 * **rooms_per_page** (positive integer or `infinity`, default: 10) - Specifies maximal number of rooms returned for a single Disco request.
 * **rooms_in_rosters** (boolean, default: `false`) - When enabled, rooms the user occupies are included in their roster.
 * **config_schema** (list; see below, default: `["roomname", "subject"]`) - A list of fields allowed in the room configuration.
- The field type may be specified but the default is "binary", i.e. effectively a string. 
+ The field type may be specified but the default is "binary", i.e. effectively a string.
  **WARNING!** Lack of the `roomname` field will cause room names in Disco results and Roster items be set to the room username.
-* **default_config** (list, default: `[{"roomname, "Untitled"}, {"subject", ""}]`) - Custom default room configuration; must be a subset of config schema. 
- It's a list of KV tuples with string keys and values of appriopriate type. 
+* **default_config** (list, default: `[{"roomname, "Untitled"}, {"subject", ""}]`) - Custom default room configuration; must be a subset of config schema.
+ It's a list of KV tuples with string keys and values of appriopriate type.
  String values will be converted to binary automatically.
+* **read_only_config_fields** (list, default: `[]`) - A list of config fields which are read only.
+ A read only field can only be set while creating a room.
 
 ### Config schema
 
@@ -64,6 +66,7 @@ Valid config field types are:
              {rooms_per_page, 5},
              {rooms_in_rosters, true},
              {config_schema, ["roomname", {"display-lines", integer}]},
-             {default_config, [{"roomname", "The Room"}, {"display-lines", 30}]}
+             {default_config, [{"roomname", "The Room"}, {"display-lines", 30}]},
+             {read_only_config_fields, ["display-lines"]}
             ]},
 ```


### PR DESCRIPTION
Proposed changes include:
* ability to define which config fields are read only
* updated doc
* updated tests

A read only field can only be set while creating a room. Later any attempt to modify the filed will have no effect.

