### PR TITLE
Fix test-runner test cases completion for inbox_SUITE

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -63,7 +63,7 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    case is_odbc_enabled(domain()) of
+    case (not ct_helper:is_ct_running()) orelse is_odbc_enabled(domain()) of
       true ->
           tests();
       false ->


### PR DESCRIPTION
This PR addresses the error in autocompletion:

```erlang
./tools/test-runner.sh --skip-small-tests --preset mysql_mnesia --skip-cover --rerun-big-tests -- inbox:all_call_failed suite=inbox_SUITE reason=error:badarg                                                                                                        
 stacktrace=[{ets,select,                                                                                                         
                 [ct_attributes,                                                                                                  
                  [{{ct_conf,'_','$1','_','_',hosts,'_'},[],[{{'$1'}}]}]],                                                        
                 []},                                                                                                             
             {ct_config,lookup_name,1,[{file,"ct_config.erl"},{line,414}]},                                                       
             {ct_config,lookup_config,1,[{file,"ct_config.erl"},{line,406}]},          
             {ct_config,get_config,3,[{file,"ct_config.erl"},{line,352}]},                                                        
             {inbox_SUITE,all,0,[{file,"inbox_SUITE.erl"},{line,66}]},                                                            
             {complete_test_name,all,1,                          
                 [{file,"tools/test_runner/complete_test_name.erl"},                                                              
                  {line,17}]},                                                                                                    
             {complete_test_name,suggest_for_suite,1,                                  
                 [{file,"tools/test_runner/complete_test_name.erl"},                                                              
                  {line,11}]},                                                                                                    
             {complete_test_name,main,1,                         
                 [{file,"tools/test_runner/complete_test_name.erl"},                   
                  {line,5}]}]  
```

Be aware, that we should not call CT from all/0 callback.