### PR TITLE
stabilise pubsub_SUITE

### DIFF
--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -606,7 +606,7 @@ notify_only_available_users_test(Config) ->
 
               pubsub_tools:subscribe(Bob, Node, [{jid_type, bare}]),
 
-              escalus:send(Bob, escalus_stanza:presence(<<"unavailable">>)),
+              push_helper:become_unavailable(Bob),
 
               %% Item from node 2 not received (blocked by resource-based delivery)
               pubsub_tools:publish(Alice, <<"item2">>, Node, []),
@@ -625,7 +625,7 @@ notify_unavailable_user_test(Config) ->
 
               pubsub_tools:subscribe(Bob, Node, [{jid_type, bare}]),
 
-              escalus:send(Bob, escalus_stanza:presence(<<"unavailable">>)),
+              push_helper:become_unavailable(Bob),
 
               %% Receive item from node 1 (also make sure the presence is processed)
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),


### PR DESCRIPTION
There are tests in `pubsub_SUITE` for sending payload to subscriber if he's online.
The scenario was that user sent `presence unavailable` and just after that item was published. 
When message was routed to user, the session table wasn't refreshed yet and he still seemed to be online. In order to fix it I use `push_helper:become_unavailable/1` that check the session table after sending the presence.
