### PR TITLE
Ignore stanzas addressed to an old c2s process

### DIFF
--- a/big_tests/tests/privacy_SUITE.erl
+++ b/big_tests/tests/privacy_SUITE.erl
@@ -106,6 +106,18 @@ init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
 end_per_testcase(CaseName, Config) ->
+    %% Two reasons for it to be here.
+    %%
+    %% Reason 1.
+    %% After case set_list, alice@localhost/res1 presence unavailable
+    %% is sometimes received in activate, but not expected.
+    %% The proper handling on the server side is done after introducing
+    %% ejabberd_c2s:process_incoming_stanza_with_conflict_check.
+    %%
+    %% Reason 2.
+    %% More than 2 users. One user receives a precence of another one.
+    %% It can be presence available or unavailable.
+    mongoose_helper:kick_everyone(),
     escalus:end_per_testcase(CaseName, Config).
 
 %%--------------------------------------------------------------------

--- a/doc/developers-guide/accumulators.md
+++ b/doc/developers-guide/accumulators.md
@@ -13,6 +13,9 @@ At the beginning of the main processing chain an accumulator is created containi
 * attrs - attributs of the root xml element of the stanza
 * from, to - full jids of the sender and recipient in binary form
 * from_jid, to_jid - same as #jid{} records.
+* sender_sid - session id (SID) of `ejabberd_c2s`. Set when we receive a stanza
+  from the user device. *property*, *optional*.
+* sender_jid - full sender JID. Set the same time as `sender_sid`. *property*, *optional*.
 
 It is then passed through all the stages until it reaches the end of its life.
 Throughout the process it is the very same accumulator; it is therefore possible to store a value in it on one stage of the processing and retrieve the same value later on.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -455,7 +455,7 @@ wait_for_auth({xmlstreamelement,
                #xmlel{name = <<"enable">>} = El}, StateData) ->
     maybe_unexpected_sm_request(wait_for_auth, El, StateData);
 wait_for_auth({xmlstreamelement, El}, StateData) ->
-    Acc0 = mongoose_acc:from_element(El),
+    Acc0 = from_sender_element(El, StateData),
     User = StateData#state.user,
     Server = StateData#state.server,
     Acc = mongoose_acc:update(Acc0, #{user => User, server => Server}),
@@ -777,7 +777,7 @@ wait_for_session_or_sm({xmlstreamelement, El}, StateData0) ->
                                             StateData0),
     case jlib:iq_query_info(El) of
         #iq{type = set, xmlns = ?NS_SESSION} ->
-            Acc0 = mongoose_acc:from_element(El),
+            Acc0 = from_sender_element(El, StateData0),
             User = StateData#state.user,
             Server = StateData#state.server,
             Acc = mongoose_acc:update(Acc0, #{user => User, server => Server}),
@@ -965,7 +965,7 @@ session_established({xmlstreamelement, El}, StateData) ->
                                                    StateData),
             % initialise accumulator, fill with data
             El1 = fix_message_from_user(El, StateData#state.lang),
-            Acc0 = mongoose_acc:from_element(El1),
+            Acc0 = from_sender_element(El1, StateData),
             User = NewState#state.user,
             Server = NewState#state.server,
             To = exml_query:attr(El, <<"to">>),
@@ -1218,7 +1218,7 @@ handle_info({force_update_presence, LUser}, StateName,
                            StateData#state.pres_last,
                            [LUser, LServer]),
             StateData2 = StateData#state{pres_last = PresenceEl},
-            Acc = mongoose_acc:from_element(PresenceEl),
+            Acc = from_sender_element(PresenceEl, StateData),
             presence_update(Acc, StateData2#state.jid, StateData2),
             StateData2;
         _ ->
@@ -1246,7 +1246,7 @@ handle_info({store_session_info, User, Server, Resource, KV, _FromPid}, StateNam
 handle_info(Info, StateName, StateData) ->
     handle_incoming_message(Info, StateName, StateData).
 
-%%% incoming messages
+%%% incoming messages from other users or services to this device
 handle_incoming_message({send_text, Text}, StateName, StateData) ->
     % it seems to be sometimes, by event sent from s2s
     send_text(StateData, Text),
@@ -1271,7 +1271,7 @@ handle_incoming_message({route, From, To, Acc0}, StateName, StateData) ->
     Acc = setup_accum(Acc0, StateData),
     Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [{route, From, To}]),
     Name = mongoose_acc:get(name, Acc1),
-    process_incoming_stanza(Name, From, To, Acc1, StateName, StateData);
+    process_incoming_stanza_with_conflict_check(Name, From, To, Acc1, StateName, StateData);
 handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
     % this is used by pubsub and should be rewritten when someone rewrites pubsub module
     Acc0 = mongoose_acc:new(),
@@ -1311,6 +1311,35 @@ handle_incoming_message(Info, StateName, StateData) ->
     ?ERROR_MSG("Unexpected info: ~p", [Info]),
     fsm_next_state(StateName, StateData).
 
+process_incoming_stanza_with_conflict_check(Name, From, To, Acc, StateName, StateData) ->
+    case is_old_session_conflict(Acc, StateData) of
+        false ->
+            process_incoming_stanza(Name, From, To, Acc, StateName, StateData);
+        true -> %% A race condition detected
+            %% Same jid, but different sids
+            SenderSID = mongoose_acc:get_prop(sender_sid, Acc),
+            ?ERROR_MSG("event=conflict_check_failed "
+                        "jid=~ts c2s_sid=~p sender_sid=~p acc=~1000p",
+                       [jid:to_binary(StateData#state.jid), StateData#state.sid,
+                        SenderSID, Acc]),
+            finish_state(ok, StateName, StateData)
+    end.
+
+%% If jid is the same, but sid is not.
+%% jid example is alice@localhost/res1.
+%% sid example is `{now(), pid()}'.
+%% The conflict can happen, when actions with an accumulator were initiated by
+%% one process but the resulting stanzas were routed to another process with
+%% the same JID but different SID.
+%% The conflict is usually happens when an user is reconnecting.
+-spec is_old_session_conflict(mongoose_acc:t(), state()) -> boolean().
+is_old_session_conflict(Acc, #state{sid = SID, jid = JID}) ->
+    SenderSID = mongoose_acc:get_prop(sender_sid, Acc),
+    SenderJID = mongoose_acc:get_prop(sender_jid, Acc),
+    (SenderJID =:= JID)
+    andalso (SenderSID =/= undefined)
+    andalso (SenderSID =/= SID).
+
 process_incoming_stanza(Name, From, To, Acc, StateName, StateData) ->
     Packet = mongoose_acc:get(element, Acc),
     {Act, _NextAcc, NextState} = case handle_routed(Name, From, To, Acc, StateData) of
@@ -1323,6 +1352,7 @@ process_incoming_stanza(Name, From, To, Acc, StateName, StateData) ->
                                          {ok, NewAcc, NewState}
                                  end,
     finish_state(Act, StateName, NextState).
+
 
 -spec preprocess_and_ship(Acc :: mongoose_acc:t(),
                           From :: jid:jid(),
@@ -1597,7 +1627,7 @@ terminate(_Reason, StateName, StateData) ->
             Packet = #xmlel{name = <<"presence">>,
                             attrs = [{<<"type">>, <<"unavailable">>}],
                             children = [StatusEl]},
-            Acc0 = mongoose_acc:from_element(Packet),
+            Acc0 = from_sender_element(Packet, StateData),
             Acc = mongoose_acc:put(from_jid, From, Acc0),
             ejabberd_sm:close_session_unset_presence(
               StateData#state.sid,
@@ -1634,7 +1664,7 @@ terminate(_Reason, StateName, StateData) ->
                     From = StateData#state.jid,
                     Packet = #xmlel{name = <<"presence">>,
                                     attrs = [{<<"type">>, <<"unavailable">>}]},
-                    Acc0 = mongoose_acc:from_element(Packet),
+                    Acc0 = from_sender_element(Packet, StateData),
                     Acc = mongoose_acc:put(from_jid, From, Acc0),
                     ejabberd_sm:close_session_unset_presence(
                       StateData#state.sid,
@@ -3350,3 +3380,9 @@ setup_accum(Acc, StateData) ->
     Server = StateData#state.server,
     mongoose_acc:update(Acc, #{server => Server, user => User}).
 
+%% @doc This function is executed when c2s receives a stanza from TCP connection.
+-spec from_sender_element(jlib:xmlel(), StateData :: state()) -> mongoose_acc:t().
+from_sender_element(El, #state{sid = SID, jid = JID}) ->
+    Acc = mongoose_acc:from_element(El),
+    Acc1 = mongoose_acc:add_prop(sender_sid, SID, Acc),
+    mongoose_acc:add_prop(sender_jid, JID, Acc1).


### PR DESCRIPTION
This PR addresses build issues.

Proposed changes include:
* Introduce ejabberd_c2s:process_incoming_stanza_with_conflict_check.
* Fix a race-condition in privacy_SUITE tests.
* New accumulator props sender_sid and sender_jid.

```erlang
13:13:57.921 [error] event=conflict_check_failed jid=alicE@localhost/res1 
c2s_sid={{1523,704437,851989},<0.2078.0>} sender_sid={{1523,704437,409824},<0.2074.0>} 
acc=#{attrs => [{<<"from_sender_element">>,<<"1">>},{<<"type">>,<<"unavailable">>}],
element => {xmlel,<<"presence">>,[{<<"from_sender_element">>,<<"1">>},{<<"type">>,<<"unavailable">>}],[]},from => <<"alicE@localhost/res1">>,
from_jid => {jid,<<"alicE">>,<<"localhost">>,<<"res1">>,<<"alice">>,<<"localhost">>,<<"res1">>},mongoose_acc => true,name => <<"presence">>,persistent_properties => [{sender_jid,{jid,<<"alicE">>,<<"localhost">>,<<"res1">>,<<"alice">>,<<"localhost">>,<<"res1">>}},{sender_sid,{{1523,704437,409824},<0.2074.0>}}],
ref => #Ref<0.2819752192.2344615938.90969>,server => <<"localhost">>,timestamp => {1523,704437,818568},type => <<"unavailable">>,user => <<"alicE">>}
```

We often use non-fresh users in our tests.
Sometimes, we have two stories one after another.
In such cases, connections from a test earlier can interfere into work of the next test.
Usually, by sending presence unavailable or by replying on presence probe.

This test fixes sending presence unavailable to the same client.

Example, when the bug is happening:

```erlang                                                                  
activate(Config) ->                                                                  
    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->                 
                                                                                     
        privacy_helper:set_list(Alice, {<<"deny_client">>, Bob}),                    
                                                                                     
        Request = escalus_stanza:privacy_activate(<<"deny_client">>),                
        escalus_client:send(Alice, Request),                                         
                                                                                     
        Response = escalus_client:wait_for_stanza(Alice),                            
        escalus:assert(is_iq_result, Response)                                       
                                                                                     
        end).                                                                        
                                                                                     
activate_nonexistent(Config) ->                                                      
    escalus:story(Config, [{alice, 1}], fun(Alice) ->                                
                                                                                     
        Request = escalus_stanza:privacy_activate(<<"some_list">>),                  
        escalus_client:send(Alice, Request),                                         
                                                                                     
        Response = escalus_client:wait_for_stanza(Alice),                            
        escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Response)     
                                                                                     
        end). 
```

There is also another type of bug, when your roster contact replies on your presence.
This can't be fixed in c2s module, we need to call 

```erlang
mongoose_helper:kick_everyone(), 
```

Another case the fix resolves is when in first case we send IQ-request, that is executed in a separate process (when iqdisc is parallel).
Than reply from first story can arrive into second story and cause unexpected stanza errors.

This PR has no test, but the test is possible :)
Test should be:

```
WHEN route stanza with the same user_jid and different user_sid.
THEN it should be dropped.
```

It's still "covered" by tests, because the check is triggered by CI several times during a build randomly.
