### PR TITLE
Change mongoose_hooks api

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -388,7 +388,7 @@ get_raw_sessions(#jid{luser = LUser, lserver = LServer}) ->
 set_presence(Acc, SID, JID, Priority, Presence, Info) ->
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
     set_session(SID, JID, Priority, Info),
-    mongoose_hooks:set_presence_hook(LServer, Acc, LUser, LResource, Presence).
+    mongoose_hooks:set_presence_hook(LServer, Acc, LUser, LServer, LResource, Presence).
 
 
 -spec unset_presence(Acc, SID, JID, Status, Info) -> Acc1 when
@@ -401,7 +401,7 @@ set_presence(Acc, SID, JID, Priority, Presence, Info) ->
 unset_presence(Acc, SID, JID, Status, Info) ->
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
     set_session(SID, JID, undefined, Info),
-    mongoose_hooks:unset_presence_hook(LServer, Acc, LUser, LResource, Status).
+    mongoose_hooks:unset_presence_hook(LServer, Acc, LUser, LServer, LResource, Status).
 
 
 -spec close_session_unset_presence(Acc, SID, JID, Status, Reason) -> Acc1 when
@@ -414,7 +414,7 @@ unset_presence(Acc, SID, JID, Status, Info) ->
 close_session_unset_presence(Acc, SID, JID, Status, Reason) ->
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
     Acc1 = close_session(Acc, SID, JID, Reason),
-    mongoose_hooks:unset_presence_hook(LServer, Acc1, LUser, LResource, Status).
+    mongoose_hooks:unset_presence_hook(LServer, Acc1, LUser, LServer, LResource, Status).
 
 
 -spec get_session_pid(JID) -> none | pid() when
@@ -795,7 +795,7 @@ do_route_offline(_, _, _, _, Acc, _) ->
 is_privacy_allow(From, To, Acc, Packet) ->
     User = To#jid.user,
     Server = To#jid.server,
-    PrivacyList = mongoose_hooks:privacy_get_user_list(Server, #userlist{}, User),
+    PrivacyList = mongoose_hooks:privacy_get_user_list(Server, #userlist{}, User, Server),
     is_privacy_allow(From, To, Acc, Packet, PrivacyList).
 
 

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1,37 +1,39 @@
 -module(mongoose_hooks).
 
--export([auth_failed/2,
-         c2s_broadcast_recipients/6,
-         c2s_filter_packet/6,
+-export([auth_failed/3,
+         c2s_broadcast_recipients/7,
+         c2s_filter_packet/7,
          c2s_preprocessing_hook/3,
          c2s_presence_in/5,
-         c2s_stream_features/1,
-         c2s_unauthenticated_iq/4,
+         c2s_stream_features/2,
+         c2s_stream_features/3,
+         c2s_unauthenticated_iq/5,
          c2s_update_presence/2,
-         check_bl_c2s/2,
+         check_bl_c2s/3,
          failed_to_store_message/4,
          forbidden_session_hook/3,
          offline_groupchat_message_hook/5,
          offline_message_hook/5,
          presence_probe_hook/5,
-         privacy_check_packet/6,
-         privacy_get_user_list/3,
+         privacy_check_packet/7,
+         privacy_get_user_list/4,
          privacy_iq_get/6,
          privacy_iq_set/5,
          privacy_updated_list/4,
-         resend_offline_messages_hook/3,
-         roster_get_subscription_lists/3,
-         roster_get_versioning_feature/1,
+         resend_offline_messages_hook/4,
+         roster_get_subscription_lists/4,
+         roster_get_versioning_feature/2,
+         roster_get_versioning_feature/3,
          roster_in_subscription/7,
-         roster_out_subscription/5,
+         roster_out_subscription/6,
          session_opening_allowed_for_user/3,
-         set_presence_hook/5,
+         set_presence_hook/6,
          sm_broadcast/6,
          sm_filter_offline_message/5,
          sm_register_connection_hook/4,
          sm_remove_connection_hook/6,
          unacknowledged_message/3,
-         unset_presence_hook/5,
+         unset_presence_hook/6,
          user_available_hook/3,
          user_receive_packet/6,
          user_sent_keep_alive/2,
@@ -39,14 +41,16 @@
          xmpp_bounce_message/2,
          xmpp_send_element/3]).
 
--spec auth_failed(Server, Username) -> Result when
-    Server :: jid:server(),
+-spec auth_failed(HookServer, Username, Server) -> Result when
+    HookServer :: jid:server() | global,
     Username :: jid:user() | unknown,
+    Server :: jid:server(),
     Result :: ok.
-auth_failed(Server, Username) ->
-    ejabberd_hooks:run_fold(auth_failed, Server, ok, [Username, Server]).
+auth_failed(HookServer, Username, Server) ->
+    ejabberd_hooks:run_fold(auth_failed, HookServer, ok, [Username, Server]).
 
--spec c2s_broadcast_recipients(Server, Acc, State, Type, From, Packet) -> Result when
+-spec c2s_broadcast_recipients(HookServer, Acc, Server, State, Type, From, Packet) -> Result when
+    HookServer :: jid:server() | global,
     Server :: jid:server(),
     Acc :: list(),
     State :: ejabberd_c2s:state(),
@@ -54,23 +58,24 @@ auth_failed(Server, Username) ->
     From :: jid:jid(),
     Packet :: exml:element(),
     Result :: list().
-c2s_broadcast_recipients(Server, Acc, State, Type, From, Packet) ->
+c2s_broadcast_recipients(HookServer, Acc, Server, State, Type, From, Packet) ->
     ejabberd_hooks:run_fold(c2s_broadcast_recipients,
-                            Server,
+                            HookServer,
                             Acc,
                             [Server, State, Type, From, Packet]).
 
--spec c2s_filter_packet(Server, Drop, State, Feature, To, Packet) -> Result when
-    Server :: jid:server(),
+-spec c2s_filter_packet(HookServer, Drop, Server, State, Feature, To, Packet) -> Result when
+    HookServer :: jid:server() | global,
     Drop :: boolean(),
+    Server :: jid:server(),
     State :: ejabberd_c2s:state(),
     Feature :: {atom(), binary()},
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: boolean().
-c2s_filter_packet(Server, Drop, State, Feature, To, Packet) ->
+c2s_filter_packet(HookServer, Drop, Server, State, Feature, To, Packet) ->
     ejabberd_hooks:run_fold(c2s_filter_packet,
-                            Server,
+                            HookServer,
                             Drop,
                             [Server, State, Feature, To, Packet]).
 
@@ -92,106 +97,118 @@ c2s_preprocessing_hook(Server, Acc, State) ->
 c2s_presence_in(Server, State, From, To, Packet) ->
     ejabberd_hooks:run_fold(c2s_presence_in, Server, State, [{From, To, Packet}]).
 
--spec c2s_stream_features(Server) -> Result when
+-spec c2s_stream_features(HookServer, Server) -> Result when
+    HookServer :: jid:server() | global,
     Server :: jid:server(),
     Result :: [exml:element()].
-c2s_stream_features(Server) ->
-    ejabberd_hooks:run_fold(c2s_stream_features, Server, [], [Server]).
+c2s_stream_features(HookServer, Server) ->
+    c2s_stream_features(HookServer, [], Server).
 
--spec c2s_unauthenticated_iq(Server, Acc, IQ, IP) -> Result when
+-spec c2s_stream_features(HookServer, Acc, Server) -> Result when
+    HookServer :: jid:server() | global,
+    Acc :: [exml:element()],
     Server :: jid:server(),
+    Result :: [exml:element()].
+c2s_stream_features(HookServer, Acc, Server) ->
+    ejabberd_hooks:run_fold(c2s_stream_features, HookServer, Acc, [Server]).
+
+-spec c2s_unauthenticated_iq(HookServer, Acc, Server, IQ, IP) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: empty,
+    Server :: jid:server(),
     IQ :: jlib:iq(),
     IP :: {inet:ip_address(), inet:port_number()} | undefined,
     Result :: exml:element() | empty.
-c2s_unauthenticated_iq(Server, Acc, IQ, IP) ->
+c2s_unauthenticated_iq(HookServer, Acc, Server, IQ, IP) ->
     ejabberd_hooks:run_fold(c2s_unauthenticated_iq,
-                            Server,
+                            HookServer,
                             Acc,
                             [Server, IQ, IP]).
 
--spec c2s_update_presence(LServer, Acc) -> Result when
-    LServer :: jid:lserver(),
+-spec c2s_update_presence(HookServer, Acc) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     Result :: mongoose_acc:t().
-c2s_update_presence(LServer, Acc) ->
-    ejabberd_hooks:run_fold(c2s_update_presence, LServer, Acc, []).
+c2s_update_presence(HookServer, Acc) ->
+    ejabberd_hooks:run_fold(c2s_update_presence, HookServer, Acc, []).
 
--spec check_bl_c2s(Blacklisted, IP) -> Result when
+-spec check_bl_c2s(HookServer, Blacklisted, IP) -> Result when
+    HookServer :: jid:server() | global,
     Blacklisted :: boolean(),
     IP ::  inet:ip_address(),
     Result :: boolean().
-check_bl_c2s(Blacklisted, IP) ->
-    ejabberd_hooks:run_fold(check_bl_c2s, Blacklisted, [IP]).
+check_bl_c2s(HookServer, Blacklisted, IP) ->
+    ejabberd_hooks:run_fold(check_bl_c2s, HookServer, Blacklisted, [IP]).
 
--spec failed_to_store_message(LServer, Acc, From, Packet) -> Result when
-    LServer :: jid:lserver(),
+-spec failed_to_store_message(HookServer, Acc, From, Packet) -> Result when
+    HookServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
-failed_to_store_message(LServer, Acc, From, Packet) ->
+failed_to_store_message(HookServer, Acc, From, Packet) ->
     ejabberd_hooks:run_fold(failed_to_store_message,
-                            LServer,
+                            HookServer,
                             Acc,
                             [From, Packet]).
 
--spec forbidden_session_hook(Server, Acc, JID) -> Result when
-    Server :: jid:server(),
+-spec forbidden_session_hook(HookServer, Acc, JID) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-forbidden_session_hook(Server, Acc, JID) ->
-    ejabberd_hooks:run_fold(forbidden_session_hook, Server, Acc, [JID]).
+forbidden_session_hook(HookServer, Acc, JID) ->
+    ejabberd_hooks:run_fold(forbidden_session_hook, HookServer, Acc, [JID]).
 
--spec offline_groupchat_message_hook(LServer, Acc, From, To, Packet) -> Result when
-    LServer :: jid:lserver(),
+-spec offline_groupchat_message_hook(HookServer, Acc, From, To, Packet) -> Result when
+    HookServer :: jid:lserver(),
     Acc :: map(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: map().
-offline_groupchat_message_hook(LServer, Acc, From, To, Packet) ->
+offline_groupchat_message_hook(HookServer, Acc, From, To, Packet) ->
     ejabberd_hooks:run_fold(offline_groupchat_message_hook,
-                            LServer,
+                            HookServer,
                             Acc,
                             [From, To, Packet]).
 
--spec offline_message_hook(LServer, Acc, From, To, Packet) -> Result when
-    LServer :: jid:lserver(),
+-spec offline_message_hook(HookServer, Acc, From, To, Packet) -> Result when
+    HookServer :: jid:lserver(),
     Acc :: map(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: map().
-offline_message_hook(LServer, Acc, From, To, Packet) ->
+offline_message_hook(HookServer, Acc, From, To, Packet) ->
     ejabberd_hooks:run_fold(offline_message_hook,
-                            LServer,
+                            HookServer,
                             Acc,
                             [From, To, Packet]).
 
--spec presence_probe_hook(Server, Acc, From, To, Pid) -> Result when
-    Server :: jid:server(),
+-spec presence_probe_hook(HookServer, Acc, From, To, Pid) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Pid :: pid(),
     Result :: mongoose_acc:t().
-presence_probe_hook(Server, Acc, From, To, Pid) ->
+presence_probe_hook(HookServer, Acc, From, To, Pid) ->
     ejabberd_hooks:run_fold(presence_probe_hook,
-                            Server,
+                            HookServer,
                             Acc,
                             [From, To, Pid]).
 
--spec privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) -> Result when
-      LServer :: jid:lserver(), Acc :: mongoose_acc:t(), User :: jid:luser(),
+-spec privacy_check_packet(HookServer, Acc, User, LServer, PrivacyList, FromToNameType, Dir) -> Result when
+      HookServer :: jid:server() | global,
+      Acc :: mongoose_acc:t(), User :: jid:luser(), LServer :: jid:lserver(),
       PrivacyList :: mongoose_privacy:userlist(),
       FromToNameType :: {jid:jid(), jid:jid(), binary(), binary()},
       Dir :: in | out,
       Result :: mongoose_acc:t().
-privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) ->
+privacy_check_packet(HookServer, Acc, User, LServer, PrivacyList, FromToNameType, Dir) ->
     ejabberd_hooks:run_fold(privacy_check_packet,
-                            LServer,
+                            HookServer,
                             mongoose_acc:set(hook, result, allow, Acc),
                             [User,
                              LServer,
@@ -199,245 +216,261 @@ privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) ->
                              FromToNameType,
                              Dir]).
 
--spec privacy_get_user_list(Server, UserList, User) -> Result when
-    Server :: jid:server(),
+-spec privacy_get_user_list(HookServer, UserList, User, Server) -> Result when
+    HookServer :: jid:server() | global,
     UserList :: mongoose_privacy:userlist(),
     User :: jid:user(),
+    Server :: jid:server(),
     Result :: mongoose_privacy:userlist().
-privacy_get_user_list(Server, UserList, User) ->
-    ejabberd_hooks:run_fold(privacy_get_user_list, Server,
+privacy_get_user_list(HookServer, UserList, User, Server) ->
+    ejabberd_hooks:run_fold(privacy_get_user_list, HookServer,
                                           UserList, [User, Server]).
 
--spec privacy_iq_get(Server, Acc, From, To, IQ, PrivList) -> Result when
-    Server :: jid:server(),
+-spec privacy_iq_get(HookServer, Acc, From, To, IQ, PrivList) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     IQ :: jlib:iq(),
     PrivList :: mongoose_privacy:userlist(),
     Result :: mongoose_acc:t().
-privacy_iq_get(Server, Acc, From, To, IQ, PrivList) ->
+privacy_iq_get(HookServer, Acc, From, To, IQ, PrivList) ->
     ejabberd_hooks:run_fold(privacy_iq_get,
-                            Server,
+                            HookServer,
                             Acc,
                             [From, To, IQ, PrivList]).
 
--spec privacy_iq_set(Server, Acc, From, To, IQ) -> Result when
-    Server :: jid:server(),
+-spec privacy_iq_set(HookServer, Acc, From, To, IQ) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     IQ :: jlib:iq(),
     Result :: mongoose_acc:t().
-privacy_iq_set(Server, Acc, From, To, IQ) ->
+privacy_iq_set(HookServer, Acc, From, To, IQ) ->
     ejabberd_hooks:run_fold(privacy_iq_set,
-                            Server,
+                            HookServer,
                             Acc,
                             [From, To, IQ]).
 
--spec privacy_updated_list(Server, Acc, OldList, NewList) -> Result when
-    Server :: jid:server(),
+-spec privacy_updated_list(HookServer, Acc, OldList, NewList) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: false,
     OldList :: mongoose_privacy:userlist(),
     NewList :: mongoose_privacy:userlist(),
     Result :: false | mongoose_privacy:userlist().
-privacy_updated_list(Server, Acc, OldList, NewList) ->
-    ejabberd_hooks:run_fold(privacy_updated_list, Server,
+privacy_updated_list(HookServer, Acc, OldList, NewList) ->
+    ejabberd_hooks:run_fold(privacy_updated_list, HookServer,
                             Acc, [OldList, NewList]).
 
--spec resend_offline_messages_hook(Server, Acc, User) -> Result when
-    Server :: jid:server(),
+-spec resend_offline_messages_hook(HookServer, Acc, User, Server) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     User :: jid:user(),
+    Server :: jid:server(),
     Result :: mongoose_acc:t().
-resend_offline_messages_hook(Server, Acc, User) ->
+resend_offline_messages_hook(HookServer, Acc, User, Server) ->
     ejabberd_hooks:run_fold(resend_offline_messages_hook,
-                            Server,
+                            HookServer,
                             Acc,
                             [User, Server]).
 
--spec roster_get_subscription_lists(Server, Acc, User) -> Result when
-    Server :: jid:server(),
+-spec roster_get_subscription_lists(HookServer, Acc, User, Server) -> Result when
+    HookServer :: jid:server() | global,
     Acc ::mongoose_acc:t(),
     User :: jid:user(),
+    Server :: jid:server(),
     Result :: mongoose_acc:t().
-roster_get_subscription_lists(Server, Acc, User) ->
-    ejabberd_hooks:run_fold(roster_get_subscription_lists, Server, Acc, [User, Server]).
+roster_get_subscription_lists(HookServer, Acc, User, Server) ->
+    ejabberd_hooks:run_fold(roster_get_subscription_lists, HookServer, Acc, [User, Server]).
 
--spec roster_get_versioning_feature(Server) -> Result when
+-spec roster_get_versioning_feature(HookServer, Server) -> Result when
+    HookServer :: jid:server() | global,
     Server :: jid:server(),
     Result :: [exml:element()].
-roster_get_versioning_feature(Server) ->
-    ejabberd_hooks:run_fold(roster_get_versioning_feature,
-                            Server, [], [Server]).
+roster_get_versioning_feature(HookServer, Server) ->
+    roster_get_versioning_feature(HookServer, [], Server).
 
--spec roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) -> Result when
-    LServer :: jid:lserver(),
+-spec roster_get_versioning_feature(HookServer, Acc, Server) -> Result when
+    HookServer :: jid:server() | global,
+    Acc :: [exml:element()],
+    Server :: jid:server(),
+    Result :: [exml:element()].
+roster_get_versioning_feature(HookServer, Acc, Server) ->
+    ejabberd_hooks:run_fold(roster_get_versioning_feature,
+                            HookServer, Acc, [Server]).
+
+
+-spec roster_in_subscription(HookServer, Acc, User, LServer, From, Type, Reason) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     User :: jid:user(),
-    Server :: jid:server(),
+    LServer :: jid:lserver(),
     From :: jid:jid(),
     Type :: mod_roster:sub_presence(),
     Reason :: any(),
     Result :: mongoose_acc:t().
-roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) ->
+roster_in_subscription(HookServer, Acc, User, LServer, From, Type, Reason) ->
     ejabberd_hooks:run_fold(
         roster_in_subscription,
-        LServer,
+        HookServer,
         Acc,
-        [User, Server, From, Type, Reason]).
+        [User, LServer, From, Type, Reason]).
 
--spec roster_out_subscription(Server, Acc, User, To, Type) -> Result when
-    Server :: jid:server(),
+-spec roster_out_subscription(HookServer, Acc, User, Server, To, Type) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     User :: jid:user(),
+    Server :: jid:server(),
     To :: jid:jid(),
     Type :: mod_roster:sub_presence(),
     Result :: mongoose_acc:t().
-roster_out_subscription(Server, Acc, User, To, Type) ->
+roster_out_subscription(HookServer, Acc, User, Server, To, Type) ->
     ejabberd_hooks:run_fold(roster_out_subscription,
-                            Server,
+                            HookServer,
                             Acc,
                             [User, Server, To, Type]).
 
--spec session_opening_allowed_for_user(Server, Allow, JID) -> Result when
-    Server :: jid:server(),
+-spec session_opening_allowed_for_user(HookServer, Allow, JID) -> Result when
+    HookServer :: jid:server() | global,
     Allow :: any(),
     JID :: jid:jid(),
     Result :: any().
-session_opening_allowed_for_user(Server, Allow, JID) ->
+session_opening_allowed_for_user(HookServer, Allow, JID) ->
     ejabberd_hooks:run_fold(session_opening_allowed_for_user,
-                            Server,
+                            HookServer,
                             Allow, [JID]).
 
--spec set_presence_hook(LServer, Acc, LUser, LResource, Presence) -> Result when
-    LServer :: jid:lserver(), Acc :: mongoose_acc:t(), LUser :: jid:luser(),
-    LResource :: jid:lresource(),
+-spec set_presence_hook(HookServer, Acc, LUser, LServer, LResource, Presence) -> Result when
+    HookServer :: jid:server() | global,
+    Acc :: mongoose_acc:t(),
+    LUser :: jid:luser(), LServer :: jid:lserver(), LResource :: jid:lresource(),
     Presence :: any(),
     Result :: mongoose_acc:t().
-set_presence_hook(LServer, Acc, LUser, LResource, Presence) ->
-    ejabberd_hooks:run_fold(set_presence_hook, LServer, Acc, [LUser, LServer, LResource, Presence]).
+set_presence_hook(HookServer, Acc, LUser, LServer, LResource, Presence) ->
+    ejabberd_hooks:run_fold(set_presence_hook, HookServer, Acc, [LUser, LServer, LResource, Presence]).
 
--spec sm_broadcast(LServer, Acc, From, To, Broadcast, SessionCount) -> Result when
-    LServer :: jid:lserver(),
+-spec sm_broadcast(HookServer, Acc, From, To, Broadcast, SessionCount) -> Result when
+    HookServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Broadcast :: ejabberd_c2s:broadcast(),
     SessionCount :: non_neg_integer(),
     Result :: mongoose_acc:t().
-sm_broadcast(LServer, Acc, From, To, Broadcast, SessionCount) ->
-    ejabberd_hooks:run_fold(sm_broadcast, LServer, Acc,
+sm_broadcast(HookServer, Acc, From, To, Broadcast, SessionCount) ->
+    ejabberd_hooks:run_fold(sm_broadcast, HookServer, Acc,
                             [From, To, Broadcast, SessionCount]).
 
--spec sm_filter_offline_message(LServer, Drop, From, To, Packet) -> Result when
-    LServer :: jid:lserver(),
+-spec sm_filter_offline_message(HookServer, Drop, From, To, Packet) -> Result when
+    HookServer :: jid:lserver(),
     Drop :: boolean(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: boolean().
-sm_filter_offline_message(LServer, Drop, From, To, Packet) ->
-    ejabberd_hooks:run_fold(sm_filter_offline_message, LServer,
+sm_filter_offline_message(HookServer, Drop, From, To, Packet) ->
+    ejabberd_hooks:run_fold(sm_filter_offline_message, HookServer,
                             Drop, [From, To, Packet]).
 
--spec sm_register_connection_hook(LServer, SID, JID, Info) -> Result when
-    LServer :: jid:lserver(),
+-spec sm_register_connection_hook(HookServer, SID, JID, Info) -> Result when
+    HookServer :: jid:lserver(),
     SID :: 'undefined' | ejabberd_sm:sid(),
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Result :: ok.
-sm_register_connection_hook(LServer, SID, JID, Info) ->
-    ejabberd_hooks:run_fold(sm_register_connection_hook, LServer, ok,
+sm_register_connection_hook(HookServer, SID, JID, Info) ->
+    ejabberd_hooks:run_fold(sm_register_connection_hook, HookServer, ok,
                        [SID, JID, Info]).
 
--spec sm_remove_connection_hook(LServer, Acc, SID, JID, Info, Reason) -> Result when
-    LServer :: jid:lserver(),
+-spec sm_remove_connection_hook(HookServer, Acc, SID, JID, Info, Reason) -> Result when
+    HookServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
     SID :: 'undefined' | ejabberd_sm:sid(),
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Reason :: ejabberd_sm:close_reason(),
     Result :: mongoose_acc:t().
-sm_remove_connection_hook(LServer, Acc, SID, JID, Info, Reason) ->
-    ejabberd_hooks:run_fold(sm_remove_connection_hook, LServer, Acc,
+sm_remove_connection_hook(HookServer, Acc, SID, JID, Info, Reason) ->
+    ejabberd_hooks:run_fold(sm_remove_connection_hook, HookServer, Acc,
                             [SID, JID, Info, Reason]).
 
--spec unacknowledged_message(Server, Acc, JID) -> Result when
-    Server :: jid:server(),
+-spec unacknowledged_message(HookServer, Acc, JID) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-unacknowledged_message(Server, Acc, JID) ->
-    ejabberd_hooks:run_fold(unacknowledged_message, Server, Acc, [JID]).
+unacknowledged_message(HookServer, Acc, JID) ->
+    ejabberd_hooks:run_fold(unacknowledged_message, HookServer, Acc, [JID]).
 
--spec unset_presence_hook(LServer, Acc, LUser, LResource, Status) -> Result when
-    LServer :: jid:lserver(),
+-spec unset_presence_hook(HookServer, Acc, LUser, LServer, LResource, Status) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     LUser :: jid:luser(),
+    LServer :: jid:lserver(),
     LResource :: jid:lresource(),
     Status :: binary(),
     Result :: mongoose_acc:t().
-unset_presence_hook(LServer, Acc, LUser, LResource, Status) ->
-    ejabberd_hooks:run_fold(unset_presence_hook, LServer, Acc,
+unset_presence_hook(HookServer, Acc, LUser, LServer, LResource, Status) ->
+    ejabberd_hooks:run_fold(unset_presence_hook, HookServer, Acc,
                             [LUser, LServer, LResource, Status]).
 
--spec user_available_hook(Server, Acc, JID) -> Result when
-    Server :: jid:server(),
+-spec user_available_hook(HookServer, Acc, JID) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-user_available_hook(Server, Acc, JID) ->
+user_available_hook(HookServer, Acc, JID) ->
     ejabberd_hooks:run_fold(user_available_hook,
-                            Server,
+                            HookServer,
                             Acc,
                             [JID]).
 
--spec user_receive_packet(Server, Acc, JID, From, To, El) -> Result when
-    Server :: jid:server(),
+-spec user_receive_packet(HookServer, Acc, JID, From, To, El) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     From :: jid:jid(),
     To :: jid:jid(),
     El :: exml:element(),
     Result :: mongoose_acc:t().
-user_receive_packet(Server, Acc, JID, From, To, El) ->
+user_receive_packet(HookServer, Acc, JID, From, To, El) ->
     ejabberd_hooks:run_fold(user_receive_packet,
-                            Server,
+                            HookServer,
                             Acc,
                             [JID, From, To, El]).
 
--spec user_sent_keep_alive(Server, JID) -> Result when
-    Server :: jid:server(),
+-spec user_sent_keep_alive(HookServer, JID) -> Result when
+    HookServer :: jid:server() | global,
     JID :: jid:jid(),
     Result :: any().
-user_sent_keep_alive(Server, JID) ->
-    ejabberd_hooks:run_fold(user_sent_keep_alive, Server, ok, [JID]).
+user_sent_keep_alive(HookServer, JID) ->
+    ejabberd_hooks:run_fold(user_sent_keep_alive, HookServer, ok, [JID]).
 
--spec user_send_packet(LServer, Acc, From, To, Packet) -> Result when
-    LServer :: jid:lserver(),
+-spec user_send_packet(HookServer, Acc, From, To, Packet) -> Result when
+    HookServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
-user_send_packet(LServer, Acc, From, To, Packet) ->
+user_send_packet(HookServer, Acc, From, To, Packet) ->
     ejabberd_hooks:run_fold(user_send_packet,
-                            LServer,
+                            HookServer,
                             Acc,
                             [From, To, Packet]).
 
--spec xmpp_bounce_message(Server, Acc) -> Result when
-    Server :: jid:server(),
+-spec xmpp_bounce_message(HookServer, Acc) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     Result :: mongoose_acc:t().
-xmpp_bounce_message(Server, Acc) ->
-    ejabberd_hooks:run_fold(xmpp_bounce_message, Server, Acc, []).
+xmpp_bounce_message(HookServer, Acc) ->
+    ejabberd_hooks:run_fold(xmpp_bounce_message, HookServer, Acc, []).
 
--spec xmpp_send_element(Server, Acc, El) -> Result when
-    Server :: jid:server(),
+-spec xmpp_send_element(HookServer, Acc, El) -> Result when
+    HookServer :: jid:server() | global,
     Acc :: mongoose_acc:t(),
     El :: exml:element(),
     Result :: mongoose_acc:t().
-xmpp_send_element(Server, Acc, El) ->
-    ejabberd_hooks:run_fold(xmpp_send_element, Server, Acc, [El]).
+xmpp_send_element(HookServer, Acc, El) ->
+    ejabberd_hooks:run_fold(xmpp_send_element, HookServer, Acc, [El]).

--- a/src/mongoose_privacy.erl
+++ b/src/mongoose_privacy.erl
@@ -65,7 +65,7 @@ privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir) ->
     Key = {cached_check, Server, User, From, To, Name, Type, Dir},
     case mongoose_acc:get(privacy, Key, undefined, Acc) of
         undefined ->
-            Acc1 = mongoose_hooks:privacy_check_packet(Server, Acc, User, PrivacyList,
+            Acc1 = mongoose_hooks:privacy_check_packet(Server, Acc, User, Server, PrivacyList,
                                                        {From, To, Name, Type}, Dir),
             Res = mongoose_acc:get(hook, result, Acc1),
             {mongoose_acc:set(privacy, Key, Res, Acc1), Res};

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -35,7 +35,6 @@ setup() ->
     meck:new(ejabberd_hooks),
     meck:expect(ejabberd_hooks, run, fun(_, _) -> ok end),
     meck:expect(ejabberd_hooks, run, fun(_, _, _) -> ok end),
-    meck:expect(ejabberd_hooks, run_fold, fun hookfold/3),
     meck:expect(ejabberd_hooks, run_fold, fun hookfold/4),
 
     meck:new(ejabberd_config),
@@ -67,8 +66,7 @@ default_global_option(language) ->  <<"en">>.
 mcred_get(dummy_creds, username) -> <<"cosmic_hippo">>;
 mcred_get(dummy_creds, auth_module) -> auuuthmodule.
 
-hookfold(check_bl_c2s, _, _) -> false.
-
+hookfold(check_bl_c2s, _, _, _) -> false;
 hookfold(roster_get_versioning_feature, _, _, _) -> [];
 hookfold(roster_get_subscription_lists, _, A, _) -> A;
 hookfold(privacy_get_user_list, _, A, _) -> A;


### PR DESCRIPTION
This PR continues work done in #2639.
Its aim is to standardize APIs exposed from `mongoose_hooks` module. Change introduced in comparison to `ejabberd_hooks` is the fact that hook caller needs to pass `Server` explicitly, even if he doesn't care about XMPP domain (in such cases an atom `global` used to be inserted). There is still a possibility to run a hook without an accumulator in some cases(an equivalent of `ejabberd_hooks:run`), but such `mongoose_hooks` always execute the same `mongoose_hook` with arity higher by 1. This way, when writing a handler one will know what is the number of arguments they should accept (one less then the biggest arity for a given `mongoose_hook`).