### PR TITLE
[skip ci] replicate Tide graph

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -34,6 +34,8 @@ Check out our test results:
 
 * Continuous integration: [https://travis-ci.org/esl/MongooseIM](https://travis-ci.org/esl/MongooseIM)
 * Code coverage: [https://coveralls.io/github/esl/MongooseIM](https://coveralls.io/github/esl/MongooseIM)
+* Load test history:  
+  ![Load test history](http://tide.erlang-solutions.com/charts/bidaily_last_year.png)
 * Stay tuned... more soon!
 
 ## MongooseIM platform components


### PR DESCRIPTION
The TTD graph of Tide was only on /README.md
