### PR TITLE
fix a memory leak in mod_revproxy

### DIFF
--- a/src/mod_revproxy.erl
+++ b/src/mod_revproxy.erl
@@ -113,6 +113,7 @@ pass_request(Host, Path, Method, Req,
     {Body, Req1} = request_body(Req, State),
     Headers1 = Headers ++ CustomHeaders,
     Response = fusco:request(Pid, Path, Method, Headers1, Body, Timeout),
+    fusco:disconnect(Pid),
     return_response(Response, Req1, State).
 
 return_response({ok, {{Status, _}, Headers, Body, _, _}}, Req, State) ->


### PR DESCRIPTION
mod_revproxy currently leaks the fusco Clients that it creates when proxying the HTTP requests, one per request.

Proposed changes include:
* Disconnect the fusco Client to stop the leak.
