### PR TITLE
Fix Tide webhook address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ notifications:
     webhooks:
         # trigger Buildtime Trend Service to parse Travis CI log
         - https://buildtimetrend.herokuapp.com/travis
-        - http://tide.erlang-solutions.com/api/travis_ci/events
+        - https://tide.erlang-solutions.com/api/travis_ci/events
     on_start: always
 
 cache:


### PR DESCRIPTION
Tide is served over encrypted connection now. If Travis pushes notification to non-encrypted endpoint it gets HTTP 301.