### PR TITLE
Erradicate registered_users warnings in tests

### DIFF
--- a/big_tests/tests/last_SUITE.erl
+++ b/big_tests/tests/last_SUITE.erl
@@ -55,7 +55,7 @@ init_per_group(_GroupName, Config0) ->
     Config2.
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, escalus:get_users([alice, bob])).
+    escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1196,8 +1196,7 @@ make_alice_and_bob_friends(Alice, Bob) ->
 run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate, Config) ->
     {DefaultMode, AlwaysUsers, NeverUsers} = PrefsState,
     IqSet = stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config),
-    escalus:send(Alice, IqSet),
-    _ReplySet = escalus:wait_for_stanza(Alice),
+    _ReplySet = escalus:send_iq_and_wait_for_result(Alice, IqSet),
     Messages = [iolist_to_binary(io_lib:format("n=~p, prefs=~p, now=~p",
                                                [N, PrefsState, os:timestamp()]))
                 || N <- [1, 2, 3, 4]],
@@ -1278,8 +1277,7 @@ print_configuration_not_supported(C, B) ->
 run_set_and_get_prefs_case({PrefsState, _ExpectedMessageStates}, Namespace, Alice, Config) ->
     {DefaultMode, AlwaysUsers, NeverUsers} = PrefsState,
     IqSet = stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config),
-    escalus:send(Alice, IqSet),
-    ReplySet = escalus:wait_for_stanza(Alice, 5000),
+    ReplySet = escalus:send_iq_and_wait_for_result(Alice, IqSet),
     ReplySetNS = exml_query:path(ReplySet, [{element, <<"prefs">>}, {attr, <<"xmlns">>}]),
     ?assert_equal(ReplySetNS, Namespace),
     escalus:send(Alice, stanza_prefs_get_request(Namespace)),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -194,8 +194,10 @@ init_per_group(_, Config0) ->
 end_per_group(advertised_endpoints, Config) ->
     Pids = ?config(meck_handlers, Config),
     unmock_inet(Pids),
+    escalus_fresh:clean(),
     Config;
 end_per_group(start_checks, Config) ->
+    escalus_fresh:clean(),
     Config;
 end_per_group(invalidation, Config) ->
     redis_query(europe_node1, [<<"HDEL">>, ?config(nodes_key, Config),

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -4128,9 +4128,8 @@ hibernated_room_is_stopped_and_restored_by_presence(Config) ->
 
         escalus:send(Bob, stanza_join_room(RoomName, <<"bob">>)),
         Presence = escalus:wait_for_stanza(Bob, ?WAIT_TIMEOUT),
-        ct:print("~p", [Presence]),
+        escalus:assert(is_presence, Presence),
         MessageWithSubject = escalus:wait_for_stanza(Bob),
-        ct:print("~p", [MessageWithSubject]),
         true = is_subject_message(MessageWithSubject, <<"Restorable">>),
 
         {ok, _Pid2} = rpc(mim(), mod_muc, room_jid_to_pid, [RoomJID]),

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -203,7 +203,7 @@ init_per_suite(Config) ->
                            {backend, Backend},
                            {rooms_in_rosters, true}]),
     Config1 = escalus:init_per_suite(Config),
-    escalus:create_users(Config1, escalus:get_users([alice, bob, kate, mike, carol])).
+    escalus:create_users(Config1, escalus:get_users([alice, bob, kate, mike])).
 
 end_per_suite(Config) ->
     Host = ct:get_config({hosts, mim, domain}),
@@ -229,8 +229,9 @@ end_per_group(_GroupName, Config) ->
 
 init_per_testcase(removing_users_from_server_triggers_room_destruction = CN, Config) ->
     set_default_mod_config(),
-    create_room(?ROOM, ?MUCHOST, carol, [], Config, ver(1)),
-    escalus:init_per_testcase(CN, Config);
+    Config1 = escalus:create_users(Config, escalus:get_users([carol])),
+    create_room(?ROOM, ?MUCHOST, carol, [], Config1, ver(1)),
+    escalus:init_per_testcase(CN, Config1);
 init_per_testcase(disco_rooms_rsm, Config) ->
     set_default_mod_config(),
     set_mod_config(rooms_per_page, 1),

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -146,7 +146,6 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     clear_db(),
-    escalus_fresh:clean(),
     Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
     dynamic_modules:stop(domain(), mod_muc_light),
     escalus:end_per_suite(Config1).

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -146,6 +146,7 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     clear_db(),
+    escalus_fresh:clean(),
     Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
     dynamic_modules:stop(domain(), mod_muc_light),
     escalus:end_per_suite(Config1).

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -67,6 +67,7 @@ init_per_suite(Config) ->
     escalus:init_per_suite(dynamic_modules:save_modules(domain(), Config)).
 
 end_per_suite(Config) ->
+    escalus_fresh:clean(),
     dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_suite(Config).
 

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -75,6 +75,7 @@ init_per_suite(Config) ->
     escalus:create_users(Config1, escalus:get_users(users())).
 
 end_per_suite(Config) ->
+    escalus_fresh:clean(),
     s2s_helper:end_s2s(Config),
     escalus:delete_users(Config, escalus:get_users(users())),
     escalus:end_per_suite(Config).


### PR DESCRIPTION
This PR addresses warnings like 

```erlang
Suite: mod_global_distrib_SUITE finished dirty. Other suites may fail because of that. Details:                                   
[{registered_users,[{<<"eve97.992760">>,<<"localhost.bis">>},                                                                     
                    {<<"eve97.992760">>,<<"localhost">>}]}, 
```

It does not remove ALL the warnings, because unregister call is async in clean (?).

- Add missing escalus_fresh:clean()