### PR TITLE
Suppress ugly error when there are no services for big tests

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -94,13 +94,19 @@ maybe_start_services() {
 }
 
 start_services() {
-    for env in ${BASE}/big_tests/services/*-compose.yml; do
-        echo "Stating service" $(basename "${env}") "..."
-        time ${BASE}/tools/docker-compose.sh -f "${env}" pull --parallel
-        time ${BASE}/tools/docker-compose.sh -f "${env}" up -d
-        echo "docker-compose execution time reported above"
-        echo ""
-    done
+    local SERVICES_DIR="${BASE}/big_tests/services"
+    local SERVICES_FILES="$SERVICES_DIR/*-compose.yml"
+    if [ -d $SERVICES_DIR ] && [ "$(ls $SERVICES_FILES)" ]; then
+        for env in $SERVICES_FILES; do
+            echo "Stating service" $(basename "${env}") "..."
+            time ${BASE}/tools/docker-compose.sh -f "${env}" pull --parallel
+            time ${BASE}/tools/docker-compose.sh -f "${env}" up -d
+            echo "docker-compose execution time reported above"
+            echo ""
+        done
+    else
+        echo "No services found."
+    fi
 }
 
 run_test_preset() {


### PR DESCRIPTION
This PR addresses removes these ugly errors when service files are missing, while retaining the services support:

```
.IOError: [Errno 2] No such file or directory: u'/home/travis/build/esl/MongooseIM/big_tests/services/*-compose.yml'
real	0m2.581s
user	0m0.020s
sys	0m0.008s
.IOError: [Errno 2] No such file or directory: u'/home/travis/build/esl/MongooseIM/big_tests/services/*-compose.yml'
real	0m0.735s
user	0m0.012s
sys	0m0.012s
docker-compose execution time reported above
```
