### PR TITLE
Fix user disco#info when rooms_in_rosters enabled

### DIFF
--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -394,7 +394,8 @@ is_presence_subscribed(#jid{luser=User, lserver=Server} = From,
                             element => undefined }),
     A2 = ejabberd_hooks:run_fold(roster_get, Server, A, [{User, Server}]),
     Roster = mongoose_acc:get(roster, items, [], A2),
-    lists:any(fun({roster, _, _, {TUser, TServer, _}, _, S, _, _, _, _}) ->
+    lists:any(fun({roster, _, _, JID, _, S, _, _, _, _}) ->
+                      {TUser, TServer} = jid:to_lus(JID),
                       LUser == TUser andalso LServer == TServer andalso S /= none
               end,
               Roster)


### PR DESCRIPTION
This PR addresses #2353.

This adds support in `mod_disco:is_presence_subscribed` for the `jid:jid()` format used by rooms when MUC Light `rooms_in_rosters` is enabled.
