### PR TITLE
Persistent cluster ID

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -79,6 +79,7 @@
 {suites, "tests", mongoose_cassandra_SUITE}.
 {suites, "tests", mongoose_elasticsearch_SUITE}.
 {suites, "tests", sasl_external_SUITE}.
+{suites, "tests", persistent_cluster_id_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -1,0 +1,110 @@
+-module(persistent_cluster_id_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% API
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         group/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2]).
+
+%% test cases
+-export([
+         all_nodes_in_the_cluster_have_the_same_cluster_id/1,
+         id_persists_after_restart/1
+        ]).
+
+all() ->
+    [
+     {group, mnesia},
+     {group, rdbms}
+    ].
+
+tests() ->
+    [
+     all_nodes_in_the_cluster_have_the_same_cluster_id,
+     id_persists_after_restart
+    ].
+
+groups() ->
+    [
+     {mnesia, [], tests()},
+     {rdbms, [], tests()}
+    ].
+
+%%%===================================================================
+%%% Overall setup/teardown
+%%%===================================================================
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%%%===================================================================
+%%% Group specific setup/teardown
+%%%===================================================================
+group(_Groupname) ->
+    [].
+
+init_per_group(mnesia, Config) ->
+    case not mongoose_helper:is_rdbms_enabled(domain()) of
+        true -> Config;
+        false -> {skip, require_no_rdbms}
+    end;
+init_per_group(_Groupname, Config) ->
+    case mongoose_helper:is_rdbms_enabled(domain()) of
+        true -> Config;
+        false -> {skip, require_rdbms}
+    end.
+
+end_per_group(_Groupname, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Testcase specific setup/teardown
+%%%===================================================================
+init_per_testcase(all_nodes_in_the_cluster_have_the_same_cluster_id, Config) ->
+    distributed_helper:add_node_to_cluster(distributed_helper:mim2(), Config),
+    Config;
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(all_nodes_in_the_cluster_have_the_same_cluster_id, Config) ->
+    distributed_helper:remove_node_from_cluster(distributed_helper:mim2(), Config),
+    Config;
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Individual Test Cases (from groups() definition)
+%%%===================================================================
+all_nodes_in_the_cluster_have_the_same_cluster_id(_Config) ->
+    {ok, ID_mim1} = mongoose_helper:successful_rpc(
+               distributed_helper:mim(),
+               mongoose_cluster_id, get_cached_cluster_id, []),
+    {ok, ID_mim2} = mongoose_helper:successful_rpc(
+               distributed_helper:mim2(),
+               mongoose_cluster_id, get_cached_cluster_id, []),
+    ct:log("ID for mim1 is ~p~n", [ID_mim1]),
+    ct:log("ID for mim2 is ~p~n", [ID_mim2]),
+    ?assertEqual(ID_mim1, ID_mim2).
+
+id_persists_after_restart(_Config) ->
+    {ok, FirstID} = mongoose_helper:successful_rpc(
+               distributed_helper:mim(),
+               mongoose_cluster_id, get_cached_cluster_id, []),
+    ejabberd_node_utils:restart_application(mongooseim),
+    {ok, SecondID} = mongoose_helper:successful_rpc(
+               distributed_helper:mim(),
+               mongoose_cluster_id, get_cached_cluster_id, []),
+    ?assertEqual(FirstID, SecondID).
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -42,9 +42,7 @@ tests() ->
 
 groups() ->
     [
-     {mnesia, [],
-      [all_nodes_in_the_cluster_have_the_same_cluster_id,
-       id_persists_after_restart]},
+     {mnesia, [], [all_nodes_in_the_cluster_have_the_same_cluster_id]},
      {rdbms, [], tests()}
     ].
 

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -611,3 +611,8 @@ ALTER TABLE [dbo].[vcard_search] ADD  DEFAULT (N'') FOR [lusername]
 GO
 ALTER TABLE [dbo].[vcard_search] ADD  DEFAULT (N'') FOR [server]
 GO
+
+CREATE TABLE mongoose_cluster_id (
+    k varchar(50) NOT NULL PRIMARY KEY,
+    v text
+);

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -444,3 +444,8 @@ CREATE TABLE event_pusher_push_subscription (
    ROW_FORMAT=DYNAMIC;
 
 CREATE INDEX i_event_pusher_push_subscription ON event_pusher_push_subscription(owner_jid);
+
+CREATE TABLE mongoose_cluster_id (
+    k varchar(50) PRIMARY KEY,
+    v text
+);

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -401,3 +401,8 @@ CREATE TABLE event_pusher_push_subscription (
  );
 
 CREATE INDEX i_event_pusher_push_subscription ON event_pusher_push_subscription(owner_jid);
+
+CREATE TABLE mongoose_cluster_id (
+    k varchar(50) PRIMARY KEY,
+    v text
+);

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -68,6 +68,7 @@ start(normal, _Args) ->
     ejabberd_rdbms:start(),
     lists:foreach(fun ejabberd_users:start/1, ?MYHOSTS),
     ejabberd_auth:start(),
+    mongoose_cluster_id:start(),
     start_services(),
     start_modules(),
     mongoose_metrics:init(),

--- a/src/mongoose_cluster_id.erl
+++ b/src/mongoose_cluster_id.erl
@@ -72,9 +72,9 @@ init_mnesia_cache() ->
                         [{type, set},
                          {record_name, mongoose_cluster_id},
                          {attributes, record_info(fields, mongoose_cluster_id)},
-                         {disc_only_copies, [node()]}
+                         {ram_copies, [node()]}
                         ]),
-    mnesia:add_table_copy(mongoose_cluster_id, node(), disc_only_copies).
+    mnesia:add_table_copy(mongoose_cluster_id, node(), ram_copies).
 
 -spec make_cluster_id() -> cluster_id().
 make_cluster_id() ->

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -656,7 +656,7 @@ abort_on_driver_error({{error, "Failed sending data on socket" ++ _} = Reply, St
 abort_on_driver_error({Reply, State}) ->
     {reply, Reply, State}.
 
--spec db_engine(Host :: server()) -> odbc | mysql | pgsql.
+-spec db_engine(Host :: server()) -> odbc | mysql | pgsql | undefined.
 db_engine(_Host) ->
     try mongoose_rdbms_backend:backend_name()
     catch error:undef -> undefined end.


### PR DESCRIPTION
TODO: tests

- [x] The same value is saved in mnesia cache and RDBMS
- [x] If enabling RDBMS after cluster_id was written to mnesia only saves the existing id to RDBMS. This will probably require stoping and starting the rdbms pools in order to simulate the situation.
- [x] Check if cluster id is written to RDBMS and Mnesia files are removed the cluster id is written back to mnesia when the module starts.
- [ ] Test (manually) if this disc_only_copies causes a dead lock in restarting clustered nodes. Start 2 nodes and cluster them together. Stop both of them, start the second first (see if it starts properly - is able to accept connections) and the start the first one and check if everything is ok.