### PR TITLE
Separate SALT for each password SCRAM hash

### DIFF
--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -441,15 +441,15 @@ verify_format(GroupName, {_User, Props}) ->
     do_verify_format(GroupName, Password, SPassword).
 
 
-do_verify_format(GroupName, _P, #{salt   := _S, iteration_count := _IC,
-                                  sha    := #{stored_key := _, server_key := _},
-                                  sha224 := #{stored_key := _, server_key := _},
-                                  sha256 := #{stored_key := _, server_key := _},
-                                  sha384 := #{stored_key := _, server_key := _},
-                                  sha512 := #{stored_key := _, server_key := _}}) when
+do_verify_format(GroupName, _P, #{iteration_count := _IC,
+                                  sha    := #{salt := _, stored_key := _, server_key := _},
+                                  sha224 := #{salt := _, stored_key := _, server_key := _},
+                                  sha256 := #{salt := _, stored_key := _, server_key := _},
+                                  sha384 := #{salt := _, stored_key := _, server_key := _},
+                                  sha512 := #{salt := _, stored_key := _, server_key := _}}) when
                  GroupName == login_scram orelse GroupName == scram ->
     true;
-do_verify_format({scram, Sha}, _Password, ScramMap = #{salt := _S, iteration_count := _IC}) ->
+do_verify_format({scram, Sha}, _Password, ScramMap = #{iteration_count := _IC}) ->
    maps:is_key(Sha, ScramMap);
 do_verify_format(login_scram, _Password, SPassword) ->
     %% returned password is a tuple containing scram data

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -5,10 +5,10 @@ Developers can use this information to create advanced endpoints for `ejabberd_a
 
 ## Format description
 
-`==MULTI_SCRAM==,<salt>,<iteration count>,===SHA1===<stored key>|<server key>,==SHA224==<stored key>|<server key>,==SHA256==<stored key>|<server key>,==SHA384==<stored key>|<server key>,==SHA512==<stored key>|<server key>`
+`==MULTI_SCRAM==,<iteration count>,===SHA1===<salt>|<stored key>|<server key>,==SHA224==<salt>|<stored key>|<server key>,==SHA256==<salt>|<stored key>|<server key>,==SHA384==<salt>|<stored key>|<server key>,==SHA512=<salt>|<stored key>|<server key>`
 
-* `<salt>` - Base64-encoded Salt
 * `<iteration count>` - Iteration Count formatted as a human-readable integer
+* `<salt>` - Base64-encoded Salt
 * `<stored key>` - Base64-encoded Stored Key
 * `<server key>` - Base64-encoded Server Key
 
@@ -24,41 +24,43 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 * *Erlang map:*
 ```
 #{iteration_count => 4096,
-  salt => <<"aml22qUoKvwJHccCCH00eQ==">>,
   sha =>
-      #{server_key => <<"gkoblYUZnW8GRBhIyJnbflHlLYs=">>,
-        stored_key => <<"+nm4+0ONdpgnoypippxdzV5sQ80=">>},
+      #{salt => <<"QClQsw/sfPEnwj4AEp6E1w==">>,
+        server_key => <<"EJvxXWM42tO7BgW21lNZyBc1dD0=">>,
+        stored_key => <<"ys1104hRhqMoRputBY5sLHKXoSw=">>},
   sha224 =>
-      #{server_key =>
-            <<"JwSXbKqMRJEwOr/iNmqN+x3UzxRikmKym9E71g==">>,
+      #{salt => <<"dk0ImXFVPoUfqD5FveV7YA==">>,
+        server_key => <<"EvE2EkZcUb3k4CooeOcVFy95P32t+NDX0xbQUA==">>,
         stored_key =>
-            <<"nUi8YwRBRMAusH/KpINo3/AO32UWzlSONX9wMA==">>},
+            <<"G0ibQ/YYuCtoun4I+1IF2zJ7Q8x2T23ETnq5Gg==">>},
   sha256 =>
-      #{server_key =>
-            <<"y0cB/hZ7AKtVMC2WCkXlo4XTNfOQVg30PLfIhK+Wf/U=">>,
+      #{salt => <<"M7BYKSo04XbzBr4C7b056g==">>,
+        server_key =>
+            <<"XhtGFf6NDWsnVSCO4xkzPD3qc046fPL0pATZi7RmaWo=">>,
         stored_key =>
-            <<"tiDUGNpvmt75PGcCvwoTLVOF/og/BiX1FOpihXlYqW8=">>},
+            <<"A779MC05nSGQln5no0hKTGHFSaQ7oguKBZgORW3s+es=">>},
   sha384 =>
-      #{server_key =>
-            <<"LJKetdkPytdOXg6aj4NN25KmJatJsl5zaU78bzjowYrBcjG+wux/I5q7E78sQVSn">>,
+      #{salt => <<"Ryu0fA29gbwgqFOBk5Mczw==">>,
+        server_key =>
+            <<"kR+LMI/E0QBG3oF405/MTAT6NAlCOfPrFOaWH3WBVGM0Viu9Brk6kGwVwXjSP8v0">>,
         stored_key =>
-            <<"s7SdIo5a+LH/EsKIMoqa4PPEveScCnDwP1LeaAzVdANT5pPSMio/CoMDN4uXfnHr">>},
+            <<"k3QwC0Lb1y1/V/31byC5KML5t3mH4JTPjFyeAz7lV2l4SPfzi3JHvLEdoNB5K/VY">>},
   sha512 =>
-      #{server_key =>
-            <<"TCuJFv5dmpshThJbQnURW0LOz7D55d5hgYndA3jdklQd2omL6PpfgfIgToyVvYlsF9sRGYOg255y+Q+ltwW3tQ==">>,
+      #{salt => <<"SLNuVNcWiNBmnYZNIdj+zg==">>,
+        server_key =>
+            <<"jUUDbuQ9ae4UnAWS6RV6W4yifX3La3ESjfZjGol+TBROIb/ihR8UawPHrSHkp4yyDJXtRhR9RlHCHy4bcCm1Yg==">>,
         stored_key =>
-            <<"4ATRLxRB+d6YyZXxi3PorT6kyS4Mr6tEuKUVhInJcRU0NDpXh94Y/Yrd+EDOSZUnPno8aAzj78NUXOTyoB98rg==">>}}
+            <<"3ey3gzSsmbxcLnoc1VKCR/739uKX6uuPCyAzn6x8o87ibcjOdUaU8qhL5X4MUI9UPTt667GagNpVTmAWTFNsjA==">>}}
+
 ```
 * *Serialized password:*
 ```
-
-==MULTI_SCRAM==,aml22qUoKvwJHccCCH00eQ==,4096,
-===SHA1===+nm4+0ONdpgnoypippxdzV5sQ80=|gkoblYUZnW8GRBhIyJnbflHlLYs=,
-==SHA224==nUi8YwRBRMAusH/KpINo3/AO32UWzlSONX9wMA==|JwSXbKqMRJEwOr/iNmqN+x3UzxRikmKym9E71g==,
-==SHA256==tiDUGNpvmt75PGcCvwoTLVOF/og/BiX1FOpihXlYqW8=|y0cB/hZ7AKtVMC2WCkXlo4XTNfOQVg30PLfIhK+Wf/U=,
-==SHA384==s7SdIo5a+LH/EsKIMoqa4PPEveScCnDwP1LeaAzVdANT5pPSMio/CoMDN4uXfnHr|LJKetdkPytdOXg6aj4NN25KmJatJsl5zaU78bzjowYrBcjG+wux/I5q7E78sQVSn,
-==SHA512==4ATRLxRB+d6YyZXxi3PorT6kyS4Mr6tEuKUVhInJcRU0NDpXh94Y/Yrd+EDOSZUnPno8aAzj78NUXOTyoB98rg==|TCuJFv5dmpshThJbQnURW0LOz7D55d5hgYndA3jdklQd2omL6PpfgfIgToyVvYlsF9sRGYOg255y+Q+ltwW3tQ==
-
+==MULTI_SCRAM==,4096,
+===SHA1===QClQsw/sfPEnwj4AEp6E1w==|ys1104hRhqMoRputBY5sLHKXoSw=|EJvxXWM42tO7BgW21lNZyBc1dD0=,
+==SHA224==dk0ImXFVPoUfqD5FveV7YA==|G0ibQ/YYuCtoun4I+1IF2zJ7Q8x2T23ETnq5Gg==|EvE2EkZcUb3k4CooeOcVFy95P32t+NDX0xbQUA==,
+==SHA256==M7BYKSo04XbzBr4C7b056g==|A779MC05nSGQln5no0hKTGHFSaQ7oguKBZgORW3s+es=|XhtGFf6NDWsnVSCO4xkzPD3qc046fPL0pATZi7RmaWo=,
+==SHA384==Ryu0fA29gbwgqFOBk5Mczw==|k3QwC0Lb1y1/V/31byC5KML5t3mH4JTPjFyeAz7lV2l4SPfzi3JHvLEdoNB5K/VY|kR+LMI/E0QBG3oF405/MTAT6NAlCOfPrFOaWH3WBVGM0Viu9Brk6kGwVwXjSP8v0,
+==SHA512==SLNuVNcWiNBmnYZNIdj+zg==|3ey3gzSsmbxcLnoc1VKCR/739uKX6uuPCyAzn6x8o87ibcjOdUaU8qhL5X4MUI9UPTt667GagNpVTmAWTFNsjA==|jUUDbuQ9ae4UnAWS6RV6W4yifX3La3ESjfZjGol+TBROIb/ihR8UawPHrSHkp4yyDJXtRhR9RlHCHy4bcCm1Yg==
 ```
 
 ## Legacy format description

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -143,28 +143,28 @@ password_to_scram(Host, Password) ->
 password_to_scram(_, #scram{} = Password, _) ->
     scram_record_to_map(Password);
 password_to_scram(Host, Password, IterationCount) ->
-    Salt = crypto:strong_rand_bytes(?SALT_LENGTH),
-    ServerStoredKeys = [password_to_scram(Password, Salt, IterationCount, HashType)
+    ServerStoredKeys = [do_password_to_scram(Password, IterationCount, HashType)
                             || {HashType, _Prefix} <- configured_sha_types(Host)],
-    ResultList = lists:merge([{salt, base64:encode(Salt)},
-                              {iteration_count, IterationCount}], ServerStoredKeys),
+    ResultList = lists:merge([{iteration_count, IterationCount}], ServerStoredKeys),
     maps:from_list(ResultList).
 
-password_to_scram(Password, Salt, IterationCount, HashType) ->
+do_password_to_scram(Password, IterationCount, HashType) ->
+    Salt = crypto:strong_rand_bytes(?SALT_LENGTH),
     SaltedPassword = salted_password(HashType, Password, Salt, IterationCount),
     StoredKey = stored_key(HashType, client_key(HashType, SaltedPassword)),
     ServerKey = server_key(HashType, SaltedPassword),
-    {HashType, #{server_key => base64:encode(ServerKey),
+    {HashType, #{salt       => base64:encode(Salt),
+                 server_key => base64:encode(ServerKey),
                  stored_key => base64:encode(StoredKey)}}.
 
 check_password(Password, Scram) when is_record(Scram, scram)->
     ScramMap = scram_record_to_map(Scram),
     check_password(Password, ScramMap);
 check_password(Password, ScramMap) when is_map(ScramMap) ->
-    #{salt := Salt, iteration_count := IterationCount} = ScramMap,
+    #{iteration_count := IterationCount} = ScramMap,
     [Sha | _] = [ShaKey || {ShaKey, _Prefix} <- supported_sha_types(),
                                                 maps:is_key(ShaKey, ScramMap)],
-    #{Sha := #{stored_key := StoredKey}} = ScramMap,
+    #{Sha := #{salt := Salt, stored_key := StoredKey}} = ScramMap,
     SaltedPassword = salted_password(Sha, Password, base64:decode(Salt), IterationCount),
     ClientStoredKey = stored_key(Sha, client_key(Sha, SaltedPassword)),
     ClientStoredKey == base64:decode(StoredKey).
@@ -175,38 +175,41 @@ serialize(#scram{storedkey = StoredKey, serverkey = ServerKey,
     << <<?SCRAM_SERIAL_PREFIX>>/binary,
        StoredKey/binary, $,, ServerKey/binary,
        $,, Salt/binary, $,, IterationCountBin/binary>>;
-serialize(#{salt   := Salt, iteration_count := IterationCount} = ScramMap) ->
+serialize(#{iteration_count := IterationCount} = ScramMap) ->
     IterationCountBin = integer_to_binary(IterationCount),
     ConfigedSha = [{ShaKey, Prefix} || {ShaKey, Prefix} <- supported_sha_types(),
                                                            maps:is_key(ShaKey, ScramMap)],
-    Header = [?MULTI_SCRAM_SERIAL_PREFIX, Salt, $, , IterationCountBin],
+    Header = [?MULTI_SCRAM_SERIAL_PREFIX, IterationCountBin],
     do_serialize(Header, ScramMap, ConfigedSha).
 
 do_serialize(Serialized, _ ,[]) ->
     erlang:iolist_to_binary(Serialized);
 do_serialize(Header, ScramMap, [{Sha, Prefix} | RemainingSha]) ->
-    #{Sha := #{server_key := ServerKey, stored_key := StoredKey}} = ScramMap,
-    ShaSerialization = [$, , Prefix, StoredKey, $|, ServerKey],
+    #{Sha := #{salt := Salt,
+               server_key := ServerKey,
+               stored_key := StoredKey}} = ScramMap,
+    ShaSerialization = [$, , Prefix, Salt, $|, StoredKey, $|, ServerKey],
     NewHeader = [Header | ShaSerialization],
     do_serialize(NewHeader, ScramMap, RemainingSha).
 
 deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
     case catch binary:split(Serialized, <<",">>, [global]) of
         [StoredKey, ServerKey, Salt, IterationCount] ->
-            {ok, #{salt => Salt,
-                   iteration_count => binary_to_integer(IterationCount),
-                   sha => #{stored_key => StoredKey, server_key => ServerKey}}};
+            {ok, #{iteration_count => binary_to_integer(IterationCount),
+                   sha => #{salt       => Salt,
+                            stored_key => StoredKey,
+                            server_key => ServerKey}}};
         _ ->
             ?WARNING_MSG("Incorrect serialized SCRAM: ~p", [Serialized]),
             {error, incorrect_scram}
     end;
 deserialize(<<?MULTI_SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
     case catch binary:split(Serialized, <<",">>, [global]) of
-        [Salt, IterationCountBin | ListOfShaSpecificDetails] ->
+        [IterationCountBin | ListOfShaSpecificDetails] ->
             IterationCount = binary_to_integer(IterationCountBin),
             DeserializedKeys = [deserialize(supported_sha_types(), ShaDetails)
                                              || ShaDetails <- ListOfShaSpecificDetails],
-            ResultList = lists:merge([{salt, Salt}, {iteration_count, IterationCount}],
+            ResultList = lists:merge([{iteration_count, IterationCount}],
                                      lists:flatten(DeserializedKeys)),
             {ok, maps:from_list(ResultList)};
         _ ->
@@ -220,12 +223,12 @@ deserialize(Bin) ->
 deserialize([], _) ->
     [];
 deserialize([{Sha, Prefix} | _RemainingSha],
-    <<Prefix:10/binary, StoredServerKeys/binary>>) ->
-    case catch binary:split(StoredServerKeys, <<"|">>, [global]) of
-        [StoredKey, ServerKey] ->
-            {Sha, #{server_key => ServerKey, stored_key => StoredKey}};
+    <<Prefix:10/binary, ShaDetails/binary>>) ->
+    case catch binary:split(ShaDetails, <<"|">>, [global]) of
+        [Salt, StoredKey, ServerKey] ->
+            {Sha, #{salt => Salt, server_key => ServerKey, stored_key => StoredKey}};
         _ ->
-            ?WARNING_MSG("Incorrect serialized SCRAM: ~p", [StoredServerKeys])
+            ?WARNING_MSG("Incorrect serialized SCRAM: ~p", [ShaDetails])
     end;
 deserialize([_CurrentSha | RemainingSha], ShaDetails) ->
     deserialize(RemainingSha, ShaDetails).
@@ -239,9 +242,9 @@ scram_to_tuple(Scram) ->
 
 -spec scram_record_to_map(scram()) -> scram_map().
 scram_record_to_map(Scram) ->
-    #{salt => Scram#scram.salt,
-      iteration_count => Scram#scram.iterationcount,
-      sha => #{stored_key => Scram#scram.storedkey,
+    #{iteration_count => Scram#scram.iterationcount,
+      sha => #{salt       => Scram#scram.salt,
+               stored_key => Scram#scram.storedkey,
                server_key => Scram#scram.serverkey}}.
 
 -spec check_digest(Scram, binary(), fun(), binary()) -> boolean() when

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -35,13 +35,14 @@
                          Salt :: binary(), Iterations :: non_neg_integer() }.
 
 -type scram_map() ::
-    #{salt := binary(),
-      iteration_count := non_neg_integer(),
+    #{iteration_count := non_neg_integer(),
       sha_key() := server_and_stored_key_type()}.
 
 -type sha_key() :: sha | sha224 | sha256 | sha384 | sha512.
 
--type server_and_stored_key_type() :: #{server_key := binary(), stored_key := binary()}.
+-type server_and_stored_key_type() :: #{salt       := binary(),
+                                        server_key := binary(),
+                                        stored_key := binary()}.
 
 -type scram() :: #scram{}.
 

--- a/src/sasl/cyrsasl_scram.erl
+++ b/src/sasl/cyrsasl_scram.erl
@@ -195,8 +195,8 @@ get_scram_attributes(UserName, LServer, Sha) ->
             {AuthModule, do_get_scram_attributes(Params, Sha)}
     end.
 
-do_get_scram_attributes(#{salt := Salt, iteration_count := IterationCount} = Params, Sha) ->
-    #{Sha := #{stored_key := StoredKey, server_key := ServerKey}} = Params,
+do_get_scram_attributes(#{iteration_count := IterationCount} = Params, Sha) ->
+    #{Sha := #{salt := Salt, stored_key := StoredKey, server_key := ServerKey}} = Params,
     {base64:decode(StoredKey), base64:decode(ServerKey),
      base64:decode(Salt), IterationCount};
 do_get_scram_attributes(Password, Sha) ->

--- a/test/auth_internal_SUITE.erl
+++ b/test/auth_internal_SUITE.erl
@@ -28,8 +28,10 @@ passwords_as_records_are_still_supported(_C) ->
     %% when we read the password via the `ejabberd_auth_internal:get_password/2
     NewScramMap = ejabberd_auth_internal:get_password(U, S),
     %% then new map with sha key is returned
-    ?assertMatch(#{iteration_count := _, salt := _,
-                   sha := #{server_key := _, stored_key := _}}, NewScramMap),
+    ?assertMatch(#{iteration_count := _,
+                   sha := #{salt := _,
+                            server_key := _,
+                            stored_key := _}}, NewScramMap),
     %% even though in db there is old record stored
     OldScram = mnesia:dirty_read({passwd, {U, S}}),
     ?assertMatch([{passwd, _, {scram, _, _, _, _}}], OldScram).
@@ -52,14 +54,29 @@ passwords_in_plain_can_be_converted_to_scram(_C) ->
     AfterMigrationPlain = mnesia:dirty_read({passwd, {U, S}}),
     %% then plain text passwords are converted to new map with sha and sha256
     ?assertMatch([{passwd, _,
-                   #{iteration_count := _, salt := _,
-                     sha := #{server_key := _, stored_key := _},
-                     sha256 := #{server_key := _, stored_key := _}}}], AfterMigrationPlain),
+                   #{iteration_count := _,
+                     sha    := #{salt       := _,
+                                 server_key := _,
+                                 stored_key := _},
+                     sha224 := #{salt       := _,
+                                 server_key := _,
+                                 stored_key := _},
+                     sha256 := #{salt       := _,
+                                 server_key := _,
+                                 stored_key := _},
+                     sha384 := #{salt       := _,
+                                 server_key := _,
+                                 stored_key := _},
+                     sha512 := #{salt       := _,
+                                 server_key := _,
+                                 stored_key := _}}}], AfterMigrationPlain),
     %% and the old scram format remains the same
     AfterMigrationScram = mnesia:dirty_read({passwd, {U2, S2}}),
     ?assertMatch([{passwd, _,
-                 #{iteration_count := _, salt := _,
-                   sha := #{server_key := _, stored_key := _}}}], AfterMigrationScram),
+                 #{iteration_count := _,
+                   sha := #{salt       := _,
+                            server_key := _,
+                            stored_key := _}}}], AfterMigrationScram),
     meck:unload().
 
 gen_user() ->

--- a/test/auth_internal_SUITE.erl
+++ b/test/auth_internal_SUITE.erl
@@ -29,7 +29,7 @@ passwords_as_records_are_still_supported(_C) ->
     NewScramMap = ejabberd_auth_internal:get_password(U, S),
     %% then new map with sha key is returned
     ?assertMatch(#{iteration_count := _,
-                   sha := #{salt := _,
+                   sha := #{salt       := _,
                             server_key := _,
                             stored_key := _}}, NewScramMap),
     %% even though in db there is old record stored


### PR DESCRIPTION
This PR addresses improving best practices for password storage by having different SALT for each password SCRAM hash.

This is according to the XEP-0438

[https://xmpp.org/extensions/xep-0438.html](https://xmpp.org/extensions/xep-0438.html)

Proposed changes include:
* changes in the password format
* updating tests that verify password format
* documentation update in the `SCRAM serialization fromat` section

