### PR TITLE
Replace dots in "host" part of metric name with underscores.

### DIFF
--- a/src/mongoose_metrics.erl
+++ b/src/mongoose_metrics.erl
@@ -174,7 +174,9 @@ pick_by_all_metrics_are_global(WhenGlobal, WhenNot) ->
 
 -spec name_by_all_metrics_are_global(Host :: jid:lserver() | global,
                                      Name :: list()) -> FinalName :: list().
-name_by_all_metrics_are_global(Host, Name) ->
+name_by_all_metrics_are_global(global, Name) -> [global | Name];
+name_by_all_metrics_are_global(Host0, Name) ->
+    Host = binary:replace(Host0, <<$.>>, <<$_>>, [global]),
     pick_by_all_metrics_are_global([global | Name], [Host | Name]).
 
 get_report_interval() ->

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -18,7 +18,7 @@ all() ->
 
 groups() ->
     [
-     {ordinary_mode, [], ?ALL_CASES},
+     {ordinary_mode, [], [dots_in_host_are_turned_to_underscore | ?ALL_CASES]},
      {all_metrics_are_global, [], ?ALL_CASES}
     ].
 
@@ -82,6 +82,13 @@ no_skip_metric(_C) ->
 subscriptions_initialised(_C) ->
     mongoose_metrics:init(),
     true = wait_for_update(exometer:get_value([carbon, packets], count), 60).
+
+dots_in_host_are_turned_to_underscore(_C) ->
+    mongoose_metrics:init(),
+    mongoose_metrics:ensure_metric(<<"host.with.dots">>, [a, metric, value], histogram),
+    mongoose_metrics:update(<<"host.with.dots">>, [a, metric, value], 10),
+    {ok, _} = exometer:get_value([<<"host_with_dots">>, a, metric, value]).
+
 
 wait_for_update({ok, [{count,X}]}, 0) ->
     X > 0;


### PR DESCRIPTION
Underscores are not a valid part of a domain name, so they
are safe to replace dots to in the metric name (i.e. this can't lead
to a collision with an existing host name).

Replacing dots with underscores prevents hosts from being treated
as multiple separate metrics nodes e.g. by Graphite and Grafana.
