### PR TITLE
Redefine location() type according to the new macro

### DIFF
--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -57,7 +57,10 @@
 %% Note about 'undefined' to_jid and from_jid: these are the special cases when JID may be
 %% truly unknown: before a client is authorized.
 
--type location() :: {Module :: module(), Function :: atom(), Line :: pos_integer()}.
+-type location() :: #{mfa := {module(), atom(), non_neg_integer()},
+                      line := non_neg_integer(),
+                      file := string()}.
+
 -type stanza_metadata() :: #{
         element := exml:element(),
         from_jid := jid:jid() | undefined,


### PR DESCRIPTION
Logger defines its own `?LOCATION` macro, which forced us to remove our
previous custom definition for it. Now, we also had a type defined
accordingly, which needs to be rewritten to match the new return value.

-> This fixes dialyzer for the otp_logger branch.