### PR TITLE
Fix pgsql docker container setup

### DIFF
--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -143,6 +143,7 @@ elif [ "$db" = 'pgsql' ]; then
     cp ${MIM_PRIV_DIR}/pg.sql ${SQL_TEMP_DIR}/.
     docker run -d \
            -e SQL_TEMP_DIR=/tmp/sql \
+           -e POSTGRES_PASSWORD=password \
            $(mount_ro_volume ${SQL_TEMP_DIR} /tmp/sql) \
            $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/postgresql/data) \
            $(mount_ro_volume ${TOOLS}/docker-setup-postgres.sh /docker-entrypoint-initdb.d/docker-setup-postgres.sh) \


### PR DESCRIPTION
This PR fixes pgsql docker container setup by specifying main `POSTGRES_PASSWORD` via env while starting the container with `docker run`
