### PR TITLE
Configure codecov to allow small coverage drop

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5
+    patch:
+      default:
+        threshold: 0.5


### PR DESCRIPTION
Our code coverage varies a bit from run to run. There is no point in failing a PR if it coverage dropped a bit (0.1%). The allowed threshold is configurable so we can adjust it if needed.

