### PR TITLE
Fix async pool writer

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -604,10 +604,8 @@ do_init_per_group(C, ConfigIn) ->
             [{archive_wait, 1500} | Config0];
         elasticsearch ->
             [{archive_wait, 2500} | Config0];
-        odbc_async_pool ->
-            [{archive_wait, 200} | Config0];
         _ ->
-            [{archive_wait, 0} | Config0]
+            [{archive_wait, 200} | Config0]
     end.
 
 end_per_group(G, Config) when G == rsm_all; G == nostore;

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -604,6 +604,8 @@ do_init_per_group(C, ConfigIn) ->
             [{archive_wait, 1500} | Config0];
         elasticsearch ->
             [{archive_wait, 2500} | Config0];
+        odbc_async_pool ->
+            [{archive_wait, 200} | Config0];
         _ ->
             [{archive_wait, 0} | Config0]
     end.

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1203,7 +1203,7 @@ simple_archive_request(Config) ->
         %%   {<<"type">>,<<"chat">>}],
         %%   [{xmlel,<<"body">>,[],[{xmlcdata,<<"OH, HAI!">>}]}]}
         escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
-        maybe_wait_for_archive(Config),
+        mam_helper:wait_for_archive_size(Alice, 1),
         escalus:send(Alice, stanza_archive_request(P, <<"q1">>)),
         Res = wait_archive_respond(P, Alice),
         assert_respond_size(1, Res),
@@ -1261,7 +1261,7 @@ simple_text_search_request(Config) ->
         escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Also my bike broke down so I'm unable ",
                                                           "to return him home">>)),
         escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Cats are awesome by the way">>)),
-        maybe_wait_for_archive(Config),
+        mam_helper:wait_for_archive_size(Alice, 3),
 
         %% 'Cat' query
         escalus:send(Alice, stanza_text_search_archive_request(P, <<"q1">>, <<"cat">>)),
@@ -1303,11 +1303,12 @@ long_text_search_request(Config) ->
         %% The test should work without this block.
         %% But sometimes on the CI server we ending up with not all messages
         %% yet archived, which leads to the test failure.
-        BobMessages = escalus:wait_for_stanzas(Bob, length(Msgs), 15000),
-        ?assert_equal_extra(length(Msgs), length(BobMessages),
+        ExpectedLen = length(Msgs),
+        BobMessages = escalus:wait_for_stanzas(Bob, ExpectedLen, 15000),
+        ?assert_equal_extra(ExpectedLen, length(BobMessages),
                             #{bob_messages => BobMessages}),
 
-        maybe_wait_for_archive(Config),
+        mam_helper:wait_for_archive_size(Bob, ExpectedLen),
         escalus:send(Alice, stanza_text_search_archive_request(P, <<"q1">>,
                                                                <<"Ribs poRk cUlpa">>)),
         Res = wait_archive_respond(P, Alice),
@@ -1337,7 +1338,7 @@ unicode_messages_can_be_extracted(Config) ->
 
         [escalus:send(Alice, escalus_stanza:chat_to(Bob, Text))
          || Text <- Texts],
-        maybe_wait_for_archive(Config),
+        mam_helper:wait_for_archive_size(Alice, length(Texts)),
 
         %% WHEN Getting all messages
         escalus:send(Alice, stanza_archive_request(P, <<"uni-q">>)),
@@ -1365,7 +1366,7 @@ save_unicode_messages(Config) ->
                 escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi! this is an unicode character lol 😂"/utf8>>)),
                 escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"this is another one no 🙅"/utf8>>)),
                 escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"This is the same again lol 😂"/utf8>>)),
-                maybe_wait_for_archive(Config),
+                mam_helper:wait_for_archive_size(Alice, 3),
 
                 %% WHEN Searching for a message with "lol" string
                 escalus:send(Alice, stanza_text_search_archive_request(P, <<"q1">>, <<"lol"/utf8>>)),
@@ -1634,7 +1635,7 @@ filter_forwarded(Config) ->
 
         %% Bob receives a message.
         escalus:wait_for_stanza(Bob),
-        maybe_wait_for_archive(Config),
+        mam_helper:wait_for_archive_size(Bob, 1),
         escalus:send(Bob, stanza_archive_request(P, <<"q1">>)),
         assert_respond_size(1, wait_archive_respond(P, Bob)),
 

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -932,7 +932,7 @@ bootstrap_archive(Config) ->
 %% Wait for messages to be written
 wait_for_msgs(Msgs, Users) ->
     UsersCnt = [{S, U, count_msgs(Msgs, S, U)} || {S, U} <- Users],
-    [wait_for_archive_size_or_warning(S, U, 10, C) || {S, U, C} <- UsersCnt],
+    [wait_for_archive_size_or_warning(S, U, 20, C) || {S, U, C} <- UsersCnt],
     ok.
 
 count_msgs(Msgs, S, U) ->

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -795,6 +795,17 @@ assert_empty_archive(Server, Username, RetryTimes) when is_integer(RetryTimes) -
        X -> ct:fail({not_empty, Server, Username, {actual_size, X}})
     end.
 
+wait_for_archive_size(User, ExpectedSize) ->
+    Server = escalus_utils:get_server(User),
+    Username = escalus_utils:jid_to_lower(escalus_utils:get_username(User)),
+    case wait_for_archive_size(Server, Username, 100, ExpectedSize) of
+		ExpectedSize ->
+			ok;
+		ArchiveSize ->
+			ct:fail({expected_archive_size, Username, Server, ExpectedSize,
+					 {actual_size, ArchiveSize}})
+	end.
+
 wait_for_archive_size(Server, Username, _RetryTimes=0, _ExpectedSize) ->
     archive_size(Server, Username);
 wait_for_archive_size(Server, Username, RetryTimes, ExpectedSize) when RetryTimes > 0 ->

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -79,6 +79,10 @@ These options will only have effect when the `odbc` backend is used:
  When set to `internal`, stores messages and JIDs in internal format.
  **Warning**: Archive MUST be empty to change this option.
 * **async_writer** (boolean, default: `true`) - Enables asynchronous writer that is faster than synchronous but harder to debug.
+  This async writer does not message routing, on the other hand messages are stored in the archive with a delay.
+* **flush_interval** (integer, default: `2000`) How often (in milliseconds) buffered message are flushed to db.
+* **max_batch_size** (integer, default, `30`) Max size of the batch insert query for async writer.
+  If the buffer is filled, messages are flushed to database immediately and the `flush_interval` is restarted.
 
 #### Common backend options
 

--- a/src/mod_mam_odbc_async_pool_writer.erl
+++ b/src/mod_mam_odbc_async_pool_writer.erl
@@ -124,16 +124,10 @@ stop(Host) ->
 
 start_pm(Host, _Opts) ->
     ejabberd_hooks:add(mam_archive_message, Host, ?MODULE, archive_message, 50),
-    ejabberd_hooks:add(mam_archive_size, Host, ?MODULE, archive_size, 30),
-    ejabberd_hooks:add(mam_lookup_messages, Host, ?MODULE, lookup_messages, 30),
-    ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 stop_pm(Host) ->
     ejabberd_hooks:delete(mam_archive_message, Host, ?MODULE, archive_message, 50),
-    ejabberd_hooks:delete(mam_archive_size, Host, ?MODULE, archive_size, 30),
-    ejabberd_hooks:delete(mam_lookup_messages, Host, ?MODULE, lookup_messages, 30),
-    ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 
@@ -142,16 +136,10 @@ stop_pm(Host) ->
 
 start_muc(Host, _Opts) ->
     ejabberd_hooks:add(mam_muc_archive_message, Host, ?MODULE, archive_message, 50),
-    ejabberd_hooks:add(mam_muc_archive_size, Host, ?MODULE, archive_size, 30),
-    ejabberd_hooks:add(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 30),
-    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 stop_muc(Host) ->
     ejabberd_hooks:delete(mam_muc_archive_message, Host, ?MODULE, archive_message, 50),
-    ejabberd_hooks:delete(mam_muc_archive_size, Host, ?MODULE, archive_size, 30),
-    ejabberd_hooks:delete(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 30),
-    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 100),
     ok.
 
 
@@ -235,7 +223,6 @@ worker_queue_length(SrvName) ->
                    ArchiveID :: mod_mam:archive_id(), ArcJID :: jid:jid()) -> integer().
 archive_size(Size, Host, ArcID, _ArcJID) when is_integer(Size), is_integer(ArcID) ->
     Size.
-
 
 -spec lookup_messages(Result :: any(), Host :: jid:server(), Params :: map()) ->
     {ok, mod_mam:lookup_result()}.


### PR DESCRIPTION
This PR addresses issue with async writer being too synchronous for reading.

Proposed changes include:
* removed `wait_for_flushing` when a user reads messages from the archive
* renamed `max_packet_size` option to `max_buffer_size`
* in tests use `mam_helper:wait_for_archive_size` in some places instead of `maybe_wait_for_archive`
* documented new behaviour and old config options for async writers

