### PR TITLE
Prevent infinite error loop

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -859,9 +859,9 @@ maybe_open_session(Acc, #state{jid = JID} = StateData) ->
             ?INFO_MSG("(~w) Forbidden session for ~s",
                       [StateData#state.socket,
                        jid:to_binary(JID)]),
-            Err = jlib:make_error_reply(Acc1, mongoose_xmpp_errors:not_allowed()),
-            Acc2 = send_element(Acc1, Err, StateData),
-            {wait, Acc2, StateData}
+            {Acc2, Err} = jlib:make_error_reply(Acc1, mongoose_xmpp_errors:not_allowed()),
+            Acc3 = send_element(Acc2, Err, StateData),
+            {wait, Acc3, StateData}
     end.
 
 -spec do_open_session(mongoose_acc:t(), jid:jid(), state()) ->
@@ -1029,8 +1029,8 @@ process_outgoing_stanza(Acc, error, _Name, StateData) ->
         <<"error">> -> StateData;
         <<"result">> -> StateData;
         _ ->
-            Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:jid_malformed()),
-            send_element(Acc, Err, StateData),
+            {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:jid_malformed()),
+            send_element(Acc1, Err, StateData),
             StateData
     end;
 process_outgoing_stanza(Acc, ToJID, <<"presence">>, StateData) ->
@@ -1360,8 +1360,8 @@ response_iq_deny(_, _, _, Acc) ->
     Acc.
 
 send_back_error(Etype, From, To, Acc) ->
-    Err = jlib:make_error_reply(Acc, Etype),
-    ejabberd_router:route(To, From, Acc, Err).
+    {Acc1, Err} = jlib:make_error_reply(Acc, Etype),
+    ejabberd_router:route(To, From, Acc1, Err).
 
 handle_routed(<<"presence">>, From, To, Acc, StateData) ->
     handle_routed_presence(From, To, Acc, StateData);
@@ -2173,11 +2173,12 @@ check_privacy_and_route(Acc, FromRoute, StateData) ->
     Packet = mongoose_acc:get(element, Acc1),
     case Res of
        deny ->
-           Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:not_acceptable_cancel()),
-           ejabberd_router:route(To, From, Acc1, Err);
+           {Acc2, Err} = jlib:make_error_reply(Acc1, Packet,
+                                               mongoose_xmpp_errors:not_acceptable_cancel()),
+           ejabberd_router:route(To, From, Acc2, Err);
        block ->
-           Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:not_acceptable_blocked()),
-           ejabberd_router:route(To, From, Acc1, Err);
+           {Acc2, Err} = jlib:make_error_reply(Acc1, Packet, mongoose_xmpp_errors:not_acceptable_blocked()),
+           ejabberd_router:route(To, From, Acc2, Err);
        allow ->
            ejabberd_router:route(FromRoute, To, Acc1, Packet)
    end.

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -115,8 +115,8 @@ process_iq(reply, Acc, From, To, El) ->
     IQReply = jlib:iq_query_or_response_info(El),
     process_iq_reply(From, To, Acc, IQReply);
 process_iq(_, Acc, From, To, El) ->
-    Err = jlib:make_error_reply(El, mongoose_xmpp_errors:bad_request()),
-    ejabberd_router:route(To, From, Acc, Err),
+    {Acc1, Err} = jlib:make_error_reply(Acc, El, mongoose_xmpp_errors:bad_request()),
+    ejabberd_router:route(To, From, Acc1, Err),
     ok.
 
 -spec process_iq_reply(From :: jid:jid(),
@@ -233,8 +233,8 @@ refresh_iq_handlers() ->
                              To :: jid:jid(),
                              El :: exml:element()) -> {'stop', mongoose_acc:t()}.
 bounce_resource_packet(Acc, From, To, El) ->
-    Err = jlib:make_error_reply(El, mongoose_xmpp_errors:item_not_found()),
-    ejabberd_router:route(To, From, Err),
+    {Acc1, Err} = jlib:make_error_reply(Acc, El, mongoose_xmpp_errors:item_not_found()),
+    ejabberd_router:route(To, From, Acc1, Err),
     {stop, Acc}.
 
 -spec register_host(Host :: jid:server()) -> ok.

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -124,7 +124,7 @@ route(From, To, Acc) ->
 
 route(From, To, Acc, {error, Reason}) ->
     ?INFO_MSG("event=cannot_route_stanza,from=~p,to=~p,reason=~p,acc=~p", [From, To, Reason, Acc]),
-    ok;
+    mongoose_acc:append(errors, Reason, Acc);
 route(From, To, Acc, El) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
         [From, To, Acc]),

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -122,6 +122,9 @@ route(From, To, Acc) ->
     El = mongoose_acc:get(element, Acc),
     route(From, To, Acc, El, routing_modules_list()).
 
+route(From, To, Acc, stop) ->
+    ?CRITICAL_MSG("event=emergency_stop,from=~p,to=~p,acc=~p", [From, To, Acc]),
+    ok;
 route(From, To, Acc, El) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
         [From, To, Acc]),

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -144,8 +144,8 @@ route_error(From, To, Acc, ErrPacket) ->
 -spec route_error_reply(jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()) ->
     mongoose_acc:t().
 route_error_reply(From, To, Acc, Error) ->
-    ErrorReply = jlib:make_error_reply(Acc, Error),
-    route_error(From, To, Acc, ErrorReply).
+    {Acc1, ErrorReply} = jlib:make_error_reply(Acc, Error),
+    route_error(From, To, Acc1, ErrorReply).
 
 
 -spec register_components([Domain :: domain()],

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -122,8 +122,8 @@ route(From, To, Acc) ->
     El = mongoose_acc:get(element, Acc),
     route(From, To, Acc, El, routing_modules_list()).
 
-route(From, To, Acc, stop) ->
-    ?CRITICAL_MSG("event=emergency_stop,from=~p,to=~p,acc=~p", [From, To, Acc]),
+route(From, To, Acc, {error, Reason}) ->
+    ?INFO_MSG("event=cannot_route_stanza,from=~p,to=~p,reason=~p,acc=~p", [From, To, Reason, Acc]),
     ok;
 route(From, To, Acc, El) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -288,9 +288,9 @@ do_route(From, To, Acc, Packet) ->
                 <<"error">> -> done;
                 <<"result">> -> done;
                 _ ->
-                    Err = jlib:make_error_reply(
-                            Packet, mongoose_xmpp_errors:service_unavailable()),
-                    ejabberd_router:route(To, From, Acc, Err)
+                    {Acc1, Err} = jlib:make_error_reply(
+                            Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
+                    ejabberd_router:route(To, From, Acc1, Err)
             end,
             done
     end.

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -867,8 +867,8 @@ bounce_element(Acc, El, Error) ->
         _ ->
             From = mongoose_acc:get(from_jid, Acc),
             To = mongoose_acc:get(to_jid, Acc),
-            Err = jlib:make_error_reply(El, Error),
-            ejabberd_router:route(To, From, Acc, Err)
+            {Acc1, Err} = jlib:make_error_reply(Acc, El, Error),
+            ejabberd_router:route(To, From, Acc1, Err)
     end.
 
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -249,9 +249,9 @@ bounce_offline_message(Acc, #jid{server = Server} = From, To, Packet) ->
                             Server,
                             Acc,
                             []),
-    Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:service_unavailable()),
-    Acc2 = ejabberd_router:route(To, From, Acc1, Err),
-    {stop, Acc2}.
+    {Acc2, Err} = jlib:make_error_reply(Acc1, Packet, mongoose_xmpp_errors:service_unavailable()),
+    Acc3 = ejabberd_router:route(To, From, Acc2, Err),
+    {stop, Acc3}.
 
 -spec disconnect_removed_user(mongoose_acc:t(), User :: jid:user(),
                               Server :: jid:server()) -> mongoose_acc:t().
@@ -717,8 +717,8 @@ do_route_offline(<<"iq">>, <<"error">>, _From, _To, _Acc, _Packet) ->
 do_route_offline(<<"iq">>, <<"result">>, _From, _To, _Acc, _Packet) ->
     ok;
 do_route_offline(<<"iq">>, _, From, To, Acc, Packet) ->
-    Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:service_unavailable()),
-    ejabberd_router:route(To, From, Acc, Err);
+    {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
+    ejabberd_router:route(To, From, Acc1, Err);
 do_route_offline(_, _, _, _, _, _) ->
     ?DEBUG("packet droped~n", []),
     ok.
@@ -826,9 +826,9 @@ route_message_by_type(_, From, To, Acc, Packet) ->
                     ok
             end;
         _ ->
-            Err = jlib:make_error_reply(
-                Packet, mongoose_xmpp_errors:service_unavailable()),
-            ejabberd_router:route(To, From, Acc, Err)
+            {Acc1, Err} = jlib:make_error_reply(
+                Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
+            ejabberd_router:route(To, From, Acc1, Err)
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -975,15 +975,15 @@ process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
             gen_iq_handler:handle(Host, Module, Function, Opts,
                                   From, To, Acc, IQ);
         [] ->
-            Err = jlib:make_error_reply(
-                    Packet, mongoose_xmpp_errors:service_unavailable()),
-            ejabberd_router:route(To, From, Acc, Err)
+            {Acc1, Err} = jlib:make_error_reply(
+                    Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
+            ejabberd_router:route(To, From, Acc1, Err)
     end;
 process_iq(reply, _From, _To, _Acc, _Packet) ->
     ok;
 process_iq(_, From, To, Acc, Packet) ->
-    Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:bad_request()),
-    ejabberd_router:route(To, From, Acc, Err),
+    {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:bad_request()),
+    ejabberd_router:route(To, From, Acc1, Err),
     ok.
 
 

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -150,8 +150,8 @@ make_error_reply(Acc, Error) ->
 make_error_reply(Acc, Packet, Error) ->
     case mongoose_acc:get(return_type, Acc, undefined) of
         error_reply ->
-            ?CRITICAL_MSG("event=error_routing_loop,stanza=~p", [Packet]),
-            {Acc, stop};
+            ?ERROR_MSG("event=error_reply_to_error,stanza=~p,error=~p", [Packet, Error]),
+            {Acc, {error, {already_an_error, Packet, Error}}};
         _ ->
             {mongoose_acc:put(return_type, error_reply, Acc),
              make_error_reply(Packet, Error)}

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -31,6 +31,7 @@
 -xep([{xep, 86}, {version, "1.0"}]).
 -export([make_result_iq_reply/1,
          make_error_reply/2,
+         make_error_reply/3,
          make_invitation/3,
          make_config_change_message/1,
          make_voice_approval_form/3,
@@ -144,8 +145,10 @@ make_error_reply(#xmlel{name = Name, attrs = Attrs,
     NewAttrs = make_error_reply_attrs(Attrs),
     #xmlel{name = Name, attrs = NewAttrs, children = SubTags ++ [Error]};
 make_error_reply(Acc, Error) ->
-    make_error_reply(mongoose_acc:get(element, Acc), Error).
+    {Acc, make_error_reply(mongoose_acc:get(element, Acc), Error)}.
 
+make_error_reply(Acc, Packet, Error) ->
+    {Acc, make_error_reply(Packet, Error)}.
 
 -spec make_error_reply_attrs([binary_pair()]) -> [binary_pair(), ...].
 make_error_reply_attrs(Attrs) ->

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -145,10 +145,17 @@ make_error_reply(#xmlel{name = Name, attrs = Attrs,
     NewAttrs = make_error_reply_attrs(Attrs),
     #xmlel{name = Name, attrs = NewAttrs, children = SubTags ++ [Error]};
 make_error_reply(Acc, Error) ->
-    {Acc, make_error_reply(mongoose_acc:get(element, Acc), Error)}.
+    make_error_reply(Acc, mongoose_acc:get(element, Acc), Error).
 
 make_error_reply(Acc, Packet, Error) ->
-    {Acc, make_error_reply(Packet, Error)}.
+    case mongoose_acc:get(return_type, Acc, undefined) of
+        error_reply ->
+            ?CRITICAL_MSG("event=error_routing_loop,stanza=~p", [Packet]),
+            {Acc, stop};
+        _ ->
+            {mongoose_acc:put(return_type, error_reply, Acc),
+             make_error_reply(Packet, Error)}
+    end.
 
 -spec make_error_reply_attrs([binary_pair()]) -> [binary_pair(), ...].
 make_error_reply_attrs(Attrs) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -322,10 +322,10 @@ locked_error({route, From, ToNick, Acc, #xmlel{attrs = Attrs} = Packet},
     ?INFO_MSG("Wrong stanza: ~p", [Packet]),
     ErrText = <<"This room is locked">>,
     Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
-    Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
+    {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
     ejabberd_router:route(jid:replace_resource(StateData#state.jid,
                                                ToNick),
-                          From, Acc, Err),
+                          From, Acc1, Err),
     {next_state, NextState, StateData}.
 
 %% @doc  Receive the room-creating Stanza. Will crash if any other stanza is
@@ -4569,16 +4569,16 @@ route_iq(Acc, #routed_iq{iq = IQ = #iq{}, packet = Packet, from = From},
     case mod_muc_iq:process_iq(Host, From, RoomJID, Acc, IQ) of
         ignore -> ok;
         error ->
-            Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:feature_not_implemented()),
-            ejabberd_router:route(RoomJID, From, Acc, Err)
+            {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:feature_not_implemented()),
+            ejabberd_router:route(RoomJID, From, Acc1, Err)
     end,
     {ok, StateData};
 route_iq(_Acc, #routed_iq{iq = reply}, StateData) ->
     {ok, StateData};
 route_iq(Acc, #routed_iq{packet = Packet, from = From}, StateData) ->
-    Err = jlib:make_error_reply(
-        Packet, mongoose_xmpp_errors:feature_not_implemented()),
-    ejabberd_router:route(StateData#state.jid, From, Acc, Err),
+    {Acc1, Err} = jlib:make_error_reply(
+        Acc, Packet, mongoose_xmpp_errors:feature_not_implemented()),
+    ejabberd_router:route(StateData#state.jid, From, Acc1, Err),
     {ok, StateData}.
 
 

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -557,9 +557,9 @@ discard_warn_sender(Acc, Msgs) ->
                           " The message has been discarded.">>,
               Lang = exml_query:attr(Packet, <<"xml:lang">>, <<>>),
               amp_failed_event(Packet, From),
-              Err = jlib:make_error_reply(
-                      Packet, mongoose_xmpp_errors:resource_constraint(Lang, ErrText)),
-              ejabberd_router:route(To, From, Acc, Err)
+              {Acc1, Err} = jlib:make_error_reply(
+                      Acc, Packet, mongoose_xmpp_errors:resource_constraint(Lang, ErrText)),
+              ejabberd_router:route(To, From, Acc1, Err)
       end, Msgs).
 
 fallback_timestamp(Days, {MegaSecs, Secs, _MicroSecs}) ->

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -402,8 +402,8 @@ config_change(Acc, _, _, _) ->
 do_route(_VHost, From, #jid{user = User,
                             resource =Resource} = To, Acc, _IQ)
   when (User /= <<"">>) or (Resource /= <<"">>) ->
-    Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:service_unavailable()),
-    ejabberd_router:route(To, From, Err);
+    {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:service_unavailable()),
+    ejabberd_router:route(To, From, Acc1, Err);
 do_route(VHost, From, To, Acc, #iq{type = set,
                                       xmlns = ?NS_SEARCH,
                                       lang = Lang,
@@ -413,14 +413,14 @@ do_route(VHost, From, To, Acc, #iq{type = set,
     RSMIn = jlib:rsm_decode(IQ),
     case XDataEl of
         false ->
-            Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:bad_request()),
-            ejabberd_router:route(To, From, Err);
+            {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:bad_request()),
+            ejabberd_router:route(To, From, Acc1, Err);
         _ ->
             XData = jlib:parse_xdata_submit(XDataEl),
             case XData of
                 invalid ->
-                    Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:bad_request()),
-                    ejabberd_router:route(To, From, Err);
+                    {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:bad_request()),
+                    ejabberd_router:route(To, From, Acc1, Err);
                 _ ->
                     {SearchResult, RSMOutEls} = search_result(Lang, To, VHost, XData, RSMIn),
                     ResIQ = IQ#iq{
@@ -448,8 +448,8 @@ do_route(VHost, From, To, _Acc, #iq{type = get,
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
 do_route(_VHost, From, To, Acc, #iq{type = set,
                                        xmlns = ?NS_DISCO_INFO}) ->
-    Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:not_allowed()),
-    ejabberd_router:route(To, From, Err);
+    {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:not_allowed()),
+    ejabberd_router:route(To, From, Acc1, Err);
 do_route(VHost, From, To, _Acc, #iq{type = get,
                                        xmlns = ?NS_DISCO_INFO,
                                        lang = Lang} = IQ) ->
@@ -473,8 +473,8 @@ do_route(VHost, From, To, _Acc, #iq{type = get,
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
 do_route(_VHost, From, To, Acc, #iq{type=set,
                                        xmlns = ?NS_DISCO_ITEMS}) ->
-    Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:not_allowed()),
-    ejabberd_router:route(To, From, Err);
+    {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:not_allowed()),
+    ejabberd_router:route(To, From, Acc1, Err);
 do_route(_VHost, From, To, _Acc, #iq{ type = get,
                                          xmlns = ?NS_DISCO_ITEMS} = IQ) ->
     ResIQ =
@@ -492,8 +492,8 @@ do_route(_VHost, From, To, _Acc, #iq{ type = get,
                                children = iq_get_vcard(Lang)}]},
     ejabberd_router:route(To, From, jlib:iq_to_xml(ResIQ));
 do_route(_VHost, From, To, Acc, _IQ) ->
-    Err = jlib:make_error_reply(Acc, mongoose_xmpp_errors:service_unavailable()),
-    ejabberd_router:route(To, From, Err).
+    {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:service_unavailable()),
+    ejabberd_router:route(To, From, Acc1, Err).
 
 iq_get_vcard(_Lang) ->
     [#xmlel{name = <<"FN">>,

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -21,6 +21,7 @@
 
 %% API
 -export([new/0, from_kv/2, put/3, get/2, get/3, find/2, append/3, remove/2]).
+-export([increment/2, get_counter/2]).
 -export([add_prop/3, get_prop/2]).
 -export([from_element/1, from_map/1, update_element/4, update/2, is_acc/1, require/2]).
 -export([strip/1, strip/2, record_sending/4, record_sending/6]).
@@ -159,6 +160,19 @@ get(Key, P) ->
 -spec get(any(), t(), any()) -> any().
 get(Key, P, Default) ->
     maps:get(Key, P, Default).
+
+%% @doc increments a counter, returns new value
+%% counters are tagged so as not to interfere with other values
+-spec increment(atom(), t()) -> {integer(), t()}.
+increment(Key, Acc) ->
+    CKey = {counter, Key},
+    NVal = get(CKey, Acc, 0) + 1,
+    {NVal, put(CKey, NVal, Acc)}.
+
+%% @doc returns current value of a counter
+-spec get_counter(atom(), t()) -> integer().
+get_counter(Key, Acc) ->
+    get({counter, Key}, Acc, 0).
 
 -spec find(any(), t()) -> {ok, any()} | error.
 find(send_result, Acc) ->

--- a/src/mongoose_subhosts.erl
+++ b/src/mongoose_subhosts.erl
@@ -57,7 +57,7 @@ register(Host, SubHost) ->
 -spec 'unregister'(SubHost :: jid:server()) -> true.
 unregister(SubHost) ->
     case get_host(SubHost) of
-        {ok, Host} -> ejabberd_hooks:run(unregister_subhost, [SubHost]);
+        {ok, _Host} -> ejabberd_hooks:run(unregister_subhost, [SubHost]);
         _ -> ok
     end,
     ets:delete(?TAB, SubHost).

--- a/test/jlib_SUITE.erl
+++ b/test/jlib_SUITE.erl
@@ -12,7 +12,8 @@ all() -> [
           make_iq_reply_changes_type_to_result,
           make_iq_reply_changes_to_to_from,
           make_iq_reply_switches_from_to_to,
-          make_iq_reply_switches_to_and_from_attrs
+          make_iq_reply_switches_to_and_from_attrs,
+          error_reply_check
          ].
 
 init_per_suite(C) ->
@@ -60,6 +61,18 @@ make_iq_reply_changes_to_to_from(_C) ->
 make_iq_reply_changes_type_to_result(_) ->
     BaseIQReply = jlib:make_result_iq_reply(base_iq()),
     <<"result">> = exml_query:attr(BaseIQReply, <<"type">>).
+
+error_reply_check(_) ->
+    BaseIQReply = jlib:make_result_iq_reply(base_iq()),
+    Acc = mongoose_acc:from_element(BaseIQReply),
+    {Acc1, ErrorReply1} = jlib:make_error_reply(Acc, BaseIQReply, #xmlel{name = <<"testerror">>}),
+    ?assertMatch(#xmlel{}, ErrorReply1),
+    {_Acc2, ErrorReply2} = jlib:make_error_reply(Acc1, ErrorReply1, #xmlel{name = <<"testerror">>}),
+    ?assertMatch({error, {already_an_error, #xmlel{}, #xmlel{}}}, ErrorReply2),
+    ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 
 base_iq() ->
     #xmlel{name = <<"iq">>,


### PR DESCRIPTION
This PR provides a safety measure to prevent infinite error looping. The loop starts when routing an error message triggers an error and mongooseim tries to route error message in response to that, and so on. In this PR we use accumulator to store a flag saying that we are routing error message, and if it loops back we do not route it.
