### PR TITLE
Allow spaces in install dir name

### DIFF
--- a/rel/files/erl
+++ b/rel/files/erl
@@ -10,19 +10,19 @@
 ## file available in $ROOTDIR/release/VSN.
 
 # Determine the abspath of where this script is executing from.
-ERTS_BIN_DIR=$(cd ${0%/*} && pwd)
+ERTS_BIN_DIR=$(cd "${0%/*}" && pwd)
 
 # Now determine the root directory -- this script runs from erts-VSN/bin,
 # so we simply need to strip off two dirs from the end of the ERTS_BIN_DIR
 # path.
-ROOTDIR=${ERTS_BIN_DIR%/*/*}
+ROOTDIR="${ERTS_BIN_DIR%/*/*}"
 
 # Parse out release and erts info
-START_ERL=`cat $ROOTDIR/releases/start_erl.data`
-ERTS_VSN=${START_ERL% *}
-APP_VSN=${START_ERL#* }
+START_ERL=`cat "$ROOTDIR"/releases/start_erl.data`
+ERTS_VSN="${START_ERL% *}"
+APP_VSN="${START_ERL#* }"
 
-BINDIR=$ROOTDIR/erts-$ERTS_VSN/bin
+BINDIR="$ROOTDIR/erts-$ERTS_VSN/bin"
 EMU=beam
 PROGNAME=`echo $0 | sed 's/.*\\///'`
 CMD="$BINDIR/erlexec"
@@ -31,4 +31,4 @@ export ROOTDIR
 export BINDIR
 export PROGNAME
 
-exec $CMD -boot $ROOTDIR/releases/$APP_VSN/start_clean ${1+"$@"}
+exec "$CMD" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" ${1+"$@"}

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -4,31 +4,31 @@
 
 RUNNER_SCRIPT_DIR={{{mongooseim_script_dir}}}
 
-RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
-RUNNER_ETC_DIR={{mongooseim_etc_dir}}
-RUNNER_LOG_DIR={{mongooseim_log_dir}}
+RUNNER_BASE_DIR="${RUNNER_SCRIPT_DIR%/*}"
+RUNNER_ETC_DIR="{{mongooseim_etc_dir}}"
+RUNNER_LOG_DIR="{{mongooseim_log_dir}}"
 # Note the trailing slash on $PIPE_DIR/
 PIPE_DIR=/tmp/mongooseim_pipe_`whoami`/
 RUNNER_USER={{mongooseim_runner_user}}
 
-EJABBERD_SO_PATH=`ls -dt $RUNNER_BASE_DIR/lib/mongooseim-*/priv/lib | head -1`
-EJABBERD_CONFIG_PATH=$RUNNER_ETC_DIR/ejabberd.cfg
+EJABBERD_SO_PATH=`ls -dt "$RUNNER_BASE_DIR"/lib/mongooseim-*/priv/lib | head -1`
+EJABBERD_CONFIG_PATH="$RUNNER_ETC_DIR"/ejabberd.cfg
 export EJABBERD_SO_PATH
 export EJABBERD_CONFIG_PATH
 
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
-    exec sudo -u $RUNNER_USER -i $0 $@
+    exec sudo -u "$RUNNER_USER" -i "$0" "$@"
 fi
 
 # Make sure CWD is set to runner base dir
-cd $RUNNER_BASE_DIR
+cd "$RUNNER_BASE_DIR"
 
 # Make sure log directory exists
-mkdir -p $RUNNER_LOG_DIR
+mkdir -p "$RUNNER_LOG_DIR"
 
 # Extract the target node name from node.args
-NAME_ARG=`egrep -e '^-s?name' $RUNNER_ETC_DIR/vm.args`
+NAME_ARG=`egrep -e '^-s?name' "$RUNNER_ETC_DIR"/vm.args`
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1
@@ -38,40 +38,47 @@ NODE=$(echo $NAME_ARG | awk '{print $2}')
 MNESIA_DIR={{mongooseim_mdb_dir}}
 
 # Extract the target cookie
-COOKIE_ARG=`grep -e '^-setcookie' $RUNNER_ETC_DIR/vm.args`
+COOKIE_ARG=`grep -e '^-setcookie' "$RUNNER_ETC_DIR"/vm.args`
 if [ -z "$COOKIE_ARG" ]; then
     echo "vm.args needs to have a -setcookie parameter."
     exit 1
 fi
 
 # Identify the script name
-SCRIPT=`basename $0`
+SCRIPT=`basename "$0"`
 
 # Parse out release and erts info
-START_ERL=`cat $RUNNER_BASE_DIR/releases/start_erl.data`
-ERTS_VSN=${START_ERL% *}
-APP_VSN=${START_ERL#* }
+START_ERL=`cat "$RUNNER_BASE_DIR"/releases/start_erl.data`
+ERTS_VSN="${START_ERL% *}"
+APP_VSN="${START_ERL#* }"
 
 # Add ERTS bin dir to our path
-ERTS_PATH=$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin
+ERTS_PATH="$RUNNER_BASE_DIR/erts-$ERTS_VSN/bin"
 
 # Setup command to control the node
-NODETOOL="$ERTS_PATH/escript $ERTS_PATH/nodetool $NAME_ARG $COOKIE_ARG"
+function nodetool {
+    "$ERTS_PATH"/escript "$ERTS_PATH"/nodetool $NAME_ARG $COOKIE_ARG "$@"
+}
+
+function exec_echo {
+    echo "Exec: $@"
+    exec "$@"
+}
 
 # Check the first argument for instructions
 case "$1" in
     start)
         # Make sure there is not already a node running
-        RES=`$NODETOOL ping`
+        RES=`nodetool ping`
         if [ "$RES" = "pong" ]; then
             echo "Node is already running!"
             exit 1
         fi
         HEART_COMMAND="$RUNNER_BASE_DIR/bin/$SCRIPT start"
         export HEART_COMMAND
-        mkdir -p $PIPE_DIR
+        mkdir -p "$PIPE_DIR"
         shift # remove $1
-        $ERTS_PATH/run_erl -daemon $PIPE_DIR $RUNNER_LOG_DIR "exec $RUNNER_BASE_DIR/bin/$SCRIPT console $@" 2>&1
+        "$ERTS_PATH"/run_erl -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" "exec \"$RUNNER_BASE_DIR/bin/$SCRIPT\" console $@" 2>&1
         ;;
 
     stop)
@@ -92,7 +99,7 @@ case "$1" in
                 PID=`ps -efW|grep "$RUNNER_BASE_DIR/.*/[b]eam"|awk '{print $2}'`
                 ;;
         esac
-        $NODETOOL stop
+        nodetool stop
         while `kill -0 $PID 2>/dev/null`;
         do
             sleep 1
@@ -100,58 +107,57 @@ case "$1" in
         ;;
     restart)
         ## Restart the VM without exiting the process
-        $NODETOOL restart
+        nodetool restart
         ;;
 
     reboot)
         ## Restart the VM completely (uses heart to restart it)
-        $NODETOOL reboot
+        nodetool reboot
         ;;
 
     ping)
         ## See if the VM is alive
-        $NODETOOL ping
+        nodetool ping
         ;;
 
     attach)
         # Make sure a node IS running
-        RES=`$NODETOOL ping`
+        RES=`nodetool ping`
         if [ "$RES" != "pong" ]; then
             echo "Node is not running!"
             exit 1
         fi
 
         shift
-        $ERTS_PATH/to_erl $PIPE_DIR
+        "$ERTS_PATH"/to_erl "$PIPE_DIR"
         ;;
 
     console|live|console_clean)
         # .boot file typically just $SCRIPT (ie, the app name)
         # however, for debugging, sometimes start_clean.boot is useful:
         case "$1" in
-            console|live)   BOOTFILE=$SCRIPT ;;
+            console|live)   BOOTFILE="$SCRIPT" ;;
             console_clean)  BOOTFILE=start_clean ;;
         esac
         # Setup beam-required vars
-        ROOTDIR=$RUNNER_BASE_DIR
-        BINDIR=$ROOTDIR/erts-$ERTS_VSN/bin
+        ROOTDIR="$RUNNER_BASE_DIR"
+        BINDIR="$ROOTDIR/erts-$ERTS_VSN/bin"
         EMU=beam
         PROGNAME=`echo $0 | sed 's/.*\\///'`
-        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE -embedded -config $RUNNER_ETC_DIR/app.config -args_file $RUNNER_ETC_DIR/vm.args -args_file $RUNNER_ETC_DIR/vm.dist.args -- ${1+"$@"}"
+
         export EMU
         export ROOTDIR
         export BINDIR
         export PROGNAME
 
         # Dump environment info for logging purposes
-        echo "Exec: $CMD"
         echo "Root: $ROOTDIR"
 
         # Log the startup
         logger -t "$SCRIPT[$$]" "Starting up"
 
         # Start the VM
-        exec $CMD
+        exec_echo "$BINDIR/erlexec" -boot "$RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE" -embedded -config "$RUNNER_ETC_DIR/app.config" -args_file "$RUNNER_ETC_DIR/vm.args" -args_file "$RUNNER_ETC_DIR/vm.dist.args" -- ${1+"$@"}
         ;;
 
     debug)
@@ -175,26 +181,25 @@ case "$1" in
         NODE=$(echo $NAME_ARG | awk '{print $2}')
         TTY=$(basename `tty`)
 
-        ROOTDIR=$RUNNER_BASE_DIR
-        BINDIR=$ROOTDIR/erts-$ERTS_VSN/bin
+        ROOTDIR="$RUNNER_BASE_DIR"
+        BINDIR="$ROOTDIR/erts-$ERTS_VSN/bin"
         PROGNAME=`echo $0 | sed 's/.*\\///'`
-        CMD="$BINDIR/erl $NAME debug-$TTY-$NODE $COOKIE_ARG -remsh $NODE -hidden -args_file $RUNNER_ETC_DIR/vm.dist.args"
 
         # Log the startup
         logger -t "$SCRIPT[$$]" "Starting up"
 
         # Start the VM
-        exec $CMD
+        exec_echo "$BINDIR/erl" "$NAME" "debug-$TTY-$NODE" $COOKIE_ARG -remsh "$NODE" -hidden -args_file "$RUNNER_ETC_DIR/vm.dist.args"
         ;;
 
     version)
-        if [ $# == 2 ] && [ $2 == '--simple' ]
+        if [ $# == 2 ] && [ "$2" == '--simple' ]
         then
-            cat $RUNNER_BASE_DIR/priv/VERSION
+            cat "$RUNNER_BASE_DIR/priv/VERSION"
         else
-            cat $RUNNER_BASE_DIR/priv/logo.txt
+            cat "$RUNNER_BASE_DIR/priv/logo.txt"
             echo -n "MongooseIM version "
-            cat $RUNNER_BASE_DIR/priv/VERSION
+            cat "$RUNNER_BASE_DIR/priv/VERSION"
         fi
         ;;
     *)

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 RUNNER_SCRIPT_DIR={{{mongooseim_script_dir}}}
 RUNNER_BASE_DIR="${RUNNER_SCRIPT_DIR%/*}"

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -1,32 +1,32 @@
 #!/bin/sh
 
 RUNNER_SCRIPT_DIR={{{mongooseim_script_dir}}}
-RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
+RUNNER_BASE_DIR="${RUNNER_SCRIPT_DIR%/*}"
 ## Depending on build time config RUNNER_ETC_DIR may depend on RUNNER_BASE_DIR.
-RUNNER_ETC_DIR={{mongooseim_etc_dir}}
-RUNNER_USER={{mongooseim_runner_user}}
+RUNNER_ETC_DIR="{{mongooseim_etc_dir}}"
+RUNNER_USER="{{mongooseim_runner_user}}"
 
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
-    exec sudo -u $RUNNER_USER -i $0 $@
+    exec sudo -u "$RUNNER_USER" -i "$0" "$@"
 fi
 
-EJABBERD_DIR=${RUNNER_SCRIPT_DIR%/*}
-EJABBERD_VMARGS_PATH=${RUNNER_ETC_DIR}/vm.args
-START_ERL=`cat $EJABBERD_DIR/releases/start_erl.data`
-ERTS_VSN=${START_ERL% *}
-ERTS_PATH=$EJABBERD_DIR/erts-$ERTS_VSN/bin
-ERL=$ERTS_PATH/erl
-EPMD=$ERTS_PATH/epmd
-EJABBERD_EBIN_PATH=$EJABBERD_DIR/lib/mongooseim-*/ebin/
+EJABBERD_DIR="${RUNNER_SCRIPT_DIR%/*}"
+EJABBERD_VMARGS_PATH="${RUNNER_ETC_DIR}"/vm.args
+START_ERL=`cat "$EJABBERD_DIR"/releases/start_erl.data`
+ERTS_VSN="${START_ERL% *}"
+ERTS_PATH="$EJABBERD_DIR/erts-$ERTS_VSN/bin"
+ERL="$ERTS_PATH"/erl
+EPMD="$ERTS_PATH"/epmd
+EJABBERD_EBIN_PATH="$EJABBERD_DIR"/lib/mongooseim-*/ebin/
 
-COOKIE_ARG=`grep -e '^-setcookie' $EJABBERD_VMARGS_PATH`
+COOKIE_ARG=`grep -e '^-setcookie' "$EJABBERD_VMARGS_PATH"`
 if [ -z "$COOKIE_ARG" ]; then
     echo "vm.args needs to have a -setcookie parameter."
     exit 1
 fi
 
-NODENAME_ARG=`egrep -e '^-s?name' $EJABBERD_VMARGS_PATH`
+NODENAME_ARG=`egrep -e '^-s?name' "$EJABBERD_VMARGS_PATH"`
 if [ -z "$NODENAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1
@@ -89,23 +89,23 @@ manage_cluster()
 
 start ()
 {
-    $RUNNER_SCRIPT_DIR/mongooseim start
+    "$RUNNER_SCRIPT_DIR"/mongooseim start
 }
 stop ()
 {
-    $RUNNER_SCRIPT_DIR/mongooseim stop
+    "$RUNNER_SCRIPT_DIR"/mongooseim stop
 }
 
 # attach to server
 debug ()
 {
-    $RUNNER_SCRIPT_DIR/mongooseim debug
+    "$RUNNER_SCRIPT_DIR"/mongooseim debug
 }
 
 # start interactive server
 live ()
 {
-    $RUNNER_SCRIPT_DIR/mongooseim console
+    "$RUNNER_SCRIPT_DIR"/mongooseim console
 }
 
 help ()
@@ -131,8 +131,8 @@ ctl ()
     # using flock if available. Expects a linux-style
     # flock that can lock a file descriptor.
     MAXCONNID=100
-    CONNLOCKDIR={{mongooseim_lock_dir}}/ctl
-    mkdir -p $CONNLOCKDIR
+    CONNLOCKDIR="{{mongooseim_lock_dir}}/ctl"
+    mkdir -p "$CONNLOCKDIR"
     FLOCK='/usr/bin/flock'
     if [ ! -x "$FLOCK" ] || [ ! -d "$CONNLOCKDIR" ] ; then
 	JOT='/usr/bin/jot'
@@ -203,12 +203,12 @@ ctlexec ()
 {
     CONN_NAME=$1; shift
     COMMAND=$@
-    $ERL \
+    "$ERL" \
       $NAME_TYPE ${CONN_NAME} \
       -noinput \
       -hidden \
       $COOKIE_ARG \
-      -args_file $RUNNER_ETC_DIR/vm.dist.args \
+      -args_file "$RUNNER_ETC_DIR"/vm.dist.args \
       -pa "$EJABBERD_EBIN_PATH" \
       -s ejabberd_ctl -extra $NODENAME $COMMAND
 }
@@ -223,7 +223,7 @@ usage ()
 # stop epmd if there is no other running node
 stop_epmd()
 {
-    $EPMD -names | grep -q name || $EPMD -kill
+    "$EPMD" -names | grep -q name || "$EPMD" -kill
 }
 
 # allow sync calls

--- a/rel/files/nodetool
+++ b/rel/files/nodetool
@@ -104,10 +104,23 @@ process_args(["-exact_sname", TargetName | Rest], Acc, _) ->
 process_args([Arg | Rest], Acc, Opts) ->
     process_args(Rest, [Arg | Acc], Opts).
 
-
 start_epmd() ->
-    [] = os:cmd(epmd_path() ++ " -daemon"),
+    EpmdPath = epmd_path(),
+    Port = open_port({spawn_executable, EpmdPath}, [exit_status, {args, ["-daemon"]}]),
+    wait_epmd(Port, []),
+    catch port_close(Port),
     ok.
+
+wait_epmd(Port, Data) ->
+    receive
+        {Port, {data, NewData}} ->
+            wait_epmd(Port, Data++NewData);
+        {Port, {exit_status, 0}} ->
+            Data;
+        {Port, {exit_status, E}} ->
+            io:format("Could not start epmd.~n"),
+            throw({badarg, E, Data})
+    end.
 
 epmd_path() ->
     ErtsBinDir = filename:dirname(escript:script_name()),

--- a/rel/files/nodetool
+++ b/rel/files/nodetool
@@ -105,9 +105,9 @@ process_args([Arg | Rest], Acc, Opts) ->
     process_args(Rest, [Arg | Acc], Opts).
 
 start_epmd() ->
-    EpmdPath = epmd_path(),
-    Port = open_port({spawn_executable, EpmdPath}, [exit_status, {args, ["-daemon"]}]),
-    wait_epmd(Port, []),
+    Port = open_port({spawn_executable, epmd_path()},
+                     [exit_status, stderr_to_stdout, {args, ["-daemon"]}]),
+    [] = wait_epmd(Port, []),
     catch port_close(Port),
     ok.
 
@@ -118,7 +118,6 @@ wait_epmd(Port, Data) ->
         {Port, {exit_status, 0}} ->
             Data;
         {Port, {exit_status, E}} ->
-            io:format("Could not start epmd.~n"),
             throw({badarg, E, Data})
     end.
 

--- a/tools/configure
+++ b/tools/configure
@@ -14,7 +14,7 @@
                reltool_vars     = "rel/configure.vars.config",
                system           = "no",
                user             = "",
-               script_dir       = "$(cd ${0%/*} && pwd)",
+               script_dir       = "$(cd \"${0%/*}\" && pwd)",
                bin_dir          = undefined,
                etc_dir          = "$RUNNER_BASE_DIR/etc",
                lib_dir          = undefined,


### PR DESCRIPTION
This PR addresses #1620

Proposed changes include:
* the bulk of the changes is just quoting bash variables correctly
* the only "interesting" change is to the `nodetool`, which is changed to call `epmd` through `open_port` directly since `os:cmd` tries to parse its parameter and, naturally, fails on spaces too.

This seems to be fully operational with OTP 20. Unfortunately, `nodetool` invocations are still broken on prior releases; this is due to escript itself breaking when invoked from a directory with spaces - I'm not sure how much can be done about that...


  