### PR TITLE
Fix a race condition in mod_global_distrib_SUITE:test_muc_conversation_history

### DIFF
--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -402,6 +402,11 @@ test_muc_conversation_history(Config0) ->
                                     Msg = <<"test-", (integer_to_binary(I))/binary>>,
                                     escalus:send(Alice, escalus_stanza:groupchat_to(RoomAddr, Msg))
                             end, lists:seq(1, 3)),
+              %% Ensure that the messages are received by the room
+              %% before trying to login Eve.
+              %% Otherwise, Eve would receive some messages from history and
+              %% some as regular groupchat messages.
+              escalus:wait_for_stanzas(Alice, 3),
 
               EveUsername = escalus_utils:get_username(Eve),
               escalus:send(Eve, muc_helper:stanza_muc_enter_room(RoomJid, EveUsername)),


### PR DESCRIPTION
This PR addresses [this error](http://mongooseim-ct-results.s3-eu-west-1.amazonaws.com/branch/master/4836/cassandra_mnesia.19.3/big/ct_run.test@travis-job-982975d2-4383-4f1f-bcae-e3e649d81c0a.2018-06-06_17.33.42/big_tests.tests.mod_global_distrib_SUITE.logs/run.2018-06-06_17.48.06/mod_global_distrib_suite.test_muc_conversation_history.html)

Proposed changes include:
* more sync way to test