### PR TITLE
Extend SCRAM auth - SHA-224, SHA-384, SHA-512

### DIFF
--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -53,7 +53,12 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 scram_tests() ->
-    [log_one, log_one_scram, log_one_scram_256].
+    [log_one,
+     log_one_scram_sha1,
+     log_one_scram_sha224,
+     log_one_scram_sha256,
+     log_one_scram_sha384,
+     log_one_scram_sha512].
 
 configure_sha256_test() ->
     [configure_sha256_log_with_sha256].
@@ -86,7 +91,7 @@ init_per_group(GroupName, Config) when
       GroupName == login_scram;
       GroupName == configure_sha256;
       GroupName == login_scram_store_plain ->
-    case mongoose_helper:supports_sasl_module(cyrsasl_scram) of
+    case mongoose_helper:supports_sasl_module(cyrsasl_scram_sha1) of
         false ->
             {skip, "scram password type not supported"};
         true ->
@@ -157,8 +162,17 @@ log_one_digest(Config) ->
 log_one_scram(Config) ->
     log_one([{escalus_auth_method, <<"SCRAM-SHA-1">>} | Config]).
 
+log_one_scram_224(Config) ->
+    log_one([{escalus_auth_method, <<"SCRAM-SHA-224">>} | Config]).
+
 log_one_scram_256(Config) ->
     log_one([{escalus_auth_method, <<"SCRAM-SHA-256">>} | Config]).
+
+ log_one_scram_384(Config) ->
+    log_one([{escalus_auth_method, <<"SCRAM-SHA-384">>} | Config]).
+
+log_one_scram_512(Config) ->
+    log_one([{escalus_auth_method, <<"SCRAM-SHA-512">>} | Config]).
 
 configure_sha256_log_with_sha256(Config) ->
     log_one([{escalus_auth_method, <<"SCRAM-SHA-256">>} | Config]).

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -144,8 +144,8 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
                        `auth_password_format` and `auth_scram_iterations` are common to `http`, `rdbms`, `internal` and `riak`.
 
         * **auth_password_format**
-             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently, popular XMPP clients support the SCRAM method and it is strongly recommended to use the hashed version. MongooseIM supports SCRAM hashing, either SHA-1 or SHA-256 can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration. The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
-             * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha256]}` are equivalent configurations)
+             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently, popular XMPP clients support the SCRAM method and it is strongly recommended to use the hashed version. MongooseIM supports SHA-1, SHA-224, SHA-256 and SHA-512 for SCRAM hashing which can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration. The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
+             * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha224, sha256, sha384, sha512]}` are equivalent configurations)
              * **Default:** `plain` (for compatibility reasons, might change soon)
 
         * **auth_scram_iterations**
@@ -163,9 +163,9 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
         * [`riak` backend options](authentication-backends/Riak-authentication-module.md#configuration-options)
 
 * **sasl_mechanisms** (local)
-    * **Description:** Specifies a list of allowed SASL mechanisms. It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code).
+    * **Description:** Specifies a list of allowed SASL mechanisms. It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code). Please note that the list of advertised authentication mechanisms is filtered out by the supported password formats to assure that it is possible to authenticate using authentication mechanisms that are offered.
     * **Warning:** This list is still filtered by [auth backends capabilities](#authentication-backend-capabilities)
-    * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_scram_sha256, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
+    * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sh384, cyrsasl_scram_sha512, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
     * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_scram_sha256, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
     * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram]`
 
@@ -178,17 +178,17 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
 
 The table below shows the supported SASL mechanisms for each authentication backend module.
 
-|           | cyrsasl<br>plain | cyrsasl<br>digest | cyrsasl<br>scram | cyrsasl<br>scram_sha256 | cyrsasl<br>anonymous | cyrsasl<br>external |
-|-----------|:----------------:|:-----------------:|:----------------:|:-----------------------:|:--------------------:|:-------------------:|
-| internal  |         x        |         x         |         x        |           x             |                   |                     |
-| rdbms     |         x        |         x         |         x        |           x             |                      |                     |
-| external  |         x        |                   |                  |                         |                      |                     |
-| anonymous |         x        |         x         |         x        |           x             |           x          |                     |
-| ldap      |         x        |                   |                  |                         |                      |          x          |
-| jwt       |         x        |                   |                  |                         |                      |                     |
-| riak      |         x        |         x         |         x        |           x             |                      |                     |
-| http      |         x        |         x         |         x        |           x             |                      |                     |
-| pki       |                  |                   |                  |                         |                      |          x          |
+|           | cyrsasl<br>plain | cyrsasl<br>digest | cyrsasl<br>scram_sha* | cyrsasl<br>anonymous | cyrsasl<br>external |
+|-----------|:----------------:|:-----------------:|:---------------------:|:--------------------:|:-------------------:|
+| internal  |         x        |         x         |           x           |                      |                     |
+| rdbms     |         x        |         x         |           x           |                      |                     |
+| external  |         x        |                   |                       |                      |                     |
+| anonymous |         x        |         x         |           x           |           x          |                     |
+| ldap      |         x        |                   |                       |                      |          x          |
+| jwt       |         x        |                   |                       |                      |                     |
+| riak      |         x        |         x         |           x           |                      |                     |
+| http      |         x        |         x         |           x           |                      |                     |
+| pki       |                  |                   |                       |                      |          x          |
 
 `cyrsasl_oauth` does not use the auth backends at all and requires the `mod_auth_token` module enabled instead.
 

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -144,7 +144,10 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
                        `auth_password_format` and `auth_scram_iterations` are common to `http`, `rdbms`, `internal` and `riak`.
 
         * **auth_password_format**
-             * **Description:** Decide whether user passwords will be kept plain or hashed in the database. Currently, popular XMPP clients support the SCRAM method and it is strongly recommended to use the hashed version. MongooseIM supports SHA-1, SHA-224, SHA-256 and SHA-512 for SCRAM hashing which can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration. The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
+             * **Description:** Decide whether user passwords will be kept plain or hashed in the database.
+             Currently, popular XMPP clients support the SCRAM method and it is strongly recommended to use the hashed version.
+             MongooseIM supports SHA-1, SHA-224, SHA-256 and SHA-512 for SCRAM hashing which can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration.
+             The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
              * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha224, sha256, sha384, sha512]}` are equivalent configurations)
              * **Default:** `plain` (for compatibility reasons, might change soon)
 
@@ -163,7 +166,9 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
         * [`riak` backend options](authentication-backends/Riak-authentication-module.md#configuration-options)
 
 * **sasl_mechanisms** (local)
-    * **Description:** Specifies a list of allowed SASL mechanisms. It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code). Please note that the list of advertised authentication mechanisms is filtered out by the supported password formats to assure that it is possible to authenticate using authentication mechanisms that are offered.
+    * **Description:** Specifies a list of allowed SASL mechanisms.
+    It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code).
+    Please note that the list of advertised authentication mechanisms is filtered out by the supported password formats to assure that it is possible to authenticate using authentication mechanisms that are offered.
     * **Warning:** This list is still filtered by [auth backends capabilities](#authentication-backend-capabilities)
     * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sh384, cyrsasl_scram_sha512, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
     * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384,cyrsasl_scram_sha512, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -166,8 +166,8 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
     * **Description:** Specifies a list of allowed SASL mechanisms. It affects the methods announced during stream negotiation and is enforced eventually (user can't pick mechanism not listed here but available in the source code). Please note that the list of advertised authentication mechanisms is filtered out by the supported password formats to assure that it is possible to authenticate using authentication mechanisms that are offered.
     * **Warning:** This list is still filtered by [auth backends capabilities](#authentication-backend-capabilities)
     * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sh384, cyrsasl_scram_sha512, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
-    * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_scram_sha256, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
-    * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram]`
+    * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384,cyrsasl_scram_sha512, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
+    * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram_sha256]`
 
 * **extauth_instances** (local)
     * **Description:** Specifies a number of workers serving external authentication requests.

--- a/doc/authentication-methods/client-certificate.md
+++ b/doc/authentication-methods/client-certificate.md
@@ -44,7 +44,7 @@ the list of `auth_opts` in MongooseIM config file:
 provided and use the user identity from the authentication request.
 
 
-If the client certificate does not contain a JID, the client must provide one in authorisation entity. 
+If the client certificate does not contain a JID, the client must provide one in authorisation entity.
 
 For the details please refer to [XEP-0178 Best Practices for Use of SASL EXTERNAL with Certificates](https://xmpp.org/extensions/xep-0178.html).
 
@@ -138,7 +138,7 @@ Authentication with a client certificate (validated with provided CA chain) or p
 
 {auth_method, [rdbms, pki]}.
 
-{sasl_mechanisms, [cyrsasl_scram, cyrsasl_external]}.
+{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_external]}.
 ```
 
 ## Client certificate prerequisites
@@ -179,4 +179,3 @@ You don't need to pre-create a user account in order to log in with a certificat
 
 If Gajim fails to connect, try to restart it.
 Version 0.16.8 sometimes "forgets" to ask for the client certificate password.
-

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -5,7 +5,7 @@ Developers can use this information to create advanced endpoints for `ejabberd_a
 
 ## Format description
 
-`==MULTI_SCRAM==,<salt>,<iteration count>,===SHA1===<stored key>|<server key>,==SHA256==<stored key>|<server key>`
+`==MULTI_SCRAM==,<salt>,<iteration count>,===SHA1===<stored key>|<server key>,==SHA224==<stored key>|<server key>,==SHA256==<stored key>|<server key>,==SHA384==<stored key>|<server key>,==SHA512==<stored key>|<server key>`
 
 * `<salt>` - Base64-encoded Salt
 * `<iteration count>` - Iteration Count formatted as a human-readable integer
@@ -22,19 +22,46 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 * *Erlang map:*
 ```
 #{iteration_count => 4096,
-   salt => <<"glF/hUXiCWD6TaJLpgVaaw==">>,
-   sha =>
-      #{server_key => <<"ztvci4eBktO3NLviLhwN3ktF15Q=">>,
-        stored_key => <<"Hxfegcj54A6p/ZzWkw7BjJsLZpM=">>},
-   sha256 =>
-      #{server_key => <<"0Tm46vWQyO/XWpAtcDCUH++7ImWVDe0VDx274zMzMXQ=">>,
-        stored_key => <<"S4XiSkYI81m688nMuCgFGUBIGbW6oG1a9rlTKktzS/A=">>}}
+  salt => <<"aml22qUoKvwJHccCCH00eQ==">>,
+  sha =>
+      #{server_key => <<"gkoblYUZnW8GRBhIyJnbflHlLYs=">>,
+        stored_key => <<"+nm4+0ONdpgnoypippxdzV5sQ80=">>},
+  sha224 =>
+      #{server_key =>
+            <<"JwSXbKqMRJEwOr/iNmqN+x3UzxRikmKym9E71g==">>,
+        stored_key =>
+            <<"nUi8YwRBRMAusH/KpINo3/AO32UWzlSONX9wMA==">>},
+  sha256 =>
+      #{server_key =>
+            <<"y0cB/hZ7AKtVMC2WCkXlo4XTNfOQVg30PLfIhK+Wf/U=">>,
+        stored_key =>
+            <<"tiDUGNpvmt75PGcCvwoTLVOF/og/BiX1FOpihXlYqW8=">>},
+  sha384 =>
+      #{server_key =>
+            <<"LJKetdkPytdOXg6aj4NN25KmJatJsl5zaU78bzjowYrBcjG+wux/I5q7E78sQVSn">>,
+        stored_key =>
+            <<"s7SdIo5a+LH/EsKIMoqa4PPEveScCnDwP1LeaAzVdANT5pPSMio/CoMDN4uXfnHr">>},
+  sha512 =>
+      #{server_key =>
+            <<"TCuJFv5dmpshThJbQnURW0LOz7D55d5hgYndA3jdklQd2omL6PpfgfIgToyVvYlsF9sRGYOg255y+Q+ltwW3tQ==">>,
+        stored_key =>
+            <<"4ATRLxRB+d6YyZXxi3PorT6kyS4Mr6tEuKUVhInJcRU0NDpXh94Y/Yrd+EDOSZUnPno8aAzj78NUXOTyoB98rg==">>}}
 ```
-* *Serialized password:* `==MULTI_SCRAM==,glF/hUXiCWD6TaJLpgVaaw==,4096,===SHA1===Hxfegcj54A6p/ZzWkw7BjJsLZpM=|ztvci4eBktO3NLviLhwN3ktF15Q=,==SHA256==S4XiSkYI81m688nMuCgFGUBIGbW6oG1a9rlTKktzS/A=|0Tm46vWQyO/XWpAtcDCUH++7ImWVDe0VDx274zMzMXQ=`
+* *Serialized password:*
+```
+
+==MULTI_SCRAM==,aml22qUoKvwJHccCCH00eQ==,4096,
+===SHA1===+nm4+0ONdpgnoypippxdzV5sQ80=|gkoblYUZnW8GRBhIyJnbflHlLYs=,
+==SHA224==nUi8YwRBRMAusH/KpINo3/AO32UWzlSONX9wMA==|JwSXbKqMRJEwOr/iNmqN+x3UzxRikmKym9E71g==,
+==SHA256==tiDUGNpvmt75PGcCvwoTLVOF/og/BiX1FOpihXlYqW8=|y0cB/hZ7AKtVMC2WCkXlo4XTNfOQVg30PLfIhK+Wf/U=,
+==SHA384==s7SdIo5a+LH/EsKIMoqa4PPEveScCnDwP1LeaAzVdANT5pPSMio/CoMDN4uXfnHr|LJKetdkPytdOXg6aj4NN25KmJatJsl5zaU78bzjowYrBcjG+wux/I5q7E78sQVSn,
+==SHA512==4ATRLxRB+d6YyZXxi3PorT6kyS4Mr6tEuKUVhInJcRU0NDpXh94Y/Yrd+EDOSZUnPno8aAzj78NUXOTyoB98rg==|TCuJFv5dmpshThJbQnURW0LOz7D55d5hgYndA3jdklQd2omL6PpfgfIgToyVvYlsF9sRGYOg255y+Q+ltwW3tQ==
+
+```
 
 ## Legacy format description
 
-MongooseIM installations prior to 3.6.3 were supporting only SHA-1 as a hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
+MongooseIM installations prior to 3.7 were supporting only SHA-1 as a hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
 
 `==SCRAM==,<stored key>,<server key>,<salt>,<iteration count>`
 

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -61,7 +61,7 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 
 ## Legacy format description
 
-MongooseIM installations prior to 3.7 were supporting only SHA-1 as a hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
+MongooseIM installations older or equal to 3.6.2 were supporting only SHA-1 as a hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
 
 `==SCRAM==,<stored key>,<server key>,<salt>,<iteration count>`
 

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -12,7 +12,9 @@ Developers can use this information to create advanced endpoints for `ejabberd_a
 * `<stored key>` - Base64-encoded Stored Key
 * `<server key>` - Base64-encoded Server Key
 
-The SCRAM format can vary depending on the SHA algorithms that are used for SCRAM. Salt and iteration count is common for different SHA types. Stored Key and Server Key are specific to a given SHA and are following a SHA prefix that is indicating which SHA they belong to.
+The SCRAM format can vary depending on the SHA algorithms that are used for SCRAM.
+Salt and iteration count is common for different SHA types.
+Stored Key and Server Key are specific to a given SHA and are following a SHA prefix that is indicating which SHA they belong to.
 
 In order to learn more about the meaning of the Stored Key, Server Key, Salt and Iteration Count, please check [the SCRAM specification](https://tools.ietf.org/html/rfc5802).
 
@@ -61,7 +63,8 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 
 ## Legacy format description
 
-MongooseIM installations older or equal to 3.6.2 were supporting only SHA-1 as a hashing algorithm for SCRAM. The SCRAM format that was used can be seen below.
+MongooseIM installations older or equal to 3.6.2 were supporting only SHA-1 as a hashing algorithm for SCRAM.
+The SCRAM format that was used can be seen below.
 
 `==SCRAM==,<stored key>,<server key>,<salt>,<iteration count>`
 

--- a/doc/migrations/3.6.0_3.6.x.md
+++ b/doc/migrations/3.6.0_3.6.x.md
@@ -3,7 +3,7 @@
 Since this version, SCRAM authentication mechanisms were extended to support additional hashing algorithms.
 So far only SHA-1 was available for hashing and now SHA-224, SHA-256, SHA-384 and SHA-512 are also supported.
 This includes the authentication mechanisms and the password format that is stored.
-Please note that enabling and using this functionality might require to adjust the server setup.
+Please note that enabling and using this functionality might require adjusting the server setup.
 
 ### SASL mechanisms
 
@@ -14,7 +14,7 @@ Please note that if you were using the following in the configurations file
 
 `{sasl_mechanisms, [cyrsasl_scram]}`
 
-Using `cyrsasl_scram` as `sasl_mechanism` is now incorrect.
+using `cyrsasl_scram` as `sasl_mechanism` is now incorrect.
 You can achieve the same result of allowing the usage of SHA-1 with SCRAM authentication mechanism with:
 
 `{sasl_mechanisms, [cyrsasl_scram_sha1]}`
@@ -23,15 +23,15 @@ You can also specify a list of all supported SCRAM-SHA mechanisms with:
 
 `{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512]}`
 
-Before setting up this configuration, please make sure that the client application is capable to authenticate with selected set of authentication mechanisms.
-For more details please refer to [authentication](../../Advanced-configuration#authentication) section.
+Before setting up this configuration, please make sure that the client application is capable authenticating with a selected set of authentication mechanisms.
+For more details please refer to the [authentication](../../Advanced-configuration#authentication) section.
 
 ### SCRAM password format
 
-To complement the extensions of the authentication mechanisms, SCRAM password format was also updated.
+To complement the extensions of the authentication mechanisms, the SCRAM password format was also updated.
 Legacy plaintext and SCRAM formats are still supported.
-Nonetheless, please note that if you were using SCRAM as a password format, this meant that SHA-1 was used as hashing algorithm.
-This allowed to authenticate with PLAINTEXT and SCRAM-SHA-1.
+Nonetheless, please note that if you were using SCRAM as a password format, this meant that SHA-1 was used as the hashing algorithm.
+This allowed authenticating with PLAINTEXT and SCRAM-SHA-1.
 
 In the new setup the user will still authenticate with those mechanisms given the possible slight syntax change explained [above](#sasl-mechanisms).
 
@@ -41,7 +41,7 @@ However, mixing of the old password format with the new authentication mechanism
 2. His old password format is only storing SHA-1 password hash.
 3. The authentication fails as it is not possible to derive SHA-256 hash from SHA-1.
 
-If you want to use the new password format with full set of supported SHA hashes, a password change is required which will calculate all the new SHA hashes.
+If you want to use the new password format with a full set of supported SHA hashes, a password change is required to calculate all the new SHA hashes.
 Otherwise, please make sure that you provide the right `sasl_mechanism` configuration, where the mechanism you authenticate with is compatible with the password format you store.
 
 For more details related to the new password format, please refer to [authentication](../../Advanced-configuration#authentication) and [SCRAM serialization](../../scram-serialization.md) sections.

--- a/doc/migrations/3.6.0_3.6.x.md
+++ b/doc/migrations/3.6.0_3.6.x.md
@@ -1,0 +1,47 @@
+## Extended SCRAM-SHA Support
+
+Since this version, SCRAM authentication mechanisms were extended to support additional hashing algorithms.
+So far only SHA-1 was available for hashing and now SHA-224, SHA-256, SHA-384 and SHA-512 are also supported.
+This includes the authentication mechanisms and the password format that is stored.
+Please note that enabling and using this functionality might require to adjust the server setup.
+
+### SASL mechanisms
+
+The possible list of allowed SALS mechanisms was changed. We've added new and more secure methods that can be used during stream negotiation.
+
+
+Please note that if you were using the following in the configurations file
+
+`{sasl_mechanisms, [cyrsasl_scram]}`
+
+Using `cyrsasl_scram` as `sasl_mechanism` is now incorrect.
+You can achieve the same result of allowing the usage of SHA-1 with SCRAM authentication mechanism with:
+
+`{sasl_mechanisms, [cyrsasl_scram_sha1]}`
+
+You can also specify a list of all supported SCRAM-SHA mechanisms with:
+
+`{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512]}`
+
+Before setting up this configuration, please make sure that the client application is capable to authenticate with selected set of authentication mechanisms.
+For more details please refer to [authentication](../../Advanced-configuration#authentication) section.
+
+### SCRAM password format
+
+To complement the extensions of the authentication mechanisms, SCRAM password format was also updated.
+Legacy plaintext and SCRAM formats are still supported.
+Nonetheless, please note that if you were using SCRAM as a password format, this meant that SHA-1 was used as hashing algorithm.
+This allowed to authenticate with PLAINTEXT and SCRAM-SHA-1.
+
+In the new setup the user will still authenticate with those mechanisms given the possible slight syntax change explained [above](#sasl-mechanisms).
+
+However, mixing of the old password format with the new authentication mechanisms can lead to conflicting situations where:
+
+1. A user wants to authenticate with e.g. SCRAM-SHA-256.
+2. His old password format is only storing SHA-1 password hash.
+3. The authentication fails as it is not possible to derive SHA-256 hash from SHA-1.
+
+If you want to use the new password format with full set of supported SHA hashes, a password change is required which will calculate all the new SHA hashes.
+Otherwise, please make sure that you provide the right `sasl_mechanism` configuration, where the mechanism you authenticate with is compatible with the password format you store.
+
+For more details related to the new password format, please refer to [authentication](../../Advanced-configuration#authentication) and [SCRAM serialization](../../scram-serialization.md) sections.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ pages:
       - '3.1.1 to 3.2.0': 'migrations/3.1.1_3.2.0.md'
       - '3.3.0 to 3.4.0': 'migrations/3.3.0_3.4.0.md'
       - '3.5.0 to 3.6.0': 'migrations/3.5.0_3.6.0.md'
+      - '3.6.0 to 3.6.x': 'migrations/3.6.0_3.6.x.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - Platform:
       - 'Contributions to ecosystem': 'Contributions.md'

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -67,7 +67,7 @@
 {http_api_client_endpoint, "8089"}.
 {s2s_use_starttls, "{s2s_use_starttls, optional}."}.
 {s2s_certfile, "{s2s_certfile, \"priv/ssl/fake_server.pem\"}."}.
-{sasl_mechanisms, "%%{sasl_mechanisms, [cyrsasl_scram, cyrsasl_plain]}."}.
+{sasl_mechanisms, "%%{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_plain]}."}.
 
 {all_metrics_are_global, "false"}.
 

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -321,21 +321,21 @@ supports_sasl_module(Host, cyrsasl_anonymous) ->
     is_sasl_anonymous_enabled(Host);
 supports_sasl_module(Host, cyrsasl_plain) ->
     is_login_anonymous_enabled(Host);
-supports_sasl_module(Host, cyrsasl_scram_sha1) ->
+supports_sasl_module(Host, cyrsasl_scram_sha1 = ScramSha) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
-supports_sasl_module(Host, cyrsasl_scram_sha224) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha224 = ScramSha) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
-supports_sasl_module(Host, cyrsasl_scram_sha256) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha256 = ScramSha) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
-supports_sasl_module(Host, cyrsasl_scram_sha384) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha384 = ScramSha) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
-supports_sasl_module(Host, cyrsasl_scram_sha512) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha512 = ScramSha) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
 supports_sasl_module(Host, cyrsasl_digest) ->
     is_login_anonymous_enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -319,8 +319,12 @@ remove_user(_LUser, _LServer) ->
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(Host, cyrsasl_anonymous) -> is_sasl_anonymous_enabled(Host);
 supports_sasl_module(Host, cyrsasl_plain) -> is_login_anonymous_enabled(Host);
-supports_sasl_module(Host, cyrsasl_scram) -> is_login_anonymous_enabled(Host);
-supports_sasl_module(Host, cyrsasl_scram_sha256) -> is_login_anonymous_enabled(Host);
+supports_sasl_module(Host, cyrsasl_scram) ->
+    is_login_anonymous_enabled(Host) andalso
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha256) ->
+    is_login_anonymous_enabled(Host) andalso
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
 supports_sasl_module(Host, cyrsasl_digest) -> is_login_anonymous_enabled(Host);
 supports_sasl_module(_, _) -> false.
 
@@ -330,5 +334,3 @@ get_vh_registered_users_number(_LServer, _Opts) -> 0.
 
 %% @doc gen_auth unimplemented callbacks
 get_password_s(_LUser, _LServer) -> erlang:error(not_implemented).
-
-

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -317,16 +317,29 @@ remove_user(_LUser, _LServer) ->
 
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
-supports_sasl_module(Host, cyrsasl_anonymous) -> is_sasl_anonymous_enabled(Host);
-supports_sasl_module(Host, cyrsasl_plain) -> is_login_anonymous_enabled(Host);
-supports_sasl_module(Host, cyrsasl_scram) ->
+supports_sasl_module(Host, cyrsasl_anonymous) ->
+    is_sasl_anonymous_enabled(Host);
+supports_sasl_module(Host, cyrsasl_plain) ->
+    is_login_anonymous_enabled(Host);
+supports_sasl_module(Host, cyrsasl_scram_sha1) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
+supports_sasl_module(Host, cyrsasl_scram_sha224) ->
+    is_login_anonymous_enabled(Host) andalso
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
 supports_sasl_module(Host, cyrsasl_scram_sha256) ->
     is_login_anonymous_enabled(Host) andalso
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
-supports_sasl_module(Host, cyrsasl_digest) -> is_login_anonymous_enabled(Host);
-supports_sasl_module(_, _) -> false.
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
+supports_sasl_module(Host, cyrsasl_scram_sha384) ->
+    is_login_anonymous_enabled(Host) andalso
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
+supports_sasl_module(Host, cyrsasl_scram_sha512) ->
+    is_login_anonymous_enabled(Host) andalso
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
+supports_sasl_module(Host, cyrsasl_digest) ->
+    is_login_anonymous_enabled(Host);
+supports_sasl_module(_, _) ->
+    false.
 
 get_vh_registered_users_number(_LServer) -> 0.
 

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -46,16 +46,16 @@ start(_Host) ->
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(Host, cyrsasl_scram_sha1) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
-supports_sasl_module(Host, cyrsasl_scram_sha224) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
-supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
-supports_sasl_module(Host, cyrsasl_scram_sha384) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
-supports_sasl_module(Host, cyrsasl_scram_sha512) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
+supports_sasl_module(Host, cyrsasl_scram_sha1 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha224 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha256 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha384 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha512 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -46,10 +46,14 @@ start(_Host) ->
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(_, cyrsasl_scram) -> true;
-supports_sasl_module(_, cyrsasl_scram_sha256) -> true;
-supports_sasl_module(Host, cyrsasl_digest) -> not mongoose_scram:enabled(Host);
-supports_sasl_module(_, _) -> false.
+supports_sasl_module(Host, cyrsasl_scram) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha256) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_digest) ->
+    not mongoose_scram:enabled(Host);
+supports_sasl_module(_, _) ->
+     false.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -46,10 +46,16 @@ start(_Host) ->
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(Host, cyrsasl_scram) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha1) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
+supports_sasl_module(Host, cyrsasl_scram_sha224) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
 supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
+supports_sasl_module(Host, cyrsasl_scram_sha384) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
+supports_sasl_module(Host, cyrsasl_scram_sha512) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -104,16 +104,16 @@ update_reg_users_counter_table(Server) ->
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) ->
     true;
-supports_sasl_module(Host, cyrsasl_scram_sha1) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
-supports_sasl_module(Host, cyrsasl_scram_sha224) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
-supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
-supports_sasl_module(Host, cyrsasl_scram_sha384) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
-supports_sasl_module(Host, cyrsasl_scram_sha512) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
+supports_sasl_module(Host, cyrsasl_scram_sha1 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha224 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha256 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha384 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha512 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -104,10 +104,16 @@ update_reg_users_counter_table(Server) ->
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) ->
     true;
-supports_sasl_module(Host, cyrsasl_scram) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha1) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
+supports_sasl_module(Host, cyrsasl_scram_sha224) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
 supports_sasl_module(Host, cyrsasl_scram_sha256) ->
     mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
+supports_sasl_module(Host, cyrsasl_scram_sha384) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
+supports_sasl_module(Host, cyrsasl_scram_sha512) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -102,11 +102,16 @@ update_reg_users_counter_table(Server) ->
     mnesia:sync_dirty(F).
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
-supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(_, cyrsasl_scram) -> true;
-supports_sasl_module(_, cyrsasl_scram_sha256) -> true;
-supports_sasl_module(Host, cyrsasl_digest) -> not mongoose_scram:enabled(Host);
-supports_sasl_module(_, _) -> false.
+supports_sasl_module(_, cyrsasl_plain) ->
+    true;
+supports_sasl_module(Host, cyrsasl_scram) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha256) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
+supports_sasl_module(Host, cyrsasl_digest) ->
+    not mongoose_scram:enabled(Host);
+supports_sasl_module(_, _) ->
+    false.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -83,11 +83,16 @@ stop(_Host) ->
     ok.
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
-supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(_, cyrsasl_scram) -> true;
-supports_sasl_module(_, cyrsasl_scram_sha256) -> true;
-supports_sasl_module(Host, cyrsasl_digest) -> not mongoose_scram:enabled(Host);
-supports_sasl_module(_, _) -> false.
+supports_sasl_module(_, cyrsasl_plain) ->
+    true;
+supports_sasl_module(Host, cyrsasl_scram) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha256) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_digest) ->
+    not mongoose_scram:enabled(Host);
+supports_sasl_module(_, _) ->
+    false.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -85,10 +85,16 @@ stop(_Host) ->
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) ->
     true;
-supports_sasl_module(Host, cyrsasl_scram) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha1) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
+supports_sasl_module(Host, cyrsasl_scram_sha224) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
 supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
+supports_sasl_module(Host, cyrsasl_scram_sha384) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
+supports_sasl_module(Host, cyrsasl_scram_sha512) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -85,16 +85,16 @@ stop(_Host) ->
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) ->
     true;
-supports_sasl_module(Host, cyrsasl_scram_sha1) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
-supports_sasl_module(Host, cyrsasl_scram_sha224) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
-supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
-supports_sasl_module(Host, cyrsasl_scram_sha384) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
-supports_sasl_module(Host, cyrsasl_scram_sha512) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
+supports_sasl_module(Host, cyrsasl_scram_sha1 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha224 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha256 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha384 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha512 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -54,10 +54,14 @@ stop(_Host) ->
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(_, cyrsasl_scram) -> true;
-supports_sasl_module(_, cyrsasl_scram_sha256) -> true;
-supports_sasl_module(Host, cyrsasl_digest) -> not mongoose_scram:enabled(Host);
-supports_sasl_module(_, _) -> false.
+supports_sasl_module(Host, cyrsasl_scram) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha256) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_digest) ->
+    not mongoose_scram:enabled(Host);
+supports_sasl_module(_, _) ->
+    false.
 
 -spec set_password(jid:luser(), jid:lserver(), binary())
         -> ok | {error, not_allowed | invalid_jid}.

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -54,10 +54,16 @@ stop(_Host) ->
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(Host, cyrsasl_scram) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+supports_sasl_module(Host, cyrsasl_scram_sha1) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
+supports_sasl_module(Host, cyrsasl_scram_sha224) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
 supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram);
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
+supports_sasl_module(Host, cyrsasl_scram_sha384) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
+supports_sasl_module(Host, cyrsasl_scram_sha512) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -54,16 +54,16 @@ stop(_Host) ->
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, cyrsasl_plain) -> true;
-supports_sasl_module(Host, cyrsasl_scram_sha1) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha1);
-supports_sasl_module(Host, cyrsasl_scram_sha224) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha224);
-supports_sasl_module(Host, cyrsasl_scram_sha256) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha256);
-supports_sasl_module(Host, cyrsasl_scram_sha384) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha384);
-supports_sasl_module(Host, cyrsasl_scram_sha512) ->
-    mongoose_scram:can_login_with_configured_password_format(Host, cyrsasl_scram_sha512);
+supports_sasl_module(Host, cyrsasl_scram_sha1 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha224 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha256 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha384 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
+supports_sasl_module(Host, cyrsasl_scram_sha512 = ScramSha) ->
+    mongoose_scram:can_login_with_configured_password_format(Host, ScramSha);
 supports_sasl_module(Host, cyrsasl_digest) ->
     not mongoose_scram:enabled(Host);
 supports_sasl_module(_, _) ->

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -112,17 +112,17 @@ enabled(Host) ->
     end.
 
 can_login_with_configured_password_format(Host, cyrsasl_scram_sha1) ->
-    is_password_fromat_allowed(Host, sha);
+    is_password_format_allowed(Host, sha);
 can_login_with_configured_password_format(Host, cyrsasl_scram_sha224) ->
-    is_password_fromat_allowed(Host, sha224);
+    is_password_format_allowed(Host, sha224);
 can_login_with_configured_password_format(Host, cyrsasl_scram_sha256) ->
-    is_password_fromat_allowed(Host, sha256);
+    is_password_format_allowed(Host, sha256);
 can_login_with_configured_password_format(Host, cyrsasl_scram_sha384) ->
-    is_password_fromat_allowed(Host, sha384);
+    is_password_format_allowed(Host, sha384);
 can_login_with_configured_password_format(Host, cyrsasl_scram_sha512) ->
-    is_password_fromat_allowed(Host, sha512).
+    is_password_format_allowed(Host, sha512).
 
-is_password_fromat_allowed(Host, Sha) ->
+is_password_format_allowed(Host, Sha) ->
     case ejabberd_auth:get_opt(Host, password_format) of
         undefined -> true;
         plain -> true;

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -39,7 +39,7 @@
       iteration_count := non_neg_integer(),
       sha_key() := server_and_stored_key_type()}.
 
--type sha_key() :: sha | sha224| sha256 | sha384 | sha512.
+-type sha_key() :: sha | sha224 | sha256 | sha384 | sha512.
 
 -type server_and_stored_key_type() :: #{server_key := binary(), stored_key := binary()}.
 

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -16,6 +16,7 @@
 
 -export([
          enabled/1,
+         can_login_with_configured_password_format/2,
          iterations/0,
          iterations/1,
          password_to_scram/2,
@@ -105,6 +106,19 @@ enabled(Host) ->
         scram -> true;
         {scram, _ScramSha} -> true;
         _ -> false
+    end.
+
+can_login_with_configured_password_format(Host, cyrsasl_scram) ->
+    is_password_fromat_allowed(Host, sha);
+can_login_with_configured_password_format(Host, cyrsasl_scram_sha256) ->
+    is_password_fromat_allowed(Host, sha256).
+
+is_password_fromat_allowed(Host, Sha) ->
+    case ejabberd_auth:get_opt(Host, password_format) of
+        undefined -> true;
+        plain -> true;
+        scram -> true;
+        {scram, ConfiguredSha} -> lists:member(Sha, ConfiguredSha)
     end.
 
 %% This function is exported and used from other modules

--- a/src/sasl/cyrsasl.erl
+++ b/src/sasl/cyrsasl.erl
@@ -140,7 +140,10 @@ get_modules(Host) ->
 default_modules() ->
     [cyrsasl_plain,
      cyrsasl_digest,
-     cyrsasl_scram,
+     cyrsasl_scram_sha1,
+     cyrsasl_scram_sha224,
      cyrsasl_scram_sha256,
+     cyrsasl_scram_sha384,
+     cyrsasl_scram_sha512,
      cyrsasl_anonymous,
      cyrsasl_oauth].

--- a/src/sasl/cyrsasl.erl
+++ b/src/sasl/cyrsasl.erl
@@ -61,6 +61,8 @@
                     ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
                                            | cyrsasl:error().
 
+-optional_callbacks([mechanism/0, mech_new/2]).
+
 -spec check_credentials(sasl_state(), mongoose_credentials:t()) -> R when
       R :: {'ok', mongoose_credentials:t()}
          | {'error', binary()}.

--- a/src/sasl/cyrsasl_scram.erl
+++ b/src/sasl/cyrsasl_scram.erl
@@ -27,7 +27,7 @@
 
 -author('stephen.roettger@googlemail.com').
 
--export([mechanism/0, mech_new/2, mech_new/3, mech_step/2]).
+-export([mech_new/3, mech_step/2]).
 
 -include("mongoose.hrl").
 
@@ -48,7 +48,7 @@
          auth_module           :: ejabberd_gen_auth:t(),
          sha                   :: sha()}).
 
--type sha() :: sha | sha256.
+-type sha() :: sha | sha224 | sha256 | sha384 | sha512.
 -type client_in() :: [binary()].
 -type username_att() :: {term(), binary()}.
 -type nonce_attr() :: {term(), binary()}.
@@ -63,12 +63,6 @@
 
 -define(NONCE_LENGTH, 16).
 
--spec mechanism() -> cyrsasl:mechanism().
-mechanism() ->
-    <<"SCRAM-SHA-1">>.
-
-mech_new(_Host, Creds) ->
-    {ok, #state{step = 2, creds = Creds, sha = sha}}.
 mech_new(_Host, Creds, Sha) ->
     {ok, #state{step = 2, creds = Creds, sha = Sha}}.
 

--- a/src/sasl/cyrsasl_scram_sha1.erl
+++ b/src/sasl/cyrsasl_scram_sha1.erl
@@ -1,0 +1,19 @@
+-module(cyrsasl_scram_sha1).
+
+-export([mechanism/0, mech_new/2, mech_step/2]).
+
+-include("mongoose.hrl").
+
+-include("jlib.hrl").
+
+-behaviour(cyrsasl).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"SCRAM-SHA-1">>.
+
+mech_new(Host, Creds) ->
+    cyrsasl_scram:mech_new(Host, Creds, sha).
+
+mech_step(State, ClientIn) ->
+    cyrsasl_scram:mech_step(State, ClientIn).

--- a/src/sasl/cyrsasl_scram_sha224.erl
+++ b/src/sasl/cyrsasl_scram_sha224.erl
@@ -1,0 +1,19 @@
+-module(cyrsasl_scram_sha224).
+
+-export([mechanism/0, mech_new/2, mech_step/2]).
+
+-include("mongoose.hrl").
+
+-include("jlib.hrl").
+
+-behaviour(cyrsasl).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"SCRAM-SHA-224">>.
+
+mech_new(Host, Creds) ->
+    cyrsasl_scram:mech_new(Host, Creds, sha224).
+
+mech_step(State, ClientIn) ->
+    cyrsasl_scram:mech_step(State, ClientIn).

--- a/src/sasl/cyrsasl_scram_sha384.erl
+++ b/src/sasl/cyrsasl_scram_sha384.erl
@@ -1,0 +1,19 @@
+-module(cyrsasl_scram_sha384).
+
+-export([mechanism/0, mech_new/2, mech_step/2]).
+
+-include("mongoose.hrl").
+
+-include("jlib.hrl").
+
+-behaviour(cyrsasl).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"SCRAM-SHA-384">>.
+
+mech_new(Host, Creds) ->
+    cyrsasl_scram:mech_new(Host, Creds, sha384).
+
+mech_step(State, ClientIn) ->
+    cyrsasl_scram:mech_step(State, ClientIn).

--- a/src/sasl/cyrsasl_scram_sha512.erl
+++ b/src/sasl/cyrsasl_scram_sha512.erl
@@ -1,0 +1,19 @@
+-module(cyrsasl_scram_sha512).
+
+-export([mechanism/0, mech_new/2, mech_step/2]).
+
+-include("mongoose.hrl").
+
+-include("jlib.hrl").
+
+-behaviour(cyrsasl).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"SCRAM-SHA-512">>.
+
+mech_new(Host, Creds) ->
+    cyrsasl_scram:mech_new(Host, Creds, sha512).
+
+mech_step(State, ClientIn) ->
+    cyrsasl_scram:mech_step(State, ClientIn).

--- a/test/auth_external_SUITE.erl
+++ b/test/auth_external_SUITE.erl
@@ -66,8 +66,10 @@ get_password_s_returns_empty_bin_if_no_cache(_C) ->
     <<"">> = ?AUTH_MOD:get_password_s(random_binary(8), domain()).
 
 supported_sasl_mechanisms(_C) ->
-    Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_external],
-    [true, false, false, false] =
+    Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_external,
+               cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256,
+               cyrsasl_scram_sha384, cyrsasl_scram_sha512],
+    [true, false, false, false, false, false, false, false] =
         [?AUTH_MOD:supports_sasl_module(domain(), Mod) || Mod <- Modules].
 
 given_user_registered() ->

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -206,12 +206,14 @@ remove_user(_Config) ->
     false = ejabberd_auth_http:does_user_exist(<<"toremove1">>, ?DOMAIN1).
 
 supported_sasl_mechanisms(Config) ->
-    Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_external],
+    Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_external,
+               cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256,
+               cyrsasl_scram_sha384, cyrsasl_scram_sha512],
     DigestSupported = case lists:keyfind(scram_group, 1, Config) of
                           {_, true} -> false;
                           _ -> true
                       end,
-    [true, DigestSupported, true, false] =
+    [true, DigestSupported, false, true, true, true, ture, ture] =
         [ejabberd_auth_http:supports_sasl_module(?DOMAIN1, Mod) || Mod <- Modules].
 
 cert_auth_fail(Config) ->

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -213,7 +213,7 @@ supported_sasl_mechanisms(Config) ->
                           {_, true} -> false;
                           _ -> true
                       end,
-    [true, DigestSupported, false, true, true, true, ture, ture] =
+    [true, DigestSupported, false, true, true, true, true, true] =
         [ejabberd_auth_http:supports_sasl_module(?DOMAIN1, Mod) || Mod <- Modules].
 
 cert_auth_fail(Config) ->

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -136,8 +136,10 @@ get_vh_registered_users(_C) ->
     [] = ejabberd_auth_jwt:get_vh_registered_users(?DOMAIN1, []).
 
 supported_sasl_mechanisms(_C) ->
-    Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_scram, cyrsasl_external],
-    [true, false, false, false] =
+    Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_external,
+               cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256,
+               cyrsasl_scram_sha384, cyrsasl_scram_sha512],
+    [true, false, false, false, false, false, false, false] =
         [ejabberd_auth_jwt:supports_sasl_module(?DOMAIN1, Mod) || Mod <- Modules].
 
 dirty_get_registered_users(_C) ->


### PR DESCRIPTION
This PR is a next step to extend SCRAM fictionality for authentication mechanisms. Changes include:
* Adding SHA-224, SHA-384 and SHA-512 as possible password formats and authentication mechanisms.
* List of authentication mechanisms that are offered is taking into account configured password format. This is to avoid situation that we store password in e.g. only SHA-1 and try to authenticate with SHA-256. The list of advertised authentication mechanisms is filtered to be compatible with password format that is configured. It is done in similar way to how it was accomplished for digest.
* Extending login_SUITE - testing if it's possible to login with different combinations of configured SCRAM SHA and not possible to login for the corner case described above.
* `cyrsasl_scram` module is more generic. Before it was handling functionalities of SHA-1 and performing generic SCRAM functionalities. SHA-1 specific functionalities are moved to cyrsasl_scram_sha1 module. This way we remain more consistent regarding naming and SHA-1 is handled as any other SHA that was added. 
* Documentation update to reflect the changes.
