### PR TITLE
Reorganise http related test_suites

### DIFF
--- a/big_tests/tests/http_helper.erl
+++ b/big_tests/tests/http_helper.erl
@@ -24,7 +24,7 @@
     {ok, pid()}.
 start(Port, Path, HandleFun) ->
     application:ensure_all_started(cowboy),
-    Dispatch = cowboy_router:compile([{'_', [{Path, http_helper, [HandleFun]}]}]),
+    Dispatch = cowboy_router:compile([{'_', [{Path, http_helper, HandleFun}]}]),
     {ok, _} = cowboy:start_clear(http_helper_listener, [{port, Port}],
                                  #{env => #{dispatch => Dispatch}}).
 
@@ -35,6 +35,6 @@ port() ->
     ranch:get_port(http_helper_listener).
 
 %% Cowboy handler callbacks
-init(Req, [HandleFun] = State) ->
+init(Req, HandleFun = State) ->
     Req2 = HandleFun(Req),
     {ok, Req2, State}.

--- a/big_tests/tests/mod_http_notification_SUITE.erl
+++ b/big_tests/tests/mod_http_notification_SUITE.erl
@@ -14,6 +14,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(ETS_TABLE, mod_http_notification).
+
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
                              rpc/4]).
@@ -24,39 +26,27 @@
 %%% Suite configuration
 %%%===================================================================
 
-all() ->
-    [
-        {group, mod_http_notification_tests},
-        {group, mod_http_notification_tests_with_prefix}
-    ].
-
-all_tests() ->
-    [simple_message, simple_message_no_listener, simple_message_failing_listener, proper_http_message_encode_decode].
-
-groups() ->
-    G = [{mod_http_notification_tests, [sequence], all_tests()},
-         {mod_http_notification_tests_with_prefix, [sequence], all_tests()}],
-    ct_helper:repeat_all_until_all_ok(G).
-
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
-set_worker(Config) ->
-    set_modules(Config, [{worker_timeout, 500}, {host, http_notifications_host()}]).
+all() ->
+    [
+     {group, no_prefix},
+     {group, with_prefix}
+    ].
 
-set_worker(Config, Prefix) ->
-    set_modules(Config, [{worker_timeout, 500}, {host, http_notifications_host()}, {path, Prefix}]).
+all_tests() ->
+    [
+     simple_message,
+     simple_message_no_listener,
+     simple_message_failing_listener,
+     proper_http_message_encode_decode
+    ].
 
-set_modules(Config0, Opts) ->
-    Config = dynamic_modules:save_modules(host(), Config0),
-    HTTPOpts = [{server, http_notifications_host()}],
-    PoolOpts = [{strategy, available_worker}, {workers, 20}],
-    ejabberd_node_utils:call_fun(mongoose_wpool, start_configured_pools,
-                                 [[{http, global, http_pool, PoolOpts, HTTPOpts}]]),
-    dynamic_modules:ensure_modules(host(), [{mod_http_notification, Opts}]),
-    Config.
-
-host() -> ct:get_config({hosts, mim, domain}).
+groups() ->
+    G = [{no_prefix, [sequence], all_tests()},
+         {with_prefix, [sequence], all_tests()}],
+    ct_helper:repeat_all_until_all_ok(G).
 
 init_per_suite(Config0) ->
     Config1 = escalus:init_per_suite(Config0),
@@ -66,68 +56,57 @@ end_per_suite(Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
-init_per_group(mod_http_notification_tests, Config) ->
-    set_worker(Config);
-init_per_group(mod_http_notification_tests_with_prefix, Config) ->
-    set_worker(Config, "/prefix").
+init_per_group(no_prefix, Config) ->
+    set_modules(Config, []);
+init_per_group(with_prefix, Config) ->
+    set_modules(Config, [{path, "/prefix"}]).
 
 end_per_group(_GroupName, Config) ->
-    ejabberd_node_utils:call_fun(mongoose_wpool, stop, [http, global, http_pool]),
     dynamic_modules:restore_modules(host(), Config),
     ok.
 
 init_per_testcase(CaseName, Config) ->
+    create_events_collection(),
     start_http_listener(CaseName, get_prefix(Config)),
+    start_pool(),
     escalus:init_per_testcase(CaseName, Config).
 
 end_per_testcase(CaseName, Config) ->
-    http_helper:stop(),
+    stop_pool(),
+    stop_http_listener(CaseName),
+    clear_events_collection(),
     escalus:end_per_testcase(CaseName, Config).
-
-start_http_listener(simple_message, Prefix) ->
-    Pid = self(),
-    http_helper:start(http_notifications_port(), Prefix, fun(Req) -> process_notification(Req, Pid) end);
-start_http_listener(simple_message_no_listener, _) ->
-    ok;
-start_http_listener(simple_message_failing_listener, Prefix) ->
-    http_helper:start(http_notifications_port(), Prefix, fun(Req) -> Req end);
-start_http_listener(proper_http_message_encode_decode, Prefix) ->
-    Pid = self(),
-    http_helper:start(http_notifications_port(), Prefix, fun(Req) -> process_notification(Req, Pid) end).
-
-process_notification(Req, Pid) ->
-    {ok, Body, Req1} = cowboy_req:read_body(Req),
-    Req2 = cowboy_req:reply(200, #{<<"content-type">> => <<"text/plain">>}, <<"OK">>, Req1),
-    Pid ! {got_http_request, Body},
-    Req2.
 
 %%%===================================================================
 %%% offline tests
 %%%===================================================================
-proper_http_message_encode_decode(Config) ->
-    Receiver= <<"bob">>,
+proper_http_message_encode_decode(Config0) ->
+    Config = escalus_fresh:create_users(Config0, [{alice, 1}, {bob, 1}]),
+    {ok, Alice} = escalus_client:start(Config, alice, <<"res1">>),
+    escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
+    {ok, Bob} = escalus_client:start(Config, bob, <<"res1">>),
+    escalus:send(Bob, escalus_stanza:presence(<<"available">>)),
+
+    Sender = jid:nameprep(escalus_users:get_username(Config, alice)),
+    Server = jid:nodeprep(escalus_users:get_host(Config, alice)),
+    Receiver = jid:nameprep(escalus_users:get_username(Config, bob)),
     Message = <<"Hi Test!&escape=Hello">>,
-    Sender = <<"alice">>,
-    Server = escalus_users:get_host(Config, alice),
+
     BobJid = escalus_users:get_jid(Config, bob),
+    Stanza = escalus_stanza:chat_to(BobJid, Message),
+    escalus:send(Alice, Stanza),
+    escalus:wait_for_stanzas(Bob, 2),
 
-    escalus:story(Config, [{alice, 1}, {bob,1}],
-        fun(Alice, Bob) ->
-            escalus:send(Alice, escalus_stanza:chat_to(BobJid, Message)),
-            escalus:wait_for_stanzas(Bob, 2)
-        end),
+    escalus_client:stop(Config, Alice),
+    escalus_client:stop(Config, Bob),
 
-    Body = receive
-               {got_http_request, Bin} ->
-                   Bin
-           after 5000 ->
-                ct:fail(http_request_timeout)
-           end,
+    Body = get_http_request(),
+
     ExtractedAndDecoded = rpc(mim(), cow_qs, parse_qs, [Body]),
     ExpectedList = [{<<"author">>,<<Sender/binary>>},
-        {<<"server">>,<<Server/binary>>},
-        {<<"receiver">>,<<Receiver/binary>>},
-        {<<"message">>,<<Message/binary>>}],
+                    {<<"server">>,<<Server/binary>>},
+                    {<<"receiver">>,<<Receiver/binary>>},
+                    {<<"message">>,<<Message/binary>>}],
     SortedExtractedAndDecoded = lists:sort(ExtractedAndDecoded),
     SortedExpectedList = lists:sort(ExpectedList),
     ?assertEqual(SortedExpectedList, SortedExtractedAndDecoded).
@@ -136,12 +115,7 @@ simple_message(Config) ->
     %% we expect one notification message
     do_simple_message(Config, <<"Hi, Simple!">>),
     %% fail if we didn't receive http notification
-    Body = receive
-               {got_http_request, Bin} -> Bin
-           after 2000 ->
-            error(missing_request)
-           end,
-
+    Body = get_http_request(),
     {_, _} = binary:match(Body, <<"alice">>),
     {_, _} = binary:match(Body, <<"Simple">>).
 
@@ -151,33 +125,35 @@ simple_message_no_listener(Config) ->
 simple_message_failing_listener(Config) ->
     do_simple_message(Config, <<"Hi, Failing!">>).
 
-do_simple_message(Config, Msg) ->
-    BobJid = escalus_users:get_jid(Config, bob),
-
+do_simple_message(Config0, Msg) ->
+    Config = escalus_fresh:create_users(Config0, [{alice, 1}, {bob, 1}]),
     %% Alice sends a message to Bob, who is offline
-    escalus:story(Config, [{alice, 1}],
-        fun(Alice) -> escalus:send(Alice, escalus_stanza:chat_to(BobJid, Msg)) end),
-
+    {ok, Alice} = escalus_client:start(Config, alice, <<"res1">>),
+    escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
+    BobJid = escalus_users:get_jid(Config, bob),
+    Stanza = escalus_stanza:chat_to(BobJid, Msg),
+    escalus:send(Alice, Stanza),
+    escalus_client:stop(Config, Alice),
     %% Bob logs in
-    Bob = login_send_presence(Config, bob),
-
+    {ok, Bob} = escalus_client:start(Config, bob, <<"res1">>),
+    escalus:send(Bob, escalus_stanza:presence(<<"available">>)),
     %% He receives his initial presence and the message
     Stanzas = escalus:wait_for_stanzas(Bob, 2),
-%%  ct:pal("Stanzas:~p", [Stanzas]),
     escalus_new_assert:mix_match([is_presence, is_chat(Msg)], Stanzas),
     escalus_client:stop(Config, Bob).
-
-
-%%%===================================================================
-%%% Custom predicates
-%%%===================================================================
-
-is_chat(Content) ->
-    fun(Stanza) -> escalus_pred:is_chat_message(Content, Stanza) end.
 
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
+
+get_http_request() ->
+    Key = got_http_request,
+    mongoose_helper:wait_until(
+      fun() -> 1 =:= length(ets:lookup(?ETS_TABLE, Key)) end,
+      true, #{name => missing_request}),
+    [Bins] = lists:map(fun({_, El}) -> El end, ets:lookup(?ETS_TABLE, Key)),
+    ets:delete(?ETS_TABLE, Key),
+    Bins.
 
 login_send_presence(Config, User) ->
     Spec = escalus_users:get_userspec(Config, User),
@@ -185,10 +161,58 @@ login_send_presence(Config, User) ->
     escalus:send(Client, escalus_stanza:presence(<<"available">>)),
     Client.
 
-get_prefix(mod_http_notification_tests) ->
+is_chat(Content) ->
+    fun(Stanza) -> escalus_pred:is_chat_message(Content, Stanza) end.
+
+get_prefix(no_prefix) ->
     "/";
-get_prefix(mod_http_notification_tests_with_prefix) ->
+get_prefix(with_prefix) ->
     "/prefix";
 get_prefix(Config) ->
     GroupName = proplists:get_value(name, proplists:get_value(tc_group_properties, Config)),
     get_prefix(GroupName).
+
+start_pool() ->
+    HTTPOpts = [{server, http_notifications_host()}],
+    PoolOpts = [{strategy, available_worker}, {workers, 5}],
+    ejabberd_node_utils:call_fun(mongoose_wpool, start_configured_pools,
+                                 [[{http, global, http_pool, PoolOpts, HTTPOpts}]]).
+
+stop_pool() ->
+    ejabberd_node_utils:call_fun(mongoose_wpool, stop, [http, global, http_pool]).
+
+set_modules(Config0, Opts) ->
+    Config = dynamic_modules:save_modules(host(), Config0),
+    ModOpts = [{worker_timeout, 500}, {host, http_notifications_host()}] ++ Opts,
+    dynamic_modules:ensure_modules(host(), [{mod_http_notification, ModOpts}]),
+    Config.
+
+start_http_listener(simple_message, Prefix) ->
+    http_helper:start(http_notifications_port(), Prefix, fun process_notification/1);
+start_http_listener(simple_message_no_listener, _) ->
+    ok;
+start_http_listener(simple_message_failing_listener, Prefix) ->
+    http_helper:start(http_notifications_port(), Prefix, fun(Req) -> Req end);
+start_http_listener(proper_http_message_encode_decode, Prefix) ->
+    http_helper:start(http_notifications_port(), Prefix, fun process_notification/1).
+
+stop_http_listener(simple_message_no_listener) ->
+    ok;
+stop_http_listener(_) ->
+    http_helper:stop().
+
+process_notification(Req) ->
+    {ok, Body, Req1} = cowboy_req:read_body(Req),
+    Req2 = cowboy_req:reply(200, #{<<"content-type">> => <<"text/plain">>}, <<"OK">>, Req1),
+    Event = {got_http_request, Body},
+    ets:insert(?ETS_TABLE, Event),
+    Req2.
+
+create_events_collection() ->
+    ets:new(?ETS_TABLE, [duplicate_bag, named_table, public]).
+
+clear_events_collection() ->
+    ets:delete_all_objects(?ETS_TABLE).
+
+host() ->
+    ct:get_config({hosts, mim, domain}).

--- a/test/http_helper.erl
+++ b/test/http_helper.erl
@@ -20,7 +20,7 @@
 
 start(Port, Path, HandleFun) ->
     application:ensure_all_started(cowboy),
-    Dispatch = cowboy_router:compile([{'_', [{Path, http_helper, [HandleFun]}]}]),
+    Dispatch = cowboy_router:compile([{'_', [{Path, http_helper, HandleFun}]}]),
     {ok, _} = cowboy:start_clear(http_helper_listener,
                                  [{port, Port}, {num_acceptors, 200}],
                                 #{env => #{dispatch => Dispatch}}).
@@ -30,7 +30,7 @@ stop() ->
 
 %% Cowboy handler callbacks
 
-init(Req, [HandleFun]) ->
+init(Req, HandleFun) ->
     Req2 = HandleFun(Req),
     {ok, Req2, no_state}.
 


### PR DESCRIPTION
Except for the place where the http pool passes a map instead of a list, this is the state of the big_tests that #2716 should be able to pass. Once this is merged to master, the http2 PR should rebase onto it and pass these tests successfully.

Note that the problem for gun was about pools being initialised before there was an available listener: in the modified test suites, the pools where being initialised earlier in the `init_per_x` hierarchy, hence gun's connection wasn't available.

Note that there's one important test, that in my fork of http2 with these tests gun is not passing, and that is the `mod_http_listener` `simple_message_no_listener` test, where there's precisely no listener. This is failing because the request timeout is of 5 seconds, so the client's process is blocked for 5 long seconds, while escalus is waiting for a stream_end stanza with also a timeout of 5 seconds, but which started way earlier than the pool's timeout.

PS: notice also that these tests are waaay faster than the originals 😄 