### PR TITLE
Do not set cookie for prod node

### DIFF
--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -23,7 +23,7 @@ else
 TLS_DIST_OPTS :=
 endif
 
-COMMON_OPTS := -sname test -setcookie ejabberd -hidden \
+COMMON_OPTS := -sname test -setcookie this_is_cookie_for_dev_nodes_only_do_not_use_it_on_production -hidden \
                $(TLS_DIST_OPTS) \
                -env REPO_DIR "$(ABS_REPO_DIR)" \
                -env TEST_DIR "$(ABS_TEST_DIR)" \

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -7,7 +7,7 @@
 %%       See s2s_SUITE for example on using `hosts` to RPC into nodes (uses CT "require").
 %% the Erlang node name of tested ejabberd/MongooseIM
 {ejabberd_node, 'mongooseim@localhost'}.
-{ejabberd_cookie, ejabberd}.
+{ejabberd_cookie, 'this_is_cookie_for_dev_nodes_only_do_not_use_it_on_production'}.
 {ejabberd_string_format, bin}.
 
 %% TODO: in every new use case this should be used instead

--- a/rebar.config
+++ b/rebar.config
@@ -119,15 +119,15 @@
                                  {overlay_vars, "rel/vars.config"},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
              %% development nodes
-             {mim1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim1.vars.config"]},
+             {mim1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim1.vars.config", "rel/dev.vars.config"]},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {mim2,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim2.vars.config"]},
+             {mim2,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim2.vars.config", "rel/dev.vars.config"]},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {mim3,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim3.vars.config"]},
+             {mim3,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim3.vars.config", "rel/dev.vars.config"]},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {fed1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/fed1.vars.config"]},
+             {fed1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/fed1.vars.config", "rel/dev.vars.config"]},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {reg1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/reg1.vars.config"]},
+             {reg1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/reg1.vars.config", "rel/dev.vars.config"]},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]}
             ]}.
 

--- a/rel/dev.vars.config
+++ b/rel/dev.vars.config
@@ -1,0 +1,1 @@
+{cluster_cookie, "this_is_cookie_for_dev_nodes_only_do_not_use_it_on_production"}.

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -10,7 +10,9 @@
 -sname {{node_name}}
 
 ## Cookie for distributed erlang
--setcookie ejabberd
+## Please make sure this is randomly generated
+## and different for all your MongooseIM or Erlang clusters.
+-setcookie {{cluster_cookie}}
 
 ## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
 ## (Disabled by default..use with caution!)


### PR DESCRIPTION
This PR doesn't set erlang cookie for the prod node build with `rebar3`'s prod profile. Only dev nodes have erlang cookie set in their `vm.args` file and the test node.

This has the following implications:
* packages and docker image doesn't contain any erlang cookie. The cookie (if not set by the operator in `vm.args`) is randomized at startup (unless there is `$HOME/.erlang.cookie` file).
* when clustering MongooseIM, the operator needs to take care of erlang cookie and set the same cookie for every node in the cluster.

TODO:
- [ ] Update documentation with clear instruction where and why the cookie needs to be set when clustering MongooseIM (for instance in [Cluster-configuration-and-node-management.md](https://github.com/esl/MongooseIM/blob/dcddf93ff9effa1f8b74f67f713f4206de333c3d/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md) )
- [ ] Create a dedicated page in our docs describing how to secure the node(s). Firewall settings, which port should not be publicly available and why.