### PR TITLE
Use calendar for  ISO-8601 / RFC 3339 timestamp processing

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1289,7 +1289,7 @@ timestamp_is_updated_on_new_message(Config) ->
 
          TStamp2 = inbox_helper:timestamp_from_item(Item2),
 
-         case timer:now_diff(TStamp2, TStamp1) > 0 of
+         case TStamp2 > TStamp1 of
              true -> ok;
              false -> error(#{ type => timestamp_is_not_greater,
                                item1 => Item1,

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -194,7 +194,7 @@ check_result(Packet, ExpectedResult) ->
 timestamp_from_item(Item) ->
     ISOTStamp = exml_query:path(Item, [{element, <<"result">>}, {element, <<"forwarded">>},
                                        {element, <<"delay">>}, {attr, <<"stamp">>}]),
-    escalus_ejabberd:rpc(jlib, datetime_binary_to_timestamp, [ISOTStamp]).
+    calendar:rfc3339_to_system_time(binary_to_list(ISOTStamp), [{unit, microsecond}]).
 
 clear_inbox_all() ->
     clear_inboxes([alice, bob, kate, mike], domain()).
@@ -565,11 +565,9 @@ to_bare_lower(User) ->
 %% Returns mim1-side time in ISO format
 -spec server_side_time() -> binary().
 server_side_time() ->
-    {_, _, Micro} = Timestamp = escalus_ejabberd:rpc(erlang, timestamp, []),
-    {Day, {H, M, S}} = calendar:now_to_datetime(Timestamp),
-    DateTimeMicro = {Day, {H, M, S, Micro}},
-    {String, TZ} = escalus_ejabberd:rpc(jlib, timestamp_to_iso, [DateTimeMicro, utc]),
-    list_to_binary(String ++ TZ).
+    USec = escalus_ejabberd:rpc(erlang, system_time, [microsecond]),
+    TS = calendar:system_time_to_rfc3339(USec, [{offset, "Z"}, {unit, microsecond}]),
+    list_to_binary(TS).
 
 %% ---------------------------------------------------------
 %% Error reporting

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -188,10 +188,7 @@ wait_for_complete_archive_response(P, Alice, ExpectedCompleteValue)
                         #{mam_props => P, parsed_iq => ParsedIQ}).
 
 make_iso_time(Micro) ->
-    Now = usec:to_now(Micro),
-    DateTime = calendar:now_to_datetime(Now),
-    {Time, TimeZone} = rpc_apply(jlib, timestamp_to_iso, [DateTime, utc]),
-    Time ++ TimeZone.
+    calendar:system_time_to_rfc3339(usec:to_sec(Micro), [{offset, "Z"}]).
 
 generate_message_text(N) when is_integer(N) ->
     <<"Message #", (list_to_binary(integer_to_list(N)))/binary>>.
@@ -866,7 +863,7 @@ generate_msg_for_date_user(Owner, Remote, DateTime) ->
 
 generate_msg_for_date_user(Owner, {RemoteBin, _, _} = Remote, DateTime, Content) ->
     MicrosecDateTime = datetime_to_microseconds(DateTime),
-    NowMicro = rpc_apply(mod_mam_utils, now_to_microseconds, [rpc_apply(erlang, now, [])]),
+    NowMicro = rpc_apply(erlang, system_time, [microsecond]),
     Microsec = min(NowMicro, MicrosecDateTime),
     MsgIdOwner = rpc_apply(mod_mam_utils, encode_compact_uuid, [Microsec, random:uniform(20)]),
     MsgIdRemote = rpc_apply(mod_mam_utils, encode_compact_uuid, [Microsec+1, random:uniform(20)]),

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -52,7 +52,7 @@
                 pres_i = gb_sets:new() :: jid_set() | debug_presences(),
                 pending_invitations = [],
                 pres_last, pres_pri,
-                pres_timestamp :: calendar:datetime() | undefined,
+                pres_timestamp :: integer() | undefined, % unix time in seconds
                 %% Are we invisible?
                 pres_invis = false :: boolean(),
                 privacy_list = #userlist{} :: mongoose_privacy:userlist(),

--- a/src/adhoc.erl
+++ b/src/adhoc.erl
@@ -124,7 +124,10 @@ produce_response(#adhoc_response{lang = _Lang,
     SessionID = if is_binary(ProvidedSessionID), ProvidedSessionID /= <<"">> ->
                         ProvidedSessionID;
                    true ->
-                        jlib:now_to_utc_binary(os:timestamp())
+                        USec = os:system_time(microsecond),
+                        TS = calendar:system_time_to_rfc3339(USec, [{offset, "Z"},
+                                                                    {unit, microsecond}]),
+                        list_to_binary(TS)
                 end,
     ActionsEls = case Actions of
                      [] ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -394,7 +394,8 @@ dump_reload_state(From, ReloadContext) ->
 
 dump_reload_state_filename() ->
     {ok, Pwd} = file:get_cwd(),
-    DateTime = jlib:now_to_utc_string(os:timestamp()),
+    DateTime = calendar:system_time_to_rfc3339(os:system_time(microsecond),
+                                               [{offset, "Z"}, {unit, microsecond}]),
     Filename = "reload_state_" ++ DateTime ++ ".dump",
     filename:join(Pwd, Filename).
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -65,9 +65,6 @@
 %% ----------------------------------------------------------------------
 %% Imports
 
--import(mod_mam_utils,
-        [microseconds_to_now/1]).
-
 %% UID
 -import(mod_mam_utils,
         [generate_message_id/0,
@@ -622,10 +619,10 @@ archive_message(Host, Params) ->
     exml:element().
 message_row_to_xml(MamNs, {MessID, SrcJID, Packet}, QueryID, SetClientNs)  ->
     {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
-    DateTime = calendar:now_to_universal_time(microseconds_to_now(Microseconds)),
+    TS = calendar:system_time_to_rfc3339(usec:to_sec(Microseconds), [{offset, "Z"}]),
     BExtMessID = mess_id_to_external_binary(MessID),
     Packet1 = mod_mam_utils:maybe_set_client_xmlns(SetClientNs, Packet),
-    wrap_message(MamNs, Packet1, QueryID, BExtMessID, DateTime, SrcJID).
+    wrap_message(MamNs, Packet1, QueryID, BExtMessID, TS, SrcJID).
 
 -spec message_row_to_ext_id(messid_jid_packet()) -> binary().
 message_row_to_ext_id({MessID, _, _}) ->

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -60,9 +60,6 @@
 %% ----------------------------------------------------------------------
 %% Imports
 
--import(mod_mam_utils,
-        [microseconds_to_now/1]).
-
 %% UID
 -import(mod_mam_utils,
         [generate_message_id/0,
@@ -509,12 +506,12 @@ archive_message(Host, Params) ->
 message_row_to_xml(MamNs, ReceiverJID, HideUser, SetClientNs, {MessID, SrcJID, Packet}, QueryID) ->
 
     {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
-    DateTime = calendar:now_to_universal_time(microseconds_to_now(Microseconds)),
+    TS = calendar:system_time_to_rfc3339(usec:to_sec(Microseconds), [{offset, "Z"}]),
     BExtMessID = mess_id_to_external_binary(MessID),
     Packet1 = maybe_delete_x_user_element(HideUser, ReceiverJID, Packet),
     Packet2 = mod_mam_utils:maybe_set_client_xmlns(SetClientNs, Packet1),
     Packet3 = replace_from_to_attributes(SrcJID, Packet2),
-    wrap_message(MamNs, Packet3, QueryID, BExtMessID, DateTime, SrcJID).
+    wrap_message(MamNs, Packet3, QueryID, BExtMessID, TS, SrcJID).
 
 maybe_delete_x_user_element(true, ReceiverJID, Packet) ->
     PacketJID = packet_to_x_user_jid(Packet),

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -203,7 +203,7 @@ archive_size(_Size, Host, _ArchiveID, ArchiveJID) ->
                     {binary(), binary()} | undefined.
 bucket(Host, MsgId) when is_integer(MsgId) ->
     {MicroSec, _} = mod_mam_utils:decode_compact_uuid(MsgId),
-    MsgNow = mod_mam_utils:microseconds_to_now(MicroSec),
+    MsgNow = usec:to_now(MicroSec),
     {MsgDate, _} = calendar:now_to_datetime(MsgNow),
     bucket(Host, MsgDate);
 bucket(Host, {_, _, _} = Date) ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3390,12 +3390,12 @@ items_event_stanza(Node, Items) ->
     case Items of
         [LastItem] ->
             {ModifNow, ModifUSR} = LastItem#pubsub_item.modification,
-            DateTime = calendar:now_to_datetime(ModifNow),
-            {TString, TzString} = jlib:timestamp_to_iso(DateTime, utc),
+            Sec = usec:to_sec(usec:from_now(ModifNow)),
+            TString = calendar:system_time_to_rfc3339(Sec, [{offset, "Z"}]),
             [#xmlel{name = <<"delay">>,
                     attrs = [{<<"xmlns">>, ?NS_DELAY},
                              {<<"from">>, jid:to_binary(ModifUSR)},
-                             {<<"stamp">>, iolist_to_binary([TString, TzString])}],
+                             {<<"stamp">>, list_to_binary(TString)}],
                     children = [{xmlcdata, <<>>}]}];
         _ ->
             []

--- a/src/pubsub/pubsub_form_utils.erl
+++ b/src/pubsub/pubsub_form_utils.erl
@@ -203,7 +203,7 @@ convert_value_from_binaries([Bin], boolean) ->
 convert_value_from_binaries([Bin], integer) ->
     binary_to_integer(Bin);
 convert_value_from_binaries([Bin], datetime) ->
-    jlib:datetime_binary_to_timestamp(Bin);
+    usec:to_now(calendar:rfc3339_to_system_time(binary_to_list(Bin), [{unit, microsecond}]));
 convert_value_from_binaries(Bins, list) when is_list(Bins) ->
     Bins.
 
@@ -215,7 +215,9 @@ convert_value_to_binaries(Value, boolean) ->
 convert_value_to_binaries(Value, integer) ->
     [integer_to_binary(Value)];
 convert_value_to_binaries(Value, datetime) ->
-    jlib:now_to_utc_binary(Value);
+    USec = usec:from_now(Value),
+    TS = calendar:system_time_to_rfc3339(USec, [{offset, "Z"}, {unit, microsecond}]),
+    list_to_binary(TS);
 convert_value_to_binaries(Value, list) when is_list(Value) ->
     Value.
 


### PR DESCRIPTION
Replace the custom functions in `jlib` for generating and parsing timestamps according to ISO 8601 with the corresponding function from the `calendar` module in the Erlang standard library.

Also:
- Remove unused time conversion utilities from `mod_mam_utils`
- Get rid of unnecessary conversions to `calendar:datetime()` and back when they happen one after the other

This is a refactoring PR, there are no functionality changes intended.
- The library functions verify the format of the parsed timestamps.
- There might be minor changes related to verification details - IMO it is better to trust the library implementation as it is [tested](https://github.com/erlang/otp/blob/master/lib/stdlib/test/calendar_SUITE.erl#L190) and the custom one had no tests.
