### PR TITLE
strip acc before running filter_local_packet

### DIFF
--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -35,12 +35,14 @@
 
 all() ->
     [
-        {group, message}
+        {group, message},
+        {group, cache_and_strip}
     ].
 
 groups() ->
     G = [
-         {message, [], message_test_cases()}
+         {message, [], message_test_cases()},
+         {cache_and_strip, [], cache_test_cases()}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -49,6 +51,9 @@ message_test_cases() ->
         one_message,
         message_altered_by_filter_local_packet_hook
     ].
+
+cache_test_cases() ->
+    [ filter_local_packet_uses_recipient_values ].
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
@@ -74,17 +79,25 @@ init_per_group(message, Config) ->
     add_handler(filter_local_packet, test_check_acc, 50),
     % checks it is the same acc and it has been stripped but keeps persistent props
     add_handler(user_receive_packet, test_check_final_acc, 50),
-    escalus:create_users(Config, escalus:get_users([alice, bob]));
+    Config;
+init_per_group(cache_and_strip, Config) ->
+    add_handler(c2s_preprocessing_hook, save_my_jid, 50),
+    add_handler(filter_local_packet, drop_if_jid_not_mine, 1),
+    Config;
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, escalus:get_users([alice, bob])).
+    Config.
 
-end_per_group(message, Config) ->
+end_per_group(message, _Config) ->
     remove_handler(c2s_preprocessing_hook, test_save_acc, 50),
     remove_handler(filter_local_packet, test_check_acc, 50),
     remove_handler(user_receive_packet, test_check_final_acc, 50),
-    escalus:delete_users(Config, escalus:get_users([alice, bob]));
-end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, escalus:get_users([alice, bob])).
+    ok;
+end_per_group(cache_and_strip, _Config) ->
+    remove_handler(c2s_preprocessing_hook, save_my_jid, 50),
+    remove_handler(filter_local_packet, drop_if_jid_not_mine, 1),
+    ok;
+end_per_group(_GroupName, _Config) ->
+    ok.
 
 init_per_testcase(message_altered_by_filter_local_packet_hook = CN, Config) ->
     add_handler(filter_local_packet, alter_message, 60),
@@ -126,6 +139,23 @@ message_altered_by_filter_local_packet_hook(Config) ->
             escalus:assert(is_chat_message, [<<"bye">>], R),
             ok
         end).
+
+
+filter_local_packet_uses_recipient_values(Config) ->
+    escalus:fresh_story(
+        Config, [{alice, 1}, {bob, 1}],
+        fun(Alice, Bob) ->
+            M = escalus_stanza:chat_to(escalus_client:short_jid(Bob), <<"hi">>),
+            escalus:send(Alice, M),
+            R = escalus_client:wait_for_stanza(Bob),
+            ct:pal("R: ~p", [R]),
+            ok
+        end).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
 
 acc_test_helper_code(Config) ->
     Dir = proplists:get_value(mim_data_dir, Config),

--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -128,6 +128,9 @@ one_message(Config) ->
         end).
 
 message_altered_by_filter_local_packet_hook(Config) ->
+    % this test uses additional hook which changes body of a message on filter_local_packet hook
+    % later processing, including stripping accumulator and replacing element, must use
+    % correct values
     escalus:fresh_story(
         Config, [{alice, 1}, {bob, 1}],
         fun(Alice, Bob) ->
@@ -142,13 +145,16 @@ message_altered_by_filter_local_packet_hook(Config) ->
 
 
 filter_local_packet_uses_recipient_values(Config) ->
+    % this test is to make sure that when a message (or rather accumulator) reaches
+    % filter_local_packet stage it's been already stripped of sender-related caches
+    % preprocessing hook stores sender jid, filter_local_packet drops a message if there
+    % a sender_jid cached in acc
     escalus:fresh_story(
         Config, [{alice, 1}, {bob, 1}],
         fun(Alice, Bob) ->
             M = escalus_stanza:chat_to(escalus_client:short_jid(Bob), <<"hi">>),
             escalus:send(Alice, M),
-            R = escalus_client:wait_for_stanza(Bob),
-            ct:pal("R: ~p", [R]),
+            escalus_client:wait_for_stanza(Bob),
             ok
         end).
 

--- a/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
+++ b/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
@@ -32,6 +32,25 @@ test_check_final_acc(#{ stanza := #{ type := <<"chat">> } } = Acc, _Jid, _From, 
 test_check_final_acc(Acc, _Jid, _From, _To, _El) ->
     Acc.
 
+save_my_jid(#{ stanza := #{ type := <<"chat">>} } = Acc, _State) ->
+    Me = mongoose_acc:get(c2s, origin_jid, Acc),
+    {_, Acc2} = cached_my_jid(Me, Acc),
+    Acc2;
+save_my_jid(Acc, _State) -> Acc.
+
+drop_if_jid_not_mine({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}) ->
+    %% since we are in filter_local_packet, means we are just about to deliver the message
+    %% sender-side processing is already completed and now we want the other guy values
+    MyJid = jid:to_binary(jid:to_lus(T)),
+    case cached_my_jid(T, Acc) of
+        {MyJid, Acc2} ->
+            {F, T, Acc2, P};
+        _ ->
+            drop
+    end;
+drop_if_jid_not_mine(X) ->
+    X.
+
 recreate_table() ->
     try ets:delete(test_message_index) catch _:_ -> ok end,
     ets:new(test_message_index, [named_table, public, {heir, whereis(ejabberd_c2s_sup), none}]).
@@ -53,3 +72,13 @@ alter_message({From, To, Acc, Packet}) ->
     PCh2 = lists:keyreplace(<<"body">>, 2, PCh, NewBody),
     {From, To, Acc, {xmlel, PName, PAttrs, PCh2}}.
 
+cached_my_jid(User, Acc) ->
+    case mongoose_acc:get(test, my_jid, undefined, Acc) of
+        undefined ->
+            lager:log(error, self(), "{User, undefined}: ~p~n", [{User, undefined}]),
+            MyJid = jid:to_binary(jid:to_lus(User)),
+            {MyJid, mongoose_acc:set(test, my_jid, MyJid, Acc)};
+        Jid ->
+            lager:log(error, self(), "{User, Jid}: ~p~n", [{User, Jid}]),
+            {Jid, Acc}
+    end.

--- a/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
+++ b/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
@@ -41,9 +41,8 @@ save_my_jid(Acc, _State) -> Acc.
 drop_if_jid_not_mine({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}) ->
     %% since we are in filter_local_packet, means we are just about to deliver the message
     %% sender-side processing is already completed and now we want the other guy values
-    MyJid = jid:to_binary(jid:to_lus(T)),
     case cached_my_jid(T, Acc) of
-        {MyJid, Acc2} ->
+        {T, Acc2} ->
             {F, T, Acc2, P};
         _ ->
             drop
@@ -75,10 +74,7 @@ alter_message({From, To, Acc, Packet}) ->
 cached_my_jid(User, Acc) ->
     case mongoose_acc:get(test, my_jid, undefined, Acc) of
         undefined ->
-            lager:log(error, self(), "{User, undefined}: ~p~n", [{User, undefined}]),
-            MyJid = jid:to_binary(jid:to_lus(User)),
-            {MyJid, mongoose_acc:set(test, my_jid, MyJid, Acc)};
+            {User, mongoose_acc:set(test, my_jid, User, Acc)};
         Jid ->
-            lager:log(error, self(), "{User, Jid}: ~p~n", [{User, Jid}]),
             {Jid, Acc}
     end.

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -136,10 +136,7 @@ socket_type() ->
 -spec process_packet(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
     El :: exml:element(), Pid :: pid()) -> any().
 process_packet(Acc, From, To, El, Pid) ->
-    Pid ! {route, From, To, mongoose_acc:strip(#{ lserver => From#jid.lserver,
-                                                  from_jid => From,
-                                                  to_jid => To,
-                                                  element => El }, Acc)}.
+    Pid ! {route, From, To, Acc}.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -816,10 +816,7 @@ route_message(From, To, Acc, Packet) ->
               %% positive
               fun({Prio, Pid}) when Prio == Priority ->
                  %% we will lose message if PID is not alive
-                      Pid ! {route, From, To, mongoose_acc:strip(#{ lserver => To#jid.lserver,
-                                                                    from_jid => From,
-                                                                    to_jid => To,
-                                                                    element => Packet }, Acc)};
+                      Pid ! {route, From, To, Acc};
                  %% Ignore other priority:
                  ({_Prio, _Pid}) ->
                       ok

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -650,10 +650,7 @@ do_route(Acc, From, To, El) ->
                     Session = lists:max(Ss),
                     Pid = element(2, Session#session.sid),
                     ?DEBUG("sending to process ~p~n", [Pid]),
-                    Pid ! {route, From, To, mongoose_acc:strip(#{ lserver => To#jid.lserver,
-                                                                  from_jid => From,
-                                                                  to_jid => To,
-                                                                  element => El }, Acc)},
+                    Pid ! {route, From, To, Acc},
                     Acc
             end
     end.

--- a/src/mongoose_local_delivery.erl
+++ b/src/mongoose_local_delivery.erl
@@ -25,7 +25,8 @@ do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, LDstDomain, Handler) ->
     case ejabberd_hooks:run_fold(filter_local_packet, LDstDomain,
         {OrigFrom, OrigTo, Acc0, OrigPacket}, []) of
         {From, To, Acc, Packet} ->
-            mongoose_packet_handler:process(Handler, Acc, From, To, Packet);
+            Acc1 = mongoose_acc:update_stanza(#{from_jid => From, to_jid => To, element => Packet}, Acc),
+            mongoose_packet_handler:process(Handler, Acc1, From, To, Packet);
         drop ->
             ejabberd_hooks:run(xmpp_stanza_dropped,
                 OrigFrom#jid.lserver,

--- a/src/mongoose_local_delivery.erl
+++ b/src/mongoose_local_delivery.erl
@@ -15,9 +15,15 @@
 
 
 do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, LDstDomain, Handler) ->
+    % strip acc from all sender-related values, from now on we are interested in the recipient
+    Acc0 = mongoose_acc:strip(#{lserver => OrigTo#jid.lserver,
+                                from_jid => OrigFrom,
+                                to_jid => OrigTo,
+                                element => OrigPacket},
+                              OrigAcc),
     %% Filter locally
     case ejabberd_hooks:run_fold(filter_local_packet, LDstDomain,
-        {OrigFrom, OrigTo, OrigAcc, OrigPacket}, []) of
+        {OrigFrom, OrigTo, Acc0, OrigPacket}, []) of
         {From, To, Acc, Packet} ->
             mongoose_packet_handler:process(Handler, Acc, From, To, Packet);
         drop ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -244,13 +244,8 @@ default_host() ->
 %% State is an extra data, required for processing
 -spec process_packet(Acc :: mongoose_acc:t(), From ::jid:jid(), To ::jid:jid(), El :: exml:element(),
                      State :: #state{}) -> any().
-process_packet(Acc, From, To, El, #state{server_host = ServerHost, access = Access, plugins = Plugins}) ->
-    Acc2 = mongoose_acc:strip(#{ lserver => From#jid.lserver,
-                                                  from_jid => From,
-                                                  to_jid => To,
-                                                  element => El }, Acc),
-    Packet = mongoose_acc:element(Acc2),
-    do_route(ServerHost, Access, Plugins, To#jid.lserver, From, To, Packet).
+process_packet(_Acc, From, To, El, #state{server_host = ServerHost, access = Access, plugins = Plugins}) ->
+    do_route(ServerHost, Access, Plugins, To#jid.lserver, From, To, El).
 
 %%====================================================================
 %% GDPR callback


### PR DESCRIPTION
This PR addresses ticket MIM-659.

The issue being solved here is that in filter_local_packet we have already done all the sender-side processing and switch to the recipient side - it is run before ejabberd_sm ships the message to the recipient process, because we don't yet know if he is online and want to do some stuff regardless. So the accumulator should be already stripped of all sender-related cached data.

Proposed changes include:
* strip acc in mongoose_local_delivery, not in ejabberd_sm
* test which stops the message if at the filter_local_packet stage the acc still contains some data cached by the sender
