### PR TITLE
reg*.log added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ deps.log
 dialyzer
 configure.out
 ejd-redis.conf
+reg*.log
 fed*.log
 mim*.log
 node*.log


### PR DESCRIPTION
This thing was not added to gitignore and it gets a bit annoying to have git all the time telling me there's an untracked file and having to be careful not to add it accidentally and ahh... Just gitignore it!