### PR TITLE
Get rid of store_type/1 in auth backends

### DIFF
--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -110,14 +110,9 @@ init_per_group(GroupName, Config0) ->
                  commands -> ejabberd_node_utils:init(Config0);
                  _ -> Config0
              end,
-    case get_auth_method() of
-        external ->
-            {skip, "external authentication requires plain password"};
-        _ ->
-            config_password_format(GroupName),
-            Config2 = escalus:create_users(Config, escalus:get_users([bob, alice])),
-            assert_password_format(GroupName, Config2)
-    end.
+    config_password_format(GroupName),
+    Config2 = escalus:create_users(Config, escalus:get_users([bob, alice])),
+    assert_password_format(GroupName, Config2).
 
 end_per_group(cleanup, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice]));
@@ -359,10 +354,6 @@ extract_tokens(#xmlel{name = <<"iq">>, children = [#xmlel{name = <<"items">>} = 
     ATD = exml_query:path(Items, [{element, <<"access_token">>}, cdata]),
     RTD = exml_query:path(Items, [{element, <<"refresh_token">>}, cdata]),
     {base64:decode(ATD), base64:decode(RTD)}.
-
-get_auth_method() ->
-    XMPPDomain = escalus_ejabberd:unify_str_arg(ct:get_config({hosts, mim, domain})),
-    rpc(mim(), ejabberd_auth, store_type, [XMPPDomain]).
 
 set_store_password(Type) ->
     XMPPDomain = escalus_ejabberd:unify_str_arg(ct:get_config({hosts, mim, domain})),

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -185,9 +185,9 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
 ### Authentication
 
 * **auth_method** (local)
-    * **Description:** Chooses an authentication module or a list of modules. Modules from a list are queried one after another until one of them replies positively.
-    * **Valid values:** `internal` (Mnesia), `rdbms`, `external`, `anonymous`, `ldap`, `jwt`, `riak`, `http`
-    * **Warning:** `external`, `jwt` and `ldap` work only with `PLAIN` SASL mechanism.
+    * **Description:** Chooses an authentication module or a list of modules. Modules from the list are queried one after another until one of them replies positively.
+    * **Valid values:** `internal` (Mnesia), `rdbms`, `external`, `anonymous`, `ldap`, `jwt`, `riak`, `http`, `pki`
+    * **Warning:** Authentication backends support only specific SASL mechanisms, see [auth backends capabilities](#authentication-backend-capabilities).
     * **Examples:** `rdbms`, `[internal, anonymous]`
 
 * **auth_opts** (local)
@@ -213,7 +213,7 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
 
 * **sasl_mechanisms** (local)
     * **Description:** Specifies a list of allowed SASL mechanisms. It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code).
-    * **Warning:** This list is still filtered by auth backends capabilities, e.g. LDAP authentication requires a password provided via SASL PLAIN.
+    * **Warning:** This list is still filtered by [auth backends capabilities](#authentication-backend-capabilities)
     * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
     * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
     * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram]`
@@ -222,6 +222,24 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
     * **Description:** Specifies a number of workers serving external authentication requests.
     * **Syntax:** `{extauth_instances, Count}.`
     * **Default:** 1
+
+#### Authentication backend capabilities
+
+The table below shows the supported SASL mechanisms for each authentication backend module.
+
+|           | cyrsasl<br>plain | cyrsasl<br>digest | cyrsasl<br>scram | cyrsasl<br>anonymous | cyrsasl<br>external |
+|-----------|:----------------:|:-----------------:|:----------------:|:--------------------:|:-------------------:|
+| internal  |         x        |         x         |         x        |                      |                     |
+| rdbms     |         x        |         x         |         x        |                      |                     |
+| external  |         x        |                   |                  |                      |                     |
+| anonymous |         x        |         x         |         x        |           x          |                     |
+| ldap      |         x        |                   |                  |                      |                     |
+| jwt       |         x        |                   |                  |                      |                     |
+| riak      |         x        |         x         |         x        |                      |                     |
+| http      |         x        |         x         |         x        |                      |                     |
+| pki       |                  |                   |                  |                      |          x          |
+
+`cyrsasl_oauth` does not use the auth backends at all and requires the `mod_auth_token` module enabled instead.
 
 ### Outgoing connections setup
 

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -53,18 +53,6 @@ For the details please refer to [XEP-0178 Best Practices for Use of SASL EXTERNA
 Please modify [`auth_opts` option](../Advanced-configuration.md#authentication) in MongooseIM's config file to include proper item.
 Also, [`pki` backend](../authentication-backends/PKI-authentication-module.md) is recommended for `SASL EXTERNAL`.
 
-### WARNING!
-
-Some authentication backends may enforce `plain` password storage format, which automatically disables `SASL EXTERNAL`.
-Below you may find a list of backends that are safe to use with `cyrsasl_external` mechanism.
-
-* `pki`
-* `anonymous`
-* `http` **without** `{is_external, true}` option
-* `internal`
-* `rdbms`
-* `riak`
-
 ### Self-signed certificates
 
 By default MongooseIM doesn't accept self-signed certs for the SASL-EXTERNAL authentication.

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -50,7 +50,7 @@
          is_user_exists_in_other_modules/3,
          remove_user/2,
          remove_user/3,
-         store_type/1,
+         supports_password_type/2,
          entropy/1
         ]).
 
@@ -122,20 +122,9 @@ get_opt(Host, Opt, Default) ->
 get_opt(Host, Opt) ->
     get_opt(Host, Opt, undefined).
 
-store_type(Server) ->
-    lists:foldl(
-      fun(_, external) ->
-              external;
-         (M, scram) ->
-              case M:store_type(Server) of
-                  external ->
-                      external;
-                  _Else ->
-                      scram
-              end;
-         (M, plain) ->
-              M:store_type(Server)
-      end, plain, auth_modules(Server)).
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(Server, PasswordType) ->
+    lists:any(fun(M) -> M:supports_password_type(Server, PasswordType) end, auth_modules(Server)).
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -53,7 +53,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1,
+         supports_password_type/2,
          get_vh_registered_users/2,
          get_vh_registered_users_number/1,
          get_vh_registered_users_number/2,
@@ -342,9 +342,11 @@ remove_user(_LUser, _LServer) ->
 remove_user(_LUser, _LServer, _Password) ->
     {error, not_allowed}.
 
-
-store_type(_) ->
-    plain.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, plain) -> true;
+supports_password_type(_, scram) -> true;
+supports_password_type(_, digest) -> true;
+supports_password_type(_, _) -> false.
 
 get_vh_registered_users_number(_LServer) -> 0.
 
@@ -352,3 +354,5 @@ get_vh_registered_users_number(_LServer, _Opts) -> 0.
 
 %% @doc gen_auth unimplemented callbacks
 get_password_s(_LUser, _LServer) -> erlang:error(not_implemented).
+
+

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -44,7 +44,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1
+         supports_password_type/2
         ]).
 
 %% Internal
@@ -88,8 +88,8 @@ check_cache_last_options(Server) ->
             end
     end.
 
-store_type(_) ->
-    external.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, Type) -> Type =:= plain.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -25,7 +25,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1,
+         supports_password_type/2,
          stop/1]).
 
 %% Pre-mongoose_credentials API
@@ -45,18 +45,11 @@
 start(_Host) ->
     ok.
 
--spec store_type(binary()) -> plain | external | scram.
-store_type(Server) ->
-    case scram:enabled(Server) of
-        false ->
-            case ejabberd_auth:get_opt(Server, is_external) of
-                true ->
-                    external;
-                _ ->
-                    plain
-            end;
-        true -> scram
-    end.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, plain) -> true;
+supports_password_type(_, scram) -> true;
+supports_password_type(Host, digest) -> not scram:enabled(Host);
+supports_password_type(_, _) -> false.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -44,7 +44,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1
+         supports_password_type/2
         ]).
 
 -export([scram_passwords/0]).
@@ -103,11 +103,11 @@ update_reg_users_counter_table(Server) ->
         end,
     mnesia:sync_dirty(F).
 
-store_type(Server) ->
-    case scram:enabled(Server) of
-        false -> plain;
-        true -> scram
-    end.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, plain) -> true;
+supports_password_type(_, scram) -> true;
+supports_password_type(Host, digest) -> not scram:enabled(Host);
+supports_password_type(_, _) -> false.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -46,7 +46,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1
+         supports_password_type/2
         ]).
 
 
@@ -72,8 +72,8 @@ start(Host) ->
 stop(_Host) ->
     ok.
 
-store_type(_Server) ->
-    external.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, PasswordType) -> PasswordType =:= plain.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_ldap.erl
+++ b/src/auth/ejabberd_auth_ldap.erl
@@ -50,7 +50,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1
+         supports_password_type/2
         ]).
 
 %% Internal
@@ -134,7 +134,8 @@ init(Host) ->
                           State#state.password, State#state.tls_options),
     {ok, State}.
 
-store_type(_) -> external.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, PasswordType) -> PasswordType =:= plain.
 
 config_change(Acc, Host, ldap, _NewConfig) ->
     stop(Host),

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -23,7 +23,7 @@
 %% ejabberd_gen_auth API
 -export([start/1,
          stop/1,
-         store_type/1,
+         supports_password_type/2,
          set_password/3,
          authorize/1,
          try_register/3,
@@ -48,8 +48,8 @@ start(_) -> ok.
 -spec stop(Host :: ejabberd:lserver()) -> ok.
 stop(_) -> ok.
 
--spec store_type(Host :: ejabberd:lserver()) -> scram | plain | external.
-store_type(_) -> scram.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, PasswordType) -> PasswordType =:= cert.
 
 -spec set_password( User :: ejabberd:luser(),
                     Server :: ejabberd:lserver(),

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -44,7 +44,7 @@
          does_user_exist/2,
          remove_user/2,
          remove_user/3,
-         store_type/1
+         supports_password_type/2
         ]).
 
 %% Internal
@@ -84,11 +84,11 @@ start(_Host) ->
 stop(_Host) ->
     ok.
 
-store_type(Server) ->
-    case scram:enabled(Server) of
-        false -> plain;
-        true -> scram
-    end.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, plain) -> true;
+supports_password_type(_, scram) -> true;
+supports_password_type(Host, digest) -> not scram:enabled(Host);
+supports_password_type(_, _) -> false.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -23,7 +23,7 @@
 %% API
 -export([start/1,
          stop/1,
-         store_type/1,
+         supports_password_type/2,
          set_password/3,
          authorize/1,
          try_register/3,
@@ -53,12 +53,11 @@ start(_Host) ->
 stop(_Host) ->
     ok.
 
--spec store_type(jid:lserver()) -> plain | scram.
-store_type(Host) ->
-    case scram:enabled(Host) of
-        false -> plain;
-        true -> scram
-    end.
+-spec supports_password_type(jid:lserver(), cyrsasl:password_type()) -> boolean().
+supports_password_type(_, plain) -> true;
+supports_password_type(_, scram) -> true;
+supports_password_type(Host, digest) -> not scram:enabled(Host);
+supports_password_type(_, _) -> false.
 
 -spec set_password(jid:luser(), jid:lserver(), binary())
         -> ok | {error, not_allowed | invalid_jid}.

--- a/src/auth/ejabberd_gen_auth.erl
+++ b/src/auth/ejabberd_gen_auth.erl
@@ -11,7 +11,8 @@
 
 -callback stop(Host :: jid:lserver()) -> ok.
 
--callback store_type(Host :: jid:lserver()) -> scram | plain | external.
+-callback supports_password_type(Host :: jid:lserver(),
+                                 PasswordType :: cyrsasl:password_type()) -> boolean().
 
 -callback set_password(User :: jid:luser(),
                        Server :: jid:lserver(),

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -45,7 +45,7 @@ stop() ->
 
 -spec mech_new(Host :: ejabberd:server(),
                Creds :: mongoose_credentials:t()) -> {ok, sasl_external_state()}.
-mech_new(Host, Creds) ->
+mech_new(_Host, Creds) ->
     Cert = mongoose_credentials:get(Creds, client_cert, no_cert),
     maybe_extract_certs(Cert, Creds).
 

--- a/test/auth_external_SUITE.erl
+++ b/test/auth_external_SUITE.erl
@@ -20,7 +20,7 @@ all_tests() ->
      does_user_exist,
      get_password_returns_false_if_no_cache,
      get_password_s_returns_empty_bin_if_no_cache,
-     store_type_external
+     supported_password_types
     ].
 
 init_per_suite(C) ->
@@ -71,8 +71,9 @@ get_password_returns_false_if_no_cache(_C) ->
 get_password_s_returns_empty_bin_if_no_cache(_C) ->
     <<"">> = ?AUTH_MOD:get_password_s(random_binary(8), domain()).
 
-store_type_external(_C) ->
-    external = ?AUTH_MOD:store_type(domain()).
+supported_password_types(_C) ->
+    [true, false, false, false] =
+        [?AUTH_MOD:supports_password_type(domain(), PT) || PT <- [plain, digest, scram, cert]].
 
 given_user_registered() ->
     {U, P} = UP = gen_user(),

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -45,7 +45,8 @@ all_tests() ->
      try_register,
      get_password,
      is_user_exists,
-     remove_user
+     remove_user,
+     supported_password_types
     ].
 
 suite() ->
@@ -170,6 +171,14 @@ remove_user(_Config) ->
     false = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
 
     {error, not_exists} = ejabberd_auth_http:remove_user(<<"toremove3">>, ?DOMAIN1, <<"wrongpass">>).
+
+supported_password_types(Config) ->
+    DigestSupported = case lists:keyfind(scram_group, 1, Config) of
+                          {_, true} -> false;
+                          _ -> true
+                      end,
+    [true, DigestSupported, true, false] =
+        [ejabberd_auth_http:supports_password_type(?DOMAIN1, PT) || PT <- [plain, digest, scram, cert]].
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -33,7 +33,7 @@ generic_tests() ->
      remove_user,
      get_vh_registered_users_number,
      get_vh_registered_users,
-     store_type,
+     supported_password_types,
      dirty_get_registered_users
     ].
 
@@ -137,8 +137,9 @@ get_vh_registered_users_number(_C) ->
 get_vh_registered_users(_C) ->
     [] = ejabberd_auth_jwt:get_vh_registered_users(?DOMAIN1, []).
 
-store_type(_C) ->
-    external = ejabberd_auth_jwt:store_type(?DOMAIN1).
+supported_password_types(_C) ->
+    [true, false, false, false] =
+        [ejabberd_auth_jwt:supports_password_type(?DOMAIN1, PT) || PT <- [plain, digest, scram, cert]].
 
 dirty_get_registered_users(_C) ->
     [] = ejabberd_auth_jwt:dirty_get_registered_users().


### PR DESCRIPTION
### Before the change

Each auth backend had a `store_type/1` callback, which could return
'external', 'plain' or 'scram'.

There was a function called `store_type/1` in `ejabberd_auth` as well.
It traversed all backends, trying to determine the store type
for the whole host with a logic that e.g. favored 'external' over
'plain' (see the implementation for details).

Each SASL mechanism had its own password type, which was stored
in the sasl_mechanism ETS table on mechanism registration.
The possible password types were 'plain', 'digest', 'scram' and 'cert'.

To determine supported mechanisms in `cyrsasl:listmech/1`,
the store type for the current host was used to filter the SASL
mechanisms with the following rules:

```
Auth store_type     Supported password types
--------------      ------------------------
external            plain
scram               plain, scram, cert
plain               plain, digest, scram
```

### After the change

There is no notion of store types anymore - auth backends have a new
`supports_password_type/1` callback, which returns a boolean that
indicates the support for individual password types.

To determine support for a particular password type for the whole host,
the corresponding function in `ejabberd_auth` checks if any backend
supports it.

To determine supported mechanisms in `cyrsasl:listmech/1`,
for each mechanism it is enough to check if the current host supports
its password type.

Furthermore, the 'cert' password type is now supported only by the 'pki'
auth backend and no longer matches mechanisms supporting SCRAM.

Configuration is simplified,
e.g. the HTTP auth backend does not disable SASL EXTERNAL for the whole host.
