### PR TITLE
reduce number of worker of MongoosePush in push_integraion_SUITE

### DIFF
--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -654,7 +654,8 @@ required_modules(API) ->
                    {nodetree, <<"dag">>},
                    {host, "pubsub.@HOST@"}]},
      {mod_push_service_mongoosepush, [{pool_name, mongoose_push_http},
-                                      {api_version, API}]},
+                                      {api_version, API},
+                                      {max_http_connections, 10}]},
      {mod_event_pusher, [{backends, [PushBackend]}]}
     ].
 


### PR DESCRIPTION
This PR reduces number of workers in the push_integration_SUITE. This is to remove recently introduced random failures related to frequent `mongoose_wpool` restarts in the SUITE

