### PR TITLE
Chat markers cache

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -76,7 +76,7 @@
 %% {escalus_user_db, {module, YourModule, ListOfOptions}}.
 
 %% Log all stanzas sent and received (consumed) in the test cases
-%% {stanza_log, true}.
+{stanza_log, true}.
 
 {escalus_users, [
     {alice, [

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -76,7 +76,7 @@
 %% {escalus_user_db, {module, YourModule, ListOfOptions}}.
 
 %% Log all stanzas sent and received (consumed) in the test cases
-{stanza_log, true}.
+%% {stanza_log, true}.
 
 {escalus_users, [
     {alice, [

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -66,7 +66,6 @@ init_per_group(chatmarkers, C) ->
         Modules = [{mod_offline, [{store_groupchat_messages, true},
                                   {backend, rdbms}]},
                    {mod_offline_chatmarkers,[{store_groupchat_messages, true}]},
-                   {mod_smart_markers,[]},
                    {mod_muc_light, [{backend, rdbms}]}],
         Config = dynamic_modules:save_modules(domain(), C),
         dynamic_modules:ensure_modules(domain(), Modules),

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -642,3 +642,42 @@ CREATE TABLE muc_registered(
     nick VARCHAR(250)       NOT NULL,
     PRIMARY KEY (muc_host, luser, lserver)
 );
+
+-- from_jid, to_jid and thread have 250 characters in MySQL
+-- but here we are limited by index size (900 bytes)
+CREATE TABLE smart_markers (
+    from_jid NVARCHAR(150) NOT NULL,
+    to_jid NVARCHAR(150) NOT NULL,
+    thread NVARCHAR(145) NOT NULL,
+    -- chat marker types:
+    -- 'R' - received
+    -- 'D' - displayed
+    -- 'A' - acknowledged
+    type NVARCHAR(1) NOT NULL,
+    msg_id NVARCHAR(250) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    CONSTRAINT pk_smart_markers PRIMARY KEY CLUSTERED(
+            from_jid ASC,
+            to_jid ASC,
+            thread ASC,
+            type ASC
+        )
+);
+
+CREATE INDEX i_smart_markers ON smart_markers(to_jid, thread);
+
+-- jid, thread and room have 250 characters in MySQL
+-- but here we are limited by index size (900 bytes)
+CREATE TABLE offline_markers (
+    jid NVARCHAR(150) NOT NULL,
+    thread NVARCHAR(145) NOT NULL,
+    room NVARCHAR(150) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    CONSTRAINT pk_offline_markers PRIMARY KEY CLUSTERED(
+                jid ASC,
+                thread ASC,
+                room ASC
+        )
+);
+
+CREATE INDEX i_offline_markers ON offline_markers(jid);

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -490,3 +490,14 @@ CREATE TABLE smart_markers (
 ) CHARACTER SET utf8mb4;
 
 CREATE INDEX i_smart_markers USING BTREE ON smart_markers(to_jid, thread);
+
+
+CREATE TABLE offline_markers (
+    jid VARCHAR(250) NOT NULL,
+    thread VARCHAR(250) NOT NULL,
+    room VARCHAR(250) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    PRIMARY KEY(jid, thread, room)
+) CHARACTER SET utf8mb4;
+
+CREATE INDEX i_offline_markers ON offline_markers(jid);

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -475,3 +475,18 @@ CREATE TABLE mongoose_cluster_id (
     k varchar(50) PRIMARY KEY,
     v text
 );
+
+CREATE TABLE smart_markers (
+    from_jid VARCHAR(250) NOT NULL,
+    to_jid VARCHAR(250) NOT NULL,
+    thread VARCHAR(250) NOT NULL,
+    -- 'R' - received
+    -- 'D' - displayed
+    -- 'A' - acknowledged
+    type ENUM('R', 'D', 'A') NOT NULL,
+    msg_id VARCHAR(250) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    PRIMARY KEY(from_jid, to_jid, thread, type)
+) CHARACTER SET utf8mb4;
+
+CREATE INDEX i_smart_markers USING BTREE ON smart_markers(to_jid, thread);

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -431,3 +431,32 @@ CREATE TABLE mongoose_cluster_id (
     k varchar(50) PRIMARY KEY,
     v text
 );
+
+-- chat marker types:
+-- 'R' - received
+-- 'D' - displayed
+-- 'A' - acknowledged
+CREATE TYPE chat_marker_type AS ENUM('R', 'D', 'A');
+
+CREATE TABLE smart_markers (
+    from_jid VARCHAR(250) NOT NULL,
+    to_jid VARCHAR(250) NOT NULL,
+    thread VARCHAR(250) NOT NULL,
+    type chat_marker_type NOT NULL,
+    msg_id VARCHAR(250) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    PRIMARY KEY(from_jid, to_jid, thread, type)
+);
+
+CREATE INDEX i_smart_markers ON smart_markers(to_jid, thread);
+
+
+CREATE TABLE offline_markers (
+    jid VARCHAR(250) NOT NULL,
+    thread VARCHAR(250) NOT NULL,
+    room VARCHAR(250) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    PRIMARY KEY(jid, thread, room)
+);
+
+CREATE INDEX i_offline_markers ON offline_markers(jid);

--- a/rebar.config
+++ b/rebar.config
@@ -192,4 +192,4 @@
   {path, ["/tmp", "_build/test/cover"]}
  ]}.
 
-{edoc_opts, [{preprocess, true}]}.
+{edoc_opts, [{preprocess, true}, {dir, "edoc"}]}.

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -1,0 +1,231 @@
+%%%----------------------------------------------------------------------------
+%%% @copyright (C) 2020, Erlang Solutions Ltd.
+%%% @doc
+%%%   this module implements storage of the latest chat markers
+%%%   sent by the users. this can be used to optimize mod_offline
+%%%   functionality, or to implement custom fetching protocol and
+%%%   avoid storage of chat markers in MAM.
+%%%
+%%%   Please be aware of the next implementation details:
+%%%
+%%%    1) current implementation is based on user_send_packet hook.
+%%%       it doesn't work for s2s connections, but usage of another
+%%%       hook (e.g. filter_local_packet) makes implementation harder
+%%%       and results in multiple processing of one and the same
+%%%       chat marker notification (sent to different users by MUC).
+%%%       however that is the only possible way to deal with group
+%%%       chat messages sent from the room to the user over s2s.
+%%%
+%%%                                            S2S
+%%%                                             +
+%%%                                             |
+%%%                +--------------------+       |
+%%%                |                    |       |   filter
+%%%                |                    +--------------->
+%%%       send     |                    |       |   filter
+%%%       +------->+       ROOM         +--------------->
+%%%                |                    |       |   filter
+%%%                |                    +--------------->
+%%%                |                    |       |
+%%%                +--------------------+       |
+%%%                                             |
+%%%                                             +
+%%%
+%%%    2) DB backend requires us to provide host information, and
+%%%       the host is always the recipient's server in case one2one
+%%%       messages, and a master domain of the MUC service in case
+%%%       of groupchat.
+%%%
+%%%    3) MUC light doesn't have message serialization! So it doesn't
+%%%       guaranty one and the same message order for different users.
+%%%       This can result in a race condition situation when different
+%%%       users track (and mark) different messages as the last in a
+%%%       chat history. however, this is rare situation, and it self
+%%%       recovers on the next message in the room. Anyway storing chat
+%%%       markers in MAM doesn't fix this problem.
+%%%
+%%% @end
+%%%----------------------------------------------------------------------------
+-module(mod_smart_markers).
+
+-include("jlib.hrl").
+
+-xep([{xep, 333}, {version, "0.3"}]).
+-behaviour(gen_mod).
+
+%% gen_mod API
+-export([start/2, stop/1]).
+
+%% gen_mod API
+-export([get_chat_markers/4]).
+
+%% Hook handlers
+-export([user_send_packet/4]).
+
+%%--------------------------------------------------------------------
+%% Type declarations
+%%--------------------------------------------------------------------
+-type maybe_thread() :: undefined|binary().
+-type chat_marker_type() :: received | displayed | acknowledged.
+-type chat_type() :: one2one | groupchat.
+
+-type chat_marker() :: #{from := jid:jid(),
+                         to := jid:jid(),
+                         thread := maybe_thread(), %%it is not optional!!!
+                         type := chat_marker_type(),
+                         timestamp := erlang:timestamp(),
+                         id := binary()}.
+
+-export_type([chat_marker/0]).
+
+%%--------------------------------------------------------------------
+%% DB backend behaviour definition
+%%--------------------------------------------------------------------
+-callback init(Host :: jid:lserver(), Opts :: proplists:proplist()) -> ok.
+
+%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
+%% as composite database key. if key is not available in the database, then
+%% chat marker must be added. otherwise this function should update chat
+%% marker record for that composite key.
+-callback update_chat_marker(Host :: jid:lserver(), ChatMarker :: chat_marker()) -> ok.
+
+%% this function must return the latest chat markers sent to the
+%% user/room (with or w/o thread) later than provided timestamp.
+-callback get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
+                           Thread :: maybe_thread(), TS :: erlang:timestamp()) ->
+                              [chat_marker()].
+
+%%--------------------------------------------------------------------
+%% gen_mod API
+%%--------------------------------------------------------------------
+-spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
+start(Host, Opts) ->
+    gen_mod:start_backend_module(?MODULE, add_default_backend(Opts)),
+    mod_smart_markers_backend:init(Host, Opts),
+    ejabberd_hooks:add(hooks(Host)).
+
+-spec stop(Host :: jid:lserver()) -> ok.
+stop(Host) ->
+    ejabberd_hooks:delete(hooks(Host)).
+
+%%--------------------------------------------------------------------
+%% Hook handlers
+%%--------------------------------------------------------------------
+-spec hooks(Host :: jid:lserver()) -> [ejabberd_hooks:hook()].
+hooks(Host) ->
+    [{user_send_packet, Host, ?MODULE, user_send_packet, 90}].
+
+-spec user_send_packet(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
+                       Packet :: exml:element()) -> mongoose_acc:t().
+user_send_packet(Acc, From, To, Packet = #xmlel{name = <<"message">>}) ->
+    case is_valid_message(From, To, Packet) of
+        {true, Host} ->
+            maybe_update_chat_markers(Host, Acc, From, To, Packet);
+        _ -> Acc
+    end;
+user_send_packet(Acc, _From, _To, _Packet) ->
+    Acc.
+
+%%--------------------------------------------------------------------
+%% Other API
+%%--------------------------------------------------------------------
+-spec get_chat_markers(ChatType :: chat_type(), To :: jid:jid(),
+                       Thread :: maybe_thread(), TS :: os:timestamp()) -> [chat_marker()].
+get_chat_markers(ChatType, #jid{lserver = LServer} = To, Thread, TS) ->
+    %% internal API, no room access rights verification here!
+    Host = case ChatType of
+               one2one -> LServer;
+               groupchat ->
+                   {ok, H} = mongoose_subhosts:get_host(LServer),
+                   H
+           end,
+    mod_smart_markers_backend:get_chat_markers(Host, To, Thread, TS).
+
+%%--------------------------------------------------------------------
+%% Local functions
+%%--------------------------------------------------------------------
+-spec maybe_update_chat_markers(Host :: jid:lserver(), Acc :: mongoose_acc:t(),
+                                From :: jid:jid(), To :: jid:jid(),
+                                Packet :: exml:element()) -> mongoose_acc:t().
+maybe_update_chat_markers(Host, Acc, From, To, Packet) ->
+    TS = mongoose_acc:timestamp(Acc),
+    case extract_chat_markers(TS, From, To, Packet) of
+        [] -> Acc;
+        ChatMarkers ->
+            [mod_smart_markers_backend:update_chat_marker(Host, CM) || CM <- ChatMarkers],
+            mongoose_acc:set_permanent(?MODULE, timestamp, TS, Acc)
+    end.
+
+-spec extract_chat_markers(erlang:timestamp(), From :: jid:jid(), To :: jid:jid(),
+                           Packet :: exml:element()) -> [chat_marker()].
+extract_chat_markers(TS, From, To, Packet) ->
+    case get_chat_markers(Packet) of
+        [] -> [];
+        ChatMarkers ->
+            CM = #{from => From, to => To, thread => get_thread(Packet), timestamp => TS},
+            [CM#{type => Type, id => Id} || {Type, Id} <- ChatMarkers]
+    end.
+
+-spec get_chat_markers(exml:element()) -> [{chat_marker_type(), Id :: binary()}].
+get_chat_markers(#xmlel{children = Children}) ->
+    lists:filtermap(fun is_chat_marker_element/1, Children).
+
+-spec is_chat_marker_element(exml:element()) ->
+    false | {true, {chat_marker_type(), Id :: binary}}.
+is_chat_marker_element(#xmlel{name = <<"received">>} = El) ->
+    check_chat_marker_attributes(received, El);
+is_chat_marker_element(#xmlel{name = <<"displayed">>} = El) ->
+    check_chat_marker_attributes(displayed, El);
+is_chat_marker_element(#xmlel{name = <<"acknowledged">>} = El) ->
+    check_chat_marker_attributes(acknowledged, El);
+is_chat_marker_element(_) ->
+    false.
+
+-spec check_chat_marker_attributes(chat_marker_type(), exml:element()) ->
+    false | {true, {chat_marker_type(), Id :: binary()}}.
+check_chat_marker_attributes(Type, El) ->
+    NS = exml_query:attr(El, <<"xmlns">>),
+    Id = exml_query:attr(El, <<"id">>),
+    ?NS_CHAT_MARKERS =:= NS andalso Id =/= undefined andalso {true, {Type, Id}}.
+
+-spec get_thread(exml:element()) -> maybe_thread().
+get_thread(El) ->
+    case exml_query:path(El, [{element, <<"thread">>}, cdata]) of
+        Thread when Thread =/= <<>> -> Thread;
+        _ -> undefined
+    end.
+
+-spec is_valid_message(From :: jid:jid(), To :: jid:jid(),
+                       Packet :: exml:element()) -> false | {true, Host :: jid:lserver()}.
+is_valid_message(From, To, Packet) ->
+    case exml_query:attr(Packet, <<"type">>, undefined) of
+        <<"groupchat">> ->
+            can_access_room(From, To) andalso get_host(groupchat, To#jid.lserver);
+        _ ->
+            get_host(one2one, To#jid.lserver)
+    end.
+
+-spec get_host(chat_type(), jid:lserver()) -> false | {true, jid:lserver()}.
+get_host(groupchat, SubHost) ->
+    case mongoose_subhosts:get_host(SubHost) of
+        undefined -> false;
+        {ok,Host} -> {true,Host}
+    end;
+get_host(one2one, Host) ->
+    Hosts = ejabberd_config:get_global_option(hosts),
+    case lists:member(Host, Hosts) of
+        false -> false;
+        _ -> {true, Host}
+    end.
+
+-spec can_access_room(User :: jid:jid(), Room :: jid:jid()) -> boolean().
+can_access_room(User, Room) ->
+    ejabberd_hooks:run_fold(can_access_room, Room#jid.lserver, false, [Room, User]).
+
+add_default_backend(Opts) ->
+    case lists:keyfind(backend, 2, Opts) of
+        false ->
+            [{backend, rdbms} | Opts];
+        _ ->
+            Opts
+    end.

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -80,7 +80,7 @@
                          to := jid:jid(),
                          thread := maybe_thread(), %%it is not optional!!!
                          type := chat_marker_type(),
-                         timestamp := erlang:timestamp(),
+                         timestamp := integer(), %microsecond
                          id := binary()}.
 
 -export_type([chat_marker/0]).
@@ -103,7 +103,7 @@
 %%% user/room (with or w/o thread) later than provided timestamp.
 %%% @end
 -callback get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
-                           Thread :: maybe_thread(), TS :: erlang:timestamp()) ->
+                           Thread :: maybe_thread(), Timestamp :: integer()) ->
                               [chat_marker()].
 
 %%--------------------------------------------------------------------
@@ -168,7 +168,7 @@ maybe_update_chat_markers(Host, Acc, From, To, Packet) ->
             mongoose_acc:set_permanent(?MODULE, timestamp, TS, Acc)
     end.
 
--spec extract_chat_markers(erlang:timestamp(), From :: jid:jid(), To :: jid:jid(),
+-spec extract_chat_markers(Timestamp::integer(), From :: jid:jid(), To :: jid:jid(),
                            Packet :: exml:element()) -> [chat_marker()].
 extract_chat_markers(TS, From, To, Packet) ->
     case get_chat_markers(Packet) of

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -1,21 +1,22 @@
 %%%----------------------------------------------------------------------------
 %%% @copyright (C) 2020, Erlang Solutions Ltd.
 %%% @doc
-%%%   this module implements storage of the latest chat markers
-%%%   sent by the users. this can be used to optimize mod_offline
+%%%   This module implements storage of the latest chat markers
+%%%   sent by the users. This can be used to optimize mod_offline
 %%%   functionality, or to implement custom fetching protocol and
 %%%   avoid storage of chat markers in MAM.
 %%%
 %%%   Please be aware of the next implementation details:
 %%%
-%%%    1) current implementation is based on user_send_packet hook.
-%%%       it doesn't work for s2s connections, but usage of another
+%%%    1) Current implementation is based on user_send_packet hook.
+%%%       It doesn't work for s2s connections, but usage of another
 %%%       hook (e.g. filter_local_packet) makes implementation harder
 %%%       and results in multiple processing of one and the same
 %%%       chat marker notification (sent to different users by MUC).
-%%%       however that is the only possible way to deal with group
+%%%       However that is the only possible way to deal with group
 %%%       chat messages sent from the room to the user over s2s.
 %%%
+%%%       ```
 %%%                                            S2S
 %%%                                             +
 %%%                                             |
@@ -30,17 +31,23 @@
 %%%                +--------------------+       |
 %%%                                             |
 %%%                                             +
+%%%    '''
 %%%
 %%%    2) DB backend requires us to provide host information, and
 %%%       the host is always the recipient's server in case one2one
 %%%       messages, and a master domain of the MUC service in case
 %%%       of groupchat.
 %%%
-%%%    3) MUC light doesn't have message serialization! So it doesn't
+%%%    3) It is the client application's responsibility to ensure that
+%%%       chat markers move only forward. There is no verification of
+%%%       chat markers in this module, it just stores the latest chat
+%%%       marker information sent by the user.
+%%%
+%%%    4) MUC light doesn't have message serialization! So it doesn't
 %%%       guaranty one and the same message order for different users.
 %%%       This can result in a race condition situation when different
 %%%       users track (and mark) different messages as the last in a
-%%%       chat history. however, this is rare situation, and it self
+%%%       chat history. However, this is a rare situation, and it self
 %%%       recovers on the next message in the room. Anyway storing chat
 %%%       markers in MAM doesn't fix this problem.
 %%%
@@ -83,14 +90,18 @@
 %%--------------------------------------------------------------------
 -callback init(Host :: jid:lserver(), Opts :: proplists:proplist()) -> ok.
 
-%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
-%% as composite database key. if key is not available in the database, then
-%% chat marker must be added. otherwise this function should update chat
-%% marker record for that composite key.
+%%% @doc
+%%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
+%%% as a composite database key. If key is not available in the database,
+%%% then chat marker must be added. Otherwise this function must update
+%%% chat marker record for that composite key.
+%%% @end
 -callback update_chat_marker(Host :: jid:lserver(), ChatMarker :: chat_marker()) -> ok.
 
-%% this function must return the latest chat markers sent to the
-%% user/room (with or w/o thread) later than provided timestamp.
+%%% @doc
+%%% This function must return the latest chat markers sent to the
+%%% user/room (with or w/o thread) later than provided timestamp.
+%%% @end
 -callback get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
                            Thread :: maybe_thread(), TS :: erlang:timestamp()) ->
                               [chat_marker()].
@@ -100,7 +111,8 @@
 %%--------------------------------------------------------------------
 -spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
 start(Host, Opts) ->
-    gen_mod:start_backend_module(?MODULE, add_default_backend(Opts)),
+    gen_mod:start_backend_module(?MODULE, add_default_backend(Opts),
+                                 [get_chat_markers, update_chat_marker]),
     mod_smart_markers_backend:init(Host, Opts),
     ejabberd_hooks:add(hooks(Host)).
 
@@ -209,7 +221,7 @@ is_valid_message(From, To, Packet) ->
 get_host(groupchat, SubHost) ->
     case mongoose_subhosts:get_host(SubHost) of
         undefined -> false;
-        {ok,Host} -> {true,Host}
+        {ok, Host} -> {true, Host}
     end;
 get_host(one2one, Host) ->
     Hosts = ejabberd_config:get_global_option(hosts),
@@ -220,7 +232,7 @@ get_host(one2one, Host) ->
 
 -spec can_access_room(User :: jid:jid(), Room :: jid:jid()) -> boolean().
 can_access_room(User, Room) ->
-    ejabberd_hooks:run_fold(can_access_room, Room#jid.lserver, false, [Room, User]).
+    mongoose_hooks:can_access_room(Room#jid.lserver, false, Room, User).
 
 add_default_backend(Opts) ->
     case lists:keyfind(backend, 2, Opts) of

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -90,18 +90,14 @@
 %%--------------------------------------------------------------------
 -callback init(Host :: jid:lserver(), Opts :: proplists:proplist()) -> ok.
 
-%%% @doc
-%%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
+%%% 'from', 'to', 'thread' and 'type' keys of the ChatMarker map serve
 %%% as a composite database key. If key is not available in the database,
 %%% then chat marker must be added. Otherwise this function must update
 %%% chat marker record for that composite key.
-%%% @end
 -callback update_chat_marker(Host :: jid:lserver(), ChatMarker :: chat_marker()) -> ok.
 
-%%% @doc
 %%% This function must return the latest chat markers sent to the
 %%% user/room (with or w/o thread) later than provided timestamp.
-%%% @end
 -callback get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
                            Thread :: maybe_thread(), Timestamp :: integer()) ->
                               [chat_marker()].

--- a/src/mod_smart_markers_rdbms.erl
+++ b/src/mod_smart_markers_rdbms.erl
@@ -1,8 +1,7 @@
 %%%----------------------------------------------------------------------------
 %%% @copyright (C) 2020, Erlang Solutions Ltd.
 %%% @doc
-%%%    mnesia backend for mod_smart_markers,
-%%%    prototyping only
+%%%    RDBMS backend for mod_smart_markers
 %%% @end
 %%%----------------------------------------------------------------------------
 -module(mod_smart_markers_rdbms).
@@ -24,17 +23,21 @@ init(Host, _) ->
                                  InsertFields, UpdateFields, KeyFields),
     ok.
 
-%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
-%% as composite database key. if key is not available in the database, then
-%% chat marker must be added. otherwise this function should update chat
-%% marker record for that composite key.
+%%% @doc
+%%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
+%%% as a composite database key. If key is not available in the database,
+%%% then chat marker must be added. Otherwise this function must update
+%%% chat marker record for that composite key.
+%%% @end
 -spec update_chat_marker(Host :: jid:lserver(),
                          ChatMarker :: mod_smart_markers:chat_marker()) -> ok.
 update_chat_marker(Host, ChatMarker) ->
     do_update_chat_marker(Host, ChatMarker).
 
-%% this function must return the latest chat markers sent to the
-%% user/room (with or w/o thread) later than provided timestamp.
+%%% @doc
+%%% This function must return the latest chat markers sent to the
+%%% user/room (with or w/o thread) later than provided timestamp.
+%%% @end
 -spec get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
                        Thread :: mod_smart_markers:maybe_thread(),
                        TS :: erlang:timestamp()) -> [mod_smart_markers:chat_marker()].

--- a/src/mod_smart_markers_rdbms.erl
+++ b/src/mod_smart_markers_rdbms.erl
@@ -20,8 +20,8 @@ init(Host, _) ->
     UpdateFields = [<<"msg_id">>, <<"timestamp">>],
     InsertFields = KeyFields ++ UpdateFields,
     QueryName = smart_markers_upsert,
-    {ok, QueryName} = rdbms_queries:prepare_upsert(Host, QueryName, smart_markers,
-                                                   InsertFields, UpdateFields, KeyFields),
+    rdbms_queries:prepare_upsert(Host, QueryName, smart_markers,
+                                 InsertFields, UpdateFields, KeyFields),
     ok.
 
 %% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve

--- a/src/mod_smart_markers_rdbms.erl
+++ b/src/mod_smart_markers_rdbms.erl
@@ -24,7 +24,7 @@ init(Host, _) ->
     ok.
 
 %%% @doc
-%%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
+%%% 'from', 'to', 'thread' and 'type' keys of the ChatMarker map serve
 %%% as a composite database key. If key is not available in the database,
 %%% then chat marker must be added. Otherwise this function must update
 %%% chat marker record for that composite key.

--- a/src/mod_smart_markers_rdbms.erl
+++ b/src/mod_smart_markers_rdbms.erl
@@ -1,0 +1,121 @@
+%%%----------------------------------------------------------------------------
+%%% @copyright (C) 2020, Erlang Solutions Ltd.
+%%% @doc
+%%%    mnesia backend for mod_smart_markers,
+%%%    prototyping only
+%%% @end
+%%%----------------------------------------------------------------------------
+-module(mod_smart_markers_rdbms).
+-author("denysgonchar").
+-behavior(mod_smart_markers).
+
+-export([init/2, update_chat_marker/2, get_chat_markers/4]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+-spec init(Host :: jid:lserver(), Opts :: proplists:proplist()) -> ok.
+init(Host, _) ->
+    KeyFields = [<<"from_jid">>, <<"to_jid">>, <<"thread">>, <<"type">>],
+    UpdateFields = [<<"msg_id">>, <<"timestamp">>],
+    InsertFields = KeyFields ++ UpdateFields,
+    QueryName = smart_markers_upsert,
+    {ok, QueryName} = rdbms_queries:prepare_upsert(Host, QueryName, smart_markers,
+                                                   InsertFields, UpdateFields, KeyFields),
+    ok.
+
+%% 'from', 'to', 'thread' and 'type' keys of the chat_marker() map serve
+%% as composite database key. if key is not available in the database, then
+%% chat marker must be added. otherwise this function should update chat
+%% marker record for that composite key.
+-spec update_chat_marker(Host :: jid:lserver(),
+                         ChatMarker :: mod_smart_markers:chat_marker()) -> ok.
+update_chat_marker(Host, ChatMarker) ->
+    do_update_chat_marker(Host, ChatMarker).
+
+%% this function must return the latest chat markers sent to the
+%% user/room (with or w/o thread) later than provided timestamp.
+-spec get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
+                       Thread :: mod_smart_markers:maybe_thread(),
+                       TS :: erlang:timestamp()) -> [mod_smart_markers:chat_marker()].
+get_chat_markers(Host, To, Thread, TS) ->
+    do_get_chat_markers(Host, To, Thread, TS).
+
+%%--------------------------------------------------------------------
+%% local functions
+%%--------------------------------------------------------------------
+do_update_chat_marker(Host, #{from := From, to := To, thread := Thread,
+                              type := Type, timestamp := TS, id := Id}) ->
+    FromEncoded = encode_jid(From),
+    ToEncoded = encode_jid(To),
+    ThreadEncoded = encode_thread(Thread),
+    TypeEncoded = encode_type(Type),
+    TSEncoded = encode_timestamp(TS),
+    KeyValues = [FromEncoded, ToEncoded, ThreadEncoded, TypeEncoded],
+    UpdateValues = [Id, TSEncoded],
+    InsertValues = KeyValues ++ UpdateValues,
+    Res = rdbms_queries:execute_upsert(Host, smart_markers_upsert,
+                                       InsertValues, UpdateValues, KeyValues),
+    ok = check_upsert_result(Res).
+
+do_get_chat_markers(Host, To, Thread, TS) ->
+    ToEscaped = escape(encode_jid(To)),
+    ThreadEscaped = escape(encode_thread(Thread)),
+    TSEscaped = escape(encode_timestamp(TS)),
+    SelectQuery = [
+        "select from_jid, to_jid, thread, type, msg_id, timestamp from smart_markers"
+        " WHERE to_jid = ", ToEscaped, " AND thread = ", ThreadEscaped,
+        " AND timestamp >= ", TSEscaped, " ;"],
+    {selected, ChatMarkers} = mongoose_rdbms:sql_query(Host, SelectQuery),
+    decode(ChatMarkers).
+
+encode_jid(JID) -> jid:to_binary(jid:to_lus(JID)).
+
+encode_thread(undefined) -> <<"">>;
+encode_thread(Thread)    -> Thread.
+
+encode_type(received)     -> <<"R">>;
+encode_type(displayed)    -> <<"D">>;
+encode_type(acknowledged) -> <<"A">>.
+
+encode_timestamp(TS) -> usec:from_now(TS).
+
+escape(String) when is_binary(String) -> escape_string(String);
+escape(Int) when is_integer(Int)      -> escape_int(Int).
+
+escape_string(String) ->
+    mongoose_rdbms:use_escaped_string(mongoose_rdbms:escape_string(String)).
+
+escape_int(Int) ->
+    mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).
+
+%% MySQL returns 1 when an upsert is an insert
+%% and 2, when an upsert acts as update
+check_upsert_result({updated, 1}) -> ok;
+check_upsert_result({updated, 2}) -> ok;
+check_upsert_result(Result) ->
+    {error, {bad_result, Result}}.
+
+decode(ChatMarkersList) ->
+    [decode_record(ChatMarker) || ChatMarker <- ChatMarkersList].
+
+decode_record({From, To, Thread, Type, Id, TS}) ->
+    #{from => decode_jid(From),
+      to => decode_jid(To),
+      thread => decode_thread(Thread),
+      type => decode_type(Type),
+      timestamp => decode_timestamp(TS),
+      id => Id}.
+
+decode_jid(EncodedJID) -> jid:from_binary(EncodedJID).
+
+decode_thread(<<"">>) -> undefined;
+decode_thread(Thread) -> Thread.
+
+decode_type(<<"R">>) -> received;
+decode_type(<<"D">>) -> displayed;
+decode_type(<<"A">>) -> acknowledged.
+
+decode_timestamp(EncodedTS) ->
+    usec:to_now(mongoose_rdbms:result_to_integer(EncodedTS)).
+

--- a/src/mod_smart_markers_rdbms.erl
+++ b/src/mod_smart_markers_rdbms.erl
@@ -40,7 +40,7 @@ update_chat_marker(Host, ChatMarker) ->
 %%% @end
 -spec get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
                        Thread :: mod_smart_markers:maybe_thread(),
-                       TS :: erlang:timestamp()) -> [mod_smart_markers:chat_marker()].
+                       Timestamp :: integer()) -> [mod_smart_markers:chat_marker()].
 get_chat_markers(Host, To, Thread, TS) ->
     do_get_chat_markers(Host, To, Thread, TS).
 
@@ -53,9 +53,8 @@ do_update_chat_marker(Host, #{from := From, to := To, thread := Thread,
     ToEncoded = encode_jid(To),
     ThreadEncoded = encode_thread(Thread),
     TypeEncoded = encode_type(Type),
-    TSEncoded = encode_timestamp(TS),
     KeyValues = [FromEncoded, ToEncoded, ThreadEncoded, TypeEncoded],
-    UpdateValues = [Id, TSEncoded],
+    UpdateValues = [Id, TS],
     InsertValues = KeyValues ++ UpdateValues,
     Res = rdbms_queries:execute_upsert(Host, smart_markers_upsert,
                                        InsertValues, UpdateValues, KeyValues),
@@ -64,7 +63,7 @@ do_update_chat_marker(Host, #{from := From, to := To, thread := Thread,
 do_get_chat_markers(Host, To, Thread, TS) ->
     ToEscaped = escape(encode_jid(To)),
     ThreadEscaped = escape(encode_thread(Thread)),
-    TSEscaped = escape(encode_timestamp(TS)),
+    TSEscaped = escape(TS),
     SelectQuery = [
         "select from_jid, to_jid, thread, type, msg_id, timestamp from smart_markers"
         " WHERE to_jid = ", ToEscaped, " AND thread = ", ThreadEscaped,
@@ -80,8 +79,6 @@ encode_thread(Thread)    -> Thread.
 encode_type(received)     -> <<"R">>;
 encode_type(displayed)    -> <<"D">>;
 encode_type(acknowledged) -> <<"A">>.
-
-encode_timestamp(TS) -> usec:from_now(TS).
 
 escape(String) when is_binary(String) -> escape_string(String);
 escape(Int) when is_integer(Int)      -> escape_int(Int).
@@ -120,5 +117,5 @@ decode_type(<<"D">>) -> displayed;
 decode_type(<<"A">>) -> acknowledged.
 
 decode_timestamp(EncodedTS) ->
-    usec:to_now(mongoose_rdbms:result_to_integer(EncodedTS)).
+    mongoose_rdbms:result_to_integer(EncodedTS).
 

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -70,7 +70,7 @@
 -type t() :: #{
         mongoose_acc := true,
         ref := reference(),
-        timestamp := erlang:timestamp(),
+        timestamp := integer(), %microsecond
         origin_pid := pid(),
         origin_location := location(),
         origin_stanza := binary() | undefined,
@@ -120,7 +120,7 @@ new(#{ location := Location, lserver := LServer } = Params) ->
     #{
       mongoose_acc => true,
       ref => make_ref(),
-      timestamp => os:timestamp(),
+      timestamp => os:system_time(microsecond),
       origin_pid => self(),
       origin_location => Location,
       origin_stanza => ElementBin,
@@ -136,7 +136,7 @@ new(#{ location := Location, lserver := LServer } = Params) ->
 ref(#{ mongoose_acc := true, ref := Ref }) ->
     Ref.
 
--spec timestamp(Acc :: t()) -> erlang:timestamp().
+-spec timestamp(Acc :: t()) -> integer().
 timestamp(#{ mongoose_acc := true, timestamp := TS }) ->
     TS.
 

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -251,7 +251,7 @@ process_decoded_packet(From, To, {ok, #iq{} = IQ}, Acc, OrigPacket) ->
 process_decoded_packet(From, #jid{ luser = RoomU } = To, {ok, RequestToRoom}, Acc, OrigPacket)
   when RoomU =/= <<>> ->
     case mod_muc_light_db_backend:room_exists(jid:to_lus(To)) of
-        true -> mod_muc_light_room:handle_request(From, To, OrigPacket, RequestToRoom);
+        true -> mod_muc_light_room:handle_request(From, To, OrigPacket, RequestToRoom, Acc);
         false -> mod_muc_light_codec_backend:encode_error(
                    {error, item_not_found}, From, To, OrigPacket, make_handler_fun(Acc))
     end;

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -24,7 +24,7 @@
 -author('piotr.nosek@erlang-solutions.com').
 
 %% API
--export([handle_request/4, maybe_forget/2, process_request/4]).
+-export([handle_request/5, maybe_forget/2, process_request/4]).
 
 %% Callbacks
 -export([participant_limit_check/2]).
@@ -39,13 +39,13 @@
 %% API
 %%====================================================================
 
--spec handle_request(From :: jid:jid(), RoomJID :: jid:jid(),
-                     OrigPacket :: exml:element(), Request :: muc_light_packet()) -> ok.
-handle_request(From, To, OrigPacket, Request) ->
+-spec handle_request(From :: jid:jid(), RoomJID :: jid:jid(), OrigPacket :: exml:element(),
+                     Request :: muc_light_packet(), Acc :: mongoose_acc:t()) -> ok.
+handle_request(From, To, OrigPacket, Request, Acc) ->
     RoomUS = jid:to_lus(To),
     AffUsersRes = mod_muc_light_db_backend:get_aff_users(RoomUS),
     Response = process_request(From, RoomUS, Request, AffUsersRes),
-    send_response(From, To, RoomUS, OrigPacket, Response).
+    send_response(From, To, RoomUS, OrigPacket, Response, Acc).
 
 -spec maybe_forget(RoomUS :: jid:simple_bare_jid(), NewAffUsers :: aff_users()) -> any().
 maybe_forget({RoomU, RoomS} = RoomUS, []) ->
@@ -223,14 +223,33 @@ process_aff_set(_AffReq, _RoomUS, Error) ->
 
 -spec send_response(From :: jid:jid(), RoomJID :: jid:jid(),
                     RoomUS :: jid:simple_bare_jid(), OrigPacket :: exml:element(),
-                    Result :: packet_processing_result()) -> ok.
-send_response(From, RoomJID, _RoomUS, OrigPacket, {error, _} = Err) ->
+                    Result :: packet_processing_result(), Acc :: mongoose_acc:t()) -> ok.
+send_response(From, RoomJID, _RoomUS, OrigPacket, {error, _} = Err, _Acc) ->
     mod_muc_light_codec_backend:encode_error(
       Err, From, RoomJID, OrigPacket, fun ejabberd_router:route/3);
-send_response(From, _RoomJID, RoomUS, _OriginalPacket, Response) ->
-    mod_muc_light_codec_backend:encode(Response, From, RoomUS, fun ejabberd_router:route/3).
+send_response(From, _RoomJID, RoomUS, _OriginalPacket, Response, Acc) ->
+    mod_muc_light_codec_backend:encode(Response, From, RoomUS, make_handler_fun(Acc)).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
+make_handler_fun(Acc) ->
+    fun(From, To, Packet) ->
+        NewAcc0 = mongoose_acc:new(#{location => ?LOCATION,
+                                     lserver => From#jid.lserver,
+                                     element => Packet,
+                                     from_jid => From,
+                                     to_jid => To}),
+        PermanentFields = get_permanent_fields(Acc),
+        NewAcc = set_permanent_fields(PermanentFields, NewAcc0),
+        ejabberd_router:route(From, To, NewAcc, Packet)
+    end.
 
+get_permanent_fields(Acc) ->
+    [{NS, Key, mongoose_acc:get(NS, Key, Acc)} ||
+        {NS, Key} <- mongoose_acc:get_permanent_keys(Acc)].
+
+set_permanent_fields([], Acc) -> Acc;
+set_permanent_fields([{NS, Key, Value} | T], Acc) ->
+    NewAcc = mongoose_acc:set_permanent(NS, Key, Value, Acc),
+    set_permanent_fields(T, NewAcc).

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -240,16 +240,7 @@ make_handler_fun(Acc) ->
                                      element => Packet,
                                      from_jid => From,
                                      to_jid => To}),
-        PermanentFields = get_permanent_fields(Acc),
-        NewAcc = set_permanent_fields(PermanentFields, NewAcc0),
+        PermanentFields = mongoose_acc:get_permanent_fields(Acc),
+        NewAcc = mongoose_acc:set_permanent(PermanentFields, NewAcc0),
         ejabberd_router:route(From, To, NewAcc, Packet)
     end.
-
-get_permanent_fields(Acc) ->
-    [{NS, Key, mongoose_acc:get(NS, Key, Acc)} ||
-        {NS, Key} <- mongoose_acc:get_permanent_keys(Acc)].
-
-set_permanent_fields([], Acc) -> Acc;
-set_permanent_fields([{NS, Key, Value} | T], Acc) ->
-    NewAcc = mongoose_acc:set_permanent(NS, Key, Value, Acc),
-    set_permanent_fields(T, NewAcc).

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -1,7 +1,26 @@
 %%%----------------------------------------------------------------------------
 %%% @copyright (C) 2020, Erlang Solutions Ltd.
 %%% @doc
-%%%   this module optimizes offline storage for chat markers
+%%%   This module optimizes offline storage for chat markers in the next way:
+%%%
+%%%      1) It filters out chat marker packets processed by mod_smart_markers:
+%%%          * These packets can be identified by the extra permanent Acc
+%%%            timestamp field added by mod_smart_markers.
+%%%          * These packets are not going to mod_offline (notice the
+%%%            difference in priorities for offline_message_hook handlers)
+%%%          * The information about these chat markers is stored in DB,
+%%%            timestamp added by mod_smart_markers is important here!
+%%%
+%%%      2) After all the offline messages are inserted by mod_offline (notice
+%%%         the difference in priorities for the resend_offline_messages_hook
+%%%         handlers), this module adds the latest chat markers as the last
+%%%         offline messages:
+%%%          * It extracts chat markers data stored for the user in the DB
+%%%            (with timestamps)
+%%%          * Requests cached chat markers from mod_smart_markers that has
+%%%            timestamp older or equal to the stored one.
+%%%          * Generates and inserts chat markers as the last offline messages
+%%%
 %%% @end
 %%%----------------------------------------------------------------------------
 -module(mod_offline_chatmarkers).
@@ -28,6 +47,12 @@
 -callback get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
                                           Room :: undefined | jid:jid(),
                                           TS :: erlang:timestamp()}]}.
+%%% @doc
+%%% Jid, Thread, and Room parameters serve as a composite database key. If
+%%% key is not available in the database, then it must be added with the
+%%% corresponding timestamp. Otherwise this function does nothing, the stored
+%%% timestamp for the composite key MUST remain unchanged!
+%%% @end
 -callback maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
                       Room :: undefined | jid:jid(), TS :: erlang:timestamp()) -> ok.
 -callback remove_user(Jid :: jid:jid()) -> ok.
@@ -40,7 +65,7 @@ deps(_,_)->
     [{mod_smart_markers, hard}].
 
 start(Host, Opts) ->
-    gen_mod:start_backend_module(?MODULE, add_default_backend(Opts)),
+    gen_mod:start_backend_module(?MODULE, add_default_backend(Opts), [get, maybe_store]),
     mod_offline_chatmarkers_backend:init(Host, Opts),
     ejabberd_hooks:add(hooks(Host)),
     ok.

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -75,19 +75,14 @@ inspect_packet(Acc, From, To, Packet) ->
     end.
 
 maybe_store_chat_marker(Acc, From, To, Packet) ->
-    %% revert this change, muclight must forward permanent acc fields!
-    case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS) of
+    case mongoose_acc:get(mod_smart_markers, timestamp, undefined, Acc) of
         undefined -> false;
-        _ ->
-            Timestamp = shift(mongoose_acc:timestamp(Acc)),
+        {_, _, _} = Timestamp ->
             Room = get_room(Acc, From),
             Thread = get_thread(Packet),
             mod_offline_chatmarkers_backend:maybe_store(To, Thread, Room, Timestamp),
             true
     end.
-
-shift(TS) ->
-    usec:to_now(usec:from_now(TS) - usec:from_now({0, 10, 0})).
 
 get_room(Acc, From) ->
     case mongoose_acc:stanza_type(Acc) of

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -4,10 +4,13 @@
 %%%   This module optimizes offline storage for chat markers in the next way:
 %%%
 %%%      1) It filters out chat marker packets processed by mod_smart_markers:
+%%%
 %%%          * These packets can be identified by the extra permanent Acc
 %%%            timestamp field added by mod_smart_markers.
+%%%
 %%%          * These packets are not going to mod_offline (notice the
-%%%            difference in priorities for offline_message_hook handlers)
+%%%            difference in priorities for the offline_message_hook handlers)
+%%%
 %%%          * The information about these chat markers is stored in DB,
 %%%            timestamp added by mod_smart_markers is important here!
 %%%
@@ -15,10 +18,13 @@
 %%%         the difference in priorities for the resend_offline_messages_hook
 %%%         handlers), this module adds the latest chat markers as the last
 %%%         offline messages:
+%%%
 %%%          * It extracts chat markers data stored for the user in the DB
 %%%            (with timestamps)
+%%%
 %%%          * Requests cached chat markers from mod_smart_markers that has
 %%%            timestamp older or equal to the stored one.
+%%%
 %%%          * Generates and inserts chat markers as the last offline messages
 %%%
 %%% @end
@@ -47,12 +53,11 @@
 -callback get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
                                           Room :: undefined | jid:jid(),
                                           Timestamp :: integer()}]}.
-%%% @doc
+
 %%% Jid, Thread, and Room parameters serve as a composite database key. If
 %%% key is not available in the database, then it must be added with the
 %%% corresponding timestamp. Otherwise this function does nothing, the stored
 %%% timestamp for the composite key MUST remain unchanged!
-%%% @end
 -callback maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
                       Room :: undefined | jid:jid(), Timestamp :: integer()) -> ok.
 -callback remove_user(Jid :: jid:jid()) -> ok.

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -10,7 +10,7 @@
 -behaviour(mongoose_module_metrics).
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, deps/2]).
 
 %% Hook handlers
 -export([inspect_packet/4,
@@ -34,6 +34,10 @@
 
 %% gen_mod callbacks
 %% ------------------------------------------------------------------
+
+-spec deps(_Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
+deps(_,_)->
+    [{mod_smart_markers, hard}].
 
 start(Host, Opts) ->
     gen_mod:start_backend_module(?MODULE, add_default_backend(Opts)),

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -46,7 +46,7 @@
 -callback init(Host :: jid:lserver(), Opts :: list()) -> ok.
 -callback get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
                                           Room :: undefined | jid:jid(),
-                                          TS :: erlang:timestamp()}]}.
+                                          Timestamp :: integer()}]}.
 %%% @doc
 %%% Jid, Thread, and Room parameters serve as a composite database key. If
 %%% key is not available in the database, then it must be added with the
@@ -54,7 +54,7 @@
 %%% timestamp for the composite key MUST remain unchanged!
 %%% @end
 -callback maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
-                      Room :: undefined | jid:jid(), TS :: erlang:timestamp()) -> ok.
+                      Room :: undefined | jid:jid(), Timestamp :: integer()) -> ok.
 -callback remove_user(Jid :: jid:jid()) -> ok.
 
 %% gen_mod callbacks
@@ -106,7 +106,7 @@ inspect_packet(Acc, From, To, Packet) ->
 maybe_store_chat_marker(Acc, From, To, Packet) ->
     case mongoose_acc:get(mod_smart_markers, timestamp, undefined, Acc) of
         undefined -> false;
-        {_, _, _} = Timestamp ->
+        Timestamp when is_integer(Timestamp)->
             Room = get_room(Acc, From),
             Thread = get_thread(Packet),
             mod_offline_chatmarkers_backend:maybe_store(To, Thread, Room, Timestamp),

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -1,0 +1,156 @@
+%%%----------------------------------------------------------------------------
+%%% @copyright (C) 2020, Erlang Solutions Ltd.
+%%% @doc
+%%%   this module optimizes offline storage for chat markers
+%%% @end
+%%%----------------------------------------------------------------------------
+-module(mod_offline_chatmarkers).
+-xep([{xep, 160}, {version, "1.0"}]).
+-behaviour(gen_mod).
+-behaviour(mongoose_module_metrics).
+
+%% gen_mod handlers
+-export([start/2, stop/1]).
+
+%% Hook handlers
+-export([inspect_packet/4,
+         remove_user/3,
+         pop_offline_messages/3]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+-include_lib("exml/include/exml.hrl").
+
+%% ------------------------------------------------------------------
+%% Backend callbacks
+
+-callback init(Host :: jid:lserver(), Opts :: list()) -> ok.
+-callback get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
+                                          Room :: undefined | jid:jid(),
+                                          TS :: erlang:timestamp()}]}.
+-callback maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
+                      Room :: undefined | jid:jid(), TS :: erlang:timestamp()) -> ok.
+-callback remove_user(Jid :: jid:jid()) -> ok.
+
+%% gen_mod callbacks
+%% ------------------------------------------------------------------
+
+start(Host, Opts) ->
+    gen_mod:start_backend_module(?MODULE, add_default_backend(Opts)),
+    mod_offline_chatmarkers_backend:init(Host, Opts),
+    ejabberd_hooks:add(hooks(Host)),
+    ok.
+
+stop(Host) ->
+    ejabberd_hooks:delete(hooks(Host)),
+    ok.
+
+hooks(Host) ->
+    DefaultHooks = [
+        {offline_message_hook, Host, ?MODULE, inspect_packet, 40},
+        {resend_offline_messages_hook, Host, ?MODULE, pop_offline_messages, 60},
+        {remove_user, Host, ?MODULE, remove_user, 50}
+    ],
+    case gen_mod:get_module_opt(Host, ?MODULE, store_groupchat_messages, false) of
+        true ->
+            GroupChatHook = {offline_groupchat_message_hook,
+                             Host, ?MODULE, inspect_packet, 40},
+            [GroupChatHook | DefaultHooks];
+        _ -> DefaultHooks
+    end.
+
+remove_user(Acc, User, Server) ->
+    mod_offline_chatmarkers_backend:remove_user(jid:make(User, Server, <<"">>)),
+    Acc.
+
+pop_offline_messages(Acc, User, Server) ->
+    mongoose_acc:append(offline, messages, offline_chatmarkers(Acc, User, Server), Acc).
+
+inspect_packet(Acc, From, To, Packet) ->
+    case maybe_store_chat_marker(Acc, From, To, Packet) of
+        true ->
+            {stop, mongoose_acc:set(offline, stored, true, Acc)};
+        false ->
+            Acc
+    end.
+
+maybe_store_chat_marker(Acc, From, To, Packet) ->
+    case mongoose_acc:get(mod_smart_markers, timestamp, undefined, Acc) of
+        undefined -> false;
+        {_, _, _} = Timestamp ->
+            Room = get_room(Acc, From),
+            Thread = get_thread(Packet),
+            mod_offline_chatmarkers_backend:maybe_store(To, Thread, Room, Timestamp),
+            true
+    end.
+
+get_room(Acc, From) ->
+    case mongoose_acc:stanza_type(Acc) of
+        <<"groupchat">> -> From;
+        _ -> undefined
+    end.
+
+get_thread(El) ->
+    case exml_query:path(El, [{element, <<"thread">>}, cdata]) of
+        Thread when Thread =/= <<>> -> Thread;
+        _ -> undefined
+    end.
+
+offline_chatmarkers(Acc, User, Server) ->
+    JID = jid:make(User, Server, <<"">>),
+    {ok, Rows} = mod_offline_chatmarkers_backend:get(JID),
+    mod_offline_chatmarkers_backend:remove_user(JID),
+    lists:concat([process_row(Acc, JID, R) || R <- Rows]).
+
+process_row(Acc, Jid, {Thread, undefined, TS}) ->
+    ChatMarkers = mod_smart_markers:get_chat_markers(one2one, Jid, Thread, TS),
+    [build_one2one_chatmarker_msg(Acc, CM) || CM <- ChatMarkers];
+process_row(Acc, Jid, {Thread, Room, TS}) ->
+    ChatMarkers = mod_smart_markers:get_chat_markers(groupchat, Room, Thread, TS),
+    [build_room_chatmarker_msg(Acc, Jid, CM) || CM <- ChatMarkers].
+
+build_one2one_chatmarker_msg(Acc, CM) ->
+    #{from := From, to := To, thread := Thread,
+      type := Type, id := Id, timestamp := TS} = CM,
+    Children = thread(Thread) ++ marker(Type, Id),
+    Attributes = [{<<"from">>, jid:to_binary(From)},
+                  {<<"to">>, jid:to_binary(To)}],
+    Packet = #xmlel{name = <<"message">>, attrs = Attributes, children = Children},
+    make_route_item(Acc, From, To, TS, Packet).
+
+build_room_chatmarker_msg(Acc, To, CM) ->
+    #{from := FromUser, to := Room, thread := Thread,
+      type := Type, id := Id, timestamp := TS} = CM,
+    FromUserBin = jid:to_binary(jid:to_lus(FromUser)),
+    From = jid:make(Room#jid.luser, Room#jid.lserver, FromUserBin),
+    FromBin = jid:to_binary(From),
+    Children = thread(Thread) ++ marker(Type, Id),
+    Attributes = [{<<"from">>, FromBin},
+                  {<<"to">>, jid:to_binary(To)},
+                  {<<"type">>, <<"groupchat">>}],
+    Packet = #xmlel{name = <<"message">>, attrs = Attributes, children = Children},
+    make_route_item(Acc, From, To, TS, Packet).
+
+make_route_item(Acc, From, To, TS, Packet) ->
+    NewStanzaParams = #{element => Packet, from_jid => From, to_jid => To},
+    Acc1 = mongoose_acc:update_stanza(NewStanzaParams, Acc),
+    Acc2 = mongoose_acc:set_permanent(mod_smart_markers, timestamp, TS, Acc1),
+    {route, From, To, Acc2}.
+
+marker(Type, Id) ->
+    [#xmlel{name = atom_to_binary(Type, latin1),
+        attrs = [{<<"xmlns">>, <<"urn:xmpp:chat-markers:0">>},
+                 {<<"id">>, Id}], children = []}].
+
+thread(undefined) -> [];
+thread(Thread) ->
+    [#xmlel{name     = <<"thread">>, attrs = [],
+            children = [#xmlcdata{content = Thread}]}].
+
+add_default_backend(Opts) ->
+    case lists:keyfind(backend, 2, Opts) of
+        false ->
+            [{backend, rdbms} | Opts];
+        _ ->
+            Opts
+    end.

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -75,14 +75,19 @@ inspect_packet(Acc, From, To, Packet) ->
     end.
 
 maybe_store_chat_marker(Acc, From, To, Packet) ->
-    case mongoose_acc:get(mod_smart_markers, timestamp, undefined, Acc) of
+    %% revert this change, muclight must forward permanent acc fields!
+    case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS) of
         undefined -> false;
-        {_, _, _} = Timestamp ->
+        _ ->
+            Timestamp = shift(mongoose_acc:timestamp(Acc)),
             Room = get_room(Acc, From),
             Thread = get_thread(Packet),
             mod_offline_chatmarkers_backend:maybe_store(To, Thread, Room, Timestamp),
             true
     end.
+
+shift(TS) ->
+    usec:to_now(usec:from_now(TS) - usec:from_now({0, 10, 0})).
 
 get_room(Acc, From) ->
     case mongoose_acc:stanza_type(Acc) of

--- a/src/offline/mod_offline_chatmarkers_rdbms.erl
+++ b/src/offline/mod_offline_chatmarkers_rdbms.erl
@@ -22,7 +22,7 @@ init(_Host, _Opts) ->
 
 -spec get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
                                       Room :: undefined | jid:jid(),
-                                      TS :: erlang:timestamp()}]}.
+                                      Timestamp :: integer()}]}.
 get(#jid{lserver = Host} = Jid) ->
     JidEscaped = escape(encode_jid(Jid)),
     SelectQuery = ["SELECT thread, room, timestamp FROM offline_markers",
@@ -37,12 +37,12 @@ get(#jid{lserver = Host} = Jid) ->
 %%% timestamp for the composite key MUST remain unchanged!
 %%% @end
 -spec maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
-                  Room :: undefined | jid:jid(), TS :: erlang:timestamp()) -> ok.
-maybe_store(#jid{lserver = Host} = Jid, Thread, Room, TS) ->
+                  Room :: undefined | jid:jid(), Timestamp :: integer()) -> ok.
+maybe_store(#jid{lserver = Host} = Jid, Thread, Room, Timestamp) ->
     JidEscaped = escape(encode_jid(Jid)),
     ThreadEscaped = escape(encode_thread(Thread)),
     RoomEscaped = escape(encode_jid(Room)),
-    TSEscaped = escape(encode_timestamp(TS)),
+    TSEscaped = escape(Timestamp),
     InsertQuery = ["INSERT INTO offline_markers (jid, thread, room, timestamp) VALUES (",
                    JidEscaped, ",", ThreadEscaped, ",", RoomEscaped, ",", TSEscaped, ");"],
     Res = mongoose_rdbms:sql_query(Host, InsertQuery),
@@ -60,8 +60,6 @@ encode_jid(JID)       -> jid:to_binary(jid:to_lus(JID)).
 
 encode_thread(undefined) -> <<"">>;
 encode_thread(Thread)    -> Thread.
-
-encode_timestamp(TS) -> usec:from_now(TS).
 
 escape(String) when is_binary(String) -> escape_string(String);
 escape(Int) when is_integer(Int)      -> escape_int(Int).
@@ -91,5 +89,5 @@ decode_thread(<<"">>)        -> undefined;
 decode_thread(EncodedThread) -> EncodedThread.
 
 decode_timestamp(EncodedTS) ->
-    usec:to_now(mongoose_rdbms:result_to_integer(EncodedTS)).
+    mongoose_rdbms:result_to_integer(EncodedTS).
 

--- a/src/offline/mod_offline_chatmarkers_rdbms.erl
+++ b/src/offline/mod_offline_chatmarkers_rdbms.erl
@@ -1,0 +1,90 @@
+%%%----------------------------------------------------------------------------
+%%% @copyright (C) 2020, Erlang Solutions Ltd.
+%%% @doc
+%%%   RDBMS backend for mod_offline_chatmarkers module.
+%%% @end
+%%%----------------------------------------------------------------------------
+
+-module(mod_offline_chatmarkers_rdbms).
+-behaviour(mod_offline_chatmarkers).
+
+-export([init/2,
+         get/1,
+         maybe_store/4,
+         remove_user/1]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+
+-spec init(Host :: jid:lserver(), Opts :: list()) -> ok.
+init(_Host, _Opts) ->
+    ok.
+
+-spec get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
+                                      Room :: undefined | jid:jid(),
+                                      TS :: erlang:timestamp()}]}.
+get(#jid{lserver = Host} = Jid) ->
+    JidEscaped = escape(encode_jid(Jid)),
+    SelectQuery = ["SELECT thread, room, timestamp FROM offline_markers",
+                   " WHERE jid = ", JidEscaped, ";"],
+    {selected, Rows} = mongoose_rdbms:sql_query(Host, SelectQuery),
+    decode(Rows).
+
+
+-spec maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
+                  Room :: undefined | jid:jid(), TS :: erlang:timestamp()) -> ok.
+maybe_store(#jid{lserver = Host} = Jid, Thread, Room, TS) ->
+    JidEscaped = escape(encode_jid(Jid)),
+    ThreadEscaped = escape(encode_thread(Thread)),
+    RoomEscaped = escape(encode_jid(Room)),
+    TSEscaped = escape(encode_timestamp(TS)),
+    InsertQuery = ["INSERT INTO offline_markers (jid, thread, room, timestamp) VALUES (",
+                   JidEscaped, ",", ThreadEscaped, ",", RoomEscaped, ",", TSEscaped, ");"],
+    Res = mongoose_rdbms:sql_query(Host, InsertQuery),
+    ok = check_insert_result(Res).
+
+-spec remove_user(Jid :: jid:jid()) -> ok.
+remove_user(#jid{lserver = Host} = Jid) ->
+    JidEscaped = escape(encode_jid(Jid)),
+    DelQuery = ["DELETE FROM offline_markers WHERE jid = ", JidEscaped, ";"],
+    {updated, _} = mongoose_rdbms:sql_query(Host, DelQuery),
+    ok.
+
+encode_jid(undefined) -> <<"">>;
+encode_jid(JID)       -> jid:to_binary(jid:to_lus(JID)).
+
+encode_thread(undefined) -> <<"">>;
+encode_thread(Thread)    -> Thread.
+
+encode_timestamp(TS) -> usec:from_now(TS).
+
+escape(String) when is_binary(String) -> escape_string(String);
+escape(Int) when is_integer(Int)      -> escape_int(Int).
+
+escape_string(String) ->
+    mongoose_rdbms:use_escaped_string(mongoose_rdbms:escape_string(String)).
+
+escape_int(Int) ->
+    mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).
+
+%% add new record if key not available, otherwise no changes to the table
+check_insert_result({error,duplicate_key}) -> ok;
+check_insert_result({updated, 1}) -> ok;
+check_insert_result(Result) ->
+    {error, {bad_result, Result}}.
+
+decode(Rows) ->
+    {ok, [decode_row(R) || R <- Rows]}.
+
+decode_row({Thread, Room, TS}) ->
+    {decode_thread(Thread), decode_jid(Room), decode_timestamp(TS)}.
+
+decode_jid(<<"">>)     -> undefined;
+decode_jid(EncodedJID) -> jid:from_binary(EncodedJID).
+
+decode_thread(<<"">>)        -> undefined;
+decode_thread(EncodedThread) -> EncodedThread.
+
+decode_timestamp(EncodedTS) ->
+    usec:to_now(mongoose_rdbms:result_to_integer(EncodedTS)).
+

--- a/src/offline/mod_offline_chatmarkers_rdbms.erl
+++ b/src/offline/mod_offline_chatmarkers_rdbms.erl
@@ -30,7 +30,12 @@ get(#jid{lserver = Host} = Jid) ->
     {selected, Rows} = mongoose_rdbms:sql_query(Host, SelectQuery),
     decode(Rows).
 
-
+%%% @doc
+%%% Jid, Thread, and Room parameters serve as a composite database key. If
+%%% key is not available in the database, then it must be added with the
+%%% corresponding timestamp. Otherwise this function does nothing, the stored
+%%% timestamp for the composite key MUST remain unchanged!
+%%% @end
 -spec maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
                   Room :: undefined | jid:jid(), TS :: erlang:timestamp()) -> ok.
 maybe_store(#jid{lserver = Host} = Jid, Thread, Room, TS) ->
@@ -67,7 +72,7 @@ escape_string(String) ->
 escape_int(Int) ->
     mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).
 
-%% add new record if key not available, otherwise no changes to the table
+%% add new record if key is not available, otherwise no changes to the table
 check_insert_result({error,duplicate_key}) -> ok;
 check_insert_result({updated, 1}) -> ok;
 check_insert_result(Result) ->

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -106,12 +106,14 @@ parse(Items) when is_list(Items) ->
 parse({selected, FieldTypeNames, Rows}) ->
     FieldsInfo = fields_to_parse_info(FieldTypeNames),
     {selected, parse_rows(Rows, FieldsInfo)};
-parse({error, "ERROR: duplicate key" ++ _}) ->
-    {error, duplicate_key};
 parse({error, Reason}) when is_atom(Reason) ->
     {error, atom_to_list(Reason)};
 parse({error, Reason}) ->
-    {error, unicode:characters_to_list(list_to_binary(Reason))};
+    ErrorStr = unicode:characters_to_list(list_to_binary(Reason)),
+    case re:run(ErrorStr, "duplicate key") of
+        nomatch -> {error, ErrorStr};
+        {match, _} -> {error, duplicate_key}
+    end;
 parse(Other) ->
     Other.
 


### PR DESCRIPTION
commands for manual DB backend testing:

test-runner.sh --one-node --skip-cover --skip-small-tests --skip-stop-nodes --preset odbc_mssql_mnesia -- offline
_build/mim1/rel/mongooseim/bin/mongooseim debug


```
mod_smart_markers_rdbms:init(<<"localhost">>,ok).

JID1=jid:make({<<"a">>,<<"c">>,<<"">>}).
JID2=jid:make({<<"a">>,<<"b">>,<<"">>}).

CM =#{from=>JID1,
      to=>JID2,
      thread=>undefined,
      type=>received,
      timestamp=>100,
      id=><<"aaa">>}.

mod_smart_markers_rdbms:update_chat_marker(<<"localhost">>,CM).
                         
mod_smart_markers_rdbms:get_chat_markers(<<"localhost">>, JID2, undefined, 100).
mod_smart_markers_rdbms:get_chat_markers(<<"localhost">>, JID2, undefined, 0).
mod_smart_markers_rdbms:get_chat_markers(<<"localhost">>, JID2, undefined, 101).

mod_smart_markers_rdbms:update_chat_marker(<<"localhost">>,CM#{id:= <<"bbb">>}).
mod_smart_markers_rdbms:update_chat_marker(<<"localhost">>,CM#{type:= displayed}).

mod_smart_markers_rdbms:get_chat_markers(<<"localhost">>, JID2, undefined, 100).

mod_smart_markers_rdbms:update_chat_marker(<<"localhost">>,CM#{thread:= <<"aaa">>}).                                             
mod_smart_markers_rdbms:get_chat_markers(<<"localhost">>, JID2, <<"aaa">>, 100).


mod_offline_chatmarkers_rdbms:init(<<"localhost">>,ok).
mod_offline_chatmarkers_rdbms:maybe_store(JID1, <<"aaa">>, undefined, 100).
mod_offline_chatmarkers_rdbms:get(JID1).
mod_offline_chatmarkers_rdbms:maybe_store(JID1, <<"aaa">>, undefined, 101).
mod_offline_chatmarkers_rdbms:get(JID1).
mod_offline_chatmarkers_rdbms:remove_user(JID1).
mod_offline_chatmarkers_rdbms:get(JID1).
mod_offline_chatmarkers_rdbms:maybe_store(JID1, <<"aaa">>, undefined, 101).
mod_offline_chatmarkers_rdbms:get(JID1).
```