### PR TITLE
Timestamp support in mod_inbox

### DIFF
--- a/big_tests/tests/inbox.hrl
+++ b/big_tests/tests/inbox.hrl
@@ -1,0 +1,8 @@
+-record(conv, {
+          unread,
+          from,
+          to,
+          content = <<>>,
+          verify = fun(_C, _Stanza) -> ok end,
+          time_after
+         }).

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -4,8 +4,7 @@
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
-
--import(escalus_ejabberd, [rpc/3]).
+-include_lib("inbox.hrl").
 
 -export([all/0,
          groups/0,
@@ -17,6 +16,7 @@
          init_per_testcase/2,
          end_per_testcase/2]).
 %% tests
+-export([returns_valid_form/1]).
 -export([msg_sent_stored_in_inbox/1,
          user_has_empty_inbox/1,
          user_has_two_unread_messages/1,
@@ -24,8 +24,8 @@
          try_to_reset_unread_counter_with_bad_marker/1,
          user_has_two_conversations/1,
          msg_sent_to_offline_user/1,
-         msg_sent_to_not_existing_user/1,
-         simple_groupchat_stored_in_all_inbox/1,
+         msg_sent_to_not_existing_user/1]).
+-export([simple_groupchat_stored_in_all_inbox/1,
          advanced_groupchat_stored_in_all_inbox/1,
          groupchat_markers_one_reset/1,
          create_groupchat/1,
@@ -42,43 +42,52 @@
          unread_count_is_reset_after_sending_chatmarker/1,
          private_messages_are_handled_as_one2one/1
         ]).
+-export([timestamp_is_updated_on_new_message/1,
+         order_by_timestamp_ascending/1,
+         get_by_timestamp_range/1,
+         get_with_start_timestamp/1,
+         get_with_end_timestamp/1]).
 
--import(muc_helper, [foreach_occupant/3, foreach_recipient/2]).
--import(muc_light_helper, [bin_aff_users/1, aff_msg_verify_fun/1, gc_message_verify_fun/3, ver/1,
-                           lbin/1, room_bin_jid/1, verify_aff_bcast/2, verify_aff_bcast/3,
-                           verify_aff_users/2, kv_el/2, to_lus/2, stanza_create_room/3,
-                           create_room/6, stanza_aff_set/2, default_config/0]).
+-import(muc_light_helper, [room_bin_jid/1]).
+-import(inbox_helper, [
+                       check_inbox/2, check_inbox/4,
+                       clear_inbox_all/0,
+                       given_conversations_between/2
+                      ]).
 
--define(NS_ESL_INBOX, <<"erlang-solutions.com:xmpp:inbox:0">>).
 -define(ROOM, <<"testroom1">>).
 -define(ROOM2, <<"testroom2">>).
 -define(ROOM3, <<"testroom3">>).
 -define(ROOM4, <<"testroom4">>).
 -define(ROOM_MARKERS, <<"room_markers">>).
--define(MUC_DOMAIN, <<"muc.localhost">>).
--record(conv, {unread, from, to, content = <<>>, verify = fun(C, Stanza) -> ok end}).
--record(inbox, {total, convs = []}).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
 
 all() ->
-    case (not ct_helper:is_ct_running()) orelse is_odbc_enabled(domain()) of
-      true ->
-          tests();
-      false ->
-          {skip, require_odbc}
-    end.
+  case (not ct_helper:is_ct_running()) orelse is_odbc_enabled(inbox_helper:domain()) of
+    true ->
+      tests();
+    false ->
+      {skip, require_odbc}
+  end.
 
 tests() ->
   [
+      {group, generic},
       {group, one_to_one},
       {group, muclight},
-      {group, muc}
+      {group, muc},
+      {group, timestamps}
   ].
 
 groups() ->
     G = [
+         {generic, [sequence],
+          [
+           returns_valid_form
+          ]},
          {one_to_one, [sequence],
           [
            user_has_empty_inbox,
@@ -111,6 +120,14 @@ groups() ->
            unread_count_is_the_same_after_going_online_again,
            unread_count_is_reset_after_sending_chatmarker,
            private_messages_are_handled_as_one2one
+          ]},
+         {timestamps, [sequence],
+          [
+           timestamp_is_updated_on_new_message,
+           order_by_timestamp_ascending,
+           get_by_timestamp_range,
+           get_with_start_timestamp,
+           get_with_end_timestamp
           ]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
@@ -123,7 +140,7 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-  ok = dynamic_modules:ensure_modules(domain(), required_modules()),
+  ok = dynamic_modules:ensure_modules(inbox_helper:domain(), required_modules()),
   InboxOptions = inbox_opts(),
   Config1 = escalus:init_per_suite(Config),
   Config2 = [{inbox_opts, InboxOptions} | Config1],
@@ -146,15 +163,12 @@ inbox_opts() ->
    {groupchat, [muclight]},
    {markers, [displayed]}].
 
-domain() ->
-  ct:get_config({hosts, mim, domain}).
-
 muclight_domain() ->
-  Domain = domain(),
+  Domain = inbox_helper:domain(),
   <<"muclight.", Domain/binary>>.
 
 muc_domain() ->
-    Domain = domain(),
+    Domain = inbox_helper:domain(),
     <<"muc.", Domain/binary>>.
 
 end_per_suite(Config) ->
@@ -166,13 +180,14 @@ end_per_suite(Config) ->
   escalus:end_per_suite(Config1).
 
 init_per_group(one_to_one, Config) ->
-  reload_inbox_option(Config, groupchat, []);
+  inbox_helper:reload_inbox_option(Config, groupchat, []);
 init_per_group(muclight, Config) ->
-  reload_inbox_option(Config, groupchat, [muclight]),
-  create_room(?ROOM, muclight_domain(), alice, [bob, kate], Config, ver(1));
+  inbox_helper:reload_inbox_option(Config, groupchat, [muclight]),
+  muc_light_helper:create_room(?ROOM, muclight_domain(), alice,
+                               [bob, kate], Config, muc_light_helper:ver(1));
 init_per_group(muc, Config) ->
   muc_helper:load_muc(muc_domain()),
-  reload_inbox_option(Config, groupchat, [muc]);
+  inbox_helper:reload_inbox_option(Config, groupchat, [muc]);
 init_per_group(_GroupName, Config) ->
   Config.
 
@@ -185,29 +200,33 @@ end_per_group(_GroupName, Config) ->
 
 init_per_testcase(create_groupchat_no_affiliation_stored, Config) ->
   clear_inbox_all(),
-  reload_inbox_option(Config, aff_changes, false),
+  inbox_helper:reload_inbox_option(Config, aff_changes, false),
   escalus:init_per_testcase(create_groupchat_no_affiliation_stored, Config);
 init_per_testcase(groupchat_markers_one_reset, Config) ->
   clear_inbox_all(),
-  create_room(?ROOM_MARKERS, muclight_domain(), alice, [bob, kate], Config, ver(1)),
+  muc_light_helper:create_room(?ROOM_MARKERS, muclight_domain(), alice, [bob, kate],
+                               Config, muc_light_helper:ver(1)),
   escalus:init_per_testcase(groupchat_markers_one_reset, Config);
 init_per_testcase(leave_and_remove_conversation, Config) ->
   clear_inbox_all(),
-  create_room(?ROOM2, muclight_domain(), alice, [bob, kate], Config, ver(1)),
+  muc_light_helper:create_room(?ROOM2, muclight_domain(), alice, [bob, kate],
+                               Config, muc_light_helper:ver(1)),
   escalus:init_per_testcase(leave_and_remove_conversation, Config);
 init_per_testcase(leave_and_store_conversation, Config) ->
   clear_inbox_all(),
-  reload_inbox_option(Config, remove_on_kicked, false),
+  inbox_helper:reload_inbox_option(Config, remove_on_kicked, false),
   escalus:init_per_testcase(leave_and_store_conversation, Config);
 init_per_testcase(no_aff_stored_and_remove_on_kicked, Config) ->
-    clear_inbox_all(),
-    create_room(?ROOM3, muclight_domain(), alice, [bob, kate], Config, ver(1)),
-    reload_inbox_option(Config, [{remove_on_kicked, true}, {aff_changes, false}]),
-    escalus:init_per_testcase(no_aff_stored_and_remove_on_kicked, Config);
+  clear_inbox_all(),
+  muc_light_helper:create_room(?ROOM3, muclight_domain(), alice, [bob, kate],
+                               Config, muc_light_helper:ver(1)),
+  inbox_helper:reload_inbox_option(Config, [{remove_on_kicked, true}, {aff_changes, false}]),
+  escalus:init_per_testcase(no_aff_stored_and_remove_on_kicked, Config);
 init_per_testcase(no_stored_and_remain_after_kicked, Config) ->
   clear_inbox_all(),
-  create_room(?ROOM4, muclight_domain(), alice, [bob, kate], Config, ver(1)),
-  reload_inbox_option(Config, [{remove_on_kicked, false}, {aff_changes, true}]),
+  muc_light_helper:create_room(?ROOM4, muclight_domain(), alice, [bob, kate],
+                               Config, muc_light_helper:ver(1)),
+  inbox_helper:reload_inbox_option(Config, [{remove_on_kicked, false}, {aff_changes, true}]),
   escalus:init_per_testcase(no_stored_and_remain_after_kicked, Config);
 init_per_testcase(TC, Config)
   when TC =:= simple_groupchat_stored_in_all_inbox_muc;
@@ -227,27 +246,27 @@ init_per_testcase(CaseName, Config) ->
 
 end_per_testcase(groupchat_markers_one_reset, Config) ->
   clear_inbox_all(),
-  restore_inbox_option(Config),
+  inbox_helper:restore_inbox_option(Config),
   escalus:end_per_testcase(groupchat_markers_one_reset, Config);
 end_per_testcase(leave_and_remove_conversation, Config) ->
   clear_inbox_all(),
-  restore_inbox_option(Config),
+  inbox_helper:restore_inbox_option(Config),
   escalus:end_per_testcase(leave_and_remove_conversation, Config);
 end_per_testcase(create_groupchat_no_affiliation_stored, Config) ->
   clear_inbox_all(),
-  restore_inbox_option(Config),
+  inbox_helper:restore_inbox_option(Config),
   escalus:end_per_testcase(create_groupchat_no_affiliation_stored, Config);
 end_per_testcase(leave_and_store_conversation, Config) ->
   clear_inbox_all(),
-  restore_inbox_option(Config),
+  inbox_helper:restore_inbox_option(Config),
   escalus:end_per_testcase(leave_and_store_conversation, Config);
 end_per_testcase(no_aff_stored_and_remove_on_kicked, Config) ->
-    clear_inbox_all(),
-    restore_inbox_option(Config),
-    escalus:end_per_testcase(no_aff_stored_and_remove_on_kicked, Config);
+  clear_inbox_all(),
+  inbox_helper:restore_inbox_option(Config),
+  escalus:end_per_testcase(no_aff_stored_and_remove_on_kicked, Config);
 end_per_testcase(no_stored_and_remain_after_kicked, Config) ->
   clear_inbox_all(),
-  restore_inbox_option(Config),
+  inbox_helper:restore_inbox_option(Config),
   escalus:end_per_testcase(no_stored_and_remain_after_kicked, Config);
 end_per_testcase(msg_sent_to_not_existing_user, Config) ->
   Host = ct:get_config({hosts, mim, domain}),
@@ -264,7 +283,47 @@ end_per_testcase(CaseName, Config) ->
   escalus:end_per_testcase(CaseName, Config).
 
 
+%%--------------------------------------------------------------------
+%% Generic Inbox tests
+%%--------------------------------------------------------------------
 
+returns_valid_form(Config) ->
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
+        escalus:send(Alice, inbox_helper:get_inbox_form_stanza()),
+        ResIQ = escalus:wait_for_stanza(Alice),
+        InboxNS = inbox_helper:inbox_ns(),
+        #{ field_count := 4 } = Form = parse_form_iq(ResIQ),
+        #{ <<"FORM_TYPE">> := #{ type := <<"hidden">>,
+                                 value := InboxNS } } = Form,
+        #{ <<"start">> := #{ type := <<"text-single">> } } = Form,
+        #{ <<"end">> := #{ type := <<"text-single">> } } = Form,
+        #{ <<"order">> := #{ type := <<"list-single">>,
+                             value := <<"desc">>,
+                             options := OrderOptions } } = Form,
+        [<<"asc">>, <<"desc">>] = lists:sort(OrderOptions)
+      end).
+
+parse_form_iq(IQ) ->
+    FieldsEls = exml_query:paths(IQ, [{element, <<"query">>},
+                                      {element, <<"x">>},
+                                      {element, <<"field">>}]),
+    lists:foldl(fun parse_form_field/2, #{ field_count => length(FieldsEls) }, FieldsEls).
+
+parse_form_field(FieldEl, Acc0) ->
+    Var = exml_query:attr(FieldEl, <<"var">>),
+    Type = exml_query:attr(FieldEl, <<"type">>),
+    Value = exml_query:path(FieldEl, [{element, <<"value">>}, cdata]),
+    Info0 = #{ type => Type, value => Value },
+    Info1 = 
+    case Type of
+        <<"list-single">> ->
+            Info0#{ options => exml_query:paths(FieldEl, [{element, <<"option">>},
+                                                          {element, <<"value">>},
+                                                          cdata]) };
+        _ ->
+            Info0
+    end,
+    Acc0#{ Var => Info1 }.
 
 %%--------------------------------------------------------------------
 %% Inbox tests one-to-one
@@ -272,116 +331,86 @@ end_per_testcase(CaseName, Config) ->
 
 user_has_empty_inbox(Config) ->
   escalus:story(Config, [{kate, 1}], fun(Kate) ->
-    Stanza = get_inbox_stanza(),
+    Stanza = inbox_helper:get_inbox_stanza(),
     %% Kate logs in for first time and ask for inbox
     escalus:send(Kate, Stanza),
     [ResIQ] = escalus:wait_for_stanzas(Kate, 1),
     true = escalus_pred:is_iq_result(ResIQ),
     %% Inbox is empty
-    TotalCount = get_inbox_count(ResIQ),
+    TotalCount = inbox_helper:get_inbox_count(ResIQ),
     0 = TotalCount
                                      end).
 
-
 msg_sent_stored_in_inbox(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-    Msg1 = escalus_stanza:chat_to(Bob, <<"Hello">>),
-    BobJid = lbin(escalus_client:full_jid(Bob)),
-    AliceJid = lbin(escalus_client:full_jid(Alice)),
-    %% Alice sends msg to Bob
-    escalus:send(Alice, Msg1),
-    M = escalus:wait_for_stanza(Bob),
-    escalus:assert(is_chat_message, M),
-    %% Both check inbox
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceJid, to = BobJid, content = <<"Hello">>}]}),
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceJid, to = BobJid, content = <<"Hello">>}]})
-                                                end).
+      #{ Alice := AliceConvs, Bob := BobConvs } = given_conversations_between(Alice, [Bob]),
+
+      %% Both check inbox
+      check_inbox(Alice, AliceConvs),
+      check_inbox(Bob, BobConvs)
+    end).
 
 user_has_two_conversations(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
-    Msg1 = escalus_stanza:chat_to(Bob, <<"Hello Bob">>),
-    Msg2 = escalus_stanza:chat_to(Kate, <<"Hello Kate">>),
-    BobJid = lbin(escalus_client:full_jid(Bob)),
-    AliceJid = lbin(escalus_client:full_jid(Alice)),
-    KateJid = lbin(escalus_client:full_jid(Kate)),
-    %% Alice sends messages to Bob and Kate
-    escalus:send(Alice, Msg1),
-    escalus:send(Alice, Msg2),
-    M1 = escalus:wait_for_stanza(Bob),
-    M2 = escalus:wait_for_stanza(Kate),
-    escalus:assert(is_chat_message, M1),
-    escalus:assert(is_chat_message, M2),
-    %% Alice has two conversations in her inbox (no unread messages)
-    check_inbox(Alice, #inbox{
-      total = 2,
-      convs =
-      [#conv{unread = 0, from = AliceJid, to = BobJid, content = <<"Hello Bob">>},
-        #conv{unread = 0, from = AliceJid, to = KateJid, content = <<"Hello Kate">>}]}),
-    %% Kate has one conversation with one unread
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceJid, to = KateJid, content = <<"Hello Kate">>}]}),
-    %% Bob has one conversation with one unread
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceJid, to = BobJid, content = <<"Hello Bob">>}]})
+      #{ Alice := AliceConvs, Bob := BobConvs, Kate := KateConvs } =
+      given_conversations_between(Alice, [Bob, Kate]),
 
-                                                           end).
+      %% Alice has two conversations in her inbox (no unread messages)
+      check_inbox(Alice, AliceConvs),
+      
+      %% Kate has one conversation with one unread
+      check_inbox(Kate, KateConvs),
+      
+      %% Bob has one conversation with one unread
+      check_inbox(Bob, BobConvs)
+    end).
 
 msg_sent_to_offline_user(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
     %% Bob goes offline
     mongoose_helper:logout_user(Config, Bob),
-    Msg1 = escalus_stanza:chat_to(Bob, <<"test">>),
-    BobJid = lbin(escalus_client:full_jid(Bob)),
-    AliceJid = lbin(escalus_client:full_jid(Alice)),
+    
     %% Alice sends a message to Bob
+    Msg1 = escalus_stanza:chat_to(Bob, <<"test">>),
     escalus:send(Alice, Msg1),
+    
     %% Bob goes online again
     {ok, NewBob} = escalus_client:start(Config, bob, <<"new-session">>),
     escalus:send(NewBob, escalus_stanza:presence(<<"available">>)),
     Stanzas = escalus:wait_for_stanzas(NewBob, 2),
+    
     escalus_new_assert:mix_match
     ([is_presence, fun(Stanza) -> escalus_pred:is_chat_message(<<"test">>, Stanza) end],
       Stanzas),
+    
     %% Alice has conversation
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceJid, to = BobJid, content = <<"test">>}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = Alice, to = Bob, content = <<"test">>}]),
+    
     %% Both check inbox and has a conversation
-    check_inbox(NewBob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceJid, to = BobJid, content = <<"test">>}]})
+    check_inbox(NewBob, [#conv{unread = 1, from = Alice, to = Bob, content = <<"test">>}])
                                                 end).
 
 msg_sent_to_not_existing_user(Config) ->
   escalus:story(Config, [{alice, 1}], fun(Alice) ->
-    Msg1 = escalus_stanza:chat_to(<<"not_existing_user@localhost">>, <<"test2">>),
-    AliceJid = lbin(escalus_client:full_jid(Alice)),
     %% Alice sends message to user that doesnt exist
+    Msg1 = escalus_stanza:chat_to(<<"not_existing_user@localhost">>, <<"test2">>),
     escalus:send(Alice, Msg1),
+
     %% Alice receives error
     ServiceUnavailable = escalus:wait_for_stanza(Alice),
     escalus_pred:is_error(<<"cancel">>,<<"service-unavailable">>, ServiceUnavailable),
+
     %% Alice has this conversation in inbox.
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0,
-                     from = AliceJid,
-                     to = <<"not_existing_user@localhost">>,
-                     content = <<"test2">>}]})
+    check_inbox(Alice,[#conv{unread = 0,
+                             from = Alice,
+                             to = <<"not_existing_user@localhost">>,
+                             content = <<"test2">>}])
                                       end).
 
 user_has_two_unread_messages(Config) ->
   escalus:story(Config, [{kate, 1}, {mike, 1}], fun(Kate, Mike) ->
     Msg1 = escalus_stanza:chat_to(Mike, <<"Hello">>),
     Msg2 = escalus_stanza:chat_to(Mike, <<"How are you">>),
-    KateJid = lbin(escalus_client:full_jid(Kate)),
-    MikeJid = lbin(escalus_client:full_jid(Mike)),
     %% Kate sends 2 messages to Mike
     escalus:send(Kate, Msg1),
     escalus:send(Kate, Msg2),
@@ -389,59 +418,43 @@ user_has_two_unread_messages(Config) ->
     escalus:assert(is_chat_message, M1),
     escalus:assert(is_chat_message, M2),
     %% Mike has two unread messages in conversation with Kate
-    check_inbox(Mike, #inbox{
-      total = 1,
-      convs = [#conv{unread = 2, from = KateJid, to = MikeJid, content = <<"How are you">>}]}),
+    check_inbox(Mike, [#conv{unread = 2, from = Kate, to = Mike, content = <<"How are you">>}]),
     %% Kate has one conv in her inbox (no unread messages)
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = KateJid, to = MikeJid, content = <<"How are you">>}]})
+    check_inbox(Kate, [#conv{unread = 0, from = Kate, to = Mike, content = <<"How are you">>}])
                                                 end).
 
 reset_unread_counter(Config) ->
   escalus:story(Config, [{kate, 1}, {mike, 1}], fun(Kate, Mike) ->
     MsgId =  <<"123123">>,
     Msg1 = escalus_stanza:set_id(escalus_stanza:chat_to(Mike, <<"Hi mike">>), MsgId),
-    KateJid = lbin(escalus_client:full_jid(Kate)),
-    MikeJid = lbin(escalus_client:full_jid(Mike)),
     %% Kate sends message to Mike
     escalus:send(Kate, Msg1),
     M1 = escalus:wait_for_stanza(Mike),
     escalus:assert(is_chat_message, M1),
     %% Mike has one unread message
-    check_inbox(Mike, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = KateJid, to = MikeJid, content = <<"Hi mike">>}]}),
-    ChatMarker = escalus_stanza:chat_marker(KateJid, <<"displayed">>, MsgId),
+    check_inbox(Mike, [#conv{unread = 1, from = Kate, to = Mike, content = <<"Hi mike">>}]),
+    ChatMarker = escalus_stanza:chat_marker(Kate, <<"displayed">>, MsgId),
     %% Mike sends "displayed" chat marker to Kate
     escalus:send(Mike, ChatMarker),
     %% Now Mike asks for inbox second time. He has 0 unread messages now
-    check_inbox(Mike, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = KateJid, to = MikeJid, content = <<"Hi mike">>}]})
+    check_inbox(Mike, [#conv{unread = 0, from = Kate, to = Mike, content = <<"Hi mike">>}])
                                                 end).
 
 try_to_reset_unread_counter_with_bad_marker(Config) ->
   escalus:story(Config, [{kate, 1}, {mike, 1}], fun(Kate, Mike) ->
     Msg1 = escalus_stanza:set_id(escalus_stanza:chat_to(Mike, <<"okey dockey">>), <<"111">>),
-    KateJid = lbin(escalus_client:full_jid(Kate)),
-    MikeJid = lbin(escalus_client:full_jid(Mike)),
     %% Kate sends message to Mike
     escalus:send(Kate, Msg1),
     M1 = escalus:wait_for_stanza(Mike),
     escalus:assert(is_chat_message, M1),
     %% Mike has one unread message
-    check_inbox(Mike, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = KateJid, to = MikeJid, content = <<"okey dockey">>}]}),
+    check_inbox(Mike, [#conv{unread = 1, from = Kate, to = Mike, content = <<"okey dockey">>}]),
     MsgId = <<"badId">>,
-    ChatMarker = escalus_stanza:chat_marker(KateJid, <<"displayed">>, MsgId),
+    ChatMarker = escalus_stanza:chat_marker(Kate, <<"displayed">>, MsgId),
     %% Mike sends "displayed" chat marker but 'id' field is wrong
     escalus:send(Mike, ChatMarker),
     %% Now Mike asks for inbox second time. Unread count should be still the same
-    check_inbox(Mike, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = KateJid, to = MikeJid, content = <<"okey dockey">>}]})
+    check_inbox(Mike, [#conv{unread = 1, from = Kate, to = Mike, content = <<"okey dockey">>}])
                                                 end).
 
 %%--------------------------------------------------------------------
@@ -452,9 +465,9 @@ simple_groupchat_stored_in_all_inbox(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
-    BobJid = lbin(escalus_client:short_jid(Bob)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    KateJid = inbox_helper:to_bare_lower(Kate),
+    BobJid = inbox_hlper:to_bare_lower(Bob),
     RoomJid = room_bin_jid(?ROOM),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Stanza = escalus_stanza:set_id(
@@ -468,16 +481,10 @@ simple_groupchat_stored_in_all_inbox(Config) ->
     escalus:assert(is_groupchat_message, R1),
     escalus:assert(is_groupchat_message, R2),
     %% Alice has 0 unread messages
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
     %% Bob and Kate have one conv with 1 unread message
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]})
+    check_inbox(Bob, [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}])
                                                            end).
 
 advanced_groupchat_stored_in_all_inbox(Config) ->
@@ -485,9 +492,9 @@ advanced_groupchat_stored_in_all_inbox(Config) ->
     Msg1 = <<"Hi Room!">>,
     Msg2 = <<"How are you?">>,
     Id = <<"MyID">>,
-    BobJid = lbin(escalus_client:short_jid(Bob)),
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
+    BobJid = inbox_helper:to_bare_lower(Bob),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     RoomJid = room_bin_jid(?ROOM),
     BobRoomJid = <<RoomJid/binary,"/", BobJid/binary>>,
     Stanza1 = escalus_stanza:set_id(
@@ -511,24 +518,18 @@ advanced_groupchat_stored_in_all_inbox(Config) ->
     escalus:assert(is_groupchat_message, R4),
     escalus:assert(is_groupchat_message, R5),
     %% Alice have one unread message (from Bob)
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg2}]}),
+    check_inbox(Alice, [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg2}]),
     %% Bob has 0 unread messages because he sent the last message
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg2}]}),
+    check_inbox(Bob, [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg2}]),
     %% Kate has 2 unread messages (from Alice and Bob)
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 2, from = BobRoomJid, to = KateJid, content = Msg2}]})
+    check_inbox(Kate, [#conv{unread = 2, from = BobRoomJid, to = KateJid, content = Msg2}])
                                                            end).
 
 groupchat_markers_one_reset(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    BobJid = lbin(escalus_client:short_jid(Bob)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    BobJid = inbox_helper:to_bare_lower(Bob),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     RoomJid = room_bin_jid(?ROOM_MARKERS),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Id = <<"markerId">>,
@@ -541,24 +542,22 @@ groupchat_markers_one_reset(Config) ->
     escalus:assert(is_groupchat_message, R0),
     escalus:assert(is_groupchat_message, R1),
     escalus:assert(is_groupchat_message, R2),
-    ChatMarker = set_type(escalus_stanza:chat_marker(RoomJid,<<"displayed">>, Id), <<"groupchat">>),
+    ChatMarkerWOType = escalus_stanza:chat_marker(RoomJid,<<"displayed">>, Id),
+    ChatMarker = escalus_stanza:setattr(ChatMarkerWOType, <<"type">>, <<"groupchat">>),
     %% User marks last message
     escalus:send(Bob, ChatMarker),
     %% participants receive marker
-    foreach_recipient([Alice, Bob, Kate], fun(Marker) ->
+    muc_helper:foreach_recipient([Alice, Bob, Kate], fun(Marker) ->
       true = escalus_pred:is_chat_marker(<<"displayed">>, Id, Marker) end),
     %% Bob has 0 unread messages because he reset his counter
-    check_inbox(Bob, #inbox{
-        total = 1,
-        convs = [#conv{unread = 0, from = AliceRoomJid, to = BobJid, content = <<"marker time!">>}]}),
+    check_inbox(Bob, [#conv{unread = 0, from = AliceRoomJid,
+                            to = BobJid, content = <<"marker time!">>}]),
     %% Alice has 0 unread messages because she was the sender
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = <<"marker time!">>}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid,
+                              to = AliceJid, content = <<"marker time!">>}]),
     %% Kate still has unread message
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = <<"marker time!">>}]})
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid,
+                             to = KateJid, content = <<"marker time!">>}])
                                                            end).
 
 %% this test combines options:
@@ -568,7 +567,7 @@ groupchat_markers_one_reset(Config) ->
 create_groupchat(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     RoomNode = <<"bobroom">>,
-    create_room_and_check_inbox(Bob, [Alice, Kate], RoomNode)
+    inbox_helper:create_room_and_check_inbox(Bob, [Alice, Kate], RoomNode)
                                                            end).
 
 
@@ -584,24 +583,18 @@ create_groupchat_no_affiliation_stored(Config) ->
     InitConfig = [{<<"roomname">>, <<"Bob's room2">>}],
     RoomNode = <<"bobroom2">>,
     RoomJid = room_bin_jid(RoomNode),
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
-    BobJid = lbin(escalus_client:short_jid(Bob)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
+    BobJid = inbox_helper:to_bare_lower(Bob),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     %% Bob creates room
-    escalus:send(Bob, stanza_create_room(RoomNode, InitConfig, InitOccupants)),
-    verify_aff_bcast(FinalOccupants, FinalOccupants),
+    escalus:send(Bob, muc_light_helper:stanza_create_room(RoomNode, InitConfig, InitOccupants)),
+    muc_light_helper:verify_aff_bcast(FinalOccupants, FinalOccupants),
     escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
     %% affiliation change messages are not stored in inbox
-    check_inbox(Alice, #inbox{
-      total = 0,
-      convs = []}),
-    check_inbox(Bob, #inbox{
-      total = 0,
-      convs = []}),
-    check_inbox(Kate, #inbox{
-      total = 0,
-      convs = []}),
+    check_inbox(Alice, []),
+    check_inbox(Bob, []),
+    check_inbox(Kate, []),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomJid, Msg), <<"123">>),
     %% Alice sends a message
@@ -613,16 +606,10 @@ create_groupchat_no_affiliation_stored(Config) ->
     escalus:assert(is_groupchat_message, R1),
     escalus:assert(is_groupchat_message, R2),
     %% Alice has 0 unread because she sent the last message
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
     %% Bob and Kate have one unread message
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]})
+    check_inbox(Bob, [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}])
                                                            end).
 
 
@@ -634,8 +621,8 @@ leave_and_remove_conversation(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     RoomJid = room_bin_jid(?ROOM2),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Stanza = escalus_stanza:set_id(
@@ -651,14 +638,10 @@ leave_and_remove_conversation(Config) ->
     %% Bob leaves the room
     muc_light_helper:user_leave(?ROOM2, Bob, [{Alice, owner}, {Kate, member}]),
     %% Alice and Kate have one message
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]),
     %% Bob doesn't have conversation in his inbox
-    check_inbox(Bob, #inbox{total = 0, convs = []})
+    check_inbox(Bob, [])
                                                            end).
 
 %% this test combines options:
@@ -668,27 +651,24 @@ leave_and_remove_conversation(Config) ->
 leave_and_store_conversation(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     RoomName = <<"kicking-room">>,
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    BobJid = lbin(escalus_client:short_jid(Bob)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    BobJid = inbox_helper:to_bare_lower(Bob),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     RoomJid = room_bin_jid(RoomName),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Msg = <<"Hi all">>,
     %% Alice creates a room and send msg
-    create_room_send_msg_check_inbox(Alice, [Bob, Kate], RoomName, Msg, <<"leave-id">>),
+    inbox_helper:create_room_send_msg_check_inbox(Alice, [Bob, Kate], RoomName,
+                                                  Msg, <<"leave-id">>),
     %% Bob leaves room
     muc_light_helper:user_leave(RoomName, Bob, [{Alice, owner}, {Kate, member}]),
     %% Alice and Kate have conversation
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]}),
-    %% Bob still has a conversation in inbox. Two unread - first is invitation, the second is the leaving affiliation
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 2, from = RoomJid, to = BobJid, verify = fun verify_is_none_aff_change/2}]})
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]),
+    %% Bob still has a conversation in inbox. Two unread - first is invitation,
+    %% the second is the leaving affiliation
+    check_inbox(Bob, [#conv{unread = 2, from = RoomJid, to = BobJid,
+                            verify = fun inbox_helper:verify_is_none_aff_change/2}])
                                                            end).
 
 %% this test combines options:
@@ -697,8 +677,8 @@ leave_and_store_conversation(Config) ->
 %%{remove_on_kicked, true},
 no_aff_stored_and_remove_on_kicked(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     RoomJid = room_bin_jid(?ROOM3),
     AliceRoomJid = <<RoomJid/binary, "/", AliceJid/binary>>,
     Msg = <<"Hi all">>,
@@ -715,14 +695,10 @@ no_aff_stored_and_remove_on_kicked(Config) ->
     %% Bob leaves the room
     muc_light_helper:user_leave(?ROOM3, Bob, [{Alice, owner}, {Kate, member}]),
     %% Alice and Kate have message in groupchats
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]),
     %% Bob doesnt have a conversation in inbox
-    check_inbox(Bob, #inbox{total = 0, convs = []})
+    check_inbox(Bob, [])
                                                            end).
 
 
@@ -732,9 +708,9 @@ no_aff_stored_and_remove_on_kicked(Config) ->
 %%{remove_on_kicked, false},
 no_stored_and_remain_after_kicked(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
-    BobJid = lbin(escalus_client:short_jid(Bob)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
+    KateJid = inbox_helper:to_bare_lower(Kate),
+    BobJid = inbox_helper:to_bare_lower(Bob),
     RoomJid = room_bin_jid(?ROOM4),
     AliceRoomJid = <<RoomJid/binary, "/", AliceJid/binary>>,
     Msg = <<"Hi all">>,
@@ -751,17 +727,11 @@ no_stored_and_remain_after_kicked(Config) ->
     %% Bob leaves the room
     muc_light_helper:user_leave(?ROOM4, Bob, [{Alice, owner}, {Kate, member}]),
     %% Alice and Kate have message in groupchats
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]}),
+    check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]),
     %% Bob have a conversation in inbox. First unread is message from Alice, the second the affiliation change
-    check_inbox(Bob, #inbox{total = 1, convs = [#conv{unread = 2,
-                                                      from = RoomJid,
-                                                      to = BobJid,
-                                                      verify = fun verify_is_none_aff_change/2}]})
+    check_inbox(Bob, [#conv{ unread = 2, from = RoomJid, to = BobJid,
+                             verify = fun inbox_helper:verify_is_none_aff_change/2}])
                                                            end).
 
 
@@ -770,40 +740,34 @@ groupchat_markers_one_reset_room_created(Config) ->
     Msg = <<"Welcome guys">>,
     RoomName = <<"markers_room">>,
     RoomJid = room_bin_jid(RoomName),
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
-    BobJid = lbin(escalus_client:short_jid(Bob)),
-    KateJid = lbin(escalus_client:short_jid(Kate)),
-    create_room_send_msg_check_inbox(Alice, [Bob, Kate], RoomName, Msg, <<"1-id">>),
+    BobJid = inbox_helper:to_bare_lower(Bob),
+    KateJid = inbox_helper:to_bare_lower(Kate),
+    inbox_helper:create_room_send_msg_check_inbox(Alice, [Bob, Kate], RoomName, Msg, <<"1-id">>),
     %% Now Bob sends marker
-    mark_last_muclight_message(Bob, [Alice, Bob, Kate]),
+    inbox_helper:mark_last_muclight_message(Bob, [Alice, Bob, Kate]),
     %% The crew ask for inbox second time. Only Kate has unread messages
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]}),
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = AliceRoomJid, to = BobJid, content = Msg}]})
+    check_inbox(Alice,[#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
+    check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]),
+    check_inbox(Bob, [#conv{unread = 0, from = AliceRoomJid, to = BobJid, content = Msg}])
 
                                                            end).
 
 groupchat_markers_all_reset_room_created(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     RoomName = <<"markers_room2">>,
-    AliceJid = lbin(escalus_client:short_jid(Alice)),
+    AliceJid = inbox_helper:to_bare_lowe(Alice),
     RoomJid = room_bin_jid(RoomName),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Msg = <<"Mark me!">>,
-    create_room_send_msg_check_inbox(Alice, [Bob, Kate], RoomName, Msg, <<"2-id">>),
-    [mark_last_muclight_message(U, [Alice, Bob, Kate]) || U <- [Bob, Kate]],
-    foreach_check_inbox([Bob, Kate, Alice], 1, 0, AliceRoomJid, Msg)
+    inbox_helper:create_room_send_msg_check_inbox(Alice, [Bob, Kate], RoomName, Msg, <<"2-id">>),
+    [inbox_helper:mark_last_muclight_message(U, [Alice, Bob, Kate]) || U <- [Bob, Kate]],
+    inbox_helper:foreach_check_inbox([Bob, Kate, Alice], 0, AliceRoomJid, Msg)
                                                            end).
 
 %%--------------------------------------------------------------------
-%% legacy MUC tests
+%% Classic MUC tests
 %%--------------------------------------------------------------------
 
 simple_groupchat_stored_in_all_inbox_muc(Config) ->
@@ -812,28 +776,24 @@ simple_groupchat_stored_in_all_inbox_muc(Config) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
     Room = ?config(room, Config),
-    RoomAddr = muc_room_address(Room),
+    RoomAddr = muc_helper:room_address(Room),
 
-    enter_room(Room, Users),
-    make_members(Room, Alice, Users -- [Alice]),
+    inbox_helper:enter_room(Room, Users),
+    inbox_helper:make_members(Room, Alice, Users -- [Alice]),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
-    wait_for_groupchat_msg(Users),
-    [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, nick(Bob)),
+    inbox_helper:wait_for_groupchat_msg(Users),
+    [AliceJid, BobJid, KateJid] = lists:map(fun inbox_helper:to_bare_lower/1, Users),
+    BobRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Bob, [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
+    check_inbox(Alice,[#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
+    check_inbox(Kate, [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}],
+                #{}, #{case_sensitive => true})
     end).
 
 simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
@@ -842,30 +802,26 @@ simple_groupchat_stored_in_offline_users_inbox_muc(Config) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
     Room = ?config(room, Config),
-    RoomAddr = muc_room_address(Room),
+    RoomAddr = muc_helper:room_address(Room),
 
-    enter_room(Room, Users),
-    make_members(Room, Alice, Users -- [Alice]),
-    leave_room(Kate, Room, Users),
+    inbox_helper:enter_room(Room, Users),
+    inbox_helper:make_members(Room, Alice, Users -- [Alice]),
+    inbox_helper:leave_room(Kate, Room, Users),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
-    wait_for_groupchat_msg(Users -- [Kate]),
+    inbox_helper:wait_for_groupchat_msg(Users -- [Kate]),
 
-    [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, nick(Bob)),
+    [AliceJid, BobJid, KateJid] = lists:map(fun inbox_helper:to_bare_lower/1, Users),
+    BobRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Bob, [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
+    check_inbox(Alice, [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
+    check_inbox(Kate, [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}],
+                #{}, #{case_sensitive => true})
     end).
 
 
@@ -875,30 +831,26 @@ unread_count_is_the_same_after_going_online_again(Config) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
     Room = ?config(room, Config),
-    RoomAddr = muc_room_address(Room),
+    RoomAddr = muc_helper:room_address(Room),
 
-    enter_room(Room, Users),
-    make_members(Room, Alice, Users -- [Alice]),
-    leave_room(Kate, Room, Users),
+    inbox_helper:enter_room(Room, Users),
+    inbox_helper:make_members(Room, Alice, Users -- [Alice]),
+    inbox_helper:leave_room(Kate, Room, Users),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
-    wait_for_groupchat_msg(Users -- [Kate]),
-    enter_room(Room, Kate, Users -- [Kate], 1),
-    [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, nick(Bob)),
+    inbox_helper:wait_for_groupchat_msg(Users -- [Kate]),
+    inbox_helper:enter_room(Room, Kate, Users -- [Kate], 1),
+    [AliceJid, BobJid, KateJid] = lists:map(fun inbox_helper:to_bare_lower/1, Users),
+    BobRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Bob, [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
     %% Alice and Kate have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
+    check_inbox(Alice, [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
+    check_inbox(Kate, [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}],
+                #{}, #{case_sensitive => true})
     end).
 
 unread_count_is_reset_after_sending_chatmarker(Config) ->
@@ -907,34 +859,31 @@ unread_count_is_reset_after_sending_chatmarker(Config) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
     Room = ?config(room, Config),
-    RoomAddr = muc_room_address(Room),
+    RoomAddr = muc_helper:room_address(Room),
 
-    enter_room(Room, Users),
-    make_members(Room, Alice, Users -- [Alice]),
+    inbox_helper:enter_room(Room, Users),
+    inbox_helper:make_members(Room, Alice, Users -- [Alice]),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
     escalus:send(Bob, Stanza),
-    wait_for_groupchat_msg(Users),
-    ChatMarker = set_type(escalus_stanza:chat_marker(RoomAddr, <<"displayed">>, Id), <<"groupchat">>),
+    inbox_helper:wait_for_groupchat_msg(Users),
+    ChatMarkerWOType = escalus_stanza:chat_marker(RoomAddr, <<"displayed">>, Id),
+    ChatMarker = escalus_stanza:setattr(ChatMarkerWOType, <<"type">>, <<"groupchat">>),
     %% User marks last message
     escalus:send(Kate, ChatMarker),
-    wait_for_groupchat_msg(Users),
+    inbox_helper:wait_for_groupchat_msg(Users),
 
-    [AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
-    BobRoomJid = muc_room_address(Room, nick(Bob)),
+    [AliceJid, BobJid, KateJid] = lists:map(fun inbox_helper:to_bare_lower/1, Users),
+    BobRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Bob)),
     %% Bob has 0 unread messages
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = BobJid,
-                     content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Bob, [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
     %% Alice have one conv with 1 unread message
-    check_inbox(Alice, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Alice, [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
     %% Kate has 0 unread messages
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}]}, #{case_sensitive => true})
+    check_inbox(Kate, [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}],
+                #{}, #{case_sensitive => true})
     end).
 
 private_messages_are_handled_as_one2one(Config) ->
@@ -943,394 +892,111 @@ private_messages_are_handled_as_one2one(Config) ->
     Msg = <<"Hi Room!">>,
     Id = <<"MyID">>,
     Room = ?config(room, Config),
-    RoomAddr = muc_room_address(Room),
-    BobRoomJid = muc_room_address(Room, nick(Bob)),
-    KateRoomJid = muc_room_address(Room, nick(Kate)),
+    BobRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Bob)),
+    KateRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Kate)),
 
-    enter_room(Room, Users),
-    make_members(Room, Alice, Users -- [Alice]),
+    inbox_helper:enter_room(Room, Users),
+    inbox_helper:make_members(Room, Alice, Users -- [Alice]),
     Stanza = escalus_stanza:set_id(
       escalus_stanza:chat_to(BobRoomJid, Msg), Id),
     escalus:send(Kate, Stanza),
-    BobsPrivMsg = escalus:wait_for_stanza(Bob),
+    _BobsPrivMsg = escalus:wait_for_stanza(Bob),
 
-    [_AliceJid, BobJid, KateJid] = lists:map(fun to_bare_lower/1, Users),
+    KateJid = inbox_helper:to_bare_lower(Kate),
     %% Bob has 1 unread message
-    check_inbox(Bob, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1, from = KateRoomJid, to = BobRoomJid,
-                     content = Msg}]}, #{case_sensitive => true}),
+    check_inbox(Bob, [#conv{unread = 1, from = KateRoomJid, to = BobRoomJid, content = Msg}],
+                #{}, #{case_sensitive => true}),
     %% Alice gets nothing
-    check_inbox(Alice, #inbox{
-      total = 0,
-      convs = []}),
+    check_inbox(Alice, []),
     %% Kate has 1 conv with 0 unread messages
-    check_inbox(Kate, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0, from = KateJid, to = BobRoomJid, content = Msg}]},
-                #{case_sensitive => true, check_resource => false})
+    check_inbox(Kate, [#conv{unread = 0, from = KateJid, to = BobRoomJid, content = Msg}],
+                #{}, #{case_sensitive => true, check_resource => false})
     end).
 
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Helpers
-
-leave_room(User, Room, Occupants) ->
-    UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
-    Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
-    escalus:send(User, Stanza),
-    lists:foreach(fun(User) -> A = escalus:wait_for_stanza(User) end,
-                  Occupants).
-
-wait_for_groupchat_msg(Users) ->
-    Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
-              Users),
-    lists:foreach(fun(Resp) -> escalus:assert(is_groupchat_message, Resp) end,
-                  Resps).
-
-
-to_bare_lower(User) ->
-    lbin(escalus_client:short_jid(User)).
-
-make_members(Room, Admin, Users) ->
-    Items = lists:map(fun(User) -> {escalus_utils:get_short_jid(User),<<"member">>} end,
-                      Users),
-    escalus:send(Admin, stanza_set_affiliations(Room, Items)),
-    SuccesResp = escalus:wait_for_stanzas(Admin, 1 + length(Users)), % gets iq result and affs changes from all users
-    lists:foreach(fun(User) -> escalus:wait_for_stanzas(User, length(Users)) end, Users). % Everybody gets aff changes of everybody
-
-% All users enter the room
-enter_room(Room, Users) ->
-    lists:foreach(fun(User) ->
-                          escalus:send(User, stanza_muc_enter_room(Room, nick(User))) end,
-                  Users),
-    lists:foreach(fun(User) ->
-                          escalus:wait_for_stanzas(User, length(Users) + 1) % everybody gets presence from everybody + a subject message
-                  end,
-                  Users).
-
-% `User` enters the room `Room` where `Users` are occupants
-enter_room(Room, User, Users, DelayedMessagesCount) ->
-    escalus:send(User, stanza_muc_enter_room(Room, nick(User))),
-    lists:foreach(fun(User) ->
-                          A = escalus:wait_for_stanza(User) end,
-                  Users),
-    escalus:wait_for_stanzas(User, length(Users) + 1 + 1 + DelayedMessagesCount). % User gets subject message and presences from everybody including himself
-
-
-stanza_set_affiliations(Room, List) ->
-    Payload = lists:map(fun aff_to_iq_item/1, List),
-    muc_helper:stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
-
-aff_to_iq_item({JID, Affiliation}) ->
-    #xmlel{name = <<"item">>,
-        attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}]}.
-
-nick(User) -> escalus_utils:get_username(User).
-
-
-
-stanza_muc_enter_room(Room, Nick) ->
-    stanza_to_room(
-        escalus_stanza:presence(<<"available">>,
-                                [#xmlel{name = <<"x">>,
-                                        attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}
-                                ]),
-        Room, Nick).
-
-stanza_to_room(Stanza, Room, Nick) ->
-    escalus_stanza:to(Stanza, muc_room_address(Room, Nick)).
-
-
-muc_room_address(Room) ->
-    RoomJid = <<Room/binary, $@, ?MUC_DOMAIN/binary>>.
-
-muc_room_address(Room, Nick) ->
-    RoomJid = <<Room/binary, $@, ?MUC_DOMAIN/binary, $/, Nick/binary>>.
-
-create_room_and_check_inbox(Owner, MemberList, RoomName) ->
-  InitOccupants = [{M, member} || M <- MemberList],
-  FinalOccupants = [{Owner, owner} | InitOccupants],
-  InitConfig = [{<<"roomname">>, <<"Just room name">>}],
-  OwnerJid = lbin(escalus_client:short_jid(Owner)),
-  MembersJids = [lbin(escalus_client:short_jid(M)) || M <- MemberList],
-  MemberAndJids = lists:zip(MemberList, MembersJids),
-  MembersAndOwner = [Owner | MemberList],
-  %% Owner creates room
-  escalus:send(Owner, stanza_create_room(RoomName, InitConfig, InitOccupants)),
-  verify_aff_bcast(FinalOccupants, FinalOccupants),
-  escalus:assert(is_iq_result, escalus:wait_for_stanza(Owner)),
-  %% check for the owner. Unread from owner is affiliation change to owner
-  check_inbox(Owner, #inbox{
-    total = 1,
-    convs = [#conv{unread = 1,
-                   from = room_bin_jid(RoomName),
-                   to = OwnerJid,
-                   verify = fun verify_is_owner_aff_change/2}]}),
-  %% check for the members. Every member has affiliation change to member
-  [check_inbox(Member, #inbox{
-      total = 1,
-      convs = [#conv{unread = 1,
-                     from = room_bin_jid(RoomName),
-                     to = Jid,
-                     verify = fun verify_is_member_aff_change/2}]})
-    || {Member, Jid} <- MemberAndJids],
-  %% Each room participant send chat marker
-  [begin mark_last_muclight_system_message(U, 1),
-         foreach_recipient(MembersAndOwner, fun(_Stanza) -> ok end) end || U <- MembersAndOwner],
-  %% counter is reset for owner
-  check_inbox(Owner, #inbox{
-    total = 1,
-    convs = [#conv{unread = 0,
-                   from = room_bin_jid(RoomName),
-                   to = OwnerJid,
-                   verify = fun verify_is_owner_aff_change/2}]}),
-  %% counter is reset for members
-  [check_inbox(Member, #inbox{
-      total = 1,
-      convs = [#conv{unread = 0,
-                     from = room_bin_jid(RoomName),
-                     to = Jid,
-                     verify = fun verify_is_member_aff_change/2}]})
-    || {Member, Jid} <- MemberAndJids].
-
-%% assume there is only one conversation
-mark_last_muclight_message(User, AllUsers) ->
-  mark_last_muclight_message(User, AllUsers, <<"displayed">>).
-
-
-mark_last_muclight_message(User, AllUsers, MarkerType) ->
-  %% User ask for inbox in order to get id of last message
-  GetInbox = get_inbox_stanza(),
-  escalus:send(User, GetInbox),
-  Stanza = escalus:wait_for_stanza(User),
-  ResIQ = escalus:wait_for_stanza(User),
-  1 = get_inbox_count(ResIQ),
-  [InnerMsg] = get_inner_msg(Stanza),
-  MsgId = exml_query:attr(InnerMsg, <<"id">>),
-  From = exml_query:attr(InnerMsg, <<"from">>),
-  FromBare = escalus_utils:get_short_jid(From),
-  ChatMarker = set_type(escalus_stanza:chat_marker(FromBare,MarkerType, MsgId), <<"groupchat">>),
-  %% User marks last message
-  escalus:send(User, ChatMarker),
-  %% participants receive marker
-  foreach_recipient(AllUsers, fun(Marker) ->
-    true = escalus_pred:is_chat_marker(MarkerType, MsgId, Marker)
-                              end).
-
-
-mark_last_muclight_system_message(User, ExpectedCount) ->
-  mark_last_muclight_system_message(User, ExpectedCount, <<"displayed">>).
-
-mark_last_muclight_system_message(User, ExpectedCount, MarkerType) ->
-  GetInbox = get_inbox_stanza(),
-  escalus:send(User, GetInbox),
-  Stanzas = escalus:wait_for_stanzas(User, ExpectedCount),
-  ResIQ = escalus:wait_for_stanza(User),
-  ExpectedCount = get_inbox_count(ResIQ),
-  LastMsg = lists:last(Stanzas),
-  [InnerMsg] = get_inner_msg(LastMsg),
-  MsgId = exml_query:attr(InnerMsg, <<"id">>),
-  From = exml_query:attr(InnerMsg, <<"from">>),
-  ChatMarker =
-    set_type(escalus_stanza:chat_marker(From,MarkerType, MsgId), <<"groupchat">>),
-  escalus:send(User, ChatMarker).
-
-
-
-create_room_send_msg_check_inbox(Owner, MemberList, RoomName, Msg, Id) ->
-  RoomJid = room_bin_jid(RoomName),
-  OwnerJid = lbin(escalus_client:short_jid(Owner)),
-  create_room_and_check_inbox(Owner, MemberList, RoomName),
-  Stanza = escalus_stanza:set_id(
-    escalus_stanza:groupchat_to(RoomJid, Msg), Id),
-  escalus:send(Owner, Stanza),
-  foreach_recipient([Owner | MemberList],
-    fun(Stanza) ->
-    escalus:assert(is_groupchat_message, Stanza)
-    end),
-  %% send chat marker per each
-  OwnerRoomJid = <<RoomJid/binary,"/", OwnerJid/binary>>,
-  %% Owner sent the message so he has unread set to 0
-  check_inbox(Owner, #inbox{
-    total = 1,
-    convs = [#conv{unread = 0, from = OwnerRoomJid, to = OwnerJid, content = Msg}]}),
-  foreach_check_inbox(MemberList, 1, 1, OwnerRoomJid, Msg).
-
-
-% Checks case insensitive
-foreach_check_inbox(Users, Total, Unread, SenderJid, Msg) ->
-  [begin
-     UserJid = lbin(escalus_client:short_jid(U)),
-     check_inbox(U, #inbox{total = Total, convs = [#conv{unread = Unread, from = SenderJid, to = UserJid, content = Msg}]})
-    end || U <- Users].
-
-check_inbox(Client, Inbox) ->
-    check_inbox(Client, Inbox, #{}).
-
-% @doc Opts are:
-%       * case_sensitive - should jids be checked case
-%                          sensitively
-%       * check_resource - should resource 
-check_inbox(Client, #inbox{total = Total, convs = Convs}, Opts0) -> 
-  Opts = fill_options(Opts0),
-  check_inbox(Client, integer_to_binary(Total), Convs, Opts).
-
-
-fill_options(Opts) ->
-    #{case_sensitive => maps:get(case_sensitive, Opts, false),
-      check_resource => maps:get(check_resource, Opts, true)}.
-
-
-
-check_inbox(Client, ExpectedCount, MsgCheckList, Opts) when is_binary(ExpectedCount) ->
-  check_inbox(Client, binary_to_integer(ExpectedCount), MsgCheckList, Opts);
-check_inbox(Client, ExpectedCount, MsgCheckList, Opts) ->
-  GetInbox = get_inbox_stanza(),
-  escalus:send(Client, GetInbox),
-  Stanzas = escalus:wait_for_stanzas(Client, ExpectedCount),
-  ResIQ = escalus:wait_for_stanza(Client),
-  ExpectedCount = get_inbox_count(ResIQ),
-  %% TODO: Replace with commented code when inbox starts sorting by timestamp by default
-  %% Merged = lists:zip(Stanzas, MsgCheckList),
-  %% [process_inbox_message(Client, M, ConvCheck) || {M, ConvCheck} <- Merged].
-  process_inbox_messages(Client, Stanzas, MsgCheckList, [], Opts).
-
-process_inbox_messages(Client, [], [], [], _) ->
-    ok;
-process_inbox_messages(Client, [], UnmatchedConvs, UnmatchedItems, #{case_sensitive := IsCaseSensitive, check_resource := CheckResource}) ->
-    ct:fail(#{ reason => inbox_mismatch,
-               unmatched_convs => UnmatchedConvs,
-               unmatched_result_items => UnmatchedItems,
-               resources_match_checked => CheckResource,
-               jids_checked_casesesitive => IsCaseSensitive});
-process_inbox_messages(Client, [Stanza | RStanzas], MsgCheckList, UnmatchedItems, Opts) ->
-    Pred = fun(Conv) -> (catch process_inbox_message(Client, Stanza, Conv, Opts)) == ok end,
-    case lists:partition(Pred, MsgCheckList) of
-        {[], _NoConvSatisfiedPred} ->
-            process_inbox_messages(Client, RStanzas, MsgCheckList, [Stanza | UnmatchedItems], Opts);
-        {[_MatchedConv], RConvs} ->
-            process_inbox_messages(Client, RStanzas, RConvs, UnmatchedItems, Opts)
-    end.
-
-process_inbox_message(Client, Stanza, Conv,
-                      #{case_sensitive := IsCaseSensitive, check_resource := CheckResource} = Opts) ->
-    do_process_inbox_message(Client, Stanza, Conv, check_jid_fun(IsCaseSensitive, CheckResource)).
-
-check_jid_fun(true, true) ->
-    fun(InnerMsg, Expected, El) -> Expected = exml_query:attr(InnerMsg, El) end;
-check_jid_fun(false, true) ->
-    fun(InnerMsg, Expected0, El) ->
-            Expected = lbin(Expected0),
-            Expected = lbin(exml_query:attr(InnerMsg, El)) end;
-check_jid_fun(true, false) ->
-    fun(InnerMsg, Expected, El) ->
-            NoResExpected = bin_to_bare(Expected),
-            NoResExpected = bin_to_bare(exml_query:attr(InnerMsg, El))
-    end;
-check_jid_fun(false, false) ->
-    fun(InnerMsg, Expected, El) ->
-            NoResExpected0 = escalus_client:short_jid(Expected),
-            NoResExpected = lbin(NoResExpected0),
-            NoResExpected = lbin(exml_query:attr(InnerMsg, El)) end.
-
-
-bin_to_bare(Jid) ->
-    case binary:split(Jid, <<"/">>) of
-        [Bare, _Res] -> Bare;
-        [Bare] -> Bare
-    end.
-
-do_process_inbox_message(Client, Message, #conv{unread = Unread, from = FromJid,
-                                             to = ToJid, content = Content, verify = Fun}, CheckJidFun) ->
-  Unread = get_unread_count(Message),
-  escalus:assert(is_message, Message),
-  Unread = get_unread_count(Message),
-  [InnerMsg] = get_inner_msg(Message),
-  CheckJidFun(InnerMsg, FromJid, <<"from">>),
-  CheckJidFun(InnerMsg, ToJid, <<"to">>),
-  InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], []),
-  Content = InnerContent,
-  Fun(Client, InnerMsg),
-  ok.
-
-
-verify_is_owner_aff_change(Client, Msg) ->
-  verify_muc_light_aff_msg(Msg, [{Client,  owner}]).
-
-verify_is_member_aff_change(Client, Msg) ->
-  verify_muc_light_aff_msg(Msg, [{Client, member}]).
-
-verify_is_none_aff_change(Client, Msg) ->
-  verify_muc_light_aff_msg(Msg, [{Client, none}]).
-
-verify_muc_light_aff_msg(Msg, AffUsersChanges) ->
-  BinAffUsersChanges = muc_light_helper:bin_aff_users(AffUsersChanges),
-  ProperNS = muc_light_helper:ns_muc_light_affiliations(),
-  SubEl = exml_query:path(Msg, [{element_with_ns, ProperNS}]),
-  undefined = exml_query:subelement(Msg, <<"prev-version">>),
-  Items = exml_query:subelements(SubEl, <<"user">>),
-  muc_light_helper:verify_aff_users(Items, BinAffUsersChanges).
-
-set_type(Msg, Type) ->
-  Attrs = lists:keystore(<<"type">>, 1, Msg#xmlel.attrs, {<<"type">>, Type}),
-  Msg#xmlel{attrs = Attrs}.
-
-
-
-get_inner_msg(Msg) ->
-  exml_query:paths(Msg, [{element, <<"result">>}, {element, <<"forwarded">>},
-    {element, <<"message">>}]).
-
-get_inbox_stanza() ->
-  GetIQ = escalus_stanza:iq_get(?NS_ESL_INBOX, []),
-  Id = escalus_stanza:id(),
-  QueryTag = #xmlel{name = <<"inbox">>,
-    attrs = [{<<"queryid">>, Id}, {<<"xmlns">>, ?NS_ESL_INBOX}]},
-  GetIQ#xmlel{children = [QueryTag]}.
-
-get_unread_count(Msg) ->
-  [Val] = exml_query:paths(Msg, [{element, <<"result">>}, {attr, <<"unread">>}]),
-  binary_to_integer(Val).
-
-get_inbox_count(Packet) ->
-  [Val] = exml_query:paths(Packet, [{element_with_ns, ?NS_ESL_INBOX}, cdata]),
-  case Val of
-    <<>> ->
-      {error, no_unread_count};
-    _ ->
-      binary_to_integer(Val)
-  end.
-
-
-
-clear_inbox_all() ->
-  Host = ct:get_config({hosts, mim, domain}),
-  clear_inboxes([alice, bob, kate, mike], Host).
-
-clear_inboxes(UserList, Host) ->
-  JIDs = [escalus_users:get_jid(escalus_users:get_users(UserList),U) || U <- UserList],
-  [escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [JID,Host]) || JID <- JIDs].
-
-reload_inbox_option(Config, KeyValueList) ->
-    Host = domain(),
-    Args = proplists:get_value(inbox_opts, Config),
-    Args2 = lists:foldl(fun({K, V}, AccIn) ->
-        lists:keyreplace(K, 1, AccIn, {K, V})
-                end, Args, KeyValueList),
-    dynamic_modules:restart(Host, mod_inbox, Args2),
-    lists:keyreplace(inbox_opts, 1, Config, {inbox_opts, Args2}).
-
-reload_inbox_option(Config, Key, Value) ->
-  Host = domain(),
-  Args = proplists:get_value(inbox_opts, Config),
-  Args1 = lists:keyreplace(Key, 1, Args, {Key, Value}),
-  dynamic_modules:restart(Host, mod_inbox, Args1),
-  lists:keyreplace(inbox_opts, 1, Config, {inbox_opts, Args1}).
-
-restore_inbox_option(Config) ->
-  Host = domain(),
-  Args = proplists:get_value(inbox_opts, Config),
-  dynamic_modules:restart(Host, mod_inbox, Args).
+%%--------------------------------------------------------------------
+%% Timestamp-related tests
+%%--------------------------------------------------------------------
+
+timestamp_is_updated_on_new_message(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+    Msg1 = escalus_stanza:chat_to(Bob, <<"Hello Bob">>),
+    Msg2 = escalus_stanza:chat_to(Bob, <<"Are you there?">>),
+
+    escalus:send(Alice, Msg1),
+    _M1 = escalus:wait_for_stanza(Bob),
+
+    %% We capture a timestamp after first message
+    [Item1] = inbox_helper:get_inbox(Alice, 1),
+    TStamp1 = inbox_helper:timestamp_from_item(Item1),
+
+    escalus:send(Alice, Msg2),
+    _M2 = escalus:wait_for_stanza(Bob),
+    
+    %% Timestamp after second message must be higher
+    [Item2] = inbox_helper:get_inbox(Alice, 1),
+    TStamp2 = inbox_helper:timestamp_from_item(Item2),
+
+    case timer:now_diff(TStamp2, TStamp1) > 0 of
+        true -> ok;
+        false -> error(#{ type => timestamp_is_not_greater,
+                          item1 => Item1,
+                          item2 => Item2,
+                          tstamp1 => TStamp1,
+                          tstamp2 => TStamp2 })
+    end
+  end).
+
+order_by_timestamp_ascending(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+      #{ Alice := AliceConvs, Bob := BobConvs, Kate := KateConvs } =
+      given_conversations_between(Alice, [Bob, Kate]),
+
+      %% Alice has two conversations in her inbox (no unread messages)
+      %% check_inbox will reverse conversation list automatically
+      check_inbox(Alice, AliceConvs, #{ order => asc }, #{}),
+      
+      %% Kate has one conversation with one unread
+      check_inbox(Kate, KateConvs),
+      
+      %% Bob has one conversation with one unread
+      check_inbox(Bob, BobConvs)
+    end).
+
+get_by_timestamp_range(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+      #{ Alice := AliceConvs, time_before := TimeBefore } =
+      given_conversations_between(Alice, [Bob, Kate]),
+
+      ConvWithBob = lists:keyfind(Bob, #conv.to, AliceConvs),
+      TimeAfterBob = ConvWithBob#conv.time_after,      
+
+      %% Between given timestamps we have only one conversation: with Bob
+      check_inbox(Alice, [ConvWithBob], #{ start => TimeBefore, 'end' => TimeAfterBob }, #{})
+    end).
+
+get_with_start_timestamp(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+      #{ Alice := AliceConvs } =
+      given_conversations_between(Alice, [Bob, Kate]),
+
+      ConvWithBob = lists:keyfind(Bob, #conv.to, AliceConvs),
+      TimeAfterBob = ConvWithBob#conv.time_after,
+      ConvWithKate = lists:keyfind(Kate, #conv.to, AliceConvs),
+
+      %% After given timestamp we have only one conversation: with Kate
+      check_inbox(Alice, [ConvWithKate], #{ start => TimeAfterBob }, #{})
+    end).
+
+get_with_end_timestamp(Config) ->
+  escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+      #{ Alice := AliceConvs } =
+      given_conversations_between(Alice, [Bob, Kate]),
+
+      ConvWithBob = lists:keyfind(Bob, #conv.to, AliceConvs),
+      TimeAfterBob = ConvWithBob#conv.time_after,      
+
+      %% Before given timestamp we have only one conversation: with Bob
+      %% TODO: Improve this test to store 3+ conversations in Alice's inbox
+      check_inbox(Alice, [ConvWithBob], #{ 'end' => TimeAfterBob }, #{})
+    end).
 

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -467,7 +467,7 @@ simple_groupchat_stored_in_all_inbox(Config) ->
     Id = <<"MyID">>,
     AliceJid = inbox_helper:to_bare_lower(Alice),
     KateJid = inbox_helper:to_bare_lower(Kate),
-    BobJid = inbox_hlper:to_bare_lower(Bob),
+    BobJid = inbox_helper:to_bare_lower(Bob),
     RoomJid = room_bin_jid(?ROOM),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Stanza = escalus_stanza:set_id(
@@ -757,7 +757,7 @@ groupchat_markers_one_reset_room_created(Config) ->
 groupchat_markers_all_reset_room_created(Config) ->
   escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
     RoomName = <<"markers_room2">>,
-    AliceJid = inbox_helper:to_bare_lowe(Alice),
+    AliceJid = inbox_helper:to_bare_lower(Alice),
     RoomJid = room_bin_jid(RoomName),
     AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
     Msg = <<"Mark me!">>,

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -1,0 +1,505 @@
+-module(inbox_helper).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("inbox.hrl").
+
+% Generic inbox
+-export([
+         clear_inbox_all/0,
+         foreach_check_inbox/4,
+         check_inbox/2, check_inbox/4,
+         get_inbox/2,
+         get_inbox_count/1,
+         get_inbox_form_stanza/0,
+         get_inbox_stanza/0,
+         inbox_ns/0,
+         reload_inbox_option/2, reload_inbox_option/3,
+         restore_inbox_option/1,
+         timestamp_from_item/1
+        ]).
+% 1-1 helpers
+-export([
+         given_conversations_between/2
+        ]).
+% MUC + MUC Light helpers
+-export([
+         create_room_and_check_inbox/3,
+         create_room_send_msg_check_inbox/5,
+         enter_room/2, enter_room/4,
+         leave_room/3,
+         make_members/3,
+         mark_last_muclight_message/2,
+         nick/1,
+         verify_is_none_aff_change/2,
+         wait_for_groupchat_msg/1
+        ]).
+% Misc
+-export([
+         domain/0,
+         to_bare_lower/1
+        ]).
+
+-import(muc_helper, [foreach_recipient/2]).
+-import(muc_light_helper, [lbin/1]).
+
+-define(NS_ESL_INBOX, <<"erlang-solutions.com:xmpp:inbox:0">>).
+-define(ROOM, <<"testroom1">>).
+-define(ROOM2, <<"testroom2">>).
+-define(ROOM3, <<"testroom3">>).
+-define(ROOM4, <<"testroom4">>).
+-define(ROOM_MARKERS, <<"room_markers">>).
+-define(MUC_DOMAIN, <<"muc.localhost">>).
+
+-type inbox_query_params() :: #{
+        order => asc | desc | undefined, % by timestamp
+        start => binary() | undefined, % ISO timestamp
+        'end' => binary() | undefined % ISO timestamp
+       }.
+
+-type inbox_check_params() :: #{
+        case_sensitive => boolean(), % should jids be checked case sensitively
+        check_resource => boolean() % should resource be verified
+       }.
+
+-type jid_verify_fun() :: fun((InnerMsg :: exml:element(),
+                               Expected :: binary(),
+                               AttrName :: binary()) -> any() | no_return()).
+
+-type conv() :: #conv{}.
+
+%% ---------------------------------------------------------
+%% Generic inbox
+%% ---------------------------------------------------------
+
+-spec inbox_ns() -> binary().
+inbox_ns() ->
+    ?NS_ESL_INBOX.
+
+foreach_check_inbox(Users, Unread, SenderJid, Msg) ->
+  [begin
+     UserJid = to_bare_lower(U),
+     check_inbox(U, [#conv{unread = Unread, from = SenderJid, to = UserJid, content = Msg}])
+    end || U <- Users].
+
+-spec check_inbox(Client :: escalus:client(), Convs :: [conv()]) -> ok | no_return().
+check_inbox(Client, Convs) ->
+    check_inbox(Client, Convs, #{}, #{}).
+
+-spec check_inbox(Client :: escalus:client(),
+                  Convs :: [conv()],
+                  QueryOpts :: inbox_query_params(),
+                  CheckOpts :: inbox_check_params()) -> ok | no_return().
+check_inbox(Client, Convs, QueryOpts, CheckOpts) ->
+  ExpectedSortedConvs = case maps:get(order, QueryOpts, undefined) of
+                          asc -> lists:reverse(Convs);
+                          _ -> Convs
+                        end,
+  ResultStanzas = get_inbox(Client, QueryOpts, length(ExpectedSortedConvs)),
+  try
+    check_inbox_result(Client, CheckOpts, ResultStanzas, ExpectedSortedConvs)
+  catch
+    _:Reason ->
+      ct:fail(#{ reason => inbox_mismatch,
+                 inbox_items => lists:map(fun exml:to_binary/1, ResultStanzas),
+                 expected_items => lists:map(fun pretty_conv/1, ExpectedSortedConvs),
+                 query_params => QueryOpts,
+                 check_params => CheckOpts,
+                 error => Reason,
+                 stacktrace => erlang:get_stacktrace() })
+  end.
+
+check_inbox_result(Client, CheckOpts, ResultStanzas, MsgCheckList) ->
+  Merged = lists:zip(ResultStanzas, MsgCheckList),
+  JIDVerifyFun = check_jid_fun(maps:get(case_sensitive, CheckOpts),
+                               maps:get(check_resource, CheckOpts)),
+  lists:foreach(fun({ResultConvStanza, ExpectedConv}) ->
+                        process_inbox_message(Client, ResultConvStanza, ExpectedConv, JIDVerifyFun)
+                end, Merged).
+
+process_inbox_message(Client, Message, #conv{unread = Unread, from = From, to = To,
+                                             content = Content, verify = Fun}, JIDVerifyFun) ->
+  FromJid = ensure_conv_binary_jid(From),
+  ToJid = ensure_conv_binary_jid(To),
+  Unread = get_unread_count(Message),
+  escalus:assert(is_message, Message),
+  Unread = get_unread_count(Message),
+  [InnerMsg] = get_inner_msg(Message),
+  JIDVerifyFun(InnerMsg, FromJid, <<"from">>),
+  JIDVerifyFun(InnerMsg, ToJid, <<"to">>),
+  InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], []),
+  Content = InnerContent,
+  Fun(Client, InnerMsg),
+  ok.
+
+-spec get_inbox(Client :: escalus:client(),
+                ExpectedCount :: non_neg_integer()) -> [exml:element()].
+get_inbox(Client, ExpectedCount) ->
+  get_inbox(Client, #{}, ExpectedCount).
+
+-spec get_inbox(Client :: escalus:client(),
+                GetParams :: inbox_query_params(),
+                ExpectedCount :: non_neg_integer()) -> [exml:element()].
+get_inbox(Client, GetParams, ExpectedCount) ->
+  GetInbox = get_inbox_stanza(GetParams),
+  escalus:send(Client, GetInbox),
+  Stanzas = escalus:wait_for_stanzas(Client, ExpectedCount),
+  ResIQ = escalus:wait_for_stanza(Client),
+  ExpectedCount = get_inbox_count(ResIQ),
+  Stanzas.
+
+get_unread_count(Msg) ->
+  [Val] = exml_query:paths(Msg, [{element, <<"result">>}, {attr, <<"unread">>}]),
+  binary_to_integer(Val).
+
+get_inbox_count(Packet) ->
+  [Val] = exml_query:paths(Packet, [{element_with_ns, ?NS_ESL_INBOX}, cdata]),
+  case Val of
+    <<>> ->
+      ct:fail(#{ error => no_unread_count,
+                 stanza => Packet });
+    _ ->
+      binary_to_integer(Val)
+  end.
+
+timestamp_from_item(Item) ->
+    ISOTStamp = exml_query:path(Item, [{element, <<"result">>}, {element, <<"forwarded">>},
+                                       {element, <<"delay">>}, {attr, <<"stamp">>}]),
+    escalus_ejabberd:rpc(jlib, datetime_binary_to_timestamp, [ISOTStamp]).
+
+clear_inbox_all() ->
+  Host = ct:get_config(domain()),
+  clear_inboxes([alice, bob, kate, mike], Host).
+
+clear_inboxes(UserList, Host) ->
+  JIDs = [escalus_users:get_jid(escalus_users:get_users(UserList),U) || U <- UserList],
+  [escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [JID,Host]) || JID <- JIDs].
+
+reload_inbox_option(Config, KeyValueList) ->
+    Host = domain(),
+    Args = proplists:get_value(inbox_opts, Config),
+    Args2 = lists:foldl(fun({K, V}, AccIn) ->
+        lists:keyreplace(K, 1, AccIn, {K, V})
+                end, Args, KeyValueList),
+    dynamic_modules:restart(Host, mod_inbox, Args2),
+    lists:keyreplace(inbox_opts, 1, Config, {inbox_opts, Args2}).
+
+reload_inbox_option(Config, Key, Value) ->
+  Host = domain(),
+  Args = proplists:get_value(inbox_opts, Config),
+  Args1 = lists:keyreplace(Key, 1, Args, {Key, Value}),
+  dynamic_modules:restart(Host, mod_inbox, Args1),
+  lists:keyreplace(inbox_opts, 1, Config, {inbox_opts, Args1}).
+
+restore_inbox_option(Config) ->
+  Host = domain(),
+  Args = proplists:get_value(inbox_opts, Config),
+  dynamic_modules:restart(Host, mod_inbox, Args).
+
+get_inner_msg(Msg) ->
+  exml_query:paths(Msg, [{element, <<"result">>}, {element, <<"forwarded">>},
+    {element, <<"message">>}]).
+
+get_inbox_form_stanza() ->
+  escalus_stanza:iq_get(?NS_ESL_INBOX, []).
+
+-spec get_inbox_stanza() -> exml:element().
+get_inbox_stanza() ->
+  get_inbox_stanza(#{}).
+
+-spec get_inbox_stanza(GetParams :: inbox_query_params()) -> exml:element().
+get_inbox_stanza(GetParams) ->
+  GetIQ = escalus_stanza:iq_set(?NS_ESL_INBOX, []),
+  QueryTag = #xmlel{name = <<"inbox">>,
+                    attrs = [{<<"xmlns">>, ?NS_ESL_INBOX}],
+                    children = [make_inbox_form(GetParams)]},
+  GetIQ#xmlel{children = [QueryTag]}.
+
+-spec check_jid_fun(IsCaseSensitive :: boolean(), CheckResource :: boolean()) -> jid_verify_fun().
+check_jid_fun(true, true) ->
+    fun(InnerMsg, Expected, El) -> Expected = exml_query:attr(InnerMsg, El) end;
+check_jid_fun(false, true) ->
+    fun(InnerMsg, Expected0, El) ->
+            Expected = lbin(Expected0),
+            Expected = lbin(exml_query:attr(InnerMsg, El)) end;
+check_jid_fun(true, false) ->
+    fun(InnerMsg, Expected, El) ->
+            NoResExpected = bin_to_bare(Expected),
+            NoResExpected = bin_to_bare(exml_query:attr(InnerMsg, El))
+    end;
+check_jid_fun(false, false) ->
+    fun(InnerMsg, Expected, El) ->
+            NoResExpected0 = escalus_client:short_jid(Expected),
+            NoResExpected = lbin(NoResExpected0),
+            NoResExpected = lbin(exml_query:attr(InnerMsg, El)) end.
+
+bin_to_bare(Jid) ->
+    case binary:split(Jid, <<"/">>) of
+        [Bare, _Res] -> Bare;
+        [Bare] -> Bare
+    end.
+
+-spec make_inbox_form(GetParams :: inbox_query_params()) -> exml:element().
+make_inbox_form(GetParams) ->
+  OrderL =
+  case maps:get(order, GetParams, undefined) of
+    undefined -> [];
+    Order -> [escalus_stanza:field_el(<<"order">>, <<"list-single">>, order_to_bin(Order))]
+  end,
+  StartL =
+  case maps:get(start, GetParams, undefined) of
+    undefined -> [];
+    Start -> [escalus_stanza:field_el(<<"start">>, <<"text-single">>, Start)]
+  end,
+  EndL =
+  case maps:get('end', GetParams, undefined) of
+    undefined -> [];
+    End -> [escalus_stanza:field_el(<<"end">>, <<"text-single">>, End)]
+  end,
+  FormTypeL = [escalus_stanza:field_el(<<"FORM_TYPE">>, <<"hidden">>, ?NS_ESL_INBOX)],
+  Fields = FormTypeL ++ OrderL ++ StartL ++ EndL,
+  escalus_stanza:x_data_form(<<"submit">>, Fields).
+
+order_to_bin(asc) -> <<"asc">>;
+order_to_bin(desc) -> <<"desc">>.
+
+%% ---------------------------------------------------------
+%% 1-1 helpers
+%% ---------------------------------------------------------
+
+-spec given_conversations_between(From :: escalus:client(), ToList :: [escalus:client()]) ->
+    #{ escalus:client() => [#conv{}] }.
+given_conversations_between(From, ToList) ->
+  lists:foldl(fun(N, #{ From := FromConvs } = Convs) ->
+                        Ord = integer_to_binary(N),
+                        ToClient = lists:nth(N, ToList),
+                        Body = <<"Msg ", Ord/binary>>,
+                        Msg = escalus_stanza:chat_to(ToClient, Body),
+                        escalus:send(From, Msg),
+                        Incoming = escalus:wait_for_stanza(ToClient),
+                        escalus:assert(is_chat_message, Incoming),
+                        NewConv = #conv{ from = From, to = ToClient,
+                                         content = Body, time_after = server_side_time() },
+                        Convs#{
+                          From := [NewConv#conv{ unread = 0 } | FromConvs],
+                          ToClient => [NewConv#conv{ unread = 1 }]
+                         }
+                end, #{ From => [], time_before => server_side_time() },
+              lists:seq(1, length(ToList))).
+
+%% ---------------------------------------------------------
+%% MUC + MUC Light helpers
+%% ---------------------------------------------------------
+
+leave_room(User, Room, Occupants) ->
+    UnavailavbleStanza = escalus_stanza:presence(<<"unavailable">>),
+    Stanza = muc_helper:stanza_to_room(UnavailavbleStanza, Room, nick(User)),
+    escalus:send(User, Stanza),
+    lists:foreach(fun escalus:wait_for_stanza/1, Occupants).
+
+wait_for_groupchat_msg(Users) ->
+    Resps = lists:map(fun(User) -> escalus:wait_for_stanza(User) end,
+              Users),
+    lists:foreach(fun(Resp) -> escalus:assert(is_groupchat_message, Resp) end,
+                  Resps).
+
+make_members(Room, Admin, Users) ->
+    Items = lists:map(fun(User) -> {escalus_utils:get_short_jid(User),<<"member">>} end,
+                      Users),
+    escalus:send(Admin, stanza_set_affiliations(Room, Items)),
+    % gets iq result and affs changes from all users
+    escalus:wait_for_stanzas(Admin, 1 + length(Users)),
+    % Everybody gets aff changes of everybody
+    lists:foreach(fun(User) -> escalus:wait_for_stanzas(User, length(Users)) end, Users). 
+
+% All users enter the room
+enter_room(Room, Users) ->
+    lists:foreach(fun(User) ->
+                          escalus:send(User, stanza_muc_enter_room(Room, nick(User))) end,
+                  Users),
+    lists:foreach(fun(User) ->
+                          escalus:wait_for_stanzas(User, length(Users) + 1) % everybody gets presence from everybody + a subject message
+                  end,
+                  Users).
+
+% `User` enters the room `Room` where `Users` are occupants
+enter_room(Room, User, Users, DelayedMessagesCount) ->
+    escalus:send(User, stanza_muc_enter_room(Room, nick(User))),
+    lists:foreach(fun escalus:wait_for_stanza/1, Users),
+    escalus:wait_for_stanzas(User, length(Users) + 1 + 1 + DelayedMessagesCount). % User gets subject message and presences from everybody including himself
+
+stanza_set_affiliations(Room, List) ->
+    Payload = lists:map(fun aff_to_iq_item/1, List),
+    muc_helper:stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
+
+aff_to_iq_item({JID, Affiliation}) ->
+    #xmlel{name = <<"item">>,
+        attrs = [{<<"jid">>, JID}, {<<"affiliation">>, Affiliation}]}.
+
+nick(User) -> escalus_utils:get_username(User).
+
+stanza_muc_enter_room(Room, Nick) ->
+    stanza_to_room(
+        escalus_stanza:presence(<<"available">>,
+                                [#xmlel{name = <<"x">>,
+                                        attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}
+                                ]),
+        Room, Nick).
+
+stanza_to_room(Stanza, Room, Nick) ->
+    escalus_stanza:to(Stanza, muc_helper:room_address(Room, Nick)).
+
+create_room_and_check_inbox(Owner, MemberList, RoomName) ->
+  InitOccupants = [{M, member} || M <- MemberList],
+  FinalOccupants = [{Owner, owner} | InitOccupants],
+  InitConfig = [{<<"roomname">>, <<"Just room name">>}],
+  OwnerJid = lbin(escalus_client:short_jid(Owner)),
+  MembersJids = [lbin(escalus_client:short_jid(M)) || M <- MemberList],
+  MemberAndJids = lists:zip(MemberList, MembersJids),
+  MembersAndOwner = [Owner | MemberList],
+  %% Owner creates room
+  escalus:send(Owner, muc_light_helper:stanza_create_room(RoomName, InitConfig, InitOccupants)),
+  muc_light_helper:verify_aff_bcast(FinalOccupants, FinalOccupants),
+  escalus:assert(is_iq_result, escalus:wait_for_stanza(Owner)),
+  %% check for the owner. Unread from owner is affiliation change to owner
+  check_inbox(Owner,[#conv{unread = 1,
+                           from = muc_light_helper:room_bin_jid(RoomName),
+                           to = OwnerJid,
+                           verify = fun verify_is_owner_aff_change/2}]),
+  %% check for the members. Every member has affiliation change to member
+  [check_inbox(Member, [#conv{unread = 1,
+                              from = muc_light_helper:room_bin_jid(RoomName),
+                              to = Jid,
+                              verify = fun verify_is_member_aff_change/2}])
+   || {Member, Jid} <- MemberAndJids],
+  %% Each room participant send chat marker
+  [begin mark_last_muclight_system_message(U, 1),
+         foreach_recipient(MembersAndOwner, fun(_Stanza) -> ok end) end || U <- MembersAndOwner],
+  %% counter is reset for owner
+  check_inbox(Owner, [#conv{unread = 0,
+                            from = muc_light_helper:room_bin_jid(RoomName),
+                            to = OwnerJid,
+                            verify = fun verify_is_owner_aff_change/2}]),
+  %% counter is reset for members
+  [check_inbox(Member, [#conv{unread = 0,
+                              from = muc_light_helper:room_bin_jid(RoomName),
+                              to = Jid,
+                              verify = fun verify_is_member_aff_change/2}])
+    || {Member, Jid} <- MemberAndJids].
+
+%% assume there is only one conversation
+mark_last_muclight_message(User, AllUsers) ->
+  mark_last_muclight_message(User, AllUsers, <<"displayed">>).
+
+mark_last_muclight_message(User, AllUsers, MarkerType) ->
+  %% User ask for inbox in order to get id of last message
+  GetInbox = get_inbox_stanza(),
+  escalus:send(User, GetInbox),
+  Stanza = escalus:wait_for_stanza(User),
+  ResIQ = escalus:wait_for_stanza(User),
+  1 = get_inbox_count(ResIQ),
+  [InnerMsg] = get_inner_msg(Stanza),
+  MsgId = exml_query:attr(InnerMsg, <<"id">>),
+  From = exml_query:attr(InnerMsg, <<"from">>),
+  FromBare = escalus_utils:get_short_jid(From),
+  ChatMarkerWOType = escalus_stanza:chat_marker(FromBare, MarkerType, MsgId),
+  ChatMarker = escalus_stanza:setattr(ChatMarkerWOType, <<"type">>, <<"groupchat">>),
+  %% User marks last message
+  escalus:send(User, ChatMarker),
+  %% participants receive marker
+  foreach_recipient(AllUsers, fun(Marker) ->
+    true = escalus_pred:is_chat_marker(MarkerType, MsgId, Marker)
+                              end).
+
+mark_last_muclight_system_message(User, ExpectedCount) ->
+  mark_last_muclight_system_message(User, ExpectedCount, <<"displayed">>).
+
+mark_last_muclight_system_message(User, ExpectedCount, MarkerType) ->
+  GetInbox = get_inbox_stanza(),
+  escalus:send(User, GetInbox),
+  Stanzas = escalus:wait_for_stanzas(User, ExpectedCount),
+  ResIQ = escalus:wait_for_stanza(User),
+  ExpectedCount = get_inbox_count(ResIQ),
+  LastMsg = lists:last(Stanzas),
+  [InnerMsg] = get_inner_msg(LastMsg),
+  MsgId = exml_query:attr(InnerMsg, <<"id">>),
+  From = exml_query:attr(InnerMsg, <<"from">>),
+  ChatMarkerWOType = escalus_stanza:chat_marker(From, MarkerType, MsgId),
+  ChatMarker = escalus_stanza:setattr(ChatMarkerWOType, <<"type">>, <<"groupchat">>),
+  escalus:send(User, ChatMarker).
+
+create_room_send_msg_check_inbox(Owner, MemberList, RoomName, Msg, Id) ->
+  RoomJid = muc_light_helper:room_bin_jid(RoomName),
+  OwnerJid = lbin(escalus_client:short_jid(Owner)),
+  create_room_and_check_inbox(Owner, MemberList, RoomName),
+  Stanza = escalus_stanza:set_id(
+    escalus_stanza:groupchat_to(RoomJid, Msg), Id),
+  escalus:send(Owner, Stanza),
+  foreach_recipient([Owner | MemberList],
+    fun(ReceivedStanza) ->
+    escalus:assert(is_groupchat_message, ReceivedStanza)
+    end),
+  %% send chat marker per each
+  OwnerRoomJid = <<RoomJid/binary,"/", OwnerJid/binary>>,
+  %% Owner sent the message so he has unread set to 0
+  check_inbox(Owner, [#conv{unread = 0, from = OwnerRoomJid, to = OwnerJid, content = Msg}]),
+  foreach_check_inbox(MemberList, 1, OwnerRoomJid, Msg).
+
+verify_is_owner_aff_change(Client, Msg) ->
+  verify_muc_light_aff_msg(Msg, [{Client,  owner}]).
+
+verify_is_member_aff_change(Client, Msg) ->
+  verify_muc_light_aff_msg(Msg, [{Client, member}]).
+
+verify_is_none_aff_change(Client, Msg) ->
+  verify_muc_light_aff_msg(Msg, [{Client, none}]).
+
+verify_muc_light_aff_msg(Msg, AffUsersChanges) ->
+  BinAffUsersChanges = muc_light_helper:bin_aff_users(AffUsersChanges),
+  ProperNS = muc_light_helper:ns_muc_light_affiliations(),
+  SubEl = exml_query:path(Msg, [{element_with_ns, ProperNS}]),
+  undefined = exml_query:subelement(Msg, <<"prev-version">>),
+  Items = exml_query:subelements(SubEl, <<"user">>),
+  muc_light_helper:verify_aff_users(Items, BinAffUsersChanges).
+
+%% ---------------------------------------------------------
+%% Misc
+%% ---------------------------------------------------------
+
+-spec domain() -> binary().
+domain() ->
+  ct:get_config({hosts, mim, domain}).
+
+-spec to_bare_lower(User :: escalus:client()) -> binary().
+to_bare_lower(User) ->
+  lbin(escalus_client:short_jid(User)).
+
+%% Returns mim1-side time in ISO format
+-spec server_side_time() -> binary().
+server_side_time() ->
+  {_, _, Micro} = Timestamp = escalus_ejabberd:rpc(erlang, timestamp, []),
+  {Day, {H, M, S}} = calendar:now_to_datetime(Timestamp),
+  DateTimeMicro = {Day, {H, M, S, Micro}},
+  {String, TZ} = escalus_ejabberd:rpc(jlib, timestamp_to_iso, [DateTimeMicro, utc]),
+  list_to_binary(String ++ TZ).
+
+%% ---------------------------------------------------------
+%% Error reporting
+%% ---------------------------------------------------------
+
+pretty_conv(#conv{ unread = Unread, from = From, to = To, content = Content, verify = Fun }) ->
+    #{
+      unread => Unread,
+      from => ensure_conv_binary_jid(From),
+      to => ensure_conv_binary_jid(To),
+      content => Content,
+      verify => Fun
+    }.
+
+ensure_conv_binary_jid(BinJid) when is_binary(BinJid) ->
+  BinJid;
+ensure_conv_binary_jid(Client) ->
+  lbin(escalus_client:full_jid(Client)).
+

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -113,8 +113,8 @@ check_inbox(Client, Convs, QueryOpts, CheckOpts) ->
 
 check_inbox_result(Client, CheckOpts, ResultStanzas, MsgCheckList) ->
   Merged = lists:zip(ResultStanzas, MsgCheckList),
-  JIDVerifyFun = check_jid_fun(maps:get(case_sensitive, CheckOpts),
-                               maps:get(check_resource, CheckOpts)),
+  JIDVerifyFun = check_jid_fun(maps:get(case_sensitive, CheckOpts, false),
+                               maps:get(check_resource, CheckOpts, true)),
   lists:foreach(fun({ResultConvStanza, ExpectedConv}) ->
                         process_inbox_message(Client, ResultConvStanza, ExpectedConv, JIDVerifyFun)
                 end, Merged).
@@ -170,8 +170,7 @@ timestamp_from_item(Item) ->
     escalus_ejabberd:rpc(jlib, datetime_binary_to_timestamp, [ISOTStamp]).
 
 clear_inbox_all() ->
-  Host = ct:get_config(domain()),
-  clear_inboxes([alice, bob, kate, mike], Host).
+  clear_inboxes([alice, bob, kate, mike], domain()).
 
 clear_inboxes(UserList, Host) ->
   JIDs = [escalus_users:get_jid(escalus_users:get_users(UserList),U) || U <- UserList],

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -46,7 +46,8 @@ A client may specify three parameters:
 
 They are encoded inside a standard XMPP [Data Forms](https://xmpp.org/extensions/xep-0004.html) format.
 Dates must be formatted according to [XMPP Date and Time Profiles](https://xmpp.org/extensions/xep-0082.html).
-See the example below.
+It is not mandatory to add an empty data form if a client prefers to use default values (`<query/>` element may be empty).
+However, the IQ type must be "set", even when data form is missing.
 
 Your client application may request the currently supported form with IQ get:
 
@@ -117,7 +118,7 @@ Alice receives:
   </result>
 </message>
 
-<iq from="alicE@localhost" to="alicE@localhost/res1" id="10bca" type="result">
+<iq from="alicE@localhost" to="alicE@localhost/res1" id="b6" type="result">
   <count xmlns='erlang-solutions.com:xmpp:inbox:0'>1</count>
 </iq>
 

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -27,12 +27,53 @@ Inbox currently supports the following DBs:
 * PgSQL via native driver
 * MSSQL via ODBC driver
 
-
 ### Legacy MUC support
 Inbox comes with support for the legacy MUC as well. It stores all groupchat messages sent to
 room in each sender's and recipient's inboxes and private messages. Currently it is not possible to
 configure it to store system messages like [subject](https://xmpp.org/extensions/xep-0045.html#enter-subject) 
 or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.
+
+### Filtering and ordering
+
+Inbox query results may be filtered by time range and sorted by timestamp.
+By default, `mod_inbox` returns all conversations, most recently updated first.
+
+A client may specify three parameters:
+
+* Start date for the result set (variable `start`, value: ISO timestamp)
+* End date for the result set (variable `end`, value: ISO timestamp)
+* Order by timestamp (variable `order`, values: `asc`, `desc`)
+
+They are encoded inside standard XMPP [Data Forms](https://xmpp.org/extensions/xep-0004.html) format.
+Dates must be formatted according to [XMPP Date and Time Profiles](https://xmpp.org/extensions/xep-0082.html).
+See example below.
+
+Your client application may request the currently supported form with IQ get:
+
+```
+Client:
+
+<iq type='get' id='c94a88ddf4957128eafd08e233f4b964'>
+  <query xmlns='erlang-solutions.com:xmpp:inbox:0'/>
+</iq>
+
+Server:
+
+<iq from='alicE@localhost' to='alicE@localhost/res1' id='c94a88ddf4957128eafd08e233f4b964' type='result'>
+  <query xmlns='erlang-solutions.com:xmpp:inbox:0'>
+    <x xmlns='jabber:x:data' type='form'>
+      <field type='hidden' var='FORM_TYPE'><value>erlang-solutions.com:xmpp:inbox:0</value></field>
+      <field var='start' type='text-single'/>
+      <field var='end' type='text-single'/>
+      <field var='order' type='list-single'>
+        <value>desc</value>
+        <option label='Ascending by timestamp'><value>asc</value></option>
+        <option label='Descending by timestamp'><value>desc</value></option>
+      </field>
+    </x>
+  </query>
+</iq>
+```
 
 ### Example Request
 
@@ -40,36 +81,44 @@ or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.
 Alice sends:
 
 <message type="chat" to="bOb@localhost/res1" id=”123”>
-<body>Hello</body>
+  <body>Hello</body>
 </message>
 
 Bob receives:
 
 <message from="alicE@localhost/res1" to="bOb@localhost/res1" id=“123” xml:lang="en" type="chat">
-<body>Hello</body>
+  <body>Hello</body>
 </message>
 
 Alice sends:
 
-<iq type="get" id="10bca">
-<inbox xmlns=”erlang-solutions.com:xmpp:inbox:0” queryid="b6"/>
+<iq type="set" id="10bca">
+  <inbox xmlns=”erlang-solutions.com:xmpp:inbox:0” queryid="b6">
+    <x xmlns='jabber:x:data' type='form'>
+      <field type='hidden' var='FORM_TYPE'><value>urn:xmpp:mam:2</value></field>
+      <field type='text-single' var='start'><value>2018-07-10T12:00:00Z</value></field>
+      <field type='text-single' var='end'><value>2018-07-11T12:00:00Z</value></field>
+      <field type='list-single' var='order'><value>asc</value></field>
+    </x>
+  </inbox>
 </iq>
 
 
 Alice receives:
 
 <message from="alicE@localhost" to="alicE@localhost" id="9b759">
-<result xmlns=”erlang-solutions.com:xmpp:inbox:0” unread="0" queryid="b6">
-<forwarded xmlns=”urn:xmpp:forward:0”>
-<message xml:lang="en" type="chat" to="bOb@localhost/res1" from="alicE@localhost/res1" id=”123”>
-<body>Hello</body>
-</message>
-</forwarded>
-</result>
+  <result xmlns="erlang-solutions.com:xmpp:inbox:0" unread="0" queryid="b6">
+    <forwarded xmlns="urn:xmpp:forward:0">
+      <delay xmlns="urn:xmpp:delay" stamp="2018-07-10T23:08:25.123456Z"/>
+      <message xml:lang="en" type="chat" to="bOb@localhost/res1" from="alicE@localhost/res1" id=”123”>
+        <body>Hello</body>
+      </message>
+    </forwarded>
+  </result>
 </message>
 
 <iq from="alicE@localhost" to="alicE@localhost/res1" id="10bca" type="result">
-<count xmlns='erlang-solutions.com:xmpp:inbox:0'>1</count>
+  <count xmlns='erlang-solutions.com:xmpp:inbox:0'>1</count>
 </iq>
 
 ```

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -36,7 +36,7 @@ or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.
 ### Filtering and ordering
 
 Inbox query results may be filtered by time range and sorted by timestamp.
-By default, `mod_inbox` returns all conversations, most recently updated first.
+By default, `mod_inbox` returns all conversations, listing the ones updated most recently first.
 
 A client may specify three parameters:
 
@@ -44,9 +44,9 @@ A client may specify three parameters:
 * End date for the result set (variable `end`, value: ISO timestamp)
 * Order by timestamp (variable `order`, values: `asc`, `desc`)
 
-They are encoded inside standard XMPP [Data Forms](https://xmpp.org/extensions/xep-0004.html) format.
+They are encoded inside a standard XMPP [Data Forms](https://xmpp.org/extensions/xep-0004.html) format.
 Dates must be formatted according to [XMPP Date and Time Profiles](https://xmpp.org/extensions/xep-0082.html).
-See example below.
+See the example below.
 
 Your client application may request the currently supported form with IQ get:
 

--- a/include/mod_inbox.hrl
+++ b/include/mod_inbox.hrl
@@ -1,15 +1,29 @@
--type username() :: binary().
--type host() :: binary().
+-type username() :: jid:luser().
+
+-type host() :: jid:lserver().
+
 -type sender() :: binary().
+
 -type content() :: binary().
--type count() :: binary().
+
+-type count_bin() :: binary().
+
 -type id() :: binary().
+
 -type get_inbox_res() :: list(inbox_res()).
--type inbox_res() :: {username(), content(), count()}.
+
+-type inbox_res() :: {RemoteUser :: username(),
+                      MsgContent :: content(),
+                      UnreadCount :: count_bin(),
+                      Timestamp :: erlang:timestamp()}.
+
 -type inbox_write_res() :: ok | {error, any()}.
+
 -type marker() :: binary().
+
 -type single_query_result() :: {selected, [tuple()]} |
-{updated, non_neg_integer() |undefined} |
-{aborted, Reason :: term()} |
-{error, Reason :: string() | duplicate_key}.
+                               {updated, non_neg_integer() | undefined} |
+                               {aborted, Reason :: term()} |
+                               {error, Reason :: string() | duplicate_key}.
+
 -type query_result() :: single_query_result() | [single_query_result()].

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -462,6 +462,7 @@ CREATE TABLE dbo.inbox(
     content VARBINARY(max) NOT NULL,
     unread_count INT NOT NULL,
     msg_id NVARCHAR(250) NOT NULL,
+    timestamp BIGINT NOT NULL,
     CONSTRAINT PK_inbox PRIMARY KEY CLUSTERED(
         luser ASC,
         lserver ASC,

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -471,6 +471,9 @@ CREATE TABLE dbo.inbox(
 )
 GO
 
+CREATE INDEX i_inbox_ts ON inbox(luser, lserver, timestamp);
+GO
+
 SET ANSI_PADDING OFF
 GO
 ALTER TABLE [dbo].[offline_message] ADD  DEFAULT (NULL) FOR [expire]

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -348,6 +348,7 @@ CREATE TABLE inbox (
     content blob                     NOT NULL,
     unread_count int                 NOT NULL,
     msg_id varchar(250),
+    timestamp BIGINT UNSIGNED        NOT NULL,
     PRIMARY KEY(luser, lserver, remote_bare_jid));
 
 CREATE INDEX i_inbox USING BTREE ON inbox(luser, lserver);

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -351,5 +351,5 @@ CREATE TABLE inbox (
     timestamp BIGINT UNSIGNED        NOT NULL,
     PRIMARY KEY(luser, lserver, remote_bare_jid));
 
-CREATE INDEX i_inbox USING BTREE ON inbox(luser, lserver);
+CREATE INDEX i_inbox USING BTREE ON inbox(luser, lserver, timestamp);
 

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -309,6 +309,7 @@ CREATE TABLE inbox (
     content bytea                    NOT NULL,
     unread_count int                 NOT NULL,
     msg_id varchar(250),
+    timestamp BIGINT                 NOT NULL,
     PRIMARY KEY(luser, lserver, remote_bare_jid));
 
 CREATE INDEX i_inbox

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -314,5 +314,5 @@ CREATE TABLE inbox (
 
 CREATE INDEX i_inbox
     ON inbox
-    USING BTREE(luser, lserver);
+    USING BTREE(luser, lserver, timestamp);
 

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -75,7 +75,7 @@ handle_system_message(Host, Room, Remote, Packet) ->
         invite->
             handle_invitation_message(Host, Room, Remote, Packet);
         other ->
-            ?WARNING_MSG("unknown system messasge for mod_inbox_muclight='~p'", [Packet]),
+            ?DEBUG("event=unknown_system_message_for_mod_inbox_muclight,stanza='~p'", [Packet]),
             ok
     end.
 
@@ -138,14 +138,16 @@ write_to_inbox(Server, RoomUser, Remote, _Sender, Packet) ->
                          Packet :: exml:element()) -> boolean().
 is_system_message(Sender, Receiver, Packet) ->
     ReceiverDomain = Receiver#jid.lserver,
-    MUCLightDomain = list_to_binary(gen_mod:get_module_opt(ReceiverDomain, mod_muc_light, host, undefined)),
+    MUCLightDomain = list_to_binary(gen_mod:get_module_opt(ReceiverDomain, mod_muc_light,
+                                                           host, undefined)),
     case {Sender#jid.lserver, Sender#jid.lresource} of
         {MUCLightDomain, <<>>} ->
             true;
         {MUCLightDomain, _RoomUser} ->
             false;
         Other ->
-            ?WARNING_MSG("unknown messasge for mod_inbox_muclight='~p' with error ~p", [Packet, Other])
+            ?WARNING_MSG("event=unknown_message_for_mod_inbox_muclight,packet='~p',error='~p'",
+                         [Packet, Other])
     end.
 
 

--- a/src/inbox/mod_inbox_odbc.erl
+++ b/src/inbox/mod_inbox_odbc.erl
@@ -13,16 +13,16 @@
 -include("mod_inbox.hrl").
 
 %% API
--export([get_inbox/2,
+-export([get_inbox/3,
          init/2,
-         set_inbox/6,
-         set_inbox_incr_unread/5,
+         set_inbox/7,
+         set_inbox_incr_unread/6,
          reset_unread/4,
          remove_inbox/3,
          clear_inbox/2]).
 
 %% For specific backends
--export([esc_string/1]).
+-export([esc_string/1, esc_int/1]).
 
 %% ----------------------------------------------------------------------
 %% API
@@ -34,9 +34,10 @@ init(VHost, _Options) ->
     ok.
 
 -spec get_inbox(LUsername :: jid:luser(),
-                LServer :: jid:lserver()) -> get_inbox_res().
-get_inbox(LUsername, LServer) ->
-    case get_inbox_rdbms(LUsername, LServer) of
+                LServer :: jid:lserver(),
+                Params :: mod_inbox:get_inbox_params()) -> get_inbox_res().
+get_inbox(LUsername, LServer, Params) ->
+    case get_inbox_rdbms(LUsername, LServer, Params) of
         {selected, []} ->
             [];
         {selected, Res} ->
@@ -44,26 +45,38 @@ get_inbox(LUsername, LServer) ->
     end.
 
 
--spec get_inbox_rdbms(LUser :: jid:luser(), Server :: jid:lserver()) -> query_result().
-get_inbox_rdbms(LUser, Server) ->
-    mongoose_rdbms:sql_query(
-        Server,
-        ["select remote_bare_jid, content, unread_count from inbox "
-        "where luser=", esc_string(LUser), " and lserver=", esc_string(Server), ";"]).
+-spec get_inbox_rdbms(LUser :: jid:luser(),
+                      LServer :: jid:lserver(),
+                      Params :: mod_inbox:get_inbox_params()) ->
+    query_result().
+get_inbox_rdbms(LUser, LServer, #{ order := Order } = Params) ->
+    OrderSQL = order_to_sql(Order),
+    BeginSQL = sql_and_where_timestamp(">=", maps:get(start, Params, undefined)),
+    EndSQL = sql_and_where_timestamp("<=", maps:get('end', Params, undefined)),
+    Query = ["SELECT remote_bare_jid, content, unread_count, timestamp FROM inbox "
+                 "WHERE luser=", esc_string(LUser),
+                 " AND lserver=", esc_string(LServer),
+                 BeginSQL, EndSQL,
+                 " ORDER BY timestamp ", OrderSQL, ";"],
+    mongoose_rdbms:sql_query(LServer, Query).
 
--spec set_inbox(Username, Server, ToBareJid, Content, Count, MsgId) -> inbox_write_res() when
+-spec set_inbox(Username, Server, ToBareJid, Content,
+                Count, MsgId, Timestamp) -> inbox_write_res() when
                 Username :: jid:luser(),
                 Server :: jid:lserver(),
                 ToBareJid :: binary(),
                 Content :: binary(),
                 Count :: binary(),
-                MsgId :: binary().
-set_inbox(Username, Server, ToBareJid, Content, Count, MsgId) ->
+                MsgId :: binary(),
+                Timestamp :: erlang:timestamp().
+set_inbox(Username, Server, ToBareJid, Content, Count, MsgId, Timestamp) ->
     LUsername = jid:nodeprep(Username),
     LServer = jid:nameprep(Server),
     LToBareJid = jid:nameprep(ToBareJid),
     BackendModule = odbc_specific_backend(Server),
-    Res = BackendModule:set_inbox(LUsername, LServer, LToBareJid, Content, Count, MsgId),
+    NumericTimestamp = usec:from_now(Timestamp),
+    Res = BackendModule:set_inbox(LUsername, LServer, LToBareJid,
+                                  Content, Count, MsgId, NumericTimestamp),
     ok = check_result(Res, 1).
 
 -spec remove_inbox(User :: binary(),
@@ -89,14 +102,18 @@ remove_inbox_rdbms(Username, Server, ToBareJid) ->
                             Server :: binary(),
                             ToBareJid :: binary(),
                             Content :: binary(),
-                            MsgId :: binary()) -> ok.
-set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId) ->
+                            MsgId :: binary(),
+                            Timestamp :: erlang:timestamp()) -> ok.
+set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId, Timestamp) ->
     LUsername = jid:nodeprep(Username),
     LServer = jid:nameprep(Server),
     LToBareJid = jid:nameprep(ToBareJid),
     BackendModule = odbc_specific_backend(Server),
-    Res = BackendModule:set_inbox_incr_unread(LUsername, LServer, LToBareJid, Content, MsgId),
-    %% psql will always return {updated, 1} but mysql will return {updated, 2} if it overwrites the row
+    NumericTimestamp = usec:from_now(Timestamp),
+    Res = BackendModule:set_inbox_incr_unread(LUsername, LServer, LToBareJid,
+                                              Content, MsgId, NumericTimestamp),
+    %% psql will always return {updated, 1}
+    %% but mysql will return {updated, 2} if it overwrites the row
     check_result(Res,[1,2]).
 
 -spec reset_unread(User :: binary(),
@@ -130,21 +147,39 @@ clear_inbox(Username, Server) ->
 esc_string(String) ->
     mongoose_rdbms:use_escaped_string(mongoose_rdbms:escape_string(String)).
 
+-spec esc_int(integer()) -> mongoose_rdbms:sql_query_part().
+esc_int(Integer) ->
+    mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Integer)).
+
+
 %% ----------------------------------------------------------------------
 %% Internal functions
 %% ----------------------------------------------------------------------
+
+-spec order_to_sql(Order :: asc | desc) -> binary().
+order_to_sql(asc) -> <<"ASC">>;
+order_to_sql(desc) -> <<"DESC">>.
+
+-spec sql_and_where_timestamp(Operator :: string(), Timestamp :: erlang:timestamp()) -> iolist().
+sql_and_where_timestamp(_Operator, undefined) ->
+    [];
+sql_and_where_timestamp(Operator, Timestamp) ->
+    NumericTimestamp = usec:from_now(Timestamp),
+    [" AND timestamp ", Operator, esc_int(NumericTimestamp)].
 
 -spec clear_inbox_rdbms(Username :: jid:luser(), Server :: jid:lserver()) -> query_result().
 clear_inbox_rdbms(Username, Server) ->
     mongoose_rdbms:sql_query(Server, ["delete from inbox where luser=",
         esc_string(Username), " and lserver=", esc_string(Server), ";"]).
 
--spec decode_row(host(), {username(), binary(), count()}) -> inbox_res().
-decode_row(LServer, {Username, Content, Count}) ->
+-spec decode_row(host(), {username(), binary(), count_bin(), non_neg_integer() | binary()}) ->
+    inbox_res().
+decode_row(LServer, {Username, Content, Count, Timestamp}) ->
     Pool = mongoose_rdbms_sup:pool(LServer),
     Data = mongoose_rdbms:unescape_binary(Pool, Content),
     BCount = count_to_bin(Count),
-    {Username, Data, BCount}.
+    NumericTimestamp = mongoose_rdbms:result_to_integer(Timestamp),
+    {Username, Data, BCount, usec:to_now(NumericTimestamp)}.
 
 
 odbc_specific_backend(Host) ->

--- a/src/inbox/mod_inbox_odbc_mysql.erl
+++ b/src/inbox/mod_inbox_odbc_mysql.erl
@@ -12,9 +12,9 @@
 
 -include("mod_inbox.hrl").
 
--export([set_inbox/6, set_inbox_incr_unread/5]).
+-export([set_inbox/7, set_inbox_incr_unread/6]).
 
--import(mod_inbox_odbc, [esc_string/1]).
+-import(mod_inbox_odbc, [esc_string/1, esc_int/1]).
 
 %% --------------------------------------------------------
 %% API
@@ -25,31 +25,37 @@
                 ToBareJid :: binary(),
                 Content :: binary(),
                 Count :: binary(),
-                MsgId :: binary()) -> query_result().
-set_inbox(Username, Server, ToBareJid, Content, Count, MsgId) ->
+                MsgId :: binary(),
+                Timestamp :: non_neg_integer()) -> query_result().
+set_inbox(Username, Server, ToBareJid, Content, Count, MsgId, Timestamp) ->
     mongoose_rdbms:sql_query(Server,
-        ["insert into inbox(luser, lserver, remote_bare_jid, content, unread_count, msg_id) "
+        ["insert into inbox (luser, lserver, remote_bare_jid, content, "
+                            "unread_count, msg_id, timestamp) "
                "values (", esc_string(Username), ",", esc_string(Server), ",",
                            esc_string(ToBareJid), ",", esc_string(Content), ",",
-                           esc_string(Count), ",", esc_string(MsgId),
+                           esc_string(Count), ",", esc_string(MsgId), ",", esc_int(Timestamp),
                        ") on duplicate key "
                "update content=", esc_string(Content),
                ", unread_count=", esc_string(Count),
-               ", msg_id=", esc_string(MsgId), ";"]).
+               ", msg_id=", esc_string(MsgId),
+               ", timestamp=", esc_int(Timestamp), ";"]).
 
 
 -spec set_inbox_incr_unread(Username :: jid:luser(),
                             Server :: jid:lserver(),
                             ToBareJid :: binary(),
                             Content :: binary(),
-                            MsgId :: binary()) -> query_result().
-set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId) ->
+                            MsgId :: binary(),
+                            Timestamp :: non_neg_integer()) -> query_result().
+set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId, Timestamp) ->
     mongoose_rdbms:sql_query(Server,
-        ["insert into inbox(luser, lserver, remote_bare_jid, content, unread_count, msg_id) "
+        ["insert into inbox(luser, lserver, remote_bare_jid, content, "
+                           "unread_count, msg_id, timestamp) "
                "values (", esc_string(Username), ", ", esc_string(Server), ",",
                            esc_string(ToBareJid), ", ", esc_string(Content), ", ", "1", ", ",
-                           esc_string(MsgId), ") on duplicate key "
+                           esc_string(MsgId), ", ", esc_int(Timestamp), ") on duplicate key "
                "update content=", esc_string(Content),
-               ", unread_count=inbox.unread_count + 1, "
-               "msg_id=", esc_string(MsgId), ";"]).
+               ", unread_count=inbox.unread_count + 1"
+               ", msg_id=", esc_string(MsgId),
+               ", timestamp=", esc_int(Timestamp), ";"]).
 

--- a/src/inbox/mod_inbox_odbc_pgsql.erl
+++ b/src/inbox/mod_inbox_odbc_pgsql.erl
@@ -12,9 +12,9 @@
 
 -include("mod_inbox.hrl").
 
--export([set_inbox/6, set_inbox_incr_unread/5]).
+-export([set_inbox/7, set_inbox_incr_unread/6]).
 
--import(mod_inbox_odbc, [esc_string/1]).
+-import(mod_inbox_odbc, [esc_string/1, esc_int/1]).
 
 %% ---------------------------------------------------------
 %% API
@@ -25,30 +25,37 @@
                 ToBareJid :: binary(),
                 Content :: binary(),
                 Count :: binary(),
-                MsgId :: binary()) -> query_result().
-set_inbox(Username, Server, ToBareJid, Content, Count, MsgId) ->
+                MsgId :: binary(),
+                Timestamp :: non_neg_integer()) -> query_result().
+set_inbox(Username, Server, ToBareJid, Content, Count, MsgId, Timestamp) ->
     mongoose_rdbms:sql_query(Server,
-        ["insert into inbox(luser, lserver, remote_bare_jid, content, unread_count, msg_id) "
+        ["insert into inbox(luser, lserver, remote_bare_jid, content, "
+                           "unread_count, msg_id, timestamp) "
                 "values (", esc_string(Username), ",", esc_string(Server), ",",
                             esc_string(ToBareJid), ",", esc_string(Content), ",",
-                            esc_string(Count), ",", esc_string(MsgId),
+                            esc_string(Count), ",", esc_string(MsgId), ",", esc_int(Timestamp),
                        ") on conflict (luser, lserver, remote_bare_jid) do "
             "update set content=", esc_string(Content),
                      ", unread_count=", esc_string(Count),
-                     ", msg_id=", esc_string(MsgId), ";"]).
+                     ", msg_id=", esc_string(MsgId),
+                     ", timestamp=", esc_int(Timestamp), ";"]).
 
 -spec set_inbox_incr_unread(Username :: jid:luser(),
                             Server :: jid:lserver(),
                             ToBareJid :: binary(),
                             Content :: binary(),
-                            MsgId :: binary()) -> query_result().
-set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId) ->
+                            MsgId :: binary(),
+                            Timestamp :: non_neg_integer()) -> query_result().
+set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId, Timestamp) ->
     mongoose_rdbms:sql_query(Server,
-        ["insert into inbox(luser, lserver, remote_bare_jid, content, unread_count, msg_id) "
+        ["insert into inbox(luser, lserver, remote_bare_jid, "
+                           "content, unread_count, msg_id, timestamp) "
                 "values (", esc_string(Username), ", ", esc_string(Server), ",",
                             esc_string(ToBareJid), ", ", esc_string(Content), ", ", "1", ", ",
-                            esc_string(MsgId), ") on conflict (luser, lserver, remote_bare_jid) do "
+                            esc_string(MsgId), ", ", esc_int(Timestamp), ") "
+            "on conflict (luser, lserver, remote_bare_jid) do "
             "update set content=", esc_string(Content), ", "
                        "unread_count=inbox.unread_count + 1, "
-                       "msg_id=", esc_string(MsgId), ";"]).
+                       "msg_id=", esc_string(MsgId), ", ",
+                       "timestamp=", esc_int(Timestamp), ";"]).
 

--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -50,7 +50,9 @@ write_to_sender_inbox(Server, Sender, Receiver, Packet) ->
     RemoteBareJid = jid:to_binary(jid:to_bare(Receiver)),
     %% no unread for a user because he writes new messages which assumes he read all previous messages.
     Count = integer_to_binary(0),
-    ok = mod_inbox_backend:set_inbox(Username, Server, RemoteBareJid, Content, Count, MsgId).
+    Timestamp = erlang:timestamp(),
+    ok = mod_inbox_backend:set_inbox(Username, Server, RemoteBareJid,
+                                     Content, Count, MsgId, Timestamp).
 
 -spec write_to_receiver_inbox(Server :: host(),
                               Sender :: jid:jid(),
@@ -61,7 +63,9 @@ write_to_receiver_inbox(Server, Sender, Receiver, Packet) ->
     Content = exml:to_binary(Packet),
     Username = Receiver#jid.luser,
     RemoteBareJid = jid:to_binary(jid:to_bare(Sender)),
-    ok = mod_inbox_backend:set_inbox_incr_unread(Username, Server, RemoteBareJid, Content, MsgId).
+    Timestamp = erlang:timestamp(),
+    ok = mod_inbox_backend:set_inbox_incr_unread(Username, Server, RemoteBareJid,
+                                                 Content, MsgId, Timestamp).
 
 -spec clear_inbox(User :: jid:luser(), Server :: host()) -> ok.
 clear_inbox(User, Server) when is_binary(User) ->

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -557,16 +557,21 @@ timestamp_to_iso({{Year, Month, Day}, {Hour, Minute, Second}}, Timezone) ->
 
 -spec timestamp_to_xml(DateTime :: calendar:datetime() | datetime_micro(),
                        Timezone :: tz(),
-                       FromJID :: jid:simple_jid() | jid:jid(),
-                       Desc :: iodata()) -> exml:element().
+                       FromJID :: jid:simple_jid() | jid:jid() | undefined,
+                       Desc :: iodata() | undefined) -> exml:element().
 timestamp_to_xml(DateTime, Timezone, FromJID, Desc) ->
     {TString, TzString} = timestamp_to_iso(DateTime, Timezone),
-    Text = [#xmlcdata{content = Desc}],
-    From = jid:to_binary(FromJID),
+    Text = case Desc of
+               undefined -> [];
+               _ -> [#xmlcdata{content = Desc}]
+           end,
+    From = case FromJID of
+               undefined -> [];
+               _ -> [{<<"from">>, jid:to_binary(FromJID)}]
+           end,
     #xmlel{name = <<"delay">>,
            attrs = [{<<"xmlns">>, ?NS_DELAY},
-                    {<<"from">>, From},
-                    {<<"stamp">>, list_to_binary(TString ++ TzString)}],
+                    {<<"stamp">>, list_to_binary(TString ++ TzString)} | From],
            children = Text}.
 
 -spec now_to_utc_string(erlang:timestamp()) -> string().


### PR DESCRIPTION
This PR adds timestamps support to `mod_inbox`, including sorting and filtering by them.

Also includes a significant refactor of Inbox tests.