### PR TITLE
Sasl external best practices

### DIFF
--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -26,6 +26,7 @@ common_test_cases() ->
      cert_with_cn_no_xmpp_addrs_requested_correct_user,
      cert_with_cn_xmpp_addrs_request_name_empty,
      cert_with_cn_one_xmpp_addrs_request_name_empty,
+     cert_with_cn_no_xmpp_addrs_request_wrong_name,
      cert_with_cn_no_xmpp_addrs_request_name_empty,
      cert_with_cn_xmpp_addrs_request_name_empty_ws,
      cert_with_cn_xmpp_addrs_request_name_empty_bosh,
@@ -140,6 +141,10 @@ cert_with_cn_no_xmpp_addrs_request_name_empty(C) ->
 
     escalus_connection:stop(Client).
 
+cert_with_cn_no_xmpp_addrs_request_wrong_name(C) ->
+    UserSpec = [{requested_name, <<"mike@localhost">>} |
+		generate_user_tcp(C, "not-mike-name")],
+    cert_fails_to_authenticate(UserSpec).
 
 cert_with_cn_xmpp_addrs_request_name_empty_ws(C) ->
     UserSpec = generate_user(C, "bob", escalus_ws),
@@ -239,6 +244,7 @@ generate_certs(C) ->
              [#{cn => "not-alice-name", xmpp_addrs => ["alice@localhost", "alice@fed1"]},
 			  #{cn => "bob", xmpp_addrs => ["bob@localhost"]},
 			  #{cn => "john"},
+			  #{cn => "not-mike-name"},
 			  #{cn => "alice-self-signed", signed => self}]],
     [{certs, maps:from_list(Certs)} | C].
 

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -26,9 +26,10 @@ common_test_cases() ->
      cert_with_cn_no_xmpp_addrs_requested_correct_user,
      cert_with_cn_xmpp_addrs_request_name_empty,
      cert_with_cn_one_xmpp_addrs_request_name_empty,
+     cert_with_cn_no_xmpp_addrs_request_name_empty,
      cert_with_cn_no_xmpp_addrs_request_wrong_name,
      cert_with_cn_xmpp_addrs_request_wrong_name,
-     cert_with_cn_no_xmpp_addrs_request_name_empty,
+     cert_with_cn_one_xmpp_addr_requested_wrong_hostname,
      cert_with_cn_xmpp_addrs_request_name_empty_ws,
      cert_with_cn_xmpp_addrs_request_name_empty_bosh,
      no_cert_fails_to_authenticate
@@ -150,6 +151,11 @@ cert_with_cn_no_xmpp_addrs_request_wrong_name(C) ->
 cert_with_cn_xmpp_addrs_request_wrong_name(C) ->
     UserSpec = [{requested_name, <<"grace@localhost">>} |
 		generate_user_tcp(C, "grace-no-address")],
+    cert_fails_to_authenticate(UserSpec).
+
+cert_with_cn_one_xmpp_addr_requested_wrong_hostname(C) ->
+    UserSpec = [{requested_name, <<"bob@fed1">>} |
+		generate_user_tcp(C, "bob")],
     cert_fails_to_authenticate(UserSpec).
 
 cert_with_cn_xmpp_addrs_request_name_empty_ws(C) ->

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -27,6 +27,7 @@ common_test_cases() ->
      cert_with_cn_xmpp_addrs_request_name_empty,
      cert_with_cn_one_xmpp_addrs_request_name_empty,
      cert_with_cn_no_xmpp_addrs_request_wrong_name,
+     cert_with_cn_xmpp_addrs_request_wrong_name,
      cert_with_cn_no_xmpp_addrs_request_name_empty,
      cert_with_cn_xmpp_addrs_request_name_empty_ws,
      cert_with_cn_xmpp_addrs_request_name_empty_bosh,
@@ -146,6 +147,11 @@ cert_with_cn_no_xmpp_addrs_request_wrong_name(C) ->
 		generate_user_tcp(C, "not-mike-name")],
     cert_fails_to_authenticate(UserSpec).
 
+cert_with_cn_xmpp_addrs_request_wrong_name(C) ->
+    UserSpec = [{requested_name, <<"grace@localhost">>} |
+		generate_user_tcp(C, "grace-no-address")],
+    cert_fails_to_authenticate(UserSpec).
+
 cert_with_cn_xmpp_addrs_request_name_empty_ws(C) ->
     UserSpec = generate_user(C, "bob", escalus_ws),
     {ok, Client, _} = escalus_connection:start(UserSpec),
@@ -240,12 +246,12 @@ no_cert_fails_to_authenticate(_C) ->
 
 generate_certs(C) ->
     Certs = [{maps:get(cn, CertSpec), generate_cert(C, CertSpec)} ||
-	     CertSpec <-
-             [#{cn => "not-alice-name", xmpp_addrs => ["alice@localhost", "alice@fed1"]},
-			  #{cn => "bob", xmpp_addrs => ["bob@localhost"]},
-			  #{cn => "john"},
-			  #{cn => "not-mike-name"},
-			  #{cn => "alice-self-signed", signed => self}]],
+             CertSpec <- [#{cn => "not-alice-name", xmpp_addrs => ["alice@localhost", "alice@fed1"]},
+                          #{cn => "bob", xmpp_addrs => ["bob@localhost"]},
+                          #{cn => "john"},
+                          #{cn => "not-mike-name"},
+                          #{cn => "grace-no-address", xmpp_addrs => ["grace@fed1", "grace@reg1"]},
+                          #{cn => "alice-self-signed", signed => self}]],
     [{certs, maps:from_list(Certs)} | C].
 
 generate_cert(C, #{cn := User} = CertSpec) ->

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -14,18 +14,21 @@ all() ->
 
 groups() ->
     G = [{fast_tls, [parallel], common_test_cases() ++ no_allowed_self_signed_test_cases()},
-	 {just_tls, [parallel], common_test_cases() ++ no_allowed_self_signed_test_cases()},
-	 {fast_tls_allow_self_signed, [parallel], common_test_cases() ++ self_signed_test_cases()},
-	 {just_tls_allow_self_signed, [parallel], common_test_cases() ++ self_signed_test_cases()}],
+         {just_tls, [parallel], common_test_cases() ++ no_allowed_self_signed_test_cases()},
+         {fast_tls_allow_self_signed, [parallel], common_test_cases() ++ self_signed_test_cases()},
+         {just_tls_allow_self_signed, [parallel], common_test_cases() ++ self_signed_test_cases()}],
     ct_helper:repeat_all_until_all_ok(G).
 
 common_test_cases() ->
-    [cert_with_cn_xmpp_addrs_requested_correct_user,
+    [
+     cert_with_cn_xmpp_addrs_requested_correct_user,
+     cert_with_cn_no_xmpp_addrs_requested_correct_user,
      cert_with_cn_xmpp_addrs_request_name_empty,
      cert_with_cn_no_xmpp_addrs_request_name_empty,
      cert_with_cn_xmpp_addrs_request_name_empty_ws,
      cert_with_cn_xmpp_addrs_request_name_empty_bosh,
-     no_cert_fails_to_authenticate].
+     no_cert_fails_to_authenticate
+    ].
 
 self_signed_test_cases() ->
     [self_signed_cert_is_allowed_with_tls,
@@ -105,6 +108,14 @@ cert_with_cn_xmpp_addrs_requested_correct_user(C) ->
     {ok, Client, _} = escalus_connection:start(UserSpec),
 
     escalus_connection:stop(Client).
+
+cert_with_cn_no_xmpp_addrs_requested_correct_user(C) ->
+    UserSpec = [{requested_name, <<"mike@localhost">>} |
+		generate_user_tcp(C, "mike")],
+    {ok, Client, _} = escalus_connection:start(UserSpec),
+
+    escalus_connection:stop(Client).
+
 
 cert_with_cn_xmpp_addrs_request_name_empty(C) ->
     UserSpec = generate_user_tcp(C, "bob"),
@@ -194,6 +205,7 @@ generate_certs(C) ->
 	     CertSpec <- [#{cn => "not-alice-name", xmpp_addrs => ["alice@localhost", "alice@fed1"]},
 			  #{cn => "bob", xmpp_addrs => ["bob@localhost"]},
 			  #{cn => "john"},
+			  #{cn => "mike", xmpp_addrs => []},
 			  #{cn => "alice-self-signed", signed => self}]],
     [{certs, maps:from_list(Certs)} | C].
 

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -214,8 +214,8 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
 * **sasl_mechanisms** (local)
     * **Description:** Specifies a list of allowed SASL mechanisms. It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code).
     * **Warning:** This list is still filtered by auth backends capabilities, e.g. LDAP authentication requires a password provided via SASL PLAIN.
-    * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_anonymous, cyrsasl_oauth`
-    * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_anonymous, cyrsasl_oauth]`
+    * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
+    * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
     * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram]`
 
 * **extauth_instances** (local)

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -27,7 +27,14 @@ Please check [Listener modules](../advanced-configuration/Listener-modules.md#ht
 A `SASL EXTERNAL` authentication method is disabled by default.
 In order to enable it, please add [`sasl_mechanisms` option](../Advanced-configuration.md#authentication) to MongooseIM config file.
 Its value must include a `cyrsasl_external` item.
-Obviously the list may be longer, if the system should support both certificate and password based authentication.
+Obviously the list may be longer, if the system should support both the certificate and password based authentication.
+The `SASL EXTERNAL` authentication method requires using the digital
+certificates. If the `xmpp_addrs` fields are included in the certificate, they are always checked first.
+When no `xmpp_addrs` are specified, the `cn` (_common name_) field might be
+used, but it is optional. If there is more than one `xmpp_addrs` or both the
+list and `cn` field are empty, the client must include
+authorization entity.
+For the details please refer to [XEP-0178 Best Practices for Use of SASL EXTERNAL with Certificates](https://xmpp.org/extensions/xep-0178.html).
 
 ### Enable compatible authentication backend
 

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -71,11 +71,15 @@ authorize(Creds) ->
     end.
 
 do_authorize({undefined, [OneXmppAddr], _ }) ->
-    %%  name from jid ?
-    OneXmppAddr;
+    get_username(OneXmppAddr);
 do_authorize({undefined, [], CommonName}) ->
     %% check if CommonName is correct jid
-    CommonName;
+    case is_binary(CommonName) of
+       true ->
+           CommonName;
+       _ ->
+            {error, <<"not-authorized">>}
+    end;
 do_authorize({RequestedName, [], CommonName}) ->
     %% check if RequestedName matches ComonName
     RequestedName;

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -59,46 +59,7 @@ set_password(_, _, _) -> {error, not_allowed}.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()} | {error, any()}.
 authorize(Creds) ->
-    Credentials = { get_credentials(Creds, requested_name),
-                    get_credentials(Creds, xmpp_addresses),
-                    get_credentials(Creds, common_name)},
-    case do_authorize(Credentials) of
-        {error, <<"not-authorized">>} ->
-            {error, <<"not-authorized">>};
-        UserName ->
-            {ok, mongoose_credentials:extend(Creds, [{username, UserName},
-                                                     {auth_module, ?MODULE}])}
-    end.
-
-do_authorize({undefined, [OneXmppAddr], _ }) ->
-    get_username(OneXmppAddr);
-do_authorize({undefined, [], CommonName}) ->
-    %% check if CommonName is correct jid
-    case is_binary(CommonName) of
-        true ->
-            CommonName;
-        _ ->
-            {error, <<"not-authorized">>}
-    end;
-do_authorize({RequestedName, [], CommonName}) ->
-    %% check if RequestedName matches ComonName
-    case get_username(RequestedName) of
-        CommonName ->
-            CommonName;
-        _ ->
-            {error, <<"not-authorized">>}
-    end;
-do_authorize({RequestedName, XmppAddrList, _}) ->
-    %% check if RequestedName matches any of XmppAddrList
-    case lists:filter(fun(XmppAddr) -> XmppAddr == RequestedName end, XmppAddrList) of
-        [OneAddr] ->
-            get_username(OneAddr);
-        _ ->
-            {error, <<"not-authorized">>}
-    end;
-do_authorize(_) ->
-    {error, <<"not-authorized">>}.
-
+            {ok, mongoose_credentials:extend(Creds, [{auth_module, ?MODULE}])}.
 
 -spec try_register( User :: ejabberd:luser(),
                     Server :: ejabberd:lserver(),
@@ -159,9 +120,3 @@ check_password(_, _, _, _, _) -> false.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% internal functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-get_credentials(Cred, Key) ->
-    mongoose_credentials:get(Cred, Key, undefined).
-
-get_username(Jid) ->
-    JidRecord = jid:binary_to_bare(Jid),
-    JidRecord#jid.user.

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -67,15 +67,15 @@ authorize(Creds) ->
                   ) -> ok | {error, exists | not_allowed | term()}.
 try_register(_, _, _) -> {error, not_allowed}.
 
--spec dirty_get_registered_users() -> [ejabberd:simple_bare_jid()].
+-spec dirty_get_registered_users() -> [jid:simple_bare_jid()].
 dirty_get_registered_users() -> [].
 
--spec get_vh_registered_users(Server :: ejabberd:lserver()) -> [ejabberd:simple_bare_jid()].
+-spec get_vh_registered_users(Server :: ejabberd:lserver()) -> [jid:simple_bare_jid()].
 get_vh_registered_users(_) -> [].
 
 -spec get_vh_registered_users( Server :: ejabberd:lserver(),
                                Opts :: list()
-                             ) -> [ejabberd:simple_bare_jid()].
+                             ) -> [jid:simple_bare_jid()].
 get_vh_registered_users(_, _) -> [].
 
 -spec get_vh_registered_users_number(Server :: ejabberd:lserver()) -> integer().

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -76,13 +76,18 @@ do_authorize({undefined, [], CommonName}) ->
     %% check if CommonName is correct jid
     case is_binary(CommonName) of
        true ->
-           CommonName;
-       _ ->
+            CommonName;
+        _ ->
             {error, <<"not-authorized">>}
     end;
 do_authorize({RequestedName, [], CommonName}) ->
     %% check if RequestedName matches ComonName
-    RequestedName;
+    case get_username(RequestedName) of
+        CommonName ->
+            CommonName;
+        _ ->
+            {error, <<"not-authorized">>}
+    end;
 do_authorize({RequestedName, XmppAddrList, _}) ->
     %% check if RequestedName matches any of XmppAddrList
     case lists:filter(fun(XmppAddr) -> XmppAddr == RequestedName end, XmppAddrList) of

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -37,27 +37,27 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3
-]).
+        ]).
 
 -export([check_password/3,
          check_password/5]).
 
-%%-callback start(Host :: ejabberd:lserver()) -> ok.
+-spec start(Host :: ejabberd:lserver()) -> ok.
 start(_) -> ok.
 
-%%-callback stop(Host :: ejabberd:lserver()) -> ok.
+-spec stop(Host :: ejabberd:lserver()) -> ok.
 stop(_) -> ok.
 
-%%-callback store_type(Host :: ejabberd:lserver()) -> scram | plain | external.
+-spec store_type(Host :: ejabberd:lserver()) -> scram | plain | external.
 store_type(_) -> scram.
 
-%%-callback set_password( User :: ejabberd:luser(),
-%%                        Server :: ejabberd:lserver(),
-%%                        Password :: binary()
-%%                      ) -> ok | {error, not_allowed | invalid_jid}.
+-spec set_password( User :: ejabberd:luser(),
+                    Server :: ejabberd:lserver(),
+                    Password :: binary()
+                  ) -> ok | {error, not_allowed | invalid_jid}.
 set_password(_, _, _) -> {error, not_allowed}.
 
-%%-callback authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()} | {error, any()}.
+-spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()} | {error, any()}.
 authorize(Creds) ->
     Credentials = { get_credentials(Creds, requested_name),
                     get_credentials(Creds, xmpp_addresses),
@@ -75,7 +75,7 @@ do_authorize({undefined, [OneXmppAddr], _ }) ->
 do_authorize({undefined, [], CommonName}) ->
     %% check if CommonName is correct jid
     case is_binary(CommonName) of
-       true ->
+        true ->
             CommonName;
         _ ->
             {error, <<"not-authorized">>}
@@ -100,55 +100,55 @@ do_authorize(_) ->
     {error, <<"not-authorized">>}.
 
 
-%%-callback try_register( User :: ejabberd:luser(),
-%%                        Server :: ejabberd:lserver(),
-%%                        Password :: binary()
-%%                      ) -> ok | {error, exists | not_allowed | term()}.
+-spec try_register( User :: ejabberd:luser(),
+                    Server :: ejabberd:lserver(),
+                    Password :: binary()
+                  ) -> ok | {error, exists | not_allowed | term()}.
 try_register(_, _, _) -> {error, not_allowed}.
 
-%%-callback dirty_get_registered_users() -> [ejabberd:simple_bare_jid()].
+-spec dirty_get_registered_users() -> [ejabberd:simple_bare_jid()].
 dirty_get_registered_users() -> [].
 
-%%-callback get_vh_registered_users(Server :: ejabberd:lserver()) -> [ejabberd:simple_bare_jid()].
+-spec get_vh_registered_users(Server :: ejabberd:lserver()) -> [ejabberd:simple_bare_jid()].
 get_vh_registered_users(_) -> [].
 
-%%-callback get_vh_registered_users( Server :: ejabberd:lserver(),
-%%                                   Opts :: list()
-%%                                 ) -> [ejabberd:simple_bare_jid()].
+-spec get_vh_registered_users( Server :: ejabberd:lserver(),
+                               Opts :: list()
+                             ) -> [ejabberd:simple_bare_jid()].
 get_vh_registered_users(_, _) -> [].
 
-%%-callback get_vh_registered_users_number(Server :: ejabberd:lserver()) -> integer().
+-spec get_vh_registered_users_number(Server :: ejabberd:lserver()) -> integer().
 get_vh_registered_users_number(_) -> 0.
 
-%%-callback get_vh_registered_users_number( Server :: ejabberd:lserver(),
-%%                                          Opts :: list()
-%%                                        ) -> integer().
+-spec get_vh_registered_users_number( Server :: ejabberd:lserver(),
+                                      Opts :: list()
+                                    ) -> integer().
 get_vh_registered_users_number(_, _) -> 0.
 
-%%-callback get_password( User :: ejabberd:luser(),
-%%                        Server :: ejabberd:lserver()
-%%                      ) -> ejabberd_auth:passterm() | false.
+-spec get_password( User :: ejabberd:luser(),
+                    Server :: ejabberd:lserver()
+                  ) -> ejabberd_auth:passterm() | false.
 get_password(_, _) -> false.
 
-%%-callback get_password_s( User :: ejabberd:luser(),
-%%                          Server :: ejabberd:lserver()
-%%                        ) -> binary().
+-spec get_password_s( User :: ejabberd:luser(),
+                      Server :: ejabberd:lserver()
+                    ) -> binary().
 get_password_s(_, _) -> <<"">>.
 
-%%-callback does_user_exist( User :: ejabberd:luser(),
-%%                           Server :: ejabberd:lserver()
-%%                         ) -> boolean() | {error, atom()}.
+-spec does_user_exist( User :: ejabberd:luser(),
+                       Server :: ejabberd:lserver()
+                     ) -> boolean() | {error, atom()}.
 does_user_exist(_, _) -> true.
 
-%%-callback remove_user( User :: ejabberd:luser(),
-%%                       Server :: ejabberd:lserver()
-%%                     ) -> ok | {error, not_allowed}.
+-spec remove_user( User :: ejabberd:luser(),
+                   Server :: ejabberd:lserver()
+                 ) -> ok | {error, not_allowed}.
 remove_user(_, _) -> {error, not_allowed}.
 
-%%-callback remove_user( User :: ejabberd:luser(),
-%%                       Server :: ejabberd:lserver(),
-%%                       Password :: binary()
-%%                     ) -> ok | {error, not_exists | not_allowed | bad_request}.
+-spec remove_user( User :: ejabberd:luser(),
+                   Server :: ejabberd:lserver(),
+                   Password :: binary()
+                 ) -> ok | {error, not_exists | not_allowed | bad_request}.
 remove_user(_, _, _) -> {error, not_allowed}.
 
 check_password(_, _, _) -> false.

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -81,7 +81,12 @@ do_authorize({RequestedName, [], CommonName}) ->
     RequestedName;
 do_authorize({RequestedName, XmppAddrList, _}) ->
     %% check if RequestedName matches any of XmppAddrList
-    RequestedName;
+    case lists:filter(fun(XmppAddr) -> XmppAddr == RequestedName end, XmppAddrList) of
+        [OneAddr] ->
+            get_username(OneAddr);
+        _ ->
+            {error, <<"not-authorized">>}
+    end;
 do_authorize(_) ->
     {error, <<"not-authorized">>}.
 
@@ -148,3 +153,6 @@ check_password(_, _, _, _, _) -> false.
 get_credentials(Cred, Key) ->
     mongoose_credentials:get(Cred, Key, undefined).
 
+get_username(Jid) ->
+    JidRecord = jid:binary_to_bare(Jid),
+    JidRecord#jid.user.


### PR DESCRIPTION
This PR addresses best practices for using `SASL EXTERNAL` as defined by https://xmpp.org/extensions/xep-0178.html.

