### PR TITLE
Fix `mongooseimctl debug` command

### DIFF
--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -35,6 +35,14 @@ if [ -z "$NAME_ARG" ]; then
 fi
 NAME=$(echo $NAME_ARG | awk '{print $1}')
 NODE=$(echo $NAME_ARG | awk '{print $2}')
+HOST=$(echo $NODE | awk -F@ '{ print $2 }')
+if [ -z "$HOST" ]; then
+    case $NAME in
+        "-sname") HOST=$(hostname -s) ;;
+        "-name")  HOST=$(hostname -f) ;;
+    esac
+    NODE=$NODE@$HOST
+fi
 MNESIA_DIR={{mongooseim_mdb_dir}}
 
 # Extract the target cookie
@@ -195,8 +203,6 @@ case "$1" in
         echo "Press 'Enter' to continue"
         read
         echo ""
-        NAME=$(echo $NAME_ARG | awk '{print $1}')
-        NODE=$(echo $NAME_ARG | awk '{print $2}')
         id=$(relx_gen_id)
 
         ROOTDIR="$RUNNER_BASE_DIR"

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -65,6 +65,11 @@ function exec_echo {
     exec "$@"
 }
 
+# Generate a random id
+relx_gen_id() {
+    od -t x -N 4 /dev/urandom | head -n1 | awk '{print $2}'
+}
+
 # Check the first argument for instructions
 case "$1" in
     start)
@@ -192,7 +197,7 @@ case "$1" in
         echo ""
         NAME=$(echo $NAME_ARG | awk '{print $1}')
         NODE=$(echo $NAME_ARG | awk '{print $2}')
-        TTY=$(basename `tty`)
+        id=$(relx_gen_id)
 
         ROOTDIR="$RUNNER_BASE_DIR"
         BINDIR="$ROOTDIR/erts-$ERTS_VSN/bin"
@@ -202,7 +207,7 @@ case "$1" in
         logger -t "$SCRIPT[$$]" "Starting up"
 
         # Start the VM
-        exec_echo "$BINDIR/erl" "$NAME" "debug-$TTY-$NODE" $COOKIE_ARG -remsh "$NODE" -hidden -args_file "$RUNNER_ETC_DIR/vm.dist.args"
+        exec_echo "$BINDIR/erl" "$NAME" "debug-$id-$NODE" $COOKIE_ARG -remsh "$NODE" -hidden -args_file "$RUNNER_ETC_DIR/vm.dist.args"
         ;;
 
     version)

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -2,7 +2,11 @@
 ##   -sname node@host
 ## or
 ##   -name node@fully.qualified.domain.name
-## Without @something suffix `mongooseimctl debug` breaks.
+#$
+## Without @something suffix `mongooseimctl debug` uses:
+##   - NODE@`hostname -s` if -sname
+##   - NODE@`hostname -f` if -name
+## to attach a remote shell.
 -sname {{node_name}}
 
 ## Cookie for distributed erlang


### PR DESCRIPTION
This approaches fixing `mongooseimctl debug` for cases of no hostname provided with `-sname`/`-name` in `vm.args`. The details are in respective commit log messages.

One remaining caveat is the case of the Mac example - running the script on a Mac is not that worrying, since it's not going to happen in production, but it means that we might run into the problem somewhere in production due to incomplete knowledge of how the Erlang VM expands `-name a` into `-name a@FQDN`.

This fix is necessary for remote shell access in a Kubernetes pod.