### PR TITLE
Update escalus to version with fixed stanza_log handling

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -9,7 +9,7 @@
         {erlsh, ".*", {git, "git://github.com/proger/erlsh.git", "2fce513"}},
         {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
-        {escalus, ".*", {git, "git://github.com/esl/escalus.git", {tag, "4.0.0"}}},
+        {escalus, ".*", {git, "git://github.com/esl/escalus.git", "8e4ceb8"}},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, ".*", {git, "git://github.com/rslota/cowboy.git", {tag, "2.0.0-pre.7-r17"}}},
         {shotgun, ".*", {git, "https://github.com/inaka/shotgun.git", "4e67065"}},


### PR DESCRIPTION
This PR updates escalus to the version from esl/escalus#178 . This version contains a fix to how escalus handles stanza_log.

