### PR TITLE
Update advertised message retraction namespaces

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -184,6 +184,7 @@
          mam_ns_binary_v04/0,
          mam_ns_binary_v06/0,
          retract_ns/0,
+         retract_tombstone_ns/0,
          make_alice_and_bob_friends/2,
          run_prefs_case/6,
          prefs_cases2/0,
@@ -2912,7 +2913,9 @@ discover_features(Config, Client, Service) ->
     escalus:assert(is_iq_result, Stanza),
     escalus:assert(has_feature, [mam_ns_binary_v04()], Stanza),
     escalus:assert(has_feature, [mam_ns_binary_v06()], Stanza),
-    ?assert_equal(message_retraction_is_enabled(Config), escalus_pred:has_feature(retract_ns(), Stanza)).
+    escalus:assert(has_feature, [retract_ns()], Stanza),
+    ?assert_equal(message_retraction_is_enabled(Config),
+                  escalus_pred:has_feature(retract_tombstone_ns(), Stanza)).
 
 metric_incremented_on_archive_request(ConfigIn) ->
     P = ?config(props, ConfigIn),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -87,10 +87,12 @@
          stanza_prefs_get_request/1,
          stanza_query_get_request/1,
          parse_prefs_result_iq/1,
+         namespaces/0,
          mam_ns_binary/0,
          mam_ns_binary_v04/0,
          mam_ns_binary_v06/0,
          retract_ns/0,
+         retract_tombstone_ns/0,
          make_alice_and_bob_friends/2,
          run_prefs_case/6,
          prefs_cases2/0,
@@ -222,10 +224,17 @@ nick(User) ->
     Name = escalus_utils:get_username(User),
     <<"unique_", Name/binary, "_nickname">>.
 
+namespaces() ->
+    [mam_ns_binary_v04(),
+     mam_ns_binary_v06(),
+     retract_ns(),
+     retract_tombstone_ns()].
+
 mam_ns_binary() -> mam_ns_binary_v04().
 mam_ns_binary_v04() -> <<"urn:xmpp:mam:1">>.
 mam_ns_binary_v06() -> <<"urn:xmpp:mam:2">>.
 retract_ns() -> <<"urn:xmpp:message-retract:0">>.
+retract_tombstone_ns() -> <<"urn:xmpp:message-retract:0#tombstone">>.
 
 skip_undefined(Xs) ->
     [X || X <- Xs, X =/= undefined].

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -2919,7 +2919,8 @@ disco_features_with_mam(Config) ->
                                   <<"vcard-temp">>,
                                   mam_helper:mam_ns_binary_v04(),
                                   mam_helper:mam_ns_binary_v06(),
-                                  mam_helper:retract_ns()]).
+                                  mam_helper:retract_ns(),
+                                  mam_helper:retract_tombstone_ns()]).
 
 disco_rooms(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
@@ -2937,25 +2938,19 @@ disco_rooms(Config) ->
     end).
 
 disco_info(Config) ->
-    muc_helper:disco_info_story(Config, [?NS_MUC,
-                                         <<"muc_public">>,
-                                         <<"muc_persistent">>,
-                                         <<"muc_open">>,
-                                         <<"muc_semianonymous">>,
-                                         <<"muc_moderated">>,
-                                         <<"muc_unsecured">>]).
+    muc_helper:disco_info_story(Config, muc_namespaces()).
 
 disco_info_with_mam(Config) ->
-    muc_helper:disco_info_story(Config, [?NS_MUC,
-                                         <<"muc_public">>,
-                                         <<"muc_persistent">>,
-                                         <<"muc_open">>,
-                                         <<"muc_semianonymous">>,
-                                         <<"muc_moderated">>,
-                                         <<"muc_unsecured">>,
-                                         mam_helper:mam_ns_binary_v04(),
-                                         mam_helper:mam_ns_binary_v06(),
-                                         mam_helper:retract_ns()]).
+    muc_helper:disco_info_story(Config, muc_namespaces() ++ mam_helper:namespaces()).
+
+muc_namespaces() ->
+    [?NS_MUC,
+     <<"muc_public">>,
+     <<"muc_persistent">>,
+     <<"muc_open">>,
+     <<"muc_semianonymous">>,
+     <<"muc_moderated">>,
+     <<"muc_unsecured">>].
 
 disco_items(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -306,9 +306,7 @@ disco_features_story(Config, HasMAM) ->
                                                         {element, <<"identity">>},
                                                         {attr, <<"category">>}]),
             FeaturesExpected = [?NS_MUC_LIGHT] ++ case HasMAM of
-                true -> [mam_helper:mam_ns_binary_v04(),
-                         mam_helper:mam_ns_binary_v06(),
-                         mam_helper:retract_ns()];
+                true -> mam_helper:namespaces();
                 false -> []
             end,
             FeaturesExpected = exml_query:paths(Stanza, [{element, <<"query">>},
@@ -329,9 +327,7 @@ disco_info_story(Config, HasMAM) ->
             escalus:send(Alice, DiscoStanza),
             Stanza = escalus:wait_for_stanza(Alice),
             FeaturesExpected = [?NS_MUC_LIGHT] ++ case HasMAM of
-                true -> [mam_helper:mam_ns_binary_v04(),
-                         mam_helper:mam_ns_binary_v06(),
-                         mam_helper:retract_ns()];
+                true -> mam_helper:namespaces();
                 false -> []
             end,
             FeaturesExpected = exml_query:paths(Stanza, [{element, <<"query">>},

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -218,19 +218,13 @@ disco_features(Config) ->
     muc_helper:disco_features_story(Config, [?NS_MUC]).
 
 disco_features_with_mam(Config) ->
-    muc_helper:disco_features_story(Config, [?NS_MUC,
-                                             mam_helper:mam_ns_binary_v04(),
-                                             mam_helper:mam_ns_binary_v06(),
-                                             mam_helper:retract_ns()]).
+    muc_helper:disco_features_story(Config, [?NS_MUC] ++ mam_helper:namespaces()).
 
 disco_info(Config) ->
     muc_helper:disco_info_story(Config, [?NS_MUC]).
 
 disco_info_with_mam(Config) ->
-    muc_helper:disco_info_story(Config, [?NS_MUC,
-                                         mam_helper:mam_ns_binary_v04(),
-                                         mam_helper:mam_ns_binary_v06(),
-                                         mam_helper:retract_ns()]).
+    muc_helper:disco_info_story(Config, [?NS_MUC] ++ mam_helper:namespaces()).
 
 disco_rooms(Config) ->
     escalus:story(Config, [{alice, 1}], fun(Alice) ->

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -95,6 +95,7 @@
 
 -define(NS_FASTEN,              <<"urn:xmpp:fasten:0">>).
 -define(NS_RETRACT,             <<"urn:xmpp:message-retract:0">>).
+-define(NS_RETRACT_TOMBSTONE,   <<"urn:xmpp:message-retract:0#tombstone">>).
 
 -define(JINGLE_NS, <<"urn:xmpp:jingle:1">>).
 

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -686,8 +686,8 @@ mam_features() ->
 
 retraction_features(Module, Host) ->
     case has_message_retraction(Module, Host) of
-        true -> [?NS_RETRACT];
-        false -> []
+        true -> [?NS_RETRACT, ?NS_RETRACT_TOMBSTONE];
+        false -> [?NS_RETRACT]
     end.
 
 %% -----------------------------------------------------------------------


### PR DESCRIPTION
Advertise the namespaces according to XEP-0424 v0.3.0:
- `urn:xmpp:message-retract:0` when MAM is enabled as retraction messages are archived in MAM
- `urn:xmpp:message-retract:0#tombstone` when message retraction is enabled as it uses tombstones

