### PR TITLE
Switch Docker image build to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
     commands:
       install_erlang:
         parameters:
-          otp:
+          otp_package:
             type: string
             description: Version of the Erlang package to install
         steps:
@@ -13,7 +13,7 @@ orbs:
             name: Install Erlang
             command: |
               sudo killall -9 apt-get || true && \
-              sudo apt-get install -y esl-erlang=<<parameters.otp>>
+              sudo apt-get install -y esl-erlang=<<parameters.otp_package>>
       fetch_packages:
         steps:
         - run:
@@ -33,7 +33,7 @@ orbs:
         machine:
           image: ubuntu-1604:201903-01
         parameters:
-          otp:
+          otp_package:
             type: string
             description: Version of the Erlang package to install
           build_prod:
@@ -50,11 +50,11 @@ orbs:
           - checkout
           - fetch_packages
           - install_erlang:
-              otp: <<parameters.otp>>
+              otp_package: <<parameters.otp_package>>
           - run:
               name: Prepare for cache
               command: |
-                ./tools/circleci-otp-to-str.sh <<parameters.otp>> > otp_version
+                ./tools/circleci-otp-to-str.sh <<parameters.otp_package>> > otp_version
           - restore_cache:
               key: build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
           - restore_cache:
@@ -95,14 +95,14 @@ orbs:
           image: ubuntu-1604:201903-01
         working_directory: ~/app
         parameters:
-          otp:
+          otp_package:
             type: string
             description: Version of the Erlang package to install
         steps:
           - checkout
           - fetch_packages
           - install_erlang:
-              otp: <<parameters.otp>>
+              otp_package: <<parameters.otp_package>>
           - run:
               name: Run Dialyzer
               command: |
@@ -114,18 +114,18 @@ orbs:
           image: ubuntu-1604:201903-01
         working_directory: ~/app
         parameters:
-          otp:
+          otp_package:
             type: string
             description: Version of the Erlang package to install
         steps:
           - checkout
           - fetch_packages
           - install_erlang:
-              otp: <<parameters.otp>>
+              otp_package: <<parameters.otp_package>>
           - run:
               name: Prepare for cache
               command: |
-                ./tools/circleci-otp-to-str.sh <<parameters.otp>> > otp_version
+                ./tools/circleci-otp-to-str.sh <<parameters.otp_package>> > otp_version
           - restore_cache:
               keys:
                 - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
@@ -169,7 +169,7 @@ orbs:
           image: ubuntu-1604:201903-01
         working_directory: ~/app
         parameters:
-          otp:
+          otp_package:
             type: string
             description: Version of the Erlang package to install
           preset:
@@ -199,11 +199,11 @@ orbs:
           - checkout
           - fetch_packages
           - install_erlang:
-              otp: <<parameters.otp>>
+              otp_package: <<parameters.otp_package>>
           - run:
               name: Prepare for cache
               command: |
-                ./tools/circleci-otp-to-str.sh <<parameters.otp>> > otp_version
+                ./tools/circleci-otp-to-str.sh <<parameters.otp_package>> > otp_version
           - restore_cache:
               keys:
                 - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
@@ -260,7 +260,7 @@ orbs:
           - run:
               name: Prepare for cache
               command: |
-                ./tools/circleci-otp-to-str.sh <<parameters.otp_package>> > otp_version
+                ./tools/circleci-otp-to-str.sh <<parameters.otp_package_package>> > otp_version
           - restore_cache:
               keys:
                 - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
@@ -287,45 +287,45 @@ workflows:
         #      # ============= BASE BUILDS =============
         #      - mim/build:
         #          name: otp_20_3
-        #          otp: 1:20.3.8.22-1
+        #          otp_package: 1:20.3.8.22-1
         #          context: mongooseim-org
         #      - mim/build:
         #          name: otp_21_3
-        #          otp: 1:21.3.8.6-1
+        #          otp_package: 1:21.3.8.6-1
         #          context: mongooseim-org
       - mim/build:
           name: otp_22
-          otp: 1:22.0.7-1
+          otp_package: 1:22.0.7-1
           build_prod: true
           context: mongooseim-org
           #      # ============= SMALL TESTS =============
           #      - mim/small_tests:
           #          name: small_tests_20_3
-          #          otp: 1:20.3.8.22-1
+          #          otp_package: 1:20.3.8.22-1
           #          context: mongooseim-org
           #          requires:
           #            - otp_20_3
           #      - mim/small_tests:
           #          name: small_tests_21_3
-          #          otp: 1:21.3.8.6-1
+          #          otp_package: 1:21.3.8.6-1
           #          context: mongooseim-org
           #          requires:
           #            - otp_21_3
           #      - mim/small_tests:
           #          name: small_tests_22
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          context: mongooseim-org
           #          requires:
           #            - otp_22
           #      # ============= DIALYZER =============
           #      - mim/dialyzer:
           #          name: dialyzer
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          context: mongooseim-org
           #      # ============= MOST RECENT VERSION TESTS =============
           #      - mim/big_tests:
           #          name: mysql_redis
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          preset: mysql_redis
           #          db: mysql
           #          context: mongooseim-org
@@ -333,7 +333,7 @@ workflows:
           #            - otp_22
           #      - mim/big_tests:
           #          name: mssql_mnesia
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          preset: odbc_mssql_mnesia
           #          db: mssql
           #          context: mongooseim-org
@@ -341,7 +341,7 @@ workflows:
           #            - otp_22
           #      - mim/big_tests:
           #          name: internal_mnesia
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          preset: internal_mnesia
           #          db: mnesia
           #          tls_dist: true
@@ -350,7 +350,7 @@ workflows:
           #            - otp_22
           #      - mim/big_tests:
           #          name: elasticsearch_and_cassandra
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          preset: elasticsearch_and_cassandra_mnesia
           #          db: "elasticsearch cassandra"
           #          context: mongooseim-org
@@ -358,7 +358,7 @@ workflows:
           #            - otp_22
           #      - mim/big_tests:
           #          name: riak_mnesia
-          #          otp: 1:22.0.7-1
+          #          otp_package: 1:22.0.7-1
           #          preset: riak_mnesia
           #          db: riak
           #          context: mongooseim-org
@@ -367,7 +367,7 @@ workflows:
           #      # ============= 1 VERSION OLDER TESTS =============
           #      - mim/big_tests:
           #          name: pgsql_mnesia
-          #          otp: 1:21.3.8.6-1
+          #          otp_package: 1:21.3.8.6-1
           #          preset: pgsql_mnesia
           #          db: pgsql
           #          context: mongooseim-org
@@ -376,7 +376,7 @@ workflows:
           #      # ============= 2 VERSIONS OLDER TESTS =============
           #      - mim/big_tests:
           #          name: ldap_mnesia
-          #          otp: 1:20.3.8.22-1
+          #          otp_package: 1:20.3.8.22-1
           #          preset: ldap_mnesia
           #          db: mnesia
           #          context: mongooseim-org

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ orbs:
           - run:
               name: Prepare for cache
               command: |
-                ./tools/circleci-otp-to-str.sh <<parameters.otp_package_package>> > otp_version
+                ./tools/circleci-otp-to-str.sh <<parameters.otp_package>> > otp_version
           - restore_cache:
               keys:
                 - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,8 @@ orbs:
           - run:
               name: Generate prod release
               command: |
+                # We cannot reuse releases generated in the previous step, because they are
+                # built with dev_mode enabled (so they use symlinks for deps)
                 if [ <<parameters.build_prod>> ]; then make rel; fi
           - run:
               name: Build Big Tests
@@ -275,129 +277,128 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-        #      # ============= PACKAGES =============
-        #      - mim/package:
-        #          name: centos7
-        #          platform: centos7
-        #          context: mongooseim-org
-        #      - mim/package:
-        #          name: debian_stretch
-        #          platform: debian_stretch
-        #          context: mongooseim-org
-        #      # ============= BASE BUILDS =============
-        #      - mim/build:
-        #          name: otp_20_3
-        #          otp_package: 1:20.3.8.22-1
-        #          context: mongooseim-org
-        #      - mim/build:
-        #          name: otp_21_3
-        #          otp_package: 1:21.3.8.6-1
-        #          context: mongooseim-org
+      # ============= PACKAGES =============
+      - mim/package:
+          name: centos7
+          platform: centos7
+          context: mongooseim-org
+      - mim/package:
+          name: debian_stretch
+          platform: debian_stretch
+          context: mongooseim-org
+      # ============= BASE BUILDS =============
+      - mim/build:
+          name: otp_20_3
+          otp_package: 1:20.3.8.22-1
+          context: mongooseim-org
+      - mim/build:
+          name: otp_21_3
+          otp_package: 1:21.3.8.6-1
+          context: mongooseim-org
       - mim/build:
           name: otp_22
           otp_package: 1:22.0.7-1
           build_prod: true
           context: mongooseim-org
-          #      # ============= SMALL TESTS =============
-          #      - mim/small_tests:
-          #          name: small_tests_20_3
-          #          otp_package: 1:20.3.8.22-1
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_20_3
-          #      - mim/small_tests:
-          #          name: small_tests_21_3
-          #          otp_package: 1:21.3.8.6-1
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_21_3
-          #      - mim/small_tests:
-          #          name: small_tests_22
-          #          otp_package: 1:22.0.7-1
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_22
-          #      # ============= DIALYZER =============
-          #      - mim/dialyzer:
-          #          name: dialyzer
-          #          otp_package: 1:22.0.7-1
-          #          context: mongooseim-org
-          #      # ============= MOST RECENT VERSION TESTS =============
-          #      - mim/big_tests:
-          #          name: mysql_redis
-          #          otp_package: 1:22.0.7-1
-          #          preset: mysql_redis
-          #          db: mysql
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_22
-          #      - mim/big_tests:
-          #          name: mssql_mnesia
-          #          otp_package: 1:22.0.7-1
-          #          preset: odbc_mssql_mnesia
-          #          db: mssql
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_22
-          #      - mim/big_tests:
-          #          name: internal_mnesia
-          #          otp_package: 1:22.0.7-1
-          #          preset: internal_mnesia
-          #          db: mnesia
-          #          tls_dist: true
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_22
-          #      - mim/big_tests:
-          #          name: elasticsearch_and_cassandra
-          #          otp_package: 1:22.0.7-1
-          #          preset: elasticsearch_and_cassandra_mnesia
-          #          db: "elasticsearch cassandra"
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_22
-          #      - mim/big_tests:
-          #          name: riak_mnesia
-          #          otp_package: 1:22.0.7-1
-          #          preset: riak_mnesia
-          #          db: riak
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_22
-          #      # ============= 1 VERSION OLDER TESTS =============
-          #      - mim/big_tests:
-          #          name: pgsql_mnesia
-          #          otp_package: 1:21.3.8.6-1
-          #          preset: pgsql_mnesia
-          #          db: pgsql
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_21_3
-          #      # ============= 2 VERSIONS OLDER TESTS =============
-          #      - mim/big_tests:
-          #          name: ldap_mnesia
-          #          otp_package: 1:20.3.8.22-1
-          #          preset: ldap_mnesia
-          #          db: mnesia
-          #          context: mongooseim-org
-          #          requires:
-          #            - otp_20_3
+      # ============= SMALL TESTS =============
+      - mim/small_tests:
+          name: small_tests_20_3
+          otp_package: 1:20.3.8.22-1
+          context: mongooseim-org
+          requires:
+            - otp_20_3
+      - mim/small_tests:
+          name: small_tests_21_3
+          otp_package: 1:21.3.8.6-1
+          context: mongooseim-org
+          requires:
+            - otp_21_3
+      - mim/small_tests:
+          name: small_tests_22
+          otp_package: 1:22.0.7-1
+          context: mongooseim-org
+          requires:
+            - otp_22
+      # ============= DIALYZER =============
+      - mim/dialyzer:
+          name: dialyzer
+          otp_package: 1:22.0.7-1
+          context: mongooseim-org
+      # ============= MOST RECENT VERSION TESTS =============
+      - mim/big_tests:
+          name: mysql_redis
+          otp_package: 1:22.0.7-1
+          preset: mysql_redis
+          db: mysql
+          context: mongooseim-org
+          requires:
+            - otp_22
+      - mim/big_tests:
+          name: mssql_mnesia
+          otp_package: 1:22.0.7-1
+          preset: odbc_mssql_mnesia
+          db: mssql
+          context: mongooseim-org
+          requires:
+            - otp_22
+      - mim/big_tests:
+          name: internal_mnesia
+          otp_package: 1:22.0.7-1
+          preset: internal_mnesia
+          db: mnesia
+          tls_dist: true
+          context: mongooseim-org
+          requires:
+            - otp_22
+      - mim/big_tests:
+          name: elasticsearch_and_cassandra
+          otp_package: 1:22.0.7-1
+          preset: elasticsearch_and_cassandra_mnesia
+          db: "elasticsearch cassandra"
+          context: mongooseim-org
+          requires:
+            - otp_22
+      - mim/big_tests:
+          name: riak_mnesia
+          otp_package: 1:22.0.7-1
+          preset: riak_mnesia
+          db: riak
+          context: mongooseim-org
+          requires:
+            - otp_22
+      # ============= 1 VERSION OLDER TESTS =============
+      - mim/big_tests:
+          name: pgsql_mnesia
+          otp_package: 1:21.3.8.6-1
+          preset: pgsql_mnesia
+          db: pgsql
+          context: mongooseim-org
+          requires:
+            - otp_21_3
+      # ============= 2 VERSIONS OLDER TESTS =============
+      - mim/big_tests:
+          name: ldap_mnesia
+          otp_package: 1:20.3.8.22-1
+          preset: ldap_mnesia
+          db: mnesia
+          context: mongooseim-org
+          requires:
+            - otp_20_3
       # ============= DOCKER IMAGE BUILD & UPLOAD =============
       - mim/docker_image:
           name: docker_build_and_ship
           context: mongooseim-org
           otp_package: 1:22.0.7-1
           requires:
-              - otp_22
-              #            - ldap_mnesia
-              #            - pgsql_mnesia
-              #            - riak_mnesia
-              #            - elasticsearch_and_cassandra
-              #            - internal_mnesia
-              #            - mysql_redis
-              #            - odbc_mssql_mnesia
-              #            - dialyzer
-              #            - small_tests_22
-              #            - small_tests_21_3
-              #            - small_tests_20_3
-              #
+            - ldap_mnesia
+            - pgsql_mnesia
+            - riak_mnesia
+            - elasticsearch_and_cassandra
+            - internal_mnesia
+            - mysql_redis
+            - odbc_mssql_mnesia
+            - dialyzer
+            - small_tests_22
+            - small_tests_21_3
+            - small_tests_20_3
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,9 @@ orbs:
           image: ubuntu-1604:201903-01
         working_directory: ~/app
         parameters:
+          otp_package:
+            type: string
+            description: Version of the Erlang package installed
         environment:
         steps:
           - checkout
@@ -383,6 +386,7 @@ workflows:
       - mim/docker_image:
           name: docker_build_and_ship
           context: mongooseim-org
+          otp_package: 1:22.0.7-1
           requires:
               - otp_22
               #            - ldap_mnesia

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ orbs:
         environment:
             OTP_RELEASE: <<parameters.otp>>
         steps:
+          - checkout
           - run:
               name: Prepare for cache
               command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,115 +242,155 @@ orbs:
               command: |
                   tools/circleci-prepare-log-dir.sh
                   if [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then tools/circleci-upload-to-s3.sh; fi
+      docker_image:
+        parallelism: 1
+        machine:
+          image: ubuntu-1604:201903-01
+        working_directory: ~/app
+        parameters:
+          otp:
+            type: string
+            description: Version of the Erlang package to use for Docker image
+        environment:
+            OTP_RELEASE: <<parameters.otp>>
+        steps:
+          - run:
+              name: Prepare for cache
+              command: |
+                ./tools/circleci-otp-to-str.sh <<parameters.otp>> > otp_version
+          - restore_cache:
+              keys:
+                - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
+          - run:
+              name: Execute Docker image build and upload
+              command: tools/circle-build-and-push-docker.sh
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-      # ============= PACKAGES =============
-      - mim/package:
-          name: centos7
-          platform: centos7
-          context: mongooseim-org
-      - mim/package:
-          name: debian_stretch
-          platform: debian_stretch
-          context: mongooseim-org
-      # ============= BASE BUILDS =============
-      - mim/build:
-          name: otp_20_3
-          otp: 1:20.3.8.22-1
-          context: mongooseim-org
-      - mim/build:
-          name: otp_21_3
-          otp: 1:21.3.8.6-1
-          context: mongooseim-org
+        #      # ============= PACKAGES =============
+        #      - mim/package:
+        #          name: centos7
+        #          platform: centos7
+        #          context: mongooseim-org
+        #      - mim/package:
+        #          name: debian_stretch
+        #          platform: debian_stretch
+        #          context: mongooseim-org
+        #      # ============= BASE BUILDS =============
+        #      - mim/build:
+        #          name: otp_20_3
+        #          otp: 1:20.3.8.22-1
+        #          context: mongooseim-org
+        #      - mim/build:
+        #          name: otp_21_3
+        #          otp: 1:21.3.8.6-1
+        #          context: mongooseim-org
       - mim/build:
           name: otp_22
           otp: 1:22.0.7-1
           context: mongooseim-org
-      # ============= SMALL TESTS =============
-      - mim/small_tests:
-          name: small_tests_20_3
-          otp: 1:20.3.8.22-1
-          context: mongooseim-org
-          requires:
-            - otp_20_3
-      - mim/small_tests:
-          name: small_tests_21_3
-          otp: 1:21.3.8.6-1
-          context: mongooseim-org
-          requires:
-            - otp_21_3
-      - mim/small_tests:
-          name: small_tests_22
+          #      # ============= SMALL TESTS =============
+          #      - mim/small_tests:
+          #          name: small_tests_20_3
+          #          otp: 1:20.3.8.22-1
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_20_3
+          #      - mim/small_tests:
+          #          name: small_tests_21_3
+          #          otp: 1:21.3.8.6-1
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_21_3
+          #      - mim/small_tests:
+          #          name: small_tests_22
+          #          otp: 1:22.0.7-1
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_22
+          #      # ============= DIALYZER =============
+          #      - mim/dialyzer:
+          #          name: dialyzer
+          #          otp: 1:22.0.7-1
+          #          context: mongooseim-org
+          #      # ============= MOST RECENT VERSION TESTS =============
+          #      - mim/big_tests:
+          #          name: mysql_redis
+          #          otp: 1:22.0.7-1
+          #          preset: mysql_redis
+          #          db: mysql
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_22
+          #      - mim/big_tests:
+          #          name: mssql_mnesia
+          #          otp: 1:22.0.7-1
+          #          preset: odbc_mssql_mnesia
+          #          db: mssql
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_22
+          #      - mim/big_tests:
+          #          name: internal_mnesia
+          #          otp: 1:22.0.7-1
+          #          preset: internal_mnesia
+          #          db: mnesia
+          #          tls_dist: true
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_22
+          #      - mim/big_tests:
+          #          name: elasticsearch_and_cassandra
+          #          otp: 1:22.0.7-1
+          #          preset: elasticsearch_and_cassandra_mnesia
+          #          db: "elasticsearch cassandra"
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_22
+          #      - mim/big_tests:
+          #          name: riak_mnesia
+          #          otp: 1:22.0.7-1
+          #          preset: riak_mnesia
+          #          db: riak
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_22
+          #      # ============= 1 VERSION OLDER TESTS =============
+          #      - mim/big_tests:
+          #          name: pgsql_mnesia
+          #          otp: 1:21.3.8.6-1
+          #          preset: pgsql_mnesia
+          #          db: pgsql
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_21_3
+          #      # ============= 2 VERSIONS OLDER TESTS =============
+          #      - mim/big_tests:
+          #          name: ldap_mnesia
+          #          otp: 1:20.3.8.22-1
+          #          preset: ldap_mnesia
+          #          db: mnesia
+          #          context: mongooseim-org
+          #          requires:
+          #            - otp_20_3
+      # ============= DOCKER IMAGE BUILD & UPLOAD =============
+      - mim/docker_image:
+          name: docker_build_and_ship
           otp: 1:22.0.7-1
           context: mongooseim-org
           requires:
-            - otp_22
-      # ============= DIALYZER =============
-      - mim/dialyzer:
-          name: dialyzer
-          otp: 1:22.0.7-1
-          context: mongooseim-org
-      # ============= MOST RECENT VERSION TESTS =============
-      - mim/big_tests:
-          name: mysql_redis
-          otp: 1:22.0.7-1
-          preset: mysql_redis
-          db: mysql
-          context: mongooseim-org
-          requires:
-            - otp_22
-      - mim/big_tests:
-          name: mssql_mnesia
-          otp: 1:22.0.7-1
-          preset: odbc_mssql_mnesia
-          db: mssql
-          context: mongooseim-org
-          requires:
-            - otp_22
-      - mim/big_tests:
-          name: internal_mnesia
-          otp: 1:22.0.7-1
-          preset: internal_mnesia
-          db: mnesia
-          tls_dist: true
-          context: mongooseim-org
-          requires:
-            - otp_22
-      - mim/big_tests:
-          name: elasticsearch_and_cassandra
-          otp: 1:22.0.7-1
-          preset: elasticsearch_and_cassandra_mnesia
-          db: "elasticsearch cassandra"
-          context: mongooseim-org
-          requires:
-            - otp_22
-      - mim/big_tests:
-          name: riak_mnesia
-          otp: 1:22.0.7-1
-          preset: riak_mnesia
-          db: riak
-          context: mongooseim-org
-          requires:
-            - otp_22
-      # ============= 1 VERSION OLDER TESTS =============
-      - mim/big_tests:
-          name: pgsql_mnesia
-          otp: 1:21.3.8.6-1
-          preset: pgsql_mnesia
-          db: pgsql
-          context: mongooseim-org
-          requires:
-            - otp_21_3
-      # ============= 2 VERSIONS OLDER TESTS =============
-      - mim/big_tests:
-          name: ldap_mnesia
-          otp: 1:20.3.8.22-1
-          preset: ldap_mnesia
-          db: mnesia
-          context: mongooseim-org
-          requires:
-            - otp_20_3
-
+              otp_22
+              #            - ldap_mnesia
+              #            - pgsql_mnesia
+              #            - riak_mnesia
+              #            - elasticsearch_and_cassandra
+              #            - internal_mnesia
+              #            - mysql_redis
+              #            - odbc_mssql_mnesia
+              #            - dialyzer
+              #            - small_tests_22
+              #            - small_tests_21_3
+              #            - small_tests_20_3
+              #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ workflows:
           otp: 1:22.0.7-1
           context: mongooseim-org
           requires:
-              otp_22
+              - otp_22
               #            - ldap_mnesia
               #            - pgsql_mnesia
               #            - riak_mnesia

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ workflows:
             - elasticsearch_and_cassandra
             - internal_mnesia
             - mysql_redis
-            - odbc_mssql_mnesia
+            - mssql_mnesia
             - dialyzer
             - small_tests_22
             - small_tests_21_3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,10 @@ orbs:
           otp:
             type: string
             description: Version of the Erlang package to install
-          build_releases:
+          build_prod:
             type: boolean
-            description: Flag to build release or not
-            default: true
+            description: When enabled, prod release will be generated besides the dev ones
+            default: false
 
         environment:
           SKIP_RELEASE: 1
@@ -74,9 +74,12 @@ orbs:
               command: |
                 make certs
           - run:
-              name: Install Releases
+              name: Generate development releases
+              command: ./tools/build-releases.sh
+          - run:
+              name: Generate prod release
               command: |
-                if [ <<parameters.build_releases>> ]; then ./tools/build-releases.sh ; fi
+                if [ <<parameters.build_prod>> ]; then make rel; fi
           - run:
               name: Build Big Tests
               command: |
@@ -248,20 +251,19 @@ orbs:
           image: ubuntu-1604:201903-01
         working_directory: ~/app
         parameters:
-          otp:
-            type: string
-            description: Version of the Erlang package to use for Docker image
         environment:
-            OTP_RELEASE: <<parameters.otp>>
         steps:
           - checkout
           - run:
               name: Prepare for cache
               command: |
-                ./tools/circleci-otp-to-str.sh <<parameters.otp>> > otp_version
+                ./tools/circleci-otp-to-str.sh <<parameters.otp_package>> > otp_version
           - restore_cache:
               keys:
                 - build-cache-{{ .Branch }}-{{ .Revision }}--{{ checksum "otp_version" }}
+          - restore_cache:
+              keys:
+                - deps-cache--{{ checksum "rebar.lock" }}--{{ checksum "big_tests/rebar.lock" }}--{{ checksum "otp_version" }}
           - run:
               name: Execute Docker image build and upload
               command: tools/circle-build-and-push-docker.sh
@@ -291,6 +293,7 @@ workflows:
       - mim/build:
           name: otp_22
           otp: 1:22.0.7-1
+          build_prod: true
           context: mongooseim-org
           #      # ============= SMALL TESTS =============
           #      - mim/small_tests:
@@ -379,7 +382,6 @@ workflows:
       # ============= DOCKER IMAGE BUILD & UPLOAD =============
       - mim/docker_image:
           name: docker_build_and_ship
-          otp: 1:22.0.7-1
           context: mongooseim-org
           requires:
               - otp_22

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,6 @@ after_failure:
         - tail -100 _build/mim1/rel/mongooseim/log/ejabberd.log
         - tail -100 _build/mim2/rel/mongooseim/log/ejabberd.log
 
-after_success:
-        - if [ -n "${DOCKERHUB_PASS}" ] && [ $PRESET = 'internal_mnesia' ];
-            then tools/travis-build-and-push-docker.sh;
-          fi
-
 after_script:
         - cat travis-pull-db.log
         # Upload logs to s3 for debugging

--- a/tools/build-releases.sh
+++ b/tools/build-releases.sh
@@ -3,7 +3,7 @@
 # - DEV_NODES - a list of releases to build
 #
 # By default all releases are built
-# When DEV_NODES is empty, no releases are built
+# When DEV_NODES is empty, all development releases are built
 
 # Use bash "strict mode"
 # Based on http://redsymbol.net/articles/unofficial-bash-strict-mode/

--- a/tools/build-releases.sh
+++ b/tools/build-releases.sh
@@ -2,7 +2,6 @@
 # Env variable:
 # - DEV_NODES - a list of releases to build
 #
-# By default all releases are built
 # When DEV_NODES is empty, all development releases are built
 
 # Use bash "strict mode"

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-MIM_TAR_FULL_NAME=mongooseim-$CIRCLE_BRANCH.OTP-$OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2
+#MIM_TAR_FULL_NAME=mongooseim-$CIRCLE_BRANCH.OTP-$OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2
 MONGOOSE_TGZ=mongooseim.tar.gz
 
 BUILD_PATH=_build/prod/rel/mongooseim
 
-tar -cjh --transform="s,${BUILD_PATH},mongooseim-${CIRCLE_BRANCH},S" -f ${MIM_TAR_FULL_NAME} ${BUILD_PATH}
+#tar -cjh --transform="s,${BUILD_PATH},mongooseim-${CIRCLE_BRANCH},S" -f ${MIM_TAR_FULL_NAME} ${BUILD_PATH}
 tar czh --transform="s,${BUILD_PATH},mongooseim,S" -f $MONGOOSE_TGZ ${BUILD_PATH}
 
 export BUILDS=`pwd`

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -14,9 +14,7 @@ DOCKERHUB_TAG=${CIRCLE_BRANCH}
 VERSION=`tools/generate_vsn.sh`
 GIT_REF=`git rev-parse --short HEAD`
 
-if [ -n ${CIRCLE_PR_NUMBER} ]; then
-    DOCKERHUB_TAG="PR-${CIRCLE_PR_NUMBER}"
-elif [ ${CIRCLE_BRANCH} == 'master' ]; then
+if [ ${CIRCLE_BRANCH} == 'master' ]; then
     DOCKERHUB_TAG="latest";
 fi
 

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
 
-#MIM_TAR_FULL_NAME=mongooseim-$CIRCLE_BRANCH.OTP-$OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2
 MONGOOSE_TGZ=mongooseim.tar.gz
 
 BUILD_PATH=_build/prod/rel/mongooseim
 
-#tar -cjh --transform="s,${BUILD_PATH},mongooseim-${CIRCLE_BRANCH},S" -f ${MIM_TAR_FULL_NAME} ${BUILD_PATH}
 tar czh --transform="s,${BUILD_PATH},mongooseim,S" -f $MONGOOSE_TGZ ${BUILD_PATH}
 
 export BUILDS=`pwd`
 
-DOCKERHUB_TAG=${CIRCLE_BRANCH}
+# We use commit hash by default, because branch name may contain characters
+# that are illegal for Docker tags, e.g. '/'.
+DOCKERHUB_TAG=${CIRCLE_SHA1}
 VERSION=`tools/generate_vsn.sh`
 GIT_REF=`git rev-parse --short HEAD`
 
-if [ ${CIRCLE_BRANCH} == 'master' ]; then
+if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+    # CircleCI doesn't provide PR number in env. var., so we need to extract it from PR URL
+    # May not work with different service than GitHub
+    # TODO: Possibly change it to something else during Tide integration
+    PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
+    DOCKERHUB_TAG="PR-${PR_NUMBER}"
+elif [ ${CIRCLE_BRANCH} == 'master' ]; then
     DOCKERHUB_TAG="latest";
 fi
+
+# TODO: Add DOCKERHUB=${VERSION} when CircleCI handles weekly builds as well
 
 echo "Tag: ${DOCKERHUB_TAG}"
 
@@ -34,6 +42,6 @@ docker build -f Dockerfile.member -t ${IMAGE_TAG} \
 	     --build-arg VERSION=${VERSION} \
 	     .
 
-#docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
+docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
 
-#docker push ${IMAGE_TAG}
+docker push ${IMAGE_TAG}

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -1,30 +1,23 @@
 #!/bin/bash
 
-./tools/configure with-all
-make rel
-
-MIM_TAR_FULL_NAME=mongooseim-$TRAVIS_BRANCH.OTP-$TRAVIS_OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2
+MIM_TAR_FULL_NAME=mongooseim-$CIRCLE_BRANCH.OTP-$OTP_RELEASE.$(lsb_release -is | tr "A-Z" "a-z").$(lsb_release -rs).$(uname -m).tar.bz2
 MONGOOSE_TGZ=mongooseim.tar.gz
 
 BUILD_PATH=_build/prod/rel/mongooseim
 
-tar -cjh --transform="s,${BUILD_PATH},mongooseim-${TRAVIS_BRANCH},S" -f ${MIM_TAR_FULL_NAME} ${BUILD_PATH}
+tar -cjh --transform="s,${BUILD_PATH},mongooseim-${CIRCLE_BRANCH},S" -f ${MIM_TAR_FULL_NAME} ${BUILD_PATH}
 tar czh --transform="s,${BUILD_PATH},mongooseim,S" -f $MONGOOSE_TGZ ${BUILD_PATH}
 
 export BUILDS=`pwd`
 
-DOCKERHUB_TAG=${TRAVIS_BRANCH}
+DOCKERHUB_TAG=${CIRCLE_BRANCH}
 VERSION=`tools/generate_vsn.sh`
 GIT_REF=`git rev-parse --short HEAD`
 
-if [ ${TRAVIS_PULL_REQUEST} != 'false' ]; then
-    DOCKERHUB_TAG="PR-${TRAVIS_PULL_REQUEST}"
-elif [ ${TRAVIS_BRANCH} == 'master' ]; then
+if [ -n ${CIRCLE_PR_NUMBER} ]; then
+    DOCKERHUB_TAG="PR-${CIRCLE_PR_NUMBER}"
+elif [ ${CIRCLE_BRANCH} == 'master' ]; then
     DOCKERHUB_TAG="latest";
-fi
-
-if [ ${TRAVIS_EVENT_TYPE} == 'cron' ]; then
-    DOCKERHUB_TAG=${VERSION};
 fi
 
 echo "Tag: ${DOCKERHUB_TAG}"
@@ -43,6 +36,6 @@ docker build -f Dockerfile.member -t ${IMAGE_TAG} \
 	     --build-arg VERSION=${VERSION} \
 	     .
 
-docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
+#docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
 
-docker push ${IMAGE_TAG}
+#docker push ${IMAGE_TAG}


### PR DESCRIPTION
This PR changes following stuff:

1. Renames `otp` parameter in many of Circle jobs to `otp_package` because it's more accurate actually.
2. Adds an optional step to build prod release in `build` job. It's faster to create it preemptively than do it in Docker job
3. Adds `docker_image` job to CircleCI, which builds and pushes an image based on OTP 22.0 prod build.
4. Adds `docker_build_and_ship` workflow that is executed when all other jobs are successful (except for packaging jobs).
5. Travis no longer builds and pushes Docker images
6. Commit hash is now the default image tag, instead of branch name
7. PR number is extracted from PR URL, because Circle doesn't provide an env. var. with the number.
8. Logic for special tags of cron jobs is temporarily disabled until we add cron builds to CircleCI.

**EDIT:** Confirmed to work:
https://hub.docker.com/layers/mongooseim/mongooseim/PR-2439/images/sha256-13081b95d0cbd85f2e5f539a653c96cd781598b093279fdfd1dcbbae99072f69