### PR TITLE
MongoosePush API v3 mock

### DIFF
--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -13,8 +13,10 @@ start(Config) ->
     CertPath = path_helper:canonicalize_path(filename:join(CertDir, "cert.pem")),
     KeyPath = path_helper:canonicalize_path(filename:join(CertDir, "key.pem")),
 
-    Dispatch = cowboy_router:compile([{'_', [{<<"/v2/notification/:token">>, ?MODULE, #{}}]},
-                                      {'_', [{<<"/v3/notification/:token">>, ?MODULE, #{}}]}]),
+    Dispatch = cowboy_router:compile([{'_', [{<<"/v2/notification/:token">>, ?MODULE, #{}},
+                                             {<<"/v3/notification/:token">>, ?MODULE, #{}}
+                                            ]}
+                                     ]),
     {ok, Pid} = cowboy:start_tls(mongoose_push_https_mock,
                                  [{certfile, CertPath}, {keyfile, KeyPath}],
                                  #{env => #{dispatch => Dispatch}}),

--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -13,7 +13,8 @@ start(Config) ->
     CertPath = path_helper:canonicalize_path(filename:join(CertDir, "cert.pem")),
     KeyPath = path_helper:canonicalize_path(filename:join(CertDir, "key.pem")),
 
-    Dispatch = cowboy_router:compile([{'_', [{<<"/v2/notification/:token">>, ?MODULE, #{}}]}]),
+    Dispatch = cowboy_router:compile([{'_', [{<<"/v2/notification/:token">>, ?MODULE, #{}}]},
+                                      {'_', [{<<"/v3/notification/:token">>, ?MODULE, #{}}]}]),
     {ok, Pid} = cowboy:start_tls(mongoose_push_https_mock,
                                  [{certfile, CertPath}, {keyfile, KeyPath}],
                                  #{env => #{dispatch => Dispatch}}),

--- a/doc/migrations/3.5.0_3.5.0plus.md
+++ b/doc/migrations/3.5.0_3.5.0plus.md
@@ -1,3 +1,7 @@
+## Push notifications
+
+In this version push notifications by default work with MongoosePush 2.0.0 and it's API v3.
+
 ## Different MUC Light room schema definition
 
 We have introduced a change that enforces defining fields with default values.
@@ -68,7 +72,7 @@ The current method makes it impossible to make the same mistake, as it disallows
                  {"priority", 10, priority, integer},
                  {"owners-height", 180.0, owners_height, float}
                 ]}
-                 
+
 ```
 
 ### What has changed? - for developers

--- a/doc/migrations/3.5.0_3.5.0plus.md
+++ b/doc/migrations/3.5.0_3.5.0plus.md
@@ -1,6 +1,6 @@
 ## Push notifications
 
-In this version push notifications by default work with MongoosePush 2.0.0 and it's API v3.
+In this version, push notifications work with MongoosePush 2.0.0 and it's API v3 by default.
 
 ## Different MUC Light room schema definition
 
@@ -86,4 +86,3 @@ For more information, please check the specs for types and functions in the afor
 
 * The default room config is still the same, i.e. `roomname` (default: `"Untitled"`) and `subject` (empty string).
 * The room config representation in databases (both Mnesia and RDBMS) is the same; no need for migration.
-

--- a/doc/modules/mod_push_service_mongoosepush.md
+++ b/doc/modules/mod_push_service_mongoosepush.md
@@ -25,7 +25,7 @@ It must be defined in [outgoing_pools setting](../advanced-configuration/outgoin
 ### Options
 
 * **pool_name** (atom, required) - name of the pool to use (as defined in `outgoing_pools`)
-* **api_version** (string, default: `v2`) - REST API version to be used.
+* **api_version** (string, default: `v3`) - REST API version to be used.
 * **max_http_connections** (integer, default: 100) - the maximum amount of concurrent http connections
 
 ### Example configuration
@@ -39,6 +39,6 @@ It must be defined in [outgoing_pools setting](../advanced-configuration/outgoin
 
 {mod_push_service_mongoosepush, [
         {pool_name, mongoose_push_http}
-        {api_version, "v2"}
+        {api_version, "v3"}
 ]}.
 ```

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -8,7 +8,7 @@ The following list shows those components as defined in
 
   * _XMPP Server_ in MongooseIM is enabled by module [mod_event_pusher_push][]
   * _App Server_ in MongooseIM is enabled by adding a `push` node type to [mod_pubsub][]'s configuration
-  * _XMPP Push Service_ is implemented as a [MongoosePush][] application, recommended version is 2.0.0 or above
+  * _XMPP Push Service_ is implemented as a [MongoosePush][] application, the recommended version is 2.0.0 or above
 
 All these entities have to be enabled and properly configured in order to use push notifications.
 So let's get to it, shall we?

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -8,7 +8,7 @@ The following list shows those components as defined in
 
   * _XMPP Server_ in MongooseIM is enabled by module [mod_event_pusher_push][]
   * _App Server_ in MongooseIM is enabled by adding a `push` node type to [mod_pubsub][]'s configuration
-  * _XMPP Push Service_ is implemented as a [MongoosePush][] application
+  * _XMPP Push Service_ is implemented as a [MongoosePush][] application, recommended version is 2.0.0 or above
 
 All these entities have to be enabled and properly configured in order to use push notifications.
 So let's get to it, shall we?
@@ -97,7 +97,7 @@ Then add `mod_push_service_mongoosepush` to the `modules` section in the config 
 
     {mod_push_service_mongoosepush, [
         {pool_name, mongoose_push_http},
-        {api_version, "v2"}]},
+        {api_version, "v3"}]},
 
     (...)
 ```
@@ -105,7 +105,7 @@ Then add `mod_push_service_mongoosepush` to the `modules` section in the config 
 First, we create the HTTP pool for communicating with [MongoosePush][].
 Here, we assume that [MongoosePush][] will be available on the localhost on port 8443 which is the default one.
 Next we enable [mod_push_service_mongoosepush][].
-First option is the name of the HTTP pool to use and the second one is the version of [MongoosePush][]'s API (currently only "_v2_" is supported).
+First option is the name of the HTTP pool to use and the second one is the version of [MongoosePush][]'s API ("_v2_" or "_v3_" are supported).
 
 And that's it, we've just completed the entire MongooseIM configuration.
 All we need to do now is to set up [MongoosePush][].

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -106,14 +106,17 @@ http_notification(Host, Method, URL, ReqHeaders, Payload) ->
             case binary_to_integer(BinStatusCode) of
                 StatusCode when StatusCode >= 200 andalso StatusCode < 300 ->
                     ok;
+                410 ->
+                    ?WARNING_MSG("issue=unable_to_submit_push_notification, https_status=410, reason=device_not_registered", []),
+                    {error, device_not_registered};
                 StatusCode when StatusCode >= 400 andalso StatusCode < 500  ->
-                    ?ERROR_MSG("Unable to submit push notification. ErrorCode ~p, Payload ~p."
-                               "Possible API mismatch - tried URL: ~p.",
-                               [StatusCode, Payload, URL]),
+                    ?ERROR_MSG("issue=unable_to_submit_push_notification, http_status=~p, url=~p, response=~p, "
+                               "details=\"Possible API mismatch\", payload=~p",
+                               [StatusCode, URL, Body, Payload]),
                     {error, {invalid_status_code, StatusCode}};
                 StatusCode ->
-                    ?WARNING_MSG("Unable to submit push notification. ErrorCode ~p, Payload ~p",
-                                 [StatusCode, Body]),
+                    ?ERROR_MSG("issue=unable_to_submit_push_notification, http_status=~p, response=~p",
+                               [StatusCode, Body]),
                     {error, {invalid_status_code, StatusCode}}
             end;
         {error, Reason} ->


### PR DESCRIPTION
Proposed changes include:
* allow to specify what HTTP status and body is returned to MongooseIM from MongoosePushMock
* extend MongoosePushMock to accept requests to API v3

