### PR TITLE
Add missing params support to mod_mam_meta

### DIFF
--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -85,14 +85,25 @@ mam_type_to_core_mod(muc) -> mod_mam_muc.
 
 -spec valid_core_mod_opts(module()) -> [atom()].
 valid_core_mod_opts(mod_mam) ->
-    [no_stanzaid_element,
+    [
+     no_stanzaid_element,
      is_archivable_message,
      archive_chat_markers,
      extra_lookup_params,
      full_text_search,
-     archive_groupchats];
+     archive_groupchats,
+     default_result_limit,
+     max_result_limit
+    ];
 valid_core_mod_opts(mod_mam_muc) ->
-    [is_archivable_message, host, extra_lookup_params, full_text_search].
+    [
+     is_archivable_message,
+     host,
+     extra_lookup_params,
+     full_text_search,
+     default_result_limit,
+     max_result_limit
+    ].
 
 -spec parse_backend_opts(odbc | cassandra | riak | elasticsearch, Type :: pm | muc,
                          Opts :: proplists:proplist(), deps()) -> deps().


### PR DESCRIPTION
This PR adds support for  `default_result_limit` and `max_result_limit` parameters in `mod_mam_meta`.