### PR TITLE
Ported User Leave and Join muc hooks from ejabberd

### DIFF
--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -178,6 +178,8 @@ This is the perfect place to plug in custom security control.
 * forget_room
 * host_config_update
 * is_muc_room_owner
+* join_room
+* leave_room
 * local_send_to_resource_hook
 * mam_archive_id
 * mam_archive_message

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1684,8 +1684,8 @@ remove_online_user(JID, StateData, Reason) ->
     Sessions = case is_last_session(Nick, StateData) of
         true ->
             add_to_log(leave, {Nick, Reason}, StateData),
-            run_leave_room_hook(JID, StateData),
             tab_remove_online_user(JID, StateData),
+            run_leave_room_hook(JID, StateData),
             dict:erase(Nick, StateData#state.sessions);
         false ->
             IsOtherLJID = fun(J) -> jid:to_lower(J) /= LJID end,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1693,7 +1693,7 @@ remove_online_user(JID, StateData, Reason) ->
     notify_users_modified(StateData#state{users = Users, sessions = Sessions}).
 
 -spec run_leave_room_hook(jid:jid(), state()) -> ok.
-run_leave_room_hook(JID, #state{room = Room, host = Host, jid = MucJID, server_host = ServerHost) ->
+run_leave_room_hook(JID, #state{room = Room, host = Host, jid = MucJID, server_host = ServerHost}) ->
   ejabberd_hooks:run(leave_room, ServerHost, [ServerHost, Room, Host, JID, MucJID]),
   ok.
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1662,11 +1662,7 @@ add_online_user(JID, Nick, Role, StateData) ->
     notify_users_modified(StateData#state{users = Users, sessions = Sessions}).
 
 -spec run_join_room_hook(jid:jid(), state()) -> ok.
-run_join_room_hook(JID, StateData) ->
-  ServerHost = StateData#state.server_host,
-  Room = StateData#state.room,
-  Host = StateData#state.host,
-  MucJID = StateData#state.jid,
+run_join_room_hook(JID, #state{room = Room, host = Host, jid = MucJID, server_host = ServerHost) ->
   ejabberd_hooks:run(join_room, ServerHost, [ServerHost, Room, Host, JID, MucJID]),
   ok.
 
@@ -1697,11 +1693,7 @@ remove_online_user(JID, StateData, Reason) ->
     notify_users_modified(StateData#state{users = Users, sessions = Sessions}).
 
 -spec run_leave_room_hook(jid:jid(), state()) -> ok.
-run_leave_room_hook(JID, StateData) ->
-  ServerHost = StateData#state.server_host,
-  Room = StateData#state.room,
-  Host = StateData#state.host,
-  MucJID = StateData#state.jid,
+run_leave_room_hook(JID, #state{room = Room, host = Host, jid = MucJID, server_host = ServerHost) ->
   ejabberd_hooks:run(leave_room, ServerHost, [ServerHost, Room, Host, JID, MucJID]),
   ok.
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4334,6 +4334,9 @@ tab_add_online_user(JID, StateData) ->
     US = {LUser, LServer},
     Room = StateData#state.room,
     Host = StateData#state.host,
+    ServerHost = StateData#state.server_host,
+    MucJID = StateData#state.jid,
+    ejabberd_hooks:run(join_room, ServerHost, [ServerHost, Room, Host, JID, MucJID]),
     catch ets:insert(
         muc_online_users,
         #muc_online_users{us = US, room = Room, host = Host}).
@@ -4345,6 +4348,9 @@ tab_remove_online_user(JID, StateData) ->
     US = {LUser, LServer},
     Room = StateData#state.room,
     Host = StateData#state.host,
+    ServerHost = StateData#state.server_host,
+    MucJID = StateData#state.jid,
+    ejabberd_hooks:run(leave_room, ServerHost, [ServerHost, Room, Host, JID, MucJID]),
     catch ets:delete_object(
         muc_online_users,
         #muc_online_users{us = US, room = Room, host = Host}).

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1662,7 +1662,7 @@ add_online_user(JID, Nick, Role, StateData) ->
     notify_users_modified(StateData#state{users = Users, sessions = Sessions}).
 
 -spec run_join_room_hook(jid:jid(), state()) -> ok.
-run_join_room_hook(JID, #state{room = Room, host = Host, jid = MucJID, server_host = ServerHost) ->
+run_join_room_hook(JID, #state{room = Room, host = Host, jid = MucJID, server_host = ServerHost}) ->
   ejabberd_hooks:run(join_room, ServerHost, [ServerHost, Room, Host, JID, MucJID]),
   ok.
 


### PR DESCRIPTION
This PR addresses lack of hook on users leaving and entering multi-user chats

Proposed changes include:
* Hooks for user enter/leave muc
* No tests added, not sure what to do in this. Will add tests if pointed in the right direction (if needed).
* Added hook to list of hooks in developer documentation hooks_description.md

