### PR TITLE
Logger/lager to logger

### DIFF
--- a/include/mongoose.hrl
+++ b/include/mongoose.hrl
@@ -28,8 +28,6 @@
 
 -define(CONFIG_PATH, "etc/mongooseim.cfg").
 
--define(LOCATION, {?MODULE, ?FUNCTION_NAME, ?LINE}).
-
 -define(MONGOOSE_URI, <<"https://www.erlang-solutions.com/products/mongooseim.html">>).
 
 %% ---------------------------------

--- a/include/mongoose_logger.hrl
+++ b/include/mongoose_logger.hrl
@@ -1,35 +1,37 @@
 -ifndef(MONGOOSEIM_LOGGER_HRL).
 -define(MONGOOSEIM_LOGGER_HRL, true).
 
+-include_lib("kernel/include/logger.hrl").
+
 -define(LOG_IF(Level, Condition, Format, Args),
-    (Condition) == true andalso lager:Level(Format, Args)).
+    (Condition) == true andalso ?LOG(Level, Format, Args)).
 
 -define(DEBUG(Format, Args),
-    lager:debug(Format, Args)).
+    ?LOG_DEBUG(Format, Args)).
 
 -define(DEBUG_IF(Condition, Format, Args),
     ?LOG_IF(debug, Condition, Format, Args)).
 
 -define(INFO_MSG(Format, Args),
-    lager:info(Format, Args)).
+    ?LOG_INFO(Format, Args)).
 
 -define(INFO_MSG_IF(Condition, Format, Args),
     ?LOG_IF(info, Condition, Format, Args)).
 
 -define(WARNING_MSG(Format, Args),
-    lager:warning(Format, Args)).
+    ?LOG_WARNING(Format, Args)).
 
 -define(WARNING_MSG_IF(Condition, Format, Args),
     ?LOG_IF(warning, Condition, Format, Args)).
 
 -define(ERROR_MSG(Format, Args),
-    lager:error(Format, Args)).
+    ?LOG_ERROR(Format, Args)).
 
 -define(ERROR_MSG_IF(Condition, Format, Args),
     ?LOG_IF(error, Condition, Format, Args)).
 
 -define(CRITICAL_MSG(Format, Args),
-    lager:critical(Format, Args)).
+    ?LOG_CRITICAL(Format, Args)).
 
 -define(CRITICAL_MSG_IF(Condition, Format, Args),
     ?LOG_IF(critical, Condition, Format, Args)).

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -1,4 +1,34 @@
 [
+ {kernel, [
+  {logger_level, warning},
+  {logger, [
+    %% Console logger
+    {handler, default, logger_std_h, #{}},
+    %% Disk logger for errors
+    {handler, disk_log, logger_disk_log_h,
+       #{config => #{
+           file => "{{mongooseim_log_dir}}/mongooseim.log",
+           type => wrap,
+           max_no_files => 5,
+           max_no_bytes => 2097152,
+           sync_mode_qlen => 2000, % If sync_mode_qlen is set to the same value as drop_mode_qlen,
+           drop_mode_qlen => 2000, % synchronous mode is disabled. That is, the handler always runs
+           flush_qlen => 5000,     % in asynchronous mode, unless dropping or flushing is invoked.
+           burst_limit_enable => true, % Default
+           burst_limit_max_count => 20, % Default
+           burst_limit_window_time => 500, % Default
+           overload_kill_enable => true,
+           overload_kill_qlen => 20000, % Default
+           overload_kill_mem_size => 3000000, % Default
+           overload_kill_restart_after => 5000 % Default
+         },
+         formatter => {logger_formatter, #{
+           depth => 12,
+           chars_limit => 1024
+         }}
+        }
+    }
+  ]}]},
  {setup, [{verify_directories, false}]},
  {{mongooseim_mdb_dir_toggle}}{mnesia, [{dir, "{{mongooseim_mdb_dir}}"}]},
  {ssl, [
@@ -11,39 +41,6 @@
     %% Variable is called log_path, however it is used for caching
     {log_path, "{{nksip_cache_dir}}"}
  ]},
- {lager, [
-    {colored, true},
-    %% Alternate colors for white background
-    %% info, notice and warning levels were changed comparing to default
-    %{colors, [
-    %          {debug,     "\e[0;38m" },
-    %          {info,      "\e[0;34m" },
-    %          {notice,    "\e[0;36m" },
-    %          {warning,   "\e[1;34m" },
-    %          {error,     "\e[1;31m" },
-    %          {critical,  "\e[1;35m" },
-    %          {alert,     "\e[1;44m" },
-    %          {emergency, "\e[1;41m" }
-    %         ]},
-    %% Limit the number of messages per second allowed from error_logger
-    {error_logger_hwm, 100},
-    %% Make logging more async
-    %% If some very heavy loaded process want to log something, it's better to
-    %% not block the process.
-    {async_threshold, 2000},
-    {async_threshold_window, 500},
-    %% Kill sink if it has more than 10k messages
-    {killer_hwm, 10000},
-    {killer_reinstall_after, 5000},
-    {log_root, "{{mongooseim_log_dir}}"},
-    {crash_log, "crash.log"},
-    {handlers, [
-        {lager_console_backend, [{level, info}]},
-%% use below line to add syslog backend for Lager
-%        {lager_syslog_backend, [ "mongooseim", local0, info]},
-        {lager_file_backend, [{file, "ejabberd.log"}, {level, info}, {size, 2097152}, {date, "$D0"}, {count, 5}]}
-    ]}
-  ]},
   %% Swagger spec
   {cowboy_swagger,
     [

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -14,13 +14,9 @@
            sync_mode_qlen => 2000, % If sync_mode_qlen is set to the same value as drop_mode_qlen,
            drop_mode_qlen => 2000, % synchronous mode is disabled. That is, the handler always runs
            flush_qlen => 5000,     % in asynchronous mode, unless dropping or flushing is invoked.
-           burst_limit_enable => true, % Default
-           burst_limit_max_count => 20, % Default
-           burst_limit_window_time => 500, % Default
-           overload_kill_enable => true,
-           overload_kill_qlen => 20000, % Default
-           overload_kill_mem_size => 3000000, % Default
-           overload_kill_restart_after => 5000 % Default
+           overload_kill_enable => true
+           % Documentation about Overload protection, together with default values, can be found here:
+           % http://erlang.org/doc/apps/kernel/logger_chapter.html#protecting-the-handler-from-overload
          },
          formatter => {logger_formatter, #{
            depth => 12,

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -38,7 +38,6 @@
 %%%
 
 start(normal, _Args) ->
-    init_log(),
     mongoose_fips:notify(),
     write_pid_file(),
     update_status_file(starting),
@@ -227,29 +226,4 @@ delete_pid_file() ->
             ok;
         PidFilename ->
             file:delete(PidFilename)
-    end.
-
-init_log() ->
-    maybe_disable_default_logger(),
-    ejabberd_loglevel:init(),
-    case application:get_env(mongooseim, keep_lager_intact, false) of
-        true ->
-            skip;
-        false ->
-            ejabberd_loglevel:set(4)
-    end.
-
-maybe_disable_default_logger() ->
-    try
-
-        Loggers = logger:get_handler_ids(),
-        case lists:member(default, Loggers) of
-            true ->
-                logger:remove_handler(default);
-            _ ->
-                ok
-        end
-    catch
-        _E:_R ->
-            ok
     end.

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -156,20 +156,20 @@ terminate(_Reason, _State) ->
 %% Internal
 %%-----------------------------------------
 msg_removed_from_config() ->
-    <<"We're sorry to hear you don't want to share the system's metrics with us. "
-      "These metrics would enable us to improve MongooseIM and know where to focus our efforts. "
-      "To stop being notified, you can add this to the services section of your config file: \n"
-      "    '{service_mongoose_system_metrics, [no_report]}' \n"
-      "For more info on how to customise, read, enable, and disable the metrics visit: \n"
-      "- MongooseIM docs - \n"
-      "     https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
-      "- MongooseIM GitHub page - https://github.com/esl/MongooseIM">>.
+    "We're sorry to hear you don't want to share the system's metrics with us. "
+    "These metrics would enable us to improve MongooseIM and know where to focus our efforts. "
+    "To stop being notified, you can add this to the services section of your config file: \n"
+    "    '{service_mongoose_system_metrics, [no_report]}' \n"
+    "For more info on how to customise, read, enable, and disable the metrics visit: \n"
+    "- MongooseIM docs - \n"
+    "     https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
+    "- MongooseIM GitHub page - https://github.com/esl/MongooseIM".
 
 msg_accept_terms_and_conditions() ->
-    <<"We are gathering the MongooseIM system's metrics to analyse the trends and needs of our users, "
-      "improve MongooseIM, and know where to focus our efforts. "
-      "For more info on how to customise, read, enable, and disable these metrics visit: \n"
-      "- MongooseIM docs - \n"
-      "      https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
-      "- MongooseIM GitHub page - https://github.com/esl/MongooseIM \n"
-      "The last sent report is also written to a file ~s">>.
+    "We are gathering the MongooseIM system's metrics to analyse the trends and needs of our users, "
+    "improve MongooseIM, and know where to focus our efforts. "
+    "For more info on how to customise, read, enable, and disable these metrics visit: \n"
+    "- MongooseIM docs - \n"
+    "      https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
+    "- MongooseIM GitHub page - https://github.com/esl/MongooseIM \n"
+    "The last sent report is also written to a file ~s".


### PR DESCRIPTION
This PR basically attempts to introduce a working logger configuration to MIM, without yet fixing tests and other helper functionality that depend on the old lager.

Work goes to a feature branch called `otp_logger`