### PR TITLE
Add option to configure whether to use cn in SASL EXTERNAL authentication

### DIFF
--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -33,7 +33,9 @@ certificates. If the `xmpp_addrs` fields are included in the certificate, they a
 When no `xmpp_addrs` are specified, the `cn` (_common name_) field might be
 used, but it is optional. If there is more than one `xmpp_addrs` or both the
 list and `cn` field are empty, the client must include
-authorization entity.
+authorization entity. By default _common name_ is used, however it can be
+disabled by adding `{authenticate_with_cn, false}` tuple to the list of
+`auth_opts` in MongooseIM config file.
 For the details please refer to [XEP-0178 Best Practices for Use of SASL EXTERNAL with Certificates](https://xmpp.org/extensions/xep-0178.html).
 
 ### Enable compatible authentication backend

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -362,7 +362,8 @@
              %% {jwt_algorithm, "RS256"},
              %% {jwt_username_key, user}
              %% For cyrsasl_external
-             %% {authenticate_with_cn, true}
+             %% {authenticate_with_cn, false}
+             {{{authenticate_with_cn}}}
             ]}.
 
 %%

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -361,6 +361,8 @@
              %% {jwt_secret_source, "/path/to/file"},
              %% {jwt_algorithm, "RS256"},
              %% {jwt_username_key, user}
+             %% For cyrsasl_external
+             %% {authenticate_with_cn, true}
             ]}.
 
 %%

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -32,6 +32,7 @@
 
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
+{authenticate_with_cn, "{authenticate_with_cn, true}"}.
 {ext_auth_script, "%%{extauth_program, \"/path/to/authentication/script\"}."}.
 {tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls,"}.
 {tls_module, ""}.


### PR DESCRIPTION
Added option in `mongooseim.cfg` to configure to use common name. This PR completes the implementation of SASL EXTERNAL best practices (https://xmpp.org/extensions/xep-0178.html).

