### PR TITLE
Inbox/custom reset stanza

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -595,7 +595,7 @@ reset_unread_counter_with_reset_stanza(Config) ->
         %% Now Mike asks for inbox second time. He has 0 unread messages now
         check_inbox(Mike, [#conv{unread = 0, from = Kate, to = Mike, content = <<"Hi mike">>}]),
         %% Kate should not be receiving this stanza
-        ?assertNot(escalus_client:has_stanzas(Kate))
+        inbox_helper:assert_has_no_stanzas(Kate)
       end).
 
 reset_unread_counter_and_show_only_unread(Config) ->
@@ -825,12 +825,7 @@ groupchat_markers_one_reset_reset_stanza(Config) ->
         MsgStanza = escalus_stanza:set_id(
           escalus_stanza:groupchat_to(RoomJid, <<"marker time!">>), <<"some_ID">>),
         escalus:send(Alice, MsgStanza),
-        R0 = escalus:wait_for_stanza(Alice),
-        R1 = escalus:wait_for_stanza(Bob),
-        R2 = escalus:wait_for_stanza(Kate),
-        escalus:assert(is_groupchat_message, R0),
-        escalus:assert(is_groupchat_message, R1),
-        escalus:assert(is_groupchat_message, R2),
+        inbox_helper:wait_for_groupchat_msg([Alice, Bob, Kate]),
         % verify that Bob has the message on inbox
         check_inbox(Bob, [#conv{unread = 1, from = AliceRoomJid,
                                 to = BobJid, content = <<"marker time!">>}]),
@@ -847,9 +842,7 @@ groupchat_markers_one_reset_reset_stanza(Config) ->
         check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid,
                                  to = KateJid, content = <<"marker time!">>}]),
         %% And nobody received any other stanza
-        ?assertNot(escalus_client:has_stanzas(Alice)),
-        ?assertNot(escalus_client:has_stanzas(Bob)),
-        ?assertNot(escalus_client:has_stanzas(Kate))
+        inbox_helper:assert_has_no_stanzas([Alice, Bob, Kate])
       end).
 
 %% this test combines options:
@@ -1242,9 +1235,7 @@ unread_count_is_reset_after_sending_reset_stanza(Config) ->
         %% Kate has 0 unread messages
         check_inbox(Kate, [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}],
                     #{}, #{case_sensitive => true}),
-        ?assertNot(escalus_client:has_stanzas(Alice)),
-        ?assertNot(escalus_client:has_stanzas(Bob)),
-        ?assertNot(escalus_client:has_stanzas(Kate))
+        inbox_helper:assert_has_no_stanzas([Alice, Bob, Kate])
       end).
 
 private_messages_are_handled_as_one2one(Config) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -48,7 +48,7 @@
          advanced_groupchat_stored_in_all_inbox/1,
          groupchat_markers_one_reset/1,
          non_reset_marker_should_not_affect_muclight_inbox/1,
-         groupchat_markers_one_reset_reset_stanza/1,
+         groupchat_reset_stanza_resets_inbox/1,
          create_groupchat/1,
          create_groupchat_no_affiliation_stored/1,
          leave_and_remove_conversation/1,
@@ -77,7 +77,7 @@
                        clear_inbox_all/0,
                        given_conversations_between/2,
                        assert_invalid_inbox_form_value_error/3,
-                       assert_invalid_reset_inbox_form/4
+                       assert_invalid_reset_inbox/4
                       ]).
 
 -define(ROOM, <<"testroom1">>).
@@ -148,7 +148,7 @@ groups() ->
            advanced_groupchat_stored_in_all_inbox,
            groupchat_markers_one_reset,
            non_reset_marker_should_not_affect_muclight_inbox,
-           groupchat_markers_one_reset_reset_stanza,
+           groupchat_reset_stanza_resets_inbox,
            create_groupchat,
            create_groupchat_no_affiliation_stored,
            leave_and_remove_conversation,
@@ -262,11 +262,11 @@ init_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config) ->
     muc_light_helper:create_room(?ROOM_MARKERS2, muclight_domain(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config);
-init_per_testcase(groupchat_markers_one_reset_reset_stanza, Config) ->
+init_per_testcase(groupchat_reset_stanza_resets_inbox, Config) ->
     clear_inbox_all(),
     muc_light_helper:create_room(?ROOM_MARKERS_RESET, muclight_domain(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
-    escalus:init_per_testcase(groupchat_markers_one_reset_reset_stanza, Config);
+    escalus:init_per_testcase(groupchat_reset_stanza_resets_inbox, Config);
 init_per_testcase(leave_and_remove_conversation, Config) ->
     clear_inbox_all(),
     muc_light_helper:create_room(?ROOM2, muclight_domain(), alice, [bob, kate],
@@ -314,10 +314,10 @@ end_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config) ->
     clear_inbox_all(),
     inbox_helper:restore_inbox_option(Config),
     escalus:end_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config);
-end_per_testcase(groupchat_markers_one_reset_reset_stanza, Config) ->
+end_per_testcase(groupchat_reset_stanza_resets_inbox, Config) ->
     clear_inbox_all(),
     inbox_helper:restore_inbox_option(Config),
-    escalus:end_per_testcase(groupchat_markers_one_reset_reset_stanza, Config);
+    escalus:end_per_testcase(groupchat_reset_stanza_resets_inbox, Config);
 end_per_testcase(leave_and_remove_conversation, Config) ->
     clear_inbox_all(),
     inbox_helper:restore_inbox_option(Config),
@@ -398,13 +398,13 @@ returns_error_when_bad_form_field_hidden_read_sent(Config) ->
 
 returns_error_when_bad_reset_field_jid(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-      assert_invalid_reset_inbox_form(
+      assert_invalid_reset_inbox(
         Alice, <<"$@/">>, <<"jid">>, <<"$@/">>)
     end).
 
 returns_error_when_no_reset_field_jid(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-      assert_invalid_reset_inbox_form(
+      assert_invalid_reset_inbox(
         Alice, undefined, <<"jid">>, <<"No Interlocutor JID provided">>)
     end).
 
@@ -813,7 +813,7 @@ non_reset_marker_should_not_affect_muclight_inbox(Config) ->
                                  to = KateJid, content = Msg}])
       end).
 
-groupchat_markers_one_reset_reset_stanza(Config) ->
+groupchat_reset_stanza_resets_inbox(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
         % %% WITH
         AliceJid = inbox_helper:to_bare_lower(Alice),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -29,7 +29,8 @@
          user_has_empty_inbox/1,
          user_has_two_unread_messages/1,
          other_resources_do_not_interfere/1,
-         reset_unread_counter/1,
+         reset_unread_counter_with_reset_chat_marker/1,
+         reset_unread_counter_with_reset_stanza/1,
          try_to_reset_unread_counter_with_bad_marker/1,
          non_reset_marker_should_not_affect_inbox/1,
          user_has_two_conversations/1,
@@ -45,6 +46,7 @@
          advanced_groupchat_stored_in_all_inbox/1,
          groupchat_markers_one_reset/1,
          non_reset_marker_should_not_affect_muclight_inbox/1,
+         groupchat_markers_one_reset_reset_stanza/1,
          create_groupchat/1,
          create_groupchat_no_affiliation_stored/1,
          leave_and_remove_conversation/1,
@@ -58,6 +60,7 @@
          unread_count_is_the_same_after_going_online_again/1,
          unread_count_is_reset_after_sending_chatmarker/1,
          non_reset_marker_should_not_affect_muc_inbox/1,
+         unread_count_is_reset_after_sending_reset_stanza/1,
          private_messages_are_handled_as_one2one/1
         ]).
 -export([timestamp_is_updated_on_new_message/1,
@@ -80,6 +83,7 @@
 -define(ROOM4, <<"testroom4">>).
 -define(ROOM_MARKERS, <<"room_markers">>).
 -define(ROOM_MARKERS2, <<"room_markers2">>).
+-define(ROOM_MARKERS_RESET, <<"room_markers_reset">>).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -123,7 +127,8 @@ groups() ->
            msg_sent_to_not_existing_user,
            user_has_two_unread_messages,
            other_resources_do_not_interfere,
-           reset_unread_counter,
+           reset_unread_counter_with_reset_chat_marker,
+           reset_unread_counter_with_reset_stanza,
            try_to_reset_unread_counter_with_bad_marker,
            non_reset_marker_should_not_affect_inbox,
            user_has_only_unread_messages_or_only_read,
@@ -138,6 +143,7 @@ groups() ->
            advanced_groupchat_stored_in_all_inbox,
            groupchat_markers_one_reset,
            non_reset_marker_should_not_affect_muclight_inbox,
+           groupchat_markers_one_reset_reset_stanza,
            create_groupchat,
            create_groupchat_no_affiliation_stored,
            leave_and_remove_conversation,
@@ -154,6 +160,7 @@ groups() ->
            unread_count_is_the_same_after_going_online_again,
            unread_count_is_reset_after_sending_chatmarker,
            non_reset_marker_should_not_affect_muc_inbox,
+           unread_count_is_reset_after_sending_reset_stanza,
            private_messages_are_handled_as_one2one
           ]},
          {timestamps, [sequence],
@@ -250,6 +257,11 @@ init_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config) ->
     muc_light_helper:create_room(?ROOM_MARKERS2, muclight_domain(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config);
+init_per_testcase(groupchat_markers_one_reset_reset_stanza, Config) ->
+    clear_inbox_all(),
+    muc_light_helper:create_room(?ROOM_MARKERS_RESET, muclight_domain(), alice, [bob, kate],
+                                 Config, muc_light_helper:ver(1)),
+    escalus:init_per_testcase(groupchat_markers_one_reset_reset_stanza, Config);
 init_per_testcase(leave_and_remove_conversation, Config) ->
     clear_inbox_all(),
     muc_light_helper:create_room(?ROOM2, muclight_domain(), alice, [bob, kate],
@@ -277,6 +289,7 @@ init_per_testcase(TC, Config)
        TC =:= unread_count_is_the_same_after_going_online_again;
        TC =:= unread_count_is_reset_after_sending_chatmarker;
        TC =:= non_reset_marker_should_not_affect_muc_inbox;
+       TC =:= unread_count_is_reset_after_sending_reset_stanza;
        TC =:= private_messages_are_handled_as_one2one ->
     clear_inbox_all(),
     Users = ?config(escalus_users, Config),
@@ -296,6 +309,10 @@ end_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config) ->
     clear_inbox_all(),
     inbox_helper:restore_inbox_option(Config),
     escalus:end_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config);
+end_per_testcase(groupchat_markers_one_reset_reset_stanza, Config) ->
+    clear_inbox_all(),
+    inbox_helper:restore_inbox_option(Config),
+    escalus:end_per_testcase(groupchat_markers_one_reset_reset_stanza, Config);
 end_per_testcase(leave_and_remove_conversation, Config) ->
     clear_inbox_all(),
     inbox_helper:restore_inbox_option(Config),
@@ -325,6 +342,7 @@ end_per_testcase(TC, Config) when TC =:= simple_groupchat_stored_in_all_inbox_mu
                                   TC =:= unread_count_is_the_same_after_going_online_again;
                                   TC =:= unread_count_is_reset_after_sending_chatmarker;
                                   TC =:= non_reset_marker_should_not_affect_muc_inbox;
+                                  TC =:= unread_count_is_reset_after_sending_reset_stanza;
                                   TC =:= private_messages_are_handled_as_one2one ->
     muc_helper:destroy_room(Config);
 end_per_testcase(CaseName, Config) ->
@@ -534,7 +552,7 @@ other_resources_do_not_interfere(Config) ->
         check_inbox(Kate, [#conv{unread = 0, from = Kate, to = Mike, content = <<"How are you">>}])
                                                   end).
 
-reset_unread_counter(Config) ->
+reset_unread_counter_with_reset_chat_marker(Config) ->
     escalus:story(Config, [{kate, 1}, {mike, 1}], fun(Kate, Mike) ->
         Msg = inbox_helper:send_msg(Kate, Mike, <<"Hi mike">>),
         MsgId = exml_query:attr(Msg, <<"id">>),
@@ -546,6 +564,22 @@ reset_unread_counter(Config) ->
         escalus:send(Mike, ChatMarker),
         %% Now Mike asks for inbox second time. He has 0 unread messages now
         check_inbox(Mike, [#conv{unread = 0, from = Kate, to = Mike, content = <<"Hi mike">>}])
+      end).
+
+reset_unread_counter_with_reset_stanza(Config) ->
+    escalus:story(Config, [{kate, 1}, {mike, 1}], fun(Kate, Mike) ->
+        _Msg = inbox_helper:send_msg(Kate, Mike, <<"Hi mike">>),
+
+        %% Mike has one unread message
+        check_inbox(Mike, [#conv{unread = 1, from = Kate, to = Mike, content = <<"Hi mike">>}]),
+        ResetStanza = inbox_helper:make_reset_inbox_stanza(Kate),
+        %% Mike sends "reset" stanza
+        escalus:send(Mike, ResetStanza),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Mike)),
+        %% Now Mike asks for inbox second time. He has 0 unread messages now
+        check_inbox(Mike, [#conv{unread = 0, from = Kate, to = Mike, content = <<"Hi mike">>}]),
+        %% Kate should not be receiving this stanza
+        ?assertNot(escalus_client:has_stanzas(Kate))
       end).
 
 reset_unread_counter_and_show_only_unread(Config) ->
@@ -762,6 +796,48 @@ non_reset_marker_should_not_affect_muclight_inbox(Config) ->
         check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid,
                                  to = KateJid, content = Msg}])
       end).
+
+groupchat_markers_one_reset_reset_stanza(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+        % %% WITH
+        AliceJid = inbox_helper:to_bare_lower(Alice),
+        BobJid = inbox_helper:to_bare_lower(Bob),
+        KateJid = inbox_helper:to_bare_lower(Kate),
+        RoomJid = room_bin_jid(?ROOM_MARKERS_RESET),
+        AliceRoomJid = <<RoomJid/binary,"/", AliceJid/binary>>,
+        % %% WHEN A MESSAGE IS SENT
+        MsgStanza = escalus_stanza:set_id(
+          escalus_stanza:groupchat_to(RoomJid, <<"marker time!">>), <<"some_ID">>),
+        escalus:send(Alice, MsgStanza),
+        R0 = escalus:wait_for_stanza(Alice),
+        R1 = escalus:wait_for_stanza(Bob),
+        R2 = escalus:wait_for_stanza(Kate),
+        escalus:assert(is_groupchat_message, R0),
+        escalus:assert(is_groupchat_message, R1),
+        escalus:assert(is_groupchat_message, R2),
+        % verify that Bob has the message on inbox
+        check_inbox(Bob, [#conv{unread = 1, from = AliceRoomJid,
+                                to = BobJid, content = <<"marker time!">>}]),
+        % %% AND WHEN SEND RESET FOR ROOM
+        ResetStanza = inbox_helper:make_reset_inbox_stanza(RoomJid),
+        escalus:send(Bob, ResetStanza),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
+        % %% THEN INBOX IS RESET FOR BOB, WITHOUT FORWARDING
+        %% Bob has 0 unread messages because he reset his counter
+        check_inbox(Bob, [#conv{unread = 0, from = AliceRoomJid,
+                                to = BobJid, content = <<"marker time!">>}]),
+        %% Alice has 0 unread messages because she was the sender
+        check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid,
+                                  to = AliceJid, content = <<"marker time!">>}]),
+        %% Kate still has unread message
+        check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid,
+                                 to = KateJid, content = <<"marker time!">>}]),
+        %% And nobody received any other stanza
+        ?assertNot(escalus_client:has_stanzas(Alice)),
+        ?assertNot(escalus_client:has_stanzas(Bob)),
+        ?assertNot(escalus_client:has_stanzas(Kate))
+      end).
+
 %% this test combines options:
 %% ...
 %%{aff_changes, true},
@@ -1120,6 +1196,43 @@ non_reset_marker_should_not_affect_muc_inbox(Config) ->
         %% Kate has 1 unread messages
         check_inbox(Kate, [#conv{unread = 1, from = BobRoomJid, to = KateJid, content = Msg}],
                     #{}, #{case_sensitive => true})
+      end).
+
+unread_count_is_reset_after_sending_reset_stanza(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+        % %% WITH
+        Users = [Alice, Bob, Kate],
+        Msg = <<"Hi Room!">>,
+        Id = <<"MyID">>,
+        Room = ?config(room, Config),
+        RoomAddr = muc_helper:room_address(Room),
+        % %% PROVIDED
+        inbox_helper:enter_room(Room, Users),
+        inbox_helper:make_members(Room, Alice, Users -- [Alice]),
+        % %% WHEN A MESSAGE IS SENT
+        Stanza = escalus_stanza:set_id(
+          escalus_stanza:groupchat_to(RoomAddr, Msg), Id),
+        escalus:send(Bob, Stanza),
+        inbox_helper:wait_for_groupchat_msg(Users),
+        % %% AND WHEN SEND RESET FOR ROOM
+        ResetStanza = inbox_helper:make_reset_inbox_stanza(RoomAddr),
+        escalus:send(Kate, ResetStanza),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Kate)),
+
+        [AliceJid, BobJid, KateJid] = lists:map(fun inbox_helper:to_bare_lower/1, Users),
+        BobRoomJid = muc_helper:room_address(Room, inbox_helper:nick(Bob)),
+        %% Bob has 0 unread messages
+        check_inbox(Bob, [#conv{unread = 0, from = BobRoomJid, to = BobJid, content = Msg}],
+                    #{}, #{case_sensitive => true}),
+        %% Alice have one conv with 1 unread message
+        check_inbox(Alice, [#conv{unread = 1, from = BobRoomJid, to = AliceJid, content = Msg}],
+                    #{}, #{case_sensitive => true}),
+        %% Kate has 0 unread messages
+        check_inbox(Kate, [#conv{unread = 0, from = BobRoomJid, to = KateJid, content = Msg}],
+                    #{}, #{case_sensitive => true}),
+        ?assertNot(escalus_client:has_stanzas(Alice)),
+        ?assertNot(escalus_client:has_stanzas(Bob)),
+        ?assertNot(escalus_client:has_stanzas(Kate))
       end).
 
 private_messages_are_handled_as_one2one(Config) ->

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -27,7 +27,7 @@
          timestamp_from_item/1,
          assert_has_no_stanzas/1,
          assert_invalid_inbox_form_value_error/3,
-         assert_invalid_reset_inbox_form/4,
+         assert_invalid_reset_inbox/4,
          assert_message_content/3
         ]).
 % 1-1 helpers
@@ -267,8 +267,7 @@ reset_inbox(From, To) ->
         ?assertNotEqual(undefined, exml_query:path(Result, [{element_with_ns, <<"reset">>,
                                                              ?NS_ESL_INBOX_CONVERSATION}])).
 
--spec make_reset_inbox_stanza(
-        undefined | jid:jid() | escalus:client() | atom() | string() | binary()) -> exml:element().
+-spec make_reset_inbox_stanza(undefined | escalus:client() | binary()) -> exml:element().
 make_reset_inbox_stanza(InterlocutorJid) when is_binary(InterlocutorJid) ->
     escalus_stanza:iq(
       <<"set">>,
@@ -284,8 +283,6 @@ make_reset_inbox_stanza(undefined) ->
               attrs = [
                        {<<"xmlns">>, ?NS_ESL_INBOX_CONVERSATION}
                       ]}]);
-make_reset_inbox_stanza(#jid{} = InterlocutorJid) ->
-    make_reset_inbox_stanza(jid:to_binary(jid:to_bare(InterlocutorJid)));
 make_reset_inbox_stanza(InterlocutorJid) ->
     make_reset_inbox_stanza(escalus_utils:get_short_jid(InterlocutorJid)).
 
@@ -617,7 +614,7 @@ assert_has_no_stanzas(UsersList) when is_list(UsersList) ->
 assert_has_no_stanzas(User) ->
     ?assertNot(escalus_client:has_stanzas(User)).
 
-assert_invalid_reset_inbox_form(From, To, Field, Value) ->
+assert_invalid_reset_inbox(From, To, Field, Value) ->
     ResetStanza = make_reset_inbox_stanza(To),
     assert_invalid_form(From, ResetStanza, Field, Value).
 

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -25,6 +25,7 @@
          reload_inbox_option/2, reload_inbox_option/3,
          restore_inbox_option/1,
          timestamp_from_item/1,
+         assert_has_no_stanzas/1,
          assert_invalid_inbox_form_value_error/3,
          assert_invalid_reset_inbox_form/4,
          assert_message_content/3
@@ -610,6 +611,11 @@ send_and_mark_msg(From, To) ->
     ChatMarker = escalus_stanza:chat_marker(From, <<"displayed">>, MsgId),
     escalus:send(To, ChatMarker),
     Msg.
+
+assert_has_no_stanzas(UsersList) when is_list(UsersList) ->
+    lists:foreach(fun(User) -> ?assertNot(escalus_client:has_stanzas(User)) end, UsersList);
+assert_has_no_stanzas(User) ->
+    ?assertNot(escalus_client:has_stanzas(User)).
 
 assert_invalid_reset_inbox_form(From, To, Field, Value) ->
     ResetStanza = make_reset_inbox_stanza(To),

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -18,6 +18,7 @@
          make_inbox_stanza/0,
          make_inbox_stanza/1,
          make_inbox_stanza/2,
+         make_reset_inbox_stanza/1,
          get_error_message/1,
          inbox_ns/0,
          reload_inbox_option/2, reload_inbox_option/3,
@@ -56,6 +57,7 @@
 -import(muc_light_helper, [lbin/1]).
 
 -define(NS_ESL_INBOX, <<"erlang-solutions.com:xmpp:inbox:0">>).
+-define(NS_ESL_INBOX_CONVERSATION, <<"erlang-solutions.com:xmpp:inbox:0#conversation">>).
 -define(ROOM, <<"testroom1">>).
 -define(ROOM2, <<"testroom2">>).
 -define(ROOM3, <<"testroom3">>).
@@ -139,7 +141,6 @@ process_inbox_message(Client, Message, #conv{unread = Unread, from = From, to = 
                                              content = Content, verify = Fun}, JIDVerifyFun) ->
     FromJid = ensure_conv_binary_jid(From),
     ToJid = ensure_conv_binary_jid(To),
-    Unread = get_unread_count(Message),
     escalus:assert(is_message, Message),
     Unread = get_unread_count(Message),
     [InnerMsg] = get_inner_msg(Message),
@@ -250,6 +251,25 @@ make_inbox_stanza(GetParams, Verify) ->
                       children = [make_inbox_form(GetParams, Verify)]},
     GetIQ#xmlel{children = [QueryTag]}.
 
+-spec make_reset_inbox_stanza(jid:jid() | escalus:client() | atom() | binary() | string()) ->
+    exml:element().
+make_reset_inbox_stanza(InterlocutorJid) ->
+    make_reset_inbox_stanza(InterlocutorJid, 0).
+
+-spec make_reset_inbox_stanza(jid:jid() | escalus:client() | atom() | binary() | string(),
+                              non_neg_integer() ) -> exml:element().
+make_reset_inbox_stanza(#jid{} = InterlocutorJid, Count) ->
+    make_reset_inbox_stanza(jid:to_binary(jid:to_bare(InterlocutorJid)), Count);
+make_reset_inbox_stanza(InterlocutorJid, Count) ->
+    escalus_stanza:iq(
+      <<"set">>,
+      [#xmlel{name = <<"reset">>,
+              attrs = [
+                       {<<"xmlns">>, ?NS_ESL_INBOX_CONVERSATION},
+                       {<<"jid">>, escalus_utils:get_short_jid(InterlocutorJid)},
+                       {<<"count">>, integer_to_binary(Count)}
+                      ],
+              children = []}]).
 
 -spec check_jid_fun(IsCaseSensitive :: boolean(), CheckResource :: boolean()) -> jid_verify_fun().
 check_jid_fun(true, true) ->

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -79,6 +79,28 @@ Server:
 </iq>
 ```
 
+### Reseting inbox
+
+An inbox can be reset at will using the stanza
+
+```xml
+<iq type='set'>
+    <reset xmlns='erlang-solutions.com:xmpp:inbox:0#conversation' jid='interlocutor_bare_jid' count='X'/>
+</iq>
+```
+
+Where `jid` is the bare jid of the interlocutor whose inbox wants to be reset,
+and `count` is the value that wants to be set, which will most often be zero.
+
+Regardless of the count value that is being set, the last message stored in
+inbox is not changed by the usage of this stanza. That is, nor this stanza nor
+anything given within will be stored; only the inbox `unread_count` changes.
+
+Resetting the inbox count by this stanza will also skip the forwarding of
+messages. While a typical chat marker will be forwarded to the interlocutor(s),
+(including the case of a big groupchat with thousands of participants!), this
+reset stanza will not.
+
 ### Example Request
 
 ```

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -81,7 +81,7 @@ Server:
 
 ### Reseting inbox
 
-An inbox can be reset at will using the stanza
+You can reset the inbox with the following stanza:
 
 ```xml
 <iq type='set'>
@@ -89,15 +89,15 @@ An inbox can be reset at will using the stanza
 </iq>
 ```
 
-Where `jid` is the bare jid of the interlocutor whose inbox wants to be reset.
-This action does not change the last message stored in inbox; that is, nor this
-stanza nor anything given within will be stored; only the inbox `unread_count`
-changes to zero.
+Here `jid` is the bare jid of the user whose inbox we want to reset. This action
+does not change the last message stored in inbox; meaning that neither this
+stanza nor anything given within will be stored; the only change is the inbox
+`unread_count` is set to zero.
 
-Resetting the inbox count by this stanza will also skip the forwarding of
-messages. While a typical chat marker will be forwarded to the interlocutor(s),
-(including the case of a big groupchat with thousands of participants!), this
-reset stanza will not.
+Resetting the inbox count will also skip the forwarding of messages. While a
+typical chat marker will be forwarded to the interlocutor(s), (including the
+case of a big groupchat with thousands of participants!), this reset stanza will
+not.
 
 ### Example Request
 

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -85,16 +85,14 @@ An inbox can be reset at will using the stanza
 
 ```xml
 <iq type='set'>
-    <reset xmlns='erlang-solutions.com:xmpp:inbox:0#conversation' jid='interlocutor_bare_jid' count='X'/>
+    <reset xmlns='erlang-solutions.com:xmpp:inbox:0#conversation' jid='interlocutor_bare_jid'/>
 </iq>
 ```
 
-Where `jid` is the bare jid of the interlocutor whose inbox wants to be reset,
-and `count` is the value that wants to be set, which will most often be zero.
-
-Regardless of the count value that is being set, the last message stored in
-inbox is not changed by the usage of this stanza. That is, nor this stanza nor
-anything given within will be stored; only the inbox `unread_count` changes.
+Where `jid` is the bare jid of the interlocutor whose inbox wants to be reset.
+This action does not change the last message stored in inbox; that is, nor this
+stanza nor anything given within will be stored; only the inbox `unread_count`
+changes to zero.
 
 Resetting the inbox count by this stanza will also skip the forwarding of
 messages. While a typical chat marker will be forwarded to the interlocutor(s),

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -1,7 +1,7 @@
 ### Module Description
 
-`Inbox` is an experimental feature implemented as a few seperate modules.
-To use it, enable mod_inbox in the config file.
+`Inbox` is an experimental feature implemented as a few separate modules.
+To use it, enable mod\_inbox in the config file.
 
 ### Options
 
@@ -135,7 +135,7 @@ Alice receives:
 
 Inbox query result IQ stanza returns the following values:
 
-* `count`: the number of all conversations (if `hidden_unread` value was set
+* `count`: the total number of conversations (if `hidden_read` value was set
   to true, this value will be equal to `active_conversations`)
 * `unread-messages`: total number of unread messages from all
   conversations

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -101,5 +101,6 @@
 
 %% Erlang Solutions custom extension - inbox feature
 -define(NS_ESL_INBOX,      <<"erlang-solutions.com:xmpp:inbox:0">>).
+-define(NS_ESL_INBOX_CONVERSATION, <<"erlang-solutions.com:xmpp:inbox:0#conversation">>).
 
 -endif.

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -498,11 +498,10 @@ get_message_type(Msg) ->
     end.
 
 reset_stanza_extract_interlocutor_jid(ResetStanza) ->
-    MaybeJid = xml:get_tag_attr(<<"jid">>, ResetStanza),
-    case MaybeJid of
-        false ->
+    case exml_query:attr(ResetStanza, <<"jid">>) of
+        undefined ->
             {error, invalid_field_value(<<"jid">>, <<"No Interlocutor JID provided">>)};
-        {value, Value} ->
+        Value ->
             case jid:from_binary(Value) of
                 error ->
                     ?ERROR_MSG("event=invalid_inbox_form_field,field=jid,value=~s", [Value]),

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -504,13 +504,17 @@ get_message_type(Msg) ->
 reset_stanza_extract_count(ResetStanza) ->
     MaybeCount = xml:get_tag_attr(<<"count">>, ResetStanza),
     case MaybeCount of
-        false -> {error, invalid_field_value(<<"count">>, <<"No Count Provided">>)};
+        false ->
+            ?DEBUG("event=invalid_inbox_form_field,field=count,value=not_provided", []),
+            {error, invalid_field_value(<<"count">>, <<"No Count Provided">>)};
         {value, Value} ->
             case catch binary_to_integer(Value) of
                 {'EXIT', _} ->
-                    {error, invalid_field_value(<<"count">>, <<"Invalid integer">>)};
+                    ?DEBUG("event=invalid_inbox_form_field,field=count,value=~c", [Value]),
+                    {error, invalid_field_value(<<"count">>, Value)};
                 Val when Val < 0 ->
-                    {error, invalid_field_value(<<"count">>, <<"Invalid integer">>)};
+                    ?DEBUG("event=invalid_inbox_form_field,field=count,value=~c", [Value]),
+                    {error, invalid_field_value(<<"count">>, Value)};
                 Val -> Val
             end
     end.
@@ -522,7 +526,9 @@ reset_stanza_extract_interlocutor_jid(ResetStanza) ->
             {error, invalid_field_value(<<"jid">>, <<"No Interlocutor JID provided">>)};
         {value, Value} ->
             case jid:from_binary(Value) of
-                error -> {error, invalid_field_value(<<"jid">>, <<"Not a valid JID">>)};
+                error ->
+                    ?ERROR_MSG("event=invalid_inbox_form_field,field=jid,value=~s", [Value]),
+                    {error, invalid_field_value(<<"jid">>, Value)};
                 JID -> JID
             end
     end.

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -185,7 +185,7 @@ maybe_process_reset_stanza(From, Acc, IQ, ResetStanza) ->
     end.
 
 process_reset_stanza(From, Acc, IQ, _ResetStanza, InterlocutorJID) ->
-    ok = mod_inbox_utils:reset_unread_count(From, InterlocutorJID, 0),
+    ok = mod_inbox_utils:reset_unread_count_to_zero(From, InterlocutorJID),
     {Acc, IQ#iq{type = result,
                 sub_el = [#xmlel{name = <<"reset">>,
                                  attrs = [{<<"xmlns">>, ?NS_ESL_INBOX_CONVERSATION}],

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -145,24 +145,24 @@ set_inbox_incr_unread(Username, Server, ToBareJid, Content, MsgId, Timestamp) ->
 -spec reset_unread(User :: binary(),
                    Server :: binary(),
                    BareJid :: binary(),
-                   binary() | non_neg_integer()) -> ok.
-reset_unread(Username, Server, ToBareJid, MsgidOrCount) ->
+                   MsgId :: binary() | undefined) -> ok.
+reset_unread(Username, Server, ToBareJid, MsgId) ->
     LUsername = jid:nodeprep(Username),
     LServer = jid:nameprep(Server),
     LToBareJid = jid:nameprep(ToBareJid),
-    Res = reset_inbox_unread_rdbms(LUsername, LServer, LToBareJid, MsgidOrCount),
+    Res = reset_inbox_unread_rdbms(LUsername, LServer, LToBareJid, MsgId),
     check_result(Res).
 
 -spec reset_inbox_unread_rdbms(Username :: jid:luser(),
                                Server :: jid:lserver(),
                                ToBareJid :: binary(),
-                               MsgId :: binary()) -> mongoose_rdbms:query_result().
-reset_inbox_unread_rdbms(Username, Server, ToBareJid, Count) when is_integer(Count) ->
-    mongoose_rdbms:sql_query(Server, ["update inbox set unread_count=", esc_int(Count),
+                               MsgId :: binary() | undefined) -> mongoose_rdbms:query_result().
+reset_inbox_unread_rdbms(Username, Server, ToBareJid, undefined) ->
+    mongoose_rdbms:sql_query(Server, ["update inbox set unread_count=0",
         " where luser=", esc_string(Username),
         " and lserver=", esc_string(Server),
         " and remote_bare_jid=", esc_string(ToBareJid), ";"]);
-reset_inbox_unread_rdbms(Username, Server, ToBareJid, MsgId) when is_binary(MsgId) ->
+reset_inbox_unread_rdbms(Username, Server, ToBareJid, MsgId) ->
     mongoose_rdbms:sql_query(Server, ["update inbox set unread_count=0 where luser=",
         esc_string(Username), " and lserver=", esc_string(Server), " and remote_bare_jid=",
         esc_string(ToBareJid), " and msg_id=", esc_string(MsgId), ";"]).

--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -17,6 +17,7 @@
 %%%%%%%%%%%%%%%%%%%
 %% DB Operations shared by mod_inbox_one2one and mod_inbox_muclight
 -export([maybe_reset_unread_count/4,
+         reset_unread_count/3,
          maybe_write_to_inbox/5,
          write_to_sender_inbox/4,
          write_to_receiver_inbox/4,
@@ -46,14 +47,14 @@ maybe_reset_unread_count(Server, User, Remote, Packet) ->
             reset_unread_count(User, Remote, Id)
     end.
 
--spec reset_unread_count(User :: jid:jid(),
-                         Remote :: jid:jid(),
-                         MsgId :: id()) -> ok.
-reset_unread_count(User, Remote, MsgId) ->
+-spec reset_unread_count(jid:jid(),
+                         jid:jid(),
+                         non_neg_integer() | id()) -> ok.
+reset_unread_count(User, Remote, MsgidOrCount) ->
     FromUsername = User#jid.luser,
     Server = User#jid.lserver,
     ToBareJid = jid:to_binary(jid:to_bare(Remote)),
-    ok = mod_inbox_backend:reset_unread(FromUsername, Server, ToBareJid, MsgId).
+    ok = mod_inbox_backend:reset_unread(FromUsername, Server, ToBareJid, MsgidOrCount).
 
 -spec write_to_sender_inbox(Server :: host(),
                             Sender :: jid:jid(),

--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -17,7 +17,7 @@
 %%%%%%%%%%%%%%%%%%%
 %% DB Operations shared by mod_inbox_one2one and mod_inbox_muclight
 -export([maybe_reset_unread_count/4,
-         reset_unread_count/3,
+         reset_unread_count_to_zero/2,
          maybe_write_to_inbox/5,
          write_to_sender_inbox/4,
          write_to_receiver_inbox/4,
@@ -47,14 +47,19 @@ maybe_reset_unread_count(Server, User, Remote, Packet) ->
             reset_unread_count(User, Remote, Id)
     end.
 
--spec reset_unread_count(jid:jid(),
-                         jid:jid(),
-                         non_neg_integer() | id()) -> ok.
-reset_unread_count(User, Remote, MsgidOrCount) ->
+-spec reset_unread_count_to_zero(jid:jid(), jid:jid()) -> ok.
+reset_unread_count_to_zero(#jid{luser = FromUsername, lserver = Server}, Remote) ->
+    ToBareJid = jid:to_binary(jid:to_bare(Remote)),
+    ok = mod_inbox_backend:reset_unread(FromUsername, Server, ToBareJid, undefined).
+
+-spec reset_unread_count(User :: jid:jid(),
+                         Remote :: jid:jid(),
+                         MsgId :: id()) -> ok.
+reset_unread_count(User, Remote, MsgId) ->
     FromUsername = User#jid.luser,
     Server = User#jid.lserver,
     ToBareJid = jid:to_binary(jid:to_bare(Remote)),
-    ok = mod_inbox_backend:reset_unread(FromUsername, Server, ToBareJid, MsgidOrCount).
+    ok = mod_inbox_backend:reset_unread(FromUsername, Server, ToBareJid, MsgId).
 
 -spec write_to_sender_inbox(Server :: host(),
                             Sender :: jid:jid(),


### PR DESCRIPTION
As a user I want to be able to (re)set my unread count. Right now, it is reset to zero only on chat markers or messages with body, which always get broadcasted to the chat. We want to be able to set the unread count to ~any desired number (not just zero)~ _zero_, with some custom stanza that doesn’t also get broadcasted.

DONE:
- [x] The stanza looks like
```xml
<iq type='set'>
	<reset xmlns='erlang-solutions.com:xmpp:inbox:0#conversation' jid='interlocutor_jid'/>
</iq>
```
- [x] There are one test for each chat type (one2one, muclight, muc), with the following scenario: a conversation is started with a message sent, the inbox is checked by one of the receivers, to have an `unread_count` of one and that message saved, the reset stanza is sent, the result iq received is asserted, the inbox is checked again to still have the message but with an `unread_count` of zero, and it is verified that all other people did not receive this message (the reset stanza is not forwarded).
- [x] The implementation uses a new gen_iq_handler with the namespace `<<"erlang-solutions.com:xmpp:inbox:0#conversation">>`. The callback matches on `#xmlel{name = <<"reset">>}`, and checks if the jid parameters is given and is valid. If anything is not ok, answers with an error, else, does the operation and answers with the iq result.

~TODO:~
~- [x] Add test for resetting the count to numbers different than zero.~
- [x] Add tests for erroneous reset stanzas.
If you feel like these todo'es are not needed, or something else is missing, then let me know immediately 😛 