### PR TITLE
Partial RPC cleanup in big tests

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -10,7 +10,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "115cffb"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "f44bd89"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},

--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -10,7 +10,7 @@
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
         {exml, ".*", {git, "git://github.com/esl/exml.git", "013fc58"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "f44bd89"}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "d6b36d5"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},

--- a/big_tests/src/ct_tty_hook.erl
+++ b/big_tests/src/ct_tty_hook.erl
@@ -28,6 +28,9 @@
 -export([terminate/1]).
 -record(state, { total, suite_total, ts, tcs, data, print_group, print_case }).
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 %% @doc Return a unique id for this CTH.
 id(_Opts) ->
     "ct_tty_hook_001".
@@ -42,7 +45,7 @@ init(_Id, Opts) ->
                  print_group = PrintGroup, print_case = PrintCase }}.
 
 %% @doc Called before init_per_suite is called.
-pre_init_per_suite(Suite,Config,State) ->
+pre_init_per_suite(_Suite, Config, State) ->
     {Config, State#state{ suite_total = 0, tcs = [] }}.
 
 %% @doc Called after init_per_suite.
@@ -140,13 +143,11 @@ maybe_print_test_case({testcase, Name,{error, Content},_}) ->
     io:format("~n====== Reason:    ~p~n", [Content]).
 
 print_group_enter(Group, #state{print_group = true}, Msg) ->
-    escalus_ejabberd:rpc(error_logger, warning_msg, ["====== ~s GROUP ~p",
-                         [Msg, Group]]);
+    rpc(mim(), error_logger, warning_msg, ["====== ~s GROUP ~p", [Msg, Group]]);
 print_group_enter(_Group, _State, _Msg) ->
     ok.
 
 print_case_enter(Group, #state{print_case = true}, Msg) ->
-    escalus_ejabberd:rpc(error_logger, warning_msg, ["====== ~s CASE ~p",
-        [Msg, Group]]);
+    rpc(mim(), error_logger, warning_msg, ["====== ~s CASE ~p", [Msg, Group]]);
 print_case_enter(_Group, _State, _Msg) ->
     ok.

--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -25,6 +25,10 @@
 
 -define(SLEEP_TIME, 50).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -46,16 +50,15 @@ message_test_cases() ->
     ].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    {Mod, Code} = escalus_ejabberd:rpc(dynamic_compile, from_string,
-                                       [acc_test_helper_code(Config)]),
-    escalus_ejabberd:rpc(code, load_binary, [Mod, "acc_test_helper.erl", Code]),
+    {Mod, Code} = rpc(mim(), dynamic_compile, from_string, [acc_test_helper_code(Config)]),
+    rpc(mim(), code, load_binary, [Mod, "acc_test_helper.erl", Code]),
     recreate_table(),
     escalus:init_per_suite(Config).
 
@@ -130,13 +133,13 @@ acc_test_helper_code(Config) ->
     binary_to_list(Code).
 
 add_handler(Hook, F, Seq) ->
-    escalus_ejabberd:rpc(ejabberd_hooks, add, [Hook, host(), acc_test_helper, F, Seq]).
+    rpc(mim(), ejabberd_hooks, add, [Hook, host(), acc_test_helper, F, Seq]).
 
 remove_handler(Hook, F, Seq) ->
-    escalus_ejabberd:rpc(ejabberd_hooks, delete, [Hook, host(), acc_test_helper, F, Seq]).
+    rpc(mim(), ejabberd_hooks, delete, [Hook, host(), acc_test_helper, F, Seq]).
 
 host() -> <<"localhost">>.
 
 %% creates a temporary ets table keeping refs and some attrs of accumulators created in c2s
 recreate_table() ->
-    escalus_ejabberd:rpc(acc_test_helper, recreate_table, []).
+    rpc(mim(), acc_test_helper, recreate_table, []).

--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -21,6 +21,10 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -53,7 +57,7 @@ groups() ->
      ].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 essential_test_cases() ->
     [create_and_terminate_session,
@@ -762,14 +766,14 @@ force_cache_trimming(Config) ->
 %%--------------------------------------------------------------------
 
 get_bosh_sessions() ->
-    escalus_ejabberd:rpc(mod_bosh_backend, get_sessions, []).
+    rpc(mim(), mod_bosh_backend, get_sessions, []).
 
 get_bosh_session(Sid) ->
     BoshSessions = get_bosh_sessions(),
     lists:keyfind(Sid, 2, BoshSessions).
 
 get_handlers(BoshSessionPid) ->
-    escalus_ejabberd:rpc(mod_bosh_socket, get_handlers, [BoshSessionPid]).
+    rpc(mim(), mod_bosh_socket, get_handlers, [BoshSessionPid]).
 
 get_bosh_sid(#client{rcv_pid = Pid}) ->
     escalus_bosh:get_sid(Pid).
@@ -835,19 +839,18 @@ ack_body(Body, Rid) ->
     Body#xmlel{attrs = NewAttrs}.
 
 set_client_acks(SessionPid, Enabled) ->
-    escalus_ejabberd:rpc(mod_bosh_socket, set_client_acks,
-                         [SessionPid, Enabled]).
+    rpc(mim(), mod_bosh_socket, set_client_acks, [SessionPid, Enabled]).
 
 get_cached_responses(SessionPid) ->
-    escalus_ejabberd:rpc(mod_bosh_socket, get_cached_responses, [SessionPid]).
+    rpc(mim(), mod_bosh_socket, get_cached_responses, [SessionPid]).
 
 inactivity() ->
     inactivity(?INACTIVITY).
 
 inactivity(Value) ->
     {inactivity,
-     fun() -> escalus_ejabberd:rpc(mod_bosh, get_inactivity, []) end,
-     fun(V) -> escalus_ejabberd:rpc(mod_bosh, set_inactivity, [V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_inactivity, []) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_inactivity, [V]) end,
      Value}.
 
 max_wait() ->
@@ -855,14 +858,14 @@ max_wait() ->
 
 max_wait(Value) ->
     {max_wait,
-     fun() -> escalus_ejabberd:rpc(mod_bosh, get_max_wait, []) end,
-     fun(V) -> escalus_ejabberd:rpc(mod_bosh, set_max_wait, [V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_max_wait, []) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_max_wait, [V]) end,
      Value}.
 
 server_acks_opt() ->
     {server_acks,
-     fun() -> escalus_ejabberd:rpc(mod_bosh, get_server_acks, []) end,
-     fun(V) -> escalus_ejabberd:rpc(mod_bosh, set_server_acks, [V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_server_acks, []) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_server_acks, [V]) end,
      true}.
 
 is_sesssion_alive(Sid) ->

--- a/big_tests/tests/cluster_commands_SUITE.erl
+++ b/big_tests/tests/cluster_commands_SUITE.erl
@@ -27,7 +27,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--define(LOCAL_NODE, mim()).
 -define(eq(Expected, Actual), ?assertEqual(Expected, Actual)).
 -define(ne(A, B), ?assertNot(A == B)).
 
@@ -37,33 +36,35 @@
 
 all() ->
     [{group, clustered},
-        {group, mnesia},
-        {group, clustering_two},
-        {group, clustering_three}].
+     {group, mnesia},
+     {group, clustering_two},
+     {group, clustering_three}].
+
 groups() ->
     [{clustered, [], [one_to_one_message]},
-        {clustering_two, [], clustering_two_tests()},
-        {clustering_three, [], clustering_three_tests()},
-        {mnesia, [], [set_master_test]}].
+     {clustering_two, [], clustering_two_tests()},
+     {clustering_three, [], clustering_three_tests()},
+     {mnesia, [], [set_master_test]}].
+
 suite() ->
     require_rpc_nodes([mim, mim2, mim3]) ++ escalus:suite().
 
 clustering_two_tests() ->
     [join_successful_prompt,
-        join_successful_force,
-        leave_successful_prompt,
-        leave_successful_force,
-        join_unsuccessful,
-        leave_unsuccessful,
-        leave_but_no_cluster,
-        join_twice,
-        leave_twice].
+     join_successful_force,
+     leave_successful_prompt,
+     leave_successful_force,
+     join_unsuccessful,
+     leave_unsuccessful,
+     leave_but_no_cluster,
+     join_twice,
+     leave_twice].
 
 clustering_three_tests() ->
     [cluster_of_three,
-        leave_the_three,
-        %remove_dead_from_cluster, % TODO: Breaks cover
-        remove_alive_from_cluster].
+     leave_the_three,
+     %remove_dead_from_cluster, % TODO: Breaks cover
+     remove_alive_from_cluster].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -80,9 +81,9 @@ init_per_suite(Config) ->
     Node2CtlPath = distributed_helper:ctl_path(Node2, Config3),
     Node3CtlPath = distributed_helper:ctl_path(Node3, Config3),
     escalus:init_per_suite([{ctl_path_atom(Node1), NodeCtlPath},
-        {ctl_path_atom(Node2), Node2CtlPath},
-        {ctl_path_atom(Node3), Node3CtlPath}]
-    ++ Config3).
+                            {ctl_path_atom(Node2), Node2CtlPath},
+                            {ctl_path_atom(Node3), Node3CtlPath}]
+                           ++ Config3).
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).

--- a/big_tests/tests/cluster_commands_SUITE.erl
+++ b/big_tests/tests/cluster_commands_SUITE.erl
@@ -17,10 +17,13 @@
 -module(cluster_commands_SUITE).
 -compile(export_all).
 
--import(distributed_helper, [add_node_to_cluster/2, rpc/5,
-        remove_node_from_cluster/2, is_sm_distributed/0]).
+-import(distributed_helper, [add_node_to_cluster/2,
+                             is_sm_distributed/0,
+                             mim/0, mim2/0, mim3/0,
+                             remove_node_from_cluster/2,
+                             require_rpc_nodes/1,
+                             rpc/5]).
 -import(ejabberdctl_helper, [ejabberdctl/3, rpc_call/3]).
--import(ejabberd_node_utils, [mim/0, mim2/0, mim3/0]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -43,8 +46,7 @@ groups() ->
         {clustering_three, [], clustering_three_tests()},
         {mnesia, [], [set_master_test]}].
 suite() ->
-    require_all_nodes() ++
-    escalus:suite().
+    require_rpc_nodes([mim, mim2, mim3]) ++ escalus:suite().
 
 clustering_two_tests() ->
     [join_successful_prompt,
@@ -62,11 +64,6 @@ clustering_three_tests() ->
         leave_the_three,
         %remove_dead_from_cluster, % TODO: Breaks cover
         remove_alive_from_cluster].
-
-require_all_nodes() ->
-    [{require, mim_node, {hosts, mim, node}},
-     {require, mim_node2, {hosts, mim2, node}},
-     {require, mim_node3, {hosts, mim3, node}}].
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -30,7 +30,9 @@
                         restart_ejabberd_node/1]).
 
 -import(distributed_helper, [add_node_to_cluster/1,
+                             mim/0,
                              remove_node_from_cluster/1,
+                             require_rpc_nodes/1,
                              start_node/2,
                              stop_node/2]).
 
@@ -68,7 +70,7 @@ groups() ->
                        ]}].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 xep0114_tests() ->
     [register_one_component,
@@ -363,8 +365,8 @@ clear_on_node_down(Config) ->
     ?assertMatch({_, _, _}, connect_component(CompOpts)),
     ?assertThrow({stream_error, _}, connect_component(CompOpts)),
 
-    stop_node(ejabberd_node_utils:mim(), Config),
-    start_node(ejabberd_node_utils:mim(), Config),
+    stop_node(mim(), Config),
+    start_node(mim(), Config),
 
     {Comp, Addr, _} = connect_component(CompOpts),
     disconnect_component(Comp, Addr).

--- a/big_tests/tests/component_helper.erl
+++ b/big_tests/tests/component_helper.erl
@@ -49,7 +49,7 @@ disconnect_components(Components, Addr) ->
 rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    escalus_ct:rpc_call(Node, M, F, A, 10000, Cookie).
+    escalus_rpc:call(Node, M, F, A, 10000, Cookie).
 
 cook_connection_step_error(E) ->
     {connection_step_failed, Step, Reason} = E,

--- a/big_tests/tests/conf_reload_SUITE.erl
+++ b/big_tests/tests/conf_reload_SUITE.erl
@@ -29,6 +29,10 @@
 -define(RELOADED_DOMAIN_USER, astrid).
 -define(INITIAL_DOMAIN_USER, alice).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -46,6 +50,7 @@ groups() ->
        ]}].
 
 suite() ->
+    require_rpc_nodes([mim]) ++
     [{required, {hosts, mim, reloaded_domain}} | escalus:suite()].
 
 %%--------------------------------------------------------------------
@@ -141,13 +146,13 @@ user_should_be_disconnected_from_removed_domain(Config) ->
 %%--------------------------------------------------------------------
 
 get_ejabberd_hosts() ->
-    escalus_ejabberd:rpc(ejabberd_config, get_global_option, [hosts]).
+    rpc(mim(), ejabberd_config, get_global_option, [hosts]).
 
 register_user_by_ejabberd_admin(User, Host) ->
-    escalus_ejabberd:rpc(ejabberd_admin, register, [User, Host, <<"doctor">>]).
+    rpc(mim(), ejabberd_admin, register, [User, Host, <<"doctor">>]).
 
 unregister_user_by_ejabberd_admin(User, Host) ->
-    escalus_ejabberd:rpc(ejabberd_admin, unregister, [User, Host]).
+    rpc(mim(), ejabberd_admin, unregister, [User, Host]).
 
 change_domain_in_config_file(Config) ->
     ejabberd_node_utils:modify_config_file(

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -62,7 +62,7 @@ rpc(Node, M, F, A) ->
 
 rpc(Node, M, F, A, TimeOut) ->
     Cookie = ct:get_config(ejabberd_cookie),
-    escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie).
+    escalus_rpc:call(Node, M, F, A, TimeOut, Cookie).
 
 %% @doc Require nodes defined in `test.config' for later convenient RPCing into.
 %%

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -3,7 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--import(ejabberd_node_utils, [get_cwd/2, mim/0, mim2/0, fed/0]).
+-import(ejabberd_node_utils, [get_cwd/2]).
 
 -compile(export_all).
 
@@ -65,6 +65,24 @@ rpc(Node, M, F, A, TimeOut) ->
     escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie).
 
 %% @doc Require nodes defined in `test.config' for later convenient RPCing into.
+%%
+%% The use case would be to require and import the same names in your suite like:
+%%
+%%  -import(distributed_helper, [mim/0, fed/0,
+%%                               require_rpc_nodes/1,
+%%                               rpc/4]).
+%%
+%%  ...
+%%
+%%  suite() ->
+%%      require_rpc_nodes([mim, fed]) ++ escalus:suite().
+%%
+%%  ...
+%%
+%%  example_test(_Config) ->
+%%      RPCResult = rpc(mim(), remote_mod, remote_fun, [arg1, arg2]),
+%%      ...
+%%
 require_rpc_nodes(Nodes) ->
     [ {require, {hosts, Node, node}} || Node <- Nodes ].
 
@@ -72,9 +90,15 @@ require_rpc_nodes(Nodes) ->
 mim() ->
     get_or_fail({hosts, mim, node}).
 
+mim2() ->
+    get_or_fail({hosts, mim2, node}).
+
+mim3() ->
+    get_or_fail({hosts, mim3, node}).
+
 %% @doc Shorthand for hosts->fed->node from `test.config'.
 fed() ->
-    get_or_fail(fed_node).
+    get_or_fail({hosts, fed, node}).
 
 get_or_fail(Key) ->
     Val = ct:get_config(Key),

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -64,6 +64,23 @@ rpc(Node, M, F, A, TimeOut) ->
     Cookie = ct:get_config(ejabberd_cookie),
     escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie).
 
+%% @doc Require nodes defined in `test.config' for later convenient RPCing into.
+require_rpc_nodes(Nodes) ->
+    [ {require, {hosts, Node, node}} || Node <- Nodes ].
+
+%% @doc Shorthand for hosts->mim->node from `test.config'.
+mim() ->
+    get_or_fail({hosts, mim, node}).
+
+%% @doc Shorthand for hosts->fed->node from `test.config'.
+fed() ->
+    get_or_fail(fed_node).
+
+get_or_fail(Key) ->
+    Val = ct:get_config(Key),
+    Val == undefined andalso error({undefined, Key}),
+    Val.
+
 start_node(Node, Config) ->
     {_, 0} = ejabberdctl_helper:ejabberdctl(Node, "start", [], Config),
     {_, 0} = ejabberdctl_helper:ejabberdctl(Node, "started", [], Config),

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -8,7 +8,7 @@
 -compile(export_all).
 
 is_sm_distributed() ->
-    Backend = escalus_ejabberd:rpc(ejabberd_sm_backend, backend, []),
+    Backend = rpc(mim(), ejabberd_sm_backend, backend, []),
     is_sm_backend_distributed(Backend).
 
 is_sm_backend_distributed(ejabberd_sm_mnesia) -> true;

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -5,14 +5,16 @@
 -export([save_modules/2, ensure_modules/2, restore_modules/2]).
 -export([stop/2, stop/3, start/3, start/4, restart/3, stop_running/2, start_running/1]).
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 save_modules(Domain, Config) ->
     [{saved_modules, get_current_modules(Domain)} | Config].
 
 ensure_modules(Domain, RequiredModules) ->
     CurrentModules = get_current_modules(Domain),
     {ToReplace, ReplaceWith} = to_replace(RequiredModules, CurrentModules, [], []),
-    ok = escalus_ejabberd:rpc(gen_mod_deps, replace_modules,
-                              [Domain, ToReplace, ReplaceWith]).
+    ok = rpc(mim(), gen_mod_deps, replace_modules, [Domain, ToReplace, ReplaceWith]).
 
 to_replace([], _CurrentModules, ReplaceAcc, ReplaceWithAcc) ->
     {lists:usort(ReplaceAcc), ReplaceWithAcc};
@@ -31,11 +33,10 @@ to_replace([RequiredModule | Rest], CurrentModules, ReplaceAcc, ReplaceWithAcc) 
 restore_modules(Domain, Config) ->
     SavedModules = ?config(saved_modules, Config),
     CurrentModules = get_current_modules(Domain),
-    escalus_ejabberd:rpc(gen_mod_deps, replace_modules,
-                         [Domain, CurrentModules, SavedModules]).
+    rpc(mim(), gen_mod_deps, replace_modules, [Domain, CurrentModules, SavedModules]).
 
 get_current_modules(Domain) ->
-    escalus_ejabberd:rpc(gen_mod, loaded_modules_with_opts, [Domain]).
+    rpc(mim(), gen_mod, loaded_modules_with_opts, [Domain]).
 
 stop(Domain, Mod) ->
     Node = escalus_ct:get_config(ejabberd_node),
@@ -92,9 +93,7 @@ stop_running(Mod, Config) ->
     ModL = atom_to_list(Mod),
     Domain = escalus_ejabberd:unify_str_arg(
                ct:get_config({hosts, mim, domain})),
-    Modules = escalus_ejabberd:rpc(ejabberd_config,
-                                   get_local_option,
-                                   [{modules, Domain}]),
+    Modules = rpc(mim(), ejabberd_config, get_local_option, [{modules, Domain}]),
     Filtered = lists:filter(fun({Module, _}) ->
                     ModuleL = atom_to_list(Module),
                     case lists:sublist(ModuleL, 1, length(ModL)) of

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -43,14 +43,14 @@ stop(Domain, Mod) ->
 
 stop(Node, Domain, Mod) ->
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    IsLoaded = escalus_ct:rpc_call(Node, gen_mod, is_loaded, [Domain, Mod], 5000, Cookie),
+    IsLoaded = escalus_rpc:call(Node, gen_mod, is_loaded, [Domain, Mod], 5000, Cookie),
     case IsLoaded of
         true -> unsafe_stop(Node, Cookie, Domain, Mod);
         false -> {error, stopped}
     end.
 
 unsafe_stop(Node, Cookie, Domain, Mod) ->
-    case escalus_ct:rpc_call(Node, gen_mod, stop_module, [Domain, Mod], 5000, Cookie) of
+    case escalus_rpc:call(Node, gen_mod, stop_module, [Domain, Mod], 5000, Cookie) of
         {badrpc, Reason} ->
             ct:fail("Cannot stop module ~p reason ~p", [Mod, Reason]);
         R -> R
@@ -62,7 +62,7 @@ start(Domain, Mod, Args) ->
 
 start(Node, Domain, Mod, Args) ->
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    case escalus_ct:rpc_call(Node, gen_mod, start_module, [Domain, Mod, Args], 5000, Cookie) of
+    case escalus_rpc:call(Node, gen_mod, start_module, [Domain, Mod, Args], 5000, Cookie) of
         {badrpc, Reason} ->
             ct:fail("Cannot start module ~p reason ~p", [Mod, Reason]);
         R -> R

--- a/big_tests/tests/ejabberd_node_utils.erl
+++ b/big_tests/tests/ejabberd_node_utils.erl
@@ -26,7 +26,7 @@
     backup_config_file/1, backup_config_file/2,
     restore_config_file/1, restore_config_file/2,
     modify_config_file/2, modify_config_file/4,
-    get_cwd/2, mim/0, mim2/0, mim3/0, fed/0]).
+    get_cwd/2]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -182,23 +182,6 @@ modify_config_file(Node, VarsFile, CfgVarsToChange, Config) ->
 get_cwd(Node, Config) ->
     cwd(Node, Config).
 
-%% MongooseIM node names
--spec mim() -> node() | no_return().
-mim() ->
-    get_or_fail({hosts, mim, node}).
-
--spec mim2() -> node() | no_return().
-mim2() ->
-    get_or_fail({hosts, mim2, node}).
-
--spec mim3() -> node() | no_return().
-mim3() ->
-    get_or_fail({hosts, mim3, node}).
-
--spec fed() -> node() | no_return().
-fed() ->
-    get_or_fail({hosts, fed, node}).
-
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
@@ -211,8 +194,3 @@ update_config_variables(CfgVarsToChange, CfgVars) ->
     lists:foldl(fun({Var, Val}, Acc) ->
                         lists:keystore(Var, 1, Acc,{Var, Val})
                 end, CfgVars, CfgVarsToChange).
-
-get_or_fail(Key) ->
-    Val = ct:get_config(Key),
-    Val == undefined andalso error({undefined, Key}),
-    Val.

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1149,10 +1149,10 @@ match_roster(ItemsValid, Items) ->
     ItemsTokens = [ string:tokens(ItemToken, "\t") || ItemToken <- string:tokens(Items, "\n") ],
 
     true = (length(ItemsValid) == length(ItemsTokens)),
-    true = lists:all(fun({Username, Domain, Nick, Group, Sub}) ->
+    true = lists:all(fun({Username, Domain, _Nick, _Group, _Sub}) ->
                     JID = escalus_utils:jid_to_lower(<<Username/binary, "@", Domain/binary >>),
                     lists:any(fun
-                                ([RosterJID, Nick, Sub, "none", Group]) ->
+                                ([RosterJID, __Nick, __Sub, "none", __Group]) ->
                                     JID =:= escalus_utils:jid_to_lower(list_to_binary(RosterJID));
                                 (_) ->
                                     false

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1149,10 +1149,10 @@ match_roster(ItemsValid, Items) ->
     ItemsTokens = [ string:tokens(ItemToken, "\t") || ItemToken <- string:tokens(Items, "\n") ],
 
     true = (length(ItemsValid) == length(ItemsTokens)),
-    true = lists:all(fun({Username, Domain, _Nick, _Group, _Sub}) ->
+    true = lists:all(fun({Username, Domain, Nick, Group, Sub}) ->
                     JID = escalus_utils:jid_to_lower(<<Username/binary, "@", Domain/binary >>),
                     lists:any(fun
-                                ([RosterJID, __Nick, __Sub, "none", __Group]) ->
+                                ([RosterJID, Nick, Sub, "none", Group]) ->
                                     JID =:= escalus_utils:jid_to_lower(list_to_binary(RosterJID));
                                 (_) ->
                                     false

--- a/big_tests/tests/jingle_SUITE.erl
+++ b/big_tests/tests/jingle_SUITE.erl
@@ -5,7 +5,10 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--import(ejabberd_node_utils, [mim/0, mim2/0]).
+-import(distributed_helper, [mim/0, mim2/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -36,14 +39,14 @@ test_cases() ->
     ].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    case escalus_ejabberd:rpc(application, get_application, [nksip]) of
+    case rpc(mim(), application, get_application, [nksip]) of
         {ok, nksip} ->
             Port = 12345,
             Host = ct:get_config({hosts, mim, domain}),
@@ -75,7 +78,7 @@ end_per_suite(Config) ->
     distributed_helper:remove_node_from_cluster(mim2(), Config),
     escalus:end_per_suite(Config).
 
-init_per_group(GroupName, Config) ->
+init_per_group(_GroupName, Config) ->
     Config.
 
 end_per_group(_GroupName, Config) ->

--- a/big_tests/tests/ldap_helper.erl
+++ b/big_tests/tests/ldap_helper.erl
@@ -27,6 +27,9 @@
          create_users/2,
          delete_users/2]).
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 -type user_spec() :: escalus_users:user_spec().
 
 -spec start(any()) -> ok.
@@ -49,7 +52,7 @@ delete_users(Config, Users) ->
 
 create_user({_User, Spec}) ->
     {User, Server, Password} = get_usp(Spec),
-    {ok, State} = escalus_ejabberd:rpc(eldap_utils, get_state, [Server, ejabberd_auth_ldap]),
+    {ok, State} = rpc(mim(), eldap_utils, get_state, [Server, ejabberd_auth_ldap]),
     UserStr=binary_to_list(User),
     DN = "cn=" ++ UserStr ++ "," ++ binary_to_list(State#state.base),
     Attrs = [{"objectclass", ["inetOrgPerson"]},
@@ -58,11 +61,11 @@ create_user({_User, Spec}) ->
              {"userPassword", [binary_to_list(Password)]},
              {"ou", ["shared_group"]},
              {"uid", [UserStr]}],
-    escalus_ejabberd:rpc(eldap_pool, add, [State#state.eldap_id, DN, Attrs]).
+    rpc(mim(), eldap_pool, add, [State#state.eldap_id, DN, Attrs]).
 
 delete_user({_Name, Spec}) ->
     {User, Server, _Password} = get_usp(Spec),
-    escalus_ejabberd:rpc(ejabberd_auth_ldap, remove_user, [User, Server]).
+    rpc(mim(), ejabberd_auth_ldap, remove_user, [User, Server]).
 
 get_usp(Spec) ->
     Username = proplists:get_value(username, Spec),

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -25,6 +25,9 @@
 
 -include_lib("exml/include/exml.hrl").
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -79,7 +82,7 @@ all_tests() ->
     ].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -217,7 +220,7 @@ register(Config) ->
     [Username2, _Server2, _Pass2] = escalus_users:get_usp(Config, UserSpec2),
     [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
 
-    escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+    distributed_helper:rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
 
     escalus:story(Config, [{admin, 1}], fun(Admin) ->
             escalus:create_users(Config, escalus:get_users([Name1, Name2])),

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -26,7 +26,8 @@
 -include_lib("exml/include/exml.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1]).
+                             require_rpc_nodes/1,
+                             rpc/4]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -89,7 +90,7 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-     escalus:init_per_suite(Config).
+    escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
@@ -125,14 +126,14 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(register, Config) ->
     escalus:delete_users(Config, escalus:get_users([admin, alice, bob]));
-end_per_group(change_account_details, Config) ->
+end_per_group(change_account_details, _Config) ->
     ok;
 end_per_group(bad_registration, _Config) ->
     ok;
 end_per_group(bad_cancelation, _Config) ->
     ok;
 end_per_group(registration_timeout, Config) ->
-    Config1 = restore_registration_timeout(Config);
+    restore_registration_timeout(Config);
 end_per_group(login_scram, Config) ->
     set_store_password(plain),
     escalus:delete_users(Config, escalus:get_users([alice, bob]));
@@ -171,7 +172,7 @@ init_per_testcase(registration_failure_timeout, Config) ->
     escalus:init_per_testcase(registration_failure_timeout, Config);
 init_per_testcase(message_zlib_limit, Config) ->
     Listeners = [Listener
-                 || {Listener, _, _} <- escalus_ejabberd:rpc(ejabberd_config, get_local_option, [listen])],
+                 || {Listener, _, _} <- rpc(mim(), ejabberd_config, get_local_option, [listen])],
     [{_U, Props}] = escalus_users:get_users([hacker]),
     Port = proplists:get_value(port, Props),
     case lists:keymember(Port, 1, Listeners) of
@@ -187,7 +188,7 @@ init_per_testcase(CaseName, Config) ->
 end_per_testcase(change_password, Config) ->
     [{alice, Details}] = escalus_users:get_users([alice]),
     Alice = {alice, lists:keyreplace(password, 1, Details, {password, strong_pwd()})},
-    {ok, result, Response} = escalus_users:delete_user(Config, Alice);
+    {ok, result, _Response} = escalus_users:delete_user(Config, Alice);
 end_per_testcase(change_password_to_null, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice]));
 end_per_testcase(message_zlib_limit, Config) ->
@@ -203,7 +204,7 @@ end_per_testcase(not_allowed_registration_cancelation, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice]));
 end_per_testcase(registration_timeout, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob]));
-end_per_testcase(registration_failure_timeout, Config) ->
+end_per_testcase(registration_failure_timeout, _Config) ->
     ok = allow_everyone_registration();
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
@@ -266,13 +267,13 @@ null_password(Config) ->
     {username, Name} = lists:keyfind(username, 1, Details),
     {server, Server} = lists:keyfind(server, 1, Details),
     escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Response),
-    false = escalus_ejabberd:rpc(ejabberd_auth, is_user_exists, [Name, Server]).
+    false = rpc(mim(), ejabberd_auth, is_user_exists, [Name, Server]).
 
 check_unregistered(Config) ->
     escalus:delete_users(Config, escalus:get_users([admin, alice, bob])),
     [{_, UserSpec}| _] = escalus_users:get_users(all),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),
-    false = escalus_ejabberd:rpc(ejabberd_auth, is_user_exists, [Username, Server]).
+    false = rpc(mim(), ejabberd_auth, is_user_exists, [Username, Server]).
 
 bad_request_registration_cancelation(Config) ->
 
@@ -532,15 +533,14 @@ strong_pwd() ->
 
 set_registration_timeout(Config) ->
     Record = {local_config, registration_timeout, ?REGISTRATION_TIMEOUT},
-    OldTimeout = escalus_ejabberd:rpc(ejabberd_config, get_local_option,
-                                      [registration_timeout]),
-    true = escalus_ejabberd:rpc(ets, insert, [local_config, Record]),
+    OldTimeout = rpc(mim(), ejabberd_config, get_local_option, [registration_timeout]),
+    true = rpc(mim(), ets, insert, [local_config, Record]),
     [ {old_timeout, OldTimeout} | Config ].
 
 restore_registration_timeout(Config) ->
     {old_timeout, OldTimeout} = proplists:lookup(old_timeout, Config),
     Record = {local_config, registration_timeout, OldTimeout},
-    true = escalus_ejabberd:rpc(ets, insert, [local_config, Record]),
+    true = rpc(mim(), ets, insert, [local_config, Record]),
     proplists:delete(old_timeout, Config).
 
 deny_everyone_registration() ->
@@ -551,8 +551,8 @@ allow_everyone_registration() ->
 
 change_registration_settings_for_everyone(Rule)
   when allow =:= Rule; deny =:= Rule ->
-    {atomic,ok} = escalus_ejabberd:rpc(ejabberd_config, add_global_option,
-        [{access, register, global}, [{Rule, all}]]),
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option,
+                      [{access, register, global}, [{Rule, all}]]),
     ok.
 
 get_client_details(Identifier) ->
@@ -564,17 +564,14 @@ get_client_details(Identifier) ->
 get_store_type() ->
     XMPPDomain = escalus_ejabberd:unify_str_arg(
                    ct:get_config({hosts, mim, domain})),
-    escalus_ejabberd:rpc(ejabberd_auth, store_type,
-                         [XMPPDomain]).
+    rpc(mim(), ejabberd_auth, store_type, [XMPPDomain]).
 
 set_store_password(Type) ->
     XMPPDomain = escalus_ejabberd:unify_str_arg(
                    ct:get_config({hosts, mim, domain})),
-    AuthOpts = escalus_ejabberd:rpc(ejabberd_config, get_local_option,
-                                    [{auth_opts, XMPPDomain}]),
+    AuthOpts = rpc(mim(), ejabberd_config, get_local_option, [{auth_opts, XMPPDomain}]),
     NewAuthOpts = lists:keystore(password_format, 1, AuthOpts, {password_format, Type}),
-    escalus_ejabberd:rpc(ejabberd_config, add_local_option,
-                         [{auth_opts, XMPPDomain}, NewAuthOpts]).
+    rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, XMPPDomain}, NewAuthOpts]).
 
 
 
@@ -593,7 +590,7 @@ verify_format(GroupName, {_User, Props}) ->
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
 
-    SPassword = escalus_ejabberd:rpc(ejabberd_auth, get_password, [Username, Server]),
+    SPassword = rpc(mim(), ejabberd_auth, get_password, [Username, Server]),
     do_verify_format(GroupName, Password, SPassword).
 
 do_verify_format(login_scram, _Password, SPassword) ->
@@ -616,7 +613,7 @@ bad_cancelation_stanza() ->
 
 restart_mod_register_with_option(Config, Name, Value) ->
     Domain = ct:get_config({hosts, mim, domain}),
-    ModuleOptions = escalus_ejabberd:rpc(gen_mod, loaded_modules_with_opts, [Domain]),
+    ModuleOptions = rpc(mim(), gen_mod, loaded_modules_with_opts, [Domain]),
     {mod_register, OldRegisterOptions} = lists:keyfind(mod_register, 1, ModuleOptions),
     ok = dynamic_modules:stop(Domain, mod_register),
     NewRegisterOptions = lists:keystore(Name, 1, OldRegisterOptions, Value),
@@ -634,7 +631,7 @@ restore_mod_register_options(Config0) ->
 user_exists(Name, Config) ->
     {Name, Client} = escalus_users:get_user_by_name(Name),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, Client),
-    escalus_ejabberd:rpc(ejabberd_auth, is_user_exists, [Username, Server]).
+    rpc(mim(), ejabberd_auth, is_user_exists, [Username, Server]).
 
 string(<<_/binary>> = Subject) ->
     erlang:binary_to_list(Subject).
@@ -650,4 +647,4 @@ modify_acl_for_blocking(Method, Spec) ->
     Domain = ct:get_config({hosts, mim, domain}),
     User = proplists:get_value(username, Spec),
     Lower = escalus_utils:jid_to_lower(User),
-    escalus_ejabberd:rpc(acl, Method, [Domain, blocked, {user, Lower}]).
+    rpc(mim(), acl, Method, [Domain, blocked, {user, Lower}]).

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -93,11 +93,11 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(register, Config) ->
-    [{escalus_user_db, xmpp} | skip_if_mod_register_not_enabled(Config)];
+    skip_if_mod_register_not_enabled([{escalus_user_db, xmpp} | Config]);
 init_per_group(bad_registration, Config) ->
     [{escalus_user_db, xmpp} | Config];
 init_per_group(bad_cancelation, Config) ->
-    [{escalus_user_db, xmpp} | skip_if_mod_register_not_enabled(Config)];
+    skip_if_mod_register_not_enabled([{escalus_user_db, xmpp} | Config]);
 init_per_group(registration_timeout, Config) ->
     case escalus_users:is_mod_register_enabled(Config) of
         true ->

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -221,7 +221,7 @@ register(Config) ->
     [Username2, _Server2, _Pass2] = escalus_users:get_usp(Config, UserSpec2),
     [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
 
-    distributed_helper:rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+    rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
 
     escalus:story(Config, [{admin, 1}], fun(Admin) ->
             escalus:create_users(Config, escalus:get_users([Name1, Name2])),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1827,7 +1827,7 @@ offline_message(Config) ->
 
     %% Bob checks his archive.
     escalus:send(Bob, stanza_archive_request(P, <<"q1">>)),
-    ArcMsgs = R = respond_messages(wait_archive_respond(P, Bob)),
+    ArcMsgs = respond_messages(wait_archive_respond(P, Bob)),
     assert_only_one_of_many_is_equal(ArcMsgs, Msg),
 
     escalus_client:stop(Config, Bob).
@@ -1844,7 +1844,7 @@ nostore_hint(Config) ->
 
         %% Bob checks his archive.
         escalus:send(Bob, stanza_archive_request(P, <<"q1">>)),
-        ArcMsgs = R = respond_messages(wait_archive_respond(P, Bob)),
+        ArcMsgs = respond_messages(wait_archive_respond(P, Bob)),
         assert_not_stored(ArcMsgs, Msg),
         ok
         end,
@@ -2019,7 +2019,7 @@ muc_archive_request(Config) ->
 %% Copied from 'muc_archive_reuest' test in case to show some bug in mod_mam_muc related to
 %% issue #512
 muc_archive_purge(Config) ->
-    P = ?config(props, Config),
+    _P = ?config(props, Config),
     F = fun(Alice, Bob) ->
         Room = ?config(room, Config),
         RoomAddr = room_address(Room),
@@ -2184,9 +2184,9 @@ muc_deny_protected_room_access(Config) ->
 %% @doc Allow access to non-in-room users who able to connect
 muc_allow_access_to_owner(Config) ->
     P = ?config(props, Config),
-    F = fun(Alice, Bob) ->
+    F = fun(Alice, _Bob) ->
         Room = ?config(room, Config),
-        RoomAddr = room_address(Room),
+        _RoomAddr = room_address(Room),
 
         %% Alice (not in room) requests the room's archive.
         escalus:send(Alice, stanza_to_room(stanza_archive_request(P, <<"q1">>), Room)),
@@ -2829,7 +2829,7 @@ after_complete_true_after11(Config) ->
 %% ------------------------------------------------------------------
 
 prefs_set_request(Config) ->
-    P = ?config(props, Config),
+    _P = ?config(props, Config),
     F = fun(Alice) ->
         %% Send
         %%
@@ -2879,7 +2879,7 @@ query_get_request(Config) ->
 %% without whitespaces. In the real world it is not true.
 %% Put "\n" between two jid elements.
 prefs_set_cdata_request(Config) ->
-    P = ?config(props, Config),
+    _P = ?config(props, Config),
     F = fun(Alice) ->
         %% Send
         %%
@@ -2909,7 +2909,7 @@ prefs_set_cdata_request(Config) ->
     escalus_fresh:story(Config, [{alice, 1}], F).
 
 mam_service_discovery(Config) ->
-    P = ?config(props, Config),
+    _P = ?config(props, Config),
     F = fun(Alice) ->
         Server = escalus_client:server(Alice),
         escalus:send(Alice, escalus_stanza:disco_info(Server)),
@@ -2928,7 +2928,7 @@ mam_service_discovery(Config) ->
 
 %% Check, that MUC is supported.
 muc_service_discovery(Config) ->
-    P = ?config(props, Config),
+    _P = ?config(props, Config),
     F = fun(Alice) ->
         Domain = ct:get_config({hosts, mim, domain}),
         Server = escalus_client:server(Alice),
@@ -3001,7 +3001,7 @@ run_prefs_cases(DefaultPolicy, ConfigIn) ->
 
 %% The same as prefs_set_request case but for different configurations
 run_set_and_get_prefs_cases(ConfigIn) ->
-    P = ?config(props, ConfigIn),
+    _P = ?config(props, ConfigIn),
     F = fun(Config, Alice, _Bob, _Kate) ->
         Namespace = mam_ns_binary_v04(),
         [run_set_and_get_prefs_case(Case, Namespace, Alice, Config) || Case <- prefs_cases2()]

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -14,6 +14,7 @@
 %% limitations under the License.
 %%==============================================================================
 -module(mam_SUITE).
+
 %% CT callbacks
 -export([all/0,
          groups/0,
@@ -116,6 +117,10 @@
          dont_archive_chat_markers/1,
          save_unicode_messages/1,
          unicode_messages_can_be_extracted/1]).
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
 
 -import(muc_helper,
         [muc_host/0,
@@ -484,7 +489,7 @@ impl_specific() ->
   [check_user_exist].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 init_per_suite(Config) ->
     muc_helper:load_muc(muc_host()),
@@ -996,10 +1001,8 @@ init_per_testcase(C=muc_text_search_request, Config) ->
 
     skip_if_cassandra(Config, Init);
 init_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config) ->
-    OrigVal = escalus_ejabberd:rpc(gen_mod, get_module_opt,
-                                   [host(), mod_mam, archive_groupchats, false]),
-    true = escalus_ejabberd:rpc(gen_mod, set_module_opt,
-                                [host(), mod_mam, archive_groupchats, true]),
+    OrigVal = rpc(mim(), gen_mod, get_module_opt, [host(), mod_mam, archive_groupchats, false]),
+    true = rpc(mim(), gen_mod, set_module_opt, [host(), mod_mam, archive_groupchats, true]),
     clean_archives(Config),
     escalus:init_per_testcase(C, [{archive_groupchats_backup, OrigVal} | Config]);
 init_per_testcase(C=archive_chat_markers, Config) ->
@@ -1084,8 +1087,7 @@ end_per_testcase(C=muc_only_archived, Config) ->
     escalus:end_per_testcase(C, Config);
 end_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config0) ->
     {value, {_, OrigVal}, Config1} = lists:keytake(archive_groupchats_backup, 1, Config0),
-    true = escalus_ejabberd:rpc(gen_mod, set_module_opt,
-                                [host(), mod_mam, archive_groupchats, OrigVal]),
+    true = rpc(mim(), gen_mod, set_module_opt, [host(), mod_mam, archive_groupchats, OrigVal]),
     escalus:end_per_testcase(C, Config1);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
@@ -3011,13 +3013,13 @@ check_user_exist(Config) ->
   %% when
   [{_, AdminSpec}] = escalus_users:get_users([admin]),
   [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
-  #{} = escalus_ejabberd:rpc(ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+  #{} = rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
   %% admin user already registered
-  true = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, AdminS]),
-  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
-  false = escalus_ejabberd:rpc(ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
+  true = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, AdminS]),
+  false = rpc(mim(), ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
+  false = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
   %% cleanup
-  ok = escalus_ejabberd:rpc(ejabberd_auth, remove_user, [AdminU, AdminS]).
+  ok = rpc(mim(), ejabberd_auth, remove_user, [AdminU, AdminS]).
 
 parallel_story(Config, ResourceCounts, F) ->
     Config1 = override_for_parallel(Config),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1704,13 +1704,13 @@ message_with_stanzaid_and_archived(Config) ->
         IdStanzaid  = exml_query:attr(ArcStanzaid, <<"id">>),
 
         %% The attributes of <stanza-id/> and <archived/> are the same
-	?assert_equal(ByArchived, ByStanzaid),
-	?assert_equal(IdArchived, IdStanzaid),
+        ?assert_equal(ByArchived, ByStanzaid),
+        ?assert_equal(IdArchived, IdStanzaid),
 
-	%% stanza-id has a namespace 'urn:xmpp:sid:0'
-	<<"urn:xmpp:sid:0">> = exml_query:attr(ArcStanzaid, <<"xmlns">>),
-	ok
-	end,
+        %% stanza-id has a namespace 'urn:xmpp:sid:0'
+        <<"urn:xmpp:sid:0">> = exml_query:attr(ArcStanzaid, <<"xmlns">>),
+        ok
+    end,
     escalus:story(Config, [{alice, 1}, {bob, 1}], F).
 
 
@@ -1951,9 +1951,9 @@ muc_message_with_archived_and_stanzaid(Config) ->
         ?assert_equal(ByArchived, ByStanzaid),
         ?assert_equal(IdArchived, IdStanzaid),
 
-	%% stanza-id has a namespace 'urn:xmpp:sid:0'
-	Xmlns = exml_query:attr(ArcStanzaid, <<"xmlns">>),
-	?assert_equal(Xmlns, <<"urn:xmpp:sid:0">>),
+        %% stanza-id has a namespace 'urn:xmpp:sid:0'
+        Xmlns = exml_query:attr(ArcStanzaid, <<"xmlns">>),
+        ?assert_equal(Xmlns, <<"urn:xmpp:sid:0">>),
         ok
         end,
     escalus:story(Config, [{alice, 1}, {bob, 1}], F).

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -953,7 +953,6 @@ parse_messages(Messages) ->
 
 bootstrap_archive(Config) ->
     random:seed(os:timestamp()),
-    _Users = escalus_ct:get_config(escalus_users),
     AliceJID    = escalus_users:get_jid(Config, alice),
     BobJID      = escalus_users:get_jid(Config, bob),
     CarolJID    = escalus_users:get_jid(Config, carol),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -44,7 +44,7 @@ rpc_apply(M, F, Args) ->
 rpc_call(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    escalus_ct:rpc_call(Node, M, F, A, 10000, Cookie).
+    escalus_rpc:call(Node, M, F, A, 10000, Cookie).
 
 mam03_props() ->
     [{data_form, true},                 %% send data forms

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -25,6 +25,9 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml_stream.hrl").
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 -import(muc_helper,
         [muc_host/0,
          room_address/1, room_address/2,
@@ -1141,7 +1144,7 @@ is_mam_possible(Host) ->
     is_cassandra_enabled(Host).
 
 is_riak_enabled(_Host) ->
-    case escalus_ejabberd:rpc(mongoose_riak, get_worker, []) of
+    case rpc(mim(), mongoose_riak, get_worker, []) of
         Pid when is_pid(Pid) ->
             true;
         _ ->
@@ -1149,7 +1152,7 @@ is_riak_enabled(_Host) ->
     end.
 
 is_cassandra_enabled(_) ->
-    case escalus_ejabberd:rpc(mongoose_cassandra_sup, get_all_workers, []) of
+    case rpc(mim(), mongoose_cassandra_sup, get_all_workers, []) of
         [_|_]=_Pools ->
             true;
         _ ->
@@ -1157,7 +1160,7 @@ is_cassandra_enabled(_) ->
     end.
 
 sql_transaction(Host, F) ->
-    escalus_ejabberd:rpc(mongoose_rdbms, sql_transaction, [Host, F]).
+    rpc(mim(), mongoose_rdbms, sql_transaction, [Host, F]).
 
 login_send_presence(Config, User) ->
     Spec = escalus_users:get_userspec(Config, User),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -953,7 +953,7 @@ parse_messages(Messages) ->
 
 bootstrap_archive(Config) ->
     random:seed(os:timestamp()),
-    Users = escalus_ct:get_config(escalus_users),
+    _Users = escalus_ct:get_config(escalus_users),
     AliceJID    = escalus_users:get_jid(Config, alice),
     BobJID      = escalus_users:get_jid(Config, bob),
     CarolJID    = escalus_users:get_jid(Config, carol),
@@ -1064,7 +1064,6 @@ muc_bootstrap_archive(Config) ->
     BobServer   = escalus_users:get_server(Config, bob),
 
     Domain = muc_host(),
-    Host = host(),
     RoomJid = make_jid(Room, Domain, <<>>),
     ArcJID = {R, RoomJid,
               rpc_apply(mod_mam_muc, archive_id, [Domain, Room])},

--- a/big_tests/tests/metrics_helper.erl
+++ b/big_tests/tests/metrics_helper.erl
@@ -4,6 +4,9 @@
 
 -compile(export_all).
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 %% We introduce a convention, where metrics-related suites use only 2 accounts
 %% but it depends on `all_metrics_are_global` flag, which duet it will be.
 -define(METRICS_GROUP_USERS, [alice, bob]).
@@ -13,7 +16,7 @@ get_counter_value(CounterName) ->
     get_counter_value(ct:get_config({hosts, mim, domain}), CounterName).
 
 get_counter_value(Host, Metric) ->
-    case escalus_ejabberd:rpc(mongoose_metrics, get_metric_value, [Host, Metric]) of
+    case rpc(mim(), mongoose_metrics, get_metric_value, [Host, Metric]) of
         {ok, [{count, Total}, {one, _}]} ->
             {value, Total};
         {ok, [{value, Value} | _]} when is_integer(Value) ->

--- a/big_tests/tests/metrics_helper.erl
+++ b/big_tests/tests/metrics_helper.erl
@@ -4,7 +4,7 @@
 
 -compile(export_all).
 
--import(distributed_helper, [mim/0,
+-import(distributed_helper, [mim/0, mim2/0,
                              rpc/4]).
 
 %% We introduce a convention, where metrics-related suites use only 2 accounts
@@ -40,7 +40,7 @@ prepare_by_all_metrics_are_global(Config, false) ->
 prepare_by_all_metrics_are_global(Config, true) ->
     Config1 = [{all_metrics_are_global, true} | Config],
     %% TODO: Refactor once escalus becomes compatible with multiple nodes RPC
-    Config2 = distributed_helper:add_node_to_cluster(ejabberd_node_utils:mim2(), Config1),
+    Config2 = distributed_helper:add_node_to_cluster(mim2(), Config1),
     escalus:create_users(Config2, escalus:get_users(?ONLY_GLOBAL_METRICS_GROUP_USERS)).
 
 -spec finalise_by_all_metrics_are_global(Config :: list(), UseAllMetricsAreGlobal :: boolean()) ->
@@ -50,8 +50,7 @@ finalise_by_all_metrics_are_global(Config, false) ->
 finalise_by_all_metrics_are_global(Config, true) ->
     Config1 = lists:keydelete(all_metrics_are_global, 1, Config),
     %% TODO: Refactor once escalus becomes compatible with multiple nodes RPC
-    distributed_helper:remove_node_from_cluster(ejabberd_node_utils:mim2(),
-                                                Config1),
+    distributed_helper:remove_node_from_cluster(mim2(), Config1),
     escalus:delete_users(Config1,
                          escalus:get_users(?ONLY_GLOBAL_METRICS_GROUP_USERS)).
 

--- a/big_tests/tests/metrics_register_SUITE.erl
+++ b/big_tests/tests/metrics_register_SUITE.erl
@@ -23,8 +23,12 @@
 -define(WAIT_TIME, 500).
 -define(RT_WAIT_TIME, 60000).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 -import(metrics_helper, [assert_counter/2,
-                      get_counter_value/1]).
+                         get_counter_value/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -38,7 +42,7 @@ groups() ->
                                  unregister]}].
 
 suite() ->
-    [{require, ejabberd_node} | escalus:suite()].
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -62,8 +66,7 @@ init_per_testcase(unregister, Config) ->
     Config;
 init_per_testcase(registered_users, Config) ->
     XMPPDomain = ct:get_config({hosts, mim, domain}),
-    case escalus_ejabberd:rpc(ejabberd_config, get_local_option,
-                              [{auth_method, XMPPDomain}]) of
+    case rpc(mim(), ejabberd_config, get_local_option, [{auth_method, XMPPDomain}]) of
         external ->
             {skip, "counter not supported with ejabberd_auth_external"};
         anonymous ->

--- a/big_tests/tests/metrics_roster_SUITE.erl
+++ b/big_tests/tests/metrics_roster_SUITE.erl
@@ -20,9 +20,12 @@
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
 
 -import(metrics_helper, [assert_counter/2,
-                      get_counter_value/1]).
+                         get_counter_value/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -39,7 +42,7 @@ groups() ->
     ].
 
 suite() ->
-    [{required, ejabberd_node} | escalus:suite()].
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 roster_tests() -> [get_roster,
                    add_contact,
@@ -293,8 +296,8 @@ add_sample_contact(Alice, Bob, Groups, Name) ->
 
 remove_roster(Config, UserSpec) ->
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),
-    escalus_ejabberd:rpc(mod_roster_odbc, remove_user, [Username, Server]),
-    escalus_ejabberd:rpc(mod_roster, remove_user, [Username, Server]).
+    rpc(mim(), mod_roster_odbc, remove_user, [Username, Server]),
+    rpc(mim(), mod_roster, remove_user, [Username, Server]).
 
 mongoose_metrics(ConfigIn, Metrics) ->
     Predefined = proplists:get_value(mongoose_metrics, ConfigIn, []),
@@ -302,4 +305,4 @@ mongoose_metrics(ConfigIn, Metrics) ->
     [{mongoose_metrics, MongooseMetrics} | ConfigIn].
 
 roster_odbc_precondition() ->
-    mod_roster_odbc == escalus_ejabberd:rpc(mod_roster_backend, backend, []).
+    mod_roster_odbc == rpc(mim(), mod_roster_backend, backend, []).

--- a/big_tests/tests/mod_aws_sns_SUITE.erl
+++ b/big_tests/tests/mod_aws_sns_SUITE.erl
@@ -273,7 +273,7 @@ start_publish_listener(Config) ->
 rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    escalus_ct:rpc_call(Node, M, F, A, 10000, Cookie).
+    escalus_rpc:call(Node, M, F, A, 10000, Cookie).
 
 make_topic_arn(Config, TopicVar) ->
     SNSConfig = proplists:get_value(sns_config, Config),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -123,7 +123,7 @@ init_per_suite(Config) ->
     end.
 
 end_per_suite(Config) ->
-    rpc(europe_node2, mongoose_cluster, leave, [ct:get_config(europe_node1)]),
+    rpc(europe_node2, mongoose_cluster, leave, []),
     escalus:end_per_suite(Config).
 
 init_per_group(start_checks, Config) ->

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -153,17 +153,17 @@ init_per_group(_, Config0) ->
     Config2 =
         lists:foldl(
           fun({NodeName, LocalHost, ReceiverPort}, Config1) ->
-                  Opts0 = ?config(extra_config, Config1) ++
-		         [{local_host, LocalHost},
-                          {hosts_refresh_interval, ?HOSTS_REFRESH_INTERVAL},
-                          {global_host, "localhost"},
-                          {endpoints, [listen_endpoint(ReceiverPort)]},
-                          {tls_opts, [
-                                      {certfile, ?config(certfile, Config1)},
-                                      {cafile, ?config(cafile, Config1)}
-                                     ]},
-                          {redis, [{port, 6379} | ?config(redis_extra_config, Config1)]},
-                          {resend_after_ms, 500}],
+                  Opts0 = (?config(extra_config, Config1) ++
+                           [{local_host, LocalHost},
+                            {hosts_refresh_interval, ?HOSTS_REFRESH_INTERVAL},
+                            {global_host, "localhost"},
+                            {endpoints, [listen_endpoint(ReceiverPort)]},
+                            {tls_opts, [
+                                        {certfile, ?config(certfile, Config1)},
+                                        {cafile, ?config(cafile, Config1)}
+                                       ]},
+                            {redis, [{port, 6379} | ?config(redis_extra_config, Config1)]},
+                            {resend_after_ms, 500}]),
                   Opts = maybe_add_advertised_endpoints(NodeName, Opts0, Config1),
 
                   OldMods = rpc(NodeName, gen_mod, loaded_modules_with_opts, [<<"localhost">>]),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -882,7 +882,7 @@ listen_endpoint(Port) ->
 rpc(NodeName, M, F, A) ->
     Node = ct:get_config(NodeName),
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    escalus_ct:rpc_call(Node, M, F, A, timer:seconds(30), Cookie).
+    escalus_rpc:call(Node, M, F, A, timer:seconds(30), Cookie).
 
 hide_node(NodeName, Config) ->
     NodesKey = ?config(nodes_key, Config),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -830,7 +830,11 @@ wait_for_connection(Config) ->
     set_endpoints(asia_node, []),
     %% Because of hosts refresher, a pool of connections to asia_node
     %% may already be present here
-    trigger_rebalance(europe_node1, <<"reg1">>),
+    wait_for(rebalance,
+             fun () ->
+                 try trigger_rebalance(europe_node1, <<"reg1">>), true
+                 catch _:_ -> false end
+             end),
 
     spawn_connection_getter(europe_node1),
 
@@ -1083,3 +1087,16 @@ refresh_mappings(NodeName, Config) ->
 trigger_rebalance(NodeName, DestinationDomain) ->
     rpc(NodeName, mod_global_distrib_server_mgr, force_refresh, [DestinationDomain]),
     timer:sleep(1000).
+
+wait_for(Label, Pred) ->
+    wait_for(Label, Pred, timer:seconds(5)).
+
+wait_for(Label, _Pred, RemainingTime) when RemainingTime =< 0 ->
+    error({timeout, Label});
+wait_for(Label, Pred, RemainingTime) ->
+    case Pred() of
+        true -> ok;
+        false ->
+            timer:sleep(100),
+            wait_for(Label, Pred, RemainingTime - 100)
+    end.

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -640,8 +640,9 @@ test_component_unregister(_Config) ->
 
 test_error_on_wrong_hosts(_Config) ->
     Opts = [{cookie, "cookie"}, {local_host, "no_such_host"}, {global_host, "localhost"}],
-    Result = rpc(europe_node1, gen_mod, start_module, [<<"localhost">>, mod_global_distrib, Opts]),
-    ?assertMatch({badrpc, {'EXIT', {"no_such_host is not a member of the host list", _}}}, Result).
+    ?assertException(error, {badrpc, {'EXIT', {"no_such_host is not a member of the host list", _}}},
+                     rpc(europe_node1, gen_mod, start_module,
+                         [<<"localhost">>, mod_global_distrib, Opts])).
 
 refresh_nodes(Config) ->
     NodesKey = ?config(nodes_key, Config),

--- a/big_tests/tests/mod_http_notification_SUITE.erl
+++ b/big_tests/tests/mod_http_notification_SUITE.erl
@@ -14,6 +14,9 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
 
 %%%===================================================================
 %%% Suite configuration
@@ -32,9 +35,8 @@ groups() ->
     [{mod_http_notification_tests, [sequence], all_tests()},
         {mod_http_notification_tests_with_prefix, [sequence], all_tests()}].
 
-
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 set_worker(Config) ->
     set_modules(Config, [{worker_timeout, 500}, {host, "http://localhost:8000"}]).
@@ -119,7 +121,7 @@ proper_http_message_encode_decode(Config) ->
            after 5000 ->
                 ct:fail(http_request_timeout)
            end,
-    ExtractedAndDecoded = escalus_ejabberd:rpc(cow_qs, parse_qs,[Body]),
+    ExtractedAndDecoded = rpc(mim(), cow_qs, parse_qs, [Body]),
     ExpectedList = [{<<"author">>,<<Sender/binary>>},
         {<<"server">>,<<Server/binary>>},
         {<<"receiver">>,<<Receiver/binary>>},

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -216,7 +216,8 @@ ensure_muc_clean() ->
 stop_online_rooms() ->
     Host = ct:get_config({hosts, mim, domain}),
     Supervisor = rpc(mim(), gen_mod, get_module_proc, [Host, ejabberd_mod_muc_sup]),
-    rpc(mim(), erlang, exit, [Supervisor, kill]),
+    SupervisorPid = rpc(mim(), erlang, whereis, [Supervisor]),
+    rpc(mim(), erlang, exit, [SupervisorPid, kill]),
     rpc(mim(), mnesia, clear_table, [muc_online_room]),
     ok.
 

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -303,7 +303,8 @@ init_per_suite(Config) ->
     Config2 = escalus:init_per_suite(Config),
     Config3 = dynamic_modules:save_modules(domain(), Config2),
     load_muc(muc_host()),
-    mongoose_helper:ensure_muc_clean(), Config3.
+    mongoose_helper:ensure_muc_clean(),
+    Config3.
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -24,6 +24,9 @@
 -include_lib("exml/include/exml.hrl").
 -include("assert_received_match.hrl").
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 -import(muc_helper,
         [load_muc/1,
          unload_muc/0,
@@ -296,7 +299,7 @@ suite() ->
 init_per_suite(Config) ->
     %% For mocking with unnamed functions
     {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-    escalus_ejabberd:rpc(code, load_binary, [?MODULE, Filename, Binary]),
+    rpc(mim(), code, load_binary, [?MODULE, Filename, Binary]),
     Config2 = escalus:init_per_suite(Config),
     Config3 = dynamic_modules:save_modules(domain(), Config2),
     load_muc(muc_host()),
@@ -394,7 +397,7 @@ handle_http_auth(Req) ->
     cowboy_req:reply(200, Headers, Resp, Req).
 
 end_per_group(room_registration_race_condition, Config) ->
-    escalus_ejabberd:rpc(meck, unload, []),
+    rpc(mim(), meck, unload, []),
     escalus:delete_users(Config, escalus:get_users([bob, alice]));
 
 end_per_group(admin_membersonly, Config) ->
@@ -439,20 +442,20 @@ domain() ->
     ct:get_config({hosts, mim, domain}).
 
 init_per_testcase(CaseName = load_already_registered_permanent_rooms, Config) ->
-    ok = escalus_ejabberd:rpc(meck, new, [mod_muc_room, [no_link, passthrough]]),
+    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
     meck_room_start(),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName = create_already_registered_room, Config) ->
-    ok = escalus_ejabberd:rpc(meck, new, [mod_muc_room, [no_link, passthrough]]),
+    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
     meck_room_start(),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName = check_presence_route_to_offline_room, Config) ->
-    ok = escalus_ejabberd:rpc(meck, new, [mod_muc_room, [no_link, passthrough]]),
+    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
     meck_room_start(),
     meck_room_route(),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName = check_message_route_to_offline_room, Config) ->
-    ok = escalus_ejabberd:rpc(meck, new, [mod_muc_room, [no_link, passthrough]]),
+    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
     meck_room_start(),
     meck_room_route(),
     escalus:init_per_testcase(CaseName, Config);
@@ -509,7 +512,7 @@ init_per_testcase(CaseName, ConfigIn) ->
 
 %% Meck will register a fake room right before a 'real' room is started
 meck_room_start() ->
-    escalus_ejabberd:rpc(meck, expect, [mod_muc_room, start,
+    rpc(mim(), meck, expect, [mod_muc_room, start,
         fun(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Opts) ->
             mod_muc:register_room(Host, Room, ?FAKEPID),
             meck:passthrough([Host,
@@ -522,7 +525,7 @@ meck_room_start() ->
                 Opts])
         end]),
 
-    escalus_ejabberd:rpc(meck, expect, [mod_muc_room, start,
+    rpc(mim(), meck, expect, [mod_muc_room, start,
         fun(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool, Creator, Nick, DefRoomOpts) ->
 
             mod_muc:register_room(Host, Room, ?FAKEPID),
@@ -541,7 +544,7 @@ meck_room_start() ->
 %% Meck will forward all calls to route to the test case instead
 meck_room_route() ->
     TestCasePid = self(),
-    ok = escalus_ejabberd:rpc(meck, expect, [mod_muc_room, route,
+    ok = rpc(mim(), meck, expect, [mod_muc_room, route,
         fun(Pid, _From, _ToNick, _Acc, _Packet) ->
             TestCasePid ! Pid
         end]).
@@ -575,16 +578,16 @@ get_group_name(Config) ->
 %    escalus:end_per_testcase(CaseName, Config);
 
 end_per_testcase(CaseName = load_already_registered_permanent_rooms, Config) ->
-    escalus_ejabberd:rpc(meck, unload, []),
+    rpc(mim(), meck, unload, []),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName = create_already_registered_room, Config) ->
-    escalus_ejabberd:rpc(meck, unload, []),
+    rpc(mim(), meck, unload, []),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName = check_presence_route_to_offline_room, Config) ->
-    escalus_ejabberd:rpc(meck, unload, []),
+    rpc(mim(), meck, unload, []),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName = check_message_route_to_offline_room, Config) ->
-    escalus_ejabberd:rpc(meck, unload, []),
+    rpc(mim(), meck, unload, []),
     escalus:end_per_testcase(CaseName, Config);
 
 end_per_testcase(CaseName =send_non_anonymous_history, Config) ->
@@ -4064,11 +4067,11 @@ hibernation_metrics_are_updated(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         given_fresh_room_is_hibernated(Alice, RoomName, [{membersonly, false}]),
 
-        OnlineRooms = escalus_ejabberd:rpc(mod_muc, online_rooms_number, []),
+        OnlineRooms = rpc(mim(), mod_muc, online_rooms_number, []),
         true = OnlineRooms > 0,
         HibernationsCnt = get_spiral_metric_count(global, [mod_muc, hibernations]),
         true = HibernationsCnt > 0,
-        HibernatedRooms = escalus_ejabberd:rpc(mod_muc, hibernated_rooms_number, []),
+        HibernatedRooms = rpc(mim(), mod_muc, hibernated_rooms_number, []),
         true = HibernatedRooms > 0
     end),
 
@@ -4128,7 +4131,7 @@ hibernated_room_is_stopped_and_restored_by_presence(Config) ->
         ct:print("~p", [MessageWithSubject]),
         true = is_subject_message(MessageWithSubject, <<"Restorable">>),
 
-        {ok, _Pid2} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
+        {ok, _Pid2} = rpc(mim(), mod_muc, room_jid_to_pid, [RoomJID]),
         ok
     end),
 
@@ -4149,7 +4152,7 @@ stopped_rooms_history_is_available(Config) ->
 
         wait_for_mam_result(RoomName, Bob, Msg),
 
-        {ok, _Pid2} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
+        {ok, _Pid2} = rpc(mim(), mod_muc, room_jid_to_pid, [RoomJID]),
         ok
     end),
 
@@ -4214,8 +4217,7 @@ can_found_in_db_when_stopped(Config) ->
         {ok, _, Pid} = given_fresh_room_is_hibernated(
                          Alice, RoomName, [{persistentroom, true}]),
         true = wait_for_room_to_be_stopped(Pid, timer:seconds(8)),
-        {ok, _} = escalus_ejabberd:rpc(mod_muc, restore_room,
-                                       [domain(), muc_host(), RoomName])
+        {ok, _} = rpc(mim(), mod_muc, restore_room, [domain(), muc_host(), RoomName])
     end),
 
     destroy_room(muc_host(), RoomName),
@@ -4245,8 +4247,7 @@ deep_hibernation_metrics_are_updated(Config) ->
     forget_room(domain(), muc_host(), RoomName).
 
 get_spiral_metric_count(Host, MetricName) ->
-    Result = escalus_ejabberd:rpc(mongoose_metrics, get_metric_value,
-                                  [Host, MetricName]),
+    Result = rpc(mim(), mongoose_metrics, get_metric_value, [Host, MetricName]),
     {ok, [{count, Count}, {one, _}]} = Result,
     Count.
 
@@ -4263,7 +4264,7 @@ given_fresh_room_for_user(Owner, RoomName, Opts) ->
     escalus:send(Owner, JoinRoom),
     escalus:wait_for_stanzas(Owner, 2),
     maybe_configure(Owner, RoomName, Opts),
-    {ok, Pid} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
+    {ok, Pid} = rpc(mim(), mod_muc, room_jid_to_pid, [RoomJID]),
     {ok, RoomJID, Pid}.
 
 maybe_configure(_, _, []) ->
@@ -4323,7 +4324,7 @@ given_fresh_room_with_messages_is_hibernated(Owner, RoomName, Opts, Participant)
     {MessageBin, Result}.
 
 forget_room(ServerHost, MUCHost, RoomName) ->
-    ok = escalus_ejabberd:rpc(mod_muc, forget_room, [ServerHost, MUCHost, RoomName]).
+    ok = rpc(mim(), mod_muc, forget_room, [ServerHost, MUCHost, RoomName]).
 
 wait_for_room_to_be_stopped(Pid, Timeout) ->
     Ref = erlang:monitor(process, Pid),
@@ -4346,7 +4347,7 @@ wait_for_hibernation(Pid, N) ->
     end.
 
 is_hibernated(Pid) ->
-    CurrentFunction = escalus_ejabberd:rpc(erlang, process_info, [Pid, current_function]),
+    CurrentFunction = rpc(mim(), erlang, process_info, [Pid, current_function]),
     {current_function, {erlang, hibernate, 3}} == CurrentFunction.
 
 wait_for_mam_result(RoomName, Client, Msg) ->
@@ -4488,16 +4489,15 @@ load_already_registered_permanent_rooms(_Config) ->
     HttpAuthPool = none,
 
     %% Write a permanent room
-    ok = escalus_ejabberd:rpc(mod_muc, store_room,
-                              [domain(), Host, Room, []]),
+    ok = rpc(mim(), mod_muc, store_room, [domain(), Host, Room, []]),
 
     % Load permanent rooms
-    escalus_ejabberd:rpc(mod_muc, load_permanent_rooms,
-                         [Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuthPool]),
+    rpc(mim(), mod_muc, load_permanent_rooms,
+        [Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuthPool]),
 
     %% Read online room
-    RoomJID = escalus_ejabberd:rpc(jid,make,[Room,Host,<<>>]),
-    {ok, Pid} = escalus_ejabberd:rpc(mod_muc,room_jid_to_pid,[RoomJID]),
+    RoomJID = rpc(mim(), jid, make, [Room, Host, <<>>]),
+    {ok, Pid} = rpc(mim(), mod_muc, room_jid_to_pid, [RoomJID]),
 
     %% Check if the pid read from mnesia matches the fake pid
     ?assert_equal(?FAKEPID, Pid).
@@ -4511,8 +4511,8 @@ create_already_registered_room(Config) ->
     %% Function has been mecked to register the room before it is started
     start_room(Config, Alice, Room, <<"aliceroom">>, default),
     %% Read the room
-    RoomJID = escalus_ejabberd:rpc(jid,make,[Room,Host,<<>>]),
-    {ok, Pid} = escalus_ejabberd:rpc(mod_muc, room_jid_to_pid, [RoomJID]),
+    RoomJID = rpc(mim(), jid, make, [Room, Host, <<>>]),
+    {ok, Pid} = rpc(mim(), mod_muc, room_jid_to_pid, [RoomJID]),
     %% Check that the stored pid is the same as the mecked pid
     ?assert_equal(?FAKEPID, Pid).
 
@@ -4530,8 +4530,7 @@ check_message_route_to_offline_room(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
         Room = <<"testroom4">>,
         Host = muc_host(),
-        ok = escalus_ejabberd:rpc(mod_muc, store_room,
-                                  [domain(), Host, Room, []]),
+        ok = rpc(mim(), mod_muc, store_room, [domain(), Host, Room, []]),
 
         %% Send a message to an offline permanent room
         escalus:send(Alice, stanza_room_subject(Room, <<"Subject line">>)),

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -462,7 +462,7 @@ init_per_testcase(CaseName = check_message_route_to_offline_room, Config) ->
 
 init_per_testcase(CaseName =send_non_anonymous_history, Config) ->
     [Alice | _] = ?config(escalus_users, Config),
-	Config1 = start_room(Config, Alice, <<"alicesroom">>, <<"alice">>, [{anonymous, false}]),
+    Config1 = start_room(Config, Alice, <<"alicesroom">>, <<"alice">>, [{anonymous, false}]),
     escalus:init_per_testcase(CaseName, Config1);
 
 init_per_testcase(CaseName =limit_history_chars, Config) ->
@@ -1980,9 +1980,9 @@ groupchat_user_enter(Config1) ->
         escalus:send(Bob, EnterRoomStanza),
         Presence = escalus:wait_for_stanza(Bob),
         escalus_pred:is_presence(Presence),
-		From = room_address(?config(room, Config), escalus_utils:get_username(Bob)),
-		From = exml_query:attr(Presence, <<"from">>)
-	end),
+        From = room_address(?config(room, Config), escalus_utils:get_username(Bob)),
+        From = exml_query:attr(Presence, <<"from">>)
+    end),
     destroy_room(Config).
 %Example 19
 %Fails - no error message sent from the server
@@ -1992,7 +1992,7 @@ groupchat_user_enter_no_nickname(Config1) ->
     Alice = connect_fresh_user(AliceSpec),
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         escalus:send(Bob, stanza_groupchat_enter_room_no_nick(?config(room, Config))),
-		escalus:assert(is_error, [<<"modify">>, <<"jid-malformed">>], escalus:wait_for_stanza(Bob)),
+        escalus:assert(is_error, [<<"modify">>, <<"jid-malformed">>], escalus:wait_for_stanza(Bob)),
         escalus_assert:has_no_stanzas(Alice),
         escalus_assert:has_no_stanzas(Bob)
     end),
@@ -2009,23 +2009,23 @@ muc_user_enter(Config1) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
 
         Presence = escalus:wait_for_stanza(Bob),
-		is_presence_with_affiliation(Presence, <<"none">>),
-		is_self_presence(Bob, ?config(room, Config), Presence),
+        is_presence_with_affiliation(Presence, <<"none">>),
+        is_self_presence(Bob, ?config(room, Config), Presence),
         escalus:wait_for_stanza(Bob),   %topic
 
         escalus:send(Eve, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Eve))),
 
         Presence2 = escalus:wait_for_stanza(Bob),
-		is_presence_with_affiliation(Presence2, <<"none">>),
-		is_presence_from(Eve, ?config(room, Config), Presence2),
+        is_presence_with_affiliation(Presence2, <<"none">>),
+        is_presence_from(Eve, ?config(room, Config), Presence2),
 
         Presence3 = escalus:wait_for_stanza(Eve),
-		is_presence_with_affiliation(Presence3, <<"none">>),
-		is_presence_from(Bob, ?config(room, Config), Presence3),
+        is_presence_with_affiliation(Presence3, <<"none">>),
+        is_presence_from(Bob, ?config(room, Config), Presence3),
 
         Presence4 = escalus:wait_for_stanza(Eve),
-		is_presence_with_affiliation(Presence4, <<"none">>),
-		is_self_presence(Eve, ?config(room, Config), Presence4),
+        is_presence_with_affiliation(Presence4, <<"none">>),
+        is_self_presence(Eve, ?config(room, Config), Presence4),
         escalus:wait_for_stanza(Eve)   %topic
     end),
     destroy_room(Config).
@@ -2040,11 +2040,11 @@ enter_non_anonymous_room(Config1) ->
     Config = given_fresh_room(Config1, AliceSpec, [{anonymous, false}]),
     escalus:story(Config, [{bob, 1}], fun(Bob) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
-		%should include code 100 in the presence messages to inform users alobut the room being non-annymous.
-		%sends an additional simple message instead
+        %should include code 100 in the presence messages to inform users alobut the room being non-annymous.
+        %sends an additional simple message instead
         Presence = escalus:wait_for_stanza(Bob),
-		is_self_presence(Bob, ?config(room, Config), Presence),
-		has_status_codes(Presence, [<<"100">>]),
+        is_self_presence(Bob, ?config(room, Config), Presence),
+        has_status_codes(Presence, [<<"100">>]),
         escalus:wait_for_stanza(Bob) %topic
     end),
     destroy_room(Config).
@@ -2072,7 +2072,7 @@ enter_password_protected_room(Config1) ->
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         escalus:send(Bob, stanza_muc_enter_password_protected_room(?config(room, Config), escalus_utils:get_username(Bob), ?PASSWORD)),
         Presence = escalus:wait_for_stanza(Bob),
-		is_self_presence(Bob, ?config(room, Config), Presence)
+        is_self_presence(Bob, ?config(room, Config), Presence)
     end),
     destroy_room(Config).
 
@@ -2250,9 +2250,9 @@ enter_room_with_logging(Config1) ->
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         %Bob enters the room
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
-		Presence = escalus:wait_for_stanza(Bob),
+        Presence = escalus:wait_for_stanza(Bob),
         is_self_presence(Bob, ?config(room, Config), Presence),
-		has_status_codes(Presence, [<<"170">>])
+        has_status_codes(Presence, [<<"170">>])
     end),
     destroy_room(Config).
 
@@ -2267,26 +2267,26 @@ send_history(Config1) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanzas(Bob, 3),
         escalus:wait_for_stanza(Alice),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
-		escalus:wait_for_stanza(Alice),
+        Msg = <<"Hi, Bob!">>,
+        Msg2 = <<"Hi, Alice!">>,
+        escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
-		escalus:wait_for_stanza(Alice),
+        escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
 
-		%Eve enters and receives the presences, the message history and finally the topic
+        %Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room(?config(room, Config), nick(Eve))),
-		escalus:wait_for_stanza(Alice),
-		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
-		is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
-		is_history_message_correct(?config(room, Config), nick(Bob),<<"groupchat">>,Msg2, escalus:wait_for_stanza(Eve)),
-		escalus:wait_for_stanza(Eve),	%topic
-		escalus_assert:has_no_stanzas(Alice),
-		escalus_assert:has_no_stanzas(Bob),
-		escalus_assert:has_no_stanzas(Eve)
+        is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
+        is_history_message_correct(?config(room, Config), nick(Bob),<<"groupchat">>,Msg2, escalus:wait_for_stanza(Eve)),
+        escalus:wait_for_stanza(Eve),  %% topic
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end),
     destroy_room(Config).
 
@@ -2302,26 +2302,26 @@ send_non_anonymous_history(Config) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanzas(Bob, 3),
         escalus:wait_for_stanza(Alice),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
-		escalus:wait_for_stanza(Alice),
+        Msg = <<"Hi, Bob!">>,
+        Msg2 = <<"Hi, Alice!">>,
+        escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
-		escalus:wait_for_stanza(Alice),
+        escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
 
-		%Eve enters and receives the presences, the message history and finally the topic
+        %Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room(?config(room, Config), nick(Eve))),
-		escalus:wait_for_stanza(Alice),
-		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
-		is_non_anonymous_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
-		is_non_anonymous_history_message_correct(?config(room, Config), nick(Bob),<<"groupchat">>,Msg2, escalus:wait_for_stanza(Eve)),
-		escalus:wait_for_stanza(Eve),	%topic
-		escalus_assert:has_no_stanzas(Alice),
-		escalus_assert:has_no_stanzas(Bob),
-		escalus_assert:has_no_stanzas(Eve)
+        is_non_anonymous_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
+        is_non_anonymous_history_message_correct(?config(room, Config), nick(Bob),<<"groupchat">>,Msg2, escalus:wait_for_stanza(Eve)),
+        escalus:wait_for_stanza(Eve),
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end).
 
 
@@ -2334,25 +2334,26 @@ limit_history_chars(Config) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanzas(Bob, 3),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
-		escalus:wait_for_stanza(Alice),
+        Msg = <<"Hi, Bob!">>,
+        Msg2 = <<"Hi, Alice!">>,
+        escalus:send(Alice, escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
-		escalus:wait_for_stanza(Alice),
+        escalus:send(Bob, escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
 
- 		%Eve enters and receives the presences, the message history and finally the topic
+        %Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room_history_setting(?config(room, Config), nick(Eve), <<"maxchars">>,<<"500">>)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
- 		is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
- 		escalus:wait_for_stanza(Eve),	%topic
- 		escalus_assert:has_no_stanzas(Alice),
- 		escalus_assert:has_no_stanzas(Bob),
- 		escalus_assert:has_no_stanzas(Eve)
+        is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
+        %% Topic
+        escalus:wait_for_stanza(Eve),
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end).
 
 %Example 38
@@ -2364,25 +2365,25 @@ limit_history_messages(Config) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanzas(Bob, 3),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        Msg= <<"Hi, Bob!">>,
+        Msg2= <<"Hi, Alice!">>,
+        escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
+        escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
 
- 		%Eve enters and receives the presences, the message history and finally the topic
+        %Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room_history_setting(?config(room, Config), nick(Eve), <<"maxstanzas">>,<<"1">>)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
- 		is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
- 		escalus:wait_for_stanza(Eve),	%topic
- 		escalus_assert:has_no_stanzas(Alice),
- 		escalus_assert:has_no_stanzas(Bob),
- 		escalus_assert:has_no_stanzas(Eve)
+        is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
+        escalus:wait_for_stanza(Eve), %topic
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end).
 
 %Example 39
@@ -2394,25 +2395,25 @@ recent_history(Config) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanzas(Bob, 3),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        Msg = <<"Hi, Bob!">>,
+        Msg2 = <<"Hi, Alice!">>,
+        escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
+        escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
 
- 		%Eve enters and receives the presences, the message history and finally the topic
+        %Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room_history_setting(?config(room, Config), nick(Eve), <<"seconds">>,<<"3">>)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
- 		is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
- 		escalus:wait_for_stanza(Eve),	%topic
- 		escalus_assert:has_no_stanzas(Alice),
- 		escalus_assert:has_no_stanzas(Bob),
- 		escalus_assert:has_no_stanzas(Eve)
+        is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
+        escalus:wait_for_stanza(Eve), %topic
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end).
 
 %Example 40
@@ -2427,26 +2428,26 @@ history_since(Config1) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanzas(Bob, 3),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        Msg = <<"Hi, Bob!">>,
+        Msg2 = <<"Hi, Alice!">>,
+        escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
+        escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
 
- 		%Eve enters and receives the presences, the message history and finally the topic
+        %Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room_history_setting(?config(room, Config), nick(Eve), <<"since">>,<<"1970-01-01T00:00:00Z">>)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
- 		is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
-		is_history_message_correct(?config(room, Config), nick(Bob),<<"groupchat">>,Msg2, escalus:wait_for_stanza(Eve)),
- 		escalus:wait_for_stanza(Eve),	%topic
- 		escalus_assert:has_no_stanzas(Alice),
- 		escalus_assert:has_no_stanzas(Bob),
- 		escalus_assert:has_no_stanzas(Eve)
+        is_history_message_correct(?config(room, Config), nick(Alice),<<"groupchat">>,Msg, escalus:wait_for_stanza(Eve)),
+        is_history_message_correct(?config(room, Config), nick(Bob),<<"groupchat">>,Msg2, escalus:wait_for_stanza(Eve)),
+        escalus:wait_for_stanza(Eve), %topic
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end),
     destroy_room(Config).
 
@@ -2459,25 +2460,25 @@ no_history(Config) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanzas(Bob, 3),
-		Msg= <<"Hi, Bob!">>,
-		Msg2= <<"Hi, Alice!">>,
-		escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
-		escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        Msg = <<"Hi, Bob!">>,
+        Msg2 = <<"Hi, Alice!">>,
+        escalus:send(Alice,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
+        escalus:send(Bob,escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg2)),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
 
- 		%Eve enters and receives the presences, the message history and finally the topic
+        % Eve enters and receives the presences, the message history and finally the topic
         escalus:send(Eve, stanza_muc_enter_room_history_setting(?config(room, Config), nick(Eve), <<"maxchars">>,<<"0">>)),
- 		escalus:wait_for_stanza(Alice),
- 		escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice),
+        escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Eve, 3), %presences
- 		escalus:wait_for_stanza(Eve),	%topic
-		timer:wait(5000),
- 		escalus_assert:has_no_stanzas(Alice),
- 		escalus_assert:has_no_stanzas(Bob),
- 		escalus_assert:has_no_stanzas(Eve)
+        escalus:wait_for_stanza(Eve), %topic
+        timer:wait(5000),
+        escalus_assert:has_no_stanzas(Alice),
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Eve)
     end).
 
 %Example 42
@@ -2486,9 +2487,9 @@ subject(Config1)->
     Config = given_fresh_room(Config1, AliceSpec, [{subject, ?SUBJECT}]),
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
-		escalus:wait_for_stanza(Bob),
-		Subject = exml_query:path(escalus:wait_for_stanza(Bob), [{element, <<"subject">>}, cdata]),
-		Subject==?SUBJECT
+        escalus:wait_for_stanza(Bob),
+        Subject = exml_query:path(escalus:wait_for_stanza(Bob), [{element, <<"subject">>}, cdata]),
+        Subject == ?SUBJECT
     end),
     destroy_room(Config).
 
@@ -2499,8 +2500,8 @@ no_subject(Config1)->
     Config = given_fresh_room(Config1, AliceSpec, []),
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
-		escalus:wait_for_stanza(Bob),
-		#xmlel{children = []} = exml_query:subelement(escalus:wait_for_stanza(Bob), <<"subject">>)
+        escalus:wait_for_stanza(Bob),
+        #xmlel{children = []} = exml_query:subelement(escalus:wait_for_stanza(Bob), <<"subject">>)
     end),
     destroy_room(Config).
 
@@ -2512,8 +2513,8 @@ send_to_all(Config1) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
         escalus:wait_for_stanzas(Bob, 2),
         escalus:send(Eve, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Eve))),
-		escalus:wait_for_stanza(Bob),
-		escalus:wait_for_stanzas(Eve, 3),
+        escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanzas(Eve, 3),
 
         Msg = <<"chat message">>,
         escalus:send(Eve, escalus_stanza:groupchat_to(room_address(?config(room, Config)), Msg)),
@@ -2588,13 +2589,13 @@ change_nickname(Config1) ->
 
         escalus:send(Bob, stanza_change_nick(?config(room, Config), <<"newbob">>)),
         Presence = escalus:wait_for_stanza(Bob),
-		has_status_codes(Presence, [<<"110">>]),
+        has_status_codes(Presence, [<<"110">>]),
         is_nick_unavailable_correct(?config(room, Config), BobNick, <<"newbob">>, escalus:wait_for_stanza(Eve)),
         is_nick_unavailable_correct(?config(room, Config), BobNick, <<"newbob">>, Presence),
         is_nick_update_correct(?config(room, Config), <<"newbob">>, escalus:wait_for_stanza(Eve)),
         Presence2 = escalus:wait_for_stanza(Bob),
         is_nick_update_correct(?config(room, Config), <<"newbob">>, Presence2),
-		has_status_codes(Presence2, [<<"110">>])
+        has_status_codes(Presence2, [<<"110">>])
     end),
     destroy_room(Config).
 
@@ -2626,7 +2627,7 @@ change_availability_status(Config1) ->
     Config = given_fresh_room(Config1, AliceSpec, []),
     Alice = connect_fresh_user(AliceSpec),
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
-		escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), nick(Bob))),
         escalus:wait_for_stanzas(Bob, 2),
         escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), nick(Alice))),
         escalus:wait_for_stanza(Bob),
@@ -2655,10 +2656,10 @@ mediated_invite(Config1) ->
         escalus:send(Alice, stanza_mediated_invitation(?config(room, Config), Bob)),
         escalus:send(Alice, stanza_mediated_invitation(?config(room, Config), Eve)),
         %Bob ignores the invitation, Eve formally declines
-		is_invitation(escalus:wait_for_stanza(Bob)),
-		is_invitation(escalus:wait_for_stanza(Eve)),
-		escalus:send(Eve, stanza_mediated_invitation_decline(?config(room, Config), Alice)),
-		is_invitation_decline(escalus:wait_for_stanza(Alice))
+        is_invitation(escalus:wait_for_stanza(Bob)),
+        is_invitation(escalus:wait_for_stanza(Eve)),
+        escalus:send(Eve, stanza_mediated_invitation_decline(?config(room, Config), Alice)),
+        is_invitation_decline(escalus:wait_for_stanza(Alice))
     end),
     destroy_room(Config).
 
@@ -2822,7 +2823,7 @@ user_unregisters_nick_twice(Config) ->
 %reserved_nickname_request(Config) ->
 %    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(_Alice,  Bob) ->
 %        %escalus:send(Bob, stanza_to_room(escalus_stanza:iq_get(<<"jabber:iq:register">>, []), ?config(room, Config))),
-%  	    %print_next_message(Bob)
+%        %print_next_message(Bob)
 %        print(stanza_to_room(stanza_reserved_nickname_request(), ?config(room, Config))),
 %        escalus:send(Bob, (stanza_to_room(stanza_reserved_nickname_request(), ?config(room, Config)))),
 %        print_next_message(Bob)
@@ -2850,12 +2851,12 @@ exit_room(Config1) ->
         escalus:wait_for_stanzas(Eve, 4),
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
-		escalus:send(Alice, stanza_to_room(escalus_stanza:presence(<<"unavailable">>), ?config(room, Config), escalus_utils:get_username(Alice))),
-		Message = escalus:wait_for_stanza(Alice),
-		has_status_codes(Message, [<<"110">>]),
-		assert_is_exit_message_correct(Alice, <<"owner">>, ?config(room, Config), Message),
-		assert_is_exit_message_correct(Alice, <<"owner">>, ?config(room, Config), escalus:wait_for_stanza(Bob)),
-		assert_is_exit_message_correct(Alice, <<"owner">>, ?config(room, Config), escalus:wait_for_stanza(Eve))
+        escalus:send(Alice, stanza_to_room(escalus_stanza:presence(<<"unavailable">>), ?config(room, Config), escalus_utils:get_username(Alice))),
+        Message = escalus:wait_for_stanza(Alice),
+        has_status_codes(Message, [<<"110">>]),
+        assert_is_exit_message_correct(Alice, <<"owner">>, ?config(room, Config), Message),
+        assert_is_exit_message_correct(Alice, <<"owner">>, ?config(room, Config), escalus:wait_for_stanza(Bob)),
+        assert_is_exit_message_correct(Alice, <<"owner">>, ?config(room, Config), escalus:wait_for_stanza(Eve))
     end),
     destroy_room(Config).
 
@@ -2878,17 +2879,17 @@ exit_room_with_status(Config1) ->
         escalus:wait_for_stanza(Alice),
         escalus:wait_for_stanza(Bob),
 
-		Status = <<"Alices exit status">>,
-		StatusXml = #xmlel{name = <<"status">>, children = [#xmlcdata{content=Status}]},
-		Presence = escalus_stanza:presence(<<"unavailable">>),
-		Presence2 = Presence#xmlel{children=[StatusXml]},
-		Stanza = stanza_to_room(Presence2,  ?config(room, Config), escalus_utils:get_username(Alice)),
-		escalus:send(Alice, Stanza),
-		Message = escalus:wait_for_stanza(Alice),
-		has_status_codes(Message, [<<"110">>]),
-		is_exit_message_with_status_correct(Alice, <<"owner">>, ?config(room, Config), Status,  Message),
-		is_exit_message_with_status_correct(Alice, <<"owner">>, ?config(room, Config), Status, escalus:wait_for_stanza(Bob)),
-		is_exit_message_with_status_correct(Alice, <<"owner">>, ?config(room, Config), Status, escalus:wait_for_stanza(Eve))
+        Status = <<"Alices exit status">>,
+        StatusXml = #xmlel{name = <<"status">>, children = [#xmlcdata{content=Status}]},
+                  Presence = escalus_stanza:presence(<<"unavailable">>),
+        Presence2 = Presence#xmlel{children=[StatusXml]},
+        Stanza = stanza_to_room(Presence2,  ?config(room, Config), escalus_utils:get_username(Alice)),
+        escalus:send(Alice, Stanza),
+        Message = escalus:wait_for_stanza(Alice),
+        has_status_codes(Message, [<<"110">>]),
+        is_exit_message_with_status_correct(Alice, <<"owner">>, ?config(room, Config), Status,  Message),
+        is_exit_message_with_status_correct(Alice, <<"owner">>, ?config(room, Config), Status, escalus:wait_for_stanza(Bob)),
+        is_exit_message_with_status_correct(Alice, <<"owner">>, ?config(room, Config), Status, escalus:wait_for_stanza(Eve))
     end),
     destroy_room(Config).
 
@@ -3043,7 +3044,7 @@ cant_enter_locked_room(Config) ->
         RoomName = fresh_room_name(),
         escalus:send(Alice, stanza_muc_enter_room(RoomName,
                                                   <<"alice-the-owner">>)),
-		Presence = escalus:wait_for_stanza(Alice),
+        Presence = escalus:wait_for_stanza(Alice),
         was_room_created(Presence),
 
         %% Bob should not be able to join the room
@@ -4329,7 +4330,7 @@ forget_room(ServerHost, MUCHost, RoomName) ->
 wait_for_room_to_be_stopped(Pid, Timeout) ->
     Ref = erlang:monitor(process, Pid),
     receive
-        {'DOWN', Ref, _Type, Pid, Info} ->
+        {'DOWN', Ref, _Type, Pid, _Info} ->
             true
     after Timeout ->
               false
@@ -4574,42 +4575,41 @@ enter_room(Room, User, AlreadyInRoom) ->
 is_history_message_correct(Room, SenderNick,Type,  Text, ReceivedMessage) ->
     %error_logger:info_msg("tested message: ~n~p~n", [ReceivedMessage]),
     escalus_pred:is_message(ReceivedMessage),
-	exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"stamp">>}]),
-	FromDelay = room_address(Room),
-	FromDelay = exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"from">>}]),
+    exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"stamp">>}]),
+    FromDelay = room_address(Room),
+    FromDelay = exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"from">>}]),
     From = room_address(Room, SenderNick),
     From = exml_query:attr(ReceivedMessage, <<"from">>),
     Type = exml_query:attr(ReceivedMessage, <<"type">>),
-	Content = exml_query:path(ReceivedMessage, [{element, <<"body">>}, cdata]),
-	Text = Content.
+    Content = exml_query:path(ReceivedMessage, [{element, <<"body">>}, cdata]),
+    Text = Content.
 
 is_non_anonymous_history_message_correct(Room, SenderNick,Type,  Text, ReceivedMessage) ->
     %error_logger:info_msg("tested message: ~n~p~n", [ReceivedMessage]),
     escalus_pred:is_message(ReceivedMessage),
-	exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"stamp">>}]),
-	FromDelay = room_address(Room),
-	FromDelay = exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"from">>}]),
+    exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"stamp">>}]),
+    FromDelay = room_address(Room),
+    FromDelay = exml_query:path(ReceivedMessage, [{element, <<"delay">>}, {attr, <<"from">>}]),
     From = room_address(Room, SenderNick),
     From = exml_query:attr(ReceivedMessage, <<"from">>),
     Type = exml_query:attr(ReceivedMessage, <<"type">>),
-	Content = exml_query:path(ReceivedMessage, [{element, <<"body">>}, cdata]),
-	Text = Content,
-	<<"http://jabber.org/protocol/address">> = exml:path(ReceivedMessage, [{element, <<"addresses">>}, {attr, <<"xmlns">>}]),
-	<<"oform">> = exml:path(ReceivedMessage, [{element, <<"addresses">>},{element, <<"address">>}, {attr, <<"type">>}]),
-	JID = escalus_utils:get_jid(SenderNick),
-	JID= exml:path(ReceivedMessage, [{element, <<"addresses">>},{element, <<"address">>}, {attr, <<"jid">>}]).
+    Content = exml_query:path(ReceivedMessage, [{element, <<"body">>}, cdata]),
+    Text = Content,
+    <<"http://jabber.org/protocol/address">> = exml:path(ReceivedMessage, [{element, <<"addresses">>}, {attr, <<"xmlns">>}]),
+    <<"oform">> = exml:path(ReceivedMessage, [{element, <<"addresses">>},{element, <<"address">>}, {attr, <<"type">>}]),
+    JID = escalus_utils:get_jid(SenderNick),
+    JID = exml:path(ReceivedMessage, [{element, <<"addresses">>},{element, <<"address">>}, {attr, <<"jid">>}]).
 
 is_self_presence(User, Room, Presence) ->
-		has_status_codes(Presence, [<<"110">>]),
-        escalus_pred:is_presence(Presence),
-		From = room_address(Room, escalus_utils:get_username(User)),
-        From = exml_query:attr(Presence, <<"from">>).
+    has_status_codes(Presence, [<<"110">>]),
+    escalus_pred:is_presence(Presence),
+    From = room_address(Room, escalus_utils:get_username(User)),
+    From = exml_query:attr(Presence, <<"from">>).
 
 is_presence_from(User, Room, Presence) ->
-        escalus_pred:is_presence(Presence),
-		From = room_address(Room, escalus_utils:get_username(User)),
-        From = exml_query:attr(Presence, <<"from">>).
-
+    escalus_pred:is_presence(Presence),
+    From = room_address(Room, escalus_utils:get_username(User)),
+    From = exml_query:attr(Presence, <<"from">>).
 
 %does not check the jid - the user might not be entitled to receive it.
 is_availability_status_notification_correct(Room, SenderNick, NewStatus, ReceivedMessage) ->
@@ -4631,20 +4631,20 @@ assert_is_message_correct(Room, SenderNick, Type, Text, ReceivedMessage) ->
     Body = exml_query:subelement(ReceivedMessage, <<"body">>).
 
 assert_is_exit_message_correct(LeavingUser,Affiliation,Room, Message) ->
-	escalus_pred:is_presence_with_type(<<"unavailable">>,Message),
-	is_presence_with_affiliation(Message,Affiliation),
+    escalus_pred:is_presence_with_type(<<"unavailable">>, Message),
+    is_presence_with_affiliation(Message, Affiliation),
     From = room_address(Room, escalus_utils:get_username(LeavingUser)),
     From = exml_query:attr(Message, <<"from">>).
 
 is_exit_message_with_status_correct(LeavingUser,Affiliation,Room,Status,  Message) ->
-	escalus_pred:is_presence_with_type(<<"unavailable">>,Message),
-	is_presence_with_affiliation(Message,Affiliation),
+    escalus_pred:is_presence_with_type(<<"unavailable">>, Message),
+    is_presence_with_affiliation(Message, Affiliation),
     From = room_address(Room, escalus_utils:get_username(LeavingUser)),
     From  = exml_query:attr(Message, <<"from">>),
-	Status = exml_query:path(Message, [{element,<<"status">>}, cdata]).
+    Status = exml_query:path(Message, [{element,<<"status">>}, cdata]).
 
 is_nick_unavailable_correct(Room, OldNick, NewNick, ReceivedMessage) ->
-     %error_logger:info_msg("tested message: ~n~p~n", [ReceivedMessage]),
+    %error_logger:info_msg("tested message: ~n~p~n", [ReceivedMessage]),
     escalus_pred:is_message(ReceivedMessage),
     From = room_address(Room, OldNick),
     From = exml_query:attr(ReceivedMessage, <<"from">>),
@@ -4724,8 +4724,8 @@ stanza_muc_enter_room_history_setting(Room, Nick, Setting, Value) ->
     stanza_to_room(
         escalus_stanza:presence(  <<"available">>,
                                 [#xmlel{ name = <<"x">>,
-                    						  attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}],
-											  children = [#xmlel{name= <<"history">>, attrs=[{Setting, Value}]}]}]),
+                                         attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}],
+                                         children = [#xmlel{name= <<"history">>, attrs=[{Setting, Value}]}] }]),
         Room, Nick).
 
 stanza_room_subject(Room, Subject) ->
@@ -4742,8 +4742,8 @@ stanza_mediated_invitation(Room, Invited) ->
 
 stanza_mediated_invitation_multi(Room, AllInvited) ->
     Payload = [ #xmlel{name = <<"invite">>,
-		       attrs = [{<<"to">>, escalus_utils:get_short_jid(Invited)}]}
-		|| Invited <- AllInvited],
+                       attrs = [{<<"to">>, escalus_utils:get_short_jid(Invited)}]}
+                || Invited <- AllInvited ],
     stanza_to_room(#xmlel{name = <<"message">>,
         children = [ #xmlel{
             name = <<"x">>,
@@ -4918,7 +4918,7 @@ stanza_get_rooms() ->
         muc_host()).
 
 
-stanza_get_services(Config) ->
+stanza_get_services(_Config) ->
     %% <iq from='hag66@shakespeare.lit/pda'
     %%     id='h7ns81g'
     %%     to='shakespeare.lit'
@@ -4929,7 +4929,6 @@ stanza_get_services(Config) ->
         ct:get_config({hosts, mim, domain})).
 
 get_nick_form_iq() ->
-    NS = <<"jabber:iq:register">>,
     GetIQ = escalus_stanza:iq_get(<<"jabber:iq:register">>, []),
     escalus_stanza:to(GetIQ, ?MUC_HOST).
 

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -5,6 +5,9 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 -type verify_fun() :: fun((Incoming :: #xmlel{}) -> any()).
 
 -define(MUC_HOST, <<"muc.localhost">>).
@@ -79,17 +82,16 @@ generate_rpc_jid({_,User}) ->
     {jid, Username, Server, <<"rpc">>, LUsername, LServer, <<"rpc">>}.
 
 create_instant_room(Host, Room, From, Nick, Opts) ->
-    Room1 = escalus_ejabberd:rpc(jid, nodeprep, [Room]),
-    escalus_ejabberd:rpc(mod_muc, create_instant_room,
+    Room1 = rpc(mim(), jid, nodeprep, [Room]),
+    rpc(mim(), mod_muc, create_instant_room,
         [Host, Room1, From, Nick, Opts]).
 
 destroy_room(Config) ->
     destroy_room(?MUC_HOST, ?config(room, Config)).
 
 destroy_room(Host, Room) when is_binary(Host), is_binary(Room) ->
-    Room1 = escalus_ejabberd:rpc(jid, nodeprep, [Room]),
-    case escalus_ejabberd:rpc(
-            ets, lookup, [muc_online_room, {Room1, Host}]) of
+    Room1 = rpc(mim(), jid, nodeprep, [Room]),
+    case rpc(mim(), ets, lookup, [muc_online_room, {Room1, Host}]) of
         [{_,_,Pid}|_] -> gen_fsm:send_all_state_event(Pid, destroy);
         _ -> ok
     end.

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -44,10 +44,10 @@ foreach_recipient(Users, VerifyFun) ->
       end, Users).
 
 load_muc(Host) ->
-    _Backend = case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
-                   true -> odbc;
-                   false -> mnesia
-               end,
+    case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
+        true -> odbc;
+        false -> mnesia
+    end,
     %% TODO refactoring. "localhost" should be passed as a parameter
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -44,10 +44,10 @@ foreach_recipient(Users, VerifyFun) ->
       end, Users).
 
 load_muc(Host) ->
-    Backend = case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
-                  true -> odbc;
-                  false -> mnesia
-              end,
+    _Backend = case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
+                   true -> odbc;
+                   false -> mnesia
+               end,
     %% TODO refactoring. "localhost" should be passed as a parameter
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -7,6 +7,9 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 -type ct_aff_user() :: {EscalusClient :: escalus:client(), Aff :: atom()}.
 -type ct_aff_users() :: [ct_aff_user()].
 
@@ -23,11 +26,11 @@ create_room(RoomU, MUCHost, Owner, Members, Config, Version) ->
     RoomUS = {RoomU, MUCHost},
     AffUsers = [{to_lus(Owner, Config), owner}
                 | [ {to_lus(Member, Config), member} || Member <- Members ]],
-    {ok, _RoomUS} = escalus_ejabberd:rpc(mod_muc_light_db_backend, create_room,
-                                         [RoomUS, DefaultConfig, AffUsers, Version]).
+    {ok, _RoomUS} = rpc(mim(), mod_muc_light_db_backend, create_room,
+                        [RoomUS, DefaultConfig, AffUsers, Version]).
 
 -spec default_config() -> list().
-default_config() -> escalus_ejabberd:rpc(mod_muc_light, default_config, [muc_host()]).
+default_config() -> rpc(mim(), mod_muc_light, default_config, [muc_host()]).
 
 -spec ns_muc_light_affiliations() -> binary().
 ns_muc_light_affiliations() ->
@@ -217,5 +220,5 @@ stanza_aff_set(Room, AffUsers) ->
     escalus_stanza:to(escalus_stanza:iq_set(?NS_MUC_LIGHT_AFFILIATIONS, Items), room_bin_jid(Room)).
 
 clear_db() ->
-    escalus_ejabberd:rpc(mod_muc_light_db_backend, force_clear, []).
+    rpc(mim(), mod_muc_light_db_backend, force_clear, []).
 

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -66,7 +66,7 @@ then_muc_light_affiliations_are_received_by(Users, {_Room, Affiliations}) ->
     [ F(escalus:wait_for_stanza(User)) || User <- Users ].
 
 when_archive_query_is_sent(Sender, RecipientJid, Config) ->
-	P = ?config(props, Config),
+    P = ?config(props, Config),
     Request = case RecipientJid of
                   undefined -> mam_helper:stanza_archive_request(P, <<"q">>);
                   _ -> escalus_stanza:to(mam_helper:stanza_archive_request(P, <<"q">>), RecipientJid)
@@ -74,7 +74,7 @@ when_archive_query_is_sent(Sender, RecipientJid, Config) ->
     escalus:send(Sender, Request).
 
 then_archive_response_is(Receiver, Expected, Config) ->
-	P = ?config(props, Config),
+    P = ?config(props, Config),
     Response = mam_helper:wait_archive_respond(P, Receiver),
     Stanzas = mam_helper:respond_messages(mam_helper:assert_respond_size(length(Expected), Response)),
     ParsedStanzas = [ mam_helper:parse_forwarded_message(Stanza) || Stanza <- Stanzas ],

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -31,6 +31,10 @@
          send_initial_presence_with_caps/2
         ]).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -53,7 +57,7 @@ groups() -> [
             ].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -312,7 +316,7 @@ random_node_ns() ->
     base64:encode(crypto:strong_rand_bytes(16)).
 
 caps_hash(PEPNodeNS) ->
-    escalus_ejabberd:rpc(mod_caps, make_disco_hash, [feature_elems(PEPNodeNS), sha1]).
+    rpc(mim(), mod_caps, make_disco_hash, [feature_elems(PEPNodeNS), sha1]).
 
 caps_node_name() ->
     <<"http://www.chatopus.com">>.

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -92,12 +92,16 @@
          disable_delivery_test/1
         ]).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() -> [
           {group, basic},
@@ -1282,7 +1286,7 @@ debug_get_items_test(Config) ->
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
               pubsub_tools:publish(Alice, <<"item2">>, Node, []),
 
-              Items = escalus_ejabberd:rpc(mod_pubsub, get_items, [NodeAddr, NodeName]),
+              Items = rpc(mim(), mod_pubsub, get_items, [NodeAddr, NodeName]),
               % We won't bother with importing records etc...
               2 = length(Items),
 
@@ -1501,12 +1505,12 @@ is_not_allowed_and_closed(IQError) ->
 %% TODO: Functions below will most probably fail when mod_pubsub gets some nice refactoring!
 
 set_service_option(Host, Key, Val) ->
-    true = escalus_ejabberd:rpc(ets, insert, [service_tab_name(Host), {Key, Val}]).
+    true = rpc(mim(), ets, insert, [service_tab_name(Host), {Key, Val}]).
 
 lookup_service_option(Host, Key) ->
-    [{_, Val}] = escalus_ejabberd:rpc(ets, lookup, [service_tab_name(Host), Key]),
+    [{_, Val}] = rpc(mim(), ets, lookup, [service_tab_name(Host), Key]),
     Val.
 
 service_tab_name(Host) ->
-    escalus_ejabberd:rpc(gen_mod, get_module_proc, [Host, config]).
+    rpc(mim(), gen_mod, get_module_proc, [Host, config]).
 

--- a/big_tests/tests/push_helper.erl
+++ b/big_tests/tests/push_helper.erl
@@ -13,6 +13,9 @@
 
 -export([ns_push/0, ns_pubsub_pub_options/0, push_form_type/0, make_form/1]).
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 ns_push() -> <<"urn:xmpp:push:0">>.
 ns_pubsub_pub_options() -> <<"http://jabber.org/protocol/pubsub#publish-options">>.
 push_form_type()-> <<"urn:xmpp:push:summary">>.
@@ -68,7 +71,7 @@ become_unavailable(Client) ->
     end). %% There is no ACK for unavailable status
 
 is_offline(LUser, LServer, LRes) ->
-    PResources =  escalus_ejabberd:rpc(ejabberd_sm, get_user_present_resources, [LUser, LServer]),
+    PResources =  rpc(mim(), ejabberd_sm, get_user_present_resources, [LUser, LServer]),
     case lists:keyfind(LRes, 2, PResources) of
         false ->
             true;

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -384,7 +384,7 @@ setup_mock_rest() ->
 handle(Req, Master) ->
     {ok, Body, Req2} = cowboy_req:read_body(Req),
     Master ! {rest_req, Req2, Body},
-	cowboy_req:reply(204, #{}, <<>>, Req).
+    cowboy_req:reply(204, #{}, <<>>, Req).
 
 teardown_mock_rest() ->
     http_helper:stop().

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -366,7 +366,7 @@ parse_form(Fields) when is_list(Fields) ->
 rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    escalus_ct:rpc_call(Node, M, F, A, 10000, Cookie).
+    escalus_rpc:call(Node, M, F, A, 10000, Cookie).
 
 bare_jid(JIDOrClient) ->
     ShortJID = escalus_client:short_jid(JIDOrClient),

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -204,10 +204,10 @@ inject_creds_to_opts(PathOpts, any) ->
     lists:keydelete(auth, 1, PathOpts);
 inject_creds_to_opts(PathOpts, Creds) ->
     case lists:keymember(auth, 1, PathOpts) of
-	    true -> 
-	        lists:keyreplace(auth, 1, PathOpts, {auth, Creds});
-	    false ->
-	        lists:append(PathOpts, [{auth, Creds}])
+        true ->
+            lists:keyreplace(auth, 1, PathOpts, {auth, Creds});
+        false ->
+            lists:append(PathOpts, [{auth, Creds}])
     end.
 
 % @doc Checks whether a config for a port is an admin or client one.

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -7,17 +7,8 @@
 -module(s2s_SUITE).
 -compile(export_all).
 
--import(distributed_helper, [rpc/4, rpc/5]).
-
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
-
--record(s2s_opts, {
-          node1_s2s_certfile = undefined,
-          node1_s2s_use_starttls = undefined,
-          node2_s2s_certfile = undefined,
-          node2_s2s_use_starttls = undefined
-         }).
 
 %%%===================================================================
 %%% Suite configuration

--- a/big_tests/tests/sasl_SUITE.erl
+++ b/big_tests/tests/sasl_SUITE.erl
@@ -26,6 +26,10 @@
 
 -behaviour(cyrsasl).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -40,7 +44,7 @@ all_tests() ->
     [text_response].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -69,17 +73,12 @@ end_per_testcase(CaseName, Config) ->
 
 text_response(Config) ->
     {Mod, Bin, File} = code:get_object_code(?MODULE),
-    escalus_ejabberd:rpc(code, load_binary, [Mod, File, Bin]),
-    escalus_ejabberd:rpc(
-      cyrsasl, register_mechanism, [?TEST_MECHANISM, ?MODULE, plain]),
-
+    rpc(mim(), code, load_binary, [Mod, File, Bin]),
+    rpc(mim(), cyrsasl, register_mechanism, [?TEST_MECHANISM, ?MODULE, plain]),
     AliceSpec = escalus_users:get_options(Config, alice),
-    {ok, Client, _} = escalus_connection:start(AliceSpec,
-                                                  [start_stream,
-                                                   stream_features]),
+    {ok, Client, _} = escalus_connection:start(AliceSpec, [start_stream, stream_features]),
     Stanza = escalus_stanza:auth(?TEST_MECHANISM,
-                                 [#xmlcdata{content =
-                                            base64:encode(<<"alice">>)}]),
+                                 [#xmlcdata{content = base64:encode(<<"alice">>)}]),
     Result = escalus:send_and_wait(Client, Stanza),
     assert_is_failure_with_text(Result).
 

--- a/big_tests/tests/sic_SUITE.erl
+++ b/big_tests/tests/sic_SUITE.erl
@@ -13,6 +13,10 @@
 
 -define(NS_SIC, <<"urn:xmpp:sic:1">>).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
 %%%===================================================================
 %%% Suite configuration
 %%%===================================================================
@@ -27,7 +31,7 @@ groups() ->
     [{mod_sic_tests, [sequence], all_tests()}].
 
 suite() ->
-    escalus:suite().
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%%===================================================================
 %%% Init & teardown
@@ -103,11 +107,11 @@ is_sic_response() ->
 
 start_module(ModuleName, Options) ->
     Args = [ct:get_config({hosts, mim, domain}), ModuleName, Options],
-    escalus_ejabberd:rpc(gen_mod, start_module, Args).
+    rpc(mim(), gen_mod, start_module, Args).
 
 stop_module(ModuleName) ->
     Args = [ct:get_config({hosts, mim, domain}), ModuleName],
-    escalus_ejabberd:rpc(gen_mod, stop_module, Args).
+    rpc(mim(), gen_mod, stop_module, Args).
 
 sic_iq_get() ->
     escalus_stanza:iq(<<"get">>, [#xmlel{

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -423,14 +423,14 @@ preserve_order(Config) ->
 receive_all_ordered(Conn, N) ->
     case catch escalus_connection:get_stanza(Conn, msg) of
         #xmlel{} = Stanza ->
-	    NN = case Stanza#xmlel.name of
-        <<"message">> ->
-%% 		    ct:pal("~p~n", [Stanza]),
-            escalus:assert(is_chat_message, [list_to_binary(integer_to_list(N))], Stanza),
-            N+1;
-		_ ->
-		    N
-	    end,
+            NN = case Stanza#xmlel.name of
+                     <<"message">> ->
+                         %ct:pal("~p~n", [Stanza]),
+                         escalus:assert(is_chat_message, [list_to_binary(integer_to_list(N))], Stanza),
+                         N + 1;
+                     _ ->
+                         N
+                 end,
             receive_all_ordered(Conn, NN);
         _Error ->
             ok

--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -1058,20 +1058,18 @@ get_ldap_pid_and_base(Server) ->
     {Pid, Base}.
 
 delete_vcards(Config) ->
-     AllVCards
-        = escalus_config:get_ct({vcard, data, all_search, expected_vcards}),
-
+    AllVCards = escalus_config:get_ct({vcard, data, all_search, expected_vcards}),
     lists:foreach(
-        fun({JID, _}) ->
-                case binary:match(JID, <<"@">>) of
-                    nomatch ->
-                        ok;
-                    _ ->
-                        RJID = get_jid_record(JID),
-                        ok = vcard_rpc(RJID,
-                                       escalus_stanza:vcard_update(JID, []))
-                end
-        end, AllVCards),
+      fun({JID, _}) ->
+              case binary:match(JID, <<"@">>) of
+                  nomatch ->
+                      ok;
+                  _ ->
+                      RJID = get_jid_record(JID),
+                      ok = vcard_rpc(RJID,
+                                     escalus_stanza:vcard_update(JID, []))
+              end
+      end, AllVCards),
     Config.
 
 get_jid_record(JID) ->
@@ -1101,7 +1099,7 @@ stop_running_vcard_mod(Config) ->
     dynamic_modules:stop(Domain, mod_vcard),
     [{mod_vcard, CurrentVcardConfig} | Config].
 
-stop_vcard_mod(Config) ->
+stop_vcard_mod(_Config) ->
     Domain = ct:get_config({hosts, mim, domain}),
     dynamic_modules:stop(Domain, mod_vcard).
 

--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -31,6 +31,9 @@
 
 -import(vcard_update, [is_vcard_ldap/0]).
 
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -58,8 +61,7 @@ all_tests() ->
      search_wildcard].
 
 suite() ->
-    escalus:suite().
-
+    require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -449,7 +451,7 @@ get_FN(Config) ->
 
 configure_ldap_vcards(Config) ->
     Domain = ct:get_config({hosts, mim, domain}),
-    CurrentConfigs = escalus_ejabberd:rpc(gen_mod, loaded_modules_with_opts, [Domain]),
+    CurrentConfigs = rpc(mim(), gen_mod, loaded_modules_with_opts, [Domain]),
     {mod_vcard, CurrentVcardConfig} = lists:keyfind(mod_vcard, 1, CurrentConfigs),
     dynamic_modules:stop(Domain, mod_vcard),
     Cfg = [{backend,ldap}, {host, "vjud.@HOST@"},

--- a/big_tests/tests/vcard_update.erl
+++ b/big_tests/tests/vcard_update.erl
@@ -5,6 +5,9 @@
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
 -type escalus_client() :: #client{}.
 
 -spec discard_vcard_update(User) -> NDiscarded when
@@ -35,8 +38,7 @@ is_vcard_update(_) ->
 
 has_mod_vcard_xupdate() ->
     Server = ct:get_config({hosts, mim, domain}),
-    escalus_ejabberd:rpc(gen_mod, is_loaded,
-                         [server_string(Server), mod_vcard_xupdate]).
+    rpc(mim(), gen_mod, is_loaded, [server_string(Server), mod_vcard_xupdate]).
 
 server_string(BString) when is_binary(BString) ->
     case server_string_type() of
@@ -63,7 +65,7 @@ server_string_type() ->
 
 -spec is_ejabberd_community() -> boolean().
 is_ejabberd_community() ->
-    Apps = escalus_ejabberd:rpc(application, which_applications, []),
+    Apps = rpc(mim(), application, which_applications, []),
     case lists:keyfind(ejabberd, 1, Apps) of
         {ejabberd, "ejabberd", "community" ++ _} ->
             true;
@@ -73,7 +75,7 @@ is_ejabberd_community() ->
 
 -spec is_mongooseim() -> boolean().
 is_mongooseim() ->
-    Apps = escalus_ejabberd:rpc(application, which_applications, []),
+    Apps = rpc(mim(), application, which_applications, []),
     case lists:keyfind(ejabberd, 1, Apps) of
         {ejabberd, "ejabberd", "2.1.8+mim" ++ _} ->
             true;
@@ -83,9 +85,7 @@ is_mongooseim() ->
 
 -spec try_ejabberd2() -> no_return().
 try_ejabberd2() ->
-    [{config, hosts,
-      [XMPPDomain | _]}] = escalus_ejabberd:rpc(ets, lookup,
-                                                [config, hosts]),
+    [{config, hosts, [XMPPDomain | _]}] = rpc(mim(), ets, lookup, [config, hosts]),
     case XMPPDomain of
         BString when is_binary(BString) ->
             throw(binary);
@@ -94,6 +94,5 @@ try_ejabberd2() ->
     end.
 
 is_vcard_ldap()->
-    ldap==escalus_ejabberd:rpc(gen_mod, get_module_opt,
-                               [ct:get_config({hosts, mim, domain}),
-                                mod_vcard, backend, mnesia]).
+    ldap == rpc(mim(), gen_mod, get_module_opt,
+                [ct:get_config({hosts, mim, domain}), mod_vcard, backend, mnesia]).

--- a/big_tests/tests/vcard_update.erl
+++ b/big_tests/tests/vcard_update.erl
@@ -56,7 +56,7 @@ server_string_type() ->
     try
         is_ejabberd_community() andalso throw(binary),
         is_mongooseim() andalso throw(binary),
-        try_ejabberd2(),
+        try_ejabberd_v2(),
         error(server_string_type_unknown)
     catch
         throw:binary -> binary;
@@ -83,8 +83,8 @@ is_mongooseim() ->
             false
     end.
 
--spec try_ejabberd2() -> no_return().
-try_ejabberd2() ->
+-spec try_ejabberd_v2() -> no_return().
+try_ejabberd_v2() ->
     [{config, hosts, [XMPPDomain | _]}] = rpc(mim(), ets, lookup, [config, hosts]),
     case XMPPDomain of
         BString when is_binary(BString) ->


### PR DESCRIPTION
This PR tests Escalus with changes from https://github.com/esl/escalus/pull/170 as well as somewhat cleans up the way RPC is done in big tests.

With regard to RPC in big tests, this is not complete. There are still things which require refactoring:
- other `escalus_ejabberd` calls which hide RPC in the library, but by default access a particular node
- `rpc_apply` in `mam_SUITE`
- modules importing `escalus_ejabberd`, but not calling `escalus_ejabberd:rpc` directly - these cases weren't caught by `sed`
- quite likely other cases, `grep rpc` or `rg rpc` in `big_tests/` should give hints.

These bullet points do not suggest this stuff should go into this PR. Rather, than even when this PR is merged, the cleanup won't be complete yet.