### PR TITLE
json result object extended with message extension properties if there are some Smack lib properties in raw message.

### DIFF
--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -30,10 +30,11 @@
 -define(NOT_IMPLEMENTED, {<<"501">>, _}).
 
 all() ->
-    [{group, messages}, {group, muc}, {group, roster}].
+    [{group, messages}, {group, muc}, {group, roster},{group, messages_with_props}].
 
 groups() ->
-    G = [{messages, [parallel], message_test_cases()},
+    G = [{messages_with_props, [parallel], message_with_props_test_cases()},
+         {messages, [parallel], message_test_cases()},
          {muc, [parallel], muc_test_cases()},
          {roster, [parallel], roster_test_cases()}],
     ct_helper:repeat_all_until_all_ok(G).
@@ -78,6 +79,14 @@ roster_test_cases() ->
      add_and_remove_some_contacts_properly,
      add_and_remove_some_contacts_with_nonexisting,
      break_stuff].
+
+message_with_props_test_cases() ->
+    [
+     msg_with_props_is_sent_and_delivered_over_xmpp,
+     msg_with_props_can_be_parsed,
+     msg_with_malformed_props_can_be_parsed
+     msg_with_malformed_props_is_sent_and_delivered_over_xmpp
+     ].
 
 init_per_suite(C) ->
     application:ensure_all_started(shotgun),
@@ -424,6 +433,81 @@ user_can_be_added_and_removed_by_room_jid(Config) ->
         ?assertEqual(<<"204">>, Status)
     end).
 
+msg_with_props_is_sent_and_delivered_over_xmpp(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        BobJID = user_jid(Bob),
+        MsgID = base16:encode(crypto:strong_rand_bytes(5)),
+        M1 = rest_helper:make_msg_stanza_with_props(BobJID,MsgID),
+
+        escalus:send(Alice, M1),
+
+        M2 = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_message, M2)
+    end).
+
+msg_with_props_can_be_parsed(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
+        BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
+        MsgID = base16:encode(crypto:strong_rand_bytes(5)),
+        M1 = rest_helper:make_msg_stanza_with_props(BobJID,MsgID),
+
+        escalus:send(Alice, M1),
+        mam_helper:maybe_wait_for_archive(Config),
+        
+        AliceCreds = {AliceJID, user_password(alice)},
+
+        % recent msgs with a limit
+        M2 = get_messages_with_props(AliceCreds, BobJID, 1),
+
+        [{MsgWithProps}|_] = M2,
+
+        Data = maps:from_list(MsgWithProps),
+
+        #{<<"properties">>:={Props}} = Data,
+        #{<<"id">>:={ReceivedMsgID}} = Data,
+
+        %we are expecting two properties:"some_string" and "some_number" for this test message
+        %test message defined in rest_helper:make_msg_stanza_with_props
+        2 = length(Props),
+        ReceivedMsgID = MsgID
+
+    end).
+
+msg_with_malformed_props_is_sent_and_delivered_over_xmpp(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        BobJID = user_jid(Bob),
+        MsgID = base16:encode(crypto:strong_rand_bytes(5)),
+
+        M1 = rest_helper:make_malformed_msg_stanza_with_props(BobJID,MsgID),
+
+        escalus:send(Alice, M1),
+
+        M2 = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_message, M2)
+    end).
+
+msg_with_malformed_props_can_be_parsed(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
+        AliceCreds = {AliceJID, user_password(alice)},
+        BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
+        MsgID = base16:encode(crypto:strong_rand_bytes(5)),
+
+        M1 = rest_helper:make_malformed_msg_stanza_with_props(BobJID,MsgID),
+        escalus:send(Alice, M1),
+        
+        mam_helper:maybe_wait_for_archive(Config),
+        
+        % recent msgs with a limit
+        M2 = get_messages_with_props(AliceCreds, BobJID, 1),
+        Recv = [_Msg] = rest_helper:decode_maplist(M2),
+
+        MsgID = maps:get(id, _Msg)
+
+    end).
+
+
 assert_room_messages(RecvMsg, {_ID, _GenFrom, GenMsg}) ->
     escalus:assert(is_chat_message, [maps:get(body, RecvMsg)], GenMsg),
     ok.
@@ -543,6 +627,22 @@ get_messages(MeCreds, Other, Before, Count) ->
                              "&limit=", integer_to_list(Count)]),
     get_messages(GetPath, MeCreds).
 
+get_messages_with_props(MeCreds, Other, Count) ->
+    GetPath = lists:flatten(["/messages/",
+                             binary_to_list(Other),
+                             "?limit=", integer_to_list(Count)]),
+    get_messages_with_props(GetPath, MeCreds).
+
+get_messages_with_props(Path, Creds) ->
+    {{<<"200">>, <<"OK">>}, Msgs} = rest_helper:gett(client, Path, Creds),
+    Msgs.
+
+get_messages_with_props(MeCreds, Other, Before, Count) ->
+    GetPath = lists:flatten(["/messages/",
+                             binary_to_list(Other),
+                             "?before=", integer_to_list(Before),
+                             "&limit=", integer_to_list(Count)]),
+    get_messages_with_props(GetPath, MeCreds).
 
 get_room_messages(Client, RoomID, Count) ->
     get_room_messages(Client, RoomID, Count, undefined).

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -465,7 +465,7 @@ msg_with_props_can_be_parsed(Config) ->
         Data = maps:from_list(MsgWithProps),
 
         #{<<"properties">> := {Props}} = Data,
-        #{<<"id">>:={ReceivedMsgID}} = Data,
+        #{<<"id">> := {ReceivedMsgID}} = Data,
 
         %we are expecting two properties:"some_string" and "some_number" for this test message
         %test message defined in rest_helper:make_msg_stanza_with_props

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -30,7 +30,7 @@
 -define(NOT_IMPLEMENTED, {<<"501">>, _}).
 
 all() ->
-    [{group, messages}, {group, muc}, {group, roster},{group, messages_with_props}].
+    [{group, messages}, {group, muc}, {group, roster}, {group, messages_with_props}].
 
 groups() ->
     G = [{messages_with_props, [parallel], message_with_props_test_cases()},
@@ -460,11 +460,11 @@ msg_with_props_can_be_parsed(Config) ->
         % recent msgs with a limit
         M2 = get_messages_with_props(AliceCreds, BobJID, 1),
 
-        [{MsgWithProps}|_] = M2,
+        [{MsgWithProps} | _] = M2,
 
         Data = maps:from_list(MsgWithProps),
 
-        #{<<"properties">>:={Props}} = Data,
+        #{<<"properties">> := {Props}} = Data,
         #{<<"id">>:={ReceivedMsgID}} = Data,
 
         %we are expecting two properties:"some_string" and "some_number" for this test message
@@ -479,7 +479,7 @@ msg_with_malformed_props_is_sent_and_delivered_over_xmpp(Config) ->
         BobJID = user_jid(Bob),
         MsgID = base16:encode(crypto:strong_rand_bytes(5)),
 
-        M1 = rest_helper:make_malformed_msg_stanza_with_props(BobJID,MsgID),
+        M1 = rest_helper:make_malformed_msg_stanza_with_props(BobJID, MsgID),
 
         escalus:send(Alice, M1),
 

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -84,7 +84,7 @@ message_with_props_test_cases() ->
     [
      msg_with_props_is_sent_and_delivered_over_xmpp,
      msg_with_props_can_be_parsed,
-     msg_with_malformed_props_can_be_parsed
+     msg_with_malformed_props_can_be_parsed,
      msg_with_malformed_props_is_sent_and_delivered_over_xmpp
      ].
 

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -21,7 +21,9 @@
     fill_archive/2,
     fill_room_archive/2,
     make_timestamp/2,
-    change_admin_creds/1
+    change_admin_creds/1,
+    make_msg_stanza_with_props/2,
+    make_malformed_msg_stanza_with_props/2
 ]).
 
 -import(distributed_helper, [mim/0,
@@ -369,3 +371,36 @@ make_room_arc_id({_, RoomJID, _}, Client) ->
     JIDBin = mam_helper:rpc_apply(jid, to_binary, [JID]),
     {JIDBin, JID, undefined}.
 
+%%Make sample message with property for Smack lib.
+make_msg_stanza_with_props(ToJID,MsgID) ->
+    escalus_stanza:from_xml(
+        <<"<message xml:lang='en' to='",ToJID/binary,"' id='",MsgID/binary,"' type='chat'>
+            <body xml:lang='en_US'>Test message with properties</body>
+            <properties xmlns='http://www.jivesoftware.com/xmlns/xmpp/properties'>
+                <property>
+                    <name>some_string</name>
+                    <value type='string'>abcdefghijklmnopqrstuvwxyz</value>
+                </property>
+                <property>
+                    <name>some_number</name>
+                    <value type='long'>1234567890</value>
+                </property>
+            </properties>
+        </message>">>).
+
+%%Make sample message with general property, malformed i.e. not for Smack lib.
+make_malformed_msg_stanza_with_props(ToJID,MsgID) ->
+    escalus_stanza:from_xml(
+        <<"<message xml:lang='en' to='",ToJID/binary,"' id='",MsgID/binary,"' type='chat'>
+            <body xml:lang='en_US'>Test message with malformed properties</body>
+            <properties>
+                <property1>
+                    <name>some_string</name>
+                    <value type='string'>abcdefghijklmnopqrstuvwxyz</value>
+                </property1>
+                <property2>
+                    <name>some_number</name>
+                    <value type='long'>1234567890</value>
+                </property2>
+            </properties>
+        </message>">>).

--- a/doc/rest-api/Client-frontend.md
+++ b/doc/rest-api/Client-frontend.md
@@ -56,7 +56,7 @@ For more details about possible `ejabberd_cowboy` configuration parameters pleas
 see the relevant documentation in the [Listener modules](../advanced-configuration/Listener-modules.md#http-based-services-bosh-websocket-rest-ejabberd_cowboy).
 
 
-##Smack library support
+## Smack library support
 REST API can fetch messages for [Smack](https://github.com/igniterealtime/Smack/blob/master/documentation/extensions/properties.md#stanza-properties) Stanza Properties.
 
 For example if we have properties in the stanza like:

--- a/doc/rest-api/Client-frontend.md
+++ b/doc/rest-api/Client-frontend.md
@@ -55,6 +55,40 @@ By default the REST API is exposed on port 8089 but this can be changed to whate
 For more details about possible `ejabberd_cowboy` configuration parameters please
 see the relevant documentation in the [Listener modules](../advanced-configuration/Listener-modules.md#http-based-services-bosh-websocket-rest-ejabberd_cowboy).
 
+
+##Smack library support
+REST API can fetch messages for [Smack](https://github.com/igniterealtime/Smack/blob/master/documentation/extensions/properties.md#stanza-properties) Stanza Properties.
+
+For example if we have properties in the stanza like:
+  ```
+      <message xml:lang='en' to='alice@localhost' id='123' type='chat'>
+        <body xml:lang='en_US'>Hi!</body>
+        <properties xmlns="http://www.jivesoftware.com/xmlns/xmpp/properties"
+            <property>
+                <name>some_number</name>
+                <value type='integer'>123</value>
+            <property>
+            <property>
+                <name>some_string</name>
+                <value type='string'>abc</value>
+            <property>
+        </properties>
+      </message>
+  ```
+then in the final json message these properties will be converted to json map without tag names:
+```
+    {   "to": "alice@localhost",
+        "timestamp": 1531329049949,
+        "id": "123",
+        "from": "bob@localhost",
+        "body": "Hi!",
+        "properties":{
+            "some_number":123,
+            "some_string":"abc"
+        }
+    }
+```
+
 ## OpenAPI specifications
 
 See the beautiful [Swagger documentation](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true) for more information.

--- a/doc/rest-api/Client-frontend.md
+++ b/doc/rest-api/Client-frontend.md
@@ -75,7 +75,7 @@ For example if we have properties in the stanza like:
         </properties>
       </message>
   ```
-then in the final json message these properties will be converted to json map without tag names:
+then in the final json message these properties will be converted to json map without tag names and all types will be taken as string:
 ```
     {   "to": "alice@localhost",
         "timestamp": 1531329049949,
@@ -83,7 +83,7 @@ then in the final json message these properties will be converted to json map wi
         "from": "bob@localhost",
         "body": "Hi!",
         "properties":{
-            "some_number":123,
+            "some_number":"123",
             "some_string":"abc"
         }
     }

--- a/src/mongoose_client_api_messages.erl
+++ b/src/mongoose_client_api_messages.erl
@@ -117,9 +117,7 @@ encode(Msg, Timestamp) ->
 
     ExtensionList =
       case RawMsgProps of
-           #xmlel{name = _,
-                  attrs = _,
-                  children = Children} ->
+           #xmlel{children = Children} ->
                                         Props = [convert_prop_child(Child) || Child <- Children],
                                         [{<<"properties">>, maps:from_list(Props)}];
                                      _ ->
@@ -136,8 +134,8 @@ encode(Msg, Timestamp) ->
     maps:from_list(L).
 
 convert_prop_child(Child)->
-    Name = exml_query:path(Child, [{element,<<"name">>}, cdata]),
-    Value = exml_query:path(Child, [{element,<<"value">>}, cdata]),
+    Name = exml_query:path(Child, [{element, <<"name">>}, cdata]),
+    Value = exml_query:path(Child, [{element, <<"value">>}, cdata]),
     {Name, Value}.
 
 maybe_jid(undefined) ->


### PR DESCRIPTION

This PR addresses #1910

Proposed changes include:
Basic idea is to add Smack Lib properties part of raw xml message to the result json. If there are properties then old json will be returned.

