### PR TITLE
fix docs about mongoose_api_admin authorization

### DIFF
--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -107,7 +107,7 @@ Unlike `ejabberd_c2s`, it doesn't use `ejabberd_receiver` or `ejabberd_listener`
 
      Example:
 
-            `{"localhost", "/api", mongoose_api_admin, [{auth, {"ala", "makotaipsa"}}]}`
+            `{"localhost", "/api", mongoose_api_admin, [{auth, {<<"ala">>, <<"makotaipsa">>}}]}`
 
   * `mongoose_api_client` - REST API for client side commands.
      Exposes all mongoose_commands marked as "user".


### PR DESCRIPTION
This PR addresses #
Fixes documentation about `mongoose_api_admin` authorization. The example given does not work, User and Password need to be binaries.

Proposed changes include:
* Make explicit that User and Password are binaries by using << >> in the example given.
