### PR TITLE
Metrics xmpp stanzas count

### DIFF
--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -46,7 +46,8 @@
          xmpp_components_are_reported/1,
          api_are_reported/1,
          transport_mechanisms_are_reported/1,
-         outgoing_pools_are_reported/1
+         outgoing_pools_are_reported/1,
+         xmpp_stanzas_counts_are_reported/1
         ]).
 
 -export([
@@ -85,6 +86,7 @@ all() ->
      api_are_reported,
      transport_mechanisms_are_reported,
      outgoing_pools_are_reported,
+     xmpp_stanzas_counts_are_reported,
      {group, log_transparency}
     ].
 
@@ -291,6 +293,9 @@ transport_mechanisms_are_reported(_Config) ->
 outgoing_pools_are_reported(_Config) ->
     mongoose_helper:wait_until(fun outgoing_pools_are_reported/0, true).
 
+xmpp_stanzas_counts_are_reported(_Config) ->
+    mongoose_helper:wait_until(fun xmpp_stanzas_counts_are_reported/0, true).
+
 just_removed_from_config_logs_question(_Config) ->
     disable_system_metrics(mim3()),
     remove_service_from_config(service_mongoose_system_metrics),
@@ -481,6 +486,9 @@ transport_mechanisms_are_reported() ->
 
 outgoing_pools_are_reported() ->
     is_in_table(<<"outgoing_pools">>).
+
+xmpp_stanzas_counts_are_reported() ->
+    is_in_table(<<"xmppMessageSent">>).
 
 more_than_one_component_is_reported() ->
     Tab = ets:tab2list(?ETS_TABLE),

--- a/src/system_metrics/mongoose_system_metrics_file.erl
+++ b/src/system_metrics/mongoose_system_metrics_file.erl
@@ -19,6 +19,17 @@ save(Reports) ->
 -spec read() -> [mongoose_system_metrics_collector:report_struct()].
 read() ->
     case file:read_file(location()) of
-        {ok, JSON} -> jiffy:decode(JSON, [return_maps]);
+        {ok, JSON} ->
+            Report = jiffy:decode(JSON, [return_maps]),
+            [#{report_name => b2a(Name), key => b2a(Key), value => b2a(Value)} ||
+                #{<<"report_name">> := Name,
+                <<"key">> := Key,
+                <<"value">> := Value}  <- Report];
         _ -> []
     end.
+
+-spec b2a(integer() | binary()) -> atom() | integer().
+b2a(Int) when is_integer(Int) ->
+    Int;
+b2a(Bin) ->
+    binary_to_atom(Bin, utf8).

--- a/src/system_metrics/mongoose_system_metrics_file.erl
+++ b/src/system_metrics/mongoose_system_metrics_file.erl
@@ -3,7 +3,7 @@
 -include("mongoose.hrl").
 
 -export([location/0]).
--export([save/1]).
+-export([save/1, read/0]).
 
 -spec location() -> string().
 location() ->
@@ -15,3 +15,10 @@ save(Reports) ->
     JSON = jiffy:encode(Reports, [pretty]),
     file:write_file(location(), JSON),
     ok.
+
+-spec read() -> [mongoose_system_metrics_collector:report_struct()].
+read() ->
+    case file:read_file(location()) of
+        {ok, JSON} -> jiffy:decode(JSON, [return_maps]);
+        _ -> []
+    end.

--- a/src/system_metrics/mongoose_system_metrics_file.erl
+++ b/src/system_metrics/mongoose_system_metrics_file.erl
@@ -3,7 +3,7 @@
 -include("mongoose.hrl").
 
 -export([location/0]).
--export([save/1, read/0]).
+-export([save/1]).
 
 -spec location() -> string().
 location() ->
@@ -16,20 +16,3 @@ save(Reports) ->
     file:write_file(location(), JSON),
     ok.
 
--spec read() -> [mongoose_system_metrics_collector:report_struct()].
-read() ->
-    case file:read_file(location()) of
-        {ok, JSON} ->
-            Report = jiffy:decode(JSON, [return_maps]),
-            [#{report_name => b2a(Name), key => b2a(Key), value => b2a(Value)} ||
-                #{<<"report_name">> := Name,
-                <<"key">> := Key,
-                <<"value">> := Value}  <- Report];
-        _ -> []
-    end.
-
--spec b2a(integer() | binary()) -> atom() | integer().
-b2a(Int) when is_integer(Int) ->
-    Int;
-b2a(Bin) ->
-    binary_to_atom(Bin, utf8).


### PR DESCRIPTION
This PR extends functionality of collecting metrics. It allows to gather the number of sent and received:
* Message Stanzas
* Iq Stanzas
* Presence Stanzas

The information is retrieved from exometer. The metrics are sending information regarding number of stanzas since the last report and total amount of stanzas as reported by exometer. 
