### PR TITLE
Rework mod_disco to use mongoose_hooks

### DIFF
--- a/src/global_distrib/mod_global_distrib_disco.erl
+++ b/src/global_distrib/mod_global_distrib_disco.erl
@@ -41,8 +41,10 @@ stop(Host) ->
 %% Hooks implementation
 %%--------------------------------------------------------------------
 
--spec get_disco_items(Acc :: term(), From :: jid:jid(), To :: jid:jid(),
-                      Node :: binary(), ejabberd:lang()) -> {result, [exml:element()]} | term().
+-spec get_disco_items(Acc :: {result, [exml:element()]} | {error, any()} | empty,
+                      From :: jid:jid(), To :: jid:jid(),
+                      Node :: binary(), ejabberd:lang())
+                     -> {result, [exml:element()]} | {error, any()} | empty.
 get_disco_items({result, Nodes}, From, To, <<"">>, _Lang) ->
     Domains = domains_for_disco(To#jid.lserver, From),
     ?DEBUG("event=domains_fetched_for_disco,domains=\"~p\",input_nodes=\"~p\"",

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -122,8 +122,10 @@ get_disco_identity(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
 
--spec get_disco_items(Acc :: term(), From :: jid:jid(), To :: jid:jid(),
-                      Node :: binary(), ejabberd:lang()) -> {result, [exml:element()]} | term().
+-spec get_disco_items(Acc :: {result, [exml:element()]} | {error, any()} | empty,
+                      From :: jid:jid(), To :: jid:jid(),
+                      Node :: binary(), ejabberd:lang())
+                     -> {result, [exml:element()]} | {error, any()}.
 get_disco_items({result, Nodes}, _From, #jid{lserver = Host} = _To, <<"">>, Lang) ->
     Item = #xmlel{name  = <<"item">>,
                   attrs = [{<<"jid">>, subhost(Host)}, {<<"name">>, my_disco_name(Lang)}]},

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -71,11 +71,11 @@ hooks(Host) ->
      {adhoc_local_commands, Host, ?MODULE, ping_command, 100}].
 %%-------------------------------------------------------------------------
 
--spec get_local_commands(Acc :: [exml:element()],
+-spec get_local_commands(Acc :: {result, [exml:element()]} | {error, any()} | empty,
                          From :: jid:jid(),
                          To :: jid:jid(),
                          NS :: binary(),
-                         ejabberd:lang()) -> {result, [exml:element()]} | [exml:element()].
+                         ejabberd:lang()) -> {result, [exml:element()]} | {error, any()} | empty.
 get_local_commands(Acc, _From, #jid{lserver = LServer} = _To, <<"">>, Lang) ->
     Display = gen_mod:get_module_opt(LServer, ?MODULE, report_commands_node, false),
     case Display of
@@ -136,7 +136,7 @@ get_sm_commands(Acc, _From, _To, _Node, _Lang) ->
                          From :: jid:jid(),
                          To :: jid:jid(),
                          NS :: binary(),
-                         ejabberd:lang()) -> {result, [exml:element()]} | [exml:element()].
+                         ejabberd:lang()) -> [exml:element()].
 get_local_identity(Acc, _From, _To, ?NS_COMMANDS, Lang) ->
     [#xmlel{name = <<"identity">>,
             attrs = [{<<"category">>, <<"automation">>},
@@ -157,7 +157,7 @@ get_local_identity(Acc, _From, _To, _Node, _Lang) ->
                      From :: jid:jid(),
                      To :: jid:jid(),
                      NS :: binary(),
-                     ejabberd:lang()) -> {result, [exml:element()]} | [exml:element()].
+                     ejabberd:lang()) -> [exml:element()].
 get_sm_identity(Acc, _From, _To, ?NS_COMMANDS, Lang) ->
     [#xmlel{name = <<"identity">>,
             attrs = [{<<"category">>, <<"automation">>},
@@ -168,11 +168,11 @@ get_sm_identity(Acc, _From, _To, _Node, _Lang) ->
 
 %%-------------------------------------------------------------------------
 
--spec get_local_features(Acc :: [exml:element()],
+-spec get_local_features(Acc :: {result, [exml:element()]} | empty | {error, any()},
                          From :: jid:jid(),
                          To :: jid:jid(),
                          NS :: binary(),
-                         ejabberd:lang()) -> {result, [exml:element()]} | [exml:element()].
+                         ejabberd:lang()) -> {result, [exml:element()]} | {error, any()}.
 get_local_features(Acc, _From, _To, <<"">>, _Lang) ->
     Feats = case Acc of
                 {result, I} -> I;
@@ -190,11 +190,11 @@ get_local_features(Acc, _From, _To, _Node, _Lang) ->
 
 %%-------------------------------------------------------------------------
 
--spec get_sm_features(Acc :: [exml:element()],
+-spec get_sm_features(Acc :: {result, [exml:element()]} | {error, any()} | empty,
                              From :: jid:jid(),
                              To :: jid:jid(),
                              NS :: binary(),
-                             ejabberd:lang()) -> {result, [exml:element()]} | [exml:element()].
+                             ejabberd:lang()) -> {result, [exml:element()]} | {error, any()} | empty.
 get_sm_features(Acc, _From, _To, <<"">>, _Lang) ->
     Feats = case Acc of
                 {result, I} -> I;
@@ -244,7 +244,7 @@ process_adhoc_request(From, To, #iq{sub_el = SubEl} = IQ, Hook) ->
     end.
 
 
--spec ping_item(Acc :: [exml:element()],
+-spec ping_item(Acc :: {result, [exml:element()]},
                 From :: jid:jid(),
                 To :: jid:jid(),
                 ejabberd:lang()) -> {result, [exml:element()]}.

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -93,6 +93,11 @@ check_packet(Acc, #jid{lserver = Host} = From, Event) ->
             Acc
     end.
 
+-spec add_local_features(Acc :: {result, [exml:element()]} | empty | {error, any()},
+                         From :: jid:jid(),
+                         To :: jid:jid(),
+                         NS :: binary(),
+                         ejabberd:lang()) -> {result, [exml:element()]} | {error, any()}.
 add_local_features(Acc, _From, _To, ?NS_AMP, _Lang) ->
     Features = result_or(Acc, []) ++ amp_features(),
     {result, Features};

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -397,6 +397,11 @@ set_vcard({error, no_handler_defined}, From, VCARD) ->
     end;
 set_vcard({error, _} = E, _From, _VCARD) -> E.
 
+-spec get_local_features(Acc :: {result, [exml:element()]} | empty | {error, any()},
+                         From :: jid:jid(),
+                         To :: jid:jid(),
+                         Node :: binary(),
+                         ejabberd:lang()) -> {result, [exml:element()]} | empty | {error, any()}.
 get_local_features({error, _Error}=Acc, _From, _To, _Node, _Lang) ->
     Acc;
 get_local_features(Acc, _From, _To, Node, _Lang) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -504,7 +504,7 @@ xmpp_send_element(Server, Acc, El) ->
 
 %% Roster related hooks
 
-%%% @doc The `roster_get' hook is called to extract user's roster.
+%%% @doc The `roster_get' hook is called to extract a user's roster.
 -spec roster_get(Server, Acc, User) -> Result when
     Server :: jid:lserver(),
     Acc :: mongoose_acc:t(),

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -276,8 +276,10 @@ prevent_service_unavailable(Acc, _From, _To, Packet) ->
         _Type -> Acc
     end.
 
--spec get_muc_service(Acc :: {result, [exml:element()]}, From :: jid:jid(), To :: jid:jid(),
-                      NS :: binary(), ejabberd:lang()) -> {result, [exml:element()]}.
+-spec get_muc_service(Acc :: {result, [exml:element()]} | empty | {error, any()},
+                      From :: jid:jid(), To :: jid:jid(),
+                      NS :: binary(), ejabberd:lang())
+                     -> {result, [exml:element()]} | empty | {error, any()}.
 get_muc_service({result, Nodes}, _From, #jid{lserver = LServer} = _To, <<"">>, _Lang) ->
     XMLNS = case gen_mod:get_module_opt_by_subhost(
                    LServer, ?MODULE, legacy_mode, ?DEFAULT_LEGACY_MODE) of

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -68,7 +68,7 @@
          in_subscription/6, out_subscription/5,
          on_user_offline/5, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
-         disco_local_items/5, disco_sm_identity/5,
+         disco_sm_identity/5,
          disco_sm_features/5, disco_sm_items/5, handle_pep_authorization_response/1]).
 
 %% exported iq handlers
@@ -355,7 +355,6 @@ hooks() ->
      {sm_remove_connection_hook, on_user_offline, 75},
      {disco_local_identity, disco_local_identity, 75},
      {disco_local_features, disco_local_features, 75},
-     {disco_local_items, disco_local_items, 75},
      {presence_probe_hook, presence_probe, 80},
      {roster_in_subscription, in_subscription, 50},
      {roster_out_subscription, out_subscription, 50},
@@ -548,7 +547,7 @@ is_subscribed(Recipient, NodeOwner, NodeOptions) ->
           _From  ::jid:jid(),
           To     ::jid:jid(),
           Node   :: <<>> | mod_pubsub:nodeId(),
-          Lang   :: binary())
+          Lang   :: ejabberd:lang())
         -> [exml:element()].
 disco_local_identity(Acc, _From, To, Node, Lang) ->
     LServer = To#jid.lserver,
@@ -577,12 +576,12 @@ disco_local_identity(Acc, _Host, _Node, _Lang) ->
     Acc.
 
 -spec disco_local_features(
-        Acc    :: [exml:element()],
+          Acc :: {result, [exml:element()]} | empty | {error, any()},
           _From  ::jid:jid(),
           To     ::jid:jid(),
-          Node   :: <<>> | mod_pubsub:nodeId(),
-          Lang   :: binary())
-        -> [binary(), ...].
+          Node   :: <<>> | mod_pubsub:nodeId() | binary(),
+          Lang   :: ejabberd:lang())
+        -> {result, [exml:element()]} | empty | {error, any()}.
 disco_local_features(Acc, _From, To, <<>>, _Lang) ->
     Host = To#jid.lserver,
     Feats = case Acc of
@@ -593,18 +592,13 @@ disco_local_features(Acc, _From, To, <<>>, _Lang) ->
 disco_local_features(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
-disco_local_items(Acc, _From, _To, <<>>, _Lang) -> Acc;
-disco_local_items(Acc, _From, _To, _Node, _Lang) -> Acc.
-
 -spec disco_sm_identity(
-        Acc  :: empty | [exml:element()],
-          From ::jid:jid(),
-          To   ::jid:jid(),
+        Acc :: [exml:element()],
+          From :: jid:jid(),
+          To :: jid:jid(),
           Node :: mod_pubsub:nodeId(),
-          Lang :: binary())
+          Lang :: ejabberd:lang())
         -> [exml:element()].
-disco_sm_identity(empty, From, To, Node, Lang) ->
-    disco_sm_identity([], From, To, Node, Lang);
 disco_sm_identity(Acc, From, To, Node, _Lang) ->
     disco_identity(jid:to_lower(jid:to_bare(To)), Node, From)
         ++ Acc.
@@ -640,12 +634,12 @@ disco_identity(Host, Node, From) ->
     end.
 
 -spec disco_sm_features(
-        Acc  :: empty | {result, Features::[Feature::binary()]},
+        Acc  :: empty | {result, Features::[Feature::binary()]} | {error, any()},
           From ::jid:jid(),
           To   ::jid:jid(),
           Node :: mod_pubsub:nodeId(),
           Lang :: binary())
-        -> {result, Features::[Feature::binary()]}.
+        -> {result, Features::[Feature::binary()]} | {error, any()}.
 disco_sm_features(empty, From, To, Node, Lang) ->
     disco_sm_features({result, []}, From, To, Node, Lang);
 disco_sm_features({result, OtherFeatures} = _Acc, From, To, Node, _Lang) ->


### PR DESCRIPTION
This PR reworks `mod_disco` to use new `mongoose_hooks` module.
I tried not to change the logic of the hooks, although sometimes it seemed a good fit for refactoring (like passing `empty` atom instead of an empty list).
The `disco_sm_items` hook call is not covered by tests at all.
