### PR TITLE
Add some deps to plt_extra_apps to get 0 Dialyzer warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -151,7 +151,7 @@
 
  ]}.
 
-{dialyzer, [{plt_extra_apps, [p1_utils]}]}.
+{dialyzer, [{plt_extra_apps, [cowboy, lasse, p1_utils, ranch]}]}.
 
 {cover_enabled, true}.
 {cover_print_enabled, true}.


### PR DESCRIPTION
This brings the number of Dialyzer warnings at commit 80b56ec from 8 to 0.

Without this change the Dialyzer output is:

```
16:51:22 erszcz @ x4 : ~/work/esl/mongooseim (master)
$ r3 dialyzer
===> Verifying dependencies...
===> Skipping goldrush (from {pkg,<<"goldrush">>,<<"0.1.7">>,
                                     <<"349A351D17C71C2FDAA18A6C2697562ABE136FEC945F147B381F0CF313160228">>}) as an app of the same name has already been fetched
===> Compiling mongooseim
===> Generating ASN.1 files.
===> Generating ASN.1 files.
===> Dialyzer starting, this may take a while...
===> Updating plt...
===> Resolving files...
===> Updating base plt...
===> Resolving files...
===> Removing 1 files from "/Users/erszcz/.cache/rebar3/rebar3_19.2_plt"...
===> Checking 163 files in "/Users/erszcz/.cache/rebar3/rebar3_19.2_plt"...
===> Copying "/Users/erszcz/.cache/rebar3/rebar3_19.2_plt" to "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...
===> Checking 163 files in "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...
===> Adding 12 files to "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...
===> Doing success typing analysis...
===> Resolving files...
===> Analyzing 291 files with "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...

_build/default/lib/mongooseim/src/global_distrib/mod_global_distrib_receiver.erl
  21: Callback info about the ranch_protocol behaviour is not available

src/mod_bosh.erl
   8: Callback info about the cowboy_loop_handler behaviour is not available

src/mod_cowboy.erl
   8: Callback info about the cowboy_http_handler behaviour is not available
   9: Callback info about the cowboy_websocket_handler behaviour is not available

src/mod_revproxy.erl
   8: Callback info about the cowboy_http_handler behaviour is not available

src/mod_websockets.erl
   8: Callback info about the cowboy_http_handler behaviour is not available
   9: Callback info about the cowboy_websocket_handler behaviour is not available

src/mongoose_client_api_sse.erl
   3: Callback info about the lasse_handler behaviour is not available
===> Warnings written to /Users/erszcz/work/esl/mongooseim/_build/default/19.2.dialyzer_warnings
===> Warnings occurred running dialyzer: 8
16:52:31 erszcz @ x4 : ~/work/esl/mongooseim (master)
$
```

With the change it is:

```
16:57:26 erszcz @ x4 : ~/work/esl/mongooseim (master +)
$ r3 dialyzer
===> Verifying dependencies...
===> Skipping goldrush (from {pkg,<<"goldrush">>,<<"0.1.7">>,
                                     <<"349A351D17C71C2FDAA18A6C2697562ABE136FEC945F147B381F0CF313160228">>}) as an app of the same name has already been fetched
===> Compiling mongooseim
===> Generating ASN.1 files.
===> Generating ASN.1 files.
===> Dialyzer starting, this may take a while...
===> Updating plt...
===> Resolving files...
===> Checking 207 files in "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...
===> Adding 1 files to "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...
===> Doing success typing analysis...
===> Resolving files...
===> Analyzing 291 files with "/Users/erszcz/work/esl/mongooseim/_build/default/rebar3_19.2_plt"...
16:59:54 erszcz @ x4 : ~/work/esl/mongooseim (master *+)
$
```