### PR TITLE
Cache found behaviour implementations

### DIFF
--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -664,7 +664,8 @@
 {services,
     [
         {service_admin_extra, [{submods, [node, accounts, sessions, vcard, gdpr,
-                                          roster, last, private, stanza, stats]}]}
+                                          roster, last, private, stanza, stats]}]},
+        {service_cache, []}
     ]
 }.
 

--- a/src/admin_extra/service_admin_extra.erl
+++ b/src/admin_extra/service_admin_extra.erl
@@ -29,7 +29,7 @@
 
 -behaviour(mongoose_service).
 
--export([start/1, stop/0]).
+-export([start/1, stop/0, deps/0]).
 
 -define(SUBMODS, [node, accounts, sessions, vcard, roster, last,
                   private, stanza, stats, gdpr
@@ -39,6 +39,8 @@
 %%%
 %%% gen_mod
 %%%
+
+deps() -> [service_cache].
 
 start(Opts) ->
     Submods = gen_mod:get_opt(submods, Opts, ?SUBMODS),

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -17,6 +17,11 @@
 %% WARNING! For simplicity, this function searches only MongooseIM code dir
 -spec find_behaviour_implementations(Behaviour :: module()) -> [module()].
 find_behaviour_implementations(Behaviour) ->
+    LookupFN = fun() -> {ok, find_implementations(Behaviour)} end,
+    {ok, Modules} = service_cache:lookup({behaviour, Behaviour}, LookupFN),
+    Modules.
+
+find_implementations(Behaviour) ->
     {ok, EbinFiles} = file:list_dir(code:lib_dir(mongooseim, ebin)),
     Mods = [ list_to_atom(filename:rootname(File))
              || File <- EbinFiles, filename:extension(File) == ".beam" ],

--- a/src/service_cache.erl
+++ b/src/service_cache.erl
@@ -1,0 +1,33 @@
+%%%-------------------------------------------------------------------
+%%% @author denys.gonchar@erlang-solutions.com
+%%% @copyright (C) 2019, Erlang Solutions
+%%% @doc
+%%%
+%%% @end
+%%% Created : 28. May 2019 17:23
+%%%-------------------------------------------------------------------
+-module(service_cache).
+
+-behaviour(mongoose_service).
+
+%% API
+-export([start/1, stop/0]).
+-export([lookup/2]).
+
+-type lookup_result() :: {ok, Value :: term()} | error.
+-type lookup_fn() :: fun(()-> lookup_result()).
+
+-export_type([lookup_fn/0, lookup_result/0]).
+
+start(Opts) -> cache_tab:new(?MODULE, Opts).
+stop() -> cache_tab:delete(?MODULE).
+
+
+-spec lookup(Key :: term(), lookup_fn()) -> lookup_result().
+lookup(Key, Fun) ->
+    case mongoose_service:is_loaded(?MODULE) of
+        true ->
+            cache_tab:lookup(?MODULE, Key, Fun);
+        false ->
+            Fun()
+    end.

--- a/test/mam_jid_mini_SUITE.erl
+++ b/test/mam_jid_mini_SUITE.erl
@@ -16,6 +16,8 @@ init_per_suite(Config) ->
             {skip,nif_not_loaded}
     end.
 
+end_per_suite(Config) -> Config.
+
 test_encode_decode_functionality(_Config) ->
     PossibleDomainNames = [<<"a">>, <<"b">>, <<"c">>, <<"d">>, <<"e">>, <<"f">>],
     PossibleUserNames = [<<"">> | PossibleDomainNames],


### PR DESCRIPTION

tested manually:

- build and run MIM:
```
make rel
_build/prod/rel/mongooseim/bin/mongooseim live
```

- run `mongoose_lid:find_behaviour_implementations/1` few times, notice dramatic decrease of execution time:
```
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
```
- disable `service_cache` and repeat the test:
```
mongoose_service:stop_service(service_cache).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
```
- re-enable `service_cache` and repeat the test:
```
mongoose_service:start_service(service_cache,[]).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
timer:tc(mongoose_lib, find_behaviour_implementations, [mongoose_service]).
```