### PR TITLE
Push notifications remove expired device

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, {git, "https://github.com/proger/erlsh.git", {ref, "4e8a107"}}},
         {jiffy, "1.0.1"},
         {proper, "1.3.0"},
-        {escalus, {git, "https://github.com/esl/escalus.git", {ref, "e85f0c7"}}},
+        {escalus, {git, "https://github.com/esl/escalus.git", {ref, "39af0b4"}}},
         {gen_fsm_compat, "0.3.0"},
         {cowboy, "2.7.0"},
         {csv, "3.0.3", {pkg, csve}},

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -19,7 +19,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"e85f0c73c8af1e765f9a96612f84ba84b1360717"}},
+       {ref,"39af0b46e6e0b9931255d6710fab49754357bf57"}},
   0},
  {<<"esip">>,{pkg,<<"esip">>,<<"1.0.30">>},0},
  {<<"exml">>,

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -8,6 +8,7 @@
 -include_lib("inbox.hrl").
 
 -define(MUCLIGHTHOST, <<"muclight.localhost">>).
+-define(RPC_SPEC, #{node => distributed_helper:mim()}).
 
 
 
@@ -25,7 +26,7 @@
          become_available/2,
          become_available/3
         ]).
--import(escalus_ejabberd, [rpc/3]).
+-import(distributed_helper, [rpc/4]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -106,14 +107,14 @@ init_per_suite(Config0) ->
 
     PoolOpts = [{strategy, available_worker}, {workers, 20}],
     HTTPOpts = [{server, "https://localhost:" ++ integer_to_list(Port)}],
-    rpc(mongoose_wpool, start_configured_pools,
+    rpc(?RPC_SPEC, mongoose_wpool, start_configured_pools,
         [[{http, global, mongoose_push_http, PoolOpts, HTTPOpts}]]),
     escalus:init_per_suite(Config).
 
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    rpc(mongoose_wpool, stop, [http, global, mongoose_push_http]),
+    rpc(?RPC_SPEC, mongoose_wpool, stop, [http, global, mongoose_push_http]),
     dynamic_modules:restore_modules(domain(), Config),
     mongoose_push_mock:stop(),
     escalus:end_per_suite(Config).
@@ -129,7 +130,7 @@ init_per_group(G, Config) when G =:= pm_notifications_with_inbox;
 init_per_group(G, Config) ->
     %% Some cleaning up
     C = init_modules(G, Config),
-    catch rpc(mod_muc_light_db_backend, force_clear, []),
+    catch rpc(?RPC_SPEC, mod_muc_light_db_backend, force_clear, []),
     C.
 
 end_per_group(_, Config) ->

--- a/doc/migrations/3.5.0_3.5.0plus.md
+++ b/doc/migrations/3.5.0_3.5.0plus.md
@@ -1,6 +1,28 @@
 ## Push notifications
 
-In this version, push notifications work with MongoosePush 2.0.0 and it's API v3 by default.
+In this version, push notifications work with MongoosePush 2.0.0 and its API v3 by default.
+
+### Push notifications are send from the server's JID
+
+Since this version, MongooseIM sends the PubSub publish request to push notifications node from the server's JID.
+Previously the publish request was sent from the user's JID.
+If the push PubSub node was created with `pubsub#access_mode` set to **whitelist** and `pubsub#publish_model` set to **publishers**,
+now the server's JID needs to be added to the push node in order to send the push notifications successfully.
+
+It can be done by sending the following request from the push node's owner:
+
+```xml
+<iq to='pubsub.mypubsub'
+    type='set'
+    id='wy6Hibg='
+    from='alice@wonderland.com/resource'>
+	<pubsub xmlns='http://jabber.org/protocol/pubsub#owner'>
+		<affiliations node='punsub_node_for_my_private_iphone'>
+			<affiliation jid='mychat.com' affiliation='publish-only'/>
+		</affiliations>
+	</pubsub>
+</iq>
+```
 
 ### `mod_push` module is no longer available
 
@@ -91,4 +113,3 @@ For more information, please check the specs for types and functions in the afor
 
 * The default room config is still the same, i.e. `roomname` (default: `"Untitled"`) and `subject` (empty string).
 * The room config representation in databases (both Mnesia and RDBMS) is the same; no need for migration.
-

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -201,8 +201,25 @@ It is also recommended and important from security perspective to configure the 
 * `access_model` set to `whitelist` so only affiliated users can access the node.
 * `publish_model` set to `publishers` so only users with `publisher` or `publisher_only` role can publish notifications.
 
+#### Adding server's JID to allowed publishers
 
-After this step, you need to have the `pubsub` host (here `pubsub.mypubsub.com`) and the node name (here: `punsub_node_for_my_private_iphone`).
+Push notifications to the push node are addressed from your server JID.
+If the push node was configured with the above recommended options, you need to allow your server's JID to publish notifications to that node.
+Considering your JID is `alice@mychat.com`, your server's JID is just `mychat.com`.
+The following stanza sent to the just created push node will allow your server JID to publish notifications:
+
+```xml
+<iq to='pubsub.mypubsub.com'
+    type='set'
+    id='wy6Hibg='
+    from='alice@mychat.com/resource'>
+	<pubsub xmlns='http://jabber.org/protocol/pubsub#owner'>
+		<affiliations node='punsub_node_for_my_private_iphone'>
+			<affiliation jid='mychat.com' affiliation='publish-only'/>
+		</affiliations>
+	</pubsub>
+</iq>
+```
 
 ### Enabling push notifications
 

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -75,8 +75,11 @@ publish_notification(Acc0, From, #jid{lserver = Host} = To, Packet, Services) ->
                                                      [BareRecipient, PubsubJID, Node, Response]),
                           Acc1
                   end,
+              %% The IQ is routed from the recipient's server JID to pubsub JID
+              %% This is recommended in the XEP and also helps process replies to this IQ
+              NotificationFrom = jid:make(<<>>, Host, <<>>),
               mod_event_pusher_push:cast(Host, ejabberd_local, route_iq,
-                                         [To, PubsubJID, Acc, Stanza, ResponseHandler])
+                                         [NotificationFrom, PubsubJID, Acc, Stanza, ResponseHandler])
       end, Services),
     Acc2.
 


### PR DESCRIPTION
This PR removes push nodes corresponding to an expired device id when MongoosePush returns appropriate error code.

Proposed changes include:
* fix for publish iq response handlers
    * now the push notification is sent from the user's **server** JID (before it was user's JID)
    * it requires to add server's JID to affiliations with `publish-only` role in case the push node is configured with more strict options
* generate IQ error reply with code `406` (`not-acceptable`) of type `cancel` in case MongoosePush API v3 returns error code `410` indicating `unregistered` device
* the migration guide and push notifications user guide where update to reflect the changes.

