### PR TITLE
Use rpc_spec()

### DIFF
--- a/big_tests/src/mim_loglevel.erl
+++ b/big_tests/src/mim_loglevel.erl
@@ -10,8 +10,8 @@ disable_logging(Hosts, Levels) ->
 
 set_custom(Host, Module, Level) ->
     Node = ct:get_config({hosts, Host, node}),
-    mongoose_helper:successful_rpc(Node, ejabberd_loglevel, set_custom, [Module, Level]).
+    mongoose_helper:successful_rpc(#{node => Node}, ejabberd_loglevel, set_custom, [Module, Level]).
 
 clear_custom(Host, Module, _Level) ->
     Node = ct:get_config({hosts, Host, node}),
-    mongoose_helper:successful_rpc(Node, ejabberd_loglevel, clear_custom, [Module]).
+    mongoose_helper:successful_rpc(#{node => Node}, ejabberd_loglevel, clear_custom, [Module]).

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -524,7 +524,7 @@ get_components(Opts, Config) ->
     [ {C, Opts ++ spec(C, Config)} || C <- Components ] ++ Config.
 
 add_domain(Config) ->
-    Node = default_node(Config),
+    Node = default_node(),
     Hosts = {hosts, "[\"localhost\", \"sogndal\"]"},
     backup_ejabberd_config_file(Node, Config),
     ejabberd_node_utils:modify_config_file([Hosts], Config),
@@ -532,7 +532,7 @@ add_domain(Config) ->
     ok.
 
 restore_domain(Config) ->
-    Node = default_node(Config),
+    Node = default_node(),
     restore_ejabberd_config_file(Node, Config),
     restart_ejabberd_node(Node),
     Config.
@@ -547,7 +547,5 @@ cluster_users() ->
     AllUsers = ct:get_config(escalus_users),
     [proplists:lookup(alice, AllUsers), proplists:lookup(clusterguy, AllUsers)].
 
-default_node(Config) ->
-    Node = ct:get_config({hosts, mim, node}),
-    Node == undefined andalso error(node_undefined, [Config]),
-    Node.
+default_node() ->
+    distributed_helper:mim().

--- a/big_tests/tests/conf_reload_SUITE.erl
+++ b/big_tests/tests/conf_reload_SUITE.erl
@@ -190,7 +190,5 @@ delete_user(User, Config) ->
     {User, UserSpec} = escalus_users:get_user_by_name(User),
     escalus_users:delete_user(Config, {User, UserSpec}).
 
-default_node(Config) ->
-    Node = ct:get_config({hosts, mim, node}),
-    Node == undefined andalso error(node_undefined, [Config]),
-    Node.
+default_node(_Config) ->
+    mim().

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -13,6 +13,8 @@
                       cookie => atom(),
                       timeout => non_neg_integer()}.
 
+-export_type([rpc_spec/0]).
+
 is_sm_distributed() ->
     Backend = rpc(mim(), ejabberd_sm_backend, backend, []),
     is_sm_backend_distributed(Backend).
@@ -26,7 +28,8 @@ add_node_to_cluster(Config) ->
 
 add_node_to_cluster(Node, Config) ->
     ClusterMemberNode = maps:get(node, mim()),
-    ok = rpc(Node, mongoose_cluster, join, [ClusterMemberNode], cluster_op_timeout()),
+    ok = rpc(Node#{timeout => cluster_op_timeout()},
+             mongoose_cluster, join, [ClusterMemberNode]),
     verify_result(Node, add),
     Config.
 
@@ -35,7 +38,7 @@ remove_node_from_cluster(_Config) ->
     remove_node_from_cluster(Node, _Config).
 
 remove_node_from_cluster(Node, _Config) ->
-    ok = rpc(Node, mongoose_cluster, leave, [], cluster_op_timeout()),
+    ok = rpc(Node#{timeout => cluster_op_timeout()}, mongoose_cluster, leave, []),
     verify_result(Node, remove),
     ok.
 

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -25,8 +25,8 @@ add_node_to_cluster(Config) ->
     add_node_to_cluster(Node2, Config).
 
 add_node_to_cluster(Node, Config) ->
-    ClusterMember = mim(),
-    ok = rpc(Node, mongoose_cluster, join, [ClusterMember], cluster_op_timeout()),
+    ClusterMemberNode = maps:get(node, mim()),
+    ok = rpc(Node, mongoose_cluster, join, [ClusterMemberNode], cluster_op_timeout()),
     verify_result(Node, add),
     Config.
 
@@ -62,13 +62,13 @@ do_verify_result(Node, Op) ->
               {VerifyNode, DbNodes1, should_belong(Op)},
               {Node, DbNodes1, true},
               {VerifyNode, DbNodes2, true}],
-    Results = [case lists:member(Element, List) of
+    Results = [case lists:member(maps:get(node, CurrentNode), RunningNodes) of
                    ShouldBelong ->
                        [];
                    _ ->
                        ct:log("~p has ~p~n~p has ~p~n", [Node, DbNodes1, VerifyNode, DbNodes2]),
                        [Check]
-               end || Check = {Element, List, ShouldBelong} <- Checks],
+               end || Check = {CurrentNode, RunningNodes, ShouldBelong} <- Checks],
     lists:append(Results).
 
 should_belong(add) -> true;

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -103,17 +103,11 @@ cluster_op_timeout() ->
 %% my_test(Config) ->
 %%    ...
 %%    ?dh:rpc(#{node => mongooseim@localhost}, ejabberd_sm, get_full_session_list, []),
-%%    %% or even use an atom, but please do NOT!
-%%    ?dh:rpc(mongooseim@localhost, ejabberd_sm, get_full_session_list, []),
 %%    ...
 %% '''
 %% @end
 -spec rpc(Spec, _, _, _) -> any() when
-      Spec :: rpc_spec() | node().
-rpc(Node, M, F, A) when is_atom(Node) ->
-    % TODO: review once https://github.com/esl/MongooseIM/pull/2533 is done
-    % ct:pal("rpc/4: use RPCSpec :: #{node := Node} instead of just Node :: atom()"),
-    rpc(#{node => Node}, M, F, A);
+      Spec :: rpc_spec().
 rpc(#{} = RPCSpec, M, F, A) ->
     Node = maps:get(node, RPCSpec),
     Cookie = maps:get(cookie, RPCSpec, erlang:get_cookie()),

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -59,16 +59,16 @@ do_verify_result(Node, Op) ->
     DbNodes1 = rpc(Node, mnesia, system_info, [running_db_nodes]),
     DbNodes2 = rpc(VerifyNode, mnesia, system_info, [running_db_nodes]),
     Checks = [{Node, DbNodes2, should_belong(Op)},
-        {VerifyNode, DbNodes1, should_belong(Op)},
-        {Node, DbNodes1, true},
-        {VerifyNode, DbNodes2, true}],
+              {VerifyNode, DbNodes1, should_belong(Op)},
+              {Node, DbNodes1, true},
+              {VerifyNode, DbNodes2, true}],
     Results = [case lists:member(Element, List) of
-         ShouldBelong ->
-             [];
-         _ ->
-             ct:log("~p has ~p~n~p has ~p~n", [Node, DbNodes1, VerifyNode, DbNodes2]),
-             [Check]
-     end || Check = {Element, List, ShouldBelong} <- Checks],
+                   ShouldBelong ->
+                       [];
+                   _ ->
+                       ct:log("~p has ~p~n~p has ~p~n", [Node, DbNodes1, VerifyNode, DbNodes2]),
+                       [Check]
+               end || Check = {Element, List, ShouldBelong} <- Checks],
     lists:append(Results).
 
 should_belong(add) -> true;

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -153,18 +153,22 @@ require_rpc_nodes(Nodes) ->
     [ {require, {hosts, Node, node}} || Node <- Nodes ].
 
 %% @doc Shorthand for hosts->mim->node from `test.config'.
+-spec mim() -> rpc_spec().
 mim() ->
-    get_or_fail({hosts, mim, node}).
+    #{node => get_or_fail({hosts, mim, node})}.
 
+-spec mim2() -> rpc_spec().
 mim2() ->
-    get_or_fail({hosts, mim2, node}).
+    #{node => get_or_fail({hosts, mim2, node})}.
 
+-spec mim3() -> rpc_spec().
 mim3() ->
-    get_or_fail({hosts, mim3, node}).
+    #{node => get_or_fail({hosts, mim3, node})}.
 
 %% @doc Shorthand for hosts->fed->node from `test.config'.
+-spec fed() -> rpc_spec().
 fed() ->
-    get_or_fail({hosts, fed, node}).
+    #{node => get_or_fail({hosts, fed, node})}.
 
 get_or_fail(Key) ->
     Val = ct:get_config(Key),

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -7,8 +7,6 @@
 
 -compile(export_all).
 
--deprecated({rpc,5}).
-
 -type rpc_spec() :: #{node := node(),
                       cookie => atom(),
                       timeout => non_neg_integer()}.
@@ -116,16 +114,6 @@ rpc(#{} = RPCSpec, M, F, A) ->
         {badrpc, Reason} -> error({badrpc, Reason}, [RPCSpec, M, F, A]);
         Result -> Result
     end.
-
-%% @deprecated Use rpc/4 instead.
--spec rpc(Spec, _, _, _, TimeOut) -> any() when
-      Spec :: rpc_spec() | node(),
-      TimeOut :: non_neg_integer().
-rpc(Node, M, F, A, TimeOut) ->
-    RPCSpec = #{node => Node,
-                cookie => ct:get_config(ejabberd_cookie),
-                timeout => TimeOut},
-    rpc(RPCSpec, M, F, A).
 
 %% @doc Require nodes defined in `test.config' for later convenient RPCing into.
 %%

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -42,6 +42,8 @@ stop(Domain, Mod) ->
     Node = escalus_ct:get_config(ejabberd_node),
     stop(Node, Domain, Mod).
 
+stop(#{node := Node}, Domain, Mod) ->
+    stop(Node, Domain, Mod);
 stop(Node, Domain, Mod) ->
     Cookie = escalus_ct:get_config(ejabberd_cookie),
     IsLoaded = escalus_rpc:call(Node, gen_mod, is_loaded, [Domain, Mod], 5000, Cookie),
@@ -61,6 +63,8 @@ start(Domain, Mod, Args) ->
     Node = escalus_ct:get_config(ejabberd_node),
     start(Node, Domain, Mod, Args).
 
+start(#{node := Node}, Domain, Mod, Args) ->
+    start(Node, Domain, Mod, Args);
 start(Node, Domain, Mod, Args) ->
     Cookie = escalus_ct:get_config(ejabberd_cookie),
     case escalus_rpc:call(Node, gen_mod, start_module, [Domain, Mod, Args], 5000, Cookie) of

--- a/big_tests/tests/ejabberd_node_utils.erl
+++ b/big_tests/tests/ejabberd_node_utils.erl
@@ -103,9 +103,10 @@ call_fun(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),
     call_fun(Node, M, F, A).
 
--spec call_fun(node(), module(), atom(), []) -> term() | {badrpc, term()}.
+-spec call_fun(distributed_helper:rpc_spec() | node(), module(), atom(), []) ->
+    term() | {badrpc, term()}.
 call_fun(Node, M, F, A) ->
-    rpc:call(Node, M, F, A).
+    distributed_helper:rpc(Node, M, F, A).
 
 %% @doc Calls the mongooseimctl script with given command `Cmd'.
 %%
@@ -186,8 +187,8 @@ get_cwd(Node, Config) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 
-set_ejabberd_node_cwd(Node, Config) ->
-    {ok, Cwd} = call_fun(Node, file, get_cwd, []),
+set_ejabberd_node_cwd(#{node := Node} = RPCSpec, Config) ->
+    {ok, Cwd} = call_fun(RPCSpec, file, get_cwd, []),
     [{{ejabberd_cwd, Node}, Cwd} | Config].
 
 update_config_variables(CfgVarsToChange, CfgVars) ->

--- a/big_tests/tests/ejabberd_node_utils.erl
+++ b/big_tests/tests/ejabberd_node_utils.erl
@@ -17,16 +17,16 @@
 -module(ejabberd_node_utils).
 
 -export([init/1, init/2,
-    node_cwd/2,
-    restart_application/1, restart_application/2,
-    call_fun/3, call_fun/4,
-    call_ctl/2, call_ctl/3,
-    call_ctl_with_args/3,
-    file_exists/1, file_exists/2,
-    backup_config_file/1, backup_config_file/2,
-    restore_config_file/1, restore_config_file/2,
-    modify_config_file/2, modify_config_file/4,
-    get_cwd/2]).
+         node_cwd/2,
+         restart_application/1, restart_application/2,
+         call_fun/3, call_fun/4,
+         call_ctl/2, call_ctl/3,
+         call_ctl_with_args/3,
+         file_exists/1, file_exists/2,
+         backup_config_file/1, backup_config_file/2,
+         restore_config_file/1, restore_config_file/2,
+         modify_config_file/2, modify_config_file/4,
+         get_cwd/2]).
 
 -include_lib("common_test/include/ct.hrl").
 

--- a/big_tests/tests/ejabberd_node_utils.erl
+++ b/big_tests/tests/ejabberd_node_utils.erl
@@ -56,7 +56,7 @@ ctl_path(Node, Config) ->
 
 -spec init(ct_config()) -> ct_config().
 init(Config) ->
-    Node = ct:get_config({hosts, mim, node}),
+    Node = distributed_helper:mim(),
     init(Node, Config).
 
 init(Node, Config) ->
@@ -69,8 +69,8 @@ node_cwd(Node, Config) ->
 
 -spec restart_application(atom()) -> ok.
 restart_application(ApplicationName) ->
-    Node = ct:get_config({hosts, mim, node}),
-    restart_application(Node, ApplicationName).
+    Node = distributed_helper:mim(),
+    restart_application(Node#{timeout => timer:seconds(30)}, ApplicationName).
 
 -spec restart_application(node(), atom()) -> ok.
 restart_application(Node, ApplicationName) ->
@@ -100,7 +100,7 @@ restore_config_file(Node, Config) ->
 
 -spec call_fun(module(), atom(), []) -> term() | {badrpc, term()}.
 call_fun(M, F, A) ->
-    Node = ct:get_config({hosts, mim, node}),
+    Node = distributed_helper:mim(),
     call_fun(Node, M, F, A).
 
 -spec call_fun(distributed_helper:rpc_spec() | node(), module(), atom(), []) ->

--- a/big_tests/tests/ejabberdctl_helper.erl
+++ b/big_tests/tests/ejabberdctl_helper.erl
@@ -19,7 +19,7 @@
 -spec ejabberdctl(Cmd :: string(), Args :: [binary() | string()], Config :: list()) ->
     {Data :: iolist(), ExitStatus :: integer()} | no_return().
 ejabberdctl(Cmd, Args, Config) ->
-    Node = mim(),
+    #{node := Node} = mim(),
     ejabberdctl(Node, Cmd, Args, Config).
 
 ejabberdctl(Node, Cmd, Args, Config) ->

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -339,9 +339,11 @@ get_diffs(L1, L2) ->
     lists:zip(L1, L2).
 
 ensure_nodes_not_clustered(Config) ->
-    Nodes1 = rpc(mim(), mnesia, system_info, [running_db_nodes]),
-    Nodes = [Node || Node <- Nodes1, Node =/= mim()],
-    [distributed_helper:remove_node_from_cluster(N, Config) || N <- Nodes],
+    #{node := Node1Name} = RPCNode = mim(),
+    Nodes1 = rpc(RPCNode, mnesia, system_info, [running_db_nodes]),
+
+    Nodes = [Node || Node <- Nodes1, Node =/= Node1Name],
+    [distributed_helper:remove_node_from_cluster(#{node => N}, Config) || N <- Nodes],
     Config ++ [{nodes_clustered, Nodes}].
 
 ensure_nodes_clustered(Config) ->

--- a/big_tests/tests/mongoose_cassandra_SUITE.erl
+++ b/big_tests/tests/mongoose_cassandra_SUITE.erl
@@ -22,7 +22,7 @@
 
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
-                             rpc/5]).
+                             rpc/4]).
 
 %%.
 %%' Preprocessor directives
@@ -244,7 +244,8 @@ call(F, A) ->
     call(mongoose_cassandra, F, A).
 
 call(M, F, A) ->
-    rpc(mim(), M, F, A, timer:minutes(1)).
+    RPCSpec = mim(),
+    rpc(RPCSpec#{timeout => timer:minutes(1)}, M, F, A).
 
 cql_args(Config, Args) ->
     [?config(pool, Config), undefined, ?MODULE | Args].

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -33,9 +33,7 @@
 -export([wait_for_pid_to_die/1]).
 -export([supports_sasl_module/1]).
 
--import(distributed_helper, [mim/0,
-                             rpc/4,
-                             rpc/5]).
+-import(distributed_helper, [mim/0, rpc/4]).
 
 -spec is_rdbms_enabled(Host :: binary()) -> boolean().
 is_rdbms_enabled(Host) ->
@@ -224,13 +222,21 @@ forget_persistent_rooms() ->
 successful_rpc(Module, Function, Args) ->
     successful_rpc(mim(), Module, Function, Args).
 
--spec successful_rpc(Node :: atom(), M :: module(), F :: atom(), A :: list()) -> term().
-successful_rpc(Node, Module, Function, Args) ->
-    successful_rpc(Node, Module, Function, Args, timer:seconds(5)).
+-spec successful_rpc(Spec, M, F, A) -> term() when
+      Spec :: distributed_helper:rpc_spec(),
+      M :: module(),
+      F :: atom(),
+      A :: list().
+successful_rpc(#{} = Spec, Module, Function, Args) ->
+    successful_rpc(Spec, Module, Function, Args, timer:seconds(5)).
 
--spec successful_rpc(Node :: atom(), M :: module(), F :: atom(), A :: list(), timeout()) -> term().
-successful_rpc(Node, Module, Function, Args, Timeout) ->
-    case rpc(Node, Module, Function, Args, Timeout) of
+-spec successful_rpc(Spec, M, F, A, timeout()) -> term() when
+      Spec :: distributed_helper:rpc_spec(),
+      M :: module(),
+      F :: atom(),
+      A :: list().
+successful_rpc(#{} = Spec, Module, Function, Args, Timeout) ->
+    case rpc(Spec#{timeout => Timeout}, Module, Function, Args) of
         {badrpc, Reason} ->
             ct:fail({badrpc, Module, Function, Args, Reason});
         Result ->
@@ -238,7 +244,7 @@ successful_rpc(Node, Module, Function, Args, Timeout) ->
     end.
 
 logout_user(Config, User) ->
-    Node = ct:get_config({hosts, mim, node}),
+    Node = distributed_helper:mim(),
     logout_user(Config, User, Node).
 
 %% This function is a version of escalus_client:stop/2

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -316,7 +316,7 @@ wait_for_user(Config, User, LeftTime) ->
     mongoose_helper:wait_until(fun() ->
                                 escalus_users:verify_creation(escalus_users:create_user(Config, User))
                                end, ok,
-							   #{
+                               #{
                                  sleep_time => 400,
                                  left_time => LeftTime,
                                  name => 'escalus_users:create_user'

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -8,7 +8,6 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 
--import(escalus_ejabberd, [rpc/3]).
 -import(distributed_helper, [mim/0,
                              rpc/4,
                              rpc/5]).
@@ -248,7 +247,8 @@ stanza_aff_set(Room, AffUsers) ->
     escalus_stanza:to(escalus_stanza:iq_set(?NS_MUC_LIGHT_AFFILIATIONS, Items), room_bin_jid(Room)).
 
 clear_db() ->
-    rpc(mim(), mod_muc_light_db_backend, force_clear, [], timer:seconds(15)).
+    Node = mim(),
+    rpc(Node#{timeout => timer:seconds(15)}, mod_muc_light_db_backend, force_clear, []).
 
 -spec ver(Int :: integer()) -> binary().
 ver(Int) ->
@@ -256,5 +256,5 @@ ver(Int) ->
 
 -spec set_mod_config(K :: atom(), V :: any(), Host :: binary()) -> ok.
 set_mod_config(K, V, Host) ->
-        true = rpc(gen_mod, set_module_opt_by_subhost, [Host, mod_muc_light, K, V]).
+        true = rpc(mim(), gen_mod, set_module_opt_by_subhost, [Host, mod_muc_light, K, V]).
 

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -9,8 +9,7 @@
 -include_lib("escalus/include/escalus_xmlns.hrl").
 
 -import(distributed_helper, [mim/0,
-                             rpc/4,
-                             rpc/5]).
+                             rpc/4]).
 
 -type ct_aff_user() :: {EscalusClient :: escalus:client(), Aff :: atom()}.
 -type ct_aff_users() :: [ct_aff_user()].

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -136,10 +136,11 @@ cluster_id_is_restored_to_mnesia_from_rdbms_if_mnesia_lost(_Config) ->
     %%  it stops the node, deletes everything related to mnesia from the system,
     %%  the hardcore way, removing folders from the OS and so on, and restarts the node.
     %%  Assuming this works correctly, then we can be sure that "mnesia files were lost".
+    Node = mim(),
     ok = distributed_helper:rpc(
-           mim(), mongoose_cluster, leave, [], timer:seconds(30)),
+           Node#{timeout => timer:seconds(30)}, mongoose_cluster, leave, []),
     {ok, SecondID} = mongoose_helper:successful_rpc(
-               mim(), mongoose_cluster_id, get_cached_cluster_id, []),
+               Node, mongoose_cluster_id, get_cached_cluster_id, []),
     ?assertEqual(FirstID, SecondID).
 
 

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -18,7 +18,7 @@
     disable_stanza/1, disable_stanza/2, become_unavailable/1
 ]).
 
--define(RPC_SPEC, #{node => distributed_helper:mim()}).
+-define(RPC_SPEC, distributed_helper:mim()).
 -define(SESSION_KEY, publish_service).
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -8,7 +8,7 @@
 -include_lib("inbox.hrl").
 
 -define(MUCLIGHTHOST, <<"muclight.localhost">>).
--define(RPC_SPEC, #{node => distributed_helper:mim()}).
+-define(RPC_SPEC, distributed_helper:mim()).
 -define(SESSION_KEY, publish_service).
 
 -import(muc_light_helper,

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -126,7 +126,7 @@ delete(Role, Path, Cred, Body) ->
 -spec make_request(request_params()) ->
     {{Number :: binary(), Text :: binary()},
      Headers :: [{binary(), binary()}],
-     Body :: map() | binary()}. 
+     Body :: map() | binary()}.
 make_request(#{ return_headers := true } = Params) ->
     NormalizedParams = normalize_path(normalize_body(fill_default_server(Params))),
     case fusco_request(NormalizedParams) of
@@ -191,9 +191,9 @@ fusco_request(Method, Path, Body, HeadersIn, Port, SSL) ->
     fusco_cp:stop(Client),
     Result.
 
--spec get_port(Role :: role(), Server :: atom()) -> Port :: integer().
-get_port(Role, Server) ->
-    Listeners = rpc(#{node => Server}, ejabberd_config, get_local_option, [listen]),
+-spec get_port(Role :: role(), Server :: distributed_helper:rpc_spec()) -> Port :: integer().
+get_port(Role, Node) ->
+    Listeners = rpc(Node, ejabberd_config, get_local_option, [listen]),
     [{PortIpNet, ejabberd_cowboy, _Opts}] =
         lists:filter(fun(Config) -> is_roles_config(Config, Role) end, Listeners),
     case PortIpNet of
@@ -202,9 +202,9 @@ get_port(Role, Server) ->
         Port -> Port
     end.
 
--spec get_ssl_status(Role :: role(), Server :: atom()) -> boolean().
-get_ssl_status(Role, Server) ->
-    Listeners = rpc(#{node => Server}, ejabberd_config, get_local_option, [listen]),
+-spec get_ssl_status(Role :: role(), Server :: distributed_helper:rpc_spec()) -> boolean().
+get_ssl_status(Role, Node) ->
+    Listeners = rpc(Node, ejabberd_config, get_local_option, [listen]),
     [{_PortIpNet, _Module, Opts}] =
         lists:filter(fun (Opts) -> is_roles_config(Opts, Role) end, Listeners),
     lists:keymember(ssl, 1, Opts).

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -192,8 +192,8 @@ fusco_request(Method, Path, Body, HeadersIn, Port, SSL) ->
     Result.
 
 -spec get_port(Role :: role(), Server :: atom()) -> Port :: integer().
-get_port(Role, Server) -> 
-    Listeners = rpc(Server, ejabberd_config, get_local_option, [listen]),
+get_port(Role, Server) ->
+    Listeners = rpc(#{node => Server}, ejabberd_config, get_local_option, [listen]),
     [{PortIpNet, ejabberd_cowboy, _Opts}] =
         lists:filter(fun(Config) -> is_roles_config(Config, Role) end, Listeners),
     case PortIpNet of
@@ -204,7 +204,7 @@ get_port(Role, Server) ->
 
 -spec get_ssl_status(Role :: role(), Server :: atom()) -> boolean().
 get_ssl_status(Role, Server) ->
-    Listeners = rpc(Server, ejabberd_config, get_local_option, [listen]),
+    Listeners = rpc(#{node => Server}, ejabberd_config, get_local_option, [listen]),
     [{_PortIpNet, _Module, Opts}] =
         lists:filter(fun (Opts) -> is_roles_config(Opts, Role) end, Listeners),
     lists:keymember(ssl, 1, Opts).

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -12,6 +12,9 @@
 -include_lib("exml/include/exml_stream.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+%% Module aliases
+-define(dh, distributed_helper).
+
 %%%===================================================================
 %%% Suite configuration
 %%%===================================================================
@@ -141,13 +144,12 @@ timeout_waiting_for_message(Config) ->
 
 connections_info(Config) ->
     simple_message(Config),
-    Node = ct:get_config({hosts, mim, node}),
     FedDomain = ct:get_config({hosts, fed, domain}),
-    S2SIn = distributed_helper:rpc(Node, ejabberd_s2s, get_info_s2s_connections, [in]),
+    S2SIn = ?dh:rpc(?dh:mim(), ejabberd_s2s, get_info_s2s_connections, [in]),
     ct:pal("S2sIn: ~p", [S2SIn]),
     true = lists:any(fun(PropList) -> [FedDomain] =:= proplists:get_value(domains, PropList) end,
                      S2SIn),
-    S2SOut = distributed_helper:rpc(Node, ejabberd_s2s, get_info_s2s_connections, [out]),
+    S2SOut = ?dh:rpc(?dh:mim(), ejabberd_s2s, get_info_s2s_connections, [out]),
     ct:pal("S2sOut: ~p", [S2SOut]),
     true = lists:any(fun(PropList) -> FedDomain =:= proplists:get_value(server, PropList) end,
                      S2SOut),

--- a/big_tests/tests/s2s_helper.erl
+++ b/big_tests/tests/s2s_helper.erl
@@ -99,7 +99,7 @@ configure_s2s(node1_tls_optional_node2_tls_required_trusted_with_cachain, Config
     S2S = ?config(s2s_opts, Config),
     {S2SPortIPProto, Mod, Opts} = S2S#s2s_opts.node2_s2s_listener,
     CACertFile = filename:join([path_helper:repo_dir(Config),
-				"tools", "ssl", "ca", "cacert.pem"]),
+                                "tools", "ssl", "ca", "cacert.pem"]),
     NewOpts = [{cafile, CACertFile} | Opts],
     configure_s2s(S2S#s2s_opts{node2_s2s_use_starttls = required_trusted,
                                node2_s2s_listener = {S2SPortIPProto, Mod, NewOpts}

--- a/big_tests/tests/s2s_helper.erl
+++ b/big_tests/tests/s2s_helper.erl
@@ -7,7 +7,7 @@
 -import(distributed_helper, [fed/0,
                              mim/0,
                              require_rpc_nodes/1,
-                             rpc/4, rpc/5]).
+                             rpc/4]).
 
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -114,30 +114,30 @@ configure_s2s(#s2s_opts{node1_s2s_certfile = Certfile1,
     configure_s2s(fed(), Certfile2, StartTLS2),
     restart_s2s(S2SOpts).
 
-configure_s2s(Node, Certfile, StartTLS) ->
-    rpc(Node, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
-    rpc(Node, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
+configure_s2s(#{} = Spec, Certfile, StartTLS) ->
+    rpc(Spec, ejabberd_config, add_local_option, [s2s_certfile, Certfile]),
+    rpc(Spec, ejabberd_config, add_local_option, [s2s_use_starttls, StartTLS]).
 
 restart_s2s(#s2s_opts{node1_s2s_listener = Node1S2SListener,
                       node2_s2s_listener = Node2S2SListener}) ->
     restart_s2s(mim(), Node1S2SListener),
     restart_s2s(fed(), Node2S2SListener).
 
-restart_s2s(Node, S2SListener) ->
-    Children = rpc(Node, supervisor, which_children, [ejabberd_s2s_out_sup]),
-    [rpc(Node, ejabberd_s2s_out, stop_connection, [Pid]) ||
+restart_s2s(#{} = Spec, S2SListener) ->
+    Children = rpc(Spec, supervisor, which_children, [ejabberd_s2s_out_sup]),
+    [rpc(Spec, ejabberd_s2s_out, stop_connection, [Pid]) ||
      {_, Pid, _, _} <- Children],
 
-    ChildrenIn = rpc(Node, supervisor, which_children, [ejabberd_s2s_in_sup]),
-    [rpc(Node, erlang, exit, [Pid, kill]) ||
+    ChildrenIn = rpc(Spec, supervisor, which_children, [ejabberd_s2s_in_sup]),
+    [rpc(Spec, erlang, exit, [Pid, kill]) ||
      {_, Pid, _, _} <- ChildrenIn],
 
     {PortIPProto, ejabberd_s2s_in, Opts} = S2SListener,
 
-    rpc(Node, ejabberd_listener, stop_listener, [PortIPProto, ejabberd_s2s_in]),
-    rpc(Node, ejabberd_listener, start_listener, [PortIPProto, ejabberd_s2s_in, Opts]).
+    rpc(Spec, ejabberd_listener, stop_listener, [PortIPProto, ejabberd_s2s_in]),
+    rpc(Spec, ejabberd_listener, start_listener, [PortIPProto, ejabberd_s2s_in, Opts]).
 
-get_listener_opts(Node, Port) ->
-    Listeners = rpc(Node, ejabberd_config, get_local_option, [listen]),
+get_listener_opts(#{} = Spec, Port) ->
+    Listeners = rpc(Spec, ejabberd_config, get_local_option, [listen]),
 
     [Item || {{ListenerPort, _, _}, _, _} = Item <- Listeners, ListenerPort =:= Port].


### PR DESCRIPTION
This PR refactors big tests to use `rpc_spec()` instances for specifying RPC call targets.