### PR TITLE
Improve parallelism of AMP tests

### DIFF
--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -19,56 +19,63 @@
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
-all() -> [{group, Group} || Group <- enabled_group_names()].
-
-enabled_group_names() ->
-    [basic, offline] ++
-    case mongoose_helper:is_rdbms_enabled(domain()) of
-        true -> [mam];
-        false -> []
-    end.
+all() ->
+    [{group, G} || G <- main_group_names(), is_enabled(G)].
 
 groups() ->
-    Gs = ([{basic, [parallel], [{group, G} || G <- subgroup_names()] ++ basic_test_cases()},
-           {mam, [], [{group, mam_success},
-                      {group, mam_failure}]},
-           {mam_success, [], [{group, G} || G <- subgroup_names()]},
-           {mam_failure, [], [{group, G} || G <- subgroup_names()]},
-           {offline, [], [{group, offline_success},
-                          {group, offline_failure}]},
-           {offline_success, [], [{group, G} || G <- subgroup_names()]},
-           {offline_failure, [], [{group, G} || G <- subgroup_names()]}
-          ] ++
-          [{G, [parallel, shuffle], notify_deliver_test_cases()}
-           || G <- notify_deliver_group_names()] ++
-          [{G, [parallel, shuffle], error_deliver_test_cases()}
-           || G <- error_deliver_group_names()] ++
-          [{G, [parallel, shuffle], drop_deliver_test_cases()}
-           || G <- drop_deliver_group_names()]),
-    ct_helper:repeat_all_until_all_ok(Gs).
+    group_spec(main_group_names()).
 
+is_enabled(mam) -> mongoose_helper:is_rdbms_enabled(domain());
+is_enabled(_) -> true.
 
-subgroup_names() -> notify_deliver_group_names() ++
-                    error_deliver_group_names() ++
-                    drop_deliver_group_names().
+%% Group definitions
 
-notify_deliver_group_names() ->
-    [notify_deliver_none,
-     notify_deliver_direct,
-     notify_deliver_stored,
-     notify_deliver_none_direct_stored].
+main_group_names() ->
+    [basic, mam, offline].
 
-error_deliver_group_names() ->
-    [error_deliver_none,
-     error_deliver_direct,
-     error_deliver_stored,
-     error_deliver_none_direct_stored].
+subgroups(mam) -> [mam_success, mam_failure];
+subgroups(offline) -> [offline_success, offline_failure];
+subgroups(_) -> [].
 
-drop_deliver_group_names() ->
-    [drop_deliver_none,
-     drop_deliver_direct,
-     drop_deliver_stored,
-     drop_deliver_none_direct_stored].
+group_spec(Groups) when is_list(Groups) ->
+    lists:flatmap(fun group_spec/1, Groups);
+group_spec(Group) ->
+    case subgroups(Group) of
+        [] -> [{Group, [parallel], test_cases(Group)}];
+        SubGroups -> [{Group, [{group, SubG} || SubG <- SubGroups]} | group_spec(SubGroups)]
+    end.
+
+test_cases(Group) ->
+    regular_tests(Group) ++ multiple_config_cth:flatten_and_strip_config(tests_with_config(Group)).
+
+regular_tests(basic) -> basic_test_cases();
+regular_tests(_) -> [].
+
+%% This function is called by multiple_config_cth for each group
+%% to get a list of configs for each test case
+-spec tests_with_config(_GroupName :: atom()) -> [{TestCase :: atom(),
+                                                  [Config :: [{Key :: atom(), Value :: term()}]]}].
+tests_with_config(_GroupName) ->
+    lists:append([deliver_tests_with_config(notify),
+                  deliver_tests_with_config(error),
+                  deliver_tests_with_config(drop)]).
+
+%% Each of the 'deliver' tests is repeated several times, each time with a different config
+deliver_tests_with_config(Action) ->
+    multiple_config_cth:add_config(deliver_rule_configs(Action), deliver_test_cases(Action)).
+
+%% Each config tests different rules in the AMP message
+deliver_rule_configs(Action) ->
+    [
+     [{rules, [{deliver, direct, Action}]}],
+     [{rules, [{deliver, stored, Action}]}],
+     [{rules, [{deliver, none, Action}]}],
+     [{rules, [{deliver, direct, Action},
+               {deliver, stored, Action},
+               {deliver, none, Action}]}]
+    ].
+
+%% Test case list, each test has to be listed exactly once
 
 basic_test_cases() ->
     [initial_service_discovery_test,
@@ -85,39 +92,48 @@ basic_test_cases() ->
 
      last_rule_applies_test].
 
-notify_deliver_test_cases() ->
+deliver_test_cases(notify) ->
     [notify_deliver_to_online_user_test,
      notify_deliver_to_online_user_bare_jid_test,
      notify_deliver_to_online_user_recipient_privacy_test,
      notify_deliver_to_offline_user_test,
      notify_deliver_to_offline_user_recipient_privacy_test,
      notify_deliver_to_stranger_test,
-     notify_deliver_to_malformed_jid_test].
-
-error_deliver_test_cases() ->
+     notify_deliver_to_malformed_jid_test];
+deliver_test_cases(error) ->
     [error_deliver_to_online_user_test,
      error_deliver_to_offline_user_test,
-     error_deliver_to_stranger_test].
-
-drop_deliver_test_cases() ->
+     error_deliver_to_stranger_test];
+deliver_test_cases(drop) ->
     [drop_deliver_to_online_user_test,
      drop_deliver_to_offline_user_test,
      drop_deliver_to_stranger_test].
 
-init_per_suite(C) ->
+%% Setup and teardown
+
+init_per_suite(Config) ->
     rpc(mim(), ejabberd_config, add_local_option, [{{s2s_host, <<"not a jid">>}, domain()}, deny]),
-    escalus:init_per_suite(C).
+    ConfigWithHooks = [{ct_hooks, [{multiple_config_cth, fun tests_with_config/1}]} | Config],
+    setup_meck(suite),
+    escalus:init_per_suite(ConfigWithHooks).
+
 end_per_suite(C) ->
     rpc(mim(), ejabberd_config, del_local_option, [{{s2s_host, <<"not a jid">>}, domain()}]),
+    teardown_meck(suite),
     escalus_fresh:clean(),
     escalus:end_per_suite(C).
 
 init_per_group(GroupName, Config) ->
-    ConfigWithModules = dynamic_modules:save_modules(domain(), Config),
-    ConfigWithRules = setup_rules(GroupName, ConfigWithModules),
-    dynamic_modules:ensure_modules(domain(), required_modules(GroupName)),
+    Config1 = case lists:member(GroupName, main_group_names()) of
+                            true ->
+                                ConfigWithModules = dynamic_modules:save_modules(domain(), Config),
+                                dynamic_modules:ensure_modules(domain(), required_modules(GroupName)),
+                                ConfigWithModules;
+                            false ->
+                                Config
+              end,
     setup_meck(GroupName),
-    save_offline_status(GroupName, ConfigWithRules).
+    save_offline_status(GroupName, Config1).
 
 setup_meck(mam_failure) ->
     ok = rpc(mim(), meck, expect, [mod_mam_rdbms_arch, archive_message, 10, {error, simulated}]);
@@ -134,7 +150,10 @@ save_offline_status(_GN, Config) -> Config.
 
 end_per_group(GroupName, Config) ->
     teardown_meck(GroupName),
-    dynamic_modules:restore_modules(domain(), Config).
+    case lists:member(GroupName, main_group_names()) of
+        true -> dynamic_modules:restore_modules(domain(), Config);
+        false -> ok
+    end.
 
 teardown_meck(G) when G == mam_failure;
                       G == offline_failure ->
@@ -144,11 +163,13 @@ teardown_meck(_) -> ok.
 init_per_testcase(Name, C) -> escalus:init_per_testcase(Name, C).
 end_per_testcase(Name, C) -> escalus:end_per_testcase(Name, C).
 
+%% Test cases
+
 initial_service_discovery_test(Config) ->
     escalus:fresh_story(
       Config, [{alice, 1}],
       fun(Alice) ->
-              escalus_client:send(Alice, disco_info(Config)),
+              escalus_client:send(Alice, disco_info()),
               Response = escalus_client:wait_for_stanza(Alice),
               escalus:assert(has_feature, [ns_amp()], Response)
       end).
@@ -163,7 +184,7 @@ actions_and_conditions_discovery_test(Config) ->
                   <<"http://jabber.org/protocol/amp?condition=deliver">>,
                   <<"http://jabber.org/protocol/amp?condition=match-resource">>
                   ],
-          escalus_client:send(Alice, disco_info_amp_node(Config)),
+          escalus_client:send(Alice, disco_info_amp_node()),
           Response = escalus_client:wait_for_stanza(Alice),
           assert_has_features(Response, Args)
       end).
@@ -686,29 +707,6 @@ client_has_mam_message(User) ->
     Res = mam_helper:wait_archive_respond(User),
     mam_helper:assert_respond_size(1, Res).
 
-setup_rules(notify_deliver_none, Config) -> [{rules, [{deliver, none, notify}]} | Config];
-setup_rules(error_deliver_none, Config) -> [{rules, [{deliver, none, error}]} | Config];
-setup_rules(drop_deliver_none, Config) -> [{rules, [{deliver, none, drop}]} | Config];
-setup_rules(notify_deliver_stored, Config) -> [{rules, [{deliver, stored, notify}]} | Config];
-setup_rules(error_deliver_stored, Config) -> [{rules, [{deliver, stored, error}]} | Config];
-setup_rules(drop_deliver_stored, Config) -> [{rules, [{deliver, stored, drop}]} | Config];
-setup_rules(notify_deliver_direct, Config) -> [{rules, [{deliver, direct, notify}]} | Config];
-setup_rules(error_deliver_direct, Config) -> [{rules, [{deliver, direct, error}]} | Config];
-setup_rules(drop_deliver_direct, Config) -> [{rules, [{deliver, direct, drop}]} | Config];
-setup_rules(notify_deliver_none_direct_stored, Config) ->
-    [{rules, [{deliver, none, notify},
-              {deliver, direct, notify},
-              {deliver, stored, notify}]} | Config];
-setup_rules(error_deliver_none_direct_stored, Config) ->
-    [{rules, [{deliver, none, error},
-              {deliver, direct, error},
-              {deliver, stored, error}]} | Config];
-setup_rules(drop_deliver_none_direct_stored, Config) ->
-    [{rules, [{deliver, none, drop},
-              {deliver, direct, drop},
-              {deliver, stored, drop}]} | Config];
-setup_rules(_, Config) -> Config.
-
 rules(Config, Default) ->
     case lists:keysearch(rules, 1, Config) of
         {value, {rules, Val}} -> Val;
@@ -748,12 +746,11 @@ client_receives_notification(Client, IntendedRecipient, Rule) ->
     Msg = escalus_client:wait_for_stanza(Client),
     assert_notification(Client, IntendedRecipient, Msg, Rule).
 
-disco_info(Config) ->
-    Server = ct:get_config({hosts, mim, domain}),
-    escalus_stanza:disco_info(Server).
-disco_info_amp_node(Config) ->
-    Server = ct:get_config({hosts, mim, domain}),
-    escalus_stanza:disco_info(Server, ns_amp()).
+disco_info() ->
+    escalus_stanza:disco_info(domain()).
+
+disco_info_amp_node() ->
+    escalus_stanza:disco_info(domain(), ns_amp()).
 
 assert_amp_error(Client, Response, Rules, AmpErrorKind) when is_list(Rules) ->
     ClientJID = escalus_client:full_jid(Client),
@@ -925,8 +922,6 @@ required_modules(mam) ->
     mam_modules(on) ++ offline_modules(off);
 required_modules(offline) ->
     mam_modules(off) ++ offline_modules(on);
-required_modules(mam_and_offline) ->
-    mam_modules(on) ++ offline_modules(on);
 required_modules(_) ->
     [].
 

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -307,7 +307,7 @@ notify_deliver_to_online_user_recipient_privacy_test(Config) ->
 
 notify_deliver_to_offline_user_test(Config) ->
     FreshConfig = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
-    escalus_fresh:story(
+    escalus:story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given
@@ -350,7 +350,7 @@ notify_deliver_to_offline_user_recipient_privacy_test(Config) ->
 
 do_notify_deliver_to_offline_user_recipient_privacy_test(Config) ->
     FreshConfig = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
-    escalus:fresh_story(
+    escalus:story(
       FreshConfig, [{alice, 1}, {bob, 1}],
       fun(Alice, Bob) ->
 
@@ -519,7 +519,7 @@ error_deliver_to_offline_user_test(Config) ->
                          _ -> stored
                      end, error},
     Rules = rules(Config, [Rule]),
-    escalus:fresh_story(
+    escalus:story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given
@@ -602,7 +602,7 @@ drop_deliver_to_offline_user_test(Config) ->
                      end, drop},
     Rules = rules(Config, [Rule]),
     Message = <<"A message in a bottle...">>,
-    escalus:fresh_story(
+    escalus:story(
       FreshConfig, [{alice, 1}],
       fun(Alice) ->
               %% given

--- a/big_tests/tests/multiple_config_cth.erl
+++ b/big_tests/tests/multiple_config_cth.erl
@@ -1,0 +1,86 @@
+-module(multiple_config_cth).
+%% @doc Support running a test multiple times with different configuration options
+%% inside a single test group. Used by amp_big_SUITE.
+
+%% Callbacks
+
+-export([id/1, init/2]).
+
+-export([pre_init_per_suite/3, post_init_per_suite/4,
+         pre_end_per_suite/3, post_end_per_suite/4,
+         pre_init_per_group/3, post_init_per_group/4,
+         pre_end_per_group/3, post_end_per_group/4,
+         pre_init_per_testcase/3, post_init_per_testcase/4,
+         pre_end_per_testcase/3, post_end_per_testcase/4]).
+
+-export([on_tc_fail/3, on_tc_skip/3, terminate/1]).
+
+-export([add_config/2, flatten_and_strip_config/1]).
+
+-record(state, {conf_fun, group_conf}).
+
+%% CTH callbacks
+
+id(_) ->
+    ?MODULE.
+
+init(_Id, ConfFun) ->
+    {ok, #state{conf_fun = ConfFun}}.
+
+pre_init_per_suite(_Suite, Config, State) ->
+    {Config, State}.
+
+post_init_per_suite(_Suite, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_suite(_Suite, Config, State) ->
+    {Config, State}.
+
+post_end_per_suite(_Suite, _Config, Return, State) ->
+    {Return, State}.
+
+pre_init_per_group(Group, Config, State = #state{conf_fun = ConfFun}) ->
+    {Config, State#state{group_conf = maps:from_list(ConfFun(Group))}}.
+
+post_init_per_group(_Group, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_group(_Group, Config, State) ->
+    {Config, State}.
+
+post_end_per_group(_Group, _Config, Return, State) ->
+    {Return, State}.
+
+pre_init_per_testcase(TC, Config, #state{group_conf = Conf} = State) ->
+    case Conf of
+        #{TC := [ExtraConfig | Rest]} ->
+            ct:log("Extra test config: ~p", [ExtraConfig]),
+            {ExtraConfig ++ Config, State#state{group_conf = Conf#{TC := Rest}}};
+        _ -> {Config, State}
+    end.
+
+post_init_per_testcase(_TC, _Config, Return, State) ->
+    {Return, State}.
+
+pre_end_per_testcase(_TC, Config, State) ->
+    {Config, State}.
+
+post_end_per_testcase(_TC, _Config, Return, State) ->
+    {Return, State}.
+
+on_tc_fail(_TC, _Reason, State) ->
+    State.
+
+on_tc_skip(_TC, _Reason, State) ->
+    State.
+
+terminate(_State) ->
+    ok.
+
+%% Helper API
+
+add_config(Configs, Cases) ->
+    [{TC, Configs} || TC <- Cases].
+
+flatten_and_strip_config(CasesWithConfig) ->
+    lists:flatmap(fun({TC, Confs}) -> [TC || _ <- Confs] end, CasesWithConfig).


### PR DESCRIPTION
AMP test suites check a matrix of conditions, e.g.
- Actions like `notify`, `error`, `drop`
- Delivery conditions like `direct`, `stored`, `none` and their combinations

This increases the number of test cases. To avoid coding every intersection of these conditions, there is a need to generate some of them. Currently this is achieved by nesting test groups, but this prevents them from running in parallel. Long group names need to be generated, what makes the test setup less readable as well.

The proposed solution is to have a new common test hook (see https://erlang.org/doc/man/ct_hooks.html) to set up a list of Config's for each test case. This would speed up the tests significantly by running them in parallel, avoid nesting groups too much and eliminate the need for hardcoding or generating long group names.

This approach could be used for more test suites.

Other changes:
- Fix module setup - it was redundantly performed for nested groups, storing the module config multiple times and then restoring it multiple times.
- Remove some unused code
- Fix double "fresh" prefixes for Alice in some tests.
- Wait for Alice to disconnect before checking for an incoming message in Bob's archive - after increasing test parallelism this bug caused random failures, as Bob got the message while Alice was still online.
