### PR TITLE
Filter REST commands by subcategory as well

### DIFF
--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -55,7 +55,8 @@ all() ->
      {group, admin},
      {group, dynamic_module},
      {group, auth},
-     {group, blank_auth}
+     {group, blank_auth},
+     {group, roster}
     ].
 
 groups() ->
@@ -309,16 +310,13 @@ list_contacts(Config) ->
     escalus:fresh_story(
         Config, [{alice, 1}, {bob, 1}],
         fun(Alice, Bob) ->
-            AliceJID = escalus_utils:jid_to_lower(
-                            escalus_client:short_jid(Alice)),
+            AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
             BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
             add_sample_contact(Bob, Alice),
             % list bob's contacts
-            {?OK, R} = gett(client, lists:flatten(["/contacts/",
-                                           binary_to_list(BobJID)])),
-            [R1] =  decode_maplist(R),
-            #{jid := AliceJID, subscription := <<"none">>,
-                ask := <<"none">>} = R1,
+            {?OK, R} = gett(admin, lists:flatten(["/contacts/", binary_to_list(BobJID)])),
+            [R1] = decode_maplist(R),
+            #{jid := AliceJID, subscription := <<"none">>, ask := <<"none">>} = R1,
             ok
         end
     ),

--- a/src/mongoose_api_admin.erl
+++ b/src/mongoose_api_admin.erl
@@ -108,9 +108,11 @@ terminate(_Reason, _Req, _State) ->
     ok.
 
 %% @doc Called for a method of type "DELETE"
-delete_resource(Req, #http_api_state{command_category = Category, bindings = B} = State) ->
+delete_resource(Req, #http_api_state{command_category = Category,
+                                     command_subcategory = SubCategory,
+                                     bindings = B} = State) ->
     Arity = length(B),
-    Cmds = mongoose_commands:list(admin, Category, method_to_action(<<"DELETE">>)),
+    Cmds = mongoose_commands:list(admin, Category, method_to_action(<<"DELETE">>), SubCategory),
     [Command] = [C || C <- Cmds, mongoose_commands:arity(C) == Arity],
     process_request(<<"DELETE">>, Command, Req, State).
 
@@ -153,8 +155,10 @@ get_control_creds(#http_api_state{auth = Creds}) ->
 %%--------------------------------------------------------------------
 
 %% @doc Called for a method of type "GET"
-to_json(Req, #http_api_state{command_category = Category, bindings = B} = State) ->
-    Cmds = mongoose_commands:list(admin, Category, method_to_action(<<"GET">>)),
+to_json(Req, #http_api_state{command_category = Category,
+                             command_subcategory = SubCategory,
+                             bindings = B} = State) ->
+    Cmds = mongoose_commands:list(admin, Category, method_to_action(<<"GET">>), SubCategory),
     Arity = length(B),
     [Command] = [C || C <- Cmds, mongoose_commands:arity(C) == Arity],
     process_request(<<"GET">>, Command, Req, State).

--- a/src/mongoose_commands.erl
+++ b/src/mongoose_commands.erl
@@ -242,7 +242,7 @@ list(U, Category, Action) ->
     list(U, Category, Action, any).
 
 %% @doc List commands, available for this user, filtered by category, action and subcategory
--spec list(caller(), binary() | any, atom(), binary() | any) -> [t()].
+-spec list(caller(), binary() | any, atom(), binary() | any | undefined) -> [t()].
 list(U, Category, Action, SubCategory) ->
     CL = command_list(Category, Action, SubCategory),
     lists:filter(fun(C) -> is_available_for(U, C) end, CL).


### PR DESCRIPTION
This PR fixes #2278

Commands in REST weren't filtered by subcategory, so for any two commands with the same method and category but different subcategories, the handler will crash and return 500 error.

Tests that would have detected the problem were for some reason disabled.