### PR TITLE
Fix chat marker archiving in MUC

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1603,7 +1603,7 @@ muc_light_stored_in_pm_if_allowed_to(Config) ->
 
 muc_light_chat_markers_are_archived_if_enabled(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-            Room = <<"testroom">>,
+            Room = <<"testroom_markers">>,
             given_muc_light_room(Room, Alice, [{Bob, member}]),
 
             %% Alice sends 3 chat markers

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -99,6 +99,7 @@
          muc_light_simple/1,
          muc_light_shouldnt_modify_pm_archive/1,
          muc_light_stored_in_pm_if_allowed_to/1,
+         muc_light_chat_markers_are_archived_if_enabled/1,
          messages_filtered_when_prefs_default_policy_is_always/1,
          messages_filtered_when_prefs_default_policy_is_never/1,
          messages_filtered_when_prefs_default_policy_is_roster/1,
@@ -430,7 +431,8 @@ muc_light_cases() ->
     [
      muc_light_simple,
      muc_light_shouldnt_modify_pm_archive,
-     muc_light_stored_in_pm_if_allowed_to
+     muc_light_stored_in_pm_if_allowed_to,
+     muc_light_chat_markers_are_archived_if_enabled
     ].
 
 muc_rsm_cases() ->
@@ -594,9 +596,9 @@ init_per_group(muc06, Config) ->
     [{props, mam06_props()}, {with_rsm, true}|Config];
 
 init_per_group(muc_configurable_archiveid, Config) ->
-    Config ++ [{params_backup, rpc_apply(gen_mod, get_module_opts, [host(), mod_mam_muc])}];
+    [backup_module_opts(mod_mam_muc) | Config];
 init_per_group(configurable_archiveid, Config) ->
-    [{params_backup, rpc_apply(gen_mod, get_module_opts, [host(), mod_mam])} | Config];
+    [backup_module_opts(mod_mam) | Config];
 
 init_per_group(muc_rsm_all, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{N, 1} || N <- user_names()]),
@@ -621,6 +623,13 @@ init_per_group(Group, ConfigIn) ->
             [{basic_group, B}, {configuration, C} | init_state(C, B, Config1)]
     end.
 
+backup_module_opts(Module) ->
+    {{params_backup, Module}, rpc_apply(gen_mod, get_module_opts, [host(), mod_mam_muc])}.
+
+restore_module_opts(Module, Config) ->
+    ParamsB = proplists:get_value({params_backup, Module}, Config),
+    rpc_apply(gen_mod, set_module_opts, [host(), Module, ParamsB]).
+
 do_init_per_group(C, ConfigIn) ->
     Config0 = create_users(ConfigIn),
     case C of
@@ -642,15 +651,10 @@ end_per_group(G, Config) when G == rsm_all; G == nostore;
     G == archived; G == mam_metrics ->
       Config;
 end_per_group(muc_configurable_archiveid, Config) ->
-    ParamsB = proplists:get_value(params_backup, Config),
-    lists:foreach(fun({Key, Value}) ->
-                          rpc_apply(gen_mod, set_module_opt, [host(), mod_mam, Key, Value])
-                  end,
-                  ParamsB),
+    restore_module_opts(mod_mam_muc, Config),
     Config;
 end_per_group(configurable_archiveid, Config) ->
-    ParamsB = proplists:get_value(params_backup, Config),
-    rpc_apply(gen_mod, set_module_opts, [host(), mod_mam, ParamsB]),
+    restore_module_opts(mod_mam, Config),
     Config;
 end_per_group(muc_rsm_all, Config) ->
     destroy_room(Config);
@@ -984,6 +988,10 @@ init_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config) ->
     true = rpc(mim(), gen_mod, set_module_opt, [host(), mod_mam, archive_groupchats, true]),
     clean_archives(Config),
     escalus:init_per_testcase(C, [{archive_groupchats_backup, OrigVal} | Config]);
+init_per_testcase(C = muc_light_chat_markers_are_archived_if_enabled, ConfigIn) ->
+    Config1 = [backup_module_opts(mod_mam_muc) | ConfigIn],
+    rpc_apply(gen_mod, set_module_opt, [host(), mod_mam_muc, archive_chat_markers, true]),
+    escalus:init_per_testcase(C, Config1);
 init_per_testcase(C=archive_chat_markers, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, Config1);
@@ -1055,6 +1063,9 @@ end_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config0) ->
     {value, {_, OrigVal}, Config1} = lists:keytake(archive_groupchats_backup, 1, Config0),
     true = rpc(mim(), gen_mod, set_module_opt, [host(), mod_mam, archive_groupchats, OrigVal]),
     escalus:end_per_testcase(C, Config1);
+end_per_testcase(C = muc_light_chat_markers_are_archived_if_enabled, Config) ->
+    restore_module_opts(mod_mam_muc, Config),
+    escalus:end_per_testcase(C, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
@@ -1588,6 +1599,34 @@ muc_light_stored_in_pm_if_allowed_to(Config) ->
             then_archive_response_is(Alice, [AliceAffEvent, MessageEvent], Config),
             when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [BobAffEvent, MessageEvent], Config)
+        end).
+
+muc_light_chat_markers_are_archived_if_enabled(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+            Room = <<"testroom">>,
+            given_muc_light_room(Room, Alice, [{Bob, member}]),
+
+            %% Alice sends 3 chat markers
+            MessageID = <<"some-fake-id">>,
+            RoomJID = muc_light_helper:room_bin_jid(Room),
+            lists:foreach(
+              fun(Type) ->
+                      Marker1 = escalus_stanza:chat_marker(RoomJID, Type, MessageID),
+                      Marker2 = escalus_stanza:setattr(Marker1, <<"type">>, <<"groupchat">>),
+                      escalus:send(Alice, Marker2),
+                      escalus:wait_for_stanza(Alice),
+                      escalus:wait_for_stanza(Bob)
+              end, [<<"received">>, <<"displayed">>, <<"acknowledged">>]),
+
+            maybe_wait_for_archive(Config),
+            when_archive_query_is_sent(Bob, muc_light_helper:room_bin_jid(Room), Config),
+            ExpectedResponse = [
+                                {create, [{Alice, owner}, {Bob, member}]},
+                                {chat_marker, <<"received">>},
+                                {chat_marker, <<"displayed">>},
+                                {chat_marker, <<"acknowledged">>}
+                               ],
+            then_archive_response_is(Bob, ExpectedResponse, Config)
         end).
 
 retrieve_form_fields(ConfigIn) ->

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -511,9 +511,15 @@ parse_children_message_result_forwarded_message(#xmlel{name = <<"x">>,
     IsUser = lists:member({<<"xmlns">>, <<"http://jabber.org/protocol/muc#user">>}, Attrs),
     M#forwarded_message{has_x_user_element = IsUser,
                         message_xs = [XEl | M#forwarded_message.message_xs]};
-%% Parse `<archived />' here.
-parse_children_message_result_forwarded_message(_, M) ->
-    M.
+%% Parse `<archived />' or chat markers.
+parse_children_message_result_forwarded_message(MaybeChatMarker, M) ->
+    case exml_query:attr(MaybeChatMarker, <<"xmlns">>) of
+        ?NS_CHAT_MARKERS ->
+            M#forwarded_message{ chat_marker = MaybeChatMarker#xmlel.name };
+        _ ->
+            % Not relevant
+            M
+    end.
 
 %% Num is 1-based.
 message_id(Num, Config) ->

--- a/big_tests/tests/mam_helper.hrl
+++ b/big_tests/tests/mam_helper.hrl
@@ -62,7 +62,8 @@
     message_type   :: binary() | undefined,
     message_body   :: binary() | undefined,
     message_xs = [] :: [#xmlel{}],
-    has_x_user_element :: boolean()
+    has_x_user_element :: boolean(),
+    chat_marker    :: binary() | undefined
 }).
 
 -record(result_iq, {

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -110,7 +110,9 @@ assert_archive_element({{muc_message, Room, Sender, Body}, Stanza}) ->
     assert_valid_muc_roles_in_user_x(XS);
 assert_archive_element({{message, Sender, Body}, Stanza}) ->
     FromJid = escalus_utils:jid_to_lower(escalus_utils:get_jid(Sender)),
-    #forwarded_message{message_body = Body, delay_from = FromJid} = Stanza.
+    #forwarded_message{message_body = Body, delay_from = FromJid} = Stanza;
+assert_archive_element({{chat_marker, Type}, Stanza}) ->
+    #forwarded_message{chat_marker = Type} = Stanza.
 
 assert_valid_muc_roles_in_user_x([#xmlel{ attrs = [{<<"xmlns">>, ?NS_MUC_USER}] } = XUser | _]) ->
     Item = exml_query:subelement(XUser, <<"item">>),

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -135,6 +135,7 @@ valid_core_mod_opts(mod_mam) ->
 valid_core_mod_opts(mod_mam_muc) ->
     [
      is_archivable_message,
+     archive_chat_markers,
      host,
      extra_lookup_params,
      full_text_search,

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -634,9 +634,10 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver = LServer, luser = LUser}, 
     ?ERROR_MSG("issue=~p, server=~p, user=~p, reason=~p, iq=~p, stacktrace=~p",
                [Issue, LServer, LUser, Reason, IQ, Stacktrace]).
 
--spec is_archivable_message(Host :: ejabberd:lserver(), Dir :: incoming | outgoing,
+-spec is_archivable_message(MUCHost :: ejabberd:lserver(), Dir :: incoming | outgoing,
                             Packet :: exml:element()) -> boolean().
-is_archivable_message(Host, Dir, Packet) ->
+is_archivable_message(MUCHost, Dir, Packet) ->
+    {ok, Host} = mongoose_subhosts:get_host(MUCHost),
     {M, F} = mod_mam_params:is_archivable_message_fun(?MODULE, Host),
     ArchiveChatMarkers = mod_mam_params:archive_chat_markers(?MODULE, Host),
     erlang:apply(M, F, [?MODULE, Dir, Packet, ArchiveChatMarkers]).


### PR DESCRIPTION
This PR fixes chat marker archiving in `mod_mam_muc`

The causes of a problem were:
- `mod_mam_meta` didn't accept `archive_chat_markers` option for `mod_mam_muc`
- `mod_mam_muc` was retrieving aforementioned option improperly