### PR TITLE
Gdpr retrieve pubsub - fix

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -247,7 +247,7 @@ retrieve_pubsub_payloads(Config) ->
                          pubsub_payloads_row_map(NodeName1, "Item3", StringItem3),
                          pubsub_payloads_row_map(NodeName2, "OtherItem", StringOther)],
 
-        maybe_stop_and_unload_module(mod_vcard, mod_vcard_backend, Config),
+        maybe_stop_and_unload_module(mod_pubsub, mod_pubsub_db_backend, Config),
         retrieve_and_validate_personal_data(
             Alice, Config, "pubsub_payloads", ["node_name", "item_id", "payload"], ExpectedItems)
                                               end).


### PR DESCRIPTION
In one of pubsub retrieval test, vcard was being disabled instead of pubsub