### PR TITLE
Change passwordlike to passterm

### DIFF
--- a/apps/ejabberd/src/cyrsasl_digest.erl
+++ b/apps/ejabberd/src/cyrsasl_digest.erl
@@ -82,7 +82,7 @@ mech_step(#state{step = 3, nonce = Nonce} = State, ClientIn) ->
                 true ->
                     AuthzId = xml:get_attr_s(<<"authzid">>, KeyVals),
                     LServer = mongoose_credentials:lserver(State#state.creds),
-                    case ejabberd_auth:get_password_with_authmodule(UserName, LServer) of
+                    case ejabberd_auth:get_passterm_with_authmodule(UserName, LServer) of
                         {false, _} ->
                             {error, <<"not-authorized">>, UserName};
                         {Passwd, AuthModule} ->

--- a/apps/ejabberd/src/cyrsasl_scram.erl
+++ b/apps/ejabberd/src/cyrsasl_scram.erl
@@ -77,7 +77,7 @@ mech_step(#state{step = 2} = State, ClientIn) ->
                                 {$r, ClientNonce} ->
                                     Creds = State#state.creds,
                                     LServer = mongoose_credentials:lserver(Creds),
-                                    case ejabberd_auth:get_password_with_authmodule(UserName, LServer) of
+                                    case ejabberd_auth:get_passterm_with_authmodule(UserName, LServer) of
                                         {false, _} -> {error, <<"not-authorized">>, UserName};
                                         {Ret, AuthModule} ->
                                             {StoredKey, ServerKey, Salt, IterationCount} =

--- a/apps/ejabberd/src/ejabberd_auth.erl
+++ b/apps/ejabberd/src/ejabberd_auth.erl
@@ -44,7 +44,7 @@
          get_vh_registered_users_number/2,
          get_password/2,
          get_password_s/2,
-         get_password_with_authmodule/2,
+         get_passterm_with_authmodule/2,
          is_user_exists/2,
          is_user_exists_in_other_modules/3,
          remove_user/2,
@@ -64,11 +64,10 @@
 -include("ejabberd.hrl").
 
 -export_type([authmodule/0,
-              passwordlike/0]).
+              passterm/0]).
 
 -type authmodule() :: module().
-%% TODO: TBH this name smells.
--type passwordlike() :: binary() | scram:scram_tuple().
+-type passterm() :: binary() | scram:scram_tuple().
 
 -define(METRIC(Name), [backends, auth, Name]).
 
@@ -428,18 +427,18 @@ do_get_password_s(LUser, LServer) ->
         end, <<"">>, auth_modules(LServer)).
 
 %% @doc Get the password(like thing) of the user and the auth module.
--spec get_password_with_authmodule(ejabberd:user(), ejabberd:server()) -> R when
-      R :: {passwordlike(), authmodule()}
+-spec get_passterm_with_authmodule(ejabberd:user(), ejabberd:server()) -> R when
+      R :: {passterm(), authmodule()}
          | {'false', 'none'}.
-get_password_with_authmodule(User, Server) ->
+get_passterm_with_authmodule(User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    do_get_password_with_authmodule(LUser, LServer).
+    do_get_passterm_with_authmodule(LUser, LServer).
 
-do_get_password_with_authmodule(LUser, LServer)
+do_get_passterm_with_authmodule(LUser, LServer)
     when LUser =:= error; LServer =:= error ->
     {false, none};
-do_get_password_with_authmodule(LUser, LServer) ->
+do_get_passterm_with_authmodule(LUser, LServer) ->
     lists:foldl(
         fun(M, {false, _}) ->
             {M:get_password(LUser, LServer), M};

--- a/apps/ejabberd/src/ejabberd_auth_http.erl
+++ b/apps/ejabberd/src/ejabberd_auth_http.erl
@@ -147,7 +147,7 @@ get_vh_registered_users_number(_Server) ->
 get_vh_registered_users_number(_Server, _Opts) ->
     0.
 
--spec get_password(ejabberd:luser(), ejabberd:lserver()) -> ejabberd_auth:passwordlike() | false.
+-spec get_password(ejabberd:luser(), ejabberd:lserver()) -> ejabberd_auth:passterm() | false.
 get_password(LUser, LServer) ->
     case make_req(get, <<"get_password">>, LUser, LServer, <<"">>) of
         {error, _} ->
@@ -305,7 +305,7 @@ check_scram_password(OriginalPassword, GotPassword, Digest, DigestGen) ->
             false
     end.
 
--spec convert_scram_to_tuple(binary()) -> ejabberd_auth:passwordlike() | false.
+-spec convert_scram_to_tuple(binary()) -> ejabberd_auth:passterm() | false.
 convert_scram_to_tuple(Password) ->
     case scram:deserialize(Password) of
         {ok, #scram{} = Scram} ->

--- a/apps/ejabberd/src/ejabberd_auth_odbc.erl
+++ b/apps/ejabberd/src/ejabberd_auth_odbc.erl
@@ -223,7 +223,7 @@ get_vh_registered_users_number(LServer, Opts) ->
     end.
 
 
--spec get_password(ejabberd:luser(), ejabberd:lserver()) -> ejabberd_auth:passwordlike() | false.
+-spec get_password(ejabberd:luser(), ejabberd:lserver()) -> ejabberd_auth:passterm() | false.
 get_password(LUser, LServer) ->
     Username = mongoose_rdbms:escape(LUser),
     case catch rdbms_queries:get_password(LServer, Username) of

--- a/apps/ejabberd/src/ejabberd_auth_riak.erl
+++ b/apps/ejabberd/src/ejabberd_auth_riak.erl
@@ -141,7 +141,7 @@ get_vh_registered_users_number(LServer) ->
 get_vh_registered_users_number(LServer, _Opts) ->
     get_vh_registered_users_number(LServer).
 
--spec get_password(ejabberd:luser(), ejabberd:lserver()) -> ejabberd_auth:passwordlike() | false.
+-spec get_password(ejabberd:luser(), ejabberd:lserver()) -> ejabberd_auth:passterm() | false.
 get_password(LUser, LServer) ->
     case do_get_password(LUser, LServer) of
         false ->

--- a/apps/ejabberd/src/ejabberd_gen_auth.erl
+++ b/apps/ejabberd/src/ejabberd_gen_auth.erl
@@ -38,7 +38,7 @@
 -callback get_vh_registered_users_number(Server :: ejabberd:lserver(), Opts :: list()) -> integer().
 
 -callback get_password(User :: ejabberd:luser(),
-                       Server :: ejabberd:lserver()) -> ejabberd_auth:passwordlike() | false.
+                       Server :: ejabberd:lserver()) -> ejabberd_auth:passterm() | false.
 
 -callback get_password_s(User :: ejabberd:luser(),
                          Server :: ejabberd:lserver()) -> binary().


### PR DESCRIPTION
The name `passwordlike` smells. As it can't be `password` because it is either binary (word) OR TUPLE of type scram:scram_tuple() we will call it `passTERM`. 

It plays a role of passWORD but instead of being a **WORD** it is a **WORD or TUPLE**. The smallest denominator then is **TERM**. This way we also let somebody extend it for any type of pass phrase he/she needs.