### PR TITLE
Remove jlib including from inside big tests

### DIFF
--- a/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/vcard_SUITE.erl
@@ -29,7 +29,9 @@
 -compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("../../../include/jlib.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("exml/include/exml.hrl").
 
 %% Element CData
 -define(EL(Element, Name), exml_query:path(Element, [{element, Name}])).


### PR DESCRIPTION
This PR addresses "don't keep all eggs in one basket".
Eradicate relative paths for good! (part 1 or 2 of more than 2 PRs).