### PR TITLE
Mod privacy refactoring

### DIFF
--- a/big_tests/tests/privacy_SUITE.erl
+++ b/big_tests/tests/privacy_SUITE.erl
@@ -673,6 +673,7 @@ block_jid_iq(Config) ->
         %% activate it
         Stanza = escalus_stanza:privacy_activate(<<"deny_localhost_iq">>),
         escalus_client:send(Alice, Stanza),
+        escalus:assert(is_iq_result, escalus_client:wait_for_stanza(Alice)),
         timer:sleep(500), %% we must let it sink in
 
         %% bob queries for version and gets an error, Alice doesn't receive the query
@@ -694,7 +695,7 @@ block_jid_iq(Config) ->
         end).
 
 block_jid_all(Config) ->
-    %% unexprected presence unavalable
+    %% unexpected presence unavalable
     mongoose_helper:kick_everyone(),
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
@@ -703,6 +704,7 @@ block_jid_all(Config) ->
         %% Alice blocks Bob
         Stanza = escalus_stanza:privacy_activate(<<"deny_jid_all">>),
         escalus_client:send(Alice, Stanza),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
 
         %% IQ response is blocked;
         %% do magic wait for the request to take effect
@@ -732,6 +734,7 @@ block_jid_all(Config) ->
         %% Just set the toy list and en~sure that only
         %% the notification push comes back.
         privacy_helper:send_set_list(Alice, {<<"deny_client">>, Bob}),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
 
         %% verify
         timer:sleep(?SLEEP_TIME),

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -30,7 +30,6 @@
                 server = <<>>         :: jid:server(),
                 resource = <<>>       :: jid:resource(),
                 sid                   :: ejabberd_sm:sid() | undefined,
-                pending_invitations = [],
                 privacy_list = #userlist{} :: mongoose_privacy:userlist(),
                 conn = unknown,
                 auth_module     :: ejabberd_auth:authmodule(),

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -73,24 +73,6 @@
                     | {'next_state', statename(), state()}
                     | {'next_state', statename(), state(), Timeout :: integer()}.
 
--type blocking_type() :: 'block' | 'unblock'.
-
--type broadcast_type() :: {exit, Reason :: binary()}
-                        | {item, IJID :: jid:simple_jid() | jid:jid(),
-                           ISubscription :: from | to | both | none | remove}
-                        | {privacy_list, PrivList :: mongoose_privacy:userlist(),
-                           PrivListName :: binary()}
-                        | {blocking, UserList :: mongoose_privacy:userlist(), What :: blocking_type(),
-                                     [binary()]}
-                        | unknown.
-
--type broadcast() :: {broadcast, broadcast_type() | mongoose_acc:t()}.
-
--type broadcast_result() :: {new_state, NewState :: state()}
-                          | {exit, Reason :: binary()}
-                          | {send_new, From :: jid:jid(), To :: jid:jid(),
-                             Packet :: exml:element(),
-                             NewState :: state()}.
 
 -type routing_result_atom() :: allow | deny | forbidden | ignore | block | invalid | probe.
 

--- a/include/mod_privacy.hrl
+++ b/include/mod_privacy.hrl
@@ -35,4 +35,8 @@
 
 -record(userlist, {name = none, list = [], needdb = false }).
 
+-record(privacy_state, {userlist}).
+
+-type privacy_state() :: #privacy_state{}.
+
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2050,7 +2050,7 @@ check_privacy_and_route_or_ignore(Acc, StateData, From, To, Packet, Dir) ->
         _ -> Acc2
     end.
 
--spec resend_subscription_requests(mongoose_acc:t(), list(), state()) -> {mongoose_acc:t(), state()}.
+-spec resend_subscription_requests(mongoose_acc:t(), [exml:element()], state()) -> {mongoose_acc:t(), state()}.
 resend_subscription_requests(Acc, Pending, StateData) ->
     {NewAcc, NewState} = lists:foldl(
                  fun(XMLPacket, {A, #state{} = State}) ->

--- a/src/mod_blocking.erl
+++ b/src/mod_blocking.erl
@@ -15,6 +15,7 @@
 -export([start/2,
          process_iq_get/5,
          process_iq_set/4,
+         update_blocking_list/4,
          stop/1
         ]).
 
@@ -24,12 +25,16 @@
 
 -type listitem() :: #listitem{}.
 
+-type blocking_type() :: 'block' | 'unblock'.
+
 start(Host, _Opts) ->
     mod_disco:register_feature(Host, ?NS_BLOCKING),
     ejabberd_hooks:add(privacy_iq_get, Host,
         ?MODULE, process_iq_get, 50),
     ejabberd_hooks:add(privacy_iq_set, Host,
         ?MODULE, process_iq_set, 50),
+    ejabberd_hooks:add(c2s_remote_hook, Host,
+        ?MODULE, update_blocking_list, 50),
     ok.
 
 stop(Host) ->
@@ -37,7 +42,15 @@ stop(Host) ->
         ?MODULE, process_iq_get, 50),
     ejabberd_hooks:delete(privacy_iq_set, Host,
         ?MODULE, process_iq_set, 50),
+    ejabberd_hooks:delete(c2s_remote_hook, Host,
+        ?MODULE, update_blocking_list, 50),
     ok.
+
+-spec update_blocking_list(privacy_state(), atom(), term(), ejabberd_c2s:state()) -> privacy_state().
+update_blocking_list(_HandlerState, mod_privacy, {blocking_change, UserList, Action, JIDs}, C2SState) ->
+    blocking_push_to_resources(Action, JIDs, C2SState),
+    blocking_presence_to_contacts(Action, JIDs, C2SState),
+    #privacy_state{userlist = UserList}.
 
 process_iq_get(Acc, _From = #jid{luser = LUser, lserver = LServer},
                _, #iq{xmlns = ?NS_BLOCKING}, _) ->
@@ -127,11 +140,9 @@ complete_iq_set(blocking_command, Acc, _, _, {error, Reason}) ->
 complete_iq_set(blocking_command, Acc, LUser, LServer, {ok, Changed, List, Type}) ->
     UserList = #userlist{name = <<"blocking">>, list = List, needdb = false},
     % send the list to all users c2s processes (resources) to make it effective immediately
-    Acc1 = broadcast_blocking_command(Acc, LUser, LServer, UserList, Changed, Type),
+    Acc1 = push_blocking_info(Acc, LUser, LServer, UserList, Changed, Type),
     % return a response here so that c2s sets the list in its state
     {Acc1, {result, [], UserList}}.
-%%complete_iq_set(blocking_command, _, _, _) ->
-%%    {result, []}.
 
 -spec blocking_list_modify(Type :: block | unblock, New :: [binary()], Old :: [listitem()]) ->
     {block|unblock|unblock_all, [binary()], [listitem()]}.
@@ -200,15 +211,16 @@ make_blocking_list_entry(J) ->
 
 %% @doc send iq confirmation to all of the user's resources
 %% if we unblock all contacts then we don't list who's been unblocked
-broadcast_blocking_command(Acc, LUser, LServer, UserList, _Changed, unblock_all) ->
-    broadcast_blocking_command(Acc, LUser, LServer, UserList, [], unblock);
-broadcast_blocking_command(Acc, LUser, LServer, UserList, Changed, Type) ->
+push_blocking_info(Acc, LUser, LServer, UserList, _Changed, unblock_all) ->
+    push_blocking_info(Acc, LUser, LServer, UserList, [], unblock);
+push_blocking_info(Acc, LUser, LServer, UserList, Changed, Type) ->
     case jid:make(LUser, LServer, <<>>) of
         error ->
             Acc;
         UserJID ->
-            Bcast = {blocking, UserList, Type, Changed},
-            ejabberd_sm:route(UserJID, UserJID, Acc, {broadcast, Bcast})
+            ejabberd_sm:run_in_all_sessions(UserJID,
+                                            mod_privacy, {blocking_change, UserList, Type, Changed}),
+            Acc
     end.
 
 blocking_query_response(Lst) ->
@@ -218,3 +230,58 @@ blocking_query_response(Lst) ->
         children = [#xmlel{name= <<"item">>,
                            attrs = [{<<"jid">>, jid:to_binary(J#listitem.value)}]} || J <- Lst]}.
 
+-spec blocking_push_to_resources(Action :: blocking_type(),
+                                 JIDS :: [binary()],
+                                 State :: ejabberd_c2s:state()) -> ok.
+blocking_push_to_resources(Action, JIDs, StateData) ->
+    SubEl =
+    case Action of
+        block ->
+            #xmlel{name = <<"block">>,
+                   attrs = [{<<"xmlns">>, ?NS_BLOCKING}],
+                   children = lists:map(
+                       fun(JID) ->
+                           #xmlel{name = <<"item">>,
+                                  attrs = [{<<"jid">>, JID}]}
+                       end, JIDs)};
+        unblock ->
+            #xmlel{name = <<"unblock">>,
+                   attrs = [{<<"xmlns">>, ?NS_BLOCKING}],
+                   children = lists:map(
+                       fun(JID) ->
+                           #xmlel{name = <<"item">>,
+                                  attrs = [{<<"jid">>, JID}]}
+                       end, JIDs)}
+    end,
+    PrivPushIQ = #iq{type = set, xmlns = ?NS_BLOCKING,
+                     id = <<"push">>,
+                     sub_el = [SubEl]},
+    T = ejabberd_c2s_state:jid(StateData),
+    F = jid:to_bare(T),
+    PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
+    ejabberd_router:route(F, T, PrivPushEl),
+    ok.
+
+-spec blocking_presence_to_contacts(Action :: blocking_type(),
+                                    JIDs :: [binary()],
+                                    State :: ejabberd_c2s:state()) -> ok.
+blocking_presence_to_contacts(_Action, [], _StateData) ->
+    ok;
+blocking_presence_to_contacts(Action, [Jid|JIDs], StateData) ->
+    Pres = case Action of
+               block ->
+                   #xmlel{name = <<"presence">>,
+                          attrs = [{<<"xml:lang">>, <<"en">>}, {<<"type">>, <<"unavailable">>}]
+                   };
+               unblock ->
+                   mongoose_c2s_presence:get_last_presence(StateData)
+           end,
+    T = jid:from_binary(Jid),
+    case mongoose_c2s_presence:is_subscribed_to_my_presence(T, StateData) of
+        true ->
+            F = jid:to_bare(ejabberd_c2s_state:jid(StateData)),
+            ejabberd_router:route(F, T, Pres);
+        false ->
+            ok
+    end,
+    blocking_presence_to_contacts(Action, JIDs, StateData).

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -121,7 +121,7 @@ start(Host, Opts) ->
                                                  get_default_list]),
     mod_privacy_backend:init(Host, Opts),
     ejabberd_hooks:add(initialise_c2s_state, Host,
-                       ?MODULE, initialise_state, 50),
+               ?MODULE, initialise_state, 50),
     ejabberd_hooks:add(privacy_iq_get, Host,
                ?MODULE, process_iq_get, 50),
     ejabberd_hooks:add(privacy_iq_set, Host,
@@ -134,12 +134,14 @@ start(Host, Opts) ->
                ?MODULE, updated_list, 50),
     ejabberd_hooks:add(remove_user, Host,
                ?MODULE, remove_user, 50),
+    ejabberd_hooks:add(c2s_remote_hook, Host,
+                mongoose_c2s_privacy, update_privacy_list, 50),
     ejabberd_hooks:add(anonymous_purge_hook, Host,
         ?MODULE, remove_user, 50).
 
 stop(Host) ->
     ejabberd_hooks:delete(initialise_c2s_state, Host,
-                          ?MODULE, initialise_state, 50),
+              ?MODULE, initialise_state, 50),
     ejabberd_hooks:delete(privacy_iq_get, Host,
               ?MODULE, process_iq_get, 50),
     ejabberd_hooks:delete(privacy_iq_set, Host,
@@ -152,6 +154,8 @@ stop(Host) ->
               ?MODULE, updated_list, 50),
     ejabberd_hooks:delete(remove_user, Host,
               ?MODULE, remove_user, 50),
+    ejabberd_hooks:delete(c2s_remote_hook, Host,
+              mongoose_c2s_privacy, update_privacy_list, 50),
     ejabberd_hooks:delete(anonymous_purge_hook, Host,
         ?MODULE, remove_user, 50).
 
@@ -164,6 +168,7 @@ initialise_state({Acc, State}) ->
     {Acc, ejabberd_c2s_state:set_handler_state(mod_privacy,
                                                 mongoose_c2s_privacy:initialise_state(JID),
                                                 State)}.
+
 process_iq_get(Acc,
                _From = #jid{luser = LUser, lserver = LServer},
                _To,
@@ -280,7 +285,7 @@ remove_privacy_list(LUser, LServer, Name) ->
     case mod_privacy_backend:remove_privacy_list(LUser, LServer, Name) of
         ok ->
             UserList = #userlist{name = Name, list = []},
-            broadcast_privacy_list(LUser, LServer, Name, UserList),
+            push_privacy_change(LUser, LServer, Name, UserList),
             {result, []};
         %% TODO if Name == Active -> conflict
         {error, conflict} ->
@@ -294,7 +299,7 @@ replace_privacy_list(LUser, LServer, Name, List) ->
         ok ->
             NeedDb = is_list_needdb(List),
             UserList = #userlist{name = Name, list = List, needdb = NeedDb},
-            broadcast_privacy_list(LUser, LServer, Name, UserList),
+            push_privacy_change(LUser, LServer, Name, UserList),
             {result, []};
         {error, _Reason} ->
             {error, mongoose_xmpp_errors:internal_server_error()}
@@ -666,16 +671,10 @@ binary_to_order_s(Order) ->
     end.
 
 
-%% Ejabberd
-%% ------------------------------------------------------------------
-
-broadcast_privacy_list(LUser, LServer, Name, UserList) ->
-    UserJID = jid:make(LUser, LServer, <<>>),
-    ejabberd_sm:route(UserJID, UserJID, broadcast_privacy_list_packet(Name, UserList)).
-
-%% TODO this is dirty
-broadcast_privacy_list_packet(Name, UserList) ->
-    {broadcast, {privacy_list, UserList, Name}}.
+push_privacy_change(LUser, LServer, Name, Userlist) ->
+    ejabberd_sm:run_in_all_sessions(jid:make(LUser, LServer, <<>>),
+                                    mod_privacy, {privacy_change, Name, Userlist}),
+    ok.
 
 roster_get_jid_info(Host, User, LJID) ->
     mongoose_hooks:roster_get_jid_info(Host,

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -44,6 +44,7 @@
          stop/1,
          process_iq/4,
          process_local_iq/4,
+         initialise_state/1,
          get_user_roster/2,
          get_subscription_lists/3,
          get_roster_entry/3,
@@ -219,6 +220,7 @@ stop(Host) ->
 
 hooks(Host) ->
     [{roster_get, Host, ?MODULE, get_user_roster, 50},
+     {initialise_c2s_state, Host, ?MODULE, initialise_state, 50},
      {roster_in_subscription, Host, ?MODULE, in_subscription, 50},
      {roster_out_subscription, Host, ?MODULE, out_subscription, 50},
      {roster_get_subscription_lists, Host, ?MODULE, get_subscription_lists, 50},
@@ -231,6 +233,18 @@ hooks(Host) ->
      %% or create here a handler which would call that module
      %% not sure which is better
      {c2s_remote_hook, Host, mongoose_c2s_presence, handle_remote_hook, 100}].
+
+initialise_state({Acc, State}) ->
+    JID = ejabberd_c2s_state:jid(State),
+    Acc1 = mongoose_hooks:roster_get_subscription_lists(JID#jid.server, Acc, JID#jid.user),
+    {Fs, Ts, _Pending} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc1),
+    LJID = jid:to_lower(jid:to_bare(JID)),
+    Fs1 = [LJID | Fs],
+    Ts1 = [LJID | Ts],
+    StateWithRoster = ejabberd_c2s_state:set_handler_state(mod_roster,
+                                                           mongoose_c2s_presence:initialise_state(Fs1, Ts1),
+                                                           State),
+    {Acc1, StateWithRoster}.
 
 get_roster_entry(LUser, LServer, Jid) ->
     mod_roster_backend:get_roster_entry(jid:nameprep(LUser), LServer, jid_arg_to_lower(Jid)).

--- a/src/mongoose_c2s_privacy.erl
+++ b/src/mongoose_c2s_privacy.erl
@@ -1,0 +1,56 @@
+-module(mongoose_c2s_privacy).
+-author("bartlomiejgorny").
+%% API
+-include("mod_privacy.hrl").
+-include("jlib.hrl").
+
+-record(privacy_state, {userlist}).
+
+-type privacy_state() :: #privacy_state{}.
+
+-export([initialise_state/1, check_packet/4, check_packet/6]).
+
+%% temporary
+-export([get_privacy_list/1, set_privacy_list/2]).
+
+
+-spec initialise_state(jid:jid()) -> privacy_state().
+initialise_state(JID) ->
+    UserList = mongoose_hooks:privacy_get_user_list(JID#jid.server, #userlist{}, JID#jid.user),
+    #privacy_state{userlist = UserList}.
+
+check_packet(Acc, To, Dir, StateData) ->
+    Jid = ejabberd_c2s_state:jid(StateData),
+    UserList = get_userlist(StateData),
+    mongoose_privacy:privacy_check_packet(Acc,
+                                          ejabberd_c2s_state:server(StateData),
+                                          Jid#jid.user,
+                                          UserList,
+                                          To,
+                                          Dir).
+
+check_packet(Acc, Packet, From, To, Dir, StateData) ->
+    UserList = get_userlist(StateData),
+    Jid = ejabberd_c2s_state:jid(StateData),
+    mongoose_privacy:privacy_check_packet({Acc, Packet},
+                                          ejabberd_c2s_state:server(StateData),
+                                          Jid#jid.user,
+                                          UserList,
+                                          From,
+                                          To,
+                                          Dir).
+
+get_userlist(StateData) ->
+    #privacy_state{userlist = UserList} = ejabberd_c2s_state:get_handler_state(mod_privacy, StateData),
+    UserList.
+
+%% temporary
+
+get_privacy_list(StateData) ->
+    case ejabberd_c2s_state:get_handler_state(mod_privacy, StateData) of
+        empty_state -> [];
+        #privacy_state{userlist = UserList} -> UserList
+    end.
+
+set_privacy_list(UserList, StateData) ->
+    ejabberd_c2s_state:set_handler_state(mod_privacy, #privacy_state{userlist = UserList}, StateData).

--- a/src/mongoose_c2s_privacy.erl
+++ b/src/mongoose_c2s_privacy.erl
@@ -53,11 +53,10 @@ update_privacy_list(_HandlerState, mod_privacy, {privacy_change, ListName, Userl
                                                 get_privacy_list(C2SState),
                                                 Userlist),
     PrivPushIQ = privacy_list_push_iq(ListName),
-    F = jid:to_bare(JID),
-    T = JID,
-    PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
+    BareJID = jid:to_bare(JID),
+    PrivPushEl = jlib:replace_from_to(BareJID, JID, jlib:iq_to_xml(PrivPushIQ)),
     Acc1 = maybe_update_presence(Acc, C2SState, NewPL),
-    _Acc2 = ejabberd_c2s:preprocess_and_ship(Acc1, F, T, PrivPushEl, C2SState),
+    _Acc2 = ejabberd_c2s:preprocess_and_ship(Acc1, BareJID, JID, PrivPushEl, C2SState),
     #privacy_state{userlist = NewPL};
 update_privacy_list(HandlerState, _, _, _) ->
     HandlerState.

--- a/src/mongoose_c2s_privacy.erl
+++ b/src/mongoose_c2s_privacy.erl
@@ -5,9 +5,6 @@
 -include("mod_privacy.hrl").
 -include("jlib.hrl").
 
--record(privacy_state, {userlist}).
-
--type privacy_state() :: #privacy_state{}.
 
 -export([initialise_state/1, check_packet/4, check_packet/6]).
 -export([process_privacy_iq/3]).
@@ -44,7 +41,7 @@ check_packet(Acc, Packet, From, To, Dir, StateData) ->
                                           Dir).
 
 %% this is called remotely by the process that received an iq
--spec update_privacy_list(privacy_state(), atom, term(), ejabberd_c2s:state()) -> privacy_state().
+-spec update_privacy_list(privacy_state(), atom(), term(), ejabberd_c2s:state()) -> privacy_state().
 update_privacy_list(_HandlerState, mod_privacy, {privacy_change, ListName, Userlist}, C2SState) ->
     JID = ejabberd_c2s_state:jid(C2SState),
     Server = ejabberd_c2s_state:server(C2SState),

--- a/src/mongoose_c2s_privacy.erl
+++ b/src/mongoose_c2s_privacy.erl
@@ -1,6 +1,7 @@
 -module(mongoose_c2s_privacy).
 -author("bartlomiejgorny").
 %% API
+-include("mongoose.hrl").
 -include("mod_privacy.hrl").
 -include("jlib.hrl").
 
@@ -9,6 +10,8 @@
 -type privacy_state() :: #privacy_state{}.
 
 -export([initialise_state/1, check_packet/4, check_packet/6]).
+-export([process_privacy_iq/3]).
+-export([update_privacy_list/4]).
 
 %% temporary
 -export([get_privacy_list/1, set_privacy_list/2]).
@@ -40,6 +43,28 @@ check_packet(Acc, Packet, From, To, Dir, StateData) ->
                                           To,
                                           Dir).
 
+%% this is called remotely by the process that received an iq
+-spec update_privacy_list(privacy_state(), atom, term(), ejabberd_c2s:state()) -> privacy_state().
+update_privacy_list(_HandlerState, mod_privacy, {privacy_change, ListName, Userlist}, C2SState) ->
+    JID = ejabberd_c2s_state:jid(C2SState),
+    Server = ejabberd_c2s_state:server(C2SState),
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => Server,
+                              element => undefined }),
+    NewPL = mongoose_hooks:privacy_updated_list(Server,
+                                                false,
+                                                get_privacy_list(C2SState),
+                                                Userlist),
+    PrivPushIQ = privacy_list_push_iq(ListName),
+    F = jid:to_bare(JID),
+    T = JID,
+    PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
+    Acc1 = maybe_update_presence(Acc, C2SState, NewPL),
+    _Acc2 = ejabberd_c2s:preprocess_and_ship(Acc1, F, T, PrivPushEl, C2SState),
+    #privacy_state{userlist = NewPL};
+update_privacy_list(HandlerState, _, _, _) ->
+    HandlerState.
+
 get_userlist(StateData) ->
     #privacy_state{userlist = UserList} = ejabberd_c2s_state:get_handler_state(mod_privacy, StateData),
     UserList.
@@ -54,3 +79,103 @@ get_privacy_list(StateData) ->
 
 set_privacy_list(UserList, StateData) ->
     ejabberd_c2s_state:set_handler_state(mod_privacy, #privacy_state{userlist = UserList}, StateData).
+
+%% it is not feasible to make this a proper IQ handler, because it requires access to
+%% the c2s state and it has to modify state to make it an active list
+-spec process_privacy_iq(Acc :: mongoose_acc:t(),
+                         To :: jid:jid(),
+                         StateData :: ejabberd_c2s:state()) -> {mongoose_acc:t(), ejabberd_c2s:state()}.
+process_privacy_iq(Acc1, To, StateData) ->
+    case mongoose_iq:info(Acc1) of
+        {#iq{type = Type, sub_el = SubEl} = IQ, Acc2} when Type == get; Type == set ->
+            From = mongoose_acc:from_jid(Acc2),
+            {Acc3, NewStateData} = process_privacy_iq(Acc2, Type, To, StateData),
+            Res = mongoose_acc:get(hook, result,
+                                   {error, mongoose_xmpp_errors:feature_not_implemented()}, Acc3),
+            IQRes = case Res of
+                        {result, Result} ->
+                            IQ#iq{type = result, sub_el = Result};
+                        {result, Result, _} ->
+                            IQ#iq{type = result, sub_el = Result};
+                        {error, Error} ->
+                            IQ#iq{type = error, sub_el = [SubEl, Error]}
+                    end,
+            Acc4 = ejabberd_c2s:preprocess_and_ship(Acc3, To, From, jlib:iq_to_xml(IQRes), StateData),
+            {Acc4, NewStateData};
+        _ ->
+            {Acc1, StateData}
+    end.
+
+-spec process_privacy_iq(Acc :: mongoose_acc:t(),
+                         Type :: get | set,
+                         To :: jid:jid(),
+                         StateData :: ejabberd_c2s:state()) -> {mongoose_acc:t(), ejabberd_c2s:state()}.
+process_privacy_iq(Acc, get, To, StateData) ->
+    From = mongoose_acc:from_jid(Acc),
+    {IQ, Acc1} = mongoose_iq:info(Acc),
+    Acc2 = mongoose_hooks:privacy_iq_get(ejabberd_c2s_state:server(StateData),
+                                         Acc1,
+                                         From, To, IQ,
+                                         get_privacy_list(StateData)),
+    {Acc2, StateData};
+process_privacy_iq(Acc, set, To, StateData) ->
+    From = mongoose_acc:from_jid(Acc),
+    {IQ, Acc1} = mongoose_iq:info(Acc),
+    Acc2 = mongoose_hooks:privacy_iq_set(ejabberd_c2s_state:server(StateData),
+                                         Acc1,
+                                         From, To, IQ),
+    case mongoose_acc:get(hook, result, undefined, Acc2) of
+        {result, _, NewPrivList} ->
+            % we have a new active list which we need to set in c2s state
+            % and send updated presence info if needed
+            Acc3 = maybe_update_presence(Acc2, StateData, NewPrivList),
+            NState = set_privacy_list(NewPrivList, StateData),
+            {Acc3, NState};
+        _ ->
+            % no change in active list; changes to privacy settings have been propagated
+            % by mod_roster hook handlers, and we will receive them presently
+            % as so-called 'routed broadcast'
+            {Acc2, StateData}
+    end.
+
+maybe_update_presence(Acc, StateData, NewList) ->
+    % Our own jid is added to pres_f, even though we're not a "contact", so for
+    % the purposes of this check we don't want it:
+    FromsExceptSelf = mongoose_c2s_presence:get_subscriptions(from_except_self, StateData),
+
+    lists:foldl(
+        fun(T, Ac) ->
+            send_unavail_if_newly_blocked(Ac, StateData, jid:make(T), NewList)
+        end, Acc, FromsExceptSelf).
+
+send_unavail_if_newly_blocked(Acc, StateData,
+                              ContactJID, NewList) ->
+    JID = ejabberd_c2s_state:jid(StateData),
+    Packet = #xmlel{name = <<"presence">>,
+                    attrs = [{<<"type">>, <<"unavailable">>}]},
+    %% WARNING: we can not use accumulator to cache privacy check result - this is
+    %% the only place where the list to check against changes
+    EmptyAcc = mongoose_acc:new(#{ location => ?LOCATION,
+                                   from_jid => JID,
+                                   to_jid => ContactJID,
+                                   lserver => ejabberd_c2s_state:server(StateData),
+                                   element => Packet }),
+    {_, OldResult} = check_packet(EmptyAcc, Packet, JID, ContactJID, out, StateData),
+    {_, NewResult} = check_packet(EmptyAcc, Packet, JID, ContactJID, out,
+                                     set_privacy_list(NewList, StateData)),
+    send_unavail_if_newly_blocked(Acc, OldResult, NewResult, JID,
+                                  ContactJID, Packet).
+
+send_unavail_if_newly_blocked(Acc, allow, deny, From, To, Packet) ->
+    ejabberd_router:route(From, To, Acc, Packet);
+send_unavail_if_newly_blocked(Acc, _, _, _, _, _) ->
+    Acc.
+
+privacy_list_push_iq(PrivListName) ->
+    #iq{type = set, xmlns = ?NS_PRIVACY,
+        id = <<"push", (mongoose_bin:gen_from_crypto())/binary>>,
+        sub_el = [#xmlel{name = <<"query">>,
+                         attrs = [{<<"xmlns">>, ?NS_PRIVACY}],
+                         children = [#xmlel{name = <<"list">>,
+                                            attrs = [{<<"name">>, PrivListName}]}]}]}.
+

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -13,6 +13,7 @@
          failed_to_store_message/4,
          filter_local_packet/2,
          filter_packet/1,
+         initialise_c2s_state/2,
          host_config_update/4,
          inbox_unread_count/3,
          local_send_to_resource_hook/5,
@@ -226,6 +227,11 @@ failed_to_store_message(LServer, Acc, From, Packet) ->
     Result :: {F :: jid:jid(), T :: jid:jid(), A :: mongoose_acc:t(), P :: exml:element()} | drop.
 filter_local_packet(Server, {From, To, Acc, Packet}) ->
     ejabberd_hooks:run_fold(filter_local_packet, Server, {From, To, Acc, Packet}, []).
+
+-spec initialise_c2s_state(jid:server(), {mongoose_acc:t(), ejabberd_c2s:state()}) ->
+    {mongoose_acc:t(), ejabberd_c2s:state()}.
+initialise_c2s_state(Server, {Acc, State}) ->
+    ejabberd_hooks:run_fold(initialise_c2s_state, Server, {Acc, State}, []).
 
 %%% @doc The `filter_packet' hook is called to filter out stanzas routed with `mongoose_router_global'.
 -spec filter_packet({From, To, Acc, Packet}) -> Result when


### PR DESCRIPTION
Follow-up to c2s and mod_roster beautification. Includes:

- removing the sm broadcasting (remote hook call used instead)
- moving nearly all privacy and blocking related code to dedicated modules (with just two lines left, because privacy iq handler is a bit unusual)
- removing pending invitations from c2s state, it was not used
- minor changes to privacy tests (in a few cases iq result is now received)

