### PR TITLE
SCRAM iteration count default increased to 10k

### DIFF
--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -147,6 +147,7 @@ init_per_group(login_scram_tls, Config) ->
             {skip, "scram password type not supported"};
         true ->
             Config1 = config_ejabberd_node_tls(Config),
+            config_password_format(login_scram_tls),
             Config2 = create_tls_users(Config1),
             assert_password_format(scram, Config2)
     end;
@@ -418,7 +419,7 @@ create_tls_users(Config) ->
 delete_tls_users(Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, neustradamus])).
 
-config_password_format(login_scram) ->
+config_password_format(GN) when GN == login_scram; GN == login_scram_tls ->
     mongoose_helper:set_store_password(scram);
 config_password_format(_) ->
     mongoose_helper:set_store_password(plain).

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -422,5 +422,11 @@ set_store_password(Type) ->
     XMPPDomain = escalus_ejabberd:unify_str_arg(
                    ct:get_config({hosts, mim, domain})),
     AuthOpts = rpc(mim(), ejabberd_config, get_local_option, [{auth_opts, XMPPDomain}]),
-    NewAuthOpts = lists:keystore(password_format, 1, AuthOpts, {password_format, Type}),
+    NewAuthOpts = build_new_auth_opts(Type, AuthOpts),
     rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, XMPPDomain}, NewAuthOpts]).
+
+build_new_auth_opts(scram, AuthOpts) ->
+    NewAuthOpts0 = lists:keystore(password_format, 1, AuthOpts, {password_format, scram}),
+    lists:keystore(password_format, 1, NewAuthOpts0, {scram_iterations, 64});
+build_new_auth_opts(Type, AuthOpts) ->
+    lists:keystore(password_format, 1, AuthOpts, {password_format, Type}).

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -146,7 +146,7 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
         * **auth_password_format**
              * **Description:** Decide whether user passwords will be kept plain or hashed in the database.
              Currently, popular XMPP clients support the SCRAM method and it is strongly recommended to use the hashed version.
-             MongooseIM supports SHA-1, SHA-224, SHA-256 and SHA-512 for SCRAM hashing which can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration.
+             MongooseIM supports SHA-1, SHA-224, SHA-256, SHA-384 and SHA-512 for SCRAM hashing which can be provided as an argument and this will result in storing and supporting only hashes specified in the configuration.
              The older XMPP clients can still use the `PLAIN` mechanism. `DIGEST-MD5` is not available with `scram`.
              * **Values:** `plain`, `scram`, `{scram, [sha256]}` (`scram` and `{scram, [sha, sha224, sha256, sha384, sha512]}` are equivalent configurations)
              * **Default:** `scram`

--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -152,8 +152,13 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
              * **Default:** `scram`
 
         * **auth_scram_iterations**
-             * **Description:** Hash function round count. The higher the value, the more difficult breaking the hashes is. We advise against setting it too low.
-             * **Default:** 4096
+             * **Description:** Hash function round count.
+               This is a tradeoff between latency and security.
+               The higher the value, the more difficult breaking the hashes is: it is a work factor: increasing the count increases the work it requires to compute a full hash, which effectively slows down brute-force attacks.
+               But it adds load on both client and server, so this parameter should be tuned as high as the business-rules allow.
+               Note that increasing the security of a password has a higher impact over the security of the algorithm, without impacting its load.
+               See more information in this [NIST guide, Appendix A.2.2](https://csrc.nist.gov/publications/detail/sp/800-132/final),
+             * **Default:** 10000, as recommended in this [XEP](https://xmpp.org/extensions/xep-0438.html#pbkdf2) and this [NIST Guidelines](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5)
 
         * [`external` backend options](authentication-backends/External-authentication-module.md#configuration-options)
 

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -347,7 +347,7 @@
              %% {password_format, scram} % default
              %% {password_format, plain}
              {{{password_format}}}
-             %% {scram_iterations, 4096} % default
+             %% {scram_iterations, 10000} % default
              {{{scram_iterations}}}
              %%
              %% For auth_http:

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -27,6 +27,7 @@
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
 {password_format, "{password_format, {scram, [sha256]}}"}.
+{scram_iterations, ", {scram_iterations, 64}"}.
 {auth_ldap,""}.
 {s2s_addr, "{ {s2s_addr, \"fed1\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -49,7 +49,7 @@
 -export_type([scram_tuple/0, scram/0, scram_map/0]).
 
 -define(SALT_LENGTH, 16).
--define(SCRAM_DEFAULT_ITERATION_COUNT, 4096).
+-define(SCRAM_DEFAULT_ITERATION_COUNT, 10000).
 -define(SCRAM_SERIAL_PREFIX, "==SCRAM==,").
 -define(MULTI_SCRAM_SERIAL_PREFIX, "==MULTI_SCRAM==,").
 -define(SCRAM_SHA1_PREFIX, "===SHA1===").


### PR DESCRIPTION
As described in the docs changes, it follows the recommendations from
* https://xmpp.org/extensions/xep-0438.html#pbkdf2
* https://pages.nist.gov/800-63-3/sp800-63b.html#sec5