### PR TITLE
Better error reporting for tools/travis-upload-to-gdrive.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ cache:
                 - $HOME/.cache/mim_builds
                 - $HOME/.cache/mim_tests
                 - $HOME/.cache/mim_certs
+                - /tmp/go/bin
 
 
 # deploy:

--- a/tools/travis-upload-to-gdrive.sh
+++ b/tools/travis-upload-to-gdrive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script uploads small- and big-test results to Google Drive. It uses
 # Google service account credentials serialized (base64) into
 # GDRIVE_SERVICE_ACCOUNT_CREDENTIALS environment variable. The script creates a
@@ -6,33 +6,61 @@
 # id of a directory; 'root' by default). The actual results are stored in a
 # tar.gz archive.
 
+
+# Debug failing commands
+error_handling()
+{
 set -euo pipefail
+}
+error_handling
 
 source tools/travis-helpers.sh
 
-echo "Uploading test results to google drive"
-export GOPATH="/tmp/go"
-go get github.com/prasmussen/gdrive
+# gdrive 2.1.0 would return "No valid arguments given" error.
+# we need to compile from source.
+# https://github.com/gdrive-org/gdrive/issues/242
+install_gdrive() {
+    echo "Uploading test results to google drive"
+    export GOPATH="/tmp/go"
+    go get github.com/prasmussen/gdrive
+}
+
+# Calls gdrive executable with set credentials
+export PATH="/tmp/go/bin:$PATH"
+
+if ! hash gdrive; then
+    install_gdrive
+fi
+MIM_GDRIVE_OPTS=""
+
+gdrive() {
+    local EXIT_CODE=0
+    set +e
+    command gdrive --config /tmp --service-account serviceAccountCredentials "$@"
+    local EXIT_CODE=$?
+    set -e
+    if [ $EXIT_CODE != 0 ]; then
+        >&2 echo FAILED command args: "$@"
+        exit $EXIT_CODE
+    fi
+}
 
 echo "${GDRIVE_SERVICE_ACCOUNT_CREDENTIALS}" | \
     base64 --decode > /tmp/serviceAccountCredentials
 
-# Calls gdrive executable with set credentials
-gdrive() {
-    /tmp/go/bin/gdrive --config /tmp \
-                       --service-account serviceAccountCredentials "$@"
-}
-
 # Gets ID of a file located under a specific parent.
 gdrive_get_id() {
+    error_handling
     local PARENT_ID="$1"
     local NAME="$2"
+    >&2 echo "gdrive_get_id PARENT_ID=$PARENT_ID"
     gdrive list --query "'${PARENT_ID}' in parents and name = '${NAME}'" | \
         tail -n+2 | head -n1 | awk '{print $1}'
 }
 
 # Creates a new directory under a specific parent.
 gdrive_mkdir() {
+    error_handling
     local PARENT_ID="$1"
     local NAME="$2"
     gdrive mkdir --parent "${PARENT_ID}" "${NAME}" | awk '{print $2}'
@@ -42,6 +70,8 @@ gdrive_mkdir() {
 # it is reused. This is needed because in Google Drive, a directory may have
 # multiple children with the same name.
 gdrive_mkdir_p() {
+
+    error_handling
     local PARENT="$1"
 
     local OLD_IFS="$IFS"
@@ -64,8 +94,18 @@ CT_REPORT_ARCHIVE="/tmp/$(basename ${CT_REPORTS_PATH}).tar.gz"
 ROOT_DIR="${GDRIVE_PARENT_DIR:-root}"
 PARENT_DIR="$(gdrive_mkdir_p ${ROOT_DIR} $(dirname ${CT_REPORTS_PATH}))"
 
+CT_REPORTS_DIR="$(dirname ${CT_REPORTS_PATH})"
+
+echo "CT_REPORTS_PATH=$CT_REPORTS_PATH"
+test -d "$CT_REPORTS_DIR" || { echo "CT_REPORTS_DIR=$CT_REPORTS_DIR is not a directory"; exit 1; }
+
 tar -czf "${CT_REPORT_ARCHIVE}" \
-    -C "$(dirname ${CT_REPORTS_PATH})" \
+    -C "$CT_REPORTS_DIR" \
     "$(basename ${CT_REPORTS_PATH})"
 
 gdrive upload --no-progress --parent "${PARENT_DIR}" "${CT_REPORT_ARCHIVE}"
+FILE_ID=$(gdrive_get_id "${PARENT_DIR}" "$(basename ${CT_REPORT_ARCHIVE})")
+echo "Uploaded with FILE_ID=$FILE_ID"
+gdrive share "$FILE_ID"
+gdrive info "$FILE_ID"
+


### PR DESCRIPTION
This PR addresses "I've finally started uploading test results to gdrive in my fork!".

Proposed changes include:
* Better error reporting for tools/travis-upload-to-gdrive.sh
* Print information about uploaded file
* Cache gdrive uploader

Prints:

```erlang
then tools/travis-upload-to-gdrive.sh; fi

tools/travis-upload-to-gdrive.sh: line 31: hash: gdrive: not found

Uploading test results to google drive

gdrive_get_id PARENT_ID=root

gdrive_get_id PARENT_ID=1h8uOvEBq0k75bdlZ2KB4-RMqu0le0HPs

gdrive_get_id PARENT_ID=1l8qkKsPsg24TOAdQEiwAAyDA0Vrb6OkY

CT_REPORTS_PATH=PR/67/729/internal_mnesia.22.0

Uploading /tmp/internal_mnesia.22.0.tar.gz

Uploaded 1xD_bjDzbZhUIhJCKW5Kh3BPmDIgs7Bnp at 221.1 KB/s, total 2.5 MB

gdrive_get_id PARENT_ID=1QWhQpVAqL_HjLRzkqCbrwGbhEz31r3qW

Uploaded with FILE_ID=1xD_bjDzbZhUIhJCKW5Kh3BPmDIgs7Bnp

Granted reader permission to anyone

Id: 1xD_bjDzbZhUIhJCKW5Kh3BPmDIgs7Bnp

Name: internal_mnesia.22.0.tar.gz

Path: PR/67/729/internal_mnesia.22.0.tar.gz

Mime: application/gzip

Size: 2.5 MB

Created: 2019-10-16 12:59:05

Modified: 2019-10-16 12:59:06

Md5sum: 24c9b448d2613e0e01750b3927850dd7

Shared: True

Parents: 1QWhQpVAqL_HjLRzkqCbrwGbhEz31r3qW

ViewUrl: https://drive.google.com/file/d/1xD_bjDzbZhUIhJCKW5Kh3BPmDIgs7Bnp/view?usp=drivesdk

DownloadUrl: https://drive.google.com/uc?id=1xD_bjDzbZhUIhJCKW5Kh3BPmDIgs7Bnp&export=download
```

Example: https://travis-ci.org/arcusfelis/MongooseIM/jobs/598614644