### PR TITLE
CI/stabilization sm

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -17,7 +17,7 @@
 
 -import(escalus_stanza, [setattr/3]).
 
--define(SHORT_RESUME_TIMEOUT, 5).
+-define(SHORT_RESUME_TIMEOUT, 3).
 -define(SMALL_SM_BUFFER, 3).
 
 %%--------------------------------------------------------------------
@@ -469,8 +469,8 @@ resend_unacked_after_resume_timeout(Config) ->
     U = proplists:get_value(username, AliceSpec),
     S = proplists:get_value(server, AliceSpec),
     1 = length(rpc(mim(), ejabberd_sm, get_user_resources, [U, S])),
-    %% wait 2 times longer to be sure that c2s is dead
-    ct:sleep({seconds, 2 * ?SHORT_RESUME_TIMEOUT}),
+    %% wait a bit longer to be sure that c2s is dead
+    ct:sleep({seconds, ?SHORT_RESUME_TIMEOUT + 1}),
     %% ensure there is no session
     0 = length(rpc(mim(), ejabberd_sm, get_user_resources, [U, S])),
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -261,8 +261,9 @@ too_many_unacked_stanzas(Config) ->
     {Bob, _} = given_fresh_user(Config, bob),
     {Alice, _} = given_fresh_user(Config, alice),
     escalus:wait_for_stanza(Alice), %% wait for ack request
-    Msg = escalus_stanza:chat_to(Alice, <<"Hi, Alice!">>),
-    [escalus:send(Bob, Msg) || _ <- lists:seq(1,?SMALL_SM_BUFFER)],
+    [escalus:send(Bob, escalus_stanza:chat_to(Alice,
+        <<(integer_to_binary(N))/binary, ": Hi, Alice!">>))
+     || N <- lists:seq(1,?SMALL_SM_BUFFER)],
     escalus:wait_for_stanzas(Alice, ?SMALL_SM_BUFFER * 2), % messages and ack requests
     escalus:assert(is_stream_error, [<<"resource-constraint">>,
                                      <<"too many unacked stanzas">>],

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -124,9 +124,9 @@ init_per_testcase(replies_are_processed_by_resumed_session = CN, Config) ->
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
-end_per_testcase(server_requests_ack_freq_2, Config) ->
+end_per_testcase(server_requests_ack_freq_2 = CN, Config) ->
     true = rpc(mim(), ?MOD_SM, set_ack_freq, [never]),
-    escalus:end_per_testcase(Config);
+    escalus:end_per_testcase(CN, Config);
 end_per_testcase(replies_are_processed_by_resumed_session = CN, Config) ->
     unregister_handler(<<"localhost">>),
     escalus:end_per_testcase(CN, Config);

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -801,19 +801,11 @@ replies_are_processed_by_resumed_session(Config) ->
 %% 7. Packet rerouting crashes on the buffered sub request, preventing resending whole buffer
 %% 8. B doesn't receive the buffered message
 subscription_requests_are_buffered_properly(Config) ->
-    AliceSpec = [{manual_ack, true}
-                 | escalus_fresh:create_fresh_user(Config, alice)],
-
+    AliceSpec = [{manual_ack, true} | escalus_fresh:create_fresh_user(Config, alice)],
     MsgBody = <<"buffered">>,
-    SubPredFun = fun(S) ->
-                         escalus_pred:is_presence_with_type(<<"subscribe">>, S)
-                 end,
-    AvailablePredFun = fun(S) ->
-                               escalus_pred:is_presence_with_type(<<"available">>, S)
-                       end,
-    MsgPredFun = fun(S) ->
-                         escalus_pred:is_chat_message(MsgBody, S)
-                 end,
+    SubPredFun = fun(S) -> escalus_pred:is_presence_with_type(<<"subscribe">>, S) end,
+    AvailablePredFun = fun(S) -> escalus_pred:is_presence_with_type(<<"available">>, S) end,
+    MsgPredFun = fun(S) -> escalus_pred:is_chat_message(MsgBody, S) end,
 
     escalus:fresh_story(Config, [{bob, 1}], fun(Bob) ->
         % GIVEN Bob's pending subscription to Alice's presence
@@ -840,7 +832,7 @@ subscription_requests_are_buffered_properly(Config) ->
         escalus_client:kill_connection(Config, Alice),
 
         % ...and reconnects with session replacement.
-        {ok, Alice2, _} = escalus_connection:start(AliceSpec),
+        {ok, Alice2, _} = escalus_connection:start(AliceSpec, connection_steps_to_session()),
 
         % THEN Alice receives (without sending initial presence):
         % * buffered available presence (because it's addressed to full JID)

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -108,7 +108,7 @@ init_per_group(_GroupName, Config) ->
 end_per_group(manual_ack_freq_long_session_timeout, Config) ->
     true = rpc(mim(), ?MOD_SM, set_ack_freq, [never]),
     Config;
-end_per_group(parallel_manual_ack, Config) ->
+end_per_group(parallel_manual_ack_freq_1, Config) ->
     true = rpc(mim(), ?MOD_SM, set_ack_freq, [never]),
     rpc(mim(), ?MOD_SM, set_resume_timeout, [600]),
     Config;

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1485,12 +1485,11 @@ terminate(_Reason, StateName, StateData) ->
     case {should_close_session(StateName), StateData#state.authenticated} of
         {false, _} ->
             ok;
-        %% if we are in an state wich have a session established
+        %% if we are in an state which has a session established
         {_, replaced} ->
             ?INFO_MSG("(~w) Replaced session for ~s",
                       [StateData#state.socket,
                        jid:to_binary(StateData#state.jid)]),
-            From = StateData#state.jid,
             StatusEl = #xmlel{name = <<"status">>,
                               children = [#xmlcdata{content = <<"Replaced by new connection">>}]},
             Packet = #xmlel{name = <<"presence">>,
@@ -1529,7 +1528,6 @@ terminate(_Reason, StateName, StateData) ->
                                               StateData#state.resource,
                                               normal);
                 _ ->
-                    From = StateData#state.jid,
                     Packet = #xmlel{name = <<"presence">>,
                                     attrs = [{<<"type">>, <<"unavailable">>}]},
                     Acc0 = element_to_origin_accum(Packet, StateData),


### PR DESCRIPTION
This PR proposes a stabilization of the stream management suite.

The problem was that, on stream replacement, the old c2s process was rerouting the messages at the same time the new c2s process is establishing the connection, making them race for the message delivery and often making the messages arrive out of order. I assume that in the case of replacement, the user most likely doesn't even have a feature for resumption, so if he wants old messages he'll probably just find them in the archive or so, but termination is not the place to rescue them, specially because of the race condition.

This also fixes all the tests that were expecting to receive these messages without explicitly requesting them, that is, executing the `resume` step with the stored `SIMD` and the last value of `h` acknowledged.

Also, I took the chance to clean the code a bit.
