### PR TITLE
Get rid of conf reload in tests

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -128,36 +128,30 @@ suite() ->
 
 init_per_suite(Config) ->
     Config0 = escalus:init_per_suite([{escalus_user_db, {module, escalus_ejabberd, []}} | Config]),
-    Config1 = ejabberd_node_utils:init(Config0),
-    ejabberd_node_utils:backup_config_file(Config1),
+    C2SPort = ct:get_config({hosts, mim, c2s_port}),
+    [{_, ejabberd_c2s, _} = C2SListener] = mongoose_helper:get_listener_opts(mim(), C2SPort),
+    Config1 = [{c2s_listener, C2SListener} | Config0],
     assert_cert_file_exists(),
     escalus:create_users(Config1, escalus:get_users([?SECURE_USER, alice])).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     escalus:delete_users(Config, escalus:get_users([?SECURE_USER, alice])),
-    restore_ejabberd_node(Config),
+    restore_c2s_listener(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(c2s_noproc, Config) ->
-    config_ejabberd_node_tls(Config,
-                             fun mk_value_for_starttls_config_pattern/0),
-    ejabberd_node_utils:restart_application(mongooseim),
+    config_ejabberd_node_c2s(Config, [starttls]),
     Config;
 init_per_group(session_replacement, Config) ->
-    config_ejabberd_node_tls(Config,
-                             fun mk_value_for_starttls_config_pattern/0),
-    ejabberd_node_utils:restart_application(mongooseim),
+    config_ejabberd_node_c2s(Config, [starttls]),
     lager_ct_backend:start(),
     Config;
 init_per_group(starttls, Config) ->
-    config_ejabberd_node_tls(Config,
-                             fun mk_value_for_starttls_required_config_pattern/0),
-    ejabberd_node_utils:restart_application(mongooseim),
+    config_ejabberd_node_c2s(Config, [starttls_required]),
     Config;
 init_per_group(tls, Config) ->
-    config_ejabberd_node_tls(Config, fun mk_value_for_tls_config_pattern/0),
-    ejabberd_node_utils:restart_application(mongooseim),
+    config_ejabberd_node_c2s(Config, [tls]),
     Users = proplists:get_value(escalus_users, Config, []),
     JoeSpec = lists:keydelete(starttls, 1, proplists:get_value(?SECURE_USER, Users)),
     JoeSpec2 = {?SECURE_USER, lists:keystore(ssl, 1, JoeSpec, {ssl, true})},
@@ -165,8 +159,7 @@ init_per_group(tls, Config) ->
     Config2 = lists:keystore(escalus_users, 1, Config, {escalus_users, NewUsers}),
     [{c2s_port, ct:get_config({hosts, mim, c2s_port})} | Config2];
 init_per_group(feature_order, Config) ->
-    config_ejabberd_node_tls(Config, fun mk_value_for_compression_config_pattern/0),
-    ejabberd_node_utils:restart_application(mongooseim),
+    config_ejabberd_node_c2s(Config, [starttls_required, {zlib, 10000}]),
     Config;
 init_per_group(just_tls,Config)->
     [{tls_module, just_tls} | Config];
@@ -175,9 +168,7 @@ init_per_group(fast_tls,Config)->
 init_per_group(session_replacement, Config) ->
     Config;
 init_per_group(proxy_protocol, Config) ->
-    %% Use 'tls_config' to add the listener option for the proxy protocol
-    ejabberd_node_utils:modify_config_file([{tls_config, "{proxy_protocol, true},"}], Config),
-    ejabberd_node_utils:restart_application(mongooseim),
+    config_ejabberd_node_c2s(Config, [{proxy_protocol, true}]),
     Config;
 init_per_group(_, Config) ->
     Config.
@@ -331,7 +322,6 @@ clients_can_connect_with_advertised_ciphers(Config) ->
     ?assert(length(ciphers_working_with_ssl_clients(Config)) > 0).
 
 'clients_can_connect_with_ECDHE-RSA-AES256-GCM-SHA384'(Config) ->
-    
     ?assert(lists:member("ECDHE-RSA-AES256-GCM-SHA384",
                          ciphers_working_with_ssl_clients(Config))).
 
@@ -763,31 +753,29 @@ openssl_client_can_use_cipher(Cipher, Port) ->
     {done, ReturnCode, _Result} = erlsh:oneliner(Cmd),
     0 == ReturnCode.
 
-restore_ejabberd_node(Config) ->
-    ejabberd_node_utils:restore_config_file(Config),
-    ejabberd_node_utils:restart_application(mongooseim).
+restore_c2s_listener(Config) ->
+    {_, _, Opts} = C2SListener = ?config(c2s_listener, Config),
+    mongoose_helper:restart_listener_with_opts(mim(), C2SListener, Opts).
 
 assert_cert_file_exists() ->
     ejabberd_node_utils:file_exists(?CERT_FILE) orelse
         ct:fail("cert file ~s not exists", [?CERT_FILE]).
 
-config_ejabberd_node_tls(Config, Fun) ->
-    TLSModConf = "{tls_module," ++ atom_to_list(?config(tls_module, Config)) ++ "},",
-    ejabberd_node_utils:modify_config_file([Fun(), {tls_module, TLSModConf}], Config).
+config_ejabberd_node_c2s(Config, ExtraC2SOpts) ->
+    Opts = ExtraC2SOpts ++ common_c2s_opts(Config),
+    C2SListener = ?config(c2s_listener, Config),
+    mongoose_helper:restart_listener_with_opts(mim(), C2SListener, Opts).
 
-mk_value_for_starttls_config_pattern() ->
-    {tls_config, "{certfile, \"" ++ ?CERT_FILE ++ "\"}, starttls,"}.
-
-mk_value_for_tls_config_pattern() ->
-    {tls_config, "{certfile, \"" ++ ?CERT_FILE ++ "\"}, tls,"}.
-
-mk_value_for_compression_config_pattern() ->
-    {tls_config, "{certfile, \"" ++ ?CERT_FILE ++ "\"}, " ++
-                 "starttls_required,  {zlib, 10000},"}.
-
-mk_value_for_starttls_required_config_pattern() ->
-    {tls_config, "{certfile, \"" ++ ?CERT_FILE ++ "\"}, " ++
-                 "starttls_required, {dhfile, \"" ++ ?DH_FILE ++ "\"},"}.
+common_c2s_opts(Config) ->
+    TLSModule = ?config(tls_module, Config),
+    [{tls_module, TLSModule},
+     {certfile, ?CERT_FILE},
+     %starttls,
+     %{zlib, 10000},
+     {access, c2s},
+     {shaper, c2s_shaper},
+     {max_stanza_size, 65536},
+     {dhfile, "priv/ssl/fake_dh_server.pem"}].
 
 set_secure_connection_protocol(UserSpec, Version) ->
     [{ssl_opts, [{versions, [Version]}]} | UserSpec].

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -112,16 +112,19 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    Config1 = mongoose_helper:backup_auth_config(Config),
+    Config0 = mongoose_helper:backup_auth_config(Config),
+    Config1 = mongoose_helper:backup_sasl_mechanisms_config(Config0),
     mongoose_helper:set_store_password(scram),
     escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     mongoose_helper:restore_auth_config(Config),
+    mongoose_helper:restore_sasl_mechanisms_config(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(login_digest, Config) ->
+init_per_group(login_digest, ConfigIn) ->
+    Config = mongoose_helper:backup_sasl_mechanisms_config(ConfigIn),
     mongoose_helper:set_store_password(plain),
     case mongoose_helper:supports_sasl_module(cyrsasl_digest) of
         false ->
@@ -162,8 +165,8 @@ init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 end_per_group(login_digest, Config) ->
-    restore_config(Config),
     mongoose_helper:set_store_password(scram),
+    mongoose_helper:restore_sasl_mechanisms_config(Config),
     escalus:delete_users(Config, escalus:get_users([alice, bob]));
 end_per_group(GroupName, Config) when
     GroupName == login_scram; GroupName == login_specific_scram ->
@@ -394,12 +397,9 @@ config_ejabberd_node_tls(Config) ->
     Config1.
 
 configure_digest(Config) ->
-    Config1 = ejabberd_node_utils:init(Config),
-    ejabberd_node_utils:backup_config_file(Config1),
-    ejabberd_node_utils:modify_config_file([{sasl_mechanisms, "{sasl_mechanisms, [cyrsasl_digest]}."}], Config1),
-    ejabberd_node_utils:restart_application(mongooseim),
+    mongoose_helper:set_sasl_mechanisms(sasl_mechanisms, [cyrsasl_digest]),
     mongoose_helper:set_store_password(plain),
-    Config1.
+    Config.
 
 restore_config(Config) ->
     ejabberd_node_utils:restore_config_file(Config),

--- a/big_tests/tests/s2s_helper.erl
+++ b/big_tests/tests/s2s_helper.erl
@@ -28,12 +28,12 @@ init_s2s(Config) ->
     Node1S2SCertfile = rpc(mim(), ejabberd_config, get_local_option, [s2s_certfile]),
     Node1S2SUseStartTLS = rpc(mim(), ejabberd_config, get_local_option, [s2s_use_starttls]),
     Node1S2SPort = ct:get_config({hosts, mim, incoming_s2s_port}),
-    [Node1S2SListener] = get_listener_opts(mim(), Node1S2SPort),
+    [Node1S2SListener] = mongoose_helper:get_listener_opts(mim(), Node1S2SPort),
 
     Node2S2SCertfile = rpc(fed(), ejabberd_config, get_local_option, [s2s_certfile]),
     Node2S2SUseStartTLS = rpc(fed(), ejabberd_config, get_local_option, [s2s_use_starttls]),
     Node2S2SPort = ct:get_config({hosts, fed, incoming_s2s_port}),
-    [Node2S2SListener] = get_listener_opts(fed(), Node2S2SPort),
+    [Node2S2SListener] = mongoose_helper:get_listener_opts(fed(), Node2S2SPort),
     S2S = #s2s_opts{node1_s2s_certfile = Node1S2SCertfile,
                     node1_s2s_use_starttls = Node1S2SUseStartTLS,
                     node1_s2s_listener = Node1S2SListener,
@@ -132,12 +132,6 @@ restart_s2s(#{} = Spec, S2SListener) ->
     [rpc(Spec, erlang, exit, [Pid, kill]) ||
      {_, Pid, _, _} <- ChildrenIn],
 
-    {PortIPProto, ejabberd_s2s_in, Opts} = S2SListener,
+    {_PortIPProto, ejabberd_s2s_in, Opts} = S2SListener,
+    mongoose_helper:restart_listener_with_opts(Spec, S2SListener, Opts).
 
-    rpc(Spec, ejabberd_listener, stop_listener, [PortIPProto, ejabberd_s2s_in]),
-    rpc(Spec, ejabberd_listener, start_listener, [PortIPProto, ejabberd_s2s_in, Opts]).
-
-get_listener_opts(#{} = Spec, Port) ->
-    Listeners = rpc(Spec, ejabberd_config, get_local_option, [listen]),
-
-    [Item || {{ListenerPort, _, _}, _, _} = Item <- Listeners, ListenerPort =:= Port].


### PR DESCRIPTION
This PR replaces some of the places in `big_tests` where config templating and application restart was needed to test some things. Now only relevant parts of MongooseIM are reconfigured and restarted when needed.
