### PR TITLE
Fix mod_ping tests so that they pass at the first go

### DIFF
--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -223,7 +223,7 @@ server_ping_pang(ConfigIn) ->
         fun(Alice) ->
                 wait_for_ping_req(Alice),
                 %% do not resp to ping req
-                ct:sleep(timer:seconds(ping_req_timeout() + 1)),
+                ct:sleep(timer:seconds(ping_req_timeout() + 0.5)),
                 TimeoutAction = ?config(timeout_action, Config),
                 check_connection(TimeoutAction, Alice),
                 escalus_client:kill_connection(Config, Alice)


### PR DESCRIPTION
There was some tricky issue: another test, ran just a little while before, did not respond to pings, waited a few seconds, then killed the connection and checked metrics. It was all fine, but the test waited for ping_req_timeout + 1, which incidentally is equal to ping_interval. Server sent one more request, which incremented metrics a few seconds later, which happened be exactly when another test was run, thus breaking that one. The second run of the other tests was ok.

