### PR TITLE
Catch timeout when stopping clients in bosh_SUITE:interleave_requests

### DIFF
--- a/big_tests/tests/bosh_interleave_reqs.erl
+++ b/big_tests/tests/bosh_interleave_reqs.erl
@@ -57,7 +57,11 @@ ct_config_giver(Config) ->
 
 maybe_stop_client(undefined) -> ok;
 maybe_stop_client(Client) ->
-    escalus_connection:stop(Client).
+    try
+        escalus_connection:stop(Client)
+    catch throw:{timeout, Details} ->
+              ct:pal("There was timeout ~p when stopping ~p", [Details, Client])
+    end.
 
 initial_state(Pid) ->
     #state{carol = undefined,


### PR DESCRIPTION
A fresh user will be used in another try so there is no need to stop testing if one user was slow to stop
