### PR TITLE
adding unacknowledged_message hook processing at event_pusher

### DIFF
--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -5,7 +5,7 @@
 -export([port/0]).
 -export([init/2]).
 -export([subscribe/2]).
--export([wait_for_push_request/1]).
+-export([wait_for_push_request/2]).
 
 start(Config) ->
     application:ensure_all_started(cowboy),
@@ -32,11 +32,11 @@ stop() ->
 subscribe(Token, Response) ->
     ets:insert(mongoose_push_mock_subscribers, {Token, self(), Response}).
 
-wait_for_push_request(Token) ->
+wait_for_push_request(Token, Timeout) ->
     receive
         {push_request, Token, Body, Resp} ->
             {jiffy:decode(Body, [return_maps]), Resp}
-    after 10000 ->
+    after Timeout ->
               ct:fail("timeout_waiting_for_push_request")
     end.
 

--- a/big_tests/tests/push_helper.erl
+++ b/big_tests/tests/push_helper.erl
@@ -14,6 +14,8 @@
 
 -export([http_notifications_port/0, http_notifications_host/0]).
 
+-export([wait_for_user_offline/1]).
+
 -import(distributed_helper, [mim/0,
                              rpc/4]).
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -1278,16 +1278,15 @@ start_hook_listener(Resource) ->
 
 rpc_start_hook_handler(TestCasePid, User) ->
     LUser=jid:nodeprep(User),
-    Handler = fun(Acc, Res) ->
-                  JID = mongoose_acc:to_jid(Acc),
-                  case jid:to_lus(JID) of
-                      {LUser, _} ->
-                          Counter = mongoose_acc:get(sm_test, counter, 0, Acc),
-                          El = mongoose_acc:element(Acc),
-                          TestCasePid ! {sm_test, Counter, Res, El},
-                          mongoose_acc:set_permanent(sm_test, counter, Counter + 1, Acc);
-                      _ -> Acc
-                  end
+    Handler = fun(Acc, U, S, R) ->
+                case jid:nodeprep(U) of
+                    LUser ->
+                        Counter = mongoose_acc:get(sm_test, counter, 0, Acc),
+                        El = mongoose_acc:element(Acc),
+                        TestCasePid ! {sm_test, Counter, R, El},
+                        mongoose_acc:set_permanent(sm_test, counter, Counter + 1, Acc);
+                    _ -> Acc
+                end
               end,
     ejabberd_hooks:add(unacknowledged_message, <<"localhost">>, Handler, 50).
 

--- a/include/mod_event_pusher_events.hrl
+++ b/include/mod_event_pusher_events.hrl
@@ -7,4 +7,3 @@
 -record(unack_msg_event, {user :: jid:user(), server :: jid:server(),
                           resource :: jid:resource()}).
 
--type event() :: #user_status_event{} | #chat_event{} | #unack_msg_event{}.

--- a/include/mod_event_pusher_events.hrl
+++ b/include/mod_event_pusher_events.hrl
@@ -4,5 +4,7 @@
 -record(chat_event, {type :: headline | normal | chat | groupchat,
                      direction :: in | out,
                      from :: jid:jid(), to :: jid:jid(), packet :: exml:element()}).
+-record(unack_msg_event, {user :: jid:user(), server :: jid:server(),
+                          resource :: jid:resource()}).
 
--type event() :: #user_status_event{} | #chat_event{}.
+-type event() :: #user_status_event{} | #chat_event{} | #unack_msg_event{}.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3025,12 +3025,13 @@ notify_unacknowledged_msg_if_in_resume_state(Acc,
 notify_unacknowledged_msg_if_in_resume_state(Acc, _) ->
     Acc.
 
-maybe_notify_unacknowledged_msg(Acc, #state{resource = Res,
+maybe_notify_unacknowledged_msg(Acc, #state{user     = User,
+                                            resource = Res,
                                             server   = Server}) ->
     case mongoose_acc:stanza_name(Acc) of
         <<"message">> ->
             NewAcc = ejabberd_hooks:run_fold(unacknowledged_message,
-                                             Server, Acc, [Res]),
+                                             Server, Acc, [User, Server, Res]),
             mongoose_acc:strip(NewAcc);
         _ -> Acc
     end.

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -22,13 +22,16 @@
 -include("jlib.hrl").
 -include("mod_event_pusher_events.hrl").
 
+-type event() :: #user_status_event{} | #chat_event{} | #unack_msg_event{}.
+-export_type([event/0]).
+
 -export([deps/2, start/2, stop/1, push_event/3]).
 
 %%--------------------------------------------------------------------
 %% Callbacks
 %%--------------------------------------------------------------------
 
--callback push_event(Acc :: mongoose_acc:t(), Host :: jid:lserver(), Event :: event()) -> any().
+-callback push_event(Acc :: mongoose_acc:t(), Host :: jid:lserver(), Event :: event()) -> mongoose_acc:t().
 
 %%--------------------------------------------------------------------
 %% API

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -56,12 +56,10 @@ deps(_Host, Opts) ->
 start(Host, Opts) ->
     create_ets(Host),
     Backends = get_backends(Opts),
-    ets:insert(ets_name(Host), {backends, [B || {B, _} <- Backends]}),
-    ejabberd_hooks:add(push_event, Host, ?MODULE, push_event, 90).
+    ets:insert(ets_name(Host), {backends, [B || {B, _} <- Backends]}).
 
 -spec stop(Host :: jid:server()) -> any().
 stop(Host) ->
-    ejabberd_hooks:delete(push_event, Host, ?MODULE, push_event, 90),
     ets:delete(ets_name(Host)).
 
 %%--------------------------------------------------------------------

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -111,7 +111,7 @@ chat_type(Acc) ->
 -spec merge_acc(mongoose_acc:t(), mongoose_acc:t()) -> mongoose_acc:t().
 merge_acc(Acc, EventPusherAcc) ->
     NS = mongoose_acc:get(event_pusher, EventPusherAcc),
-    mongoose_acc:set(event_pusher, NS, Acc).
+    mongoose_acc:set_permanent(event_pusher, NS, Acc).
 
 -spec hooks(Host :: jid:server()) -> [ejabberd_hooks:hook()].
 hooks(Host) ->

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -23,7 +23,11 @@
 -include("mod_event_pusher_events.hrl").
 
 -export([start/2, stop/1]).
--export([user_send_packet/4, filter_local_packet/1, user_present/2, user_not_present/5]).
+-export([user_send_packet/4,
+         filter_local_packet/1,
+         user_present/2,
+         user_not_present/5,
+         unacknowledged_message/4]).
 
 %%--------------------------------------------------------------------
 %% gen_mod API
@@ -40,48 +44,54 @@ stop(Host) ->
 %%--------------------------------------------------------------------
 %% Hook callbacks
 %%--------------------------------------------------------------------
-
+-type routing_data() :: {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
 -spec filter_local_packet(drop) -> drop;
-                         (RoutingData) -> RoutingData
-                                              when RoutingData :: {jid:jid(), jid:jid(), mongoose_acc:t()}.
+                         (routing_data()) -> routing_data().
 filter_local_packet(drop) ->
     drop;
-filter_local_packet({From, To = #jid{lserver = Host}, Acc, Packet}) ->
-    case chat_type(Acc) of
-        false -> skip;
-        Type ->
-            mod_event_pusher:push_event(Acc, Host,
-                                        #chat_event{type = Type, direction = out,
-                                                    from = From, to = To, packet = Packet})
-    end,
+filter_local_packet({From, To = #jid{lserver = Host}, Acc0, Packet}) ->
+    Acc = case chat_type(Acc0) of
+              false -> Acc0;
+              Type ->
+                  Event = #chat_event{type = Type, direction = out,
+                                      from = From, to = To, packet = Packet},
+                  NewAcc = mod_event_pusher:push_event(Acc0, Host, Event),
+                  merge_acc(Acc0, NewAcc)
+          end,
     {From, To, Acc, Packet}.
 
 -spec user_send_packet(mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
                        Packet :: exml:element()) -> mongoose_acc:t().
 user_send_packet(Acc, From, To, Packet = #xmlel{name = <<"message">>}) ->
     case chat_type(Acc) of
-        false -> skip;
+        false -> Acc;
         Type ->
-            mod_event_pusher:push_event(Acc, From#jid.lserver,
-                                        #chat_event{type = Type, direction = in,
-                                                    from = From, to = To, packet = Packet})
-    end,
-    Acc;
+            Event = #chat_event{type = Type, direction = in,
+                                from = From, to = To, packet = Packet},
+            NewAcc = mod_event_pusher:push_event(Acc, From#jid.lserver, Event),
+            merge_acc(Acc, NewAcc)
+    end;
 user_send_packet(Acc, _From, _To, _Packet) ->
     Acc.
 
 -spec user_present(mongoose_acc:t(), UserJID :: jid:jid()) -> mongoose_acc:t().
 user_present(Acc, #jid{} = UserJID) ->
-    mod_event_pusher:push_event(Acc, UserJID#jid.lserver,
-                                #user_status_event{jid = UserJID, status = online}),
-    Acc.
+    Event = #user_status_event{jid = UserJID, status = online},
+    NewAcc = mod_event_pusher:push_event(Acc, UserJID#jid.lserver, Event),
+    merge_acc(Acc, NewAcc).
 
 -spec user_not_present(mongoose_acc:t(), User :: jid:luser(), Server :: jid:lserver(),
                        Resource :: jid:lresource(), Status :: any()) -> mongoose_acc:t().
 user_not_present(Acc, LUser, LHost, LResource, _Status) ->
     UserJID = jid:make_noprep(LUser, LHost, LResource),
-    mod_event_pusher:push_event(Acc, LHost, #user_status_event{jid = UserJID, status = offline}),
-    Acc.
+    Event = #user_status_event{jid = UserJID, status = offline},
+    NewAcc = mod_event_pusher:push_event(Acc, LHost, Event),
+    merge_acc(Acc, NewAcc).
+
+unacknowledged_message(Acc, User, Server, Res) ->
+    Event = #unack_msg_event{resource = Res, user = User, server = Server},
+    NewAcc = mod_event_pusher:push_event(Acc, Server, Event),
+    merge_acc(Acc, NewAcc).
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -98,12 +108,18 @@ chat_type(Acc) ->
         _ -> false
     end.
 
+-spec merge_acc(mongoose_acc:t(), mongoose_acc:t()) -> mongoose_acc:t().
+merge_acc(Acc, EventPusherAcc) ->
+    NS = mongoose_acc:get(event_pusher, EventPusherAcc),
+    mongoose_acc:set(event_pusher, NS, Acc).
+
 -spec hooks(Host :: jid:server()) -> [ejabberd_hooks:hook()].
 hooks(Host) ->
     [
-     {filter_local_packet, Host, ?MODULE, filter_local_packet, 90},
-     {unset_presence_hook, Host, ?MODULE, user_not_present, 90},
-     {user_available_hook, Host, ?MODULE, user_present, 90},
-     {user_send_packet, Host, ?MODULE, user_send_packet, 90},
-     {rest_user_send_packet, Host, ?MODULE, user_send_packet, 90}
+        {filter_local_packet, Host, ?MODULE, filter_local_packet, 90},
+        {unset_presence_hook, Host, ?MODULE, user_not_present, 90},
+        {user_available_hook, Host, ?MODULE, user_present, 90},
+        {user_send_packet, Host, ?MODULE, user_send_packet, 90},
+        {rest_user_send_packet, Host, ?MODULE, user_send_packet, 90},
+        {unacknowledged_message, Host, ?MODULE, unacknowledged_message, 90}
     ].

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -89,7 +89,7 @@ user_not_present(Acc, LUser, LHost, LResource, _Status) ->
     merge_acc(Acc, NewAcc).
 
 unacknowledged_message(Acc, User, Server, Res) ->
-    Event = #unack_msg_event{resource = Res, user = User, server = Server},
+    Event = #unack_msg_event{user = User, server = Server, resource = Res},
     NewAcc = mod_event_pusher:push_event(Acc, Server, Event),
     merge_acc(Acc, NewAcc).
 

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -168,6 +168,8 @@ virtual_pubsub_hosts(Host) ->
 %%--------------------------------------------------------------------
 -spec add_virtual_pubsub_host(Host :: jid:server(), VirtualHost :: jid:server()) -> any().
 add_virtual_pubsub_host(Host, VirtualHost) ->
+    %% add_virtual_pubsub_host/2 is non-atomic interface, so execution in parallel
+    %% environment can result in race conditions.
     VHosts0 = virtual_pubsub_hosts(Host),
     VHosts = lists:usort(gen_mod:make_subhosts(VirtualHost, Host) ++ VHosts0),
     gen_mod:set_module_opt(Host, ?MODULE, normalized_virtual_pubsub_hosts, VHosts).

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -108,10 +108,8 @@ stop(Host) ->
 %%--------------------------------------------------------------------
 -spec push_event(Acc :: mongoose_acc:t(), Host :: jid:lserver(),
                  Event :: mod_event_pusher:event()) -> mongoose_acc:t().
-push_event(Acc, Host, Event = #chat_event{type = chat, direction = in, to = To}) ->
-    BareRecipient = jid:to_bare(To),
-    do_push_event(Acc, Host, Event, BareRecipient);
-push_event(Acc, Host, Event = #chat_event{type = groupchat, direction = out, to = To}) ->
+push_event(Acc, Host, Event = #chat_event{type = Type, direction = out, to = To}) when Type =:= groupchat;
+                                                                                       Type =:= chat ->
     BareRecipient = jid:to_bare(To),
     do_push_event(Acc, Host, Event, BareRecipient);
 push_event(Acc, _, _) ->

--- a/src/event_pusher/mod_event_pusher_push_plugin.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin.erl
@@ -16,39 +16,77 @@
 -include("jlib.hrl").
 -include("mongoose.hrl").
 
+-define(DEFAULT_PLUGIN_MODULE, mod_event_pusher_push_plugin_defaults).
+
 %% API
--export([should_publish/4]).
--export([publish_notification/5]).
+-export([init/1,
+         should_publish/4,
+         prepare_notification/3,
+         publish_notification/5]).
 
 
--callback should_publish(From :: jid:jid(), To :: jid:jid(), Packet :: exml:element()) ->
-    boolean().
--callback publish_notification(Acc :: mongooseim_acc:t(), From :: jid:jid(),
-                               To :: jid:jid(), Packet :: exml:element(),
-                               Services :: [mod_event_pusher_push:publish_service()]) -> mongooseim_acc:t().
+-callback should_publish(Acc :: mongooseim_acc:t(),
+                         Event :: mod_event_pusher:event(),
+                         Services :: [mod_event_pusher_push:publish_service()]) ->
+    [mod_event_pusher_push:publish_service()].
 
+-callback prepare_notification(Acc :: mongooseim_acc:t(),
+                               Event :: mod_event_pusher:event()) ->
+    push_payload() | skip.
+
+-callback publish_notification(Acc :: mongooseim_acc:t(),
+                               Event :: mod_event_pusher:event(),
+                               Payload :: push_payload(),
+                               Services :: [mod_event_pusher_push:publish_service()]) ->
+    mongooseim_acc:t().
+
+-optional_callbacks([should_publish/3, prepare_notification/2, publish_notification/4]).
+
+-type push_payload() :: mod_event_pusher_push:form().
+-export_type([push_payload/0]).
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
-
--spec should_publish(Host :: jid:server(), From :: jid:jid(),
-                     To :: jid:jid(), Packet :: exml:element()) -> boolean().
-should_publish(Host, From, To, Packet) ->
+-spec init(Host :: jid:server()) -> ok.
+init(Host) ->
     PluginModule = plugin_module(Host),
+    {module, PluginModule} = code:ensure_loaded(PluginModule),
+    ok.
+
+-spec should_publish(Host :: jid:server(), Acc :: mongooseim_acc:t(),
+                     Event :: mod_event_pusher:event(),
+                     [mod_event_pusher_push:publish_service()]) -> [mod_event_pusher_push:publish_service()].
+should_publish(Host, From, To, Packet) ->
+    PluginModule = plugin_module(Host, should_publish, 3),
     PluginModule:should_publish(From, To, Packet).
 
--spec publish_notification(Acc :: mongooseim_acc:t(), From :: jid:jid(),
-                           To :: jid:jid(), Packet :: exml:element(),
+-spec prepare_notification(Host :: jid:server(), Acc :: mongooseim_acc:t(),
+                           Event :: mod_event_pusher:event()) -> push_payload() | skip.
+prepare_notification(Host, Acc, Event) ->
+    PluginModule = plugin_module(Host, prepare_notification, 2),
+    PluginModule:prepare_notification(Acc, Event).
+
+-spec publish_notification(Host :: jid:server(), Acc :: mongooseim_acc:t(),
+                           Event :: mod_event_pusher:event(), Payload :: push_payload(),
                            Services :: [mod_event_pusher_push:publish_service()]) -> mongooseim_acc:t().
-publish_notification(Acc, From, #jid{lserver = Host} = To, Packet, Services) ->
-    PluginModule = plugin_module(Host),
-    PluginModule:publish_notification(Acc, From, To, Packet, Services).
+publish_notification(_Host, Acc, _Event, _Payload, []) ->
+    Acc;
+publish_notification(Host, Acc, Event, Payload, Services) ->
+    PluginModule = plugin_module(Host, publish_notification, 4),
+    PluginModule:publish_notification(Acc, Event, Payload, Services).
 
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
+-spec plugin_module(Host :: jid:server(), atom(), arity()) -> Module :: atom().
+plugin_module(Host, Func, Arity) ->
+    Mod = plugin_module(Host),
+    case erlang:function_exported(Mod, Func, Arity) of
+        true -> Mod;
+        false -> ?DEFAULT_PLUGIN_MODULE
+    end.
 
 -spec plugin_module(Host :: jid:server()) -> Module :: atom().
 plugin_module(Host) ->
     gen_mod:get_module_opt(Host, mod_event_pusher_push, plugin_module,
-                           mod_event_pusher_push_plugin_defaults).
+                           ?DEFAULT_PLUGIN_MODULE).

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -32,7 +32,7 @@
                      Services :: [mod_event_pusher_push:publish_service()]) ->
                         [mod_event_pusher_push:publish_service()].
 should_publish(Acc, #chat_event{to = To}, Services) ->
-    PublishedServices = mongoose_acc:get(event_pusher,published_services,[], Acc),
+    PublishedServices = mongoose_acc:get(event_pusher, published_services, [], Acc),
     case should_publish(To) of
         true -> Services -- PublishedServices;
         false -> []

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -31,9 +31,10 @@
                      Event :: mod_event_pusher:event(),
                      Services :: [mod_event_pusher_push:publish_service()]) ->
                         [mod_event_pusher_push:publish_service()].
-should_publish(_Acc, #chat_event{to = To}, Services) ->
+should_publish(Acc, #chat_event{to = To}, Services) ->
+    PublishedServices = mongoose_acc:get(event_pusher,published_services,[], Acc),
     case should_publish(To) of
-        true -> Services;
+        true -> Services -- PublishedServices;
         false -> []
     end;
 should_publish(_Acc, _Event, _Services) -> [].
@@ -68,7 +69,8 @@ publish_notification(Acc, #chat_event{to = To}, Payload, Services) ->
                               publish_via_pubsub(Host, To, Service, Payload)
                       end
                   end, Services),
-    Acc.
+
+    mongoose_acc:append(event_pusher, published_services, Services, Acc).
 
 %%--------------------------------------------------------------------
 %% local functions

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -16,35 +16,82 @@
 
 -include("jlib.hrl").
 -include("mongoose.hrl").
+-include("mod_event_pusher_events.hrl").
 
 %% Callback API
--export([should_publish/3, sender_id/2]).
--export([publish_notification/5]).
+-export([prepare_notification/2,
+         should_publish/3,
+         publish_notification/4]).
 
 -define(PUSH_FORM_TYPE, <<"urn:xmpp:push:summary">>).
+%%--------------------------------------------------------------------
+%% mod_event_pusher_push_plugin callbacks
+%%--------------------------------------------------------------------
+-spec should_publish(Acc :: mongooseim_acc:t(),
+                     Event :: mod_event_pusher:event(),
+                     Services :: [mod_event_pusher_push:publish_service()]) ->
+                        [mod_event_pusher_push:publish_service()].
+should_publish(_Acc, #chat_event{to = To}, Services) ->
+    case should_publish(To) of
+        true -> Services;
+        false -> []
+    end;
+should_publish(_Acc, _Event, _Services) -> [].
 
--type push_payload() :: [{Key :: binary(), Value :: binary()}].
+-spec prepare_notification(Acc :: mongooseim_acc:t(),
+                           Event :: mod_event_pusher:event()) ->
+                              mod_event_pusher_push_plugin:push_payload() | skip.
+prepare_notification(Acc, #chat_event{to = To, from = From, packet = Packet}) ->
+    case exml_query:subelement(Packet, <<"body">>) of
+        undefined -> skip;
+        Body ->
+            BodyCData = exml_query:cdata(Body),
+            MessageCount = get_unread_count(Acc, To),
+            SenderId = sender_id(From, Packet),
+            push_content_fields(SenderId, BodyCData, MessageCount)
+    end;
+prepare_notification(_Acc, _Event) -> skip.
+
+-spec publish_notification(Acc :: mongooseim_acc:t(),
+                           Event :: mod_event_pusher:event(),
+                           Payload :: mod_event_pusher_push_plugin:push_payload(),
+                           Services :: [mod_event_pusher_push:publish_service()]) ->
+                              mongooseim_acc:t().
+publish_notification(Acc, #chat_event{to = To}, Payload, Services) ->
+    #jid{lserver = Host} = To,
+    VirtualPubsubHosts = mod_event_pusher_push:virtual_pubsub_hosts(Host),
+    lists:foreach(fun({PubsubJID, _Node, _Form} = Service) ->
+                      case lists:member(PubsubJID#jid.lserver, VirtualPubsubHosts) of
+                          true ->
+                              publish_via_hook(Acc, Host, To, Service, Payload);
+                          false ->
+                              publish_via_pubsub(Host, To, Service, Payload)
+                      end
+                  end, Services),
+    Acc.
 
 %%--------------------------------------------------------------------
-%% Callbacks
+%% local functions
 %%--------------------------------------------------------------------
 
-%% Callback 'should_publish'
--spec should_publish(From :: jid:jid(), To :: jid:jid(), Packet :: exml:element()) ->
-                            boolean().
-should_publish(_From, To = #jid{luser = LUser, lserver = LServer}, Packet) ->
+-spec should_publish(To :: jid:jid()) -> boolean().
+should_publish(#jid{luser = LUser, lserver = LServer} = To) ->
     try ejabberd_users:does_user_exist(LUser, LServer) of
         false ->
             false;
         true ->
-            ejabberd_sm:is_offline(To) andalso has_body(Packet)
+            ejabberd_sm:is_offline(To)
     catch
         _:_ ->
-            ejabberd_sm:is_offline(To) andalso has_body(Packet)
+            ejabberd_sm:is_offline(To)
     end.
 
-%% Callback 'sender_id'
--spec sender_id(From :: jid:jid(), Packet :: exml:element()) -> SenderId :: binary().
+-spec get_unread_count(mongoose_acc:t(), jid:jid()) -> pos_integer().
+get_unread_count(Acc, To) ->
+    NewAcc = ejabberd_hooks:run_fold(inbox_unread_count, To#jid.lserver, Acc, [To]),
+    mongoose_acc:get(inbox, unread_count, 1, NewAcc).
+
+-spec sender_id(jid:jid(), exml:element()) -> binary().
 sender_id(From, Packet) ->
     case exml_query:attr(Packet, <<"type">>) of
         <<"chat">> ->
@@ -53,31 +100,23 @@ sender_id(From, Packet) ->
             jid:to_binary(jid:to_lower(From))
     end.
 
--spec publish_notification(Acc :: mongooseim_acc:t(),
-                           From :: jid:jid(),
-                           To :: jid:jid(),
-                           Packet :: exml:element(),
-                           Services :: [mod_event_pusher_push:publish_service()]) ->
-    mongooseim_acc:t().
-publish_notification(Acc0, From, #jid{lserver = Host} = To, Packet, Services) ->
-    {Acc1, MessageCount} = get_unread_count(Acc0, To),
-    VirtualPubsubHosts = mod_event_pusher_push:virtual_pubsub_hosts(Host),
-    PushPayload = push_content_fields(From, Packet, MessageCount),
-    lists:foreach(fun({PubsubJID, _Node, _Form} = Service) ->
-                          case lists:member(PubsubJID#jid.lserver, VirtualPubsubHosts) of
-                              true ->
-                                  publish_via_hook(Acc0, Host, To, Service, PushPayload);
-                              false ->
-                                  publish_via_pubsub(Host, To, Service, PushPayload)
-                          end
-                  end, Services),
-    Acc1.
+-spec push_content_fields(binary(), binary(), non_neg_integer()) ->
+    mod_event_pusher_push_plugin:push_payload() | skip.
+push_content_fields(_SenderId, <<"">>, _MessageCount) ->
+    skip;
+push_content_fields(SenderId, BodyCData, MessageCount) ->
+    [
+        {<<"message-count">>, integer_to_binary(MessageCount)},
+        {<<"last-message-sender">>, SenderId},
+        {<<"last-message-body">>, BodyCData}
+    ].
 
 -spec publish_via_hook(Acc :: mongooseim_acc:t(),
                        Host :: jid:server(),
                        To :: jid:jid(),
                        Service :: mod_event_pusher_push:publish_service(),
-                       PushPayload :: push_payload()) -> any().
+                       PushPayload :: mod_event_pusher_push_plugin:push_payload()) ->
+                          any().
 publish_via_hook(Acc0, Host, To, {PubsubJID, Node, Form}, PushPayload) ->
     OptionMap = maps:from_list(Form),
     HookArgs = [Host, [maps:from_list(PushPayload)], OptionMap],
@@ -87,16 +126,15 @@ publish_via_hook(Acc0, Host, To, {PubsubJID, Node, Form}, PushPayload) ->
     case ejabberd_hooks:run_fold(push_notifications, Host, Acc, HookArgs) of
         {error, device_not_registered} ->
             %% We disable the push node in case the error type is device_not_registered
-            BareRecipient = jid:to_bare(To),
-            mod_event_pusher_push:maybe_remove_push_node_from_sessions_info(BareRecipient, Node),
-            mod_event_pusher_push_backend:disable(BareRecipient, PubsubJID, Node);
+            mod_event_pusher_push:disable_node(To,PubsubJID, Node);
         _ -> ok
     end.
 
 -spec publish_via_pubsub(Host :: jid:server(),
                          To :: jid:jid(),
                          Service :: mod_event_pusher_push:publish_service(),
-                         PushPayload :: push_payload()) -> any().
+                         PushPayload :: mod_event_pusher_push_plugin:push_payload()) ->
+                            any().
 publish_via_pubsub(Host, To, {PubsubJID, Node, Form}, PushPayload) ->
     Stanza = push_notification_iq(Node, Form, PushPayload),
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
@@ -106,20 +144,38 @@ publish_via_pubsub(Host, To, {PubsubJID, Node, Form}, PushPayload) ->
                               to_jid => PubsubJID }),
 
     ResponseHandler =
-    fun(_From, _To, Acc1, Response) ->
-            mod_event_pusher_push:cast(Host, handle_publish_response,
+    fun(_From, _To, Acc, Response) ->
+            mod_event_pusher_push:cast(Host, fun handle_publish_response/4,
                                        [To, PubsubJID, Node, Response]),
-            Acc1
+            Acc
     end,
     %% The IQ is routed from the recipient's server JID to pubsub JID
     %% This is recommended in the XEP and also helps process replies to this IQ
     NotificationFrom = jid:make(<<>>, Host, <<>>),
-    mod_event_pusher_push:cast(Host, ejabberd_local, route_iq,
+    mod_event_pusher_push:cast(Host, fun ejabberd_local:route_iq/5,
                                [NotificationFrom, PubsubJID, Acc, Stanza, ResponseHandler]).
+
+-spec handle_publish_response(Recipient :: jid:jid(), PubsubJID :: jid:jid(),
+                              Node :: mod_event_pusher_push:pubsub_node(),
+                              Result :: timeout | jlib:iq()) -> ok.
+handle_publish_response(_Recipient, _PubsubJID, _Node, timeout) ->
+    ok;
+handle_publish_response(_Recipient, _PubsubJID, _Node, #iq{type = result}) ->
+    ok;
+handle_publish_response(Recipient, PubsubJID, Node, #iq{type = error, sub_el = Els}) ->
+    [Error | _ ] = [Err || #xmlel{name = <<"error">>} = Err <- Els],
+    case exml_query:attr(Error, <<"type">>) of
+        <<"cancel">> ->
+            %% We disable the push node in case the error type is cancel
+            mod_event_pusher_push:disable_node(Recipient,PubsubJID, Node);
+        _ ->
+            ok
+    end.
 
 -spec push_notification_iq(Node :: mod_event_pusher_push:pubsub_node(),
                            Form :: mod_event_pusher_push:form(),
-                           PushPayload :: push_payload()) -> jlib:iq().
+                           PushPayload :: mod_event_pusher_push_plugin:push_payload()) ->
+                              jlib:iq().
 push_notification_iq(Node, Form, PushPayload) ->
     NotificationFields = [{<<"FORM_TYPE">>, ?PUSH_FORM_TYPE} | PushPayload ],
 
@@ -135,25 +191,6 @@ push_notification_iq(Node, Form, PushPayload) ->
         ] ++ maybe_publish_options(Form)}
     ]}.
 
--spec push_content_fields(From :: jid:jid(),
-                          Packet :: exml:element(),
-                          MessageCount :: non_neg_integer()) -> push_payload().
-push_content_fields(From, Packet, MessageCount) ->
-    [
-     {<<"message-count">>, integer_to_binary(MessageCount)},
-     {<<"last-message-sender">>, sender_id(From, Packet)},
-     {<<"last-message-body">>, exml_query:cdata(exml_query:subelement(Packet, <<"body">>))}
-    ].
-
--spec maybe_publish_options(mod_event_pusher_push:form()) -> [exml:element()].
-maybe_publish_options([]) ->
-    [];
-maybe_publish_options(FormFields) ->
-    [#xmlel{name = <<"publish-options">>,
-            children = [
-                        make_form([{<<"FORM_TYPE">>, ?NS_PUBSUB_PUB_OPTIONS}] ++ FormFields)
-                       ]}].
-
 -spec make_form(mod_event_pusher_push:form()) -> exml:element().
 make_form(Fields) ->
     #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"submit">>}],
@@ -165,15 +202,9 @@ make_form_field({Name, Value}) ->
            attrs = [{<<"var">>, Name}],
            children = [#xmlel{name = <<"value">>, children = [#xmlcdata{content = Value}]}]}.
 
-get_unread_count(Acc, To) ->
-    Acc0 = ejabberd_hooks:run_fold(inbox_unread_count, To#jid.lserver, Acc, [To]),
-    UnreadCount = mongoose_acc:get(inbox, unread_count, 1, Acc0),
-    {Acc0, UnreadCount}.
-
-has_body(Packet) ->
-    case exml_query:path(Packet, [{element, <<"body">>}, cdata]) of
-        <<>> ->
-            false;
-        _ ->
-            true
-    end.
+-spec maybe_publish_options(mod_event_pusher_push:form()) -> [exml:element()].
+maybe_publish_options([]) ->
+    [];
+maybe_publish_options(FormFields) ->
+    Children = [make_form([{<<"FORM_TYPE">>, ?NS_PUBSUB_PUB_OPTIONS}] ++ FormFields)],
+    [#xmlel{name = <<"publish-options">>, children = Children}].


### PR DESCRIPTION
things done in this PR:
* handling of `unacknowledged_message` hook at `mod_event_pusher_hook_translator`. currently the event generated on this hook is ignored by all the `mod_event_pusher` backends.
* rework of the `mod_event_pusher_push_plugin`:
  - all the callbacks are optional. if any of them is not implemented in the pluging, `mod_event_pusher_push_plugin_defaults` implementation is used instead.
  - `should_publish` accepts the list of all services and returns the list of services where notification should be published. so it can be easily fully accepted/rejected or filtered.
  - separate `prepare_notification` interface can be used to reject the event (e.g. message doesn't have body) or create push notification payload.
  - `publish_notification` interface. `mod_event_pusher_push_plugin_defaults` module implements pubsub or the pubsubless notification mechanisms.
* tracking of the services (nodes) where the message is notified.
* basic tests of the integration with SM and mod_offline
* ensuring that buffered by SM messages are notified if session is not restored. this also theoretically implements notifications for chat messages from the S2S connections.

things to be implemented in another PR (to avoid extra merging):
* enhanced plugin to handle events generated on `unacknowledged_message` hook
* testing of the enhanced  plugin