### PR TITLE
[CI] pubsub: run bigger groups in sequence and not in parallel

### DIFF
--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -149,16 +149,20 @@ group_is_compatible(hometree_specific, OnlyNodetreeTree) -> OnlyNodetreeTree =:=
 group_is_compatible(_, _) -> true.
 
 base_groups() ->
-    G = [{basic, [parallel], basic_tests()},
+    %% NOTE: basic and collection are placed in sequence because they run bigger
+    %% sets of tests, which in parallel might cause deadlocks in the
+    %% transactions for MNESIA and MYSQL.
+    %% TODO: Optimise pubsub backends (MYSQL! Mnesia?)
+    G = [{basic, [sequence], basic_tests()},
          {service_config, [parallel], service_config_tests()},
          {node_config, [parallel], node_config_tests()},
          {node_affiliations, [parallel], node_affiliations_tests()},
          {manage_subscriptions, [parallel], manage_subscriptions_tests()},
-         {collection, [parallel], collection_tests()},
+         {collection, [sequence], collection_tests()},
          {collection_config, [parallel], collection_config_tests()},
          {debug_calls, [parallel], debug_calls_tests()},
          {pubsub_item_publisher_option, [parallel], pubsub_item_publisher_option_tests()},
-         {hometree_specific, [parallel], hometree_specific_tests()},
+         {hometree_specific, [sequence], hometree_specific_tests()},
          {last_item_cache, [parallel], last_item_cache_tests()}
         ],
     ct_helper:repeat_all_until_all_ok(G).


### PR DESCRIPTION
Certain groups are placed in sequence because they run a heavier set of tests, which in parallel might cause deadlocks in the transactions for MNESIA and MYSQL.

TODO: Optimise pubsub backends (MYSQL! Mnesia?)

NOTE: the suite used to take 20-25s, now it's closer to 50s 😞 