### PR TITLE
Stop mod_vcard process when stopping the module

### DIFF
--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -164,6 +164,7 @@ start(VHost, Opts) ->
 
 stop(VHost) ->
     Proc = gen_mod:get_module_proc(VHost, ?PROCNAME),
+    gen_server:call(Proc, stop),
     ejabberd_sup:stop_child(Proc).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This PR tries to stabilize the `ldap` job on travis. After investigation I found out that the `mod_vcard_ldap_HOST` process cannot start because the old one was not stopped (and unregistered). In this PR the main `mod_vcard_HOST` process is stopped explicitly when the module stops.

