### PR TITLE
Workaround transport delivery problems

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -378,10 +378,12 @@ h_non_given_closes_stream_gracefully(ConfigIn) ->
     Config = escalus_users:update_userspec(ConfigIn, alice,
                                            stream_management, true),
     escalus:fresh_story(Config, [{alice,1}], fun(Alice) ->
+        C2SPid = mongoose_helper:get_session_pid(Alice, mim()),
         escalus:send(Alice, AStanza),
         escalus:assert(is_stream_error,
                        [<<"policy-violation">>, <<>>],
                        escalus:wait_for_stanza(Alice)),
+        mongoose_helper:wait_for_pid_to_die(C2SPid),
         escalus:assert(is_stream_end, escalus_connection:get_stanza(Alice, stream_end)),
         true = escalus_connection:wait_for_close(Alice,timer:seconds(5))
     end).

--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -290,7 +290,7 @@ terminate(_Reason, #state{parser = Parser,
         undefined -> ok;
         _ -> gen_fsm_compat:send_event(C2SPid, closed)
     end,
-    catch workaround_transport_delivery_problems(State#state.socket, State#state.sock_mod),
+    catch shutdown_socket_and_wait_for_peer_to_close(State#state.socket, State#state.sock_mod),
     ok.
 
 %%--------------------------------------------------------------------
@@ -446,12 +446,17 @@ hibernate() ->
 maybe_hibernate(#state{hibernate_after = 0}) -> hibernate();
 maybe_hibernate(#state{hibernate_after = HA}) -> HA.
 
-%% It's workaround taken from ssl application
-workaround_transport_delivery_problems(Socket, gen_tcp) ->
+%% gen_tcp:close/2, but trying to ensure that all data is received by peer.
+%%
+%% This is based on tls_connection:workaround_transport_delivery_problems/2 code
+%% https://github.com/erlang/otp/blob/OTP_17.0-rc2/lib/ssl/src/tls_connection.erl#L959
+%%
+%% There are some more docs why we need it in http://erlang.org/doc/man/gen_tcp.html#close-1
+shutdown_socket_and_wait_for_peer_to_close(Socket, gen_tcp) ->
     %% Standard trick to try to make sure all
     %% data sent to the tcp port is really delivered to the
     %% peer application before tcp port is closed so that the peer will
-    %% get the correct TLS alert message and not only a transport close.
+    %% get the correct stream end and not only a transport close.
     inet:setopts(Socket, [{active, false}]),
     gen_tcp:shutdown(Socket, write),
     %% Will return when other side has closed or after 30 s
@@ -459,5 +464,5 @@ workaround_transport_delivery_problems(Socket, gen_tcp) ->
     %% with the network but we want to maximise the odds that
     %% peer application gets all data sent on the tcp connection.
     gen_tcp:recv(Socket, 0, 30000);
-workaround_transport_delivery_problems(Socket, SockMod) ->
+shutdown_socket_and_wait_for_peer_to_close(Socket, SockMod) ->
     SockMod:close(Socket).


### PR DESCRIPTION
Sometimes we get timeout when waiting for stream_end.

For example:

```erlang
----------------------------------------------------

2019-10-16 10:13:34.899

{h_non_given_closes_stream_gracefully,parallel}

{thrown,{timeout,stream_end}}

Testing big_tests.tests.sm_SUITE: *** FAILED test case 15 ***
```

https://travis-ci.org/arcusfelis/MongooseIM/jobs/598572297

This test can fail, because we just hit the stream end timeout of 5 seconds or that we close socket on server side without waiting for all data received. I've failed to reproduce the last condition on my Mac though. Though there are some stackoverlow ideas:
- https://stackoverflow.com/questions/36533028/how-to-send-a-message-before-closing-tcp-connection-posix
- Or OTP docs:


>       close(Socket) -> ok
             Types:
                Socket = socket()
             Closes a TCP socket.
             Note  that in most implementations of TCP, doing a close 
             does not guarantee that any data sent is delivered to the 
             recipient before the close is detected at the remote
             side. If you want to guarantee delivery of the data to the recipient 
             there are two common ways to achieve this.
               * Use gen_tcp:shutdown(Sock, write) to signal that no more data is 
                  to be sent and wait for the read side of the socket to be closed.
               * Use the socket option {packet, N} (or something similar) to make it 
                  possible for the receiver to close the connection when it knowns it 
                  has received all the  data.

Proposed changes include:
* The cute function from old Erlang/OTP ssl, that does the best we can to flush `stream-end` https://github.com/erlang/otp/blob/OTP_17.0-rc2/lib/ssl/src/tls_connection.erl#L959
