### PR TITLE
C2S crash fix

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2349,12 +2349,10 @@ get_priority_from_presence(PresencePacket) ->
                          StateData :: state()) -> {mongoose_acc:t(), state()}.
 process_privacy_iq(Acc0, To, StateData) ->
     Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
-    Acc1 = mongoose_acc:put(iq, IQ, Acc),
-    From = mongoose_acc:get(from_jid, Acc1),
-    case is_record(IQ, iq) of
-        true ->
-            #iq{type = Type, sub_el = SubEl} = IQ,
+    case mongoose_acc:get(iq_query_info, Acc) of
+        #iq{type = Type, sub_el = SubEl} = IQ ->
+            Acc1 = mongoose_acc:put(iq, IQ, Acc),
+            From = mongoose_acc:get(from_jid, Acc1),
             {Acc2, NewStateData} = process_privacy_iq(Acc1, Type, To, StateData),
             Res = mongoose_acc:get(iq_result, Acc2, {error, ?ERR_FEATURE_NOT_IMPLEMENTED}),
             IQRes = case Res of

--- a/test.disabled/ejabberd_tests/tests/mod_blocking_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_blocking_SUITE.erl
@@ -68,7 +68,8 @@ effect_test_cases() ->
         messages_from_unblocked_user_arrive_again,
         messages_from_any_blocked_resource_dont_arrive,
         blocking_doesnt_interfere,
-        blocking_propagates_to_resources
+        blocking_propagates_to_resources,
+        send_iq_with_blocking_ns
     ].
 
 offline_test_cases() ->
@@ -285,6 +286,38 @@ blocking_propagates_to_resources(Config) ->
             message_is_not_delivered(User2, [User1a], <<"hau!">>),
             message_is_not_delivered(User2, [User1b], <<"miau!">>)
         end).
+
+send_iq_with_blocking_ns(Config) ->
+    %% Will send iq with blocking namespace with type result and error
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        QueryWithPrivacyNS = escalus_stanza:query_el(?NS_BLOCKING, []),
+        BobJid = escalus_utils:get_short_jid(Bob),
+        IQError = escalus_stanza:iq(BobJid,
+                                    <<"error">>,
+                                    [QueryWithPrivacyNS]),
+        %% After sending the following IQ the server used to crash
+        %% The iq is ignored now and can not be checked for existence
+        escalus:send(Alice, IQError),
+        %% Check server still available by sending msg
+        ChatMsg1 = escalus_stanza:chat_to(Bob, <<"Hi, Bob">>),
+        escalus:send(Alice, ChatMsg1),
+        escalus:assert(is_chat_message,
+                       [<<"Hi, Bob">>],
+                       escalus:wait_for_stanza(Bob)),
+
+        IQResult = escalus_stanza:iq(BobJid,
+                                     <<"result">>,
+                                     [QueryWithPrivacyNS]),
+        %% After sending the following IQthe server used to crash
+        %% The iq is ignored now and can not be checked for existence
+        escalus:send(Alice, IQResult),
+        %% Check server still available by sending msg
+        ChatMsg2 = escalus_stanza:chat_to(Alice, <<"Hi, Alice">>),
+        escalus:send(Bob, ChatMsg2),
+        escalus:assert(is_chat_message,
+                       [<<"Hi, Alice">>],
+                       escalus:wait_for_stanza(Alice))
+    end).
 
 messages_after_relogin(Config) ->
     %% given

--- a/test.disabled/ejabberd_tests/tests/privacy_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/privacy_helper.erl
@@ -17,7 +17,9 @@
          gets_error/2,
          gets_error/3,
          is_privacy_list_push/1,
-         is_presence_error/1]).
+         is_presence_error/1,
+         does_user_process_crash/4,
+         does_user_process_crash/5]).
 
 gets_error(Who, Type) ->
     gets_error(Who, <<"cancel">>, Type).
@@ -247,3 +249,16 @@ list_content(<<"deny_3_items">>, JID) -> [
         escalus_stanza:privacy_list_jid_item(<<"3">>, <<"deny">>,
                                              <<"john@localhost">>, [])
     ].
+
+%% Sends IQ reply and checks if user process still alive
+does_user_process_crash(From, To, Type, Children) ->
+    does_user_process_crash(From, To, Type, Children, <<"Hello stranger">>).
+does_user_process_crash(From, To, Type, Children, Message) ->
+    ToShortJid = escalus_utils:get_short_jid(To),
+    IQWithType = escalus_stanza:iq(ToShortJid, Type, [Children]),
+    escalus:send(From, IQWithType),
+    ChatMsg = escalus_stanza:chat_to(ToShortJid, Message),
+    escalus:send(From, ChatMsg),
+    escalus:assert(is_chat_message,
+                   [Message],
+                   escalus:wait_for_stanza(To)).


### PR DESCRIPTION
This PR addresses crash of ejabberd_c2s process when receiving iq with blocking or privacy namespace

Proposed changes include:
Check if IQ is of record iq, if not return old state

