### PR TITLE
Upgrade worker_pool to 3.1.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -46,7 +46,7 @@
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.7.1"}}},
   {fast_tls, ".*", {git, "https://github.com/processone/fast_tls.git", "a166f0e9fe78304e5ca628fd5eff57c850241813"}},
   {lasse, ".*", {git, "https://github.com/inaka/lasse.git", "692eaec"}},
-  {worker_pool, ".*", {git, "https://github.com/inaka/worker_pool.git", {branch, "fix-spec-3.0.0"}}},
+  {worker_pool, ".*", {git, "https://github.com/inaka/worker_pool.git", {ref, "59f2ff8"}}},
 
   {riakc, ".*", {git, "https://github.com/basho/riak-erlang-client", "2.5.3"}},
   {cqerl, ".*", {git, "https://github.com/esl/cqerl.git", {ref, "08067ae"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -216,7 +216,7 @@
   0},
  {<<"worker_pool">>,
   {git,"https://github.com/inaka/worker_pool.git",
-       {ref,"888ef6a376a3797d1a517bbf901019558e6a7150"}},
+       {ref,"59f2ff8a0b3ac634d08c8332a8e04175ac52b17a"}},
   0}]}.
 [
 {pkg_hash,[

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -66,7 +66,7 @@
 start(Host, Opts) ->
     ?INFO_MSG("mod_event_pusher_push starting on host ~p", [Host]),
 
-    {ok, _} = wpool_sup:start_pool(gen_mod:get_module_proc(Host, ?MODULE),
+    {ok, _} = wpool:start_sup_pool(gen_mod:get_module_proc(Host, ?MODULE),
                                    gen_mod:get_opt(wpool, Opts, [])),
 
     gen_mod:start_backend_module(?MODULE, Opts, []),
@@ -91,7 +91,7 @@ stop(Host) ->
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_PUSH),
     mod_disco:unregister_feature(Host, ?NS_PUSH),
 
-    wpool_sup:stop_pool(gen_mod:get_module_proc(Host, ?MODULE)),
+    wpool:stop_sup_pool(gen_mod:get_module_proc(Host, ?MODULE)),
 
     ok.
 

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -50,7 +50,7 @@ start(Host, Opts) ->
     ?INFO_MSG("mod_push_service starting on host ~p", [Host]),
 
     MaxHTTPConnections = gen_mod:get_opt(max_http_connections, Opts, 100),
-    wpool_sup:start_pool(pool_name(Host, wpool), [{workers, MaxHTTPConnections}]),
+    wpool:start_sup_pool(pool_name(Host, wpool), [{workers, MaxHTTPConnections}]),
 
     %% Hooks
     ejabberd_hooks:add(push_notifications, Host, ?MODULE, push_notifications, 10),
@@ -60,7 +60,7 @@ start(Host, Opts) ->
 -spec stop(Host :: jid:server()) -> ok.
 stop(Host) ->
     ejabberd_hooks:delete(push_notifications, Host, ?MODULE, push_notifications, 10),
-    wpool_sup:stop_pool(pool_name(Host, wpool)),
+    wpool:stop_sup_pool(pool_name(Host, wpool)),
 
     ok.
 


### PR DESCRIPTION
This PR upgrades worker_pool dep to 3.1.1. In fact it uses worker_pool from branch `rel-3.1` (with small fix to function specs) since master branch works only with Erlang/OTP 21.

