### PR TITLE
Reduce waiting time for cover on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
-script: tools/travis-test.sh -p $PRESET
+script: KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET
 
 after_failure:
         - cat `ls -1 -d -t apps/ejabberd/logs/ct_run* | head -1`/apps.ejabberd.logs/run.*/suite.log

--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -293,6 +293,15 @@ analyze(Test, CoverOpts) ->
     report_time("Export cover data from MongooseIM nodes", fun() ->
             multicall(Nodes, mongoose_cover_helper, analyze, [], cover_timeout())
         end),
+    case os:getenv("KEEP_COVER_RUNNING") of
+        "1" ->
+            io:format("Skip stopping cover~n"),
+            ok;
+        _ ->
+            report_time("Stopping cover on MongooseIM nodes", fun() ->
+                            multicall(Nodes, mongoose_cover_helper, stop, [], cover_timeout())
+                    end)
+    end,
     Files = filelib:wildcard(repo_dir() ++ "/_build/**/cover/*.coverdata"),
     io:format("Files: ~p", [Files]),
     report_time("Import cover data into run_common_test node", fun() ->

--- a/src/mongoose_cover_helper.erl
+++ b/src/mongoose_cover_helper.erl
@@ -17,7 +17,7 @@
 
 
 %% API
--export([start/1, analyze/0]).
+-export([start/1, analyze/0, stop/0]).
 
 -spec start([atom()]) -> list().
 start(Apps) ->
@@ -27,6 +27,9 @@ start(Apps) ->
 analyze() ->
     file:make_dir("priv/cover"),
     cover:export("priv/cover/" ++ atom_to_list(node()) ++ ".coverdata"),
+    ok.
+
+stop() ->
     cover:stop().
 
 cover_compile_app(App) ->


### PR DESCRIPTION
This PR addresses "Slow Travis? Slow cover."

Proposed changes include:
* Add KEEP_COVER_RUNNING variable

"Executing Export cover data from MongooseIM nodes" step works 10 times faster now.