### PR TITLE
Ensure that user actually logouts in offline_SUITE tests

### DIFF
--- a/test.disabled/ejabberd_tests/tests/offline_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/offline_SUITE.erl
@@ -158,7 +158,7 @@ is_chat(Content) ->
 %%%===================================================================
 
 logout(Config, User) ->
-    escalus_client:stop(Config, User).
+    mongoose_helper:logout_user(Config, User).
 
 login_send_presence(Config, User) ->
     {ok, Client} = escalus_client:start(Config, User, <<"new-session">>),


### PR DESCRIPTION
Fixes 

This PR addresses #1667 #1672  #1664

Proposed changes include:
* Fix for failing offline tests
* New helper function mongoose_helper:logout_user/2