### PR TITLE
Better MUC light room config

### DIFF
--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -1107,10 +1107,11 @@ set_default_mod_config() ->
 
 -spec set_custom_config(RawSchema :: list(), RawDefaultConfig :: list()) -> true.
 set_custom_config(RawSchema, RawDefaultConfig) ->
-    ConfigSchema = rpc(mod_muc_light_utils, make_config_schema, [RawSchema]),
+    ConfigSchema = rpc(mod_muc_light_room_config, make_config_schema, [RawSchema]),
     _ = hd(ConfigSchema), %% checks if is a list
 
-    DefaultConfig = rpc(mod_muc_light_utils, make_default_config, [RawDefaultConfig, ConfigSchema]),
+    DefaultConfig = rpc(mod_muc_light_room_config, make_default_config,
+                        [RawDefaultConfig, ConfigSchema]),
     _ = hd(DefaultConfig), %% checks if is a list
 
     set_mod_config(config_schema, ConfigSchema, ?MUCHOST),

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -6,7 +6,6 @@
 -include_lib("exml/include/exml.hrl").
 
 -export([ % service
-         mismatched_default_config_is_rejected/1,
          removing_users_from_server_triggers_room_destruction/1
         ]).
 -export([ % entity
@@ -30,7 +29,6 @@
          all_can_configure/1,
          set_config_deny/1,
          get_room_config/1,
-         custom_schema_works_with_standard_default_config/1,
          custom_default_config_works/1,
          get_room_occupants/1,
          get_room_info/1,
@@ -75,7 +73,6 @@
 -import(muc_helper, [foreach_occupant/3, foreach_recipient/2]).
 -import(muc_light_helper, [
                            bin_aff_users/1,
-                           aff_msg_verify_fun/1,
                            gc_message_verify_fun/3,
                            lbin/1,
                            room_bin_jid/1,
@@ -83,7 +80,6 @@
                            verify_aff_bcast/3,
                            verify_aff_users/2,
                            kv_el/2,
-                           to_lus/2,
                            stanza_create_room/3,
                            create_room/6,
                            stanza_aff_set/2,
@@ -127,7 +123,6 @@ all() ->
 groups() ->
     G = [
          {service, [sequence], [
-                                mismatched_default_config_is_rejected,
                                 removing_users_from_server_triggers_room_destruction
                                ]},
          {entity, [sequence], [
@@ -151,7 +146,6 @@ groups() ->
                                  all_can_configure,
                                  set_config_deny,
                                  get_room_config,
-                                 custom_schema_works_with_standard_default_config,
                                  custom_default_config_works,
                                  get_room_occupants,
                                  get_room_info,
@@ -219,8 +213,7 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 -define(ROOM_LESS_CASES, [disco_rooms_empty_page_infinity,
-                          disco_rooms_empty_page_1,
-                          mismatched_default_config_is_rejected]).
+                          disco_rooms_empty_page_1]).
 
 -define(CUSTOM_CONFIG_CASES, [set_config_with_custom_schema,
                               deny_config_change_that_conflicts_with_schema,
@@ -238,20 +231,11 @@ init_per_testcase(disco_rooms_rsm, Config) ->
     create_room(?ROOM, ?MUCHOST, alice, [bob, kate], Config, ver(1)),
     create_room(?ROOM2, ?MUCHOST, alice, [bob, kate], Config, ver(1)),
     escalus:init_per_testcase(disco_rooms_rsm, Config);
-init_per_testcase(custom_schema_works_with_standard_default_config = CaseName, Config) ->
-    set_default_mod_config(),
-    set_custom_config(["roomname", "subject", "background", "music"], standard_default_config()),
-    create_room(?ROOM, ?MUCHOST, alice, [bob, kate], Config, ver(1)),
-    escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) ->
     set_default_mod_config(),
     case lists:member(CaseName, ?CUSTOM_CONFIG_CASES) of
-        true ->
-            CustomDefaultConfig = [{atom_to_list(K), binary_to_list(V)}
-                                   || {K, V} <- custom_default_config()],
-            set_custom_config(["background", "music"], CustomDefaultConfig);
-        _ ->
-            ok
+        true -> set_custom_config(common_custom_config());
+        _ -> ok
     end,
     case lists:member(CaseName, ?ROOM_LESS_CASES) of
         false -> create_room(?ROOM, ?MUCHOST, alice, [bob, kate], Config, ver(1));
@@ -260,9 +244,8 @@ init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
 end_per_testcase(CaseName, Config) ->
-    case lists:member(
-           CaseName, [custom_schema_works_with_standard_default_config | ?CUSTOM_CONFIG_CASES]) of
-        true -> set_custom_config(standard_config_schema(), standard_default_config());
+    case lists:member(CaseName, ?CUSTOM_CONFIG_CASES) of
+        true -> set_custom_config(default_schema_definition());
         _ -> ok
     end,
     muc_light_helper:clear_db(),
@@ -273,11 +256,6 @@ end_per_testcase(CaseName, Config) ->
 %%--------------------------------------------------------------------
 
 %% ---------------------- Service ----------------------
-
-mismatched_default_config_is_rejected(_Config) ->
-    {'EXIT', _} = (catch set_custom_config(["background", "music"], standard_default_config())),
-    {'EXIT', _} = (catch set_custom_config(["background", "music"], ["misfit"])),
-    ok.
 
 removing_users_from_server_triggers_room_destruction(Config) ->
     escalus:delete_users(Config, escalus:get_users([carol])),
@@ -498,9 +476,8 @@ set_config_deny(Config) ->
 get_room_config(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
             Stanza = stanza_config_get(?ROOM, <<"oldver">>),
-            ConfigKV = [{version, ver(1)} | default_config()],
-            ConfigKVBin = [{list_to_binary(atom_to_list(Key)), Val} || {Key, Val} <- ConfigKV],
-            foreach_occupant([Alice, Bob, Kate], Stanza, config_iq_verify_fun(ConfigKVBin)),
+            ConfigKV = [{"version", binary_to_list(ver(1))} | standard_default_config()],
+            foreach_occupant([Alice, Bob, Kate], Stanza, config_iq_verify_fun(ConfigKV)),
 
             %% Empty result when user has most recent version
             escalus:send(Bob, stanza_config_get(?ROOM, ver(1))),
@@ -509,20 +486,11 @@ get_room_config(Config) ->
             undefined = exml_query:subelement(IQRes, <<"query">>)
         end).
 
-custom_schema_works_with_standard_default_config(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
-            Stanza = stanza_config_get(?ROOM, <<"oldver">>),
-            ConfigKV = [{version, ver(1)} | default_config()],
-            ConfigKVBin = [{atom_to_binary(Key, utf8), Val} || {Key, Val} <- ConfigKV],
-            foreach_occupant([Alice, Bob, Kate], Stanza, config_iq_verify_fun(ConfigKVBin))
-        end).
-
 custom_default_config_works(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
             Stanza = stanza_config_get(?ROOM, <<"oldver">>),
-            ConfigKV = [{version, ver(1)} | custom_default_config()],
-            ConfigKVBin = [{atom_to_binary(Key, utf8), Val} || {Key, Val} <- ConfigKV],
-            foreach_occupant([Alice, Bob, Kate], Stanza, config_iq_verify_fun(ConfigKVBin))
+            ConfigKV = [{"version", binary_to_list(ver(1))} | common_custom_config()],
+            foreach_occupant([Alice, Bob, Kate], Stanza, config_iq_verify_fun(ConfigKV))
         end).
 
 
@@ -952,6 +920,7 @@ stanza_config_set(Room, ConfigChanges) ->
     Items = [ kv_el(Key, Value) || {Key, Value} <- ConfigChanges],
     escalus_stanza:to(
       escalus_stanza:iq_set(?NS_MUC_LIGHT_CONFIGURATION, Items), room_bin_jid(Room)).
+
 %%--------------------------------------------------------------------
 %% Verifiers
 %%--------------------------------------------------------------------
@@ -994,9 +963,11 @@ verify_config(ConfigRoot, Config) ->
       fun({Key, Val}) ->
               Val = exml_query:path(ConfigRoot, [{element, Key}, cdata])
       end, Config).
+
 %%--------------------------------------------------------------------
 %% Verification funs generators
 %%--------------------------------------------------------------------
+
 -spec config_msg_verify_fun(RoomConfig :: [{binary(), binary()}]) -> verify_fun().
 config_msg_verify_fun(RoomConfig) ->
     fun(Incoming) ->
@@ -1014,12 +985,14 @@ config_msg_verify_fun(RoomConfig) ->
               end, RoomConfig)
     end.
 
--spec config_iq_verify_fun(RoomConfig :: [{binary(), binary()}]) -> verify_fun().
+-spec config_iq_verify_fun(RoomConfig :: [{string(), string()}]) -> verify_fun().
 config_iq_verify_fun(RoomConfig) ->
     fun(Incoming) ->
             [Query] = exml_query:subelements(Incoming, <<"query">>),
             ?NS_MUC_LIGHT_CONFIGURATION = exml_query:attr(Query, <<"xmlns">>),
-            verify_config(Query, RoomConfig)
+            BinaryRoomConfig = [{list_to_binary(K), list_to_binary(V)}
+                                || {K, V} <- RoomConfig],
+            verify_config(Query, BinaryRoomConfig)
     end.
 
 -spec aff_iq_verify_fun(AffUsers :: ct_aff_users(), Version :: binary()) -> verify_fun().
@@ -1082,14 +1055,20 @@ assert_process_memory_not_growing(Pid, OldMemory, Counter) ->
                  end,
   assert_process_memory_not_growing(Pid, Memory, NewCounter).
 
+-spec common_custom_config() -> list().
+common_custom_config() -> [{"background", "builtin:hell"}, {"music", "builtin:screams"}].
+
+-spec default_schema_definition() -> list().
+default_schema_definition() ->
+    rpc(mod_muc_light, default_schema_definition, []).
+
 -spec standard_default_config() -> list().
-standard_default_config() -> rpc(mod_muc_light, standard_default_config, []).
-
--spec custom_default_config() -> list().
-custom_default_config() -> [{background, <<"builtin:hell">>}, {music, <<"builtin:screams">>}].
-
--spec standard_config_schema() -> list().
-standard_config_schema() -> rpc(mod_muc_light, standard_config_schema, []).
+standard_default_config() ->
+    % Default schema definition is actually a proplist with the option name as a key
+    % and the default as a value, but we verify it to avoid strange errors.
+    DefaultConfig = default_schema_definition(),
+    lists:foreach(fun({K, V}) when is_list(K), is_list(V) -> ok end, DefaultConfig),
+    DefaultConfig.
 
 -spec set_default_mod_config() -> ok.
 set_default_mod_config() ->
@@ -1105,17 +1084,17 @@ set_default_mod_config() ->
        {rooms_per_page, infinity}
       ]).
 
--spec set_custom_config(RawSchema :: list(), RawDefaultConfig :: list()) -> true.
-set_custom_config(RawSchema, RawDefaultConfig) ->
-    ConfigSchema = rpc(mod_muc_light_room_config, schema_from_definition, [RawSchema]),
-    _ = hd(ConfigSchema), %% checks if is a list
+-spec set_custom_config(UserDefSchema :: list()) -> any().
+set_custom_config(UserDefSchema) ->
+    % Valid config schema is a map
+    #{} = ConfigSchema = rpc(mod_muc_light_room_config, schema_from_definition, [UserDefSchema]),
 
-    DefaultConfig = rpc(mod_muc_light_room_config, default_from_definition,
-                        [RawDefaultConfig, ConfigSchema]),
-    _ = hd(DefaultConfig), %% checks if is a list
+    % Valid default config is a proplist
+    [_|_] = DefaultConfig = rpc(mod_muc_light_room_config, default_from_schema, [ConfigSchema]),
 
     set_mod_config(config_schema, ConfigSchema, ?MUCHOST),
     set_mod_config(default_config, DefaultConfig, ?MUCHOST).
 
 domain() ->
     ct:get_config({hosts, mim, domain}).
+

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -1086,8 +1086,7 @@ set_default_mod_config() ->
 
 -spec set_custom_config(UserDefSchema :: list()) -> any().
 set_custom_config(UserDefSchema) ->
-    % Valid config schema is a map
-    #{} = ConfigSchema = rpc(mod_muc_light_room_config, schema_from_definition, [UserDefSchema]),
+    ConfigSchema = rpc(mod_muc_light_room_config, schema_from_definition, [UserDefSchema]),
 
     % Valid default config is a proplist
     [_|_] = DefaultConfig = rpc(mod_muc_light_room_config, default_from_schema, [ConfigSchema]),

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -1107,10 +1107,10 @@ set_default_mod_config() ->
 
 -spec set_custom_config(RawSchema :: list(), RawDefaultConfig :: list()) -> true.
 set_custom_config(RawSchema, RawDefaultConfig) ->
-    ConfigSchema = rpc(mod_muc_light_room_config, make_config_schema, [RawSchema]),
+    ConfigSchema = rpc(mod_muc_light_room_config, schema_from_definition, [RawSchema]),
     _ = hd(ConfigSchema), %% checks if is a list
 
-    DefaultConfig = rpc(mod_muc_light_room_config, make_default_config,
+    DefaultConfig = rpc(mod_muc_light_room_config, default_from_definition,
                         [RawDefaultConfig, ConfigSchema]),
     _ = hd(DefaultConfig), %% checks if is a list
 

--- a/doc/migrations/3.5.0_3.5.0plus.md
+++ b/doc/migrations/3.5.0_3.5.0plus.md
@@ -1,0 +1,74 @@
+## Different MUC Light room schema definition
+
+Separate MUC Light options for the schema and default values were somewhat unintuitive and led to problems with RDBMS backend.
+When the default config was a subset of the schema and the client hasn't provided these values when a room was created, it caused incomplete config being stored in the table.
+Due to this bug, the missing config fields couldn't even be re-added by the clients.
+If you've experienced this issue, a way to fix it is described in the [Known issues](../operation-and-maintenance/known-issues.md) page.
+
+The current method makes it impossible to make the same mistake, as it disallows field definition without any default value.
+
+### What has changed? - for administrators
+
+* It's no longer possible to declare room config field only with its name.
+* There is no `default_config` option anymore.
+* Declaring field name and type without atom key is no longer supported.
+
+#### Examples
+
+```
+{config_schema, [
+                 "roomname",
+                 "subject",
+                 "background",
+                 "notification_sound"
+                ]},
+{default_config, [
+                  {"roomname", "The room"},
+                  {"subject", "Chit-chat"}
+                 ]}
+
+becomes
+
+{config_schema, [
+                 {"roomname", "The room"},
+                 {"subject", "Chit-chat"},
+                 {"background", ""},
+                 {"notification_sound", ""}
+                ]}
+```
+
+```
+{config_schema, [
+                 "roomname",
+                 {"subject", binary},
+                 {"priority", priority, integer},
+                 {"owners-height", owners_height, float}
+                ]},
+{default_config, [
+                  {"roomname", "The room"},
+                  {"subject", "Chit-chat"},
+                  {"priority", 10}]}
+
+becomes
+
+{config_schema, [
+                 {"roomname", "The room"},
+                 {"subject", "Chit-chat"},
+                 {"priority", 10, priority, integer},
+                 {"owners-height", 180.0, owners_height, float}
+                ]}
+                 
+```
+
+### What has changed? - for developers
+
+The room config schema is currently stored in a completely different data structure, so if you have any custom modules that use it, you'll need to adjust them.
+What is more, all definitions and the room config API have been extracted from `mod_muc_light.hrl` and `mod_muc_light_utils.erl` into `mod_muc_light_room_config.erl` module.
+
+For more information, please check the types and functions specs in the aforementioned file.
+
+### What hasn't changed?
+
+* The default room config is still the same, i.e. `roomname` (default: `"Untitled"`) and `subject` (empty string).
+* The room config representation in databases (both Mnesia and RDBMS) is the same; no need for migration.
+

--- a/doc/migrations/3.5.0_3.5.0plus.md
+++ b/doc/migrations/3.5.0_3.5.0plus.md
@@ -1,17 +1,18 @@
 ## Different MUC Light room schema definition
 
-Separate MUC Light options for the schema and default values were somewhat unintuitive and led to problems with RDBMS backend.
-When the default config was a subset of the schema and the client hasn't provided these values when a room was created, it caused incomplete config being stored in the table.
-Due to this bug, the missing config fields couldn't even be re-added by the clients.
+We have introduced a change that enforces defining fields with default values.
+The previous setup led to problems with the RDBMS backend as separating MUC Light options for the schema from the default values was unintuitive.
+In a specific case when the default config was a subset of the schema and the client failed to provide these values when a room was created, MUC Light stored the incomplete config in the table.
+Then the missing config fields could not be supplied by the clients.
 If you've experienced this issue, a way to fix it is described in the [Known issues](../operation-and-maintenance/known-issues.md) page.
 
 The current method makes it impossible to make the same mistake, as it disallows field definition without any default value.
 
 ### What has changed? - for administrators
 
-* It's no longer possible to declare room config field only with its name.
+* It's no longer possible to declare a room config field only with its name.
 * There is no `default_config` option anymore.
-* Declaring field name and type without atom key is no longer supported.
+* Declaring a field name and type without an atom key is no longer supported.
 
 #### Example 1
 
@@ -73,9 +74,9 @@ The current method makes it impossible to make the same mistake, as it disallows
 ### What has changed? - for developers
 
 The room config schema is currently stored in a completely different data structure, so if you have any custom modules that use it, you'll need to adjust them.
-What is more, all definitions and the room config API have been extracted from `mod_muc_light.hrl` and `mod_muc_light_utils.erl` into `mod_muc_light_room_config.erl` module.
+Additionally, all definitions and the room config API have been extracted from `mod_muc_light.hrl` and `mod_muc_light_utils.erl` into `mod_muc_light_room_config.erl` module.
 
-For more information, please check the types and functions specs in the aforementioned file.
+For more information, please check the specs for types and functions in the aforementioned file.
 
 ### What hasn't changed?
 

--- a/doc/migrations/3.5.0_3.5.0plus.md
+++ b/doc/migrations/3.5.0_3.5.0plus.md
@@ -13,7 +13,9 @@ The current method makes it impossible to make the same mistake, as it disallows
 * There is no `default_config` option anymore.
 * Declaring field name and type without atom key is no longer supported.
 
-#### Examples
+#### Example 1
+
+**Old config:**
 
 ```
 {config_schema, [
@@ -26,9 +28,11 @@ The current method makes it impossible to make the same mistake, as it disallows
                   {"roomname", "The room"},
                   {"subject", "Chit-chat"}
                  ]}
+```
 
-becomes
+**New config:**
 
+```
 {config_schema, [
                  {"roomname", "The room"},
                  {"subject", "Chit-chat"},
@@ -36,6 +40,10 @@ becomes
                  {"notification_sound", ""}
                 ]}
 ```
+
+#### Example 2
+
+**Old config:**
 
 ```
 {config_schema, [
@@ -48,9 +56,11 @@ becomes
                   {"roomname", "The room"},
                   {"subject", "Chit-chat"},
                   {"priority", 10}]}
+```
 
-becomes
+**New config:**
 
+```
 {config_schema, [
                  {"roomname", "The room"},
                  {"subject", "Chit-chat"},

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -26,22 +26,18 @@ This extension consists of several modules but only `mod_muc_light` needs to be 
 * **max_occupants** (positive integer or `infinity`, default: `infinity`) - Specifies a cap on the occupant count per room.
 * **rooms_per_page** (positive integer or `infinity`, default: 10) - Specifies maximal number of rooms returned for a single Disco request.
 * **rooms_in_rosters** (boolean, default: `false`) - When enabled, rooms the user occupies are included in their roster.
-* **config_schema** (list; see below, default: `["roomname", "subject"]`) - A list of fields allowed in the room configuration.
+* **config_schema** (list; see below, default: `[{"roomname", "Untitled"}, {"subject", ""}]`) - A list of fields allowed in the room configuration.
  The field type may be specified but the default is "binary", i.e. effectively a string. 
  **WARNING!** Lack of the `roomname` field will cause room names in Disco results and Roster items be set to the room username.
-* **default_config** (list, default: `[{"roomname, "Untitled"}, {"subject", ""}]`) - Custom default room configuration; must be a subset of config schema. 
- It's a list of KV tuples with string keys and values of appriopriate type. 
- String values will be converted to binary automatically.
 
 ### Config schema
 
 Allowed `config_schema` list items are (may be mixed):
 
-* Just the field name: `"field"` - will be expanded to "field" of a type `binary`
-* Field name and a type: `{"field", integer}`
-* Field name, an atom and a type: `{"field", field, float}` - useful only for debugging or unusual applications
+* Field name and a default value: `{"field", "value"}` - will be expanded to "field" of a type `binary` (string) with a default "value"
+* Field name, a default value, an atom (internal key representation) and a type: `{"field", "value", field, float}` - useful only for debugging or custom applications
 
-Example of such list: `["roomname", {"subject", binary}, {"priority", priority, integer}]`
+Example of such list: `[{"roomname", "My Room"}, {"subject", "Hi"}, {"priority", 0, priority, integer}]`
 
 Valid config field types are:
 
@@ -63,8 +59,7 @@ Valid config field types are:
              {max_occupants, 50},
              {rooms_per_page, 5},
              {rooms_in_rosters, true},
-             {config_schema, ["roomname", {"display-lines", integer}]},
-             {default_config, [{"roomname", "The Room"}, {"display-lines", 30}]}
+             {config_schema, [{"roomname", "The Room"}, {"display-lines", 30, display_lines, integer}]}
             ]},
 ```
 

--- a/doc/operation-and-maintenance/known-issues.md
+++ b/doc/operation-and-maintenance/known-issues.md
@@ -1,10 +1,40 @@
 This document provides a list of all known issues with MongooseIM operation and configuration.
 You may also find proposed workarounds if any is available.
 
-### Proposed workarounds
+## Missing MUC Light room config fields with RDBMS backend
 
-* Upgrade OTP to 21.2 or higher.
-* Use unencrypted communication with MySQL.
+Until MongooseIM 3.5.x (incl.) new MUC Light rooms could be created with some config fields absent in the RDBMS table.
+These options couldn't be re-added later by changing the room config via requests from the clients.
+
+It happened when the default config was a subset of the schema and the client hasn't provided these values when a room was created.
+
+### How to fix this?
+
+You have to iterate over all rooms in the DB (`muc_light_rooms` table) and add missing entries to the `muc_light_config` table.
+Every option is inserted as a separate row and is stored as plain text, so it should be straightforward.
+
+Let's say you were using the following config:
+
+```
+{config_schema, [
+                 "roomname",
+                 "subject",
+                 "background",
+                 "notification_sound"
+                ]},
+{default_config, [
+                  {"roomname", "The room"},
+                  {"subject", "Chit-chat"}
+                 ]}
+```
+
+Your client application has created some rooms without `background` option by mistake.
+
+For every `id` in the `muc_light_rooms` table, you need to execute:
+
+```
+INSERT INTO muc_light_config(room_id, opt, val) VALUES ('put id here', 'background', 'new default value');
+```
 
 ## MSSQL connectivity via ODBC
 

--- a/doc/operation-and-maintenance/known-issues.md
+++ b/doc/operation-and-maintenance/known-issues.md
@@ -3,7 +3,7 @@ You may also find proposed workarounds if any is available.
 
 ## Missing MUC Light room config fields with RDBMS backend
 
-Until MongooseIM 3.5.x (incl.) new MUC Light rooms could be created with some config fields absent in the RDBMS table.
+Before MongooseIM 3.5.x (incl.) new MUC Light rooms could be created with some config fields absent in the RDBMS table.
 These options couldn't be re-added later by changing the room config via requests from the clients.
 
 It happened when the default config was a subset of the schema and the client hasn't provided these values when a room was created.
@@ -28,7 +28,7 @@ Let's say you were using the following config:
                  ]}
 ```
 
-Your client application has created some rooms without `background` option by mistake.
+Your client application has created some rooms without the `background` option by mistake.
 
 For every `id` in the `muc_light_rooms` table, you need to execute:
 

--- a/include/mod_muc_light.hrl
+++ b/include/mod_muc_light.hrl
@@ -63,7 +63,7 @@
           id = <<>> :: binary(),
           prev_version = <<>> :: binary(),
           version = <<>> :: binary(),
-          raw_config = [] :: mod_muc_light_room_config:raw_config()
+          raw_config = [] :: mod_muc_light_room_config:binary_kv()
          }).
 
 -type config_req_props() :: #config{}.
@@ -81,7 +81,7 @@
           id = <<>> :: binary(),
           prev_version = <<>> :: binary(),
           version = <<>> :: binary(),
-          raw_config = [] :: mod_muc_light_room_config:raw_config(),
+          raw_config = [] :: mod_muc_light_room_config:binary_kv(),
           aff_users = [] :: aff_users()
          }).
 
@@ -95,7 +95,7 @@
 -record(create, {
           id = <<>> :: binary(),
           version = <<>> :: binary(),
-          raw_config = [] :: mod_muc_light_room_config:raw_config(),
+          raw_config = [] :: mod_muc_light_room_config:binary_kv(),
           aff_users = [] :: aff_users()
          }).
 

--- a/include/mod_muc_light.hrl
+++ b/include/mod_muc_light.hrl
@@ -16,15 +16,6 @@
 -define(DEFAULT_ROOMS_PER_PAGE, 10).
 -define(DEFAULT_ROOMS_IN_ROSTERS, false).
 
--type schema_value_type() :: binary | integer | float.
--type schema_item() :: {FormFieldName :: binary(), OptionName :: atom(),
-                        ValueType :: schema_value_type()}.
--type config_schema() :: [schema_item()].
-
--type config_item() :: {Key :: atom(), Value :: term()}.
--type config() :: [config_item()].
--type raw_config() :: [{Key :: binary(), Value :: binary()}].
-
 -type aff() :: owner | member | none.
 -type aff_user() :: {jid:simple_bare_jid(), aff()}.
 -type aff_users() :: [aff_user()].
@@ -72,7 +63,7 @@
           id = <<>> :: binary(),
           prev_version = <<>> :: binary(),
           version = <<>> :: binary(),
-          raw_config = [] :: raw_config()
+          raw_config = [] :: mod_muc_light_room_config:raw_config()
          }).
 
 -type config_req_props() :: #config{}.
@@ -90,7 +81,7 @@
           id = <<>> :: binary(),
           prev_version = <<>> :: binary(),
           version = <<>> :: binary(),
-          raw_config = [] :: raw_config(),
+          raw_config = [] :: mod_muc_light_room_config:raw_config(),
           aff_users = [] :: aff_users()
          }).
 
@@ -104,7 +95,7 @@
 -record(create, {
           id = <<>> :: binary(),
           version = <<>> :: binary(),
-          raw_config = [] :: raw_config(),
+          raw_config = [] :: mod_muc_light_room_config:raw_config(),
           aff_users = [] :: aff_users()
          }).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ pages:
   - Migration Guide:
       - '3.1.1 to 3.2.0': 'migrations/3.1.1_3.2.0.md'
       - '3.3.0 to 3.4.0': 'migrations/3.3.0_3.4.0.md'
+      - '3.5.0 to 3.5.0plus': 'migrations/3.5.0_3.5.0plus.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - Platform:
       - 'Contributions to ecosystem': 'Contributions.md'

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -97,11 +97,11 @@ standard_default_config() -> [{"roomname", "Untitled"}, {"subject", ""}].
 default_host() ->
     <<"muclight.@HOST@">>.
 
--spec default_config(MUCServer :: jid:lserver()) -> config().
+-spec default_config(MUCServer :: jid:lserver()) -> mod_muc_light_room_config:config().
 default_config(MUCServer) ->
     gen_mod:get_module_opt_by_subhost(MUCServer, ?MODULE, default_config, []).
 
--spec config_schema(MUCServer :: jid:lserver()) -> config_schema().
+-spec config_schema(MUCServer :: jid:lserver()) -> mod_muc_light_room_config:schema().
 config_schema(MUCServer) ->
     gen_mod:get_module_opt_by_subhost(MUCServer, ?MODULE, config_schema, undefined).
 
@@ -119,7 +119,7 @@ try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = Creatio
                         CreatorUS, RoomUS, CreationCfg#create.aff_users),
     MaxOccupants = gen_mod:get_module_opt_by_subhost(
                      RoomJID#jid.lserver, ?MODULE, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
-    case {mod_muc_light_utils:process_raw_config(
+    case {mod_muc_light_room_config:process_raw_config(
             RawConfig, default_config(RoomS), config_schema(RoomS)),
           process_create_aff_users_if_valid(RoomS, CreatorUS, InitialAffUsers)} of
         {{ok, Config0}, {ok, FinalAffUsers}} when length(FinalAffUsers) =< MaxOccupants ->
@@ -194,12 +194,12 @@ start(Host, Opts) ->
     ejabberd_router:register_route(MUCHost, mongoose_packet_handler:new(?MODULE)),
 
     %% Prepare config schema
-    ConfigSchema = mod_muc_light_utils:make_config_schema(
+    ConfigSchema = mod_muc_light_room_config:make_config_schema(
                      gen_mod:get_opt(config_schema, Opts, standard_config_schema())),
     gen_mod:set_module_opt(Host, ?MODULE, config_schema, ConfigSchema),
 
     %% Prepare default config
-    DefaultConfig = mod_muc_light_utils:make_default_config(
+    DefaultConfig = mod_muc_light_room_config:make_default_config(
                       gen_mod:get_opt(default_config, Opts, standard_default_config()),
                       ConfigSchema),
     gen_mod:set_module_opt(Host, ?MODULE, default_config, DefaultConfig),

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -54,7 +54,7 @@
 -behaviour(mongoose_packet_handler).
 
 %% API
--export([standard_config_schema/0, standard_default_config/0, default_host/0]).
+-export([default_schema_definition/0, default_host/0]).
 -export([config_schema/1, default_config/1]).
 
 %% For Administration API
@@ -87,11 +87,10 @@
 %% API
 %%====================================================================
 
--spec standard_config_schema() -> [Field :: string()].
-standard_config_schema() -> ["roomname", "subject"].
-
--spec standard_default_config() -> [{K :: string(), V :: string()}].
-standard_default_config() -> [{"roomname", "Untitled"}, {"subject", ""}].
+-spec default_schema_definition() -> mod_muc_light_room_config:user_defined_schema().
+default_schema_definition() ->
+    [{"roomname", "Untitled"},
+     {"subject", ""}].
 
 -spec default_host() -> binary().
 default_host() ->
@@ -195,13 +194,11 @@ start(Host, Opts) ->
 
     %% Prepare config schema
     ConfigSchema = mod_muc_light_room_config:schema_from_definition(
-                     gen_mod:get_opt(config_schema, Opts, standard_config_schema())),
+                     gen_mod:get_opt(config_schema, Opts, default_schema_definition())),
     gen_mod:set_module_opt(Host, ?MODULE, config_schema, ConfigSchema),
 
     %% Prepare default config
-    DefaultConfig = mod_muc_light_room_config:default_from_definition(
-                      gen_mod:get_opt(default_config, Opts, standard_default_config()),
-                      ConfigSchema),
+    DefaultConfig = mod_muc_light_room_config:default_from_schema(ConfigSchema),
     gen_mod:set_module_opt(Host, ?MODULE, default_config, DefaultConfig),
 
     ok.

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -97,7 +97,7 @@ standard_default_config() -> [{"roomname", "Untitled"}, {"subject", ""}].
 default_host() ->
     <<"muclight.@HOST@">>.
 
--spec default_config(MUCServer :: jid:lserver()) -> mod_muc_light_room_config:config().
+-spec default_config(MUCServer :: jid:lserver()) -> mod_muc_light_room_config:kv().
 default_config(MUCServer) ->
     gen_mod:get_module_opt_by_subhost(MUCServer, ?MODULE, default_config, []).
 
@@ -119,7 +119,7 @@ try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = Creatio
                         CreatorUS, RoomUS, CreationCfg#create.aff_users),
     MaxOccupants = gen_mod:get_module_opt_by_subhost(
                      RoomJID#jid.lserver, ?MODULE, max_occupants, ?DEFAULT_MAX_OCCUPANTS),
-    case {mod_muc_light_room_config:process_raw_config(
+    case {mod_muc_light_room_config:apply_binary_kv(
             RawConfig, default_config(RoomS), config_schema(RoomS)),
           process_create_aff_users_if_valid(RoomS, CreatorUS, InitialAffUsers)} of
         {{ok, Config0}, {ok, FinalAffUsers}} when length(FinalAffUsers) =< MaxOccupants ->
@@ -194,12 +194,12 @@ start(Host, Opts) ->
     ejabberd_router:register_route(MUCHost, mongoose_packet_handler:new(?MODULE)),
 
     %% Prepare config schema
-    ConfigSchema = mod_muc_light_room_config:make_config_schema(
+    ConfigSchema = mod_muc_light_room_config:schema_from_definition(
                      gen_mod:get_opt(config_schema, Opts, standard_config_schema())),
     gen_mod:set_module_opt(Host, ?MODULE, config_schema, ConfigSchema),
 
     %% Prepare default config
-    DefaultConfig = mod_muc_light_room_config:make_default_config(
+    DefaultConfig = mod_muc_light_room_config:default_from_definition(
                       gen_mod:get_opt(default_config, Opts, standard_default_config()),
                       ConfigSchema),
     gen_mod:set_module_opt(Host, ?MODULE, default_config, DefaultConfig),

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -4,40 +4,8 @@
 %%% Purpose : MUC light support
 %%% Created : 8 Sep 2014 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
 %%%
-%%% Configuration options:
-%%% * backend (mnesia) - DB backend
-%%% * equal_occupants (false) - When enabled, everyone in the room will have 'member' status,
-%%%                             including creator
-%%% * legacy_mode (false) - Enables XEP-0045 compatibility mode
-%%% * rooms_per_user (infinity) - Default maximum count of rooms the user can occupy
-%%% * blocking (true) - Blocking feature enabled/disabled
-%%% * all_can_configure (false) - Every room occupant can change room configuration
-%%% * all_can_invite (false) - Every room occupant can invite a user to the room
-%%% * max_occupants (infinity) - Maximal occupant count per room
-%%% * rooms_per_page (10) - Maximal room count per result page in room disco
-%%% * rooms_in_rosters (false) - If enabled, rooms that user occupies will be included in
-%%%                              user's roster
-%%% * config_schema (["roomname", "subject"]) - Custom list of configuration options for a room;
-%%%                               WARNING! Lack of `roomname` field will cause room names in
-%%%                               Disco results and Roster items be set to room username.
-%%% * default_config ([{"roomname, "Untitled"}, {"subject", ""}]) -
-%%%                                Custom default room configuration; must be a subset of
-%%%                                config schema. It's a list of KV tuples with string keys
-%%%                                and values of appriopriate type. String values will be
-%%%                                converted to binary automatically.
-%%%        Example: [{"roomname", "The room"}, {"subject", "Chit-chat"}, {"security", 10}]
-%%%
-%%% Allowed `config_schema` list items (may be mixed):
-%%% * Just field name: "field" - will be expanded to "field" of type 'binary'
-%%% * Field name and type: {"field", integer}
-%%% * Field name, atom and the type: {"field", field, float} - useful only for debugging
-%%%                 or unusual applications
-%%% Sample valid list: `["roomname", {"subject", binary}, {"priority", priority, integer}]`
-%%%
-%%% Valid config field types:
-%%% * binary
-%%% * integer
-%%% * float
+%%% Looking for documentation excerpt that was present here for 5 years?
+%%% Now everything is moved to doc/modules/mod_muc_light.md
 %%%
 %%%----------------------------------------------------------------------
 

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -107,7 +107,7 @@ decode_message(#xmlel{ attrs = Attrs, children = Children }) ->
 -spec decode_message_by_type(Type :: {binary(), binary()} | false,
                              Id :: {binary(), binary()} | false,
                              Children :: [jlib:xmlch()]) ->
-    {ok, msg() | {set, config()}} | {error, bad_request} | ignore.
+    {ok, msg() | {set, mod_muc_light_room_config:config()}} | {error, bad_request} | ignore.
 decode_message_by_type({_, <<"groupchat">>}, _, [#xmlel{ name = <<"subject">> } = SubjectEl]) ->
     {ok, {set, #config{ raw_config = [{<<"subject">>, exml_query:cdata(SubjectEl)}] }}};
 decode_message_by_type({_, <<"groupchat">>}, Id, Children) ->
@@ -180,11 +180,12 @@ decode_iq(_From, #iq{} = IQ) ->
 
 %% ------------------ Parsers ------------------
 
--spec parse_config(Els :: [jlib:xmlch()]) -> {ok, raw_config()}.
+-spec parse_config(Els :: [jlib:xmlch()]) -> {ok, mod_muc_light_room_config:raw_config()}.
 parse_config(Els) ->
     parse_config(Els, []).
 
--spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: raw_config()) -> {ok, raw_config()}.
+-spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: mod_muc_light_room_config:raw_config()) ->
+    {ok, mod_muc_light_room_config:raw_config()}.
 parse_config([], ConfigAcc) ->
     {ok, ConfigAcc};
 parse_config([Field | REls], ConfigAcc) ->

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -107,7 +107,7 @@ decode_message(#xmlel{ attrs = Attrs, children = Children }) ->
 -spec decode_message_by_type(Type :: {binary(), binary()} | false,
                              Id :: {binary(), binary()} | false,
                              Children :: [jlib:xmlch()]) ->
-    {ok, msg() | {set, mod_muc_light_room_config:config()}} | {error, bad_request} | ignore.
+    {ok, msg() | {set, mod_muc_light_room_config:kv()}} | {error, bad_request} | ignore.
 decode_message_by_type({_, <<"groupchat">>}, _, [#xmlel{ name = <<"subject">> } = SubjectEl]) ->
     {ok, {set, #config{ raw_config = [{<<"subject">>, exml_query:cdata(SubjectEl)}] }}};
 decode_message_by_type({_, <<"groupchat">>}, Id, Children) ->
@@ -180,12 +180,12 @@ decode_iq(_From, #iq{} = IQ) ->
 
 %% ------------------ Parsers ------------------
 
--spec parse_config(Els :: [jlib:xmlch()]) -> {ok, mod_muc_light_room_config:raw_config()}.
+-spec parse_config(Els :: [jlib:xmlch()]) -> {ok, mod_muc_light_room_config:binary_kv()}.
 parse_config(Els) ->
     parse_config(Els, []).
 
--spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: mod_muc_light_room_config:raw_config()) ->
-    {ok, mod_muc_light_room_config:raw_config()}.
+-spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: mod_muc_light_room_config:binary_kv()) ->
+    {ok, mod_muc_light_room_config:binary_kv()}.
 parse_config([], ConfigAcc) ->
     {ok, ConfigAcc};
 parse_config([Field | REls], ConfigAcc) ->

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -205,12 +205,13 @@ decode_iq(_, _) ->
 
 %% ------------------ Parsers ------------------
 
--spec parse_config(Els :: [jlib:xmlch()]) -> {ok, raw_config()} | {error, bad_request}.
+-spec parse_config(Els :: [jlib:xmlch()]) -> {ok, mod_muc_light_room_config:raw_config()}
+                                             | {error, bad_request}.
 parse_config(Els) ->
     parse_config(Els, []).
 
--spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: raw_config()) ->
-    {ok, raw_config()} | {error, bad_request}.
+-spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: mod_muc_light_room_config:raw_config()) ->
+    {ok, mod_muc_light_room_config:raw_config()} | {error, bad_request}.
 parse_config([], ConfigAcc) ->
     {ok, ConfigAcc};
 parse_config([#xmlel{ name = <<"version">> } | _], _) ->

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -205,13 +205,13 @@ decode_iq(_, _) ->
 
 %% ------------------ Parsers ------------------
 
--spec parse_config(Els :: [jlib:xmlch()]) -> {ok, mod_muc_light_room_config:raw_config()}
+-spec parse_config(Els :: [jlib:xmlch()]) -> {ok, mod_muc_light_room_config:binary_kv()}
                                              | {error, bad_request}.
 parse_config(Els) ->
     parse_config(Els, []).
 
--spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: mod_muc_light_room_config:raw_config()) ->
-    {ok, mod_muc_light_room_config:raw_config()} | {error, bad_request}.
+-spec parse_config(Els :: [jlib:xmlch()], ConfigAcc :: mod_muc_light_room_config:binary_kv()) ->
+    {ok, mod_muc_light_room_config:binary_kv()} | {error, bad_request}.
 parse_config([], ConfigAcc) ->
     {ok, ConfigAcc};
 parse_config([#xmlel{ name = <<"version">> } | _], _) ->

--- a/src/muc_light/mod_muc_light_db.erl
+++ b/src/muc_light/mod_muc_light_db.erl
@@ -31,7 +31,7 @@
 
 %% ------------------------ General room management ------------------------
 
--callback create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
+-callback create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:kv(),
                       AffUsers :: aff_users(), Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 
@@ -53,12 +53,12 @@
 %% ------------------------ Configuration manipulation ------------------------
 
 -callback get_config(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, mod_muc_light_room_config:config(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:kv(), Version :: binary()} | {error, not_exists}.
 
 -callback get_config(RoomUS :: jid:simple_bare_jid(), Key :: atom()) ->
     {ok, term(), Version :: binary()} | {error, not_exists | invalid_opt}.
 
--callback set_config(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
+-callback set_config(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:kv(),
                      Version :: binary()) -> {ok, PrevVersion :: binary()} | {error, not_exists}.
 
 -callback set_config(RoomUS :: jid:simple_bare_jid(), Key :: atom(),
@@ -93,7 +93,7 @@
 %% ------------------------ Getting room configuration ------------------------
 
 -callback get_info(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, mod_muc_light_room_config:config(), aff_users(), Version :: binary()}
+    {ok, mod_muc_light_room_config:kv(), aff_users(), Version :: binary()}
     | {error, not_exists}.
 
 %% ------------------------ API for tests ------------------------

--- a/src/muc_light/mod_muc_light_db.erl
+++ b/src/muc_light/mod_muc_light_db.erl
@@ -31,7 +31,7 @@
 
 %% ------------------------ General room management ------------------------
 
--callback create_room(RoomUS :: jid:simple_bare_jid(), Config :: config(),
+-callback create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
                       AffUsers :: aff_users(), Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 
@@ -53,12 +53,12 @@
 %% ------------------------ Configuration manipulation ------------------------
 
 -callback get_config(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, config(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:config(), Version :: binary()} | {error, not_exists}.
 
 -callback get_config(RoomUS :: jid:simple_bare_jid(), Key :: atom()) ->
     {ok, term(), Version :: binary()} | {error, not_exists | invalid_opt}.
 
--callback set_config(RoomUS :: jid:simple_bare_jid(), Config :: config(),
+-callback set_config(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
                      Version :: binary()) -> {ok, PrevVersion :: binary()} | {error, not_exists}.
 
 -callback set_config(RoomUS :: jid:simple_bare_jid(), Key :: atom(),
@@ -93,7 +93,8 @@
 %% ------------------------ Getting room configuration ------------------------
 
 -callback get_info(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, config(), aff_users(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:config(), aff_users(), Version :: binary()}
+    | {error, not_exists}.
 
 %% ------------------------ API for tests ------------------------
 

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -96,7 +96,7 @@ stop(_Host, _MUCHost) ->
 
 %% ------------------------ General room management ------------------------
 
--spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: config(),
+-spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
                   AffUsers :: aff_users(), Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 create_room(RoomUS, Config, AffUsers, Version) ->
@@ -136,7 +136,7 @@ remove_user(UserUS, Version) ->
 %% ------------------------ Configuration manipulation ------------------------
 
 -spec get_config(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, config(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:config(), Version :: binary()} | {error, not_exists}.
 get_config(RoomUS) ->
     case mnesia:dirty_read(muc_light_room, RoomUS) of
         [] -> {error, not_exists};
@@ -156,7 +156,9 @@ get_config(RoomUS, Option) ->
             Error
     end.
 
--spec set_config(RoomUS :: jid:simple_bare_jid(), Config :: config(), Version :: binary()) ->
+-spec set_config(RoomUS :: jid:simple_bare_jid(),
+                 Config :: mod_muc_light_room_config:config(),
+                 Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config(RoomUS, ConfigChanges, Version) ->
     {atomic, Res} = mnesia:transaction(fun set_config_transaction/3,
@@ -226,7 +228,8 @@ modify_aff_users(RoomUS, AffUsersChanges, ExternalCheck, Version) ->
 %% ------------------------ Misc ------------------------
 
 -spec get_info(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, config(), aff_users(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:config(), aff_users(), Version :: binary()}
+    | {error, not_exists}.
 get_info(RoomUS) ->
     case mnesia:dirty_read(muc_light_room, RoomUS) of
         [] ->
@@ -284,7 +287,8 @@ create_table(Name, TabDef) ->
 
 %% Expects config to have unique fields!
 -spec create_room_transaction(RoomUS :: jid:simple_bare_jid(),
-                              Config :: config(), AffUsers :: aff_users(),
+                              Config :: mod_muc_light_room_config:config(),
+                              AffUsers :: aff_users(),
                               Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 create_room_transaction({<<>>, Domain}, Config, AffUsers, Version) ->
@@ -344,7 +348,7 @@ remove_user_transaction(UserUS, Version) ->
 
 %% Expects config changes to have unique fields!
 -spec set_config_transaction(RoomUS :: jid:simple_bare_jid(),
-                             ConfigChanges :: config(),
+                             ConfigChanges :: mod_muc_light_room_config:config(),
                              Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config_transaction(RoomUS, ConfigChanges, Version) ->

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -96,7 +96,7 @@ stop(_Host, _MUCHost) ->
 
 %% ------------------------ General room management ------------------------
 
--spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
+-spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:kv(),
                   AffUsers :: aff_users(), Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 create_room(RoomUS, Config, AffUsers, Version) ->
@@ -136,7 +136,7 @@ remove_user(UserUS, Version) ->
 %% ------------------------ Configuration manipulation ------------------------
 
 -spec get_config(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, mod_muc_light_room_config:config(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:kv(), Version :: binary()} | {error, not_exists}.
 get_config(RoomUS) ->
     case mnesia:dirty_read(muc_light_room, RoomUS) of
         [] -> {error, not_exists};
@@ -157,7 +157,7 @@ get_config(RoomUS, Option) ->
     end.
 
 -spec set_config(RoomUS :: jid:simple_bare_jid(),
-                 Config :: mod_muc_light_room_config:config(),
+                 Config :: mod_muc_light_room_config:kv(),
                  Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config(RoomUS, ConfigChanges, Version) ->
@@ -228,7 +228,7 @@ modify_aff_users(RoomUS, AffUsersChanges, ExternalCheck, Version) ->
 %% ------------------------ Misc ------------------------
 
 -spec get_info(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, mod_muc_light_room_config:config(), aff_users(), Version :: binary()}
+    {ok, mod_muc_light_room_config:kv(), aff_users(), Version :: binary()}
     | {error, not_exists}.
 get_info(RoomUS) ->
     case mnesia:dirty_read(muc_light_room, RoomUS) of
@@ -287,7 +287,7 @@ create_table(Name, TabDef) ->
 
 %% Expects config to have unique fields!
 -spec create_room_transaction(RoomUS :: jid:simple_bare_jid(),
-                              Config :: mod_muc_light_room_config:config(),
+                              Config :: mod_muc_light_room_config:kv(),
                               AffUsers :: aff_users(),
                               Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
@@ -348,7 +348,7 @@ remove_user_transaction(UserUS, Version) ->
 
 %% Expects config changes to have unique fields!
 -spec set_config_transaction(RoomUS :: jid:simple_bare_jid(),
-                             ConfigChanges :: mod_muc_light_room_config:config(),
+                             ConfigChanges :: mod_muc_light_room_config:kv(),
                              Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config_transaction(RoomUS, ConfigChanges, Version) ->

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -156,7 +156,7 @@ get_config({RoomU, RoomS} = RoomUS) ->
             {ok, [], Version};
         [{Version, _, _} | _] ->
             RawConfig = [{Key, Val} || {_, Key, Val} <- Result],
-            {ok, Config} = mod_muc_light_utils:process_raw_config(
+            {ok, Config} = mod_muc_light_room_config:apply_binary_kv(
                              RawConfig, [], mod_muc_light:config_schema(RoomS)),
             {ok, Config, Version}
     end.
@@ -178,7 +178,8 @@ get_config({RoomU, RoomS} = RoomUS, Key) ->
             {error, invalid_opt};
         [{Version, _, ValDB}] ->
             RawConfig = [{KeyDB, ValDB}],
-            {ok, [{_, Val}]} = mod_muc_light_utils:process_raw_config(RawConfig, [], ConfigSchema),
+            {ok, [{_, Val}]} = mod_muc_light_room_config:apply_binary_kv(
+                                 RawConfig, [], ConfigSchema),
             {ok, Val, Version}
     end.
 
@@ -283,7 +284,7 @@ get_info({RoomU, RoomS} = RoomUS) ->
 
             {selected, ConfigDB} = mongoose_rdbms:sql_query(
                                         MainHost, mod_muc_light_db_rdbms_sql:select_config(RoomID)),
-            {ok, Config} = mod_muc_light_utils:process_raw_config(
+            {ok, Config} = mod_muc_light_room_config:apply_binary_kv(
                              ConfigDB, [], mod_muc_light:config_schema(RoomS)),
 
             {ok, Config, lists:sort(AffUsers), Version};

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -165,8 +165,7 @@ get_config({RoomU, RoomS} = RoomUS) ->
     {ok, term(), Version :: binary()} | {error, not_exists | invalid_opt}.
 get_config({RoomU, RoomS} = RoomUS, Key) ->
     MainHost = main_host(RoomUS),
-    ConfigSchema = mod_muc_light:config_schema(RoomS),
-    {KeyDB, _, _} = lists:keyfind(Key, 2, ConfigSchema),
+    #{ Key := KeyDB } = ConfigSchema = mod_muc_light:config_schema(RoomS),
 
     SQL = mod_muc_light_db_rdbms_sql:select_config(RoomU, RoomS, KeyDB),
     {selected, Result} = mongoose_rdbms:sql_query(MainHost, SQL),

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -82,7 +82,7 @@ stop(_Host, _MUCHost) ->
 
 %% ------------------------ General room management ------------------------
 
--spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: config(),
+-spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
                   AffUsers :: aff_users(), Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 create_room(RoomUS, Config, AffUsers, Version) ->
@@ -142,7 +142,7 @@ remove_user({_, UserS} = UserUS, Version) ->
 %% ------------------------ Configuration manipulation ------------------------
 
 -spec get_config(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, config(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:config(), Version :: binary()} | {error, not_exists}.
 get_config({RoomU, RoomS} = RoomUS) ->
     MainHost = main_host(RoomUS),
 
@@ -183,7 +183,8 @@ get_config({RoomU, RoomS} = RoomUS, Key) ->
     end.
 
 
--spec set_config(RoomUS :: jid:simple_bare_jid(), Config :: config(), Version :: binary()) ->
+-spec set_config(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
+                 Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config(RoomUS, ConfigChanges, Version) ->
     MainHost = main_host(RoomUS),
@@ -269,7 +270,8 @@ modify_aff_users(RoomUS, AffUsersChanges, ExternalCheck, Version) ->
 %% ------------------------ Misc ------------------------
 
 -spec get_info(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, config(), aff_users(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:config(), aff_users(), Version :: binary()}
+    | {error, not_exists}.
 get_info({RoomU, RoomS} = RoomUS) ->
     MainHost = main_host(RoomUS),
     case mongoose_rdbms:sql_query(
@@ -331,7 +333,8 @@ force_clear() ->
 
 %% Expects config to have unique fields!
 -spec create_room_transaction(RoomUS :: jid:simple_bare_jid(),
-                              Config :: config(), AffUsers :: aff_users(),
+                              Config :: mod_muc_light_room_config:config(),
+                              AffUsers :: aff_users(),
                               Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 create_room_transaction({NodeCandidate, RoomS}, Config, AffUsers, Version) ->
@@ -376,7 +379,8 @@ create_room_transaction({NodeCandidate, RoomS}, Config, AffUsers, Version) ->
               fun({Key, Val}) ->
                       {updated, _} = mongoose_rdbms:sql_query_t(
                                        mod_muc_light_db_rdbms_sql:insert_config(RoomID, Key, Val))
-              end, mod_muc_light_utils:config_to_raw(Config, mod_muc_light:config_schema(RoomS))),
+              end, mod_muc_light_room_config:config_to_raw(
+                     Config, mod_muc_light:config_schema(RoomS))),
             {ok, {RoomU, RoomS}}
     end.
 
@@ -410,7 +414,7 @@ remove_user_transaction({UserU, UserS} = UserUS, Version) ->
 %% ------------------------ Configuration manipulation ------------------------
 
 -spec set_config_transaction(RoomUS :: jid:simple_bare_jid(),
-                             ConfigChanges :: config(),
+                             ConfigChanges :: mod_muc_light_room_config:config(),
                              Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config_transaction({RoomU, RoomS} = RoomUS, ConfigChanges, Version) ->
@@ -425,7 +429,7 @@ set_config_transaction({RoomU, RoomS} = RoomUS, ConfigChanges, Version) ->
                       {updated, _}
                       = mongoose_rdbms:sql_query(
                           MainHost, mod_muc_light_db_rdbms_sql:update_config(RoomID, Key, Val))
-              end, mod_muc_light_utils:config_to_raw(
+              end, mod_muc_light_room_config:config_to_raw(
                      ConfigChanges, mod_muc_light:config_schema(RoomS))),
             {ok, PrevVersion};
         {selected, []} ->

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -82,7 +82,7 @@ stop(_Host, _MUCHost) ->
 
 %% ------------------------ General room management ------------------------
 
--spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
+-spec create_room(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:kv(),
                   AffUsers :: aff_users(), Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
 create_room(RoomUS, Config, AffUsers, Version) ->
@@ -142,7 +142,7 @@ remove_user({_, UserS} = UserUS, Version) ->
 %% ------------------------ Configuration manipulation ------------------------
 
 -spec get_config(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, mod_muc_light_room_config:config(), Version :: binary()} | {error, not_exists}.
+    {ok, mod_muc_light_room_config:kv(), Version :: binary()} | {error, not_exists}.
 get_config({RoomU, RoomS} = RoomUS) ->
     MainHost = main_host(RoomUS),
 
@@ -183,7 +183,7 @@ get_config({RoomU, RoomS} = RoomUS, Key) ->
     end.
 
 
--spec set_config(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:config(),
+-spec set_config(RoomUS :: jid:simple_bare_jid(), Config :: mod_muc_light_room_config:kv(),
                  Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config(RoomUS, ConfigChanges, Version) ->
@@ -270,7 +270,7 @@ modify_aff_users(RoomUS, AffUsersChanges, ExternalCheck, Version) ->
 %% ------------------------ Misc ------------------------
 
 -spec get_info(RoomUS :: jid:simple_bare_jid()) ->
-    {ok, mod_muc_light_room_config:config(), aff_users(), Version :: binary()}
+    {ok, mod_muc_light_room_config:kv(), aff_users(), Version :: binary()}
     | {error, not_exists}.
 get_info({RoomU, RoomS} = RoomUS) ->
     MainHost = main_host(RoomUS),
@@ -333,7 +333,7 @@ force_clear() ->
 
 %% Expects config to have unique fields!
 -spec create_room_transaction(RoomUS :: jid:simple_bare_jid(),
-                              Config :: mod_muc_light_room_config:config(),
+                              Config :: mod_muc_light_room_config:kv(),
                               AffUsers :: aff_users(),
                               Version :: binary()) ->
     {ok, FinalRoomUS :: jid:simple_bare_jid()} | {error, exists}.
@@ -379,7 +379,7 @@ create_room_transaction({NodeCandidate, RoomS}, Config, AffUsers, Version) ->
               fun({Key, Val}) ->
                       {updated, _} = mongoose_rdbms:sql_query_t(
                                        mod_muc_light_db_rdbms_sql:insert_config(RoomID, Key, Val))
-              end, mod_muc_light_room_config:config_to_raw(
+              end, mod_muc_light_room_config:to_binary_kv(
                      Config, mod_muc_light:config_schema(RoomS))),
             {ok, {RoomU, RoomS}}
     end.
@@ -414,7 +414,7 @@ remove_user_transaction({UserU, UserS} = UserUS, Version) ->
 %% ------------------------ Configuration manipulation ------------------------
 
 -spec set_config_transaction(RoomUS :: jid:simple_bare_jid(),
-                             ConfigChanges :: mod_muc_light_room_config:config(),
+                             ConfigChanges :: mod_muc_light_room_config:kv(),
                              Version :: binary()) ->
     {ok, PrevVersion :: binary()} | {error, not_exists}.
 set_config_transaction({RoomU, RoomS} = RoomUS, ConfigChanges, Version) ->
@@ -429,7 +429,7 @@ set_config_transaction({RoomU, RoomS} = RoomUS, ConfigChanges, Version) ->
                       {updated, _}
                       = mongoose_rdbms:sql_query(
                           MainHost, mod_muc_light_db_rdbms_sql:update_config(RoomID, Key, Val))
-              end, mod_muc_light_room_config:config_to_raw(
+              end, mod_muc_light_room_config:to_binary_kv(
                      ConfigChanges, mod_muc_light:config_schema(RoomS))),
             {ok, PrevVersion};
         {selected, []} ->

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -165,7 +165,8 @@ get_config({RoomU, RoomS} = RoomUS) ->
     {ok, term(), Version :: binary()} | {error, not_exists | invalid_opt}.
 get_config({RoomU, RoomS} = RoomUS, Key) ->
     MainHost = main_host(RoomUS),
-    #{ Key := KeyDB } = ConfigSchema = mod_muc_light:config_schema(RoomS),
+    ConfigSchema = mod_muc_light:config_schema(RoomS),
+    {ok, KeyDB} = mod_muc_light_room_config:schema_reverse_find(Key, ConfigSchema),
 
     SQL = mod_muc_light_db_rdbms_sql:select_config(RoomU, RoomS, KeyDB),
     {selected, Result} = mongoose_rdbms:sql_query(MainHost, SQL),

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -100,7 +100,7 @@ process_request(#msg{} = Msg, _From, _UserUS, _RoomUS, _Auth, AffUsers) ->
 process_request({get, #config{} = ConfigReq}, _From, _UserUS, RoomUS, _Auth, _AffUsers) ->
     {_, RoomS} = RoomUS,
     {ok, Config, RoomVersion} = mod_muc_light_db_backend:get_config(RoomUS),
-    RawConfig = mod_muc_light_utils:config_to_raw(Config, mod_muc_light:config_schema(RoomS)),
+    RawConfig = mod_muc_light_room_config:config_to_raw(Config, mod_muc_light:config_schema(RoomS)),
     {get, ConfigReq#config{ version = RoomVersion,
                             raw_config = RawConfig }};
 process_request({get, #affiliations{} = AffReq}, _From, _UserUS, RoomUS, _Auth, _AffUsers) ->
@@ -109,7 +109,7 @@ process_request({get, #affiliations{} = AffReq}, _From, _UserUS, RoomUS, _Auth, 
                                aff_users = AffUsers }};
 process_request({get, #info{} = InfoReq}, _From, _UserUS, {_, RoomS} = RoomUS, _Auth, _AffUsers) ->
     {ok, Config, AffUsers, RoomVersion} = mod_muc_light_db_backend:get_info(RoomUS),
-    RawConfig = mod_muc_light_utils:config_to_raw(Config, mod_muc_light:config_schema(RoomS)),
+    RawConfig = mod_muc_light_room_config:config_to_raw(Config, mod_muc_light:config_schema(RoomS)),
     {get, InfoReq#info{ version = RoomVersion, aff_users = AffUsers,
                         raw_config = RawConfig }};
 process_request({set, #config{} = ConfigReq}, _From, _UserUS, {_, MUCServer} = RoomUS,
@@ -158,7 +158,7 @@ process_config_set(#config{ raw_config = [{<<"subject">>, _}] } = ConfigReq, Roo
 process_config_set(_ConfigReq, _RoomUS, member, _AffUsers, false) ->
     {error, not_allowed};
 process_config_set(ConfigReq, {_, RoomS} = RoomUS, _UserAff, AffUsers, _AllCanConfigure) ->
-    case mod_muc_light_utils:process_raw_config(
+    case mod_muc_light_room_config:process_raw_config(
            ConfigReq#config.raw_config, [], mod_muc_light:config_schema(RoomS)) of
         {ok, Config} ->
             NewVersion = mongoose_bin:gen_from_timestamp(),

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -100,7 +100,7 @@ process_request(#msg{} = Msg, _From, _UserUS, _RoomUS, _Auth, AffUsers) ->
 process_request({get, #config{} = ConfigReq}, _From, _UserUS, RoomUS, _Auth, _AffUsers) ->
     {_, RoomS} = RoomUS,
     {ok, Config, RoomVersion} = mod_muc_light_db_backend:get_config(RoomUS),
-    RawConfig = mod_muc_light_room_config:config_to_raw(Config, mod_muc_light:config_schema(RoomS)),
+    RawConfig = mod_muc_light_room_config:to_binary_kv(Config, mod_muc_light:config_schema(RoomS)),
     {get, ConfigReq#config{ version = RoomVersion,
                             raw_config = RawConfig }};
 process_request({get, #affiliations{} = AffReq}, _From, _UserUS, RoomUS, _Auth, _AffUsers) ->
@@ -109,7 +109,7 @@ process_request({get, #affiliations{} = AffReq}, _From, _UserUS, RoomUS, _Auth, 
                                aff_users = AffUsers }};
 process_request({get, #info{} = InfoReq}, _From, _UserUS, {_, RoomS} = RoomUS, _Auth, _AffUsers) ->
     {ok, Config, AffUsers, RoomVersion} = mod_muc_light_db_backend:get_info(RoomUS),
-    RawConfig = mod_muc_light_room_config:config_to_raw(Config, mod_muc_light:config_schema(RoomS)),
+    RawConfig = mod_muc_light_room_config:to_binary_kv(Config, mod_muc_light:config_schema(RoomS)),
     {get, InfoReq#info{ version = RoomVersion, aff_users = AffUsers,
                         raw_config = RawConfig }};
 process_request({set, #config{} = ConfigReq}, _From, _UserUS, {_, MUCServer} = RoomUS,
@@ -158,7 +158,7 @@ process_config_set(#config{ raw_config = [{<<"subject">>, _}] } = ConfigReq, Roo
 process_config_set(_ConfigReq, _RoomUS, member, _AffUsers, false) ->
     {error, not_allowed};
 process_config_set(ConfigReq, {_, RoomS} = RoomUS, _UserAff, AffUsers, _AllCanConfigure) ->
-    case mod_muc_light_room_config:process_raw_config(
+    case mod_muc_light_room_config:apply_binary_kv(
            ConfigReq#config.raw_config, [], mod_muc_light:config_schema(RoomS)) of
         {ok, Config} ->
             NewVersion = mongoose_bin:gen_from_timestamp(),

--- a/src/muc_light/mod_muc_light_room_config.erl
+++ b/src/muc_light/mod_muc_light_room_config.erl
@@ -1,0 +1,144 @@
+%%%----------------------------------------------------------------------
+%%% File    : mod_muc_light_room_config.erl
+%%% Author  : Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%% Purpose : Stateless utilities for room config processing
+%%% Created : 15 Nov 2019 by Piotr Nosek <piotr.nosek@erlang-solutions.com>
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with this program; if not, write to the Free Software
+%%% Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+%%% 02111-1307 USA
+%%%
+%%%----------------------------------------------------------------------
+
+-module(mod_muc_light_room_config).
+-author('piotr.nosek@erlang-solutions.com').
+
+%% API
+-export([make_config_schema/1, make_default_config/2]).
+-export([process_raw_config/3, config_to_raw/2]).
+
+-include("jlib.hrl").
+-include("mongoose.hrl").
+-include("mod_muc_light.hrl").
+
+-type schema_value_type() :: binary | integer | float.
+-type schema_item() :: {FormFieldName :: binary(), OptionName :: atom(),
+                        ValueType :: schema_value_type()}.
+-type schema() :: [schema_item()].
+
+-type config_item() :: {Key :: atom(), Value :: term()}.
+-type config() :: [config_item()].
+-type raw_config() :: [{Key :: binary(), Value :: binary()}].
+
+-type user_defined_schema_item() :: FieldName :: string()
+                                    | {FieldName :: string(), FieldName :: schema_value_type()}
+                                    | schema_item().
+-type user_defined_schema() :: [user_defined_schema_item()].
+
+-type user_config_defaults_item() :: {FieldName :: string(), FieldValue :: term()}.
+-type user_config_defaults() :: [user_config_defaults_item()].
+
+-export_type([schema/0, raw_config/0, config/0]).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-spec make_config_schema(UserDefinedSchema :: user_defined_schema()) -> schema().
+make_config_schema(UserDefinedSchema) ->
+    lists:map(fun expand_config_schema_field/1, UserDefinedSchema).
+
+-spec make_default_config(UserConfigDefaults :: user_config_defaults(),
+                         ConfigSchema :: schema()) -> config().
+make_default_config(UserConfigDefaults, ConfigSchema) ->
+    DefaultConfigCandidate = lists:map(fun process_config_field/1, UserConfigDefaults),
+    lists:foreach(fun({Key, Value}) ->
+                          try
+                              {_, _, ValueType} = lists:keyfind(Key, 2, ConfigSchema),
+                              value2b(Value, ValueType)
+                          catch
+                              _:Error -> error({invalid_default_config, Key, Value, Error})
+                          end
+                  end, DefaultConfigCandidate),
+    DefaultConfigCandidate.
+
+%% Guarantees that config will have unique fields
+-spec process_raw_config(
+        RawConfig :: raw_config(), Config :: config(), ConfigSchema :: schema()) ->
+    {ok, config()} | validation_error().
+process_raw_config([], Config, _ConfigSchema) ->
+    {ok, Config};
+process_raw_config([{KeyBin, ValBin} | RRawConfig], Config, ConfigSchema) ->
+    case process_raw_config_opt(KeyBin, ValBin, ConfigSchema) of
+        {ok, Key, Val} ->
+            process_raw_config(
+              RRawConfig, lists:keystore(Key, 1, Config, {Key, Val}), ConfigSchema);
+        Error ->
+            Error
+    end.
+
+-spec config_to_raw(Config :: config(), ConfigSchema :: schema()) -> raw_config().
+config_to_raw([], _ConfigSchema) ->
+    [];
+config_to_raw([{Key, Val} | RConfig], ConfigSchema) ->
+    {KeyBin, _, ValType} = lists:keyfind(Key, 2, ConfigSchema),
+    [{KeyBin, value2b(Val, ValType)} | config_to_raw(RConfig, ConfigSchema)].
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec expand_config_schema_field(UserDefinedSchemaItem :: user_defined_schema_item()) ->
+    schema_item().
+expand_config_schema_field({FieldName, Type}) ->
+    {_, true} = {FieldName, is_valid_config_type(Type)},
+    {list_to_binary(FieldName), list_to_atom(FieldName), Type};
+expand_config_schema_field({FieldNameBin, FieldName, Type} = SchemaItem)
+  when is_binary(FieldNameBin) andalso is_atom(FieldName) ->
+    {_, true} = {FieldName, is_valid_config_type(Type)},
+    SchemaItem;
+expand_config_schema_field(Name) ->
+    {list_to_binary(Name), list_to_atom(Name), binary}.
+
+-spec process_config_field(UserConfigDefaultsItem :: user_config_defaults_item()) -> config_item().
+process_config_field({Key, Value}) when is_list(Value) ->
+    process_config_field({Key, list_to_binary(Value)});
+process_config_field({Key, Value}) ->
+    {list_to_atom(Key), Value}.
+
+-spec process_raw_config_opt(
+        KeyBin :: binary(), ValBin :: binary(), ConfigSchema :: schema()) ->
+    {ok, Key :: atom(), Val :: any()} | validation_error().
+process_raw_config_opt(KeyBin, ValBin, ConfigSchema) ->
+    case lists:keyfind(KeyBin, 1, ConfigSchema) of
+        {_, Key, Type} -> {ok, Key, b2value(ValBin, Type)};
+        _ -> {error, {KeyBin, unknown}}
+    end.
+
+-spec is_valid_config_type(Type :: schema_value_type() | atom()) -> boolean().
+is_valid_config_type(binary) -> true;
+is_valid_config_type(integer) -> true;
+is_valid_config_type(float) -> true;
+is_valid_config_type(_) -> false.
+
+-spec b2value(ValBin :: binary(), Type :: schema_value_type()) -> Converted :: any().
+b2value(ValBin, binary) -> ValBin;
+b2value(ValBin, integer) -> binary_to_integer(ValBin);
+b2value(ValBin, float) -> binary_to_float(ValBin).
+
+-spec value2b(Val :: any(), Type :: schema_value_type()) -> Converted :: binary().
+value2b(Val, binary) -> Val;
+value2b(Val, integer) -> integer_to_binary(Val);
+value2b(Val, float) -> float_to_binary(Val).
+

--- a/src/muc_light/mod_muc_light_room_config.erl
+++ b/src/muc_light/mod_muc_light_room_config.erl
@@ -44,7 +44,7 @@
 -type schema_item() :: {Default :: value(), key(), value_type()}.
 -type schema() :: #{
         form_field_name() => schema_item(),
-        key() => form_field_name()
+        key() => form_field_name() %% A kind of an index required for some operations
        }.
 
 %% Actual config

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -25,8 +25,6 @@
 -author('piotr.nosek@erlang-solutions.com').
 
 %% API
--export([make_config_schema/1, make_default_config/2]).
--export([process_raw_config/3, config_to_raw/2]).
 -export([change_aff_users/2]).
 -export([b2aff/1, aff2b/1]).
 -export([light_aff_to_muc_role/1]).
@@ -37,19 +35,12 @@
 -include("mongoose.hrl").
 -include("mod_muc_light.hrl").
 
--type user_defined_schema_item() :: FieldName :: string()
-                                    | {FieldName :: string(), FieldName :: schema_value_type()}
-                                    | schema_item().
--type user_defined_schema() :: [user_defined_schema_item()].
-
--type user_config_defaults_item() :: {FieldName :: string(), FieldValue :: term()}.
--type user_config_defaults() :: [user_config_defaults_item()].
-
 -type change_aff_success() :: {ok, NewAffUsers :: aff_users(), ChangedAffUsers :: aff_users(),
                                JoiningUsers :: [jid:simple_bare_jid()],
                                LeavingUsers :: [jid:simple_bare_jid()]}.
 
--type change_aff_success_without_users() :: {ok, NewAffUsers :: aff_users(), ChangedAffUsers :: aff_users()}.
+-type change_aff_success_without_users() :: {ok, NewAffUsers :: aff_users(),
+                                             ChangedAffUsers :: aff_users()}.
 
 -type promotion_type() :: promote_old_member | promote_joined_member | promote_demoted_owner.
 
@@ -58,46 +49,6 @@
 %%====================================================================
 %% API
 %%====================================================================
-
--spec make_config_schema(UserDefinedSchema :: user_defined_schema()) -> config_schema().
-make_config_schema(UserDefinedSchema) ->
-    lists:map(fun expand_config_schema_field/1, UserDefinedSchema).
-
--spec make_default_config(UserConfigDefaults :: user_config_defaults(),
-                         ConfigSchema :: config_schema()) -> config().
-make_default_config(UserConfigDefaults, ConfigSchema) ->
-    DefaultConfigCandidate = lists:map(fun process_config_field/1, UserConfigDefaults),
-    lists:foreach(fun({Key, Value}) ->
-                          try
-                              {_, _, ValueType} = lists:keyfind(Key, 2, ConfigSchema),
-                              value2b(Value, ValueType)
-                          catch
-                              _:Error -> error({invalid_default_config, Key, Value, Error})
-                          end
-                  end, DefaultConfigCandidate),
-    DefaultConfigCandidate.
-
-%% Guarantees that config will have unique fields
--spec process_raw_config(
-        RawConfig :: raw_config(), Config :: config(), ConfigSchema :: config_schema()) ->
-    {ok, config()} | validation_error().
-process_raw_config([], Config, _ConfigSchema) ->
-    {ok, Config};
-process_raw_config([{KeyBin, ValBin} | RRawConfig], Config, ConfigSchema) ->
-    case process_raw_config_opt(KeyBin, ValBin, ConfigSchema) of
-        {ok, Key, Val} ->
-            process_raw_config(
-              RRawConfig, lists:keystore(Key, 1, Config, {Key, Val}), ConfigSchema);
-        Error ->
-            Error
-    end.
-
--spec config_to_raw(Config :: config(), ConfigSchema :: config_schema()) -> raw_config().
-config_to_raw([], _ConfigSchema) ->
-    [];
-config_to_raw([{Key, Val} | RConfig], ConfigSchema) ->
-    {KeyBin, _, ValType} = lists:keyfind(Key, 2, ConfigSchema),
-    [{KeyBin, value2b(Val, ValType)} | config_to_raw(RConfig, ConfigSchema)].
 
 -spec change_aff_users(CurrentAffUsers :: aff_users(), AffUsersChangesAssorted :: aff_users()) ->
     change_aff_success() | {error, bad_request}.
@@ -192,56 +143,11 @@ filter_out_loop(FromUS, MUCServer, BlockingQuery, RoomsPerUser,
 filter_out_loop(_FromUS, _MUCServer, _BlockingQuery, _RoomsPerUser, []) ->
     [].
 
-%% ---------------- Configuration processing ----------------
-
--spec expand_config_schema_field(UserDefinedSchemaItem :: user_defined_schema_item()) ->
-    schema_item().
-expand_config_schema_field({FieldName, Type}) ->
-    {_, true} = {FieldName, is_valid_config_type(Type)},
-    {list_to_binary(FieldName), list_to_atom(FieldName), Type};
-expand_config_schema_field({FieldNameBin, FieldName, Type} = SchemaItem)
-  when is_binary(FieldNameBin) andalso is_atom(FieldName) ->
-    {_, true} = {FieldName, is_valid_config_type(Type)},
-    SchemaItem;
-expand_config_schema_field(Name) ->
-    {list_to_binary(Name), list_to_atom(Name), binary}.
-
--spec process_config_field(UserConfigDefaultsItem :: user_config_defaults_item()) -> config_item().
-process_config_field({Key, Value}) when is_list(Value) ->
-    process_config_field({Key, list_to_binary(Value)});
-process_config_field({Key, Value}) ->
-    {list_to_atom(Key), Value}.
-
--spec process_raw_config_opt(
-        KeyBin :: binary(), ValBin :: binary(), ConfigSchema :: config_schema()) ->
-    {ok, Key :: atom(), Val :: any()} | validation_error().
-process_raw_config_opt(KeyBin, ValBin, ConfigSchema) ->
-    case lists:keyfind(KeyBin, 1, ConfigSchema) of
-        {_, Key, Type} -> {ok, Key, b2value(ValBin, Type)};
-        _ -> {error, {KeyBin, unknown}}
-    end.
-
--spec is_valid_config_type(Type :: schema_value_type() | atom()) -> boolean().
-is_valid_config_type(binary) -> true;
-is_valid_config_type(integer) -> true;
-is_valid_config_type(float) -> true;
-is_valid_config_type(_) -> false.
-
--spec b2value(ValBin :: binary(), Type :: schema_value_type()) -> Converted :: any().
-b2value(ValBin, binary) -> ValBin;
-b2value(ValBin, integer) -> binary_to_integer(ValBin);
-b2value(ValBin, float) -> binary_to_float(ValBin).
-
--spec value2b(Val :: any(), Type :: schema_value_type()) -> Converted :: binary().
-value2b(Val, binary) -> Val;
-value2b(Val, integer) -> integer_to_binary(Val);
-value2b(Val, float) -> float_to_binary(Val).
-
 %% ---------------- Affiliations manipulation ----------------
 
 -spec maybe_select_new_owner(ChangeResult :: change_aff_success() | {error, bad_request}) ->
     change_aff_success() | {error, bad_request}.
-maybe_select_new_owner({ok, AU, AUC, JoiningUsers, LeavingUsers} = AffRes) ->
+maybe_select_new_owner({ok, AU, AUC, JoiningUsers, LeavingUsers} = _AffRes) ->
     {AffUsers, AffUsersChanged} =
         case is_new_owner_needed(AU) andalso find_new_owner(AU, AUC, JoiningUsers) of
             {NewOwner, PromotionType} ->
@@ -284,7 +190,7 @@ find_new_owner(AU, AUC, JoiningUsers) ->
 %%   3) demoted room owners
 select_promotion([U | _], _JoiningUsers, _DemotedOwners) ->
     {U, promote_old_member};
-select_promotion(_OldMembers, [U | _], DemotedOwners) ->
+select_promotion(_OldMembers, [U | _], _DemotedOwners) ->
     {U, promote_joined_member};
 select_promotion(_OldMembers, _JoiningUsers, [U | _]) ->
     {U, promote_demoted_owner};

--- a/test/muc_light_SUITE.erl
+++ b/test/muc_light_SUITE.erl
@@ -35,13 +35,13 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
+    application:ensure_all_started(stringprep),
     Config.
 
 end_per_suite(Config) ->
     Config.
 
 init_per_group(rsm_disco, Config) ->
-    application:start(stringprep),
     Config;
 init_per_group(_, Config) ->
     Config.
@@ -52,7 +52,6 @@ end_per_group(_, Config) ->
 init_per_testcase(codec_calls, Config) ->
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
-    {ok, _} = application:ensure_all_started(stringprep),
     {ok, _} = application:ensure_all_started(exometer_core),
     ets:new(local_config, [named_table]),
     ejabberd_hooks:start_link(),

--- a/test/muc_light_SUITE.erl
+++ b/test/muc_light_SUITE.erl
@@ -155,13 +155,24 @@ simple_config_items_are_parsed(_Config) ->
                   {"incarnation", "13"},
                   {"spoilers", "false"}
                  ],
-    ExpectedSchema = #{
-      <<"roomname">> => {<<"TARDIS">>, roomname, binary}, roomname => <<"roomname">>,
-      <<"subject">> => {<<"Time Travel">>, subject, binary}, subject => <<"subject">>,
-      <<"incarnation">> => {<<"13">>, incarnation, binary}, incarnation => <<"incarnation">>,
-      <<"spoilers">> => {<<"false">>, spoilers, binary}, spoilers => <<"spoilers">>
+    Schema = mod_muc_light_room_config:schema_from_definition(Definition),
+
+    ExpectedFields = #{
+      <<"roomname">> => {<<"TARDIS">>, roomname, binary},
+      <<"subject">> => {<<"Time Travel">>, subject, binary},
+      <<"incarnation">> => {<<"13">>, incarnation, binary},
+      <<"spoilers">> => {<<"false">>, spoilers, binary}
      },
-    ?assertEqual(ExpectedSchema, mod_muc_light_room_config:schema_from_definition(Definition)).
+    ?assertEqual(ExpectedFields, mod_muc_light_room_config:schema_fields(Schema)),
+
+    ExpectedRevIndex = #{
+      roomname => <<"roomname">>,
+      subject => <<"subject">>,
+      incarnation => <<"incarnation">>,
+      spoilers => <<"spoilers">>
+     },
+    ?assertEqual(ExpectedRevIndex, mod_muc_light_room_config:schema_reverse_index(Schema)).
+
 
 full_config_items_are_parsed(_Config) ->
     Definition = [
@@ -170,13 +181,24 @@ full_config_items_are_parsed(_Config) ->
                   {"incarnation", 13, incarnation, integer},
                   {"height", 1.67, height, float}
                  ],
-    ExpectedSchema = #{
-      <<"roomname">> => {<<"TARDIS">>, roomname, binary}, roomname => <<"roomname">>,
-      <<"subject">> => {<<"Time Travel">>, subject, binary}, subject => <<"subject">>,
-      <<"incarnation">> => {13, incarnation, integer}, incarnation => <<"incarnation">>,
-      <<"height">> => {1.67, height, float}, height => <<"height">>
+    Schema = mod_muc_light_room_config:schema_from_definition(Definition),
+
+    ExpectedFields = #{
+      <<"roomname">> => {<<"TARDIS">>, roomname, binary},
+      <<"subject">> => {<<"Time Travel">>, subject, binary},
+      <<"incarnation">> => {13, incarnation, integer},
+      <<"height">> => {1.67, height, float}
      },
-    ?assertEqual(ExpectedSchema, mod_muc_light_room_config:schema_from_definition(Definition)).
+    ?assertEqual(ExpectedFields, mod_muc_light_room_config:schema_fields(Schema)),
+
+    ExpectedRevIndex = #{
+      roomname => <<"roomname">>,
+      subject => <<"subject">>,
+      incarnation => <<"incarnation">>,
+      height => <<"height">>
+     },
+    ?assertEqual(ExpectedRevIndex, mod_muc_light_room_config:schema_reverse_index(Schema)).
+
 
 invalid_binary_default_value_is_rejected(_Config) ->
     ?assertError(_, mod_muc_light_room_config:schema_from_definition([{"roomname", 12345}])),
@@ -195,14 +217,21 @@ unicode_config_fields_are_supported(_Config) ->
     Definition = [{"zażółćgęśląjaźń", "gżegżółka"},
                   {"Рентгеноэлектрокардиографический", 42,
                    'Рентгеноэлектрокардиографический', integer}],
-    ExpectedSchema = #{
+    Schema = mod_muc_light_room_config:schema_from_definition(Definition),
+
+    ExpectedFields = #{
       <<"zażółćgęśląjaźń"/utf8>> => {<<"gżegżółka"/utf8>>, 'zażółćgęśląjaźń', binary},
-      'zażółćgęśląjaźń' => <<"zażółćgęśląjaźń"/utf8>>,
       <<"Рентгеноэлектрокардиографический"/utf8>> =>
-            {42, 'Рентгеноэлектрокардиографический', integer},
+            {42, 'Рентгеноэлектрокардиографический', integer}
+     },
+    ?assertEqual(ExpectedFields, mod_muc_light_room_config:schema_fields(Schema)),
+
+    ExpectedRevIndex = #{
+      'zażółćgęśląjaźń' => <<"zażółćgęśląjaźń"/utf8>>,
       'Рентгеноэлектрокардиографический' => <<"Рентгеноэлектрокардиографический"/utf8>>
      },
-    ?assertEqual(ExpectedSchema, mod_muc_light_room_config:schema_from_definition(Definition)).
+    ?assertEqual(ExpectedRevIndex, mod_muc_light_room_config:schema_reverse_index(Schema)).
+
 
 %% ------------------------------------------------------------------
 %% Properties and validators


### PR DESCRIPTION
This PR:

- [x] Changes the way room config schema is declared in MIM config (there is no separate option for default values).
- [x] Moves whole room config processing to a separate module.
- [x] Updates documentation and migration guide.

**Note for the reviewers:** Former 3 commits include only the refactoring part (item 2 in the list above) so may be reviewed independently for clarity.