### PR TITLE
Order of advertising the auth mechanisms

### DIFF
--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -171,9 +171,13 @@ Retaining the default layout is recommended so that the experienced MongooseIM u
     All SCRAM-SHA mechanisms support channel binding and are advertised as a separate authentication mechanisms that is suffixed with `-PLUS`.
     Please note that the list of advertised authentication mechanisms is filtered out by the supported password formats to assure that it is possible to authenticate using authentication mechanisms that are offered.
     * **Warning:** This list is still filtered by [auth backends capabilities](#authentication-backend-capabilities)
-    * **Valid values:** `cyrsasl_plain, cyrsasl_digest, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sh384, cyrsasl_scram_sha512, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha256_plus, cyrsasl_scram_sh384_plus, cyrsasl_scram_sha512_plus, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external`
-    * **Default:** `[cyrsasl_plain, cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256, cyrsasl_scram_sha384, cyrsasl_scram_sha512, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha256_plus, cyrsasl_scram_sh384_plus, cyrsasl_scram_sha512_plus, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external]`
-    * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_anonymous, cyrsasl_scram_sha256_plus]`
+    * **Valid values:** `cyrsasl_scram_sha512_plus, cyrsasl_scram_sha512, cyrsasl_scram_sh384_plus, cyrsasl_scram_sh384, cyrsasl_scram_sha256_plus, cyrsasl_scram_sha256, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha224, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha1, cyrsasl_plain, cyrsasl_anonymous, cyrsasl_oauth, cyrsasl_external, cyrsasl_digest`
+    * **Default:** `[cyrsasl_scram_sha512_plus, cyrsasl_scram_sha512, cyrsasl_scram_sh384_plus, cyrsasl_scram_sh384, cyrsasl_scram_sha256_plus, cyrsasl_scram_sha256, cyrsasl_scram_sha224_plus, cyrsasl_scram_sha224, cyrsasl_scram_sha1_plus, cyrsasl_scram_sha1, cyrsasl_plain, cyrsasl_anonymous, cyrsasl_oauth]`
+
+        Please note that configuring the `sasl_mechanisms` parameter will take precedence over the default list.
+        Should more than one parameter be configured in the list of `sasl_mechanisms`, the order of how they are listed in the config will be taken as the order in which they are advertised.
+
+    * **Examples:** `[cyrsasl_plain]`, `[cyrsasl_scram_sha256_plus, cyrsasl_anonymous]`
     * **Deprecations:** Please note that the DIGEST-MD5 authentication method `cyrsasl_digest` is deprecated and will be removed in the next release.
 
 * **extauth_instances** (local)

--- a/src/sasl/cyrsasl.erl
+++ b/src/sasl/cyrsasl.erl
@@ -143,16 +143,16 @@ get_modules(Host) ->
     end.
 
 default_modules() ->
-    [cyrsasl_plain,
-     cyrsasl_scram_sha1,
-     cyrsasl_scram_sha224,
-     cyrsasl_scram_sha256,
-     cyrsasl_scram_sha384,
+    [cyrsasl_scram_sha512_plus,
      cyrsasl_scram_sha512,
-     cyrsasl_scram_sha1_plus,
-     cyrsasl_scram_sha224_plus,
-     cyrsasl_scram_sha256_plus,
      cyrsasl_scram_sha384_plus,
-     cyrsasl_scram_sha512_plus,
+     cyrsasl_scram_sha384,
+     cyrsasl_scram_sha256_plus,
+     cyrsasl_scram_sha256,
+     cyrsasl_scram_sha224_plus,
+     cyrsasl_scram_sha224,
+     cyrsasl_scram_sha1_plus,
+     cyrsasl_scram_sha1,
+     cyrsasl_plain,
      cyrsasl_anonymous,
      cyrsasl_oauth].


### PR DESCRIPTION
As per the XMPP core RFC, the authentication mechanisms that are advertised to the client `SHOULD be in order of perceived strength to enable the strongest authentication possible.`

[https://tools.ietf.org/html/rfc6120#section-6.3.3](https://tools.ietf.org/html/rfc6120#section-6.3.3)

New order of advertising the authentication mechanisms is the following:
```xml
<mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
	<mechanism>SCRAM-SHA-512-PLUS</mechanism>
	<mechanism>SCRAM-SHA-512</mechanism>
	<mechanism>SCRAM-SHA-384-PLUS</mechanism>
	<mechanism>SCRAM-SHA-384</mechanism>
	<mechanism>SCRAM-SHA-256-PLUS</mechanism>
	<mechanism>SCRAM-SHA-256</mechanism>
	<mechanism>SCRAM-SHA-224-PLUS</mechanism>
	<mechanism>SCRAM-SHA-224</mechanism>
	<mechanism>SCRAM-SHA-1-PLUS</mechanism>
	<mechanism>SCRAM-SHA-1</mechanism>
	<mechanism>PLAIN</mechanism>
</mechanisms>
```

Important note on the order is that this PR is addressing the order of the default modules. Configuring the `sasl_mechanisms` parameter will take precedence over this list. Should more than one parameter be configured in in the list of `sasl_mechanisms`, the order of how they are listed in the config will be taken as the order when the mechanisms are advertised. 

Having `{sasl_mechanisms, [cyrsasl_scram_sha1, cyrsasl_plain, cyrsasl_scram_sha256]}` will result in following order:
```xml
<mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
    <mechanism>SCRAM-SHA-1</mechanism>
    <mechanism>PLAIN</mechanism>
    <mechanism>SCRAM-SHA-256</mechanism>
</mechanisms>
```
Configuration of the external authentication method is done though configuring the `sasl_mechanisms` parameter. As long as it is the `cyrsasl_external` is the first element in `sasl_mechanisms` list, it will be advertised in the first place.


