### PR TITLE
Fix complete attribute calculation for backward pagination in MAM

### DIFF
--- a/apps/ejabberd/src/mam_iq.erl
+++ b/apps/ejabberd/src/mam_iq.erl
@@ -126,15 +126,19 @@ form_to_lookup_params(QueryEl) ->
     is_simple => mod_mam_utils:form_decode_optimizations(QueryEl)}.
 
 common_lookup_params(QueryEl) ->
+    RSM = mam_iq:fix_rsm(jlib:rsm_decode(QueryEl)),
     Limit = mam_iq:elem_to_limit(QueryEl),
     #{now => p1_time_compat:system_time(micro_seconds),
-      rsm => mam_iq:fix_rsm(jlib:rsm_decode(QueryEl)),
+      rsm => RSM,
       max_result_limit => mod_mam_params:max_result_limit(),
       page_size => min(mod_mam_params:max_result_limit(),
                        mod_mam_utils:maybe_integer(Limit, mod_mam_params:default_result_limit())),
-      limit_passed => Limit =/= <<>>}.
+      limit_passed => Limit =/= <<>>,
+      ordering_direction => ordering_direction(RSM)}.
 
 lookup_params_with_archive_details(Params, ArcID, ArcJID) ->
     Params#{archive_id => ArcID,
             owner_jid => ArcJID}.
 
+ordering_direction(#rsm_in{direction = before}) -> backward;
+ordering_direction(_) -> forward.

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -93,7 +93,7 @@
 %% Other
 -import(mod_mam_utils,
         [mess_id_to_external_binary/1,
-         is_last_page/4]).
+         is_last_page/5]).
 
 %% ejabberd
 -import(mod_mam_utils,
@@ -549,7 +549,7 @@ handle_set_message_form(#jid{} = From, #jid{} = ArcJID,
                 end, MessageRows),
 
             %% Make fin message
-            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows),
+            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows, Params),
             IsStable = true,
             ResultSetEl = result_set(FirstMessID, LastMessID, Offset, TotalCount),
             FinMsg = make_fin_message(IQ#iq.xmlns, IsLastPage, IsStable, ResultSetEl, QueryID),
@@ -572,7 +572,7 @@ handle_set_message_form(#jid{} = From, #jid{} = ArcJID,
                 end, MessageRows),
 
             %% Make fin iq
-            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows),
+            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows, Params),
             IsStable = true,
             ResultSetEl = result_set(FirstMessID, LastMessID, Offset, TotalCount),
             FinElem = make_fin_element(IQ#iq.xmlns, IsLastPage, IsStable, ResultSetEl),

--- a/apps/ejabberd/src/mod_mam_muc.erl
+++ b/apps/ejabberd/src/mod_mam_muc.erl
@@ -88,7 +88,7 @@
 %% Other
 -import(mod_mam_utils,
         [mess_id_to_external_binary/1,
-         is_last_page/4]).
+         is_last_page/5]).
 
 %% ejabberd
 -import(mod_mam_utils,
@@ -527,7 +527,7 @@ handle_set_message_form(#jid{} = From, #jid{} = ArcJID,
              || Row <- MessageRows],
 
             %% Make fin message
-            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows),
+            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows, Params),
             IsStable = true,
             ResultSetEl = result_set(FirstMessID, LastMessID, Offset, TotalCount),
             FinMsg = make_fin_message(IQ#iq.xmlns, IsLastPage, IsStable, ResultSetEl, QueryID),
@@ -550,7 +550,7 @@ handle_set_message_form(#jid{} = From, #jid{} = ArcJID,
              || Row <- MessageRows],
 
             %% Make fin iq
-            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows),
+            IsLastPage = is_last_page(PageSize, TotalCount, Offset, MessageRows, Params),
             IsStable = true,
             ResultSetEl = result_set(FirstMessID, LastMessID, Offset, TotalCount),
             FinElem = make_fin_element(IQ#iq.xmlns, IsLastPage, IsStable, ResultSetEl),

--- a/apps/ejabberd/src/mod_mam_utils.erl
+++ b/apps/ejabberd/src/mod_mam_utils.erl
@@ -80,7 +80,7 @@
          calculate_msg_id_borders/3,
          calculate_msg_id_borders/4,
          maybe_encode_compact_uuid/2,
-         is_last_page/4]).
+         is_last_page/5]).
 
 %% Ejabberd
 -export([send_message/3,
@@ -963,11 +963,21 @@ maybe_previous_id(X) ->
     X - 1.
 
 
--spec is_last_page(PageSize, TotalCount, Offset, MessageRows) -> boolean() when
+-spec is_last_page(PageSize, TotalCount, Offset, MessageRows, RSM) ->
+        boolean() when
     PageSize    :: non_neg_integer(),
     TotalCount  :: non_neg_integer()|undefined,
     Offset      :: non_neg_integer()|undefined,
-    MessageRows :: list().
+    MessageRows :: list(),
+    RSM         :: map().
+is_last_page(PageSize, TotalCount, Offset, MessageRows, Params) ->
+    case maps:get(ordering_direction, Params, forward) of
+        forward ->
+            is_last_page(PageSize, TotalCount, Offset, MessageRows);
+        backward ->
+            Offset =:= 0
+   end.
+
 is_last_page(PageSize, _TotalCount, _Offset, MessageRows)
     when length(MessageRows) < PageSize ->
     true;


### PR DESCRIPTION
This PR addresses fixes "complete" attribute when paginating through results sorted backward.

- What does "complete" attribute do?
- It says the client when to stop sending requests asking for more data.

Proposed changes include:
* attribute "complete" is set correctly.

Behaviour after: Complete attribute can be used to detect if the extracted page is the last one IN THE RESULT SET.
Behaviour before: Complete attribute can be used to detect if the extracted page is the last page (contains most recent data). So, the flag was broken when paginating in the backward direction.

From MAM XEP:

>When the results returned by the server are complete (that is: when they are the last page of the result set), the server MUST include a 'complete' attribute on the <fin> element, with a value of 'true'. If it is not the last page of the result set, the server MUST either omit the 'complete' attribute, or give it a value of 'false'.
