### PR TITLE
Test change_password for both password formats

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -27,7 +27,8 @@ all() ->
      {group, bad_registration},
      {group, bad_cancelation},
      {group, registration_timeout},
-     {group, change_account_details}
+     {group, change_account_details},
+     {group, change_account_details_store_plain}
     ].
 
 groups() ->
@@ -41,14 +42,17 @@ groups() ->
                                         not_allowed_registration_cancelation]},
          {registration_timeout, [sequence], [registration_timeout,
                                              registration_failure_timeout]},
-         {change_account_details, [parallel], [change_password,
-                                               change_password_to_null]}
+         {change_account_details, [parallel], change_password_tests()},
+         {change_account_details_store_plain, [parallel], change_password_tests()}
         ],
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
+change_password_tests() ->
+    [change_password,
+     change_password_to_null].
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
@@ -77,6 +81,10 @@ init_per_group(bad_cancelation, Config) ->
     escalus:create_users(Config, escalus:get_users([alice]));
 init_per_group(change_account_details, Config) ->
     [{escalus_user_db,  {module, escalus_ejabberd}} |Config];
+init_per_group(change_account_details_store_plain, Config) ->
+    Config1 = mongoose_helper:backup_auth_config(Config),
+    mongoose_helper:set_store_password(plain),
+    [{escalus_user_db,  {module, escalus_ejabberd}} |Config1];
 init_per_group(registration_timeout, Config) ->
     set_registration_timeout(Config);
 init_per_group(_GroupName, Config) ->
@@ -84,6 +92,10 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(change_account_details, Config) ->
     escalus_fresh:clean(),
+    [{escalus_user_db, xmpp} | Config];
+end_per_group(change_account_details_store_plain, Config) ->
+    escalus_fresh:clean(),
+    mongoose_helper:restore_auth_config(Config),
     [{escalus_user_db, xmpp} | Config];
 end_per_group(bad_cancelation, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice]));


### PR DESCRIPTION
The aim of this PR it to make sure that authentication backend functionalities are tested similarly for both scram and plain password formats. 

Most of the test SUITEs are running with the default password format. This caused some of the functionalities not to be covered in the tests e.g. it turned out that change_password for riak backend was not working properly when password_format was set to scram (fixed in PR #2737).

Now, as the password format changed to scram, change_password was not testing plain format in the similar manner it was for scram.

This PR adds change_account_details_store_plain test that is changing password format to plain before running tests that are changing the account details. 