### PR TITLE
Compile cover once

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -177,10 +177,11 @@
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.
-{coveralls_coverdata, "_build/**/cover/*.coverdata"}.
+{coveralls_coverdata, "/tmp/mongoose_combined.coverdata"}.
 {coveralls_service_name, "circle-ci"}.
 
 {codecov_opts,
  [
-  {path, ["_build/**/cover"]}
+  %% Assuming /tmp/mongoose_combined.coverdata
+  {path, ["/tmp"]}
  ]}.


### PR DESCRIPTION
Proposed changes include:
* Properly detect ct_run directory in run_common_test
* Let cover to handle compiling and loading coverage once on all nodes

after: Cover compilation took 27.896 seconds
before: Cover compilation took 168.034 seconds (Also Cover compilation took 103.721 seconds)


There should be no modules with the same name used both in mim and tests.
Otherwise  similar errors are possible: https://github.com/arcusfelis/MongooseIM/pull/53#issuecomment-519278689 (it's without renaming scram module)

It also fixes elasticsearch job failing issue https://travis-ci.org/arcusfelis/MongooseIM/builds/569276362