### PR TITLE
[skip ci] Fix small documentation errors

### DIFF
--- a/doc/modules/mod_event_pusher_http.md
+++ b/doc/modules/mod_event_pusher_http.md
@@ -98,7 +98,7 @@ Below is an example of what the body of an HTTP POST request can look like:
 
 ## Metrics
 
-If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md** page.
+If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md) page.
 
 > **Warning:** the metrics' names may change once the deprecated `mod_http_notification` is removed from MongooseIM.
 

--- a/doc/modules/mod_offline.md
+++ b/doc/modules/mod_offline.md
@@ -21,8 +21,8 @@ Although `mod_offline` may be sufficient in some cases, it is preferable to use 
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md) page.
 
-| Backend action | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
+| Backend action | Type | Description (when it gets incremented) |
+| ---- | ---- | -------------------------------------- |
 | `pop_messages` | histogram | Offline messages for a user are retrieved and deleted from a DB. |
 | `write_messages` | histogram | New offline messages to a user are written in a DB. |
 


### PR DESCRIPTION
I stumbled upon small errors in `mod_offline` and `mod_event_pusher_http` descriptions and fixed them
