### PR TITLE
Async thread pool not used anymore

### DIFF
--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -16,9 +16,6 @@
 ## (Disabled by default..use with caution!)
 ##-heart
 
-## Enable a few async threads
-+A 5
-
 {{highload_vm_args}}
 
 ## Tweak GC to run more often


### PR DESCRIPTION
Since OTP 20, the Async Thread Pool is not used anymore, in favour of
the dirty schedulers, and this Async Thread Pool is left for whatever
old libraries still written to use them, but all of OTP was already
rewritten the "Dirty Schedulers" way. So these are just unused. I
haven't find any of our dependencies using this pool, and to add insult
to injury, documentation for this is hard to find in the internet.

Even, on my load tests, accounting showed results like this:
```
(mongooseim@localhost)> msacc:start(1000), msacc:print().
        Thread      aux check_io emulator       gc    other     port    sleep
Stats per type:
         async    0.00%    0.00%    0.00%    0.00%    0.00%    0.00%  100.00% <--
           aux    0.00%    0.00%    0.00%    0.00%    0.02%    0.00%   99.97%
dirty_cpu_sche    0.00%    0.00%    0.00%    0.01%    0.03%    0.00%   99.96%
dirty_io_sched    0.00%    0.00%    0.00%    0.00%    0.00%    0.00%  100.00%
          poll    0.00%    1.52%    0.00%    0.00%    0.00%    0.00%   98.48%
     scheduler    0.76%    0.95%   33.91%    6.82%   26.53%    2.45%   28.59%
```

With results consistent through time.

So If nobody has anything against dropping them... 😃 