### PR TITLE
Remove redundancy as default already means optional

### DIFF
--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -41,11 +41,11 @@ Unlike `ejabberd_c2s`, it doesn't use `ejabberd_receiver` or `ejabberd_listener`
 
 ### Configuration
 
-* `ip` (IP tuple, optional, default: `{0,0,0,0}`) - IP address to bind to.
-* `num_acceptors` (positive integer, optional, default: 100) - Number of acceptors.
-* `transport_options` (proplist, optional, default: []) - Ranch-specific transport options.
+* `ip` (IP tuple, default: `{0,0,0,0}`) - IP address to bind to.
+* `num_acceptors` (positive integer, default: 100) - Number of acceptors.
+* `transport_options` (proplist, default: []) - Ranch-specific transport options.
  See [ranch:opt()](https://ninenines.eu/docs/en/ranch/1.2/manual/ranch/#_opt).
-* `protocol_options` (proplist, optional, default: []) - Protocol configuration options for Cowboy.
+* `protocol_options` (proplist, default: []) - Protocol configuration options for Cowboy.
  See [Cowboy protocol manual](https://ninenines.eu/docs/en/cowboy/1.0/manual/cowboy_protocol/)
 * `ssl` (list of ssl options, required for https, no default value) - If specified, https will be used.
  Accepts all ranch_ssl options that don't take fun() parameters.
@@ -147,7 +147,7 @@ Please refer to the [Advanced configuration](../Advanced-configuration.md) for m
  **Warning:** this limit is checked **after** input data parsing, so it does not apply to the input data size itself.
 * `protocol_options` List of supported SSL protocols, default "no_sslv3".
  It also accepts "no_tlsv1" and "no_tlsv1_1"
-* `dhfile` (string, optional, no default value) - Path to the Diffie Hellman parameter file
+* `dhfile` (string, default: no DH file will be used) - Path to the Diffie Hellman parameter file
 
 ## XMPP components: `ejabberd_service`
 

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -16,11 +16,11 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 
 ### Configuration
 
-* `certfile` (string, optional, no default value) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
-* `starttls` (optional, default: disabled) - Enables StartTLS support; requires `certfile`.
-* `starttls_required` (optional, default: disabled) - enforces StartTLS usage.
+* `certfile` (string, default: no certfile will be used) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
+* `starttls` (default: disabled) - Enables StartTLS support; requires `certfile`.
+* `starttls_required` (default: disabled) - enforces StartTLS usage.
 * `zlib` (atom or a positive integer, default: disabled) - Enables ZLIB support, the integer value is a limit for a decompressed output size (to prevent successful [ZLIB bomb attack](http://xmpp.org/resources/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas/)); the limit can be disabled with an atom 'unlimited'.
-* `ciphers` (string, optional, default: as of OpenSSL 1.0.0 it's `ALL:!aNULL:!eNULL` [(source)](https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS)) - cipher suites to use with StartTLS.
+* `ciphers` (string, default: as of OpenSSL 1.0.0 it's `ALL:!aNULL:!eNULL` [(source)](https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS)) - cipher suites to use with StartTLS.
  Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/apps/ciphers.html) for the cipher string format.
 * `access` (atom, default: `c2s`) - Access Rule to use for C2S connections.
 * `c2s_shaper` (atom, default: `c2s_shaper`) - Connection shaper to use for incoming C2S stanzas.
@@ -30,7 +30,7 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 * `max_fsm_queue` (positive integer, the value of this option set global) - message queue limit to prevent resource exhaustion; overrides the global value of this option
 * `protocol_options` List of supported SSL protocols, default "no_sslv3".
  It also accepts "no_tlsv1" and "no_tlsv1_1"
-* `dhfile` (string, optional, no default value) - Path to the Diffie Hellman parameter file
+* `dhfile` (string, default: no DH file will be used) - Path to the Diffie Hellman parameter file
 
 ## HTTP-based services (BOSH, WebSocket, REST): `ejabberd_cowboy`
 

--- a/doc/authentication-backends/HTTP-authentication-module.md
+++ b/doc/authentication-backends/HTTP-authentication-module.md
@@ -23,10 +23,10 @@ The following options can be set in the `auth_opts` tuple in `rel/files/ejabberd
 * `host` (mandatory, `string`) - consists of protocol, hostname (or IP) and port (optional). Examples:
     * `{host, "http://localhost:12000"}`
     * `{host, "https://10.20.30.40"}`
-* `connection_pool_size` (optional, `integer`, default: 10) - the number of connections open to auth service
-* `connection_opts` (optional, default: `[]`) - extra options for hackers: http://erlang.org/doc/man/gen_tcp.html#type-connect_option
-* `basic_auth` (optional, default: `""`) - HTTP Basic Authentication in format `"username:password"`; auth service doesn't have to require authentication for HTTP auth to work
-* `path_prefix` (optional, default: `"/"`) - a path prefix to be inserted between `host` and method name; must be terminated with `/`
+* `connection_pool_size` (`integer`, default: 10) - the number of connections open to auth service
+* `connection_opts` (default: `[]`) - extra options for hackers: http://erlang.org/doc/man/gen_tcp.html#type-connect_option
+* `basic_auth` (default: `""`) - HTTP Basic Authentication in format `"username:password"`; auth service doesn't have to require authentication for HTTP auth to work
+* `path_prefix` (default: `"/"`) - a path prefix to be inserted between `host` and method name; must be terminated with `/`
 
 #### Example
 

--- a/doc/modules/mod_aws_sns.md
+++ b/doc/modules/mod_aws_sns.md
@@ -11,9 +11,9 @@ Full topics for notifications (ARN as defined in [Amazon Resource Names][aws-arn
 
 ### Options
 
-* **presence_updates_topic** (optional, string, default: unset) - Defines Amazon SNS Topic for presence change notifications. Remove this option to disable those notifications.
-* **pm_messages_topic** (optional, string, default: unset) - Defines Amazon SNS Topic for private messages notifications. Remove this option to disable those notifications.
-* **token_muc_messages_topic** (optional, string, default: unset) - Defines Amazon SNS Topic for group messages notifications. Remove this option to disable those notifications.
+* **presence_updates_topic** (string, default: unset) - Defines Amazon SNS Topic for presence change notifications. Remove this option to disable those notifications.
+* **pm_messages_topic** (string, default: unset) - Defines Amazon SNS Topic for private messages notifications. Remove this option to disable those notifications.
+* **token_muc_messages_topic** (string, default: unset) - Defines Amazon SNS Topic for group messages notifications. Remove this option to disable those notifications.
 * **plugin_module** (atom, default: 'mod_aws_sns_defaults') - Sets a callback module used for creating user's GUID used in notifications (from user's JID) and for defining custom attributes attached to a published SNS message.
 * **muc_host** (string, default: "conference.@HOST@") - Messages from this MUC host will be sent to the set SNS topic for MUCs.
 * **sns_host** (string, default: unset) - URL to the Amazon SNS service. The URL may be in [virtual host form][aws-virtual-host], and for AWS needs to point at a specific regional endpoint. The scheme, port and path specified in the URL will be used to publish notifications via HTTP POST method.


### PR DESCRIPTION
This PR attempts to unify the way docs inform about a config option being optional. It's removing the `optional` label when the default values are given. Now each config option entry should be considered optional if it has some `default` value **or** `optional` label (in which case it probably means that something is not activated at all).

The motivation for this PR was a bit of a mess when it comes to marking optional or required options. Sometimes `optional` with `default` was given, sometimes only `default` etc.