### PR TITLE
Parallel pull for docker-compose

### DIFF
--- a/tools/docker-compose.sh
+++ b/tools/docker-compose.sh
@@ -53,4 +53,7 @@ if [ -t 0 ]; then
     DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
 fi
 
-exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"
+# docker-compose is slow, help it to resolve the host
+# https://github.com/docker/compose/issues/3419#issuecomment-221793401
+exec docker run --add-host=localunixsocket.local:127.0.0.1 \
+    --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -94,6 +94,7 @@ maybe_start_services() {
 start_services() {
     for env in ${BASE}/big_tests/services/*-compose.yml; do
         echo "Stating service" $(basename "${env}") "..."
+        time ${BASE}/tools/docker-compose.sh -f "${env}" pull --parallel
         time ${BASE}/tools/docker-compose.sh -f "${env}" up -d
         echo "docker-compose execution time reported above"
         echo ""


### PR DESCRIPTION
This PR addresses "Travis is slow!".

Proposed changes include:
* use docker pull --parallel
* use "docker-compose tries to resolve an ip, so slow" - not sure, if we actually need it.
