### PR TITLE
Return error if receiver dies after sending a call to it

### DIFF
--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -1,5 +1,5 @@
 %%%----------------------------------------------------------------------
-%%% File    : ejabberd_receiver.erl
+%% File    : ejabberd_receiver.erl
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
 %%% Purpose : Socket receiver for C2S and S2S connections
 %%% Created : 10 Nov 2003 by Alexey Shchepin <alexey@process-one.net>
@@ -424,8 +424,13 @@ free_parser(Parser) ->
 gen_server_call_or_noproc(Pid, Message) ->
     try
         gen_server:call(Pid, Message)
-    catch exit:{noproc, Extra} ->
-        {error, {noproc, Extra}}
+    catch
+        exit:{noproc, Extra} ->
+            {error, {noproc, Extra}};
+        exit:{normal, Extra} ->
+            % reciver exited with normal status after the gen_server call was sent
+            % but before it was processed
+            {error, {died, Extra}}
     end.
 
 gen_fsm() -> p1_fsm.

--- a/src/ejabberd_socket.erl
+++ b/src/ejabberd_socket.erl
@@ -175,8 +175,12 @@ get_tls_socket(#socket_state{receiver = Receiver}) ->
 -spec starttls(socket_state(), list()) -> socket_state().
 starttls(SocketData, TLSOpts) ->
     tcp_to_tls(SocketData, TLSOpts),
-    NewSocket = get_tls_socket(SocketData),
-    SocketData#socket_state{socket = NewSocket, sockmod = ejabberd_tls}.
+    case get_tls_socket(SocketData) of
+        invalid_socket ->
+            exit(invalid_socket_after_upgrade_to_tls);
+        NewSocket ->
+            SocketData#socket_state{socket = NewSocket, sockmod = ejabberd_tls}
+    end.
 
 
 -spec starttls(socket_state(), _, _) -> socket_state().


### PR DESCRIPTION
This PR supersedes #1942.

Based on @ludwikbukowski work it turned out that c2s dies with reason like:
```erlang
{normal,
  {gen_server,call,
   [<6900.28922.0>,
   {starttls,
    [verify_none,
     {certfile,"priv/ssl/fake_server.pem"},
     {tls_module,just_tls},
     {protocol_options,"no_sslv3"}]}]}}}}
```

Because of a race condition around sending gen_server call to the receiver process. It might happen that receiver dies with reason `normal` after the call is sent but before it's processed by the receiver. From C2S perspective this still ok, as `noproc` case (when there is no receiver process when the call is about to be sent) is.

The PR extends receiver's code to handle the above corner case. Having repeatable tests for that is doable but very difficult. In my opinion it's not worth to add a test case for that, at least not at this moment.
