### PR TITLE
Pubsub refactoring for more efficient pubsub item in rdbms

### DIFF
--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -46,13 +46,16 @@
 -type(publishModel() :: mod_pubsub:publishModel()).
 -type(payload() :: mod_pubsub:payload()).
 -type(publishOptions() :: mod_pubsub:publishOptions()).
--type(get_item_options() :: #{access_model := accessModel(),
-                              presence_permission := boolean(),
-                              roster_permission := boolean(),
-                              rsm := none | jlib:rsm_in(),
-                              max_items => non_neg_integer(),
-                              item_ids => [itemId()],
-                              subscription_id => subId()}).
+-type(get_authorised_item_options() :: #{access_model := accessModel(),
+                                         presence_permission := boolean(),
+                                         roster_permission := boolean(),
+                                         rsm := none | jlib:rsm_in(),
+                                         max_items => non_neg_integer(),
+                                         item_ids => [itemId()],
+                                         subscription_id => subId()}).
+-type(get_item_options() :: #{rsm => none | jlib:rms_in(),
+                              max_items => undefined | non_neg_integer(),
+                              item_ids => undefined | [itemId()]}).
 
 -export([
          terminate/3,
@@ -60,6 +63,8 @@
          features/1,
          node_to_path/2
         ]).
+
+-export_type([get_item_options/0]).
 
 %% --------------------------------------------------------
 %% Callbacks
@@ -166,10 +171,10 @@
 
 -callback get_pending_nodes(Host :: host(), Owner :: jid:jid()) -> {result, [nodeId()]}.
 
--callback get_items_if_authorised(NodeIdx :: nodeIdx(), JID :: jid:jid(), get_item_options()) ->
+-callback get_items_if_authorised(NodeIdx :: nodeIdx(), JID :: jid:jid(), get_authorised_item_options()) ->
     {result, {[pubsubItem()], none | jlib:rsm_out()}} | {error, exml:element()}.
 
--callback get_items(NodeIdx :: nodeIdx(), From :: jid:jid(), RSM :: none | jlib:rsm_in()) ->
+-callback get_items(NodeIdx :: nodeIdx(), From :: jid:jid(), get_item_options()) ->
     {result, {[pubsubItem()], none | jlib:rsm_out()}}.
 
 -callback get_item(NodeIdx :: nodeIdx(),

--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -57,7 +57,7 @@
                               max_items => undefined | non_neg_integer(),
                               item_ids => undefined | [itemId()]}).
 
--export([
+-export([based_on/1,
          terminate/3,
          options/1,
          features/1,
@@ -69,6 +69,11 @@
 %% --------------------------------------------------------
 %% Callbacks
 %% --------------------------------------------------------
+
+%% @doc
+%% This function is to call the base node module in case the target node doesn't
+%% implement an optional callback
+-callback based_on() -> node_flat | node_hometree | node_dag | node_push | node_pep | none.
 
 -callback init(Host :: binary(), ServerHost :: binary(), Opts :: [any()]) -> atom().
 
@@ -225,6 +230,8 @@
 %% --------------------------------------------------------
 %% API
 %% --------------------------------------------------------
+based_on(Mod) ->
+    Mod:based_on().
 
 terminate(Mod, Host, ServerHost) ->
     Mod:terminate(Host, ServerHost).

--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -37,7 +37,6 @@
 -type(nodeIdx() :: mod_pubsub:nodeIdx()).
 -type(itemId() :: mod_pubsub:itemId()).
 -type(pubsubNode() :: mod_pubsub:pubsubNode()).
--type(pubsubState() :: mod_pubsub:pubsubState()).
 -type(pubsubItem() :: mod_pubsub:pubsubItem()).
 -type(subOptions() :: mod_pubsub:subOptions()).
 -type(affiliation() :: mod_pubsub:affiliation()).
@@ -49,35 +48,10 @@
 -type(publishOptions() :: mod_pubsub:publishOptions()).
 
 -export([
-         init/4,
          terminate/3,
          options/1,
          features/1,
-         create_node_permission/7,
-         create_node/3,
-         delete_node/2,
-         purge_node/3,
-         subscribe_node/9,
-         unsubscribe_node/5,
-         publish_item/10,
-         delete_item/5,
-         remove_extra_items/4,
-         get_node_affiliations/2,
-         get_entity_affiliations/3,
-         get_affiliation/3,
-         set_affiliation/4,
-         get_node_subscriptions/2,
-         get_entity_subscriptions/3,
-         get_subscriptions/3,
-         get_pending_nodes/3,
-         get_items/8,
-         get_items/4,
-         get_item/8,
-         get_item/3,
-         set_item/2,
-         get_item_name/4,
-         node_to_path/2,
-         path_to_node/2
+         node_to_path/2
         ]).
 
 %% --------------------------------------------------------
@@ -217,12 +191,34 @@
 
 -callback path_to_node(Path :: [nodeId()]) -> nodeId().
 
+-optional_callbacks([create_node_permission/6,
+                     create_node/2,
+                     delete_node/1,
+                     purge_node/2,
+                     subscribe_node/8,
+                     unsubscribe_node/4,
+                     publish_item/9,
+                     delete_item/4,
+                     remove_extra_items/3,
+                     get_node_affiliations/1,
+                     get_entity_affiliations/2,
+                     get_affiliation/2,
+                     set_affiliation/3,
+                     get_node_subscriptions/1,
+                     get_entity_subscriptions/2,
+                     get_subscriptions/2,
+                     get_pending_nodes/2,
+                     get_items/7,
+                     get_items/3,
+                     get_item/7,
+                     get_item/2,
+                     set_item/1,
+                     get_item_name/3,
+                     path_to_node/1]).
+
 %% --------------------------------------------------------
 %% API
 %% --------------------------------------------------------
-
-init(Mod, Host, ServerHost, Opts) ->
-    Mod:init(Host, ServerHost, Opts).
 
 terminate(Mod, Host, ServerHost) ->
     Mod:terminate(Host, ServerHost).
@@ -233,82 +229,6 @@ options(Mod) ->
 features(Mod) ->
     Mod:features().
 
-create_node_permission(Mod, Host, ServerHost, Node, ParentNode, Owner, Access) ->
-    Mod:create_node_permission(Host, ServerHost, Node, ParentNode, Owner, Access).
-
-create_node(Mod, NodeIdx, Owner) ->
-    Mod:create_node(NodeIdx, Owner).
-
-delete_node(Mod, Nodes) ->
-    Mod:delete_node(Nodes).
-
-purge_node(Mod, NodeIdx, Owner) ->
-    Mod:purge_node(NodeIdx, Owner).
-
-subscribe_node(Mod, NodeIdx, Sender, Subscriber, AccessModel, SendLast, PresenceSubscription,
-               RosterGroup, Options) ->
-    Mod:subscribe_node(NodeIdx, Sender, Subscriber, AccessModel, SendLast, PresenceSubscription,
-                       RosterGroup, Options).
-
-unsubscribe_node(Mod, NodeIdx, Sender, Subscriber, SubId) ->
-    Mod:unsubscribe_node(NodeIdx, Sender, Subscriber, SubId).
-
-publish_item(Mod, ServerHost, NodeId, Publisher, PublishModel, MaxItems, ItemId,
-             ItemPublisher, Payload, PublishOptions) ->
-    Mod:publish_item(ServerHost, NodeId, Publisher, PublishModel, MaxItems, ItemId,
-                     ItemPublisher, Payload, PublishOptions).
-
-delete_item(Mod, NodeIdx, Publisher, PublishModel, ItemId) ->
-    Mod:delete_item(NodeIdx, Publisher, PublishModel, ItemId).
-
-remove_extra_items(Mod, NodeIdx, MaxItems, ItemIds) ->
-    Mod:remove_extra_items(NodeIdx, MaxItems, ItemIds).
-
-get_node_affiliations(Mod, NodeIdx) ->
-    Mod:get_node_affiliations(NodeIdx).
-
-get_entity_affiliations(Mod, Host, Owner) ->
-    Mod:get_entity_affiliations(Host, Owner).
-
-get_affiliation(Mod, NodeIdx, Owner) ->
-    Mod:get_affiliation(NodeIdx, Owner).
-
-set_affiliation(Mod, NodeIdx, Owner, Affiliation) ->
-    Mod:set_affiliation(NodeIdx, Owner, Affiliation).
-
-get_node_subscriptions(Mod, NodeIdx) ->
-    Mod:get_node_subscriptions(NodeIdx).
-
-get_entity_subscriptions(Mod, Host, Key) ->
-    Mod:get_entity_subscriptions(Host, Key).
-
-get_subscriptions(Mod, NodeIdx, Owner) ->
-    Mod:get_subscriptions(NodeIdx, Owner).
-
-get_pending_nodes(Mod, Host, Owner) ->
-    Mod:get_pending_nodes(Host, Owner).
-
-get_items(Mod, NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
-    Mod:get_items(NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM).
-
-get_items(Mod, NodeIdx, From, RSM) ->
-    Mod:get_items(NodeIdx, From, RSM).
-
-get_item(Mod, NodeIdx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, SubId) ->
-    Mod:get_item(NodeIdx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, SubId).
-
-get_item(Mod, NodeIdx, ItemId) ->
-    Mod:get_item(NodeIdx, ItemId).
-
-set_item(Mod, Item) ->
-    Mod:set_item(Item).
-
-get_item_name(Mod, Host, ServerHost, Node) ->
-    Mod:get_item_name(Host, ServerHost, Node).
-
 node_to_path(Mod, Node) ->
     Mod:node_to_path(Node).
-
-path_to_node(Mod, Path) ->
-    Mod:path_to_node(Path).
 

--- a/src/pubsub/gen_pubsub_node.erl
+++ b/src/pubsub/gen_pubsub_node.erl
@@ -46,6 +46,13 @@
 -type(publishModel() :: mod_pubsub:publishModel()).
 -type(payload() :: mod_pubsub:payload()).
 -type(publishOptions() :: mod_pubsub:publishOptions()).
+-type(get_item_options() :: #{access_model := accessModel(),
+                              presence_permission := boolean(),
+                              roster_permission := boolean(),
+                              rsm := none | jlib:rsm_in(),
+                              max_items => non_neg_integer(),
+                              item_ids => [itemId()],
+                              subscription_id => subId()}).
 
 -export([
          terminate/3,
@@ -159,13 +166,7 @@
 
 -callback get_pending_nodes(Host :: host(), Owner :: jid:jid()) -> {result, [nodeId()]}.
 
--callback get_items(NodeIdx :: nodeIdx(),
-        JID :: jid:jid(),
-        AccessModel :: accessModel(),
-        PresenceSubscription :: boolean(),
-        RosterGroup :: boolean(),
-        SubId :: subId(),
-        RSM :: none | jlib:rsm_in()) ->
+-callback get_items_if_authorised(NodeIdx :: nodeIdx(), JID :: jid:jid(), get_item_options()) ->
     {result, {[pubsubItem()], none | jlib:rsm_out()}} | {error, exml:element()}.
 
 -callback get_items(NodeIdx :: nodeIdx(), From :: jid:jid(), RSM :: none | jlib:rsm_in()) ->
@@ -208,7 +209,7 @@
                      get_entity_subscriptions/2,
                      get_subscriptions/2,
                      get_pending_nodes/2,
-                     get_items/7,
+                     get_items_if_authorised/3,
                      get_items/3,
                      get_item/7,
                      get_item/2,

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -4196,7 +4196,14 @@ maybe_default_node(PluginModule, Function, Args) ->
         true ->
             PluginModule;
         _ ->
-            ?STDNODE_MODULE
+           case gen_pubsub_node:based_on(PluginModule) of
+               none ->
+                   ?ERROR_MSG("event=undefined_function, node_plugin=~p, function=~p",
+                              [PluginModule, Function]),
+                   exit(udefined_node_plugin_function);
+               BaseModule ->
+                   maybe_default_node(BaseModule, Function, Args)
+           end
     end.
 
 node_action(Host, Type, Function, Args) ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -113,7 +113,7 @@
 %% won't be necessary and the whole operation may be optimised in DB layer.
 -callback add_item(Nidx :: mod_pubsub:nodeIdx(),
                    JID :: jid:jid(),
-                   ItemId :: mod_pubsub:itemId()) ->
+                   ItemId :: mod_pubsub:pubsubItem()) ->
     ok.
 
 -callback remove_items(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -124,7 +124,7 @@
 -callback remove_all_items(Nidx :: mod_pubsub:nodeIdx()) ->
     ok.
 
--callback get_items(Nidx :: mod_pubsub:nodeIdx()) ->
+-callback get_items(Nidx :: mod_pubsub:nodeIdx(), gen_pubsub_node:get_item_options()) ->
     {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out()}}.
 
 -callback get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -259,9 +259,10 @@ remove_all_items(Nidx) ->
 
 -spec add_item(Nidx :: mod_pubsub:nodeIdx(),
                JID :: jid:jid(),
-               ItemId :: mod_pubsub:itemId()) ->
+               ItemId :: mod_pubsub:pubsubItem()) ->
     ok.
-add_item(Nidx, JID, ItemId) ->
+add_item(Nidx, JID, #pubsub_item{itemid = {ItemId, _}} = Item) ->
+    set_item(Item),
     {ok, State} = get_state(Nidx, jid:to_bare(JID), write),
     NewItems = [ItemId | State#pubsub_state.items],
     mnesia:write(State#pubsub_state{ items = NewItems }).

--- a/src/pubsub/node_dag.erl
+++ b/src/pubsub/node_dag.erl
@@ -24,9 +24,11 @@
 -include("pubsub.hrl").
 -include("jlib.hrl").
 
--export([init/3, terminate/2, options/0, features/0,
+-export([based_on/0, init/3, terminate/2, options/0, features/0,
          create_node_permission/6, publish_item/9, node_to_path/1,
          path_to_node/1]).
+
+based_on() -> node_hometree.
 
 init(Host, ServerHost, Opts) ->
     node_flat:init(Host, ServerHost, Opts).

--- a/src/pubsub/node_dag.erl
+++ b/src/pubsub/node_dag.erl
@@ -25,16 +25,7 @@
 -include("jlib.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
-         create_node_permission/6, create_node/2, delete_node/1,
-         purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/9, delete_item/4, remove_extra_items/3,
-         get_entity_affiliations/2, get_node_affiliations/1,
-         get_affiliation/2, set_affiliation/3,
-         get_entity_subscriptions/2, get_node_subscriptions/1,
-         get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2,
-         get_items/7, get_items/3, get_item/7,
-         get_item/2, set_item/1, get_item_name/3, node_to_path/1,
+         create_node_permission/6, publish_item/9, node_to_path/1,
          path_to_node/1]).
 
 init(Host, ServerHost, Opts) ->
@@ -52,20 +43,6 @@ features() ->
 create_node_permission(_Host, _ServerHost, _Node, _ParentNode, _Owner, _Access) ->
     {result, true}.
 
-create_node(Nidx, Owner) ->
-    node_hometree:create_node(Nidx, Owner).
-
-delete_node(Removed) ->
-    node_hometree:delete_node(Removed).
-
-subscribe_node(Nidx, Sender, Subscriber, AccessModel,
-            SendLast, PresenceSubscription, RosterGroup, Options) ->
-    node_hometree:subscribe_node(Nidx, Sender, Subscriber, AccessModel, SendLast,
-        PresenceSubscription, RosterGroup, Options).
-
-unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
-    node_hometree:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
-
 publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
              PublishOptions) ->
     case nodetree_dag:get_node(Nidx) of
@@ -75,8 +52,8 @@ publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher
                     {error,
                         ?ERR_EXTENDED((mongoose_xmpp_errors:not_allowed()), <<"publish">>)};
                 _ ->
-                    node_hometree:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems,
-                                               ItemId, ItemPublisher, Payload, PublishOptions)
+                    node_flat:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems,
+                                           ItemId, ItemPublisher, Payload, PublishOptions)
             end;
         Err -> Err
     end.
@@ -84,62 +61,6 @@ publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher
 find_opt(_, []) -> false;
 find_opt(Option, [{Option, Value} | _]) -> Value;
 find_opt(Option, [_ | T]) -> find_opt(Option, T).
-
-remove_extra_items(Nidx, MaxItems, ItemIds) ->
-    node_hometree:remove_extra_items(Nidx, MaxItems, ItemIds).
-
-delete_item(Nidx, Publisher, PublishModel, ItemId) ->
-    node_hometree:delete_item(Nidx, Publisher, PublishModel, ItemId).
-
-purge_node(Nidx, Owner) ->
-    node_hometree:purge_node(Nidx, Owner).
-
-get_entity_affiliations(Host, Owner) ->
-    node_hometree:get_entity_affiliations(Host, Owner).
-
-get_node_affiliations(Nidx) ->
-    node_hometree:get_node_affiliations(Nidx).
-
-get_affiliation(Nidx, Owner) ->
-    node_hometree:get_affiliation(Nidx, Owner).
-
-set_affiliation(Nidx, Owner, Affiliation) ->
-    node_hometree:set_affiliation(Nidx, Owner, Affiliation).
-
-get_entity_subscriptions(Host, Owner) ->
-    node_hometree:get_entity_subscriptions(Host, Owner).
-
-get_node_subscriptions(Nidx) ->
-    node_hometree:get_node_subscriptions(Nidx).
-
-get_subscriptions(Nidx, Owner) ->
-    node_hometree:get_subscriptions(Nidx, Owner).
-
-set_subscriptions(Nidx, Owner, Subscription, SubId) ->
-    node_hometree:set_subscriptions(Nidx, Owner, Subscription, SubId).
-
-get_pending_nodes(Host, Owner) ->
-    node_hometree:get_pending_nodes(Host, Owner).
-
-get_items(Nidx, From, RSM) ->
-    node_hometree:get_items(Nidx, From, RSM).
-
-get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
-    node_hometree:get_items(Nidx, JID, AccessModel,
-        PresenceSubscription, RosterGroup, SubId, RSM).
-
-get_item(Nidx, ItemId) ->
-    node_hometree:get_item(Nidx, ItemId).
-
-get_item(Nidx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, SubId) ->
-    node_hometree:get_item(Nidx, ItemId, JID, AccessModel,
-        PresenceSubscription, RosterGroup, SubId).
-
-set_item(Item) ->
-    node_hometree:set_item(Item).
-
-get_item_name(Host, Node, Id) ->
-    node_hometree:get_item_name(Host, Node, Id).
 
 node_to_path(Node) ->
     node_hometree:node_to_path(Node).

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -38,7 +38,7 @@
 -include("jlib.hrl").
 -include("mongoose.hrl").
 
--export([init/3, terminate/2, options/0, features/0,
+-export([based_on/0, init/3, terminate/2, options/0, features/0,
          create_node_permission/6, create_node/2, delete_node/1,
          purge_node/2, subscribe_node/8, unsubscribe_node/4,
          publish_item/9, delete_item/4, remove_extra_items/3,
@@ -50,6 +50,8 @@
          get_items_if_authorised/3, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1, can_fetch_item/2, is_subscribed/1]).
+
+based_on() ->  none.
 
 init(_Host, _ServerHost, _Opts) ->
     pubsub_subscription:init(),

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -345,8 +345,7 @@ publish_item(_ServerHost, Nidx, Publisher, PublishModel, MaxItems, ItemId, ItemP
                                            Payload, Publisher, ItemPublisher),
                    Items = [ItemId | GenState#pubsub_state.items -- [ItemId]],
                    {result, {_NI, OI}} = remove_extra_items(Nidx, MaxItems, Items),
-                   set_item(Item),
-                   mod_pubsub_db_backend:add_item(Nidx, Publisher, ItemId),
+                   mod_pubsub_db_backend:add_item(Nidx, Publisher, Item),
                    mod_pubsub_db_backend:remove_items(Nidx, Publisher, OI),
                    {result, {default, broadcast, OI}};
                false ->

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -47,7 +47,7 @@
          get_entity_subscriptions/2, get_node_subscriptions/1,
          get_subscriptions/2, set_subscriptions/4,
          get_pending_nodes/2,
-         get_items/7, get_items/3, get_item/7,
+         get_items_if_authorised/3, get_items/3, get_item/7,
          get_item/2, set_item/1, get_item_name/3, node_to_path/1,
          path_to_node/1, can_fetch_item/2, is_subscribed/1]).
 
@@ -582,7 +582,10 @@ get_items(Nidx, _From, _RSM) ->
             {error, mongoose_xmpp_errors:item_not_found()}
     end.
 
-get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId, RSM) ->
+get_items_if_authorised(Nidx, JID, #{access_model := AccessModel,
+                                     presence_permission := PresenceSubscription,
+                                     roster_permission := RosterGroup,
+                                     rsm := RSM}) ->
     {ok, Affiliation} = mod_pubsub_db_backend:get_affiliation(Nidx, JID),
     {ok, BareSubscriptions}
     = mod_pubsub_db_backend:get_node_entity_subscriptions(Nidx, jid:to_bare(JID)),

--- a/src/pubsub/node_hometree.erl
+++ b/src/pubsub/node_hometree.erl
@@ -32,9 +32,11 @@
 -include("pubsub.hrl").
 -include("jlib.hrl").
 
--export([init/3, terminate/2, options/0, features/0,
+-export([based_on/0, init/3, terminate/2, options/0, features/0,
          create_node_permission/6, node_to_path/1,
          path_to_node/1]).
+
+based_on() ->  node_flat.
 
 init(Host, ServerHost, Opts) ->
     node_flat:init(Host, ServerHost, Opts),

--- a/src/pubsub/node_hometree.erl
+++ b/src/pubsub/node_hometree.erl
@@ -33,16 +33,7 @@
 -include("jlib.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
-         create_node_permission/6, create_node/2, delete_node/1,
-         purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/9, delete_item/4, remove_extra_items/3,
-         get_entity_affiliations/2, get_node_affiliations/1,
-         get_affiliation/2, set_affiliation/3,
-         get_entity_subscriptions/2, get_node_subscriptions/1,
-         get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2,
-         get_items/7, get_items/3, get_item/7,
-         get_item/2, set_item/1, get_item_name/3, node_to_path/1,
+         create_node_permission/6, node_to_path/1,
          path_to_node/1]).
 
 init(Host, ServerHost, Opts) ->
@@ -82,82 +73,6 @@ create_node_permission(_Host, ServerHost, Node, _ParentNode,
             end;
         _ -> {result, false}
     end.
-
-create_node(Nidx, Owner) ->
-    node_flat:create_node(Nidx, Owner).
-
-delete_node(Nodes) ->
-    node_flat:delete_node(Nodes).
-
-subscribe_node(Nidx, Sender, Subscriber, AccessModel,
-            SendLast, PresenceSubscription, RosterGroup, Options) ->
-    node_flat:subscribe_node(Nidx, Sender, Subscriber,
-        AccessModel, SendLast, PresenceSubscription,
-        RosterGroup, Options).
-
-unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
-    node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
-
-publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
-             PublishOptions) ->
-    node_flat:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
-                           Payload, PublishOptions).
-
-remove_extra_items(Nidx, MaxItems, ItemIds) ->
-    node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).
-
-delete_item(Nidx, Publisher, PublishModel, ItemId) ->
-    node_flat:delete_item(Nidx, Publisher, PublishModel, ItemId).
-
-purge_node(Nidx, Owner) ->
-    node_flat:purge_node(Nidx, Owner).
-
-get_entity_affiliations(Host, Owner) ->
-    node_flat:get_entity_affiliations(Host, Owner).
-
-get_node_affiliations(Nidx) ->
-    node_flat:get_node_affiliations(Nidx).
-
-get_affiliation(Nidx, Owner) ->
-    node_flat:get_affiliation(Nidx, Owner).
-
-set_affiliation(Nidx, Owner, Affiliation) ->
-    node_flat:set_affiliation(Nidx, Owner, Affiliation).
-
-get_entity_subscriptions(Host, Owner) ->
-    node_flat:get_entity_subscriptions(Host, Owner).
-
-get_node_subscriptions(Nidx) ->
-    node_flat:get_node_subscriptions(Nidx).
-
-get_subscriptions(Nidx, Owner) ->
-    node_flat:get_subscriptions(Nidx, Owner).
-
-set_subscriptions(Nidx, Owner, Subscription, SubId) ->
-    node_flat:set_subscriptions(Nidx, Owner, Subscription, SubId).
-
-get_pending_nodes(Host, Owner) ->
-    node_flat:get_pending_nodes(Host, Owner).
-
-get_items(Nidx, From, RSM) ->
-    node_flat:get_items(Nidx, From, RSM).
-
-get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
-    node_flat:get_items(Nidx, JID, AccessModel,
-        PresenceSubscription, RosterGroup, SubId, RSM).
-
-get_item(Nidx, ItemId) ->
-    node_flat:get_item(Nidx, ItemId).
-
-get_item(Nidx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, SubId) ->
-    node_flat:get_item(Nidx, ItemId, JID, AccessModel,
-        PresenceSubscription, RosterGroup, SubId).
-
-set_item(Item) ->
-    node_flat:set_item(Item).
-
-get_item_name(Host, Node, Id) ->
-    node_flat:get_item_name(Host, Node, Id).
 
 %% @doc <p>Return the path of the node.</p>
 node_to_path(Node) ->

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -35,12 +35,14 @@
 %%% @doc The module <strong>{@module}</strong> is the pep PubSub plugin.
 %%% <p>PubSub plugin nodes are using the {@link gen_pubsub_node} behaviour.</p>
 
--export([init/3, terminate/2, options/0, features/0,
+-export([based_on/0, init/3, terminate/2, options/0, features/0,
          create_node_permission/6, delete_node/1,
          unsubscribe_node/4, node_to_path/1,
          get_entity_affiliations/2, get_entity_affiliations/3,
          get_entity_subscriptions/2, get_entity_subscriptions/4
          ]).
+
+based_on() ->  node_flat.
 
 init(Host, ServerHost, Opts) ->
     node_flat:init(Host, ServerHost, Opts),

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -36,17 +36,11 @@
 %%% <p>PubSub plugin nodes are using the {@link gen_pubsub_node} behaviour.</p>
 
 -export([init/3, terminate/2, options/0, features/0,
-         create_node_permission/6, create_node/2, delete_node/1,
-         purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/9, delete_item/4, remove_extra_items/3,
-         get_entity_affiliations/2, get_node_affiliations/1,
-         get_affiliation/2, set_affiliation/3,
-         get_entity_subscriptions/2, get_node_subscriptions/1,
-         get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2,
-         get_items/7, get_items/3, get_item/7,
-         get_item/2, set_item/1, get_item_name/3, node_to_path/1,
-         path_to_node/1]).
+         create_node_permission/6, delete_node/1,
+         unsubscribe_node/4, node_to_path/1,
+         get_entity_affiliations/2, get_entity_affiliations/3,
+         get_entity_subscriptions/2, get_entity_subscriptions/4
+         ]).
 
 init(Host, ServerHost, Opts) ->
     node_flat:init(Host, ServerHost, Opts),
@@ -108,37 +102,15 @@ create_node_permission(Host, ServerHost, _Node, _ParentNode,
             {result, false}
     end.
 
-create_node(Nidx, Owner) ->
-    node_flat:create_node(Nidx, Owner).
-
 delete_node(Nodes) ->
     {result, {_, _, Result}} = node_flat:delete_node(Nodes),
     {result, {[], Result}}.
-
-subscribe_node(Nidx, Sender, Subscriber, AccessModel,
-            SendLast, PresenceSubscription, RosterGroup, Options) ->
-    node_flat:subscribe_node(Nidx, Sender, Subscriber, AccessModel, SendLast,
-        PresenceSubscription, RosterGroup, Options).
 
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     case node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId) of
         {error, Error} -> {error, Error};
         {result, _} -> {result, []}
     end.
-
-publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher, Payload,
-             PublishOptions) ->
-    node_flat:publish_item(ServerHost, Nidx, Publisher, Model, MaxItems, ItemId, ItemPublisher,
-                           Payload, PublishOptions).
-
-remove_extra_items(Nidx, MaxItems, ItemIds) ->
-    node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).
-
-delete_item(Nidx, Publisher, PublishModel, ItemId) ->
-    node_flat:delete_item(Nidx, Publisher, PublishModel, ItemId).
-
-purge_node(Nidx, Owner) ->
-    node_flat:purge_node(Nidx, Owner).
 
 get_entity_affiliations(Host, #jid{ lserver = D } = Owner) ->
     get_entity_affiliations(Host, D, Owner);
@@ -156,16 +128,6 @@ get_entity_affiliations(Host, D, Owner) ->
             end,
             [], States),
     {result, Reply}.
-
-
-get_node_affiliations(Nidx) ->
-    node_flat:get_node_affiliations(Nidx).
-
-get_affiliation(Nidx, Owner) ->
-    node_flat:get_affiliation(Nidx, Owner).
-
-set_affiliation(Nidx, Owner, Affiliation) ->
-    node_flat:set_affiliation(Nidx, Owner, Affiliation).
 
 get_entity_subscriptions(Host, #jid{ lserver = D, lresource = R } = Owner) ->
     get_entity_subscriptions(Host, D, R, Owner);
@@ -202,43 +164,9 @@ accumulate_entity_subscriptions(J, Node, Ss, Acc) ->
                         [{Node, S, J} | Acc2]
                 end, Acc, Ss).
 
-get_node_subscriptions(Nidx) ->
-    node_flat:get_node_subscriptions(Nidx).
-
-get_subscriptions(Nidx, Owner) ->
-    node_flat:get_subscriptions(Nidx, Owner).
-
-set_subscriptions(Nidx, Owner, Subscription, SubId) ->
-    node_flat:set_subscriptions(Nidx, Owner, Subscription, SubId).
-
-get_pending_nodes(Host, Owner) ->
-    node_flat:get_pending_nodes(Host, Owner).
-
-get_items(Nidx, From, RSM) ->
-    node_flat:get_items(Nidx, From, RSM).
-
-get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
-    node_flat:get_items(Nidx, JID, AccessModel,
-        PresenceSubscription, RosterGroup, SubId, RSM).
-
-get_item(Nidx, ItemId) ->
-    node_flat:get_item(Nidx, ItemId).
-
-get_item(Nidx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, SubId) ->
-    node_flat:get_item(Nidx, ItemId, JID, AccessModel,
-        PresenceSubscription, RosterGroup, SubId).
-
-set_item(Item) ->
-    node_flat:set_item(Item).
-
-get_item_name(Host, Node, Id) ->
-    node_flat:get_item_name(Host, Node, Id).
 
 node_to_path(Node) ->
     node_flat:node_to_path(Node).
-
-path_to_node(Path) ->
-    node_flat:path_to_node(Path).
 
 %%%
 %%% Internal

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -17,8 +17,10 @@
 -include("jlib.hrl").
 -include("pubsub.hrl").
 
--export([init/3, terminate/2, options/0, features/0,
+-export([based_on/0, init/3, terminate/2, options/0, features/0,
          publish_item/9, node_to_path/1]).
+
+based_on() ->  node_flat.
 
 init(Host, ServerHost, Opts) ->
     node_flat:init(Host, ServerHost, Opts),

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -18,17 +18,7 @@
 -include("pubsub.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
-         create_node_permission/6, create_node/2, delete_node/1,
-         purge_node/2, subscribe_node/8, unsubscribe_node/4,
-         publish_item/9, delete_item/4, remove_extra_items/3,
-         get_entity_affiliations/2, get_node_affiliations/1,
-         get_affiliation/2, set_affiliation/3,
-         get_entity_subscriptions/2, get_node_subscriptions/1,
-         get_subscriptions/2, set_subscriptions/4,
-         get_pending_nodes/2,
-         get_items/7, get_items/3, get_item/7,
-         get_item/2, set_item/1, get_item_name/3, node_to_path/1,
-         path_to_node/1]).
+         publish_item/9, node_to_path/1]).
 
 init(Host, ServerHost, Opts) ->
     node_flat:init(Host, ServerHost, Opts),
@@ -68,23 +58,6 @@ features() ->
         <<"retrieve-affiliations">>
     ].
 
-create_node_permission(Host, ServerHost, Node, ParentNode, Owner, Access) ->
-    node_flat:create_node_permission(Host, ServerHost, Node, ParentNode, Owner, Access).
-
-create_node(Nidx, Owner) ->
-    node_flat:create_node(Nidx, Owner).
-
-delete_node(Nodes) ->
-    node_flat:delete_node(Nodes).
-
-subscribe_node(Nidx, Sender, Subscriber, AccessModel,
-               SendLast, PresenceSubscription, RosterGroup, Options) ->
-    node_flat:subscribe_node(Nidx, Sender, Subscriber, AccessModel, SendLast,
-                             PresenceSubscription, RosterGroup, Options).
-
-unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
-    node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
-
 publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublisher, Payload,
              PublishOptions) ->
     Affiliation = mod_pubsub_db_backend:get_affiliation(Nidx, Publisher),
@@ -112,68 +85,8 @@ do_publish_item(ServerHost, PublishOptions,
 do_publish_item(_ServerHost, _PublishOptions, _Payload) ->
     {error, mongoose_xmpp_errors:bad_request()}.
 
-remove_extra_items(Nidx, MaxItems, ItemIds) ->
-    node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).
-
-delete_item(Nidx, Publisher, PublishModel, ItemId) ->
-    node_flat:delete_item(Nidx, Publisher, PublishModel, ItemId).
-
-purge_node(Nidx, Owner) ->
-    node_flat:purge_node(Nidx, Owner).
-
-get_entity_affiliations(Host, Owner) ->
-    node_flat:get_entity_affiliations(Host, Owner).
-
-
-get_node_affiliations(Nidx) ->
-    node_flat:get_node_affiliations(Nidx).
-
-get_affiliation(Nidx, Owner) ->
-    node_flat:get_affiliation(Nidx, Owner).
-
-set_affiliation(Nidx, Owner, Affiliation) ->
-    node_flat:set_affiliation(Nidx, Owner, Affiliation).
-
-get_entity_subscriptions(Host, Owner) ->
-    node_flat:get_entity_subscriptions(Host, Owner).
-
-get_node_subscriptions(Nidx) ->
-    node_flat:get_node_subscriptions(Nidx).
-
-get_subscriptions(Nidx, Owner) ->
-    node_flat:get_subscriptions(Nidx, Owner).
-
-set_subscriptions(Nidx, Owner, Subscription, SubId) ->
-    node_flat:set_subscriptions(Nidx, Owner, Subscription, SubId).
-
-get_pending_nodes(Host, Owner) ->
-    node_flat:get_pending_nodes(Host, Owner).
-
-get_items(Nidx, From, RSM) ->
-    node_flat:get_items(Nidx, From, RSM).
-
-get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, SubId, RSM) ->
-    node_flat:get_items(Nidx, JID, AccessModel,
-                        PresenceSubscription, RosterGroup, SubId, RSM).
-
-get_item(Nidx, ItemId) ->
-    node_flat:get_item(Nidx, ItemId).
-
-get_item(Nidx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, SubId) ->
-    node_flat:get_item(Nidx, ItemId, JID, AccessModel,
-                       PresenceSubscription, RosterGroup, SubId).
-
-set_item(Item) ->
-    node_flat:set_item(Item).
-
-get_item_name(Host, Node, Id) ->
-    node_flat:get_item_name(Host, Node, Id).
-
 node_to_path(Node) ->
     node_flat:node_to_path(Node).
-
-path_to_node(Path) ->
-    node_flat:path_to_node(Path).
 
 %%%
 %%% Internal


### PR DESCRIPTION
This PR is a preparation for more efficient RDBMS backend for pubsub_item. Proposed changes include:

* removal of tons of unused forwarding calls in `node_*` modules
* storing the item in backend's `add_item` function
* filtering by id and limiting results in backend function

