### PR TITLE
Fix checks for matching configuration before reload_cluster.

### DIFF
--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -308,8 +308,7 @@ process_term(Term, State) ->
         {routing_modules, Mods} ->
             add_option(routing_modules, Mods, State);
         {loglevel, Loglevel} ->
-            ejabberd_loglevel:set(Loglevel),
-            State;
+            add_option(loglevel, Loglevel, State);
         {max_fsm_queue, N} ->
             add_option(max_fsm_queue, N, State);
         {sasl_mechanisms, Mechanisms} ->

--- a/src/config/mongoose_config_reload.erl
+++ b/src/config/mongoose_config_reload.erl
@@ -425,14 +425,14 @@ prepare_data_for_cluster_reloading_context([CoordinatorNodeState|_] = NodeStates
       %% All of these versions should be the same for reload_cluster to continue
       loaded_global_versions => node_values(loaded_global_version, ExtNodeStates),
       %% All of these versions should be the same for reload_cluster to continue
-      ondisc_global_versions => node_values(loaded_global_version, ExtNodeStates),
+      ondisc_global_versions => node_values(ondisc_global_version, ExtNodeStates),
 
       %% All of these versions should be the same for reload_cluster to continue
       %% Doest not count node-specific options
       loaded_local_versions => node_values(loaded_local_version, ExtNodeStates),
       %% All of these versions should be the same for reload_cluster to continue
       %% Doest not count node-specific options
-      ondisc_local_versions => node_values(loaded_local_version, ExtNodeStates),
+      ondisc_local_versions => node_values(ondisc_local_version, ExtNodeStates),
 
       %% These versions can be different
       loaded_local_node_specific_versions =>

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -497,6 +497,9 @@ handle_local_config_del(#local_config{key = Key} = El) ->
 
 handle_local_config_change({listen, Old, New}) ->
     reload_listeners(mongoose_config_reload:compare_listeners(Old, New));
+handle_local_config_change({loglevel, _Old, Loglevel}) ->
+    ejabberd_loglevel:set(Loglevel),
+    ok;
 handle_local_config_change({riak_server, _Old, _New}) ->
     mongoose_riak:stop(),
     mongoose_riak:start(),

--- a/test/ejabberd_config_SUITE_data/ejabberd.no_listeners.loglevel_err.cfg
+++ b/test/ejabberd_config_SUITE_data/ejabberd.no_listeners.loglevel_err.cfg
@@ -1,0 +1,71 @@
+{loglevel, 2}.
+{hosts, ["localhost"] }.
+%% To avoid eaddinuse, we don't define any listeners
+{listen, []}.
+{s2s_default_policy, deny }.
+{outgoing_s2s_port, 5269 }.
+{sm_backend, {mnesia, []} }.
+{auth_method, internal}.
+{shaper, normal, {maxrate, 1000}}.
+{shaper, fast, {maxrate, 50000}}.
+{max_fsm_queue, 1000}.
+{acl, local, {user_regexp, ""}}.
+{access, max_user_sessions, [{10, all}]}.
+{access, max_user_offline_messages, [{5000, admin}, {100, all}]}.
+{access, local, [{allow, local}]}.
+{access, c2s, [{deny, blocked}, {allow, all}]}.
+{access, c2s_shaper, [{none, admin}, {normal, all}]}.
+{access, s2s_shaper, [{fast, all}]}.
+{access, muc_admin, [{allow, admin}]}.
+{access, muc_create, [{allow, local}]}.
+{access, muc, [{allow, all}]}.
+{access, register, [{allow, all}]}.
+{registration_timeout, infinity}.
+
+{access, mam_set_prefs, [{default, all}]}.
+{access, mam_get_prefs, [{default, all}]}.
+{access, mam_lookup_messages, [{default, all}]}.
+{access, mam_purge_single_message, [{default, all}]}.
+{access, mam_purge_multiple_messages, [{default, all}]}.
+
+{shaper, mam_shaper, {maxrate, 1}}.
+{shaper, mam_global_shaper, {maxrate, 1000}}.
+
+{access, mam_set_prefs_shaper, [{mam_shaper, all}]}.
+{access, mam_get_prefs_shaper, [{mam_shaper, all}]}.
+{access, mam_lookup_messages_shaper, [{mam_shaper, all}]}.
+{access, mam_purge_single_message_shaper, [{mam_shaper, all}]}.
+{access, mam_purge_multiple_messages_shaper, [{mam_shaper, all}]}.
+
+{access, mam_set_prefs_global_shaper, [{mam_global_shaper, all}]}.
+{access, mam_get_prefs_global_shaper, [{mam_global_shaper, all}]}.
+{access, mam_lookup_messages_global_shaper, [{mam_global_shaper, all}]}.
+{access, mam_purge_single_message_global_shaper, [{mam_global_shaper, all}]}.
+{access, mam_purge_multiple_messages_global_shaper, [{mam_global_shaper, all}]}.
+
+{language, "en"}.
+{modules,
+ [
+  {mod_adhoc, []},
+  {mod_disco, []},
+  {mod_last, []},
+  {mod_stream_management, [ ]},
+  {mod_muc, [
+             {host, "muc.@HOST@"},
+             {access, muc},
+             {access_create, muc_create}
+            ]},
+  {mod_muc_log, [ {outdir, "/tmp/muclogs"}, {access_log, muc} ]},
+  {mod_privacy, []},
+  {mod_register, [
+                  {welcome_message, {""}},
+                  {ip_access, [{allow, "127.0.0.0/8"},
+                               {deny, "0.0.0.0/0"}]},
+                  {access, register}
+                 ]},
+  {mod_roster, []},
+  {mod_sic, []},
+  {mod_vcard, [ {allow_return_all, true}, {search_all_hosts, true} ]},
+  {mod_bosh, []}
+
+ ]}.


### PR DESCRIPTION
Config files on nodes have to be matching in order to successfully reload cluster configuration. The check was broken, so the reload could have proceeded (loading incompatible configurations on nodes) and then fail during a check if the loaded configs are compatible.