### PR TITLE
Config format equivalence tests for all presets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 	-rm -rf _build
 	-rm rel/configure.vars.config
 	-rm rel/vars.config
-	-rm rel/var-toml.config
+	-rm rel/vars-toml.config
 
 # REBAR_CT_EXTRA_ARGS comes from a test runner
 ct:

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -80,6 +80,7 @@
 {suites, "tests", mongoose_elasticsearch_SUITE}.
 {suites, "tests", sasl_external_SUITE}.
 {suites, "tests", persistent_cluster_id_SUITE}.
+{suites, "tests", config_format_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -17,7 +17,7 @@
 %%       so that we rein the "bag of things" approach
 {hosts, [{mim,  [{node, mongooseim@localhost},
                  {domain, <<"localhost">>},
-                 {vars, "mim1.vars-toml.config"},
+                 {vars, "mim1"},
                  {cluster, mim},
                  {secondary_domain, <<"localhost.bis">>},
                  {reloaded_domain, <<"sogndal">>},
@@ -36,7 +36,7 @@
                  {http_notifications_port, 8000}]},
          {mim2, [{node, ejabberd2@localhost},
                  {domain, <<"localhost">>},
-                 {vars, "mim2.vars-toml.config"},
+                 {vars, "mim2"},
                  {cluster, mim},
                  {c2s_tls_port, 5233},
                  {metrics_rest_port, 5289},
@@ -44,20 +44,20 @@
                  {service_port, 8899}]},
          {mim3, [{node, mongooseim3@localhost},
                  {domain, <<"localhost">>},
-                 {vars, "mim3.vars-toml.config"},
+                 {vars, "mim3"},
                  {c2s_tls_port, 5263},
                  {cluster, mim}]},
          %% used to test s2s features
          {fed,  [{node, fed1@localhost},
                  {domain, <<"fed1">>},
-                 {vars, "fed1.vars-toml.config"},
+                 {vars, "fed1"},
                  {incoming_s2s_port, 5299},
                  {c2s_port, 5242},
                  {cluster, fed}]},
          %% used to test global distribution features
          {reg,  [{node, reg1@localhost},
                  {domain, <<"reg1">>},
-                 {vars, "reg1.vars-toml.config"},
+                 {vars, "reg1"},
                  {service_port, 9990},
                  {c2s_port, 5252},
                  {gd_endpoint_port, 7777},
@@ -201,7 +201,9 @@
         {auth_method, <<"SASL-ANON">>}]}
                      ]}.
 
-{ejabberd_presets, [
+{presets,
+ [{toml,
+   [
     {internal_mnesia,
      %% dbs variable is used by ./tools/test_runner/presets_to_dbs.sh script
      [{dbs, [redis, minio]},
@@ -385,7 +387,142 @@
 [outgoing_pools.elastic.default]
   scope = \"global\""}
      ]}
-]}.
+   ]},
+  {cfg, % preset vars for the 'cfg' format - used only by the config equivalence tests
+   [
+    {internal_mnesia,
+     %% dbs variable is used by ./tools/test_runner/presets_to_dbs.sh script
+     [{dbs, [redis, minio]},
+      {sm_backend, "{mnesia, []}"},
+      {auth_method, "internal"},
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []}
+       ]}."},
+      {mod_offline, "{mod_offline, []},"}]},
+    {pgsql_mnesia,
+     [{dbs, [redis, pgsql]},
+      {sm_backend, "{mnesia, []}"},
+      {auth_method, "rdbms"},
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []},
+       {rdbms, global, default, [{workers, 5}],
+        [{server, {pgsql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
+                   [{ssl, required}, {ssl_opts, [{verify, verify_peer},
+                    {cacertfile, \"priv/ssl/cacert.pem\"}, {server_name_indication, disable}]}]}}]}
+       ]}."},
+      {mod_last, "{mod_last, [{backend, rdbms}]},"},
+      {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},
+      {mod_private, "{mod_private, [{backend, rdbms}]},"},
+      {mod_offline, "{mod_offline, [{backend, rdbms}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, rdbms}, {host, \"vjud.@HOST@\"}]},"},
+      {mod_roster, "{mod_roster, [{backend, rdbms}]},"}]},
+    {odbc_mssql_mnesia,
+     [{dbs, [redis, mssql]},
+      {sm_backend, "{mnesia, []}"},
+      {auth_method, "rdbms"},
+      {rdbms_server_type, "{rdbms_server_type, mssql}."},
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []},
+       {rdbms, global, default, [{workers, 5}],
+        [{server, \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\"}]}
+       ]}."},
+      {mod_last, "{mod_last, [{backend, rdbms}]},"},
+      {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},
+      {mod_private, "{mod_private, [{backend, rdbms}]},"},
+      {mod_offline, "{mod_offline, [{backend, rdbms}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, rdbms}, {host, \"vjud.@HOST@\"}]},"},
+      {mod_roster, "{mod_roster, [{backend, rdbms}]},"}]},
+    {mysql_redis,
+     [{dbs, [redis, mysql]},
+      {sm_backend, "{redis, []}"},
+      {auth_method, "rdbms"},
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []},
+       {redis, global, default, [{workers, 10}, {strategy, random_worker}], []},
+       {rdbms, global, default, [{workers, 5}],
+        [{server, {mysql, \"localhost\", \"ejabberd\", \"ejabberd\", \"mongooseim_secret\",
+                   [{versions, ['tlsv1.2']}, {verify, verify_peer}, {cacertfile, \"priv/ssl/cacert.pem\"}]}}]}
+       ]}."},
+      {mod_last, "{mod_last, [{backend, rdbms}]},"},
+      {mod_privacy, "{mod_privacy, [{backend, rdbms}]},"},
+      {mod_private, "{mod_private, [{backend, mysql}]},"},
+      {mod_offline, "{mod_offline, [{backend, rdbms}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, rdbms}, {host, \"vjud.@HOST@\"}]},"},
+      {mod_roster, "{mod_roster, [{backend, rdbms}]},"}]},
+    {ldap_mnesia,
+     [{dbs, [redis, ldap]},
+      {sm_backend, "{mnesia, []}"},
+      {auth_method, "ldap"},
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []},
+       {ldap, global, default, [{workers, 5}], [{port, 3636},
+                                                {rootdn, \"cn=admin,dc=esl,dc=com\"},
+                                                {password, \"mongooseim_secret\"},
+                                                {encrypt, tls},
+                                                {tls_options, [{versions, ['tlsv1.2']},
+                                                               {verify, verify_peer},
+                                                               {cacertfile, \"priv/ssl/cacert.pem\"},
+                                                               {certfile, \"priv/ssl/fake_cert.pem\"},
+                                                               {keyfile, \"priv/ssl/fake_key.pem\"}]}]},
+       {ldap, global, bind, [{workers, 5}], [{port, 3636},
+                                             {encrypt, tls},
+                                             {tls_options, [{versions, ['tlsv1.2']},
+                                                            {verify, verify_peer},
+                                                            {cacertfile, \"priv/ssl/cacert.pem\"},
+                                                            {certfile, \"priv/ssl/fake_cert.pem\"},
+                                                            {keyfile, \"priv/ssl/fake_key.pem\"}]}]}
+       ]}."},
+      {mod_offline, "{mod_offline, []},"},
+      {password_format, "{password_format, scram}"},
+      {auth_ldap, ", {ldap_base, \"ou=Users,dc=esl,dc=com\"},
+                     {ldap_filter, \"(objectClass=inetOrgPerson)\"}"
+      },
+      {mod_vcard,"{mod_vcard, [{backend, ldap}, {host, \"vjud.@HOST@\"},\n"
+                               "{ldap_base, \"ou=Users,dc=esl,dc=com\"},\n"
+                               "{ldap_filter,\"(objectClass=inetOrgPerson)\"}\n"
+                               "]},"}
+     ]},
+    {riak_mnesia,
+     [{dbs, [redis, riak]},
+      {sm_backend, "{mnesia, []}"},
+      {auth_method, "riak"},
+      %% Specify a list of ciphers to avoid
+      %% "no function clause matching tls_v1:enum_to_oid(28)" error
+      %% on Riak's side running with Erlang R16.
+      %% https://github.com/basho/riak-erlang-client/issues/232#issuecomment-178612129
+      %% We also set ciphers in tools/setup_riak on the server side.
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []},
+       {riak, global, default, [{workers, 5},
+                                {strategy, next_worker}],
+                               [{address, \"127.0.0.1\"},{port, 8087},
+                                {ssl_opts, [{ciphers, [\"AES256-SHA\", \"DHE-RSA-AES128-SHA256\"]},
+                                            {server_name_indication, disable}]},
+                                {credentials, \"ejabberd\", \"mongooseim_secret\"},
+                                {cacertfile, \"priv/ssl/cacert.pem\"}]}
+       ]}."},
+      {mod_roster, "{mod_roster, [{backend, riak}]},"},
+      {mod_private, "{mod_private, [{backend, riak}]},"},
+      {mod_vcard, "{mod_vcard, [{backend, riak}, {host, \"vjud.@HOST@\"}]},"},
+      {mod_offline, "{mod_offline, [{backend, riak}]},"},
+      {mod_last, "{mod_last, [{backend, riak}]},"},
+      {mod_privacy, "{mod_privacy, [{backend, riak}]},"}
+     ]},
+    {elasticsearch_and_cassandra_mnesia,
+     [{dbs, [redis, elasticsearch, cassandra]},
+      {sm_backend, "{mnesia, []}"},
+      {outgoing_pools, "{outgoing_pools, [
+       {redis, global, global_distrib, [{workers, 10}], []},
+       {cassandra, global, default, [{workers, 20}],
+                               [{ssl,[{cacertfile, \"priv/ssl/cacert.pem\"},
+                                      {verify, verify_peer}] }]},
+       {elastic, global, default, [], []}
+       ]}."},
+      {auth_method, "internal"},
+      {mod_offline, "{mod_offline, []},"}
+     ]}
+   ]}
+ ]}.
 
 {timetrap,{seconds,30}}.
 {sensible_maximum_repeats, 100}.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -294,7 +294,7 @@
       {mod_privacy, "[modules.mod_privacy]
   backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
-  backend = \"rdbms\""},
+  backend = \"mysql\""},
       {mod_offline, "[modules.mod_offline]
   backend = \"rdbms\""},
       {mod_vcard, "[modules.mod_vcard]
@@ -330,6 +330,7 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.certfile = \"priv/ssl/fake_cert.pem\"
   connection.tls.keyfile = \"priv/ssl/fake_key.pem\""},
+      {mod_offline, "[modules.mod_offline]"},
       {password_format, "password.format = \"scram\""},
       {auth_ldap, "ldap_base = \"ou=Users,dc=esl,dc=com\"
   ldap_filter = \"(objectClass=inetOrgPerson)\""},
@@ -385,7 +386,8 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.verify_peer = true
 [outgoing_pools.elastic.default]
-  scope = \"global\""}
+  scope = \"global\""},
+      {mod_offline, "[modules.mod_offline]"}
      ]}
    ]},
   {cfg, % preset vars for the 'cfg' format - used only by the config equivalence tests

--- a/big_tests/tests/config_format_SUITE.erl
+++ b/big_tests/tests/config_format_SUITE.erl
@@ -1,0 +1,155 @@
+-module(config_format_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
+-define(eq(Expected, Actual),
+        ?assertEqual(Expected, Actual)).
+
+all() ->
+    [equivalence].
+
+suite() ->
+    distributed_helper:require_rpc_nodes([mim]) ++ escalus:suite().
+
+init_per_suite(Config0) ->
+    Config1 = escalus:init_per_suite(Config0),
+    ejabberd_node_utils:init(Config1).
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+init_per_testcase(CaseName, Config0) ->
+    Config1 = escalus:init_per_testcase(CaseName, Config0),
+    ejabberd_node_utils:backup_config_file(Config1),
+    Config1.
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config),
+    ejabberd_node_utils:restore_config_file(Config),
+    ejabberd_node_utils:restart_application(mongooseim).
+
+%% Test cases
+
+equivalence(Config) ->
+    TOMLOpts = get_config_tables(),
+    ejabberd_node_utils:modify_config_file(mim, [], Config, cfg),
+    ejabberd_node_utils:restart_application(mongooseim),
+    CfgOpts = get_config_tables(),
+    compare_unordered_lists(CfgOpts, TOMLOpts, fun handle_config_option/2).
+
+%% Test case helpers
+
+get_config_tables() ->
+    Tables = [config, local_config, acl],
+    Opts = lists:flatmap(fun(Tab) -> rpc(mim(), ets, tab2list, [Tab]) end, Tables),
+    lists:filter(fun filter_config/1, Opts).
+
+filter_config({config, required_files, _}) -> false; % not supported in TOML
+filter_config({local_config, node_start, _}) -> false;
+filter_config(_) -> true.
+
+handle_config_option({Config, K1, V1}, {Config, K2, V2}) when Config =:= config;
+                                                              Config =:= local_config ->
+    ?eq(K1, K2),
+    compare_values(K1, V1, V2);
+handle_config_option(Opt1, Opt2) ->
+    ?eq(Opt1, Opt2).
+
+compare_values(listen, V1, V2) ->
+    compare_unordered_lists(V1, V2, fun handle_listener/2);
+compare_values({auth_opts, _}, V1, V2) ->
+    compare_unordered_lists(V1, V2, fun handle_auth_opt/2);
+compare_values(outgoing_pools, V1, V2) ->
+    compare_unordered_lists(V1, V2, fun handle_conn_pool/2);
+compare_values({modules, _}, V1, V2) ->
+    compare_unordered_lists(V1, V2, fun handle_item_with_opts/2);
+compare_values({services, _}, V1, V2) ->
+    compare_unordered_lists(V1, V2, fun handle_item_with_opts/2);
+compare_values({auth_method, _}, V1, V2) when is_atom(V1) ->
+    ?eq([V1], V2);
+compare_values({s2s_addr, _}, {_, _, _, _} = IP1, IP2) ->
+    ?eq(inet:ntoa(IP1), IP2);
+compare_values(K, V1, V2) ->
+    ?eq({K, V1}, {K, V2}).
+
+handle_listener({P1, M1, O1}, {P2, M2, O2}) ->
+    ?eq(P1, P2),
+    ?eq(M1, M2),
+    compare_unordered_lists(O1, O2, fun handle_listener_option/2).
+
+handle_listener_option({modules, M1}, {modules, M2}) ->
+    compare_unordered_lists(M1, M2, fun handle_listener_module/2);
+handle_listener_option({transport_options, O1}, {transport_options, O2}) ->
+    compare_unordered_lists(O1, O2);
+handle_listener_option(V1, V2) -> ?eq(V1, V2).
+
+handle_listener_module({H1, P1, M1}, M2) ->
+    handle_listener_module({H1, P1, M1, []}, M2);
+handle_listener_module({H1, P1, M1, O1}, {H2, P2, M2, O2}) ->
+    ?eq(H1, H2),
+    ?eq(P1, P2),
+    ?eq(M1, M2),
+    compare_listener_module_options(M1, O1, O2).
+
+compare_listener_module_options(mod_websockets,
+                                [{ejabberd_service, S1}], [{ejabberd_service, S2}]) ->
+    compare_unordered_lists(S1, S2);
+compare_listener_module_options(_, O1, O2) ->
+    ?eq(O1, O2).
+
+handle_auth_opt({cyrsasl_external, M}, {cyrsasl_external, [M]}) -> ok;
+handle_auth_opt(V1, V2) -> ?eq(V1, V2).
+
+handle_item_with_opts({M1, O1}, {M2, O2}) ->
+    ?eq(M1, M2),
+    compare_unordered_lists(O1, O2).
+
+handle_conn_pool({Type1, Scope1, Tag1, POpts1, COpts1},
+                 {Type2, Scope2, Tag2, POpts2, COpts2}) ->
+    ?eq(Type1, Type2),
+    ?eq(Scope1, Scope2),
+    ?eq(Tag1, Tag2),
+    compare_unordered_lists(POpts1, POpts2),
+    compare_unordered_lists(COpts1, COpts2, fun handle_conn_opt/2).
+
+handle_conn_opt({server, {D1, H1, DB1, U1, P1, O1}},
+                {server, {D2, H2, DB2, U2, P2, O2}}) ->
+    ?eq(D1, D2),
+    ?eq(H1, H2),
+    ?eq(DB1, DB2),
+    ?eq(U1, U2),
+    ?eq(P1, P2),
+    compare_unordered_lists(O1, O2, fun handle_db_server_opt/2);
+handle_conn_opt({tls_options, Opts1}, {tls_options, Opts2}) ->
+    compare_unordered_lists(Opts1, Opts2);
+handle_conn_opt(V1, V2) -> ?eq(V1, V2).
+
+handle_db_server_opt({ssl_opts, O1}, {ssl_opts, O2}) ->
+    compare_unordered_lists(O1, O2);
+handle_db_server_opt(V1, V2) -> ?eq(V1, V2).
+
+compare_unordered_lists(L1, L2) ->
+    compare_unordered_lists(L1, L2, fun(V1, V2) -> ?eq(V1, V2) end).
+
+compare_unordered_lists(L1, L2, F) ->
+    SL1 = lists:sort(L1),
+    SL2 = lists:sort(L2),
+    compare_ordered_lists(SL1, SL2, F).
+
+compare_ordered_lists([H1|T1], [H1|T2], F) ->
+    compare_ordered_lists(T1, T2, F);
+compare_ordered_lists([H1|T1], [H2|T2], F) ->
+    try F(H1, H2)
+    catch C:R:S ->
+            ct:fail({C, R, S})
+    end,
+    compare_ordered_lists(T1, T2, F);
+compare_ordered_lists([], [], _) ->
+    ok.

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -114,15 +114,13 @@
  [
   %% BOSH and WS endpoints over HTTP
   { {{{cowboy_port}}}, ejabberd_cowboy, [
-      {num_acceptors, 10},
-      {transport_options, [{max_connections, 1024}]},
+      {transport_options, [{max_connections, 1024}, {num_acceptors, 10}]},
       {modules, [
 
           {"_", "/http-bind", mod_bosh},
           {"_", "/ws-xmpp", mod_websockets, [{ejabberd_service, [
                                         {access, all},
                                         {shaper_rule, fast},
-                                        {ip, {127, 0, 0, 1}},
                                         {password, "secret"}]}
           %% Uncomment to enable connection dropping or/and server-side pings
           %{timeout, 600000}, {ping_rate, 2000}
@@ -159,8 +157,7 @@
 
   %% BOSH and WS endpoints over HTTPS
   { {{{cowboy_secure_port}}}, ejabberd_cowboy, [
-        {num_acceptors, 10},
-        {transport_options, [{max_connections, 1024}]},
+        {transport_options, [{max_connections, 1024}, {num_acceptors, 10}]},
         {{{https_config}}}
         {modules, [
             {"_", "/http-bind", mod_bosh},
@@ -180,16 +177,14 @@
   %% At least start it on different port which will be hidden behind firewall
 
   { {{{http_api_endpoint}}} , ejabberd_cowboy, [
-      {num_acceptors, 10},
-      {transport_options, [{max_connections, 1024}]},
+      {transport_options, [{max_connections, 1024}, {num_acceptors, 10}]},
       {modules, [
           {"localhost", "/api", mongoose_api_admin, []}
       ]}
   ]},
 
   { {{{http_api_client_endpoint}}} , ejabberd_cowboy, [
-      {num_acceptors, 10},
-      {transport_options, [{max_connections, 1024}]},
+      {transport_options, [{max_connections, 1024}, {num_acceptors, 10}]},
       {protocol_options, [{compress, true}]},
       {{{https_config}}}
       {modules, [
@@ -201,7 +196,7 @@
           {"_", "/api/rooms/:id/users/[:user]",    mongoose_client_api_rooms_users, []},
           {"_", "/api/rooms/[:id]/messages",    mongoose_client_api_rooms_messages, []},
           %% Swagger
-          {"_", "/api-docs", cowboy_swagger_redirect_handler, {priv_file, cowboy_swagger, "swagger/index.html"}},
+          {"_", "/api-docs", cowboy_swagger_redirect_handler, #{}},
           {"_", "/api-docs/swagger.json", cowboy_swagger_json_handler, #{}},
           {"_", "/api-docs/[...]", cowboy_static, {priv_dir, cowboy_swagger, "swagger", [{mimetypes, cow_mimetypes, all}]}}
       ]}
@@ -210,8 +205,7 @@
   %% Following HTTP API is deprected, the new one abouve should be used instead
 
   { {{{http_api_old_endpoint}}} , ejabberd_cowboy, [
-      {num_acceptors, 10},
-      {transport_options, [{max_connections, 1024}]},
+      {transport_options, [{max_connections, 1024}, {num_acceptors, 10}]},
       {modules, [
           {"localhost", "/api", mongoose_api, [{handlers, [mongoose_api_metrics,
                                                            mongoose_api_users]}]}

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -23,7 +23,8 @@
 {host_config,
 "{host_config, \"anonymous.localhost\", [{auth_method, anonymous},
                                         {allow_multiple_connections, true},
-                                        {anonymous_protocol, both}]}." }.
+                                        {anonymous_protocol, both},
+                                        {auth_opts, []}]}." }.
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
 {password_format, "{password_format, {scram, [sha256]}}"}.

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -350,8 +350,9 @@ connection_options(ldap, Options) ->
     [ldap_option(K, V) || {K, V} <- maps:to_list(Options)];
 connection_options(riak, Options = #{<<"username">> := UserName,
                                      <<"password">> := Password}) ->
+    M = maps:without([<<"username">>, <<"password">>], Options),
     [{credentials, b2l(UserName), b2l(Password)} |
-     [riak_option(K, V) || {K, V} <- maps:to_list(Options)]];
+     [riak_option(K, V) || {K, V} <- maps:to_list(M)]];
 connection_options(cassandra, Options) ->
     [cassandra_option(K, V) || {K, V} <- maps:to_list(Options)];
 connection_options(elastic, Options) ->
@@ -392,8 +393,6 @@ ldap_option(<<"tls">>, Options) -> {tls_options, client_tls_options(Options)}.
 
 riak_option(<<"address">>, Addr) -> {address, b2l(Addr)};
 riak_option(<<"port">>, Port) -> {port, Port};
-riak_option(<<"username">>, UserName) -> {username, b2l(UserName)};
-riak_option(<<"password">>, Password) -> {password, b2l(Password)};
 riak_option(<<"cacertfile">>, Path) -> {cacertfile, b2l(Path)};
 riak_option(<<"tls">>, Options) -> {ssl_opts, client_tls_options(Options)}.
 


### PR DESCRIPTION
Test that equivalent `toml` and `cfg` config files result in the same contents in the `config`, `local_config` and `acl` ETS tables in MongooseIM.

- Template both config files in big tests.
- Add the test case.
- Fix any inconsistencies discovered by the tests.

See commit messages for more details.

