### PR TITLE
[skip ci] Fixed compliance xep number, removed caveat

### DIFF
--- a/doc/user-guide/Features-and-supported-standards.md
+++ b/doc/user-guide/Features-and-supported-standards.md
@@ -78,7 +78,7 @@
 |0357|[Push Notifications](http://www.xmpp.org/extensions/xep-0357.html)|`mod_event_pusher_push`|
 |0363|[HTTP File Upload](https://xmpp.org/extensions/xep-0363.html)|`mod_http_upload`|
 |0384|[OMEMO Encryption](https://xmpp.org/extensions/xep-0384.html) (MongooseIM supports PEP, which is required by this extension)||
-|0387|[XMPP Advanced Server 2018](https://xmpp.org/extensions/xep-0387.html)|
+|0387|[XMPP Compliance Suites 2018 - all suites, Advanced Server level](https://xmpp.org/extensions/xep-0387.html)|
 
 ## Supported Open Extensions
 

--- a/doc/user-guide/Features-and-supported-standards.md
+++ b/doc/user-guide/Features-and-supported-standards.md
@@ -77,8 +77,8 @@
 |0352|[Client State Indication](http://www.xmpp.org/extensions/xep-0352.html)|`mod_csi`|
 |0357|[Push Notifications](http://www.xmpp.org/extensions/xep-0357.html)|`mod_event_pusher_push`|
 |0363|[HTTP File Upload](https://xmpp.org/extensions/xep-0363.html)|`mod_http_upload`|
-|0375|[XMPP Advanced Server 2017](https://xmpp.org/extensions/xep-0387.html) (without 0369: Mediated Information eXchange)|
 |0384|[OMEMO Encryption](https://xmpp.org/extensions/xep-0384.html) (MongooseIM supports PEP, which is required by this extension)||
+|0387|[XMPP Advanced Server 2018](https://xmpp.org/extensions/xep-0387.html)|
 
 ## Supported Open Extensions
 


### PR DESCRIPTION
The link to compliance suite was correct, but the number was not changed. Also, XEP-0387 does not require MIX.

