### PR TITLE
Ci/tcp metrics

### DIFF
--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -60,8 +60,7 @@ groups() ->
          {all_metrics_are_global, [], ?METRICS_CASES},
          {global, [], [session_counters,
                        node_uptime,
-                       cluster_size,
-                       tcp_connections_increases_with_user_connection
+                       cluster_size
                       ]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
@@ -245,18 +244,6 @@ cluster_size(Config) ->
       SingleNodeClusterState2 =
             fetch_global_incrementing_gauge_value(clusterSize, Config),
       ?assert_equal(1, SingleNodeClusterState2).
-
-tcp_connections_increases_with_user_connection(Config) ->
-    rpc(mim(), exometer, repair, [[global, tcpPortsUsed]]),
-    InitialTcpCount = fetch_global_incrementing_gauge_value(tcpPortsUsed, Config),
-    escalus:story(Config, [{alice, 1}],
-                 fun(_Alice) ->
-                         rpc(mim(), exometer, repair, [[global, tcpPortsUsed]]),
-                         NewTcpCount =
-                         fetch_global_incrementing_gauge_value(tcpPortsUsed, Config),
-                         assert_counter_inc(tcpPortsUsed, 1,
-                                            [InitialTcpCount], [NewTcpCount])
-                 end).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -152,7 +152,7 @@ Metrics specific to an extension, e.g. Message Archive Management, are described
 | `[global, cache, unique_sessions_number]` | gauge | A cached value of `uniqueSessionCount`. It is automatically updated when a unique session count is calculated. |
 | `[global, nodeUpTime]` | value | Node uptime. |
 | `[global, clusterSize]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node. |
-| `[global, tcpPortsUsed]` | value | A number of open tcp connections. This should relate to the number of connected sessions and databases, in order to detect connection leaks. |
+| `[global, tcpPortsUsed]` | value | A number of open tcp connections. This should relate to the number of connected sessions and databases, as well as federations and http requests, in order to detect connection leaks. |
 | `[global, processQueueLengths]` | probe | The number of queued messages in the
 internal message queue of every erlang process, and the internal queue of every
 fsm (ejabberd\_c2s). This is sampled every 30 seconds asynchronously. It is a

--- a/test/async_helper.erl
+++ b/test/async_helper.erl
@@ -49,38 +49,40 @@ helper_loop() ->
     end.
 
 % @doc Waits `TimeLeft` for `Fun` to return `Expected Value`, then returns `ExpectedValue`
-% If no value is returned or the result doesn't match  `ExpetedValue` error is raised
+% If no value is returned or the result doesn't match  `ExpectedValue` error is raised
 
 wait_until(Fun, ExpectedValue) ->
     wait_until(Fun, ExpectedValue, #{}).
 
 %% Example: wait_until(fun () -> ... end, SomeVal, #{time_left => timer:seconds(2)})
 wait_until(Fun, ExpectedValue, Opts) ->
-    Defaults = #{time_left => timer:seconds(5),
+    DefValidator = fun(NewValue) -> ExpectedValue =:= NewValue end,
+    Defaults = #{validator => DefValidator,
+                 time_left => timer:seconds(5),
                  sleep_time => 100,
                  history => []},
-    do_wait_until(Fun, ExpectedValue, maps:merge(Defaults, Opts)).
+    do_wait_until(Fun, maps:merge(Defaults, Opts)).
 
-do_wait_until(_Fun, _ExpectedValue, #{
-                                      time_left := TimeLeft,
-                                      history := History
-                                     }) when TimeLeft =< 0 ->
+do_wait_until(_Fun, #{
+                time_left := TimeLeft,
+                history := History
+               }) when TimeLeft =< 0 ->
     error({badmatch, lists:reverse(History)});
 
-do_wait_until(Fun, ExpectedValue, Opts) ->
+do_wait_until(Fun, #{validator := Validator} = Opts) ->
     try Fun() of
-        ExpectedValue ->
-            {ok, ExpectedValue};
-        OtherValue ->
-            wait_and_continue(Fun, ExpectedValue, OtherValue, Opts)
+        Value -> case Validator(Value) of
+                   true -> {ok, Value};
+                   _ -> wait_and_continue(Fun, Value, Opts)
+               end
     catch Error:Reason ->
-            wait_and_continue(Fun, ExpectedValue, {Error, Reason}, Opts)
+            wait_and_continue(Fun, {Error, Reason}, Opts)
     end.
 
-wait_and_continue(Fun, ExpectedValue, FunResult, #{time_left := TimeLeft,
-                                                   sleep_time := SleepTime,
-                                                   history := History} = Opts) ->
+wait_and_continue(Fun, FunResult, #{time_left := TimeLeft,
+                                    sleep_time := SleepTime,
+                                    history := History} = Opts) ->
     timer:sleep(SleepTime),
-    do_wait_until(Fun, ExpectedValue, Opts#{time_left => TimeLeft - SleepTime,
-                                            history => [FunResult | History]}).
+    do_wait_until(Fun, Opts#{time_left => TimeLeft - SleepTime,
+                             history => [FunResult | History]}).
 


### PR DESCRIPTION
Sadly, my tcp_metrics test was unstable. Very rarely, it was failing. This test tries to assert that, on a new user connection, the number of tcp connections increases exactly one. First thing is, it was failing mostly on the preset `mysql_redis`, and never in `internal_mnesia` for example.

What was happening? => _Worker Pools!_

Turns out, they can connect and disconnect at will, so the metric read from before and after the user connection are not stable whatsoever. The whole test was assuming too much, and testing stuff with too many dependencies.

With advise from @chrzaszcz, I decided to remove it from `big_tests` and test what I was supposed to test, the metric: that the metric does detect changes in the number of tcp ports. It was a task for `small_tests`

Next step was, to sync with the async nature of exometer probes, so it was obviously a task for `async_helper:wait_until`. Except for the fact that that function requires exact expectations and it has no support for pattern matching, nor extracting what it was actually returned. So I expanded this function to take a "validator" function object that will validate if retrying or returning the given module, with a default validator of `=:=` to keep compatibility with everything that was using it before.

Once done, I rewrote the old small test to use it and ensure that it returns a non-empty metric, and a new test to ensure that the metric detects with precision the connection and disconnection of a single tcp connection.