### PR TITLE
Handle available_worker incompatibility

### DIFF
--- a/doc/advanced-configuration/outgoing-connections.md
+++ b/doc/advanced-configuration/outgoing-connections.md
@@ -33,6 +33,7 @@ Where:
    with the following exception:
     * `strategy` - specifies the worker selection strategy for the given pool, default is `best_worker`,
       more details on this can be found in [Choosing strategy in worker_pool doc](https://github.com/inaka/worker_pool#choosing-a-strategy)
+      *WARNING:* `redis` and `riak` backends are not compatible with `available_worker` strategy.
     * `call_timeout` - specifies the timeout, in milliseconds, for a call operation to the pool
 * `ConnectionOptions` - options list passed to the `start` function of the pool type
 
@@ -227,6 +228,9 @@ They can be defined as follows:
  {redis, global, Tag, WorkersOptions, ConnectionOptions}
 ]}.
 ```
+
+*WARNING:* `redis` backend is not compatible with `available_worker` strategy.
+
 The `Tag` parameter can only be set to `default` for a session backend.
 For `mod_global_distrib` module it can take any value (default is **global_distrib**) but the name needs to be passed as:
 
@@ -262,6 +266,8 @@ It is configured with the following tuple inside the `outgoing_pools` config opt
  {riak, global, default, [{workers, 20}], [{address, "127.0.0.1"}, {port, 8087}]}
 ]}.
 ```
+
+*WARNING:* `riak` backend is not compatible with `available_worker` strategy.
 
 #### Riak SSL connection setup
 

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -110,9 +110,10 @@ start(Type, Host, Tag, PoolOpts, ConnOpts) ->
     CallTimeout = proplists:get_value(call_timeout, Opts, 5000),
 
     %% If a callback doesn't explicitly blacklist a strategy, let's proceed.
-    case catch call_callback(is_supported_strategy, Type, [Strategy]) of
+    CallbackModule = make_callback_module_name(Type),
+    case catch CallbackModule:is_supported_strategy(Strategy) of
         false ->
-            error({strategy_not_supported, Type, Strategy});
+            error({strategy_not_supported, Type, Host, Tag, Strategy});
         _ ->
             start(Type, Host, Tag, WpoolOptsIn, ConnOpts, Strategy, CallTimeout)
     end.

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -53,9 +53,10 @@
     {ok, {pid(), proplists:proplist()}} | {ok, pid()} |
     {external, pid()} | {error, Reason :: term()}.
 -callback default_opts() -> proplist:proplists().
+-callback is_supported_strategy(Strategy :: wpool:strategy()) -> boolean().
 -callback stop(host(), tag()) -> ok.
 
--optional_callbacks([default_opts/0]).
+-optional_callbacks([default_opts/0, is_supported_strategy/1]).
 
 ensure_started() ->
     wpool:start(),
@@ -105,11 +106,20 @@ start(Type, Host, Tag, PoolOpts) ->
 start(Type, Host, Tag, PoolOpts, ConnOpts) ->
     {Opts0, WpoolOptsIn} = proplists:split(PoolOpts, [strategy, call_timeout]),
     Opts = lists:append(Opts0) ++ default_opts(Type),
+    Strategy = proplists:get_value(strategy, Opts, best_worker),
+    CallTimeout = proplists:get_value(call_timeout, Opts, 5000),
 
+    %% If a callback doesn't explicitly blacklist a strategy, let's proceed.
+    case catch call_callback(is_supported_strategy, Type, [Strategy]) of
+        false ->
+            error({strategy_not_supported, Type, Strategy});
+        _ ->
+            start(Type, Host, Tag, WpoolOptsIn, ConnOpts, Strategy, CallTimeout)
+    end.
+
+start(Type, Host, Tag, WpoolOptsIn, ConnOpts, Strategy, CallTimeout) ->
     case mongoose_wpool_mgr:start(Type, Host, Tag, WpoolOptsIn, ConnOpts) of
         {ok, Pid} ->
-            Strategy = proplists:get_value(strategy, Opts, best_worker),
-            CallTimeout = proplists:get_value(call_timeout, Opts, 5000),
             ets:insert(?MODULE, #mongoose_wpool{name = {Type, Host, Tag},
                                                 strategy = Strategy,
                                                 call_timeout = CallTimeout}),

--- a/src/wpool/mongoose_wpool_redis.erl
+++ b/src/wpool/mongoose_wpool_redis.erl
@@ -4,6 +4,7 @@
 -export([init/0]).
 -export([start/4]).
 -export([stop/2]).
+-export([is_supported_strategy/1]).
 
 init() ->
     ok.
@@ -15,6 +16,9 @@ start(Host, Tag, WpoolOptsIn, ConnOpts) ->
 
 stop(_, _) ->
     ok.
+
+is_supported_strategy(available_worker) -> false;
+is_supported_strategy(_) -> true.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/wpool/mongoose_wpool_riak.erl
+++ b/src/wpool/mongoose_wpool_riak.erl
@@ -4,6 +4,7 @@
 -export([init/0]).
 -export([start/4]).
 -export([stop/2]).
+-export([is_supported_strategy/1]).
 -export([get_riak_opt/2]).
 -export([get_riak_opt/3]).
 
@@ -17,6 +18,9 @@ start(Host, Tag, WpoolOptsIn, ConnOpts) ->
 
 stop(_, _) ->
     ok.
+
+is_supported_strategy(available_worker) -> false;
+is_supported_strategy(_) -> true.
 
 wpool_spec(WpoolOptsIn, ConnOpts) ->
     {_, RiakAddr} = mongoose_wpool_riak:get_riak_opt(address, ConnOpts),

--- a/test/mongoose_wpool_SUITE.erl
+++ b/test/mongoose_wpool_SUITE.erl
@@ -240,11 +240,13 @@ redis_pool_cant_be_started_with_available_worker_strategy(_Config) ->
     pool_cant_be_started_with_available_worker_strategy(redis).
 
 pool_cant_be_started_with_available_worker_strategy(Type) ->
-    PoolName = mongoose_wpool:make_pool_name(Type, global, default),
+    Host = global,
+    Tag = default,
+    PoolName = mongoose_wpool:make_pool_name(Type, Host, Tag),
     meck:expect(mongoose_wpool, start_sup_pool, start_sup_pool_mock(PoolName)),
-    PoolDef = [{Type, global, default, [{strategy, available_worker}],
+    PoolDef = [{Type, Host, Tag, [{strategy, available_worker}],
                 [{address, "localhost"}, {port, 1805}]}],
-    ?assertError({strategy_not_supported, Type, available_worker},
+    ?assertError({strategy_not_supported, Type, Host, Tag, available_worker},
                  mongoose_wpool:start_configured_pools(PoolDef)).
 
 %%--------------------------------------------------------------------

--- a/test/mongoose_wpool_SUITE.erl
+++ b/test/mongoose_wpool_SUITE.erl
@@ -26,7 +26,8 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    [get_pools_returns_pool_names,
+    [
+     get_pools_returns_pool_names,
      stats_passes_through_to_wpool_stats,
      a_global_riak_pool_is_started,
      two_distinct_redis_pools_are_started,
@@ -35,7 +36,10 @@ all() ->
      pools_for_different_tag_are_expanded_with_host_specific_config_preserved,
      global_pool_is_used_by_default,
      dead_pool_is_restarted,
-     dead_pool_is_stopped_before_restarted].
+     dead_pool_is_stopped_before_restarted,
+     riak_pool_cant_be_started_with_available_worker_strategy,
+     redis_pool_cant_be_started_with_available_worker_strategy
+    ].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -226,6 +230,23 @@ dead_pool_is_stopped_before_restarted(_C) ->
     timer:sleep(timer:seconds(4)),
     ?assertEqual(undefined, erlang:whereis(PoolName)),
     meck:unload(killing_workers).
+
+%% --- available_worker strategy is banned for some backends --
+
+riak_pool_cant_be_started_with_available_worker_strategy(_Config) ->
+    pool_cant_be_started_with_available_worker_strategy(riak).
+
+redis_pool_cant_be_started_with_available_worker_strategy(_Config) ->
+    pool_cant_be_started_with_available_worker_strategy(redis).
+
+pool_cant_be_started_with_available_worker_strategy(Type) ->
+    PoolName = mongoose_wpool:make_pool_name(Type, global, default),
+    meck:expect(mongoose_wpool, start_sup_pool, start_sup_pool_mock(PoolName)),
+    PoolDef = [{Type, global, default, [{strategy, available_worker}],
+                [{address, "localhost"}, {port, 1805}]}],
+    ?assertError({strategy_not_supported, Type, available_worker},
+                 mongoose_wpool:start_configured_pools(PoolDef)).
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses #2184

`riak` and `redis` connection pools are not compatible with `available_worker` strategy, because their API needs to get a worker PID from a pool instead of sending request to it. This PR doesn't allow to start these pools with this strategy. It's not a definite solution but at least avoids confusion for now and is pretty short.
A proper solution would improve these pools to work with `available_worker` but it most likely involves adding a proxy process or modifying `worker_pool`.