### PR TITLE
Pull database images in parallel with compiling on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
         # used in MUC + s2s tests combination
         - muc.localhost
 before_install:
+        - nohup ./tools/travis-pull-db.sh > travis-pull-db.log 2>&1 < /dev/null &
         # Do not execute this step, if environment variable SKIP_RELEASE is "1"
         # Configure is a part of release creation
         - test 1 = "$SKIP_RELEASE" || tools/configure $REL_CONFIG
@@ -57,6 +58,7 @@ after_success:
           fi
 
 after_script:
+        - cat travis-pull-db.log
         # Upload logs to s3 for debugging
         - test 1 = "$SKIP_REPORT_UPLOAD" ||
             tools/travis-prepare-log-dir.sh

--- a/tools/travis-pull-db.sh
+++ b/tools/travis-pull-db.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Environment variable DB is used by this script.
+# If DB is undefined, than this script does nothing.
+
+# Docker for Mac should be used on Mac (not docker-machine!)
+# https://store.docker.com/editions/community/docker-ce-desktop-mac
+
+set -e
+TOOLS=`dirname $0`
+
+source tools/travis-common-vars.sh
+
+# Default cassandra version
+CASSANDRA_VERSION=${CASSANDRA_VERSION:-3.9}
+
+# Default ElasticSearch version
+ELASTICSEARCH_VERSION=${ELASTICSEARCH_VERSION:-5.6.9}
+
+function setup_db(){
+db=${1:-none}
+echo "Pulling up db: $db"
+
+if [ "$db" = 'mysql' ]; then
+    docker image pull mysql
+
+elif [ "$db" = 'pgsql' ]; then
+    docker image pull postgres
+
+elif [ "$db" = 'riak' ]; then
+    docker image pull "michalwski/docker-riak:1.0.6"
+
+elif [ "$db" = 'cassandra' ]; then
+    docker image pull cassandra:${CASSANDRA_VERSION}
+    docker image pull emicklei/zazkia
+
+elif [ "$db" = 'elasticsearch' ]; then
+    docker image pull docker.elastic.co/elasticsearch/elasticsearch:$ELASTICSEARCH_VERSION
+
+elif [ "$db" = 'mssql' ]; then
+    docker image pull microsoft/mssql-server-linux
+
+elif [ "$db" = 'redis' ]; then
+    docker image pull redis
+
+elif [ "$db" = 'ldap' ]; then
+    docker image pull openfrontier/openldap-server
+
+else
+    echo "Skip setting up database"
+fi
+}
+
+# The DB env var may contain single value "mysql"
+# or list of values separated with a space "elasticsearch cassandra"
+# in case of list of values all listed database will be set up (or at least tried)
+
+for db in ${DB}; do
+    setup_db $db
+done

--- a/tools/travis-pull-db.sh
+++ b/tools/travis-pull-db.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Environment variable DB is used by this script.
-# If DB is undefined, than this script does nothing.
+# If DB is undefined, then this script does nothing.
 
 # Docker for Mac should be used on Mac (not docker-machine!)
 # https://store.docker.com/editions/community/docker-ce-desktop-mac


### PR DESCRIPTION
This PR addresses "build parallelization".

Proposed changes include:
* while we compiling, we can also pull database images.
* rabbitmq is not handled. Planning to do it after moving code for ldap, redis and rabbit into travis-setup-db as a separate step
* Do magic in a separate `tools/travis-pull-db.sh`, because doing it in setup-db would make that script even more unfriendly.