### PR TITLE
Fix MUC Light "role" archived in MAM

### DIFF
--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -175,3 +175,15 @@ has_features(#xmlel{children = [ Query ]}) ->
     <<"conference">> = exml_query:attr(Identity, <<"category">>),
     true = lists:member(?NS_MUC, exml_query:paths(Query, [{element, <<"feature">>},
                                                           {attr, <<"var">>}])).
+
+assert_valid_affiliation(<<"owner">>) -> ok;
+assert_valid_affiliation(<<"admin">>) -> ok;
+assert_valid_affiliation(<<"member">>) -> ok;
+assert_valid_affiliation(<<"outcast">>) -> ok;
+assert_valid_affiliation(<<"none">>) -> ok.
+
+assert_valid_role(<<"moderator">>) -> ok;
+assert_valid_role(<<"participant">>) -> ok;
+assert_valid_role(<<"visitor">>) -> ok;
+assert_valid_role(<<"none">>) -> ok.
+

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -6,6 +6,7 @@
 -include("muc_light.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
 
 -import(escalus_ejabberd, [rpc/3]).
 -import(distributed_helper, [mim/0,
@@ -99,11 +100,21 @@ assert_archive_element({{affiliations, Affiliations}, Stanza}) ->
 assert_archive_element({{muc_message, Room, Sender, Body}, Stanza}) ->
     FromJid = escalus_utils:jid_to_lower(muc_light_room_jid(Room, Sender)),
     #forwarded_message{message_body = Body,
-                       delay_from = FromJid} = Stanza;
+                       delay_from = FromJid,
+                       message_xs = XS} = Stanza,
+    assert_valid_muc_roles_in_user_x(XS);
 assert_archive_element({{message, Sender, Body}, Stanza}) ->
     FromJid = escalus_utils:jid_to_lower(escalus_utils:get_jid(Sender)),
     #forwarded_message{message_body = Body, delay_from = FromJid} = Stanza.
 
+assert_valid_muc_roles_in_user_x([#xmlel{ attrs = [{<<"xmlns">>, ?NS_MUC_USER}] } = XUser | _]) ->
+    Item = exml_query:subelement(XUser, <<"item">>),
+    muc_helper:assert_valid_affiliation(exml_query:attr(Item, <<"affiliation">>)),
+    muc_helper:assert_valid_role(exml_query:attr(Item, <<"role">>));
+assert_valid_muc_roles_in_user_x([_ | RXs]) ->
+    assert_valid_muc_roles_in_user_x(RXs);
+assert_valid_muc_roles_in_user_x([]) ->
+    ok.
 
 muc_light_room_jid(Room, User) ->
     RoomJid = room_bin_jid(Room),

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -60,7 +60,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
                  {from_jid, Sender},
                  {room_jid, jid:make_noprep({RoomU, RoomS, <<>>})},
                  {affiliation, Aff},
-                 {role, Aff}
+                 {role, mod_muc_light_utils:light_aff_to_muc_role(Aff)}
     ],
     FilteredPacket = #xmlel{ children = Children }
         = ejabberd_hooks:run_fold(filter_room_packet, RoomS, MsgForArch, [EventData]),

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -50,7 +50,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
                  {from_jid, Sender},
                  {room_jid, jid:make_noprep({RoomU, RoomS, <<>>})},
                  {affiliation, Aff},
-                 {role, Aff}
+                 {role, mod_muc_light_utils:light_aff_to_muc_role(Aff)}
                 ],
     FilteredPacket = #xmlel{ children = Children }
                      = ejabberd_hooks:run_fold(filter_room_packet, RoomS, MsgForArch, [EventData]),

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -29,6 +29,7 @@
 -export([process_raw_config/3, config_to_raw/2]).
 -export([change_aff_users/2]).
 -export([b2aff/1, aff2b/1]).
+-export([light_aff_to_muc_role/1]).
 -export([room_limit_reached/2]).
 -export([filter_out_prevented/3]).
 
@@ -122,6 +123,11 @@ aff2b(none) -> <<"none">>.
 b2aff(<<"owner">>) -> owner;
 b2aff(<<"member">>) -> member;
 b2aff(<<"none">>) -> none.
+
+-spec light_aff_to_muc_role(aff()) -> mod_muc:role().
+light_aff_to_muc_role(owner) -> moderator;
+light_aff_to_muc_role(member) -> participant;
+light_aff_to_muc_role(none) -> none.
 
 -spec room_limit_reached(UserUS :: jid:simple_bare_jid(), RoomS :: jid:lserver()) ->
     boolean().


### PR DESCRIPTION
`x` element archived with MUC Light messages (to ensure compatibility with MAM spec) "spoofs" MUC role. However, this was set to the same value as affiliation, effectively breaking communication with Smack. With this PR, the role is spoofed correctly.

