### PR TITLE
Make s2s use hooks wrapper

### DIFF
--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -276,10 +276,9 @@ do_route(From, To, Acc, Packet) ->
                                                   Attrs),
             NewPacket = Packet#xmlel{attrs = NewAttrs},
             #jid{lserver = MyServer} = From,
-            Acc1 = ejabberd_hooks:run_fold(s2s_send_packet,
-                                           MyServer,
-                                           Acc,
-                                           [From, To, Packet]),
+            Acc1 = mongoose_hooks:s2s_send_packet(MyServer,
+                                                  Acc,
+                                                  From, To, Packet),
             send_element(Pid, Acc1, NewPacket),
             done;
         {aborted, _Reason} ->
@@ -550,8 +549,7 @@ allow_host1(MyHost, S2SHost) ->
             case ejabberd_config:get_local_option({s2s_default_policy, MyHost}) of
                 deny -> false;
                 _ ->
-                    ejabberd_hooks:run_fold(s2s_allow_host, MyHost,
-                                            allow, [MyHost, S2SHost]) /= deny
+                    mongoose_hooks:s2s_allow_host(MyHost, allow, S2SHost) /= deny
             end
     end.
 

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -369,11 +369,9 @@ choose_pid(From, Pids) ->
                 [] -> Pids;
                 Ps -> Ps
             end,
-    % Use sticky connections based on the JID of the sender (whithout
-    % the resource to ensure that a muc room always uses the same
-    % connection)
-    Pid = lists:nth(erlang:phash(jid:to_bare(From), length(Pids1)),
-                    Pids1),
+    % Use sticky connections based on the JID of the sender
+    % (without the resource to ensure that a muc room always uses the same connection)
+    Pid = lists:nth(erlang:phash(jid:to_bare(From), length(Pids1)), Pids1),
     ?DEBUG("Using ejabberd_s2s_out ~p~n", [Pid]),
     Pid.
 

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -201,9 +201,9 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
                 _ ->
                     send_element(StateData,
                                  #xmlel{name = <<"stream:features">>,
-                                        children = SASL ++ StartTLS ++
-                                                           mongoose_hooks:s2s_stream_features(Server,
-                                                                                              [])}),
+                                        children = SASL ++
+                                                   StartTLS ++
+                                                   mongoose_hooks:s2s_stream_features(Server, [])}),
                     {next_state, wait_for_feature_request, StateData#state{server = Server}}
             end;
         {<<"jabber:server">>, _, Server, true} when

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -202,10 +202,8 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
                     send_element(StateData,
                                  #xmlel{name = <<"stream:features">>,
                                         children = SASL ++ StartTLS ++
-                                                   ejabberd_hooks:run_fold(
-                                                     s2s_stream_features,
-                                                     Server,
-                                                     [], [Server])}),
+                                                           mongoose_hooks:s2s_stream_features(Server,
+                                                                                              [])}),
                     {next_state, wait_for_feature_request, StateData#state{server = Server}}
             end;
         {<<"jabber:server">>, _, Server, true} when
@@ -213,10 +211,7 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
             send_text(StateData, ?STREAM_HEADER(<<" version='1.0'">>)),
             send_element(StateData,
                          #xmlel{name = <<"stream:features">>,
-                                children = ejabberd_hooks:run_fold(
-                                             s2s_stream_features,
-                                             Server,
-                                             [], [Server])}),
+                                children = mongoose_hooks:s2s_stream_features(Server, [])}),
             {next_state, stream_established, StateData};
         {<<"jabber:server">>, <<"jabber:server:dialback">>, _Server, _} ->
             send_text(StateData, ?STREAM_HEADER(<<"">>)),
@@ -360,7 +355,6 @@ stream_established({xmlstreamelement, El}, StateData) ->
                 {_, error} -> ok;
                 _ -> route_incoming_stanza(From, To, NewEl, StateData)
             end,
-            ejabberd_hooks:run(s2s_loop_debug, [{xmlstreamelement, El}]),
             {next_state, stream_established, StateData#state{timer = Timer}}
     end;
 stream_established({valid, From, To}, StateData) ->
@@ -455,8 +449,7 @@ route_stanza(Acc) ->
     From = mongoose_acc:from_jid(Acc),
     To = mongoose_acc:to_jid(Acc),
     LTo = To#jid.lserver,
-    Acc1 = ejabberd_hooks:run_fold(s2s_receive_packet,
-                                   LTo, Acc, []),
+    Acc1 = mongoose_hooks:s2s_receive_packet(LTo, Acc),
     ejabberd_router:route(From, To, Acc1).
 
 %%----------------------------------------------------------------------

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -242,10 +242,9 @@ open_socket(init, StateData) ->
         {error, _Reason} ->
             ?INFO_MSG("s2s connection: ~s -> ~s (remote server not found)",
                       [StateData#state.myname, StateData#state.server]),
-            case ejabberd_hooks:run_fold(find_s2s_bridge,
-                                         undefined,
-                                         [StateData#state.myname,
-                                          StateData#state.server]) of
+            case mongoose_hooks:find_s2s_bridge(undefined,
+                                                StateData#state.myname,
+                                                StateData#state.server) of
                 {Mod, Fun, Type} ->
                     ?INFO_MSG("found a bridge to ~s for: ~s -> ~s",
                               [Type, StateData#state.myname,
@@ -372,9 +371,9 @@ wait_for_validation({xmlstreamelement, El}, StateData) ->
                     ?INFO_MSG("Connection established: ~s -> ~s with TLS=~p",
                               [StateData#state.myname, StateData#state.server,
                                StateData#state.tls_enabled]),
-                    ejabberd_hooks:run(s2s_connect_hook,
-                                       [StateData#state.myname,
-                                        StateData#state.server]),
+                    mongoose_hooks:s2s_connect_hook(StateData#state.myname,
+                                                    ok,
+                                                    StateData#state.server),
                     {next_state, stream_established,
                      StateData#state{queue = queue:new()}};
                 {<<"valid">>, Enabled, Required} when (Enabled==false) and (Required==true) ->
@@ -1303,9 +1302,9 @@ handle_parsed_features({false, false, _, StateData = #state{authenticated = true
     send_queue(StateData, StateData#state.queue),
     ?INFO_MSG("Connection established: ~s -> ~s",
               [StateData#state.myname, StateData#state.server]),
-    ejabberd_hooks:run(s2s_connect_hook,
-                       [StateData#state.myname,
-                        StateData#state.server]),
+    mongoose_hooks:s2s_connect_hook(StateData#state.myname,
+                                    ok,
+                                    StateData#state.server),
     {next_state, stream_established,
      StateData#state{queue = queue:new()}};
 handle_parsed_features({true, _, _, StateData = #state{try_auth = true, new = New}}) when

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -114,7 +114,7 @@
 -define(TCP_SEND_TIMEOUT, 15000).
 
 %% Maximum delay to wait before retrying to connect after a failed attempt.
-%% Specified in miliseconds. Default value is 5 minutes.
+%% Specified in milliseconds. Default value is 5 minutes.
 -define(MAX_RETRY_DELAY, 300000).
 
 -define(STREAM_HEADER(From, To, Other),
@@ -979,7 +979,7 @@ get_addr_port(Server) ->
             [{Server, outgoing_s2s_port()}];
         {ok, #hostent{h_addr_list = AddrList}} ->
             %% Probabilities are not exactly proportional to weights
-            %% for simplicity (higher weigths are overvalued)
+            %% for simplicity (higher weights are overvalued)
             case (catch lists:map(fun calc_addr_index/1, AddrList)) of
                 {'EXIT', _Reason} ->
                     [{Server, outgoing_s2s_port()}];
@@ -1157,7 +1157,7 @@ wait_before_reconnect(StateData) ->
                                                     queue = queue:new()}}.
 
 
-%% @doc Get the maximum allowed delay for retry to reconnect (in miliseconds).
+%% @doc Get the maximum allowed delay for retry to reconnect (in milliseconds).
 %% The default value is 5 minutes.
 %% The option {s2s_max_retry_delay, Seconds} can be used (in seconds).
 get_max_retry_delay() ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -78,6 +78,13 @@
 -export([get_mam_pm_gdpr_data/3,
          get_mam_muc_gdpr_data/3]).
 
+-export([find_s2s_bridge/3,
+         s2s_allow_host/3,
+         s2s_connect_hook/3,
+         s2s_receive_packet/2,
+         s2s_stream_features/2,
+         s2s_send_packet/5]).
+
 -spec auth_failed(Server, Username) -> Result when
     Server :: jid:server(),
     Username :: jid:user() | unknown,
@@ -835,3 +842,56 @@ get_mam_pm_gdpr_data(HookServer, InitialValue, JID) ->
       Result :: ejabberd_gen_mam_archive:mam_muc_gdpr_data().
 get_mam_muc_gdpr_data(HookServer, InitialValue, JID) ->
     ejabberd_hooks:run_fold(get_mam_muc_gdpr_data, HookServer, InitialValue, [JID]).
+
+%% S2S related hooks
+
+-spec find_s2s_bridge(Acc, Name, Server) -> Result when
+    Acc :: any(),
+    Name :: any(),
+    Server :: jid:server(),
+    Result :: any().
+find_s2s_bridge(Acc, Name, Server) ->
+    ejabberd_hooks:run_fold(find_s2s_bridge, Acc, [Name, Server]).
+
+-spec s2s_allow_host(MyHost, Allow, S2SHost) -> Result when
+    MyHost :: jid:server(),
+    Allow :: allow,
+    S2SHost :: jid:server(),
+    Result :: allow | deny.
+s2s_allow_host(MyHost, Allow, S2SHost) ->
+    ejabberd_hooks:run_fold(s2s_allow_host, MyHost, Allow, [MyHost, S2SHost]).
+
+-spec s2s_connect_hook(Name, Acc, Server) -> Result when
+    Name :: any(),
+    Acc :: any(),
+    Server :: jid:server(),
+    Result :: any().
+s2s_connect_hook(Name, Acc, Server) ->
+    ejabberd_hooks:run_fold(s2s_connect_hook, Name, Acc, [Server]).
+
+-spec s2s_send_packet(Server, Acc, From, To, Packet) -> Result when
+    Server :: jid:server(),
+    Acc :: mongoose_acc:t(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: mongoose_acc:t().
+s2s_send_packet(Server, Acc, From, To, Packet) ->
+    ejabberd_hooks:run_fold(s2s_send_packet,
+                            Server,
+                            Acc,
+                            [From, To, Packet]).
+
+-spec s2s_stream_features(Server, Acc) -> Result when
+    Server :: jid:server(),
+    Acc :: [exml:element()],
+    Result :: [exml:element()].
+s2s_stream_features(Server, Acc) ->
+    ejabberd_hooks:run_fold(s2s_stream_features, Server, Acc, [Server]).
+
+-spec s2s_receive_packet(LServer, Acc) -> Result when
+    LServer :: jid:lserver(),
+    Acc :: mongoose_acc:t(),
+    Result :: mongoose_acc:t().
+s2s_receive_packet(LServer, Acc) ->
+    ejabberd_hooks:run_fold(s2s_receive_packet, LServer, Acc, []).

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -845,6 +845,7 @@ get_mam_muc_gdpr_data(HookServer, InitialValue, JID) ->
 
 %% S2S related hooks
 
+%%% @doc `find_s2s_bridge' hook is called to find a s2s bridge to a foreign protocol when opening a socket to a different XMPP server fails.
 -spec find_s2s_bridge(Acc, Name, Server) -> Result when
     Acc :: any(),
     Name :: any(),
@@ -853,6 +854,9 @@ get_mam_muc_gdpr_data(HookServer, InitialValue, JID) ->
 find_s2s_bridge(Acc, Name, Server) ->
     ejabberd_hooks:run_fold(find_s2s_bridge, Acc, [Name, Server]).
 
+%%% @doc `s2s_allow_host' hook is called to check whether a server should be allowed to be connected to.
+%%%
+%%% A handler can decide that a server should not be allowed and pass this information to the caller.
 -spec s2s_allow_host(MyHost, Allow, S2SHost) -> Result when
     MyHost :: jid:server(),
     Allow :: allow,
@@ -861,6 +865,7 @@ find_s2s_bridge(Acc, Name, Server) ->
 s2s_allow_host(MyHost, Allow, S2SHost) ->
     ejabberd_hooks:run_fold(s2s_allow_host, MyHost, Allow, [MyHost, S2SHost]).
 
+%%% @doc `s2s_connect_hook' hook is called when a s2s connection is established.
 -spec s2s_connect_hook(Name, Acc, Server) -> Result when
     Name :: any(),
     Acc :: any(),
@@ -869,6 +874,7 @@ s2s_allow_host(MyHost, Allow, S2SHost) ->
 s2s_connect_hook(Name, Acc, Server) ->
     ejabberd_hooks:run_fold(s2s_connect_hook, Name, Acc, [Server]).
 
+%%% @doc `s2s_send_packet' hook is called when a message is routed.
 -spec s2s_send_packet(Server, Acc, From, To, Packet) -> Result when
     Server :: jid:server(),
     Acc :: mongoose_acc:t(),
@@ -882,6 +888,7 @@ s2s_send_packet(Server, Acc, From, To, Packet) ->
                             Acc,
                             [From, To, Packet]).
 
+%%% @doc `s2s_stream_features' hook is used to extract the stream management features supported by the server.
 -spec s2s_stream_features(Server, Acc) -> Result when
     Server :: jid:server(),
     Acc :: [exml:element()],
@@ -889,6 +896,7 @@ s2s_send_packet(Server, Acc, From, To, Packet) ->
 s2s_stream_features(Server, Acc) ->
     ejabberd_hooks:run_fold(s2s_stream_features, Server, Acc, [Server]).
 
+%%% @doc `s2s_receive_packet' hook is called when an incoming stanza is routed by the server.
 -spec s2s_receive_packet(LServer, Acc) -> Result when
     LServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),


### PR DESCRIPTION
I've moved the hook execution to the new wrapper module. However, all hooks except for `s2s_stream_features` are not handled as far as I can see. I removed `s2s_loop_debug` because it seems to be a counterpart of `c2s_loop_debug`, but I don't know whether the other ones can be removed. I am also not sure about naming conventions in s2s (especially `myname` and `server` kept in the state of `ejabberd_s2s_out`).

