### PR TITLE
Push priority configurable by node

### DIFF
--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -56,6 +56,8 @@ groups() ->
           [
            pm_msg_notify_on_apns_w_high_priority,
            pm_msg_notify_on_fcm_w_high_priority,
+           pm_msg_notify_on_apns_w_high_priority_silent,
+           pm_msg_notify_on_fcm_w_high_priority_silent,
            pm_msg_notify_on_apns_no_click_action,
            pm_msg_notify_on_fcm_no_click_action,
            pm_msg_notify_on_apns_w_click_action,
@@ -68,6 +70,8 @@ groups() ->
           [
            muclight_msg_notify_on_apns_w_high_priority,
            muclight_msg_notify_on_fcm_w_high_priority,
+           muclight_msg_notify_on_apns_w_high_priority_silent,
+           muclight_msg_notify_on_fcm_w_high_priority_silent,
            muclight_msg_notify_on_apns_no_click_action,
            muclight_msg_notify_on_fcm_no_click_action,
            muclight_msg_notify_on_apns_w_click_action,
@@ -240,6 +244,12 @@ pm_msg_notify_on_apns_w_high_priority(Config) ->
 
 pm_msg_notify_on_fcm_w_high_priority(Config) ->
     pm_msg_notify_on_fcm(Config, [{<<"priority">>, <<"high">>}]).
+
+pm_msg_notify_on_apns_w_high_priority_silent(Config) ->
+    pm_msg_notify_on_apns(Config, [{<<"silent">>, <<"true">>}, {<<"priority">>, <<"high">>}]).
+
+pm_msg_notify_on_fcm_w_high_priority_silent(Config) ->
+    pm_msg_notify_on_fcm(Config, [{<<"silent">>, <<"true">>}, {<<"priority">>, <<"high">>}]).
 
 pm_msg_notify_on_apns_w_click_action(Config) ->
     pm_msg_notify_on_apns(Config, [{<<"click_action">>, <<"myactivity">>}]).
@@ -468,6 +478,12 @@ muclight_msg_notify_on_apns_w_high_priority(Config) ->
 
 muclight_msg_notify_on_fcm_w_high_priority(Config) ->
     muclight_msg_notify_on_fcm(Config, [{<<"priority">>, <<"high">>}]).
+
+muclight_msg_notify_on_apns_w_high_priority_silent(Config) ->
+    muclight_msg_notify_on_apns(Config, [{<<"silent">>, <<"true">>}, {<<"priority">>, <<"high">>}]).
+
+muclight_msg_notify_on_fcm_w_high_priority_silent(Config) ->
+    muclight_msg_notify_on_fcm(Config, [{<<"silent">>, <<"true">>}, {<<"priority">>, <<"high">>}]).
 
 muclight_msg_notify_on_apns_w_click_action(Config) ->
     muclight_msg_notify_on_apns(Config, [{<<"click_action">>, <<"myactivity">>}]).

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -92,8 +92,10 @@ groups() ->
     G.
 
 failure_cases() ->
-    [no_push_notification_for_expired_device,
-     no_push_notification_for_internal_mongoose_push_error].
+    [
+     no_push_notification_for_expired_device,
+     no_push_notification_for_internal_mongoose_push_error
+    ].
 
 suite() ->
     escalus:suite().
@@ -155,7 +157,6 @@ end_per_testcase(CaseName, Config) ->
 %% GROUP pm_msg_notifications
 %%--------------------------------------------------------------------
 
-
 pm_msg_notify_on_apns(Config, EnableOpts) ->
     escalus:fresh_story(
         Config, [{bob, 1}, {alice, 1}],
@@ -164,6 +165,17 @@ pm_msg_notify_on_apns(Config, EnableOpts) ->
             {Notification, _} = wait_for_push_request(DeviceToken),
 
             assert_push_notification(Notification, <<"apns">>, EnableOpts, SenderJID, [])
+
+        end).
+
+pm_msg_notify_on_fcm(Config, EnableOpts) ->
+    escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            {SenderJID, DeviceToken} = pm_conversation(Alice, Bob, <<"fcm">>, EnableOpts, Config),
+            {Notification, _} = wait_for_push_request(DeviceToken),
+
+            assert_push_notification(Notification, <<"fcm">>, EnableOpts, SenderJID)
 
         end).
 
@@ -207,17 +219,6 @@ assert_push_notification(Notification, Service, EnableOpts, SenderJID, Expected)
     end.
 
 
-pm_msg_notify_on_fcm(Config, EnableOpts) ->
-    escalus:fresh_story(
-        Config, [{bob, 1}, {alice, 1}],
-        fun(Bob, Alice) ->
-            {SenderJID, DeviceToken} = pm_conversation(Alice, Bob, <<"fcm">>, EnableOpts, Config),
-            {Notification, _} = wait_for_push_request(DeviceToken),
-
-            assert_push_notification(Notification, <<"fcm">>, EnableOpts, SenderJID)
-
-        end).
-
 pm_msg_notify_on_apns_no_click_action(Config) ->
     pm_msg_notify_on_apns(Config, []).
 
@@ -238,6 +239,7 @@ pm_msg_notify_on_apns_silent(Config) ->
 
 pm_msg_notify_on_apns_w_topic(Config) ->
     pm_msg_notify_on_apns(Config, [{<<"topic">>, <<"some_topic">>}]).
+
 
 %%--------------------------------------------------------------------
 %% GROUP inbox_msg_notifications
@@ -369,10 +371,10 @@ send_message_to_room(Sender, RoomJID) ->
     Stanza = escalus_stanza:groupchat_to(RoomJID, <<"GroupChat message">>),
     escalus:send(Sender, Stanza).
 
+
 %%--------------------------------------------------------------------
 %% GROUP muclight_msg_notifications
 %%--------------------------------------------------------------------
-
 
 muclight_msg_notify_on_apns(Config, EnableOpts) ->
     escalus:fresh_story(
@@ -512,8 +514,6 @@ no_push_notification_for_internal_mongoose_push_error(Config) ->
 %%--------------------------------------------------------------------
 %% Test helpers
 %%--------------------------------------------------------------------
-
-
 
 muclight_conversation(Sender, RoomJID, Msg) ->
     Bare = bare_jid(Sender),

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -54,6 +54,8 @@ groups() ->
 
          {pm_msg_notifications, [parallel],
           [
+           pm_msg_notify_on_apns_w_high_priority,
+           pm_msg_notify_on_fcm_w_high_priority,
            pm_msg_notify_on_apns_no_click_action,
            pm_msg_notify_on_fcm_no_click_action,
            pm_msg_notify_on_apns_w_click_action,
@@ -64,6 +66,8 @@ groups() ->
           ]},
          {muclight_msg_notifications, [parallel],
           [
+           muclight_msg_notify_on_apns_w_high_priority,
+           muclight_msg_notify_on_fcm_w_high_priority,
            muclight_msg_notify_on_apns_no_click_action,
            muclight_msg_notify_on_fcm_no_click_action,
            muclight_msg_notify_on_apns_w_click_action,
@@ -212,6 +216,12 @@ assert_push_notification(Notification, Service, EnableOpts, SenderJID, Expected)
             ?assertMatch(#{<<"message-count">> := UnreadCount}, Data)
     end,
 
+    case proplists:get_value(<<"priority">>, EnableOpts) of
+        undefined -> ok;
+        Priority ->
+            ?assertMatch(Priority, maps:get(<<"priority">>, Notification, undefined))
+    end,
+
     case proplists:get_value(<<"topic">>, EnableOpts) of
         undefined -> ok;
         Topic ->
@@ -224,6 +234,12 @@ pm_msg_notify_on_apns_no_click_action(Config) ->
 
 pm_msg_notify_on_fcm_no_click_action(Config) ->
     pm_msg_notify_on_fcm(Config, []).
+
+pm_msg_notify_on_apns_w_high_priority(Config) ->
+    pm_msg_notify_on_apns(Config, [{<<"priority">>, <<"high">>}]).
+
+pm_msg_notify_on_fcm_w_high_priority(Config) ->
+    pm_msg_notify_on_fcm(Config, [{<<"priority">>, <<"high">>}]).
 
 pm_msg_notify_on_apns_w_click_action(Config) ->
     pm_msg_notify_on_apns(Config, [{<<"click_action">>, <<"myactivity">>}]).
@@ -446,6 +462,12 @@ muclight_msg_notify_on_apns_no_click_action(Config) ->
 
 muclight_msg_notify_on_fcm_no_click_action(Config) ->
     muclight_msg_notify_on_fcm(Config, []).
+
+muclight_msg_notify_on_apns_w_high_priority(Config) ->
+    muclight_msg_notify_on_apns(Config, [{<<"priority">>, <<"high">>}]).
+
+muclight_msg_notify_on_fcm_w_high_priority(Config) ->
+    muclight_msg_notify_on_fcm(Config, [{<<"priority">>, <<"high">>}]).
 
 muclight_msg_notify_on_apns_w_click_action(Config) ->
     muclight_msg_notify_on_apns(Config, [{<<"click_action">>, <<"myactivity">>}]).

--- a/doc/user-guide/Push-notifications.md
+++ b/doc/user-guide/Push-notifications.md
@@ -237,6 +237,7 @@ To enable push notifications in the simplest configuration, just send the follow
       <field var='device_id'><value>your_pns_device_token</value></field>
       <field var='silent'><value>false</value></field>
       <field var='topic'><value>some_apns_topic</value></field>
+      <field var='priority'><value>some_priority</value></field>
     </x>
   </enable>
 </iq>
@@ -253,6 +254,9 @@ Those two options are the only ones required, but there are some others that are
   * `silent` - if set to `true`, all notifications will be "silent". This means that only data
   payload will be send to push notifications provider with no notification. The data payload will
    contain all notification fields as defined in [XEP-0357].
+  * `priority` — which may be either `normal` or `high`, and if not given, defaults to `normal`.
+    This value will set the push notification priority. Please refer to FCM / APNS documentation for
+    more details on those values.
 
 ### Disabling push notifications
 

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -172,7 +172,8 @@ make_notification(Notification, Options) ->
             badge => binary_to_integer(maps:get(<<"message-count">>, Notification)),
             click_action => maps:get(<<"click_action">>, Options, null)
         },
-        topic => maps:get(<<"topic">>, Options, null)
+        topic => maps:get(<<"topic">>, Options, null),
+        priority => maps:get(<<"priority">>, Options, normal)
     }}.
 
 -spec call(Host :: jid:server(), M :: atom(), F :: atom(), A :: [any()]) -> any().

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -159,7 +159,8 @@ make_notification(Notification, Options = #{<<"silent">> := <<"true">>}) ->
         service => maps:get(<<"service">>, Options),
         mode => maps:get(<<"mode">>, Options, <<"prod">>),
         topic => maps:get(<<"topic">>, Options, null),
-        data => Notification#{<<"message-count">> => MessageCount}
+        data => Notification#{<<"message-count">> => MessageCount},
+        priority => maps:get(<<"priority">>, Options, normal)
     }};
 make_notification(Notification, Options) ->
     {ok, #{


### PR DESCRIPTION
Make the push node take into account the priority given in the enable stanza. This should be compatible with the future pubsub-less push notifications, and it makes the priority configurable with the granularity of the node.

Tests are added following the logic of the already present tests, and the values of this new field are also added to the docs.