### PR TITLE
More error resilient test runner

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -3,6 +3,8 @@
 
 {require_otp_vsn, "19|20|21"}.
 
+{src_dirs, ["src", "tests"]}.
+
 %% We use https:// instead of git://
 {deps, [{usec, ".*", {git, "https://github.com/esl/usec.git", {branch, "master"}}},
         {bbmustache, ".*", {git, "https://github.com/soranoba/bbmustache.git", "v1.4.0"}},

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -9,6 +9,8 @@
 # - VERBOSE
 # - STOP_NODES
 
+# Fail on errors
+set -e
 
 USAGE=$(cat <<-END
 This script runs small and big tests for MongooseIM
@@ -538,8 +540,6 @@ if [ "$DB_FROM_PRESETS" = true ]; then
     DBS_ARRAY=( $(./tools/test_runner/presets_to_dbs.sh $FINAL_PRESET ))
 fi
 
-./tools/test_runner/selected-tests-to-test-spec.sh "${SELECTED_TESTS[@]}"
-
 # Use env variable or default
 export SMALL_TESTS="${SMALL_TESTS:-$SMALL_TESTS_DEFAULT}"
 export COVER_ENABLED="${COVER_ENABLED:-$COVER_ENABLED_DEFAULT}"
@@ -597,6 +597,8 @@ echo ""
 ./tools/build-releases.sh
 
 ./tools/travis-build-tests.sh
+
+./tools/test_runner/selected-tests-to-test-spec.sh "${SELECTED_TESTS[@]}"
 
 ./tools/travis-setup-db.sh
 

--- a/tools/test_runner/complete-test-name.sh
+++ b/tools/test_runner/complete-test-name.sh
@@ -23,6 +23,7 @@ erlc tools/test_runner/complete_test_name.erl
 erl -noinput \
     -pa tools/test_runner \
     -pa _build/test/lib/mongooseim/test/ \
+    -pa big_tests/_build/default/lib/ejabberd_tests/ebin/ \
     -pa big_tests/tests/ \
     -s complete_test_name main "${SUITE}"
 fi

--- a/tools/test_runner/selected-tests-to-test-spec.sh
+++ b/tools/test_runner/selected-tests-to-test-spec.sh
@@ -24,6 +24,7 @@ erl -noinput \
     -pa tools/test_runner \
     -pa _build/test/lib/mongooseim/test/ \
     -pa big_tests/tests/ \
+    -pa big_tests/_build/default/lib/ejabberd_tests/ebin/ \
     -s selected_tests_to_test_spec main $@
 fi
 

--- a/tools/test_runner/selected_tests_to_test_spec.erl
+++ b/tools/test_runner/selected_tests_to_test_spec.erl
@@ -72,7 +72,7 @@ make_test_spec_sub_atoms(Dir, SubAtoms) ->
     %% Run a part of suite
     Module = spec_to_module(hd(SubAtoms)),
     Last = lists:last(SubAtoms),
-    case is_test_case(Module, Last) of
+    try is_test_case(Module, Last) of
         true ->
             Groups = sub_atoms_to_groups(SubAtoms),
             case Groups of
@@ -84,6 +84,10 @@ make_test_spec_sub_atoms(Dir, SubAtoms) ->
         false ->
             Groups = tl(SubAtoms),
             {groups, Dir, Module, Groups}
+    catch
+        error:undef ->
+            io:format("issue=module_cannot_be_loaded run_the_whole_module_instead module=~p", [Module]),
+            {suites, Dir, spec_to_module(hd(SubAtoms))}
     end.
 
 sub_atoms_to_groups(SubAtoms) ->


### PR DESCRIPTION
This PR addresses some errors, because test runner assumes that someone run it before. And it expects beam files of SUITEs to be available for spec generation and autocompletion.

Be aware, that with this patch travis test would stop, if `redis-server` is running without a docker container. Use `--db` in this case.

Later we can add code, that would test database options sanity before running any tests (gen_tcp connect? actually probing connection with some library? idk).