### PR TITLE
fix for mod_vcard_ldap:parse_option/2 function

### DIFF
--- a/test.disabled/ejabberd_tests/tests/vcard_simple_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_simple_SUITE.erl
@@ -459,7 +459,7 @@ configure_ldap_vcards(Config) ->
            {ldap_filter,"(objectClass=inetOrgPerson)"},
            {ldap_base,"ou=Users,dc=esl,dc=com"},
            {ldap_search_fields, [{"Full Name","cn"},{"User","uid"}]},
-           {ldap_vcard_map,[{"FN",[{"%s",["cn"]}]}]}],
+           {ldap_vcard_map,[{"FN","%s",["cn"]}]}],
     dynamic_modules:start(Domain, mod_vcard, Cfg),
     [{mod_vcard, CurrentVcardConfig} | Config].
 


### PR DESCRIPTION
fix for ldap_vcard_map option format, making it aligned with [description at documentation](http://mongooseim.readthedocs.io/en/latest/modules/mod_vcard/)
