### PR TITLE
Pubsub node mnesia backend

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -8,6 +8,18 @@
  ]},
  {lager, [
     {colored, true},
+    %% Alternate colors for white background
+    %% info, notice and warning levels were changed comparing to default
+    %{colors, [
+    %          {debug,     "\e[0;38m" },
+    %          {info,      "\e[0;34m" },
+    %          {notice,    "\e[0;36m" },
+    %          {warning,   "\e[1;34m" },
+    %          {error,     "\e[1;31m" },
+    %          {critical,  "\e[1;35m" },
+    %          {alert,     "\e[1;44m" },
+    %          {emergency, "\e[1;41m" }
+    %         ]},
     %% Limit the number of messages per second allowed from error_logger
     {error_logger_hwm, 100},
     %% Make logging more async

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -301,7 +301,11 @@ init_backend(Opts) ->
     TrackedDBFuns = [create_node, del_node, get_state, get_states,
                      get_states_by_lus, get_states_by_bare,
                      get_states_by_full, get_own_nodes_states,
-                     get_items, get_item, set_item, del_item, del_items],
+                     get_items, get_item, set_item, del_item, del_items,
+                     set_node, find_node_by_id, find_nodes_by_key,
+                     find_node, delete_node, get_subnodes, get_parentnodes,
+                     get_subnodes_tree, get_parentnodes_tree
+                     ],
     gen_mod:start_backend_module(mod_pubsub_db, Opts, TrackedDBFuns),
     mod_pubsub_db_backend:start(),
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -303,7 +303,7 @@ init_backend(Opts) ->
                      get_states_by_full, get_own_nodes_states,
                      get_items, get_item, set_item, del_item, del_items,
                      set_node, find_node_by_id, find_nodes_by_key,
-                     find_node, delete_node, get_subnodes, get_parentnodes,
+                     find_node_by_name, delete_node, get_subnodes, get_parentnodes,
                      get_subnodes_tree, get_parentnodes_tree
                      ],
     gen_mod:start_backend_module(mod_pubsub_db, Opts, TrackedDBFuns),

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1906,19 +1906,22 @@ parse_create_node_options_if_possible(_Host, _Type, InvalidConfigXEl) ->
     InvalidConfigXEl.
 
 create_node_transaction(Host, ServerHost, Node, Owner, Type, Access, NodeOptions) ->
-    Parent = case node_call(Host, Type, node_to_path, [Node]) of
-                 {result, [Node]} ->
-                     <<>>;
-                 {result, Path} ->
-                     element(2, node_call(Host, Type, path_to_node,
-                                          [lists:sublist(Path, length(Path)-1)]))
-             end,
+    Parent = get_parent(Host, Type, Node),
     case node_call(Host, Type, create_node_permission,
                    [Host, ServerHost, Node, Parent, Owner, Access]) of
         {result, true} ->
             create_node_authorized_transaction(Host, Node, Parent, Owner, Type, NodeOptions);
         _ ->
             {error, mongoose_xmpp_errors:forbidden()}
+    end.
+
+get_parent(Host, Type, Node) ->
+    case node_call(Host, Type, node_to_path, [Node]) of
+        {result, [Node]} ->
+            <<>>;
+        {result, Path} ->
+            element(2, node_call(Host, Type, path_to_node,
+                                 [lists:sublist(Path, length(Path)-1)]))
     end.
 
 create_node_authorized_transaction(Host, Node, Parent, Owner, Type, NodeOptions) ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -60,13 +60,15 @@
     {ok, [mod_pubsub:nodeIdx()]}.
 
 %% ----------------------- Node management ------------------------
-
+%% TODO this is not really node creation
 -callback create_node(Nidx :: mod_pubsub:nodeIdx(),
                       Owner :: jid:ljid()) ->
     ok.
 
 -callback del_node(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
+
+-callback set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
 
 -callback find_node( Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) ->
     mod_pubsub:pubsubNode() | false.

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -84,6 +84,9 @@
 -callback get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
     [mod_pubsub:pubsubNode()].
 
+-callback get_parentnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [mod_pubsub:pubsubNode()].
+
 %% ----------------------- Affiliations ------------------------
 
 -callback set_affiliation(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -79,6 +79,11 @@
 -callback find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
     [mod_pubsub:pubsubNode()].
 
+-callback find_nodes_by_id_and_pred(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
+                                    Nodes :: [mod_pubsub:nodeId()],
+                                    Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
+    [mod_pubsub:pubsubNode()].
+
 -callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 
 -callback get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -79,11 +79,6 @@
 -callback find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
     [mod_pubsub:pubsubNode()].
 
--callback find_nodes_by_id_and_pred(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
-                                    Nodes :: [mod_pubsub:nodeId()],
-                                    Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
-    [mod_pubsub:pubsubNode()].
-
 -callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 
 -callback get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
@@ -91,6 +86,12 @@
 
 -callback get_parentnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
     [mod_pubsub:pubsubNode()].
+
+-callback get_parentnodes_tree(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(), ...]}].
+
+-callback get_subnodes_tree(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(), ...]}].
 
 %% ----------------------- Affiliations ------------------------
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -70,10 +70,13 @@
 
 -callback set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
 
--callback find_node(Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) ->
+-callback find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
+    {error, not_found} | {ok, mod_pubsub:pubsubNode()}.
+
+-callback find_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
     mod_pubsub:pubsubNode() | false.
 
--callback delete_node(Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) -> ok.
+-callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 
 %% ----------------------- Affiliations ------------------------
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -70,8 +70,10 @@
 
 -callback set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
 
--callback find_node( Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) ->
+-callback find_node(Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) ->
     mod_pubsub:pubsubNode() | false.
+
+-callback delete_node(Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) -> ok.
 
 %% ----------------------- Affiliations ------------------------
 

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -81,6 +81,9 @@
 
 -callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 
+-callback get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
+    [mod_pubsub:pubsubNode()].
+
 %% ----------------------- Affiliations ------------------------
 
 -callback set_affiliation(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -68,6 +68,9 @@
 -callback del_node(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
+-callback find_node( Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) ->
+    mod_pubsub:pubsubNode() | false.
+
 %% ----------------------- Affiliations ------------------------
 
 -callback set_affiliation(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -76,6 +76,9 @@
 -callback find_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
     mod_pubsub:pubsubNode() | false.
 
+-callback find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
+    [mod_pubsub:pubsubNode()].
+
 -callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 
 %% ----------------------- Affiliations ------------------------

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -73,7 +73,7 @@
 -callback find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
     {error, not_found} | {ok, mod_pubsub:pubsubNode()}.
 
--callback find_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+-callback find_node_by_name(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
     mod_pubsub:pubsubNode() | false.
 
 -callback find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -25,8 +25,7 @@
          set_node/1,
          find_node_by_id/1,
          find_nodes_by_key/1,
-         find_nodes_by_id_and_pred/3,
-         find_node/2,
+         find_node_by_name/2,
          delete_node/2,
          get_subnodes/2,
          get_parentnodes/2,
@@ -210,11 +209,11 @@ find_node_by_id(Nidx) ->
             {error, not_found}
     end.
 
--spec find_node(
+-spec find_node_by_name(
         Key :: mod_pubsub:hostPubsub() | jid:ljid(),
-        Node :: mod_pubsub:nodeId())
-    -> mod_pubsub:pubsubNode() | false.
-find_node(Key, Node) ->
+        Node :: mod_pubsub:nodeId()) ->
+    mod_pubsub:pubsubNode() | false.
+find_node_by_name(Key, Node) ->
     case mnesia:read(pubsub_node, oid(Key, Node), read) of
         [] -> false;
         [NodeRec] -> NodeRec
@@ -226,8 +225,8 @@ find_nodes_by_key(Key) ->
     mnesia:match_object(#pubsub_node{nodeid = {Key, '_'}, _ = '_'}).
 
 -spec find_nodes_by_id_and_pred(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
-                                    Nodes :: [mod_pubsub:nodeId()],
-                                    Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
+                                Nodes :: [mod_pubsub:nodeId()],
+                                Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
     [mod_pubsub:pubsubNode()].
 find_nodes_by_id_and_pred(Key, Nodes, Pred) ->
     Q = qlc:q([N
@@ -265,7 +264,7 @@ get_subnodes(Key, Node) ->
 -spec get_parentnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
     [mod_pubsub:pubsubNode()] | {error, not_found}.
 get_parentnodes(Key, Node) ->
-    case find_node(Key, Node) of
+    case find_node_by_name(Key, Node) of
         false ->
             {error, not_found};
         #pubsub_node{parents = []} ->
@@ -296,7 +295,7 @@ get_subnodes_tree(Key, Node) ->
     end,
     Tr = fun (#pubsub_node{nodeid = {_, N}}) -> [N] end,
     traversal_helper(Pred, Tr, 1, Key, [Node],
-        [{0, [find_node(Key, Node)]}]).
+        [{0, [find_node_by_name(Key, Node)]}]).
 
 
 -spec traversal_helper(

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -25,6 +25,7 @@
          set_node/1,
          find_node_by_id/1,
          find_nodes_by_key/1,
+         find_nodes_by_id_and_pred/3,
          find_node/2,
          delete_node/2,
          get_subnodes/2,
@@ -221,6 +222,17 @@ find_node(Key, Node) ->
     [mod_pubsub:pubsubNode()].
 find_nodes_by_key(Key) ->
     mnesia:match_object(#pubsub_node{nodeid = {Key, '_'}, _ = '_'}).
+
+-spec find_nodes_by_id_and_pred(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
+                                    Nodes :: [mod_pubsub:nodeId()],
+                                    Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
+    [mod_pubsub:pubsubNode()].
+find_nodes_by_id_and_pred(Key, Nodes, Pred) ->
+    Q = qlc:q([N
+                || #pubsub_node{nodeid = {NHost, _}} = N
+                    <- mnesia:table(pubsub_node),
+                    Node <- Nodes, Key == NHost, Pred(Node, N)]),
+    qlc:e(Q).
 
 oid(Key, Name) -> {Key, Name}.
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -21,6 +21,7 @@
 % Node management
 -export([
          create_node/2,
+         set_node/1,
          find_node/2
         ]).
 % Affiliations
@@ -185,6 +186,10 @@ del_node(Nidx) ->
                           del_state(Nidx, LJID)
                   end, States),
     {ok, States}.
+
+-spec set_node(mod_pubsub:pubsubNode()) -> ok.
+set_node(Node) when is_record(Node, pubsub_node) ->
+    mnesia:write(Node).
 
 -spec find_node(
         Key :: mod_pubsub:hostPubsub(),

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -23,6 +23,7 @@
          create_node/2,
          set_node/1,
          find_node_by_id/1,
+         find_nodes_by_key/1,
          find_node/2,
          delete_node/2
         ]).
@@ -212,6 +213,11 @@ find_node(Key, Node) ->
         [] -> false;
         [NodeRec] -> NodeRec
     end.
+
+-spec find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
+    [mod_pubsub:pubsubNode()].
+find_nodes_by_key(Key) ->
+    mnesia:match_object(#pubsub_node{nodeid = {Key, '_'}, _ = '_'}).
 
 oid(Key, Name) -> {Key, Name}.
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -22,6 +22,7 @@
 -export([
          create_node/2,
          set_node/1,
+         find_node_by_id/1,
          find_node/2,
          delete_node/2
         ]).
@@ -192,8 +193,18 @@ del_node(Nidx) ->
 set_node(Node) when is_record(Node, pubsub_node) ->
     mnesia:write(Node).
 
+
+-spec find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
+    {error, not_found} | {ok, mod_pubsub:pubsubNode()}.
+find_node_by_id(Nidx) ->
+    case mnesia:index_read(pubsub_node, Nidx, #pubsub_node.id) of
+        [#pubsub_node{} = Record] -> {ok, Record};
+        [] ->
+            {error, not_found}
+    end.
+
 -spec find_node(
-        Key :: mod_pubsub:hostPubsub(),
+        Key :: mod_pubsub:hostPubsub() | jid:ljid(),
         Node :: mod_pubsub:nodeId())
     -> mod_pubsub:pubsubNode() | false.
 find_node(Key, Node) ->
@@ -205,7 +216,7 @@ find_node(Key, Node) ->
 oid(Key, Name) -> {Key, Name}.
 
 
--spec delete_node(Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) -> ok.
+-spec delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 delete_node(Key, Node) ->
     mnesia:delete({pubsub_node, oid(Key, Node)}).
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -22,7 +22,8 @@
 -export([
          create_node/2,
          set_node/1,
-         find_node/2
+         find_node/2,
+         delete_node/2
         ]).
 % Affiliations
 -export([
@@ -202,6 +203,12 @@ find_node(Key, Node) ->
     end.
 
 oid(Key, Name) -> {Key, Name}.
+
+
+-spec delete_node(Key :: mod_pubsub:hostPubsub(), Node :: mod_pubsub:nodeId()) -> ok.
+delete_node(Key, Node) ->
+    mnesia:delete({pubsub_node, oid(Key, Node)}).
+
 
 %% ------------------------ Affiliations ------------------------
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -27,7 +27,8 @@
          find_nodes_by_key/1,
          find_node/2,
          delete_node/2,
-         get_subnodes/2
+         get_subnodes/2,
+         get_parentnodes/2
         ]).
 % Affiliations
 -export([
@@ -247,6 +248,21 @@ get_subnodes(Key, Node) ->
                     Key == NKey, lists:member(Node, Parents)]),
     qlc:e(Q).
 
+-spec get_parentnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [mod_pubsub:pubsubNode()] | {error, not_found}.
+get_parentnodes(Key, Node) ->
+    case find_node(Key, Node) of
+        false ->
+            {error, not_found};
+        #pubsub_node{parents = []} ->
+            [];
+        #pubsub_node{parents = Parents} ->
+            Q = qlc:q([N
+                       || #pubsub_node{nodeid = {NHost, NNode}} = N
+                          <- mnesia:table(pubsub_node),
+                          Parent <- Parents, Key == NHost, Parent == NNode]),
+            qlc:e(Q)
+    end.
 %% ------------------------ Affiliations ------------------------
 
 -spec set_affiliation(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -22,7 +22,13 @@
 % Node management
 -export([
          create_node/2,
-         del_node/1
+         del_node/1,
+         set_node/1,
+         find_node_by_id/1,
+         find_nodes_by_key/1,
+         find_node/2,
+         delete_node/2,
+         get_subnodes/2
         ]).
 % Affiliations
 -export([
@@ -218,6 +224,33 @@ del_node(Nidx) ->
     {updated, _} = mongoose_rdbms:sql_query(global, DelAllAffsQ),
     {ok, States}.
 
+-spec set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
+set_node(Node) ->
+    mod_pubsub_db_mnesia:set_node(Node).
+
+-spec find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
+    {error, not_found} | {ok, mod_pubsub:pubsubNode()}.
+find_node_by_id(Nidx) ->
+    mod_pubsub_db_mnesia:find_node_by_id(Nidx).
+
+-spec find_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    mod_pubsub:pubsubNode() | false.
+find_node(Key, Node) ->
+    mod_pubsub_db_mnesia:find_node(Key, Node).
+
+-spec find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
+    [mod_pubsub:pubsubNode()].
+find_nodes_by_key(Key) ->
+    mod_pubsub_db_mnesia:find_nodes_by_key(Key).
+
+-spec delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
+delete_node(Key, Node) ->
+    mod_pubsub_db_mnesia:delete_node(Key, Node).
+
+-spec get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
+    [mod_pubsub:pubsubNode()].
+get_subnodes(Key, Node) ->
+    mod_pubsub_db_mnesia:get_subnodes(Key, Node).
 
 % ------------------- Affiliations --------------------------------
 

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -26,11 +26,12 @@
          set_node/1,
          find_node_by_id/1,
          find_nodes_by_key/1,
-         find_nodes_by_id_and_pred/3,
          find_node/2,
          delete_node/2,
          get_subnodes/2,
-         get_parentnodes/2
+         get_parentnodes/2,
+         get_parentnodes_tree/2,
+         get_subnodes_tree/2
         ]).
 % Affiliations
 -export([
@@ -245,12 +246,6 @@ find_node(Key, Node) ->
 find_nodes_by_key(Key) ->
     mod_pubsub_db_mnesia:find_nodes_by_key(Key).
 
--spec find_nodes_by_id_and_pred(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
-                                    Nodes :: [mod_pubsub:nodeId()],
-                                    Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
-    [mod_pubsub:pubsubNode()].
-find_nodes_by_id_and_pred(Key, Nodes, Pred) ->
-    mod_pubsub_db_mnesia:find_nodes_by_id_and_pred(Key, Nodes, Pred).
 
 -spec delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 delete_node(Key, Node) ->
@@ -264,7 +259,17 @@ get_subnodes(Key, Node) ->
 -spec get_parentnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
     [mod_pubsub:pubsubNode()].
 get_parentnodes(Key, Node) ->
-    mod_pubsbu_db_mnesia:get_parentnodes(Key, Node).
+    mod_pubsub_db_mnesia:get_parentnodes(Key, Node).
+
+-spec get_parentnodes_tree(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(), ...]}].
+get_parentnodes_tree(Key, Node) ->
+    mod_pubsub_db_mnesia:get_parentnodes_tree(Key, Node).
+
+-spec get_subnodes_tree(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(), ...]}].
+get_subnodes_tree(Key, Node) ->
+    mod_pubsub_db_mnesia:get_subnodes_tree(Key, Node).
 % ------------------- Affiliations --------------------------------
 
 -spec set_affiliation(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -28,7 +28,8 @@
          find_nodes_by_key/1,
          find_node/2,
          delete_node/2,
-         get_subnodes/2
+         get_subnodes/2,
+         get_parentnodes/2
         ]).
 % Affiliations
 -export([
@@ -252,6 +253,10 @@ delete_node(Key, Node) ->
 get_subnodes(Key, Node) ->
     mod_pubsub_db_mnesia:get_subnodes(Key, Node).
 
+-spec get_parentnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+    [mod_pubsub:pubsubNode()].
+get_parentnodes(Key, Node) ->
+    mod_pubsbu_db_mnesia:get_parentnodes(Key, Node).
 % ------------------- Affiliations --------------------------------
 
 -spec set_affiliation(Nidx :: mod_pubsub:nodeIdx(),

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -26,6 +26,7 @@
          set_node/1,
          find_node_by_id/1,
          find_nodes_by_key/1,
+         find_nodes_by_id_and_pred/3,
          find_node/2,
          delete_node/2,
          get_subnodes/2,
@@ -243,6 +244,13 @@ find_node(Key, Node) ->
     [mod_pubsub:pubsubNode()].
 find_nodes_by_key(Key) ->
     mod_pubsub_db_mnesia:find_nodes_by_key(Key).
+
+-spec find_nodes_by_id_and_pred(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
+                                    Nodes :: [mod_pubsub:nodeId()],
+                                    Pred :: fun((mod_pubsub:nodeId(), mod_pubsub:pubsubNode()) -> boolean())) ->
+    [mod_pubsub:pubsubNode()].
+find_nodes_by_id_and_pred(Key, Nodes, Pred) ->
+    mod_pubsub_db_mnesia:find_nodes_by_id_and_pred(Key, Nodes, Pred).
 
 -spec delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
 delete_node(Key, Node) ->

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -26,7 +26,7 @@
          set_node/1,
          find_node_by_id/1,
          find_nodes_by_key/1,
-         find_node/2,
+         find_node_by_name/2,
          delete_node/2,
          get_subnodes/2,
          get_parentnodes/2,
@@ -236,10 +236,11 @@ set_node(Node) ->
 find_node_by_id(Nidx) ->
     mod_pubsub_db_mnesia:find_node_by_id(Nidx).
 
--spec find_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) ->
+-spec find_node_by_name(Key :: mod_pubsub:hostPubsub() | jid:ljid(),
+                        Node :: mod_pubsub:nodeId()) ->
     mod_pubsub:pubsubNode() | false.
-find_node(Key, Node) ->
-    mod_pubsub_db_mnesia:find_node(Key, Node).
+find_node_by_name(Key, Node) ->
+    mod_pubsub_db_mnesia:find_node_by_name(Key, Node).
 
 -spec find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
     [mod_pubsub:pubsubNode()].

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -86,11 +86,11 @@ delete_node(Key, Node) ->
 options() ->
     nodetree_tree:options().
 
-get_node(Host, Node, _From) ->
-    get_node(Host, Node).
+get_node(Key, Node, _From) ->
+    get_node(Key, Node).
 
-get_node(Host, Node) ->
-    case mod_pubsub_db_backend:find_node(Host, Node) of
+get_node(Key, Node) ->
+    case mod_pubsub_db_backend:find_node(Key, Node) of
         false -> {error, mongoose_xmpp_errors:item_not_found()};
         Record -> Record
     end.
@@ -104,15 +104,15 @@ get_nodes(Key, From) ->
 get_nodes(Key) ->
     nodetree_tree:get_nodes(Key).
 
-get_parentnodes(Host, Node, _From) ->
-    case mod_pubsub_db_backend:find_node(Host, Node) of
+get_parentnodes(Key, Node, _From) ->
+    case mod_pubsub_db_backend:find_node(Key, Node) of
         false ->
             {error, mongoose_xmpp_errors:item_not_found()};
         #pubsub_node{parents = Parents} ->
             Q = qlc:q([N
                         || #pubsub_node{nodeid = {NHost, NNode}} = N
                             <- mnesia:table(pubsub_node),
-                            Parent <- Parents, Host == NHost, Parent == NNode]),
+                            Parent <- Parents, Key == NHost, Parent == NNode]),
             qlc:e(Q)
     end.
 

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -45,7 +45,7 @@ terminate(Host, ServerHost) ->
 set_node(#pubsub_node{nodeid = {Key, _}, owners = Owners, options = Options} = Node) ->
     Parents = find_opt(collection, ?DEFAULT_PARENTS, Options),
     case validate_parentage(Key, Owners, Parents) of
-        true -> mnesia:write(Node#pubsub_node{parents = Parents});
+        true -> mod_pubsub_db_backend:set_node(Node#pubsub_node{parents = Parents});
         Other -> Other
     end.
 
@@ -73,10 +73,9 @@ delete_node(Key, Node) ->
             lists:foreach(fun (#pubsub_node{options = Opts} = Child) ->
                         NewOpts = remove_config_parent(Node, Opts),
                         Parents = find_opt(collection, ?DEFAULT_PARENTS, NewOpts),
-                        ok = mnesia:write(pubsub_node,
-                                Child#pubsub_node{parents = Parents,
-                                    options = NewOpts},
-                                write)
+                        ok = mod_pubsub_db_backend:set_node(
+                               Child#pubsub_node{parents = Parents,
+                                                 options = NewOpts})
                 end,
                 get_subnodes(Key, Node)),
             pubsub_index:free(node, Record#pubsub_node.id),

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -128,28 +128,13 @@ get_subnodes(Host, Node, _From) ->
     get_subnodes(Host, Node).
 
 get_subnodes(Host, <<>>) ->
-    get_subnodes_helper(Host, <<>>);
+    mod_pubsub_db_backend:get_subnodes(Host, <<>>);
+
 get_subnodes(Host, Node) ->
     case mod_pubsub_db_backend:find_node(Host, Node) of
         false -> {error, mongoose_xmpp_errors:item_not_found()};
-        _ -> get_subnodes_helper(Host, Node)
+        _ -> mod_pubsub_db_backend:get_subnodes(Host, Node)
     end.
-
-get_subnodes_helper(Host, <<>>) ->
-    Q = qlc:q([N
-                || #pubsub_node{nodeid = {NHost, _},
-                                parents = []} = N
-                       <- mnesia:table(pubsub_node),
-                   Host == NHost]),
-    qlc:e(Q);
-get_subnodes_helper(Host, Node) ->
-    Q = qlc:q([N
-                || #pubsub_node{nodeid = {NHost, _},
-                        parents = Parents} =
-                    N
-                    <- mnesia:table(pubsub_node),
-                    Host == NHost, lists:member(Node, Parents)]),
-    qlc:e(Q).
 
 get_subnodes_tree(Host, Node, From) ->
     Pred = fun (NID, #pubsub_node{parents = Parents}) ->

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -79,7 +79,7 @@ delete_node(Key, Node) ->
                 end,
                 get_subnodes(Key, Node)),
             pubsub_index:free(node, Record#pubsub_node.id),
-            mnesia:delete_object(pubsub_node, Record, write),
+            mod_pubsub_db_backend:delete_node(Key, Node),
             [Record]
     end.
 

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -51,7 +51,7 @@ set_node(#pubsub_node{nodeid = {Key, _}, owners = Owners, options = Options} = N
 
 create_node(Key, Node, Type, Owner, Options, Parents) ->
     OwnerJID = jid:to_lower(jid:to_bare(Owner)),
-    case mod_pubsub_db_backend:find_node(Key, Node) of
+    case mod_pubsub_db_backend:find_node_by_name(Key, Node) of
         false ->
             Nidx = pubsub_index:new(node),
             N = #pubsub_node{nodeid = {Key, Node}, id = Nidx,
@@ -66,7 +66,7 @@ create_node(Key, Node, Type, Owner, Options, Parents) ->
     end.
 
 delete_node(Key, Node) ->
-    case mod_pubsub_db_backend:find_node(Key, Node) of
+    case mod_pubsub_db_backend:find_node_by_name(Key, Node) of
         false ->
             {error, mongoose_xmpp_errors:item_not_found()};
         Record ->
@@ -90,7 +90,7 @@ get_node(Key, Node, _From) ->
     get_node(Key, Node).
 
 get_node(Key, Node) ->
-    case mod_pubsub_db_backend:find_node(Key, Node) of
+    case mod_pubsub_db_backend:find_node_by_name(Key, Node) of
         false -> {error, mongoose_xmpp_errors:item_not_found()};
         Record -> Record
     end.
@@ -122,7 +122,7 @@ get_subnodes(Host, <<>>) ->
     mod_pubsub_db_backend:get_subnodes(Host, <<>>);
 
 get_subnodes(Host, Node) ->
-    case mod_pubsub_db_backend:find_node(Host, Node) of
+    case mod_pubsub_db_backend:find_node_by_name(Host, Node) of
         false -> {error, mongoose_xmpp_errors:item_not_found()};
         _ -> mod_pubsub_db_backend:get_subnodes(Host, Node)
     end.
@@ -165,7 +165,7 @@ validate_parentage(Key, Owners, [[] | T]) ->
 validate_parentage(Key, Owners, [<<>> | T]) ->
     validate_parentage(Key, Owners, T);
 validate_parentage(Key, Owners, [ParentID | T]) ->
-    case mod_pubsub_db_backend:find_node(Key, ParentID) of
+    case mod_pubsub_db_backend:find_node_by_name(Key, ParentID) of
         false ->
             {error, mongoose_xmpp_errors:item_not_found()};
         #pubsub_node{owners = POwners, options = POptions} ->

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -155,7 +155,7 @@ find_opt(Key, Default, Options) ->
 
 -spec traversal_helper(
         Pred    :: fun(),
-        Tr      :: fun(),
+        Transform :: fun(),
         Host    :: mod_pubsub:hostPubsub(),
         Nodes :: [mod_pubsub:nodeId(), ...])
         -> [{Depth::non_neg_integer(), Nodes::[mod_pubsub:pubsubNode(), ...]}].
@@ -165,11 +165,7 @@ traversal_helper(Pred, Tr, Host, Nodes) ->
 traversal_helper(_Pred, _Tr, _Depth, _Host, [], Acc) ->
     Acc;
 traversal_helper(Pred, Tr, Depth, Host, Nodes, Acc) ->
-    Q = qlc:q([N
-                || #pubsub_node{nodeid = {NHost, _}} = N
-                    <- mnesia:table(pubsub_node),
-                    Node <- Nodes, Host == NHost, Pred(Node, N)]),
-    NodeRecs = qlc:e(Q),
+    NodeRecs = mod_pubsub_db_backend:find_nodes_by_id_and_pred(Host, Nodes, Pred),
     IDs = lists:flatmap(Tr, NodeRecs),
     traversal_helper(Pred, Tr, Depth + 1, Host, IDs, [{Depth, NodeRecs} | Acc]).
 

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -105,15 +105,11 @@ get_nodes(Key) ->
     nodetree_tree:get_nodes(Key).
 
 get_parentnodes(Key, Node, _From) ->
-    case mod_pubsub_db_backend:find_node(Key, Node) of
-        false ->
+    case mod_pubsub_db_backend:get_parentnodes(Key, Node) of
+        {error, not_found} ->
             {error, mongoose_xmpp_errors:item_not_found()};
-        #pubsub_node{parents = Parents} ->
-            Q = qlc:q([N
-                        || #pubsub_node{nodeid = {NHost, NNode}} = N
-                            <- mnesia:table(pubsub_node),
-                            Parent <- Parents, Key == NHost, Parent == NNode]),
-            qlc:e(Q)
+        Result when is_list(Result) ->
+            Result
     end.
 
 get_parentnodes_tree(Host, Node, _From) ->

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -51,15 +51,6 @@
          delete_node/2]).
 
 init(_Host, _ServerHost, _Options) ->
-    mnesia:create_table(pubsub_node,
-        [{disc_copies, [node()]},
-            {attributes, record_info(fields, pubsub_node)}]),
-    mnesia:add_table_index(pubsub_node, id),
-    NodesFields = record_info(fields, pubsub_node),
-    case mnesia:table_info(pubsub_node, attributes) of
-        NodesFields -> ok;
-        _ -> ok
-    end,
     ok.
 
 terminate(_Host, _ServerHost) ->

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -72,8 +72,8 @@ get_node(Host, Node) ->
     end.
 
 get_node(Nidx) ->
-    case catch mnesia:index_read(pubsub_node, Nidx, #pubsub_node.id) of
-        [Record] when is_record(Record, pubsub_node) -> Record;
+    case catch mod_pubsub_db_backend:find_node_by_id(Nidx) of
+        {ok, Node} -> Node;
         _ -> {error, mongoose_xmpp_errors:item_not_found()}
     end.
 

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -95,24 +95,8 @@ get_parentnodes_tree(Host, Node, _From) ->
     end.
 
 get_subnodes(Host, Node, _From) ->
-    get_subnodes(Host, Node).
+    mod_pubsub_db_backend:get_subnodes(Host, Node).
 
-get_subnodes(Host, <<>>) ->
-    Q = qlc:q([N
-                || #pubsub_node{nodeid = {NHost, _},
-                        parents = Parents} =
-                    N
-                    <- mnesia:table(pubsub_node),
-                    Host == NHost, Parents == []]),
-    qlc:e(Q);
-get_subnodes(Host, Node) ->
-    Q = qlc:q([N
-                || #pubsub_node{nodeid = {NHost, _},
-                        parents = Parents} =
-                    N
-                    <- mnesia:table(pubsub_node),
-                    Host == NHost, lists:member(Node, Parents)]),
-    qlc:e(Q).
 
 get_subnodes_tree(Host, Node, _From) ->
     get_subnodes_tree(Host, Node).

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -59,8 +59,8 @@ terminate(_Host, _ServerHost) ->
 options() ->
     [{virtual_tree, false}].
 
-set_node(Node) when is_record(Node, pubsub_node) ->
-    mnesia:write(Node).
+set_node(Node) ->
+    mod_pubsub_db_backend:set_node(Node).
 
 get_node(Host, Node, _From) ->
     get_node(Host, Node).
@@ -143,10 +143,11 @@ create_node(Host, Node, Type, Owner, Options, Parents) ->
             case check_parent_and_its_owner_list(Host, Parents, BJID) of
                 true ->
                     Nidx = pubsub_index:new(node),
-                    mnesia:write(#pubsub_node{nodeid = {Host, Node},
-                            id = Nidx, parents = Parents,
-                            type = Type, owners = [BJID],
-                            options = Options}),
+                    Node = #pubsub_node{nodeid = {Host, Node},
+                                        id = Nidx, parents = Parents,
+                                        type = Type, owners = [BJID],
+                                        options = Options},
+                    set_node(Node),
                     {ok, Nidx};
                 false ->
                     {error, mongoose_xmpp_errors:forbidden()}

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -77,11 +77,11 @@ get_node(Nidx) ->
         _ -> {error, mongoose_xmpp_errors:item_not_found()}
     end.
 
-get_nodes(Host, _From) ->
-    get_nodes(Host).
+get_nodes(Key, _From) ->
+    get_nodes(Key).
 
-get_nodes(Host) ->
-    mnesia:match_object(#pubsub_node{nodeid = {Host, '_'}, _ = '_'}).
+get_nodes(Key) ->
+    mod_pubsub_db_backend:find_nodes_by_key(Key).
 
 get_parentnodes(_Host, _Node, _From) ->
     [].

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -178,7 +178,7 @@ delete_node(Host, Node) ->
     Removed = get_subnodes_tree(Host, Node),
     lists:foreach(fun (#pubsub_node{nodeid = {_, SubNode}, id = SubNidx}) ->
                 pubsub_index:free(node, SubNidx),
-                mnesia:delete({pubsub_node, {Host, SubNode}})
+                mod_pubsub_db_backend:delete_node(Host, SubNode)
         end,
         Removed),
     Removed.

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -66,7 +66,7 @@ get_node(Host, Node, _From) ->
     get_node(Host, Node).
 
 get_node(Host, Node) ->
-    case catch mod_pubsub_db_backend:find_node(Host, Node) of
+    case catch mod_pubsub_db_backend:find_node_by_name(Host, Node) of
         #pubsub_node{} = Record -> Record;
         _ -> {error, mongoose_xmpp_errors:item_not_found()}
     end.
@@ -89,7 +89,7 @@ get_parentnodes(_Host, _Node, _From) ->
 %% @doc <p>Default node tree does not handle parents, return a list
 %% containing just this node.</p>
 get_parentnodes_tree(Host, Node, _From) ->
-    case catch mod_pubsub_db_backend:find_node(Host, Node) of
+    case catch mod_pubsub_db_backend:find_node_by_name(Host, Node) of
         #pubsub_node{} = Record -> [{0, [Record]}];
         _ -> []
     end.
@@ -122,7 +122,7 @@ get_subnodes_of_existing_tree(Host, Node, NodeRec) ->
 
 create_node(Host, Node, Type, Owner, Options, Parents) ->
     BJID = jid:to_lower(jid:to_bare(Owner)),
-    case catch mod_pubsub_db_backend:find_node(Host, Node) of
+    case catch mod_pubsub_db_backend:find_node_by_name(Host, Node) of
         false ->
             case check_parent_and_its_owner_list(Host, Parents, BJID) of
                 true ->
@@ -147,7 +147,7 @@ check_parent_and_its_owner_list({_U, _S, _R}, _Parents, _BJID) ->
 check_parent_and_its_owner_list(_Host, [], _BJID) ->
     true;
 check_parent_and_its_owner_list(Host, [Parent | _], BJID) ->
-    case catch mod_pubsub_db_backend:find_node(Host, Parent) of
+    case catch mod_pubsub_db_backend:find_node_by_name(Host, Parent) of
         #pubsub_node{owners = [{[], Host, []}]} ->
             true;
         #pubsub_node{owners = Owners} ->


### PR DESCRIPTION
This PR extracts mnesia operations around pubsub_node table to the backend module. Fully covered is the `nodetree_dag` module implementing [Pub Sub Collection Nodes](https://xmpp.org/extensions/xep-0248.html). The default `nodetree_tree` module (implementing custom nodes structure)  is covered to some extend.

