### PR TITLE
Deprecate DIGEST-MD5 authentication method

### DIFF
--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -172,8 +172,9 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
     Please note that the list of advertised authentication mechanisms is filtered out by the supported password formats to assure that it is possible to authenticate using authentication mechanisms that are offered.
     * **Warning:** This list is still filtered by [auth backends capabilities](#authentication-backend-capabilities)
     * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sh384, cyrsasl_scram_sha512, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha256_plus, cyrsasl_scram_sh384_plus, cyrsasl_scram_sha512_plus, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
-    * **Default:** `[cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha256_plus, cyrsasl_scram_sh384_plus, cyrsasl_scram_sha512_plus, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
+    * **Default:** `[cyrsasl_plain, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha256_plus, cyrsasl_scram_sh384_plus, cyrsasl_scram_sha512_plus, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
     * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram_sha256_plus]`
+    * **Deprecations:** Please note that the DIGEST-MD5 authentication method `cyrsasl_digest` is deprecated and will be removed in the next release.
 
 * **extauth_instances** (local)
     * **Description:** Specifies a number of workers serving external authentication requests.
@@ -197,6 +198,8 @@ The table below shows the supported SASL mechanisms for each authentication back
 | pki       |                  |                   |                       |                      |          x          |
 
 `cyrsasl_oauth` does not use the auth backends at all and requires the `mod_auth_token` module enabled instead.
+
+`cyrsasl_digest` is deprecated and will be removed in the next release.
 
 ### Outgoing connections setup
 

--- a/src/sasl/cyrsasl.erl
+++ b/src/sasl/cyrsasl.erl
@@ -144,7 +144,6 @@ get_modules(Host) ->
 
 default_modules() ->
     [cyrsasl_plain,
-     cyrsasl_digest,
      cyrsasl_scram_sha1,
      cyrsasl_scram_sha224,
      cyrsasl_scram_sha256,

--- a/src/sasl/cyrsasl_digest.erl
+++ b/src/sasl/cyrsasl_digest.erl
@@ -53,6 +53,12 @@ mechanism() ->
                Creds  :: mongoose_credentials:t(),
                Socket :: term()) -> {ok, state()}.
 mech_new(Host, Creds, _Socket) ->
+    mongoose_deprecations:log(
+        {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
+        "The DIGEST-MD5 authentication mechanism is deprecated and "
+        " will be removed in the next release, please consider using"
+        " any of the SCRAM-SHA methods or equivalent instead.",
+        [{log_level, warning}]),
     {ok, #state{step = 1,
                 nonce = mongoose_bin:gen_from_crypto(),
                 host = Host,

--- a/src/sasl/cyrsasl_digest.erl
+++ b/src/sasl/cyrsasl_digest.erl
@@ -30,6 +30,8 @@
          mech_new/3,
          mech_step/2]).
 
+-deprecated({'_', '_', next_major_release}).
+
 -include("mongoose.hrl").
 
 -behaviour(cyrsasl).


### PR DESCRIPTION
This PR addresses deprecating DIGEST-MD5 as authentication method. 

The change include adding log message stating that DIGEST-MD5 is deprecated and will be removed in the next release. Log message is added using mongoose_deprecations module.

RFC on Moving DIGEST-MD5 to Historic can be found below:
[https://tools.ietf.org/html/rfc6331](https://tools.ietf.org/html/rfc6331 )

