### PR TITLE
Separated database logic from mod_muc into backend modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
         - slapd
         - ldap-utils
         - golang # used for google drive test results upload
+    hosts:
+        # travis tries to resolve muc.localhost and fails
+        # used in MUC + s2s tests combination
+        - muc.localhost
 before_install:
         - tools/configure $REL_CONFIG
 install:

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -8,6 +8,7 @@ Also `mod_muc_log` is a logging submodule.
 ### Options
 * `host` (string, default: `"conference.@HOST@"`): Subdomain for MUC service to reside under. 
  `@HOST@` is replaced with each served domain.
+* `backend` (atom, default: `mnesia`): Storage backend. Currently only `mnesia` is supported.
 * `access` (atom, default: `all`): Access Rule to determine who is allowed to use the MUC service.
 * `access_create` (atom, default: `all`): Who is allowed to create rooms.
 * `access_admin` (atom, default: `none`): Who is the administrator in all rooms.
@@ -27,6 +28,7 @@ Also `mod_muc_log` is a logging submodule.
 * `user_presence_shaper` (atom, default: `none`): Shaper for user presences processed by a room (global for the room).
 * `max_user_conferences` (non-negative, default: 10): Specifies the number of rooms that a user can occupy simultaneously.
 * `http_auth_pool` (atom, default: `none`): If an external HTTP service is chosen to check passwords for password-protected rooms, this option specifies the HTTP pool name to use (see [External HTTP Authentication](#external-http-authentication) below).
+* `load_permanent_rooms_at_startup` (boolean, default: false) - Load all rooms at startup (can be unsafe when there are many rooms, that's why disabled).
 * `hibernate_timeout` (timeout, default: `90000`): Timeout (in milliseconds) defining the inactivity period after which the room's process should be hibernated.
 * `hibernated_room_check_interval` (timeout, default: `infinity`): Interval defining how often the hibernated rooms will be checked (a timer is global for a node).
 * `hibernated_room_timeout` (timeout, default: `inifitniy`): A time after which a hibernated room is stopped (deeply hibernated).

--- a/include/mod_muc.hrl
+++ b/include/mod_muc.hrl
@@ -1,0 +1,13 @@
+-record(muc_room, {
+          name_host,
+          opts
+         }).
+
+-record(muc_online_room, {name_host,
+                          pid
+                         }).
+
+-record(muc_registered, {
+          us_host,
+          nick
+         }).

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -58,7 +58,9 @@
          stanza_errort/5,
          stream_error/1,
          stream_errort/3,
-         remove_delay_tags/1]).
+         remove_delay_tags/1,
+         expr_to_term/1,
+         term_to_expr/1]).
 
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl"). % only used to define stream types
@@ -868,3 +870,12 @@ remove_delay_tags(#xmlel{children = Els} = Packet) ->
                               El ++ [R]
                 end, [], Els),
     Packet#xmlel{children=NEl}.
+
+expr_to_term(Expr) ->
+    Str = binary_to_list(<<Expr/binary, ".">>),
+    {ok, Tokens, _} = erl_scan:string(Str),
+    {ok, Term} = erl_parse:parse_term(Tokens),
+    Term.
+
+term_to_expr(Term) ->
+    list_to_binary(io_lib:print(Term)).

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -58,9 +58,7 @@
          stanza_errort/5,
          stream_error/1,
          stream_errort/3,
-         remove_delay_tags/1,
-         expr_to_term/1,
-         term_to_expr/1]).
+         remove_delay_tags/1]).
 
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl"). % only used to define stream types
@@ -870,12 +868,3 @@ remove_delay_tags(#xmlel{children = Els} = Packet) ->
                               El ++ [R]
                 end, [], Els),
     Packet#xmlel{children=NEl}.
-
-expr_to_term(Expr) ->
-    Str = binary_to_list(<<Expr/binary, ".">>),
-    {ok, Tokens, _} = erl_scan:string(Str),
-    {ok, Term} = erl_parse:parse_term(Tokens),
-    Term.
-
-term_to_expr(Term) ->
-    list_to_binary(io_lib:print(Term)).

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -230,6 +230,8 @@ can_use_nick(_ServerHost, _Host, _JID, <<>>) ->
 can_use_nick(ServerHost, Host, JID, Nick) ->
     mod_muc_db_backend:can_use_nick(ServerHost, Host, JID, Nick).
 
+set_nick(LServer, Host, From, <<>>) ->
+    {error, should_not_be_empty};
 set_nick(LServer, Host, From, Nick) ->
     mod_muc_db_backend:set_nick(LServer, Host, From, Nick).
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -36,13 +36,13 @@
          start/2,
          stop/1,
          room_destroyed/3,
-         store_room/3,
-         restore_room/2,
-         forget_room/2,
+         store_room/4,
+         restore_room/3,
+         forget_room/3,
          create_instant_room/5,
          process_iq_disco_items/4,
          broadcast_service_message/2,
-         can_use_nick/3,
+         can_use_nick/4,
          room_jid_to_pid/1,
          default_host/0]).
 
@@ -89,30 +89,17 @@
          Packet :: packet()}.
 -type access() :: {_AccessRoute, _AccessCreate, _AccessAdmin, _AccessPersistent}.
 
--record(muc_room, {
-    name_host,
-    opts
-}).
+-include("mod_muc.hrl").
 
 -type muc_room() :: #muc_room{
     name_host    :: room_host(),
     opts         :: list()
 }.
 
--record(muc_online_room, {
-    name_host,
-    pid
-}).
-
 -type muc_online_room() :: #muc_online_room{
     name_host :: room_host(),
     pid       :: pid()
 }.
-
--record(muc_registered, {
-    us_host,
-    nick
-}).
 
 -type muc_registered() :: #muc_registered{
                              us_host    :: jid:literal_jid(),
@@ -155,6 +142,9 @@ start_link(Host, Opts) ->
     {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start(Host, Opts) ->
     ensure_metrics(Host),
+    TrackedDBFuns = [store_room, restore_room, forget_room, get_rooms,
+                     can_use_nick, get_nick, set_nick, unset_nick],
+    gen_mod:start_backend_module(mod_muc_db, Opts, TrackedDBFuns),
     start_supervisor(Host),
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     ChildSpec =
@@ -204,35 +194,21 @@ create_instant_room(Host, Name, From, Nick, Opts) ->
     gen_server:call(Proc, {create_instant, Name, From, Nick, Opts}).
 
 
--spec store_room(jid:server(), room(), list())
-            -> {'aborted', _} | {'atomic', _}.
-store_room(Host, Name, Opts) ->
-    F = fun() ->
-                mnesia:write(#muc_room{name_host = {Name, Host},
-                                       opts = Opts})
-        end,
-    mnesia:transaction(F).
+-spec store_room(jid:server(), jid:server(), room(), list()) ->
+    {'aborted', _} | {'atomic', _}.
+store_room(ServerHost, Host, Name, Opts) ->
+    mod_muc_db_backend:store_room(ServerHost, Host, Name, Opts).
 
 
--spec restore_room(jid:server(), room())
-                                    -> 'error' | 'undefined' | [any()].
-restore_room(Host, Name) ->
-    case catch mnesia:dirty_read(muc_room, {Name, Host}) of
-        [#muc_room{opts = Opts}] ->
-            Opts;
-        _ ->
-            error
-    end.
+-spec restore_room(jid:server(), jid:server(), room()) ->
+        {error, _} | {ok, _}.
+restore_room(ServerHost, Host, Name) ->
+    mod_muc_db_backend:restore_room(ServerHost, Host, Name).
 
 
--spec forget_room(jid:server(), room()) -> 'ok'.
-forget_room(Host, Name) ->
-    F = fun() ->
-                mnesia:delete({muc_room, {Name, Host}})
-        end,
-    mnesia:transaction(F),
-    ejabberd_hooks:run(forget_room, Host, [Host, Name]),
-    ok.
+-spec forget_room(jid:server(), jid:server(), room()) -> 'ok'.
+forget_room(ServerHost, Host, Name) ->
+    mod_muc_db_backend:forget_room(ServerHost, Host, Name).
 
 
 -spec process_iq_disco_items(Host :: jid:server(), From :: jid:jid(),
@@ -248,26 +224,20 @@ process_iq_disco_items(Host, From, To, #iq{lang = Lang} = IQ) ->
                           jlib:iq_to_xml(Res)).
 
 
--spec can_use_nick(jid:server(), jid:jid(), nick()) -> boolean().
-can_use_nick(_Host, _JID, <<>>) ->
+-spec can_use_nick(jid:server(), jid:server(), jid:jid(), nick()) -> boolean().
+can_use_nick(_ServerHost, _Host, _JID, <<>>) ->
     false;
-can_use_nick(Host, JID, Nick) ->
-    {LUser, LServer, _} = jid:to_lower(JID),
-    LUS = {LUser, LServer},
-    case catch mnesia:dirty_select(
-                 muc_registered,
-                 [{#muc_registered{us_host = '$1',
-                                   nick = Nick,
-                                   _ = '_'},
-                   [{'==', {element, 2, '$1'}, Host}],
-                   ['$_']}]) of
-        {'EXIT', _Reason} ->
-            true;
-        [] ->
-            true;
-        [#muc_registered{us_host = {U, _Host}}] ->
-            U == LUS
-    end.
+can_use_nick(ServerHost, Host, JID, Nick) ->
+    mod_muc_db_backend:can_use_nick(ServerHost, Host, JID, Nick).
+
+set_nick(LServer, Host, From, Nick) ->
+    mod_muc_db_backend:set_nick(LServer, Host, From, Nick).
+
+unset_nick(LServer, Host, From) ->
+    mod_muc_db_backend:unset_nick(LServer, Host, From).
+
+get_nick(LServer, Host, From) ->
+    mod_muc_db_backend:get_nick(LServer, Host, From).
 
 %%====================================================================
 %% gen_server callbacks
@@ -282,22 +252,14 @@ can_use_nick(Host, JID, Nick) ->
 %%--------------------------------------------------------------------
 -spec init([jid:server() | list(), ...]) -> {'ok', state()}.
 init([Host, Opts]) ->
-    mnesia:create_table(muc_room,
-                        [{disc_copies, [node()]},
-                         {attributes, record_info(fields, muc_room)}]),
-    mnesia:create_table(muc_registered,
-                        [{disc_copies, [node()]},
-                         {attributes, record_info(fields, muc_registered)}]),
+    mod_muc_db_backend:init(Host, Opts),
     mnesia:create_table(muc_online_room,
                         [{ram_copies, [node()]},
                          {attributes, record_info(fields, muc_online_room)}]),
     mnesia:add_table_copy(muc_online_room, node(), ram_copies),
-    mnesia:add_table_copy(muc_room, node(), disc_copies),
-    mnesia:add_table_copy(muc_registered, node(), disc_copies),
     catch ets:new(muc_online_users, [bag, named_table, public, {keypos, 2}]),
     MyHost = gen_mod:get_opt_subhost(Host, Opts, default_host()),
     clean_table_from_bad_node(node(), MyHost),
-    mnesia:add_table_index(muc_registered, nick),
     mnesia:subscribe(system),
     Access = gen_mod:get_opt(access, Opts, all),
     AccessCreate = gen_mod:get_opt(access_create, Opts, all),
@@ -330,9 +292,17 @@ init([Host, Opts]) ->
     ejabberd_router:register_route(MyHost, mongoose_packet_handler:new(?MODULE, State)),
     mongoose_subhosts:register(Host, MyHost),
 
-    load_permanent_rooms(MyHost, Host,
-                         {Access, AccessCreate, AccessAdmin, AccessPersistent},
-                         HistorySize, RoomShaper, HttpAuthPool),
+    case gen_mod:get_module_opt(Host, mod_muc, load_permanent_rooms_at_startup, false) of
+        false ->
+            ?INFO_MSG("issue=load_permanent_rooms_at_startup, skip=true, "
+                      "details=\"each room is loaded when someone access the room\"", []);
+        true ->
+            ?INFO_MSG("issue=load_permanent_rooms_at_startup, skip=false, "
+                      "details=\"it can take some time\"", []),
+            load_permanent_rooms(MyHost, Host,
+                                 {Access, AccessCreate, AccessAdmin, AccessPersistent},
+                                 HistorySize, RoomShaper, HttpAuthPool)
+    end,
     set_persistent_rooms_timer(State),
     {ok, State}.
 
@@ -567,15 +537,15 @@ get_registered_room_or_route_error_from_packet(Room, From, To, _Acc, Packet,
                                         host = Host,
                                         access = Access} = State) ->
 
-    case restore_room(Host, Room) of
-        error ->
+    case restore_room(ServerHost, Host, Room) of
+        {error, _} ->
             Lang = exml_query:attr(Packet, <<"xml:lang">>, <<>>),
             ErrText = <<"Conference room does not exist">>,
             Err = jlib:make_error_reply(
                     Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
             ejabberd_router:route(To, From, Err),
             {route_error, ErrText};
-        Opts ->
+        {ok, Opts} ->
             ?DEBUG("MUC: restore room '~s'~n", [Room]),
             #state{history_size = HistorySize,
                    room_shaper = RoomShaper,
@@ -618,16 +588,17 @@ route_by_type(<<"iq">>, {From, To, _Acc, Packet}, #state{host = Host} = State) -
         #iq{type = get, xmlns = ?NS_DISCO_ITEMS} = IQ ->
             spawn(?MODULE, process_iq_disco_items, [Host, From, To, IQ]);
         #iq{type = get, xmlns = ?NS_REGISTER = XMLNS, lang = Lang} = IQ ->
+            Result = iq_get_register_info(ServerHost, Host, From, Lang),
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = [{<<"xmlns">>, XMLNS}],
-                                         children = iq_get_register_info(Host, From, Lang)}]},
+                                         children = Result}]},
             ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{type = set,
             xmlns = ?NS_REGISTER = XMLNS,
             lang = Lang,
             sub_el = SubEl} = IQ ->
-            case process_iq_register_set(Host, From, SubEl, Lang) of
+            case process_iq_register_set(ServerHost, Host, From, SubEl, Lang) of
                 {result, IQRes} ->
                     Res = IQ#iq{type = result,
                                 sub_el = [#xmlel{name = <<"query">>,
@@ -651,9 +622,13 @@ route_by_type(<<"iq">>, {From, To, _Acc, Packet}, #state{host = Host} = State) -
                                         children = [iq_get_unique(From)]}]},
            ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{} ->
+            ?INFO_MSG("issue=ignore_unknown_iq from=~ts to=~ts packet=~1000p",
+                      [jid:to_binary(From), jid:to_binary(To), exml:to_binary(Packet)]),
             Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:feature_not_implemented()),
             ejabberd_router:route(To, From, Err);
         _ ->
+            ?INFO_MSG("issue=failed_to_parse_iq from=~ts to=~ts packet=~1000p",
+                      [jid:to_binary(From), jid:to_binary(To), exml:to_binary(Packet)]),
             ok
     end;
 route_by_type(<<"message">>, {From, To, _Acc, Packet},
@@ -696,10 +671,7 @@ check_user_can_create_room(ServerHost, AccessCreate, From, RoomID) ->
         RoomShaper :: shaper:shaper(), HttpAuthPool :: none | mongoose_http_client:pool()) -> 'ok'.
 load_permanent_rooms(Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuthPool) ->
     RoomsToLoad =
-    case catch mnesia:dirty_select(
-                 muc_room, [{#muc_room{name_host = {'_', Host}, _ = '_'},
-                             [],
-                             ['$_']}]) of
+    case catch mod_muc_db_backend:get_rooms(ServerHost, Host) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p", [Reason]),
             [];
@@ -733,14 +705,14 @@ load_permanent_rooms(Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuth
 start_new_room(Host, ServerHost, Access, Room,
                HistorySize, RoomShaper, HttpAuthPool, From,
                Nick, DefRoomOpts) ->
-    case mnesia:dirty_read(muc_room, {Room, Host}) of
-        [] ->
+    case mod_muc_db_backend:restore_room(ServerHost, Host, Room) of
+        {error, _} ->
             ?DEBUG("MUC: open new room '~s'~n", [Room]),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
                                RoomShaper, HttpAuthPool, From,
                                Nick, DefRoomOpts);
-        [#muc_room{opts = Opts}|_] ->
+        {ok, Opts} ->
             ?DEBUG("MUC: restore room '~s'~n", [Room]),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
@@ -921,21 +893,19 @@ iq_get_unique(From) ->
                                                          randoms:get_string()]))}.
 
 
--spec iq_get_register_info('undefined' | jid:server(),
+-spec iq_get_register_info(jid:server(), jid:server(),
         jid:simple_jid() | jid:jid(), ejabberd:lang())
-            -> [exml:element(), ...].
-iq_get_register_info(Host, From, Lang) ->
-    {LUser, LServer, _} = jid:to_lower(From),
-    LUS = {LUser, LServer},
+            -> [jlib:xmlel(), ...].
+iq_get_register_info(ServerHost, Host, From, Lang) ->
     {Nick, Registered} =
-    case catch mnesia:dirty_read(muc_registered, {LUS, Host}) of
-        {'EXIT', _Reason} ->
-            {<<>>, []};
-        [] ->
-            {<<>>, []};
-        [#muc_registered{nick = N}] ->
-            {N, [#xmlel{name = <<"registered">>}]}
-    end,
+        case catch get_nick(ServerHost, Host, From) of
+            {'EXIT', _Reason} ->
+                {<<>>, []};
+            {error, _} ->
+                {<<>>, []};
+            {ok, N} ->
+                {N, [#xmlel{name = <<"registered">>}]}
+        end,
     ClientReqText = translate:translate(
                       Lang, <<"You need a client that supports x:data to register the nickname">>),
     ClientReqEl = #xmlel{name = <<"instructions">>,
@@ -954,71 +924,66 @@ iq_get_register_info(Host, From, Lang) ->
                         xfield(<<"text-single">>, <<"Nickname">>, <<"nick">>, Nick, Lang)]}].
 
 
--spec iq_set_register_info(jid:server(),
+-spec iq_set_register_info(jid:server(), jid:server(),
         jid:simple_jid() | jid:jid(), nick(), ejabberd:lang())
-            -> {'error', exml:element()} | {'result', []}.
-iq_set_register_info(Host, From, Nick, Lang) ->
-    {LUser, LServer, _} = jid:to_lower(From),
-    LUS = {LUser, LServer},
-    case mnesia:transaction(iq_set_register_info_t(Host, LUS, Nick)) of
-        {atomic, ok} ->
+            -> {'error', jlib:xmlel()} | {'result', []}.
+iq_set_register_info(ServerHost, Host, From, Nick, Lang) ->
+    case set_nick(ServerHost, Host, From, Nick) of
+        ok ->
             {result, []};
-        {atomic, false} ->
+        {error, conflict} ->
             ErrText = <<"That nickname is registered by another person">>,
             {error, mongoose_xmpp_errors:conflict(Lang, ErrText)};
-        _ ->
+        {error, should_not_be_empty} ->
+            ErrText = <<"You must fill in field \"Nickname\" in the form">>,
+            {error, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)};
+        {error, ErrorReason} ->
+            ?ERROR_MSG("issue=iq_set_register_info_failed, "
+                        "jid=~ts, nick=~p, reason=~p",
+                       [jid:to_binary(From), Nick, ErrorReason]),
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
--spec iq_set_register_info_t(Host :: jid:server(), LUS :: jid:simple_bare_jid(),
-                             Nick :: binary()) -> fun(() -> ok | false).
-iq_set_register_info_t(Host, LUS, <<>>) ->
-    fun() ->
-            mnesia:delete({muc_registered, {LUS, Host}}),
-            ok
-    end;
-iq_set_register_info_t(Host, LUS, Nick) ->
-    Allow =
-    case mnesia:select(muc_registered,
-                       [{#muc_registered{us_host = '$1', nick = Nick, _ = '_'},
-                         [{'==', {element, 2, '$1'}, Host}],
-                         ['$_']}]) of
-        [] ->
-            true;
-        [#muc_registered{us_host = {U, _Host}}] ->
-            U == LUS
-    end,
-    case Allow of
-        true ->
-            mnesia:write(#muc_registered{us_host = {LUS, Host}, nick = Nick}),
-            ok;
-        false ->
-            false
+-spec iq_set_unregister_info(jid:server(), jid:server(),
+        jid:simple_jid() | jid:jid(), ejabberd:lang())
+            -> {'error', jlib:xmlel()} | {'result', []}.
+iq_set_unregister_info(ServerHost, Host, From, _Lang) ->
+    case unset_nick(ServerHost, Host, From) of
+        ok ->
+            {result, []};
+        {error, ErrorReason} ->
+            ?ERROR_MSG("issue=iq_set_unregister_info_failed, "
+                        "jid=~ts, reason=~p",
+                       [jid:to_binary(From), ErrorReason]),
+            {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
--spec process_iq_register_set(jid:server(),jid:jid(), exml:element(), ejabberd:lang()) ->
-    {error, exml:element()} | {result, []}.
-process_iq_register_set(Host, From, #xmlel{ children = Els } = SubEl, Lang) ->
+-spec process_iq_register_set(jid:server(), jid:server(),
+                              jid:jid(), jlib:xmlel(), ejabberd:lang())
+            -> {'error', jlib:xmlel()} | {'result', []}.
+process_iq_register_set(ServerHost, Host, From, SubEl, Lang) ->
+    #xmlel{children = Els} = SubEl,
     case xml:get_subtag(SubEl, <<"remove">>) of
         false ->
             case xml:remove_cdata(Els) of
                 [#xmlel{name = <<"x">>} = XEl] ->
                     process_register(xml:get_tag_attr_s(<<"xmlns">>, XEl),
                                      xml:get_tag_attr_s(<<"type">>, XEl),
-                                     Host, From, Lang, XEl);
+                                     ServerHost, Host, From, Lang, XEl);
                 _ ->
                     {error, mongoose_xmpp_errors:bad_request()}
             end;
         _ ->
-            iq_set_register_info(Host, From, <<>>, Lang)
+            iq_set_unregister_info(ServerHost, Host, From, Lang)
     end.
 
--spec process_register(XMLNS :: binary(), Type :: binary(), Host :: jid:server(),
-                       From ::jid:jid(), Lang :: ejabberd:lang(), XEl :: exml:element()) ->
+-spec process_register(XMLNS :: binary(), Type :: binary(),
+                       ServerHost :: jid:server(), Host :: jid:server(),
+                       From :: jid:jid(), Lang :: ejabberd:lang(), XEl :: exml:element()) ->
     {error, exml:element()} | {result, []}.
-process_register(?NS_XDATA, <<"cancel">>, _Host, _From, _Lang, _XEl) ->
+process_register(?NS_XDATA, <<"cancel">>, _ServerHost, _Host, _From, _Lang, _XEl) ->
     {result, []};
-process_register(?NS_XDATA, <<"submit">>, Host, From, Lang, XEl) ->
+process_register(?NS_XDATA, <<"submit">>, ServerHost, Host, From, Lang, XEl) ->
     XData = jlib:parse_xdata_submit(XEl),
     case XData of
         invalid ->
@@ -1026,13 +991,13 @@ process_register(?NS_XDATA, <<"submit">>, Host, From, Lang, XEl) ->
         _ ->
             case lists:keysearch(<<"nick">>, 1, XData) of
                 {value, {_, [Nick]}} when Nick /= <<>> ->
-                    iq_set_register_info(Host, From, Nick, Lang);
+                    iq_set_register_info(ServerHost, Host, From, Nick, Lang);
                 _ ->
                     ErrText = <<"You must fill in field \"Nickname\" in the form">>,
                     {error, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)}
             end
     end;
-process_register(_, _, _Host, _From, _Lang, _XEl) ->
+process_register(_, _, _ServerHost, _Host, _From, _Lang, _XEl) ->
     {error, mongoose_xmpp_errors:bad_request()}.
 
 -spec iq_get_vcard(ejabberd:lang()) -> [exml:element(), ...].

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -294,10 +294,10 @@ init([Host, Opts]) ->
 
     case gen_mod:get_module_opt(Host, mod_muc, load_permanent_rooms_at_startup, false) of
         false ->
-            ?INFO_MSG("issue=load_permanent_rooms_at_startup, skip=true, "
+            ?INFO_MSG("event=load_permanent_rooms_at_startup, skip=true, "
                       "details=\"each room is loaded when someone access the room\"", []);
         true ->
-            ?INFO_MSG("issue=load_permanent_rooms_at_startup, skip=false, "
+            ?INFO_MSG("event=load_permanent_rooms_at_startup, skip=false, "
                       "details=\"it can take some time\"", []),
             load_permanent_rooms(MyHost, Host,
                                  {Access, AccessCreate, AccessAdmin, AccessPersistent},
@@ -622,12 +622,12 @@ route_by_type(<<"iq">>, {From, To, _Acc, Packet}, #state{host = Host} = State) -
                                         children = [iq_get_unique(From)]}]},
            ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{} ->
-            ?INFO_MSG("issue=ignore_unknown_iq from=~ts to=~ts packet=~1000p",
+            ?INFO_MSG("event=ignore_unknown_iq from=~ts to=~ts packet=~1000p",
                       [jid:to_binary(From), jid:to_binary(To), exml:to_binary(Packet)]),
             Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:feature_not_implemented()),
             ejabberd_router:route(To, From, Err);
         _ ->
-            ?INFO_MSG("issue=failed_to_parse_iq from=~ts to=~ts packet=~1000p",
+            ?INFO_MSG("event=failed_to_parse_iq from=~ts to=~ts packet=~1000p",
                       [jid:to_binary(From), jid:to_binary(To), exml:to_binary(Packet)]),
             ok
     end;
@@ -938,7 +938,7 @@ iq_set_register_info(ServerHost, Host, From, Nick, Lang) ->
             ErrText = <<"You must fill in field \"Nickname\" in the form">>,
             {error, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)};
         {error, ErrorReason} ->
-            ?ERROR_MSG("issue=iq_set_register_info_failed, "
+            ?ERROR_MSG("event=iq_set_register_info_failed, "
                         "jid=~ts, nick=~p, reason=~p",
                        [jid:to_binary(From), Nick, ErrorReason]),
             {error, mongoose_xmpp_errors:internal_server_error()}
@@ -952,7 +952,7 @@ iq_set_unregister_info(ServerHost, Host, From, _Lang) ->
         ok ->
             {result, []};
         {error, ErrorReason} ->
-            ?ERROR_MSG("issue=iq_set_unregister_info_failed, "
+            ?ERROR_MSG("event=iq_set_unregister_info_failed, "
                         "jid=~ts, reason=~p",
                        [jid:to_binary(From), ErrorReason]),
             {error, mongoose_xmpp_errors:internal_server_error()}

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -195,7 +195,7 @@ create_instant_room(Host, Name, From, Nick, Opts) ->
 
 
 -spec store_room(jid:server(), jid:server(), room(), list()) ->
-    {'aborted', _} | {'atomic', _}.
+    {error, _} | ok.
 store_room(ServerHost, Host, Name, Opts) ->
     mod_muc_db_backend:store_room(ServerHost, Host, Name, Opts).
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -713,12 +713,13 @@ check_user_can_create_room(ServerHost, AccessCreate, From, RoomID) ->
         RoomShaper :: shaper:shaper(), HttpAuthPool :: none | mongoose_http_client:pool()) -> 'ok'.
 load_permanent_rooms(Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuthPool) ->
     RoomsToLoad =
-    case catch mod_muc_db_backend:get_rooms(ServerHost, Host) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("~p", [Reason]),
-            [];
-        Rs ->
-            Rs
+    case mod_muc_db_backend:get_rooms(ServerHost, Host) of
+        {ok, Rs} ->
+            Rs;
+        {error, Reason} ->
+            ?ERROR_MSG("event=get_rooms_failed event=skip_load_permanent_rooms reason=~p",
+                       [Reason]),
+            []
     end,
     lists:foreach(
       fun(R) ->

--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -38,7 +38,7 @@
 
 %% Register nick
 -callback set_nick(server_host(), muc_host(), client_jid(), mod_muc:nick()) ->
-    ok | {error, conflict} | {error, should_not_be_empty} | {error, term()}.
+    ok | {error, conflict} | {error, term()}.
 
 %% Unregister nick
 %% Unregistered nicks can be used by someone else

--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -20,7 +20,7 @@
 -callback init(server_host(), ModuleOpts :: list()) -> ok.
 
 -callback store_room(server_host(), muc_host(), mod_muc:room(), room_opts()) ->
-    {aborted, _} | {atomic, _}.
+    ok | {error, term()}.
 
 -callback restore_room(server_host(), muc_host(), mod_muc:room()) ->
     {ok, room_opts()} | {error, room_not_found} | {error, term()}.

--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -1,0 +1,46 @@
+-module(mod_muc_db).
+-include("mod_muc.hrl").
+
+%% Defines which ODBC pool to use
+%% Parent host of the MUC service
+-type server_host() :: ejabberd:server().
+
+%% Host of MUC service
+-type muc_host() :: ejabberd:server().
+
+%% User's JID. Can be on another domain accessable over FED.
+%% Only bare part (user@host) is important.
+-type client_jid() :: ejabberd:jid().
+
+-type room_opts() :: [{OptionName :: atom(), OptionValue :: term()}].
+
+
+
+%% Called when MUC service starts or restarts for each domain
+-callback init(server_host(), ModuleOpts :: list()) -> ok.
+
+-callback store_room(server_host(), muc_host(), mod_muc:room(), room_opts()) ->
+    {aborted, _} | {atomic, _}.
+
+-callback restore_room(server_host(), muc_host(), mod_muc:room()) ->
+    {ok, room_opts()} | {error, room_not_found} | {error, term()}.
+
+-callback forget_room(server_host(), muc_host(), mod_muc:room()) -> ok.
+
+-callback can_use_nick(server_host(), muc_host(),
+                       client_jid(), mod_muc:nick()) -> boolean().
+
+-callback get_rooms(server_host(), muc_host()) -> [#muc_room{}].
+
+%% Get nick associated with jid client_jid() across muc_host() domain
+-callback get_nick(server_host(), muc_host(), client_jid()) ->
+    {ok, mod_muc:nick()} | {error, not_registered} | {error, term()}.
+
+%% Register nick
+-callback set_nick(server_host(), muc_host(), client_jid(), mod_muc:nick()) ->
+    ok | {error, conflict} | {error, should_not_be_empty} | {error, term()}.
+
+%% Unregister nick
+%% Unregistered nicks can be used by someone else
+-callback unset_nick(server_host(), muc_host(), client_jid()) ->
+    ok | {error, term()}.

--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -31,7 +31,8 @@
 -callback can_use_nick(server_host(), muc_host(),
                        client_jid(), mod_muc:nick()) -> boolean().
 
--callback get_rooms(server_host(), muc_host()) -> [#muc_room{}].
+-callback get_rooms(server_host(), muc_host()) ->
+    {ok, [#muc_room{}]} | {error, term()}.
 
 %% Get nick associated with jid client_jid() across muc_host() domain
 -callback get_nick(server_host(), muc_host(), client_jid()) ->

--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -25,7 +25,8 @@
 -callback restore_room(server_host(), muc_host(), mod_muc:room()) ->
     {ok, room_opts()} | {error, room_not_found} | {error, term()}.
 
--callback forget_room(server_host(), muc_host(), mod_muc:room()) -> ok.
+-callback forget_room(server_host(), muc_host(), mod_muc:room()) ->
+    ok | {error, term()}.
 
 -callback can_use_nick(server_host(), muc_host(),
                        client_jid(), mod_muc:nick()) -> boolean().

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -140,9 +140,8 @@ get_nick(_ServerHost, MucHost, From) ->
             {error, {Class, Reason}}
     end.
 
-set_nick(_ServerHost, _MucHost, _From, <<>>) ->
-    {error, should_not_be_empty};
-set_nick(_ServerHost, MucHost, From, Nick) ->
+set_nick(_ServerHost, MucHost, From, Nick)
+      when is_binary(Nick), Nick =/= <<>> ->
     LUS = jid:to_lus(From),
     F = fun () ->
             case can_use_nick_internal(MucHost, Nick, LUS) of

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -109,7 +109,7 @@ get_rooms(_Lserver, MucHost) ->
 -spec can_use_nick(ejabberd:server(), ejabberd:server(),
                    ejabberd:jid(), mod_muc:nick()) -> boolean().
 can_use_nick(_ServerHost, MucHost, JID, Nick) ->
-    LUS = jid_to_lower_us(JID),
+    LUS = jid:to_lus(JID),
     can_use_nick_internal(MucHost, Nick, LUS).
 
 can_use_nick_internal(MucHost, Nick, LUS) ->
@@ -128,7 +128,7 @@ can_use_nick_internal(MucHost, Nick, LUS) ->
     end.
 
 get_nick(_ServerHost, MucHost, From) ->
-    LUS = jid_to_lower_us(From),
+    LUS = jid:to_lus(From),
     try mnesia:dirty_read(muc_registered, {LUS, MucHost}) of
         [] ->
             {error, not_registered};
@@ -143,7 +143,7 @@ get_nick(_ServerHost, MucHost, From) ->
 set_nick(_ServerHost, _MucHost, _From, <<>>) ->
     {error, should_not_be_empty};
 set_nick(_ServerHost, MucHost, From, Nick) ->
-    LUS = jid_to_lower_us(From),
+    LUS = jid:to_lus(From),
     F = fun () ->
             case can_use_nick_internal(MucHost, Nick, LUS) of
                 true ->
@@ -164,7 +164,7 @@ set_nick(_ServerHost, MucHost, From, Nick) ->
     end.
 
 unset_nick(_ServerHost, MucHost, From) ->
-    LUS = jid_to_lower_us(From),
+    LUS = jid:to_lus(From),
     F = fun () ->
             mnesia:delete({muc_registered, {LUS, MucHost}})
         end,
@@ -176,7 +176,3 @@ unset_nick(_ServerHost, MucHost, From) ->
                        [jid:to_binary(From), ErrorResult]),
             {error, ErrorResult}
     end.
-
-jid_to_lower_us(JID) ->
-    {LUser, LServer, _} = jid:to_lower(JID),
-    {LUser, LServer}.

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -66,7 +66,7 @@ store_room(_ServerHost, MucHost, RoomName, Opts) ->
         {atomic, _} ->
             ok;
         _ ->
-            ?ERROR_MSG("issue=store_room_failed room=~ts", [RoomName])
+            ?ERROR_MSG("event=store_room_failed room=~ts", [RoomName])
     end,
     Result.
 
@@ -80,7 +80,7 @@ restore_room(_ServerHost, MucHost, RoomName) ->
         Other ->
             {error, Other}
         catch Class:Reason ->
-            ?ERROR_MSG("issue=restore_room_failed room=~ts reason=~p:~p",
+            ?ERROR_MSG("event=restore_room_failed room=~ts reason=~p:~p",
                        [RoomName, Class, Reason]),
             {error, {Class, Reason}}
     end.
@@ -96,7 +96,7 @@ forget_room(_ServerHost, MucHost, RoomName) ->
             ejabberd_hooks:run(forget_room, MucHost, [MucHost, RoomName]),
             ok;
         _ ->
-            ?ERROR_MSG("issue=forget_room_failed room=~ts", [RoomName])
+            ?ERROR_MSG("event=forget_room_failed room=~ts", [RoomName])
     end,
     ok.
 
@@ -122,7 +122,7 @@ can_use_nick_internal(MucHost, Nick, LUS) ->
         [#muc_registered{us_host = {U, _Host}}] ->
             U == LUS
         catch Class:Reason ->
-            ?ERROR_MSG("issue=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
+            ?ERROR_MSG("event=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
                        [jid:to_binary(LUS), Nick, Class, Reason]),
             false
     end.
@@ -135,7 +135,7 @@ get_nick(_ServerHost, MucHost, From) ->
         [#muc_registered{nick = Nick}] ->
             {ok, Nick}
         catch Class:Reason ->
-            ?ERROR_MSG("issue=get_nick_failed jid=~ts reason=~p:~p",
+            ?ERROR_MSG("event=get_nick_failed jid=~ts reason=~p:~p",
                        [jid:to_binary(From), Class, Reason]),
             {error, {Class, Reason}}
     end.
@@ -158,7 +158,7 @@ set_nick(_ServerHost, MucHost, From, Nick) ->
         {atomic, Result} ->
             Result;
         ErrorResult ->
-            ?ERROR_MSG("issue=set_nick_failed jid=~ts nick=~ts reason=~1000p",
+            ?ERROR_MSG("event=set_nick_failed jid=~ts nick=~ts reason=~1000p",
                        [jid:to_binary(From), Nick, ErrorResult]),
             {error, ErrorResult}
     end.
@@ -172,7 +172,7 @@ unset_nick(_ServerHost, MucHost, From) ->
         {atomic, _} ->
             ok;
         ErrorResult ->
-            ?ERROR_MSG("issue=unset_nick_failed jid=~ts reason=~1000p",
+            ?ERROR_MSG("event=unset_nick_failed jid=~ts reason=~1000p",
                        [jid:to_binary(From), ErrorResult]),
             {error, ErrorResult}
     end.

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -1,0 +1,182 @@
+%%%----------------------------------------------------------------------
+%%% Based on file mod_muc.
+%%%
+%%% Original header and copyright notice:
+%%%
+%%% Author  : Alexey Shchepin <alexey@process-one.net>
+%%% Purpose : MUC support (XEP-0045)
+%%%
+%%%
+%%% ejabberd, Copyright (C) 2002-2011   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with this program; if not, write to the Free Software
+%%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+%%% 02111-1307 USA
+%%%
+%%%----------------------------------------------------------------------
+
+-module(mod_muc_db_mnesia).
+-behaviour(mod_muc_db).
+-export([init/2,
+         store_room/4,
+         restore_room/3,
+         forget_room/3,
+         get_rooms/2,
+         can_use_nick/4,
+         get_nick/3,
+         set_nick/4,
+         unset_nick/3]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+-include("mod_muc.hrl").
+
+init(_Host, _Opts) ->
+    mnesia:create_table(muc_room,
+                        [{disc_copies, [node()]},
+                         {attributes, record_info(fields, muc_room)}]),
+    mnesia:create_table(muc_registered,
+                        [{disc_copies, [node()]},
+                         {attributes, record_info(fields, muc_registered)}]),
+    mnesia:add_table_copy(muc_room, node(), disc_copies),
+    mnesia:add_table_copy(muc_registered, node(), disc_copies),
+    mnesia:add_table_index(muc_registered, nick),
+    ok.
+
+-spec store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
+            -> {'aborted', _} | {'atomic', _}.
+store_room(_ServerHost, MucHost, RoomName, Opts) ->
+    F = fun() ->
+                mnesia:write(#muc_room{name_host = {RoomName, MucHost},
+                                       opts = Opts})
+        end,
+    Result = mnesia:transaction(F),
+    case Result of
+        {atomic, _} ->
+            ok;
+        _ ->
+            ?ERROR_MSG("issue=store_room_failed room=~ts", [RoomName])
+    end,
+    Result.
+
+
+restore_room(_ServerHost, MucHost, RoomName) ->
+    try mnesia:dirty_read(muc_room, {RoomName, MucHost}) of
+        [#muc_room{opts = Opts}] ->
+            {ok, Opts};
+        [] ->
+            {error, room_not_found};
+        Other ->
+            {error, Other}
+        catch Class:Reason ->
+            ?ERROR_MSG("issue=restore_room_failed room=~ts reason=~p:~p",
+                       [RoomName, Class, Reason]),
+            {error, {Class, Reason}}
+    end.
+
+-spec forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) -> 'ok'.
+forget_room(_ServerHost, MucHost, RoomName) ->
+    F = fun() ->
+                mnesia:delete({muc_room, {RoomName, MucHost}})
+        end,
+    Result = mnesia:transaction(F),
+    case Result of
+        {atomic, _} ->
+            ejabberd_hooks:run(forget_room, MucHost, [MucHost, RoomName]),
+            ok;
+        _ ->
+            ?ERROR_MSG("issue=forget_room_failed room=~ts", [RoomName])
+    end,
+    ok.
+
+get_rooms(_Lserver, MucHost) ->
+    Query = [{#muc_room{name_host = {'_', MucHost}, _ = '_'},
+             [],
+             ['$_']}],
+    mnesia:dirty_select(muc_room, Query).
+
+-spec can_use_nick(ejabberd:server(), ejabberd:server(),
+                   ejabberd:jid(), mod_muc:nick()) -> boolean().
+can_use_nick(_ServerHost, MucHost, JID, Nick) ->
+    LUS = jid_to_lower_us(JID),
+    can_use_nick_internal(MucHost, Nick, LUS).
+
+can_use_nick_internal(MucHost, Nick, LUS) ->
+    Query = [{#muc_registered{us_host = '$1', nick = Nick, _ = '_'},
+             [{'==', {element, 2, '$1'}, MucHost}],
+             ['$_']}],
+    try mnesia:dirty_select(muc_registered, Query) of
+        [] ->
+            true;
+        [#muc_registered{us_host = {U, _Host}}] ->
+            U == LUS
+        catch Class:Reason ->
+            ?ERROR_MSG("issue=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
+                       [jid:to_binary(LUS), Nick, Class, Reason]),
+            false
+    end.
+
+get_nick(_ServerHost, MucHost, From) ->
+    LUS = jid_to_lower_us(From),
+    try mnesia:dirty_read(muc_registered, {LUS, MucHost}) of
+        [] ->
+            {error, not_registered};
+        [#muc_registered{nick = Nick}] ->
+            {ok, Nick}
+        catch Class:Reason ->
+            ?ERROR_MSG("issue=get_nick_failed jid=~ts reason=~p:~p",
+                       [jid:to_binary(From), Class, Reason]),
+            {error, {Class, Reason}}
+    end.
+
+set_nick(_ServerHost, _MucHost, _From, <<>>) ->
+    {error, should_not_be_empty};
+set_nick(_ServerHost, MucHost, From, Nick) ->
+    LUS = jid_to_lower_us(From),
+    F = fun () ->
+            case can_use_nick_internal(MucHost, Nick, LUS) of
+                true ->
+                    Object = #muc_registered{us_host = {LUS, MucHost}, nick = Nick},
+                    mnesia:write(Object),
+                    ok;
+                false ->
+                    {error, conflict}
+            end
+        end,
+    case mnesia:transaction(F) of
+        {atomic, Result} ->
+            Result;
+        ErrorResult ->
+            ?ERROR_MSG("issue=set_nick_failed jid=~ts nick=~ts reason=~1000p",
+                       [jid:to_binary(From), Nick, ErrorResult]),
+            {error, ErrorResult}
+    end.
+
+unset_nick(_ServerHost, MucHost, From) ->
+    LUS = jid_to_lower_us(From),
+    F = fun () ->
+            mnesia:delete({muc_registered, {LUS, MucHost}})
+        end,
+    case mnesia:transaction(F) of
+        {atomic, _} ->
+            ok;
+        ErrorResult ->
+            ?ERROR_MSG("issue=unset_nick_failed jid=~ts reason=~1000p",
+                       [jid:to_binary(From), ErrorResult]),
+            {error, ErrorResult}
+    end.
+
+jid_to_lower_us(JID) ->
+    {LUser, LServer, _} = jid:to_lower(JID),
+    {LUser, LServer}.

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -79,10 +79,10 @@ restore_room(_ServerHost, MucHost, RoomName) ->
             {error, room_not_found};
         Other ->
             {error, Other}
-        catch Class:Reason ->
-            ?ERROR_MSG("event=restore_room_failed room=~ts reason=~p:~p",
-                       [RoomName, Class, Reason]),
-            {error, {Class, Reason}}
+    catch Class:Reason ->
+        ?ERROR_MSG("event=restore_room_failed room=~ts reason=~p:~p",
+                   [RoomName, Class, Reason]),
+        {error, {Class, Reason}}
     end.
 
 -spec forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) ->
@@ -122,10 +122,10 @@ can_use_nick_internal(MucHost, Nick, LUS) ->
             true;
         [#muc_registered{us_host = {U, _Host}}] ->
             U == LUS
-        catch Class:Reason ->
-            ?ERROR_MSG("event=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
-                       [jid:to_binary(LUS), Nick, Class, Reason]),
-            false
+    catch Class:Reason ->
+        ?ERROR_MSG("event=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
+                   [jid:to_binary(LUS), Nick, Class, Reason]),
+        false
     end.
 
 get_nick(_ServerHost, MucHost, From) ->
@@ -135,10 +135,10 @@ get_nick(_ServerHost, MucHost, From) ->
             {error, not_registered};
         [#muc_registered{nick = Nick}] ->
             {ok, Nick}
-        catch Class:Reason ->
-            ?ERROR_MSG("event=get_nick_failed jid=~ts reason=~p:~p",
-                       [jid:to_binary(From), Class, Reason]),
-            {error, {Class, Reason}}
+    catch Class:Reason ->
+        ?ERROR_MSG("event=get_nick_failed jid=~ts reason=~p:~p",
+                   [jid:to_binary(From), Class, Reason]),
+        {error, {Class, Reason}}
     end.
 
 set_nick(_ServerHost, MucHost, From, Nick)

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -55,7 +55,7 @@ init(_Host, _Opts) ->
     ok.
 
 -spec store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
-            -> {'aborted', _} | {'atomic', _}.
+            -> ok | {error, term()}.
 store_room(_ServerHost, MucHost, RoomName, Opts) ->
     F = fun() ->
                 mnesia:write(#muc_room{name_host = {RoomName, MucHost},
@@ -66,10 +66,10 @@ store_room(_ServerHost, MucHost, RoomName, Opts) ->
         {atomic, _} ->
             ok;
         _ ->
-            ?ERROR_MSG("event=store_room_failed room=~ts", [RoomName])
-    end,
-    Result.
-
+            ?ERROR_MSG("event=store_room_failed room=~ts reason=~p",
+                       [RoomName, Result]),
+            {error, Result}
+    end.
 
 restore_room(_ServerHost, MucHost, RoomName) ->
     try mnesia:dirty_read(muc_room, {RoomName, MucHost}) of

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -105,7 +105,13 @@ get_rooms(_Lserver, MucHost) ->
     Query = [{#muc_room{name_host = {'_', MucHost}, _ = '_'},
              [],
              ['$_']}],
-    mnesia:dirty_select(muc_room, Query).
+    try
+        {ok, mnesia:dirty_select(muc_room, Query)}
+    catch Class:Reason ->
+        ?ERROR_MSG("event=get_rooms_failed reason=~p:~p",
+                   [Class, Reason]),
+        {error, {Class, Reason}}
+    end.
 
 -spec can_use_nick(ejabberd:server(), ejabberd:server(),
                    ejabberd:jid(), mod_muc:nick()) -> boolean().

--- a/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_SUITE.erl
@@ -4515,11 +4515,12 @@ load_already_registered_permanent_rooms(_Config) ->
     HttpAuthPool = none,
 
     %% Write a permanent room
-    {atomic, ok} = escalus_ejabberd:rpc(mod_muc, store_room,
-                                        [domain(), Host, Room, []]),
+    ok = escalus_ejabberd:rpc(mod_muc, store_room,
+                              [domain(), Host, Room, []]),
 
     % Load permanent rooms
-    escalus_ejabberd:rpc(mod_muc, load_permanent_rooms , [Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuthPool]),
+    escalus_ejabberd:rpc(mod_muc, load_permanent_rooms,
+                         [Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuthPool]),
 
     %% Read online room
     RoomJID = escalus_ejabberd:rpc(jid,make,[Room,Host,<<>>]),
@@ -4556,8 +4557,8 @@ check_message_route_to_offline_room(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
         Room = <<"testroom4">>,
         Host = muc_host(),
-        {atomic, ok} = escalus_ejabberd:rpc(mod_muc, store_room,
-                                            [domain(), Host, Room, []]),
+        ok = escalus_ejabberd:rpc(mod_muc, store_room,
+                                  [domain(), Host, Room, []]),
 
         %% Send a message to an offline permanent room
         escalus:send(Alice, stanza_room_subject(Room, <<"Subject line">>)),

--- a/test.disabled/ejabberd_tests/tests/muc_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/muc_helper.erl
@@ -41,8 +41,15 @@ foreach_recipient(Users, VerifyFun) ->
       end, Users).
 
 load_muc(Host) ->
+    Backend = case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
+                  true -> odbc;
+                  false -> mnesia
+              end,
+    %% TODO refactoring. "localhost" should be passed as a parameter
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},
+                          %% XXX TODO Uncomment, when mod_muc_db_odbc is written
+                          %{backend, Backend},
                            {hibernate_timeout, 2000},
                            {hibernated_room_check_interval, 1000},
                            {hibernated_room_timeout, 2000},

--- a/test.disabled/ejabberd_tests/tests/s2s_helper.erl
+++ b/test.disabled/ejabberd_tests/tests/s2s_helper.erl
@@ -1,0 +1,134 @@
+-module(s2s_helper).
+-export([suite/1]).
+-export([init_s2s/2]).
+-export([end_s2s/1]).
+-export([configure_s2s/2]).
+
+-import(distributed_helper, [rpc/4, rpc/5]).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-record(s2s_opts, {
+          node1_s2s_certfile = undefined,
+          node1_s2s_use_starttls = undefined,
+          node2_s2s_certfile = undefined,
+          node2_s2s_use_starttls = undefined
+         }).
+
+
+suite(Config) ->
+    require_s2s_nodes() ++ Config.
+
+require_s2s_nodes() ->
+    [{require, mim_node, {hosts, mim, node}},
+     {require, fed_node, {hosts, fed, node}}].
+
+init_s2s(Config, CoverEnabled) when is_boolean(CoverEnabled) ->
+    Node1S2SCertfile = rpc(mim(), ejabberd_config, get_local_option, [s2s_certfile]),
+    Node1S2SUseStartTLS = rpc(mim(), ejabberd_config, get_local_option, [s2s_use_starttls]),
+    case CoverEnabled of
+        true ->
+            rpc(fed(), mongoose_cover_helper, start, [[ejabberd]]);
+        _ ->
+            ok
+    end,
+    Node2S2SCertfile = rpc(fed(), ejabberd_config, get_local_option, [s2s_certfile]),
+    Node2S2SUseStartTLS = rpc(fed(), ejabberd_config, get_local_option, [s2s_use_starttls]),
+    S2S = #s2s_opts{node1_s2s_certfile = Node1S2SCertfile,
+                    node1_s2s_use_starttls = Node1S2SUseStartTLS,
+                    node2_s2s_certfile = Node2S2SCertfile,
+                    node2_s2s_use_starttls = Node2S2SUseStartTLS},
+
+    [{s2s_opts, S2S},
+     {escalus_user_db, xmpp},
+     {cover_enabled, CoverEnabled} | Config].
+
+end_s2s(Config) ->
+    S2SOrig = ?config(s2s_opts, Config),
+    configure_s2s(S2SOrig),
+    CoverEnabled = ?config(cover_enabled, Config),
+    case CoverEnabled of
+        true ->
+            rpc(fed(), mongoose_cover_helper, analyze, []);
+        _ ->
+            ok
+    end.
+
+configure_s2s(both_plain, Config) ->
+    configure_s2s(#s2s_opts{}),
+    Config;
+configure_s2s(both_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config), %The initial config assumes that both nodes are configured to use encrypted s2s
+    configure_s2s(S2S),
+    Config;
+configure_s2s(both_tls_required, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required,
+                               node2_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_optional_node2_tls_required, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_required_node2_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_required_trusted_node2_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required_trusted}),
+    Config;
+configure_s2s(node1_tls_false_node2_tls_optional, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = false}),
+    Config;
+configure_s2s(node1_tls_optional_node2_tls_false, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = false}),
+    Config;
+configure_s2s(node1_tls_false_node2_tls_required, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = false,
+                               node2_s2s_use_starttls = required}),
+    Config;
+configure_s2s(node1_tls_required_node2_tls_false, Config) ->
+    S2S = ?config(s2s_opts, Config),
+    configure_s2s(S2S#s2s_opts{node1_s2s_use_starttls = required,
+                               node2_s2s_use_starttls = false}),
+    Config.
+
+configure_s2s(#s2s_opts{node1_s2s_certfile = Certfile1,
+                        node1_s2s_use_starttls = StartTLS1,
+                        node2_s2s_certfile = Certfile2,
+                        node2_s2s_use_starttls = StartTLS2}) ->
+    configure_s2s(mim(), Certfile1, StartTLS1),
+    configure_s2s(fed(), Certfile2, StartTLS2),
+    restart_s2s().
+
+configure_s2s(Node, Certfile, StartTLS) ->
+    rpc(Node, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
+    rpc(Node, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
+
+restart_s2s() ->
+    restart_s2s(mim()),
+    restart_s2s(fed()).
+
+restart_s2s(Node) ->
+    Children = rpc(Node, supervisor, which_children, [ejabberd_s2s_out_sup]),
+    [rpc(Node, ejabberd_s2s_out, stop_connection, [Pid]) ||
+     {_, Pid, _, _} <- Children],
+
+    ChildrenIn = rpc(Node, supervisor, which_children, [ejabberd_s2s_in_sup]),
+    [rpc(Node, erlang, exit, [Pid, kill]) ||
+     {_, Pid, _, _} <- ChildrenIn].
+
+mim() ->
+    get_or_fail(mim_node).
+
+fed() ->
+    get_or_fail(fed_node).
+
+get_or_fail(Key) ->
+    Val = ct:get_config(Key),
+    Val == undefined andalso error({undefined, Key}),
+    Val.


### PR DESCRIPTION
It's a **subset** of https://github.com/esl/MongooseIM/pull/1311
Includes mnesia backend
Includes common backend code
Includes registration tests

We want to add odbc backend as a separate PR.
Because we first need to discuss schema.
Maybe we would have two RDBMS backends, one normalized, one denormalized and compare performance.

Add load_permanent_rooms_at_startup option

New result format for some mod_muc functions

Document mod_muc.backend option

Remove mnesia migrations from mod_muc

Replace catch with try..catch

Simplify mod_muc Mnesia code

Subtruct unset_nick from set_nick function

Do not allow to use a nick if DB returns an error

Add MUC registration tests

Test registration over S2S

Move generic s2s code into s2s_helper

Use s2s_helper in muc_SUITE

Disable fed1 cover for MUC-over-S2S tests

Increase timeout for hibernation tests

Add muc_SUITE:can_found_in_db_when_stopped testcase/1
