### PR TITLE
Incremental sleep redundancy

### DIFF
--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -189,7 +189,7 @@ do_not_accept_0_hold_value(Config) ->
 send_specific_hold(Config, HoldValue) ->
     {Server, Path, Client} = get_fusco_connection(Config),
 
-    Rid = random:uniform(1000000),
+    Rid = rand:uniform(1000000),
     Body0 = escalus_bosh:session_creation_body(2, <<"1.0">>, <<"en">>, Rid, Server, nil),
     #xmlel{attrs = Attrs0} = Body0,
     Attrs = lists:keyreplace(<<"hold">>, 1, Attrs0, {<<"hold">>, HoldValue}),
@@ -878,13 +878,15 @@ wait_for_session_close(Sid) ->
     mongoose_helper:wait_until(fun() -> is_session_alive(Sid) end, false,
                                #{
                                  time_left => timer:seconds(10),
-                                 time_sleep => timer:seconds(1)
+                                 time_sleep => timer:seconds(1),
+                                 name => is_session_alive
                                 }).
 
 wait_for_handler(Pid) ->
     mongoose_helper:wait_until(fun() -> length(get_handlers(Pid)) end, 1, #{
                                                                             time_left => timer:seconds(10),
-                                                                            time_sleep => timer:seconds(1)
+                                                                            time_sleep => timer:seconds(1),
+                                                                            name => get_handlers
                                                                            }).
 
 domain() ->

--- a/big_tests/tests/component_helper.erl
+++ b/big_tests/tests/component_helper.erl
@@ -44,7 +44,7 @@ disconnect_component(Component, Addr) ->
 disconnect_components(Components, Addr) ->
     %% TODO replace 'kill' with 'stop' when server supports stream closing
     [escalus_connection:kill(Component) || Component <- Components],
-    mongoose_helper:wait_until(fun() -> rpc(ejabberd_router, lookup_component, [Addr]) =:= [] end, 5, 200).
+    mongoose_helper:wait_until(fun() -> rpc(ejabberd_router, lookup_component, [Addr]) =:= [] end, true, 1000, 200).
 
 rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),

--- a/big_tests/tests/component_helper.erl
+++ b/big_tests/tests/component_helper.erl
@@ -44,7 +44,7 @@ disconnect_component(Component, Addr) ->
 disconnect_components(Components, Addr) ->
     %% TODO replace 'kill' with 'stop' when server supports stream closing
     [escalus_connection:kill(Component) || Component <- Components],
-    mongoose_helper:wait_until(fun() -> rpc(ejabberd_router, lookup_component, [Addr]) =:= [] end, true, 1000, 200).
+    mongoose_helper:wait_until(fun() -> rpc(ejabberd_router, lookup_component, [Addr]) =:= [] end, true).
 
 rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),

--- a/big_tests/tests/component_helper.erl
+++ b/big_tests/tests/component_helper.erl
@@ -44,7 +44,8 @@ disconnect_component(Component, Addr) ->
 disconnect_components(Components, Addr) ->
     %% TODO replace 'kill' with 'stop' when server supports stream closing
     [escalus_connection:kill(Component) || Component <- Components],
-    mongoose_helper:wait_until(fun() -> rpc(ejabberd_router, lookup_component, [Addr]) =:= [] end, true).
+    mongoose_helper:wait_until(fun() -> rpc(ejabberd_router, lookup_component, [Addr]) =:= [] end, true,
+                               #{name => rpc}).
 
 rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -794,16 +794,22 @@ wait_for_archive_size(User, ExpectedSize) ->
 wait_for_archive_size(Server, Username, ExpectedSize) ->
     mongoose_helper:wait_until(fun() -> archive_size(Server, Username) end,
                                ExpectedSize,
-                               #{time_left => timer:seconds(20)}).
+                               #{
+                                 time_left => timer:seconds(20),
+                                 name => archive_size
+                                }).
 
 wait_for_archive_size_or_warning(Server, Username, ExpectedSize) ->
     try mongoose_helper:wait_until(fun() -> archive_size(Server, Username) end,
-                                       ExpectedSize,
-                                       #{time_left => timer:seconds(20)}) of
+                                   ExpectedSize,
+                                   #{
+                                     time_left => timer:seconds(20),
+                                     name => archive_size
+                                    }) of
         {ok, ExpectedSize} ->
             ok
     catch
-        Error:Reason ->
+        _Error:Reason ->
             ct:pal("issue=wait_for_archive_size_or_warning, expected_size=~p, log=~p",
                    [ExpectedSize, Reason])
     end.
@@ -811,12 +817,15 @@ wait_for_archive_size_or_warning(Server, Username, ExpectedSize) ->
 wait_for_room_archive_size(Server, Username, ExpectedSize) ->
     try mongoose_helper:wait_until(fun() -> room_archive_size(Server, Username) end,
                                    ExpectedSize,
-                                   #{time_left => timer:seconds(20)}) of
+                                   #{
+                                     time_left => timer:seconds(20),
+                                     name => room_archive_size
+                                    }) of
         {ok, ExpectedSize} ->
             ExpectedSize
     catch
-        Error:Reason ->
-            ct:pal("issue=wait_for_archive_size_or_warning, expected_size=~p, log=~p",
+        _Error:Reason ->
+            ct:pal("issue=wait_for_room_archive_size, expected_size=~p, log=~p",
                    [ExpectedSize, Reason])
     end.
 

--- a/big_tests/tests/metrics_register_SUITE.erl
+++ b/big_tests/tests/metrics_register_SUITE.erl
@@ -30,7 +30,6 @@
 -import(metrics_helper, [assert_counter/2,
                          get_counter_value/1]).
 
--import(mongoose_helper, [factor_backoff/3]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -95,14 +94,10 @@ register(Config) ->
 
     Alice = escalus_users:get_user_by_name(alice),
     escalus_users:create_user(Config, Alice),
-
-    factor_backoff(fun() -> assert_counter(Registarations + 1, modRegisterCount) end,
+    mongoose_helper:wait_until(fun() -> assert_counter(Registarations + 1, modRegisterCount) end,
                    {value, Registarations + 1},
-                   #{
-                             attempts => 10,
-                             min_time => 30,
-                             max_time => 150
-                            }
+                   1000,
+                   100
                   ).
 
 
@@ -111,12 +106,8 @@ unregister(Config) ->
 
     Alice = escalus_users:get_user_by_name(alice),
     escalus_users:delete_user(Config, Alice),
-
-    factor_backoff(fun() -> assert_counter(Deregistarations + 1, modUnregisterCount) end,
-                   {value, Deregistarations + 1},
-                   #{
-                             attempts => 10,
-                             min_time => 30,
-                             max_time => 150
-                            }
-                  ).
+    mongoose_helper:wait_until(fun() ->
+                                       assert_counter(Deregistarations + 1, modUnregisterCount) end,
+                               {value, Deregistarations + 1},
+                               1000,
+                               100).

--- a/big_tests/tests/metrics_register_SUITE.erl
+++ b/big_tests/tests/metrics_register_SUITE.erl
@@ -90,24 +90,27 @@ end_per_testcase(_CaseName, Config) ->
 %%--------------------------------------------------------------------
 
 register(Config) ->
-    {value, Registarations} = get_counter_value(modRegisterCount),
+    {value, Registrations} = get_counter_value(modRegisterCount),
 
     Alice = escalus_users:get_user_by_name(alice),
     escalus_users:create_user(Config, Alice),
-    mongoose_helper:wait_until(fun() -> assert_counter(Registarations + 1, modRegisterCount) end,
-                   {value, Registarations + 1},
-                   1000,
-                   100
-                  ).
-
+    wait_for_registrations(Registrations + 1).
 
 unregister(Config) ->
-    {value, Deregistarations} = get_counter_value(modUnregisterCount),
+    {value, Deregistrations} = get_counter_value(modUnregisterCount),
 
     Alice = escalus_users:get_user_by_name(alice),
     escalus_users:delete_user(Config, Alice),
-    mongoose_helper:wait_until(fun() ->
-                                       assert_counter(Deregistarations + 1, modUnregisterCount) end,
-                               {value, Deregistarations + 1},
-                               1000,
-                               100).
+    wait_for_deregistrations(Deregistrations + 1).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+wait_for_registrations(Count) ->
+    mongoose_helper:wait_until(fun() -> assert_counter(Count, modRegisterCount) end,
+                               {value, Count}).
+
+wait_for_deregistrations(Count) ->
+    mongoose_helper:wait_until(fun() -> assert_counter(Count, modUnregisterCount) end,
+                               {value, Count}).

--- a/big_tests/tests/metrics_register_SUITE.erl
+++ b/big_tests/tests/metrics_register_SUITE.erl
@@ -109,8 +109,10 @@ unregister(Config) ->
 
 wait_for_registrations(Count) ->
     mongoose_helper:wait_until(fun() -> assert_counter(Count, modRegisterCount) end,
-                               {value, Count}).
+                               {value, Count},
+                               #{name => assert_counter}).
 
 wait_for_deregistrations(Count) ->
     mongoose_helper:wait_until(fun() -> assert_counter(Count, modUnregisterCount) end,
-                               {value, Count}).
+                               {value, Count},
+                               #{name => assert_counter}).

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -24,6 +24,8 @@
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("exml/include/exml.hrl").
 
+-define(HOSTS_REFRESH_INTERVAL, 200). %% in ms
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -313,13 +313,19 @@ test_advertised_endpoints_override_endpoints(Config) ->
 %% Also actually verifies that refresher properly reads host list
 %% from backend and starts appropriate pool.
 test_host_refreshing(_Config) ->
-    mongoose_helper:wait_until(fun() -> trees_for_connections_present() end, 2, ?HOSTS_REFRESH_INTERVAL),
+    mongoose_helper:wait_until(fun() -> trees_for_connections_present() end, 
+                               true,
+                               1000, 
+                               ?HOSTS_REFRESH_INTERVAL),
     ConnectionSups = out_connection_sups(asia_node),
     {europe_node1, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
     EuropeSup = rpc(asia_node, mod_global_distrib_utils, server_to_sup_name, [list_to_binary(EuropeHost)]),
     {_, EuropePid, supervisor, _} = lists:keyfind(EuropeSup, 1, ConnectionSups),
     erlang:exit(EuropePid, kill), % it's ok to kill temporary process
-    mongoose_helper:wait_until(fun() -> tree_for_sup_present(asia_node, EuropeSup) end, 2, ?HOSTS_REFRESH_INTERVAL).
+    mongoose_helper:wait_until(fun() -> tree_for_sup_present(asia_node, EuropeSup) end, 
+                               true,
+                               400, 
+                               ?HOSTS_REFRESH_INTERVAL).
 
 %% When run in mod_global_distrib group - tests simple case of connection
 %% between two users connected to different clusters.
@@ -737,7 +743,7 @@ test_update_senders_host(Config) ->
               = fun() ->
                         rpc(asia_node, mod_global_distrib_mapping, for_jid, [AliceJid])
                 end,
-              mongoose_helper:wait_until(GetCachesFun, error, 10, 1000),
+              mongoose_helper:wait_until(GetCachesFun, error, 10000, 1000),
 
               %% TODO: Should prevent Redis refresher from executing for a moment,
               %%       as it may collide with this test.
@@ -772,7 +778,7 @@ test_update_senders_host_by_ejd_service(Config) ->
                          rpc(europe_node2, mod_global_distrib_mapping, for_jid, [EveJid])
                         }
                 end,
-              mongoose_helper:wait_until(GetCachesFun, {error, error}, 10, 1000),
+              mongoose_helper:wait_until(GetCachesFun, {error, error}, 10000, 1000),
 
               %% Component is connected to europe_node1
               %% but we force asia_node to connect to europe_node2 by hiding europe_node1
@@ -873,7 +879,9 @@ closed_connection_is_removed_from_disabled(_Config) ->
     restart_receiver(asia_node, [listen_endpoint(10001)]),
 
     mongoose_helper:wait_until(fun() -> get_outgoing_connections(europe_node1, <<"reg1">>) end,
-               {[], [], []}, 5, 1000).
+                               {[], [], []}, 
+                               5000, 
+                               1000).
 
 %%--------------------------------------------------------------------
 %% Test helpers

--- a/big_tests/tests/mod_http_upload_SUITE.erl
+++ b/big_tests/tests/mod_http_upload_SUITE.erl
@@ -1,4 +1,5 @@
 -module(mod_http_upload_SUITE).
+
 -compile(export_all).
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -276,14 +276,16 @@ wait_until(Fun, ExpectedValue) ->
 wait_until(Fun, ExpectedValue, Opts) ->
     Defaults = #{time_left => timer:seconds(5),
                  sleep_time => 100,
-                 history => []},
+                 history => [],
+                 name => badmatch},
     do_wait_until(Fun, ExpectedValue, maps:merge(Defaults, Opts)).
 
 do_wait_until(_Fun, _ExpectedValue, #{
                                       time_left := TimeLeft,
-                                      history := History
+                                      history := History,
+                                      name := Name
                                      }) when TimeLeft =< 0 ->
-    error({badmatch, History});
+    error({Name, History});
 
 do_wait_until(Fun, ExpectedValue, Opts) ->
     try Fun() of

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -266,8 +266,11 @@ logout_user(Config, User) ->
             end
     end.
 
-% @doc Waits `TimeLeft` for `Fun` to return `Expected Value`, then returns `ExpectedValue`
-% If no value is returned or the result doesn't match  `ExpetedValue` error is raised 
+%% @doc Waits `TimeLeft` for `Fun` to return `ExpectedValue`
+%% If the result of `Fun` matches `ExpectedValue`, returns {ok, ExpectedValue}
+%% If no value is returned or the result doesn't match `ExpectedValue`, returns one of the following:
+%% {Name, History}, if Opts as #{name => Name} is passed
+%% {timeout, History}, otherwise
 
 wait_until(Fun, ExpectedValue) ->
     wait_until(Fun, ExpectedValue, #{}).
@@ -277,7 +280,7 @@ wait_until(Fun, ExpectedValue, Opts) ->
     Defaults = #{time_left => timer:seconds(5),
                  sleep_time => 100,
                  history => [],
-                 name => badmatch},
+                 name => timeout},
     do_wait_until(Fun, ExpectedValue, maps:merge(Defaults, Opts)).
 
 do_wait_until(_Fun, _ExpectedValue, #{
@@ -285,7 +288,7 @@ do_wait_until(_Fun, _ExpectedValue, #{
                                       history := History,
                                       name := Name
                                      }) when TimeLeft =< 0 ->
-    error({Name, History});
+    error({Name, lists:reverse(History)});
 
 do_wait_until(Fun, ExpectedValue, Opts) ->
     try Fun() of

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -4339,7 +4339,7 @@ wait_for_room_to_be_stopped(Pid, Timeout) ->
     end.
 
 wait_for_hibernation(Pid) ->
-    mongoose_helper:wait_until(fun() -> is_hibernated(Pid) end, true).
+    mongoose_helper:wait_until(fun() -> is_hibernated(Pid) end, true, #{name => is_hibernated}).
 
 is_hibernated(Pid) ->
     CurrentFunction = rpc(mim(), erlang, process_info, [Pid, current_function]),

--- a/big_tests/tests/push_helper.erl
+++ b/big_tests/tests/push_helper.erl
@@ -80,5 +80,5 @@ wait_for_user_offline(Client) ->
                                                   escalus_utils:jid_to_lower(escalus_client:server(Client)),
                                                   escalus_utils:jid_to_lower(escalus_client:resource(Client)))
                                end,
-                              true,
-                              #{time_left => timer:seconds(20)}).
+                               true,
+                               #{time_left => timer:seconds(20), name => is_offline}).

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -14,7 +14,7 @@
         create_room/6
     ]).
 -import(escalus_ejabberd, [rpc/3]).
--import(push_helper, [enable_stanza/3, wait_for/2, become_unavailable/1]).
+-import(push_helper, [enable_stanza/3, become_unavailable/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -834,11 +834,7 @@ extract_state_name(SysStatus) ->
     proplists:get_value("StateName", FSMData).
 
 wait_until_disconnected(UserSpec) ->
-    mongoose_helper:wait_until(fun() ->
-                                       get_user_resources(UserSpec) =:= [] end,
-                               true,
-                               1000,
-                              200).
+    mongoose_helper:wait_until(fun() -> get_user_resources(UserSpec) =:= [] end, true).
 
 get_session_pid(UserSpec, Resource) ->
     {U, S} = get_us_from_spec(UserSpec),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -836,7 +836,9 @@ extract_state_name(SysStatus) ->
 wait_until_disconnected(UserSpec) ->
     mongoose_helper:wait_until(fun() ->
                                        get_user_resources(UserSpec) =:= [] end,
-                               5, 200).
+                               true,
+                               1000,
+                              200).
 
 get_session_pid(UserSpec, Resource) ->
     {U, S} = get_us_from_spec(UserSpec),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -834,7 +834,8 @@ extract_state_name(SysStatus) ->
     proplists:get_value("StateName", FSMData).
 
 wait_until_disconnected(UserSpec) ->
-    mongoose_helper:wait_until(fun() -> get_user_resources(UserSpec) =:= [] end, true).
+    mongoose_helper:wait_until(fun() -> get_user_resources(UserSpec) =:= [] end, true,
+                               #{name => get_user_resources}).
 
 get_session_pid(UserSpec, Resource) ->
     {U, S} = get_us_from_spec(UserSpec),

--- a/big_tests/tests/users_api_SUITE.erl
+++ b/big_tests/tests/users_api_SUITE.erl
@@ -103,6 +103,12 @@ wait_for_user_removal(false) ->
     ok;
 wait_for_user_removal(_) ->
     Domain = ct:get_config({hosts, mim, domain}),
-    mongoose_helper:wait_until(fun() -> rpc(mim(), ejabberd_auth_riak, get_vh_registered_users_number, [Domain]) end,
-                              0,
-			      #{ time_sleep => 500, time_left => 5000}).
+    try mongoose_helper:wait_until(fun() -> rpc(mim(), ejabberd_auth_riak, get_vh_registered_users_number, [Domain]) end, 0,
+                               #{ time_sleep => 500, time_left => 5000, name => rpc}) of
+	    {ok, 0} ->
+		    ok
+    catch	
+	_Error:Reason ->
+		ct:pal("~p", [Reason]),
+		ok
+    end.

--- a/big_tests/tests/users_api_SUITE.erl
+++ b/big_tests/tests/users_api_SUITE.erl
@@ -102,16 +102,7 @@ auth_modules() ->
 wait_for_user_removal(false) ->
     ok;
 wait_for_user_removal(_) ->
-    do_wait_for_user_removal(10).
-
-do_wait_for_user_removal(0) ->
-    ok;
-do_wait_for_user_removal(N) ->
     Domain = ct:get_config({hosts, mim, domain}),
-    case rpc(mim(), ejabberd_auth_riak, get_vh_registered_users_number, [Domain]) of
-        0 ->
-            ok;
-        _ ->
-            timer:sleep(500),
-            do_wait_for_user_removal(N-1)
-    end.
+    mongoose_helper:wait_until(fun() -> rpc(mim(), ejabberd_auth_riak, get_vh_registered_users_number, [Domain]) end,
+                              0,
+			      #{ time_sleep => 500, time_left => 5000}).


### PR DESCRIPTION
Refactor ```mongoose_helper:wait_until/{2,3}``` for simple and overridable interface and raplace as many as possible ```wait_for_SOMETHING``` functions in big tests

