### PR TITLE
Broadcast refactor part one

### DIFF
--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -99,8 +99,7 @@
 
 -type blocking_type() :: 'block' | 'unblock'.
 
--type broadcast_type() :: {exit, Reason :: binary()}
-                        | {item, IJID :: jid:simple_jid() | jid:jid(),
+-type broadcast_type() :: {item, IJID :: jid:simple_jid() | jid:jid(),
                            ISubscription :: from | to | both | none | remove}
                         | {privacy_list, PrivList :: mongoose_privacy:userlist(),
                            PrivListName :: binary()}
@@ -111,7 +110,6 @@
 -type broadcast() :: {broadcast, broadcast_type() | mongoose_acc:t()}.
 
 -type broadcast_result() :: {new_state, NewState :: state()}
-                          | {exit, Reason :: binary()}
                           | {send_new, From :: jid:jid(), To :: jid:jid(),
                              Packet :: exml:element(),
                              NewState :: state()}.

--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -266,7 +266,7 @@ kick_sessions(User, Server, Reason) ->
     JID = jid:make(User, Server, <<>>),
     lists:map(
         fun(Resource) ->
-                service_admin_extra_sessions:kick_this_session(User, Server, Resource, Reason)
+                service_admin_extra_sessions:kick_session(User, Server, Resource, Reason)
         end,
         ejabberd_sm:get_user_resources(JID)).
 

--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -261,7 +261,7 @@ ban_account(User, Host, ReasonText) ->
             {error, ErrorReason}
     end.
 
--spec kick_sessions(jid:user(), jid:server(), binary()) -> [mongoose_acc:t()].
+-spec kick_sessions(jid:user(), jid:server(), binary()) -> [ok].
 kick_sessions(User, Server, Reason) ->
     JID = jid:make(User, Server, <<>>),
     lists:map(

--- a/src/admin_extra/service_admin_extra_sessions.erl
+++ b/src/admin_extra/service_admin_extra_sessions.erl
@@ -32,7 +32,6 @@
     num_resources/2,
     resource_num/3,
     kick_session/4,
-    kick_this_session/4,
     prepare_reason/1,
     status_num/2, status_num/1,
     status_list/2, status_list/1,
@@ -187,22 +186,12 @@ resource_num(User, Host, Num) ->
             lists:flatten(io_lib:format("Error: Wrong resource number: ~p", [Num]))
     end.
 
-
 -spec kick_session(jid:user(), jid:server(), jid:resource(),
-        ReasonText :: binary()) -> 'ok'.
+        ReasonText :: binary() | list()) -> 'ok'.
 kick_session(User, Server, Resource, ReasonText) ->
-    kick_this_session(User, Server, Resource, prepare_reason(ReasonText)),
+    ejabberd_c2s:terminate_session(jid:make(User, Server, Resource),
+                                   prepare_reason(ReasonText)),
     ok.
-
-
--spec kick_this_session(jid:user(), jid:server(), jid:resource(),
-        Reason :: binary()) -> mongoose_acc:t().
-kick_this_session(User, Server, Resource, Reason) ->
-    ejabberd_sm:route(
-        jid:make(<<"">>, <<"">>, <<"">>),
-        jid:make(User, Server, Resource),
-        {broadcast, {exit, Reason}}).
-
 
 -spec prepare_reason(binary() | string()) -> binary().
 prepare_reason(<<>>) ->
@@ -212,10 +201,7 @@ prepare_reason([Reason]) ->
 prepare_reason(Reason) when is_list(Reason) ->
     list_to_binary(Reason);
 prepare_reason(Reason) when is_binary(Reason) ->
-    Reason;
-prepare_reason(StringList) ->
-    prepare_reason(string:join(StringList, "_")).
-
+    Reason.
 
 -spec status_num('all' | jid:server(), status()) -> non_neg_integer().
 status_num(Host, Status) ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -29,6 +29,7 @@
 %% External exports
 -export([start/2,
          stop/1,
+         terminate_session/2,
          start_link/2,
          send_text/2,
          socket_type/0,
@@ -140,8 +141,18 @@ send_filtered(FsmRef, Feature, From, To, Packet) ->
 broadcast(FsmRef, Type, From, Packet) ->
     FsmRef ! {broadcast, Type, From, Packet}.
 
+%% @doc Stops the session gracefully, entering resume state if applicable
 stop(FsmRef) ->
     p1_fsm_old:send_event(FsmRef, closed).
+
+%% @doc terminates the session immediately and unconditionally, sending the user a stream conflict
+%% error specifying the reason
+terminate_session(none, _Reason) ->
+    ok;
+terminate_session(#jid{} = Jid, Reason) ->
+    terminate_session(ejabberd_sm:get_session_pid(Jid), Reason);
+terminate_session(Pid, Reason) when is_pid(Pid) ->
+    Pid ! {exit, Reason}.
 
 store_session_info(FsmRef, JID, KV) ->
     FsmRef ! {store_session_info, JID, KV, self()}.
@@ -1007,6 +1018,14 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 
 
 %%% system events
+handle_info({exit, Reason}, _StateName, StateData) ->
+    Lang = StateData#state.lang,
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => StateData#state.server, %% TODO: use new state API
+                              element => undefined }),
+    send_element(Acc, mongoose_xmpp_errors:stream_conflict(Lang, Reason), StateData),
+    send_trailer(StateData),
+    {stop, normal, StateData};
 handle_info(replaced, _StateName, StateData) ->
     Lang = StateData#state.lang,
     StreamConflict = mongoose_xmpp_errors:stream_conflict(Lang, <<"Replaced by new connection">>),
@@ -1336,8 +1355,6 @@ handle_routed_iq(_From, _To, Acc, IQ, StateData)
 handle_routed_broadcast(Acc, {item, IJID, ISubscription}, StateData) ->
     {Acc2, NewState} = roster_change(Acc, IJID, ISubscription, StateData),
     {Acc2, {new_state, NewState}};
-handle_routed_broadcast(Acc, {exit, Reason}, _StateData) ->
-    {Acc, {exit, Reason}};
 handle_routed_broadcast(Acc, {privacy_list, PrivList, PrivListName}, StateData) ->
     case mongoose_hooks:privacy_updated_list(StateData#state.server,
                                  false, StateData#state.privacy_list, PrivList) of
@@ -1363,11 +1380,6 @@ handle_routed_broadcast(Acc, _, StateData) ->
 -spec handle_broadcast_result(mongoose_acc:t(), broadcast_result(), StateName :: atom(),
     StateData :: state()) ->
     any().
-handle_broadcast_result(Acc, {exit, ErrorMessage}, _StateName, StateData) ->
-    Lang = StateData#state.lang,
-    send_element(Acc, mongoose_xmpp_errors:stream_conflict(Lang, ErrorMessage), StateData),
-    send_trailer(StateData),
-    {stop, normal, StateData};
 handle_broadcast_result(Acc, {send_new, From, To, Stanza, NewState}, StateName, _StateData) ->
     {Act, _, NewStateData} = ship_to_local_user(Acc, {From, To, Stanza}, NewState),
     finish_state(Act, StateName, NewStateData);

--- a/src/ejabberd_c2s_info_handler.erl
+++ b/src/ejabberd_c2s_info_handler.erl
@@ -17,6 +17,7 @@
 
 % API for ejabberd_c2s
 -export([get_for/2,
+         get_for/3,
          add_to_state/3,
          remove_from_state/2,
          safe_call/4]).
@@ -52,9 +53,19 @@ call_after(Time, #jid{} = JID, Tag, Data) ->
 call_after(Time, FsmRef, Tag, Data) ->
     erlang:send_after(Time, FsmRef, {call_info_handler, Tag, Data}).
 
--spec get_for(handler_tag(), state()) -> {handler_tag(), handler_state()} | no_handler.
+-spec get_for(handler_tag(), state(), term()) -> handler_state().
+get_for(Tag, #state{} = State, Default) ->
+    case get_for(Tag, State) of
+        no_handler -> Default;
+        HandlerState -> HandlerState
+    end.
+
+-spec get_for(handler_tag(), state()) -> handler_state() | no_handler.
 get_for(Tag, #state{ info_handlers = InfoHandlers }) ->
-    maps:get(Tag, InfoHandlers, no_handler).
+    case maps:get(Tag, InfoHandlers, no_handler) of
+        {Tag, HandlerState} -> HandlerState;
+        no_handler -> no_handler
+    end.
 
 -spec add_to_state(handler_tag(), handler_state(), state()) -> state().
 add_to_state(Tag, HandlerState, #state{ info_handlers = InfoHandlers0 } = C2SState) ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -34,6 +34,7 @@
 -behaviour(gen_server).
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
+-behaviour(ejabberd_c2s_info_handler).
 
 -export([read_caps/1, caps_stream_features/2,
          disco_features/5, disco_identity/5, disco_info/5]).
@@ -46,8 +47,10 @@
          handle_cast/2, terminate/2, code_change/3]).
 
 -export([user_send_packet/4, user_receive_packet/5,
-         c2s_presence_in/2, c2s_filter_packet/6,
-         c2s_broadcast_recipients/6]).
+         c2s_presence_in/2, c2s_filter_packet/6]).
+
+%% info handler callbacks
+-export([handle_c2s_info/3]).
 
 %% for test cases
 -export([delete_caps/1, make_disco_hash/2]).
@@ -101,6 +104,12 @@ get_features_list(Host, Caps) ->
         unknown -> [];
         Features -> Features
     end.
+
+handle_c2s_info({pep_message, Feature, From, Packet}, HandlerState, #{server := LHost}) ->
+    Recipients = filter_recipients_by_caps(Feature, LHost, HandlerState),
+    lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,
+                  lists:usort(Recipients)),
+    HandlerState.
 
 -spec get_features(jid:lserver(), nothing | caps()) -> unknown | list().
 get_features(_LHost, nothing) -> [];
@@ -236,12 +245,8 @@ c2s_presence_in(C2SState,
     case Insert or Delete of
         true ->
             LFrom = jid:to_lower(From),
-            Rs = case ejabberd_c2s:get_aux_field(caps_resources,
-                                                 C2SState)
-                 of
-                     {ok, Rs1} -> Rs1;
-                     error -> gb_trees:empty()
-                 end,
+            Rs = ejabberd_c2s_info_handler:get_for(?MODULE,
+                                                 C2SState, gb_trees:empty()),
             Caps = read_caps(Els),
             NewRs = case Caps of
                         nothing when Insert == true -> Rs;
@@ -250,8 +255,7 @@ c2s_presence_in(C2SState,
                             upsert_caps(LFrom, From, To, Caps, Rs);
                         _ -> gb_trees:delete_any(LFrom, Rs)
                     end,
-            ejabberd_c2s:set_aux_field(caps_resources, NewRs,
-                                       C2SState);
+            ejabberd_c2s_info_handler:add_to_state(?MODULE, NewRs, C2SState);
         false -> C2SState
     end.
 
@@ -270,38 +274,28 @@ upsert_caps(LFrom, From, To, Caps, Rs) ->
             gb_trees:update(LFrom, Caps, Rs)
     end.
 
-c2s_filter_packet(InAcc, LHost, C2SState, {pep_message, Feature}, To, _Packet) ->
-    case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of
-        {ok, Rs} ->
-            ?DEBUG("Look for CAPS for ~p in ~p (res: ~p)", [To, C2SState, Rs]),
-            LTo = jid:to_lower(To),
-            case gb_trees:lookup(LTo, Rs) of
-                {value, Caps} ->
-                    Drop = not lists:member(Feature, get_features_list(LHost, Caps)),
-                    {stop, Drop};
-                none ->
-                    {stop, true}
-            end;
-        _ -> InAcc
+c2s_filter_packet(_InAcc, LHost, C2SState, {pep_message, Feature}, To, _Packet) ->
+    Rs = ejabberd_c2s_info_handler:get_for(?MODULE,
+                                           C2SState, gb_trees:empty()),
+    ?DEBUG("Look for CAPS for ~p in ~p (res: ~p)", [To, C2SState, Rs]),
+    LTo = jid:to_lower(To),
+    case gb_trees:lookup(LTo, Rs) of
+        {value, Caps} ->
+            Drop = not lists:member(Feature, get_features_list(LHost, Caps)),
+            {stop, Drop};
+        none ->
+            {stop, true}
     end;
 c2s_filter_packet(Acc, _, _, _, _, _) -> Acc.
 
-c2s_broadcast_recipients(InAcc, LHost, C2SState, {pep_message, Feature}, _From, _Packet) ->
-    case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of
-        {ok, Rs} ->
-            filter_recipients_by_caps(InAcc, Feature, LHost, Rs);
-        _ -> InAcc
-    end;
-c2s_broadcast_recipients(Acc, _, _, _, _, _) -> Acc.
-
-filter_recipients_by_caps(InAcc, Feature, LHost, Rs) ->
+filter_recipients_by_caps(Feature, LHost, Rs) ->
     gb_trees_fold(fun(USR, Caps, Acc) ->
                           case lists:member(Feature, get_features_list(LHost, Caps)) of
                               true -> [USR | Acc];
                               false -> Acc
                           end
                   end,
-                  InAcc, Rs).
+                  [], Rs).
 
 init_db(mnesia, _Host) ->
     case catch mnesia:table_info(caps_features, storage_type) of
@@ -334,8 +328,6 @@ init([Host, Opts]) ->
                        c2s_presence_in, 75),
     ejabberd_hooks:add(c2s_filter_packet, Host, ?MODULE,
                        c2s_filter_packet, 75),
-    ejabberd_hooks:add(c2s_broadcast_recipients, Host,
-                       ?MODULE, c2s_broadcast_recipients, 75),
     ejabberd_hooks:add(user_send_packet, Host, ?MODULE,
                        user_send_packet, 75),
     ejabberd_hooks:add(user_receive_packet, Host, ?MODULE,
@@ -367,8 +359,6 @@ terminate(_Reason, State) ->
                           c2s_presence_in, 75),
     ejabberd_hooks:delete(c2s_filter_packet, Host, ?MODULE,
                           c2s_filter_packet, 75),
-    ejabberd_hooks:delete(c2s_broadcast_recipients, Host,
-                          ?MODULE, c2s_broadcast_recipients, 75),
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE,
                           user_send_packet, 75),
     ejabberd_hooks:delete(user_receive_packet, Host,

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -226,11 +226,7 @@ commands() ->
 
 kick_session(Host, User, Resource) ->
     J = jid:make(User, Host, Resource),
-    ejabberd_sm:route(
-      jid:make(<<"">>, <<"">>, <<"">>),
-      J,
-      {broadcast, {exit, <<"kicked">>}}),
-    <<"kicked">>.
+    ejabberd_c2s:terminate_session(J, <<"kicked">>).
 
 list_sessions(Host) ->
     Lst = ejabberd_sm:get_vh_session_list(Host),

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3623,10 +3623,12 @@ broadcast_stanza({LUser, LServer, LResource}, Publisher, Node, Nidx, Type, NodeO
             %% Also, add "replyto" if entity has presence subscription to the account owner
             %% See XEP-0163 1.1 section 4.3.1
             ReplyTo = extended_headers([jid:to_binary(Publisher)]),
-            ejabberd_c2s:broadcast(C2SPid,
-                                   {pep_message, <<((Node))/binary, "+notify">>},
-                                   _Sender = jid:make(LUser, LServer, <<"">>),
-                                   _StanzaToSend = add_extended_headers(Stanza, ReplyTo));
+            ejabberd_c2s_info_handler:call(C2SPid,
+                                           mod_caps,
+                                           {pep_message, <<((Node))/binary, "+notify">>,
+                                            jid:make(LUser, LServer, <<"">>),
+                                            add_extended_headers(Stanza, ReplyTo)
+                                           });
         _ ->
             ?DEBUG("~p@~p has no session; can't deliver ~p to contacts",
                    [LUser, LServer, BaseStanza])


### PR DESCRIPTION
The first two users of the infamous "broadcast" are now using the new c2s handlers:
* exiting user process (a.k.a. kicking a user) is now achieved by a direct call to a function in `ejabberd_c2s` module
* pubsub module sends a pep message by calling a `mod_caps` info handler - it may seem a bit strange, but in pep it is `mod_caps` which determines to whom a message is to be sent, and since handlers are fully encapsulated, so they can not access each other's state, it is `mod_caps` which has to handle it and send messages. 
