### PR TITLE
Amp logic fix

### DIFF
--- a/include/amp.hrl
+++ b/include/amp.hrl
@@ -4,6 +4,8 @@
 %% @copyright 2014 Erlang Solutions, Ltd.
 %% This work was sponsored by Grindr LLC
 
+-include_lib("exml/include/exml.hrl").
+
 -define(NS_AMP, <<"http://jabber.org/protocol/amp">>).
 -define(NS_AMP_FEATURE, <<"http://jabber.org/feature/amp">>).
 
@@ -11,7 +13,9 @@
 -record(amp_rule, {
           condition :: amp_condition(),
           value     :: amp_value(),
-          action    :: amp_action()
+          action    :: amp_action(),
+          element   :: #xmlel{} | undefined,
+          result    :: amp_match_result() | undefined
          }).
 
 %% @doc This includes all well-formed but nonsensical rules, like:

--- a/src/amp.erl
+++ b/src/amp.erl
@@ -12,6 +12,7 @@
 -export([extract_requested_rules/1,
          make_response/3,
          make_error_response/4,
+         update_rules/2,
          rule_to_xmlel/1,
          strip_amp_el/1,
 
@@ -109,6 +110,16 @@ make_error_el(Errors, Rules) ->
            attrs = [{<<"type">>, <<"modify">>},
                     {<<"code">>, error_code(hd(Errors))}],
            children = [ErrorMarker, RuleContainer]}.
+
+-spec update_rules(#xmlel{}, [amp_rule()]) -> #xmlel{}.
+update_rules(Packet = #xmlel{children = Children}, Rules) ->
+    Packet#xmlel{children = [update_rules_in_element(El, Rules) || El <- Children]}.
+
+update_rules_in_element(El, Rules) ->
+    case is_amp_el(El) of
+        true -> El#xmlel{children = [rule_to_xmlel(R) || R <- Rules]};
+        false -> El
+    end.
 
 -spec rule_to_xmlel(amp_any_rule()) -> #xmlel{}.
 rule_to_xmlel(#amp_rule{condition=C, value=V, action=A}) ->

--- a/src/amp_resolver.erl
+++ b/src/amp_resolver.erl
@@ -37,12 +37,8 @@ resolve(#amp_strategy{deliver = Values}, #amp_rule{condition = deliver, value = 
         true -> undecided;
         false -> no_match
     end;
-resolve(#amp_strategy{deliver = Values}, #amp_rule{condition = deliver, value = Value, action = Action})
-  when is_list(Values), Action == drop orelse Action == error, Value /= none ->
-    case lists:member(Value, Values) of
-        true -> match;
-        false -> no_match
-    end;
+resolve(#amp_strategy{deliver = [Value | _]}, #amp_rule{condition = deliver, value = Value, action = Action})
+  when Action == drop orelse Action == error -> match;
 resolve(#amp_strategy{'match-resource' = Value}, #amp_rule{condition = 'match-resource', value = any})
   when Value /= undefined -> match;
 resolve(#amp_strategy{'match-resource' = Value}, #amp_rule{condition = 'match-resource', value = Value}) ->

--- a/src/amp_strategy.erl
+++ b/src/amp_strategy.erl
@@ -43,7 +43,7 @@ deliver_strategy({offline, []}, initial_check) -> [none];
 deliver_strategy({_Session, _ }, initial_check) -> [direct, none];
 deliver_strategy({offline, []}, archived) -> [stored];
 deliver_strategy({_Session, _}, archived) -> [direct, stored];
-deliver_strategy(_, delivery_failed) -> [none];
+deliver_strategy(_, delivery_failed) -> [stored, none];
 deliver_strategy({offline, []}, mam_failed) -> [none];
 deliver_strategy({_Session, _}, mam_failed) -> [direct, none];
 deliver_strategy(_, offline_failed) -> [none];

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -469,18 +469,21 @@ handle_get_message_form(_From=#jid{lserver = Host}, _ArcJID=#jid{}, IQ=#iq{}) ->
     return_message_form_iq(Host, IQ).
 
 
-determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
+determine_amp_strategy(Strategy = #amp_strategy{deliver = Deliver},
                        FromJID, ToJID, Packet, initial_check) ->
     #jid{luser = LUser, lserver = LServer} = ToJID,
     ShouldBeStored = is_archivable_message(LServer, incoming, Packet)
         andalso is_interesting(ToJID, FromJID)
         andalso ejabberd_auth:is_user_exists(LUser, LServer),
     case ShouldBeStored of
-        true -> Strategy#amp_strategy{deliver = [stored, none]};
+        true -> Strategy#amp_strategy{deliver = amp_deliver_strategy(Deliver)};
         false -> Strategy
     end;
 determine_amp_strategy(Strategy, _, _, _, _) ->
     Strategy.
+
+amp_deliver_strategy([none]) -> [stored, none];
+amp_deliver_strategy([direct, none]) -> [direct, stored, none].
 
 -spec handle_package(Dir :: incoming | outgoing, ReturnMessID :: boolean(),
                      LocJID :: jid:jid(), RemJID :: jid:jid(), SrcJID :: jid:jid(),

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -159,8 +159,11 @@ process_amp_rules(Packet, From, Event, Rules) ->
             send_error_and_drop(Packet, From, ValidationError, InvalidRule);
         [] ->
             Strategy = determine_strategy(Packet, From, Event),
-            ApplyResult = fold_apply_rules(Packet, From, Strategy, ValidRules),
-            take_action(Packet, From, Event, ApplyResult)
+            RulesWithResults = apply_rules(fun(Rule) ->
+                                                   resolve_condition(From, Strategy, Event, Rule)
+                                           end, ValidRules),
+            PacketResult = take_action(Packet, From, RulesWithResults),
+            return_result(PacketResult, Packet, RulesWithResults)
     end.
 
 %% @doc ejabberd_hooks helpers
@@ -175,39 +178,40 @@ determine_strategy(Packet, From, Event) ->
                                           amp_strategy:null_strategy(),
                                           From, To, Packet, Event).
 
--spec fold_apply_rules(exml:element(), jid:jid(), amp_strategy(), [amp_rule()]) ->
-                              no_match | {match | undecided, amp_rule()}.
-fold_apply_rules(_, _, _, []) -> 'no_match';
-fold_apply_rules(Packet, From, Strategy, [Rule|Rest]) ->
-    case resolve_condition(From, Strategy, Rule) of
-        no_match -> fold_apply_rules(Packet, From, Strategy, Rest);
-        Status -> {Status, Rule}
+apply_rules(F, Rules) ->
+    [Rule#amp_rule{result = F(Rule)} || Rule <- Rules].
+
+-spec resolve_condition(jid:jid(), amp_strategy(), amp_event(), amp_rule()) -> amp_match_result().
+resolve_condition(From, Strategy, Event, Rule) ->
+    Result = mongoose_hooks:amp_check_condition(host(From), no_match, Strategy, Rule),
+    match_undecided_for_final_event(Rule, Event, Result).
+
+match_undecided_for_final_event(#amp_rule{condition = deliver}, Event, undecided)
+  when Event =:= delivered;
+       Event =:= delivery_failed -> match;
+match_undecided_for_final_event(_, _, Result) -> Result.
+
+take_action(Packet, From, Rules) ->
+    case find(fun(#amp_rule{result = Result}) -> Result =:= match end, Rules) of
+        not_found -> pass;
+        {found, Rule} -> take_action_for_matched_rule(Packet, From, Rule)
     end.
 
--spec resolve_condition(jid:jid(), amp_strategy(), amp_rule()) -> amp_match_result().
-resolve_condition(From, Strategy, Rule) ->
-    mongoose_hooks:amp_check_condition(host(From),
-                                       no_match,
-                                       Strategy, Rule).
+return_result(drop, _Packet, _Rules) -> drop;
+return_result(pass, Packet, Rules) ->
+    update_rules(Packet, lists:filter(fun(#amp_rule{result = Result}) ->
+                                              Result =:= undecided
+                                      end, Rules)).
 
--spec take_action(exml:element(),
-                  jid:jid(),
-                  amp_event(),
-                  no_match | {matched | undecided, amp_rule()}) ->
-    exml:element() | drop.
-take_action(Packet, _From, initial_check, no_match) ->
-    amp:strip_amp_el(Packet);
-take_action(Packet, From, _, {match, Rule}) ->
-    take_action_for_matched_rule(Packet, From, Rule);
-take_action(Packet, _From, _, _) ->
-    Packet.
+update_rules(Packet, []) -> amp:strip_amp_el(Packet);
+update_rules(Packet, Rules) -> amp:update_rules(Packet, Rules).
 
--spec take_action_for_matched_rule(exml:element(), jid:jid(), amp_rule()) -> exml:element() | drop.
+-spec take_action_for_matched_rule(exml:element(), jid:jid(), amp_rule()) -> pass | drop.
 take_action_for_matched_rule(Packet, From, #amp_rule{action = notify} = Rule) ->
     Host = host(From),
     reply_to_sender(Rule, server_jid(From), From, Packet),
     mongoose_hooks:amp_notify_action_triggered(Host, ok),
-    amp:strip_amp_el(Packet);
+    pass;
 take_action_for_matched_rule(Packet, From, #amp_rule{action = error} = Rule) ->
     send_error_and_drop(Packet, From, 'undefined-condition', Rule);
 take_action_for_matched_rule(Packet, From, #amp_rule{action = drop}) ->
@@ -261,4 +265,11 @@ message_target(El) ->
     case exml_query:attr(El, <<"to">>) of
         undefined -> undefined;
         J -> jid:from_binary(J)
+    end.
+
+find(_Pred, []) -> not_found;
+find(Pred, [H|T]) ->
+    case Pred(H) of
+        true -> {found, H};
+        false -> find(Pred, T)
     end.

--- a/test/amp_resolver_SUITE.erl
+++ b/test/amp_resolver_SUITE.erl
@@ -58,7 +58,7 @@ deliver_error_drop_match_test(_) ->
                            #amp_rule{condition = deliver, value = Dr, action = A})) ||
         Ds <- strategy_deliver_values(),
         Dr <- rule_deliver_values(),
-        [Dr] == Ds orelse (Ds /= undefined andalso Dr /= none andalso lists:member(Dr, Ds)),
+        hd(Ds) == Dr,
         A <- [error, drop]],
     ok.
 
@@ -67,7 +67,7 @@ deliver_error_drop_no_match_test(_) ->
                               #amp_rule{condition = deliver, value = Dr, action = A})) ||
         Ds <- strategy_deliver_values(),
         Dr <- rule_deliver_values(),
-        [Dr] /= Ds,
+        hd(Ds) /= Dr,
         Ds == undefined orelse Dr == none orelse not lists:member(Dr, Ds),
         A <- [error, drop]],
     ok.


### PR DESCRIPTION
**Bug fix**
When MongooseIM fails to deliver the message to the recipient and message archive is enabled, there was no notification from AMP for the `stored` delivery condition although the message was stored successfully.

**Motivation**
On failed delivery we need to always trigger AMP delivery conditions: either ‘none’ or ‘stored’. There shouldn't be a case when no condition is triggered.

**Changes**
- Add ‘stored’ as a possible delivery condition on delivery failure.
- If there is an ‘undecided’ delivery rule for a final delivery event, match it (this helps resolve ambiguous cases).
- Only the first rule can be matched for ‘error’ and ‘drop’ actions - this prevents ‘stored’ events from being matched during the initial check if the user is online.
- Detailed docs added, describing the logic from the user's perspective.

**Note**: `notify_deliver_to_online_user_recipient_privacy_test` was passing for MAM before because of the bug. Fixing it caused the test to fail as MAM stored the message although it was excluded by the privacy list. This test is skipped now as MAM does not respect privacy lists.