### PR TITLE
Fix error iqs in mod last

### DIFF
--- a/big_tests/tests/last_SUITE.erl
+++ b/big_tests/tests/last_SUITE.erl
@@ -135,14 +135,14 @@ user_not_subscribed_receives_error(Config) ->
         escalus_client:send(Alice, escalus_stanza:last_activity(BobShortJID)),
 
         %% server replies with an error, since there is no subscription
-        Stanza = escalus_client:wait_for_stanza(Alice),
-        escalus:assert(is_iq_error, Stanza),
+        Error = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Error),
 
         BobFullJID = escalus_client:full_jid(Bob),
         escalus_client:send(Alice, escalus_stanza:last_activity(BobFullJID)),
 
-        Stanza1 = escalus_client:wait_for_stanza(Alice),
-        escalus:assert(is_iq_error, Stanza1),
+        Error1 = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Error1),
         ok
     end).
 

--- a/big_tests/tests/last_SUITE.erl
+++ b/big_tests/tests/last_SUITE.erl
@@ -24,15 +24,20 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    [{group, last}].
+    [{group, valid_queries},
+     {group, invalid_queries}].
 
 groups() ->
-    G = [{last, [sequence], test_cases()}],
+    G = [{valid_queries, [sequence], valid_test_cases()},
+         {invalid_queries, invalid_test_cases()}],
     ct_helper:repeat_all_until_all_ok(G).
 
-test_cases() -> [last_online_user,
-                 last_offline_user,
-                 last_server].
+valid_test_cases() -> [last_online_user,
+                       last_offline_user,
+                       last_server ].
+
+invalid_test_cases() -> [user_not_subscribed_receives_error].
+
 suite() ->
     escalus:suite().
 
@@ -42,7 +47,7 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
-init_per_group(_GroupName, Config0) ->
+init_per_group(valid_queries, Config0) ->
     Config1 = escalus_fresh:create_users(Config0, [{alice, 1}, {bob, 1}]),
     Config2 = escalus:make_everyone_friends(Config1),
     %% This check ensures that there are no registered sessions.
@@ -53,9 +58,11 @@ init_per_group(_GroupName, Config0) ->
     %% Kick "friendly" users
     %% kick_everyone uses ejabberd_c2s_sup to information about client processes.
     mongoose_helper:kick_everyone(),
-    Config2.
+    Config2;
+init_per_group(invalid_queries, Config) ->
+    Config.
 
-end_per_group(_GroupName, Config) ->
+end_per_group(_GroupName, _Config) ->
     escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
@@ -120,6 +127,25 @@ last_server(Config) ->
                           escalus:assert(is_last_result, Stanza),
                           true = (get_last_activity(Stanza) > 0)
                   end).
+
+user_not_subscribed_receives_error(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        %% Alice asks about Bob's last activity
+        BobShortJID = escalus_client:short_jid(Bob),
+        escalus_client:send(Alice, escalus_stanza:last_activity(BobShortJID)),
+
+        %% server replies with an error, since there is no subscription
+        Stanza = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_error, Stanza),
+
+        BobFullJID = escalus_client:full_jid(Bob),
+        escalus_client:send(Alice, escalus_stanza:last_activity(BobFullJID)),
+
+        Stanza1 = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_error, Stanza1),
+        ok
+    end).
+
 
 %%-----------------------------------------------------------------
 %% Helpers

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1311,7 +1311,7 @@ handle_routed_iq(From, To, Acc, StateData) ->
                        IQ :: invalid | not_iq | jlib:iq(),
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc0, #iq{ xmlns = ?NS_LAST, type = Type }, StateData)
-  when Type /= result ->
+  when Type /= result, Type /= error ->
     %% TODO: Support for mod_last / XEP-0012. Can we move it to the respective module?
     %%   Thanks to add_iq_handler(ejabberd_sm, ...)?
     {Acc, HasFromSub} = case is_subscribed_to_my_presence(From, StateData) of

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1312,8 +1312,7 @@ handle_routed_iq(From, To, Acc, StateData) ->
                        StateData :: state()) -> routing_result().
 handle_routed_iq(From, To, Acc0, #iq{ xmlns = ?NS_LAST, type = Type }, StateData)
   when Type /= result, Type /= error ->
-    %% TODO: Support for mod_last / XEP-0012. Can we move it to the respective module?
-    %%   Thanks to add_iq_handler(ejabberd_sm, ...)?
+    % we could make iq handlers handle full jids as well, but wouldn't it be an overkill?
     {Acc, HasFromSub} = case is_subscribed_to_my_presence(From, StateData) of
                              true ->
                                  {A, R} = privacy_check_packet(Acc0, To, out, StateData),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -1037,6 +1037,7 @@ process_iq(From, To, Acc0, Packet) ->
     process_iq(IQ, From, To, Acc, Packet).
 
 process_iq(#iq{type = Type}, _From, _To, Acc, _Packet) when Type == result; Type == error ->
+    % results and errors are always sent to full jids, so we ignore them here
     Acc;
 process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
     Host = To#jid.lserver,


### PR DESCRIPTION
This PR addresses #MIM-752: errors sent in jabber:iq:last namespace were rejected with an error, which means that error response to a last activity query addressed to a subscription=none peer did not come. Also, if full jid was used, error stanzas entered an infinite loop.

This PR adds a tiny clause to the c2s function, plus tests.

