### PR TITLE
Disable tests that break cover

### DIFF
--- a/test.disabled/ejabberd_tests/tests/cluster_commands_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/cluster_commands_SUITE.erl
@@ -60,7 +60,7 @@ clustering_two_tests() ->
 clustering_three_tests() ->
     [cluster_of_three,
         leave_the_three,
-        remove_dead_from_cluster,
+        %remove_dead_from_cluster, % TODO: Breaks cover
         remove_alive_from_cluster].
 
 require_all_nodes() ->

--- a/test.disabled/ejabberd_tests/tests/component_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/component_SUITE.erl
@@ -46,7 +46,10 @@ groups() ->
     [{xep0114_tcp, [], xep0114_tests()},
      {xep0114_ws, [], xep0114_tests()},
      {subdomain, [], [register_subdomain]},
-     {distributed, [], [register_in_cluster, register_same_on_both, clear_on_node_down]}].
+     {distributed, [], [register_in_cluster,
+                        register_same_on_both
+                        %clear_on_node_down TODO: Breaks cover
+                       ]}].
 
 suite() ->
     escalus:suite().


### PR DESCRIPTION
This PR disables test cases that stop MIM node completely, effectively breaking (stopping) cover.

These should be fixed later.