### PR TITLE
Treat minified javascript as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# These javascript libraries are minified
+# This produces ugly results of "git diff" and "git grep" commands
+# Treating them as binary would reduce noise
+# TODO consider moving such libraries into a separate branch/repo
+examples/websockets/jsjac/jsjac.js      binary
+doc/swagger/swagger-ui.min.js           binary
+doc/swagger/lib/*.js                    binary
+doc/open-extensions/prettify.js         binary


### PR DESCRIPTION
This PR addresses ugly output of "git grep function" and similar commands.
Minified files are usually one-liner, that matches almost every search request.
This PR would replace output with:

```
git grep function | grep js                                                    
Binary file doc/open-extensions/prettify.js matches                                                                               
Binary file doc/swagger/lib/backbone-min.js matches                                                                               
Binary file doc/swagger/lib/es5-shim.js matches                                                                                   
Binary file doc/swagger/lib/handlebars-2.0.0.js matches                                                                           
Binary file doc/swagger/lib/highlight.9.1.0.pack.js matches                                                                       
Binary file doc/swagger/lib/highlight.9.1.0.pack_extended.js matches                                                              
Binary file doc/swagger/lib/jquery.ba-bbq.min.js matches                                                                          
Binary file doc/swagger/lib/jquery.slideto.min.js matches                                                                         
Binary file doc/swagger/lib/jquery.wiggle.min.js matches                                                                          
Binary file doc/swagger/lib/js-yaml.min.js matches                                                                                
Binary file doc/swagger/lib/jsoneditor.min.js matches                                                                             
Binary file doc/swagger/lib/lodash.min.js matches                                                                                 
Binary file doc/swagger/lib/marked.js matches                                                                                     
Binary file doc/swagger/lib/object-assign-pollyfill.js matches                                                                    
Binary file doc/swagger/lib/swagger-oauth.js matches                                                                              
Binary file doc/swagger/swagger-ui.min.js matches                
Binary file examples/websockets/jsjac/jsjac.js matches
```
