### PR TITLE
Always return success status code for sending codecov in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ orbs:
                 sudo pip install codecov && codecov
                 ./rebar3 codecov analyze
                 codecov --disable=gcov --env PRESET
-                ./rebar3 coveralls send
+                ./rebar3 coveralls send || true
           - run:
               name: Build Failed - Logs
               when: on_fail


### PR DESCRIPTION
Due to error that happens:
```
<h2>This website is under heavy load (queue full)</h2><p>We're sorry, too many people are accessing this website at the same time. We're working on this problem. Please try again later.</p>
```

We should just ignore that error

