### PR TITLE
Wait for affiliation change

### DIFF
--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -239,3 +239,12 @@ ver(Int) ->
 -spec set_mod_config(K :: atom(), V :: any(), Host :: binary()) -> ok.
 set_mod_config(K, V, Host) ->
         true = rpc(gen_mod, set_module_opt_by_subhost, [Host, mod_muc_light, K, V]).
+
+assert_aff_change_stanza(Stanza, Target, Change) ->
+    TargetJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Target)),
+    ID = exml_query:attr(Stanza, <<"id">>),
+    true = is_binary(ID) andalso ID /= <<>>,
+    Users = exml_query:paths(Stanza, [{element, <<"x">>}, {element, <<"user">>}]),
+    [User] = [User || User <- Users, TargetJID == exml_query:cdata(User)],
+    Change = exml_query:attr(User, <<"affiliation">>),
+    TargetJID = exml_query:cdata(User).

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -104,6 +104,8 @@ create_unique_room(Config) ->
                   subject => <<"Lewis Carol">>
                 },
         {{<<"201">>, _}, _} = rest_helper:post(admin, Path, Body),
+        AffChange = escalus:wait_for_stanza(Alice),
+        muc_light_helper:assert_aff_change_stanza(AffChange, Alice, <<"owner">>),
         [Item] = get_disco_rooms(Alice),
         MUCLightDomain = muc_light_domain(),
         true = is_room_name(Name, Item),
@@ -124,6 +126,8 @@ create_identifiable_room(Config) ->
                   subject => <<"Lewis Carol">>
                 },
         {{<<"201">>, _}, RoomJID} = rest_helper:putt(admin, Path, Body),
+        AffChange = escalus:wait_for_stanza(Alice),
+        muc_light_helper:assert_aff_change_stanza(AffChange, Alice, <<"owner">>),
         [Item] = get_disco_rooms(Alice),
         [RoomIDescaped, MUCLightDomain] = binary:split(RoomJID, <<"@">>),
         MUCLightDomain = muc_light_domain(),

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -22,7 +22,7 @@
          ).
 
 -import(muc_light_helper,
-        [set_mod_config/3]).
+        [set_mod_config/3, assert_aff_change_stanza/3]).
 
 -import(escalus_ejabberd, [rpc/3]).
 
@@ -789,15 +789,6 @@ send_messages(Config, Alice, Bob, Kate) ->
     M3 = send_message(kate, Kate, Alice),
     mam_helper:maybe_wait_for_archive(Config),
     [M1, M2, M3].
-
-assert_aff_change_stanza(Stanza, Target, Change) ->
-    TargetJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Target)),
-    ID = exml_query:attr(Stanza, <<"id">>),
-    true = is_binary(ID) andalso ID /= <<>>,
-    Users = exml_query:paths(Stanza, [{element, <<"x">>}, {element, <<"user">>}]),
-    [User] = [User || User <- Users, TargetJID == exml_query:cdata(User)],
-    Change = exml_query:attr(User, <<"affiliation">>),
-    TargetJID = exml_query:cdata(User).
 
 assert_room_info(Owner, RoomInfo) ->
     true = is_property_present(<<"subject">>, RoomInfo),


### PR DESCRIPTION
This PR fixes a race condition where we got affiliation change when expected disco result. Now we consume the affiliation change before querying for disco.
