### PR TITLE
Fix deb package logic

### DIFF
--- a/tools/pkg/platforms/debian_stretch/files/build/debian/postinst
+++ b/tools/pkg/platforms/debian_stretch/files/build/debian/postinst
@@ -18,15 +18,15 @@ set -e
 # the debian-policy package
 
 NAME="mongooseim"
-PKG_ROOT="/usr/lib/${NAME}/"
+PKG_ROOT="/usr/lib/${NAME}"
 
 MIM_CTL="/usr/bin/mongooseimctl"
 
-ETC_DIR="/etc/${NAME}/"
+ETC_DIR="/etc/${NAME}"
 
-VAR_LIB="/var/lib/${NAME}/"
-VAR_LOCK="/var/lock/${NAME}/"
-VAR_LOG="/var/log/${NAME}/"
+VAR_LIB="/var/lib/${NAME}"
+VAR_LOCK="/var/lock/${NAME}"
+VAR_LOG="/var/log/${NAME}"
 
 . /usr/share/debconf/confmodule
 

--- a/tools/pkg/platforms/debian_stretch/files/build/debian/postrm
+++ b/tools/pkg/platforms/debian_stretch/files/build/debian/postrm
@@ -21,10 +21,6 @@ set -e
 
 case "$1" in
     purge)
-	if which deluser >/dev/null ; then
-	    deluser $NAME 2>/dev/null || true
-	    delgroup $NAME 2>/dev/null || true
-	fi
     ;;
 
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/tools/pkg/platforms/debian_stretch/files/build/debian/prerm
+++ b/tools/pkg/platforms/debian_stretch/files/build/debian/prerm
@@ -19,7 +19,6 @@ set -e
 
 case "$1" in
     remove)
-    rm -rf /usr/lib/$NAME/lib/ejabberd-2.1.8+mim-1.3.1/priv/snmp/db/*
     ;;
 
     upgrade|deconfigure)


### PR DESCRIPTION
This PR addresses #1404 and #1405 

Changes include:
* removing trailing slashes in `postinst` script
* removing unnecessary commands in `prerm` and `postrm` scripts


