### PR TITLE
Update OTP versions matrix for Travis and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ orbs:
             name: Install basic packages
             command: |
               sudo killall -9 apt-get || true && \
+              sudo apt-get update && \
               sudo apt-get install unixodbc-dev -y && \
               sudo apt-get install unixodbc -y && \
               sudo apt-get install tdsodbc -y && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      # ============= PACKAGES =============
       - mim/package:
           name: centos7
           platform: centos7
@@ -255,57 +256,63 @@ workflows:
           name: debian_stretch
           platform: debian_stretch
           context: mongooseim-org
+      # ============= BASE BUILDS =============
+      - mim/build:
+          name: otp_20_3
+          otp: 1:20.3.8.22-1
+          context: mongooseim-org
       - mim/build:
           name: otp_21_3
-          otp: 1:21.3.8.4-1
+          otp: 1:21.3.8.6-1
           context: mongooseim-org
       - mim/build:
           name: otp_22
-          otp: 1:22.0.4-1
+          otp: 1:22.0.7-1
           context: mongooseim-org
+      # ============= SMALL TESTS =============
+      - mim/small_tests:
+          name: small_tests_20_3
+          otp: 1:20.3.8.22-1
+          context: mongooseim-org
+          requires:
+            - otp_20_3
       - mim/small_tests:
           name: small_tests_21_3
-          otp: 1:21.3.8.4-1
+          otp: 1:21.3.8.6-1
           context: mongooseim-org
           requires:
             - otp_21_3
       - mim/small_tests:
           name: small_tests_22
-          otp: 1:22.0.4-1
+          otp: 1:22.0.7-1
           context: mongooseim-org
           requires:
             - otp_22
+      # ============= DIALYZER =============
       - mim/dialyzer:
           name: dialyzer
-          otp: 1:22.0.4-1
+          otp: 1:22.0.7-1
           context: mongooseim-org
+      # ============= MOST RECENT VERSION TESTS =============
       - mim/big_tests:
           name: mysql_redis
-          otp: 1:21.3.8.4-1
+          otp: 1:22.0.7-1
           preset: mysql_redis
           db: mysql
           context: mongooseim-org
           requires:
-            - otp_21_3
+            - otp_22
       - mim/big_tests:
           name: mssql_mnesia
-          otp: 1:22.0.4-1
+          otp: 1:22.0.7-1
           preset: odbc_mssql_mnesia
           db: mssql
           context: mongooseim-org
           requires:
             - otp_22
       - mim/big_tests:
-          name: ldap_mnesia
-          otp: 1:22.0.4-1
-          preset: ldap_mnesia
-          db: mnesia
-          context: mongooseim-org
-          requires:
-            - otp_22
-      - mim/big_tests:
           name: internal_mnesia
-          otp: 1:22.0.4-1
+          otp: 1:22.0.7-1
           preset: internal_mnesia
           db: mnesia
           tls_dist: true
@@ -314,25 +321,36 @@ workflows:
             - otp_22
       - mim/big_tests:
           name: elasticsearch_and_cassandra
-          otp: 1:22.0.4-1
+          otp: 1:22.0.7-1
           preset: elasticsearch_and_cassandra_mnesia
           db: "elasticsearch cassandra"
           context: mongooseim-org
           requires:
             - otp_22
       - mim/big_tests:
+          name: riak_mnesia
+          otp: 1:22.0.7-1
+          preset: riak_mnesia
+          db: riak
+          context: mongooseim-org
+          requires:
+            - otp_22
+      # ============= 1 VERSION OLDER TESTS =============
+      - mim/big_tests:
           name: pgsql_mnesia
-          otp: 1:21.3.8.4-1
+          otp: 1:21.3.8.6-1
           preset: pgsql_mnesia
           db: pgsql
           context: mongooseim-org
           requires:
             - otp_21_3
+      # ============= 2 VERSIONS OLDER TESTS =============
       - mim/big_tests:
-          name: riak_mnesia
-          otp: 1:21.3.8.4-1
-          preset: riak_mnesia
-          db: riak
+          name: ldap_mnesia
+          otp: 1:20.3.8.22-1
+          preset: ldap_mnesia
+          db: mnesia
           context: mongooseim-org
           requires:
-            - otp_21_3
+            - otp_20_3
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ after_failure:
         - tail -100 _build/mim2/rel/mongooseim/log/ejabberd.log
 
 after_success:
-        - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ] && [ $TRAVIS_OTP_RELEASE = "20.3" ];
+        - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ];
             then tools/travis-build-and-push-docker.sh;
           fi
 
@@ -77,9 +77,7 @@ services:
 
 branches:
         only:
-                - deps_upgrade_erl_22
                 - master
-                - stable
                 - /^rel\-\d+\.\d+$/
                 - /^\d+\.\d+\.\d+([a-z0-9\-\+])*/
 
@@ -92,28 +90,24 @@ env:
   matrix:
       # When changing jobs, update EXAMPLES in tools/test-runner.sh
     - PRESET=small_tests RUN_SMALL_TESTS=true SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-    - PRESET=internal_mnesia DB=mnesia REL_CONFIG=with-all TLS_DIST=true
-    - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG=with-odbc
-    - PRESET=ldap_mnesia DB=mnesia REL_CONFIG=with-none
+    - PRESET=internal_mnesia DB=mnesia REL_CONFIG="with-all" TLS_DIST=true RUN_SMALL_TESTS=true
+    - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG="with-odbc"
+    - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
+    - PRESET=riak_mnesia DB=riak REL_CONFIG="with-riak"
     - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
       REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
       ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
+    - PRESET=dialyzer_only SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
       # In case you want to test with another ODBC driver, uncomment this
       # - PRESET=odbc_pgsql_mnesia DB=pgsql REL_CONFIG=with-odbc
 
 
 matrix:
   include:
-    - otp_release: 22.0
-      env: PRESET=dialyzer_only
-           SKIP_RELEASE=1 SKIP_BUILD_TESTS=1 SKIP_COV=1 SKIP_REPORT_UPLOAD=1
     - otp_release: 21.3
-      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql with-jingle-sip"
-           RUN_SMALL_TESTS=true
-    - otp_release: 21.3
-      env: PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
-    - otp_release: 21.3
-      env: PRESET=riak_mnesia DB=riak REL_CONFIG="with-riak with-jingle-sip" RUN_SMALL_TESTS=true
+      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql"
+    - otp_release: 20.3
+      env: PRESET=ldap_mnesia DB=mnesia REL_CONFIG="with-jingle-sip" RUN_SMALL_TESTS=true
     - language: generic
       env: PRESET=pkg pkg_PLATFORM=centos7
            SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ env:
     - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG="with-odbc"
     - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
     - PRESET=riak_mnesia DB=riak REL_CONFIG="with-riak"
+    - PRESET=ldap_mnesia DB=mnesia REL_CONFIG="with-none"
     - PRESET=elasticsearch_and_cassandra_mnesia DB="elasticsearch cassandra"
       REL_CONFIG="with-elasticsearch with-cassandra" TESTSPEC=mam.spec
       ELASTICSEARCH_VERSION=5.6.9 CASSANDRA_VERSION=3.9
@@ -106,8 +107,6 @@ matrix:
   include:
     - otp_release: 21.3
       env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql"
-    - otp_release: 20.3
-      env: PRESET=ldap_mnesia DB=mnesia REL_CONFIG="with-jingle-sip" RUN_SMALL_TESTS=true
     - language: generic
       env: PRESET=pkg pkg_PLATFORM=centos7
            SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -76,29 +76,29 @@ Script examples:
     Disables big tests and cover
 
 ./tools/test-runner.sh --skip-big-tests
-    Travis build job 1
+    Travis build job with small tests
 
 ./tools/test-runner.sh --skip-small-tests --db redis --tls-dist --preset internal_mnesia
-    Travis build job 2
+    Travis build job with internal_mnesia
 
 ./tools/test-runner.sh --skip-small-tests --db redis mysql --preset mysql_redis
-    Travis build job 3
+    Travis build job with mysql_redis
 
 ./tools/test-runner.sh --skip-small-tests --db redis mssql --preset odbc_mssql_mnesia
-    Travis build job 4
+    Travis build job with odbc_mssql_mnesia
 
 ./tools/test-runner.sh --skip-small-tests --db redis ldap --preset ldap_mnesia
-    Travis build job 5
+    Travis build job with ldap_mnesia
 
 ./tools/test-runner.sh --skip-small-tests --db redis elasticsearch cassandra --preset elasticsearch_and_cassandra_mnesia -- mam mongoose_cassandra mongoose_elasticsearch
-    Travis build job 6
+    Travis MAM-only build job with elasticsearch_and_cassandra_mnesia
     Separator -- between presets and suites
 
 ./tools/test-runner.sh --db redis pgsql --preset pgsql_mnesia
-    Travis build job 8
+    Travis build job with pgsql_mnesia
 
 ./tools/test-runner.sh --db redis riak --preset riak_mnesia
-    Travis build job 9
+    Travis build job with riak_mnesia
 
 ./tools/test-runner.sh --skip-small-tests --db mysql --preset mysql_mnesia --skip-stop-nodes -- mam
     Runs mam_SUITE with MySQL


### PR DESCRIPTION
This PR changes the versions matrix to follow these rules:

* Use OTP 22 for almost everything
* Use OTP 20 and 21 for one preset each
* Execute small tests for 20, 21 and 22

I've decided to run everything on OTP 22 except for `ldap_mnesia` (OTP 20.3) and `pgsql_mnesia` (OTP 21.3). The choice is pretty much arbitrary.