### PR TITLE
Refactor PubSub code to prepare for RDBMS

### DIFF
--- a/include/pubsub.hrl
+++ b/include/pubsub.hrl
@@ -58,12 +58,8 @@
 %% of the current node. For example:
 %% ```<<"/home/localhost/user">>'''</p>
 
--type(nodeIdx() :: pos_integer() | binary()).
+-type(nodeIdx() :: pos_integer()).
 %% @type nodeIdx() = integer() | binary().
-%% note: pos_integer() should always be used, but we allow anything else coded
-%% as binary, so one can have a custom implementation of nodetree with custom
-%% indexing (see nodetree_virtual). this also allows to use any kind of key for
-%% indexing nodes, as this can be usefull with external backends such as rdbms.
 
 -type(itemId() :: binary()).
 %% @type itemId() = string().

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -116,8 +116,15 @@ are_equal(_, _) ->
     false.
 
 %% @doc Returns true if `are_equal(to_bare(A), to_bare(B))'
+-spec are_bare_equal(jid() | ljid(), jid() | ljid()) -> boolean().
 are_bare_equal(#jid{luser = LUser, lserver = LServer},
                #jid{luser = LUser, lserver = LServer}) ->
+    true;
+are_bare_equal(#jid{luser = LUser, lserver = LServer}, {LUser, LServer, _}) ->
+    true;
+are_bare_equal({LUser, LServer, _}, #jid{luser = LUser, lserver = LServer}) ->
+    true;
+are_bare_equal({LUser, LServer, _}, {LUser, LServer, _}) ->
     true;
 are_bare_equal(_, _) ->
     false.

--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -122,7 +122,7 @@
 
 -callback subscribe_node(NodeIdx :: nodeIdx(),
         Sender :: jid:jid(),
-        Subscriber :: jid:jid(),
+        Subscriber :: jid:ljid(),
         AccessModel :: accessModel(),
         SendLast :: 'never' | 'on_sub' | 'on_sub_and_presence',
         PresenceSubscription :: boolean(),

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -20,6 +20,8 @@
 
 -callback stop() -> ok.
 
+%% ----------------------- Fun execution ------------------------
+
 -callback transaction(Fun :: fun(() -> {result | error, any()})) ->
     {result | error, any()}.
 
@@ -27,16 +29,20 @@
 -callback dirty(Fun :: fun(() -> {result | error, any()})) ->
     {result | error, any()}.
 
--callback set_state(State :: mod_pubsub:pubsubState()) -> ok.
+%% ----------------------- Direct #pubsub_state access ------------------------
 
+%% TODO: Replace with del_node when it is fully possible from backend
+%%       i.e. when pubsub_item is migrated to RDBMS as well
 -callback del_state(Nidx :: mod_pubsub:nodeIdx(),
-                    UserLJID :: jid:ljid()) -> ok.
+                    LJID :: jid:ljid()) -> ok.
 
 %% When a state is not found, returns empty state.
+%% Maybe can be removed completely later?
 -callback get_state(Nidx :: mod_pubsub:nodeIdx(),
-                    UserLJID :: jid:ljid()) ->
+                    JID :: jid:jid()) ->
     {ok, mod_pubsub:pubsubState()}.
 
+%% Maybe can be removed completely later?
 -callback get_states(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
@@ -51,6 +57,66 @@
 
 -callback get_own_nodes_states(JID :: jid:jid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
+
+%% ----------------------- Affiliations ------------------------
+
+-callback set_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                          JID :: jid:jid(),
+                          Affiliation :: mod_pubsub:affiliation()) ->
+    ok.
+
+-callback get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                          JID :: jid:jid()) ->
+    {ok, mod_pubsub:affiliation()}.
+
+%% ----------------------- Subscriptions ------------------------
+
+-callback add_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                           JID :: jid:jid(),
+                           Sub :: mod_pubsub:subscription(),
+                           SubId :: mod_pubsub:subId()) ->
+    ok.
+
+-callback update_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                              JID :: jid:jid(),
+                              Subscription :: mod_pubsub:subscription(),
+                              SubId :: mod_pubsub:subId()) ->
+    ok.
+
+-callback get_node_subscriptions(Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [{Entity :: jid:jid(), Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+
+-callback get_node_entity_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
+                                        JID :: jid:jid()) ->
+    {ok, [{Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+
+-callback delete_subscription(
+            Nidx :: mod_pubsub:nodeIdx(),
+            JID :: jid:jid(),
+            SubId :: mod_pubsub:subId()) ->
+    ok.
+
+-callback delete_all_subscriptions(
+            Nidx :: mod_pubsub:nodeIdx(),
+            JID :: jid:jid()) ->
+    ok.
+
+%% ----------------------- Items ------------------------
+
+%% TODO: Refactor to use MaxItems value, so separate remove_items in publishing
+%% won't be necessary and the whole operation may be optimised in DB layer.
+-callback add_item(Nidx :: mod_pubsub:nodeIdx(),
+                   JID :: jid:jid(),
+                   ItemId :: mod_pubsub:itemId()) ->
+    ok.
+
+-callback remove_items(Nidx :: mod_pubsub:nodeIdx(),
+                       JID :: jid:jid(),
+                       ItemIds :: [mod_pubsub:itemId()]) ->
+    ok.
+
+-callback remove_all_items(Nidx :: mod_pubsub:nodeIdx()) ->
+    ok.
 
 %%====================================================================
 %% API

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -87,17 +87,7 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
 
 publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublisher, Payload,
              PublishOptions) ->
-    SubKey = jid:to_lower(Publisher),
-    GenKey = jid:to_bare(SubKey),
-    {ok, GenState} = mod_pubsub_db_backend:get_state(Nidx, GenKey),
-    SubState = case SubKey of
-                   GenKey ->
-                       GenState;
-                   _ ->
-                       {ok, SubState0} = mod_pubsub_db_backend:get_state(Nidx, SubKey),
-                       SubState0
-               end,
-    Affiliation = SubState#pubsub_state.affiliation,
+    Affiliation = mod_pubsub_db_backend:get_affiliation(Nidx, Publisher),
     ElPayload = [El || #xmlel{} = El <- Payload],
 
     case is_allowed_to_publish(Model, Affiliation) of


### PR DESCRIPTION
This PR refactors DB calls, mostly in `node_flat`, to be more efficient for future RDBMS backend. Causes more Mnesia operations but Mnesia backend should probably be rewritten or deprecated anyway.

