### PR TITLE
Remove XMLNS strip in ejabberd_c2s

### DIFF
--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -320,12 +320,18 @@ given_conversations_between(From, ToList) ->
                         Ord = integer_to_binary(N),
                         ToClient = lists:nth(N, ToList),
                         Body = <<"Msg ", Ord/binary>>,
-                        Msg = escalus_stanza:chat_to(ToClient, Body),
+                        Msg0 = escalus_stanza:chat_to(ToClient, Body),
+                        Msg = escalus_stanza:setattr(Msg0, <<"xmlns">>, ?NS_JABBER_CLIENT),
                         escalus:send(From, Msg),
                         Incoming = escalus:wait_for_stanza(ToClient),
                         escalus:assert(is_chat_message, Incoming),
+                        VerifyXMLNSFun
+                            = fun(_, InnerMsg) ->
+                                      ?NS_JABBER_CLIENT = exml_query:attr(InnerMsg, <<"xmlns">>)
+                              end,
                         NewConv = #conv{ from = From, to = ToClient,
-                                         content = Body, time_after = server_side_time() },
+                                         content = Body, time_after = server_side_time(),
+                                         verify = VerifyXMLNSFun },
                         Convs#{
                           From := [NewConv#conv{ unread = 0 } | FromConvs],
                           ToClient => [NewConv#conv{ unread = 1 }]

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1558,8 +1558,7 @@ reroute_unacked_messages(StateData) ->
 %%%----------------------------------------------------------------------
 
 fix_message_from_user(#xmlel{attrs = Attrs} = El0, Lang) ->
-    % do some cryptic preparation on xmlel
-    NewEl1 = jlib:remove_attr(<<"xmlns">>, jlib:remove_delay_tags(El0)),
+    NewEl1 = jlib:remove_delay_tags(El0),
     case xml:get_attr_s(<<"xml:lang">>, Attrs) of
         <<>> ->
             case Lang of


### PR DESCRIPTION
This PR removes XMLNS stripping in ejabberd_c2s, as there are no clear reasons why we do it and it makes some clients sad.

The stripping code dates back to 2006, quite likely it is no longer valid.

