### PR TITLE
Allow extra HTTP headers in BOSH and WebSockets.

### DIFF
--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -163,10 +163,16 @@
         {transport_options, [{max_connections, 1024}]},
         {{{https_config}}}
         {modules, [
-            {"_", "/http-bind", mod_bosh},
+            {"_", "/http-bind", mod_bosh, [
+            %% Uncomment to enable HTTP custom headers. Header names must be
+            %% lowercase.
+            % {headers,[{"access-control-request-origin", "*"}]}
+            ]},
             {"_", "/ws-xmpp", mod_websockets, [
-            %% Uncomment to enable connection dropping or/and server-side pings
-            %{timeout, 600000}, {ping_rate, 60000}
+            %% Uncomment to enable connection dropping, server-side pings
+            %% and/or custom HTTP headers. Header names must be lowercase.
+            % {timeout, 600000}, {ping_rate, 60000},
+            % {headers,[{"access-control-Request-origin", "*"}]}
             ]}
             %% Uncomment to serve static files
             %{"_", "/static/[...]", cowboy_static,

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -66,10 +66,12 @@ init(Req, Opts) ->
     Req1 = add_sec_websocket_protocol_header(Req),
     ?DEBUG("cowboy init: ~p~n", [{Req, Opts}]),
     Timeout = gen_mod:get_opt(timeout, Opts, 60000),
-
-    AllModOpts = [{peer, Peer}, {peercert, PeerCert} | Opts],
+    ExtraHeaders = proplists:get_value(headers, Opts, []),
+    Req2 = cowboy:set_resp_headers(ExtraHeaders, Req1),
+    Opts1 = proplists:delete(headers, Opts),
+    AllModOpts = [{peer, Peer}, {peercert, PeerCert} | Opts1],
     %% upgrade protocol
-    {cowboy_websocket, Req1, AllModOpts, #{idle_timeout => Timeout}}.
+    {cowboy_websocket, Req2, AllModOpts, #{idle_timeout => Timeout}}.
 
 terminate(_Reason, _Req, _State) ->
     ok.


### PR DESCRIPTION
This is a WIP PR

Proposed changes include:
* Allowing extra headers for BOSH and WebSockets

This isn't ready yet. I just wanted to test the waters and see if you had an appetite for a patch like this. We want the ability to add CORS headers and security headers like HSTS to the BOSH and WebSockets endpoints.
