### PR TITLE
Fix format of backend API Swagger docs

### DIFF
--- a/doc/http-api/backend_swagger.yml
+++ b/doc/http-api/backend_swagger.yml
@@ -285,13 +285,6 @@ paths:
         - "Contacts"
       parameters:
         - in: body
-          name: user
-          required: true
-          schema:
-            properties:
-              jid:
-                type: string
-        - in: body
           name: contact
           required: true
           schema:
@@ -349,9 +342,9 @@ paths:
         required: true
         type: string
     put:
-      description: "An administrative action to set roster entries and two-way subscriptions. 
+      description: "An administrative action to set roster entries and two-way subscriptions.
       There are two possible actions: 'connect' sets roster entries and performs subsciption in both ways, thus
-      effectively connecting the two users; 'disconnect' removes them from each other's roster. 
+      effectively connecting the two users; 'disconnect' removes them from each other's roster.
       The operation involves many stages and is not atomic (can succeed partially)."
       tags:
         - "Contacts"
@@ -404,9 +397,6 @@ paths:
           schema:
             title: roomName
             type: string
-  /muc-lights/{XMPPHost}:
-    parameters:
-      - $ref: '#/parameters/hostName'
     put:
       tags:
         - "MUC-light management"
@@ -678,7 +668,7 @@ definitions:
       ask:
         type: string
         description: |
-          Tells whether one of us has asked the other for subscription to presence info and is waiting for approval. 
+          Tells whether one of us has asked the other for subscription to presence info and is waiting for approval.
           Possible states:
           * none
           * out - I asked the contact and am waiting for his approval


### PR DESCRIPTION
This PR fixes a couple of backend API documentation format issues. The docs should now render properly.

Closes #1411

