### PR TITLE
Event pusher improvements

### DIFF
--- a/big_tests/tests/push_http_SUITE.erl
+++ b/big_tests/tests/push_http_SUITE.erl
@@ -1,0 +1,279 @@
+-module(push_http_SUITE).
+-compile(export_all).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+        {group, single},
+        {group, customised},
+        {group, multiple}
+    ].
+
+groups() ->
+    [{single, [sequence], [simple_push]},
+     {customised, [sequence], [custom_push]},
+     {multiple, [sequence], [push_to_many]}
+    ].
+
+suite() ->
+    escalus:suite().
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    start_pool(),
+    setup_modules(),
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    stop_pool(),
+    teardown_modules(),
+    escalus_fresh:clean(),
+    escalus:end_per_suite(Config).
+
+init_per_group(GroupName, Config) ->
+    Config2 = dynamic_modules:save_modules(domain(), Config),
+    dynamic_modules:ensure_modules(domain(),
+                                   required_modules(GroupName)),
+    escalus:create_users(Config2, escalus:get_users([alice, bob])).
+
+end_per_group(_, Config) ->
+    dynamic_modules:restore_modules(domain(), Config),
+    escalus:delete_users(Config, escalus:get_users([alice, bob])).
+
+init_per_testcase(CaseName, Config) ->
+    start_http_listener(),
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    stop_http_listener(),
+    escalus:end_per_testcase(CaseName, Config).
+
+required_modules(single) ->
+    [{mod_event_pusher,
+        [{backends,
+            [{http,
+                [{path, "/push"},
+                    {pool_name, http_pool}]
+                }]
+        }]
+    }];
+required_modules(customised) ->
+    [{mod_event_pusher,
+        [{backends,
+            [{http,
+                [{path, "/push"},
+                    {callback_module, mod_event_pusher_http_custom},
+                    {pool_name, http_pool}]
+                }]
+        }]
+    }];
+required_modules(multiple) ->
+    [{mod_event_pusher,
+        [{backends,
+            [{http,
+                [{path, "/push"},
+                 {callback_module, mod_event_pusher_http_custom},
+                 {pool_name, http_pool}]
+             },
+             {http,
+                [{path, "/push2"},
+                 {callback_module, mod_event_pusher_http_custom_2},
+                 {pool_name, http_pool}]
+            }]
+        }]
+     }].
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+simple_push(Config) ->
+    escalus:fresh_story(
+        Config, [{alice, 1}, {bob, 1}],
+        fun(Alice, Bob) ->
+            Send = fun(Body) ->
+                       Stanza = escalus_stanza:chat_to(Bob, Body),
+                       escalus_client:send(Alice, Stanza)
+                   end,
+            Send(<<"hej">>),
+            [R] = got_push(push, 1),
+            check_default_format(Alice, Bob, <<"hej">>, R),
+            Send(<<>>),
+            got_no_push(push),
+            ok
+        end).
+
+custom_push(Config) ->
+    escalus:fresh_story(
+        Config, [{alice, 1}, {bob, 1}],
+        fun(Alice, Bob) ->
+            Send = fun(Body) ->
+                       Stanza = escalus_stanza:chat_to(Bob, Body),
+                ct:pal("Stanza: ~p", [Stanza]),
+                       escalus_client:send(Alice, Stanza)
+                   end,
+            Send(<<"hej">>),
+            Send(<<>>),
+%%            now we receive them both ways, and with a custom body
+            Res = got_push(push, 4),
+            ?assertEqual([<<"in-">>,<<"in-hej">>,<<"out-">>,<<"out-hej">>], lists:sort(Res)),
+            ok
+        end).
+
+push_to_many(Config) ->
+    escalus:fresh_story(
+        Config, [{alice, 1}, {bob, 1}],
+        fun(Alice, Bob) ->
+            Send = fun(Body) ->
+                       Stanza = escalus_stanza:chat_to(Bob, Body),
+                       escalus_client:send(Alice, Stanza)
+                   end,
+            Send(<<"hej">>),
+            Send(<<>>),
+%%            now we receive them both ways, and with a custom body
+            Res = got_push(push, 4),
+            ?assertEqual([<<"in-">>,<<"in-hej">>,<<"out-">>,<<"out-hej">>], lists:sort(Res)),
+%%            while the other backend sends only those 'out'
+            Res2 = got_push(push2, 2),
+            ?assertEqual([<<"2-out-">>,<<"2-out-hej">>], lists:sort(Res2)),
+            ok
+        end).
+
+start_pool() ->
+    ejabberd_node_utils:call_fun(mongoose_http_client, start, [[]]),
+    ejabberd_node_utils:call_fun(mongoose_http_client,
+        start_pool,
+        [http_pool, [{server, "http://localhost:8000"}]]),
+    ok.
+
+stop_pool() ->
+    ejabberd_node_utils:call_fun(mongoose_http_client, stop_pool, [http_pool]),
+    ejabberd_node_utils:call_fun(mongoose_http_client, stop, []),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Libs
+%%--------------------------------------------------------------------
+
+receive_push(Type) ->
+    receive
+        {{got_http_push, Type}, Bin} ->
+            ct:pal("{Type, Bin}: ~p", [{Type, Bin}]),
+            Bin
+    after 1000 ->
+        nothing
+    end.
+
+got_push(Type) ->
+    case receive_push(Type) of
+        nothing -> ct:fail(http_request_timeout);
+        Bin -> Bin
+    end.
+
+got_no_push(Type) ->
+    case receive_push(Type) of
+        nothing -> ok;
+        _ -> ct:fail(unwanted_push)
+    end.
+
+got_push(Type, Count)->
+    got_push(Type, Count, []).
+
+got_push(Type, 0, Res) ->
+    got_no_push(Type),
+    lists:reverse(Res);
+got_push(Type, N, Res) ->
+    got_push(Type, N - 1, [got_push(Type) | Res]).
+
+
+start_http_listener() ->
+    Pid = self(),
+    http_helper:start(8000, '_', fun(Req) -> process_notification(Req, Pid) end).
+
+stop_http_listener() ->
+    http_helper:stop().
+
+process_notification(Req, Pid) ->
+    <<$/, BType/binary>> = cowboy_req:path(Req),
+    Type = binary_to_atom(BType, utf8),
+    {ok, Body, Req1} = cowboy_req:read_body(Req),
+    Req2 = cowboy_req:reply(200, #{<<"content-type">> => <<"text/plain">>}, <<"OK">>, Req1),
+    Pid ! {{got_http_push, Type}, Body},
+    Req2.
+
+check_default_format(From, To, Body, Msg) ->
+    Attrs = lists:map(fun(P) -> list_to_tuple(binary:split(P, <<$=>>)) end, binary:split(Msg, <<$&>>, [global])),
+    ?assertEqual(to_lower(escalus_client:username(From)), proplists:get_value(<<"author">>, Attrs)),
+    ?assertEqual(to_lower(escalus_client:username(To)), proplists:get_value(<<"receiver">>, Attrs)),
+    ?assertEqual(Body, proplists:get_value(<<"message">>, Attrs)),
+    ?assertEqual(<<"localhost">>, proplists:get_value(<<"server">>, Attrs)),
+    ok.
+
+setup_modules() ->
+    {Mod, Code} = rpc(dynamic_compile, from_string, [custom_module_code()]),
+    rpc(code, load_binary, [Mod, "mod_event_pusher_http_custom.erl", Code]),
+    {Mod2, Code2} = rpc(dynamic_compile, from_string, [custom_module_code_2()]),
+    rpc(code, load_binary, [Mod2, "mod_event_pusher_http_custom_2.erl", Code2]),
+    ok.
+
+teardown_modules() ->
+    ok.
+
+rpc(M, F, A) ->
+    distributed_helper:rpc(distributed_helper:mim(), M, F, A).
+
+custom_module_code() ->
+    "-module(mod_event_pusher_http_custom).
+     -export([should_make_req/5, prepare_body/6, prepare_headers/6]).
+     should_make_req(Acc, _, _, _, _) ->
+         case mongoose_acc:stanza_name(Acc) of
+             <<\"message\">> -> true;
+             _ -> false
+         end.
+     prepare_headers(_, _, _, _, _, _) ->
+         mod_event_pusher_http_defaults:prepare_headers(x, x, x, x, x, x).
+     prepare_body(_Acc, Dir, _Host, Message, _Sender, _Receiver) ->
+         <<(atom_to_binary(Dir, utf8))/binary, $-, Message/binary>>.
+     "
+.
+
+custom_module_code_2() ->
+    "-module(mod_event_pusher_http_custom_2).
+     -export([should_make_req/5, prepare_body/6, prepare_headers/6]).
+     should_make_req(Acc, out, _, _, _) ->
+         case mongoose_acc:stanza_name(Acc) of
+             <<\"message\">> -> true;
+             _ -> false
+         end;
+     should_make_req(_, in, _, _, _) -> false.
+     prepare_headers(_, _, _, _, _, _) ->
+         mod_event_pusher_http_defaults:prepare_headers(x, x, x, x, x, x).
+     prepare_body(_Acc, Dir, _Host, Message, _Sender, _Receiver) ->
+         <<$2, $-, (atom_to_binary(Dir, utf8))/binary, $-, Message/binary>>.
+     "
+    .
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+to_lower(B) ->
+    list_to_binary(
+        string:to_lower(
+            binary_to_list(
+                B
+            )
+        )
+    ).

--- a/big_tests/tests/push_http_SUITE.erl
+++ b/big_tests/tests/push_http_SUITE.erl
@@ -237,31 +237,31 @@ rpc(M, F, A) ->
 
 custom_module_code() ->
     "-module(mod_event_pusher_http_custom).
-     -export([should_make_req/5, prepare_body/6, prepare_headers/6]).
-     should_make_req(Acc, _, _, _, _) ->
+     -export([should_make_req/6, prepare_body/7, prepare_headers/7]).
+     should_make_req(Acc, _, _, _, _, _) ->
          case mongoose_acc:stanza_name(Acc) of
              <<\"message\">> -> true;
              _ -> false
          end.
-     prepare_headers(_, _, _, _, _, _) ->
-         mod_event_pusher_http_defaults:prepare_headers(x, x, x, x, x, x).
-     prepare_body(_Acc, Dir, _Host, Message, _Sender, _Receiver) ->
+     prepare_headers(_, _, _, _, _, _, _) ->
+         mod_event_pusher_http_defaults:prepare_headers(x, x, x, x, x, x, x).
+     prepare_body(_Acc, Dir, _Host, Message, _Sender, _Receiver, _Opts) ->
          <<(atom_to_binary(Dir, utf8))/binary, $-, Message/binary>>.
      "
 .
 
 custom_module_code_2() ->
     "-module(mod_event_pusher_http_custom_2).
-     -export([should_make_req/5, prepare_body/6, prepare_headers/6]).
-     should_make_req(Acc, out, _, _, _) ->
+     -export([should_make_req/6, prepare_body/7, prepare_headers/7]).
+     should_make_req(Acc, out, _, _, _, _) ->
          case mongoose_acc:stanza_name(Acc) of
              <<\"message\">> -> true;
              _ -> false
          end;
-     should_make_req(_, in, _, _, _) -> false.
-     prepare_headers(_, _, _, _, _, _) ->
-         mod_event_pusher_http_defaults:prepare_headers(x, x, x, x, x, x).
-     prepare_body(_Acc, Dir, _Host, Message, _Sender, _Receiver) ->
+     should_make_req(_, in, _, _, _, _) -> false.
+     prepare_headers(_, _, _, _, _, _, _) ->
+         mod_event_pusher_http_defaults:prepare_headers(x, x, x, x, x, x, x).
+     prepare_body(_Acc, Dir, _Host, Message, _Sender, _Receiver, _Opts) ->
          <<$2, $-, (atom_to_binary(Dir, utf8))/binary, $-, Message/binary>>.
      "
     .

--- a/big_tests/tests/push_http_SUITE.erl
+++ b/big_tests/tests/push_http_SUITE.erl
@@ -26,7 +26,7 @@ groups() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -49,31 +49,36 @@ start(Host, _Opts) ->
 stop(_Host) ->
     ok.
 
-push_event(Acc, _, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
+push_event(Acc, _Host, #chat_event{direction = in, from = From, to = To, packet = Packet}) ->
+    lists:map(fun(Opts) -> push_event(Acc, From, To, Packet, Opts) end,
+              gen_mod:get_module_opt(From#jid.lserver, ?MODULE, configs, [])),
+    Acc;
+push_event(Acc, _Host, _Event) ->
+    Acc.
+
+push_event(Acc, From, To, Packet, Opts) ->
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
-    Mod = get_callback_module(From#jid.lserver),
+    Mod = get_callback_module(Opts),
     case Mod:should_make_req(Acc, Packet, From, To) of
         true ->
-            make_req(Acc, From#jid.lserver, From#jid.luser, To#jid.luser, Body);
+            make_req(Acc, From#jid.lserver, From#jid.luser, To#jid.luser, Body, Opts);
         _ ->
             ok
     end,
-    Acc;
-push_event(Acc, _, _Event) ->
     Acc.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
 
-get_callback_module(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, callback_module, mod_event_pusher_http_defaults).
+get_callback_module(Opts) ->
+    proplists:get_value(callback_module, Opts, mod_event_pusher_http_defaults).
 
-make_req(Acc, Host, Sender, Receiver, Message) ->
-    Path = fix_path(list_to_binary(gen_mod:get_module_opt(Host, ?MODULE, path, ?DEFAULT_PATH))),
-    PoolName = gen_mod:get_module_opt(Host, ?MODULE, pool_name, ?DEFAULT_POOL_NAME),
+make_req(Acc, Host, Sender, Receiver, Message, Opts) ->
+    Path = fix_path(list_to_binary(proplists:get_value(path, Opts, ?DEFAULT_PATH))),
+    PoolName = proplists:get_value(pool_name, Opts, ?DEFAULT_POOL_NAME),
     Pool = mongoose_http_client:get_pool(PoolName),
-    Mod = get_callback_module(Host),
+    Mod = get_callback_module(Opts),
     Body = Mod:prepare_body(Acc, Host, Message, Sender, Receiver),
     Headers = Mod:prepare_headers(Acc, Host, Message, Sender, Receiver),
     ?INFO_MSG("Making request '~p' for user ~s@~s...", [Path, Sender, Host]),

--- a/src/event_pusher/mod_event_pusher_http_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_http_defaults.erl
@@ -11,7 +11,7 @@
 -behaviour(mod_event_pusher_http).
 
 %% API
--export([should_make_req/3]).
+-export([should_make_req/3, prepare_body/4, prepare_headers/4]).
 
 %% @doc This function determines whether to send http notification or not.
 %% Can be reconfigured by creating a custom module implementing should_make_req/3
@@ -26,3 +26,10 @@ should_make_req(<<"chat">>, Body, _From, _To) when Body /= <<"">> ->
     true;
 should_make_req(_, _, _, _) ->
     false.
+
+prepare_body(Host, Message, Sender, Receiver) ->
+    cow_qs:qs([{<<"author">>, Sender},
+        {<<"server">>, Host}, {<<"receiver">>, Receiver}, {<<"message">>, Message}]).
+
+prepare_headers(_Host, _Sender, _Receiver, _Message) ->
+    [{<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}].

--- a/src/event_pusher/mod_event_pusher_http_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_http_defaults.erl
@@ -11,25 +11,25 @@
 -behaviour(mod_event_pusher_http).
 
 %% API
--export([should_make_req/3, prepare_body/4, prepare_headers/4]).
+-export([should_make_req/4, prepare_body/5, prepare_headers/5]).
 
 %% @doc This function determines whether to send http notification or not.
 %% Can be reconfigured by creating a custom module implementing should_make_req/3
 %% and adding it to mod_event_pusher_http settings as {callback_module}
 %% Default behaviour is to send all chat messages with non-empty body.
-should_make_req(Packet, From, To) ->
+should_make_req(Acc, Packet, From, To) ->
     Type = exml_query:attr(Packet, <<"type">>, <<>>),
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
-    should_make_req(Type, Body, From, To).
+    should_make_req(Acc, Type, Body, From, To).
 
-should_make_req(<<"chat">>, Body, _From, _To) when Body /= <<"">> ->
+should_make_req(_Acc, <<"chat">>, Body, _From, _To) when Body /= <<"">> ->
     true;
-should_make_req(_, _, _, _) ->
+should_make_req(_Acc, _, _, _, _) ->
     false.
 
-prepare_body(Host, Message, Sender, Receiver) ->
+prepare_body(_Acc, Host, Message, Sender, Receiver) ->
     cow_qs:qs([{<<"author">>, Sender},
         {<<"server">>, Host}, {<<"receiver">>, Receiver}, {<<"message">>, Message}]).
 
-prepare_headers(_Host, _Sender, _Receiver, _Message) ->
+prepare_headers(_Acc, _Host, _Sender, _Receiver, _Message) ->
     [{<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}].

--- a/src/event_pusher/mod_event_pusher_http_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_http_defaults.erl
@@ -11,25 +11,27 @@
 -behaviour(mod_event_pusher_http).
 
 %% API
--export([should_make_req/4, prepare_body/5, prepare_headers/5]).
+-export([should_make_req/5, prepare_body/6, prepare_headers/6]).
 
 %% @doc This function determines whether to send http notification or not.
 %% Can be reconfigured by creating a custom module implementing should_make_req/3
 %% and adding it to mod_event_pusher_http settings as {callback_module}
 %% Default behaviour is to send all chat messages with non-empty body.
-should_make_req(Acc, Packet, From, To) ->
+should_make_req(_Acc, out, _Packet, _From, _To) ->
+    false;
+should_make_req(Acc, in, Packet, From, To) ->
     Type = exml_query:attr(Packet, <<"type">>, <<>>),
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
-    should_make_req(Acc, Type, Body, From, To).
+    should_make_req_type(Acc, Type, Body, From, To).
 
-should_make_req(_Acc, <<"chat">>, Body, _From, _To) when Body /= <<"">> ->
+should_make_req_type(_Acc, <<"chat">>, Body, _From, _To) when Body /= <<"">> ->
     true;
-should_make_req(_Acc, _, _, _, _) ->
+should_make_req_type(_Acc, _, _, _, _) ->
     false.
 
-prepare_body(_Acc, Host, Message, Sender, Receiver) ->
+prepare_body(_Acc, _Dir, Host, Message, Sender, Receiver) ->
     cow_qs:qs([{<<"author">>, Sender},
         {<<"server">>, Host}, {<<"receiver">>, Receiver}, {<<"message">>, Message}]).
 
-prepare_headers(_Acc, _Host, _Sender, _Receiver, _Message) ->
+prepare_headers(_Acc, _Dir, _Host, _Sender, _Receiver, _Message) ->
     [{<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}].

--- a/src/event_pusher/mod_event_pusher_http_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_http_defaults.erl
@@ -11,15 +11,15 @@
 -behaviour(mod_event_pusher_http).
 
 %% API
--export([should_make_req/5, prepare_body/6, prepare_headers/6]).
+-export([should_make_req/6, prepare_body/7, prepare_headers/7]).
 
 %% @doc This function determines whether to send http notification or not.
 %% Can be reconfigured by creating a custom module implementing should_make_req/3
 %% and adding it to mod_event_pusher_http settings as {callback_module}
 %% Default behaviour is to send all chat messages with non-empty body.
-should_make_req(_Acc, out, _Packet, _From, _To) ->
+should_make_req(_Acc, out, _Packet, _From, _To, _Opts) ->
     false;
-should_make_req(Acc, in, Packet, From, To) ->
+should_make_req(Acc, in, Packet, From, To, _Opts) ->
     Type = exml_query:attr(Packet, <<"type">>, <<>>),
     Body = exml_query:path(Packet, [{element, <<"body">>}, cdata], <<>>),
     should_make_req_type(Acc, Type, Body, From, To).
@@ -29,9 +29,9 @@ should_make_req_type(_Acc, <<"chat">>, Body, _From, _To) when Body /= <<"">> ->
 should_make_req_type(_Acc, _, _, _, _) ->
     false.
 
-prepare_body(_Acc, _Dir, Host, Message, Sender, Receiver) ->
+prepare_body(_Acc, _Dir, Host, Message, Sender, Receiver, _Opts) ->
     cow_qs:qs([{<<"author">>, Sender},
         {<<"server">>, Host}, {<<"receiver">>, Receiver}, {<<"message">>, Message}]).
 
-prepare_headers(_Acc, _Dir, _Host, _Sender, _Receiver, _Message) ->
+prepare_headers(_Acc, _Dir, _Host, _Sender, _Receiver, _Message, _Opts) ->
     [{<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}].


### PR DESCRIPTION
This PR improves mod_event_pusher a bit, making it more configurable (ref. MIM-70):

Proposed changes include:
- pass accumulator down to event pushing logic
- http backend can have multiple configurations (like, push messages to various backends using various predicates)
- http backend callbacks can customise message body and headers
- http backend can push both incoming and outgoing messages

