### PR TITLE
Handle cache directory path for nksip in tools/configure

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -2,6 +2,10 @@
  {setup, [{verify_directories, false}]},
  {{mongooseim_mdb_dir_toggle}}{mnesia, [{dir, "{{mongooseim_mdb_dir}}"}]},
  {ssl, [{session_lifetime, 600}]}, %% 10 minutes
+ {nkservice, [
+    %% Variable is called log_path, however it is used for caching
+    {log_path, "{{nksip_cache_dir}}"}
+ ]},
  {lager, [
     {colored, true},
     %% Limit the number of messages per second allowed from error_logger

--- a/tools/configure
+++ b/tools/configure
@@ -19,7 +19,11 @@
                mdb_dir          = "$RUNNER_BASE_DIR/Mnesia.$NODE",
                mdb_dir_toggle   = "%",
                lock_dir         = "$EJABBERD_DIR/var/lock",
-               nodetool_etc_dir = "etc"}).
+               nodetool_etc_dir = "etc",
+               % nksip writes an erlang module file, which is used as a cache.
+               % By default it uses "log" directory, and we want to change it.
+               nksip_cache_dir  = "priv/nksip_cache"
+              }).
 
 main([]) ->
     usage();
@@ -97,7 +101,8 @@ system_install(Opts) ->
               mdb_dir           = "$PREFIX/var/lib/mongooseim",
               mdb_dir_toggle    = "",
               lock_dir          = "$PREFIX/var/lock/mongooseim",
-              nodetool_etc_dir  = "$PREFIX/etc/mongooseim"}.
+              nodetool_etc_dir  = "$PREFIX/etc/mongooseim",
+              nksip_cache_dir   = "$PREFIX/var/lib/mongooseim/nksip"}.
 
 process_app("none", _Apps) -> [];
 process_app("all", _Apps) -> all_apps();
@@ -169,7 +174,8 @@ write(reltool, FileName, Opts) ->
             rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir),
             rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle),
             rt_var(mongooseim_lock_dir, Opts#opts.lock_dir),
-            rt_var(mongooseim_nodetool_etc_dir, Opts#opts.nodetool_etc_dir)],
+            rt_var(mongooseim_nodetool_etc_dir, Opts#opts.nodetool_etc_dir),
+            rt_var(nksip_cache_dir, Opts#opts.nksip_cache_dir)],
     file:write_file(FileName, Data).
 
 expand_prefix(Opts) when Opts#opts.system /= "yes" -> Opts;
@@ -182,7 +188,8 @@ expand_prefix(Opts) ->
                               #opts.log_dir,
                               #opts.mdb_dir,
                               #opts.lock_dir,
-                              #opts.nodetool_etc_dir]),
+                              #opts.nodetool_etc_dir,
+                              #opts.nksip_cache_dir]),
     NOpts.
 
 expand_prefix(Index, {Opts, Prefix}) ->


### PR DESCRIPTION
Problem
---
By default `nkservice`, which is part of `nksip`, writes the source of Erlang module to the "log" directory. This module is used for caching (the name of the file suggests it: `nksip_config_cache.erl`). While it is not a problem on development environment, it makes MongooseIM hard to use in production environment, because `nksip` tries to write file to installation directory of MongooseIM (e.g.: `/usr/lib/mongooseim`), which should not be writeable.

Solution
---
The `nkservice` allows to configure a path, where aforementioned file will be saved. This PR introduces  changes to`tools/configure`, in order to control with application environmental variable, where the file is save.
The name of the variable is misleading: `log`, however it controls path used for saving caching module.

This resolves #2008

