### PR TITLE
ldap uids option bug

### DIFF
--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -456,6 +456,7 @@ configure_ldap_vcards(Config) ->
     {mod_vcard, CurrentVcardConfig} = lists:keyfind(mod_vcard, 1, CurrentConfigs),
     dynamic_modules:stop(Domain, mod_vcard),
     Cfg = [{backend,ldap}, {host, "vjud.@HOST@"},
+           {ldap_uids, [{<<"uid">>}]}, %% equivalent to {<<"uid">>, <<"%u">>}
            {ldap_filter,"(objectClass=inetOrgPerson)"},
            {ldap_base,"ou=Users,dc=esl,dc=com"},
            {ldap_search_fields, [{"Full Name","cn"},{"User","uid"}]},

--- a/doc/modules/mod_vcard.md
+++ b/doc/modules/mod_vcard.md
@@ -22,6 +22,9 @@ This module provides support for vCards, as specified in [XEP-0054: vcard-temp](
  For the default setting, please see `[MongooseIM root]/src/mod_vcard_ldap.erl`, line 109.
 * `ldap_search_operator` (`or` | `and`, default: `and`): A default operator used for search query items.
 * `ldap_binary_search_fields` (list of binaries, default: `[]`): A list of search fields, which values should be Base64-encoded by MongooseIM before sending to LDAP.
+* `ldap_uids` (list of `{LDAPUIattr, LDAPUIformat}` or `{LDAPUIattr}`), for
+  the detailed description please see [LDAP Authentication
+module](../authentication-backends/LDAP-authentication-module.md).
 
 ### Example Configuration
 ```

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -515,7 +515,8 @@ parse_options(Host, Opts) ->
                                                iolist_to_binary(P)}
                                               || {S, P} <- Ls]
                                      end, ?SEARCH_REPORTED),
-    UIDAttrs = [UAttr || {UAttr, _} <- UIDs],
+    UIDAttrs = lists:map(fun({UID, _}) -> UID;
+                            ({UID}) -> UID end, UIDs),
     VCardMapAttrs = lists:usort(lists:append([A
                                               || {_, _, A} <- VCardMap])
                                   ++ UIDAttrs),


### PR DESCRIPTION
This PR repairs the following bug:

`mod_vcard_ldap` ignored `ldap_uids` formed as `{"attribute"}` and only parsed `{"attribute", "format"}` correctly

Both option formats are now acceptable

