### PR TITLE
[WIP] Remove hooks used only for metrics in mod_mam

### DIFF
--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -255,12 +255,12 @@ process_mam_iq(From=#jid{lserver=Host}, To, Acc, IQ) ->
                 {error, max_delay_reached} ->
                     ?WARNING_MSG("issue=max_delay_reached, action=~p, host=~p, from=~p",
                                  [Action, Host, From]),
-                    Acc1 = mongoose_hooks:mam_drop_iq(Host, Acc, To, IQ, Action, max_delay_reached),
-                    {Acc1, return_max_delay_reached_error_iq(IQ)}
+                    mongoose_metrics:update(Host, modMamDroppedIQ, 1),
+                    {Acc, return_max_delay_reached_error_iq(IQ)}
             end;
         false ->
-            Acc1 = mongoose_hooks:mam_drop_iq(Host, Acc, To, IQ, Action, action_not_allowed),
-            {Acc1, return_action_not_allowed_error_iq(IQ)}
+            mongoose_metrics:update(Host, modMamDroppedIQ, 1),
+            {Acc, return_action_not_allowed_error_iq(IQ)}
     end.
 
 
@@ -618,9 +618,9 @@ message_row_to_xml(MamNs, {MessID, SrcJID, Packet}, QueryID, SetClientNs)  ->
 message_row_to_ext_id({MessID, _, _}) ->
     mess_id_to_external_binary(MessID).
 
-handle_error_iq(Host, Acc, To, Action, {error, Reason, IQ}) ->
-    Acc1 = mongoose_hooks:mam_drop_iq(Host, Acc, To, IQ, Action, Reason),
-    {Acc1, IQ};
+handle_error_iq(Host, Acc, _To, _Action, {error, _Reason, IQ}) ->
+    mongoose_metrics:update(Host, modMamDroppedIQ, 1),
+    {Acc, IQ};
 handle_error_iq(_Host, Acc, _To, _Action, IQ) ->
     {Acc, IQ}.
 

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -84,7 +84,7 @@ archive_message(_Result, Host, MessageId, _UserId, LocalJid, RemoteJid, SourceJi
         {error, _} = Err ->
             ?ERROR_MSG("event=archive_message_failed server=~s user=~s remote=~s mess_id=~p reason=~1000p",
                        [Host, Owner, Remote, MessageId, Err]),
-            mongoose_hooks:mam_drop_message(Host, ok),
+            mongoose_metrics:update(Host, modMamDropped, 1),
             Err
     end.
 

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -256,9 +256,8 @@ room_process_mam_iq(From = #jid{lserver = Host}, To, Acc, IQ) ->
                     handle_error_iq(Acc, Host, To, Action,
                                     handle_mam_iq(Action, From, To, IQ));
                 {error, max_delay_reached} ->
-                    Acc1 = mongoose_hooks:mam_muc_drop_iq(Host, Acc, To, IQ,
-                                                          Action, max_delay_reached),
-                    {Acc1, return_max_delay_reached_error_iq(IQ)}
+                    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1),
+                    {Acc, return_max_delay_reached_error_iq(IQ)}
             end;
         false -> {Acc, return_action_not_allowed_error_iq(IQ)}
     end.
@@ -541,9 +540,9 @@ message_row_to_ext_id({MessID, _, _}) ->
 
 -spec handle_error_iq(mongoose_acc:t(), jid:lserver(), jid:jid(), atom(),
     {error, term(), jlib:iq()} | jlib:iq() | ignore) -> {mongoose_acc:t(), jlib:iq() | ignore}.
-handle_error_iq(Acc, Host, To, Action, {error, Reason, IQ}) ->
-    Acc1 = mongoose_hooks:mam_muc_drop_iq(Host, Acc, To, IQ, Action, Reason),
-    {Acc1, IQ};
+handle_error_iq(Acc, Host, _To, _Action, {error, _Reason, IQ}) ->
+    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1),
+    {Acc, IQ};
 handle_error_iq(Acc, _Host, _To, _Action, IQ) ->
     {Acc, IQ}.
 

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -87,7 +87,7 @@ archive_message(_Result, Host, MessageId, _UserId, RoomJid, FromJID, SourceJid, 
         {error, _} = Err ->
             ?ERROR_MSG("event=archive_muc_message_failed server=~s room=~s source=~s mess_id=~p reason=~1000p",
                        [Host, Room, SourceBinJid, MessageId, Err]),
-            mongoose_hooks:mam_drop_message(Host, ok),
+            mongoose_metrics:update(Host, modMamDropped, 1),
             Err
     end.
 

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -173,7 +173,7 @@ archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
             receive
                 {'DOWN', MonRef, process, Pid, normal} -> ok;
                 {'DOWN', MonRef, process, Pid, _} ->
-                    mongoose_hooks:mam_drop_message(Host, ok),
+                    mongoose_metrics:update(Host, modMamDropped, 1),
                     {error, timeout}
             end
     end.
@@ -258,7 +258,7 @@ do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
     case InsertResult of
         {updated, _Count} -> ok;
         {error, Reason} ->
-            mongoose_hooks:mam_drop_messages(Host, ok, MessageCount),
+            mongoose_metrics:update(Host, modMamDropped2, MessageCount),
             ?ERROR_MSG("archive_message query failed with reason ~p", [Reason]),
             ok
     end,

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -194,7 +194,7 @@ archive_message(_Result, Host,
             receive
                 {'DOWN', MonRef, process, Pid, normal} -> ok;
                 {'DOWN', MonRef, process, Pid, _} ->
-                    mongoose_hooks:mam_drop_message(Host, ok),
+                    mongoose_metrics:update(Host, modMamDropped, 1),
                     {error, timeout}
             end
     end.
@@ -265,12 +265,12 @@ do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
     case InsertResult of
         {updated, _Count} -> ok;
         {error, Reason} ->
-            mongoose_hooks:mam_drop_messages(Host, ok, MessageCount),
+            mongoose_metrics:update(Host, modMamDropped2, MessageCount),
             ?ERROR_MSG("archive_message query failed with reason ~p", [Reason]),
             ok
     end,
     spawn_link(fun() ->
-                       mongoose_hooks:mam_flush_messages(Host, ok, MessageCount)
+                       mongoose_metrics:update(Host, modMamFlushed, MessageCount)
                end),
     erlang:garbage_collect(),
     State#state{acc=[], flush_interval_tref=undefined}.

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -139,7 +139,7 @@ archive_message(_Result, Host, MessId, _UserID, LocJID, RemJID, SrcJID, _Dir, Pa
     catch _Type:Reason:StackTrace ->
             ?WARNING_MSG("Could not write message to archive, reason: ~p",
                          [{Reason, StackTrace}]),
-            mongoose_hooks:mam_drop_message(Host, ok),
+            mongoose_metrics:update(Host, modMamDropped, 1),
             {error, Reason}
     end.
 
@@ -153,7 +153,7 @@ archive_message_muc(_Result, Host, MessId, _UserID, LocJID, FromJID, SrcJID, _Di
     catch _Type:Reason:StackTrace ->
         ?WARNING_MSG("Could not write MUC message to archive, reason: ~p",
                      [{Reason, StackTrace}]),
-        mongoose_hooks:mam_drop_message(Host, ok),
+        mongoose_metrics:update(Host, modMamDropped, 1),
         {error, Reason}
     end.
 

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -349,18 +349,12 @@ filter_hook(mam_set_prefs) -> skip;
 filter_hook(mam_remove_archive) -> skip;
 filter_hook(mam_archive_message) -> skip;
 filter_hook(mam_flush_messages) -> skip;
-filter_hook(mam_drop_message) -> skip;
-filter_hook(mam_drop_iq) -> skip;
-filter_hook(mam_drop_messages) -> skip;
 filter_hook(mam_muc_get_prefs) -> skip;
 filter_hook(mam_muc_set_prefs) -> skip;
 filter_hook(mam_muc_remove_archive) -> skip;
 filter_hook(mam_muc_lookup_messages) -> skip;
 filter_hook(mam_muc_archive_message) -> skip;
 filter_hook(mam_muc_flush_messages) -> skip;
-filter_hook(mam_muc_drop_message) -> skip;
-filter_hook(mam_muc_drop_iq) -> skip;
-filter_hook(mam_muc_drop_messages) -> skip;
 
 filter_hook(_) -> use.
 

--- a/src/metrics/mongoose_metrics_mam_hooks.erl
+++ b/src/metrics/mongoose_metrics_mam_hooks.erl
@@ -20,20 +20,12 @@
          mam_remove_archive/4,
          mam_lookup_messages/3,
          mam_archive_message/9,
-         mam_flush_messages/3,
-         mam_drop_message/2,
-         mam_drop_iq/6,
-         mam_drop_messages/3,
          mam_muc_get_prefs/4,
          mam_muc_set_prefs/7,
          mam_muc_remove_archive/4,
          mam_muc_lookup_messages/3,
          mam_muc_archive_message/9,
-         mam_muc_flush_messages/3,
-         mam_muc_drop_message/1,
-         mam_muc_drop_iq/6,
-         mam_muc_drop_messages/2
-        ]).
+         mam_muc_flush_messages/3]).
 
 -type metrics_notify_return() :: mongoose_metrics_hooks:metrics_notify_return().
 
@@ -48,10 +40,6 @@ get_hooks(Host) ->
      [mam_set_prefs, Host, ?MODULE, mam_set_prefs, 50],
      [mam_get_prefs, Host, ?MODULE, mam_get_prefs, 50],
      [mam_archive_message, Host, ?MODULE, mam_archive_message, 50],
-     [mam_flush_messages, Host, ?MODULE, mam_flush_messages, 50],
-     [mam_drop_message, Host, ?MODULE, mam_drop_message, 50],
-     [mam_drop_iq, Host, ?MODULE, mam_drop_iq, 50],
-     [mam_drop_messages, Host, ?MODULE, mam_drop_messages, 50],
      [mam_remove_archive, Host, ?MODULE, mam_remove_archive, 50],
      [mam_lookup_messages, Host, ?MODULE, mam_lookup_messages, 100],
      [mam_muc_set_prefs, Host, ?MODULE, mam_muc_set_prefs, 50],
@@ -108,34 +96,6 @@ mam_archive_message(Result, Host,
     mongoose_metrics:update(Host, modMamArchived, 1),
     Result.
 
--spec mam_flush_messages(Acc :: map(),
-                         Host :: jid:server(),
-                         MessageCount :: integer()) -> metrics_notify_return().
-mam_flush_messages(Acc, Host, MessageCount) ->
-    mongoose_metrics:update(Host, modMamFlushed, MessageCount),
-    Acc.
-
-%% #rh
--spec mam_drop_message(Acc :: map(), Host :: jid:server()) -> metrics_notify_return().
-mam_drop_message(Acc, Host) ->
-    mongoose_metrics:update(Host, modMamDropped, 1),
-    Acc.
-
-%% #rh
--spec mam_drop_iq(Acc :: mongoose_acc:t(), Host :: jid:server(), _To :: jid:jid(),
-    _IQ :: jlib:iq(), _Action :: any(), _Reason :: any()) -> Acc :: mongoose_acc:t().
-mam_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update(Host, modMamDroppedIQ, 1),
-    Acc.
-
-%% #rh
--spec mam_drop_messages(Acc :: map(),
-                        Host :: jid:server(),
-                        Count :: integer()) -> metrics_notify_return().
-mam_drop_messages(Acc, Host, Count) ->
-    mongoose_metrics:update(Host, modMamDropped2, Count),
-    Acc.
-
 %% ----------------------------------------------------------------------------
 %% mod_mam_muc
 
@@ -170,16 +130,5 @@ mam_muc_archive_message(Result, Host,
 mam_muc_flush_messages(Acc, Host, MessageCount) ->
     mongoose_metrics:update(Host, modMucMamFlushed, MessageCount),
     Acc.
-
-mam_muc_drop_message(Host) ->
-    mongoose_metrics:update(Host, modMucMamDropped, 1).
-
-%% #rh
-mam_muc_drop_iq(Acc, Host, _To, _IQ, _Action, _Reason) ->
-    mongoose_metrics:update(Host, modMucMamDroppedIQ, 1),
-    Acc.
-
-mam_muc_drop_messages(Host, Count) ->
-    mongoose_metrics:update(Host, modMucMamDropped2, Count).
 
 %%% vim: set sts=4 ts=4 sw=4 et filetype=erlang foldmarker=%%%',%%%. foldmethod=marker:

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -84,21 +84,16 @@
          can_access_room/4,
          muc_room_pid/3]).
 
--export([mam_drop_iq/6,
-         mam_archive_id/3,
+-export([mam_archive_id/3,
          mam_archive_size/4,
          mam_get_behaviour/5,
          mam_set_prefs/7,
          mam_get_prefs/4,
          mam_remove_archive/4,
          mam_lookup_messages/3,
-         mam_archive_message/9,
-         mam_drop_message/2,
-         mam_drop_messages/3,
-         mam_flush_messages/3]).
+         mam_archive_message/9]).
 
--export([mam_muc_drop_iq/6,
-         mam_muc_archive_id/3,
+-export([mam_muc_archive_id/3,
          mam_muc_archive_size/4,
          mam_muc_get_behaviour/5,
          mam_muc_set_prefs/7,
@@ -938,17 +933,6 @@ can_access_room(HookServer, Acc, Room, User) ->
 
 %% MAM related hooks
 
-%%% @doc The `mam_drop_iq' hooks is called when a MAM related IQ was dropped by the server.
--spec mam_drop_iq(HookServer, Acc, To, IQ, Action, Reason) -> ok when
-      HookServer :: jid:lserver(),
-      Acc :: mongoose_acc:t(),
-      To :: jid:jid(),
-      IQ :: jlib:iq(),
-      Action :: mam_iq:action(),
-      Reason :: term().
-mam_drop_iq(HookServer, Acc, To, IQ, Action, Reason) ->
-    ejabberd_hooks:run_fold(mam_drop_iq, HookServer, Acc, [HookServer, To, IQ, Action, Reason]).
-
 %%% @doc The `mam_archive_id' hook is called to determine the id of an archive for a particular user or entity.
 %%% The hook handler is expected to accept the following arguments:
 %%% * Acc with an initial value of `undefined',
@@ -1057,37 +1041,8 @@ mam_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, Re
                             [HookServer, MessageID, ArchiveID, OwnerJID,
                              RemoteJID, SenderJID, Dir, Packet]).
 
-%%% @doc The `mam_drop_message' hook is called when message archive failed.
-%%%
-%%% For those MAM backends which perform synchronous writes of messages the hook is called when there was an error while writing the message.
-%%% In case of backends performing asynchronous writes,
-%%% this hook is called when the process responsible for async and bulk writes died when talking to it.
--spec mam_drop_message(HookServer :: jid:lserver(), InitialValue :: ok) -> ok.
-mam_drop_message(HookServer, InitialValue) ->
-    ejabberd_hooks:run_fold(mam_drop_message, HookServer, InitialValue, [HookServer]).
-
-%%% @doc The `mam_drop_messages' hook is called when the async bulk write operation failed.
--spec mam_drop_messages(HookServer :: jid:lserver(), InitialValue :: ok, MessageCount :: integer()) -> ok.
-mam_drop_messages(HookServer, InitialValue, MessageCount) ->
-    ejabberd_hooks:run_fold(mam_drop_messages, HookServer, InitialValue, [HookServer, MessageCount]).
-
-%%% @doc The `mam_flush_messages' hook is run after the async bulk write happens despite the write operation's result.
--spec mam_flush_messages(HookServer :: jid:lserver(), InitialValue :: ok, MessageCount :: integer()) -> ok.
-mam_flush_messages(HookServer, InitialValue, MessageCount) ->
-    ejabberd_hooks:run_fold(mam_flush_messages, HookServer, InitialValue, [HookServer, MessageCount]).
 
 %% MAM MUC related hooks
-
-%%% @doc The `mam_muc_drop_iq' hooks is called when a MAM related IQ was dropped by the server.
--spec mam_muc_drop_iq(HookServer, Acc, To, IQ, Action, Reason) -> ok when
-      HookServer :: jid:lserver(),
-      Acc :: mongoose_acc:t(),
-      To :: jid:jid(),
-      IQ :: jlib:iq(),
-      Action :: mam_iq:action(),
-      Reason :: term().
-mam_muc_drop_iq(HookServer, Acc, To, IQ, Action, Reason) ->
-    ejabberd_hooks:run_fold(mam_muc_drop_iq, HookServer, Acc, [HookServer, To, IQ, Action, Reason]).
 
 %%% @doc The `mam_muc_archive_id' hook is called to determine the archive ID for a particular room.
 %%% The hook handler is expected to accept the following arguments:


### PR DESCRIPTION
I've made fairly mechanical changes removing hooks used only for metrics in `mod_mam`. I don't know however if it is not a step to far as we loose some API as metrics are updated directly.
