### PR TITLE
Fix user send packet hook from mod commands

### DIFF
--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -655,7 +655,7 @@
 %%
 {modules,
  [
-
+  {{{mod_mongoose_hooks_sanity_check}}}
   %% The format for a single route is as follows:
   %% {Host, Path, Method, Upstream}
   %%

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -39,6 +39,7 @@
         {max_stanza_size, 65536}
     ]},"}.
 {mod_amp, "{mod_amp, []},"}.
+{mod_mongoose_hooks_sanity_check, "{mod_mongoose_hooks_sanity_check, []},"}.
 {ejabberd_service, ",{ {{ service_port }}, ejabberd_service, [\n"
                  "                {access, all},\n"
                  "                {shaper_rule, fast},\n"

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -24,6 +24,7 @@
 % But it increases memory usage.
 {highload_vm_args, "+P 10000000 -env ERL_MAX_PORTS 250000"}.
 {mod_amp, ""}.
+{mod_mongoose_hooks_sanity_check, ""}.
 {ejabberd_service, ",{8888, ejabberd_service, [\n"
                  "                {access, all},\n"
                  "                {shaper_rule, fast},\n"

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -264,9 +264,14 @@ send_message(From, To, Body) ->
     Packet = build_packet(message_chat, Body),
     F = jid:from_binary(From),
     T = jid:from_binary(To),
-    ejabberd_hooks:run(user_send_packet,
-                       F#jid.lserver,
-                       [F, T, Packet]),
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => F#jid.lserver,
+                              element => Packet,
+                              from_jid => F,
+                              to_jid => T }),
+    ejabberd_hooks:run_fold(user_send_packet,
+                            F#jid.lserver, Acc,
+                            [F, T, Packet]),
     %% privacy check is missing, but is it needed?
     ejabberd_router:route(F, T, Packet),
     ok.

--- a/src/mod_mongoose_hooks_sanity_check.erl
+++ b/src/mod_mongoose_hooks_sanity_check.erl
@@ -1,0 +1,87 @@
+-module(mod_mongoose_hooks_sanity_check).
+
+-behaviour(gen_mod).
+-behaviour(mongoose_module_metrics).
+
+-include("mongoose_logger.hrl").
+-include("jid.hrl").
+-include("jlib.hrl").
+
+-export([start/2]).
+-export([stop/1]).
+
+-export([user_send_packet_in/4]).
+-export([user_send_packet_out/4]).
+
+-spec start(Host :: jid:server(), Opts :: list()) -> ok.
+start(Host, _) ->
+    ejabberd_hooks:add(hooks(Host)),
+    ok.
+
+-spec stop(Host :: jid:server()) -> ok.
+stop(Host) ->
+    ejabberd_hooks:delete(hooks(Host)),
+    ok.
+
+hooks(Host) ->
+    [
+     {user_send_packet, Host, ?MODULE, user_send_packet_in, 0}, %% I want it to be called first
+     {user_send_packet, Host, ?MODULE, user_send_packet_out, 1000} %% I want it to be called last
+    ].
+
+
+-spec user_send_packet_in(Acc :: mongoose_acc:t(), From :: jid:jid(),
+                          To :: jid:jid(),
+                          Packet :: exml:element()) -> map().
+user_send_packet_in(Acc, From, To, Packet) ->
+    Checks = [{fun is_acc/4, "Acc", Acc},
+              {fun is_full_jid/4, "From", From},
+              {fun is_full_jid/4, "To", To},
+              {fun is_exml_element/4, "Packet", Packet}],
+    verify_hook(user_send_packet, in, Checks, Acc).
+
+-spec user_send_packet_out(Acc :: mongoose_acc:t(), From :: jid:jid(),
+                           To :: jid:jid(),
+                           Packet :: exml:element()) -> map().
+user_send_packet_out(Acc, _From, _To, _Packet) ->
+    verify_hook(user_send_packet, in, [{fun is_acc/4, "Acc", Acc}], Acc).
+
+verify_hook(HookName, Direction, Checks, RetVal) ->
+    case run_verifications(HookName, Direction, Checks, []) of
+        [] ->
+            RetVal;
+        Results ->
+            ?ERROR_MSG("event=hook_verification_failed, hook=~p, dir=~p, fail_ci_build=true, results=~p",
+                       [HookName, Direction, Results]),
+            stop
+    end.
+
+run_verifications(_, _, [], Result) ->
+    Result;
+run_verifications(HookName, Direction, [{Fun, ArgName, Arg} | Rest], Result) ->
+    case Fun(HookName, Direction, ArgName, Arg) of
+        true -> run_verifications(HookName, Direction, Rest, Result);
+        Other -> run_verifications(HookName, Direction, Rest, [Other | Result])
+    end.
+
+is_acc(_HookName, _Dir, _AccName, #{mongoose_acc := true}) ->
+    true;
+is_acc(HookName, Dir, AccName, Acc) ->
+    ?ERROR_MSG("event=hook_verification_failed, hook=~p, dir=~p, arg=~s, reason=not_an_acc, arg_value=~p",
+               [HookName, Dir, AccName, Acc]),
+    {not_a_map, AccName, Acc}.
+
+is_full_jid(_HookName, _Direction, _ArgName, #jid{}) ->
+    true;
+is_full_jid(HookName, Direction, ArgName, ArgValue) ->
+    ?ERROR_MSG("event=hook_verification_failed, hook=~p, dir=~p, arg=~s, reason=not_a_jid, arg_value=~p",
+               [HookName, Direction, ArgName, ArgValue]),
+    {not_a_jid, ArgName, ArgValue}.
+
+is_exml_element(_HookName, _Direction, _ArgName, #xmlel{}) ->
+    true;
+is_exml_element(HookName, Direction, ArgName, ArgValue) ->
+    ?ERROR_MSG("event=hook_verification_failed, hook=~p, dir=~p, arg=~s, reason=not_a_xml_element, arg_value=~p",
+               [HookName, Direction, ArgName, ArgValue]),
+    {not_a_xml_element, ArgName, ArgValue}.
+


### PR DESCRIPTION
It's not possible to have a static analysation of hooks execution.
Tests does not always check if a hook was executed and finished with expected arguments.
I thought it'd be worth to add a module (enabled only on dev nodes) checking the hook arguments before any other hook is run and after all hooks.
Our code not always check the return value of a hook run, that's why I had to add the log message with `fail_ci_build=true` in order to mark the whole build as failed. These log messages are printed on CIs.

This PR introduces only verification of `user_send_packet` hook.

Also this PR fixes `user_send_packet` hook run from mod_commands as discovered by @jasl in #2590 

