### PR TITLE
Message retraction: RDBMS

### DIFF
--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -120,7 +120,7 @@ init_per_group(GroupName, Config) ->
     save_offline_status(GroupName, ConfigWithRules).
 
 setup_meck(mam_failure) ->
-    ok = rpc(mim(), meck, expect, [mod_mam_rdbms_arch, archive_message, 9, {error, simulated}]);
+    ok = rpc(mim(), meck, expect, [mod_mam_rdbms_arch, archive_message, 10, {error, simulated}]);
 setup_meck(offline_failure) ->
     ok = rpc(mim(), meck, expect, [mod_offline_mnesia, write_messages, 3, {error, simulated}]);
 setup_meck(_) -> ok.

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -92,6 +92,7 @@
          archived/1,
          message_with_stanzaid/1,
          retract_message/1,
+         retract_wrong_message/1,
          filter_forwarded/1,
          offline_message/1,
          nostore_hint/1,
@@ -386,7 +387,8 @@ stanzaid_cases() ->
     [message_with_stanzaid].
 
 retract_cases() ->
-    [retract_message].
+    [retract_message,
+     retract_wrong_message].
 
 nostore_cases() ->
     [offline_message,
@@ -886,7 +888,8 @@ init_per_testcase(C=querying_for_all_messages_with_jid, Config) ->
 init_per_testcase(C=archived, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, Config1);
-init_per_testcase(C=retract_message, Config) ->
+init_per_testcase(C, Config) when C =:= retract_message;
+                                  C =:= retract_wrong_message ->
     skip_if_retraction_not_supported(Config, fun() -> escalus:init_per_testcase(C, Config) end);
 init_per_testcase(C=offline_message, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}, {carol, 1}]),
@@ -1770,6 +1773,55 @@ retract_message(Config) ->
         [ArcMsg3, ArcMsg4] = respond_messages(assert_respond_size(2, wait_archive_respond(Bob))),
         #forwarded_message{message_body = undefined,
                            message_children = [#xmlel{name = <<"retracted">>}]} = parse_forwarded_message(ArcMsg3),
+        #forwarded_message{message_body = undefined,
+                           message_children = [ApplyToElement]} = parse_forwarded_message(ArcMsg4),
+
+        ok
+    end,
+    escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
+
+retract_wrong_message(Config) ->
+    P = ?config(props, Config),
+    F = fun(Alice, Bob) ->
+
+        %% GIVEN Alice sends a message with 'origin-id' to Bob...
+        Body = <<"OH, HAI!">>,
+        Msg = #xmlel{children = Children} = escalus_stanza:chat_to(Bob, Body),
+        Msg2 = Msg#xmlel{children = Children ++ [origin_id_element(<<"orig-id-1">>)]},
+        escalus:send(Alice, Msg2),
+
+        %% ...and Bob receives it
+        Msg3 = escalus:wait_for_stanza(Bob),
+        OriginId = exml_query:subelement(Msg3, <<"origin-id">>),
+        <<"urn:xmpp:sid:0">> = exml_query:attr(OriginId, <<"xmlns">>),
+        <<"orig-id-1">> = exml_query:attr(OriginId, <<"id">>),
+
+        %% WHEN Alice tries to retract a non-existing message
+        ApplyToElement = apply_to_element(<<"orig-id-2">>),
+        RetractMsg = #xmlel{name = <<"message">>,
+                            attrs = [{<<"type">>, <<"chat">>},
+                                     {<<"to">>, escalus_utils:get_jid(Bob)}],
+                            children = [ApplyToElement]},
+        escalus:send(Alice, RetractMsg),
+
+        %% THEN Bob receives the message with 'retract'...
+        RecvRetract = escalus:wait_for_stanza(Bob),
+        ApplyTo = exml_query:subelement(RecvRetract, <<"apply-to">>),
+        <<"urn:xmpp:fasten:0">> = exml_query:attr(ApplyTo, <<"xmlns">>),
+
+        maybe_wait_for_archive(Config),
+
+        %% ... and Alice and Bob have the original message and the 'retract' message in their archives
+        escalus:send(Alice, stanza_archive_request(P, <<"q1">>)),
+        [ArcMsg1, ArcMsg2] = respond_messages(assert_respond_size(2, wait_archive_respond(Alice))),
+
+        #forwarded_message{message_body = Body} = parse_forwarded_message(ArcMsg1),
+        #forwarded_message{message_body = undefined,
+                           message_children = [ApplyToElement]} = parse_forwarded_message(ArcMsg2),
+
+        escalus:send(Bob, stanza_archive_request(P, <<"q2">>)),
+        [ArcMsg3, ArcMsg4] = respond_messages(assert_respond_size(2, wait_archive_respond(Bob))),
+        #forwarded_message{message_body = Body} = parse_forwarded_message(ArcMsg3),
         #forwarded_message{message_body = undefined,
                            message_children = [ApplyToElement]} = parse_forwarded_message(ArcMsg4),
 

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -1733,6 +1733,8 @@ retract_message(Config) ->
         ApplyTo = exml_query:subelement(RecvRetract, <<"apply-to">>),
         <<"urn:xmpp:fasten:0">> = exml_query:attr(ApplyTo, <<"xmlns">>),
 
+        maybe_wait_for_archive(Config),
+
         %% ... and Alice and Bob have the tombstone and the 'retract' message in their archives
         escalus:send(Alice, stanza_archive_request(P, <<"q1">>)),
         [ArcMsg1, ArcMsg2] = respond_messages(assert_respond_size(2, wait_archive_respond(Alice))),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -485,13 +485,13 @@ parse_children_message_result_forwarded_message(#xmlel{name = <<"x">>,
     M#forwarded_message{has_x_user_element = IsUser,
                         message_xs = [XEl | M#forwarded_message.message_xs]};
 %% Parse `<archived />' or chat markers.
-parse_children_message_result_forwarded_message(MaybeChatMarker, M) ->
-    case exml_query:attr(MaybeChatMarker, <<"xmlns">>) of
+parse_children_message_result_forwarded_message(Elem, M) ->
+    case exml_query:attr(Elem, <<"xmlns">>) of
         ?NS_CHAT_MARKERS ->
-            M#forwarded_message{ chat_marker = MaybeChatMarker#xmlel.name };
+            M#forwarded_message{ chat_marker = Elem#xmlel.name };
         _ ->
             % Not relevant
-            M
+            M#forwarded_message{ message_children = [Elem | M#forwarded_message.message_children] }
     end.
 
 %% Num is 1-based.

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -891,8 +891,8 @@ put_msg({{MsgIdOwner, MsgIdRemote},
          {_ToBin, ToJID, ToArcID},
          {_, Source, _}, Packet}) ->
     Host = ct:get_config({hosts, mim, domain}),
-    archive_message([Host, MsgIdOwner, FromArcID, FromJID, ToJID, Source, outgoing, Packet]),
-    archive_message([Host, MsgIdRemote, ToArcID, ToJID, FromJID, Source, incoming, Packet]).
+    archive_message([Host, MsgIdOwner, FromArcID, FromJID, ToJID, Source, none, outgoing, Packet]),
+    archive_message([Host, MsgIdRemote, ToArcID, ToJID, FromJID, Source, none, incoming, Packet]).
 
 archive_message(Args) ->
     rpc_apply(mod_mam, archive_message, Args).
@@ -940,7 +940,7 @@ archive_muc_msg(Host, {{MsgID, _},
                 {_RoomBin, RoomJID, RoomArcID},
                 {_FromBin, FromJID, SrcJID}, _, Packet}) ->
     rpc_apply(mod_mam_muc, archive_message, [Host, MsgID, RoomArcID, RoomJID,
-                                             FromJID, SrcJID, incoming, Packet]).
+                                             FromJID, SrcJID, none, incoming, Packet]).
 
 %% @doc Get a binary jid of the user, that tagged with `UserName' in the config.
 nick_to_jid(UserName, Config) when is_atom(UserName) ->

--- a/big_tests/tests/mam_helper.hrl
+++ b/big_tests/tests/mam_helper.hrl
@@ -61,6 +61,7 @@
     message_from   :: binary() | undefined,
     message_type   :: binary() | undefined,
     message_body   :: binary() | undefined,
+    message_children = [] :: [#xmlel{}],
     message_xs = [] :: [#xmlel{}],
     has_x_user_element :: boolean(),
     chat_marker    :: binary() | undefined

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -353,9 +353,9 @@ put_msg({{MsgIdOwner, MsgIdRemote},
     {_ToBin, ToJID, ToArcID},
     {_, Source, _}, Packet}) ->
     Host = ct:get_config({hosts, mim, domain}),
-    OutArgs = [Host, MsgIdOwner, FromArcID, FromJID, ToJID, Source, outgoing, Packet],
+    OutArgs = [Host, MsgIdOwner, FromArcID, FromJID, ToJID, Source, none, outgoing, Packet],
     ok = mam_helper:rpc_apply(mod_mam, archive_message, OutArgs),
-    InArgs = [Host, MsgIdRemote, ToArcID, ToJID, FromJID, Source, incoming, Packet],
+    InArgs = [Host, MsgIdRemote, ToArcID, ToJID, FromJID, Source, none, incoming, Packet],
     ok = mam_helper:rpc_apply(mod_mam, archive_message, InArgs).
 
 make_arc_id(Client) ->
@@ -394,7 +394,7 @@ put_room_msg({{_, MsgID},
     Host = ct:get_config({hosts, mim, domain}),
     ok = mam_helper:rpc_apply(mod_mam_muc, archive_message,
                          [Host, MsgID, ToArcID, ToJID, FromJID, SrcJID,
-                          incoming, Msg]),
+                          none, incoming, Msg]),
     {MsgID, FromJIDBin, Msg}.
 
 make_timestamp(Offset, Time) ->

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -93,6 +93,9 @@
 
 -define(NS_CHAT_MARKERS,        <<"urn:xmpp:chat-markers:0">>).
 
+-define(NS_FASTEN,              <<"urn:xmpp:fasten:0">>).
+-define(NS_RETRACT,             <<"urn:xmpp:message-retract:0">>).
+
 -define(JINGLE_NS, <<"urn:xmpp:jingle:1">>).
 
 %% Erlang Solutions custom extension - token based authentication

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -66,14 +66,21 @@ CREATE TABLE [dbo].[mam_message](
 	[direction] [nvarchar](1) NOT NULL,
 	[message] [varbinary](max) NOT NULL,
 	[search_body] [nvarchar](max) NOT NULL,
+	[origin_id] [nvarchar](250) NULL,
  CONSTRAINT [PK_mam_message_user_id] PRIMARY KEY CLUSTERED
 (
 	[user_id] ASC,
 	[id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
-
 GO
+
+CREATE INDEX i_mam_message_username_jid_id ON mam_message (user_id, remote_bare_jid, id);
+GO
+
+CREATE INDEX i_mam_message_username_jid_origin_id ON mam_message (user_id, remote_bare_jid, origin_id);
+GO
+
 SET ANSI_PADDING OFF
 GO
 /****** Object:  Table [dbo].[mam_muc_message]    Script Date: 9/17/2014 6:20:03 AM ******/
@@ -92,6 +99,7 @@ CREATE TABLE [dbo].[mam_muc_message](
 	[nick_name] [nvarchar](250) NOT NULL,
 	[message] [varbinary](max) NOT NULL,
 	[search_body] [nvarchar](max) NOT NULL,
+	[origin_id] [nvarchar](250) NULL,
  CONSTRAINT [PK_mam_muc_message_id] PRIMARY KEY CLUSTERED
 (
     [room_id] ASC,
@@ -101,6 +109,9 @@ CREATE TABLE [dbo].[mam_muc_message](
 GO
 
 CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message(sender_id);
+GO
+
+CREATE INDEX i_mam_muc_message_room_id_sender_id_origin_id ON mam_muc_message (room_id, sender_id, origin_id);
 GO
 
 SET ANSI_PADDING OFF

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -239,6 +239,7 @@ CREATE TABLE mam_message(
   -- Type test_types.binary_data_16m
   message mediumblob NOT NULL,
   search_body mediumtext,
+  origin_id varchar(250) CHARACTER SET binary,
   PRIMARY KEY (user_id, id),
   INDEX i_mam_message_rem USING BTREE (user_id, remote_bare_jid, id)
 ) CHARACTER SET utf8mb4
@@ -249,7 +250,7 @@ CREATE TABLE mam_message(
 -- Partition is selected based on MOD(user_id, 32)
 -- See for more information
 -- http://dev.mysql.com/doc/refman/5.1/en/partitioning-hash.html
-
+CREATE INDEX i_mam_message_username_jid_origin_id USING BTREE ON mam_message (user_id, remote_bare_jid, origin_id);
 
 CREATE TABLE mam_config(
   user_id INT UNSIGNED NOT NULL,
@@ -283,11 +284,13 @@ CREATE TABLE mam_muc_message(
   -- Term-encoded message packet
   message mediumblob NOT NULL,
   search_body mediumtext,
+  origin_id varchar(250) CHARACTER SET binary,
   PRIMARY KEY (room_id, id)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 
 CREATE INDEX i_mam_muc_message_sender_id USING BTREE ON mam_muc_message(sender_id);
+CREATE INDEX i_mam_muc_message_room_id_sender_id_origin_id USING BTREE ON mam_muc_message (room_id, sender_id, origin_id);
 
 CREATE TABLE offline_message(
   id BIGINT UNSIGNED        NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -250,10 +250,12 @@ CREATE TABLE mam_muc_message(
   -- Term-encoded message packet
   message bytea NOT NULL,
   search_body text,
+  origin_id varchar,
   PRIMARY KEY (room_id, id)
 );
 
 CREATE INDEX i_mam_muc_message_sender_id ON mam_muc_message USING BTREE (sender_id);
+CREATE INDEX i_mam_muc_message_room_id_sender_id_origin_id ON mam_muc_message USING BTREE (room_id, sender_id, origin_id);
 
 CREATE TABLE offline_message(
     id SERIAL UNIQUE PRIMARY Key,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -205,17 +205,17 @@ CREATE TABLE mam_message(
   -- Term-encoded message packet
   message bytea NOT NULL,
   search_body text,
-  origin_id varchar(250),
+  origin_id varchar,
   PRIMARY KEY(user_id, id)
 );
 CREATE INDEX i_mam_message_username_jid_id
     ON mam_message
     USING BTREE
     (user_id, remote_bare_jid, id);
-CREATE INDEX i_mam_message_origin_id
+CREATE INDEX i_mam_message_username_jid_origin_id
     ON mam_message
     USING BTREE
-    (user_id, origin_id);
+    (user_id, remote_bare_jid, origin_id);
 
 CREATE TABLE mam_config(
   user_id INT NOT NULL,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -205,12 +205,17 @@ CREATE TABLE mam_message(
   -- Term-encoded message packet
   message bytea NOT NULL,
   search_body text,
+  origin_id varchar(250),
   PRIMARY KEY(user_id, id)
 );
 CREATE INDEX i_mam_message_username_jid_id
     ON mam_message
     USING BTREE
     (user_id, remote_bare_jid, id);
+CREATE INDEX i_mam_message_origin_id
+    ON mam_message
+    USING BTREE
+    (user_id, origin_id);
 
 CREATE TABLE mam_config(
   user_id INT NOT NULL,

--- a/src/mam/ejabberd_gen_mam_archive.erl
+++ b/src/mam/ejabberd_gen_mam_archive.erl
@@ -7,7 +7,8 @@
 -callback archive_message(_Result, jid:server(),
                           MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),
                           LocJID :: jid:jid(), RemJID :: jid:jid(),
-                          SrcJID :: jid:jid(), Dir :: atom(), Packet :: any()) ->
+                          SrcJID :: jid:jid(), OriginID :: binary(),
+                          Dir :: atom(), Packet :: any()) ->
     ok | {error, timeout}.
 
 -callback lookup_messages(Result :: any(), Host :: jid:server(),

--- a/src/mam/ejabberd_gen_mam_archive.erl
+++ b/src/mam/ejabberd_gen_mam_archive.erl
@@ -7,7 +7,7 @@
 -callback archive_message(_Result, jid:server(),
                           MessID :: mod_mam:message_id(), ArchiveID :: mod_mam:archive_id(),
                           LocJID :: jid:jid(), RemJID :: jid:jid(),
-                          SrcJID :: jid:jid(), OriginID :: binary(),
+                          SrcJID :: jid:jid(), OriginID :: binary() | none,
                           Dir :: atom(), Packet :: any()) ->
     ok | {error, timeout}.
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -590,7 +590,7 @@ lookup_messages_without_policy_violation_check(Host, #{search_text := SearchText
 
 -spec archive_message(Host :: jid:server(), MessID :: message_id(),
                       ArcID :: archive_id(), LocJID :: jid:jid(), RemJID :: jid:jid(),
-                      SrcJID :: jid:jid(), OriginID :: binary(),
+                      SrcJID :: jid:jid(), OriginID :: binary() | none,
                       Dir :: incoming | outgoing, Packet :: term()
                      ) -> ok | {error, timeout}.
 archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet) ->

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -56,7 +56,7 @@
 -export([get_personal_data/2]).
 
 %%private
--export([archive_message/8]).
+-export([archive_message/9]).
 -export([lookup_messages/2]).
 -export([archive_id_int/2]).
 
@@ -484,11 +484,12 @@ handle_package(Dir, ReturnMessID,
          andalso should_archive_if_groupchat(Host, exml_query:attr(Packet, <<"type">>)) of
         true ->
             ArcID = archive_id_int(Host, LocJID),
+            OriginID = mod_mam_utils:get_origin_id(Packet),
             case is_interesting(Host, LocJID, RemJID, ArcID) of
                 true ->
                     MessID = generate_message_id(),
                     Result = archive_message(Host, MessID, ArcID,
-                                             LocJID, RemJID, SrcJID, Dir, Packet),
+                                             LocJID, RemJID, SrcJID, OriginID, Dir, Packet),
                     return_external_message_id_if_ok(ReturnMessID, Result, MessID);
                 false ->
                     undefined
@@ -589,12 +590,13 @@ lookup_messages_without_policy_violation_check(Host, #{search_text := SearchText
 
 -spec archive_message(Host :: jid:server(), MessID :: message_id(),
                       ArcID :: archive_id(), LocJID :: jid:jid(), RemJID :: jid:jid(),
-                      SrcJID :: jid:jid(), Dir :: incoming | outgoing, Packet :: term()
+                      SrcJID :: jid:jid(), OriginID :: binary(),
+                      Dir :: incoming | outgoing, Packet :: term()
                      ) -> ok | {error, timeout}.
-archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet) ->
+archive_message(Host, MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet) ->
     StartT = os:timestamp(),
     R = mongoose_hooks:mam_archive_message(Host, ok, MessID, ArcID,
-                                           LocJID, RemJID, SrcJID, Dir, Packet),
+                                           LocJID, RemJID, SrcJID, OriginID, Dir, Packet),
     Diff = timer:now_diff(os:timestamp(), StartT),
     mongoose_metrics:update(Host, [backends, ?MODULE, archive], Diff),
     R.

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -18,7 +18,7 @@
 
 %% MAM hook handlers
 -export([archive_size/4,
-         archive_message/9,
+         archive_message/10,
          lookup_messages/3,
          remove_archive/4]).
 
@@ -148,7 +148,7 @@ insert_query_cql() ->
         "VALUES (?, ?, ?, ?, ?, ?)".
 
 archive_message(Result, Host, MessID, _UserID,
-                LocJID, RemJID, SrcJID, Dir, Packet) ->
+                LocJID, RemJID, SrcJID, _OriginID, Dir, Packet) ->
     try
         archive_message2(Result, Host, MessID,
                          LocJID, RemJID, SrcJID, Dir, Packet)

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -27,7 +27,7 @@
 -export([stop/1]).
 
 %% ejabberd_gen_mam_archive callbacks
--export([archive_message/9]).
+-export([archive_message/10]).
 -export([lookup_messages/3]).
 -export([remove_archive/4]).
 -export([archive_size/4]).
@@ -72,7 +72,7 @@ get_mam_pm_gdpr_data(Acc, Owner) ->
 %% ejabberd_gen_mam_archive callbacks
 %%-------------------------------------------------------------------
 
-archive_message(_Result, Host, MessageId, _UserId, LocalJid, RemoteJid, SourceJid, _Dir, Packet) ->
+archive_message(_Result, Host, MessageId, _UserId, LocalJid, RemoteJid, SourceJid, _OriginID, _Dir, Packet) ->
     Owner = mod_mam_utils:bare_jid(LocalJid),
     Remote = mod_mam_utils:bare_jid(RemoteJid),
     SourceBinJid = mod_mam_utils:full_jid(SourceJid),

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -131,6 +131,7 @@ valid_core_mod_opts(mod_mam) ->
      archive_chat_markers,
      extra_lookup_params,
      full_text_search,
+     message_retraction,
      archive_groupchats,
      default_result_limit,
      max_result_limit
@@ -142,6 +143,7 @@ valid_core_mod_opts(mod_mam_muc) ->
      host,
      extra_lookup_params,
      full_text_search,
+     message_retraction,
      default_result_limit,
      max_result_limit
     ].

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -224,8 +224,9 @@ archive_room_packet(Packet, FromNick, FromJID=#jid{}, RoomJID=#jid{}, Role, Affi
         true ->
             MessID = generate_message_id(),
             Packet1 = replace_x_user_element(FromJID, Role, Affiliation, Packet),
+            OriginID = mod_mam_utils:get_origin_id(Packet),
             Result = archive_message(Host, MessID, ArcID,
-                                     RoomJID, FromJID, SrcJID, none, incoming, Packet1),
+                                     RoomJID, FromJID, SrcJID, OriginID, incoming, Packet1),
             %% Packet2 goes to archive, Packet to other users
             case Result of
                 ok ->
@@ -493,7 +494,7 @@ lookup_messages_without_policy_violation_check(Host, #{search_text := SearchText
 
 -spec archive_message(jid:server(), MessId :: mod_mam:message_id(),
                       ArcId :: mod_mam:archive_id(), LocJID :: jid:jid(),
-                      SenderJID :: jid:jid(), SrcJID :: jid:jid(), OriginID :: none,
+                      SenderJID :: jid:jid(), SrcJID :: jid:jid(), OriginID :: binary() | none,
                       Dir :: 'incoming', packet()) -> any().
 archive_message(Host, MessID, ArcID, LocJID, SenderJID, SrcJID, OriginID, Dir, Packet) ->
     mongoose_hooks:mam_muc_archive_message(Host, ok, MessID, ArcID,

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -52,7 +52,7 @@
 -export([get_personal_data/2]).
 
 %% private
--export([archive_message/8]).
+-export([archive_message/9]).
 -export([lookup_messages/2]).
 -export([archive_id_int/2]).
 -export([handle_set_message_form/3]).
@@ -225,7 +225,7 @@ archive_room_packet(Packet, FromNick, FromJID=#jid{}, RoomJID=#jid{}, Role, Affi
             MessID = generate_message_id(),
             Packet1 = replace_x_user_element(FromJID, Role, Affiliation, Packet),
             Result = archive_message(Host, MessID, ArcID,
-                                     RoomJID, FromJID, SrcJID, incoming, Packet1),
+                                     RoomJID, FromJID, SrcJID, none, incoming, Packet1),
             %% Packet2 goes to archive, Packet to other users
             case Result of
                 ok ->
@@ -493,11 +493,11 @@ lookup_messages_without_policy_violation_check(Host, #{search_text := SearchText
 
 -spec archive_message(jid:server(), MessId :: mod_mam:message_id(),
                       ArcId :: mod_mam:archive_id(), LocJID :: jid:jid(),
-                      SenderJID :: jid:jid(), SrcJID :: jid:jid(), Dir :: 'incoming',
-                      packet()) -> any().
-archive_message(Host, MessID, ArcID, LocJID, SenderJID, SrcJID, Dir, Packet) ->
+                      SenderJID :: jid:jid(), SrcJID :: jid:jid(), OriginID :: none,
+                      Dir :: 'incoming', packet()) -> any().
+archive_message(Host, MessID, ArcID, LocJID, SenderJID, SrcJID, OriginID, Dir, Packet) ->
     mongoose_hooks:mam_muc_archive_message(Host, ok, MessID, ArcID,
-                                           LocJID, SenderJID, SrcJID, Dir, Packet).
+                                           LocJID, SenderJID, SrcJID, OriginID, Dir, Packet).
 
 %% ----------------------------------------------------------------------
 %% Helpers

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -13,7 +13,7 @@
 
 %% MAM hook handlers
 -export([archive_size/4,
-         archive_message/9,
+         archive_message/10,
          lookup_messages/3,
          remove_archive/4]).
 
@@ -150,10 +150,9 @@ insert_query_cql() ->
         "VALUES (?, ?, ?, ?, ?, ?)".
 
 archive_message(Result, Host, MessID, _RoomID,
-                LocJID, FromJID, NickName, Dir, Packet) ->
+                LocJID, FromJID, NickName, _OriginID, _Dir, Packet) ->
     try
-        archive_message2(Result, Host, MessID, LocJID,
-                         FromJID, NickName, Dir, Packet)
+        archive_message2(Result, Host, MessID, LocJID, FromJID, NickName, Packet)
     catch _Type:Reason ->
             {error, Reason}
     end.
@@ -161,7 +160,7 @@ archive_message(Result, Host, MessID, _RoomID,
 archive_message2(_Result, _Host, MessID,
                  LocJID = #jid{},
                  FromJID = #jid{},
-                 _SrcJID = #jid{lresource = BNick}, _Dir, Packet) ->
+                 _SrcJID = #jid{lresource = BNick}, Packet) ->
     BLocJID = mod_mam_utils:bare_jid(LocJID),
     BFromJID = mod_mam_utils:bare_jid(FromJID),
     BPacket = packet_to_stored_binary(Packet),

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -26,7 +26,7 @@
 -export([stop/1]).
 
 %% ejabberd_gen_mam_archive callbacks
--export([archive_message/9]).
+-export([archive_message/10]).
 -export([lookup_messages/3]).
 -export([remove_archive/4]).
 -export([archive_size/4]).
@@ -75,7 +75,7 @@ get_mam_muc_gdpr_data(Acc, Source) ->
             Acc
     end.
 
-archive_message(_Result, Host, MessageId, _UserId, RoomJid, FromJID, SourceJid, _Dir, Packet) ->
+archive_message(_Result, Host, MessageId, _UserId, RoomJid, FromJID, SourceJid, _OriginID, _Dir, Packet) ->
     Room = mod_mam_utils:bare_jid(RoomJid),
     SourceBinJid = mod_mam_utils:full_jid(SourceJid),
     From = mod_mam_utils:bare_jid(FromJID),

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -168,9 +168,10 @@ retract_message(Host, RoomID, SenderJID, OriginID) ->
     ok.
 
 query_for_messages_to_retract(SRoomID, SSenderID, SOriginID) ->
-    ["SELECT id, message FROM mam_muc_message"
+    {LimitSQL, LimitMSSQL} = rdbms_queries:get_db_specific_limits(1),
+    ["SELECT ", LimitMSSQL, " id, message FROM mam_muc_message"
      " WHERE room_id = ", SRoomID, " AND sender_id = ", SSenderID, " AND origin_id = ", SOriginID,
-     " ORDER BY id DESC LIMIT 1"].
+     " ORDER BY id DESC ", LimitSQL].
 
 query_to_make_tombstone(STombstoneData, SRoomID, BMessID) ->
     ["UPDATE mam_muc_message SET message = ", STombstoneData, ", search_body = ''"

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -143,7 +143,7 @@ archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
     end.
 
 retract_message(Host, _MessID, RoomID, SenderJID, _UserRoomJID, _OriginID, Packet) ->
-    case mod_mam_utils:get_retract_id(Packet) of
+    case mod_mam_utils:get_retract_id(mod_mam_muc, Host, Packet) of
         none -> ok;
         OriginIDToRetract -> retract_message(Host, RoomID, SenderJID, OriginIDToRetract)
     end.

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -154,13 +154,15 @@ retract_message(Host, RoomID, SenderJID, OriginID) ->
     SSenderID = use_escaped_integer(mongoose_rdbms:escape_integer(SenderID)),
     SOriginID = use_escaped_string(mongoose_rdbms:escape_string(OriginID)),
     Query = query_for_messages_to_retract(SRoomID, SSenderID, SOriginID),
-    {selected, [{BMessID, SDataRaw}]} = mod_mam_utils:success_sql_query(Host, Query),
-    Data = mongoose_rdbms:unescape_binary(Host, SDataRaw),
+    {selected, [{ResMessID, ResData}]} = mod_mam_utils:success_sql_query(Host, Query),
+    Data = mongoose_rdbms:unescape_binary(Host, ResData),
     Packet = stored_binary_to_packet(Host, Data),
     Tombstone = mod_mam_utils:tombstone(Packet, OriginID),
     TombstoneData = packet_to_stored_binary(Host, Tombstone),
     STombstoneData = mongoose_rdbms:use_escaped_binary(
                        mongoose_rdbms:escape_binary(Host, TombstoneData)),
+    MessID = mongoose_rdbms:result_to_integer(ResMessID),
+    BMessID = use_escaped_integer(escape_message_id(MessID)),
     UpdateQuery = query_to_make_tombstone(STombstoneData, SRoomID, BMessID),
     {updated, 1} = mod_mam_utils:success_sql_query(Host, UpdateQuery),
     ok.

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -19,7 +19,7 @@
 -callback decode(binary()) -> term().
 
 -export([archive_size/4,
-         archive_message/9,
+         archive_message/10,
          lookup_messages/3,
          remove_archive/4]).
 
@@ -127,9 +127,9 @@ archive_size(Size, Host, RoomID, _RoomJID) when is_integer(Size) ->
 -spec archive_message(_Result, jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), _LocJID :: jid:jid(),
                       SenderJID :: jid:jid(),
-                      UserRoomJID :: jid:jid(), incoming, Packet :: packet()) -> ok.
+                      UserRoomJID :: jid:jid(), none, incoming, Packet :: packet()) -> ok.
 archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
-                SenderJID = #jid{}, UserRoomJID = #jid{}, incoming, Packet) ->
+                SenderJID = #jid{}, UserRoomJID = #jid{}, none, incoming, Packet) ->
     try
         Row = prepare_message(Host, MessID, RoomID, SenderJID, UserRoomJID, Packet),
         {updated, 1} = mod_mam_utils:success_sql_execute(Host, insert_mam_muc_message, Row),

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -24,7 +24,7 @@
          remove_archive/4]).
 
 %% Called from mod_mam_rdbms_async_writer
--export([prepare_message/6, prepare_insert/2]).
+-export([prepare_message/7, retract_message/7, prepare_insert/2]).
 
 %gdpr
 -export([get_mam_muc_gdpr_data/2]).
@@ -126,13 +126,14 @@ archive_size(Size, Host, RoomID, _RoomJID) when is_integer(Size) ->
 
 -spec archive_message(_Result, jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), _LocJID :: jid:jid(),
-                      SenderJID :: jid:jid(),
-                      UserRoomJID :: jid:jid(), none, incoming, Packet :: packet()) -> ok.
+                      SenderJID :: jid:jid(), UserRoomJID :: jid:jid(),
+                      OriginID :: binary() | none, incoming, Packet :: packet()) -> ok.
 archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
-                SenderJID = #jid{}, UserRoomJID = #jid{}, none, incoming, Packet) ->
+                SenderJID = #jid{}, UserRoomJID = #jid{}, OriginID, incoming, Packet) ->
     try
-        Row = prepare_message(Host, MessID, RoomID, SenderJID, UserRoomJID, Packet),
+        Row = prepare_message(Host, MessID, RoomID, SenderJID, UserRoomJID, OriginID, Packet),
         {updated, 1} = mod_mam_utils:success_sql_execute(Host, insert_mam_muc_message, Row),
+        retract_message(Host, MessID, RoomID, SenderJID, UserRoomJID, OriginID, Packet),
         ok
     catch _Type:Reason:StackTrace ->
             ?ERROR_MSG("event=archive_message_failed mess_id=~p room_id=~p "
@@ -141,20 +142,57 @@ archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
             {error, Reason}
     end.
 
+retract_message(Host, _MessID, RoomID, SenderJID, _UserRoomJID, _OriginID, Packet) ->
+    case mod_mam_utils:get_retract_id(Packet) of
+        none -> ok;
+        OriginIDToRetract -> retract_message(Host, RoomID, SenderJID, OriginIDToRetract)
+    end.
+
+retract_message(Host, RoomID, SenderJID, OriginID) ->
+    SRoomID = use_escaped_integer(escape_room_id(RoomID)),
+    SenderID = mod_mam:archive_id_int(Host, jid:to_bare(SenderJID)),
+    SSenderID = use_escaped_integer(mongoose_rdbms:escape_integer(SenderID)),
+    SOriginID = use_escaped_string(mongoose_rdbms:escape_string(OriginID)),
+    Query = query_for_messages_to_retract(SRoomID, SSenderID, SOriginID),
+    {selected, [{BMessID, SDataRaw}]} = mod_mam_utils:success_sql_query(Host, Query),
+    Data = mongoose_rdbms:unescape_binary(Host, SDataRaw),
+    Packet = stored_binary_to_packet(Host, Data),
+    Tombstone = mod_mam_utils:tombstone(Packet, OriginID),
+    TombstoneData = packet_to_stored_binary(Host, Tombstone),
+    STombstoneData = mongoose_rdbms:use_escaped_binary(
+                       mongoose_rdbms:escape_binary(Host, TombstoneData)),
+    UpdateQuery = query_to_make_tombstone(STombstoneData, SRoomID, BMessID),
+    {updated, 1} = mod_mam_utils:success_sql_query(Host, UpdateQuery),
+    ok.
+
+query_for_messages_to_retract(SRoomID, SSenderID, SOriginID) ->
+    ["SELECT id, message FROM mam_muc_message"
+     " WHERE room_id = ", SRoomID, " AND sender_id = ", SSenderID, " AND origin_id = ", SOriginID,
+     " ORDER BY id DESC LIMIT 1"].
+
+query_to_make_tombstone(STombstoneData, SRoomID, BMessID) ->
+    ["UPDATE mam_muc_message SET message = ", STombstoneData, ", search_body = ''"
+     " WHERE room_id = ", SRoomID, " AND id = '", BMessID, "'"].
+
 -spec prepare_message(Host :: jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), SenderJID :: jid:jid(),
-                      UserRoomJID :: jid:jid(), Packet :: packet()) -> [binary() | integer()].
-prepare_message(Host, MessID, RoomID, SenderJID, #jid{ lresource = FromNick }, Packet) ->
+                      UserRoomJID :: jid:jid(), OriginID :: binary() | none,
+                      Packet :: packet()) -> [binary() | integer()].
+prepare_message(Host, MessID, RoomID, SenderJID, #jid{ lresource = FromNick }, OriginID, Packet) ->
     BareSenderJID = jid:to_bare(SenderJID),
     Data = packet_to_stored_binary(Host, Packet),
     TextBody = mod_mam_utils:packet_to_search_body(mod_mam_muc, Host, Packet),
     SenderID = mod_mam:archive_id_int(Host, BareSenderJID),
-    [MessID, RoomID, SenderID, FromNick, Data, TextBody].
+    SOriginID = case OriginID of
+                    none -> null;
+                    _ -> OriginID
+                end,
+    [MessID, RoomID, SenderID, FromNick, SOriginID, Data, TextBody].
 
 -spec prepare_insert(Name :: atom(), NumRows :: pos_integer()) -> ok.
 prepare_insert(Name, NumRows) ->
     Table = mam_muc_message,
-    Fields = [id, room_id, sender_id, nick_name, message, search_body],
+    Fields = [id, room_id, sender_id, nick_name, origin_id, message, search_body],
     Query = rdbms_queries:create_bulk_insert_query(Table, Fields, NumRows),
     mongoose_rdbms:prepare(Name, Table, Fields, Query),
     ok.

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -155,21 +155,20 @@ stop_worker(Proc) ->
 -spec archive_message(_Result, Host :: jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), _LocJID :: jid:jid(),
                       SenderJID :: jid:jid(), UserRoomJID :: jid:jid(),
-                      _OriginID :: binary() | none, _Dir :: atom(),
+                      OriginID :: binary() | none, _Dir :: atom(),
                       Packet :: packet()) -> ok | {error, timeout}.
 archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
-                SenderJID = #jid{}, UserRoomJID = #jid{}, _OriginID, _Dir, Packet) ->
-    Row = mod_mam_muc_rdbms_arch:prepare_message(Host, MessID, RoomID,
-                                                 SenderJID, UserRoomJID, Packet),
+                SenderJID = #jid{}, UserRoomJID = #jid{}, OriginID, _Dir, Packet) ->
+    Args = [Host, MessID, RoomID, SenderJID, UserRoomJID, OriginID, Packet],
     Worker = select_worker(Host, RoomID),
     WorkerPid = whereis(Worker),
     %% Send synchronously if queue length is too long.
     case is_overloaded(WorkerPid) of
         false ->
-            gen_server:cast(Worker, {archive_message, Row});
+            gen_server:cast(Worker, {archive_message, Args});
         true ->
             {Pid, MonRef} = spawn_monitor(fun() ->
-                                                  gen_server:cast(Worker, {archive_message, Row})
+                                                  gen_server:cast(Worker, {archive_message, Args})
                                           end),
             receive
                 {'DOWN', MonRef, process, Pid, normal} -> ok;
@@ -244,12 +243,14 @@ do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
     cancel_and_flush_timer(TRef),
     ?DEBUG("Flushed ~p entries.", [MessageCount]),
 
+    Rows = [apply(mod_mam_muc_rdbms_arch, prepare_message, Args) || Args <- Acc],
+
     InsertResult =
         case MessageCount of
             MaxSize ->
-                mongoose_rdbms:execute(Host, insert_mam_muc_messages, lists:append(Acc));
+                mongoose_rdbms:execute(Host, insert_mam_muc_messages, lists:append(Rows));
             OtherSize ->
-                Results = [mongoose_rdbms:execute(Host, insert_mam_muc_message, Row) || Row <- Acc],
+                Results = [mongoose_rdbms:execute(Host, insert_mam_muc_message, Row) || Row <- Rows],
                 case lists:keyfind(error, 1, Results) of
                     false -> {updated, OtherSize};
                     Error -> Error
@@ -263,6 +264,9 @@ do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
             ?ERROR_MSG("archive_message query failed with reason ~p", [Reason]),
             ok
     end,
+
+    [apply(mod_mam_muc_rdbms_arch, retract_message, Args) || Args <- Acc],
+
     spawn_link(fun() ->
                        mongoose_hooks:mam_muc_flush_messages(Host, ok, MessageCount)
                end),
@@ -306,14 +310,14 @@ init([Host, MaxSize]) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 
-handle_cast({archive_message, Row},
+handle_cast({archive_message, Args},
             State=#state{acc=Acc, flush_interval_tref=TRef, flush_interval=Int,
                          max_batch_size=Max}) ->
     TRef2 = case {Acc, TRef} of
                 {[], undefined} -> erlang:send_after(Int, self(), flush);
                 {_, _} -> TRef
             end,
-    State2 = State#state{acc=[Row|Acc], flush_interval_tref=TRef2},
+    State2 = State#state{acc=[Args|Acc], flush_interval_tref=TRef2},
     case length(Acc) + 1 >= Max of
         true -> {noreply, run_flush(State2)};
         false -> {noreply, State2}

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -15,7 +15,7 @@
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_archive).
 -export([archive_size/4,
-         archive_message/9,
+         archive_message/10,
          lookup_messages/3,
          remove_archive/4]).
 
@@ -154,10 +154,11 @@ stop_worker(Proc) ->
 
 -spec archive_message(_Result, Host :: jid:server(), MessID :: mod_mam:message_id(),
                       RoomID :: mod_mam:archive_id(), _LocJID :: jid:jid(),
-                      SenderJID :: jid:jid(), UserRoomJID :: jid:jid(), Dir :: atom(),
+                      SenderJID :: jid:jid(), UserRoomJID :: jid:jid(),
+                      _OriginID :: binary() | none, _Dir :: atom(),
                       Packet :: packet()) -> ok | {error, timeout}.
 archive_message(_Result, Host, MessID, RoomID, _LocJID = #jid{},
-                SenderJID = #jid{}, UserRoomJID = #jid{}, _Dir, Packet) ->
+                SenderJID = #jid{}, UserRoomJID = #jid{}, _OriginID, _Dir, Packet) ->
     Row = mod_mam_muc_rdbms_arch:prepare_message(Host, MessID, RoomID,
                                                  SenderJID, UserRoomJID, Packet),
     Worker = select_worker(Host, RoomID),

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -184,13 +184,15 @@ retract_message(Host, UserID, LocJID, RemJID, OriginID, Dir) ->
     SBareRemJID = use_escaped_string(minify_and_escape_bare_jid(Host, LocJID, RemJID)),
     SDir = encode_direction(Dir),
     Query = query_for_messages_to_retract(SUserID, SBareRemJID, SOriginID, SDir),
-    {selected, [{BMessID, SDataRaw}]} = mod_mam_utils:success_sql_query(Host, Query),
-    Data = mongoose_rdbms:unescape_binary(Host, SDataRaw),
+    {selected, [{ResMessID, ResData}]} = mod_mam_utils:success_sql_query(Host, Query),
+    Data = mongoose_rdbms:unescape_binary(Host, ResData),
     Packet = stored_binary_to_packet(Host, Data),
     Tombstone = mod_mam_utils:tombstone(Packet, OriginID),
     TombstoneData = packet_to_stored_binary(Host, Tombstone),
     STombstoneData = mongoose_rdbms:use_escaped_binary(
                        mongoose_rdbms:escape_binary(Host, TombstoneData)),
+    MessID = mongoose_rdbms:result_to_integer(ResMessID),
+    BMessID = use_escaped_integer(escape_message_id(MessID)),
     UpdateQuery = query_to_make_tombstone(STombstoneData, SUserID, BMessID),
     {updated, 1} = mod_mam_utils:success_sql_query(Host, UpdateQuery),
     ok.

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -183,7 +183,7 @@ retract_message(Host, UserID, LocJID, RemJID, OriginID, Dir) ->
     SOriginID = use_escaped_string(escape_string(OriginID)),
     SBareRemJID = use_escaped_string(minify_and_escape_bare_jid(Host, LocJID, RemJID)),
     SDir = encode_direction(Dir),
-    Query = query_for_messages_to_retract(Host, SUserID, SBareRemJID, SOriginID, SDir),
+    Query = query_for_messages_to_retract(SUserID, SBareRemJID, SOriginID, SDir),
     {selected, [{BMessID, SDataRaw}]} = mod_mam_utils:success_sql_query(Host, Query),
     Data = mongoose_rdbms:unescape_binary(Host, SDataRaw),
     Packet = stored_binary_to_packet(Host, Data),
@@ -195,7 +195,7 @@ retract_message(Host, UserID, LocJID, RemJID, OriginID, Dir) ->
     {updated, 1} = mod_mam_utils:success_sql_query(Host, UpdateQuery),
     ok.
 
-query_for_messages_to_retract(_Host, SUserID, SBareRemJID, SOriginID, SDir) ->
+query_for_messages_to_retract(SUserID, SBareRemJID, SOriginID, SDir) ->
     ["SELECT id, message FROM mam_message"
      " WHERE user_id = ", SUserID, " AND remote_bare_jid = ", SBareRemJID,
      " AND origin_id = ", SOriginID, " AND direction = '", SDir, "'"

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -198,10 +198,11 @@ retract_message(Host, UserID, LocJID, RemJID, OriginID, Dir) ->
     ok.
 
 query_for_messages_to_retract(SUserID, SBareRemJID, SOriginID, SDir) ->
-    ["SELECT id, message FROM mam_message"
+    {LimitSQL, LimitMSSQL} = rdbms_queries:get_db_specific_limits(1),
+    ["SELECT ", LimitMSSQL, " id, message FROM mam_message"
      " WHERE user_id = ", SUserID, " AND remote_bare_jid = ", SBareRemJID,
      " AND origin_id = ", SOriginID, " AND direction = '", SDir, "'"
-     " ORDER BY id DESC LIMIT 1"].
+     " ORDER BY id DESC ", LimitSQL].
 
 query_to_make_tombstone(STombstoneData, SUserID, BMessID) ->
     ["UPDATE mam_message SET message = ", STombstoneData, ", search_body = ''"

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -173,7 +173,7 @@ do_archive_message(_Result, Host, MessID, UserID, LocJID, RemJID, SrcJID, Origin
     retract_message(Host, MessID, UserID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet).
 
 retract_message(Host, _MessID, UserID, LocJID, RemJID, _SrcJID, _OriginID, Dir, Packet) ->
-    case mod_mam_utils:get_retract_id(Packet) of
+    case mod_mam_utils:get_retract_id(mod_mam, Host, Packet) of
         none -> ok;
         OriginIDToRetract -> retract_message(Host, UserID, LocJID, RemJID, OriginIDToRetract, Dir)
     end.

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -152,7 +152,7 @@ index_hint_sql(Host) ->
 -spec archive_message(_Result, Host :: jid:server(),
                       MessID :: mod_mam:message_id(), UserID :: mod_mam:archive_id(),
                       LocJID :: jid:jid(), RemJID :: jid:jid(),
-                      SrcJID :: jid:jid(), OriginID :: binary(),
+                      SrcJID :: jid:jid(), OriginID :: binary() | none,
                       Dir :: atom(), Packet :: any()) -> ok.
 archive_message(Result, Host, MessID, UserID,
                 LocJID, RemJID, SrcJID, OriginID, Dir, Packet) when is_integer(UserID) ->

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -178,10 +178,10 @@ stop_worker(Proc) ->
 archive_message(_Result, Host,
                 MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet)
         when is_integer(ArcID) ->
+    Args = [Host, MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet],
     Worker = select_worker(Host, ArcID),
     WorkerPid = whereis(Worker),
     %% Send synchronously if queue length is too long.
-    Args = [Host, MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet],
     case is_overloaded(WorkerPid) of
         false ->
             gen_server:cast(Worker, {archive_message, Args});

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -29,7 +29,7 @@
 -behaviour(mongoose_module_metrics).
 
 -export([archive_size/4,
-         archive_message/9,
+         archive_message/10,
          lookup_messages/3]).
 
 %% Helpers for debugging
@@ -173,13 +173,13 @@ stop_worker(Proc) ->
 
 -spec archive_message(_Result, jid:server(), MessID :: mod_mam:message_id(),
                       ArchiveID :: mod_mam:archive_id(), LocJID :: jid:jid(),
-                      RemJID :: jid:jid(), SrcJID :: jid:jid(), Dir :: atom(),
+                      RemJID :: jid:jid(), SrcJID :: jid:jid(), OriginID :: binary(), Dir :: atom(),
                       Packet :: any()) -> ok.
 archive_message(_Result, Host,
-                MessID, ArcID, LocJID, RemJID, SrcJID, Dir, Packet)
+                MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet)
         when is_integer(ArcID) ->
     Row = mod_mam_rdbms_arch:prepare_message(Host, MessID, ArcID, LocJID,
-                                            RemJID, SrcJID, Dir, Packet),
+                                            RemJID, SrcJID, OriginID, Dir, Packet),
 
     Worker = select_worker(Host, ArcID),
     WorkerPid = whereis(Worker),

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -178,18 +178,16 @@ stop_worker(Proc) ->
 archive_message(_Result, Host,
                 MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet)
         when is_integer(ArcID) ->
-    Row = mod_mam_rdbms_arch:prepare_message(Host, MessID, ArcID, LocJID,
-                                            RemJID, SrcJID, OriginID, Dir, Packet),
-
     Worker = select_worker(Host, ArcID),
     WorkerPid = whereis(Worker),
     %% Send synchronously if queue length is too long.
+    Args = [Host, MessID, ArcID, LocJID, RemJID, SrcJID, OriginID, Dir, Packet],
     case is_overloaded(WorkerPid) of
         false ->
-            gen_server:cast(Worker, {archive_message, Row});
+            gen_server:cast(Worker, {archive_message, Args});
         true ->
             {Pid, MonRef} = spawn_monitor(fun() ->
-                                                  gen_server:cast(Worker, {archive_message, Row})
+                                                  gen_server:cast(Worker, {archive_message, Args})
                                           end),
             receive
                 {'DOWN', MonRef, process, Pid, normal} -> ok;
@@ -250,12 +248,14 @@ do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
     cancel_and_flush_timer(TRef),
     ?DEBUG("Flushed ~p entries.", [MessageCount]),
 
+    Rows = [apply(mod_mam_rdbms_arch, prepare_message, Args) || Args <- Acc],
+
     InsertResult =
         case MessageCount of
             MaxSize ->
-                mongoose_rdbms:execute(Host, insert_mam_messages, lists:append(Acc));
+                mongoose_rdbms:execute(Host, insert_mam_messages, lists:append(Rows));
             OtherSize ->
-                Results = [mongoose_rdbms:execute(Host, insert_mam_message, Row) || Row <- Acc],
+                Results = [mongoose_rdbms:execute(Host, insert_mam_message, Row) || Row <- Rows],
                 case lists:keyfind(error, 1, Results) of
                     false -> {updated, OtherSize};
                     Error -> Error
@@ -269,6 +269,9 @@ do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
             ?ERROR_MSG("archive_message query failed with reason ~p", [Reason]),
             ok
     end,
+
+    [apply(mod_mam_rdbms_arch, retract_message, Args) || Args <- Acc],
+
     spawn_link(fun() ->
                        mongoose_metrics:update(Host, modMamFlushed, MessageCount)
                end),
@@ -319,14 +322,14 @@ init([Host, N, MaxSize]) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 
-handle_cast({archive_message, Row},
+handle_cast({archive_message, Args},
             State=#state{acc=Acc, flush_interval_tref=TRef, flush_interval=Int,
                          max_batch_size=Max}) ->
     TRef2 = case {Acc, TRef} of
                 {[], undefined} -> erlang:send_after(Int, self(), flush);
                 {_, _} -> TRef
             end,
-    State2 = State#state{acc=[Row|Acc], flush_interval_tref=TRef2},
+    State2 = State#state{acc=[Args|Acc], flush_interval_tref=TRef2},
     case length(Acc) + 1 >= Max of
         true -> {noreply, run_flush(State2)};
         false -> {noreply, State2}

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -35,7 +35,7 @@
          remove_archive/4]).
 
 -export([archive_message/10,
-         archive_message_muc/9,
+         archive_message_muc/10,
          lookup_messages/3,
          lookup_messages_muc/3]).
 
@@ -146,7 +146,7 @@ archive_message(_Result, Host, MessId, _UserID, LocJID, RemJID, SrcJID, _OriginI
 %% LocJID - MUC/MUC Light room's JID
 %% FromJID - "Real" sender JID
 %% SrcJID - Full JID of user within room (room@domain/user)
-archive_message_muc(_Result, Host, MessId, _UserID, LocJID, FromJID, SrcJID, _Dir, Packet) ->
+archive_message_muc(_Result, Host, MessId, _UserID, LocJID, FromJID, SrcJID, _OriginID, _Dir, Packet) ->
     RemJIDMuc = maybe_muc_jid(SrcJID),
     try
         archive_message(Host, MessId, LocJID, RemJIDMuc, SrcJID, FromJID, Packet, muc)

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -34,7 +34,7 @@
          lookup_messages/2,
          remove_archive/4]).
 
--export([archive_message/9,
+-export([archive_message/10,
          archive_message_muc/9,
          lookup_messages/3,
          lookup_messages_muc/3]).
@@ -133,7 +133,7 @@ mam_bucket_type(Host) ->
 %% LocJID - archive owner's JID
 %% RemJID - interlocutor's JID
 %% SrcJID - "Real" sender JID
-archive_message(_Result, Host, MessId, _UserID, LocJID, RemJID, SrcJID, _Dir, Packet) ->
+archive_message(_Result, Host, MessId, _UserID, LocJID, RemJID, SrcJID, _OriginID, _Dir, Packet) ->
     try
         archive_message(Host, MessId, LocJID, RemJID, SrcJID, LocJID, Packet, pm)
     catch _Type:Reason:StackTrace ->

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -33,7 +33,7 @@
          get_one_of_path/2,
          get_one_of_path/3,
          is_archivable_message/4,
-         get_retract_id/1,
+         get_retract_id/3,
          get_origin_id/1,
          tombstone/2,
          wrap_message/6,
@@ -389,6 +389,12 @@ has_chat_marker(Packet) ->
         #xmlel{name = <<"displayed">>}    -> true;
         #xmlel{name = <<"acknowledged">>} -> true;
         _                                 -> false
+    end.
+
+get_retract_id(Module, Host, Packet) ->
+    case has_message_retraction(Module, Host) of
+        true -> get_retract_id(Packet);
+        false -> none
     end.
 
 get_retract_id(Packet) ->
@@ -791,6 +797,10 @@ packet_to_search_body(Module, Host, Packet) ->
 -spec has_full_text_search(Module :: mod_mam | mod_mam_muc, Host :: jid:server()) -> boolean().
 has_full_text_search(Module, Host) ->
     gen_mod:get_module_opt(Host, Module, full_text_search, true).
+
+-spec has_message_retraction(Module :: mod_mam | mod_mam_muc, Host :: jid:server()) -> boolean().
+has_message_retraction(Module, Host) ->
+    gen_mod:get_module_opt(Host, Module, message_retraction, true).
 
 %% -----------------------------------------------------------------------
 %% JID serialization

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -392,13 +392,13 @@ has_chat_marker(Packet) ->
     end.
 
 get_retract_id(Packet) ->
-    case exml_query:subelement_with_ns(Packet, ?NS_FASTEN) of
-        El = #xmlel{name = <<"apply-to">>} ->
-            case exml_query:subelement_with_ns(El, ?NS_RETRACT) of
-                #xmlel{name = <<"retract">>} -> exml_query:attr(El, <<"id">>, none);
-                _ -> none
+    case exml_query:subelement_with_name_and_ns(Packet, <<"apply-to">>, ?NS_FASTEN) of
+        El = #xmlel{} ->
+            case exml_query:subelement_with_name_and_ns(El, <<"retract">>, ?NS_RETRACT) of
+                #xmlel{} -> exml_query:attr(El, <<"id">>, none);
+                undefined -> none
             end;
-        _ -> none
+        undefined -> none
     end.
 
 get_origin_id(Packet) ->

--- a/src/metrics/mongoose_metrics_mam_hooks.erl
+++ b/src/metrics/mongoose_metrics_mam_hooks.erl
@@ -24,7 +24,7 @@
          mam_muc_set_prefs/7,
          mam_muc_remove_archive/4,
          mam_muc_lookup_messages/3,
-         mam_muc_archive_message/9,
+         mam_muc_archive_message/10,
          mam_muc_flush_messages/3]).
 
 -type metrics_notify_return() :: mongoose_metrics_hooks:metrics_notify_return().
@@ -123,7 +123,7 @@ mam_muc_lookup_messages(Result = {error, _},
 
 
 mam_muc_archive_message(Result, Host,
-    _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
+    _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _OriginID, _Dir, _Packet) ->
     mongoose_metrics:update(Host, modMucMamArchived, 1),
     Result.
 

--- a/src/metrics/mongoose_metrics_mam_hooks.erl
+++ b/src/metrics/mongoose_metrics_mam_hooks.erl
@@ -19,7 +19,7 @@
          mam_set_prefs/7,
          mam_remove_archive/4,
          mam_lookup_messages/3,
-         mam_archive_message/9,
+         mam_archive_message/10,
          mam_muc_get_prefs/4,
          mam_muc_set_prefs/7,
          mam_muc_remove_archive/4,
@@ -90,9 +90,10 @@ mam_lookup_messages(Result = {error, _}, _Host, _Params) ->
 -spec mam_archive_message(Result :: any(), Host :: jid:server(),
     _MessId :: mod_mam:message_id(), _ArcID :: mod_mam:archive_id(),
     _LocJID :: jid:jid(), _RemJID :: jid:jid(),
-    _SrcJID :: jid:jid(), _Dir :: atom(), _Packet :: exml:element()) -> any().
+    _SrcJID :: jid:jid(), _OriginID :: binary(),
+    _Dir :: atom(), _Packet :: exml:element()) -> any().
 mam_archive_message(Result, Host,
-    _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _Dir, _Packet) ->
+    _MessID, _ArcID, _LocJID, _RemJID, _SrcJID, _OriginID, _Dir, _Packet) ->
     mongoose_metrics:update(Host, modMamArchived, 1),
     Result.
 

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -100,7 +100,7 @@
          mam_muc_get_prefs/4,
          mam_muc_remove_archive/4,
          mam_muc_lookup_messages/3,
-         mam_muc_archive_message/9,
+         mam_muc_archive_message/10,
          mam_muc_flush_messages/3]).
 
 -export([get_mam_pm_gdpr_data/3,
@@ -1045,7 +1045,7 @@ mam_lookup_messages(HookServer, InitialValue, Params) ->
     OwnerJID :: jid:jid(),
     RemoteJID :: jid:jid(),
     SenderJID :: jid:jid(),
-    OriginID :: binary(),
+    OriginID :: binary() | none,
     Dir :: incoming | outgoing,
     Packet :: term(),
     Result :: ok | {error, timeout}.
@@ -1148,7 +1148,7 @@ mam_muc_lookup_messages(HookServer, InitialValue, Params) ->
                             [HookServer, Params]).
 
 %%% @doc The `mam_muc_archive_message' hook is called in order to store the MUC message in the archive.
--spec mam_muc_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, Dir, Packet) ->
+-spec mam_muc_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, OriginID, Dir, Packet) ->
     Result when
     HookServer :: jid:lserver(),
     InitialValue :: ok,
@@ -1157,13 +1157,14 @@ mam_muc_lookup_messages(HookServer, InitialValue, Params) ->
     OwnerJID :: jid:jid(),
     RemoteJID :: jid:jid(),
     SenderJID :: jid:jid(),
+    OriginID :: binary() | none,
     Dir :: incoming | outgoing,
     Packet :: term(),
     Result :: ok | {error, timeout}.
-mam_muc_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, Dir, Packet) ->
+mam_muc_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, OriginID, Dir, Packet) ->
     ejabberd_hooks:run_fold(mam_muc_archive_message, HookServer, InitialValue,
                             [HookServer, MessageID, ArchiveID, OwnerJID,
-                             RemoteJID, SenderJID, Dir, Packet]).
+                             RemoteJID, SenderJID, OriginID, Dir, Packet]).
 
 %%% @doc The `mam_muc_flush_messages' hook is run after the async bulk write happens for MUC messages despite the result of the write.
 -spec mam_muc_flush_messages(HookServer :: jid:lserver(), InitialValue :: ok, MessageCount :: integer()) -> ok.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -91,7 +91,7 @@
          mam_get_prefs/4,
          mam_remove_archive/4,
          mam_lookup_messages/3,
-         mam_archive_message/9]).
+         mam_archive_message/10]).
 
 -export([mam_muc_archive_id/3,
          mam_muc_archive_size/4,
@@ -1036,7 +1036,7 @@ mam_lookup_messages(HookServer, InitialValue, Params) ->
                             [HookServer, Params]).
 
 %%% @doc The `mam_archive_message' hook is called in order to store the message in the archive.
--spec mam_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, Dir, Packet) ->
+-spec mam_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, OriginID, Dir, Packet) ->
     Result when
     HookServer :: jid:lserver(),
     InitialValue :: ok,
@@ -1045,13 +1045,14 @@ mam_lookup_messages(HookServer, InitialValue, Params) ->
     OwnerJID :: jid:jid(),
     RemoteJID :: jid:jid(),
     SenderJID :: jid:jid(),
+    OriginID :: binary(),
     Dir :: incoming | outgoing,
     Packet :: term(),
     Result :: ok | {error, timeout}.
-mam_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, Dir, Packet) ->
+mam_archive_message(HookServer, InitialValue, MessageID, ArchiveID, OwnerJID, RemoteJID, SenderJID, OriginID, Dir, Packet) ->
     ejabberd_hooks:run_fold(mam_archive_message, HookServer, InitialValue,
                             [HookServer, MessageID, ArchiveID, OwnerJID,
-                             RemoteJID, SenderJID, Dir, Packet]).
+                             RemoteJID, SenderJID, OriginID, Dir, Packet]).
 
 
 %% MAM MUC related hooks


### PR DESCRIPTION
Message retraction support in MAM for RDBMS

This PR introduces the support for [XEP-0424 Message Retraction](https://xmpp.org/extensions/xep-0424.html).
- Retraction messages are stored in MAM archives even though they contain no body, as required by the XEP.
- MAM archives using RDBMS handle the retraction messages by replacing the original message (referenced by `origin-id`) with a tombstone.

TO DO in next pull requests:
- Discovery of the retraction feature.
- Documentation of the retraction feature.
- Possible error replies to the sender when the message to retract from MAM does not exist.