### PR TITLE
Disabled stream mgmt crashes

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -1106,7 +1106,7 @@ no_crash_if_stream_mgmt_disabled_but_client_requests_stream_mgmt(Config) ->
     escalus_connection:send(Alice, escalus_stanza:enable_sm()),
     % escalus_connection:send(Alice, escalus_stanza:enable_sm([resume])),
     Response = escalus_connection:get_stanza(Alice, service_unavailable),
-    escalus_assert:is_error(Response, <<"cancel">>, <<"service-unavailable">>),
+    escalus:assert(is_sm_failed, [<<"feature-not-implemented">>], Response),
     escalus_connection:stop(Alice).
 
 no_crash_if_stream_mgmt_disabled_but_client_requests_stream_mgmt_with_resumption(Config) ->
@@ -1116,7 +1116,7 @@ no_crash_if_stream_mgmt_disabled_but_client_requests_stream_mgmt_with_resumption
     %% Should not crash anything!
     escalus_connection:send(Alice, escalus_stanza:enable_sm([resume])),
     Response = escalus_connection:get_stanza(Alice, service_unavailable),
-    escalus_assert:is_error(Response, <<"cancel">>, <<"service-unavailable">>),
+    escalus:assert(is_sm_failed, [<<"feature-not-implemented">>], Response),
     escalus_connection:stop(Alice).
 
 %%--------------------------------------------------------------------

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2772,7 +2772,7 @@ maybe_enable_stream_mgmt(NextState, El, StateData) ->
             send_trailer(StateData),
             {stop, normal, StateData};
         {?NS_STREAM_MGNT_3, disabled, _} ->
-            send_element_from_server_jid(StateData, jlib:make_error_reply(El, mongoose_xmpp_errors:service_unavailable())),
+            send_element_from_server_jid(StateData, stream_mgmt_failed(<<"feature-not-implemented">>)),
             send_trailer(StateData),
             {stop, normal, StateData};
         {_, _, _} ->

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -49,7 +49,10 @@ setup() ->
     meck:expect(mongoose_bin, gen_from_crypto, fun() -> <<"57">> end),
 
     meck:new(mongoose_metrics),
-    meck:expect(mongoose_metrics, update, fun (_, _, _) -> ok end).
+    meck:expect(mongoose_metrics, update, fun (_, _, _) -> ok end),
+
+    meck:new(gen_mod),
+    meck:expect(gen_mod, is_loaded, fun (_, _) -> true end).
 
 
 teardown() ->


### PR DESCRIPTION
If `mod_stream_management` is disabled, the session shouldn't crash if it requests so. Rather, the server should simply respond with a`service-unavailable` and continue.

Currently, as the code for stream management is mostly hardcoded in ejabberd_c2s, if the client sends the `<<"enable">>` stanza, the server goes nuts:
https://github.com/esl/MongooseIM/blob/1fa0898d6901549e5df5a646dcbd95a7c05b9e7d/src/ejabberd_c2s.erl#L2737-L2749

If the user requests stream management without resumption, the server answers with a nonsensical `<<"enabled">>` and continues as if nothing happened, until it crashes, and if the client requests so but _with_ resumption, then his c2s process fails fast.

TODO:
- [x] FIX IT! This is only a regression test for now 😛 