### PR TITLE
Reduce exometer memory usage for dev builds

### DIFF
--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -34,3 +34,4 @@
 {mongooseim_mdb_dir_toggle, "%"}.
 {mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.
+{extra_metrics_options, "{extra_metrics_options, [{min_heap_size,1}]}."}.

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -650,7 +650,7 @@
 
 {all_metrics_are_global, {{{all_metrics_are_global}}} }.
 
-{extra_metrics_options, [{min_heap_size,1}]}.
+{{{extra_metrics_options}}}
 
 {{{cowboy_server_name}}}
 

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -650,6 +650,8 @@
 
 {all_metrics_are_global, {{{all_metrics_are_global}}} }.
 
+{extra_metrics_options, [{min_heap_size,1}]}.
+
 {{{cowboy_server_name}}}
 
 %%%.   ========

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -81,3 +81,5 @@
 {mongooseim_mdb_dir_toggle, "%"}.
 {mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.
+
+{extra_metrics_options, "{extra_metrics_options, [{min_heap_size,1}]}."}.

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -56,3 +56,5 @@
 {mongooseim_mdb_dir_toggle, "%"}.
 {mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.
+
+{extra_metrics_options, "{extra_metrics_options, [{min_heap_size,1}]}."}.

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -53,3 +53,5 @@
 {mongooseim_mdb_dir_toggle, "%"}.
 {mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.
+
+{extra_metrics_options, "{extra_metrics_options, [{min_heap_size,1}]}."}.

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -41,3 +41,5 @@
 {mongooseim_mdb_dir_toggle, "%"}.
 {mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.
+
+{extra_metrics_options, "{extra_metrics_options, [{min_heap_size,1}]}."}.


### PR DESCRIPTION
This PR addresses high memory usage of exometer.

Proposed changes include:
* extra_metrics_options argument
* ask exometer to not set its own min_heap_size value.
