### PR TITLE
Update fast_tls to stat-less version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,7 @@
   {idna, ".*", {git, "git://github.com/benoitc/erlang-idna.git", {tag, "1.2.0"}}},
   {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "1.5.1"}}},
   {uuid, ".*", {git, "git://github.com/okeuday/uuid.git", {tag, "v1.7.1"}}},
-  {fast_tls, ".*", {git, "git://github.com/processone/fast_tls.git", {tag, "1.0.20"}}},
+  {fast_tls, ".*", {git, "git://github.com/processone/fast_tls.git", "a166f0e9fe78304e5ca628fd5eff57c850241813"}},
   {lasse, ".*", {git, "git://github.com/inaka/lasse.git", "692eaec"}},
   {worker_pool, ".*", {git, "git://github.com/inaka/worker_pool.git", {tag, "3.0.0"}}},
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -65,7 +65,7 @@
   0},
  {<<"fast_tls">>,
   {git,"git://github.com/processone/fast_tls.git",
-       {ref,"7953ca64808039ff4b5c7accc5befe28fdc8e67d"}},
+       {ref,"a166f0e9fe78304e5ca628fd5eff57c850241813"}},
   0},
  {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.5">>},1},
  {<<"fusco">>,


### PR DESCRIPTION
There is no tagged version yet but the latest version fixes important performance issue.