### PR TITLE
Improve ct_markdown_errors hook

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -147,6 +147,8 @@ run_tests() {
   echo "Running big tests (big_tests)"
   echo "############################"
 
+  rm -f /tmp/ct_summary
+
   time ${TOOLS}/start-nodes.sh || { echo "Failed to start MongooseIM nodes"; return 1; }
 
   maybe_pause_before_test
@@ -180,6 +182,12 @@ run_tests() {
     [ $BIG_STATUS -ne 0 ]   && echo "    big tests failed - missing suites (error code: $BIG_STATUS)"
     [ $LOG_STATUS -ne 0 ]   && echo "    log contains errors"
     print_running_nodes
+  fi
+
+  if [ -f /tmp/ct_summary ]; then
+      echo "Failed big cases:"
+      cat /tmp/ct_summary
+      echo ""
   fi
 
   # Do not stop nodes if big tests failed


### PR DESCRIPTION
This PR addresses:
old version of ct_markdown_errors_hook does not include all groups.
mam_SUITE uses a lot of subgroups.

Proposed changes include:
* properly handle groups - show complete testcase paths
* create summary_file with failed tests, so we can use this one to restart tests (done separately)


Let's compare testcase format before and after:
before: mam_SUITE:muc_rsm04:pagination_simple_before10
after: mam_SUITE:rdbms_async_pool_muc_all:muc_rsm_all:muc_rsm04:pagination_simple_before10