### PR TITLE
Build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,18 +84,14 @@ jobs:
         - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
       after_success:
         - tools/travis-upload-build-artifacts-to-s3.sh
-    - stage: test
-      script:
-        - ls -la _build
-        - ls -la tools/ssl
 
 stages:
   - build
   - test
 
-#env:
-#        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
-#        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
+env:
+        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
+        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
 #          #        - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
 #          #        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
 #          #        - PRESET=cassandra_mnesia DB=cassandra REL_CONFIG=with-cassandra CASSANDRA_VERSION=3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,35 +73,56 @@ branches:
 
 otp_release:
         - 19.3
-env:
-        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
-        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
-        - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
-        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
-        - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
-          REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
-          ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
-          # In case you want to test with another ODBC driver, uncomment this
-      # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
 
-matrix:
-    include:
-        - otp_release: 20.0
-          env: PRESET=dialyzer_only
-               SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-        - otp_release: 20.0
-          env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
-        - otp_release: 18.3
-          env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
-        - language: generic
-          env: PRESET=pkg pkg_PLATFORM=centos7
-               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-        - language: generic
-          env: PRESET=pkg pkg_PLATFORM=debian_stretch
-               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+jobs:
+  include:
+    - stage: build
+      script: make rel
+      env:
+        - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+      after_success:
+        - echo "need to upload artifacts to s3"
+    - stage: test
+      before_install:
+        - echo "I wonder when this is run"
+      script:
+        - ls -la _build
+        - ls -la tools/ssl
 
+stages:
+  - build
+  - test
+
+#env:
+#        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
+#        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
+#          #        - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
+#          #        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
+#          #        - PRESET=cassandra_mnesia DB=cassandra REL_CONFIG=with-cassandra CASSANDRA_VERSION=3.9
+#          #        - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
+#          #          REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
+#          #          ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
+#          #          # In case you want to test with another ODBC driver, uncomment this
+#          #      # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
+#          #
+#matrix:
+#  include:
+#          #        - otp_release: 20.0
+#          #          env: PRESET=dialyzer_only
+#          #               SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+#    - otp_release: 20.0
+#      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
+#    - otp_release: 18.3
+#      env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
+#          #        - language: generic
+#          #          env: PRESET=pkg pkg_PLATFORM=centos7
+#          #               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+#          #               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+#          #        - language: generic
+#          #          env: PRESET=pkg pkg_PLATFORM=debian_stretch
+#          #               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+#          #               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+#
 notifications:
     webhooks:
         # trigger Buildtime Trend Service to parse Travis CI log

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,10 @@ jobs:
       env:
         - PRESET=only_small_tests SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
     - stage: test
-      otp_release: 20.3
+      otp_release: 20.0
       env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip" RUN_SMALL_TESTS=true
     - stage: test
-      otp_release: 20.3
+      otp_release: 20.0
       env: PRESET=dialyzer_only SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
     - stage: test
       otp_release: 18.3
@@ -117,17 +117,19 @@ stages:
   - post tests
 
 env:
-        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes RUN_SMALL_TESTS=false
-        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis" RUN_SMALL_TESTS=false
-#          #        - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
-#          #        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
-#          #        - PRESET=cassandra_mnesia DB=cassandra REL_CONFIG=with-cassandra CASSANDRA_VERSION=3.9
-#          #        - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
-#          #          REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
-#          #          ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
-#          #          # In case you want to test with another ODBC driver, uncomment this
-#          #      # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
-#          #
+  global:
+    - RUN_SMALL_TESTS=false
+  matrix:
+    - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
+    - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
+    - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
+    - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
+    - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
+      REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
+      ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
+    # In case you want to test with another ODBC driver, uncomment this
+    # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
+
 
 notifications:
     webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
         - muc.localhost
 before_install:
         - pip install --user awscli
+        - tools/travis-download-build-artifacts-from-s3.sh
         # Do not execute this step, if environment variable SKIP_RELEASE is "1"
         # Configure is a part of release creation
         - test 1 = "$SKIP_RELEASE" || tools/configure $REL_CONFIG
@@ -84,8 +85,6 @@ jobs:
       after_success:
         - tools/travis-upload-build-artifacts-to-s3.sh
     - stage: test
-      before_install:
-        - echo "I wonder when this is run"
       script:
         - ls -la _build
         - ls -la tools/ssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
         # used in MUC + s2s tests combination
         - muc.localhost
 before_install:
+        - pip install --user awscli
         # Do not execute this step, if environment variable SKIP_RELEASE is "1"
         # Configure is a part of release creation
         - test 1 = "$SKIP_RELEASE" || tools/configure $REL_CONFIG
@@ -81,7 +82,7 @@ jobs:
       env:
         - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
       after_success:
-        - echo "need to upload artifacts to s3"
+        - tools/travis-upload-build-artifacts-to-s3.sh
     - stage: test
       before_install:
         - echo "I wonder when this is run"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ jobs:
   include:
     - stage: build
       script:
-        - make rel
         - make ct
       env:
         - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 install:
         - test 1 = "$SKIP_COMPILE" || travis_retry ./rebar3 get-deps
         - test 1 = "$SKIP_COMPILE" || ./rebar3 compile
+        - test 1 = "$SKIP_COMPILE" || make certs
         - test 1 = "$SKIP_RELEASE" || make devrel
         - test 1 = "$SKIP_BUILD_TESTS" || tools/travis-build-tests.sh
         - test 1 = "$SKIP_COV" || travis_retry pip install --user codecov
@@ -83,7 +84,7 @@ jobs:
         - make rel
         - make ct
       env:
-        - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+        - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1
       after_success:
         - tools/travis-upload-build-artifacts-to-s3.sh
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
         - muc.localhost
 before_install:
         - pip install --user awscli
-        - tools/travis-download-build-artifacts-from-s3.sh
+        - if [ $PRESET != "pkg" ]; then tools/travis-download-build-artifacts-from-s3.sh; fi
         # Do not execute this step, if environment variable SKIP_RELEASE is "1"
         # Configure is a part of release creation
         - test 1 = "$SKIP_RELEASE" || tools/configure $REL_CONFIG
@@ -88,11 +88,33 @@ jobs:
       script: make ct
       env:
         - PRESET=only_small_tests SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+    - stage: test
+      otp_release: 20.3
+      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip" RUN_SMALL_TESTS=true
+    - stage: test
+      otp_release: 20.3
+      env: PRESET=dialyzer_only SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+    - stage: test
+      otp_release: 18.3
+      env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak RUN_SMALL_TESTS=true
+    - stage: post tests
+      language: generic
+      env: PRESET=pkg pkg_PLATFORM=centos7
+           SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+           SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+    - stage: post tests
+      language: generic
+      env: PRESET=pkg pkg_PLATFORM=debian_stretch
+           SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+           SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+
+
 
 stages:
   - build
   - pre test
   - test
+  - post tests
 
 env:
         - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes RUN_SMALL_TESTS=false
@@ -106,24 +128,7 @@ env:
 #          #          # In case you want to test with another ODBC driver, uncomment this
 #          #      # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
 #          #
-#matrix:
-#  include:
-#          #        - otp_release: 20.0
-#          #          env: PRESET=dialyzer_only
-#          #               SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-#    - otp_release: 20.0
-#      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
-#    - otp_release: 18.3
-#      env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
-#          #        - language: generic
-#          #          env: PRESET=pkg pkg_PLATFORM=centos7
-#          #               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-#          #               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-#          #        - language: generic
-#          #          env: PRESET=pkg pkg_PLATFORM=debian_stretch
-#          #               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-#          #               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-#
+
 notifications:
     webhooks:
         # trigger Buildtime Trend Service to parse Travis CI log

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
-script: KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET
+script: KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET -s $RUN_SMALL_TESTS
 
 after_failure:
         - cat `ls -1 -d -t apps/ejabberd/logs/ct_run* | head -1`/apps.ejabberd.logs/run.*/suite.log
@@ -84,14 +84,19 @@ jobs:
         - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
       after_success:
         - tools/travis-upload-build-artifacts-to-s3.sh
+    - stage: pre test
+      script: make ct
+      env:
+        - PRESET=only_small_tests SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
 
 stages:
   - build
+  - pre test
   - test
 
 env:
-        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
-        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
+        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes RUN_SMALL_TESTS=false
+        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis" RUN_SMALL_TESTS=false
 #          #        - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
 #          #        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
 #          #        - PRESET=cassandra_mnesia DB=cassandra REL_CONFIG=with-cassandra CASSANDRA_VERSION=3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,15 +79,13 @@ otp_release:
 jobs:
   include:
     - stage: build
-      script: make rel
+      script:
+        - make rel
+        - make ct
       env:
         - SKIP_REPORT_UPLOAD=1 SKIP_COV=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
       after_success:
         - tools/travis-upload-build-artifacts-to-s3.sh
-    - stage: pre test
-      script: make ct
-      env:
-        - PRESET=only_small_tests SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
     - stage: test
       otp_release: 20.0
       env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip" RUN_SMALL_TESTS=true
@@ -109,10 +107,8 @@ jobs:
            SKIP_COV=1 SKIP_REPORT_UPLOAD=1
 
 
-
 stages:
   - build
-  - pre test
   - test
   - post tests
 

--- a/tools/travis-download-build-artifacts-from-s3.sh
+++ b/tools/travis-download-build-artifacts-from-s3.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source tools/travis-helpers.sh
+
+set -euo pipefail
+
+AWS_BUCKET="${AWS_BUCKET:-mongooseim-ct-results}"
+
+ARTIFACT_NAME=${TRAVIS_BUILD_ID}-${TRAVIS_OTP_RELEASE}.bz2
+echo "Artifact name: ${ARTIFACT_NAME}"
+
+## If there is no build artifacts, we simply continue without them
+## the test is still possible, only will take longer to complet
+
+set +e
+echo "sync build artifacts from S3"
+time aws s3 cp s3://${AWS_BUCKET}/build_artifacts/${ARTIFACT_NAME} /tmp/${ARTIFACT_NAME}
+if [ "$?" -ne 0 ]; then echo "missing build artifacts, continuing without them"; exit 0; fi
+set -e
+
+echo "extract"
+time tar -xjf /tmp/${ARTIFACT_NAME} -C /tmp
+
+mkdir -p ${TRAVIS_BUILD_DIR}/_build
+mkdir -p ${TRAVIS_BUILD_DIR}/tools/ssl
+
+ARTIFACTS_DIR=/tmp/build_artifacts
+
+cp -r -a ${ARTIFACTS_DIR}/_build ${TRAVIS_BUILD_DIR}
+cp -r ${ARTIFACTS_DIR}/ssl ${TRAVIS_BUILD_DIR}/tools
+
+echo "Listing ${TRAVIS_BUILD_DIR}"
+ls -lth ${TRAVIS_BUILD_DIR}
+echo "Listing ${TRAVIS_BUILD_DIR}/_build"
+ls -lth ${TRAVIS_BUILD_DIR}/_build
+echo "Listing ${TRAVIS_BUILD_DIR}/tools/ssl"
+ls -lth ${TRAVIS_BUILD_DIR}/tools/ssl
+

--- a/tools/travis-download-build-artifacts-from-s3.sh
+++ b/tools/travis-download-build-artifacts-from-s3.sh
@@ -28,6 +28,7 @@ ARTIFACTS_DIR=/tmp/build_artifacts
 
 cp -r -a ${ARTIFACTS_DIR}/_build ${TRAVIS_BUILD_DIR}
 cp -r ${ARTIFACTS_DIR}/ssl ${TRAVIS_BUILD_DIR}/tools
+cp -r ${ARTIFACTS_DIR}/big_tests_build ${TRAVIS_BUILD_DIR}/big_tests/_build
 
 echo "Listing ${TRAVIS_BUILD_DIR}"
 ls -lth ${TRAVIS_BUILD_DIR}

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -67,7 +67,7 @@ run_small_tests() {
   echo "    Add option \"-s false\" to skip embeded common tests"
   echo "Example: "
   echo "    ./tools/travis-test.sh -s false"
-  make ct
+  time make ct
   SMALL_SUMMARIES_DIRS=${BASE}/_build/test/logs/ct_run*
   SMALL_SUMMARIES_DIR=$(summaries_dir ${SMALL_SUMMARIES_DIRS} 1)
   ${TOOLS}/summarise-ct-results ${SMALL_SUMMARIES_DIR}

--- a/tools/travis-upload-build-artifacts-to-s3.sh
+++ b/tools/travis-upload-build-artifacts-to-s3.sh
@@ -10,6 +10,7 @@ ARTIFACTS_DIR=/tmp/build_artifacts
 mkdir $ARTIFACTS_DIR
 
 cp -r -a $TRAVIS_BUILD_DIR/_build ${ARTIFACTS_DIR}
+cp -r $TRAVIS_BUILD_DIR/big_tests/_build ${ARTIFACTS_DIR}/big_tests_build
 cp -r $TRAVIS_BUILD_DIR/tools/ssl ${ARTIFACTS_DIR}
 
 ARTIFACT_NAME=${TRAVIS_BUILD_ID}-${TRAVIS_OTP_RELEASE}.bz2

--- a/tools/travis-upload-build-artifacts-to-s3.sh
+++ b/tools/travis-upload-build-artifacts-to-s3.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source tools/travis-helpers.sh
+
+set -euo pipefail
+
+AWS_BUCKET="${AWS_BUCKET:-mongooseim-ct-results}"
+
+ARTIFACTS_DIR=/tmp/build_artifacts
+mkdir $ARTIFACTS_DIR
+
+cp -r -a $TRAVIS_BUILD_DIR/_build ${ARTIFACTS_DIR}
+cp -r $TRAVIS_BUILD_DIR/tools/ssl ${ARTIFACTS_DIR}
+
+ARTIFACT_NAME=${TRAVIS_BUILD_ID}-${TRAVIS_OTP_RELEASE}.bz2
+
+echo "Creating artifact archive: ${ARTIFACT_NAME}"
+time tar -cj -C /tmp -f /tmp/${ARTIFACT_NAME} build_artifacts
+
+echo "Uploading the archive to S3"
+time aws s3 cp /tmp/${ARTIFACT_NAME} s3://${AWS_BUCKET}/build_artifacts/${ARTIFACT_NAME}
+


### PR DESCRIPTION
This PR introduces build stages on travis-ci.

## How does it work?

For Erlang/OTP 19.3 (the one used in most jobs on travis) there is:
* a `Build` stage where dependencies are downloaded and the whole code is compiled. Also there is the `prod` release build mainly to produce all the ssl certificates and `small tests` are run
    * `_build`, `tools/ssl` and `big_tests/_build` directories are put in a `bzip2` archive, named `$TRAVIS_BUILD_IS-$TRAVIS_OTP_VERSION` and uploaded to S3 (the same bucket as for test results)
   * the whole stage takes around 11 minutes (depending how loaded travis-ci is)
   * artefact building takes on avg 2min 30s
   * artefact upload takes on avg 35s
* then there is the `Test` stage where there are 8 parallel jobs (the same presets as currently without stages)
    * 5 of them running on Erlang/OTP 19.3 reuse the build artefact and doesn't run small tests (as they were already run). This reduces these jobs time by around 7 to 9 minutes.
    * 3 of them on Erlang/OTP 20.0 and 18.3 are the same as currently (without any artefacts and with small tests run).
* then there is the `Post tests` stage where currently there are 2 jobs running pkg scripts.

## Advantages:
 * reduces total build time by around 30 minutes and can be optimise a bit more

## Disadvantages:
 * Build artefacts are not uploaded and download for PR from other repository (there is no travis secure evns for such builds, so we are not able to upload artefacts). This means that `Build` stage is useless as all other stages will be building MongooseIM as it happens now.
 * More complicated `.travis.yml` file and whole pipeline.
 * First test results are visible around 10 minutes later then it's now (due to `Build` and `Pre test` stages)

## TODO:
- [x] maybe combine `Build` and `Pre test` stage
- [ ] fix coverage report for the stage with only small tests run
- [x] maybe build `big tests` in `Build stage` and add it to the archive so that it doesn't have to be compiled on all the jobs (will safe up 2 minutes for every job on Erlang/OTP 19.3
