### PR TITLE
Remove the check which compares Mnesia directory with the value set in the app env when deleting Mnesia files

### DIFF
--- a/src/mongoose_cluster.erl
+++ b/src/mongoose_cluster.erl
@@ -130,8 +130,10 @@ delete_mnesia() ->
         Dir ->
             %% Both settings match, OK!
             ok;
-        _NotDir ->
-            error(mnesia_dir_inconsistent)
+        AppEnvDir ->
+            ?WARNING_MSG("mnesia:system_info(directory) returned ~p, but application:get_env(mnesia, dir) "
+                         "returned ~p: the values are different", [Dir, AppEnvDir]),
+            ok
     end,
     ok = rmrf(Dir),
     ?WARNING_MSG("Mnesia schema and files deleted", []),


### PR DESCRIPTION
This patch removes the check if Mnesia directory reported by `mnesia:system_info(directory)` is the same as `application:get_env(mnesia, dir)` when deleting Mnesia files.

The check sometimes resulted in unexpected errors. Users set Mnesia directory path using application env `mnesia.dir`. This path might be a relative path (it might be even an atom!). When Mnesia starts, it takes this value, converts it to absolute path and stored it in initial config. This is what `mnesia:system_info(directory)` returns, thus the check failed in simple situations when someone sets `mnesia.dir` to relative path. The check only succeeded in cases when `mnesia.dir` path is a normalized, absolute path, or when Mnesia is stopped, in which caes `mnesia:system_info(directory)` falls back to application env's values.
