### PR TITLE
CVE-2011-4320

### DIFF
--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -113,7 +113,12 @@
          get_item_with_publisher_option_test/1,
          receive_item_notification_with_publisher_option_test/1
         ]).
-
+-import(pubsub_tools, [pubsub_node/0,
+                       domain/0,
+                       node_addr/0,
+                       rand_name/1,
+                       encode_group_name/2,
+                       decode_group_name/1]).
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
                              rpc/4]).
@@ -264,14 +269,6 @@ last_item_cache_tests() ->
      send_last_published_item_no_items_test,
      purge_all_items_test
     ].
-
-encode_group_name(BaseName, NodeTree) ->
-    binary_to_atom(<<NodeTree/binary, $+, (atom_to_binary(BaseName, utf8))/binary>>, utf8).
-
-decode_group_name(ComplexName) ->
-    [NodeTree, BaseName] = binary:split(atom_to_binary(ComplexName, utf8), <<"+">>),
-    #{node_tree => NodeTree, base_name => binary_to_atom(BaseName, utf8)}.
-
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
@@ -1824,25 +1821,6 @@ deleting_parent_path_deletes_children(Config) ->
 %%-----------------------------------------------------------------
 %% Helpers
 %%-----------------------------------------------------------------
-
-domain() ->
-    ct:get_config({hosts, mim, domain}).
-
-node_addr() ->
-    Domain = domain(),
-    <<"pubsub.", Domain/binary>>.
-
-rand_name(Prefix) ->
-    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
-    <<Prefix/binary, "_", Suffix/binary>>.
-
-%% Generates nodetree_tree-safe names
-pubsub_node_name() ->
-    Name0 = rand_name(<<"princely_musings">>),
-    re:replace(Name0, "/", "_", [global, {return, binary}]).
-
-pubsub_node() ->
-    {node_addr(), pubsub_node_name()}.
 
 path_node_and_parent(Client, {NodeAddr, NodeName}) ->
     %% TODO: Add proper JID stringprepping to escalus!!!

--- a/big_tests/tests/pubsub_s2s_SUITE.erl
+++ b/big_tests/tests/pubsub_s2s_SUITE.erl
@@ -22,9 +22,11 @@
          publish_without_node_attr_test/1
         ]).
 
--import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
-                             rpc/4]).
+-import(distributed_helper, [require_rpc_nodes/1]).
+-import(pubsub_tools, [pubsub_node/0,
+                       domain/0,
+                       encode_group_name/2,
+                       decode_group_name/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -51,13 +53,6 @@ basic_tests() ->
      publish_test,
      publish_without_node_attr_test
     ].
-
-encode_group_name(BaseName, NodeTree) ->
-    binary_to_atom(<<NodeTree/binary, $+, (atom_to_binary(BaseName, utf8))/binary>>, utf8).
-
-decode_group_name(ComplexName) ->
-    [NodeTree, BaseName] = binary:split(atom_to_binary(ComplexName, utf8), <<"+">>),
-    #{node_tree => NodeTree, base_name => binary_to_atom(BaseName, utf8)}.
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -129,25 +124,6 @@ publish_without_node_attr_test(Config) ->
               pubsub_tools:publish_without_node_attr(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),
               pubsub_tools:delete_node(Alice, Node, [])
       end).
-
-pubsub_node() ->
-    {node_addr(), pubsub_node_name()}.
-
-domain() ->
-    ct:get_config({hosts, mim, domain}).
-
-node_addr() ->
-    Domain = domain(),
-    <<"pubsub.", Domain/binary>>.
-
-rand_name(Prefix) ->
-    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
-    <<Prefix/binary, "_", Suffix/binary>>.
-
-%% Generates nodetree_tree-safe names
-pubsub_node_name() ->
-    Name0 = rand_name(<<"princely_musings">>),
-    re:replace(Name0, "/", "_", [global, {return, binary}]).
 
 required_modules(ExtraOpts) ->
     [{mod_pubsub, [

--- a/big_tests/tests/pubsub_s2s_SUITE.erl
+++ b/big_tests/tests/pubsub_s2s_SUITE.erl
@@ -1,0 +1,157 @@
+%%%===================================================================
+%%% @copyright (C) 2015, Erlang Solutions Ltd.
+%%% @doc Suite for testing pubsub features over s2s
+%%% @end
+%%%===================================================================
+
+-module(pubsub_s2s_SUITE).
+
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("exml/include/exml_stream.hrl").
+
+-export([suite/0, all/0, groups/0]).
+-export([init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2]).
+
+-export([
+         publish_test/1,
+         publish_without_node_attr_test/1
+        ]).
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+suite() ->
+    require_rpc_nodes([mim, fed]) ++ escalus:suite().
+
+all() ->
+    [{group, GN} || {GN, _, _} <- groups()].
+
+groups() ->
+    [{encode_group_name(BaseGroup, NodeTree), Opts, Cases} || {BaseGroup, Opts, Cases} <- base_groups(),
+                                                               NodeTree <- [<<"dag">>, <<"tree">>]].
+
+base_groups() ->
+    G = [
+         {basic, [parallel], basic_tests()}
+        ],
+    ct_helper:repeat_all_until_all_ok(G).
+
+basic_tests() ->
+    [
+     publish_test,
+     publish_without_node_attr_test
+    ].
+
+encode_group_name(BaseName, NodeTree) ->
+    binary_to_atom(<<NodeTree/binary, $+, (atom_to_binary(BaseName, utf8))/binary>>, utf8).
+
+decode_group_name(ComplexName) ->
+    [NodeTree, BaseName] = binary:split(atom_to_binary(ComplexName, utf8), <<"+">>),
+    #{node_tree => NodeTree, base_name => binary_to_atom(BaseName, utf8)}.
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    Config1 = s2s_helper:init_s2s(escalus:init_per_suite(Config)),
+    escalus:create_users(Config1, escalus:get_users(users())).
+
+end_per_suite(Config) ->
+    escalus_fresh:clean(),
+    s2s_helper:end_s2s(Config),
+    escalus:delete_users(Config, escalus:get_users(users())),
+    escalus:end_per_suite(Config).
+
+init_per_group(ComplexName, Config) ->
+    DecodedGroupName = decode_group_name(ComplexName),
+    ExtraOptions = extra_options_by_group_name(DecodedGroupName),
+    Config2 = dynamic_modules:save_modules(domain(), Config),
+    dynamic_modules:ensure_modules(domain(), required_modules(ExtraOptions)),
+    s2s_helper:configure_s2s(both_plain, Config2).
+
+extra_options_by_group_name(#{ node_tree := NodeTree }) ->
+    [{nodetree, NodeTree},
+     {plugins, [plugin_by_nodetree(NodeTree)]}].
+
+plugin_by_nodetree(<<"dag">>) -> <<"dag">>;
+plugin_by_nodetree(<<"tree">>) -> <<"flat">>.
+
+end_per_group(_GroupName, Config) ->
+    dynamic_modules:restore_modules(domain(), Config).
+
+init_per_testcase(_TestName, Config) ->
+    escalus:init_per_testcase(_TestName, Config).
+
+end_per_testcase(TestName, Config) ->
+    escalus:end_per_testcase(TestName, Config).
+
+users() ->
+    [alice2, alice].
+
+%%--------------------------------------------------------------------
+%% Test cases for XEP-0060
+%% Comments in test cases refer to sections is the XEP
+%%--------------------------------------------------------------------
+
+%%--------------------------------------------------------------------
+%% Main PubSub cases
+%%--------------------------------------------------------------------
+publish_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {alice2, 1}],
+      fun(Alice, Alice2) ->
+              Node = pubsub_node(),
+              pubsub_tools:create_node(Alice, Node, []),
+              pubsub_tools:publish(Alice, <<"item1">>, Node, []),
+              pubsub_tools:publish(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),
+              pubsub_tools:delete_node(Alice, Node, [])
+      end).
+
+publish_without_node_attr_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}, {alice2, 1}],
+      fun(Alice, Alice2) ->
+              Node = pubsub_node(),
+              pubsub_tools:create_node(Alice, Node, []),
+              pubsub_tools:publish(Alice, <<"item1">>, Node, []),
+              pubsub_tools:publish_without_node_attr(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),
+              pubsub_tools:delete_node(Alice, Node, [])
+      end).
+
+pubsub_node() ->
+    {node_addr(), pubsub_node_name()}.
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+node_addr() ->
+    Domain = domain(),
+    <<"pubsub.", Domain/binary>>.
+
+rand_name(Prefix) ->
+    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
+    <<Prefix/binary, "_", Suffix/binary>>.
+
+%% Generates nodetree_tree-safe names
+pubsub_node_name() ->
+    Name0 = rand_name(<<"princely_musings">>),
+    re:replace(Name0, "/", "_", [global, {return, binary}]).
+
+required_modules(ExtraOpts) ->
+    [{mod_pubsub, [
+                   {backend, mongoose_helper:mnesia_or_rdbms_backend()},
+                   {host, "pubsub.@HOST@"}
+                   | ExtraOpts
+                  ]}].

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -15,6 +15,13 @@
 -include_lib("exml/include/exml_stream.hrl").
 -include_lib("eunit/include/eunit.hrl").
 %% Send request, receive (optional) response
+-export([pubsub_node/0,
+         domain/0,
+         node_addr/0,
+         rand_name/1,
+         pubsub_node_name/0,
+         encode_group_name/2,
+         decode_group_name/1]).
 -export([
          discover_nodes/3,
 
@@ -618,3 +625,28 @@ decode_affiliations(IQResult) ->
 
     [ {exml_query:attr(F, <<"jid">>), exml_query:attr(F, <<"affiliation">>)} || F <- Fields ].
 
+pubsub_node() ->
+    {node_addr(), pubsub_node_name()}.
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+node_addr() ->
+    Domain = domain(),
+    <<"pubsub.", Domain/binary>>.
+
+rand_name(Prefix) ->
+    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
+    <<Prefix/binary, "_", Suffix/binary>>.
+
+%% Generates nodetree_tree-safe names
+pubsub_node_name() ->
+    Name0 = rand_name(<<"princely_musings">>),
+    re:replace(Name0, "/", "_", [global, {return, binary}]).
+
+encode_group_name(BaseName, NodeTree) ->
+    binary_to_atom(<<NodeTree/binary, $+, (atom_to_binary(BaseName, utf8))/binary>>, utf8).
+
+decode_group_name(ComplexName) ->
+    [NodeTree, BaseName] = binary:split(atom_to_binary(ComplexName, utf8), <<"+">>),
+    #{node_tree => NodeTree, base_name => binary_to_atom(BaseName, utf8)}.


### PR DESCRIPTION
This PR addresses ejabberd CVE (https://www.cvedetails.com/cve/CVE-2011-4320/) about infinite loop causing DoS when a user from other domain publishes an item to not existent node (no `node` attribute).

- Added new test suite for pubsub over s2s
- Added 2 test cases for publish item by remote user
  - Node attribute is present
  - Without node attribute
In both cases `remote-server-not-found` error should be returned

