### PR TITLE
Move logic from jid:from_binary into a nif

### DIFF
--- a/c_src/jid.cpp
+++ b/c_src/jid.cpp
@@ -1,0 +1,75 @@
+#include "erl_nif.h"
+#include <cstring>
+
+ERL_NIF_TERM
+mk_error(ErlNifEnv* env)
+{
+    ERL_NIF_TERM ret;
+    enif_make_existing_atom(env, "error", &ret, ERL_NIF_LATIN1);
+    return ret;
+}
+
+static ERL_NIF_TERM
+from_binary_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    if(argc != 1) {
+        return enif_make_badarg(env);
+    }
+
+    ErlNifBinary bin;
+    if (!enif_inspect_binary(env, argv[0], &bin)) {
+        return enif_make_badarg(env);
+    }
+
+    const unsigned size = bin.size;
+    unsigned commercial_at = -1;
+    unsigned slash = size;
+    for (unsigned i = 0; i < size ; ++i) {
+        switch(bin.data[i]) {
+            case '/':
+                if (slash == size) {
+                    slash = i;
+                    goto end_loop;
+                }
+                break;
+            case '@':
+                if (commercial_at == -1) {
+                    commercial_at = i;
+                } else
+                    return mk_error(env);
+                break;
+        }
+    }
+end_loop:
+    if (commercial_at == 0 || slash == 0) {
+        return mk_error(env);
+    }
+
+    unsigned host_size = slash - commercial_at - 1;
+    if (host_size == 0) return mk_error(env);
+    ERL_NIF_TERM host;
+    unsigned char *host_data = enif_make_new_binary(env, host_size, &host);
+    std::memcpy(host_data, &(bin.data[commercial_at+1]), host_size);
+
+    ERL_NIF_TERM resource;
+    unsigned res_size = slash >= size-1 ? 0 : size-1-slash;
+    unsigned char *res_data = enif_make_new_binary(env, res_size, &resource);
+    std::memcpy(res_data, &(bin.data[slash + 1]), res_size);
+
+    ERL_NIF_TERM user;
+    unsigned user_size = commercial_at == -1 ? 0 : commercial_at;
+    unsigned char *user_data = enif_make_new_binary(env, user_size, &user);
+    std::memcpy(user_data, &(bin.data[0]), user_size);
+
+    return enif_make_tuple3(
+            env,
+            user,
+            host,
+            resource);
+}
+
+static ErlNifFunc jid_nif_funcs[] = {
+    {"from_binary_nif", 1, from_binary_nif}
+};
+
+ERL_NIF_INIT(jid, jid_nif_funcs, NULL, NULL, NULL, NULL);

--- a/c_src/jid.cpp
+++ b/c_src/jid.cpp
@@ -114,7 +114,7 @@ to_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     unsigned index = 0;
     unsigned len =
         server.size + // there's always a server
-        (user.size == 0 ? 0 : user.size + 1) + // user plus commertial_at, if any
+        (user.size == 0 ? 0 : user.size + 1) + // user plus commercial_at, if any
         (resource.size == 0 ? 0 : resource.size + 1); // res plus slash, if any
 
     ERL_NIF_TERM final_jid;

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,8 @@
 {port_specs,
  [
   {".*", "priv/lib/ejabberd_zlib_drv.so", ["c_src/ejabberd_zlib_drv.c"], [{env, [{"LDFLAGS", "$LDFLAGS -lz"}]}]},
-  {".*", "priv/lib/mongoose_mam_id.so", ["c_src/mongoose_mam_id.cpp"], [{env, [{"CXXFLAGS", "$CXXFLAGS -std=c++11"}]}]}
+  {".*", "priv/lib/mongoose_mam_id.so", ["c_src/mongoose_mam_id.cpp"], [{env, [{"CXXFLAGS", "$CXXFLAGS -std=c++11"}]}]},
+  {".*", "priv/lib/jid.so", ["c_src/jid.cpp"], [{env, [{"CXXFLAGS", "$CXXFLAGS -std=c++11"}]}]}
  ]}.
 
 {require_min_otp_vsn, "21"}.

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -66,6 +66,9 @@
              ]).
 
 -define(SANE_LIMIT, 1024).
+-define(XMPP_JID_SIZE_LIMIT, 3071).
+% Maximum JID size in octets (bytes) as defined in
+% https://tools.ietf.org/html/rfc7622#section-3.1
 
 -spec make(User :: user(), Server :: server(), Res :: resource()) -> jid()  | error.
 make(User, Server, Res) ->
@@ -123,11 +126,13 @@ are_bare_equal(_, _) ->
     false.
 
 -spec from_binary(binary()) ->  error  | jid().
-from_binary(J) ->
+from_binary(J) when is_binary(J), byte_size(J) < ?XMPP_JID_SIZE_LIMIT ->
     case from_binary_nif(J) of
         {U, H, R} -> make(U, H, R);
         error -> error
-    end.
+    end;
+from_binary(_) ->
+    error.
 
 -spec from_binary_nif(binary()) ->  error | simple_jid().
 from_binary_nif(_) ->

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -134,10 +134,14 @@ from_binary(J) when is_binary(J), byte_size(J) < ?XMPP_JID_SIZE_LIMIT ->
 from_binary(_) ->
     error.
 
+%% Original Erlang equivalent can be found in test/jid_SUITE.erl,
+%% together with `proper` generators to check for equivalence
 -spec from_binary_nif(binary()) ->  error | simple_jid().
 from_binary_nif(_) ->
     erlang:nif_error(not_loaded).
 
+%% Original Erlang equivalent can be found in test/jid_SUITE.erl,
+%% together with `proper` generators to check for equivalence
 -spec to_binary(simple_jid() | simple_bare_jid() | jid()) ->  binary().
 to_binary(_) ->
     erlang:nif_error(not_loaded).

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -125,11 +125,11 @@ are_bare_equal(_, _) ->
 -spec from_binary(binary()) ->  error  | jid().
 from_binary(J) ->
     case from_binary_nif(J) of
-        {U,H,R} -> make(U,H,R);
+        {U, H, R} -> make(U, H, R);
         error -> error
     end.
 
--spec from_binary_nif(binary()) ->  error  | {binary(), binary(), binary()}.
+-spec from_binary_nif(binary()) ->  error | simple_jid().
 from_binary_nif(_) ->
     erlang:nif_error(not_loaded).
 

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -130,32 +130,12 @@ from_binary(J) ->
     end.
 
 -spec from_binary_nif(binary()) ->  error  | {binary(), binary(), binary()}.
-from_binary_nif(B) when is_binary(B) ->
+from_binary_nif(_) ->
     erlang:nif_error(not_loaded).
 
 -spec to_binary(simple_jid() | simple_bare_jid() | jid()) ->  binary().
-to_binary(Jid) when is_binary(Jid) ->
-    % sometimes it is used to format error messages
-    Jid;
-to_binary(#jid{user = User, server = Server, resource = Resource}) ->
-    to_binary({User, Server, Resource});
-to_binary({User, Server}) ->
-    to_binary({User, Server, <<>>});
-to_binary({Node, Server, Resource}) ->
-    S1 = case Node of
-             <<>> ->
-                 <<>>;
-             _ ->
-                 <<Node/binary, "@">>
-         end,
-    S2 = <<S1/binary, Server/binary>>,
-    S3 = case Resource of
-             <<>> ->
-                 S2;
-             _ ->
-                 <<S2/binary, "/", Resource/binary>>
-         end,
-    S3.
+to_binary(_) ->
+    erlang:nif_error(not_loaded).
 
 -spec is_nodename(<<>> | binary()) -> boolean().
 is_nodename(<<>>) ->

--- a/test/jid_SUITE.erl
+++ b/test/jid_SUITE.erl
@@ -140,3 +140,91 @@ compare_bare_jids(_) ->
                     equals(jid:are_equal(jid:to_bare(AA), jid:to_bare(BB)),
                            jid:are_bare_equal(AA, BB))
                  end)).
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Original code kept for documentation purposes
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Some property based testing to check for equivalence
+prop_to() ->
+    ?FORALL(L, binary(), from_binary(L) =:= jid:from_binary(L)).
+
+prop_from() ->
+    ?FORALL(L, from_jid_gen(), to_binary(L) =:= jid:to_binary(L)).
+
+from_jid_gen() ->
+    oneof([
+            {jid_gen:username(), jid_gen:domain(), jid_gen:resource()},
+            {<<>>, jid_gen:domain(), jid_gen:resource()},
+            {jid_gen:username(), jid_gen:domain()},
+            {jid, jid_gen:username(), jid_gen:domain(), jid_gen:resource(),
+             jid_gen:username(), jid_gen:domain(), jid_gen:resource()}
+          ]).
+
+% Original code
+-spec from_binary(binary()) ->  error  | jid:jid().
+from_binary(J) ->
+    binary_to_jid1(J, []).
+
+-spec binary_to_jid1(binary(), [byte()]) -> 'error' | jid:jid().
+binary_to_jid1(<<$@, _J/binary>>, []) ->
+    error;
+binary_to_jid1(<<$@, J/binary>>, N) ->
+    binary_to_jid2(J, lists:reverse(N), []);
+binary_to_jid1(<<$/, _J/binary>>, []) ->
+    error;
+binary_to_jid1(<<$/, J/binary>>, N) ->
+    binary_to_jid3(J, [], lists:reverse(N), []);
+binary_to_jid1(<<C, J/binary>>, N) ->
+    binary_to_jid1(J, [C | N]);
+binary_to_jid1(<<>>, []) ->
+    error;
+binary_to_jid1(<<>>, N) ->
+    jid:make(<<>>, list_to_binary(lists:reverse(N)), <<>>).
+
+%% @doc Only one "@" is admitted per JID
+-spec binary_to_jid2(binary(), [byte()], [byte()]) -> 'error' | jid:jid().
+binary_to_jid2(<<$@, _J/binary>>, _N, _S) ->
+    error;
+binary_to_jid2(<<$/, _J/binary>>, _N, []) ->
+    error;
+binary_to_jid2(<<$/, J/binary>>, N, S) ->
+    binary_to_jid3(J, N, lists:reverse(S), []);
+binary_to_jid2(<<C, J/binary>>, N, S) ->
+    binary_to_jid2(J, N, [C | S]);
+binary_to_jid2(<<>>, _N, []) ->
+    error;
+binary_to_jid2(<<>>, N, S) ->
+    jid:make(list_to_binary(N), list_to_binary(lists:reverse(S)), <<>>).
+
+-spec binary_to_jid3(binary(), [byte()], [byte()], [byte()]) -> 'error' | jid:jid().
+binary_to_jid3(<<C, J/binary>>, N, S, R) ->
+    binary_to_jid3(J, N, S, [C | R]);
+binary_to_jid3(<<>>, N, S, R) ->
+    jid:make(list_to_binary(N), list_to_binary(S), list_to_binary(lists:reverse(R))).
+
+-spec to_binary(jid:simple_jid() | jid:simple_bare_jid() | jid:jid()) ->  binary().
+to_binary(Jid) when is_binary(Jid) ->
+    % sometimes it is used to format error messages
+    Jid;
+to_binary(#jid{user = User, server = Server, resource = Resource}) ->
+    to_binary({User, Server, Resource});
+to_binary({User, Server}) ->
+    to_binary({User, Server, <<>>});
+to_binary({Node, Server, Resource}) ->
+    S1 = case Node of
+             <<>> ->
+                 <<>>;
+             _ ->
+                 <<Node/binary, "@">>
+         end,
+    S2 = <<S1/binary, Server/binary>>,
+    S3 = case Resource of
+             <<>> ->
+                 S2;
+             _ ->
+                 <<S2/binary, "/", Resource/binary>>
+         end,
+    S3.


### PR DESCRIPTION
When running and profiling MIM, a thing to pay attention to was these results from `cprof` on master, for a scenario like "5k users sending a 1-to-1 message per second", where this was the very top:
```
 [{jid,580785,
      [{{jid,binary_to_jid2,3},151070},
       {{jid,binary_to_jid1,2},147721},
       {{jid,to_binary,1},60428},
       {{jid,binary_to_jid3,4},45315},
       {{jid,from_binary,1},15107},
```
Curious about the module `jid` being the most often called module, this is what I got from `eprof`:
```
FUNCTION                        CALLS        %      TIME  [uS / CALLS]
--------                        -----  -------      ----  [----------]
jid:from_binary/1               18166     0.04     14198  [      0.78]
jid:binary_to_jid1/2           177606     0.19     75071  [      0.42]
jid:binary_to_jid2/3           181660     0.19     77570  [      0.43]
jid:binary_to_jid3/4            50679     0.05     21607  [      0.43]
jid:to_binary/1                 73192     0.24     97110  [      1.33]
```

After moving these two most expensive to/from functions to a nif, the `jid` module shows much lower on the `cprof` stats, and on `eprof`, I get this:

```
FUNCTION                        CALLS        %      TIME  [uS / CALLS]
--------                        -----  -------      ----  [----------]
jid:from_binary/1               18129     0.04      7708  [ 0.43]
jid:from_binary_nif/1           18129     0.08     16364  [ 0.90]
jid:to_binary/1                 36258     0.14     28505  [ 0.79]
```

---

In micro-benchmarking, I get results like these:
```
> ListOfJids = test:make_random_jid_list(1000000).
[<<"45481fe0-4bc9-47d5-a4e9-65d7eb97d29c@erlang-solutions.com/e04444b4-0b43-4a40
-9583-09f305c2a7fd">>,
 <<"bf274267-d1e6-4db4-98d8-a1539d13dd25@erlang-solutions.com/53e96ff0-0ef8-412e
-92dd-293d906ff79a">>,
 <<...>>|...]
> timer:tc(fun() -> [ test:from_binary_old(J) || J <- ListOfJids], ok end).
{17448361,ok}
> timer:tc(fun() -> [ mongooseim_jid:from_binary(J) || J <- ListOfJids], ok end).
{3968555,ok}
```
and
```
> ListOfJids = test:make_random_bin_list(1000000).
[{<<"f54468b2-e7cd-4c35-9cba-88f8346afad3">>,
  <<"erlang-solutions.com">>,
  <<"cb166805-b9af-4698-ad29-1ed58eef6e8b">>},
 {...}|...]
> timer:tc(fun() -> [ test:to_binary_old(J) || J <- ListOfJids], ok end).
{4773948,ok}
> timer:tc(fun() -> [ jid:to_binary(J) || J <- ListOfJids], ok end).
{2741042,ok}
```
Where resulting times are consistent across repeats, with an apparent improvement of at least x4.

---

And more, using proper as given in the test files, I get the new nif implementation to be equivalent to the old one for several passes of a million test cases
```
prop_to() ->
    ?FORALL(L, binary(), from_binary(L) =:= jid:from_binary(L)).

prop_from() ->
    ?FORALL(L, from_jid_gen(), to_binary(L) =:= jid:to_binary(L)).
```

---

[master_vs_jidnif.tar.gz](https://github.com/esl/MongooseIM/files/3905790/master_vs_jidnif.tar.gz)
Attached a tar with cprof, eprof, and fprof files with the results from the same scenario both on master and on this branch.