### PR TITLE
Fix value is set to infinity but it is parsed as 0 by ldap backend

### DIFF
--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -52,6 +52,7 @@ all() ->
     [{group, rw},
      {group, ro_full},
      {group, ro_limited},
+     {group, params_limited_infinity},
      {group, ro_no},
      {group, ldap_only}
      ].
@@ -62,6 +63,7 @@ groups() ->
     G = [{rw, [sequence], rw_tests()},
          {ro_full, [], ro_full_search_tests()},
          {ro_limited, [], ro_limited_search_tests()},
+         {params_limited_infinity, [], rw_tests()},
          {ro_no, [sequence], ro_no_search_tests()},
          {ldap_only, [], ldap_only_tests()}
         ],
@@ -145,6 +147,9 @@ end_per_suite(Config) ->
 
 init_per_group(rw, Config) ->
     restart_vcard_mod(Config, rw),
+    Config;
+init_per_group(params_limited_infinity, Config) ->
+    restart_vcard_mod(Config, params_limited_infinity),
     Config;
 init_per_group(ldap_only, Config) ->
     VCardConfig = ?config(mod_vcard, Config),
@@ -1082,6 +1087,8 @@ vcard_rpc(JID, Stanza) ->
 
 restart_vcard_mod(Config, ro_limited) ->
     restart_mod(params_limited(Config));
+restart_vcard_mod(Config, params_limited_infinity) ->
+    restart_mod(params_limited_infinity(Config));
 restart_vcard_mod(Config, ro_no) ->
     restart_mod(params_no(Config));
 restart_vcard_mod(Config, ldap_only) ->
@@ -1109,6 +1116,10 @@ params_all(Config) ->
 
 params_limited(Config) ->
     add_backend_param([{matches, 1},
+                       {host, "directory.@HOST@"}], ?config(mod_vcard, Config)).
+
+params_limited_infinity(Config) ->
+    add_backend_param([{matches, infinity},
                        {host, "directory.@HOST@"}], ?config(mod_vcard, Config)).
 
 params_no(Config) ->

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -82,7 +82,7 @@
          binary_search_fields       :: [binary()],
          deref = neverDerefAliases  :: neverDerefAliases | derefInSearching
                                      | derefFindingBaseObj | derefAlways,
-         matches = 0                :: non_neg_integer()}).
+         matches = 0                :: non_neg_integer() | infinity}).
 
 -define(VCARD_MAP,
         [{<<"NICKNAME">>, <<"%u">>, []},
@@ -464,9 +464,9 @@ process_pattern(Str, {User, Domain}, AttrValues) ->
 parse_options(Host, Opts) ->
     MyHost = gen_mod:get_opt_subhost(Host, Opts, mod_vcard:default_host()),
     Matches = eldap_utils:get_mod_opt(matches, Opts,
-                              fun(infinity) -> 0;
-                                 (I) when is_integer(I), I>0 -> I
-                              end, 30),
+                             fun(infinity) -> infinity;
+                                (I) when is_integer(I), I>=0 -> I
+                             end, 30),
     EldapID = atom_to_binary(gen_mod:get_module_proc(Host, ?PROCNAME), utf8),
     Cfg = eldap_utils:get_config(Host, Opts),
     UIDsTemp = eldap_utils:get_opt(


### PR DESCRIPTION
This PR fixes the issue with `infinity` mapped to `0` in `matches` option in `vcard_ldap`.