### PR TITLE
Perf/ejabberd auth redundant stringprepping

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -155,7 +155,7 @@ admin_notify(Config) ->
     [Username2, _Server2, _Pass2] = escalus_users:get_usp(Config, UserSpec2),
     [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
 
-    rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+    rpc(mim(), ejabberd_auth, try_register, [make_jid(AdminU, AdminS), AdminP]),
     escalus:story(Config, [{admin, 1}], fun(Admin) ->
         escalus:create_users(Config, escalus:get_users([Name1, Name2])),
 
@@ -186,12 +186,12 @@ null_password(Config) ->
     {username, Name} = lists:keyfind(username, 1, Details),
     {server, Server} = lists:keyfind(server, 1, Details),
     escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Response),
-    false = rpc(mim(), ejabberd_auth, is_user_exists, [Name, Server]).
+    false = rpc(mim(), ejabberd_auth, is_user_exists, [make_jid(Name, Server)]).
 
 check_unregistered(Config) ->
     [{_, UserSpec}] = escalus_users:get_users([bob]),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),
-    false = rpc(mim(), ejabberd_auth, is_user_exists, [Username, Server]).
+    false = rpc(mim(), ejabberd_auth, is_user_exists, [make_jid(Username, Server)]).
 
 bad_request_registration_cancelation(Config) ->
 
@@ -361,7 +361,7 @@ bad_cancelation_stanza() ->
 user_exists(Name, Config) ->
     {Name, Client} = escalus_users:get_user_by_name(Name),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, Client),
-    rpc(mim(), ejabberd_auth, is_user_exists, [Username, Server]).
+    rpc(mim(), ejabberd_auth, is_user_exists, [make_jid(Username, Server)]).
 
 reload_mod_register_option(Config, Key, Value) ->
     Host = domain(),
@@ -386,4 +386,5 @@ watcher(Watcher) ->
 domain() ->
     ct:get_config({hosts, mim, domain}).
 
-			
+make_jid(U, S) ->
+    rpc(mim(), jid, make, [U, S, <<>>]).

--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -387,4 +387,4 @@ domain() ->
     ct:get_config({hosts, mim, domain}).
 
 make_jid(U, S) ->
-    rpc(mim(), jid, make, [U, S, <<>>]).
+    mongoose_helper:make_jid(U, S, <<>>).

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -206,7 +206,8 @@ end_per_testcase(delete_old_users, Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),
     lists:foreach(fun({_User, UserSpec}) ->
                 {Username, Domain, Pass} = get_user_data(UserSpec, Config),
-                rpc(mim(), ejabberd_auth, try_register, [Username, Domain, Pass])
+                JID = mongoose_helper:make_jid(Username, Domain, <<>>),
+                rpc(mim(), ejabberd_auth, try_register, [JID, Pass])
         end, Users),
     escalus:end_per_testcase(delete_old_users, Config);
 end_per_testcase(CaseName, Config) ->
@@ -1128,7 +1129,8 @@ set_last(User, Domain, TStamp) ->
 delete_users(Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),
     lists:foreach(fun({User, Domain}) ->
-                rpc(mim(), ejabberd_auth, remove_user, [User, Domain])
+                JID = mongoose_helper:make_jid(User, Domain, <<>>),
+                rpc(mim(), ejabberd_auth, remove_user, [JID])
         end, get_registered_users()).
 
 %%-----------------------------------------------------------------

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -236,8 +236,8 @@ verify_format(GroupName, {_User, Props}) ->
     Username = escalus_utils:jid_to_lower(proplists:get_value(username, Props)),
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
-
-    SPassword = rpc(mim(), ejabberd_auth, get_password, [Username, Server]),
+    JID = mongoose_helper:make_jid(Username, Server, <<>>),
+    SPassword = rpc(mim(), ejabberd_auth, get_password, [JID]),
     do_verify_format(GroupName, Password, SPassword).
 
 do_verify_format(login_scram, _Password, SPassword) ->

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2850,13 +2850,14 @@ check_user_exist(Config) ->
   %% when
   [{_, AdminSpec}] = escalus_users:get_users([admin]),
   [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
-  ok = rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+  JID = mongoose_helper:make_jid(AdminU, AdminS, <<>>),
+  ok = rpc(mim(), ejabberd_auth, try_register, [JID, AdminP]),
   %% admin user already registered
   true = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, AdminS]),
   false = rpc(mim(), ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
   false = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
   %% cleanup
-  ok = rpc(mim(), ejabberd_auth, remove_user, [AdminU, AdminS]).
+  ok = rpc(mim(), ejabberd_auth, remove_user, [JID]).
 
 %% This function supports only one device, one user.
 %% We don't send initial presence to avoid presence broadcasts between resources

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2853,9 +2853,9 @@ check_user_exist(Config) ->
   JID = mongoose_helper:make_jid(AdminU, AdminS, <<>>),
   ok = rpc(mim(), ejabberd_auth, try_register, [JID, AdminP]),
   %% admin user already registered
-  true = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, AdminS]),
-  false = rpc(mim(), ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
-  false = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
+  true = rpc(mim(), ejabberd_users, does_user_exist, [JID]),
+  false = rpc(mim(), ejabberd_users, does_user_exist, [mongoose_helper:make_jid(<<"fake-user">>, AdminS, <<>>)]),
+  false = rpc(mim(), ejabberd_users, does_user_exist, [mongoose_helper:make_jid(AdminU, <<"fake-domain">>, <<>>)]),
   %% cleanup
   ok = rpc(mim(), ejabberd_auth, remove_user, [JID]).
 

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -375,7 +375,8 @@ verify_format(GroupName, {_User, Props}) ->
     Username = escalus_utils:jid_to_lower(proplists:get_value(username, Props)),
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
-    SPassword = rpc(mim(), ejabberd_auth, get_password, [Username, Server]),
+    JID = mongoose_helper:make_jid(Username, Server, <<>>),
+    SPassword = rpc(mim(), ejabberd_auth, get_password, [JID]),
     do_verify_format(GroupName, Password, SPassword).
 
 do_verify_format(login_scram, _Password, SPassword) ->

--- a/include/mod_roster.hrl
+++ b/include/mod_roster.hrl
@@ -23,7 +23,7 @@
                  jid,
                  name = <<>>,
                  subscription = none :: both | from | to | none | remove,
-                 ask = none,
+                 ask = none :: subscribe | unsubscribe | in | out | both | none,
                  groups = [],
                  askmessage = <<>>,
                  xs = []}).

--- a/src/admin_extra/service_admin_extra_gdpr.erl
+++ b/src/admin_extra/service_admin_extra_gdpr.erl
@@ -25,9 +25,10 @@ commands() -> [
 
 -spec retrieve_all(jid:user(), jid:server(), Path :: binary()) -> ok | {error, Reason :: any()}.
 retrieve_all(Username, Domain, ResultFilePath) ->
-    case user_exists(Username, Domain) of
+    JID = jid:make(Username, Domain, <<>>),
+    case user_exists(JID) of
         true ->
-            DataFromModules = get_data_from_modules(Username, Domain),
+            DataFromModules = get_data_from_modules(JID),
             % The contract is that we create personal data files only when there are any items
             % returned for the data group.
             DataToWrite = lists:filter(fun({_, _, Items}) -> Items /= [] end, DataFromModules),
@@ -60,6 +61,10 @@ retrieve_all(Username, Domain, ResultFilePath) ->
 -spec get_data_from_modules(jid:user(), jid:server()) -> gdpr:personal_data().
 get_data_from_modules(Username, Domain) ->
     JID = jid:make(Username, Domain, <<>>),
+    get_data_from_modules(JID).
+
+-spec get_data_from_modules(jid:jid()) -> gdpr:personal_data().
+get_data_from_modules(JID) ->
     mongoose_hooks:get_personal_data(JID#jid.lserver, [], JID).
 
 -spec to_csv_file(CsvFilename :: binary(), gdpr:schema(), gdpr:entities(), file:name()) -> ok.
@@ -70,9 +75,9 @@ to_csv_file(Filename, DataSchema, DataRows, TmpDir) ->
     lists:foreach(fun(Row) -> csv_gen:row(File, Row) end, DataRows),
     file:close(File).
 
--spec user_exists(gdpr:username(), gdpr:domain()) -> boolean().
-user_exists(Username, Domain) ->
-    ejabberd_auth:is_user_exists(Username, Domain).
+-spec user_exists(jid:jid()) -> boolean().
+user_exists(JID) ->
+    ejabberd_auth:is_user_exists(JID).
 
 -spec make_tmp_dir() -> file:name().
 make_tmp_dir() ->

--- a/src/admin_extra/service_admin_extra_last.erl
+++ b/src/admin_extra/service_admin_extra_last.erl
@@ -61,11 +61,12 @@ commands() ->
 -spec set_last(jid:user(), jid:server(), _, _) -> {Res, string()} when
     Res :: ok | user_does_not_exist.
 set_last(User, Server, Timestamp, Status) ->
-    case ejabberd_auth:is_user_exists(User, Server) of
+    JID = jid:make(User, Server, <<>>),
+    case ejabberd_auth:is_user_exists(JID) of
         true ->
-            mod_last:store_last_info(jid:nodeprep(User), jid:nameprep(Server), Timestamp, Status),
-            {ok, io_lib:format("Last activity for user ~s@~s is set as ~B with status ~s",
-                               [User, Server, Timestamp, Status])};
+            mod_last:store_last_info(JID#jid.luser, JID#jid.lserver, Timestamp, Status),
+            {ok, io_lib:format("Last activity for user ~s is set as ~B with status ~s",
+                               [jid:to_binary(JID), Timestamp, Status])};
         false ->
             String = io_lib:format("User ~s@~s does not exist", [User, Server]),
             {user_does_not_exist, String}

--- a/src/admin_extra/service_admin_extra_sessions.erl
+++ b/src/admin_extra/service_admin_extra_sessions.erl
@@ -199,7 +199,7 @@ kick_session(User, Server, Resource, ReasonText) ->
         Reason :: binary()) -> mongoose_acc:t().
 kick_this_session(User, Server, Resource, Reason) ->
     ejabberd_sm:route(
-        jid:make(<<"">>, <<"">>, <<"">>),
+        jid:make_noprep(<<>>, <<>>, <<>>),
         jid:make(User, Server, Resource),
         {broadcast, {exit, Reason}}).
 

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -46,6 +46,7 @@
          get_password_s/2,
          get_passterm_with_authmodule/2,
          does_user_exist/1,
+         is_user_exists/1,
          is_user_exists/2,
          is_user_exists_in_other_modules/3,
          remove_user/2,
@@ -462,6 +463,14 @@ do_get_passterm_with_authmodule(LUser, LServer) ->
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
+-spec is_user_exists(JID :: jid:jid()) -> boolean().
+is_user_exists(#jid{luser = <<>>}) ->
+    false;
+is_user_exists(#jid{luser = LUser, lserver = LServer}) ->
+    do_does_user_exist(LUser, LServer);
+is_user_exists(error) ->
+    false.
+
 -spec is_user_exists(User :: jid:user(),
                      Server :: jid:server()) -> boolean().
 is_user_exists(<<"">>, _) ->
@@ -472,8 +481,7 @@ is_user_exists(User, Server) ->
     do_does_user_exist(LUser, LServer).
 
 -spec does_user_exist(JID :: jid:jid()) -> boolean().
-does_user_exist(JID) ->
-    #jid{luser = LUser, lserver = LServer} = JID,
+does_user_exist(#jid{luser = LUser, lserver = LServer}) ->
     do_does_user_exist(LUser, LServer).
 
 do_does_user_exist(LUser, LServer) when LUser =:= error; LServer =:= error ->

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -220,9 +220,9 @@ check_password(LUser, LServer, Password) ->
 check_password(LUser, LServer, _Password, _Digest, _DigestGen) ->
     %% We refuse login for registered accounts (They cannot logged but
     %% they however are "reserved")
-    case ejabberd_auth:is_user_exists_in_other_modules(?MODULE,
-                                                       LUser, LServer) of
-        %% If user exists in other module, reject anonymous authentication
+    case ejabberd_auth:is_user_exists_in_other_modules(
+           ?MODULE, jid:make_noprep(LUser, LServer, <<>>)) of
+        %% If user exists in other module, reject anonnymous authentication
         true  -> false;
         %% If we are not sure whether the user exists in other module, reject anon auth
         maybe  -> false;

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -331,7 +331,7 @@ register(Host, Password) ->
                                       | {'exists', io_lib:chars()}
                                       | {'ok', io_lib:chars()}.
 register(User, Host, Password) ->
-    case ejabberd_auth:try_register(User, Host, Password) of
+    case ejabberd_auth:try_register(jid:make(User, Host, <<>>), Password) of
         {error, exists} ->
             String = io_lib:format("User ~s@~s already registered at node ~p",
                                    [User, Host, node()]),
@@ -353,7 +353,7 @@ generate_user() ->
 -spec unregister(User :: jid:user(),
                  Host :: jid:server()) -> {'ok', []}.
 unregister(User, Host) ->
-    ejabberd_auth:remove_user(User, Host),
+    ejabberd_auth:remove_user(jid:make(User, Host, <<>>)),
     {ok, ""}.
 
 -spec registered_users(Host :: jid:server()) -> [jid:user()].
@@ -435,7 +435,7 @@ registrator_proc(Manager, Result) ->
                                  {null_password, jid:user()} |
                                  {bad_csv, binary()}.
 do_register([User, Host, Password]) ->
-    case ejabberd_auth:try_register(User, Host, Password) of
+    case ejabberd_auth:try_register(jid:make(User, Host, <<>>), Password) of
         {error, Reason} -> {Reason, User};
         _ -> {ok, User}
     end;

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -323,7 +323,7 @@ stream_start_negotiate_features(#state{} = S) ->
     end.
 
 stream_start_features_before_auth(#state{server = Server} = S) ->
-    Creds = maybe_add_cert(mongoose_credentials:new(Server), S),
+    Creds = maybe_add_cert(mongoose_credentials:new_from_stringprepped(Server), S),
     SASLState = cyrsasl:server_new(<<"jabber">>, Server, <<>>, [], Creds),
     SockMod = (S#state.sockmod):get_sockmod(S#state.socket),
     send_element_from_server_jid(S, stream_features(determine_features(SockMod, S))),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2383,8 +2383,8 @@ process_unauthenticated_stanza(StateData, El) ->
                     ResIQ = IQ#iq{type = error,
                                   sub_el = [mongoose_xmpp_errors:service_unavailable()]},
                     Res1 = jlib:replace_from_to(
-                             jid:make(<<>>, StateData#state.server, <<>>),
-                             jid:make(<<>>, <<>>, <<>>),
+                             jid:make_noprep(<<>>, StateData#state.server, <<>>),
+                             jid:make_noprep(<<>>, <<>>, <<>>),
                              jlib:iq_to_xml(ResIQ)),
                     send_element_from_server_jid(StateData, jlib:remove_attr(<<"to">>, Res1));
                 _ ->

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -414,7 +414,7 @@ check_access_commands(AccessCommands, Auth, Method, Command, Arguments) ->
 -spec check_auth(auth()) -> {ok, User :: binary(), Server :: binary()} | no_return().
 check_auth({User, Server, Password}) ->
     %% Check the account exists and password is valid
-    AccountPass = ejabberd_auth:get_password_s(User, Server),
+    AccountPass = ejabberd_auth:get_password_s(jid:make(User, Server, <<>>)),
     AccountPassMD5 = get_md5(AccountPass),
     case Password of
         AccountPass -> {ok, User, Server};

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -315,7 +315,7 @@ remove_info(JID, Key) ->
       Type :: any(),
       Reason :: any().
 check_in_subscription(Acc, User, Server, _JID, _Type, _Reason) ->
-    case ejabberd_auth:is_user_exists(User, Server) of
+    case ejabberd_auth:is_user_exists(jid:make(User, Server, <<>>)) of
         true ->
             Acc;
         false ->

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -71,7 +71,7 @@ start_link(ProcName, Host) ->
 
 
 -spec does_user_exist(LUser :: jid:luser(),
-                     LServer :: jid:lserver() | string()) -> boolean().
+                      LServer :: jid:lserver() | string()) -> boolean().
 does_user_exist(LUser, LServer) ->
     case does_cached_user_exist(LUser, LServer) of
         true -> true;
@@ -173,7 +173,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 -spec does_stored_user_exist(jid:luser(), jid:lserver()) -> boolean().
 does_stored_user_exist(LUser, LServer) ->
-    ejabberd_auth:is_user_exists(LUser, LServer)
+    ejabberd_auth:is_user_exists(jid:make(LUser, LServer, <<>>))
     andalso not is_anonymous_user(LUser, LServer).
 
 

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -78,8 +78,8 @@ publish_notification(Acc, _, Payload, Services) ->
 %%--------------------------------------------------------------------
 
 -spec should_publish(To :: jid:jid()) -> boolean().
-should_publish(#jid{luser = LUser, lserver = LServer} = To) ->
-    try ejabberd_users:does_user_exist(LUser, LServer) of
+should_publish(#jid{} = To) ->
+    try ejabberd_users:does_user_exist(To) of
         false ->
             false;
         true ->
@@ -146,10 +146,10 @@ publish_via_pubsub(Host, To, {PubsubJID, Node, Form}, PushPayload) ->
                               to_jid => PubsubJID }),
 
     ResponseHandler =
-    fun(_From, _To, Acc, Response) ->
+    fun(_From, _To, FAcc, Response) ->
             mod_event_pusher_push:cast(Host, fun handle_publish_response/4,
                                        [To, PubsubJID, Node, Response]),
-            Acc
+            FAcc
     end,
     %% The IQ is routed from the recipient's server JID to pubsub JID
     %% This is recommended in the XEP and also helps process replies to this IQ

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -272,9 +272,9 @@ maybe_process_message(Host, From, To, Msg, Dir) ->
                          To :: jid:jid(),
                          Dir :: outgoing | incoming) -> boolean().
 inbox_owner_exists(From, _To, outgoing) ->
-    ejabberd_users:does_user_exist(From#jid.luser, From#jid.lserver);
+    ejabberd_users:does_user_exist(From);
 inbox_owner_exists(_From, To, incoming) ->
-    ejabberd_users:does_user_exist(To#jid.luser, To#jid.lserver).
+    ejabberd_users:does_user_exist(To).
 
 maybe_process_acceptable_message(Host, From, To, Msg, Dir, one2one) ->
             process_message(Host, From, To, Msg, Dir, one2one);

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -70,7 +70,7 @@
 % Maximum JID size in octets (bytes) as defined in
 % https://tools.ietf.org/html/rfc7622#section-3.1
 
--spec make(User :: user(), Server :: server(), Res :: resource()) -> jid()  | error.
+-spec make(User :: user(), Server :: server(), Res :: resource()) -> jid() | error.
 make(User, Server, Res) ->
     case {nodeprep(User), nameprep(Server), resourceprep(Res)} of
         {error, _, _} -> error;

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -292,12 +292,12 @@ user_send_packet(Acc, From, To, Packet) ->
 -spec filter_packet(Value :: fpacket() | drop) -> fpacket() | drop.
 filter_packet(drop) ->
     drop;
-filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Acc, Packet}) ->
+filter_packet({From, To=#jid{lserver=LServer}, Acc, Packet}) ->
     % let them to their amp-related mambo jumbo on stanza
     ?DEBUG("Receive packet~n    from ~p ~n    to ~p~n    packet ~p.",
            [From, To, Packet]),
     {AmpEvent, PacketAfterArchive} =
-        case ejabberd_users:does_user_exist(LUser, LServer) of
+        case ejabberd_users:does_user_exist(To) of
             false ->
                 {mam_failed, Packet};
             true ->

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -461,10 +461,10 @@ handle_get_message_form(_From=#jid{lserver = Host}, _ArcJID=#jid{}, IQ=#iq{}) ->
 
 determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
                        FromJID, ToJID, Packet, initial_check) ->
-    #jid{luser = LUser, lserver = LServer} = ToJID,
+    #jid{lserver = LServer} = ToJID,
     ShouldBeStored = is_archivable_message(LServer, incoming, Packet)
         andalso is_interesting(ToJID, FromJID)
-        andalso ejabberd_auth:is_user_exists(LUser, LServer),
+        andalso ejabberd_auth:is_user_exists(ToJID),
     case ShouldBeStored of
         true -> Strategy#amp_strategy{deliver = [stored, none]};
         false -> Strategy

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -227,7 +227,7 @@ commands() ->
 kick_session(Host, User, Resource) ->
     J = jid:make(User, Host, Resource),
     ejabberd_sm:route(
-      jid:make(<<"">>, <<"">>, <<"">>),
+      jid:make_noprep(<<>>, <<>>, <<>>),
       J,
       {broadcast, {exit, <<"kicked">>}}),
     <<"kicked">>.
@@ -324,8 +324,8 @@ delete_contact(Caller, JabberID) ->
 
 -spec jid_exists(binary(), binary()) -> boolean().
 jid_exists(CJid, Jid) ->
-    FJid = jid:from_binary(CJid),
-    Res = mod_roster:get_roster_entry(FJid#jid.luser, FJid#jid.lserver, Jid),
+    #jid{} = FJid = jid:from_binary(CJid),
+    Res = mod_roster:get_roster_entry(FJid, Jid),
     Res =/= does_not_exist.
 
 registered_commands() ->

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -380,10 +380,10 @@ get_sm_items(empty, From, To, _Node, _Lang) ->
 
 
 -spec is_presence_subscribed(jid:jid(), jid:jid()) -> boolean().
-is_presence_subscribed(#jid{luser=User, lserver=Server} = From,
-                       #jid{luser=LUser, lserver=LServer} = _To) ->
+is_presence_subscribed(#jid{luser = User, lserver = Server} = _From,
+                       #jid{luser = LUser, lserver = LServer} = _To) ->
     A = mongoose_acc:new(#{ location => ?LOCATION,
-                            lserver => From#jid.lserver,
+                            lserver => Server,
                             element => undefined }),
     A2 = mongoose_hooks:roster_get(Server, A, User, Server),
     Roster = mongoose_acc:get(roster, items, [], A2),
@@ -430,8 +430,8 @@ process_sm_iq_info(From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl} =
                       To :: jid:jid(),
                       Node :: binary(),
                       Lang :: ejabberd:lang()) -> [exml:element()].
-get_sm_identity(Acc, _From, #jid{luser = LUser, lserver = LServer}, _Node, _Lang) ->
-    Acc ++ case ejabberd_auth:is_user_exists(LUser, LServer) of
+get_sm_identity(Acc, _From, #jid{} = UserJID, _Node, _Lang) ->
+    Acc ++ case ejabberd_auth:is_user_exists(UserJID) of
                true ->
                    [#xmlel{name = <<"identity">>,
                            attrs = [{<<"category">>, <<"account">>},

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -198,13 +198,13 @@ process_iq_get(From, _To, #iq{lang = Lang, sub_el = Child} = IQ, _Source) ->
     true = is_query_element(Child),
     {_IsRegistered, UsernameSubels, QuerySubels} =
     case From of
-        #jid{luser = LUser} ->
+        #jid{user = User} ->
                 case ejabberd_auth:is_user_exists(From) of
                     true ->
-                        {true, [#xmlcdata{content = LUser}],
+                        {true, [#xmlcdata{content = User}],
                          [#xmlel{name = <<"registered">>}]};
                     false ->
-                        {false, [#xmlcdata{content = LUser}], []}
+                        {false, [#xmlcdata{content = User}], []}
                 end;
             _ ->
                 {false, [], []}

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -46,15 +46,13 @@
          process_local_iq/4,
          get_user_roster/2,
          get_subscription_lists/3,
+         get_roster_entry/2,
          get_roster_entry/3,
-         get_roster_entry/4,
-         get_roster_entry_t/3,
-         get_roster_entry_t/4,
          get_roster/2,
          item_to_map/1,
          in_subscription/6,
          out_subscription/5,
-         set_items/3,
+         set_items/2,
          set_roster_entry/4,
          remove_user/2, % for tests
          remove_user/3,
@@ -68,7 +66,7 @@
 
 -export([remove_test_user/2,
          transaction/2,
-         process_subscription_transaction/6,
+         process_subscription_transaction/5,
          get_user_rosters_length/2]). % for testing
 
 -export([get_personal_data/2]).
@@ -226,18 +224,14 @@ hooks(Host) ->
      {roster_get_versioning_feature, Host, ?MODULE, get_versioning_feature, 50},
      {get_personal_data, Host, ?MODULE, get_personal_data, 50}].
 
-get_roster_entry(LUser, LServer, Jid) ->
-    mod_roster_backend:get_roster_entry(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid)).
+get_roster_entry(#jid{luser = LUser, lserver = LServer}, Jid) ->
+    mod_roster_backend:get_roster_entry(LUser, LServer, jid_arg_to_lower(Jid)).
 
-get_roster_entry(LUser, LServer, Jid, full) ->
-    mod_roster_backend:get_roster_entry(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid), full).
+get_roster_entry(#jid{luser = LUser, lserver = LServer}, Jid, full) ->
+    mod_roster_backend:get_roster_entry(LUser, LServer, jid_arg_to_lower(Jid), full).
 
-get_roster_entry_t(LUser, LServer, Jid) ->
-    mod_roster_backend:get_roster_entry_t(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid)).
-
-get_roster_entry_t(LUser, LServer, Jid, full) ->
-    mod_roster_backend:get_roster_entry_t(jid:nameprep(LUser), LServer,
-                                          jid_arg_to_lower(Jid), full).
+get_roster_entry_t(#jid{luser = LUser, lserver = LServer}, Jid, full) ->
+    mod_roster_backend:get_roster_entry_t(LUser, LServer, jid_arg_to_lower(Jid), full).
 
 -spec jid_arg_to_lower(JID :: jid:simple_jid() | jid:jid() | binary()) ->
     error | jid:simple_jid().
@@ -461,29 +455,24 @@ process_item_set(_From, _To, _) -> ok.
 
 -spec do_process_item_set(error | jid:jid(), jid:jid(), jid:jid(), exml:element()) -> ok.
 do_process_item_set(error, _, _, _) -> ok;
-do_process_item_set(JID1,
-                    #jid{user = User, luser = LUser, lserver = LServer} = From,
-                    To,
+do_process_item_set(#jid{} = JID1, #jid{} = From, #jid{} = To,
                     #xmlel{attrs = Attrs, children = Els}) ->
-    LJID = jid:to_lower(JID1),
     MakeItem2 = fun(Item) ->
                     Item1 = process_item_attrs(Item, Attrs),
                     process_item_els(Item1, Els)
                 end,
-    set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2).
+    set_roster_item(JID1, From, To, MakeItem2).
 
 %% @doc this is run when a roster item is to be added, updated or removed
 %% the interface of this func could probably be a bit simpler
--spec set_roster_item(User :: binary(),
-                      LUser :: binary(),
-                      LServer :: binary(),
-                      LJID :: jid:simple_jid() | error,
-                      From ::jid:jid(),
-                      To ::jid:jid(),
+-spec set_roster_item(JID1 :: jid:jid(),
+                      From :: jid:jid(),
+                      To :: jid:jid(),
                       MakeItem2 :: fun( (roster()) -> roster())) -> ok.
-set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2) ->
+set_roster_item(JID1, #jid{luser = LUser, lserver = LServer} = From, To, MakeItem2) ->
+    LJID = jid:to_lower(JID1),
     F = fun () ->
-                Item = case get_roster_entry(LUser, LServer, LJID) of
+                Item = case get_roster_entry(From, LJID) of
                            does_not_exist ->
                                #roster{usj = {LUser, LServer, LJID},
                                        us = {LUser, LServer},
@@ -505,7 +494,7 @@ set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2) ->
         end,
     case transaction(LServer, F) of
         {atomic, {OldItem, NewItem}} ->
-            push_item(User, LServer, To, NewItem),
+            push_item(From, To, NewItem),
             case NewItem#roster.subscription of
                 remove ->
                     send_unsubscribing_presence(From, OldItem), ok;
@@ -553,26 +542,30 @@ process_item_els(Item, [{xmlcdata, _} | Els]) ->
     process_item_els(Item, Els);
 process_item_els(Item, []) -> Item.
 
-push_item(User, Server, From, Item) ->
-    #jid{luser = LUser} = JID = jid:make(User, Server, <<"">>),
-    ejabberd_sm:route(jid:make(<<"">>, <<"">>, <<"">>), JID,
+push_item(#jid{luser = LUser, lserver = LServer} = JID, From, Item) ->
+    ejabberd_sm:route(jid:make_noprep(<<>>, <<>>, <<>>), JID,
                       {broadcast, {item, Item#roster.jid, Item#roster.subscription}}),
-    case roster_versioning_enabled(Server) of
+    case roster_versioning_enabled(LServer) of
         true ->
-            push_item_version(JID, Server, User, From, Item,
-                              roster_version(Server, LUser));
+            push_item_version(JID, From, Item, roster_version(LServer, LUser));
         false ->
-            lists:foreach(fun (Resource) ->
-                                  push_item(User, Server, Resource, From, Item)
+            lists:foreach(fun(Resource) ->
+                                  push_item_without_version(JID, Resource, From, Item)
                           end,
                           ejabberd_sm:get_user_resources(JID))
     end.
 
-push_item(User, Server, Resource, From, Item) ->
+push_item_without_version(#jid{lserver = Server} = JID, Resource, From, Item) ->
     mongoose_hooks:roster_push(Server, ok, From, Item),
-    push_item(User, Server, Resource, From, Item, not_found).
+    push_item_final(jid:replace_resource(JID, Resource), From, Item, not_found).
 
-push_item(User, Server, Resource, From, Item, RosterVersion) ->
+push_item_version(JID, From, Item, RosterVersion) ->
+    lists:foreach(fun (Resource) ->
+                          push_item_final(jid:replace_resource(JID, Resource), From, Item, RosterVersion)
+                  end,
+                  ejabberd_sm:get_user_resources(JID)).
+
+push_item_final(JID, From, Item, RosterVersion) ->
     ExtraAttrs = case RosterVersion of
                      not_found -> [];
                      _ -> [{<<"ver">>, RosterVersion}]
@@ -585,26 +578,14 @@ push_item(User, Server, Resource, From, Item, RosterVersion) ->
                 [#xmlel{name = <<"query">>,
                         attrs = [{<<"xmlns">>, ?NS_ROSTER} | ExtraAttrs],
                         children = [item_to_xml(Item)]}]},
-    ejabberd_router:route(From,
-                          jid:make(User, Server, Resource),
-                          jlib:iq_to_xml(ResIQ)).
-
-push_item_version(JID, Server, User, From, Item,
-                  RosterVersion) ->
-    lists:foreach(fun (Resource) ->
-                          push_item(User, Server, Resource, From, Item,
-                                    RosterVersion)
-                  end,
-                  ejabberd_sm:get_user_resources(JID)).
+    ejabberd_router:route(From, JID, jlib:iq_to_xml(ResIQ)).
 
 -spec get_subscription_lists(Acc :: mongoose_acc:t(),
                              User :: binary(),
                              Server :: binary()) -> mongoose_acc:t().
 get_subscription_lists(Acc, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
+    #jid{luser = LUser, lserver = LServer} = JID = jid:make(User, Server, <<>>),
     Items = mod_roster_backend:get_subscription_lists(Acc, LUser, LServer),
-    JID = jid:make(User, Server, <<>>),
     SubLists = fill_subscription_lists(JID, LServer, Items, [], [], []),
     mongoose_acc:set(roster, subscription_lists, SubLists, Acc).
 
@@ -683,11 +664,11 @@ out_subscription(Acc, User, Server, JID, Type) ->
     mongoose_acc:set(hook, result, Res, Acc).
 
 process_subscription(Direction, User, Server, JID1, Type, Reason) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
+    JID = jid:make(User, Server, <<>>),
+    LServer = case JID of #jid{lserver = LS} -> LS; error -> error end,
     LJID = jid:to_lower(JID1),
-    TransactionFun = fun() -> process_subscription_transaction(Direction, LUser, LServer,
-                                                               LJID, Type, Reason) end,
+    TransactionFun =
+        fun() -> process_subscription_transaction(Direction, JID, LJID, Type, Reason) end,
     case transaction(LServer, TransactionFun) of
         {atomic, {Push, AutoReply}} ->
             case AutoReply of
@@ -696,13 +677,13 @@ process_subscription(Direction, User, Server, JID1, Type, Reason) ->
                     PresenceStanza = #xmlel{name = <<"presence">>,
                                             attrs = [{<<"type">>, autoreply_to_type(AutoReply)}],
                                             children = []},
-                    ejabberd_router:route(jid:make(User, Server, <<"">>), JID1, PresenceStanza)
+                    ejabberd_router:route(JID, JID1, PresenceStanza)
             end,
             case Push of
                 {push, #roster{ subscription = none, ask = in }} ->
                     true;
                 {push, Item} ->
-                    push_item(User, Server, jid:make(User, Server, <<"">>), Item),
+                    push_item(JID, JID, Item),
                     true;
                 none -> false
             end;
@@ -712,11 +693,13 @@ process_subscription(Direction, User, Server, JID1, Type, Reason) ->
 autoreply_to_type(subscribed) -> <<"subscribed">>;
 autoreply_to_type(unsubscribed) -> <<"unsubscribed">>.
 
-process_subscription_transaction(Direction, LUser, LServer, LJID, Type, Reason) ->
-    Item = case mod_roster_backend:get_roster_entry_t(LUser, LServer, LJID, full) of
+process_subscription_transaction(Direction, JID, LJID, Type, Reason) ->
+    #jid{luser = LUser, lserver = LServer} = JID,
+    Item = case get_roster_entry_t(JID, LJID, full) of
                does_not_exist ->
                    #roster{usj = {LUser, LServer, LJID},
-                       us = {LUser, LServer}, jid = LJID};
+                           us = {LUser, LServer},
+                           jid = LJID};
                R -> R
            end,
     NewState = case Direction of
@@ -867,21 +850,24 @@ get_user_rosters_length(User, Server) ->
 
 %% Used only by tests
 remove_user(User, Server) ->
-    Acc = mongoose_acc:new(#{ location => ?LOCATION,
-                              lserver => <<_/binary>> = jid:nameprep(Server),
-                              element => undefined }),
+    Acc = mongoose_acc:new(#{location => ?LOCATION,
+                             lserver => <<_/binary>> = jid:nameprep(Server),
+                             element => undefined}),
     remove_user(Acc, User, Server).
 
 remove_user(Acc, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    Acc1 = try_send_unsubscription_to_rosteritems(Acc, LUser, LServer),
-    mod_roster_backend:remove_user(LUser, LServer),
-    Acc1.
+    case jid:make(User, Server, <<>>) of
+        #jid{luser = LUser, lserver = LServer} = JID ->
+            Acc1 = try_send_unsubscription_to_rosteritems(Acc, JID),
+            mod_roster_backend:remove_user(LUser, LServer),
+            Acc1;
+        error ->
+            Acc
+    end.
 
-try_send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
+try_send_unsubscription_to_rosteritems(Acc, JID) ->
     try
-        send_unsubscription_to_rosteritems(Acc, LUser, LServer)
+        send_unsubscription_to_rosteritems(Acc, JID)
     catch
         E:R:S ->
             ?WARNING_MSG("event=cannot_send_unsubscription_to_rosteritems,"
@@ -892,14 +878,13 @@ try_send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
 %% For each contact with Subscription:
 %% Both or From, send a "unsubscribed" presence stanza;
 %% Both or To, send a "unsubscribe" presence stanza.
-send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
+send_unsubscription_to_rosteritems(Acc, JID) ->
+    #jid{luser = LUser, lserver = LServer} = JID,
     Acc1 = get_user_roster(Acc, {LUser, LServer}),
     RosterItems = mongoose_acc:get(roster, items, [], Acc1),
-    From = jid:make({LUser, LServer, <<"">>}),
-    lists:foreach(fun (RosterItem) ->
-                          send_unsubscribing_presence(From, RosterItem)
-                  end,
-                  RosterItems),
+    lists:foreach(fun(RosterItem) ->
+                          send_unsubscribing_presence(JID, RosterItem)
+                  end, RosterItems),
     Acc1.
 
 %% @spec (From::jid(), Item::roster()) -> any()
@@ -924,15 +909,12 @@ send_presence_type(From, To, Type) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-set_items(User, Server, SubEl) ->
+set_items(#jid{luser = LUser, lserver = LServer}, SubEl) ->
     #xmlel{children = Els} = SubEl,
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
     F = fun () ->
-                lists:foreach(fun (El) ->
+                lists:foreach(fun(El) ->
                                       process_item_set_t(LUser, LServer, El)
-                              end,
-                              Els)
+                              end, Els)
         end,
     transaction(LServer, F).
 
@@ -947,25 +929,13 @@ set_roster_entry(UserJid, ContactBin, Name, Groups) ->
                        Groups :: [binary()] | unchanged,
                        NewSubscription :: remove | unchanged) -> ok|error.
 set_roster_entry(UserJid, ContactBin, Name, Groups, NewSubscription) ->
-    LUser = UserJid#jid.luser,
-    LServer = UserJid#jid.lserver,
-    JID1 = jid:from_binary(ContactBin),
-    case JID1 of
+    case jid:from_binary(ContactBin) of
         error -> error;
-        _ ->
-            LJID = jid:to_lower(JID1),
+        JID1 ->
             MakeItem = fun(Item) ->
-                            modify_roster_item(Item, Name, Groups, NewSubscription)
-                        end,
-            set_roster_item(
-                LUser, % User
-                LUser, % LUser
-                LServer, % LServer
-                LJID, % LJID
-                UserJid, % From
-                UserJid, % To
-                MakeItem
-            )
+                               modify_roster_item(Item, Name, Groups, NewSubscription)
+                       end,
+            set_roster_item(JID1, UserJid, UserJid, MakeItem)
     end.
 
 modify_roster_item(Item, Name, Groups, NewSubscription) ->
@@ -1048,11 +1018,12 @@ process_item_attrs_ws(Item, []) ->
                    Server :: jid:lserver(),
                    JID ::jid:jid() | jid:ljid()) -> {subscription_state(), [binary()]}.
 get_jid_info(_, User, Server, JID) ->
-    case get_roster_entry(User, Server, JID, full) of
+    ToJID = jid:make(User, Server, <<>>),
+    case get_roster_entry(ToJID, JID, full) of
         error -> {none, []};
         does_not_exist ->
             LRJID = jid:to_bare(jid:to_lower(JID)),
-            case get_roster_entry(User, Server, LRJID, full) of
+            case get_roster_entry(ToJID, LRJID, full) of
                 error -> {none, []};
                 does_not_exist -> {none, []};
                 R -> {R#roster.subscription, R#roster.groups}

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -411,7 +411,7 @@ search_group_info(State, Group) ->
                         end
                 end,
     AuthChecker = case State#state.auth_check of
-                      true -> fun ejabberd_auth:is_user_exists/2;
+                      true -> fun(U, S) -> ejabberd_auth:is_user_exists(jid:make(U, S, <<>>)) end;
                       _ -> fun (_U, _S) -> true end
                   end,
     Host = State#state.host,

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -129,7 +129,7 @@
 %%--------------------------------------------------------------------
 
 -spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ luser = LUser, lserver = LServer }) ->
+get_personal_data(Acc, #jid{luser = LUser, lserver = LServer}) ->
     Jid = jid:to_binary({LUser, LServer}),
     Schema = ["jid", "vcard"],
     Entries = case mod_vcard_backend:get_vcard(LUser, LServer) of

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -148,7 +148,7 @@ get_vcard(LUser, LServer) ->
     Proc = gen_mod:get_module_proc(LServer, ?PROCNAME),
     {ok, State} = gen_server:call(Proc, get_state),
     LServer = State#state.serverhost,
-    case ejabberd_auth:is_user_exists(LUser, LServer) of
+    case ejabberd_auth:is_user_exists(jid:make_noprep(LUser, LServer, <<>>)) of
         true ->
             VCardMap = State#state.vcard_map,
             case find_ldap_user(LUser, State) of
@@ -408,7 +408,7 @@ attrs_to_item_xml(Attrs, #state{uids = UIDs} = State) ->
 make_user_item_if_exists(Username, Attrs,
                          #state{serverhost = LServer, search_reported = SearchReported,
                                 vcard_map = VCardMap, binary_search_fields = BinFields}) ->
-    case ejabberd_auth:is_user_exists(Username, LServer) of
+    case ejabberd_auth:is_user_exists(jid:make(Username, LServer, <<>>)) of
         true ->
             RFields = lists:map(fun ({_, VCardName}) ->
                                         {VCardName, map_vcard_attr(VCardName, Attrs, VCardMap,

--- a/src/mongoose_api_client.erl
+++ b/src/mongoose_api_client.erl
@@ -30,7 +30,6 @@
 
 -import(mongoose_api_common, [action_to_method/1,
                               method_to_action/1,
-                              error_code/1,
                               process_request/4,
                               error_response/4,
                               parse_request_body/1]).
@@ -153,9 +152,8 @@ do_authorize({basic, User, Password}, Req, State) ->
 do_authorize(_, Req, State) ->
     make_unauthorized_response(Req, State).
 
-do_check_password(#jid{luser = User, lserver = Server} = JID,
-    Password, Req, State) ->
-    case ejabberd_auth:check_password(User, Server, Password) of
+do_check_password(#jid{} = JID, Password, Req, State) ->
+    case ejabberd_auth:check_password(JID, Password) of
         true ->
             {true, Req, State#http_api_state{entity = jid:to_binary(JID)}};
         _ ->

--- a/src/mongoose_api_users.erl
+++ b/src/mongoose_api_users.erl
@@ -82,9 +82,10 @@ put_user(Data, Bindings) ->
 delete_user(Bindings) ->
     Host = gen_mod:get_opt(host, Bindings),
     Username = gen_mod:get_opt(username, Bindings),
-    case ejabberd_auth:is_user_exists(Username, Host) of
+    JID = jid:make(Username, Host, <<>>),
+    case ejabberd_auth:is_user_exists(JID) of
         true ->
-            maybe_delete_user(Username, Host);
+            maybe_delete_user(JID);
         false ->
             {error, not_found}
     end.
@@ -93,25 +94,26 @@ delete_user(Bindings) ->
 %% internal functions
 %%--------------------------------------------------------------------
 maybe_register_user(Username, Host, Password) ->
-    case ejabberd_auth:try_register(Username, Host, Password) of
+    JID = jid:make(Username, Host, <<>>),
+    case ejabberd_auth:try_register(JID, Password) of
         {error, not_allowed} ->
             ?ERROR;
         {error, exists} ->
-            maybe_change_password(Username, Host, Password);
+            maybe_change_password(JID, Password);
         _ ->
             ok
     end.
 
-maybe_change_password(Username, Host, Password) ->
-    case ejabberd_auth:set_password(Username, Host, Password) of
+maybe_change_password(JID, Password) ->
+    case ejabberd_auth:set_password(JID, Password) of
         {error, _} ->
             ?ERROR;
         ok ->
             ok
     end.
 
-maybe_delete_user(Username, Host) ->
-    case ejabberd_auth:remove_user(Username, Host) of
+maybe_delete_user(JID) ->
+    case ejabberd_auth:remove_user(JID) of
         ok ->
             ok;
         _ ->

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -115,7 +115,7 @@ check_password(<<>>, _) ->
     false;
 check_password(User, Password) ->
     #jid{luser = RawUser, lserver = Server} = jid:from_binary(User),
-    Creds0 = mongoose_credentials:new(Server),
+    Creds0 = mongoose_credentials:new_from_stringprepped(Server),
     Creds1 = mongoose_credentials:set(Creds0, username, RawUser),
     Creds2 = mongoose_credentials:set(Creds1, password, Password),
     case ejabberd_auth:authorize(Creds2) of

--- a/src/mongoose_client_api/mongoose_client_api_contacts.erl
+++ b/src/mongoose_client_api/mongoose_client_api_contacts.erl
@@ -191,6 +191,6 @@ to_binary(S) ->
 
 -spec jid_exists(binary(), binary()) -> boolean().
 jid_exists(CJid, Jid) ->
-    FJid = jid:from_binary(CJid),
-    Res = mod_roster:get_roster_entry(FJid#jid.luser, FJid#jid.lserver, Jid),
+    #jid{} = FJid = jid:from_binary(CJid),
+    Res = mod_roster:get_roster_entry(FJid, Jid),
     Res =/= does_not_exist.

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -1,6 +1,7 @@
 -module(mongoose_credentials).
 
 -export([new/1,
+         new_from_stringprepped/1,
          lserver/1,
          get/2, get/3,
          set/3,
@@ -29,6 +30,9 @@ new(Server) ->
         LServer when is_binary(LServer) ->
             #mongoose_credentials{lserver = LServer}
     end.
+
+new_from_stringprepped(LServer) when is_binary(LServer) ->
+    #mongoose_credentials{lserver = LServer}.
 
 -spec lserver(t()) -> jid:lserver().
 lserver(#mongoose_credentials{lserver = S}) -> S.

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -31,6 +31,7 @@ new(Server) ->
             #mongoose_credentials{lserver = LServer}
     end.
 
+-spec new_from_stringprepped(jid:lserver()) -> mongoose_credentials:t().
 new_from_stringprepped(LServer) when is_binary(LServer) ->
     #mongoose_credentials{lserver = LServer}.
 

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -254,9 +254,8 @@ srv_name(Host) ->
     gen_mod:get_module_proc(Host, srv_name()).
 
 determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
-                       _FromJID, ToJID, _Packet, initial_check) ->
-    ShouldBeStored = ejabberd_auth:is_user_exists(ToJID),
-    case ShouldBeStored of
+                       _FromJID, #jid{} = ToJID, _Packet, initial_check) ->
+    case ejabberd_auth:is_user_exists(ToJID) of
         true -> Strategy#amp_strategy{deliver = [stored, none]};
         false -> Strategy
     end;

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -255,8 +255,7 @@ srv_name(Host) ->
 
 determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
                        _FromJID, ToJID, _Packet, initial_check) ->
-    #jid{luser = LUser, lserver = LServer} = ToJID,
-    ShouldBeStored = ejabberd_auth:is_user_exists(LUser, LServer),
+    ShouldBeStored = ejabberd_auth:is_user_exists(ToJID),
     case ShouldBeStored of
         true -> Strategy#amp_strategy{deliver = [stored, none]};
         false -> Strategy

--- a/src/sasl/cyrsasl_anonymous.erl
+++ b/src/sasl/cyrsasl_anonymous.erl
@@ -48,7 +48,7 @@ mech_step(#state{creds = Creds}, _ClientIn) ->
     User = <<(mongoose_bin:gen_from_crypto())/binary,
              (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
     %% Checks that the username is available
-    case ejabberd_auth:is_user_exists(User, mongoose_credentials:lserver(Creds)) of
+    case ejabberd_auth:is_user_exists(jid:make(User, mongoose_credentials:lserver(Creds), <<>>)) of
         true  -> {error, <<"not-authorized">>};
         false -> {ok, mongoose_credentials:extend(Creds, [{username, User},
                                                           {auth_module, ?MODULE}])}

--- a/src/sasl/cyrsasl_digest.erl
+++ b/src/sasl/cyrsasl_digest.erl
@@ -99,7 +99,7 @@ authorize_if_uri_valid(State, KeyVals, Nonce) ->
 maybe_authorize(UserName, KeyVals, Nonce, State) ->
     AuthzId = xml:get_attr_s(<<"authzid">>, KeyVals),
     LServer = mongoose_credentials:lserver(State#state.creds),
-    case ejabberd_auth:get_passterm_with_authmodule(UserName, LServer) of
+    case ejabberd_auth:get_passterm_with_authmodule(jid:make(UserName, LServer, <<>>)) of
         {false, _} ->
             {error, <<"not-authorized">>, UserName};
         {Passwd, AuthModule} ->

--- a/src/sasl/cyrsasl_scram.erl
+++ b/src/sasl/cyrsasl_scram.erl
@@ -74,7 +74,8 @@ mech_step(#state{step = 2} = State, ClientIn) ->
                                 {$r, ClientNonce} ->
                                     Creds = State#state.creds,
                                     LServer = mongoose_credentials:lserver(Creds),
-                                    case ejabberd_auth:get_passterm_with_authmodule(UserName, LServer) of
+                                    case ejabberd_auth:get_passterm_with_authmodule(
+                                           jid:make(UserName, LServer, <<>>)) of
                                         {false, _} -> {error, <<"not-authorized">>, UserName};
                                         {Ret, AuthModule} ->
                                             {StoredKey, ServerKey, Salt, IterationCount} =

--- a/test/commands_backend_SUITE.erl
+++ b/test/commands_backend_SUITE.erl
@@ -673,7 +673,7 @@ do_request(Path, Method, Body, {headers, Headers}) ->
 
 request(Path, Method, BodyData, {{_User, _Pass} = Auth, Authorized}) ->
     setup(client_module()),
-    meck:expect(ejabberd_auth, check_password, fun(_, _, _) -> Authorized end),
+    meck:expect(ejabberd_auth, check_password, fun(_, _) -> Authorized end),
     Body = maybe_add_body(BodyData),
     AuthHeader = maybe_add_auth_header(Auth),
     AcceptHeader = maybe_add_accepted_headers(Method),

--- a/test/ejabberd_admin_SUITE.erl
+++ b/test/ejabberd_admin_SUITE.erl
@@ -3,6 +3,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("jlib.hrl").
 
 -import(ejabberd_helper, [data/2]).
 
@@ -24,21 +25,17 @@ end_per_suite(_Config) ->
 init_per_group(_, Config) ->
     meck:new(ejabberd_auth, [no_link]),
     meck:expect(ejabberd_auth, try_register,
-                fun(<<"existing_user">>, _, _) -> {error, exists};
-                   (<<"null_password_user">>, _, _) -> {error, null_password};
-                   (_, <<"not_allowed_domain">>, _) -> {error, not_allowed};
-                   (<<"invalid_jid_user">>, _, _) -> {error, invalid_jid};
-                   (_, _, _) -> ok
+                fun(#jid{user = <<"existing_user">>}, _) -> {error, exists};
+                   (#jid{user = <<"null_password_user">>}, _) -> {error, null_password};
+                   (#jid{server = <<"not_allowed_domain">>}, _) -> {error, not_allowed};
+                   (#jid{user = <<"invalid_jid_user">>}, _) -> {error, invalid_jid};
+                   (_, _) -> ok
                 end),
-    Config;
-
-init_per_group(_, Config) -> Config.
+    Config.
 
 end_per_group(_, _Config) ->
     meck:unload(ejabberd_auth),
-    ok;
-
-end_per_group(_, _) -> ok.
+    ok.
 
 init_per_testcase(_TestCase, Config) ->
     Config.
@@ -73,7 +70,7 @@ import_users_from_valid_csv_with_quoted_fields(Config) ->
     ?assertEqual([{ok, <<"username,with,commas">>}],
                  Result).
 
-import_from_invalid_csv(Config) ->
+import_from_invalid_csv(_Config) ->
     % given
     NonExistingPath = "",
     % then

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -26,7 +26,7 @@ setup() ->
     meck:expect(cyrsasl, listmech, fun(_) -> [] end),
 
     meck:new(mongoose_credentials),
-    meck:expect(mongoose_credentials, new, fun(_) -> ok end),
+    meck:expect(mongoose_credentials, new_from_stringprepped, fun(_) -> ok end),
     meck:expect(mongoose_credentials, get,
                 fun(dummy_creds, sasl_success_response, undefined) ->
                     undefined end),

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -67,7 +67,7 @@ end_per_testcase(_TC, C) ->
 roster_old(_C) ->
     R1 = get_roster_old(),
     ?assertEqual(length(R1), 0),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     subscription(out, subscribe),
     assert_state_old(none, out),
@@ -76,7 +76,7 @@ roster_old(_C) ->
 roster_old_with_filter(_C) ->
     R1 = get_roster_old(),
     ?assertEqual(0, length(R1)),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     subscription(in, subscribe),
     R2 = get_roster_old(),
@@ -86,29 +86,29 @@ roster_old_with_filter(_C) ->
     ok.
 
 roster_new(_C) ->
-    R1 = mod_roster:get_roster_entry(a(), host(), bob()),
+    R1 = mod_roster:get_roster_entry(alice_jid(), bob()),
     ?assertEqual(does_not_exist, R1),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     ct:pal("get_roster_old(): ~p", [get_roster_old()]),
-    R2 = mod_roster:get_roster_entry(a(), host(), bob()),
+    R2 = mod_roster:get_roster_entry(alice_jid(), bob()),
     ?assertMatch(#roster{}, R2), % is not guaranteed to contain full info
-    R3 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
     subscription(out, subscribe),
-    R4 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R4 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R4, none, out, [<<"friends">>]).
 
 
 roster_case_insensitive(_C) ->
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     R1 = get_roster_old(),
     ?assertEqual(1, length(R1)),
     R2 = get_roster_old(ae()),
     ?assertEqual(1, length(R2)),
-    R3 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
-    R3 = mod_roster:get_roster_entry(ae(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alicE_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
     ok.
 
@@ -125,8 +125,7 @@ assert_state(Rentry, Subscription, Ask, Groups) ->
 subscription(Direction, Type) ->
     LBob = jid:to_lower(jid:from_binary(bob())),
     TFun = fun() -> mod_roster:process_subscription_transaction(Direction,
-                                                                a(),
-                                                                host(),
+                                                                alice_jid(),
                                                                 LBob,
                                                                 Type,
                                                                 <<"">>)
@@ -165,6 +164,12 @@ delete_ets() ->
     catch ets:delete(local_config),
     catch ets:delete(mongoose_services),
     ok.
+
+alice_jid() ->
+    jid:make(a(), host(), <<>>).
+
+alicE_jid() ->
+    jid:make(ae(), host(), <<>>).
 
 a() -> <<"alice">>.
 ae() -> <<"alicE">>.


### PR DESCRIPTION
Kind of a continuation over #2648, this time about `ejabberd_auth` redundant stringprepping. There's at the bottom of such file, commented out, possible exports for the old deprecated functions, if we need them (?)