### PR TITLE
Let reload_cluster not check if configs are the same

### DIFF
--- a/doc/operation-and-maintenance/Reloading-configuration-on-a-running-system.md
+++ b/doc/operation-and-maintenance/Reloading-configuration-on-a-running-system.md
@@ -10,10 +10,14 @@
 This might introduce inconsistencies between different nodes of the cluster.
 It's available as a safety mechanism for the rare case of a cluster-global reload failing.
 
-`reload_cluster` is generally safe. It will try to apply the configuration
+`reload_cluster [safety_check]` is generally safe. It will try to apply the configuration
 on all nodes of the cluster.
 The prerequisite is that the modified config file must be available on
 all nodes at the same location (the location where MongooseIM expects its config file).
+Option `safety_check`can be one of the following:
+* hard - ctl will check whether all configs are the same on all the nodes vefore reloading changes
+* soft - ctl will only check if config files on nodes are modified after config was loaded to memory and reload changes on nodes that satisfy this contraint
+* none - will not check consistency between nodes' configs
 
 ### Non-reloadable options
 Some options require restarting the server in order to be reloaded.

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -155,9 +155,12 @@ commands() ->
                         module = ejabberd_config, function = reload_local,
                         args = [], result = {res, restuple}},
      #ejabberd_commands{name = reload_cluster, tags = [server],
-                        desc = "Reload configuration file in the cluster",
+                        desc = "Reload configuration file in the cluster. safety_mode can be one of the following:
+                                hard - does this
+                                soft - does this
+                                none - performs no check",
                         module = ejabberd_config, function = reload_cluster,
-                        args = [], result = {res, restuple}},
+                        args = [{safety_mode, string}], result = {res, restuple}},
      #ejabberd_commands{name = join_cluster, tags = [server],
                         desc = "Join the node to a cluster. Call it from the joining node.
                                 Use `-f` or `--force` flag to avoid question prompt and force join the node",

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -875,7 +875,7 @@ reload_cluster("hard") ->
     State1 = State0#state{override_global = true,
                           override_local  = true, override_acls = true},
     case catch apply_changes(CC, LC, LHC, State1, ConfigVersion) of
-        {ok, _CurrentNode} ->
+        {ok, CurrentNode} ->
             %% apply on other nodes
             RPCResult = rpc:multicall(nodes(), ?MODULE, apply_changes_remote,
                                       [ConfigFile, ConfigDiff,

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -969,8 +969,8 @@ reload_softly(ApplyChangesFun, Args) ->
 
 is_config_file_fresh() ->
     [{last_loaded, LastLoaded}] = ets:lookup(config_reload_info, last_loaded),
-    LastModified = filelib:last_modified(get_ejabberd_config_path()),
-    ?ERROR_MSG("LastLoaded = ~p~nLastModified = ~p~nLastLoaded < LastModified = ~p", [LastLoaded, LastModified, LastLoaded < LastModified]),
+    LastModified = calendar:local_time_to_universal_time(filelib:last_modified(get_ejabberd_config_path())),
+    ?ERROR_MSG("config path: ~p~nLastLoaded = ~p~nLastModified = ~p~nLastLoaded < LastModified = ~p", [get_ejabberd_config_path(), LastLoaded, LastModified, LastLoaded < LastModified]),
     LastLoaded < LastModified.
 
 prepare_fail_result(Error, ConfigFile) ->
@@ -1108,7 +1108,7 @@ apply_changes_unsafe(ConfigChanges, LocalConfigChanges, LocalHostsChanges, State
     reload_config(ConfigChanges),
     reload_local_config(LocalConfigChanges),
     reload_local_hosts_config(LocalHostsChanges),
-    ets:insert(config_reload_info, {last_laoded, timestamp()}),
+    ets:insert(config_reload_info, {last_loaded, timestamp()}),
 
     {ok, node()}.
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -48,6 +48,7 @@
 %% conf reload
 -export([reload_local/0,
          reload_cluster/1,
+         reload_softly_remote/2,
          reload_softly/3,
          apply_changes_remote/4,
          apply_changes_remote_unsafe/2,
@@ -904,7 +905,7 @@ reload_cluster("soft") ->
         {error, _, Msg} ->
             {ok, msg("Failed to apply config on node ~p: ~p", [node(), Msg])};
         {ok, _} ->
-            RPCResult = rpc:multicall(nodes(), ?MODULE, reload_softly, [ConfigDiff, State1, ConfigDiff]),
+            RPCResult = rpc:multicall(nodes(), ?MODULE, reload_softly_remote, [ConfigFile, ConfigDiff]),
             prepare_result(RPCResult)
     end;
 reload_cluster("none") ->
@@ -939,9 +940,23 @@ reload_softly({CC, LC, LHC}, State1, ConfigVersion) ->
             case catch apply_changes(CC, LC, LHC, State1, ConfigVersion) of
                 {ok, CurrentNode} ->
                     {ok, CurrentNode};
-                Error ->
-                    ?ERROR_MSG("Error while reloading softly: ~p", [Error]),
-                    Error
+                {_, ErrorMsg} ->
+                    ?ERROR_MSG("Error while reloading softly: ~p", [ErrorMsg]),
+                    {error, node(), ErrorMsg}
+            end
+    end.
+
+reload_softly_remote(ConfigFile, {CC, LC, LHC} = ConfigDiff) ->
+    case is_config_file_more_fresh() of
+        false ->
+            {error, node(), "Config file was modified before current config was laoded and `soft` safety check was chosen."};
+        true ->
+            case catch apply_changes_remote_unsafe(ConfigFile, ConfigDiff) of
+                {ok, CurrentNode} ->
+                    {ok, CurrentNode};
+                {_, ErrorMsg} ->
+                    ?ERROR_MSG("Error while reloading softly: ~p", [ErrorMsg]),
+                    {error, node(), ErrorMsg}
             end
     end.
 


### PR DESCRIPTION
Give user a possibility to specify whether to check that config files are exactly the same on each node in cluster when using mongooseimctl's `reload_cluster` command. It is done by adding options to this command. These are:
* hard - exactly how it's now done by default
* soft - it reloads files on a node if the file is modified more recently than current config in memory 
* none - no checks are performed, it reloads files no matter how different they are