### PR TITLE
Change Global Distribution loglevels + some new logs

### DIFF
--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -125,17 +125,17 @@ init(RefreshAfter) ->
     {ok, RefreshAfter}.
 
 handle_info(refresh, RefreshAfter) ->
-    ?INFO_MSG("event=refreshing_hosts", []),
+    ?DEBUG("event=refreshing_own_hosts", []),
     refresh_hosts(),
-    ?INFO_MSG("event=refreshing_nodes", []),
+    ?DEBUG("event=refreshing_own_nodes", []),
     refresh_nodes(),
-    ?INFO_MSG("event=refreshing_jids", []),
+    ?DEBUG("event=refreshing_own_jids", []),
     refresh_jids(),
-    ?INFO_MSG("event=refreshing_endpoints", []),
+    ?DEBUG("event=refreshing_own_endpoints", []),
     refresh_endpoints(),
-    ?INFO_MSG("event=refreshing_domains", []),
+    ?DEBUG("event=refreshing_own_domains", []),
     refresh_domains(),
-    ?INFO_MSG("event=refreshing_done,next_refresh_in=~p", [RefreshAfter]),
+    ?DEBUG("event=refreshing_own_data_done,next_refresh_in=~p", [RefreshAfter]),
     erlang:send_after(timer:seconds(RefreshAfter), self(), refresh),
     {noreply, RefreshAfter}.
 

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -289,8 +289,13 @@ refresh_connections(#state{ server = Server, pending_endpoints = PendingEndpoint
 
     FinalPendingEndpoints = PendingEndpoints ++ NPendingEndpoints,
 
-    ?DEBUG("event=endpoints_update_scheduled,server='~s',new_changes=~p,pending_changes=~p",
-           [Server, length(NPendingEndpoints), length(FinalPendingEndpoints)]),
+    case FinalPendingEndpoints of
+        [] ->
+            no_log;
+        _ ->
+            ?DEBUG("event=endpoints_update_scheduled,server='~s',new_changes=~p,pending_changes=~p",
+                   [Server, length(NPendingEndpoints), length(FinalPendingEndpoints)])
+    end,
     State#state{ pending_endpoints = FinalPendingEndpoints }.
 
 -spec get_endpoints(Server :: jid:lserver()) -> {ok, [mod_global_distrib_utils:endpoint()]}.
@@ -317,6 +322,8 @@ resolve_pending([MaybeToEnable | RNewEndpoints], OldEnabled) ->
 
 -spec log_endpoints_changes(Server :: jid:lserver(),
                             EndpointsChanges :: endpoints_changes()) -> any().
+log_endpoints_changes(Server, []) ->
+    ?DEBUG("event=endpoints_changes,server='~s',to_enable='[]',to_disable='[]'", [Server]);
 log_endpoints_changes(Server, EndpointsChanges) ->
     ?INFO_MSG("event=endpoints_changes,server='~s',to_enable='~p',to_disable='~p'",
               [Server, [ E || {enable, E} <- EndpointsChanges ],

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -46,7 +46,7 @@ binary_to_metric_atom(Binary) ->
     list_to_atom(List).
 
 ensure_metric(Metric, Type) ->
-    case catch mongoose_metrics:ensure_metric(global, Metric, Type) of
+    case mongoose_metrics:ensure_metric(global, Metric, Type) of
         ok ->
             Reporters = exometer_report:list_reporters(),
             Interval = mongoose_metrics:get_report_interval(),

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -57,7 +57,7 @@ ensure_metric(Metric, Type) ->
               end,
               Reporters);
         {ok, already_present} ->
-            ?INFO_MSG("issue=metric_already_exists,metric=\"~p\",type=\"~p\"", [Metric, Type]),
+            ?DEBUG("issue=metric_already_exists,metric=\"~p\",type=\"~p\"", [Metric, Type]),
             ok;
         Other ->
             ?WARNING_MSG("issue=cannot_create_metric,metric=\"~p\",type=\"~p\",reason=\"~p\"",

--- a/src/mongoose_metrics.erl
+++ b/src/mongoose_metrics.erl
@@ -81,7 +81,8 @@ init_subscriptions() ->
                 subscribe_to_all(Name, Interval)
         end, Reporters).
 
--spec create_generic_hook_metric(jid:lserver(), atom()) -> ok | {ok, already_present}.
+-spec create_generic_hook_metric(jid:lserver(), atom()) ->
+    ok | {ok, already_present} | {error, any()}.
 create_generic_hook_metric(Host, Hook) ->
     FilteredHookName = filter_hook(Hook),
     do_create_generic_hook_metric(Host, FilteredHookName).
@@ -99,7 +100,8 @@ update(Host, Name, Change) when is_list(Name) ->
 update(Host, Name, Change) ->
     update(Host, [Name], Change).
 
--spec ensure_metric(jid:lserver() | global, atom() | list(), term()) -> ok | {error, term()}.
+-spec ensure_metric(jid:lserver() | global, atom() | list(), term()) ->
+    ok | {ok, already_present} | {error, any()}.
 ensure_metric(Host, Metric, Type) when is_tuple(Type) ->
     ensure_metric(Host, Metric, Type, element(1, Type));
 ensure_metric(Host, Metric, Type) ->
@@ -177,7 +179,7 @@ get_report_interval() ->
                         ?DEFAULT_REPORT_INTERVAL).
 
 -spec do_create_generic_hook_metric(Host :: jid:lserver() | global, Metric :: list()) ->
-    ok | {ok, already_present}.
+    ok | {ok, already_present} | {error, any()}.
 do_create_generic_hook_metric(_, [_, skip]) ->
     ok;
 do_create_generic_hook_metric(Host, Metric) ->
@@ -332,7 +334,7 @@ ensure_metric(Host, Metric, Type, ShortType) when is_list(Metric) ->
             case catch exometer:new(PrefixedMetric, Type) of
                 {'EXIT', {exists, _}} -> {ok, already_present};
                 ok -> ok;
-                Error -> Error
+                {'EXIT', Error} -> {error, Error}
             end
     end.
 

--- a/src/mongoose_metrics.erl
+++ b/src/mongoose_metrics.erl
@@ -328,7 +328,12 @@ ensure_metric(Host, Metric, Type, ShortType) when is_list(Metric) ->
     PrefixedMetric = name_by_all_metrics_are_global(Host, Metric),
     case exometer:info(PrefixedMetric, type) of
         ShortType -> {ok, already_present};
-        undefined -> exometer:new(PrefixedMetric, Type)
+        undefined ->
+            case catch exometer:new(PrefixedMetric, Type) of
+                {'EXIT', {exists, _}} -> {ok, already_present};
+                ok -> ok;
+                Error -> Error
+            end
     end.
 
 -spec metrics_hooks('add' | 'delete', jid:server()) -> 'ok'.


### PR DESCRIPTION
This pull request:
* Changes level of some less important logs to `debug`.
* Fixes the check for existing metric.
* Adds 2 new logs: with resolved endpoints diff (info) and full resolved endpoints list (debug).
* Renames Redis refresher logs, so their content can't be confused with server manager refresh logs.