### PR TITLE
[jingle_sip] Fix wrong xmlns for ringing stanza

### DIFF
--- a/big_tests/tests/jingle_SUITE.erl
+++ b/big_tests/tests/jingle_SUITE.erl
@@ -403,7 +403,9 @@ assert_ringing(InviteStanza, RingingStanza) ->
     JingleEl = exml_query:subelement(RingingStanza, <<"jingle">>),
     ?assertEqual(<<"session-info">>,
                  (exml_query:attr(JingleEl, <<"action">>))),
-    ?assertMatch(#xmlel{}, exml_query:subelement(JingleEl, <<"ringing">>)),
+    Ringing = exml_query:subelement(JingleEl, <<"ringing">>),
+    ?assertMatch(#xmlel{}, Ringing),
+    ?assertEqual(<<"urn:xmpp:jingle:apps:rtp:info:1">>, exml_query:attr(Ringing, <<"xmlns">>)),
 
     assert_same_sid(InviteStanza, RingingStanza).
 

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -290,7 +290,7 @@ send_ringing_session_info(SIPMsg) ->
     mod_jingle_sip_backend:set_outgoing_handle(CallID, DialogHandle, FromJID, ToJID),
 
     RingingEl = #xmlel{name = <<"ringing">>,
-                       attrs = [{<<"xmlns">>, <<"urn:xmpp:jingle:apps:rtp:1:info">>}]},
+                       attrs = [{<<"xmlns">>, <<"urn:xmpp:jingle:apps:rtp:info:1">>}]},
     JingleEl = jingle_sip_helper:jingle_element(CallID, <<"session-info">>, [RingingEl]),
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
     Acc = mongoose_acc:new(#{ location => ?LOCATION,


### PR DESCRIPTION
This PR addresses #

Proposed changes include:
There is a typo in xmlns in jingle handling.
Relevant docs https://xmpp.org/extensions/xep-0167.html#info-ringing
Provided additional check in suite.

