### PR TITLE
Change ?MYHOST to To#jid.lserver

### DIFF
--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -38,7 +38,7 @@ stop(_Host) ->
 
 push_event(_, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
-    Mod = get_callback_module(To#jid.lserver),
+    Mod = get_callback_module(From#jid.lserver),
     case Mod:should_make_req(Packet, From, To) of
         true ->
             make_req(From#jid.lserver, From#jid.luser, To#jid.luser, Body);

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -38,7 +38,7 @@ stop(_Host) ->
 
 push_event(_, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
-    Mod = get_callback_module(),
+    Mod = get_callback_module(To#jid.lserver),
     case Mod:should_make_req(Packet, From, To) of
         true ->
             make_req(From#jid.lserver, From#jid.luser, To#jid.luser, Body);
@@ -52,8 +52,8 @@ push_event(_, _Event) ->
 %%% Internal functions
 %%%===================================================================
 
-get_callback_module() ->
-    gen_mod:get_module_opt(?MYNAME, ?MODULE, callback_module, mod_event_pusher_http_defaults).
+get_callback_module(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, callback_module, mod_event_pusher_http_defaults).
 
 make_req(Host, Sender, Receiver, Message) ->
     Path = fix_path(list_to_binary(gen_mod:get_module_opt(Host, ?MODULE, path, ?DEFAULT_PATH))),


### PR DESCRIPTION
Remove usage of constant to get callback module for http notifications

# Rationale behind using To-server to find callback module
Some investigations were made and tests were run to figure out in which context the callback module is needed. My conclusion so far is to use the To-server due to the following.

### From XEP-0203: Delayed Delivery
Attribute: `From`
Description: The Jabber ID of the entity that originally sent the XML stanza or that **delayed the delivery of the stanza**

#### Delivered message with receiving user's host as the from attribute in the delay element
The "from" attribute in the delay element is the same as the receiving user's host:
```
{xmlel,<<"message">>,
                [{<<"from">>,<<"bOb@localhost">>},
                {<<"to">>,<<"alicE@localhost.bis">>},
                 {<<"xml:lang">>,<<"en">>},
                 {<<"type">>,<<"chat">>}],
                [{xmlel,<<"body">>,[],[{xmlcdata,<<"Hi, Alice!">>}]},
                 {xmlel,<<"delay">>,
                        [{<<"xmlns">>,<<"urn:xmpp:delay">>},
                         {<<"from">>,<<"localhost.bis">>},
                         {<<"stamp">>,<<"2018-01-08T16:10:22.380309Z">>}],
                        [{xmlcdata,<<"Offline Storage">>}]}]}
```
and
```
{xmlel,<<"message">>,
                [{<<"from">>,<<"alicE@localhost.bis">>},
                 {<<"to">>,<<"bOb@localhost">>},
                 {<<"xml:lang">>,<<"en">>},
                 {<<"type">>,<<"chat">>}],
                [{xmlel,<<"body">>,[],[{xmlcdata,<<"Hi, Bob!">>}]},
                 {xmlel,<<"delay">>,
                        [{<<"xmlns">>,<<"urn:xmpp:delay">>},
                         {<<"from">>,<<"localhost">>},
                         {<<"stamp">>,<<"2018-01-08T16:10:22.380301Z">>}],
                        [{xmlcdata,<<"Offline Storage">>}]}]}
```
I am unsure if this justifies the changes made so be mean to me if I am making any weird assumptions here.

  