### PR TITLE
Set user 'unavailable' after ping timeout

### DIFF
--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -169,6 +169,11 @@ handle_cast({iq_pong, JID, timeout}, State) ->
             #jid{user = User, server = Server, resource = Resource} = JID,
             case ejabberd_sm:get_session_pid(User, Server, Resource) of
                 Pid when is_pid(Pid) ->
+                    Presence = #xmlel{name = <<"presence">>,
+                                      attrs = [{<<"type">>, <<"unavailable">>},
+                                               {<<"from">>, jid:to_binary(JID)}],
+                                      children = []},
+                    ejabberd_router:route(JID, jid:make(<<>>, Server, <<>>), Presence),
                     ejabberd_c2s:stop(Pid);
                 _ ->
                     ok


### PR DESCRIPTION
If a user is timed out due to mod_ping then there is no presence
information broadcasted, the session is simply killed or hibernated
(when stream management is used). This patch lets mod_ping send an
'unavailable' presence instead of the user such that other peers
are informed about the timed out session.