### PR TITLE
Fix inbox unread count retrieval for push notifications

### DIFF
--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -246,16 +246,19 @@ inbox_msg_reset_unread_count_fcm(Config) ->
 
 inbox_msg_unread_count(Config, Service, EnableOpts) ->
     escalus:fresh_story(
-      Config, [{bob, 1}, {alice, 1}],
-      fun(Bob, Alice) ->
+      Config, [{bob, 1}, {alice, 1}, {kate, 1}],
+      fun(Bob, Alice, Kate) ->
               DeviceToken = enable_push_for_user(Bob, Service, EnableOpts),
               send_private_message(Alice, Bob),
+              check_notification(DeviceToken, 1),
+              send_private_message(Kate, Bob),
               check_notification(DeviceToken, 1),
               send_private_message(Alice, Bob),
               check_notification(DeviceToken, 2),
               send_private_message(Alice, Bob),
-              check_notification(DeviceToken, 3)
-
+              check_notification(DeviceToken, 3),
+              send_private_message(Kate, Bob),
+              check_notification(DeviceToken, 2)
       end).
 
 inbox_msg_reset_unread_count(Config, Service, EnableOpts) ->

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -248,15 +248,29 @@ inbox_msg_unread_count(Config, Service, EnableOpts) ->
     escalus:fresh_story(
       Config, [{bob, 1}, {alice, 1}, {kate, 1}],
       fun(Bob, Alice, Kate) ->
+              % In this test Bob is the only recipient of all messages
               DeviceToken = enable_push_for_user(Bob, Service, EnableOpts),
+             
+              % We're going to interleave messages from Alice and Kate to ensure
+              % that their unread counts don't leak to each other's notifications
+
+              % We send a first message from Alice, unread counts in convs.: Alice 1, Kate 0
               send_private_message(Alice, Bob),
               check_notification(DeviceToken, 1),
+
+              % We send a first message from Kate, unread counts in convs.: Alice 1, Kate 1
               send_private_message(Kate, Bob),
               check_notification(DeviceToken, 1),
+              
+              % Now a second message from Alice, unread counts in convs.: Alice 2, Kate 1
               send_private_message(Alice, Bob),
               check_notification(DeviceToken, 2),
+              
+              % And one more from Alice, unread counts in convs.: Alice 3, Kate 1
               send_private_message(Alice, Bob),
               check_notification(DeviceToken, 3),
+
+              % Time for Kate again, unread counts in convs.: Alice 3, Kate 2
               send_private_message(Kate, Bob),
               check_notification(DeviceToken, 2)
       end).

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -73,9 +73,10 @@
                       Username :: jid:luser(),
                       Server :: jid:lserver().
 
--callback get_inbox_unread(Username, Server) -> {ok, integer()} when
+-callback get_inbox_unread(Username, Server, InterlocutorJID) -> {ok, integer()} when
                       Username :: jid:luser(),
-                      Server :: jid:lserver().
+                      Server :: jid:lserver(),
+                      InterlocutorJID :: jid:jid().
 
 -type get_inbox_params() :: #{
         start => erlang:timestamp(),
@@ -398,7 +399,8 @@ get_inbox_unread(Value, Acc, _) when is_integer(Value) ->
 get_inbox_unread(undefined, Acc, To) ->
 %% TODO this value should be bound to a stanza reference inside Acc
     {User, Host} = jid:to_lus(To),
-    {ok, Count} = mod_inbox_utils:get_inbox_unread(User, Host),
+    InterlocutorJID = mongoose_acc:from_jid(Acc),
+    {ok, Count} = mod_inbox_utils:get_inbox_unread(User, Host, InterlocutorJID),
     mongoose_acc:set(inbox, unread_count, Count, Acc).
 
 hooks(Host) ->

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -23,7 +23,7 @@
          remove_inbox/3,
          clear_inbox/1,
          clear_inbox/2,
-         get_inbox_unread/2]).
+         get_inbox_unread/3]).
 
 %% For specific backends
 -export([esc_string/1, esc_int/1]).
@@ -69,10 +69,13 @@ get_inbox_rdbms(LUser, LServer, #{ order := Order } = Params) ->
     mongoose_rdbms:sql_query(LServer, Query).
 
 
-get_inbox_unread(Username, Server) ->
+get_inbox_unread(Username, Server, InterlocutorJID) ->
+    RemBareJIDBin = jid:to_binary(jid:to_lus(InterlocutorJID)),
     Res = mongoose_rdbms:sql_query(Server,
                                    ["select unread_count from inbox "
                                     "WHERE luser=", esc_string(Username),
+                                      "AND lserver=", esc_string(Server),
+                                      "AND remote_bare_jid=", esc_string(RemBareJIDBin),
                                     ";"]),
     {ok, Val} = check_result(Res),
     %% We read unread_count value when the message is sent and is not yet in receiver inbox

--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -31,7 +31,7 @@
          get_option_write_aff_changes/1,
          get_option_remove_on_kicked/1,
          reset_marker_to_bin/1,
-         get_inbox_unread/2
+         get_inbox_unread/3
         ]).
 
 -spec maybe_reset_unread_count(Server :: host(),
@@ -186,8 +186,8 @@ reset_marker_to_bin(acknowledged) -> <<"acknowledged">>;
 reset_marker_to_bin(received) -> <<"received">>;
 reset_marker_to_bin(Unknown) -> throw({unknown_marker, Unknown}).
 
-get_inbox_unread(User, Server) ->
-    mod_inbox_backend:get_inbox_unread(User, Server).
+get_inbox_unread(User, Server, InterlocutorJID) ->
+    mod_inbox_backend:get_inbox_unread(User, Server, InterlocutorJID).
 
 all_chat_markers() ->
     [<<"received">>, <<"displayed">>, <<"acknowledged">>].


### PR DESCRIPTION
This PR fixes the unread count retrieval in a conversation for the push notifications logic.

The root cause was insufficient filtering in the SQL query.

TBH now I see that we really lack proper docs with examples for this feature. And also I think that it would be more useful to return total unread count for all conversations, as this is what is usually displayed on the app badge.
However, the PgSQL-specific logic implies that the code is supposed to return unread count for the conversation, not the sum for all of them, so this is the approach taken in this PR.