### PR TITLE
Change ejabberd_c2s to use mongoose_hooks

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -343,8 +343,7 @@ stream_start_features_after_auth(#state{server = Server} = S) ->
     fsm_next_state(wait_for_feature_after_auth, S).
 
 maybe_roster_versioning_feature(Server) ->
-    ejabberd_hooks:run_fold(roster_get_versioning_feature,
-                            Server, [], [Server]).
+    mongoose_hooks:roster_get_versioning_feature(Server).
 
 stream_features(FeatureElements) ->
     #xmlel{name = <<"stream:features">>,
@@ -392,7 +391,7 @@ maybe_sasl_mechanisms(#state{server = Server} = S) ->
     end.
 
 hook_enabled_features(Server) ->
-    ejabberd_hooks:run_fold(c2s_stream_features, Server, [], [Server]).
+    mongoose_hooks:c2s_stream_features(Server).
 
 starttls(TLSRequired)
   when TLSRequired =:= required;
@@ -712,8 +711,7 @@ maybe_open_session(Acc, #state{jid = JID} = StateData) ->
         true ->
             do_open_session(Acc, JID, StateData);
         _ ->
-            Acc1 = ejabberd_hooks:run_fold(forbidden_session_hook,
-                               StateData#state.server, Acc, [JID]),
+            Acc1 = mongoose_hooks:forbidden_session_hook(StateData#state.server, Acc, JID),
             ?INFO_MSG("(~w) Forbidden session for ~s",
                       [StateData#state.socket,
                        jid:to_binary(JID)]),
@@ -743,12 +741,12 @@ do_open_session(Acc, JID, StateData) ->
 
 do_open_session_common(Acc, JID, #state{user = U, server = S} = NewStateData0) ->
     change_shaper(NewStateData0, JID),
-    Acc1 = ejabberd_hooks:run_fold(roster_get_subscription_lists, S, Acc, [U, S]),
+    Acc1 = mongoose_hooks:roster_get_subscription_lists(S, Acc, U),
     {Fs, Ts, Pending} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc1),
     LJID = jid:to_lower(jid:to_bare(JID)),
     Fs1 = [LJID | Fs],
     Ts1 = [LJID | Ts],
-    PrivList = ejabberd_hooks:run_fold(privacy_get_user_list, S, #userlist{}, [U, S]),
+    PrivList = mongoose_hooks:privacy_get_user_list(S, #userlist{}, U),
     SID = {erlang:timestamp(), self()},
     Conn = get_conn_type(NewStateData0),
     Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
@@ -823,8 +821,8 @@ session_established({xmlstreamelement, El}, StateData) ->
             % initialise accumulator, fill with data
             El1 = fix_message_from_user(El, StateData#state.lang),
             Acc0 = element_to_origin_accum(El1, StateData),
-            Acc1 = ejabberd_hooks:run_fold(c2s_preprocessing_hook, StateData#state.server,
-                                           Acc0, [NewState]),
+            Acc1 = mongoose_hooks:c2s_preprocessing_hook(StateData#state.server,
+                                           Acc0, NewState),
             case mongoose_acc:get(hook, result, undefined, Acc1) of
                 drop -> fsm_next_state(session_established, NewState);
                 _ -> process_outgoing_stanza(Acc1, NewState)
@@ -861,17 +859,17 @@ process_outgoing_stanza(Acc, StateData) ->
     ToJID = mongoose_acc:to_jid(Acc),
     Element = mongoose_acc:element(Acc),
     NState = process_outgoing_stanza(Acc, ToJID, Element#xmlel.name, StateData),
-    ejabberd_hooks:run(c2s_loop_debug, [{xmlstreamelement, Element}]),
+    mongoose_hooks:c2s_loop_debug({xmlstreamelement, Element}),
     fsm_next_state(session_established, NState).
 
 process_outgoing_stanza(Acc, ToJID, <<"presence">>, StateData) ->
     #jid{ user = User, server = Server, lserver = LServer } = FromJID = mongoose_acc:from_jid(Acc),
-    Res = ejabberd_hooks:run_fold(c2s_update_presence, LServer, Acc, []),
+    Res = mongoose_hooks:c2s_update_presence(LServer, Acc),
     El = mongoose_acc:element(Res),
-    Res1 = ejabberd_hooks:run_fold(user_send_packet,
+    Res1 = mongoose_hooks:user_send_packet(
                                    LServer,
                                    Res,
-                                   [FromJID, ToJID, El]),
+                                   FromJID, ToJID, El),
     {_Acc1, NState} = case ToJID of
                           #jid{user = User,
                                server = Server,
@@ -892,10 +890,10 @@ process_outgoing_stanza(Acc0, ToJID, <<"iq">>, StateData) ->
                          ?NS_BLOCKING ->
                              process_privacy_iq(Acc, ToJID, StateData);
                          _ ->
-                             Acc2 = ejabberd_hooks:run_fold(user_send_packet,
+                             Acc2 = mongoose_hooks:user_send_packet(
                                                             LServer,
                                                             Acc,
-                                                            [FromJID, ToJID, El]),
+                                                            FromJID, ToJID, El),
                              Acc3 = check_privacy_and_route(Acc2, StateData),
                              {Acc3, StateData}
     end,
@@ -904,10 +902,10 @@ process_outgoing_stanza(Acc, ToJID, <<"message">>, StateData) ->
     FromJID = mongoose_acc:from_jid(Acc),
     LServer = mongoose_acc:lserver(Acc),
     El = mongoose_acc:element(Acc),
-    Acc1 = ejabberd_hooks:run_fold(user_send_packet,
+    Acc1 = mongoose_hooks:user_send_packet(
                                    LServer,
                                    Acc,
-                                   [FromJID, ToJID, El]),
+                                   FromJID, ToJID, El),
     _Acc2 = check_privacy_and_route(Acc1, StateData),
     StateData;
 process_outgoing_stanza(_Acc, _ToJID, _Name, StateData) ->
@@ -959,7 +957,7 @@ resume_session(resume, From, SD) ->
 %%----------------------------------------------------------------------
 handle_event(keep_alive_packet, session_established,
              #state{server = Server, jid = JID} = StateData) ->
-    ejabberd_hooks:run(user_sent_keep_alive, Server, [JID]),
+    mongoose_hooks:user_sent_keep_alive(Server, JID),
     fsm_next_state(session_established, StateData);
 handle_event(_Event, StateName, StateData) ->
     fsm_next_state(StateName, StateData).
@@ -1065,15 +1063,12 @@ handle_info({force_update_presence, LUser}, StateName,
             #state{user = LUser, server = LServer} = StateData) ->
     NewStateData =
     case StateData#state.pres_last of
-        #xmlel{name = <<"presence">>} ->
-            PresenceEl = ejabberd_hooks:run_fold(
-                           c2s_update_presence,
+        #xmlel{name = <<"presence">>} = PresEl ->
+            Acc = element_to_origin_accum(PresEl, StateData),
+            mongoose_hooks:c2s_update_presence(
                            LServer,
-                           StateData#state.pres_last,
-                           [LUser, LServer]),
-            StateData2 = StateData#state{pres_last = PresenceEl},
-            Acc = element_to_origin_accum(PresenceEl, StateData),
-            presence_update(Acc, StateData2#state.jid, StateData2),
+                           Acc),
+            {_Acc, StateData2} = presence_update(Acc, StateData#state.jid, StateData),
             StateData2;
         _ ->
             StateData
@@ -1107,18 +1102,18 @@ handle_info(Info, StateName, StateData) ->
 handle_incoming_message({send_text, Text}, StateName, StateData) ->
     % it seems to be sometimes, by event sent from s2s
     send_text(StateData, Text),
-    ejabberd_hooks:run(c2s_loop_debug, [Text]),
+    mongoose_hooks:c2s_loop_debug(Text),
     fsm_next_state(StateName, StateData);
 handle_incoming_message({broadcast, Broadcast}, StateName, StateData) ->
     Acc0 = mongoose_acc:new(#{ location => ?LOCATION,
                                lserver => StateData#state.server,
                                element => undefined }),
-    Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc0, [{broadcast, Broadcast}]),
+    Acc1 = mongoose_hooks:c2s_loop_debug(Acc0, {broadcast, Broadcast}),
     ?DEBUG("event=broadcast,data=~p", [Broadcast]),
     {Acc2, Res} = handle_routed_broadcast(Acc1, Broadcast, StateData),
     handle_broadcast_result(Acc2, Res, StateName, StateData);
 handle_incoming_message({route, From, To, Acc0}, StateName, StateData) ->
-    Acc1 = ejabberd_hooks:run_fold(c2s_loop_debug, Acc0, [{route, From, To}]),
+    Acc1 = mongoose_hooks:c2s_loop_debug(Acc0, {route, From, To}),
     process_incoming_stanza_with_conflict_check(From, To, Acc1, StateName, StateData);
 handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
     % this is used by pubsub and should be rewritten when someone rewrites pubsub module
@@ -1127,9 +1122,8 @@ handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, S
                               to_jid => To,
                               lserver => To#jid.lserver,
                               element => Packet }),
-    Drop = ejabberd_hooks:run_fold(c2s_filter_packet, StateData#state.server,
-        true, [StateData#state.server, StateData,
-            Feature, To, Packet]),
+    Drop = mongoose_hooks:c2s_filter_packet(StateData#state.server, true, StateData,
+                                            Feature, To, Packet),
     case {Drop, StateData#state.jid} of
         {true, _} ->
             ?DEBUG("Dropping packet from ~p to ~p", [jid:to_binary(From), jid:to_binary(To)]),
@@ -1152,9 +1146,9 @@ handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, S
     end;
 handle_incoming_message({broadcast, Type, From, Packet}, StateName, StateData) ->
     %% this version is used only by mod_pubsub, which does things the old way
-    Recipients = ejabberd_hooks:run_fold(
-        c2s_broadcast_recipients, StateData#state.server,
-        [], [StateData#state.server, StateData, Type, From, Packet]),
+    Recipients = mongoose_hooks:c2s_broadcast_recipients(StateData#state.server,
+                                                        [],
+                                                        StateData, Type, From, Packet),
     lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,
         lists:usort(Recipients)),
     fsm_next_state(StateName, StateData);
@@ -1239,10 +1233,10 @@ preprocess_and_ship(Acc, From, To, El, StateData) ->
         jid:to_binary(To),
         Attrs),
     FixedEl = El#xmlel{attrs = Attrs2},
-    Acc2 = ejabberd_hooks:run_fold(user_receive_packet,
+    Acc2 = mongoose_hooks:user_receive_packet(
                                    StateData#state.server,
                                    Acc,
-                                   [StateData#state.jid, From, To, FixedEl]),
+                                   StateData#state.jid, From, To, FixedEl),
     ship_to_local_user(Acc2, {From, To, FixedEl}, StateData).
 
 response_negative(<<"iq">>, forbidden, From, To, Acc) ->
@@ -1341,8 +1335,8 @@ handle_routed_broadcast(Acc, {item, IJID, ISubscription}, StateData) ->
 handle_routed_broadcast(Acc, {exit, Reason}, _StateData) ->
     {Acc, {exit, Reason}};
 handle_routed_broadcast(Acc, {privacy_list, PrivList, PrivListName}, StateData) ->
-    case ejabberd_hooks:run_fold(privacy_updated_list, StateData#state.server,
-                                 false, [StateData#state.privacy_list, PrivList]) of
+    case mongoose_hooks:privacy_updated_list(StateData#state.server,
+                                 false, StateData#state.privacy_list, PrivList) of
         false ->
             {Acc, {new_state, StateData}};
         NewPL ->
@@ -1388,8 +1382,8 @@ privacy_list_push_iq(PrivListName) ->
                              Acc0 :: mongoose_acc:t(), StateData :: state()) -> routing_result().
 handle_routed_presence(From, To, Acc, StateData) ->
     Packet = mongoose_acc:element(Acc),
-    State = ejabberd_hooks:run_fold(c2s_presence_in, StateData#state.server,
-                                    StateData, [{From, To, Packet}]),
+    State = mongoose_hooks:c2s_presence_in(StateData#state.server,
+                                    StateData, From, To, Packet),
     case mongoose_acc:stanza_type(Acc) of
         <<"probe">> ->
             {LFrom, LBFrom} = lowcase_and_bare(From),
@@ -1639,7 +1633,7 @@ send_element_from_server_jid(Acc, StateData, #xmlel{} = El) ->
 %% @doc This is the termination point - from here stanza is sent to the user
 -spec send_element(mongoose_acc:t(), exml:element(), state()) -> mongoose_acc:t().
 send_element(Acc, El, #state{server = Server} = StateData) ->
-    Acc1 = ejabberd_hooks:run_fold(xmpp_send_element, Server, Acc, [El]),
+    Acc1 = mongoose_hooks:xmpp_send_element(Server, Acc, El),
     Res = do_send_element(El, StateData),
     mongoose_acc:set(c2s, send_result, Res, Acc1).
 
@@ -1798,10 +1792,10 @@ check_privacy_and_route_probe(StateData, From, To, Acc, Packet) ->
     case Res of
         allow ->
             Pid = element(2, StateData#state.sid),
-            Acc2 = ejabberd_hooks:run_fold(presence_probe_hook,
+            Acc2 = mongoose_hooks:presence_probe_hook(
                                StateData#state.server,
-                                Acc1,
-                               [From, To, Pid]),
+                               Acc1,
+                               From, To, Pid),
             %% Don't route a presence probe to oneself
             case jid:are_equal(From, To) of
                 false ->
@@ -1941,17 +1935,15 @@ presence_update_to_available(Acc, From, Packet, StateData) ->
                                    Packet :: exml:element(),
                                    StateData :: state()) -> {mongoose_acc:t(), state()}.
 presence_update_to_available(true, Acc, _, NewPriority, From, Packet, StateData) ->
-    Acc2 = ejabberd_hooks:run_fold(user_available_hook,
-                                   StateData#state.server,
-                                   Acc,
-                                   [StateData#state.jid]),
+    Acc2 = mongoose_hooks:user_available_hook(StateData#state.server,
+                                              Acc,
+                                              StateData#state.jid),
     Res = case NewPriority >= 0 of
               true ->
-                  Acc3 = ejabberd_hooks:run_fold(roster_get_subscription_lists,
+                  Acc3 = mongoose_hooks:roster_get_subscription_lists(
                                                  StateData#state.server,
                                                  Acc2,
-                                                 [StateData#state.user,
-                                                 StateData#state.server]),
+                                                 StateData#state.user),
                   {_, _, Pending} = mongoose_acc:get(roster, subscription_lists,
                                                      {[], [], []}, Acc3),
                   Acc4 = resend_offline_messages(Acc3, StateData),
@@ -2000,31 +1992,31 @@ presence_track(Acc, StateData) ->
             {Acc1, StateData#state{pres_i = I,
                                    pres_a = A}};
         <<"subscribe">> ->
-            Acc2 = ejabberd_hooks:run_fold(roster_out_subscription,
+            Acc2 = mongoose_hooks:roster_out_subscription(
                                            Server,
                                            Acc,
-                                           [User, Server, To, subscribe]),
+                                           User, To, subscribe),
             Acc3 = check_privacy_and_route(Acc2, jid:to_bare(From), StateData),
             {Acc3, StateData};
         <<"subscribed">> ->
-            Acc2 = ejabberd_hooks:run_fold(roster_out_subscription,
+            Acc2 = mongoose_hooks:roster_out_subscription(
                                            Server,
                                            Acc,
-                                           [User, Server, To, subscribed]),
+                                           User, To, subscribed),
             Acc3 = check_privacy_and_route(Acc2, jid:to_bare(From), StateData),
             {Acc3, StateData};
         <<"unsubscribe">> ->
-            Acc2 = ejabberd_hooks:run_fold(roster_out_subscription,
+            Acc2 = mongoose_hooks:roster_out_subscription(
                                            Server,
                                            Acc,
-                                           [User, Server, To, unsubscribe]),
+                                           User, To, unsubscribe),
             Acc3 = check_privacy_and_route(Acc2, jid:to_bare(From), StateData),
             {Acc3, StateData};
         <<"unsubscribed">> ->
-            Acc2 = ejabberd_hooks:run_fold(roster_out_subscription,
+            Acc2 = mongoose_hooks:roster_out_subscription(
                                            Server,
                                            Acc,
-                                           [User, Server, To, unsubscribed]),
+                                           User,To, unsubscribed),
             Acc3 = check_privacy_and_route(Acc2, jid:to_bare(From), StateData),
             {Acc3, StateData};
         <<"error">> ->
@@ -2296,18 +2288,16 @@ process_privacy_iq(Acc1, To, StateData) ->
 process_privacy_iq(Acc, get, To, StateData) ->
     From = mongoose_acc:from_jid(Acc),
     {IQ, Acc1} = mongoose_iq:info(Acc),
-    Acc2 = ejabberd_hooks:run_fold(privacy_iq_get,
-                                   StateData#state.server,
-                                   Acc1,
-                                   [From, To, IQ, StateData#state.privacy_list]),
+    Acc2 = mongoose_hooks:privacy_iq_get(StateData#state.server,
+                                         Acc1,
+                                         From, To, IQ, StateData#state.privacy_list),
     {Acc2, StateData};
 process_privacy_iq(Acc, set, To, StateData) ->
     From = mongoose_acc:from_jid(Acc),
     {IQ, Acc1} = mongoose_iq:info(Acc),
-    Acc2 = ejabberd_hooks:run_fold(privacy_iq_set,
-                                   StateData#state.server,
-                                   Acc1,
-                                   [From, To, IQ]),
+    Acc2 = mongoose_hooks:privacy_iq_set(StateData#state.server,
+                                         Acc1,
+                                         From, To, IQ),
     case mongoose_acc:get(hook, result, undefined, Acc2) of
         {result, _, NewPrivList} ->
             Acc3 = maybe_update_presence(Acc2, StateData, NewPrivList),
@@ -2320,10 +2310,10 @@ process_privacy_iq(Acc, set, To, StateData) ->
 -spec resend_offline_messages(mongoose_acc:t(), state()) -> mongoose_acc:t().
 resend_offline_messages(Acc, StateData) ->
     ?DEBUG("resend offline messages~n", []),
-    Acc1 = ejabberd_hooks:run_fold(resend_offline_messages_hook,
+    Acc1 = mongoose_hooks:resend_offline_messages_hook(
                                    StateData#state.server,
                                    Acc,
-                                   [StateData#state.user, StateData#state.server]),
+                                   StateData#state.user),
     Rs = mongoose_acc:get(offline, messages, [], Acc1),
     Acc2 = lists:foldl(
                        fun({route, From, To, MsgAcc}, A) ->
@@ -2405,11 +2395,10 @@ process_unauthenticated_stanza(StateData, El) ->
             end,
     case jlib:iq_query_info(NewEl) of
         #iq{} = IQ ->
-            Res = ejabberd_hooks:run_fold(c2s_unauthenticated_iq,
+            Res = mongoose_hooks:c2s_unauthenticated_iq(
                                           StateData#state.server,
                                           empty,
-                                          [StateData#state.server, IQ,
-                                           StateData#state.ip]),
+                                          IQ, StateData#state.ip),
             case Res of
                 empty ->
                     % The only reasonable IQ's here are auth and register IQ's
@@ -2477,7 +2466,7 @@ fsm_reply(Reply, StateName, StateData) ->
 is_ip_blacklisted(undefined) ->
     false;
 is_ip_blacklisted({IP, _Port}) ->
-    ejabberd_hooks:run_fold(check_bl_c2s, false, [IP]).
+    mongoose_hooks:check_bl_c2s(false, IP).
 
 
 %% @doc Check from attributes.
@@ -3033,7 +3022,7 @@ maybe_notify_unacknowledged_msg(Acc, #state{jid = Jid}) ->
     end.
 
 notify_unacknowledged_msg(Acc, #jid{lserver = Server} = Jid) ->
-    NewAcc = ejabberd_hooks:run_fold(unacknowledged_message, Server, Acc, [Jid]),
+    NewAcc = mongoose_hooks:unacknowledged_message(Server, Acc, Jid),
     mongoose_acc:strip(NewAcc).
 
 finish_state(ok, StateName, StateData) ->
@@ -3283,11 +3272,11 @@ handle_sasl_step(#state{server = Server, socket = Sock} = State, StepRes) ->
             IP = peerip(State#state.sockmod, Sock),
             ?INFO_MSG("(~w) Failed authentication for ~s@~s from IP ~s (~w)",
                       [Sock, Username, Server, jlib:ip_to_list(IP), IP]),
-            ejabberd_hooks:run(auth_failed, Server, [Username, Server]),
+            mongoose_hooks:auth_failed(Server, Username),
             send_element_from_server_jid(State, sasl_failure_stanza(Error)),
             {wait_for_feature_before_auth, State};
         {error, Error} ->
-            ejabberd_hooks:run(auth_failed, Server, [unknown, Server]),
+            mongoose_hooks:auth_failed(Server, unknown),
             send_element_from_server_jid(State, sasl_failure_stanza(Error)),
             {wait_for_feature_before_auth, State}
     end.
@@ -3301,9 +3290,9 @@ user_allowed(JID, #state{server = Server, access = Access}) ->
     end.
 
 open_session_allowed_hook(Server, JID) ->
-    allow == ejabberd_hooks:run_fold(session_opening_allowed_for_user,
+    allow == mongoose_hooks:session_opening_allowed_for_user(
                                      Server,
-                                     allow, [JID]).
+                                     allow, JID).
 
 terminate_when_tls_required_but_not_enabled(true, false, StateData, _El) ->
     Lang = StateData#state.lang,

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -3,8 +3,6 @@
 -export([auth_failed/2,
          c2s_broadcast_recipients/6,
          c2s_filter_packet/6,
-         c2s_loop_debug/1,
-         c2s_loop_debug/2,
          c2s_preprocessing_hook/3,
          c2s_presence_in/5,
          c2s_stream_features/1,
@@ -75,18 +73,6 @@ c2s_filter_packet(Server, Drop, State, Feature, To, Packet) ->
                             Server,
                             Drop,
                             [Server, State, Feature, To, Packet]).
-
--spec c2s_loop_debug(Info) -> Result when
-    Info :: any(),
-    Result :: any().
-c2s_loop_debug(Info) ->
-    ejabberd_hooks:run(c2s_loop_debug, [Info]).
--spec c2s_loop_debug(Acc, Info) -> Result when
-    Acc :: mongoose_acc:t(),
-    Info :: any(),
-    Result :: any().
-c2s_loop_debug(Acc, Info) ->
-    ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [Info]).
 
 -spec c2s_preprocessing_hook(Server, Acc, State) -> Result when
     Server :: jid:server(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1,18 +1,142 @@
 -module(mongoose_hooks).
 
--export([failed_to_store_message/4,
+-export([auth_failed/2,
+         c2s_broadcast_recipients/6,
+         c2s_filter_packet/6,
+         c2s_loop_debug/1,
+         c2s_loop_debug/2,
+         c2s_preprocessing_hook/3,
+         c2s_presence_in/5,
+         c2s_stream_features/1,
+         c2s_unauthenticated_iq/4,
+         c2s_update_presence/2,
+         check_bl_c2s/2,
+         failed_to_store_message/4,
+         forbidden_session_hook/3,
          offline_groupchat_message_hook/5,
          offline_message_hook/5,
+         presence_probe_hook/5,
          privacy_check_packet/6,
          privacy_get_user_list/3,
+         privacy_iq_get/6,
+         privacy_iq_set/5,
+         privacy_updated_list/4,
+         resend_offline_messages_hook/3,
+         roster_get_subscription_lists/3,
+         roster_get_versioning_feature/1,
          roster_in_subscription/7,
+         roster_out_subscription/5,
+         session_opening_allowed_for_user/3,
          set_presence_hook/5,
          sm_broadcast/6,
          sm_filter_offline_message/5,
          sm_register_connection_hook/4,
          sm_remove_connection_hook/6,
+         unacknowledged_message/3,
          unset_presence_hook/5,
-         xmpp_bounce_message/2]).
+         user_available_hook/3,
+         user_receive_packet/6,
+         user_sent_keep_alive/2,
+         user_send_packet/5,
+         xmpp_bounce_message/2,
+         xmpp_send_element/3]).
+
+-spec auth_failed(Server, Username) -> Result when
+    Server :: jid:server(),
+    Username :: jid:user() | unknown,
+    Result :: ok.
+auth_failed(Server, Username) ->
+    ejabberd_hooks:run_fold(auth_failed, Server, ok, [Username, Server]).
+
+-spec c2s_broadcast_recipients(Server, Acc, State, Type, From, Packet) -> Result when
+    Server :: jid:server(),
+    Acc :: list(),
+    State :: ejabberd_c2s:state(),
+    Type :: {atom(), any()},
+    From :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: list().
+c2s_broadcast_recipients(Server, Acc, State, Type, From, Packet) ->
+    ejabberd_hooks:run_fold(c2s_broadcast_recipients,
+                            Server,
+                            Acc,
+                            [Server, State, Type, From, Packet]).
+
+-spec c2s_filter_packet(Server, Drop, State, Feature, To, Packet) -> Result when
+    Server :: jid:server(),
+    Drop :: boolean(),
+    State :: ejabberd_c2s:state(),
+    Feature :: {atom(), binary()},
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: boolean().
+c2s_filter_packet(Server, Drop, State, Feature, To, Packet) ->
+    ejabberd_hooks:run_fold(c2s_filter_packet,
+                            Server,
+                            Drop,
+                            [Server, State, Feature, To, Packet]).
+
+-spec c2s_loop_debug(Info) -> Result when
+    Info :: any(),
+    Result :: any().
+c2s_loop_debug(Info) ->
+    ejabberd_hooks:run(c2s_loop_debug, [Info]).
+-spec c2s_loop_debug(Acc, Info) -> Result when
+    Acc :: mongoose_acc:t(),
+    Info :: any(),
+    Result :: any().
+c2s_loop_debug(Acc, Info) ->
+    ejabberd_hooks:run_fold(c2s_loop_debug, Acc, [Info]).
+
+-spec c2s_preprocessing_hook(Server, Acc, State) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    State :: ejabberd_c2s:state(),
+    Result :: mongoose_acc:t().
+c2s_preprocessing_hook(Server, Acc, State) ->
+    ejabberd_hooks:run_fold(c2s_preprocessing_hook, Server, Acc, [State]).
+
+-spec c2s_presence_in(Server, State, From, To, Packet) -> Result when
+    Server :: jid:server(),
+    State :: ejabberd_c2s:state(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: ejabberd_c2s:state().
+c2s_presence_in(Server, State, From, To, Packet) ->
+    ejabberd_hooks:run_fold(c2s_presence_in, Server, State, [{From, To, Packet}]).
+
+-spec c2s_stream_features(Server) -> Result when
+    Server :: jid:server(),
+    Result :: [exml:element()].
+c2s_stream_features(Server) ->
+    ejabberd_hooks:run_fold(c2s_stream_features, Server, [], [Server]).
+
+-spec c2s_unauthenticated_iq(Server, Acc, IQ, IP) -> Result when
+    Server :: jid:server(),
+    Acc :: empty,
+    IQ :: jlib:iq(),
+    IP :: {inet:ip_address(), inet:port_number()} | undefined,
+    Result :: exml:element() | empty.
+c2s_unauthenticated_iq(Server, Acc, IQ, IP) ->
+    ejabberd_hooks:run_fold(c2s_unauthenticated_iq,
+                            Server,
+                            Acc,
+                            [Server, IQ, IP]).
+
+-spec c2s_update_presence(LServer, Acc) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    Result :: mongoose_acc:t().
+c2s_update_presence(LServer, Acc) ->
+    ejabberd_hooks:run_fold(c2s_update_presence, LServer, Acc, []).
+
+-spec check_bl_c2s(Blacklisted, IP) -> Result when
+    Blacklisted :: boolean(),
+    IP ::  inet:ip_address(),
+    Result :: boolean().
+check_bl_c2s(Blacklisted, IP) ->
+    ejabberd_hooks:run_fold(check_bl_c2s, Blacklisted, [IP]).
 
 -spec failed_to_store_message(LServer, Acc, From, Packet) -> Result when
     LServer :: jid:lserver(),
@@ -25,6 +149,14 @@ failed_to_store_message(LServer, Acc, From, Packet) ->
                             LServer,
                             Acc,
                             [From, Packet]).
+
+-spec forbidden_session_hook(Server, Acc, JID) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    JID :: jid:jid(),
+    Result :: mongoose_acc:t().
+forbidden_session_hook(Server, Acc, JID) ->
+    ejabberd_hooks:run_fold(forbidden_session_hook, Server, Acc, [JID]).
 
 -spec offline_groupchat_message_hook(LServer, Acc, From, To, Packet) -> Result when
     LServer :: jid:lserver(),
@@ -46,11 +178,24 @@ offline_groupchat_message_hook(LServer, Acc, From, To, Packet) ->
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: map().
-    offline_message_hook(LServer, Acc, From, To, Packet) ->
+offline_message_hook(LServer, Acc, From, To, Packet) ->
     ejabberd_hooks:run_fold(offline_message_hook,
                             LServer,
                             Acc,
                             [From, To, Packet]).
+
+-spec presence_probe_hook(Server, Acc, From, To, Pid) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Pid :: pid(),
+    Result :: mongoose_acc:t().
+presence_probe_hook(Server, Acc, From, To, Pid) ->
+    ejabberd_hooks:run_fold(presence_probe_hook,
+                            Server,
+                            Acc,
+                            [From, To, Pid]).
 
 -spec privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) -> Result when
       LServer :: jid:lserver(), Acc :: mongoose_acc:t(), User :: jid:luser(),
@@ -77,6 +222,69 @@ privacy_get_user_list(Server, UserList, User) ->
     ejabberd_hooks:run_fold(privacy_get_user_list, Server,
                                           UserList, [User, Server]).
 
+-spec privacy_iq_get(Server, Acc, From, To, IQ, PrivList) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    IQ :: jlib:iq(),
+    PrivList :: mongoose_privacy:userlist(),
+    Result :: mongoose_acc:t().
+privacy_iq_get(Server, Acc, From, To, IQ, PrivList) ->
+    ejabberd_hooks:run_fold(privacy_iq_get,
+                            Server,
+                            Acc,
+                            [From, To, IQ, PrivList]).
+
+-spec privacy_iq_set(Server, Acc, From, To, IQ) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    IQ :: jlib:iq(),
+    Result :: mongoose_acc:t().
+privacy_iq_set(Server, Acc, From, To, IQ) ->
+    ejabberd_hooks:run_fold(privacy_iq_set,
+                            Server,
+                            Acc,
+                            [From, To, IQ]).
+
+-spec privacy_updated_list(Server, Acc, OldList, NewList) -> Result when
+    Server :: jid:server(),
+    Acc :: false,
+    OldList :: mongoose_privacy:userlist(),
+    NewList :: mongoose_privacy:userlist(),
+    Result :: false | mongoose_privacy:userlist().
+privacy_updated_list(Server, Acc, OldList, NewList) ->
+    ejabberd_hooks:run_fold(privacy_updated_list, Server,
+                            Acc, [OldList, NewList]).
+
+-spec resend_offline_messages_hook(Server, Acc, User) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    User :: jid:user(),
+    Result :: mongoose_acc:t().
+resend_offline_messages_hook(Server, Acc, User) ->
+    ejabberd_hooks:run_fold(resend_offline_messages_hook,
+                            Server,
+                            Acc,
+                            [User, Server]).
+
+-spec roster_get_subscription_lists(Server, Acc, User) -> Result when
+    Server :: jid:server(),
+    Acc ::mongoose_acc:t(),
+    User :: jid:user(),
+    Result :: mongoose_acc:t().
+roster_get_subscription_lists(Server, Acc, User) ->
+    ejabberd_hooks:run_fold(roster_get_subscription_lists, Server, Acc, [User, Server]).
+
+-spec roster_get_versioning_feature(Server) -> Result when
+    Server :: jid:server(),
+    Result :: [exml:element()].
+roster_get_versioning_feature(Server) ->
+    ejabberd_hooks:run_fold(roster_get_versioning_feature,
+                            Server, [], [Server]).
+
 -spec roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) -> Result when
     LServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
@@ -92,6 +300,29 @@ roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) ->
         LServer,
         Acc,
         [User, Server, From, Type, Reason]).
+
+-spec roster_out_subscription(Server, Acc, User, To, Type) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    User :: jid:user(),
+    To :: jid:jid(),
+    Type :: mod_roster:sub_presence(),
+    Result :: mongoose_acc:t().
+roster_out_subscription(Server, Acc, User, To, Type) ->
+    ejabberd_hooks:run_fold(roster_out_subscription,
+                            Server,
+                            Acc,
+                            [User, Server, To, Type]).
+
+-spec session_opening_allowed_for_user(Server, Allow, JID) -> Result when
+    Server :: jid:server(),
+    Allow :: any(),
+    JID :: jid:jid(),
+    Result :: any().
+session_opening_allowed_for_user(Server, Allow, JID) ->
+    ejabberd_hooks:run_fold(session_opening_allowed_for_user,
+                            Server,
+                            Allow, [JID]).
 
 -spec set_presence_hook(LServer, Acc, LUser, LResource, Presence) -> Result when
     LServer :: jid:lserver(), Acc :: mongoose_acc:t(), LUser :: jid:luser(),
@@ -130,7 +361,7 @@ sm_filter_offline_message(LServer, Drop, From, To, Packet) ->
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Result :: ok.
-    sm_register_connection_hook(LServer, SID, JID, Info) ->
+sm_register_connection_hook(LServer, SID, JID, Info) ->
     ejabberd_hooks:run_fold(sm_register_connection_hook, LServer, ok,
                        [SID, JID, Info]).
 
@@ -145,6 +376,15 @@ sm_filter_offline_message(LServer, Drop, From, To, Packet) ->
 sm_remove_connection_hook(LServer, Acc, SID, JID, Info, Reason) ->
     ejabberd_hooks:run_fold(sm_remove_connection_hook, LServer, Acc,
                             [SID, JID, Info, Reason]).
+
+-spec unacknowledged_message(Server, Acc, JID) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    JID :: jid:jid(),
+    Result :: mongoose_acc:t().
+unacknowledged_message(Server, Acc, JID) ->
+    ejabberd_hooks:run_fold(unacknowledged_message, Server, Acc, [JID]).
+
 -spec unset_presence_hook(LServer, Acc, LUser, LResource, Status) -> Result when
     LServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
@@ -156,9 +396,62 @@ unset_presence_hook(LServer, Acc, LUser, LResource, Status) ->
     ejabberd_hooks:run_fold(unset_presence_hook, LServer, Acc,
                             [LUser, LServer, LResource, Status]).
 
+-spec user_available_hook(Server, Acc, JID) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    JID :: jid:jid(),
+    Result :: mongoose_acc:t().
+user_available_hook(Server, Acc, JID) ->
+    ejabberd_hooks:run_fold(user_available_hook,
+                            Server,
+                            Acc,
+                            [JID]).
+
+-spec user_receive_packet(Server, Acc, JID, From, To, El) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    JID :: jid:jid(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    El :: exml:element(),
+    Result :: mongoose_acc:t().
+user_receive_packet(Server, Acc, JID, From, To, El) ->
+    ejabberd_hooks:run_fold(user_receive_packet,
+                            Server,
+                            Acc,
+                            [JID, From, To, El]).
+
+-spec user_sent_keep_alive(Server, JID) -> Result when
+    Server :: jid:server(),
+    JID :: jid:jid(),
+    Result :: any().
+user_sent_keep_alive(Server, JID) ->
+    ejabberd_hooks:run_fold(user_sent_keep_alive, Server, ok, [JID]).
+
+-spec user_send_packet(LServer, Acc, From, To, Packet) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: mongoose_acc:t().
+user_send_packet(LServer, Acc, From, To, Packet) ->
+    ejabberd_hooks:run_fold(user_send_packet,
+                            LServer,
+                            Acc,
+                            [From, To, Packet]).
+
 -spec xmpp_bounce_message(Server, Acc) -> Result when
     Server :: jid:server(),
     Acc :: mongoose_acc:t(),
     Result :: mongoose_acc:t().
 xmpp_bounce_message(Server, Acc) ->
     ejabberd_hooks:run_fold(xmpp_bounce_message, Server, Acc, []).
+
+-spec xmpp_send_element(Server, Acc, El) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    El :: exml:element(),
+    Result :: mongoose_acc:t().
+xmpp_send_element(Server, Acc, El) ->
+    ejabberd_hooks:run_fold(xmpp_send_element, Server, Acc, [El]).


### PR DESCRIPTION
This PR updates `ejabberd_c2s` to use new `mongoose_hooks` module. I have tried to write specs for the functions from `mongoose_hooks` as correctly as possible. I have noted hooks that are good candidates for removal, because they are not handled as far as I can see:
-  `c2s_update_presence` - it was not only not handled but also called with different number of arguments. One place when this hook is fired is in `handle_info({force_update_presence, LUser}...` in `c2s`. This message is sent only in `ejabberd_sm` and is exposed in API as `force_update_presence/1`. Is there a reason for such functionality? It seems that nothing executes this code right now.
- `forbidden_session_hook`
- ` c2s_loop_debug` which is also executed with different arguments but does not seem to be handled
- `session_opening_allowed_for_user`
- `check_bl_c2s` which is supposed to be used by "c2s blacklist plugins", but I don't know if such plugins exist.
