### PR TITLE
otp-ish API for starting/stopping modules via gen_mod

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1067,7 +1067,7 @@ fallback_timestamp(Days, {MegaSecs, Secs, _MicroSecs}) ->
 
 start_mod_admin_extra() ->
     Domain = ct:get_config({hosts, mim, domain}),
-    ok = dynamic_modules:restart(Domain, mod_admin_extra, []).
+    {ok, _} = dynamic_modules:restart(Domain, mod_admin_extra, []).
 
 get_user_data(User, Config) when is_atom(User) ->
     get_user_data(escalus_users:get_options(Config, User, <<"newres">>), Config);

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -615,17 +615,17 @@ restart_mod_register_with_option(Config, Name, Value) ->
     Domain = ct:get_config({hosts, mim, domain}),
     ModuleOptions = escalus_ejabberd:rpc(gen_mod, loaded_modules_with_opts, [Domain]),
     {mod_register, OldRegisterOptions} = lists:keyfind(mod_register, 1, ModuleOptions),
-    {atomic, ok} = dynamic_modules:stop(Domain, mod_register),
+    ok = dynamic_modules:stop(Domain, mod_register),
     NewRegisterOptions = lists:keystore(Name, 1, OldRegisterOptions, Value),
-    ok = dynamic_modules:start(Domain, mod_register, NewRegisterOptions),
+    {ok, _} = dynamic_modules:start(Domain, mod_register, NewRegisterOptions),
     [{old_mod_register_opts, OldRegisterOptions}|Config].
 
 restore_mod_register_options(Config0) ->
     Domain = ct:get_config({hosts, mim, domain}),
     {value, {old_mod_register_opts, RegisterOpts}, Config1} =
         lists:keytake(old_mod_register_opts, 1, Config0),
-    {atomic, ok} = dynamic_modules:stop(Domain, mod_register),
-    ok = dynamic_modules:start(Domain, mod_register, RegisterOpts),
+    ok = dynamic_modules:stop(Domain, mod_register),
+    {ok, _} = dynamic_modules:start(Domain, mod_register, RegisterOpts),
     Config1.
 
 user_exists(Name, Config) ->

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -674,10 +674,6 @@ init_modules(BT = riak_timed_yz_buckets, muc_light, Config) ->
     init_modules(BT, generic, [{muc_domain, "muclight.@HOST@"} | Config]);
 init_modules(BT = cassandra, muc_light, config) ->
     init_modules_for_muc_light(BT, config);
-init_modules(BackendType, muc_light, Config) ->
-    Config1 = init_modules_for_muc_light(BackendType, Config),
-    init_module(host(), mod_mam_odbc_user, [muc, pm]),
-    Config1;
 init_modules(cassandra, muc_all, Config) ->
     init_module(host(), mod_mam_muc_cassandra_arch, []),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
@@ -729,6 +725,8 @@ init_modules(odbc_mnesia_muc_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_cache_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
+init_modules(odbc_mnesia_muc_cache, _, _Config) ->
+    skip;
 init_modules(odbc_mnesia_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_odbc_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
@@ -736,6 +734,10 @@ init_modules(odbc_mnesia_cache, muc_all, Config) ->
     init_module(host(), mod_mam_cache_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}, add_archived_element]),
     Config;
+init_modules(BackendType, muc_light, Config) ->
+    Config1 = init_modules_for_muc_light(BackendType, Config),
+    init_module(host(), mod_mam_odbc_user, [muc, pm]),
+    Config1;
 init_modules(odbc, C, Config) ->
     init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm]),
@@ -796,8 +798,6 @@ init_modules(odbc_async_cache, C, Config) ->
     init_module(host(), mod_mam_odbc_user, [pm]),
     init_module(host(), mod_mam_cache_user, [pm]),
     Config;
-init_modules(odbc_mnesia_muc_cache, _, _Config) ->
-    skip;
 init_modules(odbc_mnesia_cache, C, Config) ->
     init_module(host(), mod_mam, [add_archived_element] ++ addin_mam_options(C, Config)),
     init_module(host(), mod_mam_odbc_arch, [pm]),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1093,7 +1093,7 @@ init_module(Host, Mod, Args) ->
     orelse
     ct:fail("Unknown module ~p", [Mod]),
     stop_module(Host, Mod),
-    ok = start_module(Host, Mod, Args).
+    {ok, _} = start_module(Host, Mod, Args).
 
 is_loaded_module(Host, Mod) ->
     rpc_apply(gen_mod, is_loaded, [Host, Mod]).
@@ -1109,8 +1109,7 @@ stop_module(Host, Mod) ->
     end.
 
 just_stop_module(Host, Mod) ->
-    {atomic, ok} = rpc_apply(gen_mod, stop_module, [Host, Mod]),
-    ok.
+    ok = rpc_apply(gen_mod, stop_module, [Host, Mod]).
 
 %%--------------------------------------------------------------------
 %% Group name helpers

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1069,7 +1069,7 @@ restart_receiver(NodeName, NewEndpoints) ->
     OldOpts = rpc(NodeName, gen_mod, get_module_opts,
                   [<<"localhost">>, mod_global_distrib_receiver]),
     NewOpts = lists:keyreplace(endpoints, 1, OldOpts, {endpoints, NewEndpoints}),
-    ok = rpc(NodeName, gen_mod, reload_module,
+    {ok, _} = rpc(NodeName, gen_mod, reload_module,
              [<<"localhost">>, mod_global_distrib_receiver, NewOpts]).
 
 refresh_mappings(NodeName, Config) ->

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -470,9 +470,9 @@ stop_start_command_module(_) ->
     %% described above we test both transition from `started' to
     %% `stopped' and from `stopped' to `started'.
     {?OK, _} = gett(admin, <<"/commands">>),
-    {atomic, ok} = dynamic_modules:stop(host(), mod_commands),
+    ok = dynamic_modules:stop(host(), mod_commands),
     {?NOT_FOUND, _} = gett(admin, <<"/commands">>),
-    ok = dynamic_modules:start(host(), mod_commands, []),
+    {ok, _} = dynamic_modules:start(host(), mod_commands, []),
     timer:sleep(200), %% give the server some time to build the paths again
     {?OK, _} = gett(admin, <<"/commands">>).
 

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -215,7 +215,7 @@ stop_module_keep_config(Host, Module) ->
             ok
     end.
 
--spec reload_module(jid:server(), module(), [any()]) -> 'error' | 'ok'.
+-spec reload_module(jid:server(), module(), [any()]) -> {ok, term()} | {error, already_started}.
 reload_module(Host, Module, Opts) ->
     stop_module_keep_config(Host, Module),
     start_module(Host, Module, Opts).

--- a/test.disabled/ejabberd_tests/tests/gen_mod_SUITE.erl
+++ b/test.disabled/ejabberd_tests/tests/gen_mod_SUITE.erl
@@ -1,0 +1,53 @@
+%%==============================================================================
+%% Copyright 2018 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(gen_mod_SUITE).
+-compile(export_all).
+-author('bartlomiej.gorny@erlang-solutions.com').
+
+-include_lib("common_test/include/ct.hrl").
+
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [start_and_stop].
+
+init_per_suite(Config) ->
+    dynamic_modules:stop(host(a), mod_vcard),
+    dynamic_modules:stop(host(b), mod_vcard),
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+start_and_stop(_Config) ->
+    {ok, _} = escalus_ejabberd:rpc(gen_mod, start_module, [host(a), mod_vcard, []]),
+    {ok, _} = escalus_ejabberd:rpc(gen_mod, start_module, [host(b), mod_vcard, []]),
+    {error, already_started} = escalus_ejabberd:rpc(gen_mod, start_module, [host(a), mod_vcard, []]),
+    {error, already_started} = escalus_ejabberd:rpc(gen_mod, start_module, [host(b), mod_vcard, []]),
+    ok = escalus_ejabberd:rpc(gen_mod, stop_module, [host(a), mod_vcard]),
+    ok = escalus_ejabberd:rpc(gen_mod, stop_module, [host(b), mod_vcard]),
+    {error, not_loaded} = escalus_ejabberd:rpc(gen_mod, stop_module, [host(a), mod_vcard]),
+    {error, not_loaded} = escalus_ejabberd:rpc(gen_mod, stop_module, [host(b), mod_vcard]),
+    ok.
+
+host(a) ->
+    <<"localhost">>;
+host(b) ->
+    <<"localhost.bis">>.


### PR DESCRIPTION
This PR refers to the discussion about improvements to module/service management. Part of the scope was making gen_mod check if a module has already been started (for a host) and if so refuse to start it (same for stopping). After some changes to return values gen_mod behaves now a bit like OTP.
