### PR TITLE
Advertise MAM in disco#info

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -89,6 +89,7 @@
          parse_prefs_result_iq/1,
          mam_ns_binary/0,
          mam_ns_binary_v04/0,
+         mam_ns_binary_v06/0,
          make_alice_and_bob_friends/2,
          run_prefs_case/6,
          prefs_cases2/0,

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -619,7 +619,7 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #state{host = Host} = State) ->
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = [{<<"xmlns">>, XMLNS}],
-                                         children = iq_disco_info(Lang) ++ Info}]},
+                                         children = iq_disco_info(Lang, From, To) ++ Info}]},
             ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{type = get, xmlns = ?NS_DISCO_ITEMS} = IQ ->
             spawn(?MODULE, process_iq_disco_items, [Host, From, To, IQ]);
@@ -793,8 +793,9 @@ room_jid_to_pid(#jid{luser=RoomName, lserver=MucService}) ->
 -spec default_host() -> binary().
 default_host() -> <<"conference.@HOST@">>.
 
--spec iq_disco_info(ejabberd:lang()) -> [exml:element(), ...].
-iq_disco_info(Lang) ->
+-spec iq_disco_info(ejabberd:lang(), jid:jid(), jid:jid()) -> [exml:element(), ...].
+iq_disco_info(Lang, From, To) ->
+    {result, RegisteredFeatures} = mod_disco:get_local_features(empty, From, To, <<>>, <<>>),
     [#xmlel{name = <<"identity">>,
             attrs = [{<<"category">>, <<"conference">>},
                      {<<"type">>, <<"text">>},
@@ -805,7 +806,8 @@ iq_disco_info(Lang) ->
      #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_MUC_UNIQUE}]},
      #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_REGISTER}]},
      #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_RSM}]},
-     #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_VCARD}]}].
+     #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_VCARD}]}] ++
+    [#xmlel{name = <<"feature">>, attrs = [{<<"var">>, URN}]} || {{URN, _Host}} <- RegisteredFeatures].
 
 
 -spec iq_disco_items(jid:server(), jid:jid(), ejabberd:lang(),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3956,8 +3956,12 @@ config_opt_to_feature(Opt, Fiftrue, Fiffalse) ->
                                       | {'result', [exml:element(), ...], state()}.
 process_iq_disco_info(_From, set, _Lang, _StateData) ->
     {error, mongoose_xmpp_errors:not_allowed()};
-process_iq_disco_info(_From, get, Lang, StateData) ->
+process_iq_disco_info(From, get, Lang, StateData) ->
     Config = StateData#state.config,
+    RoomJID = StateData#state.jid,
+    {result, RegisteredFeatures} = mod_disco:get_local_features(empty, From, RoomJID, <<>>, <<>>),
+    RegisteredFeaturesXML = [#xmlel{name = <<"feature">>, attrs = [{<<"var">>, URN}]} ||
+                             {{URN, _Host}} <- RegisteredFeatures],
     {result, [#xmlel{name = <<"identity">>,
                      attrs = [{<<"category">>, <<"conference">>},
                           {<<"type">>, <<"text">>},
@@ -3975,7 +3979,7 @@ process_iq_disco_info(_From, get, Lang, StateData) ->
                          <<"muc_moderated">>, <<"muc_unmoderated">>),
               config_opt_to_feature((Config#config.password_protected),
                          <<"muc_passwordprotected">>, <<"muc_unsecured">>)
-             ] ++ iq_disco_info_extras(Lang, StateData), StateData}.
+             ] ++ iq_disco_info_extras(Lang, StateData) ++ RegisteredFeaturesXML, StateData}.
 
 
 -spec rfieldt(binary(), binary(), binary()) -> exml:element().

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -240,12 +240,14 @@ parse_blocking_list([Item | RItemsEls], ItemsAcc) ->
     {iq_reply, ID :: binary()} |
     {iq_reply, XMLNS :: binary(), Els :: [jlib:xmlch()], ID :: binary()} |
     noreply.
-encode_meta({get, #disco_info{ id = ID }}, _RoomJID, _SenderJID, _HandleFun) ->
+encode_meta({get, #disco_info{ id = ID }}, RoomJID, SenderJID, _HandleFun) ->
+    {result, RegisteredFeatures} = mod_disco:get_local_features(empty, SenderJID, RoomJID, <<>>, <<>>),
     DiscoEls = [#xmlel{name = <<"identity">>,
                        attrs = [{<<"category">>, <<"conference">>},
                                 {<<"type">>, <<"text">>},
                                 {<<"name">>, <<"MUC Light">>}]},
-                #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_MUC}]}],
+                #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_MUC}]}] ++
+               [#xmlel{name = <<"feature">>, attrs = [{<<"var">>, URN}]} || {{URN, _Host}} <- RegisteredFeatures],
     {iq_reply, ?NS_DISCO_INFO, DiscoEls, ID};
 encode_meta({get, #disco_items{ rooms = Rooms, id = ID, rsm = RSMOut }},
           _RoomJID, _SenderJID, _HandleFun) ->


### PR DESCRIPTION
This PR addresses #2269.

Proposed changes include:
 * Advertise MAM for user JIDs.
 * Advertise MAM for MUC Light rooms.

As currently written, this unconditionally advertises MAM for MUC Light rooms, since MAM is a requirement for MUC Light.