### PR TITLE
Fix 'make console' for big tests

### DIFF
--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -27,9 +27,8 @@ COMMON_OPTS := -sname test -setcookie ejabberd -hidden \
                $(TLS_DIST_OPTS) \
                -env REPO_DIR "$(ABS_REPO_DIR)" \
                -env TEST_DIR "$(ABS_TEST_DIR)" \
-               -pa `pwd`/tests \
-                   `pwd`/ebin \
-                   `pwd`/_build/default/lib/*/ebin \
+               -pa `pwd`/_build/default/lib/*/ebin \
+                   `pwd`/tests \
                $(DEPS_PATHS)
 
 ifeq ($(shell uname), Linux)


### PR DESCRIPTION
This is a quickfix to a problem that I had while testing `metrics_api_SUITE`, for which @chrzaszcz got a solution. First of all the `pwd/ebin` folder does not exist, and second, tons of `{error, enoent}` were thrown because the paths were given in the wrong order and couldn't find what it was looking for. In my case it was the `*_data/` folders inside of `tests/`, which should have been the first folder in the _path_ (note that `-pa` appends the given paths one by one, hence, they end up kinda reverted in the _path_).

People might remember me complaining on our slack channel that I had to `rebar3 clean | make clean | git clean -fdx | git unicorn-blood | universe restart` to get the tests working again.