### PR TITLE
TOML config split

### DIFF
--- a/include/mongoose.hrl
+++ b/include/mongoose.hrl
@@ -26,7 +26,7 @@
 -define(MYNAME,  hd(ejabberd_config:get_global_option(hosts))).
 -define(MYLANG,  ejabberd_config:get_global_option(language)).
 
--define(CONFIG_PATH, "etc/mongooseim.cfg").
+-define(CONFIG_PATH, "etc/mongooseim.toml").
 
 -define(LOCATION, {?MODULE, ?FUNCTION_NAME, ?LINE}).
 

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -18,7 +18,7 @@ EJABBERD_STATUS_PATH="{{mongooseim_status_dir}}/status"
 export EJABBERD_STATUS_PATH="$EJABBERD_STATUS_PATH"
 
 EJABBERD_SO_PATH=`ls -dt "$RUNNER_BASE_DIR"/lib/mongooseim-*/priv/lib | head -1`
-EJABBERD_CONFIG_PATH="$RUNNER_ETC_DIR"/mongooseim.cfg
+EJABBERD_CONFIG_PATH="$RUNNER_ETC_DIR"/mongooseim.toml
 export EJABBERD_SO_PATH
 export EJABBERD_CONFIG_PATH
 

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -1,32 +1,32 @@
-%% @doc Pure config logic.
-%% No ets table manipulations, no Mnesia, no starting modules, no file reading here.
-%% Everything here is safe, side effect free.
-%% OK, logging is possible, but keep it to minimum.
+%% @doc Parsing and processing of MongooseIM config files
+%%   - parser backends: 'cfg' and 'toml'
+%%   - config state management
 -module(mongoose_config_parser).
--export([parse_terms/1]).
--export([check_hosts/2]).
--export([can_be_ignored/1]).
--export([is_not_host_specific/1]).
 
--export([allow_override_all/1,
+%% parser API
+-export([parse_file/1]).
+
+%% state API
+-export([new_state/0,
+         allow_override_all/1,
          allow_override_local_only/1,
+         override_global/1,
+         override_local/1,
+         override_acls/1,
+         set_opts/2,
+         set_hosts/2,
+         get_opts/1,
          state_to_opts/1,
          state_to_host_opts/1,
          state_to_global_opt/3,
          state_to_required_files/1,
          can_override/2]).
 
-%% for TOML parsing
--export([opts_to_state/2,
-         dedup_state_opts/1,
+%% config post-processing
+-export([dedup_state_opts/1,
          add_dep_modules/1]).
 
-%% for unit tests
--export([group_host_changes/1]).
-
-%% Support for 'include_config_file'
--export([config_filenames_to_include/1,
-         include_config_files/2]).
+-callback parse_file(FileName :: string()) -> state().
 
 -include("mongoose.hrl").
 -include("ejabberd_config.hrl").
@@ -53,452 +53,20 @@
 
 -type host() :: any(). % TODO: specify this
 -type state() :: #state{}.
--type macro() :: {macro_key(), macro_value()}.
 
-%% The atom must have all characters in uppercase.
--type macro_key() :: atom().
+%% Parser API
 
--type macro_value() :: term().
+parse_file(FileName) ->
+    ParserModule = parser_module(filename:extension(FileName)),
+    ParserModule:parse_file(FileName).
 
--type known_term() :: override_global
-                    | override_local
-                    | override_acls
-                    | {acl, _, _}
-                    | {alarms, _}
-                    | {access, _, _}
-                    | {shaper, _, _}
-                    | {host, _}
-                    | {hosts, _}
-                    | {host_config, _, _}
-                    | {listen, _}
-                    | {language, _}
-                    | {sm_backend, _}
-                    | {outgoing_s2s_port, integer()}
-                    | {outgoing_s2s_options, _, integer()}
-                    | {{s2s_addr, _}, _}
-                    | {s2s_dns_options, [tuple()]}
-                    | {s2s_use_starttls, integer()}
-                    | {s2s_certfile, _}
-                    | {domain_certfile, _, _}
-                    | {node_type, _}
-                    | {cluster_nodes, _}
-                    | {registration_timeout, integer()}
-                    | {mongooseimctl_access_commands, list()}
-                    | {loglevel, _}
-                    | {max_fsm_queue, _}
-                    | {sasl_mechanisms, _}
-                    | host_term().
+parser_module(".toml") -> mongoose_config_parser_toml;
+parser_module(".cfg") -> mongoose_config_parser_cfg.
 
--type host_term() :: {acl, _, _}
-                   | {access, _, _}
-                   | {shaper, _, _}
-                   | {host, _}
-                   | {hosts, _}.
-
--spec search_hosts_and_pools({host|hosts, [host()] | host()} , state()) -> any().
-search_hosts_and_pools({host, Host}, State) ->
-    search_hosts_and_pools({hosts, [Host]}, State);
-search_hosts_and_pools({hosts, Hosts}, State=#state{hosts = []}) ->
-    add_hosts_to_option(Hosts, State);
-search_hosts_and_pools({hosts, Hosts}, #state{hosts = OldHosts}) ->
-    ?ERROR_MSG("event=\"too many host definitions\" "
-               "new_hosts=~1000p old_hosts=~1000p", []),
-    exit(#{issue => "too many hosts definitions",
-           new_hosts => Hosts,
-           old_hosts => OldHosts});
-search_hosts_and_pools(_Term, State) ->
-    State.
-
--spec add_hosts_to_option(Hosts :: [host()],
-                          State :: state()) -> state().
-add_hosts_to_option(Hosts, State) ->
-    PrepHosts = normalize_hosts(Hosts),
-    add_option(hosts, PrepHosts, State#state{hosts = PrepHosts}).
-
--spec normalize_hosts([host()]) -> [binary() | tuple()].
-normalize_hosts(Hosts) ->
-    normalize_hosts(Hosts, []).
-
-
-normalize_hosts([], PrepHosts) ->
-    lists:reverse(PrepHosts);
-normalize_hosts([Host | Hosts], PrepHosts) ->
-    case jid:nodeprep(host_to_binary(Host)) of
-        error ->
-            ?ERROR_MSG("event=invalid_hostname_in_config "
-                       "hostname=~p", [Host]),
-            erlang:error(#{issue => invalid_hostname,
-                           hostname => Host});
-        PrepHost ->
-            normalize_hosts(Hosts, [PrepHost | PrepHosts])
-    end.
-
-host_to_binary(Host) ->
-    unicode:characters_to_binary(Host).
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% Support for Macro
-
-%% @doc Replace the macros with their defined values.
--spec replace_macros(Terms :: [term()]) -> [term()].
-replace_macros(Terms) ->
-    {TermsOthers, Macros} = split_terms_macros(Terms),
-    replace(TermsOthers, Macros).
-
-
-%% @doc Split Terms into normal terms and macro definitions.
--spec split_terms_macros(Terms :: [term()]) -> {[term()], [macro()]}.
-split_terms_macros(Terms) ->
-    lists:foldl(fun split_terms_macros_fold/2, {[], []}, Terms).
-
--spec split_terms_macros_fold(any(), Acc) -> Acc when
-      Acc :: {[term()], [{Key :: any(), Value :: any()}]}.
-split_terms_macros_fold({define_macro, Key, Value} = Term, {TOs, Ms}) ->
-    case is_macro_name(Key) of
-        true ->
-            {TOs, Ms ++ [{Key, Value}]};
-        false ->
-            exit({macro_not_properly_defined, Term})
-    end;
-split_terms_macros_fold(Term, {TOs, Ms}) ->
-    {TOs ++ [Term], Ms}.
-
-
-%% @doc Recursively replace in Terms macro usages with the defined value.
--spec replace(Terms :: [term()],
-              Macros :: [macro()]) -> [term()].
-replace([], _) ->
-    [];
-replace([Term | Terms], Macros) ->
-    [replace_term(Term, Macros) | replace(Terms, Macros)].
-
-
-replace_term(Key, Macros) when is_atom(Key) ->
-    case is_macro_name(Key) of
-        true ->
-            case proplists:get_value(Key, Macros) of
-                undefined -> exit({undefined_macro, Key});
-                Value -> Value
-            end;
-        false ->
-            Key
-    end;
-replace_term({use_macro, Key, Value}, Macros) ->
-    proplists:get_value(Key, Macros, Value);
-replace_term(Term, Macros) when is_list(Term) ->
-    replace(Term, Macros);
-replace_term(Term, Macros) when is_tuple(Term) ->
-    List = tuple_to_list(Term),
-    List2 = replace(List, Macros),
-    list_to_tuple(List2);
-replace_term(Term, _) ->
-    Term.
-
-%% Check is the term is a config macro
--spec is_macro_name(atom()) -> boolean().
-is_macro_name(Atom) when is_atom(Atom) ->
-    is_all_uppercase(Atom) andalso has_any_uppercase(Atom);
-is_macro_name(_) ->
-    false.
-
--spec is_all_uppercase(atom()) -> boolean().
-is_all_uppercase(Atom) ->
-    String = erlang:atom_to_list(Atom),
-    lists:all(fun(C) when C >= $a, C =< $z -> false;
-                 (_) -> true
-              end, String).
-
-has_any_uppercase(Atom) ->
-    String = erlang:atom_to_list(Atom),
-    lists:any(fun(C) when C >= $A, C =< $Z -> true;
-                 (_) -> false
-              end, String).
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% Process terms
-
--spec process_term(Term :: known_term(),
-                   State :: state()) -> state().
-process_term(Term, State) ->
-    case Term of
-        override_global ->
-            State#state{override_global = true};
-        override_local ->
-            State#state{override_local = true};
-        override_acls ->
-            State#state{override_acls = true};
-        {acl, _ACLName, _ACLData} ->
-            process_host_term(Term, global, State);
-        {alarms, Env} ->
-            add_option(alarms, Env, State);
-        {access, _RuleName, _Rules} ->
-            process_host_term(Term, global, State);
-        {shaper, _Name, _Data} ->
-            %%lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
-            %%          State, State#state.hosts);
-            process_host_term(Term, global, State);
-        {host, _Host} ->
-            State;
-        {hosts, _Hosts} ->
-            State;
-        {host_config, Host, Terms} ->
-            lists:foldl(fun(T, S) ->
-                            process_host_term(T, list_to_binary(Host), S) end,
-                        State, Terms);
-        {listen, Listeners} ->
-            Listeners2 =
-                lists:map(
-                  fun({PortIP, Module, Opts}) ->
-                      {Port, IPT, _, _, Proto, OptsClean} =
-                          ejabberd_listener:parse_listener_portip(PortIP, Opts),
-                      {{Port, IPT, Proto}, Module, OptsClean}
-                  end,
-                  Listeners),
-            add_option(listen, Listeners2, State);
-        {language, Val} ->
-            add_option(language, list_to_binary(Val), State);
-        {sm_backend, Val} ->
-            add_option(sm_backend, Val, State);
-        {rdbms_server_type, Val} ->
-            add_option(rdbms_server_type, Val, State);
-        {outgoing_s2s_port, Port} ->
-            add_option(outgoing_s2s_port, Port, State);
-        {outgoing_s2s_options, Methods, Timeout} ->
-            add_option(outgoing_s2s_options, {Methods, Timeout}, State);
-        {{s2s_addr, Host}, Addr} ->
-            add_option({s2s_addr, list_to_binary(Host)}, Addr, State);
-        {{global_distrib_addr, Host}, Addr} ->
-            add_option({global_distrib_addr, list_to_binary(Host)}, Addr, State);
-        {s2s_dns_options, PropList} ->
-            add_option(s2s_dns_options, PropList, State);
-        {s2s_use_starttls, Port} ->
-            add_option(s2s_use_starttls, Port, State);
-        {s2s_ciphers, Ciphers} ->
-            add_option(s2s_ciphers, Ciphers, State);
-        {s2s_certfile, CertFile} ->
-            State2 = compact_global_option(required_files, [CertFile], State),
-            add_option(s2s_certfile, CertFile, State2);
-        {domain_certfile, Domain, CertFile} ->
-            State2 = compact_global_option(required_files, [CertFile], State),
-            add_option({domain_certfile, Domain}, CertFile, State2);
-        {node_type, NodeType} ->
-            add_option(node_type, NodeType, State);
-        {cluster_nodes, Nodes} ->
-            add_option(cluster_nodes, Nodes, State);
-        {watchdog_admins, Admins} ->
-            add_option(watchdog_admins, Admins, State);
-        {watchdog_large_heap, LH} ->
-            add_option(watchdog_large_heap, LH, State);
-        {registration_timeout, Timeout} ->
-            add_option(registration_timeout, Timeout, State);
-        {mongooseimctl_access_commands, ACs} ->
-            add_option(mongooseimctl_access_commands, ACs, State);
-        {routing_modules, Mods} ->
-            add_option(routing_modules, Mods, State);
-        {loglevel, Loglevel} ->
-            add_option(loglevel, Loglevel, State);
-        {max_fsm_queue, N} ->
-            add_option(max_fsm_queue, N, State);
-        {sasl_mechanisms, Mechanisms} ->
-            add_option(sasl_mechanisms, Mechanisms, State);
-        {all_metrics_are_global, Value} ->
-            add_option(all_metrics_are_global, Value, State);
-        {cowboy_server_name, Value} ->
-            add_option(cowboy_server_name, Value, State);
-        {services, Value} ->
-            add_option(services, Value, State);
-        {_Opt, _Val} ->
-            lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
-                        State, State#state.hosts)
-    end.
-
--spec process_host_term(Term :: host_term(),
-                        Host :: acl:host(),
-                        State :: state()) -> state().
-process_host_term(Term, Host, State) ->
-    case Term of
-        {acl, ACLName, ACLData} ->
-            OptRec = acl:to_record(Host, ACLName, ACLData),
-            append_option(OptRec, State);
-        {access, RuleName, Rules} ->
-            append_global_opt({access, RuleName, Host}, Rules, State);
-        {shaper, Name, Data} ->
-            append_global_opt({shaper, Name, Host}, Data, State);
-        {host, Host} ->
-            State;
-        {hosts, _Hosts} ->
-            State;
-        {outgoing_pools, Pools} when is_list(Pools) ->
-            add_option(outgoing_pools, Pools, State);
-        {node_specific_options, NodeOpts} ->
-            add_option(node_specific_options, NodeOpts, State);
-        {Opt, Val} ->
-            add_option({Opt, Host}, Val, State)
-    end.
-
--spec add_option(Opt :: key(),
-                 Val :: value(),
-                 State :: state()) -> state().
-add_option(Opt, Val, State) ->
-    Table = opt_table(Opt),
-    add_option(Table, Opt, Val, State).
-
-add_option(config, Opt, Val, State) ->
-    append_global_opt(Opt, Val, State);
-add_option(local_config, {{add, OptName}, Host}, Val, State) ->
-    compact_option({OptName, Host}, Val, State);
-add_option(local_config, Opt, Val, State) ->
-    append_local_opt(Opt, Val, State).
-
-append_global_opt(OptName, OptValue, State) ->
-    OptRec = #config{key = OptName, value = OptValue},
-    append_option(OptRec, State).
-
-append_local_opt(OptName, OptValue, State) ->
-    OptRec = #local_config{key = OptName, value = OptValue},
-    append_option(OptRec, State).
-
-append_option(OptRec, State = #state{opts = Opts}) ->
-    State#state{ opts = [OptRec | Opts] }.
-
-%% Merges two values of a local option
-compact_option(Opt, Val, State) ->
-    Opts2 = compact(Opt, Val, State#state.opts, []),
-    State#state{opts = Opts2}.
-
-compact({OptName, Host} = Opt, Val, [], Os) ->
-    %% The option is defined for host using host_config before the global option.
-    %% The host_option can be overwritten.
-    %% TODO or maybe not. We need a test.
-    ?WARNING_MSG("event=host_config_option_can_be_overwritten "
-                 "option_name=~1000p host=~p "
-                 "solution=\"define global options before host options\"",
-                 [OptName, Host]),
-    [#local_config{key = Opt, value = Val}] ++ Os;
-%% Traverse the list of the options already parsed
-compact(Opt, Val, [#local_config{key = Opt, value = OldVal} | Os1], Os2) ->
-    %% If the key of a local_config matches the Opt that wants to be added
-    OptRec = #local_config{key = Opt, value = Val ++ OldVal},
-    %% Then prepend the new value to the list of old values
-    Os2 ++ [OptRec] ++ Os1;
-compact(Opt, Val, [O | Os1], Os2) ->
-    compact(Opt, Val, Os1, Os2 ++ [O]).
-
-
-%% Merges two values of a global option
-compact_global_option(Opt, Val, State) when is_list(Val) ->
-    Opts2 = compact_global(Opt, Val, State#state.opts, []),
-    State#state{opts = Opts2}.
-
-compact_global(Opt, Val, [], Os) ->
-    [#config{key = Opt, value = Val}] ++ Os;
-%% Traverse the list of the options already parsed
-compact_global(Opt, Val, [#config{key = Opt, value = OldVal} | Os1], Os2) ->
-    %% If the key of a local_config matches the Opt that wants to be added
-    OptRec = #config{key = Opt, value = Val ++ OldVal},
-    %% Then prepend the new value to the list of old values
-    Os2 ++ [OptRec] ++ Os1;
-compact_global(Opt, Val, [O | Os1], Os2) ->
-    compact_global(Opt, Val, Os1, Os2 ++ [O]).
-
-
-opt_table(Opt) ->
-    case is_global_option(Opt) of
-        true ->
-            config;
-        false ->
-            local_config
-    end.
-
-is_global_option(Opt) ->
-    lists:member(Opt, global_options()).
-
-global_options() ->
-    [
-        hosts,
-        language,
-        sm_backend,
-        node_specific_options
-    ].
-
-
-%%--------------------------------------------------------------------
-%% Configuration parsing
-%%--------------------------------------------------------------------
-
--spec parse_terms(term()) -> state().
-parse_terms(Terms) ->
-    State = just_parse_terms(Terms),
-    State2 = dedup_state_opts(State),
-    add_dep_modules(State2).
-
-just_parse_terms(Terms) ->
-    State = lists:foldl(fun search_hosts_and_pools/2, #state{}, Terms),
-    TermsWExpandedMacros = replace_macros(Terms),
-    lists:foldl(fun process_term/2, State, TermsWExpandedMacros).
-
--spec check_hosts([jid:server()], [jid:server()]) ->
-    {[jid:server()], [jid:server()]}.
-check_hosts(NewHosts, OldHosts) ->
-    Old = sets:from_list(OldHosts),
-    New = sets:from_list(NewHosts),
-    ListToAdd = sets:to_list(sets:subtract(New, Old)),
-    ListToDel = sets:to_list(sets:subtract(Old, New)),
-    {ListToDel, ListToAdd}.
-
-
--spec can_be_ignored(Key :: atom() | tuple()) -> boolean().
-can_be_ignored(Key) when is_atom(Key);
-                         is_tuple(Key) ->
-    L = [domain_certfile, s2s, all_metrics_are_global, rdbms],
-    lists:member(Key, L).
-
-% group values which can be grouped like rdbms ones
--spec group_host_changes([term()]) -> [{atom(), [term()]}].
-group_host_changes(Changes) when is_list(Changes) ->
-    D = lists:foldl(fun(#local_config{key = {Key, Host}, value = Val}, Dict) ->
-                        BKey = atom_to_binary(Key, utf8),
-                        case get_key_group(BKey, Key) of
-                            Key ->
-                                dict:append({Key, Host}, Val, Dict);
-                            NewKey ->
-                                dict:append({NewKey, Host}, {Key, Val}, Dict)
-                        end
-                    end, dict:new(), Changes),
-    [{Group, lists:sort(lists:flatten(MaybeDeepList))}
-     || {Group, MaybeDeepList} <- dict:to_list(D)].
-
-
--spec is_not_host_specific(atom()
-                           | {atom(), jid:server()}
-                           | {atom(), atom(), atom()}) -> boolean().
-is_not_host_specific(Key) when is_atom(Key) ->
-    true;
-is_not_host_specific({Key, Host}) when is_atom(Key), is_binary(Host) ->
-    false;
-is_not_host_specific({Key, PoolType, PoolName})
-  when is_atom(Key), is_atom(PoolType), is_atom(PoolName) ->
-    true.
-
--spec get_key_group(binary(), atom()) -> atom().
-get_key_group(<<"ldap_", _/binary>>, _) ->
-    ldap;
-get_key_group(<<"rdbms_", _/binary>>, _) ->
-    rdbms;
-get_key_group(<<"pgsql_", _/binary>>, _) ->
-    rdbms;
-get_key_group(<<"auth_", _/binary>>, _) ->
-    auth;
-get_key_group(<<"ext_auth_", _/binary>>, _) ->
-    auth;
-get_key_group(<<"s2s_", _/binary>>, _) ->
-    s2s;
-get_key_group(_, Key) when is_atom(Key) ->
-    Key.
-
-%% -----------------------------------------------------------------
 %% State API
-%% -----------------------------------------------------------------
+
+new_state() ->
+    #state{}.
 
 allow_override_all(State = #state{}) ->
     State#state{override_global = true,
@@ -510,9 +78,25 @@ allow_override_local_only(State = #state{}) ->
                 override_local  = true,
                 override_acls   = false}.
 
-opts_to_state(Opts, Hosts) ->
-    #state{opts = Opts, hosts = Hosts}.
+override_global(State) ->
+    State#state{override_global = true}.
 
+override_local(State) ->
+    State#state{override_local = true}.
+
+override_acls(State) ->
+    State#state{override_acls = true}.
+
+set_opts(Opts, State) ->
+    State#state{opts = Opts}.
+
+set_hosts(Hosts, State) ->
+    State#state{hosts = Hosts}.
+
+get_opts(State) ->
+    State#state.opts.
+
+%% final getter - reverses the accumulated options
 state_to_opts(#state{opts = Opts}) ->
     lists:reverse(Opts).
 
@@ -543,89 +127,7 @@ opts_to_global_opt([_|Opts], OptName, Default) ->
 opts_to_global_opt([], _OptName, Default) ->
     Default.
 
-
-%% -----------------------------------------------------------------
-%% Support for 'include_config_file'
-%% -----------------------------------------------------------------
-
-config_filenames_to_include([{include_config_file, Filename} | Terms]) ->
-    [Filename|config_filenames_to_include(Terms)];
-config_filenames_to_include([{include_config_file, Filename, _Options} | Terms]) ->
-    [Filename|config_filenames_to_include(Terms)];
-config_filenames_to_include([_Other | Terms]) ->
-    config_filenames_to_include(Terms);
-config_filenames_to_include([]) ->
-    [].
-
-include_config_files(Terms, Configs) ->
-    include_config_files(Terms, Configs, []).
-
-include_config_files([], _Configs, Res) ->
-    Res;
-include_config_files([{include_config_file, Filename} | Terms], Configs, Res) ->
-    include_config_files([{include_config_file, Filename, []} | Terms],
-                         Configs, Res);
-include_config_files([{include_config_file, Filename, Options} | Terms],
-                     Configs, Res) ->
-    IncludedTerms = find_plain_terms_for_file(Filename, Configs),
-    Disallow = proplists:get_value(disallow, Options, []),
-    IncludedTerms2 = delete_disallowed(Disallow, IncludedTerms),
-    AllowOnly = proplists:get_value(allow_only, Options, all),
-    IncludedTerms3 = keep_only_allowed(AllowOnly, IncludedTerms2),
-    include_config_files(Terms, Configs, Res ++ IncludedTerms3);
-include_config_files([Term | Terms], Configs, Res) ->
-    include_config_files(Terms, Configs, Res ++ [Term]).
-
-find_plain_terms_for_file(Filename, Configs) ->
-    case lists:keyfind(Filename, 1, Configs) of
-        false ->
-            %% Terms were not provided by caller for this file
-            erlang:error({config_not_found, Filename});
-        {Filename, Terms} ->
-            Terms
-    end.
-
-%% @doc Filter from the list of terms the disallowed.
-%% Returns a sublist of Terms without the ones which first element is
-%% included in Disallowed.
--spec delete_disallowed(Disallowed :: [atom()],
-                        Terms :: [term()]) -> [term()].
-delete_disallowed(Disallowed, Terms) ->
-    lists:foldl(
-      fun(Dis, Ldis) ->
-          delete_disallowed2(Dis, Ldis)
-      end,
-      Terms,
-      Disallowed).
-
-delete_disallowed2(Disallowed, [H | T]) ->
-    case element(1, H) of
-        Disallowed ->
-            ?WARNING_MSG("event=ignore_disallowed_option option=~p", [Disallowed]),
-            delete_disallowed2(Disallowed, T);
-        _ ->
-            [H | delete_disallowed2(Disallowed, T)]
-    end;
-delete_disallowed2(_, []) ->
-    [].
-
-%% @doc Keep from the list only the allowed terms.
-%% Returns a sublist of Terms with only the ones which first element is
-%% included in Allowed.
--spec keep_only_allowed(Allowed :: [atom()],
-                        Terms :: [term()]) -> [term()].
-keep_only_allowed(all, Terms) ->
-    Terms;
-keep_only_allowed(Allowed, Terms) ->
-    {As, NAs} = lists:partition(
-                  fun(Term) ->
-                      lists:member(element(1, Term), Allowed)
-                  end,
-                  Terms),
-    [?WARNING_MSG("event=ignore_disallowed_option option=~p", [NA])
-     || NA <- NAs],
-    As.
-
+%% Config post-processing
 
 dedup_state_opts(State = #state{opts = RevOpts}) ->
     {RevOpts2, _Removed} = dedup_state_opts_list(RevOpts, [], [], sets:new()),
@@ -645,7 +147,6 @@ dedup_state_opts_list([H|List], Removed, Keep, Set) ->
     dedup_state_opts_list(List, Removed, [H|Keep], Set);
 dedup_state_opts_list([], Removed, Keep, _Set) ->
     {Keep, Removed}.
-
 
 add_dep_modules(State = #state{opts = Opts}) ->
     Opts2 = add_dep_modules_opts(Opts),

--- a/src/config/mongoose_config_parser_cfg.erl
+++ b/src/config/mongoose_config_parser_cfg.erl
@@ -1,0 +1,408 @@
+%% @doc Config parsing and processing for the 'cfg' format
+-module(mongoose_config_parser_cfg).
+
+-behaviour(mongoose_config_parser).
+
+-export([parse_file/1]).
+
+%% For tests
+-export([parse_terms/1]).
+
+-include("mongoose.hrl").
+-include("ejabberd_config.hrl").
+
+-type macro() :: {macro_key(), macro_value()}.
+
+%% The atom must have all characters in uppercase.
+-type macro_key() :: atom().
+
+-type macro_value() :: term().
+
+-type known_term() :: override_global
+                    | override_local
+                    | override_acls
+                    | {acl, _, _}
+                    | {alarms, _}
+                    | {access, _, _}
+                    | {shaper, _, _}
+                    | {host, _}
+                    | {hosts, _}
+                    | {host_config, _, _}
+                    | {listen, _}
+                    | {language, _}
+                    | {sm_backend, _}
+                    | {outgoing_s2s_port, integer()}
+                    | {outgoing_s2s_options, _, integer()}
+                    | {{s2s_addr, _}, _}
+                    | {s2s_dns_options, [tuple()]}
+                    | {s2s_use_starttls, integer()}
+                    | {s2s_certfile, _}
+                    | {domain_certfile, _, _}
+                    | {node_type, _}
+                    | {cluster_nodes, _}
+                    | {registration_timeout, integer()}
+                    | {mongooseimctl_access_commands, list()}
+                    | {loglevel, _}
+                    | {max_fsm_queue, _}
+                    | {sasl_mechanisms, _}
+                    | host_term().
+
+-type host_term() :: {acl, _, _}
+                   | {access, _, _}
+                   | {shaper, _, _}
+                   | {host, _}
+                   | {hosts, _}.
+
+%%--------------------------------------------------------------------
+%% Configuration parsing
+%%--------------------------------------------------------------------
+
+-spec parse_file(FileName :: string()) -> mongoose_config_parser:state().
+parse_file(FileName) ->
+    Terms = mongoose_config_terms:get_plain_terms_file(FileName),
+    parse_terms(Terms).
+
+-spec parse_terms(term()) -> mongoose_config_parser:state().
+parse_terms(Terms) ->
+    State = just_parse_terms(Terms),
+    State2 = mongoose_config_parser:dedup_state_opts(State),
+    mongoose_config_parser:add_dep_modules(State2).
+
+just_parse_terms(Terms) ->
+    State = lists:foldl(fun search_hosts_and_pools/2, mongoose_config_parser:new_state(), Terms),
+    TermsWExpandedMacros = replace_macros(Terms),
+    lists:foldl(fun process_term/2, State, TermsWExpandedMacros).
+
+-spec search_hosts_and_pools({host|hosts,
+                              [mongoose_config_parser:host()] | mongoose_config_parser:host()},
+                             mongoose_config_parser:state()) -> any().
+search_hosts_and_pools({host, Host}, State) ->
+    search_hosts_and_pools({hosts, [Host]}, State);
+search_hosts_and_pools({hosts, Hosts}, State) ->
+    case mongoose_config_parser:state_to_host_opts(State) of
+        [] ->
+            add_hosts_to_option(Hosts, State);
+        OldHosts ->
+            ?ERROR_MSG("event=\"too many host definitions\" "
+                       "new_hosts=~1000p old_hosts=~1000p", []),
+            exit(#{issue => "too many hosts definitions",
+                   new_hosts => Hosts,
+                   old_hosts => OldHosts})
+    end;
+search_hosts_and_pools(_Term, State) ->
+    State.
+
+-spec add_hosts_to_option(Hosts :: [mongoose_config_parser:host()],
+                          State :: mongoose_config_parser:state()) ->
+          mongoose_config_parser:state().
+add_hosts_to_option(Hosts, State) ->
+    PrepHosts = normalize_hosts(Hosts),
+    add_option(hosts, PrepHosts, mongoose_config_parser:set_hosts(PrepHosts, State)).
+
+-spec normalize_hosts([mongoose_config_parser:host()]) -> [binary() | tuple()].
+normalize_hosts(Hosts) ->
+    normalize_hosts(Hosts, []).
+
+
+normalize_hosts([], PrepHosts) ->
+    lists:reverse(PrepHosts);
+normalize_hosts([Host | Hosts], PrepHosts) ->
+    case jid:nodeprep(host_to_binary(Host)) of
+        error ->
+            ?ERROR_MSG("event=invalid_hostname_in_config "
+                       "hostname=~p", [Host]),
+            erlang:error(#{issue => invalid_hostname,
+                           hostname => Host});
+        PrepHost ->
+            normalize_hosts(Hosts, [PrepHost | PrepHosts])
+    end.
+
+host_to_binary(Host) ->
+    unicode:characters_to_binary(Host).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Support for Macro
+
+%% @doc Replace the macros with their defined values.
+-spec replace_macros(Terms :: [term()]) -> [term()].
+replace_macros(Terms) ->
+    {TermsOthers, Macros} = split_terms_macros(Terms),
+    replace(TermsOthers, Macros).
+
+
+%% @doc Split Terms into normal terms and macro definitions.
+-spec split_terms_macros(Terms :: [term()]) -> {[term()], [macro()]}.
+split_terms_macros(Terms) ->
+    lists:foldl(fun split_terms_macros_fold/2, {[], []}, Terms).
+
+-spec split_terms_macros_fold(any(), Acc) -> Acc when
+      Acc :: {[term()], [{Key :: any(), Value :: any()}]}.
+split_terms_macros_fold({define_macro, Key, Value} = Term, {TOs, Ms}) ->
+    case is_macro_name(Key) of
+        true ->
+            {TOs, Ms ++ [{Key, Value}]};
+        false ->
+            exit({macro_not_properly_defined, Term})
+    end;
+split_terms_macros_fold(Term, {TOs, Ms}) ->
+    {TOs ++ [Term], Ms}.
+
+
+%% @doc Recursively replace in Terms macro usages with the defined value.
+-spec replace(Terms :: [term()],
+              Macros :: [macro()]) -> [term()].
+replace([], _) ->
+    [];
+replace([Term | Terms], Macros) ->
+    [replace_term(Term, Macros) | replace(Terms, Macros)].
+
+
+replace_term(Key, Macros) when is_atom(Key) ->
+    case is_macro_name(Key) of
+        true ->
+            case proplists:get_value(Key, Macros) of
+                undefined -> exit({undefined_macro, Key});
+                Value -> Value
+            end;
+        false ->
+            Key
+    end;
+replace_term({use_macro, Key, Value}, Macros) ->
+    proplists:get_value(Key, Macros, Value);
+replace_term(Term, Macros) when is_list(Term) ->
+    replace(Term, Macros);
+replace_term(Term, Macros) when is_tuple(Term) ->
+    List = tuple_to_list(Term),
+    List2 = replace(List, Macros),
+    list_to_tuple(List2);
+replace_term(Term, _) ->
+    Term.
+
+%% Check is the term is a config macro
+-spec is_macro_name(atom()) -> boolean().
+is_macro_name(Atom) when is_atom(Atom) ->
+    is_all_uppercase(Atom) andalso has_any_uppercase(Atom);
+is_macro_name(_) ->
+    false.
+
+-spec is_all_uppercase(atom()) -> boolean().
+is_all_uppercase(Atom) ->
+    String = erlang:atom_to_list(Atom),
+    lists:all(fun(C) when C >= $a, C =< $z -> false;
+                 (_) -> true
+              end, String).
+
+has_any_uppercase(Atom) ->
+    String = erlang:atom_to_list(Atom),
+    lists:any(fun(C) when C >= $A, C =< $Z -> true;
+                 (_) -> false
+              end, String).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Process terms
+
+-spec process_term(Term :: known_term(),
+                   State :: mongoose_config_parser:state()) -> mongoose_config_parser:state().
+process_term(Term, State) ->
+    case Term of
+        override_global ->
+            mongoose_config_parser:override_global(State);
+        override_local ->
+            mongoose_config_parser:override_local(State);
+        override_acls ->
+            mongoose_config_parser:override_acls(State);
+        {acl, _ACLName, _ACLData} ->
+            process_host_term(Term, global, State);
+        {alarms, Env} ->
+            add_option(alarms, Env, State);
+        {access, _RuleName, _Rules} ->
+            process_host_term(Term, global, State);
+        {shaper, _Name, _Data} ->
+            %%lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
+            %%          State, State#state.hosts);
+            process_host_term(Term, global, State);
+        {host, _Host} ->
+            State;
+        {hosts, _Hosts} ->
+            State;
+        {host_config, Host, Terms} ->
+            lists:foldl(fun(T, S) ->
+                            process_host_term(T, list_to_binary(Host), S) end,
+                        State, Terms);
+        {listen, Listeners} ->
+            Listeners2 =
+                lists:map(
+                  fun({PortIP, Module, Opts}) ->
+                      {Port, IPT, _, _, Proto, OptsClean} =
+                          ejabberd_listener:parse_listener_portip(PortIP, Opts),
+                      {{Port, IPT, Proto}, Module, OptsClean}
+                  end,
+                  Listeners),
+            add_option(listen, Listeners2, State);
+        {language, Val} ->
+            add_option(language, list_to_binary(Val), State);
+        {sm_backend, Val} ->
+            add_option(sm_backend, Val, State);
+        {rdbms_server_type, Val} ->
+            add_option(rdbms_server_type, Val, State);
+        {outgoing_s2s_port, Port} ->
+            add_option(outgoing_s2s_port, Port, State);
+        {outgoing_s2s_options, Methods, Timeout} ->
+            add_option(outgoing_s2s_options, {Methods, Timeout}, State);
+        {{s2s_addr, Host}, Addr} ->
+            add_option({s2s_addr, list_to_binary(Host)}, Addr, State);
+        {{global_distrib_addr, Host}, Addr} ->
+            add_option({global_distrib_addr, list_to_binary(Host)}, Addr, State);
+        {s2s_dns_options, PropList} ->
+            add_option(s2s_dns_options, PropList, State);
+        {s2s_use_starttls, Port} ->
+            add_option(s2s_use_starttls, Port, State);
+        {s2s_ciphers, Ciphers} ->
+            add_option(s2s_ciphers, Ciphers, State);
+        {s2s_certfile, CertFile} ->
+            State2 = compact_global_option(required_files, [CertFile], State),
+            add_option(s2s_certfile, CertFile, State2);
+        {domain_certfile, Domain, CertFile} ->
+            State2 = compact_global_option(required_files, [CertFile], State),
+            add_option({domain_certfile, Domain}, CertFile, State2);
+        {node_type, NodeType} ->
+            add_option(node_type, NodeType, State);
+        {cluster_nodes, Nodes} ->
+            add_option(cluster_nodes, Nodes, State);
+        {watchdog_admins, Admins} ->
+            add_option(watchdog_admins, Admins, State);
+        {watchdog_large_heap, LH} ->
+            add_option(watchdog_large_heap, LH, State);
+        {registration_timeout, Timeout} ->
+            add_option(registration_timeout, Timeout, State);
+        {mongooseimctl_access_commands, ACs} ->
+            add_option(mongooseimctl_access_commands, ACs, State);
+        {routing_modules, Mods} ->
+            add_option(routing_modules, Mods, State);
+        {loglevel, Loglevel} ->
+            add_option(loglevel, Loglevel, State);
+        {max_fsm_queue, N} ->
+            add_option(max_fsm_queue, N, State);
+        {sasl_mechanisms, Mechanisms} ->
+            add_option(sasl_mechanisms, Mechanisms, State);
+        {all_metrics_are_global, Value} ->
+            add_option(all_metrics_are_global, Value, State);
+        {cowboy_server_name, Value} ->
+            add_option(cowboy_server_name, Value, State);
+        {services, Value} ->
+            add_option(services, Value, State);
+        {_Opt, _Val} ->
+            lists:foldl(fun(Host, S) -> process_host_term(Term, Host, S) end,
+                        State, mongoose_config_parser:state_to_host_opts(State))
+    end.
+
+-spec process_host_term(Term :: host_term(),
+                        Host :: acl:host(),
+                        State :: mongoose_config_parser:state()) -> mongoose_config_parser:state().
+process_host_term(Term, Host, State) ->
+    case Term of
+        {acl, ACLName, ACLData} ->
+            OptRec = acl:to_record(Host, ACLName, ACLData),
+            append_option(OptRec, State);
+        {access, RuleName, Rules} ->
+            append_global_opt({access, RuleName, Host}, Rules, State);
+        {shaper, Name, Data} ->
+            append_global_opt({shaper, Name, Host}, Data, State);
+        {host, Host} ->
+            State;
+        {hosts, _Hosts} ->
+            State;
+        {outgoing_pools, Pools} when is_list(Pools) ->
+            add_option(outgoing_pools, Pools, State);
+        {node_specific_options, NodeOpts} ->
+            add_option(node_specific_options, NodeOpts, State);
+        {Opt, Val} ->
+            add_option({Opt, Host}, Val, State)
+    end.
+
+-spec add_option(Opt :: mongoose_config_parser:key(),
+                 Val :: mongoose_config_parser:value(),
+                 State :: mongoose_config_parser:state()) -> mongoose_config_parser:state().
+add_option(Opt, Val, State) ->
+    Table = opt_table(Opt),
+    add_option(Table, Opt, Val, State).
+
+add_option(config, Opt, Val, State) ->
+    append_global_opt(Opt, Val, State);
+add_option(local_config, {{add, OptName}, Host}, Val, State) ->
+    compact_option({OptName, Host}, Val, State);
+add_option(local_config, Opt, Val, State) ->
+    append_local_opt(Opt, Val, State).
+
+append_global_opt(OptName, OptValue, State) ->
+    OptRec = #config{key = OptName, value = OptValue},
+    append_option(OptRec, State).
+
+append_local_opt(OptName, OptValue, State) ->
+    OptRec = #local_config{key = OptName, value = OptValue},
+    append_option(OptRec, State).
+
+append_option(OptRec, State) ->
+    Opts = mongoose_config_parser:get_opts(State),
+    mongoose_config_parser:set_opts([OptRec | Opts], State).
+
+%% Merges two values of a local option
+compact_option(Opt, Val, State) ->
+    Opts = mongoose_config_parser:get_opts(State),
+    Opts2 = compact(Opt, Val, Opts, []),
+    mongoose_config_parser:set_opts(Opts2, State).
+
+compact({OptName, Host} = Opt, Val, [], Os) ->
+    %% The option is defined for host using host_config before the global option.
+    %% The host_option can be overwritten.
+    %% TODO or maybe not. We need a test.
+    ?WARNING_MSG("event=host_config_option_can_be_overwritten "
+                 "option_name=~1000p host=~p "
+                 "solution=\"define global options before host options\"",
+                 [OptName, Host]),
+    [#local_config{key = Opt, value = Val}] ++ Os;
+%% Traverse the list of the options already parsed
+compact(Opt, Val, [#local_config{key = Opt, value = OldVal} | Os1], Os2) ->
+    %% If the key of a local_config matches the Opt that wants to be added
+    OptRec = #local_config{key = Opt, value = Val ++ OldVal},
+    %% Then prepend the new value to the list of old values
+    Os2 ++ [OptRec] ++ Os1;
+compact(Opt, Val, [O | Os1], Os2) ->
+    compact(Opt, Val, Os1, Os2 ++ [O]).
+
+
+%% Merges two values of a global option
+compact_global_option(Opt, Val, State) when is_list(Val) ->
+    Opts2 = compact_global(Opt, Val, mongoose_config_parser:get_opts(State), []),
+    mongoose_config_parser:set_opts(Opts2, State).
+
+compact_global(Opt, Val, [], Os) ->
+    [#config{key = Opt, value = Val}] ++ Os;
+%% Traverse the list of the options already parsed
+compact_global(Opt, Val, [#config{key = Opt, value = OldVal} | Os1], Os2) ->
+    %% If the key of a local_config matches the Opt that wants to be added
+    OptRec = #config{key = Opt, value = Val ++ OldVal},
+    %% Then prepend the new value to the list of old values
+    Os2 ++ [OptRec] ++ Os1;
+compact_global(Opt, Val, [O | Os1], Os2) ->
+    compact_global(Opt, Val, Os1, Os2 ++ [O]).
+
+
+opt_table(Opt) ->
+    case is_global_option(Opt) of
+        true ->
+            config;
+        false ->
+            local_config
+    end.
+
+is_global_option(Opt) ->
+    lists:member(Opt, global_options()).
+
+global_options() ->
+    [
+        hosts,
+        language,
+        sm_backend,
+        node_specific_options
+    ].

--- a/src/config/mongoose_config_terms.erl
+++ b/src/config/mongoose_config_terms.erl
@@ -1,0 +1,145 @@
+%%% @doc Parsing of the 'cfg' file to Erlang terms
+-module(mongoose_config_terms).
+
+-export([get_plain_terms_file/1]).
+
+-include("mongoose.hrl").
+-include("ejabberd_config.hrl").
+
+%% @doc Read an ejabberd configuration file and return the terms.
+%% Input is an absolute or relative path to an ejabberd config file.
+%% Returns a list of plain terms,
+%% in which the options 'include_config_file' were parsed
+%% and the terms in those files were included.
+-spec get_plain_terms_file(string()) -> [term()].
+get_plain_terms_file(File1) ->
+    File = mongoose_config_utils:get_absolute_path(File1),
+    case file:consult(File) of
+        {ok, Terms} ->
+            include_config_files(Terms);
+        {error, {LineNumber, erl_parse, _ParseMessage} = Reason} ->
+            ExitText = describe_config_problem(File, Reason, LineNumber),
+            ?ERROR_MSG(ExitText, []),
+            mongoose_config_utils:exit_or_halt(ExitText);
+        {error, Reason} ->
+            ExitText = describe_config_problem(File, Reason),
+            ?ERROR_MSG(ExitText, []),
+            mongoose_config_utils:exit_or_halt(ExitText)
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Support for 'include_config_file'
+
+%% @doc Include additional configuration files in the list of terms.
+-spec include_config_files([term()]) -> [term()].
+include_config_files(Terms) ->
+    Filenames = config_filenames_to_include(Terms),
+    Configs = lists:map(fun(Filename) ->
+            {Filename, get_plain_terms_file(Filename)}
+        end, Filenames),
+    include_config_files(Terms, Configs).
+
+config_filenames_to_include([{include_config_file, Filename} | Terms]) ->
+    [Filename|config_filenames_to_include(Terms)];
+config_filenames_to_include([{include_config_file, Filename, _Options} | Terms]) ->
+    [Filename|config_filenames_to_include(Terms)];
+config_filenames_to_include([_Other | Terms]) ->
+    config_filenames_to_include(Terms);
+config_filenames_to_include([]) ->
+    [].
+
+include_config_files(Terms, Configs) ->
+    include_config_files(Terms, Configs, []).
+
+include_config_files([], _Configs, Res) ->
+    Res;
+include_config_files([{include_config_file, Filename} | Terms], Configs, Res) ->
+    include_config_files([{include_config_file, Filename, []} | Terms],
+                         Configs, Res);
+include_config_files([{include_config_file, Filename, Options} | Terms],
+                     Configs, Res) ->
+    IncludedTerms = find_plain_terms_for_file(Filename, Configs),
+    Disallow = proplists:get_value(disallow, Options, []),
+    IncludedTerms2 = delete_disallowed(Disallow, IncludedTerms),
+    AllowOnly = proplists:get_value(allow_only, Options, all),
+    IncludedTerms3 = keep_only_allowed(AllowOnly, IncludedTerms2),
+    include_config_files(Terms, Configs, Res ++ IncludedTerms3);
+include_config_files([Term | Terms], Configs, Res) ->
+    include_config_files(Terms, Configs, Res ++ [Term]).
+
+find_plain_terms_for_file(Filename, Configs) ->
+    case lists:keyfind(Filename, 1, Configs) of
+        false ->
+            %% Terms were not provided by caller for this file
+            erlang:error({config_not_found, Filename});
+        {Filename, Terms} ->
+            Terms
+    end.
+
+%% @doc Filter from the list of terms the disallowed.
+%% Returns a sublist of Terms without the ones which first element is
+%% included in Disallowed.
+-spec delete_disallowed(Disallowed :: [atom()],
+                        Terms :: [term()]) -> [term()].
+delete_disallowed(Disallowed, Terms) ->
+    lists:foldl(
+      fun(Dis, Ldis) ->
+          delete_disallowed2(Dis, Ldis)
+      end,
+      Terms,
+      Disallowed).
+
+delete_disallowed2(Disallowed, [H | T]) ->
+    case element(1, H) of
+        Disallowed ->
+            ?WARNING_MSG("event=ignore_disallowed_option option=~p", [Disallowed]),
+            delete_disallowed2(Disallowed, T);
+        _ ->
+            [H | delete_disallowed2(Disallowed, T)]
+    end;
+delete_disallowed2(_, []) ->
+    [].
+
+%% @doc Keep from the list only the allowed terms.
+%% Returns a sublist of Terms with only the ones which first element is
+%% included in Allowed.
+-spec keep_only_allowed(Allowed :: [atom()],
+                        Terms :: [term()]) -> [term()].
+keep_only_allowed(all, Terms) ->
+    Terms;
+keep_only_allowed(Allowed, Terms) ->
+    {As, NAs} = lists:partition(
+                  fun(Term) ->
+                      lists:member(element(1, Term), Allowed)
+                  end,
+                  Terms),
+    [?WARNING_MSG("event=ignore_disallowed_option option=~p", [NA])
+     || NA <- NAs],
+    As.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Errors reading the config file
+
+-type config_problem() :: atom() | {integer(), atom() | tuple(), _}. % spec me better
+
+-spec describe_config_problem(Filename :: string(),
+                              Reason :: config_problem()) -> string().
+describe_config_problem(Filename, Reason) ->
+    Text1 = lists:flatten("Problem loading MongooseIM config file " ++ Filename),
+    Text2 = lists:flatten(" : " ++ file:format_error(Reason)),
+    ExitText = Text1 ++ Text2,
+    ExitText.
+
+
+-spec describe_config_problem(Filename :: string(),
+                              Reason :: config_problem(),
+                              Line :: pos_integer()) -> string().
+describe_config_problem(Filename, Reason, LineNumber) ->
+    Text1 = lists:flatten("Problem loading ejabberd config file " ++ Filename),
+    Text2 = lists:flatten(" approximately in the line "
+                          ++ file:format_error(Reason)),
+    ExitText = Text1 ++ Text2,
+    Lines = mongoose_config_utils:get_config_lines(Filename, LineNumber, 10, 3),
+    ?ERROR_MSG("The following lines from your configuration file might be"
+               " relevant to the error: ~n~s", [Lines]),
+    ExitText.

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -97,9 +97,9 @@ start() ->
 
 
 %% @doc Get the filename of the ejabberd configuration file.
-%% The filename can be specified with: erl -config "/path/to/mongooseim.cfg".
+%% The filename can be specified with: erl -config "/path/to/mongooseim.toml".
 %% It can also be specified with the environtment variable EJABBERD_CONFIG_PATH.
-%% If not specified, the default value 'mongooseim.cfg' is assumed.
+%% If not specified, the default value 'mongooseim.toml' is assumed.
 -spec get_ejabberd_config_path() -> string().
 get_ejabberd_config_path() ->
     DefaultPath = case os:getenv("EJABBERD_CONFIG_PATH") of
@@ -314,11 +314,10 @@ handle_table_does_not_exist_error(Table) ->
 %%--------------------------------------------------------------------
 -spec parse_file(file:name()) -> state().
 parse_file(ConfigFile) ->
-    TOMLFile = filename:rootname(ConfigFile) ++ ".toml",
-    case filelib:is_file(TOMLFile) of
-        true ->
-            mongoose_config_parser_toml:read_file(TOMLFile);
-        false ->
+    case filename:extension(ConfigFile) of
+        ".toml" ->
+            mongoose_config_parser_toml:read_file(ConfigFile);
+        ".cfg" ->
             Terms = get_plain_terms_file(ConfigFile),
             mongoose_config_parser:parse_terms(Terms)
     end.

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -55,7 +55,7 @@
 
 -export([other_cluster_nodes/0]).
 
--import(mongoose_config_parser, [can_be_ignored/1]).
+-import(mongoose_config_reload, [can_be_ignored/1]).
 
 -export([apply_reloading_change/1]).
 
@@ -89,7 +89,7 @@ start() ->
                          {local_content, true},
                          {attributes, record_info(fields, local_config)}]),
     mnesia:add_table_copy(local_config, node(), ram_copies),
-    Config = get_ejabberd_config_path(),
+    Config = get_config_path(),
     ejabberd_config:load_file(Config),
     %% This start time is used by mod_last:
     add_local_option(node_start, {node_start, erlang:system_time(second)}),
@@ -100,8 +100,8 @@ start() ->
 %% The filename can be specified with: erl -config "/path/to/mongooseim.toml".
 %% It can also be specified with the environtment variable EJABBERD_CONFIG_PATH.
 %% If not specified, the default value 'mongooseim.toml' is assumed.
--spec get_ejabberd_config_path() -> string().
-get_ejabberd_config_path() ->
+-spec get_config_path() -> string().
+get_config_path() ->
     DefaultPath = case os:getenv("EJABBERD_CONFIG_PATH") of
                       false ->
                           ?CONFIG_PATH;
@@ -116,75 +116,12 @@ get_ejabberd_config_path() ->
 %% This function will crash if finds some error in the configuration file.
 -spec load_file(File :: string()) -> ok.
 load_file(File) ->
-    State = parse_file(File),
+    State = mongoose_config_parser:parse_file(File),
     assert_required_files_exist(State),
     set_opts(State).
 
-
-%% @doc Read an ejabberd configuration file and return the terms.
-%% Input is an absolute or relative path to an ejabberd config file.
-%% Returns a list of plain terms,
-%% in which the options 'include_config_file' were parsed
-%% and the terms in those files were included.
--spec get_plain_terms_file(string()) -> [term()].
-get_plain_terms_file(File1) ->
-    File = mongoose_config_utils:get_absolute_path(File1),
-    case file:consult(File) of
-        {ok, Terms} ->
-            include_config_files(Terms);
-        {error, {LineNumber, erl_parse, _ParseMessage} = Reason} ->
-            ExitText = describe_config_problem(File, Reason, LineNumber),
-            ?ERROR_MSG(ExitText, []),
-            mongoose_config_utils:exit_or_halt(ExitText);
-        {error, Reason} ->
-            ExitText = describe_config_problem(File, Reason),
-            ?ERROR_MSG(ExitText, []),
-            mongoose_config_utils:exit_or_halt(ExitText)
-    end.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% Errors reading the config file
-
--type config_problem() :: atom() | {integer(), atom() | tuple(), _}. % spec me better
-
--spec describe_config_problem(Filename :: string(),
-                              Reason :: config_problem()) -> string().
-describe_config_problem(Filename, Reason) ->
-    Text1 = lists:flatten("Problem loading MongooseIM config file " ++ Filename),
-    Text2 = lists:flatten(" : " ++ file:format_error(Reason)),
-    ExitText = Text1 ++ Text2,
-    ExitText.
-
-
--spec describe_config_problem(Filename :: string(),
-                              Reason :: config_problem(),
-                              Line :: pos_integer()) -> string().
-describe_config_problem(Filename, Reason, LineNumber) ->
-    Text1 = lists:flatten("Problem loading ejabberd config file " ++ Filename),
-    Text2 = lists:flatten(" approximately in the line "
-                          ++ file:format_error(Reason)),
-    ExitText = Text1 ++ Text2,
-    Lines = mongoose_config_utils:get_config_lines(Filename, LineNumber, 10, 3),
-    ?ERROR_MSG("The following lines from your configuration file might be"
-               " relevant to the error: ~n~s", [Lines]),
-    ExitText.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%% Support for 'include_config_file'
-
-%% @doc Include additional configuration files in the list of terms.
--spec include_config_files([term()]) -> [term()].
-include_config_files(Terms) ->
-    Filenames = mongoose_config_parser:config_filenames_to_include(Terms),
-    Configs = lists:map(fun(Filename) ->
-            {Filename, get_plain_terms_file(Filename)}
-        end, Filenames),
-    mongoose_config_parser:include_config_files(Terms, Configs).
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Process terms
-
 
 -spec set_opts(state()) -> 'ok' | none().
 set_opts(State) ->
@@ -312,16 +249,6 @@ handle_table_does_not_exist_error(Table) ->
 %%--------------------------------------------------------------------
 %% Configuration reload
 %%--------------------------------------------------------------------
--spec parse_file(file:name()) -> state().
-parse_file(ConfigFile) ->
-    case filename:extension(ConfigFile) of
-        ".toml" ->
-            mongoose_config_parser_toml:read_file(ConfigFile);
-        ".cfg" ->
-            Terms = get_plain_terms_file(ConfigFile),
-            mongoose_config_parser:parse_terms(Terms)
-    end.
-
 -spec reload_local() -> {ok, iolist()} | no_return().
 reload_local() ->
     reload_nodes(reload_local, [node()], false).
@@ -472,7 +399,7 @@ handle_config_del(#config{key = hosts, value = Hosts}) ->
 
 %% handle add/remove new hosts
 handle_config_change({hosts, OldHosts, NewHosts}) ->
-    {ToDel, ToAdd} = mongoose_config_parser:check_hosts(NewHosts, OldHosts),
+    {ToDel, ToAdd} = mongoose_config_reload:check_hosts(NewHosts, OldHosts),
     lists:foreach(fun remove_virtual_host/1, ToDel),
     lists:foreach(fun add_virtual_host/1, ToAdd);
 handle_config_change({language, _Old, _New}) ->
@@ -592,7 +519,7 @@ get_host_local_config() ->
 
 -spec get_local_config() -> [{local_config, term(), term()}].
 get_local_config() ->
-    Keys = lists:filter(fun mongoose_config_parser:is_not_host_specific/1, mnesia:dirty_all_keys(local_config)),
+    Keys = lists:filter(fun mongoose_config_reload:is_not_host_specific/1, mnesia:dirty_all_keys(local_config)),
     lists:flatten(lists:map(fun(Key) ->
                                 mnesia:dirty_read(local_config, Key)
                             end,
@@ -613,8 +540,8 @@ get_categorized_options() ->
 %% This function prepares all state data to pass into pure code part
 %% (i.e. mongoose_config_parser and mongoose_config_reload).
 config_state() ->
-    ConfigFile = get_ejabberd_config_path(),
-    State = parse_file(ConfigFile),
+    ConfigFile = get_config_path(),
+    State = mongoose_config_parser:parse_file(ConfigFile),
     %% Performance optimization hint:
     %% terms_to_missing_and_required_files/1 actually parses Terms into State.
     #{missing_files := MissingFiles,
@@ -644,8 +571,8 @@ config_states(Nodes) ->
     end.
 
 compute_config_file_version() ->
-    ConfigFile = get_ejabberd_config_path(),
-    State = parse_file(ConfigFile),
+    ConfigFile = get_config_path(),
+    State = mongoose_config_parser:parse_file(ConfigFile),
     mongoose_config_reload:compute_config_file_version(State).
 
 compute_loaded_config_version() ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -19,13 +19,13 @@ end_per_suite(_Config) ->
     ok.
 
 equivalence(Config) ->
-    {ok, Terms} = file:consult(ejabberd_helper:data(Config, "mongooseim-pgsql.cfg")),
-    State1 = mongoose_config_parser:parse_terms(Terms),
+    CfgPath = ejabberd_helper:data(Config, "mongooseim-pgsql.cfg"),
+    State1 = mongoose_config_parser_cfg:parse_file(CfgPath),
     Hosts1 = mongoose_config_parser:state_to_host_opts(State1),
     Opts1 = mongoose_config_parser:state_to_opts(State1),
 
     TOMLPath = ejabberd_helper:data(Config, "mongooseim-pgsql.toml"),
-    State2 = mongoose_config_parser_toml:read_file(TOMLPath),
+    State2 = mongoose_config_parser_toml:parse_file(TOMLPath),
     Hosts2 = mongoose_config_parser:state_to_host_opts(State2),
     Opts2 = mongoose_config_parser:state_to_opts(State2),
 

--- a/test/ejabberd_config_SUITE.erl
+++ b/test/ejabberd_config_SUITE.erl
@@ -75,7 +75,7 @@ smoke(Config) ->
     ok = stop_ejabberd().
 
 coalesce_multiple_local_config_options(_Config) ->
-    F = fun mongoose_config_parser:group_host_changes/1,
+    F = fun mongoose_config_reload:group_host_changes/1,
     ?eq(coalesced_modules_section(), F(multiple_modules_sections())).
 
 add_a_module(C) ->

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -84,7 +84,7 @@ match_cases() ->
 
 
 flat_state_case(_C) ->
-    State = mongoose_config_parser:parse_terms(cool_mod_mam_config()),
+    State = mongoose_config_parser_cfg:parse_terms(cool_mod_mam_config()),
     ?assertEqual(cool_mod_mam_config_flat(),
                  mongoose_config_reload:state_to_flat_local_opts(State)).
 
@@ -98,7 +98,7 @@ cool_mod_mam_config_flat() ->
      {[h,<<"localhost">>,module_opt,mod_mam,pool],cool_pool}].
 
 flat_module_subopts_case(_C) ->
-    State = mongoose_config_parser:parse_terms(gd_config()),
+    State = mongoose_config_parser_cfg:parse_terms(gd_config()),
     FlatOpts = mongoose_config_reload:state_to_flat_local_opts(State),
     NumConnsKey = [h,<<"localhost">>,module_subopt,mod_global_distrib,
                    connections,num_of_connections],
@@ -112,7 +112,7 @@ flat_module_subopts_case(_C) ->
     ok.
 
 expand_opts_case(_C) ->
-    State = mongoose_config_parser:parse_terms(cool_mod_mam_config()),
+    State = mongoose_config_parser_cfg:parse_terms(cool_mod_mam_config()),
     FlatOpts = mongoose_config_reload:state_to_flat_local_opts(State),
     ExpandedOpts = mongoose_config_flat:expand_all_opts(FlatOpts),
     CatOpts = mongoose_config_reload:state_to_categorized_options(State),
@@ -123,7 +123,7 @@ expand_opts_case(_C) ->
     ok.
 
 expand_module_subopts_case(_C) ->
-    State = mongoose_config_parser:parse_terms(gd_config()),
+    State = mongoose_config_parser_cfg:parse_terms(gd_config()),
     FlatOpts = mongoose_config_reload:state_to_flat_local_opts(State),
     ExpandedOpts = mongoose_config_flat:expand_all_opts(FlatOpts),
     CatOpts = mongoose_config_reload:state_to_categorized_options(State),
@@ -174,7 +174,7 @@ auth_config_states() ->
     [auth_config_node1_config_v1()].
 
 auth_config_node1_config_v1() ->
-    State = mongoose_config_parser:parse_terms(auth_config()),
+    State = mongoose_config_parser_cfg:parse_terms(auth_config()),
     #{mongoose_node => mim1,
       config_file => "/etc/mongooseim.cfg",
       loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State),
@@ -188,22 +188,22 @@ auth_host_local_config() ->
 
 auth_config_state() ->
     Terms = auth_config(),
-    mongoose_config_parser:parse_terms(Terms).
+    mongoose_config_parser_cfg:parse_terms(Terms).
 
 %% Check that underscore is not treated as a config macro by config parser
 parse_config_with_underscore_pattern_case(_C) ->
-    mongoose_config_parser:parse_terms(node_specific_cool_mod_mam_config()).
+    mongoose_config_parser_cfg:parse_terms(node_specific_cool_mod_mam_config()).
 
 %% Check that we can convert state into node_specific_options list
 node_specific_options_presents_case(_C) ->
-    State = mongoose_config_parser:parse_terms(node_specific_cool_mod_mam_config()),
+    State = mongoose_config_parser_cfg:parse_terms(node_specific_cool_mod_mam_config()),
     NodeOpts = mongoose_config_parser:state_to_global_opt(node_specific_options, State, missing),
     ?assertEqual([ [h,'_',module_opt,mod_mam,pool] ],
                  NodeOpts).
 
 %% Check that we would not crash if node_specific_options is not defined
 node_specific_options_missing_case(_C) ->
-    State = mongoose_config_parser:parse_terms(cool_mod_mam_config()),
+    State = mongoose_config_parser_cfg:parse_terms(cool_mod_mam_config()),
     NodeOpts = mongoose_config_parser:state_to_global_opt(node_specific_options, State, missing),
     ?assertEqual(missing, NodeOpts).
 
@@ -247,7 +247,7 @@ example_config_states() ->
 
 %% node1_config_v1 configuration both in memory and on disc
 config_node1_config_v1() ->
-    State = mongoose_config_parser:parse_terms(node1_config_v1()),
+    State = mongoose_config_parser_cfg:parse_terms(node1_config_v1()),
     #{mongoose_node => mim1,
       config_file => "/etc/mongooseim.cfg",
       loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State),
@@ -256,7 +256,7 @@ config_node1_config_v1() ->
 
 %% node2_config_v1 configuration both in memory and on disc
 config_node2_config_v1() ->
-    State = mongoose_config_parser:parse_terms(node2_config_v1()),
+    State = mongoose_config_parser_cfg:parse_terms(node2_config_v1()),
     #{mongoose_node => mim2,
       config_file => "/etc/mongooseim.cfg",
       loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State),
@@ -266,8 +266,8 @@ config_node2_config_v1() ->
 %% node1_config_v1 configuration in memory
 %% node1_config_v2 configuration on disc
 config_node1_config_v2() ->
-    State_v1 = mongoose_config_parser:parse_terms(node1_config_v1()),
-    State_v2 = mongoose_config_parser:parse_terms(node1_config_v2()),
+    State_v1 = mongoose_config_parser_cfg:parse_terms(node1_config_v1()),
+    State_v2 = mongoose_config_parser_cfg:parse_terms(node1_config_v2()),
     #{mongoose_node => mim1,
       config_file => "/etc/mongooseim.cfg",
       loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State_v1),
@@ -277,8 +277,8 @@ config_node1_config_v2() ->
 %% node2_config_v1 configuration in memory
 %% node2_config_v2 configuration on disc
 config_node2_config_v2() ->
-    State_v1 = mongoose_config_parser:parse_terms(node2_config_v1()),
-    State_v2 = mongoose_config_parser:parse_terms(node2_config_v2()),
+    State_v1 = mongoose_config_parser_cfg:parse_terms(node2_config_v1()),
+    State_v2 = mongoose_config_parser_cfg:parse_terms(node2_config_v2()),
     #{mongoose_node => mim2,
       config_file => "/etc/mongooseim.cfg",
       loaded_categorized_options => mongoose_config_reload:state_to_categorized_options(State_v1),
@@ -372,8 +372,8 @@ node2_config_v2() ->
 
 get_config_diff_case(_C) ->
     %% Calculate changes to node1 reload_local to transit from v1 to v2
-    State_v1 = mongoose_config_parser:parse_terms(node1_config_v1()),
-    State_v2 = mongoose_config_parser:parse_terms(node1_config_v2()),
+    State_v1 = mongoose_config_parser_cfg:parse_terms(node1_config_v1()),
+    State_v2 = mongoose_config_parser_cfg:parse_terms(node1_config_v2()),
     CatOptions = mongoose_config_reload:state_to_categorized_options(State_v1),
     Diff = mongoose_config_reload:get_config_diff(State_v2, CatOptions),
     #{local_hosts_changes := #{ to_reload := ToReload }} = Diff,
@@ -395,7 +395,7 @@ config_with_required_files() ->
     ].
 
 parse_config_with_required_files_case(_C) ->
-    State = mongoose_config_parser:parse_terms(config_with_required_files()),
+    State = mongoose_config_parser_cfg:parse_terms(config_with_required_files()),
     ?assertEqual(["priv/ssl/localhost_server.pem",
                   "priv/ssl/fake_server.pem"],
                  mongoose_config_parser:state_to_required_files(State)),


### PR DESCRIPTION
**Functional changes**
Choose config format (cfg or TOML) by looking at file extension. Previously even though the configured path ended with 'cfg', the '.cfg' file extension was stripped and if there was a '.toml' file with the same root name, it was used instead. This was counter-intuitive and now the config file name is configured explicitly - it is `mongooseim.toml` by default.
There is no implicit fallback to `mongooseim.cfg` anymore.
Having one explicitly configured config path is less error prone.

Right now the way to change it would be to edit the `mongooseim` script. We could make it simpler if we want to support both formats. The goal for now is to keep only TOML after a possible transition period (not decided yet).

**Refactoring**
- Move the parser of the `cfg` format to `mongoose_config_parser_cfg`
- Extract term parsing to `mongoose_config_terms`
- Extract reload helpers to `mongoose_config_reload`

