### PR TITLE
Improve room http api

### DIFF
--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -58,6 +58,7 @@ muc_test_cases() ->
       sending_message_with_wrong_body_results_in_bad_request,
       sending_message_with_no_body_results_in_bad_request,
       sending_message_not_in_JSON_results_in_bad_request,
+      sending_message_by_not_room_member_results_in_forbidden,
       messages_are_archived_in_room,
       only_room_participant_can_read_messages,
       messages_can_be_paginated_in_room,
@@ -297,6 +298,16 @@ invitation_to_room_is_forbidden_for_non_memeber(Config) ->
 msg_is_sent_and_delivered_in_room(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         given_new_room_with_users_and_msgs({alice, Alice}, [{bob, Bob}])
+    end).
+
+
+sending_message_by_not_room_member_results_in_forbidden(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        Sender = {alice, Alice},
+        RoomID = given_new_room_with_users(Sender, []),
+        Result = given_message_sent_to_room(RoomID, {bob, Bob}, #{body => <<"Hello, I'm not member">>}),
+        ?assertMatch({{<<"403">>, <<"Forbidden">>}, _}, Result)
+
     end).
 
 sending_message_with_wrong_body_results_in_bad_request(Config) ->

--- a/doc/rest-api/Client-frontend_swagger.yml
+++ b/doc/rest-api/Client-frontend_swagger.yml
@@ -204,6 +204,8 @@ paths:
           description: Message was sent, ID returned in the body.
           schema:
             $ref: "#/definitions/ResourceID"
+        400:
+          description: When the request body is in wrong format.
         404:
           description: When there is no room with a given ID.
         403:

--- a/src/mongoose_client_api.erl
+++ b/src/mongoose_client_api.erl
@@ -7,6 +7,8 @@
 -export([allowed_methods/2]).
 -export([to_json/2]).
 -export([rest_init/2]).
+-export([bad_request/2]).
+-export([forbidden_request/2]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -51,6 +53,17 @@ options(Req, State) ->
 to_json(Req, User) ->
     {<<"{}">>, Req, User}.
 
+
+bad_request(Req, State) ->
+    reply(400, Req, State).
+
+forbidden_request(Req, State) ->
+    cowboy_req:reply(403, Req),
+    {halt, Req, State}.
+
+reply(StatusCode, Req, State) ->
+    cowboy_req:reply(StatusCode, Req),
+    {halt, Req, State}.
 %%--------------------------------------------------------------------
 %% Authorization
 %%--------------------------------------------------------------------

--- a/src/mongoose_client_api.erl
+++ b/src/mongoose_client_api.erl
@@ -58,8 +58,7 @@ bad_request(Req, State) ->
     reply(400, Req, State).
 
 forbidden_request(Req, State) ->
-    cowboy_req:reply(403, Req),
-    {halt, Req, State}.
+    reply(403, Req, State).
 
 reply(StatusCode, Req, State) ->
     cowboy_req:reply(StatusCode, Req),

--- a/src/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api_rooms.erl
@@ -8,8 +8,6 @@
 -export([allowed_methods/2]).
 -export([resource_exists/2]).
 
--export([forbidden_request/2]).
-
 -export([to_json/2]).
 -export([from_json/2]).
 
@@ -56,7 +54,7 @@ resource_exists(Req, #{jid := #jid{lserver = Server}} = State) ->
                 {ok, RoomID} ->
                     does_room_exist(RoomID, MUCLightDomain, Req2, State);
                 _ ->
-                    bad_request(Req2, State)
+                    mongoose_client_api:bad_request(Req2, State)
             end
     end.
 
@@ -73,14 +71,6 @@ does_room_exist(RoomU, RoomS, Req, #{jid := JID} = State) ->
         _ ->
             {false, Req, NewState}
     end.
-
-forbidden_request(Req, State) ->
-    cowboy_req:reply(403, Req),
-    {halt, Req, State}.
-
-bad_request(Req, State) ->
-    cowboy_req:reply(400, Req),
-    {halt, Req, State}.
 
 to_json(Req, #{room := Room} = State) ->
     Config = maps:get(config, Room),

--- a/src/mongoose_client_api_rooms_messages.erl
+++ b/src/mongoose_client_api_rooms_messages.erl
@@ -73,6 +73,8 @@ to_json(Req, #{jid := UserJID, room := Room} = State) ->
     JSONData = [make_json_item(Msg) || Msg <- Msgs],
     {jiffy:encode(JSONData), Req3, State}.
 
+from_json(Req, #{role_in_room := none} = State) ->
+    mongoose_client_api:forbidden_request(Req, State);
 from_json(Req, #{user := User, jid := JID, room := Room} = State) ->
     {ok, Body, Req2} = cowboy_req:body(Req),
     try

--- a/src/mongoose_client_api_rooms_users.erl
+++ b/src/mongoose_client_api_rooms_users.erl
@@ -51,10 +51,10 @@ from_json(Req, #{user := User,
                                               UserToInvite, <<"member">>),
     {true, Req2, State};
 from_json(Req, State) ->
-    mongoose_client_api_rooms:forbidden_request(Req, State).
+    mongoose_client_api:forbidden_request(Req, State).
 
 delete_resource(Req, #{role_in_room := none} = State) ->
-    mongoose_client_api_rooms:forbidden_request(Req, State);
+    mongoose_client_api:forbidden_request(Req, State);
 delete_resource(Req, #{role_in_room := owner,
                        user := User} = State) ->
     {UserToRemove, Req2} = cowboy_req:binding(user, Req),
@@ -65,7 +65,7 @@ delete_resource(Req, #{user := User} = State) ->
         User ->
             remove_user_from_room(User, User, Req, State);
         _ ->
-            mongoose_client_api_rooms:forbidden_request(Req2, State)
+            mongoose_client_api:forbidden_request(Req2, State)
     end.
 
 remove_user_from_room(Remover, Target, Req,


### PR DESCRIPTION
With this PR MongooseIM will respond with the following error for room's message sending via client's HTTP API
* `400 Bad Request` if the request body is not valid:
    * the body is not JSON
    * or doesn't have `body` element
    * or the `body` element is not string
* `403 Forbidden` if the user sending the message is not member of the room


