### PR TITLE
Fix hometree_specific group

### DIFF
--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -642,9 +642,10 @@ decode_affiliations(IQResult) ->
 
 pubsub_node() -> pubsub_node(1).
 pubsub_node(Num) ->
-    {pubsub_tools:node_addr(), <<"node_",
-                                 (integer_to_binary(Num))/binary, "_",
-                                 (base64:encode(crypto:strong_rand_bytes(6)))/binary>>}.
+    Name = <<"node_", (integer_to_binary(Num))/binary, "_",
+             (base64:encode(crypto:strong_rand_bytes(6)))/binary>>,
+    SanitizedName = binary:replace(Name, <<"/">>, <<".">>, [global]),
+    {pubsub_tools:node_addr(), SanitizedName}.
 
 domain() ->
     ct:get_config({hosts, mim, domain}).


### PR DESCRIPTION
Hometree consideres the character "/" as a path divider. When pubsub_node() creates a random name, it can indeed use this character, and hence randomly make hometree consider the path longer than expected and hence returning an auth failure.