### PR TITLE
Add `clusterState` metric

### DIFF
--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -338,7 +338,8 @@ get_diffs(L1, L2) ->
     lists:zip(L1, L2).
 
 ensure_nodes_not_clustered(Config) ->
-    Nodes = rpc(mim(), mnesia, system_info, [running_db_nodes]),
+    Nodes1 = rpc(mim(), mnesia, system_info, [running_db_nodes]),
+    Nodes = [Node || Node <- Nodes1, Node =/= mim()],
     [distributed_helper:remove_node_from_cluster(N, Config) || N <- Nodes],
     Config ++ [{nodes_clustered, Nodes}].
 

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -57,7 +57,8 @@ groups() ->
          {metrics, [], ?METRICS_CASES},
          {all_metrics_are_global, [], ?METRICS_CASES},
          {global, [], [session_counters,
-                       node_uptime]}
+                       node_uptime,
+                       cluster_state]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -77,9 +78,15 @@ init_per_group(GroupName, Config) ->
 end_per_group(GroupName, Config) ->
     metrics_helper:finalise_by_all_metrics_are_global(Config, GroupName =:= all_metrics_are_global).
 
+init_per_testcase(cluster_state = CN, Config) ->
+    Config1 = ensure_nodes_not_clustered(Config),
+    escalus:init_per_testcase(CN, Config1);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
+end_per_testcase(cluster_state = CN, Config) ->
+    Config1 = ensure_nodes_clustered(Config),
+    escalus:end_per_testcase(CN, Config1);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
@@ -220,6 +227,21 @@ node_uptime(Config) ->
       Y = fetch_global_incrementing_gauge_value(nodeUpTime, Config),
       ?assert_equal_extra(true, Y > X, [{counter, nodeUpTime}, {first, X}, {second, Y}]).
 
+cluster_state(Config) ->
+      SingleNodeClusterState =
+            fetch_global_incrementing_gauge_value(clusterState, Config),
+      ?assert_equal(1, SingleNodeClusterState),
+
+      distributed_helper:add_node_to_cluster(Config),
+      TwoNodesClusterState =
+            fetch_global_incrementing_gauge_value(clusterState, Config),
+      ?assert_equal(2, TwoNodesClusterState),
+
+      distributed_helper:remove_node_from_cluster(Config),
+      SingleNodeClusterState2 =
+            fetch_global_incrementing_gauge_value(clusterState, Config),
+      ?assert_equal(1, SingleNodeClusterState2).
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
@@ -312,3 +334,14 @@ assert_counter_inc(_Name, Inc, Counter1, Counter2) when Counter1 + Inc =:= Count
 
 get_diffs(L1, L2) ->
     lists:zip(L1, L2).
+
+ensure_nodes_not_clustered(Config) ->
+    Nodes = mnesia:system_info(running_db_nodes),
+    [distributed_helper:remove_node_from_cluster(N, Config) || N <- Nodes],
+    Config ++ [{nodes_clustered, Nodes}].
+
+ensure_nodes_clustered(Config) ->
+    NodesToBeClustered = proplists:get_value(nodes_clustered, Config),
+    [distributed_helper:add_node_to_cluster(N, Config)
+     || N <- NodesToBeClustered],
+    Config.

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -18,6 +18,8 @@
 
 -include_lib("common_test/include/ct.hrl").
 
+-import(distributed_helper, [mim/0, rpc/4]).
+
 -define(assert_equal(E, V), (
     [ct:fail("assert_equal(~s, ~s)~n\tExpected ~p~n\tValue ~p~n",
              [(??E), (??V), (E), (V)])
@@ -336,7 +338,7 @@ get_diffs(L1, L2) ->
     lists:zip(L1, L2).
 
 ensure_nodes_not_clustered(Config) ->
-    Nodes = mnesia:system_info(running_db_nodes),
+    Nodes = rpc(mim(), mnesia, system_info, [running_db_nodes]),
     [distributed_helper:remove_node_from_cluster(N, Config) || N <- Nodes],
     Config ++ [{nodes_clustered, Nodes}].
 

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -60,7 +60,7 @@ groups() ->
          {all_metrics_are_global, [], ?METRICS_CASES},
          {global, [], [session_counters,
                        node_uptime,
-                       cluster_state]}
+                       cluster_size]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -80,13 +80,13 @@ init_per_group(GroupName, Config) ->
 end_per_group(GroupName, Config) ->
     metrics_helper:finalise_by_all_metrics_are_global(Config, GroupName =:= all_metrics_are_global).
 
-init_per_testcase(cluster_state = CN, Config) ->
+init_per_testcase(cluster_size = CN, Config) ->
     Config1 = ensure_nodes_not_clustered(Config),
     escalus:init_per_testcase(CN, Config1);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
-end_per_testcase(cluster_state = CN, Config) ->
+end_per_testcase(cluster_size = CN, Config) ->
     Config1 = ensure_nodes_clustered(Config),
     escalus:end_per_testcase(CN, Config1);
 end_per_testcase(CaseName, Config) ->
@@ -229,19 +229,19 @@ node_uptime(Config) ->
       Y = fetch_global_incrementing_gauge_value(nodeUpTime, Config),
       ?assert_equal_extra(true, Y > X, [{counter, nodeUpTime}, {first, X}, {second, Y}]).
 
-cluster_state(Config) ->
+cluster_size(Config) ->
       SingleNodeClusterState =
-            fetch_global_incrementing_gauge_value(clusterState, Config),
+            fetch_global_incrementing_gauge_value(clusterSize, Config),
       ?assert_equal(1, SingleNodeClusterState),
 
       distributed_helper:add_node_to_cluster(Config),
       TwoNodesClusterState =
-            fetch_global_incrementing_gauge_value(clusterState, Config),
+            fetch_global_incrementing_gauge_value(clusterSize, Config),
       ?assert_equal(2, TwoNodesClusterState),
 
       distributed_helper:remove_node_from_cluster(Config),
       SingleNodeClusterState2 =
-            fetch_global_incrementing_gauge_value(clusterState, Config),
+            fetch_global_incrementing_gauge_value(clusterSize, Config),
       ?assert_equal(1, SingleNodeClusterState2).
 
 %%--------------------------------------------------------------------

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -151,6 +151,7 @@ Metrics specific to an extension, e.g. Message Archive Management, are described
 | `[global, uniqueSessionCount]` | value | A number of unique users connected to a MongooseIM cluster (e.g. 3 sessions of the same user will be counted as 1 in this metric). |
 | `[global, cache, unique_sessions_number]` | gauge | A cached value of `uniqueSessionCount`. It is automatically updated when a unique session count is calculated. |
 | `[global nodeUpTime]` | value | Node uptime. |
+| `[global, clusterState]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node. |
 
 ### Data metrics
 

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -151,7 +151,7 @@ Metrics specific to an extension, e.g. Message Archive Management, are described
 | `[global, uniqueSessionCount]` | value | A number of unique users connected to a MongooseIM cluster (e.g. 3 sessions of the same user will be counted as 1 in this metric). |
 | `[global, cache, unique_sessions_number]` | gauge | A cached value of `uniqueSessionCount`. It is automatically updated when a unique session count is calculated. |
 | `[global nodeUpTime]` | value | Node uptime. |
-| `[global, clusterState]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node. |
+| `[global, clusterSize]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node. |
 
 ### Data metrics
 

--- a/src/mongoose_metrics.erl
+++ b/src/mongoose_metrics.erl
@@ -38,6 +38,7 @@
          get_rdbms_data_stats/1,
          get_dist_data_stats/0,
          get_up_time/0,
+         get_mnesia_running_db_nodes_count/0,
          remove_host_metrics/1,
          remove_all_metrics/0,
          get_report_interval/0,
@@ -161,6 +162,10 @@ get_dist_data_stats() ->
 -spec get_up_time() -> {value, integer()}.
 get_up_time() ->
     {value, erlang:round(element(1, erlang:statistics(wall_clock))/1000)}.
+
+-spec get_mnesia_running_db_nodes_count() -> {value, non_neg_integer()}.
+get_mnesia_running_db_nodes_count() ->
+    {value, length(mnesia:system_info(running_db_nodes))}.
 
 remove_host_metrics(Host) ->
     lists:foreach(fun remove_metric/1, exometer:find_entries([Host])).

--- a/src/mongoose_metrics_definitions.hrl
+++ b/src/mongoose_metrics_definitions.hrl
@@ -77,6 +77,9 @@
            eval, ?EX_EVAL_SINGLE_VALUE}},
          {nodeUpTime,
           {function, mongoose_metrics, get_up_time, [],
+           tagged, [value]}},
+         {clusterState,
+          {function, mongoose_metrics, get_mnesia_running_db_nodes_count, [],
            tagged, [value]}}
         ]
 ).

--- a/src/mongoose_metrics_definitions.hrl
+++ b/src/mongoose_metrics_definitions.hrl
@@ -78,7 +78,7 @@
          {nodeUpTime,
           {function, mongoose_metrics, get_up_time, [],
            tagged, [value]}},
-         {clusterState,
+         {clusterSize,
           {function, mongoose_metrics, get_mnesia_running_db_nodes_count, [],
            tagged, [value]}}
         ]


### PR DESCRIPTION
This PR addresses **MIM-261**.

I have some doubts regarding this line: https://github.com/esl/MongooseIM/compare/add-cluster-state-metric?expand=1#diff-54e29ccb6566fec2bcf8aad705f9d93eR83, specifically this `tagged` atom. Do you know what it exactly does?

TODO:
* ~~update documentation~~