### PR TITLE
Wait longer for replaced c2s

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -161,11 +161,11 @@ end_per_group(session_replacement, Config) ->
 end_per_group(_, Config) ->
     Config.
 
-init_per_testcase(replaced_session_cannot_terminate, Config) ->
+init_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
     S = escalus_users:get_server(Config, alice),
     OptKey = {replaced_wait_timeout, S},
     {atomic, _} = rpc(mim(), ejabberd_config, add_local_option, [OptKey, 1]),
-    [{opt_to_del, OptKey} | Config];
+    escalus:init_per_testcase(CN, [{opt_to_del, OptKey} | Config]);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -41,8 +41,10 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    [ {group, fast_tls}
-     ,{group, just_tls}
+    [
+     {group, fast_tls},
+     {group, just_tls},
+     {group, session_replacement}
     ].
 
 groups() ->
@@ -65,12 +67,17 @@ groups() ->
                                        auth_compression_bind_session,
                                        auth_bind_compression_session,
                                        bind_server_generated_resource]},
-          {just_tls,all_groups()},
-          {fast_tls,all_groups()}
+          {just_tls, tls_groups()},
+          {fast_tls, tls_groups()},
+          {session_replacement, [], [
+                                     same_resource_replaces_session,
+                                     clean_close_of_replaced_session,
+                                     replaced_session_cannot_terminate
+                                    ]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
-all_groups()->
+tls_groups()->
     [{group, c2s_noproc},
      {group, starttls},
      {group, feature_order},
@@ -142,15 +149,30 @@ init_per_group(just_tls,Config)->
     end;
 init_per_group(fast_tls,Config)->
     [{tls_module, fast_tls} | Config];
+init_per_group(session_replacement, Config) ->
+    lager_ct_backend:start(),
+    Config;
 init_per_group(_, Config) ->
     Config.
 
+end_per_group(session_replacement, Config) ->
+    lager_ct_backend:stop(),
+    Config;
 end_per_group(_, Config) ->
     Config.
 
+init_per_testcase(replaced_session_cannot_terminate, Config) ->
+    S = escalus_users:get_server(Config, alice),
+    OptKey = {replaced_wait_timeout, S},
+    {atomic, _} = rpc(mim(), ejabberd_config, add_local_option, [OptKey, 1]),
+    [{opt_to_del, OptKey} | Config];
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
+end_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
+    {_, OptKey} = lists:keyfind(opt_to_del, 1, Config),
+    {atomic, _} = rpc(mim(), ejabberd_config, del_local_option, [OptKey]),
+    escalus:end_per_testcase(CN, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
@@ -545,6 +567,45 @@ bind_server_generated_resource(Config) ->
     {resource, Resource} = lists:keyfind(resource, 1, NewSpec),
     ?assert(is_binary(Resource)),
     ?assert(byte_size(Resource) > 0).
+
+same_resource_replaces_session(Config) ->
+    UserSpec = [{resource, <<"confict">>} | escalus_users:get_userspec(Config, alice)],
+    {ok, Alice1, _} = escalus_connection:start(UserSpec),
+
+    {ok, _Alice2, _} = escalus_connection:start(UserSpec),
+
+    ConflictError = escalus:wait_for_stanza(Alice1),
+    escalus:assert(is_stream_error, [<<"conflict">>, <<>>], ConflictError),
+    false = escalus_connection:is_connected(Alice1).
+
+clean_close_of_replaced_session(Config) ->
+    lager_ct_backend:capture(warning),
+
+    same_resource_replaces_session(Config),
+
+    lager_ct_backend:stop_capture(),
+    FilterFun = fun(_, Msg) ->
+                        re:run(Msg, "replaced_wait_timeout") /= nomatch
+                end,
+    [] = lager_ct_backend:recv(FilterFun).
+
+replaced_session_cannot_terminate(Config) ->
+    lager_ct_backend:capture(warning),
+    UserSpec = [{resource, <<"confict">>} | escalus_users:get_userspec(Config, alice)],
+    {ok, _Alice1, _} = escalus_connection:start(UserSpec),
+    [C2SPid] = children_specs_to_pids(rpc(mim(), supervisor, which_children, [ejabberd_c2s_sup])),
+    ok = rpc(mim(), sys, suspend, [C2SPid]),
+
+    {ok, _Alice2, _} = escalus_connection:start(UserSpec),
+
+    timer:sleep(2000),
+
+    rpc(mim(), sys, resume, [C2SPid]),
+    lager_ct_backend:stop_capture(),
+    FilterFun = fun(_, Msg) ->
+                        re:run(Msg, "replaced_wait_timeout") /= nomatch
+                end,
+    [_] = lager_ct_backend:recv(FilterFun).
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/big_tests/tests/lager_ct_backend.erl
+++ b/big_tests/tests/lager_ct_backend.erl
@@ -23,7 +23,7 @@
 %% ------------------------------------------------------------
 
 start() ->
-    mongoose_helper:inject_module(?MODULE, true),
+    mongoose_helper:inject_module(?MODULE, no_reload),
     successful_rpc(gen_event, add_handler, [lager_event, ?MODULE, []]).
 
 stop() ->

--- a/big_tests/tests/lager_ct_backend.erl
+++ b/big_tests/tests/lager_ct_backend.erl
@@ -23,13 +23,7 @@
 %% ------------------------------------------------------------
 
 start() ->
-    case successful_rpc(code, is_loaded, [?MODULE]) of
-        false ->
-            {Mod, Bin, File} = code:get_object_code(?MODULE),
-            successful_rpc(code, load_binary, [Mod, File, Bin]);
-        _ ->
-            already_loaded
-    end,
+    mongoose_helper:inject_module(?MODULE, true),
     successful_rpc(gen_event, add_handler, [lager_event, ?MODULE, []]).
 
 stop() ->

--- a/big_tests/tests/lager_ct_backend.erl
+++ b/big_tests/tests/lager_ct_backend.erl
@@ -1,0 +1,109 @@
+-module(lager_ct_backend).
+
+-behaviour(gen_event).
+
+% API for tests
+-export([start/0, stop/0]).
+-export([capture/1, stop_capture/0]).
+-export([recv/1]).
+
+% gen_event callbacks
+-export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2, code_change/3]).
+
+-import(mongoose_helper, [successful_rpc/3]).
+
+-type state() :: #{
+        receivers := [{pid(), lager:log_level()}]
+       }.
+
+-type filter_fun() :: fun((lager:log_leverl(), binary()) -> boolean()).
+
+%% ------------------------------------------------------------
+%% API for tests
+%% ------------------------------------------------------------
+
+start() ->
+    case successful_rpc(code, is_loaded, [?MODULE]) of
+        false ->
+            {Mod, Bin, File} = code:get_object_code(?MODULE),
+            successful_rpc(code, load_binary, [Mod, File, Bin]);
+        _ ->
+            already_loaded
+    end,
+    successful_rpc(gen_event, add_handler, [lager_event, ?MODULE, []]).
+
+stop() ->
+    successful_rpc(gen_event, delete_handler, [lager_event, ?MODULE, []]).
+
+-spec capture(Level :: lager:log_level()) -> ok.
+capture(Level) ->
+    successful_rpc(gen_event, call, [lager_event, ?MODULE, {capture, self(), Level}]).
+
+stop_capture() ->
+    successful_rpc(gen_event, call, [lager_event, ?MODULE, {stop_capture, self()}]).
+
+-spec recv(filter_fun()) -> ReceivedLogs :: [binary()].
+recv(FilterFun) ->
+    recv(FilterFun, []).
+
+%% ------------------------------------------------------------
+%% gen_event callbacks
+%% ------------------------------------------------------------
+
+-spec init(any()) -> {ok, state()}.
+init(_) ->
+    {ok, #{ receivers => [] }}.
+
+handle_call({capture, Pid, Level}, #{ receivers := Receivers } = State) ->
+    NReceivers = lists:keystore(Pid, 1, Receivers, {Pid, Level}),
+    {ok, ok, State#{ receivers := NReceivers }};
+handle_call({stop_capture, Pid}, #{ receivers := Receivers } = State) ->
+    NReceivers = lists:keydelete(Pid, 1, Receivers),
+    {ok, ok, State#{ receivers := NReceivers }}.
+
+handle_event({log, LagerMsg}, #{ receivers := Receivers } = State) ->
+    Msg = iolist_to_binary(lager_msg:message(LagerMsg)),
+    Severity = lager_msg:severity(LagerMsg),
+    lists:foreach(
+      fun({Pid, Level}) when Level == Severity ->
+              Pid ! {captured_log, Severity, Msg};
+         ({_Pid, _Level}) ->
+              ok
+      end, Receivers),
+    {ok, State};
+handle_event(_Event, State) ->
+    {ok, State}.
+
+handle_info(_Info, State) ->
+    {ok, State}.
+
+terminate(_Arg, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ------------------------------------------------------------
+%% Internal functions
+%% ------------------------------------------------------------
+
+-spec recv(FilterFun :: filter_fun(), OtherMsgs :: [term()]) -> ReceivedLogs :: [binary()].
+recv(FilterFun, OtherMsgs) ->
+    receive
+        {captured_log, Severity, Msg} ->
+            case FilterFun(Severity, Msg) of
+                true ->
+                    [ {Severity, Msg} | recv(FilterFun, OtherMsgs) ];
+                false ->
+                    recv(FilterFun, OtherMsgs)
+            end;
+        OtherMsg ->
+            recv(FilterFun, [OtherMsg | OtherMsgs])
+    after
+        100 ->
+            lists:foreach(fun(Msg) ->
+                                  self() ! Msg
+                          end, lists:reverse(OtherMsgs)),
+            []
+    end.
+

--- a/big_tests/tests/mod_aws_sns_SUITE.erl
+++ b/big_tests/tests/mod_aws_sns_SUITE.erl
@@ -69,8 +69,7 @@ init_per_suite(Config) ->
     case rpc(application, ensure_all_started, [erlcloud]) of
         {ok, _} ->
             %% For mocking with unnamed functions
-            {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-            rpc(code, load_binary, [?MODULE, Filename, Binary]),
+            mongoose_helper:inject_module(?MODULE),
 
             muc_helper:load_muc(muc_host()),
             escalus:init_per_suite(Config);

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -145,7 +145,7 @@ init_per_group(rebalancing, Config) ->
     init_per_group(rebalancing_generic, [{extra_config, ExtraConfig},
                                          {redis_extra_config, RedisExtraConfig} | Config]);
 init_per_group(advertised_endpoints, Config) ->
-    load_suite_module_on_nodes(),
+    mongoose_helper:inject_module(?MODULE),
     mock_inet_on_each_node(),
     init_per_group(advertised_endpoints_generic,
                [{add_advertised_endpoints,
@@ -999,10 +999,6 @@ maybe_add_advertised_endpoints(NodeName, Opts, Config) ->
             NewConnections = {connections, [{advertised_endpoints, E} | Connections]},
             [NewConnections | Opts]
     end.
-
-load_suite_module_on_nodes() ->
-    {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-    execute_on_each_node(code, load_binary, [?MODULE, Filename, Binary]).
 
 mock_inet_on_each_node() ->
     Nodes = lists:map(fun({NodeName, _, _}) -> ct:get_config(NodeName) end, get_hosts()),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -145,7 +145,10 @@ init_per_group(rebalancing, Config) ->
     init_per_group(rebalancing_generic, [{extra_config, ExtraConfig},
                                          {redis_extra_config, RedisExtraConfig} | Config]);
 init_per_group(advertised_endpoints, Config) ->
-    mongoose_helper:inject_module(?MODULE),
+    lists:foreach(fun({NodeName, _, _}) ->
+                          Node = ct:get_config(NodeName),
+                          mongoose_helper:inject_module(Node, ?MODULE, false)
+                  end, get_hosts()),
     mock_inet_on_each_node(),
     init_per_group(advertised_endpoints_generic,
                [{add_advertised_endpoints,

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -147,7 +147,7 @@ init_per_group(rebalancing, Config) ->
 init_per_group(advertised_endpoints, Config) ->
     lists:foreach(fun({NodeName, _, _}) ->
                           Node = ct:get_config(NodeName),
-                          mongoose_helper:inject_module(Node, ?MODULE, false)
+                          mongoose_helper:inject_module(Node, ?MODULE, reload)
                   end, get_hosts()),
     mock_inet_on_each_node(),
     init_per_group(advertised_endpoints_generic,

--- a/big_tests/tests/mongoose_cassandra_SUITE.erl
+++ b/big_tests/tests/mongoose_cassandra_SUITE.erl
@@ -86,7 +86,7 @@ not_so_happy_cases() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(gun),
-    load_test_module(Config),
+    mongoose_helper:inject_module(?MODULE),
 
     case mam_helper:is_cassandra_enabled() of
         true ->
@@ -239,10 +239,6 @@ getenv_or_fail(EnvVar) ->
         false -> error("environment variable " ++ EnvVar ++ "not defined");
         Value -> Value
     end.
-
-load_test_module(_Config) ->
-    {Mod, Bin, File} = code:get_object_code(?MODULE),
-    call(code, load_binary, [Mod, File, Bin]).
 
 call(F, A) ->
     call(mongoose_cassandra, F, A).

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -24,7 +24,7 @@
 -export([logout_user/2]).
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
--export([inject_module/1]).
+-export([inject_module/1, inject_module/2]).
 
 -import(distributed_helper, [mim/0,
                              rpc/4]).

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -310,24 +310,25 @@ wait_for_user(Config, User, LeftTime) ->
 % Loads a module present in big tests into a MongooseIM node
 -spec inject_module(Module :: module()) -> ok.
 inject_module(Module) ->
-    inject_module(Module, false).
+    inject_module(Module, no_reload).
 
--spec inject_module(Module :: module(), CheckIfLoadedAlready :: boolean()) -> ok | already_loaded.
-inject_module(Module, CheckIfLoadedAlready) ->
-    inject_module(mim(), Module, CheckIfLoadedAlready).
+-spec inject_module(Module :: module(),
+                    ReloadIfAlreadyLoaded :: no_reload | reload) -> ok | already_loaded.
+inject_module(Module, ReloadIfAlreadyLoaded) ->
+    inject_module(mim(), Module, ReloadIfAlreadyLoaded).
 
 -spec inject_module(Node :: atom(),
                     Module :: module(),
-                    CheckIfLoadedAlready :: boolean()) ->
+                    ReloadIfAlreadyLoaded :: no_reload | reload) ->
     ok | already_loaded.
-inject_module(Node, Module, true) ->
+inject_module(Node, Module, no_reload) ->
     case successful_rpc(Node, code, is_loaded, [Module]) of
         false ->
-            inject_module(Node, Module, false);
+            inject_module(Node, Module, reload);
         _ ->
             already_loaded
     end;
-inject_module(Node, Module, false) ->
+inject_module(Node, Module, reload) ->
     {Mod, Bin, File} = code:get_object_code(Module),
     successful_rpc(Node, code, load_binary, [Mod, File, Bin]).
 

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -24,7 +24,7 @@
 -export([logout_user/2]).
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
--export([inject_module/1, inject_module/2]).
+-export([inject_module/1, inject_module/2, inject_module/3]).
 
 -import(distributed_helper, [mim/0,
                              rpc/4]).

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -300,8 +300,7 @@ suite() ->
 
 init_per_suite(Config) ->
     %% For mocking with unnamed functions
-    {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-    rpc(mim(), code, load_binary, [?MODULE, Filename, Binary]),
+    mongoose_helper:inject_module(?MODULE),
     Config2 = escalus:init_per_suite(Config),
     Config3 = dynamic_modules:save_modules(domain(), Config2),
     load_muc(muc_host()),

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -75,8 +75,7 @@ suite() ->
 
 init_per_suite(Config) ->
     %% For mocking with unnamed functions
-    {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-    rpc(code, load_binary, [?MODULE, Filename, Binary]),
+    mongoose_helper:inject_module(?MODULE),
     escalus:init_per_suite(Config).
 end_per_suite(Config) ->
     escalus_fresh:clean(),

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -48,8 +48,7 @@ init_per_suite(Config) ->
     application:ensure_all_started(cowboy),
 
     %% For mocking with unnamed functions
-    {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-    rpc(code, load_binary, [?MODULE, Filename, Binary]),
+    mongoose_helper:inject_module(?MODULE),
 
     %% Start modules
     Config2 = dynamic_modules:save_modules(domain(), Config),

--- a/big_tests/tests/race_conditions_SUITE.erl
+++ b/big_tests/tests/race_conditions_SUITE.erl
@@ -50,7 +50,7 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_, Config) ->
-    load_suite_module_on_the_default_node(),
+    mongoose_helper:inject_module(?MODULE),
     start_delayiq_handler(),
     Config.
 
@@ -161,12 +161,6 @@ delayiq_iq() ->
 
 domain() ->
     ct:get_config({hosts, mim, domain}).
-
-%% Copy this module into MongoseIM.
-load_suite_module_on_the_default_node() ->
-    {_Module, Binary, Filename} = code:get_object_code(?MODULE),
-    Args = [?MODULE, Filename, Binary],
-    mongoose_helper:successful_rpc(code, load_binary, Args).
 
 %% This function is executed by MongooseIM
 handle_delayiq_iq(_From, _To, Acc, IQ) ->

--- a/big_tests/tests/sasl_SUITE.erl
+++ b/big_tests/tests/sasl_SUITE.erl
@@ -73,8 +73,7 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 
 text_response(Config) ->
-    {Mod, Bin, File} = code:get_object_code(?MODULE),
-    rpc(mim(), code, load_binary, [Mod, File, Bin]),
+    mongoose_helper:inject_module(?MODULE),
     rpc(mim(), cyrsasl, register_mechanism, [?TEST_MECHANISM, ?MODULE, plain]),
     AliceSpec = escalus_users:get_options(Config, alice),
     {ok, Client, _} = escalus_connection:start(AliceSpec, [start_stream, stream_features]),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -501,8 +501,9 @@ resume_session_state_send_message(Config) ->
 
     escalus_connection:send(Bob, escalus_stanza:chat_to(common_helper:get_bjid(AliceSpec), <<"msg-1">>)),
     %% kill alice connection
+    {ok, C2SPid} = get_session_pid(AliceSpec, escalus_client:resource(Alice)),
     escalus_connection:kill(Alice),
-    ct:sleep(200), %% alice should be in resume_session_state
+    wait_for_c2s_state_change(C2SPid, resume_session),
 
     U = proplists:get_value(username, AliceSpec),
     S = proplists:get_value(server, AliceSpec),
@@ -558,7 +559,7 @@ resume_session_state_stop_c2s(Config) ->
     %% get pid of c2s and stop him !
     C2SRef = rpc(mim(), ejabberd_sm, get_session_pid, [U, S, Res]),
     rpc(mim(), ejabberd_c2s, stop, [C2SRef] ),
-    ct:sleep(1000), %% c2s should be in resume_session_state
+    wait_for_c2s_state_change(C2SRef, resume_session),
 
     %% alice comes back and receives unacked message
     {ok, NewAlice, _} = escalus_connection:start(AliceSpec, ConnSteps),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -544,6 +544,8 @@ resume_session_state_stop_c2s(Config) ->
     escalus_connection:get_stanza(Alice, presence),
 
     escalus:assert(is_sm_ack_request, escalus_connection:get_stanza(Alice, ack)),
+    escalus_connection:send(Alice, escalus_stanza:sm_ack(1)),
+
     escalus_connection:send(Bob, escalus_stanza:chat_to(common_helper:get_bjid(AliceSpec), <<"msg-1">>)),
 
     % kill alice connection

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -329,7 +329,7 @@ There are some additional options that influence all database connections in the
     * **Example:** `{routing_modules, [mongoose_router_global, mongoose_router_localdomain]}.`
 
 * **replaced_wait_timeout** (local)
-    * **Description:** When a user session is replaced (due to a full JID conflict) by a new one, this parameter specifies time that MongooseIM waits for old sessions to close. The default value is sufficient in most cases. If you observe `replaced_wait_timeout` warning in logs, then most probably old sessions are frozen for some reason and it should be investigated.
+    * **Description:** When a user session is replaced (due to a full JID conflict) by a new one, this parameter specifies the time MongooseIM waits for the old sessions to close. The default value is sufficient in most cases. If you observe `replaced_wait_timeout` warning in logs, then most probably the old sessions are frozen for some reason and it should be investigated.
     * **Syntax:** `{replaced_wait_timeout, TimeInMilliseconds}`
     * **Default:** `2000`
 

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -328,6 +328,11 @@ There are some additional options that influence all database connections in the
     * **Default:** `[mongoose_router_global, mongoose_router_localdomain, mongoose_router_external_localnode, mongoose_router_external, ejabberd_s2s]`
     * **Example:** `{routing_modules, [mongoose_router_global, mongoose_router_localdomain]}.`
 
+* **replaced_wait_timeout** (local)
+    * **Description:** When a user session is replaced (due to a full JID conflict) by a new one, this parameter specifies time that MongooseIM waits for old sessions to close. The default value is sufficient in most cases. If you observe `replaced_wait_timeout` warning in logs, then most probably old sessions are frozen for some reason and it should be investigated.
+    * **Syntax:** `{replaced_wait_timeout, TimeInMilliseconds}`
+    * **Default:** `2000`
+
 ### Modules
 
 For a specific configuration, please refer to [Modules](advanced-configuration/Modules.md) page.

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -74,7 +74,8 @@
                 stream_mgmt_constraint_check_tref,
                 csi_state = active :: mod_csi:state(),
                 csi_buffer = [],
-                hibernate_after = 0 :: non_neg_integer()
+                hibernate_after = 0 :: non_neg_integer(),
+                replaced_pids = [] :: [{MonitorRef :: reference(), ReplacedPid :: pid()}]
                 }).
 -type aux_key() :: atom().
 -type aux_value() :: any().

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1035,18 +1035,15 @@ handle_info({'DOWN', Monitor, _Type, Object, _Info}, StateName,
                          [Monitor, Object]),
             fsm_next_state(StateName, StateData)
     end;
-handle_info(replaced_wait_timeout, StateName, StateData) ->
-    case StateData#state.replaced_pids of
-        [] ->
-            fsm_next_state(StateName, StateData);
-        ReplacedPids ->
-            lists:foreach(
-              fun({Monitor, Pid}) ->
-                      ?WARNING_MSG("event=replaced_wait_timeout,monitor=~p,replaced_pid=~p",
-                                   [Monitor, Pid])
-              end, ReplacedPids),
-            fsm_next_state(StateName, StateData#state{ replaced_pids = [] })
-    end;
+handle_info(replaced_wait_timeout, StateName, #state{ replaced_pids = [] } = StateData) ->
+    fsm_next_state(StateName, StateData);
+handle_info(replaced_wait_timeout, StateName, #state{ replaced_pids = ReplacedPids } = StateData) ->
+    lists:foreach(
+      fun({Monitor, Pid}) ->
+              ?WARNING_MSG("event=replaced_wait_timeout,monitor=~p,replaced_pid=~p",
+                           [Monitor, Pid])
+      end, ReplacedPids),
+    fsm_next_state(StateName, StateData#state{ replaced_pids = [] });
 handle_info(system_shutdown, StateName, StateData) ->
     case StateName of
         wait_for_stream ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -762,7 +762,7 @@ do_open_session_common(Acc, JID, #state{user = U, resource = R} = NewStateData0)
         fun({MonitorRef, PID}) ->
             receive
                 {'DOWN', MonitorRef, _, _, _} -> ok
-            after 100 ->
+            after 2000 ->
                 ?WARNING_MSG("C2S process ~p for ~s replaced by ~p has not stopped before timeout",
                              [PID, jid:to_binary(NewStateData0#state.jid), self()])
             end

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -756,7 +756,7 @@ do_open_session_common(Acc, JID, #state{user = U, server = S, resource = R} = Ne
         [] ->
             ok;
         _ ->
-            Timeout = ejabberd_config:get_local_option_or_default({replaced_wait_timeout, S}, 2000),
+            Timeout = get_replaced_wait_timeout(S),
             erlang:send_after(Timeout, self(), replaced_wait_timeout)
     end,
 
@@ -769,6 +769,13 @@ do_open_session_common(Acc, JID, #state{user = U, server = S, resource = R} = Ne
                         pending_invitations = Pending,
                         privacy_list = PrivList},
     {established, Acc1, NewStateData}.
+
+get_replaced_wait_timeout(S) ->
+    ejabberd_config:get_local_option_or_default({replaced_wait_timeout, S},
+                                                default_replaced_wait_timeout()).
+
+default_replaced_wait_timeout() ->
+    2000.
 
 -spec session_established(Item :: ejabberd:xml_stream_item(),
                           State :: state()) -> fsm_return().

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -737,41 +737,33 @@ do_open_session(Acc, JID, StateData) ->
             end
     end.
 
-do_open_session_common(Acc, JID, #state{user = U, resource = R} = NewStateData0) ->
+do_open_session_common(Acc, JID, #state{user = U, server = S, resource = R} = NewStateData0) ->
     change_shaper(NewStateData0, JID),
-    Acc1 = ejabberd_hooks:run_fold(roster_get_subscription_lists,
-                                  NewStateData0#state.server,
-                                  Acc,
-                                  [U, NewStateData0#state.server]),
+    Acc1 = ejabberd_hooks:run_fold(roster_get_subscription_lists, S, Acc, [U, S]),
     {Fs, Ts, Pending} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc1),
     LJID = jid:to_lower(jid:to_bare(JID)),
     Fs1 = [LJID | Fs],
     Ts1 = [LJID | Ts],
-    PrivList = ejabberd_hooks:run_fold(privacy_get_user_list,
-                                       NewStateData0#state.server,
-                                       #userlist{},
-                                       [U, NewStateData0#state.server]),
+    PrivList = ejabberd_hooks:run_fold(privacy_get_user_list, S, #userlist{}, [U, S]),
     SID = {p1_time_compat:timestamp(), self()},
     Conn = get_conn_type(NewStateData0),
     Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
             {auth_module, NewStateData0#state.auth_module}],
-    ReplacedPids = ejabberd_sm:open_session(SID, U, NewStateData0#state.server, R, Info),
+    ReplacedPids = ejabberd_sm:open_session(SID, U, S, R, Info),
 
-    MonitorRefs = ordsets:from_list([{monitor(process, PID), PID} || PID <- ReplacedPids]),
-    lists:foreach(
-        fun({MonitorRef, PID}) ->
-            receive
-                {'DOWN', MonitorRef, _, _, _} -> ok
-            after 2000 ->
-                ?WARNING_MSG("C2S process ~p for ~s replaced by ~p has not stopped before timeout",
-                             [PID, jid:to_binary(NewStateData0#state.jid), self()])
-            end
-        end,
-        MonitorRefs),
+    RefsAndPids = [{monitor(process, PID), PID} || PID <- ReplacedPids],
+    case RefsAndPids of
+        [] ->
+            ok;
+        _ ->
+            Timeout = ejabberd_config:get_local_option_or_default({replaced_wait_timeout, S}, 2000),
+            erlang:send_after(Timeout, self(), replaced_wait_timeout)
+    end,
 
     NewStateData =
     NewStateData0#state{sid = SID,
                         conn = Conn,
+                        replaced_pids = RefsAndPids,
                         pres_f = gb_sets:from_list(Fs1),
                         pres_t = gb_sets:from_list(Ts1),
                         pending_invitations = Pending,
@@ -1032,6 +1024,29 @@ handle_info(new_offline_messages, session_established,
 handle_info({'DOWN', Monitor, _Type, _Object, _Info}, _StateName, StateData)
   when Monitor == StateData#state.socket_monitor ->
     maybe_enter_resume_session(StateData#state.stream_mgmt_id, StateData);
+handle_info({'DOWN', Monitor, _Type, Object, _Info}, StateName,
+            #state{ replaced_pids = ReplacedPids } = StateData) ->
+    case lists:keytake(Monitor, 1, ReplacedPids) of
+        {value, {Monitor, Object}, NReplacedPids} ->
+            NStateData = StateData#state{ replaced_pids = NReplacedPids },
+            fsm_next_state(StateName, NStateData);
+        _ ->
+            ?WARNING_MSG("event=unexpected_c2s_down_info,monitor=~p,monitored_pid=~p",
+                         [Monitor, Object]),
+            fsm_next_state(StateName, StateData)
+    end;
+handle_info(replaced_wait_timeout, StateName, StateData) ->
+    case StateData#state.replaced_pids of
+        [] ->
+            fsm_next_state(StateName, StateData);
+        ReplacedPids ->
+            lists:foreach(
+              fun({Monitor, Pid}) ->
+                      ?WARNING_MSG("event=replaced_wait_timeout,monitor=~p,replaced_pid=~p",
+                                   [Monitor, Pid])
+              end, ReplacedPids),
+            fsm_next_state(StateName, StateData#state{ replaced_pids = [] })
+    end;
 handle_info(system_shutdown, StateName, StateData) ->
     case StateName of
         wait_for_stream ->


### PR DESCRIPTION
This PR addresses #1880 

When a node is slow, it may take more than 100ms for the replaced session to close or for `'DOWN'` message to reach the new c2s.

TODO:

- [x] Tests
- [x] C2S state could store replaced PIDs list in the state so they may be ignored in `handle_info`
- [x] Wait time for replaced sessions may be configurable
- [x] Docs