### PR TITLE
added new module: mod_filter

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -41,6 +41,7 @@
 {suites, "tests", mod_event_pusher_rabbit_SUITE}.
 {suites, "tests", mod_event_pusher_http_SUITE}.
 {suites, "tests", mod_global_distrib_SUITE}.
+{suites, "tests", mod_filter_SUITE}.
 {suites, "tests", mod_http_upload_SUITE}.
 {suites, "tests", mod_ping_SUITE}.
 {suites, "tests", mod_time_SUITE}.

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -2,7 +2,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--export([save_modules/2, ensure_modules/2, restore_modules/2]).
+-export([save_modules/2, ensure_modules/1, ensure_modules/2, restore_modules/2]).
 -export([stop/2, stop/3, start/3, start/4, restart/3, stop_running/2, start_running/1]).
 
 -import(distributed_helper, [mim/0,
@@ -10,6 +10,13 @@
 
 save_modules(Domain, Config) ->
     [{saved_modules, get_current_modules(Domain)} | Config].
+
+%extract a list of supported domains 
+%and apply ensure_modules/2 for each of them
+ensure_modules(RequiredModules) ->
+    Hosts = rpc(mim(), ejabberd_config, get_global_option, [hosts]),
+    [ok = ensure_modules(Host, RequiredModules) || Host <- Hosts],
+    ok.
 
 ensure_modules(Domain, RequiredModules) ->
     CurrentModules = get_current_modules(Domain),
@@ -113,3 +120,4 @@ stop_running(Mod, Config) ->
             stop(Domain, Module),
             [{running, [Head]} | Config]
     end.
+    

--- a/big_tests/tests/mod_filter_SUITE.erl
+++ b/big_tests/tests/mod_filter_SUITE.erl
@@ -1,0 +1,156 @@
+-module(mod_filter_SUITE).
+-compile(export_all).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, messages}].
+
+groups() ->
+    [{messages, [sequence], [
+                             allowed_messages_story,
+                             denied_messages_story
+                             ]}].
+
+suite() ->
+    escalus:suite().
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    ok = dynamic_modules:ensure_modules(required_modules()),
+    update_rules(),
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    escalus_fresh:clean(),
+    escalus:end_per_suite(Config).
+
+init_per_group(_GroupName, Config) ->
+    escalus:create_users(Config, escalus:get_users([alice, bob, astrid, kate])).
+
+end_per_group(_GroupName, Config) ->
+    escalus:delete_users(Config, escalus:get_users([alice, bob, astrid, kate])).
+
+init_per_testcase(CaseName, Config0) ->
+    NewUsers = proplists:get_value(escalus_users, Config0) ++ escalus_ct:get_config(escalus_anon_users),
+    Config = [{escalus_users, NewUsers}] ++ Config0,
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    AnonJID = erlang:get(anon_user),
+    mongoose_helper:clear_last_activity(Config, AnonJID),
+    escalus:end_per_testcase(CaseName, Config).
+
+required_modules() ->
+  [{mod_filter, []}].
+
+% The configuration of rules is done using mim ACL and ACCESS.
+% mod_filter allows  limit traffic between domains or users based on their type.
+%
+% On this `update_rules` example, next rules are applied:
+%    1. the users of a private vhosts (localhost and sogndal)
+%       can only chat with themselves. so that particular host
+%       will have no connection to the exterior.
+%    2. anonymous users of some host (anonymous.localhost)
+%       can only chat with shared single chat user(some bot, i.e kate@localhost), 
+%       so that particular host will have no connection
+%       to the other hosts (localhost, sogndal) listed in hosts 
+update_rules()->
+    {atomic,ok} = rpc(mim(), acl, add, [global, domain1, {server_glob, <<"localhost">>}]),
+    {atomic,ok} = rpc(mim(), acl, add, [global, domain2, {server_glob, <<"sogndal">>}]),
+    {atomic,ok} = rpc(mim(), acl, add, [global, bot, {user, <<"kate">>, <<"localhost">>}]),
+    {atomic,ok} = rpc(mim(), acl, add, [global, anon_user, {server_glob, <<"anonymous.localhost">>}]),
+
+
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, mod_filter, global}, [
+                                                                                        {allow, all}]]),
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, mod_filter_presence, global},
+                                                                                        [{allow, all}]]),
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, mod_filter_message, global}, [
+                                                                                        {local, bot},
+                                                                                        {restrict_bot, anon_user},
+                                                                                        {restrict_dom1, domain1},
+                                                                                        {restrict_dom2, domain2}
+                                                                                        ]]),
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, mod_filter_iq, global}, 
+                                                                                        [{allow, all}]]),
+
+    %restriction for localhost
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, restrict_dom1, global}, 
+                                                                  [{allow, domain1}, {deny, all}]]),
+    %restriction for sogndal
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, restrict_dom2, global},
+                                                                  [{allow, domain2}, {deny, all}]]),
+    %restriction for bot
+    {atomic,ok} = rpc(mim(), ejabberd_config, add_global_option, [{access, restrict_bot, global}, 
+                                                                  [{allow, bot}, {deny, all}]]).
+%%--------------------------------------------------------------------
+%% Message tests
+%%--------------------------------------------------------------------
+
+allowed_messages_story(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}, {jon, 1}], fun(Alice, Bob, Kate, Jon) ->
+        %according to update_rules() example, anonymous can send message to bot.
+        erlang:put(anon_user, escalus_utils:get_jid(Jon)),
+        escalus_client:send(Jon, escalus_stanza:chat_to(Kate, <<"Hi!">>)),
+        escalus:assert(is_chat_message, [<<"Hi!">>],
+                       escalus:wait_for_stanza(Kate)),
+
+        %according to update_rules() example, bot can send message to anonymous.
+        erlang:put(anon_user, escalus_utils:get_jid(Jon)),
+        escalus_client:send(Kate, escalus_stanza:chat_to(Jon, <<"Hi!">>)),
+        escalus:assert(is_chat_message, [<<"Hi!">>],
+                       escalus:wait_for_stanza(Jon)),
+
+        %according to update_rules() example, user can send message to
+        %other user within one host.
+        escalus_client:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi!">>)),
+        escalus:assert(is_chat_message, [<<"Hi!">>],
+                       escalus:wait_for_stanza(Bob)),
+
+        %according to update_rules() example, user can send message to bot.
+        escalus_client:send(Alice, escalus_stanza:chat_to(Kate, <<"Hi!">>)),
+        escalus:assert(is_chat_message, [<<"Hi!">>],
+                       escalus:wait_for_stanza(Kate)),
+    
+        %according to update_rules() example, bot can send message to user.
+        escalus_client:send(Kate, escalus_stanza:chat_to(Alice, <<"Hi!">>)),
+        escalus:assert(is_chat_message, [<<"Hi!">>],
+                       escalus:wait_for_stanza(Alice))
+    end).
+
+denied_messages_story(Config) ->
+    escalus:story(Config, [{alice, 1}, {astrid, 1}, {bob, 1}, {jon, 1}], fun(Alice, Astrid, Bob, Jon) ->
+        erlang:put(anon_user, escalus_utils:get_jid(Jon)),
+
+        %according to update_rules() example, anonymous can't send message to user.
+        escalus_client:send(Jon, escalus_stanza:chat_to(Bob, <<"Hi!">>)),
+        client_gets_nothing(Bob),
+        
+        %according to update_rules() example, user can't send message to anonymous.
+        escalus_client:send(Alice, escalus_stanza:chat_to(Jon, <<"Hi!">>)),
+        client_gets_nothing(Jon),
+
+        %according to update_rules() example, user 
+        %can't send message to other user with different host.
+        escalus_client:send(Astrid, escalus_stanza:chat_to(Bob, <<"Hi!">>)),
+        client_gets_nothing(Bob)
+    end).
+
+
+client_gets_nothing(Client) ->
+    ct:sleep(500),
+    escalus_assert:has_no_stanzas(Client).
+
+

--- a/big_tests/tests/mod_filter_SUITE.erl
+++ b/big_tests/tests/mod_filter_SUITE.erl
@@ -25,6 +25,9 @@ groups() ->
 suite() ->
     escalus:suite().
 
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
@@ -32,13 +35,15 @@ suite() ->
 init_per_suite(Config) ->
     dynamic_modules:ensure_modules(required_modules()),
     update_rules(),
-    escalus:init_per_suite(Config).
+    escalus:init_per_suite(dynamic_modules:save_modules(domain(), Config)).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
+    dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
+    dynamic_modules:ensure_modules(domain(), required_modules()),
     escalus:create_users(Config, escalus:get_users([alice, bob, astrid, kate])).
 
 end_per_group(_GroupName, Config) ->

--- a/doc/modules/mod_filter.md
+++ b/doc/modules/mod_filter.md
@@ -1,0 +1,27 @@
+### Module Description
+This module is a generic interface for flexible packet filtering by server policy.
+
+
+### Options
+
+none
+
+### Example configuration
+
+```
+  {mod_filter, []},
+```
+
+The configuration of rules is done using mim's ACL and ACCESS, so you should also study the corresponding section on ejabberd guide.
+
+default ACCESS configuration:
+```
+{access, mod_filter, [{allow, all}]}.
+{access, mod_filter_presence, [{allow, all}]}.
+{access, mod_filter_message, [{allow, all}]}.
+{access, mod_filter_iq, [{allow, all}]}.
+```
+
+For more example refer to mod_filter_SUITE in big_tests or to origin [code].
+
+[code]: https://github.com/knobo/mod_filter

--- a/src/mod_filter.erl
+++ b/src/mod_filter.erl
@@ -1,53 +1,40 @@
-%%%----------------------------------------------------------------------
-%%% Author  : Magnus Henoch <henoch@dtek.chalmers.se>
-%%% Purpose : flexible filtering by server policy
-%%% Created : 21 Sep 2005 by Magnus Henoch <henoch@dtek.chalmers.se>
-%%% Updated : 14 Jan 2016 by John Brodie <john@brodie.me>
-%%% Updated : 25 Jul 2018 by Beisenbek Baisakov <beysenbek@gmail.com>
-%%%----------------------------------------------------------------------
-
 -module(mod_filter).
 -behaviour(gen_mod).
 -include("jlib.hrl").
--include("jid.hrl").
 -include("mongoose.hrl").
--export([start/2, stop/1, filter_packet/1]).
+-export([start/2, stop/1, filter_global_packet/1, filter_local_packet/1]).
 
 start(Host, _Opts) ->
-    ejabberd_hooks:add(filter_local_packet, Host, ?MODULE, filter_packet, 90).
+    ejabberd_hooks:add(filter_packet, Host, ?MODULE, filter_global_packet, 90),
+    ejabberd_hooks:add(filter_local_packet, Host, ?MODULE, filter_local_packet, 90).
 
 stop(Host) ->
-    ejabberd_hooks:delete(filter_local_packet, Host, ?MODULE, filter_packet, 90).
+    ejabberd_hooks:delete(filter_packet, Host, ?MODULE, filter_global_packet, 90),
+    ejabberd_hooks:delete(filter_local_packet, Host, ?MODULE, filter_local_packet, 90).
+    
+filter_global_packet(Input) ->
+   filter_packet(global, Input).
 
-filter_packet({_From, _To, _Acc, #xmlel{name = StanzaType}} = Input) ->
-    AccessRule = case StanzaType of
-		     <<"presence">> -> mod_filter_presence;
-		     <<"message">> -> mod_filter_message;
-		     <<"iq">> -> mod_filter_iq
-		 end,
-    check_stanza_type(<<"from">>, AccessRule, Input).
+filter_local_packet({_From, _To = #jid{lserver = Host}, _Acc, _Packet} = Input) ->
+   filter_packet(Host, Input).
 
-check_stanza_type(Direction, AccessRule, {From = #jid{lserver = HostFrom}, 
-                                          To = #jid{lserver = HostTo},
-                                          _Acc,
-                                          _Packet} = Input) ->
-    Access = case Direction of
-                <<"from">> -> acl:match_rule(HostFrom, AccessRule, From);
-                <<"to">> -> acl:match_rule(HostTo, AccessRule, To)
-            end,
-    check_access(Direction, AccessRule, Access, Input).
-
-%% If the access results in 'allow' or 'deny', treat that as the
-%% result. Else it is a rule to be applied to the receiver.
-check_access(Direction, AccessRule, Access, Input) when Access =:= allow ->
-    case AccessRule of 
-        mod_filter -> Input;
-        _ -> check_stanza_type(Direction, mod_filter, Input)   
-    end;
-check_access(_Direction, _AccessRule, Access, _Input) when Access =:= deny ->
+filter_packet(Host, {From, To, _Acc, #xmlel{name = StanzaType}} = Input) ->
+    case StanzaType of
+		     <<"message">> -> 
+                              Access = acl:match_rule(Host, mod_filter_message, From),
+                              check_access(Host, To, Access, Input);
+		     _ ->  Input
+	end.
+    
+-spec check_access(Server :: binary() | global,
+                   User :: binary(), 
+                   Access :: allow | deny | term(), 
+                   FilterInput :: binary()) ->
+     drop | binary().
+check_access(_Host, _To, deny, _Input) ->
     drop;
-check_access(_Direction, AccessRule, Access, Input) ->
-    case AccessRule of 
-        mod_filter -> Input;
-        _ -> check_stanza_type(<<"to">>, Access, Input)   
-    end.
+check_access(_Host, _To, allow, Input) ->
+    Input;
+check_access(Host, To, NestedAccessRule, Input) ->
+    Access = acl:match_rule(Host, NestedAccessRule, To),
+    check_access(Host, To, Access, Input).

--- a/src/mod_filter.erl
+++ b/src/mod_filter.erl
@@ -1,0 +1,73 @@
+%%%----------------------------------------------------------------------
+%%% Author  : Magnus Henoch <henoch@dtek.chalmers.se>
+%%% Purpose : flexible filtering by server policy
+%%% Created : 21 Sep 2005 by Magnus Henoch <henoch@dtek.chalmers.se>
+%%% Updated : 14 Jan 2016 by John Brodie <john@brodie.me>
+%%% Updated : 25 Jul 2018 by Beisenbek Baisakov <beysenbek@gmail.com>
+%%%----------------------------------------------------------------------
+
+-module(mod_filter).
+-behaviour(gen_mod).
+-include("jlib.hrl").
+-include("jid.hrl").
+-include("mongoose.hrl").
+-export([start/2,stop/1,
+         filter_packet/1]).
+
+start(Host, _Opts) ->
+    ejabberd_hooks:add(filter_local_packet, Host, ?MODULE, filter_packet, 90).
+
+stop(Host) ->
+    ejabberd_hooks:delete(filter_local_packet, Host, ?MODULE, filter_packet, 90).
+
+-type fpacket() :: {From :: jid:jid(),
+                    To :: jid:jid(),
+                    Acc :: mongoose_acc:t(),
+                    Packet :: exml:element()}.
+-spec filter_packet(Value :: fpacket() | drop) -> fpacket() | drop.
+filter_packet(drop) ->   
+    drop;
+filter_packet({From, To, Acc, Packet} = Input) ->
+    X = case check_stanza(Input) of
+        drop -> 
+            drop;
+        _ -> Input
+    end,
+    X.
+
+check_stanza({From,To,Acc,#xmlel{name = StanzaType}} = Input) ->
+    AccessRule = case StanzaType of
+		     <<"presence">> -> mod_filter_presence;
+		     <<"message">> -> mod_filter_message;
+		     <<"iq">> -> mod_filter_iq
+		 end,
+    check_stanza_type(AccessRule, Input).
+
+check_stanza_type(AccessRule, {From = #jid{lserver = HostFrom}, To = #jid{lserver = HostTo}, Acc, Packet} = Input) ->
+    FromAccess = acl:match_rule(HostFrom, AccessRule, From),
+    case FromAccess of
+        allow -> check_access(Input);
+        deny -> 
+            drop;
+        ToAccessRule -> 
+            ToAccess = acl:match_rule(HostTo, ToAccessRule, To),
+            case ToAccess of
+                allow -> check_access(Input);
+                deny -> drop
+            end
+    end.
+
+check_access({From = #jid{lserver = HostFrom}, To = #jid{lserver = HostTo}, Acc, Packet} = Input) ->
+    FromAccess = acl:match_rule(HostFrom, mod_filter, From),
+    %% If the rule results in 'allow' or 'deny', treat that as the
+    %% result.  Else it is a rule to be applied to the receiver.
+    case FromAccess of
+        allow -> Input;
+        deny -> drop;
+        ToAccessRule ->
+            ToAccess = acl:match_rule(HostTo, ToAccessRule, To),
+            case ToAccess of
+                allow -> Input;
+                deny -> drop
+            end
+    end.


### PR DESCRIPTION
This PR addresses #2031 and #1985

Proposed changes include:
* added generic interface for flexible packet filtering by server policy, for example,  limit traffic between domains or users based on their type.
* `dynamic_modules.erl`  extended with ` ensure_modules/1` which would extract a list of supported domains automatically e.g. via `RPC` and then apply `ensure_modules/2` for each of them 
* added documentation for `mod_filter`
* added test suite for `mod_filter`
