### PR TITLE
System metrics - additional and configurable Tracking ID

### DIFF
--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -9,7 +9,7 @@
 -define(ETS_TABLE, qs).
 -define(TRACKING_ID, "UA-151671255-2").
 -define(TRACKING_ID_CI, "UA-151671255-1").
--define(TRACKING_ID_ADDITIONAL, "UA-151671255-3").
+-define(TRACKING_ID_EXTRA, "UA-151671255-3").
 
 -record(event, {
     cid = "",
@@ -185,7 +185,7 @@ system_metrics_are_reported_to_google_analytics_when_mim_starts(_Config) ->
     all_event_have_the_same_client_id().
 
 tracking_id_is_correctly_configured(_Config) ->
-    TrackingId = distributed_helper:rpc(mim(), ejabberd_config, get_local_option, [dev_google_analytics_tracking_id]),
+    TrackingId = distributed_helper:rpc(mim(), ejabberd_config, get_local_option, [google_analytics_tracking_id]),
     case os:getenv("CI") of
         "true" ->
             ?assertEqual(?TRACKING_ID_CI, TrackingId);
@@ -282,11 +282,11 @@ system_metrics_service_is_disabled(Node) ->
     not system_metrics_service_is_enabled(Node).
 
 configure_additional_tracking_id(Node) ->
-    TrackingIdArgs = [google_analytics_tracking_id, ?TRACKING_ID_ADDITIONAL],
+    TrackingIdArgs = [extra_google_analytics_tracking_id, ?TRACKING_ID_EXTRA],
     {atomic, ok} = mongoose_helper:successful_rpc(Node, ejabberd_config, add_local_option, TrackingIdArgs).
 
 remove_additional_tracking_id(Node) ->
-    mongoose_helper:successful_rpc(Node, ejabberd_config, del_local_option, [ google_analytics_tracking_id ]).
+    mongoose_helper:successful_rpc(Node, ejabberd_config, del_local_option, [ extra_google_analytics_tracking_id ]).
 
 events_are_reported_to_additional_tracking_id() ->
     Tab = ets:tab2list(?ETS_TABLE),

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -290,8 +290,8 @@ remove_additional_tracking_id(Node) ->
 
 events_are_reported_to_additional_tracking_id() ->
     Tab = ets:tab2list(?ETS_TABLE),
-    UniqueSortedTab = lists:usort([Tid ||#event{tid = Tid} <- Tab]),
-    2 == length(UniqueSortedTab).
+    SetTab = sets:from_list([Tid ||#event{tid = Tid} <- Tab]),
+    2 == sets:size(SetTab).
 
 events_are_reported_to_configurable_tracking_id() ->
     ConfigurableTrackingId = <<"configurable_tracking_id">>,

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -302,8 +302,6 @@ process_term(Term, State) ->
             add_option(cowboy_server_name, Value, State);
         {services, Value} ->
             add_option(services, Value, State);
-        {google_analytics_tracking_id, Value} ->
-            add_option(google_analytics_tracking_id, Value, State);
         {_Opt, _Val} ->
             lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
                         State, State#state.hosts)

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -304,6 +304,8 @@ process_term(Term, State) ->
             add_option(services, Value, State);
         {google_analytics_url, Value} ->
             add_option(google_analytics_url, Value, State);
+        {google_analytics_tracking_id, Value} ->
+            add_option(google_analytics_tracking_id, Value, State);
         {_Opt, _Val} ->
             lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
                         State, State#state.hosts)

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -302,8 +302,6 @@ process_term(Term, State) ->
             add_option(cowboy_server_name, Value, State);
         {services, Value} ->
             add_option(services, Value, State);
-        {google_analytics_url, Value} ->
-            add_option(google_analytics_url, Value, State);
         {google_analytics_tracking_id, Value} ->
             add_option(google_analytics_tracking_id, Value, State);
         {_Opt, _Val} ->

--- a/src/system_metrics/mongoose_system_metrics_sender.erl
+++ b/src/system_metrics/mongoose_system_metrics_sender.erl
@@ -11,7 +11,7 @@
 
 -spec send(string(), [report_struct()]) -> ok.
 send(ClientId, ReportStructs) ->
-    TrackingIds = get_tracking_id(),
+    TrackingIds = get_tracking_ids(),
     Reports = build_reports_for_each_tracking_id(ClientId, TrackingIds, ReportStructs),
     send_reports(Reports),
     ok.
@@ -40,7 +40,7 @@ send_reports(ReportsList) ->
 get_url() ->
     ejabberd_config:get_local_option_or_default(google_analytics_url, ?BASE_URL).
 
-get_tracking_id() ->
+get_tracking_ids() ->
     DevTrackingId = ejabberd_config:get_local_option_or_default(dev_google_analytics_tracking_id, ?TRACKING_ID),
     AdditionalTrackingId = ejabberd_config:get_local_option(google_analytics_tracking_id),
     case AdditionalTrackingId of

--- a/src/system_metrics/mongoose_system_metrics_sender.erl
+++ b/src/system_metrics/mongoose_system_metrics_sender.erl
@@ -16,7 +16,7 @@ send(ClientId, ReportStructs) ->
     send_reports(Reports),
     ok.
 
--spec build_reports_for_each_tracking_id(string(), string(), [report_struct()]) -> ok.
+-spec build_reports_for_each_tracking_id(string(), string(), [report_struct()]) -> [google_analytics_report()].
 build_reports_for_each_tracking_id(ClientId, TrackingIds, ReportStructs) ->
     lists:map(
         fun(Tid) ->
@@ -32,7 +32,10 @@ build_reports(ClientId, TrackingId, ReportStructs) ->
 
 send_reports(ReportsList) ->
     Url = get_url(),
-    [flush_reports(Url, Reports) || Reports <- ReportsList].
+    lists:map(
+        fun(Reports) ->
+            flush_reports(Url, Reports)
+        end, ReportsList).
 
 get_url() ->
     ejabberd_config:get_local_option_or_default(google_analytics_url, ?BASE_URL).

--- a/src/system_metrics/mongoose_system_metrics_sender.erl
+++ b/src/system_metrics/mongoose_system_metrics_sender.erl
@@ -16,7 +16,7 @@ send(ClientId, ReportStructs) ->
     send_reports(Reports),
     ok.
 
--spec build_reports_for_each_tracking_id(string(), list(), [report_struct()]) -> ok.
+-spec build_reports_for_each_tracking_id(string(), string(), [report_struct()]) -> ok.
 build_reports_for_each_tracking_id(ClientId, TrackingIds, ReportStructs) ->
     lists:map(
         fun(Tid) ->

--- a/src/system_metrics/mongoose_system_metrics_sender.erl
+++ b/src/system_metrics/mongoose_system_metrics_sender.erl
@@ -41,11 +41,11 @@ get_url() ->
     ejabberd_config:get_local_option_or_default(google_analytics_url, ?BASE_URL).
 
 get_tracking_ids() ->
-    DevTrackingId = ejabberd_config:get_local_option_or_default(dev_google_analytics_tracking_id, ?TRACKING_ID),
-    AdditionalTrackingId = ejabberd_config:get_local_option(google_analytics_tracking_id),
-    case AdditionalTrackingId of
+    DevTrackingId = ejabberd_config:get_local_option_or_default(google_analytics_tracking_id, ?TRACKING_ID),
+    ExtraTrackingId = ejabberd_config:get_local_option(extra_google_analytics_tracking_id),
+    case ExtraTrackingId of
         undefined -> [DevTrackingId];
-        AdditionalTrackingId -> [DevTrackingId, AdditionalTrackingId]
+        ExtraTrackingId -> [DevTrackingId, ExtraTrackingId]
     end.
 % % https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#batch-limitations
 % % A maximum of 20 hits can be specified per request.

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -56,7 +56,8 @@ handle_info(spawn_reporter, #system_metrics_state{report_after = ReportAfter,
                     mongoose_system_metrics_sender:send(ClientId, Reports)
                 end),
             erlang:send_after(ReportAfter, self(), spawn_reporter),
-            {noreply, State#system_metrics_state{reporter_monitor = Monitor, reporter_pid = Pid}}
+            {noreply, State#system_metrics_state{reporter_monitor = Monitor,
+                                                 reporter_pid = Pid}}
     end;
 handle_info(spawn_reporter, #system_metrics_state{reporter_pid = Pid} = State) ->
     exit(Pid, kill),
@@ -120,6 +121,8 @@ metrics_module_config(Args) ->
             InitialReport= proplists:get_value(initial_report, Args, ?DEFAULT_INITIAL_REPORT),
             ReportAfter = proplists:get_value(report_after, Args, ?DEFAULT_REPORT_AFTER)
     end,
+    AdditionalTrackingID = proplists:get_value(tracking_id, Args, undefined),
+    ejabberd_config:add_local_option(google_analytics_tracking_id, AdditionalTrackingID),
     {InitialReport, ReportAfter}.
 
 % %%-----------------------------------------

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -112,11 +112,11 @@ maybe_create_table() ->
 metrics_module_config(Args) ->
     case os:getenv("CI") of
         "true" ->
-            ejabberd_config:add_local_option(google_analytics_tracking_id, ?TRACKING_ID_CI),
+            ejabberd_config:add_local_option(dev_google_analytics_tracking_id, ?TRACKING_ID_CI),
             InitialReport = proplists:get_value(initial_report, Args, timer:seconds(20)),
             ReportAfter = proplists:get_value(report_after, Args, timer:minutes(5));
         _ ->
-            ejabberd_config:add_local_option(google_analytics_tracking_id, ?TRACKING_ID),
+            ejabberd_config:add_local_option(dev_google_analytics_tracking_id, ?TRACKING_ID),
             InitialReport= proplists:get_value(initial_report, Args, ?DEFAULT_INITIAL_REPORT),
             ReportAfter = proplists:get_value(report_after, Args, ?DEFAULT_REPORT_AFTER)
     end,

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -113,16 +113,16 @@ maybe_create_table() ->
 metrics_module_config(Args) ->
     case os:getenv("CI") of
         "true" ->
-            ejabberd_config:add_local_option(dev_google_analytics_tracking_id, ?TRACKING_ID_CI),
+            ejabberd_config:add_local_option(google_analytics_tracking_id, ?TRACKING_ID_CI),
             InitialReport = proplists:get_value(initial_report, Args, timer:seconds(20)),
             ReportAfter = proplists:get_value(report_after, Args, timer:minutes(5));
         _ ->
-            ejabberd_config:add_local_option(dev_google_analytics_tracking_id, ?TRACKING_ID),
+            ejabberd_config:add_local_option(google_analytics_tracking_id, ?TRACKING_ID),
             InitialReport= proplists:get_value(initial_report, Args, ?DEFAULT_INITIAL_REPORT),
             ReportAfter = proplists:get_value(report_after, Args, ?DEFAULT_REPORT_AFTER)
     end,
-    AdditionalTrackingID = proplists:get_value(tracking_id, Args, undefined),
-    ejabberd_config:add_local_option(google_analytics_tracking_id, AdditionalTrackingID),
+    ExtraTrackingID = proplists:get_value(tracking_id, Args, undefined),
+    ejabberd_config:add_local_option(extra_google_analytics_tracking_id, ExtraTrackingID),
     {InitialReport, ReportAfter}.
 
 % %%-----------------------------------------


### PR DESCRIPTION
When gathering system metrics is allowed, this PR allows to configure additional Tracking ID for gathering metrics in Google Analytics. On every reporting cycle, the metrics are being sent twice with different tracking IDs. 
*DEV Google Analytics dashboard 
*Configured Tracking ID

MIM User is assumed to have access to the configured Tracking ID. Using this feature allows User to view and possibly use for their purposes, all system metrics that are being collected.

