### PR TITLE
Upgrade fast_tls to a version using two-level namespace on macOS.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,7 @@
   {idna, ".*", {git, "git://github.com/benoitc/erlang-idna.git", {tag, "1.2.0"}}},
   {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "1.5.1"}}},
   {uuid, ".*", {git, "git://github.com/okeuday/uuid.git", {tag, "v1.7.1"}}},
-  {fast_tls, ".*", {git, "git://github.com/processone/fast_tls.git", {tag, "1.0.10"}}},
+  {fast_tls, ".*", {git, "git://github.com/processone/fast_tls.git", {ref, "a2b2154"}}},
   {lasse, ".*", {git, "git://github.com/inaka/lasse.git", "692eaec"}},
   {worker_pool, ".*", {git, "git://github.com/inaka/worker_pool.git", {tag, "3.0.0"}}},
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -59,7 +59,7 @@
   0},
  {<<"fast_tls">>,
   {git,"git://github.com/processone/fast_tls.git",
-       {ref,"ff634a5dabd64a5e2d5e606cb3e6b7c5cf8aa7d9"}},
+       {ref,"a2b2154d11280becbf3077e62f7b5621d52b54fd"}},
   0},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.5">>},1},
  {<<"fusco">>,


### PR DESCRIPTION
This PR upgrades fast_tls to a version that eschews -flat_namespace linking flag that - on macOS High Sierra - caused wrong TLS library to be found during runtime, which resulted in segmentation faults.

There are quite a few changes between the version we used and the version this PR upgrades to, probably the most important being [a switch from port to NIF implementation](https://github.com/processone/fast_tls/commit/17bfcb769cb6573c53497e01957fffccd384cf6a), so we should look closely at load test results.