### PR TITLE
Add flush_time metric to MAM RDBMS async pool writers.

### DIFF
--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -218,6 +218,8 @@ If you'd like to learn more about metrics in MongooseIM, please visit [MongooseI
 | `[Host, modMucMamPrefsGets]` | spiral | MUC archiving preferences have been requested by a client. |
 | `[Host, modMucMamPrefsSets]` | spiral | MUC archiving preferences have been updated by a client. |
 | `[Host, mod_mam_odbc_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MAM worker. |
+| `[Host, mod_mam_odbc_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MAM worker. |
+| `[Host, mod_mam_muc_odbc_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MUC MAM worker. |
+| `[Host, mod_mam_muc_odbc_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MUC MAM worker. |
 | `[Host, backends, mod_mam, lookup]` | histogram | Time it took to perform a lookup in an archive. |
 | `[Host, backends, mod_mam, archive]` | histogram | Time it took to save one message in an archive. |
-

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -204,6 +204,7 @@ These are **total** times of respective operations.
 One operation usually requires only a single call to an auth backend but sometimes with e.g. 3 backends configured, the operation may fail for first 2 backends.
 In such case, these metrics will be updated with combined time of 2 failed and 1 successful request.
 
-Additionaly, RDMBS layer in MongooseIM exposes one more metric, if RDBMS is configured:
+Additionaly, RDMBS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
 
-* `[global, backends, mongoose_rdbms, query]` - Execution time of a "not prepared" query by a DB driver.
+* `[global, backends, mongoose_rdbms, query]` - Execution time of a "simple"" (not prepared) query by a DB driver.
+* `[global, backends, mongoose_rdbms, execute]` - Execution time of a prepared query by a DB driver.

--- a/src/mam/mod_mam_muc_odbc_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_odbc_async_pool_writer.erl
@@ -30,6 +30,7 @@
          terminate/2, code_change/3]).
 
 -define(PER_MESSAGE_FLUSH_TIME, [?MODULE, per_message_flush_time]).
+-define(FLUSH_TIME, [?MODULE, flush_time]).
 -define(DEFAULT_POOL_SIZE, 32).
 
 -include("mongoose.hrl").
@@ -87,6 +88,8 @@ worker_number(Host, ArcID) ->
 
 -spec start(jid:server(), _) -> 'ok'.
 start(Host, Opts) ->
+    mongoose_metrics:ensure_metric(Host, ?PER_MESSAGE_FLUSH_TIME, histogram),
+    mongoose_metrics:ensure_metric(Host, ?FLUSH_TIME, histogram),
     PoolName = gen_mod:get_opt(odbc_pool, Opts, mongoose_rdbms_sup:pool(Host)),
     MaxSize = gen_mod:get_module_opt(Host, ?MODULE, max_batch_size, 30),
     mod_mam_muc_odbc_arch:prepare_insert(insert_mam_muc_message, 1),
@@ -256,6 +259,7 @@ run_flush(State = #state{host = Host, acc = Acc}) ->
     MessageCount = length(Acc),
     {FlushTime, NewState} = timer:tc(fun do_run_flush/2, [MessageCount, State]),
     mongoose_metrics:update(Host, ?PER_MESSAGE_FLUSH_TIME, round(FlushTime / MessageCount)),
+    mongoose_metrics:update(Host, ?FLUSH_TIME, FlushTime),
     NewState.
 
 do_run_flush(MessageCount, State = #state{host = Host, connection_pool = Pool,

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -428,7 +428,7 @@ to_bool(_) -> false.
 -spec init(pool()) -> {ok, state()}.
 init(Pool) ->
     process_flag(trap_exit, true),
-    backend_module:create(?MODULE, db_engine(Pool), [query]),
+    backend_module:create(?MODULE, db_engine(Pool), [query, execute]),
     Settings = mongoose_rdbms_sup:get_option(Pool, odbc_server),
     MaxStartInterval = get_start_interval(Pool),
     case connect(Settings, ?CONNECT_RETRIES, 2, MaxStartInterval) of


### PR DESCRIPTION
This PR adds very useful metrics for gauging MAM's performance with `async_writer` enabled (default).