### PR TITLE
Pass a commit msg to MIM dockerfile

### DIFF
--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -40,7 +40,7 @@ cp ../${MONGOOSE_TGZ} member
 docker build -f Dockerfile.member -t ${IMAGE_TAG} \
              --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 	     --build-arg VCS_REF=${GIT_REF} \
-	     --build-arg VCS_REF_DESC=${GIT_COMMIT_MSG} \
+	     --build-arg VCS_REF_DESC="${GIT_COMMIT_MSG}" \
 	     --build-arg VERSION=${VERSION} \
 	     .
 

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -13,6 +13,7 @@ export BUILDS=`pwd`
 DOCKERHUB_TAG=${CIRCLE_SHA1}
 VERSION=`tools/generate_vsn.sh`
 GIT_REF=`git rev-parse --short HEAD`
+GIT_COMMIT_MSG=`git log --format=%B -n 1 HEAD`
 
 if [ -n "$CIRCLE_PULL_REQUEST" ]; then
     # CircleCI doesn't provide PR number in env. var., so we need to extract it from PR URL
@@ -39,6 +40,7 @@ cp ../${MONGOOSE_TGZ} member
 docker build -f Dockerfile.member -t ${IMAGE_TAG} \
              --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 	     --build-arg VCS_REF=${GIT_REF} \
+	     --build-arg VCS_REF_DESC=${GIT_COMMIT_MSG} \
 	     --build-arg VERSION=${VERSION} \
 	     .
 

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -33,7 +33,7 @@ IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
-git checkout 8105a0af3f673a92836af49ed797a16d66b51b2f
+git checkout b01568e230edc86dfe8e02e80ccefe064afc3a5e
 
 cp ../${MONGOOSE_TGZ} member
 


### PR DESCRIPTION
This PR updates docker image building scripts so a commit message is passed to MIM dockerfile. The message is attached to an image as a new label.

