### PR TITLE
Allow for boolean types in REST calls

### DIFF
--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -248,9 +248,11 @@ add_location_header(Result, ResourcePath, Req) ->
     Headers = #{<<"location">> => Path},
     cowboy_req:reply(201, Headers, Req).
 
--spec convert_arg(atom(), any()) -> integer() | float() | binary() | string() | {error, bad_type}.
+-spec convert_arg(atom(), any()) -> boolean() | integer() | float() | binary() | string() | {error, bad_type}.
 convert_arg(binary, Binary) when is_binary(Binary) ->
     Binary;
+convert_arg(boolean, Value) when is_boolean(Value) ->
+    Value;
 convert_arg(integer, Binary) when is_binary(Binary) ->
     binary_to_integer(Binary);
 convert_arg(integer, Integer) when is_integer(Integer) ->

--- a/src/mongoose_commands.erl
+++ b/src/mongoose_commands.erl
@@ -148,7 +148,7 @@
 
 -type typedef() :: [typedef_basic()] | typedef_basic().
 
--type typedef_basic() :: integer | binary | float. %% most basic primitives, string is a binary
+-type typedef_basic() :: boolean | integer | binary | float. %% most basic primitives, string is a binary
 
 -type argspec() :: typedef()
                   | {atom(), typedef()} %% a named argument
@@ -424,6 +424,8 @@ maybe_ignore_result(_, Res) ->
 check_type(ok, _) ->
     ok;
 check_type(A, A) ->
+    true;
+check_type({_Name, boolean}, Value) when is_boolean(Value) ->
     true;
 check_type({_Name, binary}, Value) when is_binary(Value) ->
     true;

--- a/test/commands_SUITE.erl
+++ b/test/commands_SUITE.erl
@@ -171,6 +171,9 @@ new_type_checker(_C) ->
     {false, _} = t_check_type([integer], [1, <<"z">>, 3]),
     true = t_check_type([], [1, 2, 3]),
     true = t_check_type([], []),
+    true = t_check_type({msg, boolean}, true),
+    true = t_check_type({msg, boolean}, false),
+    {false, _} = t_check_type({msg, boolean}, <<"true">>),
     ok.
 
 t_check_type(Spec, Value) ->


### PR DESCRIPTION
Maybe TODO: test it? Anybody has any idea how?

This allows to use JSON boolean types when we define commands like

```erlang
{name, some_name},
{category, <<"some_name">>},
{desc, <<"Do something">>},
{module, ?MODULE},
{function, some_name},
{action, some_action},
{args, [{caller, binary},
    {conversation_id, binary},
    {some_boolean_condition, boolean}]}, % <---
{result, {some_kind_of_result, binary}}
```

As we know, in JSON, `<<"false">>` is of type string, while `false` is of type boolean. Two different things, good to have both.