### PR TITLE
pubsub_state RDBMS backend

### DIFF
--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -2,7 +2,8 @@
 
 %% API
 
--export([is_rdbms_enabled/1]).
+-export([is_rdbms_enabled/1,
+        backend_by_db_enabled/0]).
 
 -export([auth_modules/0]).
 
@@ -24,7 +25,6 @@
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
                              rpc/4]).
 
 -spec is_rdbms_enabled(Host :: binary()) -> boolean().
@@ -32,6 +32,14 @@ is_rdbms_enabled(Host) ->
     case rpc(mim(), mongoose_rdbms, sql_transaction, [Host, fun erlang:yield/0]) of
         {atomic, _} -> true;
         _ -> false
+    end.
+
+-spec backend_by_db_enabled() -> atom().
+backend_by_db_enabled() ->
+    Host = ct:get_config({hosts, mim, domain}),
+    case mongoose_helper:is_rdbms_enabled(Host) of
+        true -> rdbms;
+        false -> mnesia
     end.
 
 -spec auth_modules() -> [atom()].

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -3,7 +3,7 @@
 %% API
 
 -export([is_rdbms_enabled/1,
-        backend_by_db_enabled/0]).
+        mnesia_or_rdbms_backend/0]).
 
 -export([auth_modules/0]).
 
@@ -34,8 +34,8 @@ is_rdbms_enabled(Host) ->
         _ -> false
     end.
 
--spec backend_by_db_enabled() -> atom().
-backend_by_db_enabled() ->
+-spec mnesia_or_rdbms_backend() -> atom().
+mnesia_or_rdbms_backend() ->
     Host = ct:get_config({hosts, mim, domain}),
     case mongoose_helper:is_rdbms_enabled(Host) of
         true -> rdbms;

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -46,10 +46,6 @@ foreach_recipient(Users, VerifyFun) ->
 load_muc(Host) ->
     %% Stop modules before trying to start them
     unload_muc(),
-    case mongoose_helper:is_rdbms_enabled(<<"localhost">>) of
-        true -> rdbms;
-        false -> mnesia
-    end,
     %% TODO refactoring. "localhost" should be passed as a parameter
     dynamic_modules:start(<<"localhost">>, mod_muc,
                           [{host, binary_to_list(Host)},

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -196,13 +196,9 @@ suite() ->
 
 init_per_suite(Config) ->
     Host = ct:get_config({hosts, mim, domain}),
-    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
-                  true -> rdbms;
-                  false -> mnesia
-              end,
     dynamic_modules:start(Host, mod_muc_light,
                           [{host, binary_to_list(?MUCHOST)},
-                           {backend, Backend},
+                           {backend, mongoose_helper:backend_by_db_enabled()},
                            {rooms_in_rosters, true}]),
     Config1 = escalus:init_per_suite(Config),
     escalus:create_users(Config1, escalus:get_users([alice, bob, kate, mike])).

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -198,7 +198,7 @@ init_per_suite(Config) ->
     Host = ct:get_config({hosts, mim, domain}),
     dynamic_modules:start(Host, mod_muc_light,
                           [{host, binary_to_list(?MUCHOST)},
-                           {backend, mongoose_helper:backend_by_db_enabled()},
+                           {backend, mongoose_helper:mnesia_or_rdbms_backend()},
                            {rooms_in_rosters, true}]),
     Config1 = escalus:init_per_suite(Config),
     escalus:create_users(Config1, escalus:get_users([alice, bob, kate, mike])).

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -61,15 +61,10 @@ negative_response() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    Host = ct:get_config({hosts, mim, domain}),
-    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
-              true -> rdbms;
-              false -> mnesia
-            end,
-
     dynamic_modules:start(<<"localhost">>, mod_muc_light,
         [{host, binary_to_list(muc_light_domain())},
-         {rooms_in_rosters, true}, {backend, Backend}]),
+         {rooms_in_rosters, true},
+         {backend, mongoose_helper:backend_by_db_enabled()}]),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -64,7 +64,7 @@ init_per_suite(Config) ->
     dynamic_modules:start(<<"localhost">>, mod_muc_light,
         [{host, binary_to_list(muc_light_domain())},
          {rooms_in_rosters, true},
-         {backend, mongoose_helper:backend_by_db_enabled()}]),
+         {backend, mongoose_helper:mnesia_or_rdbms_backend()}]),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -137,7 +137,7 @@ init_per_suite(Config) ->
     Host = domain(),
     dynamic_modules:start(Host, mod_muc_light,
                           [{host, binary_to_list(?MUCHOST)},
-                           {backend, mongoose_helper:backend_by_db_enabled()},
+                           {backend, mongoose_helper:mnesia_or_rdbms_backend()},
                            {legacy_mode, true}]),
     Config1 = escalus:init_per_suite(Config),
     escalus:create_users(Config1, escalus:get_users([alice, bob, kate, mike])).

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -135,13 +135,9 @@ suite() ->
 
 init_per_suite(Config) ->
     Host = domain(),
-    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
-                  true -> rdbms;
-                  false -> mnesia
-              end,
     dynamic_modules:start(Host, mod_muc_light,
                           [{host, binary_to_list(?MUCHOST)},
-                           {backend, Backend},
+                           {backend, mongoose_helper:backend_by_db_enabled()},
                            {legacy_mode, true}]),
     Config1 = escalus:init_per_suite(Config),
     escalus:create_users(Config1, escalus:get_users([alice, bob, kate, mike])).

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -290,16 +290,11 @@ unsubscribe_after_presence_unsubscription(Config) ->
 %%-----------------------------------------------------------------
 
 required_modules() ->
-    Host = ct:get_config({hosts, mim, domain}),
-    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
-                  true -> rdbms;
-                  false -> mnesia
-              end,
     [{mod_caps, []},
      {mod_pubsub, [
                    {plugins, [<<"dag">>, <<"pep">>]},
                    {nodetree, <<"dag">>},
-                   {backend, Backend},
+                   {backend, mongoose_helper:backend_by_db_enabled()},
                    {pep_mapping, []},
                    {host, "pubsub.@HOST@"}
                   ]}].

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -294,7 +294,7 @@ required_modules() ->
      {mod_pubsub, [
                    {plugins, [<<"dag">>, <<"pep">>]},
                    {nodetree, <<"dag">>},
-                   {backend, mongoose_helper:backend_by_db_enabled()},
+                   {backend, mongoose_helper:mnesia_or_rdbms_backend()},
                    {pep_mapping, []},
                    {host, "pubsub.@HOST@"}
                   ]}].

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -1536,7 +1536,7 @@ required_modules() ->
     [{mod_pubsub, [
                    {plugins, [<<"dag">>]},
                    {nodetree, <<"dag">>},
-                   {backend, mongoose_helper:backend_by_db_enabled()},
+                   {backend, mongoose_helper:mnesia_or_rdbms_backend()},
                    {host, "pubsub.@HOST@"}
                   ]}].
 

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -1533,9 +1533,15 @@ pubsub_node() ->
     {node_addr(), pubsub_node_name()}.
 
 required_modules() ->
+    Host = ct:get_config({hosts, mim, domain}),
+    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
+                  true -> rdbms;
+                  false -> mnesia
+              end,
     [{mod_pubsub, [
                    {plugins, [<<"dag">>]},
                    {nodetree, <<"dag">>},
+                   {backend, Backend},
                    {host, "pubsub.@HOST@"}
                   ]}].
 

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -1533,15 +1533,10 @@ pubsub_node() ->
     {node_addr(), pubsub_node_name()}.
 
 required_modules() ->
-    Host = ct:get_config({hosts, mim, domain}),
-    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
-                  true -> rdbms;
-                  false -> mnesia
-              end,
     [{mod_pubsub, [
                    {plugins, [<<"dag">>]},
                    {nodetree, <<"dag">>},
-                   {backend, Backend},
+                   {backend, mongoose_helper:backend_by_db_enabled()},
                    {host, "pubsub.@HOST@"}
                   ]}].
 

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -466,9 +466,15 @@ h2_req(Conn, Method, Path, Body) ->
     end.
 
 required_modules() ->
+    Host = ct:get_config({hosts, mim, domain}),
+    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
+                  true -> rdbms;
+                  false -> mnesia
+              end,
     [
         {mod_pubsub, [
             {plugins, [<<"dag">>, <<"push">>]},
+            {backend, Backend},
             {nodetree, <<"dag">>},
             {host, "pubsub.@HOST@"}
         ]},

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -466,15 +466,10 @@ h2_req(Conn, Method, Path, Body) ->
     end.
 
 required_modules() ->
-    Host = ct:get_config({hosts, mim, domain}),
-    Backend = case mongoose_helper:is_rdbms_enabled(Host) of
-                  true -> rdbms;
-                  false -> mnesia
-              end,
     [
         {mod_pubsub, [
             {plugins, [<<"dag">>, <<"push">>]},
-            {backend, Backend},
+            {backend, mongoose_helper:backend_by_db_enabled()},
             {nodetree, <<"dag">>},
             {host, "pubsub.@HOST@"}
         ]},

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -469,7 +469,7 @@ required_modules() ->
     [
         {mod_pubsub, [
             {plugins, [<<"dag">>, <<"push">>]},
-            {backend, mongoose_helper:backend_by_db_enabled()},
+            {backend, mongoose_helper:mnesia_or_rdbms_backend()},
             {nodetree, <<"dag">>},
             {host, "pubsub.@HOST@"}
         ]},

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -16,7 +16,7 @@ It's all about tailoring PubSub to your needs!
 * `iqdisc` (default: `one_queue`)
 * `host` (string, default: `"pubsub.@HOST@"`): Subdomain for Pubsub service to reside under.
 `@HOST@` is replaced with each served domain.
-* `backend` (atom, default: `mnesia`) - Database backend to use. Only `mnesia` is supported currently..
+* `backend` (atom, default: `mnesia`) - Database backend to use. `mnesia` and `rdbms` (*warning!* experimental) are supported currently.
 * `access_create` (atom, default: `all`): Who is allowed to create pubsub nodes.
 * `max_items_node` (integer, default: `10`): Define the maximum number of items that can be stored in a node.
 * `max_subscriptions_node` (integer, default: `undefined` - no limitation): The maximum number of subscriptions managed by a node.
@@ -32,6 +32,12 @@ E.g. pair `{"urn:xmpp:microblog:0", "mb"}` will use module `node_mb` instead of 
 Node configuration still uses the default configuration defined by the node plugin, and overrides any items by the value defined in this configurable list.
 * `item_publisher` (boolean, default: `false`): When enabled, a JID of the publisher will be saved in the item metadata.
  This effectively makes them an owner of this item.
+
+#### Note about RDBMS backend
+
+Current RDBMS backend replaces `pubsub_state` Mnesia table with RDBMS equivalents.
+Due to a fact that some data is still maintained in Mnesia, there is a certain risk of data becoming inconsistent.
+The schema used by this backend may change until it reaches stable status.
 
 ### Example Configuration
 

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -474,6 +474,32 @@ GO
 CREATE INDEX i_inbox_ts ON inbox(luser, lserver, timestamp);
 GO
 
+CREATE TABLE dbo.pubsub_affiliations (
+    nidx BIGINT NOT NULL,
+    luser NVARCHAR(250) NOT NULL,
+    lserver NVARCHAR(250) NOT NULL,
+    aff TINYINT NOT NULL
+)
+GO
+
+CREATE TABLE dbo.pubsub_items (
+    nidx BIGINT NOT NULL,
+    itemid NVARCHAR(250) NOT NULL,
+    luser NVARCHAR(250) NOT NULL,
+    lserver NVARCHAR(250) NOT NULL
+)
+GO
+
+CREATE TABLE dbo.pubsub_subscriptions (
+    nidx BIGINT NOT NULL,
+    luser NVARCHAR(250) NOT NULL,
+    lserver NVARCHAR(250) NOT NULL,
+    lresource NVARCHAR(250) NOT NULL,
+    type TINYINT NOT NULL,
+    sub_id NVARCHAR(125) NOT NULL
+)
+GO
+
 SET ANSI_PADDING OFF
 GO
 ALTER TABLE [dbo].[offline_message] ADD  DEFAULT (NULL) FOR [expire]

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -478,8 +478,16 @@ CREATE TABLE dbo.pubsub_affiliations (
     nidx BIGINT NOT NULL,
     luser NVARCHAR(250) NOT NULL,
     lserver NVARCHAR(250) NOT NULL,
-    aff TINYINT NOT NULL
+    aff TINYINT NOT NULL,
+    CONSTRAINT PK_pubsub_affiliations PRIMARY KEY CLUSTERED(
+        luser ASC,
+        lserver ASC,
+        nidx ASC
+    )
 )
+GO
+
+CREATE INDEX i_pubsub_affiliations_nidx ON pubsub_affiliations(nidx);
 GO
 
 CREATE TABLE dbo.pubsub_items (
@@ -490,6 +498,13 @@ CREATE TABLE dbo.pubsub_items (
 )
 GO
 
+-- we skip luser and lserver in this one as this is little chance (even impossible?)
+-- to have itemid duplication for distinct users
+CREATE INDEX i_pubsub_items_nidx_itemid ON pubsub_items(nidx, itemid);
+GO
+CREATE INDEX i_pubsub_items_lus_nidx ON pubsub_items(luser, lserver, nidx);
+GO
+
 CREATE TABLE dbo.pubsub_subscriptions (
     nidx BIGINT NOT NULL,
     luser NVARCHAR(250) NOT NULL,
@@ -498,6 +513,11 @@ CREATE TABLE dbo.pubsub_subscriptions (
     type TINYINT NOT NULL,
     sub_id NVARCHAR(125) NOT NULL
 )
+GO
+
+CREATE INDEX i_pubsub_subscriptions_lus_nidx ON pubsub_subscriptions(luser, lserver, nidx);
+GO
+CREATE INDEX i_pubsub_subscriptions_nidx ON pubsub_subscriptions(nidx);
 GO
 
 SET ANSI_PADDING OFF

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -353,3 +353,29 @@ CREATE TABLE inbox (
 
 CREATE INDEX i_inbox USING BTREE ON inbox(luser, lserver, timestamp);
 
+CREATE TABLE pubsub_affiliations (
+    nidx BIGINT UNSIGNED NOT NULL,
+    luser VARCHAR(250) NOT NULL,
+    lserver VARCHAR(250) NOT NULL,
+    aff TINYINT UNSIGNED NOT NULL
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pubsub_items (
+    nidx BIGINT UNSIGNED NOT NULL,
+    itemid VARCHAR(250) NOT NULL,
+    luser VARCHAR(250) NOT NULL,
+    lserver VARCHAR(250) NOT NULL
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pubsub_subscriptions (
+    nidx BIGINT UNSIGNED NOT NULL,
+    luser VARCHAR(250) NOT NULL,
+    lserver VARCHAR(250) NOT NULL,
+    lresource VARCHAR(250) NOT NULL,
+    type TINYINT UNSIGNED NOT NULL,
+    sub_id VARCHAR(125) NOT NULL
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -357,9 +357,12 @@ CREATE TABLE pubsub_affiliations (
     nidx BIGINT UNSIGNED NOT NULL,
     luser VARCHAR(250) NOT NULL,
     lserver VARCHAR(250) NOT NULL,
-    aff TINYINT UNSIGNED NOT NULL
+    aff TINYINT UNSIGNED NOT NULL,
+    PRIMARY KEY(luser, lserver(50), nidx)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_pubsub_affiliations_nidx USING BTREE ON pubsub_affiliations(nidx);
 
 CREATE TABLE pubsub_items (
     nidx BIGINT UNSIGNED NOT NULL,
@@ -368,6 +371,11 @@ CREATE TABLE pubsub_items (
     lserver VARCHAR(250) NOT NULL
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
+
+-- we skip luser and lserver in this one as this is little chance (even impossible?)
+-- to have itemid duplication for distinct users
+CREATE INDEX i_pubsub_items_nidx_itemid USING BTREE ON pubsub_items(nidx, itemid);
+CREATE INDEX i_pubsub_items_lus_nidx USING BTREE ON pubsub_items(luser, lserver(50), nidx);
 
 CREATE TABLE pubsub_subscriptions (
     nidx BIGINT UNSIGNED NOT NULL,
@@ -378,4 +386,7 @@ CREATE TABLE pubsub_subscriptions (
     sub_id VARCHAR(125) NOT NULL
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_pubsub_subscriptions_lus_nidx USING BTREE ON pubsub_subscriptions(luser, lserver(50), nidx);
+CREATE INDEX i_pubsub_subscriptions_nidx USING BTREE ON pubsub_subscriptions(nidx);
 

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -316,3 +316,26 @@ CREATE INDEX i_inbox
     ON inbox
     USING BTREE(luser, lserver, timestamp);
 
+CREATE TABLE pubsub_affiliations (
+    nidx BIGINT             NOT NULL,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    aff SMALLINT            NOT NULL
+);
+
+CREATE TABLE pubsub_items (
+    nidx BIGINT             NOT NULL,
+    itemid VARCHAR(250)     NOT NULL,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL
+);
+
+CREATE TABLE pubsub_subscriptions (
+    nidx BIGINT             NOT NULL,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    lresource VARCHAR(250)  NOT NULL,
+    type SMALLINT           NOT NULL,
+    sub_id VARCHAR(125)     NOT NULL
+);
+

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -320,8 +320,11 @@ CREATE TABLE pubsub_affiliations (
     nidx BIGINT             NOT NULL,
     luser VARCHAR(250)      NOT NULL,
     lserver VARCHAR(250)    NOT NULL,
-    aff SMALLINT            NOT NULL
+    aff SMALLINT            NOT NULL,
+    PRIMARY KEY(luser, lserver, nidx)
 );
+
+CREATE INDEX i_pubsub_affiliations_nidx ON pubsub_affiliations(nidx);
 
 CREATE TABLE pubsub_items (
     nidx BIGINT             NOT NULL,
@@ -329,6 +332,11 @@ CREATE TABLE pubsub_items (
     luser VARCHAR(250)      NOT NULL,
     lserver VARCHAR(250)    NOT NULL
 );
+
+-- we skip luser and lserver in this one as this is little chance (even impossible?)
+-- to have itemid duplication for distinct users
+CREATE INDEX i_pubsub_items_nidx_itemid ON pubsub_items(nidx, itemid);
+CREATE INDEX i_pubsub_items_lus_nidx ON pubsub_items(luser, lserver, nidx);
 
 CREATE TABLE pubsub_subscriptions (
     nidx BIGINT             NOT NULL,
@@ -338,4 +346,7 @@ CREATE TABLE pubsub_subscriptions (
     type SMALLINT           NOT NULL,
     sub_id VARCHAR(125)     NOT NULL
 );
+
+CREATE INDEX i_pubsub_subscriptions_lus_nidx ON pubsub_subscriptions(luser, lserver, nidx);
+CREATE INDEX i_pubsub_subscriptions_nidx ON pubsub_subscriptions(nidx);
 

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -243,8 +243,10 @@ to_lower({U, S, R}) ->
         error
     end.
 
--spec to_lus(JID :: jid()) -> error | simple_bare_jid().
+-spec to_lus(JID :: jid() | ljid()) -> simple_bare_jid().
 to_lus(#jid{luser = U, lserver = S}) ->
+    {U, S};
+to_lus({U, S, _}) ->
     {U, S}.
 
 -spec to_bare(simple_jid()  | jid()) ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -4344,8 +4344,8 @@ on_user_offline(Acc, _, JID, _, _) ->
     end,
     Acc.
 
-purge_offline(LJID) ->
-    Host = host(element(2, LJID)),
+purge_offline({_, LServer, _} = LJID) ->
+    Host = host(LServer),
     Plugins = plugins(Host),
     Affs = lists:foldl(
              fun (PluginType, Acc) ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1244,7 +1244,7 @@ iq_sm(From, To, Acc, #iq{type = Type, sub_el = SubEl, xmlns = XMLNS, lang = Lang
           end,
     case Res of
         {result, IQRes} -> {Acc, IQ#iq{type = result, sub_el = IQRes}};
-        {error, Error} -> {Acc, IQ#iq{type = error, sub_el = [Error, SubEl]}}
+        {error, Error} -> {Acc, make_error_reply(IQ, Error)}
     end.
 
 iq_get_vcard(Lang) ->
@@ -4413,6 +4413,11 @@ purge_item_of_offline_user(Host, #pubsub_node{ id = Nidx, nodeid = {_, NodeId},
 timestamp() ->
     os:timestamp().
 
+make_error_reply(#iq{ sub_el = SubEl } = IQ, #xmlel{} = ErrorEl) ->
+    IQ#iq{type = error, sub_el = [ErrorEl, SubEl]};
+make_error_reply(#iq{ sub_el = SubEl } = IQ, Error) ->
+    ?ERROR_MSG("event=pubsub_crash,details=~p", [Error]),
+    IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:internal_server_error(), SubEl]};
 make_error_reply(Packet, #xmlel{} = ErrorEl) ->
     jlib:make_error_reply(Packet, ErrorEl);
 make_error_reply(Packet, Error) ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -10,7 +10,7 @@
 
 -include("mongoose_logger.hrl").
 
--export([transaction_error/2, dirty_error/4]).
+-export([db_error/3]).
 
 %%====================================================================
 %% Behaviour callbacks
@@ -149,19 +149,10 @@
 
 %% These are made as separate functions to make tracing easier, just in case.
 
--spec transaction_error(Reason :: any(), ErrorDebug :: map()) ->
+-spec db_error(ReasonData :: map(), ErrorDebug :: map(), Event :: any()) ->
     {error, Details :: map()}.
-transaction_error(Reason, ErrorDebug) ->
-    {error, ErrorDebug#{ event => transaction_failure,
-                         reason => Reason }}.
-
--spec dirty_error(Class :: atom(), Reason :: any(), StackTrace :: list(), ErrorDebug :: map()) ->
-    {error, Details :: map()}.
-dirty_error(Class, Reason, StackTrace, ErrorDebug) ->
-    {error, ErrorDebug#{ event => dirty_failure,
-                         class => Class,
-                         reason => Reason,
-                         stacktrace => StackTrace}}.
+db_error(ReasonData, ErrorDebug, Event) ->
+    {error, maps:merge(ErrorDebug#{ event => Event }, ReasonData)}.
 
 %%====================================================================
 %% Internal functions

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -45,66 +45,72 @@
 %% When a state is not found, returns empty state.
 %% Maybe can be removed completely later?
 -callback get_state(Nidx :: mod_pubsub:nodeIdx(),
-                    JID :: jid:jid()) ->
+                    JID :: jid:ljid()) ->
     {ok, mod_pubsub:pubsubState()}.
 
 %% Maybe can be removed completely later?
 -callback get_states(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_lus(JID :: jid:jid()) ->
+-callback get_states_by_lus(JID :: jid:ljid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_bare(JID :: jid:jid()) ->
+-callback get_states_by_bare(JID :: jid:ljid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_states_by_bare_and_full(JID :: jid:jid()) ->
+-callback get_states_by_bare_and_full(JID :: jid:ljid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback get_own_nodes_states(JID :: jid:jid()) ->
-    {ok, [mod_pubsub:pubsubState()]}.
+-callback get_idxs_of_own_nodes_with_pending_subs(JID :: jid:ljid()) ->
+    {ok, [mod_pubsub:nodeIdx()]}.
+
+%% ----------------------- Node management ------------------------
+
+-callback create_node(Nidx :: mod_pubsub:nodeIdx(),
+                      Owner :: jid:ljid()) ->
+    ok.
 
 %% ----------------------- Affiliations ------------------------
 
 -callback set_affiliation(Nidx :: mod_pubsub:nodeIdx(),
-                          JID :: jid:jid(),
+                          JID :: jid:ljid(),
                           Affiliation :: mod_pubsub:affiliation()) ->
     ok.
 
 -callback get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
-                          JID :: jid:jid()) ->
+                          JID :: jid:ljid()) ->
     {ok, mod_pubsub:affiliation()}.
 
 %% ----------------------- Subscriptions ------------------------
 
 -callback add_subscription(Nidx :: mod_pubsub:nodeIdx(),
-                           JID :: jid:jid(),
+                           JID :: jid:ljid(),
                            Sub :: mod_pubsub:subscription(),
                            SubId :: mod_pubsub:subId()) ->
     ok.
 
 -callback update_subscription(Nidx :: mod_pubsub:nodeIdx(),
-                              JID :: jid:jid(),
+                              JID :: jid:ljid(),
                               Subscription :: mod_pubsub:subscription(),
                               SubId :: mod_pubsub:subId()) ->
     ok.
 
 -callback get_node_subscriptions(Nidx :: mod_pubsub:nodeIdx()) ->
-    {ok, [{Entity :: jid:jid(), Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+    {ok, [{Entity :: jid:ljid(), Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
 
 -callback get_node_entity_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
-                                        JID :: jid:jid()) ->
+                                        JID :: jid:ljid()) ->
     {ok, [{Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
 
 -callback delete_subscription(
             Nidx :: mod_pubsub:nodeIdx(),
-            JID :: jid:jid(),
+            JID :: jid:ljid(),
             SubId :: mod_pubsub:subId()) ->
     ok.
 
 -callback delete_all_subscriptions(
             Nidx :: mod_pubsub:nodeIdx(),
-            JID :: jid:jid()) ->
+            JID :: jid:ljid()) ->
     ok.
 
 %% ----------------------- Items ------------------------
@@ -112,12 +118,12 @@
 %% TODO: Refactor to use MaxItems value, so separate remove_items in publishing
 %% won't be necessary and the whole operation may be optimised in DB layer.
 -callback add_item(Nidx :: mod_pubsub:nodeIdx(),
-                   JID :: jid:jid(),
-                   ItemId :: mod_pubsub:pubsubItem()) ->
+                   JID :: jid:ljid(),
+                   PubSubItem :: mod_pubsub:pubsubItem()) ->
     ok.
 
 -callback remove_items(Nidx :: mod_pubsub:nodeIdx(),
-                       JID :: jid:jid(),
+                       JID :: jid:ljid(),
                        ItemIds :: [mod_pubsub:itemId()]) ->
     ok.
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -144,8 +144,8 @@ get_idxs_of_own_nodes_with_pending_subs(LJID) ->
     MyStates = mnesia:match_object(#pubsub_state{stateid = {LBare, '_'},
                                                  affiliation = owner, _ = '_'}),
     NodeIdxs = [Nidx || #pubsub_state{stateid = {_, Nidx}} <- MyStates],
-    ResultNidxs = mnesia:fold(pa:bind(fun get_idxs_with_pending_subs/3, NodeIdxs),
-                              [], pubsub_state),
+    ResultNidxs = mnesia:foldl(pa:bind(fun get_idxs_with_pending_subs/3, NodeIdxs),
+                               [], pubsub_state),
     {ok, ResultNidxs}.
 
 -spec del_state(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -17,7 +17,11 @@
 % Direct #pubsub_state access
 -export([del_state/2, get_state/2,
          get_states/1, get_states_by_lus/1, get_states_by_bare/1,
-         get_states_by_bare_and_full/1, get_own_nodes_states/1]).
+         get_states_by_bare_and_full/1, get_idxs_of_own_nodes_with_pending_subs/1]).
+% Node management
+-export([
+         create_node/2
+        ]).
 % Affiliations
 -export([
          set_affiliation/3,
@@ -100,10 +104,10 @@ dirty(Fun, ErrorDebug) ->
 %% ------------------------ Direct #pubsub_state access ------------------------
 
 -spec get_state(Nidx :: mod_pubsub:nodeIdx(),
-                JID :: jid:jid()) ->
+                LJID :: jid:ljid()) ->
     {ok, mod_pubsub:pubsubState()}.
-get_state(Nidx, JID) ->
-    get_state(Nidx, JID, read).
+get_state(Nidx, LJID) ->
+    get_state(Nidx, LJID, read).
 
 -spec get_states(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
@@ -115,135 +119,141 @@ get_states(Nidx) ->
              end,
     {ok, States}.
 
--spec get_states_by_lus(JID :: jid:jid()) ->
+-spec get_states_by_lus(LJID :: jid:ljid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
-get_states_by_lus(#jid{ luser = LUser, lserver = LServer }) ->
+get_states_by_lus({ LUser, LServer, _ }) ->
     {ok, mnesia:match_object(#pubsub_state{stateid = {{LUser, LServer, '_'}, '_'}, _ = '_'})}.
 
--spec get_states_by_bare(JID :: jid:jid()) ->
+-spec get_states_by_bare(LJID :: jid:ljid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
-get_states_by_bare(JID) ->
-    LBare = jid:to_bare(jid:to_lower(JID)),
+get_states_by_bare(LJID) ->
+    LBare = jid:to_bare(LJID),
     {ok, mnesia:match_object(#pubsub_state{stateid = {LBare, '_'}, _ = '_'})}.
 
--spec get_states_by_bare_and_full(JID :: jid:jid()) ->
+-spec get_states_by_bare_and_full(LJID :: jid:ljid()) ->
     {ok, [mod_pubsub:pubsubState()]}.
-get_states_by_bare_and_full(JID) ->
-    LJID = jid:to_lower(JID),
+get_states_by_bare_and_full(LJID) ->
     LBare = jid:to_bare(LJID),
     {ok, mnesia:match_object(#pubsub_state{stateid = {LJID, '_'}, _ = '_'})
      ++ mnesia:match_object(#pubsub_state{stateid = {LBare, '_'}, _ = '_'})}.
 
--spec get_own_nodes_states(JID :: jid:jid()) ->
-    {ok, [mod_pubsub:pubsubState()]}.
-get_own_nodes_states(JID) ->
-    LBare = jid:to_bare(jid:to_lower(JID)),
+-spec get_idxs_of_own_nodes_with_pending_subs(LJID :: jid:ljid()) ->
+    {ok, [mod_pubsub:nodeIdx()]}.
+get_idxs_of_own_nodes_with_pending_subs(LJID) ->
+    LBare = jid:to_bare(LJID),
     MyStates = mnesia:match_object(#pubsub_state{stateid = {LBare, '_'},
                                                  affiliation = owner, _ = '_'}),
     NodeIdxs = [Nidx || #pubsub_state{stateid = {_, Nidx}} <- MyStates],
-    OwnNodesStates =
-    mnesia:foldl(fun (#pubsub_state{stateid = {_, Nidx}} = PubSubState, Acc) ->
-                         case lists:member(Nidx, NodeIdxs) of
-                             true -> [PubSubState | Acc];
+    ResultNidxs =
+    mnesia:foldl(fun (#pubsub_state{stateid = {_, Nidx}, subscriptions = Subs}, Acc) ->
+                         case lists:member(Nidx, NodeIdxs)
+                              andalso lists:any(fun is_pending_sub/1, Subs) of
+                             true -> [Nidx | Acc];
                              false -> Acc
                          end
                  end,
                  [], pubsub_state),
-    {ok, OwnNodesStates}.
+    {ok, ResultNidxs}.
 
 -spec del_state(Nidx :: mod_pubsub:nodeIdx(),
-                JIDorLJID :: jid:ljid() | jid:jid()) -> ok.
-del_state(Nidx, #jid{} = JID) ->
-    del_state(Nidx, jid:to_lower(JID));
+                LJID :: jid:ljid()) -> ok.
 del_state(Nidx, LJID) ->
     mnesia:delete({pubsub_state, {LJID, Nidx}}).
+
+%% ------------------------ Node management ------------------------
+
+-spec create_node(Nidx :: mod_pubsub:nodeIdx(),
+                  Owner :: jid:ljid()) ->
+    ok.
+create_node(Nidx, Owner) ->
+    set_affiliation(Nidx, Owner, owner).
 
 %% ------------------------ Affiliations ------------------------
 
 -spec set_affiliation(Nidx :: mod_pubsub:nodeIdx(),
-                      JID :: jid:jid(),
+                      LJID :: jid:ljid(),
                       Affiliation :: mod_pubsub:affiliation()) -> ok.
-set_affiliation(Nidx, JID, Affiliation) ->
-    BareJID = jid:to_bare(JID),
-    {ok, State} = get_state(Nidx, BareJID, write),
+set_affiliation(Nidx, LJID, Affiliation) ->
+    BareLJID = jid:to_bare(LJID),
+    {ok, State} = get_state(Nidx, BareLJID, write),
     case {Affiliation, State#pubsub_state.subscriptions} of
-        {none, []} -> del_state(Nidx, BareJID);
+        {none, []} -> del_state(Nidx, BareLJID);
         _ ->  mnesia:write(State#pubsub_state{ affiliation = Affiliation })
     end.
 
 -spec get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
-                      JID :: jid:jid()) ->
+                      LJID :: jid:ljid()) ->
     {ok, mod_pubsub:affiliation()}.
-get_affiliation(Nidx, JID) ->
-    {ok, State} = get_state(Nidx, jid:to_bare(JID), read),
+get_affiliation(Nidx, LJID) ->
+    {ok, State} = get_state(Nidx, jid:to_bare(LJID), read),
     {ok, State#pubsub_state.affiliation}.
 
 %% ------------------------ Subscriptions ------------------------
 
 -spec add_subscription(Nidx :: mod_pubsub:nodeIdx(),
-                       JID :: jid:jid(),
+                       LJID :: jid:ljid(),
                        Sub :: mod_pubsub:subscription(),
                        SubId :: mod_pubsub:subId()) -> ok.
-add_subscription(Nidx, JID, Sub, SubId) ->
-    {ok, State} = get_state(Nidx, JID, write),
+add_subscription(Nidx, LJID, Sub, SubId) ->
+    {ok, State} = get_state(Nidx, LJID, write),
     NSubscriptions = [{Sub, SubId} | State#pubsub_state.subscriptions ],
     mnesia:write(State#pubsub_state{ subscriptions = NSubscriptions }).
 
 -spec get_node_subscriptions(Nidx :: mod_pubsub:nodeIdx()) ->
-    {ok, [{Entity :: jid:jid(), Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+    {ok, [{Entity :: jid:ljid(), Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
 get_node_subscriptions(Nidx) ->
     {ok, States} = get_states(Nidx),
     {ok, states_to_subscriptions(States)}.
 
 -spec get_node_entity_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
-                                    JID :: jid:jid()) ->
+                                    LJID :: jid:ljid()) ->
     {ok, [{Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
-get_node_entity_subscriptions(Nidx, JID) ->
-    {ok, State} = get_state(Nidx, JID, read),
+get_node_entity_subscriptions(Nidx, LJID) ->
+    {ok, State} = get_state(Nidx, LJID, read),
     {ok, State#pubsub_state.subscriptions}.
 
 -spec delete_subscription(
         Nidx :: mod_pubsub:nodeIdx(),
-        JID :: jid:jid(),
+        LJID :: jid:ljid(),
         SubId :: mod_pubsub:subId()) ->
     ok.
-delete_subscription(Nidx, JID, SubId) ->
-    {ok, State} = get_state(Nidx, JID, write),
+delete_subscription(Nidx, LJID, SubId) ->
+    {ok, State} = get_state(Nidx, LJID, write),
     NewSubs = lists:keydelete(SubId, 2, State#pubsub_state.subscriptions),
     case {State#pubsub_state.affiliation, NewSubs} of
-        {none, []} -> del_state(Nidx, JID);
+        {none, []} -> del_state(Nidx, LJID);
         _ -> mnesia:write(State#pubsub_state{subscriptions = NewSubs})
     end.
 
 -spec delete_all_subscriptions(
         Nidx :: mod_pubsub:nodeIdx(),
-        JID :: jid:jid()) ->
+        LJID :: jid:ljid()) ->
     ok.
-delete_all_subscriptions(Nidx, JID) ->
-    {ok, State} = get_state(Nidx, JID, write),
+delete_all_subscriptions(Nidx, LJID) ->
+    {ok, State} = get_state(Nidx, LJID, write),
     case State#pubsub_state.affiliation of
-        none -> del_state(Nidx, JID);
+        none -> del_state(Nidx, LJID);
         _ -> mnesia:write(State#pubsub_state{subscriptions = []})
     end.
 
 -spec update_subscription(Nidx :: mod_pubsub:nodeIdx(),
-                          JID :: jid:jid(),
+                          LJID :: jid:ljid(),
                           Subscription :: mod_pubsub:subscription(),
                           SubId :: mod_pubsub:subId()) ->
     ok.
-update_subscription(Nidx, JID, Subscription, SubId) ->
-    {ok, State} = get_state(Nidx, JID, write),
+update_subscription(Nidx, LJID, Subscription, SubId) ->
+    {ok, State} = get_state(Nidx, LJID, write),
     NewSubs = lists:keyreplace(SubId, 2, State#pubsub_state.subscriptions, {Subscription, SubId}),
     mnesia:write(State#pubsub_state{ subscriptions = NewSubs }).
 
 %% ------------------------ Items ------------------------
 
 -spec remove_items(Nidx :: mod_pubsub:nodeIdx(),
-                   JID :: jid:jid(),
+                   LJID :: jid:ljid(),
                    ItemIds :: [mod_pubsub:itemId()]) ->
     ok.
-remove_items(Nidx, JID, ItemIds) ->
-    {ok, State} = get_state(Nidx, jid:to_bare(JID), write),
+remove_items(Nidx, LJID, ItemIds) ->
+    {ok, State} = get_state(Nidx, jid:to_bare(LJID), write),
     NewItems = State#pubsub_state.items -- ItemIds,
     mnesia:write(State#pubsub_state{ items = NewItems }).
 
@@ -258,8 +268,8 @@ remove_all_items(Nidx) ->
                   end, States).
 
 -spec add_item(Nidx :: mod_pubsub:nodeIdx(),
-               JID :: jid:jid(),
-               ItemId :: mod_pubsub:pubsubItem()) ->
+               JID :: jid:ljid(),
+               Item :: mod_pubsub:pubsubItem()) ->
     ok.
 add_item(Nidx, JID, #pubsub_item{itemid = {ItemId, _}} = Item) ->
     set_item(Item),
@@ -316,11 +326,11 @@ del_items(Nidx, ItemIds) ->
 %%====================================================================
 
 -spec get_state(Nidx :: mod_pubsub:nodeIdx(),
-                JID :: jid:jid(),
+                LJID :: jid:ljid(),
                 LockKind :: write | read) ->
     {ok, mod_pubsub:pubsubState()}.
-get_state(Nidx, JID, LockKind) ->
-    StateId = {jid:to_lower(JID), Nidx},
+get_state(Nidx, LJID, LockKind) ->
+    StateId = {LJID, Nidx},
     case catch mnesia:read(pubsub_state, StateId, LockKind) of
         [#pubsub_state{} = State] -> {ok, State};
         _ -> {ok, #pubsub_state{stateid = StateId}}
@@ -343,4 +353,8 @@ add_jid_to_subs([], _J, RStates) ->
     states_to_subscriptions(RStates);
 add_jid_to_subs([{S, SubId} | RSubs], J, RStates) ->
     [ {J, S, SubId} | add_jid_to_subs(RSubs, J, RStates) ].
+
+is_pending_sub({pending, _}) -> true;
+is_pending_sub(pending) -> true;
+is_pending_sub(_) -> false.
 

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -157,7 +157,7 @@ create_node(Nidx, LJID) ->
 set_affiliation(Nidx, { LU, LS, _ } = LJID, none) ->
     BareLJID = jid:to_bare(LJID),
     case get_node_entity_subscriptions(Nidx, BareLJID) of
-        [] ->
+        {ok, []} ->
             del_state(Nidx, BareLJID);
         _ ->
             delete_affiliation_wo_subs_check(Nidx, LU, LS)
@@ -227,7 +227,7 @@ delete_subscription(Nidx, { LU, LS, LR }, SubId) ->
     ok.
 delete_all_subscriptions(Nidx, { LU, LS, LR } = LJID) ->
     case get_affiliation(Nidx, LJID) of
-        none ->
+        {ok, none} ->
             del_state(Nidx, LJID);
         _ ->
             SQL = sql_delete_all_subscriptions(Nidx, LU, LS, LR),
@@ -499,7 +499,7 @@ sql_get_entity_items(Nidx, LU, LS) ->
 -spec sql_delete_item(Nidx :: mod_pubsub:nodeIdx(),
                       LU :: jid:luser(),
                       LS :: jid:lserver(),
-                      ItemId :: mod_pubsub:nodeIdx()) -> iolist().
+                      ItemId :: mod_pubsub:itemId()) -> iolist().
 sql_delete_item(Nidx, LU, LS, ItemId) ->
     ["DELETE FROM pubsub_items"
     " WHERE nidx = ", esc_int(Nidx),

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -137,8 +137,8 @@ get_idxs_of_own_nodes_with_pending_subs({ LU, LS, _ }) ->
 
 -spec del_state(Nidx :: mod_pubsub:nodeIdx(),
                 LJID :: jid:ljid()) -> ok.
-del_state(Nidx, {LU, LS, _} = LJID) ->
-    delete_all_subscriptions(Nidx, LJID),
+del_state(Nidx, {LU, LS, LR}) ->
+    delete_all_subscriptions_wo_aff_check(Nidx, LU, LS, LR),
     delete_affiliation_wo_subs_check(Nidx, LU, LS),
     {updated, _} = mongoose_rdbms:sql_query(global, sql_delete_node_entity_items(Nidx, LU, LS)),
     ok.
@@ -230,8 +230,7 @@ delete_all_subscriptions(Nidx, { LU, LS, LR } = LJID) ->
         {ok, none} ->
             del_state(Nidx, LJID);
         _ ->
-            SQL = sql_delete_all_subscriptions(Nidx, LU, LS, LR),
-            {updated, _} = mongoose_rdbms:sql_query(global, SQL)
+            delete_all_subscriptions_wo_aff_check(Nidx, LU, LS, LR)
     end,
     ok.
 
@@ -515,6 +514,15 @@ sql_delete_all_items(Nidx) ->
 %%====================================================================
 %% Helpers
 %%====================================================================
+
+-spec delete_all_subscriptions_wo_aff_check(Nidx :: mod_pubsub:nodeIdx(),
+                                            LU :: jid:luser(),
+                                            LS :: jid:lserver(),
+                                            LR :: jid:lresource()) -> ok.
+delete_all_subscriptions_wo_aff_check(Nidx, LU, LS, LR) ->
+    SQL = sql_delete_all_subscriptions(Nidx, LU, LS, LR),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
 
 -spec delete_affiliation_wo_subs_check(Nidx :: mod_pubsub:nodeIdx(),
                                        LU :: jid:luser(),

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -1,0 +1,609 @@
+%%%----------------------------------------------------------------------
+%%% File    : mod_pubsub_db_rdbms.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : PubSub RDBMS backend
+%%% Created : 2 Nov 2018 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%%----------------------------------------------------------------------
+
+-module(mod_pubsub_db_rdbms).
+-author('piotr.nosek@erlang-solutions.com').
+
+-include("pubsub.hrl").
+-include("jlib.hrl").
+
+-export([start/0, stop/0]).
+% Funs execution
+-export([transaction/2, dirty/2]).
+% Direct #pubsub_state access
+-export([del_state/2, get_state/2,
+         get_states/1, get_states_by_lus/1, get_states_by_bare/1,
+         get_states_by_bare_and_full/1, get_idxs_of_own_nodes_with_pending_subs/1]).
+% Node management
+-export([
+         create_node/2
+        ]).
+% Affiliations
+-export([
+         set_affiliation/3,
+         get_affiliation/2
+        ]).
+% Subscriptions
+-export([
+         add_subscription/4,
+         get_node_subscriptions/1,
+         get_node_entity_subscriptions/2,
+         delete_subscription/3,
+         delete_all_subscriptions/2,
+         update_subscription/4
+        ]).
+% Items
+-export([
+         add_item/3,
+         remove_items/3,
+         remove_all_items/1
+        ]).
+
+%%====================================================================
+%% Behaviour callbacks
+%%====================================================================
+
+%% ------------------------ Backend start/stop ------------------------
+
+-spec start() -> ok.
+start() ->
+    ok.
+
+-spec stop() -> ok.
+stop() ->
+    ok.
+
+%% ------------------------ Fun execution ------------------------
+
+%% TODO: Replace these with RDBMS counterparts when this backend supports all
+%% PubSub operations!
+
+transaction(Fun, ErrorDebug) ->
+    mod_pubsub_db_mnesia:transaction(Fun, ErrorDebug).
+
+dirty(Fun, ErrorDebug) ->
+    mod_pubsub_db_mnesia:dirty(Fun, ErrorDebug).
+
+%% ------------------------ Direct #pubsub_state access ------------------------
+
+%% TODO: Functions for direct #pubsub_access are currently inefficient for RDBMS
+%%       - refactor them or remove as many of them as possible from the API at some point
+-spec get_state(Nidx :: mod_pubsub:nodeIdx(),
+                LJID :: jid:ljid()) ->
+    {ok, mod_pubsub:pubsubState()}.
+get_state(Nidx, LJID) ->
+    {ok, ItemIds} = get_entity_items(Nidx, LJID),
+    {ok, Affiliation} = get_affiliation(Nidx, LJID),
+    {ok, Subscriptions} = get_node_entity_subscriptions(Nidx, LJID),
+    {ok, #pubsub_state{
+            stateid = {LJID, Nidx},
+            items = ItemIds,
+            affiliation = Affiliation,
+            subscriptions = Subscriptions
+           }}.
+
+-spec get_states(Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+get_states(Nidx) ->
+    {selected, ItemRows} = mongoose_rdbms:sql_query(global, sql_get_item_rows(Nidx)),
+    {selected, AffiliationRows} = mongoose_rdbms:sql_query(global, sql_get_affiliation_rows(Nidx)),
+    {selected, SubRows} = mongoose_rdbms:sql_query(global, sql_get_subscriptions_rows(Nidx)),
+    States = build_states(ItemRows, AffiliationRows, SubRows),
+    {ok, States}.
+
+-spec get_states_by_lus(LJID :: jid:ljid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+get_states_by_lus({ LU, LS, _ }) ->
+    {selected, ItemRows} = mongoose_rdbms:sql_query(
+                             global, sql_get_item_rows(LU, LS)),
+    {selected, AffiliationRows} = mongoose_rdbms:sql_query(
+                                    global, sql_get_affiliation_rows(LU, LS)),
+    {selected, SubRows} = mongoose_rdbms:sql_query(
+                            global, sql_get_subscriptions_rows(LU, LS)),
+    States = build_states(ItemRows, AffiliationRows, SubRows),
+    {ok, States}.
+
+-spec get_states_by_bare(LJID :: jid:ljid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+get_states_by_bare({ LU, LS, _ }) ->
+    {selected, ItemRows} = mongoose_rdbms:sql_query(
+                             global, sql_get_item_rows(LU, LS)),
+    {selected, AffiliationRows} = mongoose_rdbms:sql_query(
+                                    global, sql_get_affiliation_rows(LU, LS)),
+    {selected, SubRows} = mongoose_rdbms:sql_query(
+                            global, sql_get_subscriptions_rows(LU, LS, <<>>)),
+    States = build_states(ItemRows, AffiliationRows, SubRows),
+    {ok, States}.
+
+-spec get_states_by_bare_and_full(LJID :: jid:ljid()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+get_states_by_bare_and_full({ LU, LS, LR } = LJID) ->
+    {ok, StatesBare} = get_states_by_bare(LJID),
+    {selected, SubRows} = mongoose_rdbms:sql_query(
+                            global, sql_get_subscriptions_rows(LU, LS, LR)),
+    StatesFull = build_states([], [], SubRows),
+    {ok, StatesFull ++ StatesBare}.
+
+-spec get_idxs_of_own_nodes_with_pending_subs(LJID :: jid:ljid()) ->
+    {ok, [mod_pubsub:nodeIdx()]}.
+get_idxs_of_own_nodes_with_pending_subs({ LU, LS, _ }) ->
+    {selected, Rows} = mongoose_rdbms:sql_query(
+                         global, sql_get_idxs_of_own_nodes_with_pending_subs(LU, LS)),
+    {ok, [ Nidx || {Nidx} <- Rows ]}.
+
+-spec del_state(Nidx :: mod_pubsub:nodeIdx(),
+                LJID :: jid:ljid()) -> ok.
+del_state(Nidx, {LU, LS, _} = LJID) ->
+    delete_all_subscriptions(Nidx, LJID),
+    delete_affiliation_wo_subs_check(Nidx, LU, LS),
+    {updated, _} = mongoose_rdbms:sql_query(global, sql_delete_node_entity_items(Nidx, LU, LS)),
+    ok.
+
+% ------------------- Node management --------------------------------
+
+-spec create_node(Nidx :: mod_pubsub:nodeIdx(), Owner :: jid:ljid()) -> ok.
+create_node(Nidx, LJID) ->
+    set_affiliation(Nidx, LJID, owner).
+
+% ------------------- Affiliations --------------------------------
+
+-spec set_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                      LJID :: jid:ljid(),
+                      Affiliation :: mod_pubsub:affiliation()) -> ok.
+set_affiliation(Nidx, { LU, LS, _ } = LJID, none) ->
+    BareLJID = jid:to_bare(LJID),
+    case get_node_entity_subscriptions(Nidx, BareLJID) of
+        [] ->
+            del_state(Nidx, BareLJID);
+        _ ->
+            delete_affiliation_wo_subs_check(Nidx, LU, LS)
+    end;
+set_affiliation(Nidx, { LU, LS, _ } = LJID, Affiliation) ->
+    %% TODO: Replace with proper upsert!!!
+    case get_affiliation(Nidx, LJID) of
+        {ok, none} ->
+            SQL = sql_insert_affiliation(Nidx, LU, LS, aff2int(Affiliation)),
+            {updated, _} = mongoose_rdbms:sql_query(global, SQL);
+        _ ->
+            SQL = sql_update_affiliation(Nidx, LU, LS, aff2int(Affiliation)),
+            {updated, _} = mongoose_rdbms:sql_query(global, SQL)
+    end,
+    ok.
+
+-spec get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                      LJID :: jid:ljid()) ->
+    {ok, mod_pubsub:affiliation()}.
+get_affiliation(Nidx, { LU, LS, _ }) ->
+    SQL = sql_get_affiliation(Nidx, LU, LS),
+    case mongoose_rdbms:sql_query(global, SQL) of
+        {selected, [{AffInt}]} ->
+            {ok, int2aff(AffInt)};
+        {selected, []} ->
+            {ok, none}
+    end.
+
+% ------------------- Subscriptions --------------------------------
+
+-spec add_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                       LJID :: jid:ljid(),
+                       Sub :: mod_pubsub:subscription(),
+                       SubId :: mod_pubsub:subId()) -> ok.
+add_subscription(Nidx, { LU, LS, LR }, Sub, SubId) ->
+    SQL = sql_insert_subscription(Nidx, LU, LS, LR, sub2int(Sub), SubId),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
+
+-spec get_node_subscriptions(Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [{Entity :: jid:ljid(), Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+get_node_subscriptions(Nidx) ->
+    SQL = sql_get_node_subs(Nidx),
+    {selected, QueryResult} = mongoose_rdbms:sql_query(global, SQL),
+    {ok, [{{LU, LS, LR}, int2sub(SubInt), SubId}
+          || {LU, LS, LR, SubInt, SubId} <- QueryResult ]}.
+
+-spec get_node_entity_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
+                                    LJID :: jid:ljid()) ->
+    {ok, [{Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+get_node_entity_subscriptions(Nidx, { LU, LS, LR }) ->
+    SQL = sql_get_node_entity_subs(Nidx, LU, LS, LR),
+    {selected, QueryResult} = mongoose_rdbms:sql_query(global, SQL),
+    {ok, [{int2sub(SubInt), SubId} || {SubInt, SubId} <- QueryResult ]}.
+
+-spec delete_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                          LJID :: jid:ljid(),
+                          SubId :: mod_pubsub:subId()) ->
+    ok.
+delete_subscription(Nidx, { LU, LS, LR }, SubId) ->
+    SQL = sql_delete_subscription(Nidx, LU, LS, LR, SubId),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
+
+-spec delete_all_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
+                               LJID :: jid:ljid()) ->
+    ok.
+delete_all_subscriptions(Nidx, { LU, LS, LR } = LJID) ->
+    case get_affiliation(Nidx, LJID) of
+        none ->
+            del_state(Nidx, LJID);
+        _ ->
+            SQL = sql_delete_all_subscriptions(Nidx, LU, LS, LR),
+            {updated, _} = mongoose_rdbms:sql_query(global, SQL)
+    end,
+    ok.
+
+-spec update_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                          LJID :: jid:ljid(),
+                          Subscription :: mod_pubsub:subscription(),
+                          SubId :: mod_pubsub:subId()) ->
+    ok.
+update_subscription(Nidx, { LU, LS, LR }, Subscription, SubId) ->
+    SQL = sql_update_subscription(Nidx, LU, LS, LR, sub2int(Subscription), SubId),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
+
+% ------------------- Items --------------------------------
+
+-spec add_item(Nidx :: mod_pubsub:nodeIdx(),
+               LJID :: jid:ljid(),
+               ItemId :: mod_pubsub:itemId()) ->
+    ok.
+add_item(Nidx, { LU, LS, _ }, ItemId) ->
+    SQL = sql_insert_item(Nidx, LU, LS, ItemId),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
+
+%% TODO: Make public at some point
+-spec get_entity_items(Nidx :: mod_pubsub:nodeIdx(),
+                       LJID :: jid:ljid()) ->
+    {ok, [mod_pubsub:itemId()]}.
+get_entity_items(Nidx, { LU, LS, _ }) ->
+    SQL = sql_get_entity_items(Nidx, LU, LS),
+    {selected, ItemIds} = mongoose_rdbms:sql_query(global, SQL),
+    {ok, [ ItemId || {ItemId} <- ItemIds]}.
+
+-spec remove_items(Nidx :: mod_pubsub:nodeIdx(),
+                   LJID :: jid:ljid(),
+                   ItemIds :: [mod_pubsub:itemId()]) ->
+    ok.
+remove_items(Nidx, { LU, LS, _ }, ItemIds) ->
+    lists:foreach(fun(ItemId) ->
+                          SQL = sql_delete_item(Nidx, LU, LS, ItemId),
+                          {updated, _} = mongoose_rdbms:sql_query(global, SQL)
+                  end, ItemIds).
+
+-spec remove_all_items(Nidx :: mod_pubsub:nodeIdx()) ->
+    ok.
+remove_all_items(Nidx) ->
+    SQL = sql_delete_all_items(Nidx),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
+
+%%====================================================================
+%% SQL queries
+%%====================================================================
+
+% -------------------- State building ----------------------------
+
+-spec sql_get_item_rows(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+sql_get_item_rows(Nidx) ->
+    ["SELECT nidx, luser, lserver, itemid FROM pubsub_items"
+    " WHERE nidx = ", esc_int(Nidx)].
+
+-spec sql_get_affiliation_rows(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+sql_get_affiliation_rows(Nidx) ->
+    ["SELECT nidx, luser, lserver, aff FROM pubsub_affiliations"
+    " WHERE nidx = ", esc_int(Nidx)].
+
+-spec sql_get_subscriptions_rows(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+sql_get_subscriptions_rows(Nidx) ->
+    ["SELECT nidx, luser, lserver, lresource, type, sub_id FROM pubsub_subscriptions"
+    " WHERE nidx = ", esc_int(Nidx)].
+
+-spec sql_get_item_rows(LU :: jid:luser(),
+                        LS :: jid:lserver()) -> iolist().
+sql_get_item_rows(LU, LS) ->
+    ["SELECT nidx, luser, lserver, itemid FROM pubsub_items"
+    " WHERE luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS)].
+
+-spec sql_get_affiliation_rows(LU :: jid:luser(),
+                               LS :: jid:lserver()) -> iolist().
+sql_get_affiliation_rows(LU, LS) ->
+    ["SELECT nidx, luser, lserver, aff FROM pubsub_affiliations"
+    " WHERE luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS)].
+
+-spec sql_get_subscriptions_rows(LU :: jid:luser(),
+                                 LS :: jid:lserver()) -> iolist().
+sql_get_subscriptions_rows(LU, LS) ->
+    ["SELECT nidx, luser, lserver, lresource, type, sub_id FROM pubsub_subscriptions"
+    " WHERE luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS)].
+
+-spec sql_get_subscriptions_rows(LU :: jid:luser(),
+                                 LS :: jid:lserver(),
+                                 LR :: jid:lresource()) -> iolist().
+sql_get_subscriptions_rows(LU, LS, LR) ->
+    ["SELECT nidx, luser, lserver, lresource, type, sub_id FROM pubsub_subscriptions"
+    " WHERE luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS),
+      " AND lresource = ", esc_string(LR)].
+
+-spec sql_get_idxs_of_own_nodes_with_pending_subs(LU :: jid:luser(),
+                                                  LS :: jid:lserver()) -> iolist().
+sql_get_idxs_of_own_nodes_with_pending_subs(LU, LS) ->
+    ["SELECT DISTINCT s.nidx"
+    " FROM pubsub_affiliations AS a INNER JOIN pubsub_subscriptions s ON a.nidx = s.nidx"
+    " WHERE a.aff = ", esc_int(aff2int(owner)),
+      " AND a.luser = ", esc_string(LU),
+      " AND a.lserver = ", esc_string(LS),
+      " AND s.type = ", esc_int(sub2int(pending))].
+
+-spec sql_delete_node_entity_items(Nidx :: mod_pubsub:nodeIdx(),
+                                   LU :: jid:luser(),
+                                   LS :: jid:lserver()) -> iolist().
+sql_delete_node_entity_items(Nidx, LU, LS) ->
+    ["DELETE FROM pubsub_items"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS)].
+
+% ------------------- Affiliations --------------------------------
+
+%% Due to lack of many specs in mod_pubsub and its submodules,
+%% sometimes it's very difficult to predict if we're going to
+%% get jid() or ljid()... Will be clarified in the future.
+
+-spec sql_insert_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                             LU :: jid:luser(),
+                             LS :: jid:lserver(),
+                             AffInt :: integer()) -> iolist().
+sql_insert_affiliation(Nidx, LU, LS, AffInt) ->
+    ["INSERT INTO pubsub_affiliations (nidx, luser, lserver, aff)"
+    " VALUES (", esc_int(Nidx), ", ",
+                 esc_string(LU), ", ",
+                 esc_string(LS), ", ",
+                 esc_int(AffInt), ")"].
+
+-spec sql_update_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                             LU :: jid:luser(),
+                             LS :: jid:lserver(),
+                             AffInt :: integer()) -> iolist().
+sql_update_affiliation(Nidx, LU, LS, AffInt) ->
+    ["UPDATE pubsub_affiliations"
+    " SET aff = ", esc_int(AffInt),
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS) ].
+
+-spec sql_get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                          LU :: jid:luser(),
+                          LS :: jid:lserver()) -> iolist().
+sql_get_affiliation(Nidx, LU, LS) ->
+    ["SELECT aff"
+    " FROM pubsub_affiliations"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS) ].
+
+-spec sql_delete_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                             LU :: jid:luser(),
+                             LS :: jid:lserver()) -> iolist().
+sql_delete_affiliation(Nidx, LU, LS) ->
+    ["DELETE FROM pubsub_affiliations"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS) ].
+
+% ------------------- Subscriptions --------------------------------
+
+-spec sql_insert_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                              LU :: jid:luser(),
+                              LS :: jid:lserver(),
+                              LR :: jid:lresource(),
+                              SubInt :: integer(),
+                              SubId :: binary()) -> iolist().
+sql_insert_subscription(Nidx, LU, LS, LR, SubInt, SubId) ->
+    ["INSERT INTO pubsub_subscriptions (nidx, luser, lserver, lresource, type, sub_id)"
+    " VALUES (", esc_int(Nidx), ", ",
+                 esc_string(LU), ", ",
+                 esc_string(LS), ", ",
+                 esc_string(LR), ", ",
+                 esc_int(SubInt), ", ",
+                 esc_string(SubId), ")"].
+
+-spec sql_get_node_subs(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+sql_get_node_subs(Nidx) ->
+    ["SELECT luser, lserver, lresource, type, sub_id"
+    " FROM pubsub_subscriptions"
+    " WHERE nidx = ", esc_int(Nidx)].
+
+-spec sql_get_node_entity_subs(Nidx :: mod_pubsub:nodeIdx(),
+                               LU :: jid:luser(),
+                               LS :: jid:lserver(),
+                               LR :: jid:lresource()) -> iolist().
+sql_get_node_entity_subs(Nidx, LU, LS, LR) ->
+    ["SELECT type, sub_id"
+    " FROM pubsub_subscriptions"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS),
+      " AND lresource = ", esc_string(LR)].
+
+-spec sql_delete_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                              LU :: jid:luser(),
+                              LS :: jid:lserver(),
+                              LR :: jid:lresource(),
+                              SubId :: binary()) -> iolist().
+sql_delete_subscription(Nidx, LU, LS, LR, SubId) ->
+    ["DELETE FROM pubsub_subscriptions"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS),
+      " AND lresource = ", esc_string(LR),
+      " AND sub_id = ", esc_string(SubId)].
+
+-spec sql_delete_all_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
+                                   LU :: jid:luser(),
+                                   LS :: jid:lserver(),
+                                   LR :: jid:lresource()) -> iolist().
+sql_delete_all_subscriptions(Nidx, LU, LS, LR) ->
+    ["DELETE FROM pubsub_subscriptions"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS),
+      " AND lresource = ", esc_string(LR)].
+
+-spec sql_update_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                              LU :: jid:luser(),
+                              LS :: jid:lserver(),
+                              LR :: jid:lresource(),
+                              SubInt :: integer(),
+                              SubId :: binary()) -> iolist().
+sql_update_subscription(Nidx, LU, LS, LR, SubInt, SubId) ->
+    ["UPDATE pubsub_subscriptions",
+    " SET type = ", esc_int(SubInt),
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS),
+      " AND lresource = ", esc_string(LR),
+      " AND sub_id = ", esc_string(SubId)].
+
+% ------------------- Items --------------------------------
+
+-spec sql_insert_item(Nidx :: mod_pubsub:nodeIdx(),
+                      LU :: jid:luser(),
+                      LS :: jid:lserver(),
+                      ItemId :: mod_pubsub:itemId()) -> iolist().
+sql_insert_item(Nidx, LU, LS, ItemId) ->
+    ["INSERT INTO pubsub_items (nidx, luser, lserver, itemid)"
+    " VALUES (", esc_int(Nidx), ", ",
+                 esc_string(LU), ", ",
+                 esc_string(LS), ", ",
+                 esc_string(ItemId), ")"].
+
+-spec sql_get_entity_items(Nidx :: mod_pubsub:nodeIdx(),
+                           LU :: jid:luser(),
+                           LS :: jid:lserver()) -> iolist().
+sql_get_entity_items(Nidx, LU, LS) ->
+    ["SELECT itemid"
+    " FROM pubsub_items"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS) ].
+
+-spec sql_delete_item(Nidx :: mod_pubsub:nodeIdx(),
+                      LU :: jid:luser(),
+                      LS :: jid:lserver(),
+                      ItemId :: mod_pubsub:nodeIdx()) -> iolist().
+sql_delete_item(Nidx, LU, LS, ItemId) ->
+    ["DELETE FROM pubsub_items"
+    " WHERE nidx = ", esc_int(Nidx),
+      " AND luser = ", esc_string(LU),
+      " AND lserver = ", esc_string(LS),
+      " AND itemid = ", esc_string(ItemId) ].
+
+-spec sql_delete_all_items(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+sql_delete_all_items(Nidx) ->
+    ["DELETE FROM pubsub_items"
+    " WHERE nidx = ", esc_int(Nidx)].
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+-spec delete_affiliation_wo_subs_check(Nidx :: mod_pubsub:nodeIdx(),
+                                       LU :: jid:luser(),
+                                       LS :: jid:lserver()) -> ok.
+delete_affiliation_wo_subs_check(Nidx, LU, LS) ->
+    SQL = sql_delete_affiliation(Nidx, LU, LS),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
+    ok.
+
+-type item_row() :: { Nidx :: mod_pubsub:nodeIdx(),
+                      LU :: binary(),
+                      LS :: binary(),
+                      ItemId :: binary() }.
+-type aff_row() :: { Nidx :: mod_pubsub:nodeIdx(),
+                     LU :: binary(),
+                     LS :: binary(),
+                     AffInt :: integer() }.
+-type sub_row() :: { Nidx :: mod_pubsub:nodeIdx(),
+                     LU :: binary(),
+                     LS :: binary(),
+                     LR :: binary(),
+                     TypeInt :: integer(),
+                     SubId :: binary() }.
+
+-spec build_states(ItemRows :: [item_row()], AffRows :: [aff_row()], SubRows :: [sub_row()]) ->
+    [mod_pubsub:pubsubState()].
+build_states(ItemRows, AffRows, SubRows) ->
+    Result1 = item_rows_to_states(ItemRows, #{}),
+    Result2 = aff_rows_to_states(AffRows, Result1),
+    maps:values(sub_rows_to_states(SubRows, Result2)).
+
+item_rows_to_states([], Acc) ->
+    Acc;
+item_rows_to_states([{ Nidx, LU, LS, ItemId } | RRows], Acc) ->
+    LJID = { LU, LS, <<>> },
+    #pubsub_state{ items = Items0 }
+    = PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    NAcc = Acc#{ {LJID, Nidx} => PS#pubsub_state{ items = [ItemId | Items0] } },
+    item_rows_to_states(RRows, NAcc).
+
+aff_rows_to_states([], Acc) ->
+    Acc;
+aff_rows_to_states([{ Nidx, LU, LS, AffInt } | RRows], Acc) ->
+    LJID = { LU, LS, <<>> },
+    PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    NAcc = Acc#{ {LJID, Nidx} => PS#pubsub_state{ affiliation = int2aff(AffInt) } },
+    aff_rows_to_states(RRows, NAcc).
+
+sub_rows_to_states([], Acc) ->
+    Acc;
+sub_rows_to_states([{ Nidx, LU, LS, LR, TypeInt, SubId } | RRows], Acc) ->
+    LJID = { LU, LS, LR },
+    #pubsub_state{ subscriptions = Subs0 }
+    = PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    NAcc = Acc#{ {LJID, Nidx} => PS#pubsub_state{
+                                subscriptions = [{int2sub(TypeInt), SubId} | Subs0] } },
+    sub_rows_to_states(RRows, NAcc).
+
+esc_string(String) ->
+    mongoose_rdbms:use_escaped_string(mongoose_rdbms:escape_string(String)).
+
+esc_int(Int) ->
+    mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).
+
+-spec aff2int(mod_pubsub:affiliation()) -> integer().
+aff2int(none) -> 0;
+aff2int(owner) -> 1;
+aff2int(publisher) -> 2;
+aff2int(publish_only) -> 3;
+aff2int(member) -> 4;
+aff2int(outcast) -> 5.
+
+-spec int2aff(integer()) -> mod_pubsub:affiliation().
+int2aff(0) -> none;
+int2aff(1) -> owner;
+int2aff(2) -> publisher;
+int2aff(3) -> publish_only;
+int2aff(4) -> member;
+int2aff(5) -> outcast.
+
+-spec sub2int(mod_pubsub:subscription()) -> integer().
+sub2int(none) -> 0;
+sub2int(pending) -> 1;
+sub2int(unconfigured) -> 2;
+sub2int(subscribed) -> 3.
+
+-spec int2sub(integer()) -> mod_pubsub:subscription().
+int2sub(0) -> none;
+int2sub(1) -> pending;
+int2sub(2) -> unconfigured;
+int2sub(3) -> subscribed.
+

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -44,7 +44,7 @@
         ]).
 % Whole items
 -export([
-         get_items/1,
+         get_items/2,
          get_item/2,
          set_item/1,
          del_item/2,
@@ -160,10 +160,10 @@ del_state(Nidx, {LU, LS, LR}) ->
 
 %% ------------------------ Direct #pubsub_item access ------------------------
 
--spec get_items(Nidx :: mod_pubsub:nodeIdx()) ->
+-spec get_items(Nidx :: mod_pubsub:nodeIdx(), gen_pubsub_node:get_item_options()) ->
     {ok, {[mod_pubsub:pubsubItem()], none}}.
-get_items(Nidx) ->
-    mod_pubsub_db_mnesia:get_items(Nidx).
+get_items(Nidx, Opts) ->
+    mod_pubsub_db_mnesia:get_items(Nidx, Opts).
 
 -spec get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
     {ok, mod_pubsub:pubsubItem()} | {error, item_not_found}.
@@ -281,9 +281,10 @@ update_subscription(Nidx, { LU, LS, LR }, Subscription, SubId) ->
 
 -spec add_item(Nidx :: mod_pubsub:nodeIdx(),
                LJID :: jid:ljid(),
-               ItemId :: mod_pubsub:itemId()) ->
+               Item :: mod_pubsub:pubsubItem()) ->
     ok.
-add_item(Nidx, { LU, LS, _ }, ItemId) ->
+add_item(Nidx, { LU, LS, _ }, #pubsub_item{ itemid = {ItemId, _} } = Item) ->
+    mod_pubsub_db_mnesia:set_item(Item),
     SQL = mod_pubsub_db_rdbms_sql:insert_item(Nidx, LU, LS, ItemId),
     {updated, _} = mongoose_rdbms:sql_query(global, SQL),
     ok.

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -36,12 +36,21 @@
          delete_all_subscriptions/2,
          update_subscription/4
         ]).
-% Items
+% Item ids in state
 -export([
          add_item/3,
          remove_items/3,
          remove_all_items/1
         ]).
+% Whole items
+-export([
+         get_items/1,
+         get_item/2,
+         set_item/1,
+         del_item/2,
+         del_items/2
+        ]).
+
 % For SQL queries
 -export([aff2int/1, sub2int/1]).
 
@@ -53,11 +62,11 @@
 
 -spec start() -> ok.
 start() ->
-    ok.
+    mod_pubsub_db_mnesia:start().
 
 -spec stop() -> ok.
 stop() ->
-    ok.
+    mod_pubsub_db_mnesia:stop().
 
 %% ------------------------ Fun execution ------------------------
 
@@ -148,6 +157,30 @@ del_state(Nidx, {LU, LS, LR}) ->
     DelItemsSQL = mod_pubsub_db_rdbms_sql:delete_node_entity_items(Nidx, LU, LS),
     {updated, _} = mongoose_rdbms:sql_query(global, DelItemsSQL),
     ok.
+
+%% ------------------------ Direct #pubsub_item access ------------------------
+
+-spec get_items(Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, {[mod_pubsub:pubsubItem()], none}}.
+get_items(Nidx) ->
+    mod_pubsub_db_mnesia:get_items(Nidx).
+
+-spec get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
+    {ok, mod_pubsub:pubsubItem()} | {error, item_not_found}.
+get_item(Nidx, ItemId) ->
+    mod_pubsub_db_mnesia:get_item(Nidx, ItemId).
+
+-spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.
+set_item(Item) ->
+    mod_pubsub_db_mnesia:set_item(Item).
+
+-spec del_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) -> ok.
+del_item(Nidx, ItemId) ->
+    mod_pubsub_db_mnesia:del_item(Nidx, ItemId).
+
+-spec del_items(Nidx :: mod_pubsub:nodeIdx(), [ItemId :: mod_pubsub:itemId()]) -> ok.
+del_items(Nidx, ItemIds) ->
+    mod_pubsub_db_mnesia:del_items(Nidx, ItemIds).
 
 % ------------------- Node management --------------------------------
 

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -335,8 +335,8 @@ item_rows_to_states([], Acc) ->
     Acc;
 item_rows_to_states([{ Nidx, LU, LS, ItemId } | RRows], Acc) ->
     LJID = { LU, LS, <<>> },
-    #pubsub_state{ items = Items0 }
-    = PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    #pubsub_state{ items = Items0 } = PS,
     NAcc = Acc#{ {LJID, Nidx} => PS#pubsub_state{ items = [ItemId | Items0] } },
     item_rows_to_states(RRows, NAcc).
 
@@ -352,8 +352,8 @@ sub_rows_to_states([], Acc) ->
     Acc;
 sub_rows_to_states([{ Nidx, LU, LS, LR, TypeInt, SubId } | RRows], Acc) ->
     LJID = { LU, LS, LR },
-    #pubsub_state{ subscriptions = Subs0 }
-    = PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
+    #pubsub_state{ subscriptions = Subs0 } = PS,
     NAcc = Acc#{ {LJID, Nidx} => PS#pubsub_state{
                                 subscriptions = [{sql2sub(TypeInt), SubId} | Subs0] } },
     sub_rows_to_states(RRows, NAcc).

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -138,7 +138,7 @@ get_states_by_bare_and_full({ LU, LS, LR } = LJID) ->
 get_idxs_of_own_nodes_with_pending_subs({ LU, LS, _ }) ->
     IdxsSQL = mod_pubsub_db_rdbms_sql:get_idxs_of_own_nodes_with_pending_subs(LU, LS),
     {selected, Rows} = mongoose_rdbms:sql_query(global, IdxsSQL),
-    {ok, [ Nidx || {Nidx} <- Rows ]}.
+    {ok, [ mongoose_rdbms:result_to_integer(Nidx) || {Nidx} <- Rows ]}.
 
 -spec del_state(Nidx :: mod_pubsub:nodeIdx(),
                 LJID :: jid:ljid()) -> ok.
@@ -168,16 +168,9 @@ set_affiliation(Nidx, { LU, LS, _ } = LJID, none) ->
         _ ->
             delete_affiliation_wo_subs_check(Nidx, LU, LS)
     end;
-set_affiliation(Nidx, { LU, LS, _ } = LJID, Affiliation) ->
-    %% TODO: Replace with proper upsert!!!
-    case get_affiliation(Nidx, LJID) of
-        {ok, none} ->
-            SQL = mod_pubsub_db_rdbms_sql:insert_affiliation(Nidx, LU, LS, aff2int(Affiliation)),
-            {updated, _} = mongoose_rdbms:sql_query(global, SQL);
-        _ ->
-            SQL = mod_pubsub_db_rdbms_sql:update_affiliation(Nidx, LU, LS, aff2int(Affiliation)),
-            {updated, _} = mongoose_rdbms:sql_query(global, SQL)
-    end,
+set_affiliation(Nidx, { LU, LS, _ }, Affiliation) ->
+    SQL = mod_pubsub_db_rdbms_sql:upsert_affiliation(Nidx, LU, LS, aff2int(Affiliation)),
+    {updated, _} = mongoose_rdbms:sql_query(global, SQL),
     ok.
 
 -spec get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
@@ -309,15 +302,15 @@ delete_affiliation_wo_subs_check(Nidx, LU, LS) ->
     {updated, _} = mongoose_rdbms:sql_query(global, SQL),
     ok.
 
--type item_row() :: { Nidx :: mod_pubsub:nodeIdx(),
+-type item_row() :: { NidxSql :: integer() | binary(),
                       LU :: binary(),
                       LS :: binary(),
                       ItemId :: binary() }.
--type aff_row() :: { Nidx :: mod_pubsub:nodeIdx(),
+-type aff_row() :: { NidxSql :: integer() | binary(),
                      LU :: binary(),
                      LS :: binary(),
                      AffInt :: integer() }.
--type sub_row() :: { Nidx :: mod_pubsub:nodeIdx(),
+-type sub_row() :: { NidxSql :: integer() | binary(),
                      LU :: binary(),
                      LS :: binary(),
                      LR :: binary(),
@@ -333,7 +326,8 @@ build_states(ItemRows, AffRows, SubRows) ->
 
 item_rows_to_states([], Acc) ->
     Acc;
-item_rows_to_states([{ Nidx, LU, LS, ItemId } | RRows], Acc) ->
+item_rows_to_states([{ NidxSql, LU, LS, ItemId } | RRows], Acc) ->
+    Nidx = mongoose_rdbms:result_to_integer(NidxSql),
     LJID = { LU, LS, <<>> },
     PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
     #pubsub_state{ items = Items0 } = PS,
@@ -342,7 +336,8 @@ item_rows_to_states([{ Nidx, LU, LS, ItemId } | RRows], Acc) ->
 
 aff_rows_to_states([], Acc) ->
     Acc;
-aff_rows_to_states([{ Nidx, LU, LS, AffInt } | RRows], Acc) ->
+aff_rows_to_states([{ NidxSql, LU, LS, AffInt } | RRows], Acc) ->
+    Nidx = mongoose_rdbms:result_to_integer(NidxSql),
     LJID = { LU, LS, <<>> },
     PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
     NAcc = Acc#{ {LJID, Nidx} => PS#pubsub_state{ affiliation = sql2aff(AffInt) } },
@@ -350,7 +345,8 @@ aff_rows_to_states([{ Nidx, LU, LS, AffInt } | RRows], Acc) ->
 
 sub_rows_to_states([], Acc) ->
     Acc;
-sub_rows_to_states([{ Nidx, LU, LS, LR, TypeInt, SubId } | RRows], Acc) ->
+sub_rows_to_states([{ NidxSql, LU, LS, LR, TypeInt, SubId } | RRows], Acc) ->
+    Nidx = mongoose_rdbms:result_to_integer(NidxSql),
     LJID = { LU, LS, LR },
     PS = maps:get({LJID, Nidx}, Acc, #pubsub_state{ stateid = {LJID, Nidx} }),
     #pubsub_state{ subscriptions = Subs0 } = PS,

--- a/src/pubsub/mod_pubsub_db_rdbms_sql.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms_sql.erl
@@ -166,7 +166,7 @@ upsert_affiliation_mssql(Nidx, LU, LS, AffInt) ->
          " SET aff = ", EscAffInt,
      " WHEN NOT MATCHED THEN INSERT"
          " (nidx, luser, lserver, aff)"
-         " VALUES (", EscNidx, ", ", EscLU, ", ", EscLS, ", ", EscAffInt, ")"].
+         " VALUES (", EscNidx, ", ", EscLU, ", ", EscLS, ", ", EscAffInt, ");"].
 
 -spec get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
                       LU :: jid:luser(),

--- a/src/pubsub/mod_pubsub_db_rdbms_sql.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms_sql.erl
@@ -1,0 +1,289 @@
+%%%----------------------------------------------------------------------
+%%% File    : mod_pubsub_db_rdbms_sql.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : SQL queries for PubSub RDBMS backend
+%%% Created : 15 Nov 2018 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%%----------------------------------------------------------------------
+
+-module(mod_pubsub_db_rdbms_sql).
+-author('piotr.nosek@erlang-solutions.com').
+
+% State building
+-export([
+         get_item_rows/1,
+         get_affiliation_rows/1,
+         get_subscriptions_rows/1,
+         get_item_rows/2,
+         get_affiliation_rows/2,
+         get_subscriptions_rows/2,
+         get_subscriptions_rows/3,
+         get_idxs_of_own_nodes_with_pending_subs/2,
+         delete_node_entity_items/3
+        ]).
+
+% Affiliations
+-export([
+         insert_affiliation/4,
+         update_affiliation/4,
+         get_affiliation/3,
+         delete_affiliation/3
+        ]).
+
+% Subscriptions
+-export([
+         insert_subscription/6,
+         get_node_subs/1,
+         get_node_entity_subs/4,
+         delete_subscription/5,
+         delete_all_subscriptions/4,
+         update_subscription/6
+        ]).
+
+% Items
+-export([
+         insert_item/4,
+         get_entity_items/3,
+         delete_item/4,
+         delete_all_items/1
+        ]).
+
+%%====================================================================
+%% SQL queries
+%%====================================================================
+
+% -------------------- State building ----------------------------
+
+-spec get_item_rows(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+get_item_rows(Nidx) ->
+    ["SELECT nidx, luser, lserver, itemid FROM pubsub_items"
+     " WHERE nidx = ", esc_int(Nidx)].
+
+-spec get_affiliation_rows(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+get_affiliation_rows(Nidx) ->
+    ["SELECT nidx, luser, lserver, aff FROM pubsub_affiliations"
+     " WHERE nidx = ", esc_int(Nidx)].
+
+-spec get_subscriptions_rows(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+get_subscriptions_rows(Nidx) ->
+    ["SELECT nidx, luser, lserver, lresource, type, sub_id FROM pubsub_subscriptions"
+     " WHERE nidx = ", esc_int(Nidx)].
+
+-spec get_item_rows(LU :: jid:luser(),
+                    LS :: jid:lserver()) -> iolist().
+get_item_rows(LU, LS) ->
+    ["SELECT nidx, luser, lserver, itemid FROM pubsub_items"
+     " WHERE luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS)].
+
+-spec get_affiliation_rows(LU :: jid:luser(),
+                           LS :: jid:lserver()) -> iolist().
+get_affiliation_rows(LU, LS) ->
+    ["SELECT nidx, luser, lserver, aff FROM pubsub_affiliations"
+     " WHERE luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS)].
+
+-spec get_subscriptions_rows(LU :: jid:luser(),
+                             LS :: jid:lserver()) -> iolist().
+get_subscriptions_rows(LU, LS) ->
+    ["SELECT nidx, luser, lserver, lresource, type, sub_id FROM pubsub_subscriptions"
+     " WHERE luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS)].
+
+-spec get_subscriptions_rows(LU :: jid:luser(),
+                             LS :: jid:lserver(),
+                             LR :: jid:lresource()) -> iolist().
+get_subscriptions_rows(LU, LS, LR) ->
+    ["SELECT nidx, luser, lserver, lresource, type, sub_id FROM pubsub_subscriptions"
+     " WHERE luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS),
+     " AND lresource = ", esc_string(LR)].
+
+-spec get_idxs_of_own_nodes_with_pending_subs(LU :: jid:luser(),
+                                              LS :: jid:lserver()) -> iolist().
+get_idxs_of_own_nodes_with_pending_subs(LU, LS) ->
+    ["SELECT DISTINCT s.nidx"
+     " FROM pubsub_affiliations AS a INNER JOIN pubsub_subscriptions s ON a.nidx = s.nidx"
+     " WHERE a.aff = ", esc_int(mod_pubsub_db_rdbms:aff2int(owner)),
+     " AND a.luser = ", esc_string(LU),
+     " AND a.lserver = ", esc_string(LS),
+     " AND s.type = ", esc_int(mod_pubsub_db_rdbms:sub2int(pending))].
+
+-spec delete_node_entity_items(Nidx :: mod_pubsub:nodeIdx(),
+                               LU :: jid:luser(),
+                               LS :: jid:lserver()) -> iolist().
+delete_node_entity_items(Nidx, LU, LS) ->
+    ["DELETE FROM pubsub_items"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS)].
+
+% ------------------- Affiliations --------------------------------
+
+%% Due to lack of many specs in mod_pubsub and its submodules,
+%% sometimes it's very difficult to predict if we're going to
+%% get jid() or ljid()... Will be clarified in the future.
+
+-spec insert_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                         LU :: jid:luser(),
+                         LS :: jid:lserver(),
+                         AffInt :: integer()) -> iolist().
+insert_affiliation(Nidx, LU, LS, AffInt) ->
+    ["INSERT INTO pubsub_affiliations (nidx, luser, lserver, aff)"
+     " VALUES (", esc_int(Nidx), ", ",
+     esc_string(LU), ", ",
+     esc_string(LS), ", ",
+     esc_int(AffInt), ")"].
+
+-spec update_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                         LU :: jid:luser(),
+                         LS :: jid:lserver(),
+                         AffInt :: integer()) -> iolist().
+update_affiliation(Nidx, LU, LS, AffInt) ->
+    ["UPDATE pubsub_affiliations"
+     " SET aff = ", esc_int(AffInt),
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS) ].
+
+-spec get_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                      LU :: jid:luser(),
+                      LS :: jid:lserver()) -> iolist().
+get_affiliation(Nidx, LU, LS) ->
+    ["SELECT aff"
+     " FROM pubsub_affiliations"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS) ].
+
+-spec delete_affiliation(Nidx :: mod_pubsub:nodeIdx(),
+                         LU :: jid:luser(),
+                         LS :: jid:lserver()) -> iolist().
+delete_affiliation(Nidx, LU, LS) ->
+    ["DELETE FROM pubsub_affiliations"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS) ].
+
+% ------------------- Subscriptions --------------------------------
+
+-spec insert_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                          LU :: jid:luser(),
+                          LS :: jid:lserver(),
+                          LR :: jid:lresource(),
+                          SubInt :: integer(),
+                          SubId :: binary()) -> iolist().
+insert_subscription(Nidx, LU, LS, LR, SubInt, SubId) ->
+    ["INSERT INTO pubsub_subscriptions (nidx, luser, lserver, lresource, type, sub_id)"
+     " VALUES (", esc_int(Nidx), ", ",
+     esc_string(LU), ", ",
+     esc_string(LS), ", ",
+     esc_string(LR), ", ",
+     esc_int(SubInt), ", ",
+     esc_string(SubId), ")"].
+
+-spec get_node_subs(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+get_node_subs(Nidx) ->
+    ["SELECT luser, lserver, lresource, type, sub_id"
+     " FROM pubsub_subscriptions"
+     " WHERE nidx = ", esc_int(Nidx)].
+
+-spec get_node_entity_subs(Nidx :: mod_pubsub:nodeIdx(),
+                           LU :: jid:luser(),
+                           LS :: jid:lserver(),
+                           LR :: jid:lresource()) -> iolist().
+get_node_entity_subs(Nidx, LU, LS, LR) ->
+    ["SELECT type, sub_id"
+     " FROM pubsub_subscriptions"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS),
+     " AND lresource = ", esc_string(LR)].
+
+-spec delete_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                          LU :: jid:luser(),
+                          LS :: jid:lserver(),
+                          LR :: jid:lresource(),
+                          SubId :: binary()) -> iolist().
+delete_subscription(Nidx, LU, LS, LR, SubId) ->
+    ["DELETE FROM pubsub_subscriptions"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS),
+     " AND lresource = ", esc_string(LR),
+     " AND sub_id = ", esc_string(SubId)].
+
+-spec delete_all_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
+                               LU :: jid:luser(),
+                               LS :: jid:lserver(),
+                               LR :: jid:lresource()) -> iolist().
+delete_all_subscriptions(Nidx, LU, LS, LR) ->
+    ["DELETE FROM pubsub_subscriptions"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS),
+     " AND lresource = ", esc_string(LR)].
+
+-spec update_subscription(Nidx :: mod_pubsub:nodeIdx(),
+                          LU :: jid:luser(),
+                          LS :: jid:lserver(),
+                          LR :: jid:lresource(),
+                          SubInt :: integer(),
+                          SubId :: binary()) -> iolist().
+update_subscription(Nidx, LU, LS, LR, SubInt, SubId) ->
+    ["UPDATE pubsub_subscriptions",
+     " SET type = ", esc_int(SubInt),
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS),
+     " AND lresource = ", esc_string(LR),
+     " AND sub_id = ", esc_string(SubId)].
+
+% ------------------- Items --------------------------------
+
+-spec insert_item(Nidx :: mod_pubsub:nodeIdx(),
+                  LU :: jid:luser(),
+                  LS :: jid:lserver(),
+                  ItemId :: mod_pubsub:itemId()) -> iolist().
+insert_item(Nidx, LU, LS, ItemId) ->
+    ["INSERT INTO pubsub_items (nidx, luser, lserver, itemid)"
+     " VALUES (", esc_int(Nidx), ", ",
+     esc_string(LU), ", ",
+     esc_string(LS), ", ",
+     esc_string(ItemId), ")"].
+
+-spec get_entity_items(Nidx :: mod_pubsub:nodeIdx(),
+                       LU :: jid:luser(),
+                       LS :: jid:lserver()) -> iolist().
+get_entity_items(Nidx, LU, LS) ->
+    ["SELECT itemid"
+     " FROM pubsub_items"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS) ].
+
+-spec delete_item(Nidx :: mod_pubsub:nodeIdx(),
+                  LU :: jid:luser(),
+                  LS :: jid:lserver(),
+                  ItemId :: mod_pubsub:itemId()) -> iolist().
+delete_item(Nidx, LU, LS, ItemId) ->
+    ["DELETE FROM pubsub_items"
+     " WHERE nidx = ", esc_int(Nidx),
+     " AND luser = ", esc_string(LU),
+     " AND lserver = ", esc_string(LS),
+     " AND itemid = ", esc_string(ItemId) ].
+
+-spec delete_all_items(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+delete_all_items(Nidx) ->
+    ["DELETE FROM pubsub_items"
+     " WHERE nidx = ", esc_int(Nidx)].
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+esc_string(String) ->
+    mongoose_rdbms:use_escaped_string(mongoose_rdbms:escape_string(String)).
+
+esc_int(Int) ->
+    mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).
+

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -115,10 +115,12 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     end.
 
 get_entity_affiliations(Host, #jid{ lserver = D } = Owner) ->
-    get_entity_affiliations(Host, D, Owner);
+    get_entity_affiliations(Host, D, jid:to_lower(Owner));
 get_entity_affiliations(Host, {_, D, _} = Owner) ->
     get_entity_affiliations(Host, D, Owner).
 
+get_entity_affiliations(Host, D, #jid{} = Owner) ->
+     get_entity_affiliations(Host, D, jid:to_lower(Owner));
 get_entity_affiliations(Host, D, Owner) ->
     {ok, States} = mod_pubsub_db_backend:get_states_by_bare(Owner),
     NodeTree = mod_pubsub:tree(Host),

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -137,12 +137,13 @@ get_entity_subscriptions(Host, {_, D, R} = Owner) ->
     get_entity_subscriptions(Host, D, R, Owner).
 
 get_entity_subscriptions(Host, D, R, Owner) ->
+    LOwner = jid:to_lower(Owner),
     States = case R of
                  <<>> ->
-                     {ok, States0} = mod_pubsub_db_backend:get_states_by_lus(Owner),
+                     {ok, States0} = mod_pubsub_db_backend:get_states_by_lus(LOwner),
                      States0;
                  _ ->
-                     {ok, States0} = mod_pubsub_db_backend:get_states_by_bare_and_full(Owner),
+                     {ok, States0} = mod_pubsub_db_backend:get_states_by_bare_and_full(LOwner),
                      States0
              end,
     NodeTree = mod_pubsub:tree(Host),

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -119,8 +119,6 @@ get_entity_affiliations(Host, #jid{ lserver = D } = Owner) ->
 get_entity_affiliations(Host, {_, D, _} = Owner) ->
     get_entity_affiliations(Host, D, Owner).
 
-get_entity_affiliations(Host, D, #jid{} = Owner) ->
-     get_entity_affiliations(Host, D, jid:to_lower(Owner));
 get_entity_affiliations(Host, D, Owner) ->
     {ok, States} = mod_pubsub_db_backend:get_states_by_bare(Owner),
     NodeTree = mod_pubsub:tree(Host),

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -62,7 +62,7 @@ features() ->
 
 publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublisher, Payload,
              PublishOptions) ->
-    Affiliation = mod_pubsub_db_backend:get_affiliation(Nidx, Publisher),
+    Affiliation = mod_pubsub_db_backend:get_affiliation(Nidx, jid:to_lower(Publisher)),
     ElPayload = [El || #xmlel{} = El <- Payload],
 
     case is_allowed_to_publish(Model, Affiliation) of


### PR DESCRIPTION
This PR adds PubSub RDBMS backend for `pubsub_state` operations.

- [x] Optimise some calls (e.g. affiliations upsert)
- [x] Update docs
- [x] Add indices to schema
- [x] Add support for MSSQL
- [x] Add support for PgSQL
- [x] Extract SQL queries to separate file

*Notes:*

- I have switched the input format of JIDs for backends to `jid:ljid()` as unfortunately `mod_pubsub` is a bit careless about what it passes (`jid()` vs. `ljid()`) to the node implementations. I've decided it makes more sense to reduce `jid()` to `ljid()` when necessary than the other way around.
- At some point `del_state` operation shouldn't be necessary, as items table will be expanded and no longer should be cleared e.g. when a user is removed from the node.

