### PR TITLE
add pubsub_s2s_SUITE to default.spec

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -57,6 +57,7 @@
 {suites, "tests", privacy_SUITE}.
 {suites, "tests", private_SUITE}.
 {suites, "tests", pubsub_SUITE}.
+{suites, "tests", pubsub_s2s_SUITE}.
 {suites, "tests", push_SUITE}.
 {suites, "tests", push_http_SUITE}.
 {suites, "tests", push_integration_SUITE}.


### PR DESCRIPTION
I saw it disabled in our test environment, basically by not being written to big_tests/default.spec. I checked several master builds on aws and it’s not on the reports either, so I’m pretty confident it’s just never ran. Tested in on my fork and it’s all green. On the git history I haven’t found any place where it was added and then removed from default.spec. So let's just add it there.