### PR TITLE
Pass PRESET variable to codecov to distinguish builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ after_failure:
         - tail -100 _build/mim2/rel/mongooseim/log/ejabberd.log
 
 after_success:
-        - codecov
+        # env variables help to distinguish CI builds
+        # It takes less time without gcov
+        - codecov --disable=gcov --env PRESET
         - ./rebar3 coveralls send
         - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ] && [ $TRAVIS_OTP_RELEASE = "19.3" ];
             then tools/travis-build-and-push-docker.sh;


### PR DESCRIPTION
Pass PRESET variable to codecov to distinguish builds on a build tab
Also disable gcov


# What it does

[Before](https://codecov.io/gh/esl/MongooseIM/commit/fc9abfe5bb79e55c6c0151142061829bf57e572c/build)
[After](https://codecov.io/gh/esl/MongooseIM/commit/5def43b1c8e0683fc95a93be0623400c2edf6b0f/build)