### PR TITLE
Gdpr retrieve personal data from mod_private

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -75,7 +75,8 @@ groups() ->
                                                       retrieve_vcard,
                                                       retrieve_logs,
                                                       retrieve_roster,
-                                                      retrieve_all_pubsub_data
+                                                      retrieve_all_pubsub_data,
+                                                      retrieve_multiple_private_xmls
                                                      ]},
      {retrieve_personal_data_private_xml, [], [
                                                retrieve_private_xml,
@@ -432,6 +433,7 @@ retrieve_multiple_private_xmls(Config) ->
                                   {contains, binary_to_list(Content)}]}
                 end, lists:zip(NSs, Contents)),
 
+            maybe_stop_and_unload_module(mod_private, mod_private_backend, Config),
             retrieve_and_validate_personal_data(
               Alice, Config, "private", ExpectedHeader, ExpectedItems)
         end).

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -128,6 +128,10 @@ init_per_testcase(retrieve_mam = CN, Config) ->
             dynamic_modules:ensure_modules(domain(), mam_required_modules(Backend)),
             escalus:init_per_testcase(CN, Config)
     end;
+init_per_testcase(retrieve_private_xml = CN, Config) ->
+    escalus:init_per_testcase(CN, Config);
+init_per_testcase(retrieve_multiple_private_xmls = CN, Config) ->
+    escalus:init_per_testcase(CN, Config);
 init_per_testcase(CN, Config) ->
     escalus:init_per_testcase(CN, Config).
 
@@ -400,7 +404,7 @@ retrieve_multiple_private_xmls(Config) ->
             Contents =
                 [<<"You do not talk about FIGHT CLUB.">>,
                  <<"You do not talk about FIGHT CLUB.">>,
-                 <<"If someone says \"stop\" or goes limp, taps out the fight is over.">>,
+                 <<"If someone says stop or goes limp, taps out the fight is over.">>,
                  <<"Only two guys to a fight.">>,
                  <<"One fight at a time.">>],
             lists:map(

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -22,7 +22,7 @@
          dont_retrieve_other_user_pubsub_payload/1,
          retrieve_pubsub_subscriptions/1,
          retrieve_private_xml/1,
-         dont_retrieve_orher_user_private_xml/1,
+         dont_retrieve_other_user_private_xml/1,
          retrieve_multiple_private_xmls/1,
          retrieve_inbox/1,
          retrieve_logs/1
@@ -79,7 +79,7 @@ groups() ->
                                                      ]},
      {retrieve_personal_data_private_xml, [], [
                                                retrieve_private_xml,
-                                               dont_retrieve_orher_user_private_xml,
+                                               dont_retrieve_other_user_private_xml,
                                                retrieve_multiple_private_xmls
                                               ]},
      {retrieve_negative, [], [
@@ -133,12 +133,6 @@ init_per_testcase(retrieve_mam = CN, Config) ->
             dynamic_modules:ensure_modules(domain(), mam_required_modules(Backend)),
             escalus:init_per_testcase(CN, Config)
     end;
-init_per_testcase(retrieve_private_xml = CN, Config) ->
-    escalus:init_per_testcase(CN, Config);
-init_per_testcase(retrieve_multiple_private_xmls = CN, Config) ->
-    escalus:init_per_testcase(CN, Config);
-init_per_testcase(dont_retrieve_orher_user_private_xml = CN, Config) ->
-    escalus:init_per_testcase(CN, Config);
 init_per_testcase(CN, Config) ->
     escalus:init_per_testcase(CN, Config).
 
@@ -394,7 +388,7 @@ retrieve_private_xml(Config) ->
               Alice, Config, "private", ExpectedHeader, ExpectedItems)
         end).
 
-dont_retrieve_orher_user_private_xml(Config) ->
+dont_retrieve_other_user_private_xml(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
             AliceNS = <<"alice:gdpr:ns">>,
             AliceContent = <<"To be or not to be">>,

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -57,7 +57,7 @@ groups() ->
                                            retrieve_roster,
                                            %retrieve_mam,
                                            %retrieve_offline,
-                                           %retrieve_private_xml,
+                                           retrieve_private_xml,
                                            %retrieve_inbox,
                                            retrieve_logs,
                                            {group, retrieve_personal_data_pubsub}

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -89,7 +89,7 @@ get_personal_data(Username, Server) ->
     lists:flatmap(fun(B) ->
                           get_personal_data_from_backend(B, LUser, LServer)
                   end, mongoose_lib:find_behaviour_implementations(mod_private)),
-    [{private, Schema, Entries}].
+    [{private, Schema, lists:usort(Entries)}].
 
 get_personal_data_from_backend(Backend, LUser, LServer) ->
     try

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -73,7 +73,7 @@
 -callback get_all_nss(LUser, LServer) -> NSs when
     LUser   :: binary(),
     LServer :: binary(),
-    NSs      :: [binary()].
+    NSs     :: [binary()].
 
 %%--------------------------------------------------------------------
 %% gdpr callback

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -74,10 +74,10 @@
 %% gdpr callback
 %%--------------------------------------------------------------------
 
--callback get_all_nss(LUser, LServer) -> NS when
+-callback get_all_nss(LUser, LServer) -> NSs when
     LUser   :: binary(),
     LServer :: binary(),
-    NS      :: binary().
+    NSs      :: [binary()].
 
 -spec get_personal_data(jid:user(), jid:server()) ->
     [{gdpr:data_group(), gdpr:schema(), gdpr:entries()}].

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -70,14 +70,14 @@
     LUser   :: binary(),
     LServer :: binary().
 
-%%--------------------------------------------------------------------
-%% gdpr callback
-%%--------------------------------------------------------------------
-
 -callback get_all_nss(LUser, LServer) -> NSs when
     LUser   :: binary(),
     LServer :: binary(),
     NSs      :: [binary()].
+
+%%--------------------------------------------------------------------
+%% gdpr callback
+%%--------------------------------------------------------------------
 
 -spec get_personal_data(jid:user(), jid:server()) ->
     [{gdpr:data_group(), gdpr:schema(), gdpr:entries()}].

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -85,12 +85,12 @@ get_personal_data(Username, Server) ->
     LUser = jid:nodeprep(Username),
     LServer = jid:nameprep(Server),
     Schema = ["ns", "xml"],
-    %% TODO: Replace separate `mysql` backend with a switch for `rdbms` one
+    %% TODO: Replace separate `mod_private_mysql` backend with a switch for `rdbms` one
     %% or simply always use dedicated queries when the RDBMS backend type is `mysql`
     %%
-    %% We remove `mysql` from the list because calling all possible backends resulted
+    %% We remove `mod_private_mysql` from the list because calling all possible backends resulted
     %% in duplicate entries with RDBMS.
-    Backends = mongoose_lib:find_behaviour_implementations(mod_private) -- [mysql],
+    Backends = mongoose_lib:find_behaviour_implementations(mod_private) -- [mod_private_mysql],
     Entries =
     lists:flatmap(fun(B) ->
                           get_personal_data_from_backend(B, LUser, LServer)

--- a/src/mod_private_mnesia.erl
+++ b/src/mod_private_mnesia.erl
@@ -36,6 +36,8 @@
          multi_get_data/3,
          remove_user/2]).
 
+-export([get_all_nss/2]).
+
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
@@ -65,6 +67,13 @@ set_data_t(LUser, LServer, NS, XML) ->
 
 multi_get_data(LUser, LServer, NS2Def) ->
     [get_data(LUser, LServer, NS, Default) || {NS, Default} <- NS2Def].
+
+get_all_nss(LUser, LServer) ->
+    F = fun() ->
+        select_namespaces_t(LUser, LServer)
+    end,
+    {atomic, NSs} = mnesia:transaction(F),
+    NSs.
 
 %% @doc Return stored value or default.
 get_data(LUser, LServer, NS, Default) ->

--- a/src/mod_private_mysql.erl
+++ b/src/mod_private_mysql.erl
@@ -57,6 +57,6 @@ remove_user(LUser, LServer) ->
 
 get_all_nss(LUser, LServer) ->
     EscLUser = mongoose_rdbms:escape_string(LUser),
-    {selected, Res} = rdbms_queries:get_all_roster_namespaces(LServer, EscLUser),
-    Keys = lists:map(fun({R}) -> R end, Res),
-    Keys.
+    {selected, Res} = rdbms_queries:get_all_private_namespaces(LServer, EscLUser),
+    lists:map(fun({R}) -> R end, Res).
+

--- a/src/mod_private_mysql.erl
+++ b/src/mod_private_mysql.erl
@@ -9,6 +9,8 @@
          multi_get_data/3,
          remove_user/2]).
 
+-export([get_all_nss/2]).
+
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
@@ -52,3 +54,9 @@ select_value({NS, Def}, RowsDict) ->
 remove_user(LUser, LServer) ->
     SLUser = mongoose_rdbms:escape_string(LUser),
     rdbms_queries:del_user_private_storage(LServer, SLUser).
+
+get_all_nss(LUser, LServer) ->
+    EscLUser = mongoose_rdbms:escape_string(LUser),
+    {selected, Res} = rdbms_queries:get_all_roster_namespaces(LServer, EscLUser),
+    Keys = lists:map(fun({R}) -> R end, Res),
+    Keys.

--- a/src/mod_private_rdbms.erl
+++ b/src/mod_private_rdbms.erl
@@ -78,14 +78,9 @@ get_data(LUser, LServer, NS, Default) ->
     end.
 
 get_all_nss(LUser, LServer) ->
-    SLUser = mongoose_rdbms:escape_string(LUser),
-    lager:error("LUser = ~p\n", [LUser]),
-    lager:error("LServer = ~p\n", [LServer]),
-    {selected, Res} = mongoose_rdbms:sql_query(
-      LServer,
-      [<<"select namespace from private_storage where username=">>, mongoose_rdbms:use_escaped_string(SLUser)]),
+    EscLUser = mongoose_rdbms:escape_string(LUser),
+    {selected, Res} = rdbms_queries:get_all_roster_namespaces(LServer, EscLUser),
     Keys = lists:map(fun({R}) -> R end, Res),
-    lager:error("Keys = ~p\n", [Keys]),
     Keys.
 
 remove_user(LUser, LServer) ->

--- a/src/mod_private_rdbms.erl
+++ b/src/mod_private_rdbms.erl
@@ -79,9 +79,8 @@ get_data(LUser, LServer, NS, Default) ->
 
 get_all_nss(LUser, LServer) ->
     EscLUser = mongoose_rdbms:escape_string(LUser),
-    {selected, Res} = rdbms_queries:get_all_roster_namespaces(LServer, EscLUser),
-    Keys = lists:map(fun({R}) -> R end, Res),
-    Keys.
+    {selected, Res} = rdbms_queries:get_all_private_namespaces(LServer, EscLUser),
+    lists:map(fun({R}) -> R end, Res).
 
 remove_user(LUser, LServer) ->
     SLUser = mongoose_rdbms:escape_string(LUser),

--- a/src/mod_private_rdbms.erl
+++ b/src/mod_private_rdbms.erl
@@ -36,6 +36,8 @@
          multi_get_data/3,
          remove_user/2]).
 
+-export([get_all_nss/2]).
+
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
@@ -74,6 +76,17 @@ get_data(LUser, LServer, NS, Default) ->
         _ ->
             Default
     end.
+
+get_all_nss(LUser, LServer) ->
+    SLUser = mongoose_rdbms:escape_string(LUser),
+    lager:error("LUser = ~p\n", [LUser]),
+    lager:error("LServer = ~p\n", [LServer]),
+    {selected, Res} = mongoose_rdbms:sql_query(
+      LServer,
+      [<<"select namespace from private_storage where username=">>, mongoose_rdbms:use_escaped_string(SLUser)]),
+    Keys = lists:map(fun({R}) -> R end, Res),
+    lager:error("Keys = ~p\n", [Keys]),
+    Keys.
 
 remove_user(LUser, LServer) ->
     SLUser = mongoose_rdbms:escape_string(LUser),

--- a/src/mod_private_riak.erl
+++ b/src/mod_private_riak.erl
@@ -23,6 +23,8 @@
          multi_get_data/3,
          remove_user/2]).
 
+-export([get_all_nss/2]).
+
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
@@ -61,6 +63,16 @@ remove_user(LUser, LServer) ->
 set_private_data(LUser, LServer, NS, XML) ->
     Obj = riakc_obj:new(bucket_type(LServer), key(LUser, NS), exml:to_binary(XML)),
     mongoose_riak:put(Obj).
+
+get_all_nss(LUser, LServer) ->
+    {ok, KeysWithUsername} = mongoose_riak:list_keys(bucket_type(LServer)),
+    lists:map(
+        fun(Key) ->
+            [LUser, ResultKey] = binary:split(Key, <<"/">>),
+            ResultKey
+        end,
+        KeysWithUsername
+    ).
 
 get_private_data(LUser, LServer, NS, Default) ->
     case mongoose_riak:get(bucket_type(LServer), key(LUser, NS)) of

--- a/src/mod_private_riak.erl
+++ b/src/mod_private_riak.erl
@@ -66,12 +66,14 @@ set_private_data(LUser, LServer, NS, XML) ->
 
 get_all_nss(LUser, LServer) ->
     {ok, KeysWithUsername} = mongoose_riak:list_keys(bucket_type(LServer)),
-    lists:map(
-        fun(Key) ->
-            [LUser, ResultKey] = binary:split(Key, <<"/">>),
-            ResultKey
+    lists:foldl(
+        fun(Key, Acc) ->
+            case binary:split(Key, <<"/">>) of
+                [LUser, ResultKey] -> [ResultKey | Acc];
+                _ -> Acc
+            end
         end,
-        KeysWithUsername
+        [], KeysWithUsername
     ).
 
 get_private_data(LUser, LServer, NS, Default) ->

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -67,6 +67,7 @@
          get_subscription_t/3,
          set_private_data/4,
          set_private_data_sql/3,
+         get_all_roster_namespaces/2,
          get_private_data/3,
          multi_get_private_data/3,
          multi_set_private_data/3,
@@ -640,6 +641,12 @@ set_private_data_sql(Username, LXMLNS, SData) ->
         "values (">>, mongoose_rdbms:use_escaped_string(Username), ", ",
                       mongoose_rdbms:use_escaped_string(LXMLNS), ", ",
                       mongoose_rdbms:use_escaped_string(SData), ");"]].
+
+get_all_roster_namespaces(LServer, Username) ->
+    mongoose_rdbms:sql_query(
+      LServer,
+      [<<"select namespace from private_storage where username=">>,
+       mongoose_rdbms:use_escaped_string(Username), " ;"]).
 
 get_private_data(LServer, Username, LXMLNS) ->
     mongoose_rdbms:sql_query(

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -67,7 +67,7 @@
          get_subscription_t/3,
          set_private_data/4,
          set_private_data_sql/3,
-         get_all_roster_namespaces/2,
+         get_all_private_namespaces/2,
          get_private_data/3,
          multi_get_private_data/3,
          multi_set_private_data/3,
@@ -642,7 +642,7 @@ set_private_data_sql(Username, LXMLNS, SData) ->
                       mongoose_rdbms:use_escaped_string(LXMLNS), ", ",
                       mongoose_rdbms:use_escaped_string(SData), ");"]].
 
-get_all_roster_namespaces(LServer, Username) ->
+get_all_private_namespaces(LServer, Username) ->
     mongoose_rdbms:sql_query(
       LServer,
       [<<"select namespace from private_storage where username=">>,


### PR DESCRIPTION
This PR retrieves personal data from mod_private
- [x] rebase after https://github.com/esl/MongooseIM/pull/2293 is merged
- [x] add test for retrieving more than one private xml

implement `get_all_nss/2` callback for:
- [x] mnesia
- [x] riak
- [x] rdbms
- [x] mysql ??