### PR TITLE
Escalus update before the release

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]}]}.
 
-{require_otp_vsn, "19|20|21"}.
+{require_otp_vsn, "20|21|22"}.
 
 {src_dirs, ["src", "tests"]}.
 

--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, {git, "https://github.com/proger/erlsh.git", {ref, "4e8a107"}}},
         {jiffy, "0.15.2"},
         {proper, "1.3.0"},
-        {escalus, {git, "https://github.com/esl/escalus.git", {branch, "master"}}},
+        {escalus, {git, "https://github.com/esl/escalus.git", {tag, "4.1.0"}}},
         {gen_fsm_compat, "0.3.0"},
         {cowboy, "2.4.0"},
         {csv, "3.0.3", {pkg, csve}},

--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, {git, "https://github.com/proger/erlsh.git", {ref, "4e8a107"}}},
         {jiffy, "0.15.2"},
         {proper, "1.3.0"},
-        {escalus, {git, "https://github.com/esl/escalus.git", {ref, "8911491"}}},
+        {escalus, {git, "https://github.com/esl/escalus.git", {branch, "master"}}},
         {gen_fsm_compat, "0.3.0"},
         {cowboy, "2.4.0"},
         {csv, "3.0.3", {pkg, csve}},

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -16,7 +16,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"4349a80bb977d9f13aeafc400209516d5333fe63"}},
+       {ref,"b6ff24ad55d81b9dbabdeef8c522ac6994e63c66"}},
   0},
  {<<"esip">>,
   {git,"https://github.com/processone/esip.git",

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -16,7 +16,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"b6ff24ad55d81b9dbabdeef8c522ac6994e63c66"}},
+       {ref,"58b2487abc08c33e5828aa856c133ff446da5d62"}},
   0},
  {<<"esip">>,
   {git,"https://github.com/processone/esip.git",


### PR DESCRIPTION
This PR addresses updates escalus reference to the most recent master in order to verify if we can tag it with new version number.
