### PR TITLE
Change ejabberd_sm hooks to use mongoose_hooks

### DIFF
--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -153,10 +153,10 @@ remove_connection(SID, LUser, LServer) ->
 
 
 %% @doc Register connection
--spec register_connection(Acc :: map(),
+-spec register_connection(Acc,
                           SID :: ejabberd_sm:sid(),
                           JID :: jid:jid(),
-                          Info :: list()) -> map().
+                          Info :: list()) -> Acc when Acc :: any().
 register_connection(Acc, SID, #jid{luser = LUser, lserver = LServer}, Info) ->
     case lists:keyfind(auth_module, 1, Info) of
         {_, ?MODULE} ->

--- a/src/global_distrib/mod_global_distrib_mapping.erl
+++ b/src/global_distrib/mod_global_distrib_mapping.erl
@@ -163,8 +163,8 @@ deps(Host, Opts) ->
 %% Hooks implementation
 %%--------------------------------------------------------------------
 
--spec session_opened(mongoose_acc:t(), ejabberd_sm:sid(), UserJID :: jid:jid(), Info :: list()) ->
-    mongoose_acc:t().
+-spec session_opened(Acc, ejabberd_sm:sid(), UserJID :: jid:jid(), Info :: list()) ->
+    Acc when Acc :: any().
 session_opened(Acc, _SID, UserJid, _Info) ->
     insert_for_jid(UserJid),
     Acc.

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -59,7 +59,7 @@ run_initial_check(Acc, _C2SState) ->
 
 
 -spec check_packet(mongoose_acc:t() | exml:element(), amp_event()) ->
-    mongoose_acc:t() | exml:element() | drop.
+    mongoose_acc:t() | exml:element().
 check_packet(Packet = #xmlel{attrs = Attrs}, Event) ->
     % it is called this way only from ejabberd_c2s:send_and_maybe_buffer_stanza/3, line 1666
     % maybe Paweł Chrząszcz knows why and can advise what to do about it
@@ -73,7 +73,7 @@ check_packet(Acc, Event) ->
     check_packet(Acc, mongoose_acc:from_jid(Acc), Event).
 
 -spec check_packet(exml:element()|mongoose_acc:t(), jid:jid(), amp_event()) ->
-    exml:element() | mongoose_acc:t() | drop.
+    exml:element() | mongoose_acc:t().
 check_packet(Packet = #xmlel{name = <<"message">>}, From, Event) ->
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => From#jid.lserver,

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -204,6 +204,9 @@ iq_ping(_From, _To, Acc, #iq{type = get, sub_el = #xmlel{ name = <<"ping">> }} =
 iq_ping(_From, _To, Acc, #iq{sub_el = SubEl} = IQ) ->
     {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:feature_not_implemented()]}}.
 
+-spec user_online(Acc, _SID, JID, _Info) -> Acc when
+                  Acc :: any(),
+                  JID :: jid:jid().
 user_online(Acc, _SID, JID, _Info) ->
     start_ping(JID#jid.lserver, JID),
     Acc.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1,6 +1,56 @@
 -module(mongoose_hooks).
 
--export([privacy_check_packet/6]).
+-export([failed_to_store_message/4,
+         offline_groupchat_message_hook/5,
+         offline_message_hook/5,
+         privacy_check_packet/6,
+         privacy_get_user_list/3,
+         roster_in_subscription/7,
+         set_presence_hook/5,
+         sm_broadcast/6,
+         sm_filter_offline_message/5,
+         sm_register_connection_hook/4,
+         sm_remove_connection_hook/6,
+         unset_presence_hook/5,
+         xmpp_bounce_message/2]).
+
+-spec failed_to_store_message(LServer, Acc, From, Packet) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: mongoose_acc:t().
+failed_to_store_message(LServer, Acc, From, Packet) ->
+    ejabberd_hooks:run_fold(failed_to_store_message,
+                            LServer,
+                            Acc,
+                            [From, Packet]).
+
+-spec offline_groupchat_message_hook(LServer, Acc, From, To, Packet) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: map(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: map().
+offline_groupchat_message_hook(LServer, Acc, From, To, Packet) ->
+    ejabberd_hooks:run_fold(offline_groupchat_message_hook,
+                            LServer,
+                            Acc,
+                            [From, To, Packet]).
+
+-spec offline_message_hook(LServer, Acc, From, To, Packet) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: map(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: map().
+    offline_message_hook(LServer, Acc, From, To, Packet) ->
+    ejabberd_hooks:run_fold(offline_message_hook,
+                            LServer,
+                            Acc,
+                            [From, To, Packet]).
 
 -spec privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) -> Result when
       LServer :: jid:lserver(), Acc :: mongoose_acc:t(), User :: jid:luser(),
@@ -17,3 +67,98 @@ privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) ->
                              PrivacyList,
                              FromToNameType,
                              Dir]).
+
+-spec privacy_get_user_list(Server, UserList, User) -> Result when
+    Server :: jid:server(),
+    UserList :: mongoose_privacy:userlist(),
+    User :: jid:user(),
+    Result :: mongoose_privacy:userlist().
+privacy_get_user_list(Server, UserList, User) ->
+    ejabberd_hooks:run_fold(privacy_get_user_list, Server,
+                                          UserList, [User, Server]).
+
+-spec roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    User :: jid:user(),
+    Server :: jid:server(),
+    From :: jid:jid(),
+    Type :: mod_roster:sub_presence(),
+    Reason :: any(),
+    Result :: mongoose_acc:t().
+roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) ->
+    ejabberd_hooks:run_fold(
+        roster_in_subscription,
+        LServer,
+        Acc,
+        [User, Server, From, Type, Reason]).
+
+-spec set_presence_hook(LServer, Acc, LUser, LResource, Presence) -> Result when
+    LServer :: jid:lserver(), Acc :: mongoose_acc:t(), LUser :: jid:luser(),
+    LResource :: jid:lresource(),
+    Presence :: any(),
+    Result :: mongoose_acc:t().
+set_presence_hook(LServer, Acc, LUser, LResource, Presence) ->
+    ejabberd_hooks:run_fold(set_presence_hook, LServer, Acc, [LUser, LServer, LResource, Presence]).
+
+-spec sm_broadcast(LServer, Acc, From, To, Broadcast, SessionCount) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Broadcast :: ejabberd_c2s:broadcast(),
+    SessionCount :: non_neg_integer(),
+    Result :: mongoose_acc:t().
+sm_broadcast(LServer, Acc, From, To, Broadcast, SessionCount) ->
+    ejabberd_hooks:run_fold(sm_broadcast, LServer, Acc,
+                            [From, To, Broadcast, SessionCount]).
+
+-spec sm_filter_offline_message(LServer, Drop, From, To, Packet) -> Result when
+    LServer :: jid:lserver(),
+    Drop :: boolean(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: boolean().
+sm_filter_offline_message(LServer, Drop, From, To, Packet) ->
+    ejabberd_hooks:run_fold(sm_filter_offline_message, LServer,
+                            Drop, [From, To, Packet]).
+
+-spec sm_register_connection_hook(LServer, SID, JID, Info) -> Result when
+    LServer :: jid:lserver(),
+    SID :: 'undefined' | ejabberd_sm:sid(),
+    JID :: jid:jid(),
+    Info :: ejabberd_sm:info(),
+    Result :: ok.
+    sm_register_connection_hook(LServer, SID, JID, Info) ->
+    ejabberd_hooks:run_fold(sm_register_connection_hook, LServer, ok,
+                       [SID, JID, Info]).
+
+-spec sm_remove_connection_hook(LServer, Acc, SID, JID, Info, Reason) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    SID :: 'undefined' | ejabberd_sm:sid(),
+    JID :: jid:jid(),
+    Info :: ejabberd_sm:info(),
+    Reason :: ejabberd_sm:close_reason(),
+    Result :: mongoose_acc:t().
+sm_remove_connection_hook(LServer, Acc, SID, JID, Info, Reason) ->
+    ejabberd_hooks:run_fold(sm_remove_connection_hook, LServer, Acc,
+                            [SID, JID, Info, Reason]).
+-spec unset_presence_hook(LServer, Acc, LUser, LResource, Status) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    LUser :: jid:luser(),
+    LResource :: jid:lresource(),
+    Status :: binary(),
+    Result :: mongoose_acc:t().
+unset_presence_hook(LServer, Acc, LUser, LResource, Status) ->
+    ejabberd_hooks:run_fold(unset_presence_hook, LServer, Acc,
+                            [LUser, LServer, LResource, Status]).
+
+-spec xmpp_bounce_message(Server, Acc) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    Result :: mongoose_acc:t().
+xmpp_bounce_message(Server, Acc) ->
+    ejabberd_hooks:run_fold(xmpp_bounce_message, Server, Acc, []).


### PR DESCRIPTION
This PR makes `ejabberd_sm` use newly written hooks in `mongoose_hooks` module. It also fixes some inconsistencies found in specs for handlers.

