### PR TITLE
Refactor mod privacy as handler

### DIFF
--- a/big_tests/tests/privacy_SUITE.erl
+++ b/big_tests/tests/privacy_SUITE.erl
@@ -673,6 +673,7 @@ block_jid_iq(Config) ->
         %% activate it
         Stanza = escalus_stanza:privacy_activate(<<"deny_localhost_iq">>),
         escalus_client:send(Alice, Stanza),
+        escalus:assert(is_iq_result, escalus_client:wait_for_stanza(Alice)),
         timer:sleep(500), %% we must let it sink in
 
         %% bob queries for version and gets an error, Alice doesn't receive the query
@@ -694,7 +695,7 @@ block_jid_iq(Config) ->
         end).
 
 block_jid_all(Config) ->
-    %% unexprected presence unavalable
+    %% unexpected presence unavalable
     mongoose_helper:kick_everyone(),
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
@@ -703,6 +704,7 @@ block_jid_all(Config) ->
         %% Alice blocks Bob
         Stanza = escalus_stanza:privacy_activate(<<"deny_jid_all">>),
         escalus_client:send(Alice, Stanza),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
 
         %% IQ response is blocked;
         %% do magic wait for the request to take effect
@@ -732,6 +734,7 @@ block_jid_all(Config) ->
         %% Just set the toy list and en~sure that only
         %% the notification push comes back.
         privacy_helper:send_set_list(Alice, {<<"deny_client">>, Bob}),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
 
         %% verify
         timer:sleep(?SLEEP_TIME),

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -73,25 +73,6 @@
                     | {'next_state', statename(), state()}
                     | {'next_state', statename(), state(), Timeout :: integer()}.
 
--type blocking_type() :: 'block' | 'unblock'.
-
--type broadcast_type() :: {exit, Reason :: binary()}
-                        | {item, IJID :: jid:simple_jid() | jid:jid(),
-                           ISubscription :: from | to | both | none | remove}
-                        | {privacy_list, PrivList :: mongoose_privacy:userlist(),
-                           PrivListName :: binary()}
-                        | {blocking, UserList :: mongoose_privacy:userlist(), What :: blocking_type(),
-                                     [binary()]}
-                        | unknown.
-
--type broadcast() :: {broadcast, broadcast_type() | mongoose_acc:t()}.
-
--type broadcast_result() :: {new_state, NewState :: state()}
-                          | {exit, Reason :: binary()}
-                          | {send_new, From :: jid:jid(), To :: jid:jid(),
-                             Packet :: exml:element(),
-                             NewState :: state()}.
-
 -type routing_result_atom() :: allow | deny | forbidden | ignore | block | invalid | probe.
 
 -type routing_result() :: {DoRoute :: routing_result_atom(), NewAcc :: mongoose_acc:t(),

--- a/include/mod_privacy.hrl
+++ b/include/mod_privacy.hrl
@@ -35,4 +35,8 @@
 
 -record(userlist, {name = none, list = [], needdb = false }).
 
+-record(privacy_state, {userlist}).
+
+-type privacy_state() :: #privacy_state{}.
+
 

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -80,6 +80,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include("mod_roster.hrl").
+-include_lib("exml/include/exml.hrl").
 
 -export_type([roster/0, sub_presence/0]).
 
@@ -117,7 +118,7 @@
     Acc :: term(),
     LUser :: jid:luser(),
     LServer :: jid:lserver(),
-    Result :: term().
+    Result :: [roster()].
 -callback roster_subscribe_t(LUser, LServer, LJid, SJid) -> Result when
     LUser :: jid:luser(),
     LServer :: jid:lserver(),
@@ -220,7 +221,7 @@ stop(Host) ->
 
 hooks(Host) ->
     [{roster_get, Host, ?MODULE, get_user_roster, 50},
-     {initialise_c2s_state, Host,?MODULE, initialise_state, 50},
+     {initialise_c2s_state, Host, ?MODULE, initialise_state, 50},
      {roster_in_subscription, Host, ?MODULE, in_subscription, 50},
      {roster_out_subscription, Host, ?MODULE, out_subscription, 50},
      {roster_get_subscription_lists, Host, ?MODULE, get_subscription_lists, 50},
@@ -584,28 +585,38 @@ get_subscription_lists(Acc, User, Server) ->
     mongoose_acc:set(roster, subscription_lists, SubLists, Acc).
 
 
-fill_subscription_lists(JID, LServer, [#roster{} = I | Is], F, T, P) ->
+-spec fill_subscription_lists(JID :: jid:jid(),
+                              LServer :: jid:lserver(),
+                              RosterList :: [roster()],
+                              FromSubs :: [jid:simple_jid()],
+                              ToSubs :: [jid:simple_jid()],
+                              PendingSubs :: [exml:element()]) ->
+    {[jid:simple_jid()],
+     [jid:simple_jid()],
+     [exml:element()]}.
+fill_subscription_lists(JID, LServer, [#roster{} = I | Is], FromSubs, ToSubs, PendingSubs) ->
     J = element(3, I#roster.usj),
 
-    NewP = build_pending(I, JID, P),
+    NewP = build_pending(I, JID, PendingSubs),
 
     case I#roster.subscription of
         both ->
-            fill_subscription_lists(JID, LServer, Is, [J | F], [J | T], NewP);
+            fill_subscription_lists(JID, LServer, Is, [J | FromSubs], [J | ToSubs], NewP);
         from ->
-            fill_subscription_lists(JID, LServer, Is, [J | F], T, NewP);
-        to -> fill_subscription_lists(JID, LServer, Is, F, [J | T], NewP);
-        _ -> fill_subscription_lists(JID, LServer, Is, F, T, NewP)
+            fill_subscription_lists(JID, LServer, Is, [J | FromSubs], ToSubs, NewP);
+        to -> fill_subscription_lists(JID, LServer, Is, FromSubs, [J | ToSubs], NewP);
+        _ -> fill_subscription_lists(JID, LServer, Is, FromSubs, ToSubs, NewP)
     end;
-fill_subscription_lists(JID, LServer, [RawI | Is], F, T, P) ->
+fill_subscription_lists(JID, LServer, [RawI | Is], FromSubs, ToSubs, PendingSubs) ->
     I = mod_roster_backend:raw_to_record(LServer, RawI),
     case I of
         %% Bad JID in database:
-        error -> fill_subscription_lists(JID, LServer, Is, F, T, P);
-        _ -> fill_subscription_lists(JID, LServer, [I | Is], F, T, P)
+        error -> fill_subscription_lists(JID, LServer, Is, FromSubs, ToSubs, PendingSubs);
+        _ -> fill_subscription_lists(JID, LServer, [I | Is], FromSubs, ToSubs, PendingSubs)
     end;
-fill_subscription_lists(_, _LServer, [], F, T, P) -> {F, T, P}.
+fill_subscription_lists(_, _LServer, [], FromSubs, ToSubs, PendingSubs) -> {FromSubs, ToSubs, PendingSubs}.
 
+-spec build_pending(roster(), jid:jid(), [exml:element()]) -> [exml:element()].
 build_pending(#roster{ask = Ask} = I, JID, P)
   when Ask == in; Ask == both ->
     Status = case I#roster.askmessage of

--- a/src/mongoose_c2s_privacy.erl
+++ b/src/mongoose_c2s_privacy.erl
@@ -1,0 +1,177 @@
+-module(mongoose_c2s_privacy).
+-author("bartlomiejgorny").
+%% API
+-include("mongoose.hrl").
+-include("mod_privacy.hrl").
+-include("jlib.hrl").
+
+
+-export([initialise_state/1, check_packet/4, check_packet/6]).
+-export([process_privacy_iq/3]).
+-export([update_privacy_list/4]).
+
+%% temporary
+-export([get_privacy_list/1, set_privacy_list/2]).
+
+
+-spec initialise_state(jid:jid()) -> privacy_state().
+initialise_state(JID) ->
+    UserList = mongoose_hooks:privacy_get_user_list(JID#jid.server, #userlist{}, JID#jid.user),
+    #privacy_state{userlist = UserList}.
+
+check_packet(Acc, To, Dir, StateData) ->
+    Jid = ejabberd_c2s_state:jid(StateData),
+    UserList = get_userlist(StateData),
+    mongoose_privacy:privacy_check_packet(Acc,
+                                          ejabberd_c2s_state:server(StateData),
+                                          Jid#jid.user,
+                                          UserList,
+                                          To,
+                                          Dir).
+
+check_packet(Acc, Packet, From, To, Dir, StateData) ->
+    UserList = get_userlist(StateData),
+    Jid = ejabberd_c2s_state:jid(StateData),
+    mongoose_privacy:privacy_check_packet({Acc, Packet},
+                                          ejabberd_c2s_state:server(StateData),
+                                          Jid#jid.user,
+                                          UserList,
+                                          From,
+                                          To,
+                                          Dir).
+
+%% this is called remotely by the process that received an iq
+-spec update_privacy_list(privacy_state(), atom(), term(), ejabberd_c2s:state()) -> privacy_state().
+update_privacy_list(_HandlerState, mod_privacy, {privacy_change, ListName, Userlist}, C2SState) ->
+    JID = ejabberd_c2s_state:jid(C2SState),
+    Server = ejabberd_c2s_state:server(C2SState),
+    Acc = mongoose_acc:new(#{ location => ?LOCATION,
+                              lserver => Server,
+                              element => undefined }),
+    NewPL = mongoose_hooks:privacy_updated_list(Server,
+                                                false,
+                                                get_privacy_list(C2SState),
+                                                Userlist),
+    PrivPushIQ = privacy_list_push_iq(ListName),
+    BareJID = jid:to_bare(JID),
+    PrivPushEl = jlib:replace_from_to(BareJID, JID, jlib:iq_to_xml(PrivPushIQ)),
+    Acc1 = maybe_update_presence(Acc, C2SState, NewPL),
+    _Acc2 = ejabberd_c2s:preprocess_and_ship(Acc1, BareJID, JID, PrivPushEl, C2SState),
+    #privacy_state{userlist = NewPL};
+update_privacy_list(HandlerState, _, _, _) ->
+    HandlerState.
+
+get_userlist(StateData) ->
+    #privacy_state{userlist = UserList} = ejabberd_c2s_state:get_handler_state(mod_privacy, StateData),
+    UserList.
+
+%% temporary
+
+get_privacy_list(StateData) ->
+    case ejabberd_c2s_state:get_handler_state(mod_privacy, StateData) of
+        empty_state -> [];
+        #privacy_state{userlist = UserList} -> UserList
+    end.
+
+set_privacy_list(UserList, StateData) ->
+    ejabberd_c2s_state:set_handler_state(mod_privacy, #privacy_state{userlist = UserList}, StateData).
+
+%% it is not feasible to make this a proper IQ handler, because it requires access to
+%% the c2s state and it has to modify state to make it an active list
+-spec process_privacy_iq(Acc :: mongoose_acc:t(),
+                         To :: jid:jid(),
+                         StateData :: ejabberd_c2s:state()) -> {mongoose_acc:t(), ejabberd_c2s:state()}.
+process_privacy_iq(Acc1, To, StateData) ->
+    case mongoose_iq:info(Acc1) of
+        {#iq{type = Type, sub_el = SubEl} = IQ, Acc2} when Type == get; Type == set ->
+            From = mongoose_acc:from_jid(Acc2),
+            {Acc3, NewStateData} = process_privacy_iq(Acc2, Type, To, StateData),
+            Res = mongoose_acc:get(hook, result,
+                                   {error, mongoose_xmpp_errors:feature_not_implemented()}, Acc3),
+            IQRes = case Res of
+                        {result, Result} ->
+                            IQ#iq{type = result, sub_el = Result};
+                        {result, Result, _} ->
+                            IQ#iq{type = result, sub_el = Result};
+                        {error, Error} ->
+                            IQ#iq{type = error, sub_el = [SubEl, Error]}
+                    end,
+            Acc4 = ejabberd_c2s:preprocess_and_ship(Acc3, To, From, jlib:iq_to_xml(IQRes), StateData),
+            {Acc4, NewStateData};
+        _ ->
+            {Acc1, StateData}
+    end.
+
+-spec process_privacy_iq(Acc :: mongoose_acc:t(),
+                         Type :: get | set,
+                         To :: jid:jid(),
+                         StateData :: ejabberd_c2s:state()) -> {mongoose_acc:t(), ejabberd_c2s:state()}.
+process_privacy_iq(Acc, get, To, StateData) ->
+    From = mongoose_acc:from_jid(Acc),
+    {IQ, Acc1} = mongoose_iq:info(Acc),
+    Acc2 = mongoose_hooks:privacy_iq_get(ejabberd_c2s_state:server(StateData),
+                                         Acc1,
+                                         From, To, IQ,
+                                         get_privacy_list(StateData)),
+    {Acc2, StateData};
+process_privacy_iq(Acc, set, To, StateData) ->
+    From = mongoose_acc:from_jid(Acc),
+    {IQ, Acc1} = mongoose_iq:info(Acc),
+    Acc2 = mongoose_hooks:privacy_iq_set(ejabberd_c2s_state:server(StateData),
+                                         Acc1,
+                                         From, To, IQ),
+    case mongoose_acc:get(hook, result, undefined, Acc2) of
+        {result, _, NewPrivList} ->
+            % we have a new active list which we need to set in c2s state
+            % and send updated presence info if needed
+            Acc3 = maybe_update_presence(Acc2, StateData, NewPrivList),
+            NState = set_privacy_list(NewPrivList, StateData),
+            {Acc3, NState};
+        _ ->
+            % no change in active list; changes to privacy settings have been propagated
+            % by mod_roster hook handlers, and we will receive them presently
+            % as so-called 'routed broadcast'
+            {Acc2, StateData}
+    end.
+
+maybe_update_presence(Acc, StateData, NewList) ->
+    % Our own jid is added to pres_f, even though we're not a "contact", so for
+    % the purposes of this check we don't want it:
+    FromsExceptSelf = mongoose_c2s_presence:get_subscriptions(from_except_self, StateData),
+
+    lists:foldl(
+        fun(T, Ac) ->
+            send_unavail_if_newly_blocked(Ac, StateData, jid:make(T), NewList)
+        end, Acc, FromsExceptSelf).
+
+send_unavail_if_newly_blocked(Acc, StateData,
+                              ContactJID, NewList) ->
+    JID = ejabberd_c2s_state:jid(StateData),
+    Packet = #xmlel{name = <<"presence">>,
+                    attrs = [{<<"type">>, <<"unavailable">>}]},
+    %% WARNING: we can not use accumulator to cache privacy check result - this is
+    %% the only place where the list to check against changes
+    EmptyAcc = mongoose_acc:new(#{ location => ?LOCATION,
+                                   from_jid => JID,
+                                   to_jid => ContactJID,
+                                   lserver => ejabberd_c2s_state:server(StateData),
+                                   element => Packet }),
+    {_, OldResult} = check_packet(EmptyAcc, Packet, JID, ContactJID, out, StateData),
+    {_, NewResult} = check_packet(EmptyAcc, Packet, JID, ContactJID, out,
+                                     set_privacy_list(NewList, StateData)),
+    send_unavail_if_newly_blocked(Acc, OldResult, NewResult, JID,
+                                  ContactJID, Packet).
+
+send_unavail_if_newly_blocked(Acc, allow, deny, From, To, Packet) ->
+    ejabberd_router:route(From, To, Acc, Packet);
+send_unavail_if_newly_blocked(Acc, _, _, _, _, _) ->
+    Acc.
+
+privacy_list_push_iq(PrivListName) ->
+    #iq{type = set, xmlns = ?NS_PRIVACY,
+        id = <<"push", (mongoose_bin:gen_from_crypto())/binary>>,
+        sub_el = [#xmlel{name = <<"query">>,
+                         attrs = [{<<"xmlns">>, ?NS_PRIVACY}],
+                         children = [#xmlel{name = <<"list">>,
+                                            attrs = [{<<"name">>, PrivListName}]}]}]}.
+

--- a/src/mongoose_c2s_privacy.erl
+++ b/src/mongoose_c2s_privacy.erl
@@ -56,7 +56,7 @@ update_privacy_list(_HandlerState, mod_privacy, {privacy_change, ListName, Userl
     BareJID = jid:to_bare(JID),
     PrivPushEl = jlib:replace_from_to(BareJID, JID, jlib:iq_to_xml(PrivPushIQ)),
     Acc1 = maybe_update_presence(Acc, C2SState, NewPL),
-    _Acc2 = ejabberd_c2s:preprocess_and_ship(Acc1, BareJID, JID, PrivPushEl, C2SState),
+    _Acc2 = ejabberd_c2s:send_to_local_user(Acc1, BareJID, JID, PrivPushEl, C2SState),
     #privacy_state{userlist = NewPL};
 update_privacy_list(HandlerState, _, _, _) ->
     HandlerState.
@@ -96,7 +96,7 @@ process_privacy_iq(Acc1, To, StateData) ->
                         {error, Error} ->
                             IQ#iq{type = error, sub_el = [SubEl, Error]}
                     end,
-            Acc4 = ejabberd_c2s:preprocess_and_ship(Acc3, To, From, jlib:iq_to_xml(IQRes), StateData),
+            Acc4 = ejabberd_c2s:send_to_local_user(Acc3, To, From, jlib:iq_to_xml(IQRes), StateData),
             {Acc4, NewStateData};
         _ ->
             {Acc1, StateData}


### PR DESCRIPTION
Includes:
- removing the sm broadcasting (remote hook call used instead)
- moving nearly all privacy and blocking related code to dedicated modules (with just two lines left, because privacy iq handler is a bit unusual)
- minor changes to privacy tests (in a few cases iq result is now received)

