### PR TITLE
Dockerize LDAP

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -257,6 +257,7 @@
       {auth_method, "ldap"},
       {mod_offline, "{mod_offline, []},"},
       {auth_ldap, "{ldap_servers,[\"localhost\"]}.\n"
+                  "{ldap_port,3389}.\n"
                   "{ldap_rootdn,\"cn=admin,dc=esl,dc=com\"}.\n"
                   "{ldap_password, \"mongooseim_secret\"}.\n"
                   "{ldap_base, \"ou=Users,dc=esl,dc=com\"}.\n"

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -33,3 +33,13 @@ function data_on_volume
         echo "$@"
     fi
 }
+
+# Example: mktempdir "SUFFIX_OR_PREFIX"
+function mktempdir
+{
+    case "$(uname -s)" in
+        Darwin*)    mktemp -d -t "$1" ;; # On mac -t is prefix
+        Linux*)     mktemp -d --suffix="$1" ;; # gnu mktemp
+        *)          mktemp -d
+    esac
+}

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -34,12 +34,14 @@ function data_on_volume
     fi
 }
 
-# Example: mktempdir "SUFFIX_OR_PREFIX"
+# Example: mktempdir "PREFIX"
+#
+# MAC OS X and docker specific:
+#   Docker for Mac limits where mounts can be.
+#   Mounts can be in /tmp, /Users, /Volumes but not in /var/folders/cd/
+#   Default behaviour of mktemp on Mac is to create a directory like
+#   /var/folders/cd/qgvc26bj6hg1kgr41q96zydh0000gp/T/tmp.Sa9w8Xp3
 function mktempdir
 {
-    case "$(uname -s)" in
-        Darwin*)    mktemp -d -t "$1" ;; # On mac -t is prefix
-        Linux*)     mktemp -d --suffix="$1" ;; # gnu mktemp
-        *)          mktemp -d
-    esac
+    mktemp -d "/tmp/$1.XXXXXXXXX"
 }

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -17,3 +17,19 @@ DEV_NODES="${DEV_NODES:-$DEFAULT_DEV_NODES}"
 
 # Create a bash array DEFAULT_DEV_NODES with node names
 IFS=' ' read -r -a DEV_NODES_ARRAY <<< "$DEV_NODES"
+
+# Linux volumes are faster than layer fs.
+# Mac volumes are actually slower than layer fs.
+case "$(uname -s)" in
+    Darwin*)    DEFAULT_DATA_ON_VOLUME=false;;
+    *)          DEFAULT_DATA_ON_VOLUME=true
+esac
+DATA_ON_VOLUME=${DATA_ON_VOLUME:-$DEFAULT_DATA_ON_VOLUME}
+
+# Returns its arguments if data on volume is enabled
+function data_on_volume
+{
+    if [ "$DATA_ON_VOLUME" = 'true' ]; then
+        echo "$@"
+    fi
+}

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -26,23 +26,8 @@ if [ "$TRAVIS" = 'true' ]; then
     RM_FLAG=""
 fi
 
-# Linux volumes are faster than layer fs.
-# Mac volumes are actually slower than layer fs.
-case "$(uname -s)" in
-    Darwin*)    DEFAULT_DATA_ON_VOLUME=false;;
-    *)          DEFAULT_DATA_ON_VOLUME=true
-esac
-DATA_ON_VOLUME=${DATA_ON_VOLUME:-$DEFAULT_DATA_ON_VOLUME}
-
+# DATA_ON_VOLUME variable and data_on_volume function come from travis-common-vars.sh
 echo "DATA_ON_VOLUME is $DATA_ON_VOLUME"
-
-# Returns its arguments if data on volume is enabled
-function data_on_volume
-{
-    if [ "$DATA_ON_VOLUME" = 'true' ]; then
-        echo "$@"
-    fi
-}
 
 # Default cassandra version
 CASSANDRA_VERSION=${CASSANDRA_VERSION:-3.9}

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -85,7 +85,7 @@ EOL
 }
 
 # Stores all the data needed by the container
-SQL_ROOT_DIR="$(mktemp -d --suffix=mongoose_sql_root)"
+SQL_ROOT_DIR="$(mktempdir mongoose_sql_root)"
 echo "SQL_ROOT_DIR is $SQL_ROOT_DIR"
 
 # A directory, that contains resources that needed to bootstrap a container

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -26,6 +26,8 @@ ou: users
 EOL
 
 docker rm -f mongooseim-ldap || echo "Skip removing previous container"
+# Host on non-standard higher port 3389 to avoid problems with lower ports
+# Default LDAP port is 389
 docker run -d \
     --name mongooseim-ldap \
     -p 3389:389 \

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
+set -e
+source tools/travis-common-vars.sh
 LDAP_ROOTPASS=mongooseim_secret
 
 LDAP_ROOT="cn=admin,dc=esl,dc=com"
@@ -10,8 +12,12 @@ echo "configuring slapd"
 
 LDAP_ROOT_DIR="$(mktemp -d --suffix=mongoose_ldap_root)"
 LDAP_SCHEMAS_DIR="$LDAP_ROOT_DIR/prepopulate"
+LDAP_DATA_DIR="$LDAP_ROOT_DIR/data"
+LDAP_CONFIG_DIR="$LDAP_ROOT_DIR/config"
 
-mkdir -p "$LDAP_SCHEMAS_DIR"
+echo "LDAP_ROOT_DIR=$LDAP_ROOT_DIR"
+
+mkdir -p "$LDAP_SCHEMAS_DIR" "$LDAP_DATA_DIR" "$LDAP_CONFIG_DIR"
 
 cat > "$LDAP_SCHEMAS_DIR/init_entries.ldif" << EOL
 dn: ou=Users,dc=esl,dc=com
@@ -26,5 +32,7 @@ docker run -d \
     -e SLAPD_DOMAIN="$LDAP_DOMAIN" \
     -e SLAPD_PASSWORD="$LDAP_ROOTPASS" \
     -e SLAPD_ORGANIZATION="$LDAP_ORGANISATION" \
+    $(data_on_volume -v "$LDAP_CONFIG_DIR:/etc/ldap") \
+    $(data_on_volume -v "$LDAP_DATA_DIR:/var/lib/ldap") \
     -v "$LDAP_SCHEMAS_DIR":/etc/ldap.dist/prepopulate/ \
     openfrontier/openldap-server

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -10,7 +10,7 @@ LDAP_ORGANISATION="Erlang Solutions"
 
 echo "configuring slapd"
 
-LDAP_ROOT_DIR="$(mktemp -d --suffix=mongoose_ldap_root)"
+LDAP_ROOT_DIR="$(mktempdir mongoose_ldap_root)"
 LDAP_SCHEMAS_DIR="$LDAP_ROOT_DIR/prepopulate"
 LDAP_DATA_DIR="$LDAP_ROOT_DIR/data"
 LDAP_CONFIG_DIR="$LDAP_ROOT_DIR/config"


### PR DESCRIPTION
This PR addresses "Travis scripts are too travis specific".

Proposed changes include:
* LDAP running in docker container
* Make docker-volume logic generic