### PR TITLE
Reorganise certs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # You can add personal rules in your file .git/info/exclude
 tools/*.tar.gz
 tools/*.pyc
+tools/ssl/ca
+tools/ssl/mongooseim
+tools/ssl/ca-clients
 src/#*
 src/.#*
 test/.#*
@@ -115,6 +118,7 @@ get-deps.log
 big_tests/src/mim_ct_rest.erl
 big_tests/src/mim_ct_rest_handler.erl
 big_tests/src/mim_ct_sup.erl
+big_tests/priv/ssl
 test_preset.log
 
 codecov.json

--- a/Makefile
+++ b/Makefile
@@ -53,19 +53,7 @@ $(DEVNODES): certs configure.out rel/vars.config
 	(. ./configure.out && \
 	DEVNODE=true $(RUN) $(REBAR) as $@ release)
 
-certs: tools/ssl/ca/cacert.pem \
-       tools/ssl/fake_cert.pem \
-       tools/ssl/fake_key.pem \
-       tools/ssl/fake_pubkey.pem \
-       tools/ssl/fake_server.pem \
-       tools/ssl/fake_dh_server.pem
-
-tools/ssl/ca/cacert.pem \
-tools/ssl/fake_cert.pem \
-tools/ssl/fake_key.pem \
-tools/ssl/fake_pubkey.pem \
-tools/ssl/fake_server.pem \
-tools/ssl/fake_dh_server.pem:
+certs:
 	cd tools/ssl && $(MAKE)
 
 xeplist: escript

--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -85,15 +85,15 @@ mim_ct_rest: \
 vm.dist.args: vm.dist.args.in certs
 	$(SED) -e 's%__PWD__%$(PWD)%g' $< > $@
 
-certs: priv/ssl/fake_cert.pem priv/ssl/fake_key.pem priv/ssl/cacert.pem
+certs: priv/ssl/cert.pem priv/ssl/key.pem priv/ssl/cacert.pem
 
-priv/ssl/fake_cert.pem priv/ssl/fake_key.pem priv/ssl/cacert.pem: \
-  $(REPO_DIR)/tools/ssl/fake_cert.pem \
-  $(REPO_DIR)/tools/ssl/fake_key.pem \
+priv/ssl/cert.pem priv/ssl/key.pem priv/ssl/cacert.pem: \
+  $(REPO_DIR)/tools/ssl/mongooseim/cert.pem \
+  $(REPO_DIR)/tools/ssl/mongooseim/key.pem \
   $(REPO_DIR)/tools/ssl/ca/cacert.pem
 	mkdir -p $(@D)
 	cp $^ $(@D)/
-	cat priv/ssl/fake_key.pem >> priv/ssl/fake_cert.pem
+	cat priv/ssl/key.pem >> priv/ssl/cert.pem
 
 console: $(PREPARE)
 	erl $(COMMON_OPTS) $(ADD_OPTS)

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -113,11 +113,7 @@ init_per_suite(Config) ->
         {{ok, _}, {ok, _}} ->
             ok = rpc(europe_node2, mongoose_cluster, join, [ct:get_config(europe_node1)]),
 
-            CertDir = filename:join(path_helper:test_dir(Config), "priv/ssl"),
-            CertPath = path_helper:canonicalize_path(filename:join(CertDir, "fake_cert.pem")),
-            CACertPath = path_helper:canonicalize_path(filename:join(CertDir, "cacert.pem")),
             escalus:init_per_suite([{add_advertised_endpoints, []},
-                                    {certfile, CertPath}, {cafile, CACertPath},
                                     {extra_config, []}, {redis_extra_config, []} | Config]);
         _ ->
             {skip, "Cannot connect to Redis server on 127.0.0.1 6379"}
@@ -160,8 +156,8 @@ init_per_group(_, Config0) ->
                             {global_host, "localhost"},
                             {endpoints, [listen_endpoint(ReceiverPort)]},
                             {tls_opts, [
-                                        {certfile, ?config(certfile, Config1)},
-                                        {cafile, ?config(cafile, Config1)}
+                                        {certfile, "priv/ssl/fake_server.pem"},
+                                        {cafile, "priv/ssl/ca/cacert.pem"}
                                        ]},
                             {redis, [{port, 6379} | ?config(redis_extra_config, Config1)]},
                             {resend_after_ms, 500}]),

--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -10,8 +10,8 @@
 start(Config) ->
     application:ensure_all_started(cowboy),
     CertDir = filename:join(path_helper:test_dir(Config), "priv/ssl"),
-    CertPath = path_helper:canonicalize_path(filename:join(CertDir, "fake_cert.pem")),
-    KeyPath = path_helper:canonicalize_path(filename:join(CertDir, "fake_key.pem")),
+    CertPath = path_helper:canonicalize_path(filename:join(CertDir, "cert.pem")),
+    KeyPath = path_helper:canonicalize_path(filename:join(CertDir, "key.pem")),
 
     Dispatch = cowboy_router:compile([{'_', [{<<"/v2/notification/:token">>, ?MODULE, #{}}]}]),
     {ok, Pid} = cowboy:start_tls(mongoose_push_https_mock, 100,

--- a/big_tests/vm.dist.args.in
+++ b/big_tests/vm.dist.args.in
@@ -12,8 +12,8 @@
 ## Once a connection is established, Erlang doesn't differentiate between
 ## a client and a server - the same certs/keys can be used on both sides.
 -proto_dist inet_tls
--ssl_dist_opt server_certfile   __PWD__/priv/ssl/fake_cert.pem client_certfile   __PWD__/priv/ssl/fake_cert.pem
-              server_keyfile    __PWD__/priv/ssl/fake_key.pem  client_keyfile    __PWD__/priv/ssl/fake_key.pem
+-ssl_dist_opt server_certfile   __PWD__/priv/ssl/cert.pem client_certfile   __PWD__/priv/ssl/cert.pem
+              server_keyfile    __PWD__/priv/ssl/key.pem  client_keyfile    __PWD__/priv/ssl/key.pem
               server_cacertfile __PWD__/priv/ssl/cacert.pem    client_cacertfile __PWD__/priv/ssl/cacert.pem
               client_verify verify_peer
               server_verify verify_peer

--- a/rebar.config
+++ b/rebar.config
@@ -88,10 +88,10 @@
 
         {overlay, [
                    {mkdir, "priv/ssl"},
-                   {copy, "tools/ssl/fake_cert.pem",        "priv/ssl/fake_cert.pem"},
-                   {copy, "tools/ssl/fake_key.pem",         "priv/ssl/fake_key.pem"},
-                   {copy, "tools/ssl/fake_server.pem",      "priv/ssl/fake_server.pem"},
-                   {copy, "tools/ssl/fake_dh_server.pem",   "priv/ssl/fake_dh_server.pem"},
+                   {copy, "tools/ssl/mongooseim/cert.pem",        "priv/ssl/fake_cert.pem"},
+                   {copy, "tools/ssl/mongooseim/key.pem",         "priv/ssl/fake_key.pem"},
+                   {copy, "tools/ssl/mongooseim/server.pem",      "priv/ssl/fake_server.pem"},
+                   {copy, "tools/ssl/mongooseim/dh_server.pem",   "priv/ssl/fake_dh_server.pem"},
                    {copy, "tools/ssl/ca/cacert.pem",        "priv/ssl/cacert.pem"},
 
                    {copy,     "rel/files/erl",          "erts-\{\{erts_vsn\}\}/bin/erl"},

--- a/src/global_distrib/mod_global_distrib_connection.erl
+++ b/src/global_distrib/mod_global_distrib_connection.erl
@@ -63,7 +63,8 @@ init([{Addr, Port}, Server]) ->
                     peer = mod_global_distrib_transport:peername(Socket)}}
     catch
         error:{badmatch, Reason} ->
-            ?ERROR_MSG("Connection to ~p failed: ~p", [{Addr, Port}, Reason]),
+            ?ERROR_MSG("Connection to ~p failed: ~p~n~p",
+                       [{Addr, Port}, Reason, erlang:get_stacktrace()]),
             {stop, normal}
     end.
 

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -64,8 +64,8 @@ end_per_suite(Config) ->
 
 init_per_group(public_key, Config) ->
     Root = small_path_helper:repo_dir(Config),
-    PrivkeyPath = filename:join([Root, "tools", "ssl", "fake_privkey.pem"]),
-    PubkeyPath = filename:join([Root, "tools", "ssl", "fake_pubkey.pem"]),
+    PrivkeyPath = filename:join([Root, "tools", "ssl", "mongooseim", "privkey.pem"]),
+    PubkeyPath = filename:join([Root, "tools", "ssl", "mongooseim", "pubkey.pem"]),
     {ok, PrivKey} = file:read_file(PrivkeyPath),
     set_auth_opts(PubkeyPath, undefined, "RS256", bookingNumber),
     ok = ejabberd_auth_jwt:start(?DOMAIN1),

--- a/tools/db_configs/cassandra/docker_entry.sh
+++ b/tools/db_configs/cassandra/docker_entry.sh
@@ -14,8 +14,8 @@ cat - >>"${CASSANDRA_CONFIG}/cassandra.yaml" <<-EOF
 
 openssl pkcs12 -export                                     \
                -out "${CASSANDRA_CONFIG}/fake_server.p12"  \
-               -in /ssl/fake_cert.pem                      \
-               -inkey /ssl/fake_privkey.pem                \
+               -in /ssl/mongooseim/cert.pem                      \
+               -inkey /ssl/mongooseim/privkey.pem                \
                -password "pass:${password}"
 
 keytool -importkeystore                                     \

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -3,23 +3,20 @@ all: mongooseim/server.pem mongooseim/cert.pem \
   mongooseim/pubkey.pem mongooseim/privkey.pem \
   ca/cacert.pem ca/cakey.pem \
 
-%/cacert.pem: openssl-%.cnf
+%/cacert.pem %/cakey.pem: openssl-%.cnf
 	mkdir -p $(@D)
-	openssl req -x509 -config $< -newkey rsa:2048 -sha256 -nodes -out $@ -outform PEM
+	openssl req -x509 -config $< -newkey rsa:2048 -sha256 -nodes \
+	            -out $(@D)/cacert.pem -keyout $(@D)/cakey.pem -outform PEM
 
-%/cakey.pem: %/cacert.pem;
-
-%/cert.csr: openssl-%.cnf
+%/cert.csr %/key.pem: openssl-%.cnf
 	mkdir -p $(@D)
 	openssl req -config $< -newkey rsa:2048 -sha256 -nodes \
-		-out $@ -keyout $(subst cert.csr,key.pem,$@) \
+		-out $(@D)/cert.csr -keyout $(@D)/key.pem \
 		-outform PEM
 
 %/cert.pem: %/cert.csr openssl-ca.cnf ca/cacert.pem ca/cakey.pem | ca/index.txt ca/serial.txt
 	yes | openssl ca -config openssl-ca.cnf -policy signing_policy \
 		-extensions signing_req -out $@ -infiles $<
-
-%/key.pem: %/cert.pem;
 
 %/server.pem: %/cert.pem %/key.pem
 	cat $^ > $@

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -1,41 +1,45 @@
-CA_SUB  = /C=PL/ST=Malopolska/L=Krakow/CN=MongooseIM Fake CA
-SRV_SUB = /C=PL/ST=Malopolska/L=Krakow/CN=MongooseIM Server
+all: mongooseim/server.pem mongooseim/cert.pem \
+  mongooseim/key.pem mongooseim/dh_server.pem \
+  mongooseim/pubkey.pem mongooseim/privkey.pem \
+  ca/cacert.pem ca/cakey.pem \
 
-all: ca/cacert.pem fake_cert.pem fake_pubkey.pem fake_privkey.pem fake_server.pem fake_dh_server.pem
+%/cacert.pem: openssl-%.cnf
+	mkdir -p $(@D)
+	openssl req -x509 -config $< -newkey rsa:2048 -sha256 -nodes -out $@ -outform PEM
 
-ca/cacert.pem ca/cakey.pem: openssl-ca.cnf
-	mkdir -p ca
-	-rm ca/cacert.pem
-	-rm ca/cakey.pem
-	openssl req -x509 -config $< -newkey rsa:2048 -sha256 -nodes \
-		-subj '$(CA_SUB)' -out ca/cacert.pem -outform PEM
+%/cakey.pem: %/cacert.pem;
 
-fake_cert.csr: openssl-server.cnf
-	openssl req -config $< -newkey rsa:2048 -sha256 -nodes -out $@ \
-		-subj '$(SRV_SUB)' -outform PEM
+%/cert.csr: openssl-%.cnf
+	mkdir -p $(@D)
+	openssl req -config $< -newkey rsa:2048 -sha256 -nodes \
+		-out $@ -keyout $(subst cert.csr,key.pem,$@) \
+		-outform PEM
 
-fake_cert.pem: fake_cert.csr openssl-ca.cnf ca/cacert.pem ca/cakey.pem ca/index.txt ca/serial.txt
+%/cert.pem: %/cert.csr openssl-ca.cnf ca/cacert.pem ca/cakey.pem | ca/index.txt ca/serial.txt
 	yes | openssl ca -config openssl-ca.cnf -policy signing_policy \
-		-extensions signing_req -out $@ -infiles fake_cert.csr
+		-extensions signing_req -out $@ -infiles $<
 
-fake_pubkey.pem: fake_cert.pem
-	openssl x509 -pubkey -noout -in fake_cert.pem > fake_pubkey.pem
+%/key.pem: %/cert.pem;
 
-fake_privkey.pem: fake_key.pem
-	openssl rsa -in fake_key.pem -out fake_privkey.pem
-
-fake_server.pem: fake_cert.pem fake_key.pem
+%/server.pem: %/cert.pem %/key.pem
 	cat $^ > $@
 
-fake_dh_server.pem:
+%/pubkey.pem: %/cert.pem
+	openssl x509 -pubkey -noout -in $< > $@
+
+%/privkey.pem: %/key.pem
+	openssl rsa -in $< -out $@
+
+%/dh_server.pem:
 	openssl dhparam -outform PEM -out $@ 1024
 
 ca/index.txt:
-	touch ca/index.txt
+	mkdir -p $(@D)
+	touch $@
 
 ca/serial.txt:
+	mkdir -p $(@D)
 	echo 01 > $@
 
 clean:
-	-rm -f ca/*
-	-rm fake_cert.csr fake_cert.pem fake_key.pem fake_server.pem
+	rm -rf ca ca-clients mongooseim

--- a/tools/ssl/openssl-ca.cnf
+++ b/tools/ssl/openssl-ca.cnf
@@ -37,20 +37,14 @@ default_keyfile     = ca/cakey.pem
 distinguished_name  = ca_distinguished_name
 #x509_extensions     = ca_extensions
 string_mask         = utf8only
+prompt              = no
 
 ####################################################################
 [ ca_distinguished_name ]
 countryName                 = PL
-countryName_default         = PL
-
 stateOrProvinceName         = Malopolska
-stateOrProvinceName_default = Malopolska
-
 localityName                = Krakow
-localityName_default        = Krakow
-
 commonName                  = MongooseIM Fake CA
-commonName_default          = MongooseIM Fake CA
 
 ####################################################################
 [ signing_policy ]

--- a/tools/ssl/openssl-ca.cnf
+++ b/tools/ssl/openssl-ca.cnf
@@ -33,7 +33,6 @@ unique_subject      = no                    # Set to 'no' to allow creation of
 ####################################################################
 [ req ]
 default_bits        = 4096
-default_keyfile     = ca/cakey.pem
 distinguished_name  = ca_distinguished_name
 #x509_extensions     = ca_extensions
 string_mask         = utf8only

--- a/tools/ssl/openssl-mongooseim.cnf
+++ b/tools/ssl/openssl-mongooseim.cnf
@@ -1,30 +1,20 @@
-## This file is based on a tutorial from StackOverflow:
-## http://stackoverflow.com/questions/21297139/how-do-you-sign-certificate-signing-request-with-your-certification-authority/21340898#21340898
-
 HOME            = .
 RANDFILE        = $ENV::HOME/.rnd
 
 ####################################################################
 [ req ]
 default_bits        = 4096
-default_keyfile     = fake_key.pem
 distinguished_name  = server_distinguished_name
 req_extensions      = server_req_extensions
 string_mask         = utf8only
+prompt              = no
 
 ####################################################################
 [ server_distinguished_name ]
 countryName                 = PL
-countryName_default         = PL
-
 stateOrProvinceName         = Malopolska
-stateOrProvinceName_default = Malopolska
-
 localityName                = Krakow
-localityName_default        = Krakow
-
-commonName            = MongooseIM
-commonName_default    = MongooseIM
+commonName                  = MongooseIM
 
 ####################################################################
 [ server_req_extensions ]

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -111,8 +111,8 @@ if [ "$db" = 'mysql' ]; then
     # TODO We should not use sudo
     sudo -n service mysql stop || echo "Failed to stop mysql"
     docker rm -f mongooseim-mysql || echo "Skip removing previous container"
-    cp ${SSLDIR}/fake_cert.pem ${SQL_TEMP_DIR}/
-    openssl rsa -in ${SSLDIR}/fake_key.pem -out ${SQL_TEMP_DIR}/fake_key.pem
+    cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
+    openssl rsa -in ${SSLDIR}/mongooseim/key.pem -out ${SQL_TEMP_DIR}/fake_key.pem
     # mysql_native_password is needed until mysql-otp implements caching-sha2-password
     # https://github.com/mysql-otp/mysql-otp/issues/83
     docker run -d \
@@ -138,8 +138,8 @@ elif [ "$db" = 'pgsql' ]; then
     echo "Configuring postgres with SSL"
     sudo -n service postgresql stop || echo "Failed to stop psql"
     docker rm -f mongooseim-pgsql || echo "Skip removing previous container"
-    cp ${SSLDIR}/fake_cert.pem ${SQL_TEMP_DIR}/.
-    cp ${SSLDIR}/fake_key.pem ${SQL_TEMP_DIR}/.
+    cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
+    cp ${SSLDIR}/mongooseim/key.pem ${SQL_TEMP_DIR}/fake_key.pem
     cp ${DB_CONF_DIR}/postgresql.conf ${SQL_TEMP_DIR}/.
     cp ${DB_CONF_DIR}/pg_hba.conf ${SQL_TEMP_DIR}/.
     cp ${MIM_PRIV_DIR}/pg.sql ${SQL_TEMP_DIR}/.
@@ -168,8 +168,8 @@ elif [ "$db" = 'riak' ]; then
         -e DOCKER_RIAK_CLUSTER_SIZE=1 \
         --name=mongooseim-riak \
 	$(mount_ro_volume "${DB_CONF_DIR}/advanced.config" "/etc/riak/advanced.config") \
-	$(mount_ro_volume "${SSLDIR}/fake_cert.pem" "/etc/riak/cert.pem") \
-	$(mount_ro_volume "${SSLDIR}/fake_key.pem" "/etc/riak/key.pem") \
+	$(mount_ro_volume "${SSLDIR}/mongooseim/cert.pem" "/etc/riak/cert.pem") \
+	$(mount_ro_volume "${SSLDIR}/mongooseim/key.pem" "/etc/riak/key.pem") \
 	$(mount_ro_volume "${SSLDIR}/ca/cacert.pem" "/etc/riak/ca/cacertfile.pem") \
         $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/riak) \
         --health-cmd='riak-admin status' \


### PR DESCRIPTION
This PR reorganises a bit how certificates are generated and used in tests. This refactoring was inspired by the work done by @chrzaszcz in a side project.

This is needed for the SASL end-2-end tests I'm currently working on.