### PR TITLE
Sm/update

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -687,8 +687,7 @@ resume_session_with_wrong_h_does_not_leak_sessions(Config) ->
         Steps = connection_steps_to_authenticate(),
         {ok, Alice, _} = escalus_connection:start(AliceSpec, Steps),
         Resumed = try_to_resume_stream(Alice, SMID, 30),
-        escalus:assert(is_stream_error, [<<"policy-violation">>,
-                                         <<"h attribute too big">>], Resumed),
+        escalus:assert(is_stream_error, [<<"undefined-condition">>, <<>>], Resumed),
 
         [] = get_user_present_resources(AliceSpec),
         [] = get_sid_by_stream_id(SMID),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -43,6 +43,7 @@ parallel_test_cases() ->
      server_returns_failed_after_start,
      server_returns_failed_after_auth,
      server_enables_resumption,
+     client_enables_sm_twice_fails,
      basic_ack,
      h_ok_before_session,
      h_ok_after_session_enabled_before_session,
@@ -177,6 +178,17 @@ server_returns_failed(Config, ConnActions) ->
     escalus:assert(is_sm_failed, [<<"unexpected-request">>],
                    escalus_connection:get_stanza(Alice, enable_sm_failed)).
 
+client_enables_sm_twice_fails(Config) ->
+    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
+    Steps = connection_steps_to_session(),
+    {ok, Alice, Features} = escalus_connection:start(AliceSpec, Steps),
+    escalus_session:stream_management(Alice, Features),
+    escalus_connection:send(Alice, escalus_stanza:enable_sm()),
+    escalus:assert(is_sm_failed, [<<"unexpected-request">>],
+                   escalus_connection:get_stanza(Alice, enable_sm_failed)),
+    escalus:assert(is_stream_end,
+                   escalus_connection:get_stanza(Alice, enable_sm_failed)),
+    false = escalus_connection:is_connected(Alice).
 
 basic_ack(Config) ->
     AliceSpec = escalus_fresh:create_fresh_user(Config, alice),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -191,7 +191,7 @@ client_enables_sm_twice_fails_with_correct_error_stanza(Config) ->
                    escalus_connection:get_stanza(Alice, enable_sm_failed)),
     escalus:assert(is_stream_end,
                    escalus_connection:get_stanza(Alice, enable_sm_failed)),
-    false = escalus_connection:is_connected(Alice).
+    wait_until_client_disconnects(Alice).
 
 session_resumed_then_old_session_is_closed_gracefully_with_correct_error_stanza(Config) ->
     %% GIVEN USER WITH STREAM RESUMPTION ENABLED
@@ -206,7 +206,7 @@ session_resumed_then_old_session_is_closed_gracefully_with_correct_error_stanza(
                    escalus_connection:get_stanza(Alice, close_old_stream)),
     escalus:assert(is_stream_end,
                    escalus_connection:get_stanza(Alice, close_old_stream)),
-    false = escalus_connection:is_connected(Alice),
+    wait_until_client_disconnects(Alice),
     true = escalus_connection:is_connected(Alice2),
     escalus_connection:stop(Alice2).
 
@@ -325,7 +325,7 @@ client_acks_more_than_sent(Config) ->
     <<"0">> = exml_query:attr(HandledCountSubElement, <<"send-count">>),
     %% Assert graceful stream end
     escalus:assert(is_stream_end, escalus_connection:get_stanza(Alice, stream_end)),
-    false = escalus_connection:is_connected(Alice).
+    wait_until_client_disconnects(Alice).
 
 too_many_unacked_stanzas(Config) ->
     {Bob, _} = given_fresh_user(Config, bob),
@@ -1066,6 +1066,10 @@ extract_state_name(SysStatus) ->
 wait_until_disconnected(UserSpec) ->
     mongoose_helper:wait_until(fun() -> get_user_alive_resources(UserSpec) =:= [] end, true,
                                #{name => get_user_alive_resources}).
+
+wait_until_client_disconnects(Client) ->
+    mongoose_helper:wait_until(fun() -> escalus_connection:is_connected(Client)
+                               end, false, #{name => client_disconnected}).
 
 monitor_session(Client) ->
     UserSpec = Client#client.props,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2752,8 +2752,9 @@ maybe_enable_stream_mgmt(NextState, El, StateData) ->
                                        stream_mgmt_ack_freq = AckFreq,
                                        stream_mgmt_resume_timeout = ResumeTimeout});
         {?NS_STREAM_MGNT_3, _, _} ->
-            %% already on, ignore
-            fsm_next_state(NextState, StateData);
+            send_element_from_server_jid(StateData, stream_mgmt_failed(<<"unexpected-request">>)),
+            send_trailer(StateData),
+            {stop, normal, StateData};
         {_, _, _} ->
             %% invalid namespace
             send_element_from_server_jid(StateData, mongoose_xmpp_errors:invalid_namespace()),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1513,6 +1513,10 @@ terminate(_Reason, StateName, StateData) ->
             presence_broadcast(Acc1, StateData#state.pres_i, StateData),
             reroute_unacked_messages(StateData);
         {_, resumed} ->
+            StreamConflict = mongoose_xmpp_errors:stream_conflict(
+                               StateData#state.lang, <<"Resumed by new connection">>),
+            maybe_send_element_from_server_jid_safe(StateData, StreamConflict),
+            maybe_send_trailer_safe(StateData),
             ?INFO_MSG("(~w) Stream ~p resumed for ~s",
                       [StateData#state.socket,
                        StateData#state.stream_mgmt_id,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2805,6 +2805,12 @@ stream_mgmt_handle_ack(NextState, El, #state{} = SD) ->
             maybe_send_element_from_server_jid_safe(SD, mongoose_xmpp_errors:invalid_namespace()),
             maybe_send_trailer_safe(SD),
             {stop, normal, SD};
+        error:badarg ->
+            PolicyViolationErr = mongoose_xmpp_errors:policy_violation(
+                                   SD#state.lang, <<"Invalid h attribute">>),
+            maybe_send_element_from_server_jid_safe(SD, PolicyViolationErr),
+            maybe_send_trailer_safe(SD),
+            {stop, normal, SD};
         throw:{undefined_condition, H, OldAcked} ->
             #xmlel{children = [UndefCond, Text]} = ErrorStanza0
                 = mongoose_xmpp_errors:undefined_condition(

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2956,7 +2956,6 @@ flush_stream_mgmt_buffer(#state{stream_mgmt_buffer = Buffer}) ->
     re_route_packets(Buffer).
 
 re_route_packets(Buffer) ->
-    %% TODO add delayed on it?
     [ejabberd_router:route(From, To, Packet)
      || {From, To, Packet} <- lists:reverse(Buffer)],
     ok.
@@ -3112,8 +3111,7 @@ maybe_add_timestamp({F, T, #xmlel{name= <<"message">>}=Packet}=PacketTuple, Time
         <<"headline">> ->
             PacketTuple;
         _ ->
-            %% TODO: ?MYNAME (or server taken from c2s state) not <<"localhost">>
-            {F, T, add_timestamp(Timestamp, <<"localhost">>, Packet)}
+            {F, T, add_timestamp(Timestamp, ?MYNAME, Packet)}
     end;
 maybe_add_timestamp(Packet, _Timestamp) ->
     Packet.

--- a/src/mongoose_xmpp_errors.erl
+++ b/src/mongoose_xmpp_errors.erl
@@ -245,6 +245,9 @@ unsupported_version() ->
 xml_not_well_formed() ->
     jlib:stream_error(<<"xml-not-well-formed">>).
 
+undefined_condition() ->
+    jlib:stream_error(<<"undefined-condition">>).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Text Stream Errors
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -321,6 +324,9 @@ xml_not_well_formed(Lang, Text) ->
 
 xml_not_well_formed_bin() ->
     exml:to_binary(xml_not_well_formed()).
+
+undefined_condition(Lang, Text) ->
+    jlib:stream_errort(<<"undefined-condition">>, Lang, Text).
 
 bad_format_bin() ->
     exml:to_binary(bad_format()).


### PR DESCRIPTION
This PR addresses changes in the [Stream Management XEP](https://xmpp.org/extensions/xep-0198.html).

Proposed changes are (hopefully) very well explained in the tests:

* `client_enables_sm_twice_fails_with_correct_error_stanza`: the new XEP _requires_ enabling be requested only once. If a client requests so twice, the client should be considered faulty and closed gracefully.
* `session_resumed_then_old_session_is_closed_gracefully_with_correct_error_stanza`: We were not testing what happened to the old session on resumption apart from being closed. The XEP requires that if the connection is still there, a `<conflict>` stream error be send and connection be closed gracefully.
* `session_resumed_and_old_session_dead_doesnt_route_error_to_new_session`: verifies that if the old session cannot receive the `<conflict>` stanzas, they're not rerouted to the newly connected session anyway.
* `h_non_given_closes_stream_gracefully` is a test that should have been there before. The XEP _requires_ the `h` attribute to be given. When it's not, the connection is faulty and should be closed. We were doing too happily a `binary_to_integer(xml:get_tag_attr_s(<<"h">>, El))` without catching the possible error, which was then provoking the `c2s` process to die ungracefully. Now this error is caught and a proper stream:error is send together with a stream closing.
* One more old test had to change, `client_acks_more_than_sent`, as the expected error that this test checks was checking is also now differently defined.

A todo about timestamps on rerouting was removed, because they're already added in https://github.com/esl/MongooseIM/blob/b288406a5f0ea70b04fbc3e218f4436bbd79cbd3/src/ejabberd_c2s.erl#L1147, when the execution path reaches `buffer_out_stanza`, so no need to worry if it was done or not, it was always done indeed.

PS: There's one more feature in SM coming in, but it's all complex by itself so it will come in a different PR.