### PR TITLE
Replace is_result with is_iq_result

### DIFF
--- a/test.disabled/ejabberd_tests/tests/push_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_SUITE.erl
@@ -234,7 +234,7 @@ enable_should_succeed_without_form(Config) ->
             PubsubJID = pubsub_jid(Config),
 
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             ok
         end).
@@ -258,13 +258,13 @@ enable_should_accept_correct_from(Config) ->
             PubsubJID = pubsub_jid(Config),
 
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [])),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [
                 {<<"secret1">>, <<"token1">>},
                 {<<"secret2">>, <<"token2">>}
             ])),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             ok
         end).
@@ -314,7 +314,7 @@ disable_all(Config) ->
             PubsubJID = pubsub_jid(Config),
 
             escalus:send(Bob, disable_stanza(PubsubJID)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             ok
         end).
@@ -326,7 +326,7 @@ disable_node(Config) ->
             PubsubJID = pubsub_jid(Config),
 
             escalus:send(Bob, disable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             ok
         end).
@@ -353,7 +353,7 @@ pm_no_msg_notifications_if_user_online(Config) ->
             PubsubJID = pubsub_jid(Config),
 
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
 
@@ -369,7 +369,7 @@ pm_msg_notify_if_user_offline(Config) ->
 
             AliceJID = bare_jid(Alice),
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
             become_unavailable(Bob),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
@@ -401,7 +401,7 @@ pm_msg_notify_if_user_offline_with_publish_options(Config) ->
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>,
                                             [{<<"field1">>, <<"value1">>},
                                              {<<"field2">>, <<"value2">>}])),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
             become_unavailable(Bob),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
@@ -428,11 +428,11 @@ pm_msg_notify_stops_after_disabling(Config) ->
 
             %% Enable
             escalus:send(Bob, enable_stanza(PubsubJID, <<"NodeId">>, [])),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             %% Disable
             escalus:send(Bob, disable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Bob)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
             become_unavailable(Bob),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
@@ -474,7 +474,7 @@ muclight_no_msg_notifications_if_user_online(Config) ->
 
             create_room(Room, [bob, alice, kate], Config),
             escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
             become_unavailable(Kate),
 
             Msg = <<"Heyah!">>,
@@ -495,7 +495,7 @@ muclight_msg_notify_if_user_offline(Config) ->
 
             create_room(Room, [bob, alice, kate], Config),
             escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
             become_unavailable(Alice),
 
             Msg = <<"Heyah!">>,
@@ -531,7 +531,7 @@ muclight_msg_notify_if_user_offline_with_publish_options(Config) ->
             escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>,
                                             [{<<"field1">>, <<"value1">>},
                                              {<<"field2">>, <<"value2">>}])),
-            escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
             become_unavailable(Alice),
 
             Msg = <<"Heyah!">>,
@@ -562,11 +562,11 @@ muclight_msg_notify_stops_after_disabling(Config) ->
 
             %% Enable
             escalus:send(Alice, enable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
 
             %% Disable
             escalus:send(Alice, disable_stanza(PubsubJID, <<"NodeId">>)),
-            escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
             become_unavailable(Alice),
 
             Msg = <<"Heyah!">>,

--- a/test.disabled/ejabberd_tests/tests/push_integration_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_integration_SUITE.erl
@@ -378,7 +378,7 @@ enable_push_for_user(User, Service, EnableOpts) ->
     escalus:send(User, enable_stanza(PubsubJID, NodeName,
                                      [{<<"service">>, Service},
                                       {<<"device_id">>, DeviceToken}] ++ EnableOpts)),
-    escalus:assert(is_result, escalus:wait_for_stanza(User)),
+    escalus:assert(is_iq_result, escalus:wait_for_stanza(User)),
     become_unavailable(User),
     DeviceToken.
 

--- a/test.disabled/ejabberd_tests/tests/push_pubsub_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/push_pubsub_SUITE.erl
@@ -189,7 +189,7 @@ publish_succeeds_with_valid_options(Config) ->
 
             PublishIQ = publish_iq(Alice, Node, Content, Options),
             escalus:send(Alice, PublishIQ),
-            escalus:assert(is_result, escalus:wait_for_stanza(Alice)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
 
             ok
 
@@ -287,7 +287,7 @@ rest_service_gets_correct_payload_silent_v2(Config) ->
 send_notification(User, Node, Notification, Options) ->
     PublishIQ = publish_iq(User, Node, Notification, Options),
     escalus:send(User, PublishIQ),
-    escalus:assert(is_result, escalus:wait_for_stanza(User)).
+    escalus:assert(is_iq_result, escalus:wait_for_stanza(User)).
 
 get_mocked_request() ->
     {Req, BodyRaw} = next_rest_req(),


### PR DESCRIPTION
is_result is deprecated

This PR addresses 

```erlang
=INFO REPORT==== 8-Feb-2018::17:19:04 ===
calling deprecated function is_result, use is_iq_result instead
[{escalus_new_assert,assert,2,[{file,"src/escalus_new_assert.erl"},{line,31}]},
 {push_SUITE,'-muclight_no_msg_notifications_if_user_online/1-fun-1-',4,
             [{file,"push_SUITE.erl"},{line,477}]},
 {escalus_story,story,4,[{file,"src/escalus_story.erl"},{line,72}]},
 {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1529}]},
 {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1045}]},
 {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,977}]}]
```

in CI tests