### PR TITLE
Elastic search and cassandra job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ env:
         - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
         - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
         - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
-          REL_CONFIG="with-elasticsearch with-cassandra"
+          REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
           ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
           # In case you want to test with another ODBC driver, uncomment this
       # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,9 @@ env:
         - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
         - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
         - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
-        - PRESET=cassandra_mnesia DB=cassandra REL_CONFIG=with-cassandra CASSANDRA_VERSION=3.9
-        - PRESET=elasticsearch_mnesia DB=elasticsearch REL_CONFIG=with-elasticsearch ELASTICSEARCH_VERSION=5.6.9
+        - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
+          REL_CONFIG="with-elasticsearch with-cassandra"
+          ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
           # In case you want to test with another ODBC driver, uncomment this
       # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
 

--- a/big_tests/mam.spec
+++ b/big_tests/mam.spec
@@ -1,0 +1,33 @@
+%% Spec examples:
+%%
+%%   {suites, "tests", amp_SUITE}.
+%%   {groups, "tests", amp_SUITE, [discovery]}.
+%%   {groups, "tests", amp_SUITE, [discovery], {cases, [stream_feature_test]}}.
+%%   {cases, "tests", amp_SUITE, [stream_feature_test]}.
+%%
+%% For more info see:
+%% http://www.erlang.org/doc/apps/common_test/run_test_chapter.html#test_specifications
+
+%% do not remove below SUITE if testing mongoose
+{suites, "tests", mongoose_sanity_checks_SUITE}.
+
+{suites, "tests", mam_SUITE}.
+{suites, "tests", mongoose_cassandra_SUITE}.
+{suites, "tests", mongoose_elasticsearch_SUITE}.
+
+{config, ["test.config"]}.
+{logdir, "ct_report"}.
+
+%% ct_tty_hook will log CT failures to TTY verbosely
+%% ct_mongoose_hook will:
+%% * log suite start/end events in the MongooseIM console
+%% * ensure preset value is passed to ct Config
+%% * check server's purity after SUITE
+{ct_hooks, [ct_tty_hook, ct_mongoose_hook, ct_progress_hook,
+            ct_markdown_errors_hook,
+            {ct_mongoose_log_hook, [ejabberd_node, ejabberd_cookie]},
+            {ct_mongoose_log_hook, [ejabberd2_node, ejabberd_cookie]}
+           ]}.
+
+%% To enable printing group and case enters on server side
+%%{ct_hooks, [{ct_mongoose_hook, [print_group, print_case]}]}.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -300,6 +300,14 @@
       {elasticsearch_server, "{elasticsearch_server, []}."},
       {auth_method, "internal"},
       {mod_offline, "{mod_offline, []},"}
+     ]},
+    {elasticsearch_and_cassandra_mnesia,
+     [{sm_backend, "{mnesia, []}"},
+      {elasticsearch_server, "{elasticsearch_server, []}."},
+      {cassandra_servers, "{cassandra_servers, [{default, [{ssl,[{cacertfile, \"priv/ssl/cacert.pem\"},
+                                                                 {verify, verify_peer}] }] }] }."},
+      {auth_method, "internal"},
+      {mod_offline, "{mod_offline, []},"}
      ]}
 ]}.
 

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -7,14 +7,11 @@
 # https://store.docker.com/editions/community/docker-ce-desktop-mac
 
 set -e
-
 TOOLS=`dirname $0`
 
 source tools/travis-common-vars.sh
 
 MIM_PRIV_DIR=${BASE}/priv
-
-DB_CONF_DIR=${BASE}/${TOOLS}/db_configs/$DB
 
 MYSQL_DIR=/etc/mysql/conf.d
 
@@ -103,7 +100,13 @@ SQL_TEMP_DIR="$SQL_ROOT_DIR/temp"
 SQL_DATA_DIR="$SQL_ROOT_DIR/data"
 mkdir -p "$SQL_TEMP_DIR" "$SQL_DATA_DIR"
 
-if [ "$DB" = 'mysql' ]; then
+function setup_db(){
+db=${1:-none}
+echo "Setting up db: $db"
+DB_CONF_DIR=${BASE}/${TOOLS}/db_configs/$db
+
+
+if [ "$db" = 'mysql' ]; then
     echo "Configuring mysql"
     # TODO We should not use sudo
     sudo -n service mysql stop || echo "Failed to stop mysql"
@@ -127,7 +130,7 @@ if [ "$DB" = 'mysql' ]; then
         -p 3306:3306 --name=mongooseim-mysql \
         mysql --default-authentication-plugin=mysql_native_password
 
-elif [ "$DB" = 'pgsql' ]; then
+elif [ "$db" = 'pgsql' ]; then
     # If you see "certificate verify failed" error in Mongoose logs, try:
     # Inside tools/ssl/:
     # make clean && make
@@ -150,7 +153,7 @@ elif [ "$DB" = 'pgsql' ]; then
     cp ${SSLDIR}/ca/cacert.pem ${PGSQL_ODBC_CERT_DIR}/root.crt
     install_odbc_ini
 
-elif [ "$DB" = 'riak' ]; then
+elif [ "$db" = 'riak' ]; then
     echo "Configuring Riak with SSL"
     docker rm -f mongooseim-riak || echo "Skip removing previous container"
     # Instead of docker run, use "docker create" + "docker start".
@@ -195,7 +198,7 @@ elif [ "$DB" = 'riak' ]; then
     # Use this command to read Riak's logs if something goes wrong
     # docker exec -it mongooseim-riak bash -c 'tail -f /var/log/riak/*'
 
-elif [ "$DB" = 'cassandra' ]; then
+elif [ "$db" = 'cassandra' ]; then
     docker image pull cassandra:${CASSANDRA_VERSION}
     docker rm -f mongooseim-cassandra mongooseim-cassandra-proxy || echo "Skip removing previous container"
 
@@ -247,7 +250,7 @@ elif [ "$DB" = 'cassandra' ]; then
                        sh -c 'exec cqlsh "$CASSANDRA_PORT_9042_TCP_ADDR" --ssl -f /cassandra.cql'
     done
 
-elif [ "$DB" = 'elasticsearch' ]; then
+elif [ "$db" = 'elasticsearch' ]; then
     ELASTICSEARCH_IMAGE=docker.elastic.co/elasticsearch/elasticsearch:$ELASTICSEARCH_VERSION
     ELASTICSEARCH_PORT=9200
     ELASTICSEARCH_NAME=mongoooseim-elasticsearch
@@ -274,7 +277,7 @@ elif [ "$DB" = 'elasticsearch' ]; then
     (curl -X PUT $ELASTICSEARCH_URL/muc_messages -d "@$ELASTICSEARCH_MUC_MAPPING" -w "status: %{http_code}" | grep "status: 200" > /dev/null) || \
         echo "Failed to put MUC mapping into ElasticSearch"
 
-elif [ "$DB" = 'mssql' ]; then
+elif [ "$db" = 'mssql' ]; then
     # LICENSE STUFF, IMPORTANT
     #
     # SQL Server Developer edition
@@ -340,3 +343,12 @@ elif [ "$DB" = 'mssql' ]; then
 else
     echo "Skip setting up database"
 fi
+}
+
+# The DB env var may contain single value "mysql"
+# or list of values separated with a space "elasticsearch cassandra"
+# in case of list of values all listed database will be set up (or at least tried)
+
+for db in ${DB}; do
+    setup_db $db
+done

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -105,11 +105,12 @@ run_test_preset() {
   tools/print-dots.sh start
   cd ${BASE}/big_tests
   local MAKE_RESULT=0
+  TESTSPEC=${TESTSPEC:-default.spec}
   if [ "$COVER_ENABLED" = "true" ]; then
-    make cover_test_preset TESTSPEC=default.spec PRESET=$PRESET
+    make cover_test_preset TESTSPEC=$TESTSPEC PRESET=$PRESET
     MAKE_RESULT=$?
   else
-    make test_preset TESTSPEC=default.spec PRESET=$PRESET
+    make test_preset TESTSPEC=$TESTSPEC PRESET=$PRESET
     MAKE_RESULT=$?
   fi
   cd -


### PR DESCRIPTION
This PR addresses travis-ci usage optimisations.

The only unique functionality for ElasticSearch and Cassandra job is MAM. In this PR both these jobs are combined into one and mam_SUITE is tested with both back-ends. Additionally there are cassandra and elastic specific suites run.

Thanks to that the needed functionality is tests in less then 20 minutes instead of almost 1 hour as it was before when these 2 jobs were run separately.

