### PR TITLE
Fix a race condition in rest_client_SUITE

### DIFF
--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -666,7 +666,7 @@ add_contact_and_invite(Config) ->
             % another roster push
             Push2 = escalus:wait_for_stanza(Bob),
             escalus:assert(is_roster_set, Push2),
-            ct:pal("Push2: ~p", [Push2]),
+            ct:log("Push2: ~p", [Push2]),
             % she receives  a subscription request
             Sub = escalus:wait_for_stanza(Alice),
             escalus:assert(is_presence_with_type, [<<"subscribe">>], Sub),
@@ -688,8 +688,14 @@ add_contact_and_invite(Config) ->
                          escalus_stanza:presence_direct(
                              escalus_client:short_jid(Bob),
                              <<"subscribed">>)),
+            %% Wait for push before trying to query endpoint
+            %% If we just call endpoint,
+            %% the "subscribed" stanza can not yet be processed.
+            Push3 = escalus:wait_for_stanza(Bob),
+            ct:log("Push3 ~p", [Push3]),
+            escalus:assert(is_roster_set, Push3),
+
             % now check Bob's roster
-            timer:sleep(100),
             {?OK, R4} = gett(client, "/contacts", BCred),
             Result4 = decode_maplist(R4),
             [Res4] = Result4,


### PR DESCRIPTION
This PR addresses

```erlang
====== Suite FAILED: rest_client_SUITE (1 of 30 tests failed)    
                                                                 
                                                                 
                                                                 
====== Test name: add_contact_and_invite                         
====== Reason:    {{badmatch,                                    
                       #{ask => <<"out">>,                       
                         jid => <<"alice12.325484@localhost">>,  
                         subscription => <<"none">>}},           
                   [{rest_client_SUITE,'-add_contact_and_invite/1-fun-0-',2,                                                      
                        [{file,"rest_client_SUITE.erl"},{line,697}]},                                                             
                    {escalus_story,story,4,                      
                        [{file,"src/escalus_story.erl"},{line,72}]},                                                              
                    {rest_client_SUITE,add_contact_and_invite,1, 
                        [{file,"rest_client_SUITE.erl"},{line,643}]},                                                             
                    {test_server,ts_tc,3,                        
                        [{file,"test_server.erl"},{line,1529}]},                                                                  
                    {test_server,run_test_case_eval1,6,
                        [{file,"test_server.erl"},{line,1045}]},
                    {test_server,run_test_case_eval,9,
                        [{file,"test_server.erl"},{line,977}]}]}
```

Proposed changes include:
* wait for processing confirmation.
