### PR TITLE
Use esl/exml 3.0.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
   {base16, ".*", {git, "git://github.com/goj/base16.git", "f78918e"}},
   {cuesport, ".*", {git, "git://github.com/esl/cuesport.git", "d82ff25"}},
   {redo, ".*", {git, "git://github.com/Wallapop/redo.git", "35a8d1c"}},
-  {exml, ".*", {git, "git://github.com/esl/exml.git", {tag, "3.0.0"}}},
+  {exml, ".*", {git, "git://github.com/esl/exml.git", {tag, "3.0.1"}}},
   {lager, ".*", {git, "git://github.com/basho/lager.git", "3.2.4"}},
   {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog.git", "3.0.3"}},
   {cowboy, ".*", {git, "git://github.com/ninenines/cowboy.git", "1.1.2"}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -57,7 +57,7 @@
   0},
  {<<"exml">>,
   {git,"git://github.com/esl/exml.git",
-       {ref,"a064e571062a305cefae191234ae14e8b90c039e"}},
+       {ref,"01f6941176d5f339aaf0c3af890f726eb19b7158"}},
   0},
  {<<"exometer_core">>,
   {git,"git://github.com/esl/exometer_core.git",


### PR DESCRIPTION
The one with a workaround to `enif_inspect_binary` for Erlang/OTP older than 20

