### PR TITLE
Use Acquire::ForceIPv4 with default ubuntu repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ orbs:
             name: Install basic packages
             command: |
               sudo killall -9 apt-get || true && \
-              sudo sed -i 's#archive.ubuntu.com/ubuntu#ftp.heanet.ie/pub/ubuntu#g' /etc/apt/sources.list && \
-              sudo sed -i 's#security.ubuntu.com/ubuntu#ftp.heanet.ie/pub/ubuntu#g' /etc/apt/sources.list && \
+              echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4 && \
               wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
               sudo dpkg -i erlang-solutions_1.0_all.deb && \
               sudo apt-get update && \


### PR DESCRIPTION
This PR addresses 

```
Reading package lists... Done

W: Failed to fetch http://ftp.heanet.ie/pub/ubuntu/dists/xenial/InRelease  Could not resolve 'ftp.heanet.ie'
W: Failed to fetch http://ftp.heanet.ie/pub/ubuntu/dists/xenial-updates/InRelease  Could not resolve 'ftp.heanet.ie'
W: Failed to fetch http://ftp.heanet.ie/pub/ubuntu/dists/xenial-backports/InRelease  Could not resolve 'ftp.heanet.ie'
W: Failed to fetch http://ftp.heanet.ie/pub/ubuntu/dists/xenial-security/InRelease  Could not resolve 'ftp.heanet.ie'
W: Some index files failed to download. They have been ignored, or old ones used instead.
```
