### PR TITLE
Refactor the calculation to avoid reduntant time conversions

### DIFF
--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -356,7 +356,7 @@ process_data(Data, #state{parser = Parser,
                           stanza_chunk_size = ChunkSize,
                           c2s_pid = C2SPid} = State) ->
     ?DEBUG("Received XML on stream = \"~s\"", [Data]),
-    Size = size(Data),
+    Size = byte_size(Data),
     maybe_run_keep_alive_hook(Size, State),
     {C2SEvents, NewParser} =
         case exml_stream:parse(Parser, Data) of

--- a/src/shaper.erl
+++ b/src/shaper.erl
@@ -22,7 +22,7 @@
 -record(shaper, {
     max_rate :: undefined | pos_integer(),
     tokens = 0 :: non_neg_integer(),
-    last_update = erlang:monotonic_time() :: integer()
+    last_update = erlang:monotonic_time(millisecond) :: integer()
 }).
 
 -type shaper() :: #shaper{} | none.
@@ -32,9 +32,11 @@
 -spec new(atom()) -> shaper().
 new(Name) ->
     case ejabberd_config:get_global_option({shaper, Name, global}) of
-        undefined -> none;
-        none -> none;
-        {maxrate, MaxRate} -> #shaper{max_rate = MaxRate, tokens = MaxRate}
+        {maxrate, MaxRatePerSecond} ->
+            #shaper{max_rate = MaxRatePerSecond,
+                    tokens = MaxRatePerSecond,
+                    last_update = erlang:monotonic_time(millisecond)};
+        _ -> none
     end.
 
 %% @doc Update shaper.
@@ -42,21 +44,20 @@ new(Name) ->
 -spec update(shaper(), Size :: pos_integer()) -> {shaper(), Delay :: non_neg_integer()}.
 update(none, _Size) ->
     {none, 0};
-update(Shaper, Size) ->
-    Now = erlang:monotonic_time(),
-    Second = erlang:convert_time_unit(1, seconds, native),
-
-    SecondsSinceLastUpdate = (Now - Shaper#shaper.last_update) / Second,
-    TokenGrowth = round(Shaper#shaper.max_rate * SecondsSinceLastUpdate),
-    Tokens = min(Shaper#shaper.max_rate, Shaper#shaper.tokens + TokenGrowth),
-
-    TokensLeft = max(0, Tokens - Size),
-    AdditionalTokensNeeded = max(0, Size - Tokens),
-
-    TimeNeededForTokensToGrow = round(AdditionalTokensNeeded / Shaper#shaper.max_rate * Second),
-    Delay = erlang:convert_time_unit(TimeNeededForTokensToGrow, native, millisecond),
-    LastUpdate = Now + TimeNeededForTokensToGrow,
-
-    lager:debug("Tokens: ~p (+~p,-~p), delay: ~p ms", [TokensLeft, TokenGrowth, Size, Delay]),
-
-    {Shaper#shaper{last_update = LastUpdate, tokens = TokensLeft}, Delay}.
+update(#shaper{max_rate = MaxRatePerSecond,
+               tokens = LastAvailableTokens,
+               last_update = LastUpdate}, NowUsed) ->
+    Now = erlang:monotonic_time(millisecond),
+    % How much we might have recovered since last time, in milliseconds arithmetic
+    GrowthPerMillisecond = MaxRatePerSecond / 1000,
+    MilliSecondsSinceLastUpdate = (Now - LastUpdate),
+    PossibleTokenGrowth = round(GrowthPerMillisecond * MilliSecondsSinceLastUpdate),
+    % Available plus recovered cannot grow higher than the actual rate limit
+    ExactlyAvailableNow = min(MaxRatePerSecond, LastAvailableTokens + PossibleTokenGrowth),
+    TokensAvailable = max(0, ExactlyAvailableNow - NowUsed),
+    TokensOverused = max(0, NowUsed - ExactlyAvailableNow),
+    MaybeDelay = round(TokensOverused / GrowthPerMillisecond),
+    {#shaper{max_rate = MaxRatePerSecond,
+             tokens = TokensAvailable,
+             last_update = Now + MaybeDelay},
+     MaybeDelay}.


### PR DESCRIPTION
On `shaper.erl`, the arithmetics are done by converting to and from `native`-`second` time units, which shows on the profiling statistics I gathered last time:

> for a scenario like "5k users sending a 1-to-1 message per second"

```
FUNCTION                              CALLS        %      TIME  [uS / CALLS]
--------                              -----  -------      ----  [----------]
erlang:monotonic_time/0                5999     0.01      1022  [      0.17]
erlang:convert_time_unit/3            11998     0.04      8580  [      0.72]
```

We see that `convert_time_unit/3` is called twice as often as `monotonic_time/0`, which is exactly what `shaper:update/2` does.

On `fprof`, we can see that, of the accumulated 130us that `shaper:update/2` takes, 20us of them are spent on `erlang:convert_time_unit/3`, plus 4us on `erlang:monotonic_time/0`, while
```
{[{{ejabberd_receiver,process_data,2},         1409,  130.061,   51.471}],     
 { {shaper,update,2},                          1409,  130.061,   51.471},     %
 [{{erlang,convert_time_unit,3},               2818,   34.792,   20.457},      
  {{lager_config,get,2},                       1409,   15.401,   10.091},      
  {{erlang,whereis,1},                         2818,    9.563,    9.563},      
  {{erlang,max,2},                             2818,    9.154,    9.154},      
  {{erlang,monotonic_time,0},                  1409,    4.882,    4.882},      
  {{erlang,min,2},                             1409,    4.798,    4.798}]}.    

```

My main idea to optimise this, is this quote from the [`erlang:monotonic_time/1`](http://erlang.org/doc/man/erlang.html#monotonic_time-1) docs:

> Same as calling erlang:convert_time_unit(erlang:monotonic_time(), native, Unit), however optimized for commonly used Units.