### PR TITLE
Install unixodbc dev package in pkg builder containers

### DIFF
--- a/tools/pkg/platforms/centos6/Dockerfile
+++ b/tools/pkg/platforms/centos6/Dockerfile
@@ -10,7 +10,7 @@ RUN rpm -ivh epel-release-6-8.noarch.rpm
 RUN wget http://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm
 RUN rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
 RUN yum --setopt=obsoletes=0 install -y sudo telnet lsof vim gcc rpm-build rpm-sign make automake expat-devel \
-                   git devtoolset-4-gcc-c++ devtoolset-4-gcc kernel-devel openssl openssl-devel yum-utils chrpath esl-erlang-18.3-1 \
+                   git devtoolset-4-gcc-c++ devtoolset-4-gcc kernel-devel openssl openssl-devel yum-utils chrpath unixODBC-devel esl-erlang-18.3-1 \
  && yum clean all
 # Fix locale setup once packages are installed.
 # See https://github.com/CentOS/sig-cloud-instance-images/issues/71#issuecomment-266957519

--- a/tools/pkg/platforms/centos7/Dockerfile
+++ b/tools/pkg/platforms/centos7/Dockerfile
@@ -9,7 +9,7 @@ RUN rpm -ivh epel-release-7-9.noarch.rpm
 RUN wget http://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm
 RUN rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
 RUN yum --setopt=obsoletes=0 install -y sudo telnet lsof vim gcc rpm-build rpm-sign make automake expat-devel \
-                   git gcc-c++ kernel-devel openssl openssl-devel yum-utils chrpath esl-erlang-19.3.6-1 \
+                   git gcc-c++ kernel-devel openssl openssl-devel yum-utils chrpath unixODBC-devel esl-erlang-19.3.6-1 \
  && yum clean all
 # Fix locale setup once packages are installed.
 # See https://github.com/CentOS/sig-cloud-instance-images/issues/71#issuecomment-266957519

--- a/tools/pkg/platforms/debian_stretch/Dockerfile
+++ b/tools/pkg/platforms/debian_stretch/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get install -y git \
                        libexpat-dev \
                        zlib1g-dev \
                        locales \
+                       unixodbc-dev \
                        esl-erlang=1:19.3.6
 
 # fix locales


### PR DESCRIPTION
This package includes `sql.h` file which is required to compile eodbc.
Somehow it stopped being installed when creating the builder container so Mongoose could not be compiled.

