### PR TITLE
Resend unacked on reconnection fix

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -49,7 +49,7 @@ parallel_test_cases() ->
      h_ok_after_session_enabled_before_session,
      h_ok_after_session_enabled_after_session,
      h_ok_after_a_chat,
-%    resend_unacked_on_reconnection, % TODO fix it #1638
+     resend_unacked_on_reconnection, % TODO fix it #1638
      session_established,
      wait_for_resumption,
      resume_session,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2511,7 +2511,7 @@ resend_offline_message(A, StateData, From, To, Packet, in) ->
     #xmlel{name = Name} = Packet,
     Type = exml_query:attr(Packet, <<"type">>),
     M = #{name => Name, type => Type, element => Packet, from_jid => From,
-        from => jid:to_binary(From), to_jid => To, to => jid:to_binary(To)},
+          from => jid:to_binary(From), to_jid => To, to => jid:to_binary(To)},
     Acc = mongoose_acc:update(A, M),
     check_privacy_and_route_or_ignore(Acc, StateData, From, To, Packet, in).
 
@@ -3282,6 +3282,7 @@ maybe_add_timestamp({F, T, #xmlel{name= <<"message">>}=Packet}=PacketTuple, Time
         <<"headline">> ->
             PacketTuple;
         _ ->
+            %% TODO: ?MYNAME (or server taken from c2s state) not <<"localhost">>
             {F, T, add_timestamp(Timestamp, <<"localhost">>, Packet)}
     end;
 maybe_add_timestamp(Packet, _Timestamp) ->


### PR DESCRIPTION
This PR fixes only `resend_unacked_on_resonnection` test itself. It doesn't fix the real problem.

