### PR TITLE
Hide service name option

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -655,7 +655,7 @@ close_connection_if_service_type_is_hidden(_Config) ->
                             end,
     Connection = escalus_tcp:connect(#{ on_reply => FailIfAnyDataReturned }),
     Ref = monitor(process, Connection),
-    escalus_tcp:send(Connection, "malformed"),
+    escalus_tcp:send(Connection, <<"malformed">>),
     receive
         {'DOWN', Ref, _, _, _} -> ok
     after

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -42,6 +42,8 @@
 all() ->
     [
      {group, session_replacement},
+     {group, security},
+     %% these groups must be last, as they really... complicate configuration
      {group, fast_tls},
      {group, just_tls}
     ].
@@ -75,7 +77,11 @@ groups() ->
                                      same_resource_replaces_session,
                                      clean_close_of_replaced_session,
                                      replaced_session_cannot_terminate
-                                    ]}
+                                    ]},
+          {security, [], [
+                          return_proper_stream_error_if_service_is_not_hidden,
+                          close_connection_if_service_type_is_hidden
+                         ]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -169,6 +175,10 @@ end_per_group(session_replacement, Config) ->
 end_per_group(_, Config) ->
     Config.
 
+init_per_testcase(close_connection_if_service_type_is_hidden = CN, Config) ->
+    OptName = {hide_service_name, <<"localhost">>},
+    mongoose_helper:successful_rpc(ejabberd_config, add_local_option, [OptName, true]),
+    escalus:init_per_testcase(CN, Config);
 init_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
     S = escalus_users:get_server(Config, alice),
     OptKey = {replaced_wait_timeout, S},
@@ -177,6 +187,10 @@ init_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
+end_per_testcase(close_connection_if_service_type_is_hidden = CN, Config) ->
+    OptName = {hide_service_name, <<"localhost">>},
+    mongoose_helper:successful_rpc(ejabberd_config, del_local_option, [OptName]),
+    escalus:end_per_testcase(CN, Config);
 end_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
     {_, OptKey} = lists:keyfind(opt_to_del, 1, Config),
     {atomic, _} = rpc(mim(), ejabberd_config, del_local_option, [OptKey]),
@@ -617,6 +631,37 @@ replaced_session_cannot_terminate(Config) ->
     lager_ct_backend:stop_capture(),
 
     escalus_connection:stop(Alice2).
+
+return_proper_stream_error_if_service_is_not_hidden(_Config) ->
+    % GIVEN MongooseIM is running default configuration
+    % WHEN we send non-XMPP payload
+    % THEN the server replies with stream error xml-not-well-formed and closes the connection
+    SendMalformedDataStep = fun(Client, Features) ->
+                                    escalus_connection:send_raw(Client, <<"malformed">>),
+                                    {Client, Features}
+                            end,
+    {ok, Connection, _} = escalus_connection:start([], [SendMalformedDataStep]),
+    escalus_connection:receive_stanza(Connection, #{ assert => is_stream_start }),
+    StreamErrorAssertion = {is_stream_error, [<<"xml-not-well-formed">>, <<>>]},
+    escalus_connection:receive_stanza(Connection, #{ assert => StreamErrorAssertion }),
+    false = escalus_connection:is_connected(Connection).
+
+close_connection_if_service_type_is_hidden(_Config) ->
+    % GIVEN the option to hide service name is enabled
+    % WHEN we send non-XMPP payload
+    % THEN connection is closed without any response from the server
+    FailIfAnyDataReturned = fun(Reply) ->
+                                    ct:fail({unexpected_data, Reply})
+                            end,
+    Connection = escalus_tcp:connect(#{ on_reply => FailIfAnyDataReturned }),
+    Ref = monitor(process, Connection),
+    escalus_tcp:send(Connection, "malformed"),
+    receive
+        {'DOWN', Ref, _, _, _} -> ok
+    after
+        5000 ->
+            ct:fail(connection_not_closed)
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -644,7 +644,8 @@ return_proper_stream_error_if_service_is_not_hidden(_Config) ->
     escalus_connection:receive_stanza(Connection, #{ assert => is_stream_start }),
     StreamErrorAssertion = {is_stream_error, [<<"xml-not-well-formed">>, <<>>]},
     escalus_connection:receive_stanza(Connection, #{ assert => StreamErrorAssertion }),
-    false = escalus_connection:is_connected(Connection).
+    %% Sometimes escalus needs a moment to report the connection as closed
+    mongoose_helper:wait_until(fun() -> escalus_connection:is_connected(Connection) end, false).
 
 close_connection_if_service_type_is_hidden(_Config) ->
     % GIVEN the option to hide service name is enabled

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -645,7 +645,7 @@ return_proper_stream_error_if_service_is_not_hidden(_Config) ->
     StreamErrorAssertion = {is_stream_error, [<<"xml-not-well-formed">>, <<>>]},
     escalus_connection:receive_stanza(Connection, #{ assert => StreamErrorAssertion }),
     %% Sometimes escalus needs a moment to report the connection as closed
-    mongoose_helper:wait_until(fun() -> escalus_connection:is_connected(Connection) end, false).
+    escalus_connection:wait_for_close(Connection, 5000).
 
 close_connection_if_service_type_is_hidden(_Config) ->
     % GIVEN the option to hide service name is enabled

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -306,6 +306,12 @@ There are some additional options that influence all database connections in the
     * **Default:** no value, i.e. `Cowboy` is used as a header value
     * **Example:** `{cowboy_server_name, "Apache"}`
 
+* **hide_service_name** (local)
+    * **Description:** According to RFC 6210, even when a client sends invalid data after opening a connection, the server must open XML stream and return stream error anyway. For extra security, this option may be enabled. It changes MIM behaviour to simply close the connection without any errors returned (effectively hiding server's identity).
+    * **Syntax:** `{hide_service_name, Boolean}`
+    * **Default:** `false`
+    * **Example:** `{hide_service_name, true}`
+
 ### Modules
 
 For a specific configuration, please refer to [Modules](advanced-configuration/Modules.md) page.

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -307,7 +307,7 @@ There are some additional options that influence all database connections in the
     * **Example:** `{cowboy_server_name, "Apache"}`
 
 * **hide_service_name** (local)
-    * **Description:** According to RFC 6210, even when a client sends invalid data after opening a connection, the server must open XML stream and return stream error anyway. For extra security, this option may be enabled. It changes MIM behaviour to simply close the connection without any errors returned (effectively hiding server's identity).
+    * **Description:** According to RFC 6210, even when a client sends invalid data after opening a connection, the server must open an XML stream and return a stream error anyway. For extra security, this option may be enabled. It changes MIM behaviour to simply close the connection without any errors returned (effectively hiding the server's identity).
     * **Syntax:** `{hide_service_name, Boolean}`
     * **Default:** `false`
     * **Example:** `{hide_service_name, true}`

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -251,18 +251,16 @@ wait_for_stream({xmlstreamstart, _Name, _} = StreamStart, StateData) ->
     handle_stream_start(StreamStart, StateData);
 wait_for_stream(timeout, StateData) ->
     {stop, normal, StateData};
-%% TODO: this clause is most likely dead code - can't be triggered
-%%       with XMPP level tests;
-%%       see github.com/esl/ejabberd_tests/tree/element-before-stream-start
-wait_for_stream({xmlstreamelement, _}, StateData) ->
-    c2s_stream_error(mongoose_xmpp_errors:xml_not_well_formed(), StateData);
-wait_for_stream({xmlstreamend, _}, StateData) ->
-    c2s_stream_error(mongoose_xmpp_errors:xml_not_well_formed(), StateData);
-wait_for_stream({xmlstreamerror, _}, StateData) ->
-    send_header(StateData, ?MYNAME, << "1.0">>, <<"">>),
-    c2s_stream_error(mongoose_xmpp_errors:xml_not_well_formed(), StateData);
 wait_for_stream(closed, StateData) ->
-    {stop, normal, StateData}.
+    {stop, normal, StateData};
+wait_for_stream(_UnexpectedItem, #state{ server = Server } = StateData) ->
+    case ejabberd_config:get_local_option(hide_service_name, Server) of
+        true ->
+            {stop, normal, StateData};
+        _ ->
+            send_header(StateData, Server, << "1.0">>, <<"">>),
+            c2s_stream_error(mongoose_xmpp_errors:xml_not_well_formed(), StateData)
+    end.
 
 handle_stream_start({xmlstreamstart, _Name, Attrs}, #state{} = S0) ->
     Server = jid:nameprep(xml:get_attr_s(<<"to">>, Attrs)),


### PR DESCRIPTION
This PR adds a new option, that allows to hide XMPP service type when a client purposefully sends malformed data to XMPP socket. With `hide_service_name` option enabled, MongooseIM will simply close the connection instead of acting by the RFC 6120 which obliges the XMPP server to reply with stream error anyway.
