### PR TITLE
Remove dead ejabberd_auth:remove_user/3

### DIFF
--- a/doc/authentication-backends/External-authentication-module.md
+++ b/doc/authentication-backends/External-authentication-module.md
@@ -20,7 +20,6 @@ The following list describes packets that the script should support.
 * `setpass:<username>:<domain>:<password>` - Set password.
 * `tryregister:<username>:<domain>:<password>` - Register a user.
 * `removeuser:<username>:<domain>` - Remove a user.
-* `removeuser3:<username>:<domain>:<password>` - Remove a user if the password is correct.
 * `isuser:<username>:<domain>` - Check if a user exists.
 
 ## Configuration options

--- a/doc/authentication-backends/HTTP-authentication-module.md
+++ b/doc/authentication-backends/HTTP-authentication-module.md
@@ -12,7 +12,7 @@ The module can be especially useful for users maintaining their own central user
 For a full reference please check [Advanced-configuration#authentication](../Advanced-configuration.md#authentication).
 The simplest way is to just replace the default `auth_method` option in `rel/files/mongooseim.cfg` with `{auth_method, http}`.
 
-Enabling the module **is not enough!** 
+Enabling the module **is not enough!**
 Please follow instructions below.
 
 ### Configuration options
@@ -102,7 +102,7 @@ A body can be missing in the first data chunk read from a socket, leading to str
 * **Return values:**
     * 200, password in the body
     * anything else - `get_password` will fail
-    
+
 ### Method `get_certs`
 
 * **Description:** Must return all the valid certificates of a user in the [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail).
@@ -111,7 +111,7 @@ A body can be missing in the first data chunk read from a socket, leading to str
 * **Return values:**
     * 200, all the user's certificates listed one after another (as in a PEM file)
     * anything else - `get_certs` will fail
-    
+
 ### Method `user_exists`
 
 * **Description:** Must return the information whether the user exists in DB.
@@ -140,17 +140,6 @@ A body can be missing in the first data chunk read from a socket, leading to str
     * 200 or 201 or 204 - success
     * 404 - user does not exist
     * 403 - not allowed for some reason
-    * 40X - will be treated as `bad request`
-
-### Method `remove_user_validate`
-
-* **Description:** Removes a user account only if the provided password is valid.
-* **HTTP method:** POST
-* **Type:** mandatory when `mod_register` is enabled
-* **Return values:**
-    * 200 or 201 or 204 - success
-    * 404 - user does not exist
-    * 403 - invalid user password or not allowed for other reason
     * 40X - will be treated as `bad request`
 
 ### Authentication service API recipes

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -48,7 +48,6 @@
          get_password/3,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2,
          get_vh_registered_users/2,
          get_vh_registered_users_number/1,
@@ -316,12 +315,6 @@ does_user_exist(LUser, LServer) ->
 remove_user(_LUser, _LServer) ->
     {error, not_allowed}.
 
-
--spec remove_user(LUser :: jid:luser(),
-                  LServer :: jid:lserver(),
-                  Password :: binary()) -> {error, not_allowed}.
-remove_user(_LUser, _LServer, _Password) ->
-    {error, not_allowed}.
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(Host, cyrsasl_anonymous) -> is_sasl_anonymous_enabled(Host);

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -21,7 +21,6 @@
          get_password_s/2,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2,
          scram_passwords/0]).
 
@@ -91,12 +90,6 @@ does_user_exist(_User, _Server) ->
 %% @doc Remove user.
 %% Note: it returns ok even if there was some problem removing the user.
 remove_user(_User, _Server) ->
-    ok.
-
-%% @spec (User, Server, Password) -> ok | not_exists | not_allowed | bad_request
-%% @doc Remove user if the provided password is correct.
-remove_user(_User, _Server, _Password) ->
-    %% in fact not_supported
     ok.
 
 supports_sasl_module(_, cyrsasl_plain) -> true;

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -42,7 +42,6 @@
          get_password_s/2,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2
         ]).
 
@@ -210,23 +209,6 @@ remove_user(LUser, LServer) ->
                 false -> ok;
                 {true, _CacheTime} ->
                     ejabberd_auth_internal:remove_user(LUser, LServer)
-            end,
-            ok
-    end.
-
-
--spec remove_user(LUser :: jid:luser(),
-                  LServer :: jid:lserver(),
-                  Password :: binary()
-                  ) -> ok | {error, not_allowed}.
-remove_user(LUser, LServer, Password) ->
-    case extauth:remove_user(LUser, LServer, Password) of
-        false -> {error, not_allowed};
-        true ->
-            case get_cache_option(LServer) of
-                false -> ok;
-                {true, _CacheTime} ->
-                    ejabberd_auth_internal:remove_user(LUser, LServer, Password)
             end,
             ok
     end.

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -24,7 +24,6 @@
          get_password_s/2,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2,
          stop/1]).
 
@@ -173,23 +172,6 @@ remove_user(LUser, LServer) ->
     case remove_user_req(LUser, LServer, <<"">>, <<"remove_user">>) of
         ok -> ok;
         _ -> {error, not_allowed}
-    end.
-
--spec remove_user(jid:luser(), jid:lserver(), binary()) ->
-    ok | {error, not_allowed | not_exists | bad_request}.
-remove_user(LUser, LServer, Password) ->
-    case mongoose_scram:enabled(LServer) of
-        false ->
-            remove_user_req(LUser, LServer, Password, <<"remove_user_validate">>);
-        true ->
-            case verify_scram_password(LUser, LServer, Password) of
-                {ok, true} ->
-                    remove_user_req(LUser, LServer, <<"">>, <<"remove_user">>);
-                {ok, false} ->
-                    {error, not_allowed};
-                {error, _} = Error ->
-                    Error
-            end
     end.
 
 -spec remove_user_req(binary(), binary(), binary(), binary()) ->

--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -44,7 +44,6 @@
          get_password_s/2,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2
         ]).
 
@@ -192,15 +191,6 @@ does_user_exist(_LUser, _LServer) ->
                   ) -> ok | {error, not_allowed}.
 remove_user(_LUser, _LServer) ->
     ok.
-
-
-%% @doc Remove user if the provided password is correct.
--spec remove_user(LUser :: jid:luser(),
-                  LServer :: jid:lserver(),
-                  Password :: binary()
-                  ) -> ok | {error, not_exists | not_allowed | bad_request}.
-remove_user(_LUser, _LServer, _Password) ->
-    {error, not_allowed}.
 
 %%%----------------------------------------------------------------------
 %%% Internal helpers

--- a/src/auth/ejabberd_auth_ldap.erl
+++ b/src/auth/ejabberd_auth_ldap.erl
@@ -48,7 +48,6 @@
          get_password_s/2,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2
         ]).
 
@@ -254,23 +253,6 @@ remove_user(LUser, LServer) ->
       false -> {error, not_allowed};
       DN -> eldap_pool:delete(State#state.eldap_id, DN)
     end.
-
-
--spec remove_user(LUser :: jid:luser(),
-                  LServer :: jid:lserver(),
-                  Password :: binary()
-                  ) -> ok | {error, not_exists | not_allowed}.
-remove_user(LUser, LServer, Password) ->
-    {ok, State} = eldap_utils:get_state(LServer, ?MODULE),
-    case find_user_dn(LUser, State) of
-      false -> {error, not_exists};
-      DN ->
-            case eldap_pool:bind(State#state.bind_eldap_id, DN, Password) of
-                ok -> ok = eldap_pool:delete(State#state.eldap_id, DN);
-                _ -> {error, not_allowed}
-            end
-    end.
-
 
 %%%----------------------------------------------------------------------
 %%% Internal functions

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -35,8 +35,7 @@
          get_password/2,
          get_password_s/2,
          does_user_exist/2,
-         remove_user/2,
-         remove_user/3
+         remove_user/2
         ]).
 
 -export([check_password/3,
@@ -105,12 +104,6 @@ does_user_exist(_, _) -> true.
                    Server :: ejabberd:lserver()
                  ) -> ok | {error, not_allowed}.
 remove_user(_, _) -> {error, not_allowed}.
-
--spec remove_user( User :: ejabberd:luser(),
-                   Server :: ejabberd:lserver(),
-                   Password :: binary()
-                 ) -> ok | {error, not_exists | not_allowed | bad_request}.
-remove_user(_, _, _) -> {error, not_allowed}.
 
 check_password(_, _, _) -> false.
 

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -42,7 +42,6 @@
          get_password_s/2,
          does_user_exist/2,
          remove_user/2,
-         remove_user/3,
          supports_sasl_module/2
         ]).
 
@@ -355,29 +354,6 @@ remove_user(LUser, LServer) ->
         ok
     end,
     ok.
-
-
-%% @doc Remove user if the provided password is correct.
--spec remove_user(LUser :: jid:luser(),
-                  LServer :: jid:lserver(),
-                  Password :: binary()
-                 ) -> ok | {error, not_exists | not_allowed}.
-remove_user(LUser, LServer, Password) ->
-    Username = mongoose_rdbms:escape_string(LUser),
-    case check_password_wo_escape(LUser, Username, LServer, Password) of
-        true ->
-            case catch rdbms_queries:del_user(LServer, Username) of
-                {'EXIT', Error} ->
-                    ?WARNING_MSG("Failed SQL query: ~p", [Error]),
-                    {error, not_allowed};
-                _ ->
-                    ok
-            end;
-        not_exists ->
-            {error, not_exists};
-        false ->
-            {error, not_allowed}
-    end.
 
 %%%------------------------------------------------------------------
 %%% SCRAM

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -35,8 +35,7 @@
          get_password/2,
          get_password_s/2,
          does_user_exist/2,
-         remove_user/2,
-         remove_user/3
+         remove_user/2
         ]).
 
 -export([bucket_type/1]).
@@ -179,9 +178,6 @@ remove_user(LUser, LServer) ->
             ?WARNING_MSG("Failed Riak query: ~p", [Error]),
             {error, not_allowed}
     end.
-
-remove_user(_LUser, _LServer, _Password) ->
-    erlang:error(not_implemented).
 
 -spec bucket_type(jid:lserver()) -> {binary(), jid:lserver()}.
 bucket_type(LServer) ->

--- a/src/auth/ejabberd_gen_auth.erl
+++ b/src/auth/ejabberd_gen_auth.erl
@@ -52,11 +52,6 @@
                       Server :: jid:lserver()
                       ) -> ok | {error, not_allowed}.
 
--callback remove_user(User :: jid:luser(),
-                      Server :: jid:lserver(),
-                      Password :: binary()
-                      ) -> ok | {error, not_exists | not_allowed | bad_request}.
-
 -export_type([t/0]).
 
 -type t() :: module().

--- a/src/auth/extauth.erl
+++ b/src/auth/extauth.erl
@@ -33,7 +33,6 @@
          set_password/3,
          try_register/3,
          remove_user/2,
-         remove_user/3,
          is_user_exists/2]).
 
 -include("mongoose.hrl").
@@ -113,12 +112,6 @@ try_register(User, Server, Password) ->
 -spec remove_user(jid:user(), jid:server()) -> any().
 remove_user(User, Server) ->
     call_port(Server, [<<"removeuser">>, User, Server]).
-
-
--spec remove_user(jid:user(), jid:server(), binary()) -> any().
-remove_user(User, Server, Password) ->
-    call_port(Server, [<<"removeuser3">>, User, Server, Password]).
-
 
 -spec call_port(jid:server(), [any(), ...]) -> any().
 call_port(Server, Msg) ->

--- a/test/auth_external_SUITE.erl
+++ b/test/auth_external_SUITE.erl
@@ -15,7 +15,6 @@ groups() ->
 all_tests() ->
     [try_register_ok,
      remove_user_ok,
-     remove_user_with_pass_ok,
      set_password_ok,
      does_user_exist,
      get_password_returns_false_if_no_cache,
@@ -47,11 +46,6 @@ try_register_ok(_C) ->
 remove_user_ok(_C) ->
     {U, P} = given_user_registered(),
     ok = ?AUTH_MOD:remove_user(U, domain()),
-    false = ?AUTH_MOD:check_password(U, domain(), P).
-
-remove_user_with_pass_ok(_C) ->
-    {U, P} = given_user_registered(),
-    ok = ?AUTH_MOD:remove_user(U, domain(), P),
     false = ?AUTH_MOD:check_password(U, domain(), P).
 
 set_password_ok(_C) ->

--- a/test/auth_external_SUITE_data/sample_external_auth.py
+++ b/test/auth_external_SUITE_data/sample_external_auth.py
@@ -51,12 +51,6 @@ def removeuser(username, server):
     serialize()
     return True
 
-def removeuser3(username, server, password):
-    if auth(username, server, password):
-        return removeuser(username, server)
-    else:
-        return False
-
 def serialize():
     f = open(outfile, 'a')
     pickle.dump(users, f)

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -203,15 +203,7 @@ is_user_exists(_Config) ->
 remove_user(_Config) ->
     true = ejabberd_auth_http:does_user_exist(<<"toremove1">>, ?DOMAIN1),
     ok = ejabberd_auth_http:remove_user(<<"toremove1">>, ?DOMAIN1),
-    false = ejabberd_auth_http:does_user_exist(<<"toremove1">>, ?DOMAIN1),
-
-    true = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
-    {error, not_allowed} = ejabberd_auth_http:remove_user(<<"toremove2">>, ?DOMAIN1, <<"wrongpass">>),
-    true = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
-    ok = ejabberd_auth_http:remove_user(<<"toremove2">>, ?DOMAIN1, <<"pass">>),
-    false = ejabberd_auth_http:does_user_exist(<<"toremove2">>, ?DOMAIN1),
-
-    {error, not_exists} = ejabberd_auth_http:remove_user(<<"toremove3">>, ?DOMAIN1, <<"wrongpass">>).
+    false = ejabberd_auth_http:does_user_exist(<<"toremove1">>, ?DOMAIN1).
 
 supported_sasl_mechanisms(Config) ->
     Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_external],

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -127,9 +127,7 @@ is_user_exists(_Config) ->
 
 % remove_user/2,3
 remove_user(_Config) ->
-    ok = ejabberd_auth_jwt:remove_user(<<"toremove3">>, ?DOMAIN1),
-    {error, not_allowed} = ejabberd_auth_jwt:remove_user(<<"toremove3">>,
-                                                         ?DOMAIN1, <<"wrongpass">>).
+    ok = ejabberd_auth_jwt:remove_user(<<"toremove3">>, ?DOMAIN1).
 
 get_vh_registered_users_number(_C) ->
     0 = ejabberd_auth_jwt:get_vh_registered_users_number(?DOMAIN1, []).


### PR DESCRIPTION
Currently there is no way to call this function other than from MongooseIM console.
In the past (long time ago) this function was used to verify if a user is allowed to remove itself by providing the password.
Nowadays there is no admin interface for that nor XMPP protocol / XEP.