### PR TITLE
make sure we don't ping user w/o resource

### DIFF
--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -72,6 +72,9 @@ start_link(Host, Opts) ->
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
 start_ping(Host, JID) when JID#jid.lresource =/= <<>> ->
+    %% Guard check above ensures we are not adding a user without a
+    %% resource by accident. If this happens the server ends up in a
+    %% hot loop of iq-error replies.
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
     gen_server:cast(Proc, {start_ping, JID});
 start_ping(_Host, _JID) -> ok.

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -71,9 +71,10 @@ start_link(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
-start_ping(Host, JID) ->
+start_ping(Host, JID) when JID#jid.lresource =/= <<>> ->
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
-    gen_server:cast(Proc, {start_ping, JID}).
+    gen_server:cast(Proc, {start_ping, JID});
+start_ping(_Host, _JID) -> ok.
 
 stop_ping(Host, JID) ->
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
@@ -270,4 +271,3 @@ wait_for_process_to_stop(Pid) ->
         1000 ->
             {error, still_running}
     end.
-


### PR DESCRIPTION
In some cases it can happen that a jid without resource ends up in mod_ping's internal 'database'.

In our case it was that a custom module injected messages manually into the system for users without a resource and manually ran the user_send_packet hook. 

The result is an endless loop of iq-error replies bringing the whole system to a halt within a short time (system replying a 'bad-request' error to an iq-error and so on). 

The proposed fix just makes sure we never try to ping a user without a resource.
