### PR TITLE
Set directory for erl_crash.dump

### DIFF
--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -33,6 +33,9 @@ cd "$RUNNER_BASE_DIR"
 # Make sure log directory exists
 mkdir -p "$RUNNER_LOG_DIR"
 
+# Save possible erl_crash.dump in log directory
+export ERL_CRASH_DUMP="${RUNNER_LOG_DIR}/erl_crash.dump"
+
 # Extract the target node name from node.args
 NAME_ARG=`egrep -e '^-s?name' "$RUNNER_ETC_DIR"/vm.args`
 if [ -z "$NAME_ARG" ]; then


### PR DESCRIPTION
After this PR change place for the possible `erl_crash.dump` will be explicitly set to `${RUNNER_LOG_DIR}/erl_crash.dump`.

