### PR TITLE
Fix tls erlang 20 issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ after_success:
         - test 1 = "$SKIP_COV" || ./rebar3 codecov analyze
         - test 1 = "$SKIP_COV" || codecov --disable=gcov --env PRESET
         - test 1 = "$SKIP_COV" || ./rebar3 coveralls send
-        - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ] && [ $TRAVIS_OTP_RELEASE = "19.3" ];
+        - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ] && [ $TRAVIS_OTP_RELEASE = "20.3" ];
             then tools/travis-build-and-push-docker.sh;
           fi
 
@@ -81,7 +81,7 @@ branches:
                 - gdpr-remove-vcard
 
 otp_release:
-        - 19.3
+        - 20.3
 env:
   global:
     - RUN_SMALL_TESTS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ env:
       # When changing jobs, update EXAMPLES in tools/test-runner.sh
     - PRESET=small_tests RUN_SMALL_TESTS=true SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
     - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=yes
-    - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
     - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
     - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
     - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
@@ -107,6 +106,8 @@ matrix:
     - otp_release: 21.3
       env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
            RUN_SMALL_TESTS=true
+    - otp_release: 21.3
+      env: PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
     - otp_release: 21.3
       env: PRESET=riak_mnesia DB=riak REL_CONFIG="with-riak with-jingle-sip" RUN_SMALL_TESTS=true
     - language: generic

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -221,9 +221,7 @@
        {redis, global, default, [{workers, 10}, {strategy, random_worker}], []},
        {rdbms, global, default, [{workers, 5}],
         [{server, {mysql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
-                   [{verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"},
-                    %% To avoid ssl-handshake error in erlang 20 and newer
-                    {server_name_indication, \"localhost\"}]}}]}
+                   [{verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"}]}}]}
        ]}."},
       {mod_last, "{mod_last, [{backend, rdbms}]},"},
       {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -221,7 +221,9 @@
        {redis, global, default, [{workers, 10}, {strategy, random_worker}], []},
        {rdbms, global, default, [{workers, 5}],
         [{server, {mysql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
-                   [{verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"}]}}]}
+                   [{verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"},
+                    %% To avoid ssl-handshake error in erlang 20 and newer
+                    {server_name_indication, \"localhost\"}]}}]}
        ]}."},
       {mod_last, "{mod_last, [{backend, rdbms}]},"},
       {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -69,15 +69,10 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
-    try not ct_helper:is_ct_running() orelse mongoose_helper:is_rdbms_enabled(host()) of
-        false -> {skip, bad_configuration};
+    case not ct_helper:is_ct_running() orelse mongoose_helper:is_rdbms_enabled(host()) of
+        false -> {skip, rdbms_or_ct_not_running};
         true -> escalus:init_per_suite(Config)
-    catch
-        E:Err ->
-            ct:log("ERROR: ~p : ~p", [E, Err]),
-            {skip, init_error}
     end.
-
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -29,10 +29,7 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    case not ct_helper:is_ct_running() orelse mongoose_helper:is_rdbms_enabled(host()) of
-        false -> [];
-        true  -> [{group, rdbms_queries}]
-    end.
+    [{group, rdbms_queries}].
 
 groups() ->
     G = [{rdbms_queries, [sequence], rdbms_queries_cases()}],
@@ -72,7 +69,15 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
-    escalus:init_per_suite(Config).
+    try not ct_helper:is_ct_running() orelse mongoose_helper:is_rdbms_enabled(host()) of
+        false -> {skip, bad_configuration};
+        true -> escalus:init_per_suite(Config)
+    catch
+        E:Err ->
+            ct:log("ERROR: ~p : ~p", [E, Err]),
+            {skip, init_error}
+    end.
+
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).

--- a/doc/advanced-configuration/outgoing-connections.md
+++ b/doc/advanced-configuration/outgoing-connections.md
@@ -123,7 +123,8 @@ An example configuration can look as follows:
 {outgoing_pools, [
  {rdbms, global, default, [{workers, 5}],
   [{server, {mysql, "localhost", 3306, "mydb", "mim", "mimpass",
-             [{verify, verify_peer}, {cacertfile, "path/to/cacert.pem"}]}}]}
+             [{verify, verify_peer}, {cacertfile, "path/to/cacert.pem"},
+              {server_name_indication, disable}]}}]}
 ]}.
 ```
 

--- a/tools/ssl/openssl-mongooseim.cnf
+++ b/tools/ssl/openssl-mongooseim.cnf
@@ -29,9 +29,12 @@ nsComment                   = "Fake Dev-Only Certificate"
 [ alternate_names ]
 
 DNS.1       = localhost
+
 ##adding node names to let tls distribution with OTP 20.3
 DNS.2       = mongooseim@localhost
 DNS.3       = ejabberd2@localhost
 DNS.4       = fed1@localhost
 DNS.5       = reg1@localhost
 DNS.6       = mongooseim3@localhost
+
+IP          = 127.0.0.1

--- a/tools/ssl/openssl-mongooseim.cnf
+++ b/tools/ssl/openssl-mongooseim.cnf
@@ -29,3 +29,9 @@ nsComment                   = "Fake Dev-Only Certificate"
 [ alternate_names ]
 
 DNS.1       = localhost
+##adding node names to let tls distribution with OTP 20.3
+DNS.2       = mongooseim@localhost
+DNS.3       = ejabberd2@localhost
+DNS.4       = fed1@localhost
+DNS.5       = reg1@localhost
+DNS.6       = mongooseim3@localhost


### PR DESCRIPTION
This PR abandons OTP 19 and changes Travis jobs to OTP 20. It also fixes issue with  distributed TLS and MongooseIMs connecting fail due to adding http://erlang.org/doc/man/public_key.html#pkix_verify_hostname-2 to `ssl:connect/2,3`.