### PR TITLE
Fix/push integration tests

### DIFF
--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -42,10 +42,6 @@ init(Req, State) ->
     {ok, Body, Req2} = cowboy_req:read_body(Req),
     [{_, Subscriber}] = ets:lookup(mongoose_push_mock_subscribers, Token),
     Subscriber ! {push_request, Token, Body},
-
     Req3 = cowboy_req:reply(204, #{}, <<>>, Req2),
     {ok, Req3, State}.
-
-
-
 

--- a/big_tests/tests/push_helper.erl
+++ b/big_tests/tests/push_helper.erl
@@ -8,7 +8,7 @@
 -export([enable_stanza/2, enable_stanza/3, enable_stanza/4,
          disable_stanza/1, disable_stanza/2]).
 
--export([become_unavailable/1, become_available/2]).
+-export([become_unavailable/1, become_available/3, become_available/2]).
 
 -export([ns_push/0, ns_pubsub_pub_options/0, push_form_type/0, make_form/1]).
 
@@ -66,9 +66,11 @@ become_unavailable(Client) ->
     {ok, _} = wait_for_user_offline(Client).
 
 become_available(Client, NumberOfUnreadMessages) ->
+    become_available(Client, NumberOfUnreadMessages, 5000).
+become_available(Client, NumberOfUnreadMessages, Timeout) ->
     escalus:send(Client, escalus_stanza:presence(<<"available">>)),
     Preds = [ is_presence | lists:duplicate(NumberOfUnreadMessages, is_message) ],
-    Stanzas = escalus:wait_for_stanzas(Client, NumberOfUnreadMessages + 1),
+    Stanzas = escalus:wait_for_stanzas(Client, NumberOfUnreadMessages + 1, Timeout),
     escalus:assert_many(Preds, Stanzas),
     {ok, true} = wait_for_user_online(Client).
 

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -368,8 +368,7 @@ muclight_aff_change(Config, Service, EnableOpts) ->
                                        [{body, <<"First!">>}, {unread_count, 2}, {badge, 2}]),
 
               when_muc_light_affiliations_are_set(Alice, Room, [{Bob, member}]),
-              escalus:wait_for_stanza(Alice),
-              escalus:wait_for_stanza(Bob),
+              muc_light_helper:verify_aff_bcast([{Bob, member}, {Alice, owner}], [{Bob, member}]),
 
               muclight_conversation(Alice, RoomJID, <<"Second!">>),
               escalus:wait_for_stanza(Alice),
@@ -535,7 +534,7 @@ required_modules() ->
         ]},
         {mod_muc_light, [
             {host, binary_to_list(?MUCHOST)},
-            {backend, rdbms},
+            {backend, mongoose_helper:mnesia_or_rdbms_backend()},
             {rooms_in_rosters, true}
         ]},
         {mod_inbox, inbox_opts()}

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -7,7 +7,7 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("inbox.hrl").
 
--define(MUCHOST,                        <<"muclight.@HOST@">>).
+-define(MUCHOST, <<"muclight.localhost">>).
 
 
 
@@ -292,14 +292,14 @@ muclight_inbox_msg_unread_count(Config, Service, EnableOpts) ->
               SenderJID = muclight_conversation(Alice, RoomJID, <<"First!">>),
               Notification = wait_for_push_request(KateToken),
               assert_push_notification(Notification, Service, EnableOpts, SenderJID,
-                                       [{body, <<"First!">>}, {unread_count, 2}, {badge, 2}]),
+                                       [{body, <<"First!">>}, {unread_count, 1}, {badge, 1}]),
 
               muclight_conversation(Alice, RoomJID, <<"Second!">>),
               escalus:wait_for_stanza(Alice),
 
               Notification2 = wait_for_push_request(KateToken),
               assert_push_notification(Notification2, Service, EnableOpts, SenderJID,
-                                       [{body, <<"Second!">>}, {unread_count, 3}, {badge, 2}]),
+                                       [{body, <<"Second!">>}, {unread_count, 2}, {badge, 1}]),
 
               timer:sleep(1000),
               become_available(Kate, 0),
@@ -307,7 +307,7 @@ muclight_inbox_msg_unread_count(Config, Service, EnableOpts) ->
               muclight_conversation(Alice, RoomJID, <<"Third!">>),
               escalus:wait_for_stanza(Kate),
               escalus:wait_for_stanza(Alice),
-              inbox_helper:check_inbox(Kate, [#conv{unread = 4, from = SenderJID, to = KateJid, content = <<"Third!">>}]),
+              inbox_helper:check_inbox(Kate, [#conv{unread = 3, from = SenderJID, to = KateJid, content = <<"Third!">>}]),
             ok
       end).
 
@@ -386,17 +386,18 @@ muclight_aff_change(Config, Service, EnableOpts) ->
 %%
               Notification = wait_for_push_request(KateToken),
               assert_push_notification(Notification, Service, EnableOpts, SenderJID,
-                                       [{body, <<"First!">>}, {unread_count, 2}, {badge, 2}]),
+                                       [{body, <<"First!">>}, {unread_count, 1}, {badge, 1}]),
 %%
               {_, Aff} = when_muc_light_affiliations_are_set(Alice, Room, [{Bob, member}]),
               then_muc_light_affiliations_are_received_by([Alice, Bob], {Room, Aff}),
               escalus:wait_for_stanza(Alice),
+
               {_, B2, M2} = when_muc_light_message_is_sent(Alice, Room, <<"Second!">>, <<"M2">>),
               then_muc_light_message_is_received_by([Alice, Bob], {Room, B2, M2}),
 
               Notification2 = wait_for_push_request(KateToken),
               assert_push_notification(Notification2, Service, EnableOpts, SenderJID,
-                                       [{body, <<"Second!">>}, {unread_count, 4}, {badge, 2}]),
+                                       [{body, <<"Second!">>}, {unread_count, 2}, {badge, 1}]),
 
             ok
       end).

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -21,7 +21,7 @@
          then_archive_response_is/3]).
 
 -import(escalus_ejabberd, [rpc/3]).
--import(push_helper, [enable_stanza/3, become_unavailable/1, become_available/2]).
+-import(push_helper, [enable_stanza/3, become_unavailable/1, become_available/3, become_available/2]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -395,12 +395,8 @@ muclight_aff_change(Config, Service, EnableOpts) ->
               then_muc_light_message_is_received_by([Alice, Bob], {Room, B2, M2}),
 
               Notification2 = wait_for_push_request(KateToken),
-              assert_push_notification(Notification2, Service, EnableOpts, RoomJID,
-                                       [{body, <<>>}, {unread_count, 3}, {badge, 3}]),
-
-              Notification3 = wait_for_push_request(KateToken),
-              assert_push_notification(Notification3, Service, EnableOpts, SenderJID,
-                                       [{body, <<"Second!">>}, {unread_count, 4}, {badge, 3}]),
+              assert_push_notification(Notification2, Service, EnableOpts, SenderJID,
+                                       [{body, <<"Second!">>}, {unread_count, 4}, {badge, 2}]),
 
             ok
       end).

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -295,23 +295,18 @@ muclight_inbox_msg_unread_count(Config, Service, EnableOpts) ->
               KateToken = enable_push_for_user(Kate, Service, EnableOpts),
 
               SenderJID = muclight_conversation(Alice, RoomJID, <<"First!">>),
+              escalus:wait_for_stanza(Alice),
               Notification = wait_for_push_request(KateToken),
               assert_push_notification(Notification, Service, EnableOpts, SenderJID,
                                        [{body, <<"First!">>}, {unread_count, 1}, {badge, 1}]),
 
               muclight_conversation(Alice, RoomJID, <<"Second!">>),
-
+              escalus:wait_for_stanza(Alice),
               Notification2 = wait_for_push_request(KateToken),
               assert_push_notification(Notification2, Service, EnableOpts, SenderJID,
                                        [{body, <<"Second!">>}, {unread_count, 2}, {badge, 1}]),
 
-              mongoose_helper:wait_until(fun() ->
-                                                 become_available(Kate, 0)
-                                         end,
-                                         {ok, true},
-                                         #{sleep_time => 50,
-                                           time_left => timer:seconds(1),
-                                           name => available}),
+              {ok, true} = become_available(Kate, 0),
 
               muclight_conversation(Alice, RoomJID, <<"Third!">>),
               escalus:wait_for_stanza(Kate),

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -301,14 +301,14 @@ muclight_inbox_msg_unread_count(Config, Service, EnableOpts) ->
               assert_push_notification(Notification2, Service, EnableOpts, SenderJID,
                                        [{body, <<"Second!">>}, {unread_count, 2}, {badge, 1}]),
 
-              timer:sleep(1000),
-              become_available(Kate, 0),
-
+              mongoose_helper:wait_until(fun() ->
+                                                 become_available(Kate, 1)
+                                         end, true,
+                                         #{sleep_time => 500, time_left => timer:seconds(20), name => available}),
               muclight_conversation(Alice, RoomJID, <<"Third!">>),
               escalus:wait_for_stanza(Kate),
               escalus:wait_for_stanza(Alice),
-              inbox_helper:check_inbox(Kate, [#conv{unread = 3, from = SenderJID, to = KateJid, content = <<"Third!">>}]),
-            ok
+              inbox_helper:check_inbox(Kate, [#conv{unread = 3, from = SenderJID, to = KateJid, content = <<"Third!">>}])
       end).
 
 send_private_message(Sender, Recipient) ->
@@ -358,8 +358,7 @@ muclight_msg_notify_on_fcm(Config, EnableOpts) ->
             SenderJID = muclight_conversation(Alice, RoomJID, <<"Heyah!">>),
             Notification = wait_for_push_request(DeviceToken),
             assert_push_notification(Notification, <<"fcm">>,
-                                     EnableOpts, SenderJID, [{body, <<"Heyah!">>}, {unread_count, 1}, {badge, 1}]),
-    ok
+                                     EnableOpts, SenderJID, [{body, <<"Heyah!">>}, {unread_count, 1}, {badge, 1}])
         end).
 
 muclight_aff_change(Config, Service, EnableOpts) ->
@@ -381,11 +380,11 @@ muclight_aff_change(Config, Service, EnableOpts) ->
 
               {Room, Body, M1} = when_muc_light_message_is_sent(Alice, Room, <<"First!">>, <<"M1">>),
               then_muc_light_message_is_received_by([Alice], {Room, Body, M1}),
-%%
+
               Notification = wait_for_push_request(KateToken),
               assert_push_notification(Notification, Service, EnableOpts, SenderJID,
                                        [{body, <<"First!">>}, {unread_count, 1}, {badge, 1}]),
-%%
+
               {_, Aff} = when_muc_light_affiliations_are_set(Alice, Room, [{Bob, member}]),
               then_muc_light_affiliations_are_received_by([Alice, Bob], {Room, Aff}),
               escalus:wait_for_stanza(Alice),
@@ -395,9 +394,8 @@ muclight_aff_change(Config, Service, EnableOpts) ->
 
               Notification2 = wait_for_push_request(KateToken),
               assert_push_notification(Notification2, Service, EnableOpts, SenderJID,
-                                       [{body, <<"Second!">>}, {unread_count, 2}, {badge, 1}]),
+                                       [{body, <<"Second!">>}, {unread_count, 2}, {badge, 1}])
 
-            ok
       end).
 
 


### PR DESCRIPTION
DONE
- Extension of MUC Light/push notification tests
- Fix: no PN is sent when the body is empty

Proposed changes to be done include:
1. Add more values as `change_aff` option of `mod_inbox`:
- `false` (do not store affiltiotion messages
- `true` (store all affiliation messages
- `user` (store only affiliations which apply to the user)

2. Add option in `mod_exent_pusher_push_plugin` to enable/disable push notifications
after the list of members of a room is changed.