### PR TITLE
Hooks wrapper muc and muc_light

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -217,7 +217,7 @@ forget_room(ServerHost, Host, Name) ->
             %% (i.e. in case we want to expose room removal over REST or SQS).
             %%
             %% In some _rare_ cases this hook can be called more than once for the same room.
-            ejabberd_hooks:run(forget_room, ServerHost, [Host, Name]);
+            mongoose_hooks:forget_room(ServerHost, ok, Host, Name);
         _ ->
             %% Room is not removed or we don't know.
             %% XXX Handle this case better.
@@ -244,7 +244,7 @@ can_use_nick(_ServerHost, _Host, _JID, <<>>) ->
 can_use_nick(ServerHost, Host, JID, Nick) ->
     mod_muc_db_backend:can_use_nick(ServerHost, Host, JID, Nick).
 
-set_nick(LServer, Host, From, <<>>) ->
+set_nick(_LServer, _Host, _From, <<>>) ->
     {error, should_not_be_empty};
 set_nick(LServer, Host, From, Nick) ->
     mod_muc_db_backend:set_nick(LServer, Host, From, Nick).
@@ -616,8 +616,7 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #state{host = Host} = State) ->
     ServerHost = State#state.server_host,
     case jlib:iq_query_info(Packet) of
         #iq{type = get, xmlns = ?NS_DISCO_INFO = XMLNS, lang = Lang} = IQ ->
-            Info = ejabberd_hooks:run_fold(disco_info, ServerHost, [],
-                                           [ServerHost, ?MODULE, <<"">>, Lang]),
+            Info = mongoose_hooks:disco_info(ServerHost, [], ?MODULE, <<"">>, Lang),
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = [{<<"xmlns">>, XMLNS}],

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -102,6 +102,10 @@
          amp_notify_action_triggered/2,
          amp_verify_support/3]).
 
+-export([filter_room_packet/3,
+         forget_room/4,
+         room_send_packet/3]).
+
 -spec auth_failed(Server, Username) -> Result when
     Server :: jid:server(),
     Username :: jid:user() | unknown,
@@ -1103,4 +1107,31 @@ amp_notify_action_triggered(Server, Acc) ->
 amp_verify_support(Server, Acc, Rules) ->
     ejabberd_hooks:run_fold(amp_verify_support, Server, Acc, [Rules]).
 
+%% MUC Light related hooks
 
+-spec filter_room_packet(Server, Packet, EventData) -> Result when
+    Server :: jid:lserver(),
+    Packet :: exml:element(),
+    EventData :: [{atom(), any()}],
+    Result :: exml:element().
+filter_room_packet(Server, Packet, EventData) ->
+    ejabberd_hooks:run_fold(filter_room_packet, Server, Packet, [EventData]).
+
+%%% @doc The `forget_room' hook is called when a room is removed from the database.
+-spec forget_room(HookServer, Acc, Host, Room) -> Result when
+    HookServer :: jid:server(),
+    Acc :: any(),
+    Host :: jid:server(),
+    Room :: jid:luser(),
+    Result :: any().
+forget_room(HookServer, Acc, Host, Room) ->
+    ejabberd_hooks:run_fold(forget_room, HookServer, Acc, [Host, Room]).
+
+%%% @doc The `room_send_packet' hook is called when a message is sent to a room.
+-spec room_send_packet(Server, Packet, EventData) -> Result when
+    Server :: jid:lserver(),
+    Packet :: exml:element(),
+    EventData :: [{atom(), any()}],
+    Result :: exml:element().
+room_send_packet(Server, Packet, EventData) ->
+    ejabberd_hooks:run_fold(room_send_packet, Server, Packet, [EventData]).

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -104,7 +104,12 @@
 
 -export([filter_room_packet/3,
          forget_room/4,
-         room_send_packet/3]).
+         invitation_sent/7,
+         join_room/6,
+         leave_room/6,
+         room_packet/6,
+         room_send_packet/3,
+         update_inbox_for_muc/2]).
 
 -spec auth_failed(Server, Username) -> Result when
     Server :: jid:server(),
@@ -1107,7 +1112,7 @@ amp_notify_action_triggered(Server, Acc) ->
 amp_verify_support(Server, Acc, Rules) ->
     ejabberd_hooks:run_fold(amp_verify_support, Server, Acc, [Rules]).
 
-%% MUC Light related hooks
+%% MUC and MUC Light related hooks
 
 -spec filter_room_packet(Server, Packet, EventData) -> Result when
     Server :: jid:lserver(),
@@ -1127,6 +1132,60 @@ filter_room_packet(Server, Packet, EventData) ->
 forget_room(HookServer, Acc, Host, Room) ->
     ejabberd_hooks:run_fold(forget_room, HookServer, Acc, [Host, Room]).
 
+-spec invitation_sent(HookServer, Acc, Host, RoomJID, From, To, Reason) -> Result when
+    HookServer :: jid:server(),
+    Acc :: any(),
+    Host :: jid:server(),
+    RoomJID :: jid:jid(),
+    From :: jid:jid(),
+    To :: jid:jid(),
+    Reason :: binary(),
+    Result :: any().
+invitation_sent(HookServer, Acc, Host, RoomJID, From, To, Reason) ->
+    ejabberd_hooks:run_fold(invitation_sent,
+                            HookServer,
+                            Acc,
+                            [HookServer, Host, RoomJID, From, To, Reason]).
+
+%%% @doc The `join_room' hook is called when a user joins a MUC room.
+-spec join_room(HookServer, Acc, Room, Host, JID, MucJID) -> Result when
+    HookServer :: jid:server(),
+    Acc :: any(),
+    Room :: mod_muc:room(),
+    Host :: jid:server(),
+    JID :: jid:jid(),
+    MucJID :: jid:jid(),
+    Result :: any().
+join_room(HookServer, Acc, Room, Host, JID, MucJID) ->
+    ejabberd_hooks:run_fold(join_room, HookServer, Acc, [HookServer, Room, Host, JID, MucJID]).
+
+%%% @doc The `leave_room' hook is called when a user joins a MUC room.
+-spec leave_room(HookServer, Acc, Room, Host, JID, MucJID) -> Result when
+    HookServer :: jid:server(),
+    Acc :: any(),
+    Room :: mod_muc:room(),
+    Host :: jid:server(),
+    JID :: jid:jid(),
+    MucJID :: jid:jid(),
+    Result :: any().
+leave_room(HookServer, Acc, Room, Host, JID, MucJID) ->
+    ejabberd_hooks:run_fold(leave_room, HookServer, Acc, [HookServer, Room, Host, JID, MucJID]).
+
+%%% @doc The `room_packet' hook is called when a message is added to room's history.
+-spec room_packet(Server, Acc, FromNick, FromJID, JID, Packet) -> Result when
+    Server :: jid:lserver(),
+    Acc :: any(),
+    FromNick :: mod_muc:nick(),
+    FromJID :: jid:jid(),
+    JID :: jid:jid(),
+    Packet :: exml:element(),
+    Result :: any().
+room_packet(Server, Acc, FromNick, FromJID, JID, Packet) ->
+    ejabberd_hooks:run_fold(room_packet,
+                            Server,
+                            Acc,
+                            [FromNick, FromJID, JID, Packet]).
+
 %%% @doc The `room_send_packet' hook is called when a message is sent to a room.
 -spec room_send_packet(Server, Packet, EventData) -> Result when
     Server :: jid:lserver(),
@@ -1135,3 +1194,10 @@ forget_room(HookServer, Acc, Host, Room) ->
     Result :: exml:element().
 room_send_packet(Server, Packet, EventData) ->
     ejabberd_hooks:run_fold(room_send_packet, Server, Packet, [EventData]).
+
+-spec update_inbox_for_muc(Server, Info) -> Result when
+    Server :: jid:server(),
+    Info :: mod_muc_room:update_inbox_for_muc_payload(),
+    Result :: mod_muc_room:update_inbox_for_muc_payload().
+update_inbox_for_muc(Server, Info) ->
+    ejabberd_hooks:run_fold(update_inbox_for_muc, Server, Info, []).

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -63,8 +63,8 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
                  {role, mod_muc_light_utils:light_aff_to_muc_role(Aff)}
     ],
     FilteredPacket = #xmlel{ children = Children }
-        = ejabberd_hooks:run_fold(filter_room_packet, RoomS, MsgForArch, [EventData]),
-    ejabberd_hooks:run(room_send_packet, RoomS, [FilteredPacket, EventData]),
+        = mongoose_hooks:filter_room_packet(RoomS, MsgForArch, EventData),
+    mongoose_hooks:room_send_packet(RoomS, FilteredPacket, EventData),
     lists:foreach(
       fun({{U, S}, _}) ->
               send_to_aff_user(RoomJID, U, S, <<"message">>, Attrs, Children, HandleFun)

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -243,7 +243,7 @@ get_info(RoomUS) ->
 
 -spec force_clear() -> ok.
 force_clear() ->
-    lists:foreach(fun({RoomU, RoomS}) -> ejabberd_hooks:run(forget_room, RoomS, [RoomS, RoomU]) end,
+    lists:foreach(fun({RoomU, RoomS}) -> mongoose_hooks:forget_room(RoomS, ok, RoomS, RoomU) end,
                   mnesia:dirty_all_keys(muc_light_room)),
     lists:foreach(fun mnesia:clear_table/1,
                   [muc_light_room, muc_light_user_room, muc_light_blocking]).

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -49,7 +49,7 @@ handle_request(From, To, OrigPacket, Request) ->
 
 -spec maybe_forget(RoomUS :: jid:simple_bare_jid(), NewAffUsers :: aff_users()) -> any().
 maybe_forget({RoomU, RoomS} = RoomUS, []) ->
-    ejabberd_hooks:run(forget_room, RoomS, [RoomS, RoomU]),
+    mongoose_hooks:forget_room(RoomS, ok, RoomS, RoomU),
     mod_muc_light_db_backend:destroy_room(RoomUS);
 maybe_forget(_, _) ->
     my_room_will_go_on.


### PR DESCRIPTION
This PR changes `muc_light` as well as `muc` modules to use new `mongoose_hooks` module. 
As usually some hooks seem to not be handled at all.
In this PR I decided to change some code around the `filter_local_packet` hook, as it will never return the `drop` atom. Dialyzer was not happy about expecting this atom in a case expression branch, so I had to either change the specs to be less precise or incorrect, or to change the implementation and chose the latter. In general the `filter_local_packet` hook was not really used for filtering as I understand.