### PR TITLE
Let reload_cluster not check some config values

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1123,15 +1123,17 @@ methods_to_auth_modules(A) when is_atom(A) ->
 
 compute_config_version(LC, LCH) ->
     L0 = lists:filter(mk_node_start_filter(), LC ++ LCH),
-    L1 = filter_out_node_specific_options(L0),
+    L1 = filter_out_node_specific_options(L0, config),
     L2 = sort_config(L1),
     crypto:hash(sha, term_to_binary(L2)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options(Opts),
+    Opts2 = filter_out_node_specific_options(Opts, config_file),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
 
+filter_out_node_specific_options(Opts, Label) ->
+    filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->
     [];

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1127,7 +1127,10 @@ compute_config_version(LC, LCH) ->
     crypto:hash(sha, term_to_binary(L1)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
+    ?ERROR_MSG("[reload_cluster] Opts in:~n~p", [Opts]),
     Opts2 = filter_out_node_specific_options(Opts),
+    ?ERROR_MSG("[reload_cluster] Opts out:~n~p", [Opts2]),
+    ?ERROR_MSG("hosts:~n~p", []),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1147,28 +1147,29 @@ filter_out_node_specific_options([Opt | Opts]) ->
 % a list of keys in proplist that should be deleted (if such
 % path exists). The `root path` for them is a list of modules.
 node_specific_module_options() ->
-    [
-     [mod_global_distrib, connections, endpoints],
-     [mod_global_distrib, redis, server],
-     % Endpoints
-     [mod_global_distrib_sender, endpoints],
-     [mod_global_distrib_sender, connections, endpoints],
+    endpoints_options() ++ redis_options() ++ advertised_endpoints_options().
 
-     [mod_global_distrib_mapping, connections, endpoints],
+endpoints_options() ->
+    with_modules([endpoints]) ++ with_modules([connections, endpoints]).
 
-     [mod_global_distrib_receiver, connections, endpoints],
-     [mod_global_distrib_receiver, endpoints],
+redis_options() ->
+    with_modules([redis, server]).
 
-     [mod_global_distrib_bounce, connections, endpoints],
+advertised_endpoints_options() ->
+    with_modules([connections, advertised_endpoints]).
 
-     [mod_global_distrib_disco, connections, endpoints],
-     % Redis
-     [mod_global_distrib_sender, redis, server],
-     [mod_global_distrib_mapping, redis, server],
-     [mod_global_distrib_receiver, redis, server],
-     [mod_global_distrib_bounce, redis, server],
-     [mod_global_distrib_disco, redis, server]
-    ].
+with_modules(Path) ->
+    lists:map(fun(Module) -> [Module | Path] end, gd_modules()).
+
+gd_modules() ->
+    [mod_global_distrib,
+     mod_global_distrib_sender,
+     mod_global_distrib_mapping,
+     mod_global_distrib_receiver,
+     mod_global_distrib_bounce,
+     mod_global_distrib_disco].
+
+
 
 delete_path_in_proplist(Plist, [Step]) ->
     lists:keydelete(Step, 1, Plist);

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1151,7 +1151,7 @@ filter_out_node_specific_options([Opt | Opts]) ->
 node_specific_module_options() ->
     [
      [mod_global_distrib, connections, endpoints],
-     [mod_global_ditrib, redis, server]
+     [mod_global_distrib, redis, server]
     ].
 
 delete_path_in_proplist(Plist, [Step]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1127,15 +1127,18 @@ compute_config_version(LC, LCH) ->
     crypto:hash(sha, term_to_binary(L1)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options(Opts),
+    Opts2 = filter_out_node_specific_options(Opts, wrapper),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
 
+filter_out_node_specific_options(Opts, wrapper) ->
+    filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->
     [];
 filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) -> % use record
-    NewMods = lists:foldl(fun(Path, Mods) -> delete_path_in_proplist(Mods, Path) end,
+    ?ERROR_MSG("[reload_cluster2] modules for host: ~p", [Host]),
+    NewMods = lists:foldl(fun(Path, Mods) -> ?ERROR_MSG("deleting ~p", [Path]), delete_path_in_proplist(Mods, Path) end,
                           Mods, node_specific_module_options()),
     [{local_config, {modules, Host}, NewMods} | filter_out_node_specific_options(Opts)];
 filter_out_node_specific_options([Opt | Opts]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1135,12 +1135,16 @@ filter_out_node_specific_options([]) ->
     [];
 filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) ->
     NewMods = lists:foldl(fun(Path, Mods) -> delete_path_in_proplist(Mods, Path) end,
-                          Mods, node_specific_options()),
+                          Mods, node_specific_module_options()),
     [{local_config, {modules, Host}, NewMods} | Opts];
 filter_out_node_specific_options([Opt | Opts]) ->
     [Opt | filter_out_node_specific_options(Opts)].
 
-node_specific_options() ->
+% @doc The list of options that should not be checked if equal
+% between nodes in cluster. Each option is expressed as
+% a list of keys in proplist that should be deleted (if such
+% path exists). The `root path` for them is a list of modules.
+node_specific_module_options() ->
     [
      [mod_global_distrib, connections, endpoints]
     ].

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1142,7 +1142,7 @@ filter_out_node_specific_options([#local_config{key = {modules, Host}, value = M
 filter_out_node_specific_options([Opt | Opts]) ->
     [Opt | filter_out_node_specific_options(Opts)].
 
-% @doc The list of options that should not be checked if equal
+% @doc The list of options that should not be compared
 % between nodes in cluster. Each option is expressed as
 % a list of keys in proplist that should be deleted (if such
 % path exists). The `root path` for them is a list of modules.

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1123,23 +1123,20 @@ methods_to_auth_modules(A) when is_atom(A) ->
 
 compute_config_version(LC, LCH) ->
     L0 = lists:filter(mk_node_start_filter(), LC ++ LCH),
-    L1 = filter_out_node_specific_options(L0, compute_config_version),
+    L1 = filter_out_node_specific_options(L0),
     L2 = sort_config(L1),
     crypto:hash(sha, term_to_binary(L2)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options(Opts, compute_config_file_version),
+    Opts2 = filter_out_node_specific_options(Opts),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
 
-filter_out_node_specific_options(Opts, _Label) ->
-    filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->
     [];
 filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) -> % use record
-    ?ERROR_MSG("[reload_cluster2] modules for host: ~p", [Host]),
-    NewMods = lists:foldl(fun(Path, ModList) -> ?ERROR_MSG("deleting ~p", [Path]), delete_path_in_proplist(ModList, Path) end,
+    NewMods = lists:foldl(fun(Path, ModList) -> delete_path_in_proplist(ModList, Path) end,
                           Mods, node_specific_module_options()),
     [{local_config, {modules, Host}, NewMods} | filter_out_node_specific_options(Opts)];
 filter_out_node_specific_options([Opt | Opts]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1138,7 +1138,7 @@ filter_out_node_specific_options([]) ->
     [];
 filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) -> % use record
     ?ERROR_MSG("[reload_cluster2] modules for host: ~p", [Host]),
-    NewMods = lists:foldl(fun(Path, Mods) -> ?ERROR_MSG("deleting ~p", [Path]), delete_path_in_proplist(Mods, Path) end,
+    NewMods = lists:foldl(fun(Path, ModList) -> ?ERROR_MSG("deleting ~p", [Path]), delete_path_in_proplist(ModList, Path) end,
                           Mods, node_specific_module_options()),
     [{local_config, {modules, Host}, NewMods} | filter_out_node_specific_options(Opts)];
 filter_out_node_specific_options([Opt | Opts]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1148,6 +1148,10 @@ filter_out_node_specific_options([Opt | Opts]) ->
 % between nodes in cluster. Each option is expressed as
 % a list of keys in proplist that should be deleted (if such
 % path exists). The `root path` for them is a list of modules.
+% It is build this way to include options created dynamically.
+% As they might appear in every module that uses one of them, we exclude them
+% from every module (not in all of them there necessarily exists one of these
+% options).
 node_specific_module_options() ->
     endpoints_options() ++ redis_options() ++ advertised_endpoints_options().
 
@@ -1158,7 +1162,7 @@ redis_options() ->
     with_modules([redis, server]).
 
 advertised_endpoints_options() ->
-    with_modules([connections, advertised_endpoints]).
+    with_modules([connections, advertised_endpoints]) ++ with_modules([advertised_endpoints]).
 
 with_modules(Path) ->
     lists:map(fun(Module) -> [Module | Path] end, gd_modules()).

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1152,7 +1152,25 @@ filter_out_node_specific_options([Opt | Opts]) ->
 node_specific_module_options() ->
     [
      [mod_global_distrib, connections, endpoints],
-     [mod_global_distrib, redis, server]
+     [mod_global_distrib, redis, server],
+     % Endpoints
+     [mod_global_distrib_sender, endpoints],
+     [mod_global_distrib_sender, connections, endpoints],
+
+     [mod_global_distrib_mapping, connections, endpoints],
+
+     [mod_global_distrib_receiver, connections, endpoints],
+     [mod_global_distrib_receiver, endpoints],
+
+     [mod_global_distrib_bounce, connections, endpoints],
+
+     [mod_global_distrib_disco, connections, endpoints],
+     % Redis
+     [mod_global_distrib_sender, redis, server],
+     [mod_global_distrib_mapping, redis, server],
+     [mod_global_distrib_receiver, redis, server],
+     [mod_global_distrib_bounce, redis, server],
+     [mod_global_distrib_disco, redis, server]
     ].
 
 delete_path_in_proplist(Plist, [Step]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1123,15 +1123,16 @@ methods_to_auth_modules(A) when is_atom(A) ->
 
 compute_config_version(LC, LCH) ->
     L0 = lists:filter(mk_node_start_filter(), LC ++ LCH),
-    L1 = sort_config(L0),
-    crypto:hash(sha, term_to_binary(L1)).
+    L1 = filter_out_node_specific_options(L0, compute_config_version),
+    L2 = sort_config(L1),
+    crypto:hash(sha, term_to_binary(L2)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options(Opts, wrapper),
+    Opts2 = filter_out_node_specific_options(Opts, compute_config_file_version),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
 
-filter_out_node_specific_options(Opts, wrapper) ->
+filter_out_node_specific_options(Opts, _Label) ->
     filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1122,14 +1122,17 @@ methods_to_auth_modules(A) when is_atom(A) ->
 
 compute_config_version(LC, LCH) ->
     L0 = lists:filter(mk_node_start_filter(), LC ++ LCH),
-    L1 = filter_out_node_specific_options(L0),
+    L1 = filter_out_node_specific_options(L0, compute_config_version),
     L2 = sort_config(L1),
     crypto:hash(sha, term_to_binary(L2)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options(Opts),
+    Opts2 = filter_out_node_specific_options(Opts, compute_config_file_version),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
+
+filter_out_node_specific_options(Opts, Label) ->
+    filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->
     [];

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1127,19 +1127,17 @@ compute_config_version(LC, LCH) ->
     crypto:hash(sha, term_to_binary(L1)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options_tmp_wrapper(Opts),
+    Opts2 = filter_out_node_specific_options(Opts),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
 
-filter_out_node_specific_options_tmp_wrapper(Opts) ->
-    filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->
     [];
-filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) ->
+filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) -> % use record
     NewMods = lists:foldl(fun(Path, Mods) -> delete_path_in_proplist(Mods, Path) end,
                           Mods, node_specific_module_options()),
-    [{local_config, {modules, Host}, NewMods} | Opts];
+    [{local_config, {modules, Host}, NewMods} | filter_out_node_specific_options(Opts)];
 filter_out_node_specific_options([Opt | Opts]) ->
     [Opt | filter_out_node_specific_options(Opts)].
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1123,17 +1123,14 @@ methods_to_auth_modules(A) when is_atom(A) ->
 
 compute_config_version(LC, LCH) ->
     L0 = lists:filter(mk_node_start_filter(), LC ++ LCH),
-    L1 = filter_out_node_specific_options(L0, config),
+    L1 = filter_out_node_specific_options(L0),
     L2 = sort_config(L1),
     crypto:hash(sha, term_to_binary(L2)).
 
 compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
-    Opts2 = filter_out_node_specific_options(Opts, config_file),
+    Opts2 = filter_out_node_specific_options(Opts),
     L = sort_config(Opts2 ++ Hosts),
     crypto:hash(sha, term_to_binary(L)).
-
-filter_out_node_specific_options(Opts, Label) ->
-    filter_out_node_specific_options(Opts).
 
 filter_out_node_specific_options([]) ->
     [];

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1151,7 +1151,7 @@ filter_out_node_specific_options([Opt | Opts]) ->
 node_specific_module_options() ->
     [
      [mod_global_distrib, connections, endpoints],
-     [mod_global_sitrib, redis, server]
+     [mod_global_ditrib, redis, server]
     ].
 
 delete_path_in_proplist(Plist, [Step]) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1138,7 +1138,7 @@ filter_out_node_specific_options([]) ->
 filter_out_node_specific_options([#local_config{key = {modules, Host}, value = Mods} | Opts]) ->
     NewMods = lists:foldl(fun(Path, ModList) -> delete_path_in_proplist(ModList, Path) end,
                           Mods, node_specific_module_options()),
-    [{local_config, {modules, Host}, NewMods} | filter_out_node_specific_options(Opts)];
+    [#local_config{key = {modules, Host}, value = NewMods} | filter_out_node_specific_options(Opts)];
 filter_out_node_specific_options([Opt | Opts]) ->
     [Opt | filter_out_node_specific_options(Opts)].
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1135,7 +1135,7 @@ compute_config_file_version(#state{opts = Opts, hosts = Hosts}) ->
 
 filter_out_node_specific_options([]) ->
     [];
-filter_out_node_specific_options([{local_config, {modules, Host}, Mods} | Opts]) -> % use record
+filter_out_node_specific_options([#local_config{key = {modules, Host}, value = Mods} | Opts]) ->
     NewMods = lists:foldl(fun(Path, ModList) -> delete_path_in_proplist(ModList, Path) end,
                           Mods, node_specific_module_options()),
     [{local_config, {modules, Host}, NewMods} | filter_out_node_specific_options(Opts)];


### PR DESCRIPTION
Right now we just filter this option out of config when calculating sha with `ejabberd_config:filter_out_node_specific_endpoints/1` called in `compute_config_file_version/1` and `compute_config_version/1`. In the future it should probably be more general (if the number of such different-among-nodes options increase).