### PR TITLE
Remove excessive logging in CI

### DIFF
--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -108,7 +108,8 @@ cluster_op_timeout() ->
 -spec rpc(Spec, _, _, _) -> any() when
       Spec :: rpc_spec() | node().
 rpc(Node, M, F, A) when is_atom(Node) ->
-    ct:pal("rpc/4: use RPCSpec :: #{node := Node} instead of just Node :: atom()"),
+    % TODO: review once https://github.com/esl/MongooseIM/pull/2533 is done
+    % ct:pal("rpc/4: use RPCSpec :: #{node := Node} instead of just Node :: atom()"),
     rpc(#{node => Node}, M, F, A);
 rpc(#{} = RPCSpec, M, F, A) ->
     Node = maps:get(node, RPCSpec),


### PR DESCRIPTION
Until https://github.com/esl/MongooseIM/pull/2533 is ready, CI has very long logs that basically leave both Travis and CI a bit unreadable across very long scrolls, for example in https://circleci.com/gh/esl/MongooseIM/11097

So I think that this commit can be reverted together with the merge from 2533 once he's ready 🙁 