### PR TITLE
Muc inbox

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -37,7 +37,9 @@
          no_aff_stored_and_remove_on_kicked/1,
          no_stored_and_remain_after_kicked/1,
          simple_groupchat_stored_in_all_inbox_muc/1,
-        simple_groupchat_stored_in_offline_users_inbox_muc/1
+         simple_groupchat_stored_in_offline_users_inbox_muc/1,
+         unread_count_is_the_same_after_going_online_again/1,
+         unread_count_is_reset_after_sending_chatmarker/1
         ]).
 
 -import(muc_helper, [foreach_occupant/3, foreach_recipient/2]).
@@ -54,6 +56,8 @@
 -define(ROOM_MARKERS, <<"room_markers">>).
 -define(MUC_ROOM, <<"some_muc_room">>).
 -define(MUC_ROOM2, <<"some_muc_room2">>).
+-define(MUC_ROOM3, <<"some_muc_room3">>).
+-define(MUC_ROOM4, <<"some_muc_room4">>).
 -define(MUC_DOMAIN, <<"muc.localhost">>).
 -record(conv, {unread, from, to, content = <<>>, verify = fun(C, Stanza) -> ok end}).
 -record(inbox, {total, convs = []}).
@@ -106,7 +110,9 @@ groups() ->
          {muc, [sequence],
           [
            simple_groupchat_stored_in_all_inbox_muc,
-           simple_groupchat_stored_in_offline_users_inbox_muc
+           simple_groupchat_stored_in_offline_users_inbox_muc,
+           unread_count_is_the_same_after_going_online_again,
+           unread_count_is_reset_after_sending_chatmarker
           ]}
         ].
     %ct_helper:repeat_all_until_all_ok(G).
@@ -176,7 +182,7 @@ end_per_group(muclight, Config) ->
   muc_light_helper:clear_db(),
   Config;
 end_per_group(muc, Config) ->
-    muc_helper:destroy_room(Config);
+    Config;
 end_per_group(_GroupName, Config) ->
   Config.
 
@@ -217,6 +223,17 @@ init_per_testcase(simple_groupchat_stored_in_offline_users_inbox_muc = TC, Confi
   [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
   Config2 = muc_helper:start_room(Config, User, ?MUC_ROOM2, <<"some_friendly_name">>, default),
   escalus:init_per_testcase(TC, Config2);
+init_per_testcase(unread_count_is_the_same_after_going_online_again = TC, Config) ->
+  clear_inbox_all(),
+  [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
+  Config2 = muc_helper:start_room(Config, User, ?MUC_ROOM3, <<"some_friendly_name">>, default),
+  escalus:init_per_testcase(TC, Config2);
+init_per_testcase(unread_count_is_reset_after_sending_chatmarker = TC, Config) ->
+  clear_inbox_all(),
+  [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
+  Config2 = muc_helper:start_room(Config, User, ?MUC_ROOM4, <<"some_friendly_name">>, default),
+  escalus:init_per_testcase(TC, Config2);
+
 init_per_testcase(CaseName, Config) ->
   clear_inbox_all(),
   escalus:init_per_testcase(CaseName, Config).
@@ -249,6 +266,11 @@ end_per_testcase(msg_sent_to_not_existing_user, Config) ->
   Host = ct:get_config({hosts, mim, domain}),
   escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [<<"not_existing_user@localhost">>,Host]),
   escalus:end_per_testcase(msg_sent_to_not_existing_user, Config);
+end_per_testcase(TC, Config) when TC =:= simple_groupchat_stored_in_all_inbox_muc,
+                                  TC =:= simple_groupchat_stored_in_offline_users_inbox_muc,
+                                  TC =:= unread_count_is_the_same_after_going_online_again,
+                                  TC =:= unread_count_is_reset_after_sending_chatmarker ->
+    muc_helper:destroy_room(Config);
 end_per_testcase(CaseName, Config) ->
   clear_inbox_all(),
   escalus:end_per_testcase(CaseName, Config).
@@ -792,7 +814,9 @@ groupchat_markers_all_reset_room_created(Config) ->
     foreach_check_inbox([Bob, Kate, Alice], 1, 0, AliceRoomJid, Msg)
                                                            end).
 
+%%--------------------------------------------------------------------
 %% legacy MUC tests
+%%--------------------------------------------------------------------
 
 simple_groupchat_stored_in_all_inbox_muc(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
@@ -862,10 +886,94 @@ simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
     end).
 
 
+unread_count_is_the_same_after_going_online_again(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+    Users = [Alice, Bob, Kate],
+    Msg = <<"Hi Room!">>,
+    Id = <<"MyID">>,
+    Room = ?config(room, Config),
+    RoomAddr = muc_room_address(Room),
+
+    enter_room(Room, Users),
+    make_members(Room, Alice, Users -- [Alice]),
+    go_offline(Kate, Room, Users),
+    Stanza = escalus_stanza:set_id(
+      escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
+    escalus:send(Bob, Stanza),
+    Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
+              Users -- [Kate]),
+    lists:foreach(fun(Resp) -> escalus:assert(is_groupchat_message, Resp) end,
+                  Resps),
+    enter_room(Room, Kate, Users -- [Kate], 1),
+    [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
+    BobRoomJid = muc_room_address(Room, lbin(nick(Bob))),
+    %% Bob has 0 unread messages
+    check_inbox(Bob, #inbox{
+      total = 1,
+      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
+                     content = Msg}]}),
+    %% Alice and Kate have one conv with 1 unread message
+    check_inbox(Alice, #inbox{
+      total = 1,
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
+    check_inbox(Kate, #inbox{
+      total = 1,
+      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
+    end).
+
+unread_count_is_reset_after_sending_chatmarker(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+    Users = [Alice, Bob, Kate],
+    Msg = <<"Hi Room!">>,
+    Id = <<"MyID">>,
+    Room = ?config(room, Config),
+    RoomAddr = muc_room_address(Room),
+
+    enter_room(Room, Users),
+    make_members(Room, Alice, Users -- [Alice]),
+    Stanza = escalus_stanza:set_id(
+      escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
+    escalus:send(Bob, Stanza),
+    Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
+              Users -- [Kate]),
+    lists:foreach(fun(Resp) -> escalus:assert(is_groupchat_message, Resp) end,
+                  Resps),
+
+    ChatMarker = set_type(escalus_stanza:chat_marker(RoomAddr, <<"displayed">>, Id), <<"groupchat">>),
+    %% User marks last message
+    escalus:send(Kate, ChatMarker),
+
+    [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
+    BobRoomJid = muc_room_address(Room, lbin(nick(Bob))),
+    %% Bob has 0 unread messages
+    check_inbox(Bob, #inbox{
+      total = 1,
+      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
+                     content = Msg}]}),
+    %% Alice have one conv with 1 unread message
+    check_inbox(Alice, #inbox{
+      total = 1,
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
+    %% Kate has 0 unread messages
+    check_inbox(Kate, #inbox{
+      total = 1,
+      convs = [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}]})
+    end).
+
+
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Helpers
 
 go_offline(User, Room, Occupants) ->
+    UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
+    Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
+    escalus:send(User, Stanza),
+    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User), ct:pal("A: ~p", [A]) end,
+                  Occupants).
+
+go_online(User, Room, Occupants) ->
     UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
     Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
     escalus:send(User, Stanza),
@@ -884,6 +992,7 @@ make_members(Room, Admin, Users) ->
     ct:pal("SuccessResp: ~p", [SuccesResp]),
     lists:foreach(fun(User) -> escalus:wait_for_stanzas(User, length(Users)) end, Users). % Everybody gets aff changes of everybody
 
+% All users enter the room
 enter_room(Room, Users) ->
     lists:foreach(fun(User) ->
                           escalus:send(User, stanza_muc_enter_room(Room, nick(User))) end,
@@ -893,6 +1002,15 @@ enter_room(Room, Users) ->
                           ct:pal("For ~p: ~p", [escalus_client:short_jid(User), A])
                   end,
                   Users).
+
+% `User` enters the room `Room` where `Users` are occupants
+enter_room(Room, User, Users, DelayedMessagesCount) ->
+    escalus:send(User, stanza_muc_enter_room(Room, nick(User))),
+    lists:foreach(fun(User) ->
+                          A = escalus:wait_for_stanza(User), ct:pal("~p: Got presence from user: ~p", [escalus_client:short_jid(User), A]) end,
+                  Users),
+    Subj = escalus:wait_for_stanzas(User, length(Users) + 1 + 1 + DelayedMessagesCount), % User gets subject message and presences from everybody including himself
+    ct:pal("Subj and presence messages: ~p", [Subj]).
 
 
 stanza_set_affiliations(Room, List) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -179,8 +179,6 @@ init_per_group(_GroupName, Config) ->
 end_per_group(muclight, Config) ->
   muc_light_helper:clear_db(),
   Config;
-end_per_group(muc, Config) ->
-    Config;
 end_per_group(_GroupName, Config) ->
   Config.
 

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -846,7 +846,7 @@ simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
 
     enter_room(Room, Users),
     make_members(Room, Alice, Users -- [Alice]),
-    go_offline(Kate, Room, Users),
+    leave_room(Kate, Room, Users),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
@@ -879,7 +879,7 @@ unread_count_is_the_same_after_going_online_again(Config) ->
 
     enter_room(Room, Users),
     make_members(Room, Alice, Users -- [Alice]),
-    go_offline(Kate, Room, Users),
+    leave_room(Kate, Room, Users),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
@@ -976,7 +976,7 @@ private_messages_are_handled_as_one2one(Config) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Helpers
 
-go_offline(User, Room, Occupants) ->
+leave_room(User, Room, Occupants) ->
     UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
     Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
     escalus:send(User, Stanza),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1159,7 +1159,7 @@ create_room_send_msg_check_inbox(Owner, MemberList, RoomName, Msg, Id) ->
   foreach_check_inbox(MemberList, 1, 1, OwnerRoomJid, Msg).
 
 
-% Checks case insesitive
+% Checks case insensitive
 foreach_check_inbox(Users, Total, Unread, SenderJid, Msg) ->
   [begin
      UserJid = lbin(escalus_client:short_jid(U)),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -446,6 +446,7 @@ simple_groupchat_stored_in_all_inbox(Config) ->
     escalus:assert(is_groupchat_message, R0),
     escalus:assert(is_groupchat_message, R1),
     escalus:assert(is_groupchat_message, R2),
+    {ok, [X]} = io:fread("input number: ", "~d"),
     %% Alice has 0 unread messages
     check_inbox(Alice, #inbox{
       total = 1,
@@ -800,10 +801,11 @@ simple_groupchat_stored_in_all_inbox_muc(Config) ->
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
-    Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
-              Users),
-    lists:foreach(fun(Resp) -> escalus:assert(is_groupchat_message, Resp) end,
-                  Resps),
+%    Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
+%              Users),
+%    lists:foreach(fun(Resp) -> escalus:assert(is_groupchat_message, Resp) end,
+%                  Resps),
+    {ok, [X]} = io:fread("input number: ", "~d"),
     [AliceJid, BobJid, KateJid] = lists:map(fun(User) -> escalus_client:full_jid(User) end, Users),
     AliceRoomJid = muc_room_address(Room, nick(Alice)),
     %% Alice has 0 unread messages

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -980,14 +980,14 @@ go_offline(User, Room, Occupants) ->
     UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
     Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
     escalus:send(User, Stanza),
-    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User), ct:pal("A: ~p", [A]) end,
+    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User) end,
                   Occupants).
 
 go_online(User, Room, Occupants) ->
     UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
     Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
     escalus:send(User, Stanza),
-    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User), ct:pal("A: ~p", [A]) end,
+    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User) end,
                   Occupants).
 
 wait_for_groupchat_msg(Users) ->
@@ -1013,8 +1013,7 @@ enter_room(Room, Users) ->
                           escalus:send(User, stanza_muc_enter_room(Room, nick(User))) end,
                   Users),
     lists:foreach(fun(User) ->
-                          A = escalus:wait_for_stanzas(User, length(Users) + 1), % everybody gets presence from everybody + a subject message
-                          ct:pal("For ~p: ~p", [escalus_client:short_jid(User), A])
+                          escalus:wait_for_stanzas(User, length(Users) + 1) % everybody gets presence from everybody + a subject message
                   end,
                   Users).
 
@@ -1022,10 +1021,9 @@ enter_room(Room, Users) ->
 enter_room(Room, User, Users, DelayedMessagesCount) ->
     escalus:send(User, stanza_muc_enter_room(Room, nick(User))),
     lists:foreach(fun(User) ->
-                          A = escalus:wait_for_stanza(User), ct:pal("~p: Got presence from user: ~p", [escalus_client:short_jid(User), A]) end,
+                          A = escalus:wait_for_stanza(User) end,
                   Users),
-    Subj = escalus:wait_for_stanzas(User, length(Users) + 1 + 1 + DelayedMessagesCount), % User gets subject message and presences from everybody including himself
-    ct:pal("Subj and presence messages: ~p", [Subj]).
+    escalus:wait_for_stanzas(User, length(Users) + 1 + 1 + DelayedMessagesCount). % User gets subject message and presences from everybody including himself
 
 
 stanza_set_affiliations(Room, List) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -844,17 +844,17 @@ simple_groupchat_stored_in_all_inbox_muc(Config) ->
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
     BobRoomJid = muc_room_address(Room, nick(Bob)), % removed lbin !!!
     %% Bob has 0 unread messages
-    check_inbox_casesensitive(Bob, #inbox{
+    check_inbox(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}),
+                     content = Msg}]}, #{case_sensitive => true}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox_casesensitive(Alice, #inbox{
+    check_inbox(Alice, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox_casesensitive(Kate, #inbox{
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
+      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
     end).
 
 simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
@@ -876,17 +876,17 @@ simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
     BobRoomJid = muc_room_address(Room, nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox_casesensitive(Bob, #inbox{
+    check_inbox(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}),
+                     content = Msg}]}, #{case_sensitive => true}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox_casesensitive(Alice, #inbox{
+    check_inbox(Alice, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox_casesensitive(Kate, #inbox{
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
+      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
     end).
 
 
@@ -909,17 +909,17 @@ unread_count_is_the_same_after_going_online_again(Config) ->
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
     BobRoomJid = muc_room_address(Room, nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox_casesensitive(Bob, #inbox{
+    check_inbox(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}),
+                     content = Msg}]}, #{case_sensitive => true}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox_casesensitive(Alice, #inbox{
+    check_inbox(Alice, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox_casesensitive(Kate, #inbox{
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
+      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
     end).
 
 unread_count_is_reset_after_sending_chatmarker(Config) ->
@@ -944,18 +944,18 @@ unread_count_is_reset_after_sending_chatmarker(Config) ->
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
     BobRoomJid = muc_room_address(Room, nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox_casesensitive(Bob, #inbox{
+    check_inbox(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}),
+                     content = Msg}]}, #{case_sensitive => true}),
     %% Alice have one conv with 1 unread message
-    check_inbox_casesensitive(Alice, #inbox{
+    check_inbox(Alice, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
     %% Kate has 0 unread messages
-    check_inbox_casesensitive(Kate, #inbox{
+    check_inbox(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}]})
+      convs = [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
     end).
 
 private_messages_are_(Config) ->
@@ -977,18 +977,18 @@ private_messages_are_(Config) ->
 
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
     %% Bob has 1 unread message
-    check_inbox_casesensitive(Bob, #inbox{
+    check_inbox(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = KateRoomJid, to = BobRoomJid,
-                     content = Msg}]}),
+                     content = Msg}]}, #{case_sensitive => true}),
     %% Alice gets nothing
-    check_inbox_casesensitive(Alice, #inbox{
+    check_inbox(Alice, #inbox{
       total = 0,
-      convs = []}),
+      convs = []}, #{case_sensitive => true}),
     %% Kate has 1 conv with 0 unread messages
-    check_inbox_casesensitive(Kate, #inbox{
+    check_inbox(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 0, from = KateJid, to = BobRoomJid, content = Msg}]})
+      convs = [#conv{unread = 0, from = KateJid, to = BobRoomJid, content = Msg}]}, #{case_sensitive => true})
     end).
 
 
@@ -1200,23 +1200,32 @@ create_room_send_msg_check_inbox(Owner, MemberList, RoomName, Msg, Id) ->
 foreach_check_inbox(Users, Total, Unread, SenderJid, Msg) ->
   [begin
      UserJid = lbin(escalus_client:short_jid(U)),
-     check_inbox(U, Total, [#conv{unread = Unread, from = SenderJid,  to = UserJid, content = Msg}], false)
+     check_inbox(U, #inbox{total = Total, convs = [#conv{unread = Unread, from = SenderJid, to = UserJid, content = Msg}]})
     end || U <- Users].
 
-check_inbox_casesensitive(Client, Inbox) ->
-    check_inbox(Client, Inbox, true).
-
 check_inbox(Client, Inbox) ->
-    check_inbox(Client, Inbox, false).
+    check_inbox(Client, Inbox, #{}).
 
-check_inbox(Client, #inbox{total = Total, convs = Convs}, IsCaseSensitive) ->
-  check_inbox(Client, integer_to_binary(Total), Convs, IsCaseSensitive).
+% @doc Opts are:
+%       * case_sensitive - should resource be checked case
+%                          sensitively
+%       * check_resource - should resource 
+check_inbox(Client, #inbox{total = Total, convs = Convs}, Opts0) -> 
+  Opts = fill_options(Opts0),
+  check_inbox(Client, integer_to_binary(Total), Convs, Opts).
+
+
+fill_options(Opts) ->
+    #{case_sensitive => maps:get(case_sensitive, Opts, false),
+      check_resource => maps:get(check_resource, Opts, true)}.
 
 
 
-check_inbox(Client, ExpectedCount, MsgCheckList, IsCaseSensitive) when is_binary(ExpectedCount) ->
-  check_inbox(Client, binary_to_integer(ExpectedCount), MsgCheckList, IsCaseSensitive);
-check_inbox(Client, ExpectedCount, MsgCheckList, IsCaseSensitive) ->
+% This should be only called by some wrapper
+%
+check_inbox(Client, ExpectedCount, MsgCheckList, Opts) when is_binary(ExpectedCount) ->
+  check_inbox(Client, binary_to_integer(ExpectedCount), MsgCheckList, Opts);
+check_inbox(Client, ExpectedCount, MsgCheckList, Opts) ->
   GetInbox = get_inbox_stanza(),
   escalus:send(Client, GetInbox),
   Stanzas = escalus:wait_for_stanzas(Client, ExpectedCount),
@@ -1225,57 +1234,56 @@ check_inbox(Client, ExpectedCount, MsgCheckList, IsCaseSensitive) ->
   %% TODO: Replace with commented code when inbox starts sorting by timestamp by default
   %% Merged = lists:zip(Stanzas, MsgCheckList),
   %% [process_inbox_message(Client, M, ConvCheck) || {M, ConvCheck} <- Merged].
-  process_inbox_messages(Client, Stanzas, MsgCheckList, [], IsCaseSensitive).
+  process_inbox_messages(Client, Stanzas, MsgCheckList, [], Opts).
 
 process_inbox_messages(Client, [], [], [], _) ->
     ok;
-process_inbox_messages(Client, [], UnmatchedConvs, UnmatchedItems, IsCaseSensitive) ->
+process_inbox_messages(Client, [], UnmatchedConvs, UnmatchedItems, #{case_sensitive := IsCaseSensitive, check_resource := CheckResource}) ->
     ct:fail(#{ reason => inbox_mismatch,
                unmatched_convs => UnmatchedConvs,
                unmatched_result_items => UnmatchedItems,
+               resources_match_checked => CheckResource,
                jids_checked_casesesitive => IsCaseSensitive});
-process_inbox_messages(Client, [Stanza | RStanzas], MsgCheckList, UnmatchedItems, IsCaseSensitive) ->
-    Pred = fun(Conv) -> (catch process_inbox_message(Client, Stanza, Conv, IsCaseSensitive)) == ok end,
+process_inbox_messages(Client, [Stanza | RStanzas], MsgCheckList, UnmatchedItems, Opts) ->
+    Pred = fun(Conv) -> (catch process_inbox_message(Client, Stanza, Conv, Opts)) == ok end,
     case lists:partition(Pred, MsgCheckList) of
         {[], _NoConvSatisfiedPred} ->
-            process_inbox_messages(Client, RStanzas, MsgCheckList, [Stanza | UnmatchedItems], IsCaseSensitive);
+            process_inbox_messages(Client, RStanzas, MsgCheckList, [Stanza | UnmatchedItems], Opts);
         {[_MatchedConv], RConvs} ->
-            process_inbox_messages(Client, RStanzas, RConvs, UnmatchedItems, IsCaseSensitive)
+            process_inbox_messages(Client, RStanzas, RConvs, UnmatchedItems, Opts)
     end.
 
-process_inbox_message(Client, Stanza, Conv, IsCaseSensitive) ->
-    case IsCaseSensitive of
-        true -> process_inbox_message_casesensitive(Client, Stanza, Conv);
-        false -> process_inbox_message(Client, Stanza, Conv)
-    end.
+process_inbox_message(Client, Stanza, Conv, 
+                      #{case_sensitive := IsCaseSensitive, check_resource := CheckResource}) ->
+    do_process_inbox_message(Client, Stanza, Conv, check_jid_fun(IsCaseSensitive, CheckResource)).
 
-process_inbox_message(Client, Message, #conv{unread = Unread, from = FromJid,
-                                             to = ToJid, content = Content, verify = Fun}) ->
+check_jid_fun(true, true) ->
+    fun(InnerMsg, Expected, El) -> Expected = exml_query:attr(InnerMsg, El) end;
+check_jid_fun(false, true) ->
+    fun(InnerMsg, Expected, El) -> Expected = lbin(exml_query:attr(InnerMsg, El)) end;
+check_jid_fun(true, false) ->
+    fun(InnerMsg, Expected, El) ->
+            NoResExpected = escalus_client:short_jid(Expected),
+            NoResExpected = exml_query:attr(InnerMsg, El) end;
+check_jid_fun(false, false) ->
+    fun(InnerMsg, Expected, El) ->
+            NoResExpected = escalus_client:short_jid(Expected),
+            NoResExpected = lbin(exml_query:attr(InnerMsg, El)) end.
+
+
+
+do_process_inbox_message(Client, Message, #conv{unread = Unread, from = FromJid,
+                                             to = ToJid, content = Content, verify = Fun}, CheckJidFun) ->
   Unread = get_unread_count(Message),
   escalus:assert(is_message, Message),
   Unread = get_unread_count(Message),
   [InnerMsg] = get_inner_msg(Message),
-  FromJid = lbin(exml_query:attr(InnerMsg, <<"from">>)),
-  ToJid = lbin(exml_query:attr(InnerMsg, <<"to">>)),
+  CheckJidFun(InnerMsg, FromJid, <<"from">>),
+  CheckJidFun(InnerMsg, ToJid, <<"to">>),
   InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], []),
   Content = InnerContent,
   Fun(Client, InnerMsg),
   ok.
-
-% TODO refactor
-process_inbox_message_casesensitive(Client, Message, #conv{unread = Unread, from = FromJid,
-                                             to = ToJid, content = Content, verify = Fun}) ->
-  Unread = get_unread_count(Message),
-  escalus:assert(is_message, Message),
-  Unread = get_unread_count(Message),
-  [InnerMsg] = get_inner_msg(Message),
-  FromJid = exml_query:attr(InnerMsg, <<"from">>),
-  ToJid = exml_query:attr(InnerMsg, <<"to">>),
-  InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], []),
-  Content = InnerContent,
-  Fun(Client, InnerMsg),
-  ok.
-
 
 
 verify_is_owner_aff_change(Client, Msg) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -146,6 +146,10 @@ muclight_domain() ->
   Domain = domain(),
   <<"muclight.", Domain/binary>>.
 
+muc_domain() ->
+    Domain = domain(),
+    <<"muc.", Domain/binary>>.
+
 end_per_suite(Config) ->
   Host = ct:get_config({hosts, mim, domain}),
   Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
@@ -160,7 +164,7 @@ init_per_group(muclight, Config) ->
   reload_inbox_option(Config, groupchat, [muclight]),
   create_room(?ROOM, muclight_domain(), alice, [bob, kate], Config, ver(1));
 init_per_group(muc, Config) ->
-  muc_helper:load_muc(?MUC_DOMAIN),
+  muc_helper:load_muc(muc_domain()),
   reload_inbox_option(Config, groupchat, [muc]),
   [User | _] = ?config(escalus_users, Config),
   muc_helper:start_room(Config, User, ?MUC_ROOM, <<"some_friendly_name">>, default);
@@ -804,7 +808,7 @@ simple_groupchat_stored_in_all_inbox_muc(Config) ->
     %% Alice has 0 unread messages
     check_inbox(Alice, #inbox{
       total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, 
+      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid,
                      content = <<"Msg">>}]}),
     %% Bob and Kate have one conv with 1 unread message
     check_inbox(Bob, #inbox{

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -987,13 +987,15 @@ reload_inbox_option(Config, KeyValueList) ->
     Args2 = lists:foldl(fun({K, V}, AccIn) ->
         lists:keyreplace(K, 1, AccIn, {K, V})
                 end, Args, KeyValueList),
-    dynamic_modules:restart(Host, mod_inbox, Args2).
+    dynamic_modules:restart(Host, mod_inbox, Args2),
+    lists:keyreplace(inbox_opts, 1, Config, {inbox_opts, Args2}).
 
 reload_inbox_option(Config, Key, Value) ->
   Host = domain(),
   Args = proplists:get_value(inbox_opts, Config),
   Args1 = lists:keyreplace(Key, 1, Args, {Key, Value}),
-  dynamic_modules:restart(Host, mod_inbox, Args1).
+  dynamic_modules:restart(Host, mod_inbox, Args1),
+  lists:keyreplace(inbox_opts, 1, Config, {inbox_opts, Args1}).
 
 restore_inbox_option(Config) ->
   Host = domain(),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -215,7 +215,6 @@ init_per_testcase(TC, Config)
        TC =:= unread_count_is_the_same_after_going_online_again;
        TC =:= unread_count_is_reset_after_sending_chatmarker;
        TC =:= private_messages_are_handled_as_one2one ->
-    ct:pal("In !!!", []),
     clear_inbox_all(),
     [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
     Config2 = muc_helper:start_room(Config, User, muc_helper:fresh_room_name(), <<"some_friendly_name">>, default),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -842,17 +842,17 @@ simple_groupchat_stored_in_all_inbox_muc(Config) ->
     escalus:send(Bob, Stanza),
     wait_for_groupchat_msg(Users),
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, lbin(nick(Bob))), % removed lbin !!!
+    BobRoomJid = muc_room_address(Room, nick(Bob)), % removed lbin !!!
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
+    check_inbox_casesensitive(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
                      content = Msg}]}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
+    check_inbox_casesensitive(Alice, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
+    check_inbox_casesensitive(Kate, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
     end).
@@ -874,17 +874,17 @@ simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
     wait_for_groupchat_msg(Users -- [Kate]),
 
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, lbin(nick(Bob))),
+    BobRoomJid = muc_room_address(Room, nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
+    check_inbox_casesensitive(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
                      content = Msg}]}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
+    check_inbox_casesensitive(Alice, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
+    check_inbox_casesensitive(Kate, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
     end).
@@ -907,17 +907,17 @@ unread_count_is_the_same_after_going_online_again(Config) ->
     wait_for_groupchat_msg(Users -- [Kate]),
     enter_room(Room, Kate, Users -- [Kate], 1),
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, lbin(nick(Bob))),
+    BobRoomJid = muc_room_address(Room, nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
+    check_inbox_casesensitive(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
                      content = Msg}]}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
+    check_inbox_casesensitive(Alice, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
+    check_inbox_casesensitive(Kate, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
     end).
@@ -942,18 +942,18 @@ unread_count_is_reset_after_sending_chatmarker(Config) ->
     wait_for_groupchat_msg(Users),
 
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, lbin(nick(Bob))),
+    BobRoomJid = muc_room_address(Room, nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
+    check_inbox_casesensitive(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
                      content = Msg}]}),
     %% Alice have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
+    check_inbox_casesensitive(Alice, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
     %% Kate has 0 unread messages
-    check_inbox(Kate, #inbox{
+    check_inbox_casesensitive(Kate, #inbox{
       total = 1,
       convs = [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}]})
     end).
@@ -977,18 +977,18 @@ private_messages_are_(Config) ->
 
     [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
     %% Bob has 1 unread message
-    check_inbox(Bob, #inbox{
+    check_inbox_casesensitive(Bob, #inbox{
       total = 1,
       convs = [#conv{unread = 1, from = KateRoomJid, to = BobRoomJid,
                      content = Msg}]}),
     %% Alice gets nothing
-    check_inbox(Alice, #inbox{
-      total = 1,
+    check_inbox_casesensitive(Alice, #inbox{
+      total = 0,
       convs = []}),
     %% Kate has 1 conv with 0 unread messages
-    check_inbox(Kate, #inbox{
+    check_inbox_casesensitive(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 0, from = KateRoomJid, to = BobRoomJid, content = Msg}]})
+      convs = [#conv{unread = 0, from = KateJid, to = BobRoomJid, content = Msg}]})
     end).
 
 
@@ -1196,18 +1196,27 @@ create_room_send_msg_check_inbox(Owner, MemberList, RoomName, Msg, Id) ->
   foreach_check_inbox(MemberList, 1, 1, OwnerRoomJid, Msg).
 
 
+% Checks case insesitive
 foreach_check_inbox(Users, Total, Unread, SenderJid, Msg) ->
   [begin
      UserJid = lbin(escalus_client:short_jid(U)),
-     check_inbox(U, Total, [#conv{unread = Unread, from = SenderJid,  to = UserJid, content = Msg}])
+     check_inbox(U, Total, [#conv{unread = Unread, from = SenderJid,  to = UserJid, content = Msg}], false)
     end || U <- Users].
 
-check_inbox(Client, #inbox{total = Total, convs = Convs}) ->
-  check_inbox(Client, integer_to_binary(Total), Convs).
+check_inbox_casesensitive(Client, Inbox) ->
+    check_inbox(Client, Inbox, true).
 
-check_inbox(Client, ExpectedCount, MsgCheckList) when is_binary(ExpectedCount) ->
-  check_inbox(Client, binary_to_integer(ExpectedCount), MsgCheckList);
-check_inbox(Client, ExpectedCount, MsgCheckList) ->
+check_inbox(Client, Inbox) ->
+    check_inbox(Client, Inbox, false).
+
+check_inbox(Client, #inbox{total = Total, convs = Convs}, IsCaseSensitive) ->
+  check_inbox(Client, integer_to_binary(Total), Convs, IsCaseSensitive).
+
+
+
+check_inbox(Client, ExpectedCount, MsgCheckList, IsCaseSensitive) when is_binary(ExpectedCount) ->
+  check_inbox(Client, binary_to_integer(ExpectedCount), MsgCheckList, IsCaseSensitive);
+check_inbox(Client, ExpectedCount, MsgCheckList, IsCaseSensitive) ->
   GetInbox = get_inbox_stanza(),
   escalus:send(Client, GetInbox),
   Stanzas = escalus:wait_for_stanzas(Client, ExpectedCount),
@@ -1216,21 +1225,28 @@ check_inbox(Client, ExpectedCount, MsgCheckList) ->
   %% TODO: Replace with commented code when inbox starts sorting by timestamp by default
   %% Merged = lists:zip(Stanzas, MsgCheckList),
   %% [process_inbox_message(Client, M, ConvCheck) || {M, ConvCheck} <- Merged].
-  process_inbox_messages(Client, Stanzas, MsgCheckList, []).
+  process_inbox_messages(Client, Stanzas, MsgCheckList, [], IsCaseSensitive).
 
-process_inbox_messages(Client, [], [], []) ->
+process_inbox_messages(Client, [], [], [], _) ->
     ok;
-process_inbox_messages(Client, [], UnmatchedConvs, UnmatchedItems) ->
+process_inbox_messages(Client, [], UnmatchedConvs, UnmatchedItems, IsCaseSensitive) ->
     ct:fail(#{ reason => inbox_mismatch,
                unmatched_convs => UnmatchedConvs,
-               unmatched_result_items => UnmatchedItems });
-process_inbox_messages(Client, [Stanza | RStanzas], MsgCheckList, UnmatchedItems) ->
-    Pred = fun(Conv) -> (catch process_inbox_message(Client, Stanza, Conv)) == ok end,
+               unmatched_result_items => UnmatchedItems,
+               jids_checked_casesesitive => IsCaseSensitive});
+process_inbox_messages(Client, [Stanza | RStanzas], MsgCheckList, UnmatchedItems, IsCaseSensitive) ->
+    Pred = fun(Conv) -> (catch process_inbox_message(Client, Stanza, Conv, IsCaseSensitive)) == ok end,
     case lists:partition(Pred, MsgCheckList) of
         {[], _NoConvSatisfiedPred} ->
-            process_inbox_messages(Client, RStanzas, MsgCheckList, [Stanza | UnmatchedItems]);
+            process_inbox_messages(Client, RStanzas, MsgCheckList, [Stanza | UnmatchedItems], IsCaseSensitive);
         {[_MatchedConv], RConvs} ->
-            process_inbox_messages(Client, RStanzas, RConvs, UnmatchedItems)
+            process_inbox_messages(Client, RStanzas, RConvs, UnmatchedItems, IsCaseSensitive)
+    end.
+
+process_inbox_message(Client, Stanza, Conv, IsCaseSensitive) ->
+    case IsCaseSensitive of
+        true -> process_inbox_message_casesensitive(Client, Stanza, Conv);
+        false -> process_inbox_message(Client, Stanza, Conv)
     end.
 
 process_inbox_message(Client, Message, #conv{unread = Unread, from = FromJid,
@@ -1245,6 +1261,22 @@ process_inbox_message(Client, Message, #conv{unread = Unread, from = FromJid,
   Content = InnerContent,
   Fun(Client, InnerMsg),
   ok.
+
+% TODO refactor
+process_inbox_message_casesensitive(Client, Message, #conv{unread = Unread, from = FromJid,
+                                             to = ToJid, content = Content, verify = Fun}) ->
+  Unread = get_unread_count(Message),
+  escalus:assert(is_message, Message),
+  Unread = get_unread_count(Message),
+  [InnerMsg] = get_inner_msg(Message),
+  FromJid = exml_query:attr(InnerMsg, <<"from">>),
+  ToJid = exml_query:attr(InnerMsg, <<"to">>),
+  InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], []),
+  Content = InnerContent,
+  Fun(Client, InnerMsg),
+  ok.
+
+
 
 verify_is_owner_aff_change(Client, Msg) ->
   verify_muc_light_aff_msg(Msg, [{Client,  owner}]).

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -786,6 +786,7 @@ groupchat_markers_all_reset_room_created(Config) ->
 
 simple_groupchat_stored_in_all_inbox_muc(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+    ct:pal("Bob: ~p", [Bob]),
     Users = [Alice, Bob, Kate],
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
@@ -807,19 +808,19 @@ simple_groupchat_stored_in_all_inbox_muc(Config) ->
 %                  Resps),
     {ok, [X]} = io:fread("input number: ", "~d"),
     [AliceJid, BobJid, KateJid] = lists:map(fun(User) -> escalus_client:full_jid(User) end, Users),
-    AliceRoomJid = muc_room_address(Room, nick(Alice)),
-    %% Alice has 0 unread messages
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid,
-                     content = <<"Msg">>}]}),
-    %% Bob and Kate have one conv with 1 unread message
+    BobRoomJid = muc_room_address(Room, nick(Bob)),
+    %% Bob has 0 unread messages
     check_inbox(Bob, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]}),
+      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
+                     content = Msg}]}),
+    %% Alice and Kate have one conv with 1 unread message
+    check_inbox(Alice, #inbox{
+      total = 1,
+      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}),
     check_inbox(Kate, #inbox{
       total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]})
+      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]})
     end).
 
 

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1020,19 +1020,19 @@ enter_room(Room, User, Users, DelayedMessagesCount) ->
 
 
 stanza_set_affiliations(Room, List) ->
-    Payload = lists:map(fun({JID, Affiliation}) ->
-        #xmlel{name = <<"item">>,
+    Payload = lists:map(fun aff_to_iq_item/1, List),
+    muc_helper:stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
+
+aff_to_iq_item({JID, Affiliation}) ->
+    #xmlel{name = <<"item">>,
         attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}]};
-    ({JID, Affiliation, Reason}) ->
-        #xmlel{name = <<"item">>,
+aff_to_iq_item({JID, Affiliation, Reason}) ->
+    #xmlel{name = <<"item">>,
         attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}],
         children = [#xmlel{
             name = <<"reason">>,
             children = [#xmlcdata{content = Reason}]}
-        ]}
-    end, List),
-    muc_helper:stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
-
+        ]}.
 
 nick(User) -> escalus_utils:get_username(User).
 

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -112,8 +112,8 @@ groups() ->
            unread_count_is_reset_after_sending_chatmarker,
            private_messages_are_handled_as_one2one
           ]}
-        ].
-    %ct_helper:repeat_all_until_all_ok(G).
+        ],
+    ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
   escalus:suite().

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -216,8 +216,10 @@ init_per_testcase(TC, Config)
        TC =:= unread_count_is_reset_after_sending_chatmarker;
        TC =:= private_messages_are_handled_as_one2one ->
     clear_inbox_all(),
-    [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
-    Config2 = muc_helper:start_room(Config, User, muc_helper:fresh_room_name(), <<"some_friendly_name">>, default),
+    Users = ?config(escalus_users, Config),
+    Alice = lists:keyfind(alice, 1, Users),
+    Config2 = muc_helper:start_room(Config, Alice, 
+                                    muc_helper:fresh_room_name(), <<"some_friendly_name">>, default),
     escalus:init_per_testcase(TC, Config2);
 init_per_testcase(CaseName, Config) ->
   clear_inbox_all(),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1025,14 +1025,7 @@ stanza_set_affiliations(Room, List) ->
 
 aff_to_iq_item({JID, Affiliation}) ->
     #xmlel{name = <<"item">>,
-        attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}]};
-aff_to_iq_item({JID, Affiliation, Reason}) ->
-    #xmlel{name = <<"item">>,
-        attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}],
-        children = [#xmlel{
-            name = <<"reason">>,
-            children = [#xmlcdata{content = Reason}]}
-        ]}.
+        attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}]}.
 
 nick(User) -> escalus_utils:get_username(User).
 

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1200,8 +1200,6 @@ fill_options(Opts) ->
 
 
 
-% This should be only called by some wrapper
-%
 check_inbox(Client, ExpectedCount, MsgCheckList, Opts) when is_binary(ExpectedCount) ->
   check_inbox(Client, binary_to_integer(ExpectedCount), MsgCheckList, Opts);
 check_inbox(Client, ExpectedCount, MsgCheckList, Opts) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -40,7 +40,7 @@
          simple_groupchat_stored_in_offline_users_inbox_muc/1,
          unread_count_is_the_same_after_going_online_again/1,
          unread_count_is_reset_after_sending_chatmarker/1,
-         private_messages_are_/1
+         private_messages_are_handled_as_one2one/1
         ]).
 
 -import(muc_helper, [foreach_occupant/3, foreach_recipient/2]).
@@ -115,7 +115,7 @@ groups() ->
            simple_groupchat_stored_in_offline_users_inbox_muc,
            unread_count_is_the_same_after_going_online_again,
            unread_count_is_reset_after_sending_chatmarker,
-           private_messages_are_
+           private_messages_are_handled_as_one2one
           ]}
         ].
     %ct_helper:repeat_all_until_all_ok(G).
@@ -236,7 +236,7 @@ init_per_testcase(unread_count_is_reset_after_sending_chatmarker = TC, Config) -
   [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
   Config2 = muc_helper:start_room(Config, User, ?MUC_ROOM4, <<"some_friendly_name">>, default),
   escalus:init_per_testcase(TC, Config2);
-init_per_testcase(private_messages_are_ = TC, Config) ->
+init_per_testcase(private_messages_are_handled_as_one2one = TC, Config) ->
   clear_inbox_all(),
   [User | _] = ?config(escalus_users, Config), % probably change this line as it should always take Alice to create the room
   Config2 = muc_helper:start_room(Config, User, ?MUC_ROOM5, <<"some_friendly_name">>, default),
@@ -278,7 +278,7 @@ end_per_testcase(TC, Config) when TC =:= simple_groupchat_stored_in_all_inbox_mu
                                   TC =:= simple_groupchat_stored_in_offline_users_inbox_muc,
                                   TC =:= unread_count_is_the_same_after_going_online_again,
                                   TC =:= unread_count_is_reset_after_sending_chatmarker,
-                                  TC =:= private_messages_are_ ->
+                                  TC =:= private_messages_are_handled_as_one2one ->
     muc_helper:destroy_room(Config);
 end_per_testcase(CaseName, Config) ->
   clear_inbox_all(),
@@ -958,7 +958,7 @@ unread_count_is_reset_after_sending_chatmarker(Config) ->
       convs = [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
     end).
 
-private_messages_are_(Config) ->
+private_messages_are_handled_as_one2one(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     Users = [Alice, Bob, Kate],
     Msg = <<"Hi Room!">>,

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -983,13 +983,6 @@ leave_room(User, Room, Occupants) ->
     lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User) end,
                   Occupants).
 
-go_online(User, Room, Occupants) ->
-    UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
-    Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
-    escalus:send(User, Stanza),
-    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User) end,
-                  Occupants).
-
 wait_for_groupchat_msg(Users) ->
     Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
               Users),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1005,7 +1005,6 @@ make_members(Room, Admin, Users) ->
                       Users),
     escalus:send(Admin, stanza_set_affiliations(Room, Items)),
     SuccesResp = escalus:wait_for_stanzas(Admin, 1 + length(Users)), % gets iq result and affs changes from all users
-    ct:pal("SuccessResp: ~p", [SuccesResp]),
     lists:foreach(fun(User) -> escalus:wait_for_stanzas(User, length(Users)) end, Users). % Everybody gets aff changes of everybody
 
 % All users enter the room

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -10,8 +10,7 @@ To use it, enable mod_inbox in the config file.
 This works when [Chat Markers](https://xmpp.org/extensions/xep-0333.html) are enabled on the client side.
 Possible values are from the set: `displayed`, `received`, `acknowledged`. Setting as empty list (not recommended) means that no chat marker can decrease the counter value.
 * **groupchat** (list, default: `[muclight]`) - The list indicating which groupchats will be included in inbox.
-Possible value is `muclight` [Multi-User Chat Light](https://xmpp.org/extensions/inbox/muc-light.html).
-Soon the classic [Multi-User Chat](https://xmpp.org/extensions/xep-0045.html) will be supported.
+Possible values are `muclight` [Multi-User Chat Light](https://xmpp.org/extensions/inbox/muc-light.html) or `muc` [Multi-User Chat](https://xmpp.org/extensions/xep-0045.html).
 * **aff_changes** (boolean, default: `true`) - use this option when `muclight` is enabled.
 Indicates if MUC Light affiliation change messages should be included in the conversation inbox.
 Only changes that affect the user directly will be stored in their inbox.

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -29,7 +29,7 @@ Inbox currently supports the following DBs:
 
 
 ### Legacy MUC support
-Inbox comes with support for legacy MUC as well. It stores all groupchat messages sent to
+Inbox comes with support for the legacy MUC as well. It stores all groupchat messages sent to
 room in each sender's and recipient's inboxes and private messages. Currently it is not possible to
 configure it to store system messages like [subject](https://xmpp.org/extensions/xep-0045.html#enter-subject) 
 or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -27,6 +27,13 @@ Inbox currently supports the following DBs:
 * PgSQL via native driver
 * MSSQL via ODBC driver
 
+
+### Legacy MUC support
+Inbox comes with a support for legacy MUC as well. It stores all groupchat messages sent to
+room in each sender's and recipient's inboxes and private messages. Currently it is not possible to
+configure it to store system messages like [subject](https://xmpp.org/extensions/xep-0045.html#enter-subject) 
+or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.
+
 ### Example Request
 
 ```

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -29,7 +29,7 @@ Inbox currently supports the following DBs:
 
 
 ### Legacy MUC support
-Inbox comes with a support for legacy MUC as well. It stores all groupchat messages sent to
+Inbox comes with support for legacy MUC as well. It stores all groupchat messages sent to
 room in each sender's and recipient's inboxes and private messages. Currently it is not possible to
 configure it to store system messages like [subject](https://xmpp.org/extensions/xep-0045.html#enter-subject) 
 or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -204,19 +204,7 @@ build_forward_el(Content) ->
 
 %%%%%%%%%%%%%%%%%%%
 %% Helpers
-%%
 
--spec muc_type(Host :: binary()) -> muclight | muc.
-muc_type(Host) ->
-    [Type] = gen_mod:get_module_opt(Host, ?MODULE, groupchat, [muclight]),
-    Type.
-
--spec muc_module(Host :: binary()) -> mod_inbox_muclight | mod_inbox_muc.
-muc_module(Host) ->
-    muc_module_from_type(muc_type(Host)).
-
-muc_module_from_type(muclight) -> mod_inbox_muclight;
-muc_module_from_type(muc) -> mod_inbox_muc.
 
 -spec muclight_enabled(Host :: binary()) -> boolean().
 muclight_enabled(Host) ->

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -68,7 +68,7 @@ start(Host, Opts) ->
     [MucType] = gen_mod:get_opt(groupchat, Opts),
     case MucType of % change the way we check it mod_muc is turned on
         muc ->
-            ejabberd_hooks:add(update_inbox, Host, mod_inbox_muc, update_inbox, 90);
+            mod_inbox_muc:start(Host);
         muclight ->
             ejabberd_hooks:add(user_send_packet, Host, ?MODULE, user_send_packet, 90),
             ejabberd_hooks:add(filter_local_packet, Host, ?MODULE, filter_packet, 90)
@@ -83,7 +83,7 @@ muc_host_defined(_) -> true.
 -spec stop(Host :: jid:server()) -> ok.
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_ESL_INBOX),
-    ejabberd_hooks:delete(update_inbox, Host, mod_inbox_muc, update_inbox, 90),
+    mod_inbox_muc:stop(Host),
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:delete(filter_local_packet, Host, ?MODULE, filter_packet, 90),
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_ESL_INBOX).

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -75,9 +75,6 @@ start(Host, Opts) ->
     store_bin_reset_markers(Host, Opts),
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_ESL_INBOX, ?MODULE, process_iq, IQDisc).
 
-muc_host_defined(undefined) -> false;
-muc_host_defined(_) -> true.
-
 
 -spec stop(Host :: jid:server()) -> ok.
 stop(Host) ->

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -202,19 +202,19 @@ build_forward_el(Content) ->
 %% Helpers
 %%
 
--spec muc_type(Host :: binary()) :: muclight | muc.
+-spec muc_type(Host :: binary()) -> muclight | muc.
 muc_type(Host) ->
     [Type] = gen_mod:get_module_opt(Host, ?MODULE, groupchat, [muclight]),
     Type.
 
--spec muc_module(Host :: binary()) :: mod_inbox_muclight | mod_inbox_muc.
+-spec muc_module(Host :: binary()) -> mod_inbox_muclight | mod_inbox_muc.
 muc_module(Host) ->
     muc_module_from_type(muc_type(Host)).
 
 muc_module_from_type(muclight) -> mod_inbox_muclight;
 muc_module_from_type(muc) -> mod_inbox_muc.
 
--spec muc_type(Host :: binary()) :: boolean().
+-spec groupchats_enabled(Host :: binary()) -> boolean().
 groupchats_enabled(Host) ->
     case gen_mod:get_module_opt(Host, ?MODULE, groupchat, [muclight]) of
         [] -> false;

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -65,9 +65,9 @@ start(Host, Opts) ->
     {ok, _} = gen_mod:start_backend_module(?MODULE, Opts, callback_funs()),
     mod_disco:register_feature(Host, ?NS_ESL_INBOX),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, no_queue),
-    MUCHost = gen_mod:get_module_opt(Host, mod_muc, host, undefined), %% Abstract to another funciton or even to module `mod_inbox_muc`
-    muc_host_defined(MUCHost) andalso
-    ejabberd_hooks:add(update_inbox, MUCHost, mod_inbox_muc, update_inbox, 90),
+    MUCHost = gen_mod:get_module_opt(Host, mod_muc, host, undefined),
+    muc_host_defined(MUCHost) andalso % change the way we check it mod_muc is turned on
+    ejabberd_hooks:add(update_inbox, Host, mod_inbox_muc, update_inbox, 90),
     ejabberd_hooks:add(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:add(filter_local_packet, Host, ?MODULE, filter_packet, 90),
     store_bin_reset_markers(Host, Opts),
@@ -81,7 +81,7 @@ muc_host_defined(_) -> true.
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_ESL_INBOX),
     MUCHost = gen_mod:get_module_opt(Host, mod_muc, host, undefined),
-    ejabberd_hooks:delete(update_inbox, MUCHost, mod_inbox_muc, update_inbox, 90),
+    ejabberd_hooks:delete(update_inbox, Host, mod_inbox_muc, update_inbox, 90),
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:delete(filter_local_packet, Host, ?MODULE, filter_local_packet, 90),
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_ESL_INBOX).

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -65,15 +65,23 @@ start(Host, Opts) ->
     {ok, _} = gen_mod:start_backend_module(?MODULE, Opts, callback_funs()),
     mod_disco:register_feature(Host, ?NS_ESL_INBOX),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, no_queue),
+    MUCHost = gen_mod:get_module_opt(Host, mod_muc, host, undefined), %% Abstract to another funciton or even to module `mod_inbox_muc`
+    muc_host_defined(MUCHost) andalso
+    ejabberd_hooks:add(update_inbox, MUCHost, mod_inbox_muc, update_inbox, 90),
     ejabberd_hooks:add(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:add(filter_local_packet, Host, ?MODULE, filter_packet, 90),
     store_bin_reset_markers(Host, Opts),
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_ESL_INBOX, ?MODULE, process_iq, IQDisc).
 
+muc_host_defined(undefined) -> false;
+muc_host_defined(_) -> true.
+
 
 -spec stop(Host :: jid:server()) -> ok.
 stop(Host) ->
     mod_disco:unregister_feature(Host, ?NS_ESL_INBOX),
+    MUCHost = gen_mod:get_module_opt(Host, mod_muc, host, undefined),
+    ejabberd_hooks:delete(update_inbox, MUCHost, mod_inbox_muc, update_inbox, 90),
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:delete(filter_local_packet, Host, ?MODULE, filter_local_packet, 90),
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_ESL_INBOX).

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -1,0 +1,204 @@
+%%%-------------------------------------------------------------------
+%%% @author ludwikbukowski
+%%% @copyright (C) 2018, Erlang-Solutions
+%%% @doc
+%%%
+%%% @end
+%%% Created : 30. Jan 2018 13:22
+%%%-------------------------------------------------------------------
+-module(mod_inbox_muc).
+-author("ludwikbukowski").
+-include("mod_muc_light.hrl").
+-include("mod_inbox.hrl").
+-include("jlib.hrl").
+-include("jid.hrl").
+-include("mongoose_ns.hrl").
+-include("mongoose.hrl").
+
+-export([handle_outgoing_message/4, handle_incoming_message/4, update_inbox/4]).
+-type packet() :: exml:element().
+-type role() :: r_member() | r_owner() | r_none().
+-type r_member() :: binary().
+-type r_owner() :: binary().
+-type r_none() :: binary().
+
+update_inbox(Acc, From, Affs, Packet) ->
+    ?WARNING_MSG("Update inbox hook: ~p, ~p, ~p, ~p", [Acc, From, Affs, Packet]),
+    Acc.
+
+-spec handle_outgoing_message(Host :: jid:server(),
+                              User :: jid:jid(),
+                              Room :: jid:jid(),
+                              Packet :: packet()) -> any().
+handle_outgoing_message(Host, User, Room, Packet) ->
+    ok.
+%    Markers = mod_inbox_utils:get_reset_markers(Host),
+%    case mod_inbox_utils:if_chat_marker_get_id(Packet, Markers) of
+%        undefined ->
+%            %% we store in inbox only on incoming messages
+%            ok;
+%        Id ->
+%            mod_inbox_utils:reset_unread_count(User, Room, Id)
+%    end.
+
+-spec handle_incoming_message(Host :: jid:server(),
+                              RoomUser :: jid:jid(),
+                              Remote :: jid:jid(),
+                              Packet :: packet()) -> any().
+handle_incoming_message(Host, RoomUser, Remote, Packet) ->
+    ok.
+%    Markers = mod_inbox_utils:get_reset_markers(Host),
+%    case mod_inbox_utils:has_chat_marker(Packet, Markers) of
+%        true ->
+%            %% don't store chat markers in inbox
+%            ok;
+%        false ->
+%            maybe_handle_system_message(Host, RoomUser, Remote, Packet)
+%    end.
+
+-spec maybe_handle_system_message(Host :: host(),
+                                  RoomUser :: jid:jid(),
+                                  Receiver :: jid:jid(),
+                                  Packet :: exml:element()) -> ok.
+maybe_handle_system_message(Host, RoomUser, Receiver, Packet) ->
+    case is_system_message(RoomUser, Receiver, Packet) of
+        true ->
+            handle_system_message(Host, RoomUser, Receiver, Packet);
+        _ ->
+            Sender = jid:from_binary(RoomUser#jid.lresource),
+            ?WARNING_MSG("Storing: ~p for ~p", [Packet, RoomUser]),
+            write_to_inbox(Host, RoomUser, Receiver, Sender, Packet)
+    end.
+
+-spec handle_system_message(Host :: host(),
+                            Room :: jid:jid(),
+                            Remote :: jid:jid(),
+                            Packet :: exml:element()) -> ok.
+handle_system_message(Host, Room, Remote, Packet) ->
+    case system_message_type(Remote, Packet) of
+        kick ->
+            handle_kicked_message(Host, Room, Remote, Packet);
+        invite->
+            handle_invitation_message(Host, Room, Remote, Packet);
+        other ->
+            ?WARNING_MSG("unknown system messasge for mod_inbox_muclight='~p' with error ~p", [Packet]),
+            ok
+    end.
+
+-spec handle_invitation_message(Host :: host(),
+                                Room :: jid:jid(),
+                                Remote :: jid:jid(),
+                                Packet :: exml:element()) -> ok.
+handle_invitation_message(Host, Room, Remote, Packet) ->
+    maybe_store_system_message(Host, Room, Remote, Packet).
+
+-spec handle_kicked_message(Host :: host(),
+                            Room :: jid:jid(),
+                            Remote :: jid:jid(),
+                            Packet :: exml:element()) -> ok.
+handle_kicked_message(Host, Room, Remote, Packet) ->
+    CheckRemove = mod_inbox_utils:get_option_remove_on_kicked(Host),
+    maybe_store_system_message(Host, Room, Remote, Packet),
+    maybe_remove_inbox_row(Host, Room, Remote, CheckRemove).
+
+-spec maybe_store_system_message(Host :: host(),
+                                  Room :: jid:jid(),
+                                  Remote :: jid:jid(),
+                                  Packet :: exml:element()) -> ok.
+maybe_store_system_message(Host, Room, Remote, Packet) ->
+    WriteAffChanges = mod_inbox_utils:get_option_write_aff_changes(Host),
+    case WriteAffChanges of
+        true ->
+            mod_inbox_utils:write_to_receiver_inbox(Host, Room, Remote, Packet);
+        false ->
+            ok
+    end.
+
+-spec maybe_remove_inbox_row(Host :: host(),
+                             Room :: jid:jid(),
+                             Remote :: jid:jid(),
+                             WriteAffChanges :: boolean()) -> ok.
+maybe_remove_inbox_row(_, _, _, false) ->
+    ok;
+maybe_remove_inbox_row(Host, Room, Remote, true) ->
+    UserBin = (jid:to_bare(Remote))#jid.luser,
+    RoomBin = jid:to_binary(Room),
+    ok = mod_inbox_backend:remove_inbox(UserBin, Host, RoomBin).
+
+-spec write_to_inbox(Server :: host(),
+                     RoomUser :: jid:jid(),
+                     Remote :: jid:jid(),
+                     Sender :: jid:jid(),
+                     Packet :: exml:element()) -> ok.
+write_to_inbox(Server, RoomUser, Remote, Remote, Packet) ->
+    mod_inbox_utils:write_to_sender_inbox(Server, Remote, RoomUser, Packet);
+write_to_inbox(Server, RoomUser, Remote, _Sender, Packet) ->
+    mod_inbox_utils:write_to_receiver_inbox(Server, RoomUser, Remote, Packet).
+
+%%%%%%%
+%% Predicate funs
+
+%% check if sender is just 'roomname@muclight.domain' with no resource
+-spec  is_system_message(Sender :: jid:jid(),
+                         Receiver :: jid:jid(),
+                         Packet :: exml:element()) -> boolean().
+is_system_message(Sender, Receiver, Packet) ->
+    ReceiverDomain = Receiver#jid.lserver,
+    MUCLightDomain = list_to_binary(gen_mod:get_module_opt(ReceiverDomain, mod_muc_light, host, undefined)),
+    is_subject_msg(Packet) orelse
+    case {Sender#jid.lserver, Sender#jid.lresource} of
+        {MUCLightDomain, <<>>} ->
+            true;
+        {MUCLightDomain, _RoomUser} ->
+            false;
+        true -> true;
+        Other ->
+            ?WARNING_MSG("unknown messasge for mod_inbox_muclight='~p' with error ~p", [Packet, Other])
+    end.
+
+
+-spec is_change_aff_message(jid:jid(), exml:element(), role()) -> boolean().
+is_change_aff_message(User, Packet, Role) ->
+    AffItems = exml_query:paths(Packet, [{element_with_ns, ?NS_MUC_LIGHT_AFFILIATIONS},
+        {element, <<"user">>}]),
+    AffList = get_users_with_affiliation(AffItems, Role),
+    Jids = [Jid || #xmlel{children = [#xmlcdata{content = Jid}]} <- AffList],
+    UserBin = jid:to_binary(jid:to_lower(jid:to_bare(User))),
+    lists:member(UserBin, Jids).
+
+-spec system_message_type(User :: jid:jid(), Packet :: exml:element()) -> invite | kick | other.
+system_message_type(User, Packet) ->
+    IsInviteMsg = is_invitation_message(User, Packet),
+    IsNewOwnerMsg = is_new_owner_message(User, Packet),
+    IsKickedMsg = is_kicked_message(User, Packet),
+    if IsInviteMsg orelse IsNewOwnerMsg ->
+        invite;
+       IsKickedMsg ->
+            kick;
+       true ->
+            other
+            end.
+
+is_subject_msg(Packet) ->
+    case exml_query:subelement(Packet, <<"body">>, undefined) of
+        undefined -> true;
+        #xmlel{children = []} -> true;
+        _ -> false
+    end.
+        
+
+-spec is_invitation_message(jid:jid(), exml:element()) -> boolean().
+is_invitation_message(User, Packet) ->
+    is_change_aff_message(User, Packet, <<"member">>).
+
+-spec is_new_owner_message(jid:jid(), exml:element()) -> boolean().
+is_new_owner_message(User, Packet) ->
+    is_change_aff_message(User, Packet, <<"owner">>).
+
+-spec is_kicked_message(jid:jid(), exml:element()) -> boolean().
+is_kicked_message(User, Packet) ->
+    is_change_aff_message(User, Packet, <<"none">>).
+
+-spec get_users_with_affiliation(list(exml:element()), role()) -> list(exml:element()).
+get_users_with_affiliation(AffItems, Role) ->
+    [M || #xmlel{name = <<"user">>, attrs = [{<<"affiliation">>, R}]} = M <- AffItems, R == Role].

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -24,6 +24,8 @@
 
 start(Host) ->
     ejabberd_hooks:add(update_inbox, Host, ?MODULE, update_inbox, 90),
+    % TODO check ooptions: if system messages stored -> 
+    % add hook handler for system messages on hook ie. invitation_sent
     ok.
 
 stop(Host) ->

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -13,13 +13,13 @@
 -export([update_inbox/5, start/1, stop/1]).
 
 start(Host) ->
-    ejabberd_hooks:add(update_inbox, Host, ?MODULE, update_inbox, 90),
+    ejabberd_hooks:add(update_inbox_for_muc, Host, ?MODULE, update_inbox, 90),
     % TODO check ooptions: if system messages stored -> 
     % add hook handler for system messages on hook ie. invitation_sent
     ok.
 
 stop(Host) ->
-    ejabberd_hooks:delete(update_inbox, Host, ?MODULE, update_inbox, 90),
+    ejabberd_hooks:delete(update_inbox_for_muc, Host, ?MODULE, update_inbox, 90),
     ok.
 
 update_inbox(Acc, Room, {From, FromRoomJid}, AffsDict, Packet) ->

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -68,17 +68,11 @@ alter_receivers_packet(Packet, Room, To) ->
     Packet2 = change_from_el(Packet, Room),
     change_to_el(Packet2, To).
 
-% TODO refactor
 change_from_el(#xmlel{name = <<"message">>, attrs = Attrs} = Packet, NewFrom) ->
-    Attrs2 = lists:keydelete(<<"from">>, 1, Attrs),
-    Attrs3 = [{<<"from">>, jid:to_binary(NewFrom)} | Attrs2],
-    Packet#xmlel{attrs = Attrs3}.
+    xml:replace_tag_attr(<<"from">>, jid:to_binary(NewFrom), Packet).
 
 change_to_el(#xmlel{name = <<"message">>, attrs = Attrs} = Packet, NewTo) ->
-    Attrs2 = lists:keydelete(<<"to">>, 1, Attrs),
-    Attrs3 = [{<<"to">>, jid:to_binary(NewTo)} | Attrs2],
-    Packet#xmlel{attrs = Attrs3}.
-
+    xml:replace_tag_attr(<<"to">>, jid:to_binary(NewTo), Packet).
 
 handle_outgoing_message(Host, User, Room, Packet) ->
     Markers = mod_inbox_utils:get_reset_markers(Host),

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -28,7 +28,7 @@ update_inbox(Acc, Room, From, AffsDict, Packet) ->
     FromBare = jid:to_bare(From),
     ?WARNING_MSG("Update inbox hook:~n From: ~p~nUsers: ~p,~n Acc: ~p", 
                  [FromBare, Users, Acc]),
-    lists:foreach(fun(User) -> update_inbox(Room, FromBare, User, Packet) end,
+    lists:foreach(fun(User) -> ?WARNING_MSG("~p:~p", [FromBare, User]), update_inbox(Room, FromBare, User, Packet) end,
                   Users),
     Acc.
 
@@ -38,12 +38,14 @@ affs_to_allowed_users(Users) ->
     lists:map(fun({{User, Domain, Res}, _Aff}) -> jid:make(User, Domain, Res) end,
               AllowedUsers).
 
-update_inbox(Room, From, From, Packet) ->
-    Host = From#jid.server,
-    mod_inbox_utils:write_to_sender_inbox(Host, From, Room, Packet);
-update_inbox(Room, _From, To, Packet) ->
+update_inbox(Room, From, To, Packet) ->
     Host = To#jid.server,
-    mod_inbox_utils:write_to_receiver_inbox(Host, Room, To, Packet).
+    case jid:are_equal(From, To) of
+        true ->
+            mod_inbox_utils:write_to_sender_inbox(Host, From, Room, Packet);
+        false ->
+            mod_inbox_utils:write_to_receiver_inbox(Host, Room, To, Packet)
+    end.
 
 
 -spec handle_outgoing_message(Host :: jid:server(),

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -1,26 +1,16 @@
 %%%-------------------------------------------------------------------
-%%% @author ludwikbukowski
+%%% @author Dominik Stanaszek dominik.stanaszek@erlang-solutions.com
 %%% @copyright (C) 2018, Erlang-Solutions
 %%% @doc
 %%%
 %%% @end
-%%% Created : 30. Jan 2018 13:22
+%%% Created : 6.07.2018 
 %%%-------------------------------------------------------------------
 -module(mod_inbox_muc).
--author("ludwikbukowski").
--include("mod_muc_light.hrl").
--include("mod_inbox.hrl").
+-author("dominik.stanaszek@erlang-solutions.com").
 -include("jlib.hrl").
--include("jid.hrl").
--include("mongoose_ns.hrl").
--include("mongoose.hrl").
 
 -export([update_inbox/5, start/1, stop/1]).
--type packet() :: exml:element().
--type role() :: r_member() | r_owner() | r_none().
--type r_member() :: binary().
--type r_owner() :: binary().
--type r_none() :: binary().
 
 start(Host) ->
     ejabberd_hooks:add(update_inbox, Host, ?MODULE, update_inbox, 90),
@@ -106,155 +96,5 @@ handle_incoming_message(Host, Room, To, Packet) ->
             %% don't store chat markers in inbox
             ok;
         false ->
-            %maybe_handle_system_message(Host, RoomUser, Remote, Packet)
             mod_inbox_utils:write_to_receiver_inbox(Host, Room, To, Packet)
     end.
-
--spec maybe_handle_system_message(Host :: host(),
-                                  RoomUser :: jid:jid(),
-                                  Receiver :: jid:jid(),
-                                  Packet :: exml:element()) -> ok.
-maybe_handle_system_message(Host, RoomUser, Receiver, Packet) ->
-    case is_system_message(RoomUser, Receiver, Packet) of
-        true ->
-            handle_system_message(Host, RoomUser, Receiver, Packet);
-        _ ->
-            Sender = jid:from_binary(RoomUser#jid.lresource),
-            ?WARNING_MSG("Storing: ~p for ~p", [Packet, RoomUser]),
-            write_to_inbox(Host, RoomUser, Receiver, Sender, Packet)
-    end.
-
--spec handle_system_message(Host :: host(),
-                            Room :: jid:jid(),
-                            Remote :: jid:jid(),
-                            Packet :: exml:element()) -> ok.
-handle_system_message(Host, Room, Remote, Packet) ->
-    % SYSTEM MESSAGES DON'T GO TO update_inbox HOOK!
-    case system_message_type(Remote, Packet) of
-        kick ->
-            handle_kicked_message(Host, Room, Remote, Packet);
-        invite->
-            handle_invitation_message(Host, Room, Remote, Packet);
-        other ->
-            ?WARNING_MSG("muc) unknown system messasge for mod_inbox_muclight='~p' with error ~p", [Packet]),
-            ok
-    end.
-
--spec handle_invitation_message(Host :: host(),
-                                Room :: jid:jid(),
-                                Remote :: jid:jid(),
-                                Packet :: exml:element()) -> ok.
-handle_invitation_message(Host, Room, Remote, Packet) ->
-    maybe_store_system_message(Host, Room, Remote, Packet).
-
--spec handle_kicked_message(Host :: host(),
-                            Room :: jid:jid(),
-                            Remote :: jid:jid(),
-                            Packet :: exml:element()) -> ok.
-handle_kicked_message(Host, Room, Remote, Packet) ->
-    CheckRemove = mod_inbox_utils:get_option_remove_on_kicked(Host),
-    maybe_store_system_message(Host, Room, Remote, Packet),
-    maybe_remove_inbox_row(Host, Room, Remote, CheckRemove).
-
--spec maybe_store_system_message(Host :: host(),
-                                  Room :: jid:jid(),
-                                  Remote :: jid:jid(),
-                                  Packet :: exml:element()) -> ok.
-maybe_store_system_message(Host, Room, Remote, Packet) ->
-    WriteAffChanges = mod_inbox_utils:get_option_write_aff_changes(Host),
-    case WriteAffChanges of
-        true ->
-            mod_inbox_utils:write_to_receiver_inbox(Host, Room, Remote, Packet);
-        false ->
-            ok
-    end.
-
--spec maybe_remove_inbox_row(Host :: host(),
-                             Room :: jid:jid(),
-                             Remote :: jid:jid(),
-                             WriteAffChanges :: boolean()) -> ok.
-maybe_remove_inbox_row(_, _, _, false) ->
-    ok;
-maybe_remove_inbox_row(Host, Room, Remote, true) ->
-    UserBin = (jid:to_bare(Remote))#jid.luser,
-    RoomBin = jid:to_binary(Room),
-    ok = mod_inbox_backend:remove_inbox(UserBin, Host, RoomBin).
-
--spec write_to_inbox(Server :: host(),
-                     RoomUser :: jid:jid(),
-                     Remote :: jid:jid(),
-                     Sender :: jid:jid(),
-                     Packet :: exml:element()) -> ok.
-write_to_inbox(Server, RoomUser, Remote, Remote, Packet) ->
-    mod_inbox_utils:write_to_sender_inbox(Server, Remote, RoomUser, Packet);
-write_to_inbox(Server, RoomUser, Remote, _Sender, Packet) ->
-    mod_inbox_utils:write_to_receiver_inbox(Server, RoomUser, Remote, Packet).
-
-%%%%%%%
-%% Predicate funs
-
-%% check if sender is just 'roomname@muclight.domain' with no resource
--spec  is_system_message(Sender :: jid:jid(),
-                         Receiver :: jid:jid(),
-                         Packet :: exml:element()) -> boolean().
-is_system_message(Sender, Receiver, Packet) ->
-    ReceiverDomain = Receiver#jid.lserver,
-    MUCLightDomain = list_to_binary(gen_mod:get_module_opt(ReceiverDomain, mod_muc_light, host, undefined)),
-    is_subject_msg(Packet) orelse
-    case {Sender#jid.lserver, Sender#jid.lresource} of
-        {MUCLightDomain, <<>>} ->
-            true;
-        {MUCLightDomain, _RoomUser} ->
-            false;
-        true -> true;
-        Other ->
-            ?WARNING_MSG("unknown messasge for mod_inbox_muclight='~p' with error ~p", [Packet, Other])
-    end.
-
-
--spec is_change_aff_message(jid:jid(), exml:element(), role()) -> boolean().
-is_change_aff_message(User, Packet, Role) ->
-    AffItems = exml_query:paths(Packet, [{element_with_ns, ?NS_MUC_LIGHT_AFFILIATIONS},
-        {element, <<"user">>}]),
-    AffList = get_users_with_affiliation(AffItems, Role),
-    Jids = [Jid || #xmlel{children = [#xmlcdata{content = Jid}]} <- AffList],
-    UserBin = jid:to_binary(jid:to_lower(jid:to_bare(User))),
-    lists:member(UserBin, Jids).
-
--spec system_message_type(User :: jid:jid(), Packet :: exml:element()) -> invite | kick | other.
-system_message_type(User, Packet) ->
-    IsInviteMsg = is_invitation_message(User, Packet),
-    IsNewOwnerMsg = is_new_owner_message(User, Packet),
-    IsKickedMsg = is_kicked_message(User, Packet),
-    if IsInviteMsg orelse IsNewOwnerMsg ->
-        invite;
-       IsKickedMsg ->
-            kick;
-       true ->
-            other
-            end.
-
-is_subject_msg(Packet) ->
-    %% IN update_inbox HOOK THERE WON'T BE SUBJECT MESSAGES
-    case exml_query:subelement(Packet, <<"body">>, undefined) of
-        undefined -> true;
-        #xmlel{children = []} -> true;
-        _ -> false
-    end.
-        
-
--spec is_invitation_message(jid:jid(), exml:element()) -> boolean().
-is_invitation_message(User, Packet) ->
-    is_change_aff_message(User, Packet, <<"member">>).
-
--spec is_new_owner_message(jid:jid(), exml:element()) -> boolean().
-is_new_owner_message(User, Packet) ->
-    is_change_aff_message(User, Packet, <<"owner">>).
-
--spec is_kicked_message(jid:jid(), exml:element()) -> boolean().
-is_kicked_message(User, Packet) ->
-    is_change_aff_message(User, Packet, <<"none">>).
-
--spec get_users_with_affiliation(list(exml:element()), role()) -> list(exml:element()).
-get_users_with_affiliation(AffItems, Role) ->
-    [M || #xmlel{name = <<"user">>, attrs = [{<<"affiliation">>, R}]} = M <- AffItems, R == Role].

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -75,7 +75,7 @@ handle_system_message(Host, Room, Remote, Packet) ->
         invite->
             handle_invitation_message(Host, Room, Remote, Packet);
         other ->
-            ?WARNING_MSG("muclight) unknown system messasge for mod_inbox_muclight='~p' with error ~p", [Packet]),
+            ?WARNING_MSG("unknown system messasge for mod_inbox_muclight='~p'", [Packet]),
             ok
     end.
 

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -75,7 +75,7 @@ handle_system_message(Host, Room, Remote, Packet) ->
         invite->
             handle_invitation_message(Host, Room, Remote, Packet);
         other ->
-            ?WARNING_MSG("unknown system messasge for mod_inbox_muclight='~p' with error ~p", [Packet]),
+            ?WARNING_MSG("muclight) unknown system messasge for mod_inbox_muclight='~p' with error ~p", [Packet]),
             ok
     end.
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -504,7 +504,6 @@ route_to_room(Room, Routed, #state{host=Host} = State) ->
     end.
 
 route_to_online_room(Pid, {From, To, Acc, Packet}) ->
-    ?DEBUG("MUC: send to process ~p~n", [Pid]),
     {_, _, Nick} = jid:to_lower(To),
     ok = mod_muc_room:route(Pid, From, Nick, Acc, Packet).
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -504,6 +504,7 @@ route_to_room(Room, Routed, #state{host=Host} = State) ->
     end.
 
 route_to_online_room(Pid, {From, To, Acc, Packet}) ->
+    ?DEBUG("MUC: send to process ~p~n", [Pid]),
     {_, _, Nick} = jid:to_lower(To),
     ok = mod_muc_room:route(Pid, From, Nick, Acc, Packet).
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4654,7 +4654,6 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From,
     lang = Lang, nick = ToNick, jid = false}, StateData) ->
-    ?WARNING_MSG("Recipient not in the room", []),
     ErrText = <<"Recipient is not in the conference room">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -880,11 +880,13 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
             next_normal_state(StateData);
         FilteredPacket ->
             ejabberd_hooks:run(room_send_packet, StateData#state.host, [FilteredPacket, EventData]),
-            ?WARNING_MSG("Jid of room: ~p", [StateData#state.jid]),
-            ejabberd_hooks:run(update_inbox, StateData#state.server_host,
-                               [StateData#state.jid, From, StateData#state.affiliations, Packet]),
             RouteFrom = jid:replace_resource(StateData#state.jid,
                                              FromNick),
+            RoomName = StateData#state.jid,
+
+            ejabberd_hooks:run(update_inbox, StateData#state.server_host,
+                               [RoomName, {From, RouteFrom}, StateData#state.affiliations, FilteredPacket]),
+
             lists:foreach(fun({_LJID, Info}) ->
                                   ejabberd_router:route(RouteFrom,
                                                         Info#user.jid,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -882,10 +882,10 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
             ejabberd_hooks:run(room_send_packet, StateData#state.host, [FilteredPacket, EventData]),
             RouteFrom = jid:replace_resource(StateData#state.jid,
                                              FromNick),
-            RoomName = StateData#state.jid,
+            RoomJid = StateData#state.jid,
 
-            ejabberd_hooks:run(update_inbox, StateData#state.server_host,
-                               [RoomName, {From, RouteFrom}, StateData#state.affiliations, FilteredPacket]),
+            ejabberd_hooks:run(update_inbox_for_muc, StateData#state.server_host,
+                               [RoomJid, {From, RouteFrom}, StateData#state.affiliations, FilteredPacket]),
 
             lists:foreach(fun({_LJID, Info}) ->
                                   ejabberd_router:route(RouteFrom,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -880,8 +880,9 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
             next_normal_state(StateData);
         FilteredPacket ->
             ejabberd_hooks:run(room_send_packet, StateData#state.host, [FilteredPacket, EventData]),
+            ?WARNING_MSG("Jid of room: ~p", [StateData#state.jid]),
             ejabberd_hooks:run(update_inbox, StateData#state.server_host,
-                               [From, StateData#state.affiliations, Packet]),
+                               [StateData#state.jid, From, StateData#state.affiliations, Packet]),
             RouteFrom = jid:replace_resource(StateData#state.jid,
                                              FromNick),
             lists:foreach(fun({_LJID, Info}) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1762,6 +1762,8 @@ is_nick_exists(Nick, StateData) ->
 
 -spec find_jids_by_nick(mod_muc:nick(), state()) -> [jid:jid()].
 find_jids_by_nick(Nick, StateData) ->
+    ?WARNING_MSG("Nick: ~p", [Nick]),
+    ?WARNING_MSG("Sesions: ~p", [dict:to_list(StateData#state.sessions)]),
     case dict:find(Nick, StateData#state.sessions) of
         error -> [];
         {ok, JIDs} -> JIDs
@@ -4654,6 +4656,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From,
     lang = Lang, nick = ToNick, jid = false}, StateData) ->
+    ?WARNING_MSG("Recipient not in the room", []),
     ErrText = <<"Recipient is not in the conference room">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
@@ -4665,6 +4668,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From, jid = ToJID}, StateData) ->
+    ?WARNING_MSG("OK, jid: ~p", [ToJID]),
     {ok, #user{nick = FromNick}} = dict:find(jid:to_lower(From),
         StateData#state.users),
     ejabberd_router:route(

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -880,7 +880,7 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
             next_normal_state(StateData);
         FilteredPacket ->
             ejabberd_hooks:run(room_send_packet, StateData#state.host, [FilteredPacket, EventData]),
-            ejabberd_hooks:run(update_inbox, binary_to_list(StateData#state.host), % why it's string here and binary at registering handler????
+            ejabberd_hooks:run(update_inbox, StateData#state.server_host,
                                [From, StateData#state.affiliations, Packet]),
             RouteFrom = jid:replace_resource(StateData#state.jid,
                                              FromNick),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -880,6 +880,8 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
             next_normal_state(StateData);
         FilteredPacket ->
             ejabberd_hooks:run(room_send_packet, StateData#state.host, [FilteredPacket, EventData]),
+            ejabberd_hooks:run(update_inbox, binary_to_list(StateData#state.host), % why it's string here and binary at registering handler????
+                               [From, StateData#state.affiliations, Packet]),
             RouteFrom = jid:replace_resource(StateData#state.jid,
                                              FromNick),
             lists:foreach(fun({_LJID, Info}) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1762,8 +1762,6 @@ is_nick_exists(Nick, StateData) ->
 
 -spec find_jids_by_nick(mod_muc:nick(), state()) -> [jid:jid()].
 find_jids_by_nick(Nick, StateData) ->
-    ?WARNING_MSG("Nick: ~p", [Nick]),
-    ?WARNING_MSG("Sesions: ~p", [dict:to_list(StateData#state.sessions)]),
     case dict:find(Nick, StateData#state.sessions) of
         error -> [];
         {ok, JIDs} -> JIDs
@@ -4668,7 +4666,6 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From, jid = ToJID}, StateData) ->
-    ?WARNING_MSG("OK, jid: ~p", [ToJID]),
     {ok, #user{nick = FromNick}} = dict:find(jid:to_lower(From),
         StateData#state.users),
     ejabberd_router:route(


### PR DESCRIPTION
Main functionalities TODO:
- [x] Main functionality - storing muc messages in inbox
- [x] chat markers function
- [x] private messages
- [ ] ~~invitation messages~~ (not in the scope of this PR)
- [ ] ~~Other system messages (?)~~ (not in the scope of this PR)

small TODO:
- [x] Extract common parts. Some functions are copied from other suites right now.
- [x] Check why host for muc is string in `mod_muc_room`
- [ ] ~~Don't rely on affiliations but maybe rather make inbox subscribe to rooms~~ (not in the scope of this PR)
- [x] On what host should the hook be registered on?
- [x] Refactor test suite: inits and ends
- [x] Remove unnecessary logging in test suite and add necessary logging in MIM
- [ ] Move all the message processing for muclight to `mod_inbox_muclight`, then make it implement the same behaviour as `mod_inbox_muc`