### PR TITLE
CircleCI install packages order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ orbs:
               wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
               sudo killall -9 apt-get || true && \
               sudo dpkg -i erlang-solutions_1.0_all.deb
-              sudo apt-get update && \
               sudo apt-get install -y esl-erlang=<<parameters.otp>>
       fetch_packages:
         steps:
@@ -49,6 +48,7 @@ orbs:
 
         steps:
           - checkout
+          - fetch_packages
           - install_erlang:
               otp: <<parameters.otp>>
           - run:
@@ -59,7 +59,6 @@ orbs:
               key: build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
           - restore_cache:
               key: deps-cache--{{ checksum "rebar.lock" }}--{{ checksum "big_tests/rebar.lock" }}--{{ checksum "otp_version" }}
-          - fetch_packages
           - run:
               name: Get deps
               command: |
@@ -195,9 +194,9 @@ orbs:
           REDIS_VERSION: 3.2.10
         steps:
           - checkout
+          - fetch_packages
           - install_erlang:
               otp: <<parameters.otp>>
-          - fetch_packages
           - run:
               name: Prepare for cache
               command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ orbs:
         - run:
             name: Install Erlang
             command: |
-              wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
               sudo killall -9 apt-get || true && \
               sudo dpkg -i erlang-solutions_1.0_all.deb
               sudo apt-get install -y esl-erlang=<<parameters.otp>>
@@ -22,6 +21,7 @@ orbs:
             name: Install basic packages
             command: |
               sudo killall -9 apt-get || true && \
+              wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
               sudo apt-get update && \
               sudo apt-get install unixodbc-dev -y && \
               sudo apt-get install unixodbc -y && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ orbs:
             name: Install Erlang
             command: |
               sudo killall -9 apt-get || true && \
-              sudo dpkg -i erlang-solutions_1.0_all.deb
               sudo apt-get install -y esl-erlang=<<parameters.otp>>
       fetch_packages:
         steps:
@@ -22,6 +21,7 @@ orbs:
             command: |
               sudo killall -9 apt-get || true && \
               wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
+              sudo dpkg -i erlang-solutions_1.0_all.deb && \
               sudo apt-get update && \
               sudo apt-get install unixodbc-dev -y && \
               sudo apt-get install unixodbc -y && \


### PR DESCRIPTION
Don't `apt-get update` twice in CircleCI config.

PS. Seems that recently `apt-get update` hangs too long (4 minutes) because of that issue:
https://askubuntu.com/questions/574569/apt-get-stuck-at-0-connecting-to-us-archive-ubuntu-com
If its not temporal issue, some hack fix needs to be added