### PR TITLE
Add sender_id to mam_muc_message RDBMS table

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -131,7 +131,7 @@ groups() ->
                                        {group, retrieve_personal_data_mam_cassandra},
                                        {group, retrieve_personal_data_mam_elasticsearch}
                                       ]},
-     {retrieve_personal_data_mam_rdbms, [], mam_testcases()},
+     {retrieve_personal_data_mam_rdbms, [], all_mam_testcases()},
      {retrieve_personal_data_mam_riak, [], mam_testcases()},
      {retrieve_personal_data_mam_cassandra, [], all_mam_testcases()},
      {retrieve_personal_data_mam_elasticsearch, [], all_mam_testcases()},

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -685,32 +685,32 @@ init_modules(elasticsearch, muc_all, Config) ->
 init_modules(rdbms, muc_all, Config) ->
     init_module(host(), mod_mam_rdbms_arch, [muc]),
     init_module(host(), mod_mam_rdbms_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
 init_modules(rdbms_simple, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, [muc, rdbms_simple_opts()]),
     init_module(host(), mod_mam_rdbms_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
 init_modules(rdbms_async_pool, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, [no_writer]),
     init_module(host(), mod_mam_muc_rdbms_async_pool_writer, [{flush_interval, 1}]), %% 1ms
     init_module(host(), mod_mam_rdbms_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
 init_modules(rdbms_mnesia, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
 init_modules(rdbms_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, []),
     init_module(host(), mod_mam_rdbms_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_cache_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
@@ -718,14 +718,14 @@ init_modules(rdbms_async_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, [no_writer]),
     init_module(host(), mod_mam_muc_rdbms_async_pool_writer, [{flush_interval, 1}]), %% 1ms
     init_module(host(), mod_mam_rdbms_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_cache_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
 init_modules(rdbms_mnesia_muc_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_muc_cache_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
@@ -734,7 +734,7 @@ init_modules(rdbms_mnesia_muc_cache, _, _Config) ->
 init_modules(rdbms_mnesia_cache, muc_all, Config) ->
     init_module(host(), mod_mam_muc_rdbms_arch, []),
     init_module(host(), mod_mam_mnesia_prefs, [muc]),
-    init_module(host(), mod_mam_rdbms_user, [muc]),
+    init_module(host(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host(), mod_mam_cache_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1494,22 +1494,23 @@ muc_querying_for_all_messages(Config) ->
 
 muc_querying_for_all_messages_with_jid(Config) ->
     P = ?config(props, Config),
-    F = fun(Alice, Bob) ->
-        Room = ?config(room, Config),
-        BWithJID = room_address(Room, nick(bob)),
+    F = fun(Alice) ->
+            Room = ?config(room, Config),
+            BobNick = ?config(bob_nickname, Config),
+            BWithJID = room_address(Room, BobNick),
 
-        MucMsgs = ?config(pre_generated_muc_msgs, Config),
-        WithJID = [1 || {_, _, {JID, _, _}, _, _} <- MucMsgs, JID == BWithJID],
-        Len = lists:sum(WithJID),
+            MucMsgs = ?config(pre_generated_muc_msgs, Config),
+            WithJID = [1 || {_, _, {JID, _, _}, _, _} <- MucMsgs, JID == BWithJID],
+            Len = lists:sum(WithJID),
 
-        IQ = stanza_filtered_by_jid_request(P, BWithJID),
-        escalus:send(Alice, stanza_to_room(IQ, Room)),
-        Result = wait_archive_respond(P, Alice),
+            IQ = stanza_filtered_by_jid_request(P, BWithJID),
+            escalus:send(Alice, stanza_to_room(IQ, Room)),
+            Result = wait_archive_respond(P, Alice),
 
-        assert_respond_size(Len, Result),
-        ok
+            assert_respond_size(Len, Result),
+            ok
         end,
-    escalus:story(Config, [{alice, 1}, {bob, 1}], F).
+    escalus:story(Config, [{alice, 1}], F).
 
 muc_light_simple(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -200,7 +200,9 @@ rsm_send1(Config, User, Packet) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
-nick(User) -> escalus_utils:get_username(User).
+nick(User) ->
+    Name = escalus_utils:get_username(User),
+    <<"unique_", Name/binary, "_nickname">>.
 
 mam_ns_binary() -> mam_ns_binary_v03().
 mam_ns_binary_v03() -> <<"urn:xmpp:mam:0">>.
@@ -989,8 +991,10 @@ archive_message(Args) ->
 muc_bootstrap_archive(Config) ->
     Room = ?config(room, Config),
 
-    A = room_address(Room, nick(alice)),
-    B = room_address(Room, nick(bob)),
+    AliceNick = nick(alice),
+    BobNick = nick(bob),
+    A = room_address(Room, AliceNick),
+    B = room_address(Room, BobNick),
     R = room_address(Room),
 
     AliceName   = escalus_users:get_username(Config, alice),
@@ -1004,16 +1008,18 @@ muc_bootstrap_archive(Config) ->
               rpc_apply(mod_mam_muc, archive_id, [Domain, Room])},
     Msgs = generate_msgs_for_days(ArcJID,
                                  [{B, make_jid(BobName, BobServer, <<"res1">>),
-                                  rpc_apply(jid, replace_resource, [RoomJid, nick(bob)])},
+                                  rpc_apply(jid, replace_resource, [RoomJid, BobNick])},
                                   {A, make_jid(AliceName, AliceServer, <<"res1">>),
-                                   rpc_apply(jid, replace_resource, [RoomJid, nick(alice)])}], 16),
+                                   rpc_apply(jid, replace_resource, [RoomJid, AliceNick])}], 16),
 
     put_muc_msgs(Msgs),
 
     maybe_wait_for_archive(Config),
     wait_for_room_archive_size(Domain, Room, length(Msgs)),
 
-    [{pre_generated_muc_msgs, sort_msgs(Msgs)} | Config].
+    [{pre_generated_muc_msgs, sort_msgs(Msgs)},
+     {alice_nickname, AliceNick},
+     {bob_nickname, BobNick} | Config].
 
 put_muc_msgs(Msgs) ->
     Host = host(),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1021,9 +1021,9 @@ put_muc_msgs(Msgs) ->
 
 archive_muc_msg(Host, {{MsgID, _},
                 {_RoomBin, RoomJID, RoomArcID},
-                {_FromBin, _FromJID, SrcJID}, _, Packet}) ->
+                {_FromBin, FromJID, SrcJID}, _, Packet}) ->
     rpc_apply(mod_mam_muc, archive_message, [Host, MsgID, RoomArcID, RoomJID,
-                                             SrcJID, SrcJID, incoming, Packet]).
+                                             FromJID, SrcJID, incoming, Packet]).
 
 %% @doc Get a binary jid of the user, that tagged with `UserName' in the config.
 nick_to_jid(UserName, Config) when is_atom(UserName) ->

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -381,7 +381,7 @@ init_per_group(hibernation, Config) ->
         rdbms ->
     dynamic_modules:start(domain(), mod_mam_muc_rdbms_arch, [muc]),
     dynamic_modules:start(domain(), mod_mam_rdbms_prefs, [muc]),
-    dynamic_modules:start(domain(), mod_mam_rdbms_user, [muc]),
+    dynamic_modules:start(domain(), mod_mam_rdbms_user, [pm, muc]),
             dynamic_modules:start(domain(), mod_mam_muc, [{host, "muc.@HOST@"}]);
         _ ->
             ok

--- a/doc/migrations/3.3.0_3.3.0plus.md
+++ b/doc/migrations/3.3.0_3.3.0plus.md
@@ -1,0 +1,58 @@
+## New field in Message Archive Management MUC entries: Sender ID
+
+As a part of ensuring GDPR compliance, it turned out it's essential to be able to efficiently query MAM MUC data via sender ID (to retrieve user's personal data).
+Originally, the sender JID could be found only as a part of encoded XML message element, so finding all items sent by a certain user would be **extremely** inefficient (or rather: anti-efficient).
+MongooseIM 3.3.0++ uses modified schema for MAM MUC backends which enables way more efficient extraction.
+
+You may find migration instructions specific to your MAM backend below.
+
+### RDBMS
+
+#### Step 1
+
+Please execute following SQL statements on your MIM database:
+
+**MySQL**
+
+```
+ALTER TABLE mam_muc_message ADD COLUMN sender_id INT UNSIGNED;
+CREATE INDEX i_mam_muc_message_sender_id USING BTREE ON mam_muc_message(sender_id);
+```
+
+**PostgreSQL**
+
+```
+ALTER TABLE mam_muc_message ADD COLUMN sender_id INT;
+CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message USING BTREE (sender_id);
+```
+
+**MSSQL**
+
+```
+ALTER TABLE [dbo].[mam_muc_message] ADD sender_id bigint;
+CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message(sender_id);
+```
+
+#### Step 2
+
+Now you have a schema that is compatible with MIM 3.3.0++ but isn't GDPR-compliant yet because the new column has no meaningful data.
+
+Please pick your favourite scripting/programming language and populate the new column with [dedicated script's help](jid-from-mam-muc-script.md) help.
+You'll need to iterate over whole `mam_muc_message` table with the following algorithm:
+
+1. Provide `message` column content to the script.
+2. The script returns **sender's JID** as `username@server` string. You need to split it to get separate username and server parts.
+3. Select ID from `mam_server_user` by the username and server. If it doesn't exist, insert a new one (`id` column is automatically incremented).
+4. Update the `sender_id` column in `mam_muc_message` with the retrieved ID.
+
+### Cassandra
+
+TODO
+
+### Riak
+
+TODO
+
+### ElasticSearch
+
+TODO

--- a/doc/migrations/3.3.0_3.3.0plus.md
+++ b/doc/migrations/3.3.0_3.3.0plus.md
@@ -37,7 +37,7 @@ CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message(sender_id);
 
 Now you have a schema that is compatible with MIM 3.3.0++ but isn't GDPR-compliant yet because the new column has no meaningful data.
 
-Please pick your favourite scripting/programming language and populate the new column with [dedicated script's help](jid-from-mam-muc-script.md) help.
+Please pick your favourite scripting/programming language and populate the new column with [dedicated script's help](jid-from-mam-muc-script.md).
 You'll need to iterate over whole `mam_muc_message` table with the following algorithm:
 
 1. Provide `message` column content to the script.

--- a/doc/migrations/3.3.0_3.3.0plus.md
+++ b/doc/migrations/3.3.0_3.3.0plus.md
@@ -1,10 +1,10 @@
 ## New field in Message Archive Management MUC entries: Sender ID
 
-As a part of ensuring GDPR compliance, it turned out it's essential to be able to efficiently query MAM MUC data via sender ID (to retrieve user's personal data).
-Originally, the sender JID could be found only as a part of encoded XML message element, so finding all items sent by a certain user would be **extremely** inefficient (or rather: anti-efficient).
-MongooseIM 3.3.0++ uses modified schema for MAM MUC backends which enables way more efficient extraction.
+As a part of ensuring GDPR compliance, it is essential to be able to efficiently query MAM MUC data via sender ID (to retrieve user's personal data).
+Originally, the sender JID could be found only as a part of an encoded XML message element, so finding all items sent by a certain user would be **extremely** inefficient (or rather: anti-efficient).
+MongooseIM 3.3.0++ uses a modified schema for MAM MUC backends which enables a more efficient extraction.
 
-You may find migration instructions specific to your MAM backend below.
+Below you may find migration instructions specific to your MAM backend.
 
 ### RDBMS
 
@@ -37,11 +37,11 @@ CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message(sender_id);
 
 Now you have a schema that is compatible with MIM 3.3.0++ but isn't GDPR-compliant yet because the new column has no meaningful data.
 
-Please pick your favourite scripting/programming language and populate the new column with [dedicated script's help](jid-from-mam-muc-script.md).
-You'll need to iterate over whole `mam_muc_message` table with the following algorithm:
+Please pick your favourite scripting/programming language and populate the new column with the help of a [dedicated script](jid-from-mam-muc-script.md).
+You'll need to iterate over the whole `mam_muc_message` table with the following algorithm:
 
 1. Provide `message` column content to the script.
-2. The script returns **sender's JID** as `username@server` string. You need to split it to get separate username and server parts.
+2. The script returns **sender's JID** as `username@server` string. You need to split it to get a separate username and server.
 3. Select ID from `mam_server_user` by the username and server. If it doesn't exist, insert a new one (`id` column is automatically incremented).
 4. Update the `sender_id` column in `mam_muc_message` with the retrieved ID.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ pages:
       - 'How to Set up Jingle/SIP': 'user-guide/Jingle-SIP-setup.md'
   - Migration Guide:
       - '3.1.1 to 3.2.0': 'migrations/3.1.1_3.2.0.md'
+      - '3.3.0 to 3.3.0++': 'migrations/3.3.0_3.3.0plus.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - Platform:
       - 'Contributions to ecosystem': 'Contributions.md'

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -89,6 +89,7 @@ GO
 CREATE TABLE [dbo].[mam_muc_message](
 	[id] [bigint] NOT NULL,
 	[room_id] [bigint] NOT NULL,
+	[sender_id] [bigint] NOT NULL,
 	[nick_name] [nvarchar](250) NOT NULL,
 	[message] [varbinary](max) NOT NULL,
 	[search_body] [nvarchar](max) NOT NULL,
@@ -98,8 +99,11 @@ CREATE TABLE [dbo].[mam_muc_message](
 	[id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
-
 GO
+
+CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message(sender_id);
+GO
+
 SET ANSI_PADDING OFF
 GO
 /****** Object:  Table [dbo].[mam_server_user]    Script Date: 9/17/2014 6:20:03 AM ******/

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -278,6 +278,7 @@ CREATE TABLE mam_muc_message(
   -- A server-assigned UID that MUST be unique within the archive.
   id BIGINT UNSIGNED NOT NULL,
   room_id INT UNSIGNED NOT NULL,
+  sender_id INT UNSIGNED NOT NULL,
   -- A nick of the message's originator
   nick_name varchar(250) NOT NULL,
   -- Term-encoded message packet
@@ -286,6 +287,8 @@ CREATE TABLE mam_muc_message(
   PRIMARY KEY (room_id, id)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_mam_muc_message_sender_id USING BTREE ON mam_muc_message(sender_id);
 
 CREATE TABLE offline_message(
   id BIGINT UNSIGNED        NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -240,6 +240,7 @@ CREATE TABLE mam_muc_message(
   -- A server-assigned UID that MUST be unique within the archive.
   id BIGINT NOT NULL,
   room_id INT NOT NULL,
+  sender_id INT NOT NULL,
   -- A nick of the message's originator
   nick_name varchar(250) NOT NULL,
   -- Term-encoded message packet
@@ -247,6 +248,8 @@ CREATE TABLE mam_muc_message(
   search_body text,
   PRIMARY KEY (room_id, id)
 );
+
+CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message USING BTREE (sender_id);
 
 CREATE TABLE offline_message(
     id SERIAL UNIQUE PRIMARY Key,

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -179,7 +179,7 @@ parse_backend_opts(rdbms, Type, Opts0, Deps0) ->
         end,
 
     Deps1 = add_dep(ModRDBMSArch, [Type], Deps0),
-    Deps = add_dep(mod_mam_rdbms_user, [Type], Deps1),
+    Deps = add_dep(mod_mam_rdbms_user, user_db_types(Type), Deps1),
 
     lists:foldl(
       pa:bind(fun parse_rdbms_opt/5, Type, ModRDBMSArch, ModAsyncWriter),
@@ -198,6 +198,11 @@ parse_backend_opts(elasticsearch, Type, Opts, Deps0) ->
         mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
         _ -> Deps
     end.
+
+% muc backend requires both pm and muc user DB to populate sender_id column
+-spec user_db_types(pm | muc) -> [pm | muc].
+user_db_types(pm) -> [pm];
+user_db_types(muc) -> [pm, muc].
 
 -spec normalize(proplists:proplist()) -> [{atom(), term()}].
 normalize(Opts) ->

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -539,11 +539,11 @@ lookup_messages_without_policy_violation_check(Host, #{search_text := SearchText
 
 -spec archive_message(jid:server(), MessId :: mod_mam:message_id(),
                       ArcId :: mod_mam:archive_id(), LocJID :: jid:jid(),
-                      RemJID :: jid:jid(), SrcJID :: jid:jid(), Dir :: 'incoming',
+                      SenderJID :: jid:jid(), SrcJID :: jid:jid(), Dir :: 'incoming',
                       packet()) -> any().
-archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
+archive_message(Host, MessID, ArcID, LocJID, SenderJID, SrcJID, Dir, Packet) ->
     ejabberd_hooks:run_fold(mam_muc_archive_message, Host, ok,
-                            [Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet]).
+                            [Host, MessID, ArcID, LocJID, SenderJID, SrcJID, Dir, Packet]).
 
 %% ----------------------------------------------------------------------
 %% Helpers

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -156,7 +156,7 @@ archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
 
 -spec prepare_message(Host :: jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), SenderJID :: jid:jid(),
-                      UserRoomJID :: jid:jid(), Packet :: packet()) -> list().
+                      UserRoomJID :: jid:jid(), Packet :: packet()) -> [binary() | integer()].
 prepare_message(Host, MessID, RoomID, SenderJID, #jid{ lresource = FromNick }, Packet) ->
     BareSenderJID = jid:to_bare(SenderJID),
     Data = packet_to_stored_binary(Host, Packet),

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -26,8 +26,10 @@
          purge_multiple_messages/9]).
 
 %% Called from mod_mam_rdbms_async_writer
--export([prepare_message/8, prepare_insert/2, get_mam_muc_gdpr_data/2]).
+-export([prepare_message/6, prepare_insert/2]).
 
+%gdpr
+-export([get_mam_muc_gdpr_data/2]).
 
 %% ----------------------------------------------------------------------
 %% Imports
@@ -42,8 +44,7 @@
          apply_end_border/2]).
 
 -import(mongoose_rdbms,
-        [escape_string/1,
-         escape_integer/1,
+        [escape_integer/1,
          use_escaped_string/1,
          use_escaped_integer/1]).
 
@@ -138,46 +139,35 @@ archive_size(Size, Host, RoomID, _RoomJID) when is_integer(Size) ->
 
 -spec archive_message(_Result, jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), _LocJID :: jid:jid(),
-                      _RemJID :: jid:jid(),
-                      _SrcJID :: jid:jid(), incoming, Packet :: packet()) -> ok.
-archive_message(_Result, Host, MessID, RoomID,
-                _LocJID=#jid{},
-                _RemJID=#jid{},
-                _SrcJID=#jid{lresource=FromNick}, incoming, Packet) ->
+                      SenderJID :: jid:jid(),
+                      UserRoomJID :: jid:jid(), incoming, Packet :: packet()) -> ok.
+archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
+                SenderJID = #jid{}, UserRoomJID = #jid{}, incoming, Packet) ->
     try
-        archive_message_unsafe(Host, MessID, RoomID, FromNick, Packet)
+        Row = prepare_message(Host, MessID, RoomID, SenderJID, UserRoomJID, Packet),
+        {updated, 1} = mod_mam_utils:success_sql_execute(Host, insert_mam_muc_message, Row),
+        ok
     catch _Type:Reason ->
             ?ERROR_MSG("event=archive_message_failed mess_id=~p room_id=~p "
                        "from_nick=~p reason='~p' stacktrace=~p",
-                       [MessID, RoomID, FromNick, Reason, erlang:get_stacktrace()]),
+                       [MessID, RoomID, UserRoomJID#jid.lresource, Reason, erlang:get_stacktrace()]),
             {error, Reason}
     end.
 
--spec archive_message_unsafe(jid:server(), mod_mam:message_id(), mod_mam:archive_id(),
-                             FromNick :: jid:user(), packet()) -> ok.
-archive_message_unsafe(Host, MessID, RoomID, FromNick, Packet) ->
-    Row = prepare_message(Host, MessID, RoomID, FromNick, Packet),
-    {updated, 1} = mod_mam_utils:success_sql_execute(Host, insert_mam_muc_message, Row),
-    ok.
-
--spec prepare_message(jid:server(), mod_mam:message_id(), mod_mam:archive_id(),
-                      _LocJID :: jid:jid(), _RemJID :: jid:jid(),
-                      _SrcJID :: jid:jid(), incoming, packet()) -> list().
-prepare_message(Host, MessID, RoomID,
-                _LocJID=#jid{},
-                _RemJID=#jid{},
-                _SrcJID=#jid{lresource=FromNick}, incoming, Packet) ->
-    prepare_message(Host, MessID, RoomID, FromNick, Packet).
-
-prepare_message(Host, MessID, RoomID, FromNick, Packet) ->
+-spec prepare_message(Host :: jid:server(), MessID :: mod_mam:message_id(),
+                      RoomID :: mod_mam:archive_id(), SenderJID :: jid:jid(),
+                      UserRoomJID :: jid:jid(), Packet :: packet()) -> list().
+prepare_message(Host, MessID, RoomID, SenderJID, #jid{ lresource = FromNick }, Packet) ->
+    BareSenderJID = jid:to_bare(SenderJID),
     Data = packet_to_stored_binary(Host, Packet),
     TextBody = mod_mam_utils:packet_to_search_body(mod_mam_muc, Host, Packet),
-    [MessID, RoomID, FromNick, Data, TextBody].
+    SenderID = mod_mam:archive_id_int(Host, BareSenderJID),
+    [MessID, RoomID, SenderID, FromNick, Data, TextBody].
 
 -spec prepare_insert(Name :: atom(), NumRows :: pos_integer()) -> ok.
 prepare_insert(Name, NumRows) ->
     Table = mam_muc_message,
-    Fields = [id, room_id, nick_name, message, search_body],
+    Fields = [id, room_id, sender_id, nick_name, message, search_body],
     Query = rdbms_queries:create_bulk_insert_query(Table, Fields, NumRows),
     mongoose_rdbms:prepare(Name, Table, Fields, Query),
     ok.

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -154,16 +154,15 @@ stop_worker(Proc) ->
     supervisor:terminate_child(mod_mam_sup, Proc),
     supervisor:delete_child(mod_mam_sup, Proc).
 
-
--spec archive_message(_, Host :: jid:server(), MessID :: mod_mam:message_id(),
-                      ArcID :: mod_mam:archive_id(), LocJID :: jid:jid(),
-                      RemJID :: jid:jid(), SrcJID :: jid:jid(), Dir :: atom(),
+-spec archive_message(_Result, Host :: jid:server(), MessID :: mod_mam:message_id(),
+                      RoomID :: mod_mam:archive_id(), _LocJID :: jid:jid(),
+                      SenderJID :: jid:jid(), UserRoomJID :: jid:jid(), Dir :: atom(),
                       Packet :: packet()) -> ok | {error, timeout}.
-archive_message(_Result, Host,
-                MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
-    Row = mod_mam_muc_rdbms_arch:prepare_message(Host,
-                                                MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet),
-    Worker = select_worker(Host, ArcID),
+archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
+                SenderJID = #jid{}, UserRoomJID = #jid{}, _Dir, Packet) ->
+    Row = mod_mam_muc_rdbms_arch:prepare_message(Host, MessID, RoomID,
+                                                 SenderJID, UserRoomJID, Packet),
+    Worker = select_worker(Host, RoomID),
     WorkerPid = whereis(Worker),
     %% Send synchronously if queue length is too long.
     case is_overloaded(WorkerPid) of

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -116,7 +116,7 @@ stop(Host) ->
 -spec get_mam_pm_gdpr_data(jid:user(), jid:server()) ->
     {ok, ejabberd_gen_mam_archive:mam_pm_gdpr_data()}.
 get_mam_pm_gdpr_data(User, Host) ->
-    case mod_mam_rdbms_user:get_archive_id(User, Host) of
+    case mod_mam_rdbms_user:get_archive_id(Host,User) of
         undefined -> {ok, []};
         ArchiveID ->
             {selected, Rows} = extract_gdpr_messages(Host, ArchiveID),

--- a/src/mam/mod_mam_rdbms_user.erl
+++ b/src/mam/mod_mam_rdbms_user.erl
@@ -132,7 +132,7 @@ archive_id(ArcID, _Host, _ArcJID) ->
 
 -spec get_archive_id(jid:server(), jid:user()) -> undefined | mod_mam:archive_id().
 get_archive_id(Host, User) ->
-    #jid{lserver = Server, luser = UserName} = jid:make(Host, User, <<"">>),
+    #jid{lserver = Server, luser = UserName} = jid:make(User, Host, <<"">>),
     SServer = mongoose_rdbms:escape_string(Server),
     SUserName = mongoose_rdbms:escape_string(UserName),
     DbType = mongoose_rdbms_type:get(),

--- a/test/mod_mam_meta_SUITE.erl
+++ b/test/mod_mam_meta_SUITE.erl
@@ -138,7 +138,7 @@ example_muc_only_no_pref_good_performance(_Config) ->
                 ]),
 
     check_equal_deps([
-                      {mod_mam_rdbms_user, [muc]},
+                      {mod_mam_rdbms_user, [muc, pm]},
                       {mod_mam_cache_user, [muc]},
                       %% 'muc' argument is ignored by the module
                       {mod_mam_muc_rdbms_arch, [muc, no_writer]},


### PR DESCRIPTION
This PR adds new column to `mam_muc_message` table in RDBMS, which is required for GDPR retrieval to work efficiently.