### PR TITLE
GDPR retrieve inbox (clean)

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
                                          ]},
      {retrieve_personal_data_with_mods_disabled, [], [
                                                       retrieve_vcard,
+                                                      retrieve_inbox,
                                                       retrieve_logs,
                                                       retrieve_roster,
                                                       retrieve_all_pubsub_data,

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -25,6 +25,7 @@
          dont_retrieve_other_user_private_xml/1,
          retrieve_multiple_private_xmls/1,
          retrieve_inbox/1,
+         retrieve_inbox_for_multiple_messages/1,
          retrieve_logs/1
         ]).
 -export([
@@ -59,7 +60,8 @@ groups() ->
                                            retrieve_roster,
                                            %retrieve_mam,
                                            %retrieve_offline,
-                                           %retrieve_inbox,
+                                           retrieve_inbox,
+                                           retrieve_inbox_for_multiple_messages,
                                            retrieve_logs,
                                            {group, retrieve_personal_data_pubsub},
                                            {group, retrieve_personal_data_private_xml}
@@ -111,14 +113,9 @@ end_per_group(_GN, Config) ->
     Config.
 
 init_per_testcase(retrieve_inbox = CN, Config) ->
-    case (not ct_helper:is_ct_running())
-         orelse mongoose_helper:is_rdbms_enabled(domain()) of
-        true ->
-            dynamic_modules:ensure_modules(domain(), inbox_required_modules()),
-            escalus:init_per_testcase(CN, Config);
-        false ->
-            {skip, require_rdbms}
-    end;
+    init_inbox(CN, Config);
+init_per_testcase(retrieve_inbox_for_multiple_messages = CN, Config) ->
+    init_inbox(CN, Config);
 init_per_testcase(retrieve_vcard = CN, Config) ->
     case vcard_update:is_vcard_ldap() of
         true ->
@@ -140,8 +137,25 @@ init_per_testcase(CN, Config) ->
 end_per_testcase(CN, Config) ->
     escalus:end_per_testcase(CN, Config).
 
+init_inbox(CN, Config) ->
+    case (not ct_helper:is_ct_running())
+         orelse mongoose_helper:is_rdbms_enabled(domain()) of
+        true ->
+            dynamic_modules:ensure_modules(domain(), inbox_required_modules()),
+            escalus:init_per_testcase(CN, Config);
+        false ->
+            {skip, require_rdbms}
+    end.
 inbox_required_modules() ->
-    [{mod_inbox, []}].
+    [
+     {mod_inbox, inbox_opts()}
+    ].
+
+inbox_opts() ->
+    [{aff_changes, true},
+     {remove_on_kicked, true},
+     {groupchat, [muclight]},
+     {markers, [displayed]}].
 
 pick_backend_for_mam() ->
     BackendsList = [
@@ -435,18 +449,50 @@ retrieve_multiple_private_xmls(Config) ->
 
 retrieve_inbox(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+            BobU = escalus_utils:jid_to_lower(escalus_client:username(Bob)),
+            BobS = escalus_utils:jid_to_lower(escalus_client:server(Bob)),
+            AliceU = escalus_utils:jid_to_lower(escalus_client:username(Alice)),
+            AliceS = escalus_utils:jid_to_lower(escalus_client:server(Alice)),
             Body = <<"With spam?">>,
-            escalus:send(Bob, escalus_stanza:chat_to(Alice, Body)),
-            Msg = escalus:wait_for_stanza(Alice),
-            escalus:assert(is_chat_message, [Body], Msg),
-
-            BobJid = escalus_client:short_jid(Bob),
-            ExpectedHeader = ["jid", "content", "unread_count", "msg_id", "timestamp"],
-            ExpectedItems = [
-                             #{ "content" => Body, "jid" => BobJid }
+            send_and_assert_is_chat_message(Bob, Alice, Body),
+            ExpectedHeader = ["jid", "content", "unread_count", "timestamp"],
+            ExpectedAliceItems = [
+                             #{ "content" => [{contains, Body}],
+                                "jid" => [{contains, BobS},
+                                          {contains, BobU}],
+                                "unread_count" => "1" }
+                            ],
+            ExpectedBobItems = [
+                             #{ "content" => [{contains, Body}],
+                                "jid" => [{contains, AliceS},
+                                          {contains, AliceU}],
+                                "unread_count" => "0" }
                             ],
             retrieve_and_validate_personal_data(
-              Alice, Config, "inbox", ExpectedHeader, ExpectedItems)
+              Alice, Config, "inbox", ExpectedHeader, ExpectedAliceItems),
+            retrieve_and_validate_personal_data(
+              Bob, Config, "inbox", ExpectedHeader, ExpectedBobItems)
+        end).
+
+retrieve_inbox_for_multiple_messages(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+            Bodies = [ <<"Nobody exists on purpose.">>,
+                       <<"Nobody belongs anywhere.">>,
+                       <<"We're all going to die.">>,
+                       <<"Come watch TV.">>],
+            lists:foreach(fun(Body) -> send_and_assert_is_chat_message(Bob, Alice, Body) end, Bodies),
+            BobU = escalus_utils:jid_to_lower(escalus_client:username(Bob)),
+            BobS = escalus_utils:jid_to_lower(escalus_client:server(Bob)),
+
+            ExpectedHeader = ["jid", "content", "unread_count", "timestamp"],
+            ExpectedAliceItems = [
+                             #{ "content" => [{contains, lists:last(Bodies)}],
+                                "jid" => [{contains, BobS},
+                                          {contains, BobU}],
+                                "unread_count" => integer_to_list(length(Bodies)) }
+                            ],
+            retrieve_and_validate_personal_data(
+              Alice, Config, "inbox", ExpectedHeader, ExpectedAliceItems)
         end).
 
 retrieve_logs(Config) ->
@@ -609,4 +655,9 @@ send_and_assert_private_stanza(User, NS, Content) ->
     PrivateStanza = escalus_stanza:private_set(XML),
     escalus_client:send(User, PrivateStanza),
     escalus:assert(is_iq_result, [PrivateStanza], escalus_client:wait_for_stanza(User)).
+
+send_and_assert_is_chat_message(UserFrom, UserTo, Body) ->
+    escalus:send(UserFrom, escalus_stanza:chat_to(UserTo, Body)),
+    Msg = escalus:wait_for_stanza(UserTo),
+    escalus:assert(is_chat_message, [Body], Msg).
 

--- a/include/mod_inbox.hrl
+++ b/include/mod_inbox.hrl
@@ -18,7 +18,7 @@
 
 -type get_inbox_res() :: list(inbox_res()).
 
--type inbox_res() :: {RemoteUser :: username(),
+-type inbox_res() :: {RemoteBinJID :: binary(),
                       MsgContent :: content(),
                       UnreadCount :: count_bin(),
                       Timestamp :: erlang:timestamp()}.

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -12,6 +12,8 @@
 -include("mongoose.hrl").
 -include("mod_inbox.hrl").
 
+-behaviour(mod_inbox).
+
 %% API
 -export([get_inbox/3,
          init/2,


### PR DESCRIPTION
This PR supersedes #2282

It adds personal data retrieval from inbox.

