### PR TITLE
Simplify and augment content (WIP)

### DIFF
--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -1,22 +1,19 @@
+In this short guide we will set MongooseIM up and get your users chatting right away.
+This will guide also you through basic operation, and validation.
+Training and getting to know MongooseIM is the goal here.
+This setup is not intended for production.
+
 ## Installation
 
-In this short guide we will set MongooseIM up and get your users chatting right away.
-You can either compile everything from the source code or install binaries from a package.
+We recommand, you install mongooseIM binaries from a package Erlang Solutions delivers.
 
-### Install from source code
+Alternatively, check out our tutorial [How to build MongooseIM from source code](How-to-build.md) for an introduction to compiling, building and testing MongooseIM.
 
-Check out our tutorial [How to build MongooseIM from source code](How-to-build.md) for an introduction to compiling, building and testing MongooseIM.
-
-### Install from package
+### Download a package
 
 Go to the [downloads](https://www.erlang-solutions.com/resources/download.html) section of the Erlang Solution website, and choose the version of MongooseIM you want. The following sections describe the installation process for different operating systems.
 
-#### Mac
-
-Once the DMG is downloaded, double click it and the contents of the package will open.
-Double click the .pkg file and follow the instructions of the installation wizard.
-
-#### Ubuntu
+### Ubuntu and Debian
 
 Once the deb file is downloaded, open a terminal window and navigate to the directory containing the package. Use the following command to unpack and install MongooseIM:
 
@@ -24,9 +21,9 @@ Once the deb file is downloaded, open a terminal window and navigate to the dire
 $ sudo dpkg -i mongooseim_[version here].deb
 ```
 
-#### CentOS
+### CentOS
 
-An ODBC driver must be installed on your machine to unpack and install from rpm packages. Enter the following command in a terminal window to install the latest unixODBC driver:
+An ODBC (RDBMS) driver must be installed on your machine to unpack and install from rpm packages. Enter the following command in a terminal window to install the latest unixODBC driver:
 ```bash
 $ sudo yum install unixODBC
 ```
@@ -35,106 +32,238 @@ Once the rpm file is downloaded, open a terminal window and navigate to the dire
 $ sudo rpm -i mongooseim_[version here].rpm
 ```
 
-## Running MongooseIM installed from package
+## Running MongooseIM
+
+MongooseIM will use its default database Mnesia, which is faster and simpler tu setup, but not intended for production purposes.
+
+Please note that it is possible at anytime to use external databases, check at the end of this guide.
 
 The following command will start the MongooseIM server:
 ```bash
 $ mongooseimctl start
 ```
-The following command shows the status of a started MongooseIM server:
-```bash
-$ mongooseimctl status
-```
+
 Use the following command to stop the MongooseIM server:
 ```bash
 $ mongooseimctl stop
 ```
+This takes a few seconds.
 
-Alternatively, you can also run the server in the interactive mode:
+At any given time, the following command shows the status of a MongooseIM server:
+```bash
+$ mongooseimctl status
+```
+If the command replies `nodedown` then MongooseIM is not running.
+If MongooseIM is properly running, it will show its version.
+
+Alternatively, you can also launch the server in the interactive mode:
 ```bash
 $ mongooseimctl live
 ```
+This will allow you to better detect and understand the errors in the configuration.
+When MongooseIM is properly running, the Erlang shell/console is then shown.
+Just type twice Control-C to exit, the server will then be shut down.
 
 For running MongooseIM in a non-interactive way within a supervision system (e.g. systemd) it is
 recommended to use the foreground mode:
 ```bash
 $ mongooseimctl foreground
 ```
+Typing Control-C will stop the server.
 
-## Registering a user
+## Chat users
+
+### Registering (creating) a user
 
 The default XMPP domain served by MongooseIM right after installation is `localhost`.
-Users on a different computer can register using the server’s IP address.
 
 You can register a user with the `mongooseimctl` utility.
-This command registers a user with a random username part of the jid.
-```
-mongooseimctl register domain password
-```
 
-And the following one registers the user `user@domain` using password `password`.
+This command registers the user `user@domain` using password `password`.
 ```
 mongooseimctl register_identified user domain password
 ```
+Example:
+```
+mongooseimctl register_identified alice localhost qwerty
+mongooseimctl register_identified bob localhost 12345678
+mongooseimctl register_identified carol localhost abc123
+```
 
-## Connecting with an XMPP client
+You can check that it has correctly been created:
+```
+mongooseimctl check_account user host
+```
+Example:
+```
+mongooseimctl check_account alice localhost
+mongooseimctl check_account bob localhost
+mongooseimctl check_account carol localhost
+```
 
-### Adium (Mac)
+Now you can list all registered users in your host:
+```
+mongooseimctl registered_users host
+```
+Example:
+```
+mongooseimctl registered_users localhost
+```
 
-1. Launch Adium. If the Adium Setup Assistant opens, close it.
-2. In the **Adium** menu, select **Preferences**, and then select the **Accounts** tab.
-3. Click the **+** button and select **XMPP (Jabber)**.
-4. Enter a Jabber ID (for example, “user1@localhost”) and password, and then click **Register New Account**.
-5. In the **Server** field, enter the following:
-	* users registering on the computer on which MongooseIM is running: `localhost`,
-	* users registering from a different computer: the MongooseIM server’s IP address.
-6. Click **Request New Account**.
+### Populate their contact lists (rosters)
 
-After registration, the user will connect automatically.
+Fo a given user (`localuser` and `localserver`), add a contact (`user` and `server`):
+```
+mongooseimctl add_rosteritem localuser localserver user server nick group subs 
+```
+Example:
+```
+mongooseimctl add_rosteritem alice localhost bob localhost bob friends both
+mongooseimctl add_rosteritem bob localhost alice localhost alice friends both
+```
 
-Registered users wishing to add an existing account to Adium should enter the MongooseIM server’s IP address in the **Connect Server** field on the **Options** tab.
+Verify the contact list:
+```
+mongooseimctl get_roster user host 
+```
+Example:
+```
+mongooseimctl get_roster alice localhost
+mongooseimctl get_roster bob localhost
+```
 
-### Pidgin (Ubuntu & CentOS)
+## Basic MongooseIM configuration
 
-1. Launch Pidgin.
-2. Click the Add button to configure your account.
-3. In the **Basic** tab choose **XMPP** as protocol, then enter Username, Domain and Password and click **Add**. After Registration the user will connect automatically.
+You can edit the `mongooseim.cfg` file:
+```
+/etc/mongooseim/mongooseim.cfg 
+```
 
-### Gajim (Ubuntu & CentOS)
+We recommand you do not touch the advanced settings at this stage.
+For each change, save (and optionally backup) the configuration file and restart the MongooseIM server.
 
-The following steps assumes that you have already registered a user on the MongooseIM server, see section **Registering a user** above.
+### Logging
+
+Change your own loglevel:
+```erlang
+% {loglevel, 3}.
+{loglevel, 4}.
+```
+
+Restart and check your loglevel from the command line:
+```
+mongooseimctl get_loglevel
+```
+
+Read the `ejabberd.log` file:
+```
+/var/log/mongooseim/ejabberd.log
+```
+
+You can use commands such `cat`, `more` or `less`, even `head` or `tail`.
+In order to see live logs:
+```
+tail -f /var/log/mongooseim/ejabberd.log
+```
+
+### MUC (Multi-User Chat) for groupchats
+
+Enable MUC (Multi-User Chat) for groupchats in the `mongooseim.cfg` file:
+```erlang
+{mod_muc, [{host, "muc.@HOST@"},
+           {access, muc},
+           {access_create, muc_create}
+          ]},
+```
+
+### Roster versionning
+
+For faster contact list downloads at each (re)connection:
+```erlang
+{mod_roster, [
+              {versioning, true},
+              {store_current_id, true}
+             ]}
+```
+
+## Using an XMPP client/app
+
+The following steps uses the registered users on the MongooseIM server, done above.
+
+Users that are registered on your server can now add their accounts in a chat application like Gajim (specifying either the server’s IP address or domain name), and start chatting!
+
+### Connect Gajim
+
+Gajim is available on Ubuntu, CentOS & Windows.
+
+Warning: Gajim has largely obsolete UX
+Gajim is still maintained, and has console that is extremely useful for debugging and testing/validation purposes.
+
 1. Launch Gajim. Ignore the window with Plugin updates.
 2. Go to Edit -> Accounts.
 3. Click Add in the left part of the window and select **I already have an account I want to use**, click Forward
 4. Enter the user, domain and password for the already registered account, click Forward and then Finish.
 5. Close the Account window.
 
-## Domains
+Repeat for `alice`, `bob`, and `carol`.
 
-To use your system’s domain name instead of localhost, edit the MongooseIM configuration file: `MongooseIM/_build/prod/rel/mongooseim/etc/mongooseim.cfg`.
-Find and replace the line:
+### Chat with another person
 
-```erlang
-{hosts, ["localhost"] }.
+Use `alice`'s account to send messages directly to `bob` and `carol.
+Use `bob`'s account to send messages directly to `alice` and `carol`.
+Use `carol`'s account to send messages directly to `alice` and `bob`.
+
+TODO
+
+### Group chats
+
+Use `alice`'s account to create a groupchat on your `muc.localhost` service, and invite`bob` and `carol.
+
+TODO
+
+### Contact lists
+
+Use `carol`'s account to add `alice` and `bob` to her contact list.
+
+Use `alice`'s and `bob`'s accounts accept those additions.
+
+Verify on the MongooseIM server:
+```
+mongooseimctl get_roster carol localhost
 ```
 
-using your own hostname, for example:
+TODO
 
-```erlang
-{hosts, ["example.org"] }.
+### Profile (vCard)
+
+Use `alice`'s account to edit her user's profile (vCard).
+
+Verify on the MongooseIM server:
+```
+mongooseimctl get_vcard carol host name
 ```
 
-Save the configuration file and restart the MongooseIM server.
-A user's Jabber ID will then contain the new domain instead of localhost, for example: `user1@example.org`.
-Note that existing user accounts will not be automatically migrated to the new domain.
+TODO
 
-You can also configure multiple domains for one server:
+## Verify on MongooseIM side
 
-```erlang
-{hosts, ["example1.org", "example2.org"] }.
+Check what users are currently connected:
+```
+mongooseimctl connected_users_info
 ```
 
+Send a direct chat message from a user to another:
+```
+mongooseimctl send_message_chat from to body
+```
+Example:
+```
+mongooseimctl send_message_chat alice bob hello
+```
+Check in your app/client that the message has well been received.
 
-## Get chatting!
+```
+mongooseimctl stats
+```
 
-Users that are registered on your server can now add their accounts in a chat application like Adium (specifying either the server’s IP address or domain name), add each other as contacts, and start chatting!
+TODO


### PR DESCRIPTION
* Linearise and simplify the process, lighten this doc:
    * Removed the installation from source (just kept the pointer to the compilation doc), as it is too painful for a beginner
    * Removed Adium and Pidgin, as both are hugely obsolete, and do not support properly the open standards (libpurple)
    * Removed domain config, as users do not have one yet for such a stage
* Removed the macOS section
    * Mac OS X instead of macOS
    * in https://www.erlang-solutions.com/resources/download.html the 2.0.0 is the latest version, which highly obsolete
    => I suggest to remove this "Mac OS X" section in the downloads page (Windows is not here), as it is misleading
* Moved intro upper in its own section, added precision (operation and validation)
* Added info about default Mnesia DB
* Added basic info on operations: start, stop, status, live, foreground
* Moved MIM config before client setup
* Populate users' contact lists (rosters) from MIM and from client/app
* Logs config and checking
* Enable MUC, Multi-User Chat (groupchats)
* Enable roster versionning
* Play with client/app: one-to-one chats, group chats, and profile (vCard)
* Check connected users, vcards from MIM

TODO
* Lots of `TODO` left...

Suggestions:
* maybe use Psi or Psi+ instead of Gajim, because Gajim does not work on macOS, Psi/Psi+ support macOS, Windows, Linux
* remove this "Mac OS X" section in the downloads page of ESL's website
* next step would be to clean accounts, configure RDBMS and MAM, re-create and validate accounts

This PR addresses #

Proposed changes include:
* describe the functionality changes
* describe new or updated tests
* describe changes to the documentation

