### PR TITLE
muc light user affiliation rework

### DIFF
--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -269,16 +269,20 @@ find_new_owner(AU, AUC, JoiningUsers) ->
     NewMembers = [U || {U, member} <- (AUC)],
     OldMembers = AllMembers -- NewMembers,
     DemotedOwners = NewMembers -- JoiningUsers,
-    %% try to select the new owner from:
-    %%   1) old unchanged room members
-    %%   2) new just joined room members
-    %%   3) demoted room owners
-    case {OldMembers, JoiningUsers, DemotedOwners} of
-        {[U | _], _, _} -> {U, promote_old_member};
-        {_, [U | _], _} -> {U, promote_joined_member};
-        {_, _, [U | _]} -> {U, promote_demoted_owner};
-        _ -> false
-    end.
+    generate_promotion(OldMembers, JoiningUsers, DemotedOwners).
+
+%% @doc try to select the new owner from:
+%%   1) old unchanged room members
+%%   2) new just joined room members
+%%   3) demoted room owners
+generate_promotion([U | _], _JoiningUsers, _DemotedOwners) ->
+    {U, promote_old_member};
+generate_promotion(_OldMembers, [U | _], DemotedOwners) ->
+    {U, promote_joined_member};
+generate_promotion(_OldMembers, _JoiningUsers, [U | _]) ->
+    {U, promote_demoted_owner};
+generate_promotion(_, _, _) ->
+    false.
 
 -spec maybe_demote_old_owner(ChangeResult :: change_aff_success() | {error, bad_request}) ->
     change_aff_success() | {error, bad_request}.

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -237,7 +237,7 @@ maybe_select_new_owner({ok, AU, AUC, JoiningUsers, LeavingUsers} = AffRes) ->
     {AffUsers, AffUsersChanged} =
         case is_new_owner_needed(AU) of
             true ->
-                {NewOwner, PromotionType} = find_new_owner(AffRes),
+                {NewOwner, PromotionType} = find_new_owner(AU, AUC, JoiningUsers),
                 NewAU = lists:keyreplace(NewOwner, 1, AU, {NewOwner, owner}),
                 NewAUC = update_au(PromotionType, NewOwner, AUC),
                 {NewAU, NewAUC};
@@ -264,7 +264,7 @@ is_new_owner_needed(AU) ->
 
 -spec find_new_owner(ChangeResult :: change_aff_success()) ->
     {jid:simple_bare_jid(), promotion_type()} | false.
-find_new_owner({ok, AU, AUC, JoiningUsers, _LeavingUsers}) ->
+find_new_owner(AU, AUC, JoiningUsers) ->
     AllMembers = [U || {U, member} <- (AU)],
     NewMembers = [U || {U, member} <- (AUC)],
     OldMembers = AllMembers -- NewMembers,

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -235,9 +235,8 @@ value2b(Val, float) -> float_to_binary(Val).
     change_aff_success() | {error, bad_request}.
 maybe_select_new_owner({ok, AU, AUC, JoiningUsers, LeavingUsers} = AffRes) ->
     {AffUsers, AffUsersChanged} =
-        case is_new_owner_needed(AU) of
-            true ->
-                {NewOwner, PromotionType} = find_new_owner(AU, AUC, JoiningUsers),
+        case is_new_owner_needed(AU) andalso find_new_owner(AU, AUC, JoiningUsers) of
+            {NewOwner, PromotionType} ->
                 NewAU = lists:keyreplace(NewOwner, 1, AU, {NewOwner, owner}),
                 NewAUC = update_auc(PromotionType, NewOwner, AUC),
                 {NewAU, NewAUC};

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -257,8 +257,8 @@ update_auc(promote_demoted_owner, NewOwner, AUC) ->
 
 is_new_owner_needed(AU) ->
     case lists:keyfind(owner, 2, AU) of
-        false -> false;
-        _ -> true
+        false -> true;
+        _ -> false
     end.
 
 

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -290,17 +290,16 @@ maybe_demote_old_owner({ok, AU, AUC, JoiningUsers, LeavingUsers}) ->
     Owners = [U || {U, owner} <- AU],
     PromotedOwners = [U || {U, owner} <- AUC],
     OldOwners = Owners -- PromotedOwners,
-    if
-        length(Owners) =< 1 ->
+    case {Owners, OldOwners} of
+        _ when length(Owners) =< 1 ->
             {ok, AU, AUC, JoiningUsers, LeavingUsers};
-        length(Owners) =:= 2 andalso length(OldOwners) =:= 1 ->
-            [U] = OldOwners,
-            NewAU = lists:keyreplace(U, 1, AU, {U, member}),
-            NewAUC = [{U, member} | AUC],
+        {[_, _], [OldOwner]} ->
+            NewAU = lists:keyreplace(OldOwner, 1, AU, {OldOwner, member}),
+            NewAUC = [{OldOwner, member} | AUC],
             {ok, NewAU, NewAUC, JoiningUsers, LeavingUsers};
-        true ->
+        _ ->
             {error, bad_request}
-    end;
+    end
 maybe_demote_old_owner(Error) ->
     Error.
 

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -238,22 +238,22 @@ maybe_select_new_owner({ok, AU, AUC, JoiningUsers, LeavingUsers} = AffRes) ->
         case {lists:keyfind(owner, 2, AU), find_new_owner(AffRes)} of
             {false, {NewOwner, PromotionType}} -> %select new owner
                 NewAU = lists:keyreplace(NewOwner, 1, AU, {NewOwner, owner}),
-                NewAUC = case PromotionType of
-                             promote_old_member ->
-                                 [{NewOwner, owner} | AUC];
-                             promote_joined_member ->
-                                 lists:keyreplace(NewOwner, 1, AUC, {NewOwner, owner});
-                             promote_demoted_owner ->
-                                 lists:keydelete(NewOwner, 1, AUC)
-                         end,
+                NewAUC = update_auc(PromotionType, NewOwner, AUC),
                 {NewAU, NewAUC};
-
             _ ->
                 {AU, AUC}
         end,
     {ok, AffUsers, AffUsersChanged, JoiningUsers, LeavingUsers};
 maybe_select_new_owner(Error) ->
     Error.
+
+update_auc(promote_old_member, NewOwner, AUC) ->
+    [{NewOwner, owner} | AUC];
+update_auc(promote_joined_member, NewOwner, AUC) ->
+    lists:keyreplace(NewOwner, 1, AUC, {NewOwner, owner});
+update_auc(promote_demoted_owner, NewOwner, AUC) ->
+    lists:keydelete(NewOwner, 1, AUC).
+
 
 -spec find_new_owner(ChangeResult :: change_aff_success()) ->
     {jid:simple_bare_jid(), promotion_type()} | false.

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -262,7 +262,7 @@ is_new_owner_needed(AU) ->
     end.
 
 
--spec find_new_owner(ChangeResult :: change_aff_success()) ->
+-spec find_new_owner(aff_users(), aff_users(), [jid:simple_bare_jid()]) ->
     {jid:simple_bare_jid(), promotion_type()} | false.
 find_new_owner(AU, AUC, JoiningUsers) ->
     AllMembers = [U || {U, member} <- (AU)],
@@ -299,7 +299,7 @@ maybe_demote_old_owner({ok, AU, AUC, JoiningUsers, LeavingUsers}) ->
             {ok, NewAU, NewAUC, JoiningUsers, LeavingUsers};
         _ ->
             {error, bad_request}
-    end
+    end;
 maybe_demote_old_owner(Error) ->
     Error.
 


### PR DESCRIPTION
tried to simplify user affiliation change code.
hope this version is a bit easier to read. 
multiple room ownership can be enabled by removing `maybe_demote_old_owner/1` call from `change_aff_users/2`