### PR TITLE
Fix tide status in github

### DIFF
--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -12,7 +12,7 @@ export BUILDS=`pwd`
 # git tag when building from tag itself, and is unique in any other case
 VERSION=`tools/generate_vsn.sh`
 DOCKERHUB_TAG=${VERSION}
-GIT_REF=`git rev-parse --short HEAD`
+GIT_REF=`git rev-parse HEAD`
 GIT_COMMIT_MSG=`git log --format=%B -n 1 HEAD`
 
 if [ -n "$CIRCLE_PULL_REQUEST" ]; then


### PR DESCRIPTION
This PR aims to restore Tide notifications to Github, to be shown there together with Travis and CircleCi status. The fix includes:
* pass full git commit sha (not the short form) to be later used by Tide when posting status to Github
* update the github access token for Tide (this part is to be done in Tide repo)
