### PR TITLE
Optimise pubsub's node removal

### DIFF
--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -298,7 +298,7 @@ init([ServerHost, Opts]) ->
     {ok, State}.
 
 init_backend(Opts) ->
-    TrackedDBFuns = [set_state, del_state, get_state, get_states,
+    TrackedDBFuns = [create_node, del_node, get_state, get_states,
                      get_states_by_lus, get_states_by_bare,
                      get_states_by_full, get_own_nodes_states,
                      get_items, get_item, set_item, del_item, del_items],

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -37,11 +37,6 @@
 
 %% ----------------------- Direct #pubsub_state access ------------------------
 
-%% TODO: Replace with del_node when it is fully possible from backend
-%%       i.e. when pubsub_item is migrated to RDBMS as well
--callback del_state(Nidx :: mod_pubsub:nodeIdx(),
-                    LJID :: jid:ljid()) -> ok.
-
 %% When a state is not found, returns empty state.
 %% Maybe can be removed completely later?
 -callback get_state(Nidx :: mod_pubsub:nodeIdx(),
@@ -69,6 +64,9 @@
 -callback create_node(Nidx :: mod_pubsub:nodeIdx(),
                       Owner :: jid:ljid()) ->
     ok.
+
+-callback del_node(Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
 
 %% ----------------------- Affiliations ------------------------
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -163,11 +163,6 @@ get_idxs_of_own_nodes_with_pending_subs(LJID) ->
                                [], pubsub_state),
     {ok, ResultNidxs}.
 
--spec del_state(Nidx :: mod_pubsub:nodeIdx(),
-               LJID :: jid:ljid()) -> ok.
-del_state(Nidx, LJID) ->
-    mnesia:delete({pubsub_state, {LJID, Nidx}}).
-
 %% ------------------------ Node management ------------------------
 
 -spec create_node(Nidx :: mod_pubsub:nodeIdx(),
@@ -342,6 +337,11 @@ del_items(Nidx, ItemIds) ->
 %%====================================================================
 %% Internal functions
 %%====================================================================
+
+-spec del_state(Nidx :: mod_pubsub:nodeIdx(),
+               LJID :: jid:ljid()) -> ok.
+del_state(Nidx, LJID) ->
+    mnesia:delete({pubsub_state, {LJID, Nidx}}).
 
 -spec get_state(Nidx :: mod_pubsub:nodeIdx(),
                 LJID :: jid:ljid(),

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -15,7 +15,7 @@
 % Funs execution
 -export([transaction/2, dirty/2]).
 % Direct #pubsub_state access
--export([del_state/2, get_state/2,
+-export([del_node/1, get_state/2,
          get_states/1, get_states_by_lus/1, get_states_by_bare/1,
          get_states_by_bare_and_full/1, get_idxs_of_own_nodes_with_pending_subs/1]).
 % Node management
@@ -164,7 +164,7 @@ get_idxs_of_own_nodes_with_pending_subs(LJID) ->
     {ok, ResultNidxs}.
 
 -spec del_state(Nidx :: mod_pubsub:nodeIdx(),
-                LJID :: jid:ljid()) -> ok.
+               LJID :: jid:ljid()) -> ok.
 del_state(Nidx, LJID) ->
     mnesia:delete({pubsub_state, {LJID, Nidx}}).
 
@@ -175,6 +175,16 @@ del_state(Nidx, LJID) ->
     ok.
 create_node(Nidx, Owner) ->
     set_affiliation(Nidx, Owner, owner).
+
+-spec del_node(Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, [mod_pubsub:pubsubState()]}.
+del_node(Nidx) ->
+    {ok, States} = get_states(Nidx),
+    lists:foreach(fun (#pubsub_state{stateid = {LJID, _}, items = Items}) ->
+                          del_items(Nidx, Items),
+                          del_state(Nidx, LJID)
+                  end, States),
+    {ok, States}.
 
 %% ------------------------ Affiliations ------------------------
 

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -151,13 +151,6 @@ get_idxs_of_own_nodes_with_pending_subs({ LU, LS, _ }) ->
     {selected, Rows} = mongoose_rdbms:sql_query(global, IdxsSQL),
     {ok, [ mongoose_rdbms:result_to_integer(Nidx) || {Nidx} <- Rows ]}.
 
--spec del_state(Nidx :: mod_pubsub:nodeIdx(),
-                LJID :: jid:ljid()) -> ok.
-del_state(Nidx, {LU, LS, LR}) ->
-    delete_all_subscriptions_wo_aff_check(Nidx, LU, LS, LR),
-    delete_affiliation_wo_subs_check(Nidx, LU, LS),
-    ok.
-
 %% ------------------------ Direct #pubsub_item access ------------------------
 
 -spec get_items(Nidx :: mod_pubsub:nodeIdx(), gen_pubsub_node:get_item_options()) ->
@@ -354,6 +347,13 @@ remove_all_items(Nidx) ->
 %%====================================================================
 %% Helpers
 %%====================================================================
+
+-spec del_state(Nidx :: mod_pubsub:nodeIdx(),
+                LJID :: jid:ljid()) -> ok.
+del_state(Nidx, {LU, LS, LR}) ->
+    delete_all_subscriptions_wo_aff_check(Nidx, LU, LS, LR),
+    delete_affiliation_wo_subs_check(Nidx, LU, LS),
+    ok.
 
 -spec delete_all_subscriptions_wo_aff_check(Nidx :: mod_pubsub:nodeIdx(),
                                             LU :: jid:luser(),

--- a/src/pubsub/mod_pubsub_db_rdbms_sql.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms_sql.erl
@@ -25,7 +25,8 @@
 -export([
          upsert_affiliation/4,
          get_affiliation/3,
-         delete_affiliation/3
+         delete_affiliation/3,
+         delete_all_affiliations/1
         ]).
 
 % Subscriptions
@@ -35,6 +36,7 @@
          get_node_entity_subs/4,
          delete_subscription/5,
          delete_all_subscriptions/4,
+         delete_all_subscriptions/1,
          update_subscription/6
         ]).
 
@@ -191,6 +193,11 @@ delete_affiliation(Nidx, LU, LS) ->
      " AND luser = ", esc_string(LU),
      " AND lserver = ", esc_string(LS) ].
 
+-spec delete_all_affiliations(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+delete_all_affiliations(Nidx) ->
+    ["DELETE FROM pubsub_affiliations"
+     " WHERE nidx = ", esc_int(Nidx)].
+
 % ------------------- Subscriptions --------------------------------
 
 -spec insert_subscription(Nidx :: mod_pubsub:nodeIdx(),
@@ -249,6 +256,11 @@ delete_all_subscriptions(Nidx, LU, LS, LR) ->
      " AND luser = ", esc_string(LU),
      " AND lserver = ", esc_string(LS),
      " AND lresource = ", esc_string(LR)].
+
+-spec delete_all_subscriptions(Nidx :: mod_pubsub:nodeIdx()) -> iolist().
+delete_all_subscriptions(Nidx) ->
+    ["DELETE FROM pubsub_subscriptions"
+     " WHERE nidx = ", esc_int(Nidx)].
 
 -spec update_subscription(Nidx :: mod_pubsub:nodeIdx(),
                           LU :: jid:luser(),

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -123,11 +123,7 @@ delete_node(Nodes) ->
             lists:map(fun (S) -> {J, S} end, Ss)
     end,
     Reply = lists:map(fun (#pubsub_node{id = Nidx} = PubsubNode) ->
-                    {ok, States} = mod_pubsub_db_backend:get_states(Nidx),
-                    lists:foreach(fun (#pubsub_state{stateid = {LJID, _}, items = Items}) ->
-                                del_items(Nidx, Items),
-                                mod_pubsub_db_backend:del_state(Nidx, LJID)
-                        end, States),
+                    {ok, States} = mod_pubsub_db_backend:del_node(Nidx),
                     {PubsubNode, lists:flatmap(Tr, States)}
             end, Nodes),
     {result, {default, broadcast, Reply}}.


### PR DESCRIPTION
This PR optimizes the way a pubsub node is removed. New function `del_node` was introduced which removes all data associated with given node id.

