### PR TITLE
fix filesystem permissionproblem with clustering mongeese

### DIFF
--- a/src/mongoose_cluster.erl
+++ b/src/mongoose_cluster.erl
@@ -157,7 +157,6 @@ rmrf(Dir) ->
             ok = file:delete(Dir);
         {ok, Dirs} ->
             [ ok = rmrf(filename:join(Dir, Sub)) || Sub <- Dirs],
-            ok = file:del_dir(Dir),
             ok
     end.
 


### PR DESCRIPTION
MongooseIM in production systems usually has mnesia in something like /var/lib/mongoose, whereby /var/lib is not writable for the user which is running mongooseim. Joining or leaving a cluster requires wiping out mnesia dir, but we don't have to recreate the dir itself; attempt to do so may fail due to lack of permissions.
