### PR TITLE
Do not return 'none' from get_session_pid if there are many sessions

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -419,12 +419,9 @@ close_session_unset_presence(Acc, SID, JID, Status, Reason) ->
 -spec get_session_pid(JID) -> none | pid() when
       JID :: jid:jid().
 get_session_pid(JID) ->
-    #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
-    case ejabberd_gen_sm:get_sessions(sm_backend(), LUser, LServer, LResource) of
-        [#session{sid = {_, Pid}}] ->
-            Pid;
-        _ ->
-            none
+    case get_session(JID) of
+        offline -> none;
+        {_, {_, Pid}, _, _} -> Pid
     end.
 
 -spec get_unique_sessions_number() -> integer().


### PR DESCRIPTION
If there is more than one session for the given full JID,
choose the one with the highest session ID.

Motivation:
- Fix a bug during resumption: stanzas were not routed to the user
- Make the function consistent with get_session/1

