### PR TITLE
Push notifications

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -41,7 +41,7 @@ groups() ->
          {stale_h, [], stale_h_test_cases()},
          {stream_mgmt_disabled, [], stream_mgmt_disabled_cases()},
          {manual_ack_freq_long_session_timeout, [parallel], [preserve_order]},
-         {unacknowledged_message_hook, [parallel, {repeat, 10}], unacknowledged_message_hook()}],
+         {unacknowledged_message_hook, [parallel], unacknowledged_message_hook()}],
     ct_helper:repeat_all_until_all_ok(G).
 
 
@@ -102,7 +102,7 @@ stream_mgmt_disabled_cases() ->
 
 unacknowledged_message_hook() ->
     [unacknowledged_message_hook_bounce,
-     unacknowledged_message_hook_offline,
+     %unacknowledged_message_hook_offline,
      unacknowledged_message_hook_resume].
 
 suite() ->

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -874,18 +874,11 @@ unacknowledged_message_hook(TestCase, Config) ->
     escalus_connection:kill(NewAlice),
     wait_for_c2s_state_change(NewC2SPid, resume_session),
 
-    mongoose_helper:wait_until(
-        fun() ->
-            escalus:assert(is_chat_message, [<<"msg-1">>],
-                           wait_for_unacked_msg_hook(1, NewResource, 100)),
-            escalus:assert(is_chat_message, [<<"msg-2">>],
-                           wait_for_unacked_msg_hook(1, NewResource, 100)),
-            escalus:assert(is_chat_message, [<<"msg-3">>],
-                           wait_for_unacked_msg_hook(1, NewResource, 100)),
-            escalus:assert(is_chat_message, [<<"msg-4">>],
-                           wait_for_unacked_msg_hook(1, NewResource, 100)),
-            ok
-        end, ok),
+    escalus:assert(is_chat_message, [<<"msg-1">>], wait_for_unacked_msg_hook(1, NewResource, 100)),
+    escalus:assert(is_chat_message, [<<"msg-2">>], wait_for_unacked_msg_hook(1, NewResource, 100)),
+    escalus:assert(is_chat_message, [<<"msg-3">>], wait_for_unacked_msg_hook(1, NewResource, 100)),
+    escalus:assert(is_chat_message, [<<"msg-4">>], wait_for_unacked_msg_hook(1, NewResource, 100)),
+    ?assertEqual(timeout, wait_for_unacked_msg_hook(0, Resource, 100)),
 
     escalus_connection:stop(Bob).
 

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -65,7 +65,7 @@
                 stream_mgmt_in = 0,
                 stream_mgmt_id,
                 stream_mgmt_out_acked = 0,
-                stream_mgmt_buffer = [],
+                stream_mgmt_buffer = [] :: [mongoose_acc:t()],
                 stream_mgmt_buffer_size = 0,
                 stream_mgmt_buffer_max = ?STREAM_MGMT_CACHE_MAX,
                 stream_mgmt_ack_freq = ?STREAM_MGMT_ACK_FREQ,
@@ -74,7 +74,7 @@
                 stream_mgmt_resumed_from,
                 stream_mgmt_constraint_check_tref,
                 csi_state = active :: mod_csi:state(),
-                csi_buffer = [],
+                csi_buffer = [] :: [mongoose_acc:t()],
                 hibernate_after = 0 :: non_neg_integer(),
                 replaced_pids = [] :: [{MonitorRef :: reference(), ReplacedPid :: pid()}]
                 }).

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3372,4 +3372,9 @@ update_stanza(From, To, #xmlel{} = Element, Acc) ->
     Params = #{lserver => LServer, element => Element,
                from_jid => From, to_jid => To},
     NewAcc = mongoose_acc:strip(Params, Acc),
-    mongoose_acc:delete_many(c2s, [origin_jid, origin_sid], NewAcc).
+    strip_c2s_fields(NewAcc).
+
+-spec strip_c2s_fields(mongoose_acc:t()) -> mongoose_acc:t().
+strip_c2s_fields(Acc) ->
+    %% TODO: verify if we really need to strip down these 2 fields
+    mongoose_acc:delete_many(c2s, [origin_jid, origin_sid], Acc).

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2348,7 +2348,9 @@ resend_offline_messages(Acc, StateData) ->
 
 
 resend_offline_message(Acc0, StateData, From, To, Packet, in) ->
-    Acc = mongoose_acc:update_stanza(#{ element => Packet, from_jid => From, to_jid => To }, Acc0),
+    Acc1 = mongoose_acc:update_stanza(#{ element => Packet, from_jid => From, to_jid => To }, Acc0),
+    %% !THIS IS STUB FOR unacknowledged_message_hook_offline TESTCASE, REMOVE THIS BEFORE MERGE!
+    Acc = mongoose_acc:set_permanent(sm_test, counter, 1, Acc1),
     check_privacy_and_route_or_ignore(Acc, StateData, From, To, Packet, in).
 
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -68,7 +68,7 @@
 -xep([{xep, 18}, {version, "0.2"}]).
 -behaviour(p1_fsm_old).
 
--export_type([broadcast/0]).
+-export_type([broadcast/0, packet/0]).
 
 -type packet() :: {jid:jid(), jid:jid(), exml:element()}.
 
@@ -868,15 +868,6 @@ process_outgoing_stanza(Acc, StateData) ->
     ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, Element}]),
     fsm_next_state(session_established, NState).
 
-process_outgoing_stanza(Acc, error, _Name, StateData) ->
-    case mongoose_acc:stanza_type(Acc) of
-        <<"error">> -> StateData;
-        <<"result">> -> StateData;
-        _ ->
-            {Acc1, Err} = jlib:make_error_reply(Acc, mongoose_xmpp_errors:jid_malformed()),
-            send_element(Acc1, Err, StateData),
-            StateData
-    end;
 process_outgoing_stanza(Acc, ToJID, <<"presence">>, StateData) ->
     #jid{ user = User, server = Server, lserver = LServer } = FromJID = mongoose_acc:from_jid(Acc),
     Res = ejabberd_hooks:run_fold(c2s_update_presence, LServer, Acc, []),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3060,8 +3060,7 @@ maybe_enter_resume_session(_SMID, #state{} = SD) ->
                   Seconds = timer:seconds(SD#state.stream_mgmt_resume_timeout),
                   TRef = erlang:send_after(Seconds, self(), resume_timeout),
                   NewState=SD#state{stream_mgmt_resume_tref = TRef},
-                  notify_unacknowledged_messages(NewState),
-                  NewState;
+                  notify_unacknowledged_messages(NewState);
               _TRef ->
                   SD
           end,
@@ -3197,10 +3196,8 @@ handover_session(SD, From)->
 do_handover_session(SD, UnreadMessages) ->
     Messages = flush_messages(UnreadMessages),
     NewCsiBuffer = Messages ++ SD#state.csi_buffer,
-    NewBuffer = Messages ++ SD#state.stream_mgmt_buffer,
     SD#state{authenticated = resumed,
-             csi_buffer = NewCsiBuffer,
-             stream_mgmt_buffer = NewBuffer}.
+             csi_buffer = NewCsiBuffer}.
 
 maybe_add_timestamp({F, T, #xmlel{name= <<"message">>}=Packet}=PacketTuple, Timestamp, Server) ->
     Type = xml:get_tag_attr_s(<<"type">>, Packet),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2348,9 +2348,7 @@ resend_offline_messages(Acc, StateData) ->
 
 
 resend_offline_message(Acc0, StateData, From, To, Packet, in) ->
-    Acc1 = mongoose_acc:update_stanza(#{ element => Packet, from_jid => From, to_jid => To }, Acc0),
-    %% !THIS IS STUB FOR unacknowledged_message_hook_offline TESTCASE, REMOVE THIS BEFORE MERGE!
-    Acc = mongoose_acc:set_permanent(sm_test, counter, 1, Acc1),
+    Acc = mongoose_acc:update_stanza(#{ element => Packet, from_jid => From, to_jid => To }, Acc0),
     check_privacy_and_route_or_ignore(Acc, StateData, From, To, Packet, in).
 
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3368,6 +3368,8 @@ make_c2s_info(_StateData = #state{stream_mgmt_buffer_size = SMBufSize}) ->
 -spec update_stanza(jid:jid(), jid:jid(), exml:element(), mongoose_acc:t()) ->
     mongoose_acc:t().
 update_stanza(From, To, #xmlel{} = Element, Acc) ->
-    Params = #{from_jid => From, to_jid => To, element => Element},
-    NewAcc = mongoose_acc:update_stanza(Params, Acc),
-    mongoose_acc:strip(NewAcc).
+    LServer = mongoose_acc:lserver(Acc),
+    Params = #{lserver => LServer, element => Element,
+               from_jid => From, to_jid => To},
+    NewAcc = mongoose_acc:strip(Params, Acc),
+    mongoose_acc:delete_many(c2s, [origin_jid, origin_sid], NewAcc).

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1745,7 +1745,7 @@ result_to_amp_event(_) -> delivery_failed.
     {ok | any(), mongoose_acc:t(), state()}.
 send_and_maybe_buffer_stanza_no_ack(Acc, {_, _, Stanza} = Packet, State) ->
     SendResult = maybe_send_element_from_server_jid_safe(Acc, State, Stanza),
-    BufferedStateData = buffer_out_stanza(Packet, State),
+    BufferedStateData = buffer_out_stanza(Acc, Packet, State),
     {SendResult, Acc, BufferedStateData}.
 
 
@@ -2376,7 +2376,7 @@ resend_subscription_requests(Acc, #state{pending_invitations = Pending} = StateD
                          {value, From} =  xml:get_tag_attr(<<"from">>, XMLPacket),
                          {value, To} = xml:get_tag_attr(<<"to">>, XMLPacket),
                          PacketTuple = {jid:from_binary(From), jid:from_binary(To), XMLPacket},
-                         BufferedStateData = buffer_out_stanza(PacketTuple, State),
+                         BufferedStateData = buffer_out_stanza(A1, PacketTuple, State),
                          % this one will be next to tackle
                          A2 = maybe_send_ack_request(A1, BufferedStateData),
                          {A2, BufferedStateData}
@@ -2524,8 +2524,8 @@ fsm_limit_opts(Opts) ->
 -spec bounce_messages(list()) -> 'ok'.
 bounce_messages(UnreadMessages) ->
     case get_msg(UnreadMessages) of
-        {ok, {route, From, To, El}, RemainedUnreadMessages} ->
-            ejabberd_router:route(From, To, El),
+        {ok, {route, From, To, Acc}, RemainedUnreadMessages} ->
+            ejabberd_router:route(From, To, Acc),
             bounce_messages(RemainedUnreadMessages);
         {ok, {store_session_info, User, Server, Resource, KV, _FromPid}, _} ->
             ejabberd_sm:store_info(User, Server, Resource, KV);
@@ -2537,26 +2537,23 @@ bounce_messages(UnreadMessages) ->
     end.
 
 %% Return the messages in reverse order than they were received in!
--spec flush_messages(list()) -> {N :: non_neg_integer(), Msgs :: [packet()]}.
+-spec flush_messages(list()) -> [mongoose_acc:t()].
 flush_messages(UnreadMessages) ->
-    flush_messages(0, [], UnreadMessages).
+    flush_messages([], UnreadMessages).
 
--spec flush_messages(N :: non_neg_integer(), Msgs :: [packet()], list()) ->
-    {N :: non_neg_integer(), Msgs :: [packet()]}.
-flush_messages(N, Acc, UnreadMessages) ->
+-spec flush_messages([mongoose_acc:t()], list()) -> [mongoose_acc:t()].
+flush_messages(Acc, UnreadMessages) ->
     case get_msg(UnreadMessages) of
-        {ok, {route, From, To, #xmlel{} = Packet}, RemainedUnreadMessages} ->
-            NewAcc = [{From, To, Packet} | Acc],
-            flush_messages(N + 1, NewAcc, RemainedUnreadMessages);
         {ok, {route, From, To, MongooseAcc}, RemainedUnreadMessages} ->
-            % TODO: SM buffer should hold acc, not xmlels
-            NewAcc = [{From, To, mongoose_acc:element(MongooseAcc)} | Acc],
-            flush_messages(N + 1, NewAcc, RemainedUnreadMessages);
+            El = mongoose_acc:element(MongooseAcc),
+            NewMongooseAcc = update_stanza(From, To, El, MongooseAcc),
+            NewAcc = [NewMongooseAcc | Acc],
+            flush_messages(NewAcc, RemainedUnreadMessages);
         {ok, _, RemainedUnreadMessages} ->
             % ignore this one, get the next message
-            flush_messages(N, Acc, RemainedUnreadMessages);
+            flush_messages(Acc, RemainedUnreadMessages);
         {error, no_messages} ->
-            {N, Acc}
+            Acc
     end.
 
 get_msg([H | T]) ->
@@ -2743,39 +2740,30 @@ ship_to_local_user(Acc, Packet, State) ->
     {ok | resume, mongoose_acc:t(), state()}.
 maybe_csi_inactive_optimisation(Acc, Packet, #state{csi_state = active} = State) ->
     send_and_maybe_buffer_stanza(Acc, Packet, State);
-maybe_csi_inactive_optimisation(Acc, Packet, #state{csi_buffer = Buffer} = State) ->
-    NewBuffer = [Packet | Buffer],
-    NewState = flush_or_buffer_packets(Acc, State#state{csi_buffer = NewBuffer}),
+maybe_csi_inactive_optimisation(Acc, {From,To,El}, #state{csi_buffer = Buffer} = State) ->
+    NewAcc = update_stanza(From, To, El, Acc),
+    NewBuffer = [NewAcc | Buffer],
+    NewState = flush_or_buffer_packets(State#state{csi_buffer = NewBuffer}),
     {ok, Acc, NewState}.
 
-flush_or_buffer_packets(Acc, State) ->
+flush_or_buffer_packets(State) ->
     MaxBuffSize = gen_mod:get_module_opt(State#state.server, mod_csi,
                                          buffer_max, 20),
     case length(State#state.csi_buffer) > MaxBuffSize of
         true ->
-            flush_csi_buffer(Acc, State);
+            flush_csi_buffer(State);
         _ ->
             State
     end.
 
 -spec flush_csi_buffer(state()) -> state().
-flush_csi_buffer(State) ->
-    Acc = mongoose_acc:new(#{location => ?LOCATION,
-                             lserver => State#state.server,
-                             element => undefined, from_jid => undefined, to_jid => undefined}),
-    flush_csi_buffer(Acc, State).
-
--spec flush_csi_buffer(mongoose_acc:t(), state()) -> state().
-flush_csi_buffer(Acc, #state{csi_buffer = BufferOut} = State) ->
+flush_csi_buffer(#state{csi_buffer = BufferOut} = State) ->
     %%lists:foldr to preserve order
-    F = fun({From, To, El}, {_, A, OldState}) ->
-                Accum = mongoose_acc:update_stanza(#{from_jid => From,
-                                                     to_jid => To,
-                                                     element => El },
-                                                   A),
-                send_and_maybe_buffer_stanza_no_ack(Accum, {From, To, El}, OldState)
+    F = fun(Acc, {_, _, OldState}) ->
+            {From, To, El} = mongoose_acc:packet(Acc),
+            send_and_maybe_buffer_stanza_no_ack(Acc, {From, To, El}, OldState)
         end,
-    {_, _, NewState} = lists:foldr(F, {ok, Acc, State}, BufferOut),
+    {_, _, NewState} = lists:foldr(F, {ok, ok, State}, BufferOut),
     NewState#state{csi_buffer = []}.
 
 bounce_csi_buffer(#state{csi_buffer = []}) ->
@@ -2948,29 +2936,29 @@ stream_mgmt_ack(NIncoming) ->
            attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3},
                     {<<"h">>, integer_to_binary(NIncoming)}]}.
 
--spec buffer_out_stanza(packet(), state()) -> state().
-buffer_out_stanza(_Packet, #state{stream_mgmt = StreamMgmt} = S)
+-spec buffer_out_stanza(mongoose_acc:t(), packet(), state()) -> state().
+buffer_out_stanza(_Acc, _Packet, #state{stream_mgmt = StreamMgmt} = S)
   when StreamMgmt =:= false; StreamMgmt =:= disabled ->
     S;
-buffer_out_stanza(_Packet, #state{stream_mgmt_buffer_max = no_buffer} = S) ->
+buffer_out_stanza(_Acc, _Packet, #state{stream_mgmt_buffer_max = no_buffer} = S) ->
     S;
-buffer_out_stanza(Packet, #state{server = Server,
-                                 stream_mgmt_buffer = Buffer,
-                                 stream_mgmt_buffer_size = BufferSize,
-                                 stream_mgmt_buffer_max = BufferMax} = S) ->
+buffer_out_stanza(Acc, Packet, #state{server = Server,
+                                      stream_mgmt_buffer = Buffer,
+                                      stream_mgmt_buffer_size = BufferSize,
+                                      stream_mgmt_buffer_max = BufferMax} = S) ->
     NewSize = BufferSize + 1,
     Timestamp = os:timestamp(),
-    NPacket = maybe_add_timestamp(Packet, Timestamp, Server),
-
+    {From, To, El} = maybe_add_timestamp(Packet, Timestamp, Server),
+    Acc1 = update_stanza(From, To, El, Acc),
     NS = case is_buffer_full(NewSize, BufferMax) of
              true ->
                  defer_resource_constraint_check(S);
              _ ->
                  S
          end,
-    notify_unacknowledged_msg(S, NPacket),
+    Acc2 = notify_unacknowledged_msg(Acc1, NS),
     NS#state{stream_mgmt_buffer_size = NewSize,
-             stream_mgmt_buffer = [NPacket | Buffer]}.
+             stream_mgmt_buffer = [Acc2 | Buffer]}.
 
 is_buffer_full(_BufferSize, infinity) ->
     false;
@@ -3032,36 +3020,27 @@ flush_stream_mgmt_buffer(#state{stream_mgmt_buffer = Buffer}) ->
     re_route_packets(Buffer).
 
 re_route_packets(Buffer) ->
-    [ejabberd_router:route(From, To, Packet)
-     || {From, To, Packet} <- lists:reverse(Buffer)],
+    [begin
+         {From, To, _El} = mongoose_acc:packet(Acc),
+         ejabberd_router:route(From, To, Acc)
+     end || Acc <- lists:reverse(Buffer)],
     ok.
 
 notify_unacknowledged_messages(#state{stream_mgmt_buffer = Buffer} = State) ->
-    notify_unacknowledged_messages(State, Buffer).
+    NewBuffer = [notify_unacknowledged_msg(Acc, State) || Acc <- lists:reverse(Buffer)],
+    State#state{stream_mgmt_buffer = lists:reverse(NewBuffer)}.
 
-notify_unacknowledged_messages(State, Buffer) ->
-    [notify_unacknowledged_msg(State, Msg) || Msg <- lists:reverse(Buffer)],
-    ok.
-
-notify_unacknowledged_msg(#state{resource                = Res,
-                                 server                  = Server,
-                                 stream_mgmt             = SM,
-                                 stream_mgmt_resume_tref = ResumeTimer},
-                          {From, To, Packet}) ->
+notify_unacknowledged_msg(Acc, #state{resource                = Res,
+                                      server                  = Server,
+                                      stream_mgmt             = SM,
+                                      stream_mgmt_resume_tref = ResumeTimer}) ->
     case {SM, ResumeTimer} of
-        {false, _} -> ok;
-        {true, undefined} -> ok;
+        {false, _} -> Acc;
+        {true, undefined} -> Acc;
         _ ->
-            Acc = mongoose_acc:new(#{ location => ?LOCATION,
-                from_jid => From,
-                to_jid => To,
-                lserver => Server,
-                element => Packet }),
-            ejabberd_hooks:run_fold(unacknowledged_message,
-                                    Server,
-                                    Acc,
-                                    [From, To, Packet, Res]),
-            ok
+            NewAcc = ejabberd_hooks:run_fold(unacknowledged_message,
+                                             Server, Acc, [Res]),
+            mongoose_acc:strip(NewAcc)
     end.
 
 
@@ -3106,7 +3085,7 @@ maybe_resume_session(NextState, El, StateData) ->
       FromSMID :: {sid, ejabberd_sm:sid()} | {stale_h, non_neg_integer()} | {error, smid_not_found},
       StateData :: state(),
       NewState :: tuple().
-do_resume_session(SMID, El, {sid, {_, Pid}}, #state{server = Server} = StateData) ->
+do_resume_session(SMID, El, {sid, {_, Pid}}, StateData) ->
     try
         {ok, OldState} = p1_fsm_old:sync_send_event(Pid, resume),
         SID = {erlang:timestamp(), self()},
@@ -3131,12 +3110,10 @@ do_resume_session(SMID, El, {sid, {_, Pid}}, #state{server = Server} = StateData
                     Resumed = stream_mgmt_resumed(NSD#state.stream_mgmt_id,
                                                   NSD#state.stream_mgmt_in),
                     send_element_from_server_jid(NSD, Resumed),
-                    [send_element(mongoose_acc:new(#{ location => ?LOCATION,
-                                                      from_jid => FromJID,
-                                                      to_jid => ToJID,
-                                                      lserver => Server,
-                                                      element => Packet }), Packet, NSD)
-                     || {FromJID, ToJID, Packet} <- lists:reverse(NSD#state.stream_mgmt_buffer)],
+                    [begin
+                         Elem = mongoose_acc:element(Acc),
+                         send_element(Acc, Elem, NSD)
+                     end || Acc <- lists:reverse(NSD#state.stream_mgmt_buffer)],
 
                     NSD2 = flush_csi_buffer(NSD),
 
@@ -3218,11 +3195,11 @@ handover_session(SD, From)->
     {stop, {handover_session, From}, SD}.
 
 do_handover_session(SD, UnreadMessages) ->
-    {N, Messages} = flush_messages(UnreadMessages),
-    NewSize = N + SD#state.stream_mgmt_buffer_size,
+    Messages = flush_messages(UnreadMessages),
+    NewCsiBuffer = Messages ++ SD#state.csi_buffer,
     NewBuffer = Messages ++ SD#state.stream_mgmt_buffer,
     SD#state{authenticated = resumed,
-             stream_mgmt_buffer_size = NewSize,
+             csi_buffer = NewCsiBuffer,
              stream_mgmt_buffer = NewBuffer}.
 
 maybe_add_timestamp({F, T, #xmlel{name= <<"message">>}=Packet}=PacketTuple, Timestamp, Server) ->
@@ -3387,3 +3364,10 @@ maybe_hibernate(#state{hibernate_after = HA}) -> HA.
 
 make_c2s_info(_StateData = #state{stream_mgmt_buffer_size = SMBufSize}) ->
     #{stream_mgmt_buffer_size => SMBufSize}.
+
+-spec update_stanza(jid:jid(), jid:jid(), exml:element(), mongoose_acc:t()) ->
+    mongoose_acc:t().
+update_stanza(From, To, #xmlel{} = Element, Acc) ->
+    Params = #{from_jid => From, to_jid => To, element => Element},
+    NewAcc = mongoose_acc:update_stanza(Params, Acc),
+    mongoose_acc:strip(NewAcc).

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -35,15 +35,21 @@
 -export([update_stanza/2]).
 % Access to namespaced fields
 -export([
+         set/3,
          set/4,
+         set_permanent/3,
          set_permanent/4,
          append/4,
+         get_permanent_keys/1,
+         get/2,
          get/3,
          get/4,
-         delete/3
+         delete/3,
+         delete/2,
+         delete_many/3
         ]).
-% Strip and replace stanza
--export([strip/2]).
+% Strip with or without stanza replacement
+-export([strip/1, strip/2]).
 
 %% Note about 'undefined' to_jid and from_jid: these are the special cases when JID may be
 %% truly unknown: before a client is authorized.
@@ -70,7 +76,7 @@
         stanza := stanza_metadata() | undefined,
         lserver := jid:lserver(),
         non_strippable := sets:set(ns_key()),
-        {NS :: any(), Key :: any()} => Value :: any()
+        ns_key() => Value :: any()
        }.
 -export_type([t/0]).
 
@@ -169,6 +175,13 @@ update_stanza(NewStanzaParams, #{ mongoose_acc := true } = Acc) ->
 set(NS, K, V, #{ mongoose_acc := true } = Acc) ->
     Acc#{ {NS, K} => V }.
 
+-spec set(Namespace :: any(), [{K :: any(), V :: any()}], Acc :: t()) -> t().
+set(_, [], Acc) ->
+    Acc;
+set(NS, [{K, V} | T], Acc) ->
+    NewAcc = set(NS, K, V, Acc),
+    set(NS, T, NewAcc).
+
 %% .. while these are not.
 -spec set_permanent(Namespace :: any(), K :: any(), V :: any(), Acc :: t()) -> t().
 set_permanent(NS, K, V, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc) ->
@@ -176,28 +189,66 @@ set_permanent(NS, K, V, #{ mongoose_acc := true, non_strippable := NonStrippable
     NewNonStrippable = sets:add_element(Key, NonStrippable),
     Acc#{ Key => V, non_strippable => NewNonStrippable }.
 
+-spec set_permanent(Namespace :: any(), [{K :: any(), V :: any()}], Acc :: t()) -> t().
+set_permanent(_, [], #{mongoose_acc := true} = Acc) ->
+    Acc;
+set_permanent(NS, [{K, V} | T], Acc) ->
+    NewAcc = set_permanent(NS, K, V, Acc),
+    set_permanent(NS, T, NewAcc).
+
 -spec append(NS :: any(), Key :: any(), Val :: any() | [any()], Acc :: t()) -> t().
 append(NS, Key, Val, Acc) ->
     OldVal = get(NS, Key, [], Acc),
     set(NS, Key, append(OldVal, Val), Acc).
 
+-spec get_permanent_keys(Acc :: t()) -> [ns_key()].
+get_permanent_keys(#{mongoose_acc := true, non_strippable := NonStrippable}) ->
+    sets:to_list(NonStrippable).
+
+-spec get(Namespace :: any(), Acc :: t()) -> [{K :: any(), V :: any()}].
+get(NS, #{mongoose_acc := true} = Acc) ->
+    Fn = fun({Namespace, K}, V, List) when Namespace =:= NS ->
+                [{K, V} | List];
+            (_, _, List) ->
+                List
+         end,
+    maps:fold(Fn, [], Acc).
+
+-spec get(Namespace :: any(), K :: any(), Acc :: t()) -> V :: any().
 get(NS, K, #{ mongoose_acc := true } = Acc) ->
     maps:get({NS, K}, Acc).
 
+-spec get(Namespace :: any(), K :: any(), Default :: any(), Acc :: t()) -> V :: any().
 get(NS, K, Default, #{ mongoose_acc := true } = Acc) ->
     maps:get({NS, K}, Acc, Default).
 
+-spec delete(Namespace :: any(), K :: any(), Acc :: t()) -> t().
 delete(NS, K, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc0) ->
     Key = {NS, K},
     Acc1 = maps:remove(Key, Acc0),
     Acc1#{ non_strippable => sets:del_element(Key, NonStrippable) }.
 
--spec strip(ParamsToOverwrite :: strip_params(), Acc :: t()) -> t().
-strip(#{ lserver := NewLServer } = Params,
-      #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc) ->
+-spec delete_many(Namespace :: any(), [K :: any()], Acc :: t()) -> t().
+delete_many(_, [], Acc) ->
+    Acc;
+delete_many(NS, [K | T], Acc) ->
+    NewAcc = delete(NS, K, Acc),
+    delete_many(NS, T, NewAcc).
+
+-spec delete(Namespace :: any(), Acc :: t()) -> t().
+delete(NS, Acc) ->
+    KeyList = [K || {K, _} <- get(NS, Acc)],
+    delete_many(NS, KeyList, Acc).
+
+-spec strip(Acc :: t()) -> t().
+strip(#{ mongoose_acc := true, non_strippable := NonStrippable } = Acc) ->
     NonStrippableL = sets:to_list(NonStrippable),
-    StrippedAcc = maps:with(NonStrippableL ++ default_non_strippable(), Acc),
-    StrippedAcc#{ lserver => NewLServer, stanza => stanza_from_params(Params) }.
+    maps:with(NonStrippableL ++ default_non_strippable(), Acc).
+
+-spec strip(ParamsToOverwrite :: strip_params(), Acc :: t()) -> t().
+strip(#{ lserver := NewLServer } = Params, Acc) ->
+    StrippedAcc = strip(Acc),
+    StrippedAcc#{ lserver := NewLServer, stanza := stanza_from_params(Params) }.
 
 %% --------------------------------------------------------
 %% Internal functions
@@ -232,10 +283,11 @@ default_non_strippable() ->
      origin_pid,
      origin_location,
      origin_stanza,
+     stanza,
+     lserver,
      non_strippable
     ].
 
 -spec append(OldVal :: list(), Val :: list() | any()) -> list().
 append(OldVal, Val) when is_list(OldVal), is_list(Val) -> OldVal ++ Val;
 append(OldVal, Val) when is_list(OldVal) -> [Val | OldVal].
-

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -27,6 +27,7 @@
          element/1,
          to_jid/1,
          from_jid/1,
+         packet/1,
          stanza_name/1,
          stanza_type/1,
          stanza_ref/1
@@ -78,6 +79,7 @@
         non_strippable := sets:set(ns_key()),
         ns_key() => Value :: any()
        }.
+
 -export_type([t/0]).
 
 -type new_acc_params() :: #{
@@ -127,40 +129,57 @@ new(#{ location := Location, lserver := LServer } = Params) ->
       non_strippable => sets:new()
      }.
 
+-spec ref(Acc :: t()) -> reference().
 ref(#{ mongoose_acc := true, ref := Ref }) ->
     Ref.
 
+-spec timestamp(Acc :: t()) -> erlang:timestamp().
 timestamp(#{ mongoose_acc := true, timestamp := TS }) ->
     TS.
 
+-spec lserver(Acc :: t()) -> jid:lserver().
 lserver(#{ mongoose_acc := true, lserver := LServer }) ->
     LServer.
 
+-spec element(Acc :: t()) -> exml:element() | undefined.
 element(#{ mongoose_acc := true, stanza := #{ element := El } }) ->
     El;
 element(#{ mongoose_acc := true }) ->
     undefined.
 
+-spec from_jid(Acc :: t()) -> jid:jid() | undefined.
 from_jid(#{ mongoose_acc := true, stanza := #{ from_jid := FromJID } }) ->
     FromJID;
 from_jid(#{ mongoose_acc := true }) ->
     undefined.
 
+-spec to_jid(Acc :: t()) -> jid:jid() | undefined.
 to_jid(#{ mongoose_acc := true, stanza := #{ to_jid := ToJID } }) ->
     ToJID;
 to_jid(#{ mongoose_acc := true }) ->
     undefined.
 
+-spec packet(Acc :: t()) -> ejabberd_c2s:packet() | undefined.
+packet(#{ mongoose_acc := true, stanza := #{ to_jid := ToJID,
+                                             from_jid := FromJID,
+                                             element := El } }) ->
+    {FromJID, ToJID, El};
+packet(#{ mongoose_acc := true }) ->
+    undefined.
+
+-spec stanza_name(Acc :: t()) -> binary() | undefined.
 stanza_name(#{ mongoose_acc := true, stanza := #{ name := Name } }) ->
     Name;
 stanza_name(#{ mongoose_acc := true }) ->
     undefined.
 
+-spec stanza_type(Acc :: t()) -> binary() | undefined.
 stanza_type(#{ mongoose_acc := true, stanza := #{ type := Type } }) ->
     Type;
 stanza_type(#{ mongoose_acc := true }) ->
     undefined.
 
+-spec stanza_ref(Acc :: t()) -> reference() | undefined.
 stanza_ref(#{ mongoose_acc := true, stanza := #{ ref := StanzaRef } }) ->
     StanzaRef;
 stanza_ref(#{ mongoose_acc := true }) ->

--- a/test/acc_SUITE.erl
+++ b/test/acc_SUITE.erl
@@ -23,7 +23,8 @@ groups() ->
     [
      {basic, [sequence],
       [
-       store_and_retrieve,
+       store_retrieve_and_delete,
+       store_retrieve_and_delete_many,
        init_from_element,
        produce_iq_meta_automatically,
        strip,
@@ -42,16 +43,69 @@ end_per_suite(C) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% test methods
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-store_and_retrieve(_C) ->
+store_retrieve_and_delete(_C) ->
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => <<"localhost">>,
                               element => undefined }),
     Acc2 = mongoose_acc:set(ns, check, 1, Acc),
     ?assertEqual(1, mongoose_acc:get(ns, check, Acc2)),
+    Acc3 = mongoose_acc:set(ns, check, 2, Acc2),
+    ?assertEqual(2, mongoose_acc:get(ns, check, Acc3)),
+    Acc4 = mongoose_acc:delete(ns, check, Acc3),
+    ?assertError(_, mongoose_acc:get(ns, check, Acc4)),
     ok.
 
+store_permanent_retrieve_and_delete(_C) ->
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => <<"localhost">>,
+                              element => undefined }),
+    Acc2 = mongoose_acc:set_permanent(ns, check, 1, Acc),
+    ?assertEqual(1, mongoose_acc:get(ns, check, Acc2)),
+    Acc3 = mongoose_acc:set_permanent(ns, check, 2, Acc2),
+    ?assertEqual(2, mongoose_acc:get(ns, check, Acc3)),
+    ?assertEqual([{ns, check}], mongoose_acc:get_permanent_keys(Acc3)),
+    Acc4 = mongoose_acc:delete(ns, check, Acc3),
+    ?assertError(_, mongoose_acc:get(ns, check, Acc4)),
+    ?assertEqual([], mongoose_acc:get_permanent_keys(Acc4)),
+    ok.
+
+store_retrieve_and_delete_many(_C) ->
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => <<"localhost">>,
+                              element => undefined}),
+    KV = [{check, 1}, {check2, 2}, {check3, 3}],
+    Acc2 = mongoose_acc:set(ns, [{check3, 0} | KV], Acc),
+    [?assertEqual(V, mongoose_acc:get(ns, K, Acc2)) || {K, V} <- KV],
+    NS = mongoose_acc:get(ns, Acc2),
+    ?assertEqual(lists:sort(NS), lists:sort(KV)),
+    Acc3 = mongoose_acc:delete_many(ns, [K || {K, _} <- KV], Acc2),
+    [?assertError(_, mongoose_acc:get(ns, K, Acc3)) || {K, _} <- KV],
+    ?assertEqual([], mongoose_acc:get(ns, Acc3)),
+    Acc4 = mongoose_acc:delete(ns, Acc2),
+    [?assertError(_, mongoose_acc:get(ns, K, Acc4)) || {K, _} <- KV],
+    ?assertEqual([], mongoose_acc:get(ns, Acc4)),
+    ok.
+
+store_permanent_retrieve_and_delete_many(_C) ->
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => <<"localhost">>,
+                              element => undefined}),
+    KV = [{check, 1}, {check2, 2}, {check3, 3}],
+    NK = [{ns, K} || {K, _} <- KV],
+    Acc2 = mongoose_acc:set_permanent(ns, [{check3, 0} | KV], Acc),
+    [?assertEqual(V, mongoose_acc:get(ns, K, Acc2)) || {K, V} <- KV],
+    NS = mongoose_acc:get(ns, Acc2),
+    ?assertEqual(lists:sort(NS), lists:sort(KV)),
+    ?assertEqual(lists:sort(NK),lists:sort(mongoose_acc:get_permanent_keys(Acc2))),
+    Acc3 = mongoose_acc:delete_many(ns, [K || {K, _} <- KV], Acc2),
+    [?assertError(_, mongoose_acc:get(ns, K, Acc3)) || {K, _} <- KV],
+    ?assertEqual([], mongoose_acc:get(ns, Acc3)),
+    ?assertEqual([],mongoose_acc:get_permanent_keys(Acc3)),
+    Acc4 = mongoose_acc:delete(ns, Acc2),
+    [?assertError(_, mongoose_acc:get(ns, K, Acc4)) || {K, _} <- KV],
+    ?assertEqual([], mongoose_acc:get(ns, Acc4)),
+    ?assertEqual([],mongoose_acc:get_permanent_keys(Acc4)),
+    ok.
 
 init_from_element(_C) ->
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
@@ -96,15 +150,20 @@ strip(_C) ->
     ?assertEqual(<<"set">>, mongoose_acc:stanza_type(Acc1)),
     ?assertEqual(undefined, mongoose_acc:get(ns, ppp, undefined, Acc1)),
     Acc2 = mongoose_acc:set_permanent(ns, ppp, 997, Acc1),
-    ?assertEqual(997, mongoose_acc:get(ns, ppp, Acc2)),
-    Ref = mongoose_acc:ref(Acc2),
+    Acc3 = mongoose_acc:set_permanent(ns2, [{a, 1}, {b, 2}], Acc2),
+    ?assertMatch([_, _], mongoose_acc:get(ns2, Acc3)),
+    Acc4 = mongoose_acc:delete(ns2, Acc3),
+    ?assertEqual(997, mongoose_acc:get(ns, ppp, Acc4)),
+    ?assertEqual([], mongoose_acc:get(ns2, Acc4)),
+    Ref = mongoose_acc:ref(Acc4),
     NAcc1 = mongoose_acc:strip(#{ lserver => <<"localhost">>,
-                                 element => sample_stanza() }, Acc2),
+                                 element => sample_stanza() }, Acc4),
     {XMLNS2, NAcc2} = mongoose_iq:xmlns(NAcc1),
     ?assertEqual(<<"urn:xmpp:blocking">>, XMLNS2),
     ?assertEqual(jid:from_binary(<<"a@localhost">>), mongoose_acc:to_jid(NAcc2)),
     ?assertEqual(Ref, mongoose_acc:ref(NAcc2)),
-    ?assertEqual(997, mongoose_acc:get(ns, ppp, NAcc2)).
+    ?assertEqual(997, mongoose_acc:get(ns, ppp, NAcc2)),
+    ?assertEqual([], mongoose_acc:get(ns2, NAcc2)).
 
 
 sample_stanza() ->


### PR DESCRIPTION
the work on the push notifications is restarted in this branch/PR just too preserve the initial discussion/comments.

this PR will focus only on the changes in c2s:
* storing stripped accumulators instead of exml in C2S buffers (we must preserve `non_strippable` fields when rerouting message or resuming the session).
* proper implementation of the `unacknowledged_message` hook (hook handler must be able to modify the original message accumulator, the list of the nodes where the message is pushed can be added/extended by `mod_event_pusher_push` as `non_strippable` field).

things to be implemented in the separate PRs:
* mod_offline must preserve `non_strippable` fields of the message accumulator and return them on `resend_offline_messages_hook` (testcase is already implemented but disabled, see `unacknowledged_message_hook_offline`)
* handling of `unacknowledged_message` hook  at `mod_event_pusher` and passing it to the backends + corresponding changes in backends (just ignoring of such messages, no functional changes)
* rework of `mod_event_pusher_push` and creation of the more advanced plugin for it (behavior of the `default` plugin should remain unchanged)
