### PR TITLE
Update recommended config values

### DIFF
--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -84,7 +84,7 @@ innodb_file_format=BARRACUDA
 innodb_file_format_max=BARRACUDA
 innodb_file_per_table=true
 ```
-For versions `5.7.9` and later, all of the above options are set correctly by default.
+For versions `5.7.9` and newer, all of the above options are set correctly by default.
 ## PostgreSQL
 
 **Can be used for:**

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -76,7 +76,7 @@ Please refer to the [Advanced configuration/Database setup](../Advanced-configur
 
 **Version notice**
 
-The required minimum version of MySQL is `5.5.14`. For versions `5.7.6` or older, add the following options to your MySQL configuration file:
+The required minimum version of MySQL is `5.5.14`. For versions `5.7.8` and older, add the following options to your MySQL configuration file:
 
 ```bash
 innodb_large_prefix=true
@@ -84,7 +84,7 @@ innodb_file_format=BARRACUDA
 innodb_file_format_max=BARRACUDA
 innodb_file_per_table=true
 ```
-
+For versions `5.7.9` and later, all of the above options are set correctly by default.
 ## PostgreSQL
 
 **Can be used for:**

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -76,12 +76,13 @@ Please refer to the [Advanced configuration/Database setup](../Advanced-configur
 
 **Version notice**
 
-The required minimum version of MySQL is `5.5.14`. If you are using a version `5.7.6` or older, add the following options to your MySQL configuration file:
+The required minimum version of MySQL is `5.5.14`. For versions `5.7.6` or older, add the following options to your MySQL configuration file:
 
 ```bash
-innodb_large_prefix=ON
+innodb_large_prefix=true
 innodb_file_format=BARRACUDA
 innodb_file_format_max=BARRACUDA
+innodb_file_per_table=true
 ```
 
 ## PostgreSQL

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -19,7 +19,8 @@
 
 -- Needs MySQL (at least 5.5.14) with innodb back-end
 -- See the MongooseIM Database Backends documentation for how to configure
--- MySQL versions 5.5.14 to 5.7.6 to use this schema
+-- MySQL versions 5.5.14 to 5.7.8 to use this schema.
+-- Later versions are compatible by default.
 
 CREATE TABLE users (
     username varchar(250) PRIMARY KEY,


### PR DESCRIPTION
This PR updates recommended configuration options for MySQL backend.

## Tested with v 5.7.20
Default for both variables is `on`.
### innodb_large_prefix
Default is **on**
Accepts `on/true` and `off/false`.
### innodb_file_per_table
Default is **on**
Accepts `on/off` and `true/false`

## Tested with v 5.6.38
### innodb_large_prefix
Default is **off**,
Accepts `on/true` and `off/false`

### innodb_file_per_table
for v. <= 5.6.5, default is **off**
and v. >= 5.6.6, it is **on**
Accepts `on/true` and `off/false`

