### PR TITLE
Create mogoose user stats prototype

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -11,6 +11,7 @@
 %% do not remove below SUITE if testing mongoose
 {suites, "tests", mongoose_sanity_checks_SUITE}.
 
+{suites, "tests", mongoose_user_stats_SUITE}.
 {suites, "tests", rdbms_SUITE}.
 {suites, "tests", race_conditions_SUITE}.
 {suites, "tests", acc_e2e_SUITE}.

--- a/big_tests/tests/mongoose_user_stats_SUITE.erl
+++ b/big_tests/tests/mongoose_user_stats_SUITE.erl
@@ -125,13 +125,17 @@ remove_dummy_cowboy_handler() ->
 %%--------------------------------------------------------------------
 
 handler_init(Req0, _State) ->
-    Qs = maps:get(qs, Req0),
-    Event = qs_to_event(Qs),
-    ets:insert(?ETS_TABLE, Event),
-    Req1 = cowboy_req:reply(200, #{}, <<"">>, Req0),
+    {ok, Body, Req} = cowboy_req:read_body(Req0),
+    StrEvents = string:split(Body, "\n", all),
+    lists:map(
+        fun(StrEvent) ->
+            Event = str_to_event(StrEvent),
+            ets:insert(?ETS_TABLE, Event)
+        end, StrEvents),
+    Req1 = cowboy_req:reply(200, #{}, <<"">>, Req),
     {ok, Req1, no_state}.
 
-qs_to_event(Qs) ->
+str_to_event(Qs) ->
     StrParams = string:split(Qs, "&", all),
     Params = lists:map(
         fun(StrParam) ->

--- a/big_tests/tests/mongoose_user_stats_SUITE.erl
+++ b/big_tests/tests/mongoose_user_stats_SUITE.erl
@@ -76,10 +76,10 @@ number_of_hosts_is_reported_to_google_analytics_when_mim_starts(_Config) ->
     % Restart MIM will not work, because on restart config file is read and config is reloaded,
     %  which overwrites the config and the passed option is not set
     % WHEN
-    mongoose_helper:successful_rpc(mongoose_user_stats, report_user_stats, []),
+    mongoose_helper:successful_rpc(mongoose_user_stats, report, []),
     % THEN
     mongoose_helper:wait_until(fun hosts_count_is_reported/0, true),
-    mongoose_helper:wait_until(fun hosts_count_is_reported/0, true),
+    mongoose_helper:wait_until(fun modules_are_reported/0, true),
     ok.
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/mongoose_user_stats_SUITE.erl
+++ b/big_tests/tests/mongoose_user_stats_SUITE.erl
@@ -1,0 +1,154 @@
+-module(mongoose_user_stats_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-define(COWBOY_DUMMY_HANDLER_MODULE, my_cowboy_mecked_module).
+-define(SERVER_URL, "http://localhost:8765").
+-define(ETS_TABLE, qs).
+
+-record(event, {
+    el = "",
+    cid = "",
+    ec = "",
+    ea = ""
+    }).
+
+-compile(export_all).
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+suite() ->
+    require_rpc_nodes([mim]).
+
+all() ->
+    [
+        number_of_hosts_is_reported_to_google_analytics_when_mim_starts
+    ].
+
+groups() ->
+    [].
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+-define(APPS, [inets, crypto, ssl, fusco, ranch, cowlib, cowboy]).
+
+init_per_suite(Config) ->
+    [ {ok, _} = application:ensure_all_started(App) || App <- ?APPS ],
+    create_dummy_cowboy_handler(),
+    start_cowboy(),
+    Config.
+
+end_per_suite(Config) ->
+    stop_cowboy(),
+    remove_dummy_cowboy_handler(),
+    Config.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+init_per_testcase(_CaseName, Config) ->
+    ets:new(?ETS_TABLE, [duplicate_bag, named_table, public]),
+    Args = [google_analytics_url, "http://localhost:8765?dummy=arg"],
+    {atomic, ok} = mongoose_helper:successful_rpc(ejabberd_config, add_local_option, Args),
+    Config.
+
+end_per_testcase(_CaseName, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+
+number_of_hosts_is_reported_to_google_analytics_when_mim_starts(_Config) ->
+    % Restart MIM will not work, because on restart config file is read and config is reloaded,
+    %  which overwrites the config and the passed option is not set
+    % WHEN
+    mongoose_helper:successful_rpc(mongoose_user_stats, report_user_stats, []),
+    % THEN
+    mongoose_helper:wait_until(fun hosts_count_is_reported/0, true),
+    mongoose_helper:wait_until(fun hosts_count_is_reported/0, true),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+hosts_count_is_reported() ->
+    is_in_table(<<"hosts_count">>).
+
+modules_are_reported() ->
+    is_in_table(<<"modules">>).
+
+is_in_table(EventCategory) ->
+    Tab = ets:tab2list(?ETS_TABLE),
+    lists:any(
+        fun(#event{ec = EC}) when EC == EventCategory -> true;
+        (_) -> false
+        end, Tab).
+
+start_cowboy() ->
+    Dispatch = cowboy_router:compile([
+        {'_', [{"/[...]", ?COWBOY_DUMMY_HANDLER_MODULE, []}]}
+    ]),
+    {ok, _Pid} = cowboy:start_clear(http_listener,
+                                    #{num_acceptors => 20,
+                                      socket_opts => [{port, 8765}]},
+                                    #{env => #{dispatch => Dispatch}}).
+
+stop_cowboy() ->
+    ok = cowboy:stop_listener(http_listener).
+
+create_dummy_cowboy_handler() ->
+    ok = meck:new(?COWBOY_DUMMY_HANDLER_MODULE, [non_strict, no_link]),
+    ok = meck:expect(?COWBOY_DUMMY_HANDLER_MODULE, init, fun handler_init/2),
+    ok = meck:expect(?COWBOY_DUMMY_HANDLER_MODULE, terminate, fun handler_terminate/3).
+
+remove_dummy_cowboy_handler() ->
+    true = meck:validate(?COWBOY_DUMMY_HANDLER_MODULE),
+    ok = meck:unload(?COWBOY_DUMMY_HANDLER_MODULE).
+
+%%--------------------------------------------------------------------
+%% Cowboy handlers
+%%--------------------------------------------------------------------
+
+handler_init(Req0, _State) ->
+    Qs = maps:get(qs, Req0),
+    Event = qs_to_event(Qs),
+    ets:insert(?ETS_TABLE, Event),
+    Req1 = cowboy_req:reply(200, #{}, <<"">>, Req0),
+    {ok, Req1, no_state}.
+
+qs_to_event(Qs) ->
+    StrParams = string:split(Qs, "&", all),
+    Params = lists:map(
+        fun(StrParam) ->
+            [StrKey, StrVal] = string:split(StrParam, "="),
+            {binary_to_atom(StrKey, utf8), StrVal}
+        end, StrParams),
+    #event{
+        el = get(el, Params),
+        cid = get(cid, Params),
+        ec = get(ec, Params),
+        ea = get(ea, Params)
+    }.
+
+get(Key, Proplist) ->
+    proplists:get_value(Key, Proplist, undef).
+
+handler_terminate(_Reason, _Req, _State) ->
+    ok.
+
+

--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -9,6 +9,8 @@
 {http_api_old_endpoint_port, 5293}.
 {http_api_client_endpoint_port, 8095}.
 
+{mongoose_user_stats_is_allowed, true}.
+
 %% This node is for s2s testing.
 %% "localhost" host should NOT be defined.
 {hosts, "[ \"fed1\" ]"}.

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -640,6 +640,8 @@
     ]
 }.
 
+{mongoose_user_stats_is_allowed, {{{mongoose_user_stats_is_allowed}}} }.
+
 %%%.   =======
 %%%'   MODULES
 

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -16,6 +16,8 @@
 {http_notifications_port, 8000}.
 {gd_endpoint_port, 5555}.
 
+{mongoose_user_stats_is_allowed, true}.
+
 {hosts, "[\"localhost\",
           \"anonymous.localhost\",
           \"localhost.bis\"

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -13,6 +13,8 @@
 {metrics_rest_port, 5289}.
 {gd_endpoint_port, 6666}.
 
+{mongoose_user_stats_is_allowed, true}.
+
 {hosts, "[\"localhost\",
           \"anonymous.localhost\",
           \"localhost.bis\"

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -10,6 +10,8 @@
 {http_api_endpoint_port, 8092}.
 {http_api_client_endpoint_port, 8093}.
 
+{mongoose_user_stats_is_allowed, true}.
+
 {hosts, "[\"localhost\",
           \"anonymous.localhost\",
           \"localhost.bis\"

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -13,6 +13,8 @@
 {gd_extra_endpoint_port, 10000}.
 {gd_supplementary_endpoint_port, 10001}.
 
+{mongoose_user_stats_is_allowed, true}.
+
 %% This node is for global distribution testing.
 %% reg is short for region.
 %% Both local and global hosts should be defined.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -15,6 +15,8 @@
 {http_api_old_endpoint_port, ""}.
 {http_api_client_endpoint_port, ""}.
 
+{mongoose_user_stats_is_allowed, false}.
+
 {hosts, "[\"localhost\"]"}.
 {host_config, ""}.
 {auth_ldap, ""}.

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -302,6 +302,10 @@ process_term(Term, State) ->
             add_option(cowboy_server_name, Value, State);
         {services, Value} ->
             add_option(services, Value, State);
+        {mongoose_user_stats_is_allowed, Value} ->
+            add_option(mongoose_user_stats_is_allowed, Value, State);
+        {google_analytics_url, Value} ->
+            add_option(google_analytics_url, Value, State);
         {_Opt, _Val} ->
             lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
                         State, State#state.hosts)

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -75,7 +75,7 @@ start(normal, _Args) ->
     ejabberd_admin:start(),
     update_status_file(started),
     ?INFO_MSG("ejabberd ~s is started in the node ~p", [?MONGOOSE_VERSION, node()]),
-    mongoose_user_stats:report_user_stats(),
+    mongoose_user_stats:report(),
     Sup;
 start(_, _) ->
     {error, badarg}.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -75,6 +75,7 @@ start(normal, _Args) ->
     ejabberd_admin:start(),
     update_status_file(started),
     ?INFO_MSG("ejabberd ~s is started in the node ~p", [?MONGOOSE_VERSION, node()]),
+    mongoose_user_stats:report_user_stats(),
     Sup;
 start(_, _) ->
     {error, badarg}.

--- a/src/mongoose_user_stats.erl
+++ b/src/mongoose_user_stats.erl
@@ -31,13 +31,13 @@ report_number_of_hosts(Hosts) ->
     report(hosts_count, Len).
 
 report_used_modules(Hosts) ->
-    Modules = lists:flatten(lists:map(fun gen_mod:loaded_modules/1, Hosts)),
+    ModulesWithOpts = lists:flatten(
+        lists:map(fun gen_mod:loaded_modules_with_opts/1, Hosts)),
     lists:foreach(
-        fun(Module) ->
-            % TODO extract backend for a module
-            Backend = wololo,
+        fun({Module, Opts}) ->
+            Backend = proplists:get_value(backend, Opts, none),
             report(modules, Module, Backend)
-        end, Modules).
+        end, ModulesWithOpts).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%% HELPERS %%%%%%%%%%%%%%%%%%%%%%

--- a/src/mongoose_user_stats.erl
+++ b/src/mongoose_user_stats.erl
@@ -2,51 +2,51 @@
 
 -author('aleksander.lisiecki@erlang-solutions.com').
 
-% TODO replace tid to official ESL one
--define(URL_BASE, "https://www.google-analytics.com/collect?v=1&tid=UA-151110014-1&t=event").
-
 -export([report_user_stats/0]).
 
+% TODO replace tid to official ESL one
+-define(BASE_URL, "https://www.google-analytics.com/collect?v=1&tid=UA-151110014-1&t=event").
+
 report_user_stats() ->
-    IsAllowed = ejabberd_config:get_local_option_or_default(is_report_user_stats_allowed, true),
-    report_user_stats(IsAllowed).
+    ReportUrl = ejabberd_config:get_local_option_or_default(google_analytics_url, ?BASE_URL),
+    report_user_stats(ReportUrl).
 
 % Functions are spawned and not linked, as MongooseIM should not care if they fail or not.
 % Moreover the MongooseIM's start should not be blocked.
-report_user_stats(true) ->
+report_user_stats(disable) -> ok;
+report_user_stats(ReportUrl) ->
     % Data used for more then one report
     Hosts = ejabberd_config:get_global_option(hosts),
     Reports = [
-        fun() -> report_number_of_hosts(Hosts) end,
-        fun() -> report_used_modules(Hosts) end
+        fun() -> report_number_of_hosts(Hosts, ReportUrl) end,
+        fun() -> report_used_modules(Hosts, ReportUrl) end
     ],
     lists:foreach(
         fun(Fun) ->
             spawn(Fun)
-        end, Reports);
-report_user_stats(_) -> ok.
+        end, Reports).
 
-report_number_of_hosts(Hosts) ->
+report_number_of_hosts(Hosts, ReportUrl) ->
     Len = length(Hosts),
-    report(hosts_count, Len).
+    report(ReportUrl, hosts_count, Len).
 
-report_used_modules(Hosts) ->
+report_used_modules(Hosts, ReportUrl) ->
     ModulesWithOpts = lists:flatten(
         lists:map(fun gen_mod:loaded_modules_with_opts/1, Hosts)),
     lists:foreach(
         fun({Module, Opts}) ->
             Backend = proplists:get_value(backend, Opts, none),
-            report(modules, Module, Backend)
+            report(ReportUrl, modules, Module, Backend)
         end, ModulesWithOpts).
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%%% HELPERS %%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
 
-report(EventCategory, EventAction) ->
-    report(EventCategory, EventAction, empty).
+report(ReportUrl, EventCategory, EventAction) ->
+    report(ReportUrl, EventCategory, EventAction, empty).
 
-report(EventCategory, EventAction, EventLabel) ->
+report(ReportUrl, EventCategory, EventAction, EventLabel) ->
     MaybeLabel = case EventLabel of
         empty ->
             [];
@@ -58,7 +58,7 @@ report(EventCategory, EventAction, EventLabel) ->
     LstEventCategory = term_to_string(EventCategory),
     LstEventAction = term_to_string(EventAction),
     ListUrl = [
-        ?URL_BASE,
+        ReportUrl,
         "&cid=", LstClientId,
         "&ec=", LstEventCategory,
         "&ea=", LstEventAction

--- a/src/mongoose_user_stats.erl
+++ b/src/mongoose_user_stats.erl
@@ -1,0 +1,71 @@
+-module(mongoose_user_stats).
+
+-author('aleksander.lisiecki@erlang-solutions.com').
+
+% TODO replace tid to official ESL one
+-define(URL_BASE, "https://www.google-analytics.com/collect?v=1&tid=UA-151110014-1&t=event").
+
+-export([report_user_stats/0]).
+
+% Functions are spawned and not linked, as MongooseIM should not care if they fail or not.
+% Moreover the MongooseIM's start should not be blocked.
+report_user_stats() ->
+    % Data used for more then one report
+    Hosts = ejabberd_config:get_global_option(hosts),
+    Reports = [
+    fun() -> report_number_of_hosts(Hosts) end,
+    fun() -> report_used_modules(Hosts) end
+    ],
+    lists:foreach(
+        fun(Fun) ->
+            spawn(Fun)
+        end, Reports).
+
+report_number_of_hosts(Hosts) ->
+    Len = length(Hosts),
+    report(hosts_count, Len).
+
+report_used_modules(Hosts) ->
+    Modules = gen_mod:loaded_modules(Hosts),
+    lists:foreach(
+        fun(Module) ->
+            % TODO extract backend for a module
+            Backend = wololo,
+            report(modules, Module, Backend)
+        end, Modules).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%% HELPERS %%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+report(EventCategory, EventAction) ->
+    report(EventCategory, EventAction, empty).
+
+report(EventCategory, EventAction, EventLabel) ->
+    MaybeLabel = case EventLabel of
+        empty ->
+            [];
+        AnyEventLabel ->
+            LstEventLabel = term_to_string(AnyEventLabel),
+            ["&el=", LstEventLabel]
+    end,
+    LstClientId = term_to_string(client_id()),
+    LstEventCategory = term_to_string(EventCategory),
+    LstEventAction = term_to_string(EventAction),
+    ListUrl = [
+        ?URL_BASE,
+        "&cid=", LstClientId,
+        "&ec=", LstEventCategory,
+        "&ea=", LstEventAction
+        ] ++ MaybeLabel,
+    URL = string:join(ListUrl, ""),
+    lager:debug("~p reported = ~p", [?MODULE, URL]),
+    httpc:request(URL).
+
+term_to_string(Term) ->
+    R= io_lib:format("~p",[Term]),
+    lists:flatten(R).
+
+client_id() ->
+    % TODO in the later implementation store client's ID in eg mnesia table and report stats with the same ID for the same client
+    rand:uniform(1000 * 1000 * 1000 * 1000 * 1000).


### PR DESCRIPTION
This PR creates a module reporting MongooseIM usage data to Google Analytics.

Currently reporting:
 - Number of configured hosts
 - Open source mods with backends (if configured)