### PR TITLE
stabilise amp_big_SUITE

### DIFF
--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -285,7 +285,7 @@ notify_deliver_to_online_user_recipient_privacy_test(Config) ->
 
 notify_deliver_to_offline_user_test(Config) ->
     FreshConfig = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
-    escalus:story(
+    escalus_fresh:story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given
@@ -327,14 +327,14 @@ notify_deliver_to_offline_user_recipient_privacy_test(Config) ->
 
 do_notify_deliver_to_offline_user_recipient_privacy_test(Config) ->
     FreshConfig = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
-    escalus:story(
+    escalus:fresh_story(
       FreshConfig, [{bob, 1}],
       fun(Bob) ->
               %% given
               privacy_helper:set_and_activate(Bob, <<"deny_all_message">>),
               privacy_helper:set_default_list(Bob, <<"deny_all_message">>)
       end),
-    escalus:story(
+    escalus:fresh_story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given
@@ -498,7 +498,7 @@ error_deliver_to_offline_user_test(Config) ->
                          _ -> stored
                      end, error},
     Rules = rules(Config, [Rule]),
-    escalus:story(
+    escalus:fresh_story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given
@@ -579,7 +579,7 @@ drop_deliver_to_offline_user_test(Config) ->
                          _ -> stored
                      end, drop},
     Rules = rules(Config, [Rule]),
-    escalus:story(
+    escalus:fresh_story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given
@@ -649,7 +649,7 @@ last_rule_applies_test(Config) ->
 %% Internal
 
 user_has_no_incoming_offline_messages(FreshConfig, UserName) ->
-    escalus:story(
+    escalus:fresh_story(
       FreshConfig, [{UserName, 1}],
       fun(User) ->
               client_receives_nothing(User),

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -14,6 +14,7 @@
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
                              rpc/4]).
+-import(muc_light_helper, [lbin/1]).
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
@@ -328,19 +329,17 @@ notify_deliver_to_offline_user_recipient_privacy_test(Config) ->
 do_notify_deliver_to_offline_user_recipient_privacy_test(Config) ->
     FreshConfig = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:fresh_story(
-      FreshConfig, [{bob, 1}],
-      fun(Bob) ->
-              %% given
+      FreshConfig, [{alice, 1}, {bob, 1}],
+      fun(Alice, Bob) ->
+
               privacy_helper:set_and_activate(Bob, <<"deny_all_message">>),
-              privacy_helper:set_default_list(Bob, <<"deny_all_message">>)
-      end),
-    escalus:fresh_story(
-      FreshConfig, [{alice, 1}],
-      fun(Alice) ->
+              privacy_helper:set_default_list(Bob, <<"deny_all_message">>),
+              mongoose_helper:logout_user(Config, Bob),
               %% given
               Rule = {deliver, none, notify},
               Rules = rules(Config, [Rule]),
-              BobJid = escalus_users:get_jid(FreshConfig, bob),
+              BobJid = lbin(escalus_client:short_jid(Bob)),
+
               Msg = amp_message_to(BobJid, Rules, <<"A message in a bottle...">>),
 
               %% when


### PR DESCRIPTION
There were some remaining `escalus:story` even though the test was intended to run with parallelisation. In this PR I change those to `fresh_story`.
I believe it was the reason of some failing tests due to privacy lists duplication (because one non-parallel test created a list for a user and another non-parallel test did the same for the same user).

