### PR TITLE
Extend `scram-sha` mnesia tests

### DIFF
--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -272,10 +272,10 @@ get_password(LUser, LServer) ->
     US = {LUser, LServer},
     case catch dirty_read_passwd(US) of
         [#passwd{password = Scram}] when is_record(Scram, scram) ->
-            {base64:decode(Scram#scram.storedkey),
-             base64:decode(Scram#scram.serverkey),
-             base64:decode(Scram#scram.salt),
-             Scram#scram.iterationcount};
+            #{salt => Scram#scram.salt,
+              iteration_count => Scram#scram.iterationcount,
+              sha => #{stored_key => Scram#scram.storedkey,
+                       server_key => Scram#scram.serverkey}};
         [#passwd{password = Params}] when is_map(Params)->
             Params;
         [#passwd{password = Password}] ->

--- a/src/sasl/cyrsasl_scram.erl
+++ b/src/sasl/cyrsasl_scram.erl
@@ -177,8 +177,6 @@ get_scram_attributes(UserName, LServer, Sha) ->
             {AuthModule, do_get_scram_attributes(Params, Sha)}
     end.
 
-do_get_scram_attributes(Params, _) when is_tuple(Params) ->
-    Params;
 do_get_scram_attributes(#{salt := Salt, iteration_count := IterationCount} = Params, Sha) ->
     #{Sha  := #{stored_key := StoredKey, server_key := ServerKey}} = Params,
     {base64:decode(StoredKey), base64:decode(ServerKey),

--- a/test/auth_internal_SUITE.erl
+++ b/test/auth_internal_SUITE.erl
@@ -1,0 +1,78 @@
+-module(auth_internal_SUITE).
+
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-include("scram.hrl").
+
+all() ->
+    [passwords_as_records_are_still_supported,
+     passwords_in_plain_can_be_converted_to_scramed].
+
+init_per_suite(C) ->
+    application:ensure_all_started(jid),
+    ok = mnesia:create_schema([node()]),
+    ok = mnesia:start(),
+    ejabberd_auth_internal:start(<<"server">>),
+    C.
+
+end_per_suite(_C) ->
+    mnesia:stop(),
+    mnesia:delete_schema([node()]).
+
+passwords_as_records_are_still_supported(_C) ->
+    %% given in mnesia there is a user with password in old scram format
+    {U, S, P} = gen_user(),
+    OldScramFormat = old_password_to_scram(P, 340),
+    UserRecord = {passwd, {U, S}, OldScramFormat},
+    mnesia:dirty_write(UserRecord),
+    %% when we read the password via the `ejabberd_auth_internal:get_password/2
+    NewScramMap = ejabberd_auth_internal:get_password(U, S),
+    %% then new map with sha key is returned
+    ?assertMatch(#{iteration_count := _, salt := _,
+                   sha := #{server_key := _, stored_key := _}}, NewScramMap),
+    %% even though in db there is old record stored
+    OldScram = mnesia:dirty_read({passwd, {U, S}}),
+    ?assertMatch([{passwd, _, {scram, _, _, _, _}}], OldScram).
+
+passwords_in_plain_can_be_converted_to_scramed(_C) ->
+    %% Given there in mnesia there are users
+    %% with plain text password
+    {U, S, P} = gen_user(),
+    UserRecord = {passwd, {U, S}, P},
+    mnesia:dirty_write(UserRecord),
+    %% and password in the old record format
+    {U2, S2, P2} = gen_user(),
+    OldScramFormat = old_password_to_scram(P2, 340),
+    UserRecord2 = {passwd, {U2, S2}, OldScramFormat},
+    mnesia:dirty_write(UserRecord2),
+    meck:new(ejabberd_auth),
+    meck:expect(ejabberd_auth, get_opt, fun(_, scram_iterations, D) -> D end),
+    %% when the migration function is run
+    ejabberd_auth_internal:scram_passwords(),
+    AfterMigrationPlain = mnesia:dirty_read({passwd, {U, S}}),
+    %% then plain text passwords are converted to new map with sha and sha256
+    ?assertMatch([{passwd, _,
+                   #{iteration_count := _, salt := _,
+                     sha := #{server_key := _, stored_key := _},
+                     sha256 := #{server_key := _, stored_key := _}}}], AfterMigrationPlain),
+    %% and the old scram format remains the same
+    AfterMigrationOldScram = mnesia:dirty_read({passwd, {U2, S2}}),
+    ?assertMatch([{passwd, _, {scram, _, _, _, _}}], AfterMigrationOldScram),
+    meck:unload().
+
+gen_user() ->
+    {base64:encode(crypto:strong_rand_bytes(5)),
+     <<"server">>,
+     base64:encode(crypto:strong_rand_bytes(6))}.
+
+old_password_to_scram(Password, IterationCount) ->
+    Salt = crypto:strong_rand_bytes(16),
+    SaltedPassword = mongoose_scram:salted_password(sha, Password, Salt, IterationCount),
+    ClientKey = mongoose_scram:client_key(sha, SaltedPassword),
+    StoredKey = mongoose_scram:stored_key(sha, ClientKey),
+    ServerKey = mongoose_scram:server_key(sha, SaltedPassword),
+    #scram{storedkey = base64:encode(StoredKey),
+           serverkey = base64:encode(ServerKey),
+           salt = base64:encode(Salt),
+           iterationcount = IterationCount}.
+


### PR DESCRIPTION
This PR extends tests to check if mnesia can properly work with entries in the old scram format

Proposed changes include:
* `ejabberd_auth_internal:get_password` returns new map if old entry is found in the database
* new tests for:
    * `get_password`
    * plaintext to scram converstion script
