### PR TITLE
Add test for GDPR removal of data from mod_private

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -307,11 +307,9 @@ remove_private(Config) ->
                          children = [#xmlcdata{ content = <<"Something to declare">> }]},
         SetPrivateResult = escalus:send_and_wait(Alice,
                              escalus_stanza:private_set(Element)),
-        ct:log("SetPrivateResult: ~p", [SetPrivateResult]),
         escalus:assert(is_iq_result, SetPrivateResult),
 
         %% Verify the data is stored
-        ct:log("Verify the data is stored", []),
         mongoose_helper:wait_until(
             fun() ->
                 mongoose_helper:successful_rpc(mod_private, get_personal_data,
@@ -326,7 +324,6 @@ remove_private(Config) ->
         {0, _} = unregister(Alice, Config),
 
         %% Expect her data to be gone
-        ct:log("Expect her data to be gone", []),
         mongoose_helper:wait_until(
             fun() ->
                 mongoose_helper:successful_rpc(mod_private, get_personal_data,


### PR DESCRIPTION
This PR addresses MIM-338
https://erlangsolutions.atlassian.net/browse/MIM-338
Remove data from mod_private

Proposed changes include:
* add test for removal of data from mod_private


