### PR TITLE
Use mongoose_acc in mod_amp

### DIFF
--- a/apps/ejabberd/include/amp.hrl
+++ b/apps/ejabberd/include/amp.hrl
@@ -4,6 +4,8 @@
 %% @copyright 2014 Erlang Solutions, Ltd.
 %% This work was sponsored by Grindr LLC
 
+-include_lib("exml/include/exml.hrl").
+
 -define(NS_AMP, <<"http://jabber.org/protocol/amp">>).
 -define(NS_AMP_FEATURE, <<"http://jabber.org/feature/amp">>).
 
@@ -11,7 +13,9 @@
 -record(amp_rule, {
           condition :: amp_condition(),
           value     :: amp_value(),
-          action    :: amp_action()
+          action    :: amp_action(),
+          element   :: #xmlel{} | undefined,
+          result    :: amp_match_result() | undefined
          }).
 
 %% @doc This includes all well-formed but nonsensical rules, like:

--- a/apps/ejabberd/src/amp.erl
+++ b/apps/ejabberd/src/amp.erl
@@ -12,6 +12,7 @@
 -export([extract_requested_rules/1,
          make_response/3,
          make_error_response/4,
+         update_rules/2,
          rule_to_xmlel/1,
          strip_amp_el/1,
 
@@ -109,6 +110,13 @@ make_error_el(Errors, Rules) ->
            attrs = [{<<"type">>, <<"modify">>},
                     {<<"code">>, error_code(hd(Errors))}],
            children = [ErrorMarker, RuleContainer]}.
+
+-spec update_rules(#xmlel{}, [amp_rule()]) -> #xmlel{}.
+update_rules(Packet = #xmlel{children = Children}, Rules) ->
+    Packet#xmlel{children = [case is_amp_el(El) of
+                                 true -> El#xmlel{children = [rule_to_xmlel(R) || R <- Rules]};
+                                 false -> El
+                             end || El <- Children]}.
 
 -spec rule_to_xmlel(amp_any_rule()) -> #xmlel{}.
 rule_to_xmlel(#amp_rule{condition=C, value=V, action=A}) ->

--- a/apps/ejabberd/src/amp.erl
+++ b/apps/ejabberd/src/amp.erl
@@ -12,7 +12,6 @@
 -export([extract_requested_rules/1,
          make_response/3,
          make_error_response/4,
-         update_rules/2,
          rule_to_xmlel/1,
          strip_amp_el/1,
 
@@ -110,13 +109,6 @@ make_error_el(Errors, Rules) ->
            attrs = [{<<"type">>, <<"modify">>},
                     {<<"code">>, error_code(hd(Errors))}],
            children = [ErrorMarker, RuleContainer]}.
-
--spec update_rules(#xmlel{}, [amp_rule()]) -> #xmlel{}.
-update_rules(Packet = #xmlel{children = Children}, Rules) ->
-    Packet#xmlel{children = [case is_amp_el(El) of
-                                 true -> El#xmlel{children = [rule_to_xmlel(R) || R <- Rules]};
-                                 false -> El
-                             end || El <- Children]}.
 
 -spec rule_to_xmlel(amp_any_rule()) -> #xmlel{}.
 rule_to_xmlel(#amp_rule{condition=C, value=V, action=A}) ->

--- a/apps/ejabberd/src/amp_resolver.erl
+++ b/apps/ejabberd/src/amp_resolver.erl
@@ -37,12 +37,8 @@ resolve(#amp_strategy{deliver = Values}, #amp_rule{condition = deliver, value = 
         true -> undecided;
         false -> no_match
     end;
-resolve(#amp_strategy{deliver = Values}, #amp_rule{condition = deliver, value = Value, action = Action})
-  when is_list(Values), Action == drop orelse Action == error, Value /= none ->
-    case lists:member(Value, Values) of
-        true -> match;
-        false -> no_match
-    end;
+resolve(#amp_strategy{deliver = [Value | _]}, #amp_rule{condition = deliver, value = Value, action = Action})
+  when Action == drop orelse Action == error -> match;
 resolve(#amp_strategy{'match-resource' = Value}, #amp_rule{condition = 'match-resource', value = any})
   when Value /= undefined -> match;
 resolve(#amp_strategy{'match-resource' = Value}, #amp_rule{condition = 'match-resource', value = Value}) ->

--- a/apps/ejabberd/src/amp_strategy.erl
+++ b/apps/ejabberd/src/amp_strategy.erl
@@ -43,7 +43,7 @@ deliver_strategy({offline, []}, initial_check) -> [none];
 deliver_strategy({_Session, _ }, initial_check) -> [direct, none];
 deliver_strategy({offline, []}, archived) -> [stored];
 deliver_strategy({_Session, _}, archived) -> [direct, stored];
-deliver_strategy(_, delivery_failed) -> [none];
+deliver_strategy(_, delivery_failed) -> [stored, none];
 deliver_strategy({offline, []}, mam_failed) -> [none];
 deliver_strategy({_Session, _}, mam_failed) -> [direct, none];
 deliver_strategy(_, offline_failed) -> [none];

--- a/apps/ejabberd/src/ejabberd_sm.erl
+++ b/apps/ejabberd/src/ejabberd_sm.erl
@@ -822,8 +822,7 @@ route_message_by_type(_, From, To, Acc, Packet) ->
                         Acc,
                         [From, To, Packet]);
                 false ->
-                    ejabberd_hooks:run_fold(failed_to_store_message,
-                        LServer, Packet, [From]),
+                    ejabberd_hooks:run_fold(failed_to_store_message, LServer, Acc, []),
                     ok
             end;
         _ ->

--- a/apps/ejabberd/src/mod_amp.erl
+++ b/apps/ejabberd/src/mod_amp.erl
@@ -8,13 +8,11 @@
 -behavior(gen_mod).
 -xep([{xep, 79}, {version, "1.2"}, {comment, "partially implemented."}]).
 -export([start/2, stop/1]).
--export([check_packet/2,
-         check_packet/3,
-         add_local_features/5,
-         add_stream_feature/2,
+-export([
          run_initial_check/2,
-         amp_check_packet/3,
-         strip_amp_el_from_request/1
+         check_packet/2,
+         add_local_features/5,
+         add_stream_feature/2
         ]).
 
 -include_lib("ejabberd/include/amp.hrl").
@@ -39,56 +37,25 @@ hooks(Host) ->
     [{c2s_stream_features, Host, ?MODULE, add_stream_feature, 50},
      {disco_local_features, Host, ?MODULE, add_local_features, 99},
      {c2s_preprocessing_hook, Host, ?MODULE, run_initial_check, 10},
-     {amp_check_packet, Host, ?MODULE, amp_check_packet, 10},
      {amp_verify_support, Host, ?AMP_RESOLVER, verify_support, 10},
      {amp_check_condition, Host, ?AMP_RESOLVER, check_condition, 10},
      {amp_determine_strategy, Host, ?AMP_STRATEGY, determine_strategy, 10}].
-%% Business API
 
+%% Business API
 
 -spec run_initial_check(mongoose_acc:t(), ejabberd_c2s:state()) -> mongoose_acc:t().
 run_initial_check(#{result := drop} = Acc, _C2SState) ->
     Acc;
 run_initial_check(Acc, _C2SState) ->
-    Acc1 = mod_amp:check_packet(Acc, mongoose_acc:get(from_jid, Acc), initial_check),
-    case mongoose_acc:get(amp_check_result, Acc1, ok) of
-        drop -> mongoose_acc:put(result, drop, Acc1);
-        _ -> Acc1
+    case mongoose_acc:get(name, Acc) of
+        <<"message">> -> run_initial_check(Acc);
+        _ -> Acc
     end.
 
-
--spec check_packet(mongoose_acc:t() | exml:element(), amp_event()) ->
-    mongoose_acc:t() | exml:element() | drop.
-check_packet(Packet = #xmlel{attrs = Attrs}, Event) ->
-    % it is called this way only from ejabberd_c2s:send_and_maybe_buffer_stanza/3, line 1666
-    % maybe Paweł Chrząszcz knows why and can advise what to do about it
-    ?DEPRECATED, % -> Paweł
-    case xml:get_attr(<<"from">>, Attrs) of
-        {value, From} ->
-            check_packet(Packet, jid:from_binary(From), Event);
-        _ ->
-            Packet
-    end;
 check_packet(Acc, Event) ->
-    check_packet(Acc, mongoose_acc:get(from_jid, Acc), Event).
-
--spec check_packet(exml:element()|mongoose_acc:t(), jid(), amp_event()) ->
-    exml:element() | mongoose_acc:t() | drop.
-check_packet(Packet = #xmlel{name = <<"message">>}, From, Event) ->
-    ?DEPRECATED, % -> Paweł
-    mongoose_acc:get(element, check_packet(mongoose_acc:from_element(Packet), From, Event));
-check_packet(Packet = #xmlel{}, _, _) ->
-    ?DEPRECATED, % -> Paweł
-    Packet;
-check_packet(Acc, #jid{lserver = Host} = From, Event) ->
-    case mongoose_acc:get(name, Acc) of
-        <<"message">> ->
-            % this hook replaces original element with something modified by amp
-            % which is a hack, but since we have accumulator here we have a chance
-            % to fix implementation
-            ejabberd_hooks:run_fold(amp_check_packet, Host, Acc, [From, Event]);
-        _ ->
-            Acc
+    case mongoose_acc:get(amp_state, Acc, none) of
+        none -> Acc;
+        AmpState -> process_event(Acc, AmpState, Event)
     end.
 
 add_local_features(Acc, _From, _To, ?NS_AMP, _Lang) ->
@@ -100,33 +67,32 @@ add_local_features(Acc, _From, _To, _NS, _Lang) ->
 add_stream_feature(Acc, _Host) ->
     lists:keystore(<<"amp">>, #xmlel.name, Acc, ?AMP_FEATURE).
 
--spec amp_check_packet(mongoose_acc:t(), jid(), amp_event()) -> mongoose_acc:t().
-amp_check_packet(Acc, From, Event) ->
-    Res = mongoose_acc:get(amp_check_result, Acc, ok),
-    Name = mongoose_acc:get(name, Acc),
-    amp_check_packet(Res, Name, Acc, From, Event).
+%% Internal
 
-amp_check_packet(drop, _, Acc, _, _) ->
-    Acc;
-amp_check_packet(_, <<"message">>, Acc, From, Event) ->
+run_initial_check(Acc) ->
+    Event = initial_check,
     Packet = mongoose_acc:get(element, Acc),
-    Res = case amp:extract_requested_rules(Packet) of
-              none                    -> Packet;
-              {rules, Rules}          -> process_amp_rules(Packet, From, Event, Rules);
-              {errors, Errors}        -> send_errors_and_drop(Packet, From, Errors)
-          end,
-    case Res of
+    From = mongoose_acc:get(from_jid, Acc),
+    Result = case amp:extract_requested_rules(Packet) of
+                 none -> Acc;
+                 {rules, Rules} -> validate_and_process_rules(Packet, From, Event, Rules);
+                 {errors, Errors} -> send_errors_and_drop(Packet, From, Errors)
+             end,
+    case Result of
         drop ->
-            mongoose_acc:put(amp_check_result, drop, Acc);
-        NewElem ->
-            mongoose_acc:put(element, NewElem, Acc)
-    end;
-amp_check_packet(_, _, Acc, _, _) ->
-    Acc.
+            mongoose_acc:put(result, drop, Acc);
+        NewRules ->
+            Acc1 = mongoose_acc:append(amp_state, {Event, NewRules}, Acc),
+            mongoose_acc:put(element, strip_amp_el_from_request(Packet), Acc1)
+    end.
+
+process_event(Acc, [{_LastEvent, Rules} | _], Event) ->
+    Packet = mongoose_acc:get(element, Acc),
+    From = mongoose_acc:get(from_jid, Acc),
+    NewRules = process_rules(Packet, From, Event, Rules),
+    mongoose_acc:append(amp_state, {Event, NewRules}, Acc).
 
 strip_amp_el_from_request(Packet) ->
-    % this will probably be removed - we have accumulator so we won't need anymore to store amp
-    % markers in stanza
     case amp:is_amp_request(Packet) of
         true -> amp:strip_amp_el(Packet);
         false -> Packet
@@ -141,8 +107,8 @@ amp_features() ->
    , <<"http://jabber.org/protocol/amp?condition=match-resource">>
     ].
 
--spec process_amp_rules(exml:element(), jid(), amp_event(), amp_rules()) -> exml:element() | drop.
-process_amp_rules(Packet, From, Event, Rules) ->
+-spec validate_and_process_rules(exml:element(), jid(), amp_event(), amp_rules()) -> exml:element() | drop.
+validate_and_process_rules(Packet, From, Event, Rules) ->
     VerifiedRules = verify_support(host(From), Rules),
     {Good, Bad} = lists:partition(fun is_supported_rule/1, VerifiedRules),
     ValidRules = [ Rule || {supported, Rule} <- Good ],
@@ -150,13 +116,16 @@ process_amp_rules(Packet, From, Event, Rules) ->
         [{error, ValidationError, InvalidRule} | _] ->
             send_error_and_drop(Packet, From, ValidationError, InvalidRule);
         [] ->
-            Strategy = determine_strategy(Packet, From, Event),
-            RulesWithResults = apply_rules(fun(Rule) ->
-                                                   resolve_condition(From, Strategy, Event, Rule)
-                                           end, ValidRules),
-            PacketResult = take_action(Packet, From, RulesWithResults),
-            return_result(PacketResult, Packet, RulesWithResults)
+            process_rules(Packet, From, Event, ValidRules)
     end.
+
+process_rules(Packet, From, Event, Rules) ->
+    Strategy = determine_strategy(Packet, From, Event),
+    RulesWithResults = apply_rules(fun(Rule) ->
+                                           resolve_condition(From, Strategy, Event, Rule)
+                                   end, Rules),
+    PacketResult = take_action(Packet, From, RulesWithResults),
+    return_result(PacketResult, Event, RulesWithResults).
 
 %% @doc ejabberd_hooks helpers
 -spec verify_support(binary(), amp_rules()) -> [amp_rule_support()].
@@ -190,14 +159,11 @@ take_action(Packet, From, Rules) ->
         {found, Rule} -> take_action_for_matched_rule(Packet, From, Rule)
     end.
 
-return_result(drop, _Packet, _Rules) -> drop;
-return_result(pass, Packet, Rules) ->
-    update_rules(Packet, lists:filter(fun(#amp_rule{result = Result}) ->
-                                              Result =:= undecided
-                                      end, Rules)).
-
-update_rules(Packet, []) -> amp:strip_amp_el(Packet);
-update_rules(Packet, Rules) -> amp:update_rules(Packet, Rules).
+return_result(drop, initial_check, _Rules) -> drop;
+return_result(pass, _Event, Rules) ->
+    lists:filter(fun(#amp_rule{result = Result}) ->
+                         Result =:= undecided
+                 end, Rules).
 
 -spec take_action_for_matched_rule(exml:element(), jid(), amp_rule()) -> pass | drop.
 take_action_for_matched_rule(Packet, From, #amp_rule{action = notify} = Rule) ->

--- a/apps/ejabberd/src/mod_mam.erl
+++ b/apps/ejabberd/src/mod_mam.erl
@@ -618,18 +618,21 @@ handle_purge_single_message(ArcJID=#jid{},
     PurgingResult = purge_single_message(Host, MessID, ArcID, ArcJID, Now),
     return_purge_single_message_iq(IQ, PurgingResult).
 
-determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
+determine_amp_strategy(Strategy = #amp_strategy{deliver = Deliver},
                        FromJID, ToJID, Packet, initial_check) ->
     #jid{luser = LUser, lserver = LServer} = ToJID,
     ShouldBeStored = mod_mam_params:is_archivable_message(?MODULE, incoming, Packet)
         andalso is_interesting(ToJID, FromJID)
         andalso ejabberd_auth:is_user_exists(LUser, LServer),
     case ShouldBeStored of
-        true -> Strategy#amp_strategy{deliver = [stored, none]};
+        true -> Strategy#amp_strategy{deliver = amp_deliver_strategy(Deliver)};
         false -> Strategy
     end;
 determine_amp_strategy(Strategy, _, _, _, _) ->
     Strategy.
+
+amp_deliver_strategy([none]) -> [stored, none];
+amp_deliver_strategy([direct, none]) -> [direct, stored, none].
 
 -spec handle_package(Dir :: incoming | outgoing, ReturnMessID :: boolean(),
                      LocJID :: ejabberd:jid(), RemJID :: ejabberd:jid(), SrcJID :: ejabberd:jid(),

--- a/apps/ejabberd/src/mongoose_acc.erl
+++ b/apps/ejabberd/src/mongoose_acc.erl
@@ -208,7 +208,7 @@ strip(Acc, El) ->
                            maps:put(Attrib, Val, AccIn)
                        end,
                        Acc1, Attributes),
-    OptionalAttributes = [from, from_jid, to, to_jid, persistent_properties],
+    OptionalAttributes = [from, from_jid, to, to_jid, amp_state, persistent_properties],
     lists:foldl(fun(Attrib, AccIn) ->
                     case maps:get(Attrib, Acc, undefined) of
                         undefined -> AccIn;

--- a/test.disabled/ejabberd_tests/tests/amp_big_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/amp_big_SUITE.erl
@@ -13,52 +13,66 @@
 
 all() -> [{group, Group} || Group <- enabled_group_names()].
 
+groups() ->
+    lists:flatmap(fun group_spec/1, subgroups()).
+
 enabled_group_names() ->
     [basic, offline] ++
     case mongoose_helper:is_odbc_enabled(domain()) of
-        true -> [mam];
+        true -> [mam_odbc];
         false -> []
     end.
 
-groups() ->
-    [{basic, [parallel], [{group, G} || G <- subgroup_names()] ++ basic_test_cases()},
-     {mam, [], [{group, mam_success},
-                {group, mam_failure}]},
-     {mam_success, [], [{group, G} || G <- subgroup_names()]},
-     {mam_failure, [], [{group, G} || G <- subgroup_names()]},
-     {offline, [], [{group, offline_success},
-                    {group, offline_failure}]},
-     {offline_success, [], [{group, G} || G <- subgroup_names()]},
-     {offline_failure, [], [{group, G} || G <- subgroup_names()]}
-    ] ++
-        [{G, [parallel, shuffle], notify_deliver_test_cases()}
-         || G <- notify_deliver_group_names()] ++
-        [{G, [parallel, shuffle], error_deliver_test_cases()}
-         || G <- error_deliver_group_names()] ++
-        [{G, [parallel, shuffle], drop_deliver_test_cases()}
-         || G <- drop_deliver_group_names()].
+group_spec({Group, []}) ->
+    [{Group, [parallel], test_cases(Group)}];
+group_spec({Group, SubGroups}) ->
+    [{Group, [{group, SubG} || SubG <- SubGroups]}
+     | [{SubG, [parallel], test_cases(SubG)} || SubG <- SubGroups]].
 
-subgroup_names() -> notify_deliver_group_names() ++
-                        error_deliver_group_names() ++
-                        drop_deliver_group_names().
+test_cases(Group) ->
+    lists:flatmap(fun({TC, Confs}) -> [TC || _ <- Confs] end, maps:to_list(conf(Group))).
 
-notify_deliver_group_names() ->
-    [notify_deliver_none,
-     notify_deliver_direct,
-     notify_deliver_stored,
-     notify_deliver_none_direct_stored].
+conf(Group) ->
+    maps:from_list(
+      lists:append([with_empty_conf(basic_test_cases(Group)),
+                    with_deliver_rule_conf(notify, notify_deliver_test_cases()),
+                    with_deliver_rule_conf(drop, drop_deliver_test_cases()),
+                    with_deliver_rule_conf(error, error_deliver_test_cases())])).
 
-error_deliver_group_names() ->
-    [error_deliver_none,
-     error_deliver_direct,
-     error_deliver_stored,
-     error_deliver_none_direct_stored].
+with_empty_conf(Cases) ->
+    [{TC, [[]]} || TC <- Cases].
 
-drop_deliver_group_names() ->
-    [drop_deliver_none,
-     drop_deliver_direct,
-     drop_deliver_stored,
-     drop_deliver_none_direct_stored].
+with_deliver_rule_conf(Action, Cases) ->
+    [{TC, deliver_rule_conf(Action)} || TC <- Cases].
+
+basic_test_cases(basic) -> basic_test_cases();
+basic_test_cases(_Group) -> [].
+
+supergroup(Group) ->
+    proplists:get_value(Group, [{SubG, G} || {G, SubGroups} <- subgroups(), SubG <- SubGroups]).
+
+subgroups(Group) ->
+    proplists:get_value(Group, subgroups()).
+
+subgroups() ->
+    [{basic, []},
+     {mam_odbc, [mam_odbc_success, mam_odbc_failure]},
+     {offline, [offline_success, offline_failure]}].
+
+flat_groups() ->
+    [basic].
+
+deliver_rule_conf(Action) ->
+    [
+     [{rules, [{deliver, direct, Action}]}],
+     [{rules, [{deliver, stored, Action}]}],
+     [{rules, [{deliver, none, Action}]}],
+     [{rules, [{deliver, direct, Action},
+               {deliver, stored, Action},
+               {deliver, none, Action}]}]
+    ].
+
+%% Test case list, each test has to be listed exactly once
 
 basic_test_cases() ->
     [initial_service_discovery_test,
@@ -94,14 +108,18 @@ drop_deliver_test_cases() ->
      drop_deliver_to_offline_user_test,
      drop_deliver_to_stranger_test].
 
-init_per_suite(C) ->
+%% Setup and teardown
+
+init_per_suite(Config) ->
     escalus_ejabberd:rpc(ejabberd_config, add_local_option,
                          [outgoing_s2s_options, {[ipv4, ipv6], 1000}]),
-    escalus:init_per_suite(C).
-end_per_suite(C) ->
-    escalus_ejabberd:rpc(ejabberd_config, del_local_option,
-                         [outgoing_s2s_options]),
+    ConfigWithHooks = [{ct_hooks, [{multiple_config_cth, fun conf/1}]} | Config],
+    setup_meck(suite),
+    escalus:init_per_suite(ConfigWithHooks).
 
+end_per_suite(C) ->
+    escalus_ejabberd:rpc(ejabberd_config, del_local_option, [outgoing_s2s_options]),
+    teardown_meck(suite),
     escalus_fresh:clean(),
     escalus:end_per_suite(C).
 
@@ -112,7 +130,7 @@ init_per_group(GroupName, Config) ->
     setup_meck(GroupName),
     save_offline_status(GroupName, ConfigWithRules).
 
-setup_meck(mam_failure) ->
+setup_meck(mam_odbc_failure) ->
     ok = escalus_ejabberd:rpc(meck, expect, [mod_mam_odbc_arch, archive_message, 9,
                                              {error, simulated}]);
 setup_meck(offline_failure) ->
@@ -120,8 +138,8 @@ setup_meck(offline_failure) ->
                                              {error, simulated}]);
 setup_meck(_) -> ok.
 
-save_offline_status(mam_success, Config) -> [{offline_storage, mam} | Config];
-save_offline_status(mam_failure, Config) -> [{offline_storage, mam_failure} | Config];
+save_offline_status(mam_odbc_success, Config) -> [{offline_storage, mam} | Config];
+save_offline_status(mam_odbc_failure, Config) -> [{offline_storage, mam_failure} | Config];
 save_offline_status(offline_success, Config) -> [{offline_storage, offline} | Config];
 save_offline_status(offline_failure, Config) -> [{offline_storage, offline_failure} | Config];
 save_offline_status(basic, Config) -> [{offline_storage, none} | Config];
@@ -131,19 +149,24 @@ end_per_group(GroupName, Config) ->
     teardown_meck(GroupName),
     dynamic_modules:restore_modules(domain(), Config).
 
-teardown_meck(G) when G == mam_failure;
-                      G == offline_failure ->
+teardown_meck(mam_odbc_failure) ->
+    escalus_ejabberd:rpc(meck, unload, [mod_mam_odbc_arch]);
+teardown_meck(offline_failure) ->
+    escalus_ejabberd:rpc(meck, unload, [mod_offline_mnesia]);
+teardown_meck(suite) ->
     escalus_ejabberd:rpc(meck, unload, []);
 teardown_meck(_) -> ok.
 
 init_per_testcase(Name, C) -> escalus:init_per_testcase(Name, C).
 end_per_testcase(Name, C) -> escalus:end_per_testcase(Name, C).
 
+%% Test cases
+
 initial_service_discovery_test(Config) ->
     escalus:fresh_story(
       Config, [{alice, 1}],
       fun(Alice) ->
-              escalus_client:send(Alice, disco_info(Config)),
+              escalus_client:send(Alice, disco_info()),
               Response = escalus_client:wait_for_stanza(Alice),
               escalus:assert(has_feature, [ns_amp()], Response)
       end).
@@ -158,7 +181,7 @@ actions_and_conditions_discovery_test(Config) ->
                   <<"http://jabber.org/protocol/amp?condition=deliver">>,
                   <<"http://jabber.org/protocol/amp?condition=match-resource">>
                   ],
-          escalus_client:send(Alice, disco_info_amp_node(Config)),
+          escalus_client:send(Alice, disco_info_amp_node()),
           Response = escalus_client:wait_for_stanza(Alice),
           assert_has_features(Response, Args)
       end).
@@ -745,12 +768,11 @@ client_receives_notification(Client, IntendedRecipient, Rule) ->
     Msg = escalus_client:wait_for_stanza(Client),
     assert_notification(Client, IntendedRecipient, Msg, Rule).
 
-disco_info(Config) ->
-    Server = ct:get_config({hosts, mim, domain}),
-    escalus_stanza:disco_info(Server).
-disco_info_amp_node(Config) ->
-    Server = ct:get_config({hosts, mim, domain}),
-    escalus_stanza:disco_info(Server, ns_amp()).
+disco_info() ->
+    escalus_stanza:disco_info(domain()).
+
+disco_info_amp_node() ->
+    escalus_stanza:disco_info(domain(), ns_amp()).
 
 assert_amp_error(Client, Response, Rules, AmpErrorKind) when is_list(Rules) ->
     ClientJID = escalus_client:full_jid(Client),
@@ -918,12 +940,10 @@ is_module_loaded(Mod) ->
 
 required_modules(basic) ->
     mam_modules(off) ++ offline_modules(off);
-required_modules(mam) ->
+required_modules(mam_odbc) ->
     mam_modules(on) ++ offline_modules(off);
 required_modules(offline) ->
     mam_modules(off) ++ offline_modules(on);
-required_modules(mam_and_offline) ->
-    mam_modules(on) ++ offline_modules(on);
 required_modules(_) ->
     [].
 

--- a/test.disabled/ejabberd_tests/tests/amp_big_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/amp_big_SUITE.erl
@@ -95,6 +95,7 @@ notify_deliver_test_cases() ->
      notify_deliver_to_online_user_recipient_privacy_test,
      notify_deliver_to_offline_user_test,
      notify_deliver_to_offline_user_recipient_privacy_test,
+     notify_deliver_to_online_user_broken_connection_test,
      notify_deliver_to_stranger_test,
      notify_deliver_to_malformed_jid_test].
 
@@ -114,8 +115,22 @@ init_per_suite(Config) ->
     escalus_ejabberd:rpc(ejabberd_config, add_local_option,
                          [outgoing_s2s_options, {[ipv4, ipv6], 1000}]),
     ConfigWithHooks = [{ct_hooks, [{multiple_config_cth, fun conf/1}]} | Config],
+    {Mod, Code} = escalus_ejabberd:rpc(dynamic_compile, from_string,
+                                       [amp_test_helper_code()]),
+    escalus_ejabberd:rpc(code,load_binary, [Mod, "amp_test_helper.erl", Code]),
     setup_meck(suite),
     escalus:init_per_suite(ConfigWithHooks).
+
+amp_test_helper_code() ->
+    "-module(amp_test_helper).\n"
+    "-compile(export_all).\n"
+    "setup_meck() ->\n"
+    "  meck:expect(ejabberd_socket, send, fun ejabberd_socket_send/2).\n"
+    "ejabberd_socket_send(Socket, Data) ->\n"
+    "  case catch binary:match(Data, <<\"Recipient connection breaks\">>) of\n"
+    "    {N, _} when is_integer(N) -> {error, simulated};\n"
+    "    _ -> meck:passthrough([Socket, Data])\n"
+    "  end.\n".
 
 end_per_suite(C) ->
     escalus_ejabberd:rpc(ejabberd_config, del_local_option, [outgoing_s2s_options]),
@@ -130,6 +145,9 @@ init_per_group(GroupName, Config) ->
     setup_meck(GroupName),
     save_offline_status(GroupName, ConfigWithRules).
 
+setup_meck(suite) ->
+    ok = escalus_ejabberd:rpc(meck, new, [ejabberd_socket, [passthrough, no_link]]),
+    ok = escalus_ejabberd:rpc(amp_test_helper, setup_meck, []);
 setup_meck(mam_odbc_failure) ->
     ok = escalus_ejabberd:rpc(meck, expect, [mod_mam_odbc_arch, archive_message, 9,
                                              {error, simulated}]);
@@ -280,6 +298,12 @@ notify_deliver_to_online_user_bare_jid_test(Config) ->
       end).
 
 notify_deliver_to_online_user_recipient_privacy_test(Config) ->
+    case is_module_loaded(mod_mam) of
+        true -> skipped; %% MAM does not support privacy lists
+        false -> do_notify_deliver_to_online_user_recipient_privacy_test(Config)
+    end.
+
+do_notify_deliver_to_online_user_recipient_privacy_test(Config) ->
     escalus:fresh_story(
       Config, [{alice, 1}, {bob, 1}],
       fun(Alice, Bob) ->
@@ -298,6 +322,30 @@ notify_deliver_to_online_user_recipient_privacy_test(Config) ->
                   false -> ok
               end,
               client_receives_generic_error(Alice, <<"503">>, <<"cancel">>),
+              client_receives_nothing(Alice),
+              client_receives_nothing(Bob)
+      end).
+
+notify_deliver_to_online_user_broken_connection_test(Config) ->
+    escalus:fresh_story(
+      Config, [{alice, 1}, {bob, 1}],
+      fun(Alice, Bob) ->
+              %% given
+              Rule = {deliver, case ?config(offline_storage, Config) of
+                                   mam -> stored;
+                                   _ -> none
+                               end, notify},
+              Rules = rules(Config, [Rule]),
+              Msg = amp_message_to(Bob, Rules, <<"Recipient connection breaks">>),
+
+              %% when
+              client_sends_message(Alice, Msg),
+
+              % then
+              case lists:member(Rule, Rules) of
+                  true -> client_receives_notification(Alice, Bob, Rule);
+                  false -> ok
+              end,
               client_receives_nothing(Alice),
               client_receives_nothing(Bob)
       end).

--- a/test.disabled/ejabberd_tests/tests/multiple_config_cth.erl
+++ b/test.disabled/ejabberd_tests/tests/multiple_config_cth.erl
@@ -1,0 +1,74 @@
+-module(multiple_config_cth).
+%% @doc Support running a test multiple times with different configuration options
+%% inside a single test group. Used by amp_big_SUITE.
+
+%% Callbacks
+
+-export([id/1, init/2]).
+
+-export([pre_init_per_suite/3, post_init_per_suite/4,
+         pre_end_per_suite/3, post_end_per_suite/4,
+         pre_init_per_group/3, post_init_per_group/4,
+         pre_end_per_group/3, post_end_per_group/4,
+         pre_init_per_testcase/3, post_init_per_testcase/4,
+         pre_end_per_testcase/3, post_end_per_testcase/4]).
+
+-export([on_tc_fail/3, on_tc_skip/3, terminate/1]).
+
+-record(state, {conf_f, group_conf}).
+
+id(_) ->
+    ?MODULE.
+
+init(_Id, ConfFun) ->
+    {ok, #state{conf_f = ConfFun}}.
+
+pre_init_per_suite(_Suite, Config, State) ->
+    {Config, State}.
+
+post_init_per_suite(_Suite, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_suite(_Suite, Config, State) ->
+    {Config, State}.
+
+post_end_per_suite(_Suite, _Config, Return, State) ->
+    {Return, State}.
+
+pre_init_per_group(Group, Config, State = #state{conf_f = ConfF}) ->
+    {Config, State#state{group_conf = ConfF(Group)}}.
+
+post_init_per_group(_Group, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_group(_Group, Config, State) ->
+    {Config, State}.
+
+post_end_per_group(_Group, _Config, Return, State) ->
+    {Return, State}.
+
+pre_init_per_testcase(TC, Config, State) ->
+    #state{group_conf = Conf = #{TC := [ExtraConfig | Rest]}} = State,
+    case ExtraConfig of
+        [] -> ok;
+        _ -> ct:log("Extra test config: ~p", [ExtraConfig])
+    end,
+    {ExtraConfig ++ Config, State#state{group_conf = Conf#{TC := Rest}}}.
+
+post_init_per_testcase(_TC, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_testcase(_TC, Config, State) ->
+    {Config, State}.
+
+post_end_per_testcase(_TC, _Config, Return, State) ->
+    {Return, State}.
+
+on_tc_fail(_TC, _Reason, State) ->
+    State.
+
+on_tc_skip(_TC, _Reason, State) ->
+    State.
+
+terminate(_State) ->
+    ok.


### PR DESCRIPTION
- Save AMP state in the accumulator instead of storing modified rules in the message itself.
- Handle the corner case when the message is stored in MAM but sending it to the recipient fails.
- Document AMP logic in more detail