### PR TITLE
Use map syntax to pass ranch transport options

### DIFF
--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -55,9 +55,9 @@ Unlike `ejabberd_c2s`, it doesn't use `ejabberd_receiver` or `ejabberd_listener`
 * `ip` (IP tuple, default: `{0,0,0,0}`) - IP address to bind to.
 * `num_acceptors` (positive integer, default: 100) - Number of acceptors.
 * `transport_options` (proplist, default: []) - Ranch-specific transport options.
- See [ranch:opt()](https://ninenines.eu/docs/en/ranch/1.5/manual/ranch/#_opt).
+ See [ranch:opt()](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch/#_opt).
 * `protocol_options` (proplist, default: []) - Protocol configuration options for Cowboy.
- See [Cowboy HTTP module docs](https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_http/).
+ See [Cowboy HTTP module docs](https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy_http/).
 * `ssl` (list of ssl options, required for https, no default value) - If specified, https will be used.
  Accepts all ranch_ssl options that don't take fun() parameters.
  Only `certfile` and `keyfile` are mandatory.

--- a/test/cowboy_SUITE.erl
+++ b/test/cowboy_SUITE.erl
@@ -214,8 +214,8 @@ mixed_requests(_Config) ->
     Responses = lists:duplicate(50, {TextPong, true, TextPong, true}).
 
 start_cowboy_returns_error_eaddrinuse(_C) ->
-    Opts = [{transport_options, [{port, 8088},
-                                 {ip, {127, 0, 0, 1}}]},
+    Opts = [{transport_options, #{socket_opts => [{port, 8088},
+                                                  {ip, {127, 0, 0, 1}}]}},
             {modules, []},
             {retries, {2, 10}}],
     {ok, _Pid} = ejabberd_cowboy:start_cowboy(a_ref, Opts),
@@ -274,7 +274,8 @@ start_cowboy() ->
                    ]}]
                 }]),
     {ok, _Pid} = cowboy:start_clear(http_listener,
-                                    [{num_acceptors, 20}, {port, 8080}],
+                                    #{num_acceptors => 20,
+                                      socket_opts => [{port, 8080}]},
                                     #{env => #{dispatch => Dispatch}}).
 
 stop_cowboy() ->


### PR DESCRIPTION
After upgrading `Cowboy` to version `2.6` Ranch was automatically upgraded to version `1.7`. This version deprecates old API where transport options are passed as proplists where socket options are mixed with other ranch specific options.
This PR uses the new map syntax where all socket specific options like `port`, `ip` and `ssl_opts` are passed as `socket_opts` key in the map. 

