### PR TITLE
Test mongooseimctl after package installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# big_tests directory
+big_tests
+# everything inside _builde
+_build/*
+#except of _build/default so that we don't fetch deps when they are fetched
+!_build/default
+# no .so files (C code copilation artifacts)
+**/*.so
+# no .o files (C code copilation artifacts)
+**/*.o
+# no beam files
+**/*.beam
+#no erlcinfo files (in order to have cleaner logs when compiling in the container)
+**/erlcinfo

--- a/tools/pkg/Dockerfile_deb
+++ b/tools/pkg/Dockerfile_deb
@@ -34,7 +34,7 @@ RUN ./deb/build_package.sh $version $revision
 FROM $dockerfile_platform
 
 # Copy built package from previous image and install it with required dependencies
-RUN apt-get update && apt-get -y install openssl netcat && apt-get -y clean
+RUN apt-get update && apt-get -y install openssl procps netcat && apt-get -y clean
 WORKDIR /root/
 COPY --from=builder /root/*.deb .
 
@@ -43,9 +43,9 @@ RUN apt-get update; dpkg -i *.deb; apt-get install -y -f
 
 # Simple check if MiM works
 COPY --from=builder /root/mongooseim/tools/wait-for-it.sh .
-RUN mongooseimctl start && \
-    ./wait-for-it.sh -h localhost -p 5222 -t 60 && \
-    mongooseimctl stop
+COPY --from=builder /root/mongooseim/tools/pkg/scripts/smoke_test.sh .
+
+RUN ./smoke_test.sh
 
 RUN mkdir /built_packages
 CMD mv /root/mongooseim*.deb /built_packages

--- a/tools/pkg/Dockerfile_deb
+++ b/tools/pkg/Dockerfile_deb
@@ -18,9 +18,10 @@ RUN apt-get install -y esl-erlang=1:$erlang_version
 RUN locale-gen en_US.UTF-8
 
 # Copy source code and put building files
+# The .dockerignore file in root dir ensures only needed files
+# including not commited changes are used to build the package
 WORKDIR /root/
 COPY . ./mongooseim
-RUN rm -rf ./mongooseim/_build
 
 RUN cp -r ./mongooseim/tools/pkg/scripts/deb .
 

--- a/tools/pkg/Dockerfile_rpm
+++ b/tools/pkg/Dockerfile_rpm
@@ -44,9 +44,9 @@ RUN yum -y update; yum install -y mongooseim*.rpm
 
 # Simple check if MiM works
 COPY --from=builder /root/rpmbuild/BUILD/mongooseim/tools/wait-for-it.sh .
-RUN mongooseimctl start && \
-    ./wait-for-it.sh -h localhost -p 5222 -t 60 && \
-    mongooseimctl stop
+COPY --from=builder /root/rpmbuild/BUILD/mongooseim/tools/pkg/scripts/smoke_test.sh .
+
+RUN ./smoke_test.sh
 
 RUN mkdir /built_packages
 CMD mv /root/mongooseim*.rpm /built_packages

--- a/tools/pkg/Dockerfile_rpm
+++ b/tools/pkg/Dockerfile_rpm
@@ -19,10 +19,12 @@ RUN curl -O https://packages.erlang-solutions.com/erlang-solutions-2.0-1.noarch.
 
 # Copy source code and put building files in proper directories according to
 # defaults of `rpmdev-setuptree` and `rpmbuild` commands
+# The .dockerignore file in root dir ensures only needed files
+# including not commited changes are used to build the package
 RUN rpmdev-setuptree
 WORKDIR /root/rpmbuild
 COPY . ./BUILD/mongooseim
-RUN rm -rf ./BUILD/mongooseim/_build
+
 RUN cp ./BUILD/mongooseim/tools/pkg/scripts/rpm/mongooseim.spec ./SPECS/.
 RUN cp ./BUILD/mongooseim/tools/pkg/scripts/rpm/mongooseim.service \
        ./SOURCES/mongooseim.service

--- a/tools/pkg/scripts/smoke_test.sh
+++ b/tools/pkg/scripts/smoke_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Use bash "strict mode"
+# Based on http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -eu pipefail
+IFS=$'\n\t'
+
+echo "Starting mongooseim via 'mongooseimctl start'"
+mongooseimctl start
+
+echo "Waiting for the port 5222 to accept TCP connections"
+./wait-for-it.sh -h localhost -p 5222 -t 60
+
+echo "Checking status via 'mongooseimctl status'"
+mongooseimctl status
+
+echo "Trying to register a user with 'mongooseimctl register localhost a_password'"
+mongooseimctl register localhost a_password
+
+echo "Trying to register a user with 'mongooseimctl register_identified user localhost a_password_2'"
+mongooseimctl register_identified user localhost a_password_2
+
+echo "Checking if 2 users are registered on host 'localhost'"
+expected=2
+registered=$(mongooseimctl registered_users localhost | wc -l)
+if [ ${registered} -ne ${expected} ]; then
+    echo "registered value is ${registered} but expected ${expected}"
+    exit 1
+fi
+
+echo "Stopping mongooseim via 'mongooseimctl stop'"
+mongooseimctl stop
+


### PR DESCRIPTION
A bug related to `mongooseimctl` script was fixed in #2631. This PR adds tests in order extend .deb and .rpm package verification and to catch similar bugs in the future.

