### PR TITLE
Unexpected c2s stanzas

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -43,6 +43,7 @@ all() ->
     [
      {group, session_replacement},
      {group, security},
+     {group, incorrect_behaviors},
      %% these groups must be last, as they really... complicate configuration
      {group, fast_tls},
      {group, just_tls}
@@ -81,7 +82,8 @@ groups() ->
           {security, [], [
                           return_proper_stream_error_if_service_is_not_hidden,
                           close_connection_if_service_type_is_hidden
-                         ]}
+                         ]},
+          {incorrect_behaviors, [parallel], [close_connection_if_start_stream_duplicated]}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
@@ -663,6 +665,18 @@ close_connection_if_service_type_is_hidden(_Config) ->
         5000 ->
             ct:fail(connection_not_closed)
     end.
+
+close_connection_if_start_stream_duplicated(Config) ->
+    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
+    Steps = [start_stream, stream_features],
+    {ok, Alice, _Features} = escalus_connection:start(AliceSpec, Steps),
+    escalus:send(Alice, escalus_stanza:stream_start(ct:get_config({hosts, mim, domain}),
+                                                   ?NS_JABBER_CLIENT)),
+    escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>],
+                   escalus_connection:get_stanza(Alice, no_stream_error_stanza_received)),
+    escalus:assert(is_stream_end,
+                   escalus_connection:get_stanza(Alice, no_stream_end_stanza_received)),
+    true = escalus_connection:wait_for_close(Alice,timer:seconds(5)).
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -669,32 +669,16 @@ close_connection_if_service_type_is_hidden(_Config) ->
     end.
 
 close_connection_if_start_stream_duplicated(Config) ->
-    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    Steps = [start_stream, stream_features],
-    {ok, Alice, _Features} = escalus_connection:start(AliceSpec, Steps),
-    escalus:send(Alice, escalus_stanza:stream_start(ct:get_config({hosts, mim, domain}),
-                                                    ?NS_JABBER_CLIENT)),
-    escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>],
-                   escalus_connection:get_stanza(Alice, no_stream_error_stanza_received)),
-    escalus:assert(is_stream_end,
-                   escalus_connection:get_stanza(Alice, no_stream_end_stanza_received)),
-    true = escalus_connection:wait_for_close(Alice,timer:seconds(5)).
+    close_connection_if_protocol_violation(Config, [start_stream, stream_features]).
 
 close_connection_if_protocol_violation_after_authentication(Config) ->
-    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    Steps = [start_stream, stream_features, authenticate],
-    {ok, Alice, _Features} = escalus_connection:start(AliceSpec, Steps),
-    escalus:send(Alice, escalus_stanza:stream_start(ct:get_config({hosts, mim, domain}),
-                                                    ?NS_JABBER_CLIENT)),
-    escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>],
-                   escalus_connection:get_stanza(Alice, no_stream_error_stanza_received)),
-    escalus:assert(is_stream_end,
-                   escalus_connection:get_stanza(Alice, no_stream_end_stanza_received)),
-    true = escalus_connection:wait_for_close(Alice,timer:seconds(5)).
+    close_connection_if_protocol_violation(Config, [start_stream, stream_features, authenticate]).
 
 close_connection_if_protocol_violation_after_binding(Config) ->
+    close_connection_if_protocol_violation(Config, [start_stream, stream_features, authenticate, bind]).
+
+close_connection_if_protocol_violation(Config, Steps) ->
     AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    Steps = [start_stream, stream_features, authenticate, bind],
     {ok, Alice, _Features} = escalus_connection:start(AliceSpec, Steps),
     escalus:send(Alice, escalus_stanza:stream_start(ct:get_config({hosts, mim, domain}),
                                                     ?NS_JABBER_CLIENT)),
@@ -703,7 +687,6 @@ close_connection_if_protocol_violation_after_binding(Config) ->
     escalus:assert(is_stream_end,
                    escalus_connection:get_stanza(Alice, no_stream_end_stanza_received)),
     true = escalus_connection:wait_for_close(Alice,timer:seconds(5)).
-
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -671,7 +671,7 @@ close_connection_if_start_stream_duplicated(Config) ->
     Steps = [start_stream, stream_features],
     {ok, Alice, _Features} = escalus_connection:start(AliceSpec, Steps),
     escalus:send(Alice, escalus_stanza:stream_start(ct:get_config({hosts, mim, domain}),
-                                                   ?NS_JABBER_CLIENT)),
+                                                    ?NS_JABBER_CLIENT)),
     escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>],
                    escalus_connection:get_stanza(Alice, no_stream_error_stanza_received)),
     escalus:assert(is_stream_end,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -521,7 +521,9 @@ wait_for_feature_before_auth({xmlstreamerror, _}, StateData) ->
     send_trailer(StateData),
     {stop, normal, StateData};
 wait_for_feature_before_auth(closed, StateData) ->
-    {stop, normal, StateData}.
+    {stop, normal, StateData};
+wait_for_feature_before_auth(_, StateData) ->
+    c2s_stream_error(mongoose_xmpp_errors:policy_violation(), StateData).
 
 compressed() ->
     #xmlel{name = <<"compressed">>,
@@ -622,7 +624,10 @@ wait_for_feature_after_auth({xmlstreamerror, _}, StateData) ->
     {stop, normal, StateData};
 
 wait_for_feature_after_auth(closed, StateData) ->
-    {stop, normal, StateData}.
+    {stop, normal, StateData};
+
+wait_for_feature_after_auth(_, StateData) ->
+    c2s_stream_error(mongoose_xmpp_errors:policy_violation(), StateData).
 
 -spec wait_for_session_or_sm(Item :: ejabberd:xml_stream_item(),
                              State :: state()) -> fsm_return().
@@ -666,7 +671,10 @@ wait_for_session_or_sm({xmlstreamerror, _}, StateData) ->
     {stop, normal, StateData};
 
 wait_for_session_or_sm(closed, StateData) ->
-    {stop, normal, StateData}.
+    {stop, normal, StateData};
+
+wait_for_session_or_sm(_, StateData) ->
+    c2s_stream_error(mongoose_xmpp_errors:policy_violation(), StateData).
 
 maybe_do_compress(El = #xmlel{name = Name, attrs = Attrs}, NextState, StateData) ->
     SockMod = (StateData#state.sockmod):get_sockmod(StateData#state.socket),


### PR DESCRIPTION
Addressing my introductory story MIM-849. While setting session up in `ejabberd_c2s` fsm there are cases where on receiving stanzas that are not following any of the standarized sequence the state machine is crashing. I ensured these cases to close fsm gracefully and reply to client with `policy-violation` error.

Due to difficulties with stanzas injecting into `ejabberd_c2s:wait_for_sasl_response/2` state using `escalus` library, I agreed with @NelsonVides to omit this part of PR and focus on discovering another parts of the project.

I also took the opportunity to do a little refactor of copy-pasted code in state machine.