### PR TITLE
Elixir support

### DIFF
--- a/elixir_libs/mongooseim_elixir/.gitignore
+++ b/elixir_libs/mongooseim_elixir/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/elixir_libs/mongooseim_elixir/README.md
+++ b/elixir_libs/mongooseim_elixir/README.md
@@ -1,0 +1,21 @@
+# MongooseimElixir
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `mongooseim_elixir` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:mongooseim_elixir, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/mongooseim_elixir](https://hexdocs.pm/mongooseim_elixir).
+

--- a/elixir_libs/mongooseim_elixir/config/config.exs
+++ b/elixir_libs/mongooseim_elixir/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :mongooseim_elixir, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:mongooseim_elixir, :key)
+#
+# You can also configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/elixir_libs/mongooseim_elixir/lib/mongooseim_elixir.ex
+++ b/elixir_libs/mongooseim_elixir/lib/mongooseim_elixir.ex
@@ -1,0 +1,18 @@
+defmodule MongooseimElixir do
+  @moduledoc """
+  Documentation for MongooseimElixir.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> MongooseimElixir.hello
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/elixir_libs/mongooseim_elixir/mix.exs
+++ b/elixir_libs/mongooseim_elixir/mix.exs
@@ -1,0 +1,28 @@
+defmodule MongooseimElixir.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :mongooseim_elixir,
+      version: "0.1.0",
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+    ]
+  end
+end

--- a/elixir_libs/mongooseim_elixir/test/mongooseim_elixir_test.exs
+++ b/elixir_libs/mongooseim_elixir/test/mongooseim_elixir_test.exs
@@ -1,0 +1,8 @@
+defmodule MongooseimElixirTest do
+  use ExUnit.Case
+  doctest MongooseimElixir
+
+  test "greets the world" do
+    assert MongooseimElixir.hello() == :world
+  end
+end

--- a/elixir_libs/mongooseim_elixir/test/test_helper.exs
+++ b/elixir_libs/mongooseim_elixir/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/rebar.config
+++ b/rebar.config
@@ -135,6 +135,8 @@
   %% This plugin is totally optional and everything would work without it (just slower)
   {rebar_faster_deps, {git, "https://github.com/arcusfelis/rebar3-faster-deps-plugin.git",
       {ref, "eb3cded5b050edd82cf8653f8c850c6c9890f732"}}},
+  {rebar3_elixir_compile, ".*",
+    {git, "https://github.com/barrel-db/rebar3_elixir_compile.git", {branch, "master"}}},
   {pc, {git, "https://github.com/blt/port_compiler.git", {ref, "c2f3fb1"}}},
   {coveralls, {git, "https://github.com/michalwski/coveralls-erl.git", {ref, "f124a62"}}},
   {provider_asn1, {git, "https://github.com/knusbaum/provider_asn1.git", {ref, "29f7850"}}}
@@ -174,3 +176,9 @@
 {cover_export_enabled, true}.
 {coveralls_coverdata, "_build/**/cover/*.coverdata"}.
 {coveralls_service_name, "travis-ci"}.
+
+{elixir_opts,
+  [
+    {env, dev}
+  ]
+}.

--- a/rebar.config
+++ b/rebar.config
@@ -135,6 +135,7 @@
   %% This plugin is totally optional and everything would work without it (just slower)
   {rebar_faster_deps, {git, "https://github.com/arcusfelis/rebar3-faster-deps-plugin.git",
       {ref, "eb3cded5b050edd82cf8653f8c850c6c9890f732"}}},
+  %% optional, if elixir application included
   {rebar3_elixir_compile, ".*",
     {git, "https://github.com/barrel-db/rebar3_elixir_compile.git", {branch, "master"}}},
   {pc, {git, "https://github.com/blt/port_compiler.git", {ref, "c2f3fb1"}}},
@@ -143,8 +144,14 @@
  ]}.
 
 {provider_hooks,
- [{pre,  [{compile, {asn, compile}}, {compile, {pc, compile}}]},
-  {post, [{clean, {asn, clean}}, {clean, {pc, clean}}]
+ [{pre, [
+    {compile, {ex, compile}}, %% optional, if elixir application included
+    {compile, {asn, compile}},
+    {compile, {pc, compile}},
+    {release, {ex, compile}}]}, %% optional, if elixir application included
+  {post, [
+    {clean, {asn, clean}},
+    {clean, {pc, clean}}]
   }]}.
 
 {overrides,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -56,12 +56,12 @@ end,
 
 RequiredApps = fun() -> [mongooseim, inets, tools] end,
 EnvApps = GetEnvApps(),
+EnvAppsToInclude = [ list_to_atom(App) || App <- string:tokens(EnvApps, " \n\r") ],
 
 SetupIncludedApps =
 fun(Config, EnvApps) ->
         RelxCfg = proplists:get_value(relx, Config),
         {release, Desc, _Apps} = lists:keyfind(release, 1, RelxCfg),
-        EnvAppsToInclude = [ list_to_atom(App) || App <- string:tokens(EnvApps, " \n\r") ],
         AppsToIncludeIn = RequiredApps() ++ DevAppsToInclude() ++ EnvAppsToInclude,
         AppsToInclude = ordsets:to_list(ordsets:from_list(AppsToIncludeIn)),
         NewReleaseCfg = {release, Desc, AppsToInclude},
@@ -82,6 +82,39 @@ MaybeFIPSSupport = fun(Config) ->
     end
 end,
 
+%% Removes hook handler from provider_hooks list
+DisableHooksFor = fun(Config, DisabledPluginName) ->
+    Hooks = proplists:get_value(provider_hooks, Config),
+    Hooks2 = [[Rule || {_Command, {Plugin, _Call}} = Rule <- Rules,
+                       Plugin =/= DisabledPluginName]
+              || {PreOrPost, Rules} <- Hooks],
+    lists:keyreplace(provider_hooks, 1, Config, {provider_hooks, Hooks2})
+end,
+
+%% There are several ways to specify plugin
+GetPluginName = fun(Plugin) when is_tuple(Plugin) -> element(1, Plugin);
+                   (Plugin) -> Plugin end, %% most likely atom
+
+DisablePlugin = fun(Config, DisabledPluginName) ->
+    Plugins = proplists:get_value(plugins, Config),
+    Plugins2 = [Plugin || Plugin <- Plugins,
+                GetPluginName(Plugin) =/= DisabledPluginName],
+    lists:keyreplace(plugins, 1, Config, {plugins, Plugins2})
+end,
+
+%% If tools/configure has added elixir application, we keep config as-is
+%% Otherwise, we can remove rebar3_elixir_compile and it's hooks
+MaybeDisableElixirSupport = fun(Config) ->
+    case lists:member(elixir, EnvAppsToInclude) of
+        true ->
+            Config;
+        false ->
+            Config2 = DisableHooksFor(Config, ex),
+            DisablePlugin(Config2, rebar3_elixir_compile)
+    end
+end,
+
 Config0 = MaybeConfigureCoveralls(CONFIG),
 Config1 = SetupIncludedApps(Config0, EnvApps),
-MaybeFIPSSupport(Config1).
+Config2 = MaybeFIPSSupport(Config1),
+MaybeDisableElixirSupport(Config2).

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -103,7 +103,7 @@ DisablePlugin = fun(Config, DisabledPluginName) ->
 end,
 
 %% If tools/configure has added elixir application, we keep config as-is
-%% Otherwise, we can remove rebar3_elixir_compile and it's hooks
+%% Otherwise, we can remove rebar3_elixir_compile and its hooks
 MaybeDisableElixirSupport = fun(Config) ->
     case lists:member(elixir, EnvAppsToInclude) of
         true ->

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -173,7 +173,7 @@ case "$1" in
             -- ${1+"$@"}
         ;;
 
-    debug)
+    debug|iex_debug)
         echo "--------------------------------------------------------------------"
         echo ""
         echo "IMPORTANT: we will attempt to attach an INTERACTIVE shell"
@@ -198,11 +198,18 @@ case "$1" in
         BINDIR="$ROOTDIR/erts-$ERTS_VSN/bin"
         PROGNAME=`echo $0 | sed 's/.*\\///'`
 
+        EXOPTIONS=""
+        case "$1" in
+            iex_debug)
+                EXOPTIONS="-noshell -eval 'Elixir.IEx':start()."
+                ;;
+        esac
+
         # Log the startup
         logger -t "$SCRIPT[$$]" "Starting up"
 
         # Start the VM
-        exec_echo "$BINDIR/erl" "$NAME" "debug-$TTY-$NODE" $COOKIE_ARG -remsh "$NODE" -hidden -args_file "$RUNNER_ETC_DIR/vm.dist.args"
+        exec_echo "$BINDIR/erl" "$NAME" "debug-$TTY-$NODE" $COOKIE_ARG -remsh "$NODE" -hidden -args_file "$RUNNER_ETC_DIR/vm.dist.args" $EXOPTIONS
         ;;
 
     version)

--- a/tools/configure
+++ b/tools/configure
@@ -44,6 +44,7 @@ app_opts() ->
      {"jingle-sip",    ["nksip"],           include_driver("nksip")},
      {"cassandra",     ["cqerl"],           include_driver("cassandra")},
      {"elasticsearch", ["tirerl"],          include_driver("elasticsearch")},
+     {"elixir",        ["elixir", "iex"],   "include elixir support"},
      {"aws",           ["erlcloud"],        "include support for AWS services"}].
 
 opts() ->

--- a/tools/configure
+++ b/tools/configure
@@ -44,7 +44,8 @@ app_opts() ->
      {"jingle-sip",    ["nksip"],           include_driver("nksip")},
      {"cassandra",     ["cqerl"],           include_driver("cassandra")},
      {"elasticsearch", ["tirerl"],          include_driver("elasticsearch")},
-     {"elixir",        ["elixir", "iex"],   "include elixir support"},
+     {"elixir",        ["elixir", "iex", "mongooseim_elixir"],
+                                            "include elixir support"},
      {"aws",           ["erlcloud"],        "include support for AWS services"}].
 
 opts() ->


### PR DESCRIPTION
This PR addresses "experimental" stuff.

- [x] Make elixir optional
- [x] Hello world module in `elixir_libs/mongooseim_elixir/lib/mongooseim_elixir.ex`
- [x]  Elixir test example `elixir_libs/mongooseim_elixir/test/mongooseim_elixir_test.exs`
- [x] remote iex shell can be started using `_build/mim1/rel/mongooseim/bin/mongooseim iex_debug`



# Where should we store our elixir files?

`elixir_libs` is hardcoded in https://github.com/barrel-db/rebar3_elixir_compile/blob/master/src/rebar3_elixir_compile.erl

Alternative is to move `elixir_libs/mongooseim_elixir/` into just `elixir` or `ex` and make a patch for `rebar3_elixir_compile`. But I am fine with the current `elixir_libs/mongooseim_elixir/` during prototype stage of the feature.

