### PR TITLE
Restore previous ordering of roster-related stanzas

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -681,21 +681,12 @@ presence_after_add_rosteritem(Config) ->
          end).
 
 push_roster(Config) ->
-    % subscribe Alice to all contacts from the file
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
                 BobJid = escalus_users:get_jid(Config, bob),
                 {AliceName, Domain, _} = get_user_data(alice, Config),
                 TemplatePath = escalus_config:get_config(roster_template, Config),
 
                 {_, 0} = ejabberdctl("push_roster", [TemplatePath, AliceName, Domain], Config),
-                Sets = escalus:wait_for_stanzas(Alice, 4),
-                % four new contacts, nobody is online
-                escalus:assert_many([is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set
-                                    ],
-                                   Sets),
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster1 = escalus:wait_for_stanza(Alice),
                 escalus:assert(is_roster_result, Roster1),
@@ -877,26 +868,10 @@ process_rosteritems_delete_advanced2(Config) ->
     end).
 
 push_roster_all(Config) ->
-    % take the roster file, subscribe everybody to everybody
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
                 TemplatePath = escalus_config:get_config(roster_template, Config),
 
                 {_, 0} = ejabberdctl("push_roster_all", [TemplatePath], Config),
-                SetsAlice = escalus:wait_for_stanzas(Alice, 5),
-                % four new contacts, one is online so we receive one presence
-                escalus:assert_many([is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set,
-                                     is_presence ],
-                                    SetsAlice),
-                SetsBob = escalus:wait_for_stanzas(Bob, 5),
-                escalus:assert_many([is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set,
-                                     is_presence ],
-                                    SetsBob),
 
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster1 = escalus:wait_for_stanza(Alice),
@@ -915,7 +890,6 @@ push_roster_all(Config) ->
         end).
 
 push_roster_alltoall(Config) ->
-    % subscribe everybody to everybody else system-wide
     escalus:story(Config, [{alice, 1}], fun(Alice) ->
                 BobJid = escalus_users:get_jid(Config, bob),
                 MikeJid = escalus_users:get_jid(Config, mike),
@@ -923,11 +897,6 @@ push_roster_alltoall(Config) ->
                 {_, Domain, _} = get_user_data(alice, Config),
 
                 {_, 0} = ejabberdctl("push_roster_alltoall", [Domain, "MyGroup"], Config),
-                SetsAlice = escalus:wait_for_stanzas(Alice, 3),
-                escalus:assert_many([is_roster_set,
-                                     is_roster_set,
-                                     is_roster_set],
-                                    SetsAlice),
 
                 escalus:send(Alice, escalus_stanza:roster_get()),
                 Roster = escalus:wait_for_stanza(Alice),

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -24,8 +24,6 @@
                              require_rpc_nodes/1,
                              rpc/4]).
 
--import(mongoose_helper, [check_subscription_stanzas/2, check_subscription_stanzas/3]).
-
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -238,18 +236,19 @@ invisible_presence(Config) ->
         escalus:send(Bob, escalus_stanza:roster_add_contact(Alice,
                                                             [<<"enemies">>],
                                                              <<"Alice">>)),
-        Response1 = escalus:wait_for_stanzas(Bob, 2),
-        escalus:assert_many([is_roster_set, is_iq_result], Response1),
-        [PushReqB] = lists:filter(fun(S) -> escalus_pred:is_roster_set(S) end, Response1),
+        PushReqB = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_roster_set, PushReqB),
         escalus:send(Bob, escalus_stanza:iq_result(PushReqB)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
         escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
-        Stanzas = escalus:wait_for_stanzas(Alice, 3),
+        Stanzas = escalus:wait_for_stanzas(Alice, 2),
 
-        check_subscription_stanzas(Stanzas, <<"subscribed">>, <<"available">>),
+        check_subscription_stanzas(Stanzas, <<"subscribed">>),
+        escalus:assert(is_presence, escalus:wait_for_stanza(Alice)),
 
         %% Bob receives roster push
         PushReqB1 = escalus:wait_for_stanza(Bob),
@@ -344,18 +343,19 @@ versioning(Config) ->
         Stanza = escalus_stanza:roster_add_contact(Bob, bobs_default_groups(),
                                                    bobs_default_name()),
         escalus:send(Alice, Stanza),
-        Received = escalus:wait_for_stanzas(Alice, 3),
+        Received = escalus:wait_for_stanzas(Alice, 2),
 
         escalus:assert_many([is_roster_set, is_iq_result], Received),
 
-        [RosterSet] = [R || R <- Received, escalus_pred:is_roster_set(R)],
+        RosterSet = hd(Received),
 
         Ver2 = exml_query:path(RosterSet, [{element, <<"query">>}, {attr, <<"ver">>}]),
 
         true = Ver2 /= undefined,
 
-        escalus:assert(count_roster_items, [1], RosterSet),
-        escalus:send(Alice, escalus_stanza:iq_result(RosterSet)),
+        Result = hd([R || R <- Received, escalus_pred:is_roster_set(R)]),
+        escalus:assert(count_roster_items, [1], Result),
+        escalus:send(Alice, escalus_stanza:iq_result(Result)),
 
         %% check roster, send old ver
         escalus:send(Alice, escalus_stanza:roster_get(Ver)),
@@ -411,19 +411,20 @@ subscribe(Config) ->
         escalus:send(Bob, escalus_stanza:roster_add_contact(Alice,
                                                             [<<"enemies">>],
                                                              <<"Alice">>)),
-        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
         PushReqB = escalus:wait_for_stanza(Bob),
         escalus:assert(is_roster_set, PushReqB),
         escalus:send(Bob, escalus_stanza:iq_result(PushReqB)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
         escalus:send(Bob, escalus_stanza:presence_direct(AliceJid,
                      <<"subscribed">>)),
 
         %% Alice receives subscribed
-        Stanzas = escalus:wait_for_stanzas(Alice, 3),
+        Stanzas = escalus:wait_for_stanzas(Alice, 2),
 
-        check_subscription_stanzas(Stanzas, <<"subscribed">>, <<"available">>),
+        check_subscription_stanzas(Stanzas, <<"subscribed">>),
+        escalus:assert(is_presence, escalus:wait_for_stanza(Alice)),
 
         %% Bob receives roster push
         PushReqB1 = escalus:wait_for_stanza(Bob),
@@ -571,17 +572,18 @@ unsubscribe(Config) ->
         escalus:send(Bob, escalus_stanza:roster_add_contact(Alice,
                                                             [<<"enemies">>],
                                                              <<"Alice">>)),
-
-        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
         PushReqB = escalus:wait_for_stanza(Bob),
         escalus:send(Bob, escalus_stanza:iq_result(PushReqB)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
         escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
-        Stanzas = escalus:wait_for_stanzas(Alice, 3),
-        check_subscription_stanzas(Stanzas, <<"subscribed">>, <<"available">>),
+        Stanzas = escalus:wait_for_stanzas(Alice, 2),
+
+        check_subscription_stanzas(Stanzas, <<"subscribed">>),
+        escalus:assert(is_presence, escalus:wait_for_stanza(Alice)),
 
         %% Bob receives roster push
         PushReqB1 = escalus:wait_for_stanza(Bob),
@@ -590,16 +592,19 @@ unsubscribe(Config) ->
         %% Alice sends unsubscribe
         escalus:send(Alice, escalus_stanza:presence_direct(BobJid, <<"unsubscribe">>)),
 
-        Stanzas1 = escalus:wait_for_stanzas(Alice, 2),
-        escalus:assert_many([is_roster_set, fun(S) -> escalus_pred:is_presence_with_type(<<"unavailable">>, S) end],
-                            Stanzas1),
+        PushReqA2 = escalus:wait_for_stanza(Alice),
+        escalus_assert:is_roster_set(PushReqA2),
+        escalus:send(Alice, escalus_stanza:iq_result(PushReqA2)),
 
         %% Bob receives unsubscribe
 
         StanzasB = escalus:wait_for_stanzas(Bob, 2),
+
         check_subscription_stanzas(StanzasB, <<"unsubscribe">>),
-        
-        ok
+
+        %% Alice receives unsubscribed
+        escalus:assert(is_presence_with_type, [<<"unavailable">>],
+                       escalus:wait_for_stanza(Alice))
     end).
 
 remove_unsubscribe(Config) ->
@@ -622,17 +627,19 @@ remove_unsubscribe(Config) ->
         escalus:send(Bob, escalus_stanza:roster_add_contact(Alice,
                                                             [<<"enemies">>],
                                                             <<"Alice">>)),
-        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
         PushReqB = escalus:wait_for_stanza(Bob),
         escalus:send(Bob, escalus_stanza:iq_result(PushReqB)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
         %% Bob sends subscribed presence
         escalus:send(Bob, escalus_stanza:presence_direct(AliceJid, <<"subscribed">>)),
 
         %% Alice receives subscribed
-        Stanzas = escalus:wait_for_stanzas(Alice, 3),
+        Stanzas = [escalus:wait_for_stanza(Alice),
+                   escalus:wait_for_stanza(Alice)],
 
-        check_subscription_stanzas(Stanzas, <<"subscribed">>, <<"available">>),
+        check_subscription_stanzas(Stanzas, <<"subscribed">>),
+        escalus:assert(is_presence, escalus:wait_for_stanza(Alice)),
 
         %% Bob receives roster push
         PushReqB1 = escalus:wait_for_stanza(Bob),
@@ -673,6 +680,12 @@ add_sample_contact(Alice, Bob) ->
     escalus:assert(count_roster_items, [1], Result),
     escalus:send(Alice, escalus_stanza:iq_result(Result)).
 
+check_subscription_stanzas(Stanzas, Type) ->
+    IsPresWithType = fun(S) ->
+                         escalus_pred:is_presence_with_type(Type, S)
+                     end,
+    escalus:assert_many([is_roster_set, IsPresWithType], Stanzas).
+
 remove_roster(Config, UserSpec) ->
     [Username, Server, _Pass] = [escalus_ejabberd:unify_str_arg(Item) ||
                                  Item <- escalus_users:get_usp(Config, UserSpec)],
@@ -712,6 +725,7 @@ check_roster_count(User, ExpectedCount) ->
     % the user sends get_roster iq
     escalus_client:send(User, escalus_stanza:roster_get()),
     Roster = escalus_client:wait_for_stanza(User),
+    ct:pal("Roster: ~p", [Roster]),
     % Roster contains all created users excluding user
     escalus:assert(is_roster_result, Roster),
     escalus:assert(count_roster_items, [ExpectedCount], Roster).

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -999,10 +999,10 @@ add_contact_and_invite(Config) ->
             % adds him to her contacts
             escalus:send(Alice, escalus_stanza:roster_add_contact(Bob,
                          [], <<"Bob">>)),
-            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
             PushReqB = escalus:wait_for_stanza(Alice),
             escalus:assert(is_roster_set, PushReqB),
             escalus:send(Alice, escalus_stanza:iq_result(PushReqB)),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
             %% Alice sends subscribed presence
             escalus:send(Alice,
                          escalus_stanza:presence_direct(
@@ -1011,8 +1011,9 @@ add_contact_and_invite(Config) ->
             %% Wait for push before trying to query endpoint
             %% If we just call endpoint,
             %% the "subscribed" stanza can not yet be processed.
-            PushAndPresence = escalus:wait_for_stanzas(Bob, 3),
-            escalus:assert_many([is_roster_set, is_presence, is_presence], PushAndPresence),
+            Push3 = escalus:wait_for_stanza(Bob),
+            ct:log("Push3 ~p", [Push3]),
+            escalus:assert(is_roster_set, Push3),
 
             % now check Bob's roster
             {?OK, R4} = gett(client, "/contacts", BCred),

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -54,8 +54,7 @@
                                    _Group}.
 -type subs() :: atom() | binary().
 
--type push_action() :: remove
-                       | none
+-type push_action() :: none
                        | {add, Nick :: binary(), Subs :: subs(),
    Group :: binary() | string()}.
 -type delete_action() :: {'delete', Subs :: [atom()], Asks :: [atom()],
@@ -352,11 +351,7 @@ build_roster_item(U, S, {add, Nick, Subs, Group}) ->
                      {<<"name">>, Nick},
                      {<<"subscription">>, Subs}],
             children = [#xmlel{name = <<"group">>, children = [#xmlcdata{content = Group}]}]
-    };
-build_roster_item(U, S, remove) ->
-    #xmlel{ name = <<"item">>,
-            attrs = [{<<"jid">>, jid:to_binary(jid:make(U, S, <<"">>))},
-                     {<<"subscription">>, <<"remove">>}]}.
+    }.
 
 %%-----------------------------
 %% Purge roster items

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1184,6 +1184,13 @@ handle_incoming_message({run_remote_hook, HandlerName, Args}, StateName, StateDa
                        [HandlerName, Args, HandlerState, E]),
             fsm_next_state(StateName,
                            StateData);
+        {update_buffers, NewHandlerState, NewStateData} ->
+            % if a handler sent some stanzas directly it has to pass updated state like this
+            % so that we update stream management buffers
+            StateData1 = StateData#state{stream_mgmt_buffer_size = NewStateData#state.stream_mgmt_buffer_size,
+                                         stream_mgmt_buffer = NewStateData#state.stream_mgmt_buffer},
+            fsm_next_state(StateName,
+                           ejabberd_c2s_state:set_handler_state(HandlerName, NewHandlerState, StateData1));
         NewHandlerState ->
             fsm_next_state(StateName,
                            ejabberd_c2s_state:set_handler_state(HandlerName, NewHandlerState, StateData))

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1184,13 +1184,11 @@ handle_incoming_message({run_remote_hook, HandlerName, Args}, StateName, StateDa
                        [HandlerName, Args, HandlerState, E]),
             fsm_next_state(StateName,
                            StateData);
-        {update_buffers, NewHandlerState, NewStateData} ->
+        {update_c2s_state, NewHandlerState, NewStateData} ->
             % if a handler sent some stanzas directly it has to pass updated state like this
             % so that we update stream management buffers
-            StateData1 = StateData#state{stream_mgmt_buffer_size = NewStateData#state.stream_mgmt_buffer_size,
-                                         stream_mgmt_buffer = NewStateData#state.stream_mgmt_buffer},
             fsm_next_state(StateName,
-                           ejabberd_c2s_state:set_handler_state(HandlerName, NewHandlerState, StateData1));
+                           ejabberd_c2s_state:set_handler_state(HandlerName, NewHandlerState, NewStateData));
         NewHandlerState ->
             fsm_next_state(StateName,
                            ejabberd_c2s_state:set_handler_state(HandlerName, NewHandlerState, StateData))

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -886,7 +886,7 @@ send_presence_type(From, To, Type) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% used for testing only - should be removed
+%% used by ejabberdctl
 set_items(User, Server, SubEl) ->
     #xmlel{children = Els} = SubEl,
     LUser = jid:nodeprep(User),

--- a/src/mongoose_c2s_presence.erl
+++ b/src/mongoose_c2s_presence.erl
@@ -315,7 +315,7 @@ roster_change(Item, StateData, C2SState) ->
     #roster{jid = IJID, subscription = ISubscription} = Item,
     {BecomeAvailable, BecomeUnavailable, NState} = do_roster_change(IJID, ISubscription, From, StateData),
     send_updated_presence(BecomeAvailable, BecomeUnavailable, From, To, C2SState),
-    send_roster_iq(From, Item),
+    send_roster_iq(From, Item, C2SState),
     NState.
 
 send_updated_presence(true, _, From, To, C2SState) ->
@@ -338,7 +338,7 @@ send_updated_presence(_, true, From, To, C2SState) ->
 send_updated_presence(_, _, _From, _To, _C2SState) ->
     ok.
 
-send_roster_iq(From, Item) ->
+send_roster_iq(From, Item, C2SState) ->
     Server = From#jid.lserver,
     LUser = From#jid.luser,
     RosterVersion = case mod_roster:roster_versioning_enabled(Server) of
@@ -360,7 +360,7 @@ send_roster_iq(From, Item) ->
                 [#xmlel{name = <<"query">>,
                         attrs = [{<<"xmlns">>, ?NS_ROSTER} | ExtraAttrs],
                         children = [mod_roster:item_to_xml(Item)]}]},
-    ejabberd_router:route(jid:to_bare(From), From, jlib:iq_to_xml(ResIQ)).
+    ejabberd_c2s:send_to_local_user(jid:to_bare(From), From, jlib:iq_to_xml(ResIQ), C2SState).
 
 do_roster_change(IJID, ISubscription, OwnerJid, StateData) ->
     LIJID = jid:to_lower(IJID),

--- a/src/mongoose_c2s_presence.erl
+++ b/src/mongoose_c2s_presence.erl
@@ -308,7 +308,7 @@ pack_string(String, Pack) ->
 
 -spec roster_change(Item :: roster(),
                     StateData :: roster_state(),
-                    State :: ejabberd_c2s:state()) -> {update_buffers, roster_state(), ejabberd_c2s:state()}.
+                    State :: ejabberd_c2s:state()) -> {update_c2s_state, roster_state(), ejabberd_c2s:state()}.
 roster_change(Item, StateData, C2SState) ->
     From = ejabberd_c2s_state:jid(C2SState),
     To = jid:make(Item#roster.jid),
@@ -317,7 +317,7 @@ roster_change(Item, StateData, C2SState) ->
     send_updated_presence(BecomeAvailable, BecomeUnavailable, From, To, C2SState),
     C2SState1 = send_roster_iq(From, Item, C2SState),
     % because we send iq from this process and have to update stream management buffer
-    {update_buffers, NState, C2SState1}.
+    {update_c2s_state, NState, C2SState1}.
 
 send_updated_presence(true, _, From, To, C2SState) ->
     P = get_last_presence(C2SState),

--- a/src/mongoose_c2s_presence.erl
+++ b/src/mongoose_c2s_presence.erl
@@ -308,7 +308,7 @@ pack_string(String, Pack) ->
 
 -spec roster_change(Item :: roster(),
                     StateData :: roster_state(),
-                    State :: ejabberd_c2s:state()) -> roster_state().
+                    State :: ejabberd_c2s:state()) -> {update_buffers, roster_state(), ejabberd_c2s:state()}.
 roster_change(Item, StateData, C2SState) ->
     From = ejabberd_c2s_state:jid(C2SState),
     To = jid:make(Item#roster.jid),


### PR DESCRIPTION
This PR introduces a new API function of ejabberd_c2s, called `send_to_local_user`. It is meant to be used by modules which want to send a stanza to the user of the current c2s process. Instead of using `ejabberd_router:route`, they can now send a stanza immediately, which helps ensure proper ordering of stanzas. 

Tests are reverted to what they were before mod_roster refactoring, and they are supposed to pass.

