### PR TITLE
Wait for Alice archive in full text archive search test

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1310,6 +1310,7 @@ long_text_search_request(Config) ->
                             #{bob_messages => BobMessages}),
 
         mam_helper:wait_for_archive_size(Bob, ExpectedLen),
+        mam_helper:wait_for_archive_size(Alice, ExpectedLen),
         escalus:send(Alice, stanza_text_search_archive_request(P, <<"q1">>,
                                                                <<"Ribs poRk cUlpa">>)),
         Res = wait_archive_respond(P, Alice),


### PR DESCRIPTION
It happened that messages send from Alice to Bob were indexed by Elastic Search for Bob already, but were not yet for Alice. In this PR the test waits until all messages are indexed for Alice before the search query is sent.

