### PR TITLE
Improve global distribution logs and tests

### DIFF
--- a/big_tests/src/mim_loglevel.erl
+++ b/big_tests/src/mim_loglevel.erl
@@ -1,0 +1,17 @@
+-module(mim_loglevel).
+-export([enable_logging/2]).
+-export([disable_logging/2]).
+
+enable_logging(Hosts, Levels) ->
+    [set_custom(Host, Module, Level) || Host <- Hosts, {Module, Level} <- Levels].
+
+disable_logging(Hosts, Levels) ->
+    [clear_custom(Host, Module, Level) || Host <- Hosts, {Module, Level} <- Levels].
+
+set_custom(Host, Module, Level) ->
+    Node = ct:get_config({hosts, Host, node}),
+    mongoose_helper:successful_rpc(Node, ejabberd_loglevel, set_custom, [Module, Level]).
+
+clear_custom(Host, Module, _Level) ->
+    Node = ct:get_config({hosts, Host, node}),
+    mongoose_helper:successful_rpc(Node, ejabberd_loglevel, clear_custom, [Module]).

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -872,6 +872,7 @@ wait_for_node(Node,Jid) ->
                                  name => rpc}).
 
 test_update_senders_host_by_ejd_service(Config) ->
+    refresh_hosts([mim, mim2, reg]),
     %% Connects to europe_node1
     ComponentConfig = [{server, <<"localhost">>}, {host, <<"localhost">>}, {password, <<"secret">>},
                        {port, service_port()}, {component, <<"test_service">>}],

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -133,6 +133,7 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     disable_logging(),
+    escalus_fresh:clean(),
     rpc(europe_node2, mongoose_cluster, leave, []),
     escalus:end_per_suite(Config).
 
@@ -191,7 +192,7 @@ init_per_group_generic(Config0) ->
 
                   %% To reduce load when sending many messages
                   VirtHosts = [<<"localhost">>, <<"localhost.bis">>],
-                  ModulesToStop = [mod_offline, mod_privacy, mod_roster],
+                  ModulesToStop = [mod_offline, mod_privacy, mod_roster, mod_last],
 
                   OldMods = save_modules(NodeName, VirtHosts),
 
@@ -242,8 +243,7 @@ end_per_group_generic(Config) ->
               rpc(NodeName, mod_stream_management, set_resume_timeout,
                   [?config({resume_timeout, NodeName}, Config)])
       end,
-      get_hosts()),
-    escalus_fresh:clean().
+      get_hosts()).
 
 init_per_testcase(CaseName, Config)
   when CaseName == test_muc_conversation_on_one_host; CaseName == test_global_disco;

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -414,8 +414,8 @@ test_two_way_pm(Alice, Eve) ->
     escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi from Europe1!">>)),
     escalus_client:send(Eve, escalus_stanza:chat_to(Alice, <<"Hi from Asia!">>)),
 
-    FromAlice = escalus_client:wait_for_stanza(Eve),
-    FromEve = escalus_client:wait_for_stanza(Alice),
+    FromAlice = escalus_client:wait_for_stanza(Eve, timer:seconds(15)),
+    FromEve = escalus_client:wait_for_stanza(Alice, timer:seconds(15)),
 
     AliceJid = escalus_client:full_jid(Alice),
     EveJid = escalus_client:full_jid(Eve),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -139,7 +139,8 @@ end_per_suite(Config) ->
 init_per_group(start_checks, Config) ->
     Config;
 init_per_group(multi_connection, Config) ->
-    ExtraConfig = [{resend_after_ms, 20000}, {connections_per_endpoint, 100}],
+    ExtraConfig = [{resend_after_ms, 20000},
+                   {connections_per_endpoint, 100}],
     init_per_group_generic([{extra_config, ExtraConfig} | Config]);
 init_per_group(invalidation, Config) ->
     Config1 = init_per_group(invalidation_generic, Config),
@@ -1303,6 +1304,8 @@ disable_logging() ->
 
 custom_loglevels() ->
     %% for "s2s connection to muc.localhost not found" debugging
-    [{ejabberd_s2s, debug}].
+    [{ejabberd_s2s, debug},
+    %% for debugging event=refreshing_own_data_done
+     {mod_global_distrib_mapping_redis, debug}].
 
 test_hosts() -> [mim, mim2, reg].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -604,9 +604,7 @@ test_location_disconnect(Config) ->
           end)
     after
         rpc(asia_node, application, start, [ranch]),
-        rpc(asia_node, application, start, [mongooseim]),
-        %% stream_start failed workaround
-        wait_for_user_able_to_connect(Config, eve)
+        rpc(asia_node, application, start, [mongooseim])
     end.
 
 test_pm_with_disconnection_on_other_server(Config) ->
@@ -784,6 +782,8 @@ refresh_nodes(Config) ->
     {ok, undefined} = redis_query(europe_node1, [<<"HGET">>, NodesKey, NodeBin]).
 
 test_in_order_messages_on_multiple_connections(Config) ->
+    %% stream_start failed workaround
+    wait_for_user_able_to_connect(Config, eve),
     escalus:fresh_story(
       Config, [{alice, 1}, {eve, 1}],
       fun(Alice, Eve) ->
@@ -803,6 +803,8 @@ test_in_order_messages_on_multiple_connections(Config) ->
       end).
 
 test_in_order_messages_on_multiple_connections_with_bounce(Config) ->
+    %% stream_start failed workaround
+    wait_for_user_able_to_connect(Config, eve),
     escalus:fresh_story(
       Config, [{alice, 1}, {eve, 1}],
       fun(Alice, Eve) ->
@@ -822,6 +824,8 @@ test_in_order_messages_on_multiple_connections_with_bounce(Config) ->
       end).
 
 test_messages_bounced_in_order(Config) ->
+    %% stream_start failed workaround
+    wait_for_user_able_to_connect(Config, eve),
     escalus:fresh_story(
       Config, [{alice, 1}, {eve, 1}],
       fun(Alice, Eve) ->

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1306,6 +1306,6 @@ custom_loglevels() ->
     %% for "s2s connection to muc.localhost not found" debugging
     [{ejabberd_s2s, debug},
     %% for debugging event=refreshing_own_data_done
-     {mod_global_distrib_mapping_redis, debug}].
+     {mod_global_distrib_mapping_redis, info}].
 
 test_hosts() -> [mim, mim2, reg].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1306,6 +1306,9 @@ custom_loglevels() ->
     %% for "s2s connection to muc.localhost not found" debugging
     [{ejabberd_s2s, debug},
     %% for debugging event=refreshing_own_data_done
-     {mod_global_distrib_mapping_redis, info}].
+     {mod_global_distrib_mapping_redis, info},
+    %% to know if connection is already started or would be started
+    %% event=outgoing_conn_start_progress
+     {mod_global_distrib_outgoing_conns_sup, info}].
 
 test_hosts() -> [mim, mim2, reg].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -244,6 +244,10 @@ init_per_testcase(CaseName, Config)
     %% For now it's easier to hide node2
     %% TODO: Do it right at some point!
     hide_node(europe_node2, Config),
+    %% There would be no new connections to europe_node2, but there can be some old ones.
+    %% We need to disconnect previous connections.
+    {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
+    trigger_rebalance(asia_node, EuropeHost),
     %% Load muc on mim node
     muc_helper:load_muc(<<"muc.localhost">>),
     RegNode = ct:get_config({hosts, reg, node}),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -247,7 +247,7 @@ init_per_testcase(CaseName, Config)
     %% There would be no new connections to europe_node2, but there can be some old ones.
     %% We need to disconnect previous connections.
     {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
-    trigger_rebalance(asia_node, EuropeHost),
+    trigger_rebalance(asia_node, list_to_binary(EuropeHost)),
     %% Load muc on mim node
     muc_helper:load_muc(<<"muc.localhost">>),
     RegNode = ct:get_config({hosts, reg, node}),
@@ -904,7 +904,7 @@ test_update_senders_host_by_ejd_service(Config) ->
 
               hide_node(europe_node1, Config),
               {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
-              trigger_rebalance(asia_node, EuropeHost),
+              trigger_rebalance(asia_node, list_to_binary(EuropeHost)),
 
               escalus:send(Eve, escalus_stanza:chat_to(Addr, <<"hi">>)),
               escalus:wait_for_stanza(Comp),
@@ -1215,9 +1215,9 @@ restart_receiver(NodeName, NewEndpoints) ->
     {ok, _} = rpc(NodeName, gen_mod, reload_module,
              [<<"localhost">>, mod_global_distrib_receiver, NewOpts]).
 
-trigger_rebalance(NodeName, DestinationDomain) ->
+trigger_rebalance(NodeName, DestinationDomain) when is_binary(DestinationDomain) ->
     %% To ensure that the manager exists, otherwise we can get noproc error in the force_refresh call
-    rpc(NodeName, mod_global_distrib_outgoing_conns_sup, ensure_server_started, [DestinationDomain]),
+    ok = rpc(NodeName, mod_global_distrib_outgoing_conns_sup, ensure_server_started, [DestinationDomain]),
     rpc(NodeName, mod_global_distrib_server_mgr, force_refresh, [DestinationDomain]),
     timer:sleep(1000).
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -117,6 +117,7 @@ init_per_suite(Config) ->
         {{ok, _}, {ok, _}} ->
             ok = rpc(europe_node2, mongoose_cluster, join, [ct:get_config(europe_node1)]),
 
+            enable_logging(),
             % We have to pass [no_opts] because [] is treated as string and converted
             % automatically to <<>>
             escalus:init_per_suite([{add_advertised_endpoints, []},
@@ -127,6 +128,7 @@ init_per_suite(Config) ->
     end.
 
 end_per_suite(Config) ->
+    disable_logging(),
     rpc(europe_node2, mongoose_cluster, leave, []),
     escalus:end_per_suite(Config).
 
@@ -1286,3 +1288,16 @@ can_connect_to_port(Port) ->
             ct:pal("can_connect_to_port port=~p result=~p", [Port, Other]),
             false
     end.
+
+
+enable_logging() ->
+    mim_loglevel:enable_logging(test_hosts(), custom_loglevels()).
+
+disable_logging() ->
+    mim_loglevel:disable_logging(test_hosts(), custom_loglevels()).
+
+custom_loglevels() ->
+    %% for "s2s connection to muc.localhost not found" debugging
+    [{ejabberd_s2s, debug}].
+
+test_hosts() -> [mim, mim2, reg].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1309,7 +1309,11 @@ custom_loglevels() ->
      {mod_global_distrib_mapping_redis, info},
     %% to know if connection is already started or would be started
     %% event=outgoing_conn_start_progress
-     {mod_global_distrib_outgoing_conns_sup, info}].
+     {mod_global_distrib_outgoing_conns_sup, info},
+    %% to debug bound connection issues
+     {mod_global_distrib, debug},
+    %% to know all new connections pids
+     {mod_global_distrib_connection, debug}].
 
 test_hosts() -> [mim, mim2, reg].
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -153,6 +153,7 @@ init_per_group(rebalancing, Config) ->
     %% We need to prevent automatic refreshes, because they may interfere with tests
     %% and we need early disabled garbage collection to check its validity
     ExtraConfig = [{endpoint_refresh_interval, 3600},
+                   {endpoint_refresh_interval_when_empty, 3600},
                    {disabled_gc_interval, 1}],
     RedisExtraConfig = [{refresh_after, 3600}],
     init_per_group_generic([{extra_config, ExtraConfig},

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -403,6 +403,12 @@ test_pm_between_users_before_available_presence(Config) ->
     escalus_client:stop(Config1, Eve).
 
 test_two_way_pm(Alice, Eve) ->
+    %% Ensure that users are properly registered
+    %% Otherwise you can get "Unable to route global message... user not found in the routing table"
+    %% error, because "escalus_client:start" can return before SM registration is completed.
+    wait_for_registration(Alice, ct:get_config({hosts, mim, node})),
+    wait_for_registration(Eve, ct:get_config({hosts, reg, node})),
+
     escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi from Europe1!">>)),
     escalus_client:send(Eve, escalus_stanza:chat_to(Alice, <<"Hi from Asia!">>)),
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1128,12 +1128,13 @@ execute_on_each_node(M, F, A) ->
     lists:map(fun({NodeName, _, _}) -> rpc(NodeName, M, F, A) end, get_hosts()).
 
 mock_inet() ->
-    meck:new(inet, [non_strict, passthrough, unstick]),
-    meck:expect(inet, getaddrs, fun(_, inet) -> {ok, [{127, 0, 0, 1}]};
-                                   (_, inet6) -> {error, "No ipv6 address"} end).
+    %% We don't want to mock inet module itself to avoid strange networking issues
+    meck:new(mod_global_distrib_utils, [non_strict, passthrough, unstick]),
+    meck:expect(mod_global_distrib_utils, getaddrs, fun(_, inet) -> {ok, [{127, 0, 0, 1}]};
+                                                       (_, inet6) -> {error, "No ipv6 address"} end).
 
 unmock_inet(_Pids) ->
-    execute_on_each_node(meck, unload, [inet]).
+    execute_on_each_node(meck, unload, [mod_global_distrib_utils]).
 
 out_connection_sups(Node) ->
     Children = rpc(Node, supervisor, which_children, [mod_global_distrib_outgoing_conns_sup]),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -244,6 +244,9 @@ init_per_testcase(CaseName, Config)
     %% For now it's easier to hide node2
     %% TODO: Do it right at some point!
     hide_node(europe_node2, Config),
+    %% Ensure, that old connections to europe_node2 are down
+    {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
+    trigger_rebalance(asia_node, EuropeHost),
     %% Load muc on mim node
     muc_helper:load_muc(<<"muc.localhost">>),
     RegNode = ct:get_config({hosts, reg, node}),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1210,6 +1210,8 @@ restart_receiver(NodeName, NewEndpoints) ->
              [<<"localhost">>, mod_global_distrib_receiver, NewOpts]).
 
 trigger_rebalance(NodeName, DestinationDomain) ->
+    %% To ensure that the manager exists, otherwise we can get noproc error in the force_refresh call
+    rpc(NodeName, mod_global_distrib_outgoing_conns_sup, ensure_server_started, [DestinationDomain]),
     rpc(NodeName, mod_global_distrib_server_mgr, force_refresh, [DestinationDomain]),
     timer:sleep(1000).
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -140,6 +140,8 @@ init_per_group(start_checks, Config) ->
     Config;
 init_per_group(multi_connection, Config) ->
     ExtraConfig = [{resend_after_ms, 20000},
+                   %% Disable unused feature to avoid interferance
+                   {disabled_gc_interval, 10000},
                    {connections_per_endpoint, 100}],
     init_per_group_generic([{extra_config, ExtraConfig} | Config]);
 init_per_group(invalidation, Config) ->
@@ -1327,7 +1329,9 @@ custom_loglevels() ->
     %% to debug bound connection issues
      {mod_global_distrib, debug},
     %% to know all new connections pids
-     {mod_global_distrib_connection, debug}].
+     {mod_global_distrib_connection, debug},
+    %% to check if gc or refresh is triggered
+     {mod_global_distrib_server_mgr, info}].
 
 test_hosts() -> [mim, mim2, reg].
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -47,7 +47,6 @@ groups() ->
           [
            test_pm_between_users_at_different_locations,
            test_pm_between_users_before_available_presence,
-           test_muc_conversation_on_one_host,
            test_component_disconnect,
            test_component_on_one_host,
            test_components_in_different_regions,
@@ -57,10 +56,13 @@ groups() ->
            test_pm_with_ungraceful_reconnection_to_different_server,
            test_pm_with_ungraceful_reconnection_to_different_server_with_asia_refreshes_first,
            test_pm_with_ungraceful_reconnection_to_different_server_with_europe_refreshes_first,
-           test_global_disco,
            test_component_unregister,
            test_update_senders_host,
-           test_update_senders_host_by_ejd_service
+           test_update_senders_host_by_ejd_service,
+
+           %% with node 2 disabled
+           test_muc_conversation_on_one_host,
+           test_global_disco
            %% TODO: Add test case fo global_distrib_addr option
           ]},
          {hosts_refresher, [],
@@ -81,9 +83,11 @@ groups() ->
          {multi_connection, [],
           [
            test_in_order_messages_on_multiple_connections,
-           test_muc_conversation_history,
            test_in_order_messages_on_multiple_connections_with_bounce,
-           test_messages_bounced_in_order
+           test_messages_bounced_in_order,
+
+           %% with node 2 disabled
+           test_muc_conversation_history
           ]},
          {rebalancing, [],
           [
@@ -244,9 +248,6 @@ init_per_testcase(CaseName, Config)
     %% For now it's easier to hide node2
     %% TODO: Do it right at some point!
     hide_node(europe_node2, Config),
-    %% Ensure, that old connections to europe_node2 are down
-    {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
-    trigger_rebalance(asia_node, EuropeHost),
     %% Load muc on mim node
     muc_helper:load_muc(<<"muc.localhost">>),
     RegNode = ct:get_config({hosts, reg, node}),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1334,7 +1334,7 @@ custom_loglevels() ->
     %% to check if gc or refresh is triggered
      {mod_global_distrib_server_mgr, info},
    %% To debug incoming connections
-     {mod_global_distrib_receiver, info},
+%    {mod_global_distrib_receiver, info},
    %% to debug global session set/delete
      {mod_global_distrib_mapping, debug}
     ].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -411,8 +411,8 @@ test_two_way_pm(Alice, Eve) ->
     wait_for_registration(Alice, ct:get_config({hosts, mim, node})),
     wait_for_registration(Eve, ct:get_config({hosts, reg, node})),
 
-    escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi from Europe1!">>)),
-    escalus_client:send(Eve, escalus_stanza:chat_to(Alice, <<"Hi from Asia!">>)),
+    escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi to Eve from Europe1!">>)),
+    escalus_client:send(Eve, escalus_stanza:chat_to(Alice, <<"Hi to Alice from Asia!">>)),
 
     FromAlice = escalus_client:wait_for_stanza(Eve, timer:seconds(15)),
     FromEve = escalus_client:wait_for_stanza(Alice, timer:seconds(15)),
@@ -420,9 +420,9 @@ test_two_way_pm(Alice, Eve) ->
     AliceJid = escalus_client:full_jid(Alice),
     EveJid = escalus_client:full_jid(Eve),
 
-    escalus:assert(is_chat_message_from_to, [AliceJid, EveJid, <<"Hi from Europe1!">>],
+    escalus:assert(is_chat_message_from_to, [AliceJid, EveJid, <<"Hi to Eve from Europe1!">>],
                    FromAlice),
-    escalus:assert(is_chat_message_from_to, [EveJid, AliceJid, <<"Hi from Asia!">>],
+    escalus:assert(is_chat_message_from_to, [EveJid, AliceJid, <<"Hi to Alice from Asia!">>],
                    FromEve).
 
 test_muc_conversation_on_one_host(Config0) ->
@@ -1333,7 +1333,10 @@ custom_loglevels() ->
     %% to check if gc or refresh is triggered
      {mod_global_distrib_server_mgr, info},
    %% To debug incoming connections
-     {mod_global_distrib_receiver, info}].
+     {mod_global_distrib_receiver, info},
+   %% to debug global session set/delete
+     {mod_global_distrib_mapping, debug}
+    ].
 
 test_hosts() -> [mim, mim2, reg].
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -1331,7 +1331,9 @@ custom_loglevels() ->
     %% to know all new connections pids
      {mod_global_distrib_connection, debug},
     %% to check if gc or refresh is triggered
-     {mod_global_distrib_server_mgr, info}].
+     {mod_global_distrib_server_mgr, info},
+   %% To debug incoming connections
+     {mod_global_distrib_receiver, info}].
 
 test_hosts() -> [mim, mim2, reg].
 

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -20,7 +20,7 @@
 
 -export([kick_everyone/0]).
 -export([ensure_muc_clean/0]).
--export([successful_rpc/3, successful_rpc/4]).
+-export([successful_rpc/3, successful_rpc/4, successful_rpc/5]).
 -export([logout_user/2, logout_user/3]).
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
@@ -30,7 +30,8 @@
 -export([wait_for_pid_to_die/1]).
 
 -import(distributed_helper, [mim/0,
-                             rpc/4]).
+                             rpc/4,
+                             rpc/5]).
 
 -spec is_rdbms_enabled(Host :: binary()) -> boolean().
 is_rdbms_enabled(Host) ->
@@ -221,7 +222,11 @@ successful_rpc(Module, Function, Args) ->
 
 -spec successful_rpc(Node :: atom(), M :: module(), F :: atom(), A :: list()) -> term().
 successful_rpc(Node, Module, Function, Args) ->
-    case rpc(Node, Module, Function, Args) of
+    successful_rpc(Node, Module, Function, Args, timer:seconds(5)).
+
+-spec successful_rpc(Node :: atom(), M :: module(), F :: atom(), A :: list(), timeout()) -> term().
+successful_rpc(Node, Module, Function, Args, Timeout) ->
+    case rpc(Node, Module, Function, Args, Timeout) of
         {badrpc, Reason} ->
             ct:fail({badrpc, Module, Function, Args, Reason});
         Result ->

--- a/doc/modules/mod_global_distrib.md
+++ b/doc/modules/mod_global_distrib.md
@@ -125,6 +125,7 @@ Global distribution modules expose several per-datacenter metrics that can be us
 * **connections_per_endpoint** (integer, default: `1`): Number of outgoing connections that will be established from the current node to each endpoint assigned to a remote domain.
 * **endpoint_refresh_interval** (seconds, default: `60`): An interval between remote endpoint list refresh (and connection rebalancing).
   A separate timer is maintained for every remote domain.
+* **endpoint_refresh_interval_when_empty** (seconds, default: `3`): Endpoint refresh interval, when list of endpoints is empty.
 * **disabled_gc_interval** (seconds, default: `60`): An interval between disabled endpoints "garbage collection".
   It means that disabled endpoints are periodically verified and if Global Distribution detects that connections is no longer alive, the connection pool is closed completely.
 * **tls_opts** (list, required): Options for TLS connections passed to the `fast_tls` driver.<a name="tls_opts"></a>

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -288,6 +288,8 @@ do_route(From, To, Acc, Packet) ->
                 <<"error">> -> done;
                 <<"result">> -> done;
                 _ ->
+                    ?DEBUG("event=s2s_connection_not_found from=~1000p to=~1000p packet=~1000p",
+                           [From, To, Packet]),
                     {Acc1, Err} = jlib:make_error_reply(
                             Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
                     ejabberd_router:route(To, From, Acc1, Err)

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -161,9 +161,9 @@ maybe_initialize_metadata({From, To, Acc, Packet}) ->
 
 get_bound_connection_noisy(TargetHost, GDID, FPacket) ->
     try get_bound_connection(TargetHost, GDID)
-    catch Class:Reason ->
-              Stacktrace = erlang:get_stacktrace(),
-              ?ERROR_MSG("event=gd_get_process_for_failed server=~ts gd_id=~s reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
+    catch Class:Reason:Stacktrace ->
+              ?ERROR_MSG("event=gd_get_process_for_failed "
+                         "server=~ts gd_id=~s reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
                            [TargetHost, GDID, Class, Reason, FPacket, Stacktrace]),
               erlang:raise(Class, Reason, Stacktrace)
     end.

--- a/src/global_distrib/mod_global_distrib_connection.erl
+++ b/src/global_distrib/mod_global_distrib_connection.erl
@@ -42,6 +42,7 @@ start_link(Endpoint, Server) ->
     gen_server:start_link(?MODULE, [Endpoint, Server], []).
 
 init([{Addr, Port}, Server]) ->
+    ?DEBUG("event=outgoing_gd_connection remote_server=~ts address=~1000p:~p pid=~p", [Server, Addr, Port, self()]),
     process_flag(trap_exit, true),
     MetricServer = mod_global_distrib_utils:binary_to_metric_atom(Server),
     mod_global_distrib_utils:ensure_metric(?GLOBAL_DISTRIB_MESSAGES_SENT(MetricServer), spiral),

--- a/src/global_distrib/mod_global_distrib_connection.erl
+++ b/src/global_distrib/mod_global_distrib_connection.erl
@@ -63,8 +63,8 @@ init([{Addr, Port}, Server]) ->
                     peer = mod_global_distrib_transport:peername(Socket)}}
     catch
         error:{badmatch, Reason}:StackTrace ->
-            ?ERROR_MSG("Connection to ~p failed: ~p~n~p",
-                       [{Addr, Port}, Reason, StackTrace]),
+            ?ERROR_MSG("event=gd_connection_failed server=~ts address=~p:~p reason=~1000p stacktrace=~1000p",
+                       [Server, Addr, Port, Reason, StackTrace]),
             {stop, normal}
     end.
 

--- a/src/global_distrib/mod_global_distrib_hosts_refresher.erl
+++ b/src/global_distrib/mod_global_distrib_hosts_refresher.erl
@@ -81,11 +81,17 @@ init([RefreshInterval]) ->
     NState = schedule_refresh(#state{ refresh_interval = RefreshInterval }),
     {ok, NState}.
 
+handle_call(pause, _From, State = #state{tref = undefined}) ->
+    ?ERROR_MSG("event=already_paused", []),
+    {reply, ok, State};
 handle_call(pause, _From, State) ->
     erlang:cancel_timer(State#state.tref),
     {reply, ok, State#state{ tref = undefined }};
-handle_call(unpause, _From, State) ->
+handle_call(unpause, _From, State = #state{tref = undefined}) ->
     {reply, ok, schedule_refresh(State)};
+handle_call(unpause, _From, State = #state{tref = TRef}) ->
+    ?ERROR_MSG("event=not_paused, timer_ref=~p", [TRef]),
+    {reply, ok, State};
 handle_call(Request, From, State) ->
     ?ERROR_MSG("issue=unknown_call request=~p from=~p", [Request, From]),
     {reply, {error, unknown_request}, State}.

--- a/src/global_distrib/mod_global_distrib_mapping.erl
+++ b/src/global_distrib/mod_global_distrib_mapping.erl
@@ -272,10 +272,12 @@ get_session(Key) ->
 
 -spec put_session(Key :: binary()) -> ok.
 put_session(Key) ->
+    ?DEBUG("event=put_session key=~ts", [Key]),
     mod_global_distrib_mapping_backend:put_session(Key).
 
 -spec delete_session(Key :: binary()) -> ok.
 delete_session(Key) ->
+    ?DEBUG("event=delete_session key=~ts", [Key]),
     mod_global_distrib_mapping_backend:delete_session(Key).
 
 -spec get_domain(Key :: binary()) -> {ok, term()} | error.

--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -185,7 +185,7 @@ nodes_key() ->
     nodes_key(LocalHost).
 
 -spec nodes_key(Host :: jid:lserver()) -> binary().
-nodes_key(Host) ->
+nodes_key(Host) when is_binary(Host) ->
     <<Host/binary, "#{nodes}">>.
 
 -spec endpoints_key() -> binary().

--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -116,7 +116,12 @@ get_public_domains() ->
 
 -spec get_endpoints(Host :: jid:lserver()) -> {ok, [mod_global_distrib_utils:endpoint()]}.
 get_endpoints(Host) ->
-    Nodes = [_ | _] = get_nodes(Host), %% TODO: error: unknown host
+    Nodes = get_nodes(Host),
+    get_endpoints_for_nodes(Host, Nodes).
+
+get_endpoints_for_nodes(_Host, []) ->
+    {ok, []};
+get_endpoints_for_nodes(Host, Nodes) ->
     EndpointKeys = [endpoints_key(Host, Node) || Node <- Nodes],
     {ok, BinEndpoints} = q([<<"SUNION">> | EndpointKeys]),
     {ok, lists:map(fun binary_to_endpoint/1, BinEndpoints)}.

--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -136,7 +136,7 @@ init(RefreshAfter) ->
 
 handle_info(refresh, RefreshAfter) ->
     refresh(),
-    ?DEBUG("event=refreshing_own_data_done,next_refresh_in=~p", [RefreshAfter]),
+    ?INFO_MSG("event=refreshing_own_data_done,next_refresh_in=~p", [RefreshAfter]),
     erlang:send_after(timer:seconds(RefreshAfter), self(), refresh),
     {noreply, RefreshAfter}.
 

--- a/src/global_distrib/mod_global_distrib_sender.erl
+++ b/src/global_distrib/mod_global_distrib_sender.erl
@@ -55,6 +55,7 @@ send(Worker, {From, _To, _Acc, _Packet} = FPacket) ->
 start(Host, Opts0) ->
     Opts = [{listen_port, 5555},
             {connections_per_endpoint, 1},
+            {endpoint_refresh_interval_when_empty, 3},
             {endpoint_refresh_interval, 60},
             {disabled_gc_interval, 60} | Opts0],
     mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).

--- a/src/global_distrib/mod_global_distrib_sender.erl
+++ b/src/global_distrib/mod_global_distrib_sender.erl
@@ -31,8 +31,15 @@
 
 -spec send(jid:lserver() | pid(), {jid:jid(), jid:jid(), mongoose_acc:t(), xmlel:packet()}) -> ok.
 send(Server, Packet) when is_binary(Server) ->
-    Worker = get_process_for(Server),
-    send(Worker, Packet);
+    try get_process_for(Server) of
+        Worker ->
+           send(Worker, Packet)
+    catch Class:Reason ->
+              Stacktrace = erlang:get_stacktrace(),
+              ?ERROR_MSG("event=gd_get_process_for_failed server=~ts reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
+                           [Server, Class, Reason, Packet, Stacktrace]),
+              erlang:raise(Class, Reason, Stacktrace)
+    end;
 send(Worker, {From, _To, _Acc, _Packet} = FPacket) ->
     BinPacket = term_to_binary(FPacket),
     BinFrom = mod_global_distrib_utils:recipient_to_worker_key(From, opt(global_host)),

--- a/src/global_distrib/mod_global_distrib_sender.erl
+++ b/src/global_distrib/mod_global_distrib_sender.erl
@@ -34,9 +34,9 @@ send(Server, Packet) when is_binary(Server) ->
     try get_process_for(Server) of
         Worker ->
            send(Worker, Packet)
-    catch Class:Reason ->
-              Stacktrace = erlang:get_stacktrace(),
-              ?ERROR_MSG("event=gd_get_process_for_failed server=~ts reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
+    catch Class:Reason:Stacktrace ->
+              ?ERROR_MSG("event=gd_get_process_for_failed server=~ts "
+                         "reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
                            [Server, Class, Reason, Packet, Stacktrace]),
               erlang:raise(Class, Reason, Stacktrace)
     end;

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -61,7 +61,7 @@
 %%--------------------------------------------------------------------
 
 -spec start_link(Server :: jid:lserver(), ServerSup :: pid()) -> {ok, pid()} | {error, any()}.
-start_link(Server, ServerSup) ->
+start_link(Server, ServerSup) when is_binary(Server) ->
     Name = mod_global_distrib_utils:server_to_mgr_name(Server),
     gen_server:start_link({local, Name}, ?MODULE, [Server, ServerSup], []).
 

--- a/src/global_distrib/mod_global_distrib_server_sup.erl
+++ b/src/global_distrib/mod_global_distrib_server_sup.erl
@@ -39,9 +39,9 @@ get_connection(Server) ->
         %% Possible issues:
         %% - {'EXIT', {noproc, _}}
         %%  - {case_clause,{'EXIT',{no_connections...
-    catch Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
-            ?ERROR_MSG("event=get_gd_connection_failed server=~ts reason=~p:~p stacktrace=~1000p",
+    catch Class:Reason:Stacktrace ->
+            ?ERROR_MSG("event=get_gd_connection_failed "
+                       "server=~ts reason=~p:~p stacktrace=~1000p",
                        [Server, Class, Reason, Stacktrace]),
             %% May be caused by missing server_sup or missing connection manager
             %% The former occurs when a process tries to send a message to Server

--- a/src/global_distrib/mod_global_distrib_server_sup.erl
+++ b/src/global_distrib/mod_global_distrib_server_sup.erl
@@ -41,7 +41,7 @@ get_connection(Server) ->
         %%  - {case_clause,{'EXIT',{no_connections...
     catch Class:Reason ->
             Stacktrace = erlang:get_stacktrace(),
-            ?ERROR_MSG("even=get_gd_connection_failed server=~ts reason=~p:~p stacktrace=~1000p",
+            ?ERROR_MSG("event=get_gd_connection_failed server=~ts reason=~p:~p stacktrace=~1000p",
                        [Server, Class, Reason, Stacktrace]),
             %% May be caused by missing server_sup or missing connection manager
             %% The former occurs when a process tries to send a message to Server

--- a/src/global_distrib/mod_global_distrib_transport.erl
+++ b/src/global_distrib/mod_global_distrib_transport.erl
@@ -47,7 +47,7 @@ wrap(Socket, Opts0) ->
         Error -> Error
     end.
 
--spec setopts(t(), Opts :: proplists:proplist()) -> ok.
+-spec setopts(t(), Opts :: proplists:proplist()) -> ok | {error, term()}.
 setopts(#?MODULE{transport = gen_tcp, socket = Socket}, Opts) ->
     inet:setopts(Socket, Opts);
 setopts(#?MODULE{transport = fast_tls, socket = Socket}, Opts) ->

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -28,6 +28,8 @@
          parse_address/1
         ]).
 
+-export([getaddrs/2]).
+
 -type domain_name() :: string().
 -type endpoint() :: {inet:ip_address() | domain_name(), inet:port_number()}.
 
@@ -261,7 +263,7 @@ translate_opt(Opt) ->
 -spec to_ip_tuples(Addr :: inet:ip_address() | string()) ->
                          {ok, [inet:ip_address()]} | {error, {V6 :: atom(), V4 :: atom()}}.
 to_ip_tuples(Addr) ->
-    case {inet:getaddrs(Addr, inet6), inet:getaddrs(Addr, inet)} of
+    case {?MODULE:getaddrs(Addr, inet6), ?MODULE:getaddrs(Addr, inet)} of
         {{error, Reason6}, {error, Reason4}} ->
             {error, {Reason6, Reason4}};
         {Addrs, {error, Msg}} ->
@@ -299,3 +301,6 @@ is_domain(DomainOrIp) ->
 local_host() ->
     opt(mod_global_distrib, local_host).
 
+%% For mocking in tests
+getaddrs(Addr, Type) ->
+    inet:getaddrs(Addr, Type).

--- a/src/global_distrib/mod_global_distrib_worker.erl
+++ b/src/global_distrib/mod_global_distrib_worker.erl
@@ -14,6 +14,8 @@
 %% limitations under the License.
 %%==============================================================================
 
+%% Routing worker
+
 -module(mod_global_distrib_worker).
 -author('konrad.zemek@erlang-solutions.com').
 


### PR DESCRIPTION
This PR addresses "sometimes global distribution tests are failing"

Proposed changes include:
* Print gd_id where possible (id, assigned by global distribution module)
* Add conn_id to track connection GD names (*we changed GD initial handshake, we pass server name inside XML object instead of just server name. It would allow us to add arbitrary stuff there without breaking compatibility between versions again*)
* `mod_global_distrib_mapping_redis:refresh/1` takes Reason as an argument now. Allows to find out, who triggered refresh.
* New config option endpoint_refresh_interval_when_empty. It allows to refresh more often, when it is actually needed. And still avoids endpoints to be refreshed too often, once we are connected.
* New module mim_loglevel to increase log level for modules under test.
* Do not mock inet module directly, because bad stuff can happen.