### PR TITLE
Pubsub last item cache

### DIFF
--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -59,6 +59,14 @@ groups() ->
            authorize_access_model,
            unsubscribe_after_presence_unsubscription
           ]
+         },
+         {cache_tests, [parallel],
+          [
+           send_caps_after_login_test,
+           delayed_receive,
+           delayed_receive_with_sm,
+           unsubscribe_after_presence_unsubscription
+          ]
          }
         ],
     ct_helper:repeat_all_until_all_ok(G).
@@ -78,9 +86,18 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_suite(Config).
 
+init_per_group(cache_tests, Config) ->
+    Config0 = dynamic_modules:save_modules(domain(), Config),
+    NewConfig =  required_modules(cache_tests),
+    dynamic_modules:ensure_modules(domain(), NewConfig),
+    Config0;
+
 init_per_group(_GroupName, Config) ->
     dynamic_modules:ensure_modules(domain(), required_modules()),
     Config.
+
+end_per_group(cache_tests, Config) ->
+    dynamic_modules:restore_modules(domain(), Config);
 
 end_per_group(_GroupName, Config) ->
     Config.
@@ -297,6 +314,16 @@ required_modules() ->
                    {backend, mongoose_helper:mnesia_or_rdbms_backend()},
                    {pep_mapping, []},
                    {host, "pubsub.@HOST@"}
+                  ]}].
+required_modules(cache_tests) ->
+    [{mod_caps, []},
+     {mod_pubsub, [
+                   {plugins, [<<"dag">>, <<"pep">>]},
+                   {nodetree, <<"dag">>},
+                   {backend, mongoose_helper:mnesia_or_rdbms_backend()},
+                   {pep_mapping, []},
+                   {host, "pubsub.@HOST@"},
+                   {last_item_cache, mongoose_helper:mnesia_or_rdbms_backend()}
                   ]}].
 
 send_initial_presence_with_caps(NodeNS, User) ->

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -46,7 +46,8 @@
          disable_persist_items_test/1,
          notify_only_available_users_test/1,
          notify_unavailable_user_test/1,
-         send_last_published_item_test/1
+         send_last_published_item_test/1,
+         send_last_published_item_no_items_test/1
         ]).
 
 -export([
@@ -254,6 +255,7 @@ hometree_specific_tests() ->
 last_item_cache_tests() ->
     [
      send_last_published_item_test,
+     send_last_published_item_no_items_test,
      purge_all_items_test
     ].
 
@@ -821,6 +823,23 @@ send_last_published_item_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, [])
       end).
+
+send_last_published_item_no_items_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {bob, 1}],
+      fun(Alice, Bob) ->
+              NodeConfig = [{<<"pubsub#send_last_published_item">>, <<"on_sub_and_presence">>}],
+              Node = pubsub_node(),
+              pubsub_tools:create_node(Alice, Node, [{config, NodeConfig}]),
+
+              %% Note: when Bob subscribes, the last item would is sent to him
+              pubsub_tools:subscribe(Bob, Node, [{receive_response, false}]),
+              escalus_assert:has_no_stanzas(Bob),
+              pubsub_tools:delete_node(Alice, Node, [])
+      end).
+
+
 
 %%--------------------------------------------------------------------
 %% Node affiliations management

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -149,7 +149,8 @@ base_groups() ->
          {collection_config, [parallel], collection_config_tests()},
          {debug_calls, [parallel], debug_calls_tests()},
          {pubsub_item_publisher_option, [parallel], pubsub_item_publisher_option_tests()},
-         {hometree_specific, [parallel], hometree_specific_tests()}
+         {hometree_specific, [parallel], hometree_specific_tests()},
+         {last_item_cache, [parallel], last_item_cache_tests()}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -250,6 +251,12 @@ hometree_specific_tests() ->
      deleting_parent_path_deletes_children
     ].
 
+last_item_cache_tests() ->
+    [
+     send_last_published_item_test,
+     purge_all_items_test
+    ].
+
 encode_group_name(BaseName, NodeTree) ->
     binary_to_atom(<<NodeTree/binary, $+, (atom_to_binary(BaseName, utf8))/binary>>, utf8).
 
@@ -284,6 +291,11 @@ extra_options_by_group_name(#{ node_tree := NodeTree,
                                base_name := hometree_specific }) ->
     [{nodetree, NodeTree},
      {plugins, [<<"hometree">>]}];
+extra_options_by_group_name(#{ node_tree := NodeTree,
+                               base_name := last_item_cache}) ->
+    [{nodetree, NodeTree},
+     {plugins, [plugin_by_nodetree(NodeTree)]},
+     {last_item_cache, mongoose_helper:mnesia_or_rdbms_backend()}];
 extra_options_by_group_name(#{ node_tree := NodeTree }) ->
     [{nodetree, NodeTree},
      {plugins, [plugin_by_nodetree(NodeTree)]}].

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -508,6 +508,17 @@ CREATE TABLE dbo.pubsub_items (
     )
 )
 GO
+
+CREATE TABLE dbo.pubsub_last_item (
+    nidx BIGINT                      NOT NULL PRIMARY KEY,
+    itemid NVARCHAR(250)             NOT NULL,
+    created_luser NVARCHAR(250)      NOT NULL,
+    created_lserver NVARCHAR(250)    NOT NULL,
+    created_at BIGINT                NOT NULL,
+    payload VARBINARY(max)           NOT NULL
+)
+GO
+
 -- we skip luser and lserver in this one as this is little chance (even impossible?)
 -- to have itemid duplication for distinct users
 CREATE INDEX i_pubsub_items_lus_nidx ON pubsub_items(created_luser, created_lserver, nidx);

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -379,6 +379,17 @@ CREATE TABLE pubsub_items (
     PRIMARY KEY(nidx, itemid)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pubsub_last_item (
+    nidx BIGINT                      NOT NULL,
+    itemid VARCHAR(250)              NOT NULL,
+    created_luser VARCHAR(250)       NOT NULL,
+    created_lserver VARCHAR(250)     NOT NULL,
+    created_at BIGINT                NOT NULL,
+    payload TEXT                     NOT NULL,
+	PRIMARY KEY (nidx)
+);
+
 -- we skip luser and lserver in this one as this is little chance (even impossible?)
 -- to have itemid duplication for distinct users
 CREATE INDEX i_pubsub_items_nidx_itemid USING BTREE ON pubsub_items(nidx);

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -341,6 +341,16 @@ CREATE TABLE pubsub_items (
     PRIMARY KEY(nidx, itemid)
 );
 
+CREATE TABLE pubsub_last_item (
+    nidx                BIGINT       NOT NULL,
+    itemid              VARCHAR(250) NOT NULL,
+    created_luser       VARCHAR(250) NOT NULL,
+    created_lserver     VARCHAR(250) NOT NULL,
+    created_at          BIGINT       NOT NULL,
+    payload             TEXT         NOT NULL,
+	PRIMARY KEY (nidx)
+);
+
 -- we skip luser and lserver in this one as this is little chance (even impossible?)
 -- to have itemid duplication for distinct users
 CREATE INDEX i_pubsub_items_lus_nidx ON pubsub_items(created_luser, created_lserver, nidx);

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -4032,7 +4032,7 @@ set_cached_item({_, ServerHost, _}, Nidx, ItemId, Publisher, Payload) ->
     set_cached_item(ServerHost, Nidx, ItemId, Publisher, Payload);
 set_cached_item(Host, Nidx, ItemId, Publisher, Payload) ->
     is_last_item_cache_enabled(Host) andalso
-        mod_pubsub_cache_backend:upsert_last_item(Nidx, ItemId, Publisher, Payload).
+        mod_pubsub_cache_backend:upsert_last_item(serverhost(Host), Nidx, ItemId, Publisher, Payload).
 
 unset_cached_item({_, ServerHost, _}, Nidx) ->
     unset_cached_item(ServerHost, Nidx);

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -4047,7 +4047,7 @@ get_cached_item({_, ServerHost, _}, Nidx) ->
 get_cached_item(Host, Nidx) ->
     is_last_item_cache_enabled(Host) andalso
         case mod_pubsub_cache_backend:get_last_item(serverhost(Host), Nidx) of
-                [#pubsub_last_item{itemid = ItemId, creation = Creation, payload = Payload}] ->
+            {ok, #pubsub_last_item{itemid = ItemId, creation = Creation, payload = Payload}} ->
                     #pubsub_item{itemid = {ItemId, Nidx},
                                  payload = Payload, creation = Creation,
                                  modification = Creation};

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -4038,7 +4038,7 @@ unset_cached_item({_, ServerHost, _}, Nidx) ->
     unset_cached_item(ServerHost, Nidx);
 unset_cached_item(Host, Nidx) ->
     is_last_item_cache_enabled(Host) andalso
-        mod_pubsub_cache_backend:delete_last_item(Nidx).
+        mod_pubsub_cache_backend:delete_last_item(serverhost(Host), Nidx).
 
 -spec get_cached_item(ServerHost :: mod_pubsub:host(),
                       Nidx :: mod_pubsub:nodeIdx()) -> false | mod_pubsub:pubsubItem().
@@ -4046,7 +4046,7 @@ get_cached_item({_, ServerHost, _}, Nidx) ->
     get_cached_item(ServerHost, Nidx);
 get_cached_item(Host, Nidx) ->
     is_last_item_cache_enabled(Host) andalso
-        case mod_pubsub_cache_backend:get_last_item(Nidx) of
+        case mod_pubsub_cache_backend:get_last_item(serverhost(Host), Nidx) of
                 [#pubsub_last_item{itemid = ItemId, creation = Creation, payload = Payload}] ->
                     #pubsub_item{itemid = {ItemId, Nidx},
                                  payload = Payload, creation = Creation,

--- a/src/pubsub/mod_pubsub_cache.erl
+++ b/src/pubsub/mod_pubsub_cache.erl
@@ -19,7 +19,9 @@
                            Publisher::jid:ljid(),
                            Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
 
--callback delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
+-callback delete_last_item(Host :: binary(),
+                           Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
 
--callback get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+-callback get_last_item(Host :: binary(),
+                        Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
 

--- a/src/pubsub/mod_pubsub_cache.erl
+++ b/src/pubsub/mod_pubsub_cache.erl
@@ -10,15 +10,16 @@
 
 -callback stop() -> ok.
 
--callback upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
+-callback upsert_last_item(ServerHost :: binary(),
+                           Nidx :: mod_pubsub:nodeIdx(),
                            ItemID :: mod_pubsub:itemId(),
                            Publisher::jid:ljid(),
                            Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
 
--callback delete_last_item(Host :: binary(),
+-callback delete_last_item(ServerHost :: binary(),
                            Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
 
--callback get_last_item(Host :: binary(),
+-callback get_last_item(ServerHost :: binary(),
                         Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, LastItem :: mod_pubsub:pubsubLastItem()} | {error, Reason :: term()}.
 

--- a/src/pubsub/mod_pubsub_cache.erl
+++ b/src/pubsub/mod_pubsub_cache.erl
@@ -1,0 +1,25 @@
+-module(mod_pubsub_cache).
+
+%%====================================================================
+%% Behaviour callbacks
+%%====================================================================
+
+%% ------------------------ Backend start/stop ------------------------
+
+-callback start() -> ok.
+
+-callback stop() -> ok.
+
+-callback create_table() -> ok | {error, Reason :: term()}.
+
+-callback delete_table() -> ok | {error, Reason :: term()}.
+
+-callback upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
+                           ItemID :: mod_pubsub:itemId(),
+                           Publisher::jid:ljid(),
+                           Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
+
+-callback delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
+
+-callback get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+

--- a/src/pubsub/mod_pubsub_cache.erl
+++ b/src/pubsub/mod_pubsub_cache.erl
@@ -10,10 +10,6 @@
 
 -callback stop() -> ok.
 
--callback create_table() -> ok | {error, Reason :: term()}.
-
--callback delete_table() -> ok | {error, Reason :: term()}.
-
 -callback upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
                            ItemID :: mod_pubsub:itemId(),
                            Publisher::jid:ljid(),

--- a/src/pubsub/mod_pubsub_cache.erl
+++ b/src/pubsub/mod_pubsub_cache.erl
@@ -19,5 +19,6 @@
                            Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
 
 -callback get_last_item(Host :: binary(),
-                        Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+                        Nidx :: mod_pubsub:nodeIdx()) ->
+    {ok, LastItem :: mod_pubsub:pubsubLastItem()} | {error, Reason :: term()}.
 

--- a/src/pubsub/mod_pubsub_cache_mnesia.erl
+++ b/src/pubsub/mod_pubsub_cache_mnesia.erl
@@ -5,36 +5,74 @@
 
 -export([start/0, stop/0]).
 
--export([create_table/0, delete_table/0, insert_last_item/4, delete_last_item/1, get_last_item/1]).
+-export([
+    create_table/0,
+    delete_table/0,
+    upsert_last_item/4,
+    get_last_item/1,
+    delete_last_item/1]).
+
 %% ------------------------ Backend start/stop ------------------------
 
 -spec start() -> ok.
 start() ->
-   ok.
+    create_table().
 
 -spec stop() -> ok.
 stop() ->
-    ok.
+    delete_table().
 
 -spec create_table() -> ok | {error, Reason :: term()}.
 create_table() ->
-    ok.
+    QueryResult = mnesia:create_table(
+        pubsub_last_item,
+        [
+            {ram_copies, [node()]},
+            {attributes, record_info(fields, pubsub_last_item)}
+        ]),
+        mnesia:add_table_copy(pubsub_last_item, node(), ram_copies),
+        process_query_result(QueryResult).
 
 -spec delete_table() -> ok | {error, Reason :: term()}.
 delete_table() ->
-    ok.
+    QueryResult = mnesia:del_table_copy(pubsub_last_item, node()),
+    process_query_result(QueryResult).
 
--spec insert_last_item(Nidx :: mod_pubsub:nodeIdx(),
+-spec upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
                  ItemID :: mod_pubsub:itemId(),
-                 Publisher::{erlang:timestamp(), jid:ljid()},
+                 Publisher::jid:ljid(),
                  Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
-insert_last_item(_, _, _, _) ->
-    ok.
-
--spec delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
-delete_last_item(_) ->
-    ok.
+upsert_last_item(Nidx, ItemId, Publisher, Payload) ->
+    try mnesia:dirty_write(
+        {pubsub_last_item,
+        Nidx,
+        ItemId,
+        {os:timestamp(), jid:to_lower(jid:to_bare(Publisher))},
+        Payload}
+    ) of
+        ok -> ok
+    catch
+        exit:{aborted, Reason} -> {error, Reason}
+    end.
 
 -spec get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
-get_last_item(_) ->
-    [].
+get_last_item(Nidx) ->
+    try mnesia:dirty_read({pubsub_last_item, Nidx}) of
+        L when is_list(L) -> L
+    catch
+        exit:{aborted, Reason} -> {error, Reason}
+    end.
+
+-spec delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
+delete_last_item(Nidx) ->
+    try mnesia:dirty_delete({pubsub_last_item, Nidx}) of
+        ok -> ok
+    catch
+        exit:{aborted, Reason} -> {error, Reason}
+    end.
+
+%% ------------------------ Helpers ----------------------------
+
+process_query_result({atomic, ok}) -> ok;
+process_query_result({aborted, {already_exists, pubsub_last_item}}) -> ok;
+process_query_result({aborted, Reason}) -> {error, Reason}.

--- a/src/pubsub/mod_pubsub_cache_mnesia.erl
+++ b/src/pubsub/mod_pubsub_cache_mnesia.erl
@@ -6,11 +6,11 @@
 -export([start/0, stop/0]).
 
 -export([
-    create_table/0,
-    delete_table/0,
-    upsert_last_item/4,
-    get_last_item/1,
-    delete_last_item/1]).
+         create_table/0,
+         delete_table/0,
+         upsert_last_item/4,
+         get_last_item/2,
+         delete_last_item/2]).
 
 %% ------------------------ Backend start/stop ------------------------
 
@@ -55,16 +55,18 @@ upsert_last_item(Nidx, ItemId, Publisher, Payload) ->
         exit:{aborted, Reason} -> {error, Reason}
     end.
 
--spec get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
-get_last_item(Nidx) ->
+-spec get_last_item(Host :: binary(),
+                    Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+get_last_item(_Host, Nidx) ->
     try mnesia:dirty_read({pubsub_last_item, Nidx}) of
         L when is_list(L) -> L
     catch
         exit:{aborted, Reason} -> {error, Reason}
     end.
 
--spec delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
-delete_last_item(Nidx) ->
+-spec delete_last_item(Host :: binary(),
+                       Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
+delete_last_item(_Host, Nidx) ->
     try mnesia:dirty_delete({pubsub_last_item, Nidx}) of
         ok -> ok
     catch

--- a/src/pubsub/mod_pubsub_cache_mnesia.erl
+++ b/src/pubsub/mod_pubsub_cache_mnesia.erl
@@ -1,0 +1,40 @@
+-module(mod_pubsub_cache_mnesia).
+
+-include("pubsub.hrl").
+-include("jlib.hrl").
+
+-export([start/0, stop/0]).
+
+-export([create_table/0, delete_table/0, insert_last_item/4, delete_last_item/1, get_last_item/1]).
+%% ------------------------ Backend start/stop ------------------------
+
+-spec start() -> ok.
+start() ->
+   ok.
+
+-spec stop() -> ok.
+stop() ->
+    ok.
+
+-spec create_table() -> ok | {error, Reason :: term()}.
+create_table() ->
+    ok.
+
+-spec delete_table() -> ok | {error, Reason :: term()}.
+delete_table() ->
+    ok.
+
+-spec insert_last_item(Nidx :: mod_pubsub:nodeIdx(),
+                 ItemID :: mod_pubsub:itemId(),
+                 Publisher::{erlang:timestamp(), jid:ljid()},
+                 Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
+insert_last_item(_, _, _, _) ->
+    ok.
+
+-spec delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
+delete_last_item(_) ->
+    ok.
+
+-spec get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+get_last_item(_) ->
+    [].

--- a/src/pubsub/mod_pubsub_cache_mnesia.erl
+++ b/src/pubsub/mod_pubsub_cache_mnesia.erl
@@ -41,7 +41,8 @@ upsert_last_item(Nidx, ItemId, Publisher, Payload) ->
                     Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
 get_last_item(_Host, Nidx) ->
     try mnesia:dirty_read({pubsub_last_item, Nidx}) of
-        L when is_list(L) -> L
+        [LastItem] -> {ok, LastItem};
+        [] -> {error, no_items}
     catch
         exit:{aborted, Reason} -> {error, Reason}
     end.

--- a/src/pubsub/mod_pubsub_cache_mnesia.erl
+++ b/src/pubsub/mod_pubsub_cache_mnesia.erl
@@ -6,8 +6,6 @@
 -export([start/0, stop/0]).
 
 -export([
-         create_table/0,
-         delete_table/0,
          upsert_last_item/4,
          get_last_item/2,
          delete_last_item/2]).
@@ -20,23 +18,7 @@ start() ->
 
 -spec stop() -> ok.
 stop() ->
-    delete_table().
-
--spec create_table() -> ok | {error, Reason :: term()}.
-create_table() ->
-    QueryResult = mnesia:create_table(
-        pubsub_last_item,
-        [
-            {ram_copies, [node()]},
-            {attributes, record_info(fields, pubsub_last_item)}
-        ]),
-        mnesia:add_table_copy(pubsub_last_item, node(), ram_copies),
-        process_query_result(QueryResult).
-
--spec delete_table() -> ok | {error, Reason :: term()}.
-delete_table() ->
-    QueryResult = mnesia:del_table_copy(pubsub_last_item, node()),
-    process_query_result(QueryResult).
+    ok.
 
 -spec upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
                  ItemID :: mod_pubsub:itemId(),
@@ -74,6 +56,17 @@ delete_last_item(_Host, Nidx) ->
     end.
 
 %% ------------------------ Helpers ----------------------------
+
+-spec create_table() -> ok | {error, Reason :: term()}.
+create_table() ->
+    QueryResult = mnesia:create_table(
+        pubsub_last_item,
+        [
+            {ram_copies, [node()]},
+            {attributes, record_info(fields, pubsub_last_item)}
+        ]),
+        mnesia:add_table_copy(pubsub_last_item, node(), ram_copies),
+        process_query_result(QueryResult).
 
 process_query_result({atomic, ok}) -> ok;
 process_query_result({aborted, {already_exists, pubsub_last_item}}) -> ok;

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -6,8 +6,7 @@
 
 -export([start/0, stop/0]).
 
--export([create_table/0,
-         delete_table/0,
+-export([
          upsert_last_item/4,
          delete_last_item/2,
          get_last_item/2]).
@@ -20,12 +19,6 @@ start() -> ok.
 stop() -> ok.
 
 %% ------------------- Pubusub last item ------------------------------
-
--spec create_table() -> ok | {error, Reason :: term()}.
-create_table() -> ok.
-
--spec delete_table() -> ok | {error, Reason :: term()}.
-delete_table() -> ok.
 
 -spec upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
     ItemID :: mod_pubsub:itemId(),

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -1,0 +1,40 @@
+-module(mod_pubsub_cache_rdbms).
+
+-include("pubsub.hrl").
+-include("jlib.hrl").
+
+-export([start/0, stop/0]).
+
+-export([create_table/0, delete_table/0, insert_last_item/4, delete_last_item/1, get_last_item/1]).
+%% ------------------------ Backend start/stop ------------------------
+
+-spec start() -> ok.
+start() ->
+   ok.
+
+-spec stop() -> ok.
+stop() ->
+    ok.
+
+-spec create_table() -> ok | {error, Reason :: term()}.
+create_table() ->
+    ok.
+
+-spec delete_table() -> ok | {error, Reason :: term()}.
+delete_table() ->
+    ok.
+
+-spec insert_last_item(Nidx :: mod_pubsub:nodeIdx(),
+                 ItemID :: mod_pubsub:itemId(),
+                 Publisher::{erlang:timestamp(), jid:ljid()},
+                 Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
+insert_last_item(_, _, _, _) ->
+    ok.
+
+-spec delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
+delete_last_item(_) ->
+    ok.
+
+-spec get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+get_last_item(_) ->
+    [].

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -30,14 +30,14 @@ upsert_last_item(ServerHost, Nidx, ItemID, Publisher, Payload) ->
     PayloadXML = #xmlel{name = <<"item">>, children = Payload},
     ReadQuerySQL = upsert_pubsub_last_item(Nidx, ItemID, Publisher, PayloadXML, Backend),
     Res = mongoose_rdbms:sql_query(ServerHost, ReadQuerySQL),
-    check_rdbms_response(Res).
+    convert_rdbms_response(Res).
 
 -spec delete_last_item(ServerHost :: binary(),
                        Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
 delete_last_item(ServerHost, Nidx) ->
     DeleteQuerySQL = delete_pubsub_last_item(Nidx),
     Res = mongoose_rdbms:sql_query(ServerHost, DeleteQuerySQL),
-    check_rdbms_response(Res).
+    convert_rdbms_response(Res).
 
 -spec get_last_item(ServerHost :: binary(),
                     Nidx :: mod_pubsub:nodeIdx()) ->
@@ -45,7 +45,7 @@ delete_last_item(ServerHost, Nidx) ->
 get_last_item(ServerHost, Nidx) ->
     ReadQuerySQL = get_pubsub_last_item(Nidx),
     Res = mongoose_rdbms:sql_query(ServerHost, ReadQuerySQL),
-    check_rdbms_response(Res).
+    convert_rdbms_response(Res).
 
 -spec get_pubsub_last_item(mod_pubsub:nodeIdx()) -> iolist().
 get_pubsub_last_item(Nidx) ->
@@ -129,14 +129,14 @@ upsert_parametrized(Nidx, ItemId, Publisher, Payload, OnConflictLine) ->
 %% Helpers
 %%====================================================================
 
-check_rdbms_response({selected, []}) ->
+convert_rdbms_response({selected, []}) ->
     {error, no_items};
-check_rdbms_response({selected, [SelectedItem]}) ->
+convert_rdbms_response({selected, [SelectedItem]}) ->
     LastItem = item_to_record(SelectedItem),
     {ok, LastItem};
-check_rdbms_response({updated, _}) ->
+convert_rdbms_response({updated, _}) ->
     ok;
-check_rdbms_response(Response) ->
+convert_rdbms_response(Response) ->
     ?ERROR_MSG("RDBMS cache failed with: ~p", [Response]),
     {error, pubsub_rdbms_cache_failed}.
 

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -39,7 +39,7 @@ delete_last_item(Host, Nidx) ->
 
 -spec get_last_item(Host :: binary(),
                     Nidx :: mod_pubsub:nodeIdx()) ->
-    [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+    {ok, LastItem :: mod_pubsub:pubsubLastItem()} | {error, Reason :: term()}.
 get_last_item(Host, Nidx) ->
     ReadQuerySQL = get_pubsub_last_item(Nidx),
     Res = mongoose_rdbms:sql_query(Host, ReadQuerySQL),
@@ -127,8 +127,8 @@ upsert_parametrized(Nidx, ItemId, Publisher, Payload, OnConflictLine) ->
 %% Helpers
 %%====================================================================
 
-check_rdbms_response({selected, LastItemRows}) ->
-    LastItemRows;
+check_rdbms_response({selected, [LastItem]}) ->
+    {ok, LastItem};
 check_rdbms_response({updated, _}) ->
     ok;
 check_rdbms_response(Response) ->

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -5,36 +5,91 @@
 
 -export([start/0, stop/0]).
 
--export([create_table/0, delete_table/0, insert_last_item/4, delete_last_item/1, get_last_item/1]).
+-export([create_table/0,
+    delete_table/0,
+    insert_last_item/4,
+    delete_last_item/1,
+    get_last_item/1]).
 %% ------------------------ Backend start/stop ------------------------
 
 -spec start() -> ok.
-start() ->
-   ok.
+start() -> ok.
 
 -spec stop() -> ok.
-stop() ->
-    ok.
+stop() -> ok.
 
 -spec create_table() -> ok | {error, Reason :: term()}.
-create_table() ->
-    ok.
+create_table() -> ok.
 
 -spec delete_table() -> ok | {error, Reason :: term()}.
-delete_table() ->
-    ok.
+delete_table() -> ok.
 
 -spec insert_last_item(Nidx :: mod_pubsub:nodeIdx(),
-                 ItemID :: mod_pubsub:itemId(),
-                 Publisher::{erlang:timestamp(), jid:ljid()},
-                 Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
-insert_last_item(_, _, _, _) ->
+    ItemID :: mod_pubsub:itemId(),
+    Publisher::{erlang:timestamp(), jid:ljid()},
+    Payload::mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
+insert_last_item(Nidx, ItemID, Publisher, Payload) ->
+    ReadQuerySQL = insert_pubsub_last_item(Nidx, ItemID, Publisher, Payload),
+    mongoose_rdbms:sql_query(Publisher#jid.lserver, ReadQuerySQL),
     ok.
 
 -spec delete_last_item(Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
-delete_last_item(_) ->
+delete_last_item(Nidx) ->
+    DeleteQuerySQL = delete_pubsub_last_item(Nidx),
+    {updated, _} = mongoose_rdbms:sql_query(global, DeleteQuerySQL),
     ok.
 
--spec get_last_item(Nidx :: mod_pubsub:nodeIdx()) -> [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
-get_last_item(_) ->
-    [].
+-spec get_last_item(Nidx :: mod_pubsub:nodeIdx()) ->
+    [mod_pubsub:pubsubLastItem()] | {error, Reason :: term()}.
+get_last_item(Nidx) ->
+    ReadQuerySQL = get_pubsub_last_item(Nidx),
+    {selected, LastItemRows} = mongoose_rdbms:sql_query(global, ReadQuerySQL),
+    LastItemRows.
+
+%% ------------------- Pubusub last item ------------------------------
+
+-spec get_pubsub_last_item(mod_pubsub:nodeIdx()) -> iolist().
+get_pubsub_last_item(Nidx) ->
+    ["SELECT * FROM pubsub_last_item"
+    " WHERE nidx = ", esc_int(Nidx), ";"].
+
+ -spec delete_pubsub_last_item(mod_pubsub:nodeIdx()) -> iolist().
+delete_pubsub_last_item(Nidx) ->
+    ["DELETE FROM pubsub_last_item"
+    " WHERE nidx = ", esc_int(Nidx), ";"].
+
+ -spec insert_pubsub_last_item(
+    Nidx::mod_pubsub:nodeIdx(),
+    ItemId::mod_pubsub:itemId(),
+    Publisher::jid:ljid(),
+    Payload::mod_pubsub:payload()) -> iolist().
+insert_pubsub_last_item(Nidx, ItemId, Jid, Payload) ->
+   EscCreatedAt = esc_int(usec:from_now(os:timestamp())),
+   BinaryPayload = exml:to_binary(Payload),
+   EscPayload = esc_string(BinaryPayload),
+   EscModifiedLUser = esc_string(Jid#jid.luser),
+   EscModifiedLServer = esc_string(Jid#jid.lserver),
+   [
+       "INSERT INTO pubsub_last_item (",
+       columns(),
+       ") VALUES (",
+           esc_int(Nidx),", ",
+           esc_string(ItemId),", ",
+           EscModifiedLUser,", ",
+           EscModifiedLServer,", ",
+           EscCreatedAt,", ",
+           EscPayload,
+   ");"].
+
+columns() -> "nidx, itemid, created_luser, created_lserver, created_at, payload".
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+esc_string(String) ->
+    mongoose_rdbms:use_escaped_string(mongoose_rdbms:escape_string(String)).
+
+esc_int(Int) ->
+    mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).
+

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -7,7 +7,7 @@
 -export([start/0, stop/0]).
 
 -export([
-         upsert_last_item/4,
+         upsert_last_item/5,
          delete_last_item/2,
          get_last_item/2]).
 %% ------------------------ Backend start/stop ------------------------
@@ -20,29 +20,30 @@ stop() -> ok.
 
 %% ------------------- Pubusub last item ------------------------------
 
--spec upsert_last_item(Nidx :: mod_pubsub:nodeIdx(),
-    ItemID :: mod_pubsub:itemId(),
-    Publisher ::jid:jid(),
-    Payload :: mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
-upsert_last_item(Nidx, ItemID, Publisher, Payload) ->
-    Backend = {mongoose_rdbms:db_engine(global), mongoose_rdbms_type:get()},
+-spec upsert_last_item(ServerHost :: binary(),
+                       Nidx :: mod_pubsub:nodeIdx(),
+                       ItemID :: mod_pubsub:itemId(),
+                       Publisher ::jid:jid(),
+                       Payload :: mod_pubsub:payload()) -> ok | {error, Reason :: term()}.
+upsert_last_item(ServerHost, Nidx, ItemID, Publisher, Payload) ->
+    Backend = {mongoose_rdbms:db_engine(ServerHost), mongoose_rdbms_type:get()},
     ReadQuerySQL = upsert_pubsub_last_item(Nidx, ItemID, Publisher, Payload, Backend),
-    Res = mongoose_rdbms:sql_query(Publisher#jid.lserver, ReadQuerySQL),
+    Res = mongoose_rdbms:sql_query(ServerHost, ReadQuerySQL),
     check_rdbms_response(Res).
 
--spec delete_last_item(Host :: binary(),
+-spec delete_last_item(ServerHost :: binary(),
                        Nidx :: mod_pubsub:nodeIdx()) -> ok | {error, Reason :: term()}.
-delete_last_item(Host, Nidx) ->
+delete_last_item(ServerHost, Nidx) ->
     DeleteQuerySQL = delete_pubsub_last_item(Nidx),
-    Res = mongoose_rdbms:sql_query(Host, DeleteQuerySQL),
+    Res = mongoose_rdbms:sql_query(ServerHost, DeleteQuerySQL),
     check_rdbms_response(Res).
 
--spec get_last_item(Host :: binary(),
+-spec get_last_item(ServerHost :: binary(),
                     Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, LastItem :: mod_pubsub:pubsubLastItem()} | {error, Reason :: term()}.
-get_last_item(Host, Nidx) ->
+get_last_item(ServerHost, Nidx) ->
     ReadQuerySQL = get_pubsub_last_item(Nidx),
-    Res = mongoose_rdbms:sql_query(Host, ReadQuerySQL),
+    Res = mongoose_rdbms:sql_query(ServerHost, ReadQuerySQL),
     check_rdbms_response(Res).
 
 -spec get_pubsub_last_item(mod_pubsub:nodeIdx()) -> iolist().


### PR DESCRIPTION
This PR introduces following changes to `mod_pubsub`:

- `mnesia` cache backend for `pubsub_last_item` extracted to a separate _cache_ backend module
- _cache_ backend can be configured also to use `rdbms`
- the `mod_pubsub_cache_rdbms` is implemented