### PR TITLE
System Metrics - prod node GA Tracking ID

### DIFF
--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -417,11 +417,11 @@ remove_additional_tracking_id(Node) ->
     mongoose_helper:successful_rpc(
         Node, ejabberd_config, del_local_option, [ extra_google_analytics_tracking_id ]).
 
-    remove_service_from_config(Service) ->
-            Services = distributed_helper:rpc(
-                           mim3(),ejabberd_config, get_local_option_or_default, [services, []]),
-            NewServices = proplists:delete(Service, Services),
-            distributed_helper:rpc(mim3(), ejabberd_config, add_local_option, [services, NewServices]).
+remove_service_from_config(Service) ->
+        Services = distributed_helper:rpc(
+                       mim3(),ejabberd_config, get_local_option_or_default, [services, []]),
+        NewServices = proplists:delete(Service, Services),
+        distributed_helper:rpc(mim3(), ejabberd_config, add_local_option, [services, NewServices]).
 
 events_are_reported_to_additional_tracking_id() ->
     Tab = ets:tab2list(?ETS_TABLE),

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -8,7 +8,7 @@
 -define(ETS_TABLE, qs).
 -define(TRACKING_ID, "UA-151671255-2").
 -define(TRACKING_ID_CI, "UA-151671255-1").
--define(TRACKING_ID_EXTRA, "UA-151671255-3").
+-define(TRACKING_ID_EXTRA, "UA-EXTRA-TRACKING-ID").
 
 -record(event, {
     cid = "",

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -419,7 +419,7 @@ remove_additional_tracking_id(Node) ->
 
 remove_service_from_config(Service) ->
         Services = distributed_helper:rpc(
-                       mim3(),ejabberd_config, get_local_option_or_default, [services, []]),
+                       mim3(), ejabberd_config, get_local_option_or_default, [services, []]),
         NewServices = proplists:delete(Service, Services),
         distributed_helper:rpc(mim3(), ejabberd_config, add_local_option, [services, NewServices]).
 

--- a/rebar.config
+++ b/rebar.config
@@ -127,7 +127,8 @@
 
 {profiles, [ {prod,    [{relx, [ {dev_mode, false},
                                  {overlay_vars, "rel/vars.config"},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
+                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]},
+                                 {erl_opts, [{d, 'PROD_NODE'}]} ]},
              %% development nodes
              {mim1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim1.vars.config"]},
                                  {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -640,8 +640,9 @@
 {services,
     [
         {service_admin_extra, [{submods, [node, accounts, sessions, vcard, gdpr,
-                                          roster, last, private, stanza, stats]}]}
-        {{{service_mongoose_system_metrics}}}
+                                          roster, last, private, stanza, stats]}]},
+        {service_mongoose_system_metrics, [{initial_report, 300000},
+                                           {periodic_report, 10800000}]}
     ]
 }.
 

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -29,10 +29,6 @@
 {auth_ldap,""}.
 {s2s_addr, "{ {s2s_addr, \"fed1\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
-{service_mongoose_system_metrics, % , before the service as it will be added at the end of a tuple
-    ",{service_mongoose_system_metrics,\n"
-    "          [{initial_report, 60000},\n"
-    "           {periodic_report, 10800000}]}"}. % initial report after 1 minute, periodic every 3 hours
 % Disable highload args to save memory for dev builds
 {highload_vm_args, ""}.
 {secondary_c2s,

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -21,10 +21,6 @@
 {auth_method, "internal"}.
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
-{service_mongoose_system_metrics, % , before the service as it will be added at the end of a tuple
-    ",{service_mongoose_system_metrics,\n"
-    "          [{initial_report, 60000},\n"
-    "           {periodic_report, 10800000}]}"}. % initial report after 1 minute, periodic every 3 hours
 {highload_vm_args, ""}.
 {mod_last, "{mod_last, []},"}.
 {mod_privacy, "{mod_privacy, []},"}.

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -18,11 +18,6 @@
 {auth_method, "internal"}.
 {s2s_addr, "{ {s2s_addr, \"localhost2\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
-% Removed to test that metrics are not gathered for this one
-% {service_mongoose_system_metrics, % , before the service as it will be added at the end of a tuple
-%     ",{service_mongoose_system_metrics,\n"
-%     "          [{initial_report, 60000},\n"
-%     "           {periodic_report, 10800000}]}"}. % initial report after 1 minute, periodic every 3 hours
 {highload_vm_args, ""}.
 {ejabberd_service, ""}.
 {mod_last, "{mod_last, []},"}.

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -6,7 +6,11 @@
 
 -define(DEFAULT_INITIAL_REPORT, timer:minutes(5)).
 -define(DEFAULT_REPORT_AFTER, timer:hours(3)).
+-ifdef(PROD_NODE).
+-define(TRACKING_ID, "UA-151671255-3").
+-else.
 -define(TRACKING_ID, "UA-151671255-2").
+-endif.
 -define(TRACKING_ID_CI, "UA-151671255-1").
 
 -include("mongoose.hrl").


### PR DESCRIPTION
This PR:
* enables system metrics service by default on all nodes
* new GA Tracking ID is added for prod nodes
* metrics tests refactoring

