### PR TITLE
Register command with automatic jid creation

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -172,6 +172,10 @@ end_per_group(Rosters, Config) when (Rosters == roster) or (Rosters == roster_ad
 end_per_group(_GroupName, Config) ->
     Config.
 
+get_registered_users() ->
+    Host = ct:get_config({hosts, mim, domain}),
+    Users = rpc(mim(), ejabberd_auth, get_vh_registered_users, [Host]).
+
 init_per_testcase(CaseName, Config)
   % these cases are incompatible with domainless rdbms schema
   when CaseName == delete_old_users_vhost
@@ -305,7 +309,7 @@ delete_old_users_vhost(Config) ->
     Now = Mega*1000000+Secs,
     set_last(AliceName, Domain, Now-86400*30),
 
-    {_, 0} = ejabberdctl("register", [KateName, SecDomain, KatePass], Config),
+    {_, 0} = ejabberdctl("register_identified", [KateName, SecDomain, KatePass], Config),
     {_, 0} = ejabberdctl("check_account", [KateName, SecDomain], Config),
     {_, 0} = ejabberdctl("delete_old_users_vhost", [SecDomain, "10"], Config),
     {_, 0} = ejabberdctl("check_account", [AliceName, Domain], Config),
@@ -907,10 +911,17 @@ simple_register(Config) ->
     Domain = ct:get_config({hosts, mim, domain}),
     {Name, Password} = {<<"tyler">>, <<"durden">>},
     %% when
-    {_, 0} = ejabberdctl("register", [Name, Domain, Password], Config),
+    {R1, 0} = ejabberdctl("registered_users", [Domain], Config),
+    {match, ResList1} = re:run(R1, "(.+)", [global]),
+    Before = length(ResList1),
+    {_, 0} = ejabberdctl("register", [Domain, Password], Config),
+    {_, 0} = ejabberdctl("register", [Domain, Password], Config),
+
     {R2, 0} = ejabberdctl("registered_users", [Domain], Config),
+    {match, ResList2} = re:run(R2, "(.+)", [global]),
+    After = length(ResList2),
     %% then
-    {match, _} = re:run(R2, ".*(" ++ binary_to_list(Name) ++ ").*").
+    2 = After - Before.
 
 simple_unregister(Config) ->
     %% given
@@ -927,8 +938,8 @@ register_twice(Config) ->
     Domain = ct:get_config({hosts, mim, domain}),
     {Name,  Password} = {<<"tyler">>, <<"durden">>},
     %% when
-    {_, 0} = ejabberdctl("register", [Name, Domain, Password], Config),
-    {R, Code} = ejabberdctl("register", [Name, Domain, Password], Config),
+    {_, 0} = ejabberdctl("register_identified", [Name, Domain, Password], Config),
+    {R, Code} = ejabberdctl("register_identified", [Name, Domain, Password], Config),
     %% then
     {match, _} = re:run(R, ".*(already registered).*"),
     true = (Code =/= 0),
@@ -1110,10 +1121,9 @@ set_last(User, Domain, TStamp) ->
 
 delete_users(Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),
-    lists:foreach(fun({_User, UserSpec}) ->
-                {Username, Domain, _Pass} = get_user_data(UserSpec, Config),
-                rpc(mim(), ejabberd_auth, remove_user, [Username, Domain])
-        end, Users).
+    lists:foreach(fun({User, Domain}) ->
+                rpc(mim(), ejabberd_auth, remove_user, [User, Domain])
+        end, get_registered_users()).
 
 %%-----------------------------------------------------------------
 %% Predicates

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -912,14 +912,12 @@ simple_register(Config) ->
     {Name, Password} = {<<"tyler">>, <<"durden">>},
     %% when
     {R1, 0} = ejabberdctl("registered_users", [Domain], Config),
-    {match, ResList1} = re:run(R1, "(.+)", [global]),
-    Before = length(ResList1),
+    Before = length(string:tokens(R1, "\n")),
     {_, 0} = ejabberdctl("register", [Domain, Password], Config),
     {_, 0} = ejabberdctl("register", [Domain, Password], Config),
 
     {R2, 0} = ejabberdctl("registered_users", [Domain], Config),
-    {match, ResList2} = re:run(R2, "(.+)", [global]),
-    After = length(ResList2),
+    After = length(string:tokens(R2, "\n")),
     %% then
     2 = After - Before.
 

--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -67,10 +67,14 @@ The default XMPP domain served by MongooseIM right after installation is `localh
 Users on a different computer can register using the server’s IP address.
 
 You can register a user with the `mongooseimctl` utility.
-The following command registers the user `user@domain` using password `password`.
-
+This command registers a user with a random username part of the jid.
 ```
-mongooseimctl register user domain password
+mongooseimctl register domain password
+```
+
+And the following one registers the user `user@domain` using password `password`.
+```
+mongooseimctl register_identified user domain password
 ```
 
 ## Connecting with an XMPP client

--- a/doc/user-guide/ICE_tutorial.md
+++ b/doc/user-guide/ICE_tutorial.md
@@ -78,8 +78,8 @@ For this demo we need two users: *movie@myxmpp.com* and *phone@myxmpp.com*, for 
 In order to do that, type:
 
 ```bash
-$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl register phone myxmpp.com xmpp_password
-$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl register movie myxmpp.com xmpp_password
+$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl register_identified phone myxmpp.com xmpp_password
+$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl register_identified movie myxmpp.com xmpp_password
 ```
 
 on the machine that has [MongooseIM] installed.

--- a/doc/user-guide/Jingle-SIP-setup.md
+++ b/doc/user-guide/Jingle-SIP-setup.md
@@ -112,8 +112,8 @@ and in [Modules configuration](../advanced-configuration/Modules.md)
 
 Now we are registering both users in MongooseIM by calling the following commands:
 
-    bin/mongooseimctl register xmpp.user xmpp.example test_pass
-    bin/mongooseimctl register sip.user sip.example test_pass
+    bin/mongooseimctl register_identified xmpp.user xmpp.example test_pass
+    bin/mongooseimctl register_identified sip.user sip.example test_pass
 
 Yes, we need to have the `sip.user@sip.example` registered in MongooseIM.
 This is needed because a Jingle call can be initiated by a regular XMPP client only when the app knows the other user's full JID.

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -34,7 +34,7 @@
          status/0,
          send_service_message_all_mucs/2,
          %% Accounts
-         register/3, unregister/2,
+         register/3, register/2, unregister/2,
          registered_users/1,
          import_users/1,
          %% Purge DB
@@ -86,6 +86,11 @@ commands() ->
                         result = {res, restuple}},
      #ejabberd_commands{name = register, tags = [accounts],
                         desc = "Register a user",
+                        module = ?MODULE, function = register,
+                        args = [{host, binary}, {password, binary}],
+                        result = {res, restuple}},
+    #ejabberd_commands{name = register_identified, tags = [accounts],
+                        desc = "Register a user with a specific jid",
                         module = ?MODULE, function = register,
                         args = [{user, binary}, {host, binary}, {password, binary}],
                         result = {res, restuple}},
@@ -314,6 +319,14 @@ send_service_message_all_mucs(Subject, AnnouncementText) ->
 %%% Account management
 %%%
 
+-spec register(Host :: jid:server(),
+               Password :: binary()) -> {'cannot_register', io_lib:chars()}
+                                      | {'exists', io_lib:chars()}
+                                      | {'ok', io_lib:chars()}.
+register(Host, Password) ->
+    User = generate_user(),
+    register(User, Host, Password).
+
 -spec register(User :: jid:user(),
                Host :: jid:server(),
                Password :: binary()) -> {'cannot_register', io_lib:chars()}
@@ -332,6 +345,11 @@ register(User, Host, Password) ->
         _ ->
             {ok, io_lib:format("User ~s@~s successfully registered", [User, Host])}
     end.
+
+generate_user() ->
+    mongoose_bin:join([mongoose_bin:gen_from_timestamp(),
+                      mongoose_bin:gen_from_crypto()],
+                      $-).
 
 
 -spec unregister(User :: jid:user(),


### PR DESCRIPTION
This PR modifies `register` command in the cli as well as adds `register_identified` command.

`register` - it no longer accepts username argument and instead generates random and monotonic user uid.
`register_identified` - it behaves the same way as `register` used to behave.

TODO:
- [ ] We have to think if the random string suffix is necessary (added so that we don't have collisions with MUCs.
- [ ] Think of a schema of jids. Do we want to have a special format of user id? Should it conatin information like whether it is a private user jid or room jid (and this way avoid collisions with mucs from point 1.?