### PR TITLE
Strict control for starting supervised processes

### DIFF
--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -44,6 +44,8 @@ foreach_recipient(Users, VerifyFun) ->
       end, Users).
 
 load_muc(Host) ->
+    %% Stop modules before trying to start them
+    unload_muc(),
     case mongoose_helper:is_odbc_enabled(<<"localhost">>) of
         true -> odbc;
         false -> mnesia

--- a/src/cassandra/mongoose_cassandra_sup.erl
+++ b/src/cassandra/mongoose_cassandra_sup.erl
@@ -20,12 +20,11 @@ stop() ->
 
 start(PoolName, WorkerCount) ->
     create_worker_pool(PoolName),
-    supervisor:start_child(ejabberd_sup, supervisor_spec(PoolName, WorkerCount)).
+    ejabberd_sup:start_child(supervisor_spec(PoolName, WorkerCount)).
 
 stop(PoolName) ->
     Tag = {mongoose_cassandra_sup, PoolName},
-    supervisor:terminate_child(ejabberd_sup, Tag),
-    supervisor:delete_child(ejabberd_sup, Tag),
+    ejabberd_sup:stop_child(Tag),
     delete_worker_pool(PoolName).
 
 start_link(PoolName, WorkerCount) ->

--- a/src/ejabberd_auth_http.erl
+++ b/src/ejabberd_auth_http.erl
@@ -49,12 +49,11 @@ start(Host) ->
     ChildMods = [fusco],
     ChildMF = {fusco, start_link},
     ChildArgs = {for_all, [AuthHost, Opts]},
-
-    {ok, _} = supervisor:start_child(ejabberd_sup,
-                                     {{ejabberd_auth_http_sup, Host},
-                                      {cuesport, start_link,
-                                       [pool_name(Host), PoolSize, ChildMods, ChildMF, ChildArgs]},
-                                      transient, 2000, supervisor, [cuesport | ChildMods]}),
+    ChildSpec = {{ejabberd_auth_http_sup, Host},
+                  {cuesport, start_link,
+                   [pool_name(Host), PoolSize, ChildMods, ChildMF, ChildArgs]},
+                  transient, 2000, supervisor, [cuesport | ChildMods]},
+    ejabberd_sup:start_child(ChildSpec),
     ok.
 
 

--- a/src/ejabberd_auth_ldap.erl
+++ b/src/ejabberd_auth_ldap.erl
@@ -101,7 +101,7 @@ start(Host) ->
     ChildSpec = {Proc, {?MODULE, start_link, [Host]},
                  transient, 1000, worker, [?MODULE]},
     ejabberd_hooks:add(host_config_update, Host, ?MODULE, config_change, 50),
-    {ok, _} = supervisor:start_child(ejabberd_sup, ChildSpec),
+    ejabberd_sup:start_child(ChildSpec),
     ok.
 
 -spec stop(Host :: jid:lserver()) -> ok.
@@ -109,8 +109,7 @@ stop(Host) ->
     ejabberd_hooks:delete(host_config_update, Host, ?MODULE, config_change, 50),
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
     gen_server:call(Proc, stop),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc),
+    ejabberd_sup:stop_child(Proc),
     ok.
 
 start_link(Host) ->

--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -225,7 +225,7 @@ start_module_sup(_PortIPProto, Module) ->
          infinity,
          supervisor,
          [ejabberd_tmp_sup]},
-    %% XXX Rewrite using ejabberd_sup:start_child
+    %% TODO Rewrite using ejabberd_sup:start_child
     %% This function is called more than once
     supervisor:start_child(ejabberd_sup, ChildSpec).
 

--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -217,15 +217,17 @@ start_listener2(Port, Module, Opts) ->
 -spec start_module_sup(_, Module :: module())
       -> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
 start_module_sup(_PortIPProto, Module) ->
-    Proc1 = gen_mod:get_module_proc("sup", Module),
-    ChildSpec1 =
-        {Proc1,
-         {ejabberd_tmp_sup, start_link, [Proc1, Module]},
+    Proc = gen_mod:get_module_proc("sup", Module),
+    ChildSpec =
+        {Proc,
+         {ejabberd_tmp_sup, start_link, [Proc, Module]},
          permanent,
          infinity,
          supervisor,
          [ejabberd_tmp_sup]},
-    supervisor:start_child(ejabberd_sup, ChildSpec1).
+    %% XXX Rewrite using ejabberd_sup:start_child
+    %% This function is called more than once
+    supervisor:start_child(ejabberd_sup, ChildSpec).
 
 -spec start_listener_sup(port_ip_proto(), Module :: atom(), Opts :: [any()])
       -> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.

--- a/src/ejabberd_rdbms.erl
+++ b/src/ejabberd_rdbms.erl
@@ -53,7 +53,7 @@ start_pool_sup() ->
          infinity,
          supervisor,
          [mongoose_rdbms_sup]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 pools() ->
     ejabberd_config:get_local_option_or_default(odbc_pools, []).

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -50,7 +50,7 @@ start(Host) ->
      5000,
      worker,
      [ejabberd_users]},
-    supervisor:start_child(ejabberd_sup, UserChildSpec),
+    ejabberd_sup:start_child(UserChildSpec),
     ejabberd_hooks:add(remove_user, Host, ?MODULE, remove_user, 50),
     ok.
 

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -50,13 +50,15 @@ start(Host) ->
      5000,
      worker,
      [ejabberd_users]},
-    ejabberd_sup:start_child(UserChildSpec),
+    %% XXX lifecycle of this child is broken
+    supervisor:start_child(ejabberd_sup, UserChildSpec),
     ejabberd_hooks:add(remove_user, Host, ?MODULE, remove_user, 50),
     ok.
 
 
 -spec stop(jid:server()) -> 'ok'.
 stop(Host) ->
+    %% TODO properly remove ejabberd_sup child
     ejabberd_hooks:delete(remove_user, Host, ?MODULE, remove_user, 50),
     ok.
 

--- a/src/global_distrib/mod_global_distrib_bounce.erl
+++ b/src/global_distrib/mod_global_distrib_bounce.erl
@@ -165,13 +165,12 @@ start() ->
     ejabberd_hooks:add(mod_global_distrib_unknown_recipient, Host, ?MODULE, maybe_store_message, 80),
     ejabberd_hooks:add(mod_global_distrib_known_recipient, Host, ?MODULE, reroute_messages, 80),
     ChildSpec = {?MODULE, {?MODULE, start_link, []}, permanent, 1000, worker, [?MODULE]},
-    {ok, _} = supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 -spec stop() -> any().
 stop() ->
     Host = opt(global_host),
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
+    ejabberd_sup:stop_child(?MODULE),
     ejabberd_hooks:delete(mod_global_distrib_known_recipient, Host, ?MODULE, reroute_messages, 80),
     ejabberd_hooks:delete(mod_global_distrib_unknown_recipient, Host, ?MODULE, maybe_store_message, 80),
     ets:delete(?MS_BY_TARGET),

--- a/src/global_distrib/mod_global_distrib_hosts_refresher.erl
+++ b/src/global_distrib/mod_global_distrib_hosts_refresher.erl
@@ -164,10 +164,9 @@ start_outgoing_conns_sup() ->
       type => supervisor,
       modules => [ConnsSup]
      },
-    {ok, _Pid} = supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 
 stop_outgoing_conns_sup() ->
     ConnsSup = mod_global_distrib_outgoing_conns_sup,
-    supervisor:terminate_child(ejabberd_sup, ConnsSup),
-    supervisor:delete_child(ejabberd_sup, ConnsSup).
+    ejabberd_sup:stop_child(ConnsSup).

--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -59,16 +59,15 @@ start(Opts) ->
     Refresher = {mod_global_distrib_redis_refresher,
                  {gen_server, start_link, [?MODULE, RefreshAfter, []]},
                  permanent, 1000, supervisor, [?MODULE]},
-    {ok, _} = supervisor:start_child(ejabberd_sup, WorkerPool),
-    {ok, _} = supervisor:start_child(ejabberd_sup, Refresher),
+    ejabberd_sup:start_child(WorkerPool),
+    ejabberd_sup:start_child(Refresher),
     ok.
 
 -spec stop() -> any().
 stop() ->
     lists:foreach(
      fun(Id) ->
-             supervisor:terminate_child(ejabberd_sup, Id),
-             supervisor:delete_child(ejabberd_sup, Id)
+             ejabberd_sup:stop_child(Id)
      end,
       [?MODULE, mod_global_distrib_redis_refresher]),
     [ets:delete(Tab) || Tab <- [?MODULE, ?JIDS_ETS, ?DOMAINS_ETS, ?PUBLIC_DOMAINS_ETS]].

--- a/src/global_distrib/mod_global_distrib_receiver.erl
+++ b/src/global_distrib/mod_global_distrib_receiver.erl
@@ -128,7 +128,7 @@ start() ->
     mod_global_distrib_utils:ensure_metric(?GLOBAL_DISTRIB_INCOMING_CLOSED(undefined), spiral),
     ChildMod = mod_global_distrib_worker_sup,
     Child = {ChildMod, {ChildMod, start_link, []}, permanent, 10000, supervisor, [ChildMod]},
-    {ok, _}= supervisor:start_child(ejabberd_sup, Child),
+    ejabberd_sup:start_child(Child),
     Endpoints = mod_global_distrib_utils:resolve_endpoints(opt(endpoints)),
     ets:insert(?MODULE, {endpoints, Endpoints}),
     start_listeners().
@@ -136,8 +136,7 @@ start() ->
 -spec stop() -> any().
 stop() ->
     stop_listeners(),
-    supervisor:terminate_child(ejabberd_sup, mod_global_distrib_worker_sup),
-    supervisor:delete_child(ejabberd_sup, mod_global_distrib_worker_sup).
+    ejabberd_sup:stop_child(mod_global_distrib_worker_sup).
 
 -spec opt(Key :: atom()) -> term().
 opt(Key) ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -90,13 +90,12 @@ start(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     ChildSpec = {Proc, {?MODULE, start_link, [Host, Opts]},
                  transient, 1000, worker, [?MODULE]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 get_features_list(Host, Caps) ->
     case get_features(Host, Caps) of

--- a/src/mod_mam_cache_user.erl
+++ b/src/mod_mam_cache_user.erl
@@ -97,6 +97,7 @@ writer_child_spec() ->
      [?MODULE]}.
 
 start_server(_Host) ->
+    %% TODO make per host server
     supervisor:start_child(ejabberd_sup, writer_child_spec()).
 
 stop_server(_Host) ->

--- a/src/mod_mam_muc_cache_user.erl
+++ b/src/mod_mam_muc_cache_user.erl
@@ -75,6 +75,7 @@ writer_child_spec() ->
      [?MODULE]}.
 
 start_server(_Host) ->
+    %% XXX make per host server
     supervisor:start_child(ejabberd_sup, writer_child_spec()).
 
 stop_server(_Host) ->

--- a/src/mod_mam_muc_cache_user.erl
+++ b/src/mod_mam_muc_cache_user.erl
@@ -75,7 +75,9 @@ writer_child_spec() ->
      [?MODULE]}.
 
 start_server(_Host) ->
-    %% XXX make per host server
+    %% TODO make per host server to be consistent with the way
+    %%      other modules start servers
+    %% This is a global server
     supervisor:start_child(ejabberd_sup, writer_child_spec()).
 
 stop_server(_Host) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -154,8 +154,7 @@ start(Host, Opts) ->
          1000,
          worker,
          [?MODULE]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
-
+    ejabberd_sup:start_child(ChildSpec).
 
 -spec stop(jid:server()) -> 'ok'
     | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
@@ -167,8 +166,7 @@ stop_gen_server(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
     %% Proc can still be alive because of a race condition
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 
 %% @doc This function is called by a room in three situations:
@@ -456,15 +454,14 @@ start_supervisor(Host) ->
          infinity,
          supervisor,
          [ejabberd_tmp_sup]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 
 -spec stop_supervisor(jid:server()) -> 'ok'
     | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop_supervisor(Host) ->
     Proc = gen_mod:get_module_proc(Host, ejabberd_mod_muc_sup),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 
 -spec process_packet(Acc :: mongoose_acc:t(),

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -106,7 +106,7 @@ start(Host, Opts) ->
          1000,
          worker,
          [?MODULE]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 
 -spec stop(jid:server()) -> 'ok'
@@ -114,7 +114,7 @@ start(Host, Opts) ->
 stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 
 -spec add_to_log(jid:server(), Type :: any(), Data :: any(), mod_muc:room(),

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -233,12 +233,11 @@ start_worker(Host, AccessMaxOfflineMsgs) ->
     {Proc,
      {?MODULE, start_link, [Proc, Host, AccessMaxOfflineMsgs]},
      permanent, 5000, worker, [?MODULE]},
-    {ok, _} = supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 stop_worker(Host) ->
     Proc = srv_name(Host),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 start_link(Name, Host, AccessMaxOfflineMsgs) ->
     gen_server:start_link({local, Name}, ?MODULE, [Host, AccessMaxOfflineMsgs], []).

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -235,13 +235,12 @@ start(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     ChildSpec = {Proc, {?MODULE, start_link, [Host, Opts]},
                  transient, 1000, worker, [?MODULE]},
-    {ok, _} = supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
-    ok = supervisor:terminate_child(ejabberd_sup, Proc),
-    ok = supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 -spec default_host() -> binary().
 default_host() ->

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -101,12 +101,11 @@ start(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
     ChildSpec = {Proc, {?MODULE, start_link, [Host, Opts]},
                  permanent, 1000, worker, [?MODULE]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?MODULE),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 %%--------------------------------------------------------------------
 %% Hooks

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -160,12 +160,11 @@ start(VHost, Opts) ->
     Proc = gen_mod:get_module_proc(VHost, ?PROCNAME),
     ChildSpec = {Proc, {?MODULE, start_link, [VHost, Opts]},
                  transient, 1000, worker, [?MODULE]},
-    supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 stop(VHost) ->
     Proc = gen_mod:get_module_proc(VHost, ?PROCNAME),
-    supervisor:terminate_child(ejabberd_sup, Proc),
-    supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 
 %%--------------------------------------------------------------------
 %% mongoose_packet_handler callbacks

--- a/src/mongoose_http_client.erl
+++ b/src/mongoose_http_client.erl
@@ -162,10 +162,9 @@ start_supervisor() ->
          infinity,
          supervisor,
          [Proc]},
-    {ok, _} = supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 
 stop_supervisor() ->
     Proc = sup_proc_name(),
-    ok = supervisor:terminate_child(ejabberd_sup, Proc),
-    ok = supervisor:delete_child(ejabberd_sup, Proc).
+    ejabberd_sup:stop_child(Proc).
 

--- a/src/mongoose_riak_sup.erl
+++ b/src/mongoose_riak_sup.erl
@@ -36,7 +36,7 @@
 start(Workers, Addr, Port, PBOpts) ->
     ChildSpec = {?MODULE, {?MODULE, start_link, [Workers, Addr, Port, PBOpts]},
         transient, infinity, supervisor, [?MODULE]},
-    {ok, _} = supervisor:start_child(ejabberd_sup, ChildSpec).
+    ejabberd_sup:start_child(ChildSpec).
 %%--------------------------------------------------------------------
 %% @doc
 %% Starts the supervisor
@@ -50,8 +50,7 @@ start_link(Workers, Addr, Port, PBOpts) ->
 
 -spec stop() -> _.
 stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE).
+    ejabberd_sup:stop_child(?MODULE).
 
 %%%===================================================================
 %%% Supervisor callbacks

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -549,8 +549,8 @@ outer_transaction(F, NRestarts, _Reason, State) ->
                  Class:Other ->
                      Stacktrace = erlang:get_stacktrace(),
                      ?ERROR_MSG("issue=outer_transaction_failed "
-                                "stacktrace=~1000p",
-                                [Stacktrace]),
+                                "reason=~p:~p stacktrace=~1000p",
+                                [Class, Other, Stacktrace]),
                      {'EXIT', Other}
           end,
     erase(?STATE_KEY), % Explicitly ignore state changed inside transaction


### PR DESCRIPTION
This PR ensures that start_module would fail, if start_child fails.
It allows to catch badly started module at start time, not when we try to use it.

It helps with failing muc_http_api_SUITE, that fails with service unavailable reason sometimes.

```erlang
big_tests/tests/muc_http_api_SUITE.erl:    muc_helper:load_muc(muc_helper:muc_host()),
```

Proposed changes include:
* `ejabberd_sup:start_child/1` crashes when child already present
* I haven't touched places, when code expects to add child several times. i.e. ejabberd_users. It needs an extra refactoring effort.
* `muc_helper:load_muc/1` unloads already started module and proceeds instead of doing nothing.