### PR TITLE
Do not test s2s routing in AMP tests

### DIFF
--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -105,10 +105,10 @@ drop_deliver_test_cases() ->
      drop_deliver_to_stranger_test].
 
 init_per_suite(C) ->
-    rpc(mim(), ejabberd_config, add_local_option, [outgoing_s2s_options, {[ipv4, ipv6], 1000}]),
+    rpc(mim(), ejabberd_config, add_local_option, [{{s2s_host, <<"not a jid">>}, domain()}, deny]),
     escalus:init_per_suite(C).
 end_per_suite(C) ->
-    rpc(mim(), ejabberd_config, del_local_option, [outgoing_s2s_options]),
+    rpc(mim(), ejabberd_config, del_local_option, [{{s2s_host, <<"not a jid">>}, domain()}]),
     escalus_fresh:clean(),
     escalus:end_per_suite(C).
 
@@ -394,8 +394,8 @@ notify_deliver_to_malformed_jid_test(Config) ->
                   true -> client_receives_notification(Alice, StrangerJid, Rule);
                   false -> ok
               end,
-              % Error codes may vary because of s2s config - accept any code
-              client_receives_generic_error(Alice, any, <<"cancel">>),
+              % s2s does not allow routing to 'not a jid', so error 503 is expected
+              client_receives_generic_error(Alice, <<"503">>, <<"cancel">>),
               client_receives_nothing(Alice)
       end).
 

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -55,7 +55,7 @@ essentials() ->
     [simple_message].
 
 all_tests() ->
-    essentials() ++ [nonexistent_user, unknown_domain].
+    essentials() ++ [nonexistent_user, unknown_domain, malformed_jid].
 
 negative() ->
     [timeout_waiting_for_message].
@@ -145,6 +145,20 @@ unknown_domain(Config) ->
         %% Alice@localhost1 sends message to Xyz@localhost3
         escalus:send(Alice1, escalus_stanza:chat_to(
             <<"xyz@somebogushost">>,
+            <<"Hello, unreachable!">>)),
+
+        %% Alice@localhost1 receives stanza error: remote-server-not-found
+        Stanza = escalus:wait_for_stanza(Alice1, 10000),
+        escalus:assert(is_error, [<<"cancel">>, <<"remote-server-not-found">>], Stanza)
+
+    end).
+
+malformed_jid(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice1) ->
+
+        %% Alice@localhost1 sends message to Xyz@localhost3
+        escalus:send(Alice1, escalus_stanza:chat_to(
+            <<"not a jid">>,
             <<"Hello, unreachable!">>)),
 
         %% Alice@localhost1 receives stanza error: remote-server-not-found


### PR DESCRIPTION
This PR addresses https://redmine.erlang-solutions.com/issues/19508

Although I could not reproduce the exact issue, I found that in some cases the response from s2s might be a bit delayed for some messages. In general, AMP tests should not test s2s functionality, so I 
extracted the check for s2s routing to a malformed JID out of `amp_big_SUITE` and put it in `s2s_SUITE`, where it belongs.
