### PR TITLE
Print more debug information when an error is caught in mod_vcard

### DIFF
--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -286,7 +286,17 @@ process_sm_iq(From, To, Acc, #iq{type = set, sub_el = VCARD} = IQ) ->
                           sub_el = [VCARD, Reason]}
             catch
                 E:R ->
-                    ?ERROR_MSG("~p", [{E, R}]),
+                    Stack = erlang:get_stacktrace(),
+                    ?ERROR_MSG("issue=process_sm_iq_set_failed "
+                                "reason=~p:~p "
+                                "stacktrace=~1000p "
+                                "from=~ts "
+                                "to=~ts "
+                                "sub_el=~ts",
+                                [E, R, Stack,
+                                 jid:to_binary(From),
+                                 jid:to_binary(To),
+                                 exml:to_binary(VCARD)]),
                     IQ#iq{type = error,
                           sub_el = [VCARD, ?ERR_INTERNAL_SERVER_ERROR]}
             end;
@@ -295,15 +305,25 @@ process_sm_iq(From, To, Acc, #iq{type = set, sub_el = VCARD} = IQ) ->
                   sub_el = [VCARD, ?ERR_NOT_ALLOWED]}
     end,
     {Acc, Res};
-process_sm_iq(_From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
+process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
     #jid{luser = LUser, lserver = LServer} = To,
-    Res = case catch mod_vcard_backend:get_vcard(LUser, LServer) of
+    Res = try mod_vcard_backend:get_vcard(LUser, LServer) of
         {ok, VCARD} ->
             IQ#iq{type = result, sub_el = VCARD};
         {error, Reason} ->
-            IQ#iq{type = error, sub_el = [SubEl, Reason]};
-        Else ->
-            ?ERROR_MSG("~p", [Else]),
+            IQ#iq{type = error, sub_el = [SubEl, Reason]}
+        catch E:R ->
+            Stack = erlang:get_stacktrace(),
+            ?ERROR_MSG("issue=process_sm_iq_get_failed "
+                        "reason=~p:~p "
+                        "stacktrace=~1000p "
+                        "from=~ts "
+                        "to=~ts "
+                        "sub_el=~ts",
+                        [E, R, Stack,
+                         jid:to_binary(From),
+                         jid:to_binary(To),
+                         exml:to_binary(SubEl)]),
             IQ#iq{type = error,
                   sub_el = [SubEl, ?ERR_INTERNAL_SERVER_ERROR]}
     end,


### PR DESCRIPTION
This PR addresses very obscure error reports when something bad happens in mod_vcard code.

Example of before report:
http://mongooseim-ct-results.s3-eu-west-1.amazonaws.com/PR/1697/4089/riak_mnesia.18.3/big/ct_run.test@travis-job-31e90c86-1d4e-42f8-bbd1-a60c5f954d67.2018-02-08_19.17.42/mongooseim@localhost.log.html#L313
