### PR TITLE
Better distributed_helper:rpc/4

### DIFF
--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -78,6 +78,33 @@ cluster_op_timeout() ->
     %% This timeout is deliberately a long one.
     timer:seconds(30).
 
+%% @doc Perform a remote call on a target node described by `RPCSpec'.
+%%
+%% You can define the spec once for multiple calls:
+%%
+%% ```
+%% -define(dh, distributed_helper).
+%%
+%% my_test(Config) ->
+%%    Spec = #{node => ?dh:mim()},
+%%    ...
+%%    ?dh:rpc(Spec, ejabberd_sm, get_full_session_list, []),
+%%    ?dh:rpc(Spec#{timeout => timer:seconds(30),
+%%            mongoose_cluster, join, [Node1])
+%%    ...
+%% '''
+%%
+%% Or inline for a quick-and-dirty hack (but don't blame me if it doesn't pass code review):
+%%
+%% ```
+%% my_test(Config) ->
+%%    ...
+%%    ?dh:rpc(#{node => mongooseim@localhost}, ejabberd_sm, get_full_session_list, []),
+%%    %% or even use an atom, but please do NOT!
+%%    ?dh:rpc(mongooseim@localhost, ejabberd_sm, get_full_session_list, []),
+%%    ...
+%% '''
+%% @end
 -spec rpc(Spec, _, _, _) -> any() when
       Spec :: rpc_spec() | node().
 rpc(Node, M, F, A) when is_atom(Node) ->

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -87,7 +87,7 @@ rpc(#{} = RPCSpec, M, F, A) ->
     Node = maps:get(node, RPCSpec),
     Cookie = maps:get(cookie, RPCSpec, erlang:get_cookie()),
     TimeOut = maps:get(timeout, RPCSpec, timer:seconds(5)),
-    case escalus_ct:rpc_call(Node, M, F, A, TimeOut, Cookie) of
+    case ct_rpc:call(Node, M, F, A, TimeOut, Cookie) of
         {badrpc, Reason} -> error({badrpc, Reason}, [RPCSpec, M, F, A]);
         Result -> Result
     end.

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -80,7 +80,7 @@ cluster_op_timeout() ->
 
 %% @doc Perform a remote call on a target node described by `RPCSpec'.
 %%
-%% You can define the spec once for multiple calls:
+%% We can define the spec once for multiple calls:
 %%
 %% ```
 %% -define(dh, distributed_helper).
@@ -94,7 +94,7 @@ cluster_op_timeout() ->
 %%    ...
 %% '''
 %%
-%% Or inline for a quick-and-dirty hack (but don't blame me if it doesn't pass code review):
+%% Or inline for a quick-and-dirty hack (but beware of code review):
 %%
 %% ```
 %% my_test(Config) ->

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -7,6 +7,8 @@
 
 -compile(export_all).
 
+-deprecated({rpc,5}).
+
 -type rpc_spec() :: #{node := node(),
                       cookie => atom(),
                       timeout => non_neg_integer()}.
@@ -91,7 +93,6 @@ rpc(#{} = RPCSpec, M, F, A) ->
     end.
 
 %% @deprecated Use rpc/4 instead.
--deprecated({rpc,5}).
 -spec rpc(Spec, _, _, _, TimeOut) -> any() when
       Spec :: rpc_spec() | node(),
       TimeOut :: non_neg_integer().


### PR DESCRIPTION
This PR ports a `distributed_helper:rpc/4` improvement from a private project. It aims to make the call target explicit, but maintains backwards compatibility to some extent by providing an extra clause and an extra arity helper.