### PR TITLE
Fix MSSQL GDRP pubsub retrival for long usernames

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -12,7 +12,7 @@
         {erlsh, {git, "https://github.com/proger/erlsh.git", {ref, "4e8a107"}}},
         {jiffy, "1.0.1"},
         {proper, "1.3.0"},
-        {escalus, {git, "https://github.com/esl/escalus.git", {ref, "2ef7514"}}},
+        {escalus, {git, "https://github.com/esl/escalus.git", {ref, "e85f0c7"}}},
         {gen_fsm_compat, "0.3.0"},
         {cowboy, "2.7.0"},
         {csv, "3.0.3", {pkg, csve}},

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -19,7 +19,7 @@
   0},
  {<<"escalus">>,
   {git,"https://github.com/esl/escalus.git",
-       {ref,"2ef7514d0c91e957c0ced73584dcf51ef2ea923a"}},
+       {ref,"e85f0c73c8af1e765f9a96612f84ba84b1360717"}},
   0},
  {<<"esip">>,{pkg,<<"esip">>,<<"1.0.30">>},0},
  {<<"exml">>,

--- a/src/pubsub/mod_pubsub_db_rdbms_sql.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms_sql.erl
@@ -474,7 +474,7 @@ select_nodes_by_owner(LJID) ->
         {odbc, mssql} ->
             ["SELECT name, type"
             " FROM pubsub_nodes"
-            " WHERE cast(owners as varchar) = ", esc_string(iolist_to_binary(["[\"", LJID, "\"]"]))
+            " WHERE cast(owners as nvarchar(max)) = ", esc_string(iolist_to_binary(["[\"", LJID, "\"]"]))
             ]
     end.
 


### PR DESCRIPTION
After merging esl/escalus#179 the `gdpr_SUITE` stopped working in test cases related to pubsub. This was because previous way of selecting nodes by owner didn't work with long JIDs and the PR to escalus made usernames significantly longer.

