### PR TITLE
System Metrics: types of outgoing pools

### DIFF
--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -45,7 +45,8 @@
          cluster_uptime_is_reported/1,
          xmpp_components_are_reported/1,
          api_are_reported/1,
-         transport_mechanisms_are_reported/1
+         transport_mechanisms_are_reported/1,
+         outgoing_pools_are_reported/1
         ]).
 
 -export([
@@ -83,6 +84,7 @@ all() ->
      xmpp_components_are_reported,
      api_are_reported,
      transport_mechanisms_are_reported,
+     outgoing_pools_are_reported,
      {group, log_transparency}
     ].
 
@@ -286,6 +288,9 @@ api_are_reported(_Config) ->
 transport_mechanisms_are_reported(_Config) ->
     mongoose_helper:wait_until(fun transport_mechanisms_are_reported/0, true).
 
+outgoing_pools_are_reported(_Config) ->
+    mongoose_helper:wait_until(fun outgoing_pools_are_reported/0, true).
+
 just_removed_from_config_logs_question(_Config) ->
     disable_system_metrics(mim3()),
     remove_service_from_config(service_mongoose_system_metrics),
@@ -473,6 +478,9 @@ api_are_reported() ->
 
 transport_mechanisms_are_reported() ->
     is_in_table(<<"transport_mechanism">>).
+
+outgoing_pools_are_reported() ->
+    is_in_table(<<"outgoing_pools">>).
 
 more_than_one_component_is_reported() ->
     Tab = ets:tab2list(?ETS_TABLE),

--- a/src/system_metrics/mongoose_system_metrics_collector.erl
+++ b/src/system_metrics/mongoose_system_metrics_collector.erl
@@ -31,7 +31,8 @@ report_getters() ->
         fun get_components/0,
         fun get_api/0,
         fun get_transport_mechanisms/0,
-        fun get_tls_options/0
+        fun get_tls_options/0,
+        fun get_outgoing_pools/0
     ].
 
 get_hosts_count() ->
@@ -129,7 +130,7 @@ filter_unknown_api(ApiList) ->
     [Api || Api <- ApiList, lists:member(Api, AllowedToReport)].
 
 get_service_option(Service) ->
-    Listen = ejabberd_config:get_local_option(listen),
+    Listen = ejabberd_config:get_local_option_or_default(listen, []),
     Result = [ Option || {_, S, Option} <- Listen, S == Service],
     lists:flatten(Result).
 
@@ -181,3 +182,9 @@ check_tls_specific_option() ->
         true -> just_tls;
         _ -> fast_tls
     end.
+
+get_outgoing_pools() ->
+    OutgoingPools = ejabberd_config:get_local_option_or_default(outgoing_pools, []),
+    [#{report_name => outgoing_pools,
+       key => type,
+       value => Type} || {Type, _, _, _, _} <- OutgoingPools].


### PR DESCRIPTION
Extending system metrics to collect information regarding types of outgoing pools that are configured. 

