### PR TITLE
Deprecate MAM 0.3

### DIFF
--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -4,6 +4,9 @@ It enables a service to store all user messages for one-to-one chats as well as 
 It uses [XEP-0059: Result Set Management](http://xmpp.org/extensions/xep-0059.html) for paging.
 It is a highly customizable module, that requires some skill and knowledge to operate properly and efficiently.
 
+MongooseIM is compatible with MAM 0.4-0.6.
+Version 0.3 is deprecated and won't be supported by the next release.
+
 Configure MAM with different storage backends:
 
 * RDBMS (databases like MySQL, PostgreSQL, MS SQL Server)
@@ -103,7 +106,7 @@ These options will only have effect when the `rdbms` backend is used:
 
 Servers SHOULD NOT archive messages that do not have a `<body/>` child tag. Servers SHOULD NOT archive delayed messages.
 
-From MAM v0.3 onwards it is expected that all messages that hold meaningful content, rather than state changes such as Chat State Notifications, are archived.
+By default, all messages that hold meaningful content, rather than state changes such as Chat State Notifications, are archived.
 
 #### Archiving chat markers
 

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -252,9 +252,16 @@ maybe_add_arcid_elems(To, MessID, Packet, AddStanzaid) ->
         _ -> Packet
     end.
 
-maybe_log_deprecation(_IQ) ->
-    %% Left for future deprecations
-    ok.
+maybe_log_deprecation(IQ) ->
+    case IQ#iq.xmlns of
+        ?NS_MAM_03 ->
+            Msg = "MongooseIM has received MAM 0.3 request. This version is deprecated and won't"
+                  " be supported by the next MongooseIM release."
+                  " Please update your client application.",
+            mongoose_deprecations:log(mam03, Msg, [{log_level, warning}]);
+        _ ->
+            ok
+    end.
 
 %% @doc Return true, if the first element points on `By'.
 -spec is_arcid_elem_for(ElemName :: binary(), exml:element(), By :: binary()) -> boolean().


### PR DESCRIPTION
This PR adds a deprecation message when MAM 0.3 request is received from a client.

It also adds a note to MAM documentation about the supported versions.

*EDIT:* Deprecation message may be seen in https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/2466/5113/elasticsearch_and_cassandra_mnesia.2207/logs/2019-09-20_10.34.24/mim1/log/ejabberd.log