### PR TITLE
Fix pruning in stream_management_stale_h

### DIFF
--- a/src/stream_management/stream_management_stale_h.erl
+++ b/src/stream_management/stream_management_stale_h.erl
@@ -119,6 +119,6 @@ handle_info(Info, #smgc_state{gc_repeat_after = RepeatAfter,
     {noreply, State, RepeatAfter}.
 
 clear_table(GeriatricAge) ->
-    TimeToDie = erlang:monotonic_time(second) + GeriatricAge,
+    TimeToDie = erlang:monotonic_time(second) - GeriatricAge,
     MS = ets:fun2ms(fun(#stream_mgmt_stale_h{stamp=S}) when S < TimeToDie -> true end),
     ets:select_delete(stream_mgmt_stale_h, MS).


### PR DESCRIPTION
This PR addresses "sm_SUITE:stale_h:resume_expired_session_returns_correct_h" fails sometimes with stale_h not found in failed resumption stanza.

```erlang
FailedResumption {xmlel,<<“failed”>>,
                       [{<<“xmlns”>>,<<“urn:xmpp:sm:3”>>}],
                       [{xmlel,<<“item-not-found”>>,
                               [{<<“xmlns”>>,
                                 <<“urn:ietf:params:xml:ns:xmpp-stanzas”>>}],
                               []}]}
```

Failed test example:
* https://travis-ci.org/arcusfelis/MongooseIM/jobs/601763639#L4477

Proposed changes include:
* Fix cutoff time calculation in removal of old data code.

Logs:

```erlang
2019-10-23 11:18:41.473 [info] <0.11698.0>@ejabberd_c2s:terminate:1540 ({socket_state,gen_tcp,#Port<0.951>,<0.11697.0>}) Close session for alicE18.142936@localhost/escalus-default-resource
2019-10-23 11:18:41.539 [info] <0.11690.0>@stream_management_stale_h:clear_table:129 event=clear_table max_age=3600 deleted=1
2019-10-23 11:18:41.587 [info] <0.11904.0>@ejabberd_c2s:handle_sasl_success:3235 ({socket_state,gen_tcp,#Port<0.952>,<0.11903.0>}) Accepted authentication for alicE18.142936 by ejabberd_auth_riak
2019-10-23 11:18:41.593 [info] <0.11904.0>@ejabberd_c2s:do_resume_session:3100 event=resumption_error reason=no_previous_session_for_smid smid=<<"I83clkTYwoULUxZiRGkgNYalqLQp">>
```

TODO:
- would be nice to have test, checking that some data is still in the table after GC.
