### PR TITLE
Don't try to push message without body

### DIFF
--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -105,8 +105,9 @@ push_event(_, _) ->
     ok.
 
 do_push_event(Host, #chat_event{from = From, to = To, packet = Packet}) ->
-    mod_event_pusher_push_plugin:should_publish(Host, From, To, Packet) andalso
-        publish_message(From, To, Packet).
+    mod_event_pusher_push_plugin:should_publish(Host, From, To, Packet)
+    andalso exml_query:subelement(Packet, <<"body">>) /= undefined
+    andalso publish_message(From, To, Packet).
 
 %% Hook 'remove_user'
 -spec remove_user(Acc :: mongoose_acc:t(), LUser :: binary(), LServer :: binary()) ->

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -105,8 +105,13 @@ push_event(_, _) ->
     ok.
 
 do_push_event(Host, #chat_event{from = From, to = To, packet = Packet}) ->
-    mod_event_pusher_push_plugin:should_publish(Host, From, To, Packet)
-    andalso exml_query:subelement(Packet, <<"body">>) /= undefined
+    %% First condition means that we won't try to push messages without
+    %% <body/> element because it is required later in payload generation.
+    %% In such case we don't care about plugin's decision, so it is checked
+    %% as a second condition.
+    %% Messages with empty body will still be pushed.
+    exml_query:subelement(Packet, <<"body">>) /= undefined
+    andalso mod_event_pusher_push_plugin:should_publish(Host, From, To, Packet)
     andalso publish_message(From, To, Packet).
 
 %% Hook 'remove_user'


### PR DESCRIPTION
This PR addresses #1722

It adds a hard check for `body` subelement in message processed by `mod_event_pusher_push`. It overrides `should_publish` result, as this element is mandatory in constructed payload.