### PR TITLE
Properly detect that redis is not running in ejabberd_sm_SUITE

### DIFF
--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -78,7 +78,7 @@ init_redis_group(true, Config) ->
                   Self ! ready,
                   receive stop -> ok end
           end),
-    receive ready -> ok end,
+    receive ready -> ok after timer:seconds(30) -> ct:fail(test_helper_not_ready) end,
     [{backend, ejabberd_sm_redis} | Config];
 init_redis_group(_, _) ->
     {skip, "redis not running"}.


### PR DESCRIPTION
The old way would not work, if redis is running in docker

Proposed changes include:
* Use eredis_client instead of ps to check if redis is running

