### PR TITLE
Use escalus with copy-xml-pretty-viewer fix

### DIFF
--- a/test.disabled/ejabberd_tests/rebar.config
+++ b/test.disabled/ejabberd_tests/rebar.config
@@ -10,7 +10,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "978400f16cadb944211593652b57dad638df872c"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "f417af8c2fd0e68069e5c5f36e1ae4e5ddf38079"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},


### PR DESCRIPTION
New code copies XSL file to ct_reports.
It should fix XML stanza reports in Chrome.

This PR addresses https://github.com/esl/escalus/pull/165

Example, should work in chrome
http://mongooseim-ct-results.s3-eu-west-1.amazonaws.com/PR/1687/4023/pgsql_mnesia.20.0/big/ct_run.test@travis-job-a932f466-a9c7-4eca-80fb-70f5d2844923.2018-01-24_13.46.14/ejabberd_tests.tests.push_integration_SUITE.logs/run.2018-01-24_14.00.06/log_private/muclight_msg_notify_on_fcm_w_click_action.xml
