### PR TITLE
Default inbox backend fix

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -183,8 +183,7 @@ required_modules() ->
     ].
 
 inbox_opts() ->
-    [{backend, rdbms},
-     {aff_changes, true},
+    [{aff_changes, true},
      {remove_on_kicked, true},
      {groupchat, [muclight]},
      {markers, [displayed]}].


### PR DESCRIPTION
The only supported backned for `mod_inbox` is `rdms`. This PR makes it default.

