### PR TITLE
Use patched nkpacket lib

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -69,7 +69,7 @@
   {csv, {git, "https://github.com/bszaf/csv.git", {branch, "master"}}},
   {cpool, "0.1.0"},
   {observer_cli, "1.4.1"},
-  {nkpacket, {git, "https://github.com/michalwski/nkpacket.git", {ref, "b6f8c73"}}},
+  {nkpacket, {git, "https://github.com/michalwski/nkpacket.git", {ref, "f7c5349"}}},
   {nksip, {git, "https://github.com/NetComposer/nksip.git", {ref, "1a29ef3"}}},
   {eredis, {git, "https://github.com/igors/eredis.git", {ref, "e9688a1"}}},
   {gen_fsm_compat, "0.3.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -94,7 +94,7 @@
   1},
  {<<"nkpacket">>,
   {git,"https://github.com/michalwski/nkpacket.git",
-       {ref,"b6f8c735e3778ce3d351b6564d8cf21c14fbab5e"}},
+       {ref,"f7c5349af285ec0e5c43e90b9ef7668a2d2411c8"}},
   0},
  {<<"nkservice">>,
   {git,"https://github.com/Nekso/nkservice",

--- a/tools/summarise-ct-results
+++ b/tools/summarise-ct-results
@@ -49,7 +49,11 @@ verify_results_with_groups(OkGroups, FailedGroups, EventuallyOkTests,
             erlang:halt(100404);
         OkGroups =< 0 ->
             erlang:halt(100405);
+        AutoSkipped > 0 ->
+            io:format("Failing the test due to auto skipped cases~n"),
+            erlang:halt(AutoSkipped);
         true ->
+            io:format("Failing the test due failed rerun groups~n"),
             erlang:halt(FailedGroups + FailedTests - EventuallyOkTests)
     end.
 


### PR DESCRIPTION
This PR uses patched `nkpacket` lib which works fine with ranch 1.7.
Also this PR includes a fix for test verification, more details in #2146

