### PR TITLE
TOML config templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ priv/mibs/EJABBERD-MIB.bin
 ebin/ejabberd.app
 rel/configure.vars.config
 rel/vars.config
+rel/vars-toml.config
 compile_commands.json
 # Compilation/test ephemera
 *.d

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ clean:
 	-rm -rf _build
 	-rm rel/configure.vars.config
 	-rm rel/vars.config
+	-rm rel/var-toml.config
 
 # REBAR_CT_EXTRA_ARGS comes from a test runner
 ct:
@@ -22,7 +23,7 @@ ct:
 		then $(RUN) $(REBAR) ct --dir test --suite $(SUITE) ; \
 		else $(RUN) $(REBAR) ct $(REBAR_CT_EXTRA_ARGS); fi)
 
-rel: certs configure.out rel/vars.config
+rel: certs configure.out rel/vars.config rel/vars-toml.config
 	. ./configure.out && $(REBAR) as prod release
 
 shell: certs etc/mongooseim.cfg
@@ -38,6 +39,9 @@ rock:
 rel/vars.config: rel/vars.config.in rel/configure.vars.config
 	cat $^ > $@
 
+rel/vars-toml.config: rel/vars-toml.config.in rel/configure.vars.config
+	cat $^ > $@
+
 ## Don't allow these files to go out of sync!
 configure.out rel/configure.vars.config:
 	./tools/configure with-all without-jingle-sip
@@ -51,7 +55,7 @@ devrel: $(DEVNODES)
 print_devnodes:
 	@echo $(DEVNODES)
 
-$(DEVNODES): certs configure.out rel/vars.config
+$(DEVNODES): certs configure.out rel/vars.config rel/vars-toml.config
 	@echo "building $@"
 	(. ./configure.out && \
 	DEVNODE=true $(RUN) $(REBAR) as $@ release)

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -17,7 +17,7 @@
 %%       so that we rein the "bag of things" approach
 {hosts, [{mim,  [{node, mongooseim@localhost},
                  {domain, <<"localhost">>},
-                 {vars, "mim1.vars.config"},
+                 {vars, "mim1.vars-toml.config"},
                  {cluster, mim},
                  {secondary_domain, <<"localhost.bis">>},
                  {reloaded_domain, <<"sogndal">>},
@@ -36,7 +36,7 @@
                  {http_notifications_port, 8000}]},
          {mim2, [{node, ejabberd2@localhost},
                  {domain, <<"localhost">>},
-                 {vars, "mim2.vars.config"},
+                 {vars, "mim2.vars-toml.config"},
                  {cluster, mim},
                  {c2s_tls_port, 5233},
                  {metrics_rest_port, 5289},
@@ -44,20 +44,20 @@
                  {service_port, 8899}]},
          {mim3, [{node, mongooseim3@localhost},
                  {domain, <<"localhost">>},
-                 {vars, "mim3.vars.config"},
+                 {vars, "mim3.vars-toml.config"},
                  {c2s_tls_port, 5263},
                  {cluster, mim}]},
          %% used to test s2s features
          {fed,  [{node, fed1@localhost},
                  {domain, <<"fed1">>},
-                 {vars, "fed1.vars.config"},
+                 {vars, "fed1.vars-toml.config"},
                  {incoming_s2s_port, 5299},
                  {c2s_port, 5242},
                  {cluster, fed}]},
          %% used to test global distribution features
          {reg,  [{node, reg1@localhost},
                  {domain, <<"reg1">>},
-                 {vars, "reg1.vars.config"},
+                 {vars, "reg1.vars-toml.config"},
                  {service_port, 9990},
                  {c2s_port, 5252},
                  {gd_endpoint_port, 7777},
@@ -205,133 +205,184 @@
     {internal_mnesia,
      %% dbs variable is used by ./tools/test_runner/presets_to_dbs.sh script
      [{dbs, [redis, minio]},
-      {sm_backend, "{mnesia, []}"},
-      {auth_method, "internal"},
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []}
-       ]}."},
-      {mod_offline, "{mod_offline, []},"}]},
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10"},
+      {mod_offline, "[modules.mod_offline]"}]},
     {pgsql_mnesia,
      [{dbs, [redis, pgsql]},
-      {sm_backend, "{mnesia, []}"},
-      {auth_method, "rdbms"},
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []},
-       {rdbms, global, default, [{workers, 5}],
-        [{server, {pgsql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
-                   [{ssl, required}, {ssl_opts, [{verify, verify_peer},
-                    {cacertfile, \"priv/ssl/cacert.pem\"}, {server_name_indication, disable}]}]}}]}
-       ]}."},
-      {mod_last, "{mod_last, [{backend, rdbms}]},"},
-      {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},
-      {mod_private, "{mod_private, [{backend, rdbms}]},"},
-      {mod_offline, "{mod_offline, [{backend, rdbms}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, rdbms}, {host, \"vjud.@HOST@\"}]},"},
-      {mod_roster, "{mod_roster, [{backend, rdbms}]},"}]},
+      {auth_method, "\"rdbms\""},
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10
+[outgoing_pools.rdbms.default]
+  scope = \"global\"
+  workers = 5
+  connection.driver = \"pgsql\"
+  connection.host = \"localhost\"
+  connection.database = \"ejabberd\"
+  connection.username = \"ejabberd\"
+  connection.password = \"mongooseim_secret\"
+  connection.tls.required = true
+  connection.tls.verify_peer = true
+  connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
+  connection.tls.server_name_indication = false"},
+      {mod_last, "[modules.mod_last]
+  backend = \"rdbms\""},
+      {mod_privacy, "[modules.mod_privacy]
+  backend = \"rdbms\""},
+      {mod_private, "[modules.mod_private]
+  backend = \"rdbms\""},
+      {mod_offline, "[modules.mod_offline]
+  backend = \"rdbms\""},
+      {mod_vcard, "[modules.mod_vcard]
+  backend = \"rdbms\"
+  host = \"vjud.@HOST@\""},
+      {mod_roster, "[modules.mod_roster]
+  backend = \"rdbms\""}]},
     {odbc_mssql_mnesia,
      [{dbs, [redis, mssql]},
-      {sm_backend, "{mnesia, []}"},
-      {auth_method, "rdbms"},
-      {rdbms_server_type, "{rdbms_server_type, mssql}."},
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []},
-       {rdbms, global, default, [{workers, 5}],
-        [{server, \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\"}]}
-       ]}."},
-      {mod_last, "{mod_last, [{backend, rdbms}]},"},
-      {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},
-      {mod_private, "{mod_private, [{backend, rdbms}]},"},
-      {mod_offline, "{mod_offline, [{backend, rdbms}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, rdbms}, {host, \"vjud.@HOST@\"}]},"},
-      {mod_roster, "{mod_roster, [{backend, rdbms}]},"}]},
+      {auth_method, "\"rdbms\""},
+      {rdbms_server_type, "rdbms_server_type = \"mssql\""},
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10
+[outgoing_pools.rdbms.default]
+  scope = \"global\"
+  workers = 5
+  connection.driver = \"odbc\"
+  connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
+      {mod_last, "[modules.mod_last]
+  backend = \"rdbms\""},
+      {mod_privacy, "[modules.mod_privacy]
+  backend = \"rdbms\""},
+      {mod_private, "[modules.mod_private]
+  backend = \"rdbms\""},
+      {mod_offline, "[modules.mod_offline]
+  backend = \"rdbms\""},
+      {mod_vcard, "[modules.mod_vcard]
+  backend = \"rdbms\"
+  host = \"vjud.@HOST@\""},
+      {mod_roster, "[modules.mod_roster]
+  backend = \"rdbms\""}]},
     {mysql_redis,
      [{dbs, [redis, mysql]},
-      {sm_backend, "{redis, []}"},
-      {auth_method, "rdbms"},
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []},
-       {redis, global, default, [{workers, 10}, {strategy, random_worker}], []},
-       {rdbms, global, default, [{workers, 5}],
-        [{server, {mysql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
-                   [{versions, ['tlsv1.2']}, {verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"}]}}]}
-       ]}."},
-      {mod_last, "{mod_last, [{backend, rdbms}]},"},
-      {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},
-      {mod_private, "{mod_private, [{backend, mysql}]},"},
-      {mod_offline, "{mod_offline, [{backend, rdbms}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, rdbms}, {host, \"vjud.@HOST@\"}]},"},
-      {mod_roster, "{mod_roster, [{backend, rdbms}]},"}]},
+      {sm_backend, "\"redis\""},
+      {auth_method, "\"rdbms\""},
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10
+[outgoing_pools.redis.default]
+  scope = \"global\"
+  workers = 10
+  strategy = \"random_worker\"
+[outgoing_pools.rdbms.default]
+  scope = \"global\"
+  workers = 5
+  connection.driver = \"mysql\"
+  connection.host = \"localhost\"
+  connection.database = \"ejabberd\"
+  connection.username = \"ejabberd\"
+  connection.password = \"mongooseim_secret\"
+  connection.tls.verify_peer = true
+  connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
+  connection.tls.versions = [\"tlsv1.2\"]"},
+      {mod_last, "[modules.mod_last]
+  backend = \"rdbms\""},
+      {mod_privacy, "[modules.mod_privacy]
+  backend = \"rdbms\""},
+      {mod_private, "[modules.mod_private]
+  backend = \"rdbms\""},
+      {mod_offline, "[modules.mod_offline]
+  backend = \"rdbms\""},
+      {mod_vcard, "[modules.mod_vcard]
+  backend = \"rdbms\"
+  host = \"vjud.@HOST@\""},
+      {mod_roster, "[modules.mod_roster]
+  backend = \"rdbms\""}]},
     {ldap_mnesia,
      [{dbs, [redis, ldap]},
-      {sm_backend, "{mnesia, []}"},
-      {auth_method, "ldap"},
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []},
-       {ldap, global, default, [{workers, 5}], [{port, 3636},
-                                                {rootdn, \"cn=admin,dc=esl,dc=com\"},
-                                                {password, \"mongooseim_secret\"},
-                                                {encrypt, tls},
-                                                {tls_options, [{versions, ['tlsv1.2']},
-                                                               {verify, verify_peer},
-                                                               {cacertfile, \"priv/ssl/cacert.pem\"},
-                                                               {certfile, \"priv/ssl/fake_cert.pem\"},
-                                                               {keyfile, \"priv/ssl/fake_key.pem\"}]}]},
-       {ldap, global, bind, [{workers, 5}], [{port, 3636},
-                                             {encrypt, tls},
-                                             {tls_options, [{versions, ['tlsv1.2']},
-                                                            {verify, verify_peer},
-                                                            {cacertfile, \"priv/ssl/cacert.pem\"},
-                                                            {certfile, \"priv/ssl/fake_cert.pem\"},
-                                                            {keyfile, \"priv/ssl/fake_key.pem\"}]}]}
-       ]}."},
-      {mod_offline, "{mod_offline, []},"},
-      {password_format, "{password_format, scram}"},
-      {auth_ldap, ", {ldap_base, \"ou=Users,dc=esl,dc=com\"},
-                     {ldap_filter, \"(objectClass=inetOrgPerson)\"}"
-      },
-      {mod_vcard,"{mod_vcard, [{backend, ldap}, {host, \"vjud.@HOST@\"},\n"
-                               "{ldap_base, \"ou=Users,dc=esl,dc=com\"},\n"
-                               "{ldap_filter,\"(objectClass=inetOrgPerson)\"}\n"
-                               "]},"}
-     ]},
+      {auth_method, "\"ldap\""},
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10
+[outgoing_pools.ldap.default]
+  scope = \"global\"
+  workers = 5
+  connection.port = 3636
+  connection.rootdn = \"cn=admin,dc=esl,dc=com\"
+  connection.password = \"mongooseim_secret\"
+  connection.encrypt = \"tls\"
+  connection.tls.versions = [\"tlsv1.2\"]
+  connection.tls.verify_peer = true
+  connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
+  connection.tls.certfile = \"priv/ssl/fake_cert.pem\"
+  connection.tls.keyfile = \"priv/ssl/fake_key.pem\"
+[outgoing_pools.ldap.bind]
+  scope = \"global\"
+  workers = 5
+  connection.port = 3636
+  connection.encrypt = \"tls\"
+  connection.tls.versions = [\"tlsv1.2\"]
+  connection.tls.verify_peer = true
+  connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
+  connection.tls.certfile = \"priv/ssl/fake_cert.pem\""},
+      {password_format, "password.format = \"scram\""},
+      {auth_ldap, "ldap_base = \"ou=Users,dc=esl,dc=com\"
+  ldap_filter = \"(objectClass=inetOrgPerson)\""},
+      {mod_vcard, "[modules.mod_vcard]
+  backend = \"ldap\"
+  host = \"vjud.@HOST@\"
+  ldap_base = \"ou=Users,dc=esl,dc=com\"
+  ldap_filter = \"(objectClass=inetOrgPerson)\""}]},
     {riak_mnesia,
      [{dbs, [redis, riak]},
-      {sm_backend, "{mnesia, []}"},
-      {auth_method, "riak"},
+      {auth_method, "\"riak\""},
       %% Specify a list of ciphers to avoid
       %% "no function clause matching tls_v1:enum_to_oid(28)" error
       %% on Riak's side running with Erlang R16.
       %% https://github.com/basho/riak-erlang-client/issues/232#issuecomment-178612129
       %% We also set ciphers in tools/setup_riak on the server side.
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []},
-       {riak, global, default, [{workers, 5},
-                                {strategy, next_worker}],
-                               [{address, \"127.0.0.1\"},{port, 8087},
-                                {ssl_opts, [{ciphers, [\"AES256-SHA\", \"DHE-RSA-AES128-SHA256\"]},
-                                            {server_name_indication, disable}]},
-                                {credentials, \"ejabberd\", \"mongooseim_secret\"},
-                                {cacertfile, \"priv/ssl/cacert.pem\"}]}
-       ]}."},
-      {mod_roster, "{mod_roster, [{backend, riak}]},"},
-      {mod_private, "{mod_private, [{backend, riak}]},"},
-      {mod_vcard, "{mod_vcard, [{backend, riak}, {host, \"vjud.@HOST@\"}]},"},
-      {mod_offline, "{mod_offline, [{backend, riak}]},"},
-      {mod_last, "{mod_last, [{backend, riak}]},"},
-      {mod_privacy, "{mod_privacy, [{backend, riak}]},"}
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10
+[outgoing_pools.riak.default]
+  scope = \"global\"
+  workers = 5
+  strategy = \"next_worker\"
+  connection.address = \"127.0.0.1\"
+  connection.port = 8087
+  connection.username = \"ejabberd\"
+  connection.password = \"mongooseim_secret\"
+  connection.tls.ciphers = [\"AES256-SHA\", \"DHE-RSA-AES128-SHA256\"]
+  connection.tls.server_name_indication = false
+  connection.cacertfile = \"priv/ssl/cacert.pem\""},
+      {mod_last, "[modules.mod_last]
+  backend = \"riak\""},
+      {mod_privacy, "[modules.mod_privacy]
+  backend = \"riak\""},
+      {mod_private, "[modules.mod_private]
+  backend = \"riak\""},
+      {mod_offline, "[modules.mod_offline]
+  backend = \"riak\""},
+      {mod_vcard, "[modules.mod_vcard]
+  backend = \"riak\"
+  host = \"vjud.@HOST@\""},
+      {mod_roster, "[modules.mod_roster]
+  backend = \"riak\""}
      ]},
     {elasticsearch_and_cassandra_mnesia,
      [{dbs, [redis, elasticsearch, cassandra]},
-      {sm_backend, "{mnesia, []}"},
-      {outgoing_pools, "{outgoing_pools, [
-       {redis, global, global_distrib, [{workers, 10}], []},
-       {cassandra, global, default, [{workers, 20}],
-                               [{ssl,[{cacertfile, \"priv/ssl/cacert.pem\"},
-                                      {verify, verify_peer}] }]},
-       {elastic, global, default, [], []}
-       ]}."},
-      {auth_method, "internal"},
-      {mod_offline, "{mod_offline, []},"}
+      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+  scope = \"global\"
+  workers = 10
+[outgoing_pools.cassandra.default]
+  scope = \"global\"
+  workers = 20
+  connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
+  connection.tls.verify_peer = true
+[outgoing_pools.elastic.default]
+  scope = \"global\""}
      ]}
 ]}.
 

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -525,7 +525,7 @@ get_components(Opts, Config) ->
 
 add_domain(Config) ->
     Node = default_node(),
-    Hosts = {hosts, "[\"localhost\", \"sogndal\"]"},
+    Hosts = {hosts, "\"localhost\", \"sogndal\""},
     backup_ejabberd_config_file(Node, Config),
     ejabberd_node_utils:modify_config_file([Hosts], Config),
     reload_through_ctl(Node, Config),

--- a/big_tests/tests/conf_reload_SUITE.erl
+++ b/big_tests/tests/conf_reload_SUITE.erl
@@ -160,7 +160,7 @@ change_domain_in_config_file(Config) ->
       [mk_value_for_hosts_pattern(?RELOADED_DOMAIN)], Config).
 
 mk_value_for_hosts_pattern(Domain) ->
-    {hosts, "[\"" ++ binary_to_list(Domain) ++ "\"]"}.
+    {hosts, "\"" ++ binary_to_list(Domain) ++ "\""}.
 
 run_config_file_modification_fun(Config) ->
     Fun = ?config(modify_config_file_fun, Config),

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -389,14 +389,15 @@ message_zlib_limit(Config) ->
 config_ejabberd_node_tls(Config) ->
     Config1 = ejabberd_node_utils:init(Config),
     ejabberd_node_utils:backup_config_file(Config1),
-    ejabberd_node_utils:modify_config_file([{tls_config, "{certfile, \"" ++ ?CERT_FILE ++ "\"}, tls,"}], Config1),
+    ejabberd_node_utils:modify_config_file([{tls_config, "certfile = \"" ++ ?CERT_FILE ++ "\"\n"
+                                                         "  tls.mode = \"tls\""}], Config1),
     ejabberd_node_utils:restart_application(mongooseim),
     Config1.
 
 configure_digest(Config) ->
     Config1 = ejabberd_node_utils:init(Config),
     ejabberd_node_utils:backup_config_file(Config1),
-    ejabberd_node_utils:modify_config_file([{sasl_mechanisms, "{sasl_mechanisms, [cyrsasl_digest]}."}], Config1),
+    ejabberd_node_utils:modify_config_file([{sasl_mechanisms, "sasl_mechanisms = [\"cyrsasl_digest\"]"}], Config1),
     ejabberd_node_utils:restart_application(mongooseim),
     mongoose_helper:set_store_password(plain),
     Config1.

--- a/big_tests/tests/reload_helper.erl
+++ b/big_tests/tests/reload_helper.erl
@@ -63,9 +63,9 @@ update_config_variables(CfgVarsToChange, CfgVars) ->
                 end, CfgVars, CfgVarsToChange).
 
 node_cfg(N, current, C) ->
-    filename:join(ejabberd_node_utils:node_cwd(N, C), "etc/mongooseim.cfg");
+    filename:join(ejabberd_node_utils:node_cwd(N, C), "etc/mongooseim.toml");
 node_cfg(N, backup, C)  ->
-    filename:join(ejabberd_node_utils:node_cwd(N, C), "etc/mongooseim.cfg.bak").
+    filename:join(ejabberd_node_utils:node_cwd(N, C), "etc/mongooseim.toml.bak").
 
 node_ctl(N, C) ->
     filename:join(ejabberd_node_utils:node_cwd(N, C), "bin/mongooseimctl").

--- a/rebar.config
+++ b/rebar.config
@@ -132,22 +132,20 @@
  ]}.
 
 {profiles, [ {prod,    [{relx, [ {dev_mode, false},
-                                 {overlay_vars, "rel/vars.config"},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]},
+                                 {overlay_vars, "rel/vars-toml.config"},
+                                 {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]},
                                  {erl_opts, [{d, 'PROD_NODE'}]} ]},
              %% development nodes
-             {mim1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim1.vars.config"]},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}%,
-                                            %{copy, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}
-                                           ]} ]}]},
-             {mim2,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim2.vars.config"]},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {mim3,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/mim3.vars.config"]},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {fed1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/fed1.vars.config"]},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]},
-             {reg1,    [{relx, [ {overlay_vars, ["rel/vars.config", "rel/reg1.vars.config"]},
-                                 {overlay, [{template, "rel/files/mongooseim.cfg", "etc/mongooseim.cfg"}]} ]}]}
+             {mim1,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/mim1.vars-toml.config"]},
+                                 {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
+             {mim2,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/mim2.vars-toml.config"]},
+                                 {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
+             {mim3,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/mim3.vars-toml.config"]},
+                                 {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
+             {fed1,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/fed1.vars-toml.config"]},
+                                 {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
+             {reg1,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/reg1.vars-toml.config"]},
+                                 {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]}
             ]}.
 
 {plugins,

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -1,0 +1,39 @@
+{node_name, "fed1@localhost"}.
+
+{c2s_port, 5242}.
+{incoming_s2s_port, 5299}.
+{http_port, 5282}.
+{https_port, 5287}.
+{http_api_endpoint_port, 5294}.
+{http_api_old_endpoint_port, 5293}.
+{http_api_client_endpoint_port, 8095}.
+
+%% This node is for s2s testing.
+%% "localhost" host should NOT be defined.
+{hosts, "\"fed1\""}.
+
+{s2s_addr, "[[s2s.address]]
+    host = \"localhost\"
+    ip_address = \"127.0.0.1\"
+
+  [[s2s.address]]
+    host = \"localhost.bis\"
+    ip_address = \"127.0.0.1\""}.
+{s2s_default_policy, "\"allow\""}.
+{highload_vm_args, ""}.
+{listen_service, ""}.
+
+{tls_config, "certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"starttls\"
+  ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
+{secondary_c2s, ""}.
+
+{http_api_old_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_old_endpoint_port }}"}.
+{http_api_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_endpoint_port }}"}.
+{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
+
+{c2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -1,18 +1,16 @@
 [general]
   loglevel = 3
-  hosts = [
-    "localhost",
-    "anonymous.localhost",
-    "localhost.bis"
-  ]
+  hosts = [{{{hosts}}}]
   registration_timeout = "infinity"
   language = "en"
-  all_metrics_are_global = false
-  sm_backend = "mnesia"
+  all_metrics_are_global = {{{all_metrics_are_global}}}
+  sm_backend = {{{sm_backend}}}
   max_fsm_queue = 1000
+  {{{http_server_name}}}
+  {{{rdbms_server_type}}}
 
 [[listen.http]]
-  port = 5280
+  port = {{{http_port}}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
@@ -30,12 +28,10 @@
       password = "secret"
 
 [[listen.http]]
-  port = 5285
+  port = {{{https_port}}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
-  tls.certfile = "priv/ssl/fake_cert.pem"
-  tls.keyfile = "priv/ssl/fake_key.pem"
-  tls.password = ""
+  {{{https_config}}}
 
   [[listen.http.handlers.mod_bosh]]
     host = "_"
@@ -46,8 +42,7 @@
     path = "/ws-xmpp"
 
 [[listen.http]]
-  port = 8088
-  ip_address = "127.0.0.1"
+  {{{http_api_endpoint}}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
@@ -56,13 +51,11 @@
     path = "/api"
 
 [[listen.http]]
-  port = 8089
+  {{{http_api_client_endpoint}}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
   protocol.compress = true
-  tls.certfile = "priv/ssl/fake_cert.pem"
-  tls.keyfile = "priv/ssl/fake_key.pem"
-  tls.password = ""
+  {{{https_config}}}
 
   [[listen.http.handlers.lasse_handler]]
     host = "_"
@@ -109,8 +102,7 @@
     content_path = "swagger"
 
 [[listen.http]]
-  port = 5288
-  ip_address = "127.0.0.1"
+  {{{http_api_old_endpoint}}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
@@ -120,77 +112,54 @@
     handlers = ["mongoose_api_metrics", "mongoose_api_users"]
 
 [[listen.c2s]]
-  port = 5222
-  certfile = "priv/ssl/fake_server.pem"
-  starttls = true
-  zlib = 10000
+  port = {{{c2s_port}}}
+  {{{tls_config}}}
+  {{{tls_module}}}
+  {{{proxy_protocol}}}
+  {{{zlib}}}
   access = "c2s"
   shaper = "c2s_shaper"
   max_stanza_size = 65536
-  dhfile = "priv/ssl/fake_dh_server.pem"
+  {{{c2s_dhfile}}}
 
-[[listen.c2s]]
-  port = 5223
-  zlib = 4096
-  access = "c2s"
-  shaper = "c2s_shaper"
-  max_stanza_size = 65536
+{{{secondary_c2s}}}
 
 [[listen.s2s]]
-  port = 5269
+  port = {{{incoming_s2s_port}}}
   shaper = "s2s_shaper"
   max_stanza_size = 131072
-  dhfile = "priv/ssl/fake_dh_server.pem"
+  {{{s2s_dhfile}}}
 
-[[listen.service]]
-  port = 8888
-  access = "all"
-  shaper_rule = "fast"
-  ip_address = "127.0.0.1"
-  password = "secret"
-
-[[listen.service]]
-  port = 8666
-  access = "all"
-  conflict_behaviour = "kick_old"
-  shaper_rule = "fast"
-  ip_address = "127.0.0.1"
-  password = "secret"
-
-[[listen.service]]
-  port = 8189
-  access = "all"
-  hidden_components = true
-  shaper_rule = "fast"
-  ip_address = "127.0.0.1"
-  password = "secret"
+{{{listen_service}}}
 
 [auth]
-  methods = ["rdbms"]
-  password.format = "scram"
-  password.hash = ["sha256"]
-  scram_iterations = 64
-  cyrsasl_external = ["standard"]
+  {{{auth_ldap}}}
+  methods = [{{{auth_method}}}]
+  {{{password_format}}}
+  {{{scram_iterations}}}
+  cyrsasl_external = [{{{cyrsasl_external}}}]
+  {{{sasl_mechanisms}}}
 
-[outgoing_pools.redis.global_distrib]
-  scope = "single_host"
-  host = "localhost"
-  workers = 10
-
-[outgoing_pools.rdbms.default]
-  scope = "global"
-  workers = 5
-
-  [outgoing_pools.rdbms.default.connection]
-    driver = "pgsql"
-    host = "localhost"
-    database = "ejabberd"
-    username = "ejabberd"
-    password = "mongooseim_secret"
-    tls.required = true
-    tls.verify_peer = true
-    tls.cacertfile = "priv/ssl/cacert.pem"
-    tls.server_name_indication = false
+{{{outgoing_pools}}}
+#[outgoing_pools.redis.global_distrib]
+#  scope = "single_host"
+#  host = "localhost"
+#  workers = 10
+#
+#[outgoing_pools.rdbms.default]
+#  scope = "global"
+#  workers = 5
+#
+#  [outgoing_pools.rdbms.default.connection]
+#    driver = "pgsql"
+#    host = "localhost"
+#    database = "ejabberd"
+#    username = "ejabberd"
+#    password = "mongooseim_secret"
+#    tls.required = true
+#    tls.verify_peer = true
+#    tls.cacertfile = "priv/ssl/cacert.pem"
+#    tls.server_name_indication = false
 
 [services.service_admin_extra]
   submods = ["node", "accounts", "sessions", "vcard", "gdpr", "upload",
@@ -202,7 +171,7 @@
 
 [modules.mod_adhoc]
 
-[modules.mod_amp]
+{{{mod_amp}}}
 
 [modules.mod_disco]
   users_can_see_hidden_services = false
@@ -213,21 +182,17 @@
 
 [modules.mod_muc_light_commands]
 
-[modules.mod_last]
-  backend = "rdbms"
+{{{mod_last}}}
 
 [modules.mod_stream_management]
 
-[modules.mod_offline]
-  backend = "rdbms"
+{{{mod_offline}}}
 
-[modules.mod_privacy]
-  backend = "rdbms"
+{{{mod_privacy}}}
 
-[modules.mod_blocking]
+{{{mod_blocking}}}
 
-[modules.mod_private]
-  backend = "rdbms"
+{{{mod_private}}}
 
 [modules.mod_register]
   welcome_message = ""
@@ -237,18 +202,17 @@
   ]
   access = "register"
 
-[modules.mod_roster]
-  backend = "rdbms"
+{{{mod_roster}}}
 
 [modules.mod_sic]
 
-[modules.mod_vcard]
-  backend = "rdbms"
-  host = "vjud.@HOST@"
+{{{mod_vcard}}}
 
 [modules.mod_bosh]
 
 [modules.mod_carboncopy]
+
+{{{mod_http_notification}}}
 
 [shaper.normal]
   max_rate = 1000
@@ -346,19 +310,18 @@
   ]
 
 [s2s]
-  use_starttls = "optional"
-  certfile = "priv/ssl/fake_server.pem"
-  default_policy = "allow"
-  outgoing_port = 5299
+  {{{s2s_use_starttls}}}
+  {{{s2s_certfile}}}
+  default_policy = {{{s2s_default_policy}}}
+  outgoing_port = {{{outgoing_s2s_port}}}
 
-  [[s2s.address]]
-    host = "fed1"
-    ip_address = "127.0.0.1"
+  {{{s2s_addr}}}
 
-[[host_config]]
-  host = "anonymous.localhost"
-
-  [host_config.auth]
-    methods = ["anonymous"]
-    allow_multiple_connections = true
-    anonymous_protocol = "both"
+{{{host_config}}}
+#[[host_config]]
+#  host = "anonymous.localhost"
+#
+#  [host_config.auth]
+#    methods = ["anonymous"]
+#    allow_multiple_connections = true
+#    anonymous_protocol = "both"

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -1,0 +1,65 @@
+{c2s_tls_port, 5223}.
+{outgoing_s2s_port, 5299}.
+{service_port, 8888}.
+{kicking_service_port, 8666}.
+{hidden_service_port, 8189}.
+
+{hosts, "\"localhost\",
+         \"anonymous.localhost\",
+         \"localhost.bis\"
+        "}.
+{host_config,
+  "[[host_config]]
+  host = \"anonymous.localhost\"
+
+  [host_config.auth]
+    methods = [\"anonymous\"]
+    allow_multiple_connections = true
+    anonymous_protocol = \"both\""}.
+{password_format, "password.format = \"scram\"
+    password.hash = [\"sha256\"]"}.
+{scram_iterations, "scram_iterations = 64"}.
+{s2s_addr, "[[s2s.address]]
+    host = \"fed1\"
+    ip_address = \"127.0.0.1\""}.
+{s2s_default_policy, "\"allow\""}.
+
+% Disable highload args to save memory for dev builds
+{highload_vm_args, ""}.
+
+{secondary_c2s,
+  "[[listen.c2s]]
+  port = {{ c2s_tls_port }}
+  zlib = 4096
+  access = \"c2s\"
+  shaper = \"c2s_shaper\"
+  max_stanza_size = 65536"}.
+{listen_service,
+  "[[listen.service]]
+  port = {{ service_port }}
+  access = \"all\"
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\"
+
+[[listen.service]]
+  port = {{ kicking_service_port }}
+  access = \"all\"
+  conflict_behaviour = \"kick_old\"
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\"
+
+[[listen.service]]
+  port = {{ hidden_service_port }}
+  access = \"all\"
+  hidden_components = true
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\""}.
+
+{mod_amp, "[modules.mod_amp]"}.
+{mod_private, "[modules.mod_private]"}.
+{zlib, "zlib = 10_000"}.
+{c2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -1,0 +1,55 @@
+{node_name, "ejabberd2@localhost"}.
+
+{c2s_port, 5232}.
+{c2s_tls_port, 5233}.
+{incoming_s2s_port, 5279}.
+{http_port, 5281}.
+{https_port, 5286}.
+{http_api_old_endpoint_port, 5289}.
+{http_api_endpoint_port, 8090}.
+{http_api_client_endpoint_port, 8091}.
+{service_port, 8899}.
+
+{hosts, "\"localhost\",
+         \"anonymous.localhost\",
+         \"localhost.bis\"
+         "}.
+{s2s_addr, "[[s2s.address]]
+    host = \"localhost2\"
+    ip_address = \"127.0.0.1\""}.
+{s2s_default_policy, "\"allow\""}.
+{highload_vm_args, ""}.
+
+{http_api_old_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_old_endpoint_port }}"}.
+{http_api_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_endpoint_port }}"}.
+{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
+
+{tls_config, "certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"starttls\"
+  ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
+
+{secondary_c2s,
+  "[[listen.c2s]]
+  port = {{ c2s_tls_port }}
+  zlib = 4096
+  access = \"c2s\"
+  shaper = \"c2s_shaper\"
+  max_stanza_size = 65536
+  certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"tls\"
+  ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
+{listen_service,
+  "[[listen.service]]
+  port = {{ service_port }}
+  access = \"all\"
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\""}.
+{all_metrics_are_global, "true"}.
+
+{http_server_name, "http_server_name = \"Classified\""}.
+
+{c2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -1,0 +1,54 @@
+{node_name, "mongooseim3@localhost"}.
+
+{c2s_port, 5262}.
+{c2s_tls_port, 5263}.
+{outgoing_s2s_port, 5295}.
+{incoming_s2s_port, 5291}.
+{http_port, 5283}.
+{https_port, 5290}.
+{http_api_old_endpoint_port, 5292}.
+{http_api_endpoint_port, 8092}.
+{http_api_client_endpoint_port, 8093}.
+
+{hosts, "\"localhost\",
+         \"anonymous.localhost\",
+          \"localhost.bis\""}.
+
+{s2s_addr, "[[s2s.address]]
+    host = \"localhost2\"
+    ip_address = \"127.0.0.1\""}.
+{s2s_default_policy, "\"allow\""}.
+{highload_vm_args, ""}.
+{listen_service, ""}.
+{mod_http_notification, "[modules.mod_http_notification]"}.
+
+{tls_config, "certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"starttls\"
+  ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
+
+{secondary_c2s,
+  "[[listen.c2s]]
+  port = {{ c2s_tls_port }}
+  zlib = 4096
+  access = \"c2s\"
+  shaper = \"c2s_shaper\"
+  max_stanza_size = 65536
+  certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"tls\"
+  tls.module = \"just_tls\"
+
+  [[listen.c2s.tls.ciphers]]
+    cipher = \"aes_256_gcm\"
+    key_exchange = \"ecdhe_rsa\"
+    mac = \"aead\"
+    prf = \"sha384\""}.
+
+{http_api_old_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_old_endpoint_port }}"}.
+{http_api_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_endpoint_port }}"}.
+{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
+
+{c2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -1,0 +1,46 @@
+{node_name, "reg1@localhost"}.
+
+{c2s_port, 5252}.
+{incoming_s2s_port, 5298}.
+{http_port, 5272}.
+{https_port, 5277}.
+{service_port, 9990}.
+{http_api_endpoint_port, 8074}.
+{http_api_old_endpoint_port, 5273}.
+{http_api_client_endpoint_port, 8075}.
+
+%% This node is for global distribution testing.
+%% reg is short for region.
+%% Both local and global hosts should be defined.
+%% "localhost" is a global host.
+%% "reg1" is a local host.
+{hosts, "\"reg1\", \"localhost\""}.
+{s2s_addr, "[[s2s.address]]
+    host = \"localhost\"
+    ip_address = \"127.0.0.1\"
+
+  [[s2s.address]]
+    host = \"localhost.bis\"
+    ip_address = \"127.0.0.1\""}.
+{s2s_default_policy, "\"allow\""}.
+{listen_service, "[[listen.service]]
+  port = {{ service_port }}
+  access = \"all\"
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\""}.
+
+{tls_config, "certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"starttls\"
+  ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
+{secondary_c2s, ""}.
+
+{http_api_old_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_old_endpoint_port }}"}.
+{http_api_endpoint, "ip_address = \"127.0.0.1\"
+  port = {{ http_api_endpoint_port }}"}.
+{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
+
+{c2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -1,0 +1,64 @@
+{node_name, "mongooseim@localhost"}.
+
+{c2s_port, 5222}.
+{outgoing_s2s_port, 5269}.
+{incoming_s2s_port, 5269}.
+{http_port, 5280}.
+{https_port, 5285}.
+
+% vm.args
+{highload_vm_args, "+P 10000000 -env ERL_MAX_PORTS 250000"}.
+
+% TOML config
+{hosts, "\"localhost\""}.
+{host_config, ""}.
+{auth_ldap, ""}.
+{s2s_addr, ""}.
+{s2s_default_policy, "\"deny\""}.
+{mod_amp, ""}.
+{listen_service, "[[listen.service]]
+  port = 8888
+  access = \"all\"
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\""}.
+{mod_last, "[modules.mod_last]"}.
+{mod_offline, "[modules.mod_offline]
+  access_max_user_messages = \"max_user_offline_messages\""}.
+{mod_privacy, "[modules.mod_privacy]"}.
+{mod_blocking, "[modules.mod_blocking]"}.
+{mod_private, "[modules.mod_private]"}.
+{mod_roster, "[modules.mod_roster]"}.
+{mod_vcard, "[modules.mod_vcard]
+  host = \"vjud.@HOST@\""}.
+{sm_backend, "\"mnesia\""}.
+{auth_method, "\"internal\""}.
+{cyrsasl_external, "\"standard\""}.
+{tls_config, "certfile = \"priv/ssl/fake_server.pem\"
+  tls.mode = \"starttls\""}.
+{tls_module, ""}.
+{https_config, "tls.certfile = \"priv/ssl/fake_cert.pem\"
+  tls.keyfile = \"priv/ssl/fake_key.pem\"
+  tls.password =  \"\""}.
+{zlib, ""}.
+{outgoing_pools, ""}.
+{http_api_old_endpoint, "ip_address = \"127.0.0.1\"
+  port = 5288"}.
+{http_api_endpoint, "ip_address = \"127.0.0.1\"
+  port = 8088"}.
+{http_api_client_endpoint, "port = 8089"}.
+{s2s_use_starttls, "use_starttls = \"optional\""}.
+{s2s_certfile, "certfile = \"priv/ssl/fake_server.pem\""}.
+{sasl_mechanisms, ""}.
+{all_metrics_are_global, "false"}.
+
+%% Defined in Makefile by appending configure.vars.config
+%% Uncomment for manual release generation.
+%{mongooseim_runner_user, ""}.
+%{mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.
+%{mongooseim_etc_dir, "$RUNNER_BASE_DIR/etc"}.
+%{mongooseim_log_dir, "log"}.
+%{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
+%{mongooseim_mdb_dir_toggle, "%"}.
+%{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+%{mongooseim_nodetool_etc_dir, "etc"}.

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -55,7 +55,8 @@
 
 -export([check_digest/4]).
 
--export([auth_modules/1]).
+-export([auth_modules/1,
+         auth_methods/1]).
 
 %% Library functions for reuse in ejabberd_auth_* modules
 -export([authorize_with_check_password/2]).
@@ -589,9 +590,13 @@ auth_modules() ->
 %% Return the list of authenticated modules for a given host
 -spec auth_modules(Server :: jid:lserver()) -> [authmodule()].
 auth_modules(LServer) ->
-    Method = ejabberd_config:get_local_option({auth_method, LServer}),
-    Methods = get_auth_method_as_a_list(Method),
+    Methods = auth_methods(LServer),
     [list_to_atom("ejabberd_auth_" ++ atom_to_list(M)) || M <- Methods].
+
+-spec auth_methods(jid:lserver()) -> [atom()].
+auth_methods(LServer) ->
+    Method = ejabberd_config:get_local_option({auth_method, LServer}),
+    get_auth_method_as_a_list(Method).
 
 get_auth_method_as_a_list(undefined) -> [];
 get_auth_method_as_a_list(AuthMethod) when is_list(AuthMethod) -> AuthMethod;

--- a/src/config/mongoose_config_reload.erl
+++ b/src/config/mongoose_config_reload.erl
@@ -40,7 +40,7 @@
         mongoose_node => node(),
         config_file => string(),
         loaded_categorized_options => categorized_options(),
-        ondisc_config_terms => list(),
+        ondisc_config_state => state(),
         missing_files => list(file:filename()),
         required_files => list(file:filename())}.
 
@@ -458,15 +458,14 @@ node_values(Key, NodeStates) ->
 %% mongoose_node => node(),
 %% config_file => string(),
 %% loaded_categorized_options => categorized_options(),
-%% ondisc_config_terms => list()
+%% ondisc_config_state => state()
 
 extend_node_states(NodeStates) ->
     lists:map(fun(NodeState) -> extend_node_state(NodeState) end, NodeStates).
 
 extend_node_state(NodeState=#{
                     loaded_categorized_options := LoadedCatOptions,
-                    ondisc_config_terms := OndiscTerms}) ->
-    OndiscState = mongoose_config_parser:parse_terms(OndiscTerms),
+                    ondisc_config_state := OndiscState}) ->
     OndiscCatOptions = state_to_categorized_options(OndiscState),
     NodeSpecificPatterns = mongoose_config_parser:state_to_global_opt(node_specific_options, OndiscState, []),
     LoadedFlatGlobalOptions = categorize_options_to_flat_global_config_opts(LoadedCatOptions),

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -616,16 +616,16 @@ get_categorized_options() ->
 %% (i.e. mongoose_config_parser and mongoose_config_reload).
 config_state() ->
     ConfigFile = get_ejabberd_config_path(),
-    Terms = get_plain_terms_file(ConfigFile),
+    State = parse_file(ConfigFile),
     %% Performance optimization hint:
     %% terms_to_missing_and_required_files/1 actually parses Terms into State.
     #{missing_files := MissingFiles,
       required_files := RequiredFiles} =
-        terms_to_missing_and_required_files(Terms),
+        state_to_missing_and_required_files(State),
     #{mongoose_node => node(),
       config_file => ConfigFile,
       loaded_categorized_options => get_categorized_options(),
-      ondisc_config_terms => Terms,
+      ondisc_config_state => State,
       missing_files => MissingFiles,
       required_files => RequiredFiles}.
 
@@ -682,8 +682,7 @@ assert_required_files_exist(State) ->
                            filenames => MissingFiles})
     end.
 
-terms_to_missing_and_required_files(Terms) ->
-    State = mongoose_config_parser:parse_terms(Terms),
+state_to_missing_and_required_files(State) ->
     RequiredFiles = mongoose_config_parser:state_to_required_files(State),
     MissingFiles = missing_files(RequiredFiles),
     #{missing_files => MissingFiles, required_files => RequiredFiles}.

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -294,9 +294,8 @@ get_local_option_or_default(Opt, Default) ->
 
 %% @doc Return the list of hosts handled by a given module
 get_vh_by_auth_method(AuthMethod) ->
-    mnesia:dirty_select(local_config,
-                        [{#local_config{key   = {auth_method, '$1'},
-                                        value = AuthMethod}, [], ['$1']}]).
+    lists:filter(fun(Host) -> lists:member(AuthMethod, ejabberd_auth:auth_methods(Host)) end,
+                 ?MYHOSTS).
 
 handle_table_does_not_exist_error(Table) ->
     MnesiaDirectory = mnesia:system_info(directory),

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -122,7 +122,7 @@
 [[listen.c2s]]
   port = 5222
   certfile = "tools/ssl/mongooseim/server.pem"
-  starttls = true
+  tls.mode = "starttls"
   zlib = 10000
   access = "c2s"
   shaper = "c2s_shaper"

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -174,16 +174,16 @@ auth_config_states() ->
     [auth_config_node1_config_v1()].
 
 auth_config_node1_config_v1() ->
-    Terms = auth_config(),
+    State = mongoose_config_parser:parse_terms(auth_config()),
     #{mongoose_node => mim1,
       config_file => "/etc/mongooseim.cfg",
-      loaded_categorized_options => terms_to_categorized_options(Terms),
-      ondisc_config_terms => Terms,
+      loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State),
+      ondisc_config_state => State,
       missing_files => [], required_files => []}.
 
 auth_host_local_config() ->
-    Terms = auth_config(),
-    CatOpts = terms_to_categorized_options(Terms),
+    State = auth_config_state(),
+    CatOpts = mongoose_config_reload:state_to_categorized_options(State),
     maps:get(host_config, CatOpts).
 
 auth_config_state() ->
@@ -211,11 +211,6 @@ node_specific_cool_mod_mam_config() ->
     [{hosts, ["localhost"]},
      {node_specific_options, [ [h,'_',module_opt,mod_mam,pool] ]},
      {modules, [{mod_mam, [{pool, cool_pool}]}]}].
-
-
-terms_to_categorized_options(Terms) ->
-    State = mongoose_config_parser:parse_terms(Terms),
-    mongoose_config_reload:state_to_categorized_options(State).
 
 states_to_reloading_context_case(_C) ->
     Context = mongoose_config_reload:states_to_reloading_context(example_config_states()),
@@ -252,42 +247,42 @@ example_config_states() ->
 
 %% node1_config_v1 configuration both in memory and on disc
 config_node1_config_v1() ->
-    Terms = node1_config_v1(),
+    State = mongoose_config_parser:parse_terms(node1_config_v1()),
     #{mongoose_node => mim1,
       config_file => "/etc/mongooseim.cfg",
-      loaded_categorized_options => terms_to_categorized_options(Terms),
-      ondisc_config_terms => Terms,
+      loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State),
+      ondisc_config_state => State,
       missing_files => [], required_files => []}.
 
 %% node2_config_v1 configuration both in memory and on disc
 config_node2_config_v1() ->
-    Terms = node2_config_v1(),
+    State = mongoose_config_parser:parse_terms(node2_config_v1()),
     #{mongoose_node => mim2,
       config_file => "/etc/mongooseim.cfg",
-      loaded_categorized_options => terms_to_categorized_options(Terms),
-      ondisc_config_terms => Terms,
+      loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State),
+      ondisc_config_state => State,
       missing_files => [], required_files => []}.
 
 %% node1_config_v1 configuration in memory
 %% node1_config_v2 configuration on disc
 config_node1_config_v2() ->
-    Terms_v1 = node1_config_v1(),
-    Terms_v2 = node1_config_v2(),
+    State_v1 = mongoose_config_parser:parse_terms(node1_config_v1()),
+    State_v2 = mongoose_config_parser:parse_terms(node1_config_v2()),
     #{mongoose_node => mim1,
       config_file => "/etc/mongooseim.cfg",
-      loaded_categorized_options => terms_to_categorized_options(Terms_v1),
-      ondisc_config_terms => Terms_v2,
+      loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State_v1),
+      ondisc_config_state => State_v2,
       missing_files => [], required_files => []}.
 
 %% node2_config_v1 configuration in memory
 %% node2_config_v2 configuration on disc
 config_node2_config_v2() ->
-    Terms_v1 = node2_config_v1(),
-    Terms_v2 = node2_config_v2(),
+    State_v1 = mongoose_config_parser:parse_terms(node2_config_v1()),
+    State_v2 = mongoose_config_parser:parse_terms(node2_config_v2()),
     #{mongoose_node => mim2,
       config_file => "/etc/mongooseim.cfg",
-      loaded_categorized_options => terms_to_categorized_options(Terms_v1),
-      ondisc_config_terms => Terms_v2,
+      loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State_v1),
+      ondisc_config_state => State_v2,
       missing_files => [], required_files => []}.
 
 node1_config_v1() ->
@@ -377,11 +372,10 @@ node2_config_v2() ->
 
 get_config_diff_case(_C) ->
     %% Calculate changes to node1 reload_local to transit from v1 to v2
-    Terms_v1 = node1_config_v1(),
-    Terms_v2 = node1_config_v2(),
-    CatOptions = terms_to_categorized_options(Terms_v1),
-    State = mongoose_config_parser:parse_terms(Terms_v2),
-    Diff = mongoose_config_reload:get_config_diff(State, CatOptions),
+    State_v1 = mongoose_config_parser:parse_terms(node1_config_v1()),
+    State_v2 = mongoose_config_parser:parse_terms(node1_config_v2()),
+    CatOptions = mongoose_config_reload:state_to_categorized_options(State_v1),
+    Diff = mongoose_config_reload:get_config_diff(State_v2, CatOptions),
     #{local_hosts_changes := #{ to_reload := ToReload }} = Diff,
     [{ {modules,<<"localhost">>}, OldModules, NewModules }] = ToReload,
     ?assertEqual(<<"secret">>, get_module_opt(mod_mam, password, OldModules)),

--- a/tools/test_runner/apply_templates.erl
+++ b/tools/test_runner/apply_templates.erl
@@ -20,8 +20,8 @@ main([NodeAtom, BuildDirAtom]) ->
 
 
 overlay_vars(Node) ->
-    Vars = consult_map("rel/vars.config"),
-    NodeVars = consult_map("rel/" ++ atom_to_list(Node) ++ ".vars.config"),
+    Vars = consult_map("rel/vars-toml.config"),
+    NodeVars = consult_map("rel/" ++ atom_to_list(Node) ++ ".vars-toml.config"),
     %% NodeVars overrides Vars
     maps:merge(Vars, NodeVars).
 
@@ -43,7 +43,8 @@ simple_templates() ->
      {"rel/files/app.config",       "etc/app.config"},
      {"rel/files/vm.args",          "etc/vm.args"},
      {"rel/files/vm.dist.args",     "etc/vm.dist.args"},
-     {"rel/files/mongooseim.cfg",   "etc/mongooseim.cfg"}
+     {"rel/files/mongooseim.cfg",   "etc/mongooseim.cfg"},
+     {"rel/files/mongooseim.toml",  "etc/mongooseim.toml"}
     ].
 
 erts_templates(RelDir) ->


### PR DESCRIPTION
Use the mustache templates for the TOML config file - make it work the same as for the '.cfg' file.

Notes:
- Failures for big tests are expected on CI except `pgsql_mnesia`, which should pass
- There is a fix for getting hosts by auth method. This bug was revealed by the TOML config which provided a list of methods (which should be valid) instead of an atom with one method.
- The templating is a bit inconsistent: sometimes we template only the value and sometimes one or more key-value pairs. It could be more organised, but this might be done as a separate story - not to change too much in one go. This is consistent with how it worked with 'cfg'.
- The templated config file contains a lot of empty lines, maybe this could be improved, but this falls outside of the scope of this story.
- TOML config does **not** support 'required files' - this should be done in a separate story as well.
