### PR TITLE
CI/fix migration scripts

### DIFF
--- a/test/script_helper.erl
+++ b/test/script_helper.erl
@@ -40,7 +40,7 @@ read(Port, Buffer) ->
             erlang:error(#{ reason => script_has_terminated,
                             exit_status => ExitStatus,
                             data_received => Buffer })
-    after 2000 ->
+    after 5000 ->
         erlang:error(#{ reason => timeout,
                         data_received => Buffer })
     end.
@@ -60,7 +60,7 @@ read(Port, Buffer, ExpectedLen) ->
                             data_received => Buffer,
                             received_len => byte_size(Buffer),
                             expected_len => ExpectedLen })
-    after 2000 ->
+    after 5000 ->
               erlang:error(#{ reason => timeout,
                               data_received => Buffer,
                               received_len => byte_size(Buffer),


### PR DESCRIPTION
When debugging the errors, I discovered that the operation was failing
by returning `{error, terminated}` from `file:read_line(standard_io)`,
which was not matching any clause. Then I realised that this could only
happen by `group_leader` dying, which could only happen by the app being
signaled to die. When debugging, I discovered that `group_leader` was
dying with error `epipe`, which is, that a Unix pipe has been closed on
the other side all the while this side of the pipe still tries to read
from it. What is the other side of the pipe? Common_test!

So in the end, I noticed that successful tests were always passing in
like 1.9s, when the timeout is 2s. So when not receiving anything in
time, the test was failing, the process owning the port was dying, hence
signalling the port with a `sigpipe`, hence telling the OS to end the
pipe, hence signalling the other side with a `epipe` when it was
insisting in continuing, hence, _failing!_.

Ah, so much investigation for just a timeout.

---
~~I'm just throwing tests to CI like crazy. Don't merge it!~~
~~And yes, if the issue is with a timeout I'm going to be sad, I wanted some more fancy answer to this.~~