### PR TITLE
Deprecate OTPs older than 21.2

### DIFF
--- a/doc/developers-guide/OpenSSL-and-FIPS.md
+++ b/doc/developers-guide/OpenSSL-and-FIPS.md
@@ -16,7 +16,7 @@ Make sure the option `--enable-fips` is specified for `configure` command.
 If you want to use a different OpenSSL than the default one, specify the option `--with-ssl=PATH_TO_YOUR_OPENSSL` as well.
 Here's an example of a command for building Erlang/OTP with kerl:
 ```
-KERL_CONFIGURE_OPTIONS="--enable-fips" ./kerl build 20.0 20.0-fips
+KERL_CONFIGURE_OPTIONS="--enable-fips" ./kerl build 21.3 21.3-fips
 ```
 
 ### Building MongooseIM with a custom OpenSSL

--- a/doc/modules/mod_jingle_sip.md
+++ b/doc/modules/mod_jingle_sip.md
@@ -96,7 +96,7 @@ tools/configure with-all without-odbc
 tools/configure with-all
 ```
 
-MongooseIM 2.2.x packages are built with OTP 19.3, so they include Jingle/SIP support.
+MongooseIM packages are built with Jingle/SIP support.
 
 ### Options
 

--- a/doc/operation-and-maintenance/known-issues.md
+++ b/doc/operation-and-maintenance/known-issues.md
@@ -7,7 +7,7 @@ MongooseIM will not connect to MySQL over TLS on OTP 20.3 due to [the MySQL driv
 
 ### Proposed workarounds
 
-* Upgrade OTP to 21.0 or higher.
+* Upgrade OTP to 21.2 or higher.
 * Use unencrypted communication with MySQL.
 
 ## MSSQL connectivity via ODBC

--- a/doc/user-guide/How-to-build.md
+++ b/doc/user-guide/How-to-build.md
@@ -21,7 +21,7 @@ To compile MongooseIM you need:
     * CentOS: `gcc`, `gcc-c++`
     * Ubuntu: `gcc`, `g++`
     * Mac: Xcode Command Line Tools
-*   Erlang/OTP 20.x or higher; **WARNING:** There are certain issues with TLS support in Erlang 20.3. It is highly recommended to use 21.3 or newer.
+*   Erlang/OTP 21.2 or higher; Versions 20.0-21.1 work as well but they are deprecated. The next MIM release won't support them.
     * CentOS: `erlang` 
     * Ubuntu: `erlang`
     * Mac (Homebrew): `erlang`

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
  ]}.
 
 %% We use functions introduced in Erlang/OTP 19
-{require_min_otp_vsn, "19"}.
+{require_min_otp_vsn, "20"}.
 
 %% We agreed to use https:// for deps because of possible firewall issues.
 %% By default, deps are downloaded without using git by rebar_faster_deps.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -46,6 +46,7 @@ start(normal, _Args) ->
     db_init(),
     application:start(cache_tab),
 
+    warning_if_pre_21_2_otp(),
     translate:start(),
     acl:start(),
     ejabberd_node_id:start(),
@@ -249,3 +250,14 @@ maybe_disable_default_logger() ->
         _E:_R ->
             ok
     end.
+
+warning_if_pre_21_2_otp() ->
+    OTPVsn = erlang:system_info(version),
+    case lists:map(fun erlang:list_to_integer/1, string:split(OTPVsn, ".", all)) < [10, 2] of
+        true ->
+            ?WARNING_MSG("MongooseIM is running on a deprecated OTP version."
+                         " The next release will require at least OTP 21.2.", []);
+        false ->
+            ok
+    end.
+


### PR DESCRIPTION
This PR adds deprecation warning for OTP < 21.2 and updates documentation accordingly.

No tests added as IMO it's sufficient to verify on CI that the warning is shown on OTP 20.3 and not in the other jobs.
