### PR TITLE
Fix Travis tests with new MySQL

### DIFF
--- a/big_tests/tests/privacy_SUITE.erl
+++ b/big_tests/tests/privacy_SUITE.erl
@@ -679,6 +679,8 @@ block_jid_iq(Config) ->
         end).
 
 block_jid_all(Config) ->
+    %% unexprected presence unavalable
+    mongoose_helper:kick_everyone(),
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
         privacy_helper:set_list(Alice, {<<"deny_jid_all">>, Bob}),

--- a/tools/docker-setup-mysql.sh
+++ b/tools/docker-setup-mysql.sh
@@ -10,4 +10,6 @@ chmod 444 ${MYSQLDIR}/fake_cert.pem
 chmod 400 ${MYSQLDIR}/fake_key.pem
 
 echo 'Configuring mysql'
-mysql -u root -h localhost --password=${MYSQL_ROOT_PASSWORD} -e "GRANT USAGE ON *.* TO '${MYSQL_USER}'@'%' REQUIRE SSL;"
+mysql -u root -h localhost --password=${MYSQL_ROOT_PASSWORD} -e \
+      "GRANT USAGE ON *.* TO '${MYSQL_USER}'@'%'; \
+       ALTER USER '${MYSQL_USER}'@'%' REQUIRE SSL;"

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -28,6 +28,8 @@ if [ "$DB" = 'mysql' ]; then
     mkdir -p ${SQL_TEMP_DIR}
     cp ${SSLDIR}/fake_cert.pem ${SQL_TEMP_DIR}/.
     openssl rsa -in ${SSLDIR}/fake_key.pem -out ${SQL_TEMP_DIR}/fake_key.pem
+    # mysql_native_password is needed until mysql-otp implements caching-sha2-password
+    # https://github.com/mysql-otp/mysql-otp/issues/83
     docker run -d \
         -e SQL_TEMP_DIR=${SQL_TEMP_DIR} \
         -e MYSQL_ROOT_PASSWORD=secret \
@@ -39,7 +41,8 @@ if [ "$DB" = 'mysql' ]; then
         -v ${BASE}/${TOOLS}/docker-setup-mysql.sh:/docker-entrypoint-initdb.d/docker-setup-mysql.sh \
         -v ${SQL_TEMP_DIR}:${SQL_TEMP_DIR} \
         --health-cmd='mysqladmin ping --silent' \
-        -p 3306:3306 --name=mongooseim-mysql mysql
+        -p 3306:3306 --name=mongooseim-mysql \
+        mysql --default-authentication-plugin=mysql_native_password
 
 elif [ "$DB" = 'pgsql' ]; then
     echo "Configuring postgres with SSL"


### PR DESCRIPTION
From 8.0.11 release notes:

The following features related to account management have been removed:

Using GRANT to modify account properties other than privilege assignments. This includes authentication, SSL, and resource-limit properties. Instead, establish such properties at account-creation time with CREATE USER or modify them afterward with ALTER USER.