### PR TITLE
Perf/mod roster refactor

### DIFF
--- a/include/mod_roster.hrl
+++ b/include/mod_roster.hrl
@@ -23,7 +23,7 @@
                  jid,
                  name = <<>>,
                  subscription = none :: both | from | to | none | remove,
-                 ask = none,
+                 ask = none :: subscribe | unsubscribe | in | out | both | none,
                  groups = [],
                  askmessage = <<>>,
                  xs = []}).

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -46,6 +46,7 @@
          get_password_s/2,
          get_passterm_with_authmodule/2,
          does_user_exist/1,
+         is_user_exists/1,
          is_user_exists/2,
          is_user_exists_in_other_modules/3,
          remove_user/2,
@@ -461,6 +462,14 @@ do_get_passterm_with_authmodule(LUser, LServer) ->
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
+-spec is_user_exists(JID :: jid:jid()) -> boolean().
+is_user_exists(#jid{luser = <<>>}) ->
+    false;
+is_user_exists(#jid{luser = LUser, lserver = LServer}) ->
+    do_does_user_exist(LUser, LServer);
+is_user_exists(error) ->
+    false.
+
 -spec is_user_exists(User :: jid:user(),
                      Server :: jid:server()) -> boolean().
 is_user_exists(<<"">>, _) ->
@@ -471,8 +480,7 @@ is_user_exists(User, Server) ->
     do_does_user_exist(LUser, LServer).
 
 -spec does_user_exist(JID :: jid:jid()) -> boolean().
-does_user_exist(JID) ->
-    #jid{luser = LUser, lserver = LServer} = JID,
+does_user_exist(#jid{luser = LUser, lserver = LServer}) ->
     do_does_user_exist(LUser, LServer).
 
 do_does_user_exist(LUser, LServer) when LUser =:= error; LServer =:= error ->

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -323,8 +323,8 @@ delete_contact(Caller, JabberID) ->
 
 -spec jid_exists(binary(), binary()) -> boolean().
 jid_exists(CJid, Jid) ->
-    FJid = jid:from_binary(CJid),
-    Res = mod_roster:get_roster_entry(FJid#jid.luser, FJid#jid.lserver, Jid),
+    #jid{} = FJid = jid:from_binary(CJid),
+    Res = mod_roster:get_roster_entry(FJid, Jid),
     Res =/= does_not_exist.
 
 registered_commands() ->

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -46,15 +46,13 @@
          process_local_iq/4,
          get_user_roster/2,
          get_subscription_lists/3,
+         get_roster_entry/2,
          get_roster_entry/3,
-         get_roster_entry/4,
-         get_roster_entry_t/3,
-         get_roster_entry_t/4,
          get_roster/2,
          item_to_map/1,
          in_subscription/6,
          out_subscription/5,
-         set_items/3,
+         set_items/2,
          set_roster_entry/4,
          remove_user/2, % for tests
          remove_user/3,
@@ -68,7 +66,7 @@
 
 -export([remove_test_user/2,
          transaction/2,
-         process_subscription_transaction/6,
+         process_subscription_transaction/5,
          get_user_rosters_length/2]). % for testing
 
 -export([get_personal_data/2]).
@@ -226,18 +224,14 @@ hooks(Host) ->
      {roster_get_versioning_feature, Host, ?MODULE, get_versioning_feature, 50},
      {get_personal_data, Host, ?MODULE, get_personal_data, 50}].
 
-get_roster_entry(LUser, LServer, Jid) ->
-    mod_roster_backend:get_roster_entry(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid)).
+get_roster_entry(#jid{luser = LUser, lserver = LServer}, Jid) ->
+    mod_roster_backend:get_roster_entry(LUser, LServer, jid_arg_to_lower(Jid)).
 
-get_roster_entry(LUser, LServer, Jid, full) ->
-    mod_roster_backend:get_roster_entry(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid), full).
+get_roster_entry(#jid{luser = LUser, lserver = LServer}, Jid, full) ->
+    mod_roster_backend:get_roster_entry(LUser, LServer, jid_arg_to_lower(Jid), full).
 
-get_roster_entry_t(LUser, LServer, Jid) ->
-    mod_roster_backend:get_roster_entry_t(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid)).
-
-get_roster_entry_t(LUser, LServer, Jid, full) ->
-    mod_roster_backend:get_roster_entry_t(jid:nameprep(LUser), LServer,
-                                          jid_arg_to_lower(Jid), full).
+get_roster_entry_t(#jid{luser = LUser, lserver = LServer}, Jid, full) ->
+    mod_roster_backend:get_roster_entry_t(LUser, LServer, jid_arg_to_lower(Jid), full).
 
 -spec jid_arg_to_lower(JID :: jid:simple_jid() | jid:jid() | binary()) ->
     error | jid:simple_jid().
@@ -461,29 +455,24 @@ process_item_set(_From, _To, _) -> ok.
 
 -spec do_process_item_set(error | jid:jid(), jid:jid(), jid:jid(), exml:element()) -> ok.
 do_process_item_set(error, _, _, _) -> ok;
-do_process_item_set(JID1,
-                    #jid{user = User, luser = LUser, lserver = LServer} = From,
-                    To,
+do_process_item_set(#jid{} = JID1, #jid{} = From, #jid{} = To,
                     #xmlel{attrs = Attrs, children = Els}) ->
-    LJID = jid:to_lower(JID1),
     MakeItem2 = fun(Item) ->
                     Item1 = process_item_attrs(Item, Attrs),
                     process_item_els(Item1, Els)
                 end,
-    set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2).
+    set_roster_item(JID1, From, To, MakeItem2).
 
 %% @doc this is run when a roster item is to be added, updated or removed
 %% the interface of this func could probably be a bit simpler
--spec set_roster_item(User :: binary(),
-                      LUser :: binary(),
-                      LServer :: binary(),
-                      LJID :: jid:simple_jid() | error,
-                      From ::jid:jid(),
-                      To ::jid:jid(),
+-spec set_roster_item(JID1 :: jid:jid(),
+                      From :: jid:jid(),
+                      To :: jid:jid(),
                       MakeItem2 :: fun( (roster()) -> roster())) -> ok.
-set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2) ->
+set_roster_item(JID1, #jid{luser = LUser, lserver = LServer} = From, To, MakeItem2) ->
+    LJID = jid:to_lower(JID1),
     F = fun () ->
-                Item = case get_roster_entry(LUser, LServer, LJID) of
+                Item = case get_roster_entry(From, LJID) of
                            does_not_exist ->
                                #roster{usj = {LUser, LServer, LJID},
                                        us = {LUser, LServer},
@@ -505,7 +494,7 @@ set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2) ->
         end,
     case transaction(LServer, F) of
         {atomic, {OldItem, NewItem}} ->
-            push_item(User, LServer, To, NewItem),
+            push_item(From, To, NewItem),
             case NewItem#roster.subscription of
                 remove ->
                     send_unsubscribing_presence(From, OldItem), ok;
@@ -553,26 +542,30 @@ process_item_els(Item, [{xmlcdata, _} | Els]) ->
     process_item_els(Item, Els);
 process_item_els(Item, []) -> Item.
 
-push_item(User, Server, From, Item) ->
-    #jid{luser = LUser} = JID = jid:make(User, Server, <<"">>),
-    ejabberd_sm:route(jid:make(<<"">>, <<"">>, <<"">>), JID,
+push_item(#jid{luser = LUser, lserver = LServer} = JID, From, Item) ->
+    ejabberd_sm:route(jid:make_noprep(<<>>, <<>>, <<>>), JID,
                       {broadcast, {item, Item#roster.jid, Item#roster.subscription}}),
-    case roster_versioning_enabled(Server) of
+    case roster_versioning_enabled(LServer) of
         true ->
-            push_item_version(JID, Server, User, From, Item,
-                              roster_version(Server, LUser));
+            push_item_version(JID, From, Item, roster_version(LServer, LUser));
         false ->
-            lists:foreach(fun (Resource) ->
-                                  push_item(User, Server, Resource, From, Item)
+            lists:foreach(fun(Resource) ->
+                                  push_item_without_version(JID, Resource, From, Item)
                           end,
                           ejabberd_sm:get_user_resources(JID))
     end.
 
-push_item(User, Server, Resource, From, Item) ->
+push_item_without_version(#jid{lserver = Server} = JID, Resource, From, Item) ->
     mongoose_hooks:roster_push(Server, ok, From, Item),
-    push_item(User, Server, Resource, From, Item, not_found).
+    push_item_final(jid:replace_resource(JID, Resource), From, Item, not_found).
 
-push_item(User, Server, Resource, From, Item, RosterVersion) ->
+push_item_version(JID, From, Item, RosterVersion) ->
+    lists:foreach(fun (Resource) ->
+                          push_item_final(jid:replace_resource(JID, Resource), From, Item, RosterVersion)
+                  end,
+                  ejabberd_sm:get_user_resources(JID)).
+
+push_item_final(JID, From, Item, RosterVersion) ->
     ExtraAttrs = case RosterVersion of
                      not_found -> [];
                      _ -> [{<<"ver">>, RosterVersion}]
@@ -585,26 +578,14 @@ push_item(User, Server, Resource, From, Item, RosterVersion) ->
                 [#xmlel{name = <<"query">>,
                         attrs = [{<<"xmlns">>, ?NS_ROSTER} | ExtraAttrs],
                         children = [item_to_xml(Item)]}]},
-    ejabberd_router:route(From,
-                          jid:make(User, Server, Resource),
-                          jlib:iq_to_xml(ResIQ)).
-
-push_item_version(JID, Server, User, From, Item,
-                  RosterVersion) ->
-    lists:foreach(fun (Resource) ->
-                          push_item(User, Server, Resource, From, Item,
-                                    RosterVersion)
-                  end,
-                  ejabberd_sm:get_user_resources(JID)).
+    ejabberd_router:route(From, JID, jlib:iq_to_xml(ResIQ)).
 
 -spec get_subscription_lists(Acc :: mongoose_acc:t(),
                              User :: binary(),
                              Server :: binary()) -> mongoose_acc:t().
 get_subscription_lists(Acc, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
+    #jid{luser = LUser, lserver = LServer} = JID = jid:make(User, Server, <<>>),
     Items = mod_roster_backend:get_subscription_lists(Acc, LUser, LServer),
-    JID = jid:make(User, Server, <<>>),
     SubLists = fill_subscription_lists(JID, LServer, Items, [], [], []),
     mongoose_acc:set(roster, subscription_lists, SubLists, Acc).
 
@@ -683,11 +664,11 @@ out_subscription(Acc, User, Server, JID, Type) ->
     mongoose_acc:set(hook, result, Res, Acc).
 
 process_subscription(Direction, User, Server, JID1, Type, Reason) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
+    JID = jid:make(User, Server, <<>>),
+    LServer = case JID of #jid{lserver = LS} -> LS; error -> error end,
     LJID = jid:to_lower(JID1),
-    TransactionFun = fun() -> process_subscription_transaction(Direction, LUser, LServer,
-                                                               LJID, Type, Reason) end,
+    TransactionFun =
+        fun() -> process_subscription_transaction(Direction, JID, LJID, Type, Reason) end,
     case transaction(LServer, TransactionFun) of
         {atomic, {Push, AutoReply}} ->
             case AutoReply of
@@ -696,13 +677,13 @@ process_subscription(Direction, User, Server, JID1, Type, Reason) ->
                     PresenceStanza = #xmlel{name = <<"presence">>,
                                             attrs = [{<<"type">>, autoreply_to_type(AutoReply)}],
                                             children = []},
-                    ejabberd_router:route(jid:make(User, Server, <<"">>), JID1, PresenceStanza)
+                    ejabberd_router:route(JID, JID1, PresenceStanza)
             end,
             case Push of
                 {push, #roster{ subscription = none, ask = in }} ->
                     true;
                 {push, Item} ->
-                    push_item(User, Server, jid:make(User, Server, <<"">>), Item),
+                    push_item(JID, JID, Item),
                     true;
                 none -> false
             end;
@@ -712,11 +693,13 @@ process_subscription(Direction, User, Server, JID1, Type, Reason) ->
 autoreply_to_type(subscribed) -> <<"subscribed">>;
 autoreply_to_type(unsubscribed) -> <<"unsubscribed">>.
 
-process_subscription_transaction(Direction, LUser, LServer, LJID, Type, Reason) ->
-    Item = case mod_roster_backend:get_roster_entry_t(LUser, LServer, LJID, full) of
+process_subscription_transaction(Direction, JID, LJID, Type, Reason) ->
+    #jid{luser = LUser, lserver = LServer} = JID,
+    Item = case get_roster_entry_t(JID, LJID, full) of
                does_not_exist ->
                    #roster{usj = {LUser, LServer, LJID},
-                       us = {LUser, LServer}, jid = LJID};
+                           us = {LUser, LServer},
+                           jid = LJID};
                R -> R
            end,
     NewState = case Direction of
@@ -867,21 +850,24 @@ get_user_rosters_length(User, Server) ->
 
 %% Used only by tests
 remove_user(User, Server) ->
-    Acc = mongoose_acc:new(#{ location => ?LOCATION,
-                              lserver => <<_/binary>> = jid:nameprep(Server),
-                              element => undefined }),
+    Acc = mongoose_acc:new(#{location => ?LOCATION,
+                             lserver => <<_/binary>> = jid:nameprep(Server),
+                             element => undefined}),
     remove_user(Acc, User, Server).
 
 remove_user(Acc, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    Acc1 = try_send_unsubscription_to_rosteritems(Acc, LUser, LServer),
-    mod_roster_backend:remove_user(LUser, LServer),
-    Acc1.
+    case jid:make(User, Server, <<>>) of
+        #jid{luser = LUser, lserver = LServer} = JID ->
+            Acc1 = try_send_unsubscription_to_rosteritems(Acc, JID),
+            mod_roster_backend:remove_user(LUser, LServer),
+            Acc1;
+        error ->
+            Acc
+    end.
 
-try_send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
+try_send_unsubscription_to_rosteritems(Acc, JID) ->
     try
-        send_unsubscription_to_rosteritems(Acc, LUser, LServer)
+        send_unsubscription_to_rosteritems(Acc, JID)
     catch
         E:R:S ->
             ?LOG_WARNING(#{what => roster_unsubcribe_failed,
@@ -892,14 +878,13 @@ try_send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
 %% For each contact with Subscription:
 %% Both or From, send a "unsubscribed" presence stanza;
 %% Both or To, send a "unsubscribe" presence stanza.
-send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
+send_unsubscription_to_rosteritems(Acc, JID) ->
+    #jid{luser = LUser, lserver = LServer} = JID,
     Acc1 = get_user_roster(Acc, {LUser, LServer}),
     RosterItems = mongoose_acc:get(roster, items, [], Acc1),
-    From = jid:make({LUser, LServer, <<"">>}),
-    lists:foreach(fun (RosterItem) ->
-                          send_unsubscribing_presence(From, RosterItem)
-                  end,
-                  RosterItems),
+    lists:foreach(fun(RosterItem) ->
+                          send_unsubscribing_presence(JID, RosterItem)
+                  end, RosterItems),
     Acc1.
 
 %% @spec (From::jid(), Item::roster()) -> any()
@@ -924,15 +909,12 @@ send_presence_type(From, To, Type) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-set_items(User, Server, SubEl) ->
+set_items(#jid{luser = LUser, lserver = LServer}, SubEl) ->
     #xmlel{children = Els} = SubEl,
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
     F = fun () ->
-                lists:foreach(fun (El) ->
+                lists:foreach(fun(El) ->
                                       process_item_set_t(LUser, LServer, El)
-                              end,
-                              Els)
+                              end, Els)
         end,
     transaction(LServer, F).
 
@@ -947,25 +929,13 @@ set_roster_entry(UserJid, ContactBin, Name, Groups) ->
                        Groups :: [binary()] | unchanged,
                        NewSubscription :: remove | unchanged) -> ok|error.
 set_roster_entry(UserJid, ContactBin, Name, Groups, NewSubscription) ->
-    LUser = UserJid#jid.luser,
-    LServer = UserJid#jid.lserver,
-    JID1 = jid:from_binary(ContactBin),
-    case JID1 of
+    case jid:from_binary(ContactBin) of
         error -> error;
-        _ ->
-            LJID = jid:to_lower(JID1),
+        JID1 ->
             MakeItem = fun(Item) ->
-                            modify_roster_item(Item, Name, Groups, NewSubscription)
-                        end,
-            set_roster_item(
-                LUser, % User
-                LUser, % LUser
-                LServer, % LServer
-                LJID, % LJID
-                UserJid, % From
-                UserJid, % To
-                MakeItem
-            )
+                               modify_roster_item(Item, Name, Groups, NewSubscription)
+                       end,
+            set_roster_item(JID1, UserJid, UserJid, MakeItem)
     end.
 
 modify_roster_item(Item, Name, Groups, NewSubscription) ->
@@ -1048,11 +1018,12 @@ process_item_attrs_ws(Item, []) ->
                    Server :: jid:lserver(),
                    JID ::jid:jid() | jid:ljid()) -> {subscription_state(), [binary()]}.
 get_jid_info(_, User, Server, JID) ->
-    case get_roster_entry(User, Server, JID, full) of
+    ToJID = jid:make(User, Server, <<>>),
+    case get_roster_entry(ToJID, JID, full) of
         error -> {none, []};
         does_not_exist ->
             LRJID = jid:to_bare(jid:to_lower(JID)),
-            case get_roster_entry(User, Server, LRJID, full) of
+            case get_roster_entry(ToJID, LRJID, full) of
                 error -> {none, []};
                 does_not_exist -> {none, []};
                 R -> {R#roster.subscription, R#roster.groups}

--- a/src/mongoose_client_api/mongoose_client_api_contacts.erl
+++ b/src/mongoose_client_api/mongoose_client_api_contacts.erl
@@ -193,6 +193,6 @@ to_binary(S) ->
 
 -spec jid_exists(binary(), binary()) -> boolean().
 jid_exists(CJid, Jid) ->
-    FJid = jid:from_binary(CJid),
-    Res = mod_roster:get_roster_entry(FJid#jid.luser, FJid#jid.lserver, Jid),
+    #jid{} = FJid = jid:from_binary(CJid),
+    Res = mod_roster:get_roster_entry(FJid, Jid),
     Res =/= does_not_exist.

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -67,7 +67,7 @@ end_per_testcase(_TC, C) ->
 roster_old(_C) ->
     R1 = get_roster_old(),
     ?assertEqual(length(R1), 0),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     subscription(out, subscribe),
     assert_state_old(none, out),
@@ -76,7 +76,7 @@ roster_old(_C) ->
 roster_old_with_filter(_C) ->
     R1 = get_roster_old(),
     ?assertEqual(0, length(R1)),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     subscription(in, subscribe),
     R2 = get_roster_old(),
@@ -86,29 +86,29 @@ roster_old_with_filter(_C) ->
     ok.
 
 roster_new(_C) ->
-    R1 = mod_roster:get_roster_entry(a(), host(), bob()),
+    R1 = mod_roster:get_roster_entry(alice_jid(), bob()),
     ?assertEqual(does_not_exist, R1),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     ct:pal("get_roster_old(): ~p", [get_roster_old()]),
-    R2 = mod_roster:get_roster_entry(a(), host(), bob()),
+    R2 = mod_roster:get_roster_entry(alice_jid(), bob()),
     ?assertMatch(#roster{}, R2), % is not guaranteed to contain full info
-    R3 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
     subscription(out, subscribe),
-    R4 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R4 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R4, none, out, [<<"friends">>]).
 
 
 roster_case_insensitive(_C) ->
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     R1 = get_roster_old(),
     ?assertEqual(1, length(R1)),
     R2 = get_roster_old(ae()),
     ?assertEqual(1, length(R2)),
-    R3 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
-    R3 = mod_roster:get_roster_entry(ae(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alicE_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
     ok.
 
@@ -125,8 +125,7 @@ assert_state(Rentry, Subscription, Ask, Groups) ->
 subscription(Direction, Type) ->
     LBob = jid:to_lower(jid:from_binary(bob())),
     TFun = fun() -> mod_roster:process_subscription_transaction(Direction,
-                                                                a(),
-                                                                host(),
+                                                                alice_jid(),
                                                                 LBob,
                                                                 Type,
                                                                 <<"">>)
@@ -165,6 +164,12 @@ delete_ets() ->
     catch ets:delete(local_config),
     catch ets:delete(mongoose_services),
     ok.
+
+alice_jid() ->
+    jid:make(a(), host(), <<>>).
+
+alicE_jid() ->
+    jid:make(ae(), host(), <<>>).
 
 a() -> <<"alice">>.
 ae() -> <<"alicE">>.


### PR DESCRIPTION
In line with https://github.com/esl/MongooseIM/pull/2582, here I continue removing a bit amount of extra stringprepping, this time from roster related functionality.

Actually the most tricky part was to reason what happens when `jid:make/3` returns `error`. Sometimes the old code was assuming that `jid:nameprep/1` or `jid:nodeprep/1` was not returning so, and it would crash on a pattern match somewhere with this assumption, so my new code assumes as well that `jid:make/3` will return a `#jid{}` record and fail in the same manner than old code anyway. When this assumption was not the case, I had to add some pattern-matching for `jid:make/3` returning error and not crash in such case.

For example we can try following `service_admin_extra_roster:add_roster_item/7`. It is a command, so it will take just a bunch of strings. After making jids for the local and the remote user, `ejabberd_auth:is_user_exists/2` would return false after stringprepping and matching on any error in `ejabberd_auth:does_user_exists/2`, hence my new `ejabberd_auth:is_user_exists/1` should pattern match on `jid:make/3` returning `error`. BUT, then, the old `service_admin_extra_roster:subscribe/8` passes the remote's user and server to `service_admin_extra_roster:build_roster_item/3`, which does `jid:to_binary(jid:make(U, S, <<"">>))`, and if `jid:make/3` returns an error, `jid:to_binary/1` would crash with a `function_clause` error. So I don't check for that and let the new `service_admin_extra_roster:build_roster_item/2` crash in the same way.

Same reasoning in `src/mongoose_client_api/mongoose_client_api_contacts.erl` for example.

By the way, in this same `service_admin_extra_roster:add_roster_item/7`, try following everything that could be called in the old implementation: we stringprep `LocalUser` I think like five times, and `User` (the remote) another two 😄 