### PR TITLE
Self-signed certs for SASL-EXTERNAL

### DIFF
--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -13,10 +13,10 @@ all() ->
      {group, just_tls_allow_self_signed}].
 
 groups() ->
-    G = [{fast_tls, [], common_test_cases() ++ no_allowed_self_signed_test_cases()},
-	 {just_tls, [], common_test_cases() ++ no_allowed_self_signed_test_cases()},
-	 {fast_tls_allow_self_signed, [], common_test_cases() ++ self_signed_test_cases()},
-	 {just_tls_allow_self_signed, [], common_test_cases() ++ self_signed_test_cases()}],
+    G = [{fast_tls, [parallel], common_test_cases() ++ no_allowed_self_signed_test_cases()},
+	 {just_tls, [parallel], common_test_cases() ++ no_allowed_self_signed_test_cases()},
+	 {fast_tls_allow_self_signed, [parallel], common_test_cases() ++ self_signed_test_cases()},
+	 {just_tls_allow_self_signed, [parallel], common_test_cases() ++ self_signed_test_cases()}],
     ct_helper:repeat_all_until_all_ok(G).
 
 common_test_cases() ->

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -158,7 +158,7 @@ self_signed_cert_fails_to_authenticate(C, EscalusTransport) ->
 	escalus_connected ->
 	    ct:fail(authenticated_but_should_not)
     after 10000 ->
-	      ct:fail(authenticated_but_should_not)
+	      ct:fail(timeout_waiting_for_authentication_error)
     end.
 
 self_signed_cert_is_allowed_with_tls(C) ->

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -9,11 +9,13 @@
 all() ->
     [{group, fast_tls},
      {group, just_tls},
+     {group, fast_tls_allow_self_signed},
      {group, just_tls_allow_self_signed}].
 
 groups() ->
     G = [{fast_tls, [], common_test_cases() ++ no_allowed_self_signed_test_cases()},
 	 {just_tls, [], common_test_cases() ++ no_allowed_self_signed_test_cases()},
+	 {fast_tls_allow_self_signed, [], common_test_cases() ++ self_signed_test_cases()},
 	 {just_tls_allow_self_signed, [], common_test_cases() ++ self_signed_test_cases()}],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -71,13 +73,17 @@ tls_module_by_group_name(fast_tls) ->
 tls_module_by_group_name(just_tls) ->
     just_tls;
 tls_module_by_group_name(just_tls_allow_self_signed) ->
-    just_tls.
+    just_tls;
+tls_module_by_group_name(fast_tls_allow_self_signed) ->
+    fast_tls.
 
 ssl_options_by_group_name(fast_tls) ->
     "";
 ssl_options_by_group_name(just_tls) ->
     "{ssl_options, [{verify_fun, {peer, false}}]},";
 ssl_options_by_group_name(just_tls_allow_self_signed) ->
+    "{ssl_options, [{verify_fun, {selfsigned_peer, true}}]},";
+ssl_options_by_group_name(fast_tls_allow_self_signed) ->
     "{ssl_options, [{verify_fun, {selfsigned_peer, true}}]},".
 
 verify_mode_by_group_name(fast_tls) ->
@@ -85,6 +91,8 @@ verify_mode_by_group_name(fast_tls) ->
 verify_mode_by_group_name(just_tls) ->
     "";
 verify_mode_by_group_name(just_tls_allow_self_signed) ->
+    "{verify_mode, selfsigned_peer},";
+verify_mode_by_group_name(fast_tls_allow_self_signed) ->
     "{verify_mode, selfsigned_peer},".
 
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -46,11 +46,33 @@ Below you may find a list of backends that are safe to use with `cyrsasl_externa
 * `rdbms`
 * `riak`
 
+### Self-signed certificates
+
+By default MongooseIM doesn't accept self-signed certs for the SASL-EXTERNAL authentication.
+They may be handy in development so we made it possible to tell MongooseIM to accept them.
+
+#### Self-signed certificates for regular TCP/TLS connections
+
+In order to tell MongooseIM to accept self-signed certs, `ssl_options` list needs to be added to `ejabberd_c2s` listener config like below:
+
+```Erlang
+{ssl_options, [{verify_fun, {selfsigned_peer, true}}]}
+```
+
+#### Self-signed certificates for WS or BOSH
+
+In order to accept self-signed certs for WS or BOSH connections, `ssl` option list of `ejabberd_cowboy` must contain the following pair:
+
+```Erlang
+{verify_mode, selfsigned_peer}
+```
+
+
 ### Examples
 
 Certificate authentication only.
 
-```
+```Erlang
 {listen, [
            (...)
            {5222, ejabberd_c2s, [

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -49,11 +49,11 @@ Below you may find a list of backends that are safe to use with `cyrsasl_externa
 ### Self-signed certificates
 
 By default MongooseIM doesn't accept self-signed certs for the SASL-EXTERNAL authentication.
-They may be handy in development so we made it possible to tell MongooseIM to accept them.
+For development purposes, it is possible to tell MongooseIM to accept them.
 
 #### Self-signed certificates for regular TCP/TLS connections
 
-In order to tell MongooseIM to accept self-signed certs, `ssl_options` list needs to be added to `ejabberd_c2s` listener config like below:
+In order to tell MongooseIM to accept self-signed certs, the `ssl_options` list needs to be added to `ejabberd_c2s` listener config like below:
 
 ```Erlang
 {ssl_options, [{verify_fun, {selfsigned_peer, true}}]}
@@ -61,7 +61,7 @@ In order to tell MongooseIM to accept self-signed certs, `ssl_options` list need
 
 #### Self-signed certificates for WS or BOSH
 
-In order to accept self-signed certs for WS or BOSH connections, `ssl` option list of `ejabberd_cowboy` must contain the following pair:
+In order to accept self-signed certs for WS or BOSH connections, the `ssl` option list of `ejabberd_cowboy` must contain the following pair:
 
 ```Erlang
 {verify_mode, selfsigned_peer}

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -56,8 +56,16 @@ For development purposes, it is possible to tell MongooseIM to accept them.
 In order to tell MongooseIM to accept self-signed certs, the `ssl_options` list needs to be added to `ejabberd_c2s` listener config like below:
 
 ```Erlang
-{ssl_options, [{verify_fun, {selfsigned_peer, true}}]}
+{ssl_options, [{verify_fun, {selfsigned_peer, DisconnectOnVerificationFailure}}]}
 ```
+
+where the `DisconnectOnVerificationFailure` is a boolean with the following meaning only for `just_tls`:
+
+* `true` the connection is closed if a certificate is invalid,
+* `false` the connection is not be closed, but the certificate is not be returned if is invalid.
+  This leads to authentication failure but allows the client to choose different auth method if set.
+
+For `fast_tls` backend, the configuration is the same, only the `DisconnectOnVerificationFailure` is ignored.
 
 #### Self-signed certificates for WS or BOSH
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -61,9 +61,9 @@ In order to tell MongooseIM to accept self-signed certs, the `ssl_options` list 
 
 where the `DisconnectOnVerificationFailure` is a boolean with the following meaning only for `just_tls`:
 
-* `true` the connection is closed if a certificate is invalid,
-* `false` the connection is not be closed, but the certificate is not be returned if is invalid.
-  This leads to authentication failure but allows the client to choose different auth method if set.
+* `true` - the connection is closed if a certificate is invalid,
+* `false` - the connection isn't closed, but the certificate is not returned if it's invalid.
+  This leads to an authentication failure but allows the client to choose a different auth method if available.
 
 For `fast_tls` backend, the configuration is the same, only the `DisconnectOnVerificationFailure` is ignored.
 

--- a/src/ejabberd_tls.erl
+++ b/src/ejabberd_tls.erl
@@ -119,7 +119,7 @@ get_peer_certificate(#ejabberd_tls_socket{tls_module = fast_tls, tls_socket = S,
         {0, {ok, Cert}} -> {ok, Cert};
         {Error, {ok, Cert}} ->
             SSLOpts = proplists:get_value(ssl_options, TLSOpts, []),
-            maybe_self_signed(Error, Cert, SSLOpts);
+            maybe_allow_selfsigned(Error, Cert, SSLOpts);
         {_, error} -> no_peer_cert
     end.
 
@@ -144,14 +144,14 @@ has_peer_cert(Opts) ->
     end.
 
 %% 18 is OpenSSL's and fast_tls's error code for self-signed certs
-maybe_self_signed(18 = Error, Cert, SSLOpts) ->
+maybe_allow_selfsigned(18 = Error, Cert, SSLOpts) ->
     case lists:keyfind(verify_fun, 1, SSLOpts) of
         {verify_fun, {selfsigned_peer, _}} ->
             {ok, Cert};
         _ ->
             cert_verification_error(Error, Cert)
     end;
-maybe_self_signed(Error, Cert, _SSLOpts) ->
+maybe_allow_selfsigned(Error, Cert, _SSLOpts) ->
     cert_verification_error(Error, Cert).
 
 cert_verification_error(Error, Cert) ->


### PR DESCRIPTION
Proposed changes include:
* extended test cases when self-signed certs are allowed and not
* extended ejabberd_cowboy to allow self-signed certs

TODO:

- [x]  documentation on how to enable self-signed certs
- [x] allow self-signed certs with fast_tls driver

