### PR TITLE
Message retraction: discovery

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -90,6 +90,7 @@
          mam_ns_binary/0,
          mam_ns_binary_v04/0,
          mam_ns_binary_v06/0,
+         retract_ns/0,
          make_alice_and_bob_friends/2,
          run_prefs_case/6,
          prefs_cases2/0,
@@ -224,6 +225,7 @@ nick(User) ->
 mam_ns_binary() -> mam_ns_binary_v04().
 mam_ns_binary_v04() -> <<"urn:xmpp:mam:1">>.
 mam_ns_binary_v06() -> <<"urn:xmpp:mam:2">>.
+retract_ns() -> <<"urn:xmpp:message-retract:0">>.
 
 skip_undefined(Xs) ->
     [X || X <- Xs, X =/= undefined].

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -2918,7 +2918,8 @@ disco_features_with_mam(Config) ->
                                   ?NS_RSM,
                                   <<"vcard-temp">>,
                                   mam_helper:mam_ns_binary_v04(),
-                                  mam_helper:mam_ns_binary_v06()]).
+                                  mam_helper:mam_ns_binary_v06(),
+                                  mam_helper:retract_ns()]).
 
 disco_rooms(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
@@ -2953,7 +2954,8 @@ disco_info_with_mam(Config) ->
                                          <<"muc_moderated">>,
                                          <<"muc_unsecured">>,
                                          mam_helper:mam_ns_binary_v04(),
-                                         mam_helper:mam_ns_binary_v06()]).
+                                         mam_helper:mam_ns_binary_v06(),
+                                         mam_helper:retract_ns()]).
 
 disco_items(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -307,7 +307,8 @@ disco_features_story(Config, HasMAM) ->
                                                         {attr, <<"category">>}]),
             FeaturesExpected = [?NS_MUC_LIGHT] ++ case HasMAM of
                 true -> [mam_helper:mam_ns_binary_v04(),
-                         mam_helper:mam_ns_binary_v06()];
+                         mam_helper:mam_ns_binary_v06(),
+                         mam_helper:retract_ns()];
                 false -> []
             end,
             FeaturesExpected = exml_query:paths(Stanza, [{element, <<"query">>},
@@ -329,7 +330,8 @@ disco_info_story(Config, HasMAM) ->
             Stanza = escalus:wait_for_stanza(Alice),
             FeaturesExpected = [?NS_MUC_LIGHT] ++ case HasMAM of
                 true -> [mam_helper:mam_ns_binary_v04(),
-                         mam_helper:mam_ns_binary_v06()];
+                         mam_helper:mam_ns_binary_v06(),
+                         mam_helper:retract_ns()];
                 false -> []
             end,
             FeaturesExpected = exml_query:paths(Stanza, [{element, <<"query">>},

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -220,7 +220,8 @@ disco_features(Config) ->
 disco_features_with_mam(Config) ->
     muc_helper:disco_features_story(Config, [?NS_MUC,
                                              mam_helper:mam_ns_binary_v04(),
-                                             mam_helper:mam_ns_binary_v06()]).
+                                             mam_helper:mam_ns_binary_v06(),
+                                             mam_helper:retract_ns()]).
 
 disco_info(Config) ->
     muc_helper:disco_info_story(Config, [?NS_MUC]).
@@ -228,7 +229,8 @@ disco_info(Config) ->
 disco_info_with_mam(Config) ->
     muc_helper:disco_info_story(Config, [?NS_MUC,
                                          mam_helper:mam_ns_binary_v04(),
-                                         mam_helper:mam_ns_binary_v06()]).
+                                         mam_helper:mam_ns_binary_v06(),
+                                         mam_helper:retract_ns()]).
 
 disco_rooms(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -84,7 +84,8 @@
          make_fin_element/4,
          parse_prefs/1,
          borders_decode/1,
-         is_mam_result_message/1]).
+         is_mam_result_message/1,
+         features/2]).
 
 %% Forms
 -import(mod_mam_utils,
@@ -196,8 +197,7 @@ start(Host, Opts) ->
 
     %% `parallel' is the only one recommended here.
     IQDisc = gen_mod:get_opt(iqdisc, Opts, parallel), %% Type
-    mod_disco:register_feature(Host, ?NS_MAM_04),
-    mod_disco:register_feature(Host, ?NS_MAM_06),
+    [mod_disco:register_feature(Host, Feature) || Feature <- features(?MODULE, Host)],
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_MAM_04,
                                   ?MODULE, process_mam_iq, IQDisc),
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_MAM_06,
@@ -229,8 +229,7 @@ stop(Host) ->
     ejabberd_hooks:delete(get_personal_data, Host, ?MODULE, get_personal_data, 50),
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_MAM_04),
     gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_MAM_06),
-    mod_disco:unregister_feature(Host, ?NS_MAM_04),
-    mod_disco:unregister_feature(Host, ?NS_MAM_06),
+    [mod_disco:unregister_feature(Host, Feature) || Feature <- features(?MODULE, Host)],
     ok.
 
 %% ----------------------------------------------------------------------

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -81,7 +81,8 @@
          make_fin_message/5,
          make_fin_element/4,
          parse_prefs/1,
-         borders_decode/1]).
+         borders_decode/1,
+         features/2]).
 
 %% Forms
 -import(mod_mam_utils,
@@ -158,8 +159,7 @@ start(Host, Opts) ->
     %% MUC host.
     MUCHost = gen_mod:get_opt_subhost(Host, Opts, mod_muc:default_host()),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, parallel), %% Type
-    mod_disco:register_feature(MUCHost, ?NS_MAM_04),
-    mod_disco:register_feature(MUCHost, ?NS_MAM_06),
+    [mod_disco:register_feature(MUCHost, Feature) || Feature <- features(?MODULE, Host)],
     gen_iq_handler:add_iq_handler(mod_muc_iq, MUCHost, ?NS_MAM_04,
                                   ?MODULE, room_process_mam_iq, IQDisc),
     gen_iq_handler:add_iq_handler(mod_muc_iq, MUCHost, ?NS_MAM_06,
@@ -180,8 +180,7 @@ stop(Host) ->
     ejabberd_hooks:delete(get_personal_data, Host, ?MODULE, get_personal_data, 50),
     gen_iq_handler:remove_iq_handler(mod_muc_iq, MUCHost, ?NS_MAM_04),
     gen_iq_handler:remove_iq_handler(mod_muc_iq, MUCHost, ?NS_MAM_06),
-    mod_disco:unregister_feature(MUCHost, ?NS_MAM_04),
-    mod_disco:unregister_feature(MUCHost, ?NS_MAM_06),
+    [mod_disco:unregister_feature(MUCHost, Feature) || Feature <- features(?MODULE, Host)],
     ok.
 
 %% ----------------------------------------------------------------------


### PR DESCRIPTION
Add the message retraction feature to service discovery
- For the main XMPP service, register it when enabled for mod_mam
- For the MUC service, register it when enabled for mod_mam_muc

Also:
- Make the MUC test actually check MAM features
  (muc service check is left as it can be useful to ensure MUC works)
- Remove stanza printout from the MAM test as we have stanza_log
- Check for both supported MAM namespaces

Notes:
- When message retraction is disabled in MAM, retraction messages are still stored although they do not cause any change to the original messages. The motivation is to allow the clients to handle the retraction message themselves, when they are back online. In this case there seems to be no reason for advertising of message retraction by the server.