### PR TITLE
Add and use muc_helper:story_with_room/4

### DIFF
--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -242,3 +242,14 @@ assert_valid_role(<<"participant">>) -> ok;
 assert_valid_role(<<"visitor">>) -> ok;
 assert_valid_role(<<"none">>) -> ok.
 
+
+story_with_room(Config, RoomOpts, [{Owner, _}|_] = UserSpecs, StoryFun) ->
+    Config1 = escalus_fresh:create_users(Config, UserSpecs),
+    AliceSpec = escalus_users:get_userspec(Config1, Owner),
+    Config2 = given_fresh_room(Config1, AliceSpec, RoomOpts),
+    try
+        StoryFun2 = fun(Args) -> apply(StoryFun, [Config2 | Args]) end,
+        escalus_story:story_with_client_list(Config2, UserSpecs, StoryFun2)
+    after
+        destroy_room(Config2)
+    end.


### PR DESCRIPTION
escalus stanza log does not work for users, connected outside of story.
So, with old code we would not see Alice in logs.

This PR addresses "no Alice in stanza logs".

Proposed changes include:
* helper function `story_with_room` to be used instead of `connect_fresh_user`.
* Create fresh room and all fresh users in one call.
* Less stuff in init_per_testcase.
* In some tests kate is eve for some reason :)