### PR TITLE
Remove undefined functions from exports

### DIFF
--- a/src/mongoose_rabbit_worker.erl
+++ b/src/mongoose_rabbit_worker.erl
@@ -18,7 +18,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2]).
 
 -record(state, {connection, channel}).
 


### PR DESCRIPTION
It makes compilation working.
