### PR TITLE
Sysmetrics/log transparency

### DIFF
--- a/big_tests/tests/lager_ct_backend.erl
+++ b/big_tests/tests/lager_ct_backend.erl
@@ -16,7 +16,7 @@
         receivers := [{pid(), lager:log_level()}]
        }.
 
--type filter_fun() :: fun((lager:log_leverl(), binary()) -> boolean()).
+-type filter_fun() :: fun((lager:log_level(), binary()) -> boolean()).
 
 %% ------------------------------------------------------------
 %% API for tests

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -22,6 +22,7 @@
 -export([
          all/0,
          suite/0,
+         groups/0,
          init_per_suite/1,
          end_per_suite/1,
          init_per_group/2,
@@ -46,7 +47,14 @@
          transport_mechanisms_are_reported/1
         ]).
 
--import(distributed_helper, [mim/0, mim2/0,
+-export([
+         just_removed_from_config_logs_question/1,
+         in_config_unmodified_logs_request_for_agreement/1,
+         in_config_with_explicit_no_report_goes_off_silently/1,
+         in_config_with_explicit_reporting_goes_on_silently/1
+        ]).
+
+-import(distributed_helper, [mim/0, mim2/0, mim3/0,
                              require_rpc_nodes/1
                             ]).
 
@@ -77,7 +85,18 @@ all() ->
      cluster_uptime_is_reported,
      xmpp_componenets_are_reported,
      api_are_reported,
-     transport_mechanisms_are_reported
+     transport_mechanisms_are_reported,
+     {group, log_transparency}
+    ].
+
+groups() ->
+    [
+     {log_transparency, [], [
+                             just_removed_from_config_logs_question,
+                             in_config_unmodified_logs_request_for_agreement,
+                             in_config_with_explicit_no_report_goes_off_silently,
+                             in_config_with_explicit_reporting_goes_on_silently
+                            ]}
     ].
 
 -define(APPS, [inets, crypto, ssl, ranch, cowlib, cowboy]).
@@ -106,9 +125,16 @@ end_per_suite(Config) ->
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
+init_per_group(log_transparency, Config) ->
+    lager_ct_backend:start(),
+    lager_ct_backend:capture(warning),
+    Config;
 init_per_group(_GroupName, Config) ->
     Config.
 
+end_per_group(log_transparency, Config) ->
+    lager_ct_backend:stop_capture(),
+    Config;
 end_per_group(_GroupName, Config) ->
     Config.
 
@@ -153,6 +179,9 @@ init_per_testcase(module_backend_is_reported, Config) ->
 init_per_testcase(_TestcaseName, Config) ->
     create_events_collection(),
     enable_system_metrics(mim()),
+    Config;
+init_per_testcase(_TestCase, Config) ->
+    create_events_collection(),
     Config.
 
 
@@ -185,6 +214,9 @@ end_per_testcase(system_metrics_are_reported_to_additional_google_analytics, Con
 end_per_testcase(_TestcaseName, Config) ->
     clear_events_collection(),
     disable_system_metrics(mim()),
+    Config;
+end_per_testcase(_TestCase, Config) ->
+    clear_events_collection(),
     Config.
 
 
@@ -251,6 +283,61 @@ api_are_reported(_Config) ->
 
 transport_mechanisms_are_reported(_Config) ->
     mongoose_helper:wait_until(fun transport_mechanisms_are_reported/0, true).
+
+just_removed_from_config_logs_question(_Config) ->
+    %% WHEN
+    disable_system_metrics(mim()),
+    lager_ct_backend:capture(warning),
+    start_system_metrics_module(mim(), [removed_from_config]),
+    lager_ct_backend:stop_capture(),
+    %% THEN
+    FilterFun = fun(_, Msg) ->
+                        re:run(Msg, "Are you sure") /= nomatch
+                end,
+    mongoose_helper:wait_until(fun() -> length(lager_ct_backend:recv(FilterFun)) end, 1),
+    %% CLEAN
+    disable_system_metrics(mim()).
+
+in_config_unmodified_logs_request_for_agreement(_Config) ->
+    %% WHEN
+    lager_ct_backend:capture(warning),
+    enable_system_metrics(mim()),
+    lager_ct_backend:stop_capture(),
+    %% THEN
+    FilterFun = fun(_, Msg) ->
+                        re:run(Msg, "Do you agree with reporting") /= nomatch
+                end,
+    mongoose_helper:wait_until(fun() -> length(lager_ct_backend:recv(FilterFun)) end, 1),
+    %% CLEAN
+    disable_system_metrics(mim()).
+
+in_config_with_explicit_no_report_goes_off_silently(_Config) ->
+    %% WHEN
+    lager_ct_backend:capture(warning),
+    start_system_metrics_module(mim(), [no_report]),
+    lager_ct_backend:stop_capture(),
+    %% THEN
+    FilterFun = fun(warning, Msg) ->
+                        re:run(Msg, "metrics") /= nomatch;
+                   (_,_) -> false
+                end,
+    [] = lager_ct_backend:recv(FilterFun),
+    %% CLEAN
+    disable_system_metrics(mim()).
+
+in_config_with_explicit_reporting_goes_on_silently(_Config) ->
+    %% WHEN
+    lager_ct_backend:capture(warning),
+    start_system_metrics_module(mim(), [report]),
+    lager_ct_backend:stop_capture(),
+    %% THEN
+    FilterFun = fun(warning, Msg) ->
+                        re:run(Msg, "metrics") /= nomatch;
+                   (_,_) -> false
+                end,
+    [] = lager_ct_backend:recv(FilterFun),
+    %% CLEAN
+    disable_system_metrics(mim()).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -18,10 +18,11 @@
 {auth_method, "internal"}.
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
-{service_mongoose_system_metrics, % , before the service as it will be added at the end of a tuple
-    ",{service_mongoose_system_metrics,\n"
-    "          [{initial_report, 60000},\n"
-    "           {periodic_report, 10800000}]}"}. % initial report after 1 minute, periodic every 3 hours
+% Removed to test that metrics are not gathered for this one
+% {service_mongoose_system_metrics, % , before the service as it will be added at the end of a tuple
+%     ",{service_mongoose_system_metrics,\n"
+%     "          [{initial_report, 60000},\n"
+%     "           {periodic_report, 10800000}]}"}. % initial report after 1 minute, periodic every 3 hours
 {highload_vm_args, ""}.
 {ejabberd_service, ""}.
 {mod_last, "{mod_last, []},"}.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -151,11 +151,20 @@ stop_modules() ->
 
 -spec start_services() -> ok.
 start_services() ->
-    Services = ejabberd_config:get_local_option_or_default(services, []),
     lists:foreach(
         fun({Service, Opts}) -> mongoose_service:ensure_loaded(Service, Opts) end,
-        Services
+        services_with_maybe_metrics()
     ).
+
+-spec services_with_maybe_metrics() -> [term()].
+services_with_maybe_metrics() ->
+    Services = ejabberd_config:get_local_option_or_default(services, []),
+    case proplists:is_defined(service_mongoose_system_metrics, Services) of
+        false ->
+            [{service_mongoose_system_metrics, [removed_from_config]} | Services];
+        true ->
+            Services
+    end.
 
 -spec stop_services() -> ok.
 stop_services() ->

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -151,9 +151,10 @@ stop_modules() ->
 
 -spec start_services() -> ok.
 start_services() ->
+    Services = ejabberd_config:get_local_option_or_default(services, []),
     lists:foreach(
-        fun({Service, _}) -> mongoose_service:ensure_loaded(Service) end,
-        ejabberd_config:get_local_option_or_default(services, [])
+        fun({Service, Opts}) -> mongoose_service:ensure_loaded(Service, Opts) end,
+        Services
     ).
 
 -spec stop_services() -> ok.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -71,6 +71,7 @@ start(normal, _Args) ->
     mongoose_cluster_id:start(),
     start_services(),
     start_modules(),
+    service_mongoose_system_metrics:verify_if_configured(),
     mongoose_metrics:init(),
     ejabberd_listener:start_listeners(),
     ejabberd_admin:start(),
@@ -153,18 +154,8 @@ stop_modules() ->
 start_services() ->
     lists:foreach(
         fun({Service, Opts}) -> mongoose_service:ensure_loaded(Service, Opts) end,
-        services_with_maybe_metrics()
+        ejabberd_config:get_local_option_or_default(services, [])
     ).
-
--spec services_with_maybe_metrics() -> [term()].
-services_with_maybe_metrics() ->
-    Services = ejabberd_config:get_local_option_or_default(services, []),
-    case proplists:is_defined(service_mongoose_system_metrics, Services) of
-        false ->
-            [{service_mongoose_system_metrics, [removed_from_config]} | Services];
-        true ->
-            Services
-    end.
 
 -spec stop_services() -> ok.
 stop_services() ->

--- a/src/mongoose_service.erl
+++ b/src/mongoose_service.erl
@@ -24,6 +24,7 @@
          is_loaded/1,
          assert_loaded/1,
          ensure_loaded/1,
+         ensure_loaded/2,
          purge_service/1,
          get_service_opts/1,
          loaded_services_with_opts/0
@@ -71,14 +72,14 @@ stop_service(Service) ->
 
 -spec ensure_loaded(service()) -> ok.
 ensure_loaded(Service) ->
-    case is_loaded(Service) of
-        true ->
-            ok;
-        false ->
-            Options = ejabberd_config:get_local_option_or_default(services, []),
-            start_service(Service, proplists:get_value(Service, Options)),
-            ok
-    end.
+    Options = ejabberd_config:get_local_option_or_default(services, []),
+    start_service(Service, proplists:get_value(Service, Options)),
+    ok.
+
+-spec ensure_loaded(service(), options()) -> ok.
+ensure_loaded(Service, Opts) ->
+    start_service(Service, Opts),
+    ok.
 
 -spec assert_loaded(service()) -> ok.
 assert_loaded(Service) ->


### PR DESCRIPTION
This is basically what we want to tell the user:
```
    enabled                         | printout | reporting
------------------------------------+----------+-----------
[x] removed from config             |  true    |   false   -> we print "are you sure you don't want to report anything? :("
[x] in config, explicit no_report   |  false   |   false
[x] just in config                  |  true    |   true    -> we print "Do you agree that we're reporting stuff" (for transparency)
[x] in config, explicit report      |  false   |   true
```

I'm only missing now more detailed messages to tell to the user, you can find them in the macros on the source code in `src/system_metrics/service_mongoose_system_metrics.erl`

PS: big thanks to @fenek for that amazing `lager_ct_backend`, I would never know how to test log messages otherwise 😄 