### PR TITLE
Remove the empty 'to' attribute from archived MUC messages

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1790,7 +1790,9 @@ muc_archive_request(Config) ->
                            message_to=MsgTo, message_from=MsgFrom} =
             parse_forwarded_message(ArcMsg),
         %% XEP: the 'to' of the forwarded stanza MUST be empty
-        ?assert_equal_extra(<<>>, MsgTo, message_to),
+        %% However, Smack crashes if it is present, so it is removed
+        ?assert_equal_extra(undefined, MsgTo, message_to),
+
         %% XEP: the 'from' MUST be the occupant JID of the sender of the archived message
         ?assert_equal_extra(escalus_utils:jid_to_lower(room_address(Room, nick(Alice))),
                             escalus_utils:jid_to_lower(MsgFrom), message_from),

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -250,11 +250,16 @@ make_voice_approval_form(From, Nick, Role) ->
         ]}.
 
 
--spec replace_from_to_attrs(From :: binary(), To :: binary(), [binary_pair()]) -> [binary_pair()].
+-spec replace_from_to_attrs(From :: binary(),
+                            To :: binary() | undefined,
+                            [binary_pair()]) -> [binary_pair()].
 replace_from_to_attrs(From, To, Attrs) ->
     Attrs1 = lists:keydelete(<<"to">>, 1, Attrs),
     Attrs2 = lists:keydelete(<<"from">>, 1, Attrs1),
-    Attrs3 = [{<<"to">>, To} | Attrs2],
+    Attrs3 = case To of
+                 undefined -> Attrs2;
+                 _ -> [{<<"to">>, To} | Attrs2]
+             end,
     Attrs4 = [{<<"from">>, From} | Attrs3],
     Attrs4.
 

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -554,8 +554,9 @@ maybe_delete_x_user_element(false, _ReceiverJID, Packet) ->
 %% When sending out the archives to a requesting client, the 'to' of the
 %% forwarded stanza MUST be empty, and the 'from' MUST be the occupant JID
 %% of the sender of the archived message.
+%% However, Smack crashes if 'to' is present, so it is removed.
 replace_from_to_attributes(SrcJID, Packet = #xmlel{attrs = Attrs}) ->
-    NewAttrs = jlib:replace_from_to_attrs(jid:to_binary(SrcJID), <<>>, Attrs),
+    NewAttrs = jlib:replace_from_to_attrs(jid:to_binary(SrcJID), undefined, Attrs),
     Packet#xmlel{attrs = NewAttrs}.
 
 -spec message_row_to_ext_id(row()) -> binary().


### PR DESCRIPTION
According to [XEP-0313](https://xmpp.org/extensions/attic/xep-0313-0.4.1.html#sect-idp1586112) the 'to' attribute of the forwarded stanza MUST be empty.

However, Smack fails to parse archived MUC messages with 'to'.