### PR TITLE
Move policy-violation check from backend modules into mod_mam

### DIFF
--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -667,7 +667,14 @@ remove_archive(Host, ArcID, ArcJID=#jid{}) ->
     {ok, mod_mam:lookup_result()}
     | {error, 'policy-violation'}
     | {error, Reason :: term()}.
-lookup_messages(Host, #{search_text := SearchText} = Params) ->
+lookup_messages(Host, Params) ->
+    Result = lookup_messages_without_policy_violation_check(Host, Params),
+    %% If a query returns a number of stanzas greater than this limit and the
+    %% client did not specify a limit using RSM then the server should return
+    %% a policy-violation error to the client.
+    mod_mam_utils:check_result_for_policy_violation(Params, Result).
+
+lookup_messages_without_policy_violation_check(Host, #{search_text := SearchText} = Params) ->
     case SearchText /= undefined andalso not mod_mam_params:has_full_text_search(?MODULE, Host) of
         true -> %% Use of disabled full text search
             {error, 'not-supported'};

--- a/src/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/src/mod_mam_muc_odbc_async_pool_writer.erl
@@ -232,7 +232,7 @@ archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size) ->
 
 
 -spec lookup_messages(Result :: any(), Host :: jid:server(), Params :: map()) ->
-    {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
+    {ok, mod_mam:lookup_result()}.
 lookup_messages(Result, Host, #{archive_id := ArcID, end_ts := End, now := Now}) ->
     wait_flushing_before(Host, ArcID, End, Now),
     Result.

--- a/src/mod_mam_odbc_async_pool_writer.erl
+++ b/src/mod_mam_odbc_async_pool_writer.erl
@@ -242,7 +242,7 @@ archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size) ->
 
 
 -spec lookup_messages(Result :: any(), Host :: jid:server(), Params :: map()) ->
-    {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
+    {ok, mod_mam:lookup_result()}.
 lookup_messages(Result, Host, #{archive_id := ArcID, end_ts := End, now := Now}) ->
     wait_flushing_before(Host, ArcID, End, Now),
     Result.

--- a/src/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mod_mam_riak_timed_arch_yz.erl
@@ -270,14 +270,7 @@ lookup_messages(Host, Params) ->
                                            [{rows, 1}], F),
             Offset = calculate_offset(RSM, TotalCountFullQuery, length(SortedKeys),
                                       {OwnerJID, RemoteJID, MsgIdStartNoRSM, SearchText}),
-            LimitPassed = maps:get(limit_passed, Params),
-            MaxResultLimit = maps:get(max_result_limit, Params),
-            case TotalCount - Offset > MaxResultLimit andalso not LimitPassed of
-                true ->
-                    {error, 'policy-violation'};
-                _ ->
-                    {ok, {TotalCount, Offset, get_messages(Host, SortedKeys)}}
-            end
+            {ok, {TotalCount, Offset, get_messages(Host, SortedKeys)}}
     end.
 
 


### PR DESCRIPTION
This PR addresses simplifies MAM-backend code.

Proposed changes include:
* do policy check in one place in mod_mam/muc. 

There is a small performance degradation in case we hit the policy violation (we extract but don't forward the messages). But the policy-violation is never hit in the real systems.

Motivation: KISSify MAM backend modules.