### PR TITLE
Fail the test if there are auto skipped cases

### DIFF
--- a/tools/summarise-ct-results
+++ b/tools/summarise-ct-results
@@ -49,7 +49,11 @@ verify_results_with_groups(OkGroups, FailedGroups, EventuallyOkTests,
             erlang:halt(100404);
         OkGroups =< 0 ->
             erlang:halt(100405);
+        AutoSkipped > 0 ->
+            io:format("Failing the test due to auto skipped cases~n"),
+            erlang:halt(AutoSkipped);
         true ->
+            io:format("Failing the test due failed rerun groups~n"),
             erlang:halt(FailedGroups + FailedTests - EventuallyOkTests)
     end.
 


### PR DESCRIPTION
This PR fixes a bug in verification if a test run was successful or not. Accidentally we stopped looking at the auto skipped cases, which in our tests show a bug in init_per_suite or init_per_group.

