### PR TITLE
Extended PubSub tests to cover Mnesia + #pubsub_node usage

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, ".*", {git, "https://github.com/proger/erlsh.git", "4e8a107"}},
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
-        {escalus, ".*", {git, "https://github.com/esl/escalus.git", {branch, "better-pubsub-forms"}}},
+        {escalus, ".*", {git, "https://github.com/esl/escalus.git", {ref, "94e1498c349c888ca3aaf69628429c9eed497536"}}},
         {gen_fsm_compat, "0.3.0"},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, "2.4.0"},

--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, ".*", {git, "https://github.com/proger/erlsh.git", "4e8a107"}},
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", "0.14.8"}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "v1.2"}},
-        {escalus, ".*", {git, "https://github.com/esl/escalus.git", {ref, "36856c2"}}},
+        {escalus, ".*", {git, "https://github.com/esl/escalus.git", {branch, "better-pubsub-forms"}}},
         {gen_fsm_compat, "0.3.0"},
         %% Switch cowboy to upstream after ditching support for OTP 17.x
         {cowboy, "2.4.0"},

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -20,7 +20,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"95ff749cce1be3799929fb93610a25901ac0c67d"}},
+       {ref,"94e1498c349c888ca3aaf69628429c9eed497536"}},
   0},
  {<<"esip">>,
   {git,"https://github.com/processone/esip.git",

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -20,7 +20,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"36856c22d4c94e89fa2580b9544827ed95f79175"}},
+       {ref,"95ff749cce1be3799929fb93610a25901ac0c67d"}},
   0},
  {<<"esip">>,
   {git,"https://github.com/processone/esip.git",

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -328,7 +328,7 @@ discover_nodes_test(Config) ->
               %% Response:     Ex.10 Service returns all first-level nodes
               %% it shouldn't contain the Node which will be created in a moment
               {_, NodeName} = Node = pubsub_node(),
-              pubsub_tools:discover_nodes(Bob, node_addr(), [{expected_result, {no, NodeName}}]),
+              pubsub_tools:discover_nodes(Bob, node_addr(), [{expected_result, [{no, NodeName}]}]),
 
               pubsub_tools:create_node(Alice, Node, []),
               pubsub_tools:discover_nodes(Bob, node_addr(), [{expected_result, [NodeName]}]),
@@ -1346,7 +1346,7 @@ discover_top_level_nodes_test(Config) ->
               % This one is not
 
               LeafConfig = [{<<"pubsub#collection">>, NodeName}],
-              Leaf = pubsub_leaf(),
+              {_, LeafName} = Leaf = pubsub_leaf(),
               pubsub_tools:create_node(Alice, Leaf, [{config, LeafConfig}]),
 
               % This one is visible, as it is not associated with any collection
@@ -1355,7 +1355,8 @@ discover_top_level_nodes_test(Config) ->
 
               %% Discover top-level nodes, only the collection expected
               pubsub_tools:discover_nodes(Bob, node_addr(),
-                                          [{expected_result, [NodeName, CollectionlessName]}]),
+                                          [{expected_result, [NodeName, CollectionlessName,
+                                                              {no, LeafName}]}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Node, []),
@@ -1374,7 +1375,7 @@ discover_child_nodes_test(Config) ->
               CollectionConfig = [{<<"pubsub#node_type">>, <<"collection">>}],
               pubsub_tools:create_node(Alice, Node, [{config, CollectionConfig}]),
 
-              pubsub_tools:discover_nodes(Bob, Node, [{expected_result, {no, NodeName}}]),
+              pubsub_tools:discover_nodes(Bob, Node, [{expected_result, [{no, NodeName}]}]),
 
               NodeConfig = [{<<"pubsub#collection">>, NodeName}],
               {_, LeafName} = Leaf = pubsub_leaf(),

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -1697,12 +1697,17 @@ deleting_parent_path_deletes_children(Config) ->
       Config,
       [{alice, 1}],
       fun(Alice) ->
-              {Parent, Node} = path_node_and_parent(Alice, pubsub_node()),
+              {{_, ParentName} = Parent, {_, NodeName} = Node}
+              = path_node_and_parent(Alice, pubsub_node()),
+
               pubsub_tools:create_node(Alice, Parent, []),
               pubsub_tools:create_node(Alice, Node, []),
               
               pubsub_tools:delete_node(Alice, Parent, []),
-              pubsub_tools:delete_node(Alice, Node, [{expected_error_type, <<"cancel">>}])
+
+              pubsub_tools:discover_nodes(Alice, node_addr(),
+                                          [{expected_result, [{no, ParentName}, {no, NodeName}]}]),
+              pubsub_tools:discover_nodes(Alice, Node, [{expected_error_type, <<"cancel">>}])
       end).
 
 %%-----------------------------------------------------------------

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -1065,8 +1065,6 @@ create_delete_collection_test(Config) ->
               %% Request:  7.3.1 Ex.30 delete collection node
               %% Response: 7.3.2 Ex.31 success
               pubsub_tools:delete_node(Alice, Node, [])
-
-              %% Subnodes should be deleted as well
       end).
 
 subscribe_unsubscribe_collection_test(Config) ->
@@ -1128,9 +1126,9 @@ notify_collection_test(Config) ->
               %% Publish to leaf nodes, Bob should get notifications
               %% 5.3.1.1 Ex.5 Subscriber receives a publish notification from a collection
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, [{collection, Node}]),
               pubsub_tools:publish(Alice, <<"item2">>, Leaf2, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item2">>, Leaf2, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item2">>, Leaf2, [{collection, Node}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Leaf2, []),
@@ -1158,7 +1156,7 @@ notify_collection_leaf_and_item_test(Config) ->
 
               %% Publish to leaf node, Bob should get notified
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, [{collection, Node}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Node, [])
@@ -1181,12 +1179,14 @@ notify_collection_bare_jid_test(Config) ->
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
 
               %% Bob subscribed with resource
-              pubsub_tools:receive_item_notification(Bob1, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob1, <<"item1">>, Leaf, [{collection, Node}]),
               escalus_assert:has_no_stanzas(Bob2),
 
               %% Geralt subscribed without resource
-              pubsub_tools:receive_item_notification(Geralt1, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Geralt2, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Geralt1, <<"item1">>, Leaf,
+                                                     [{collection, Node}]),
+              pubsub_tools:receive_item_notification(Geralt2, <<"item1">>, Leaf,
+                                                     [{collection, Node}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Node, [])
@@ -1209,8 +1209,10 @@ notify_collection_and_leaf_test(Config) ->
 
               %% Publish to leaf nodes, Bob and Geralt should get notifications
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Geralt, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf,
+                                                     [{collection, Node}]),
+              pubsub_tools:receive_item_notification(Geralt, <<"item1">>, Leaf,
+                                                     [no_collection_shim]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Node, [])
@@ -1233,7 +1235,7 @@ notify_collection_and_leaf_same_user_test(Config) ->
 
               %% Bob should get only one notification
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, [{collection, Node}]),
               escalus_assert:has_no_stanzas(Bob),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
@@ -1260,8 +1262,10 @@ notify_collections_with_same_leaf_test(Config) ->
 
               %% Publish to leaf node, Bob and Geralt should get notifications
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Geralt, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf,
+                                                     [{collection, Collection1}]),
+              pubsub_tools:receive_item_notification(Geralt, <<"item1">>, Leaf,
+                                                     [{collection, Collection2}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Collection1, []),
@@ -1292,8 +1296,10 @@ notify_nested_collections_test(Config) ->
 
               %% Publish to leaf node, Bob and Geralt should get notifications
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
-              pubsub_tools:receive_item_notification(Geralt, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf,
+                                                     [{collection, MiddleCollection}]),
+              pubsub_tools:receive_item_notification(Geralt, <<"item1">>, Leaf,
+                                                     [{collection, TopCollection}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, MiddleCollection, []),
@@ -1464,8 +1470,8 @@ disable_payload_leaf_test(Config) ->
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
 
               %% Payloads disabled
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>,
-                                                     Leaf, [{with_payload, false}]),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf,
+                                                     [{with_payload, false}, {collection, Node}]),
 
               pubsub_tools:delete_node(Alice, Leaf, []),
               pubsub_tools:delete_node(Alice, Node, [])
@@ -1489,7 +1495,7 @@ disable_persist_items_leaf_test(Config) ->
               pubsub_tools:publish(Alice, <<"item1">>, Leaf, []),
 
               %% Notifications should work
-              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, []),
+              pubsub_tools:receive_item_notification(Bob, <<"item1">>, Leaf, [{collection, Node}]),
 
               %% No items should be stored
               pubsub_tools:get_all_items(Bob, Leaf, [{expected_result, []}]),

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -319,13 +319,17 @@ check_node_discovery_response(Response, {NodeAddr, NodeName}, ExpectedNodes) ->
     [NodeAddr = exml_query:attr(Item, <<"jid">>) || Item <- Items],
     ReceivedNodes = [exml_query:attr(Item, <<"node">>) || Item <- Items],
     ReceivedSet = ordsets:from_list(ReceivedNodes),
-    case ExpectedNodes of
-        {no, NoNodeName} ->
-            false = ordsets:is_element(NoNodeName, ReceivedSet);
-        _ ->
-            ExpectedSet = ordsets:from_list(ExpectedNodes),
-            true = ordsets:is_subset(ExpectedSet, ReceivedSet)
-    end,
+    {MustHaveNodes, MustNotHaveNodes}
+    = lists:splitwith(fun({no, _}) -> false;
+                         (_) -> true
+                      end, ExpectedNodes),
+
+    MustHaveSet = ordsets:from_list(MustHaveNodes),
+    true = ordsets:is_subset(MustHaveSet, ReceivedSet),
+
+    MustNotHaveSet = ordsets:from_list([HeWhoMustNotBeNamed
+                                        || {no, HeWhoMustNotBeNamed} <- MustNotHaveNodes]),
+    [] = ordsets:intersection(MustNotHaveSet, ReceivedSet),
 
     Response.
 

--- a/src/pubsub/gen_pubsub_nodetree.erl
+++ b/src/pubsub/gen_pubsub_nodetree.erl
@@ -32,9 +32,9 @@
 
 -include("jlib.hrl").
 
--export([init/4, terminate/3, options/1, set_node/2, get_node/4, get_node/3, get_node/2,
-         get_nodes/3, get_nodes/2, get_parentnodes/4, get_parentnodes_tree/4,
-         get_subnodes/4, get_subnodes_tree/4, create_node/7, delete_node/3]).
+-export([init/4, terminate/3, set_node/2, get_node/3, get_node/2,
+         get_nodes/3, get_parentnodes_tree/4,
+         get_subnodes/4, create_node/7, delete_node/3]).
 
 -type(host() :: mod_pubsub:host()).
 -type(nodeId() :: mod_pubsub:nodeId()).
@@ -50,13 +50,8 @@
 
 -callback terminate(Host :: host(), ServerHost :: binary()) -> atom().
 
--callback options() -> nodeOptions().
-
 -callback set_node(PubsubNode :: pubsubNode()) ->
     ok | {result, NodeIdx::nodeIdx()} | {error, exml:element()}.
-
--callback get_node(Host :: host(), NodeId :: nodeId(), From :: jid:jid()) ->
-    pubsubNode() | {error, exml:element()}.
 
 -callback get_node(Host :: host(), NodeId :: nodeId()) -> pubsubNode() | {error, exml:element()}.
 
@@ -64,17 +59,10 @@
 
 -callback get_nodes(Host :: host(), From :: jid:jid()) -> [pubsubNode()].
 
--callback get_nodes(Host :: host()) -> [pubsubNode()].
-
--callback get_parentnodes(Host :: host(), NodeId :: nodeId(), From :: jid:jid()) ->
-    [pubsubNode()] | {error, exml:element()}.
-
 -callback get_parentnodes_tree(Host :: host(), NodeId :: nodeId(), From :: jid:jid()) ->
     [{0, [pubsubNode(), ...]}].
 
 -callback get_subnodes(Host :: host(), NodeId :: nodeId(), From :: jid:jid()) -> [pubsubNode()].
-
--callback get_subnodes_tree(Host :: host(), NodeId :: nodeId(), From :: jid:jid()) -> [pubsubNode()].
 
 -callback create_node(Host :: host(),
                       NodeId :: nodeId(),
@@ -96,14 +84,8 @@ init(Mod, Host, ServerHost, Opts) ->
 terminate(Mod, Host, ServerHost) ->
     Mod:terminate(Host, ServerHost).
 
-options(Mod) ->
-    Mod:option().
-
 set_node(Mod, PubsubNode) ->
     Mod:set_node(PubsubNode).
-
-get_node(Mod, Host, NodeId, From) ->
-    Mod:get_node(Host, NodeId, From).
 
 get_node(Mod, Host, NodeId) ->
    Mod:get_node(Host, NodeId).
@@ -114,20 +96,11 @@ get_node(Mod, NodeIdx) ->
 get_nodes(Mod, Host, From) ->
     Mod:get_nodes(Host, From).
 
-get_nodes(Mod, Host) ->
-   Mod:get_nodes(Host).
-
-get_parentnodes(Mod, Host, NodeId, From) ->
-    Mod:get_parentnodes(Host, NodeId, From).
-
 get_parentnodes_tree(Mod, Host, NodeId, From) ->
     Mod:get_parentnodes_tree(Host, NodeId, From).
 
 get_subnodes(Mod, Host, NodeId, From) ->
    Mod:get_subnodes(Host, NodeId, From).
-
-get_subnodes_tree(Mod, Host, NodeId, From) ->
-   Mod:get_subnodes_tree(Host, NodeId, From).
 
 create_node(Mod, Host, NodeId, Type, Owner, Options, Parents) ->
     Mod:create_node(Host, NodeId, Type, Owner, Options, Parents).

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3683,7 +3683,7 @@ get_configure_transaction(Host, ServerHost, Node, From, Lang,
     end.
 
 get_default(Host, Node, _From, Lang) ->
-    Type = select_type(Host, Host, Node),
+    Type = select_type(Host, Node),
     Options = node_options(Host, Type),
     DefaultEl = #xmlel{name = <<"default">>, attrs = [],
                        children =
@@ -4104,6 +4104,12 @@ config(ServerHost, Key, Default) ->
         _ -> Default
     end.
 
+select_type(Host, Node) ->
+    select_type(serverhost(Host), Host, Node).
+
+select_type(ServerHost, Host, Node) ->
+    select_type(ServerHost, Host, Node, hd(plugins(ServerHost))).
+
 select_type(ServerHost, Host, Node, Type) ->
     SelectedType = case Host of
                        {_User, _Server, _Resource} ->
@@ -4114,14 +4120,11 @@ select_type(ServerHost, Host, Node, Type) ->
                        _ ->
                            Type
                    end,
-    ConfiguredTypes = plugins(ServerHost),
+    ConfiguredTypes = plugins(Host),
     case lists:member(SelectedType, ConfiguredTypes) of
         true -> SelectedType;
         false -> hd(ConfiguredTypes)
     end.
-
-select_type(ServerHost, Host, Node) ->
-    select_type(ServerHost, Host, Node, hd(plugins(ServerHost))).
 
 feature(<<"rsm">>) -> ?NS_RSM;
 feature(Feature) -> <<(?NS_PUBSUB)/binary, "#", Feature/binary>>.

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3514,7 +3514,7 @@ get_options_for_subs(Nidx, Subs) ->
                         Acc
                 end, [], Subs).
 
-broadcast_stanza(Host, _Node, _Nidx, _Type, NodeOptions,
+broadcast_stanza(Host, Node, _Nidx, _Type, NodeOptions,
                  SubsByDepth, NotifyType, BaseStanza, SHIM) ->
     NotificationType = get_option(NodeOptions, notification_type, headline),
     %% Option below is not standard, but useful
@@ -3523,7 +3523,7 @@ broadcast_stanza(Host, _Node, _Nidx, _Type, NodeOptions,
     Stanza = add_message_type(BaseStanza, NotificationType),
     %% Handles explicit subscriptions
     SubIDsByJID = subscribed_nodes_by_jid(NotifyType, SubsByDepth),
-    lists:foreach(fun ({LJID, _NodeName, SubIDs}) ->
+    lists:foreach(fun ({LJID, SubNodeName, SubIDs}) ->
                           LJIDs = case BroadcastAll of
                                       true ->
                                           {U, S, _} = LJID,
@@ -3531,16 +3531,9 @@ broadcast_stanza(Host, _Node, _Nidx, _Type, NodeOptions,
                                       false ->
                                           [LJID]
                                   end,
-                          %% Determine if the stanza should have SHIM ('SubID' and 'name') headers
-                          StanzaToSend = case {SHIM, SubIDs} of
-                                             {false, _} ->
-                                                 Stanza;
-                                             %% If there's only one SubID, don't add it
-                                             {true, [_]} ->
-                                                 Stanza;
-                                             {true, SubIDs} ->
-                                                 add_shim_headers(Stanza, subid_shim(SubIDs))
-                                         end,
+                          StanzaToSend = maybe_add_shim_headers(Stanza, SHIM, SubIDs,
+                                                                Node, SubNodeName),
+
                           lists:foreach(fun(To) ->
                                                 ejabberd_router:route(From, jid:make(To),
                                                                       StanzaToSend)
@@ -4313,14 +4306,22 @@ add_message_type(#xmlel{name = <<"message">>, attrs = Attrs, children = Els}, Ty
 add_message_type(XmlEl, _Type) ->
     XmlEl.
 
-%% Place of <headers/> changed at the bottom of the stanza
-%% cf. http://xmpp.org/extensions/xep-0060.html#publisher-publish-success-subid
-%%
-%% "[SHIM Headers] SHOULD be included after the event notification information
-%% (i.e., as the last child of the <message/> stanza)".
-
-add_shim_headers(Stanza, HeaderEls) ->
-    add_headers(Stanza, <<"headers">>, ?NS_SHIM, HeaderEls).
+maybe_add_shim_headers(Stanza, false, _SubIDs, _OriginNode, _SubNode) ->
+    Stanza;
+maybe_add_shim_headers(Stanza, true, SubIDs, OriginNode, SubNode) ->
+    Headers1 = case SubIDs of
+                   [_OnlyOneSubID] ->
+                       [];
+                   _ ->
+                       subid_shim(SubIDs)
+               end,
+    Headers2 = case SubNode of
+                   OriginNode ->
+                       Headers1;
+                   _ ->
+                       [collection_shim(SubNode) | Headers1]
+               end,
+    add_headers(Stanza, <<"headers">>, ?NS_SHIM, Headers2).
 
 add_extended_headers(Stanza, HeaderEls) ->
     add_headers(Stanza, <<"addresses">>, ?NS_ADDRESS, HeaderEls).
@@ -4333,10 +4334,15 @@ add_headers(#xmlel{name = Name, attrs = Attrs, children = Els}, HeaderName, Head
            children = lists:append(Els, [HeaderEl])}.
 
 subid_shim(SubIds) ->
-    [#xmlel{name = <<"header">>,
-            attrs = [{<<"name">>, <<"SubId">>}],
-            children = [{xmlcdata, SubId}]}
+    [#xmlel{ name = <<"header">>,
+             attrs = [{<<"name">>, <<"SubId">>}],
+             children = [#xmlcdata{ content = SubId }]}
      || SubId <- SubIds].
+
+collection_shim(CollectionNode) ->
+    #xmlel{ name = <<"header">>,
+            attrs = [{<<"name">>, <<"Collection">>}],
+            children = [#xmlcdata{ content = CollectionNode }] }.
 
 %% The argument is a list of Jids because this function could be used
 %% with the 'pubsub#replyto' (type=jid-multi) node configuration.

--- a/src/pubsub/node_hometree.erl
+++ b/src/pubsub/node_hometree.erl
@@ -66,11 +66,11 @@ create_node_permission(Host, _ServerHost, _Node, _ParentNode,
                        #jid{ luser = <<>>, lserver = Host, lresource = <<>> }, _Access) ->
     {result, true}; % pubsub service always allowed
 create_node_permission(_Host, ServerHost, Node, _ParentNode,
-                       #jid{ luser = User, lserver = Server } = Owner, Access) ->
+                       #jid{ luser = LUser, lserver = LServer } = Owner, Access) ->
     case acl:match_rule(ServerHost, Access, Owner) of
         allow ->
             case node_to_path(Node) of
-                [<<"home">>, Server, User | _] -> {result, true};
+                [<<"home">>, LServer, LUser | _] -> {result, true};
                 _ -> {result, false}
             end;
         _ -> {result, false}

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -26,10 +26,10 @@
 -include("pubsub.hrl").
 -include("jlib.hrl").
 
--export([init/3, terminate/2, options/0, set_node/1,
-         get_node/3, get_node/2, get_node/1, get_nodes/2,
-         get_nodes/1, get_parentnodes/3, get_parentnodes_tree/3,
-         get_subnodes/3, get_subnodes_tree/3, create_node/6,
+-export([init/3, terminate/2, set_node/1,
+         get_node/2, get_node/1, get_nodes/2,
+         get_parentnodes_tree/3,
+         get_subnodes/3, create_node/6,
          delete_node/2]).
 
 -define(DEFAULT_NODETYPE, leaf).
@@ -83,12 +83,6 @@ delete_node(Key, Node) ->
             [Record]
     end.
 
-options() ->
-    nodetree_tree:options().
-
-get_node(Key, Node, _From) ->
-    get_node(Key, Node).
-
 get_node(Key, Node) ->
     case mod_pubsub_db_backend:find_node_by_name(Key, Node) of
         false -> {error, mongoose_xmpp_errors:item_not_found()};
@@ -100,17 +94,6 @@ get_node(Node) ->
 
 get_nodes(Key, From) ->
     nodetree_tree:get_nodes(Key, From).
-
-get_nodes(Key) ->
-    nodetree_tree:get_nodes(Key).
-
-get_parentnodes(Key, Node, _From) ->
-    case mod_pubsub_db_backend:get_parentnodes(Key, Node) of
-        {error, not_found} ->
-            {error, mongoose_xmpp_errors:item_not_found()};
-        Result when is_list(Result) ->
-            Result
-    end.
 
 get_parentnodes_tree(Key, Node, _From) ->
     mod_pubsub_db_backend:get_parentnodes_tree(Key, Node).
@@ -126,9 +109,6 @@ get_subnodes(Host, Node) ->
         false -> {error, mongoose_xmpp_errors:item_not_found()};
         _ -> mod_pubsub_db_backend:get_subnodes(Host, Node)
     end.
-
-get_subnodes_tree(Host, Node, _From) ->
-    mod_pubsub_db_backend:get_subnodes_tree(Host, Node).
 
 %%====================================================================
 %% Internal functions

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -44,10 +44,10 @@
 -include("pubsub.hrl").
 -include("jlib.hrl").
 
--export([init/3, terminate/2, options/0, set_node/1,
-         get_node/3, get_node/2, get_node/1, get_nodes/2,
-         get_nodes/1, get_parentnodes/3, get_parentnodes_tree/3,
-         get_subnodes/3, get_subnodes_tree/3, create_node/6,
+-export([init/3, terminate/2, set_node/1,
+         get_node/2, get_node/1, get_nodes/2,
+         get_parentnodes_tree/3,
+         get_subnodes/3, create_node/6,
          delete_node/2]).
 
 init(_Host, _ServerHost, _Options) ->
@@ -56,14 +56,8 @@ init(_Host, _ServerHost, _Options) ->
 terminate(_Host, _ServerHost) ->
     ok.
 
-options() ->
-    [{virtual_tree, false}].
-
 set_node(Node) ->
     mod_pubsub_db_backend:set_node(Node).
-
-get_node(Host, Node, _From) ->
-    get_node(Host, Node).
 
 get_node(Host, Node) ->
     case catch mod_pubsub_db_backend:find_node_by_name(Host, Node) of
@@ -78,13 +72,7 @@ get_node(Nidx) ->
     end.
 
 get_nodes(Key, _From) ->
-    get_nodes(Key).
-
-get_nodes(Key) ->
     mod_pubsub_db_backend:find_nodes_by_key(Key).
-
-get_parentnodes(_Host, _Node, _From) ->
-    [].
 
 %% @doc <p>Default node tree does not handle parents, return a list
 %% containing just this node.</p>
@@ -97,15 +85,6 @@ get_parentnodes_tree(Host, Node, _From) ->
 get_subnodes(Host, Node, _From) ->
     mod_pubsub_db_backend:get_subnodes(Host, Node).
 
-
-get_subnodes_tree(Host, Node, _From) ->
-    get_subnodes_tree(Host, Node).
-
-get_subnodes_tree(Host, Node) ->
-    case get_node(Host, Node) of
-        {error, _} -> [];
-        NodeRec -> get_subnodes_of_existing_tree(Host, Node, NodeRec)
-    end.
 
 get_subnodes_of_existing_tree(Host, Node, NodeRec) ->
     BasePlugin = binary_to_atom(<<"node_", (NodeRec#pubsub_node.type)/binary>>, utf8),
@@ -148,7 +127,7 @@ check_parent_and_its_owner_list(_Host, [], _BJID) ->
     true;
 check_parent_and_its_owner_list(Host, [Parent | _], BJID) ->
     case catch mod_pubsub_db_backend:find_node_by_name(Host, Parent) of
-        #pubsub_node{owners = [{[], Host, []}]} ->
+        #pubsub_node{owners = [{<<>>, Host, <<>>}]} ->
             true;
         #pubsub_node{owners = Owners} ->
             lists:member(BJID, Owners);
@@ -166,3 +145,10 @@ delete_node(Host, Node) ->
         end,
         Removed),
     Removed.
+
+get_subnodes_tree(Host, Node) ->
+    case get_node(Host, Node) of
+        {error, _} -> [];
+        NodeRec -> get_subnodes_of_existing_tree(Host, Node, NodeRec)
+    end.
+

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -99,14 +99,14 @@ get_subnodes_of_existing_tree(Host, Node, NodeRec) ->
                  end,
                  [], pubsub_node).
 
-create_node(Host, Node, Type, Owner, Options, Parents) ->
+create_node(Host, NodeName, Type, Owner, Options, Parents) ->
     BJID = jid:to_lower(jid:to_bare(Owner)),
-    case catch mod_pubsub_db_backend:find_node_by_name(Host, Node) of
+    case catch mod_pubsub_db_backend:find_node_by_name(Host, NodeName) of
         false ->
             case check_parent_and_its_owner_list(Host, Parents, BJID) of
                 true ->
                     Nidx = pubsub_index:new(node),
-                    Node = #pubsub_node{nodeid = {Host, Node},
+                    Node = #pubsub_node{nodeid = {Host, NodeName},
                                         id = Nidx, parents = Parents,
                                         type = Type, owners = [BJID],
                                         options = Options},


### PR DESCRIPTION
This PR adds new or extends existing PubSub test cases to significantly improve coverage of code that performs `pubsub_node` operations in DB. It also includes small fixes and removes unused functions in plugins.

Depends on esl/escalus#193