### PR TITLE
Fix starting rabbit pool if no options are passed

### DIFF
--- a/src/mongoose_amqp.erl
+++ b/src/mongoose_amqp.erl
@@ -31,7 +31,7 @@
 
 
 %%%===================================================================
-%%% Types
+%%% Types and definitions
 %%%===================================================================
 
 -type network_params() :: #amqp_params_network{}.
@@ -45,6 +45,7 @@
 
 -type message() :: #amqp_msg{}.
 
+-define(DEFAULT_PORT, 5672).
 
 %%%===================================================================
 %%% API
@@ -90,11 +91,10 @@ message(Payload) ->
 %%% Helpers
 %%%===================================================================
 
-network_params(Opts, #amqp_params_network{host = Host, port = Port,
-                                          username = UserName,
+network_params(Opts, #amqp_params_network{host = Host, username = UserName,
                                           password = Password}) ->
     #amqp_params_network{
        host = proplists:get_value(host, Opts, Host),
-       port = proplists:get_value(port, Opts, Port),
+       port = proplists:get_value(port, Opts, ?DEFAULT_PORT),
        username = proplists:get_value(username, Opts, UserName),
        password = proplists:get_value(password, Opts, Password)}.

--- a/src/wpool/mongoose_wpool_rabbit.erl
+++ b/src/wpool/mongoose_wpool_rabbit.erl
@@ -30,12 +30,17 @@ stop(_, _) ->
 amqp_client_opts(AMQPOpts) ->
     Opts = [{host, proplists:get_value(amqp_host, AMQPOpts)},
             {port, proplists:get_value(amqp_port, AMQPOpts)},
-            {username, binary:list_to_bin(proplists:get_value(amqp_username,
-                                                              AMQPOpts))},
-            {password, binary:list_to_bin(proplists:get_value(amqp_password,
-                                                              AMQPOpts))}],
+            {username, list_to_bin_or_undef(proplists:get_value(amqp_username,
+                                                                AMQPOpts))},
+            {password, list_to_bin_or_undef(proplists:get_value(amqp_password,
+                                                                AMQPOpts))}],
     VerifiedOpts = verify_opts(Opts),
     mongoose_amqp:network_params(VerifiedOpts).
+
+list_to_bin_or_undef(Val) when is_list(Val) ->
+    binary:list_to_bin(Val);
+list_to_bin_or_undef(_) ->
+    undefined.
 
 verify_opts(Opts) ->
     lists:filter(fun({_Opt, undefined}) -> false;


### PR DESCRIPTION
Rabbit pool should pick up default options when none of `PoolOptions`
and `ConnectionOptions` are passed via the `outgoing_pools` config option.

