### PR TITLE
Run small tests with Erlang/OTP 19.3 in their own job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,15 @@ before_install:
 install:
         - test 1 = "$SKIP_COMPILE" || travis_retry ./rebar3 get-deps
         - test 1 = "$SKIP_COMPILE" || ./rebar3 compile
+          ## Certs are needed by some tests in small_tests
+        - test 1 = "$SKIP_COMPILE" || make certs
         - test 1 = "$SKIP_RELEASE" || make devrel
         - test 1 = "$SKIP_BUILD_TESTS" || tools/travis-build-tests.sh
         - test 1 = "$SKIP_COV" || travis_retry pip install --user codecov
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
-script: KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET
+script: KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET -s $RUN_SMALL_TESTS
 
 after_failure:
         - cat `ls -1 -d -t apps/ejabberd/logs/ct_run* | head -1`/apps.ejabberd.logs/run.*/suite.log
@@ -76,33 +78,39 @@ branches:
 otp_release:
         - 19.3
 env:
-        - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
-        - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
-        - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
-        - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
-        - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
-          REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
-          ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
-          # In case you want to test with another ODBC driver, uncomment this
+  global:
+    - RUN_SMALL_TESTS=false
+  matrix:
+    - PRESET=small_tests RUN_SMALL_TESTS=true SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+    - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
+    - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis"
+    - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
+    - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
+    - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
+      REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
+      ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
+      # In case you want to test with another ODBC driver, uncomment this
       # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
 
+
 matrix:
-    include:
-        - otp_release: 20.0
-          env: PRESET=dialyzer_only
-               SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-        - otp_release: 20.0
-          env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
-        - otp_release: 18.3
-          env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak
-        - language: generic
-          env: PRESET=pkg pkg_PLATFORM=centos7
-               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
-        - language: generic
-          env: PRESET=pkg pkg_PLATFORM=debian_stretch
-               SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-               SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+  include:
+    - otp_release: 20.0
+      env: PRESET=dialyzer_only
+           SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+    - otp_release: 20.0
+      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
+           RUN_SMALL_TESTS=true
+    - otp_release: 18.3
+      env: PRESET=riak_mnesia DB=riak REL_CONFIG=with-riak RUN_SMALL_TESTS=true
+    - language: generic
+      env: PRESET=pkg pkg_PLATFORM=centos7
+           SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+           SKIP_COV=1 SKIP_REPORT_UPLOAD=1
+    - language: generic
+      env: PRESET=pkg pkg_PLATFORM=debian_stretch
+           SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
+           SKIP_COV=1 SKIP_REPORT_UPLOAD=1
 
 notifications:
     webhooks:

--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -79,7 +79,8 @@ prepare: mim_ct_rest compile vm.dist.args
 mim_ct_rest: \
 	$(REPO_DIR)/test/mim_ct_rest.erl \
 	$(REPO_DIR)/test/mim_ct_rest_handler.erl \
-	$(REPO_DIR)/test/mim_ct_sup.erl
+	$(REPO_DIR)/test/mim_ct_sup.erl \
+	$(REPO_DIR)/test/codecov_helper.erl
 	cp $^ src/
 
 vm.dist.args: vm.dist.args.in certs

--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -525,72 +525,8 @@ import_code_paths(FromNode) when is_atom(FromNode) ->
     Paths = rpc:call(FromNode, code, get_path, []),
     code:add_paths(Paths).
 
-%% covecov.json cover format
-%% ------------------------------------------------------------------
-
-%% Writes codecov.json into root of the repo directory
-%%
-%% Format:
-%%
-%% {"coverage": {
-%%     "src/mod_mam.erl": [0, 1, 4, null]
-%% }}
-%%
-%% Where:
-%%
-%% - 0 - zero hits
-%% - null - lines, that are not executed (comments, patterns...)
-%% - 1 - called once
-%% - 4 - called 4 times
 export_codecov_json() ->
-    Modules = cover:imported_modules(),
-    %% Result is a flat map of `{{Module, Line}, CallTimes}'
-    {result, Result, _} = cover:analyse(Modules, calls, line),
-    Mod2Data = lists:foldl(fun add_cover_line_into_array/2, #{}, Result),
-    JSON = maps:fold(fun format_array_to_list/3, [], Mod2Data),
-    Binary = jiffy:encode(#{<<"coverage">> => {JSON}}),
-    file:write_file(repo_dir() ++ "/codecov.json", Binary).
-
-add_cover_line_into_array({{Module, Line}, CallTimes}, Acc) ->
-    %% Set missing lines to null
-    CallsPerLineArray = maps:get(Module, Acc, array:new({default, null})),
-    Acc#{Module => array:set(Line, CallTimes, CallsPerLineArray)}.
-
-format_array_to_list(Module, CallsPerLineArray, Acc) ->
-    ListOfCallTimes = array:to_list(CallsPerLineArray),
-    BinPath = list_to_binary(get_source_path(Module)),
-    [{BinPath, ListOfCallTimes}|Acc].
-
-%% We assume that all mongooseim modules are loaded on this node
-get_source_path(Module) when is_atom(Module) ->
-    try
-        AbsPath = proplists:get_value(source, Module:module_info(compile)),
-        string_prefix(AbsPath, get_repo_dir())
-    catch Error:Reason ->
-        Stacktrace = erlang:get_stacktrace(),
-        error_logger:warning_msg("issue=get_source_path_failed module=~p "
-                                  "reason=~p:~p stacktrace=~1000p",
-                                 [Module, Error, Reason, Stacktrace]),
-        atom_to_list(Module) ++ ".erl"
-    end.
-
-get_repo_dir() ->
-    %% We make an assumption, that mongooseim.erl is in src/ directory
-    MongoosePath = proplists:get_value(source, mongooseim:module_info(compile)),
-    string_suffix(MongoosePath, "src/mongooseim.erl").
-
-%% Removes string prefix
-%% string:prefix/2 that works for any version of erlang and does not return nomatch
-string_prefix([H|String], [H|Prefix]) ->
-    string_prefix(String, Prefix);
-string_prefix(String, []) ->
-    String.
-
-%% Removes string suffix
-string_suffix(String, Suffix) ->
-    StringR = lists:reverse(String),
-    SuffixR = lists:reverse(Suffix),
-    lists:reverse(string_prefix(StringR, SuffixR)).
+    codecov_helper:to_json(repo_dir() ++ "/codecov.json").
 
 %% Gets result of file operation and prints filename, if we have any issues.
 handle_file_error(FileName, {error, Reason}) ->

--- a/rebar.config
+++ b/rebar.config
@@ -142,7 +142,7 @@
   {rebar_faster_deps, {git, "https://github.com/arcusfelis/rebar3-faster-deps-plugin.git",
       {ref, "eb3cded5b050edd82cf8653f8c850c6c9890f732"}}},
   {pc, {git, "https://github.com/blt/port_compiler.git", {ref, "c2f3fb1"}}},
-  {coveralls, {git, "https://github.com/markusn/coveralls-erl.git", {ref, "aaa2444"}}},
+  {coveralls, {git, "https://github.com/michalwski/coveralls-erl.git", {ref, "ad5a5ac"}}},
   {provider_asn1, {git, "https://github.com/knusbaum/provider_asn1.git", {ref, "29f7850"}}}
  ]}.
 
@@ -177,9 +177,5 @@
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.
-{coveralls_coverdata, ["_build/test/cover/ct.coverdata",
-                       "_build/mim1/rel/mongooseim/priv/cover/mongooseim@localhost.coverdata",
-                       "_build/mim2/rel/mongooseim/priv/cover/ejabberd2@localhost.coverdata",
-                       "_build/mim3/rel/mongooseim/priv/cover/mongooseim3@localhost.coverdata"
-                       ]}.
+{coveralls_coverdata, "_build/**/cover/*.coverdata"}.
 {coveralls_service_name, "travis-ci"}.

--- a/test/codecov_helper.erl
+++ b/test/codecov_helper.erl
@@ -1,0 +1,88 @@
+-module(codecov_helper).
+
+-export([to_json/1]).
+
+-export([analyze/1]).
+
+%% covecov.json cover format
+%% ------------------------------------------------------------------
+
+%% Writes codecov.json into root of the repo directory
+%%
+%% Format:
+%%
+%% {"coverage": {
+%%     "src/mod_mam.erl": [0, 1, 4, null]
+%% }}
+%%
+%% Where:
+%%
+%% - 0 - zero hits
+%% - null - lines, that are not executed (comments, patterns...)
+%% - 1 - called once
+%% - 4 - called 4 times
+to_json(OutputFile) ->
+    Modules = cover:imported_modules(),
+    %% Result is a flat map of `{{Module, Line}, CallTimes}'
+    {result, Result, _} = cover:analyse(Modules, calls, line),
+    Mod2Data = lists:foldl(fun add_cover_line_into_array/2, #{}, Result),
+    JSON = maps:fold(fun format_array_to_list/3, [], Mod2Data),
+    Binary = jiffy:encode(#{<<"coverage">> => {JSON}}),
+    file:write_file(OutputFile, Binary).
+%% We assume that all mongooseim modules are loaded on this node
+add_cover_line_into_array({{Module, Line}, CallTimes}, Acc) ->
+    %% Set missing lines to null
+    CallsPerLineArray = maps:get(Module, Acc, array:new({default, null})),
+    Acc#{Module => array:set(Line, CallTimes, CallsPerLineArray)}.
+
+format_array_to_list(Module, CallsPerLineArray, Acc) ->
+    ListOfCallTimes = array:to_list(CallsPerLineArray),
+    BinPath = list_to_binary(get_source_path(Module)),
+    [{BinPath, ListOfCallTimes}|Acc].
+
+get_source_path(Module) when is_atom(Module) ->
+    try
+        AbsPath = proplists:get_value(source, Module:module_info(compile)),
+        string_prefix(AbsPath, get_repo_dir())
+    catch Error:Reason ->
+        Stacktrace = erlang:get_stacktrace(),
+        error_logger:warning_msg("issue=get_source_path_failed module=~p "
+                                  "reason=~p:~p stacktrace=~1000p",
+                                 [Module, Error, Reason, Stacktrace]),
+        atom_to_list(Module) ++ ".erl"
+    end.
+
+
+get_repo_dir() ->
+    %% We make an assumption, that mongooseim.erl is in src/ directory
+    MongoosePath = proplists:get_value(source, mongooseim:module_info(compile)),
+    string_suffix(MongoosePath, "src/mongooseim.erl").
+%% Removes string prefix
+%% string:prefix/2 that works for any version of erlang and does not return nomatch
+string_prefix([H|String], [H|Prefix]) ->
+    string_prefix(String, Prefix);
+string_prefix(String, []) ->
+    String.
+
+%% Removes string suffix
+string_suffix(String, Suffix) ->
+    StringR = lists:reverse(String),
+    SuffixR = lists:reverse(Suffix),
+    lists:reverse(string_prefix(StringR, SuffixR)).
+
+
+analyze(Args) ->
+    try
+        io:format("starting ~p~n", [Args]),
+        [InFile, OutFile] = Args,
+        cover:start(),
+        io:format("importing ~s~n", [InFile]),
+        ok = cover:import(InFile),
+        io:format("exporting ~s~n", [OutFile]),
+        to_json(OutFile),
+        init:stop(0)
+    catch E:R ->
+              io:format("~p:~p~n", [E, R]),
+              io:format("~p", [erlang:get_stacktrace()]),
+              init:stop(1)
+    end.

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -60,13 +60,6 @@ summaries_dir() {
 }
 
 run_small_tests() {
-  echo "############################"
-  echo "Running small tests (test/)"
-  echo "############################"
-  echo "Advice: "
-  echo "    Add option \"-s false\" to skip embeded common tests"
-  echo "Example: "
-  echo "    ./tools/travis-test.sh -s false"
   make ct
   SMALL_SUMMARIES_DIRS=${BASE}/_build/test/logs/ct_run*
   SMALL_SUMMARIES_DIR=$(summaries_dir ${SMALL_SUMMARIES_DIRS} 1)
@@ -75,6 +68,13 @@ run_small_tests() {
 
 maybe_run_small_tests() {
   if [ "$SMALL_TESTS" = "true" ]; then
+    echo "############################"
+    echo "Running small tests (test/)"
+    echo "############################"
+    echo "Advice: "
+    echo "    Add option \"-s false\" to skip embeded common tests"
+    echo "Example: "
+    echo "    ./tools/travis-test.sh -s false"
     run_small_tests
   else
     echo "############################"
@@ -199,6 +199,8 @@ if [ $PRESET == "dialyzer_only" ]; then
   exit ${RESULT}
 elif [ $PRESET == "pkg" ]; then
   build_pkg $pkg_PLATFORM
+elif [ $PRESET == "small_tests" ]; then
+  run_small_tests
 else
   [ x"$TLS_DIST" == xyes ] && enable_tls_dist
   run_tests

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -200,7 +200,9 @@ if [ $PRESET == "dialyzer_only" ]; then
 elif [ $PRESET == "pkg" ]; then
   build_pkg $pkg_PLATFORM
 elif [ $PRESET == "small_tests" ]; then
-  run_small_tests
+  time run_small_tests
+  time erl -noinput -pa _build/test/lib/mongooseim/test -pa _build/test/lib/mongooseim/ebin -pa _build/default/lib/*/ebin \
+       -s codecov_helper analyze _build/test/cover/ct.coverdata codecov.json
 else
   [ x"$TLS_DIST" == xyes ] && enable_tls_dist
   run_tests


### PR DESCRIPTION
This PR is mainly to see the total tests time difference when small tests are run in their own job.
The job is on Erlang/OTP 19.3 so other jobs using this version will not run small tests.
Jobs running on other version of Erlang will still run small tests as before.

