### PR TITLE
Send coverage report from small tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,6 @@ orbs:
                 sudo pip install codecov && codecov
                 ./rebar3 codecov analyze
                 codecov --disable=gcov --env PRESET
-                ./rebar3 coveralls send || true
           - run:
               name: Upload results
               when: always
@@ -237,7 +236,6 @@ orbs:
                 sudo pip install codecov && codecov
                 ./rebar3 codecov analyze
                 codecov --disable=gcov --env PRESET
-                ./rebar3 coveralls send || true
           - run:
               name: Build Failed - Logs
               when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,8 @@ orbs:
           otp:
             type: string
             description: Version of the Erlang package to install
+        environment:
+          PRESET: small_tests
         steps:
           - checkout
           - fetch_packages
@@ -134,13 +136,22 @@ orbs:
               command: |
                 SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p small_tests -s true
           - run:
+              name: Coverage
+              when: on_success
+              command: |
+                echo "Success!"
+                sudo pip install codecov && codecov
+                ./rebar3 codecov analyze
+                codecov --disable=gcov --env PRESET
+                ./rebar3 coveralls send || true
+          - run:
               name: Upload results
               when: always
               command: |
                   tools/circleci-prepare-log-dir.sh
                   if [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then tools/circleci-upload-to-s3.sh; fi
 
-                
+
       package:
         parallelism: 1
         machine:

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,5 @@ xeplist:
 install: configure.out rel
 	@. ./configure.out && tools/install
 
-cover_report: /tmp/mongoose_combined.coverdata
-	$(RUN) erl -noshell -pa _build/default/lib/*/ebin \
-			-eval 'ecoveralls:travis_ci("$?"), init:stop()'
-
 elvis:
 	rebar3 as lint lint

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM)
 [![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](https://mongooseim.readthedocs.org/en/latest/?badge=latest)
-[![Coverage Status](https://img.shields.io/coveralls/esl/MongooseIM.svg)](https://coveralls.io/r/esl/MongooseIM?branch=master)
 [![codecov](https://codecov.io/gh/esl/MongooseIM/branch/master/graph/badge.svg)](https://codecov.io/gh/esl/MongooseIM)
 [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
 
@@ -13,8 +12,8 @@
 * Product page: [https://www.erlang-solutions.com/products/mongooseim.html](https://www.erlang-solutions.com/products/mongooseim.html)
 * Documentation: [https://mongooseim.readthedocs.org/](https://mongooseim.readthedocs.org/)
 
-## Get to know MongooseIM 
-MongooseIM is a robust and efficient chat (or instant messaging) platform aimed at large installations. 
+## Get to know MongooseIM
+MongooseIM is a robust and efficient chat (or instant messaging) platform aimed at large installations.
 
 <img align="left" src="doc/MongooseIM_logo.png" alt="MongooseIM platform's logo"/>
 
@@ -56,7 +55,7 @@ Check out our test results:
 * Continuous integration: [https://travis-ci.org/esl/MongooseIM](https://travis-ci.org/esl/MongooseIM)
 * Code coverage: [https://coveralls.io/github/esl/MongooseIM](https://coveralls.io/github/esl/MongooseIM)
 * Continuous Load Testing: [https://tide.erlang-solutions.com/](https://tide.erlang-solutions.com/)
-* Load test history:  
+* Load test history:
   ![Load test history](https://tide.erlang-solutions.com/charts/bidaily_last_year.png)
 
 
@@ -79,7 +78,7 @@ Latest releases:
 * [1.6.1](https://mongooseim.readthedocs.io/en/1.6.1/)
 * [1.6.0](https://mongooseim.readthedocs.io/en/1.6.0/)
 
- 
+
 **MongooseIM documentation highligts:**
 
 When developing new features/modules, please make sure you add basic documentation to the 'doc/' directory, and add a link to your document in 'doc/README.md.'
@@ -94,7 +93,7 @@ When developing new features/modules, please make sure you add basic documentati
 * [REST API](https://mongooseim.readthedocs.io/en/latest/rest-api/Client-frontend/). Explore MongooseIM features using our REST API and [Swagger documentation](https://mongooseim.readthedocs.io/en/latest/swagger/index.html).
 * [Operation and maintenance](https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/Cluster-management-considerations/). See what to consider when building, monitoring, testing and distributing MongooseIM clusters.
 * [Server developer's guide](doc/developers-guide/Testing-MongooseIM.md). Get all the information you need to expand MongooseIM platform.
-    
+
 
 ## Participate!
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,5 @@
 # MongooseIM platform
-[![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM) [![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](https://mongooseim.readthedocs.org/en/latest/?badge=latest) [![Coverage Status](https://img.shields.io/coveralls/esl/MongooseIM.svg)](https://coveralls.io/r/esl/MongooseIM?branch=master) [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
+[![Build Status](https://travis-ci.org/esl/MongooseIM.svg?branch=master)](https://travis-ci.org/esl/MongooseIM) [![Documentation Status](https://readthedocs.org/projects/mongooseim/badge/?version=latest)](https://mongooseim.readthedocs.org/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/esl/MongooseIM/branch/master/graph/badge.svg)](https://codecov.io/gh/esl/MongooseIM) [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
 
 * Home: [http://github.com/esl/MongooseIM](http://github.com/esl/MongooseIM)
 * Product page: [https://www.erlang-solutions.com/products/mongooseim.html](https://www.erlang-solutions.com/products/mongooseim.html)
@@ -8,7 +8,7 @@
 
 ## Get to know MongooseIM
 
-MongooseIM is a robust and efficient chat (or instant messaging) platform aimed at large installations. 
+MongooseIM is a robust and efficient chat (or instant messaging) platform aimed at large installations.
 
 <img align="left" src="MongooseIM_logo.png" alt="MongooseIM platform's logo" style="padding-right: 20px;"/>
 
@@ -63,9 +63,9 @@ For a quick start just download:
 Check out our test results:
 
 * Continuous integration: [https://travis-ci.org/esl/MongooseIM](https://travis-ci.org/esl/MongooseIM)
-* Code coverage: [https://coveralls.io/github/esl/MongooseIM](https://coveralls.io/github/esl/MongooseIM)
+* Code coverage: [https://codecov.io/gh/esl/MongooseIM](https://codecov.io/gh/esl/MongooseIM)
 * Continuous Load Testing: [http://tide.erlang-solutions.com/](http://tide.erlang-solutions.com/)
-* Load test history:  
+* Load test history:
   ![Load test history](https://tide.erlang-solutions.com/charts/bidaily_last_year.png)
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -144,7 +144,6 @@
   {rebar_faster_deps, {git, "https://github.com/arcusfelis/rebar3-faster-deps-plugin.git",
       {ref, "eb3cded5b050edd82cf8653f8c850c6c9890f732"}}},
   {pc, {git, "https://github.com/blt/port_compiler.git", {ref, "c2f3fb1"}}},
-  {coveralls, {git, "https://github.com/michalwski/coveralls-erl.git", {ref, "f124a62"}}},
   {provider_asn1, {git, "https://github.com/knusbaum/provider_asn1.git", {ref, "29f7850"}}},
   {rebar3_codecov, {git, "https://github.com/zofpolkowska/rebar3_codecov.git", {ref, "b539c5c"}}},
   {rebar3_lint, {git, "https://github.com/project-fifo/rebar3_lint.git", {tag, "0.1.2"}}}
@@ -181,11 +180,9 @@
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.
-{coveralls_coverdata, ["/tmp/mongoose_combined.coverdata", "_build/test/cover/ct.coverdata"]}.
-{coveralls_service_name, "circle-ci"}.
 
 {codecov_opts,
  [
   %% Assuming /tmp/mongoose_combined.coverdata
-  {path, ["/tmp", "_build/test/cover/ct.coverdata"]}
+  {path, ["/tmp", "_build/test/cover"]}
  ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -181,11 +181,11 @@
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.
-{coveralls_coverdata, "/tmp/mongoose_combined.coverdata"}.
+{coveralls_coverdata, ["/tmp/mongoose_combined.coverdata", "_build/test/cover/ct.coverdata"]}.
 {coveralls_service_name, "circle-ci"}.
 
 {codecov_opts,
  [
   %% Assuming /tmp/mongoose_combined.coverdata
-  {path, ["/tmp"]}
+  {path, ["/tmp", "_build/test/cover/ct.coverdata"]}
  ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -35,19 +35,6 @@ fun() ->
         end
 end,
 
-MaybeConfigureCoveralls =
-fun(Config) ->
-case os:getenv("CI") of
-    "true" ->
-        Token = os:getenv("COVERALLS_REPO_TOKEN"),
-        JobId   = os:getenv("CIRCLE_BUILD_NUM"),
-        CONFIG1 = lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId}),
-        lists:keystore(coveralls_repo_token, 1, CONFIG1, {coveralls_repo_token, Token});
-    _ ->
-        Config
-end
-end,
-
 DevAppsToInclude =
 fun() ->
         case os:getenv("DEVNODE") of
@@ -84,6 +71,5 @@ MaybeFIPSSupport = fun(Config) ->
     end
 end,
 
-Config0 = MaybeConfigureCoveralls(CONFIG),
-Config1 = SetupIncludedApps(Config0, EnvApps),
+Config1 = SetupIncludedApps(CONFIG, EnvApps),
 MaybeFIPSSupport(Config1).


### PR DESCRIPTION
This PR addresses re-enables coverage reporting from small tests. It also removes integration with coveralls which was broken since Jun.
