### PR TITLE
Reduce memory usage for dev MongooseIM VMs

### DIFF
--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -7,6 +7,7 @@
 {s2s_addr, "{ {s2s_addr, \"localhost\"}, {127,0,0,1} }. { {s2s_addr, \"localhost.bis\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {node_name, "fed1@localhost"}.
+{highload_vm_args, ""}.
 {ejabberd_c2s_port, 5242}.
 {ejabberd_s2s_in_port, 5299}.
 {cowboy_port, 5282}.

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -19,10 +19,8 @@
 ## Enable kernel poll and a few async threads
 +K true
 +A 5
-+P 10000000
 
-## Increase number of concurrent ports/sockets
--env ERL_MAX_PORTS 250000
+{{highload_vm_args}}
 
 ## Tweak GC to run more often
 -env ERL_FULLSWEEP_AFTER 2

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -13,6 +13,8 @@
 {s2s_addr, "{ {s2s_addr, \"fed1\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {node_name, "mongooseim@localhost"}.
+% Disable highload args to save memory for dev builds
+{highload_vm_args, ""}.
 {ejabberd_c2s_port, 5222}.
 {secondary_c2s,
     "{ 5223, ejabberd_c2s, [

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -8,6 +8,7 @@
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {node_name, "ejabberd2@localhost"}.
+{highload_vm_args, ""}.
 {ejabberd_c2s_port, 5232}.
 {ejabberd_s2s_in_port, 5279}.
 {cowboy_port, 5281}.

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -8,6 +8,7 @@
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {node_name, "mongooseim3@localhost"}.
+{highload_vm_args, ""}.
 {ejabberd_c2s_port, 5262}.
 {ejabberd_s2s_in_port, 5291}.
 {cowboy_port, 5283}.

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -10,6 +10,7 @@
 {s2s_addr, "{ {s2s_addr, \"localhost\"}, {127,0,0,1} }. { {s2s_addr, \"localhost.bis\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {node_name, "reg1@localhost"}.
+{highload_vm_args, ""}.
 {ejabberd_c2s_port, 5252}.
 {ejabberd_s2s_in_port, 5298}.
 {cowboy_port, 5272}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -5,6 +5,9 @@
 {s2s_default_policy, deny}.
 {outgoing_s2s_port, 5269}.
 {node_name, "mongooseim@localhost"}.
+% More processes and more ports.
+% But it increases memory usage.
+{highload_vm_args, "+P 10000000 -env ERL_MAX_PORTS 250000"}.
 {ejabberd_c2s_port, 5222}.
 {ejabberd_s2s_in_port, 5269}.
 {cowboy_port, 5280}.


### PR DESCRIPTION
Disable high-performance, high-memory usage Erlang VM options for dev builds

This PR addresses high memory usage of dev mongooseim VMs and slow start.

Proposed changes include:
* less memory usage by tweaking vm-args.