### PR TITLE
[skip ci] SASL EXTERNAL docs

### DIFF
--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -17,8 +17,12 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 ### Configuration
 
 * `certfile` (string, default: no certfile will be used) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
+* `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA certificate that will be used to verify clients. Won't have any effect if `verify_peer` is not enabled.
+* `crlfiles` (list of strings, default: []) - A list of paths to Certificate Revocation Lists.
+* `verify_peer` (default: disabled) - Enforces verification of a client certificate. Requires valid `cafile`.
 * `starttls` (default: disabled) - Enables StartTLS support; requires `certfile`.
 * `starttls_required` (default: disabled) - enforces StartTLS usage.
+* `tls_module` (atom, default: `fast_tls`) - Provides a TLS library to use. `fast_tls` uses OpenSSL-based NIFs, while `just_tls` uses Erlang TLS implementation provided by OTP. The latter one is required for `SASL EXTERNAL` (certificate-based) authentication method.
 * `zlib` (atom or a positive integer, default: disabled) - Enables ZLIB support, the integer value is a limit for a decompressed output size (to prevent successful [ZLIB bomb attack](http://xmpp.org/resources/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas/)); the limit can be disabled with an atom 'unlimited'.
 * `ciphers` (string, default: as of OpenSSL 1.0.0 it's `ALL:!aNULL:!eNULL` [(source)](https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS)) - cipher suites to use with StartTLS.
  Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/apps/ciphers.html) for the cipher string format.

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -17,12 +17,12 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 ### Configuration
 
 * `certfile` (string, default: no certfile will be used) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
-* `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA certificate that will be used to verify clients. Won't have any effect if `verify_peer` is not enabled.
-* `crlfiles` (list of strings, default: []) - A list of paths to Certificate Revocation Lists.
+* `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA chain that will be used to verify clients. Won't have any effect if `verify_peer` is not enabled.
+* `crlfiles` (list of strings, default: []) - A list of paths to Certificate Revocation Lists. Not supported by `fast_tls` TLS module.
 * `verify_peer` (default: disabled) - Enforces verification of a client certificate. Requires valid `cafile`.
 * `starttls` (default: disabled) - Enables StartTLS support; requires `certfile`.
 * `starttls_required` (default: disabled) - enforces StartTLS usage.
-* `tls_module` (atom, default: `fast_tls`) - Provides a TLS library to use. `fast_tls` uses OpenSSL-based NIFs, while `just_tls` uses Erlang TLS implementation provided by OTP. The latter one is required for `SASL EXTERNAL` (certificate-based) authentication method.
+* `tls_module` (atom, default: `fast_tls`) - Provides a TLS library to use. `fast_tls` uses OpenSSL-based NIFs, while `just_tls` uses Erlang TLS implementation provided by OTP. They are fully interchangeable, with some exceptions (`ejabberd_c2s` options supported by only one of them are explicitly described, e.g. `crlfiles`).
 * `zlib` (atom or a positive integer, default: disabled) - Enables ZLIB support, the integer value is a limit for a decompressed output size (to prevent successful [ZLIB bomb attack](http://xmpp.org/resources/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas/)); the limit can be disabled with an atom 'unlimited'.
 * `ciphers` (string, default: as of OpenSSL 1.0.0 it's `ALL:!aNULL:!eNULL` [(source)](https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS)) - cipher suites to use with StartTLS.
  Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/apps/ciphers.html) for the cipher string format.

--- a/doc/authentication-backends/PKI-authentication-module.md
+++ b/doc/authentication-backends/PKI-authentication-module.md
@@ -1,0 +1,20 @@
+## Overview
+
+PKI authentication backend is compatible only with SASL mechanisms, that are based on client certificates.
+Currently there is only one such mechanism: `SASL EXTERNAL`.
+
+It extracts Common Name from a certificate and returns it as a username part in JID.
+
+## WARNING
+
+Some of its callbacks return hardcoded values, as it's impossible for this backend to properly acquire certain pieces of information.
+These include:
+
+* `function` - `hardcoded value` - Explanation.
+* `does_user_exist` - `true` - This function is used e.g. by `mod_mam` to verify if the user's interlocutor actually exists, so messages to nonexistent users will be stored anyway. It is not necessarily a security threat but requires extra caution.
+* `dirty_get_registered_users`, `get_vh_registered_users`, `get_vh_registered_users_number` - `[]` - Any metrics or statistics (e.g. available via `mongooseimctl`) related to accounts list or count, won't display proper values, as this backend cannot possibly "know" how many users there are.
+
+## Configuration options
+
+None.
+

--- a/doc/authentication-backends/PKI-authentication-module.md
+++ b/doc/authentication-backends/PKI-authentication-module.md
@@ -5,6 +5,10 @@ Currently there is only one such mechanism: `SASL EXTERNAL`.
 
 It extracts Common Name from a certificate and returns it as a username part in JID.
 
+## Client certificate requirements
+
+Common Name must be equal to username part of the client JID.
+
 ## WARNING
 
 Some of its callbacks return hardcoded values, as it's impossible for this backend to properly acquire certain pieces of information.

--- a/doc/authentication-backends/PKI-authentication-module.md
+++ b/doc/authentication-backends/PKI-authentication-module.md
@@ -1,22 +1,23 @@
 ## Overview
 
-PKI authentication backend is compatible only with SASL mechanisms, that are based on client certificates.
-Currently there is only one such mechanism: `SASL EXTERNAL`.
+The PKI authentication backend is compatible only with SASL mechanisms, that are based on client certificates.
+Currently only `SASL EXTERNAL` meets that requirement.
 
-It extracts Common Name from a certificate and returns it as a username part in JID.
+It extracts the Common Name from a certificate and returns it as a username part in JID.
 
 ## Client certificate requirements
 
-Common Name must be equal to username part of the client JID.
+Common Name must be equal to the username part of the client JID.
 
 ## WARNING
 
 Some of its callbacks return hardcoded values, as it's impossible for this backend to properly acquire certain pieces of information.
 These include:
 
-* `function` - `hardcoded value` - Explanation.
-* `does_user_exist` - `true` - This function is used e.g. by `mod_mam` to verify if the user's interlocutor actually exists, so messages to nonexistent users will be stored anyway. It is not necessarily a security threat but requires extra caution.
-* `dirty_get_registered_users`, `get_vh_registered_users`, `get_vh_registered_users_number` - `[]` - Any metrics or statistics (e.g. available via `mongooseimctl`) related to accounts list or count, won't display proper values, as this backend cannot possibly "know" how many users there are.
+| Function | Hardcoded value | Explanation |
+| ---------- | ----------------- | ----------- |
+| `does_user_exist` | `true` | PKI reponds with `true` to modules checking if user's interlocutor actually exists so e.g. messages to nonexistent users will always be stored by `mod_mam`. This is not necessarily a security threat but something to be aware of. |
+| `dirty_get_registered_users`, `get_vh_registered_users`, `get_vh_registered_users_number` | `[]` | Any metrics or statistics (e.g. available via `mongooseimctl`) related to accounts list or numbers, won't display proper values, as this backend cannot possibly "know" how many users there are. |
 
 ## Configuration options
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -1,7 +1,7 @@
 ## Overview
 
 Clients connected to MongooseIM may authenticate with their TLS certificates.
-This method is a combination of `SASL EXTERNAL` mechanism and compatible certificate-aware backend.
+This method is a combination of the `SASL EXTERNAL` mechanism and a compatible certificate-aware backend.
 
 ## Server-side prerequisites
 
@@ -99,9 +99,9 @@ openssl pkcs12 -export -inkey client.key -in client.crt -out client.p12
 
 ### Configure MongooseIM
 
-See examples before this section. We recommend the first snippet for sake of simplicity.
+See examples in the section above. We recommend using the first snippet for simplicity.
 
-You don't need to pre-create user account in order to log in with certificate.
+You don't need to pre-create a user account in order to log in with a certificate.
 
 ### Add an account in Gajim
 
@@ -110,8 +110,8 @@ You don't need to pre-create user account in order to log in with certificate.
 3. Jabber ID is `[Common Name from certificate]@localhost` (domain is different if you've changed it in `hosts` option). Press "Next".
 5. Untick "Connect when I press Finish" and press "Advanced".
 6. Unfold "Client certificate" and choose the `.p12` you've created earlier. Tick "Certificate is encrypted".
-7. Click "Close" and set status to "Available". Tell Gajim to ingnore unverified server certificate (by default it's self-signed).
+7. Click "Close" and set status to "Available". Tell Gajim to ingnore the unverified server certificate (by default it's self-signed).
 
 If Gajim fails to connect, try to restart it.
-Version 0.16.8 sometimes "forgets" to ask for client certificate password.
+Version 0.16.8 sometimes "forgets" to ask for the client certificate password.
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -31,7 +31,9 @@ Below you may find a list of backends that are safe to use with `cyrsasl_externa
 * `pki`
 * `anonymous`
 * `http` **without** `{is_external, true}` option
+* `internal`
 * `odbc`
+* `riak`
 
 ### Examples
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -1,0 +1,108 @@
+## Overview
+
+Clients connected to MongooseIM may authenticate with their TLS certificates.
+This method is based on combination of [`ejabberd_auth_pki` backend](../authentication-backends/PKI-authentication-module.md) and `SASL EXTERNAL` mechanism.
+
+## Server-side prerequisites
+
+### Properly configure `ejabberd_c2s` listener
+
+By default MongooseIM uses `fast_tls` driver but unfortunatelly it doesn't implement an API to get the client certificate.
+In order for this method to work properly, we'll need `just_tls` module (`tls_module` option), which uses an OTP TLS implementation.
+
+Proper client verification is required as well, so you'll need to enable `verify_peer` option and provide a path to a certificate of a CA that signed client's certificate (`cafile` option).
+
+Please check [Listener modules](../advanced-configuration/Listener-modules.md#client-to-server-c2s-ejabberd_c2s) page for more information or simply follow the examples at the end of this section.
+
+### Enable `SASL EXTERNAL` method
+
+A `SASL EXTERNAL` authentication method is disabled by default.
+In order to enable it, please add [`sasl_mechanisms` option](../Advanced-configuration.md#authentication) to MongooseIM config file.
+Its value must include a `cyrsasl_external` item.
+Obviously the list may be longer, if the system should support both certificate and password based authentication.
+
+### Enable PKI authentication backend
+
+A PKI authentication backend extracts username from certificate's Common Name.
+Please modify [`auth_opts` option](../Advanced-configuration.md#authentication) in MongooseIM's config file to include `pki` item.
+
+### Examples
+
+Certificate authentication only.
+
+```
+{listen, [
+           (...)
+           {5222, ejabberd_c2s, [
+                                  (...)
+                                  {cafile, "/path/to/ca.pem"},
+                                  {tls_module, just_tls},
+                                  verify_peer,
+                                  (...)
+                                ]},
+           (...)
+         ]}.
+
+{auth_method, [pki]}.
+
+{sasl_mechanisms, [cyrsasl_external]}.
+```
+
+Authentication with a client certificate (validated with provided CA certificate) or password (validated with data stored in RDBMS).
+
+```
+{listen, [
+           (...)
+           {5222, ejabberd_c2s, [
+                                  (...)
+                                  {cafile, "/path/to/ca.pem"},
+                                  {tls_module, just_tls},
+                                  verify_peer,
+                                  (...)
+                                ]},
+           (...)
+         ]}.
+
+
+{auth_method, [odbc, pki]}.
+
+{sasl_mechanisms, [cyrsasl_scram, cyrsasl_external]}.
+```
+
+## Client certificate prerequisites
+
+All the client must provide, is a certificate with the username in Common Name.
+
+## Usage example - Gajim
+
+Verified with Gajim 0.16.8, installed from package `gajim-0.16.8-1.fc25.noarch`.
+
+### Generate client certificate
+
+```
+openssl genrsa -des3 -out rootCA.key 4096
+openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr # Remember to provide username as Common Name!
+openssl x509 -req -in client.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out client.crt -days 500 -sha256
+openssl pkcs12 -export -inkey client.key -in client.crt -out client.p12
+```
+
+### Configure MongooseIM
+
+See examples before this section. Configuration without `odbc` and `cyrsasl_scram` is sufficient.
+
+You don't need to pre-create user account in order to log in with certificate.
+
+### Add an account in Gajim
+
+1. Edit -> Accounts -> Add.
+2. Pick "I already have an account I want to use".
+3. Jabber ID is `[Common Name from certificate]@localhost` (domain is different if you've changed it in `hosts` option). Press "Next".
+5. Untick "Connect when I press Finish" and press "Advanced".
+6. Unfold "Client certificate" and choose the `.p12` you've created earlier. Tick "Certificate is encrypted".
+7. Click "Close" and set status to "Available". Tell Gajim to ingnore unverified server certificate (by default it's self-signed).
+
+If Gajim fails to connect, try to restart it.
+Version 0.16.8 sometimes "forgets" to ask for client certificate password.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,11 +32,14 @@ pages:
       - 'Listener Modules': 'advanced-configuration/Listener-modules.md'
       - 'ACL': 'advanced-configuration/acl.md'
       - 'Services': 'advanced-configuration/Services.md'
+  - 'Authentication methods':
+      - 'Client Certificate': 'authentication-methods/client-certificate.md'
   - 'Authentication backends':
       - 'External Authentication Module': 'authentication-backends/External-authentication-module.md'
       - 'HTTP Authentication Module': 'authentication-backends/HTTP-authentication-module.md'
       - 'JWT Authentication Module': 'authentication-backends/JWT-authentication-module.md'
       - 'LDAP Authentication Module': 'authentication-backends/LDAP-authentication-module.md'
+      - 'PKI Authentication Module': 'authentication-backends/PKI-authentication-module.md'
   - 'MongooseIM open XMPP extensions':
       - 'MUC light': 'open-extensions/muc_light.md'
       - 'Token-based reconnection': 'open-extensions/token-reconnection.md'
@@ -81,6 +84,7 @@ pages:
           - 'Push backend': 'modules/mod_event_pusher_push.md'
           - 'SNS backend': 'modules/mod_event_pusher_sns.md'
       - 'mod_http_upload': 'modules/mod_http_upload.md'
+      - 'mod_jingle_sip': 'modules/mod_jingle_sip.md'
       - 'mod_keystore': 'modules/mod_keystore.md'
       - 'mod_last': 'modules/mod_last.md'
       - 'mod_mam': 'modules/mod_mam.md'


### PR DESCRIPTION
This PR:

- Updates `Listener modules` page with missing c2s options.
- Adds "Client Certificate" page under new section: Authentication Methods
- Adds "PKI" page under Authentication Backends section

As a bonus:

- Adds missing `mod_jingle_sip` entry in `mkdocs.yml`