### PR TITLE
Make packet_to_component GD handler more robust

### DIFF
--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -15,7 +15,12 @@
 {ejabberd_s2s_in_port, 5298}.
 {cowboy_port, 5272}.
 {cowboy_port_secure, 5277}.
-{ejabberd_service, ""}.
+{ejabberd_service, ",{9990, ejabberd_service, [\n"
+                 "                {access, all},\n"
+                 "                {shaper_rule, fast},\n"
+                 "                {ip, {127, 0, 0, 1}},\n"
+                 "                {password, \"secret\"}\n"
+                 "           ]}"}.
 {mod_roster, "{mod_roster, []},"}.
 {http_api_endpoint, "{5389, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -43,15 +43,21 @@ start(Host, Opts0) ->
 stop(Host) ->
     mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
 
--spec get_metadata(mongoose_acc:t(), Key :: term(), Default :: term()) -> Value :: term().
+-spec get_metadata(mongoose_acc:t(), Key :: term(), Default :: term()) ->
+    Value :: term() | {error, missing_gd_structure}.
 get_metadata(Acc, Key, Default) ->
-    GD = mongoose_acc:get(global_distrib, Acc),
-    maps:get(Key, GD, Default).
+    case mongoose_acc:get(global_distrib, Acc, undefined) of
+        undefined -> {error, missing_gd_structure};
+        GD -> maps:get(Key, GD, Default)
+    end.
 
--spec get_metadata(mongoose_acc:t(), Key :: term()) -> Value :: term().
+-spec get_metadata(mongoose_acc:t(), Key :: term()) ->
+    Value :: term() | {error, missing_gd_structure}.
 get_metadata(Acc, Key) ->
-    GD = mongoose_acc:get(global_distrib, Acc),
-    maps:get(Key, GD).
+    case mongoose_acc:get(global_distrib, Acc, undefined) of
+        undefined -> {error, missing_gd_structure};
+        GD -> maps:get(Key, GD)
+    end.
 
 -spec put_metadata(mongoose_acc:t(), Key :: term(), Value :: term()) -> mongoose_acc:t().
 put_metadata(Acc, Key, Value) ->

--- a/src/global_distrib/mod_global_distrib_bounce.erl
+++ b/src/global_distrib/mod_global_distrib_bounce.erl
@@ -87,9 +87,9 @@ terminate(_Reason, _State) ->
 maybe_store_message(drop) -> drop;
 maybe_store_message({From, To, Acc0, Packet} = FPacket) ->
     LocalHost = opt(local_host),
-    {ok, ID} = mod_global_distrib:get_metadata(Acc0, id),
+    {ok, ID} = mod_global_distrib:find_metadata(Acc0, id),
     case mod_global_distrib:get_metadata(Acc0, {bounce_ttl, LocalHost}, opt(max_retries)) of
-        {ok, 0} ->
+        0 ->
             FromBin = jid:to_binary(From),
             ToBin = jid:to_binary(To),
             ?DEBUG("Not storing global message id=~s from=~s to=~s as bounce_ttl=0",
@@ -99,7 +99,7 @@ maybe_store_message({From, To, Acc0, Packet} = FPacket) ->
                           [ID, FromBin, ToBin]),
             mongoose_metrics:update(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, 1),
             FPacket;
-        {ok, OldTTL} ->
+        OldTTL ->
             ?DEBUG("Storing global message id=~s from=~s to=~s to "
                    "resend after ~B ms (bounce_ttl=~B)",
                    [ID, jid:to_binary(From), jid:to_binary(To),

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -205,7 +205,7 @@ maybe_update_mapping(From, Acc) ->
                 {error, missing_gd_structure} ->
                     %% .. so we can insert From into cache with local host as mapping
                     mod_global_distrib_mapping:insert_for_jid(From);
-                Origin ->
+                {ok, Origin} ->
                     mod_global_distrib_mapping:insert_for_jid(From, Origin)
             end;
         _ ->
@@ -224,7 +224,7 @@ ensure_domain_inserted(Acc, Domain) ->
             case mod_global_distrib:get_metadata(Acc, origin) of
                 {error, missing_gd_structure} ->
                     mod_global_distrib_mapping:insert_for_domain(Domain);
-                Origin ->
+                {ok, Origin} ->
                     mod_global_distrib_mapping:insert_for_domain(Domain, Origin)
             end;
         _ ->

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -200,7 +200,7 @@ maybe_update_mapping(#jid{luser = <<>>, lserver = LServer} = From, Acc) ->
 maybe_update_mapping(From, Acc) ->
     case mod_global_distrib_mapping:for_jid(From) of
         error ->
-            case mod_global_distrib:get_metadata(Acc, origin) of
+            case mod_global_distrib:find_metadata(Acc, origin) of
                 %% Lack of 'global_distrib' indicates 100% local routing...
                 {error, missing_gd_structure} ->
                     %% .. so we can insert From into cache with local host as mapping
@@ -221,7 +221,7 @@ ensure_domain_inserted(Acc, Domain) ->
     case mod_global_distrib_mapping:for_domain(Domain) of
         error ->
             %% See the comments in the last match of maybe_update_mapping/2 function
-            case mod_global_distrib:get_metadata(Acc, origin) of
+            case mod_global_distrib:find_metadata(Acc, origin) of
                 {error, missing_gd_structure} ->
                     mod_global_distrib_mapping:insert_for_domain(Domain);
                 {ok, Origin} ->

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -20,7 +20,7 @@
 -include("mongoose.hrl").
 
 %% API
--export([new/0, from_kv/2, put/3, get/2, get/3, append/3, remove/2]).
+-export([new/0, from_kv/2, put/3, get/2, get/3, find/2, append/3, remove/2]).
 -export([add_prop/3, get_prop/2]).
 -export([from_element/1, from_map/1, update_element/4, update/2, is_acc/1, require/2]).
 -export([strip/1, strip/2, record_sending/4, record_sending/6]).
@@ -159,6 +159,15 @@ get(Key, P) ->
 -spec get(any(), t(), any()) -> any().
 get(Key, P, Default) ->
     maps:get(Key, P, Default).
+
+-spec find(any(), t()) -> {ok, any()} | error.
+find(send_result, Acc) ->
+    case maps:find(send_result, Acc) of
+        error -> error;
+        {ok, SRs} -> hd(SRs)
+    end;
+find(Key, P) ->
+    maps:find(Key, P).
 
 -spec append(any(), any(), t()) -> t().
 append(Key, Val, P) ->

--- a/test.disabled/ejabberd_tests/tests/component_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/component_SUITE.erl
@@ -468,8 +468,8 @@ connect_component(ComponentOpts, StartStep) ->
     case Res of
     {ok, Component, _} ->
         {component, ComponentName} = lists:keyfind(component, 1, ComponentOpts),
-        {host, ComponentHost} = lists:keyfind(host, 1, ComponentOpts),
-        ComponentAddr = <<ComponentName/binary, ".", ComponentHost/binary>>,
+        {server, ComponentServer} = lists:keyfind(server, 1, ComponentOpts),
+        ComponentAddr = <<ComponentName/binary, ".", ComponentServer/binary>>,
         {Component, ComponentAddr, ComponentName};
     {error, E} ->
         throw(cook_connection_step_error(E))

--- a/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
@@ -46,6 +46,7 @@ groups() ->
        test_muc_conversation_on_one_host,
        test_component_disconnect,
        test_component_on_one_host,
+       test_components_in_different_regions,
        test_pm_with_disconnection_on_other_server,
        test_pm_with_graceful_reconnection_to_different_server,
        test_pm_with_ungraceful_reconnection_to_different_server,
@@ -370,6 +371,26 @@ test_component_on_one_host(Config) ->
             end,
 
     [escalus:fresh_story(Config, [{User, 1}], Story) || User <- [alice, eve]].
+
+%% Ensures that 2 components in distinct data centers can communicate.
+test_components_in_different_regions(_Config) ->
+    ComponentCommonConfig = [{host, <<"localhost">>}, {password, <<"secret">>},
+                             {server, <<"localhost">>}, {component, <<"test_service">>}],
+    Component1Config = [{port, 8888}, {component, <<"service1">>} | ComponentCommonConfig],
+    Component2Config = [{port, 9990}, {component, <<"service2">>} | ComponentCommonConfig],
+
+    {Comp1, Addr1, _Name1} = component_SUITE:connect_component(Component1Config),
+    {Comp2, Addr2, _Name2} = component_SUITE:connect_component(Component2Config),
+
+    Msg1 = escalus_stanza:from(escalus_stanza:chat_to(Addr2, <<"Hi from 1!">>), Addr1),
+    escalus:send(Comp1, Msg1),
+    GotMsg1 = escalus:wait_for_stanza(Comp2),
+    escalus:assert(is_chat_message, [<<"Hi from 1!">>], GotMsg1),
+
+    Msg2 = escalus_stanza:from(escalus_stanza:chat_to(Addr1, <<"Hi from 2!">>), Addr2),
+    escalus:send(Comp2, Msg2),
+    GotMsg2 = escalus:wait_for_stanza(Comp1),
+    escalus:assert(is_chat_message, [<<"Hi from 2!">>], GotMsg2).
 
 test_component_disconnect(Config) ->
     ComponentConfig = [{server, <<"localhost">>}, {host, <<"localhost">>}, {password, <<"secret">>},
@@ -834,10 +855,9 @@ get_mapping(Node, Client) ->
     What.
 
 delete_mapping(Node, Client) ->
-    {FullJid, BareJid} = jids(Client),
-    redis_query(Node, [<<"DEL">>, FullJid, BareJid]),
+    {FullJid, _BareJid} = jids(Client),
     Jid = rpc(Node, jid, from_binary, [FullJid]),
-    rpc(Node, mod_global_distrib_mapping, clear_cache, [Jid]).
+    rpc(Node, mod_global_distrib_mapping, delete_for_jid, [Jid]).
 
 set_mapping(Node, Client, Mapping) ->
     {FullJid, BareJid} = jids(Client),

--- a/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/mod_global_distrib_SUITE.erl
@@ -854,10 +854,13 @@ get_mapping(Node, Client) ->
     {ok, What} = redis_query(Node, [<<"GET">>, FullJid]),
     What.
 
+%% Warning! May not work properly with alice or any other user whose
+%% stringprepped JID is different than original one
 delete_mapping(Node, Client) ->
-    {FullJid, _BareJid} = jids(Client),
+    {FullJid, BareJid} = jids(Client),
+    redis_query(Node, [<<"DEL">>, FullJid, BareJid]),
     Jid = rpc(Node, jid, from_binary, [FullJid]),
-    rpc(Node, mod_global_distrib_mapping, delete_for_jid, [Jid]).
+    rpc(Node, mod_global_distrib_mapping, clear_cache, [Jid]).
 
 set_mapping(Node, Client, Mapping) ->
     {FullJid, BareJid} = jids(Client),


### PR DESCRIPTION
* `mod_global_distrib:get_metadata/2,3` now may return `{error, missing_gd_structure}` error.
* Fixed ETS creation in `mod_global_distrib_utils` - `{heir, none, testing}` parameter is illegal.
* `maybe_update_mapping/2` won't crash now if `global_distrib` structure is missing in acc.
* New integration test is a byproduct of attempts to reproduce the issue; since it covers a new scenario, I haven't removed it.
* Fixed `component_SUITE:connect_component/2` as it was returning invalid component address.