### PR TITLE
tools: generate_vsn: remove bashism and use POSIX /bin/sh

### DIFF
--- a/tools/generate_vsn.sh
+++ b/tools/generate_vsn.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#!/bin/sh
+DIR="$( cd "$( dirname "$0" )" && pwd )"
 GIT_VSN=`git describe --always --tags 2>/dev/null`
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
This PR addresses #1988

Proposed changes include:
* removal of dependency on `/bin/bash` for generating the version number, use POSIX `/bin/sh`
