### PR TITLE
jid reload

### DIFF
--- a/c_src/jid.cpp
+++ b/c_src/jid.cpp
@@ -142,4 +142,8 @@ static ErlNifFunc jid_nif_funcs[] = {
     {"from_binary_nif", 1, from_binary_nif}
 };
 
-ERL_NIF_INIT(jid, jid_nif_funcs, NULL, NULL, NULL, NULL);
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info) {
+    return 0;
+};
+
+ERL_NIF_INIT(jid, jid_nif_funcs, NULL, NULL, upgrade, NULL);


### PR DESCRIPTION
BEAM requires some `upgrade` function in the nifs definition in order to be able to reload the module. This is just a stub that does nothing, as this module is stateless, but it is required if we want to do a `l(jid)` on the shell 🤷‍♂ 