### PR TITLE
Fix ssl handshake error on erlang 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,6 @@ env:
       # When changing jobs, update EXAMPLES in tools/test-runner.sh
     - PRESET=small_tests RUN_SMALL_TESTS=true SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
     - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
-    - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
     - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
     - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
     - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
@@ -107,6 +106,8 @@ matrix:
            RUN_SMALL_TESTS=true
     - otp_release: 21.0
       env: PRESET=riak_mnesia DB=riak REL_CONFIG="with-riak with-jingle-sip" RUN_SMALL_TESTS=true
+    - otp_release: 20.1
+      env: PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
     - language: generic
       env: PRESET=pkg pkg_PLATFORM=centos7
            SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ clean:
 	-rm -rf _build
 	-rm rel/configure.vars.config
 	-rm rel/vars.config
+	-rm src/eldap_filter_yecc.erl
 
 # REBAR_CT_EXTRA_ARGS comes from a test runner
 ct:

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -221,7 +221,9 @@
        {redis, global, default, [{workers, 10}, {strategy, random_worker}], []},
        {rdbms, global, default, [{workers, 5}],
         [{server, {mysql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
-                   [{verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"}]}}]}
+                   [{verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"},
+                    %% To avoid ssl-handshake error in erlang 20 and newer
+                    {server_name_indication, disable}]}}]}
        ]}."},
       {mod_last, "{mod_last, [{backend, rdbms}]},"},
       {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},


### PR DESCRIPTION
This PR addresses errors below.

Proposed changes include:
* Remove autogenerated eldap_filter_yecc.erl in make clean 
* Set server_name_indication=disable in mysql_redis preset 


Error 1:

```erlang
===> Compiling src/eldap_filter_yecc.erl failed

../Library/Application Support/ErlangInstaller/21.1/lib/parsetools-2.1.8/include/yeccpre.hrl:59: illegal pattern

../Library/Application Support/ErlangInstaller/21.1/lib/parsetools-2.1.8/include/yeccpre.hrl:60: variable 'Error' is unbound

../Library/Application Support/ErlangInstaller/21.1/lib/parsetools-2.1.8/include/yeccpre.hrl:60: variable 'Stacktrace' is unbound

../Library/Application Support/ErlangInstaller/21.1/lib/parsetools-2.1.8/include/yeccpre.hrl:63: variable 'Stacktrace' unsafe in 'try' (line 60)

../Library/Application Support/ErlangInstaller/21.1/lib/parsetools-2.1.8/include/yeccpre.hrl:64: variable 'Error' unsafe in 'try' (line 60)

../Library/Application Support/ErlangInstaller/21.1/lib/parsetools-2.1.8/include/yeccpre.hrl:64: variable 'Stacktrace' unsafe in 'try' (line 60)
```

Error 2:

```erlang
2019-01-31 13:53:02 =SUPERVISOR REPORT====
     Supervisor: {local,'mongoose_wpool$rdbms$global$default'}
     Context:    start_error
     Reason:     {shutdown,{failed_to_start_child,'wpool_pool-mongoose_wpool$rdbms$global$default-1',{error,{failed_to_upgrade_socket,{tls_alert,"handshake failure"}}}}}
     Offender:   [{pid,undefined},{id,'wpool_pool-mongoose_wpool$rdbms$global$default-process-sup'},{mfargs,{wpool_process_sup,start_link,['mongoose_wpool$rdbms$global$default','wpool_pool-mongoose_wpool$rdbms$global$default-process-sup',[{queue_manager,'wpool_pool-mongoose_wpool$rdbms$global$default-queue-manager'},{time_checker,'wpool_pool-mongoose_wpool$rdbms$global$default-time-checker'},{worker,{mongoose_rdbms,[{server,{mysql,"localhost","ejabberd","ejabberd","mongooseim_secret",[{verify,verify_peer},{cacertfile,"priv/ssl/cacert.pem"}]}}]}},{pool_sup_shutdown,infinity},{workers,5},{overrun_warning,infinity},{max_overrun_warnings,infinity},{overrun_handler,{error_logger,warning_report}},{workers,100},{worker_opt,[]},{queue_type,fifo}]]}},{restart_type,permanent},{shutdown,infinity},{child_type,supervisor}]
```