### PR TITLE
Ensure that process is stopped in mod_global_distrib_SUITE:test_pm_with_graceful_reconnection_to_different_server

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -21,6 +21,7 @@
                  {cluster, mim},
                  {secondary_domain, <<"localhost.bis">>},
                  {reloaded_domain, <<"sogndal">>},
+                 {c2s_port, 5222},
                  {s2s_port, 5269},
                  {metrics_rest_port, 5288},
                  {metrics_rest_port2, 5289}]},

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -604,8 +604,6 @@ test_pm_with_graceful_reconnection_to_different_server(Config) ->
 
               escalus_client:send(Alice, chat_with_seqnum(Eve, <<"Hi from Europe1!">>)),
               NewEve = connect_from_spec(EveSpec2, Config),
-              %% TODO: This basically makes it way less likely to fail. Fix some day.
-              timer:sleep(500),
 
               escalus_client:send(Alice, chat_with_seqnum(Eve, <<"Hi again from Europe1!">>)),
               escalus_client:send(NewEve, escalus_stanza:chat_to(Alice, <<"Hi again from Asia!">>)),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -229,9 +229,8 @@ init_per_testcase(CaseName, Config)
     hide_node(europe_node2, Config),
     muc_helper:load_muc(<<"muc.localhost">>),
     escalus:init_per_testcase(CaseName, Config);
-init_per_testcase(test_pm_with_graceful_reconnection_to_different_server = CN, Config) ->
-    escalus:init_per_testcase(CN, init_user_eve(Config));
-init_per_testcase(test_pm_with_ungraceful_reconnection_to_different_server = CN, Config) ->
+init_per_testcase(CN, Config) when CN == test_pm_with_graceful_reconnection_to_different_server;
+                                   CN == test_pm_with_ungraceful_reconnection_to_different_server ->
     escalus:init_per_testcase(CN, init_user_eve(Config));
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -250,7 +250,11 @@ end_per_testcase(CN, Config) when CN == test_pm_with_graceful_reconnection_to_di
     %% Clean Eve from reg cluster
     escalus_fresh:clean(),
     %% Clean Eve from mim cluster
-    escalus_users:delete_users(Config, [{mim_eve, MimEveSpec}]),
+    %% For shared databases (i.e. mysql, pgsql...),
+    %% removing from one cluster would remove from all clusters.
+    %% For mnesia auth backend we need to call removal from each cluster.
+    %% That's why there is a catch here.
+    catch escalus_users:delete_users(Config, [{mim_eve, MimEveSpec}]),
     generic_end_per_testcase(CN, Config);
 end_per_testcase(CaseName, Config)
   when CaseName == test_muc_conversation_on_one_host; CaseName == test_global_disco;

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -21,7 +21,7 @@
 -export([kick_everyone/0]).
 -export([ensure_muc_clean/0]).
 -export([successful_rpc/3, successful_rpc/4]).
--export([logout_user/2]).
+-export([logout_user/2, logout_user/3]).
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
 -export([inject_module/1, inject_module/2, inject_module/3]).
@@ -225,14 +225,18 @@ successful_rpc(Node, Module, Function, Args) ->
             Result
     end.
 
+logout_user(Config, User) ->
+    Node = ct:get_config({hosts, mim, node}),
+    logout_user(Config, User, Node).
+
 %% This function is a version of escalus_client:stop/2
 %% that ensures that c2s process is dead.
 %% This allows to avoid race conditions.
-logout_user(Config, User) ->
+logout_user(Config, User, Node) ->
     Resource = escalus_client:resource(User),
     Username = escalus_client:username(User),
     Server = escalus_client:server(User),
-    Result = successful_rpc(ejabberd_sm, get_session_pid,
+    Result = successful_rpc(Node, ejabberd_sm, get_session_pid,
                             [Username, Server, Resource]),
     case Result of
         none ->

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -25,6 +25,7 @@
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
 -export([inject_module/1, inject_module/2, inject_module/3]).
+-export([get_session_pid/2]).
 
 -import(distributed_helper, [mim/0,
                              rpc/4]).
@@ -236,8 +237,7 @@ logout_user(Config, User, Node) ->
     Resource = escalus_client:resource(User),
     Username = escalus_client:username(User),
     Server = escalus_client:server(User),
-    Result = successful_rpc(Node, ejabberd_sm, get_session_pid,
-                            [Username, Server, Resource]),
+    Result = get_session_pid(User, Node),
     case Result of
         none ->
             %% This case can be a side effect of some error, you should
@@ -336,3 +336,11 @@ inject_module(Node, Module, reload) ->
     {Mod, Bin, File} = code:get_object_code(Module),
     successful_rpc(Node, code, load_binary, [Mod, File, Bin]).
 
+
+
+get_session_pid(User, Node) ->
+    Resource = escalus_client:resource(User),
+    Username = escalus_client:username(User),
+    Server = escalus_client:server(User),
+    successful_rpc(Node, ejabberd_sm, get_session_pid,
+                            [Username, Server, Resource]).

--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -30,6 +30,8 @@
          put_domain/2, get_domain/1, delete_domain/1,
          get_endpoints/1, get_domains/0, get_public_domains/0, get_hosts/0]).
 
+-export([refresh/0]).
+
 -export([init/1, handle_info/2]).
 
 %% Only for debug & tests!
@@ -128,6 +130,12 @@ init(RefreshAfter) ->
     {ok, RefreshAfter}.
 
 handle_info(refresh, RefreshAfter) ->
+    refresh(),
+    ?DEBUG("event=refreshing_own_data_done,next_refresh_in=~p", [RefreshAfter]),
+    erlang:send_after(timer:seconds(RefreshAfter), self(), refresh),
+    {noreply, RefreshAfter}.
+
+refresh() ->
     ?DEBUG("event=refreshing_own_hosts", []),
     refresh_hosts(),
     ?DEBUG("event=refreshing_own_nodes", []),
@@ -140,9 +148,7 @@ handle_info(refresh, RefreshAfter) ->
     refresh_domains(),
     ?DEBUG("event=refreshing_own_public_domains", []),
     refresh_public_domains(),
-    ?DEBUG("event=refreshing_own_data_done,next_refresh_in=~p", [RefreshAfter]),
-    erlang:send_after(timer:seconds(RefreshAfter), self(), refresh),
-    {noreply, RefreshAfter}.
+    ok.
 
 %%--------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
This PR addresses error in mod_global_distrib_SUITE:mod_global_distrib:test_pm_with_graceful_reconnection_to_different_server

TLDR:
- escalus_connection:stop(Eve) is async
- the message is delivered to Eve, not NewEve.

Proposed changes include:
* Otherwise timeout waiting for SecondFromAlice message
* Remove old hot fix

TODO:
- [x] Handle case with user removal from shared (i.e. rdbms) and per-domain databases (i.e. mnesia)

```erlang
{test_pm_with_graceful_reconnection_to_different_server,mod_global_distrib}

{timeout_when_waiting_for_stanza,

    [{escalus_client,wait_for_stanza,

         [{client,<<"eve81.429937@localhost/res1">>,escalus_tcp,<0.22576.0>,

              [{event_manager,<0.22569.0>},

               {server,<<"localhost">>},

               {username,<<"eve81.429937">>},

               {resource,<<"res1">>}],

              [{event_client,

                   [{event_manager,<0.22569.0>},

                    {server,<<"localhost">>},

                    {username,<<"eve81.429937">>},

                    {resource,<<"res1">>}]},

               {resource,<<"res1">>},

               {username,<<"eve81.429937">>},

               {server,<<"localhost">>},

               {host,<<"localhost">>},

               {port,7000},

               {auth,{escalus_auth,auth_plain}},

               {wspath,undefined},

               {port,7000},

               {port,7005},

               {username,<<"eve81.429937">>},

               {server,<<"localhost">>},

               {password,<<"password">>},

               {host_port,{reg,c2s_port}},

               {stream_id,<<"5EFE9353CA936DA3">>}]},

          5000],

         [{file,

              "/home/travis/build/arcusfelis/MongooseIM/big_tests/_build/default/lib/escalus/src/escalus_client.erl"},

          {line,136}]},

     {mod_global_distrib_SUITE,

         '-test_pm_with_graceful_reconnection_to_different_server/1-fun-0-',3,

         [{file,

              "/home/travis/build/arcusfelis/MongooseIM/big_tests/_build/default/lib/ejabberd_tests/tests/mod_global_distrib_SUITE.erl"},

          {line,589}]},

     {escalus_story,story,4,

         [{file,

              "/home/travis/build/arcusfelis/MongooseIM/big_tests/_build/default/lib/escalus/src/escalus_story.erl"},

          {line,72}]},

     {mod_global_distrib_SUITE,

         test_pm_with_graceful_reconnection_to_different_server,1,

         [{file,

              "/home/travis/build/arcusfelis/MongooseIM/big_tests/_build/default/lib/ejabberd_tests/tests/mod_global_distrib_SUITE.erl"},

          {line,571}]},

     {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1562}]},

     {test_server,run_test_case_eval1,6,

         [{file,"test_server.erl"},{line,1080}]},

     {test_server,run_test_case_eval,9,

         [{file,"test_server.erl"},{line,1012}]}]}
```

