### PR TITLE
[clt-rabbit] Don't crash RMQ worker when amqp exception occurs

### DIFF
--- a/src/event_pusher/mod_event_pusher_rabbit.erl
+++ b/src/event_pusher/mod_event_pusher_rabbit.erl
@@ -100,8 +100,9 @@ initialize_metrics(Host) ->
 -spec create_exchanges(Host :: jid:server()) -> ok.
 create_exchanges(Host) ->
     Res = [wpool:call(pool_name(Host),
-                      {amqp_call, mongoose_amqp:exchange_declare(ExName, Type)},
-                      available_worker) || {ExName, Type} <- exchanges(Host)],
+                      {amqp_call, mongoose_amqp:exchange_declare(ExName, Type),
+                       [{host, Host}]}, available_worker)
+           || {ExName, Type} <- exchanges(Host)],
     verify_exchanges_were_created_or_crash(Res).
 
 -spec handle_user_presence_change(JID :: jid:jid(), Status :: atom()) -> ok.
@@ -248,7 +249,7 @@ verify_opts(Opts) ->
 -spec verify_exchanges_were_created_or_crash(Res :: list()) -> ok | no_return().
 verify_exchanges_were_created_or_crash(Res) ->
     case lists:all(fun(E) ->
-                           E == mongoose_amqp:exchange_declare_ok()
+                           element(2, E) == mongoose_amqp:exchange_declare_ok()
                    end, Res) of
         true ->
             ok;

--- a/src/mongoose_amqp.erl
+++ b/src/mongoose_amqp.erl
@@ -27,12 +27,14 @@
          exchange_declare_ok/0, exchange_delete/1, basic_publish/2,
          confirm_select/0, confirm_select_ok/0, message/1]).
 
--export_type([method/0, message/0]).
+-export_type([network_params/0, method/0, message/0]).
 
 
 %%%===================================================================
 %%% Types
 %%%===================================================================
+
+-type network_params() :: #amqp_params_network{}.
 
 -type method() :: #'exchange.declare'{}
                 | #'exchange.declare_ok'{}
@@ -43,11 +45,12 @@
 
 -type message() :: #amqp_msg{}.
 
+
 %%%===================================================================
 %%% API
 %%%===================================================================
 
--spec network_params() -> #amqp_params_network{}.
+-spec network_params() -> network_params().
 network_params() ->
     network_params([]).
 

--- a/test/mongoose_rabbit_worker_SUITE.erl
+++ b/test/mongoose_rabbit_worker_SUITE.erl
@@ -1,0 +1,162 @@
+%%==============================================================================
+%% Copyright 2018 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+-module(mongoose_rabbit_worker_SUITE).
+-compile(export_all).
+-author('kacper.mentel@erlang-solutions.com').
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("assert_received_match.hrl").
+
+-define(HOST, <<"localhost">>).
+-define(AMQP_MOCK_MODULES, [amqp_connection, amqp_channel]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     no_request_in_worker_queue_is_lost_when_amqp_call_fails,
+     worker_creates_fresh_amqp_conection_and_channel_when_amqp_call_fails
+    ].
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    application:ensure_all_started(lager),
+    mock_amqp(),
+    mock_metrics(),
+    WorkerOpts = [{host, ?HOST},
+                  {amqp_client_opts, []},
+                  {confirms, false}],
+    {ok, WorkerPid} = gen_server:start(mongoose_rabbit_worker, WorkerOpts, []),
+    Config ++ [{worker_pid, WorkerPid}].
+
+end_per_suite(Config) ->
+    exit(proplists:get_value(worker_pid, Config), kill),
+    unload_amqp(),
+    meck:unload(mongoose_metrics),
+    Config.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+no_request_in_worker_queue_is_lost_when_amqp_call_fails(Config) ->
+    %% given
+    Worker = proplists:get_value(worker_pid, Config),
+    Ref = make_ref(),
+    Lock = lock_fun(),
+    SendBack = send_back_fun(),
+    Exception = exception_fun(),
+
+    %% when
+    gen_server:cast(Worker,
+                    {amqp_publish, {Lock, Ref}, ok, [{host, ?HOST}]}),
+    gen_server:cast(Worker,
+                    {amqp_publish, {Exception, ok}, ok, [{host, ?HOST}]}),
+    gen_server:cast(Worker,
+                    {amqp_publish, {SendBack, Ref}, ok, [{host, ?HOST}]}),
+    spawn(fun() ->
+                  gen_server:call(Worker,
+                                  {amqp_call, {Exception, ok}, [{host, ?HOST}]})
+          end),
+    spawn(fun() ->
+                  gen_server:call(Worker,
+                                  {amqp_call, {SendBack, Ref}, [{host, ?HOST}]})
+          end),
+
+    %% unlock the worker
+    Worker ! Ref,
+
+    %% then
+    [?assertReceivedMatch(Ref) || _ <- lists:seq(1,2)].
+
+worker_creates_fresh_amqp_conection_and_channel_when_amqp_call_fails(Config) ->
+    %% given
+    Worker = proplists:get_value(worker_pid, Config),
+    Exception = exception_fun(),
+    ConnectionAndChannel0 = get_worker_conn_and_chann(Worker),
+
+    %% when amqp_publish fails
+    gen_server:cast(Worker,
+                    {amqp_publish, {Exception, ok}, ok, [{host, ?HOST}]}),
+    %% then
+    ConnectionAndChannel1 = get_worker_conn_and_chann(Worker),
+    ?assertNotMatch(ConnectionAndChannel0, ConnectionAndChannel1),
+
+    %% when amqp_call fails
+    gen_server:call(Worker,
+                    {amqp_call, {Exception, ok}, [{host, ?HOST}]}),
+
+    %% then
+    ConnectionAndChannel2 = get_worker_conn_and_chann(Worker),
+    ?assertNotMatch(ConnectionAndChannel1, ConnectionAndChannel2).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+mock_amqp() ->
+    [meck:new(M, [no_link, passthrough]) || M <- ?AMQP_MOCK_MODULES],
+    meck:expect(amqp_connection, start, fun(_) -> {ok, random_pid()} end),
+    meck:expect(amqp_connection, open_channel, fun(_) -> {ok, random_pid()} end),
+    meck:expect(amqp_connection, close, fun(_) -> ok end),
+    meck:expect(amqp_channel, close, fun(_) -> ok end),
+    meck:expect(amqp_channel, call, fun(_, {F, A}) when is_function(F) -> F(A);
+                                       (_, _) -> ok
+                                    end),
+    meck:expect(amqp_channel, call, fun(_, {F, A}, _) when is_function(F) -> F(A);
+                                       (_, _, _) -> ok
+                                    end).
+
+mock_metrics() ->
+    meck:new(mongoose_metrics, [no_link, passthrough]),
+    meck:expect(mongoose_metrics, update, fun(_, _, _) -> ok end).
+
+unload_amqp() ->
+    [meck:unload(M) || M <- ?AMQP_MOCK_MODULES].
+
+random_pid() ->
+    spawn(fun() -> ok end).
+
+lock_fun() ->
+    fun(R) ->
+            receive
+                R -> unlocked
+            end
+    end.
+
+send_back_fun() ->
+    S = self(),
+    fun(Msg) -> S ! Msg end.
+
+exception_fun() ->
+    fun(_) -> throw(exception) end.
+
+get_worker_conn_and_chann(Worker) ->
+    State = sys:get_state(Worker),
+    {element(3, State), element(4, State)}.


### PR DESCRIPTION
Closes https://github.com/esl/tide/issues/418#issuecomment-434607213.

