### PR TITLE
Transform mod_*_commands.erl into services

### DIFF
--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -4,6 +4,7 @@
 
 -export([save_modules/2, ensure_modules/2, restore_modules/2]).
 -export([stop/2, stop/3, start/3, start/4, restart/3, stop_running/2, start_running/1]).
+-export([stop_service/1, start_service/2]).
 
 -import(distributed_helper, [mim/0,
                              rpc/4]).
@@ -66,6 +67,24 @@ start(Node, Domain, Mod, Args) ->
     case escalus_rpc:call(Node, gen_mod, start_module, [Domain, Mod, Args], 5000, Cookie) of
         {badrpc, Reason} ->
             ct:fail("Cannot start module ~p reason ~p", [Mod, Reason]);
+        R -> R
+    end.
+
+stop_service(Mod) ->
+    Node = escalus_ct:get_config(ejabberd_node),
+    Cookie = escalus_ct:get_config(ejabberd_cookie),
+    case escalus_rpc:call(Node, mongoose_service, stop_service, [Mod], 5000, Cookie) of
+        {badrpc, Reason} ->
+            ct:fail("Cannot stop service ~p reason ~p", [Mod, Reason]);
+        R -> R
+    end.
+
+start_service(Mod, Args) ->
+    Node = escalus_ct:get_config(ejabberd_node),
+    Cookie = escalus_ct:get_config(ejabberd_cookie),
+    case escalus_rpc:call(Node, mongoose_service, start_service, [Mod, Args], 5000, Cookie) of
+        {badrpc, Reason} ->
+            ct:fail("Cannot start service ~p reason ~p", [Mod, Reason]);
         R -> R
     end.
 

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -470,9 +470,9 @@ stop_start_command_module(_) ->
     %% described above we test both transition from `started' to
     %% `stopped' and from `stopped' to `started'.
     {?OK, _} = gett(admin, <<"/commands">>),
-    {ok, _Opts} = dynamic_modules:stop(host(), mod_commands),
+    ok = dynamic_modules:stop_service(service_commands),
     {?NOT_FOUND, _} = gett(admin, <<"/commands">>),
-    {ok, _} = dynamic_modules:start(host(), mod_commands, []),
+    {ok, _} = dynamic_modules:start_service(service_commands, []),
     timer:sleep(200), %% give the server some time to build the paths again
     {?OK, _} = gett(admin, <<"/commands">>).
 

--- a/doc/user-guide/ICE_tutorial/mongooseim.cfg
+++ b/doc/user-guide/ICE_tutorial/mongooseim.cfg
@@ -558,6 +558,24 @@
 
 {all_metrics_are_global, false }.
 
+%%%.   ========
+%%%'   SERVICES
+
+%% Unlike modules, services are started per node and provide either features which are not
+%% related to any particular host, or backend stuff which is used by modules.
+%% This is handled by `mongoose_service` module.
+
+{services,
+    [
+        {service_admin_extra, [{submods, [node, accounts, sessions, vcard, gdpr,
+                                          roster, last, private, stanza, stats]}]},
+        {service_cache, []},
+        {service_commands, []},
+        {service_muc_commands, []},
+        {service_muc_light_commands, []}
+    ]
+}.
+
 %%%.   =======
 %%%'   MODULES
 
@@ -606,9 +624,6 @@
   {mod_adhoc, []},
 
   {mod_disco, []},
-  {mod_commands, []},
-  {mod_muc_commands, []},
-  {mod_muc_light_commands, []},
   {mod_last, []},
   {mod_stream_management, [
                            % default 100

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -650,7 +650,10 @@
     [
         {service_admin_extra, [{submods, [node, accounts, sessions, vcard, gdpr,
                                           roster, last, private, stanza, stats]}]},
-        {service_cache, []}
+        {service_cache, []},
+        {service_commands, []},
+        {service_muc_commands, []},
+        {service_muc_light_commands, []}
     ]
 }.
 
@@ -701,9 +704,6 @@
   {mod_adhoc, []},
   {{{mod_amp}}}
   {mod_disco, [{users_can_see_hidden_services, false}]},
-  {mod_commands, []},
-  {mod_muc_commands, []},
-  {mod_muc_light_commands, []},
   {{{mod_last}}}
   {mod_stream_management, [
                            % default 100

--- a/src/muc_light/service_muc_light_commands.erl
+++ b/src/muc_light/service_muc_light_commands.erl
@@ -17,10 +17,10 @@
 %% Description: Administration commands for MUC Light
 %%==============================================================================
 
--module(mod_muc_light_commands).
+-module(service_muc_light_commands).
 
--behaviour(gen_mod).
--export([start/2, stop/1]).
+-behaviour(mongoose_service).
+-export([start/1, stop/0]).
 
 -export([create_unique_room/4]).
 -export([create_identifiable_room/5]).
@@ -40,10 +40,10 @@
 %% `gen_mod' callbacks
 %%--------------------------------------------------------------------
 
-start(_, _) ->
+start(_) ->
     mongoose_commands:register(commands()).
 
-stop(_) ->
+stop() ->
     mongoose_commands:unregister(commands()).
 
 

--- a/src/service_commands.erl
+++ b/src/service_commands.erl
@@ -1,10 +1,9 @@
--module(mod_commands).
+-module(service_commands).
 -author('bartlomiej.gorny@erlang-solutions.com').
 
--behaviour(gen_mod).
+-behaviour(mongoose_service).
 
--export([start/0, stop/0,
-         start/2, stop/1,
+-export([start/1, stop/0,
          register/3,
          unregister/2,
          registered_commands/0,
@@ -29,14 +28,11 @@
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 
-start() ->
+start(_) ->
     mongoose_commands:register(commands()).
 
 stop() ->
     mongoose_commands:unregister(commands()).
-
-start(_, _) -> start().
-stop(_) -> stop().
 
 %%%
 %%% mongoose commands

--- a/src/service_muc_commands.erl
+++ b/src/service_muc_commands.erl
@@ -17,10 +17,10 @@
 %% Description: Administration commands for Mult-user Chat (MUC)
 %%==============================================================================
 
--module(mod_muc_commands).
+-module(service_muc_commands).
 
 -behaviour(gen_mod).
--export([start/2, stop/1]).
+-export([start/1, stop/0]).
 
 -export([create_instant_room/4]).
 -export([invite_to_room/5]).
@@ -31,10 +31,10 @@
 -include("jlib.hrl").
 -include("mod_muc_room.hrl").
 
-start(_, _) ->
+start(_) ->
     mongoose_commands:register(commands()).
 
-stop(_) ->
+stop() ->
     mongoose_commands:unregister(commands()).
 
 commands() ->


### PR DESCRIPTION
This PR addresses #2278

It transforms `mod_*_commands.erl` into services. They don't register commands on per-host basis, so using multiple vhosts led to broken API calls.

Update: Nvm, this PR doesn't solve the issue but may be considered anyway.