### PR TITLE
Transport consistency

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -381,8 +381,8 @@ determine_features(SockMod, #state{tls = TLS, tls_enabled = TLSEnabled,
     case can_use_tls(SockMod, TLS, TLSEnabled) of
         true ->
             case TLSRequired of
-                true -> [starttls(required)];
-                _    -> [starttls(optional)] ++ OtherFeatures
+                true -> [starttls_stanza(required)];
+                _    -> [starttls_stanza(optional)] ++ OtherFeatures
             end;
         false ->
             OtherFeatures
@@ -406,7 +406,7 @@ maybe_sasl_mechanisms(#state{server = Server} = S) ->
 hook_enabled_features(Server) ->
     mongoose_hooks:c2s_stream_features(Server, []).
 
-starttls(TLSRequired)
+starttls_stanza(TLSRequired)
   when TLSRequired =:= required;
        TLSRequired =:= optional ->
     #xmlel{name = <<"starttls">>,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -506,10 +506,9 @@ wait_for_feature_before_auth({xmlstreamelement, El}, StateData) ->
                                lists:keydelete(
                                  certfile, 1, StateData#state.tls_options)]
                       end,
-            Socket = StateData#state.socket,
-            TLSSocket = (StateData#state.sockmod):starttls(
-                                                    Socket, TLSOpts,
-                                                    exml:to_binary(tls_proceed())),
+            TLSSocket = mongoose_transport:starttls(StateData#state.sockmod,
+                                                    StateData#state.socket,
+                                                    TLSOpts, exml:to_binary(tls_proceed())),
             fsm_next_state(wait_for_stream,
                            StateData#state{socket = TLSSocket,
                                            streamid = new_id(),

--- a/src/mongoose_transport.erl
+++ b/src/mongoose_transport.erl
@@ -29,6 +29,8 @@
 
 -callback starttls(Transport :: t(), TLSOpts :: list()) -> t().
 
+-callback starttls(Transport :: t(), TLSOpts :: list(), Data :: binary()) -> t().
+
 -callback monitor(Transport :: t()) -> MonitorRef :: reference().
 
 -callback send_xml(Transport :: t(), Data :: send_xml_input()) -> ok.
@@ -39,11 +41,14 @@
 %% API
 %%----------------------------------------------------------------------
 
--export([starttls/3, monitor/2, send_xml/3, peername/2,
+-export([starttls/3, starttls/4, monitor/2, send_xml/3, peername/2,
          get_peer_certificate/2]).
 
 -spec starttls(TransportMod :: module(), Transport :: t(), TLSOpts :: list()) -> t().
 starttls(TransportMod, Transport, TLSOpts) -> TransportMod:starttls(Transport, TLSOpts).
+
+-spec starttls(TransportMod :: module(), Transport :: t(), TLSOpts :: list(), binary()) -> t().
+starttls(TransportMod, Transport, TLSOpts, Data) -> TransportMod:starttls(Transport, TLSOpts, Data).
 
 -spec monitor(TransportMod :: module(), Transport :: t()) -> reference().
 monitor(TransportMod, Transport) -> TransportMod:monitor(Transport).


### PR DESCRIPTION
`ejabberd_c2s` is calling `starttls` in two different ways: in one, it
calls it through the `mongoose_transport` behaviour, which in turns calls
`starttls` on the module that was given to the first as a parameter, and
on the second it calls it directly over such module, which seems like an
inconsistent way to call such function.

All the modules we have that implement mongoose_transport actually
implement two `starttls` callbacks, and even in some, like in
`mod_websockets`, we mention in the comments that some callbacks are just
to make them compatible with `ejabberd_sockets`, but the `starttls/3`
callback is not required in the behaviour definition. So that's a first
code cleaning.