### PR TITLE
Move pubsub_index to backend

### DIFF
--- a/src/pubsub/gen_pubsub_nodetree.erl
+++ b/src/pubsub/gen_pubsub_nodetree.erl
@@ -51,7 +51,7 @@
 -callback terminate(Host :: host(), ServerHost :: binary()) -> atom().
 
 -callback set_node(PubsubNode :: pubsubNode()) ->
-    ok | {result, NodeIdx::nodeIdx()} | {error, exml:element()}.
+    {ok, NodeIdx::nodeIdx()} | {error, exml:element()}.
 
 -callback get_node(Host :: host(), NodeId :: nodeId()) -> pubsubNode() | {error, exml:element()}.
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -267,7 +267,6 @@ init([ServerHost, Opts]) ->
 
     init_backend(Opts),
 
-    pubsub_index:init(Host, ServerHost, Opts),
     ets:new(gen_mod:get_module_proc(ServerHost, config), [set, named_table, public]),
     {Plugins, NodeTree, PepMapping} = init_plugins(Host, ServerHost, Opts),
 
@@ -2856,7 +2855,7 @@ get_sub_options_xml(Host, JID, _Lang, Node, Nidx, RequestedSubId, Type) ->
                                            <<"invalid-subid">>)}
             end
     end.
-    
+
 make_and_wrap_sub_xform(Options, Node, Subscriber, SubId) ->
     {ok, XForm} = pubsub_form_utils:make_sub_xform(Options),
     OptionsEl = #xmlel{name = <<"options">>,
@@ -2865,7 +2864,7 @@ make_and_wrap_sub_xform(Options, Node, Subscriber, SubId) ->
                                 | node_attr(Node)],
                        children = [XForm]},
     PubSubEl = #xmlel{name = <<"pubsub">>,
-                      attrs = [{<<"xmlns">>, ?NS_PUBSUB}], 
+                      attrs = [{<<"xmlns">>, ?NS_PUBSUB}],
                       children = [OptionsEl]},
     {result, PubSubEl}.
 
@@ -3865,7 +3864,7 @@ set_configure_valid_transaction(Host, #pubsub_node{ type = Type, options = Optio
         NewOpts when is_list(NewOpts) ->
             NewNode = NodeRec#pubsub_node{options = NewOpts},
             case tree_call(Host, set_node, [NewNode]) of
-                ok -> {result, NewNode};
+                {ok, _} -> {result, NewNode};
                 Err -> Err
             end;
         Error ->

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -68,7 +68,7 @@
 -callback del_node(Nidx :: mod_pubsub:nodeIdx()) ->
     {ok, [mod_pubsub:pubsubState()]}.
 
--callback set_node(Node :: mod_pubsub:pubsubNode()) -> ok.
+-callback set_node(Node :: mod_pubsub:pubsubNode()) -> {ok, mod_pubsub:nodeIdx()}.
 
 -callback find_node_by_id(Nidx :: mod_pubsub:nodeIdx()) ->
     {error, not_found} | {ok, mod_pubsub:pubsubNode()}.
@@ -162,7 +162,7 @@
     ok.
 
 -callback get_items(Nidx :: mod_pubsub:nodeIdx(), gen_pubsub_node:get_item_options()) ->
-    {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out()}}.
+    {ok, {[mod_pubsub:pubsubItem()], jlib:rsm_out() | none}}.
 
 -callback get_item(Nidx :: mod_pubsub:nodeIdx(), ItemId :: mod_pubsub:itemId()) ->
     {ok, mod_pubsub:pubsubItem()} | {error, item_not_found}.

--- a/src/pubsub/mod_pubsub_db.erl
+++ b/src/pubsub/mod_pubsub_db.erl
@@ -79,7 +79,7 @@
 -callback find_nodes_by_key(Key :: mod_pubsub:hostPubsub() | jid:ljid()) ->
     [mod_pubsub:pubsubNode()].
 
--callback delete_node(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId()) -> ok.
+-callback delete_node(Node :: mod_pubsub:pubsubNode()) -> ok.
 
 -callback get_subnodes(Key :: mod_pubsub:hostPubsub() | jid:ljid(), Node :: mod_pubsub:nodeId() | <<>>) ->
     [mod_pubsub:pubsubNode()].

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -8,6 +8,8 @@
 -module(mod_pubsub_db_mnesia).
 -author('piotr.nosek@erlang-solutions.com').
 
+-behaviour(mod_pubsub_db).
+
 -include("pubsub.hrl").
 -include("jlib.hrl").
 -include_lib("stdlib/include/qlc.hrl").
@@ -366,7 +368,9 @@ get_node_subscriptions(Nidx) ->
 
 -spec get_node_entity_subscriptions(Nidx :: mod_pubsub:nodeIdx(),
                                     LJID :: jid:ljid()) ->
-    {ok, [{Sub :: mod_pubsub:subscription(), SubId :: mod_pubsub:subId()}]}.
+    {ok, [{Sub :: mod_pubsub:subscription(),
+           SubId :: mod_pubsub:subId(),
+           Opts :: mod_pubsub:subOptions()}]}.
 get_node_entity_subscriptions(Nidx, LJID) ->
     {ok, State} = get_state(Nidx, LJID, read),
     {ok, add_opts_to_subs(State#pubsub_state.subscriptions)}.
@@ -470,7 +474,7 @@ get_item(Nidx, ItemId) ->
         _ -> {error, item_not_found}
     end.
 
--spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.
+-spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
 set_item(Item) ->
     mnesia:write(Item).
 

--- a/src/pubsub/mod_pubsub_db_mnesia.erl
+++ b/src/pubsub/mod_pubsub_db_mnesia.erl
@@ -258,8 +258,7 @@ oid(Key, Name) -> {Key, Name}.
 
 
 -spec delete_node(Node :: mod_pubsub:pubsubNode()) -> ok.
-delete_node(#pubsub_node{nodeid = NodeId, id = NodeIdx}) ->
-    pubsub_index:free(node, NodeIdx),
+delete_node(#pubsub_node{nodeid = NodeId}) ->
     mnesia:delete({pubsub_node, NodeId}).
 
 

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -308,8 +308,7 @@ find_nodes_by_key(Key) ->
 
 
 -spec delete_node(Node :: mod_pubsub:pubsubNode()) -> ok.
-delete_node(#pubsub_node{nodeid = {Key, Node}, id = NodeIdx}) ->
-    pubsub_index:free(node, NodeIdx),
+delete_node(#pubsub_node{nodeid = {Key, Node}}) ->
     SQL = mod_pubsub_db_rdbms_sql:delete_node(encode_key(Key), Node),
     {updated, _} = mongoose_rdbms:sql_query(global, SQL),
     ok.

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -9,6 +9,8 @@
 -author('piotr.nosek@erlang-solutions.com').
 -author('michal.piotrowski@erlang-solutions.com').
 
+-behaviour(mod_pubsub_db).
+
 -include("pubsub.hrl").
 -include("mongoose_logger.hrl").
 -include("jlib.hrl").
@@ -183,7 +185,7 @@ get_item(Nidx, ItemId) ->
             {ok, item_to_record(Item)}
     end.
 
--spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok | abort.
+-spec set_item(Item :: mod_pubsub:pubsubItem()) -> ok.
 set_item(#pubsub_item{itemid = {ItemId, NodeIdx},
                       creation = {CreatedAt, {CreatedLUser, CreatedLServer, _}},
                       modification = {ModifiedAt, {ModifiedLUser, ModifiedLServer, ModifiedLResource}},

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -56,10 +56,7 @@ create_node(Key, Node, Type, Owner, Options, Parents) ->
             N = #pubsub_node{nodeid = {Key, Node},
                     type = Type, parents = Parents, owners = [OwnerJID],
                     options = Options},
-            case set_node(N) of
-                {ok, Nidx} -> {ok, Nidx};
-                Other -> Other
-            end;
+            set_node(N);
         _ ->
             {error, mongoose_xmpp_errors:conflict()}
     end.

--- a/src/pubsub/nodetree_dag.erl
+++ b/src/pubsub/nodetree_dag.erl
@@ -53,12 +53,11 @@ create_node(Key, Node, Type, Owner, Options, Parents) ->
     OwnerJID = jid:to_lower(jid:to_bare(Owner)),
     case mod_pubsub_db_backend:find_node_by_name(Key, Node) of
         false ->
-            Nidx = pubsub_index:new(node),
-            N = #pubsub_node{nodeid = {Key, Node}, id = Nidx,
+            N = #pubsub_node{nodeid = {Key, Node},
                     type = Type, parents = Parents, owners = [OwnerJID],
                     options = Options},
             case set_node(N) of
-                ok -> {ok, Nidx};
+                {ok, Nidx} -> {ok, Nidx};
                 Other -> Other
             end;
         _ ->
@@ -73,13 +72,12 @@ delete_node(Key, Node) ->
             lists:foreach(fun (#pubsub_node{options = Opts} = Child) ->
                         NewOpts = remove_config_parent(Node, Opts),
                         Parents = find_opt(collection, ?DEFAULT_PARENTS, NewOpts),
-                        ok = mod_pubsub_db_backend:set_node(
-                               Child#pubsub_node{parents = Parents,
-                                                 options = NewOpts})
+                        {ok, _} = mod_pubsub_db_backend:set_node(
+                                    Child#pubsub_node{parents = Parents,
+                                                      options = NewOpts})
                 end,
                 get_subnodes(Key, Node)),
-            pubsub_index:free(node, Record#pubsub_node.id),
-            mod_pubsub_db_backend:delete_node(Key, Node),
+            mod_pubsub_db_backend:delete_node(Record),
             [Record]
     end.
 

--- a/src/pubsub/nodetree_tree.erl
+++ b/src/pubsub/nodetree_tree.erl
@@ -91,13 +91,11 @@ create_node(Host, NodeName, Type, Owner, Options, Parents) ->
         false ->
             case check_parent_and_its_owner_list(Host, Parents, BJID) of
                 true ->
-                    Nidx = pubsub_index:new(node),
                     Node = #pubsub_node{nodeid = {Host, NodeName},
-                                        id = Nidx, parents = Parents,
+                                        parents = Parents,
                                         type = Type, owners = [BJID],
                                         options = Options},
-                    set_node(Node),
-                    {ok, Nidx};
+                    set_node(Node);
                 false ->
                     {error, mongoose_xmpp_errors:forbidden()}
             end;
@@ -126,9 +124,8 @@ check_parent_and_its_owner_list(_Host, _Parents, _BJID) ->
 delete_node(Host, Node) ->
     SubNodesTree = mod_pubsub_db_backend:get_subnodes_tree(Host, Node),
     Removed = lists:flatten([Nodes || {_, Nodes} <- SubNodesTree]),
-    lists:foreach(fun (#pubsub_node{nodeid = {_, SubNode}, id = SubNidx}) ->
-                pubsub_index:free(node, SubNidx),
-                mod_pubsub_db_backend:delete_node(Host, SubNode)
+    lists:foreach(fun (NodeToDel) ->
+                mod_pubsub_db_backend:delete_node(NodeToDel)
         end,
         Removed),
     Removed.

--- a/src/pubsub/pubsub_index.erl
+++ b/src/pubsub/pubsub_index.erl
@@ -33,7 +33,7 @@
 
 -include("pubsub.hrl").
 
--export([init/0, new/1, free/2]).
+-export([init/0, new/1]).
 
 init() ->
     mnesia:create_table(pubsub_index,
@@ -43,25 +43,11 @@ init() ->
 new(Index) ->
     case mnesia:read({pubsub_index, Index}) of
         [I] ->
-            case I#pubsub_index.free of
-                [] ->
-                    Id = I#pubsub_index.last + 1,
-                    mnesia:write(I#pubsub_index{last = Id}),
-                    Id;
-                [Id | Free] ->
-                    mnesia:write(I#pubsub_index{free = Free}),
-                    Id
-            end;
+            Id = I#pubsub_index.last + 1,
+            mnesia:write(I#pubsub_index{last = Id}),
+            Id;
         _ ->
             mnesia:write(#pubsub_index{index = Index, last = 1, free = []}),
             1
     end.
 
-free(Index, Id) ->
-    case mnesia:read({pubsub_index, Index}) of
-        [I] ->
-            Free = I#pubsub_index.free,
-            mnesia:write(I#pubsub_index{free = [Id | Free]});
-        _ ->
-            ok
-    end.

--- a/src/pubsub/pubsub_index.erl
+++ b/src/pubsub/pubsub_index.erl
@@ -4,13 +4,13 @@
 %%% compliance with the License. You should have received a copy of the
 %%% Erlang Public License along with this software. If not, it can be
 %%% retrieved via the world wide web at http://www.erlang.org/.
-%%% 
+%%%
 %%%
 %%% Software distributed under the License is distributed on an "AS IS"
 %%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
 %%% the License for the specific language governing rights and limitations
 %%% under the License.
-%%% 
+%%%
 %%%
 %%% The Initial Developer of the Original Code is ProcessOne.
 %%% Portions created by ProcessOne are Copyright 2006-2015, ProcessOne
@@ -33,9 +33,9 @@
 
 -include("pubsub.hrl").
 
--export([init/3, new/1, free/2]).
+-export([init/0, new/1, free/2]).
 
-init(_Host, _ServerHost, _Opts) ->
+init() ->
     mnesia:create_table(pubsub_index,
                         [{disc_copies, [node()]},
                          {attributes, record_info(fields, pubsub_index)}]).
@@ -49,7 +49,8 @@ new(Index) ->
                     mnesia:write(I#pubsub_index{last = Id}),
                     Id;
                 [Id | Free] ->
-                    mnesia:write(I#pubsub_index{free = Free}), Id
+                    mnesia:write(I#pubsub_index{free = Free}),
+                    Id
             end;
         _ ->
             mnesia:write(#pubsub_index{index = Index, last = 1, free = []}),


### PR DESCRIPTION
This PR moves calls to pubsub_index to pubsub's backend modules

Proposed changes include:
* simplified pubsub_index API, removed `free` function
* backend modules call pubsub_index when the `id` is not passed

