### PR TITLE
Fix crash if user JID binary is empty

### DIFF
--- a/src/mongoose_client_api.erl
+++ b/src/mongoose_client_api.erl
@@ -110,6 +110,8 @@ do_authorize({AuthMethod, User, Password}, HTTPMethod) ->
             mongoose_api_common:is_known_auth_method(AuthMethod)
     end.
 
+check_password(<<>>, Password) ->
+    false;
 check_password(User, Password) ->
     #jid{luser = RawUser, lserver = Server} = jid:from_binary(User),
     Creds0 = mongoose_credentials:new(Server),

--- a/src/mongoose_client_api.erl
+++ b/src/mongoose_client_api.erl
@@ -110,7 +110,7 @@ do_authorize({AuthMethod, User, Password}, HTTPMethod) ->
             mongoose_api_common:is_known_auth_method(AuthMethod)
     end.
 
-check_password(<<>>, Password) ->
+check_password(<<>>, _) ->
     false;
 check_password(User, Password) ->
     #jid{luser = RawUser, lserver = Server} = jid:from_binary(User),


### PR DESCRIPTION
When user try do authorization by REST API and try send data without JID in Authorization field eg, `base64(<<":password">>)` or `<<"">>` -  the MongooseIM provide crash report.

Proposed changes include:
* Fix crash if User JID binary is empty
```sh
12:24:10.481 [error] CRASH REPORT Process <0.1343.0> with 0 neighbours crashed with reason: no match of right hand value error in mongoose_client_api:check_password/2 line 115
12:24:10.483 [error] Lager event handler error_logger_lager_h exited with reason {'EXIT',{{case_clause,['ejabberd_cowboy_0.0.0.0_8089',<0.1341.0>,2,<0.1343.0>,{badmatch,error},[{mongoose_client_api,check_password,2,[{file,"/home/user/mongooseim/_build/prod/lib/mongooseim/src/mongoose_client_api.erl"},{line,115}]},{mongoose_client_api,do_authorize,2,[{file,"/home/user/mongooseim/_build/prod/lib/mongooseim/src/mongoose_client_api.erl"},{line,109}]},{mongoose_client_api,authorize,4,[{file,"/home/user/mongooseim/_build/prod/l..."},...]},...]]},...}}
```

