### PR TITLE
SM/update_return_old_h

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -367,7 +367,8 @@ h_non_given_closes_stream_gracefully(ConfigIn) ->
         escalus:assert(is_stream_error,
                        [<<"policy-violation">>, <<>>],
                        escalus:wait_for_stanza(Alice)),
-        escalus:assert(is_stream_end, escalus_connection:get_stanza(Alice, stream_end))
+        escalus:assert(is_stream_end, escalus_connection:get_stanza(Alice, stream_end)),
+        true = escalus_connection:wait_for_close(Alice,timer:seconds(5))
     end).
 
 client_acks_more_than_sent(Config) ->

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -186,6 +186,7 @@ end_per_testcase(CN, Config) when CN =:= resume_expired_session_returns_correct_
                                   CN =:= gc_repeat_after_timeout_does_clean
                                    ->
     dynamic_modules:stop(domain(), ?MOD_SM),
+    rpc(mim(), ejabberd_sup, stop_child, [stream_management_stale_h]),
     dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(server_requests_ack_freq_2 = CN, Config) ->

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -704,7 +704,7 @@ resume_session_with_wrong_h_does_not_leak_sessions(Config) ->
         escalus:assert(is_stream_error, [<<"undefined-condition">>, <<>>], Resumed),
 
         [] = get_user_present_resources(AliceSpec),
-        [] = get_sid_by_stream_id(SMID),
+        smid_not_found = get_sid_by_stream_id(SMID),
         escalus_connection:wait_for_close(Alice, timer:seconds(5))
     end).
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -98,8 +98,9 @@ stream_management_with_stale_h(RepeatAfter, Geriatric) ->
     [
      {ack_freq, 1},
      {resume_timeout, ?SHORT_RESUME_TIMEOUT},
-     {stale_h, {true, [{gc_repeat_after, RepeatAfter},
-                       {gc_geriatric, Geriatric}]}}]}].
+     {stale_h, [{enabled, true},
+                {stale_h_repeat_after, RepeatAfter},
+                {stale_h_geriatric, Geriatric}]}]}].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -643,7 +644,7 @@ resume_expired_session_returns_correct_h(Config) ->
     escalus_connection:stop(NewAlice).
 
 gc_repeat_after_never_means_no_cleaning(Config) ->
-    true = rpc(mim(), ?MOD_SM, set_gc_repeat_after, [never]),
+    true = rpc(mim(), ?MOD_SM, set_stale_h_repeat_after, [?BIG_BIG_BIG_TIMEOUT]),
     [{SMID1, _}, {SMID2, _}, {SMID3, _}] = ?config(smid_test, Config),
     {stale_h, 1} = rpc(mim(), ?MOD_SM, get_session_from_smid, [SMID1]),
     {stale_h, 2} = rpc(mim(), ?MOD_SM, get_session_from_smid, [SMID2]),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -17,6 +17,7 @@
 
 -import(escalus_stanza, [setattr/3]).
 
+-define(BIG_BIG_BIG_TIMEOUT, 30000000000).
 -define(SHORT_RESUME_TIMEOUT, 3).
 -define(SMALL_SM_BUFFER, 3).
 
@@ -157,12 +158,12 @@ register_some_smid_h(Config) ->
     [{smid_test, [S1, S2, S3]} | Config].
 
 init_per_testcase(resume_expired_session_returns_correct_h = CN, Config) ->
-    Config2 = set_gc_parameters(never, never, Config),
+    Config2 = set_gc_parameters(?BIG_BIG_BIG_TIMEOUT, ?BIG_BIG_BIG_TIMEOUT, Config),
     rpc(mim(), ?MOD_SM, set_resume_timeout, [?SHORT_RESUME_TIMEOUT]),
     true = rpc(mim(), ?MOD_SM, set_ack_freq, [1]),
     escalus:init_per_testcase(CN, Config2);
 init_per_testcase(gc_repeat_after_never_means_no_cleaning = CN, Config) ->
-    Config2 = set_gc_parameters(never, 1, Config),
+    Config2 = set_gc_parameters(?BIG_BIG_BIG_TIMEOUT, ?SHORT_RESUME_TIMEOUT, Config),
     Config3 = register_some_smid_h(Config2),
     escalus:init_per_testcase(CN, Config3);
 init_per_testcase(gc_repeat_after_timeout_does_clean = CN, Config) ->

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -736,7 +736,7 @@ resume_session_with_wrong_h_does_not_leak_sessions(Config) ->
         escalus:assert(is_stream_error, [<<"undefined-condition">>, <<>>], Resumed),
 
         [] = get_user_present_resources(AliceSpec),
-        smid_not_found = get_sid_by_stream_id(SMID),
+        {error, smid_not_found} = get_sid_by_stream_id(SMID),
         escalus_connection:wait_for_close(Alice, timer:seconds(5))
     end).
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -148,14 +148,14 @@ set_gc_parameters(RepeatAfter, Geriatric, Config) ->
       domain(), stream_management_with_stale_h(RepeatAfter, Geriatric)),
     Config2.
 
+register_smid(IntSmidId) ->
+    S = {SMID = make_smid(), IntSmidId},
+    ok = rpc(mim(), ?MOD_SM, register_stale_smid_h, [SMID, IntSmidId]),
+    S.
+
 register_some_smid_h(Config) ->
-    S1 = {SMID1 = make_smid(), 1},
-    S2 = {SMID2 = make_smid(), 2},
-    S3 = {SMID3 = make_smid(), 3},
-    ok = rpc(mim(), ?MOD_SM, register_stale_smid_h, [SMID1, 1]),
-    ok = rpc(mim(), ?MOD_SM, register_stale_smid_h, [SMID2, 2]),
-    ok = rpc(mim(), ?MOD_SM, register_stale_smid_h, [SMID3, 3]),
-    [{smid_test, [S1, S2, S3]} | Config].
+    TestSmids = lists:map(fun register_smid/1, lists:seq(1, 3)),
+    [{smid_test, TestSmids} | Config].
 
 init_per_testcase(resume_expired_session_returns_correct_h = CN, Config) ->
     Config2 = set_gc_parameters(?BIG_BIG_BIG_TIMEOUT, ?BIG_BIG_BIG_TIMEOUT, Config),
@@ -179,8 +179,8 @@ init_per_testcase(replies_are_processed_by_resumed_session = CN, Config) ->
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
-end_per_testcase(CN, Config) when CN =:= resume_expired_session_returns_correct_h,
-                                  CN =:= gc_repeat_after_never_means_no_cleaning,
+end_per_testcase(CN, Config) when CN =:= resume_expired_session_returns_correct_h;
+                                  CN =:= gc_repeat_after_never_means_no_cleaning;
                                   CN =:= gc_repeat_after_timeout_does_clean
                                    ->
     dynamic_modules:stop(domain(), ?MOD_SM),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -37,7 +37,8 @@ groups() ->
          {parallel_manual_ack_freq_1, [parallel], parallel_manual_ack_test_cases()},
          {stale_h, [], stale_h_test_cases()},
          {manual_ack_freq_long_session_timeout, [parallel], [preserve_order]}],
-    G.
+    ct_helper:repeat_all_until_all_ok(G).
+
 
 parallel_test_cases() ->
     [server_announces_sm,

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -569,7 +569,6 @@ resume_expired_session_returns_correct_h(Config) ->
     escalus_connection:kill(Alice),
     %% ensure there is no session
     wait_until_disconnected(AliceSpec),
-    0 = length(get_user_alive_resources(AliceSpec)),
     %% alice comes back, but too late, so resumption doesn't work,
     %% but she receives the previous h = 1 anyway
     {ok, NewAlice, _} = escalus_connection:start(AliceSpec, connection_steps_to_authenticate()),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -17,7 +17,7 @@
 
 -import(escalus_stanza, [setattr/3]).
 
--define(BIG_BIG_BIG_TIMEOUT, 30000000000).
+-define(BIG_BIG_BIG_TIMEOUT, 3600).
 -define(SHORT_RESUME_TIMEOUT, 3).
 -define(SMALL_SM_BUFFER, 3).
 
@@ -37,7 +37,7 @@ groups() ->
          {parallel_manual_ack_freq_1, [parallel], parallel_manual_ack_test_cases()},
          {stale_h, [], stale_h_test_cases()},
          {manual_ack_freq_long_session_timeout, [parallel], [preserve_order]}],
-    ct_helper:repeat_all_until_all_ok(G).
+    G.
 
 parallel_test_cases() ->
     [server_announces_sm,

--- a/doc/modules/mod_stream_management.md
+++ b/doc/modules/mod_stream_management.md
@@ -1,14 +1,91 @@
 ### Module Description
-Enables [XEP-0198: Stream Management](http://xmpp.org/extensions/xep-0198.html). 
-It is implemented mostly in `ejabberd_c2s`. 
-This module is just a "starter", to supply the configuration values to new client connections.
-It also provides a basic session table API and adds a new stream feature.
+
+Enables [XEP-0198: Stream Management](http://xmpp.org/extensions/xep-0198.html).
+Most of the logic regarding session resumption and acknowledgement is implemented in `ejabberd_c2s`,
+while the management of the session tables and configuration is implemented in
+`mod_stream_management`.
+
+### In `ejabberd_c2s`
+
+The record `#state{}` in the `ejabberd_c2s` `gen_fsm` server keeps fields like:
+
+```erlang
+stream_mgmt = false, %% whether SM is enabled, used in pattern matching inside `ejabberd_c2s`
+stream_mgmt_in = 0, %% amount of msgs on the server and not acked by the user (server's <h>)
+stream_mgmt_id, %% the mod_stream_management:smid() unique identifier
+stream_mgmt_out_acked = 0, %% messages delivered to the user, and acked by the user (user's <h>)
+stream_mgmt_buffer = [], %% buffered stanzas not yet acked by the user
+stream_mgmt_buffer_size = 0, %% amount of messages buffered for the user
+stream_mgmt_buffer_max = ?STREAM_MGMT_CACHE_MAX, %% server's capacity for buffering
+stream_mgmt_ack_freq = ?STREAM_MGMT_ACK_FREQ, %% how often the server requests acks
+stream_mgmt_resume_timeout = ?STREAM_MGMT_RESUME_TIMEOUT, %% resumption timeout
+stream_mgmt_resume_tref, %% a ref() to pattern-match a given timeout
+stream_mgmt_resumed_from, %% a ejabberd_sm:sid() to keep identifiying the old session
+stream_mgmt_constraint_check_tref, %% another ref() for a timeout, this time for buffer_full check
+```
+
+### In `mod_stream_management`
+
+This module is just a "starter", to supply the configuration values to new client connections. It
+also provides a basic session table API and adds a new stream feature.
+
+At a bare minimum, this module keeps the config values in its `gen_mod` records, and it keeps a
+mnesia table defined as follows:
+
+```erlang
+-record(sm_session,
+        {smid :: smid(),
+         sid :: ejabberd_sm:sid()
+        }).
+```
+
+Where `smid` is a unique identifier — in this case a random binary, and `sid` is an opaque session
+identifier from `ejabberd_sm`, which is needed to find the previous session we want to resume from.
+This module implements hooks that run on connection removals and session cleanups, in order to clean
+records from a dying session; and it also implements registration callbacks, used in `ejabberd_c2s`
+when a session is registered for resumption.
+
+In order to be compliant with the XEP version 1.6, where a server can do the best effort to give the
+user the value of the server's `<h>` when a session timed out and cannot be resumed anymore, there's
+a second optional table:
+
+```erlang
+-record(stream_mgmt_stale_h,
+        {smid :: smid(),
+         h :: non_neg_integer(),
+         stamp :: non_neg_integer()
+        }).
+```
+
+This table is created, together with a `gen_server` responsible for cleaning up the tables, when
+`stale_h` is set to true with the proper garbage collection configuration. Then, when removing a
+record from the `sm_session` table (which happens when the state of the previous session is also
+dropped), a new record is added to this new table with the `smid` and `h` values of the dropped
+session, together with a timestamp. Then, when a new session attempting resumption queries
+`mod_stream_management` for the data behind a `smid`, `mod_stream_management` can answer one of the
+following:
+
+```erlang
+{sid, ejabberd_sm:sid()} | {stale_h, non_neg_integer()} | {error, smid_not_found}.
+```
+
+And `ejabberd_c2s` will pattern-match and act accordingly.
 
 ### Options
 
 * `buffer_max` (default: 100): Buffer size for messages yet to be acknowledged.
-* `ack_freq` (default: 1): Frequency of ack requests sent from the server to the client, e.g. 1 means a request after each stanza, 3 means a request after each 3 stanzas.
-* `resume_timeout` (default: 600): Timeout for the session resumption. Sessions will be removed after the specified number of seconds.
+* `ack_freq` (default: 1): Frequency of ack requests sent from the server to the client, e.g. 1
+  means a request after each stanza, 3 means a request after each 3 stanzas.
+* `resume_timeout` (default: 600): Timeout for the session resumption. Sessions will be removed
+  after the specified number of seconds.
+* `stale_h`: enable keeping old server's `<h>` values after the resumption timed out. Defaults to
+  `{false, []}`. When enabled, parameters for the garbage collection of these tables have to be
+  provided, for example as `{true, [{gc_repeat_after, 1800}, {gc_geriatric, 3600}]}` — 1800 for
+  `gc_repeat_after` and 3600 for `gc_geriatric` are the defaults.
+  - `gc_repeat_after`: How often the garbage collection will run in the background to clean this
+    table. Defaults to 1800 seconds (half an hour).
+  - `gc_geriatric`: The maximum lifespan of a record in memory. After this, they will be chased for
+    cleanup. Defaults to 3600 seconds (one hour).
 
 ### Example Configuration
 
@@ -16,6 +93,8 @@ It also provides a basic session table API and adds a new stream feature.
   {mod_stream_management, [{buffer_max, 30},
                            {ack_freq, 1},
                            {resume_timeout, 600}
+                           {stale_h, {true, [{gc_repeat_after, 1800},
+                                             {gc_geriatric, 3600}]}
                           ]},
 ```
 

--- a/doc/modules/mod_stream_management.md
+++ b/doc/modules/mod_stream_management.md
@@ -79,13 +79,13 @@ And `ejabberd_c2s` will pattern-match and act accordingly.
 * `resume_timeout` (default: 600): Timeout for the session resumption. Sessions will be removed
   after the specified number of seconds.
 * `stale_h`: enable keeping old server's `<h>` values after the resumption timed out. Defaults to
-  `{false, []}`. When enabled, parameters for the garbage collection of these tables have to be
-  provided, for example as `{true, [{gc_repeat_after, 1800}, {gc_geriatric, 3600}]}` — 1800 for
-  `gc_repeat_after` and 3600 for `gc_geriatric` are the defaults.
-  - `gc_repeat_after`: How often the garbage collection will run in the background to clean this
+  `[{enabled, false}]`. When enabled, parameters for the garbage collection of these tables should
+  be provided, for example as `[{enabled, true}, {stale_h_repeat_after, 1800}, {stale_h_geriatric,
+  3600}]` — 1800 for `stale_h_repeat_after` and 3600 for `stale_h_geriatric` are the defaults.
+  - `stale_h_repeat_after`: How often the garbage collection will run in the background to clean this
     table. Defaults to 1800 seconds (half an hour).
-  - `gc_geriatric`: The maximum lifespan of a record in memory. After this, they will be chased for
-    cleanup. Defaults to 3600 seconds (one hour).
+  - `stale_h_geriatric`: The maximum lifespan of a record in memory. After this, they will be chased
+    for cleanup. Defaults to 3600 seconds (one hour).
 
 ### Example Configuration
 
@@ -93,8 +93,9 @@ And `ejabberd_c2s` will pattern-match and act accordingly.
   {mod_stream_management, [{buffer_max, 30},
                            {ack_freq, 1},
                            {resume_timeout, 600}
-                           {stale_h, {true, [{gc_repeat_after, 1800},
-                                             {gc_geriatric, 3600}]}
+                           {stale_h, [{enabled, true},
+                                      {stale_h_repeat_after, 1800},
+                                      {stale_h_geriatric, 3600}]}
                           ]},
 ```
 

--- a/doc/modules/mod_stream_management.md
+++ b/doc/modules/mod_stream_management.md
@@ -7,7 +7,7 @@ while the management of the session tables and configuration is implemented in
 
 ### In `ejabberd_c2s`
 
-The record `#state{}` in the `ejabberd_c2s` `gen_fsm` server keeps fields like:
+The record `#smgc_state{}` in the `ejabberd_c2s` `gen_fsm` server keeps fields like:
 
 ```erlang
 stream_mgmt = false, %% whether SM is enabled, used in pattern matching inside `ejabberd_c2s`
@@ -26,11 +26,11 @@ stream_mgmt_constraint_check_tref, %% another ref() for a timeout, this time for
 
 ### In `mod_stream_management`
 
-This module is just a "starter", to supply the configuration values to new client connections. It
+This module is just a "starter", to provide the configuration values to new client connections. It
 also provides a basic session table API and adds a new stream feature.
 
-At a bare minimum, this module keeps the config values in its `gen_mod` records, and it keeps a
-mnesia table defined as follows:
+At a bare minimum, this module keeps the config values in its `gen_mod` records, and keeps a mnesia
+table defined as follows:
 
 ```erlang
 -record(sm_session,
@@ -39,15 +39,15 @@ mnesia table defined as follows:
         }).
 ```
 
-Where `smid` is a unique identifier — in this case a random binary, and `sid` is an opaque session
+where `smid` is a unique identifier — in this case a random binary, and `sid` is an opaque session
 identifier from `ejabberd_sm`, which is needed to find the previous session we want to resume from.
 This module implements hooks that run on connection removals and session cleanups, in order to clean
 records from a dying session; and it also implements registration callbacks, used in `ejabberd_c2s`
 when a session is registered for resumption.
 
-In order to be compliant with the XEP version 1.6, where a server can do the best effort to give the
-user the value of the server's `<h>` when a session timed out and cannot be resumed anymore, there's
-a second optional table:
+XEP version 1.6 requires the server to attempt giving the user the value of the server's `<h>` when
+a session timed out and cannot be resumed anymore. To be compliant with it, there's a second
+optional table:
 
 ```erlang
 -record(stream_mgmt_stale_h,
@@ -61,9 +61,9 @@ This table is created, together with a `gen_server` responsible for cleaning up 
 `stale_h` is set to true with the proper garbage collection configuration. Then, when removing a
 record from the `sm_session` table (which happens when the state of the previous session is also
 dropped), a new record is added to this new table with the `smid` and `h` values of the dropped
-session, together with a timestamp. Then, when a new session attempting resumption queries
-`mod_stream_management` for the data behind a `smid`, `mod_stream_management` can answer one of the
-following:
+session, together with a timestamp. Next, when a new session attempting resumption queries
+`mod_stream_management` for the data behind a `smid`, `mod_stream_management` can answer with one of
+the following:
 
 ```erlang
 {sid, ejabberd_sm:sid()} | {stale_h, non_neg_integer()} | {error, smid_not_found}.

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -707,6 +707,11 @@
 
                            % default: 600 seconds
                            % {resume_timeout, 600}
+
+                           % default: false
+                           % {stale_h, {false, []}
+                           % {stale_h, {true, [{gc_repeat_after, 30000},
+                           %                   {gc_geriatric, 60000}]}
                           ]},
   %% {mod_muc_light, [{host, "muclight.@HOST@"}]},
   %% {mod_muc, [{host, "muc.@HOST@"},

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -710,8 +710,8 @@
 
                            % default: false
                            % {stale_h, {false, []}
-                           % {stale_h, {true, [{gc_repeat_after, 30000},
-                           %                   {gc_geriatric, 60000}]}
+                           % {stale_h, {true, [{gc_repeat_after, 1800},
+                           %                   {gc_geriatric, 3600}]}
                           ]},
   %% {mod_muc_light, [{host, "muclight.@HOST@"}]},
   %% {mod_muc, [{host, "muc.@HOST@"},

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -708,10 +708,11 @@
                            % default: 600 seconds
                            % {resume_timeout, 600}
 
-                           % default: false
-                           % {stale_h, {false, []}
-                           % {stale_h, {true, [{gc_repeat_after, 1800},
-                           %                   {gc_geriatric, 3600}]}
+                           % default:  [{enabled, false}]
+                           % {stale_h, [{enabled, false}]
+                           % {stale_h, [{enabled, true},
+                           %            {stale_h_repeat_after, 1800},
+                           %            {stale_h_geriatric, 3600}]}
                           ]},
   %% {mod_muc_light, [{host, "muclight.@HOST@"}]},
   %% {mod_muc, [{host, "muc.@HOST@"},

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3071,12 +3071,12 @@ do_resume_session(SMID, El, {sid, {_, Pid}}, #state{server = Server} = StateData
     end;
 
 do_resume_session(SMID, _El, {stale_h, H}, StateData) when is_integer(H) ->
-    ?WARNING_MSG("no previous session with stream id ~p~n", [SMID]),
+    ?INFO_MSG("Previous session with stream id ~p timed out with h=~p~n", [SMID, H]),
     send_element_from_server_jid(
       StateData, stream_mgmt_failed(<<"item-not-found">>, [{<<"h">>, integer_to_binary(H)}])),
     fsm_next_state(wait_for_feature_after_auth, StateData);
 do_resume_session(SMID, _El, {error, smid_not_found}, StateData) ->
-    ?WARNING_MSG("no previous session with stream id ~p~n", [SMID]),
+    ?INFO_MSG("no previous session with stream id ~p~n", [SMID]),
     send_element_from_server_jid(StateData, stream_mgmt_failed(<<"item-not-found">>)),
     fsm_next_state(wait_for_feature_after_auth, StateData).
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -376,9 +376,9 @@ unset_presence(Acc, SID, User, Server, Resource, Status, Info) ->
       Reason :: close_reason(),
       Acc1 :: mongoose_acc:t().
 close_session_unset_presence(Acc, SID, User, Server, Resource, Status, Reason) ->
-    close_session(Acc, SID, User, Server, Resource, Reason),
     LServer = jid:nameprep(Server),
-    ejabberd_hooks:run_fold(unset_presence_hook, LServer, Acc,
+    Acc1 = close_session(Acc, SID, User, LServer, Resource, Reason),
+    ejabberd_hooks:run_fold(unset_presence_hook, LServer, Acc1,
                        [jid:nodeprep(User), LServer,
                         jid:resourceprep(Resource), Status]).
 

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -103,11 +103,12 @@ cleanup(Node) ->
                          ['$_']}]),
                 lists:foreach(fun(#session{ usr = {U, S, R}, sid = SID }) ->
                                       mnesia:delete({session, SID}),
-                                      ejabberd_hooks:run_fold(session_cleanup, S,
-                                                              mongoose_acc:new(
-                                                                #{location => ?LOCATION,
-                                                                  lserver => S,
-                                                                  element => undefined}),
+                                      Acc = mongoose_acc:new(
+                                              #{location => ?LOCATION,
+                                                lserver => S,
+                                                element => undefined}),
+                                      ejabberd_hooks:run_fold(session_cleanup,
+                                                              S, Acc,
                                                               [U, S, R, SID])
                               end, Es)
 

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -103,7 +103,12 @@ cleanup(Node) ->
                          ['$_']}]),
                 lists:foreach(fun(#session{ usr = {U, S, R}, sid = SID }) ->
                                       mnesia:delete({session, SID}),
-                                      ejabberd_hooks:run(session_cleanup, S, [U, S, R, SID])
+                                      ejabberd_hooks:run_fold(session_cleanup, S,
+                                                              mongoose_acc:new(
+                                                                #{location => ?LOCATION,
+                                                                  lserver => S,
+                                                                  element => undefined}),
+                                                              [U, S, R, SID])
                               end, Es)
 
         end,

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -125,11 +125,11 @@ cleanup(Node) ->
                           %% Add possible removed ":" from encoded SID
                           SID = binary_to_term(ejabberd_binary:join(SIDEncoded, <<":">>)),
                           delete_session(SID, U, S, R),
-                          ejabberd_hooks:run_fold(session_cleanup, S,
-                                                  mongoose_acc:new(
-                                                    #{location => ?LOCATION,
-                                                      lserver => S,
-                                                      element => undefined}),
+                          Acc = mongoose_acc:new(
+                                  #{location => ?LOCATION,
+                                    lserver => S,
+                                    element => undefined}),
+                          ejabberd_hooks:run_fold(session_cleanup, S, Acc,
                                                   [U, S, R, SID])
                   end, Hashes).
 

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -125,7 +125,12 @@ cleanup(Node) ->
                           %% Add possible removed ":" from encoded SID
                           SID = binary_to_term(ejabberd_binary:join(SIDEncoded, <<":">>)),
                           delete_session(SID, U, S, R),
-                          ejabberd_hooks:run(session_cleanup, S, [U, S, R, SID])
+                          ejabberd_hooks:run_fold(session_cleanup, S,
+                                                  mongoose_acc:new(
+                                                    #{location => ?LOCATION,
+                                                      lserver => S,
+                                                      element => undefined}),
+                                                  [U, S, R, SID])
                   end, Hashes).
 
 

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -96,12 +96,7 @@ remove_smid(Acc, SID, _JID, _Info, _Reason) ->
 -spec session_cleanup(Acc :: map(), LUser :: jid:luser(), LServer :: jid:lserver(),
                       LResource :: jid:lresource(), SID :: ejabberd_sm:sid()) -> any().
 session_cleanup(Acc, _LUser, _LServer, _LResource, SID) ->
-    Acc1 = do_remove_smid(Acc, SID),
-    case mongoose_acc:get(stream_mgmt, smid, Acc1) of
-        {error, smid_not_found} -> ok;
-        {ok, SMID} -> remove_stale_smid_h(SMID)
-    end,
-    Acc.
+    do_remove_smid(Acc, SID).
 
 -spec do_remove_smid(Acc, SID) -> Acc1 when
       Acc :: mongoose_acc:t(),

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -81,10 +81,26 @@ sm() ->
       Reason :: undefined | ejabberd_sm:close_reason(),
       Acc1 :: mongoose_acc:t().
 remove_smid(Acc, SID, _JID, _Info, _Reason) ->
+    do_remove_smid(Acc, SID).
+
+-spec session_cleanup(Acc :: map(), LUser :: jid:luser(), LServer :: jid:lserver(),
+                      LResource :: jid:lresource(), SID :: ejabberd_sm:sid()) -> any().
+session_cleanup(Acc, _LUser, _LServer, _LResource, SID) ->
+    Acc1 = do_remove_smid(Acc, SID),
+    case mongoose_acc:get(stream_mgmt, smid, Acc1) of
+        {error, smid_not_found} -> ok;
+        {ok, SMID} -> remove_stale_smid_h(SMID)
+    end,
+    Acc.
+
+-spec do_remove_smid(Acc, SID) -> Acc1 when
+      Acc :: mongoose_acc:t(),
+      SID :: ejabberd_sm:sid(),
+      Acc1 :: mongoose_acc:t().
+do_remove_smid(Acc, SID) ->
     H = mongoose_acc:get(stream_mgmt, h, undefined, Acc),
     MaybeSMID = case mnesia:dirty_index_read(sm_session, SID, #sm_session.sid) of
-        [] ->
-            ok;
+        [] -> {error, smid_not_found};
         [#sm_session{smid = SMID} = SMSession] ->
             mnesia:sync_dirty(
               fun() ->
@@ -96,20 +112,9 @@ remove_smid(Acc, SID, _JID, _Info, _Reason) ->
                               mnesia:write(#stream_mgmt_stale_h{smid = SMID, h = H})
                       end
               end),
-            SMID
+            {ok, SMID}
     end,
     mongoose_acc:set(stream_mgmt, smid, MaybeSMID, Acc).
-
--spec session_cleanup(Acc :: map(), LUser :: jid:luser(), LServer :: jid:lserver(),
-                      LResource :: jid:lresource(), SID :: ejabberd_sm:sid()) -> any().
-session_cleanup(Acc, _LUser, _LServer, _LResource, SID) ->
-    Acc1 = remove_smid(Acc, SID, undefined, undefined, undefined),
-    MaybeSMID = mongoose_acc:get(stream_mgmt, smid, Acc1),
-    case MaybeSMID of
-        ok -> ok;
-        _ -> remove_stale_smid_h(MaybeSMID)
-    end,
-    Acc.
 
 %%
 %% `mongooseim.cfg' options (don't use outside of tests)

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -328,8 +328,8 @@ start_link(Host, Opts) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [Host, Opts], []).
 
 init([_Host, GCOpts]) ->
-    RepeatAfter = proplists:get_value(gc_repeat_after, GCOpts, 30000),
-    GeriatricAge = proplists:get_value(gc_geriatric, GCOpts, 60000),
+    RepeatAfter = proplists:get_value(gc_repeat_after, GCOpts, 1800),
+    GeriatricAge = proplists:get_value(gc_geriatric, GCOpts, 3600),
     State = #state{gc_repeat_after = RepeatAfter,
                    gc_geriatric = GeriatricAge},
     {ok, State, RepeatAfter}.

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -90,6 +90,7 @@ maybe_start_stale_h(Host, Opts) ->
         {false, []} ->
             ok;
         {true, GCOpts} ->
+            ?INFO_MSG("stream_mgmt_stale_h starting", []),
             mnesia:create_table(stream_mgmt_stale_h,
                                 [{ram_copies, [node()]},
                                  {attributes, record_info(fields, stream_mgmt_stale_h)}]),

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -331,10 +331,7 @@ init([_Host, GCOpts]) ->
     GeriatricAge = proplists:get_value(gc_geriatric, GCOpts, 60000),
     State = #state{gc_repeat_after = RepeatAfter,
                    gc_geriatric = GeriatricAge},
-     case RepeatAfter of
-         never -> ignore;
-         _ when is_integer(RepeatAfter) ->  {ok, State, RepeatAfter}
-     end.
+    {ok, State, RepeatAfter}.
 
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -163,25 +163,27 @@ make_smid() ->
 
 %% Getters
 -spec get_session_from_smid(SMID :: smid()) ->
-    ejabberd_sm:sid() | non_neg_integer() | smid_not_found.
+    {sid, ejabberd_sm:sid()} | {stale_h, non_neg_integer()} | {error, smid_not_found}.
 get_session_from_smid(SMID) ->
     case get_sid(SMID) of
-        {_,_} = SID -> SID;
-        smid_not_found -> get_stale_h(SMID)
+        {sid, SID} -> {sid, SID};
+        {error, smid_not_found} -> get_stale_h(SMID)
     end.
 
--spec get_sid(SMID :: smid()) -> ejabberd_sm:sid() | smid_not_found.
+-spec get_sid(SMID :: smid()) ->
+    {sid, ejabberd_sm:sid()} | {error, smid_not_found}.
 get_sid(SMID) ->
     case mnesia:dirty_read(sm_session, SMID) of
-        [#sm_session{sid = SID}] -> SID;
-        [] -> smid_not_found
+        [#sm_session{sid = SID}] -> {sid, SID};
+        [] -> {error, smid_not_found}
     end.
 
--spec get_stale_h(SMID :: smid()) -> non_neg_integer() | smid_not_found.
+-spec get_stale_h(SMID :: smid()) ->
+    {stale_h, non_neg_integer()} | {error, smid_not_found}.
 get_stale_h(SMID) ->
     case mnesia:dirty_read(stream_mgmt_stale_h, SMID) of
-        [#stream_mgmt_stale_h{h = H}] -> H;
-        [] -> smid_not_found
+        [#stream_mgmt_stale_h{h = H}] -> {stale_h, H};
+        [] -> {error, smid_not_found}
     end.
 
 %% Setters

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -202,16 +202,16 @@ register_smid(SMID, SID) ->
     end.
 
 register_stale_smid_h(SMID, H) ->
-    mnesia:sync_dirty(fun mnesia:write/1,
-                      [#stream_mgmt_stale_h{smid = SMID, h = H}]).
+    try
+        mnesia:sync_dirty(fun mnesia:write/1,
+                          [#stream_mgmt_stale_h{smid = SMID, h = H}])
+    catch exit:Reason ->
+              {error, Reason}
+    end.
+
 
 remove_stale_smid_h(SMID) ->
-    case mnesia:dirty_read(stream_mgmt_stale_h, SMID) of
-        [] ->
-            ok;
-        [#stream_mgmt_stale_h{} = StaleSMID] ->
-            mnesia:sync_dirty(fun mnesia:delete_object/1, [StaleSMID])
-    end.
+    mnesia:dirty_delete(stream_mgmt_stale_h, SMID).
 
 %%
 %% Helpers

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -1,10 +1,22 @@
 -module(mod_stream_management).
 -xep([{xep, 198}, {version, "1.6"}]).
 -behaviour(gen_mod).
+-behaviour(gen_server).
+
+-include_lib("stdlib/include/ms_transform.hrl").
 
 %% `gen_mod' callbacks
 -export([start/2,
          stop/1]).
+
+%% Internal exports
+-export([start_link/2]).
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2
+        ]).
 
 %% `ejabberd_hooks' handlers
 -export([add_sm_feature/2,
@@ -17,7 +29,12 @@
          get_ack_freq/1,
          set_ack_freq/1,
          get_resume_timeout/1,
-         set_resume_timeout/1]).
+         set_resume_timeout/1,
+         get_gc_repeat_after/1,
+         set_gc_repeat_after/1,
+         get_gc_geriatric/1,
+         set_gc_geriatric/1
+        ]).
 
 %% API for `ejabberd_c2s'
 -export([
@@ -35,14 +52,27 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
--record(sm_session, {smid, sid}).
--record(stream_mgmt_stale_h, {smid, h}).
+-record(state,
+        {gc_repeat_after :: non_neg_integer(),
+         gc_geriatric :: non_neg_integer()
+        }).
+
+-record(sm_session,
+        {smid :: smid(),
+         sid :: ejabberd_sm:sid()
+        }).
+
+-record(stream_mgmt_stale_h,
+        {smid :: smid(),
+         h :: non_neg_integer(),
+         stamp :: non_neg_integer()
+        }).
 
 %%
 %% `gen_mod' callbacks
 %%
 
-start(Host, _Opts) ->
+start(Host, Opts) ->
     ?INFO_MSG("mod_stream_management starting", []),
     ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:add(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
@@ -51,16 +81,34 @@ start(Host, _Opts) ->
                                      {attributes, record_info(fields, sm_session)}]),
     mnesia:add_table_index(sm_session, sid),
     mnesia:add_table_copy(sm_session, node(), ram_copies),
-    mnesia:create_table(stream_mgmt_stale_h,
-                        [{ram_copies, [node()]},
-                         {attributes, record_info(fields, stream_mgmt_stale_h)}]),
-    mnesia:add_table_copy(stream_mgmt_stale_h, node(), ram_copies).
+    maybe_start_stale_h(Host, Opts),
+    ok.
+
+maybe_start_stale_h(Host, Opts) ->
+    StaleOpts = gen_mod:get_opt(stale_h, Opts, {false, []}),
+    case StaleOpts of
+        {false, []} ->
+            ok;
+        {true, GCOpts} ->
+            mnesia:create_table(stream_mgmt_stale_h,
+                                [{ram_copies, [node()]},
+                                 {attributes, record_info(fields, stream_mgmt_stale_h)}]),
+            mnesia:add_table_copy(stream_mgmt_stale_h, node(), ram_copies),
+            start_cleaner(Host, GCOpts)
+    end.
 
 stop(Host) ->
     ?INFO_MSG("mod_stream_management stopping", []),
     ejabberd_hooks:delete(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:delete(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
-    ejabberd_hooks:delete(session_cleanup, Host, ?MODULE, session_cleanup, 50).
+    ejabberd_hooks:delete(session_cleanup, Host, ?MODULE, session_cleanup, 50),
+    StaleOpts = gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, {false, []}),
+    case StaleOpts of
+        {false, []} ->
+            ok;
+        {true, _GCOpts} ->
+            stop_cleaner(?MODULE)
+    end.
 
 %%
 %% `ejabberd_hooks' handlers
@@ -101,17 +149,12 @@ do_remove_smid(Acc, SID) ->
     H = mongoose_acc:get(stream_mgmt, h, undefined, Acc),
     MaybeSMID = case mnesia:dirty_index_read(sm_session, SID, #sm_session.sid) of
         [] -> {error, smid_not_found};
-        [#sm_session{smid = SMID} = SMSession] ->
-            mnesia:sync_dirty(
-              fun() ->
-                      mnesia:delete_object(SMSession),
-                      case H of
-                          undefined ->
-                              ok;
-                          _ ->
-                              mnesia:write(#stream_mgmt_stale_h{smid = SMID, h = H})
-                      end
-              end),
+        [#sm_session{smid = SMID}] ->
+            mnesia:dirty_delete(sm_session, SMID),
+            case H of
+                undefined -> ok;
+                _ -> register_stale_smid_h(SMID, H)
+            end,
             {ok, SMID}
     end,
     mongoose_acc:set(stream_mgmt, smid, MaybeSMID, Acc).
@@ -158,6 +201,50 @@ get_resume_timeout(Default) ->
 set_resume_timeout(ResumeTimeout) ->
     set_module_opt(?MYNAME, ?MODULE, resume_timeout, ResumeTimeout).
 
+
+-spec get_gc_repeat_after(pos_integer()) -> pos_integer().
+get_gc_repeat_after(Default) ->
+    S = gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, undefined),
+    case S of
+        {true, GCOpts} ->
+            proplists:get_value(gc_repeat_after, GCOpts, Default);
+        _ -> Default
+    end.
+
+-spec set_gc_repeat_after(pos_integer()) -> boolean().
+set_gc_repeat_after(ResumeTimeout) ->
+    S = gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, undefined),
+    case S of
+        {true, GCOpts} ->
+            NewGCOpts = lists:keystore(gc_repeat_after, 1, GCOpts,
+                                       {gc_repeat_after, ResumeTimeout}),
+            NewStaleOpts = {true, NewGCOpts},
+            set_module_opt(?MYNAME, ?MODULE, stale_h, NewStaleOpts);
+        _ -> false
+    end.
+
+-spec get_gc_geriatric(pos_integer()) -> pos_integer().
+get_gc_geriatric(Default) ->
+    S = gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, undefined),
+    case S of
+        {true, GCOpts} ->
+            proplists:get_value(gc_geriatric, GCOpts, Default);
+        _ -> Default
+    end.
+
+-spec set_gc_geriatric(pos_integer()) -> boolean().
+set_gc_geriatric(ResumeTimeout) ->
+    S = gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, undefined),
+    case S of
+        {true, GCOpts} ->
+            NewGCOpts = lists:keystore(gc_geriatric, 1, GCOpts,
+                                       {gc_geriatric, ResumeTimeout}),
+            NewStaleOpts = {true, NewGCOpts},
+            set_module_opt(?MYNAME, ?MODULE, stale_h, NewStaleOpts);
+        _ -> false
+    end.
+
+
 %%
 %% API for `ejabberd_c2s'
 %%
@@ -186,9 +273,13 @@ get_sid(SMID) ->
 -spec get_stale_h(SMID :: smid()) ->
     {stale_h, non_neg_integer()} | {error, smid_not_found}.
 get_stale_h(SMID) ->
-    case mnesia:dirty_read(stream_mgmt_stale_h, SMID) of
-        [#stream_mgmt_stale_h{h = H}] -> {stale_h, H};
-        [] -> {error, smid_not_found}
+    case gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, {false, []}) of
+        {false, []} -> {error, smid_not_found};
+        {true, _} ->
+            case mnesia:dirty_read(stream_mgmt_stale_h, SMID) of
+                [#stream_mgmt_stale_h{h = H}] -> {stale_h, H};
+                [] -> {error, smid_not_found}
+            end
     end.
 
 %% Setters
@@ -202,20 +293,76 @@ register_smid(SMID, SID) ->
     end.
 
 register_stale_smid_h(SMID, H) ->
-    try
-        mnesia:sync_dirty(fun mnesia:write/1,
-                          [#stream_mgmt_stale_h{smid = SMID, h = H}])
-    catch exit:Reason ->
-              {error, Reason}
+    case gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, {false, []}) of
+        {false, []} -> ok;
+        {true, _} ->
+            try
+                Stamp = now_to_seconds(erlang:timestamp()),
+                mnesia:sync_dirty(fun mnesia:write/1,
+                                  [#stream_mgmt_stale_h{
+                                      smid = SMID, h = H, stamp = Stamp}])
+            catch exit:Reason ->
+                      {error, Reason}
+            end
     end.
 
-
 remove_stale_smid_h(SMID) ->
-    mnesia:dirty_delete(stream_mgmt_stale_h, SMID).
+    case gen_mod:get_module_opt(?MYNAME, ?MODULE, stale_h, {false, []}) of
+        {false, []} -> ok;
+        {true, _} -> mnesia:dirty_delete(stream_mgmt_stale_h, SMID)
+    end.
+
+%%
+%% gen_server
+start_cleaner(Host, Opts) ->
+    ChildSpec = {?MODULE,
+                 {?MODULE, start_link, [Host, Opts]},
+                 permanent, 5000, worker, [?MODULE]},
+    ejabberd_sup:start_child(ChildSpec).
+
+stop_cleaner(Proc) ->
+    ejabberd_sup:stop_child(Proc).
+
+start_link(Host, Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [Host, Opts], []).
+
+init([_Host, GCOpts]) ->
+    RepeatAfter = proplists:get_value(gc_repeat_after, GCOpts, 30000),
+    GeriatricAge = proplists:get_value(gc_geriatric, GCOpts, 60000),
+    State = #state{gc_repeat_after = RepeatAfter,
+                   gc_geriatric = GeriatricAge},
+     case RepeatAfter of
+         never -> ignore;
+         _ when is_integer(RepeatAfter) ->  {ok, State, RepeatAfter}
+     end.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(timeout, #state{gc_repeat_after = RepeatAfter,
+                            gc_geriatric = GeriatricAge} = State) ->
+    TimeToDie = now_to_seconds(erlang:timestamp()) + GeriatricAge,
+    ets:select_delete(
+      stream_mgmt_stale_h,
+      ets:fun2ms(
+        fun(#stream_mgmt_stale_h{stamp=S}) when S < TimeToDie -> true end
+       )
+     ),
+    {noreply, State, RepeatAfter};
+handle_info(_Info, #state{gc_repeat_after = RepeatAfter,
+                          gc_geriatric = _GeriatricAge} = State) ->
+    {noreply, State, RepeatAfter}.
 
 %%
 %% Helpers
 %%
+-spec now_to_seconds(erlang:timestamp()) -> non_neg_integer().
+now_to_seconds({MegaSecs, Secs, _MicroSecs}) ->
+    MegaSecs * 1000000 + Secs.
+
 
 %% copy-n-paste from gen_mod.erl
 -record(ejabberd_module, {module_host, opts}).

--- a/src/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api_sse.erl
@@ -56,7 +56,11 @@ terminate(_Reson, _Req, State) ->
             ok;
         SID ->
             #jid{user = U, server = S, resource = R} = maps:get(jid, State),
-            ejabberd_sm:close_session(SID, U, S, R, normal)
+            Acc = mongoose_acc:new(
+                    #{location => ?LOCATION,
+                      lserver => S,
+                      element => undefined}),
+            ejabberd_sm:close_session(Acc, SID, U, S, R, normal)
     end,
     State.
 

--- a/src/stream_management/mod_stream_management_stale_h.erl
+++ b/src/stream_management/mod_stream_management_stale_h.erl
@@ -1,0 +1,136 @@
+-module(mod_stream_management_stale_h).
+-behaviour(gen_server).
+
+-include("mongoose.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-record(state,
+        {gc_repeat_after :: non_neg_integer(),
+         gc_geriatric :: non_neg_integer()
+        }).
+
+-record(stream_mgmt_stale_h,
+        {smid :: mod_stream_management:smid(),
+         h :: non_neg_integer(),
+         stamp :: non_neg_integer()
+        }).
+
+-export([read_stale_h/1,
+         write_stale_h/2,
+         delete_stale_h/1
+        ]).
+
+-export([maybe_start/2,
+         stop/0
+        ]).
+
+%% Internal exports
+-export([start_link/2]).
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2
+        ]).
+
+-spec read_stale_h(SMID :: mod_stream_management:smid()) ->
+    {stale_h, non_neg_integer()} | {error, smid_not_found}.
+read_stale_h(SMID) ->
+    try
+        case mnesia:dirty_read(stream_mgmt_stale_h, SMID) of
+            [#stream_mgmt_stale_h{h = H}] -> {stale_h, H};
+            [] -> {error, smid_not_found}
+        end
+    catch exit:_Reason ->
+              {error, smid_not_found}
+    end.
+
+-spec write_stale_h(SMID :: mod_stream_management:smid(), H :: non_neg_integer()) ->
+    ok | {error, any()}.
+write_stale_h(SMID, H) ->
+    try
+        Stamp = timestamp_to_seconds(erlang:timestamp()),
+        mnesia:dirty_write(
+          #stream_mgmt_stale_h{
+             smid = SMID, h = H, stamp = Stamp})
+    catch exit:Reason ->
+              {error, Reason}
+    end.
+
+-spec delete_stale_h(SMID :: mod_stream_management:smid()) ->
+    ok | {error, any()}.
+delete_stale_h(SMID) ->
+    try
+        mnesia:dirty_delete(stream_mgmt_stale_h, SMID)
+    catch exit:Reason ->
+              {error, Reason}
+    end.
+
+
+%%
+%% gen_server
+maybe_start(Host, Opts) ->
+    StaleOpts = gen_mod:get_opt(stale_h, Opts, {false, []}),
+    case StaleOpts of
+        {false, []} ->
+            ok;
+        {true, GCOpts} ->
+            ?INFO_MSG("stream_mgmt_stale_h starting", []),
+            mnesia:create_table(stream_mgmt_stale_h,
+                                [{ram_copies, [node()]},
+                                 {attributes, record_info(fields, stream_mgmt_stale_h)}]),
+            mnesia:add_table_copy(stream_mgmt_stale_h, node(), ram_copies),
+            start_cleaner(Host, GCOpts)
+    end.
+
+start_cleaner(Host, Opts) ->
+    ChildSpec = {?MODULE,
+                 {?MODULE, start_link, [Host, Opts]},
+                 permanent, 5000, worker, [?MODULE]},
+    ejabberd_sup:start_child(ChildSpec).
+
+stop() ->
+    ejabberd_sup:stop_child(?MODULE).
+
+
+start_link(Host, Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [Host, Opts], []).
+
+init([_Host, GCOpts]) ->
+    RepeatAfter = proplists:get_value(gc_repeat_after, GCOpts, 1800),
+    GeriatricAge = proplists:get_value(gc_geriatric, GCOpts, 3600),
+    State = #state{gc_repeat_after = RepeatAfter,
+                   gc_geriatric = GeriatricAge},
+    {ok, State, RepeatAfter}.
+
+handle_call(Msg, _From, State) ->
+    ?WARNING_MSG("unexpected message ~p", [Msg]),
+    {reply, ok, State}.
+
+handle_cast(Msg, State) ->
+    ?WARNING_MSG("unexpected message ~p", [Msg]),
+    {noreply, State}.
+
+handle_info(timeout, #state{gc_repeat_after = RepeatAfter,
+                            gc_geriatric = GeriatricAge} = State) ->
+    TimeToDie = timestamp_to_seconds(erlang:timestamp()) + GeriatricAge,
+    ets:select_delete(
+      stream_mgmt_stale_h,
+      ets:fun2ms(
+        fun(#stream_mgmt_stale_h{stamp=S}) when S < TimeToDie -> true end
+       )
+     ),
+    {noreply, State, RepeatAfter};
+handle_info(Info, #state{gc_repeat_after = RepeatAfter,
+                          gc_geriatric = _GeriatricAge} = State) ->
+    ?WARNING_MSG("unexpected message ~p", [Info]),
+    {noreply, State, RepeatAfter}.
+
+%%
+%% Helpers
+%%
+-spec timestamp_to_seconds(erlang:timestamp()) -> non_neg_integer().
+timestamp_to_seconds({MegaSecs, Secs, _MicroSecs}) ->
+    MegaSecs * 1000000 + Secs.
+
+

--- a/src/stream_management/stream_management_stale_h.erl
+++ b/src/stream_management/stream_management_stale_h.erl
@@ -89,8 +89,7 @@ start_cleaner(Opts) ->
     ejabberd_sup:start_child(ChildSpec).
 
 stop() ->
-    ejabberd_sup:stop_child(?MODULE).
-
+    ok.
 
 start_link(Opts) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [Opts], []).

--- a/src/stream_management/stream_management_stale_h.erl
+++ b/src/stream_management/stream_management_stale_h.erl
@@ -50,7 +50,7 @@ read_stale_h(SMID) ->
     ok | {error, any()}.
 write_stale_h(SMID, H) ->
     try
-        Stamp = erlang:system_time(seconds),
+        Stamp = erlang:monotonic_time(seconds),
         mnesia:dirty_write(#stream_mgmt_stale_h{smid = SMID, h = H, stamp = Stamp})
     catch exit:Reason ->
               {error, Reason}
@@ -120,6 +120,6 @@ handle_info(Info, #smgc_state{gc_repeat_after = RepeatAfter,
     {noreply, State, RepeatAfter}.
 
 clear_table(GeriatricAge) ->
-    TimeToDie = erlang:system_time(seconds) + GeriatricAge,
+    TimeToDie = erlang:monotonic_time(seconds) + GeriatricAge,
     MS = ets:fun2ms(fun(#stream_mgmt_stale_h{stamp=S}) when S < TimeToDie -> true end),
     ets:select_delete(stream_mgmt_stale_h, MS).

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -4,7 +4,7 @@
 setup() ->
     meck:new(ejabberd_sm),
     meck:expect(ejabberd_sm, close_session,
-                fun(_SID, _User, _Server, _Resource, _Reason) -> ok end),
+                fun(Acc, _SID, _User, _Server, _Resource, _Reason) -> Acc end),
     meck:expect(ejabberd_sm, open_session, fun(_, _, _, _, _) -> [] end),
 
     meck:new(ejabberd_socket),

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -327,7 +327,8 @@ set_test_case_meck(MaxUserSessions) ->
     meck:new(acl, []),
     meck:expect(acl, match_rule, fun(_, _, _) -> MaxUserSessions end),
     meck:new(ejabberd_hooks, []),
-    meck:expect(ejabberd_hooks, run, fun(_, _, _) -> ok end).
+    meck:expect(ejabberd_hooks, run, fun(_, _, _) -> ok end),
+    meck:expect(ejabberd_hooks, run_fold, fun(_, _, Acc, _) -> Acc end).
 
 set_test_case_meck_unique_count_crash(Backend) ->
     F = get_fun_for_unique_count(Backend),

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -106,13 +106,13 @@ stream_management(_Config) ->
     {U, S, R, _JID, SID} = get_fake_session(),
     SMID = <<"123">>,
     mod_stream_management:register_smid(SMID, SID),
-    SID = mod_stream_management:get_sid(SMID),
+    {sid, SID} = mod_stream_management:get_sid(SMID),
     Acc = mongoose_acc:new(
             #{location => ?LOCATION,
               lserver => S,
               element => undefined}),
     ejabberd_hooks:run_fold(session_cleanup, ?HOST, Acc, [U, S, R, SID]),
-    smid_not_found = mod_stream_management:get_sid(SMID).
+    {error, smid_not_found} = mod_stream_management:get_sid(SMID).
 
 local(_Config) ->
     ejabberd_local:start_link(),

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -1,6 +1,7 @@
 -module(mongoose_cleanup_SUITE).
 
 -include_lib("eunit/include/eunit.hrl").
+-include("mongoose.hrl").
 
 -export([all/0,
          init_per_suite/1, end_per_suite/1,
@@ -16,7 +17,6 @@
 
 -define(HOST, <<"localhost">>).
 -define(NS_CC_2, <<"urn:xmpp:carbons:2">>).
--define(LOCATION, {?MODULE, ?FUNCTION_NAME, ?LINE}).
 
 %% -----------------------------------------------------
 %% CT callbacks

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -16,6 +16,7 @@
 
 -define(HOST, <<"localhost">>).
 -define(NS_CC_2, <<"urn:xmpp:carbons:2">>).
+-define(LOCATION, {?MODULE, ?FUNCTION_NAME, ?LINE}).
 
 %% -----------------------------------------------------
 %% CT callbacks
@@ -105,9 +106,13 @@ stream_management(_Config) ->
     {U, S, R, _JID, SID} = get_fake_session(),
     SMID = <<"123">>,
     mod_stream_management:register_smid(SMID, SID),
-    [SID] = mod_stream_management:get_sid(SMID),
-    ejabberd_hooks:run(session_cleanup, ?HOST, [U, S, R, SID]),
-    [] = mod_stream_management:get_sid(SMID).
+    SID = mod_stream_management:get_sid(SMID),
+    Acc = mongoose_acc:new(
+            #{location => ?LOCATION,
+              lserver => S,
+              element => undefined}),
+    ejabberd_hooks:run_fold(session_cleanup, ?HOST, Acc, [U, S, R, SID]),
+    smid_not_found = mod_stream_management:get_sid(SMID).
 
 local(_Config) ->
     ejabberd_local:start_link(),


### PR DESCRIPTION
In the context of stream resumption, the new XEP (1.6) says as following:

In the **_POSITIVE_** case, which hasn’t changed and is in line with our implementation:
> If the server CAN resume the former stream, it MUST return a `<resumed/>` element, which MUST include a 'previd' attribute set to the SM-ID of the former stream and MUST also include an 'h' attribute set to the sequence number of the last handled stanza sent over the former stream from the client to the server (in the unlikely case that the server never received any stanzas, it would set 'h' to zero).
>Example 12. Stream resumed
```xml
<resumed xmlns='urn:xmpp:sm:3' h='some-number' previd='some-long-sm-id'/>
```

But, in the **_NEGATIVE_** case, there’s a suggested change:

> If the server DOES NOT SUPPORT session resumption, it MUST return a `<failed/>` element, which SHOULD include an error condition of `<feature-not-implemented/>`.
> If the server DOES NOT RECOGNIZE THE 'previd' as an earlier session (e.g., because the former session has timed out), it MUST return a `<failed/>` element, which SHOULD include an error condition of `<item-not-found/>`.
>If the server **_DOES RECOGNIZE_** the 'previd' as an earlier session that has **_TIMED OUT_** the server MAY also include a 'h' attribute indicating the number of stanzas received before the timeout. (Note: For this to work the server has to store the SM-ID/sequence number tuple past the time out of the actual session.)
>Example 13. Stream timed out
```xml
<failed xmlns='urn:xmpp:sm:3' h='some-number'>
    <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
</failed>
```
> In both of these failure cases, the server SHOULD allow the client to bind a resource at this point rather than forcing the client to restart the stream negotiation process and re-authenticate.

**_This all means that, when returning the failure for an unsuccessful resumption, we might as well notify of the old h value. That is effectively the only change._**

---

To implement this, now when requesting `mod_stream_management` for the SID of the previous session, given the `SMID`, `mod_stream_management` might return the found `SID` if we’re still within the timeout, just the old `h` if we passed the timeout or lost the information (the XEP asks only for a best-effort policy!), or nothing found.

Accordingly, `ejabberd_c2s` has to either proceed with the resumption if the `SID` is given, or return the error and proceed with the binding if not. This error will have the `h` attribute depending on it being given or not.

So `ejabberd_c2s` basically needs one more pattern matching, and `mod_stream_management` one more table.

---

For this functionality, I needed to pass important data around (`h` and `SMID`, but luckily — or unfortunately, but I think luckily — the functions implicated are all running through hooks, run_folds, and passing Accumulators. Hence, the logic is implemented around these, the Accs.

---

Maybe TODO: implement some `stream_mgmt_stale_h` eviction policy (TTL, garbage collection, timestamps, something like that). <- please give me some feedback!