### PR TITLE
Better packages versions

### DIFF
--- a/tools/generate_vsn.sh
+++ b/tools/generate_vsn.sh
@@ -27,8 +27,8 @@ echo_git_vsn() {
 }
 
 echo_file_vsn() {
-	FILE_VSN=`cat ${DIR}/../VERSION`
-    
+    FILE_VSN=`cat ${DIR}/../VERSION`
+
     if [ "$VSN_TYPE" == "tag" ]; then
         echo $FILE_VSN
     elif [ "$VSN_TYPE" == "commits" ]; then

--- a/tools/generate_vsn.sh
+++ b/tools/generate_vsn.sh
@@ -1,9 +1,48 @@
 #!/bin/bash
+
+# generate_vsn.sh [type]
+# type = describe | tag | commits
+#
+# Certain 'type' values will produce following results:
+# - With "describe" output being "3.0.0-233-g984dd6df7"...
+# - "tag" will return "3.0.0"
+# - "commits" will return "233"
+# "describe" is the default value
+#
+# With git information missing, contents of VERSION file
+# will be returned for "describe" and "tag"; "0" will be returned
+# for "commits".
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-GIT_VSN=`git describe --always --tags 2>/dev/null`
+VSN_TYPE=${1:-"describe"}
+
+echo_git_vsn() {
+    if [ "$VSN_TYPE" == "tag" ]; then
+        echo $LAST_TAG
+    elif [ "$VSN_TYPE" == "commits" ]; then
+        echo `git rev-list --count $LAST_TAG..HEAD 2>/dev/null`
+    else
+        echo `git describe --always --tags 2>/dev/null`
+    fi
+}
+
+echo_file_vsn() {
+	FILE_VSN=`cat ${DIR}/../VERSION`
+    
+    if [ "$VSN_TYPE" == "tag" ]; then
+        echo $FILE_VSN
+    elif [ "$VSN_TYPE" == "commits" ]; then
+        echo "0"
+    else
+        echo $FILE_VSN
+    fi
+}
+
+LAST_TAG=`git describe --tags --abbrev=0 2>/dev/null`
 
 if [ $? -eq 0 ]; then
-	echo $GIT_VSN
+    echo_git_vsn
 else
-	echo `cat ${DIR}/../VERSION`
+    echo_file_vsn
 fi
+

--- a/tools/pkg/files/build
+++ b/tools/pkg/files/build
@@ -3,7 +3,7 @@
 set -e
 
 VER=$1
-REVISION=${2:-1}
+REVISION=$2
 
 if [ x"$VER" == x"" ]; then
     echo "$0: which version to build?"
@@ -11,5 +11,5 @@ if [ x"$VER" == x"" ]; then
 fi
 
 cd /buildfiles
-bash ./script.sh ${VER} ${REVISION}
+bash -x ./script.sh ${VER} ${REVISION}
 cp -i mongooseim*.??? /packages/

--- a/tools/pkg/files/build
+++ b/tools/pkg/files/build
@@ -11,5 +11,5 @@ if [ x"$VER" == x"" ]; then
 fi
 
 cd /buildfiles
-bash -x ./script.sh ${VER} ${REVISION}
+bash ./script.sh ${VER} ${REVISION}
 cp -i mongooseim*.??? /packages/

--- a/tools/pkg/platforms/centos6/Dockerfile
+++ b/tools/pkg/platforms/centos6/Dockerfile
@@ -10,7 +10,7 @@ RUN rpm -ivh epel-release-6-8.noarch.rpm
 RUN wget http://packages.erlang-solutions.com/erlang-solutions-1.0-1.noarch.rpm
 RUN rpm -Uvh erlang-solutions-1.0-1.noarch.rpm
 RUN yum --setopt=obsoletes=0 install -y sudo telnet lsof vim gcc rpm-build rpm-sign make automake expat-devel \
-                   git devtoolset-4-gcc-c++ devtoolset-4-gcc kernel-devel openssl openssl-devel yum-utils chrpath unixODBC-devel esl-erlang-18.3-1 \
+                   git devtoolset-4-gcc-c++ devtoolset-4-gcc kernel-devel openssl openssl-devel yum-utils chrpath unixODBC-devel esl-erlang-19.3.6-1 \
  && yum clean all
 # Fix locale setup once packages are installed.
 # See https://github.com/CentOS/sig-cloud-instance-images/issues/71#issuecomment-266957519

--- a/tools/pkg/platforms/centos6/files/build/mongooseim.spec
+++ b/tools/pkg/platforms/centos6/files/build/mongooseim.spec
@@ -13,7 +13,7 @@ License: %{_license}
 Group: "Development/Languages"
 BuildArch: @ARCH@
 BuildRoot: %{_topdir}/BUILDROOT/%{name}-%{version}.@ARCH@
-BuildRequires:  esl-erlang <= 18.3
+BuildRequires:  esl-erlang >= 19.3
 BuildRequires:  expat-devel
 BuildRequires:	chrpath
 Requires(pre): shadow-utils

--- a/tools/pkg/platforms/centos6/files/build/script.sh
+++ b/tools/pkg/platforms/centos6/files/build/script.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 COMMIT=$1
-REV=$2
 set -e
 
 HOSTNAME=`hostname`
@@ -15,7 +14,9 @@ git clone ${MONGOOSEIM_REPO} mongooseim
 cd mongooseim
 git checkout ${COMMIT}
 
-VER=$(cat VERSION)
+VER=$(./tools/generate_vsn.sh tag)
+COMMITS_COUNT=$(./tools/generate_vsn.sh commits)
+REV=${2:-$((COMMITS_COUNT+1))}
 
 
 export ERL_TOP=`pwd`

--- a/tools/pkg/platforms/centos7/files/build/mongooseim.spec
+++ b/tools/pkg/platforms/centos7/files/build/mongooseim.spec
@@ -13,7 +13,7 @@ License: %{_license}
 Group: "Development/Languages"
 BuildArch: @ARCH@
 BuildRoot: %{_topdir}/BUILDROOT/%{name}-%{version}.@ARCH@
-BuildRequires:  esl-erlang >= 18.3, esl-erlang <= 20.3
+BuildRequires:  esl-erlang >= 19.3, esl-erlang <= 21.0
 BuildRequires:  expat-devel
 BuildRequires:	chrpath
 Requires(pre): shadow-utils

--- a/tools/pkg/platforms/centos7/files/build/script.sh
+++ b/tools/pkg/platforms/centos7/files/build/script.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 COMMIT=$1
-REV=$2
 set -e
 
 HOSTNAME=`hostname`
@@ -15,8 +14,9 @@ git clone ${MONGOOSEIM_REPO} mongooseim
 cd mongooseim
 git checkout ${COMMIT}
 
-VER=$(cat VERSION)
-
+VER=$(./tools/generate_vsn.sh tag)
+COMMITS_COUNT=$(./tools/generate_vsn.sh commits)
+REV=${2:-$((COMMITS_COUNT+1))}
 
 export ERL_TOP=`pwd`
 sudo groupadd mongooseim

--- a/tools/pkg/run
+++ b/tools/pkg/run
@@ -14,7 +14,7 @@ if [ x"$VERSION" = x"" ]; then
     VERSION=$(../../tools/generate_vsn.sh tag)
 fi
 
-#REVISION=${3:-$(($(../../tools/generate_vsn.sh commits) + 1))}
+REVISION=${3:-$(($(../../tools/generate_vsn.sh commits) + 1))}
 
 echo "Building package for"
 echo "    platform: $PLATFORM"

--- a/tools/pkg/run
+++ b/tools/pkg/run
@@ -11,10 +11,10 @@ PLATFORM=$1
 
 VERSION=$2
 if [ x"$VERSION" = x"" ]; then
-    VERSION=$(cat ../../VERSION)
+    VERSION=$(../../tools/generate_vsn.sh tag)
 fi
 
-REVISION=${3:-1}
+#REVISION=${3:-$(($(../../tools/generate_vsn.sh commits) + 1))}
 
 echo "Building package for"
 echo "    platform: $PLATFORM"


### PR DESCRIPTION
This PR addresses changes the way packages are versioned. With these changes `generate_vsn.sh` script is used instead of `VERSION` file contents. It makes building easier for everyone who builds packages from tags or branches but doesn't want to update `VERSION` every time.

Bonus: `centos6` package is built with OTP 19.3 now.