### PR TITLE
[Small] Modernise time functionality for mod_last

### DIFF
--- a/doc/developers-guide/flat_options.md
+++ b/doc/developers-guide/flat_options.md
@@ -100,7 +100,7 @@ Each flat option key starts with an option type:
 {[l,listener_opt,{8189,{127,0,0,1},tcp},ejabberd_service,password],"secret"}.
 {[l,all_metrics_are_global],false}.
 {[l,s2s_certfile],"priv/ssl/fake_server.pem"}.
-{[l,node_start],{1530,15976,143119}}.
+{[l,node_start],{node_start,143119}}.
 {[l,rdbms_pools],[]}.
 {[l,registration_timeout],infinity}.
 {[l,outgoing_s2s_port],5299}.

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -93,7 +93,7 @@ start() ->
     Config = get_ejabberd_config_path(),
     ejabberd_config:load_file(Config),
     %% This start time is used by mod_last:
-    add_local_option(node_start, erlang:timestamp()),
+    add_local_option(node_start, {node_start, erlang:system_time(second)}),
     ok.
 
 

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -133,15 +133,11 @@ process_local_iq(_From, _To, Acc,
 -spec get_node_uptime() -> non_neg_integer().
 get_node_uptime() ->
     case ejabberd_config:get_local_option(node_start) of
-        {_, _, _} = StartNow ->
-            erlang:system_time(second) - now_to_seconds(StartNow);
+        {node_start, Seconds} when is_integer(Seconds) ->
+            erlang:system_time(second) - Seconds;
         _Undefined ->
             trunc(element(1, erlang:statistics(wall_clock))/1000)
     end.
-
--spec now_to_seconds(erlang:timestamp()) -> non_neg_integer().
-now_to_seconds({MegaSecs, Secs, _MicroSecs}) ->
-    MegaSecs * 1000000 + Secs.
 
 %%%
 %%% Serve queries about user last online


### PR DESCRIPTION
http://erlang.org/doc/man/erlang.html#timestamp-0 says that
> Current Erlang system time can more efficiently be retrieved in the time unit of your choice using `erlang:system_time/1`.

So we save erts time, and also time on the `now_to_seconds` function. I just though of tagging the value into a tagged tuple, so ensure some sort of "type-safety" 🤷‍♂ 