### PR TITLE
Fix optargs issue

### DIFF
--- a/src/mongoose_api_admin.erl
+++ b/src/mongoose_api_admin.erl
@@ -171,7 +171,7 @@ from_json(Req, #http_api_state{command_category = Category,
             Cmds = mongoose_commands:list(admin, Category, method_to_action(Method), SubCategory),
             QVals = cowboy_req:parse_qs(Req),
             Arity = length(B) + length(Params) + length(QVals),
-            case [C || C <- Cmds, mongoose_commands:arity(C) == Arity] of
+            case [C || C <- Cmds, mongoose_commands:func_arity(C) == Arity] of
                 [Command] ->
                     process_request(Method, Command, {Params, Req}, State);
                 [] ->


### PR DESCRIPTION
When you tried to define a command for action different than read/GET MIM would not take optional arguments into consideration.

It was because we checked actual number of arguments against `command arity` instead of `function arity` (which is not the same!!!).

This PR fixes this problem.
