### PR TITLE
Revert "Fix broken lager_console_backend backend"

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -6,7 +6,7 @@
     {log_root, "{{mongooseim_log_dir}}"},
     {crash_log, "crash.log"},
     {handlers, [
-        {lager_console_backend, [{level, info}]},
+        {lager_console_backend, [info, {lager_default_formatter,[{eol, "\r\n"}]}]},
 %% use below line to add syslog backend for Lager
 %        {lager_syslog_backend, [ "mongooseim", local0, info]},
         {lager_file_backend, [{file, "ejabberd.log"}, {level, info}, {size, 2097152}, {date, "$D0"}, {count, 5}]}


### PR DESCRIPTION
Reverts esl/MongooseIM#1832 as it actually has broken the console logger.