### PR TITLE
Configuration of cyrsasl_external

### DIFF
--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -366,7 +366,7 @@ generate_self_signed_cert(C, User, UserConfig, UserKey) ->
     UserCert = filename:join(?config(priv_dir, C), User ++ "_self_signed_cert.pem"),
 
     Cmd = ["openssl", "req", "-config", UserConfig, "-newkey", "rsa:2048", "-sha256", "-nodes",
-	   "-out", UserCert, "-keyout", UserKey, "-x509", "-outform", "PEM"],
+	   "-out", UserCert, "-keyout", UserKey, "-x509", "-outform", "PEM", "-extensions", "client_req_extensions"],
     {done, 0, _Output} = erlsh:run(Cmd),
     #{key => UserKey,
       cert => UserCert}.

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -326,7 +326,7 @@ generate_certs(C) ->
                           #{cn => "john"},
                           #{cn => "not-mike-name"},
                           #{cn => "grace-no-address", xmpp_addrs => ["grace@fed1", "grace@reg1"]},
-                          #{cn => "alice-self-signed", signed => self}]],
+                          #{cn => "alice-self-signed", xmpp_addrs => ["alice@localhost"], signed => self}]],
     [{certs, maps:from_list(Certs)} | C].
 
 generate_cert(C, #{cn := User} = CertSpec) ->

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -16,7 +16,7 @@ groups() ->
           TLSMod <- [<<"just_tls">>, <<"fast_tls">>], check(TLSMod, BaseGroup, Signed)] end,
            [<<"ca_signed">>, <<"self_signed">>] ).
 
-check(<<"fast_tls">>, _,  _) -> false;
+check(<<"fast_tls">>, _,  <<"self_signed">>) -> false;
 check(_, _, _) -> true.
 
 base_groups(Signed) ->
@@ -25,7 +25,7 @@ base_groups(Signed) ->
      {standard, [parallel], standard_test_cases(Signed)},
      {use_common_name, [parallel], use_common_name_test_cases(Signed)},
      {allow_just_user_identity, [parallel], allow_just_user_identity_test_cases(Signed)},
-     {self_signed_test_cases, [sequence], self_signed_test_cases(Signed)}
+     {self_signed_test_cases, [parallel], self_signed_test_cases(Signed)}
     ],
     ct_helper:repeat_all_until_all_ok(G).
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -33,8 +33,16 @@ The `SASL EXTERNAL` authentication method requires a digital client certificate.
 This digital certificate should contain `xmppAddr` field(s), which is always checked first.
 If there is more than one JID specified in the `xmppAddr` fields, the client must include the authorisation entity which corresponds to the one of the specified JIDs.
 
-When no `xmppAddr` is specified, the `cn` (common name) field might be used to provide client's username, but it is optional (enabled by default).
-Usage of a `cn` field can be disabled by adding the `{authenticate_with_cn, false}` tuple to the list of `auth_opts` in MongooseIM config file.
+When no `xmppAddr` is specified, the `cn` (common name) field might be used to provide client's username, but it is optional (not enabled by default).
+There are three possible ways of using the `SASL EXTERNAL` authentication
+method. It can be configured by adding one of the following options to
+the list of `auth_opts` in MongooseIM config file:
+
+* `{cyrsasl_external, standard}` - do not accept a certificate with no `xmpp_addrs` field (default);
+* `{cyrsasl_external, use_common_name}` - use the `common_name` field if it is provided in the certificate;
+* `{cyrsasl_external, allow_just_user_identity}` - accept a certificate if there are no `xmpp_addrs`
+provided and use the user identity from the authentication request.
+
 
 If the client certificate does not contain a JID, the client must provide one in authorisation entity. 
 

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -363,7 +363,7 @@
              %% {jwt_username_key, user}
              %% For cyrsasl_external
              %% {authenticate_with_cn, false}
-             {{{authenticate_with_cn}}}
+             {{{cyrsasl_external}}}
             ]}.
 
 %%

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -32,7 +32,7 @@
 
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
-{authenticate_with_cn, "{authenticate_with_cn, true}"}.
+{cyrsasl_external, "{cyrsasl_external, standard}"}.
 {ext_auth_script, "%%{extauth_program, \"/path/to/authentication/script\"}."}.
 {tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls,"}.
 {tls_module, ""}.


### PR DESCRIPTION
This PR adds three three options of the configuration of `cyrsasl_external`:

- with the use of `common_name`;
- standard (according to `XEP 0178`);
- with the use only of identity of the user.

