### PR TITLE
Fix a race condition in a call to GD conn manager

### DIFF
--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -70,7 +70,7 @@ force_refresh(Server) ->
 close_disabled(Server) ->
     do_call(Server, close_disabled).
 
--spec get_connection(Server :: jid:lserver()) -> pid() | {error, any()}.
+-spec get_connection(Server :: jid:lserver()) -> {ok, pid()} | {error, any()}.
 get_connection(Server) ->
     do_call(Server, get_connection).
 
@@ -117,7 +117,7 @@ handle_call(get_connection, From, #state{ enabled = [], pending_gets = PendingGe
     {noreply, State#state{ pending_gets = queue:in(From, PendingGets) }};
 handle_call(get_connection, _From, #state{ enabled = Enabled } = State) ->
     Connection = pick_connection(Enabled),
-    {reply, Connection, State};
+    {reply, {ok, Connection}, State};
 handle_call(force_refresh, _From, State) ->
     {reply, ok, refresh_connections(State)};
 handle_call(close_disabled, _From, #state{ disabled = Disabled } = State) ->
@@ -157,7 +157,7 @@ handle_info(process_pending_get, #state{ pending_gets = PendingGets,
     case queue:out(PendingGets) of
         {{value, From}, NewPendingGets} ->
             Connection = pick_connection(Enabled),
-            gen_server:reply(From, Connection),
+            gen_server:reply(From, {ok, Connection}),
 
             NState0 = State#state{ pending_gets = NewPendingGets },
             maybe_schedule_process_get(NState0);

--- a/src/global_distrib/mod_global_distrib_server_sup.erl
+++ b/src/global_distrib/mod_global_distrib_server_sup.erl
@@ -46,6 +46,9 @@ get_connection(Server) ->
             %% so the main outgoing_conns_sup becomes a synchronisation point
             %% because it's impossible to learn that the server_sup is `already_started`
             %% without it finishing the init first (thus finishing the init of mgr as well).
+            %%
+            %% TODO: Write a test for it, once we establish a good way to reproduce
+            %%       race conditions in tests!
             {error, not_available};
         Result ->
             Result

--- a/src/global_distrib/mod_global_distrib_server_sup.erl
+++ b/src/global_distrib/mod_global_distrib_server_sup.erl
@@ -33,9 +33,23 @@ start_link(Server) ->
     SupName = mod_global_distrib_utils:server_to_sup_name(Server),
     supervisor:start_link({local, SupName}, ?MODULE, [Server]).
 
--spec get_connection(Server :: jid:lserver()) -> pid().
+-spec get_connection(Server :: jid:lserver()) -> {ok, pid()} | {error, not_available}.
 get_connection(Server) ->
-    mod_global_distrib_server_mgr:get_connection(Server).
+    case catch mod_global_distrib_server_mgr:get_connection(Server) of
+        {'EXIT', {noproc, _}} ->
+            %% May be caused by missing server_sup or missing connection manager
+            %% The former occurs when a process tries to send a message to Server
+            %% for the first time.
+            %% The latter occurs when some other process already started server_sup,
+            %% which hasn't started manager yet.
+            %% In both cases the caller should attempt to start server_sup,
+            %% so the main outgoing_conns_sup becomes a synchronisation point
+            %% because it's impossible to learn that the server_sup is `already_started`
+            %% without it finishing the init first (thus finishing the init of mgr as well).
+            {error, not_available};
+        Result ->
+            Result
+    end.
 
 -spec start_pool(Supervisor :: pid(),
                  Endpoint :: mod_global_distrib_utils:endpoint(),


### PR DESCRIPTION
This PR addresses an issue observed in load tests, where sometimes a call to `get_connection` crashed with `noproc` exception (that applies to connection manager process).

It may happen if a process starts outgoing connections supervisor and second one tries to access the pool in a state, when supervisor is already running but manager (child of the supervisor) is not (yet).

Also please check the comments in the code.

Load tests confirm that this branch fixes the issue.