### PR TITLE
SCRAM default password format

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -285,7 +285,7 @@
                                                             {keyfile, \"priv/ssl/fake_key.pem\"}]}]}
        ]}."},
       {mod_offline, "{mod_offline, []},"},
-      {password_format, "{password_format, plain}"},
+      {password_format, "{password_format, scram}"},
       {auth_ldap, ", {ldap_base, \"ou=Users,dc=esl,dc=com\"},
                      {ldap_filter, \"(objectClass=inetOrgPerson)\"}"
       },

--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -229,7 +229,7 @@ not_allowed_registration_cancelation(Config) ->
 
 registration_timeout(Config) ->
     [Alice, Bob] = escalus_users:get_users([alice, bob]),
-		
+
 	%% The first user should be created successfully
 	wait_for_user(Config, Alice, ?REGISTRATION_TIMEOUT),
 
@@ -245,7 +245,7 @@ registration_timeout(Config) ->
 
     %% After timeout, the user should be registered successfully
     wait_for_user(Config, Alice, erlang:round(?REGISTRATION_TIMEOUT * 1.5 * 1000)).
-			
+
 registration_failure_timeout(Config) ->
     timer:sleep(timer:seconds(?REGISTRATION_TIMEOUT + 1)),
     [Alice] = escalus_users:get_users([alice]),
@@ -385,5 +385,3 @@ watcher(Watcher) ->
 
 domain() ->
     ct:get_config({hosts, mim, domain}).
-
-			

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -276,13 +276,22 @@ init_per_testcase(CaseName, Config)
         true -> {skip, vhost_rdbms_incompatible};
         false -> escalus:init_per_testcase(CaseName, Config)
     end;
-init_per_testcase(CaseName, Config)
-    when CaseName == check_password_hash;
-         CaseName == delete_old_users ->
+init_per_testcase(check_password_hash, Config) ->
+    {_, AuthMods} = lists:keyfind(ctl_auth_mods, 1, Config),
+    case lists:member(ejabberd_auth_ldap, AuthMods) of
+        true ->
+            {skip, not_fully_supported_with_ldap};
+        false ->
+            Config1 = mongoose_helper:backup_auth_config(Config),
+            mongoose_helper:set_store_password(plain),
+            Config2 = escalus:create_users(Config1, escalus:get_users([carol])),
+            escalus:init_per_testcase(check_password_hash, Config2)
+    end;
+init_per_testcase(delete_old_users, Config) ->
     {_, AuthMods} = lists:keyfind(ctl_auth_mods, 1, Config),
     case lists:member(ejabberd_auth_ldap, AuthMods) of
         true -> {skip, not_fully_supported_with_ldap};
-        false -> escalus:init_per_testcase(CaseName, Config)
+        false -> escalus:init_per_testcase(delete_old_users, Config)
     end;
 init_per_testcase(CaseName, Config) when CaseName == real_upload_without_content_type;
                                          CaseName == real_upload_with_content_type ->
@@ -300,6 +309,9 @@ end_per_testcase(delete_old_users, Config) ->
                 rpc(mim(), ejabberd_auth, try_register, [Username, Domain, Pass])
         end, Users),
     escalus:end_per_testcase(delete_old_users, Config);
+end_per_testcase(check_password_hash, Config) ->
+    mongoose_helper:restore_auth_config(Config),
+    escalus:delete_users(Config, escalus:get_users([carol]));
 end_per_testcase(CaseName, Config) ->
     %% Because kick_session fails with unexpected stanza received:
     %% <presence from="alicE@localhost/res3"
@@ -408,7 +420,7 @@ change_password(Config) ->
     escalus_client:stop(Config, Alice2).
 
 check_password_hash(Config) ->
-    {User, Domain, Pass} = get_user_data(alice, Config),
+    {User, Domain, Pass} = get_user_data(carol, Config),
     MD5Hash = get_md5(Pass),
     MD5HashBad = get_md5(<<Pass/binary, "bad">>),
     SHAHash = get_sha(Pass),

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -112,12 +112,25 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    escalus:init_per_suite(Config).
+    Config1 = mongoose_helper:backup_auth_config(Config),
+    mongoose_helper:set_store_password(scram),
+    escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
+    mongoose_helper:restore_auth_config(Config),
     escalus:end_per_suite(Config).
 
+init_per_group(login_digest, Config) ->
+    mongoose_helper:set_store_password(plain),
+    case mongoose_helper:supports_sasl_module(cyrsasl_digest) of
+        false ->
+            mongoose_helper:set_store_password(scram),
+            {skip, "digest password type not supported"};
+        true ->
+            Config1 = configure_digest(Config),
+            escalus:create_users(Config1, escalus:get_users([alice, bob]))
+    end;
 init_per_group(GroupName, Config) when
       GroupName == login_scram; GroupName == login_scram_store_plain ->
     case are_sasl_scram_modules_supported() of
@@ -134,7 +147,6 @@ init_per_group(login_scram_tls, Config) ->
             {skip, "scram password type not supported"};
         true ->
             Config1 = config_ejabberd_node_tls(Config),
-            config_password_format(login_scram),
             Config2 = create_tls_users(Config1),
             assert_password_format(scram, Config2)
     end;
@@ -148,26 +160,20 @@ init_per_group(login_specific_scram, Config) ->
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
+end_per_group(login_digest, Config) ->
+    restore_config(Config),
+    mongoose_helper:set_store_password(scram),
+    escalus:delete_users(Config, escalus:get_users([alice, bob]));
 end_per_group(GroupName, Config) when
     GroupName == login_scram; GroupName == login_specific_scram ->
-    set_store_password(plain),
+    mongoose_helper:set_store_password(scram),
     escalus:delete_users(Config, escalus:get_users([alice, bob, neustradamus]));
 end_per_group(login_scram_tls, Config) ->
     restore_config(Config),
-    set_store_password(plain),
     delete_tls_users(Config);
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
-init_per_testcase(CaseName, Config) when
-      CaseName =:= log_one_digest; CaseName =:= log_non_existent_digest ->
-    case mongoose_helper:supports_sasl_module(cyrsasl_digest) of
-        false ->
-            {skip, "digest password type not supported"};
-        true ->
-            Config1 = configure_digest(Config),
-            escalus:init_per_testcase(CaseName, Config1)
-    end;
 init_per_testcase(CaseName, Config) when
       CaseName =:= log_one_scram_sha1; CaseName =:= log_non_existent_scram ->
     case mongoose_helper:supports_sasl_module(cyrsasl_scram_sha1) of
@@ -193,10 +199,6 @@ init_per_testcase(CaseName, Config) ->
 
 end_per_testcase(message_zlib_limit, Config) ->
     escalus:delete_users(Config, escalus:get_users([hacker]));
-end_per_testcase(CaseName, Config) when
-    CaseName =:= log_one_digest; CaseName =:= log_non_existent_digest ->
-    restore_config(Config),
-    escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
@@ -395,6 +397,7 @@ configure_digest(Config) ->
     ejabberd_node_utils:backup_config_file(Config1),
     ejabberd_node_utils:modify_config_file([{sasl_mechanisms, "{sasl_mechanisms, [cyrsasl_digest]}."}], Config1),
     ejabberd_node_utils:restart_application(mongooseim),
+    mongoose_helper:set_store_password(plain),
     Config1.
 
 restore_config(Config) ->
@@ -415,17 +418,10 @@ create_tls_users(Config) ->
 delete_tls_users(Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, neustradamus])).
 
-set_store_password(Type) ->
-    XMPPDomain = escalus_ejabberd:unify_str_arg(
-                   ct:get_config({hosts, mim, domain})),
-    AuthOpts = rpc(mim(), ejabberd_config, get_local_option, [{auth_opts, XMPPDomain}]),
-    NewAuthOpts = lists:keystore(password_format, 1, AuthOpts, {password_format, Type}),
-    rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, XMPPDomain}, NewAuthOpts]).
-
 config_password_format(login_scram) ->
-    set_store_password(scram);
+    mongoose_helper:set_store_password(scram);
 config_password_format(_) ->
-    set_store_password(plain).
+    mongoose_helper:set_store_password(plain).
 
 assert_password_format(GroupName, Config) ->
     Users = proplists:get_value(escalus_users, Config),
@@ -471,22 +467,22 @@ modify_acl_for_blocking(Method, Spec) ->
     rpc(mim(), acl, Method, [Domain, blocked, {user, Lower}]).
 
 configure_and_log_scram(Config, Sha, Mech) ->
-    set_store_password({scram, [Sha]}),
+    mongoose_helper:set_store_password({scram, [Sha]}),
     assert_password_format({scram, Sha}, Config),
     log_one([{escalus_auth_method, Mech} | Config]).
 
 configure_and_log_scram_plus(Config, Sha, Mech) ->
-    set_store_password({scram, [Sha]}),
+    mongoose_helper:set_store_password({scram, [Sha]}),
     assert_password_format({scram, Sha}, Config),
     log_one_scram_plus([{escalus_auth_method, Mech} | Config]).
 
 configure_and_fail_log_scram(Config, Sha, Mech) ->
-    set_store_password({scram, [Sha]}),
+    mongoose_helper:set_store_password({scram, [Sha]}),
     assert_password_format({scram, Sha}, Config),
     {expected_challenge, _, _} = fail_log_one([{escalus_auth_method, Mech} | Config]).
 
 configure_scram_plus_and_fail_log_scram(Config, Sha, Mech) ->
-    set_store_password({scram, [Sha]}),
+    mongoose_helper:set_store_password({scram, [Sha]}),
     assert_password_format({scram, Sha}, Config),
     {expected_challenge, _, _} = fail_log_one_scram_plus([{escalus_auth_method, Mech} | Config]).
 

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -33,6 +33,8 @@
 -export([wait_for_route_message_count/2]).
 -export([wait_for_pid_to_die/1]).
 -export([supports_sasl_module/1]).
+-export([backup_auth_config/1, restore_auth_config/1]).
+-export([set_store_password/1]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
@@ -405,3 +407,20 @@ wait_for_pid_to_die(Pid) ->
 supports_sasl_module(Module) ->
     Host = ct:get_config({hosts, mim, domain}),
     rpc(mim(), ejabberd_auth, supports_sasl_module, [Host, Module]).
+
+backup_auth_config(Config) ->
+    XMPPDomain = escalus_ejabberd:unify_str_arg(ct:get_config({hosts, mim, domain})),
+    AuthOpts = rpc(mim(), ejabberd_config, get_local_option, [{auth_opts, XMPPDomain}]),
+    [{auth_opts, AuthOpts} | Config].
+
+restore_auth_config(Config) ->
+    XMPPDomain = escalus_ejabberd:unify_str_arg(ct:get_config({hosts, mim, domain})),
+    AuthOpts = proplists:get_value(auth_opts, Config),
+    rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, XMPPDomain}, AuthOpts]).
+
+set_store_password(Type) ->
+    XMPPDomain = escalus_ejabberd:unify_str_arg(
+                   ct:get_config({hosts, mim, domain})),
+    AuthOpts = rpc(mim(), ejabberd_config, get_local_option, [{auth_opts, XMPPDomain}]),
+    NewAuthOpts = lists:keystore(password_format, 1, AuthOpts, {password_format, Type}),
+    rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, XMPPDomain}, NewAuthOpts]).

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -149,7 +149,7 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
              MongooseIM supports SHA-1, SHA-224, SHA-256 and SHA-512 for SCRAM hashing which can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration.
              The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
              * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha224, sha256, sha384, sha512]}` are equivalent configurations)
-             * **Default:** `plain` (for compatibility reasons, might change soon)
+             * **Default:** `scram`
 
         * **auth_scram_iterations**
              * **Description:** Hash function round count. The higher the value, the more difficult breaking the hashes is. We advise against setting it too low.

--- a/doc/migrations/3.6.0_3.6.x.md
+++ b/doc/migrations/3.6.0_3.6.x.md
@@ -21,14 +21,32 @@ You can achieve the same result of allowing the usage of SHA-1 with SCRAM authen
 
 You can also specify a list of all supported SCRAM-SHA mechanisms with:
 
-`{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512]}`
+`{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha256_plus, cyrsasl_scram_sha384_plus, cyrsasl_scram_sha512_plus]}`
 
-Before setting up this configuration, please make sure that the client application is capable authenticating with a selected set of authentication mechanisms.
+Before setting up this configuration, please make sure that the client application is capable of authenticating with a selected set of authentication mechanisms.
 For more details please refer to the [authentication](../../Advanced-configuration#authentication) section.
 
 ### SCRAM password format
 
 To complement the extensions of the authentication mechanisms, the SCRAM password format was also updated.
+Please note that SCRAM is now the default password format.
+While it is still possible to configure the password storage in plaintext format, we highly discourage doing so for security reasons.
+Changing the default of this option can lead to unexpected behaviours, so if after the upgrade you encounter issues with authenticating the users, please check the conifg file.
+If you are missing any of the following configuration lines:
+
+`{password_format, scram}` or `{password_format, plain}`
+
+it means that you were using the default plaintext format.
+
+Since the default of the password format has changed, your MongooseIM server thinks that the plaintext passwords are stored as SCRAM hashes.
+This can lead to users failing to authenticate.
+
+If you are still using the plaintext password format, please consider migrating your password storage to store scram hashes instead.
+Using the plaintext password format is still possible to support legacy installations and to ease the debuging while developing new features.
+Should you want to continue using the plaintext password format please add the following in the `auth_opts`:
+
+`{password_format, plain}`
+
 Legacy plaintext and SCRAM formats are still supported.
 Nonetheless, please note that if you were using SCRAM as a password format, this meant that SHA-1 was used as the hashing algorithm.
 This allowed authenticating with PLAINTEXT and SCRAM-SHA-1.
@@ -77,6 +95,6 @@ ALTER TABLE mam_message ADD origin_id nvarchar(250) NULL;
 CREATE INDEX i_mam_message_username_jid_id ON mam_message (user_id, remote_bare_jid, id);
 CREATE INDEX i_mam_message_username_jid_origin_id ON mam_message (user_id, remote_bare_jid, origin_id);
 
-ALTER TABLE mam_muc_message ADD origin_id nvarchar(250) NULL; 
+ALTER TABLE mam_muc_message ADD origin_id nvarchar(250) NULL;
 CREATE INDEX i_mam_muc_message_room_id_sender_id_origin_id ON mam_muc_message (room_id, sender_id, origin_id);
 ```

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -344,8 +344,8 @@
 {auth_method, {{{auth_method}}} }.
 {auth_opts, [
              %% Store the plain passwords or hashed for SCRAM:
-             %% {password_format, plain} % default
-             %% {password_format, scram}
+             %% {password_format, scram} % default
+             %% {password_format, plain}
              {{{password_format}}}
              %% {scram_iterations, 4096} % default
              {{{scram_iterations}}}

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -26,6 +26,7 @@
                                         {anonymous_protocol, both}]}." }.
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
+{password_format, "{password_format, {scram, [sha256]}}"}.
 {auth_ldap,""}.
 {s2s_addr, "{ {s2s_addr, \"fed1\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -46,8 +46,8 @@
 
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
-{password_format, "{password_format, plain}"}.
-{cyrsasl_external, ",{cyrsasl_external, standard}"}.
+{password_format, "{password_format, scram}"}.
+{cyrsasl_external, ", {cyrsasl_external, standard}"}.
 {tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls,"}.
 {tls_module, ""}.
 {https_config, "{ssl, [{certfile, \"priv/ssl/fake_cert.pem\"}, {keyfile, \"priv/ssl/fake_key.pem\"}, {password, \"\"}]},"}. %% Applies to Websockets, BOSH and metrics; PEM format

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -65,7 +65,10 @@ set_password(LUser, LServer, Password) ->
             {error, invalid_password};
         Password ->
             User = mongoose_riak:fetch_type(bucket_type(LServer), LUser),
-            do_set_password(User, LUser, LServer, Password)
+            do_set_password(User, LUser, LServer, Password);
+        {<<>>, Scram} ->
+            User = mongoose_riak:fetch_type(bucket_type(LServer), LUser),
+            do_set_password(User, LUser, LServer, {<<>>, Scram})
     end.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -106,10 +106,10 @@ mask(Key, Data) ->
     <<C:KeySize>>.
 
 enabled(Host) ->
-    case ejabberd_auth:get_opt(Host, password_format) of
-        scram -> true;
-        {scram, _ScramSha} -> true;
-        _ -> false
+    case ejabberd_auth:get_opt(Host, password_format, scram) of
+        plain -> false;
+        {scram, _Sha} -> true;
+        scram -> true
     end.
 
 enabled(Host, cyrsasl_scram_sha1)   -> is_password_format_allowed(Host, sha);
@@ -125,8 +125,7 @@ enabled(Host, cyrsasl_scram_sha512_plus) -> is_password_format_allowed(Host, sha
 enabled(_Host, _Mechanism) -> false.
 
 is_password_format_allowed(Host, Sha) ->
-    case ejabberd_auth:get_opt(Host, password_format) of
-        undefined -> true;
+    case ejabberd_auth:get_opt(Host, password_format, scram) of
         plain -> true;
         scram -> true;
         {scram, ConfiguredSha} -> lists:member(Sha, ConfiguredSha)

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -240,7 +240,7 @@ creds_with_cert(Config, Username) ->
 meck_config(Config) ->
     meck:unload(),
     ScramOpts = case lists:keyfind(scram_group, 1, Config) of
-                    {_, true} -> [{password_format, scram}];
+                    {_, false} -> [{password_format, plain}];
                     _ -> []
                 end,
     meck:new(ejabberd_config),


### PR DESCRIPTION
This PR addresses changing default password format to SCRAM.

Proposed changes include:
* changing default password format
* refactoring tests that were verifying with plaintext as default
* documentation update

