### PR TITLE
Change roster related hook executions to use mongoose_hooks

### DIFF
--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -253,7 +253,7 @@ get_roster(User, Server) ->
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => UserJID#jid.lserver,
                               element => undefined }),
-    Acc2 = ejabberd_hooks:run_fold(roster_get, Server, Acc, [jid:to_lus(UserJID)]),
+    Acc2 = mongoose_hooks:roster_get(Server, Acc, UserJID#jid.luser, Server),
     Items = mongoose_acc:get(roster, items, [], Acc2),
     make_roster(Items).
 

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -278,7 +278,7 @@ list_contacts(Caller) ->
                                element => undefined }),
     Acc1 = mongoose_acc:set(roster, show_full_roster, true, Acc0),
     {User, Host} = jid:to_lus(CallerJID),
-    Acc2 = ejabberd_hooks:run_fold(roster_get, Host, Acc1, [{User, Host}]),
+    Acc2 = mongoose_hooks:roster_get(Host, Acc1, User, Host),
     Res = mongoose_acc:get(roster, items, Acc2),
     [roster_info(mod_roster:item_to_map(I)) || I <- Res].
 
@@ -410,11 +410,9 @@ run_subscription(Type, CallerJid, OtherJid) ->
     % set subscription to
     Server = CallerJid#jid.server,
     LUser = CallerJid#jid.luser,
-    LServer = CallerJid#jid.lserver,
-    Acc2 = ejabberd_hooks:run_fold(roster_out_subscription,
-                                   Server,
-                                   Acc1,
-                                   [LUser, LServer, OtherJid, Type]),
+    Acc2 = mongoose_hooks:roster_out_subscription(Server,
+                                                  Acc1,
+                                                  LUser, OtherJid, Type),
     ejabberd_router:route(CallerJid, OtherJid, Acc2),
     ok.
 

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -385,7 +385,7 @@ is_presence_subscribed(#jid{luser=User, lserver=Server} = From,
     A = mongoose_acc:new(#{ location => ?LOCATION,
                             lserver => From#jid.lserver,
                             element => undefined }),
-    A2 = mongoose_hooks:roster_get(Server, A, User),
+    A2 = mongoose_hooks:roster_get(Server, A, User, Server),
     Roster = mongoose_acc:get(roster, items, [], A2),
     lists:any(fun({roster, _, _, JID, _, S, _, _, _, _}) ->
                       {TUser, TServer} = jid:to_lus(JID),

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -150,16 +150,18 @@ process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
     User = To#jid.luser,
     Server = To#jid.lserver,
     {Subscription, _Groups} =
-    ejabberd_hooks:run_fold(roster_get_jid_info, Server,
-                            {none, []}, [User, Server, From]),
+    mongoose_hooks:roster_get_jid_info(Server,
+                                       {none, []},
+                                       User, From),
     MutualSubscription = Subscription == both,
     RequesterSubscribedToTarget = Subscription == from,
     QueryingSameUsersLast = (From#jid.luser == To#jid.luser) and
                             (From#jid.lserver == To#jid.lserver),
     case MutualSubscription or RequesterSubscribedToTarget or QueryingSameUsersLast of
         true ->
-            UserListRecord = ejabberd_hooks:run_fold(privacy_get_user_list, Server,
-                                                     #userlist{}, [User, Server]),
+            UserListRecord = mongoose_hooks:privacy_get_user_list(Server,
+                                                                  #userlist{},
+                                                                  User),
             ok,
             {Acc1, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, User,
                                                              UserListRecord, To, From,

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -323,7 +323,7 @@ check_packet(Acc, User, Server,
     {Subscription, Groups} =
         case NeedDb of
             true ->
-                roster_get_jid_info(Server, User, Server, LJID);
+                roster_get_jid_info(Server, User, LJID);
             false ->
                 {[], []}
         end,
@@ -666,12 +666,10 @@ broadcast_privacy_list(LUser, LServer, Name, UserList) ->
 broadcast_privacy_list_packet(Name, UserList) ->
     {broadcast, {privacy_list, UserList, Name}}.
 
-roster_get_jid_info(Host, User, Server, LJID) ->
-    ejabberd_hooks:run_fold(
-        roster_get_jid_info,
-        Host,
-        {none, []},
-        [User, Server, LJID]).
+roster_get_jid_info(Host, User, LJID) ->
+    mongoose_hooks:roster_get_jid_info(Host,
+                                       {none, []},
+                                       User, LJID).
 
 config_metrics(Host) ->
     OptsToReport = [{backend, mnesia}], %list of tuples {option, defualt_value}


### PR DESCRIPTION
I believe `roster_push`  should be called from `mod_roster:push_item/5` not `/4` . It is used for metrics and now it seems it is executed only when roster versioning is not enabled, but I didn't change the logic for now.

