### PR TITLE
Adjust "conflict_check_failed" log severity

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1319,10 +1319,10 @@ process_incoming_stanza_with_conflict_check(Name, From, To, Acc, StateName, Stat
         conflict -> %% A race condition detected
             %% Same jid, but different sids
             OriginSID = mongoose_acc:get_prop(origin_sid, Acc),
-            ?ERROR_MSG("event=conflict_check_failed "
-                        "jid=~ts c2s_sid=~p origin_sid=~p acc=~1000p",
-                       [jid:to_binary(StateData#state.jid), StateData#state.sid,
-                        OriginSID, Acc]),
+            ?WARNING_MSG("event=conflict_check_failed "
+                          "jid=~ts c2s_sid=~p origin_sid=~p acc=~1000p",
+                         [jid:to_binary(StateData#state.jid), StateData#state.sid,
+                          OriginSID, Acc]),
             finish_state(ok, StateName, StateData);
         _ -> %% Continue processing
             process_incoming_stanza(Name, From, To, Acc, StateName, StateData)


### PR DESCRIPTION
See #1963. There are error logs occuring when a client attempts to
reconnect in a very short timespan and at the same time a stanza is
routed to the old invalid connection.

As this is just an application/client oddity the log severity should be
lowered to "warning". This is simply nothing to alert an operations guy
in the middle of the night.

There are actually a lot more logs like this but this one currently
stands out ;).