### PR TITLE
Adds optional tear_down callback to mod_vcard backends

### DIFF
--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -119,6 +119,10 @@
     VHost :: jid:lserver(),
     Lang :: binary().
 
+-callback tear_down(jid:lserver()) -> ok.
+
+-optional_callbacks([tear_down/1]).
+
 -spec default_search_fields() -> list().
 default_search_fields() ->
     [{<<"User">>, <<"user">>},
@@ -164,6 +168,14 @@ start(VHost, Opts) ->
 
 stop(VHost) ->
     Proc = gen_mod:get_module_proc(VHost, ?PROCNAME),
+    try
+      mod_vcard_backend:tear_down(VHost)
+    catch
+      error:undef ->
+        %% This is expected for other backends than ldap
+        ok
+    end,
+
     gen_server:call(Proc, stop),
     ejabberd_sup:stop_child(Proc).
 

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -43,6 +43,7 @@
 
 %% mod_vcards callbacks
 -export([init/2,
+         tear_down/1,
          remove_user/2,
          get_vcard/2,
          set_vcard/4,
@@ -139,6 +140,11 @@
 
 init(VHost, Options) ->
     start_link(VHost, Options),
+    ok.
+
+tear_down(LServer) ->
+    Proc = gen_mod:get_module_proc(LServer, ?PROCNAME),
+    gen_server:call(Proc, stop),
     ok.
 
 remove_user(_LUser, _LServer) ->


### PR DESCRIPTION
In this PR mod_vcard calls optional `tear_down` callback on the backend module. This is needed mostly to properly stop all vcard processes (including the one holding eldap connection) in tests.

