### PR TITLE
Install pid and status directories explicitly

### DIFF
--- a/doc/user-guide/release_config.md
+++ b/doc/user-guide/release_config.md
@@ -88,11 +88,15 @@ export LIB_DIR="$PREFIX/usr/lib/mongooseim"
 export LOG_DIR="$PREFIX/var/log/mongooseim"
 export MDB_DIR="$PREFIX/var/lib/mongooseim"
 export LOCK_DIR="$PREFIX/var/lock/mongooseim"
+export PID_DIR="$PREFIX/var/lib/mongooseim"
+export STATUS_DIR="$PREFIX/var/lib/mongooseim"
 {mongooseim_runner_user, "erszcz"}.
 {mongooseim_script_dir, "/tmp/mim-sandbox-system/usr/lib/mongooseim/bin"}.
 {mongooseim_etc_dir, "/tmp/mim-sandbox-system/etc/mongooseim"}.
 {mongooseim_log_dir, "/tmp/mim-sandbox-system/var/log/mongooseim"}.
 {mongooseim_mdb_dir, "/tmp/mim-sandbox-system/var/lib/mongooseim"}.
+{mongooseim_pid_dir, "/tmp/mim-sandbox-system/var/lib/mongooseim"}.
+{mongooseim_status_dir, "/tmp/mim-sandbox-system/var/lib/mongooseim"}.
 {mongooseim_mdb_dir_toggle, []}.
 {mongooseim_lock_dir, "/tmp/mim-sandbox-system/var/lock/mongooseim"}.
 ```
@@ -140,6 +144,8 @@ var/lib/mongooseim/roster_version.DCD
 var/lib/mongooseim/schema.DAT
 var/lib/mongooseim/vcard.DAT
 var/lib/mongooseim/vcard_search.DCD
+var/lib/mongooseim/pid
+var/lib/mongooseim/status
 var/log/mongooseim/crash.log
 var/log/mongooseim/ejabberd.log
 var/log/mongooseim/erlang.log.1

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -11,10 +11,10 @@ RUNNER_LOG_DIR="{{mongooseim_log_dir}}"
 PIPE_DIR=/tmp/mongooseim_pipe_`whoami`/
 RUNNER_USER={{mongooseim_runner_user}}
 
-EJABBERD_PID_PATH="${EJABBERD_PID_PATH:-$RUNNER_BASE_DIR/var/pid}"
+EJABBERD_PID_PATH="{{mongooseim_pid_dir}}/pid"
 export EJABBERD_PID_PATH="$EJABBERD_PID_PATH"
 
-EJABBERD_STATUS_PATH="${EJABBERD_STATUS_PATH:-$RUNNER_BASE_DIR/var/status}"
+EJABBERD_STATUS_PATH="{{mongooseim_status_dir}}/status"
 export EJABBERD_STATUS_PATH="$EJABBERD_STATUS_PATH"
 
 EJABBERD_SO_PATH=`ls -dt "$RUNNER_BASE_DIR"/lib/mongooseim-*/priv/lib | head -1`

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -20,7 +20,7 @@ ERL="$ERTS_PATH"/erl
 EPMD="$ERTS_PATH"/epmd
 EJABBERD_EBIN_PATH="$EJABBERD_DIR"/lib/mongooseim-*/ebin/
 
-EJABBERD_STATUS_PATH="${EJABBERD_STATUS_PATH:-$RUNNER_BASE_DIR/var/status}"
+EJABBERD_STATUS_PATH="{{mongooseim_status_dir}}/status"
 export EJABBERD_STATUS_PATH="$EJABBERD_STATUS_PATH"
 
 COOKIE_ARG=`grep -e '^-setcookie' "$EJABBERD_VMARGS_PATH"`

--- a/tools/configure
+++ b/tools/configure
@@ -19,6 +19,8 @@
                mdb_dir          = "$RUNNER_BASE_DIR/Mnesia.$NODE",
                mdb_dir_toggle   = "%",
                lock_dir         = "$EJABBERD_DIR/var/lock",
+               pid_dir          = "$RUNNER_BASE_DIR/var",
+               status_dir       = "$RUNNER_BASE_DIR/var",
                nodetool_etc_dir = "etc",
                % nksip writes an erlang module file, which is used as a cache.
                % By default it uses "log" directory, and we want to change it.
@@ -99,6 +101,8 @@ system_install(Opts) ->
               etc_dir           = "$PREFIX/etc/mongooseim",
               lib_dir           = "$PREFIX/usr/lib/mongooseim",
               log_dir           = "$PREFIX/var/log/mongooseim",
+              pid_dir           = "$PREFIX/var/lib/mongooseim",
+              status_dir        = "$PREFIX/var/lib/mongooseim",
               mdb_dir           = "$PREFIX/var/lib/mongooseim",
               mdb_dir_toggle    = "",
               lock_dir          = "$PREFIX/var/lock/mongooseim",
@@ -163,6 +167,8 @@ write(shell, FileName, Opts) ->
              [sh_var("ETC_DIR", [Opts#opts.etc_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("LIB_DIR", [Opts#opts.lib_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("LOG_DIR", [Opts#opts.log_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("PID_DIR", [Opts#opts.pid_dir]) || Opts#opts.system == "yes"] ++
+             [sh_var("STATUS_DIR", [Opts#opts.status_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("MDB_DIR", [Opts#opts.mdb_dir]) || Opts#opts.system == "yes"] ++
              [sh_var("LOCK_DIR", [Opts#opts.lock_dir]) || Opts#opts.system == "yes"] ),
     file:write_file(FileName, Data);
@@ -175,6 +181,8 @@ write(reltool, FileName, Opts) ->
             rt_var(mongooseim_mdb_dir, Opts#opts.mdb_dir),
             rt_var(mongooseim_mdb_dir_toggle, Opts#opts.mdb_dir_toggle),
             rt_var(mongooseim_lock_dir, Opts#opts.lock_dir),
+            rt_var(mongooseim_pid_dir, Opts#opts.pid_dir),
+            rt_var(mongooseim_status_dir, Opts#opts.status_dir),
             rt_var(mongooseim_nodetool_etc_dir, Opts#opts.nodetool_etc_dir),
             rt_var(nksip_cache_dir, Opts#opts.nksip_cache_dir)],
     file:write_file(FileName, Data).
@@ -189,6 +197,8 @@ expand_prefix(Opts) ->
                               #opts.log_dir,
                               #opts.mdb_dir,
                               #opts.lock_dir,
+                              #opts.pid_dir,
+                              #opts.status_dir,
                               #opts.nodetool_etc_dir,
                               #opts.nksip_cache_dir]),
     NOpts.

--- a/tools/install
+++ b/tools/install
@@ -51,6 +51,8 @@ chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${LIB_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${LOG_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${MDB_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${LOCK_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${PID_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${STATUS_DIR}
 
 ## Do the bookkeeping.
 ## TODO: How to automate this? If done manually, there's always space for a cock-up.
@@ -71,6 +73,8 @@ find ${LIB_DIR} >> $LOG
 [ x"$SYSTEM" == x"yes" ] && log ${LOG_DIR}
 [ x"$SYSTEM" == x"yes" ] && log ${MDB_DIR}
 [ x"$SYSTEM" == x"yes" ] && log ${LOCK_DIR}
+[ x"$SYSTEM" == x"yes" ] && log ${PID_DIR}
+[ x"$SYSTEM" == x"yes" ] && log ${STATUS_DIR}
 
 ## Voila!
 echo MongooseIM successfully installed to ${LIB_DIR} >&2


### PR DESCRIPTION
This PR allows configure to set directories for `pid` and `status` files. Their default location for system install is now set to `/var/lib/mongooseim`.