### PR TITLE
Extract pubsub_item table operation to pubsub's mnesia backend

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, ".*", {git, "https://github.com/proger/erlsh.git", "4e8a107"}},
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
-        {escalus, ".*", {git, "https://github.com/esl/escalus.git", {ref, "25da83d"}}},
+        {escalus, ".*", {git, "https://github.com/esl/escalus.git", {ref, "36856c2"}}},
         {gen_fsm_compat, "0.3.0"},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, "2.4.0"},

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -20,7 +20,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"25da83d55a80ebe4e8278a9bc3905bfe3ab470bc"}},
+       {ref,"36856c22d4c94e89fa2580b9544827ed95f79175"}},
   0},
  {<<"esip">>,
   {git,"https://github.com/processone/esip.git",

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -300,7 +300,7 @@ init_backend(Opts) ->
     TrackedDBFuns = [set_state, del_state, get_state, get_states,
                      get_states_by_lus, get_states_by_bare,
                      get_states_by_full, get_own_nodes_states,
-                     get_items, get_item, set_item],
+                     get_items, get_item, set_item, del_item, del_items],
     gen_mod:start_backend_module(mod_pubsub_db, Opts, TrackedDBFuns),
     mod_pubsub_db_backend:start(),
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -273,15 +273,15 @@ process_packet(Acc, From, To, El, Pid) ->
 init([ServerHost, Opts]) ->
     ?DEBUG("pubsub init ~p ~p", [ServerHost, Opts]),
     Host = gen_mod:get_opt_subhost(ServerHost, Opts, default_host()),
-    
+
     init_backend(Opts),
 
     pubsub_index:init(Host, ServerHost, Opts),
     ets:new(gen_mod:get_module_proc(ServerHost, config), [set, named_table, public]),
     {Plugins, NodeTree, PepMapping} = init_plugins(Host, ServerHost, Opts),
-    
+
     mod_disco:register_feature(ServerHost, ?NS_PUBSUB),
-    
+
     store_config_in_ets(Host, ServerHost, Opts, Plugins, NodeTree, PepMapping),
     add_hooks(ServerHost, hooks()),
     case lists:member(?PEPNODE, Plugins) of
@@ -299,7 +299,8 @@ init([ServerHost, Opts]) ->
 init_backend(Opts) ->
     TrackedDBFuns = [set_state, del_state, get_state, get_states,
                      get_states_by_lus, get_states_by_bare,
-                     get_states_by_full, get_own_nodes_states],
+                     get_states_by_full, get_own_nodes_states,
+                     get_items, get_item, set_item],
     gen_mod:start_backend_module(mod_pubsub_db, Opts, TrackedDBFuns),
     mod_pubsub_db_backend:start(),
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -125,10 +125,10 @@
     ok.
 
 -callback get_items(Nidx :: mod_pubsub:nodeIdx()) ->
-    {result, {[mod_pubsub:pubsubItem()], none}}.
+    {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out()}}.
 
 -callback get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
-    {result, mod_pubsub:pubsubItem()} | {error, exml:element()}.
+    {ok, mod_pubsub:pubsubItem()} | {error, exml:element()}.
 
 -callback set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -124,7 +124,18 @@
 -callback remove_all_items(Nidx :: mod_pubsub:nodeIdx()) ->
     ok.
 
+-callback get_items(Nidx :: mod_pubsub:nodeIdx()) ->
+    {result, {[mod_pubsub:pubsubItem()], none}}.
+
+-callback get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
+    {result, mod_pubsub:pubsubItem()} | {error, exml:element()}.
+
+-callback set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
+
+-callback del_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) -> ok.
+
 %%====================================================================
+
 %% API
 %%====================================================================
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -128,7 +128,7 @@
     {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out()}}.
 
 -callback get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
-    {ok, mod_pubsub:pubsubItem()} | {error, exml:element()}.
+    {ok, mod_pubsub:pubsubItem()} | {error, item_not_found}.
 
 -callback set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -134,6 +134,8 @@
 
 -callback del_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) -> ok.
 
+-callback del_items(Nidx :: mod_pubsub:nodeIdx(), [ItemId :: mod_pubsub:itemId()]) -> ok.
+
 %%====================================================================
 
 %% API

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -269,16 +269,16 @@ add_item(Nidx, JID, ItemId) ->
 %% ------------------------ Direct #pubsub_item access ------------------------
 
 -spec get_items(Nidx :: mod_pubsub:nodeIdx()) ->
-    {result, {[mod_pubsub:pubsubItem()], none}}.
+    {ok, {[mod_pubsub:pubsubItem()], none}}.
 get_items(Nidx) ->
     Items = mnesia:match_object(#pubsub_item{itemid = {'_', Nidx}, _ = '_'}),
-    {result, {lists:reverse(lists:keysort(#pubsub_item.modification, Items)), none}}.
+    {ok, {lists:reverse(lists:keysort(#pubsub_item.modification, Items)), none}}.
 
 -spec get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
     {result, mod_pubsub:pubsubItem()} | {error, exml:element()}.
 get_item(Nidx, ItemId) ->
     case mnesia:read({pubsub_item, {ItemId, Nidx}}) of
-        [Item] when is_record(Item, pubsub_item) -> {result, Item};
+        [Item] when is_record(Item, pubsub_item) -> {ok, Item};
         _ -> {error, mongoose_xmpp_errors:item_not_found()}
     end.
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -45,7 +45,8 @@
          get_items/1,
          get_item/2,
          set_item/1,
-         del_item/2
+         del_item/2,
+         del_items/2
         ]).
 
 %%====================================================================
@@ -288,6 +289,11 @@ set_item(Item) ->
 -spec del_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) -> ok.
 del_item(Nidx, ItemId) ->
     mnesia:delete({pubsub_item, {ItemId, Nidx}}).
+
+-spec del_items(Nidx :: mod_pubsub:nodeIdx(), [ItemId :: mod_pubsub:itemId()]) -> ok.
+del_items(Nidx, ItemIds) ->
+    lists:foreach(fun (ItemId) -> del_item(Nidx, ItemId) end,
+                  ItemIds).
 
 %%====================================================================
 %% Internal functions

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -32,11 +32,20 @@
          delete_all_subscriptions/2,
          update_subscription/4
         ]).
-% Items
+% Item ids in state
 -export([
          add_item/3,
          remove_items/3,
          remove_all_items/1
+        ]).
+
+% Whole Items
+
+-export([
+         get_items/1,
+         get_item/2,
+         set_item/1,
+         del_item/2
         ]).
 
 %%====================================================================
@@ -52,6 +61,10 @@ start() ->
                          {type, ordered_set},
                          {attributes, record_info(fields, pubsub_state)}]),
     mnesia:add_table_copy(pubsub_state, node(), disc_copies),
+    mnesia:create_table(pubsub_item,
+                        [{disc_only_copies, [node()]},
+                         {attributes, record_info(fields, pubsub_item)}]),
+    mnesia:add_table_copy(pubsub_item, node(), disc_only_copies),
     ok.
 
 -spec stop() -> ok.
@@ -251,6 +264,30 @@ add_item(Nidx, JID, ItemId) ->
     {ok, State} = get_state(Nidx, jid:to_bare(JID), write),
     NewItems = [ItemId | State#pubsub_state.items],
     mnesia:write(State#pubsub_state{ items = NewItems }).
+
+%% ------------------------ Direct #pubsub_item access ------------------------
+
+-spec get_items(Nidx :: mod_pubsub:nodeIdx()) ->
+    {result, {[mod_pubsub:pubsubItem()], none}}.
+get_items(Nidx) ->
+    Items = mnesia:match_object(#pubsub_item{itemid = {'_', Nidx}, _ = '_'}),
+    {result, {lists:reverse(lists:keysort(#pubsub_item.modification, Items)), none}}.
+
+-spec get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
+    {result, mod_pubsub:pubsubItem()} | {error, exml:element()}.
+get_item(Nidx, ItemId) ->
+    case mnesia:read({pubsub_item, {ItemId, Nidx}}) of
+        [Item] when is_record(Item, pubsub_item) -> {result, Item};
+        _ -> {error, mongoose_xmpp_errors:item_not_found()}
+    end.
+
+-spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.
+set_item(Item) ->
+    mnesia:write(Item).
+
+-spec del_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) -> ok.
+del_item(Nidx, ItemId) ->
+    mnesia:delete({pubsub_item, {ItemId, Nidx}}).
 
 %%====================================================================
 %% Internal functions

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -275,11 +275,11 @@ get_items(Nidx) ->
     {ok, {lists:reverse(lists:keysort(#pubsub_item.modification, Items)), none}}.
 
 -spec get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
-    {result, mod_pubsub:pubsubItem()} | {error, exml:element()}.
+    {ok, mod_pubsub:pubsubItem()} | {error, item_not_found}.
 get_item(Nidx, ItemId) ->
     case mnesia:read({pubsub_item, {ItemId, Nidx}}) of
         [Item] when is_record(Item, pubsub_item) -> {ok, Item};
-        _ -> {error, mongoose_xmpp_errors:item_not_found()}
+        _ -> {error, item_not_found}
     end.
 
 -spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -632,9 +632,7 @@ del_item(Nidx, ItemId) ->
     mod_pubsub_db_backend:del_item(Nidx, ItemId).
 
 del_items(Nidx, ItemIds) ->
-    lists:foreach(fun (ItemId) -> del_item(Nidx, ItemId)
-        end,
-        ItemIds).
+    mod_pubsub_db_backend:del_items(Nidx, ItemIds).
 
 get_item_name(_Host, _Node, Id) ->
     Id.

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -579,8 +579,8 @@ get_items(Nidx, _From, _RSM) ->
     case mod_pubsub_db_backend:get_items(Nidx) of
         {ok, Result} ->
             {result, Result};
-        {error, Error} ->
-            {error, Error}
+        {error, item_not_found} ->
+            {error, mongoose_xmpp_errors:item_not_found()}
     end.
 
 get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId, RSM) ->

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -576,7 +576,12 @@ get_node_if_has_pending_subs(NodeTree, #pubsub_state{stateid = {_, N}, subscript
 %% <p>PubSub plugins can store the items where they wants (for example in a
 %% relational database), or they can even decide not to persist any items.</p>
 get_items(Nidx, _From, _RSM) ->
-    mod_pubsub_db_backend:get_items(Nidx).
+    case mod_pubsub_db_backend:get_items(Nidx) of
+        {ok, Result} ->
+            {result, Result};
+        {error, Error} ->
+            {error, Error}
+    end.
 
 get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId, RSM) ->
     {ok, Affiliation} = mod_pubsub_db_backend:get_affiliation(Nidx, JID),
@@ -595,7 +600,12 @@ get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId, RSM
 %% @doc <p>Returns an item (one item list), given its reference.</p>
 
 get_item(Nidx, ItemId) ->
-    mod_pubsub_db_backend:get_item(Nidx, ItemId).
+    case mod_pubsub_db_backend:get_item(Nidx, ItemId) of
+        {ok, Item} ->
+            {result, Item};
+        {error, Error} ->
+            {error, Error}
+    end.
 
 get_item(Nidx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId) ->
     {ok, Affiliation} = mod_pubsub_db_backend:get_affiliation(Nidx, JID),


### PR DESCRIPTION
This PR only moves low level functions modifying `pubsub_item` table to the `mod_pubsub_db_mnesia` backend.
