### PR TITLE
Fix routing messages to bare jids

### DIFF
--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -789,7 +789,7 @@ route_message(From, To, Acc, Packet) ->
               %% positive
               fun({Prio, Pid}) when Prio == Priority ->
                  %% we will lose message if PID is not alive
-                      Pid ! {route, From, To, mongoose_acc:strip(Acc)};
+                      Pid ! {route, From, To, mongoose_acc:strip(Acc, Packet)};
                  %% Ignore other priority:
                  ({_Prio, _Pid}) ->
                       ok

--- a/test.disabled/ejabberd_tests/default.spec
+++ b/test.disabled/ejabberd_tests/default.spec
@@ -11,6 +11,7 @@
 %% do not remove below SUITE if testing mongoose
 {suites, "tests", mongoose_sanity_checks_SUITE}.
 
+{suites, "tests", acc_e2e_SUITE}.
 {suites, "tests", adhoc_SUITE}.
 {suites, "tests", amp_big_SUITE}.
 {suites, "tests", anonymous_SUITE}.

--- a/test.disabled/ejabberd_tests/tests/acc_e2e_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/acc_e2e_SUITE.erl
@@ -75,8 +75,9 @@ init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(message, Config) ->
-    remove_handler(c2s_preprocessing_hook, test_preprocess, 50),
+    remove_handler(c2s_preprocessing_hook, test_save_acc, 50),
     remove_handler(filter_local_packet, test_check_acc, 50),
+    remove_handler(user_receive_packet, test_check_final_acc, 50),
     escalus:delete_users(Config, escalus:get_users([alice, bob]));
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob])).

--- a/test.disabled/ejabberd_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
@@ -1,7 +1,7 @@
 -module(acc_test_helper).
--compile(export_all).
 -author("bartek").
 
+-compile(export_all).
 
 test_save_acc(#{type := <<"chat">>} = Acc, _State) ->
     Rand = rand:uniform(),
@@ -45,4 +45,11 @@ check_acc(_Acc) -> ok.
 check_acc(Acc, stripped) ->
     undefined = mongoose_acc:get(should_be_stripped, Acc, undefined),
     check_acc(Acc).
+
+alter_message({From, To, Acc, Packet}) ->
+    % Not using #xmlel as it causes some strange error in dynamic compilation
+    {xmlel, PName, PAttrs, PCh} = Packet,
+    NewBody = {xmlel, <<"body">>, [], [{xmlcdata, <<"bye">> }]},
+    PCh2 = lists:keyreplace(<<"body">>, 2, PCh, NewBody),
+    {From, To, Acc, {xmlel, PName, PAttrs, PCh2}}.
 


### PR DESCRIPTION
The `Packet` has to be passed to mongoose_acc:strip in this case.
Otherwise the recipient will get the original stanza from Acc which
may not be correct.
Simple case to reproduce:
1. `User A` sends and IQ to MongooseIM
2. This IQ results in a `message` stanza to `User B` (bare jid)
3. Withtout this change `User B` recieves the IQ sent by `User A`
