### PR TITLE
Configurable archiveid element

### DIFF
--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -60,6 +60,7 @@
 
 %% for feature (escalus) tests
 -export([set_params/1]).
+-export([overwrite_params/1]).
 
 %% ----------------------------------------------------------------------
 %% Imports
@@ -931,6 +932,9 @@ params_helper(Params) ->
 
 set_params(Params) ->
     compile_params_module(Params ++ mod_mam_params:params()).
+
+overwrite_params(Params) ->
+    compile_params_module(Params).
 
 %% @doc Enable support for `<archived/>' element from MAM v0.2
 -spec add_archived_element() -> boolean().

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -190,11 +190,11 @@ start(Host, Opts) ->
             ok
     end,
     case gen_mod:get_opt(add_archived_element, Opts, undefined) of
-        true ->
+        undefined -> ok;
+        _ ->
             ?WARNING_MSG("Archived element is going to be deprecated in one of future releases."
                          " It is not recommended to use it."
-                         " Consider using <stanza-id/> element", []);
-        _ -> ok
+                         " Consider using <stanza-id/> element", [])
     end,
 
     compile_params_module(Opts),
@@ -913,14 +913,14 @@ params_helper(Params) ->
           "-module(mod_mam_params).~n"
           "-compile(export_all).~n"
           "add_archived_element() -> ~p.~n"
-          "add_stanzaid_element() -> ~p.~n"
+          "add_stanzaid_element() -> not ~p.~n"
           "is_archivable_message(Mod, Dir, Packet) -> ~p:~p(Mod, Dir, Packet).~n"
           "archive_chat_markers() -> ~p.~n"
           "default_result_limit() -> ~p.~n"
           "max_result_limit() -> ~p.~n"
           "params() -> ~p.~n",
-          [proplists:get_value(add_archived_element, Params, false),
-           proplists:get_value(add_stanzaid_element, Params, true),
+          [proplists:get_bool(add_archived_element, Params),
+           proplists:get_bool(no_stanzaid_element, Params),
            IsArchivableModule, IsArchivableFunction,
            proplists:get_bool(archive_chat_markers, Params),
            proplists:get_value(default_result_limit, Params, 50),

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -195,7 +195,7 @@ start(Host, Opts) ->
         _ ->
             ?WARNING_MSG("Archived element is going to be deprecated in one of future releases."
                          " It is not recommended to use it."
-                         " Consider using <stanza-id/> element instead", [])
+                         " Consider using a <stanza-id/> element instead", [])
     end,
 
     compile_params_module(Opts),

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -194,7 +194,7 @@ start(Host, Opts) ->
         _ ->
             ?WARNING_MSG("Archived element is going to be deprecated in one of future releases."
                          " It is not recommended to use it."
-                         " Consider using <stanza-id/> element", [])
+                         " Consider using <stanza-id/> element instead", [])
     end,
 
     compile_params_module(Opts),

--- a/apps/ejabberd/src/mod_mam_meta.erl
+++ b/apps/ejabberd/src/mod_mam_meta.erl
@@ -86,6 +86,7 @@ mam_type_to_core_mod(muc) -> mod_mam_muc.
 -spec valid_core_mod_opts(module()) -> [atom()].
 valid_core_mod_opts(mod_mam) ->
     [add_archived_element,
+     add_stanzaid_element,
      is_archivable_message,
      archive_chat_markers,
      full_text_search,

--- a/apps/ejabberd/src/mod_mam_meta.erl
+++ b/apps/ejabberd/src/mod_mam_meta.erl
@@ -86,7 +86,7 @@ mam_type_to_core_mod(muc) -> mod_mam_muc.
 -spec valid_core_mod_opts(module()) -> [atom()].
 valid_core_mod_opts(mod_mam) ->
     [add_archived_element,
-     add_stanzaid_element,
+     no_stanzaid_element,
      is_archivable_message,
      archive_chat_markers,
      full_text_search,

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -165,7 +165,7 @@ start(Host, Opts) ->
         _ ->
             ?WARNING_MSG("Archived element is going to be deprecated in one of future releases."
                         " It is not recommended to use it."
-                        " Consider using <stanza-id/> element instead", [])
+                        " Consider using a <stanza-id/> element instead", [])
     end,
     compile_params_module(Opts),
     %% MUC host.

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -54,6 +54,7 @@
 -export([archive_message/8]).
 -export([lookup_messages/2]).
 -export([archive_id_int/2]).
+-export([set_params/1]).
 %% ----------------------------------------------------------------------
 %% Imports
 
@@ -864,11 +865,16 @@ params_helper(Params) ->
           "-compile(export_all).~n"
           "add_archived_element() -> ~p.~n"
           "add_stanzaid_element() -> not ~p.~n"
-          "is_archivable_message(Mod, Dir, Packet) -> ~p:~p(Mod, Dir, Packet).~n",
+          "is_archivable_message(Mod, Dir, Packet) -> ~p:~p(Mod, Dir, Packet).~n"
+          "params() -> ~p.~n",
           [proplists:get_bool(add_archived_element, Params),
            proplists:get_bool(no_stanzaid_element, Params),
-           IsArchivableModule, IsArchivableFunction]),
+           IsArchivableModule, IsArchivableFunction,
+           Params]),
     binary_to_list(iolist_to_binary(Format)).
+
+set_params(Params) ->
+    compile_params_module(Params).
 
 %% @doc Enable support for `<archived/>' element from MAM v0.2
 -spec add_archived_element() -> boolean().

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -164,7 +164,7 @@ start(Host, Opts) ->
         _ ->
             ?WARNING_MSG("Archived element is going to be deprecated in one of future releases."
                         " It is not recommended to use it."
-                        " Consider using <stanza-id/> element", [])
+                        " Consider using <stanza-id/> element instead", [])
     end,
     compile_params_module(Opts),
     %% MUC host.

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -159,6 +159,13 @@ archive_id(SubHost, RoomName) when is_binary(SubHost), is_binary(RoomName) ->
 -spec start(Host :: ejabberd:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
     ?DEBUG("mod_mam_muc starting", []),
+    case gen_mod:get_opt(add_archived_element, Opts, undefined) of
+        undefined -> ok;
+        _ ->
+            ?WARNING_MSG("Archived element is going to be deprecated in one of future releases."
+                        " It is not recommended to use it."
+                        " Consider using <stanza-id/> element", [])
+    end,
     compile_params_module(Opts),
     %% MUC host.
     MUCHost = gen_mod:get_opt_subhost(Host, Opts, mod_muc:default_host()),
@@ -856,10 +863,10 @@ params_helper(Params) ->
           "-module(mod_mam_muc_params).~n"
           "-compile(export_all).~n"
           "add_archived_element() -> ~p.~n"
-          "add_stanzaid_element() -> ~p.~n"
+          "add_stanzaid_element() -> not ~p.~n"
           "is_archivable_message(Mod, Dir, Packet) -> ~p:~p(Mod, Dir, Packet).~n",
-          [proplists:get_value(add_archived_element, Params, false),
-           proplists:get_value(add_stanzaid_element, Params, true),
+          [proplists:get_bool(add_archived_element, Params),
+           proplists:get_bool(no_stanzaid_element, Params),
            IsArchivableModule, IsArchivableFunction]),
     binary_to_list(iolist_to_binary(Format)).
 

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -21,7 +21,8 @@
          wrapper_id/0]).
 
 %% XML
--export([add_arcid_elems/3,
+-export([add_archived_elem/3,
+         add_stanzaid_elem/3,
          is_arcid_elem_for/3,
          replace_arcid_elem/4,
          replace_x_user_element/4,
@@ -229,11 +230,15 @@ external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) ->
 %% -----------------------------------------------------------------------
 %% XML
 
-%% @doc Adds all arcid elements (for backward compatibility)
--spec add_arcid_elems(By :: binary(), Id :: binary(), jlib:xmlel()) -> jlib:xmlel().
-add_arcid_elems(By, Id, Packet) ->
-    WithArchived = replace_arcid_elem(<<"archived">>, By, Id, Packet),
-    replace_arcid_elem(<<"stanza-id">>, By, Id, WithArchived).
+-spec add_archived_elem(binary(), binary(), jlib:xmlel()) ->
+      jlib:xmlel().
+add_archived_elem(By, Id, Packet) ->
+    replace_arcid_elem(<<"archived">>, By, Id, Packet).
+
+-spec add_stanzaid_elem(binary(), binary(), jlib:xmlel()) ->
+      jlib:xmlel().
+add_stanzaid_elem(By, Id, Packet) ->
+    replace_arcid_elem(<<"stanza-id">>, By, Id, Packet).
 
 %% @doc Return true, if the first element points on `By'.
 -spec is_arcid_elem_for(ElemName :: binary(), jlib:xmlel(), By :: binary()) -> boolean().

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -229,8 +229,9 @@ external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) ->
 %% -----------------------------------------------------------------------
 %% XML
 
--spec maybe_add_arcid_elems(To :: binary(), MessID :: binary(), Packet :: jlib:xmlel(),
-                               AddArchived :: boolean(), AddStanzaid :: boolean()) ->
+-spec maybe_add_arcid_elems(To :: ejabberd:simple_jid()  | ejabberd:jid(),
+                            MessID :: binary(), Packet :: jlib:xmlel(),
+                            AddArchived :: boolean(), AddStanzaid :: boolean()) ->
           AlteredPacket :: jlib:xmlel().
 maybe_add_arcid_elems(To, MessID, Packet, AddArchived, AddStanzaid) ->
     BareTo = jid:to_binary(jid:to_bare(To)),

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -21,8 +21,7 @@
          wrapper_id/0]).
 
 %% XML
--export([add_archived_elem/3,
-         add_stanzaid_elem/3,
+-export([maybe_add_arcid_elems/5,
          is_arcid_elem_for/3,
          replace_arcid_elem/4,
          replace_x_user_element/4,
@@ -230,15 +229,22 @@ external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) ->
 %% -----------------------------------------------------------------------
 %% XML
 
--spec add_archived_elem(binary(), binary(), jlib:xmlel()) ->
-      jlib:xmlel().
-add_archived_elem(By, Id, Packet) ->
-    replace_arcid_elem(<<"archived">>, By, Id, Packet).
+-spec maybe_add_arcid_elems(To :: binary(), MessID :: binary(), Packet :: jlib:xmlel(),
+                               AddArchived :: boolean(), AddStanzaid :: boolean()) ->
+          AlteredPacket :: jlib:xmlel().
+maybe_add_arcid_elems(To, MessID, Packet, AddArchived, AddStanzaid) ->
+    BareTo = jid:to_binary(jid:to_bare(To)),
+    WithArchived = case AddArchived of
+                       true ->
+                           replace_arcid_elem(<<"archived">>, BareTo, MessID, Packet);
+                       _ -> Packet
+                   end,
+    case AddStanzaid of
+        true ->
+            replace_arcid_elem(<<"stanza-id">>, BareTo, MessID, WithArchived);
+        _ -> WithArchived
+    end.
 
--spec add_stanzaid_elem(binary(), binary(), jlib:xmlel()) ->
-      jlib:xmlel().
-add_stanzaid_elem(By, Id, Packet) ->
-    replace_arcid_elem(<<"stanza-id">>, By, Id, Packet).
 
 %% @doc Return true, if the first element points on `By'.
 -spec is_arcid_elem_for(ElemName :: binary(), jlib:xmlel(), By :: binary()) -> boolean().

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -25,8 +25,8 @@ For now `odbc` backend has very limited support for this feature, while `cassand
 ### Options
 
 * **backend** (atom, default: `odbc`) - Database backend to use. `odbc`, `riak` and `cassandra` are supported.
-* **add_archived_element** (boolean, default: `false`) - Add `<archived/>` element from MAM v0.2. **Be aware:** The element is going to be deprecated in one of future releases so it's not recommended to enable this option.
-* **no_stanzaid_element** (boolean, default: `false`) - Do not add `<stanza-id/>` element from MAM v0.6.
+* **add_archived_element** (boolean, default: `false`) - Add an `<archived/>` element from MAM v0.2. **Please note:** The element is going to be deprecated in one of future releases so it's not recommended to enable this option.
+* **no_stanzaid_element** (boolean, default: `false`) - Do not add a `<stanza-id/>` element from MAM v0.6.
 * **is_archivable_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_archivable_message/3` callback](#is_archivable_message) that determines if the message should be archived.
  **Warning**: if you are using MUC Light, make sure this option is set to the MUC Light domain.
 * **archive_chat_markers** (boolean, default: `false`) - If set to true, XEP-0333 chat markers will be archived. See more details [here](#archiving-chat-markers)

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -25,14 +25,15 @@ For now `odbc` backend has very limited support for this feature, while `cassand
 ### Options
 
 * **backend** (atom, default: `odbc`) - Database backend to use. `odbc`, `riak` and `cassandra` are supported.
-* **add_archived_element** (boolean, default: `false`) - Add `<archived/>` element from MAM v0.2.
+* **add_archived_element** (boolean, default: `false`) - Add `<archived/>` element from MAM v0.2. **Be aware:** The element is going to be deprecated in one of future releases so it's not recommended to enable this option.
+* **no_stanzaid_element** (boolean, default: `false`) - Do not add `<stanza-id/>` element from MAM v0.6.
 * **is_archivable_message** (module, default: `mod_mam_utils`) - Name of a module implementing [`is_archivable_message/3` callback](#is_archivable_message) that determines if the message should be archived.
  **Warning**: if you are using MUC Light, make sure this option is set to the MUC Light domain.
 * **archive_chat_markers** (boolean, default: `false`) - If set to true, XEP-0333 chat markers will be archived. See more details [here](#archiving-chat-markers)
 * **pm** (list | `false`, default: `[]`) - Override options for archivization of one-to-one messages. If the value of this option is `false`, one-to-one message archive is disabled.
 * **muc** (list | `false`, default: `false`) - Override options for archivization of group chat messages. If the value of this option is `false`, group chat message archive is disabled.
 
-**backend**, **add_archived_element** and **is_archivable_message** will be applied to both `pm` and `muc` (if they are enabled), unless overriden explicitly (see example below).
+**backend**, **add_archived_element**, **no_stanzaid_element** and **is_archivable_message** will be applied to both `pm` and `muc` (if they are enabled), unless overriden explicitly (see example below).
 
 #### PM-specific options
 
@@ -147,7 +148,7 @@ You can change the default settings using extra parameters:
 {mod_mam_meta, [
         {backend, odbc},
 
-        {add_archived_element, true},
+        {no_stanzaid_element, true},
 
         {pm, [{user_prefs_store, odbc}]},
         {muc, [

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -840,7 +840,12 @@
 %   {muc, [
 %     {host, "muc.@HOST@"}
       %% As with pm, top-level options can be overriden for MUC archive
-%   ]}
+%   ]},
+%
+    %% Use <stanza-id/> element (default)
+%   {add_stanzaid_element, true},
+    %% Do not use <archived/> element (default)
+%   {add_archived_element, false}
 % ]},
 
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -842,7 +842,7 @@
       %% As with pm, top-level options can be overriden for MUC archive
 %   ]},
 %
-    %% Do not use <stanza-id/> element (by default stanzaid is used)
+    %% Do not use a <stanza-id/> element (by default stanzaid is used)
 %   no_stanzaid_element,
     %% Use <archived/> element (by default it is not used and not recommended)
 %   add_archived_element

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -842,10 +842,10 @@
       %% As with pm, top-level options can be overriden for MUC archive
 %   ]},
 %
-    %% Use <stanza-id/> element (default)
-%   {add_stanzaid_element, true},
-    %% Do not use <archived/> element (default)
-%   {add_archived_element, false}
+    %% Do not use <stanza-id/> element (by default stanzaid is used)
+%   no_stanzaid_element,
+    %% Uuse <archived/> element (by default it is not used and not recommended)
+%   add_archived_element
 % ]},
 
 

--- a/rel/files/ejabberd.cfg
+++ b/rel/files/ejabberd.cfg
@@ -844,7 +844,7 @@
 %
     %% Do not use <stanza-id/> element (by default stanzaid is used)
 %   no_stanzaid_element,
-    %% Uuse <archived/> element (by default it is not used and not recommended)
+    %% Use <archived/> element (by default it is not used and not recommended)
 %   add_archived_element
 % ]},
 

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -26,7 +26,15 @@
          end_per_testcase/2]).
 
 %% Tests
--export([mam_service_discovery/1,
+-export([no_elements/1,
+         only_stanzaid/1,
+         only_archived/1,
+         both_elements/1,
+         muc_no_elements/1,
+         muc_both_elements/1,
+         muc_only_stanzaid/1,
+         muc_only_archived/1,
+         mam_service_discovery/1,
          muc_service_discovery/1,
          simple_archive_request/1,
          text_search_query_fails_if_disabled/1,
@@ -263,7 +271,8 @@ is_skipped(_, _) ->
 
 
 basic_groups() ->
-    [{mam_all, [parallel],
+    [
+     {mam_all, [parallel],
            [{mam_metrics, [], mam_metrics_cases()},
             {mam02, [parallel], mam_cases() ++ [querying_for_all_messages_with_jid]},
             {mam03, [parallel], mam_cases() ++ [retrieve_form_fields] ++ text_search_cases()},
@@ -272,6 +281,7 @@ basic_groups() ->
             {nostore, [parallel], nostore_cases()},
             {archived, [parallel], archived_cases()},
             {mam_purge, [parallel], mam_purge_cases()},
+            {configurable_archiveid, [], configurable_archiveid_cases()},
             {rsm_all, [parallel],
              [{rsm02,      [parallel], rsm_cases()},
               {rsm03,      [parallel], rsm_cases()},
@@ -286,6 +296,7 @@ basic_groups() ->
             {muc03, [parallel], muc_cases() ++ muc_text_search_cases()},
             {muc04, [parallel], muc_cases() ++ muc_text_search_cases()},
             {muc06, [parallel], muc_cases() ++ muc_stanzaid_cases()},
+            {muc_configurable_archiveid, [], muc_configurable_archiveid_cases()},
             {muc_rsm_all, [parallel],
              [{muc_rsm02, [parallel], muc_rsm_cases()},
               {muc_rsm03, [parallel], muc_rsm_cases()},
@@ -369,6 +380,20 @@ muc_cases() ->
 
 muc_stanzaid_cases() ->
     [muc_message_with_archived_and_stanzaid].
+
+muc_configurable_archiveid_cases() ->
+    [
+     muc_no_elements,
+     muc_both_elements,
+     muc_only_stanzaid,
+     muc_only_archived
+    ].
+
+configurable_archiveid_cases() ->
+    [no_elements,
+     only_stanzaid,
+     only_archived,
+     both_elements].
 
 muc_light_cases() ->
     [
@@ -528,6 +553,10 @@ init_per_group(muc04, Config) ->
 init_per_group(muc06, Config) ->
     [{props, mam06_props()}, {with_rsm, true}|Config];
 
+init_per_group(muc_configurable_archiveid, Config) ->
+    Config ++ [{params_backup, rpc_apply(mod_mam_muc_params, params, [])}];
+init_per_group(configurable_archiveid, Config) ->
+    [{params_backup, rpc_apply(mod_mam_params, params, [])} | Config];
 
 init_per_group(muc_rsm_all, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{N, 1} || N <- user_names()]),
@@ -572,6 +601,14 @@ end_per_group(G, Config) when G == rsm_all; G == mam_purge; G == nostore;
     G == muc06; G == mam06;
     G == archived; G == mam_metrics ->
       Config;
+end_per_group(muc_configurable_archiveid, Config) ->
+    ParamsB = proplists:get_value(params_backup, Config),
+    rpc_apply(mod_mam_muc, set_params, [ParamsB]),
+    Config;
+end_per_group(configurable_archiveid, Config) ->
+    ParamsB = proplists:get_value(params_backup, Config),
+    rpc_apply(mod_mam, overwrite_params, [ParamsB]),
+    Config;
 end_per_group(muc_rsm_all, Config) ->
     destroy_room(Config);
 end_per_group(Group, Config) ->
@@ -828,6 +865,46 @@ init_per_testcase(C=muc_querying_for_all_messages_with_jid, Config) ->
 init_per_testcase(C=muc_archive_request, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=muc_no_elements, Config) ->
+    rpc_apply(mod_mam_muc, set_params,
+              [ [no_stanzaid_element] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=muc_both_elements, Config) ->
+    rpc_apply(mod_mam_muc, set_params,
+              [ [add_archived_element] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=muc_only_stanzaid, Config) ->
+    rpc_apply(mod_mam_muc, set_params,
+              [ [] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=muc_only_archived, Config) ->
+    rpc_apply(mod_mam_muc, set_params,
+              [ [no_stanzaid_element, add_archived_element] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=no_elements, Config) ->
+    rpc_apply(mod_mam, overwrite_params,
+              [ [no_stanzaid_element] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=both_elements, Config) ->
+    rpc_apply(mod_mam, overwrite_params,
+              [ [add_archived_element] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=only_stanzaid, Config) ->
+    rpc_apply(mod_mam, overwrite_params,
+              [ [] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=only_archived, Config) ->
+    rpc_apply(mod_mam, overwrite_params,
+              [ [no_stanzaid_element, add_archived_element] ]),
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
+    escalus:init_per_testcase(C, start_alice_room(Config1));
 init_per_testcase(C=muc_message_with_archived_and_stanzaid, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, start_alice_room(Config1));
@@ -948,6 +1025,18 @@ end_per_testcase(C=muc_querying_for_all_messages_with_jid, Config) ->
 end_per_testcase(C=muc_message_with_archived_and_stanzaid, Config) ->
     destroy_room(Config),
     escalus:end_per_testcase(C, Config);
+end_per_testcase(C=muc_no_elements, Config) ->
+    destroy_room(Config),
+    escalus:end_per_testcase(C, Config);
+end_per_testcase(C=muc_both_elements, Config) ->
+    destroy_room(Config),
+    escalus:end_per_testcase(C, Config);
+end_per_testcase(C=muc_only_stanzaid, Config) ->
+    destroy_room(Config),
+    escalus:end_per_testcase(C, Config);
+end_per_testcase(C=muc_only_archived, Config) ->
+    destroy_room(Config),
+    escalus:end_per_testcase(C, Config);
 end_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config0) ->
     {value, {_, OrigVal}, Config1} = lists:keytake(archive_groupchats_backup, 1, Config0),
     true = escalus_ejabberd:rpc(gen_mod, set_module_opt,
@@ -1031,6 +1120,105 @@ delete_delimiter("_" ++ Tail) ->
 %%--------------------------------------------------------------------
 %% Adhoc tests
 %%--------------------------------------------------------------------
+
+% @doc Helper function, sends an example message to a user and checks
+% if archive id elements are defined or not
+send_and_check_archive_elements(Config, Archived, Stanzaid) ->
+    F = fun(Alice, Bob) ->
+        %% Archive must be empty.
+        %% Alice sends "OH, HAI!" to Bob.
+        escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
+
+        %% Bob receives a message.
+        BobMsg = escalus:wait_for_stanza(Bob),
+        case exml_query:subelement(BobMsg, <<"archived">>) of
+                undefined ->
+                    ?assert_equal(Archived, false);
+                _ ->
+                    ?assert_equal(Archived, true)
+        end,
+        case exml_query:subelement(BobMsg, <<"stanza-id">>) of
+                   undefined ->
+                       ?assert_equal(Stanzaid, false);
+                   _ ->
+                       ?assert_equal(Stanzaid, true)
+        end,
+        ok
+        end,
+    %% Made fresh in init_per_testcase
+    escalus:story(Config, [{alice, 1}, {bob, 1}], F).
+
+% @doc Helper function, sends an example message to a room and checks
+% if archive id elements are defined or not
+muc_send_and_check_archive_elements(Config, Archived, Stanzaid) ->
+    F = fun(Alice, Bob) ->
+        Room = ?config(room, Config),
+        RoomAddr = room_address(Room),
+        Text = <<"Hi, Bob!">>,
+        escalus:send(Alice, stanza_muc_enter_room(Room, nick(Alice))),
+        escalus:send(Bob, stanza_muc_enter_room(Room, nick(Bob))),
+
+        %% Bob received presences.
+        escalus:wait_for_stanzas(Bob, 2),
+
+        %% Bob received the room's subject.
+        escalus:wait_for_stanzas(Bob, 1),
+
+        %% Alice sends another message to Bob.
+        %% The message is not archived by the room.
+        escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
+        escalus:assert(is_message, escalus:wait_for_stanza(Bob)),
+
+        %% Alice sends to the chat room.
+        escalus:send(Alice, escalus_stanza:groupchat_to(RoomAddr, Text)),
+
+        %% Bob received the message "Hi, Bob!".
+        %% This message will be archived (by alicesroom@localhost).
+        %% User's archive is disabled (i.e. bob@localhost).
+        BobMsg = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_message, BobMsg),
+        case exml_query:subelement(BobMsg, <<"archived">>) of
+                undefined ->
+                    ?assert_equal(Archived, false);
+                _ ->
+                    ?assert_equal(Archived, true)
+        end,
+        case exml_query:subelement(BobMsg, <<"stanza-id">>) of
+                   undefined ->
+                       ?assert_equal(Stanzaid, false);
+                   _ ->
+                       ?assert_equal(Stanzaid, true)
+               end,
+        ok
+        end,
+    escalus:story(Config, [{alice, 1}, {bob, 1}], F).
+
+%% Archive id elements should be present when config says so
+muc_no_elements(Config) ->
+    muc_send_and_check_archive_elements(Config, false, false).
+
+muc_both_elements(Config) ->
+    muc_send_and_check_archive_elements(Config, true, true).
+
+muc_only_stanzaid(Config) ->
+    muc_send_and_check_archive_elements(Config, false, true).
+
+muc_only_archived(Config) ->
+    muc_send_and_check_archive_elements(Config, true, false).
+
+no_elements(Config) ->
+    send_and_check_archive_elements(Config, false, false).
+
+both_elements(Config) ->
+    send_and_check_archive_elements(Config, true, true).
+
+only_stanzaid(Config) ->
+    send_and_check_archive_elements(Config, false, true).
+
+only_archived(Config) ->
+    send_and_check_archive_elements(Config, true, false).
+
+
 
 %% Querying the archive for messages
 simple_archive_request(Config) ->

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -1027,8 +1027,7 @@ end_per_testcase(C=muc_message_with_archived_and_stanzaid, Config) ->
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C=muc_no_elements, Config) ->
     timer:sleep(50),
-    A = destroy_room(Config),
-    io:format("destroy: ~p~n", [A]),
+    destroy_room(Config),
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C=muc_both_elements, Config) ->
     timer:sleep(50),

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -1026,15 +1026,20 @@ end_per_testcase(C=muc_message_with_archived_and_stanzaid, Config) ->
     destroy_room(Config),
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C=muc_no_elements, Config) ->
-    destroy_room(Config),
+    timer:sleep(50),
+    A = destroy_room(Config),
+    io:format("destroy: ~p~n", [A]),
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C=muc_both_elements, Config) ->
+    timer:sleep(50),
     destroy_room(Config),
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C=muc_only_stanzaid, Config) ->
+    timer:sleep(50),
     destroy_room(Config),
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C=muc_only_archived, Config) ->
+    timer:sleep(50),
     destroy_room(Config),
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config0) ->


### PR DESCRIPTION
This PR makes archive id elements introduced in XEP 0313 (<stanza-id/> v0.6 and <archived/> v0.2) configurable which means they can be enabled or disabled with the ejabberd.cfg file.


* archived - disabled by default (and warning if someone enables it with suggestion to use stanza-id)
* stanza-id - enabled by default