### PR TITLE
Unlock mongooseim-docker version

### DIFF
--- a/tools/travis-build-and-push-docker.sh
+++ b/tools/travis-build-and-push-docker.sh
@@ -33,7 +33,6 @@ IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
-git checkout 7f623a7
 
 cp ../${MONGOOSE_TGZ} member
 


### PR DESCRIPTION
`mongooseim-docker` is not updated very frequently and when it is,
it's easy to forget to update MongooseIM scripts to use the updated
version.

With the unlocked version it will be easier to try changes in
mongooseim-docerk on Tide so we'll know sooner if everything still works
as expected.
