### PR TITLE
Fix caching iq info in accumulator

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -9,7 +9,7 @@
         {erlsh, ".*", {git, "git://github.com/proger/erlsh.git", "2fce513"}},
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
-        {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
+        {exml, ".*", {git, "git://github.com/esl/exml.git", {branch, "add_ref_to_xmlel"}}},
         {escalus, ".*", {git, "git://github.com/esl/escalus.git", "aa77ba506fd46cf2bf9a0ac3639bc2ed6e1a8173"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},

--- a/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
+++ b/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
@@ -48,8 +48,8 @@ check_acc(Acc, stripped) ->
 
 alter_message({From, To, Acc, Packet}) ->
     % Not using #xmlel as it causes some strange error in dynamic compilation
-    {xmlel, PName, PAttrs, PCh} = Packet,
-    NewBody = {xmlel, <<"body">>, [], [{xmlcdata, <<"bye">> }]},
+    {xmlel, PName, PRef, PAttrs, PCh} = Packet,
+    NewBody = {xmlel, <<"body">>, undefined, [], [{xmlcdata, <<"bye">> }]},
     PCh2 = lists:keyreplace(<<"body">>, 2, PCh, NewBody),
-    {From, To, Acc, {xmlel, PName, PAttrs, PCh2}}.
+    {From, To, Acc, {xmlel, PName, PRef, PAttrs, PCh2}}.
 

--- a/include/jlib.hrl
+++ b/include/jlib.hrl
@@ -27,6 +27,7 @@
 -include("jid.hrl").
 
 -record(iq, {id = <<>>    :: binary(),
+             ref          :: reference() | undefined,
              type         :: atom(),
              xmlns = <<>> :: binary(),
              lang = <<>>  :: ejabberd:lang(),

--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
   {base16, ".*", {git, "git://github.com/goj/base16.git", "f78918e"}},
   {cuesport, ".*", {git, "git://github.com/esl/cuesport.git", "d82ff25"}},
   {redo, ".*", {git, "git://github.com/Wallapop/redo.git", "35a8d1c"}},
-  {exml, ".*", {git, "git://github.com/esl/exml.git", {tag, "3.0.0"}}},
+  {exml, ".*", {git, "git://github.com/esl/exml.git", {branch, "add_ref_to_xmlel"}}},
   {lager, ".*", {git, "git://github.com/basho/lager.git", "3.2.4"}},
   {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", "3.0.3"}},
   {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", "1.1.2"}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -53,7 +53,7 @@
   0},
  {<<"exml">>,
   {git,"git://github.com/esl/exml.git",
-       {ref,"a064e571062a305cefae191234ae14e8b90c039e"}},
+       {ref,"88b8f8f66a9ceb077a237abf3087bae14c68f9c5"}},
   0},
  {<<"exometer_core">>,
   {git,"git://github.com/esl/exometer_core.git",

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -94,7 +94,7 @@ start_link() ->
                     | {'error', 'lager_not_running'} | {'process_iq', _, _, _}.
 process_iq(Acc0, From, To, El) ->
     Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
+    IQ = mongoose_acc:get(iq_query_info, Acc, El),
     process_iq(IQ, Acc, From, To, El).
 
 process_iq(#iq{xmlns = XMLNS} = IQ, Acc, From, To, _El) ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -968,7 +968,7 @@ get_max_user_sessions(LUser, Host) ->
       Result :: ok | todo | pid() | {error, lager_not_running} | {process_iq, _, _, _}.
 process_iq(From, To, Acc0, Packet) ->
     Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
+    IQ = mongoose_acc:get(iq_query_info, Acc, Packet),
     process_iq(IQ, From, To, Acc0, Packet).
 
 process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -235,7 +235,7 @@ disco_info(Acc, Host, Module, Node, Lang) ->
     end.
 
 c2s_presence_in(C2SState,
-                {From, To, {_, _, Attrs, Els}}) ->
+                {From, To, #xmlel{attrs = Attrs, children = Els}}) ->
     ?DEBUG("Presence to ~p from ~p with Els ~p", [To, From, Els]),
     Type = xml:get_attr_s(<<"type">>, Attrs),
     Subscription = ejabberd_c2s:get_subscription(From,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -453,7 +453,7 @@ normal_state({route, From, <<>>, Acc0,
           #xmlel{name = <<"iq">>} = Packet},
          StateData) ->
     Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
+    IQ = mongoose_acc:get(iq_query_info, Acc, Packet),
     {RoutingEffect, NewStateData} = route_iq(Acc, #routed_iq{
         iq = IQ,
         from = From,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4284,7 +4284,7 @@ send_decline_invitation({Packet, XEl, DEl, ToJID}, RoomJID, FromJID) ->
 %% replace the instance of the subelement in element with the new subelement.
 -spec replace_subelement(exml:element(), exml:element()) -> exml:element().
 replace_subelement(XE = #xmlel{children = SubEls}, NewSubEl) ->
-    {_, NameNewSubEl, _, _} = NewSubEl,
+    #xmlel{name = NameNewSubEl} = NewSubEl,
     SubEls2 = lists:keyreplace(NameNewSubEl, 2, SubEls, NewSubEl),
     XE#xmlel{children = SubEls2}.
 

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -232,9 +232,9 @@ handle_call(stop, _From, State) ->
 handle_call(_Request, _From, State) ->
     {reply, bad_request, State}.
 
-handle_info({route, From, To, Acc, _El}, State) ->
+handle_info({route, From, To, Acc, El}, State) ->
     Acc1 = mongoose_acc:require(iq_query_info, Acc),
-    IQ = mongoose_acc:get(iq_query_info, Acc1),
+    IQ = mongoose_acc:get(iq_query_info, Acc1, El),
     case catch do_route(State#state.host, From, To, Acc1, IQ) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p", [Reason]);

--- a/src/service_admin_extra_private.erl
+++ b/src/service_admin_extra_private.erl
@@ -80,10 +80,11 @@ private_get(Username, Host, Element, Ns) ->
 do_private_get(Acc, Username, Host, Element, Ns) ->
     From = jid:make(Username, Host, <<"">>),
     To = jid:make(Username, Host, <<"">>),
-    IQ = {iq, <<"">>, get, ?NS_PRIVATE, <<"">>,
-          #xmlel{ name = <<"query">>,
-                  attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
-                  children = [#xmlel{ name = Element, attrs = [{<<"xmlns">>, Ns}]}] } },
+    IQ = #iq{type = get,
+             xmlns = ?NS_PRIVATE,
+             sub_el = #xmlel{name = <<"query">>,
+                             attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
+                             children = [#xmlel{ name = Element, attrs = [{<<"xmlns">>, Ns}]}] } },
     {_, ResIq} = mod_private:process_sm_iq(From, To, Acc, IQ),
     [#xmlel{ name = <<"query">>,
              attrs = [{<<"xmlns">>, <<"jabber:iq:private">>}],
@@ -118,10 +119,11 @@ do_private_set2(Acc, Username, Host, Xml) ->
         true ->
             From = jid:make(Username, Host, <<"">>),
             To = jid:make(Username, Host, <<"">>),
-            IQ = {iq, <<"">>, set, ?NS_PRIVATE, <<"">>,
-                  #xmlel{ name = <<"query">>,
-                          attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
-                          children = [Xml]}},
+            IQ = #iq{type = set,
+                     xmlns = ?NS_PRIVATE,
+                     sub_el = #xmlel{name = <<"query">>,
+                                     attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
+                                     children = [Xml]}},
             mod_private:process_sm_iq(From, To, Acc, IQ),
             {ok, ""};
         false ->

--- a/src/service_admin_extra_vcard.erl
+++ b/src/service_admin_extra_vcard.erl
@@ -215,7 +215,7 @@ set_vcard_content(Acc, User, Server, Data, ContentList) ->
     %% Get old vcard
     A4 = case IQr#iq.sub_el of
              [A1] ->
-                 {_, _, _, A2} = A1,
+                 #xmlel{children = A2} = A1,
                  update_vcard_els(Data, ContentList, A2);
              _ ->
                  update_vcard_els(Data, ContentList, [])
@@ -246,7 +246,7 @@ update_vcard_els(Data, ContentList, Els1) ->
                      ContentOld1 = OldEl#xmlel.children,
                      Content2 = [#xmlel{ name = D2, children = [#xmlcdata{content=Content}]}
                                  || Content <- ContentList],
-                     ContentOld2 = [A || {_, X, _, _} = A <- ContentOld1, X/=D2],
+                     ContentOld2 = [A || #xmlel{name = X} = A <- ContentOld1, X/=D2],
                      ContentOld3 = lists:keysort(2, ContentOld2),
                      ContentNew = lists:keymerge(2, Content2, ContentOld3),
                      [#xmlel{ name = Data1, children = ContentNew}]

--- a/test/acc_SUITE.erl
+++ b/test/acc_SUITE.erl
@@ -7,7 +7,6 @@
 -include("ejabberd_commands.hrl").
 -include("jlib.hrl").
 
--define(PRT(X, Y), ct:pal("~p: ~p", [X, Y])).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% suite configuration
@@ -22,7 +21,7 @@ groups() ->
     [
      {basic, [sequence],
       [store_and_retrieve, init_from_element, get_and_require, strip,
-          parse_with_cdata]
+          parse_with_cdata, reference]
      }
     ].
 
@@ -42,7 +41,6 @@ store_and_retrieve(_C) ->
 init_from_element(_C) ->
     Acc = mongoose_acc:from_element(sample_stanza()),
     mongoose_acc:dump(Acc),
-    ?PRT("Acc", Acc),
     ?assertEqual(mongoose_acc:get(name, Acc), <<"iq">>),
     ?assertEqual(mongoose_acc:get(type, Acc), <<"set">>),
     ok.
@@ -87,11 +85,24 @@ strip(_C) ->
     ?assertEqual(mongoose_acc:get(ref, NAcc, ref), Ref),
     ?assertEqual(997, mongoose_acc:get_prop(ppp, NAcc)).
 
+reference(_C) ->
+    Acc = mongoose_acc:from_element(sample_stanza()),
+    Ref = mongoose_acc:get(ref, Acc),
+    El = mongoose_acc:get(element, Acc),
+    ?assertEqual(Ref, El#xmlel.ref),
+    NAcc = mongoose_acc:strip(Acc),
+    ?assertEqual(Ref, mongoose_acc:get(ref, NAcc)),
+    NEl = mongoose_acc:get(element, NAcc),
+    ?assertEqual(Ref, NEl#xmlel.ref),
+    ok.
+
+
 
 sample_stanza() ->
     {xmlel, <<"iq">>,
+        undefined,
         [{<<"xml:lang">>, <<"en">>}, {<<"type">>, <<"set">>}],
-        [{xmlel, <<"block">>,
+        [{xmlel, <<"block">>, undefined,
             [{<<"xmlns">>, <<"urn:xmpp:blocking">>}],
             [{xmlel, <<"item">>,
                 [{<<"jid">>, <<"bob37.814302@localhost">>}],
@@ -106,16 +117,19 @@ stanza_with_cdata() ->
 
 iq_stanza() ->
     {xmlel,<<"iq">>,
+        undefined,
         [{<<"type">>,<<"set">>},
             {<<"id">>,<<"a31baa4c478896af19b76bac799b65ed">>}],
-        [{xmlel,<<"session">>,
+        [{xmlel,<<"session">>, undefined,
             [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-session">>}],
             []}]}.
 
 another_iq_stanza() ->
     {xmlel,<<"iq">>,
+        undefined,
         [{<<"type">>,<<"pet">>},
             {<<"id">>,<<"a31baa4c478896af19b76bac799b65ed">>}],
         [{xmlel,<<"session">>,
             [{<<"xmlns">>,<<"urn:ietf:params:xml:ns:xmpp-session">>}],
             []}]}.
+

--- a/test/ejabberd_c2s_SUITE.erl
+++ b/test/ejabberd_c2s_SUITE.erl
@@ -163,22 +163,22 @@ stream_header(Domain) ->
                               <<"http://etherx.jabber.org/streams">>}]}.
 
 auth_stanza() ->
-    {xmlel, <<"auth">>,
+    {xmlel, <<"auth">>, undefined,
         [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-sasl">>},
          {<<"mechanism">>, <<"PLAIN">>}],
         [{xmlcdata, <<"AGFsaWNFOTkuODk3NzMzAG1hdHlncnlzYQ==">>}]}.
 
 bind_stanza() ->
-    {xmlel, <<"iq">>,
+    {xmlel, <<"iq">>, undefined,
             [{<<"type">>, <<"set">>}, {<<"id">>, <<"4436">>}],
-            [{xmlel, <<"bind">>,
+            [{xmlel, <<"bind">>, undefined,
                     [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-bind">>}],
-                    [{xmlel, <<"resource">>, [], [{xmlcdata, <<"res1">>}]}]}]}.
+                    [{xmlel, <<"resource">>, undefined, [], [{xmlcdata, <<"res1">>}]}]}]}.
 
 setsession_stanza() ->
-    {xmlel, <<"iq">>,
+    {xmlel, <<"iq">>, undefined,
         [{<<"type">>, <<"set">>}, {<<"id">>, <<"4436">>}],
-        [{xmlel, <<"session">>, [{<<"xmlns">>,
+        [{xmlel, <<"session">>, undefined, [{<<"xmlns">>,
                                   <<"urn:ietf:params:xml:ns:xmpp-session">>}],
             []}]}.
 

--- a/test/privacy_SUITE.erl
+++ b/test/privacy_SUITE.erl
@@ -132,9 +132,9 @@ userlist(_) ->
 
 
 presence() ->
-    {xmlel, <<"presence">>, [{<<"xml:lang">>, <<"en">>}], []}.
+    {xmlel, <<"presence">>, undefined, [{<<"xml:lang">>, <<"en">>}], []}.
 
 message() ->
-    {xmlel, <<"message">>,
+    {xmlel, <<"message">>, undefined,
         [{<<"type">>, <<"chat">>}, {<<"to">>, <<"bob@localhost">>}],
-        [{xmlel, <<"body">>, [], [{xmlcdata, <<"roar!">>}]}]}.
+        [{xmlel, <<"body">>, undefined,  [], [{xmlcdata, <<"roar!">>}]}]}.


### PR DESCRIPTION
This PR addresses the issue of wrong iq info being used in some places. The reason is that iq_query_info, being a bit costly to generate out of an xmlel, is cached in the accumulator (using `mongoose_acc:require/2`) and then reused. Sometimes, though, we are processing a different stanza then the original one, e.g. when we are replying with an error - iq_query_info retrieved from accumulator is in such case inaccurate.

Proposed solution: when creating an acc lets copy its reference to the element being stored. Then we can easily check whether an element being processed is the initial one or something else, and proceed accordingly.

