### PR TITLE
Fix mod_websockets:close/1

### DIFF
--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -245,7 +245,7 @@ get_sockmod(_SocketData) ->
     ?MODULE.
 
 close(#websocket{pid = Pid}) ->
-    Pid ! close.
+    Pid ! stop.
 
 -spec peername(socket()) -> mongoose_transport:peername_return().
 peername(#websocket{peername = PeerName}) ->


### PR DESCRIPTION
This PR addresses #1602

Proposed changes include:
* change `mod_websockets:close/1` to send `stop` message as this is what `mod_websockets:websocket_info` expects to get

