### PR TITLE
Deprecate TLS older than 1.2

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -642,7 +642,7 @@ openssl_client_can_use_cipher(Cipher, Port) ->
     PortStr = integer_to_list(Port),
     Cmd = "echo '' | openssl s_client -connect localhost:" ++ PortStr ++
           " -cipher " "\"" ++ Cipher ++ "\" 2>&1",
-    {done, ReturnCode, Result} = erlsh:oneliner(Cmd),
+    {done, ReturnCode, _Result} = erlsh:oneliner(Cmd),
     0 == ReturnCode.
 
 restore_ejabberd_node(Config) ->

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -245,7 +245,7 @@ should_fail_with_tlsv1_1(Config) ->
 
 should_fail_with(Config, Protocol) ->
     %% Connection process is spawned with a link so besides the crash itself,
-    %% we will receive exit signal. We don't want to terminate the test due to this.
+    %%   we will receive an exit signal. We don't want to terminate the test due to this.
     %% TODO: Investigate if this behaviour is not a ticking bomb which may affect other test cases.
     process_flag(trap_exit, true),
     %% GIVEN

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -30,7 +30,6 @@
 -define(SECURE_USER, secure_joe).
 -define(CERT_FILE, "priv/ssl/fake_server.pem").
 -define(DH_FILE, "priv/ssl/fake_dh_server.pem").
--define(TLS_VERSIONS, ["tlsv1.2"]).
 
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
@@ -43,7 +42,6 @@
 all() ->
     [
      {group, session_replacement},
-     %% these groups must be last, as they really... complicate configuration
      {group, fast_tls},
      {group, just_tls}
     ].
@@ -56,10 +54,13 @@ groups() ->
                             invalid_host,
                             invalid_stream_namespace,
                             deny_pre_xmpp_1_0_stream]},
-          {starttls, [], test_cases()},
+          {starttls, [], [should_fail_to_authenticate_without_starttls,
+                          should_not_send_other_features_with_starttls_required,
+                          auth_bind_pipelined_starttls_skipped_error | protocol_test_cases()]},
           {tls, [parallel], [auth_bind_pipelined_session,
-                             auth_bind_pipelined_auth_failure |
-                             generate_tls_vsn_tests() ++ cipher_test_cases()]},
+                             auth_bind_pipelined_auth_failure,
+                             should_pass_with_tlsv1_2
+                             | protocol_test_cases() ++ cipher_test_cases()]},
           {feature_order, [parallel], [stream_features_test,
                                        tls_authenticate,
                                        tls_compression_fail,
@@ -79,30 +80,33 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 tls_groups()->
-    [{group, c2s_noproc},
-     {group, starttls},
+    [{group, starttls},
+     {group, c2s_noproc},
      {group, feature_order},
      {group, tls}].
 
-test_cases() ->
-    generate_tls_vsn_tests() ++
-    [should_fail_with_sslv3,
-     should_fail_to_authenticate_without_starttls,
-     should_not_send_other_features_with_starttls_required,
-     auth_bind_pipelined_starttls_skipped_error].
+protocol_test_cases() ->
+    [
+     should_fail_with_sslv3,
+     should_fail_with_tlsv1,
+     should_fail_with_tlsv1_1,
+     should_pass_with_tlsv1_2
+    ].
 
 cipher_test_cases() ->
     [
+     %% Server certificate is signed only with RSA for now, don't try to use ECDSA!
      clients_can_connect_with_advertised_ciphers,
-     'clients_can_connect_with_DHE-RSA-AES256-SHA',
-     'clients_can_connect_with_DHE-RSA-AES128-SHA',
-     %% node2 accepts DHE-RSA-AES256-SHA exclusively (see mongooseim.cfg)
-     'clients_can_connect_with_DHE-RSA-AES256-SHA_only'
+     % String cipher
+     'clients_can_connect_with_ECDHE-RSA-AES256-GCM-SHA384',
+     %% MIM2 accepts ECDHE-RSA-AES256-GCM-SHA384 exclusively with fast_tls on alternative port
+     %% MIM3 accepts #{cipher => aes_256_gcm, key_exchange => ecdhe_rsa, mac => aead, prf => sha384}
+     %%      exclusively with just_tls on alternative port
+     'clients_can_connect_with_ECDHE-RSA-AES256-GCM-SHA384_only'
     ].
 
-
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim, mim2, mim3]) ++ escalus:suite().
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -126,6 +130,12 @@ init_per_group(c2s_noproc, Config) ->
                              fun mk_value_for_starttls_config_pattern/0),
     ejabberd_node_utils:restart_application(mongooseim),
     Config;
+init_per_group(session_replacement, Config) ->
+    config_ejabberd_node_tls(Config,
+                             fun mk_value_for_starttls_config_pattern/0),
+    ejabberd_node_utils:restart_application(mongooseim),
+    lager_ct_backend:start(),
+    Config;
 init_per_group(starttls, Config) ->
     config_ejabberd_node_tls(Config,
                              fun mk_value_for_starttls_required_config_pattern/0),
@@ -145,15 +155,10 @@ init_per_group(feature_order, Config) ->
     ejabberd_node_utils:restart_application(mongooseim),
     Config;
 init_per_group(just_tls,Config)->
-    case catch list_to_integer(erlang:system_info(otp_release)) of
-        I when is_integer(I) andalso I>=19 ->
-            [{tls_module, just_tls} | Config];
-        _ -> {skip,"just_tls backend is supported only since OTP19"}
-    end;
+    [{tls_module, just_tls} | Config];
 init_per_group(fast_tls,Config)->
     [{tls_module, fast_tls} | Config];
 init_per_group(session_replacement, Config) ->
-    lager_ct_backend:start(),
     Config;
 init_per_group(_, Config) ->
     Config.
@@ -178,10 +183,6 @@ end_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
-
-generate_tls_vsn_tests() ->
-    [list_to_existing_atom("should_pass_with_" ++ VSN)
-     || VSN <- ?TLS_VERSIONS].
 
 %%--------------------------------------------------------------------
 %% Tests
@@ -234,25 +235,35 @@ deny_pre_xmpp_1_0_stream(Config) ->
     escalus_connection:stop(Conn).
 
 should_fail_with_sslv3(Config) ->
+    should_fail_with(Config, sslv3).
+
+should_fail_with_tlsv1(Config) ->
+    should_fail_with(Config, tlsv1).
+
+should_fail_with_tlsv1_1(Config) ->
+    should_fail_with(Config, 'tlsv1.1').
+
+should_fail_with(Config, Protocol) ->
+    %% Connection process is spawned with a link so besides the crash itself,
+    %% we will receive exit signal. We don't want to terminate the test due to this.
+    %% TODO: Investigate if this behaviour is not a ticking bomb which may affect other test cases.
+    process_flag(trap_exit, true),
     %% GIVEN
     UserSpec0 = escalus_users:get_userspec(Config, ?SECURE_USER),
-    UserSpec1 = set_secure_connection_protocol(UserSpec0, sslv3),
+    UserSpec1 = set_secure_connection_protocol(UserSpec0, Protocol),
     %% WHEN
     try escalus_connection:start(UserSpec1) of
     %% THEN
         _ ->
-            error(client_connected_using_sslv3)
+            error({client_connected, Protocol})
     catch
-        error:_ ->
+        _C:_R ->
             ok
     end.
 
-'should_pass_with_tlsv1.2'(Config) ->
-    should_pass_with_tls('tlsv1.2', Config).
-
-should_pass_with_tls(Version, Config)->
+should_pass_with_tlsv1_2(Config) ->
     UserSpec0 = escalus_fresh:create_fresh_user(Config, ?SECURE_USER),
-    UserSpec1 = set_secure_connection_protocol(UserSpec0, Version),
+    UserSpec1 = set_secure_connection_protocol(UserSpec0, 'tlsv1.2'),
 
     %% WHEN
     Result = escalus_connection:start(UserSpec1),
@@ -292,26 +303,22 @@ should_not_send_other_features_with_starttls_required(Config) ->
 clients_can_connect_with_advertised_ciphers(Config) ->
     ?assert(length(ciphers_working_with_ssl_clients(Config)) > 0).
 
-'clients_can_connect_with_DHE-RSA-AES256-SHA'(Config) ->
-    ?assert(lists:member("DHE-RSA-AES256-SHA",
+'clients_can_connect_with_ECDHE-RSA-AES256-GCM-SHA384'(Config) ->
+    
+    ?assert(lists:member("ECDHE-RSA-AES256-GCM-SHA384",
                          ciphers_working_with_ssl_clients(Config))).
 
-'clients_can_connect_with_DHE-RSA-AES256-SHA_only'(Config) ->
+'clients_can_connect_with_ECDHE-RSA-AES256-GCM-SHA384_only'(Config) ->
     Port = case ?config(tls_module, Config) of
                just_tls -> 5263; %mim3 secondary_c2s port
                fast_tls -> 5233  %mim2 secondary_c2s port
            end,
     Config1 = [{c2s_port, Port} | Config],
-    CiphersStr = os:cmd("openssl ciphers 'DHE-RSA-AES256-SHA'"),
+    CiphersStr = os:cmd("openssl ciphers 'ECDHE-RSA-AES256-GCM-SHA384'"),
     ct:pal("Available cipher suites for : ~s", [CiphersStr]),
     ct:pal("Openssl version: ~s", [os:cmd("openssl version")]),
-    ?assertEqual(["DHE-RSA-AES256-SHA"],
+    ?assertEqual(["ECDHE-RSA-AES256-GCM-SHA384"],
                  ciphers_working_with_ssl_clients(Config1)).
-
-'clients_can_connect_with_DHE-RSA-AES128-SHA'(Config) ->
-    ?assert(lists:member("DHE-RSA-AES128-SHA",
-                         ciphers_working_with_ssl_clients(Config))).
-
 
 reset_stream_noproc(Config) ->
     UserSpec = escalus_users:get_userspec(Config, alice),
@@ -395,7 +402,7 @@ compress_noproc(Config) ->
     end,
     ok.
 
-%% Tests featuress advertisement
+%% Tests features advertisement
 stream_features_test(Config) ->
     UserSpec = escalus_fresh:freshen_spec(Config, ?SECURE_USER),
     List = [start_stream, stream_features, {?MODULE, verify_features}],
@@ -635,7 +642,7 @@ openssl_client_can_use_cipher(Cipher, Port) ->
     PortStr = integer_to_list(Port),
     Cmd = "echo '' | openssl s_client -connect localhost:" ++ PortStr ++
           " -cipher " "\"" ++ Cipher ++ "\" 2>&1",
-    {done, ReturnCode, _Result} = erlsh:oneliner(Cmd),
+    {done, ReturnCode, Result} = erlsh:oneliner(Cmd),
     0 == ReturnCode.
 
 restore_ejabberd_node(Config) ->

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -77,10 +77,10 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
 * **s2s_certfile** (global)
     * **Description:** Path to X509 PEM file with a certificate and a private key inside (not protected by any password). Required if `s2s_use_starttls` is enabled.
 
-* **s2s_ciphers** (global)
+* **s2s_ciphers** (global) <a name="s2s-ciphers"></a>
     * **Description:** Defines a list of accepted SSL ciphers in **outgoing** S2S connection.
       Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/apps/ciphers.html) for the cipher string format.
-    * **Default:** As of OpenSSL 1.0.0 it's `ALL:!aNULL:!eNULL` ([source](https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS))
+    * **Default:** `"TLSv1.2:TLSv1.3"`
 
 * **domain_certfile** (multi, global)
     * **Description:** Overrides common certificates with new ones specific for chosen XMPP domains.

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -39,7 +39,7 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 * `certfile` (string, default: no certfile will be used) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
   If the certificate is signed by an intermediate CA, you should specify here the whole CA chain by concatenating all public keys together and appending the private key after that.
 * `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA chain that will be used to verify clients. Won't have any effect if `verify_peer` is not enabled.
-* `verify_peer` (default: disabled) - Enforces verification of a client certificate. Requires valid `cafile`.
+* `verify_peer` (default: disabled) - Enforces verification of a client certificate. Requires a valid `cafile`.
 * `dhfile` (string, default: no DH file will be used) - Path to the Diffie Hellman parameter file
 
 #### `fast_tls` - specific options

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -27,8 +27,7 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 * `tls` (default: disabled) - When this option is set, clients must initiate a TLS session immediately after connecting, before beginning the normal XML stream.
 * `tls_module` (atom, default: `fast_tls`) - Provides a TLS library to use. `fast_tls` uses OpenSSL-based NIFs, while `just_tls` uses Erlang TLS implementation provided by OTP. They are fully interchangeable, with some exceptions (`ejabberd_c2s` options supported by only one of them are explicitly described, e.g. `crlfiles`).
 * `zlib` (atom or a positive integer, default: disabled) - Enables ZLIB support, the integer value is a limit for a decompressed output size (to prevent successful [ZLIB bomb attack](https://xmpp.org/community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.html)); the limit can be disabled with an atom 'unlimited'.
-* `ciphers` (string, default: as of OpenSSL 1.0.2 it's `ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2` [(source)](https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER_STRINGS)) - cipher suites to use with StartTLS.
- Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format.
+* `ciphers` (string, default: `"TLSv1.2:TLSv1.3"`) - <a name="c2s-ciphers"></a>cipher suites to use with StartTLS. Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format.
 * `access` (atom, default: `c2s`) - Access Rule to use for C2S connections.
 * `c2s_shaper` (atom, default: `none`) - Connection shaper to use for incoming C2S stanzas.
 * `max_stanza_size` (positive integer, default: infinity) - Maximum allowed incoming stanza size.
@@ -163,7 +162,7 @@ Please refer to the [Advanced configuration](../Advanced-configuration.md) for m
 * `protocol_options` List of supported SSL protocols, default "no_sslv3".
  It also accepts "no_tlsv1" and "no_tlsv1_1"
 * `dhfile` (string, default: no DH file will be used) - Path to the Diffie Hellman parameter file
-* `ciphers` (string, default: as of OpenSSL 1.0.2 it's `ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2` [(source)](https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER_STRINGS)) - cipher suites to use with StartTLS.
+* `ciphers` (string, default: `"TLSv1.2:TLSv1.3"`) - cipher suites to use with StartTLS. <a name="s2s-ciphers"></a>
 * `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA chain that will be used to verify clients (here server initiating S2S connection).
 
 ## XMPP components: `ejabberd_service`

--- a/doc/advanced-configuration/Listener-modules.md
+++ b/doc/advanced-configuration/Listener-modules.md
@@ -16,31 +16,40 @@ You only need to declare running `ejabberd_c2s`, to have the other 2 modules sta
 
 ### Configuration
 
+#### General
 
-* `certfile` (string, default: no certfile will be used) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
-  If the certificate is signed by an intermediate CA, you should specify here the whole CA chain by concatenating all public keys together and appending the private key after that.
-* `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA chain that will be used to verify clients. Won't have any effect if `verify_peer` is not enabled.
-* `crlfiles` (list of strings, default: []) - A list of paths to Certificate Revocation Lists. Not supported by `fast_tls` TLS module.
-* `verify_peer` (default: disabled) - Enforces verification of a client certificate. Requires valid `cafile`.
-* `starttls` (default: disabled) - Enables StartTLS support; requires `certfile`.
-* `starttls_required` (default: disabled) - enforces StartTLS usage.
-* `tls` (default: disabled) - When this option is set, clients must initiate a TLS session immediately after connecting, before beginning the normal XML stream.
-* `tls_module` (atom, default: `fast_tls`) - Provides a TLS library to use. `fast_tls` uses OpenSSL-based NIFs, while `just_tls` uses Erlang TLS implementation provided by OTP. They are fully interchangeable, with some exceptions (`ejabberd_c2s` options supported by only one of them are explicitly described, e.g. `crlfiles`).
-* `zlib` (atom or a positive integer, default: disabled) - Enables ZLIB support, the integer value is a limit for a decompressed output size (to prevent successful [ZLIB bomb attack](https://xmpp.org/community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.html)); the limit can be disabled with an atom 'unlimited'.
-* `ciphers` (string, default: `"TLSv1.2:TLSv1.3"`) - <a name="c2s-ciphers"></a>cipher suites to use with StartTLS. Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format.
 * `access` (atom, default: `c2s`) - Access Rule to use for C2S connections.
 * `c2s_shaper` (atom, default: `none`) - Connection shaper to use for incoming C2S stanzas.
 * `max_stanza_size` (positive integer, default: infinity) - Maximum allowed incoming stanza size.
  **Warning:** this limit is checked **after** the input data parsing, so it does not apply to the input data size itself.
 * `backlog` (positive integer, default 100) - overrides the default TCP backlog value
 * `max_fsm_queue` (positive integer, the value of this option set global) - message queue limit to prevent resource exhaustion; overrides the global value of this option
-* `protocol_options` List of supported SSL protocols, default "no_sslv3".
- It also accepts "no_tlsv1" and "no_tlsv1_1"
-* `dhfile` (string, default: no DH file will be used) - Path to the Diffie Hellman parameter file
 * `hibernate_after` (integer, default: 0) - Time in milliseconds after which a client process spawned by this listener will hibernate.
   Hibernation greatly reduces memory consumption of client processes, but *may* result in increased CPU consumption if a client is used *very* frequently.
   The default, recommended value of 0 means that the client processes will hibernate at every opportunity.
 * `acceptors_num` (integer, default: 100) - For TCP-based listeners: the number of processes accepting new connections on the listening socket.
+* `zlib` (atom or a positive integer, default: disabled) - Enables ZLIB support, the integer value is a limit for a decompressed output size (to prevent successful [ZLIB bomb attack](https://xmpp.org/community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.html)); the limit can be disabled with an atom 'unlimited'.
+
+#### Common TLS options
+
+* `starttls` (default: disabled) - Enables StartTLS support; requires `certfile`.
+* `starttls_required` (default: disabled) - enforces StartTLS usage.
+* `tls` (default: disabled) - When this option is set, clients must initiate a TLS session immediately after connecting, before beginning the normal XML stream.
+* `tls_module` (atom, default: `fast_tls`) - Provides a TLS library to use. `fast_tls` uses OpenSSL-based NIFs, while `just_tls` uses Erlang TLS implementation provided by OTP. They are fully interchangeable, with some exceptions (`ejabberd_c2s` options supported by only one of them are explicitly described, e.g. `crlfiles`).
+* `certfile` (string, default: no certfile will be used) - Path to the X509 PEM file with a certificate and a private key (not protected by a password).
+  If the certificate is signed by an intermediate CA, you should specify here the whole CA chain by concatenating all public keys together and appending the private key after that.
+* `cafile` (string, default: no CA file will be used) - Path to the X509 PEM file with a CA chain that will be used to verify clients. Won't have any effect if `verify_peer` is not enabled.
+* `verify_peer` (default: disabled) - Enforces verification of a client certificate. Requires valid `cafile`.
+* `dhfile` (string, default: no DH file will be used) - Path to the Diffie Hellman parameter file
+
+#### `fast_tls` - specific options
+
+* `ciphers` (string, default: `"TLSv1.2:TLSv1.3"`) - <a name="c2s-ciphers"></a>Cipher suites to use with StartTLS or TLS. Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format.
+* `protocol_options` List of OpenSSL options, the default value is `["no_sslv2", "no_sslv3", "no_tlsv1, "no_tlsv1_1"]`. You can find the mappings between supported options and actual OpenSSL flags in the `fast_tls` [source code](https://github.com/processone/fast_tls/blob/master/c_src/options.h).
+
+#### `just_tls` - specific options
+
+* `crlfiles` (list of strings, default: []) - A list of paths to Certificate Revocation Lists.
 
 ## HTTP-based services (BOSH, WebSocket, REST): `ejabberd_cowboy`
 

--- a/doc/advanced-configuration/TLS-hardening.md
+++ b/doc/advanced-configuration/TLS-hardening.md
@@ -33,7 +33,7 @@ It is still possible to enable earlier versions, however it is strongly discoura
 ## OTP TLS hardening
 
 Protocol list for OTP TLS is set via the `protocol_version` environment variable.
-It's an Erlang runtime variable, so it is not configured in OS but rather in `app.config` file.
+It's an Erlang runtime variable, so it is not configured in the OS but rather in the`app.config` file.
 It may be found in `etc/` folder inside MongooseIM release and in `[repository root]/rel/files/`.
 
 In order to change the list, please find the following lines:

--- a/doc/advanced-configuration/TLS-hardening.md
+++ b/doc/advanced-configuration/TLS-hardening.md
@@ -63,7 +63,7 @@ By default, MongooseIM sets this option to `TLSv1.2:TLSv1.3` for each component.
 The list below enumerates all components that use Fast TLS and describes how to change this string.
 
 * `ejabberd_c2s` - main user session abstraction + XMPP over TCP listener
-    * Please consult respective section in [Listener modules](Listener-modules.md#c2s-ciphers).
+    * Please consult the respective section in [Listener modules](Listener-modules.md#c2s-ciphers).
 * `ejabberd_s2s_in` - incoming S2S connections (XMPP Federation)
     * Please consult respective section in [Listener modules](Listener-modules.md#s2s-ciphers).
 * `ejabberd_s2s_out` - outgoing S2S connections (XMPP Federation)

--- a/doc/advanced-configuration/TLS-hardening.md
+++ b/doc/advanced-configuration/TLS-hardening.md
@@ -9,7 +9,7 @@ Large part of the logic is implemented in Erlang but it calls OpenSSL API for so
 The latter is a community-maintained driver, which is implemented as NIFs (native C code).
 It uses OpenSSL API for all operations.
 
-Most MongooseIM components use TLS library provided by OTP.
+Most MongooseIM components use the TLS library provided by OTP.
 However, some of them choose to integrate with `fast_tls` library instead.
 The former one is used primarily by MIM dependencies, while the latter is used only by MIM modules.
 

--- a/doc/advanced-configuration/TLS-hardening.md
+++ b/doc/advanced-configuration/TLS-hardening.md
@@ -65,7 +65,7 @@ The list below enumerates all components that use Fast TLS and describes how to 
 * `ejabberd_c2s` - main user session abstraction + XMPP over TCP listener
     * Please consult the respective section in [Listener modules](Listener-modules.md#c2s-ciphers).
 * `ejabberd_s2s_in` - incoming S2S connections (XMPP Federation)
-    * Please consult respective section in [Listener modules](Listener-modules.md#s2s-ciphers).
+    * Please consult the respective section in [Listener modules](Listener-modules.md#s2s-ciphers).
 * `ejabberd_s2s_out` - outgoing S2S connections (XMPP Federation)
     * Please check [the documentation](../Advanced-configuration.md#s2s-ciphers) for `s2s_ciphers` option.
 * `mod_global_distrib` - Global Distribution module

--- a/doc/advanced-configuration/TLS-hardening.md
+++ b/doc/advanced-configuration/TLS-hardening.md
@@ -32,7 +32,7 @@ It is still possible to enable earlier versions, however it is strongly discoura
 
 ## OTP TLS hardening
 
-Protocols list for OTP TLS is set via `protocol_version` environment variable.
+Protocol list for OTP TLS is set via the `protocol_version` environment variable.
 It's an Erlang runtime variable, so it is not configured in OS but rather in `app.config` file.
 It may be found in `etc/` folder inside MongooseIM release and in `[repository root]/rel/files/`.
 

--- a/doc/advanced-configuration/TLS-hardening.md
+++ b/doc/advanced-configuration/TLS-hardening.md
@@ -1,0 +1,73 @@
+## OTP TLS vs. Fast TLS
+
+Before we explain the TLS hardening in MongooseIM, we need to describe the TLS libraries used in the project.
+These are "OTP TLS" and "Fast TLS".
+
+The former is provided by (as the name suggests) OTP as the `ssl` application.
+Large part of the logic is implemented in Erlang but it calls OpenSSL API for some operations anyway.
+
+The latter is a community-maintained driver, which is implemented as NIFs (native C code).
+It uses OpenSSL API for all operations.
+
+Most MongooseIM components use TLS library provided by OTP.
+However, some of them choose to integrate with `fast_tls` library instead.
+The former one is used primarily by MIM dependencies, while the latter is used only by MIM modules.
+
+None of them is strictly better than the other.
+Below you may find a summary of the differences between them.
+
+* `fast_tls` is faster.
+* There are options that OTP TLS (a.k.a `just_tls` in the `ejabberd_c2s` configuration) supports exclusively:
+    * Immediate connection drop when the client certificate is invalid
+    * Certificate Revocation Lists
+    * More flexible certificate verification options
+* Allowed protocol versions may be configured:
+    * Globally for OTP TLS via an environment variable
+    * Per socket in Fast TLS via OpenSSL cipher string
+
+## Deprecations
+
+MongooseIM is configured to allow only TLS 1.2 or higher, due to known vulnerabilities in TLS 1.0 and 1.1.
+It is still possible to enable earlier versions, however it is strongly discouraged.
+
+## OTP TLS hardening
+
+Protocols list for OTP TLS is set via `protocol_version` environment variable.
+It's an Erlang runtime variable, so it is not configured in OS but rather in `app.config` file.
+It may be found in `etc/` folder inside MongooseIM release and in `[repository root]/rel/files/`.
+
+In order to change the list, please find the following lines:
+
+```
+{protocol_version, ['tlsv1.2'
+                 %, 'tlsv1.3' % supported in OTP >= 22
+          ]}
+```
+
+By default only TLS 1.2 is enabled, as 1.3 is not supported by OTPs older than 22.0.
+If you are using OTP 22.0 or newer, you may remove leading `%` before `'tlsv1.3'`.
+The remaining valid values are: `'tlsv1.1'`, `tlsv1`, `sslv3`.
+
+This setting affects the following MongooseIM components:
+
+* Raw XMPP over TCP connections, if `ejabberd_c2s` listener is configured to use `just_tls`.
+* All outgoing connections (databases, AMQP, SIP etc.)
+* HTTP endpoints
+
+## Fast TLS hardening
+
+Fast TLS expects an OpenSSL cipher string as one of optional connection parameters.
+This string is configured individually for every module that uses it.
+By default, MongooseIM sets this option to `TLSv1.2:TLSv1.3` for each component.
+
+The list below enumerates all components that use Fast TLS and describes how to change this string.
+
+* `ejabberd_c2s` - main user session abstraction + XMPP over TCP listener
+    * Please consult respective section in [Listener modules](Listener-modules.md#c2s-ciphers).
+* `ejabberd_s2s_in` - incoming S2S connections (XMPP Federation)
+    * Please consult respective section in [Listener modules](Listener-modules.md#s2s-ciphers).
+* `ejabberd_s2s_out` - outgoing S2S connections (XMPP Federation)
+    * Please check [the documentation](../Advanced-configuration.md#s2s-ciphers) for `s2s_ciphers` option.
+* `mod_global_distrib` - Global Distribution module
+    * Please add `{ciphers, "string"}` to `tls_opts` parameter of `mod_global_distrib`, as [described in the documentation](../modules/mod_global_distrib.md#tls_opts).
+

--- a/doc/modules/mod_global_distrib.md
+++ b/doc/modules/mod_global_distrib.md
@@ -127,7 +127,7 @@ Global distribution modules expose several per-datacenter metrics that can be us
   A separate timer is maintained for every remote domain.
 * **disabled_gc_interval** (seconds, default: `60`): An interval between disabled endpoints "garbage collection".
   It means that disabled endpoints are periodically verified and if Global Distribution detects that connections is no longer alive, the connection pool is closed completely.
-* **tls_opts** (list, required): Options for TLS connections passed to the `fast_tls` driver.
+* **tls_opts** (list, required): Options for TLS connections passed to the `fast_tls` driver.<a name="tls_opts"></a>
   May be set to `false`, in which case all data will be sent via standard TCP connections.
   Otherwise, they should at least include `certfile` and `cafile` options.
 

--- a/doc/user-guide/ICE_tutorial/mongooseim.cfg
+++ b/doc/user-guide/ICE_tutorial/mongooseim.cfg
@@ -227,8 +227,7 @@
                         %% {ciphers, "TLSv1.2:TLSv1.3"},
                         {access, c2s},
                         {shaper, c2s_shaper},
-                        {max_stanza_size, 65536},
-                        {protocol_options, ["no_sslv3"]}
+                        {max_stanza_size, 65536}
 
                        ]},
 
@@ -246,8 +245,7 @@
 
   { 5269, ejabberd_s2s_in, [
                            {shaper, s2s_shaper},
-                           {max_stanza_size, 131072},
-                           {protocol_options, ["no_sslv3"]}
+                           {max_stanza_size, 131072}
 
                           ]}
 

--- a/doc/user-guide/ICE_tutorial/mongooseim.cfg
+++ b/doc/user-guide/ICE_tutorial/mongooseim.cfg
@@ -224,7 +224,7 @@
                         {certfile, "priv/ssl/fake_server.pem"}, starttls,
                         %%{zlib, 10000},
                         %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-                        %% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+                        %% {ciphers, "TLSv1.2:TLSv1.3"},
                         {access, c2s},
                         {shaper, c2s_shaper},
                         {max_stanza_size, 65536},
@@ -280,7 +280,7 @@
 {s2s_certfile, "priv/ssl/fake_server.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ pages:
       - 'Basic Configuration': 'Basic-configuration.md'
       - 'Erlang Cookie Security': 'Erlang-cookie-security.md'
       - 'Advanced Configuration': 'Advanced-configuration.md'
+      - 'TLS hardening': 'advanced-configuration/TLS-hardening.md'
       - 'Database backends configuration': 'advanced-configuration/database-backends-configuration.md'
       - 'Outgoing connections': 'advanced-configuration/outgoing-connections.md'
       - 'Extension Modules': 'advanced-configuration/Modules.md'

--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -16,7 +16,7 @@
 {http_api_endpoint, "{5389, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
-{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"DHE-RSA-AES256-SHA\"},"}.
+{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"ECDHE-RSA-AES256-GCM-SHA384\"},"}.
 {tls_module, ""}.
 {secondary_c2s, ""}.
 {http_api_old_endpoint, "{5293, \"127.0.0.1\"}"}.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -1,7 +1,12 @@
 [
  {setup, [{verify_directories, false}]},
  {{mongooseim_mdb_dir_toggle}}{mnesia, [{dir, "{{mongooseim_mdb_dir}}"}]},
- {ssl, [{session_lifetime, 600}]}, %% 10 minutes
+ {ssl, [
+        {session_lifetime, 600}, % 10 minutes
+        {protocol_version, ['tlsv1.2'
+                            %, 'tlsv1.3' % supported in OTP >= 22
+                           ]}
+       ]},
  {nkservice, [
     %% Variable is called log_path, however it is used for caching
     {log_path, "{{nksip_cache_dir}}"}

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -232,7 +232,7 @@
                         {{{tls_module}}}
                         {{{zlib}}}
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536},
@@ -283,7 +283,7 @@
 {{{s2s_certfile}}}
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -235,8 +235,7 @@
 			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
-			{max_stanza_size, 65536},
-			{protocol_options, ["no_sslv3"]}
+			{max_stanza_size, 65536}
                         {{{c2s_dhfile}}}
 		       ]},
 
@@ -254,8 +253,7 @@
 
   { {{{ejabberd_s2s_in_port}}}, ejabberd_s2s_in, [
 			   {shaper, s2s_shaper},
-			   {max_stanza_size, 131072},
-			   {protocol_options, ["no_sslv3"]}
+			   {max_stanza_size, 131072}
 			   {{{s2s_dhfile}}}
 			  ]}
 

--- a/rel/files/mongooseim.cfg.token-support
+++ b/rel/files/mongooseim.cfg.token-support
@@ -180,7 +180,7 @@
                         {certfile, "priv/ssl/fake_server.pem"}, starttls,
                         {zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -239,7 +239,7 @@
 {s2s_certfile, "priv/ssl/fake_server.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -26,7 +26,7 @@
 {http_api_client_endpoint, "8091"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
-{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"DHE-RSA-AES256-SHA\"},"}.
+{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"ECDHE-RSA-AES256-GCM-SHA384\"},"}.
 {tls_module, ""}.
 {secondary_c2s,
     "{5233, ejabberd_c2s, [
@@ -35,7 +35,7 @@
         {shaper, c2s_shaper},
         {max_stanza_size, 65536},
         {certfile, \"priv/ssl/fake_server.pem\"}, tls,
-        {ciphers, \"DHE-RSA-AES256-SHA\"}
+        {ciphers, \"ECDHE-RSA-AES256-GCM-SHA384\"}
     ]},"}.
 {ejabberd_service, ",{8899, ejabberd_service, [\n"
     "                {access, all},\n"

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -26,7 +26,7 @@
                 "]},"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
-{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"DHE-RSA-AES256-SHA\"},"}.
+{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"ECDHE-RSA-AES256-GCM-SHA384\"},"}.
 {tls_module, ""}.
 {secondary_c2s,
   "{5263, ejabberd_c2s, [
@@ -36,7 +36,7 @@
       {max_stanza_size, 65536},
       {certfile, \"priv/ssl/fake_server.pem\"}, tls,
       {tls_module, just_tls},
-      {ssl_options,[{ciphers, [{dhe_rsa,aes_256_cbc,sha}]}]}
+      {ssl_options,[{ciphers, [#{cipher => aes_256_gcm, key_exchange => ecdhe_rsa, mac => aead, prf => sha384}]}]}
   ]},"}.
 {http_api_old_endpoint, "{5292, \"127.0.0.1\"}"}.
 {http_api_endpoint, "{8092, \"127.0.0.1\"}"}.

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -24,7 +24,7 @@
 {http_api_endpoint, "{5389, \"127.0.0.1\"}"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
-{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"DHE-RSA-AES256-SHA\"},"}.
+{tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls, {ciphers, \"ECDHE-RSA-AES256-GCM-SHA384\"},"}.
 {secondary_c2s, ""}.
 {http_api_old_endpoint, "{5273, \"127.0.0.1\"}"}.
 {http_api_endpoint, "{8074, \"127.0.0.1\"}"}.

--- a/src/ejabberd_socket.erl
+++ b/src/ejabberd_socket.erl
@@ -158,7 +158,7 @@ connect(Addr, Port, Opts, Timeout) ->
 -spec tcp_to_tls(socket_state(), list()) -> ejabberd_tls:tls_socket().
 tcp_to_tls(#socket_state{receiver = Receiver}, TLSOpts) ->
     SanitizedTLSOpts = case lists:keyfind(protocol_options, 1, TLSOpts) of
-        false -> TLSOpts;
+        false -> [{protocol_options, "no_sslv2|no_sslv3|no_tlsv1|no_tlsv1_1"} | TLSOpts];
         {_, ProtoOpts} ->
             NewProtoOpts = {protocol_options, string:join(ProtoOpts, "|")},
             lists:keyreplace(protocol_options, 1, TLSOpts, NewProtoOpts)

--- a/src/global_distrib/mod_global_distrib_transport.erl
+++ b/src/global_distrib/mod_global_distrib_transport.erl
@@ -37,8 +37,12 @@ wrap(Socket, [connect | false]) ->
     wrap(Socket, false);
 wrap(Socket, false) ->
     {ok, #?MODULE{transport = gen_tcp, socket = Socket}};
-wrap(Socket, Opts) ->
-    case fast_tls:tcp_to_tls(Socket, Opts) of
+wrap(Socket, Opts0) ->
+    Opts1 = case proplists:get_value(ciphers, Opts0) of
+                undefined -> [{ciphers, "TLSv1.2:TLSv1.3"} | Opts0];
+                _ -> Opts0
+            end,
+    case fast_tls:tcp_to_tls(Socket, Opts1) of
         {ok, TLSSocket} -> {ok, #?MODULE{transport = fast_tls, socket = TLSSocket}};
         Error -> Error
     end.

--- a/test/cowboy_SUITE_data/mongooseim.onlyhttp.cfg
+++ b/test/cowboy_SUITE_data/mongooseim.onlyhttp.cfg
@@ -167,7 +167,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -222,7 +222,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/cowboy_SUITE_data/mongooseim.onlyws.cfg
+++ b/test/cowboy_SUITE_data/mongooseim.onlyws.cfg
@@ -167,7 +167,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -222,7 +222,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/ejabberd_config_SUITE_data/mongooseim.default.cfg
+++ b/test/ejabberd_config_SUITE_data/mongooseim.default.cfg
@@ -146,7 +146,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -201,7 +201,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/ejabberd_config_SUITE_data/mongooseim.split.cfg
+++ b/test/ejabberd_config_SUITE_data/mongooseim.split.cfg
@@ -163,7 +163,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -218,7 +218,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/ejabberd_config_SUITE_data/mongooseim.with_mod_offline.cfg
+++ b/test/ejabberd_config_SUITE_data/mongooseim.with_mod_offline.cfg
@@ -146,7 +146,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -201,7 +201,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/ejabberd_config_SUITE_data/mongooseim.with_mod_offline.different_opts.cfg
+++ b/test/ejabberd_config_SUITE_data/mongooseim.with_mod_offline.different_opts.cfg
@@ -146,7 +146,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -201,7 +201,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/revproxy_SUITE_data/mongooseim.norules.cfg
+++ b/test/revproxy_SUITE_data/mongooseim.norules.cfg
@@ -167,7 +167,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -222,7 +222,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.

--- a/test/revproxy_SUITE_data/mongooseim.onerule.cfg
+++ b/test/revproxy_SUITE_data/mongooseim.onerule.cfg
@@ -167,7 +167,7 @@
                         %%{certfile, "/path/to/ssl.pem"}, starttls,
                         %%{zlib, 10000},
 			%% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-			%% {ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"},
+			%% {ciphers, "TLSv1.2:TLSv1.3"},
 			{access, c2s},
 			{shaper, c2s_shaper},
 			{max_stanza_size, 65536}
@@ -222,7 +222,7 @@
 %%{s2s_certfile, "/path/to/ssl.pem"}.
 
 %% https://www.openssl.org/docs/apps/ciphers.html#CIPHER_STRINGS
-%% {s2s_ciphers, "DEFAULT:!EXPORT:!LOW:!SSLv2"}.
+%% {s2s_ciphers, "TLSv1.2:TLSv1.3"}.
 
 %%
 %% domain_certfile: Specify a different certificate for each served hostname.


### PR DESCRIPTION
Due to known vulnerabilities in 1.0 and 1.1.
