### PR TITLE
Fix error handling in silent_exec when VERBOSE=1

### DIFF
--- a/tools/silent_exec.sh
+++ b/tools/silent_exec.sh
@@ -7,6 +7,8 @@
 # Env variables:
 # - VERBOSE=0 (default) - hide command output, forward output into file
 # - VERBOSE=1 - forward command output to console and into file
+set -e
+
 TOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 OUT_FILE="$1"
@@ -28,7 +30,14 @@ echo "LOG: $OUT_ABSNAME/$OUT_BASENAME"
 echo ""
 
 if [ "$VERBOSE" = "1" ]; then
-    $@ 2>&1 | tee "$OUT_FILE" || exit 1
+    # Returns the same error as $@
+    echo "" > "$OUT_FILE"
+    tail -f "$OUT_FILE" &
+    tail_pid=$!
+    exit_code=0
+    $@ 2>&1 > "$OUT_FILE" || exit_code=$?
+    kill $tail_pid
+    exit $exit_code
 else
     $@ > "$OUT_FILE" 2>&1 || (cat "$OUT_FILE"; exit 1)
 fi


### PR DESCRIPTION
tee was always returning 0

This PR addresses:

Before:

```
~/erlang/mim_july|master $ VERBOSE=1 ./tools/silent_exec.sh cat nonono
RUN: nonono
LOG: /Users/mikhailuvarov/erlang/mim_july/cat

./tools/silent_exec.sh: line 31: nonono: command not found
~/erlang/mim_july|master $ echo "$?"
0 # This is wrooong



~/erlang/mim_july|master $ VERBOSE=0 ./tools/silent_exec.sh cat nonono
RUN: nonono
LOG: /Users/mikhailuvarov/erlang/mim_july/cat

./tools/silent_exec.sh: line 33: nonono: command not found
~/erlang/mim_july|master $ echo "$?"
1
```


After:

```
VERBOSE=1 ./tools/silent_exec.sh cat nonono
RUN: nonono
LOG: /Users/mikhailuvarov/erlang/mim_july/cat

./tools/silent_exec.sh: line 38: nonono: command not found
~/erlang/mim_july|fix-exit-code-handling-in-silent-exec $ echo "$?"
127
```

