### PR TITLE
Inbox/fix chat markers being stored incorrectly

### DIFF
--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -13,6 +13,9 @@
 
 -export([update_inbox_for_muc/1, start/1, stop/1]).
 
+%% For test purposes only
+-export([handle_outgoing_message/4, handle_incoming_message/4]).
+
 %% User jid example is "alice@localhost"
 -type user_jid() :: jid:jid().
 %% Receiver's host in lowercase
@@ -23,7 +26,7 @@
 
 start(Host) ->
     ejabberd_hooks:add(update_inbox_for_muc, Host, ?MODULE, update_inbox_for_muc, 90),
-    % TODO check ooptions: if system messages stored ->
+    % TODO check options: if system messages stored ->
     % add hook handler for system messages on hook ie. invitation_sent
     ok.
 

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -95,13 +95,8 @@ direction(From, To) ->
       To :: receiver_bare_user_jid(),
       Packet :: packet().
 handle_outgoing_message(Host, Room, To, Packet) ->
-    Markers = mod_inbox_utils:get_reset_markers(Host),
-    case mod_inbox_utils:if_chat_marker_get_id(Packet, Markers) of
-        undefined ->
-            mod_inbox_utils:write_to_sender_inbox(Host, To, Room, Packet);
-        Id ->
-            mod_inbox_utils:reset_unread_count(To, Room, Id)
-    end.
+    maybe_reset_unread_count(Host, To, Room, Packet),
+    maybe_write_to_inbox(Host, To, Room, Packet, fun write_to_sender_inbox/4).
 
 -spec handle_incoming_message(Host, Room, To, Packet) -> term() when
       Host :: receiver_host(),
@@ -109,14 +104,19 @@ handle_outgoing_message(Host, Room, To, Packet) ->
       To :: receiver_bare_user_jid(),
       Packet :: packet().
 handle_incoming_message(Host, Room, To, Packet) ->
-    Markers = mod_inbox_utils:get_reset_markers(Host),
-    case mod_inbox_utils:has_chat_marker(Packet, Markers) of
-        true ->
-            %% don't store chat markers in inbox
-            ok;
-        false ->
-            mod_inbox_utils:write_to_receiver_inbox(Host, Room, To, Packet)
-    end.
+    maybe_write_to_inbox(Host, Room, To, Packet, fun write_to_receiver_inbox/4).
+
+maybe_reset_unread_count(Host, User, Room, Packet) ->
+    mod_inbox_utils:maybe_reset_unread_count(Host, User, Room, Packet).
+
+maybe_write_to_inbox(Host, User, Remote, Packet, WriteF) ->
+    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, WriteF).
+
+write_to_sender_inbox(Server, User, Remote, Packet) ->
+    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet).
+
+write_to_receiver_inbox(Server, User, Remote, Packet) ->
+    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet).
 
 %% @doc Check, that the host is served by MongooseIM.
 %% A local host can be used to fire hooks or write into database on this node.

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -16,34 +16,27 @@
 -include("mongoose.hrl").
 
 -export([handle_outgoing_message/4, handle_incoming_message/4]).
+
 -type packet() :: exml:element().
 -type role() :: r_member() | r_owner() | r_none().
 -type r_member() :: binary().
 -type r_owner() :: binary().
 -type r_none() :: binary().
 
-
 -spec handle_outgoing_message(Host :: jid:server(),
                               User :: jid:jid(),
                               Room :: jid:jid(),
                               Packet :: packet()) -> any().
 handle_outgoing_message(Host, User, Room, Packet) ->
-    Markers = mod_inbox_utils:get_reset_markers(Host),
-    case mod_inbox_utils:if_chat_marker_get_id(Packet, Markers) of
-        undefined ->
-            %% we store in inbox only on incoming messages
-            ok;
-        Id ->
-            mod_inbox_utils:reset_unread_count(User, Room, Id)
-    end.
+    maybe_reset_unread_count(Host, User, Room, Packet).
 
 -spec handle_incoming_message(Host :: jid:server(),
                               RoomUser :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet()) -> any().
 handle_incoming_message(Host, RoomUser, Remote, Packet) ->
-    Markers = mod_inbox_utils:get_reset_markers(Host),
-    case mod_inbox_utils:has_chat_marker(Packet, Markers) of
+    AllMarkers = [<<"received">>, <<"displayed">>, <<"acknowledged">>],
+    case mod_inbox_utils:has_chat_marker(Packet, AllMarkers) of
         true ->
             %% don't store chat markers in inbox
             ok;
@@ -51,17 +44,20 @@ handle_incoming_message(Host, RoomUser, Remote, Packet) ->
             maybe_handle_system_message(Host, RoomUser, Remote, Packet)
     end.
 
+maybe_reset_unread_count(Host, User, Room, Packet) ->
+    mod_inbox_utils:maybe_reset_unread_count(Host, User, Room, Packet).
+
 -spec maybe_handle_system_message(Host :: host(),
-                                  RoomUser :: jid:jid(),
+                                  RoomOrUser :: jid:jid(),
                                   Receiver :: jid:jid(),
                                   Packet :: exml:element()) -> ok.
-maybe_handle_system_message(Host, RoomUser, Receiver, Packet) ->
-    case is_system_message(RoomUser, Receiver, Packet) of
+maybe_handle_system_message(Host, RoomOrUser, Receiver, Packet) ->
+    case is_system_message(RoomOrUser, Receiver, Packet) of
         true ->
-            handle_system_message(Host, RoomUser, Receiver, Packet);
+            handle_system_message(Host, RoomOrUser, Receiver, Packet);
         _ ->
-            Sender = jid:from_binary(RoomUser#jid.lresource),
-            write_to_inbox(Host, RoomUser, Receiver, Sender, Packet)
+            Sender = jid:from_binary(RoomOrUser#jid.lresource),
+            write_to_inbox(Host, RoomOrUser, Receiver, Sender, Packet)
     end.
 
 -spec handle_system_message(Host :: host(),
@@ -72,7 +68,7 @@ handle_system_message(Host, Room, Remote, Packet) ->
     case system_message_type(Remote, Packet) of
         kick ->
             handle_kicked_message(Host, Room, Remote, Packet);
-        invite->
+        invite ->
             handle_invitation_message(Host, Room, Remote, Packet);
         other ->
             ?DEBUG("event=unknown_system_message_for_mod_inbox_muclight,stanza='~p'", [Packet]),
@@ -96,14 +92,14 @@ handle_kicked_message(Host, Room, Remote, Packet) ->
     maybe_remove_inbox_row(Host, Room, Remote, CheckRemove).
 
 -spec maybe_store_system_message(Host :: host(),
-                                  Room :: jid:jid(),
-                                  Remote :: jid:jid(),
-                                  Packet :: exml:element()) -> ok.
+                                 Room :: jid:jid(),
+                                 Remote :: jid:jid(),
+                                 Packet :: exml:element()) -> ok.
 maybe_store_system_message(Host, Room, Remote, Packet) ->
     WriteAffChanges = mod_inbox_utils:get_option_write_aff_changes(Host),
     case WriteAffChanges of
         true ->
-            mod_inbox_utils:write_to_receiver_inbox(Host, Room, Remote, Packet);
+            write_to_inbox(Host, Room, Remote, Room, Packet);
         false ->
             ok
     end.
@@ -132,7 +128,7 @@ write_to_inbox(Server, RoomUser, Remote, _Sender, Packet) ->
 %%%%%%%
 %% Predicate funs
 
-%% check if sender is just 'roomname@muclight.domain' with no resource
+%% @doc Check if sender is just 'roomname@muclight.domain' with no resource
 -spec  is_system_message(Sender :: jid:jid(),
                          Receiver :: jid:jid(),
                          Packet :: exml:element()) -> boolean().

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -35,8 +35,7 @@ handle_outgoing_message(Host, User, Room, Packet) ->
                               Remote :: jid:jid(),
                               Packet :: packet()) -> any().
 handle_incoming_message(Host, RoomUser, Remote, Packet) ->
-    AllMarkers = [<<"received">>, <<"displayed">>, <<"acknowledged">>],
-    case mod_inbox_utils:has_chat_marker(Packet, AllMarkers) of
+    case mod_inbox_utils:has_chat_marker(Packet) of
         true ->
             %% don't store chat markers in inbox
             ok;

--- a/src/inbox/mod_inbox_one2one.erl
+++ b/src/inbox/mod_inbox_one2one.erl
@@ -21,29 +21,24 @@
                               Remote :: jid:jid(),
                               Packet :: packet()) -> ok.
 handle_outgoing_message(Host, User, Remote, Packet) ->
-    Markers = mod_inbox_utils:get_reset_markers(Host),
-    case mod_inbox_utils:if_chat_marker_get_id(Packet, Markers) of
-        undefined ->
-            FromBin = jid:to_binary(User),
-            Packet2 = mod_inbox_utils:fill_from_attr(Packet, FromBin),
-            Server = User#jid.lserver,
-            mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet2);
-        Id ->
-            mod_inbox_utils:reset_unread_count(User, Remote, Id)
-    end.
+    maybe_reset_unread_count(Host, User, Remote, Packet),
+    maybe_write_to_inbox(Host, User, Remote, Packet, fun write_to_sender_inbox/4).
+
 -spec handle_incoming_message(Host :: jid:server(),
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet()) -> ok | {ok, integer()}.
 handle_incoming_message(Host, User, Remote, Packet) ->
-    Markers = mod_inbox_utils:get_reset_markers(Host),
-    case mod_inbox_utils:if_chat_marker_get_id(Packet, Markers) of
-        undefined ->
-            FromBin = jid:to_binary(User),
-            Packet2 = mod_inbox_utils:fill_from_attr(Packet, FromBin),
-            mod_inbox_utils:write_to_receiver_inbox(Host, User, Remote, Packet2);
-        _Id ->
-            %% do not store chat markers in inbox
-            ok
-    end.
+    maybe_write_to_inbox(Host, User, Remote, Packet, fun write_to_receiver_inbox/4).
 
+maybe_reset_unread_count(Host, User, Remote, Packet) ->
+    mod_inbox_utils:maybe_reset_unread_count(Host, User, Remote, Packet).
+
+maybe_write_to_inbox(Host, User, Remote, Packet, WriteF) ->
+    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, WriteF).
+
+write_to_sender_inbox(Server, User, Remote, Packet) ->
+    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet).
+
+write_to_receiver_inbox(Server, User, Remote, Packet) ->
+    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet).

--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -25,13 +25,16 @@
          clear_inbox/2,
          get_reset_markers/1,
          if_chat_marker_get_id/2,
+         has_chat_marker/1,
          has_chat_marker/2,
          fill_from_attr/2,
          wrapper_id/0,
          get_option_write_aff_changes/1,
          get_option_remove_on_kicked/1,
          reset_marker_to_bin/1,
-         get_inbox_unread/2]).
+         get_inbox_unread/2,
+         all_chat_markers/0
+        ]).
 
 -spec maybe_reset_unread_count(Server :: host(),
                                User :: jid:jid(),
@@ -118,6 +121,12 @@ if_chat_marker_get_id(Packet, Marker) ->
         _ ->
             undefined
     end.
+
+
+-spec has_chat_marker(Packet :: exml:element()) -> boolean().
+has_chat_marker(Packet) ->
+    has_chat_marker(Packet, mod_inbox_utils:all_chat_markers()).
+
 -spec has_chat_marker(Packet :: exml:element(), list(marker())) -> boolean().
 has_chat_marker(Packet, Markers) ->
     case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS, no_marker) of
@@ -135,8 +144,7 @@ has_chat_marker(Packet, Markers) ->
       %% WriteF is write_to_receiver_inbox/4 or write_to_sender_inbox/4
       WriteF :: fun().
 maybe_write_to_inbox(Host, User, Remote, Packet, WriteF) ->
-    AllMarkers = [<<"received">>, <<"displayed">>, <<"acknowledged">>],
-    case mod_inbox_utils:has_chat_marker(Packet, AllMarkers) of
+    case mod_inbox_utils:has_chat_marker(Packet) of
         true ->
             ok;
         false ->
@@ -177,3 +185,6 @@ reset_marker_to_bin(Unknown) -> throw({unknown_marker, Unknown}).
 
 get_inbox_unread(User, Server) ->
     mod_inbox_backend:get_inbox_unread(User, Server).
+
+all_chat_markers() ->
+    [<<"received">>, <<"displayed">>, <<"acknowledged">>].

--- a/test/inbox_SUITE.erl
+++ b/test/inbox_SUITE.erl
@@ -1,0 +1,195 @@
+%%%-------------------------------------------------------------------
+%%% @author nelson vides
+%%% @copyright (C) 2019, Erlang Solutions
+%%% @doc
+%%%
+%%% @end
+%%% Created : 2019-09-05
+%%%-------------------------------------------------------------------
+-module(inbox_SUITE).
+-author('nelson.vides@erlang-solutions.com').
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+-include("mongoose_ns.hrl").
+
+%% API
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2
+        ]).
+
+%% Test cases
+-export([
+         incoming_any_marker_should_not_affect_inbox/1,
+         outgoing_any_marker_should_not_be_written_to_inbox/1,
+         outgoing_reset_marker_should_reset_unread_counter/1,
+         outgoing_other_marker_should_not_change_unread_counter/1,
+         has_chat_marker_tests/1
+        ]).
+
+all() ->
+    [
+     {group, one2one},
+     {group, muclight},
+     {group, muc},
+     has_chat_marker_tests
+    ].
+
+groups() ->
+    [
+     {one2one, [], check_marker_activity()},
+     {muclight, [], check_marker_activity()},
+     {muc, [], check_marker_activity()}
+    ].
+
+check_marker_activity() ->
+    [
+     incoming_any_marker_should_not_affect_inbox,
+     outgoing_any_marker_should_not_be_written_to_inbox,
+     outgoing_reset_marker_should_reset_unread_counter,
+     outgoing_other_marker_should_not_change_unread_counter
+    ].
+
+
+%%%===================================================================
+%%% Suite setup/teardown
+%%%===================================================================
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(stringprep),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%%===================================================================
+%%% Group specific setup/teardown
+%%%===================================================================
+init_per_group(one2one, Config) ->
+    [{module, mod_inbox_one2one}| Config];
+init_per_group(muclight, Config) ->
+    [{module, mod_inbox_muclight}| Config];
+init_per_group(muc, Config) ->
+    [{module, mod_inbox_muc}| Config].
+
+end_per_group(_,_C) ->
+    [].
+
+%%%===================================================================
+%%% Individual Test Cases
+%%%===================================================================
+
+has_chat_marker_tests(_) ->
+    AllMarkers = chat_markers(),
+    Funs = lists:flatten([
+        [
+         fun() -> ?assert(mod_inbox_utils:has_chat_marker(
+                            marker(M, ?NS_CHAT_MARKERS), [M])) end,
+         fun() -> ?assert(mod_inbox_utils:has_chat_marker(
+                            marker(M, ?NS_CHAT_MARKERS), AllMarkers)) end,
+         fun() -> ?assertNot(mod_inbox_utils:has_chat_marker(
+                               marker(<<"non-valid-marker">>, ?NS_CHAT_MARKERS), AllMarkers)) end,
+         fun() -> ?assertNot(mod_inbox_utils:has_chat_marker(
+                               marker(M, <<"unknown-namespace">>), [M])) end,
+         fun() -> ?assertNot(mod_inbox_utils:has_chat_marker(
+                               marker(M, <<"unknown-namespace">>), AllMarkers)) end
+        ] || M <- AllMarkers]),
+    Ret = lists:map(fun(F) -> F() end, Funs),
+    ?assert(lists:all(fun(X) -> X =:= ok end, Ret)),
+    ?assertEqual(length(Funs), length(Ret)).
+
+incoming_any_marker_should_not_affect_inbox(Config) ->
+    Mod = ?config(module, Config),
+    lists:foreach(
+      fun(Mark) ->
+              ct:log("Testing Marker ~p~n", [Mark]),
+              test_mod_inbox_one2one(Mark, fun Mod:handle_incoming_message/4),
+              ct:log("ok", [])
+      end,
+      chat_markers()
+     ).
+
+outgoing_any_marker_should_not_be_written_to_inbox(Config) ->
+    Mod = ?config(module, Config),
+    lists:foreach(
+      fun(Mark) ->
+              ct:log("Testing Marker ~p~n", [Mark]),
+              test_mod_inbox_one2one(Mark, fun Mod:handle_outgoing_message/4),
+              ct:log("ok", [])
+      end,
+      chat_markers()
+     ).
+
+outgoing_reset_marker_should_reset_unread_counter(Config) ->
+    Mod = ?config(module, Config),
+    test_mod_inbox_one2one(
+      <<"displayed">>,
+      fun(Host, User, Remote, Packet) ->
+              Mod:handle_outgoing_message(Host, User, Remote, Packet),
+              ?assert(meck:called(mod_inbox_utils, reset_unread_count, 3)),
+              ?assertEqual(0, meck:num_calls(mod_inbox_utils, write_to_sender_inbox, 4))
+      end).
+
+outgoing_other_marker_should_not_change_unread_counter(Config) ->
+    Mod = ?config(module, Config),
+    test_mod_inbox_one2one(
+      <<"received">>,
+      fun(Host, User, Remote, Packet) ->
+              Mod:handle_outgoing_message(Host, User, Remote, Packet),
+              ?assertNot(meck:called(mod_inbox_utils, reset_unread_count, 3)),
+              ?assertEqual(0, meck:num_calls(mod_inbox_utils, write_to_sender_inbox, 4))
+      end).
+
+test_mod_inbox_one2one(Mark, HandleMessage) ->
+    %% given
+    Marker = #xmlel{name = Mark,
+                    attrs = [{<<"xmlns">>, ?NS_CHAT_MARKERS},
+                             {<<"id">>, <<"fake-id">>}]},
+    Packet = #xmlel{name = <<"message">>, children = [Marker]},
+    Host = <<"localhost">>,
+    User = jid:make(<<"alice">>, Host, <<"wonderland">>),
+    Remote = jid:make(<<"bob">>, Host, <<"home">>),
+    %% test funs
+    Setup = fun setup_meck/0,
+    Test = fun() -> HandleMessage(Host, User, Remote, Packet) end,
+    Cleanup = fun unload_meck/0,
+    %% when / then
+    ?assertEqual(ok, run_one_eunit_test(Setup, Test, Cleanup)).
+
+%%%===================================================================
+%%% helper functions
+%%%===================================================================
+marker(MarkerKind, NS) ->
+    Marker = #xmlel{name = MarkerKind, attrs = [{<<"xmlns">>, NS}]},
+    #xmlel{name = <<"message">>, children = [Marker]}.
+
+run_one_eunit_test(Setup, Test, Cleanup) ->
+    try
+        Setup(),
+        Test()
+    after
+        Cleanup()
+    end.
+
+setup_meck() ->
+    ResetMarkers = [<<"displayed">>],
+    meck:new(mod_inbox_utils, [passthrough]),
+    meck:new(gen_mod, [passthrough]),
+    meck:expect(mod_inbox_utils, write_to_receiver_inbox, 4, marker_written),
+    meck:expect(mod_inbox_utils, write_to_sender_inbox, 4, marker_written),
+    meck:expect(mod_inbox_utils, get_reset_markers, 1, ResetMarkers),
+    meck:expect(mod_inbox_utils, reset_unread_count, 3, ok),
+    meck:expect(gen_mod, get_module_opt, 4,
+                fun(_,_,_,undefined) -> "localhost";
+                   (_,_,_,Def) -> Def
+                end).
+
+unload_meck() ->
+    meck:unload([mod_inbox_utils, gen_mod]).
+
+chat_markers() ->
+    [<<"displayed">>, <<"acknowledged">>, <<"received">>].

--- a/test/inbox_SUITE.erl
+++ b/test/inbox_SUITE.erl
@@ -192,4 +192,4 @@ unload_meck() ->
     meck:unload([mod_inbox_utils, gen_mod]).
 
 chat_markers() ->
-    [<<"displayed">>, <<"acknowledged">>, <<"received">>].
+    mod_inbox_utils:all_chat_markers().


### PR DESCRIPTION
The fix to one2one and muclight is a cherry-pick/rebase from Radek, the fix to muc is a port from the previous fixes. The tests are based on Radek's tests, but his were made on eunit, which wouldn't run on CI, so I lazily rewrote them to common_test.

There's a `has_chat_markers_tests` that basically tests if chat markers are correctly detected on a given stanza, and tries a lot of cases in one test. This was adapted from a eunit' fixture.

There are another four tests. The first one verifies whether inbox is not affected on any incoming chat marker, nor resetting the count nor saving it as a last message either. The three following tests verify the behaviour for outgoing messages: outgoing reset chat markers should reset the inbox count, outgoing chat markers which are not configured as reset should not affect the inbox count, and any chat marker should be stored as a last message whatsoever.

Funny thing that confused me for a while, notice how in `mod_inbox_muc:handle_outgoing_message`, the order of parameters is `Room, To`, but the functions inside are called with the inverted order `To, Room` 🤷‍♂ 