### PR TITLE
[don't merge] Test if escalus with get_config/2 throwing errors doesn't mess up the tests

### DIFF
--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -10,7 +10,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "4786ac4972da8d02626239aee8f0487c2fea2dfd"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "193ce8d"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},


### PR DESCRIPTION
This PR tests if a change to Escalus public API, i.e. `escalus_config:get_config/2`, doesn't break the tests. The change is introduced in https://github.com/esl/escalus/pull/161.

Don't merge! This PR only intends to test an Escalus side branch. Once it's merged we can switch MIM to use the new Escalus.