### PR TITLE
Add cockroach backend to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,131 +298,131 @@ workflows:
   build_and_test:
     jobs:
       # ============= PACKAGES =============
-      - mim/package:
-          name: centos_7
-          platform: centos_7
-          otp_package: 22.1.8-2
-          context: mongooseim-org
-          filters: *all_tags
-      - mim/package:
-          name: debian_stretch
-          platform: debian_stretch
-          otp_package: 22.1.8-1
-          context: mongooseim-org
-          filters: *all_tags
-      # ============= BASE BUILDS =============
-      - mim/build:
-          name: otp_21_3
-          otp_package: 21.3.8.6-1
-          context: mongooseim-org
-          filters: *all_tags
+      #- mim/package:
+      #    name: centos_7
+      #    platform: centos_7
+      #    otp_package: 22.1.8-2
+      #    context: mongooseim-org
+      #    filters: *all_tags
+      #- mim/package:
+      #    name: debian_stretch
+      #    platform: debian_stretch
+      #    otp_package: 22.1.8-1
+      #    context: mongooseim-org
+      #    filters: *all_tags
+      ## ============= BASE BUILDS =============
+      #- mim/build:
+      #    name: otp_21_3
+      #    otp_package: 21.3.8.6-1
+      #    context: mongooseim-org
+      #    filters: *all_tags
       - mim/build:
           name: otp_22
           otp_package: 22.1.8-1
           build_prod: true
           context: mongooseim-org
           filters: *all_tags
-      # ============= SMALL TESTS =============
-      - mim/small_tests:
-          name: small_tests_21_3
-          otp_package: 21.3.8.6-1
-          context: mongooseim-org
-          requires:
-            - otp_21_3
-          filters: *all_tags
-      - mim/small_tests:
-          name: small_tests_22
-          otp_package: 22.1.8-1
-          context: mongooseim-org
-          requires:
-            - otp_22
-          filters: *all_tags
-      # ============= DIALYZER =============
-      - mim/dialyzer:
-          name: dialyzer
-          otp_package: 22.1.8-1
-          context: mongooseim-org
-          filters: *all_tags
-      # ============= MOST RECENT VERSION TESTS =============
-      - mim/big_tests:
-          name: mysql_redis
-          otp_package: 22.1.8-1
-          preset: mysql_redis
-          db: mysql
-          context: mongooseim-org
-          requires:
-            - otp_22
-          filters: *all_tags
-      - mim/big_tests:
-          name: mssql_mnesia
-          otp_package: 22.1.8-1
-          preset: odbc_mssql_mnesia
-          db: mssql
-          context: mongooseim-org
-          requires:
-            - otp_22
-          filters: *all_tags
-      - mim/big_tests:
-          name: internal_mnesia
-          otp_package: 22.1.8-1
-          preset: internal_mnesia
-          db: mnesia
-          tls_dist: true
-          context: mongooseim-org
-          requires:
-            - otp_22
-          filters: *all_tags
-      - mim/big_tests:
-          name: elasticsearch_and_cassandra
-          otp_package: 22.1.8-1
-          preset: elasticsearch_and_cassandra_mnesia
-          db: "elasticsearch cassandra"
-          context: mongooseim-org
-          requires:
-            - otp_22
-          filters: *all_tags
-      - mim/big_tests:
-          name: riak_mnesia
-          otp_package: 22.1.8-1
-          preset: riak_mnesia
-          db: riak
-          context: mongooseim-org
-          requires:
-            - otp_22
-          filters: *all_tags
+      ## ============= SMALL TESTS =============
+      #- mim/small_tests:
+      #    name: small_tests_21_3
+      #    otp_package: 21.3.8.6-1
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_21_3
+      #    filters: *all_tags
+      #- mim/small_tests:
+      #    name: small_tests_22
+      #    otp_package: 22.1.8-1
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_22
+      #    filters: *all_tags
+      ## ============= DIALYZER =============
+      #- mim/dialyzer:
+      #    name: dialyzer
+      #    otp_package: 22.1.8-1
+      #    context: mongooseim-org
+      #    filters: *all_tags
+      ## ============= MOST RECENT VERSION TESTS =============
+      #- mim/big_tests:
+      #    name: mysql_redis
+      #    otp_package: 22.1.8-1
+      #    preset: mysql_redis
+      #    db: mysql
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_22
+      #    filters: *all_tags
+      #- mim/big_tests:
+      #    name: mssql_mnesia
+      #    otp_package: 22.1.8-1
+      #    preset: odbc_mssql_mnesia
+      #    db: mssql
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_22
+      #    filters: *all_tags
+      #- mim/big_tests:
+      #    name: internal_mnesia
+      #    otp_package: 22.1.8-1
+      #    preset: internal_mnesia
+      #    db: mnesia
+      #    tls_dist: true
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_22
+      #    filters: *all_tags
+      #- mim/big_tests:
+      #    name: elasticsearch_and_cassandra
+      #    otp_package: 22.1.8-1
+      #    preset: elasticsearch_and_cassandra_mnesia
+      #    db: "elasticsearch cassandra"
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_22
+      #    filters: *all_tags
+      #- mim/big_tests:
+      #    name: riak_mnesia
+      #    otp_package: 22.1.8-1
+      #    preset: riak_mnesia
+      #    db: riak
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_22
+      #    filters: *all_tags
       - mim/big_tests:
           name: pgsql_mnesia
           otp_package: 22.1.8-1
           preset: pgsql_mnesia
-          db: pgsql
+          db: cockroach
           context: mongooseim-org
           requires:
             - otp_22
           filters: *all_tags
       # ============= 1 VERSION OLDER TESTS =============
-      - mim/big_tests:
-          name: ldap_mnesia
-          otp_package: 21.3.8.6-1
-          preset: ldap_mnesia
-          db: mnesia
-          context: mongooseim-org
-          requires:
-            - otp_21_3
-          filters: *all_tags
-      # ============= DOCKER IMAGE BUILD & UPLOAD =============
-      - mim/docker_image:
-          name: docker_build_and_ship
-          context: mongooseim-org
-          otp_package: 22.1.8-1
-          requires:
-            - ldap_mnesia
-            - pgsql_mnesia
-            - riak_mnesia
-            - elasticsearch_and_cassandra
-            - internal_mnesia
-            - mysql_redis
-            - mssql_mnesia
-            - dialyzer
-            - small_tests_22
-            - small_tests_21_3
-          filters: *all_tags
+      #- mim/big_tests:
+      #    name: ldap_mnesia
+      #    otp_package: 21.3.8.6-1
+      #    preset: ldap_mnesia
+      #    db: mnesia
+      #    context: mongooseim-org
+      #    requires:
+      #      - otp_21_3
+      #    filters: *all_tags
+      ## ============= DOCKER IMAGE BUILD & UPLOAD =============
+      #- mim/docker_image:
+      #    name: docker_build_and_ship
+      #    context: mongooseim-org
+      #    otp_package: 22.1.8-1
+      #    requires:
+      #      - ldap_mnesia
+      #      - pgsql_mnesia
+      #      - riak_mnesia
+      #      - elasticsearch_and_cassandra
+      #      - internal_mnesia
+      #      - mysql_redis
+      #      - mssql_mnesia
+      #      - dialyzer
+      #      - small_tests_22
+      #      - small_tests_21_3
+      #    filters: *all_tags

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -207,9 +207,8 @@
       {outgoing_pools, "{outgoing_pools, [
        {redis, global, global_distrib, [{workers, 10}], []},
        {rdbms, global, default, [{workers, 5}],
-        [{server, {pgsql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
-                   [{ssl, required}, {ssl_opts, [{verify, verify_peer},
-                    {cacertfile, \"priv/ssl/cacert.pem\"}, {server_name_indication, disable}]}]}}]}
+        [{server, {pgsql, \"localhost\", 5432, \"ejabberd\", \"ejabberd\", \"mongooseim_secret\"
+                   }}]}
        ]}."},
       {mod_last, "{mod_last, [{backend, rdbms}]},"},
       {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -378,7 +378,8 @@ check_unicode(Config, Value) when is_binary(Value) ->
                         "VALUES (", use_escaped(Config, SValue), ")"],
     SelectQuery = <<"SELECT unicode FROM test_types">>,
     InsertResult = sql_query(Config, InsertQuery),
-    SelectResult = sql_query(Config, SelectQuery),
+    {selected, [{SelectedValue}]} = sql_query(Config, SelectQuery),
+    SelectResult = {selected, [{unescape_binary(<<>>, SelectedValue)}]},
     %% Compare as binaries
     ?assert_equal_extra({selected, [{Value}]},
                         SelectResult,
@@ -419,7 +420,8 @@ check_ascii_string(Config, Value) when is_binary(Value) ->
                         "VALUES (", use_escaped(Config, SValue), ")"],
     SelectQuery = <<"SELECT ascii_string FROM test_types">>,
     InsertResult = sql_query(Config, InsertQuery),
-    SelectResult = sql_query(Config, SelectQuery),
+    {selected, [{SelectedValue}]} = sql_query(Config, SelectQuery),
+    SelectResult = {selected, [{unescape_binary(<<>>, SelectedValue)}]},
     %% Compare as binaries
     ?assert_equal_extra({selected, [{Value}]},
                         SelectResult,

--- a/priv/cockroach-pg.sql
+++ b/priv/cockroach-pg.sql
@@ -350,8 +350,8 @@ CREATE TABLE pubsub_nodes (
     p_key VARCHAR(250) NOT NULL,
     name VARCHAR(250)  NOT NULL,
     type VARCHAR(250)  NOT NULL,
-    owners JSON        NOT NULL,
-    options JSON       NOT NULL
+    owners TEXT        NOT NULL,
+    options TEXT       NOT NULL
 );
 
 CREATE UNIQUE INDEX i_pubsub_nodes_key_name ON pubsub_nodes USING btree (p_key, name);
@@ -367,7 +367,8 @@ CREATE TABLE pubsub_affiliations (
     luser VARCHAR(250)      NOT NULL,
     lserver VARCHAR(250)    NOT NULL,
     aff SMALLINT            NOT NULL,
-    PRIMARY KEY(luser, lserver, nidx)
+    PRIMARY KEY(luser, lserver, nidx),
+    UNIQUE(nidx, luser, lserver)
 );
 
 CREATE INDEX i_pubsub_affiliations_nidx ON pubsub_affiliations(nidx);
@@ -410,7 +411,7 @@ CREATE TABLE pubsub_subscriptions (
     lresource VARCHAR(250)  NOT NULL,
     type SMALLINT           NOT NULL,
     sub_id VARCHAR(125)     NOT NULL,
-    options JSON            NOT NULL
+    options TEXT            NOT NULL
 );
 
 CREATE INDEX i_pubsub_subscriptions_lus_nidx ON pubsub_subscriptions(luser, lserver, nidx);
@@ -420,7 +421,7 @@ CREATE TABLE event_pusher_push_subscription (
      owner_jid VARCHAR(250),
      node VARCHAR(250),
      pubsub_jid VARCHAR(250),
-     form JSON NOT NULL,
+     form TEXT NOT NULL,
      created_at BIGINT NOT NULL,
      PRIMARY KEY(owner_jid, node, pubsub_jid)
  );

--- a/priv/cockroach-pg.sql
+++ b/priv/cockroach-pg.sql
@@ -1,0 +1,433 @@
+--
+-- ejabberd, Copyright (C) 2002-2011   ProcessOne
+--
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License as
+-- published by the Free Software Foundation; either version 2 of the
+-- License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-- General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+--
+
+--CREATE TYPE test_enum_char AS ENUM('A','B', 'C');
+CREATE TABLE test_types(
+    unicode text,
+    binary_data_8k bytea, -- byte a has 1 GB limit
+    binary_data_65k bytea,
+    binary_data_16m bytea,
+    ascii_char character(1),
+    ascii_string varchar(250),
+    int32 integer,
+    int64 bigint,
+    int8 smallint, -- has no tinyint, so the next one is 2-bytes smallint
+    enum_char TEXT,
+    bool_flag boolean
+);
+
+CREATE TABLE users (
+    username varchar(250) PRIMARY KEY,
+    "password" text NOT NULL,
+    pass_details text,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+
+CREATE TABLE last (
+    username varchar(250) PRIMARY KEY,
+    seconds integer NOT NULL,
+    state text NOT NULL
+);
+
+CREATE INDEX i_last_seconds ON last USING btree (seconds);
+
+
+CREATE TABLE rosterusers (
+    username varchar(250) NOT NULL,
+    jid text NOT NULL,
+    nick text NOT NULL,
+    subscription character(1) NOT NULL,
+    ask character(1) NOT NULL,
+    askmessage text NOT NULL,
+    server character(1) NOT NULL,
+    subscribe text,
+    "type" text,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX i_rosteru_user_jid ON rosterusers USING btree (username, jid);
+CREATE INDEX i_rosteru_username ON rosterusers USING btree (username);
+CREATE INDEX i_rosteru_jid ON rosterusers USING btree (jid);
+
+
+CREATE TABLE rostergroups (
+    username varchar(250) NOT NULL,
+    jid text NOT NULL,
+    grp text NOT NULL
+);
+
+CREATE INDEX pk_rosterg_user_jid ON rostergroups USING btree (username, jid);
+
+
+CREATE TABLE vcard (
+    username varchar(150),
+    server varchar(100),
+    vcard text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    PRIMARY KEY (server, username)
+);
+
+CREATE TABLE vcard_search (
+    username varchar(150) NOT NULL,
+    lusername varchar(100),
+    server varchar(250),
+    fn text NOT NULL,
+    lfn text NOT NULL,
+    family_ text NOT NULL,
+    lfamily text NOT NULL,
+    given text NOT NULL,
+    lgiven text NOT NULL,
+    middle text NOT NULL,
+    lmiddle text NOT NULL,
+    nickname text NOT NULL,
+    lnickname text NOT NULL,
+    bday text NOT NULL,
+    lbday text NOT NULL,
+    ctry text NOT NULL,
+    lctry text NOT NULL,
+    locality text NOT NULL,
+    llocality text NOT NULL,
+    email text NOT NULL,
+    lemail text NOT NULL,
+    orgname text NOT NULL,
+    lorgname text NOT NULL,
+    orgunit text NOT NULL,
+    lorgunit text NOT NULL,
+    PRIMARY KEY (server, lusername)
+);
+
+CREATE INDEX i_vcard_search_lfn       ON vcard_search(lfn);
+CREATE INDEX i_vcard_search_lfamily   ON vcard_search(lfamily);
+CREATE INDEX i_vcard_search_lgiven    ON vcard_search(lgiven);
+CREATE INDEX i_vcard_search_lmiddle   ON vcard_search(lmiddle);
+CREATE INDEX i_vcard_search_lnickname ON vcard_search(lnickname);
+CREATE INDEX i_vcard_search_lbday     ON vcard_search(lbday);
+CREATE INDEX i_vcard_search_lctry     ON vcard_search(lctry);
+CREATE INDEX i_vcard_search_llocality ON vcard_search(llocality);
+CREATE INDEX i_vcard_search_lemail    ON vcard_search(lemail);
+CREATE INDEX i_vcard_search_lorgname  ON vcard_search(lorgname);
+CREATE INDEX i_vcard_search_lorgunit  ON vcard_search(lorgunit);
+
+CREATE TABLE privacy_default_list (
+    username varchar(250) PRIMARY KEY,
+    name text NOT NULL
+);
+
+CREATE TABLE privacy_list (
+    username varchar(250) NOT NULL,
+    name text NOT NULL,
+    id SERIAL UNIQUE,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    PRIMARY KEY (username,name)
+);
+
+CREATE TABLE privacy_list_data (
+    id bigint REFERENCES privacy_list(id) ON DELETE CASCADE,
+    t character(1) NOT NULL,
+    value text NOT NULL,
+    action character(1) NOT NULL,
+    ord NUMERIC NOT NULL,
+    match_all boolean NOT NULL,
+    match_iq boolean NOT NULL,
+    match_message boolean NOT NULL,
+    match_presence_in boolean NOT NULL,
+    match_presence_out boolean NOT NULL,
+    PRIMARY KEY (id, ord)
+);
+
+CREATE TABLE private_storage (
+    username varchar(250) NOT NULL,
+    namespace text NOT NULL,
+    data text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX i_private_storage_username ON private_storage USING btree (username);
+CREATE UNIQUE INDEX i_private_storage_username_namespace ON private_storage USING btree (username, namespace);
+
+
+CREATE TABLE roster_version (
+    username varchar(250) PRIMARY KEY,
+    version text NOT NULL
+);
+
+-- To update from 0.9.8:
+-- CREATE SEQUENCE spool_seq_seq;
+-- ALTER TABLE spool ADD COLUMN seq integer;
+-- ALTER TABLE spool ALTER COLUMN seq SET DEFAULT nextval('spool_seq_seq');
+-- UPDATE spool SET seq = DEFAULT;
+-- ALTER TABLE spool ALTER COLUMN seq SET NOT NULL;
+
+-- To update from 1.x:
+-- ALTER TABLE rosterusers ADD COLUMN askmessage text;
+-- UPDATE rosterusers SET askmessage = '';
+-- ALTER TABLE rosterusers ALTER COLUMN askmessage SET NOT NULL;
+
+-- To update from 2.0.0:
+-- ALTER TABLE mam_message ADD COLUMN search_body text;
+-- ALTER TABLE mam_muc_message ADD COLUMN search_body text;
+
+--CREATE TYPE mam_behaviour AS ENUM('A', 'N', 'R');
+--CREATE TYPE mam_direction AS ENUM('I','O');
+
+CREATE TABLE mam_message(
+  -- Message UID (64 bits)
+  -- A server-assigned UID that MUST be unique within the archive.
+  id BIGINT NOT NULL,
+  user_id INT NOT NULL,
+  -- FromJID used to form a message without looking into stanza.
+  -- This value will be send to the client "as is".
+  from_jid varchar(250) NOT NULL,
+  -- The remote JID that the stanza is to (for an outgoing message) or from (for an incoming message).
+  -- This field is for sorting and filtering.
+  remote_bare_jid varchar(250) NOT NULL,
+  remote_resource varchar(250) NOT NULL,
+  -- I - incoming, remote_jid is a value from From.
+  -- O - outgoing, remote_jid is a value from To.
+  -- Has no meaning for MUC-rooms.
+  direction text NOT NULL,
+  -- Term-encoded message packet
+  message bytea NOT NULL,
+  search_body text,
+  PRIMARY KEY(user_id, id)
+);
+CREATE INDEX i_mam_message_username_jid_id
+    ON mam_message
+    USING BTREE
+    (user_id, remote_bare_jid, id);
+
+CREATE TABLE mam_config(
+  user_id INT NOT NULL,
+  -- If empty, than it is a default behaviour.
+  remote_jid varchar(250) NOT NULL,
+  -- A - always archive;
+  -- N - never archive;
+  -- R - roster (only for remote_jid == "")
+  behaviour text NOT NULL,
+  PRIMARY KEY(user_id, remote_jid)
+);
+
+CREATE TABLE mam_server_user(
+  id SERIAL UNIQUE PRIMARY KEY,
+  server    varchar(250) NOT NULL,
+  user_name varchar(250) NOT NULL
+);
+CREATE UNIQUE INDEX i_mam_server_user_name
+    ON mam_server_user
+    USING BTREE
+    (server, user_name);
+
+
+CREATE TABLE mam_muc_message(
+  -- Message UID
+  -- A server-assigned UID that MUST be unique within the archive.
+  id BIGINT NOT NULL,
+  room_id INT NOT NULL,
+  sender_id INT NOT NULL,
+  -- A nick of the message's originator
+  nick_name varchar(250) NOT NULL,
+  -- Term-encoded message packet
+  message bytea NOT NULL,
+  search_body text,
+  PRIMARY KEY (room_id, id)
+);
+
+CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message USING BTREE (sender_id);
+
+CREATE TABLE offline_message(
+    id SERIAL UNIQUE PRIMARY Key,
+    timestamp BIGINT NOT NULL,
+    expire    BIGINT,
+    server    varchar(250)    NOT NULL,
+    username  varchar(250)    NOT NULL,
+    from_jid  varchar(250)    NOT NULL,
+    packet    text            NOT NULL,
+    permanent_fields bytea
+);
+CREATE INDEX i_offline_message
+    ON offline_message
+    USING BTREE
+    (server, username, id);
+
+CREATE TABLE auth_token(
+    owner   TEXT    NOT NULL PRIMARY KEY,
+    seq_no  BIGINT  NOT NULL
+);
+
+CREATE TABLE muc_light_rooms(
+    id BIGSERIAL            NOT NULL UNIQUE,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    version VARCHAR(20)     NOT NULL,
+    PRIMARY KEY (lserver, luser)
+);
+
+CREATE TABLE muc_rooms(
+    id BIGSERIAL            NOT NULL UNIQUE,
+    muc_host VARCHAR(250)   NOT NULL,
+    room_name VARCHAR(250)       NOT NULL,
+    options JSON            NOT NULL,
+    PRIMARY KEY (muc_host, room_name)
+);
+
+CREATE TABLE muc_room_aff(
+    room_id BIGINT          NOT NULL REFERENCES muc_rooms(id),
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    resource VARCHAR(250)   NOT NULL,
+    aff SMALLINT            NOT NULL
+);
+
+CREATE INDEX i_muc_room_aff_id ON muc_room_aff (room_id);
+
+CREATE TABLE muc_registered(
+    muc_host VARCHAR(250)   NOT NULL,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    nick VARCHAR(250)       NOT NULL,
+    PRIMARY KEY (muc_host, luser, lserver)
+);
+
+CREATE TABLE muc_light_occupants(
+    room_id BIGINT          NOT NULL REFERENCES muc_light_rooms(id),
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    aff SMALLINT            NOT NULL
+);
+
+CREATE INDEX i_muc_light_occupants_id ON muc_light_occupants (room_id);
+CREATE INDEX i_muc_light_occupants_us ON muc_light_occupants (lserver, luser);
+
+CREATE TABLE muc_light_config(
+    room_id BIGINT          NOT NULL REFERENCES muc_light_rooms(id),
+    opt VARCHAR(100)        NOT NULL,
+    val VARCHAR(250)        NOT NULL
+);
+
+CREATE INDEX i_muc_light_config ON muc_light_config (room_id);
+
+CREATE TABLE muc_light_blocking(
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    what SMALLINT           NOT NULL,
+    who VARCHAR(500)        NOT NULL
+);
+
+CREATE INDEX i_muc_light_blocking ON muc_light_blocking (luser, lserver);
+
+CREATE TABLE inbox (
+    luser VARCHAR(250)               NOT NULL,
+    lserver VARCHAR(250)             NOT NULL,
+    remote_bare_jid VARCHAR(250)     NOT NULL,
+    content bytea                    NOT NULL,
+    unread_count int                 NOT NULL,
+    msg_id varchar(250),
+    timestamp BIGINT                 NOT NULL,
+    PRIMARY KEY(luser, lserver, remote_bare_jid));
+
+CREATE INDEX i_inbox
+    ON inbox
+    USING BTREE(luser, lserver, timestamp);
+
+CREATE TABLE pubsub_nodes (
+    nidx               BIGSERIAL PRIMARY KEY,
+    p_key VARCHAR(250) NOT NULL,
+    name VARCHAR(250)  NOT NULL,
+    type VARCHAR(250)  NOT NULL,
+    owners JSON        NOT NULL,
+    options JSON       NOT NULL
+);
+
+CREATE UNIQUE INDEX i_pubsub_nodes_key_name ON pubsub_nodes USING btree (p_key, name);
+
+CREATE TABLE pubsub_node_collections (
+    name VARCHAR(250)        NOT NULL,
+    parent_name VARCHAR(250) NOT NULL,
+    PRIMARY KEY(name, parent_name)
+);
+
+CREATE TABLE pubsub_affiliations (
+    nidx BIGINT             NOT NULL,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    aff SMALLINT            NOT NULL,
+    PRIMARY KEY(luser, lserver, nidx)
+);
+
+CREATE INDEX i_pubsub_affiliations_nidx ON pubsub_affiliations(nidx);
+
+CREATE TABLE pubsub_items (
+    nidx BIGINT                         NOT NULL,
+    itemid VARCHAR(250)                 NOT NULL,
+    created_luser VARCHAR(250)          NOT NULL,
+    created_lserver VARCHAR(250)        NOT NULL,
+    created_at BIGINT                   NOT NULL,
+    modified_luser VARCHAR(250)         NOT NULL,
+    modified_lserver VARCHAR(250)       NOT NULL,
+    modified_lresource VARCHAR(250)     NOT NULL,
+    modified_at BIGINT                  NOT NULL,
+    publisher TEXT,
+    payload TEXT                        NOT NULL,
+    PRIMARY KEY(nidx, itemid)
+);
+
+CREATE TABLE pubsub_last_item (
+    nidx                BIGINT       NOT NULL,
+    itemid              VARCHAR(250) NOT NULL,
+    created_luser       VARCHAR(250) NOT NULL,
+    created_lserver     VARCHAR(250) NOT NULL,
+    created_at          BIGINT       NOT NULL,
+    payload             TEXT         NOT NULL,
+	PRIMARY KEY (nidx)
+);
+
+-- we skip luser and lserver in this one as this is little chance (even impossible?)
+-- to have itemid duplication for distinct users
+CREATE INDEX i_pubsub_items_lus_nidx ON pubsub_items(created_luser, created_lserver, nidx);
+CREATE INDEX i_pubsub_items_nidx ON pubsub_items(nidx);
+
+
+CREATE TABLE pubsub_subscriptions (
+    nidx BIGINT             NOT NULL,
+    luser VARCHAR(250)      NOT NULL,
+    lserver VARCHAR(250)    NOT NULL,
+    lresource VARCHAR(250)  NOT NULL,
+    type SMALLINT           NOT NULL,
+    sub_id VARCHAR(125)     NOT NULL,
+    options JSON            NOT NULL
+);
+
+CREATE INDEX i_pubsub_subscriptions_lus_nidx ON pubsub_subscriptions(luser, lserver, nidx);
+CREATE INDEX i_pubsub_subscriptions_nidx ON pubsub_subscriptions(nidx);
+
+CREATE TABLE event_pusher_push_subscription (
+     owner_jid VARCHAR(250),
+     node VARCHAR(250),
+     pubsub_jid VARCHAR(250),
+     form JSON NOT NULL,
+     created_at BIGINT NOT NULL,
+     PRIMARY KEY(owner_jid, node, pubsub_jid)
+ );
+
+CREATE INDEX i_event_pusher_push_subscription ON event_pusher_push_subscription(owner_jid);
+
+CREATE TABLE mongoose_cluster_id (
+    k varchar(50) PRIMARY KEY,
+    v text
+);

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -322,11 +322,11 @@ find_node_by_name(Key, Node) ->
 
 decode_pubsub_node_row({Nidx, KeySQL, Name, Type, Owners, Options}) ->
     Key = decode_key(KeySQL),
-    {DecodedOpts} = jiffy:decode(Options),
+    {DecodedOpts} = jiffy:decode(mongoose_rdbms:unescape_binary(<<>>, Options)),
     DecodedOptions = [maybe_option_value_to_atom(key_to_existing_atom(Item)) ||
                       Item <- DecodedOpts],
     DecodedOwners = [jid:to_lower(jid:from_binary(Owner)) ||
-                     Owner <- jiffy:decode(Owners)],
+                     Owner <- jiffy:decode(mongoose_rdbms:unescape_binary(<<>>, Owners))],
     #pubsub_node{nodeid = {Key, Name},
                  id = mongoose_rdbms:result_to_integer(Nidx),
                  type = Type,

--- a/src/rdbms/mongoose_rdbms_pgsql.erl
+++ b/src/rdbms/mongoose_rdbms_pgsql.erl
@@ -34,8 +34,27 @@ escape_binary(Bin) when is_binary(Bin) ->
 -spec unescape_binary(binary()) -> binary().
 unescape_binary(<<"\\x", Bin/binary>>) ->
     bin_to_hex:hex_to_bin(Bin);
-unescape_binary(Bin) when is_binary(Bin) ->
-    Bin.
+unescape_binary(Bin) ->
+    list_to_binary(unescape_characters(binary_to_list(Bin))).
+
+unescape_characters([$\\ | [$\\ = C | S]]) when is_list(S) ->
+    [C |  unescape_characters(S)];
+unescape_characters([$\\ | [$0 | S]]) when is_list(S) ->
+    ["\0" |  unescape_characters(S)];
+unescape_characters([$\\ | [$n | S]]) when is_list(S) ->
+    ["\n" |  unescape_characters(S)];
+unescape_characters([$\\ | [$t | S]]) when is_list(S) ->
+    ["\t" |  unescape_characters(S)];
+unescape_characters([$\\ | [$b | S]]) when is_list(S) ->
+    ["\b" |  unescape_characters(S)];
+unescape_characters([$\\ | [$r | S]]) when is_list(S) ->
+    ["\r" |  unescape_characters(S)];
+unescape_characters([$\\ | S]) when is_list(S) ->
+    unescape_characters(S);
+unescape_characters([]) ->
+    [];
+unescape_characters([C | S]) when is_list(S) ->
+    [C | unescape_characters(S)].
 
 -spec connect(Args :: any(), QueryTimeout :: non_neg_integer()) ->
                      {ok, Connection :: term()} | {error, Reason :: any()}.

--- a/tools/docker-setup-cockroach.sh
+++ b/tools/docker-setup-cockroach.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Configuring postgres and creating schema
-./cockroach sql --insecure --execute "CREATE DATABASE mongooseim"
-./cockroach sql --insecure --execute "CREATE USER mongooseim"
-./cockroach sql --insecure --execute "GRANT ALL ON DATABASE mongooseim TO mongooseim"
+./cockroach sql --insecure --execute "CREATE DATABASE ejabberd"
+./cockroach sql --insecure --execute "CREATE USER ejabberd"
+./cockroach sql --insecure --execute "GRANT ALL ON DATABASE ejabberd TO ejabberd"
 ./cockroach sql --insecure \
-    --database "mongooseim" \
-    --user "mongooseim" \
+    --database "ejabberd" \
+    --user "ejabberd" \
     < ${SQL_TEMP_DIR}/cockroach-pg.sql

--- a/tools/docker-setup-cockroach.sh
+++ b/tools/docker-setup-cockroach.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Configuring postgres and creating schema
+./cockroach sql --insecure --execute "CREATE DATABASE mongooseim"
+./cockroach sql --insecure --execute "CREATE USER mongooseim"
+./cockroach sql --insecure --execute "GRANT ALL ON DATABASE mongooseim TO mongooseim"
+./cockroach sql --insecure \
+    --database "mongooseim" \
+    --user "mongooseim" \
+    < ${SQL_TEMP_DIR}/cockroach-pg.sql


### PR DESCRIPTION
This PR addresses using an experimental CockroachDB backend.

Here is the summary of the research around using CockroachDB and YugabyteDB with MongooseIM.

## CockroachDB

At the first glance Cockroach seems to be a bit more mature project than Yugabyte. I've simply encountered less serious bugs when working with Cockroach. However, on the other hand, Cockroach has (in my opinion which is based on just several hours of playing with the db) a bit worse compatibility with Postgres drivers than Yuga. Below is the list of steps I've taken to make MIM work with Cockroach:

1. Modify `pg.sql` schema:
    1. `ENUM` type is not supported.
    2. `family` word has special meaning.
    3. `JSON` fields don't want to work with pubsub (as far as I understand JSON escaped by MIM is not accepted by JSON type in the db).
    4. Fields that are used in `ON CONFLICT` clause need to be `UNIQUE`, see: https://github.com/esl/MongooseIM/pull/2680/files#diff-e0bb6223ac581f8935ad246096a537d5R371.

2. String escaping - in general string escaping differs between Postgres and Cockroach:

MIM with Postgres:
```
(mongooseim@localhost)1> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT 1;">>).
{selected,[{<<"1">>}]}
(mongooseim@localhost)2> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT '\';">>).
{selected,[{<<>>}]}
(mongooseim@localhost)3> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT '\\';">>).
{error,"unterminated quoted string at or near \"'\\';\""}
(mongooseim@localhost)4> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT '\\\\';">>).
{selected,[{<<"\\">>}]}
(mongooseim@localhost)5>
``` 
MIM with Cockroach:
```
(mongooseim@localhost)25> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT 1;">>).
{selected,[{<<"1">>}]}
(mongooseim@localhost)26> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT '\';">>).
{selected,[{<<>>}]}
(mongooseim@localhost)27> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT '\\';">>).
{selected,[{<<"\\">>}]}
(mongooseim@localhost)28> mongoose_rdbms:sql_query(<<"localhost">>, <<"SELECT '\\\\';">>).
{selected,[{<<"\\\\">>}]}
(mongooseim@localhost)29>
```

I've created a PoC for escaping problem, see: https://github.com/esl/MongooseIM/pull/2680/files#diff-98c5e078be0cdd48c01b07ef75dceb89L37-R57. It was necessary, for example, to make one of pubsub test cases pass. But it also required changing the server code. IMO to solve that problem we should write a proper unescaping function for CockroachDB and change some of the server code so DB results that might need unescaping go through that function.

Please notice that it's possible that there are more problems out there but I have not found it yet. I've started with `mam_SUITE`. When it passed I just went through SUITEs that failed on CI. So far I've looked into `rdbms_SUITE` and `pubsub_SUITE`.

This PR also contains code that sets up CockroachDB in a docker container and provisiones it to be ready to work with MIM.

## YugabyteDB

I found some critical bugs e.g. `ORDER BY` clause causing different length of results or some weird errors when using concurrent connections to the DB. I've created [an issue](https://github.com/yugabyte/yugabyte-db/issues/4004) on Yuga github re the former issue and their team responded almost immediately and the bug has been solved within a few days - chapeau bas Yougabyte team!

When it comes the latter bug, here is the error:
```
reason={case_clause,#{class => throw,reason => {aborted,#{reason => "Query error: Restart read required at: { read: { physical: 1584977855699547 } local_limit: { physical: 1584977855704746 } global_limit: <min> in_txn_limit: <max> serial_no: 0 }",sql_query => ["SELECT ","nidx, p_key, name, type, owners, options"," from pubsub_nodes WHERE p_key = ",[39,<<"pubsub.localhost">>,39]," AND name = ",[39,<<"princely_musings_yeWbz8Oh">>,39]]}},stacktrace => [{mongoose_rdbms,sql_query_t,2,[{file,"/Users/kacpermentel/ESL/other/yugabyte/MongooseIM/_build/mim1/lib/mongooseim/src/rdbms/mongoose_rdbms.erl"},{line,239}]},{mod_pubsub_db_rdbms,find_node_by_name,2,[{file,"/Users/kacpermentel/ESL/other/yugabyte/MongooseIM/_build/mim1/lib/mongooseim/src/pubsub/mod_pubsub_db_rdbms.erl"},{line,316}]},{timer,tc,3,[{file,"timer.erl"},{line,197}]},{mod_pubsub_db_backend,find_node_by_name,2,[{file,[]},{line,103}]},{nodetree_dag,create_node,6,[{file,"/Users/kacpermentel/ESL/other/yugabyte/MongooseIM/_build/mim1/lib/mongooseim/src/pubsub/nodetree_dag.erl"},{line,56}]},{mod_pubsub,create_node_authorized_transaction,6,[{file,"/Users/kacpermentel/ESL/other/yugabyte/MongooseIM/_build/mim1/lib/mongooseim/src/pubsub/mod_pubsub.erl"},{line,1995}]},{mod_pubsub_db,'-extra_debug_fun/1-fun-0-',1,[{file,"/U..."},...]},...]}}
```
It comes form MIM logs when running pubsub suite. Setting DB workers to `1` in MIM config solved the problem.

Very strong advantage of YugabyteDB is its compatibility with Postgres driver. **The DB SQL API behaves exactly the same as original Postgres one (as far as I could test it).**