### PR TITLE
Improve setup db script

### DIFF
--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -1,5 +1,4 @@
-﻿USE [ejabberd]
-GO
+﻿GO
 CREATE TABLE [dbo].[test_types](
     [unicode] [nvarchar](max),
     [binary_data_8k] [varbinary](8000),
@@ -593,36 +592,4 @@ GO
 ALTER TABLE [dbo].[vcard_search] ADD  DEFAULT (N'') FOR [lusername]
 GO
 ALTER TABLE [dbo].[vcard_search] ADD  DEFAULT (N'') FOR [server]
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.last' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'last'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.mam_config' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'mam_config'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.mam_message' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'mam_message'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.mam_muc_message' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'mam_muc_message'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.mam_server_user' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'mam_server_user'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.offline_message' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'offline_message'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.privacy_default_list' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'privacy_default_list'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.privacy_list' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'privacy_list'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.privacy_list_data' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'privacy_list_data'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.private_storage' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'private_storage'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.roster_version' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'roster_version'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.rostergroups' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'rostergroups'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.rosterusers' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'rosterusers'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.users' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'users'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.vcard' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'vcard'
-GO
-EXEC sys.sp_addextendedproperty @name=N'MS_SSMA_SOURCE', @value=N'ejabberd.vcard_search' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1name=N'vcard_search'
 GO

--- a/tools/setup-mssql-database.sh
+++ b/tools/setup-mssql-database.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+source tools/travis-common-vars.sh
+
+NAME=$(db_name mssql)
+DB_NAME=${DB_NAME:-ejabberd}
+
+echo "Container $NAME"
+
+docker exec -t $NAME \
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
+    -Q "CREATE DATABASE $DB_NAME"
+docker exec -t $NAME \
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
+    -Q "ALTER DATABASE $DB_NAME SET READ_COMMITTED_SNAPSHOT ON"
+docker exec -t $NAME \
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
+    -d $DB_NAME \
+    -i mongoose.sql

--- a/tools/setup-redis.sh
+++ b/tools/setup-redis.sh
@@ -3,7 +3,7 @@
 source tools/travis-common-vars.sh
 NAME=$(db_name redis)
 REDIS_PORT=${REDIS_PORT:-6379}
-docker rm -f $NAME || echo "Skip removing the previous container"
+docker rm -v -f $NAME || echo "Skip removing the previous container"
 docker run -d --name $NAME \
     -p $REDIS_PORT:6379 \
     --health-cmd='redis-cli -h "127.0.0.1" ping' \

--- a/tools/setup-redis.sh
+++ b/tools/setup-redis.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 source tools/travis-common-vars.sh
 NAME=$(db_name redis)

--- a/tools/setup-redis.sh
+++ b/tools/setup-redis.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
-docker rm -f mongooseim-redis || echo "Skip removing the previous container"
-docker run -d --name mongooseim-redis \
+
+NAME=mongooseim-redis
+docker rm -f $NAME || echo "Skip removing the previous container"
+docker run -d --name $NAME \
     -p 6379:6379 \
     --health-cmd='redis-cli -h "127.0.0.1" ping' \
     redis

--- a/tools/setup-redis.sh
+++ b/tools/setup-redis.sh
@@ -2,8 +2,9 @@
 
 source tools/travis-common-vars.sh
 NAME=$(db_name redis)
+REDIS_PORT=${REDIS_PORT:-6379}
 docker rm -f $NAME || echo "Skip removing the previous container"
 docker run -d --name $NAME \
-    -p 6379:6379 \
+    -p $REDIS_PORT:6379 \
     --health-cmd='redis-cli -h "127.0.0.1" ping' \
     redis

--- a/tools/setup-redis.sh
+++ b/tools/setup-redis.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-NAME=mongooseim-redis
+source tools/travis-common-vars.sh
+NAME=$(db_name redis)
 docker rm -f $NAME || echo "Skip removing the previous container"
 docker run -d --name $NAME \
     -p 6379:6379 \

--- a/tools/setup_riak
+++ b/tools/setup_riak
@@ -13,6 +13,7 @@ RIAK_PORT=${RIAK_PORT:-"8098"}
 RIAK_HOST="http://${RIAK_HOST}:${RIAK_PORT}"
 RIAK_PASSWORD="${RIAK_PASSWORD:-mongooseim_secret}"
 RIAK_SECURITY=${RIAK_SECURITY:-"enabled"}
+SETUP_BUCKET_TYPES=${SETUP_BUCKET_TYPES:-true}
 
 RIAK_VCARD_SCHEMA_PATH=${RIAK_VCARD_SCHEMA_PATH:-"tools/vcard_search_schema.xml"}
 RIAK_MAM_SCHEMA_PATH=${RIAK_MAM_SCHEMA_PATH:-"tools/mam_search_schema.xml"}
@@ -39,28 +40,27 @@ curl -v -XPUT $RIAK_HOST/search/schema/vcard \
     -H 'Content-Type:application/xml' \
     --data-binary @${RIAK_VCARD_SCHEMA_PATH}
 
-wait_for_http_status "200" $RIAK_HOST/search/schema/vcard
-
-echo "Creating vcard search index"
-curl -v -XPUT $RIAK_HOST/search/index/vcard \
-    -H 'Content-Type: application/json' \
-    -d '{"schema":"vcard"}'
-
-wait_for_http_status "200"  $RIAK_HOST/search/index/vcard
 
 echo "Creating mam schema"
 curl -v -XPUT $RIAK_HOST/search/schema/mam \
     -H 'Content-Type:application/xml' \
     --data-binary @${RIAK_MAM_SCHEMA_PATH}
 
-wait_for_http_status "200"  $RIAK_HOST/search/schema/mam
+wait_for_http_status "200" $RIAK_HOST/search/schema/vcard
+wait_for_http_status "200" $RIAK_HOST/search/schema/mam
+
+echo "Creating vcard search index"
+curl -v -XPUT $RIAK_HOST/search/index/vcard \
+    -H 'Content-Type: application/json' \
+    -d '{"schema":"vcard"}'
 
 echo "Creating mam index"
 curl -v -XPUT $RIAK_HOST/search/index/mam \
     -H 'Content-Type: application/json' \
     -d '{"schema":"mam"}'
 
-wait_for_http_status "200"  $RIAK_HOST/search/index/mam
+wait_for_http_status "200" $RIAK_HOST/search/index/vcard
+wait_for_http_status "200" $RIAK_HOST/search/index/mam
 
 # Allow to pass RIAK_ADMIN as an env variable.
 # Use riak-admin as a default command.
@@ -81,6 +81,7 @@ if [ "$RIAK_SECURITY" == "enabled" ]; then
     $RIAK_ADMIN security grant $RIAK_USER_PERMISSIONS on any to ejabberd
 fi
 
+if [ "$SETUP_BUCKET_TYPES" == "true" ]; then
 $RIAK_ADMIN bucket-type create users '{"props":{"datatype":"map"}}'
 $RIAK_ADMIN bucket-type activate users
 
@@ -113,6 +114,7 @@ $RIAK_ADMIN bucket-type activate privacy_lists_names
 
 $RIAK_ADMIN bucket-type create privacy_lists '{"props":{"last_write_wins":true,"dvv_enabled":false}}'
 $RIAK_ADMIN bucket-type activate privacy_lists
+fi
 
 
 if [ "$RIAK_SECURITY" == "enabled" ]; then

--- a/tools/setup_riak.escript
+++ b/tools/setup_riak.escript
@@ -1,0 +1,112 @@
+#!/usr/bin/env escript
+-mode(compile).
+
+main(_) ->
+    Cookie = riak,
+    io:format("~nsetup_riak START~n", []),
+    {ok, _} = net_kernel:start([node_name(setup_riak)]),
+    erlang:set_cookie(node(), Cookie),
+    RiakNode = node_name(riak),
+    case net_adm:ping(RiakNode) of
+        pang ->
+            io:format("Failed to ping ~p~n", [RiakNode]),
+            init:stop(1);
+        pong ->
+            io:format("Riak node ~p~n", [RiakNode]),
+            try setup_riak_node(RiakNode)
+            catch Class:Reason ->
+                Stacktrace = erlang:get_stacktrace(),
+                io:format("Failed ~p:~p~n~p~n", [Class, Reason, Stacktrace]),
+                init:stop(1)
+            end,
+        io:format("setup_riak DONE~n", [])
+    end.
+
+node_name(ShortName) ->
+    list_to_atom(atom_to_list(ShortName) ++ "@" ++ format_ip(local_ip_v4())).
+
+format_ip({A,B,C,D}) ->
+    integer_to_list(A) ++ "." ++
+    integer_to_list(B) ++ "." ++
+    integer_to_list(C) ++ "." ++
+    integer_to_list(D).
+
+local_ip_v4() ->
+    {ok, Addrs} = inet:getifaddrs(),
+    hd([
+         Addr || {_, Opts} <- Addrs, {addr, Addr} <- Opts,
+         size(Addr) == 4, Addr =/= {127,0,0,1}
+    ]).
+
+setup_riak_node(RiakNode) ->
+    setup_access(RiakNode),
+    setup_types(RiakNode).
+
+setup_access(RiakNode) ->
+    User = "ejabberd",
+    Password = "mongooseim_secret",
+    ok = rpc:call(RiakNode, riak_core_console, security_enable, [[]]),
+    ok = rpc:call(RiakNode, riak_core_console, add_user, [[User, "password=" ++ Password]]),
+    ok = rpc:call(RiakNode, riak_core_console, add_source, [["all", "127.0.0.1/32", "password"]]),
+    ok = rpc:call(RiakNode, riak_core_console, add_source, [[User, "0.0.0.0/0", "password"]]),
+    ok = rpc:call(RiakNode, riak_core_console, grant, [[permissions(), "on", "any", "to", User]]),
+    ok = rpc:call(RiakNode, riak_core_console, ciphers, [[ciphers()]]),
+    ok.
+
+ciphers() ->
+    "AES256-SHA:DHE-RSA-AES128-SHA256".
+
+permissions() ->
+    "riak_kv.get,riak_kv.put,riak_kv.delete,riak_kv.index,"
+    "riak_kv.list_keys,riak_kv.list_buckets,riak_kv.mapreduce,"
+    "riak_core.get_bucket,riak_core.set_bucket,riak_core.set_bucket_type,"
+    "riak_core.get_bucket_type,search.admin,search.query".
+
+setup_types(RiakNode) ->
+    Def = [{last_write_wins, true}, {dvv_enabled, false}],
+    Map = [{datatype, map}],
+    Set = [{datatype, set}],
+    create_and_activate_bucket_type(RiakNode, <<"users">>, Map),
+    create_and_activate_bucket_type(RiakNode, <<"rosters">>, Map),
+    create_and_activate_bucket_type(RiakNode, <<"roster_versions">>, Def),
+    create_and_activate_bucket_type(RiakNode, <<"private">>, Def),
+    create_and_activate_bucket_type(RiakNode, <<"vcard">>, [{search_index, <<"vcard">>}|Def]),
+    create_and_activate_bucket_type(RiakNode, <<"mam_yz">>, [{search_index, <<"mam">>}|Map]),
+    create_and_activate_bucket_type(RiakNode, <<"last">>, Def),
+    create_and_activate_bucket_type(RiakNode, <<"offline">>, Def),
+    create_and_activate_bucket_type(RiakNode, <<"privacy_defaults">>, Def),
+    create_and_activate_bucket_type(RiakNode, <<"privacy_lists_names">>, Set),
+    create_and_activate_bucket_type(RiakNode, <<"privacy_lists">>, Def),
+    ok.
+
+
+create_and_activate_bucket_type(Node, Type, Props) ->
+    ok = rpc:call(Node, riak_core_bucket_type, create, [Type, Props]),
+    wait_until_bucket_type_status(Type, ready, Node),
+    ok = rpc:call(Node, riak_core_bucket_type, activate, [Type]),
+    wait_until_bucket_type_status(Type, active, Node).
+
+wait_until_bucket_type_status(Type, ExpectedStatus, Nodes) when is_list(Nodes) ->
+    [wait_until_bucket_type_status(Type, ExpectedStatus, Node) || Node <- Nodes];
+wait_until_bucket_type_status(Type, ExpectedStatus, Node) ->
+    F = fun() ->
+                ActualStatus = rpc:call(Node, riak_core_bucket_type, status, [Type]),
+                ExpectedStatus =:= ActualStatus
+        end,
+    ok = wait_until(F, 30, 100).
+
+
+%% @doc Retry `Fun' until it returns `Retry' times, waiting `Delay'
+%% milliseconds between retries. This is our eventual consistency bread
+%% and butter
+wait_until(Fun, Retry, Delay) when Retry > 0 ->
+    Res = Fun(),
+    case Res of
+        true ->
+            ok;
+        _ when Retry == 1 ->
+            {fail, Res};
+        _ ->
+            timer:sleep(Delay),
+            wait_until(Fun, Retry-1, Delay)
+    end.

--- a/tools/setup_riak.escript
+++ b/tools/setup_riak.escript
@@ -96,9 +96,9 @@ wait_until_bucket_type_status(Type, ExpectedStatus, Node) ->
     ok = wait_until(F, 30, 100).
 
 
-%% @doc Retry `Fun' until it returns `Retry' times, waiting `Delay'
-%% milliseconds between retries. This is our eventual consistency bread
-%% and butter
+%% @doc Retry `Fun' until it returns true.
+%% Repeat maximum `Retry' times.
+%% Wait `Delay' milliseconds between retries.
 wait_until(Fun, Retry, Delay) when Retry > 0 ->
     Res = Fun(),
     case Res of

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -33,8 +33,12 @@ all: mongooseim/cert.pem mongooseim/key.pem \
 # It speeds up generation of dhparam
 # Speed is useful for fake certificates
 # https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours
+#
+# Certs generated with -dsaparam don't work with our slapd container though.
+# So, let's remove the option for now.
+# https://bugs.launchpad.net/ubuntu/+source/openldap/+bug/1724285
 %/dh_server.pem:
-	openssl dhparam -outform PEM -out $@ 2048 -dsaparam
+	openssl dhparam -outform PEM -out $@ 1024
 
 %/index.txt:
 	mkdir -p $(@D)

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -34,7 +34,7 @@ all: mongooseim/cert.pem mongooseim/key.pem \
 # Speed is useful for fake certificates
 # https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours
 %/dh_server.pem:
-	openssl dhparam -outform PEM -out $@ 1024 -dsaparam
+	openssl dhparam -outform PEM -out $@ 2048 -dsaparam
 
 %/index.txt:
 	mkdir -p $(@D)

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -10,6 +10,8 @@ else
     BASE=`readlink -f ${TOOLS}/..`
     SED=sed
 fi
+# Make it full
+TOOLS="$BASE/tools"
 
 TLS_DIST=${TLS_DIST:-false}
 START_NODES=${START_NODES:-true}

--- a/tools/travis-common-vars.sh
+++ b/tools/travis-common-vars.sh
@@ -54,3 +54,8 @@ function mount_ro_volume
 {
     echo "-v $1:$2:ro"
 }
+
+function db_name
+{
+    echo mongooseim-$1
+}

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -94,7 +94,7 @@ DB_CONF_DIR=${TOOLS}/db_configs/$db
 
 
 if [ "$db" = 'mysql' ]; then
-    NAME=mongooseim-mysql
+    NAME=$(db_name mysql)
     echo "Configuring mysql"
     # TODO We should not use sudo
     sudo -n service mysql stop || echo "Failed to stop mysql"
@@ -121,7 +121,7 @@ if [ "$db" = 'mysql' ]; then
     tools/wait_for_healthcheck.sh $NAME
 
 elif [ "$db" = 'pgsql' ]; then
-    NAME=mongooseim-pgsql
+    NAME=$(db_name pgsql)
     # If you see "certificate verify failed" error in Mongoose logs, try:
     # Inside tools/ssl/:
     # make clean && make
@@ -144,7 +144,7 @@ elif [ "$db" = 'pgsql' ]; then
     cp ${SSLDIR}/ca/cacert.pem ${PGSQL_ODBC_CERT_DIR}/root.crt
 
 elif [ "$db" = 'riak' ]; then
-    NAME=mongooseim-riak
+    NAME=$(db_name riak)
     echo "Configuring Riak with SSL"
     docker rm -f $NAME || echo "Skip removing previous container"
     # Instead of docker run, use "docker create" + "docker start".
@@ -190,8 +190,8 @@ elif [ "$db" = 'riak' ]; then
     # docker exec -t $NAME bash -c 'tail -f /var/log/riak/*'
 
 elif [ "$db" = 'cassandra' ]; then
-    NAME=mongooseim-cassandra
-    PROXY_NAME=mongooseim-cassandra-proxy
+    NAME=$(db_name cassandra)
+    PROXY_NAME=$(db_name cassandra-proxy)
     docker image pull cassandra:${CASSANDRA_VERSION}
     docker rm -f $NAME $PROXY_NAME || echo "Skip removing previous container"
 
@@ -246,7 +246,7 @@ elif [ "$db" = 'cassandra' ]; then
 elif [ "$db" = 'elasticsearch' ]; then
     ELASTICSEARCH_IMAGE=docker.elastic.co/elasticsearch/elasticsearch:$ELASTICSEARCH_VERSION
     ELASTICSEARCH_PORT=9200
-    NAME=mongooseim-elasticsearch
+    NAME=$(db_name elasticsearch)
 
     echo $ELASTICSEARCH_IMAGE
     docker image pull $ELASTICSEARCH_IMAGE
@@ -273,7 +273,7 @@ elif [ "$db" = 'elasticsearch' ]; then
         echo "Failed to put MUC mapping into ElasticSearch"
 
 elif [ "$db" = 'mssql' ]; then
-    NAME=mongooseim-mssql
+    NAME=$(db_name mssql)
     # LICENSE STUFF, IMPORTANT
     #
     # SQL Server Developer edition

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -197,7 +197,7 @@ elif [ "$db" = 'riak' ]; then
     export RIAK_ADMIN="docker exec mongooseim-riak riak-admin"
     tools/setup_riak
     # Use this command to read Riak's logs if something goes wrong
-    # docker exec -it mongooseim-riak bash -c 'tail -f /var/log/riak/*'
+    # docker exec -t mongooseim-riak bash -c 'tail -f /var/log/riak/*'
 
 elif [ "$db" = 'cassandra' ]; then
     docker image pull cassandra:${CASSANDRA_VERSION}
@@ -243,7 +243,7 @@ elif [ "$db" = 'cassandra' ]; then
     TEST_SCHEMA=$(pwd)/big_tests/tests/mongoose_cassandra_SUITE_data/schema.cql
     for cql_file in $MIM_SCHEMA $TEST_SCHEMA; do
         echo "Apply ${cql_file}"
-        docker run -it $RM_FLAG -e SSL_CERTFILE=/cacert.pem         \
+        docker run -t $RM_FLAG -e SSL_CERTFILE=/cacert.pem         \
 	               $(mount_ro_volume "${SSLDIR}/ca/cacert.pem" "/cacert.pem")  \
                        $(mount_ro_volume "${cql_file}" "/cassandra.cql")           \
                        --link mongooseim-cassandra:cassandra        \
@@ -334,13 +334,13 @@ elif [ "$db" = 'mssql' ]; then
     tools/wait_for_healthcheck.sh mongoose-mssql
     tools/wait_for_service.sh mongoose-mssql 1433
 
-    docker exec -it mongoose-mssql \
+    docker exec -t mongoose-mssql \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -Q "CREATE DATABASE ejabberd"
-    docker exec -it mongoose-mssql \
+    docker exec -t mongoose-mssql \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -Q "ALTER DATABASE ejabberd SET READ_COMMITTED_SNAPSHOT ON"
-    docker exec -it mongoose-mssql \
+    docker exec -t mongoose-mssql \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -i mongoose.sql
 

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -335,15 +335,7 @@ elif [ "$db" = 'mssql' ]; then
     tools/wait_for_healthcheck.sh $NAME
     tools/wait_for_service.sh $NAME 1433
 
-    docker exec -t $NAME \
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
-        -Q "CREATE DATABASE ejabberd"
-    docker exec -t $NAME \
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
-        -Q "ALTER DATABASE ejabberd SET READ_COMMITTED_SNAPSHOT ON"
-    docker exec -t $NAME \
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
-        -i mongoose.sql
+    tools/setup-mssql-database.sh
 
     install_odbc_ini
 

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -7,7 +7,6 @@
 # https://store.docker.com/editions/community/docker-ce-desktop-mac
 
 set -e
-TOOLS=`dirname $0`
 
 source tools/travis-common-vars.sh
 
@@ -17,7 +16,7 @@ MYSQL_DIR=/etc/mysql/conf.d
 
 PGSQL_ODBC_CERT_DIR=~/.postgresql
 
-SSLDIR=${BASE}/${TOOLS}/ssl
+SSLDIR=${TOOLS}/ssl
 
 # Don't need it for travis for speed up
 RM_FLAG=" --rm "
@@ -103,7 +102,7 @@ mkdir -p "$SQL_TEMP_DIR" "$SQL_DATA_DIR"
 function setup_db(){
 db=${1:-none}
 echo "Setting up db: $db"
-DB_CONF_DIR=${BASE}/${TOOLS}/db_configs/$db
+DB_CONF_DIR=${TOOLS}/db_configs/$db
 
 
 if [ "$db" = 'mysql' ]; then
@@ -124,7 +123,7 @@ if [ "$db" = 'mysql' ]; then
         -e MYSQL_PASSWORD=mongooseim_secret \
 	$(mount_ro_volume ${DB_CONF_DIR}/mysql.cnf ${MYSQL_DIR}/mysql.cnf) \
         $(mount_ro_volume ${MIM_PRIV_DIR}/mysql.sql /docker-entrypoint-initdb.d/mysql.sql) \
-	$(mount_ro_volume ${BASE}/${TOOLS}/docker-setup-mysql.sh /docker-entrypoint-initdb.d/docker-setup-mysql.sh) \
+	$(mount_ro_volume ${TOOLS}/docker-setup-mysql.sh /docker-entrypoint-initdb.d/docker-setup-mysql.sh) \
 	$(mount_ro_volume ${SQL_TEMP_DIR} /tmp/sql) \
         $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/mysql) \
         --health-cmd='mysqladmin ping --silent' \
@@ -149,7 +148,7 @@ elif [ "$db" = 'pgsql' ]; then
            -e SQL_TEMP_DIR=/tmp/sql \
            $(mount_ro_volume ${SQL_TEMP_DIR} /tmp/sql) \
            $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/postgresql/data) \
-           $(mount_ro_volume ${BASE}/${TOOLS}/docker-setup-postgres.sh /docker-entrypoint-initdb.d/docker-setup-postgres.sh) \
+           $(mount_ro_volume ${TOOLS}/docker-setup-postgres.sh /docker-entrypoint-initdb.d/docker-setup-postgres.sh) \
            -p 5432:5432 --name=mongooseim-pgsql postgres
     mkdir -p ${PGSQL_ODBC_CERT_DIR}
     cp ${SSLDIR}/ca/cacert.pem ${PGSQL_ODBC_CERT_DIR}/root.crt

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -167,9 +167,11 @@ elif [ "$db" = 'riak' ]; then
 	$(mount_ro_volume "${SSLDIR}/mongooseim/cert.pem" "/etc/riak/cert.pem") \
 	$(mount_ro_volume "${SSLDIR}/mongooseim/key.pem" "/etc/riak/key.pem") \
 	$(mount_ro_volume "${SSLDIR}/ca/cacert.pem" "/etc/riak/ca/cacertfile.pem") \
+	$(mount_ro_volume "$TOOLS/setup_riak.escript" "/setup_riak.escript") \
         $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/riak) \
         --health-cmd='riak-admin status' \
-        "michalwski/docker-riak:1.0.6"
+        "michalwski/docker-riak:1.0.6" \
+        /sbin/my_init --skip-startup-files
     # Use a temporary file to store config
     TEMP_RIAK_CONF=$(mktemp)
     # Export config from a container
@@ -188,9 +190,10 @@ elif [ "$db" = 'riak' ]; then
     tools/wait_for_healthcheck.sh $NAME
     echo "Waiting for a listener to appear"
     tools/wait_for_service.sh $NAME 8098
-    # Use riak-admin from inside the container
-    export RIAK_ADMIN="docker exec $NAME riak-admin"
-    tools/setup_riak
+    # Setup schema and indexes
+    RIAK_SECURITY=disabled SETUP_BUCKET_TYPES=false ./tools/setup_riak
+    # Setup access and bucket types
+    time docker exec $NAME riak escript /setup_riak.escript
     tools/wait_for_service.sh $NAME 8087
     # Use this command to read Riak's logs if something goes wrong
     # docker exec -t $NAME bash -c 'tail -f /var/log/riak/*'

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -130,6 +130,7 @@ if [ "$db" = 'mysql' ]; then
         --health-cmd='mysqladmin ping --silent' \
         -p 3306:3306 --name=mongooseim-mysql \
         mysql --default-authentication-plugin=mysql_native_password
+    tools/wait_for_healthcheck.sh mongooseim-mysql
 
 elif [ "$db" = 'pgsql' ]; then
     # If you see "certificate verify failed" error in Mongoose logs, try:

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -191,6 +191,7 @@ elif [ "$db" = 'riak' ]; then
     # Use riak-admin from inside the container
     export RIAK_ADMIN="docker exec $NAME riak-admin"
     tools/setup_riak
+    tools/wait_for_service.sh $NAME 8087
     # Use this command to read Riak's logs if something goes wrong
     # docker exec -t $NAME bash -c 'tail -f /var/log/riak/*'
 

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -99,7 +99,7 @@ if [ "$db" = 'mysql' ]; then
     echo "Configuring mysql"
     # TODO We should not use sudo
     sudo -n service mysql stop || echo "Failed to stop mysql"
-    docker rm -f $NAME || echo "Skip removing previous container"
+    docker rm -v -f $NAME || echo "Skip removing previous container"
     cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
     openssl rsa -in ${SSLDIR}/mongooseim/key.pem -out ${SQL_TEMP_DIR}/fake_key.pem
     chmod a+r ${SQL_TEMP_DIR}/fake_key.pem
@@ -130,7 +130,7 @@ elif [ "$db" = 'pgsql' ]; then
     # Than rerun the script to create a new docker container.
     echo "Configuring postgres with SSL"
     sudo -n service postgresql stop || echo "Failed to stop psql"
-    docker rm -f $NAME || echo "Skip removing previous container"
+    docker rm -v -f $NAME || echo "Skip removing previous container"
     cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
     cp ${SSLDIR}/mongooseim/key.pem ${SQL_TEMP_DIR}/fake_key.pem
     cp ${DB_CONF_DIR}/postgresql.conf ${SQL_TEMP_DIR}/.
@@ -151,7 +151,7 @@ elif [ "$db" = 'riak' ]; then
     export RIAK_PORT=${RIAK_PORT:-8098}
     RIAK_PB_PORT=${RIAK_PB_PORT:-8087}
     echo "Configuring Riak with SSL"
-    docker rm -f $NAME || echo "Skip removing previous container"
+    docker rm -v -f $NAME || echo "Skip removing previous container"
     # Instead of docker run, use "docker create" + "docker start".
     # So we can prepare our container.
     # We use HEALTHCHECK here, check "docker ps" to get healthcheck status.
@@ -200,7 +200,7 @@ elif [ "$db" = 'cassandra' ]; then
     CASSANDRA_PROXY_API_PORT=${CASSANDRA_PROXY_API_PORT:-9191}
     CASSANDRA_PORT=${CASSANDRA_PORT:-9042}
     docker image pull cassandra:${CASSANDRA_VERSION}
-    docker rm -f $NAME $PROXY_NAME || echo "Skip removing previous container"
+    docker rm -v -f $NAME $PROXY_NAME || echo "Skip removing previous container"
 
     opts="$(docker inspect -f '{{range .Config.Entrypoint}}{{println}}{{.}}{{end}}' cassandra:${CASSANDRA_VERSION})"
     opts+="$(docker inspect -f '{{range .Config.Cmd}}{{println}}{{.}}{{end}}' cassandra:${CASSANDRA_VERSION})"
@@ -257,7 +257,7 @@ elif [ "$db" = 'elasticsearch' ]; then
 
     echo $ELASTICSEARCH_IMAGE
     docker image pull $ELASTICSEARCH_IMAGE
-    docker rm -f  $NAME || echo "Skip removing previous container"
+    docker rm -v -f $NAME || echo "Skip removing previous container"
 
     echo "Starting ElasticSearch $ELASTICSEARCH_VERSION from Docker container"
     docker run -d $RM_FLAG \
@@ -303,7 +303,7 @@ elif [ "$db" = 'mssql' ]; then
     # > a third party the results of any benchmark test of the software.
 
     # SCRIPTING STUFF
-    docker rm -f $NAME || echo "Skip removing previous container"
+    docker rm -v -f $NAME || echo "Skip removing previous container"
     docker volume rm -f $NAME-data || echo "Skip removing previous volume"
     #
     # MSSQL wants secure passwords

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -71,18 +71,6 @@ Password    = mongooseim_secret+ESL123
 Charset     = UTF-8
 TDS_Version = 7.2
 client_charset = UTF-8
-
-[ejabberd-pgsql]
-Driver               = PostgreSQL Unicode
-ServerName           = localhost
-Port                 = 5432
-Database             = ejabberd
-Username             = ejabberd
-Password             = mongooseim_secret
-sslmode              = verify-full
-Protocol             = 9.3.5
-Debug                = 1
-ByteaAsLongVarBinary = 1
 EOL
 }
 
@@ -106,10 +94,11 @@ DB_CONF_DIR=${TOOLS}/db_configs/$db
 
 
 if [ "$db" = 'mysql' ]; then
+    NAME=mongooseim-mysql
     echo "Configuring mysql"
     # TODO We should not use sudo
     sudo -n service mysql stop || echo "Failed to stop mysql"
-    docker rm -f mongooseim-mysql || echo "Skip removing previous container"
+    docker rm -f $NAME || echo "Skip removing previous container"
     cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
     openssl rsa -in ${SSLDIR}/mongooseim/key.pem -out ${SQL_TEMP_DIR}/fake_key.pem
     chmod a+r ${SQL_TEMP_DIR}/fake_key.pem
@@ -127,18 +116,19 @@ if [ "$db" = 'mysql' ]; then
 	$(mount_ro_volume ${SQL_TEMP_DIR} /tmp/sql) \
         $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/mysql) \
         --health-cmd='mysqladmin ping --silent' \
-        -p 3306:3306 --name=mongooseim-mysql \
+        -p 3306:3306 --name=$NAME \
         mysql --default-authentication-plugin=mysql_native_password
-    tools/wait_for_healthcheck.sh mongooseim-mysql
+    tools/wait_for_healthcheck.sh $NAME
 
 elif [ "$db" = 'pgsql' ]; then
+    NAME=mongooseim-pgsql
     # If you see "certificate verify failed" error in Mongoose logs, try:
     # Inside tools/ssl/:
     # make clean && make
     # Than rerun the script to create a new docker container.
     echo "Configuring postgres with SSL"
     sudo -n service postgresql stop || echo "Failed to stop psql"
-    docker rm -f mongooseim-pgsql || echo "Skip removing previous container"
+    docker rm -f $NAME || echo "Skip removing previous container"
     cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
     cp ${SSLDIR}/mongooseim/key.pem ${SQL_TEMP_DIR}/fake_key.pem
     cp ${DB_CONF_DIR}/postgresql.conf ${SQL_TEMP_DIR}/.
@@ -149,14 +139,14 @@ elif [ "$db" = 'pgsql' ]; then
            $(mount_ro_volume ${SQL_TEMP_DIR} /tmp/sql) \
            $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/postgresql/data) \
            $(mount_ro_volume ${TOOLS}/docker-setup-postgres.sh /docker-entrypoint-initdb.d/docker-setup-postgres.sh) \
-           -p 5432:5432 --name=mongooseim-pgsql postgres
+           -p 5432:5432 --name=$NAME postgres
     mkdir -p ${PGSQL_ODBC_CERT_DIR}
     cp ${SSLDIR}/ca/cacert.pem ${PGSQL_ODBC_CERT_DIR}/root.crt
-    install_odbc_ini
 
 elif [ "$db" = 'riak' ]; then
+    NAME=mongooseim-riak
     echo "Configuring Riak with SSL"
-    docker rm -f mongooseim-riak || echo "Skip removing previous container"
+    docker rm -f $NAME || echo "Skip removing previous container"
     # Instead of docker run, use "docker create" + "docker start".
     # So we can prepare our container.
     # We use HEALTHCHECK here, check "docker ps" to get healthcheck status.
@@ -167,7 +157,7 @@ elif [ "$db" = 'riak' ]; then
     time docker create -p 8087:8087 -p 8098:8098 \
         -e DOCKER_RIAK_BACKEND=leveldb \
         -e DOCKER_RIAK_CLUSTER_SIZE=1 \
-        --name=mongooseim-riak \
+        --name=$NAME \
 	$(mount_ro_volume "${DB_CONF_DIR}/advanced.config" "/etc/riak/advanced.config") \
 	$(mount_ro_volume "${SSLDIR}/mongooseim/cert.pem" "/etc/riak/cert.pem") \
 	$(mount_ro_volume "${SSLDIR}/mongooseim/key.pem" "/etc/riak/key.pem") \
@@ -178,30 +168,32 @@ elif [ "$db" = 'riak' ]; then
     # Use a temporary file to store config
     TEMP_RIAK_CONF=$(mktemp)
     # Export config from a container
-    docker cp "mongooseim-riak:/etc/riak/riak.conf" "$TEMP_RIAK_CONF"
+    docker cp "$NAME:/etc/riak/riak.conf" "$TEMP_RIAK_CONF"
     # Enable search
     $SED -i "s/^search = \(.*\)/search = on/" "$TEMP_RIAK_CONF"
     # Enable ssl by appending settings from riak.conf.ssl
     cat "${DB_CONF_DIR}/riak.conf.ssl" >> "$TEMP_RIAK_CONF"
     # Import config back into container
-    docker cp "$TEMP_RIAK_CONF" "mongooseim-riak:/etc/riak/riak.conf"
+    docker cp "$TEMP_RIAK_CONF" "$NAME:/etc/riak/riak.conf"
     # Erase temporary config file
     rm "$TEMP_RIAK_CONF"
-    docker start mongooseim-riak
+    docker start $NAME
     echo "Waiting for docker healthcheck"
     echo ""
-    tools/wait_for_healthcheck.sh mongooseim-riak
+    tools/wait_for_healthcheck.sh $NAME
     echo "Waiting for a listener to appear"
-    tools/wait_for_service.sh mongooseim-riak 8098
+    tools/wait_for_service.sh $NAME 8098
     # Use riak-admin from inside the container
-    export RIAK_ADMIN="docker exec mongooseim-riak riak-admin"
+    export RIAK_ADMIN="docker exec $NAME riak-admin"
     tools/setup_riak
     # Use this command to read Riak's logs if something goes wrong
-    # docker exec -t mongooseim-riak bash -c 'tail -f /var/log/riak/*'
+    # docker exec -t $NAME bash -c 'tail -f /var/log/riak/*'
 
 elif [ "$db" = 'cassandra' ]; then
+    NAME=mongooseim-cassandra
+    PROXY_NAME=mongooseim-cassandra-proxy
     docker image pull cassandra:${CASSANDRA_VERSION}
-    docker rm -f mongooseim-cassandra mongooseim-cassandra-proxy || echo "Skip removing previous container"
+    docker rm -f $NAME $PROXY_NAME || echo "Skip removing previous container"
 
     opts="$(docker inspect -f '{{range .Config.Entrypoint}}{{println}}{{.}}{{end}}' cassandra:${CASSANDRA_VERSION})"
     opts+="$(docker inspect -f '{{range .Config.Cmd}}{{println}}{{.}}{{end}}' cassandra:${CASSANDRA_VERSION})"
@@ -220,14 +212,14 @@ elif [ "$db" = 'cassandra' ]; then
 	       $(mount_ro_volume "${SSLDIR}" "/ssl") \
 	       $(mount_ro_volume "${docker_entry}" "/entry.sh") \
                $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/cassandra) \
-               --name=mongooseim-cassandra       \
+               --name=$NAME       \
                --entrypoint "/entry.sh"          \
                cassandra:${CASSANDRA_VERSION}    \
                "${init_opts[@]}"
-    tools/wait_for_service.sh mongooseim-cassandra 9042 || docker logs mongooseim-cassandra
+    tools/wait_for_service.sh $NAME 9042 || docker logs $NAME
 
     # Start TCP proxy
-    CASSANDRA_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mongooseim-cassandra)
+    CASSANDRA_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $NAME)
     echo "Connecting TCP proxy to Cassandra on $CASSANDRA_IP..."
     cp ${DB_CONF_DIR}/proxy/zazkia-routes.json "$SQL_TEMP_DIR/"
     $SED -i "s/\"service-hostname\": \".*\"/\"service-hostname\": \"$CASSANDRA_IP\"/g" "$SQL_TEMP_DIR/zazkia-routes.json"
@@ -235,9 +227,9 @@ elif [ "$db" = 'cassandra' ]; then
                -p 9042:9042                     \
                -p 9191:9191                     \
                $(mount_ro_volume "$SQL_TEMP_DIR" /data)  \
-               --name=mongooseim-cassandra-proxy \
+               --name=$PROXY_NAME \
                emicklei/zazkia
-    tools/wait_for_service.sh mongooseim-cassandra-proxy 9042 || docker logs mongooseim-cassandra-proxy
+    tools/wait_for_service.sh $PROXY_NAME 9042 || docker logs $PROXY_NAME
 
     MIM_SCHEMA=$(pwd)/priv/cassandra.cql
     TEST_SCHEMA=$(pwd)/big_tests/tests/mongoose_cassandra_SUITE_data/schema.cql
@@ -246,7 +238,7 @@ elif [ "$db" = 'cassandra' ]; then
         docker run -t $RM_FLAG -e SSL_CERTFILE=/cacert.pem         \
 	               $(mount_ro_volume "${SSLDIR}/ca/cacert.pem" "/cacert.pem")  \
                        $(mount_ro_volume "${cql_file}" "/cassandra.cql")           \
-                       --link mongooseim-cassandra:cassandra        \
+                       --link $NAME:cassandra        \
                        cassandra:${CASSANDRA_VERSION}               \
                        sh -c 'exec cqlsh "$CASSANDRA_PORT_9042_TCP_ADDR" --ssl -f /cassandra.cql'
     done
@@ -254,11 +246,11 @@ elif [ "$db" = 'cassandra' ]; then
 elif [ "$db" = 'elasticsearch' ]; then
     ELASTICSEARCH_IMAGE=docker.elastic.co/elasticsearch/elasticsearch:$ELASTICSEARCH_VERSION
     ELASTICSEARCH_PORT=9200
-    ELASTICSEARCH_NAME=mongooseim-elasticsearch
+    NAME=mongooseim-elasticsearch
 
     echo $ELASTICSEARCH_IMAGE
     docker image pull $ELASTICSEARCH_IMAGE
-    docker rm -f  $ELASTICSEARCH_NAME || echo "Skip removing previous container"
+    docker rm -f  $NAME || echo "Skip removing previous container"
 
     echo "Starting ElasticSearch $ELASTICSEARCH_VERSION from Docker container"
     docker run -d $RM_FLAG \
@@ -266,10 +258,10 @@ elif [ "$db" = 'elasticsearch' ]; then
            -e "http.host=0.0.0.0" \
            -e "transport.host=127.0.0.1" \
            -e "xpack.security.enabled=false" \
-           --name $ELASTICSEARCH_NAME \
+           --name $NAME \
            $ELASTICSEARCH_IMAGE
     echo "Waiting for ElasticSearch to start listening on port"
-    tools/wait_for_service.sh $ELASTICSEARCH_NAME $ELASTICSEARCH_PORT || docker logs $ELASTICSEARCH_NAME
+    tools/wait_for_service.sh $NAME $ELASTICSEARCH_PORT || docker logs $NAME
 
     ELASTICSEARCH_URL=http://localhost:$ELASTICSEARCH_PORT
     ELASTICSEARCH_PM_MAPPING="$(pwd)/priv/elasticsearch/pm.json"
@@ -281,6 +273,7 @@ elif [ "$db" = 'elasticsearch' ]; then
         echo "Failed to put MUC mapping into ElasticSearch"
 
 elif [ "$db" = 'mssql' ]; then
+    NAME=mongooseim-mssql
     # LICENSE STUFF, IMPORTANT
     #
     # SQL Server Developer edition
@@ -302,8 +295,8 @@ elif [ "$db" = 'mssql' ]; then
     # > a third party the results of any benchmark test of the software.
 
     # SCRIPTING STUFF
-    docker rm -f mongoose-mssql || echo "Skip removing previous container"
-    docker volume rm -f mongoose-mssql-data || echo "Skip removing previous volume"
+    docker rm -f $NAME || echo "Skip removing previous container"
+    docker volume rm -f $NAME-data || echo "Skip removing previous volume"
     #
     # MSSQL wants secure passwords
     # i.e. just "mongooseim_secret" would not work.
@@ -323,24 +316,24 @@ elif [ "$db" = 'mssql' ]; then
     # Otherwise we get an error in logs
     # Error 87(The parameter is incorrect.) occurred while opening file '/var/opt/mssql/data/master.mdf'
     docker run -d -p 1433:1433                                  \
-               --name=mongoose-mssql                            \
+               --name=$NAME                            \
                -e "ACCEPT_EULA=Y"                               \
                -e "SA_PASSWORD=mongooseim_secret+ESL123"        \
                $(mount_ro_volume "$(pwd)/priv/mssql2012.sql" "/mongoose.sql")  \
                $(data_on_volume -v ${SQL_DATA_DIR}:/var/opt/mssql) \
-               $(data_on_volume -v mongoose-mssql-data:/var/opt/mssql/data) \
+               $(data_on_volume -v $NAME-data:/var/opt/mssql/data) \
                --health-cmd='/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" -Q "SELECT 1"' \
                microsoft/mssql-server-linux
-    tools/wait_for_healthcheck.sh mongoose-mssql
-    tools/wait_for_service.sh mongoose-mssql 1433
+    tools/wait_for_healthcheck.sh $NAME
+    tools/wait_for_service.sh $NAME 1433
 
-    docker exec -t mongoose-mssql \
+    docker exec -t $NAME \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -Q "CREATE DATABASE ejabberd"
-    docker exec -t mongoose-mssql \
+    docker exec -t $NAME \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -Q "ALTER DATABASE ejabberd SET READ_COMMITTED_SNAPSHOT ON"
-    docker exec -t mongoose-mssql \
+    docker exec -t $NAME \
         /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "mongooseim_secret+ESL123" \
         -i mongoose.sql
 

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -4,6 +4,8 @@ set -e
 source tools/travis-common-vars.sh
 LDAP_ROOTPASS=mongooseim_secret
 
+NAME=mongooseim-ldap
+
 LDAP_ROOT="cn=admin,dc=esl,dc=com"
 LDAP_DOMAIN="esl.com"
 LDAP_ORGANISATION="Erlang Solutions"
@@ -29,12 +31,12 @@ EOL
 cp tools/ssl/mongooseim/{cert,key}.pem "$LDAP_CERT_DIR"
 cp tools/ssl/ca/cacert.pem "$LDAP_CERT_DIR"
 
-docker rm -f mongooseim-ldap || echo "Skip removing previous container"
+docker rm -f $NAME || echo "Skip removing previous container"
 # Host on non-standard higher ports 3389 and 3636 to avoid problems with lower ports
 # Default LDAP ports are 389 (TCP) and 636 (TLS)
 
 docker run -d \
-    --name mongooseim-ldap \
+    --name $NAME \
     -p 3389:389 \
     -p 3636:636 \
     -e LDAP_DOMAIN="$LDAP_DOMAIN" \

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -4,7 +4,7 @@ set -e
 source tools/travis-common-vars.sh
 LDAP_ROOTPASS=mongooseim_secret
 
-NAME=mongooseim-ldap
+NAME=$(db_name ldap)
 
 LDAP_ROOT="cn=admin,dc=esl,dc=com"
 LDAP_DOMAIN="esl.com"

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -58,7 +58,7 @@ docker run -d \
 n=0
 until [ $n -ge 10 ]
 do
-    echo "Q" | openssl s_client -connect localhost:3636 \
+    echo "Q" | openssl s_client -connect localhost:$LDAP_SECURE_PORT \
                        -cert tools/ssl/mongooseim/cert.pem -key tools/ssl/mongooseim/key.pem \
                        -CAfile tools/ssl/ca/cacert.pem && break
     n=$[$n+1]

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -35,10 +35,13 @@ docker rm -f $NAME || echo "Skip removing previous container"
 # Host on non-standard higher ports 3389 and 3636 to avoid problems with lower ports
 # Default LDAP ports are 389 (TCP) and 636 (TLS)
 
+LDAP_PORT=${LDAP_PORT:-3389}
+LDAP_SECURE_PORT=${LDAP_SECURE_PORT:-3636}
+
 docker run -d \
     --name $NAME \
-    -p 3389:389 \
-    -p 3636:636 \
+    -p $LDAP_PORT:389 \
+    -p $LDAP_SECURE_PORT:636 \
     -e LDAP_DOMAIN="$LDAP_DOMAIN" \
     -e LDAP_ADMIN_PASSWORD="$LDAP_ROOTPASS" \
     -e LDAP_ORGANISATION="$LDAP_ORGANISATION" \

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -31,7 +31,7 @@ EOL
 cp tools/ssl/mongooseim/{cert,key}.pem "$LDAP_CERT_DIR"
 cp tools/ssl/ca/cacert.pem "$LDAP_CERT_DIR"
 
-docker rm -f $NAME || echo "Skip removing previous container"
+docker rm -v -f $NAME || echo "Skip removing previous container"
 # Host on non-standard higher ports 3389 and 3636 to avoid problems with lower ports
 # Default LDAP ports are 389 (TCP) and 636 (TLS)
 

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -24,7 +24,7 @@ mkdir -p "$LDAP_SCHEMAS_DIR" "$LDAP_DATA_DIR" "$LDAP_CONFIG_DIR" "$LDAP_CERT_DIR
 
 function write_init_entries
 {
-cat > "$LDAP_SCHEMAS_DIR/init_entries$1.ldif" << EOL
+    cat > "$LDAP_SCHEMAS_DIR/init_entries$1.ldif" << EOL
 dn: ou=Users$1,dc=esl,dc=com
 objectClass: organizationalUnit
 EOL

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -27,7 +27,6 @@ function write_init_entries
 cat > "$LDAP_SCHEMAS_DIR/init_entries$1.ldif" << EOL
 dn: ou=Users$1,dc=esl,dc=com
 objectClass: organizationalUnit
-ou: users
 EOL
 }
 

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -22,11 +22,21 @@ echo "LDAP_ROOT_DIR=$LDAP_ROOT_DIR"
 
 mkdir -p "$LDAP_SCHEMAS_DIR" "$LDAP_DATA_DIR" "$LDAP_CONFIG_DIR" "$LDAP_CERT_DIR"
 
-cat > "$LDAP_SCHEMAS_DIR/init_entries.ldif" << EOL
-dn: ou=Users,dc=esl,dc=com
+function write_init_entries
+{
+cat > "$LDAP_SCHEMAS_DIR/init_entries$1.ldif" << EOL
+dn: ou=Users$1,dc=esl,dc=com
 objectClass: organizationalUnit
 ou: users
 EOL
+}
+
+write_init_entries
+
+# Make Users1, Users2, ... Users10 OU-s, which can be used for parallel jobs
+for i in {1..10}; do
+    write_init_entries $i
+done
 
 cp tools/ssl/mongooseim/{cert,key,dh_server}.pem "$LDAP_CERT_DIR"
 cp tools/ssl/ca/cacert.pem "$LDAP_CERT_DIR"

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -83,4 +83,4 @@ do
     sleep 15
 done
 
-./tools/wait_for_healthcheck.sh "$NAME"
+./tools/wait_for_healthcheck.sh "$NAME" || { docker logs $NAME; exit 1; }

--- a/tools/travis-setup-ldap.sh
+++ b/tools/travis-setup-ldap.sh
@@ -35,6 +35,12 @@ docker rm -v -f $NAME || echo "Skip removing previous container"
 # Host on non-standard higher ports 3389 and 3636 to avoid problems with lower ports
 # Default LDAP ports are 389 (TCP) and 636 (TLS)
 
+for i in "$LDAP_CERT_DIR/"*; do
+    echo "Print $i"
+    cat "$i"
+    echo ""
+done
+
 LDAP_PORT=${LDAP_PORT:-3389}
 LDAP_SECURE_PORT=${LDAP_SECURE_PORT:-3636}
 

--- a/tools/wait_for_service.sh
+++ b/tools/wait_for_service.sh
@@ -20,7 +20,7 @@ if [ `uname` = "Darwin" ]; then
   docker run --rm -d --name wait-helper ubuntu sleep infinity || echo "We can continue if the wait-helper exists"
   docker cp tools/wait-for-it.sh wait-helper:/wait-for-it.sh
   echo "Wait for $IP:$PORT"
-  docker exec -it wait-helper /wait-for-it.sh -h "$IP" -p "$PORT"
+  docker exec -t wait-helper /wait-for-it.sh -h "$IP" -p "$PORT"
 else
   tools/wait-for-it.sh -h "$IP" -p "$PORT"
 fi


### PR DESCRIPTION
This PR addresses "some tweaks".

Proposed changes include:
* Move some code into tools/setup-mssql-database.sh to allow calling it separately, when needed
* Remove unused stuff from mssql schema
* Rewrite setup_riak script into erlang (because it's faaaster)
* `-dsaparam` optimization goes away :( (but we cache certs anyway, so...).
* But we improve starting time of ldap container, because we don't need to generate dh pair (we reuse mongooseim pair).
* Fix a bug with path calculation, allowing to run start_setup_db from any directory
* `docker rm` removes volumes now (finally)
* Make database ports configurable using env variables (we don't use the feature yet)
* Use `docker exec` to setup cassandra schemas (speedup)
* Remove "docker -i" attribute (to allow to run from non-interactive shell).