### PR TITLE
Fix rdbms typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,7 +529,7 @@ Special thanks to our contributors: @andrewvmail @igors !
 
 ## Fixed
 
-- Fix RDMBS backoff calculation (#1394)
+- Fix RDBMS backoff calculation (#1394)
 - URL escaping and reporting in `mod_http_upload` (#1391)
 - Fixed Unicode support in the MAM full text search with a Riak backend (#1407)
 - Authentication crash with SASL PLAIN and an invalid password (#1433)

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -202,7 +202,7 @@ The table below shows the supported SASL mechanisms for each authentication back
          {http, host, auth, [], [{server, "127.0.0.1"}]}
 ```
 
-### RDMBS connection setup
+### RDBMS connection setup
 
 RDBMS connection pools are set using [outgoing connections configuration](./advanced-configuration/outgoing-connections.md).
 There are some additional options that influence all database connections in the server:

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -200,7 +200,7 @@ These are **total** times of respective operations.
 One operation usually requires only a single call to an auth backend but sometimes with e.g. 3 backends configured, the operation may fail for first 2 backends.
 In such case, these metrics will be updated with combined time of 2 failed and 1 successful request.
 
-Additionaly, RDMBS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
+Additionaly, RDBMS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
 
 * `[global, backends, mongoose_rdbms, query]` - Execution time of a "simple"" (not prepared) query by a DB driver.
 * `[global, backends, mongoose_rdbms, execute]` - Execution time of a prepared query by a DB driver.


### PR DESCRIPTION
I found typo in word "RDBMS" when reading docs, so I corrected the typo across the whole project.

