### PR TITLE
Don't compile tests twice on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ orbs:
           - run:
               name: Build package
               command: |
-                KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p pkg -s false
+                SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p pkg -s false
       big_tests:
         parallelism: 1
         machine:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
         - if [ $PRESET = 'mysql_redis' ]; then sudo tools/travis-setup-rmq.sh; fi
 script:
-    - KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET -s $RUN_SMALL_TESTS
+    - SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET -s $RUN_SMALL_TESTS
 
 after_failure:
         - cat `ls -1 -d -t apps/ejabberd/logs/ct_run* | head -1`/apps.ejabberd.logs/run.*/suite.log

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -87,6 +87,7 @@
 %% * ensure preset value is passed to ct Config
 %% * check server's purity after SUITE
 {ct_hooks, [ct_groups_summary_hook, ct_tty_hook, ct_mongoose_hook, ct_progress_hook,
+            ct_mim_config_hook,
             ct_markdown_errors_hook,
             {ct_mongoose_log_hook, [ejabberd_node, ejabberd_cookie]},
             {ct_mongoose_log_hook, [ejabberd2_node, ejabberd_cookie]}

--- a/big_tests/mam.spec
+++ b/big_tests/mam.spec
@@ -26,6 +26,7 @@
 %% * check server's purity after SUITE
 {ct_hooks, [ct_groups_summary_hook, ct_tty_hook, ct_mongoose_hook, ct_progress_hook,
             ct_markdown_errors_hook,
+            ct_mim_config_hook,
             {ct_mongoose_log_hook, [ejabberd_node, ejabberd_cookie]},
             {ct_mongoose_log_hook, [ejabberd2_node, ejabberd_cookie]}
            ]}.

--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -206,6 +206,7 @@ preset_names(Presets) ->
 
 do_run_quick_test(Test, CoverOpts) ->
     prepare_cover(Test, CoverOpts),
+    load_test_modules(Test),
     Result = ct:run_test(Test),
     case Result of
         {error, Reason} ->
@@ -218,6 +219,7 @@ do_run_quick_test(Test, CoverOpts) ->
 
 run_config_test({Name, Variables}, Test, N, Tests) ->
     enable_preset(Name, Variables, Test, N, Tests),
+    load_test_modules(Test),
     Result = ct:run_test([{label, Name} | Test]),
     case Result of
         {error, Reason} ->
@@ -610,4 +612,38 @@ ct_opts() ->
             [{auto_compile, false}];
         _ ->
             []
+    end.
+
+
+%% Common Tests does not try to use code autoloading feature
+%% for loading suites.
+%% So, if we want to use SKIP_AUTO_COMPILE, we need to put tests, where Common tests
+%% can find it. Or we can load modules instead (what we do here).
+load_test_modules(Opts) ->
+    Spec = proplists:get_value(spec, Opts),
+    %% Read test spec properties
+    Props = read_file(Spec),
+    Modules = lists:usort(test_modules(Props)),
+    [try_load_module(M) || M <- Modules].
+
+test_modules([H|T]) when is_tuple(H) ->
+    test_modules_list(tuple_to_list(H)) ++ test_modules(T);
+test_modules([_|T]) ->
+    test_modules(T);
+test_modules([]) ->
+    [].
+
+test_modules_list([suites, _, Suite|_]) ->
+    [Suite];
+test_modules_list([groups, _, Suite|_]) ->
+    [Suite];
+test_modules_list([cases, _, Suite|_]) ->
+    [Suite];
+test_modules_list(_) ->
+    [].
+
+try_load_module(Module) ->
+    case code:is_loaded(Module) of
+        true -> already_loaded;
+        _ -> code:load_file(Module)
     end.

--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -145,7 +145,7 @@ tests_to_run(TestSpec) ->
     TestSpecFile = atom_to_list(TestSpec),
     [
      {spec, TestSpecFile}
-    ].
+    ] ++ ct_opts().
 
 save_count(Test, Configs) ->
     Repeat = case proplists:get_value(repeat, Test) of
@@ -599,4 +599,15 @@ anaylyze_groups_runs(LatestCTRun) ->
       {error, Error} ->
             error_logger:error_msg("Error reading all_groups.summary: ~p~n", [Error]),
             undefined
+    end.
+
+
+ct_opts() ->
+    %% Tell Common Tests that it should not compile any more files
+    %% (they are compiled by rebar)
+    case os:getenv("SKIP_AUTO_COMPILE") of
+        "true" ->
+            [{auto_compile, false}];
+        _ ->
+            []
     end.

--- a/big_tests/src/ct_mim_config_hook.erl
+++ b/big_tests/src/ct_mim_config_hook.erl
@@ -1,0 +1,34 @@
+-module(ct_mim_config_hook).
+
+%% @doc Add the following line in your *.spec file to enable
+%% fixes for Common Tests for your common tests:
+%% {ct_hooks, [ct_mim_config_hook]}.
+
+%% Callbacks
+-export([id/1]).
+-export([init/2]).
+-export([pre_init_per_suite/3]).
+-record(state, { }).
+
+%% @doc Return a unique id for this CTH.
+id(_Opts) ->
+    ?MODULE_STRING ++ "_001".
+
+%% @doc Always called before any other callback function. Use this to initiate
+%% any common state.
+init(_Id, _Opts) ->
+    {ok, #state{  }}.
+
+%% Fix data_dir for init_per_suite function
+pre_init_per_suite(SuiteName, Config, State) ->
+    {fix_data_dir(SuiteName, Config), State}.
+
+%% Common tests set data dir based on beam source file attribute.
+%% Which makes us care, where the file has been compiled and makes
+%% us less portable.
+%% Lets set out own data_dir.
+%% Be aware, CT would try to set data_dir over and over again,
+%% so to be safe we use new mim_data_dir option instead.
+fix_data_dir(SuiteName, Config) ->
+    DataDir = path_helper:data_dir(SuiteName, Config),
+    [{mim_data_dir, DataDir}|Config].

--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -128,7 +128,7 @@ message_altered_by_filter_local_packet_hook(Config) ->
         end).
 
 acc_test_helper_code(Config) ->
-    Dir = proplists:get_value(data_dir, Config),
+    Dir = proplists:get_value(mim_data_dir, Config),
     F = filename:join(Dir, "acc_test_helper.erl"),
     {ok, Code} = file:read_file(F),
     binary_to_list(Code).

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -110,7 +110,7 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 init_per_suite(Config) ->
-    Cwd0 = escalus_config:get_config(data_dir, Config),
+    Cwd0 = escalus_config:get_config(mim_data_dir, Config),
     CwdTokens = string:tokens(Cwd0, "/"),
     Cwd =  [$/ | string:join(lists:sublist(CwdTokens, 1, length(CwdTokens)-2), "/")],
     TemplatePath = Cwd ++ "/roster.template",

--- a/big_tests/tests/katt_helper.erl
+++ b/big_tests/tests/katt_helper.erl
@@ -70,7 +70,7 @@ start_apps([App|Tail]=All, Acc) ->
 
 blueprint(Name, Config) ->
     File = atom_to_list(Name) ++ ".apib",
-    filename:join([?config(data_dir, Config), File]).
+    filename:join([?config(mim_data_dir, Config), File]).
 
 failed_transactions(Results) ->
     lists:filtermap(fun

--- a/big_tests/tests/path_helper.erl
+++ b/big_tests/tests/path_helper.erl
@@ -5,6 +5,7 @@
 -export([test_dir/1]).
 -export([ct_run_dir/1]).
 -export([ct_run_dir_in_browser/1]).
+-export([data_dir/2]).
 
 %% Path transformation
 -export([canonicalize_path/1]).
@@ -13,11 +14,11 @@
 repo_dir(Config) ->
     get_env_var("REPO_DIR").
 
-%% @doc Get `test.disabled/ejabberd_tests/' directory
+%% @doc Get `big_tests/' directory
 test_dir(Config) ->
     get_env_var("TEST_DIR").
 
-%% @doc Returns`test.disabled/ejabberd_tests/ct_report/ct_run.*' directory
+%% @doc Returns`big_tests/ct_report/ct_run.*' directory
 %% Run it from a test case functions only (not group or suite functions)
 ct_run_dir(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
@@ -45,3 +46,7 @@ get_env_var(VarName) ->
         Value ->
             Value
     end.
+
+%% Hand-made data_dir from Common Tests
+data_dir(SuiteName, Config) ->
+    filename:join([test_dir(Config), "tests", atom_to_list(SuiteName) ++ "_data"]).

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -323,7 +323,7 @@ generate_certs(C) ->
     [{certs, maps:from_list(Certs)} | C].
 
 generate_cert(C, #{cn := User} = CertSpec) ->
-    ConfigTemplate = filename:join(?config(data_dir, C), "openssl-user.cnf"),
+    ConfigTemplate = filename:join(?config(mim_data_dir, C), "openssl-user.cnf"),
     {ok, Template} = file:read_file(ConfigTemplate),
     XMPPAddrs = maps:get(xmpp_addrs, CertSpec, undefined),
     TemplateValues = prepare_template_values(User, XMPPAddrs),
@@ -347,7 +347,7 @@ generate_ca_signed_cert(C, User, UserConfig, UserKey ) ->
     {done, 0, _Output} = erlsh:run(Cmd),
 
     UserCert = filename:join(?config(priv_dir, C), User ++ "_cert.pem"),
-    SignCmd = filename:join(?config(data_dir, C), "sign_cert.sh"),
+    SignCmd = filename:join(?config(mim_data_dir, C), "sign_cert.sh"),
     Cmd2 = [SignCmd, "--req", UserCsr, "--out", UserCert],
     LogFile = filename:join(?config(priv_dir, C), User ++ "signing.log"),
     SSLDir = filename:join([path_helper:repo_dir(C), "tools", "ssl"]),


### PR DESCRIPTION
This PR speeds up compilation by allowing travis to use test files, already compiled by rebar3.

Proposed changes include:
* SKIP_AUTO_COMPILE=true variable to tell ct to not compile anything
* some linking and copying (because ct and rebar don't like each other haha).

