### PR TITLE
initial implementation of the enhanced push plugin

### DIFF
--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -19,6 +19,8 @@
 ]).
 
 -define(RPC_SPEC, #{node => distributed_helper:mim()}).
+-define(SESSION_KEY, publish_service).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -414,13 +416,13 @@ disable_node_enabled_in_session_removes_it_from_session_info(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             Info = mongoose_helper:get_session_info(?RPC_SPEC, Bob),
-            {push_notifications, {NodeId, _}} = lists:keyfind(push_notifications, 1, Info),
+            {?SESSION_KEY, {_JID, NodeId, _}} = lists:keyfind(?SESSION_KEY, 1, Info),
 
             escalus:send(Bob, disable_stanza(PubsubJID, NodeId)),
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             Info2 = mongoose_helper:get_session_info(?RPC_SPEC, Bob),
-            false = lists:keyfind(push_notifications, 1, Info2)
+            false = lists:keyfind(?SESSION_KEY, 1, Info2)
         end).
 
 disable_all_nodes_removes_it_from_all_user_session_infos(Config) ->
@@ -438,10 +440,10 @@ disable_all_nodes_removes_it_from_all_user_session_infos(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob2)),
 
             Info = mongoose_helper:get_session_info(?RPC_SPEC, Bob1),
-            {push_notifications, {NodeId, _}} = lists:keyfind(push_notifications, 1, Info),
+            {?SESSION_KEY, {_JID, NodeId, _}} = lists:keyfind(?SESSION_KEY, 1, Info),
 
             Info2 = mongoose_helper:get_session_info(?RPC_SPEC, Bob2),
-            {push_notifications, {NodeId2, _}} = lists:keyfind(push_notifications, 1, Info2),
+            {?SESSION_KEY, {_JID, NodeId2, _}} = lists:keyfind(?SESSION_KEY, 1, Info2),
 
             %% Now Bob1 disables all nodes
             escalus:send(Bob1, disable_stanza(PubsubJID)),
@@ -449,10 +451,10 @@ disable_all_nodes_removes_it_from_all_user_session_infos(Config) ->
 
             %% And we check if Bob1 and Bob2 have push notifications cleared from session info
             Info3 = mongoose_helper:get_session_info(?RPC_SPEC, Bob1),
-            false = lists:keyfind(push_notifications, 1, Info3),
+            false = lists:keyfind(?SESSION_KEY, 1, Info3),
 
             Info4 = mongoose_helper:get_session_info(?RPC_SPEC, Bob2),
-            false = lists:keyfind(push_notifications, 1, Info4)
+            false = lists:keyfind(?SESSION_KEY, 1, Info4)
         end).
 
 disable_node_enabled_in_other_session_leaves_current_info_unchanged(Config) ->
@@ -470,10 +472,10 @@ disable_node_enabled_in_other_session_leaves_current_info_unchanged(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob2)),
 
             Info = mongoose_helper:get_session_info(?RPC_SPEC, Bob1),
-            {push_notifications, {NodeId, _}} = lists:keyfind(push_notifications, 1, Info),
+            {?SESSION_KEY, {_JID, NodeId, _}} = lists:keyfind(?SESSION_KEY, 1, Info),
 
             Info2 = mongoose_helper:get_session_info(?RPC_SPEC, Bob2),
-            {push_notifications, {NodeId2, _}} = lists:keyfind(push_notifications, 1, Info2),
+            {?SESSION_KEY, {_JID, NodeId2, _}} = lists:keyfind(?SESSION_KEY, 1, Info2),
 
             %% Now Bob1 disables the node registered by Bob2
             escalus:send(Bob1, disable_stanza(PubsubJID, NodeId)),
@@ -481,7 +483,7 @@ disable_node_enabled_in_other_session_leaves_current_info_unchanged(Config) ->
 
             %% And we check if Bob1 still has its own Node in the session info
             Info3 = mongoose_helper:get_session_info(?RPC_SPEC, Bob1),
-            false = lists:keyfind(push_notifications, 1, Info3)
+            false = lists:keyfind(?SESSION_KEY, 1, Info3)
         end).
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -9,8 +9,7 @@
 
 -define(MUCLIGHTHOST, <<"muclight.localhost">>).
 -define(RPC_SPEC, #{node => distributed_helper:mim()}).
-
-
+-define(SESSION_KEY, publish_service).
 
 -import(muc_light_helper,
         [
@@ -644,7 +643,7 @@ maybe_check_if_push_node_was_disabled("v3", User, PushNode) ->
 
     Fun2 = fun() ->
                    Info = mongoose_helper:get_session_info(?RPC_SPEC, User),
-                   lists:keyfind(push_notifications, 1, Info)
+                   lists:keyfind(?SESSION_KEY, 1, Info)
            end,
     mongoose_helper:wait_until(Fun2, false).
 
@@ -731,8 +730,7 @@ add_user_server_to_whitelist(User, {NodeAddr, NodeName}) ->
 
 assert_push_notification_in_session(User, NodeName, Service, DeviceToken) ->
     Info = mongoose_helper:get_session_info(?RPC_SPEC, User),
-
-    {push_notifications, {NodeName, Details}} = lists:keyfind(push_notifications, 1, Info),
+    {?SESSION_KEY, {_JID, NodeName, Details}} = lists:keyfind(?SESSION_KEY, 1, Info),
     ?assertMatch({<<"service">>, Service}, lists:keyfind(<<"service">>, 1, Details)),
     ?assertMatch({<<"device_id">>, DeviceToken}, lists:keyfind(<<"device_id">>, 1, Details)).
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -1278,8 +1278,9 @@ start_hook_listener(Resource) ->
 
 rpc_start_hook_handler(TestCasePid, User) ->
     LUser=jid:nodeprep(User),
-    Handler = fun(Acc, U, S, R) ->
-                case jid:nodeprep(U) of
+    Handler = fun(Acc, Jid) ->
+                {U, _S, R} = jid:to_lower(Jid),
+                case U of
                     LUser ->
                         Counter = mongoose_acc:get(sm_test, counter, 0, Acc),
                         El = mongoose_acc:element(Acc),

--- a/include/mod_event_pusher_events.hrl
+++ b/include/mod_event_pusher_events.hrl
@@ -4,6 +4,5 @@
 -record(chat_event, {type :: headline | normal | chat | groupchat,
                      direction :: in | out,
                      from :: jid:jid(), to :: jid:jid(), packet :: exml:element()}).
--record(unack_msg_event, {user :: jid:user(), server :: jid:server(),
-                          resource :: jid:resource()}).
+-record(unack_msg_event, {to ::  jid:jid()}).
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3025,16 +3025,15 @@ notify_unacknowledged_msg_if_in_resume_state(Acc,
 notify_unacknowledged_msg_if_in_resume_state(Acc, _) ->
     Acc.
 
-maybe_notify_unacknowledged_msg(Acc, #state{user     = User,
-                                            resource = Res,
-                                            server   = Server}) ->
+maybe_notify_unacknowledged_msg(Acc, #state{jid = Jid}) ->
     case mongoose_acc:stanza_name(Acc) of
-        <<"message">> ->
-            NewAcc = ejabberd_hooks:run_fold(unacknowledged_message,
-                                             Server, Acc, [User, Server, Res]),
-            mongoose_acc:strip(NewAcc);
+        <<"message">> -> notify_unacknowledged_msg(Acc, Jid);
         _ -> Acc
     end.
+
+notify_unacknowledged_msg(Acc, #jid{lserver = Server} = Jid) ->
+    NewAcc = ejabberd_hooks:run_fold(unacknowledged_message, Server, Acc, [Jid]),
+    mongoose_acc:strip(NewAcc).
 
 finish_state(ok, StateName, StateData) ->
     fsm_next_state(StateName, StateData);

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -36,6 +36,7 @@
          open_session/3, open_session/4,
          close_session/4,
          store_info/2,
+         get_info/2,
          remove_info/2,
          check_in_subscription/6,
          bounce_offline_message/4,
@@ -272,6 +273,20 @@ store_info(JID, {Key, _Value} = KV) ->
                     %% Async operation
                     ejabberd_c2s:store_session_info(Pid, JID, KV),
                     {ok, KV}
+            end
+    end.
+
+-spec get_info(jid:jid(), info_key()) ->
+    {ok, any()} | {error, offline | not_set}.
+get_info(JID, Key) ->
+    case get_session(JID) of
+        offline -> {error, offline};
+        {_SUser, _SID, _SPriority, SInfo} ->
+            case lists:keyfind(Key, 1, SInfo) of
+                {Key, Value} ->
+                    {ok, Value};
+                _ ->
+                    {error, not_set}
             end
     end.
 

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -89,7 +89,7 @@ user_not_present(Acc, LUser, LHost, LResource, _Status) ->
     merge_acc(Acc, NewAcc).
 
 unacknowledged_message(Acc, User, Server, Res) ->
-    Event = #unack_msg_event{user = User, server = Server, resource = Res},
+    Event = #unack_msg_event{to = jid:make(User, Server, Res)},
     NewAcc = mod_event_pusher:push_event(Acc, Server, Event),
     merge_acc(Acc, NewAcc).
 

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -27,7 +27,7 @@
          filter_local_packet/1,
          user_present/2,
          user_not_present/5,
-         unacknowledged_message/4]).
+         unacknowledged_message/2]).
 
 %%--------------------------------------------------------------------
 %% gen_mod API
@@ -88,8 +88,8 @@ user_not_present(Acc, LUser, LHost, LResource, _Status) ->
     NewAcc = mod_event_pusher:push_event(Acc, LHost, Event),
     merge_acc(Acc, NewAcc).
 
-unacknowledged_message(Acc, User, Server, Res) ->
-    Event = #unack_msg_event{to = jid:make(User, Server, Res)},
+unacknowledged_message(Acc, #jid{lserver = Server} = Jid) ->
+    Event = #unack_msg_event{to = Jid},
     NewAcc = mod_event_pusher:push_event(Acc, Server, Event),
     merge_acc(Acc, NewAcc).
 

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -84,6 +84,8 @@ start(Host, Opts) ->
     gen_mod:start_backend_module(?MODULE, Opts, [enable, disable, get_publish_services]),
     mod_event_pusher_push_backend:init(Host, Opts),
 
+    mod_event_pusher_push_plugin:init(Host),
+
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
     mod_disco:register_feature(Host, ?NS_PUSH),
     gen_iq_handler:add_iq_handler(ejabberd_local, Host, ?NS_PUSH, ?MODULE,

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -117,8 +117,8 @@ push_event(Acc, Host, Event = #chat_event{direction = out, to = To,
                                                              Type =:= chat ->
     BareRecipient = jid:to_bare(To),
     do_push_event(Acc, Host, Event, BareRecipient);
-push_event(Acc, Host, Event = #unack_msg_event{user = U, server = S}) ->
-    BareRecipient = jid:make(U, S, <<"">>),
+push_event(Acc, Host, Event = #unack_msg_event{to = To}) ->
+    BareRecipient = jid:to_bare(To),
     do_push_event(Acc, Host, Event, BareRecipient);
 push_event(Acc, _, _) ->
     Acc.

--- a/src/event_pusher/mod_event_pusher_push_plugin.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin.erl
@@ -50,7 +50,7 @@
 -spec init(Host :: jid:server()) -> ok.
 init(Host) ->
     PluginModule = plugin_module(Host),
-    {module, PluginModule} = code:ensure_loaded(PluginModule),
+    ensure_loaded(PluginModule),
     ok.
 
 -spec should_publish(Host :: jid:server(), Acc :: mongooseim_acc:t(),
@@ -90,3 +90,7 @@ plugin_module(Host, Func, Arity) ->
 plugin_module(Host) ->
     gen_mod:get_module_opt(Host, mod_event_pusher_push, plugin_module,
                            ?DEFAULT_PLUGIN_MODULE).
+
+-spec ensure_loaded(module()) -> {module, module()}.
+ensure_loaded(PluginModule) ->
+    {module, PluginModule} = code:ensure_loaded(PluginModule).

--- a/src/event_pusher/mod_event_pusher_push_plugin_enhanced.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_enhanced.erl
@@ -28,8 +28,7 @@
                      Event :: mod_event_pusher:event(),
                      Services :: [mod_event_pusher_push:publish_service()]) ->
                         [mod_event_pusher_push:publish_service()].
-should_publish(Acc, #unack_msg_event{user = U, server = S, resource = R}, _Services) ->
-    Jid = jid:make(U, S, R),
+should_publish(Acc, #unack_msg_event{to = Jid}, _Services) ->
     PublishedServices = mongoose_acc:get(event_pusher, published_services, [], Acc),
     case ejabberd_sm:get_info(Jid, publish_service) of
         {ok, Service} -> [Service] -- PublishedServices;

--- a/src/event_pusher/mod_event_pusher_push_plugin_enhanced.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_enhanced.erl
@@ -1,0 +1,39 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mod_event_pusher_push_plugin_enhanced).
+-behavior(mod_event_pusher_push_plugin).
+
+-include("mod_event_pusher_events.hrl").
+
+%% API
+-export([should_publish/3]).
+
+%%--------------------------------------------------------------------
+%% mod_event_pusher_push_plugin callbacks
+%%--------------------------------------------------------------------
+-spec should_publish(Acc :: mongooseim_acc:t(),
+                     Event :: mod_event_pusher:event(),
+                     Services :: [mod_event_pusher_push:publish_service()]) ->
+                        [mod_event_pusher_push:publish_service()].
+should_publish(Acc, #unack_msg_event{user = U, server = S, resource = R}, _Services) ->
+    Jid = jid:make(U, S, R),
+    PublishedServices = mongoose_acc:get(event_pusher, published_services, [], Acc),
+    case ejabberd_sm:get_info(Jid, publish_service) of
+        {ok, Service} -> [Service] -- PublishedServices;
+        {error, _} -> []
+    end;
+should_publish(Acc, Event, Services) ->
+    mod_event_pusher_push_plugin_defaults:should_publish(Acc, Event, Services).


### PR DESCRIPTION
This branch contains implementation of the enhanced push plugin (`mod_event_pusher_push_plugin_enhanced`), here are some notes:

the implementation is minimalistic. comparing to the default plugin enhanced one adds only immediate push notifications to the devices that just lost connection (session waits for resumption) also it works only if device (re)enabled notifications during the session. this helps to avoid the notification duplicates in most of the cases. 

