### PR TITLE
Add --colors option for test-runner

### DIFF
--- a/tools/test-runner-complete.sh
+++ b/tools/test-runner-complete.sh
@@ -115,6 +115,7 @@ _run_all_tests() {
                           --show-small-reports \
                           --show-big-reports \
                           --rerun-big-tests \
+                          --colors \
                           '"$SUGGESTIONS"' \
                           '"$SUITES"' \
                            --' -- $cur ) );;


### PR DESCRIPTION
This PR adds a new option for test runner.

So this works:

```bash
./tools/test-runner.sh --help --examples --colors | more
```

Before we would only use colors if they are supported my terminal. i.e.

```bash
# still has colors usually
./tools/test-runner.sh --help --examples 

# Nope, no colors, it's a pipe
./tools/test-runner.sh --help --examples | more
```

