### PR TITLE
Update accumulator to currently routed element in ejabberd_router:route/4

### DIFF
--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -111,7 +111,8 @@ route(From, To, Acc) ->
     El = mongoose_acc:get(element, Acc),
     route(From, To, Acc, El, routing_modules_list()).
 
-route(From, To, Acc, El) ->
+route(From, To, Acc0, El) ->
+    Acc = mongoose_acc:update_element(Acc0, El, From, To),
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
         [From, To, Acc]),
     route(From, To, Acc, El, routing_modules_list()).


### PR DESCRIPTION
This change makes `ejabberd_router:route/4` always update the accumulator to contain information about currently routed element. Before this change, element and accumulator being routed could be out of sync.

If the accumulator is already in sync with the element, `ejabberd_route:route/3` should be used.

