### PR TITLE
Rename scram to mongoose_scram to avoid name clashes with escalus

### DIFF
--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -67,7 +67,7 @@
               passterm/0]).
 
 -type authmodule() :: module().
--type passterm() :: binary() | scram:scram_tuple().
+-type passterm() :: binary() | mongoose_scram:scram_tuple().
 
 -define(METRIC(Name), [backends, auth, Name]).
 

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -24,7 +24,7 @@
 %%%
 %%%----------------------------------------------------------------------
 
--module(scram).
+-module(mongoose_scram).
 
 -author('stephen.roettger@googlemail.com').
 
@@ -130,7 +130,7 @@ password_to_scram(#scram{} = Password, _) ->
 password_to_scram(Password, IterationCount) ->
     Salt = crypto:strong_rand_bytes(?SALT_LENGTH),
     SaltedPassword = salted_password(Password, Salt, IterationCount),
-    StoredKey = stored_key(scram:client_key(SaltedPassword)),
+    StoredKey = stored_key(client_key(SaltedPassword)),
     ServerKey = server_key(SaltedPassword),
     #scram{storedkey = base64:encode(StoredKey),
            serverkey = base64:encode(ServerKey),

--- a/src/sasl/cyrsasl_scram.erl
+++ b/src/sasl/cyrsasl_scram.erl
@@ -86,13 +86,13 @@ mech_step(#state{step = 2} = State, ClientIn) ->
                                                    TempSalt =
                                                    crypto:strong_rand_bytes(?SALT_LENGTH),
                                                    SaltedPassword =
-                                                   scram:salted_password(Ret,
-                                                                         TempSalt,
-                                                                         scram:iterations()),
-                                                   {scram:stored_key(scram:client_key(SaltedPassword)),
-                                                    scram:server_key(SaltedPassword),
+                                                   mongoose_scram:salted_password(Ret,
+                                                                                  TempSalt,
+                                                                                  mongoose_scram:iterations()),
+                                                   {mongoose_scram:stored_key(mongoose_scram:client_key(SaltedPassword)),
+                                                    mongoose_scram:server_key(SaltedPassword),
                                                     TempSalt,
-                                                    scram:iterations()}
+                                                    mongoose_scram:iterations()}
                                             end,
                                             {NStart, _} = binary:match(ClientIn, <<"n=">>),
                                             ClientFirstMessageBare = binary:part(ClientIn,
@@ -149,15 +149,15 @@ mech_step(#state{step = 4} = State, ClientIn) ->
                                                             binary:part(ClientIn, 0, PStart)
                                                            ]),
                                            ClientSignature =
-                                           scram:client_signature(State#state.stored_key,
-                                                                  AuthMessage),
-                                           ClientKey = scram:client_key(ClientProof,
-                                                                        ClientSignature),
-                                           CompareStoredKey = scram:stored_key(ClientKey),
+                                           mongoose_scram:client_signature(State#state.stored_key,
+                                                                           AuthMessage),
+                                           ClientKey = mongoose_scram:client_key(ClientProof,
+                                                                                 ClientSignature),
+                                           CompareStoredKey = mongoose_scram:stored_key(ClientKey),
                                            if CompareStoredKey == State#state.stored_key ->
                                                   ServerSignature =
-                                                  scram:server_signature(State#state.server_key,
-                                                                         AuthMessage),
+                                                  mongoose_scram:server_signature(State#state.server_key,
+                                                                                  AuthMessage),
                                                   R = [{username, State#state.username},
                                                        {sasl_success_response,
                                                         <<"v=", (jlib:encode_base64(ServerSignature))/binary>>},

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -142,7 +142,7 @@ try_register(_Config) ->
 
 % get_password + get_password_s
 get_password(_Config) ->
-    case scram:enabled(?DOMAIN1) of
+    case mongoose_scram:enabled(?DOMAIN1) of
         false ->
             <<"makota">> = ejabberd_auth_http:get_password(<<"alice">>, ?DOMAIN1),
             <<"makota">> = ejabberd_auth_http:get_password_s(<<"alice">>, ?DOMAIN1);
@@ -206,7 +206,7 @@ meck_cleanup() ->
 do_scram(Pass, Config) ->
     case lists:keyfind(scram_group, 1, Config) of
         {_, true} ->
-            scram:serialize(scram:password_to_scram(Pass, scram:iterations(?DOMAIN1)));
+            mongoose_scram:serialize(mongoose_scram:password_to_scram(Pass, mongoose_scram:iterations(?DOMAIN1)));
         _ ->
             Pass
     end.


### PR DESCRIPTION
There are two _different_ scram modules:

in mongooseim - https://github.com/esl/MongooseIM/blob/8e0d3e2d35f73921ec7d2343ceb803b091bc781a/src/scram.erl
in escalus - https://github.com/esl/escalus/blob/master/src/scram.erl

Which cause conflicts, if you try to load escalus into mongooseim.

As a developer, I want to resolve name conflict.



(it blocks compilation of cover modules, done from the CT node)