### PR TITLE
Remove esip from default build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ rel/vars.config: rel/vars.config.in rel/configure.vars.config
 
 ## Don't allow these files to go out of sync!
 configure.out rel/configure.vars.config:
-	./tools/configure with-all
+	./tools/configure with-all without-jingle-sip
 
 etc/ejabberd.cfg:
 	@mkdir -p $(@D)

--- a/doc/modules/mod_jingle_sip.md
+++ b/doc/modules/mod_jingle_sip.md
@@ -21,6 +21,20 @@ The translation back from SIP to Jingle is done for following SIP messages:
 * `BYE`
 * `INFO`
 
+### Prerequisites
+
+By default, MongooseIM is built without SIP support, as it is **not compatible with OTP 20.0 and newer**.
+In order to build the server with SIP support, please use `tools/configure` script before the release generation.
+You may either pick only certain drivers (with SIP included) or simply use `with-all` option. Examples:
+
+```
+tools/configure with-mysql with-jingle-sip
+tools/configure with-all without-odbc
+tools/configure with-all
+```
+
+MongooseIM 2.2.x packages are built with OTP 19.3, so they include Jingle/SIP support.
+
 ### Options
 
 * `proxy_host` (default: "localhost") name or IP address of the SIP Proxy to which MongooseIM will send SIP messages

--- a/tools/configure
+++ b/tools/configure
@@ -62,6 +62,8 @@ all_apps() ->
 
 process_args(["with-" ++ App | Args], #opts{apps = Apps} = Opts) ->
     process_args(Args, Opts#opts{apps = process_app(App, Apps)});
+process_args(["without-" ++ App | Args], #opts{apps = Apps} = Opts) ->
+    process_args(Args, Opts#opts{apps = exclude_app(App, Apps)});
 
 process_args(["prefix=" ++ Prefix | Args], #opts{} = Opts) ->
     process_args(Args, Opts#opts{prefix = Prefix});
@@ -105,6 +107,10 @@ process_app(App, Apps) ->
     {App, AppDeps, _} = lists:keyfind(App, 1, app_opts()),
     AppDeps ++ Apps.
 
+exclude_app(App, Apps) ->
+    {App, AppDeps, _} = lists:keyfind(App, 1, app_opts()),
+    Apps -- AppDeps.
+
 validate_apps(Apps) -> validate_apps(Apps, []).
 
 validate_apps(["odbc" = App | Apps], Acc) ->
@@ -130,11 +136,13 @@ usage() ->
           "\n"
           "Writes rel/configure.vars.config which can be used as Reltool input.\n"
           "\n"
-          "3rd party apps:\n\n~s\n"
+          "3rd party apps:\n\n~s~s\n"
           "Options:\n\n~s\n",
           [progname(),
            [ io_lib:format("    with-~.15s~s\n", [Opt, Desc])
              || {Opt, _, Desc} <- app_opts() ],
+           [ io_lib:format("    without-~.12sdo not ~s\n", [Opt, Desc])
+             || {Opt, _, Desc} <- app_opts(), Opt /= "all", Opt /= "none" ],
            [ io_lib:format("    ~.10s~s. Default: ~s\n", [Opt, Desc, Default])
              || {Opt, Default, Desc} <- opts() ]]).
 


### PR DESCRIPTION
- [x] Remove `esip` from default build, as it is incompatible with 20.0 and newer
- [x] Update Jingle/SIP docs with information about proper build and OTP compatibility
