### PR TITLE
Cache built deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ before_install:
         # Always use git protocol for github - tiny optimization
         - git config --global url."git://github".insteadOf https://github
 install:
-        - test 1 = "$SKIP_COMPILE" || ./tools/cache-build.sh restore
-        - test 1 = "$SKIP_BUILD_TESTS" || ./tools/cache-tests.sh restore
-        - test 1 = "$SKIP_COMPILE" || ./tools/cache-certs.sh restore
+        # Make full build for Cron builds
+        - test cron = "$TRAVIS_EVENT_TYPE" -o 1 = "$SKIP_COMPILE"     || ./tools/cache-build.sh restore
+        - test cron = "$TRAVIS_EVENT_TYPE" -o 1 = "$SKIP_BUILD_TESTS" || ./tools/cache-tests.sh restore
+        - test cron = "$TRAVIS_EVENT_TYPE" -o 1 = "$SKIP_COMPILE"     || ./tools/cache-certs.sh restore
         - test 1 = "$SKIP_COMPILE" || travis_retry ./rebar3 get-deps
           ## Certs are needed by some tests in small_tests
         - test 1 = "$SKIP_COMPILE" || make certs

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,18 @@ before_install:
         # Always use git protocol for github - tiny optimization
         - git config --global url."git://github".insteadOf https://github
 install:
+        - test 1 = "$SKIP_COMPILE" || ./tools/cache-build.sh restore
+        - test 1 = "$SKIP_BUILD_TESTS" || ./tools/cache-tests.sh restore
+        - test 1 = "$SKIP_COMPILE" || ./tools/cache-certs.sh restore
         - test 1 = "$SKIP_COMPILE" || travis_retry ./rebar3 get-deps
           ## Certs are needed by some tests in small_tests
         - test 1 = "$SKIP_COMPILE" || make certs
         - test 1 = "$SKIP_RELEASE" || ./tools/build-releases.sh
         - test 1 = "$SKIP_BUILD_TESTS" || tools/travis-build-tests.sh
         - test 1 = "$SKIP_COV" || travis_retry pip install --user codecov
+        - test 1 = "$SKIP_COMPILE" || ./tools/cache-build.sh store
+        - test 1 = "$SKIP_BUILD_TESTS" || ./tools/cache-tests.sh store
+        - test 1 = "$SKIP_COMPILE" || ./tools/cache-certs.sh store
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
@@ -123,6 +129,10 @@ notifications:
 cache:
         directories:
                 - $HOME/.cache/rebar3
+                - $HOME/.cache/mim_builds
+                - $HOME/.cache/mim_tests
+                - $HOME/.cache/mim_certs
+
 
 # deploy:
 #   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
         - test 1 = "$SKIP_RELEASE" || ./tools/build-releases.sh
         - test 1 = "$SKIP_BUILD_TESTS" || tools/travis-build-tests.sh
         - test 1 = "$SKIP_COV" || travis_retry pip install --user codecov
+          # Update cache if needed and if build step succeded.
         - test 1 = "$SKIP_COMPILE" || ./tools/cache-build.sh store
         - test 1 = "$SKIP_BUILD_TESTS" || ./tools/cache-tests.sh store
         - test 1 = "$SKIP_COMPILE" || ./tools/cache-certs.sh store

--- a/tools/cache-build.sh
+++ b/tools/cache-build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Travis packs all cache directories into one archive for caching.
+# So, we put files into tar, not tar.gz to improve compression
+# (because the files are shared between mongooseim and big_tests)
+
+set -e
+CACHE_DIR=~/.cache/mim_builds
+
+## Use array assignment to get just hash without filename
+## https://stackoverflow.com/a/5773761
+SHA_ARRAY=($(cat "rebar.config" "rebar.lock" | shasum))
+SHA_HASH=$(echo $SHA_ARRAY)
+
+EXT=.tar
+TMP_FILE=/tmp/mim_cache
+
+echo "SHA_HASH=$SHA_HASH"
+
+ARCHIVE_FILE=$CACHE_DIR/${SHA_HASH}${EXT}
+
+if [ "$1" = 'restore' ]; then
+    if test -f "$ARCHIVE_FILE"; then
+        echo "Build cache found, restore"
+        tar xf "$ARCHIVE_FILE"
+    fi
+elif [ "$1" = 'store' ]; then
+    if ! test -f "$ARCHIVE_FILE"; then
+        rm -f "$TMP_FILE"
+        tar \
+            --exclude='_build/default/mongooseim' \
+            -cf "$TMP_FILE" "_build/default/"
+        mkdir -p "$CACHE_DIR"
+        # Remove any previous files to preserve space
+        rm -f "$CACHE_DIR/*"
+        mv "$TMP_FILE" "$ARCHIVE_FILE"
+    fi
+fi

--- a/tools/cache-certs.sh
+++ b/tools/cache-certs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Travis packs all cache directories into one archive for caching.
+# So, we put files into tar, not tar.gz to improve compression
+# (because the files are shared between mongooseim and big_tests)
+
+set -e
+CACHE_DIR=~/.cache/mim_certs
+
+# Get hash of last commit in tools/ssl
+SHA_HASH=$(cd tools/ssl && git log -1 --pretty=format:"%h" --abbrev=40 .)
+
+EXT=.tar
+TMP_FILE=/tmp/mim_cache
+
+echo "SHA_HASH=$SHA_HASH"
+
+ARCHIVE_FILE=$CACHE_DIR/${SHA_HASH}${EXT}
+
+if [ "$1" = 'restore' ]; then
+    if test -f "$ARCHIVE_FILE"; then
+        echo "Build cache found, restore"
+        tar xf "$ARCHIVE_FILE"
+    fi
+elif [ "$1" = 'store' ]; then
+    if ! test -f "$ARCHIVE_FILE"; then
+        rm -f "$TMP_FILE"
+        tar \
+            -cf "$TMP_FILE" "tools/ssl"
+        mkdir -p "$CACHE_DIR"
+        # Remove any previous files to preserve space
+        rm -f "$CACHE_DIR/*"
+        mv "$TMP_FILE" "$ARCHIVE_FILE"
+    fi
+fi

--- a/tools/cache-tests.sh
+++ b/tools/cache-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Travis packs all cache directories into one archive for caching.
+# So, we put files into tar, not tar.gz to improve compression
+# (because the files are shared between mongooseim and big_tests)
+
+set -e
+CACHE_DIR=~/.cache/mim_tests
+
+## Use array assignment to get just hash without filename
+## https://stackoverflow.com/a/5773761
+SHA_ARRAY=($(cat "big_tests/rebar.config" "big_tests/rebar.lock" | shasum))
+SHA_HASH=$(echo $SHA_ARRAY)
+
+EXT=.tar
+TMP_FILE=/tmp/mim_cache
+
+echo "SHA_HASH=$SHA_HASH"
+
+ARCHIVE_FILE=$CACHE_DIR/${SHA_HASH}${EXT}
+
+if [ "$1" = 'restore' ]; then
+    if test -f "$ARCHIVE_FILE"; then
+        echo "Build cache found, restore"
+        tar xf "$ARCHIVE_FILE"
+    fi
+elif [ "$1" = 'store' ]; then
+    if ! test -f "$ARCHIVE_FILE"; then
+        rm -f "$TMP_FILE"
+        tar \
+            --exclude='_build/default/lib/ejabberd_tests' \
+            -cf "$TMP_FILE" "_build/default/"
+        mkdir -p "$CACHE_DIR"
+        # Remove any previous files to preserve space
+        rm -f "$CACHE_DIR/*"
+        mv "$TMP_FILE" "$ARCHIVE_FILE"
+    fi
+fi


### PR DESCRIPTION
This PR addresses "we don't need to recompile deps each build".

Proposed changes include:
* Cache binaries of deps based on hash of our configs
* Each job has its own cache
* We would assume, that job uses cache of a parent
* Allow full builds during crons to detect possible problems with missing deps, for example
* Changes in rebar.config or rebar.lock would invalidate cache