### PR TITLE
allow to select sha algorithm from config file

### DIFF
--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -140,12 +140,12 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
     * **Examples:** `rdbms`, `[internal, anonymous]`
 
 * **auth_opts** (local)
-    * **Description:** Provides different parameters that will be applied to a choosen authentication method.
+    * **Description:** Provides different parameters that will be applied to a chosen authentication method.
                        `auth_password_format` and `auth_scram_iterations` are common to `http`, `rdbms`, `internal` and `riak`.
 
         * **auth_password_format**
-             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently the popular XMPP clients support the SCRAM method, so it is strongly recommended to use the hashed version. The older ones can still use `PLAIN` mechiansm. `DIGEST-MD5` is not available with `scram`.
-             * **Values:** `plain`, `scram`
+             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently, the popular XMPP clients support the SCRAM method. It is strongly recommended to use the hashed version. SCRAM hashing with use of the SHA-1 and SHA-256 is supported. Hashing algorithms can be provided as an argument. This will result in storing and supporting only hashes specified in the configuration. The older XMPP clients can still use `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
+             * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha256]}` are equivalent configurations)
              * **Default:** `plain` (for compatibility reasons, might change soon)
 
         * **auth_scram_iterations**
@@ -223,7 +223,7 @@ There are some additional options that influence all database connections in the
 
 ### Traffic shapers
 
-* **shaper** (mutli, global)
+* **shaper** (multi, global)
     * **Description:** Define a class of a shaper which is a mechanism for limiting traffic to prevent DoS attack or calming down too noisy clients.
     * **Syntax:** `{shaper, AtomName, {maxrate, BytesPerSecond}}`
 

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -144,7 +144,7 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
                        `auth_password_format` and `auth_scram_iterations` are common to `http`, `rdbms`, `internal` and `riak`.
 
         * **auth_password_format**
-             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently, the popular XMPP clients support the SCRAM method. It is strongly recommended to use the hashed version. SCRAM hashing with use of the SHA-1 and SHA-256 is supported. Hashing algorithms can be provided as an argument. This will result in storing and supporting only hashes specified in the configuration. The older XMPP clients can still use `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
+             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently, popular XMPP clients support the SCRAM method and it is strongly recommended to use the hashed version. MongooseIM supports SCRAM hashing, either SHA-1 or SHA-256 can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration. The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
              * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha256]}` are equivalent configurations)
              * **Default:** `plain` (for compatibility reasons, might change soon)
 

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -12,7 +12,7 @@ Developers can use this information to create advanced endpoints for `ejabberd_a
 * `<stored key>` - Base64-encoded Stored Key
 * `<server key>` - Base64-encoded Server Key
 
-The SCRAM format can vary depending on the SHA algorithms that are used for SCRAM. Salt and iteration count is common for different SHA types. Stored Key and Server Key are specific to a given SHA and are following SHA prefix that is indicating which SHA they belong to.
+The SCRAM format can vary depending on the SHA algorithms that are used for SCRAM. Salt and iteration count is common for different SHA types. Stored Key and Server Key are specific to a given SHA and are following a SHA prefix that is indicating which SHA they belong to.
 
 In order to learn more about the meaning of the Stored Key, Server Key, Salt and Iteration Count, please check [the SCRAM specification](https://tools.ietf.org/html/rfc5802).
 
@@ -34,7 +34,7 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 
 ## Legacy format description
 
-MongooseIM installations prior to 3.6.3 were supporting only SHA-1 as hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
+MongooseIM installations prior to 3.6.3 were supporting only SHA-1 as a hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
 
 `==SCRAM==,<stored key>,<server key>,<salt>,<iteration count>`
 

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -5,6 +5,37 @@ Developers can use this information to create advanced endpoints for `ejabberd_a
 
 ## Format description
 
+`==MULTI_SCRAM==,<salt>,<iteration count>,===SHA1===<stored key>|<server key>,==SHA256==<stored key>|<server key>`
+
+* `<salt>` - Base64-encoded Salt
+* `<iteration count>` - Iteration Count formatted as a human-readable integer
+* `<stored key>` - Base64-encoded Stored Key
+* `<server key>` - Base64-encoded Server Key
+
+The SCRAM format can vary depending on the SHA algorithms that are used for SCRAM. Salt and iteration count is common for different SHA types. Stored Key and Server Key are specific to a given SHA and are following SHA prefix that is indicating which SHA they belong to.
+
+In order to learn more about the meaning of the Stored Key, Server Key, Salt and Iteration Count, please check [the SCRAM specification](https://tools.ietf.org/html/rfc5802).
+
+### Example
+
+* *Password:* `padthai`
+* *Erlang map:*
+```
+#{iteration_count => 4096,
+   salt => <<"glF/hUXiCWD6TaJLpgVaaw==">>,
+   sha =>
+      #{server_key => <<"ztvci4eBktO3NLviLhwN3ktF15Q=">>,
+        stored_key => <<"Hxfegcj54A6p/ZzWkw7BjJsLZpM=">>},
+   sha256 =>
+      #{server_key => <<"0Tm46vWQyO/XWpAtcDCUH++7ImWVDe0VDx274zMzMXQ=">>,
+        stored_key => <<"S4XiSkYI81m688nMuCgFGUBIGbW6oG1a9rlTKktzS/A=">>}}
+```
+* *Serialized password:* `==MULTI_SCRAM==,glF/hUXiCWD6TaJLpgVaaw==,4096,===SHA1===Hxfegcj54A6p/ZzWkw7BjJsLZpM=|ztvci4eBktO3NLviLhwN3ktF15Q=,==SHA256==S4XiSkYI81m688nMuCgFGUBIGbW6oG1a9rlTKktzS/A=|0Tm46vWQyO/XWpAtcDCUH++7ImWVDe0VDx274zMzMXQ=`
+
+## Legacy format description
+
+MongooseIM installations prior to 3.6.3 were supporting only SHA-1 as hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
+
 `==SCRAM==,<stored key>,<server key>,<salt>,<iteration count>`
 
 * `<stored key>` - Base64-encoded Stored Key
@@ -19,4 +50,3 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 * *Password:* `misio`
 * *Erlang record:* `#scram{ storedkey = <<"tmi5IE+9pceRV/jkPLFHEaVY33c=">>, serverkey = <<"MiWNa8T3dniVDwmh77ufJ41fpAQ=">>, salt = <<"inKXODlSY5y5SCsLxibi0w==">>, iterationcount = 4096 }`
 * *Serialized password:* `==SCRAM==,tmi5IE+9pceRV/jkPLFHEaVY33c=,MiWNa8T3dniVDwmh77ufJ41fpAQ=,inKXODlSY5y5SCsLxibi0w==,4096`
-

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -94,8 +94,8 @@ check_password(LUser, LServer, Password, Digest, DigestGen) ->
 -spec set_password(jid:luser(), jid:lserver(), binary()) -> ok | {error, not_allowed}.
 set_password(LUser, LServer, Password) ->
     PasswordFinal = case mongoose_scram:enabled(LServer) of
-                        true -> mongoose_scram:serialize(mongoose_scram:password_to_scram(
-                                                  Password, mongoose_scram:iterations(LServer), LServer));
+                        true -> mongoose_scram:serialize(mongoose_scram:password_to_scram(LServer,
+                                                  Password, mongoose_scram:iterations(LServer)));
                         false -> Password
                     end,
     case make_req(post, <<"set_password">>, LUser, LServer, PasswordFinal) of
@@ -108,8 +108,8 @@ set_password(LUser, LServer, Password) ->
     ok | {error, exists | not_allowed}.
 try_register(LUser, LServer, Password) ->
     PasswordFinal = case mongoose_scram:enabled(LServer) of
-                        true -> mongoose_scram:serialize(mongoose_scram:password_to_scram(
-                                                  Password, mongoose_scram:iterations(LServer), LServer));
+                        true -> mongoose_scram:serialize(LServer, mongoose_scram:password_to_scram(
+                                                  Password, mongoose_scram:iterations(LServer)));
                         false -> Password
                     end,
     case make_req(post, <<"register">>, LUser, LServer, PasswordFinal) of

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -108,7 +108,7 @@ set_password(LUser, LServer, Password) ->
     ok | {error, exists | not_allowed}.
 try_register(LUser, LServer, Password) ->
     PasswordFinal = case mongoose_scram:enabled(LServer) of
-                        true -> mongoose_scram:serialize(LServer, mongoose_scram:password_to_scram(
+                        true -> mongoose_scram:serialize(mongoose_scram:password_to_scram(LServer,
                                                   Password, mongoose_scram:iterations(LServer)));
                         false -> Password
                     end,

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -95,7 +95,7 @@ check_password(LUser, LServer, Password, Digest, DigestGen) ->
 set_password(LUser, LServer, Password) ->
     PasswordFinal = case mongoose_scram:enabled(LServer) of
                         true -> mongoose_scram:serialize(mongoose_scram:password_to_scram(
-                                                  Password, mongoose_scram:iterations(LServer)));
+                                                  Password, mongoose_scram:iterations(LServer), LServer));
                         false -> Password
                     end,
     case make_req(post, <<"set_password">>, LUser, LServer, PasswordFinal) of
@@ -109,7 +109,7 @@ set_password(LUser, LServer, Password) ->
 try_register(LUser, LServer, Password) ->
     PasswordFinal = case mongoose_scram:enabled(LServer) of
                         true -> mongoose_scram:serialize(mongoose_scram:password_to_scram(
-                                                  Password, mongoose_scram:iterations(LServer)));
+                                                  Password, mongoose_scram:iterations(LServer), LServer));
                         false -> Password
                     end,
     case make_req(post, <<"register">>, LUser, LServer, PasswordFinal) of

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -153,7 +153,7 @@ set_password(LUser, LServer, Password) ->
     F = fun() ->
         Password2 = case mongoose_scram:enabled(LServer) of
                         true ->
-                            mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(LServer));
+                            mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(LServer), LServer);
                         false -> Password
                     end,
         write_passwd(#passwd{us = US, password = Password2})
@@ -326,7 +326,7 @@ scram_passwords() ->
 
 -spec scramming_function(passwd()) -> passwd().
 scramming_function(#passwd{us = {_, Server}, password = Password} = P) ->
-    Scram = mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(Server)),
+    Scram = mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(Server), Server),
     P#passwd{password = Scram}.
 
 -spec dirty_read_passwd(US :: jid:simple_bare_jid()) -> [passwd()].
@@ -349,7 +349,7 @@ write_counter(#reg_users_counter{} = Counter) ->
 get_scram(LServer, Password) ->
     case mongoose_scram:enabled(LServer) and is_binary(Password) of
         true ->
-            mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(LServer));
+            mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(LServer), LServer);
         false -> Password
     end.
 

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -153,7 +153,7 @@ set_password(LUser, LServer, Password) ->
     F = fun() ->
         Password2 = case mongoose_scram:enabled(LServer) of
                         true ->
-                            mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(LServer), LServer);
+                            mongoose_scram:password_to_scram(LServer, Password, mongoose_scram:iterations(LServer));
                         false -> Password
                     end,
         write_passwd(#passwd{us = US, password = Password2})
@@ -326,7 +326,7 @@ scram_passwords() ->
 
 -spec scramming_function(passwd()) -> passwd().
 scramming_function(#passwd{us = {_, Server}, password = Password} = P) ->
-    Scram = mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(Server), Server),
+    Scram = mongoose_scram:password_to_scram(Server, Password, mongoose_scram:iterations(Server)),
     P#passwd{password = Scram}.
 
 -spec dirty_read_passwd(US :: jid:simple_bare_jid()) -> [passwd()].
@@ -349,7 +349,7 @@ write_counter(#reg_users_counter{} = Counter) ->
 get_scram(LServer, Password) ->
     case mongoose_scram:enabled(LServer) and is_binary(Password) of
         true ->
-            mongoose_scram:password_to_scram(Password, mongoose_scram:iterations(LServer), LServer);
+            mongoose_scram:password_to_scram(LServer, Password, mongoose_scram:iterations(LServer));
         false -> Password
     end.
 

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -224,15 +224,15 @@ do_set_password({ok, Map}, LUser, LServer, Password) ->
     UpdateMap = mongoose_riak:update_map(Map, Ops),
     mongoose_riak:update_type(bucket_type(LServer), LUser, riakc_map:to_op(UpdateMap)).
 
-prepare_password(Iterations, Password, Server) when is_integer(Iterations) ->
-    Scram = mongoose_scram:password_to_scram(Password, Iterations, Server),
+prepare_password(Server, Iterations, Password) when is_integer(Iterations) ->
+    Scram = mongoose_scram:password_to_scram(Server, Password, Iterations),
     PassDetails = mongoose_scram:serialize(Scram),
     {<<"">>, PassDetails}.
 
 prepare_password(Server, Password) ->
     case mongoose_scram:enabled(Server) of
         true ->
-            prepare_password(mongoose_scram:iterations(Server), Password, Server);
+            prepare_password(Server, mongoose_scram:iterations(Server), Password);
         _ ->
             Password
     end.

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -224,15 +224,15 @@ do_set_password({ok, Map}, LUser, LServer, Password) ->
     UpdateMap = mongoose_riak:update_map(Map, Ops),
     mongoose_riak:update_type(bucket_type(LServer), LUser, riakc_map:to_op(UpdateMap)).
 
-prepare_password(Iterations, Password) when is_integer(Iterations) ->
-    Scram = mongoose_scram:password_to_scram(Password, Iterations),
+prepare_password(Iterations, Password, Server) when is_integer(Iterations) ->
+    Scram = mongoose_scram:password_to_scram(Password, Iterations, Server),
     PassDetails = mongoose_scram:serialize(Scram),
-    {<<"">>, PassDetails};
+    {<<"">>, PassDetails}.
 
 prepare_password(Server, Password) ->
     case mongoose_scram:enabled(Server) of
         true ->
-            prepare_password(mongoose_scram:iterations(Server), Password);
+            prepare_password(mongoose_scram:iterations(Server), Password, Server);
         _ ->
             Password
     end.

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -243,14 +243,9 @@ supported_sha_types() ->
      {sha256,   <<?SCRAM_SHA256_PREFIX>>}].
 
 configured_sha_types(Host) ->
-    PasswordFormat = ejabberd_auth:get_opt(Host, password_format),
-    ScramSha = proplists:get_value(scram, [PasswordFormat]),
-    case ejabberd_auth:get_opt(Host, password_format) of
-        scram ->
-            supported_sha_types();
-        {scram, []} ->
-            supported_sha_types();
-        {scram, ScramSha} ->
+    case catch ejabberd_auth:get_opt(Host, password_format) of
+        {scram, ScramSha} when length(ScramSha) > 0 ->
             lists:filter(fun({Sha, _Prefix}) ->
-                            lists:member(Sha, ScramSha) end, supported_sha_types())
+                            lists:member(Sha, ScramSha) end, supported_sha_types());
+        _ -> supported_sha_types()
     end.

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -139,7 +139,8 @@ check_password(Password, Scram) when is_record(Scram, scram)->
     check_password(Password, ScramMap);
 check_password(Password, ScramMap) when is_map(ScramMap) ->
     #{salt := Salt, iteration_count := IterationCount} = ScramMap,
-    [Sha | _] = [ShaKey || {ShaKey, _Prefix} <- supported_sha_types(),  maps:is_key(ShaKey, ScramMap)],
+    [Sha | _] = [ShaKey || {ShaKey, _Prefix} <- supported_sha_types(),
+                                                maps:is_key(ShaKey, ScramMap)],
     #{Sha := #{stored_key := StoredKey}} = ScramMap,
     SaltedPassword = salted_password(Sha, Password, base64:decode(Salt), IterationCount),
     ClientStoredKey = stored_key(Sha, client_key(Sha, SaltedPassword)),
@@ -151,26 +152,20 @@ serialize(#scram{storedkey = StoredKey, serverkey = ServerKey,
     << <<?SCRAM_SERIAL_PREFIX>>/binary,
        StoredKey/binary, $,, ServerKey/binary,
        $,, Salt/binary, $,, IterationCountBin/binary>>;
-serialize(#{salt   := Salt, iteration_count := IterationCount,
-            sha    := #{server_key := ShaServerKey, stored_key := ShaStoredKey},
-            sha256 := #{server_key := Sha256ServerKey, stored_key :=  Sha256StoredKey}}) ->
+serialize(#{salt   := Salt, iteration_count := IterationCount} = ScramMap) ->
     IterationCountBin = integer_to_binary(IterationCount),
-    << <<?MULTI_SCRAM_SERIAL_PREFIX>>/binary,
-    Salt/binary, $,, IterationCountBin/binary, $,,
-    <<?SCRAM_SHA_PREFIX>>/binary, ShaStoredKey/binary, $|, ShaServerKey/binary, $,,
-    <<?SCRAM_SHA256_PREFIX>>/binary, Sha256StoredKey/binary, $|, Sha256ServerKey/binary >>;
-serialize(#{salt   := Salt, iteration_count := IterationCount,
-            sha    := #{server_key := ServerKey, stored_key := StoredKey}}) ->
-    IterationCountBin = integer_to_binary(IterationCount),
-    << <<?MULTI_SCRAM_SERIAL_PREFIX>>/binary,
-    Salt/binary, $,, IterationCountBin/binary, $,,
-    <<?SCRAM_SHA_PREFIX>>/binary, StoredKey/binary, $|, ServerKey/binary >>;
-serialize(#{salt   := Salt, iteration_count := IterationCount,
-            sha256 := #{server_key := ServerKey, stored_key := StoredKey}}) ->
-    IterationCountBin = integer_to_binary(IterationCount),
-    << <<?MULTI_SCRAM_SERIAL_PREFIX>>/binary,
-    Salt/binary, $,, IterationCountBin/binary, $,,
-    <<?SCRAM_SHA256_PREFIX>>/binary, StoredKey/binary, $|, ServerKey/binary >>.
+    ConfigedSha = [{ShaKey, Prefix} || {ShaKey, Prefix} <- supported_sha_types(),
+                                                           maps:is_key(ShaKey, ScramMap)],
+    Header = [?MULTI_SCRAM_SERIAL_PREFIX, Salt, $, , IterationCountBin],
+    do_serialize(Header, ScramMap, ConfigedSha).
+
+do_serialize(Serialized, _ ,[]) ->
+    erlang:iolist_to_binary(Serialized);
+do_serialize(Header, ScramMap, [{Sha, Prefix} | RemainingSha]) ->
+    #{Sha := #{server_key := ServerKey, stored_key := StoredKey}} = ScramMap,
+    ShaSerialization = [$, , Prefix, StoredKey, $|, ServerKey],
+    NewHeader = [Header | ShaSerialization],
+    do_serialize(NewHeader, ScramMap, RemainingSha).
 
 deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
     case catch binary:split(Serialized, <<",">>, [global]) of

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -258,7 +258,7 @@ meck_cleanup() ->
 do_scram(Pass, Config) ->
     case lists:keyfind(scram_group, 1, Config) of
         {_, true} ->
-            mongoose_scram:serialize(mongoose_scram:password_to_scram(Pass, mongoose_scram:iterations(?DOMAIN1)));
+            mongoose_scram:serialize(mongoose_scram:password_to_scram(Pass, mongoose_scram:iterations(?DOMAIN1), ?DOMAIN1));
         _ ->
             Pass
     end.

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -258,7 +258,7 @@ meck_cleanup() ->
 do_scram(Pass, Config) ->
     case lists:keyfind(scram_group, 1, Config) of
         {_, true} ->
-            mongoose_scram:serialize(mongoose_scram:password_to_scram(Pass, mongoose_scram:iterations(?DOMAIN1), ?DOMAIN1));
+            mongoose_scram:serialize(mongoose_scram:password_to_scram(?DOMAIN1, Pass, mongoose_scram:iterations(?DOMAIN1)));
         _ ->
             Pass
     end.


### PR DESCRIPTION
This PR extends functionality of multi sha support. This PR allows to specify which sha algorithms can be used for storing passwords in scram format. 

The change of the config file allows now to specify scram password format in two different ways:
* {password_format, scram} - how the password format was specified so far
* {password_format, {scram, [sha, sha256]}} - new format allowing to select sha algorithms within the list. This format will allow to store the scram of the passwords using only those algorithms that are specified in the list.

