### PR TITLE
Add a clarification about session replacement to docs

### DIFF
--- a/doc/user-guide/Features-and-supported-standards.md
+++ b/doc/user-guide/Features-and-supported-standards.md
@@ -5,7 +5,7 @@
     * **Note:** In RFC 6120 there are 3 different strategies defined in case of a session conflict (same full JID).
     They are described in [7.7.2.2. Conflict](https://tools.ietf.org/html/rfc6120#section-7.7.2.2)".
     MongooseIM always uses the 3rd option.
-    It terminates the older session with `<conflict/>` stream error.
+    It terminates the older session with a `<conflict/>` stream error.
 * XMPP Instant Messaging and Presence: [RFC 3921](https://tools.ietf.org/html/rfc3921),
 [RFC 6121](https://tools.ietf.org/html/rfc6121)
 * Client connections:

--- a/doc/user-guide/Features-and-supported-standards.md
+++ b/doc/user-guide/Features-and-supported-standards.md
@@ -2,6 +2,10 @@
 
 * XMPP Core: [RFC 3920](https://tools.ietf.org/html/rfc3920),
 [RFC 6120](https://tools.ietf.org/html/rfc6120)
+    * **Note:** In RFC 6120 there are 3 different strategies defined in case of a session conflict (same full JID).
+    They are described in "7.7.2.2. Conflict".
+    MongooseIM always uses the 3rd option.
+    It terminates the older session with `<conflict/>` stream error.
 * XMPP Instant Messaging and Presence: [RFC 3921](https://tools.ietf.org/html/rfc3921),
 [RFC 6121](https://tools.ietf.org/html/rfc6121)
 * Client connections:

--- a/doc/user-guide/Features-and-supported-standards.md
+++ b/doc/user-guide/Features-and-supported-standards.md
@@ -3,7 +3,7 @@
 * XMPP Core: [RFC 3920](https://tools.ietf.org/html/rfc3920),
 [RFC 6120](https://tools.ietf.org/html/rfc6120)
     * **Note:** In RFC 6120 there are 3 different strategies defined in case of a session conflict (same full JID).
-    They are described in "7.7.2.2. Conflict".
+    They are described in [7.7.2.2. Conflict](https://tools.ietf.org/html/rfc6120#section-7.7.2.2)".
     MongooseIM always uses the 3rd option.
     It terminates the older session with `<conflict/>` stream error.
 * XMPP Instant Messaging and Presence: [RFC 3921](https://tools.ietf.org/html/rfc3921),

--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -254,7 +254,7 @@ Users that are registered on your server can now add their accounts in a chat ap
 #### Note about session conflicts
 
 If you're going to connect several clients with the same username and domain (for example a phone and a laptop), please make sure they are using different resource names (a kind of device/client identifier).
-This should be configurable in account settings in every XMPP client.
+This should be configurable in the account settings of every XMPP client.
 
 Otherwise, the clients will keep disconnecting each other, because MongooseIM always terminates the older session in case of a conflict.
 

--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -251,6 +251,13 @@ The following steps use the registered users on the MongooseIM server, done abov
 
 Users that are registered on your server can now add their accounts in a chat application like Gajim (specifying either the server’s IP address or domain name), and start chatting!
 
+#### Note about session conflicts
+
+If you're going to connect several clients with the same username and domain, please make sure they are using different resource names (a kind of device/client identifier).
+This should be configurable in account settings in every XMPP client.
+
+Otherwise, the clients will keep disconnecting each other, because MongooseIM always terminates the older session in case of a conflict.
+
 ### Connect Gajim
 
 Gajim is available on Ubuntu, CentOS & Windows.

--- a/doc/user-guide/Getting-started.md
+++ b/doc/user-guide/Getting-started.md
@@ -253,7 +253,7 @@ Users that are registered on your server can now add their accounts in a chat ap
 
 #### Note about session conflicts
 
-If you're going to connect several clients with the same username and domain, please make sure they are using different resource names (a kind of device/client identifier).
+If you're going to connect several clients with the same username and domain (for example a phone and a laptop), please make sure they are using different resource names (a kind of device/client identifier).
 This should be configurable in account settings in every XMPP client.
 
 Otherwise, the clients will keep disconnecting each other, because MongooseIM always terminates the older session in case of a conflict.


### PR DESCRIPTION
This PR adds a note to "Features & supported standards" and "Getting started" pages about MongooseIM behaviour in case of a session collision.