### PR TITLE
stabilise connect_SUITE

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -46,13 +46,13 @@ all() ->
     ].
 
 groups() ->
-    G = [ {c2s_suspend, [], [reset_stream_suspend,
-                            starttls_suspend,
-                            compress_suspend,
-                            bad_xml,
-                            invalid_host,
-                            invalid_stream_namespace,
-                            pre_xmpp_1_0_stream]},
+    G = [ {c2s_error_cases, [], [reset_stream_no_receiver,
+                                 starttls_no_receiver,
+                                 compress_no_receiver,
+                                 bad_xml,
+                                 invalid_host,
+                                 invalid_stream_namespace,
+                                 pre_xmpp_1_0_stream]},
           {starttls, [], test_cases()},
           {tls, [parallel], [auth_bind_pipelined_session,
                              auth_bind_pipelined_auth_failure |
@@ -71,7 +71,7 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 all_groups()->
-    [{group, c2s_suspend},
+    [{group, c2s_error_cases},
      {group, starttls},
      {group, feature_order},
      {group, tls}].
@@ -111,7 +111,7 @@ end_per_suite(Config) ->
     restore_ejabberd_node(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(c2s_suspend, Config) ->
+init_per_group(c2s_error_cases, Config) ->
     config_ejabberd_node_tls(Config,
                              fun mk_value_for_starttls_config_pattern/0),
     ejabberd_node_utils:restart_application(mongooseim),
@@ -294,7 +294,7 @@ clients_can_connect_with_advertised_ciphers(Config) ->
                          ciphers_working_with_ssl_clients(Config))).
 
 
-reset_stream_suspend(Config) ->
+reset_stream_no_receiver(Config) ->
     UserSpec = escalus_users:get_userspec(Config, alice),
     Steps = [start_stream, stream_features],
     {ok, Conn, _Features} = escalus_connection:start(UserSpec, Steps),
@@ -303,7 +303,7 @@ reset_stream_suspend(Config) ->
     [RcvPid] = children_specs_to_pids(rpc(mim(), supervisor, which_children, [ejabberd_receiver_sup])),
     MonRef = erlang:monitor(process, C2sPid),
     ok = rpc(mim(), sys, suspend, [C2sPid]),
-    timer:sleep(100),
+    wait_until_c2s_is_suspended(C2sPid),
     %% Add auth element into message queue of the c2s process
     %% There is no reply because the process is suspended
     ?assertThrow({timeout, auth_reply}, escalus_session:authenticate(Conn)),
@@ -322,7 +322,7 @@ reset_stream_suspend(Config) ->
     end,
     ok.
 
-starttls_suspend(Config) ->
+starttls_no_receiver(Config) ->
     UserSpec = escalus_users:get_userspec(Config, alice),
     Steps = [start_stream, stream_features],
     {ok, Conn, _Features} = escalus_connection:start(UserSpec, Steps),
@@ -331,7 +331,9 @@ starttls_suspend(Config) ->
     [RcvPid] = children_specs_to_pids(rpc(mim(), supervisor, which_children, [ejabberd_receiver_sup])),
     MonRef = erlang:monitor(process, C2sPid),
     ok = rpc(mim(), sys, suspend, [C2sPid]),
-    timer:sleep(100),
+
+    wait_until_c2s_is_suspended(C2sPid),
+
     %% Add starttls element into message queue of the c2s process
     %% There is no reply because the process is suspended
     ?assertThrow({timeout, proceed}, escalus_session:starttls(Conn)),
@@ -350,7 +352,7 @@ starttls_suspend(Config) ->
     end,
     ok.
 
-compress_suspend(Config) ->
+compress_no_receiver(Config) ->
     UserSpec = escalus_users:get_userspec(Config, alice),
     Steps = [start_stream, stream_features],
     {ok, Conn = #client{props = Props}, _Features} = escalus_connection:start(UserSpec, Steps),
@@ -359,7 +361,7 @@ compress_suspend(Config) ->
     [RcvPid] = children_specs_to_pids(rpc(mim(), supervisor, which_children, [ejabberd_receiver_sup])),
     MonRef = erlang:monitor(process, C2sPid),
     ok = rpc(mim(), sys, suspend, [C2sPid]),
-    timer:sleep(100),
+    wait_until_c2s_is_suspended(C2sPid),
     %% Add compress element into message queue of the c2s process
     %% There is no reply because the process is suspended
     ?assertThrow({timeout, compressed},
@@ -664,3 +666,12 @@ pipeline_connect(UserSpec) ->
 
     escalus_connection:send(Conn, [Stream, Auth, AuthStream, Bind, Session]),
     Conn.
+
+wait_until_c2s_is_suspended(C2sPid) ->
+    ok = mongoose_helper:wait_until(fun() -> check_if_c2s_is_suspended(C2sPid) end,
+                                    10, 100).
+
+check_if_c2s_is_suspended(C2sPid) ->
+    {current_function, {M, F, _}} = rpc(mim(), erlang, process_info, [C2sPid, current_function]),
+    {M, F} == {sys, suspend_loop}.
+


### PR DESCRIPTION
The story:
- in `connect_SUITE:starttls_noproc`[0] we setup monitor for c2s process and we catch DOWN's event:
```
{'DOWN', MonRef, process, C2sPid, Reason = {normal,
                                 {gen_server,call,
                                  [<6900.28922.0>,
                                   {starttls,
                                    [verify_none,
                                     {certfile,"priv/ssl/fake_server.pem"},
                                     {tls_module,just_tls},
                                     {protocol_options,"no_sslv3"}]}]}}}}
```
instead of `Reason` being just `normal`.

When you go through some OTP sources [1] [2] you can see that such a `{normal, Reason}` exception will be thrown when gen_server's process exits/crashes in the middle of call.

The major issue is that we suspend [3] the process just before the call [4] so `gen_server:call(Proc, {starttls ... `[5] shouldn't even be triggered - because after suspending process, it won't consume any message except the system's messages. If it went to `starttls` branches means that it consumed some xml-related messages.

Anyway, I believe it might be related to some race conditions between calling `suspend` and starting TLS. 
In this PR I add additional 100 ms sleep after suspending process and want to see if the problem still happens.

BTW I change all `noproc` names to `suspend` cause its not about killing process but suspending

[0] https://github.com/esl/MongooseIM/blob/master/big_tests/tests/connect_SUITE.erl#L345
[1] https://github.com/erlang/otp/blob/9d5af99762b3795c763fb62c1516247bd3f8e12f/lib/stdlib/src/gen_server.erl#L215
[2] https://github.com/erlang/otp/blob/9d5af99762b3795c763fb62c1516247bd3f8e12f/lib/stdlib/src/gen.erl#L177
[3] https://github.com/esl/MongooseIM/blob/master/big_tests/tests/connect_SUITE.erl#L332
[4] https://github.com/esl/MongooseIM/blob/master/big_tests/tests/connect_SUITE.erl#L335
[5] https://github.com/esl/MongooseIM/blob/master/src/ejabberd_receiver.erl#L87