### PR TITLE
Curate ct_helper:repeat_all_until_all_ok

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -325,6 +325,7 @@
 ]}.
 
 {timetrap,{seconds,30}}.
+{sensible_maximum_repeats, 100}.
 
 %% Log drop stanza in parallel stories in mam_SUITE.
 %% Helps with debugging mam test cases.


### PR DESCRIPTION
This function was first of all overwriting any other repeat type given
to common test, so when doing for example, CI stabilization, if I wanted
to do a `{repeat_until_any_fail,10000}` just so to see it never failing, I
always had to remove the call to repeat_all_until_all_ok, which was
redundant, and confusing when staging only the selected changes.

This PR pretty much doesn't change the interface of common_tests, but it
curates this misbehaviour. It also prevents us from not giving a limit
to the repeats (like giving `repeat_until_all_ok` instead of
`{repeat_until_all_ok,100}`), which would then run foreveeeer. This
limit is configured in test.config.