### PR TITLE
Add codecov integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ test.disabled/ejabberd_tests/src/mim_ct_rest.erl
 test.disabled/ejabberd_tests/src/mim_ct_rest_handler.erl
 test.disabled/ejabberd_tests/src/mim_ct_sup.erl
 test_preset.log
+
+codecov.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
         - ./rebar3 compile
         - make dev
         - tools/travis-build-tests.sh
+        - pip install --user codecov
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
@@ -29,6 +30,7 @@ after_failure:
         - tail -100 _build/mim2/rel/mongooseim/log/ejabberd.log
 
 after_success:
+        - codecov
         - ./rebar3 coveralls send
         - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ] && [ $TRAVIS_OTP_RELEASE = "19.3" ];
             then tools/travis-build-and-push-docker.sh;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # MongooseIM platform
 
-[![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM) [![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](http://mongooseim.readthedocs.org/en/latest/?badge=latest) [![Coverage Status](https://img.shields.io/coveralls/esl/MongooseIM.svg)](https://coveralls.io/r/esl/MongooseIM?branch=master) [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
+[![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM)
+[![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](http://mongooseim.readthedocs.org/en/latest/?badge=latest)
+[![Coverage Status](https://img.shields.io/coveralls/esl/MongooseIM.svg)](https://coveralls.io/r/esl/MongooseIM?branch=master)
+[![codecov](https://codecov.io/gh/esl/MongooseIM/branch/master/graph/badge.svg)](https://codecov.io/gh/esl/MongooseIM)
+[![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
+
 
 * [Getting started](http://mongooseim.readthedocs.io/en/latest/user-guide/Getting-started/)
 * [Developer's guide](http://mongooseim.readthedocs.io/en/latest/developers-guide/Testing-MongooseIM/)

--- a/test.disabled/ejabberd_tests/run_common_test.erl
+++ b/test.disabled/ejabberd_tests/run_common_test.erl
@@ -256,6 +256,9 @@ analyze(Test, CoverOpts) ->
     report_time("Export merged cover data", fun() ->
 			cover:export("/tmp/mongoose_combined.coverdata")
 		end),
+    report_time("Export merged cover data in codecov.json format", fun() ->
+            export_codecov_json()
+        end),
     case os:getenv("TRAVIS_JOB_ID") of
         false ->
             make_html(modules_to_analyze(CoverOpts));
@@ -453,3 +456,67 @@ travis_fold(Description, Fun) ->
 import_code_paths(FromNode) when is_atom(FromNode) ->
     Paths = rpc:call(FromNode, code, get_path, []),
     code:add_paths(Paths).
+
+%% covecov.json cover format
+%% ------------------------------------------------------------------
+
+%% Writes codecov.json into root of the repo directory
+%%
+%% Format:
+%%
+%% {"coverage": {
+%%     "src/mod_mam.erl": [0, 1, 4, null]
+%% }}
+%%
+%% Where:
+%%
+%% - 0 - zero hits
+%% - null - lines, that are not executed (comments, patterns...)
+%% - 1 - called once
+%% - 4 - called 4 times
+export_codecov_json() ->
+    Modules = cover:imported_modules(),
+    %% Result is a flat map of `{{Module, Line}, CallTimes}'
+    {result, Result, _} = cover:analyse(Modules, calls, line),
+    Mod2Data = lists:foldl(fun add_cover_line_into_array/2, #{}, Result),
+    JSON = maps:fold(fun format_array_to_list/3, [], Mod2Data),
+    Binary = jiffy:encode(#{<<"coverage">> => {JSON}}),
+    file:write_file(?ROOT_DIR ++ "/codecov.json", Binary).
+
+add_cover_line_into_array({{Module, Line}, CallTimes}, Acc) ->
+    %% Set missing lines to null
+    CallsPerLineArray = maps:get(Module, Acc, array:new({default, null})),
+    Acc#{Module => array:set(Line, CallTimes, CallsPerLineArray)}.
+
+format_array_to_list(Module, CallsPerLineArray, Acc) ->
+    ListOfCallTimes = array:to_list(CallsPerLineArray),
+    BinPath = list_to_binary(get_source_path(Module)),
+    [{BinPath, ListOfCallTimes}|Acc].
+
+%% We assume that all mongooseim modules are loaded on this node
+get_source_path(Module) when is_atom(Module) ->
+    try
+        AbsPath = proplists:get_value(source, Module:module_info(compile)),
+        string:prefix(AbsPath, get_repo_dir())
+    of nomatch ->
+        error_logger:warning_msg("issue=get_source_path_failed reason=nomatch module=~p", [Module]),
+        atom_to_list(Module) ++ ".erl";
+       Name ->
+           Name
+    catch _:_ ->
+        error_logger:warning_msg("issue=get_source_path_failed module=~p", [Module]),
+        atom_to_list(Module) ++ ".erl"
+    end.
+
+get_repo_dir() ->
+    %% We make an assumption, that mongooseim.erl is in src/ directory
+    MongoosePath = proplists:get_value(source, mongooseim:module_info(compile)),
+    string_suffix(MongoosePath, "src/mongooseim.erl").
+
+%% Removes string suffix
+string_suffix(String, Suffix) ->
+    StringR = lists:reverse(String),
+    SuffixR = lists:reverse(Suffix),
+    lists:reverse(string:prefix(StringR, SuffixR)).
+
+%% ------------------------------------------------------------------


### PR DESCRIPTION
Example: https://codecov.io/gh/esl/MongooseIM/tree/651a44752aa95cb390c4e277a3119c9463905292/src


Import coverdata into codecov.json.

Use module_info to find source files location.

It increases travis job time by ~ 15 seconds.
- pip install - 5 seconds
- codecov - 5 seconds
- codecov.json generation - 2 seconds


Admin stuff
----

The PR can be merged without "admin stuff" tasks.
Apparently, the only thing is missing without granting access is a check in "All checks have passed" from codecov.

To enable codecov bot, add esl/MongooseIM to https://codecov.io/ (10 minutes for someone who have admin access for esl github account).

- first auth codecov using github oauth. It does not give codecov code access, but they can comment to PRs.
- than enable codecov for a specific repo on codecov site. Probably somewhere https://codecov.io/gh/esl/MongooseIM

- The bot makes comments like this: https://github.com/arcusfelis/MongooseIM/pull/26#issuecomment-369713492
- Should be free for public repos.
