### PR TITLE
Allow to enable preset on just some nodes

### DIFF
--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -223,8 +223,8 @@ maybe_enable_preset_on_node(Node, PresetVars, HostVars, HostName) ->
 is_test_host_enabled(HostName) ->
     case os:getenv("TEST_HOSTS") of
         false ->
-            true;
-        EnvValue ->
+            true; %% By default all hosts are enabled
+        EnvValue -> %% EnvValue examples are "mim" or "mim mim2"
             BinHosts = binary:split(iolist_to_binary(EnvValue), <<" ">>, [global]),
             lists:member(atom_to_binary(HostName, utf8), BinHosts)
     end.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -16,6 +16,7 @@
 %% TODO: introduce host option verification ASAP,
 %%       so that we rein the "bag of things" approach
 {hosts, [{mim,  [{node, mongooseim@localhost},
+                 {relname, mim1},
                  {domain, <<"localhost">>},
                  {vars, "mim1.vars.config"},
                  {cluster, mim},
@@ -24,20 +25,24 @@
                  {metrics_rest_port, 5288},
                  {metrics_rest_port2, 5289}]},
          {mim2, [{node, ejabberd2@localhost},
+                 {relname, mim2},
                  {domain, <<"localhost">>},
                  {vars, "mim2.vars.config"},
                  {cluster, mim}]},
          {mim3, [{node, mongooseim3@localhost},
+                 {relname, mim3},
                  {domain, <<"localhost">>},
                  {vars, "mim3.vars.config"},
                  {cluster, mim}]},
          %% used to test s2s features
          {fed,  [{node, fed1@localhost},
+                 {relname, fed1},
                  {domain, <<"fed1">>},
                  {vars, "fed1.vars.config"},
                  {cluster, fed}]},
          %% used to test global distribution features
          {reg,  [{node, reg1@localhost},
+                 {relname, reg1},
                  {domain, <<"reg1">>},
                  {vars, "reg1.vars.config"},
                  {cluster, reg}]}

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -16,7 +16,6 @@
 %% TODO: introduce host option verification ASAP,
 %%       so that we rein the "bag of things" approach
 {hosts, [{mim,  [{node, mongooseim@localhost},
-                 {relname, mim1},
                  {domain, <<"localhost">>},
                  {vars, "mim1.vars.config"},
                  {cluster, mim},
@@ -25,24 +24,20 @@
                  {metrics_rest_port, 5288},
                  {metrics_rest_port2, 5289}]},
          {mim2, [{node, ejabberd2@localhost},
-                 {relname, mim2},
                  {domain, <<"localhost">>},
                  {vars, "mim2.vars.config"},
                  {cluster, mim}]},
          {mim3, [{node, mongooseim3@localhost},
-                 {relname, mim3},
                  {domain, <<"localhost">>},
                  {vars, "mim3.vars.config"},
                  {cluster, mim}]},
          %% used to test s2s features
          {fed,  [{node, fed1@localhost},
-                 {relname, fed1},
                  {domain, <<"fed1">>},
                  {vars, "fed1.vars.config"},
                  {cluster, fed}]},
          %% used to test global distribution features
          {reg,  [{node, reg1@localhost},
-                 {relname, reg1},
                  {domain, <<"reg1">>},
                  {vars, "reg1.vars.config"},
                  {cluster, reg}]}


### PR DESCRIPTION
Allows to start just some nodes for tests:

```erlang
./tools/configure with-all
DB=mysql ./tools/travis-setup-db.sh
make mim1
%% just run with one node
%% be aware, that tests, that need other nodes would fail :(
%% but I usually test with modified test spec file, that does not have all the tests enabled.
TEST_HOSTS="mim" DEV_NODES="mim1" ./tools/travis-test.sh -c false -s false -e false -p mysql_mnesia
```

or

```erlang
TEST_HOSTS="mim fed" DEV_NODES="mim1 fed1" ./tools/travis-test.sh -c false -s false -e false -p mysql_mnesia
```

Without this PR we need to run all nodes to run a test.