### PR TITLE
Vcard ldap handle user not found

### DIFF
--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -106,6 +106,7 @@ ro_no_search_tests() ->
 
 ldap_only_tests() ->
     [search_some_many_fields_with_or_operator,
+     user_doesnt_exist,
      return_photo_inserted_as_binary_by_3rd_party_service].
 
 suite() ->

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -246,8 +246,8 @@ find_ldap_user(User, State) ->
         {ok, EldapFilter} ->
             Res = eldap_pool_search(EldapID, Base, EldapFilter, State#state.deref, VCardAttrs, false),
             case Res of
-                L when is_list(L) ->
-                    hd(Res);
+                [H | _] ->
+                    H;
                 _ ->
                     Res
             end;


### PR DESCRIPTION
This PR is an attempt to fix error when `eldap_pool_search/6` returns empty list in `mod_vcard_ldap`.