### PR TITLE
Fix xeplist Makefile rule and xep_tool escript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(DEVNODES): certs configure.out rel/vars.config
 certs:
 	cd tools/ssl && $(MAKE)
 
-xeplist: escript
+xeplist:
 	escript $(XEP_TOOL)/xep_tool.escript markdown $(EBIN)
 
 install: configure.out rel

--- a/tools/xep_tool/xep_tool.escript
+++ b/tools/xep_tool/xep_tool.escript
@@ -1,5 +1,4 @@
 #!/usr/bin/env escript
-%%!  -s inets start
 %% -*- erlang -*-
 %%
 %% Example usage:
@@ -45,16 +44,21 @@ match_zeros(Number) when Number > 9 ->
 match_zeros(Number) ->
     ["000", integer_to_list(Number)].
 
--spec main(list(iolist())) -> ok | no_return().
-main([Command, InDir]) ->
+main(Args) ->
+    {ok, _} = application:ensure_all_started(ssl),
+    {ok, _} = application:ensure_all_started(inets),
+    run(Args).
+
+-spec run(list(iolist())) -> ok | no_return().
+run([Command, InDir]) ->
     code:set_path(code:get_path() ++ [InDir]),
     do(Command, ?FILE_NAME);
 
-main([Command, InDir, Output]) ->
+run([Command, InDir, Output]) ->
     code:set_path(code:get_path() ++ [InDir]),
     do(Command, Output);
 
-main(_) ->
+run(_) ->
     usage().
 
 -spec usage() -> no_return().


### PR DESCRIPTION
In order to answer #2251.

I don't know why, but following https://mongooseim.readthedocs.io/en/latest/developers-guide/xep_tool/ showed that the procedure to run `make xeplist` or even `escript tools/xep_tool/xep_tool.escript markdown _build/default/lib/mongooseim/ebin/` does not work. After the changes it works for me, but it would be good if somebody else could also try it. Works for me on Erlang 21.3.