### PR TITLE
Update ref to esl/mongooseim-docker

### DIFF
--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -33,7 +33,7 @@ IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
-git checkout 6c616f9ef03ad806b826e0917e57ea0daf08643e
+git checkout aeeeef12ea64a00aa72da88472aff8c4f0e049a6
 
 cp ../${MONGOOSE_TGZ} member
 


### PR DESCRIPTION
This PR uses mongooseim-docker where:
* The base image was updated to `phusion/baseimage:master` which is based on Ubuntu 18.04
* Installs OpenSSL 1.1

This PR supersedes #2687 and #2683