### PR TITLE
Stabilizing MUC light transaction on MSSQL

### DIFF
--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -176,7 +176,6 @@ send_message_to_room(Config) ->
         escalus:wait_for_stanza(Alice),
         %% XMPP: And Alice gets IQ result
         CreationResult = escalus:wait_for_stanza(Alice),
-        ct:pal("Result: ~p", [CreationResult]),
         escalus:assert(is_iq_result, CreationResult),
         %% XMPP: Get Bob and Kate recieve their affiliation information.
         [ escalus:wait_for_stanza(U) || U <- [Bob, Kate] ],

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -26,6 +26,8 @@
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("exml/include/exml.hrl").
 
+-import(muc_light_helper, [stanza_create_room/3]).
+
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -291,24 +293,4 @@ check_delete_room(Config, RoomNameToCreate, RoomNameToDelete, RoomOwner,
 muc_light_domain() ->
     XMPPParentDomain = ct:get_config({hosts, mim, domain}),
     <<"muclight", ".", XMPPParentDomain/binary>>.
-
-
-stanza_create_room(RoomNode, InitConfig, InitOccupants) ->
-    ToBinJID = case RoomNode of
-                   undefined -> muc_light_domain();
-                   _ -> <<RoomNode/binary, $@, (muc_light_domain())/binary>>
-               end,
-    ConfigItem = #xmlel{ name = <<"configuration">>,
-        children = [ kv_el(K, V) || {K, V} <- InitConfig ] },
-    OccupantsItems = [ #xmlel{ name = <<"user">>,
-        attrs = [{<<"affiliation">>, BinAff}],
-        children = [#xmlcdata{ content = BinJID }] }
-        || {BinJID, BinAff} <- muc_light_helper:bin_aff_users(InitOccupants) ],
-    OccupantsItem = #xmlel{ name = <<"occupants">>, children = OccupantsItems },
-    escalus_stanza:to(escalus_stanza:iq_set(<<"urn:xmpp:muclight:0#create">>,
-                                            [ConfigItem, OccupantsItem]),
-                      ToBinJID).
-
-kv_el(K, V) ->
-    #xmlel{ name = K, children = [ #xmlcdata{ content = V } ] }.
 

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -58,6 +58,7 @@ Persistent Data:
 * privacy/block lists
 * last activity
 * mam (message archive management)
+* muc_light rooms
 
 **Setup**
 
@@ -96,6 +97,7 @@ For versions `5.7.9` and newer, all of the above options are set correctly by de
 * privacy/block lists
 * last activity
 * mam (message archive management)
+* muc_light rooms
 
 **Setup**
 
@@ -124,6 +126,7 @@ Microsoft SQL Server, sometimes called MSSQL, or Azure SQL Database.
 * privacy/block lists
 * last activity
 * mam (message archive management)
+* muc_light rooms
 
 **Setup**
 
@@ -141,33 +144,36 @@ You also need FreeTDS (an ODBC driver for MSSQL) installed in your system.
 Then you need to configure the ODBC and FreeTDS drivers.
 You can find an example configuration for CentOS, given that unixODBC and freetds packages have been installed.
 
-Add your database (``mongooseim`` here) to the ``/etc/odbc.ini`` file:
+Add your database (``mongooseim`` here) to the ``/etc/odbc.ini`` or ``$HOME/.odbc.ini`` file:
 ```ini
 [mongoose-mssql]
-Driver = FreeTDS
-Servername = mssql-local
-Database = mongooseim
+Driver      = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
+Setup       = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so
+Server      = 127.0.0.1
+Port        = 1433
+Database    = mongooseim
+Charset     = UTF-8
+TDS_Version = 7.2
+client_charset = UTF-8
 ```
 
-Add path to the ``FreeTDS`` driver to the ``/etc/odbcinst.ini`` file:
-```ini
-[FreeTDS]
-Description = TDS driver (Sybase/MS SQL)
-Setup = /usr/lib64/libtdsS.so.2
-Driver = /usr/lib64/libtdsodbc.so.0
-UsageCount = 1
-```
-For more details please refer to the [odbc.ini and odbcinst.ini documentation](http://www.unixodbc.org/odbcinst.html).
+For more details please refer to the [freetds.conf documentation](http://www.freetds.org/userguide/freetdsconf.htm) and
+[unixodbc documentation](http://www.unixodbc.org/odbcinst.html).
 
-Add database host to the ``/etc/freetds.conf`` file:
-```ini
-[mssql-local]
-    host = localhost
-    port = 1433
-    tds version = 8.0
-    client charset = UTF-8
+**Deadlocks notice**
+
+If muc_light's backend is set to odbc and in your system there is many rooms created in parallel,
+there may be some deadlocks due to the `READ_COMMITTED_SNAPSHOT` set to `OFF` by default.
+In this case we recommend to set this database property to `ON`, this will enable row level locking which significantly reduces
+deadlock chances around muc_light operations.
+
+This property can be set by the following `ALTER DATABASE` query:
+
+```sql
+ALTER DATABASE $name_of_your_db SET READ_COMMITTED_SNAPSHOT ON
 ```
-For more details please refer to the [freetds.conf documentation](http://www.freetds.org/userguide/freetdsconf.htm).
+
+The above command may take some time.
 
 Then you need to import the SQL schema from either ``mssql2012.sql`` or ``azuresql.sql`` file depending on which database you are using.
 You can use a Microsoft's GUI tool (the provided .sql files should work with it) or isql, but after a slight modification of the dump file:

--- a/src/mod_muc_light_db_odbc.erl
+++ b/src/mod_muc_light_db_odbc.erl
@@ -362,7 +362,8 @@ create_room_transaction({NodeCandidate, RoomS}, Config, AffUsers, Version) ->
                 [] ->
                     ok;
                 _ ->
-                    ?ERROR_MSG("event=many_ids_for_pk_select, ids=~p aborting the transaction", [AllIds]),
+                    ?ERROR_MSG("event=many_ids_for_pk_select room_name=~p ids=~p aborting the transaction",
+                               [RoomU, AllIds]),
                     throw({aborted, <<"Many IDs returned for PK select query, most probably MSSQL deadlock">>})
             end,
             lists:foreach(

--- a/src/mod_muc_light_db_odbc.erl
+++ b/src/mod_muc_light_db_odbc.erl
@@ -356,8 +356,15 @@ create_room_transaction({NodeCandidate, RoomS}, Config, AffUsers, Version) ->
                     {error, exists}
             end;
         {updated, _} ->
-            {selected, [{RoomID}]} = mongoose_rdbms:sql_query_t(
+            {selected, [{RoomID} | Rest] = AllIds} = mongoose_rdbms:sql_query_t(
                                           mod_muc_light_db_odbc_sql:select_room_id(RoomU, RoomS)),
+            case Rest of
+                [] ->
+                    ok;
+                _ ->
+                    ?ERROR_MSG("event=many_ids_for_pk_select, ids=~p aborting the transaction", [AllIds]),
+                    throw({aborted, <<"Many IDs returned for PK select query, most probably MSSQL deadlock">>})
+            end,
             lists:foreach(
               fun({{UserU, UserS}, Aff}) ->
                       {updated, _} = mongoose_rdbms:sql_query_t(

--- a/src/mongoose_commands.erl
+++ b/src/mongoose_commands.erl
@@ -356,7 +356,8 @@ execute_command(Caller, Command, Args) ->
         caller_jid_mismatch ->
             {error, denied, <<"Caller ids do not match">>};
         X:E ->
-            ?ERROR_MSG("Caught ~p:~p while executing ~p", [X, E, Command#mongoose_command.name]),
+            ?ERROR_MSG("Caught ~p:~p while executing ~p stacktrace=~p",
+                       [X, E, Command#mongoose_command.name, erlang:get_stacktrace()]),
             {error, internal, term_to_binary(E)}
     end.
 

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -333,6 +333,9 @@ elif [ "$DB" = 'mssql' ]; then
         -Q "CREATE DATABASE ejabberd"
     docker exec -it mongoose-mssql \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
+        -Q "ALTER DATABASE ejabberd SET READ_COMMITTED_SNAPSHOT ON"
+    docker exec -it mongoose-mssql \
+        /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -i mongoose.sql
 
     install_odbc_ini


### PR DESCRIPTION
After deeper investigation it turned out that MUC light's transactions causes many deadlocks in MSSQL. This resulted, for instance, in the strange duplicated (the same id) returned when selecting data by a primary key. In fact MSSQL returned only one row (which was expected) along with an error notifying about a deadlock (found when tracing with Wireshark).

The root cause of these deadlocks was default `READ_COMMITED_SNAPSHOT` (database property) set to `OFF`. With this property set to `OFF` MSSQL uses shared locks, which tries to be intelligent  and locks more then really needed when it sees a transaction modifies many data. If this property is set to `ON`, row-level locks are used which limits deadlocks in muc light's transaction while still keeping the needed transaction isolation.

