### PR TITLE
Run builds on CircleCi when adding tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ orbs:
 
 filters: &all_tags
   tags:
-    only: /.*/
+    only: /^\d+\.\d+\.\d+([a-z0-9\-\+])*/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,10 @@ orbs:
               name: Execute Docker image build and upload
               command: tools/circle-build-and-push-docker.sh
 
+filters: &all_tags
+  tags:
+    only: /.*/
+
 workflows:
   version: 2
   build_and_test:
@@ -293,24 +297,29 @@ workflows:
           name: centos7
           platform: centos7
           context: mongooseim-org
+          filters: *all_tags
       - mim/package:
           name: debian_stretch
           platform: debian_stretch
           context: mongooseim-org
+          filters: *all_tags
       # ============= BASE BUILDS =============
       - mim/build:
           name: otp_20_3
           otp_package: 1:20.3.8.22-1
           context: mongooseim-org
+          filters: *all_tags
       - mim/build:
           name: otp_21_3
           otp_package: 1:21.3.8.6-1
           context: mongooseim-org
+          filters: *all_tags
       - mim/build:
           name: otp_22
           otp_package: 1:22.0.7-1
           build_prod: true
           context: mongooseim-org
+          filters: *all_tags
       # ============= SMALL TESTS =============
       - mim/small_tests:
           name: small_tests_20_3
@@ -318,23 +327,27 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_20_3
+          filters: *all_tags
       - mim/small_tests:
           name: small_tests_21_3
           otp_package: 1:21.3.8.6-1
           context: mongooseim-org
           requires:
             - otp_21_3
+          filters: *all_tags
       - mim/small_tests:
           name: small_tests_22
           otp_package: 1:22.0.7-1
           context: mongooseim-org
           requires:
             - otp_22
+          filters: *all_tags
       # ============= DIALYZER =============
       - mim/dialyzer:
           name: dialyzer
           otp_package: 1:22.0.7-1
           context: mongooseim-org
+          filters: *all_tags
       # ============= MOST RECENT VERSION TESTS =============
       - mim/big_tests:
           name: mysql_redis
@@ -344,6 +357,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_22
+          filters: *all_tags
       - mim/big_tests:
           name: mssql_mnesia
           otp_package: 1:22.0.7-1
@@ -352,6 +366,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_22
+          filters: *all_tags
       - mim/big_tests:
           name: internal_mnesia
           otp_package: 1:22.0.7-1
@@ -361,6 +376,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_22
+          filters: *all_tags
       - mim/big_tests:
           name: elasticsearch_and_cassandra
           otp_package: 1:22.0.7-1
@@ -369,6 +385,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_22
+          filters: *all_tags
       - mim/big_tests:
           name: riak_mnesia
           otp_package: 1:22.0.7-1
@@ -377,6 +394,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_22
+          filters: *all_tags
       # ============= 1 VERSION OLDER TESTS =============
       - mim/big_tests:
           name: pgsql_mnesia
@@ -386,6 +404,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_21_3
+          filters: *all_tags
       # ============= 2 VERSIONS OLDER TESTS =============
       - mim/big_tests:
           name: ldap_mnesia
@@ -395,6 +414,7 @@ workflows:
           context: mongooseim-org
           requires:
             - otp_20_3
+          filters: *all_tags
       # ============= DOCKER IMAGE BUILD & UPLOAD =============
       - mim/docker_image:
           name: docker_build_and_ship
@@ -412,4 +432,4 @@ workflows:
             - small_tests_22
             - small_tests_21_3
             - small_tests_20_3
-
+          filters: *all_tags

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -8,10 +8,10 @@ tar czh --transform="s,${BUILD_PATH},mongooseim,S" -f $MONGOOSE_TGZ ${BUILD_PATH
 
 export BUILDS=`pwd`
 
-# We use commit hash by default, because branch name may contain characters
-# that are illegal for Docker tags, e.g. '/'.
-DOCKERHUB_TAG=${CIRCLE_SHA1}
+# We use output of generate_vsn, because it does not contain illegal characters, returns
+# git tag when building from tag itself, and is unique in any other case
 VERSION=`tools/generate_vsn.sh`
+DOCKERHUB_TAG=${VERSION}
 GIT_REF=`git rev-parse --short HEAD`
 GIT_COMMIT_MSG=`git log --format=%B -n 1 HEAD`
 


### PR DESCRIPTION
Adding tags to MIM did not trigger builds on CircleCI, which gave unwanted results such as no Docker image for 3.5.0 on dockerhub.
I added filters which should not affect normal builds, but also run all jobs when CircleCI sees that a new tag was added.
Maybe there is a more elegant way to do it, this copy-paste approach is a quick fix, perhaps someone more experienced with yml/CircleCI can take a look. I hope proposed changes really don't brake our CI, as I tested on a fork of MIM.

Some links with additional information:
[CircleCI docs](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag)
[Similar problem](https://discuss.circleci.com/t/can-you-filter-on-a-workflow-level/30624/5)


