### PR TITLE
Eradicate relative paths for small tests

### DIFF
--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -63,7 +63,7 @@ end_per_suite(Config) ->
     Config.
 
 init_per_group(public_key, Config) ->
-    Root = filename:join(["..", "..", "..", ".."]),
+    Root = small_path_helper:repo_dir(Config),
     PrivkeyPath = filename:join([Root, "tools", "ssl", "fake_privkey.pem"]),
     PubkeyPath = filename:join([Root, "tools", "ssl", "fake_pubkey.pem"]),
     {ok, PrivKey} = file:read_file(PrivkeyPath),

--- a/test/component_reg_SUITE.erl
+++ b/test/component_reg_SUITE.erl
@@ -3,8 +3,8 @@
 
 -include_lib("exml/include/exml.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("../include/mongoose.hrl").
--include("../include/external_component.hrl").
+-include("mongoose.hrl").
+-include("external_component.hrl").
 
 all() ->
     [ registering, registering_with_local ].

--- a/test/small_path_helper.erl
+++ b/test/small_path_helper.erl
@@ -1,0 +1,30 @@
+%% @doc Common filename functions for Small Tests
+%%
+%% Big tests version is named just path_helper.
+-module(small_path_helper).
+%% Paths
+-export([repo_dir/1]).
+-export([test_dir/1]).
+
+%% @doc Get repository root directory
+repo_dir(_Config) ->
+    %% Full path of present working directory.
+    %% We are using the fact that rebar3 runs from inside the repo root.
+    %% There is one case when it's not true:
+    %% if someone is using MongooseIM as a dependency.
+    %%
+    %% Big tests use a separate env variable here, but for small tests
+    %% we still want "./rebar3 ct" to work without specifying any extra args.
+    get_env_var("PWD").
+
+%% @doc Get `test/' directory
+test_dir(Config) ->
+    filename:join(repo_dir(Config), "test").
+
+get_env_var(VarName) ->
+    case os:getenv(VarName) of
+        false ->
+            ct:fail({undefined_envvar, VarName});
+        Value ->
+            Value
+    end.


### PR DESCRIPTION
Use PWD variable in small_path_helper module
Simplify include statements