### PR TITLE
Cover `item_publisher` option with tests

### DIFF
--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -385,7 +385,7 @@ publish_with_existing_id_test(Config) ->
               pubsub_tools:publish(Alice, <<"item1">>, Node, [{with_payload, NewEl}]),
               pubsub_tools:get_item(Alice, Node, <<"item1">>, [{expected_result,
                                                                 [#{id => <<"item1">>,
-                                                                   content => NewEl}]}]),
+                                                                   entry => NewEl}]}]),
 
 
               pubsub_tools:delete_node(Alice, Node, [])
@@ -1457,10 +1457,10 @@ get_item_with_publisher_option_test(Config) ->
 
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
 
-
+              PublisherJID =  escalus_utils:jid_to_lower(escalus_client:full_jid(Alice)),
               A = pubsub_tools:get_item(Alice, Node, <<"item1">>,
                                         [{expected_result, [#{id => <<"item1">>,
-                                                              publisher => escalus_client:full_jid(Alice)}]}]),
+                                                              publisher => PublisherJID}]}]),
               pubsub_tools:delete_node(Alice, Node, [])
       end).
 
@@ -1476,8 +1476,9 @@ receive_item_notification_with_publisher_option_test(Config) ->
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
 
 
+              PublisherJID =  escalus_utils:jid_to_lower(escalus_client:full_jid(Alice)),
               pubsub_tools:receive_item_notification(Bob, #{id => <<"item1">>,
-                                                            publisher => escalus_client:full_jid(Alice)}, Node, []),
+                                                            publisher => PublisherJID}, Node, []),
 
               pubsub_tools:delete_node(Alice, Node, [])
       end).

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -13,7 +13,7 @@
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl").
-
+-include_lib("eunit/include/eunit.hrl").
 %% Send request, receive (optional) response
 -export([
          discover_nodes/3,
@@ -459,13 +459,18 @@ check_items(ReceivedItemsElem, ExpectedItemIds, NodeName) ->
 check_item(ExpectedItem, ReceivedItem) ->
     ExpectedItemMap = decode_expected_item(ExpectedItem),
     maps:map(fun(K, V) ->
-    KBin = atom_to_binary(K, utf8),
+                     KBin = atom_to_binary(K, utf8),
                      check_item_field(KBin, V, ReceivedItem) end, ExpectedItemMap).
 
 check_item_field(Field = <<"entry">>, ExpectedValue, ReceivedItem) ->
-    ExpectedValue = exml_query:subelement(ReceivedItem, Field);
+    ?assertEqual(ExpectedValue, exml_query:subelement(ReceivedItem, Field));
 check_item_field(Field, ExpectedValue, ReceivedItem) ->
-    ExpectedValue = exml_query:attr(ReceivedItem, Field).
+    case exml_query:attr(ReceivedItem, Field)of
+        ExpectedValue ->
+            ok;
+        Value ->
+            ct:fail("Assertion failed for key: ~p, expected value: ~p, actual: ~p", [Field, ExpectedValue, Value])
+    end.
 
 decode_expected_item(AMap) when is_map(AMap) ->
     case maps:is_key(entry, AMap) of

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -457,11 +457,15 @@ check_items(ReceivedItemsElem, ExpectedItemIds, NodeName, WithPayload) ->
         {ReceivedItem, ExpectedItemId} <- lists:zip(ReceivedItems, ExpectedItemIds)].
 
 check_item(ExpectedItem, WithPayload, ReceivedItem) ->
-    #{id := ExpectedItemId} = ExpectedItemMap = decode_expected_item(ExpectedItem),
-    ExpectedItemId = exml_query:attr(ReceivedItem, <<"id">>),
-    Content = item_content(WithPayload),
-    ExpectedContent = maps:get(content, ExpectedItemMap, Content),
-    ExpectedContent = exml_query:subelement(ReceivedItem, <<"entry">>).
+    ExpectedItemMap = decode_expected_item(ExpectedItem),
+    maps:map(fun(K, V) ->
+    KBin = atom_to_binary(K, utf8),
+                     check_item_field(KBin, V, ReceivedItem) end, ExpectedItemMap).
+
+check_item_field(Field = <<"entry">>, ExpectedValue, ReceivedItem) ->
+    ExpectedValue = exml_query:subelement(ReceivedItem, Field);
+check_item_field(Field, ExpectedValue, ReceivedItem) ->
+    ExpectedValue = exml_query:attr(ReceivedItem, Field).
 
 decode_expected_item(AMap) when is_map(AMap) ->
     AMap;


### PR DESCRIPTION
This PR add two test cases for `mod_pubsub` configured with `{publisher, true}`.

