### PR TITLE
Make s2s files pass elivs checks

### DIFF
--- a/apps/ejabberd/src/ejabberd_s2s_out.erl
+++ b/apps/ejabberd/src/ejabberd_s2s_out.erl
@@ -413,7 +413,7 @@ wait_for_validation({xmlstreamelement, El}, StateData) ->
                     send_event(Type, Pid, StateData),
                     NextState = wait_for_validation,
                     {next_state, NextState, StateData,
-                     get_timeout_interval(NextState)}.
+                     get_timeout_interval(NextState)}
 
             end;
         _ ->


### PR DESCRIPTION
This PR improves s2s modules code style in order to make the modules pass Elvis checks.

Changes that was made:
* decrease nesting level in some functions
* remove if expressions
* improve spec
* remove macros from function calls
* cosmetic changes (too long lines, indentation)

