### PR TITLE
Refactoring auth_opts in the config file

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -285,7 +285,7 @@
                                                             {keyfile, \"priv/ssl/fake_key.pem\"}]}]}
        ]}."},
       {mod_offline, "{mod_offline, []},"},
-      {cyrsasl_external, "{cyrsasl_external, standard}"}, % just to put a term before 'auth_ldap'
+      {password_format, "{password_format, plain}"},
       {auth_ldap, ", {ldap_base, \"ou=Users,dc=esl,dc=com\"},
                      {ldap_filter, \"(objectClass=inetOrgPerson)\"}"
       },

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -160,7 +160,7 @@ modify_config_and_restart(CyrsaslExternalConfig, Config) ->
 			                      "{keyfile, \"priv/ssl/fake_key.pem\"}, {password, \"\"},"
 				              "{verify, verify_peer}," ++ VerifyMode ++
 					      "{cacertfile, \"" ++ CACertFile ++ "\"}]},"},
-                       {cyrsasl_external, "{cyrsasl_external," ++ CyrsaslExternalConfig ++ "}"},
+                       {cyrsasl_external, ", {cyrsasl_external," ++ CyrsaslExternalConfig ++ "}"},
 		       {sasl_mechanisms, "{sasl_mechanisms, [cyrsasl_external]}."} | AuthMethods],
     ejabberd_node_utils:modify_config_file(NewConfigValues, Config),
     ejabberd_node_utils:restart_application(mongooseim).

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -356,7 +356,7 @@
              %% auth_http requires {http, Host | global, auth, ..., ...} outgoing pool.
              %%
              %% For auth_external
-             {{{ext_auth_script}}}
+             %% {extauth_program, "/path/to/authentication/script"}
              %%
              %% For auth_jwt
              %% {jwt_secret_source, "/path/to/file"},

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -46,8 +46,8 @@
 
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
-{cyrsasl_external, "{cyrsasl_external, standard}"}.
-{ext_auth_script, "%%{extauth_program, \"/path/to/authentication/script\"}."}.
+{password_format, "{password_format, plain}"}.
+{cyrsasl_external, ",{cyrsasl_external, standard}"}.
 {tls_config, "{certfile, \"priv/ssl/fake_server.pem\"}, starttls,"}.
 {tls_module, ""}.
 {https_config, "{ssl, [{certfile, \"priv/ssl/fake_cert.pem\"}, {keyfile, \"priv/ssl/fake_key.pem\"}, {password, \"\"}]},"}. %% Applies to Websockets, BOSH and metrics; PEM format


### PR DESCRIPTION
This PR addresses refactoring of the `auth_opts` list in the config file. `auth_opts` is a list of options usually with few elements. 

Problem example - adding `{{{password_format}}}`
* This should be achieved by e.g. `{password_format, "{password_format, plain},"}` but if it happened that it was the only element of that list, the tailing coma resulted in the syntax error.
* The problem is that some test presets have something in this list while other don't. Either adding this element with tailing coma or without it, was resulting somewhere as a syntax error of the config file.

The changes include:
* Adding `{password_format, plain}` to `auth_opts` - default password_format to be explicitly put as part of configuration
* It will be added as `{password_format, "{password_format, plain}"}.` - without tailing coma
* All other `auth_opts` that will be added for some presets/nodes will be prefixed with `,` 
* Removing `{{{ext_auth_script}}}` form `vars.config` as it was not used anywhere in the code. Sample usage was added explicitly as a comment to `mognooseim.cfg`

