### PR TITLE
Kill old nodes in test-runner (optional)

### DIFF
--- a/tools/test-runner-complete.sh
+++ b/tools/test-runner-complete.sh
@@ -121,6 +121,7 @@ _run_all_tests() {
                           --show-small-reports \
                           --show-big-reports \
                           --rerun-big-tests \
+                          --kill-old-nodes \
                           --colors \
                           '"$SUGGESTIONS"' \
                           '"$SUITES"' \

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -104,6 +104,10 @@ Script examples:
     Sets dev-nodes and test-hosts to empty lists
     Reruns mam_SUITE
 
+./tools/test-runner.sh --preset mysql_redis --skip-small-tests --skip-cover --one-node --kill-old-nodes -- rdbms
+    Runs rdbms_SUITE
+    Stops currently running MongooseIM nodes (useful to ensure that the latest code is being tested)
+
 ./tools/test-runner.sh --rerun-big-tests -- mam
     The same command as above
 
@@ -286,6 +290,7 @@ PRESET_ENABLED_DEFAULT=true
 BIG_TESTS=true
 BUILD_TESTS=true
 STOP_NODES=true
+KILL_OLD_NODES=false
 TLS_DIST=no
 
 SELECTED_TESTS=()
@@ -419,6 +424,11 @@ case $key in
     --skip-stop-nodes)
         shift # past argument
         STOP_NODES=false
+    ;;
+
+    --kill-old-nodes)
+        shift # past argument
+        KILL_OLD_NODES=true # poor nodes :(
     ;;
 
     --tls-dist)
@@ -592,7 +602,17 @@ echo "    REBAR_CT_EXTRA_ARGS=$REBAR_CT_EXTRA_ARGS"
 echo "    TESTSPEC=$TESTSPEC"
 echo "    TLS_DIST=$TLS_DIST"
 echo "    STOP_NODES=$STOP_NODES"
+echo "    KILL_OLD_NODES=$KILL_OLD_NODES"
 echo ""
+
+
+if [ "$KILL_OLD_NODES" = true ] && [ ! -z "$TEST_HOSTS" ]
+then
+    NODES_TO_STOP=$(./tools/test_runner/hosts_to_nodes.sh $TEST_HOSTS)
+    echo "Ensure that $NODES_TO_STOP nodes are not running"
+    ./tools/test_runner/kill_nodes.sh $NODES_TO_STOP
+fi
+
 
 ./tools/build-releases.sh
 

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -283,6 +283,8 @@ TEST_HOSTS_ARRAY=(
     reg
 )
 
+ALL_TEST_HOSTS="${TEST_HOSTS_ARRAY[@]}"
+
 SMALL_TESTS_DEFAULT=true
 COVER_ENABLED_DEFAULT=true
 PRESET_ENABLED_DEFAULT=true
@@ -608,9 +610,12 @@ echo ""
 
 if [ "$KILL_OLD_NODES" = true ] && [ ! -z "$TEST_HOSTS" ]
 then
-    NODES_TO_STOP=$(./tools/test_runner/hosts_to_nodes.sh $TEST_HOSTS)
-    echo "Ensure that $NODES_TO_STOP nodes are not running"
-    ./tools/test_runner/kill_nodes.sh $NODES_TO_STOP
+    # Stop all known nodes
+    NODES_TO_STOP=$(./tools/test_runner/hosts_to_nodes.sh $ALL_TEST_HOSTS)
+    # Replace new lines with whitespaces
+    NODES_TO_STOP_ONE_LINER="${NODES_TO_STOP//$'\n'/ }"
+    echo "Ensure that nodes are not running: $NODES_TO_STOP_ONE_LINER"
+    ./tools/test_runner/kill_nodes.sh $NODES_TO_STOP_ONE_LINER
 fi
 
 

--- a/tools/test_runner/hosts_to_nodes.erl
+++ b/tools/test_runner/hosts_to_nodes.erl
@@ -1,0 +1,38 @@
+-module(hosts_to_nodes).
+-export([main/0]).
+-export([main/1]).
+
+main() ->
+    main([]).
+
+main(Opts) ->
+    Hosts = opts_to_hosts(Opts),
+    Names = hosts_to_nodes(Hosts),
+    print_names(Names),
+    erlang:halt().
+
+-spec hosts_to_nodes(atom()) -> [atom()].
+hosts_to_nodes(Hosts) ->
+    {ok, Config} = file:consult("big_tests/test.config"),
+    Nodes = proplists:get_value(hosts, Config, []),
+    lists:map(fun(Host) ->
+                      HostConfig = proplists:get_value(Host, Nodes),
+                      case HostConfig of
+                          undefined ->
+                              error_logger:error_msg("Host not found ~p", [Host]);
+                          _ ->
+                              ok
+                      end,
+                      proplists:get_value(node, HostConfig)
+              end, Hosts).
+
+print_names(DbNames) ->
+    [io:format("~p~n", [D]) || D <- DbNames].
+
+%% Nodes can be passed as a list of arguments "node1" "node2"
+%% or as a list inside an argument "node1 node2"
+opts_to_hosts(Opts) when is_list(Opts) ->
+    OptsStrings = lists:map(fun atom_to_list/1, Opts),
+    Joined = string:join(OptsStrings, " "),
+    Nodes = string:tokens(Joined, " "),
+    lists:map(fun list_to_atom/1, Nodes).

--- a/tools/test_runner/hosts_to_nodes.sh
+++ b/tools/test_runner/hosts_to_nodes.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# This script converts a list of test hosts into a list of erlang nodes based on test.config
+#
+# Usage:
+# ./tools/test_runner/hosts_to_nodes.sh mim mim2
+# mongooseim@localhost
+# ejabberd2@localhost
+
+set -e
+
+# Go to the repo directory
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../..
+
+erlc tools/test_runner/hosts_to_nodes.erl
+erl -noinput \
+    -pa tools/test_runner \
+    -s hosts_to_nodes main $@

--- a/tools/test_runner/kill_nodes.erl
+++ b/tools/test_runner/kill_nodes.erl
@@ -1,0 +1,23 @@
+-module(kill_nodes).
+-export([main/0]).
+-export([main/1]).
+
+main() ->
+    main([]).
+
+main(Opts) ->
+    Nodes = opts_to_nodes(Opts),
+    Result = kill_nodes(Nodes),
+    io:format("kill_nodes: done ~p~n", [Result]),
+    erlang:halt().
+
+kill_nodes(Nodes) ->
+    [{Node, rpc:call(Node, init, stop, [])} || Node <- Nodes].
+
+%% Nodes can be passed as a list of arguments "node1" "node2"
+%% or as a list inside an argument "node1 node2"
+opts_to_nodes(Opts) when is_list(Opts) ->
+    OptsStrings = lists:map(fun atom_to_list/1, Opts),
+    Joined = string:join(OptsStrings, " "),
+    Nodes = string:tokens(Joined, " "),
+    lists:map(fun list_to_atom/1, Nodes).

--- a/tools/test_runner/kill_nodes.sh
+++ b/tools/test_runner/kill_nodes.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# This script kills a list of nodes passed as arguments
+#
+# Usage:
+# ./tools/test_runner/kill_nodes.sh 'mongooseim@localhost'
+
+set -e
+
+# Go to the repo directory
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../..
+
+erlc tools/test_runner/kill_nodes.erl
+erl -noinput \
+    -sname killer_$$@localhost \
+    -setcookie ejabberd \
+    -pa tools/test_runner \
+    -s kill_nodes main $@


### PR DESCRIPTION
This PR addresses me.

Proposed changes include:
* Tired of running `pkill beam`?
* Not sure if it's up or down?
* Irritated that nodes are kept running, if big-tests fails?
* This PR adds `--kill-old-nodes` argument, that stops already running nodes before compiling and starting any other nodes.
* No other erlang node gets hurt (only MongooseIM ones).
* Some documentation included.
