### PR TITLE
"fix" test in global_distrib_SUITE

### DIFF
--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -582,6 +582,9 @@ test_pm_with_graceful_reconnection_to_different_server(Config) ->
     escalus_users:delete_users(Config, [{eve, [{port, 5222} | EveSpec]}]).
 
 test_pm_with_ungraceful_reconnection_to_different_server(Config0) ->
+%% This tests the feature which has not been implemented (yet?) by mod_global_distrib
+%% Can be either turned off or removed
+%% See PR #2392
     Config = escalus_users:update_userspec(Config0, eve, stream_management, true),
     EveSpec = escalus_fresh:create_fresh_user(Config, eve),
     EveSpec2 = lists:keystore(port, 1, EveSpec, {port, 5222}),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -583,7 +583,7 @@ test_pm_with_graceful_reconnection_to_different_server(Config) ->
 
 test_pm_with_ungraceful_reconnection_to_different_server(Config0) ->
 %% This tests the feature which has not been implemented (yet?) by mod_global_distrib
-%% Can be either turned off or removed
+%% It is susceptible to a race condition, however it is very unlikely to occur
 %% See PR #2392
     Config = escalus_users:update_userspec(Config0, eve, stream_management, true),
     EveSpec = escalus_fresh:create_fresh_user(Config, eve),
@@ -910,7 +910,7 @@ refresh_node(NodeName, Config) ->
 connect_from_spec(UserSpec, Config) ->
     {ok, User} = escalus_client:start(Config, UserSpec, <<"res1">>),
     escalus_story:send_initial_presence(User),
-              escalus:wait_for_stanza(User),
+    escalus:wait_for_stanza(User),
     escalus_connection:set_filter_predicate(User, fun(S) -> not escalus_pred:is_presence(S) end),
     User.
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -54,7 +54,7 @@ groups() ->
            test_hidden_component_disco_in_different_region,
            test_pm_with_disconnection_on_other_server,
            test_pm_with_graceful_reconnection_to_different_server,
-           test_pm_with_ungraceful_reconnection_to_different_server,
+%%           test_pm_with_ungraceful_reconnection_to_different_server, % PR #2391
            test_global_disco,
            test_component_unregister,
            test_update_senders_host,

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -54,7 +54,7 @@ groups() ->
            test_hidden_component_disco_in_different_region,
            test_pm_with_disconnection_on_other_server,
            test_pm_with_graceful_reconnection_to_different_server,
-%%           test_pm_with_ungraceful_reconnection_to_different_server, % PR #2391
+           test_pm_with_ungraceful_reconnection_to_different_server,
            test_global_disco,
            test_component_unregister,
            test_update_senders_host,
@@ -907,6 +907,7 @@ refresh_node(NodeName, Config) ->
 connect_from_spec(UserSpec, Config) ->
     {ok, User} = escalus_client:start(Config, UserSpec, <<"res1">>),
     escalus_story:send_initial_presence(User),
+              escalus:wait_for_stanza(User),
     escalus_connection:set_filter_predicate(User, fun(S) -> not escalus_pred:is_presence(S) end),
     User.
 


### PR DESCRIPTION
First issue:
After sending initial presence to the server's we were not waiting till it is sent back the the client.

Solving the above issue makes the race condition described below even MORE unlikely to happen.
Still, `mod_global_distrib` does not support the feature which is tested in `test_pm_with_ungraceful_reconnection_to_different_server`  and it (the feature) is not trivial to implement. 

When race condition happens:

1. Eve’s process is killed on cluster 1.
2. Alice sends a message to Eve.
3. Eve connects to cluster 2. Entry in Redis from C1 is overwritten by C2.
4. The session/routing table is refreshed on C1. Since Eve’s session is still present there, entry from C2 is overwritten by C1.
5. The message is not delivered to C2, as it is supposed to (it goes to C1 instead).

It fails only if refresh of routing/session table of C1 happens just after the client reconnects.
If we modify `refresh_after` parameter and set it to be significantly longer on C2 than on C1 then the test always fails. 

We should decide what to do with the test (turn it off/delete/leave it) @fenek 
