### PR TITLE
Pass empty map to node_cleanup hook

### DIFF
--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -51,6 +51,8 @@
 -export([add/1,
          delete/1]).
 
+-export([error_running_hook/3]).
+
 -include("mongoose.hrl").
 
 -type hook() :: {atom(), jid:server() | global, module(), fun() | atom(), integer()}.
@@ -249,8 +251,7 @@ run_fold1([{_Seq, Module, Function} | Ls], Hook, Val, Args) ->
     Res = hook_apply_function(Module, Function, Val, Args),
     case Res of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("~p~nrunning hook: ~p",
-                       [Reason, {Hook, Args}]),
+            error_running_hook(Reason, Hook, Args),
             run_fold1(Ls, Hook, Val, Args);
         stop ->
             stopped;
@@ -265,3 +266,5 @@ hook_apply_function(_Module, Function, Val, Args) when is_function(Function) ->
 hook_apply_function(Module, Function, Val, Args) ->
     safely:apply(Module, Function, [Val | Args]).
 
+error_running_hook(Reason, Hook, Args) ->
+    ?ERROR_MSG("~p~nrunning hook: ~p", [Reason, {Hook, Args}]).

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -255,8 +255,8 @@ node_cleanup(Acc, Node) ->
                                       mnesia:delete({iq_response, Key})
                               end, Keys)
         end,
-    mnesia:async_dirty(F),
-    Acc.
+    Res = mnesia:async_dirty(F),
+    maps:put(?MODULE, Res, Acc).
 
 %%====================================================================
 %% gen_server callbacks

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -587,9 +587,9 @@ update_tables() ->
             ok
     end.
 
--spec routes_cleanup_on_nodedown(mongoose_acc:t(), node()) -> mongoose_acc:t().
+-spec routes_cleanup_on_nodedown(map(), node()) -> map().
 routes_cleanup_on_nodedown(Acc, Node) ->
     Entries = mnesia:dirty_match_object(external_component_global,
                                         #external_component{node = Node, _ = '_'}),
     [mnesia:dirty_delete_object(external_component_global, Entry) || Entry <- Entries],
-    Acc.
+    maps:put(?MODULE, ok, Acc).

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -174,7 +174,7 @@ node_cleanup(Acc, Node) ->
                               end, Es)
         end,
     Res = mnesia:async_dirty(F),
-    maps:put(cleanup_result, Res, Acc).
+    maps:put(?MODULE, Res, Acc).
 
 -spec key({jid:lserver(), jid:lserver()}, binary()) ->
     binary().

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -452,7 +452,7 @@ unregister_iq_handler(Host, XMLNS) ->
 node_cleanup(Acc, Node) ->
     Timeout = timer:minutes(1),
     Res = gen_server:call(?MODULE, {node_cleanup, Node}, Timeout),
-    maps:put(cleanup_result, Res, Acc).
+    maps:put(?MODULE, Res, Acc).
 
 %%====================================================================
 %% gen_server callbacks

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -149,7 +149,7 @@ stop(_Host) ->
 
 node_cleanup(Acc, Node) ->
     Res = mod_bosh_backend:node_cleanup(Node),
-    maps:put(cleanup_result, Res, Acc).
+    maps:put(?MODULE, Res, Acc).
 
 %%--------------------------------------------------------------------
 %% cowboy_loop_handler callbacks

--- a/src/mongoose_cleaner.erl
+++ b/src/mongoose_cleaner.erl
@@ -74,12 +74,11 @@ cleanup_modules(Node) ->
             ?DEBUG("could not get ~p~n", [?NODE_CLEANUP_LOCK(Node)]),
             {ok, aborted};
         Result ->
-            ?WARNING_MSG("cleanup result: ~p~n", [maps:get(cleanup_result, Result, none)]),
             {ok, Result}
     end.
 
 run_node_cleanup(Node) ->
-    {Elapsed, RetVal} = timer:tc(ejabberd_hooks, run, [node_cleanup, [Node]]),
+    {Elapsed, RetVal} = timer:tc(ejabberd_hooks, run_fold, [node_cleanup, #{}, [Node]]),
     ?WARNING_MSG("cleanup took=~pms, result: ~p~n",
-                 [erlang:round(Elapsed / 1000), maps:get(cleanup_result, RetVal, none)]),
+                 [erlang:round(Elapsed / 1000), RetVal]),
     RetVal.


### PR DESCRIPTION
This PR fixes node_cleanup hook handlers crashes.

