### PR TITLE
Test pubsub tools cleanup

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -1091,7 +1091,7 @@ retrieve_pubsub_subscriptions(Config) ->
 
 remove_pubsub_dont_remove_flat_pubsub_node(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        Node1 = {_,NodeName} = pubsub_tools:pubsub_node(1),
+        Node1 = {_,NodeName} = pubsub_tools:pubsub_node_with_num(1),
         pubsub_tools:create_nodes([{Alice, Node1, []}]),
 
         {0, _} = unregister(Alice, Config),
@@ -1146,7 +1146,7 @@ remove_pubsub_pep_node(Config) ->
 
 remove_pubsub_dont_remove_node_when_only_publisher(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        Node1 = {_,NodeName} = pubsub_tools:pubsub_node(1),
+        Node1 = {_,NodeName} = pubsub_tools:pubsub_node_with_num(1),
         pubsub_tools:create_nodes([{Alice, Node1, []}]),
 
         AffChange = [{Bob, <<"publish-only">>}],

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -116,7 +116,6 @@
 -import(pubsub_tools, [pubsub_node/0,
                        domain/0,
                        node_addr/0,
-                       rand_name/1,
                        encode_group_name/2,
                        decode_group_name/1]).
 -import(distributed_helper, [mim/0,
@@ -1162,7 +1161,7 @@ retrieve_pending_subscription_requests_test(Config) ->
 %% Comments in test cases refer to sections is the XEP
 %%--------------------------------------------------------------------
 
-pubsub_leaf_name() -> rand_name(<<"leaf">>).
+pubsub_leaf_name() -> pubsub_tools:rand_name(<<"leaf">>).
 pubsub_leaf() -> {node_addr(), pubsub_leaf_name()}.
 
 create_delete_collection_test(Config) ->

--- a/big_tests/tests/pubsub_s2s_SUITE.erl
+++ b/big_tests/tests/pubsub_s2s_SUITE.erl
@@ -23,7 +23,7 @@
         ]).
 
 -import(distributed_helper, [require_rpc_nodes/1]).
--import(pubsub_tools, [pubsub_node/0,
+-import(pubsub_tools, [
                        domain/0,
                        encode_group_name/2,
                        decode_group_name/1]).
@@ -106,7 +106,7 @@ publish_test(Config) ->
       Config,
       [{alice, 1}, {alice2, 1}],
       fun(Alice, Alice2) ->
-              Node = pubsub_node(),
+              Node = pubsub_tools:pubsub_node(),
               pubsub_tools:create_node(Alice, Node, []),
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
               pubsub_tools:publish(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),
@@ -118,7 +118,7 @@ publish_without_node_attr_test(Config) ->
       Config,
       [{alice, 1}, {alice2, 1}],
       fun(Alice, Alice2) ->
-              Node = pubsub_node(),
+              Node = pubsub_tools:pubsub_node(),
               pubsub_tools:create_node(Alice, Node, []),
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
               pubsub_tools:publish_without_node_attr(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -70,6 +70,8 @@
          receive_subscribe_response/3,
          receive_unsubscribe_response/3]).
 
+-type pubsub_node() :: {binary(), binary()}.
+
 %%-----------------------------------------------------------------------------
 %% Request functions with (optional) built-in response handlers
 %%-----------------------------------------------------------------------------
@@ -645,41 +647,55 @@ decode_affiliations(IQResult) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
+-spec node_addr() -> binary().
 node_addr() ->
     node_addr(<<"pubsub.">>).
 
+-spec node_addr(string() | binary()) -> binary().
 node_addr(SubDomain) when is_list(SubDomain) ->
     node_addr(list_to_binary(SubDomain));
 node_addr(SubDomain) when is_binary(SubDomain) ->
     Domain = domain(),
     <<SubDomain/binary, Domain/binary>>.
 
+-spec pubsub_node() -> pubsub_node().
 pubsub_node() ->
     {node_addr(), pubsub_node_name()}.
 
-pubsub_node_with_num(Num) when is_integer(Num) ->
+-spec sanitize_node_name(binary()) -> binary().
+sanitize_node_name(NodeName) ->
+    binary:replace(NodeName, <<"/">>, <<".">>, [global]).
+
+-spec sanitized_node_name_with_num(non_neg_integer()) -> binary().
+sanitized_node_name_with_num(Num) ->
     Name = <<"node_", (integer_to_binary(Num))/binary, "_",
              (base64:encode(crypto:strong_rand_bytes(6)))/binary>>,
-    SanitizedName = binary:replace(Name, <<"/">>, <<".">>, [global]),
+    sanitize_node_name(Name).
+
+-spec pubsub_node_with_num(pos_integer()) -> pubsub_node().
+pubsub_node_with_num(Num) when is_integer(Num) ->
+    SanitizedName = sanitized_node_name_with_num(Num),
     {node_addr(), SanitizedName}.
 
+-spec pubsub_node_with_subdomain(string() | binary()) -> pubsub_node().
 pubsub_node_with_subdomain(SubDomain) ->
     {node_addr(SubDomain), pubsub_node_name()}.
 
-pubsub_node_with_num_and_domain(Num, Dom) when is_integer(Num) ->
-    Name = <<"node_", (integer_to_binary(Num))/binary, "_",
-             (base64:encode(crypto:strong_rand_bytes(6)))/binary>>,
-    SanitizedName = binary:replace(Name, <<"/">>, <<".">>, [global]),
+-spec pubsub_node_with_num_and_domain(pos_integer(), string() | binary()) -> pubsub_node().
+pubsub_node_with_num_and_domain(Num, Dom) ->
+    SanitizedName = sanitized_node_name_with_num(Num),
     {node_addr(Dom), SanitizedName}.
 
+-spec rand_name(binary()) -> binary().
 rand_name(Prefix) ->
-    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
+    Suffix = base64:encode(crypto:strong_rand_bytes(6)),
     <<Prefix/binary, "_", Suffix/binary>>.
 
 %% Generates nodetree_tree-safe names
+-spec pubsub_node_name() -> binary().
 pubsub_node_name() ->
-    Name0 = rand_name(<<"princely_musings">>),
-    re:replace(Name0, "/", "_", [global, {return, binary}]).
+    Name = rand_name(<<"princely_musings">>),
+    sanitize_node_name(Name).
 
 encode_group_name(BaseName, NodeTree) ->
     binary_to_atom(<<NodeTree/binary, $+, (atom_to_binary(BaseName, utf8))/binary>>, utf8).
@@ -688,6 +704,7 @@ decode_group_name(ComplexName) ->
     [NodeTree, BaseName] = binary:split(atom_to_binary(ComplexName, utf8), <<"+">>),
     #{node_tree => NodeTree, base_name => binary_to_atom(BaseName, utf8)}.
 
+-spec create_node_names(non_neg_integer()) -> [pubsub_node()].
 create_node_names(Count) ->
     [pubsub_node_with_num(N) || N <- lists:seq(1, Count)].
 

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -16,7 +16,9 @@
 -include_lib("eunit/include/eunit.hrl").
 %% Send request, receive (optional) response
 -export([pubsub_node/0,
-         pubsub_node/1,
+         pubsub_node_with_num/1,
+         pubsub_node_with_subdomain/1,
+         pubsub_node_with_num_and_domain/2,
          domain/0,
          node_addr/0,
          node_addr/1,
@@ -653,13 +655,22 @@ node_addr(SubDomain) when is_binary(SubDomain) ->
     <<SubDomain/binary, Domain/binary>>.
 
 pubsub_node() ->
-    pubsub_node(1).
+    {node_addr(), pubsub_node_name()}.
 
-pubsub_node(Num) ->
+pubsub_node_with_num(Num) when is_integer(Num) ->
     Name = <<"node_", (integer_to_binary(Num))/binary, "_",
              (base64:encode(crypto:strong_rand_bytes(6)))/binary>>,
     SanitizedName = binary:replace(Name, <<"/">>, <<".">>, [global]),
-    {pubsub_tools:node_addr(), SanitizedName}.
+    {node_addr(), SanitizedName}.
+
+pubsub_node_with_subdomain(SubDomain) ->
+    {node_addr(SubDomain), pubsub_node_name()}.
+
+pubsub_node_with_num_and_domain(Num, Dom) when is_integer(Num) ->
+    Name = <<"node_", (integer_to_binary(Num))/binary, "_",
+             (base64:encode(crypto:strong_rand_bytes(6)))/binary>>,
+    SanitizedName = binary:replace(Name, <<"/">>, <<".">>, [global]),
+    {node_addr(Dom), SanitizedName}.
 
 rand_name(Prefix) ->
     Suffix = base64:encode(crypto:strong_rand_bytes(5)),
@@ -678,7 +689,7 @@ decode_group_name(ComplexName) ->
     #{node_tree => NodeTree, base_name => binary_to_atom(BaseName, utf8)}.
 
 create_node_names(Count) ->
-    [pubsub_node(N) || N <- lists:seq(1, Count)].
+    [pubsub_node_with_num(N) || N <- lists:seq(1, Count)].
 
 create_nodes(List) ->
     lists:map(fun({User, Node, Opts}) ->

--- a/big_tests/tests/pubsub_tools.erl
+++ b/big_tests/tests/pubsub_tools.erl
@@ -19,6 +19,7 @@
          pubsub_node/1,
          domain/0,
          node_addr/0,
+         node_addr/1,
          rand_name/1,
          pubsub_node_name/0,
          encode_group_name/2,
@@ -639,19 +640,26 @@ decode_affiliations(IQResult) ->
 
     [ {exml_query:attr(F, <<"jid">>), exml_query:attr(F, <<"affiliation">>)} || F <- Fields ].
 
-pubsub_node() -> pubsub_node(1).
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+node_addr() ->
+    node_addr(<<"pubsub.">>).
+
+node_addr(SubDomain) when is_list(SubDomain) ->
+    node_addr(list_to_binary(SubDomain));
+node_addr(SubDomain) when is_binary(SubDomain) ->
+    Domain = domain(),
+    <<SubDomain/binary, Domain/binary>>.
+
+pubsub_node() ->
+    pubsub_node(1).
+
 pubsub_node(Num) ->
     Name = <<"node_", (integer_to_binary(Num))/binary, "_",
              (base64:encode(crypto:strong_rand_bytes(6)))/binary>>,
     SanitizedName = binary:replace(Name, <<"/">>, <<".">>, [global]),
     {pubsub_tools:node_addr(), SanitizedName}.
-
-domain() ->
-    ct:get_config({hosts, mim, domain}).
-
-node_addr() ->
-    Domain = domain(),
-    <<"pubsub.", Domain/binary>>.
 
 rand_name(Prefix) ->
     Suffix = base64:encode(crypto:strong_rand_bytes(5)),

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -375,7 +375,7 @@ disable_node_enabled_in_session_removes_it_from_session_info(Config) ->
         Config, [{bob, 1}],
         fun(Bob) ->
             PubsubJID = pubsub_jid(Config),
-            NodeId = pubsub_node(),
+            NodeId = pubsub_tools:pubsub_node_name(),
 
             escalus:send(Bob, enable_stanza(PubsubJID, NodeId, [])),
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
@@ -395,8 +395,8 @@ disable_all_nodes_removes_it_from_all_user_session_infos(Config) ->
         Config, [{bob, 2}],
         fun(Bob1, Bob2) ->
             PubsubJID = pubsub_jid(Config),
-            NodeId = pubsub_node(),
-            NodeId2 = pubsub_node(),
+            NodeId = pubsub_tools:pubsub_node_name(),
+            NodeId2 = pubsub_tools:pubsub_node_name(),
 
             escalus:send(Bob1, enable_stanza(PubsubJID, NodeId, [])),
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob1)),
@@ -427,8 +427,8 @@ disable_node_enabled_in_other_session_leaves_current_info_unchanged(Config) ->
         Config, [{bob, 2}],
         fun(Bob1, Bob2) ->
             PubsubJID = pubsub_jid(Config),
-            NodeId = pubsub_node(),
-            NodeId2 = pubsub_node(),
+            NodeId = pubsub_tools:pubsub_node_name(),
+            NodeId2 = pubsub_tools:pubsub_node_name(),
 
             escalus:send(Bob1, enable_stanza(PubsubJID, NodeId, [])),
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob1)),
@@ -784,9 +784,6 @@ pubsub_jid(Config) ->
         virtual -> <<CaseNameBin/binary, ".hyperion">>;
         _ -> <<"pubsub@", CaseNameBin/binary>>
     end.
-
-pubsub_node() ->
-    uuid:uuid_to_string(uuid:get_v4(), binary_standard).
 
 room_name(Config) ->
     CaseName = proplists:get_value(case_name, Config),

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -648,12 +648,8 @@ lower(Bin) when is_binary(Bin) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-rand_name(Prefix) ->
-    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
-    <<Prefix/binary, "_", Suffix/binary>>.
-
 pubsub_node_name() ->
-    rand_name(<<"princely_musings">>).
+    pubsub_tools:rand_name(<<"princely_musings">>).
 
 pubsub_node(Config) ->
     NodeAddr = case ?config(pubsub_host, Config) of

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -574,8 +574,7 @@ enable_push_for_user(User, Service, EnableOpts, Config) ->
     enable_push_for_user(User, Service, EnableOpts, {200, <<"OK">>}, Config).
 
 enable_push_for_user(User, Service, EnableOpts, MockResponse, Config) ->
-    PubsubJID = node_addr(Config),
-    Node = {_, NodeName} = pubsub_node(Config),
+    Node = {PubsubJID, NodeName} = pubsub_node(Config),
 
     DeviceToken = gen_token(),
 
@@ -649,12 +648,6 @@ lower(Bin) when is_binary(Bin) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-node_addr(Config) ->
-    case ?config(pubsub_host, Config) of
-        virtual -> virtual_pubsub_host();
-        real -> real_pubsub_host()
-    end.
-
 rand_name(Prefix) ->
     Suffix = base64:encode(crypto:strong_rand_bytes(5)),
     <<Prefix/binary, "_", Suffix/binary>>.
@@ -663,15 +656,11 @@ pubsub_node_name() ->
     rand_name(<<"princely_musings">>).
 
 pubsub_node(Config) ->
-    {node_addr(Config), pubsub_node_name()}.
-
-virtual_pubsub_host() ->
-    Domain = domain(),
-    <<"virtual.", Domain/binary>>.
-
-real_pubsub_host() ->
-    Domain = domain(),
-    <<"pubsub.", Domain/binary>>.
+    NodeAddr = case ?config(pubsub_host, Config) of
+        virtual -> pubsub_tools:node_addr("virtual.");
+        real -> pubsub_tools:node_addr()
+    end,
+    {NodeAddr, pubsub_node_name()}.
 
 getenv(VarName, Default) ->
     case os:getenv(VarName) of

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -648,15 +648,12 @@ lower(Bin) when is_binary(Bin) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-pubsub_node_name() ->
-    pubsub_tools:rand_name(<<"princely_musings">>).
-
 pubsub_node(Config) ->
     NodeAddr = case ?config(pubsub_host, Config) of
         virtual -> pubsub_tools:node_addr("virtual.");
         real -> pubsub_tools:node_addr()
     end,
-    {NodeAddr, pubsub_node_name()}.
+    {NodeAddr, pubsub_tools:pubsub_node_name()}.
 
 getenv(VarName, Default) ->
     case os:getenv(VarName) of

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -574,7 +574,7 @@ enable_push_for_user(User, Service, EnableOpts, Config) ->
     enable_push_for_user(User, Service, EnableOpts, {200, <<"OK">>}, Config).
 
 enable_push_for_user(User, Service, EnableOpts, MockResponse, Config) ->
-    Node = {PubsubJID, NodeName} = pubsub_node(Config),
+    Node = {PubsubJID, NodeName} = pubsub_node_from_host(Config),
 
     DeviceToken = gen_token(),
 
@@ -648,12 +648,13 @@ lower(Bin) when is_binary(Bin) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-pubsub_node(Config) ->
-    NodeAddr = case ?config(pubsub_host, Config) of
-        virtual -> pubsub_tools:node_addr("virtual.");
-        real -> pubsub_tools:node_addr()
-    end,
-    {NodeAddr, pubsub_tools:pubsub_node_name()}.
+pubsub_node_from_host(Config) ->
+    case ?config(pubsub_host, Config) of
+        virtual ->
+            pubsub_tools:pubsub_node_with_subdomain("virtual.");
+        real ->
+            pubsub_tools:pubsub_node()
+    end.
 
 getenv(VarName, Default) ->
     case os:getenv(VarName) of

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -110,7 +110,7 @@ allocate_basic_node(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Node = pubsub_node(),
+            Node = push_pubsub_node(),
             pubsub_tools:create_node(Alice, Node, [{type, <<"push">>}])
         end).
 
@@ -122,7 +122,7 @@ publish_fails_with_invalid_item(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Node = pubsub_node(),
+            Node = push_pubsub_node(),
             pubsub_tools:create_node(Alice, Node, [{type, <<"push">>}]),
 
             Item =
@@ -142,7 +142,7 @@ publish_fails_with_no_options(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Node = pubsub_node(),
+            Node = push_pubsub_node(),
             pubsub_tools:create_node(Alice, Node, [{type, <<"push">>}]),
 
             ContentFields = [
@@ -170,7 +170,7 @@ publish_succeeds_with_valid_options(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Node = pubsub_node(),
+            Node = push_pubsub_node(),
             pubsub_tools:create_node(Alice, Node, [{type, <<"push">>}]),
 
             Content = [
@@ -196,7 +196,7 @@ push_node_can_be_configured_to_whitelist_publishers(Config) ->
     escalus:story(
         Config, [{alice, 1}, {bob, 1}],
         fun(Alice, Bob) ->
-            Node = pubsub_node(),
+            Node = push_pubsub_node(),
             Configuration = [{<<"pubsub#access_model">>, <<"whitelist">>},
                              {<<"pubsub#publish_model">>, <<"publishers">>}],
             pubsub_tools:create_node(Alice, Node, [{type, <<"push">>},
@@ -345,7 +345,7 @@ prepare_notification(CustomOptions) ->
     {Notification, Options ++ CustomOptions}.
 
 setup_pubsub(User) ->
-    Node = pubsub_node(),
+    Node = push_pubsub_node(),
     pubsub_tools:create_node(User, Node, [{type, <<"push">>}]),
     Node.
 
@@ -377,8 +377,8 @@ publish_iq(Client, Node, Content, Options) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-pubsub_node() ->
-    {pubsub_tools:node_addr(?PUBSUB_SUB_DOMAIN ++ "."), pubsub_tools:pubsub_node_name()}.
+push_pubsub_node() ->
+    pubsub_tools:pubsub_node_with_subdomain(?PUBSUB_SUB_DOMAIN ++ ".").
 
 parse_form(#xmlel{name = <<"x">>} = Form) ->
     parse_form(exml_query:subelements(Form, <<"field">>));

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -377,11 +377,8 @@ publish_iq(Client, Node, Content, Options) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-pubsub_node_name() ->
-    pubsub_tools:rand_name(<<"princely_musings">>).
-
 pubsub_node() ->
-    {pubsub_tools:node_addr(?PUBSUB_SUB_DOMAIN ++ "."), pubsub_node_name()}.
+    {pubsub_tools:node_addr(?PUBSUB_SUB_DOMAIN ++ "."), pubsub_tools:pubsub_node_name()}.
 
 parse_form(#xmlel{name = <<"x">>} = Form) ->
     parse_form(exml_query:subelements(Form, <<"field">>));

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -377,12 +377,8 @@ publish_iq(Client, Node, Content, Options) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-rand_name(Prefix) ->
-    Suffix = base64:encode(crypto:strong_rand_bytes(5)),
-    <<Prefix/binary, "_", Suffix/binary>>.
-
 pubsub_node_name() ->
-    rand_name(<<"princely_musings">>).
+    pubsub_tools:rand_name(<<"princely_musings">>).
 
 pubsub_node() ->
     {pubsub_tools:node_addr(?PUBSUB_SUB_DOMAIN ++ "."), pubsub_node_name()}.

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -96,7 +96,7 @@ has_disco_identity(Config) ->
     escalus:story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Server = node_addr(),
+            Server = pubsub_tools:node_addr(?PUBSUB_SUB_DOMAIN ++ "."),
             escalus:send(Alice, escalus_stanza:disco_info(Server)),
             Stanza = escalus:wait_for_stanza(Alice),
             escalus:assert(has_identity, [<<"pubsub">>, <<"push">>], Stanza)
@@ -377,10 +377,6 @@ publish_iq(Client, Node, Content, Options) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-node_addr() ->
-    Domain = domain(),
-    <<?PUBSUB_SUB_DOMAIN, ".", Domain/binary>>.
-
 rand_name(Prefix) ->
     Suffix = base64:encode(crypto:strong_rand_bytes(5)),
     <<Prefix/binary, "_", Suffix/binary>>.
@@ -389,7 +385,7 @@ pubsub_node_name() ->
     rand_name(<<"princely_musings">>).
 
 pubsub_node() ->
-    {node_addr(), pubsub_node_name()}.
+    {pubsub_tools:node_addr(?PUBSUB_SUB_DOMAIN ++ "."), pubsub_node_name()}.
 
 parse_form(#xmlel{name = <<"x">>} = Form) ->
     parse_form(exml_query:subelements(Form, <<"field">>));


### PR DESCRIPTION
The goal of this PR is to unify all the duplicated functionality across different test suites related to pubsub nodes: we have many functions that generate a pubsub node name, or subdomains, or tagged by number... It can all be implemented once in `pubsub_tools` and used everywhere.

Something that might have potentially been a problem is when in both `push_integration_SUITE` and `push_pubsub_SUITE` we generate a random name (`rand_name`) but we don't make sure the random string does not contain slashes (`/`), which has been a problem before in pubsub; it doesn't hurt to keep the node names always curated against it.