### PR TITLE
Accumulator refactoring - setters, getters and specs

### DIFF
--- a/include/mongoose_acc.hrl
+++ b/include/mongoose_acc.hrl
@@ -1,0 +1,8 @@
+%%%-------------------------------------------------------------------
+%%% @doc Creates a new accumulator instance setting location arguments to the caller of this macro.
+%%% @end
+%%%-------------------------------------------------------------------
+-define(new_acc(), mongoose_acc:new(?MODULE, ?FUNCTION_NAME, ?LINE)).
+-define(new_acc(Element), mongoose_acc:new(Element, ?MODULE, ?FUNCTION_NAME, ?LINE)).
+-define(new_acc(Element, From), mongoose_acc:new(Element, From, ?MODULE, ?FUNCTION_NAME, ?LINE)).
+-define(new_acc(Element, From, To), mongoose_acc:new(Element, From, To, ?MODULE, ?FUNCTION_NAME, ?LINE)).

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1029,7 +1029,7 @@ process_outgoing_stanza(Acc, StateData) ->
     fsm_next_state(session_established, NState).
 
 process_outgoing_stanza(Acc, error, _Name, StateData) ->
-    case mongoose_acc:get(type, Acc) of
+    case mongoose_acc:get_element_type(Acc) of
         <<"error">> -> StateData;
         <<"result">> -> StateData;
         _ ->
@@ -1397,7 +1397,7 @@ preprocess_and_ship(Acc, From, To, El, StateData) ->
 response_negative(<<"iq">>, forbidden, From, To, Acc) ->
     send_back_error(mongoose_xmpp_errors:forbidden(), From, To, Acc);
 response_negative(<<"iq">>, deny, From, To, Acc) ->
-    IqType = mongoose_acc:get(type, Acc),
+    IqType = mongoose_acc:get_element_type(Acc),
     response_iq_deny(IqType, From, To, Acc);
 response_negative(<<"message">>, deny, From, To, Acc) ->
     mod_amp:check_packet(Acc, From, delivery_failed),
@@ -1544,7 +1544,7 @@ handle_routed_presence(From, To, Acc, StateData) ->
     Packet = mongoose_acc:get_element(Acc),
     State = ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
                                     StateData, [{From, To, Packet}]),
-    case mongoose_acc:get(type, Acc) of
+    case mongoose_acc:get_element_type(Acc) of
         <<"probe">> ->
             {LFrom, LBFrom} = lowcase_and_bare(From),
             NewState = case am_i_available_to(LFrom, LBFrom, State) of
@@ -2018,7 +2018,7 @@ specifically_visible_to(LFrom, #state{pres_invis = Invisible} = S) ->
                       State :: state()) -> {mongoose_acc:t(), state()}.
 presence_update(Acc, From, StateData) ->
     Packet = mongoose_acc:get_element(Acc),
-    case mongoose_acc:get(type, Acc) of
+    case mongoose_acc:get_element_type(Acc) of
         <<"unavailable">> ->
             Status = case xml:get_subtag(Packet, <<"status">>) of
                          false ->
@@ -2156,7 +2156,7 @@ presence_track(Acc, StateData) ->
     LTo = jid:to_lower(To),
     User = StateData#state.user,
     Server = StateData#state.server,
-    case mongoose_acc:get(type, Acc) of
+    case mongoose_acc:get_element_type(Acc) of
         <<"unavailable">> ->
             Acc1 = check_privacy_and_route(Acc, StateData),
             I = gb_sets:del_element(LTo, StateData#state.pres_i),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1022,7 +1022,7 @@ session_established(closed, StateData) ->
 %% comes back whence it originated
 -spec process_outgoing_stanza(mongoose_acc:t(), state()) -> fsm_return().
 process_outgoing_stanza(Acc, StateData) ->
-    ToJID = mongoose_acc:get(to_jid, Acc),
+    ToJID = mongoose_acc:get_to_jid(Acc),
     Name = mongoose_acc:get(name, Acc),
     NState = process_outgoing_stanza(Acc, ToJID, Name, StateData),
     ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, mongoose_acc:get_element(Acc)}]),
@@ -2151,7 +2151,7 @@ presence_update_to_available(false, Acc, OldPriority, NewPriority, From, Packet,
 -spec presence_track(Acc :: mongoose_acc:t(),
                      State :: state()) -> {mongoose_acc:t(), state()}.
 presence_track(Acc, StateData) ->
-    To = mongoose_acc:get(to_jid, Acc),
+    To = mongoose_acc:get_to_jid(Acc),
     From = mongoose_acc:get_from_jid(Acc),
     LTo = jid:to_lower(To),
     User = StateData#state.user,
@@ -2221,7 +2221,7 @@ check_privacy_and_route(Acc, StateData) ->
                               StateData :: state()) -> mongoose_acc:t().
 check_privacy_and_route(Acc, FromRoute, StateData) ->
     From = mongoose_acc:get_from_jid(Acc),
-    To = mongoose_acc:get(to_jid, Acc),
+    To = mongoose_acc:get_to_jid(Acc),
     {Acc1, Res} = privacy_check_packet(Acc, To, out, StateData),
     Packet = mongoose_acc:get_element(Acc1),
     case Res of

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1438,9 +1438,8 @@ handle_routed(_, _From, _To, Acc, StateData) ->
                        Acc :: mongoose_acc:t(),
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc, StateData) ->
-    Acc1 = mongoose_acc:require(iq_query_info, Acc),
-    Qi = mongoose_acc:get(iq_query_info, Acc1),
-    handle_routed_iq(From, To, Acc1, Qi, StateData).
+    Qi = mongoose_acc:get_element_iq_query_info(Acc),
+    handle_routed_iq(From, To, Acc, Qi, StateData).
 
 -spec handle_routed_iq(From :: jid:jid(),
                        To :: jid:jid(),
@@ -2438,10 +2437,9 @@ get_priority_from_presence(PresencePacket) ->
                          To :: jid:jid(),
                          StateData :: state()) -> {mongoose_acc:t(), state()}.
 process_privacy_iq(Acc0, To, StateData) ->
-    Acc = mongoose_acc:require(iq_query_info, Acc0),
-    case mongoose_acc:get(iq_query_info, Acc) of
+    case mongoose_acc:get_element_iq_query_info(Acc0) of
         #iq{type = Type, sub_el = SubEl} = IQ ->
-            Acc1 = mongoose_acc:put(iq, IQ, Acc),
+            Acc1 = mongoose_acc:put(iq, IQ, Acc0),
             From = mongoose_acc:get_from_jid(Acc1),
             {Acc2, NewStateData} = process_privacy_iq(Acc1, Type, To, StateData),
             Res = mongoose_acc:get(iq_result, Acc2, {error, mongoose_xmpp_errors:feature_not_implemented()}),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1023,7 +1023,7 @@ session_established(closed, StateData) ->
 -spec process_outgoing_stanza(mongoose_acc:t(), state()) -> fsm_return().
 process_outgoing_stanza(Acc, StateData) ->
     ToJID = mongoose_acc:get_to_jid(Acc),
-    Name = mongoose_acc:get(name, Acc),
+    Name = mongoose_acc:get_element_name(Acc),
     NState = process_outgoing_stanza(Acc, ToJID, Name, StateData),
     ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, mongoose_acc:get_element(Acc)}]),
     fsm_next_state(session_established, NState).
@@ -1274,7 +1274,7 @@ handle_incoming_message({broadcast, Accum}, StateName, StateData) ->
 handle_incoming_message({route, From, To, Acc0}, StateName, StateData) ->
     Acc = setup_accum(Acc0, StateData),
     Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [{route, From, To}]),
-    Name = mongoose_acc:get(name, Acc1),
+    Name = mongoose_acc:get_element_name(Acc1),
     process_incoming_stanza_with_conflict_check(Name, From, To, Acc1, StateName, StateData);
 handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
     % this is used by pubsub and should be rewritten when someone rewrites pubsub module

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1039,7 +1039,7 @@ process_outgoing_stanza(Acc, error, _Name, StateData) ->
     end;
 process_outgoing_stanza(Acc, ToJID, <<"presence">>, StateData) ->
     FromJID = mongoose_acc:get(from_jid, Acc),
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     User = mongoose_acc:get(user, Acc),
     Res = ejabberd_hooks:run_fold(c2s_update_presence, Server, Acc, []),
     El = mongoose_acc:get(element, Res),
@@ -1059,7 +1059,7 @@ process_outgoing_stanza(Acc, ToJID, <<"presence">>, StateData) ->
 process_outgoing_stanza(Acc0, ToJID, <<"iq">>, StateData) ->
     Acc = mongoose_acc:require(xmlns, Acc0),
     FromJID = mongoose_acc:get(from_jid, Acc),
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     El = mongoose_acc:get(element, Acc),
     {_Acc, NState} = case mongoose_acc:get(xmlns, Acc, undefined) of
                          ?NS_PRIVACY ->
@@ -1077,7 +1077,7 @@ process_outgoing_stanza(Acc0, ToJID, <<"iq">>, StateData) ->
     NState;
 process_outgoing_stanza(Acc, ToJID, <<"message">>, StateData) ->
     FromJID = mongoose_acc:get(from_jid, Acc),
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     El = mongoose_acc:get(element, Acc),
     Acc1 = ejabberd_hooks:run_fold(user_send_packet,
                                    Server,
@@ -1766,7 +1766,7 @@ maybe_send_element_safe(State, El) ->
 send_element(#state{server = Server} = StateData, #xmlel{} = El) ->
     % used mostly in states other then session_established
     Acc = ?new_acc(El),
-    Acc1 = send_element(mongoose_acc:put(server, Server, Acc), El, StateData),
+    Acc1 = send_element(mongoose_acc:set_server(Acc, Server), El, StateData),
     mongoose_acc:get(send_result, Acc1).
 
 %% @doc This is the termination point - from here stanza is sent to the user

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -52,6 +52,7 @@
          delete/1]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 
 -type hook() :: {atom(), jid:server() | global, module(), fun() | atom(), integer()}.
 
@@ -128,7 +129,7 @@ run(Hook, Args) ->
           Host :: jid:server() | global,
           Args :: [any()]) -> ok.
 run(Hook, Host, Args) ->
-    run_fold(Hook, Host, mongoose_acc:new(), Args).
+    run_fold(Hook, Host, ?new_acc(), Args).
 
 %% @spec (Hook::atom(), Val, Args) -> Val | stopped | NewVal
 %% @doc Run the calls of this hook in order.

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -92,9 +92,8 @@ start_link() ->
                  El :: exml:element()
                  ) -> 'nothing' | 'ok' | 'todo' | pid()
                     | {'error', 'lager_not_running'} | {'process_iq', _, _, _}.
-process_iq(Acc0, From, To, El) ->
-    Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
+process_iq(Acc, From, To, El) ->
+    IQ = mongoose_acc:get_element_iq_query_info(Acc),
     process_iq(IQ, Acc, From, To, El).
 
 process_iq(#iq{xmlns = XMLNS} = IQ, Acc, From, To, _El) ->

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -395,7 +395,7 @@ do_route(Acc, From, To, El) ->
         user ->
             ejabberd_sm:route(From, To, Acc, El);
         server ->
-            case mongoose_acc:get(name, Acc) of
+            case mongoose_acc:get_element_name(Acc) of
                 <<"iq">> ->
                     process_iq(Acc, From, To, El);
                 _ ->

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -402,7 +402,7 @@ do_route(Acc, From, To, El) ->
                     ok
             end;
         local_resource ->
-            case mongoose_acc:get(type, Acc) of
+            case mongoose_acc:get_element_type(Acc) of
                 <<"error">> -> ok;
                 <<"result">> -> ok;
                 _ ->

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -138,7 +138,7 @@ route(From, To, Acc, El) ->
                   Acc :: mongoose_acc:t(),
                   ErrPacket :: exml:element()) -> mongoose_acc:t().
 route_error(From, To, Acc, ErrPacket) ->
-    case <<"error">> == mongoose_acc:get(type, Acc) of
+    case <<"error">> == mongoose_acc:get_element_type(Acc) of
         false ->
             route(From, To, Acc, ErrPacket);
         true ->

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -66,6 +66,7 @@
 -export([update_tables/0]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("route.hrl").
 -include("external_component.hrl").
@@ -115,7 +116,7 @@ start_link() ->
 route(From, To, #xmlel{} = Packet) ->
     % ?ERROR_MSG("Deprecated - it should be Acc: ~p", [Packet]),
     % (called by broadcasting)
-    route(From, To, mongoose_acc:from_element(Packet, From, To));
+    route(From, To, ?new_acc(Packet, From, To));
 route(From, To, Acc) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
            [From, To, Acc]),

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -120,7 +120,7 @@ route(From, To, #xmlel{} = Packet) ->
 route(From, To, Acc) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
            [From, To, Acc]),
-    El = mongoose_acc:get(element, Acc),
+    El = mongoose_acc:get_element(Acc),
     route(From, To, Acc, El, routing_modules_list()).
 
 route(From, To, Acc, {error, Reason}) ->

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -284,7 +284,7 @@ do_route(From, To, Acc, Packet) ->
             send_element(Pid, Acc1, NewPacket),
             done;
         {aborted, _Reason} ->
-            case mongoose_acc:get(type, Acc) of
+            case mongoose_acc:get_element_type(Acc) of
                 <<"error">> -> done;
                 <<"result">> -> done;
                 _ ->

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -445,7 +445,7 @@ route_stanza(_, _Acc) ->
 
 -spec route_stanza(mongoose_acc:t()) -> mongoose_acc:t().
 route_stanza(Acc) ->
-    From = mongoose_acc:get(from_jid, Acc),
+    From = mongoose_acc:get_from_jid(Acc),
     To = mongoose_acc:get(to_jid, Acc),
     LTo = To#jid.lserver,
     Acc1 = ejabberd_hooks:run_fold(s2s_receive_packet,

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -46,6 +46,7 @@
          terminate/3]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 
 -record(state, {socket,
@@ -404,7 +405,7 @@ route_incoming_stanza(From, To, El, StateData) ->
     LFrom = From#jid.lserver,
     LTo = To#jid.lserver,
     #xmlel{name = Name} = El,
-    Acc = mongoose_acc:from_element(El, From, To),
+    Acc = ?new_acc(El, From, To),
     case is_s2s_authenticated(LFrom, LTo, StateData) of
         true ->
             route_stanza(Name, Acc);

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -446,7 +446,7 @@ route_stanza(_, _Acc) ->
 -spec route_stanza(mongoose_acc:t()) -> mongoose_acc:t().
 route_stanza(Acc) ->
     From = mongoose_acc:get_from_jid(Acc),
-    To = mongoose_acc:get(to_jid, Acc),
+    To = mongoose_acc:get_to_jid(Acc),
     LTo = To#jid.lserver,
     Acc1 = ejabberd_hooks:run_fold(s2s_receive_packet,
                                    LTo, Acc, []),

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -861,7 +861,7 @@ send_queue(StateData, Q) ->
 %% @doc Bounce a single message (xmlel)
 -spec bounce_element(Acc :: mongoose_acc:t(), El :: exml:element(), Error :: exml:element()) -> 'ok'.
 bounce_element(Acc, El, Error) ->
-    case mongoose_acc:get(type, Acc) of
+    case mongoose_acc:get_element_type(Acc) of
         <<"error">> -> ok;
         <<"result">> -> ok;
         _ ->

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -866,7 +866,7 @@ bounce_element(Acc, El, Error) ->
         <<"result">> -> ok;
         _ ->
             From = mongoose_acc:get_from_jid(Acc),
-            To = mongoose_acc:get(to_jid, Acc),
+            To = mongoose_acc:get_to_jid(Acc),
             {Acc1, Err} = jlib:make_error_reply(Acc, El, Error),
             ejabberd_router:route(To, From, Acc1, Err)
     end.

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -865,7 +865,7 @@ bounce_element(Acc, El, Error) ->
         <<"error">> -> ok;
         <<"result">> -> ok;
         _ ->
-            From = mongoose_acc:get(from_jid, Acc),
+            From = mongoose_acc:get_from_jid(Acc),
             To = mongoose_acc:get(to_jid, Acc),
             {Acc1, Err} = jlib:make_error_reply(Acc, El, Error),
             ejabberd_router:route(To, From, Acc1, Err)

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -353,7 +353,7 @@ handle_info({send_element, El}, StateName, StateData) ->
     send_element(StateData, El),
     {next_state, StateName, StateData};
 handle_info({route, From, To, Acc}, StateName, StateData) ->
-    Packet = mongoose_acc:get(element, Acc),
+    Packet = mongoose_acc:get_element(Acc),
     ?DEBUG("event=packet_to_component,component=\"~s\",from=\"~s\",to=\"~s\"",
            [component_host(StateData), jid:to_binary(From), jid:to_binary(To)]),
     case acl:match_rule(global, StateData#state.access, From) of

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -74,6 +74,7 @@
 -export([do_route/4]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("ejabberd_commands.hrl").
 -include("mod_privacy.hrl").
@@ -131,9 +132,9 @@ start_link() ->
       Packet :: exml:element() | mongoose_acc:t()| ejabberd_c2s:broadcast(),
       Acc :: mongoose_acc:t().
 route(From, To, #xmlel{} = Packet) ->
-    route(From, To, mongoose_acc:from_element(Packet, From, To));
+    route(From, To, ?new_acc(Packet, From, To));
 route(From, To, {broadcast, Payload}) ->
-    route(From, To, mongoose_acc:new(), {broadcast, Payload});
+    route(From, To, ?new_acc(), {broadcast, Payload});
 route(From, To, Acc) ->
     route(From, To, Acc, mongoose_acc:get(element, Acc)).
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -136,7 +136,7 @@ route(From, To, #xmlel{} = Packet) ->
 route(From, To, {broadcast, Payload}) ->
     route(From, To, ?new_acc(), {broadcast, Payload});
 route(From, To, Acc) ->
-    route(From, To, Acc, mongoose_acc:get(element, Acc)).
+    route(From, To, Acc, mongoose_acc:get_element(Acc)).
 
 route(From, To, Acc, {broadcast, Payload}) ->
     case (catch do_route(Acc, From, To, {broadcast, Payload})) of

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -967,10 +967,9 @@ get_max_user_sessions(LUser, Host) ->
       Acc :: mongoose_acc:t(),
       Packet :: exml:element(),
       Result :: ok | todo | pid() | {error, lager_not_running} | {process_iq, _, _, _}.
-process_iq(From, To, Acc0, Packet) ->
-    Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
-    process_iq(IQ, From, To, Acc0, Packet).
+process_iq(From, To, Acc, Packet) ->
+    IQ = mongoose_acc:get_element_iq_query_info(Acc),
+    process_iq(IQ, From, To, Acc, Packet).
 
 process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
     Host = To#jid.lserver,

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -89,7 +89,7 @@ user_not_present(Acc, User, Host, Resource, _Status) ->
 
 -spec chat_type(mongoose_acc:t()) -> chat | groupchat | headline | normal | false.
 chat_type(Acc) ->
-    case mongoose_acc:get(type, Acc, <<"normal">>) of
+    case mongoose_acc:get_element_type(Acc, <<"normal">>) of
         <<"chat">> -> chat;
         <<"groupchat">> -> groupchat;
         <<"headline">> -> headline;

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -16,6 +16,7 @@
 
 -include("jlib.hrl").
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 
 %% Callback API
 -export([should_publish/3, sender_id/2]).
@@ -59,7 +60,7 @@ publish_notification(Acc0, From, #jid{lserver = Host} = To, Packet, Services) ->
     lists:foreach(
       fun({PubsubJID, Node, Form}) ->
               Stanza = push_notification_iq(From, Packet, Node, Form),
-              Acc = mongoose_acc:from_element(Stanza, To, PubsubJID),
+              Acc = ?new_acc(Stanza, To, PubsubJID),
               ResponseHandler =
                   fun(Response) ->
                           mod_event_pusher_push:cast(Host, handle_publish_response,

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -22,6 +22,7 @@
 -module(jingle_sip_callbacks).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include_lib("nksip/include/nksip.hrl").
 -include_lib("nksip/include/nksip_call.hrl").
@@ -93,7 +94,7 @@ translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary) ->
     ok = mod_jingle_sip_backend:set_incoming_request(CallID, ReqID, FromJID, ToJID, JingleEl),
 
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
 
     {reply, ringing}.
@@ -112,7 +113,7 @@ sip_reinvite_unsafe(Req, _Call) ->
     ?WARNING_MSG("ContentEls: ~p", [ContentEls]),
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"transport-info">>, ContentEls ++ OtherEls),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
     {reply, ok}.
 
@@ -137,7 +138,7 @@ sip_bye(Req, _Call) ->
                       children = [#xmlel{name = <<"success">>}]},
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-terminate">>, [ReasonEl]),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
 
     {reply, ok}.
@@ -151,7 +152,7 @@ sip_cancel(_InviteReq, Req, _Call) ->
                       children = [#xmlel{name = <<"decline">>}]},
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-terminate">>, [ReasonEl]),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
 
     {reply, ok}.
@@ -204,7 +205,7 @@ invite_resp_callback({resp, 200, SIPMsg, _Call}) ->
 
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-accept">>, ContentEls ++ OtherEls),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     ok = mod_jingle_sip_backend:set_outgoing_accepted(CallID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
     ok;
@@ -221,7 +222,7 @@ invite_resp_callback({resp, 486, SIPMsg, _Call}) ->
                       children = [#xmlel{name = <<"decline">>}]},
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-terminate">>, [ReasonEl]),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
     ok;
 invite_resp_callback({resp, ErrorCode, SIPMsg, _Call})
@@ -234,7 +235,7 @@ invite_resp_callback({resp, ErrorCode, SIPMsg, _Call})
 
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-terminate">>, [ReasonEl]),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
     ok;
 
@@ -257,7 +258,7 @@ send_ringing_session_info(SIPMsg) ->
                        attrs = [{<<"xmlns">>, <<"urn:xmpp:jingle:apps:rtp:1:info">>}]},
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-info">>, [RingingEl]),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
-    Acc = mongoose_acc:from_element(IQEl, FromJID, ToJID),
+    Acc = ?new_acc(IQEl, FromJID, ToJID),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
     ok.
 

--- a/src/jingle_sip/jingle_sip_helper.erl
+++ b/src/jingle_sip/jingle_sip_helper.erl
@@ -46,7 +46,7 @@ jingle_iq(ToBinary, FromBinary, JingleEl) ->
 -spec maybe_rewrite_to_phone(mongoose_acc:t()) -> jid:jid().
 maybe_rewrite_to_phone(Acc) ->
     Server = mongoose_acc:get_server(Acc),
-    #jid{luser = ToUser} = JID = mongoose_acc:get(to_jid, Acc),
+    #jid{luser = ToUser} = JID = mongoose_acc:get_to_jid(Acc),
     ToRewrite = gen_mod:get_module_opt(Server, mod_jingle_sip, username_to_phone, []),
     case lists:keyfind(ToUser, 1, ToRewrite) of
         {ToUser, PhoneNumber} ->

--- a/src/jingle_sip/jingle_sip_helper.erl
+++ b/src/jingle_sip/jingle_sip_helper.erl
@@ -45,7 +45,7 @@ jingle_iq(ToBinary, FromBinary, JingleEl) ->
 
 -spec maybe_rewrite_to_phone(mongoose_acc:t()) -> jid:jid().
 maybe_rewrite_to_phone(Acc) ->
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     #jid{luser = ToUser} = JID = mongoose_acc:get(to_jid, Acc),
     ToRewrite = gen_mod:get_module_opt(Server, mod_jingle_sip, username_to_phone, []),
     case lists:keyfind(ToUser, 1, ToRewrite) of

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -184,7 +184,7 @@ translate_to_sip(<<"session-initiate">>, Jingle, Acc) ->
     FromJID = mongoose_acc:get(from_jid, Acc),
     From = jid:to_binary(jid:to_lus(FromJID)),
     To = jid:to_binary(jid:to_lus(ToJID)),
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     SDP = prepare_initial_sdp(Server, Jingle),
     ProxyURI = get_proxy_uri(Server),
     RequestURI = list_to_binary(["sip:", ToUser, "@", ProxyURI]),
@@ -205,7 +205,7 @@ translate_to_sip(<<"session-initiate">>, Jingle, Acc) ->
     mod_jingle_sip_backend:set_outgoing_request(SID, Handle, FromJID, ToJID),
     {ok, Handle};
 translate_to_sip(<<"session-accept">>, Jingle, Acc) ->
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     SID = exml_query:attr(Jingle, <<"sid">>),
     case mod_jingle_sip_backend:get_incoming_request(SID, mongoose_acc:get_prop(origin_jid, Acc)) of
         {ok, ReqID} ->

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -98,10 +98,10 @@ maybe_iq_to_other_user(Acc) ->
     #jid{luser = LUser} = mongoose_acc:get_prop(origin_jid, Acc),
     case LUser of
         StanzaTo ->
-            QueryInfo = jlib:iq_query_info(mongoose_acc:get(element, Acc)),
+            QueryInfo = jlib:iq_query_info(mongoose_acc:get_element(Acc)),
             maybe_jingle_get_stanza_to_self(QueryInfo, Acc);
         _ ->
-            QueryInfo = jlib:iq_query_info(mongoose_acc:get(element, Acc)),
+            QueryInfo = jlib:iq_query_info(mongoose_acc:get_element(Acc)),
             maybe_jingle_stanza(QueryInfo, Acc)
     end.
 

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -94,7 +94,7 @@ maybe_iq_stanza(Acc) ->
     end.
 
 maybe_iq_to_other_user(Acc) ->
-    #jid{luser = StanzaTo} = mongoose_acc:get(to_jid, Acc),
+    #jid{luser = StanzaTo} = mongoose_acc:get_to_jid(Acc),
     #jid{luser = LUser} = mongoose_acc:get_prop(origin_jid, Acc),
     case LUser of
         StanzaTo ->
@@ -108,7 +108,7 @@ maybe_iq_to_other_user(Acc) ->
 maybe_jingle_stanza(#iq{xmlns = ?JINGLE_NS, sub_el = Jingle, type = set} = IQ, Acc) ->
     JingleAction = exml_query:attr(Jingle, <<"action">>),
     From = mongoose_acc:get_from_jid(Acc),
-    To = mongoose_acc:get(to_jid, Acc),
+    To = mongoose_acc:get_to_jid(Acc),
     maybe_translate_to_sip(JingleAction, From, To, IQ, Acc);
 maybe_jingle_stanza(_, Acc) ->
     Acc.
@@ -168,7 +168,7 @@ route_ok_result(From, To, IQ) ->
 
 resend_session_initiate(#iq{sub_el = Jingle} = IQ, Acc) ->
     From = mongoose_acc:get_from_jid(Acc),
-    To = mongoose_acc:get(to_jid, Acc),
+    To = mongoose_acc:get_to_jid(Acc),
     SID = exml_query:attr(Jingle, <<"sid">>),
     case mod_jingle_sip_backend:get_session_info(SID, From) of
         {ok, Session} ->

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -86,7 +86,7 @@ intercept_jingle_stanza(Acc, _C2SState) ->
     end.
 
 maybe_iq_stanza(Acc) ->
-    case mongoose_acc:get(name, Acc) of
+    case mongoose_acc:get_element_name(Acc) of
         <<"iq">> ->
             maybe_iq_to_other_user(Acc);
         _ ->

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -107,7 +107,7 @@ maybe_iq_to_other_user(Acc) ->
 
 maybe_jingle_stanza(#iq{xmlns = ?JINGLE_NS, sub_el = Jingle, type = set} = IQ, Acc) ->
     JingleAction = exml_query:attr(Jingle, <<"action">>),
-    From = mongoose_acc:get(from_jid, Acc),
+    From = mongoose_acc:get_from_jid(Acc),
     To = mongoose_acc:get(to_jid, Acc),
     maybe_translate_to_sip(JingleAction, From, To, IQ, Acc);
 maybe_jingle_stanza(_, Acc) ->
@@ -167,7 +167,7 @@ route_ok_result(From, To, IQ) ->
     ejabberd_router:route(To, From, Packet).
 
 resend_session_initiate(#iq{sub_el = Jingle} = IQ, Acc) ->
-    From = mongoose_acc:get(from_jid, Acc),
+    From = mongoose_acc:get_from_jid(Acc),
     To = mongoose_acc:get(to_jid, Acc),
     SID = exml_query:attr(Jingle, <<"sid">>),
     case mod_jingle_sip_backend:get_session_info(SID, From) of
@@ -181,7 +181,7 @@ translate_to_sip(<<"session-initiate">>, Jingle, Acc) ->
     SID = exml_query:attr(Jingle, <<"sid">>),
     FromUser = mongoose_acc:get(user, Acc),
     #jid{luser = ToUser} = ToJID = jingle_sip_helper:maybe_rewrite_to_phone(Acc),
-    FromJID = mongoose_acc:get(from_jid, Acc),
+    FromJID = mongoose_acc:get_from_jid(Acc),
     From = jid:to_binary(jid:to_lus(FromJID)),
     To = jid:to_binary(jid:to_lus(ToJID)),
     Server = mongoose_acc:get_server(Acc),
@@ -273,7 +273,7 @@ try_to_accept_session(ReqID, Jingle, Acc, Server, SID) ->
     end.
 
 terminate_session_on_other_devices(SID, Acc) ->
-    #jid{lresource = Res} = From = mongoose_acc:get(from_jid, Acc),
+    #jid{lresource = Res} = From = mongoose_acc:get_from_jid(Acc),
     FromBin = jid:to_binary(From),
     ReasonEl = #xmlel{name = <<"reason">>,
                       children = [#xmlel{name = <<"cancel">>}]},

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -145,7 +145,7 @@ make_error_reply(#xmlel{name = Name, attrs = Attrs,
     NewAttrs = make_error_reply_attrs(Attrs),
     #xmlel{name = Name, attrs = NewAttrs, children = SubTags ++ [Error]};
 make_error_reply(Acc, Error) ->
-    make_error_reply(Acc, mongoose_acc:get(element, Acc), Error).
+    make_error_reply(Acc, mongoose_acc:get_element(Acc), Error).
 
 make_error_reply(Acc, Packet, Error) ->
     case mongoose_acc:get(return_type, Acc, undefined) of

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -79,7 +79,7 @@ check_packet(Packet = #xmlel{name = <<"message">>}, From, Event) ->
 check_packet(Packet = #xmlel{}, _, _) ->
     Packet;
 check_packet(Acc, #jid{lserver = Host} = From, Event) ->
-    case mongoose_acc:get(name, Acc) of
+    case mongoose_acc:get_element_name(Acc) of
         <<"message">> ->
             % this hook replaces original element with something modified by amp
             % which is a hack, but since we have accumulator here we have a chance
@@ -101,7 +101,7 @@ add_stream_feature(Acc, _Host) ->
 -spec amp_check_packet(mongoose_acc:t(), jid:jid(), amp_event()) -> mongoose_acc:t().
 amp_check_packet(Acc, From, Event) ->
     Res = mongoose_acc:get(amp_check_result, Acc, ok),
-    Name = mongoose_acc:get(name, Acc),
+    Name = mongoose_acc:get_element_name(Acc),
     amp_check_packet(Res, Name, Acc, From, Event).
 
 amp_check_packet(drop, _, Acc, _, _) ->

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -51,7 +51,7 @@ hooks(Host) ->
 run_initial_check(#{result := drop} = Acc, _C2SState) ->
     Acc;
 run_initial_check(Acc, _C2SState) ->
-    Acc1 = mod_amp:check_packet(Acc, mongoose_acc:get(from_jid, Acc), initial_check),
+    Acc1 = mod_amp:check_packet(Acc, mongoose_acc:get_from_jid(Acc), initial_check),
     case mongoose_acc:get(amp_check_result, Acc1, ok) of
         drop -> mongoose_acc:put(result, drop, Acc1);
         _ -> Acc1
@@ -70,7 +70,7 @@ check_packet(Packet = #xmlel{attrs = Attrs}, Event) ->
             Packet
     end;
 check_packet(Acc, Event) ->
-    check_packet(Acc, mongoose_acc:get(from_jid, Acc), Event).
+    check_packet(Acc, mongoose_acc:get_from_jid(Acc), Event).
 
 -spec check_packet(exml:element()|mongoose_acc:t(), jid:jid(), amp_event()) ->
     exml:element() | mongoose_acc:t() | drop.

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -117,7 +117,7 @@ amp_check_packet(_, <<"message">>, Acc, From, Event) ->
         drop ->
             mongoose_acc:put(amp_check_result, drop, Acc);
         NewElem ->
-            mongoose_acc:put(element, NewElem, Acc)
+            mongoose_acc:set_element(Acc, NewElem)
     end;
 amp_check_packet(_, _, Acc, _, _) ->
     Acc.

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -75,7 +75,7 @@ check_packet(Acc, Event) ->
 -spec check_packet(exml:element()|mongoose_acc:t(), jid:jid(), amp_event()) ->
     exml:element() | mongoose_acc:t() | drop.
 check_packet(Packet = #xmlel{name = <<"message">>}, From, Event) ->
-    mongoose_acc:get(element, check_packet(?new_acc(Packet), From, Event));
+    mongoose_acc:get_element(check_packet(?new_acc(Packet), From, Event));
 check_packet(Packet = #xmlel{}, _, _) ->
     Packet;
 check_packet(Acc, #jid{lserver = Host} = From, Event) ->
@@ -107,7 +107,7 @@ amp_check_packet(Acc, From, Event) ->
 amp_check_packet(drop, _, Acc, _, _) ->
     Acc;
 amp_check_packet(_, <<"message">>, Acc, From, Event) ->
-    Packet = mongoose_acc:get(element, Acc),
+    Packet = mongoose_acc:get_element(Acc),
     Res = case amp:extract_requested_rules(Packet) of
               none                    -> Packet;
               {rules, Rules}          -> process_amp_rules(Packet, From, Event, Rules);

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -19,6 +19,7 @@
 
 -include("amp.hrl").
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("ejabberd_c2s.hrl").
 
@@ -74,7 +75,7 @@ check_packet(Acc, Event) ->
 -spec check_packet(exml:element()|mongoose_acc:t(), jid:jid(), amp_event()) ->
     exml:element() | mongoose_acc:t() | drop.
 check_packet(Packet = #xmlel{name = <<"message">>}, From, Event) ->
-    mongoose_acc:get(element, check_packet(mongoose_acc:from_element(Packet), From, Event));
+    mongoose_acc:get(element, check_packet(?new_acc(Packet), From, Event));
 check_packet(Packet = #xmlel{}, _, _) ->
     Packet;
 check_packet(Acc, #jid{lserver = Host} = From, Event) ->

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -26,6 +26,7 @@
         ]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 
@@ -387,7 +388,7 @@ lookup_recent_messages(ArcJID, WithJID, Before, Limit) ->
     L.
 
 create_acc(CallerJid, Name, Type) ->
-    A = mongoose_acc:new(),
+    A = ?new_acc(),
     Map = #{name => Name, type => Type, from => jid:to_binary(CallerJid),
             from_jid => CallerJid},
     mongoose_acc:update(A, Map).

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -416,7 +416,7 @@ run_subscription(Type, CallerJid, OtherJid) ->
                                    Server,
                                    Acc1,
                                    [LUser, LServer, OtherJid, Type]),
-    ejabberd_router:route(CallerJid, OtherJid, mongoose_acc:get(element, Acc2)),
+    ejabberd_router:route(CallerJid, OtherJid, mongoose_acc:get_element(Acc2)),
     ok.
 
 set_subscription(Caller, Other, <<"connect">>) ->

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -51,6 +51,7 @@
          unregister_subhost/2]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 
 -type feature() :: any().
@@ -389,7 +390,7 @@ get_sm_items(empty, From, To, _Node, _Lang) ->
 -spec is_presence_subscribed(jid:jid(), jid:jid()) -> boolean().
 is_presence_subscribed(#jid{luser=User, lserver=Server}, #jid{luser=LUser, lserver=LServer}) ->
     % TODO this one probably could be smarter too
-    A = mongoose_acc:new(),
+    A = ?new_acc(),
     A2 = ejabberd_hooks:run_fold(roster_get, Server, A, [{User, Server}]),
     Roster = mongoose_acc:get(roster, A2, []),
     lists:any(fun({roster, _, _, {TUser, TServer, _}, _, S, _, _, _, _}) ->

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -317,7 +317,7 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Acc, Packet}) ->
                                            mod_mam_params:add_stanzaid_element(?MODULE, LServer))}
                 end
         end,
-    Acc1 = mongoose_acc:put(element, PacketAfterArchive, Acc),
+    Acc1 = mongoose_acc:set_element(Acc, PacketAfterArchive),
     Acc2 = mod_amp:check_packet(Acc1, From, AmpEvent),
     {From, To, Acc, mongoose_acc:get(element, Acc2)}.
 

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -319,7 +319,7 @@ filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Acc, Packet}) ->
         end,
     Acc1 = mongoose_acc:set_element(Acc, PacketAfterArchive),
     Acc2 = mod_amp:check_packet(Acc1, From, AmpEvent),
-    {From, To, Acc, mongoose_acc:get(element, Acc2)}.
+    {From, To, Acc, mongoose_acc:get_element(Acc2)}.
 
 
 process_incoming_packet(From, To, Packet) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -449,11 +449,10 @@ normal_state({route, From, <<>>, _Acc,
         packet = Packet,
         lang = Lang}, StateData),
     next_normal_state(NewStateData);
-normal_state({route, From, <<>>, Acc0,
+normal_state({route, From, <<>>, Acc,
           #xmlel{name = <<"iq">>} = Packet},
          StateData) ->
-    Acc = mongoose_acc:require(iq_query_info, Acc0),
-    IQ = mongoose_acc:get(iq_query_info, Acc),
+    IQ = mongoose_acc:get_element_iq_query_info(Acc),
     {RoutingEffect, NewStateData} = route_iq(Acc, #routed_iq{
         iq = IQ,
         from = From,

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -395,7 +395,7 @@ store_packet(Acc, From, To = #jid{luser = LUser, lserver = LServer},
              to = To,
              packet = jlib:remove_delay_tags(Packet)},
     Pid ! {Acc, Msg},
-    mongoose_acc:put(stored_offlne, true, Acc).
+    Acc.
 
 %% Check if the packet has any content about XEP-0022 or XEP-0085
 check_event_chatstates(Acc, From, To, Packet) ->

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -31,6 +31,7 @@
 -behavior(gen_server).
 -xep([{xep, 199}, {version, "2.0"}]).
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 
 -define(SUPERVISOR, ejabberd_sup).
@@ -190,7 +191,7 @@ handle_info({timeout, _TRef, {ping, JID}},
                 gen_server:cast(Pid, {iq_pong, JID, Response})
         end,
     From = jid:make(<<"">>, State#state.host, <<"">>),
-    Acc = mongoose_acc:from_element(IQ, From, JID),
+    Acc = ?new_acc(IQ, From, JID),
     ejabberd_local:route_iq(From, JID, Acc, IQ, F, PingReqTimeout),
     Timers = add_timer(JID, State#state.ping_interval, State#state.timers),
     {noreply, State#state{timers = Timers}};

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -705,7 +705,7 @@ disco_items(Host, Node, From) ->
 
 handle_pep_authorization_response({From, To, Acc, Packet}) ->
     Name = mongoose_acc:get_element_name(Acc),
-    Type = mongoose_acc:get(type, Acc),
+    Type = mongoose_acc:get_element_type(Acc),
     handle_pep_authorization_response(Name, Type, From, To, Acc, Packet).
 
 handle_pep_authorization_response(_, <<"error">>, From, To, Acc, Packet) ->

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -704,7 +704,7 @@ disco_items(Host, Node, From) ->
 %%
 
 handle_pep_authorization_response({From, To, Acc, Packet}) ->
-    Name = mongoose_acc:get(name, Acc),
+    Name = mongoose_acc:get_element_name(Acc),
     Type = mongoose_acc:get(type, Acc),
     handle_pep_authorization_response(Name, Type, From, To, Acc, Packet).
 

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -69,6 +69,7 @@
 -export([remove_test_user/2, transaction/2, process_subscription_transaction/6]). % for testing
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("mod_roster.hrl").
 
@@ -824,7 +825,7 @@ remove_test_user(User, Server) ->
     mod_roster_backend:remove_user(User, Server).
 
 remove_user(User, Server) ->
-    remove_user(mongoose_acc:new(), User, Server).
+    remove_user(?new_acc(), User, Server).
 
 remove_user(Acc, User, Server) ->
     LUser = jid:nodeprep(User),
@@ -1009,7 +1010,7 @@ get_roster_old(LUser, LServer) ->
     get_roster_old(LServer, LUser, LServer).
 
 get_roster_old(DestServer, LUser, LServer) ->
-    A = mongoose_acc:new(),
+    A = ?new_acc(),
     A2 = ejabberd_hooks:run_fold(roster_get, DestServer, A, [{LUser, LServer}]),
     mongoose_acc:get(roster, A2, []).
 

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -233,9 +233,8 @@ handle_call(_Request, _From, State) ->
     {reply, bad_request, State}.
 
 handle_info({route, From, To, Acc, _El}, State) ->
-    Acc1 = mongoose_acc:require(iq_query_info, Acc),
-    IQ = mongoose_acc:get(iq_query_info, Acc1),
-    case catch do_route(State#state.host, From, To, Acc1, IQ) of
+    IQ = mongoose_acc:get_element_iq_query_info(Acc),
+    case catch do_route(State#state.host, From, To, Acc, IQ) of
         {'EXIT', Reason} ->
             ?ERROR_MSG("~p", [Reason]);
         _ ->

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -1,300 +1,263 @@
 %%%-------------------------------------------------------------------
 %%% @doc
-%%% This module encapsulates a data type which will is instantiated when stanza
-%%% enters the system and is passed all the way along processing chain.
-%%% Its interface is map-like, and you can put there whatever you want, bearing in mind two things:
-%%% 1. It is read-only, you can't change value once you wrote it (accumulator is to accumulate)
-%%% 2. Whatever you put will be removed before the acc is sent to another c2s process
-%%%
-%%% There are three caveats to the above:
-%%% 1. Although you can not put to an existing key, you can append as many times as you like
-%%% 2. A special key 'result' is writeable and is meant to be used to get return value from hook calls
-%%% 3. If you want to pass something to another c2s process you can use add_prop/3 - values
-%%%    put there are not stripped.
+%%% TODO: docs
 %%% @end
 %%%-------------------------------------------------------------------
 -module(mongoose_acc).
--author("bartek").
 
 -include("jlib.hrl").
 -include("mongoose.hrl").
 
-%% API
--export([new/0, from_kv/2, put/3, get/2, get/3, find/2, append/3, remove/2]).
--export([increment/2, get_counter/2]).
--export([add_prop/3, get_prop/2]).
--export([from_element/1, from_map/1, update_element/4, update/2, is_acc/1, require/2]).
--export([strip/1, strip/2, record_sending/4, record_sending/6]).
--export([dump/1, to_binary/1]).
--export([to_element/1]).
+%%%-------------------------------------------------------------------
+%%% Exported types
+%%%-------------------------------------------------------------------
+
 -export_type([t/0]).
--export([from_element/3]).
+-export_type([element/0, element_name/0, element_type/0, element_attrs/0]).
 
-%% if it is defined as -opaque then dialyzer fails
--type t() :: map().
+-export_type([getter_result/1]).
 
-%%% This module encapsulates implementation of mongoose_acc
-%%% its interface is map-like but implementation might change
-%%% it is passed along many times, and relatively rarely read or written to
-%%% might be worth reimplementing as binary
+                 % Key name starting with 'a' will make it appear early when the accumulator is
+                 % printed and the map has only a few entries. Possibly could help with debugging.
+-opaque t() :: #{accumulator   := true,
+                 init_location := init_location(),
+                 element       => element_props(),
+                 from          => jid_props(),
+                 to            => jid_props()}.
 
-dump(Acc) ->
-    dump(Acc, lists:sort(maps:keys(Acc))).
+-type element()       :: exml:element() | jlib:iq().
+-type element_name()  :: binary().
+-type element_type()  :: binary() | undefined.
+-type element_attrs() :: [exml:attr()].
 
-to_binary(#xmlel{} = Packet) ->
-    exml:to_binary(Packet);
-to_binary({broadcast, Payload}) ->
-    case is_acc(Payload) of
-        true ->
-            to_binary(Payload);
-        false ->
-            list_to_binary(io_lib:format("~p", [Payload]))
-    end;
-to_binary(Acc) ->
-    % replacement to exml:to_binary, for error logging
-    case is_acc(Acc) of
-        true ->
-            El = get(element, Acc),
-            case El of
-                #xmlel{} -> exml:to_binary(El);
-                _ -> list_to_binary(io_lib:format("~p", [El]))
-            end;
-        false ->
-            list_to_binary(io_lib:format("~p", [Acc]))
+-type getter_result(Prop) :: {ok, Prop} | error.
+
+%%%-------------------------------------------------------------------
+%%% Internal types
+%%%-------------------------------------------------------------------
+
+-type init_location() :: {Module :: module(), Function :: atom(), Line :: pos_integer()}.
+-type prop() :: {element, element_props()}
+              | {from, jid_props()}
+              | {to, jid_props()}.
+-type element_props() :: #{record := element(),
+                           name   := element_name(),
+                           type   := element_type(),
+                           attrs  := element_attrs()}.
+-type jid_props() :: #{jid     := jid:jid(),
+                       bin_jid := binary()}.
+
+%%%-------------------------------------------------------------------
+%%% API
+%%%-------------------------------------------------------------------
+
+-export([new/3, new/4, new/5, new/6]).
+-export([get_element/1, get_element_name/1, get_element_type/1, get_element_attrs/1]).
+-export([get_from_jid/1, get_from_bin/1]).
+-export([get_to_jid/1, get_to_bin/1]).
+
+%%%-------------------------------------------------------------------
+% @doc Creates a new accumulator instance given location in the source code.
+%
+% The location arguments are required because they make it easier to debug where the accumulator
+% is coming from, whether it was initialized in the XMPP, HTTP or CLI context.
+% @end
+%-------------------------------------------------------------------
+-spec new(module(), atom(), pos_integer()) -> t().
+new(Module, Function, Line) when is_atom(Module),
+                                 is_atom(Function),
+                                 is_integer(Line),
+                                 Line > 0 ->
+    #{accumulator => true, init_location => {Module, Function, Line}}.
+
+%-------------------------------------------------------------------
+% @doc Creates a new accumulator instance given XML stanza which initiated the processing and
+% location in the source code.
+%
+% See `new/3' for more information.
+% @end
+%-------------------------------------------------------------------
+-spec new(element(), module(), atom(), pos_integer()) -> t().
+new(Element, Module, Function, Line) ->
+    set_element(new(Module, Function, Line), Element).
+
+%-------------------------------------------------------------------
+% @doc Creates a new accumulator instance given XML stanza which initiated the processing,
+% JID of the sender of that stanza and location in the source code.
+%
+% See `new/3' for more information.
+% @end
+%-------------------------------------------------------------------
+-spec new(element(), jid:jid(), module(), atom(), pos_integer()) -> t().
+new(Element, From, Module, Function, Line) ->
+    set_from(new(Element, Module, Function, Line), From).
+
+%-------------------------------------------------------------------
+% @doc Creates a new accumulator instance given XML stanza which initiated the processing,
+% JIDs of the sender and the recipient of that stanza, and location in the source code.
+%
+% See `new/3' for more information.
+% @end
+%-------------------------------------------------------------------
+-spec new(element(), jid:jid(), jid:jid(), module(), atom(), pos_integer()) -> t().
+new(Element, From, To, Module, Function, Line) ->
+    set_to(new(Element, From, Module, Function, Line), To).
+
+%-------------------------------------------------------------------
+% @doc Retrieves the whole XML element record set using `new/4,5,6'.
+%
+% Returns `error' atom if element isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_element(t()) -> getter_result(element()).
+get_element(Acc) ->
+    case maps:find(element, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(record, ElProps)};
+        error ->
+            error
     end.
 
-%% This function is for transitional period, eventually all hooks will use accumulator
-%% and we will not have to check
-is_acc(A) when is_map(A) ->
-    maps:get(mongoose_acc, A, false);
-is_acc(_) ->
-    false.
+%-------------------------------------------------------------------
+% @doc Retrieves name of the XML element record set using `new/4,5,6'.
+%
+% Returns `error' atom if element isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_element_name(t()) -> getter_result(element_name()).
+get_element_name(Acc) ->
+    case maps:find(element, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(name, ElProps)};
+        error ->
+            error
+    end.
 
-%% this is a temporary hack - right now processes receive accumulators and stanzas, it is all
-%% mixed up so we have to cater for this
--spec to_element(exml:element() | t()) -> exml:element().
-to_element(A) ->
-    case is_acc(A) of
-        true -> get(element, A, undefined);
-        false -> A
+%-------------------------------------------------------------------
+% @doc Retrieves type of the XML element set using `new/4,5,6'.
+%
+% Returns `error' atom if element isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_element_type(t()) -> getter_result(element_type()).
+get_element_type(Acc) ->
+    case maps:find(element, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(type, ElProps)};
+        error ->
+            error
+    end.
+
+%-------------------------------------------------------------------
+% @doc Retrieves list of attributes of the XML element set using `new/4,5,6'.
+%
+% Returns `error' atom if element isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_element_attrs(t()) -> getter_result(element_attrs()).
+get_element_attrs(Acc) ->
+    case maps:find(element, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(attrs, ElProps)};
+        error ->
+            error
+    end.
+
+%-------------------------------------------------------------------
+% @doc Retrieves `jid:jid()' representation of the sender of the stanza set using `new/5,6'.
+%
+% Returns `error' atom if sender isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_from_jid(t()) -> getter_result(jid:jid()).
+get_from_jid(Acc) ->
+    case maps:find(from, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(jid, ElProps)};
+        error ->
+            error
+    end.
+
+%-------------------------------------------------------------------
+% @doc Retrieves binary representation of the sender of the stanza set using `new/5,6'.
+%
+% Returns `error' atom if sender isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_from_bin(t()) -> getter_result(binary()).
+get_from_bin(Acc) ->
+    case maps:find(from, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(bin_jid, ElProps)};
+        error ->
+            error
+    end.
+
+%-------------------------------------------------------------------
+% @doc Retrieves `jid:jid()' representation of the recipient of the stanza set using `new/6'.
+%
+% Returns `error' atom if recipient isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_to_jid(t()) -> getter_result(jid:jid()).
+get_to_jid(Acc) ->
+    case maps:find(to, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(jid, ElProps)};
+        error ->
+            error
+    end.
+
+%-------------------------------------------------------------------
+% @doc Retrieves binary representation of the recipient of the stanza set using `new/5,6'.
+%
+% Returns `error' atom if recipient isn't set.
+% @end
+%-------------------------------------------------------------------
+-spec get_to_bin(t()) -> getter_result(binary()).
+get_to_bin(Acc) ->
+    case maps:find(to, Acc) of
+        {ok, ElProps} ->
+            {ok, maps:get(bin_jid, ElProps)};
+        error ->
+            error
     end.
 
 
-%%%%% API %%%%%
+%%%-------------------------------------------------------------------
+%%% Internal "API"
+%%%-------------------------------------------------------------------
 
--spec new() -> t().
-new() ->
-    #{mongoose_acc => true, timestamp => os:timestamp(), ref => make_ref()}.
+-spec put_prop(t(), prop()) -> t().
+put_prop(Acc, {PropKey, PropVal}) ->
+    maps:put(PropKey, PropVal, Acc).
 
--spec from_kv(atom(), any()) -> t().
-from_kv(K, V) ->
-    M = maps:put(K, V, #{}),
-    maps:put(mongoose_acc, true, M).
+-spec set_element(t(), element()) -> t().
+set_element(Acc, #xmlel{name = ElName, attrs = ElAttrs} = El) ->
+    ElType = exml_query:attr(El, <<"type">>, undefined),
+    ElProps = #{record => El,
+                name   => ElName,
+                type   => ElType,
+                attrs  => ElAttrs},
+    put_prop(Acc, {element, ElProps});
+set_element(Acc, #iq{type = IqType} = El) ->
+    ElType = atom_to_binary(IqType, latin1),
+    ElAttrs = [{<<"type">>, ElType}],
+    ElProps = #{record => El,
+                name   => <<"iq">>,
+                type   => ElType,
+                attrs  => ElAttrs},
+    put_prop(Acc, {element, ElProps}).
 
-%% @doc This one has an alternative form because normally an acc carries an xml element, as
-%% received from client, but sometimes messages are generated internally (broadcast) by sm
-%% and sent to c2s
--spec from_element(exml:element() | jlib:iq() | tuple()) -> t().
-from_element(#xmlel{name = Name, attrs = Attrs} = El) ->
-    Type = exml_query:attr(El, <<"type">>, undefined),
-    #{element => El, mongoose_acc => true, name => Name, attrs => Attrs, type => Type,
-        timestamp => os:timestamp(), ref => make_ref()
-        };
-from_element(#iq{type = Type} = El) ->
-    #{element => El, mongoose_acc => true, name => <<"iq">>, type => Type,
-        timestamp => os:timestamp(), ref => make_ref()
-    };
-from_element(El) when is_tuple(El) ->
-    Name = <<"broadcast">>,
-    Type = element(1, El),
-    % ref and timestamp will be filled in by strip/2
-    #{element => El, name => Name, type => Type, mongoose_acc => true}.
+-spec set_from(t(), jid:jid()) -> t().
+set_from(Acc, #jid{} = Jid) ->
+    JidProps = #{jid     => Jid,
+                 bin_jid => jid:to_binary(Jid)},
+    put_prop(Acc, {from, JidProps}).
 
--spec from_element(exml:element() | jlib:iq(), jid:jid(), jid:jid()) -> t().
-from_element(El, From, To) ->
-    Acc = from_element(El),
-    M = #{from_jid => From, to_jid => To, from => jid:to_binary(From), to => jid:to_binary(To)},
-    update(Acc, M).
+-spec set_to(t(), jid:jid()) -> t().
+set_to(Acc, #jid{} = Jid) ->
+    JidProps = #{jid     => Jid,
+                 bin_jid => jid:to_binary(Jid)},
+    put_prop(Acc, {to, JidProps}).
 
--spec from_map(map()) -> t().
-from_map(M) ->
-    maps:put(mongoose_acc, true, M).
-
--spec update_element(t(), exml:element(), jid:jid(), jid:jid()) -> t().
-update_element(Acc, Element, From, To) ->
-    update(Acc, from_element(Element, From, To)).
-
--spec update(t(), map() | t()) -> t().
-update(Acc, M) ->
-    maps:merge(Acc, M).
-
--spec put(any(), any(), t()) -> t().
-put(from_jid, Val, Acc) ->
-    % used only when we have to manually construct an acc (instead of calling from_element)
-    % namely: in c2s terminate, since it is not triggered by stanza, and in some
-    % deprecated functions
-    A = maps:put(from_jid, Val, Acc),
-    maps:put(from, jid:to_binary(Val), A);
-put(result, Val, Acc) ->
-    maps:put(result, Val, Acc);
-put(Key, Val, Acc) ->
-    % check whether we are replacing existing value (warning now, later it will become
-    % read-only; accumulator is for accumulating)
-    case maps:is_key(Key, Acc) of
-        true ->
-%%            ?WARNING_MSG("Overwriting existing key \"~p\" in accumulator,"
-%%                         "are you sure you have to do it?",
-%%                         [Key]);
-            ok;
-        false ->
-            ok
-    end,
-    maps:put(Key, Val, Acc).
-
--spec get(any()|[any()], t()) -> any().
-get(send_result, Acc) ->
-    hd(maps:get(send_result, Acc));
-get(Key, P) ->
-    maps:get(Key, P).
-
--spec get(any(), t(), any()) -> any().
-get(Key, P, Default) ->
-    maps:get(Key, P, Default).
-
-%% @doc increments a counter, returns new value
-%% counters are tagged so as not to interfere with other values
--spec increment(atom(), t()) -> {integer(), t()}.
-increment(Key, Acc) ->
-    CKey = {counter, Key},
-    NVal = get(CKey, Acc, 0) + 1,
-    {NVal, put(CKey, NVal, Acc)}.
-
-%% @doc returns current value of a counter
--spec get_counter(atom(), t()) -> integer().
-get_counter(Key, Acc) ->
-    get({counter, Key}, Acc, 0).
-
--spec find(any(), t()) -> {ok, any()} | error.
-find(send_result, Acc) ->
-    case maps:find(send_result, Acc) of
-        error -> error;
-        {ok, SRs} -> hd(SRs)
-    end;
-find(Key, P) ->
-    maps:find(Key, P).
-
--spec append(any(), any(), t()) -> t().
-append(Key, Val, P) ->
-    L = get(Key, P, []),
-    maps:put(Key, append(Val, L), P).
-
--spec remove(Key :: any(), Accumulator :: t()) -> t().
-remove(Key, Accumulator) ->
-    maps:remove(Key, Accumulator).
-
-%% @doc adds a persistent property to an accumulator
--spec add_prop(atom(), any(), t()) -> t().
-add_prop(Key, Value, Acc) ->
-    append(persistent_properties, {Key, Value}, Acc).
-
--spec get_prop(atom(), t()) -> any().
-get_prop(Key, Acc) ->
-    proplists:get_value(Key, get(persistent_properties, Acc, [])).
-
-%% @doc Make sure the acc has certain keys - some of them require expensive computations and
-%% are therefore not calculated upon instantiation, this func is saying "I will need these,
-%% please prepare them for me"
--spec require(any() | [any()], t()) -> t().
-require([], Acc) ->
-    Acc;
-require([Key|Tail], Acc) ->
-    Acc1 = case maps:is_key(Key, Acc) of
-               true -> Acc;
-               false -> produce(Key, Acc)
-           end,
-    require(Tail, Acc1);
-require(Key, Acc) ->
-    require([Key], Acc).
-
-%% @doc Convert the acc before routing it out to another c2s process - remove everything except
-%% the very bare minimum
-%% We get rid of all caches, traces etc.
-%% There is a special key "persistent_properties" which is also kept, use add_prop to store
-%% persistent stuff you want to pass between processes there.
--spec strip(t()) -> t().
-strip(Acc) ->
-    strip(Acc, get(element, Acc)).
-
-%% @doc alt version in case we want to replace the xmlel we are sending
--spec strip(t(), exml:element()) -> t().
-strip(Acc, El) ->
-    Acc1 = from_element(El),
-    Attributes = [ref, timestamp],
-    NewAcc = lists:foldl(fun(Attrib, AccIn) ->
-                           Val = maps:get(Attrib, Acc),
-                           maps:put(Attrib, Val, AccIn)
-                       end,
-                       Acc1, Attributes),
-    OptionalAttributes = [from, from_jid, to, to_jid, persistent_properties, global_distrib],
-    lists:foldl(fun(Attrib, AccIn) ->
-                    case maps:get(Attrib, Acc, undefined) of
-                        undefined -> AccIn;
-                        Val -> maps:put(Attrib, Val, AccIn)
-                    end
-                end,
-        NewAcc, OptionalAttributes).
-
-%% @doc Recording info about sending out a stanza/accumulator
-%% There are two versions because when we send xml element from c2s then
-%% there is no From and To args available, everything is already in the stanza
-%% while from ejabberd_router:route we get bare stanza and two jids.
--spec record_sending(t(), exml:element(), atom(), any()) -> t().
-record_sending(Acc, Stanza, Module, Result) ->
-    record_sending(Acc, none, none, Stanza, Module, Result).
--spec record_sending(t(),jid:jid()|none,jid:jid()|none, exml:element(), atom(), any()) -> t().
-record_sending(Acc, _From, _To, _Stanza, _Module, Result) ->
-    mongoose_acc:append(send_result, Result, Acc).
-
-%%%%% internal %%%%%
-
-append(Val, L) when is_list(L), is_list(Val) ->
-    L ++ Val;
-append(Val, L) when is_list(L) ->
-    [Val | L].
-
-dump(_, []) ->
-    ok;
-dump(Acc, [K|Tail]) ->
-    ?ERROR_MSG("~p = ~p", [K, maps:get(K, Acc)]),
-    dump(Acc, Tail).
-
-
-%% @doc pattern-match to figure out (a) which attrs can be 'required' (b) how to cook them
-produce(iq_query_info, Acc) ->
-    Iq = jlib:iq_query_info(get(element, Acc)), % it doesn't change
-    put(iq_query_info, Iq, Acc);
-produce(xmlns, Acc) ->
-    read_children(Acc);
-produce(command, Acc) ->
-    read_children(Acc).
-
-
-%% @doc scan xml children to look for namespace; the name of xml element containing namespace
-%% defines the purpose of a stanza, we store it as 'command'; if absent, we store 'undefined'.
-read_children(Acc) ->
-    Acc1 = put(command, undefined, put(xmlns, undefined, Acc)),
-    #xmlel{children = Children} = get(element, Acc1),
-    read_children(Acc, Children).
-
-read_children(Acc, []) ->
-    Acc;
-read_children(Acc, [#xmlel{} = Chld|Tail]) ->
-    case exml_query:attr(Chld, <<"xmlns">>, undefined) of
-        undefined ->
-            read_children(Acc, Tail);
-        Ns ->
-            #xmlel{name = Name} = Chld,
-            put(command, Name, put(xmlns, Ns, Acc))
-    end;
-read_children(Acc, [_|Tail]) ->
-    read_children(Acc, Tail).

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -156,8 +156,6 @@ get_element(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves name of the XML element record set using `new/4,5,6'.
-%
-% Returns `error' atom if element isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_element_name(t()) -> getter_result(element_name()).
@@ -166,8 +164,6 @@ get_element_name(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves type of the XML element set using `new/4,5,6'.
-%
-% Returns `error' atom if element isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_element_type(t()) -> getter_result(element_type()).
@@ -176,8 +172,6 @@ get_element_type(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves list of attributes of the XML element set using `new/4,5,6'.
-%
-% Returns `error' atom if element isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_element_attrs(t()) -> getter_result(element_attrs()).
@@ -211,8 +205,6 @@ get_element_iq_query_info(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves `jid:jid()' representation of the sender of the stanza set using `new/5,6'.
-%
-% Returns `error' atom if sender isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_from_jid(t()) -> getter_result(jid:jid()).
@@ -221,8 +213,6 @@ get_from_jid(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves binary representation of the sender of the stanza set using `new/5,6'.
-%
-% Returns `error' atom if sender isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_from_bin(t()) -> getter_result(binary()).
@@ -231,8 +221,6 @@ get_from_bin(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves `jid:jid()' representation of the recipient of the stanza set using `new/6'.
-%
-% Returns `error' atom if recipient isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_to_jid(t()) -> getter_result(jid:jid()).
@@ -241,8 +229,6 @@ get_to_jid(Acc) ->
 
 %-------------------------------------------------------------------
 % @doc Retrieves binary representation of the recipient of the stanza set using `new/5,6'.
-%
-% Returns `error' atom if recipient isn't set.
 % @end
 %-------------------------------------------------------------------
 -spec get_to_bin(t()) -> getter_result(binary()).

--- a/src/mongoose_acc_old.erl
+++ b/src/mongoose_acc_old.erl
@@ -1,0 +1,300 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% This module encapsulates a data type which will is instantiated when stanza
+%%% enters the system and is passed all the way along processing chain.
+%%% Its interface is map-like, and you can put there whatever you want, bearing in mind two things:
+%%% 1. It is read-only, you can't change value once you wrote it (accumulator is to accumulate)
+%%% 2. Whatever you put will be removed before the acc is sent to another c2s process
+%%%
+%%% There are three caveats to the above:
+%%% 1. Although you can not put to an existing key, you can append as many times as you like
+%%% 2. A special key 'result' is writeable and is meant to be used to get return value from hook calls
+%%% 3. If you want to pass something to another c2s process you can use add_prop/3 - values
+%%%    put there are not stripped.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mongoose_acc_old).
+-author("bartek").
+
+-include("jlib.hrl").
+-include("mongoose.hrl").
+
+%% API
+-export([new/0, from_kv/2, put/3, get/2, get/3, find/2, append/3, remove/2]).
+-export([increment/2, get_counter/2]).
+-export([add_prop/3, get_prop/2]).
+-export([from_element/1, from_map/1, update_element/4, update/2, is_acc/1, require/2]).
+-export([strip/1, strip/2, record_sending/4, record_sending/6]).
+-export([dump/1, to_binary/1]).
+-export([to_element/1]).
+-export_type([t/0]).
+-export([from_element/3]).
+
+%% if it is defined as -opaque then dialyzer fails
+-type t() :: map().
+
+%%% This module encapsulates implementation of mongoose_acc
+%%% its interface is map-like but implementation might change
+%%% it is passed along many times, and relatively rarely read or written to
+%%% might be worth reimplementing as binary
+
+dump(Acc) ->
+    dump(Acc, lists:sort(maps:keys(Acc))).
+
+to_binary(#xmlel{} = Packet) ->
+    exml:to_binary(Packet);
+to_binary({broadcast, Payload}) ->
+    case is_acc(Payload) of
+        true ->
+            to_binary(Payload);
+        false ->
+            list_to_binary(io_lib:format("~p", [Payload]))
+    end;
+to_binary(Acc) ->
+    % replacement to exml:to_binary, for error logging
+    case is_acc(Acc) of
+        true ->
+            El = get(element, Acc),
+            case El of
+                #xmlel{} -> exml:to_binary(El);
+                _ -> list_to_binary(io_lib:format("~p", [El]))
+            end;
+        false ->
+            list_to_binary(io_lib:format("~p", [Acc]))
+    end.
+
+%% This function is for transitional period, eventually all hooks will use accumulator
+%% and we will not have to check
+is_acc(A) when is_map(A) ->
+    maps:get(mongoose_acc, A, false);
+is_acc(_) ->
+    false.
+
+%% this is a temporary hack - right now processes receive accumulators and stanzas, it is all
+%% mixed up so we have to cater for this
+-spec to_element(exml:element() | t()) -> exml:element().
+to_element(A) ->
+    case is_acc(A) of
+        true -> get(element, A, undefined);
+        false -> A
+    end.
+
+
+%%%%% API %%%%%
+
+-spec new() -> t().
+new() ->
+    #{mongoose_acc => true, timestamp => os:timestamp(), ref => make_ref()}.
+
+-spec from_kv(atom(), any()) -> t().
+from_kv(K, V) ->
+    M = maps:put(K, V, #{}),
+    maps:put(mongoose_acc, true, M).
+
+%% @doc This one has an alternative form because normally an acc carries an xml element, as
+%% received from client, but sometimes messages are generated internally (broadcast) by sm
+%% and sent to c2s
+-spec from_element(exml:element() | jlib:iq() | tuple()) -> t().
+from_element(#xmlel{name = Name, attrs = Attrs} = El) ->
+    Type = exml_query:attr(El, <<"type">>, undefined),
+    #{element => El, mongoose_acc => true, name => Name, attrs => Attrs, type => Type,
+        timestamp => os:timestamp(), ref => make_ref()
+        };
+from_element(#iq{type = Type} = El) ->
+    #{element => El, mongoose_acc => true, name => <<"iq">>, type => Type,
+        timestamp => os:timestamp(), ref => make_ref()
+    };
+from_element(El) when is_tuple(El) ->
+    Name = <<"broadcast">>,
+    Type = element(1, El),
+    % ref and timestamp will be filled in by strip/2
+    #{element => El, name => Name, type => Type, mongoose_acc => true}.
+
+-spec from_element(exml:element() | jlib:iq(), jid:jid(), jid:jid()) -> t().
+from_element(El, From, To) ->
+    Acc = from_element(El),
+    M = #{from_jid => From, to_jid => To, from => jid:to_binary(From), to => jid:to_binary(To)},
+    update(Acc, M).
+
+-spec from_map(map()) -> t().
+from_map(M) ->
+    maps:put(mongoose_acc, true, M).
+
+-spec update_element(t(), exml:element(), jid:jid(), jid:jid()) -> t().
+update_element(Acc, Element, From, To) ->
+    update(Acc, from_element(Element, From, To)).
+
+-spec update(t(), map() | t()) -> t().
+update(Acc, M) ->
+    maps:merge(Acc, M).
+
+-spec put(any(), any(), t()) -> t().
+put(from_jid, Val, Acc) ->
+    % used only when we have to manually construct an acc (instead of calling from_element)
+    % namely: in c2s terminate, since it is not triggered by stanza, and in some
+    % deprecated functions
+    A = maps:put(from_jid, Val, Acc),
+    maps:put(from, jid:to_binary(Val), A);
+put(result, Val, Acc) ->
+    maps:put(result, Val, Acc);
+put(Key, Val, Acc) ->
+    % check whether we are replacing existing value (warning now, later it will become
+    % read-only; accumulator is for accumulating)
+    case maps:is_key(Key, Acc) of
+        true ->
+%%            ?WARNING_MSG("Overwriting existing key \"~p\" in accumulator,"
+%%                         "are you sure you have to do it?",
+%%                         [Key]);
+            ok;
+        false ->
+            ok
+    end,
+    maps:put(Key, Val, Acc).
+
+-spec get(any()|[any()], t()) -> any().
+get(send_result, Acc) ->
+    hd(maps:get(send_result, Acc));
+get(Key, P) ->
+    maps:get(Key, P).
+
+-spec get(any(), t(), any()) -> any().
+get(Key, P, Default) ->
+    maps:get(Key, P, Default).
+
+%% @doc increments a counter, returns new value
+%% counters are tagged so as not to interfere with other values
+-spec increment(atom(), t()) -> {integer(), t()}.
+increment(Key, Acc) ->
+    CKey = {counter, Key},
+    NVal = get(CKey, Acc, 0) + 1,
+    {NVal, put(CKey, NVal, Acc)}.
+
+%% @doc returns current value of a counter
+-spec get_counter(atom(), t()) -> integer().
+get_counter(Key, Acc) ->
+    get({counter, Key}, Acc, 0).
+
+-spec find(any(), t()) -> {ok, any()} | error.
+find(send_result, Acc) ->
+    case maps:find(send_result, Acc) of
+        error -> error;
+        {ok, SRs} -> hd(SRs)
+    end;
+find(Key, P) ->
+    maps:find(Key, P).
+
+-spec append(any(), any(), t()) -> t().
+append(Key, Val, P) ->
+    L = get(Key, P, []),
+    maps:put(Key, append(Val, L), P).
+
+-spec remove(Key :: any(), Accumulator :: t()) -> t().
+remove(Key, Accumulator) ->
+    maps:remove(Key, Accumulator).
+
+%% @doc adds a persistent property to an accumulator
+-spec add_prop(atom(), any(), t()) -> t().
+add_prop(Key, Value, Acc) ->
+    append(persistent_properties, {Key, Value}, Acc).
+
+-spec get_prop(atom(), t()) -> any().
+get_prop(Key, Acc) ->
+    proplists:get_value(Key, get(persistent_properties, Acc, [])).
+
+%% @doc Make sure the acc has certain keys - some of them require expensive computations and
+%% are therefore not calculated upon instantiation, this func is saying "I will need these,
+%% please prepare them for me"
+-spec require(any() | [any()], t()) -> t().
+require([], Acc) ->
+    Acc;
+require([Key|Tail], Acc) ->
+    Acc1 = case maps:is_key(Key, Acc) of
+               true -> Acc;
+               false -> produce(Key, Acc)
+           end,
+    require(Tail, Acc1);
+require(Key, Acc) ->
+    require([Key], Acc).
+
+%% @doc Convert the acc before routing it out to another c2s process - remove everything except
+%% the very bare minimum
+%% We get rid of all caches, traces etc.
+%% There is a special key "persistent_properties" which is also kept, use add_prop to store
+%% persistent stuff you want to pass between processes there.
+-spec strip(t()) -> t().
+strip(Acc) ->
+    strip(Acc, get(element, Acc)).
+
+%% @doc alt version in case we want to replace the xmlel we are sending
+-spec strip(t(), exml:element()) -> t().
+strip(Acc, El) ->
+    Acc1 = from_element(El),
+    Attributes = [ref, timestamp],
+    NewAcc = lists:foldl(fun(Attrib, AccIn) ->
+                           Val = maps:get(Attrib, Acc),
+                           maps:put(Attrib, Val, AccIn)
+                       end,
+                       Acc1, Attributes),
+    OptionalAttributes = [from, from_jid, to, to_jid, persistent_properties, global_distrib],
+    lists:foldl(fun(Attrib, AccIn) ->
+                    case maps:get(Attrib, Acc, undefined) of
+                        undefined -> AccIn;
+                        Val -> maps:put(Attrib, Val, AccIn)
+                    end
+                end,
+        NewAcc, OptionalAttributes).
+
+%% @doc Recording info about sending out a stanza/accumulator
+%% There are two versions because when we send xml element from c2s then
+%% there is no From and To args available, everything is already in the stanza
+%% while from ejabberd_router:route we get bare stanza and two jids.
+-spec record_sending(t(), exml:element(), atom(), any()) -> t().
+record_sending(Acc, Stanza, Module, Result) ->
+    record_sending(Acc, none, none, Stanza, Module, Result).
+-spec record_sending(t(),jid:jid()|none,jid:jid()|none, exml:element(), atom(), any()) -> t().
+record_sending(Acc, _From, _To, _Stanza, _Module, Result) ->
+    mongoose_acc:append(send_result, Result, Acc).
+
+%%%%% internal %%%%%
+
+append(Val, L) when is_list(L), is_list(Val) ->
+    L ++ Val;
+append(Val, L) when is_list(L) ->
+    [Val | L].
+
+dump(_, []) ->
+    ok;
+dump(Acc, [K|Tail]) ->
+    ?ERROR_MSG("~p = ~p", [K, maps:get(K, Acc)]),
+    dump(Acc, Tail).
+
+
+%% @doc pattern-match to figure out (a) which attrs can be 'required' (b) how to cook them
+produce(iq_query_info, Acc) ->
+    Iq = jlib:iq_query_info(get(element, Acc)), % it doesn't change
+    put(iq_query_info, Iq, Acc);
+produce(xmlns, Acc) ->
+    read_children(Acc);
+produce(command, Acc) ->
+    read_children(Acc).
+
+
+%% @doc scan xml children to look for namespace; the name of xml element containing namespace
+%% defines the purpose of a stanza, we store it as 'command'; if absent, we store 'undefined'.
+read_children(Acc) ->
+    Acc1 = put(command, undefined, put(xmlns, undefined, Acc)),
+    #xmlel{children = Children} = get(element, Acc1),
+    read_children(Acc, Children).
+
+read_children(Acc, []) ->
+    Acc;
+read_children(Acc, [#xmlel{} = Chld|Tail]) ->
+    case exml_query:attr(Chld, <<"xmlns">>, undefined) of
+        undefined ->
+            read_children(Acc, Tail);
+        Ns ->
+            #xmlel{name = Name} = Chld,
+            put(command, Name, put(xmlns, Ns, Acc))
+    end;
+read_children(Acc, [_|Tail]) ->
+    read_children(Acc, Tail).

--- a/src/mongoose_client_api_messages.erl
+++ b/src/mongoose_client_api_messages.erl
@@ -85,7 +85,7 @@ send_message(Req, #{user := RawUser, jid := FromJID} = State) ->
     Acc0 = ?new_acc(XMLMsg0, FromJID, ToJID),
     Acc1 = ejabberd_hooks:run_fold(rest_user_send_packet, FromJID#jid.lserver, Acc0,
                                    [FromJID, ToJID, XMLMsg0]),
-    XMLMsg1 = mongoose_acc:get(element, Acc1),
+    XMLMsg1 = mongoose_acc:get_element(Acc1),
     ejabberd_router:route(FromJID, ToJID, Acc1, XMLMsg1),
     Resp = #{<<"id">> => UUID},
     Req3 = cowboy_req:set_resp_body(jiffy:encode(Resp), Req2),

--- a/src/mongoose_client_api_messages.erl
+++ b/src/mongoose_client_api_messages.erl
@@ -16,6 +16,7 @@
 -export([maybe_before_to_us/2]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 -include_lib("exml/include/exml.hrl").
@@ -81,7 +82,7 @@ send_message(Req, #{user := RawUser, jid := FromJID} = State) ->
     ToJID = jid:from_binary(To),
     UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
     XMLMsg0 = build_message(RawUser, To, UUID, MsgBody),
-    Acc0 = mongoose_acc:from_element(XMLMsg0, FromJID, ToJID),
+    Acc0 = ?new_acc(XMLMsg0, FromJID, ToJID),
     Acc1 = ejabberd_hooks:run_fold(rest_user_send_packet, FromJID#jid.lserver, Acc0,
                                    [FromJID, ToJID, XMLMsg0]),
     XMLMsg1 = mongoose_acc:get(element, Acc1),

--- a/src/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api_sse.erl
@@ -43,7 +43,7 @@ handle_info(_Msg, State) ->
 
 handle_msg(<<"message">>, Acc, El, State) ->
     Timestamp = usec:from_now(os:timestamp()),
-    Type = mongoose_acc:get(type, Acc),
+    Type = mongoose_acc:get_element_type(Acc),
     maybe_send_message_event(Type, El, Timestamp, State).
 
 handle_error(_Msg, _Reson, State) ->

--- a/src/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api_sse.erl
@@ -37,7 +37,7 @@ handle_notify(_Msg, State) ->
     {nosend, State}.
 
 handle_info({route, _From, _To, Acc}, State) ->
-    handle_msg(mongoose_acc:get(name, Acc), Acc, mongoose_acc:get(element, Acc), State);
+    handle_msg(mongoose_acc:get(name, Acc), Acc, mongoose_acc:get_element(Acc), State);
 handle_info(_Msg, State) ->
     {nosend, State}.
 

--- a/src/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api_sse.erl
@@ -37,7 +37,7 @@ handle_notify(_Msg, State) ->
     {nosend, State}.
 
 handle_info({route, _From, _To, Acc}, State) ->
-    handle_msg(mongoose_acc:get(name, Acc), Acc, mongoose_acc:get_element(Acc), State);
+    handle_msg(mongoose_acc:get_element_name(Acc), Acc, mongoose_acc:get_element(Acc), State);
 handle_info(_Msg, State) ->
     {nosend, State}.
 

--- a/src/mongoose_metrics_hooks.erl
+++ b/src/mongoose_metrics_hooks.erl
@@ -143,7 +143,7 @@ xmpp_send_element(Acc, _El) ->
     case mongoose_acc:get(type, Acc) of
         <<"error">> ->
             mongoose_metrics:update(Server, xmppErrorTotal, 1),
-            case mongoose_acc:get(name, Acc) of
+            case mongoose_acc:get_element_name(Acc) of
                 <<"iq">> ->
                     mongoose_metrics:update(Server, xmppErrorIq, 1);
                 <<"message">> ->

--- a/src/mongoose_metrics_hooks.erl
+++ b/src/mongoose_metrics_hooks.erl
@@ -126,7 +126,7 @@ user_receive_packet_type(Server, #xmlel{name = <<"presence">>}) ->
 
 -spec xmpp_bounce_message(Acc :: mongoose_acc:t()) -> metrics_notify_return().
 xmpp_bounce_message(Acc) ->
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     mongoose_metrics:update(Server, xmppMessageBounced, 1),
     Acc.
 
@@ -138,7 +138,7 @@ xmpp_stanza_dropped(Acc, #jid{server = Server} , _, _) ->
 
 -spec xmpp_send_element(Acc :: map(), Server :: jid:server()) -> ok | metrics_notify_return().
 xmpp_send_element(Acc, _El) ->
-    Server = mongoose_acc:get(server, Acc),
+    Server = mongoose_acc:get_server(Acc),
     mongoose_metrics:update(Server, xmppStanzaCount, 1),
     case mongoose_acc:get(type, Acc) of
         <<"error">> ->

--- a/src/mongoose_metrics_hooks.erl
+++ b/src/mongoose_metrics_hooks.erl
@@ -140,7 +140,7 @@ xmpp_stanza_dropped(Acc, #jid{server = Server} , _, _) ->
 xmpp_send_element(Acc, _El) ->
     Server = mongoose_acc:get_server(Acc),
     mongoose_metrics:update(Server, xmppStanzaCount, 1),
-    case mongoose_acc:get(type, Acc) of
+    case mongoose_acc:get_element_type(Acc) of
         <<"error">> ->
             mongoose_metrics:update(Server, xmppErrorTotal, 1),
             case mongoose_acc:get_element_name(Acc) of

--- a/src/mongoose_privacy.erl
+++ b/src/mongoose_privacy.erl
@@ -57,7 +57,7 @@ privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir) ->
                            SType = exml_query:attr(Stanza, <<"type">>, undefined),
                            {A, SName, SType};
                        _ ->
-                           {Acc0, mongoose_acc:get(name, Acc0), mongoose_acc:get(type, Acc0)}
+                           {Acc0, mongoose_acc:get_element_name(Acc0), mongoose_acc:get(type, Acc0)}
                    end,
     % check if it is there, if not then set default and run a hook
     FromBin = jid:to_binary(From),

--- a/src/mongoose_privacy.erl
+++ b/src/mongoose_privacy.erl
@@ -57,7 +57,7 @@ privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir) ->
                            SType = exml_query:attr(Stanza, <<"type">>, undefined),
                            {A, SName, SType};
                        _ ->
-                           {Acc0, mongoose_acc:get_element_name(Acc0), mongoose_acc:get(type, Acc0)}
+                           {Acc0, mongoose_acc:get_element_name(Acc0), mongoose_acc:get_element_type(Acc0)}
                    end,
     % check if it is there, if not then set default and run a hook
     FromBin = jid:to_binary(From),

--- a/src/mongoose_privacy.erl
+++ b/src/mongoose_privacy.erl
@@ -37,7 +37,7 @@ privacy_check_packet(Acc0, Server, User, PrivacyList, To, Dir) ->
            {Acc, #xmlel{}} -> Acc;
             _ -> Acc0
         end,
-    From = mongoose_acc:get(from_jid, Acc1),
+    From = mongoose_acc:get_from_jid(Acc1),
     privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir).
 
 %% @doc check packet, store result in accumulator, return acc and result for quick check

--- a/src/service_admin_extra_private.erl
+++ b/src/service_admin_extra_private.erl
@@ -34,6 +34,7 @@
     ]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("ejabberd_commands.hrl").
 -include("jlib.hrl").
 -include_lib("exml/include/exml.hrl").
@@ -69,7 +70,7 @@ commands() ->
 -spec private_get(jid:user(), jid:server(), binary(), binary()) ->
     {error, string()} | string().
 private_get(Username, Host, Element, Ns) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     case ejabberd_auth:is_user_exists(Username, Host) of
         true ->
             do_private_get(Acc, Username, Host, Element, Ns);
@@ -105,7 +106,7 @@ private_set(Username, Host, ElementString) ->
 
 
 private_set2(Username, Host, Xml) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     case ejabberd_auth:is_user_exists(Username, Host) of
         true ->
             do_private_set2(Acc, Username, Host, Xml);

--- a/src/service_admin_extra_roster.erl
+++ b/src/service_admin_extra_roster.erl
@@ -39,6 +39,7 @@
     ]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("ejabberd_commands.hrl").
 -include("mod_roster.hrl").
 -include("jlib.hrl").
@@ -252,7 +253,7 @@ unsubscribe(LU, LS, User, Server) ->
 get_roster(User, Server) ->
     LUser = jid:nodeprep(User),
     LServer = jid:nameprep(Server),
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     Acc2 = ejabberd_hooks:run_fold(roster_get, Server, Acc, [{LUser, LServer}]),
     Items = mongoose_acc:get(roster, Acc2, []),
     make_roster(Items).

--- a/src/service_admin_extra_vcard.erl
+++ b/src/service_admin_extra_vcard.erl
@@ -37,6 +37,7 @@
 ]).
 
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 -include("ejabberd_commands.hrl").
 -include("mod_roster.hrl").
 -include("jlib.hrl").
@@ -124,7 +125,7 @@ commands() ->
 -spec get_vcard(jid:user(), jid:server(), any())
                -> {error, string()} | [binary()].
 get_vcard(User, Host, Name) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     case ejabberd_auth:is_user_exists(User, Host) of
         true ->
             get_vcard_content(Acc, User, Host, [Name]);
@@ -135,7 +136,7 @@ get_vcard(User, Host, Name) ->
 -spec get_vcard(jid:user(), jid:server(), any(), any())
                -> {error, string()} | [binary()].
 get_vcard(User, Host, Name, Subname) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     case ejabberd_auth:is_user_exists(User, Host) of
         true ->
             get_vcard_content(Acc, User, Host, [Name, Subname]);
@@ -146,7 +147,7 @@ get_vcard(User, Host, Name, Subname) ->
 -spec set_vcard(jid:user(), jid:server(), [binary()],
                 binary() | [binary()]) -> {ok, string()} | {user_does_not_exist, string()}.
 set_vcard(User, Host, Name, SomeContent) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     case ejabberd_auth:is_user_exists(User, Host) of
         true ->
             set_vcard_content(Acc, User, Host, [Name], SomeContent);
@@ -157,7 +158,7 @@ set_vcard(User, Host, Name, SomeContent) ->
 -spec set_vcard(jid:user(), jid:server(), [binary()], [binary()],
                 binary() | [binary()]) -> {ok, string()} | {user_does_not_exist, string()}.
 set_vcard(User, Host, Name, Subname, SomeContent) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     case ejabberd_auth:is_user_exists(User, Host) of
         true ->
             set_vcard_content(Acc, User, Host, [Name, Subname], SomeContent);

--- a/src/test.erl
+++ b/src/test.erl
@@ -1,0 +1,8 @@
+-module(test).
+
+-include("mongoose_acc.hrl").
+
+-compile(export_all).
+
+test() ->
+    ?new_acc().

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -1,5 +1,8 @@
 -module(ejabberd_c2s_SUITE_mocks).
--export([setup/0, teardown/0]).
+
+-include("mongoose_acc.hrl").
+
+-export([setup/0, teardown/0])
 
 setup() ->
     meck:new(ejabberd_sm),
@@ -66,7 +69,7 @@ mcred_get(dummy_creds, auth_module) -> auuuthmodule.
 hookfold(check_bl_c2s, _, _) -> false.
 
 hookfold(roster_get_versioning_feature, _, _, _) -> [];
-hookfold(roster_get_subscription_lists, _, _, _) -> mongoose_acc:new();
+hookfold(roster_get_subscription_lists, _, _, _) -> ?new_acc();
 hookfold(privacy_get_user_list, _, A, _) -> A;
 hookfold(session_opening_allowed_for_user, _, _, _) -> allow;
 hookfold(c2s_stream_features, _, _, _) -> [];

--- a/test/jlib_SUITE.erl
+++ b/test/jlib_SUITE.erl
@@ -2,6 +2,7 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include_lib("common_test/include/ct.hrl").
 -compile([export_all]).
@@ -64,7 +65,7 @@ make_iq_reply_changes_type_to_result(_) ->
 
 error_reply_check(_) ->
     BaseIQReply = jlib:make_result_iq_reply(base_iq()),
-    Acc = mongoose_acc:from_element(BaseIQReply),
+    Acc = ?new_acc(BaseIQReply),
     {Acc1, ErrorReply1} = jlib:make_error_reply(Acc, BaseIQReply, #xmlel{name = <<"testerror">>}),
     ?assertMatch(#xmlel{}, ErrorReply1),
     {_Acc2, ErrorReply2} = jlib:make_error_reply(Acc1, ErrorReply1, #xmlel{name = <<"testerror">>}),

--- a/test/mod_aws_sns_SUITE.erl
+++ b/test/mod_aws_sns_SUITE.erl
@@ -2,6 +2,7 @@
 
 -compile([export_all]).
 
+-include("mongoose_acc.hrl").
 -include("jlib.hrl").
 -include("mod_event_pusher_events.hrl").
 -include_lib("exml/include/exml.hrl").
@@ -146,19 +147,19 @@ send_packet_callback(Config, Type, Body) ->
     Packet = message(Config, Type, Body),
     Sender = #jid{lserver = Host} = ?config(sender, Config),
     Recipient = ?config(recipient, Config),
-    mod_event_pusher_sns:push_event(mongoose_acc:new(), Host,
+    mod_event_pusher_sns:push_event(?new_acc(), Host,
                                     #chat_event{type = chat, direction = in,
                                                 from = Sender, to = Recipient,
                                                 packet = Packet}).
 
 user_present_callback(Config) ->
     Jid = #jid{lserver = Host} = ?config(sender, Config),
-    mod_event_pusher_sns:push_event(mongoose_acc:new(), Host,
+    mod_event_pusher_sns:push_event(?new_acc(), Host,
                                     #user_status_event{jid = Jid, status = online}).
 
 user_not_present_callback(Config) ->
     Jid = #jid{lserver = Host} = ?config(sender, Config),
-    mod_event_pusher_sns:push_event(mongoose_acc:new(), Host,
+    mod_event_pusher_sns:push_event(?new_acc(), Host,
                                     #user_status_event{jid = Jid, status = offline}).
 
 %% Helpers

--- a/test/mod_global_distrib_SUITE.erl
+++ b/test/mod_global_distrib_SUITE.erl
@@ -18,6 +18,7 @@
 -compile(export_all).
 -author('piotr.nosek@erlang-solutions.com').
 
+-include("mongoose_acc.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
 
@@ -84,7 +85,7 @@ missing_struct_in_message_from_user(_Config) ->
     {Acc, To} = fake_acc_to_component(From),
     % The handler must not crash and return unchanged Acc
     Acc = mod_global_distrib_mapping:packet_to_component(Acc, From, To).
-        
+
 %% Update logic has two separate paths: when a packet is sent by a user or by another
 %% component. This test covers the latter.
 missing_struct_in_message_from_component(_Config) ->
@@ -117,7 +118,7 @@ fake_acc_to_component(From) ->
                 attrs = [{<<"from">>, FromBin}, {<<"to">>, ToBin}, {<<"type">>, <<"chat">>}],
                 children = [BodyEl]
                },
-    {mongoose_acc:from_element(Packet), To}.
+    {?new_acc(Packet), To}.
 
 %%--------------------------------------------------------------------
 %% Meck & fake zone

--- a/test/privacy_SUITE.erl
+++ b/test/privacy_SUITE.erl
@@ -14,6 +14,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("mod_privacy.hrl").
 -include("mongoose.hrl").
+-include("mongoose_acc.hrl").
 
 -define(ALICE, jid:from_binary(<<"alice@localhost">>)).
 -define(BOB, jid:from_binary(<<"bob@localhost">>)).
@@ -47,7 +48,7 @@ end_per_suite(_C) ->
     ok.
 
 check_with_allowed(_C) ->
-    Acc = mongoose_acc:from_element(message(), ?ALICE, ?BOB),
+    Acc = ?new_acc(message(), ?ALICE, ?BOB),
     Acc1 = make_check(Acc, userlist(none), ?BOB, out, allow),
     Acc2 = make_check(Acc1, userlist(none), ?BOB, in, allow),
     Acc3 = make_check(Acc2, userlist(none), ?JEFF, out, allow),
@@ -56,13 +57,13 @@ check_with_allowed(_C) ->
 
 check_with_denied(_C) ->
     % message
-    Acc = mongoose_acc:from_element(message(), ?ALICE, ?BOB),
+    Acc = ?new_acc(message(), ?ALICE, ?BOB),
     Acc1 = make_check(Acc, userlist(deny_all_message), ?BOB, out, allow),
     Acc2 = make_check(Acc1, userlist(deny_all_message), ?BOB, in, deny),
     Acc3 = make_check(Acc2, userlist(deny_all_message), ?JEFF, out, allow),
     _Acc4 = make_check(Acc3, userlist(deny_all_message), ?JEFF, in, deny),
     % presence
-    NAcc = mongoose_acc:from_element(presence(), ?ALICE, ?BOB),
+    NAcc = ?new_acc(presence(), ?ALICE, ?BOB),
     NAcc1 = make_check(NAcc, userlist(deny_all_message), ?BOB, out, allow),
     NAcc2 = make_check(NAcc1, userlist(deny_all_message), ?BOB, in, allow),
     NAcc3 = make_check(NAcc2, userlist(deny_all_message), ?JEFF, out, allow),
@@ -70,7 +71,7 @@ check_with_denied(_C) ->
     ok.
 
 check_with_denied_bob(_C) ->
-    Acc = mongoose_acc:from_element(message(), ?ALICE, ?BOB),
+    Acc = ?new_acc(message(), ?ALICE, ?BOB),
     Acc1 = make_check(Acc, userlist(deny_all_message), ?BOB, out, allow),
     Acc2 = make_check(Acc1, userlist(deny_all_message), ?BOB, in, deny),
     Acc3 = make_check(Acc2, userlist(none), ?JEFF, out, allow),
@@ -78,13 +79,13 @@ check_with_denied_bob(_C) ->
     ok.
 
 check_with_bob_blocked(_C) ->
-    Acc = mongoose_acc:from_element(message(), ?ALICE, ?BOB),
+    Acc = ?new_acc(message(), ?ALICE, ?BOB),
     Acc1 = make_check(Acc, userlist(block_bob), ?BOB, out, block),
     Acc2 = make_check(Acc1, userlist(block_bob), ?BOB, in, allow),
     Acc3 = make_check(Acc2, userlist(none), ?JEFF, out, allow),
     _Acc4 = make_check(Acc3, userlist(none), ?JEFF, in, allow),
     % presence
-    NAcc = mongoose_acc:from_element(presence(), ?ALICE, ?BOB),
+    NAcc = ?new_acc(presence(), ?ALICE, ?BOB),
     NAcc1 = make_check(NAcc, userlist(block_bob), ?BOB, out, block),
     NAcc2 = make_check(NAcc1, userlist(block_bob), ?BOB, in, allow),
     NAcc3 = make_check(NAcc2, userlist(block_bob), ?JEFF, out, allow),
@@ -96,7 +97,7 @@ check_with_changing_stanza(_C) ->
     M = message(),
     P = presence(),
     Ul = userlist(deny_all_message),
-    Acc = mongoose_acc:from_element(M, ?ALICE, ?BOB),
+    Acc = ?new_acc(M, ?ALICE, ?BOB),
     Acc1 = make_check({Acc, M}, Ul, ?BOB, out, allow),
     Acc2 = make_check({Acc1, M}, Ul, ?BOB, in, deny),
     Acc3 = make_check({Acc2, M}, Ul, ?JEFF, out, allow),

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -9,6 +9,7 @@
 -module(roster_SUITE).
 -author("bartek").
 
+-include("mongoose_acc.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include("ejabberd_c2s.hrl").
 -include_lib("exml/include/exml_stream.hrl").
@@ -140,7 +141,7 @@ get_roster_old() ->
     get_roster_old(a()).
 
 get_roster_old(User) ->
-    Acc = mongoose_acc:new(),
+    Acc = ?new_acc(),
     Acc1 = mod_roster:get_user_roster(Acc, {User, host()}),
     mongoose_acc:get(roster, Acc1).
 

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -1,6 +1,7 @@
 -module(router_SUITE).
 -compile([export_all]).
 
+-include("mongoose_acc.hrl").
 -include_lib("exml/include/exml.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -30,7 +31,7 @@ init_per_suite(C) ->
     ok = stringprep:start(),
     application:ensure_all_started(lager),
     ok = mnesia:create_schema([node()]),
-    ok = mnesia:start(), 
+    ok = mnesia:start(),
     {ok, _} = application:ensure_all_started(exometer_core),
     C.
 
@@ -97,17 +98,17 @@ basic_routing(_C) ->
 do_not_reroute_errors(_) ->
     From = <<"ja@localhost">>,
     To = <<"ty@localhost">>,
-    Stanza = #xmlel{name = <<"iq">>, 
+    Stanza = #xmlel{name = <<"iq">>,
         attrs = [{<<"from">>, From}, {<<"to">>, To}, {<<"type">>, <<"get">>} ]
     },
-    Acc = mongoose_acc:from_element(Stanza),
+    Acc = ?new_acc(Stanza),
     meck:new(xmpp_router_a, [non_strict]),
     meck:expect(xmpp_router_a, filter,
                 fun(From0, To0, Acc0, Packet0) -> {From0, To0, Acc0, Packet0} end),
     meck:expect(xmpp_router_a, route, fun resend_as_error/4),
     ejabberd_router:route(From, To, Acc, Stanza),
     ok.
-     
+
 update_tables_hidden_components(_C) ->
     %% Tables as of b076e4a62a8b21188245f13c42f9cfd93e06e6b7
     create_component_tables([domain, handler, node]),


### PR DESCRIPTION
The intention of this PR is to introduce more "safe" interface to the accumulator module. While accumulators proved to be very useful when values need to be exchanged between multiple modules or for debugging purposes (e.g. registering hook calls and send results), I believe that they're underused due to lack of confidence when working with them - we never know if an accumulator field is there and what is its value.

My goal is to remove completely the "generic" part of the accumulator - no more `get`, `put` and update. All fields should have explicit, documented and typespeced getters and setters.

## Changes so far

The code in this PR won't pass any tests - I have refactored maybe 1/3 of the whole accumulator usages. Changes so far include:

- When accumulator is created, module, function and line number need to be passed to `new/3,4,5,6`. This help immensely when debugging, when we're not sure if accumulator comes from HTTP interface, c2s, external component etc.
- The `element` attribute can be only set as a whole, i.e. the whole record, its name, type and attributes are always in sync. There is a `set_element/2` function, but it should be removed and the stanza should be an immutable field, set only when creating an accumulator.
- `from` and `to` properties can be set only when creating an accumulator, they are immutable due to the lack of setters.
- `iq_query_info`, as previously, is computed lazily and stored in the accumulator and is always in sync with corresponding `exml:element()` (although that wouldn't be an issue if element was immutable)
- `server` is a regular, mutable property

## Concerns so far

I'd really appreciate anyone's input on these topic.

- getters currently raise an error when there is no property set. However, sometimes we'd like to perform some logic based on the fact that the property is not there. We can do it in two ways:
  - make all getters return `{ok, ...} | error`. The downside is that we lose nice error message and instead will end up with `badmatch`es in cases when we're willing to crash when property is not there.
  - add additional `has_` function for each property, but that would make the interface really bloated. The upside is that we retain a nice error message when the property is not there.
- `element` should be completely immutable, it should be set to the stanza entering the node and initiating the "routing chain"
- `server` and `user` attributes should be completely immutable as well. They should represent the user and server of the user who initiated the current routing chain (in other words, user and server of the current c2s process or HTTP handler or CLI process). Maybe we could name those properties differently?
- How `from` differs from `user` and `server`? 
- `to` should be completely immutable as well.

## TODOs and questions for the future

Here is a list of things which I've found that are left to do. Please point out anything that you think is missing here:

#### Properties

- [ ] `result` property - 
- [ ] `subscription_lists` property - mutable, used by `roster_get_subscription_lists` hook handlers.
- [ ] `roster` property - filled by modules building roster. It should be mutable, getter should return empty list if the value hasn't been set yet.
- [ ] `amp_check_result` property - also mutable
- [ ] `privacy_check` property - immutable per privacy check cache key, see https://github.com/esl/MongooseIM/blob/master/src/mongoose_privacy.erl#L65
- [ ] `send_result` property - append-only list of records of sending the stanza. I'm not sure if anyone is using that, maybe we should remove it? It's used in https://github.com/esl/MongooseIM/blob/master/src/ejabberd_c2s.erl#L1769, but from what I see its value doesn't matter anyway. It's probably only useful for debugging.
- [ ] `ref` property - immutable, set on creation. Again, I'm not sure if we need it, but AFAIK @fenek has used it in the past
- [ ] `timestamp` property - immutable, set on creation. I don't know anyone who's used it, I guess we could remove it.
- [ ] `global_distrib` property - regular, mutable property
- [ ] `return_type` - used by `jlib` in https://github.com/esl/MongooseIM/blob/master/src/jlib.erl#L150. To me it could be removed - based on that `jlib` decides whether IQ passed to the linked function is already an error - but one could pass unrelated accumulator and error IQ there, and the function won't return an error. I saw that these lines are covered by tests, but I believe it comes only from unit tests which call it directly.
- [ ] `iq_result` property. I'm not sure if it has any meaningful usage. I see that it's set in a couple of places in `mod_muc_light` but it's only retrieved in `c2s`. Maybe someone know what it's created for.
- [ ] `offline_messages` - append only list, should be removable because c2s clears them
- [ ] `hook_runs` and `handler_runs` - record fired hooks and handlers, probably useful for debugging. They're not retrieved anywhere.

#### Functions

- [ ] - `strip` - we should figure out which elements are worth to keep persistent. Currently persistent properties are: `ref`, `timestamp`, `from`, `to`, `global_distrib` and `persistent_properties` (of which at this point only `origin_jid` is used). Do we want to make this list smaller?

# But is it worth it?

As you can see, these modifications would bring huge changes to the code base. IMO it's worth it, I'd definitely fill more confident when using accumulators, but I'd like us all to decide.