### PR TITLE
Dynamic lookup of GDPR-related modules for retrieval

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -431,6 +431,7 @@ maybe_stop_and_unload_module(Module, BackendProxy, Config) ->
     case proplists:get_value(disable_module, Config) of
         true ->
             dynamic_modules:stop(domain(), Module),
+            mongoose_helper:successful_rpc(code, purge, [BackendProxy]),
             true = mongoose_helper:successful_rpc(code, delete, [BackendProxy]);
         _ ->
             ok

--- a/src/admin_extra/service_admin_extra_gdpr.erl
+++ b/src/admin_extra/service_admin_extra_gdpr.erl
@@ -56,10 +56,7 @@ retrieve_all(Username, Domain, ResultFilePath) ->
 
 -spec modules_with_personal_data() -> [module()].
 modules_with_personal_data() ->
-    [
-     mod_vcard,
-     mod_pubsub
-    ].
+    mongoose_lib:find_behaviour_implementations(gdpr).
 
 -spec get_data_from_modules(jid:user(), jid:server()) ->
     [{gdpr:data_group(), gdpr:schema(), gdpr:entries()}].

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -134,12 +134,17 @@ get_personal_data(Username, Server) ->
     LServer = jid:nameprep(Server),
     Jid = jid:to_binary({LUser, LServer}),
     Schema = ["jid", "vcard"],
-    Entries = case mod_vcard_backend:get_vcard(LUser, LServer) of
-        {ok, Record} ->
-            SerializedRecords = exml:to_binary(Record),
-            [{Jid, SerializedRecords}];
-         _ -> []
-        end,
+    Entries = lists:flatmap(fun(B) ->
+                                    try B:get_vcard(LUser, LServer) of
+                                        {ok, Record} ->
+                                            SerializedRecords = exml:to_binary(Record),
+                                            [{Jid, SerializedRecords}];
+                                        _ -> []
+                                    catch
+                                        _:_ ->
+                                            []
+                                    end
+                            end, mongoose_lib:find_behaviour_implementations(mod_vcard)),
     [{vcard, Schema, Entries}].
 
 -spec default_search_fields() -> list().

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -18,11 +18,12 @@
 -spec find_behaviour_implementations(Behaviour :: module()) -> [module()].
 find_behaviour_implementations(Behaviour) ->
     {ok, EbinFiles} = file:list_dir(code:lib_dir(mongooseim, ebin)),
-    Mods = [ list_to_existing_atom(filename:rootname(File))
+    Mods = [ list_to_atom(filename:rootname(File))
              || File <- EbinFiles, filename:extension(File) == ".beam" ],
     lists:filter(fun(M) ->
                          try lists:keyfind([Behaviour], 2, M:module_info(attributes)) of
-                             {Key, _} when Key == behaviour; Key == behavior -> true;
+                             {behavior, _} -> true;
+                             {behaviour, _} -> true;
                              _ -> false
                          catch
                              _:_ -> false

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -1,6 +1,7 @@
 -module(mongoose_lib).
--export([bin_to_int/1, log_if_backend_error/4]).
 
+-export([find_behaviour_implementations/1]).
+-export([log_if_backend_error/4]).
 %% Maps
 -export([maps_append/3]).
 -export([maps_foreach/2]).
@@ -9,15 +10,28 @@
 
 -include("mongoose.hrl").
 
-%% @doc string:to_integer/1 for binaries
-bin_to_int(Bin) ->
-    bin_to_int(Bin, 0).
+%% ------------------------------------------------------------------
+%% Behaviour util
+%% ------------------------------------------------------------------
 
-bin_to_int(<<H, T/binary>>, X) when $0 =< H, H =< $9 ->
-    bin_to_int(T, (X*10)+(H-$0));
-bin_to_int(Bin, X) ->
-    {X, Bin}.
+%% WARNING! For simplicity, this function searches only MongooseIM code dir
+-spec find_behaviour_implementations(Behaviour :: module()) -> [module()].
+find_behaviour_implementations(Behaviour) ->
+    {ok, EbinFiles} = file:list_dir(code:lib_dir(mongooseim, ebin)),
+    Mods = [ list_to_existing_atom(filename:rootname(File))
+             || File <- EbinFiles, filename:extension(File) == ".beam" ],
+    lists:filter(fun(M) ->
+                         try lists:keyfind([Behaviour], 2, M:module_info(attributes)) of
+                             {Key, _} when Key == behaviour; Key == behavior -> true;
+                             _ -> false
+                         catch
+                             _:_ -> false
+                         end
+                 end, Mods).
 
+%% ------------------------------------------------------------------
+%% Logging
+%% ------------------------------------------------------------------
 
 %% @doc Database backends for various modules return ok, {atomic, ok}
 %% or {atomic, []} on success, and usually {error, ...} on failure.


### PR DESCRIPTION
This PR replaces hardcoded GDPR modules list with a dynamic lookup. It also changes the retrieval implementations to query all module backends.

- [x] Implementation
- [x] Tests?