### PR TITLE
Add chat markers support to room REST API

### DIFF
--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -260,12 +260,15 @@ is_roles_config({_PortIpNet, ejabberd_cowboy, Opts}, client) ->
 is_roles_config(_, _) -> false.
 
 mapfromlist(L) ->
-    Nl = lists:keymap(fun(B) -> binary_to_existing_atom(B, utf8) end, 1, L),
+    Nl = lists:map(fun({K, {V}}) when is_list(V) ->
+                           {binary_to_existing_atom(K, utf8), mapfromlist(V)};
+                      ({K, V}) ->
+                           {binary_to_existing_atom(K, utf8), V}
+                   end, L),
     maps:from_list(Nl).
 
 decode_maplist(Ml) ->
-    Pl = [C || {C} <- Ml],
-    [mapfromlist(L) || L <- Pl].
+    [mapfromlist(L) || {L} <- Ml].
 
 
 to_list(V) when is_binary(V) ->
@@ -278,14 +281,14 @@ maybe_enable_mam(rdbms, Host, Config) ->
     init_module(Host, mod_mam_muc_rdbms_arch, []),
     init_module(Host, mod_mam_rdbms_prefs, [muc, pm]),
     init_module(Host, mod_mam_rdbms_user, [muc, pm]),
-    init_module(Host, mod_mam, []),
-    init_module(Host, mod_mam_muc, [{host, "muclight.@HOST@"}]),
+    init_module(Host, mod_mam, [{archive_chat_markers, true}]),
+    init_module(Host, mod_mam_muc, [{host, "muclight.@HOST@"}, {archive_chat_markers, true}]),
     [{mam_backend, rdbms} | Config];
 maybe_enable_mam(riak, Host,  Config) ->
     init_module(Host, mod_mam_riak_timed_arch_yz, [pm, muc]),
     init_module(Host, mod_mam_mnesia_prefs, [pm, muc]),
-    init_module(Host, mod_mam, []),
-    init_module(Host, mod_mam_muc, [{host, "muclight.@HOST@"}]),
+    init_module(Host, mod_mam, [{archive_chat_markers, true}]),
+    init_module(Host, mod_mam_muc, [{host, "muclight.@HOST@"}, {archive_chat_markers, true}]),
     [{mam_backend, riak}, {archive_wait, 2500} | Config];
 maybe_enable_mam(_, _, C) ->
     [{mam_backend, disabled} | C].

--- a/doc/rest-api/Client-frontend_swagger.yml
+++ b/doc/rest-api/Client-frontend_swagger.yml
@@ -496,6 +496,19 @@ definitions:
     properties:
       body:
         type: string
+        description: Required if chat marker property is not set.
+      markable:
+        type: boolean
+        description: May only be used when body is present as well.
+      chat_marker:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: [received, displayed, acknowledged]
+          id:
+            type: string
+        description: May be used independently of body and markable properties.
   RecvRoomMessage:
     properties:
       type:
@@ -532,6 +545,16 @@ definitions:
         description: |
           The new affiliation of a user in the room.
           Present only if the type is "affiliation".
+      markable:
+        type: boolean
+      chat_marker:
+        type: object
+        properties:
+          type:
+            type: string
+            enum: [received, displayed, acknowledged]
+          id:
+            type: string
   JID:
     type: string
     example: "alice@wonderland.lit"


### PR DESCRIPTION
This PR adds support for chat markers in rooms' messages endpoint in client API. Similar support for 1-1 messages is out of scope for now.

This is based on #2271, which should be merged first.