### PR TITLE
Fixes to MUC configuration cancellation and form submission handling

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -10,7 +10,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "3da55e4d1d5697b2edd4ed82a6d0d248df67e954"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "115cffb"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -3446,6 +3446,7 @@ cancel_iq_sent_to_locked_room_destroys_it(Config) ->
         Nick = <<"the-owner">>,
 
         PresenceResp = escalus:send_and_wait(Alice, stanza_muc_enter_room(Room, Nick)),
+        escalus:wait_for_stanza(Alice),
         ?assert(is_presence_with_affiliation(PresenceResp, <<"owner">>)),
         ?assert(is_presence_with_role(PresenceResp, <<"moderator">>)),
 
@@ -3461,6 +3462,7 @@ cancel_iq_sent_to_unlocked_room_is_unexpected(Config) ->
         Nick = <<"the-owner">>,
 
         PresenceResp = escalus:send_and_wait(Alice, stanza_muc_enter_room(Room, Nick)),
+        escalus:wait_for_stanza(Alice),
         ?assert(is_presence_with_affiliation(PresenceResp, <<"owner">>)),
         ?assert(is_presence_with_role(PresenceResp, <<"moderator">>)),
 
@@ -3481,6 +3483,7 @@ reserved_room_cant_be_created_before_form_is_fetched(Config) ->
         Nick = <<"the-owner">>,
 
         PresenceResp = escalus:send_and_wait(Alice, stanza_muc_enter_room(Room, Nick)),
+        escalus:wait_for_stanza(Alice),
         ?assert(is_presence_with_affiliation(PresenceResp, <<"owner">>)),
         ?assert(is_presence_with_role(PresenceResp, <<"moderator">>)),
 
@@ -3497,6 +3500,7 @@ room_cant_be_reconfigured_before_form_is_fetched(Config) ->
         Nick = <<"the-owner">>,
 
         PresenceResp = escalus:send_and_wait(Alice, stanza_muc_enter_room(Room, Nick)),
+        escalus:wait_for_stanza(Alice),
         ?assert(is_presence_with_affiliation(PresenceResp, <<"owner">>)),
         ?assert(is_presence_with_role(PresenceResp, <<"moderator">>)),
 


### PR DESCRIPTION

Fix handling of form submits and cancels in MUC rooms

Previously any cancel request sent at any time would trigger room destruction. Additionally, form with non-default values could be submitted without fetching the form first (which is disallowed in the XEP).

The new behaviour is as follows:
* cancel IQs sent when room is in the locked state destroy the room ([link](https://xmpp.org/extensions/xep-0045.html#example-162))
* cancel IQs sent when the room is unlocked, but before fetching the
  form return an error
* cancel IQs sent when the room is unlocked, but after fetching the
  form return an IQ result and don't modify any values in the room ([link](https://xmpp.org/extensions/xep-0045.html#example-166))
* submit IQs without modified values sent when the room is locked
  create an instant room ([link](https://xmpp.org/extensions/xep-0045.html#createroom-instant))
* submit IQs with modified values sent before fetching the form return
  an error
* submit IQs with modified values sent when the room is locked, but
  after fetching the form, create a reserved room ([link](https://xmpp.org/extensions/xep-0045.html#createroom-reserved))
* submit IQs with modififed valued sent when the room is unlocked, but
  after fetching the form, reconfigure the room ([link](https://xmpp.org/extensions/xep-0045.html#roomconfig))

While fixes to cancel IQ handling are necessary and need to be applied (because the rooms were being destroyd unexpectedly), changes made to form submission handling are subject to the discussion. Now, each time a client wants to reconfigure the room, they have to fetch the form first, and only submit it then. This might give significant performance overhead when configuration is changed frequently. On the other hand, these changes make our implementation more in line with the [MUC XEP](https://xmpp.org/extensions/xep-0045.html).

