### PR TITLE
Extend session manager

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -42,6 +42,7 @@
          send_filtered/5,
          broadcast/4,
          store_session_info/5,
+         remove_session_info/5,
          get_info/1]).
 
 %% gen_fsm callbacks
@@ -148,6 +149,10 @@ stop(FsmRef) ->
 
 store_session_info(FsmRef, User, Server, Resource, KV) ->
     FsmRef ! {store_session_info, User, Server, Resource, KV, self()}.
+
+remove_session_info(FsmRef, User, Server, Resource, Key) ->
+    FsmRef ! {remove_session_info, User, Server, Resource, Key, self()}.
+
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm
@@ -1104,6 +1109,9 @@ handle_info(check_buffer_full, StateName, StateData) ->
     end;
 handle_info({store_session_info, User, Server, Resource, KV, _FromPid}, StateName, StateData) ->
     ejabberd_sm:store_info(User, Server, Resource, KV),
+    fsm_next_state(StateName, StateData);
+handle_info({remove_session_info, User, Server, Resource, Key, _FromPid}, StateName, StateData) ->
+    ejabberd_sm:remove_info(User, Server, Resource, Key),
     fsm_next_state(StateName, StateData);
 handle_info(Info, StateName, StateData) ->
     handle_incoming_message(Info, StateName, StateData).

--- a/src/ejabberd_gen_sm.erl
+++ b/src/ejabberd_gen_sm.erl
@@ -7,9 +7,14 @@
     [ejabberd_sm:session()].
 -callback get_sessions(jid:user(), jid:server(), jid:resource()
                       ) -> [ejabberd_sm:session()].
--callback create_session(_User :: jid:user(),
-                         _Server :: jid:server(),
-                         _Resource :: jid:resource(),
+-callback create_session(_User :: jid:luser(),
+                         _Server :: jid:lserver(),
+                         _Resource :: jid:lresource(),
+                         Session :: ejabberd_sm:session()) ->
+    ok | {error, term()}.
+-callback update_session(_User :: jid:luser(),
+                         _Server :: jid:lserver(),
+                         _Resource :: jid:lresource(),
                          Session :: ejabberd_sm:session()) ->
     ok | {error, term()}.
 -callback delete_session(ejabberd_sm:sid(),
@@ -21,7 +26,7 @@
 -callback unique_count() -> integer().
 
 -export([start/2, get_sessions/1, get_sessions/2, get_sessions/3,
-         get_sessions/4, create_session/5, delete_session/5, cleanup/2,
+         get_sessions/4, create_session/5, update_session/5, delete_session/5, cleanup/2,
          total_count/1, unique_count/1]).
 
 -spec start(module(), list()) -> any().
@@ -55,6 +60,13 @@ get_sessions(Mod, User, Server, Resource) ->
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
 create_session(Mod, User, Server, Resource, Session) ->
     Mod:create_session(User, Server, Resource, Session).
+
+-spec update_session(Mod :: module(), User :: jid:luser(),
+                     Server :: jid:lserver(),
+                     Resource :: jid:lresource(),
+                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+update_session(Mod, User, Server, Resource, Session) ->
+    Mod:update_session(User, Server, Resource, Session).
 
 -spec delete_session(Mod :: module(), Sid :: ejabberd_sm:sid(),
                      User :: jid:user(),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -236,12 +236,12 @@ store_info(User, Server, Resource, {Key, _Value} = KV) ->
         {_SUser, SID, SPriority, SInfo} ->
             case SID of
                 {_, Pid} when self() =:= Pid ->
-                    %% It's safe to allow process update it's own record
+                    %% It's safe to allow process update its own record
                     update_session(SID, User, Server, Resource, SPriority,
                                    lists:keystore(Key, 1, SInfo, KV)),
                     {ok, KV};
                 {_, Pid} ->
-                    %% Ask the process to update it's record itself
+                    %% Ask the process to update its record itself
                     %% Async operation
                     ejabberd_c2s:store_session_info(Pid, User, Server, Resource, KV),
                     {ok, KV}
@@ -256,12 +256,12 @@ remove_info(User, Server, Resource, Key) ->
         {_SUser, SID, SPriority, SInfo} ->
             case SID of
                 {_, Pid} when self() =:= Pid ->
-                    %% It's safe to allow process update it's own record
+                    %% It's safe to allow process update its own record
                     update_session(SID, User, Server, Resource, SPriority,
                                    lists:keydelete(Key, 1, SInfo)),
                     ok;
                 {_, Pid} ->
-                    %% Ask the process to update it's record itself
+                    %% Ask the process to update its record itself
                     %% Async operation
                     ejabberd_c2s:remove_session_info(Pid, User, Server, Resource, Key),
                     ok

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -237,8 +237,8 @@ store_info(User, Server, Resource, {Key, _Value} = KV) ->
             case SID of
                 {_, Pid} when self() =:= Pid ->
                     %% It's safe to allow process update it's own record
-                    set_session(SID, User, Server, Resource, SPriority,
-                                lists:keystore(Key, 1, SInfo, KV)),
+                    update_session(SID, User, Server, Resource, SPriority,
+                                   lists:keystore(Key, 1, SInfo, KV)),
                     {ok, KV};
                 {_, Pid} ->
                     %% Ask the process to update it's record itself
@@ -257,8 +257,8 @@ remove_info(User, Server, Resource, Key) ->
             case SID of
                 {_, Pid} when self() =:= Pid ->
                     %% It's safe to allow process update it's own record
-                    set_session(SID, User, Server, Resource, SPriority,
-                                lists:keydelete(Key, 1, SInfo)),
+                    update_session(SID, User, Server, Resource, SPriority,
+                                   lists:keydelete(Key, 1, SInfo)),
                     ok;
                 {_, Pid} ->
                     %% Ask the process to update it's record itself
@@ -618,6 +618,22 @@ set_session(SID, User, Server, Resource, Priority, Info) ->
                        info = Info},
     ejabberd_gen_sm:create_session(sm_backend(), LUser, LServer, LResource, Session).
 
+-spec update_session(SID, User, Server, Resource, Prio, Info) -> ok | {error, any()} when
+      SID :: sid() | 'undefined',
+      User :: jid:luser(),
+      Server :: jid:lserver(),
+      Resource :: jid:lresource(),
+      Prio :: priority(),
+      Info :: undefined | [any()].
+update_session(SID, LUser, LServer, LResource, Priority, Info) ->
+    US = {LUser, LServer},
+    USR = {LUser, LServer, LResource},
+    Session = #session{sid = SID,
+                       usr = USR,
+                       us = US,
+                       priority = Priority,
+                       info = Info},
+    ejabberd_gen_sm:update_session(sm_backend(), LUser, LServer, LResource, Session).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 do_filter(From, To, Packet) ->

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -68,9 +68,9 @@ get_sessions(User, Server, Resource) ->
     mnesia:dirty_index_read(session, {User, Server, Resource}, #session.usr).
 
 
--spec create_session(_User :: jid:user(),
-                     _Server :: jid:server(),
-                     _Resource :: jid:resource(),
+-spec create_session(_User :: jid:luser(),
+                     _Server :: jid:lserver(),
+                     _Resource :: jid:lresource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
 create_session(User, Server, Resource, Session) ->
     case get_sessions(User, Server, Resource) of

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -19,6 +19,7 @@
          get_sessions/2,
          get_sessions/3,
          create_session/4,
+         update_session/4,
          delete_session/4,
          cleanup/1,
          total_count/0,
@@ -82,6 +83,13 @@ create_session(User, Server, Resource, Session) ->
                               (Session, hd(lists:sort(Sessions))),
             mnesia:sync_dirty(fun() -> mnesia:write(MergedSession) end)
     end.
+
+-spec update_session(_User :: jid:luser(),
+                     _Server :: jid:lserver(),
+                     _Resource :: jid:lresource(),
+                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+update_session(_User, _Server, _Resource, Session) ->
+    mnesia:sync_dirty(fun() -> mnesia:write(Session) end).
 
 -spec delete_session(ejabberd_sm:sid(),
                      _User :: jid:user(),

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -18,6 +18,7 @@
          get_sessions/2,
          get_sessions/3,
          create_session/4,
+         update_session/4,
          delete_session/4,
          cleanup/1,
          total_count/0,
@@ -75,9 +76,9 @@ get_sessions(User, Server, Resource) ->
 
     lists:map(fun(S) -> binary_to_term(S) end, Sessions).
 
--spec create_session(User :: jid:user(),
-                     Server :: jid:server(),
-                     Resource :: jid:resource(),
+-spec create_session(User :: jid:luser(),
+                     Server :: jid:lserver(),
+                     Resource :: jid:lresource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
 create_session(User, Server, Resource, Session) ->
     OldSessions = get_sessions(User, Server, Resource),
@@ -86,6 +87,28 @@ create_session(User, Server, Resource, Session) ->
             MergedInfoSession = mongoose_session:merge_info(Session, OldSession),
             BOldSession = term_to_binary(OldSession),
             BSession = term_to_binary(MergedInfoSession),
+            mongoose_redis:cmds([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
+                                 ["SREM", hash(User, Server), BOldSession],
+                                 ["SREM", hash(User, Server, Resource), BOldSession],
+                                 ["SADD", hash(User, Server), BSession],
+                                 ["SADD", hash(User, Server, Resource), BSession]]);
+        false ->
+            BSession = term_to_binary(Session),
+            mongoose_redis:cmds([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
+                                 ["SADD", hash(User, Server), BSession],
+                                 ["SADD", hash(User, Server, Resource), BSession]])
+    end.
+
+-spec update_session(User :: jid:luser(),
+                     Server :: jid:lserver(),
+                     Resource :: jid:lresource(),
+                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+update_session(User, Server, Resource, Session) ->
+    OldSessions = get_sessions(User, Server, Resource),
+    case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
+        {value, OldSession} ->
+            BOldSession = term_to_binary(OldSession),
+            BSession = term_to_binary(Session),
             mongoose_redis:cmds([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
                                  ["SREM", hash(User, Server), BOldSession],
                                  ["SREM", hash(User, Server, Resource), BOldSession],

--- a/src/mongoose_session.erl
+++ b/src/mongoose_session.erl
@@ -8,9 +8,8 @@
 merge_info(New, Old) ->
     NewInfo = orddict:from_list(New#session.info),
     OldInfo = orddict:from_list(Old#session.info),
-    New#session{info =
-                    orddict:to_list(orddict:merge(fun merger/3,
-                                                  NewInfo, OldInfo))}.
+    MergedInfo = orddict:to_list(orddict:merge(fun merger/3, NewInfo, OldInfo)),
+    New#session{info = MergedInfo}.
 
 merger(_Key, NewVal, _OldVal) ->
     NewVal.

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -56,7 +56,9 @@ tests() ->
      session_info_keys_not_truncated_if_session_opened_with_empty_infolist,
      kv_can_be_stored_for_session,
      kv_can_be_updated_for_session,
+     kv_can_be_removed_for_session,
      store_info_sends_message_to_the_session_owner,
+     remove_info_sends_message_to_the_session_owner,
      cannot_reproduce_race_condition_in_store_info
     ].
 
@@ -271,17 +273,17 @@ remove_info_sends_message_to_the_session_owner(C) ->
     Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = []},
     %% Create session in one process
     ?B(C):create_session(U, S, R, Session),
-    %% but call store_info from another process
+    %% but call remove_info from another process
     spawn_link(fun() -> ejabberd_sm:remove_info(U, S, R, cc) end),
     %% The original process receives a message
-    receive {store_session_info, User, Server, Resource, Key, _FromPid} ->
+    receive {remove_session_info, User, Server, Resource, Key, _FromPid} ->
         ?eq(U, User),
         ?eq(S, Server),
         ?eq(R, Resource),
         ?eq(cc, Key),
         ok
         after 5000 ->
-            ct:fail("store_info_sends_message_to_the_session_owner=timeout")
+            ct:fail("remove_info_sends_message_to_the_session_owner=timeout")
     end.
 
 delete_session(C) ->

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -244,6 +244,27 @@ store_info_sends_message_to_the_session_owner(C) ->
             ct:fail("store_info_sends_message_to_the_session_owner=timeout")
     end.
 
+remove_info_sends_message_to_the_session_owner(C) ->
+    SID = {erlang:timestamp(), self()},
+    U = <<"alice2">>,
+    S = <<"localhost">>,
+    R = <<"res1">>,
+    Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = []},
+    %% Create session in one process
+    ?B(C):create_session(U, S, R, Session),
+    %% but call store_info from another process
+    spawn_link(fun() -> ejabberd_sm:remove_info(U, S, R, cc) end),
+    %% The original process receives a message
+    receive {store_session_info, User, Server, Resource, Key, _FromPid} ->
+        ?eq(U, User),
+        ?eq(S, Server),
+        ?eq(R, Resource),
+        ?eq(cc, Key),
+        ok
+        after 5000 ->
+            ct:fail("store_info_sends_message_to_the_session_owner=timeout")
+    end.
+
 delete_session(C) ->
     {Sid, {U, S, R} = USR} = generate_random_user(<<"localhost">>),
     given_session_opened(Sid, USR),


### PR DESCRIPTION
This PR allows to remove keys from session's info attribute.

Proposed changes include:
* new `ejabberd_sm:remove_info` function
* internal change to ejabberd_sm and its backends which updates a session (not trying to create one and merge with previous) when `store_info` or `remove_info` functions are called.

