### PR TITLE
Actually cache gdrive script on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ install:
         - test 1 = "$SKIP_COMPILE" || ./tools/cache-build.sh store
         - test 1 = "$SKIP_BUILD_TESTS" || ./tools/cache-tests.sh store
         - test 1 = "$SKIP_COMPILE" || ./tools/cache-certs.sh store
+        - test 1 = "$SKIP_REPORT_UPLOAD" ||
+            if [ -n "${GDRIVE_SERVICE_ACCOUNT_CREDENTIALS}" ]; then JUST_INSTALL=1 tools/travis-upload-to-gdrive.sh; fi
 before_script:
         - tools/travis-setup-db.sh
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi

--- a/tools/travis-upload-to-gdrive.sh
+++ b/tools/travis-upload-to-gdrive.sh
@@ -20,7 +20,7 @@ source tools/travis-helpers.sh
 # we need to compile from source.
 # https://github.com/gdrive-org/gdrive/issues/242
 install_gdrive() {
-    echo "Uploading test results to google drive"
+    echo "Installing gdrive..."
     export GOPATH="/tmp/go"
     go get github.com/prasmussen/gdrive
 }
@@ -31,6 +31,15 @@ export PATH="/tmp/go/bin:$PATH"
 if ! hash gdrive; then
     install_gdrive
 fi
+
+JUST_INSTALL="${JUST_INSTALL:-0}"
+if test 1 = "$JUST_INSTALL"; then
+    echo "Exit after installing..."
+    exit 0
+fi
+
+echo "Uploading test results to google drive"
+
 MIM_GDRIVE_OPTS=""
 
 gdrive() {


### PR DESCRIPTION
This PR hot-fixes https://github.com/esl/MongooseIM/pull/2492

Proposed changes include:
* Caching is done before tools/travis-upload-to-gdrive.sh is triggered
* We need to call install_gdrive inside 'install' block
* Cache is working in action here https://travis-ci.org/arcusfelis/MongooseIM/jobs/599611167 - 10 seconds difference
