### PR TITLE
Replace jsx with jiffy

### DIFF
--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -288,7 +288,7 @@ send_notification(User, Node, Notification, Options) ->
 
 get_mocked_request() ->
     {Req, BodyRaw} = next_rest_req(),
-    Body = jsx:decode(BodyRaw, [return_maps]),
+    Body = jiffy:decode(BodyRaw, [return_maps]),
     {Req, Body}.
 
 prepare_notification() ->


### PR DESCRIPTION
This PR unifies json library usages, by replacing jsx with jiffy. 