### PR TITLE
lowercase HTTP headers in mod_bosh for HTTP/2 compliance

### DIFF
--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -233,7 +233,7 @@ options_request(Config) ->
     fusco_cp:stop(Client),
     {{<<"200">>, <<"OK">>}, Headers, <<>>, _, _} = Result,
     <<"1728000">> = proplists:get_value(<<"access-control-max-age">>, Headers),
-    <<"Content-Type">> = proplists:get_value(<<"access-control-allow-headers">>, Headers),
+    <<"content-type">> = proplists:get_value(<<"access-control-allow-headers">>, Headers),
     <<"POST, OPTIONS, GET">> = proplists:get_value(<<"access-control-allow-methods">>, Headers),
     Server = proplists:get_value(<<"access-control-allow-origin">>, Headers).
 

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -436,16 +436,16 @@ content_type() ->
     {<<"content-type">>, <<"text/xml; charset=utf8">>}.
 
 ac_allow_origin(Origin) ->
-    {<<"Access-Control-Allow-Origin">>, Origin}.
+    {<<"access-control-allow-origin">>, Origin}.
 
 ac_allow_methods() ->
-    {<<"Access-Control-Allow-Methods">>, <<"POST, OPTIONS, GET">>}.
+    {<<"access-control-allow-methods">>, <<"POST, OPTIONS, GET">>}.
 
 ac_allow_headers() ->
-    {<<"Access-Control-Allow-Headers">>, <<"Content-Type">>}.
+    {<<"access-control-allow-headers">>, <<"content-type">>}.
 
 ac_max_age() ->
-    {<<"Access-Control-Max-Age">>, integer_to_binary(?DEFAULT_MAX_AGE)}.
+    {<<"access-control-max-age">>, integer_to_binary(?DEFAULT_MAX_AGE)}.
 
 
 -spec ac_all('undefined' | binary()) -> headers_list().


### PR DESCRIPTION
This PR addresses #2210 

Proposed changes include:
* make HTTP headers lowercase to avoid HTTP/2 connection errors

