### PR TITLE
Use gen_mod opts in MAM

### DIFF
--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -435,10 +435,9 @@ handle_lookup_messages(#jid{} = From, #jid{} = ArcJID,
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
-    ExtraParamsModule = param(Host, extra_lookup_params, undefined),
-    Params0 = mam_iq:query_to_lookup_params(IQ, param(Host, max_result_limit, 50),
-                                            param(Host, default_result_limit, 50),
-                                            ExtraParamsModule),
+    Params0 = mam_iq:query_to_lookup_params(IQ, max_result_limit(Host),
+                                            default_result_limit(Host),
+                                            extra_params_module(Host)),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID),
     case lookup_messages(Host, Params) of
         {error, 'policy-violation'} ->
@@ -469,10 +468,9 @@ handle_set_message_form(#jid{} = From, #jid{} = ArcJID,
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
-    ExtraParamsModule = param(Host, extra_lookup_params, undefined),
-    Params0 = mam_iq:form_to_lookup_params(IQ, param(Host, max_result_limit, 50),
-                                           param(Host, default_result_limit, 50),
-                                           ExtraParamsModule),
+    Params0 = mam_iq:form_to_lookup_params(IQ, max_result_limit(Host),
+                                           default_result_limit(Host),
+                                           extra_params_module(Host)),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID),
     PageSize = maps:get(page_size, Params),
     case lookup_messages(Host, Params) of
@@ -815,10 +813,16 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver=LServer, luser=LUser}, IQ) 
 
 
 %% ----------------------------------------------------------------------
-%% Dynamic params module
+%% Dynamic params
 
-param(Host, Opt, Default) ->
-    mod_mam_utils:param(?MODULE, Host, Opt, Default).
+extra_params_module(Host) ->
+    mod_mam_utils:param(?MODULE, Host, extra_lookup_params, undefined).
+
+max_result_limit(Host) ->
+    mod_mam_utils:param(?MODULE, Host, max_result_limit, 50).
+
+default_result_limit(Host) ->
+    mod_mam_utils:param(?MODULE, Host, default_result_limit, 50).
 
 is_archivable_message(Host, Dir, Packet) ->
     mod_mam_utils:call_is_archivable_message(?MODULE, Host, Dir, Packet).

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -314,9 +314,10 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Acc, Packet}) ->
                 PacketWithoutAmp = mod_amp:strip_amp_el_from_request(Packet),
                 case process_incoming_packet(From, To, PacketWithoutAmp) of
                     undefined -> {mam_failed, Packet};
-                    MessID -> {archived, maybe_add_arcid_elems(To, MessID, Packet,
-                                                               add_archived_element(LServer),
-                                                               add_stanzaid_element(LServer))}
+                    MessID -> {archived, maybe_add_arcid_elems(
+                                           To, MessID, Packet,
+                                           mod_mam_params:add_archived_element(?MODULE, LServer),
+                                           mod_mam_params:add_stanzaid_element(?MODULE, LServer))}
                 end
         end,
     Acc1 = mongoose_acc:put(element, PacketAfterArchive, Acc),
@@ -435,9 +436,9 @@ handle_lookup_messages(#jid{} = From, #jid{} = ArcJID,
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
-    Params0 = mam_iq:query_to_lookup_params(IQ, max_result_limit(Host),
-                                            default_result_limit(Host),
-                                            extra_params_module(Host)),
+    Params0 = mam_iq:query_to_lookup_params(IQ, mod_mam_params:max_result_limit(?MODULE, Host),
+                                            mod_mam_params:default_result_limit(?MODULE, Host),
+                                            mod_mam_params:extra_params_module(?MODULE, Host)),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID),
     case lookup_messages(Host, Params) of
         {error, 'policy-violation'} ->
@@ -468,9 +469,9 @@ handle_set_message_form(#jid{} = From, #jid{} = ArcJID,
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
-    Params0 = mam_iq:form_to_lookup_params(IQ, max_result_limit(Host),
-                                           default_result_limit(Host),
-                                           extra_params_module(Host)),
+    Params0 = mam_iq:form_to_lookup_params(IQ, mod_mam_params:max_result_limit(?MODULE, Host),
+                                           mod_mam_params:default_result_limit(?MODULE, Host),
+                                           mod_mam_params:extra_params_module(?MODULE, Host)),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID),
     PageSize = maps:get(page_size, Params),
     case lookup_messages(Host, Params) of
@@ -672,7 +673,7 @@ remove_archive(Host, ArcID, ArcJID=#jid{}) ->
     | {error, 'policy-violation'}
     | {error, Reason :: term()}.
 lookup_messages(Host, #{search_text := SearchText} = Params) ->
-    case SearchText /= undefined andalso not mod_mam_utils:has_full_text_search(?MODULE, Host) of
+    case SearchText /= undefined andalso not mod_mam_params:has_full_text_search(?MODULE, Host) of
         true -> %% Use of disabled full text search
             {error, 'not-supported'};
         false ->
@@ -811,24 +812,9 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver=LServer, luser=LUser}, IQ) 
     ?ERROR_MSG("issue=~p, server=~p, user=~p, reason=~p, iq=~p, stacktrace=~p",
                [Issue, LServer, LUser, Reason, IQ, Stacktrace]).
 
-
-%% ----------------------------------------------------------------------
-%% Dynamic params
-
-extra_params_module(Host) ->
-    mod_mam_utils:param(?MODULE, Host, extra_lookup_params, undefined).
-
-max_result_limit(Host) ->
-    mod_mam_utils:param(?MODULE, Host, max_result_limit, 50).
-
-default_result_limit(Host) ->
-    mod_mam_utils:param(?MODULE, Host, default_result_limit, 50).
-
+-spec is_archivable_message(Host :: ejabberd:lserver(), Dir :: incoming | outgoing,
+                            Packet :: exml:element()) -> boolean().
 is_archivable_message(Host, Dir, Packet) ->
-    mod_mam_utils:call_is_archivable_message(?MODULE, Host, Dir, Packet).
-
-add_archived_element(Host) ->
-    mod_mam_utils:add_archived_element(?MODULE, Host).
-
-add_stanzaid_element(Host) ->
-    mod_mam_utils:add_stanzaid_element(?MODULE, Host).
+    {M, F} = mod_mam_params:is_archivable_message_fun(?MODULE, Host),
+    ArchiveChatMarkers = mod_mam_params:archive_chat_markers(?MODULE, Host),
+    erlang:apply(M, F, [?MODULE, Dir, Packet, ArchiveChatMarkers]).

--- a/src/mod_mam_muc.erl
+++ b/src/mod_mam_muc.erl
@@ -248,8 +248,8 @@ archive_room_packet(Packet, FromNick, FromJID=#jid{}, RoomJID=#jid{}, Role, Affi
                     maybe_add_arcid_elems(RoomJID,
                                           mess_id_to_external_binary(MessID),
                                              Packet,
-                                             add_archived_element(Host),
-                                             add_stanzaid_element(Host));
+                                             mod_mam_params:add_archived_element(?MODULE, Host),
+                                             mod_mam_params:add_stanzaid_element(?MODULE, Host));
                 {error, _} -> Packet
             end;
         false -> Packet
@@ -402,9 +402,9 @@ handle_lookup_messages(#jid{} = From, #jid{} = ArcJID,
     {ok, Host} = mongoose_subhosts:get_host(ArcJID#jid.lserver),
     ArcID = archive_id_int(Host, ArcJID),
     QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
-    Params0 = mam_iq:query_to_lookup_params(IQ, max_result_limit(Host),
-                                            default_result_limit(Host),
-                                            extra_params_module(Host)),
+    Params0 = mam_iq:query_to_lookup_params(IQ, mod_mam_params:max_result_limit(?MODULE, Host),
+                                            mod_mam_params:default_result_limit(?MODULE, Host),
+                                            mod_mam_params:extra_params_module(?MODULE, Host)),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID),
     case lookup_messages(Host, Params) of
         {error, 'policy-violation'} ->
@@ -434,9 +434,9 @@ handle_lookup_messages(#jid{} = From, #jid{} = ArcJID,
 handle_set_message_form(#jid{} = From, #jid{} = ArcJID, IQ) ->
     {ok, Host} = mongoose_subhosts:get_host(ArcJID#jid.lserver),
     ArcID = archive_id_int(Host, ArcJID),
-    Params0 = mam_iq:form_to_lookup_params(IQ, max_result_limit(Host),
-                                           default_result_limit(Host),
-                                           extra_params_module(Host)),
+    Params0 = mam_iq:form_to_lookup_params(IQ, mod_mam_params:max_result_limit(?MODULE, Host),
+                                           mod_mam_params:default_result_limit(?MODULE, Host),
+                                           mod_mam_params:extra_params_module(?MODULE, Host)),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID),
     Result = lookup_messages(Host, Params),
     handle_lookup_result(Result, From, IQ, Params).
@@ -598,7 +598,7 @@ remove_archive(Host, ArcID, ArcJID = #jid{}) ->
     | {error, 'policy-violation'}
     | {error, Reason :: term()}.%Result :: any(),
 lookup_messages(Host, #{search_text := SearchText} = Params) ->
-    case SearchText /= undefined andalso not mod_mam_utils:has_full_text_search(?MODULE, Host) of
+    case SearchText /= undefined andalso not mod_mam_params:has_full_text_search(?MODULE, Host) of
         true -> %% Use of disabled full text search
             {error, 'not-supported'};
         false ->
@@ -763,23 +763,9 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver = LServer, luser = LUser}, 
     ?ERROR_MSG("issue=~p, server=~p, user=~p, reason=~p, iq=~p, stacktrace=~p",
                [Issue, LServer, LUser, Reason, IQ, Stacktrace]).
 
-%% ----------------------------------------------------------------------
-%% Dynamic params
-
-extra_params_module(Host) ->
-    mod_mam_utils:param(?MODULE, Host, extra_lookup_params, undefined).
-
-max_result_limit(Host) ->
-    mod_mam_utils:param(?MODULE, Host, max_result_limit, 50).
-
-default_result_limit(Host) ->
-    mod_mam_utils:param(?MODULE, Host, default_result_limit, 50).
-
+-spec is_archivable_message(Host :: ejabberd:lserver(), Dir :: incoming | outgoing,
+                            Packet :: exml:element()) -> boolean().
 is_archivable_message(Host, Dir, Packet) ->
-    mod_mam_utils:call_is_archivable_message(?MODULE, Host, Dir, Packet).
-
-add_archived_element(Host) ->
-    mod_mam_utils:add_archived_element(?MODULE, Host).
-
-add_stanzaid_element(Host) ->
-    mod_mam_utils:add_stanzaid_element(?MODULE, Host).
+    {M, F} = mod_mam_params:is_archivable_message_fun(?MODULE, Host),
+    ArchiveChatMarkers = mod_mam_params:archive_chat_markers(?MODULE, Host),
+    erlang:apply(M, F, [?MODULE, Dir, Packet, ArchiveChatMarkers]).

--- a/src/mod_mam_params.erl
+++ b/src/mod_mam_params.erl
@@ -1,0 +1,78 @@
+%%==============================================================================
+%% Copyright 2018 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(mod_mam_params).
+
+-type mam_module() :: mod_mam | mod_mam_muc.
+
+-export([extra_params_module/2, max_result_limit/2, default_result_limit/2,
+         has_full_text_search/2, is_archivable_message_fun/2, archive_chat_markers/2,
+         add_archived_element/2, add_stanzaid_element/2]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec extra_params_module(mam_module(), Host :: ejabberd:lserver()) -> module() | undefined.
+extra_params_module(Module, Host) ->
+    param(Module, Host, extra_lookup_params, undefined).
+
+-spec max_result_limit(mam_module(), Host :: ejabberd:lserver()) -> pos_integer().
+max_result_limit(Module, Host) ->
+    param(Module, Host, max_result_limit, 50).
+
+-spec default_result_limit(mam_module(), Host :: ejabberd:lserver()) -> pos_integer().
+default_result_limit(Module, Host) ->
+    param(Module, Host, default_result_limit, 50).
+
+-spec has_full_text_search(Module :: mod_mam | mod_mam_muc, Host :: ejabberd:server()) -> boolean().
+has_full_text_search(Module, Host) ->
+    param(Module, Host, full_text_search, true).
+
+-spec is_archivable_message_fun(mam_module(), Host :: ejabberd:lserver()) ->
+                                       MF :: {module(), atom()}.
+is_archivable_message_fun(Module, Host) ->
+    {IsArchivableModule, IsArchivableFunction} =
+        case param(Module, Host, is_archivable_message, undefined) of
+            undefined ->
+                case param(Module, Host, is_complete_message, undefined) of
+                    undefined -> {mod_mam_utils, is_archivable_message};
+                    OldStyleMod -> {OldStyleMod, is_complete_message}
+                end;
+
+            Mod -> {Mod, is_archivable_message}
+        end,
+    {IsArchivableModule, IsArchivableFunction}.
+
+-spec archive_chat_markers(mam_module(), Host :: ejabberd:lserver()) -> boolean().
+archive_chat_markers(Module, Host) ->
+    param(Module, Host, archive_chat_markers, false).
+
+-spec add_archived_element(mam_module(), Host :: ejabberd:lserver()) -> boolean().
+add_archived_element(Module, Host) ->
+    param(Module, Host, add_archived_element, false).
+
+-spec add_stanzaid_element(mam_module(), Host :: ejabberd:lserver()) -> boolean().
+add_stanzaid_element(Module, Host) ->
+    not param(Module, Host, no_stanzaid_element, false).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+-spec param(mam_module(), Host :: ejabberd:lserver(), Opt :: term(), Default :: term()) -> term().
+param(Module, Host, Opt, Default) ->
+    gen_mod:get_module_opt(Host, Module, Opt, Default).

--- a/src/mod_mam_utils.erl
+++ b/src/mod_mam_utils.erl
@@ -1067,9 +1067,12 @@ error_on_sql_error(_HostOrConn, _Query, Result) ->
 wrapper_id() ->
     uuid:uuid_to_string(uuid:get_v4(), binary_standard).
 
+-spec param(module(), Host :: ejabberd:lserver(), Opt :: term(), Default :: term()) -> term().
 param(Module, Host, Opt, Default) ->
     gen_mod:get_module_opt(Host, Module, Opt, Default).
 
+-spec call_is_archivable_message(module(), Host :: ejabberd:lserver(),
+                                 Dir :: incoming | outgoing, Packet :: jlib:xmlel()) -> boolean().
 call_is_archivable_message(Module, Host, Dir, Packet) ->
     {IsArchivableModule, IsArchivableFunction} =
         case param(Module, Host, is_archivable_message, undefined) of
@@ -1086,10 +1089,10 @@ call_is_archivable_message(Module, Host, Dir, Packet) ->
                  [Module, Dir, Packet, ArchiveChatMarkers]).
 
 %% @doc Enable support for `<archived/>' element from MAM v0.2
-%% -spec add_archived_element(Host :: ejabberd:lserver()) -> boolean().
+-spec add_archived_element(module(), Host :: ejabberd:lserver()) -> boolean().
 add_archived_element(Module, Host) ->
     param(Module, Host, add_archived_element, false).
 
-%% -spec add_stanzaid_element(Host :: ejabberd:lserver()) -> boolean().
+-spec add_stanzaid_element(module(), Host :: ejabberd:lserver()) -> boolean().
 add_stanzaid_element(Module, Host) ->
     not param(Module, Host, no_stanzaid_element, false).

--- a/src/mod_mam_utils.erl
+++ b/src/mod_mam_utils.erl
@@ -69,10 +69,6 @@
 %% SQL
 -export([success_sql_query/2, success_sql_execute/3]).
 
-%% Params
--export([param/4, call_is_archivable_message/4,
-         add_archived_element/2, add_stanzaid_element/2]).
-
 %% Other
 -export([maybe_integer/2,
          maybe_min/2,
@@ -1066,33 +1062,3 @@ error_on_sql_error(_HostOrConn, _Query, Result) ->
 -spec wrapper_id() -> binary().
 wrapper_id() ->
     uuid:uuid_to_string(uuid:get_v4(), binary_standard).
-
--spec param(module(), Host :: ejabberd:lserver(), Opt :: term(), Default :: term()) -> term().
-param(Module, Host, Opt, Default) ->
-    gen_mod:get_module_opt(Host, Module, Opt, Default).
-
--spec call_is_archivable_message(module(), Host :: ejabberd:lserver(),
-                                 Dir :: incoming | outgoing, Packet :: jlib:xmlel()) -> boolean().
-call_is_archivable_message(Module, Host, Dir, Packet) ->
-    {IsArchivableModule, IsArchivableFunction} =
-        case param(Module, Host, is_archivable_message, undefined) of
-            undefined ->
-                case param(Module, Host, is_complete_message, undefined) of
-                    undefined -> {mod_mam_utils, is_archivable_message};
-                    OldStyleMod -> {OldStyleMod, is_complete_message}
-                end;
-
-            Mod -> {Mod, is_archivable_message}
-        end,
-    ArchiveChatMarkers = param(Module, Host, archive_chat_markers, false),
-    erlang:apply(IsArchivableModule, IsArchivableFunction,
-                 [Module, Dir, Packet, ArchiveChatMarkers]).
-
-%% @doc Enable support for `<archived/>' element from MAM v0.2
--spec add_archived_element(module(), Host :: ejabberd:lserver()) -> boolean().
-add_archived_element(Module, Host) ->
-    param(Module, Host, add_archived_element, false).
-
--spec add_stanzaid_element(module(), Host :: ejabberd:lserver()) -> boolean().
-add_stanzaid_element(Module, Host) ->
-    not param(Module, Host, no_stanzaid_element, false).


### PR DESCRIPTION
This PR removes dynamically compiled `mod_mam_prefs` and `mod_mam_muc_prefs` modules in favor of fetching module options with ETS via `gen_mod:get_module_opts()` and then searching for the right option with `lists:keyfind`.