### PR TITLE
Get rid of binary_to_(existing_)atom

### DIFF
--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -89,7 +89,7 @@ check_password(LUser, LServer, Password) ->
               {env, Var} -> list_to_binary(os:getenv(Var))
           end,
     BinAlg = ejabberd_auth:get_opt(LServer, jwt_algorithm),
-    Alg = binary_to_atom(stringprep:tolower(BinAlg), latin1),
+    Alg = binary_to_atom(stringprep:tolower(BinAlg), utf8),
     case jwerl:verify(Password, Alg, Key) of
         {ok, TokenData} ->
             UserKey = ejabberd_auth:get_opt(LServer, jwt_username_key),

--- a/src/ejabberd_zlib.erl
+++ b/src/ejabberd_zlib.erl
@@ -81,7 +81,7 @@ recv_data2(ZlibSock, Packet) ->
             Res
     end.
 
--spec recv_data1(zlibsock(), iolist()) -> {'error', string()} | {'ok', binary()}.
+-spec recv_data1(zlibsock(), iolist()) -> {'error', atom()} | {'ok', binary()}.
 recv_data1(#zlibsock{zlibport = Port, inflate_size_limit = SizeLimit} = _ZlibSock, Packet) ->
     case port_control(Port, SizeLimit bsl 2 + ?INFLATE, Packet) of
         <<0, In/binary>> ->
@@ -90,7 +90,7 @@ recv_data1(#zlibsock{zlibport = Port, inflate_size_limit = SizeLimit} = _ZlibSoc
             {error, erlang:binary_to_existing_atom(Error, utf8)}
     end.
 
--spec send(zlibsock(), iolist()) -> ok | {error, string()}.
+-spec send(zlibsock(), iolist()) -> ok | {error, atom()}.
 send(#zlibsock{sockmod = SockMod, socket = Socket, zlibport = Port},
      Packet) ->
     case port_control(Port, ?DEFLATE, Packet) of

--- a/src/mod_auth_token.erl
+++ b/src/mod_auth_token.erl
@@ -62,7 +62,6 @@
       Owner :: jid:jid().
 
 -define(A2B(A), atom_to_binary(A, utf8)).
--define(B2A(B), binary_to_atom(B, utf8)).
 
 -define(I2B(I), integer_to_binary(I)).
 -define(B2I(B), binary_to_integer(B)).
@@ -348,7 +347,7 @@ default_validity_period(refresh) -> {25, days}.
       Token :: token().
 get_token_as_record(BToken) ->
     [BType, User, Expiry | Rest] = binary:split(BToken, <<(field_separator())>>, [global]),
-    T = #token{type = ?B2A(BType),
+    T = #token{type = decode_token_type(BType),
                expiry_datetime = seconds_to_datetime(binary_to_integer(Expiry)),
                user_jid = jid:from_binary(User)},
     T1 = case {BType, Rest} of
@@ -363,6 +362,14 @@ get_token_as_record(BToken) ->
                          mac_signature = base16:decode(BMAC)}
          end,
     T1#token{token_body = join_fields(T1)}.
+
+-spec decode_token_type(binary()) -> token_type().
+decode_token_type(<<"access">>) ->
+    access;
+decode_token_type(<<"refresh">>) ->
+    refresh;
+decode_token_type(<<"provision">>) ->
+    provision.
 
 -spec get_key_for_user(token_type(), jid:jid()) -> binary().
 get_key_for_user(TokenType, User) ->

--- a/src/mod_blocking.erl
+++ b/src/mod_blocking.erl
@@ -61,7 +61,7 @@ process_iq_set(Acc, From, _To, #iq{xmlns = ?NS_BLOCKING, sub_el = SubEl}) ->
     %% collect needed data
     #jid{luser = LUser, lserver = LServer} = From,
     #xmlel{name = BType} = SubEl,
-    Type = binary_to_existing_atom(BType, latin1),
+    Type = parse_command_type(BType),
     Usrs = exml_query:paths(SubEl, [{element, <<"item">>}, {attr, <<"jid">>}]),
     CurrList = case mod_privacy_backend:get_privacy_list(LUser, LServer, <<"blocking">>) of
                   {ok, List} ->
@@ -78,6 +78,9 @@ process_iq_set(Acc, From, _To, #iq{xmlns = ?NS_BLOCKING, sub_el = SubEl}) ->
     mongoose_acc:set(hook, result, Res1, Acc2);
 process_iq_set(Val, _, _, _) ->
     Val.
+
+parse_command_type(<<"block">>) -> block;
+parse_command_type(<<"unblock">>) -> unblock.
 
 %% @doc Set IQ must do the following:
 %% * get / create a dedicated privacy list (we call it "blocking")

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -391,8 +391,11 @@ lookup_recent_messages(ArcJID, WithJID, Before, Limit) ->
     L.
 
 subscription(Caller, Other, Action) ->
-    Act = binary_to_existing_atom(Action, latin1),
+    Act = decode_action(Action),
     run_subscription(Act, jid:from_binary(Caller), jid:from_binary(Other)).
+
+decode_action(<<"subscribe">>) -> subscribe;
+decode_action(<<"subscribed">>) -> subscribed.
 
 -spec run_subscription(subscribe | subscribed, jid:jid(), jid:jid()) -> ok.
 run_subscription(Type, CallerJid, OtherJid) ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3734,7 +3734,7 @@ set_xoption([{<<"muc#roomconfig_getmemberlist">>, Val} | Opts], Config) ->
         [<<"none">>] ->
             ?SET_XOPT(maygetmemberlist, []);
         _ ->
-            ?SET_XOPT(maygetmemberlist, [binary_to_existing_atom(V, latin1) || V <- Val])
+            ?SET_XOPT(maygetmemberlist, [binary_to_role(V) || V <- Val])
     end;
 set_xoption([{<<"muc#roomconfig_enablelogging">>, [Val]} | Opts], Config) ->
     ?SET_BOOL_XOPT(logging, Val);

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1332,8 +1332,23 @@ all_metrics() ->
      {get, affiliations},
      {set, affiliations}].
 
+iq_action_to_metric_name(<<"create">>) -> create;
+iq_action_to_metric_name(<<"publish">>) -> publish;
+iq_action_to_metric_name(<<"retract">>) -> retract;
+iq_action_to_metric_name(<<"subscribe">>) -> subscribe;
+iq_action_to_metric_name(<<"unsubscribe">>) -> unsubscribe;
+iq_action_to_metric_name(<<"items">>) -> items;
+iq_action_to_metric_name(<<"options">>) -> options;
+iq_action_to_metric_name(<<"configure">>) -> configure;
+iq_action_to_metric_name(<<"default">>) -> default;
+iq_action_to_metric_name(<<"delete">>) -> delete;
+iq_action_to_metric_name(<<"purge">>) -> purge;
+iq_action_to_metric_name(<<"subscriptions">>) -> subscriptions;
+iq_action_to_metric_name(<<"affiliations">>) -> affiliations.
+
+
 metric_name(IQType, Name, MetricSuffix) when is_binary(Name) ->
-    NameAtom = binary_to_existing_atom(Name, utf8),
+    NameAtom = iq_action_to_metric_name(Name),
     metric_name(IQType, NameAtom, MetricSuffix);
 metric_name(IQType, Name, MetricSuffix) when is_atom(Name) ->
     [pubsub, IQType, Name, MetricSuffix].


### PR DESCRIPTION
This PR replaces usage of `binary_to_atom` or `binary_to_existing_atom` where possible and needed.
