### PR TITLE
acc-related fixes and cleanups

### DIFF
--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -381,10 +381,11 @@ make_friends(Bob, Alice) ->
     escalus:wait_for_stanzas(Alice, 10, 200),
     BobStanzas = escalus:wait_for_stanzas(Bob, 10, 200),
     lists:filter(fun(S) -> N = S#xmlel.name,
-        ct:pal("N: ~p", [N]),
                            N =/= <<"iq">>
-                             andalso N =/= <<"presence">>
-                             andalso N =/= <<"r">>
+                           andalso
+                           N =/= <<"presence">>
+                           andalso
+                           N =/= <<"r">>
                  end,
                  BobStanzas).
 

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -44,6 +44,7 @@
 
 %% Receive notification or response
 -export([receive_item_notification/4,
+         check_item_notification/4,
          receive_subscription_notification/4,
          receive_subscription_request/4,
          receive_subscription_requests/4,

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -102,8 +102,8 @@ process_iq(#iq{xmlns = XMLNS} = IQ, Acc, From, To, _El) ->
     case ets:lookup(?IQTABLE, {XMLNS, Host}) of
         [{_, Module, Function}] ->
             case Module:Function(From, To, IQ) of
-                ignore -> ok;
-                ResIQ -> ejabberd_router:route(To, From, Acc, jlib:iq_to_xml(ResIQ))
+                {_Acc, ignore} -> ok;
+                {Acc1, ResIQ} -> ejabberd_router:route(To, From, Acc1, jlib:iq_to_xml(ResIQ))
             end;
         [{_, Module, Function, Opts}] ->
             gen_iq_handler:handle(Host, Module, Function, Opts,

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -126,6 +126,10 @@ route(From, To, Acc) ->
     El = mongoose_acc:get(element, Acc),
     route(From, To, Acc, El, routing_modules_list()).
 
+-spec route(From   :: jid:jid(),
+            To     :: jid:jid(),
+            Acc :: mongoose_acc:t(),
+            El :: exml:element() | {error, term()}) -> mongoose_acc:t().
 route(From, To, Acc, {error, Reason}) ->
     ?INFO_MSG("event=cannot_route_stanza,from=~p,to=~p,reason=~p,acc=~p", [From, To, Reason, Acc]),
     mongoose_acc:append(errors, Reason, Acc);

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -114,8 +114,12 @@ start_link() ->
     Packet :: mongoose_acc:t()|exml:element()) -> mongoose_acc:t().
 route(From, To, #xmlel{} = Packet) ->
     % ?ERROR_MSG("Deprecated - it should be Acc: ~p", [Packet]),
+    Acc0 = mongoose_acc:from_element(Packet, From, To),
+    Acc1 = mongoose_acc:update(Acc0,
+                               #{user => From#jid.luser,
+                                 server => From#jid.lserver}),
     % (called by broadcasting)
-    route(From, To, mongoose_acc:from_element(Packet, From, To));
+    route(From, To, Acc1);
 route(From, To, Acc) ->
     ?DEBUG("route~n\tfrom ~p~n\tto ~p~n\tpacket ~p~n",
            [From, To, Acc]),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -131,9 +131,18 @@ start_link() ->
       Packet :: exml:element() | mongoose_acc:t()| ejabberd_c2s:broadcast(),
       Acc :: mongoose_acc:t().
 route(From, To, #xmlel{} = Packet) ->
-    route(From, To, mongoose_acc:from_element(Packet, From, To));
+    Acc0 = mongoose_acc:from_element(Packet, From, To),
+    Acc1 = mongoose_acc:update(Acc0,
+                              #{user => From#jid.luser,
+                                server => From#jid.lserver}),
+    route(From, To, Acc1);
 route(From, To, {broadcast, Payload}) ->
-    route(From, To, mongoose_acc:new(), {broadcast, Payload});
+    Acc0 = mongoose_acc:new(),
+    Acc1 = mongoose_acc:update(Acc0,
+                               #{user => From#jid.luser,
+                                 server => From#jid.lserver,
+                                 type => undefined}),
+    route(From, To, Acc1, {broadcast, Payload});
 route(From, To, Acc) ->
     route(From, To, Acc, mongoose_acc:get(element, Acc)).
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -989,9 +989,9 @@ process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
     case ets:lookup(sm_iqtable, {XMLNS, Host}) of
         [{_, Module, Function}] ->
             case Module:Function(From, To, IQ) of
-                ignore -> ok;
-                ResIQ ->
-                    ejabberd_router:route(To, From, Acc,
+                {_Acc, ignore} -> ok;
+                {Acc1, ResIQ} ->
+                    ejabberd_router:route(To, From, Acc1,
                         jlib:iq_to_xml(ResIQ))
             end;
         [{_, Module, Function, Opts}] ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -635,10 +635,10 @@ do_route(Acc, From, To, El) ->
                     Session = lists:max(Ss),
                     Pid = element(2, Session#session.sid),
                     ?DEBUG("sending to process ~p~n", [Pid]),
-                    Pid ! {route, From, To, mongoose_acc:strip(Acc, El)}
+                    Pid ! {route, From, To, mongoose_acc:strip(Acc, El)},
+                    Acc
             end
-    end,
-    Acc.
+    end.
 
 -spec do_route_no_resource_presence_prv(From, To, Acc, Packet, Type, Reason) -> boolean() when
       From :: jid:jid(),
@@ -679,24 +679,24 @@ do_route_no_resource_presence(_, _, _, _, _) ->
     true.
 
 
--spec do_route_no_resource(Name, Type, From, To, Acc, El) -> Result when
+-spec do_route_no_resource(Name, Type, From, To, Acc, El) -> Acc when
       Name :: undefined | binary(),
       Type :: any(),
       From :: jid:jid(),
       To :: jid:jid(),
       Acc :: mongoose_acc:t(),
-      El :: exml:element(),
-      Result ::ok | stop | todo | pid() | {error, lager_not_running} | {process_iq, _, _, _}.
+      El :: exml:element().
 do_route_no_resource(<<"presence">>, Type, From, To, Acc, El) ->
     case do_route_no_resource_presence(Type, From, To, Acc, El) of
         true ->
             PResources = get_user_present_resources(To#jid.luser, To#jid.lserver),
-            lists:foreach(
-              fun({_, R}) ->
-                      do_route(Acc, From, jid:replace_resource(To, R), El)
-              end, PResources);
+            lists:foldl(fun({_, R}, A) ->
+                            do_route(A, From, jid:replace_resource(To, R), El)
+                        end,
+                        Acc,
+                        PResources);
         false ->
-            ok
+            Acc
     end;
 do_route_no_resource(<<"message">>, _, From, To, Acc, El) ->
     route_message(From, To, Acc, El);
@@ -706,10 +706,10 @@ do_route_no_resource(<<"broadcast">>, _, From, To, Acc, El) ->
     %% Backward compatibility
     ejabberd_hooks:run(sm_broadcast, To#jid.lserver, [From, To, Acc]),
     broadcast_packet(From, To, Acc, El);
-do_route_no_resource(_, _, _, _, _, _) ->
-    ok.
+do_route_no_resource(_, _, _, _, Acc, _) ->
+    Acc.
 
--spec do_route_offline(Name, Type, From, To, Acc, Packet) -> ok | stop when
+-spec do_route_offline(Name, Type, From, To, Acc, Packet) -> mongoose_acc:t() when
       Name :: 'undefined' | binary(),
       Type :: binary(),
       From :: jid:jid(),
@@ -724,33 +724,33 @@ do_route_offline(<<"message">>, _, From, To, Acc, Packet)  ->
             route_message(From, To, Acc, Packet);
         true ->
             ?DEBUG("issue=\"message droped\", to=~1000p", [To]),
-            ok
+            Acc
     end;
-do_route_offline(<<"iq">>, <<"error">>, _From, _To, _Acc, _Packet) ->
-    ok;
-do_route_offline(<<"iq">>, <<"result">>, _From, _To, _Acc, _Packet) ->
-    ok;
+do_route_offline(<<"iq">>, <<"error">>, _From, _To, Acc, _Packet) ->
+    Acc;
+do_route_offline(<<"iq">>, <<"result">>, _From, _To, Acc, _Packet) ->
+    Acc;
 do_route_offline(<<"iq">>, _, From, To, Acc, Packet) ->
     {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
     ejabberd_router:route(To, From, Acc1, Err);
-do_route_offline(_, _, _, _, _, _) ->
+do_route_offline(_, _, _, _, Acc, _) ->
     ?DEBUG("packet droped~n", []),
-    ok.
+    Acc.
 
 %% Backward compatibility
 -spec broadcast_packet(From :: jid:jid(),
                        To :: jid:jid(),
                        Acc :: mongoose_acc:t(),
-                       El :: exml:element()) -> ok.
+                       El :: exml:element()) -> mongoose_acc:t().
 broadcast_packet(From, To, Acc, El) ->
     #jid{user = User, server = Server} = To,
-    lists:foreach(
-      fun(R) ->
-              do_route(Acc,
+    lists:foldl(
+      fun(A, R) ->
+              do_route(A,
                        From,
                        jid:replace_resource(To, R),
                        El)
-      end, get_user_resources(User, Server)).
+      end, Acc, get_user_resources(User, Server)).
 
 %% @doc The default list applies to the user as a whole,
 %% and is processed if there is no active list set
@@ -785,12 +785,11 @@ is_privacy_allow(_From, To, Acc, _Packet, PrivacyList) ->
     allow == Res.
 
 
--spec route_message(From, To, Acc, Packet) -> Res when
+-spec route_message(From, To, Acc, Packet) -> Acc when
       From :: jid:jid(),
       To :: jid:jid(),
       Acc :: mongoose_acc:t(),
-      Packet :: exml:element(),
-      Res :: ok | stop | mongoose_acc:t() | {stop, mongoose_acc:t()}.
+      Packet :: exml:element().
 route_message(From, To, Acc, Packet) ->
     LUser = To#jid.luser,
     LServer = To#jid.lserver,
@@ -807,14 +806,15 @@ route_message(From, To, Acc, Packet) ->
                  ({_Prio, _Pid}) ->
                       ok
               end,
-              PrioPid);
+              PrioPid),
+              Acc;
         _ ->
             MessageType = xml:get_tag_attr_s(<<"type">>, Packet),
             route_message_by_type(MessageType, From, To, Acc, Packet)
     end.
 
-route_message_by_type(<<"error">>, _From, _To, _Acc, _Packet) ->
-    ok;
+route_message_by_type(<<"error">>, _From, _To, Acc, _Packet) ->
+    Acc;
 route_message_by_type(<<"groupchat">>, From, To, Acc, Packet) ->
     LServer = To#jid.lserver,
     ejabberd_hooks:run_fold(offline_groupchat_message_hook,
@@ -822,7 +822,8 @@ route_message_by_type(<<"groupchat">>, From, To, Acc, Packet) ->
         Acc,
         [From, To, Packet]);
 route_message_by_type(<<"headline">>, From, To, Acc, Packet) ->
-    bounce_offline_message(Acc, From, To, Packet);
+    {stop, Acc1} = bounce_offline_message(Acc, From, To, Packet),
+    Acc1;
 route_message_by_type(_, From, To, Acc, Packet) ->
     LUser = To#jid.luser,
     LServer = To#jid.lserver,
@@ -836,8 +837,9 @@ route_message_by_type(_, From, To, Acc, Packet) ->
                         [From, To, Packet]);
                 false ->
                     ejabberd_hooks:run_fold(failed_to_store_message,
-                        LServer, Packet, [From]),
-                    ok
+                                            LServer,
+                                            Acc,
+                                            [From, Packet])
             end;
         _ ->
             {Acc1, Err} = jlib:make_error_reply(
@@ -973,12 +975,11 @@ get_max_user_sessions(LUser, Host) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec process_iq(From, To, Acc, Packet) -> Result when
+-spec process_iq(From, To, Acc, Packet) -> Acc when
       From :: jid:jid(),
       To :: jid:jid(),
       Acc :: mongoose_acc:t(),
-      Packet :: exml:element(),
-      Result :: ok | todo | pid() | {error, lager_not_running} | {process_iq, _, _, _}.
+      Packet :: exml:element().
 process_iq(From, To, Acc0, Packet) ->
     Acc = mongoose_acc:require(iq_query_info, Acc0),
     IQ = mongoose_acc:get(iq_query_info, Acc),
@@ -989,7 +990,7 @@ process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
     case ets:lookup(sm_iqtable, {XMLNS, Host}) of
         [{_, Module, Function}] ->
             case Module:Function(From, To, IQ) of
-                {_Acc, ignore} -> ok;
+                {Acc1, ignore} -> Acc1;
                 {Acc1, ResIQ} ->
                     ejabberd_router:route(To, From, Acc1,
                         jlib:iq_to_xml(ResIQ))
@@ -1002,12 +1003,11 @@ process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
                     Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
             ejabberd_router:route(To, From, Acc1, Err)
     end;
-process_iq(reply, _From, _To, _Acc, _Packet) ->
-    ok;
+process_iq(reply, _From, _To, Acc, _Packet) ->
+    Acc;
 process_iq(_, From, To, Acc, Packet) ->
     {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:bad_request()),
-    ejabberd_router:route(To, From, Acc1, Err),
-    ok.
+   ejabberd_router:route(To, From, Acc1, Err).
 
 
 -spec force_update_presence({binary(), jid:server()}) -> 'ok'.

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -61,9 +61,10 @@ publish_notification(Acc0, From, #jid{lserver = Host} = To, Packet, Services) ->
               Stanza = push_notification_iq(From, Packet, Node, Form),
               Acc = mongoose_acc:from_element(Stanza, To, PubsubJID),
               ResponseHandler =
-                  fun(Response) ->
+                  fun(_From, _To, Acc1, Response) ->
                           mod_event_pusher_push:cast(Host, handle_publish_response,
-                                                     [BareRecipient, PubsubJID, Node, Response])
+                                                     [BareRecipient, PubsubJID, Node, Response]),
+                          Acc1
                   end,
               mod_event_pusher_push:cast(Host, ejabberd_local, route_iq, [To, PubsubJID, Acc, Stanza, ResponseHandler])
       end, Services),

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -415,8 +415,8 @@ feature_request(Acc, Host, From, Caps,
                               {ok, TS} -> now_ts() >= TS + (?BAD_HASH_LIFETIME);
                               _ -> true
                           end,
-            F = fun (IQReply) ->
-                        feature_response(Acc, IQReply, Host, From, Caps,
+            F = fun (_From, _To, Acc1, IQReply) ->
+                        feature_response(Acc1, IQReply, Host, From, Caps,
                                          SubNodes)
                 end,
             case NeedRequest of

--- a/src/mod_muc_iq.erl
+++ b/src/mod_muc_iq.erl
@@ -36,14 +36,13 @@ start_link() ->
 %% @doc Handle custom IQ.
 %% Called from mod_muc_room.
 -spec process_iq(jid:server(), jid:jid(), jid:jid(), mongoose_acc:t(),
-        jlib:iq()) -> error | ignore.
+        jlib:iq()) -> mongoose_acc:t() | {mongoose_acc:t(), error}.
 process_iq(Host, From, RoomJID, Acc, IQ = #iq{xmlns = XMLNS}) ->
     case ets:lookup(tbl_name(), {XMLNS, Host}) of
         [{_, Module, Function, Opts}] ->
             gen_iq_handler:handle(Host, Module, Function, Opts, From,
-                                  RoomJID, Acc, IQ),
-            ignore;
-        [] -> error
+                                              RoomJID, Acc, IQ);
+        [] -> {Acc, error}
     end.
 
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4588,10 +4588,10 @@ route_iq(Acc, #routed_iq{iq = IQ = #iq{}, packet = Packet, from = From},
          #state{host = Host, jid = RoomJID} = StateData) ->
     %% Custom IQ, addressed to this room's JID.
     case mod_muc_iq:process_iq(Host, From, RoomJID, Acc, IQ) of
-        ignore -> ok;
-        error ->
-            {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:feature_not_implemented()),
-            ejabberd_router:route(RoomJID, From, Acc1, Err)
+        {Acc1, error} ->
+            {Acc2, Err} = jlib:make_error_reply(Acc1, Packet, mongoose_xmpp_errors:feature_not_implemented()),
+            ejabberd_router:route(RoomJID, From, Acc2, Err);
+        _ -> ok
     end,
     {ok, StateData};
 route_iq(_Acc, #routed_iq{iq = reply}, StateData) ->

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -45,7 +45,7 @@
          remove_user/2,
          remove_user/3,
          determine_amp_strategy/5,
-         amp_failed_event/2]).
+         amp_failed_event/3]).
 
 %% Internal exports
 -export([start_link/3]).
@@ -166,8 +166,8 @@ stop(Host) ->
 %% Server side functions
 %% ------------------------------------------------------------------
 
-amp_failed_event(Packet, From) ->
-    mod_amp:check_packet(Packet, From, offline_failed).
+amp_failed_event(Acc, From, _Packet) ->
+    mod_amp:check_packet(Acc, From, offline_failed).
 
 handle_offline_msg(Acc, #offline_msg{us=US} = Msg, AccessMaxOfflineMsgs) ->
     {LUser, LServer} = US,
@@ -555,7 +555,7 @@ discard_warn_sender(Acc, Msgs) ->
               ErrText = <<"Your contact offline message queue is full."
                           " The message has been discarded.">>,
               Lang = exml_query:attr(Packet, <<"xml:lang">>, <<>>),
-              amp_failed_event(Packet, From),
+              amp_failed_event(Acc, From, Packet),
               {Acc1, Err} = jlib:make_error_reply(
                       Acc, Packet, mongoose_xmpp_errors:resource_constraint(Lang, ErrText)),
               ejabberd_router:route(To, From, Acc1, Err)

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -186,8 +186,9 @@ handle_info({timeout, _TRef, {ping, JID}},
              sub_el = [#xmlel{name = <<"ping">>,
                               attrs = [{<<"xmlns">>, ?NS_PING}]}]},
     Pid = self(),
-    F = fun(Response) ->
-                gen_server:cast(Pid, {iq_pong, JID, Response})
+    F = fun(_From, _To, Acc, Response) ->
+                gen_server:cast(Pid, {iq_pong, JID, Response}),
+                Acc
         end,
     From = jid:make(<<"">>, State#state.host, <<"">>),
     Acc = mongoose_acc:from_element(IQ, From, JID),

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -219,7 +219,7 @@ process_iq(From, To, Acc, IQ) ->
         true ->
             process_local_iq(From, To, Acc, IQ);
         _ ->
-            IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:item_not_found()]}
+            {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:item_not_found()]}}
     end.
 
 process_local_iq(From, To, Acc, #iq{type = Type} = IQ) ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -257,10 +257,10 @@ process_decoded_packet(From, To, {ok, {_, #blocking{}} = Blocking}, _Acc, OrigPa
     end;
 process_decoded_packet(From, To, {ok, #iq{} = IQ}, Acc, OrigPacket) ->
     case mod_muc_iq:process_iq(To#jid.lserver, From, To, Acc, IQ) of
-        ignore -> ok;
-        error ->
+        {_Acc1, error} ->
             mod_muc_light_codec_backend:encode_error(
-              {error, feature_not_implemented}, From, To, OrigPacket, fun ejabberd_router:route/3)
+              {error, feature_not_implemented}, From, To, OrigPacket, fun ejabberd_router:route/3);
+        _ -> ok
     end;
 process_decoded_packet(From, #jid{ luser = RoomU } = To, {ok, RequestToRoom}, _Acc, OrigPacket)
   when RoomU =/= <<>> ->

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -108,7 +108,7 @@ stream_management(_Config) ->
 local(_Config) ->
     ejabberd_local:start_link(),
     Self = self(),
-    SelfNotify = fun(Arg) -> Self ! Arg end,
+    SelfNotify = fun(_, _, _, Arg) -> Self ! Arg end,
     ID = <<"abc123">>,
 
     ejabberd_local:register_iq_response_handler(?HOST, ID, undefined, SelfNotify, 50),


### PR DESCRIPTION
In some corner cases (e.g. when using pubsub with stream management on) it triggered errors on hook calls, because some handlers rely on server key being present (which is usually the case). It produced error log messages, made some metrics incorrect, and could potentially cause more trouble.

I think we should make those two values required in accumulator, as kind of "environment variables", whereby server is host in context of which we are operating, and user is the caller. Server-generated actions and admin's rest api calls might have user=undefined.

Also, this PR fixes acc processing in iq handling machinery, also cleaning it up so that functions have the same signatures and fixing function specs.