### PR TITLE
Change mod_amp to use mongoose_hooks

### DIFF
--- a/src/amp_strategy.erl
+++ b/src/amp_strategy.erl
@@ -26,7 +26,7 @@ determine_strategy(_, _, To, _, Event) ->
                   'expire-at' = undefined}.
 
 %% @doc This strategy will never be matched by any amp_rules.
-%% Use it as a seed parameter to ejaberd_hooks:run_fold
+%% Use it as a seed parameter to `mongoose_hooks'.
 -spec null_strategy() -> amp_strategy().
 null_strategy() ->
     #amp_strategy{deliver = undefined,

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -123,7 +123,7 @@ if [ "$db" = 'mysql' ]; then
         $(data_on_volume -v ${SQL_DATA_DIR}:/var/lib/mysql) \
         --health-cmd='mysqladmin ping --silent' \
         -p $MYSQL_PORT:3306 --name=$NAME \
-        mysql --default-authentication-plugin=mysql_native_password
+        mysql:8.0 --default-authentication-plugin=mysql_native_password
     tools/wait_for_healthcheck.sh $NAME
 
 elif [ "$db" = 'pgsql' ]; then


### PR DESCRIPTION
This PR changes `mod_amp` module to use new `mongoose_hooks` module.
My comments for possible future refactoring of hooks:
* `amp_notify_action_triggered` and `amp_error_action_triggered` seem to not be handled anywhere
* `amp_check_condition`, `amp_verify_support` and `amp_check_packet` seem to only be handled in AMP modules. Also `amp_check_packet` call contains a weird comment which I do not fully understand,
* `amp_determine_strategy` has specs that suggest that `To` argument may be `undefined` but only one handler reacts to this correctly (`determine_strategy` in `amp_strategy`) and handlers`determine_amp_strategy` in `mod_offline` and `mod_mam` may fail because of that. I do not know whether it is possible for `To` to really be undefined so I did not know whether to change specs in this case.
* `xmpp_stanza_dropped` seem to be only used for `mongoose_metrics` but also it seems to be skipped when creating metrics, so in the end not really used at all. Perhaps I am missing something here.