### PR TITLE
Pubsub push node improvements

### DIFF
--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -454,7 +454,10 @@ enable_push_for_user(User, Service, EnableOpts) ->
 
     DeviceToken = gen_token(),
 
-    pubsub_tools:create_node(User, Node, [{type, <<"push">>}]),
+    Configuration = [{<<"pubsub#access_model">>, <<"whitelist">>},
+                     {<<"pubsub#publish_model">>, <<"publishers">>}],
+    pubsub_tools:create_node(User, Node, [{type, <<"push">>},
+                                          {config, Configuration}]),
     escalus:send(User, enable_stanza(PubsubJID, NodeName,
                                      [{<<"service">>, Service},
                                       {<<"device_id">>, DeviceToken}] ++ EnableOpts)),
@@ -544,10 +547,10 @@ required_modules(pm_notifications_with_inbox) ->
     [{mod_inbox, inbox_opts()}|required_modules()];
 required_modules(groupchat_notifications_with_inbox)->
     [{mod_inbox, inbox_opts()}, {mod_muc_light, muc_light_opts()}|required_modules()];
-required_modules(pm_msg_notifications) ->
-    required_modules();
 required_modules(muclight_msg_notifications) ->
-    [{mod_muc_light, muc_light_opts()}|required_modules()].
+    [{mod_muc_light, muc_light_opts()}|required_modules()];
+required_modules(_) ->
+    required_modules().
 
 required_modules() ->
     [

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -173,6 +173,19 @@ The client sends the following stanza to the server:
     id='create1'>
   <pubsub xmlns='http://jabber.org/protocol/pubsub'>
     <create node='punsub_node_for_my_private_iphone' type='push'/>
+    <configure>
+      <x xmlns='jabber:x:data' type='submit'>
+        <field var='FORM_TYPE' type='hidden'>
+          <value>http://jabber.org/protocol/pubsub#node_config</value>
+        </field>
+        <field var='pubsub#access_model'>
+          <value>whitelist</value>
+        </field>
+        <field var='pubsub#publish_model'>
+          <value>publishers</value>
+        </field>
+      </x>
+    </configure>
   </pubsub>
 </iq>
 ```
@@ -183,6 +196,11 @@ The most important and only distinction from the standard node creation is the `
 This denotes that you need a node that will handle your push notifications.
 Here we create a node called `punsub_node_for_my_private_iphone`.
 This node should be unique to the device and you may reuse nodes already created this way.
+It is also recommended and important from security perspective to configure the node with:
+
+* `access_model` set to `whitelist` so only affiliated users can access the node.
+* `publish_model` set to `publishers` so only users with `publisher` or `publisher_only` role can publish notifications.
+
 
 After this step, you need to have the `pubsub` host (here `pubsub.mypubsub.com`) and the node name (here: `punsub_node_for_my_private_iphone`).
 

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -62,7 +62,7 @@ features() ->
 
 publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublisher, Payload,
              PublishOptions) ->
-    Affiliation = mod_pubsub_db_backend:get_affiliation(Nidx, jid:to_lower(Publisher)),
+    {ok, Affiliation} = mod_pubsub_db_backend:get_affiliation(Nidx, jid:to_lower(Publisher)),
     ElPayload = [El || #xmlel{} = El <- Payload],
 
     case is_allowed_to_publish(Model, Affiliation) of


### PR DESCRIPTION
This PR checks if push node configuration takes effect

Proposed changes include:
* fixed affiliation checking in node_push
* push_integration_SUITE now always creates push node with the following configuration:
    * `access_model` -> `whitelist`
    * `publish_model` -> `publishers`
