### PR TITLE
Properly handle resource reusing between stories in ejabberdctl_SUITE

### DIFF
--- a/big_tests/tests/cluster_commands_SUITE.erl
+++ b/big_tests/tests/cluster_commands_SUITE.erl
@@ -401,7 +401,7 @@ run_interactive(Cmd, Response, Timeout) ->
     Port = erlang:open_port({spawn, Cmd}, [exit_status]),
     %% respond to interactive question (yes/no)
     Port ! {self(), {command, Response}},
-    ejabberdctl_helper:loop(Port, [], Timeout).
+    ejabberdctl_helper:loop(Cmd, Port, [], Timeout).
 
 nodes_clustered(Node1, Node2, ShouldBe) ->
     DbNodes1 = distributed_helper:rpc(Node1, mnesia, system_info, [db_nodes]),

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -194,6 +194,9 @@ end_per_testcase(delete_old_users, Config) ->
         end, Users),
     escalus:end_per_testcase(delete_old_users, Config);
 end_per_testcase(CaseName, Config) ->
+    %% Because kick_session fails with unexprected stanza received:
+    %% <presence from="alicE@localhost/res3" to="alice@localhost/res1" type="unavailable" />
+    mongoose_helper:kick_everyone(),
     escalus:end_per_testcase(CaseName, Config).
 
 %%--------------------------------------------------------------------
@@ -455,7 +458,8 @@ rosteritem_rw(Config) ->
                 {Items2, 0} = ejabberdctl("get_roster", [AliceName, Domain], Config),
                 match_roster([{MikeName, Domain, "MyMike", "MyGroup", "both"}], Items2),
 
-                escalus:send(Alice, escalus_stanza:roster_remove_contact(MikeJid))  % cleanup
+                escalus:send(Alice, escalus_stanza:roster_remove_contact(MikeJid)),  % cleanup
+                escalus:wait_for_stanzas(Alice, 2, 5000)
         end).
 
 presence_after_add_rosteritem(Config) ->
@@ -469,7 +473,9 @@ presence_after_add_rosteritem(Config) ->
                  escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
                  escalus:assert(is_presence, escalus:wait_for_stanza(Bob)),
 
-                 escalus:send(Alice, escalus_stanza:roster_remove_contact(BobJid))  % cleanup
+                 escalus:send(Alice, escalus_stanza:roster_remove_contact(BobJid)),  % cleanup
+                 %% Wait for stanzas, so they would not end up in the next story
+                 escalus:wait_for_stanzas(Alice, 3, 5000)
          end).
 
 push_roster(Config) ->
@@ -484,7 +490,8 @@ push_roster(Config) ->
                 escalus:assert(is_roster_result, Roster1),
                 escalus:assert(roster_contains, [BobJid], Roster1),
 
-                escalus:send(Alice, escalus_stanza:roster_remove_contact(BobJid)) % cleanup
+                escalus:send(Alice, escalus_stanza:roster_remove_contact(BobJid)), % cleanup
+                escalus:wait_for_stanzas(Alice, 2, 5000)
         end).
 
 process_rosteritems_list_simple(Config) ->

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -194,8 +194,11 @@ end_per_testcase(delete_old_users, Config) ->
         end, Users),
     escalus:end_per_testcase(delete_old_users, Config);
 end_per_testcase(CaseName, Config) ->
-    %% Because kick_session fails with unexprected stanza received:
-    %% <presence from="alicE@localhost/res3" to="alice@localhost/res1" type="unavailable" />
+    %% Because kick_session fails with unexpected stanza received:
+    %% <presence from="alicE@localhost/res3"
+    %%     to="alice@localhost/res1" type="unavailable" />
+    %% TODO: Remove when escalus learns how to automatically deal
+    %% with 'unavailable' stanzas on client stop.
     mongoose_helper:kick_everyone(),
     escalus:end_per_testcase(CaseName, Config).
 

--- a/big_tests/tests/ejabberdctl_helper.erl
+++ b/big_tests/tests/ejabberdctl_helper.erl
@@ -43,12 +43,12 @@ run(Cmd) ->
 
 run(Cmd, Timeout) ->
     Port = erlang:open_port({spawn, Cmd},[exit_status]),
-    loop(Port,[], Timeout).
+    loop(Cmd, Port, [], Timeout).
 
-loop(Port, Data, Timeout) ->
+loop(Cmd, Port, Data, Timeout) ->
     receive
-        {Port, {data, NewData}} -> loop(Port, Data++NewData, Timeout);
+        {Port, {data, NewData}} -> loop(Cmd, Port, Data++NewData, Timeout);
         {Port, {exit_status, ExitStatus}} -> {Data, ExitStatus}
     after Timeout ->
-        throw(timeout)
+        erlang:error(#{reason => timeout, command => Cmd})
     end.


### PR DESCRIPTION
This PR is similar to #1803.
It also addresses the same resource reuse between several stories.

Proposed changes include:
* ejabberdctl_helper prints command, when a timeout error occurs
* kick_everyone between test cases
* Actually wait for cleanup to finish, not just fire a stanza and forget (because the result can arrive to a reconnected device)