### PR TITLE
Remove otp 20 from MIM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,11 +305,6 @@ workflows:
           filters: *all_tags
       # ============= BASE BUILDS =============
       - mim/build:
-          name: otp_20_3
-          otp_package: 1:20.3.8.22-1
-          context: mongooseim-org
-          filters: *all_tags
-      - mim/build:
           name: otp_21_3
           otp_package: 1:21.3.8.6-1
           context: mongooseim-org
@@ -321,13 +316,6 @@ workflows:
           context: mongooseim-org
           filters: *all_tags
       # ============= SMALL TESTS =============
-      - mim/small_tests:
-          name: small_tests_20_3
-          otp_package: 1:20.3.8.22-1
-          context: mongooseim-org
-          requires:
-            - otp_20_3
-          filters: *all_tags
       - mim/small_tests:
           name: small_tests_21_3
           otp_package: 1:21.3.8.6-1
@@ -395,25 +383,24 @@ workflows:
           requires:
             - otp_22
           filters: *all_tags
-      # ============= 1 VERSION OLDER TESTS =============
       - mim/big_tests:
           name: pgsql_mnesia
-          otp_package: 1:21.3.8.6-1
+          otp_package: 1:22.0.7-1
           preset: pgsql_mnesia
           db: pgsql
           context: mongooseim-org
           requires:
-            - otp_21_3
+            - otp_22
           filters: *all_tags
-      # ============= 2 VERSIONS OLDER TESTS =============
+      # ============= 1 VERSION OLDER TESTS =============
       - mim/big_tests:
           name: ldap_mnesia
-          otp_package: 1:20.3.8.22-1
+          otp_package: 1:21.3.8.6-1
           preset: ldap_mnesia
           db: mnesia
           context: mongooseim-org
           requires:
-            - otp_20_3
+            - otp_21_3
           filters: *all_tags
       # ============= DOCKER IMAGE BUILD & UPLOAD =============
       - mim/docker_image:
@@ -431,5 +418,4 @@ workflows:
             - dialyzer
             - small_tests_22
             - small_tests_21_3
-            - small_tests_20_3
           filters: *all_tags

--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]}]}.
 
-{require_otp_vsn, "20|21|22"}.
+{require_min_otp_vsn, "21"}.
 
 {src_dirs, ["src", "tests"]}.
 

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -73,8 +73,6 @@ User Data:
 
 **Setup**
 
-**Warning: MongooseIM cannot connect to [MySQL over TLS with OTP 20.3](../operation-and-maintenance/known-issues.md).**
-
 The schema files can be found in the `priv` directory.
 The default schema is defined in the `mysql.sql` file.
 

--- a/doc/advanced-configuration/outgoing-connections.md
+++ b/doc/advanced-configuration/outgoing-connections.md
@@ -116,8 +116,6 @@ SSL configuration options for MySQL:
     * **Syntax:** `[Opt]`
     * **Supported values:** The options are just a **list** of Erlang `ssl:ssl_option()`. More details can be found in [official Erlang ssl documentation](http://erlang.org/doc/man/ssl.html).
 
-**Warning: MongooseIM cannot connect to [MySQL over TLS with OTP 20.3](../operation-and-maintenance/known-issues.md).**
-
 ###### Example configuration
 
 An example configuration can look as follows:

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -4,7 +4,6 @@ The test runner script is used to compile MongooseIM and run tests.
 
 ## IMPORTANT!
 
-* Some examples in this guide use the MySQL database. Please keep in mind that MongooseIM cannot connect to [MySQL via TLS on OTP 20.3](../operation-and-maintenance/known-issues.md).
 * ODBC preset can only be tested [on Ubuntu Xenial x64](../operation-and-maintenance/known-issues.md).
 * SELinux may prevent containers from accessing the disk. Please either disable it or add proper rules to the policy.
 

--- a/doc/operation-and-maintenance/known-issues.md
+++ b/doc/operation-and-maintenance/known-issues.md
@@ -1,10 +1,6 @@
 This document provides a list of all known issues with MongooseIM operation and configuration.
 You may also find proposed workarounds if any is available.
 
-## MySQL + TLS + OTP 20.3
-
-MongooseIM will not connect to MySQL over TLS on OTP 20.3 due to [the MySQL driver bug](https://github.com/mysql-otp/mysql-otp/issues/85).
-
 ### Proposed workarounds
 
 * Upgrade OTP to 21.2 or higher.

--- a/doc/user-guide/How-to-build.md
+++ b/doc/user-guide/How-to-build.md
@@ -21,7 +21,7 @@ To compile MongooseIM you need:
     * CentOS: `gcc`, `gcc-c++`
     * Ubuntu: `gcc`, `g++`
     * Mac: Xcode Command Line Tools
-*   Erlang/OTP 21.2 or higher; Versions 20.0-21.1 work as well but they are deprecated. The next MIM release won't support them.
+*   Erlang/OTP 21.2 or higher;
     * CentOS: `erlang` 
     * Ubuntu: `erlang`
     * Mac (Homebrew): `erlang`

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,6 @@
   {".*", "priv/lib/mongoose_mam_id.so", ["c_src/mongoose_mam_id.cpp"], [{env, [{"CXXFLAGS", "$CXXFLAGS -std=c++11"}]}]}
  ]}.
 
-%% We use syntax introduced in Erlang/OTP 21
 {require_min_otp_vsn, "21"}.
 
 %% We agreed to use https:// for deps because of possible firewall issues.

--- a/rebar.config
+++ b/rebar.config
@@ -22,8 +22,8 @@
   {".*", "priv/lib/mongoose_mam_id.so", ["c_src/mongoose_mam_id.cpp"], [{env, [{"CXXFLAGS", "$CXXFLAGS -std=c++11"}]}]}
  ]}.
 
-%% We use functions introduced in Erlang/OTP 19
-{require_min_otp_vsn, "20"}.
+%% We use syntax introduced in Erlang/OTP 21
+{require_min_otp_vsn, "21"}.
 
 %% We agreed to use https:// for deps because of possible firewall issues.
 %% By default, deps are downloaded without using git by rebar_faster_deps.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -46,7 +46,6 @@ start(normal, _Args) ->
     db_init(),
     application:start(cache_tab),
 
-    warning_if_pre_21_2_otp(),
     translate:start(),
     acl:start(),
     ejabberd_node_id:start(),
@@ -250,14 +249,3 @@ maybe_disable_default_logger() ->
         _E:_R ->
             ok
     end.
-
-warning_if_pre_21_2_otp() ->
-    OTPVsn = erlang:system_info(version),
-    case lists:map(fun erlang:list_to_integer/1, string:split(OTPVsn, ".", all)) < [10, 2] of
-        true ->
-            ?WARNING_MSG("MongooseIM is running on a deprecated OTP version."
-                         " The next release will require at least OTP 21.2.", []);
-        false ->
-            ok
-    end.
-

--- a/test/ejabberd_loglevel_SUITE.erl
+++ b/test/ejabberd_loglevel_SUITE.erl
@@ -18,19 +18,8 @@ all() ->
     ].
 
 init_per_suite(Config) ->
-    OTPRelease = list_to_integer(erlang:system_info(otp_release)),
-    case OTPRelease > 20 of
-        true ->
-            %% This is a workaround for Erlang 21 where by default
-            %% progress reports are not visible so the log file is filled with new
-            %% content after lager backend is started.
-            %% We need this in tests in order to reliably wait for the backend start
-            %% TODO remove the case when we stop supporting Erlang 20
-            LoggerConfig = logger:get_primary_config(),
-            logger:set_primary_config(LoggerConfig#{level := info});
-        _ ->
-            ok
-    end,
+    LoggerConfig = logger:get_primary_config(),
+    logger:set_primary_config(LoggerConfig#{level := info}),
     Config.
 
 end_per_suite(Config) ->


### PR DESCRIPTION
This PR removes support for OTP 20.* and older from CircleCI and older OTPs deprecation message.