### PR TITLE
Use dsaparam argument when generating DH parameters to speed up generation

### DIFF
--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -28,8 +28,12 @@ all: mongooseim/cert.pem mongooseim/key.pem \
 %/privkey.pem: %/key.pem
 	openssl rsa -in $< -out $@
 
+# About dsaparam argument
+# It speeds up generation of dhparam
+# Speed is useful for fake certificates
+# https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours
 %/dh_server.pem:
-	openssl dhparam -outform PEM -out $@ 1024
+	openssl dhparam -outform PEM -out $@ 1024 -dsaparam
 
 %/index.txt:
 	mkdir -p $(@D)


### PR DESCRIPTION
Speed up tests on travis a little bit.

Comparing "cd tools/ssl && time make"

Before:
make  10.26s user 0.13s system 99% cpu 10.487 total

After:
make  5.46s user 0.10s system 98% cpu 5.625 total


