### PR TITLE
Allow to configure ElasticSearch pool via outgoing_options

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -320,8 +320,10 @@
     {elasticsearch_mnesia,
      [{dbs, [redis, elasticsearch]},
       {sm_backend, "{mnesia, []}"},
-      {elasticsearch_server, "{elasticsearch_server, []}."},
       {auth_method, "internal"},
+      {outgoing_pools, "{outgoing_pools, [
+       {elastic, global, elasticsearch, [], []}
+       ]}."},
       {mod_offline, "{mod_offline, []},"}
      ]},
     {elasticsearch_and_cassandra_mnesia,
@@ -331,7 +333,8 @@
       {outgoing_pools, "{outgoing_pools, [
        {cassandra, global, default, [{workers, 20}],
                                [{ssl,[{cacertfile, \"priv/ssl/cacert.pem\"},
-                                      {verify, verify_peer}] }]}
+                                      {verify, verify_peer}] }]},
+       {elastic, global, elasticsearch, [], []}
        ]}."},
       {auth_method, "internal"},
       {mod_offline, "{mod_offline, []},"}

--- a/big_tests/tests/mongoose_elasticsearch_SUITE.erl
+++ b/big_tests/tests/mongoose_elasticsearch_SUITE.erl
@@ -81,10 +81,5 @@ start_and_stop_sequence(_Config) ->
 
 -spec is_elasticsearch_enabled() -> boolean().
 is_elasticsearch_enabled() ->
-    case rpc(mim(), mongoose_elasticsearch, health, []) of
-        {ok, _} ->
-            true;
-        {error, _} ->
-            false
-    end.
+    rpc(mim(), mongoose_wpool, is_configured, [elastic]).
 

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -354,41 +354,6 @@ sslmode     = verify-full
 sslrootcert = /path/to/ca/cert
 ```
 
-### ElasticSearch connection setup
-
-Currently MongooseIM allows to create only a single pool of connections to a single ElasticSearch node.
-To enable a pool you need to add `elasticsearch_server` option in `mongooseim.cfg`:
-
-```
-{elasticsearch_server, [Option1, Option2]}.
-```
-
-Options include:
-* `host` (default: `"localhost"`) - hostname or IP address of ElasticSearch node
-* `port` (default: `9200`) - port the ElasticSearch node's HTTP API is listening on
-
-You can verify that MongooseIM has established the connection by running the following function in the MongooseIM shell:
-
-```
-1> mongoose_elasticsearch:health().
-{ok,#{<<"active_primary_shards">> => 15,<<"active_shards">> => 15,
-       <<"active_shards_percent_as_number">> => 50.0,
-       <<"cluster_name">> => <<"docker-cluster">>,
-       <<"delayed_unassigned_shards">> => 0,
-       <<"initializing_shards">> => 0,
-       <<"number_of_data_nodes">> => 1,
-       <<"number_of_in_flight_fetch">> => 0,
-       <<"number_of_nodes">> => 1,
-       <<"number_of_pending_tasks">> => 0,
-       <<"relocating_shards">> => 0,
-       <<"status">> => <<"yellow">>,
-       <<"task_max_waiting_in_queue_millis">> => 0,
-       <<"timed_out">> => false,
-       <<"unassigned_shards">> => 15}}
-```
-
-Note that the output might differ based on your ElasticSearch cluster configuration.
-
 ### Outgoing HTTP connections
 
 The `http_connections` option configures a list of named pools of outgoing HTTP connections that may be used by various modules. Each of the pools has a name (atom) and a list of options:

--- a/doc/advanced-configuration/outgoing-connections.md
+++ b/doc/advanced-configuration/outgoing-connections.md
@@ -209,16 +209,16 @@ If no errors occurred and your output is similar to the one above then your Mong
 
 ## ElasticSearch connection setup
 
-A connection pool to ElasticSearch can be configured as below:
+A connection pool to ElasticSearch can be configured as follows:
 
 ```erlang
 {outgoing_pools, [
- {elastic, global, elasticsearch, [], []}
+ {elastic, global, elasticsearch, [], [{host, "localhost"}]}
 ]}.
 ```
 
 MongooseIM uses [inaka/tirerl](https://github.com/inaka/tirerl) library to communicate with ElasticSearch.
-This library starts pool of worker by its own so:
+This library starts a pool of workers on its own so the following options are not configurable via `WPoolOpts`:
 
 * number of workers (which is 50)
 * `call_timeout` (inifinity)
@@ -226,12 +226,12 @@ This library starts pool of worker by its own so:
 
 are not possible to change via `WPoolOpts`.
 
-Only `ConnectionOpts` can be set and in them the following options can be added (as `{key, value}` pairs):
+Only configurable options are `ConnectionOpts` and here you can add (as `{key, value}` pairs):
 
 * `host` (default: `"localhost"`) - hostname or IP address of ElasticSearch node
 * `port` (default: `9200`) - port the ElasticSearch node's HTTP API is listening on
 
-You can verify that MongooseIM has established the connection by running the following function in the MongooseIM shell:
+Run the following function in the MongooseIM shell to verify that the connection has been established:
 
 ```erlang
 1> mongoose_elasticsearch:health().

--- a/doc/migrations/3.1.1_3.1.1++.md
+++ b/doc/migrations/3.1.1_3.1.1++.md
@@ -10,3 +10,26 @@
 ## **`ejabberd.cfg` renamed to `mongooseim.cfg`**
 
 Rename the existing config file of MongooseIM from `ejabberd.cfg` to `mongooseim.cfg`.
+
+## Pools configuration
+
+The way how pools to external service are configured changed, please see [Outgoing Connection doc](../advanced-configuration/outgoing-connections.md) for more details.
+
+NOTE: Keep in mind that `outgoing_pools` is a list of pools, it may turn out that you will have more than one entry in the list when more than outgoing pool is needed.
+
+### ElasticSearch configuration migration
+
+Change the existing entry in the configuration file:
+
+```erlang
+{elasticsearch_server, [{host, "elastic.host.com"}, {port, 9042}]}.
+```
+
+to:
+
+```erlang
+{outgoing_pools, [
+ {elastic, global, elasticsearch, [], [{host, "elastic.host.com"}, {port, 9042}]}
+]}.
+```
+

--- a/doc/migrations/3.1.1_3.1.1++.md
+++ b/doc/migrations/3.1.1_3.1.1++.md
@@ -13,9 +13,9 @@ Rename the existing config file of MongooseIM from `ejabberd.cfg` to `mongooseim
 
 ## Pools configuration
 
-The way how pools to external service are configured changed, please see [Outgoing Connection doc](../advanced-configuration/outgoing-connections.md) for more details.
+Configuring pools to external services has changed, please see [Outgoing Connection doc](../advanced-configuration/outgoing-connections.md) for more details.
 
-NOTE: Keep in mind that `outgoing_pools` is a list of pools, it may turn out that you will have more than one entry in the list when more than outgoing pool is needed.
+NOTE: Keep in mind that outgoing_pools is a list of pools, it may turn out that you will have more than one entry in the list when more than a single outgoing pool is needed.
 
 ### ElasticSearch configuration migration
 

--- a/src/elasticsearch/mongoose_elasticsearch.erl
+++ b/src/elasticsearch/mongoose_elasticsearch.erl
@@ -135,27 +135,9 @@ delete_by_query(Index, Type, SearchQuery) ->
 
 -spec start_pool(list()) -> ok | no_return().
 start_pool(Opts) ->
-    Host = proplists:get_value(host, Opts, "localhost"),
-    Port = proplists:get_value(port, Opts, 9200),
-    case tirerl:start_pool(?POOL_NAME, [{host, list_to_binary(Host)}, {port, Port}]) of
-        {ok, _} ->
-            ?INFO_MSG("event=elasticsearch_pool_started elasticsearch_host=~p elasticsearch_port=~p",
-                      [Host, Port]),
-            ok;
-        {ok, _, _} ->
-            ?INFO_MSG("event=elasticsearch_pool_started elasticsearch_host=~p elasticsearch_port=~p",
-                      [Host, Port]),
-            ok;
-        {error, {already_started, _}} ->
-            ok;
-        {error, _} = Err ->
-            ?ERROR_MSG("event=elasticsearch_pool_start_failed elasticsearch_host=~p "
-                       "elasticsearch_port=~p reason=~1000p",
-                       [Host, Port, Err]),
-            error(Err)
-    end.
+    mongoose_wpool:start(elastic, global, ?POOL_NAME, [], Opts).
 
 -spec stop_pool() -> any().
 stop_pool() ->
-    tirerl:stop_pool(?POOL_NAME).
+    mongoose_wpool:stop(elastic, global, ?POOL_NAME).
 

--- a/src/mongoose_wpool_elastic.erl
+++ b/src/mongoose_wpool_elastic.erl
@@ -1,0 +1,27 @@
+-module(mongoose_wpool_elastic).
+-behaviour(mongoose_wpool).
+
+-export([init/0]).
+-export([start/4]).
+-export([stop/2]).
+
+init() ->
+    tirerl:start(),
+    ok.
+
+start(_Host, Tag, _WpoolOptsIn, ConnOpts) ->
+    ElasticHost = proplists:get_value(host, ConnOpts, "localhost"),
+    Port = proplists:get_value(port, ConnOpts, 9200),
+    case tirerl:start_pool(Tag, [{host, list_to_binary(ElasticHost)}, {port, Port}]) of
+        {ok, Pid} ->
+            {external, Pid};
+        {ok, Pid, _} ->
+            {external, Pid};
+        Other ->
+            Other
+    end.
+
+stop(_, Tag) ->
+    tirerl:stop_pool(Tag),
+    ok.
+


### PR DESCRIPTION
This PR changes the way how ElasticSearch pool is configured

Proposed changes include:
* mongoose_wpool_elastic - starts and stops the pool
* ability to configure ElasticSearch pool via `outgoing_pools` option
* adjust test to start the pool in the new way

