### PR TITLE
mod_global_distrib_SUITE: ignore known failure, fail otherwise

### DIFF
--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -909,9 +909,8 @@ refresh_node(NodeName, Config) ->
 
 connect_from_spec(UserSpec, Config) ->
     {ok, User} = escalus_client:start(Config, UserSpec, <<"res1">>),
-    escalus_story:send_initial_presence(User),
-    escalus:wait_for_stanza(User),
     escalus_connection:set_filter_predicate(User, fun(S) -> not escalus_pred:is_presence(S) end),
+    escalus_story:send_initial_presence(User),
     User.
 
 chat_with_seqnum(To, Text) ->


### PR DESCRIPTION
If the test fails with the known reason, simply exit the escalus story and return `{skip, Reason}`. This way, we don't get CI in red any more for the known issue, but if it ever fails with a different one, then CI will get red and we will know about it.

Unfortunately, `escalus:story` ignores the return value of the function given, so the only way to move the control flow is by throwing: it exits the function and gives us a "return value".

Yes, this is kicking the ball down the road. But it's there, and we'll have a chance to work on it if we ever need to come back to global distribution.

I also fixed the suite by ~removing the user that is created in the `ungraceful` test, which was not being removed and then leaving the environment dirty; and~ refactoring the tests by moving not relevant behaviour out of it, into `init_per_testcase` and `end_per_testcase`.