### PR TITLE
Fix roster update on subscription request

### DIFF
--- a/src/mod_roster_mnesia.erl
+++ b/src/mod_roster_mnesia.erl
@@ -82,8 +82,7 @@ get_roster_entry(LUser, LServer, LJID) ->
         [] ->
             does_not_exist;
         [I] ->
-            I#roster{jid = LJID, name = <<"">>,
-                xs = []}
+            I#roster{jid = LJID, xs = []}
     end.
 
 get_roster_entry(LUser, LServer, LJID, full) ->
@@ -94,8 +93,7 @@ get_roster_entry_t(LUser, LServer, LJID) ->
         [] ->
             does_not_exist;
         [I] ->
-            I#roster{jid = LJID, name = <<"">>,
-                xs = []}
+            I#roster{jid = LJID, xs = []}
     end.
 
 get_roster_entry_t(LUser, LServer, LJID, full) ->

--- a/src/mod_roster_odbc.erl
+++ b/src/mod_roster_odbc.erl
@@ -131,7 +131,7 @@ do_get_roster_entry(LUser, LServer, LJID, FuncName) ->
                         us = {LUser, LServer}, jid = LJID};
                 _ ->
                     R#roster{usj = {LUser, LServer, LJID},
-                        us = {LUser, LServer}, jid = LJID, name = <<"">>}
+                        us = {LUser, LServer}, jid = LJID}
             end
     end.
 

--- a/src/mod_roster_riak.erl
+++ b/src/mod_roster_riak.erl
@@ -135,7 +135,7 @@ find_in_rostermap(LJID, RosterMap) ->
 roster_entry_strip(_, does_not_exist) ->
     does_not_exist;
 roster_entry_strip(LJID, Entry) ->
-    Entry#roster{ jid = LJID, name = <<>>, groups = [], xs = [] }.
+    Entry#roster{ jid = LJID}.
 
 %% this is a transaction-less equivalent of get_t_roster
 get_rostermap(LUser, LServer) ->


### PR DESCRIPTION
This PR fixes a bug that manifests when a user adds a contact to a roster with a nickname and then sends subscription request to the same user. In such case, the nickname information will get removed when using RDBMS backend.
