### PR TITLE
Disable test_in_order_messages_on_multiple_connections_with_bounce #1683

### DIFF
--- a/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
@@ -72,7 +72,8 @@ groups() ->
       [
        test_in_order_messages_on_multiple_connections,
        test_muc_conversation_history,
-       test_in_order_messages_on_multiple_connections_with_bounce,
+       % XXX Disabled, see #1683
+%      test_in_order_messages_on_multiple_connections_with_bounce,
        test_messages_bounced_in_order
       ]},
      {rebalancing, [shuffle],


### PR DESCRIPTION
It fails to often, see #1683 with some debug info