### PR TITLE
Add dynamic backend to mod_pubsub

### DIFF
--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -16,6 +16,7 @@ It's all about tailoring PubSub to your needs!
 * `iqdisc` (default: `one_queue`)
 * `host` (string, default: `"pubsub.@HOST@"`): Subdomain for Pubsub service to reside under.
 `@HOST@` is replaced with each served domain.
+* `backend` (atom, default: `mnesia`) - Database backend to use. Only `mnesia` is supported currently..
 * `access_create` (atom, default: `all`): Who is allowed to create pubsub nodes.
 * `max_items_node` (integer, default: `10`): Define the maximum number of items that can be stored in a node.
 * `max_subscriptions_node` (integer, default: `undefined` - no limitation): The maximum number of subscriptions managed by a node.

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -103,3 +103,19 @@ Special node type that may be used as a target node for [XEP-0357 (Push Notifica
 For each published notification, a hook `push_notification` is run.
 You may enable as many modules that support this hook (all module with `mod_push_service_*` name prefix) as you like (see for example `mod_push_service_mongoosepush`).
 This node type **requires** `publish-options` with at least `device_id` and `service` fields supplied.
+
+### Metrics
+
+If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md) page.
+
+| Name | Type | Description (when it gets incremented) |
+| ---- | ---- | -------------------------------------- |
+| `[global, backends, mod_pubsub_db, set_state]` | histogram | Time to update user's state for specific node. |
+| `[global, backends, mod_pubsub_db, del_state]` | histogram | Time to remove user's state for specific node. |
+| `[global, backends, mod_pubsub_db, get_state]` | histogram | Time to fetch user's state for specific node. |
+| `[global, backends, mod_pubsub_db, get_states]` | histogram | Time to fetch node's states. |
+| `[global, backends, mod_pubsub_db, get_states_by_lus]` | histogram | Time to fetch nodes' states for user + domain. |
+| `[global, backends, mod_pubsub_db, get_states_by_bare]` | histogram | Time to fetch nodes' states for bare JID. |
+| `[global, backends, mod_pubsub_db, get_states_by_full]` | histogram | Time to fetch nodes' states for full JID. |
+| `[global, backends, mod_pubsub_db, get_own_nodes_states]` | histogram | Time to fetch state data for user's nodes. |
+

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -106,7 +106,7 @@ This node type **requires** `publish-options` with at least `device_id` and `ser
 
 ### Metrics
 
-If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md) page.
+If you'd like to learn more about metrics in MongooseIM, please visit the [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md) page.
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |

--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -70,8 +70,6 @@
          get_entity_subscriptions/3,
          get_subscriptions/3,
          get_pending_nodes/3,
-         get_states/2,
-         get_state/3,
          get_items/8,
          get_items/4,
          get_item/8,
@@ -187,10 +185,6 @@
 
 -callback get_pending_nodes(Host :: host(), Owner :: jid:jid()) -> {result, [nodeId()]}.
 
--callback get_states(NodeIdx::nodeIdx()) -> {result, [pubsubState()]}.
-
--callback get_state(NodeIdx :: nodeIdx(), Key :: jid:ljid()) -> pubsubState().
-
 -callback get_items(NodeIdx :: nodeIdx(),
         JID :: jid:jid(),
         AccessModel :: accessModel(),
@@ -293,12 +287,6 @@ get_subscriptions(Mod, NodeIdx, Owner) ->
 
 get_pending_nodes(Mod, Host, Owner) ->
     Mod:get_pending_nodes(Host, Owner).
-
-get_states(Mod, NodeIdx) ->
-    Mod:get_states(NodeIdx).
-
-get_state(Mod, NodeIdx, Key) ->
-    Mod:get_state(NodeIdx, Key).
 
 get_items(Mod, NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
     Mod:get_items(NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM).

--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -72,7 +72,6 @@
          get_pending_nodes/3,
          get_states/2,
          get_state/3,
-         set_state/2,
          get_items/8,
          get_items/4,
          get_item/8,
@@ -192,8 +191,6 @@
 
 -callback get_state(NodeIdx :: nodeIdx(), Key :: jid:ljid()) -> pubsubState().
 
--callback set_state(State::pubsubState()) -> ok | {error, exml:element()}.
-
 -callback get_items(NodeIdx :: nodeIdx(),
         JID :: jid:jid(),
         AccessModel :: accessModel(),
@@ -302,9 +299,6 @@ get_states(Mod, NodeIdx) ->
 
 get_state(Mod, NodeIdx, Key) ->
     Mod:get_state(NodeIdx, Key).
-
-set_state(Mod, State) ->
-    Mod:set_state(State).
 
 get_items(Mod, NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
     Mod:get_items(NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM).

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -274,7 +274,7 @@ init([ServerHost, Opts]) ->
     ?DEBUG("pubsub init ~p ~p", [ServerHost, Opts]),
     Host = gen_mod:get_opt_subhost(ServerHost, Opts, default_host()),
     
-    init_backend(ServerHost, Host, Opts),
+    init_backend(Opts),
 
     pubsub_index:init(Host, ServerHost, Opts),
     ets:new(gen_mod:get_module_proc(ServerHost, config), [set, named_table, public]),
@@ -293,8 +293,10 @@ init([ServerHost, Opts]) ->
     {_, State} = init_send_loop(ServerHost),
     {ok, State}.
 
-init_backend(ServerHost, Host, Opts) ->
-    TrackedDBFuns = [],
+init_backend(Opts) ->
+    TrackedDBFuns = [set_state, del_state, get_state, get_states,
+                     get_states_by_lus, get_states_by_bare,
+                     get_states_by_full, get_own_nodes_states],
     gen_mod:start_backend_module(mod_pubsub_db, Opts, TrackedDBFuns),
     mod_pubsub_db_backend:start(),
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -16,17 +16,15 @@
 
 %% ------------------------ Backend start/stop ------------------------
 
--callback start(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
+-callback start() -> ok.
 
--callback stop(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
+-callback stop() -> ok.
 
--callback transaction(PubSubHost :: jid:lserver(),
-                      Fun :: fun(() -> {result | error, any()})) ->
+-callback transaction(Fun :: fun(() -> {result | error, any()})) ->
     {result | error, any()}.
 
 %% Synchronous
--callback dirty(PubSubHost :: jid:lserver(),
-                Fun :: fun(() -> {result | error, any()})) ->
+-callback dirty(Fun :: fun(() -> {result | error, any()})) ->
     {result | error, any()}.
 
 -callback set_state(State :: mod_pubsub:pubsubState()) -> ok.

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -1,0 +1,43 @@
+%%%----------------------------------------------------------------------
+%%% File    : mod_pubsub_db.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : PubSub DB behaviour
+%%% Created : 26 Oct 2018 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%%----------------------------------------------------------------------
+
+-module(mod_pubsub_db).
+-author('piotr.nosek@erlang-solutions.com').
+
+-include("mongoose_logger.hrl").
+
+%%====================================================================
+%% Behaviour callbacks
+%%====================================================================
+
+%% ------------------------ Backend start/stop ------------------------
+
+-callback start(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
+
+-callback stop(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
+
+-callback transaction(PubSubHost :: jid:lserver(),
+                      Fun :: fun(() -> {result | error, any()})) ->
+    {result | error, any()}.
+
+%% Synchronous
+-callback dirty(PubSubHost :: jid:lserver(),
+                Fun :: fun(() -> {result | error, any()})) ->
+    {result | error, any()}.
+
+-callback set_state(PubSubHost :: jid:lserver(),
+                    mod_pubsub:pubsubState()) -> ok.
+
+%%====================================================================
+%% API
+%%====================================================================
+
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -36,15 +36,31 @@
                     Nidx :: mod_pubsub:nodeIdx(),
                     UserLJID :: jid:ljid()) -> ok.
 
--callback get_states(PubSubHost :: jid:lserver(),
-                     Nidx :: mod_pubsub:nodeIdx()) ->
-    {ok, [mod_pubsub:pubsubState()]}.
-
 %% When a state is not found, returns empty state.
 -callback get_state(PubSubHost :: jid:lserver(),
                     Nidx :: mod_pubsub:nodeIdx(),
                     UserLJID :: jid:ljid()) ->
     {ok, mod_pubsub:pubsubState()}.
+
+-callback get_states(PubSubHost :: jid:lserver(),
+                     Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+
+-callback get_states_by_lus(PubSubHost :: jid:lserver(),
+                            JID :: jid:jid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+
+-callback get_states_by_bare(PubSubHost :: jid:lserver(),
+                             JID :: jid:jid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+
+-callback get_states_by_full(PubSubHost :: jid:lserver(),
+                             JID :: jid:jid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+
+-callback get_own_nodes_states(PubSubHost :: jid:lserver(),
+                               JID :: jid:jid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
 
 %%====================================================================
 %% API

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -46,7 +46,7 @@
 -callback get_states_by_bare(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_full(JID :: jid:jid()) ->
+-callback get_states_by_bare_and_full(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
 -callback get_own_nodes_states(JID :: jid:jid()) ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -29,37 +29,29 @@
                 Fun :: fun(() -> {result | error, any()})) ->
     {result | error, any()}.
 
--callback set_state(PubSubHost :: jid:lserver(),
-                    State :: mod_pubsub:pubsubState()) -> ok.
+-callback set_state(State :: mod_pubsub:pubsubState()) -> ok.
 
--callback del_state(PubSubHost :: jid:lserver(),
-                    Nidx :: mod_pubsub:nodeIdx(),
+-callback del_state(Nidx :: mod_pubsub:nodeIdx(),
                     UserLJID :: jid:ljid()) -> ok.
 
 %% When a state is not found, returns empty state.
--callback get_state(PubSubHost :: jid:lserver(),
-                    Nidx :: mod_pubsub:nodeIdx(),
+-callback get_state(Nidx :: mod_pubsub:nodeIdx(),
                     UserLJID :: jid:ljid()) ->
     {ok, mod_pubsub:pubsubState()}.
 
--callback get_states(PubSubHost :: jid:lserver(),
-                     Nidx :: mod_pubsub:nodeIdx()) ->
+-callback get_states(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_lus(PubSubHost :: jid:lserver(),
-                            JID :: jid:jid()) ->
+-callback get_states_by_lus(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_bare(PubSubHost :: jid:lserver(),
-                             JID :: jid:jid()) ->
+-callback get_states_by_bare(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_full(PubSubHost :: jid:lserver(),
-                             JID :: jid:jid()) ->
+-callback get_states_by_full(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_own_nodes_states(PubSubHost :: jid:lserver(),
-                               JID :: jid:jid()) ->
+-callback get_own_nodes_states(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
 %%====================================================================

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -30,7 +30,21 @@
     {result | error, any()}.
 
 -callback set_state(PubSubHost :: jid:lserver(),
-                    mod_pubsub:pubsubState()) -> ok.
+                    State :: mod_pubsub:pubsubState()) -> ok.
+
+-callback del_state(PubSubHost :: jid:lserver(),
+                    Nidx :: mod_pubsub:nodeIdx(),
+                    UserLJID :: jid:ljid()) -> ok.
+
+-callback get_states(PubSubHost :: jid:lserver(),
+                     Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+
+%% When a state is not found, returns empty state.
+-callback get_state(PubSubHost :: jid:lserver(),
+                    Nidx :: mod_pubsub:nodeIdx(),
+                    UserLJID :: jid:ljid()) ->
+    {ok, mod_pubsub:pubsubState()}.
 
 %%====================================================================
 %% API

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -1,0 +1,61 @@
+%%%----------------------------------------------------------------------
+%%% File    : mod_pubsub_db_mnesia.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : PubSub Mnesia backend
+%%% Created : 26 Oct 2018 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%%----------------------------------------------------------------------
+
+-module(mod_pubsub_db_mnesia).
+-author('piotr.nosek@erlang-solutions.com').
+
+-include("pubsub.hrl").
+
+-export([start/2, stop/2]).
+-export([transaction/2, dirty/2]).
+-export([set_state/2]).
+
+%%====================================================================
+%% Behaviour callbacks
+%%====================================================================
+
+%% ------------------------ Backend start/stop ------------------------
+
+-spec start(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
+start(_, _) ->
+    mnesia:create_table(pubsub_state,
+                        [{disc_copies, [node()]},
+                         {type, ordered_set},
+                         {attributes, record_info(fields, pubsub_state)}]),
+    mnesia:add_table_copy(pubsub_state, node(), disc_copies),
+    ok.
+
+-spec stop(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
+stop(_, _) ->
+    ok.
+
+%% ------------------------ Fun execution ------------------------
+
+transaction(_PubSubHost, Fun) ->
+    case mnesia:transaction(Fun) of
+        {atomic, Result} ->
+            Result;
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
+
+dirty(_PubSubHost, Fun) ->
+    try mnesia:sync_dirty(Fun) of
+        Result ->
+            Result
+    catch
+        C:R ->
+            {error, {C, R, erlang:get_stacktrace()}}
+    end.
+
+%% ------------------------ Node state ------------------------
+
+-spec set_state(PubSubHost :: jid:lserver(),
+                mod_pubsub:pubsubState()) -> ok.
+set_state(_PubSubHost, State) ->
+    mnesia:write(State).
+

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -11,8 +11,8 @@
 -include("pubsub.hrl").
 -include("jlib.hrl").
 
--export([start/2, stop/2]).
--export([transaction/2, dirty/2]).
+-export([start/0, stop/0]).
+-export([transaction/1, dirty/1]).
 -export([set_state/1, del_state/2, get_state/2,
          get_states/1, get_states_by_lus/1, get_states_by_bare/1,
          get_states_by_full/1, get_own_nodes_states/1]).
@@ -23,8 +23,8 @@
 
 %% ------------------------ Backend start/stop ------------------------
 
--spec start(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
-start(_, _) ->
+-spec start() -> ok.
+start() ->
     mnesia:create_table(pubsub_state,
                         [{disc_copies, [node()]},
                          {type, ordered_set},
@@ -32,13 +32,13 @@ start(_, _) ->
     mnesia:add_table_copy(pubsub_state, node(), disc_copies),
     ok.
 
--spec stop(Host :: jid:lserver(), PubSubHost :: jid:lserver()) -> ok.
-stop(_, _) ->
+-spec stop() -> ok.
+stop() ->
     ok.
 
 %% ------------------------ Fun execution ------------------------
 
-transaction(_PubSubHost, Fun) ->
+transaction(Fun) ->
     case mnesia:transaction(Fun) of
         {atomic, Result} ->
             Result;
@@ -46,7 +46,7 @@ transaction(_PubSubHost, Fun) ->
             {error, Reason}
     end.
 
-dirty(_PubSubHost, Fun) ->
+dirty(Fun) ->
     try mnesia:sync_dirty(Fun, []) of
         Result ->
             Result

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -15,7 +15,7 @@
 -export([transaction/1, dirty/1]).
 -export([set_state/1, del_state/2, get_state/2,
          get_states/1, get_states_by_lus/1, get_states_by_bare/1,
-         get_states_by_full/1, get_own_nodes_states/1]).
+         get_states_by_bare_and_full/1, get_own_nodes_states/1]).
 
 %%====================================================================
 %% Behaviour callbacks
@@ -87,11 +87,13 @@ get_states_by_bare(JID) ->
     LBare = jid:to_bare(jid:to_lower(JID)),
     {ok, mnesia:match_object(#pubsub_state{stateid = {LBare, '_'}, _ = '_'})}.
 
--spec get_states_by_full(JID :: jid:jid()) ->
+-spec get_states_by_bare_and_full(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
-get_states_by_full(JID) ->
+get_states_by_bare_and_full(JID) ->
     LJID = jid:to_lower(JID),
-    {ok, mnesia:match_object(#pubsub_state{stateid = {LJID, '_'}, _ = '_'})}.
+    LBare = jid:to_bare(LJID),
+    {ok, mnesia:match_object(#pubsub_state{stateid = {LJID, '_'}, _ = '_'})
+         ++ mnesia:match_object(#pubsub_state{stateid = {LBare, '_'}, _ = '_'})}.
 
 -spec get_own_nodes_states(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.

--- a/src/pubsub/node_dag.erl
+++ b/src/pubsub/node_dag.erl
@@ -33,7 +33,7 @@
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
          get_pending_nodes/2, get_states/1, get_state/2,
-         set_state/1, get_items/7, get_items/3, get_item/7,
+         get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
 
@@ -126,9 +126,6 @@ get_states(Nidx) ->
 
 get_state(Nidx, JID) ->
     node_hometree:get_state(Nidx, JID).
-
-set_state(State) ->
-    node_hometree:set_state(State).
 
 get_items(Nidx, From, RSM) ->
     node_hometree:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_dag.erl
+++ b/src/pubsub/node_dag.erl
@@ -32,7 +32,7 @@
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2, get_states/1, get_state/2,
+         get_pending_nodes/2,
          get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
@@ -120,12 +120,6 @@ set_subscriptions(Nidx, Owner, Subscription, SubId) ->
 
 get_pending_nodes(Host, Owner) ->
     node_hometree:get_pending_nodes(Host, Owner).
-
-get_states(Nidx) ->
-    node_hometree:get_states(Nidx).
-
-get_state(Nidx, JID) ->
-    node_hometree:get_state(Nidx, JID).
 
 get_items(Nidx, From, RSM) ->
     node_hometree:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -537,9 +537,8 @@ get_entity_subscriptions(Host, Owner) ->
                      {ok, States0} = mod_pubsub_db_backend:get_states_by_lus(Owner),
                      States0;
                  _ ->
-                     {ok, States0} = mod_pubsub_db_backend:get_states_by_bare(Owner),
-                     {ok, States1} = mod_pubsub_db_backend:get_states_by_full(Owner),
-                     States0 ++ States1
+                     {ok, States0} = mod_pubsub_db_backend:get_states_by_bare_and_full(Owner),
+                     States0
              end,
     NodeTree = mod_pubsub:tree(Host),
     Reply = lists:foldl(fun (PubSubState, Acc) ->

--- a/src/pubsub/node_hometree.erl
+++ b/src/pubsub/node_hometree.erl
@@ -40,7 +40,7 @@
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2, get_states/1, get_state/2,
+         get_pending_nodes/2,
          get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
@@ -138,12 +138,6 @@ set_subscriptions(Nidx, Owner, Subscription, SubId) ->
 
 get_pending_nodes(Host, Owner) ->
     node_flat:get_pending_nodes(Host, Owner).
-
-get_states(Nidx) ->
-    node_flat:get_states(Nidx).
-
-get_state(Nidx, JID) ->
-    node_flat:get_state(Nidx, JID).
 
 get_items(Nidx, From, RSM) ->
     node_flat:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_hometree.erl
+++ b/src/pubsub/node_hometree.erl
@@ -41,7 +41,7 @@
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
          get_pending_nodes/2, get_states/1, get_state/2,
-         set_state/1, get_items/7, get_items/3, get_item/7,
+         get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
 
@@ -144,9 +144,6 @@ get_states(Nidx) ->
 
 get_state(Nidx, JID) ->
     node_flat:get_state(Nidx, JID).
-
-set_state(State) ->
-    node_flat:set_state(State).
 
 get_items(Nidx, From, RSM) ->
     node_flat:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -178,9 +178,8 @@ get_entity_subscriptions(Host, D, R, Owner) ->
                      {ok, States0} = mod_pubsub_db_backend:get_states_by_lus(Owner),
                      States0;
                  _ ->
-                     {ok, States0} = mod_pubsub_db_backend:get_states_by_bare(Owner),
-                     {ok, States1} = mod_pubsub_db_backend:get_states_by_full(Owner),
-                     States0 ++ States1
+                     {ok, States0} = mod_pubsub_db_backend:get_states_by_bare_and_full(Owner),
+                     States0
              end,
     NodeTree = mod_pubsub:tree(Host),
     Reply = lists:foldl(fun (#pubsub_state{stateid = {J, N}, subscriptions = Ss}, Acc) ->

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -44,7 +44,7 @@
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
          get_pending_nodes/2, get_states/1, get_state/2,
-         set_state/1, get_items/7, get_items/3, get_item/7,
+         get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
 
@@ -214,9 +214,6 @@ get_states(Nidx) ->
 
 get_state(Nidx, JID) ->
     node_flat:get_state(Nidx, JID).
-
-set_state(State) ->
-    node_flat:set_state(State).
 
 get_items(Nidx, From, RSM) ->
     node_flat:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -43,7 +43,7 @@
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2, get_states/1, get_state/2,
+         get_pending_nodes/2,
          get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
@@ -208,12 +208,6 @@ set_subscriptions(Nidx, Owner, Subscription, SubId) ->
 
 get_pending_nodes(Host, Owner) ->
     node_flat:get_pending_nodes(Host, Owner).
-
-get_states(Nidx) ->
-    node_flat:get_states(Nidx).
-
-get_state(Nidx, JID) ->
-    node_flat:get_state(Nidx, JID).
 
 get_items(Nidx, From, RSM) ->
     node_flat:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -26,7 +26,7 @@
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
          get_pending_nodes/2, get_states/1, get_state/2,
-         set_state/1, get_items/7, get_items/3, get_item/7,
+         get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
 
@@ -161,9 +161,6 @@ get_states(Nidx) ->
 
 get_state(Nidx, JID) ->
     node_flat:get_state(Nidx, JID).
-
-set_state(State) ->
-    node_flat:set_state(State).
 
 get_items(Nidx, From, RSM) ->
     node_flat:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -25,7 +25,7 @@
          get_affiliation/2, set_affiliation/3,
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2, get_states/1, get_state/2,
+         get_pending_nodes/2,
          get_items/7, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1]).
@@ -89,10 +89,13 @@ publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublis
              PublishOptions) ->
     SubKey = jid:to_lower(Publisher),
     GenKey = jid:to_bare(SubKey),
-    GenState = get_state(Nidx, GenKey),
+    {ok, GenState} = mod_pubsub_db_backend:get_state(?MYNAME, Nidx, GenKey),
     SubState = case SubKey of
-                   GenKey -> GenState;
-                   _ -> get_state(Nidx, SubKey)
+                   GenKey ->
+                       GenState;
+                   _ ->
+                       {ok, SubState0} = mod_pubsub_db_backend:get_state(?MYNAME, Nidx, SubKey),
+                       SubState0
                end,
     Affiliation = SubState#pubsub_state.affiliation,
     ElPayload = [El || #xmlel{} = El <- Payload],
@@ -155,12 +158,6 @@ set_subscriptions(Nidx, Owner, Subscription, SubId) ->
 
 get_pending_nodes(Host, Owner) ->
     node_flat:get_pending_nodes(Host, Owner).
-
-get_states(Nidx) ->
-    node_flat:get_states(Nidx).
-
-get_state(Nidx, JID) ->
-    node_flat:get_state(Nidx, JID).
 
 get_items(Nidx, From, RSM) ->
     node_flat:get_items(Nidx, From, RSM).

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -89,12 +89,12 @@ publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublis
              PublishOptions) ->
     SubKey = jid:to_lower(Publisher),
     GenKey = jid:to_bare(SubKey),
-    {ok, GenState} = mod_pubsub_db_backend:get_state(?MYNAME, Nidx, GenKey),
+    {ok, GenState} = mod_pubsub_db_backend:get_state(Nidx, GenKey),
     SubState = case SubKey of
                    GenKey ->
                        GenState;
                    _ ->
-                       {ok, SubState0} = mod_pubsub_db_backend:get_state(?MYNAME, Nidx, SubKey),
+                       {ok, SubState0} = mod_pubsub_db_backend:get_state(Nidx, SubKey),
                        SubState0
                end,
     Affiliation = SubState#pubsub_state.affiliation,

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -60,7 +60,6 @@ init(_Host, _ServerHost, _Options) ->
         NodesFields -> ok;
         _ -> ok
     end,
-    %% mnesia:transform_table(pubsub_state, ignore, StatesFields)
     ok.
 
 terminate(_Host, _ServerHost) ->


### PR DESCRIPTION
This PR adds dynamic DB backend to `mod_pubsub`, with Mnesia backend supporting `pubsub_state` table for now.

- [x] ~Replace `?MYNAME` in `node_flat` and `node_push` with proper PubSub domain.~
- [x] Q: What if some action requires both Mnesia and SQL transaction? - A: Transaction/Dirty shouldn't be decided and started in `mod_pubsub` context but it should be up to the backend. But it would extend the scope of this task too much so for now let's execute everything in Mnesia transaction context until RDBMS backend becomes complete.

