### PR TITLE
Remove debug log about old shapers

### DIFF
--- a/src/shaper_srv.erl
+++ b/src/shaper_srv.erl
@@ -143,7 +143,6 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info(delete_old_shapers, State) ->
-    ?DEBUG("Deleted old shapers", []),
     {noreply, delete_old_shapers(State)};
 handle_info(_Info, State) ->
     {noreply, State}.


### PR DESCRIPTION
This PR removes debug log about old shapers being deleted.

I'm not sure if these were useful to anyone ever but for me they were usually annoying and make working with debug log level more difficult (console spamming, interleaving with command being typed).

