### PR TITLE
Fix saving unicode MAM messages.

### DIFF
--- a/src/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mod_mam_riak_timed_arch_yz.erl
@@ -453,10 +453,10 @@ key_filters(LocalJid, RemoteJid, Start, End, SearchText) ->
 search_text_filter(undefined) ->
     undefined;
 search_text_filter(SearchText) ->
-    Separator = "~1 AND search_text_register:",
-    NormText = mod_mam_utils:normalize_search_text(SearchText, Separator) ++ "~1",
+    Separator = <<"~1 AND search_text_register:">>,
+    NormText = mod_mam_utils:normalize_search_text(SearchText, Separator),
     %% Fuzzy search on tokens from search phrase
-    <<"search_text_register:", (list_to_binary(NormText))/binary>>.
+    <<"search_text_register:", NormText/binary, "~1">>.
 
 jid_filters(LocalJid, undefined) ->
     <<"_yz_rk:", LocalJid/binary, "*">>;
@@ -492,4 +492,3 @@ stored_binary_to_packet(Host, Bin) ->
 -spec db_message_codec(Host :: jid:server()) -> module().
 db_message_codec(Host) ->
     gen_mod:get_module_opt(Host, ?MODULE, db_message_format, mam_message_xml).
-

--- a/src/rdbms/mongoose_rdbms_pgsql.erl
+++ b/src/rdbms/mongoose_rdbms_pgsql.erl
@@ -29,7 +29,7 @@
 
 -spec escape_binary(mongoose_rdbms:pool(), binary()) -> iodata().
 escape_binary(_Pool, Bin) when is_binary(Bin) ->
-    [<<"E'\\\\x">>, bin_to_hex:bin_to_hex(Bin), <<"'::bytea">>].
+    [<<"decode('">>, base64:encode(Bin), <<"','base64')">>].
 
 -spec unescape_binary(mongoose_rdbms:pool(), binary()) -> binary().
 unescape_binary(_Pool, <<"\\x", Bin/binary>>) ->

--- a/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mam_SUITE.erl
@@ -102,7 +102,8 @@
          metric_incremented_on_archive_request/1,
          metric_incremented_when_store_message/1,
          archive_chat_markers/1,
-         dont_archive_chat_markers/1]).
+         dont_archive_chat_markers/1,
+         save_unicode_messages/1]).
 
 -import(muc_helper,
         [muc_host/0,
@@ -322,13 +323,15 @@ mam_cases() ->
      simple_archive_request,
      range_archive_request,
      range_archive_request_not_empty,
-     limit_archive_request].
+     limit_archive_request
+    ].
 
 text_search_cases() ->
     [
      simple_text_search_request,
      long_text_search_request,
-     text_search_is_available
+     text_search_is_available,
+     save_unicode_messages
     ].
 
 disabled_text_search_cases() ->
@@ -941,6 +944,8 @@ init_per_testcase(C=simple_text_search_request, Config) ->
     skip_if_cassandra(Config, fun() -> escalus:init_per_testcase(C, Config) end);
 init_per_testcase(C=long_text_search_request, Config) ->
     skip_if_cassandra(Config, fun() -> escalus:init_per_testcase(C, Config) end);
+init_per_testcase(C=save_unicode_messages, Config) ->
+    skip_if_cassandra(Config, fun() -> escalus:init_per_testcase(C, Config) end);
 init_per_testcase(C=muc_text_search_request, Config) ->
     Init =
         fun() ->
@@ -1344,6 +1349,36 @@ long_text_search_request(Config) ->
         ?assert_equal(lists:nth(11, Msgs), Body3),
 
         ok
+        end,
+    escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
+
+save_unicode_messages(Config) ->
+    P = ?config(props, Config),
+    F = fun(Alice, Bob) ->
+                escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi! this is an unicode character lol 😂"/utf8>>)),
+                escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"this is another one no 🙅"/utf8>>)),
+                escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"This is the same again lol 😂"/utf8>>)),
+                maybe_wait_for_archive(Config),
+
+                escalus:send(Alice, stanza_text_search_archive_request(P, <<"q1">>, <<"lol"/utf8>>)),
+                Res1 = wait_archive_respond(P, Alice),
+                assert_respond_size(2, Res1),
+                assert_respond_query_id(P, <<"q1">>, parse_result_iq(P, Res1)),
+                [Msg1, Msg2] = respond_messages(Res1),
+                #forwarded_message{message_body = Body1} = parse_forwarded_message(Msg1),
+                #forwarded_message{message_body = Body2} = parse_forwarded_message(Msg2),
+                ?assert_equal(<<"Hi! this is an unicode character lol 😂"/utf8>>, Body1),
+                ?assert_equal(<<"This is the same again lol 😂"/utf8>>, Body2),
+
+                escalus:send(Alice, stanza_text_search_archive_request(P, <<"q2">>, <<"no"/utf8>>)),
+                Res2 = wait_archive_respond(P, Alice),
+                assert_respond_size(1, Res2),
+                assert_respond_query_id(P, <<"q2">>, parse_result_iq(P, Res2)),
+                [Msg3] = respond_messages(Res2),
+                #forwarded_message{message_body = Body3} = parse_forwarded_message(Msg3),
+                ?assert_equal(<<"this is another one no 🙅"/utf8>>, Body3),
+
+                ok
         end,
     escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
 


### PR DESCRIPTION
This PR allows storing and retrieving unicode messages in MAM. It changes a few places to properly handle unicode, as well as sidesteps escaping needed for some databases by using prepared queries also in synchronous writes (previously only in asynchronous)