### PR TITLE
`mod_mam` custom backends

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2052,8 +2052,8 @@ range_archive_request_not_empty(Config) ->
         [_, _, StartMsg, StopMsg | _] = Msgs,
         {{StartMsgId, _}, _, _, _, _StartMsgPacket} = StartMsg,
         {{StopMsgId, _}, _, _, _, _StopMsgPacket} = StopMsg,
-        {StartMicro, _} = rpc_apply(mod_mam_utils, decode_compact_uuid, [StartMsgId]),
-        {StopMicro, _} = rpc_apply(mod_mam_utils, decode_compact_uuid, [StopMsgId]),
+        StartMicro = rpc_apply(mod_mam_utils, maybe_message_id_to_timestamp, [StartMsgId]),
+        StopMicro = rpc_apply(mod_mam_utils, maybe_message_id_to_timestamp, [StopMsgId]),
         StartTime = make_iso_time(StartMicro),
         StopTime = make_iso_time(StopMicro),
         %% Send

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -980,8 +980,8 @@ generate_msg_for_date_user(Owner, {RemoteBin, _, _} = Remote, DateTime, Content)
     MicrosecDateTime = datetime_to_microseconds(DateTime),
     NowMicro = rpc_apply(mod_mam_utils, now_to_microseconds, [rpc_apply(erlang, now, [])]),
     Microsec = min(NowMicro, MicrosecDateTime),
-    MsgIdOwner = rpc_apply(mod_mam_utils, encode_compact_uuid, [Microsec, random:uniform(20)]),
-    MsgIdRemote = rpc_apply(mod_mam_utils, encode_compact_uuid, [Microsec+1, random:uniform(20)]),
+    MsgIdOwner = rpc_apply(mod_mam_utils, maybe_timestamp_to_message_id, [Microsec]),
+    MsgIdRemote = rpc_apply(mod_mam_utils, maybe_timestamp_to_message_id, [Microsec+1]),
     Packet = escalus_stanza:chat_to(RemoteBin, Content),
     {{MsgIdOwner, MsgIdRemote}, Owner, Remote, Owner, Packet}.
 

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -980,8 +980,8 @@ generate_msg_for_date_user(Owner, {RemoteBin, _, _} = Remote, DateTime, Content)
     MicrosecDateTime = datetime_to_microseconds(DateTime),
     NowMicro = rpc_apply(mod_mam_utils, now_to_microseconds, [rpc_apply(erlang, now, [])]),
     Microsec = min(NowMicro, MicrosecDateTime),
-    MsgIdOwner = rpc_apply(mod_mam_utils, maybe_timestamp_to_message_id, [Microsec]),
-    MsgIdRemote = rpc_apply(mod_mam_utils, maybe_timestamp_to_message_id, [Microsec+1]),
+    MsgIdOwner = rpc_apply(mod_mam_utils, maybe_timestamp_to_message_id, [Microsec, min]),
+    MsgIdRemote = rpc_apply(mod_mam_utils, maybe_timestamp_to_message_id, [Microsec+1, max]),
     Packet = escalus_stanza:chat_to(RemoteBin, Content),
     {{MsgIdOwner, MsgIdRemote}, Owner, Remote, Owner, Packet}.
 

--- a/doc/developers-guide/mod_mam_custom_backend.md
+++ b/doc/developers-guide/mod_mam_custom_backend.md
@@ -1,0 +1,83 @@
+# `mod_mam` Custom Backend
+
+You can implement a custom backend for mod_mam in order to support
+ additional databases or your own proprietary service.
+
+To configure MongooseIM to use your custom module make it have its own
+ toplevel place within the modules section of your configuration file,
+ eg:
+
+``` erlang
+{modules, [
+  ...
+  {mod_mam_custom_arch, []},
+  {mod_mam, [...]},
+  ...
+]}
+```
+
+This module needs to implement the `gen_mod` behavior and typically
+needs to add handlers for a (subset of) hooks triggered by mod_mam:
+
+ * mam_archive_message
+ * mam_archive_size
+ * mam_lookup_messages
+ * mam_remove_archive
+ * mam_purge_single_message
+ * mam_purge_multiple_messages
+
+See official backend implementations (like `mod_mam_odbc_arch.erl`) to get an idea what their
+signature looks like and what they are meant to do.
+
+A minimalistic example that only implements message lookup (without
+the actual data access):
+
+``` erlang
+start(Host, _Opts) ->
+  ...
+  ejabberd_hooks:add(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
+  ...
+  ok.
+
+...
+
+-spec lookup_messages(any(), ejabberd:server(), map()) -> {ok, mod_mam:lookup_result()} |
+                                                          {error, 'policy-violation'} |
+                                                          {error, any()}.
+lookup_messages({error, _Reason} = Result, _Host, _Params) -> Result;
+lookup_messages(_Result, Host, #{owner_jid        := OwnerJid,
+                                 rsm              := RSM,
+                                 start_ts         := undefined,
+                                 end_ts           := undefined,
+                                 with_jid         := undefined,
+                                 search_text      := undefined,
+                                 page_size        := PageSize,
+                                 limit_passed     := _LimitPassed,
+                                 max_result_limit := _MaxResultLimit,
+                                 is_simple        := _IsSimple      }) ->
+    %% Your implementation goes here
+    ...
+    ;
+lookup_messages(_Result, _Host, Params) ->
+    lager:info("unsupported params: ~p", [Params]),
+    {error, 'not-supported'}.
+
+...
+
+```
+
+If this module uses a different format for its archive-ids other than
+what's in `mam_uid_nodetime` you can configure a custom `uid_module`:
+
+``` erlang
+{modules, [
+  ...
+  {mod_mam, [{uid_module, mam_uid_custom}]},
+  ...
+]}
+```
+
+Your custom UID module needs to implement the `mam_uid` behaviour.
+
+There's `mam_uid_uuid` provided for convenience, it implements time base UUIDs.
+See https://www.famkruithof.net/guid-uuid-timebased.html for details.

--- a/src/mam/mam_uid.erl
+++ b/src/mam/mam_uid.erl
@@ -4,8 +4,8 @@
 %% This module is global, so it works for both mod_mam and mod_mam_muc
 -module(mam_uid).
 
--callback generate_message_id() -> integer().
--callback encode_compact_uuid(integer(), integer()) -> integer().
--callback decode_compact_uuid(integer()) -> {integer(),byte()}.
--callback mess_id_to_external_binary(integer()) -> binary().
--callback external_binary_to_mess_id(binary()) -> integer().
+-callback generate_message_id() -> any().
+-callback encode_compact_uuid(integer(), byte()) -> any().
+-callback decode_compact_uuid(any()) -> {integer(), byte()}.
+-callback mess_id_to_external_binary(any()) -> binary().
+-callback external_binary_to_mess_id(binary()) -> any().

--- a/src/mam/mam_uid.erl
+++ b/src/mam/mam_uid.erl
@@ -1,0 +1,11 @@
+%% @doc MAM message unique ID
+%%
+%% How to generate or represent message ids
+%% This module is global, so it works for both mod_mam and mod_mam_muc
+-module(mam_uid).
+
+-callback generate_message_id() -> integer().
+-callback encode_compact_uuid(integer(), integer()) -> integer().
+-callback decode_compact_uuid(integer()) -> {integer(),byte()}.
+-callback mess_id_to_external_binary(integer()) -> binary().
+-callback external_binary_to_mess_id(binary()) -> integer().

--- a/src/mam/mam_uid.erl
+++ b/src/mam/mam_uid.erl
@@ -11,4 +11,4 @@
 -callback mess_id_to_external_binary(any()) -> binary().
 -callback external_binary_to_mess_id(binary()) -> any().
 -callback message_id_to_timestamp(any()) -> integer().
--callback timestamp_to_message_id(integer()) -> any().
+-callback timestamp_to_message_id(integer(), atom()) -> any().

--- a/src/mam/mam_uid.erl
+++ b/src/mam/mam_uid.erl
@@ -1,11 +1,14 @@
 %% @doc MAM message unique ID
 %%
-%% How to generate or represent message ids
-%% This module is global, so it works for both mod_mam and mod_mam_muc
+%% This behaviour defines the way message IDs are generated and transformed into timestamps or vice
+%% versa. It is assumed that generated message IDs always hold the timestamp of their time of
+%% generation so that they can be compared with timestamps by mod_mam and database backends.
+%%
+%% This module is global, so it works for both mod_mam and mod_mam_muc.
 -module(mam_uid).
 
 -callback generate_message_id() -> any().
--callback encode_compact_uuid(integer(), byte()) -> any().
--callback decode_compact_uuid(any()) -> {integer(), byte()}.
 -callback mess_id_to_external_binary(any()) -> binary().
 -callback external_binary_to_mess_id(binary()) -> any().
+-callback message_id_to_timestamp(any()) -> integer().
+-callback timestamp_to_message_id(integer()) -> any().

--- a/src/mam/mam_uid_nodetime.erl
+++ b/src/mam/mam_uid_nodetime.erl
@@ -29,13 +29,13 @@ generate_message_id() ->
 %% It removes a leading 0 from 64-bit binary representation.
 %% It puts node id as a last byte.
 %% The maximum date, that can be encoded is `{{4253,5,31},{22,20,37}}'.
--spec encode_compact_uuid(integer(), integer()) -> integer().
+-spec encode_compact_uuid(integer(), byte()) -> integer().
 encode_compact_uuid(Microseconds, NodeId)
     when is_integer(Microseconds), is_integer(NodeId) ->
     (Microseconds bsl 8) + NodeId.
 
 %% @doc Extract date and node id from a message id.
--spec decode_compact_uuid(integer()) -> {integer(),byte()}.
+-spec decode_compact_uuid(integer()) -> {integer(), byte()}.
 decode_compact_uuid(Id) ->
     Microseconds = Id bsr 8,
     NodeId = Id band 255,

--- a/src/mam/mam_uid_nodetime.erl
+++ b/src/mam/mam_uid_nodetime.erl
@@ -11,7 +11,7 @@
          mess_id_to_external_binary/1,
          external_binary_to_mess_id/1,
          message_id_to_timestamp/1,
-         timestamp_to_message_id/1]).
+         timestamp_to_message_id/2]).
 
 %% -----------------------------------------------------------------------
 %% UID
@@ -43,6 +43,8 @@ message_id_to_timestamp(MessID) ->
 
 
 %% @doc Transform a timestamp to a message ID
--spec timestamp_to_message_id(mod_mam:posix_timestamp()) -> integer().
-timestamp_to_message_id(Microseconds) ->
-    Microseconds bsl 8.
+-spec timestamp_to_message_id(mod_mam:posix_timestamp(), atom()) -> integer().
+timestamp_to_message_id(Microseconds, min) ->
+    Microseconds bsl 8;
+timestamp_to_message_id(Microseconds, max) ->
+    (Microseconds bsl 8) + 255.

--- a/src/mam/mam_uid_nodetime.erl
+++ b/src/mam/mam_uid_nodetime.erl
@@ -1,0 +1,54 @@
+%% @doc Message id based on node_id and unique timestamp
+%%
+%% Message ids unique unless nodes get restarted
+%% We use HEX encoding for external ids
+%% Ids are not transarent for the clients (they can't get timestamp from id)
+-module(mam_uid_nodetime).
+-behaviour(mam_uid).
+
+%% UID
+-export([generate_message_id/0,
+         encode_compact_uuid/2,
+         decode_compact_uuid/1,
+         mess_id_to_external_binary/1,
+         external_binary_to_mess_id/1]).
+
+%% -----------------------------------------------------------------------
+%% UID
+
+-spec generate_message_id() -> integer().
+generate_message_id() ->
+    {ok, NodeId} = ejabberd_node_id:node_id(),
+    CandidateStamp = p1_time_compat:os_system_time(micro_seconds),
+    UniqueStamp = mongoose_mam_id:next_unique(CandidateStamp),
+    encode_compact_uuid(UniqueStamp, NodeId).
+
+
+%% @doc Create a message ID (UID).
+%%
+%% It removes a leading 0 from 64-bit binary representation.
+%% It puts node id as a last byte.
+%% The maximum date, that can be encoded is `{{4253,5,31},{22,20,37}}'.
+-spec encode_compact_uuid(integer(), integer()) -> integer().
+encode_compact_uuid(Microseconds, NodeId)
+    when is_integer(Microseconds), is_integer(NodeId) ->
+    (Microseconds bsl 8) + NodeId.
+
+%% @doc Extract date and node id from a message id.
+-spec decode_compact_uuid(integer()) -> {integer(),byte()}.
+decode_compact_uuid(Id) ->
+    Microseconds = Id bsr 8,
+    NodeId = Id band 255,
+    {Microseconds, NodeId}.
+
+
+%% @doc Encode a message ID to pass it to the user.
+-spec mess_id_to_external_binary(integer()) -> binary().
+mess_id_to_external_binary(MessID) when is_integer(MessID) ->
+    list_to_binary(integer_to_list(MessID, 32)).
+
+
+%% @doc Decode a message ID received from the user.
+-spec external_binary_to_mess_id(binary()) -> integer().
+external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) ->
+    binary_to_integer(BExtMessID, 32).

--- a/src/mam/mam_uid_uuid.erl
+++ b/src/mam/mam_uid_uuid.erl
@@ -9,7 +9,7 @@
          mess_id_to_external_binary/1,
          external_binary_to_mess_id/1,
          message_id_to_timestamp/1,
-         timestamp_to_message_id/1]).
+         timestamp_to_message_id/2]).
 
 %% -----------------------------------------------------------------------
 %% UID
@@ -39,8 +39,8 @@ message_id_to_timestamp(Id) ->
 
 
 %% @doc Transform a timestamp to a message ID
--spec timestamp_to_message_id(mod_mam:posix_timestamp()) -> binary().
-timestamp_to_message_id(Microseconds) ->
+-spec timestamp_to_message_id(mod_mam:posix_timestamp(), atom()) -> binary().
+timestamp_to_message_id(Microseconds, _) ->
     BinNanoSecs = integer_to_binary((Microseconds * 10) + 16#01b21dd213814000),
     Time = <<0:(60-bit_size(BinNanoSecs)), BinNanoSecs/binary>>,
     <<TimeHigh:12, TimeMid:16, TimeLow:32>> = Time,

--- a/src/mam/mam_uid_uuid.erl
+++ b/src/mam/mam_uid_uuid.erl
@@ -6,10 +6,10 @@
 
 %% UID
 -export([generate_message_id/0,
-         encode_compact_uuid/2,
-         decode_compact_uuid/1,
          mess_id_to_external_binary/1,
-         external_binary_to_mess_id/1]).
+         external_binary_to_mess_id/1,
+         message_id_to_timestamp/1,
+         timestamp_to_message_id/1]).
 
 %% -----------------------------------------------------------------------
 %% UID
@@ -21,30 +21,24 @@ generate_message_id() ->
     {UUID, _NewState} = uuid:get_v1(UState),
     list_to_binary(uuid:uuid_to_string(UUID)).
 
-%% @doc Create a message ID (UID).
-%%
-%% It removes a leading 0 from 64-bit binary representation.
-%% It puts node id as a last byte.
-%% The maximum date, that can be encoded is `{{4253,5,31},{22,20,37}}'.
--spec encode_compact_uuid(integer(), byte()) -> integer().
-encode_compact_uuid(Microseconds, NodeId)
-  when is_integer(Microseconds), is_integer(NodeId) ->
-    (Microseconds bsl 8) + NodeId.
-
-%% @doc Extract date and node id from a message id.
--spec decode_compact_uuid(binary()) -> {integer(), byte()}.
-decode_compact_uuid(UUID) ->
-    <<TimeLow:32, TimeMid:16, 1:4, TimeHi:12, _ClockID:16, NodeId:48>> = uuid:string_to_uuid(
-                                                                           binary_to_list(UUID)),
-    UUIDTimestamp = binary:decode_unsigned(<<TimeHi:16, TimeMid:16, TimeLow:32>>),
-    %% uuid offset and nanosecends step
-    UnixTimestamp = (UUIDTimestamp - 122192928000000000) div 10,
-    {UnixTimestamp , NodeId band 255}.
 
 %% @doc Encode a message ID to pass it to the user.
 -spec mess_id_to_external_binary(binary()) -> binary().
 mess_id_to_external_binary(MessID) when is_binary(MessID) -> MessID.
 
+
 %% @doc Decode a message ID received from the user.
 -spec external_binary_to_mess_id(binary()) -> binary().
 external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) -> BExtMessID.
+
+
+%% @doc Extract the date from a message ID.
+-spec message_id_to_timestamp(binary()) -> mod_mam:unix_timestamp().
+message_id_to_timestamp(Id) ->
+    Id bsr 8.
+
+
+%% @doc Transform a timestamp to a message ID
+-spec timestamp_to_message_id(mod_mam:posix_timestamp()) -> binary().
+timestamp_to_message_id(Microseconds) ->
+    (Microseconds bsl 8) + 255.

--- a/src/mam/mam_uid_uuid.erl
+++ b/src/mam/mam_uid_uuid.erl
@@ -35,7 +35,7 @@ external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) -> BExtMessID.
 %% @doc Extract the date from a message ID.
 -spec message_id_to_timestamp(binary()) -> mod_mam:unix_timestamp().
 message_id_to_timestamp(Id) ->
-    uuid:get_v1_time(Id).
+    uuid:get_v1_time(uuid:string_to_uuid(binary_to_list(Id))).
 
 
 %% @doc Transform a timestamp to a message ID

--- a/src/mam/mam_uid_uuid.erl
+++ b/src/mam/mam_uid_uuid.erl
@@ -26,13 +26,13 @@ generate_message_id() ->
 %% It removes a leading 0 from 64-bit binary representation.
 %% It puts node id as a last byte.
 %% The maximum date, that can be encoded is `{{4253,5,31},{22,20,37}}'.
--spec encode_compact_uuid(integer(), integer()) -> binary().
+-spec encode_compact_uuid(integer(), byte()) -> integer().
 encode_compact_uuid(Microseconds, NodeId)
   when is_integer(Microseconds), is_integer(NodeId) ->
     (Microseconds bsl 8) + NodeId.
 
 %% @doc Extract date and node id from a message id.
--spec decode_compact_uuid(binary()) -> {integer(),byte()}.
+-spec decode_compact_uuid(binary()) -> {integer(), byte()}.
 decode_compact_uuid(UUID) ->
     <<TimeLow:32, TimeMid:16, 1:4, TimeHi:12, _ClockID:16, NodeId:48>> = uuid:string_to_uuid(
                                                                            binary_to_list(UUID)),

--- a/src/mam/mam_uid_uuid.erl
+++ b/src/mam/mam_uid_uuid.erl
@@ -1,0 +1,50 @@
+%% @doc Time based UUIDs message IDs
+%%
+%% See https://www.famkruithof.net/guid-uuid-timebased.html for details
+-module(mam_uid_uuid).
+-behaviour(mam_uid).
+
+%% UID
+-export([generate_message_id/0,
+         encode_compact_uuid/2,
+         decode_compact_uuid/1,
+         mess_id_to_external_binary/1,
+         external_binary_to_mess_id/1]).
+
+%% -----------------------------------------------------------------------
+%% UID
+
+-spec generate_message_id() -> binary().
+generate_message_id() ->
+    quickrand:seed(),
+    UState = uuid:new(self()),
+    {UUID, _NewState} = uuid:get_v1(UState),
+    list_to_binary(uuid:uuid_to_string(UUID)).
+
+%% @doc Create a message ID (UID).
+%%
+%% It removes a leading 0 from 64-bit binary representation.
+%% It puts node id as a last byte.
+%% The maximum date, that can be encoded is `{{4253,5,31},{22,20,37}}'.
+-spec encode_compact_uuid(integer(), integer()) -> binary().
+encode_compact_uuid(Microseconds, NodeId)
+  when is_integer(Microseconds), is_integer(NodeId) ->
+    (Microseconds bsl 8) + NodeId.
+
+%% @doc Extract date and node id from a message id.
+-spec decode_compact_uuid(binary()) -> {integer(),byte()}.
+decode_compact_uuid(UUID) ->
+    <<TimeLow:32, TimeMid:16, 1:4, TimeHi:12, _ClockID:16, NodeId:48>> = uuid:string_to_uuid(
+                                                                           binary_to_list(UUID)),
+    UUIDTimestamp = binary:decode_unsigned(<<TimeHi:16, TimeMid:16, TimeLow:32>>),
+    %% uuid offset and nanosecends step
+    UnixTimestamp = (UUIDTimestamp - 122192928000000000) div 10,
+    {UnixTimestamp , NodeId band 255}.
+
+%% @doc Encode a message ID to pass it to the user.
+-spec mess_id_to_external_binary(binary()) -> binary().
+mess_id_to_external_binary(MessID) when is_binary(MessID) -> MessID.
+
+%% @doc Decode a message ID received from the user.
+-spec external_binary_to_mess_id(binary()) -> binary().
+external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) -> BExtMessID.

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -69,7 +69,7 @@
 %% UID
 -import(mod_mam_utils,
         [generate_message_id/0,
-         decode_compact_uuid/1]).
+         maybe_message_id_to_timestamp/1]).
 
 %% XML
 -import(mod_mam_utils,
@@ -655,7 +655,7 @@ archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
 -spec message_row_to_xml(binary(), messid_jid_packet(), QueryId :: binary(), boolean()) ->
     exml:element().
 message_row_to_xml(MamNs, {MessID, SrcJID, Packet}, QueryID, SetClientNs)  ->
-    {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
+    Microseconds = maybe_message_id_to_timestamp(MessID),
     DateTime = calendar:now_to_universal_time(microseconds_to_now(Microseconds)),
     BExtMessID = mess_id_to_external_binary(MessID),
     Packet1 = mod_mam_utils:maybe_set_client_xmlns(SetClientNs, Packet),

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -586,7 +586,7 @@ insert_offset_hint_query_cql() ->
 
 prepare_filter(UserJID, Borders, Start, End, WithJID) ->
     BUserJID = bare_jid(UserJID),
-    {StartID, EndID} = mod_mam_utils:calculate_msg_id_borders(Borders, Start, End),
+    {StartID, EndID} = mod_mam_utils:calculate_msg_id_borders(#rsm_in{}, Borders, Start, End),
     BWithJID = maybe_full_jid(WithJID), %% it's NOT optional field
     prepare_filter_params(BUserJID, BWithJID, StartID, EndID).
 

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -65,7 +65,7 @@
 %% UID
 -import(mod_mam_utils,
         [generate_message_id/0,
-         decode_compact_uuid/1]).
+         maybe_message_id_to_timestamp/1]).
 
 %% XML
 -import(mod_mam_utils,
@@ -533,7 +533,7 @@ archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
                                 exml:element().
 message_row_to_xml(MamNs, ReceiverJID, HideUser, SetClientNs, {MessID, SrcJID, Packet}, QueryID) ->
 
-    {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
+    Microseconds = maybe_message_id_to_timestamp(MessID),
     DateTime = calendar:now_to_universal_time(microseconds_to_now(Microseconds)),
     BExtMessID = mess_id_to_external_binary(MessID),
     Packet1 = maybe_delete_x_user_element(HideUser, ReceiverJID, Packet),

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -27,7 +27,7 @@
 
 %% UID
 -import(mod_mam_utils,
-        [maybe_timestamp_to_message_id/1]).
+        [maybe_timestamp_to_message_id/2]).
 
 %% Other
 -import(mod_mam_utils,
@@ -695,8 +695,8 @@ prepare_filter(RoomJID, Borders, Start, End, WithNick) ->
     BRoomJID = mod_mam_utils:bare_jid(RoomJID),
     Start1 = apply_start_border(Borders, Start),
     End1 = apply_end_border(Borders, End),
-    StartID = maybe_timestamp_to_message_id(Start1),
-    EndID = maybe_timestamp_to_message_id(End1),
+    StartID = maybe_timestamp_to_message_id(Start1, min),
+    EndID = maybe_timestamp_to_message_id(End1, max),
     BWithNick = maybe_nick(WithNick),
     prepare_filter_params(BRoomJID, BWithNick, StartID, EndID).
 

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -27,7 +27,7 @@
 
 %% UID
 -import(mod_mam_utils,
-        [encode_compact_uuid/2]).
+        [maybe_timestamp_to_message_id/1]).
 
 %% Other
 -import(mod_mam_utils,
@@ -693,8 +693,8 @@ insert_offset_hint_query_cql() ->
 
 prepare_filter(RoomJID, Borders, Start, End, WithNick) ->
     BRoomJID = mod_mam_utils:bare_jid(RoomJID),
-    StartID = maybe_encode_compact_uuid(Start, 0),
-    EndID = maybe_encode_compact_uuid(End, 255),
+    StartID = maybe_timestamp_to_message_id(Start),
+    EndID = maybe_timestamp_to_message_id(End),
     StartID2 = apply_start_border(Borders, StartID),
     EndID2 = apply_end_border(Borders, EndID),
     BWithNick = maybe_nick(WithNick),
@@ -775,11 +775,6 @@ calc_offset(PoolName, RoomJID, Host, F, _PS, _TC, #rsm_in{direction = aft, id = 
     calc_index(PoolName, RoomJID, Host, F, ID);
 calc_offset(_W, _RoomJID, _LS, _F, _PS, _TC, _RSM) ->
     0.
-
-maybe_encode_compact_uuid(undefined, _) ->
-    undefined;
-maybe_encode_compact_uuid(Microseconds, NodeID) ->
-    encode_compact_uuid(Microseconds, NodeID).
 
 maybe_nick(undefined) ->
     <<>>;

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -693,12 +693,12 @@ insert_offset_hint_query_cql() ->
 
 prepare_filter(RoomJID, Borders, Start, End, WithNick) ->
     BRoomJID = mod_mam_utils:bare_jid(RoomJID),
-    StartID = maybe_timestamp_to_message_id(Start),
-    EndID = maybe_timestamp_to_message_id(End),
-    StartID2 = apply_start_border(Borders, StartID),
-    EndID2 = apply_end_border(Borders, EndID),
+    Start1 = apply_start_border(Borders, Start),
+    End1 = apply_end_border(Borders, End),
+    StartID = maybe_timestamp_to_message_id(Start1),
+    EndID = maybe_timestamp_to_message_id(End1),
     BWithNick = maybe_nick(WithNick),
-    prepare_filter_params(BRoomJID, BWithNick, StartID2, EndID2).
+    prepare_filter_params(BRoomJID, BWithNick, StartID, EndID).
 
 prepare_filter_params(BRoomJID, BWithNick, StartID, EndID) ->
     #mam_muc_ca_filter{

--- a/src/mam/mod_mam_muc_odbc_arch.erl
+++ b/src/mam/mod_mam_muc_odbc_arch.erl
@@ -503,11 +503,11 @@ calc_count(Host, Filter) ->
                      WithJID :: jid:jid() | undefined, SearchText :: binary() | undefined) -> filter().
 prepare_filter(RoomID, Borders, Start, End, WithJID, SearchText) ->
     SWithNick = maybe_jid_to_escaped_resource(WithJID),
-    StartID = maybe_timestamp_to_message_id(Start),
-    EndID   = maybe_timestamp_to_message_id(End),
-    StartID2 = apply_start_border(Borders, StartID),
-    EndID2   = apply_end_border(Borders, EndID),
-    make_filter(RoomID, StartID2, EndID2, SWithNick, SearchText).
+    Start1 = apply_start_border(Borders, Start),
+    End1   = apply_end_border(Borders, End),
+    StartID = maybe_timestamp_to_message_id(Start1),
+    EndID   = maybe_timestamp_to_message_id(End1),
+    make_filter(RoomID, StartID, EndID, SWithNick, SearchText).
 
 
 -spec make_filter(RoomID  :: non_neg_integer(),

--- a/src/mam/mod_mam_muc_odbc_arch.erl
+++ b/src/mam/mod_mam_muc_odbc_arch.erl
@@ -34,7 +34,7 @@
 
 %% UMessID
 -import(mod_mam_utils,
-        [maybe_timestamp_to_message_id/1]).
+        [maybe_timestamp_to_message_id/2]).
 
 %% Other
 -import(mod_mam_utils,
@@ -505,8 +505,8 @@ prepare_filter(RoomID, Borders, Start, End, WithJID, SearchText) ->
     SWithNick = maybe_jid_to_escaped_resource(WithJID),
     Start1 = apply_start_border(Borders, Start),
     End1   = apply_end_border(Borders, End),
-    StartID = maybe_timestamp_to_message_id(Start1),
-    EndID   = maybe_timestamp_to_message_id(End1),
+    StartID = maybe_timestamp_to_message_id(Start1, min),
+    EndID   = maybe_timestamp_to_message_id(End1, max),
     make_filter(RoomID, StartID, EndID, SWithNick, SearchText).
 
 

--- a/src/mam/mod_mam_muc_odbc_arch.erl
+++ b/src/mam/mod_mam_muc_odbc_arch.erl
@@ -34,7 +34,7 @@
 
 %% UMessID
 -import(mod_mam_utils,
-        [encode_compact_uuid/2]).
+        [maybe_timestamp_to_message_id/1]).
 
 %% Other
 -import(mod_mam_utils,
@@ -503,8 +503,8 @@ calc_count(Host, Filter) ->
                      WithJID :: jid:jid() | undefined, SearchText :: binary() | undefined) -> filter().
 prepare_filter(RoomID, Borders, Start, End, WithJID, SearchText) ->
     SWithNick = maybe_jid_to_escaped_resource(WithJID),
-    StartID = maybe_encode_compact_uuid(Start, 0),
-    EndID   = maybe_encode_compact_uuid(End, 255),
+    StartID = maybe_timestamp_to_message_id(Start),
+    EndID   = maybe_timestamp_to_message_id(End),
     StartID2 = apply_start_border(Borders, StartID),
     EndID2   = apply_end_border(Borders, EndID),
     make_filter(RoomID, StartID2, EndID2, SWithNick, SearchText).
@@ -592,14 +592,6 @@ maybe_jid_to_escaped_resource(#jid{lresource = <<>>}) ->
     undefined;
 maybe_jid_to_escaped_resource(#jid{lresource = WithLResource}) ->
     mongoose_rdbms:escape_string(WithLResource).
-
-
--spec maybe_encode_compact_uuid('undefined' | integer(), 0 | 255)
-                               -> 'undefined' | integer().
-maybe_encode_compact_uuid(undefined, _) ->
-    undefined;
-maybe_encode_compact_uuid(Microseconds, NodeID) ->
-    encode_compact_uuid(Microseconds, NodeID).
 
 
 %% ----------------------------------------------------------------------

--- a/src/mam/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_odbc_async_pool_writer.erl
@@ -232,7 +232,7 @@ remove_archive(Acc, Host, ArcID, _ArcJID) ->
                            Now :: mod_mam:unix_timestamp()) ->
                                   ejabberd_gen_mam_archive:purge_single_message_result().
 purge_single_message(Result, Host, MessID, ArcID, _ArcJID, Now) ->
-    {Microseconds, _NodeMessID} = mod_mam_utils:decode_compact_uuid(MessID),
+    Microseconds = mod_mam_utils:maybe_message_id_to_timestamp(MessID),
     Result.
 
 

--- a/src/mam/mod_mam_odbc_arch.erl
+++ b/src/mam/mod_mam_odbc_arch.erl
@@ -548,11 +548,11 @@ prepare_filter(Host, UserID, UserJID, Borders, Start, End, WithJID, SearchText) 
                 {minify_and_escape_bare_jid(Host, UserJID, WithJID),
                  mongoose_rdbms:escape_string(WithLResource)}
         end,
-    StartID = maybe_timestamp_to_message_id(Start),
-    EndID   = maybe_timestamp_to_message_id(End),
-    StartID2 = apply_start_border(Borders, StartID),
-    EndID2   = apply_end_border(Borders, EndID),
-    prepare_filter_sql(UserID, StartID2, EndID2, SWithJID, SWithResource, SearchText).
+    Start1 = apply_start_border(Borders, Start),
+    End1   = apply_end_border(Borders, End),
+    StartID = maybe_timestamp_to_message_id(Start1),
+    EndID   = maybe_timestamp_to_message_id(End1),
+    prepare_filter_sql(UserID, StartID, EndID, SWithJID, SWithResource, SearchText).
 
 
 -spec prepare_filter_sql(UserID :: non_neg_integer(),

--- a/src/mam/mod_mam_odbc_arch.erl
+++ b/src/mam/mod_mam_odbc_arch.erl
@@ -31,7 +31,7 @@
 
 %% UID
 -import(mod_mam_utils,
-        [encode_compact_uuid/2]).
+        [maybe_timestamp_to_message_id/1]).
 
 %% Other
 -import(mod_mam_utils,
@@ -548,8 +548,8 @@ prepare_filter(Host, UserID, UserJID, Borders, Start, End, WithJID, SearchText) 
                 {minify_and_escape_bare_jid(Host, UserJID, WithJID),
                  mongoose_rdbms:escape_string(WithLResource)}
         end,
-    StartID = maybe_encode_compact_uuid(Start, 0),
-    EndID   = maybe_encode_compact_uuid(End, 255),
+    StartID = maybe_timestamp_to_message_id(Start),
+    EndID   = maybe_timestamp_to_message_id(End),
     StartID2 = apply_start_border(Borders, StartID),
     EndID2   = apply_end_border(Borders, EndID),
     prepare_filter_sql(UserID, StartID2, EndID2, SWithJID, SWithResource, SearchText).
@@ -632,11 +632,6 @@ escape_user_id(UserID) when is_integer(UserID) ->
 %% @doc Strip resource, minify and escape JID.
 minify_and_escape_bare_jid(Host, LocJID, JID) ->
     escape_string(jid_to_stored_binary(Host, LocJID, jid:to_bare(JID))).
-
-maybe_encode_compact_uuid(undefined, _) ->
-    undefined;
-maybe_encode_compact_uuid(Microseconds, NodeID) ->
-    encode_compact_uuid(Microseconds, NodeID).
 
 %% ----------------------------------------------------------------------
 %% Optimizations

--- a/src/mam/mod_mam_odbc_arch.erl
+++ b/src/mam/mod_mam_odbc_arch.erl
@@ -31,7 +31,7 @@
 
 %% UID
 -import(mod_mam_utils,
-        [maybe_timestamp_to_message_id/1]).
+        [maybe_timestamp_to_message_id/2]).
 
 %% Other
 -import(mod_mam_utils,
@@ -550,8 +550,8 @@ prepare_filter(Host, UserID, UserJID, Borders, Start, End, WithJID, SearchText) 
         end,
     Start1 = apply_start_border(Borders, Start),
     End1   = apply_end_border(Borders, End),
-    StartID = maybe_timestamp_to_message_id(Start1),
-    EndID   = maybe_timestamp_to_message_id(End1),
+    StartID = maybe_timestamp_to_message_id(Start1, min),
+    EndID   = maybe_timestamp_to_message_id(End1, max),
     prepare_filter_sql(UserID, StartID, EndID, SWithJID, SWithResource, SearchText).
 
 

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -169,7 +169,7 @@ archive_size(_Size, _Host, _ArchiveID, ArchiveJID) ->
 -spec bucket(calendar:date() | yearweeknum() | integer()) ->
                     {binary(), binary()} | undefined.
 bucket(MsgId) when is_integer(MsgId) ->
-    {MicroSec, _} = mod_mam_utils:decode_compact_uuid(MsgId),
+    MicroSec = mod_mam_utils:maybe_message_id_to_timestamp(MsgId),
     MsgNow = mod_mam_utils:microseconds_to_now(MicroSec),
     {MsgDate, _} = calendar:now_to_datetime(MsgNow),
     bucket(MsgDate);

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -157,7 +157,7 @@ archive_size(_Size, _Host, _ArchiveID, ArchiveJID) ->
     OwnerJID = mod_mam_utils:bare_jid(ArchiveJID),
     RemoteJID = undefined,
     {MsgIdStartNoRSM, MsgIdEndNoRSM} =
-    mod_mam_utils:calculate_msg_id_borders(undefined, undefined, undefined, undefined),
+    mod_mam_utils:calculate_msg_id_borders(#rsm_in{}, undefined, undefined, undefined),
     F = fun get_msg_id_key/3,
     {TotalCount, _} = read_archive(OwnerJID, RemoteJID,
                                    MsgIdStartNoRSM, MsgIdEndNoRSM, undefined,
@@ -253,7 +253,7 @@ lookup_messages(Host, Params) ->
             {ok, {undefined, undefined, get_messages(Host, SortedKeys)}};
         _ ->
             {MsgIdStartNoRSM, MsgIdEndNoRSM} =
-            mod_mam_utils:calculate_msg_id_borders(undefined, Borders, Start, End),
+            mod_mam_utils:calculate_msg_id_borders(#rsm_in{}, Borders, Start, End),
             {TotalCount, _} = read_archive(OwnerJID, RemoteJID,
                                            MsgIdStartNoRSM, MsgIdEndNoRSM, SearchText,
                                            [{rows, 1}], F),

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -14,8 +14,8 @@
 
 %% UID
 -export([generate_message_id/0,
-         encode_compact_uuid/2,
-         decode_compact_uuid/1,
+         message_id_to_timestamp/1,
+         timestamp_to_message_id/1,
          mess_id_to_external_binary/1,
          external_binary_to_mess_id/1,
          wrapper_id/0]).
@@ -78,9 +78,8 @@
          apply_end_border/2,
          bare_jid/1,
          full_jid/1,
-         calculate_msg_id_borders/3,
+         calculate_timestamp_borders/3,
          calculate_msg_id_borders/4,
-         maybe_encode_compact_uuid/2,
          is_complete_result_page/4,
          wait_shaper/3]).
 
@@ -104,7 +103,6 @@
                    is_valid_message/3,
                    is_valid_message_type/3,
                    is_valid_message_children/3,
-                   encode_compact_uuid/2,
                    get_one_of_path/3,
                    delay/2,
                    forwarded/3,
@@ -888,7 +886,7 @@ apply_start_border(undefined, Start) ->
 apply_start_border(#mam_borders{after_id=AfterID, from_id=FromID}, Start) ->
     After = maybe_message_id_to_timestamp(AfterID),
     From = maybe_message_id_to_timestamp(FromID),
-    maybe_max(maybe_incr_timestamp(After), maybe_max(From, Start)),
+    maybe_max(maybe_incr_timestamp(After), maybe_max(From, Start)).
 
 
 -spec apply_end_border('undefined' | mod_mam:borders(), undefined | integer()) ->
@@ -898,7 +896,7 @@ apply_end_border(undefined, End) ->
 apply_end_border(#mam_borders{before_id=BeforeID, to_id=ToID}, End) ->
     Before = maybe_message_id_to_timestamp(BeforeID),
     To = maybe_message_id_to_timestamp(ToID),
-    maybe_min(maybe_decr_timestamp(Before), maybe_min(To, End)),
+    maybe_min(maybe_decr_timestamp(Before), maybe_min(To, End)).
 
 -spec calculate_timestamp_borders(mod_mam:borders() | undefined,
                                   mod_mam:unix_timestamp() | undefined,

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -14,8 +14,8 @@
 
 %% UID
 -export([generate_message_id/0,
-         message_id_to_timestamp/1,
-         timestamp_to_message_id/1,
+         maybe_message_id_to_timestamp/1,
+         maybe_timestamp_to_message_id/1,
          mess_id_to_external_binary/1,
          external_binary_to_mess_id/1,
          wrapper_id/0]).

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -190,40 +190,33 @@ microseconds_to_datetime(MicroSeconds) when is_integer(MicroSeconds) ->
 %% -----------------------------------------------------------------------
 %% UID
 
--spec generate_message_id() -> integer().
+-spec generate_message_id() -> any().
 generate_message_id() ->
-    {ok, NodeId} = ejabberd_node_id:node_id(),
-    CandidateStamp = p1_time_compat:os_system_time(micro_seconds),
-    UniqueStamp = mongoose_mam_id:next_unique(CandidateStamp),
-    encode_compact_uuid(UniqueStamp, NodeId).
-
+    M = mod_mam:uid_module(),
+    M:generate_message_id().
 
 %% @doc Create a message ID (UID).
-%%
-%% It removes a leading 0 from 64-bit binary representation.
-%% It puts node id as a last byte.
-%% The maximum date, that can be encoded is `{{4253, 5, 31}, {22, 20, 37}}'.
--spec encode_compact_uuid(integer(), integer()) -> integer().
-encode_compact_uuid(Microseconds, NodeId)
-    when is_integer(Microseconds), is_integer(NodeId) ->
-    (Microseconds bsl 8) + NodeId.
+-spec encode_compact_uuid(integer(), integer()) -> any().
+encode_compact_uuid(Microseconds, NodeId) ->
+    M = mod_mam:uid_module(),
+    M:encode_compact_uuid(Microseconds, NodeId).
 
 
 %% @doc Extract date and node id from a message id.
--spec decode_compact_uuid(integer()) -> {integer(), byte()}.
+-spec decode_compact_uuid(any()) -> {integer(), byte()}.
 decode_compact_uuid(Id) ->
-    Microseconds = Id bsr 8,
-    NodeId = Id band 255,
-    {Microseconds, NodeId}.
+    M = mod_mam:uid_module(),
+    M:decode_compact_uuid(Id).
 
 
 %% @doc Encode a message ID to pass it to the user.
--spec mess_id_to_external_binary(integer()) -> binary().
-mess_id_to_external_binary(MessID) when is_integer(MessID) ->
-    list_to_binary(integer_to_list(MessID, 32)).
+-spec mess_id_to_external_binary(any()) -> binary().
+mess_id_to_external_binary(MessID) ->
+    M = mod_mam:uid_module(),
+    M:mess_id_to_external_binary(MessID).
 
 
--spec maybe_external_binary_to_mess_id(binary()) -> undefined | integer().
+-spec maybe_external_binary_to_mess_id(binary()) -> any().
 maybe_external_binary_to_mess_id(<<>>) ->
     undefined;
 maybe_external_binary_to_mess_id(BExtMessID) ->
@@ -231,9 +224,10 @@ maybe_external_binary_to_mess_id(BExtMessID) ->
 
 
 %% @doc Decode a message ID received from the user.
--spec external_binary_to_mess_id(binary()) -> integer().
+-spec external_binary_to_mess_id(binary()) -> any().
 external_binary_to_mess_id(BExtMessID) when is_binary(BExtMessID) ->
-    binary_to_integer(BExtMessID, 32).
+    M = mod_mam:uid_module(),
+    M:external_binary_to_mess_id(BExtMessID).
 
 %% -----------------------------------------------------------------------
 %% XML

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -879,8 +879,9 @@ maybe_integer(<<>>, Def) -> Def;
 maybe_integer(Bin, _Def) when is_binary(Bin) ->
     binary_to_integer(Bin).
 
--spec apply_start_border('undefined' | mod_mam:borders(), undefined | integer()) ->
-                                undefined | integer().
+-spec apply_start_border(undefined | mod_mam:borders(),
+                         undefined | mod_mam:unix_timestamp()) ->
+                         undefined | mod_mam:unix_timestamp().
 apply_start_border(undefined, Start) ->
     maybe_timestamp_to_message_id(Start);
 apply_start_border(#mam_borders{after_id=AfterID, from_id=FromID}, Start) ->

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -196,7 +196,7 @@ generate_message_id() ->
     M:generate_message_id().
 
 %% @doc Create a message ID (UID).
--spec encode_compact_uuid(integer(), integer()) -> any().
+-spec encode_compact_uuid(integer(), byte()) -> any().
 encode_compact_uuid(Microseconds, NodeId) ->
     M = mod_mam:uid_module(),
     M:encode_compact_uuid(Microseconds, NodeId).
@@ -923,8 +923,8 @@ calculate_msg_id_borders(#rsm_in{direction = before, id = Id}, Borders, Start, E
 calculate_msg_id_borders(_, Borders, Start, End) ->
     mod_mam_utils:calculate_msg_id_borders(Borders, Start, End).
 
--spec maybe_encode_compact_uuid(mod_mam:unix_timestamp() | undefined, integer()) ->
-    undefined | integer().
+-spec maybe_encode_compact_uuid(mod_mam:unix_timestamp() | undefined, byte()) ->
+    undefined | any().
 maybe_encode_compact_uuid(undefined, _) ->
     undefined;
 maybe_encode_compact_uuid(Microseconds, NodeID) ->

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -344,7 +344,7 @@ change_user_password(Host, User, Password) ->
 
 record_to_map({Id, From, Msg}) ->
     Jbin = jid:to_binary(From),
-    {Msec, _} = mod_mam_utils:decode_compact_uuid(Id),
+    Msec = mod_mam_utils:maybe_message_id_to_timestamp(Id),
     MsgId = case xml:get_tag_attr(<<"id">>, Msg) of
                 {value, MId} -> MId;
                 false -> <<"">>

--- a/src/mongoose_client_api_messages.erl
+++ b/src/mongoose_client_api_messages.erl
@@ -101,7 +101,7 @@ build_message(From, To, Id, Body) ->
                               children = [#xmlcdata{content = Body}]}]}.
 
 make_json_msg(Msg, MAMId) ->
-    {Microsec, _} = mod_mam_utils:decode_compact_uuid(MAMId),
+    Microsec = mod_mam_utils:maybe_message_id_to_timestamp(MAMId),
     encode(Msg, Microsec div 1000).
 
 -spec encode(exml:item(), integer()) -> map().

--- a/src/mongoose_client_api_rooms_messages.erl
+++ b/src/mongoose_client_api_rooms_messages.erl
@@ -139,7 +139,7 @@ encode(Packet, Timestamp) ->
     Msg#{room => FromJID#jid.luser}.
 
 make_json_item({MAMID, JID, Msg}) ->
-    {Microsec, _} = mod_mam_utils:decode_compact_uuid(MAMID),
+    Microsec = mod_mam_utils:maybe_message_id_to_timestamp(MAMID),
     make_json_item(Msg, JID, Microsec div 1000).
 
 make_json_item(Msg, JID, Timestamp) ->


### PR DESCRIPTION
This patch allows to have custom backends for `mod_mam` that handle archive-IDs on their own when those are encoded as UUIDs canonical textual representation (timed UUIDs).

Also fixes a bug where mod_mam would just crash when given an archive-id that is not parseable as an integer.

Also allows backends to set more meaningful error reporting (eg: 'item-not-found' etc).

