### PR TITLE
CircleCI parallel small tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,12 @@ orbs:
               name: Run Small Tests
               command: |
                 KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p small_tests -s true
+          - run:
+              name: Upload results
+              when: always
+              command: |
+                  tools/circleci-prepare-log-dir.sh
+                  if [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then tools/circleci-upload-to-s3.sh; fi
 
                 
       package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ orbs:
         environment:
           SKIP_RELEASE: 1
           SKIP_COV: 0
-          PRESET: small_tests
         working_directory: ~/app
 
         steps:
@@ -131,7 +130,7 @@ orbs:
           - run:
               name: Run Small Tests
               command: |
-                KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p $PRESET -s true
+                KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p small_tests -s true
 
                 
       package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ orbs:
               sudo apt-get install tdsodbc -y
               sudo apt-get install python-pip -y
     jobs:
-      build_and_small_tests:
+      build:
         parallelism: 1
         machine:
           image: ubuntu-1604:201903-01
@@ -67,16 +67,11 @@ orbs:
               key: deps-cache--{{ checksum "rebar.lock" }}--{{ checksum "big_tests/rebar.lock" }}--{{ checksum "otp_version" }}
               paths:
                 - ~/.cache/rebar3
-                - _build/default/lib
           - run: ./rebar3 compile
           - run:
               name: Make Certs
               command: |
                 make certs
-          - run:
-              name: Run Small Tests
-              command: |
-                KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p $PRESET -s true
           - run:
               name: Install Releases
               command: |
@@ -108,6 +103,36 @@ orbs:
               name: Run Dialyzer
               command: |
                 KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p dialyzer_only -s false
+
+      small-tests:
+        parallelism: 1
+        machine:
+          image: ubuntu-1604:201903-01
+        working_directory: ~/app
+        parameters:
+          otp:
+            type: string
+            description: Version of the Erlang package to install
+        steps:
+          - checkout
+          - fetch_packages
+          - install_erlang:
+              otp: <<parameters.otp>>
+          - run:
+              name: Prepare for cache
+              command: |
+                ./tools/circleci-otp-to-str.sh <<parameters.otp>> > otp_version
+          - restore_cache:
+              keys:
+                - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
+          - restore_cache:
+              keys:
+                - deps-cache--{{ checksum "rebar.lock" }}--{{ checksum "big_tests/rebar.lock" }}--{{ checksum "otp_version" }}
+          - run:
+              name: Run Small Tests
+              command: |
+                KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p $PRESET -s true
+
                 
       package:
         parallelism: 1
@@ -223,20 +248,30 @@ workflows:
           name: debian_stretch
           platform: debian_stretch
           context: mongooseim-org
-      - mim/build_and_small_tests:
-          name: otp_21_3_small_tests
+      - mim/build:
+          name: otp_21_3
           otp: 1:21.3.8.4-1
           context: mongooseim-org
-      - mim/build_and_small_tests:
-          name: otp_22_small_tests
+      - mim/build:
+          name: otp_22
           otp: 1:22.0.4-1
           context: mongooseim-org
+      - mim/small_tests:
+          name: small_tests_21_3
+          otp: 1:21.3.8.4-1
+          context: mongooseim-org
+          requires:
+            - otp_21_3
+      - mim/small_tests:
+          name: small_tests_22
+          otp: 1:22.0.4-1
+          context: mongooseim-org
+          requires:
+            - otp_22
       - mim/dialyzer:
           name: dialyzer
           otp: 1:22.0.4-1
           context: mongooseim-org
-          requires:
-            - otp_22_small_tests
       - mim/big_tests:
           name: mysql_redis
           otp: 1:21.3.8.4-1
@@ -244,7 +279,7 @@ workflows:
           db: mysql
           context: mongooseim-org
           requires:
-            - otp_21_3_small_tests
+            - otp_21_3
       - mim/big_tests:
           name: mssql_mnesia
           otp: 1:22.0.4-1
@@ -252,7 +287,7 @@ workflows:
           db: mssql
           context: mongooseim-org
           requires:
-            - otp_22_small_tests
+            - otp_22
       - mim/big_tests:
           name: ldap_mnesia
           otp: 1:22.0.4-1
@@ -260,7 +295,7 @@ workflows:
           db: mnesia
           context: mongooseim-org
           requires:
-            - otp_22_small_tests
+            - otp_22
       - mim/big_tests:
           name: internal_mnesia
           otp: 1:22.0.4-1
@@ -269,7 +304,7 @@ workflows:
           tls_dist: true
           context: mongooseim-org
           requires:
-            - otp_22_small_tests
+            - otp_22
       - mim/big_tests:
           name: elasticsearch_and_cassandra
           otp: 1:22.0.4-1
@@ -277,7 +312,7 @@ workflows:
           db: "elasticsearch cassandra"
           context: mongooseim-org
           requires:
-            - otp_22_small_tests
+            - otp_22
       - mim/big_tests:
           name: pgsql_mnesia
           otp: 1:21.3.8.4-1
@@ -285,7 +320,7 @@ workflows:
           db: pgsql
           context: mongooseim-org
           requires:
-            - otp_21_3_small_tests
+            - otp_21_3
       - mim/big_tests:
           name: riak_mnesia
           otp: 1:21.3.8.4-1
@@ -293,4 +328,4 @@ workflows:
           db: riak
           context: mongooseim-org
           requires:
-            - otp_21_3_small_tests
+            - otp_21_3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ orbs:
               command: |
                 KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p dialyzer_only -s false
 
-      small-tests:
+      small_tests:
         parallelism: 1
         machine:
           image: ubuntu-1604:201903-01


### PR DESCRIPTION
- We can run small tests and big tests in parallel. It makes more sense assuming we will not have limit for concurrent jobs, hopefully soon
We can **save up to 8 mins** for whole build
- Run dialyzer parallel to builds. It doesnt need releases installed. Not saving total time but we can know faster if the specs are broken