### PR TITLE
Return 404 when vcard not found

### DIFF
--- a/src/mod_vcard_mnesia.erl
+++ b/src/mod_vcard_mnesia.erl
@@ -37,14 +37,8 @@ get_vcard(LUser, LServer) ->
                  mnesia:read({vcard, US})
          end,
     case mnesia:transaction(F) of
-        %% TODO: the first clause to be out of place here - see
-        %% http://xmpp.org/extensions/xep-0054.html examples 2, 3, 4:
-        %%
-        %%   If no vCard exists, the server MUST return a stanza error
-        %%   (which SHOULD be <item-not-found/>) or an IQ-result containing
-        %%   an empty <vCard/> element.
         {atomic, []} ->
-            {error, ?ERR_SERVICE_UNAVAILABLE};
+            {error, ?ERR_ITEM_NOT_FOUND};
         {atomic, Rs} ->
             Els = lists:map(fun(R) ->
                                     R#vcard.vcard

--- a/src/mod_vcard_odbc.erl
+++ b/src/mod_vcard_odbc.erl
@@ -68,7 +68,7 @@ get_vcard(LUser, LServer) ->
                     {ok, [VCARD]}
             end;
         {selected, []} ->
-            {error, ?ERR_SERVICE_UNAVAILABLE}
+            {error, ?ERR_ITEM_NOT_FOUND}
     end.
 
 set_vcard(User, VHost, VCard, VCardSearch) ->

--- a/src/mod_vcard_riak.erl
+++ b/src/mod_vcard_riak.erl
@@ -65,7 +65,7 @@ get_vcard(LUser, LServer) ->
                     {error, ?ERR_SERVICE_UNAVAILABLE}
             end;
         {error, notfound} ->
-            {error, ?ERR_SERVICE_UNAVAILABLE};
+            {error, ?ERR_ITEM_NOT_FOUND};
         Other ->
             Other
     end.

--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -221,9 +221,10 @@ retrieve_own_card(Config) ->
 
 
 
-%% If no vCard exists or the user does not exist, the server MUST
-%% return a stanza error, which SHOULD be either
-%% <service-unavailable/> or <item-not-found/>
+%% If no vCard exists, the server MUST return a stanza error 
+%% (which SHOULD be <item-not-found/>) or an IQ-result 
+%% containing an empty <vCard/> element.
+%% We return <item-not-found/>
 user_doesnt_exist(Config) ->
     escalus:story(
       Config, [{alice, 1}],
@@ -234,7 +235,7 @@ user_doesnt_exist(Config) ->
                         escalus_stanza:vcard_request(BadJID)),
           case
           escalus_pred:is_error(<<"cancel">>,
-              <<"service-unavailable">>,
+              <<"item-not-found">>,
               Res) of
               true ->
                   ok;

--- a/test.disabled/ejabberd_tests/tests/vcard_simple_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_simple_SUITE.erl
@@ -136,9 +136,10 @@ retrieve_own_card(Config) ->
 
 
 
-%% If no vCard exists or the user does not exist, the server MUST
-%% return a stanza error, which SHOULD be either
-%% <service-unavailable/> or <item-not-found/>
+%% If no vCard exists, the server MUST return a stanza error
+%% (which SHOULD be <item-not-found/>) or an IQ-result
+%% containing an empty <vCard/> element.
+%% We return <item-not-found/>
 user_doesnt_exist(Config) ->
     escalus:story(
       Config, [{alice, 1}],
@@ -149,7 +150,7 @@ user_doesnt_exist(Config) ->
                         escalus_stanza:vcard_request(BadJID)),
                 case
                   escalus_pred:is_error(<<"cancel">>,
-                                        <<"service-unavailable">>,
+                                        <<"item-not-found">>,
                                         Res) of
                   true ->
                       ok;


### PR DESCRIPTION
I found that we return code 503 when a vcard has not been found after clients' iq get request. According to xep it should return either empty vcard or a 404 (item-not-found) error code.

