### PR TITLE
Fix mediated invite structure

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -4949,7 +4949,8 @@ get_nick(User) ->
 %%--------------------------------------------------------------------
 
 invite_has_reason(Stanza) ->
-    exml_query:path(Stanza, [{element, <<"x">>}, {element, <<"reason">>}, cdata]) =/= undefined.
+    exml_query:path(Stanza, [{element, <<"x">>}, {element, <<"invite">>},
+                             {element, <<"reason">>}, cdata]) =/= undefined.
 
 has_reason(Stanza) ->
     exml_query:path(Stanza, [{element, <<"x">>}, {element, <<"item">>},

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -195,24 +195,23 @@ make_config_change_message(Status) ->
 -spec make_invitation(From :: jid:jid(), Password :: binary(),
                       Reason :: binary()) -> exml:element().
 make_invitation(From, Password, Reason) ->
-    Elements = [#xmlel{name = <<"invite">>,
-                       attrs = [{<<"from">>, jid:to_binary(From)}]}],
-    Elements2 = case Password of
-        <<>> -> Elements;
-        _ -> [#xmlel{name = <<"password">>,
-                     children = [#xmlcdata{content = Password}]} | Elements]
-                end,
-    Elements3 = case Reason of
-        <<>> -> Elements2;
-        _ -> [#xmlel{name = <<"reason">>,
-                     children = [#xmlcdata{content = Reason}]} | Elements2]
-                end,
-
+    Children = case Password of
+                    <<>> -> [];
+                    _ -> [#xmlel{name = <<"password">>,
+                            children = [#xmlcdata{content = Password}]}]
+        end,
+    Children2 = case Reason of
+                    <<>> -> Children;
+_                    -> [#xmlel{name = <<"reason">>,
+                            children = [#xmlcdata{content = Reason}]} | Children]
+    end,
+    Invite = #xmlel{name = <<"invite">>,
+               attrs = [{<<"from">>, jid:to_binary(From)}],
+               children = Children2},
     #xmlel{name = <<"message">>,
-           children = [#xmlel{name = <<"x">>,
-                              attrs = [{<<"xmlns">>, ?NS_MUC_USER}],
-                              children = Elements3}]}.
-
+                      children = [#xmlel{name = <<"x">>,
+                      attrs = [{<<"xmlns">>, ?NS_MUC_USER}],
+                      children = [Invite]}]}.
 
 -spec form_field({binary(), binary(), binary()}
                | {binary(), binary()}

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -195,23 +195,25 @@ make_config_change_message(Status) ->
 -spec make_invitation(From :: jid:jid(), Password :: binary(),
                       Reason :: binary()) -> exml:element().
 make_invitation(From, Password, Reason) ->
-    Children = case Password of
+    Children = case Reason of
                     <<>> -> [];
-                    _ -> [#xmlel{name = <<"password">>,
-                            children = [#xmlcdata{content = Password}]}]
-        end,
-    Children2 = case Reason of
-                    <<>> -> Children;
-_                    -> [#xmlel{name = <<"reason">>,
-                            children = [#xmlcdata{content = Reason}]} | Children]
+                    _ -> [#xmlel{name = <<"reason">>,
+                        children = [#xmlcdata{content = Reason}]}]
     end,
-    Invite = #xmlel{name = <<"invite">>,
-               attrs = [{<<"from">>, jid:to_binary(From)}],
-               children = Children2},
+    Elements = [#xmlel{name = <<"invite">>,
+                       attrs = [{<<"from">>, jid:to_binary(From)}],
+                       children = Children}],
+
+    Elements2 = case Password of
+        <<>> -> Elements;
+        _ -> [#xmlel{name = <<"password">>,
+                     children = [#xmlcdata{content = Password}]} | Elements]
+                end,
+
     #xmlel{name = <<"message">>,
-                      children = [#xmlel{name = <<"x">>,
-                      attrs = [{<<"xmlns">>, ?NS_MUC_USER}],
-                      children = [Invite]}]}.
+           children = [#xmlel{name = <<"x">>,
+                              attrs = [{<<"xmlns">>, ?NS_MUC_USER}],
+                              children = Elements2}]}.
 
 -spec form_field({binary(), binary(), binary()}
                | {binary(), binary()}


### PR DESCRIPTION
This change fixes structure of invite sent from MongooseIM.
Doc reference https://xmpp.org/extensions/xep-0045.html#invite-mediated
Currently looks like:
```xml
<message
    from='coven@chat.shakespeare.lit'
    id='nzd143v8'
    to='hecate@shakespeare.lit'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <reason>Hey Hecate, this is the place for all good witches!</reason>
    <password>cauldronburn</password>
    <invite from='crone1@shakespeare.lit/desktop'/>
  </x>
</message>
```

Should be

```xml
<message
    from='coven@chat.shakespeare.lit'
    id='nzd143v8'
    to='hecate@shakespeare.lit'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <invite from='crone1@shakespeare.lit/desktop'>
      <reason>
        Hey Hecate, this is the place for all good witches!
      </reason>
    </invite>
    <password>cauldronburn</password>
  </x>
</message>
```
