### PR TITLE
Introduce XMPP Ping response (aka pong) time metric

### DIFF
--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -186,9 +186,12 @@ handle_info({timeout, _TRef, {ping, JID}},
              sub_el = [#xmlel{name = <<"ping">>,
                               attrs = [{<<"xmlns">>, ?NS_PING}]}]},
     Pid = self(),
+    T0 = erlang:monotonic_time(millisecond),
     F = fun(_From, _To, Acc, Response) ->
+                TDelta = erlang:monotonic_time(millisecond) - T0,
+                NewAcc = ejabberd_hooks:run_fold(user_ping_response, State#state.host, Acc, [JID, Response, TDelta]),
                 gen_server:cast(Pid, {iq_pong, JID, Response}),
-                Acc
+                NewAcc
         end,
     From = jid:make(<<"">>, State#state.host, <<"">>),
     Acc = mongoose_acc:new(#{ location => ?LOCATION,


### PR DESCRIPTION
This PR introduces a new hook called for successful XMPP ping responses (aka pongs). It can, for example, be used to build a response time histogram therefore roughly gauge connection quality of client devices. This, in turn, allows for `mod_ping` parameter fine-tuning.