### PR TITLE
Fix .travis.yml to execute small tests both on OTP 22 and 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ env:
   matrix:
       # When changing jobs, update EXAMPLES in tools/test-runner.sh
     - PRESET=small_tests RUN_SMALL_TESTS=true SKIP_RELEASE=1 SKIP_BUILD_TESTS=1
-    - PRESET=internal_mnesia DB=mnesia REL_CONFIG="with-all" TLS_DIST=true RUN_SMALL_TESTS=true
+    - PRESET=internal_mnesia DB=mnesia REL_CONFIG="with-all" TLS_DIST=true
     - PRESET=odbc_mssql_mnesia DB=mssql REL_CONFIG="with-odbc"
     - PRESET=mysql_redis DB=mysql REL_CONFIG="with-mysql with-redis with-amqp_client"
     - PRESET=riak_mnesia DB=riak REL_CONFIG="with-riak"
@@ -106,7 +106,7 @@ env:
 matrix:
   include:
     - otp_release: 21.3
-      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql"
+      env: PRESET=pgsql_mnesia DB=pgsql REL_CONFIG="with-pgsql" RUN_SMALL_TESTS=true
     - language: generic
       env: PRESET=pkg pkg_PLATFORM=centos7
            SKIP_COMPILE=1 SKIP_RELEASE=1 SKIP_BUILD_TESTS=1


### PR DESCRIPTION
This PR is a follow up to #2421. In the previous PR the small tests weren't executed for OTP 21.3 and executed twice on OTP 22.
