### PR TITLE
Update escalus to use xmlview

### DIFF
--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -10,7 +10,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "aa8821c1028f26823eacbaa991c8aa6ab524fd4b"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "978400f16cadb944211593652b57dad638df872c"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},


### PR DESCRIPTION
New version of escalus should display stanza log XML file using XML viewer.

Viewer example:
http://mongooseim-ct-results.s3-eu-west-1.amazonaws.com/PR/1663/3971/pgsql_mnesia.20.0/big/ct_run.test@travis-job-791bd2f0-1981-4f7a-8184-24247fc02da4.2018-01-17_17.02.39/ejabberd_tests.tests.offline_SUITE.logs/run.2018-01-17_17.15.54/log_private/error_message_is_not_stored.xml