### PR TITLE
Store push notification details in session

### DIFF
--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -26,6 +26,7 @@
 
 -export([inject_module/1, inject_module/2, inject_module/3]).
 -export([get_session_pid/2]).
+-export([get_session_info/2]).
 -export([wait_for_route_message_count/2]).
 -export([wait_for_pid_to_die/1]).
 -export([supports_sasl_module/1]).
@@ -310,12 +311,12 @@ wait_and_continue(Fun, ExpectedValue, FunResult, #{time_left := TimeLeft,
                                             history => [FunResult | History]}).
 
 wait_for_user(Config, User, LeftTime) ->
-    mongoose_helper:wait_until(fun() -> 
-                                escalus_users:verify_creation(escalus_users:create_user(Config, User)) 
+    mongoose_helper:wait_until(fun() ->
+                                escalus_users:verify_creation(escalus_users:create_user(Config, User))
                                end, ok,
 							   #{
-                                 sleep_time => 400, 
-                                 left_time => LeftTime, 
+                                 sleep_time => 400,
+                                 left_time => LeftTime,
                                  name => 'escalus_users:create_user'
                                 }).
 
@@ -353,6 +354,14 @@ get_session_pid(User, Node) ->
     successful_rpc(Node, ejabberd_sm, get_session_pid,
                             [Username, Server, Resource]).
 
+get_session_info(RpcDetails, User) ->
+    Username = escalus_client:username(User),
+    Server = escalus_client:server(User),
+    Resource = escalus_client:resource(User),
+
+    {_, _, _, Info} = rpc(RpcDetails, ejabberd_sm, get_session,
+                          [Username, Server, Resource]),
+    Info.
 
 wait_for_route_message_count(C2sPid, ExpectedCount) when is_pid(C2sPid), is_integer(ExpectedCount) ->
     mongoose_helper:wait_until(fun() -> count_route_messages(C2sPid) end, ExpectedCount, #{name => has_route_message}).

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -387,9 +387,7 @@ disable_node_enabled_in_session_removes_it_from_session_info(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             Info2 = mongoose_helper:get_session_info(?RPC_SPEC, Bob),
-            false = lists:keyfind(push_notifications, 1, Info2),
-
-            ok
+            false = lists:keyfind(push_notifications, 1, Info2)
         end).
 
 disable_all_nodes_removes_it_from_all_user_session_infos(Config) ->
@@ -421,9 +419,7 @@ disable_all_nodes_removes_it_from_all_user_session_infos(Config) ->
             false = lists:keyfind(push_notifications, 1, Info3),
 
             Info4 = mongoose_helper:get_session_info(?RPC_SPEC, Bob2),
-            false = lists:keyfind(push_notifications, 1, Info4),
-
-            ok
+            false = lists:keyfind(push_notifications, 1, Info4)
         end).
 
 disable_node_enabled_in_other_session_leaves_current_info_unchanged(Config) ->
@@ -452,9 +448,7 @@ disable_node_enabled_in_other_session_leaves_current_info_unchanged(Config) ->
 
             %% And we check if Bob1 still has its own Node in the session info
             Info3 = mongoose_helper:get_session_info(?RPC_SPEC, Bob1),
-            false = lists:keyfind(push_notifications, 1, Info3),
-
-            ok
+            false = lists:keyfind(push_notifications, 1, Info3)
         end).
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -538,7 +538,7 @@ maybe_check_if_push_node_was_disabled("v3", User, PushNode) ->
     mongoose_helper:wait_until(Fun, false),
 
     Fun2 = fun() ->
-                   Info = get_session_info(User),
+                   Info = mongoose_helper:get_session_info(?RPC_SPEC, User),
                    lists:keyfind(push_notifications, 1, Info)
            end,
     mongoose_helper:wait_until(Fun2, false).
@@ -617,21 +617,11 @@ add_user_server_to_whitelist(User, {NodeAddr, NodeName}) ->
     escalus:assert(is_iq_result, [Stanza], escalus:wait_for_stanza(User)).
 
 assert_push_notification_in_session(User, NodeName, Service, DeviceToken) ->
-    Info = get_session_info(User),
+    Info = mongoose_helper:get_session_info(?RPC_SPEC, User),
 
     {push_notifications, {NodeName, Details}} = lists:keyfind(push_notifications, 1, Info),
     ?assertMatch({<<"service">>, Service}, lists:keyfind(<<"service">>, 1, Details)),
     ?assertMatch({<<"device_id">>, DeviceToken}, lists:keyfind(<<"device_id">>, 1, Details)).
-
-get_session_info(User) ->
-    Username = escalus_client:username(User),
-    Server = escalus_client:server(User),
-    Resource = escalus_client:resource(User),
-
-    {_, _, _, Info} = rpc(?RPC_SPEC, ejabberd_sm, get_session,
-                          [Username, Server, Resource]),
-    Info.
-
 
 wait_for_push_request(DeviceToken) ->
     mongoose_push_mock:wait_for_push_request(DeviceToken).

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -535,7 +535,13 @@ maybe_check_if_push_node_was_disabled("v3", User, PushNode) ->
                   {ok, Services} = rpc(?RPC_SPEC, mod_event_pusher_push_backend, get_publish_services, [JID]),
                   lists:keymember(PushNode, 2, Services)
           end,
-    mongoose_helper:wait_until(Fun, false).
+    mongoose_helper:wait_until(Fun, false),
+
+    Fun2 = fun() ->
+                   Info = get_session_info(User),
+                   lists:keyfind(push_notifications, 1, Info)
+           end,
+    mongoose_helper:wait_until(Fun2, false).
 
 no_push_notification_for_internal_mongoose_push_error(Config) ->
     escalus:fresh_story(
@@ -611,18 +617,20 @@ add_user_server_to_whitelist(User, {NodeAddr, NodeName}) ->
     escalus:assert(is_iq_result, [Stanza], escalus:wait_for_stanza(User)).
 
 assert_push_notification_in_session(User, NodeName, Service, DeviceToken) ->
+    Info = get_session_info(User),
+
+    {push_notifications, {NodeName, Details}} = lists:keyfind(push_notifications, 1, Info),
+    ?assertMatch({<<"service">>, Service}, lists:keyfind(<<"service">>, 1, Details)),
+    ?assertMatch({<<"device_id">>, DeviceToken}, lists:keyfind(<<"device_id">>, 1, Details)).
+
+get_session_info(User) ->
     Username = escalus_client:username(User),
     Server = escalus_client:server(User),
     Resource = escalus_client:resource(User),
 
     {_, _, _, Info} = rpc(?RPC_SPEC, ejabberd_sm, get_session,
                           [Username, Server, Resource]),
-
-    {push_notifications, {NodeName, Details}} = lists:keyfind(push_notifications, 1, Info),
-    ?assertMatch({<<"service">>, Service}, lists:keyfind(<<"service">>, 1, Details)),
-    ?assertMatch({<<"device_id">>, DeviceToken}, lists:keyfind(<<"device_id">>, 1, Details)).
-
-
+    Info.
 
 
 wait_for_push_request(DeviceToken) ->

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -121,13 +121,15 @@ init_per_suite(Config) ->
     HTTPOpts = [{server, "https://localhost:" ++ integer_to_list(Port)}],
     rpc(?RPC_SPEC, mongoose_wpool, start_configured_pools,
         [[{http, global, mongoose_push_http, PoolOpts, HTTPOpts}]]),
-    escalus:init_per_suite(Config).
+    ConfigWithModules = dynamic_modules:save_modules(domain(), Config),
+    escalus:init_per_suite(ConfigWithModules).
 
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     rpc(?RPC_SPEC, mongoose_wpool, stop, [http, global, mongoose_push_http]),
     mongoose_push_mock:stop(),
+    dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_suite(Config).
 
 init_per_group(pubsub_less, Config) ->
@@ -148,11 +150,7 @@ init_per_group(G, Config) ->
     catch rpc(?RPC_SPEC, mod_muc_light_db_backend, force_clear, []),
     C.
 
-end_per_group(ComplexGroup, Config) when ComplexGroup == pubsub_less;
-                                         ComplexGroup == pubsub_ful ->
-    Config;
 end_per_group(_, Config) ->
-    dynamic_modules:restore_modules(domain(), Config),
     Config.
 
 init_per_testcase(CaseName, Config) ->

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -667,7 +667,7 @@ pubsub_node(Config) ->
 
 virtual_pubsub_host() ->
     Domain = domain(),
-    <<Domain/binary, ".", Domain/binary>>.
+    <<"virtual.", Domain/binary>>.
 
 real_pubsub_host() ->
     Domain = domain(),
@@ -725,7 +725,7 @@ required_modules_for_group(_, API, PubSubHost) ->
 
 required_modules(API, PubSubHost) ->
     VirtualHostOpt = case PubSubHost of
-                         virtual -> [{virtual_pubsub_hosts, ["@HOST@.@HOSTS@"]}];
+                         virtual -> [{virtual_pubsub_hosts, ["virtual.@HOSTS@"]}];
                          _ -> []
                      end,
     PubSub = case PubSubHost of

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -704,7 +704,8 @@ init_modules(G, Config) ->
     PubSubHost = ?config(pubsub_host, Config),
     Modules = required_modules_for_group(G, MongoosePushAPI, PubSubHost),
     C = dynamic_modules:save_modules(domain(), Config),
-    dynamic_modules:ensure_modules(domain(), Modules),
+    Fun = fun() -> catch dynamic_modules:ensure_modules(domain(), Modules) end,
+    mongoose_helper:wait_until(Fun, ok),
     [{api_v, MongoosePushAPI} | C].
 
 mongoose_push_api_for_group(failure_cases_v2) ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -250,8 +250,8 @@ store_info(User, Server, Resource, {Key, _Value} = KV) ->
             end
     end.
 
--spec remove_info(jid:user(), jid:server(), jid:resource(),
-                  info_key()) -> ok | {error, offline}.
+-spec remove_info(jid:user(), jid:server(), jid:resource(), info_key()) ->
+    ok | {error, offline}.
 remove_info(User, Server, Resource, Key) ->
     case get_session(User, Server, Resource) of
         offline -> {error, offline};

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -92,16 +92,18 @@
                       usr      :: jid:simple_jid(),
                       us       :: jid:simple_bare_jid(),
                       priority :: priority(),
-                      info     :: list()
+                      info     :: [info_item()]
                      }.
 
 %% Session representation as 4-tuple.
 -type ses_tuple() :: {USR :: jid:simple_jid(),
                       Sid :: ejabberd_sm:sid(),
                       Prio :: priority(),
-                      Info :: list()}.
+                      Info :: [info_item()]}.
 -type backend() :: ejabberd_sm_mnesia | ejabberd_sm_redis.
 -type close_reason() :: resumed | normal | replaced.
+-type info_key() :: atom().
+-type info_item() :: {info_key(), any()}.
 
 -export_type([session/0,
               sid/0,
@@ -228,8 +230,8 @@ close_session(Acc, SID, User, Server, Resource, Reason) ->
     ejabberd_hooks:run_fold(sm_remove_connection_hook, JID#jid.lserver, Acc,
                             [SID, JID, Info, Reason]).
 
--spec store_info(jid:user(), jid:server(), jid:resource(),
-                 {any(), any()}) -> {ok, {any(), any()}} | {error, offline}.
+-spec store_info(jid:user(), jid:server(), jid:resource(), info_item()) ->
+    {ok, {any(), any()}} | {error, offline}.
 store_info(User, Server, Resource, {Key, _Value} = KV) ->
     case get_session(User, Server, Resource) of
         offline -> {error, offline};
@@ -249,7 +251,7 @@ store_info(User, Server, Resource, {Key, _Value} = KV) ->
     end.
 
 -spec remove_info(jid:user(), jid:server(), jid:resource(),
-                 {any(), any()}) -> ok | {error, offline}.
+                  info_key()) -> ok | {error, offline}.
 remove_info(User, Server, Resource, Key) ->
     case get_session(User, Server, Resource) of
         offline -> {error, offline};

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -92,14 +92,15 @@
                       usr      :: jid:simple_jid(),
                       us       :: jid:simple_bare_jid(),
                       priority :: priority(),
-                      info     :: [info_item()]
+                      info     :: info()
                      }.
+-type info() :: [info_item()].
 
 %% Session representation as 4-tuple.
 -type ses_tuple() :: {USR :: jid:simple_jid(),
                       Sid :: ejabberd_sm:sid(),
                       Prio :: priority(),
-                      Info :: [info_item()]}.
+                      Info :: info()}.
 -type backend() :: ejabberd_sm_mnesia | ejabberd_sm_redis.
 -type close_reason() :: resumed | normal | replaced.
 -type info_key() :: atom().
@@ -109,7 +110,8 @@
               sid/0,
               ses_tuple/0,
               backend/0,
-              close_reason/0
+              close_reason/0,
+              info/0
              ]).
 
 %% default value for the maximum number of user connections

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -231,11 +231,12 @@ add_virtual_pubsub_host(Host, VirtualHost) ->
 -spec maybe_remove_push_node_from_session_info(jid:jid(), pubsub_node() | undefined) ->
     ok.
 maybe_remove_push_node_from_session_info(From, undefined) ->
-    %% The node is undefined which means that a user want to disabled all push nodes
+    %% The node is undefined which means that a user wants to disable all push nodes
     LUser = From#jid.luser,
     LServer = From#jid.lserver,
     AllResources = ejabberd_sm:get_user_present_resources(LUser, LServer),
-    [ejabberd_sm:remove_info(LUser, LServer, Resource, push_notifications) || {_, Resource} <- AllResources],
+    [ejabberd_sm:remove_info(LUser, LServer, Resource, push_notifications) ||
+     {_, Resource} <- AllResources],
     ok;
 maybe_remove_push_node_from_session_info(From, Node) ->
     LUser = From#jid.luser,

--- a/src/mongoose_session.erl
+++ b/src/mongoose_session.erl
@@ -1,10 +1,13 @@
 -module(mongoose_session).
+
 -export([merge_info/2]).
+-export([get_info/1]).
+-export([get_resource/1]).
 
 -include("mongoose.hrl").
 -include("session.hrl").
 
--spec merge_info(#session{}, #session{}) -> #session{}.
+-spec merge_info(ejabberd_sm:session(), ejabberd_sm:session()) -> ejabberd_sm:session().
 merge_info(New, Old) ->
     NewInfo = orddict:from_list(New#session.info),
     OldInfo = orddict:from_list(Old#session.info),
@@ -13,3 +16,11 @@ merge_info(New, Old) ->
 
 merger(_Key, NewVal, _OldVal) ->
     NewVal.
+
+-spec get_info(ejabberd_sm:session()) -> ejabberd_sm:info().
+get_info(#session{info = Info}) ->
+    Info.
+
+-spec get_resource(ejabberd_sm:session()) -> jid:lresource().
+get_resource(#session{usr = {_U, _S, R}}) ->
+    R.


### PR DESCRIPTION
This PR stores push node details (form the `enable` stanza) in user's session info field.

Proposed changes include:
* store push notifications node details (node and form fields) to user's session info field when user sends the `enable` stanza
* remove the push notifications details form user's session info field when:
    * the device id for the push node is considered expired by MongoosePush
    * the user send `disable` stanza

