### PR TITLE
Time to start travis builds ond Ubuntu Xenial 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: erlang
-dist: trusty
+dist: xenial
 sudo: required
 addons:
     apt:


### PR DESCRIPTION
Travis finally allowed to run builds on newer (not newest) Ubuntu LTS version Xenial (16.04). This change doesn't give us any performance improvements but we can finally build and test our software on newer OS. Currently used Trusty will be officially supported by Ubuntu until April 2019, we probably don't want to build and test MongooseIM on such old OS. Let's move to Xenial! 

