### PR TITLE
Fix some test runner bugs

### DIFF
--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -301,9 +301,15 @@ analyze_coverage(_, _) ->
     ok.
 
 prepare(Test) ->
-    Apps = get_apps(),
     Nodes = get_ejabberd_nodes(Test),
+    maybe_compile_cover(Nodes).
+
+maybe_compile_cover([]) ->
+    io:format("cover: skip cover compilation~n", []),
+    ok;
+maybe_compile_cover(Nodes) ->
     io:format("cover: compiling modules for nodes ~p~n", [Nodes]),
+    Apps = get_apps(),
     import_code_paths(hd(Nodes)),
     %% Time is in microseconds
     {Time, Compiled} = timer:tc(fun() ->

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -61,7 +61,7 @@ choose_newest_directory() {
   fi
 
   if [ `uname` = "Darwin" ]; then
-    ls -dt "@" | head -n 1
+    ls -dt "$@" | head -n 1
   else
     ls -d "$@" --sort time | head -n 1
   fi


### PR DESCRIPTION
This PR addresses bugs.

Proposed changes include:
* Fix failed test counting in Mac OS X (ls "@" returns nothing)
* Fix error in run_common_test:prepare/1 when there are no test nodes 

Found by @zofpolkowska