### PR TITLE
Allow emoji in vcard's nickname field

### DIFF
--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -74,7 +74,8 @@ groups() ->
 rw_tests() ->
     [
      update_own_card,
-     cant_update_own_card_with_invalid_field
+     cant_update_own_card_with_invalid_field,
+     can_update_own_card_with_emoji_in_nickname
     ].
 
 ro_full_search_tests() ->
@@ -223,6 +224,18 @@ cant_update_own_card_with_invalid_field(Config) ->
                 escalus:assert(is_iq_error, Client1SetResultStanza)
         end).
 
+can_update_own_card_with_emoji_in_nickname(Config) ->
+    escalus:story(
+        Config, [{alice, 1}],
+        fun(Client1) ->
+                %% One of "Non-character code points". Banned in stringrep but still valid UTF.
+                Client1Fields = [{<<"NICKNAME">>, <<"Jan 😊"/utf8>>}],
+                Client1SetResultStanza
+                    = escalus:send_and_wait(Client1,
+                                            escalus_stanza:vcard_update(Client1Fields)),
+                escalus:assert(is_iq_result, Client1SetResultStanza)
+        end).
+
 retrieve_own_card(Config) ->
     escalus:story(
       Config, [{alice, 1}],
@@ -236,8 +249,8 @@ retrieve_own_card(Config) ->
 
 
 
-%% If no vCard exists, the server MUST return a stanza error 
-%% (which SHOULD be <item-not-found/>) or an IQ-result 
+%% If no vCard exists, the server MUST return a stanza error
+%% (which SHOULD be <item-not-found/>) or an IQ-result
 %% containing an empty <vCard/> element.
 %% We return <item-not-found/>
 user_doesnt_exist(Config) ->

--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -205,7 +205,6 @@ do_update_own_card(Config) ->
                     = escalus:send_and_wait(Client1,
                                         escalus_stanza:vcard_update(Client1Fields)),
                 escalus:assert(is_iq_result, Client1SetResultStanza),
-                escalus_stanza:vcard_request(),
                 Client1GetResultStanza
                     = escalus:send_and_wait(Client1, escalus_stanza:vcard_request()),
                 <<"Old name">>
@@ -228,12 +227,15 @@ can_update_own_card_with_emoji_in_nickname(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Client1) ->
-                %% One of "Non-character code points". Banned in stringrep but still valid UTF.
-                Client1Fields = [{<<"NICKNAME">>, <<"Jan 😊"/utf8>>}],
+                NickWithEmoji = <<"Jan 😊"/utf8>>,
+                Client1Fields = [{<<"NICKNAME">>, NickWithEmoji}],
                 Client1SetResultStanza
                     = escalus:send_and_wait(Client1,
                                             escalus_stanza:vcard_update(Client1Fields)),
-                escalus:assert(is_iq_result, Client1SetResultStanza)
+                escalus:assert(is_iq_result, Client1SetResultStanza),
+                Client1GetResultStanza
+                    = escalus:send_and_wait(Client1, escalus_stanza:vcard_request()),
+                NickWithEmoji = stanza_get_vcard_field_cdata(Client1GetResultStanza, <<"NICKNAME">>)
         end).
 
 retrieve_own_card(Config) ->


### PR DESCRIPTION
This PR addresses #2384

Proposed changes include:
* parse vcard fields which are part of search index
* allow emoji in `NICKNAME` but remove it from the nickname index
* extend tests to check if nickname with emoji is set correctly

