### PR TITLE
TOML config fixes

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -326,7 +326,8 @@
   connection.tls.versions = [\"tlsv1.2\"]
   connection.tls.verify_peer = true
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
-  connection.tls.certfile = \"priv/ssl/fake_cert.pem\""},
+  connection.tls.certfile = \"priv/ssl/fake_cert.pem\"
+  connection.tls.keyfile = \"priv/ssl/fake_key.pem\""},
       {password_format, "password.format = \"scram\""},
       {auth_ldap, "ldap_base = \"ou=Users,dc=esl,dc=com\"
   ldap_filter = \"(objectClass=inetOrgPerson)\""},

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -17,7 +17,7 @@
     allow_multiple_connections = true
     anonymous_protocol = \"both\""}.
 {password_format, "password.format = \"scram\"
-    password.hash = [\"sha256\"]"}.
+  password.hash = [\"sha256\"]"}.
 {scram_iterations, "scram_iterations = 64"}.
 {s2s_addr, "[[s2s.address]]
     host = \"fed1\"

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -141,7 +141,7 @@ process_general(<<"max_fsm_queue">>, V) ->
 process_general(<<"http_server_name">>, V) ->
     #local_config{key = cowboy_server_name, value = b2l(V)};
 process_general(<<"rdbms_server_type">>, V) ->
-    #local_config{key = rdbms_server_type, value = V}.
+    #local_config{key = rdbms_server_type, value = b2a(V)}.
 
 process_s2s_option(<<"use_starttls">>, V) ->
     [#local_config{key = s2s_use_starttls, value = b2a(V)}];
@@ -383,6 +383,8 @@ ldap_option(<<"tls">>, Options) -> {tls_options, client_tls_options(Options)}.
 
 riak_option(<<"address">>, Addr) -> {address, b2l(Addr)};
 riak_option(<<"port">>, Port) -> {port, Port};
+riak_option(<<"username">>, UserName) -> {username, b2l(UserName)};
+riak_option(<<"password">>, Password) -> {password, b2l(Password)};
 riak_option(<<"cacertfile">>, Path) -> {cacertfile, b2l(Path)};
 riak_option(<<"tls">>, Options) -> {ssl_opts, client_tls_options(Options)}.
 
@@ -424,7 +426,8 @@ tls_cipher(#{<<"key_exchange">> := KEx,
              <<"cipher">> := Cipher,
              <<"mac">> := MAC,
              <<"prf">> := PRF}) ->
-    #{key_exchange => b2a(KEx), cipher => b2a(Cipher), mac => b2a(MAC), prf => b2a(PRF)}.
+    #{key_exchange => b2a(KEx), cipher => b2a(Cipher), mac => b2a(MAC), prf => b2a(PRF)};
+tls_cipher(Cipher) -> b2l(Cipher).
 
 verify_peer(false) -> verify_none;
 verify_peer(true) -> verify_peer.

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -346,7 +346,9 @@ connection_options(riak, Options = #{<<"username">> := UserName,
     [{credentials, b2l(UserName), b2l(Password)} |
      [riak_option(K, V) || {K, V} <- maps:to_list(Options)]];
 connection_options(cassandra, Options) ->
-    [cassandra_option(K, V) || {K, V} <- maps:to_list(Options)].
+    [cassandra_option(K, V) || {K, V} <- maps:to_list(Options)];
+connection_options(elastic, Options) ->
+    [elastic_option(K, V) || {K, V} <- maps:to_list(Options)].
 
 rdbms_server(#{<<"driver">> := <<"odbc">>,
                <<"settings">> := Settings}) ->
@@ -388,7 +390,15 @@ riak_option(<<"password">>, Password) -> {password, b2l(Password)};
 riak_option(<<"cacertfile">>, Path) -> {cacertfile, b2l(Path)};
 riak_option(<<"tls">>, Options) -> {ssl_opts, client_tls_options(Options)}.
 
+cassandra_option(<<"servers">>, Servers) -> {servers, [cassandra_server(S) || S <- Servers]};
+cassandra_option(<<"keyspace">>, KeySpace) -> {keyspace, b2a(KeySpace)};
 cassandra_option(<<"tls">>, Options) -> {ssl, client_tls_options(Options)}.
+
+elastic_option(<<"host">>, Host) -> {host, b2l(Host)};
+elastic_option(<<"port">>, Port) -> {port, Port}.
+
+cassandra_server(#{<<"ip_address">> := IPAddr, <<"port">> := Port}) -> {b2l(IPAddr), Port};
+cassandra_server(#{<<"ip_address">> := IPAddr}) -> b2l(IPAddr).
 
 db_tls(#{<<"driver">> := Driver, <<"tls">> := TLS}) -> db_tls_options(Driver, TLS);
 db_tls(_) -> no_tls.

--- a/tools/install
+++ b/tools/install
@@ -36,7 +36,7 @@ INSTALL_OPTS="-o ${RUNNER_USER} -g ${RUNNER_GROUP}"
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 555 _build/prod/rel/mongooseim/bin/mongooseimctl ${BIN_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -d ${ETC_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 _build/prod/rel/mongooseim/etc/app.config ${ETC_DIR}
-[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 _build/prod/rel/mongooseim/etc/mongooseim.cfg ${ETC_DIR}
+[ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 _build/prod/rel/mongooseim/etc/mongooseim.toml ${ETC_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 _build/prod/rel/mongooseim/etc/vm.args ${ETC_DIR}
 [ x"$SYSTEM" == x"yes" ] && install $INSTALL_OPTS -m 664 _build/prod/rel/mongooseim/etc/vm.dist.args ${ETC_DIR}
 install $INSTALL_OPTS -d ${LIB_DIR}
@@ -44,7 +44,7 @@ cp -R _build/prod/rel/mongooseim/* ${LIB_DIR}
 chown -R ${RUNNER_USER}:${RUNNER_GROUP} ${LIB_DIR}
 [ x"$SYSTEM" == x"yes" ] && {
     mv ${LIB_DIR}/etc/app.config   ${LIB_DIR}/etc/app.config.example
-    mv ${LIB_DIR}/etc/mongooseim.cfg ${LIB_DIR}/etc/mongooseim.cfg.example
+    mv ${LIB_DIR}/etc/mongooseim.toml ${LIB_DIR}/etc/mongooseim.toml.example
     mv ${LIB_DIR}/etc/vm.args      ${LIB_DIR}/etc/vm.args.example
     mv ${LIB_DIR}/etc/vm.dist.args ${LIB_DIR}/etc/vm.dist.args.example
 }
@@ -66,7 +66,7 @@ log () {
 [ x"$SYSTEM" == x"yes" ] && log ${BIN_DIR}/mongooseimctl
 [ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}
 [ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/app.config
-[ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/mongooseim.cfg
+[ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/mongooseim.toml
 [ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/vm.args
 [ x"$SYSTEM" == x"yes" ] && log ${ETC_DIR}/vm.dist.args
 find ${LIB_DIR} >> $LOG


### PR DESCRIPTION
Fix little issues with TOML.

The goal is to make all the tests green.

This does not mean that all config options that are documented in https://mongooseim.readthedocs.io/en/latest/ are working.
That would be another story - and a big one. It has to be done eventually, hopefully before the next release. The best way to do it would be to add relevant tests, especially that we are reducing the amount of config parsing in tests, see https://github.com/esl/MongooseIM/pull/2797