### PR TITLE
Change `ejabberd_*` modules to use mongoose_hooks

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -541,7 +541,7 @@ handle_local_hosts_config_change({{auth, Host}, OldVals, _}) ->
     end,
     ejabberd_auth:start(Host);
 handle_local_hosts_config_change({{ldap, Host}, _OldConfig, NewConfig}) ->
-    ok = ejabberd_hooks:run_fold(host_config_update, Host, ok, [Host, ldap, NewConfig]);
+    ok = mongoose_hooks:host_config_update(Host, ok, ldap, NewConfig);
 handle_local_hosts_config_change({{modules, Host}, OldModules, NewModules}) ->
     gen_mod_deps:replace_modules(Host, OldModules, NewModules);
 handle_local_hosts_config_change({{Key, _Host}, _Old, _New} = El) ->

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -260,7 +260,7 @@ get_accesscommands() ->
                   AccessCommands :: [ejabberd_commands:access_cmd()]
                  ) -> string() | integer() | {string(), integer()} | {string(), wrong_command_arguments}.
 try_run_ctp(Args, Auth, AccessCommands) ->
-    try ejabberd_hooks:run_fold(ejabberd_ctl_process, false, [Args]) of
+    try mongoose_hooks:ejabberd_ctl_process(false, Args) of
         false when Args /= [] ->
             try_call_command(Args, Auth, AccessCommands);
         false ->

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -404,10 +404,10 @@ do_route(Acc, From, To, El) ->
                 <<"error">> -> Acc;
                 <<"result">> -> Acc;
                 _ ->
-                    ejabberd_hooks:run_fold(local_send_to_resource_hook,
+                    mongoose_hooks:local_send_to_resource_hook(
                                             To#jid.lserver,
                                             Acc,
-                                            [From, To, El])
+                                            From, To, El)
             end
     end.
 

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -229,7 +229,7 @@ do_register_component({LDomain, _}, Handler, Node, IsHidden) ->
             Component = #external_component{domain = NDomain, handler = Handler,
                                             node = Node, is_hidden = IsHidden},
             mnesia:write(Component),
-            ejabberd_hooks:run(register_subhost, [LDomain, IsHidden]);
+            mongoose_hooks:register_subhost(ok, LDomain, IsHidden);
         _ -> mnesia:abort(route_already_exists)
     end.
 
@@ -307,7 +307,7 @@ do_unregister_component({LDomain, _}, Node) ->
             ok = mnesia:delete_object(external_component_global, Comp, write)
     end,
     ok = mnesia:delete({external_component, {LDomain, Node}}),
-    ejabberd_hooks:run(unregister_subhost, [LDomain]),
+    mongoose_hooks:unregister_subhost(ok, LDomain),
     ok.
 
 -spec unregister_component(Domain :: domain()) -> {atomic, ok}.
@@ -348,7 +348,7 @@ register_route_to_ldomain(error, Domain, _) ->
 register_route_to_ldomain(LDomain, _, Handler) ->
     mnesia:dirty_write(#route{domain = LDomain, handler = Handler}),
     % No support for hidden routes yet
-    ejabberd_hooks:run(register_subhost, [LDomain, false]).
+    mongoose_hooks:register_subhost(ok, LDomain, false).
 
 unregister_route(Domain) ->
     case jid:nameprep(Domain) of
@@ -356,7 +356,7 @@ unregister_route(Domain) ->
             erlang:error({invalid_domain, Domain});
         LDomain ->
             mnesia:dirty_delete(route, LDomain),
-            ejabberd_hooks:run(unregister_subhost, [LDomain])
+            mongoose_hooks:unregister_subhost(ok, LDomain)
     end.
 
 unregister_routes(Domains) ->

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -362,7 +362,7 @@ handle_info({route, From, To, Acc}, StateName, StateData) ->
            [component_host(StateData), jid:to_binary(From), jid:to_binary(To)]),
     case acl:match_rule(global, StateData#state.access, From) of
         allow ->
-            ejabberd_hooks:run_fold(packet_to_component, global, Acc, [From, To]),
+            mongoose_hooks:packet_to_component(Acc, From, To),
             Attrs2 = jlib:replace_from_to_attrs(jid:to_binary(From),
                                                 jid:to_binary(To),
                                                 Packet#xmlel.attrs),

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -115,9 +115,9 @@ cleanup(Node) ->
                                               #{location => ?LOCATION,
                                                 lserver => S,
                                                 element => undefined}),
-                                      ejabberd_hooks:run_fold(session_cleanup,
-                                                              S, Acc,
-                                                              [U, S, R, SID])
+                                      mongoose_hooks:session_cleanup(S,
+                                                                     Acc,
+                                                                     U, R, SID)
                               end, Es)
 
         end,

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -152,8 +152,9 @@ cleanup(Node) ->
                                   #{location => ?LOCATION,
                                     lserver => S,
                                     element => undefined}),
-                          ejabberd_hooks:run_fold(session_cleanup, S, Acc,
-                                                  [U, S, R, SID])
+                          mongoose_hooks:session_cleanup(S,
+                                                         Acc,
+                                                         U, R, SID)
                   end, Hashes).
 
 


### PR DESCRIPTION
This PR changes `ejabberd_*` modules to use `mongoose_hooks`. I did not add many doc comments because I wasn't sure about the meaning of the hooks, this should be added later.
The `ejabberd_ctl_process` has handlers added dynamically in `ejabberd_ctl:register_commands` but this part of code is not covered by tests, so I don't know whether it is used.

