### PR TITLE
Fix up received stanza size metric

### DIFF
--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -140,6 +140,7 @@ handle_call({starttls, TLSSocket}, _From, #state{parser = Parser} = State) ->
     NewParser = reset_parser(Parser, State#state.max_stanza_size),
     NewState = State#state{socket = TLSSocket,
                            sock_mod = fast_tls,
+                           stanza_chunk_size = 0,
                            parser = NewParser},
     case fast_tls:recv_data(TLSSocket, <<"">>) of
         {ok, TLSData} ->
@@ -152,6 +153,7 @@ handle_call({compress, ZlibSocket}, _From,
     NewParser = reset_parser(Parser, State#state.max_stanza_size),
     NewState = State#state{socket = ZlibSocket,
                            sock_mod = ejabberd_zlib,
+                           stanza_chunk_size = 0,
                            parser = NewParser},
     case ejabberd_zlib:recv_data(ZlibSocket, "") of
         {ok, ZlibData} ->
@@ -165,7 +167,7 @@ handle_call({compress, ZlibSocket}, _From,
     end;
 handle_call({become_controller, C2SPid}, _From, State) ->
     Parser = reset_parser(State#state.parser, State#state.max_stanza_size),
-    NewState = State#state{c2s_pid = C2SPid, parser = Parser},
+    NewState = State#state{c2s_pid = C2SPid, parser = Parser, stanza_chunk_size = 0},
     activate_socket(NewState),
     Reply = ok,
     {reply, Reply, NewState, ?HIBERNATE_TIMEOUT};

--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -137,8 +137,8 @@ init([Socket, SockMod, Shaper, MaxStanzaSize]) ->
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
 handle_call({starttls, TLSSocket}, _From, State) ->
-    ParserState = reset_parser(State),
-    NewState = ParserState#state{socket = TLSSocket,
+    StateAfterReset = reset_parser(State),
+    NewState = StateAfterReset#state{socket = TLSSocket,
                                  sock_mod = fast_tls},
     case fast_tls:recv_data(TLSSocket, <<"">>) of
         {ok, TLSData} ->
@@ -148,8 +148,8 @@ handle_call({starttls, TLSSocket}, _From, State) ->
     end;
 handle_call({compress, ZlibSocket}, _From,
   #state{c2s_pid = C2SPid} = State) ->
-    ParserState = reset_parser(State),
-    NewState = ParserState#state{socket = ZlibSocket,
+    StateAfterReset = reset_parser(State),
+    NewState = StateAfterReset#state{socket = ZlibSocket,
                                  sock_mod = ejabberd_zlib},
     case ejabberd_zlib:recv_data(ZlibSocket, "") of
         {ok, ZlibData} ->
@@ -162,8 +162,8 @@ handle_call({compress, ZlibSocket}, _From,
             {stop, normal, ok, NewState}
     end;
 handle_call({become_controller, C2SPid}, _From, State) ->
-    ParserState = reset_parser(State),
-    NewState = ParserState#state{c2s_pid = C2SPid},
+    StateAfterReset = reset_parser(State),
+    NewState = StateAfterReset#state{c2s_pid = C2SPid},
     activate_socket(NewState),
     Reply = ok,
     {reply, Reply, NewState, ?HIBERNATE_TIMEOUT};


### PR DESCRIPTION
This PR addresses #1614

Proposed changes include:

Use cumulative chunk size when reporting the size of received stanzas. Chunk size "accumulates" until exml parses out a full stanza.

This is still imperfect since a single chunk can potentially contain more than one stanza but it's a much more useful approximation than never reporting anything above MTU size.
