### PR TITLE
Refactor jid:make/3

### DIFF
--- a/src/jid.erl
+++ b/src/jid.erl
@@ -66,28 +66,20 @@
 
 -define(SANE_LIMIT, 1024).
 
--spec make(User :: user(), Server :: server(),
-           Resource :: resource()) ->
-    jid()  | error.
-make(User, Server, Resource) ->
-    make_nodeprep(nodeprep(User), Server, Resource, {User, Server, Resource}).
-
-make_nodeprep(error, _, _, _) -> error;
-make_nodeprep(LUser,  Server, Resource, T) ->
-    make_nameprep(LUser, nameprep(Server), Resource, T).
-
-make_nameprep(_, error, _, _) -> error;
-make_nameprep(LUser,  LServer, Resource, T) ->
-    make_resourceprep(LUser, LServer, resourceprep(Resource), T).
-
-make_resourceprep(_, _, error, _) -> error;
-make_resourceprep(LUser,  LServer, LResource, {User, Server, Resource}) ->
-    #jid{user = User,
-        server = Server,
-        resource = Resource,
-        luser = LUser,
-        lserver = LServer,
-        lresource = LResource}.
+-spec make(User :: user(), Server :: server(), Res :: resource()) -> jid()  | error.
+make(User, Server, Res) ->
+    case {nodeprep(User), nameprep(Server), resourceprep(Res)} of
+        {error, _, _} -> error;
+        {_, error, _} -> error;
+        {_, _, error} -> error;
+        {LUser, LServer, LRes} ->
+            #jid{user = User,
+                 server = Server,
+                 resource = Res,
+                 luser = LUser,
+                 lserver = LServer,
+                 lresource = LRes}
+    end.
 
 -spec make(simple_jid()) ->  jid()  | error.
 make({User, Server, Resource}) ->

--- a/test/jid_SUITE.erl
+++ b/test/jid_SUITE.erl
@@ -26,7 +26,7 @@ all() -> [
          ].
 
 init_per_suite(C) ->
-    application:start(stringprep),
+    {ok, _} = application:ensure_all_started(stringprep),
     C.
 
 end_per_suite(C) ->


### PR DESCRIPTION
IMO the readability benefit outweighs the extra computation cost of 3 eager calls to build the tuple, even if one fails. All in all, I'd guess the majority of these calls are successful.