### PR TITLE
Push notifications refactoring

### DIFF
--- a/big_tests/test
+++ b/big_tests/test
@@ -1,0 +1,94 @@
+-module(push_helper).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+
+-define(NS_XDATA,               <<"jabber:x:data">>).
+
+-export([enable_stanza/2, enable_stanza/3, enable_stanza/4,
+         disable_stanza/1, disable_stanza/2,
+         make_form/1, maybe_form/2]).
+
+-export([become_unavailable/1]).
+-export([wait_for/2]).
+
+-export([ns_push/0, ns_pubsub_pub_options/0, push_form_type/0]).
+
+ns_push() -> <<"urn:xmpp:push:0">>.
+ns_pubsub_pub_options() -> <<"http://jabber.org/protocol/pubsub#publish-options">>.
+push_form_type()-> <<"urn:xmpp:push:summary">>.
+
+
+disable_stanza(JID, undefined) ->
+    disable_stanza([
+        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
+        {<<"jid">>, JID}
+    ]);
+disable_stanza(JID, Node) ->
+    disable_stanza([
+        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
+        {<<"jid">>, JID},
+        {<<"node">>, Node}
+    ]).
+disable_stanza(JID) when is_binary(JID) ->
+    disable_stanza(JID, undefined);
+disable_stanza(Attrs) when is_list(Attrs) ->
+    escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"disable">>, attrs = Attrs}]).
+
+enable_stanza(JID, Node) ->
+    enable_stanza(JID, Node, undefined).
+enable_stanza(JID, Node, FormFields) ->
+    enable_stanza(JID, Node, FormFields, ns_pubsub_pub_options()).
+enable_stanza(JID, Node, FormFields, FormType) ->
+    escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"enable">>, attrs = [
+        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
+        {<<"jid">>, JID},
+        {<<"node">>, Node}
+    ], children = maybe_form(FormFields, FormType)}]).
+
+maybe_form(undefined, _FormType) ->
+    [];
+maybe_form(FormFields, FormType) ->
+    [make_form([{<<"FORM_TYPE">>, FormType} | FormFields])].
+
+make_form(Fields) ->
+    #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"submit">>}],
+           children = [make_form_field(Name, Value) || {Name, Value} <- Fields]}.
+
+make_form_field(Name, Value) ->
+    #xmlel{name = <<"field">>,
+           attrs = [{<<"var">>, Name}],
+           children = [#xmlel{name = <<"value">>, children = [#xmlcdata{content = Value}]}]}.
+
+become_unavailable(Client) ->
+    escalus:send(Client, escalus_stanza:presence(<<"unavailable">>)),
+    true = wait_for(timer:seconds(20), fun() ->
+        is_offline(escalus_utils:jid_to_lower(escalus_client:username(Client)),
+                   escalus_utils:jid_to_lower(escalus_client:server(Client)))
+    end). %% There is no ACK for unavailable status
+
+is_offline(LUser, LServer) ->
+    case catch lists:max(escalus_ejabberd:rpc(ejabberd_sm, get_user_present_pids, [LUser, LServer])) of
+        {Priority, _} when is_integer(Priority), Priority >= 0 ->
+            false;
+        _ ->
+            true
+    end.
+
+wait_for(TimeLeft, Fun) when TimeLeft < 0 ->
+    Fun();
+wait_for(TimeLeft, Fun) ->
+    Step = 500,
+    try
+        case Fun() of
+            ok -> ok;
+            true -> true;
+            {ok, _} = R -> R
+        end
+    catch
+        _:_ ->
+            timer:sleep(Step),
+            wait_for(TimeLeft - Step, Fun)
+    end.
+

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -13,7 +13,6 @@
 
 -define(PUBSUB_SUB_DOMAIN, "push").
 
-
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -158,7 +157,7 @@ publish_fails_with_no_options(Config) ->
             Item =
                 #xmlel{name = <<"notification">>,
                        attrs = [{<<"xmlns">>, ?NS_PUSH}],
-                       children = [make_form(ContentFields)]},
+                       children = [push_helper:make_form(ContentFields)]},
 
             Publish = escalus_pubsub_stanza:publish(Alice, <<"itemid">>, Item, <<"id">>, Node),
             escalus:send(Alice, Publish),
@@ -328,57 +327,14 @@ publish_iq(Client, Node, Content, Options) ->
     Item =
         #xmlel{name = <<"notification">>,
                attrs = [{<<"xmlns">>, ?NS_PUSH}],
-               children = [make_form(ContentFields)]},
+               children = [push_helper:make_form(ContentFields)]},
     OptionsEl =
-        #xmlel{name = <<"publish-options">>, children = [make_form(OptionFileds)]},
+        #xmlel{name = <<"publish-options">>, children = [push_helper:make_form(OptionFileds)]},
 
     Publish = escalus_pubsub_stanza:publish(Client, <<"itemid">>, Item, <<"id">>, Node),
     #xmlel{children = [#xmlel{} = PubsubEl]} = Publish,
     NewPubsubEl = PubsubEl#xmlel{children = PubsubEl#xmlel.children ++ [OptionsEl]},
     Publish#xmlel{children = [NewPubsubEl]}.
-
-disable_stanza(JID, undefined) ->
-    disable_stanza([
-                       {<<"xmlns">>, <<"urn:xmpp:push:0">>},
-                       {<<"jid">>, JID}
-                   ]);
-disable_stanza(JID, Node) ->
-    disable_stanza([
-                       {<<"xmlns">>, <<"urn:xmpp:push:0">>},
-                       {<<"jid">>, JID},
-                       {<<"node">>, Node}
-                   ]).
-disable_stanza(JID) when is_binary(JID) ->
-    disable_stanza(JID, undefined);
-disable_stanza(Attrs) when is_list(Attrs) ->
-    escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"disable">>, attrs = Attrs}]).
-
-enable_stanza(JID, Node) ->
-    enable_stanza(JID, Node, undefined).
-enable_stanza(JID, Node, FormFields) ->
-    enable_stanza(JID, Node, FormFields, ?NS_PUBSUB_PUB_OPTIONS).
-enable_stanza(JID, Node, FormFields, FormType) ->
-    escalus_stanza:iq(<<"set">>, [#xmlel{name = <<"enable">>, attrs = [
-        {<<"xmlns">>, <<"urn:xmpp:push:0">>},
-        {<<"jid">>, JID},
-        {<<"node">>, Node}
-    ], children = maybe_form(FormFields, FormType)}]).
-
-maybe_form(undefined, _FormType) ->
-    [];
-maybe_form(FormFields, FormType) ->
-    [make_form([{<<"FORM_TYPE">>, FormType} | FormFields])].
-
-make_form(Fields) ->
-    #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"submit">>}],
-           children = [make_form_field(Name, Value) || {Name, Value} <- Fields]}.
-
-make_form_field(Name, Value) ->
-    #xmlel{name = <<"field">>,
-           attrs = [{<<"var">>, Name}],
-           children = [#xmlel{name = <<"value">>, children = [#xmlcdata{content = Value}]}]}.
-
-
 
 %% ----------------------------------
 %% Other helpers

--- a/doc/modules/mod_event_pusher_push.md
+++ b/doc/modules/mod_event_pusher_push.md
@@ -29,11 +29,16 @@ callback returns `true`.
 -spec should_publish(From :: ejabberd:jid(), To :: ejabberd:jid(), Packet :: jlib:xmlel()) -> boolean().
 ```
 
-* `sender_id/2` - allows modifying `last-message-sender` field, which ultimately becomes a `title` of the delivered push notification.
+* `publish_notification/5` - does the actual push.
+  By default it pushes to the registered pubsub nodes.
 
 ```
--spec sender_id(From :: ejabberd:jid(), Packet :: jlib:xmlel()) -> SenderId :: binary().
+-spec publish_notification(Acc :: mongooseim_acc:t(), From :: jid:jid(),
+                           To :: jid:jid(), Packet :: exml:element(),
+                           Services :: [mod_event_pusher_push:publish_service()]) -> mongooseim_acc:t().
 ```
+
+
 
 ### Example configuration
 

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -28,7 +28,7 @@
 %% Callbacks
 %%--------------------------------------------------------------------
 
--callback push_event(Host :: jid:lserver(), Event :: event()) -> any().
+-callback push_event(Acc :: mongoose_acc:t(), Host :: jid:lserver(), Event :: event()) -> any().
 
 %%--------------------------------------------------------------------
 %% API
@@ -37,7 +37,7 @@
 %% @doc Pushes the event to each backend registered with the event_pusher.
 -spec push_event(mongoose_acc:t(), Host :: jid:server(), Event :: event()) -> mongoose_acc:t().
 push_event(Acc, Host, Event) ->
-    [B:push_event(Host, Event) || B <- ets:lookup_element(ets_name(Host), backends, 2)],
+    [B:push_event(Acc, Host, Event) || B <- ets:lookup_element(ets_name(Host), backends, 2)],
     Acc.
 
 %%--------------------------------------------------------------------

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -17,7 +17,7 @@
 -include("jlib.hrl").
 
 %% API
--export([start/2, stop/1, push_event/2]).
+-export([start/2, stop/1, push_event/3]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -36,7 +36,7 @@ start(Host, _Opts) ->
 stop(_Host) ->
     ok.
 
-push_event(_, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
+push_event(Acc, _, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
     Mod = get_callback_module(From#jid.lserver),
     case Mod:should_make_req(Packet, From, To) of
@@ -44,9 +44,10 @@ push_event(_, #chat_event{direction = in, from = From, to = To, packet = Packet}
             make_req(From#jid.lserver, From#jid.luser, To#jid.luser, Body);
         _ ->
             ok
-    end;
-push_event(_, _Event) ->
-    ok.
+    end,
+    Acc;
+push_event(Acc, _, _Event) ->
+    Acc.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -30,7 +30,7 @@
 -export([iq_handler/4,
          handle_publish_response/4,
          remove_user/3,
-         push_event/2]).
+         push_event/3]).
 
 %% Types
 -export_type([pubsub_node/0, form_field/0, form/0]).
@@ -97,12 +97,14 @@ stop(Host) ->
 %% Hooks
 %%--------------------------------------------------------------------
 
-push_event(Host, Event = #chat_event{type = chat, direction = in}) ->
-    do_push_event(Host, Event);
-push_event(Host, Event = #chat_event{type = groupchat, direction = out}) ->
-    do_push_event(Host, Event);
-push_event(_, _) ->
-    ok.
+push_event(Acc, Host, Event = #chat_event{type = chat, direction = in}) ->
+    do_push_event(Host, Event),
+    Acc;
+push_event(Acc, Host, Event = #chat_event{type = groupchat, direction = out}) ->
+    do_push_event(Host, Event),
+    Acc;
+push_event(Acc, _, _) ->
+    Acc.
 
 do_push_event(Host, #chat_event{from = From, to = To, packet = Packet}) ->
     %% First condition means that we won't try to push messages without

--- a/src/event_pusher/mod_event_pusher_push_plugin.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin.erl
@@ -17,12 +17,15 @@
 -include("mongoose.hrl").
 
 %% API
--export([should_publish/4, sender_id/3]).
+-export([should_publish/4]).
+-export([publish_notification/5]).
 
 
 -callback should_publish(From :: jid:jid(), To :: jid:jid(), Packet :: exml:element()) ->
     boolean().
--callback sender_id(From :: jid:jid(), Packet :: exml:element()) -> SenderId :: binary().
+-callback publish_notification(Acc :: mongooseim_acc:t(), From :: jid:jid(),
+                               To :: jid:jid(), Packet :: exml:element(),
+                               Services :: [mod_event_pusher_push:publish_service()]) -> mongooseim_acc:t().
 
 %%--------------------------------------------------------------------
 %% API
@@ -34,11 +37,12 @@ should_publish(Host, From, To, Packet) ->
     PluginModule = plugin_module(Host),
     PluginModule:should_publish(From, To, Packet).
 
--spec sender_id(Host :: jid:server(), From :: jid:jid(), Packet :: exml:element()) ->
-    SenderId :: binary().
-sender_id(Host, From, Packet) ->
+-spec publish_notification(Acc :: mongooseim_acc:t(), From :: jid:jid(),
+                           To :: jid:jid(), Packet :: exml:element(),
+                           Services :: [mod_event_pusher_push:publish_service()]) -> mongooseim_acc:t().
+publish_notification(Acc, From, #jid{lserver = Host} = To, Packet, Services) ->
     PluginModule = plugin_module(Host),
-    PluginModule:sender_id(From, Packet).
+    PluginModule:publish_notification(Acc, From, To, Packet, Services).
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/src/event_pusher/mod_event_pusher_sns.erl
+++ b/src/event_pusher/mod_event_pusher_sns.erl
@@ -35,7 +35,7 @@
 -export([start/2, stop/1]).
 
 %% API
--export([try_publish/5, push_event/2]).
+-export([try_publish/5, push_event/3]).
 
 %% Types
 -export_type([user_guid/0, topic_arn/0, topic/0, attributes/0]).
@@ -66,12 +66,14 @@ stop(Host) ->
     wpool:stop(pool_name(Host)),
     ok.
 
-push_event(_, #user_status_event{jid = UserJID, status = Status}) ->
-    user_presence_changed(UserJID, Status == online);
-push_event(_, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
-    handle_packet(From, To, Packet);
-push_event(_, _) ->
-    ok.
+push_event(Acc, _, #user_status_event{jid = UserJID, status = Status}) ->
+    user_presence_changed(UserJID, Status == online),
+    Acc;
+push_event(Acc, _, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
+    handle_packet(From, To, Packet),
+    Acc;
+push_event(Acc, _, _) ->
+    Acc.
 
 %%%===================================================================
 %%% Internal functions

--- a/test/mod_aws_sns_SUITE.erl
+++ b/test/mod_aws_sns_SUITE.erl
@@ -146,17 +146,20 @@ send_packet_callback(Config, Type, Body) ->
     Packet = message(Config, Type, Body),
     Sender = #jid{lserver = Host} = ?config(sender, Config),
     Recipient = ?config(recipient, Config),
-    mod_event_pusher_sns:push_event(Host, #chat_event{type = chat, direction = in,
-                                                      from = Sender, to = Recipient,
-                                                      packet = Packet}).
+    mod_event_pusher_sns:push_event(mongoose_acc:new(), Host,
+                                    #chat_event{type = chat, direction = in,
+                                                from = Sender, to = Recipient,
+                                                packet = Packet}).
 
 user_present_callback(Config) ->
     Jid = #jid{lserver = Host} = ?config(sender, Config),
-    mod_event_pusher_sns:push_event(Host, #user_status_event{jid = Jid, status = online}).
+    mod_event_pusher_sns:push_event(mongoose_acc:new(), Host,
+                                    #user_status_event{jid = Jid, status = online}).
 
 user_not_present_callback(Config) ->
     Jid = #jid{lserver = Host} = ?config(sender, Config),
-    mod_event_pusher_sns:push_event(Host, #user_status_event{jid = Jid, status = offline}).
+    mod_event_pusher_sns:push_event(mongoose_acc:new(), Host,
+                                    #user_status_event{jid = Jid, status = offline}).
 
 %% Helpers
 


### PR DESCRIPTION
The main change is that the final push notification delivery was moved to plugin module. This allows to create a plugin which can push an event to a queue so some backend service may decide what to do next with the push notification.

Additionally following changes were mad:
* Accumulator is passed to mod_event backends
* Push notification tests were refactored - helper module was created


