### PR TITLE
Introduce 'foreground' mode

### DIFF
--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -55,6 +55,11 @@ Alternatively, you can also run the server in the interactive mode:
 $ mongooseimctl live
 ```
 
+For running MongooseIM in a non-interactive way within a supervision system (e.g. systemd) it is
+recommended to use the foreground mode:
+```bash
+$ mongooseimctl foreground
+```
 
 ## Registering a user
 

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -166,10 +166,10 @@ case "$1" in
         # Start the VM
         exec_echo "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE" \
+            -embedded \
             -config "$RUNNER_ETC_DIR/app.config" \
             -args_file "$RUNNER_ETC_DIR/vm.args"  \
             -args_file "$RUNNER_ETC_DIR/vm.dist.args" \
-            -mode embedded \
             -- ${1+"$@"}
         ;;
 

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -216,7 +216,7 @@ case "$1" in
         fi
         ;;
     *)
-        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|live|console|console_clean|attach|debug|version}"
+        echo "Usage: $SCRIPT {start|stop|restart|reboot|ping|live|console|console_clean|foreground|attach|debug|version}"
         exit 1
         ;;
 esac

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -169,7 +169,7 @@ case "$1" in
             -config "$RUNNER_ETC_DIR/app.config" \
             -args_file "$RUNNER_ETC_DIR/vm.args"  \
             -args_file "$RUNNER_ETC_DIR/vm.dist.args" \
-            -mode "embedded" \
+            -mode embedded \
             -- ${1+"$@"}
         ;;
 

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -132,12 +132,19 @@ case "$1" in
         "$ERTS_PATH"/to_erl "$PIPE_DIR"
         ;;
 
-    console|live|console_clean)
+    console|live|console_clean|foreground)
         # .boot file typically just $SCRIPT (ie, the app name)
         # however, for debugging, sometimes start_clean.boot is useful:
+        FOREGROUNDOPTIONS=""
         case "$1" in
             console|live)   BOOTFILE="$SCRIPT" ;;
             console_clean)  BOOTFILE=start_clean ;;
+            foreground)
+                # start up the release in the foreground for use
+                # by supervision services (e.g. systemd, upstart)
+                BOOTFILE="$SCRIPT"
+                FOREGROUNDOPTIONS="-noshell -noinput +Bd"
+                ;;
         esac
         # Setup beam-required vars
         ROOTDIR="$RUNNER_BASE_DIR"
@@ -157,7 +164,13 @@ case "$1" in
         logger -t "$SCRIPT[$$]" "Starting up"
 
         # Start the VM
-        exec_echo "$BINDIR/erlexec" -boot "$RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE" -embedded -config "$RUNNER_ETC_DIR/app.config" -args_file "$RUNNER_ETC_DIR/vm.args" -args_file "$RUNNER_ETC_DIR/vm.dist.args" -- ${1+"$@"}
+        exec_echo "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
+            -boot "$RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE" \
+            -config "$RUNNER_ETC_DIR/app.config" \
+            -args_file "$RUNNER_ETC_DIR/vm.args"  \
+            -args_file "$RUNNER_ETC_DIR/vm.dist.args" \
+            -mode "embedded" \
+            -- ${1+"$@"}
         ;;
 
     debug)

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -108,13 +108,20 @@ live ()
     "$RUNNER_SCRIPT_DIR"/mongooseim console
 }
 
+# start non-interactive server still attached to terminal
+foreground ()
+{
+    "$RUNNER_SCRIPT_DIR"/mongooseim foreground
+}
+
 help ()
 {
     echo ""
     echo "Commands to start a MongooseIM node:"
-    echo "  start  Start a MongooseIM node in server mode"
-    echo "  debug  Attach an interactive Erlang shell to a running MongooseIM node"
-    echo "  live   Start MongooseIM node in live (interactive) mode"
+    echo "  start           Start a MongooseIM node as daemon (detached from terminal)"
+    echo "  debug           Attach an interactive Erlang shell to a running MongooseIM node"
+    echo "  live            Start MongooseIM node in live (interactive) mode"
+    echo "  foreground      Start MongooseIM node in foreground (non-interactive) mode"
     echo "MongooseIM cluster management commands:"
     echo "  join_cluster other_node_name                Add current node to cluster"
     echo "  leave_cluster                               Leave current node from the cluster"
@@ -273,6 +280,7 @@ case $1 in
     'remove_from_cluster') remove_from_cluster;;
     'debug') debug;;
     'live') live;;
+    'foreground') foreground;;
     'started') wait_for_status 0 30 2;; # wait 30x2s before timeout
     'stopped') wait_for_status 3 15 2; stop_epmd;; # wait 15x2s before timeout
     *) ctl $QUOTED_ARGS;;


### PR DESCRIPTION
In rebar the 'foreground' mode is usually used when the erlang app is
running as a daemon within a supervising service such as systemd or
upstart. To work correctly within those services some flags for 'erl'
are necessary so that for example unix pipelines can be used. This
patch introduces the 'foreground' mode as known from rebar which is
very similar to live/console but sets the following additional flags:

    -noshell -noinput +Bd

Those are documented at:

    http://erlang.org/doc/man/erl.html

The very same flags are also used in relx and distillery:

https://github.com/bitwalker/distillery/blob/master/priv/libexec/commands/foreground.sh#L18
https://github.com/erlware/relx/blob/86d415f33c500d432d6c9fa2fcbff3bb2fff3e8f/priv/templates/extended_bin#L623

It should definitely be thought about adjusting the systemd unit file so
that 'foreground' is used instead of 'start'. Otherwise the beam process
is not considered as main PID and when the beam is killed you are not
notified properly via the standard systemd tooling (e.g. 'systemctl
status' returns 0).

EDIT: Aligned the PR desciption according to discussion below.