### PR TITLE
[skip ci] Make sure it stays in one line

### DIFF
--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -153,12 +153,7 @@ Metrics specific to an extension, e.g. Message Archive Management, are described
 | `[global, nodeUpTime]` | value | Node uptime. |
 | `[global, clusterSize]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node. |
 | `[global, tcpPortsUsed]` | value | A number of open tcp connections. This should relate to the number of connected sessions and databases, as well as federations and http requests, in order to detect connection leaks. |
-| `[global, processQueueLengths]` | probe | The number of queued messages in the
-internal message queue of every erlang process, and the internal queue of every
-fsm (ejabberd\_c2s). This is sampled every 30 seconds asynchronously. It is a
-good indicator of an overloaded system: if too many messages are queued at the
-same time, the system is not able to process the data at the rate it was
-designed for. |
+| `[global, processQueueLengths]` | probe | The number of queued messages in the internal message queue of every erlang process, and the internal queue of every fsm (ejabberd\_c2s). This is sampled every 30 seconds asynchronously. It is a good indicator of an overloaded system: if too many messages are queued at the same time, the system is not able to process the data at the rate it was designed for. |
 
 ### Data metrics
 


### PR DESCRIPTION
I broke that markdown table when I put line separators 😛 
Bad markdown, bad. That's not consistent with your philosophy of considering _two_ new lines as a line separator. Evil markdown.

<img width="928" alt="Screenshot 2019-10-14 at 11 43 04" src="https://user-images.githubusercontent.com/27267603/66742405-da26b700-ee77-11e9-8c6d-2e4c423c48cc.png">
