### PR TITLE
Dedicate fed1 node for s2s tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SILENCE_COVER += | grep -v "WARNING: Deleting data for module"
 LOG_SILENCE_COVER=$(subst TARGET,$@,TARGET.log 2>&1 || (cat TARGET.log $(SILENCE_COVER); exit 1))
 XEP_TOOL = tools/xep_tool
 EBIN = ebin
-DEVNODES = mim1 mim2 mim3 fed1
+DEVNODES = mim1 mim2 mim3 fed1 reg1
 
 # Top-level targets aka user interface
 

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -55,6 +55,13 @@ $ cd $MONGOOSEIM/_build/fed1/rel/mongooseim
 $ ./bin/mongooseimctl live
 ```
 
+In shell #6:
+
+```sh
+$ cd $MONGOOSEIM/_build/reg1/rel/mongooseim
+$ ./bin/mongooseimctl live
+```
+
 Back to shell #1:
 
 ```sh
@@ -73,10 +80,12 @@ tmux new-window -n mim1 '_build/mim1/rel/mongooseim/bin/mongooseimctl live'
 tmux new-window -n mim2 '_build/mim2/rel/mongooseim/bin/mongooseimctl live'
 tmux new-window -n mim3 '_build/mim3/rel/mongooseim/bin/mongooseimctl live'
 tmux new-window -n fed1 '_build/fed1/rel/mongooseim/bin/mongooseimctl live'
+tmux new-window -n reg1 '_build/fed1/rel/mongooseim/bin/mongooseimctl live'
 _build/mim1/rel/mongooseim/bin/mongooseimctl started
 _build/mim2/rel/mongooseim/bin/mongooseimctl started
 _build/mim3/rel/mongooseim/bin/mongooseimctl started
 _build/fed1/rel/mongooseim/bin/mongooseimctl started
+_build/reg1/rel/mongooseim/bin/mongooseimctl started
 make -C test.disabled/ejabberd_tests quicktest
 ```
 
@@ -90,6 +99,7 @@ Start a new tmux and paste the commands.
 - `$MONGOOSEIM/_build/mim1/rel`, for most test SUITEs
 - `$MONGOOSEIM/_build/mim*/rel`, in order to test cluster-related commands;;
 - `$MONGOOSEIM/_build/fed1/rel`, in order to test XMPP federation (server to server communication, S2S).
+- `$MONGOOSEIM/_build/reg1/rel`, in order to test global distribution feature.
 
 In general, running a server in the interactive mode (i.e. `mongooseimctl live`) is not required to test it, but it's convenient as any warnings and errors can be spotted in real time.
 It's also easy to inspect the server state or trace execution (e.g. using `dbg`) in case of anything going wrong in some of the tests.

--- a/doc/user-guide/How-to-build.md
+++ b/doc/user-guide/How-to-build.md
@@ -98,7 +98,7 @@ For testing purposes there's a different make target available:
 
     $ make devrel
 
-which will generate releases `mim1`, `mim2`, `mim3`, `fed1` in `$REPO/_build/` and prepare them for testing and generating coverage reports.
+which will generate releases `mim1`, `mim2`, `mim3`, `fed1`, `reg1` in `$REPO/_build/` and prepare them for testing and generating coverage reports.
 
 To run the tests (from project's root directory, i.e. `$REPO`):
 

--- a/rebar.config
+++ b/rebar.config
@@ -119,7 +119,10 @@
              {mim3,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim3.vars.config"]},
                                  {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]},
              {fed1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/fed1.vars.config"]},
-                                 {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]} ]}.
+                                 {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]},
+             {reg1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/reg1.vars.config"]},
+                                 {overlay, [{template, "rel/files/ejabberd.cfg", "etc/ejabberd.cfg"}]} ]}]}
+            ]}.
 
 {plugins,
  [

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -1,17 +1,20 @@
-%% This node is for s2s testing.
-%% "localhost" host should NOT be defined.
-{hosts, "[ \"fed1\" ]"}.
+%% This node is for global distribution testing.
+%% reg is short for region.
+%% Both local and global hosts should be defined.
+%% "localhost" is a global host.
+%% "reg1" is a local host.
+{hosts, "[ \"reg1\", \"localhost\" ]"}.
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
 {outgoing_s2s_port, 5269}.
 {odbc_server, ""}.
 {s2s_addr, "{ {s2s_addr, \"localhost\"}, {127,0,0,1} }. { {s2s_addr, \"localhost.bis\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
-{node_name, "fed1@localhost"}.
-{ejabberd_c2s_port, 5242}.
-{ejabberd_s2s_in_port, 5299}.
-{cowboy_port, 5282}.
-{cowboy_port_secure, 5287}.
+{node_name, "reg1@localhost"}.
+{ejabberd_c2s_port, 5252}.
+{ejabberd_s2s_in_port, 5298}.
+{cowboy_port, 5272}.
+{cowboy_port_secure, 5277}.
 {ejabberd_service, ""}.
 {mod_roster, "{mod_roster, []},"}.
 {http_api_endpoint, "{5389, \"127.0.0.1\"}"}.
@@ -19,9 +22,9 @@
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
 {tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"DHE-RSA-AES256-SHA\"},"}.
 {secondary_c2s, ""}.
-{http_api_old_endpoint, "{5293, \"127.0.0.1\"}"}.
-{http_api_endpoint, "{8094, \"127.0.0.1\"}"}.
-{http_api_client_endpoint, "8095"}.
+{http_api_old_endpoint, "{5273, \"127.0.0.1\"}"}.
+{http_api_endpoint, "{8074, \"127.0.0.1\"}"}.
+{http_api_client_endpoint, "8075"}.
 {all_metrics_are_global, false}.
 {c2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 {s2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.

--- a/test.disabled/ejabberd_tests/test.config
+++ b/test.disabled/ejabberd_tests/test.config
@@ -31,10 +31,17 @@
                  {domain, <<"localhost">>},
                  {vars, "mim3.vars.config"},
                  {cluster, mim}]},
+         %% used to test s2s features
          {fed,  [{node, fed1@localhost},
                  {domain, <<"fed1">>},
                  {vars, "fed1.vars.config"},
-                 {cluster, fed}]}]}.
+                 {cluster, fed}]},
+         %% used to test global distribution features
+         {reg,  [{node, reg1@localhost},
+                 {domain, <<"reg1">>},
+                 {vars, "reg1.vars.config"},
+                 {cluster, reg}]}
+        ]}.
 
 %% Use RPC and ejabberd_auth API for creating/deleting test users
 {escalus_user_db, {module, escalus_ejabberd}}.
@@ -121,7 +128,7 @@
         {server, <<"sogndal">>},
         {host, <<"localhost">>},
         {password, <<"doctor">>}]},
-    {alice2, [
+    {alice2, [ %% used in s2s_SUITE
         {username, <<"alice">>},
         {server, <<"fed1">>},
         {host, <<"localhost">>},
@@ -145,11 +152,11 @@
         {host, <<"localhost">>},
         {password, <<"wasssssssup">>},
         {port, 5232}]},
-    {eve, [
+    {eve, [ %% used in mod_global_distrib_SUITE
         {username, <<"eve">>},
         {server, <<"localhost">>},
         {password, <<"password">>},
-        {port, 5242}]}
+        {port, 5252}]}
 ]}.
 
 {escalus_anon_users, [

--- a/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
@@ -87,7 +87,7 @@ groups() ->
 suite() ->
     [{require, europe_node1, {hosts, mim, node}},
      {require, europe_node2, {hosts, mim2, node}},
-     {require, asia_node, {hosts, fed, node}} |
+     {require, asia_node, {hosts, reg, node}} |
      escalus:suite()].
 
 %%--------------------------------------------------------------------
@@ -555,9 +555,9 @@ test_in_order_messages_on_multiple_connections_with_bounce(Config) ->
       Config, [{alice, 1}, {eve, 1}],
       fun(Alice, Eve) ->
               %% Send 99 messages, some while server knows the mapping and some when it doesn't
-              send_steps(Alice, Eve, 99, <<"fed1">>),
+              send_steps(Alice, Eve, 99, <<"reg1">>),
               %% Make sure that the last message is sent when the mapping is known
-              set_mapping(europe_node1, Eve, <<"fed1">>),
+              set_mapping(europe_node1, Eve, <<"reg1">>),
               escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"100">>)),
 
               %% Check that all stanzas were received in order
@@ -586,7 +586,7 @@ test_messages_bounced_in_order(Config) ->
 
               %% Restore the mapping so that bounce eventually succeeds
               ?assertEqual(undefined, get_mapping(europe_node1, Eve)),
-              set_mapping(europe_node1, Eve, <<"fed1">>),
+              set_mapping(europe_node1, Eve, <<"reg1">>),
 
               lists:foreach(
                 fun(I) ->
@@ -633,8 +633,8 @@ test_update_senders_host_by_ejd_service(Config) ->
       fun(Eve) ->
               %% Eve is connected to asia_node
               EveJid = rpc(asia_node, jid, from_binary, [escalus_client:full_jid(Eve)]),
-              {ok, <<"fed1">>} = rpc(europe_node1, mod_global_distrib_mapping, for_jid, [EveJid]),
-              {ok, <<"fed1">>} = rpc(europe_node2, mod_global_distrib_mapping, for_jid, [EveJid]),
+              {ok, <<"reg1">>} = rpc(europe_node1, mod_global_distrib_mapping, for_jid, [EveJid]),
+              {ok, <<"reg1">>} = rpc(europe_node2, mod_global_distrib_mapping, for_jid, [EveJid]),
 
               ok = rpc(asia_node, mod_global_distrib_mapping, delete_for_jid, [EveJid]),
               GetCachesFun
@@ -658,20 +658,20 @@ test_update_senders_host_by_ejd_service(Config) ->
               escalus:send(Eve, escalus_stanza:chat_to(Addr, <<"hi">>)),
               escalus:wait_for_stanza(Comp),
 
-              {ok, <<"fed1">>} = rpc(europe_node1, mod_global_distrib_mapping, for_jid, [EveJid]),
-              {ok, <<"fed1">>} = rpc(europe_node2, mod_global_distrib_mapping, for_jid, [EveJid])
+              {ok, <<"reg1">>} = rpc(europe_node1, mod_global_distrib_mapping, for_jid, [EveJid]),
+              {ok, <<"reg1">>} = rpc(europe_node2, mod_global_distrib_mapping, for_jid, [EveJid])
       end).
 
 %% -------------------------------- Rebalancing --------------------------------
 
 enable_new_endpoint_on_refresh(Config) ->
-    get_connection(europe_node1, <<"fed1">>),
+    get_connection(europe_node1, <<"reg1">>),
 
-    {Enabled1, _Disabled1, Pools1} = get_outgoing_connections(europe_node1, <<"fed1">>),
+    {Enabled1, _Disabled1, Pools1} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
     NewEndpoint = enable_extra_endpoint(asia_node, europe_node1, 10000, Config),
 
-    {Enabled2, _Disabled2, Pools2} = get_outgoing_connections(europe_node1, <<"fed1">>),
+    {Enabled2, _Disabled2, Pools2} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
     %% One new pool and one new endpoint
     [NewEndpoint] = Pools2 -- Pools1,
@@ -682,16 +682,16 @@ enable_new_endpoint_on_refresh(Config) ->
 disable_endpoint_on_refresh(Config) ->
     enable_extra_endpoint(asia_node, europe_node1, 10000, Config),
 
-    get_connection(europe_node1, <<"fed1">>),
+    get_connection(europe_node1, <<"reg1">>),
 
-    {Enabled1, Disabled1, Pools1} = get_outgoing_connections(europe_node1, <<"fed1">>),
+    {Enabled1, Disabled1, Pools1} = get_outgoing_connections(europe_node1, <<"reg1">>),
     [_, _] = Enabled1,
     [] = Disabled1,
 
     hide_extra_endpoint(asia_node),
-    trigger_rebalance(europe_node1, <<"fed1">>),
+    trigger_rebalance(europe_node1, <<"reg1">>),
 
-    {Enabled2, Disabled2, Pools2} = get_outgoing_connections(europe_node1, <<"fed1">>),
+    {Enabled2, Disabled2, Pools2} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
     %% 2 pools open even after disable
     [] = Pools1 -- Pools2,
@@ -715,7 +715,7 @@ wait_for_connection(Config) ->
     end,
 
     refresh_mappings(asia_node, Config),
-    trigger_rebalance(europe_node1, <<"fed1">>),
+    trigger_rebalance(europe_node1, <<"reg1">>),
 
     receive
         Conn when is_pid(Conn) -> ok;
@@ -725,16 +725,16 @@ wait_for_connection(Config) ->
     end.
 
 closed_connection_is_removed_from_disabled(_Config) ->
-    get_connection(europe_node1, <<"fed1">>),
+    get_connection(europe_node1, <<"reg1">>),
     set_endpoints(asia_node, []),
-    trigger_rebalance(europe_node1, <<"fed1">>),
+    trigger_rebalance(europe_node1, <<"reg1">>),
 
-    {[], [_], [_]} = get_outgoing_connections(europe_node1, <<"fed1">>),
+    {[], [_], [_]} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
     % Will drop connections and prevent them from reconnecting
     restart_receiver(asia_node, [listen_endpoint(10001)]),
 
-    wait_until(fun() -> get_outgoing_connections(europe_node1, <<"fed1">>) end,
+    wait_until(fun() -> get_outgoing_connections(europe_node1, <<"reg1">>) end,
                {[], [], []}, 5, 1000).
 
 %%--------------------------------------------------------------------
@@ -745,7 +745,7 @@ get_hosts() ->
     [
      {europe_node1, "localhost.bis", 5555},
      {europe_node2, "localhost.bis", 6666},
-     {asia_node, "fed1", 7777}
+     {asia_node, "reg1", 7777}
     ].
 
 listen_endpoint(NodeName) when is_atom(NodeName) ->
@@ -756,7 +756,8 @@ listen_endpoint(Port) ->
 
 rpc(NodeName, M, F, A) ->
     Node = ct:get_config(NodeName),
-    ct_rpc:call(Node, M, F, A).
+    Cookie = escalus_ct:get_config(ejabberd_cookie),
+    escalus_ct:rpc_call(Node, M, F, A, timer:seconds(30), Cookie).
 
 wait_until(Fun, ExpectedValue, Attempts, SleepTime) ->
     wait_until(Fun, ExpectedValue, Attempts, SleepTime, []).
@@ -815,14 +816,14 @@ send_steps(From, To, Max, ToHost) ->
 
 next_send_step(_From, _To, I, Max, _ToReset, _KnowsMapping, _ToHost) when I > Max -> ok;
 next_send_step(From, To, I, Max, 0, KnowsMapping, ToHost) ->
-    ct:print("Reset: I: ~B", [I]),
+    ct:log("Reset: I: ~B", [I]),
     case KnowsMapping of
         true -> delete_mapping(europe_node1, To);
         false -> set_mapping(europe_node1, To, ToHost)
     end,
     next_send_step(From, To, I, Max, Max div 10, not KnowsMapping, ToHost);
 next_send_step(From, To, I, Max, ToReset, KnowsMapping, ToHost) ->
-    ct:print("I: ~B ~B ~B", [I, Max, ToReset]),
+    ct:log("I: ~B ~B ~B", [I, Max, ToReset]),
     Stanza = escalus_stanza:chat_to(To, integer_to_binary(I)),
     escalus_client:send(From, Stanza),
     next_send_step(From, To, I + 1, Max, ToReset - 1, KnowsMapping, ToHost).
@@ -858,7 +859,7 @@ redis_query(Node, Query) ->
 spawn_connection_getter(SenderNode) ->
     TestPid = self(),
     spawn(fun() ->
-                  Conn = get_connection(SenderNode, <<"fed1">>),
+                  Conn = get_connection(SenderNode, <<"reg1">>),
                   TestPid ! Conn
           end).
 
@@ -868,7 +869,7 @@ enable_extra_endpoint(ListenNode, SenderNode, Port, Config) ->
 
     restart_receiver(ListenNode, [NewEndpoint, OriginalEndpoint]),
     refresh_mappings(ListenNode, Config),
-    trigger_rebalance(SenderNode, <<"fed1">>),
+    trigger_rebalance(SenderNode, <<"reg1">>),
 
     NewEndpoint.
 

--- a/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/s2s_SUITE.erl
@@ -96,13 +96,13 @@ init_per_suite(Config0) ->
 
     Config1 = [{s2s_opts, S2S} | escalus:init_per_suite(Config0)],
     Config2 = [{escalus_user_db, xmpp} | Config1],
-    escalus:create_users(Config2, escalus:get_users([alice2, alice_bis, bob])).
+    escalus:create_users(Config2, escalus:get_users([alice2, alice, bob])).
 
 end_per_suite(Config) ->
     S2SOrig = ?config(s2s_opts, Config),
     configure_s2s(S2SOrig),
     rpc(fed(), mongoose_cover_helper, analyze, []),
-    escalus:delete_users(Config, escalus:get_users([alice2, alice_bis, bob])),
+    escalus:delete_users(Config, escalus:get_users([alice2, alice, bob])),
     escalus:end_per_suite(Config).
 
 init_per_group(both_plain, Config) ->
@@ -164,7 +164,7 @@ end_per_testcase(CaseName, Config) ->
 %%%===================================================================
 
 simple_message(Config) ->
-    escalus:fresh_story(Config, [{alice2, 1}, {alice_bis, 1}], fun(Alice2, Alice1) ->
+    escalus:fresh_story(Config, [{alice2, 1}, {alice, 1}], fun(Alice2, Alice1) ->
 
         %% User on the main server sends a message to a user on a federated server
         escalus:send(Alice1, escalus_stanza:chat_to(Alice2, <<"Hi, foreign Alice!">>)),
@@ -192,7 +192,7 @@ timeout_waiting_for_message(Config) ->
     end.
 
 nonexistent_user(Config) ->
-    escalus:fresh_story(Config, [{alice_bis, 1}, {alice2, 1}], fun(Alice1, Alice2) ->
+    escalus:fresh_story(Config, [{alice, 1}, {alice2, 1}], fun(Alice1, Alice2) ->
 
         %% Alice@localhost1 sends message to Xyz@localhost2
         RemoteServer = escalus_client:server(Alice2),
@@ -207,7 +207,7 @@ nonexistent_user(Config) ->
     end).
 
 unknown_domain(Config) ->
-    escalus:fresh_story(Config, [{alice_bis, 1}], fun(Alice1) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice1) ->
 
         %% Alice@localhost1 sends message to Xyz@localhost3
         escalus:send(Alice1, escalus_stanza:chat_to(
@@ -221,7 +221,7 @@ unknown_domain(Config) ->
     end).
 
 nonascii_addr(Config) ->
-    escalus:fresh_story(Config, [{alice_bis, 1}, {bob2, 1}], fun(Alice, Bob) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob2, 1}], fun(Alice, Bob) ->
 
         %% Bob@localhost2 sends message to Alice@localhost1
         escalus:send(Bob, escalus_stanza:chat_to(Alice, <<"Cześć Alice!">>)),

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -12,7 +12,7 @@ fi
 
 TLS_DIST=${TLS_DIST:-no}
 
-DEFAULT_DEV_NODES="mim1 mim2 mim3 fed1"
+DEFAULT_DEV_NODES="mim1 mim2 mim3 fed1 reg1"
 DEV_NODES="${DEV_NODES:-$DEFAULT_DEV_NODES}"
 
 # Create a bash array DEFAULT_DEV_NODES with node names


### PR DESCRIPTION
Separate s2s and global distribution test nodes.
Global distribution tests should use new node reg1 (region 1)
localhost should not be loaded on fed1, because it would make
any additional s2s tests hard to implement.
An example of such test is muc and s2s combination.
Remove debug printing to console from mod_global_distrib_SUITE.
Use generic rpc function provided by escalus from mod_global_distrib_SUITE.
Update docs.

This PR addresses "I can't merge #1311" without this patch.

