### PR TITLE
Add option to modify Cowboy server name returned in headers

### DIFF
--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -15,6 +15,7 @@
     delete/2,
     delete/3,
     delete/4,
+    make_request/1,
     maybe_enable_mam/3,
     maybe_disable_mam/2,
     maybe_skip_mam_test_cases/3,
@@ -32,6 +33,15 @@
 -define(PATHPREFIX, <<"/api">>).
 
 -type role() :: admin | client.
+-type credentials() :: {Username :: binary(), Password :: binary()}.
+-type request_params() :: #{
+        role := role(),
+        method := binary(),
+        creds => credentials(),
+        path := binary(),
+        body := binary(),
+        return_headers := boolean(),
+        server := atom() }.
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -87,51 +97,66 @@ assert_notinmaplist([K|Keys], Map, L, Orig) ->
 
 
 gett(Role, Path) ->
-    make_request(Role, <<"GET">>, Path).
+    make_request(#{ role => Role, method => <<"GET">>, path => Path }).
 
 post(Role, Path, Body) ->
-    make_request(Role, <<"POST">>, Path, Body).
+    make_request(#{ role => Role, method => <<"POST">>, path => Path, body => Body }).
 
 putt(Role, Path, Body) ->
-    make_request(Role, <<"PUT">>, Path, Body).
+    make_request(#{ role => Role, method => <<"PUT">>, path => Path, body => Body }).
 
 delete(Role, Path) ->
-    make_request(Role, <<"DELETE">>, Path).
+    make_request(#{ role => Role, method => <<"DELETE">>, path => Path }).
 
--spec gett(role(), Path :: string()|binary(), Cred :: {Username :: binary(), Password :: binary()}) -> term().
 gett(Role, Path, Cred) ->
-    make_request(Role, {<<"GET">>, Cred}, Path).
+    make_request(#{ role => Role, method => <<"GET">>, creds => Cred, path => Path}).
 
 post(Role, Path, Body, Cred) ->
-    make_request(Role, {<<"POST">>, Cred}, Path, Body).
+    make_request(#{ role => Role, method => <<"POST">>, creds => Cred, path => Path, body => Body }).
 
 putt(Role, Path, Body, Cred) ->
-    make_request(Role, {<<"PUT">>, Cred}, Path, Body).
+    make_request(#{ role => Role, method => <<"PUT">>, creds => Cred, path => Path, body => Body }).
 
 delete(Role, Path, Cred) ->
-    make_request(Role, {<<"DELETE">>, Cred}, Path).
+    make_request(#{ role => Role, method => <<"DELETE">>, creds => Cred, path => Path }).
 
 delete(Role, Path, Cred, Body) ->
-    make_request(Role, {<<"DELETE">>, Cred}, Path, Body).
+    make_request(#{ role => Role, method => <<"DELETE">>, creds => Cred, path => Path, body => Body }).
 
+-spec make_request(request_params()) ->
+    {{Number :: binary(), Text :: binary()},
+     Headers :: [{binary(), binary()}],
+     Body :: map() | binary()}. 
+make_request(#{ return_headers := true } = Params) ->
+    NormalizedParams = normalize_path(normalize_body(fill_default_server(Params))),
+    case fusco_request(NormalizedParams) of
+        {RCode, RHeaders, Body, _, _} ->
+            {RCode, normalize_headers(RHeaders), decode(Body)};
+        {RCode, RHeaders, Body, _, _, _} ->
+            {RCode, normalize_headers(RHeaders), decode(Body)}
+    end;
+make_request(#{ return_headers := false } = Params) ->
+    {Code, _, Body} = make_request(Params#{ return_headers := true }),
+    {Code, Body};
+make_request(Params) ->
+    make_request(Params#{ return_headers => false }).
 
+normalize_path(#{ path := Path } = Params) when not is_binary(Path) ->
+    normalize_path(Params#{ path := list_to_binary(Path) });
+normalize_path(#{ path := Path } = Params) ->
+    Params#{ path := <<?PATHPREFIX/binary, Path/binary>> }.
 
-make_request(Role, Method, Path) ->
-    make_request(Role, Method, Path, <<"">>).
+normalize_body(#{ body := Body } = Params) when is_map(Body) ->
+    Params#{ body := jiffy:encode(Body) };
+normalize_body(#{ body := Body } = Params) when is_binary(Body) ->
+    Params;
+normalize_body(Params) ->
+    Params#{ body => <<>> }.
 
-make_request(Role, Method, Path, ReqBody) when is_map(ReqBody) ->
-    make_request(Role, Method, Path, jiffy:encode(ReqBody));
-make_request(Role, Method, Path, ReqBody) when not is_binary(Path) ->
-    make_request(Role, Method, list_to_binary(Path), ReqBody);
-make_request(Role, Method, Path, ReqBody) ->
-    CPath = <<?PATHPREFIX/binary, Path/binary>>,
-    {Code, RespBody} = case fusco_request(Role, Method, CPath, ReqBody) of
-                           {RCode, _, Body, _, _} ->
-                               {RCode, Body};
-                           {RCode, _, Body, _, _, _} ->
-                               {RCode, Body}
-                       end,
-    {Code, decode(RespBody)}.
+fill_default_server(#{ server := _Server } = Params) ->
+    Params;
+fill_default_server(Params) ->
+    Params#{ server => mim() }.
 
 decode(<<>>) ->
     <<"">>;
@@ -143,14 +168,21 @@ decode(RespBody) ->
             RespBody
     end.
 
+normalize_headers(Headers) ->
+    lists:map(fun({K, V}) when is_binary(V) -> {K, V};
+                 ({K, V}) when is_list(V) -> {K, iolist_to_binary(V)} end, Headers).
+
 %% a request specyfying credentials is directed to client http listener
-fusco_request(Role, {Method, {User, Password}}, Path, Body) ->
-    Basic = list_to_binary("Basic " ++ base64:encode_to_string(to_list(User) ++ ":"++ to_list(Password))),
+fusco_request(#{ role := Role, method := Method, creds := {User, Password},
+                 path := Path, body := Body, server := Server }) ->
+    EncodedAuth = base64:encode_to_string(to_list(User) ++ ":"++ to_list(Password)),
+    Basic = list_to_binary("Basic " ++ EncodedAuth),
     Headers = [{<<"authorization">>, Basic}],
-    fusco_request(Method, Path, Body, Headers, get_port(Role), get_ssl_status(Role));
+    fusco_request(Method, Path, Body, Headers,
+                  get_port(Role, Server), get_ssl_status(Role, Server));
 %% without them it is for admin (secure) interface
-fusco_request(Role, Method, Path, Body) ->
-    fusco_request(Method, Path, Body, [], get_port(Role), get_ssl_status(Role)).
+fusco_request(#{ role := Role, method := Method, path := Path, body := Body, server := Server }) ->
+    fusco_request(Method, Path, Body, [], get_port(Role, Server), get_ssl_status(Role, Server)).
 
 fusco_request(Method, Path, Body, HeadersIn, Port, SSL) ->
     {ok, Client} = fusco_cp:start_link({"localhost", Port, SSL}, [], 1),
@@ -159,20 +191,22 @@ fusco_request(Method, Path, Body, HeadersIn, Port, SSL) ->
     fusco_cp:stop(Client),
     Result.
 
--spec get_port(role()) -> Port :: integer().
-get_port(Role) -> 
-    Listeners = rpc(mim(), ejabberd_config, get_local_option, [listen]),
-    [{PortIpNet, ejabberd_cowboy, _Opts}] = lists:filter(fun(Config) -> is_roles_config(Config, Role) end, Listeners),
+-spec get_port(Role :: role(), Server :: atom()) -> Port :: integer().
+get_port(Role, Server) -> 
+    Listeners = rpc(Server, ejabberd_config, get_local_option, [listen]),
+    [{PortIpNet, ejabberd_cowboy, _Opts}] =
+        lists:filter(fun(Config) -> is_roles_config(Config, Role) end, Listeners),
     case PortIpNet of
         {Port, _Host, _Net} -> Port;
         {Port, _Host} -> Port;
         Port -> Port
     end.
 
--spec get_ssl_status(role()) -> boolean().
-get_ssl_status(Role) ->
-    Listeners = rpc(mim(), ejabberd_config, get_local_option, [listen]),
-    [{_PortIpNet, _Module, Opts}] = lists:filter(fun (Opts) -> is_roles_config(Opts, Role) end, Listeners),
+-spec get_ssl_status(Role :: role(), Server :: atom()) -> boolean().
+get_ssl_status(Role, Server) ->
+    Listeners = rpc(Server, ejabberd_config, get_local_option, [listen]),
+    [{_PortIpNet, _Module, Opts}] =
+        lists:filter(fun (Opts) -> is_roles_config(Opts, Role) end, Listeners),
     lists:keymember(ssl, 1, Opts).
 
 % @doc Changes the control credentials for admin by restarting the listener

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -20,7 +20,7 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
 
 ## Options
 
-* All options except `hosts`, `host`, `host_config`, `listen` and `outgoing_connections` and  can be used in the `host_config` tuple.
+* All options except `hosts`, `host`, `host_config`, `listen` and `outgoing_connections` may be used in the `host_config` tuple.
 
 * There are two kinds of local options - those that are kept separately for each domain in the config file (defined inside `host_config`) and the options local for a node in the cluster.
 
@@ -350,6 +350,12 @@ There are some additional options that influence all database connections in the
     * **Description:** When a user session is replaced (due to a full JID conflict) by a new one, this parameter specifies the time MongooseIM waits for the old sessions to close. The default value is sufficient in most cases. If you observe `replaced_wait_timeout` warning in logs, then most probably the old sessions are frozen for some reason and it should be investigated.
     * **Syntax:** `{replaced_wait_timeout, TimeInMilliseconds}`
     * **Default:** `2000`
+
+* **cowboy_server_name** (local)
+    * **Description:** If configured, replaces Cowboy's default name returned in `server` HTTP response header. It may be use for extra security, as it makes harder for the malicious user harder to learn what HTTP software is running under specific port. This option applies to **all** listeners started by `ejabberd_cowboy` module.
+    * **Syntax:** `{cowboy_server_name, NewName}`
+    * **Default:** no value, i.e. `Cowboy` is used as a header value
+    * **Example:** `{cowboy_server_name, "Apache"}`
 
 ### Modules
 

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -352,7 +352,7 @@ There are some additional options that influence all database connections in the
     * **Default:** `2000`
 
 * **cowboy_server_name** (local)
-    * **Description:** If configured, replaces Cowboy's default name returned in `server` HTTP response header. It may be use for extra security, as it makes harder for the malicious user harder to learn what HTTP software is running under specific port. This option applies to **all** listeners started by `ejabberd_cowboy` module.
+    * **Description:** If configured, replaces Cowboy's default name returned in the `server` HTTP response header. It may be used for extra security, as it makes it harder for the malicious user to learn what HTTP software is running under a specific port. This option applies to **all** listeners started by the `ejabberd_cowboy` module.
     * **Syntax:** `{cowboy_server_name, NewName}`
     * **Default:** no value, i.e. `Cowboy` is used as a header value
     * **Example:** `{cowboy_server_name, "Apache"}`

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -646,6 +646,8 @@
 
 {all_metrics_are_global, {{{all_metrics_are_global}}} }.
 
+{{{cowboy_server_name}}}
+
 %%%.   ========
 %%%'   SERVICES
 

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -44,6 +44,7 @@
     "                {password, \"secret\"}\n"
     "           ]}"}.
 {all_metrics_are_global, true}.
+{cowboy_server_name, "{cowboy_server_name, \"Classified\"}."}.
 {c2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 {s2s_dhfile, ",{dhfile, \"priv/ssl/fake_dh_server.pem\"}"}.
 

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -298,6 +298,8 @@ process_term(Term, State) ->
             add_option(sasl_mechanisms, Mechanisms, State);
         {all_metrics_are_global, Value} ->
             add_option(all_metrics_are_global, Value, State);
+        {cowboy_server_name, Value} ->
+            add_option(cowboy_server_name, Value, State);
         {services, Value} ->
             add_option(services, Value, State);
         {_Opt, _Val} ->

--- a/test/commands_backend_SUITE.erl
+++ b/test/commands_backend_SUITE.erl
@@ -102,6 +102,7 @@ setup(Module) ->
     %% you have to meck some stuff to get it working....
     meck:expect(ejabberd_hooks, add, fun(_, _, _, _, _) -> ok end),
     meck:expect(ejabberd_hooks, run_fold, fun(_, _, _, _) -> ok end),
+    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     spawn(fun mc_holder/0),
     meck:expect(supervisor, start_child,
         fun(ejabberd_listeners, {_, {_, start_link, [_]}, transient,
@@ -117,6 +118,7 @@ setup(Module) ->
 teardown() ->
     cowboy:stop_listener(ejabberd_cowboy:ref({?PORT, ?IP, tcp})),
     mongoose_commands:unregister(commands_new()),
+    meck:unload(ejabberd_config),
     meck:unload(ejabberd_auth),
     meck:unload(ejabberd_hooks),
     meck:unload(supervisor),

--- a/test/mod_websockets_SUITE.erl
+++ b/test/mod_websockets_SUITE.erl
@@ -47,6 +47,7 @@ setup() ->
                                          infinity, worker, [_]}) -> {ok, self()};
                    (A,B) -> meck:passthrough([A,B])
                 end),
+    meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     %% Start websocket cowboy listening
 
     Opts = [{num_acceptors, 10},


### PR DESCRIPTION
This PR adds `cowboy_server_name` config option, which sets the reported HTTP server name in response headers. It may be used for hardening MIM (by hiding Cowboy's identity).

- [x] Docs