### PR TITLE
Kernel polling flag removed since OTP21

### DIFF
--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -16,8 +16,7 @@
 ## (Disabled by default..use with caution!)
 ##-heart
 
-## Enable kernel poll and a few async threads
-+K true
+## Enable a few async threads
 +A 5
 
 {{highload_vm_args}}


### PR DESCRIPTION
According to Lukas, in the blogpost http://blog.erlang.org/IO-Polling/, the flag `+K` was removed since our very oldest supported OTP version, so we can get rid of that.