### PR TITLE
Structured logging

### DIFF
--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -530,6 +530,7 @@ handler_init(Req0) ->
     lists:map(
         fun(StrEvent) ->
             Event = str_to_event(StrEvent),
+            %% TODO there is a race condition when table is not available
             ets:insert(?ETS_TABLE, Event)
         end, StrEvents),
     Req1 = cowboy_req:reply(200, #{}, <<"">>, Req),

--- a/doc/developers-guide/Basic-iq-handler.md
+++ b/doc/developers-guide/Basic-iq-handler.md
@@ -57,8 +57,7 @@ stop(Host) ->
 
 process_iq(_From, _To, Acc, IQ) ->
     IQRes = IQ#iq{type = result},
-    ?INFO_MSG("event=example_handler request=~w response=~w", 
-                [IQ, IQRes]),
+    ?LOG_INFO(#{what => example_handler, acc => Acc, iq_result => IQRes}),
     {Acc, IQRes}.
 ```
 

--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -305,40 +305,33 @@ run_custom_hook(Host) ->
     Acc1 = mongoose_acc:set(example, value, 5, Acc),
     ResultAcc = ejabberd_hooks:run_fold(custom_new_hook, Host, Acc1, [2]),
     ResultValue = mongoose_acc:get(example, value, ResultAcc),
-    ?INFO_MSG("Final hook result: ~p", [ResultValue]),
-    ?INFO_MSG("Returned accumulator: ~p", [ResultAcc]).
+    ?LOG_INFO(#{what => hook_finished, result => ResultValue, result_acc => ResultAcc}).
 
 first_handler(Acc, Number) ->
     V0 = mongoose_acc:get(example, value, Acc),
     Result = V0 + Number,
-    ?INFO_MSG("First handler~n"
-    "  value: ~p~n"
-    "  argument: ~p~n"
-    "  will return: ~p",
-        [V0, Number, Result]),
+    ?LOG_INFO(#{what => first_handler, value => V0, argument => Number, result => Result}),
     mongoose_acc:set(example, value, Result, Acc).
 
 stopping_handler(Acc, Number) ->
     V0 = mongoose_acc:get(example, value, Acc),
     Result = V0 + Number,
-    ?INFO_MSG("Stopping handler~n"
-    "  value: ~p~n"
-    "  argument: ~p~n"
-    "  will return: ~p",
-        [V0, Number, Result]),
+    ?LOG_INFO(#{what => stopping_handler, value => V0, argument => Number, result => Result}),
     {stop, mongoose_acc:set(example, value, Result, Acc)}.
 
 never_run_handler(Acc, Number) ->
-    ?INFO_MSG("This hook won't run as it's registered with a priority bigger "
-    "than that of stopping_handler/2 is. "
-    "It doesn't matter what it returns. "
-    "This text should never get printed.", []),
+    ?LOG_INFO(#{what => never_run_handler,
+                text => <<"This hook won't run as it's registered with a priority bigger "
+                          "than that of stopping_handler/2 is. "
+                          "This text should never get printed.">>}),
     Acc * Number.
 ```
 
 The module is intended to be used from the shell for educational purposes:
 
 ```erlang
+TODO Update this once new log formatters are available
+
 (mongooseim@localhost)1> gen_mod:is_loaded(<<"localhost">>, mod_hook_example).
 false
 (mongooseim@localhost)2> gen_mod:start_module(<<"localhost">>, mod_hook_example, [no_opts]).

--- a/doc/developers-guide/logging.md
+++ b/doc/developers-guide/logging.md
@@ -46,9 +46,10 @@ Levels `warning` and `error` are the most commonly used for production systems.
 
 # Logging format
 
-We use structured logging described in [Ferd's post](https://ferd.ca/erlang-otp-21-s-new-logger.html).
+We use structured logging as inspired by [Ferd's post](https://ferd.ca/erlang-otp-21-s-new-logger.html).
 
-We use a modified [logfmt](https://brandur.org/logfmt) format as one of logger formatters.
+We use a modified [logfmt](https://brandur.org/logfmt) format as one of
+the possible default logger formatters.
 
 This format is [Splunk](https://www.splunk.com/en_us/solutions/solution-areas/log-management.html)
 and [ELK](https://www.elastic.co/elk-stack) friendly.

--- a/doc/developers-guide/logging.md
+++ b/doc/developers-guide/logging.md
@@ -15,11 +15,12 @@ or
 There are several macros for the most common logging levels:
 
 ```erlang
-DEBUG("event=debug_event info=~1000p", [Arg]),
-INFO_MSG("event=info_event info=~1000p", [Arg]),
-WARNING_MSG("event=warning_event reason=~1000p", [Arg]),
-ERROR_MSG("event=error_event reason=~1000p", [Arg]),
-CRITICAL_MSG("event=critical_event reason=~1000p", [Arg]),
+?LOG_DEBUG(#{what => debug_event, info => Arg}),
+?LOG_INFO(#{what => info_event, info => Arg}),
+?LOG_NOTICE(#{what => notice_event, info => Arg}),
+?LOG_WARNING(#{what => warning_event, info => Arg}),
+?LOG_ERROR(#{what => error_event, info => Arg}),
+?LOG_CRITICAL(#{what => critical_event, info => Arg}),
 ```
 
 Use them in correspondence with the appropriate log level.
@@ -45,54 +46,44 @@ Levels `warning` and `error` are the most commonly used for production systems.
 
 # Logging format
 
-We use a modified [logfmt](https://brandur.org/logfmt) format.
+We use structured logging described in [Ferd's post](https://ferd.ca/erlang-otp-21-s-new-logger.html).
+
+We use a modified [logfmt](https://brandur.org/logfmt) format as one of logger formatters.
 
 This format is [Splunk](https://www.splunk.com/en_us/solutions/solution-areas/log-management.html)
 and [ELK](https://www.elastic.co/elk-stack) friendly.
 
-`event=something_interesting` field is required.
+Check [the list of fields](../operation-and-maintenance/Logging-fields.md) for fields documentation.
 
-`reason=~1000p` field is commonly used.
+
+`what => something_interesting` field is required.
+
 
 ```erlang
-    ?ERROR_MSG("event=check_password_failed "
-               "reason=~p user=~ts", [Error, LUser]),
+    ?LOG_ERROR(#{event => check_password_failed,
+                 reason => Error, user => LUser})
 
     try ...
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=check_password_failed "
-                       "reason=~p:~p user=~ts stacktrace=~1000p",
-                       [Class, Reason, LUser, StackTrace]),
+            ?LOG_ERROR(#{event => check_password_failed,
+                         class => Class, reason => Reason, stacktrace => StackTrace}),
             erlang:raise(Class, Reason, StackTrace)
     end
 ```
 
-`user=~ts` is often used too.
+Field `user => <<"alice">>` is often used too.
 
-A common way to name an error event is `event=function_name_failed`.
-For example, `event=remove_user_failed`. Use the advice critically, it would
+A common way to name an error event is `what => function_name_failed`.
+For example, `what => remove_user_failed`. Use the advice critically, it would
 not work well for any function. Counter example:
 
 ```erlang
 handle_info(Info, State) ->
-    ?ERROR_MSG("issue=unexpected_info_received info=~1000p", [Info]),
+    ?LOG_WARNING(#{what => unexpected_message, msg => Info}),
     {noreply, State}.
 ```
 
-Log messages should not contain new lines.
-
-We usually use `~1000p` to log long data structures.
-
-Use whitespace as a field separator:
-
-```erlang
-%% Use
-?ERROR_MSG("event=check_password_failed reason=~p", [Reason])
-
-%% Don't use
-?ERROR_MSG("event=check_password_failed, reason=~p", [Reason])
-```
 
 # Filtering logs by module
 

--- a/doc/developers-guide/logging.md
+++ b/doc/developers-guide/logging.md
@@ -60,13 +60,13 @@ Check [the list of fields](../operation-and-maintenance/Logging-fields.md) for f
 
 
 ```erlang
-    ?LOG_ERROR(#{event => check_password_failed,
+    ?LOG_ERROR(#{what => check_password_failed,
                  reason => Error, user => LUser})
 
     try ...
     catch
         Class:Reason:StackTrace ->
-            ?LOG_ERROR(#{event => check_password_failed,
+            ?LOG_ERROR(#{what => check_password_failed,
                          class => Class, reason => Reason, stacktrace => StackTrace}),
             erlang:raise(Class, Reason, StackTrace)
     end

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -33,4 +33,6 @@ If `iq` is not available, `sub_el` could be logged as last option.
 | state_name    | atom    |             | State name in `gen_fsm`                             | `wait_for_stream`                   |                                    |
 | state         | term    |             | `gen_server` state                                  | `#state{}`                          | Consider adding a formatter        |
 | call_from     | tuple   |             | From argument in gen_server's handle_call           | `{Pid, Tag}`                        |                                    |
-
+| ip            | tuple   |             | IP address                                          | inet:ip_address()                   |                                    |
+| port          | integer |             | TCP/UDP port number                                 | 5222                                |                                    |
+| peer          | tuple   |             | `peer() :: {inet:ip_address(), inet:port_number()}` | `{{127,0,0,1},5222}`                |                                    |

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -1,11 +1,14 @@
 # Fields
 
-- reason, class, stacktrace - standard error catching fields
+- reason, class, stacktrace - standard error catching fields.
+- module, function, line, timestamp, node, when, pid - reserved fields (could be used by logger itself).
 
+When logging IQs, adding `acc` field should be enough. If `acc` not available, `iq` can be used.
+If `iq` is not available, `sub_el` could be logged as last option.
 
 | Name          | Type    | Usage       | Description                                         | Examples                            | Notes                              |
 |---------------|---------|-------------|-----------------------------------------------------|-------------------------------------|------------------------------------|
-| what          | atom    | required    | Event (or issue) name                               | remove_user_failed                  |                                    |
+| what          | atom    | required    | Event (or issue) name                               | remove_user_failed                  | Prefer `_failed` suffix            |
 | text          | binary  | recommened  | Human readable description                          | `<<"MAM failed to contact MySQL">>` |                                    |
 | path          | binary  |             | HTTP path                                           | `<<"/api/add_user">>`               |                                    |
 | code          | integer |             | HTTP code                                           | 200                                 |                                    |
@@ -15,6 +18,9 @@
 | remote_user   | binary  |             | Remote Username (usually who makes IQ requests)     | `<<"alice">>`                       | Use `#jid.luser` when available    |
 | remote_server | binary  |             | Remote Server (usually who makes IQ requests)       | `<<"otherhost">>`                   | Use `#jid.lserver` when available  |
 | acc           | map     |             | Accumulator, that would be used by formatter        | `#{...}`                            |                                    |
+| req           | map     |             | Cowboy request                                      |                                     | Provide when available             |
+| iq            | record  |             | MongooseIM IQ record                                | `#iq{}`                             | Provide when available (but it could be acc instead) |
+| sub_el        | record  |             | IQ sub element                                      | `#xmlel{}`                          | Provide ONLY if `iq` not available |
 | c2s_state     | record  |             | C2S process state, that would be used by formatter  | `#state{}`                          |                                    |
 | from_jid      | binary  | auto        | Accumulator's from_jid                              | `<<"alice@localhost">>`             |                                    |
 | to_jid        | binary  | auto        | Accumulator's to_jid                                | `<<"to@localhost">>`                |                                    |
@@ -24,4 +30,6 @@
 | class         | enum    |             | `catch Class:Reason:Stacktrace`                     | `error`                             |                                    |
 | stacktrace    | term    |             | `catch Class:Reason:Stacktrace`                     | `[...]`                             | Formatted by formatter             |
 | duration      | integer |             | Duration of some operation in milliseconds          | 5000                                | Don't use it for microseconds      |
+| state_name    | atom    |             | State name in `gen_fsm`                             | `wait_for_stream`                   |                                    |
+| state         | term    |             | `gen_server` state                                  | `#state{}`                          | Consider adding a formatter        |
 

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -9,7 +9,7 @@
 | text          | binary  | recommened  | Human readable description                          | `<<"MAM failed to contact MySQL">>` |                                    |
 | path          | binary  |             | HTTP path                                           | `<<"/api/add_user">>`               |                                    |
 | code          | integer |             | HTTP code                                           | 200                                 |                                    |
-| user          | binary  |             | Local Username                                      | `<<"alice">>`                       | Use `#jid.luser` when available    |
+| user          | binary  | recommened  | Local Username                                      | `<<"alice">>`                       | Use `#jid.luser` when available    |
 | server        | binary  |             | Local Server (host) name                            | `<<"localhost">>`                   | Use `#jid.lserver` when available  |
 | sub_host      | binary  |             | Subhost when MUC or pubsub are used                 | `<<"muc.localhost">>`               | It's not the same as `server`      |
 | remote_user   | binary  |             | Remote Username (usually who makes IQ requests)     | `<<"alice">>`                       | Use `#jid.luser` when available    |

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -85,7 +85,7 @@ Timestamp should be ordered first when possible, so that sorting is automatic.
 ## Macros for logging unexpected requests
 
 `gen_server` processes sometimes receive messages they couldn't process.
-We use macroses to log such events (just because you would need them in each
+We use macros to log such events (just because you would need them in each
 `gen_server` module).
 
 We don't need to log state or state names for such events.
@@ -109,7 +109,7 @@ handle_info(Msg, State) ->
 
 ```
 
-These macros translate into the maps with loglevel `warning`:
+These macros translate into warning logs with the following keys, respectively:
 
 ```erlang
 #{what => unexpected_cast, msg => Msg}.

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -32,4 +32,5 @@ If `iq` is not available, `sub_el` could be logged as last option.
 | duration      | integer |             | Duration of some operation in milliseconds          | 5000                                | Don't use it for microseconds      |
 | state_name    | atom    |             | State name in `gen_fsm`                             | `wait_for_stream`                   |                                    |
 | state         | term    |             | `gen_server` state                                  | `#state{}`                          | Consider adding a formatter        |
+| call_from     | tuple   |             | From argument in gen_server's handle_call           | `{Pid, Tag}`                        |                                    |
 

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -2,37 +2,81 @@
 
 - reason, class, stacktrace - standard error catching fields.
 - module, function, line, timestamp, node, when, pid - reserved fields (could be used by logger itself).
-
 When logging IQs, adding `acc` field should be enough. If `acc` not available, `iq` can be used.
 If `iq` is not available, `sub_el` could be logged as last option.
+- what - why we are logging. If something goes wrong, use `_failed` suffix (instead of `unable_to` and `_error`).
+  The common suffixes are `_starting`, `_started`, `_stopping`, `_stopped`, `_result`.
+  We often use function name as `what` field.
+  We sometimes adding prefixes to `what` to signal where we are logging from.
+  Such prefixes should be short. Please, don't prefix with the complete module name.
+  Examples for prefixes: `mam_`, `sm_`, `muc_`, `auth_`, `s2s_`, `pool_`.
+  When checking the final event name, remove duplicates from it.
+  Good event names: `s2s_dns_lookup_failed`
+  Bad event names: `s2s_dns_error`, 
 
-| Name          | Type    | Usage       | Description                                         | Examples                            | Notes                              |
-|---------------|---------|-------------|-----------------------------------------------------|-------------------------------------|------------------------------------|
-| what          | atom    | required    | Event (or issue) name                               | remove_user_failed                  | Prefer `_failed` suffix            |
-| text          | binary  | recommened  | Human readable description                          | `<<"MAM failed to contact MySQL">>` |                                    |
-| path          | binary  |             | HTTP path                                           | `<<"/api/add_user">>`               |                                    |
-| code          | integer |             | HTTP code                                           | 200                                 |                                    |
-| user          | binary  | recommened  | Local Username                                      | `<<"alice">>`                       | Use `#jid.luser` when available    |
-| server        | binary  |             | Local Server (host) name                            | `<<"localhost">>`                   | Use `#jid.lserver` when available  |
-| sub_host      | binary  |             | Subhost when MUC or pubsub are used                 | `<<"muc.localhost">>`               | It's not the same as `server`      |
-| remote_user   | binary  |             | Remote Username (usually who makes IQ requests)     | `<<"alice">>`                       | Use `#jid.luser` when available    |
-| remote_server | binary  |             | Remote Server (usually who makes IQ requests)       | `<<"otherhost">>`                   | Use `#jid.lserver` when available  |
-| acc           | map     |             | Accumulator, that would be used by formatter        | `#{...}`                            |                                    |
-| req           | map     |             | Cowboy request                                      |                                     | Provide when available             |
-| iq            | record  |             | MongooseIM IQ record                                | `#iq{}`                             | Provide when available (but it could be acc instead) |
-| sub_el        | record  |             | IQ sub element                                      | `#xmlel{}`                          | Provide ONLY if `iq` not available |
-| c2s_state     | record  |             | C2S process state, that would be used by formatter  | `#state{}`                          |                                    |
-| from_jid      | binary  | auto        | Accumulator's from_jid                              | `<<"alice@localhost">>`             |                                    |
-| to_jid        | binary  | auto        | Accumulator's to_jid                                | `<<"to@localhost">>`                |                                    |
-| packet        | binary  | auto        | Accumulator's element                               | `<<"<message>...">>`                | Encoded as XML, not erlang records |
-| exml_packet   | record  |             | Same as packet, but in `#xmlel{}` format            | `#xmlel{}`                          | Record, formatted in formatter     |
-| reason        | term    |             | `catch Class:Reason:Stacktrace`                     | `http_timeout`                      |                                    |
-| class         | enum    |             | `catch Class:Reason:Stacktrace`                     | `error`                             |                                    |
-| stacktrace    | term    |             | `catch Class:Reason:Stacktrace`                     | `[...]`                             | Formatted by formatter             |
-| duration      | integer |             | Duration of some operation in milliseconds          | 5000                                | Don't use it for microseconds      |
-| state_name    | atom    |             | State name in `gen_fsm`                             | `wait_for_stream`                   |                                    |
-| state         | term    |             | `gen_server` state                                  | `#state{}`                          | Consider adding a formatter        |
-| call_from     | tuple   |             | From argument in gen_server's handle_call           | `{Pid, Tag}`                        |                                    |
-| ip            | tuple   |             | IP address                                          | inet:ip_address()                   |                                    |
-| port          | integer |             | TCP/UDP port number                                 | 5222                                |                                    |
-| peer          | tuple   |             | `peer() :: {inet:ip_address(), inet:port_number()}` | `{{127,0,0,1},5222}`                |                                    |
+| Bad event names                    | Good event names         | Why                               |
+|------------------------------------|--------------------------|-----------------------------------|
+| `s2s_dns_error`                    | `s2s_dns_lookup_failed`  | Not `_failed` prefix              |
+| `s2s_dns_error`                    | `s2s_dns_lookup_timeout` | More specific failure reason      |
+| `mod_mam_starting`                 | `mam_starting`           | Use `mam_` prefix for MAM modules |
+| `mongoose_wpool_mgr_pool_starting` | `pool_starting`          | Too long and repetitive           |
+
+
+## Logger defaults
+Timestamp should be ordered first when possible, so that sorting is automatic.
+| Name          | Type    | Description                                         | Examples                  |
+|---------------|---------|-----------------------------------------------------|---------------------------|
+| timestamp     | atom    | The timestamp (with timezone information)           | 2018-07-11T13:41:10+00:00 |
+| at            | string  | Where in code the call or log line was emitted      | module:function:line      |
+| level         | enum    | log level according to RFC 5424                     | warning                   |
+
+## Generally required
+| Name          | Type    | Description                                         | Examples                            | Notes                              |
+|---------------|---------|-----------------------------------------------------|-------------------------------------|------------------------------------|
+| what          | atom    | Event (or issue) name                               | remove_user_failed                  |                                    |
+| text          | binary  | Human readable description                          | `<<"MAM failed to contact MySQL">>` |                                    |
+| result        | binary  | Explanation of the `what` key                       | `failed`                            | Optional                           |
+| tags          | [atom]  | The subcomponent taking action and logging data.    | [c2s, presence], [mam, rdbms]       | This category should be chosen based on filtering needs, and may represent the domain of concern for some operations |
+
+## HTTP requests
+| Name          | Type    | Description                                         | Examples                            | Notes                              |
+|---------------|---------|-----------------------------------------------------|-------------------------------------|------------------------------------|
+| path          | binary  | HTTP path                                           | `<<"/api/add_user">>`               |                                    |
+| code          | integer | HTTP code                                           | 200                                 |                                    |
+| ip            | tuple   | IP address                                          | inet:ip_address()                   |                                    |
+| port          | integer | TCP/UDP port number                                 | 5222                                |                                    |
+| peer          | tuple   | `peer() :: {inet:ip_address(), inet:port_number()}` | `{{127,0,0,1},5222}`                |                                    |
+| req           | map     | Cowboy request                                      |                                     | Provide when available             |
+
+## XMPP
+| Name          | Type    | Description                                         | Examples                            | Notes                              |
+|---------------|---------|-----------------------------------------------------|-------------------------------------|------------------------------------|
+| acc           | map     | Accumulator, that would be used by formatter        | `#{...}`                            |                                    |
+| user          | binary  | Local Username                                      | `<<"alice">>`                       | Use `#jid.luser` when available    |
+| server        | binary  | Local Server (host) name                            | `<<"localhost">>`                   | Use `#jid.lserver` when available  |
+| sub_host      | binary  | Subhost when MUC or pubsub are used                 | `<<"muc.localhost">>`               | It's not the same as `server`      |
+| remote_user   | binary  | Remote Username (usually who makes IQ requests)     | `<<"alice">>`                       | Use `#jid.luser` when available    |
+| remote_server | binary  | Remote Server (usually who makes IQ requests)       | `<<"otherhost">>`                   | Use `#jid.lserver` when available  |
+| iq            | record  | MongooseIM IQ record                                | `#iq{}`                             | Provide when available (but it could be acc instead) |
+| sub_el        | record  | IQ sub element                                      | `#xmlel{}`                          | Provide ONLY if `iq` not available |
+| c2s_state     | record  | C2S process state, that would be used by formatter  | `#state{}`                          |                                    |
+| from_jid      | binary  | Accumulator's from_jid                              | `<<"alice@localhost">>`             |                                    |
+| to_jid        | binary  | Accumulator's to_jid                                | `<<"to@localhost">>`                |                                    |
+| packet        | binary  | Accumulator's element                               | `<<"<message>...">>`                | Encoded as XML, not erlang records |
+| exml_packet   | record  | Same as packet, but in `#xmlel{}` format            | `#xmlel{}`                          | Record, formatted in formatter     |
+
+## Other requests
+| Name          | Type    | Description                                         | Examples                            | Notes                              |
+|---------------|---------|-----------------------------------------------------|-------------------------------------|------------------------------------|
+| duration      | integer | Duration of some operation in milliseconds          | 5000                                | Don't use it for microseconds      |
+| state_name    | atom    | State name in `gen_fsm`                             | `wait_for_stream`                   |                                    |
+| state         | term    | `gen_server` state                                  | `#state{}`                          | Consider adding a formatter        |
+| call_from     | tuple   | From argument in gen_server's handle_call           | `{Pid, Tag}`                        |                                    |
+
+## When logging exceptions
+`what` key should contain en `_exception` suffix. Following keys should be present:
+| Name          | Type    | Description                                         | Examples                            | Notes                              |
+|---------------|---------|-----------------------------------------------------|-------------------------------------|------------------------------------|
+| class         | enum    | `catch Class:Reason:Stacktrace`                     | `error`                             |                                    |
+| reason        | term    | `catch Class:Reason:Stacktrace`                     | `http_timeout`                      |                                    |
+| stacktrace    | term    | `catch Class:Reason:Stacktrace`                     | `[...]`                             | Formatted by formatter             |

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -23,3 +23,5 @@
 | reason        | term    |             | `catch Class:Reason:Stacktrace`                     | `http_timeout`                      |                                    |
 | class         | enum    |             | `catch Class:Reason:Stacktrace`                     | `error`                             |                                    |
 | stacktrace    | term    |             | `catch Class:Reason:Stacktrace`                     | `[...]`                             | Formatted by formatter             |
+| duration      | integer |             | Duration of some operation in milliseconds          | 5000                                | Don't use it for microseconds      |
+

--- a/include/mongoose_logger.hrl
+++ b/include/mongoose_logger.hrl
@@ -3,6 +3,9 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-define(LOG_IF(Level, Condition, Msg),
+    (Condition) == true andalso ?LOG(Level, Msg)).
+
 -define(LOG_IF(Level, Condition, Format, Args),
     (Condition) == true andalso ?LOG(Level, Format, Args)).
 

--- a/include/mongoose_logger.hrl
+++ b/include/mongoose_logger.hrl
@@ -39,4 +39,11 @@
 -define(CRITICAL_MSG_IF(Condition, Format, Args),
     ?LOG_IF(critical, Condition, Format, Args)).
 
+-define(UNEXPECTED_INFO(Msg),
+        ?LOG_WARNING(#{what => unexpected_info, msg => Msg})).
+-define(UNEXPECTED_CAST(Msg),
+        ?LOG_WARNING(#{what => unexpected_cast, msg => Msg})).
+-define(UNEXPECTED_CALL(Msg, From),
+        ?LOG_WARNING(#{what => unexpected_call, msg => Msg, call_from => From})).
+
 -endif.

--- a/include/mongoose_logger.hrl
+++ b/include/mongoose_logger.hrl
@@ -9,35 +9,41 @@
 -define(LOG_IF(Level, Condition, Format, Args),
     (Condition) == true andalso ?LOG(Level, Format, Args)).
 
+-define(DEPRECATE(Block),
+        begin
+        mongoose_lib:deprecated_logging(?LOCATION),
+        Block
+        end).
+
 -define(DEBUG(Format, Args),
-    ?LOG_DEBUG(Format, Args)).
+    ?DEPRECATE(?LOG_DEBUG(Format, Args))).
 
 -define(DEBUG_IF(Condition, Format, Args),
-    ?LOG_IF(debug, Condition, Format, Args)).
+    ?DEPRECATE(?LOG_IF(debug, Condition, Format, Args))).
 
 -define(INFO_MSG(Format, Args),
-    ?LOG_INFO(Format, Args)).
+    ?DEPRECATE(?LOG_INFO(Format, Args))).
 
 -define(INFO_MSG_IF(Condition, Format, Args),
-    ?LOG_IF(info, Condition, Format, Args)).
+    ?DEPRECATE(?LOG_IF(info, Condition, Format, Args))).
 
 -define(WARNING_MSG(Format, Args),
-    ?LOG_WARNING(Format, Args)).
+    ?DEPRECATE(?LOG_WARNING(Format, Args))).
 
 -define(WARNING_MSG_IF(Condition, Format, Args),
-    ?LOG_IF(warning, Condition, Format, Args)).
+    ?DEPRECATE(?LOG_IF(warning, Condition, Format, Args))).
 
 -define(ERROR_MSG(Format, Args),
-    ?LOG_ERROR(Format, Args)).
+    ?DEPRECATE(?LOG_ERROR(Format, Args))).
 
 -define(ERROR_MSG_IF(Condition, Format, Args),
-    ?LOG_IF(error, Condition, Format, Args)).
+    ?DEPRECATE(?LOG_IF(error, Condition, Format, Args))).
 
 -define(CRITICAL_MSG(Format, Args),
-    ?LOG_CRITICAL(Format, Args)).
+    ?DEPRECATE(?LOG_CRITICAL(Format, Args))).
 
 -define(CRITICAL_MSG_IF(Condition, Format, Args),
-    ?LOG_IF(critical, Condition, Format, Args)).
+    ?DEPRECATE(?LOG_IF(critical, Condition, Format, Args))).
 
 -define(UNEXPECTED_INFO(Msg),
         ?LOG_WARNING(#{what => unexpected_info, msg => Msg})).

--- a/include/mongoose_logger.hrl
+++ b/include/mongoose_logger.hrl
@@ -39,17 +39,4 @@
 -define(CRITICAL_MSG_IF(Condition, Format, Args),
     ?LOG_IF(critical, Condition, Format, Args)).
 
-
--define(LOG_DEBUG_IF(Condition, Map),
-        ((Condition) == true andalso ?LOG_DEBUG(Map))).
-
--define(LOG_WARNING_IF(Condition, Map),
-        ((Condition) == true andalso ?LOG_WARNING(Map))).
-
--define(LOG_ERROR_IF(Condition, Map),
-        ((Condition) == true andalso ?LOG_ERROR(Map))).
-
--define(LOG_INFO_IF(Condition, Map),
-        ((Condition) == true andalso ?LOG_INFO(Map))).
-
 -endif.

--- a/src/acl.erl
+++ b/src/acl.erl
@@ -225,10 +225,9 @@ match({resource_glob, ResourceGlob}, {_User, _Server, Resource}, _Host) ->
 match({node_glob, UserGlob, ServerGlob}, {User, Server, _Resource}, _Host) ->
     is_glob_match(Server, ServerGlob) andalso is_glob_match(User, UserGlob);
 match(WrongSpec, _LJID, _Host) ->
-    ?ERROR_MSG(
-       "Wrong ACL expression: ~p~n"
-       "Check your config file and reload it with the override_acls option enabled",
-       [WrongSpec]),
+    ?LOG_ERROR(#{what => wrong_acl_expression,
+                 text => <<"Wrong ACL expression. Check your config file and reload it with the override_acls option enabled">>,
+                 wrong_spec => WrongSpec}),
     false.
 
 -spec is_regexp_match(binary(), Regex :: regexp()) -> boolean().
@@ -239,7 +238,8 @@ is_regexp_match(String, RegExp) ->
         match ->
             true
     catch _:ErrDesc ->
-            ?ERROR_MSG("Wrong regexp ~p in ACL: ~p", [RegExp, ErrDesc]),
+              ?LOG_ERROR(#{what => acl_regexp_match_failed,
+                           string => String, regex => RegExp, reason => ErrDesc}),
             false
     end.
 

--- a/src/adhoc.erl
+++ b/src/adhoc.erl
@@ -44,7 +44,9 @@
 %% an {error, ErrorType} tuple.
 -spec parse_request(jlib:iq()) -> request() | {error, exml:element()}.
 parse_request(#iq{type = set, lang = Lang, sub_el = SubEl, xmlns = ?NS_COMMANDS}) ->
-    ?DEBUG("entering parse_request...", []),
+    ?LOG_DEBUG(#{what => adhoc_parse_request,
+                 text => <<"entering parse_request...">>,
+                 sub_el => SubEl}),
     Node = xml:get_tag_attr_s(<<"node">>, SubEl),
     SessionID = xml:get_tag_attr_s(<<"sessionid">>, SubEl),
     Action = xml:get_tag_attr_s(<<"action">>, SubEl),

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -539,7 +539,8 @@ is_regexp_match(String, RegExp) ->
                     false
             end;
         Error ->
-            ?ERROR_MSG("Wrong regexp ~p: ~p", [RegExp, Error]),
+            ?LOG_ERROR(#{what => regexp_match_failed,
+                         regex => RegExp, string => String, reason => Error}),
             false
     end.
 

--- a/src/amp.erl
+++ b/src/amp.erl
@@ -83,8 +83,11 @@ make_error_response([E|_] = Errors, [_|_] = Rules, User, Packet) ->
                     {<<"type">>, <<"error">>}],
            children = [Error, Amp]};
 make_error_response(Errors, Rules, User, Packet) ->
-    ?ERROR_MSG("amp:make_error_response/4 got invalid data: ~p",
-               [Errors, Rules, User, Packet]),
+    ?LOG_ERROR(#{what => make_error_response_failed,
+                 text => <<"amp:make_error_response/4 got invalid data">>,
+                 reason => invalid_data, errors => Errors, rules => Rules,
+                 user => User#jid.luser, server => User#jid.lserver,
+                 exml_packet => Packet}),
     error(invalid_data).
 
 error_amp_attrs('undefined-condition', User, Packet) ->

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -485,10 +485,10 @@ does_user_exist_timed(LUser, LServer) ->
         fun(M) ->
             case M:does_user_exist(LUser, LServer) of
                 {error, Error} ->
-                    ?ERROR_MSG("The authentication module ~p returned an "
-                    "error~nwhen checking user ~p in server ~p~n"
-                    "Error message: ~p",
-                        [M, LUser, LServer, Error]),
+                    ?LOG_ERROR(#{what => does_user_exist_failed,
+                                 text => <<"The authentication module returned an error">>,
+                                 auth_module => M, reason => Error,
+                                 user => LUser, server => LServer}),
                     false;
                 Else ->
                     Else
@@ -524,9 +524,10 @@ does_user_exist_in_other_modules_loop([AuthModule|AuthModules], User, Server) ->
         false ->
             does_user_exist_in_other_modules_loop(AuthModules, User, Server);
         {error, Error} ->
-            ?DEBUG("The authentication module ~p returned an error~nwhen "
-                   "checking user ~p in server ~p~nError message: ~p",
-                   [AuthModule, User, Server, Error]),
+            ?LOG_DEBUG(#{what => does_user_exist_failed,
+                         text => <<"The authentication module returned an error">>,
+                         auth_module => AuthModule, reason => Error,
+                         user => User, server => Server}),
             maybe
     end.
 
@@ -553,8 +554,9 @@ do_remove_user(LUser, LServer) ->
             mongoose_hooks:remove_user(LServer, Acc, LUser),
             ok;
         false ->
-            ?ERROR_MSG("event=backends_disallow_user_removal,user=~s,server=~s,backends=~p",
-                       [LUser, LServer, AuthModules]),
+            ?LOG_ERROR(#{what => backends_disallow_user_removal,
+                         user => LUser, server => LServer,
+                         auth_modules => AuthModules}),
             {error, not_allowed}
     end.
 

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -48,8 +48,10 @@ plain_password_required() ->
 check_password(_User, _Server, _Password) ->
     true.
 
-check_password(_User, _Server, _Password, _Digest, _DigestGen) ->
-    ?DEBUG("no support for digest authentication", []),
+check_password(User, Server, _Password, _Digest, _DigestGen) ->
+    ?LOG_DEBUG(#{what => digest_auth_unsupported,
+                 text => <<"no support for digest authentication">>,
+                 user => User, server => Server}),
     false.
 
 %% @spec (User::string(), Server::string(), Password::string()) ->

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -79,8 +79,10 @@ check_cache_last_options(Server) ->
         {true, _CacheTime} ->
             case get_mod_last_configured(Server) of
                 no_mod_last ->
-                    ?ERROR_MSG("In host ~p extauth is used, extauth_cache is enabled but "
-                               "mod_last is not enabled.", [Server]),
+                    ?LOG_ERROR(#{what => mod_last_required_by_extauth,
+                                 text => <<"extauth configured with extauth_cache,"
+                                          " but mod_last is not enabled">>,
+                                 server => Server}),
                     no_cache;
                 _ -> cache
             end
@@ -251,8 +253,10 @@ check_password_cache(LUser, LServer, Password, CacheTime) ->
         never ->
             check_password_external_cache(LUser, LServer, Password);
         mod_last_required ->
-            ?ERROR_MSG("extauth is used, extauth_cache is enabled but mod_last"
-                       " is not enabled in that host", []),
+            ?LOG_ERROR(#{what => mod_last_required_by_extauth,
+                         text => <<"extauth configured with extauth_cache but "
+                                  "mod_last is not enabled">>,
+                         user => LUser, server => LServer}),
             check_password_external_cache(LUser, LServer, Password);
         TimeStamp ->
             %% If last access exists, compare last access with cache refresh time
@@ -286,8 +290,10 @@ get_password_cache(LUser, LServer, CacheTime) ->
         never ->
             false;
         mod_last_required ->
-            ?ERROR_MSG("extauth is used, extauth_cache is enabled but mod_last"
-                       " is not enabled in that host", []),
+            ?LOG_ERROR(#{what => mod_last_required_by_extauth,
+                         text => <<"extauth configured with extauth_cache but "
+                                  "mod_last is not enabled">>,
+                         user => LUser, server => LServer}),
             false;
         TimeStamp ->
             case is_fresh_enough(TimeStamp, CacheTime) of

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -241,7 +241,9 @@ verify_scram_password(LUser, LServer, Password) ->
             case mongoose_scram:deserialize(RawPassword) of
                 {ok, DeserializedScramMap} ->
                     {ok, mongoose_scram:check_password(Password, DeserializedScramMap)};
-                _ ->
+                {error, Reason} ->
+                    ?LOG_WARNING(#{what => scram_serialisation_incorrect, reason => Reason,
+                                   user => LUser, server => LServer}),
                     {error, bad_request}
             end;
         _ ->

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -203,13 +203,18 @@ make_req(Method, Path, LUser, LServer, Password) ->
                       [{<<"Authorization">>, <<"Basic ", BasicAuth64/binary>>}]
               end,
 
-    ?DEBUG("Making request '~s' for user ~s@~s...", [Path, LUser, LServer]),
+    ?LOG_DEBUG(#{what => http_auth_request, text => <<"Making HTTP request">>,
+                 path => Path, user => LUser, server => LServer}),
+
     {ok, {Code, RespBody}} = case Method of
         get -> mongoose_http_client:get(LServer, auth, <<Path/binary, "?", Query/binary>>, Header);
         post -> mongoose_http_client:post(LServer, auth, Path, Header, Query)
     end,
 
-    ?DEBUG("Request result: ~s: ~p", [Code, RespBody]),
+    ?LOG_DEBUG(#{what => http_auth_result, text => <<"Received HTTP request result">>,
+                 path => Path, user => LUser, server => LServer,
+                 code => Code, result => RespBody}),
+
     case Code of
         <<"409">> -> {error, conflict};
         <<"404">> -> {error, not_found};

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -182,7 +182,8 @@ try_register(LUser, LServer, Password) ->
         {atomic, exists} ->
             {error, exists};
         Result ->
-            ?ERROR_MSG("transaction_result=~p", [Result]),
+            ?LOG_ERROR(#{what => registration_error,
+                         user => LUser, server => LServer, reason => Result}),
             {error, not_allowed}
     end.
 
@@ -318,7 +319,8 @@ remove_user(LUser, LServer) ->
 
 -spec scram_passwords() -> {atomic, ok}.
 scram_passwords() ->
-    ?INFO_MSG("Converting the stored passwords into SCRAM bits", []),
+    ?LOG_INFO(#{what => <<"scram_passwords">>,
+                text => <<"Converting the stored passwords into SCRAM bits">>}),
     Fields = record_info(fields, passwd),
     {atomic, ok} = mnesia:transform_table(passwd, fun scramming_function/1, Fields).
 

--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -94,17 +94,29 @@ check_password(LUser, LServer, Password) ->
             case maps:find(UserKey, TokenData) of
                 {ok, LUser} ->
                     %% Login username matches $token_user_key in TokenData
-                    ?INFO_MSG("Successfully authenticated with JWT.~nTokenData: ~p~n", [TokenData]),
+                    ?LOG_INFO(#{what => jwt_success_auth,
+                                text => <<"Successfully authenticated with JWT">>,
+                                user => LUser, server => LServer,
+                                token => TokenData}),
                     true;
                 {ok, ExpectedUser} ->
-                    ?WARNING_MSG("Wrong JWT for user ~p /= expected ~p~n", [LUser, ExpectedUser]),
+                    ?LOG_WARNING(#{what => wrong_jwt_user,
+                                   text => <<"JWT contains wrond user">>,
+                                   expected_user => ExpectedUser,
+                                   user => LUser, server => LServer}),
                     false;
                 error ->
-                    ?WARNING_MSG("Missing key ~p in JWT ~p~n", [UserKey, TokenData]),
+                    ?LOG_WARNING(#{what => missing_jwt_key,
+                                   text => <<"Missing key {user_key} in JWT data">>,
+                                   user_key => UserKey, token => TokenData,
+                                   user => LUser, server => LServer}),
                     false
             end;
         {error, Reason} ->
-            ?WARNING_MSG("Cannot verify JWT for user ~s: ~p~n", [LUser, Reason]),
+            ?LOG_WARNING(#{what => jwt_verification_failed,
+                           text => <<"Cannot verify JWT for user">>,
+                           reason => Reason,
+                           user => LUser, server => LServer}),
             false
     end.
 

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -115,7 +115,9 @@ check_password(LUser, LServer, Password, Digest, DigestGen) ->
             case mongoose_scram:deserialize(PassDetails) of
                 {ok, Scram} ->
                     mongoose_scram:check_digest(Scram, Digest, DigestGen, Password);
-                _ ->
+                {error, Reason} ->
+                    ?LOG_WARNING(#{what => scram_serialisation_incorrect, reason => Reason,
+                                   user => Username, server => LServer}),
                     false
             end;
         {selected, []} ->
@@ -147,7 +149,9 @@ check_password_wo_escape(LUser, Username, LServer, Password) ->
             case mongoose_scram:deserialize(PassDetails) of
                 {ok, Scram} ->
                     mongoose_scram:check_password(Password, Scram);
-                _ ->
+                {error, Reason} ->
+                    ?LOG_WARNING(#{what => scram_serialisation_incorrect, reason => Reason,
+                                   user => Username, server => LServer}),
                     false %% Password is not correct
             end;
         {selected, []} ->
@@ -286,7 +290,9 @@ get_password(LUser, LServer) ->
             case mongoose_scram:deserialize(PassDetails) of
                 {ok, Scram} ->
                     Scram;
-                _ ->
+                {error, Reason} ->
+                    ?LOG_WARNING(#{what => scram_serialisation_incorrect, reason => Reason,
+                                   user => Username, server => LServer}),
                     false
             end;
         {selected, []} ->

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -216,7 +216,12 @@ try_register_with_password(LUser, LServer, Password) ->
 do_get_password(LUser, LServer) ->
     case mongoose_riak:fetch_type(bucket_type(LServer), LUser) of
         {ok, Map} ->
-            extract_password(Map);
+            case extract_password(Map) of
+                false ->
+                    ?LOG_WARNING(#{what => scram_serialisation_incorrect,
+                                   user => LUser, server => LServer});
+                Pwd -> Pwd
+            end;
         _ ->
             false
     end.

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -178,7 +178,8 @@ remove_user(LUser, LServer) ->
     case mongoose_riak:delete(bucket_type(LServer), LUser) of
         ok -> ok;
         Error ->
-            ?WARNING_MSG("Failed Riak query: ~p", [Error]),
+            ?LOG_WARNING(#{what => remove_user_failed, reason => Error,
+                           user => LUser, server => LServer}),
             {error, not_allowed}
     end.
 

--- a/src/cassandra/mongoose_cassandra_worker.erl
+++ b/src/cassandra/mongoose_cassandra_worker.erl
@@ -224,8 +224,10 @@ handle_call({continue, Req}, From, State = #state{}) ->
     NewReq = Req#request{from = From},
     NewState = update_req(NewReq, State),
     {noreply, process_request(RequestId, NewState)};
-handle_call(Msg, _From, State) ->
-    ?WARNING_MSG("Unexpected call ~p", [Msg]),
+handle_call(Msg, From, State) ->
+    ?LOG_WARNING(#{what => cassandra_unexpected_call,
+                   pool => State#state.pool_name,
+                   call_from => From, msg => Msg, state => State}),
     {noreply, State}.
 
 
@@ -244,7 +246,7 @@ handle_cast({write, QueryStr, Rows, Opts}, #state{} = State) ->
     NewState = State#state{inflight = maps:put(RequestId, Request, State#state.inflight)},
     {noreply, process_request(RequestId, NewState)};
 handle_cast(Msg, State) ->
-    ?WARNING_MSG("Unexpected cast ~p", [Msg]),
+    ?LOG_WARNING(#{what => cassandra_unexpected_cast, msg => Msg, state => State}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -269,7 +271,9 @@ handle_info({'DOWN', _MRef,  _,  _,  _} = Down, #state{} = St) ->
 handle_info({retry, ReqId}, #state{} = St) ->
     case maps:get(ReqId, St#state.inflight, undefined) of
         undefined ->
-            ?WARNING_MSG("Unexpected retry request for ~p", [ReqId]),
+            ?LOG_WARNING(#{what => cassandra_unexpected_retry_request,
+                           pool => St#state.pool_name,
+                           state => St, request_id => ReqId}),
             {noreply, St};
         #request{retry_left = TryCount} = Req ->
             NextRequest = Req#request{retry_left = max(TryCount - 1, 0)},
@@ -278,7 +282,9 @@ handle_info({retry, ReqId}, #state{} = St) ->
     end;
 
 handle_info(Msg, State) ->
-    ?WARNING_MSG("Unexpected info ~p", [Msg]),
+    ?LOG_WARNING(#{what => cassandra_unexpected_message,
+                   pool => State#state.pool_name,
+                   msg => Msg, state => State}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -370,8 +376,10 @@ handle_cancel(ReqId, Reason, State) ->
         undefined ->
             State;
         #request{tag = Tag} = Req ->
-            ?WARNING_MSG("query_type=~s, tag=~p, ~s, action=aborting, abort_reason=~s",
-                         [query_type(Req), Tag, error_text(cancel, Reason, Req), Reason]),
+            ?LOG_WARNING(#{what => cassandra_abording_request,  reason => Reason,
+                           pool => State#state.pool_name,
+                           tag => Tag, error_text => error_text(cancel, Reason, Req),
+                           query_type => query_type(Req)}),
             cleanup_request(ReqId, State)
     end.
 
@@ -379,7 +387,9 @@ handle_cancel(ReqId, Reason, State) ->
 handle_result({result, Tag, Result} = R, #state{} = State) ->
     case maps:get(Tag, State#state.cql_tags, undefined) of
         undefined ->
-            ?WARNING_MSG("unexpected result ~p", [R]),
+            ?LOG_WARNING(#{what => cassandra_unexpected_result,
+                           pool => State#state.pool_name,
+                           result => R}),
             State;
         ReqId ->
             Req = #request{cql_mref = MRef} = maps:get(ReqId, State#state.inflight),
@@ -424,7 +434,9 @@ do_handle_result(Result, Req, State) ->
 handle_error({error, Tag, Reason} = Error, #state{} = State) ->
     case maps:get(Tag, State#state.cql_tags, undefined) of
         undefined ->
-            ?WARNING_MSG("unexpected error ~p", [Error]),
+            ?LOG_WARNING(#{what => cassandra_unexpected_error, error => Error,
+                           pool => State#state.pool_name,
+                           tag => Tag, reason => Reason}),
             State;
         ReqId ->
             Req = #request{cql_mref = MRef} = maps:get(ReqId, State#state.inflight),
@@ -449,14 +461,17 @@ do_handle_error(Type, Reason, Req, State) ->
 
     case retry_info(Type, Reason, Req, State) of
         {abort, AbortReason, NextState} ->
-            ?WARNING_MSG("query_type=~s, tag=~p, ~s, action=aborting, abort_reason=~s",
-                         [query_type(Req), Tag, error_text(Type, Reason, Req), AbortReason]),
+            ?LOG_WARNING(#{what => cassandra_abording_query, tag => Tag,
+                           pool => State#state.pool_name,
+                           query_type => query_type(Req), reason => AbortReason,
+                           error_text => error_text(Type, Reason, Req)}),
             maybe_reply(Req, {error, Reason}),
             cleanup_request(Req, NextState);
         {retry, WaitFor, NextState} ->
-            ?WARNING_MSG("query_type=~s, tag=~p, ~s, action=retrying, retry_left=~p "
-                         "request_opts=~p",
-                         [query_type(Req), Tag, error_text(Type, Reason, Req), RetryLeft, Opts]),
+            ?LOG_WARNING(#{what => cassandra_retrying_query, tag => Tag,
+                           pool => State#state.pool_name,
+                           query_type => query_type(Req), request_opts => Opts,
+                           error_text => error_text(Type, Reason, Req), retry_left => RetryLeft}),
             schedule_retry(ReqId, WaitFor, NextState)
     end.
 
@@ -564,6 +579,8 @@ get_client(PoolName) ->
 -spec get_client_loop(mongoose_cassandra:pool_name(), non_neg_integer()) ->
                              cqerl:client() | no_return().
 get_client_loop(PoolName, RetryNo) when RetryNo >= 500 ->
+    ?LOG_WARNING(#{what => cassandra_get_client_failed,
+                   pool => PoolName}),
     error(cannot_get_cqerl_client, [PoolName, RetryNo]);
 get_client_loop(PoolName, RetryNo) ->
     try cqerl:get_client(PoolName) of
@@ -573,10 +590,14 @@ get_client_loop(PoolName, RetryNo) ->
                 _ -> throw({dead, Pid})
             end
     catch
-        E:R -> ?INFO_MSG("error getting client: ~p retry: ~p", [{E, R}, RetryNo]),
-               Wait = rand:uniform(10),
-               timer:sleep(Wait),
-               get_client_loop(PoolName, RetryNo + 1)
+        Class:Reason:Stacktrace ->
+            ?LOG_INFO(#{what => cassandra_get_client_retry,
+                        class => Class, reason => Reason, stacktrace => Stacktrace,
+                        pool => PoolName, retry_number => RetryNo}),
+
+             Wait = rand:uniform(10),
+             timer:sleep(Wait),
+             get_client_loop(PoolName, RetryNo + 1)
     end.
 
 -spec schedule_retry(request_id(), non_neg_integer(), worker_state()) -> worker_state().

--- a/src/cassandra/mongoose_cassandra_worker.erl
+++ b/src/cassandra/mongoose_cassandra_worker.erl
@@ -372,7 +372,7 @@ handle_cancel(ReqId, Reason, State) ->
         undefined ->
             State;
         #request{tag = Tag} = Req ->
-            ?LOG_WARNING(#{what => cassandra_abording_request,  reason => Reason,
+            ?LOG_WARNING(#{what => cassandra_aborting_request,  reason => Reason,
                            pool => State#state.pool_name,
                            tag => Tag, error_text => error_text(cancel, Reason, Req),
                            query_type => query_type(Req)}),
@@ -457,7 +457,7 @@ do_handle_error(Type, Reason, Req, State) ->
 
     case retry_info(Type, Reason, Req, State) of
         {abort, AbortReason, NextState} ->
-            ?LOG_WARNING(#{what => cassandra_abording_query, tag => Tag,
+            ?LOG_WARNING(#{what => cassandra_aborting_query, tag => Tag,
                            pool => State#state.pool_name,
                            query_type => query_type(Req), reason => AbortReason,
                            error_text => error_text(Type, Reason, Req)}),

--- a/src/cassandra/mongoose_cassandra_worker.erl
+++ b/src/cassandra/mongoose_cassandra_worker.erl
@@ -225,9 +225,7 @@ handle_call({continue, Req}, From, State = #state{}) ->
     NewState = update_req(NewReq, State),
     {noreply, process_request(RequestId, NewState)};
 handle_call(Msg, From, State) ->
-    ?LOG_WARNING(#{what => cassandra_unexpected_call,
-                   pool => State#state.pool_name,
-                   call_from => From, msg => Msg, state => State}),
+    ?UNEXPECTED_CALL(Msg, From),
     {noreply, State}.
 
 
@@ -246,7 +244,7 @@ handle_cast({write, QueryStr, Rows, Opts}, #state{} = State) ->
     NewState = State#state{inflight = maps:put(RequestId, Request, State#state.inflight)},
     {noreply, process_request(RequestId, NewState)};
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => cassandra_unexpected_cast, msg => Msg, state => State}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -282,9 +280,7 @@ handle_info({retry, ReqId}, #state{} = St) ->
     end;
 
 handle_info(Msg, State) ->
-    ?LOG_WARNING(#{what => cassandra_unexpected_message,
-                   pool => State#state.pool_name,
-                   msg => Msg, state => State}),
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/config/mongoose_config_flat.erl
+++ b/src/config/mongoose_config_flat.erl
@@ -56,8 +56,7 @@ flatten_global_config_opts(LC) ->
                      ({acl, K, V}) ->
                           flatten_acl_config_opt(K, V);
                      (Other) ->
-                     ?ERROR_MSG("issue=strange_global_config value=~1000p",
-                                [Other]),
+                          ?LOG_ERROR(#{what => strange_global_config, value => Other}),
                      []
                   end, LC).
 
@@ -69,8 +68,7 @@ flatten_local_config_opts(LC) ->
                      ({acl, K, V}) ->
                           flatten_acl_config_opt(K, V);
                      (Other) ->
-                     ?ERROR_MSG("issue=strange_local_config value=~1000p",
-                                [Other]),
+                          ?LOG_ERROR(#{what => strange_local_config, value => Other}),
                      []
                   end, LC).
 
@@ -78,10 +76,9 @@ flatten_local_config_host_opts(LCH) ->
     lists:flatmap(fun(#local_config{key = {K, Host}, value = V}) ->
                           flatten_local_config_host_opt(K, Host, V);
                      (Host) when is_binary(Host) ->
-                     [{hostname, Host}];
+                          [{hostname, Host}];
                      (Other) ->
-                     ?ERROR_MSG("issue=strange_local_host_config value=~1000p",
-                                [Other]),
+                          ?LOG_ERROR(#{what => strange_local_host_config, value => Other}),
                      []
                   end, LCH).
 

--- a/src/config/mongoose_config_reload.erl
+++ b/src/config/mongoose_config_reload.erl
@@ -157,7 +157,7 @@ categorize_option({acl, _, _}, Acc) ->
     %% no need to do extra work here
     Acc;
 categorize_option(Opt, Acc) ->
-    ?ERROR_MSG("event=uncategorized_option option=~p", [Opt]),
+    ?LOG_ERROR(#{what => uncategorized_option, option => Opt}),
     Acc.
 
 as_global(El, {Config, Local, HostLocal}) -> {[El | Config], Local, HostLocal}.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -74,7 +74,7 @@ start(normal, _Args) ->
     ejabberd_listener:start_listeners(),
     ejabberd_admin:start(),
     update_status_file(started),
-    ?INFO_MSG("ejabberd ~s is started in the node ~p", [?MONGOOSE_VERSION, node()]),
+    ?LOG_NOTICE(#{what => mongooseim_node_started, version => ?MONGOOSE_VERSION, node => node()}),
     Sup;
 start(_, _) ->
     {error, badarg}.
@@ -96,7 +96,7 @@ prep_stop(State) ->
 
 %% All the processes were killed when this function is called
 stop(_State) ->
-    ?INFO_MSG("ejabberd ~s is stopped in the node ~p", [?MONGOOSE_VERSION, node()]),
+    ?LOG_NOTICE(#{what => mongooseim_node_stopped, version => ?MONGOOSE_VERSION, node => node()}),
     delete_pid_file(),
     update_status_file(stopped),
     %%ejabberd_debug:stop(),
@@ -207,7 +207,8 @@ write_pid_file(Pid, PidFilename) ->
             io:format(Fd, "~s~n", [Pid]),
             file:close(Fd);
         {error, Reason} ->
-            ?ERROR_MSG("Cannot write PID file ~s~nReason: ~p", [PidFilename, Reason]),
+            ?LOG_ERROR(#{what => cannot_write_to_pid_file,
+                         pid_file => PidFilename, reason => Reason}),
             throw({cannot_write_pid_file, PidFilename, Reason})
     end.
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -222,9 +222,8 @@ init([{SockMod, Socket}, Opts]) ->
     %% Check if IP is blacklisted:
     case is_ip_blacklisted(IP) of
         true ->
-            ?LOG_INFO(#{what => c2s_blacklisted_ip,
-                        text => <<"Connection attempt from blacklisted IP">>,
-                        ip => IP}),
+            ?LOG_INFO(#{what => c2s_blacklisted_ip, ip => IP,
+                        text => <<"Connection attempt from blacklisted IP">>}),
             {stop, normal};
         false ->
             Socket1 =
@@ -308,8 +307,7 @@ stream_start_error(Error, StateData) ->
       State :: state(),
       Result :: {stop, normal, state()}.
 c2s_stream_error(Error, StateData) ->
-    ?LOG_DEBUG(#{what => c2s_stream_error,
-                 xml_error => Error, c2s_state => StateData}),
+    ?LOG_DEBUG(#{what => c2s_stream_error, xml_error => Error, c2s_state => StateData}),
     send_element_from_server_jid(StateData, Error),
     send_trailer(StateData),
     {stop, normal, StateData}.
@@ -757,8 +755,7 @@ maybe_open_session(Acc, #state{jid = JID} = StateData) ->
 -spec do_open_session(mongoose_acc:t(), jid:jid(), state()) ->
     {stop | established, mongoose_acc:t(), state()}.
 do_open_session(Acc, JID, StateData) ->
-    ?LOG_INFO(#{what => c2s_opened_session,
-                text => <<"Opened session">>,
+    ?LOG_INFO(#{what => c2s_opened_session, text => <<"Opened session">>,
                 acc => Acc, c2s_state => StateData}),
     Resp = jlib:make_result_iq_reply(mongoose_acc:element(Acc)),
     Packet = {jid:to_bare(StateData#state.jid), StateData#state.jid, Resp},
@@ -877,9 +874,8 @@ session_established({xmlstreamerror, <<"child element too big">> = E}, StateData
 session_established({xmlstreamerror, _}, StateData) ->
     c2s_stream_error(mongoose_xmpp_errors:xml_not_well_formed(), StateData);
 session_established(closed, StateData) ->
-    ?LOG_DEBUG(#{what => c2s_closed,
-                 text => <<"Session established closed - trying to enter resume_session">>,
-                 c2s_state => StateData}),
+    ?LOG_DEBUG(#{what => c2s_closed, c2s_state => StateData,
+                 text => <<"Session established closed - trying to enter resume_session">>}),
     maybe_enter_resume_session(StateData#state.stream_mgmt_id, StateData).
 
 %% @doc Process packets sent by user (coming from user on c2s XMPP
@@ -1075,8 +1071,7 @@ handle_info({'DOWN', Monitor, _Type, Object, Info}, StateName,
         _ ->
             ?LOG_WARNING(#{what => unexpected_c2s_down_info,
                            text => <<"C2S process got DOWN message from unknown process">>,
-                           monitor => Monitor, monitored_pid => Object,
-                           down_info => Info,
+                           monitor_ref => Monitor, monitor_pid => Object, down_info => Info,
                            state_name => StateName, c2s_state => StateData}),
             fsm_next_state(StateName, StateData)
     end;
@@ -1087,8 +1082,7 @@ handle_info(replaced_wait_timeout, StateName, #state{ replaced_pids = ReplacedPi
       fun({Monitor, Pid}) ->
               ?LOG_WARNING(#{what => c2s_replaced_wait_timeout,
                              text => <<"Some processes are not responding when handling replace messages">>,
-                             monitor => Monitor,
-                             replaced_pid => Pid,
+                             monitor_ref => Monitor, replaced_pid => Pid,
                              state_name => StateName, c2s_state => StateData})
       end, ReplacedPids),
     fsm_next_state(StateName, StateData#state{ replaced_pids = [] });
@@ -1165,9 +1159,8 @@ handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, S
                                             Feature, To, Packet),
     case {Drop, StateData#state.jid} of
         {true, _} ->
-            ?LOG_DEBUG(#{what => c2s_dropped_packet,
-                         text => <<"c2s_filter_packet hook dropped a packet">>,
-                         acc => Acc}),
+            ?LOG_DEBUG(#{what => c2s_dropped_packet, acc => Acc,
+                         text => <<"c2s_filter_packet hook dropped a packet">>}),
             fsm_next_state(StateName, StateData);
         {_, To} ->
             FinalPacket = jlib:replace_from_to(From, To, Packet),
@@ -2893,9 +2886,8 @@ calc_to_drop(Handled, OldAcked) ->
 
 maybe_send_sm_ack(?NS_STREAM_MGNT_3, StreamMgmt, _NIncoming, NextState, StateData)
   when StreamMgmt =:= false; StreamMgmt =:= disabled ->
-    ?LOG_WARNING(#{what => unexpected_r,
-                   text => <<"received <r/> but stream management is off!">>,
-                   c2s_state => StateData}),
+    ?LOG_WARNING(#{what => unexpected_r, c2s_state => StateData,
+                   text => <<"received <r/> but stream management is off!">>}),
     fsm_next_state(NextState, StateData);
 maybe_send_sm_ack(?NS_STREAM_MGNT_3, true, NIncoming,
                   NextState, StateData) ->
@@ -3084,8 +3076,7 @@ maybe_resume_session(NextState, El, StateData) ->
         {InvalidNS, _} ->
             ?LOG_INFO(#{what => c2s_ignores_resume,
                         text => <<"ignoring <resume/> element with invalid namespace">>,
-                        invalid_ns => InvalidNS,
-                        c2s_state => StateData}),
+                        invalid_ns => InvalidNS, c2s_state => StateData}),
             fsm_next_state(NextState, StateData)
     end.
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -960,10 +960,7 @@ resume_session(closed, StateData) ->
 resume_session(timeout, StateData) ->
     {next_state, resume_session, StateData, hibernate()};
 resume_session(Msg, StateData) ->
-    ?LOG_WARNING(#{what => <<"unexpected_message">>,
-                   text => <<"Unexpected message in resume_session state">>,
-                   state_name => resume_session, c2s_state => StateData,
-                   unexpected_msg => Msg}),
+    ?UNEXPECTED_INFO(Msg),
     {next_state, resume_session, StateData, hibernate()}.
 
 
@@ -1204,10 +1201,7 @@ handle_incoming_message({run_remote_hook, HandlerName, Args}, StateName, StateDa
             fsm_next_state(StateName, StateData#state{handlers = NewStates})
     end;
 handle_incoming_message(Info, StateName, StateData) ->
-    ?LOG_ERROR(#{what => unexpected_info,
-                 text => <<"C2S process received an unexpected erlang message">>,
-                 info_msg => Info,
-                 state_name => StateName, c2s_state => StateData}),
+    ?UNEXPECTED_INFO(Info),
     fsm_next_state(StateName, StateData).
 
 process_incoming_stanza_with_conflict_check(From, To, Acc, StateName, StateData) ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -748,7 +748,7 @@ maybe_open_session(Acc, #state{jid = JID} = StateData) ->
             Acc1 = mongoose_hooks:forbidden_session_hook(StateData#state.server, Acc, JID),
             ?LOG_INFO(#{what => forbidden_session,
                         text => <<"User not allowed to open session">>,
-                        jid => JID, acc => Acc, c2s_state => StateData}),
+                        acc => Acc, c2s_state => StateData}),
             {Acc2, Err} = jlib:make_error_reply(Acc1, mongoose_xmpp_errors:not_allowed()),
             Acc3 = send_element(Acc2, Err, StateData),
             {wait, Acc3, StateData}
@@ -759,7 +759,7 @@ maybe_open_session(Acc, #state{jid = JID} = StateData) ->
 do_open_session(Acc, JID, StateData) ->
     ?LOG_INFO(#{what => c2s_opened_session,
                 text => <<"Opened session">>,
-                jid => JID, acc => Acc, c2s_state => StateData}),
+                acc => Acc, c2s_state => StateData}),
     Resp = jlib:make_result_iq_reply(mongoose_acc:element(Acc)),
     Packet = {jid:to_bare(StateData#state.jid), StateData#state.jid, Resp},
     case send_and_maybe_buffer_stanza(Acc, Packet, StateData) of

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1639,7 +1639,7 @@ change_shaper(StateData, JID) ->
 -spec send_text(state(), Text :: binary()) -> any().
 send_text(StateData, Text) ->
     ?LOG_DEBUG(#{what => c2s_send_text, text => <<"Send XML to the socket">>,
-                 text => Text, c2s_state => StateData}),
+                 send_text => Text, c2s_state => StateData}),
     Size = size(Text),
     mongoose_metrics:update(global, [data, xmpp, sent, xml_stanza_size], Size),
     (StateData#state.sockmod):send(StateData#state.socket, Text).

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -260,7 +260,7 @@ register_commands(Commands) ->
     lists:foreach(
       fun(Command) ->
               Inserted = ets:insert_new(ejabberd_commands, Command),
-              ?LOG_DEBUG_IF(not Inserted,
+              ?LOG_IF(debug, not Inserted,
                             #{what => register_command_duplicate,
                               text => <<"This command is already defined">>,
                               command => Command})

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -260,7 +260,10 @@ register_commands(Commands) ->
     lists:foreach(
       fun(Command) ->
               Inserted = ets:insert_new(ejabberd_commands, Command),
-              ?DEBUG_IF(not Inserted, "This command is already defined:~n~p", [Command])
+              ?LOG_DEBUG_IF(not Inserted,
+                            #{what => register_command_duplicate,
+                              text => <<"This command is already defined">>,
+                              command => Command})
       end,
       Commands).
 
@@ -341,7 +344,10 @@ execute_command(AccessCommands, Auth, Name, Arguments) ->
 execute_command2(Command, Arguments) ->
     Module = Command#ejabberd_commands.module,
     Function = Command#ejabberd_commands.function,
-    ?DEBUG("Executing command ~p:~p with Args=~p", [Module, Function, Arguments]),
+    ?LOG_DEBUG(#{what => execute_command,
+                 command_module => Module,
+                 command_function => Function,
+                 command_args => Arguments}),
     apply(Module, Function, Arguments).
 
 

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -260,7 +260,7 @@ register_commands(Commands) ->
     lists:foreach(
       fun(Command) ->
               Inserted = ets:insert_new(ejabberd_commands, Command),
-              ?LOG_IF(debug, not Inserted,
+              ?LOG_IF(warning, not Inserted,
                             #{what => register_command_duplicate,
                               text => <<"This command is already defined">>,
                               command => Command})

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -303,16 +303,14 @@ get_vh_by_auth_method(AuthMethod) ->
 
 handle_table_does_not_exist_error(Table) ->
     MnesiaDirectory = mnesia:system_info(directory),
-    Msg1 = <<"Error reading Mnesia database spool files:~n">>,
-    Msg2 = <<"The Mnesia database couldn't read the spool file for the table.~n">>,
-    Msg3 = <<"ejabberd needs read and write access in the directory.~n">>,
-    Msg4 = <<"Maybe the problem is a change in the computer hostname,~n">>,
-    Msg5 = <<"or a change in the Erlang node name.~n">>,
-    Msg6 = <<"Check the ejabberd guide for details about changing the~n">>,
-    Msg7 = <<"computer hostname or Erlang node name.~n">>,
-    ?LOG_ERROR(#{what => error_reading_mnesia_db, 
-                 text => <<Msg1/binary, Msg2/binary, Msg3/binary, Msg4/binary,
-                           Msg5/binary, Msg6/binary, Msg7/binary>>,
+    Msg = <<"Error reading Mnesia database spool files:~n"
+            "The Mnesia database couldn't read the spool file for the table.~n"
+            "ejabberd needs read and write access in the directory.~n"
+            "Maybe the problem is a change in the computer hostname,~n"
+            "or a change in the Erlang node name.~n"
+            "Check the ejabberd guide for details about changing the~n"
+            "computer hostname or Erlang node name.~n">>,
+    ?LOG_ERROR(#{what => error_reading_mnesia_db, text => Msg,
                  table => Table, directory => MnesiaDirectory, node => node()}),
     exit("Error reading Mnesia database").
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1,5 +1,5 @@
 %%%----------------------------------------------------------------------
-%%% File    : ejabberd_config.erl
+%                 %% File    : ejabberd_config.erl
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
 %%% Purpose : Load config file
 %%% Created : 14 Dec 2002 by Alexey Shchepin <alexey@process-one.net>
@@ -167,9 +167,8 @@ describe_config_problem(Filename, Reason, LineNumber) ->
                           ++ file:format_error(Reason)),
     ExitText = Text1 ++ Text2,
     Lines = mongoose_config_utils:get_config_lines(Filename, LineNumber, 10, 3),
-    ?LOG_ERROR(#{what => mim_config_file_loading_failed,
-                 text => <<"The following lines from your configuration file might be relevant to the error">>,
-                 lines => Lines}),
+    ?LOG_ERROR(#{what => mim_config_file_loading_failed, lines => Lines,
+                 text => <<"The following lines from your configuration file might be relevant to the error">>}),
     ExitText.
 
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -1,5 +1,5 @@
 %%%----------------------------------------------------------------------
-%                 %% File    : ejabberd_config.erl
+%%% File    : ejabberd_config.erl
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
 %%% Purpose : Load config file
 %%% Created : 14 Dec 2002 by Alexey Shchepin <alexey@process-one.net>

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -215,7 +215,7 @@ get_routes(Modules) ->
     Merge = fun(Paths) -> Paths ++ WildcardPaths end,
     Merged = lists:keymap(Merge, 2, proplists:delete('_', Routes)),
     Final = Merged ++ [{'_', WildcardPaths}],
-    ?DEBUG("Configured Cowboy Routes: ~p", [Final]),
+    ?LOG_DEBUG(#{what => configured_cowboy_routes, routes => Final}),
     Final.
 
 get_routes([], Routes) ->
@@ -295,8 +295,8 @@ maybe_insert_max_connections(TransportOpts, Opts) ->
 trails_store(Modules) ->
     try
         trails:store(trails:trails(collect_trails(Modules, [])))
-    catch Class:Exception ->
-        ?WARNING_MSG("Trails Call: [~p:~p/0] catched ~p:~p~n", [?MODULE, trails_store, Class, Exception])
+    catch Class:Reason ->
+              ?LOG_WARNING(#{what => caught_exception, class => Class, reason => Reason})
     end.
 
 %% -------------------------------------------------------------------

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -272,4 +272,6 @@ hook_apply_function(Module, Function, Val, Args) ->
     safely:apply(Module, Function, [Val | Args]).
 
 error_running_hook(Reason, Hook, Args) ->
-    ?ERROR_MSG("~p~nrunning hook: ~p", [Reason, {Hook, Args}]).
+    ?LOG_ERROR(#{what => hook_failed,
+                 text => <<"Error running hook">>,
+                 hook => Hook, args => Args, reason => Reason}).

--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -83,9 +83,8 @@ report_duplicated_portips(L) ->
     LNoDupsKeys = proplists:get_keys(L),
     Dups = LKeys -- LNoDupsKeys,
     ?LOG_IF(critical, Dups /= [],
-            #{what => duplicated_port_ips,
-              text => <<"In the configuration there are duplicated pair of Port number and IP address">>,
-              duplicates => Dups}).
+            #{what => duplicated_port_ips, duplicates => Dups,
+              text => <<"In the configuration there are duplicated pair of Port number and IP address">>}).
 
 %% @doc Parse any kind of ejabberd listener specification.
 %% The parsed options are returned in several formats.

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -143,12 +143,9 @@ process_packet(Acc, From, To, El, _Extra) ->
     try
         do_route(Acc, From, To, El)
     catch
-        _:Reason:StackTrace ->
-            ?ERROR_MSG("event=routing_error,from=~ts,to=~ts,module=~p,"
-                       "reason=~p,packet=~ts,stack_trace=~p",
-                       [jid:to_binary(From), jid:to_binary(To),
-                        ?MODULE, Reason, exml:to_binary(mongoose_acc:element(Acc)),
-                        StackTrace])
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{what => routing_error, acc => Acc,
+                         class => Class, reason => Reason, stacktrace => Stacktrace})
     end.
 
 -spec route_iq(From :: jid:jid(),
@@ -389,8 +386,7 @@ code_change(_OldVsn, State, _Extra) ->
                To :: jid:jid(),
                El :: mongoose_acc:t()) -> mongoose_acc:t().
 do_route(Acc, From, To, El) ->
-    ?DEBUG("local route~n\tfrom ~p~n\tto ~p~n\tpacket ~P~n",
-           [From, To, El, 8]),
+    ?LOG_DEBUG(#{what => local_routing, acc => Acc}),
     case directed_to(To) of
         user ->
             ejabberd_sm:route(From, To, Acc, El);

--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -168,11 +168,13 @@ handle_call({starttls, TLSOpts}, From, #state{socket = TCPSocket} = State) ->
                     NewState2 = process_data(TLSData, NewState),
                     {noreply, NewState2, maybe_hibernate(NewState2)};
                 {error, Reason} ->
-                    ?WARNING_MSG("tcp_to_tls failed with reason ~p~n", [Reason]),
+                    ?LOG_WARNING(#{what => tcp_to_tls_failed, reason => Reason,
+                                   c2s_pid => State#state.c2s_pid}),
                     {stop, normal, NewState}
             end;
         {error, Reason} ->
-            ?WARNING_MSG("tcp_to_tls failed with reason ~p~n", [Reason]),
+            ?LOG_WARNING(#{what => tcp_to_tls_failed, reason => Reason,
+                           c2s_pid => State#state.c2s_pid}),
             {stop, normal, State}
     end;
 handle_call({compress, ZlibSocket}, _From,
@@ -347,7 +349,7 @@ process_data(Data, #state{parser = Parser,
                           shaper_state = ShaperState,
                           stanza_chunk_size = ChunkSize,
                           c2s_pid = C2SPid} = State) ->
-    ?DEBUG("Received XML on stream = \"~s\"", [Data]),
+    ?LOG_DEBUG(#{what => received_xml_on_stream, packet => Data, c2s_pid => C2SPid}),
     Size = byte_size(Data),
     maybe_run_keep_alive_hook(Size, State),
     {C2SEvents, NewParser} =

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -112,7 +112,7 @@ start_link() ->
     To     :: jid:jid(),
     Packet :: mongoose_acc:t()|exml:element()) -> mongoose_acc:t().
 route(From, To, #xmlel{} = Packet) ->
-    % ?ERROR_MSG("Deprecated - it should be Acc: ~p", [Packet]),
+    % ?LOG_ERROR("Deprecated - it should be Acc: ~p", [Packet]),
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => From#jid.lserver,
                               element => Packet,

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -208,9 +208,7 @@ init([]) ->
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
 handle_call(Request, From, State) ->
-    ?LOG_ERROR(#{what => unexpected_cast,
-                 text => <<"ejabberd_s2s received unexpected gen_server call">>,
-                 msg => Request, call_from => From}),
+    ?UNEXPECTED_CALL(Request, From),
     Reply = ok,
     {reply, Reply, State}.
 
@@ -221,9 +219,7 @@ handle_call(Request, From, State) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 handle_cast(Msg, State) ->
-    ?LOG_ERROR(#{what => unexpected_cast,
-                 text => <<"ejabberd_s2s received unexpected gen_server cast">>,
-                 msg => Msg}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -234,9 +230,7 @@ handle_cast(Msg, State) ->
 %%--------------------------------------------------------------------
 
 handle_info(Msg, State) ->
-    ?LOG_ERROR(#{what => unexpected_message,
-                 text => <<"ejabberd_s2s received unexpected erlang message">>,
-                 msg => Msg}),
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -90,10 +90,6 @@ start_link() ->
 filter(From, To, Acc, Packet) ->
     {From, To, Acc, Packet}.
 
-route(_From, _To, Sthg) ->
-    ?ERROR_MSG("Sthg: ~p~n", [Sthg]),
-    ok.
-
 route(From, To, Acc, Packet) ->
     do_route(From, To, Acc, Packet).
 
@@ -211,7 +207,10 @@ init([]) ->
 %%                                      {stop, Reason, State}
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
-handle_call(_Request, _From, State) ->
+handle_call(Request, From, State) ->
+    ?LOG_ERROR(#{what => unexpected_cast,
+                 text => <<"ejabberd_s2s received unexpected gen_server call">>,
+                 msg => Request, call_from => From}),
     Reply = ok,
     {reply, Reply, State}.
 
@@ -221,7 +220,10 @@ handle_call(_Request, _From, State) ->
 %%                                      {stop, Reason, State}
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
-handle_cast(_Msg, State) ->
+handle_cast(Msg, State) ->
+    ?LOG_ERROR(#{what => unexpected_cast,
+                 text => <<"ejabberd_s2s received unexpected gen_server cast">>,
+                 msg => Msg}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -230,10 +232,11 @@ handle_cast(_Msg, State) ->
 %%                                       {stop, Reason, State}
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
-handle_info({route, From, To, Packet}, State) ->
-    route(From, To, Packet),
-    {noreply, State};
-handle_info(_Info, State) ->
+
+handle_info(Msg, State) ->
+    ?LOG_ERROR(#{what => unexpected_message,
+                 text => <<"ejabberd_s2s received unexpected erlang message">>,
+                 msg => Msg}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -265,11 +268,12 @@ code_change(_OldVsn, State, _Extra) ->
                Packet :: exml:element()) ->
         done. % this is the 'last resort' router, it always returns 'done'.
 do_route(From, To, Acc, Packet) ->
-    ?DEBUG("s2s manager~n\tfrom ~p~n\tto ~p~n\tpacket ~P~n",
-        [From, To, Packet, 8]),
+    ?LOG_DEBUG(#{what => s2s_route, acc => Acc}),
     case find_connection(From, To) of
         {atomic, Pid} when is_pid(Pid) ->
-            ?DEBUG("sending to process ~p~n", [Pid]),
+            ?LOG_DEBUG(#{what => s2s_found_connection,
+                         text => <<"Send packet to s2s connection">>,
+                         s2s_pid => Pid, acc => Acc}),
             #xmlel{attrs = Attrs} = Packet,
             NewAttrs = jlib:replace_from_to_attrs(jid:to_binary(From),
                                                   jid:to_binary(To),
@@ -286,8 +290,7 @@ do_route(From, To, Acc, Packet) ->
                 <<"error">> -> done;
                 <<"result">> -> done;
                 _ ->
-                    ?DEBUG("event=s2s_connection_not_found from=~1000p to=~1000p packet=~1000p",
-                           [From, To, Packet]),
+                    ?LOG_DEBUG(#{what => s2s_connection_not_found, acc => Acc}),
                     {Acc1, Err} = jlib:make_error_reply(
                             Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
                     ejabberd_router:route(To, From, Acc1, Err)
@@ -304,7 +307,7 @@ find_connection(From, To) ->
     MaxS2SConnectionsNumber = max_s2s_connections_number(FromTo),
     MaxS2SConnectionsNumberPerNode =
         max_s2s_connections_number_per_node(FromTo),
-    ?DEBUG("Finding connection for ~p~n", [FromTo]),
+    ?LOG_DEBUG(#{what => s2s_find_connection, from_server => MyServer, to_server => Server}),
     case catch mnesia:dirty_read(s2s, FromTo) of
         {'EXIT', Reason} ->
             {aborted, Reason};
@@ -372,7 +375,7 @@ choose_pid(From, Pids) ->
     % Use sticky connections based on the JID of the sender
     % (without the resource to ensure that a muc room always uses the same connection)
     Pid = lists:nth(erlang:phash(jid:to_bare(From), length(Pids1)), Pids1),
-    ?DEBUG("Using ejabberd_s2s_out ~p~n", [Pid]),
+    ?LOG_DEBUG(#{what => s2s_choose_pid, from => From, s2s_pid => Pid}),
     Pid.
 
 -spec open_several_connections(N :: pos_integer(), MyServer :: jid:server(),
@@ -396,7 +399,7 @@ open_several_connections(N, MyServer, Server, From, FromTo,
 -spec new_connection(MyServer :: jid:server(), Server :: jid:server(),
     From :: jid:jid(), FromTo :: fromto(), MaxS2S :: pos_integer(),
     MaxS2SPerNode :: pos_integer()) -> {'aborted', _} | {'atomic', _}.
-new_connection(MyServer, Server, From, FromTo,
+new_connection(MyServer, Server, From, FromTo = {FromServer, ToServer},
                MaxS2SConnectionsNumber, MaxS2SConnectionsNumberPerNode) ->
     {ok, Pid} = ejabberd_s2s_out:start(
                   MyServer, Server, new),
@@ -409,7 +412,11 @@ new_connection(MyServer, Server, From, FromTo,
                     true ->
                         mnesia:write(#s2s{fromto = FromTo,
                                           pid = Pid}),
-                        ?INFO_MSG("New s2s connection started ~p", [Pid]),
+                        ?LOG_INFO(#{what => s2s_new_connection,
+                                    text => <<"New s2s connection started">>,
+                                    from_server => FromServer,
+                                    to_server => ToServer,
+                                    s2s_pid => Pid}),
                         Pid;
                     false ->
                         choose_connection(From, L)

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -209,8 +209,7 @@ init([]) ->
 %%--------------------------------------------------------------------
 handle_call(Request, From, State) ->
     ?UNEXPECTED_CALL(Request, From),
-    Reply = ok,
-    {reply, Reply, State}.
+    {reply, {error, unexpected_call}, State}.
 
 %%--------------------------------------------------------------------
 %% Function: handle_cast(Msg, State) -> {noreply, State} |

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -698,7 +698,7 @@ handle_auth_res(true, AuthDomain, StateData) ->
                         attrs = [{<<"xmlns">>, ?NS_SASL}]}),
     ?LOG_DEBUG(#{what => s2s_auth_success,
                  text => <<"Accepted s2s authentication">>,
-                 socket => StateData#state.socket, domain => AuthDomain}),
+                 socket => StateData#state.socket, auth_domain => AuthDomain}),
     {next_state, wait_for_stream,
      StateData#state{streamid = new_id(),
                      authenticated = true,

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -132,17 +132,14 @@
 
 
 -define(CLOSE_GENERIC(StateName, Reason, StateData),
-    ?LOG_INFO(#{what => s2s_out_closing,
-                text => <<"Closing s2s connection">>,
+    ?LOG_INFO(#{what => s2s_out_closing, text => <<"Closing s2s connection">>,
                 state_name => StateName, reason => Reason,
                 myname => StateData#state.myname, server => StateData#state.server}),
     {stop, normal, StateData}).
 
 -define(CLOSE_GENERIC(StateName, Reason, El, StateData),
-    ?LOG_INFO(#{what => s2s_out_closing,
-                text => <<"Closing s2s connection">>,
-                exml_packet => El,
-                state_name => StateName, reason => Reason,
+    ?LOG_INFO(#{what => s2s_out_closing, text => <<"Closing s2s connection on stanza">>,
+                state_name => StateName, reason => Reason, exml_packet => El,
                 myname => StateData#state.myname, server => StateData#state.server}),
     {stop, normal, StateData}).
 

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -364,12 +364,12 @@ wait_for_stream(closed, StateData) ->
 wait_for_validation({xmlstreamelement, El}, StateData) ->
     case is_verify_res(El) of
         {result, To, From, Id, Type} ->
-            ?LOG_DEBUG(#{event => s2s_receive_result,
+            ?LOG_DEBUG(#{what => s2s_receive_result,
                          from => From, to => To, messag_id => Id, type => Type}),
             case {Type, StateData#state.tls_enabled, StateData#state.tls_required} of
                 {<<"valid">>, Enabled, Required} when (Enabled==true) or (Required==false) ->
                     send_queue(StateData, StateData#state.queue),
-                    ?LOG_INFO(#{event => s2s_out_connected,
+                    ?LOG_INFO(#{what => s2s_out_connected,
                                 text => <<"New outgoing s2s connection established">>,
                                 tls_enabled => StateData#state.tls_enabled,
                                 myname => StateData#state.myname, server => StateData#state.server}),
@@ -386,7 +386,7 @@ wait_for_validation({xmlstreamelement, El}, StateData) ->
                     close_generic(wait_for_validation, invalid_dialback_key, El, StateData)
             end;
         {verify, To, From, Id, Type} ->
-            ?LOG_DEBUG(#{event => s2s_receive_verify,
+            ?LOG_DEBUG(#{what => s2s_receive_verify,
                          from => From, to => To, messag_id => Id, type => Type}),
             case StateData#state.verify of
                 false ->
@@ -1004,7 +1004,7 @@ srv_lookup(Server, Timeout, Retries) ->
         {error, _Reason} ->
             case inet_res:getbyname("_jabber._tcp." ++ binary_to_list(Server), srv, Timeout) of
                 {error, timeout} ->
-                    ?LOG_ERROR(#{event => s2s_dns_error,
+                    ?LOG_ERROR(#{what => s2s_dns_error,
                                  text => <<"The DNS servers timed out on request for IN SRV."
                                            " You should check your DNS configuration.">>,
                                  nameserver => inet_db:res_option(nameserver),
@@ -1102,7 +1102,7 @@ outgoing_s2s_timeout() ->
 log_s2s_out(false, _, _, _) -> ok;
 %% Log new outgoing connections:
 log_s2s_out(_, Myname, Server, Tls) ->
-    ?LOG_INFO(#{event => s2s_out,
+    ?LOG_INFO(#{what => s2s_out,
                 text => <<"Trying to open s2s connection">>,
                 myname => Myname, server => Server, tls => Tls}).
 

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -165,7 +165,9 @@ stop_connection(Pid) ->
 -spec init([any(), ...]) -> {'ok', 'open_socket', state()}.
 init([From, Server, Type]) ->
     process_flag(trap_exit, true),
-    ?DEBUG("started: ~p", [{From, Server, Type}]),
+    ?LOG_DEBUG(#{what => s2s_out_started,
+                 text => <<"New outgoing s2s connection">>,
+                 from => From, server => Server, type => Type}),
     {TLS, TLSRequired} = case ejabberd_config:get_local_option(s2s_use_starttls) of
               UseTls when (UseTls==undefined) or (UseTls==false) ->
                   {false, false};
@@ -218,10 +220,11 @@ open_socket(init, StateData) ->
                 StateData#state.myname,
                 StateData#state.server,
                 StateData#state.tls),
-    ?DEBUG("open_socket: ~p", [{StateData#state.myname,
-                                StateData#state.server,
-                                StateData#state.new,
-                                StateData#state.verify}]),
+    ?LOG_DEBUG(#{what => s2s_open_socket,
+                 myname => StateData#state.myname,
+                 server => StateData#state.server,
+                 new => StateData#state.new,
+                 verify => StateData#state.verify}),
     AddrList = get_addr_list(StateData#state.server),
     case lists:foldl(fun({_Addr, _Port}, {ok, Socket}) ->
                              {ok, Socket};
@@ -239,16 +242,18 @@ open_socket(init, StateData) ->
             send_text(NewStateData,
                       ?STREAM_HEADER(StateData#state.myname, StateData#state.server, Version)),
             {next_state, wait_for_stream, NewStateData, ?FSMTIMEOUT};
-        {error, _Reason} ->
-            ?INFO_MSG("s2s connection: ~s -> ~s (remote server not found)",
-                      [StateData#state.myname, StateData#state.server]),
+        {error, Reason} ->
+            ?LOG_INFO(#{what => s2s_out_failed, reason => Reason,
+                        text => <<"Outgoing s2s connection failed (remote server not found)">>,
+                        myname => StateData#state.myname, server => StateData#state.server}),
             case mongoose_hooks:find_s2s_bridge(undefined,
                                                 StateData#state.myname,
                                                 StateData#state.server) of
                 {Mod, Fun, Type} ->
-                    ?INFO_MSG("found a bridge to ~s for: ~s -> ~s",
-                              [Type, StateData#state.myname,
-                               StateData#state.server]),
+                    ?LOG_INFO(#{what => s2s_out_bridge_found,
+                                text => <<"Found a bridge, relay_to_bridge next.">>,
+                                type => Type,
+                                myname => StateData#state.myname, server => StateData#state.server}),
                     NewStateData = StateData#state{bridge={Mod, Fun}},
                     {next_state, relay_to_bridge, NewStateData};
                 _ ->
@@ -256,13 +261,9 @@ open_socket(init, StateData) ->
             end
     end;
 open_socket(closed, StateData) ->
-    ?INFO_MSG("s2s connection: ~s -> ~s (stopped in open socket)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(open_socket, closed, StateData);
 open_socket(timeout, StateData) ->
-    ?INFO_MSG("s2s connection: ~s -> ~s (timeout in open socket)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(open_socket, timeout, StateData);
 open_socket(_, StateData) ->
     {next_state, open_socket, StateData}.
 
@@ -293,7 +294,8 @@ open_socket1(Host, Port) ->
                    Addr :: inet:ip_address(),
                    Port :: inet:port_number()) -> {'error', _} | {'ok', _}.
 open_socket2(Type, Addr, Port) ->
-    ?DEBUG("s2s_out: connecting to ~p:~p~n", [Addr, Port]),
+    ?LOG_DEBUG(#{what => s2s_out_connecting,
+                 address => Addr, port => Port}),
     Timeout = outgoing_s2s_timeout(),
     SockOpts = [binary,
                 {packet, 0},
@@ -305,10 +307,13 @@ open_socket2(Type, Addr, Port) ->
     case (catch ejabberd_socket:connect(Addr, Port, SockOpts, Timeout)) of
         {ok, _Socket} = R -> R;
         {error, Reason} = R ->
-            ?DEBUG("s2s_out: connect return ~p~n", [Reason]),
+            ?LOG_DEBUG(#{what => s2s_out_failed,
+                         address => Addr, port => Port, reason => Reason}),
             R;
         {'EXIT', Reason} ->
-            ?DEBUG("s2s_out: connect crashed ~p~n", [Reason]),
+            ?LOG_DEBUG(#{what => s2s_out_failed,
+                         text => <<"Failed to open s2s socket because of crashing">>,
+                         address => Addr, port => Port, reason => Reason}),
             {error, Reason}
     end.
 
@@ -334,43 +339,40 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData0) ->
             {next_state, wait_for_features, StateData#state{db_enabled = false}, ?FSMTIMEOUT};
         {NSProvided, DB, _} ->
             send_text(StateData, exml:to_binary(mongoose_xmpp_errors:invalid_namespace())),
-            ?INFO_MSG("Closing s2s connection: ~s -> ~s (invalid namespace).~n"
-                      "Namespace provided: ~p~nNamespace expected: \"jabber:server\"~n"
-                      "xmlns:db provided: ~p~nAll attributes: ~p",
-                      [StateData#state.myname, StateData#state.server, NSProvided, DB, Attrs]),
+            ?LOG_INFO(#{what => s2s_out_closing,
+                        text => <<"Closing s2s connection: (invalid namespace)">>,
+                        namespace_provided => NSProvided,
+                        namespace_expected => <<"jabber:server">>,
+                        xmlnsdb_provided => DB,
+                        all_attributes => Attrs,
+                        myname => StateData#state.myname, server => StateData#state.server}),
             {stop, normal, StateData}
     end;
 wait_for_stream({xmlstreamerror, _}, StateData) ->
     send_text(StateData,
               <<(mongoose_xmpp_errors:xml_not_well_formed_bin())/binary, (?STREAM_TRAILER)/binary>>),
-    ?INFO_MSG("Closing s2s connection: ~s -> ~s (invalid xml)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(wait_for_stream, xmlstreamerror, StateData);
 wait_for_stream({xmlstreamend, _Name}, StateData) ->
-    ?INFO_MSG("Closing s2s connection: ~s -> ~s (xmlstreamend)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(wait_for_stream, xmlstreamend, StateData);
 wait_for_stream(timeout, StateData) ->
-    ?INFO_MSG("Closing s2s connection: ~s -> ~s (timeout in wait_for_stream)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(wait_for_stream, timeout, StateData);
 wait_for_stream(closed, StateData) ->
-    ?INFO_MSG("Closing s2s connection: ~s -> ~s (close in wait_for_stream)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData}.
+    close_generic(wait_for_stream, closed, StateData).
 
 
 -spec wait_for_validation(ejabberd:xml_stream_item(), state()) -> fsm_return().
 wait_for_validation({xmlstreamelement, El}, StateData) ->
     case is_verify_res(El) of
         {result, To, From, Id, Type} ->
-            ?DEBUG("recv result: ~p", [{From, To, Id, Type}]),
+            ?LOG_DEBUG(#{event => s2s_receive_result,
+                         from => From, to => To, messag_id => Id, type => Type}),
             case {Type, StateData#state.tls_enabled, StateData#state.tls_required} of
                 {<<"valid">>, Enabled, Required} when (Enabled==true) or (Required==false) ->
                     send_queue(StateData, StateData#state.queue),
-                    ?INFO_MSG("Connection established: ~s -> ~s with TLS=~p",
-                              [StateData#state.myname, StateData#state.server,
-                               StateData#state.tls_enabled]),
+                    ?LOG_INFO(#{event => s2s_out_connected,
+                                text => <<"New outgoing s2s connection established">>,
+                                tls_enabled => StateData#state.tls_enabled,
+                                myname => StateData#state.myname, server => StateData#state.server}),
                     mongoose_hooks:s2s_connect_hook(StateData#state.myname,
                                                     ok,
                                                     StateData#state.server),
@@ -378,17 +380,14 @@ wait_for_validation({xmlstreamelement, El}, StateData) ->
                      StateData#state{queue = queue:new()}};
                 {<<"valid">>, Enabled, Required} when (Enabled==false) and (Required==true) ->
                     %% TODO: bounce packets
-                    ?INFO_MSG("Closing s2s connection: ~s -> ~s (TLS is required but unavailable)",
-                              [StateData#state.myname, StateData#state.server]),
-                    {stop, normal, StateData};
+                    close_generic(wait_for_validation, tls_required_but_unavailable, El, StateData);
                 _ ->
                     %% TODO: bounce packets
-                    ?INFO_MSG("Closing s2s connection: ~s -> ~s (invalid dialback key)",
-                              [StateData#state.myname, StateData#state.server]),
-                    {stop, normal, StateData}
+                    close_generic(wait_for_validation, invalid_dialback_key, El, StateData)
             end;
         {verify, To, From, Id, Type} ->
-            ?DEBUG("recv verify: ~p", [{From, To, Id, Type}]),
+            ?LOG_DEBUG(#{event => s2s_receive_verify,
+                         from => From, to => To, messag_id => Id, type => Type}),
             case StateData#state.verify of
                 false ->
                     NextState = wait_for_validation,
@@ -406,29 +405,28 @@ wait_for_validation({xmlstreamelement, El}, StateData) ->
             {next_state, wait_for_validation, StateData, ?FSMTIMEOUT*3}
     end;
 wait_for_validation({xmlstreamend, _Name}, StateData) ->
-    ?INFO_MSG("wait for validation: ~s -> ~s (xmlstreamend)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(wait_for_validation, xmlstreamend, StateData);
 wait_for_validation({xmlstreamerror, _}, StateData) ->
-    ?INFO_MSG("wait for validation: ~s -> ~s (xmlstreamerror)",
-              [StateData#state.myname, StateData#state.server]),
     send_text(StateData,
               <<(mongoose_xmpp_errors:xml_not_well_formed_bin())/binary, (?STREAM_TRAILER)/binary>>),
-    {stop, normal, StateData};
+    close_generic(wait_for_validation, xmlstreamerror, StateData);
 wait_for_validation(timeout, #state{verify = {VPid, VKey, SID}} = StateData)
   when is_pid(VPid) and is_binary(VKey) and is_binary(SID) ->
     %% This is an auxiliary s2s connection for dialback.
     %% This timeout is normal and doesn't represent a problem.
-    ?DEBUG("wait_for_validation: ~s -> ~s (timeout in verify connection)",
-           [StateData#state.myname, StateData#state.server]),
+    ?LOG_INFO(#{what => s2s_out_validation_timeout,
+                text => <<"Timeout in verify outgoing s2s connection. Stopping">>,
+                myname => StateData#state.myname, server => StateData#state.server}),
     {stop, normal, StateData};
 wait_for_validation(timeout, StateData) ->
-    ?INFO_MSG("wait_for_validation: ~s -> ~s (connect timeout)",
-              [StateData#state.myname, StateData#state.server]),
+    ?LOG_INFO(#{what => s2s_out_connect_timeout,
+                text => <<"Connection timeout in outgoing s2s connection. Stopping">>,
+                myname => StateData#state.myname, server => StateData#state.server}),
     {stop, normal, StateData};
 wait_for_validation(closed, StateData) ->
-    ?INFO_MSG("wait for validation: ~s -> ~s (closed)",
-              [StateData#state.myname, StateData#state.server]),
+    ?LOG_INFO(#{what => s2s_out_validation_closed,
+                text => <<"Connection closed when waiting for validation in outgoing s2s connection. Stopping">>,
+                myname => StateData#state.myname, server => StateData#state.server}),
     {stop, normal, StateData}.
 
 
@@ -453,24 +451,18 @@ wait_for_features({xmlstreamelement, El}, StateData) ->
             send_text(StateData,
                       <<(mongoose_xmpp_errors:bad_format_bin())/binary,
                       (?STREAM_TRAILER)/binary>>),
-            ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-                      [StateData#state.myname, StateData#state.server]),
-            {stop, normal, StateData}
+            close_generic(wait_for_features, bad_format, El, StateData)
     end;
 wait_for_features({xmlstreamend, _Name}, StateData) ->
-    ?INFO_MSG("wait_for_features: xmlstreamend", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_features, xmlstreamend, StateData);
 wait_for_features({xmlstreamerror, _}, StateData) ->
     send_text(StateData,
               <<(mongoose_xmpp_errors:xml_not_well_formed_bin())/binary, (?STREAM_TRAILER)/binary>>),
-    ?INFO_MSG("wait for features: xmlstreamerror", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_features, xmlstreamerror, StateData);
 wait_for_features(timeout, StateData) ->
-    ?INFO_MSG("wait for features: timeout", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_features, timeout, StateData);
 wait_for_features(closed, StateData) ->
-    ?INFO_MSG("wait for features: closed", []),
-    {stop, normal, StateData}.
+    close_generic(wait_for_features, closed, StateData).
 
 
 -spec wait_for_auth_result(ejabberd:xml_stream_item(), state()) -> fsm_return().
@@ -479,8 +471,9 @@ wait_for_auth_result({xmlstreamelement, El}, StateData) ->
         #xmlel{name = <<"success">>, attrs = Attrs} ->
             case xml:get_attr_s(<<"xmlns">>, Attrs) of
                 ?NS_SASL ->
-                    ?DEBUG("auth: ~p", [{StateData#state.myname,
-                                         StateData#state.server}]),
+                    ?LOG_DEBUG(#{what => s2s_auth_success,
+                                 myname => StateData#state.myname,
+                                 server => StateData#state.server}),
                     send_text(StateData,
                               ?STREAM_HEADER(StateData#state.myname, StateData#state.server,
                                               <<" version='1.0'">>)),
@@ -492,15 +485,15 @@ wait_for_auth_result({xmlstreamelement, El}, StateData) ->
                     send_text(StateData,
                               <<(mongoose_xmpp_errors:bad_format_bin())/binary,
                               (?STREAM_TRAILER)/binary>>),
-                    ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-                              [StateData#state.myname, StateData#state.server]),
-                    {stop, normal, StateData}
+                    close_generic(wait_for_auth_result, bad_format, El, StateData)
             end;
         #xmlel{name = <<"failure">>, attrs = Attrs} ->
             case xml:get_attr_s(<<"xmlns">>, Attrs) of
                 ?NS_SASL ->
-                    ?DEBUG("restarted: ~p", [{StateData#state.myname,
-                                              StateData#state.server}]),
+                    ?LOG_INFO(#{what => s2s_auth_failure,
+                                text => <<"Received failure result in ejabberd_s2s_out. Restarting">>,
+                                myname => StateData#state.myname,
+                                server => StateData#state.server}),
                     ejabberd_socket:close(StateData#state.socket),
                     {next_state, reopen_socket,
                      StateData#state{socket = undefined}, ?FSMTIMEOUT};
@@ -508,32 +501,24 @@ wait_for_auth_result({xmlstreamelement, El}, StateData) ->
                     send_text(StateData,
                               <<(mongoose_xmpp_errors:bad_format_bin())/binary,
                               (?STREAM_TRAILER)/binary>>),
-                    ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-                              [StateData#state.myname, StateData#state.server]),
-                    {stop, normal, StateData}
+                    close_generic(wait_for_auth_result, bad_format, El, StateData)
             end;
         _ ->
             send_text(StateData,
                       <<(mongoose_xmpp_errors:bad_format_bin())/binary,
                               (?STREAM_TRAILER)/binary>>),
-            ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-                      [StateData#state.myname, StateData#state.server]),
-            {stop, normal, StateData}
+            close_generic(wait_for_auth_result, bad_format, El, StateData)
     end;
 wait_for_auth_result({xmlstreamend, _Name}, StateData) ->
-    ?INFO_MSG("wait for auth result: xmlstreamend", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_auth_result, xmlstreamend, StateData);
 wait_for_auth_result({xmlstreamerror, _}, StateData) ->
     send_text(StateData,
               <<(mongoose_xmpp_errors:xml_not_well_formed_bin())/binary, (?STREAM_TRAILER)/binary>>),
-    ?INFO_MSG("wait for auth result: xmlstreamerror", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_auth_result, xmlstreamerror, StateData);
 wait_for_auth_result(timeout, StateData) ->
-    ?INFO_MSG("wait for auth result: timeout", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_auth_result, timeout, StateData);
 wait_for_auth_result(closed, StateData) ->
-    ?INFO_MSG("wait for auth result: closed", []),
-    {stop, normal, StateData}.
+    close_generic(wait_for_auth_result, closed, StateData).
 
 
 -spec wait_for_starttls_proceed(ejabberd:xml_stream_item(), state()) -> fsm_return().
@@ -542,8 +527,9 @@ wait_for_starttls_proceed({xmlstreamelement, El}, StateData) ->
         #xmlel{name = <<"proceed">>, attrs = Attrs} ->
             case xml:get_attr_s(<<"xmlns">>, Attrs) of
                 ?NS_TLS ->
-                    ?DEBUG("starttls: ~p", [{StateData#state.myname,
-                                             StateData#state.server}]),
+                    ?LOG_DEBUG(#{what => s2s_starttls,
+                                 myname => StateData#state.myname,
+                                 server => StateData#state.server}),
                     Socket = StateData#state.socket,
                     TLSOpts = get_tls_opts_with_certfile(StateData),
                     TLSOpts2 = get_tls_opts_with_ciphers(TLSOpts),
@@ -561,29 +547,21 @@ wait_for_starttls_proceed({xmlstreamelement, El}, StateData) ->
                     send_text(StateData,
                               <<(mongoose_xmpp_errors:bad_format_bin())/binary,
                               (?STREAM_TRAILER)/binary>>),
-                    ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-                              [StateData#state.myname, StateData#state.server]),
-                    {stop, normal, StateData}
+                    close_generic(wait_for_auth_result, bad_format, El, StateData)
             end;
         _ ->
-            ?INFO_MSG("Closing s2s connection: ~s -> ~s (bad format)",
-                      [StateData#state.myname, StateData#state.server]),
-            {stop, normal, StateData}
+            close_generic(wait_for_auth_result, bad_format, El, StateData)
     end;
 wait_for_starttls_proceed({xmlstreamend, _Name}, StateData) ->
-    ?INFO_MSG("wait for starttls proceed: xmlstreamend", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_starttls_proceed, xmlstreamend, StateData);
 wait_for_starttls_proceed({xmlstreamerror, _}, StateData) ->
     send_text(StateData,
               <<(mongoose_xmpp_errors:xml_not_well_formed_bin())/binary, (?STREAM_TRAILER)/binary>>),
-    ?INFO_MSG("wait for starttls proceed: xmlstreamerror", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_starttls_proceed, xmlstreamerror, StateData);
 wait_for_starttls_proceed(timeout, StateData) ->
-    ?INFO_MSG("wait for starttls proceed: timeout", []),
-    {stop, normal, StateData};
+    close_generic(wait_for_starttls_proceed, timeout, StateData);
 wait_for_starttls_proceed(closed, StateData) ->
-    ?INFO_MSG("wait for starttls proceed: closed", []),
-    {stop, normal, StateData}.
+    close_generic(wait_for_starttls_proceed, closed, StateData).
 
 
 -spec reopen_socket(ejabberd:xml_stream_item(), state()) -> fsm_return().
@@ -594,8 +572,7 @@ reopen_socket({xmlstreamend, _Name}, StateData) ->
 reopen_socket({xmlstreamerror, _}, StateData) ->
     {next_state, reopen_socket, StateData, ?FSMTIMEOUT};
 reopen_socket(timeout, StateData) ->
-    ?INFO_MSG("reopen socket: timeout", []),
-    {stop, normal, StateData};
+    close_generic(reopen_socket, timeout, StateData);
 reopen_socket(closed, StateData) ->
     p1_fsm:send_event(self(), init),
     {next_state, open_socket, StateData, ?FSMTIMEOUT}.
@@ -611,19 +588,20 @@ wait_before_retry(_Event, StateData) ->
 relay_to_bridge(stop, StateData) ->
     wait_before_reconnect(StateData);
 relay_to_bridge(closed, StateData) ->
-    ?INFO_MSG("relay to bridge: ~s -> ~s (closed)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(relay_to_bridge, closed, StateData);
 relay_to_bridge(_Event, StateData) ->
     {next_state, relay_to_bridge, StateData}.
 
 
 -spec stream_established(ejabberd:xml_stream_item(), state()) -> fsm_return().
 stream_established({xmlstreamelement, El}, StateData) ->
-    ?DEBUG("s2S stream established", []),
+    ?LOG_DEBUG(#{what => s2s_out_stream_established, exml_packet => El,
+                 myname => StateData#state.myname, server => StateData#state.server}),
     case is_verify_res(El) of
         {verify, VTo, VFrom, VId, VType} ->
-            ?DEBUG("recv verify: ~p", [{VFrom, VTo, VId, VType}]),
+            ?LOG_DEBUG(#{what => s2s_recv_verify,
+                         to => VTo, from => VFrom, messag_id => VId, type => VType,
+                         myname => StateData#state.myname, server => StateData#state.server}),
             case StateData#state.verify of
                 {VPid, _VKey, _SID} ->
                     send_event(VType, VPid, StateData);
@@ -635,23 +613,15 @@ stream_established({xmlstreamelement, El}, StateData) ->
     end,
     {next_state, stream_established, StateData};
 stream_established({xmlstreamend, _Name}, StateData) ->
-    ?INFO_MSG("Connection closed in stream established: ~s -> ~s (xmlstreamend)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(stream_established, xmlstreamend, StateData);
 stream_established({xmlstreamerror, _}, StateData) ->
     send_text(StateData,
               <<(mongoose_xmpp_errors:xml_not_well_formed_bin())/binary, (?STREAM_TRAILER)/binary>>),
-    ?INFO_MSG("stream established: ~s -> ~s (xmlstreamerror)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(stream_established, xmlstreamerror, StateData);
 stream_established(timeout, StateData) ->
-    ?INFO_MSG("stream established: ~s -> ~s (timeout)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(stream_established, timeout, StateData);
 stream_established(closed, StateData) ->
-    ?INFO_MSG("stream established: ~s -> ~s (closed)",
-              [StateData#state.myname, StateData#state.server]),
-    {stop, normal, StateData}.
+    close_generic(stream_established, closed, StateData).
 
 
 %%----------------------------------------------------------------------
@@ -735,7 +705,9 @@ code_change(_OldVsn, StateName, StateData, _Extra) ->
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
 handle_info({send_text, Text}, StateName, StateData) ->
-    ?ERROR_MSG("{s2s_out:send_text, Text}: ~p~n", [{send_text, Text}]), % is it ever called?
+    ?LOG_ERROR(#{what => s2s_send_text, text => <<"Deprecated ejabberd_s2s_out send_text">>,
+                 myname => StateData#state.myname, server => StateData#state.server,
+                 send_text => Text}),
     send_text(StateData, Text),
     cancel_timer(StateData#state.timer),
     Timer = erlang:start_timer(ejabberd_s2s:timeout(), self(), []),
@@ -757,10 +729,17 @@ handle_info({send_element, Acc, El}, StateName, StateData) ->
             %% In this state we relay all outbound messages
             %% to a foreign protocol bridge such as SMTP, SIP, etc.
             {Mod, Fun} = StateData#state.bridge,
-            ?DEBUG("relaying stanza via ~p:~p/1", [Mod, Fun]),
+            ?LOG_DEBUG(#{what => s2s_relay_stanza,
+                         text => <<"Relaying stanza to bridge">>,
+                         bridge_module => Mod, bridge_fun => Fun, acc => Acc,
+                         myname => StateData#state.myname, server => StateData#state.server}),
             case catch Mod:Fun(El) of
                 {'EXIT', Reason} ->
-                    ?ERROR_MSG("Error while relaying to bridge: ~p", [Reason]),
+                    ?LOG_ERROR(#{what => s2s_relay_to_bridge_failed,
+                                 bridge_module => Mod, bridge_fun => Fun,
+                                 reason => Reason, acc => Acc,
+                                 myname => StateData#state.myname,
+                                 server => StateData#state.server}),
                     bounce_element(Acc, El, mongoose_xmpp_errors:internal_server_error()),
                     wait_before_reconnect(StateData);
                 _ ->
@@ -773,15 +752,16 @@ handle_info({send_element, Acc, El}, StateName, StateData) ->
     end;
 handle_info({timeout, Timer, _}, wait_before_retry,
             #state{timer = Timer} = StateData) ->
-    ?INFO_MSG("Reconnect delay expired: Will now retry to connect to ~s when needed.",
-              [StateData#state.server]),
+    ?LOG_INFO(#{what => s2s_reconnect_delay_expired,
+                text => <<"Reconnect delay expired: Will now retry to connect when needed.">>,
+                myname => StateData#state.myname,
+                server => StateData#state.server}),
     {stop, normal, StateData};
-handle_info({timeout, Timer, _}, _StateName,
+handle_info({timeout, Timer, _}, StateName,
             #state{timer = Timer} = StateData) ->
-    ?INFO_MSG("Closing connection with ~s: timeout", [StateData#state.server]),
-    {stop, normal, StateData};
+    close_generic(StateName, s2s_out_timeout, StateData);
 handle_info(terminate_if_waiting_before_retry, wait_before_retry, StateData) ->
-    {stop, normal, StateData};
+    close_generic(wait_before_retry, terminate_if_waiting_before_retry, StateData);
 handle_info(terminate_if_waiting_before_retry, StateName, StateData) ->
     {next_state, StateName, StateData, get_timeout_interval(StateName)};
 handle_info(_, StateName, StateData) ->
@@ -793,7 +773,9 @@ handle_info(_, StateName, StateData) ->
 %% Returns: any
 %%----------------------------------------------------------------------
 terminate(Reason, StateName, StateData) ->
-    ?DEBUG("terminated: ~p", [{Reason, StateName}]),
+    ?LOG_DEBUG(#{what => s2s_out_closed, text => <<"ejabberd_s2s_out terminated">>,
+                 reason => Reason, state_name => StateName,
+                 myname => StateData#state.myname, server => StateData#state.server}),
     case StateData#state.new of
         false ->
             ok;
@@ -940,7 +922,10 @@ send_db_request(StateData) ->
         end,
         {next_state, wait_for_validation, NewStateData, ?FSMTIMEOUT*6}
     catch
-        _:_ ->
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{what => s2s_out_send_db_request_failed,
+                         class => Class, reason => Reason, stacktrace => Stacktrace,
+                         myname => StateData#state.myname, server => StateData#state.server}),
             {stop, normal, NewStateData}
     end.
 
@@ -974,7 +959,8 @@ get_addr_port(Server) ->
     Res = srv_lookup(Server),
     case Res of
         {error, Reason} ->
-            ?DEBUG("srv lookup of '~s' failed: ~p~n", [Server, Reason]),
+            ?LOG_DEBUG(#{what => s2s_srv_lookup_failed,
+                         reason => Reason, server => Server}),
             [{Server, outgoing_s2s_port()}];
         {ok, #hostent{h_addr_list = AddrList}} ->
             %% Probabilities are not exactly proportional to weights
@@ -985,7 +971,8 @@ get_addr_port(Server) ->
                 SortedList ->
                     List = lists:keysort(1, SortedList),
                     List2 = remove_addr_index(List),
-                    ?DEBUG("srv lookup of '~s': ~p~n", [Server, List2]),
+                    ?LOG_DEBUG(#{what => s2s_srv_lookup_success,
+                                 addresses => List2, server => Server}),
                     List2
             end
     end.
@@ -1017,10 +1004,11 @@ srv_lookup(Server, Timeout, Retries) ->
         {error, _Reason} ->
             case inet_res:getbyname("_jabber._tcp." ++ binary_to_list(Server), srv, Timeout) of
                 {error, timeout} ->
-                    ?ERROR_MSG("The DNS servers~n  ~p~ntimed out on request"
-                               " for ~p IN SRV."
-                               " You should check your DNS configuration.",
-                               [inet_db:res_option(nameserver), Server]),
+                    ?LOG_ERROR(#{event => s2s_dns_error,
+                                 text => <<"The DNS servers timed out on request for IN SRV."
+                                           " You should check your DNS configuration.">>,
+                                 nameserver => inet_db:res_option(nameserver),
+                                 server => Server}),
                     srv_lookup(Server, Timeout, Retries - 1);
                 R -> R
             end;
@@ -1055,10 +1043,12 @@ get_addrs(Host, Family) ->
            end,
     case inet:gethostbyname(Host, Type) of
         {ok, #hostent{h_addr_list = Addrs}} ->
-            ?DEBUG("~s of ~s resolved to: ~p~n", [Type, Host, Addrs]),
+            ?LOG_DEBUG(#{what => s2s_srv_resolve_success,
+                         type => Type, server => Host, addresses => Addrs}),
             Addrs;
         {error, Reason} ->
-            ?DEBUG("~s lookup of '~s' failed: ~p~n", [Type, Host, Reason]),
+            ?LOG_DEBUG(#{what => s2s_srv_resolve_failed,
+                         type => Type, server => Host, reason => Reason}),
             []
     end.
 
@@ -1112,8 +1102,9 @@ outgoing_s2s_timeout() ->
 log_s2s_out(false, _, _, _) -> ok;
 %% Log new outgoing connections:
 log_s2s_out(_, Myname, Server, Tls) ->
-    ?INFO_MSG("Trying to open s2s connection: ~s -> ~s with TLS=~p", [Myname, Server, Tls]).
-
+    ?LOG_INFO(#{event => s2s_out,
+                text => <<"Trying to open s2s connection">>,
+                myname => Myname, server => Server, tls => Tls}).
 
 %% @doc Calculate timeout depending on which state we are in:
 %% Can return integer > 0 | infinity
@@ -1299,8 +1290,9 @@ remove_addr_index(List) ->
 
 handle_parsed_features({false, false, _, StateData = #state{authenticated = true}}) ->
     send_queue(StateData, StateData#state.queue),
-    ?INFO_MSG("Connection established: ~s -> ~s",
-              [StateData#state.myname, StateData#state.server]),
+    ?LOG_INFO(#{what => s2s_out_connected,
+                text => <<"New outgoing s2s connection established">>,
+                myname => StateData#state.myname, server => StateData#state.server}),
     mongoose_hooks:s2s_connect_hook(StateData#state.myname,
                                     ok,
                                     StateData#state.server),
@@ -1324,8 +1316,8 @@ handle_parsed_features({_, true, _, StateData = #state{tls = true, tls_enabled =
     {next_state, wait_for_starttls_proceed, StateData,
      ?FSMTIMEOUT};
 handle_parsed_features({_, _, true, StateData = #state{tls = false}}) ->
-    ?DEBUG("restarted: ~p", [{StateData#state.myname,
-                              StateData#state.server}]),
+    ?LOG_DEBUG(#{what => s2s_out_restarted,
+                 myname => StateData#state.myname, server => StateData#state.server}),
     ejabberd_socket:close(StateData#state.socket),
     {next_state, reopen_socket,
      StateData#state{socket = undefined,
@@ -1333,9 +1325,25 @@ handle_parsed_features({_, _, true, StateData = #state{tls = false}}) ->
 handle_parsed_features({_, _, _, StateData = #state{db_enabled = true}}) ->
     send_db_request(StateData);
 handle_parsed_features({_, _, _, StateData}) ->
-    ?DEBUG("restarted: ~p", [{StateData#state.myname,
-                              StateData#state.server}]),
+    ?LOG_DEBUG(#{what => s2s_out_restarted,
+                 myname => StateData#state.myname, server => StateData#state.server}),
     % TODO: clear message queue
     ejabberd_socket:close(StateData#state.socket),
     {next_state, reopen_socket, StateData#state{socket = undefined,
                                                 use_v10 = false}, ?FSMTIMEOUT}.
+
+
+close_generic(StateName, Reason, StateData) ->
+    ?LOG_INFO(#{what => s2s_out_closing,
+                text => <<"Closing s2s connection">>,
+                state_name => StateName, reason => Reason,
+                myname => StateData#state.myname, server => StateData#state.server}),
+    {stop, normal, StateData}.
+
+close_generic(StateName, Reason, El, StateData) ->
+    ?LOG_INFO(#{what => s2s_out_closing,
+                text => <<"Closing s2s connection">>,
+                exml_packet => El,
+                state_name => StateName, reason => Reason,
+                myname => StateData#state.myname, server => StateData#state.server}),
+    {stop, normal, StateData}.

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -1004,7 +1004,7 @@ srv_lookup(Server, Timeout, Retries) ->
         {error, _Reason} ->
             case inet_res:getbyname("_jabber._tcp." ++ binary_to_list(Server), srv, Timeout) of
                 {error, timeout} ->
-                    ?LOG_ERROR(#{what => s2s_dns_error,
+                    ?LOG_ERROR(#{what => s2s_dns_lookup_failed,
                                  text => <<"The DNS servers timed out on request for IN SRV."
                                            " You should check your DNS configuration.">>,
                                  nameserver => inet_db:res_option(nameserver),

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -383,9 +383,7 @@ handle_info({'DOWN', Monitor, _Type, _Object, _Info}, _StateName, StateData)
   when Monitor == StateData#state.socket_monitor ->
     {stop, normal, StateData};
 handle_info(Info, StateName, StateData) ->
-    ?LOG_ERROR(#{what => unexpected_message,
-                 text => <<"Unexpected erlang message received by an external component process">>,
-                 msg => Info, component => component_host(StateData)}),
+    ?UNEXPECTED_INFO(Info),
     {next_state, StateName, StateData}.
 
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -198,22 +198,24 @@ route(From, To, Acc) ->
     route(From, To, Acc, mongoose_acc:element(Acc)).
 
 route(From, To, Acc, {broadcast, Payload}) ->
-    case (catch do_route(Acc, From, To, {broadcast, Payload})) of
-        {'EXIT', {Reason, StackTrace}} ->
-            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p~n~nreason=~p~n~n"
-            "broadcast=~p~n~nstack_trace=~p~n",
-                [jid:to_binary(From), jid:to_binary(To),
-                    ?MODULE, Reason, Payload, StackTrace]);
-        Acc1 -> Acc1
+    try
+        do_route(Acc, From, To, {broadcast, Payload})
+    catch Class:Reason:Stacktrace ->
+              ?LOG_ERROR(#{what => sm_route_failed,
+                           text => <<"Failed to route broadcast in ejabberd_sm">>,
+                           class => Class, reason => Reason, stacktrace => Stacktrace,
+                           payload => Payload, acc => Acc}),
+              Acc
     end;
 route(From, To, Acc, El) ->
-    case (catch do_route(Acc, From, To, El)) of
-        {'EXIT', {Reason, StackTrace}} ->
-            ?ERROR_MSG("error when routing from=~ts to=~ts in module=~p~n~nreason=~p~n~n"
-                       "packet=~ts~n~nstack_trace=~p~n",
-                       [jid:to_binary(From), jid:to_binary(To),
-                        ?MODULE, Reason, exml:to_binary(El), StackTrace]);
-        Acc1 -> Acc1
+    try
+        do_route(Acc, From, To, El)
+    catch Class:Reason:Stacktrace ->
+              ?LOG_ERROR(#{what => sm_route_failed,
+                           text => <<"Failed to route stanza in ejabberd_sm">>,
+                           class => Class, reason => Reason, stacktrace => Stacktrace,
+                           acc => Acc}),
+              Acc
     end.
 
 -spec open_session(SID, JID, Info) -> ReplacedPids when
@@ -531,8 +533,10 @@ hooks(Host) ->
 handle_call({node_cleanup, Node}, _From, State) ->
     BackendModule = sm_backend(),
     {TimeDiff, _R} = timer:tc(fun BackendModule:cleanup/1, [Node]),
-    ?INFO_MSG("sessions cleanup after node=~p, took=~pms",
-              [Node, erlang:round(TimeDiff / 1000)]),
+    ?LOG_INFO(#{what => sm_node_cleanup,
+                text => <<"Cleaning after a node that went down">>,
+                cleanup_node => Node,
+                duration => erlang:round(TimeDiff / 1000)}),
     {reply, ok, State};
 handle_call(_Request, _From, State) ->
     Reply = ok,
@@ -586,8 +590,10 @@ handle_info(_Info, State) ->
 terminate(_Reason, _State) ->
     try
         ejabberd_commands:unregister_commands(commands())
-    catch E:R:S ->
-        ?ERROR_MSG("Caught error while terminating sm: ~p:~p~n~p", [E, R, S])
+    catch Class:Reason:Stacktrace ->
+              ?LOG_ERROR(#{what => sm_terminate_failed,
+                           text => <<"Caught error while terminating SM">>,
+                           class => Class, reason => Reason, stacktrace => Stacktrace})
     end,
     ok.
 
@@ -645,14 +651,14 @@ do_filter(From, To, Packet) ->
     To :: jid:jid(),
     Payload :: exml:element() | ejabberd_c2s:broadcast().
 do_route(Acc, From, To, {broadcast, Payload} = Broadcast) ->
-    ?DEBUG("from=~p, to=~p, broadcast=~p", [From, To, Broadcast]),
+    ?LOG_DEBUG(#{what => sm_route_broadcast, acc => Acc, payload => Payload}),
     #jid{ luser = LUser, lserver = LServer, lresource = LResource} = To,
     case LResource of
         <<>> ->
             CurrentPids = get_user_present_pids(LUser, LServer),
             Acc1 = mongoose_hooks:sm_broadcast(To#jid.lserver, Acc, From, To,
                                                Broadcast, length(CurrentPids)),
-            ?DEBUG("bc_to=~p~n", [CurrentPids]),
+            ?LOG_DEBUG(#{what => sm_broadcast, session_pids => CurrentPids}),
             BCast = {broadcast, Payload},
             lists:foreach(fun({_, Pid}) -> Pid ! BCast end, CurrentPids),
             Acc1;
@@ -661,14 +667,13 @@ do_route(Acc, From, To, {broadcast, Payload} = Broadcast) ->
                 none ->
                     Acc; % do nothing
                 Pid when is_pid(Pid) ->
-                    ?DEBUG("sending to process ~p~n", [Pid]),
+                    ?LOG_DEBUG(#{what => sm_broadcast, session_pid => Pid}),
                     Pid ! Broadcast,
                     Acc
             end
     end;
 do_route(Acc, From, To, El) ->
-    ?DEBUG("session manager~n\tfrom ~p~n\tto ~p~n\tpacket ~P~n",
-           [From, To, Acc, 8]),
+    ?LOG_DEBUG(#{what => sm_route, acc => Acc}),
     #jid{lresource = LResource} = To,
     #xmlel{name = Name, attrs = Attrs} = El,
     case LResource of
@@ -681,7 +686,8 @@ do_route(Acc, From, To, El) ->
                     do_route_offline(Name, xml:get_attr_s(<<"type">>, Attrs),
                                      From, To, Acc, El);
                 Pid when is_pid(Pid) ->
-                    ?DEBUG("sending to process ~p~n", [Pid]),
+                    ?LOG_DEBUG(#{what => sm_route_to_pid,
+                                 session_pid => Pid, acc => Acc}),
                     Pid ! {route, From, To, Acc},
                     Acc
             end
@@ -764,7 +770,7 @@ do_route_offline(<<"message">>, _, From, To, Acc, Packet)  ->
         false ->
             route_message(From, To, Acc, Packet);
         true ->
-            ?DEBUG("issue=\"message droped\", to=~1000p", [To]),
+            ?LOG_DEBUG(#{what => sm_offline_dropped, acc => Acc}),
             Acc
     end;
 do_route_offline(<<"iq">>, <<"error">>, _From, _To, Acc, _Packet) ->
@@ -775,7 +781,7 @@ do_route_offline(<<"iq">>, _, From, To, Acc, Packet) ->
     {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
     ejabberd_router:route(To, From, Acc1, Err);
 do_route_offline(_, _, _, _, Acc, _) ->
-    ?DEBUG("packet droped~n", []),
+    ?LOG_DEBUG(#{what => sm_packet_dropped, acc => Acc}),
     Acc.
 
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -1092,114 +1092,72 @@ sm_backend() ->
 %%====================================================================
 %% Deprecated API
 %%====================================================================
-open_session(SID, U, S, R, Info) ->
+
+-define(FUNCTION_STRING,
+           ?MODULE_STRING ++ ":" ++
+              atom_to_list(?FUNCTION_NAME) ++ "/" ++
+                 integer_to_list(?FUNCTION_ARITY)).
+
+-define(DEPRICATE_FUNCTION,
     mongoose_deprecations:log(
       {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:open_session/5"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+      #{what => sm_function_deprecated,
+        text => <<"The function ", (list_to_binary(?FUNCTION_STRING))/binary,
+        " is deprecated, please use the #jid{} equivalent instead">>},
+      [{log_level, warning}])).
+
+open_session(SID, U, S, R, Info) ->
+    ?DEPRICATE_FUNCTION,
     open_session(SID, jid:make(U, S, R), undefined, Info).
 
 open_session(SID, U, S, R, Priority, Info) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:open_session/6"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     open_session(SID, jid:make(U, S, R), Priority, Info).
 
 close_session(Acc, SID, U, S, R, Reason) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:close_session/6"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     close_session(Acc, SID, jid:make(U, S, R), Reason).
 
 close_session_unset_presence(Acc, SID, U, S, R, Status, Reason) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:close_session_unset_presence/7"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     close_session_unset_presence(Acc, SID, jid:make(U, S, R), Status, Reason).
 
 unset_presence(Acc, SID, U, S, R, Status, Info) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:unset_presence/7"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     unset_presence(Acc, SID, jid:make(U, S, R), Status, Info).
 
 get_raw_sessions(U, S) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:get_raw_sessions/2"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     get_raw_sessions(jid:make(U, S, <<>>)).
 
 store_info(U, S, R, {Key, _Value} = KV) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:store_info/4"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     store_info(jid:make(U, S, R), {Key, _Value} = KV).
 
 set_presence(Acc, SID, U, S, R, Priority, Presence, Info) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:set_presence/8"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     set_presence(Acc, SID, jid:make(U, S, R), Priority, Presence, Info).
 
 remove_info(U, S, R, Key) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:remove_info/4"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     remove_info(jid:make(U, S, R), Key).
 
 get_user_resources(U, S) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:get_user_resources/2"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     get_user_resources(jid:make(U, S, <<>>)).
 
 get_session_pid(U, S, R) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:get_session_pid/3"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     get_session_pid(jid:make(U, S, R)).
 
 get_session(U, S, R) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:get_session/3"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     get_session(jid:make(U, S, R)).
 
 get_session_ip(U, S, R) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:get_session_ip/3"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     get_session_ip(jid:make(U, S, R)).
 
 get_user_present_resources(U, S) ->
-    mongoose_deprecations:log(
-      {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-      "The function ejabberd_sm:get_user_present_resources/2"
-      " is deprecated, please use the #jid{} equivalent instead",
-      [{log_level, warning}]),
+    ?DEPRICATE_FUNCTION,
     get_user_present_resources(jid:make(U, S, <<>>)).

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -1098,7 +1098,7 @@ sm_backend() ->
               atom_to_list(?FUNCTION_NAME) ++ "/" ++
                  integer_to_list(?FUNCTION_ARITY)).
 
--define(DEPRICATE_FUNCTION,
+-define(DEPRECATE_FUNCTION,
     mongoose_deprecations:log(
       {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
       #{what => sm_function_deprecated,
@@ -1107,57 +1107,57 @@ sm_backend() ->
       [{log_level, warning}])).
 
 open_session(SID, U, S, R, Info) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     open_session(SID, jid:make(U, S, R), undefined, Info).
 
 open_session(SID, U, S, R, Priority, Info) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     open_session(SID, jid:make(U, S, R), Priority, Info).
 
 close_session(Acc, SID, U, S, R, Reason) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     close_session(Acc, SID, jid:make(U, S, R), Reason).
 
 close_session_unset_presence(Acc, SID, U, S, R, Status, Reason) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     close_session_unset_presence(Acc, SID, jid:make(U, S, R), Status, Reason).
 
 unset_presence(Acc, SID, U, S, R, Status, Info) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     unset_presence(Acc, SID, jid:make(U, S, R), Status, Info).
 
 get_raw_sessions(U, S) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     get_raw_sessions(jid:make(U, S, <<>>)).
 
 store_info(U, S, R, {Key, _Value} = KV) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     store_info(jid:make(U, S, R), {Key, _Value} = KV).
 
 set_presence(Acc, SID, U, S, R, Priority, Presence, Info) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     set_presence(Acc, SID, jid:make(U, S, R), Priority, Presence, Info).
 
 remove_info(U, S, R, Key) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     remove_info(jid:make(U, S, R), Key).
 
 get_user_resources(U, S) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     get_user_resources(jid:make(U, S, <<>>)).
 
 get_session_pid(U, S, R) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     get_session_pid(jid:make(U, S, R)).
 
 get_session(U, S, R) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     get_session(jid:make(U, S, R)).
 
 get_session_ip(U, S, R) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     get_session_ip(jid:make(U, S, R)).
 
 get_user_present_resources(U, S) ->
-    ?DEPRICATE_FUNCTION,
+    ?DEPRECATE_FUNCTION,
     get_user_present_resources(jid:make(U, S, <<>>)).

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -28,8 +28,9 @@
 start(_Opts) ->
     %% Clean current node's sessions from previous life
     {Elapsed, RetVal} = timer:tc(?MODULE, cleanup, [node()]),
-    ?WARNING_MSG("cleanup on start took=~pms~n",
-                 [erlang:round(Elapsed / 1000)]),
+    ?LOG_NOTICE(#{what => sm_cleanup_initial,
+                  text => <<"SM cleanup on start took">>,
+                  duration => erlang:round(Elapsed / 1000)}),
     RetVal.
 
 

--- a/src/ejabberd_socket.erl
+++ b/src/ejabberd_socket.erl
@@ -229,10 +229,12 @@ send(SocketData, Data) ->
              SocketData#socket_state.socket, Data) of
         ok -> ok;
         {error, timeout} ->
-            ?INFO_MSG("Timeout on ~p:send", [SocketData#socket_state.sockmod]),
+            ?LOG_INFO(#{what => socket_error, reason => timeout,
+                        socket => SocketData#socket_state.sockmod}),
             exit(normal);
         Error ->
-            ?DEBUG("Error in ~p:send: ~p", [SocketData#socket_state.sockmod, Error]),
+            ?LOG_INFO(#{what => socket_error, reason => Error,
+                        socket => SocketData#socket_state.sockmod}),
             exit(normal)
     end.
 

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -178,8 +178,8 @@ start_child(ChildSpec) ->
             {ok, Pid};
         Other ->
             Stacktrace = element(2, erlang:process_info(self(), current_stacktrace)),
-            ?ERROR_MSG("event=start_child_failed, reason=~1000p spec=~1000p stacktrace=~1000p",
-                       [Other, ChildSpec, Stacktrace]),
+            ?LOG_ERROR(#{what => start_child_failed, spec => ChildSpec,
+                         reason => Other, stacktrace => Stacktrace}),
             erlang:error({start_child_failed, Other, ChildSpec})
     end.
 

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -135,7 +135,7 @@ handle_call(_, _From, State=#state{}) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 handle_cast(Msg, State) ->
-    ?WARNING_MSG("Strange message ~p.", [Msg]),
+    ?LOG_WARNING(#{what => unexpected_cast, cast_message => Msg}),
     {noreply, State}.
 
 
@@ -146,7 +146,7 @@ handle_cast(Msg, State) ->
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 handle_info(Msg, State) ->
-    ?WARNING_MSG("Strange message ~p.", [Msg]),
+    ?LOG_WARNING(#{what => unexpected_info, info_message => Msg}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -125,7 +125,8 @@ init([Host]) ->
 %%                                      {stop, Reason, State}
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
-handle_call(_, _From, State=#state{}) ->
+handle_call(Request, From, State=#state{}) ->
+    ?UNEXPECTED_CALL(Request, From),
     {reply, ok, State}.
 
 %%--------------------------------------------------------------------
@@ -135,7 +136,7 @@ handle_call(_, _From, State=#state{}) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, cast_message => Msg}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 
@@ -146,7 +147,7 @@ handle_cast(Msg, State) ->
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 handle_info(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_info, info_message => Msg}),
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -251,13 +251,8 @@ prepare_opt_val(Opt, Val, F, Default) ->
           end,
     case Res of
         {'EXIT', _} ->
-            ?ERROR_MSG("Configuration problem:~n"
-                      "** Option: ~p~n"
-                      "** Invalid value: ~p~n"
-                      "** Using as fallback: ~p",
-                      [ Opt,
-                        Val,
-                        Default]),
+            ?LOG_ERROR(#{what => configuration_error, option => Opt,
+                         value => Val, default => Default}),
             Default;
         _ ->
             Res

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -75,7 +75,7 @@
 %%--------------------------------------------------------------------
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
-    ?INFO_MSG("mod_event_pusher_push starting on host ~p", [Host]),
+    ?LOG_INFO(#{what => mod_event_pusher_push_starting, server => Host}),
 
     expand_and_store_virtual_pubsub_hosts(Host, Opts),
 

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -75,7 +75,7 @@
 %%--------------------------------------------------------------------
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
-    ?LOG_INFO(#{what => mod_event_pusher_push_starting, server => Host}),
+    ?LOG_INFO(#{what => event_pusher_starting, server => Host}),
 
     expand_and_store_virtual_pubsub_hosts(Host, Opts),
 

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -145,12 +145,9 @@ process_iq(Host, Module, Function, From, To, Acc, IQ) ->
         {Acc1, ResIQ} ->
             ejabberd_router:route(To, From, Acc1,
                                   jlib:iq_to_xml(ResIQ))
-    catch
-        Class:Reason:StackTrace ->
-            ?LOG_WARNING(#{what => process_iq_error,
-                           server => Host,
+    catch Class:Reason:StackTrace ->
+            ?LOG_WARNING(#{what => process_iq_error, server => Host, acc => Acc,
                            handler_module => Module, handler_function => Function,
-                           acc => Acc,
                            class => Class, reason => Reason, stacktrace => StackTrace}),
             Acc
     end.

--- a/src/gen_mod_deps.erl
+++ b/src/gen_mod_deps.erl
@@ -148,9 +148,9 @@ merge_args(Module, PreviousArgs, Args) ->
                       OldProplist;
 
                   {_, OldValue} ->
-                      ?WARNING_MSG("Overriding argument ~p for module ~p "
-                                   "with ~p.~n", [{Key, OldValue}, Module,
-                                                  {Key, Value}]),
+                      ?LOG_WARNING(#{what => overriding_argument, module => Module,
+                                     old_value => {Key, OldValue},
+                                     new_value => {Key, Value}}),
 
                       [Property | proplists:delete(Key, OldProplist)]
               end
@@ -204,13 +204,16 @@ process_dep(Module, DepModule, DepHardness, Graph) ->
         {{error, {bad_edge, CyclePath}}, hard} ->
             case find_soft_edge(Graph, CyclePath) of
                 false ->
-                    ?CRITICAL_MSG("Aborting resolving dependencies because of "
-                                  "module dependency cycle: ~p.~n", [CyclePath]),
+                    ?LOG_CRITICAL(#{what => resolving_dependencies_aborted,
+                                    text => <<"Module dependency cycle found">>,
+                                    cycle_path => CyclePath}),
                     error({dependency_cycle, CyclePath});
 
                 {EdgeId, B, A, _} ->
-                    ?INFO_MSG("Soft module dependency cycle detected: ~p. "
-                              "Dropping edge ~p -> ~p~n", [CyclePath, A, B]),
+                    ?LOG_INFO(#{what => soft_module_dependency_cycle_detected,
+                                text => <<"Soft module dependency cycle detected. "
+                                          "Dropping edge">>, edge => {A, B},
+                                cyclepath => CyclePath}),
 
                     digraph:del_edge(Graph, EdgeId),
                     ['$e' | _] = digraph:add_edge(Graph, DepModule, Module, hard),
@@ -218,8 +221,10 @@ process_dep(Module, DepModule, DepHardness, Graph) ->
             end;
 
         {{error, {bad_edge, CyclePath}}, _Soft} ->
-            ?INFO_MSG("Soft module dependency cycle detected: ~p. Dropping "
-                      "edge ~p -> ~p~n", [CyclePath, Module, DepModule]),
+            ?LOG_INFO(#{what => soft_module_dependency_cycle_detected,
+                        text => <<"Soft module dependency cycle detected. "
+                                  "Dropping edge">>, edge => {Module, DepModule},
+                        cyclepath => CyclePath}),
             ok
     end.
 

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -106,8 +106,9 @@ maybe_reroute({From, To, _, Packet} = FPacket) ->
             %% Continue routing with initialized metadata
             mongoose_hooks:mod_global_distrib_known_recipient(GlobalHost, ok,
                                                               From, To, LocalHost),
-            ?DEBUG("Routing global message id=~s from=~s to=~s to local datacenter local_host=~ts",
-                   [ID, jid:to_binary(From), jid:to_binary(To), LocalHost]),
+            ?LOG_DEBUG(#{what => gd_route_local,
+                         text => <<"Routing global message to local datacenter">>,
+                         gd_id => ID, local_host => LocalHost, acc => Acc}),
             {ok, TTL} = find_metadata(Acc, ttl),
             mongoose_metrics:update(global, ?GLOBAL_DISTRIB_DELIVERED_WITH_TTL, TTL),
             {From, To, Acc, Packet};
@@ -118,27 +119,28 @@ maybe_reroute({From, To, _, Packet} = FPacket) ->
             case find_metadata(Acc, ttl) of
                 {ok, 0} ->
                     %% Just continue routing
-                    ?INFO_MSG("event=ttl_zero gd_id=~s from=~s to=~s found_at=~s",
-                           [ID, jid:to_binary(From), jid:to_binary(To), TargetHost]),
+                    ?LOG_INFO(#{what => gd_route_ttl_zero,
+                                gd_id => ID, acc => Acc, target_host => TargetHost}),
                     mongoose_metrics:update(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, 1),
                     FPacket;
                 {ok, TTL} ->
                     %% Forward stanza to remote cluster using global distribution
-                    ?DEBUG("event=rerouting_global_message gd_id=~s from=~s to=~s to target_host=~s ttl=~B",
-                           [ID, jid:to_binary(From), jid:to_binary(To), TargetHost, TTL]),
+                    ?LOG_DEBUG(#{what => gd_reroute,
+                                 gd_id => ID, acc => Acc, target_host => TargetHost,
+                                 ttl => TTL}),
                     Acc1 = put_metadata(Acc, ttl, TTL - 1),
                     Acc2 = remove_metadata(Acc1, target_host_override),
                     %% KNOWN ISSUE: will crash loudly if there are no connections available
                     %% TODO: Discuss behaviour in such scenario
-                    Worker = get_bound_connection_noisy(TargetHost, ID, FPacket),
+                    Worker = get_bound_connection_noisy(TargetHost, ID, Acc2),
                     mod_global_distrib_sender:send(Worker, {From, To, Acc2, Packet}),
                     drop
             end;
 
         error ->
-            ?DEBUG("Unable to route global message gd_id=~s from=~s to=~s: "
-                   "user not found in the routing table",
-                   [ID, jid:to_binary(From), jid:to_binary(To)]),
+            ?LOG_DEBUG(#{what => gd_route_failed,
+                         text => <<"Unable to route global: user not found in the routing table">>,
+                         gd_id => ID, acc => Acc}),
             mongoose_hooks:mod_global_distrib_unknown_recipient(GlobalHost, {From, To, Acc, Packet})
     end.
 
@@ -147,24 +149,24 @@ maybe_reroute({From, To, _, Packet} = FPacket) ->
 %%--------------------------------------------------------------------
 
 -spec maybe_initialize_metadata({jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}) -> mongoose_acc:t().
-maybe_initialize_metadata({From, To, Acc, Packet}) ->
+maybe_initialize_metadata({_From, _To, Acc, _Packet}) ->
     case find_metadata(Acc, origin) of
         {error, undefined} ->
             Acc1 = put_metadata(Acc, ttl, opt(message_ttl)),
             ID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
             Acc2 = put_metadata(Acc1, id, ID),
-            ?DEBUG("event=gd_init_metadata gd_id=~s from=~p to=~p stanza=~p", [ID, From, To, Packet]),
+            ?LOG_DEBUG(#{what => gd_init_metadata, gd_id => ID, acc => Acc}),
             put_metadata(Acc2, origin, opt(local_host));
         _ ->
             Acc
     end.
 
-get_bound_connection_noisy(TargetHost, GDID, FPacket) ->
+get_bound_connection_noisy(TargetHost, GDID, Acc) ->
     try get_bound_connection(TargetHost, GDID)
     catch Class:Reason:Stacktrace ->
-              ?ERROR_MSG("event=gd_get_process_for_failed "
-                         "server=~ts gd_id=~s reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
-                           [TargetHost, GDID, Class, Reason, FPacket, Stacktrace]),
+              ?LOG_ERROR(#{what => gd_get_process_for_failed,
+                           gd_id => GDID, acc => Acc, target_host => TargetHost,
+                           class => Class, reason => Reason, stacktrace => Stacktrace}),
               erlang:raise(Class, Reason, Stacktrace)
     end.
 
@@ -176,15 +178,18 @@ get_bound_connection(Server, GDID) when is_binary(GDID) ->
 get_bound_connection(Server, GDID, undefined) ->
     Pid = mod_global_distrib_sender:get_process_for(Server),
     put({connection, Server}, Pid),
-    ?DEBUG("event=new_bound_connection server=~ts gd_id=~s pid=~p", [Server, GDID, Pid]),
+    ?LOG_DEBUG(#{what => gd_new_bound_connection,
+                 server => Server, gd_id => GDID, gd_pid => Pid}),
     Pid;
 get_bound_connection(Server, GDID, Pid) when is_pid(Pid) ->
     case is_process_alive(Pid) of
         false ->
-            ?DEBUG("event=dead_bound_connection server=~ts gd_id=~s pid=~p", [Server, GDID, Pid]),
+            ?LOG_DEBUG(#{what => gd_dead_bound_connection,
+                         server => Server, gd_id => GDID, gd_pid => Pid}),
             get_bound_connection(Server, GDID, undefined);
         true ->
-            ?DEBUG("event=reuse_bound_connection server=~ts gd_id=~s pid=~p", [Server, GDID, Pid]),
+            ?LOG_DEBUG(#{what => gd_reuse_bound_connection,
+                         server => Server, gd_id => GDID, gd_pid => Pid}),
             Pid
     end.
 

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -120,14 +120,15 @@ maybe_reroute({From, To, _, Packet} = FPacket) ->
                 {ok, 0} ->
                     %% Just continue routing
                     ?LOG_INFO(#{what => gd_route_ttl_zero,
+                                text => <<"Skip global distribution">>,
                                 gd_id => ID, acc => Acc, target_host => TargetHost}),
                     mongoose_metrics:update(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, 1),
                     FPacket;
                 {ok, TTL} ->
-                    %% Forward stanza to remote cluster using global distribution
-                    ?LOG_DEBUG(#{what => gd_reroute,
-                                 gd_id => ID, acc => Acc, target_host => TargetHost,
-                                 ttl => TTL}),
+                    ?LOG_DEBUG(#{what => gd_reroute, ttl => TTL,
+                                 text => <<"Forward stanza to remote cluster "
+                                           "using global distribution">>,
+                                 gd_id => ID, acc => Acc, target_host => TargetHost}),
                     Acc1 = put_metadata(Acc, ttl, TTL - 1),
                     Acc2 = remove_metadata(Acc1, target_host_override),
                     %% KNOWN ISSUE: will crash loudly if there are no connections available
@@ -138,9 +139,8 @@ maybe_reroute({From, To, _, Packet} = FPacket) ->
             end;
 
         error ->
-            ?LOG_DEBUG(#{what => gd_route_failed,
-                         text => <<"Unable to route global: user not found in the routing table">>,
-                         gd_id => ID, acc => Acc}),
+            ?LOG_DEBUG(#{what => gd_route_failed, gd_id => ID, acc => Acc,
+                         text => <<"Unable to route global: user not found in the routing table">>}),
             mongoose_hooks:mod_global_distrib_unknown_recipient(GlobalHost, {From, To, Acc, Packet})
     end.
 

--- a/src/global_distrib/mod_global_distrib_bounce.erl
+++ b/src/global_distrib/mod_global_distrib_bounce.erl
@@ -130,8 +130,7 @@ reroute_messages(Acc, From, To, TargetHost) ->
     ?LOG_IF(debug, StoredMessages =/= [],
             #{what => gd_route_stored,
               text => <<"Routing multiple previously stored messages">>,
-              stored_messages_length => length(StoredMessages),
-              from_jid => jid:to_binary(From), to_jid => jid:to_binary(To)}),
+              stored_messages_length => length(StoredMessages), acc => Acc}),
     lists:foreach(pa:bind(fun reroute_message/2, TargetHost), StoredMessages),
     Acc.
 

--- a/src/global_distrib/mod_global_distrib_bounce.erl
+++ b/src/global_distrib/mod_global_distrib_bounce.erl
@@ -96,9 +96,9 @@ maybe_store_message({From, To, Acc0, Packet} = FPacket) ->
             ?LOG_DEBUG(#{what => gd_skip_store_message,
                          text => <<"Not storing global message">>,
                          gd_id => ID, acc => Acc0, bounce_ttl => 0}),
-            ?LOG_ERROR_IF(To#jid.luser == <<>>,
-                          #{what => gd_message_to_component_ttl_zero,
-                            gd_id => ID, acc => Acc0}),
+            ?LOG_IF(error, To#jid.luser == <<>>,
+                    #{what => gd_message_to_component_ttl_zero,
+                      gd_id => ID, acc => Acc0}),
             mongoose_metrics:update(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, 1),
             FPacket;
         OldTTL ->
@@ -127,11 +127,11 @@ reroute_messages(Acc, From, To, TargetHost) ->
                   end
           end,
           ets:take(?MS_BY_TARGET, Key)),
-    ?LOG_DEBUG_IF(StoredMessages =/= [],
-                  #{what => gd_route_stored,
-                    text => <<"Routing multiple previously stored messages">>,
-                    stored_messages_length => length(StoredMessages),
-                    from_jid => jid:to_binary(From), to_jid => jid:to_binary(To)}),
+    ?LOG_IF(debug, StoredMessages =/= [],
+            #{what => gd_route_stored,
+              text => <<"Routing multiple previously stored messages">>,
+              stored_messages_length => length(StoredMessages),
+              from_jid => jid:to_binary(From), to_jid => jid:to_binary(To)}),
     lists:foreach(pa:bind(fun reroute_message/2, TargetHost), StoredMessages),
     Acc.
 

--- a/src/global_distrib/mod_global_distrib_bounce.erl
+++ b/src/global_distrib/mod_global_distrib_bounce.erl
@@ -93,19 +93,19 @@ maybe_store_message({From, To, Acc0, Packet} = FPacket) ->
         0 ->
             FromBin = jid:to_binary(From),
             ToBin = jid:to_binary(To),
-            ?DEBUG("Not storing global message id=~s from=~s to=~s as bounce_ttl=0",
-                   [ID, FromBin, ToBin]),
-            ?ERROR_MSG_IF(To#jid.luser == <<>>,
-                          "event=message_to_component_ttl_zero,id=~s,from=~s,to=~s",
-                          [ID, FromBin, ToBin]),
+            ?LOG_DEBUG(#{what => gd_skip_store_message,
+                         text => <<"Not storing global message">>,
+                         gd_id => ID, acc => Acc0, bounce_ttl => 0}),
+            ?LOG_ERROR_IF(To#jid.luser == <<>>,
+                          #{what => gd_message_to_component_ttl_zero,
+                            gd_id => ID, acc => Acc0}),
             mongoose_metrics:update(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, 1),
             FPacket;
         OldTTL ->
-            ?DEBUG("Storing global message id=~s from=~s to=~s to "
-                   "resend after ~B ms (bounce_ttl=~B)",
-                   [ID, jid:to_binary(From), jid:to_binary(To),
-                    erlang:convert_time_unit(opt(resend_after), native, millisecond),
-                    OldTTL]),
+            ?LOG_DEBUG(#{what => gd_store_message,
+                         text => <<"Storing global message">>,
+                         gd_id => ID, acc => Acc0, bounce_ttl => OldTTL,
+                         resend_after_ms => erlang:convert_time_unit(opt(resend_after), native, millisecond)}),
             Acc = mod_global_distrib:put_metadata(Acc0, {bounce_ttl, LocalHost}, OldTTL - 1),
             ResendAt = erlang:monotonic_time() + opt(resend_after),
             do_insert_in_store(ResendAt, {From, To, Acc, Packet}),
@@ -127,9 +127,11 @@ reroute_messages(Acc, From, To, TargetHost) ->
                   end
           end,
           ets:take(?MS_BY_TARGET, Key)),
-    ?DEBUG_IF(StoredMessages =/= [],
-              "Routing ~B previously stored messages addressed from ~s to ~s",
-              [length(StoredMessages), jid:to_binary(From), jid:to_binary(To)]),
+    ?LOG_DEBUG_IF(StoredMessages =/= [],
+                  #{what => gd_route_stored,
+                    text => <<"Routing multiple previously stored messages">>,
+                    stored_messages_length => length(StoredMessages),
+                    from_jid => jid:to_binary(From), to_jid => jid:to_binary(To)}),
     lists:foreach(pa:bind(fun reroute_message/2, TargetHost), StoredMessages),
     Acc.
 

--- a/src/global_distrib/mod_global_distrib_disco.erl
+++ b/src/global_distrib/mod_global_distrib_disco.erl
@@ -47,11 +47,13 @@ stop(Host) ->
                      -> {result, [exml:element()]} | {error, any()} | empty.
 get_disco_items({result, Nodes}, From, To, <<"">>, _Lang) ->
     Domains = domains_for_disco(To#jid.lserver, From),
-    ?DEBUG("event=domains_fetched_for_disco,domains=\"~p\",input_nodes=\"~p\"",
-           [Domains, Nodes]),
+    ?LOG_DEBUG(#{what => gd_domains_fetched_for_disco,
+                 domains => Domains, input_nodes => Nodes}),
     NameSet = gb_sets:from_list([exml_query:attr(Node, <<"jid">>) || Node <- Nodes]),
     FilteredDomains = [Domain || Domain <- Domains, not gb_sets:is_member(Domain, NameSet)],
-    ?DEBUG("Adding global domains ~p to disco results", [FilteredDomains]),
+    ?LOG_DEBUG(#{what => gd_get_disco_items_result,
+                 text => <<"Adding global domains to disco results">>,
+                 domains => FilteredDomains}),
     NewNodes =
         lists:foldl(
           fun(Domain, Acc) ->

--- a/src/global_distrib/mod_global_distrib_hosts_refresher.erl
+++ b/src/global_distrib/mod_global_distrib_hosts_refresher.erl
@@ -97,14 +97,11 @@ handle_call(unpause, _From, State = #state{tref = TRef}) ->
                  timer_ref => TRef}),
     {reply, ok, State};
 handle_call(Request, From, State) ->
-    ?LOG_ERROR(#{what => unexpected_call,
-                 text => <<"GD Refresher received unknown call.">>,
-                 msg => Request, call_from => From}),
+    ?UNEXPECTED_CALL(Request, From),
     {reply, {error, unknown_request}, State}.
 
 handle_cast(Request, State) ->
-    ?LOG_ERROR(#{what => unexpected_cast, msg => Request,
-                 text => <<"GD Refresher received unknown cast.">>}),
+    ?UNEXPECTED_CAST(Request),
     {noreply, State}.
 
 handle_info({timeout, TRef, refresh}, #state{ tref = TRef } = State) ->
@@ -115,8 +112,7 @@ handle_info({timeout, _, refresh}, State) ->
     %% We got refresh signal from outdated timer
     {noreply, State, hibernate};
 handle_info(Msg, State) ->
-    ?LOG_ERROR(#{what => unexpected_message, msg => Msg,
-                 text => <<"GD Refresher received unknown info message.">>}),
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State, hibernate}.
 
 terminate(Reason, _State) ->

--- a/src/global_distrib/mod_global_distrib_hosts_refresher.erl
+++ b/src/global_distrib/mod_global_distrib_hosts_refresher.erl
@@ -92,9 +92,8 @@ handle_call(pause, _From, State) ->
 handle_call(unpause, _From, State = #state{tref = undefined}) ->
     {reply, ok, schedule_refresh(State)};
 handle_call(unpause, _From, State = #state{tref = TRef}) ->
-    ?LOG_ERROR(#{what => gd_refresher_already_running,
-                 text => <<"GD Refresher received unpause, when already unpaused. Ignore.">>,
-                 timer_ref => TRef}),
+    ?LOG_ERROR(#{what => gd_refresher_already_running, timer_ref => TRef,
+                 text => <<"GD Refresher received unpause, when already unpaused. Ignore.">>}),
     {reply, ok, State};
 handle_call(Request, From, State) ->
     ?UNEXPECTED_CALL(Request, From),

--- a/src/global_distrib/mod_global_distrib_mapping.erl
+++ b/src/global_distrib/mod_global_distrib_mapping.erl
@@ -273,12 +273,12 @@ get_session(Key) ->
 
 -spec put_session(Key :: binary()) -> ok.
 put_session(Key) ->
-    ?DEBUG("event=put_session key=~ts", [Key]),
+    ?LOG_DEBUG(#{what => gd_mapper_put_session, key => Key}),
     mod_global_distrib_mapping_backend:put_session(Key).
 
 -spec delete_session(Key :: binary()) -> ok.
 delete_session(Key) ->
-    ?DEBUG("event=delete_session key=~ts", [Key]),
+    ?LOG_DEBUG(#{what => gd_mapper_delete_session, key => Key}),
     mod_global_distrib_mapping_backend:delete_session(Key).
 
 -spec get_domain(Key :: binary()) -> {ok, term()} | error.

--- a/src/global_distrib/mod_global_distrib_mapping_redis.erl
+++ b/src/global_distrib/mod_global_distrib_mapping_redis.erl
@@ -148,19 +148,19 @@ refresh_and_schedule_next(Reason, RefreshAfter) ->
 
 -spec refresh(Reason :: string()) -> ok.
 refresh(Reason) ->
-    ?DEBUG("event=refreshing_own_hosts", []),
+    ?LOG_DEBUG(#{what => gd_refreshing_own_hosts}),
     refresh_hosts(),
-    ?DEBUG("event=refreshing_own_nodes", []),
+    ?LOG_DEBUG(#{what => gd_refreshing_own_nodes}),
     refresh_nodes(),
-    ?DEBUG("event=refreshing_own_jids", []),
+    ?LOG_DEBUG(#{what => gd_refreshing_own_jids}),
     refresh_jids(),
-    ?DEBUG("event=refreshing_own_endpoints", []),
+    ?LOG_DEBUG(#{what => gd_refreshing_own_endpoints}),
     refresh_endpoints(),
-    ?DEBUG("event=refreshing_own_domains", []),
+    ?LOG_DEBUG(#{what => gd_refreshing_own_domains}),
     refresh_domains(),
-    ?DEBUG("event=refreshing_own_public_domains", []),
+    ?LOG_DEBUG(#{what => gd_refreshing_own_public_domains}),
     refresh_public_domains(),
-    ?INFO_MSG("event=refreshing_own_data_done,reason=~ts", [Reason]),
+    ?LOG_INFO(#{what => gd_refreshing_own_data_done, reason => Reason}),
     ok.
 
 %%--------------------------------------------------------------------
@@ -174,8 +174,8 @@ q(Args) ->
         {ok, _} = OKRes ->
             OKRes;
         Error ->
-            ?ERROR_MSG("event=redis_query_error,query='~p',error='~p'",
-                       [Args, Error]),
+            ?LOG_ERROR(#{what => gd_redis_query_error, worker => Worker,
+                         redis_query => Args, reason => Error}),
             error(Error)
     end.
 

--- a/src/global_distrib/mod_global_distrib_outgoing_conns_sup.erl
+++ b/src/global_distrib/mod_global_distrib_outgoing_conns_sup.erl
@@ -26,23 +26,18 @@ add_server(Server) ->
       type => supervisor,
       modules => dynamic
      },
-    ?LOG_INFO(#{what => gd_outgoing_conn_start_progress,
-                server => Server, state => starting}),
     case supervisor:start_child(?MODULE, ServerSupSpec) of
         {ok, Pid} ->
-            ?LOG_INFO(#{what => gd_outgoing_conn_start_progress,
-                        server => Server, gd_pid => Pid,
-                        state => started}),
+            ?LOG_INFO(#{what => gd_outgoing_conn_started,
+                        server => Server, gd_pid => Pid}),
             ok;
         {error, {already_started, Pid}} ->
-            ?LOG_INFO(#{what => gd_outgoing_conn_start_progress,
-                        server => Server, gd_pid => Pid,
-                        state => started_by_other}),
+            ?LOG_INFO(#{what => gd_outgoing_conn_already_started,
+                        server => Server, gd_pid => Pid}),
             ok;
         Error ->
-            ?LOG_ERROR(#{what => gd_outgoing_conn_start_progress,
-                         server => Server, reason => Error,
-                         state => start_failed}),
+            ?LOG_ERROR(#{what => gd_outgoing_conn_start_failed,
+                         server => Server, reason => Error}),
             Error
     end.
 

--- a/src/global_distrib/mod_global_distrib_outgoing_conns_sup.erl
+++ b/src/global_distrib/mod_global_distrib_outgoing_conns_sup.erl
@@ -26,19 +26,23 @@ add_server(Server) ->
       type => supervisor,
       modules => dynamic
      },
-    ?INFO_MSG("event=outgoing_conn_start_progress,server='~s',state='starting'", [Server]),
+    ?LOG_INFO(#{what => gd_outgoing_conn_start_progress,
+                server => Server, state => starting}),
     case supervisor:start_child(?MODULE, ServerSupSpec) of
         {ok, Pid} ->
-            ?INFO_MSG("event=outgoing_conn_start_progress,server='~s',"
-                      "state='started',pid='~p'", [Server, Pid]),
+            ?LOG_INFO(#{what => gd_outgoing_conn_start_progress,
+                        server => Server, gd_pid => Pid,
+                        state => started}),
             ok;
         {error, {already_started, Pid}} ->
-            ?INFO_MSG("event=outgoing_conn_start_progress,server='~s',"
-                      "state='started_by_other',pid='~p'", [Server, Pid]),
+            ?LOG_INFO(#{what => gd_outgoing_conn_start_progress,
+                        server => Server, gd_pid => Pid,
+                        state => started_by_other}),
             ok;
         Error ->
-            ?ERROR_MSG("event=outgoing_conn_start_progress,server='~s',"
-                       "state='failed',error='~p'", [Server, Error]),
+            ?LOG_ERROR(#{what => gd_outgoing_conn_start_progress,
+                         server => Server, reason => Error,
+                         state => start_failed}),
             Error
     end.
 
@@ -55,7 +59,7 @@ get_connection(Server) ->
 -spec get_connection(Server :: jid:lserver(), RetriesLeft :: non_neg_integer()) ->
     pid() | no_return().
 get_connection(Server, 0) ->
-    ?ERROR_MSG("event=cannot_acquire_outgoing_connection,server='~s'", [Server]),
+    ?LOG_ERROR(#{what => gd_cannot_acquire_outgoing_connection, server => Server}),
     throw({error, {cannot_acquire_outgoing_connection, Server}});
 get_connection(Server, RetriesLeft) ->
     case mod_global_distrib_server_sup:get_connection(Server) of

--- a/src/global_distrib/mod_global_distrib_receiver.erl
+++ b/src/global_distrib/mod_global_distrib_receiver.erl
@@ -90,12 +90,16 @@ handle_info({tcp, _Socket, RawData}, #state{socket = Socket, buffer = Buffer} = 
 handle_info({tcp_closed, _Socket}, State) ->
     {stop, normal, State};
 handle_info({tcp_error, _Socket, Reason}, State) ->
-    ?ERROR_MSG("event=incoming_global_distrib_socket_error,reason='~p',peer='~p', conn_id=~ts",
-               [Reason, State#state.peer, State#state.conn_id]),
+    ?LOG_ERROR(#{what => gd_incoming_socket_error,
+                 text => <<"mod_global_distrib_receiver received tcp_error">>,
+                 reason => Reason,
+                 peer => State#state.peer, conn_id => State#state.conn_id}),
     mongoose_metrics:update(global, ?GLOBAL_DISTRIB_INCOMING_ERRORED(State#state.host), 1),
     {stop, {error, Reason}, State};
 handle_info(Msg, State) ->
-    ?WARNING_MSG("Received unknown message ~p", [Msg]),
+    ?LOG_WARNING(#{what => unknown_message,
+                   text => <<"mod_global_distrib_receiver received unknown erlang message">>,
+                   msg => Msg}),
     {noreply, State}.
 
 handle_cast(_Message, _State) ->
@@ -108,8 +112,9 @@ code_change(_Version, State, _Extra) ->
     {ok, State}.
 
 terminate(Reason, State) ->
-    ?WARNING_MSG("event=incoming_global_distrib_socket_closed,peer='~p', host=~p, reason=~p conn_id=~ts",
-                 [State#state.peer, State#state.host, Reason, State#state.conn_id]),
+    ?LOG_WARNING(#{what => gd_incoming_socket_closed,
+                   peer => State#state.peer, server => State#state.host,
+                   reason => Reason, conn_id => State#state.conn_id}),
     mongoose_metrics:update(global, ?GLOBAL_DISTRIB_INCOMING_CLOSED(State#state.host), 1),
     catch mod_global_distrib_transport:close(State#state.socket),
     ignore.
@@ -185,8 +190,7 @@ handle_data(GdStart, State = #state{host = undefined}) ->
     mod_global_distrib_utils:ensure_metric(
       ?GLOBAL_DISTRIB_INCOMING_CLOSED(Host), spiral),
     mongoose_metrics:update(global, ?GLOBAL_DISTRIB_INCOMING_FIRST_PACKET(Host), 1),
-    ?INFO_MSG("event=gd_incoming_connection server=~ts conn_id=~ts",
-              [BinHost, ConnId]),
+    ?LOG_INFO(#{what => gd_incoming_connection, server => BinHost, conn_id => ConnId}),
     State#state{host = Host, conn_id = ConnId};
 handle_data(Data, State = #state{host = Host}) ->
     <<ClockTime:64, BinFromSize:16, _/binary>> = Data,
@@ -221,12 +225,13 @@ start_listeners() ->
 -spec start_listener(mod_global_distrib_utils:endpoint(),
                      RetriesLeft :: non_neg_integer()) -> any().
 start_listener({Addr, Port} = Ref, RetriesLeft) ->
-    ?INFO_MSG("Starting listener on ~s:~b", [inet:ntoa(Addr), Port]),
+    ?LOG_INFO(#{what => gd_start_listener, address => Addr, port => Port}),
     case ranch:start_listener(Ref, 10, ranch_tcp, [{ip, Addr}, {port, Port}], ?MODULE, []) of
         {ok, _} -> ok;
         {error, eaddrinuse} when RetriesLeft > 0 ->
-            ?ERROR_MSG("Failed to start listener on ~s:~b: address in use. Will retry in 1 second.",
-                       [inet:ntoa(Addr), Port]),
+            ?LOG_ERROR(#{what => gd_start_listener_failed,
+                         text => <<"Failed to start listener: address in use. Will retry in 1 second.">>,
+                         address => Addr, port => Port}),
             timer:sleep(?LISTEN_RETRY_DELAY),
             start_listener(Ref, RetriesLeft - 1)
     end.

--- a/src/global_distrib/mod_global_distrib_sender.erl
+++ b/src/global_distrib/mod_global_distrib_sender.erl
@@ -31,14 +31,14 @@
 
 
 -spec send(jid:lserver() | pid(), {jid:jid(), jid:jid(), mongoose_acc:t(), xmlel:packet()}) -> ok.
-send(Server, Packet) when is_binary(Server) ->
+send(Server, {_,_, Acc, _} = Packet) when is_binary(Server) ->
     try get_process_for(Server) of
         Worker ->
            send(Worker, Packet)
     catch Class:Reason:Stacktrace ->
-              ?ERROR_MSG("event=gd_get_process_for_failed server=~ts "
-                         "reason=~p:~1000p  packet=~1000p stacktrace=~1000p",
-                           [Server, Class, Reason, Packet, Stacktrace]),
+              ?LOG_ERROR(#{what => gd_get_process_for_failed, server => Server,
+                           class => Class, reason => Reason, stacktrace => Stacktrace,
+                           acc => Acc}),
               erlang:raise(Class, Reason, Stacktrace)
     end;
 send(Worker, {From, _To, _Acc, _Packet} = FPacket) ->

--- a/src/global_distrib/mod_global_distrib_sender.erl
+++ b/src/global_distrib/mod_global_distrib_sender.erl
@@ -36,9 +36,8 @@ send(Server, {_,_, Acc, _} = Packet) when is_binary(Server) ->
         Worker ->
            send(Worker, Packet)
     catch Class:Reason:Stacktrace ->
-              ?LOG_ERROR(#{what => gd_get_process_for_failed, server => Server,
-                           class => Class, reason => Reason, stacktrace => Stacktrace,
-                           acc => Acc}),
+              ?LOG_ERROR(#{what => gd_get_process_for_failed, server => Server, acc => Acc,
+                           class => Class, reason => Reason, stacktrace => Stacktrace}),
               erlang:raise(Class, Reason, Stacktrace)
     end;
 send(Worker, {From, _To, _Acc, _Packet} = FPacket) ->

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -426,12 +426,10 @@ resolve_pending([MaybeToEnable | RNewEndpoints], OldEnabled) ->
 -spec log_endpoints_changes(Server :: jid:lserver(),
                             EndpointsChanges :: endpoints_changes(), term()) -> any().
 log_endpoints_changes(Server, [], State) ->
-    ?LOG_DEBUG(ls(#{what => gd_same_endpoints,
-                    server => Server,
+    ?LOG_DEBUG(ls(#{what => gd_same_endpoints, server => Server,
                     text => <<"No endpoint changes">>}, State));
 log_endpoints_changes(Server, EndpointsChanges, State) ->
-    ?LOG_INFO(ls(#{what => gd_endpoints_changes,
-                   server => Server,
+    ?LOG_INFO(ls(#{what => gd_endpoints_changes, server => Server,
                    to_enable => [ E || {enable, E} <- EndpointsChanges ],
                    to_disable => [ E || {disable, E} <- EndpointsChanges ]}, State)).
 

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -173,9 +173,7 @@ handle_cast({call_timeout, FromPid, Msg}, State) ->
                       caller_pid => FromPid, caller_msg => Msg}, State)),
     {noreply, State};
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(ls(#{what => unexpected_cast,
-                      text => <<"mod_global_distrib_server_mgr received unknown erlang message">>,
-                      msg => Msg}, State)),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 handle_info(refresh, State) ->
@@ -296,8 +294,7 @@ handle_info({'DOWN', MonitorRef, _Type, Pid, Reason}, #state{ enabled = Enabled,
                    type => Type, endpoint => Endpoint, reason => Reason2}, State)),
     {noreply, NState};
 handle_info(Msg, State) ->
-    ?LOG_WARNING(ls(#{what => unexpected_message, msg => Msg,
-                      text => <<"GD server manager receives unknown erlang message">>}, State)),
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -137,8 +137,7 @@ init([Server, Supervisor]) ->
     schedule_refresh(State2),
     schedule_gc(State2),
 
-    ?INFO_MSG("event=mgr_started,pid='~p',server='~p',supervisor='~p',refresh_interval=~p",
-              [self(), Server, Supervisor, RefreshInterval]),
+    ?LOG_INFO(ls(#{what => gd_mgr_started}, State2)),
     {ok, State2}.
 
 handle_call(get_connection_pool, From, #state{ enabled = [],
@@ -170,11 +169,13 @@ handle_call(get_state_info, _From, State) ->
     {reply, state_info(State), State}.
 
 handle_cast({call_timeout, FromPid, Msg}, State) ->
-    ?WARNING_MSG("event=mgr_timeout, caller_pid=~p, caller_msg=~p state_info=~1000p",
-                 [FromPid, Msg, state_info(State)]),
+    ?LOG_WARNING(ls(#{what => gd_mgr_call_timeout,
+                      caller_pid => FromPid, caller_msg => Msg}, State)),
     {noreply, State};
 handle_cast(Msg, State) ->
-    ?WARNING_MSG("event=unknown_msg,msg='~p'", [Msg]),
+    ?LOG_WARNING(ls(#{what => unexpected_cast,
+                      text => <<"mod_global_distrib_server_mgr received unknown erlang message">>,
+                      msg => Msg}, State)),
     {noreply, State}.
 
 handle_info(refresh, State) ->
@@ -186,10 +187,10 @@ handle_info(refresh, State) ->
         true ->
             ok;
         _ ->
-            ?INFO_MSG("event=gd_mgr_refresh refresh_interval=~p "
-                      "pending_endpoints_before=~p pending_endpoints_after=~p",
-                      [State#state.refresh_interval,
-                       State#state.pending_endpoints, State2#state.pending_endpoints])
+            ?LOG_INFO(ls(#{what => gd_mgr_refresh,
+                           text => <<"A list of pending_endpoints has changed in GD server manager">>,
+                           pending_endpoints_before => State#state.pending_endpoints,
+                           pending_endpoints_after => State2#state.pending_endpoints}, State))
     end,
     schedule_refresh(State2),
     {noreply, State2};
@@ -208,8 +209,9 @@ handle_info(disabled_gc, #state{ disabled = Disabled } = State) ->
         [] ->
             ok;
         _ ->
-            ?INFO_MSG("event=gd_mgr_disabled_gc stopped_endpoints=~p gc_interval=~p",
-                      [StoppedEndpoints, State#state.gc_interval])
+            ?LOG_INFO(ls(#{what => gd_mgr_disabled_gc,
+                           text => <<"GD server manager stops some inactive endpoints">>,
+                           stopped_endpoints => StoppedEndpoints}, State))
     end,
     schedule_gc(State),
     {noreply, State};
@@ -233,12 +235,14 @@ handle_info(process_pending_endpoint,
     State2 =
     case catch enable(Endpoint, State) of
         {ok, NState0} ->
-            ?INFO_MSG("event=endpoint_enabled,endpoint='~p',server='~s'",
-                      [Endpoint, State#state.server]),
+            ?LOG_INFO(ls(#{what => gd_endpoint_enabled,
+                           text => <<"GD server manager enables pending endpoint">>,
+                           endpoint => Endpoint}, State)),
             NState0;
         Error ->
-            ?ERROR_MSG("event=cannot_enable_endpoint,endpoint='~p',server='~s',error='~p'",
-                       [Endpoint, State#state.server, Error]),
+            ?LOG_ERROR(ls(#{what => gd_endpoint_enabling_failed,
+                            text => <<"GD server manager cannot enable endpoint">>,
+                            endpoint => Endpoint, reason => Error}, State)),
             State
     end,
 
@@ -252,12 +256,14 @@ handle_info(process_pending_endpoint,
     State2 =
     case catch disable(Endpoint, State) of
         {ok, NState0} ->
-            ?INFO_MSG("event=endpoint_disabled,endpoint='~p',server='~s'",
-                      [Endpoint, State#state.server]),
+            ?LOG_INFO(ls(#{what => gd_endpoint_disabled,
+                           text => <<"GD server manager disables pending endpoint">>,
+                           endpoint => Endpoint}, State)),
             NState0;
         Error ->
-            ?ERROR_MSG("event=cannot_disable_endpoint,endpoint='~p',server='~s',error='~p'",
-                       [Endpoint, State#state.server, Error]),
+            ?LOG_ERROR(ls(#{what => gd_endpoint_disabling_failed,
+                            text => <<"GD server manager cannot disable endpoint">>,
+                            endpoint => Endpoint, reason => Error}, State)),
             State
     end,
 
@@ -280,17 +286,18 @@ handle_info({'DOWN', MonitorRef, _Type, Pid, Reason}, #state{ enabled = Enabled,
             end
     end,
 
-    case Reason of
-        ItsFine when ItsFine == normal; ItsFine == shutdown ->
-            ?INFO_MSG("event=endpoint_closed,endpoint='~p',type=~p,reason='normal'",
-                      [Endpoint, Type]);
-        _Other ->
-            ?ERROR_MSG("event=endpoint_closed,endpoint='~p',type=~p,reason='~p'",
-                       [Endpoint, Type, Reason])
-    end,
+    Reason2 =
+        case Reason of
+            shutdown -> normal;
+            _Other -> Reason
+        end,
+    ?LOG_INFO(ls(#{what => gd_endpoint_closed,
+                   text => <<"Disconnected from a GD endpoint">>,
+                   type => Type, endpoint => Endpoint, reason => Reason2}, State)),
     {noreply, NState};
 handle_info(Msg, State) ->
-    ?WARNING_MSG("event=unknown_msg,msg='~p'", [Msg]),
+    ?LOG_WARNING(ls(#{what => unexpected_message, msg => Msg,
+                      text => <<"GD server manager receives unknown erlang message">>}, State)),
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -361,19 +368,20 @@ pick_connection_pool(Enabled) ->
 -spec refresh_connections(State :: state()) -> state().
 refresh_connections(#state{ server = Server, pending_endpoints = PendingEndpoints,
                             last_endpoints = LastEndpoints } = State) ->
-    ?DEBUG("event=refreshing_endpoints,server='~s'", [Server]),
+    ?LOG_DEBUG(ls(#{what => gd_refreshing_endpoints}, State)),
     {ok, NewEndpoints} = get_endpoints(Server),
     case NewEndpoints of
         LastEndpoints ->
             nothing_new;
         _ ->
-            ?INFO_MSG("event=endpoints_change old_endpoints=~p new_endpoints=~p",
-                      [LastEndpoints, NewEndpoints])
+            ?LOG_INFO(ls(#{what => gd_endpoints_change,
+                           old_endpoints => LastEndpoints,
+                           new_endpoints => NewEndpoints}, State))
     end,
-    ?DEBUG("event=fetched_endpoints,server='~s',result='~p'", [Server, NewEndpoints]),
+    ?LOG_DEBUG(ls(#{what => gd_fetched_endpoints, fetched_endpoints => NewEndpoints}, State)),
 
     NPendingEndpoints = resolve_pending(NewEndpoints, State#state.enabled),
-    log_endpoints_changes(Server, NPendingEndpoints),
+    log_endpoints_changes(Server, NPendingEndpoints, State),
 
     case PendingEndpoints of
         [] -> maybe_schedule_process_endpoint(NPendingEndpoints);
@@ -386,8 +394,12 @@ refresh_connections(#state{ server = Server, pending_endpoints = PendingEndpoint
         [] ->
             no_log;
         _ ->
-            ?DEBUG("event=endpoints_update_scheduled,server='~s',new_changes=~p,pending_changes=~p",
-                   [Server, length(NPendingEndpoints), length(FinalPendingEndpoints)])
+            ?LOG_DEBUG(ls(#{what => gd_endpoints_update_scheduled,
+                            new_changes => NPendingEndpoints,
+                            pending_changes => FinalPendingEndpoints,
+                            new_changes_length => length(NPendingEndpoints),
+                            pending_changes_length => length(FinalPendingEndpoints)},
+                          State))
     end,
     State#state{ pending_endpoints = FinalPendingEndpoints, last_endpoints = NewEndpoints }.
 
@@ -415,13 +427,16 @@ resolve_pending([MaybeToEnable | RNewEndpoints], OldEnabled) ->
     end.
 
 -spec log_endpoints_changes(Server :: jid:lserver(),
-                            EndpointsChanges :: endpoints_changes()) -> any().
-log_endpoints_changes(Server, []) ->
-    ?DEBUG("event=endpoints_changes,server='~s',to_enable='[]',to_disable='[]'", [Server]);
-log_endpoints_changes(Server, EndpointsChanges) ->
-    ?INFO_MSG("event=endpoints_changes,server='~s',to_enable='~p',to_disable='~p'",
-              [Server, [ E || {enable, E} <- EndpointsChanges ],
-                       [ E || {disable, E} <- EndpointsChanges ]]).
+                            EndpointsChanges :: endpoints_changes(), term()) -> any().
+log_endpoints_changes(Server, [], State) ->
+    ?LOG_DEBUG(ls(#{what => gd_same_endpoints,
+                    server => Server,
+                    text => <<"No endpoint changes">>}, State));
+log_endpoints_changes(Server, EndpointsChanges, State) ->
+    ?LOG_INFO(ls(#{what => gd_endpoints_changes,
+                   server => Server,
+                   to_enable => [ E || {enable, E} <- EndpointsChanges ],
+                   to_disable => [ E || {disable, E} <- EndpointsChanges ]}, State)).
 
 -spec enable(Endpoint :: endpoint(), State :: state()) -> {ok, state()} | {error, any()}.
 enable(Endpoint, #state{ disabled = Disabled, supervisor = Supervisor,
@@ -457,8 +472,9 @@ stop_disabled(Endpoint, State) ->
         ok ->
             ok;
         Error ->
-            ?ERROR_MSG("event=cannot_close_disabled_connection,endpoint='~p',error='~p'",
-                       [Endpoint, Error])
+            ?LOG_ERROR(ls(#{what => gd_cannot_close_disabled_connection,
+                            reason => Error, endpoint => Endpoint},
+                          State))
     end.
 
 state_info(#state{
@@ -474,15 +490,19 @@ state_info(#state{
           pending_endpoints_listeners = PendingEndpointsListeners,
           last_endpoints = LastEndpoints
          }) ->
-    [{server, Server},
-     {supervisor, Supervisor},
-     {enabled, Enabled},
-     {disabled, Disabled},
-     {pending_endpoints, PendingEndpoints},
-     {pending_gets, PendingGets},
-     {refresh_interval, RefreshInterval},
-     {refresh_interval_when_disconnected, DisRefreshInterval},
-     {gc_interval, GCInterval},
-     {pending_endpoints_listeners, PendingEndpointsListeners},
-     {last_endpoints, LastEndpoints}].
+    #{server => Server,
+      supervisor => Supervisor,
+      enabled => Enabled,
+      disabled => Disabled,
+      pending_endpoints => PendingEndpoints,
+      pending_gets => PendingGets,
+      refresh_interval => RefreshInterval,
+      refresh_interval_when_disconnected => DisRefreshInterval,
+      gc_interval => GCInterval,
+      pending_endpoints_listeners => PendingEndpointsListeners,
+      last_endpoints => LastEndpoints}.
 
+
+%% Log State
+ls(LogMeta, State) ->
+    maps:merge(state_info(State), LogMeta).

--- a/src/global_distrib/mod_global_distrib_server_sup.erl
+++ b/src/global_distrib/mod_global_distrib_server_sup.erl
@@ -40,9 +40,8 @@ get_connection(Server) ->
         %% - {'EXIT', {noproc, _}}
         %%  - {case_clause,{'EXIT',{no_connections...
     catch Class:Reason:Stacktrace ->
-            ?ERROR_MSG("event=get_gd_connection_failed "
-                       "server=~ts reason=~p:~p stacktrace=~1000p",
-                       [Server, Class, Reason, Stacktrace]),
+            ?LOG_ERROR(#{what => gd_get_connection_failed, server => Server,
+                         class => Class, reason => Reason, stacktrace => Stacktrace}),
             %% May be caused by missing server_sup or missing connection manager
             %% The former occurs when a process tries to send a message to Server
             %% for the first time.

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -168,9 +168,9 @@ resolve_endpoint({Addr, Port}) ->
     case to_ip_tuples(Addr) of
         {ok, IpAddrs} ->
             Resolved = [{IpAddr, Port} || IpAddr <- IpAddrs],
-            ?LOG_INFO_IF(is_domain(Addr), #{what => gd_resolve_endpoint,
-                                            text => <<"GD resolved address to IPs">>,
-                                            address => Addr, ip_addresses => IpAddrs}),
+            ?LOG_IF(info, is_domain(Addr), #{what => gd_resolve_endpoint,
+                                             text => <<"GD resolved address to IPs">>,
+                                             address => Addr, ip_addresses => IpAddrs}),
             Resolved;
         {error, {Reasonv6, Reasonv4}} ->
             ?LOG_ERROR(#{what => gd_resolve_endpoint_failed,

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -273,14 +273,12 @@ to_ip_tuples(Addr) ->
         {{error, Reason6}, {error, Reason4}} ->
             {error, {Reason6, Reason4}};
         {Addrs, {error, Msg}} ->
-            ?LOG_DEBUG(#{what => resolv_error,
-                         text => <<"IPv4 address resolution error">>,
-                         address => Addr, reason => Msg}),
+            ?LOG_DEBUG(#{what => resolv_error, address => Addr, reason => Msg,
+                         text => <<"IPv4 address resolution error">>}),
             Addrs;
         {{error, Msg}, Addrs} ->
-            ?LOG_DEBUG(#{what => resolv_error,
-                         text => <<"IPv6 address resolution error">>,
-                         address => Addr, reason => Msg}),
+            ?LOG_DEBUG(#{what => resolv_error, address => Addr, reason => Msg,
+                         text => <<"IPv6 address resolution error">>}),
             Addrs;
         {{ok, Addrs6}, {ok, Addrs4}} ->
             {ok, Addrs6 ++ Addrs4}

--- a/src/global_distrib/mod_global_distrib_worker.erl
+++ b/src/global_distrib/mod_global_distrib_worker.erl
@@ -80,7 +80,6 @@ terminate(_Reason, _State) ->
 do_work(Data) ->
     {From, To, Acc, Packet} = erlang:binary_to_term(Data),
     mod_global_distrib_utils:maybe_update_mapping(From, Acc),
-    ?LOG_DEBUG(#{what => gd_route_incoming,
-                 gd_id => mod_global_distrib:get_metadata(Acc, id, "unknown"),
-                 acc => Acc}),
+    ?LOG_DEBUG(#{what => gd_route_incoming, acc => Acc,
+                 gd_id => mod_global_distrib:get_metadata(Acc, id, "unknown")}),
     ejabberd_router:route(From, To, Acc, Packet).

--- a/src/global_distrib/mod_global_distrib_worker.erl
+++ b/src/global_distrib/mod_global_distrib_worker.erl
@@ -80,7 +80,7 @@ terminate(_Reason, _State) ->
 do_work(Data) ->
     {From, To, Acc, Packet} = erlang:binary_to_term(Data),
     mod_global_distrib_utils:maybe_update_mapping(From, Acc),
-    ?DEBUG("event=route_incoming_gd,id=~s,stanza=~s",
-           [mod_global_distrib:get_metadata(Acc, id, "unknown"),
-            exml:to_binary(mongoose_acc:element(Acc))]),
+    ?LOG_DEBUG(#{what => gd_route_incoming,
+                 gd_id => mod_global_distrib:get_metadata(Acc, id, "unknown"),
+                 acc => Acc}),
     ejabberd_router:route(From, To, Acc, Packet).

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -142,9 +142,8 @@ is_system_message(Sender, Receiver, Packet) ->
         {MUCLightDomain, _RoomUser} ->
             false;
         Other ->
-            ?LOG_WARNING(#{what => unknown_message_for_mod_inbox_muclight,
-                           sender => jid:to_binary(Sender), receiver => jid:to_binary(Receiver),
-                           packet => Packet})
+            ?LOG_WARNING(#{what => inbox_muclight_unknown_message, packet => Packet,
+                           sender => jid:to_binary(Sender), receiver => jid:to_binary(Receiver)})
     end.
 
 

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -69,7 +69,8 @@ handle_system_message(Host, Room, Remote, Packet) ->
         invite ->
             handle_invitation_message(Host, Room, Remote, Packet);
         other ->
-            ?DEBUG("event=irrelevant_system_message_for_mod_inbox_muclight,stanza='~p'", [Packet]),
+            ?LOG_DEBUG(#{what => irrelevant_system_message_for_mod_inbox_muclight,
+                         room => Room, exml_packet => Packet}),
             ok
     end.
 
@@ -141,8 +142,9 @@ is_system_message(Sender, Receiver, Packet) ->
         {MUCLightDomain, _RoomUser} ->
             false;
         Other ->
-            ?WARNING_MSG("event=unknown_message_for_mod_inbox_muclight,packet='~p',error='~p'",
-                         [Packet, Other])
+            ?LOG_WARNING(#{what => unknown_message_for_mod_inbox_muclight,
+                           sender => jid:to_binary(Sender), receiver => jid:to_binary(Receiver),
+                           packet => Packet})
     end.
 
 

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -31,7 +31,7 @@
                              sip_reinvite_unsafe/2,
                              sip_bye/2,
                              sip_cancel/3,
-                             send_ringing_session_info/1,
+                             send_ringing_session_info/2,
                              invite_resp_callback/1
                              ]}).
 
@@ -48,8 +48,10 @@ sip_invite(Req, Call) ->
     try
         sip_invite_unsafe(Req, Call)
     catch Class:Reason:StackTrace ->
-            ?WARNING_MSG("Error parsing sip invite, class=~p, reason=~p, stacktrace=~p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_WARNING(#{what => sip_invite_failed,
+                             text => <<"Error parsing sip invite">>,
+                             sip_req => Req,
+                             class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, request_not_parsable}
     end.
 
@@ -57,8 +59,10 @@ sip_reinvite(Req, Call) ->
     try
         sip_reinvite_unsafe(Req, Call)
     catch Class:Reason:StackTrace ->
-            ?WARNING_MSG("Error parsing sip invite, class=~p, reason=~p, stacktrace=~p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_WARNING(#{what => sip_reinvite_failed,
+                             text => <<"Error parsing sip reinvite">>,
+                             sip_req => Req,
+                             class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, request_not_parsable}
     end.
 
@@ -71,6 +75,12 @@ sip_invite_unsafe(Req, _Call) ->
         false ->
             translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary);
         _ ->
+            CallID = nksip_sipmsg:header(<<"call-id">>, Req),
+            ?LOG_INFO(#{what => sip_invite,
+                        text => <<"Got SIP INVITE from NkSIP, but destination user is offline">>,
+                        reply => temporarily_unavailable,
+                        from_jid => FromBinary, to_jid => ToBinary,
+                        call_id => CallID, sip_req => Req}),
             {reply, temporarily_unavailable}
     end.
 
@@ -90,6 +100,11 @@ translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary) ->
 
     ok = mod_jingle_sip_backend:set_incoming_request(CallID, ReqID, FromJID, ToJID, JingleEl),
 
+    ?LOG_INFO(#{what => sip_invite,
+                text => <<"Got SIP INVITE from NkSIP">>,
+                from_jid => FromBinary, to_jid => ToBinary,
+                call_id => CallID, sip_req => Req}),
+
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => FromJID#jid.lserver,
@@ -100,8 +115,8 @@ translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary) ->
 
     {reply, ringing}.
 
-sip_reinvite_unsafe(Req, _Call) ->
-    ?INFO_MSG("re-INVITE: ~p", [Req]),
+sip_reinvite_unsafe(Req, Call) ->
+    ?LOG_INFO(#{what => sip_reinvite, sip_req => Req}),
     {FromJID, FromBinary} = get_user_from_sip_msg(from, Req),
     {ToJID, ToBinary} = get_user_from_sip_msg(to, Req),
 
@@ -115,6 +130,12 @@ sip_reinvite_unsafe(Req, _Call) ->
     ContentEls = [sip_to_jingle:sdp_media_to_content_el(Media, CodecMap) || Media <- SDP#sdp.medias],
     Name = get_action_name_from_sdp(RemainingAttrs, <<"transport-info">>),
     JingleEl = jingle_sip_helper:jingle_element(CallID, Name, ContentEls ++ OtherEls),
+
+    ?LOG_INFO(#{what => sip_reinvite,
+                text => <<"Got SIP re-INVITE from NkSIP">>,
+                from_jid => FromBinary, to_jid => ToBinary,
+                call_id => CallID, sip_req => Req}),
+
     IQEl = jingle_sip_helper:jingle_iq(ToBinary, FromBinary, JingleEl),
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => FromJID#jid.lserver,
@@ -140,8 +161,7 @@ sip_info(Req, _Call) ->
     CallID = nksip_sipmsg:header(<<"call-id">>, Req),
     Body = nksip_sipmsg:meta(body, Req),
 
-    ?INFO_MSG("event=sip_info to=~p call_id=~p body:~n~s", [ToBinary, CallID, Body]),
-
+    ?LOG_INFO(#{what => sip_info, sip_req => Req}),
     noreply.
 
 sip_bye(Req, _Call) ->
@@ -211,9 +231,9 @@ sip_dialog_update(_, _, _) ->
 %% * 603 - used to decline the INVITE by the reciving side
 %% * all error responses between 400 and 700 result in genering session-terminate reason
 invite_resp_callback({resp, 180, SIPMsg, _Call}) ->
-    send_ringing_session_info(SIPMsg);
+    send_ringing_session_info(SIPMsg, 180);
 invite_resp_callback({resp, 183, SIPMsg, _Call}) ->
-    send_ringing_session_info(SIPMsg);
+    send_ringing_session_info(SIPMsg, 183);
 invite_resp_callback({resp, 200, SIPMsg, _Call}) ->
     {ToJID, ToBinary} = get_user_from_sip_msg(from, SIPMsg),
     {FromJID, FromBinary} = get_user_from_sip_msg(to, SIPMsg),
@@ -273,19 +293,20 @@ invite_resp_callback({resp, ErrorCode, SIPMsg, _Call})
                               to_jid => ToJID }),
     maybe_route_to_all_sessions(FromJID, ToJID, Acc, IQEl),
     ok;
-
-
 invite_resp_callback(Data) ->
-    ?ERROR_MSG("Unknown SIP resp: ~p", [Data]).
+    ?LOG_ERROR(#{what => sip_unknown_response, sip_data => Data}).
 
-send_ringing_session_info(SIPMsg) ->
+send_ringing_session_info(SIPMsg, ErrorCode) ->
     %% SIP response contains the same headers as request
     %% That's why we need to switch `from` and `to` when preparing Jingle packet
     {ToJID, ToBinary} = get_user_from_sip_msg(from, SIPMsg),
     {FromJID, FromBinary} = get_user_from_sip_msg(to, SIPMsg),
 
     DialogHandle = nksip_sipmsg:meta(dialog_handle, SIPMsg),
-    CallID = nksip_sipmsg:header(<<"call-id">>, SIPMsg),
+    {SrvId, DialogId, CallID} = nksip_dialog_lib:parse_handle(DialogHandle),
+    ?LOG_INFO(#{what => sip_invite_resp_callback, error_code => ErrorCode,
+                call_id => CallID, dialog_id => DialogId, server_id => SrvId,
+                from_jid => FromBinary, to_binary => ToBinary}),
 
     mod_jingle_sip_backend:set_outgoing_handle(CallID, DialogHandle, FromJID, ToJID),
 

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -49,8 +49,7 @@ sip_invite(Req, Call) ->
         sip_invite_unsafe(Req, Call)
     catch Class:Reason:StackTrace ->
               ?LOG_WARNING(#{what => sip_invite_failed,
-                             text => <<"Error parsing sip invite">>,
-                             sip_req => Req,
+                             text => <<"Error parsing sip invite">>, sip_req => Req,
                              class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, request_not_parsable}
     end.
@@ -60,8 +59,7 @@ sip_reinvite(Req, Call) ->
         sip_reinvite_unsafe(Req, Call)
     catch Class:Reason:StackTrace ->
               ?LOG_WARNING(#{what => sip_reinvite_failed,
-                             text => <<"Error parsing sip reinvite">>,
-                             sip_req => Req,
+                             text => <<"Error parsing sip reinvite">>, sip_req => Req,
                              class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, request_not_parsable}
     end.
@@ -76,9 +74,8 @@ sip_invite_unsafe(Req, _Call) ->
             translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary);
         _ ->
             CallID = nksip_sipmsg:header(<<"call-id">>, Req),
-            ?LOG_INFO(#{what => sip_invite,
+            ?LOG_INFO(#{what => sip_invite, reply => temporarily_unavailable,
                         text => <<"Got SIP INVITE from NkSIP, but destination user is offline">>,
-                        reply => temporarily_unavailable,
                         from_jid => FromBinary, to_jid => ToBinary,
                         call_id => CallID, sip_req => Req}),
             {reply, temporarily_unavailable}
@@ -100,8 +97,7 @@ translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary) ->
 
     ok = mod_jingle_sip_backend:set_incoming_request(CallID, ReqID, FromJID, ToJID, JingleEl),
 
-    ?LOG_INFO(#{what => sip_invite,
-                text => <<"Got SIP INVITE from NkSIP">>,
+    ?LOG_INFO(#{what => sip_invite, text => <<"Got SIP INVITE from NkSIP">>,
                 from_jid => FromBinary, to_jid => ToBinary,
                 call_id => CallID, sip_req => Req}),
 
@@ -131,8 +127,7 @@ sip_reinvite_unsafe(Req, Call) ->
     Name = get_action_name_from_sdp(RemainingAttrs, <<"transport-info">>),
     JingleEl = jingle_sip_helper:jingle_element(CallID, Name, ContentEls ++ OtherEls),
 
-    ?LOG_INFO(#{what => sip_reinvite,
-                text => <<"Got SIP re-INVITE from NkSIP">>,
+    ?LOG_INFO(#{what => sip_reinvite, text => <<"Got SIP re-INVITE from NkSIP">>,
                 from_jid => FromBinary, to_jid => ToBinary,
                 call_id => CallID, sip_req => Req}),
 
@@ -305,7 +300,8 @@ send_ringing_session_info(SIPMsg, ErrorCode) ->
     DialogHandle = nksip_sipmsg:meta(dialog_handle, SIPMsg),
     {SrvId, DialogId, CallID} = nksip_dialog_lib:parse_handle(DialogHandle),
     ?LOG_INFO(#{what => sip_invite_resp_callback, error_code => ErrorCode,
-                call_id => CallID, dialog_id => DialogId, server_id => SrvId,
+                call_id => CallID, sip_req => SIPMsg,
+                dialog_id => DialogId, server_id => SrvId,
                 from_jid => FromBinary, to_binary => ToBinary}),
 
     mod_jingle_sip_backend:set_outgoing_handle(CallID, DialogHandle, FromJID, ToJID),

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -170,8 +170,7 @@ route_result({error, item_not_found}, From, To, IQ) ->
     Error = mongoose_xmpp_errors:item_not_found(),
     route_error_reply(From, To, IQ, Error);
 route_result(Other, From, To, IQ) ->
-    ?LOG_WARNING(#{what => sip_unknown_result,
-                   reason => Other, iq => IQ}),
+    ?LOG_WARNING(#{what => sip_unknown_result, reason => Other, iq => IQ}),
     Error = mongoose_xmpp_errors:internal_server_error(),
     route_error_reply(From, To, IQ, Error).
 

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -224,8 +224,8 @@ translate_to_sip(<<"session-initiate">>, Jingle, Acc) ->
     Result = mod_jingle_sip_backend:set_outgoing_request(SID, Handle, FromJID, ToJID),
     {_, SrvId, DialogId, _CallId} = nksip_sipmsg:parse_handle(Handle),
     ?LOG_INFO(#{what => sip_session_start,
-                event => set_outgoing_request,
-                jingle_action => 'session-initiate',
+                text => <<"Start SIP session with set_outgoing_request call">>,
+                jingle_action => 'session-initiate', result => Result,
                 from_jid => From, to_jid => To,
                 call_id => SID, server_id => SrvId, dialog_id => DialogId}),
     {ok, Handle};

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -150,8 +150,7 @@ maybe_translate_to_sip(JingleAction, From, To, IQ, Acc)
       route_result(Result, From, To, IQ)
     catch Class:Error:StackTrace ->
             ejabberd_router:route_error_reply(To, From, Acc, mongoose_xmpp_errors:internal_server_error()),
-            ?LOG_ERROR(#{what => sip_translate_failed,
-                         acc => Acc,
+            ?LOG_ERROR(#{what => sip_translate_failed, acc => Acc,
                          class => Class, reason => Error, stacktrace => StackTrace})
     end,
     mongoose_acc:set(hook, result, drop, Acc);

--- a/src/jingle_sip/sip_to_jingle.erl
+++ b/src/jingle_sip/sip_to_jingle.erl
@@ -209,9 +209,6 @@ maybe_add_rtcp_mux(_, Els) ->
 
 parse_candidate_extra_args([], Candidate) ->
     Candidate;
-parse_candidate_extra_args([V], Candidate) ->
-    ?WARNING_MSG("Unrecognised candidate extra arg: ~p", [V]),
-    Candidate;
 parse_candidate_extra_args([<<"typ">>, Value | Rest], Candidate) ->
     NewCandidate = Candidate#{type => Value},
     parse_candidate_extra_args(Rest, NewCandidate);
@@ -228,7 +225,9 @@ parse_candidate_extra_args([<<"tcptype">>, Value | Rest], Candidate) ->
     NewCandidate = Candidate#{tcptype => Value},
     parse_candidate_extra_args(Rest, NewCandidate);
 parse_candidate_extra_args(Rest, Candidate) ->
-    ?WARNING_MSG("Unrecognised candidate extra args: ~p", [Rest]),
+    ?LOG_WARNING(#{what => sip_unrecognised_candidate_extra_args,
+                   text => <<"Unrecognised candidate extra arg">>,
+                   extra_args => Rest}),
     Candidate.
 
 

--- a/src/jingle_sip/sip_to_jingle.erl
+++ b/src/jingle_sip/sip_to_jingle.erl
@@ -227,7 +227,7 @@ parse_candidate_extra_args([<<"tcptype">>, Value | Rest], Candidate) ->
 parse_candidate_extra_args(Rest, Candidate) ->
     ?LOG_WARNING(#{what => sip_unrecognised_candidate_extra_args,
                    text => <<"Unrecognised candidate extra arg">>,
-                   extra_args => Rest}),
+                   candidate => Candidate, extra_args => Rest}),
     Candidate.
 
 

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -130,7 +130,8 @@ make_error_reply(Acc, Error) ->
 make_error_reply(Acc, Packet, Error) ->
     case mongoose_acc:get(flag, error, false, Acc) of
         true ->
-            ?ERROR_MSG("event=error_reply_to_error,stanza=~p,error=~p", [Packet, Error]),
+            ?LOG_ERROR(#{what => error_reply_to_error, exml_packet => Packet,
+                         reason => Error}),
             {Acc, {error, {already_an_error, Packet, Error}}};
         _ ->
             {mongoose_acc:set(flag, error, true, Acc),

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -167,8 +167,7 @@ get_personal_data(Acc, #jid{ lserver = LServer } = JID) ->
 -spec delete_archive(jid:server(), jid:user()) -> 'ok'.
 delete_archive(Server, User)
   when is_binary(Server), is_binary(User) ->
-    ?LOG_DEBUG(#{what => mam_delete_archive,
-                 user => User, server => Server}),
+    ?LOG_DEBUG(#{what => mam_delete_archive, user => User, server => Server}),
     ArcJID = jid:make(User, Server, <<>>),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
@@ -197,7 +196,7 @@ archive_id(Server, User)
 
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
-    ?LOG_DEBUG(#{what => mam_starting}),
+    ?LOG_INFO(#{what => mam_starting}),
     ?LOG_IF(warning, gen_mod:get_opt(archive_groupchats, Opts, undefined) == undefined,
                     #{what => mam_configuration, text =>
      <<"mod_mam is enabled without explicit archive_groupchats option value."
@@ -228,7 +227,7 @@ start(Host, Opts) ->
 
 -spec stop(Host :: jid:server()) -> any().
 stop(Host) ->
-    ?LOG_DEBUG(#{what => mam_stopping}),
+    ?LOG_INFO(#{what => mam_stopping}),
     ejabberd_hooks:delete(sm_filter_offline_message, Host, ?MODULE, sm_filter_offline_message, 50),
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:delete(rest_user_send_packet, Host, ?MODULE, user_send_packet, 90),
@@ -383,10 +382,8 @@ handle_mam_iq(Action, From, To, IQ) ->
 handle_set_prefs(ArcJID=#jid{},
                  IQ=#iq{sub_el = PrefsEl}) ->
     {DefaultMode, AlwaysJIDs, NeverJIDs} = parse_prefs(PrefsEl),
-    ?LOG_DEBUG(#{what => mam_set_prefs,
-                 default_mode => DefaultMode,
-                 always_jids => AlwaysJIDs, never_jids => NeverJIDs,
-                 iq => IQ}),
+    ?LOG_DEBUG(#{what => mam_set_prefs, default_mode => DefaultMode,
+                 always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
     Res = set_prefs(Host, ArcID, ArcJID, DefaultMode, AlwaysJIDs, NeverJIDs),
@@ -410,10 +407,8 @@ handle_get_prefs(ArcJID=#jid{}, IQ=#iq{}) ->
     handle_get_prefs_result(Res, IQ).
 
 handle_get_prefs_result({DefaultMode, AlwaysJIDs, NeverJIDs}, IQ) ->
-    ?LOG_DEBUG(#{what => mam_get_prefs_result,
-                 default_mode => DefaultMode,
-                 always_jids => AlwaysJIDs, never_jids => NeverJIDs,
-                 iq => IQ}),
+    ?LOG_DEBUG(#{what => mam_get_prefs_result, default_mode => DefaultMode,
+                 always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
     Namespace = IQ#iq.xmlns,
     ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, Namespace),
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -197,9 +197,9 @@ archive_id(Server, User)
 
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
-    ?LOG_DEBUG(#{what => mod_mam_starting}),
+    ?LOG_DEBUG(#{what => mam_starting}),
     ?LOG_IF(warning, gen_mod:get_opt(archive_groupchats, Opts, undefined) == undefined,
-                    #{what => mod_mam_configuration, text =>
+                    #{what => mam_configuration, text =>
      <<"mod_mam is enabled without explicit archive_groupchats option value."
        " It will default to `false` in one of future releases."
        " Please check the mod_mam documentation for more details.">>,
@@ -228,7 +228,7 @@ start(Host, Opts) ->
 
 -spec stop(Host :: jid:server()) -> any().
 stop(Host) ->
-    ?LOG_DEBUG(#{what => mod_mam_stopping}),
+    ?LOG_DEBUG(#{what => mam_stopping}),
     ejabberd_hooks:delete(sm_filter_offline_message, Host, ?MODULE, sm_filter_offline_message, 50),
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 90),
     ejabberd_hooks:delete(rest_user_send_packet, Host, ?MODULE, user_send_packet, 90),
@@ -680,7 +680,7 @@ report_issue(not_implemented, _Stacktrace, _Issue, _ArcJID, _IQ) ->
 report_issue(timeout, _Stacktrace, _Issue, _ArcJID, _IQ) ->
     expected;
 report_issue(Reason, Stacktrace, Issue, #jid{lserver=LServer, luser=LUser}, IQ) ->
-    ?LOG_ERROR(#{what => mod_mam_error,
+    ?LOG_ERROR(#{what => mam_error,
                  issue => Issue, server => LServer, user => LUser,
                  reason => Reason, iq => IQ, stacktrace => Stacktrace}).
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -198,8 +198,7 @@ archive_id(Server, User)
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
     ?LOG_DEBUG(#{what => mod_mam_starting}),
-    
-    ?LOG_WARNING_IF(gen_mod:get_opt(archive_groupchats, Opts, undefined) == undefined,
+    ?LOG_IF(warning, gen_mod:get_opt(archive_groupchats, Opts, undefined) == undefined,
                     #{what => mod_mam_configuration, text =>
      <<"mod_mam is enabled without explicit archive_groupchats option value."
        " It will default to `false` in one of future releases."

--- a/src/mam/mod_mam_cache_user.erl
+++ b/src/mam/mod_mam_cache_user.erl
@@ -266,7 +266,7 @@ handle_cast({remove_user, ArcJID}, State) ->
     ets:delete(tbl_name_archive_id(), su_key(ArcJID)),
     {noreply, State};
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, cast_message => Msg, state => State}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -276,7 +276,8 @@ handle_cast(Msg, State) ->
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 
-handle_info(_Msg, State) ->
+handle_info(Msg, State) ->
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/mam/mod_mam_cassandra_prefs.erl
+++ b/src/mam/mod_mam_cassandra_prefs.erl
@@ -157,8 +157,7 @@ set_prefs(_Result, Host, _UserID, UserJID, DefaultMode, AlwaysJIDs, NeverJIDs) -
         set_prefs1(Host, UserJID, DefaultMode, AlwaysJIDs, NeverJIDs)
     catch Type:Error:StackTrace ->
               ?LOG_ERROR(#{what => mam_set_prefs_failed,
-                           user_jid => UserJID,
-                           default_mode => DefaultMode,
+                           user_jid => UserJID, default_mode => DefaultMode,
                            always_jids => AlwaysJIDs, never_jids => NeverJIDs,
                            class => Type, reason => Error, stacktrace => StackTrace}),
             {error, Error}
@@ -179,10 +178,8 @@ set_prefs1(_Host, UserJID, DefaultMode, AlwaysJIDs, NeverJIDs) ->
     Queries = [DelQuery, SetQuery],
     Res = [mongoose_cassandra:cql_write(pool_name(), UserJID, ?MODULE, Query, Params)
            || {Query, Params} <- Queries],
-    ?LOG_DEBUG(#{what => mam_set_prefs, user_jid => UserJID,
-                 default_mode => DefaultMode,
-                 always_jids => AlwaysJIDs, never_jids => NeverJIDs,
-                 result => Res}),
+    ?LOG_DEBUG(#{what => mam_set_prefs, user_jid => UserJID, default_mode => DefaultMode,
+                 always_jids => AlwaysJIDs, never_jids => NeverJIDs, result => Res}),
     ok.
 
 encode_row(BUserJID, BRemoteJID, Behaviour, Timestamp) ->
@@ -240,14 +237,11 @@ decode_behaviour(<<"R">>) -> roster;
 decode_behaviour(<<"A">>) -> always;
 decode_behaviour(<<"N">>) -> never.
 
--spec decode_prefs_rows([[term()]],
-                        DefaultMode :: mod_mam:archive_behaviour(),
-                        AlwaysJIDs :: [jid:literal_jid()],
-                        NeverJIDs :: [jid:literal_jid()]) -> {
-                             mod_mam:archive_behaviour(),
-                         [jid:literal_jid()],
-                         [jid:literal_jid()]
-                        }.
+-spec decode_prefs_rows([[term()]], DefaultMode, AlwaysJIDs, NeverJIDs) ->
+    {DefaultMode, AlwaysJIDs, NeverJIDs} when
+        DefaultMode :: mod_mam:archive_behaviour(),
+        AlwaysJIDs :: [jid:literal_jid()],
+        NeverJIDs :: [jid:literal_jid()].
 decode_prefs_rows([], DefaultMode, AlwaysJIDs, NeverJIDs) ->
     {DefaultMode, AlwaysJIDs, NeverJIDs};
 

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -332,8 +332,7 @@ archive_size(Query) ->
         {ok, Count} ->
             Count;
         {error, Reason} ->
-            ?LOG_ERROR(#{what => archive_size_failed,
-                         text => <<"Failed to retrieve count of messages from ElasticSearch">>,
-                         reason => Reason, es_query => Query}),
+            ?LOG_ERROR(#{what => archive_size_failed, reason => Reason, es_query => Query,
+                         text => <<"Failed to retrieve count of messages from ElasticSearch">>}),
             0
     end.

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -152,7 +152,7 @@ archive_id(SubHost, RoomName) when is_binary(SubHost), is_binary(RoomName) ->
 
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
-    ?LOG_DEBUG(#{what => mod_mam_muc_starting}),
+    ?LOG_DEBUG(#{what => mam_muc_starting}),
     %% MUC host.
     MUCHost = gen_mod:get_opt_subhost(Host, Opts, mod_muc:default_host()),
     IQDisc = gen_mod:get_opt(iqdisc, Opts, parallel), %% Type
@@ -171,7 +171,7 @@ start(Host, Opts) ->
 
 stop(Host) ->
     MUCHost = gen_mod:get_module_opt_subhost(Host, mod_mam_muc, mod_muc:default_host()),
-    ?LOG_DEBUG(#{what => mod_mam_muc_stopping}),
+    ?LOG_DEBUG(#{what => mam_muc_stopping}),
     ejabberd_hooks:delete(filter_room_packet, MUCHost, ?MODULE, filter_room_packet, 90),
     ejabberd_hooks:delete(forget_room, MUCHost, ?MODULE, forget_room, 90),
     ejabberd_hooks:delete(get_personal_data, Host, ?MODULE, get_personal_data, 50),
@@ -598,7 +598,7 @@ report_issue(not_implemented, _Stacktrace, _Issue, _ArcJID, _IQ) ->
 report_issue(timeout, _Stacktrace, _Issue, _ArcJID, _IQ) ->
     expected;
 report_issue(Reason, Stacktrace, Issue, #jid{lserver = LServer, luser = LUser}, IQ) ->
-    ?LOG_ERROR(#{what => mod_mam_muc_error, issue => Issue, reason => Reason,
+    ?LOG_ERROR(#{what => mam_muc_error, issue => Issue, reason => Reason,
                  user => LUser, server => LServer, iq => IQ, stacktrace => Stacktrace}).
 
 -spec is_archivable_message(MUCHost :: ejabberd:lserver(), Dir :: incoming | outgoing,

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -340,10 +340,9 @@ handle_mam_iq(Action, From, To, IQ) ->
 handle_set_prefs(ArcJID = #jid{},
                  IQ = #iq{sub_el = PrefsEl}) ->
     {DefaultMode, AlwaysJIDs, NeverJIDs} = parse_prefs(PrefsEl),
-    ?LOG_DEBUG(#{what => mam_muc_set_prefs,
+    ?LOG_DEBUG(#{what => mam_muc_set_prefs, archive_jid => ArcJID,
                  default_mode => DefaultMode,
-                 always_jids => AlwaysJIDs, never_jids => NeverJIDs,
-                 archive_jid => ArcJID, iq => IQ}),
+                 always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
     {ok, Host} = mongoose_subhosts:get_host(ArcJID#jid.lserver),
     ArcID = archive_id_int(Host, ArcJID),
     Res = set_prefs(Host, ArcID, ArcJID, DefaultMode, AlwaysJIDs, NeverJIDs),
@@ -366,10 +365,9 @@ handle_get_prefs(ArcJID=#jid{}, IQ=#iq{}) ->
     handle_get_prefs_result(ArcJID, Res, IQ).
 
 handle_get_prefs_result(ArcJID, {DefaultMode, AlwaysJIDs, NeverJIDs}, IQ) ->
-    ?LOG_DEBUG(#{what => mam_muc_get_prefs_result,
+    ?LOG_DEBUG(#{what => mam_muc_get_prefs_result, archive_jid => ArcJID, 
                  default_mode => DefaultMode,
-                 always_jids => AlwaysJIDs, never_jids => NeverJIDs,
-                 archive_jid => ArcJID, iq => IQ}),
+                 always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
     ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};
 handle_get_prefs_result(_ArcJID, {error, Reason}, IQ) ->

--- a/src/mam/mod_mam_muc_cache_user.erl
+++ b/src/mam/mod_mam_muc_cache_user.erl
@@ -210,7 +210,7 @@ handle_cast({remove_user, ArcJID}, State) ->
     ets:delete(tbl_name_archive_id(), su_key(ArcJID)),
     {noreply, State};
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, cast_message => Msg, state => State}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -232,7 +232,8 @@ handle_info({'DOWN', MonRef, process, Pid, Reason}, State) ->
             ets:delete(tbl_name_monitor(), Key)
     end,
     {noreply, State};
-handle_info(_Msg, State) ->
+handle_info(Msg, State) ->
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -333,7 +333,6 @@ archive_size(Query) ->
         {ok, Count} ->
             Count;
         {error, Reason} ->
-            ?LOG_ERROR(#{what => archive_size_failed,
-                         es_query => Query, reason => Reason}),
+            ?LOG_ERROR(#{what => archive_size_failed, es_query => Query, reason => Reason}),
             0
     end.

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -235,8 +235,7 @@ run_flush(State = #state{host = Host, acc = Acc}) ->
 do_run_flush(MessageCount, State = #state{host = Host, max_batch_size = MaxSize,
                                           flush_interval_tref = TRef, acc = Acc}) ->
     cancel_and_flush_timer(TRef),
-    ?LOG_DEBUG(#{what => mam_flush,
-                 message_count => MessageCount}),
+    ?LOG_DEBUG(#{what => mam_flush, message_count => MessageCount}),
 
     Rows = [mod_mam_muc_rdbms_arch:prepare_message(Host, Params) || Params <- Acc],
 

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -320,7 +320,7 @@ handle_cast({archive_message, Params},
         false -> {noreply, State2}
     end;
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, cast_message => Msg, state => State}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 
@@ -333,7 +333,10 @@ handle_cast(Msg, State) ->
 
 -spec handle_info('flush', state()) -> {'noreply', state()}.
 handle_info(flush, State) ->
-    {noreply, run_flush(State#state{flush_interval_tref=undefined})}.
+    {noreply, run_flush(State#state{flush_interval_tref=undefined})};
+handle_info(Msg, State) ->
+    ?UNEXPECTED_INFO(Msg),
+    {noreply, State}.
 
 %%--------------------------------------------------------------------
 %% Function: terminate(Reason, State) -> void()

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -332,7 +332,7 @@ handle_cast({archive_message, Params},
         false -> {noreply, State2}
     end;
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, cast_message => Msg, state => State}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 
@@ -344,7 +344,10 @@ handle_cast(Msg, State) ->
 %%--------------------------------------------------------------------
 
 handle_info(flush, State) ->
-    {noreply, run_flush(State#state{flush_interval_tref=undefined})}.
+    {noreply, run_flush(State#state{flush_interval_tref=undefined})};
+handle_info(Msg, State) ->
+    ?UNEXPECTED_INFO(Msg),
+    {noreply, State}.
 
 %%--------------------------------------------------------------------
 %% Function: terminate(Reason, State) -> void()

--- a/src/mam/mod_mam_rdbms_user.erl
+++ b/src/mam/mod_mam_rdbms_user.erl
@@ -209,9 +209,8 @@ create_user_archive(Host, Server, UserName) ->
             %% - {error, duplicate_key}
             %% - {error, "[FreeTDS][SQL Server]Violation of UNIQUE KEY constraint" ++ _}
             %% Let's ignore the errors and just retry in query_archive_id
-            ?LOG_WARNING(#{what => create_user_archive_failed,
-                           user => UserName, host => Host, server => Server,
-                           reason => Res}),
+            ?LOG_WARNING(#{what => create_user_archive_failed, reason => Res,
+                           user => UserName, host => Host, server => Server}),
             ok
     end.
 

--- a/src/metrics/mongoose_metrics_probe.erl
+++ b/src/metrics/mongoose_metrics_probe.erl
@@ -87,7 +87,8 @@ probe_setopts(_Entry, _Opts, _S) ->
 probe_handle_msg({'DOWN', Ref, _, _, {sample, Data}}, #state{ref = Ref} = S) ->
     {ok, S#state{ref = undefined, data = Data}};
 probe_handle_msg({'DOWN', Ref, _, _, Reason}, #state{callback_module = Mod, ref = Ref} = S) ->
-    ?WARNING_MSG("Probe callback_module ~p died with reason ~p: ", [Mod, Reason]),
+    ?LOG_WARNING(#{what => probe_callback_module_died, callback_module => Mod,
+                   reason => Reason}),
     {ok, S#state{ref = undefined}};
 probe_handle_msg(_, S) ->
     {ok, S}.

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -224,7 +224,7 @@ process_sm_iq(From, To, Acc, IQ) ->
 -spec process_adhoc_request(jid:jid(), jid:jid(), jlib:iq(),
         Hook :: atom()) -> ignore | jlib:iq().
 process_adhoc_request(From, To, #iq{sub_el = SubEl} = IQ, Hook) ->
-    ?DEBUG("About to parse ~p...", [IQ]),
+    ?LOG_DEBUG(#{what => adhoc_parse_request, iq => IQ, hook => Hook}),
     case adhoc:parse_request(IQ) of
         {error, Error} ->
             IQ#iq{type = error, sub_el = [SubEl, Error]};

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -194,8 +194,9 @@ send_error_and_drop(Packet, From, AmpError, MatchedRule) ->
 
 -spec send_errors_and_drop(exml:element(), jid:jid(), [{amp_error(), amp_rule()}]) -> drop.
 send_errors_and_drop(Packet, From, []) ->
-    ?ERROR_MSG("~p from ~p generated an empty list of errors. This shouldn't happen!",
-               [Packet, From]),
+    ?LOG_ERROR(#{what => empty_list_of_errors_generated,
+                 text => <<"This shouldn't happen!">>,
+                 exml_packet => Packet, from => From}),
     update_metric_and_drop(Packet, From);
 send_errors_and_drop(Packet, From, ErrorRules) ->
     Host = host(From),

--- a/src/mod_auth_token_rdbms.erl
+++ b/src/mod_auth_token_rdbms.erl
@@ -38,7 +38,8 @@ revoke(#jid{lserver = LServer} = JID) ->
     EBareJID = mongoose_rdbms:escape_string(BBareJID),
     RevokeQuery = revoke_query(EBareJID),
     QueryResult = mongoose_rdbms:sql_query(LServer, RevokeQuery),
-    ?DEBUG("result ~p", [QueryResult]),
+    ?LOG_DEBUG(#{what => auth_token_revoke, sql_query => RevokeQuery,
+                 sql_result => QueryResult}),
     case QueryResult of
         {updated, 1} -> ok;
         {updated, 0} -> not_found

--- a/src/mod_aws_sns.erl
+++ b/src/mod_aws_sns.erl
@@ -29,9 +29,10 @@ deps(_Host, Opts) ->
 
 -spec start(Host :: jid:server(), Opts :: proplists:proplist()) -> any().
 start(_Host, _Opts) ->
-    ?WARNING_MSG("mod_aws_sns is deprecated and will be removed in the future.~n"
-                 "Please use mod_event_pusher with sns backend.~n"
-                 "Refer to mod_event_pusher documentation for more information.", []).
+    Text = <<"mod_aws_sns is deprecated and will be removed in the future.~n"
+             "Please use mod_event_pusher with sns backend.~n"
+             "Refer to mod_event_pusher documentation for more information.">>,
+    ?LOG_WARNING(#{what => module_deprecated, text => Text}).
 
 -spec stop(Host :: jid:server()) -> ok.
 stop(_Host) ->

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -161,7 +161,7 @@ node_cleanup(Acc, Node) ->
 -type option() :: {atom(), any()}.
 -spec init(req(), _Opts :: [option()]) -> {cowboy_loop, req(), rstate()}.
 init(Req, _Opts) ->
-    ?DEBUG("issue=bosh_init", []),
+    ?LOG_DEBUG(#{what => bosh_init, req => Req}),
     Msg = init_msg(Req),
     self() ! Msg,
     %% Upgrade to cowboy_loop behaviour to enable long polling
@@ -174,7 +174,8 @@ init(Req, _Opts) ->
 info(accept_options, Req, State) ->
     Origin = cowboy_req:header(<<"origin">>, Req),
     Headers = ac_all(Origin),
-    ?DEBUG("OPTIONS response: ~p~n", [Headers]),
+    ?LOG_DEBUG(#{what => bosh_accept_options, headers => Headers,
+                 text => <<"Handle OPTIONS request in Bosh">>}),
     Req1 = cowboy_reply(200, Headers, <<>>, Req),
     {stop, Req1, State};
 info(accept_get, Req, State) ->
@@ -191,28 +192,28 @@ info(forward_body, Req, S) ->
     %%       but the session is identified inside the to-be-parsed element
     {ok, BodyElem} = exml:parse(Body),
     Sid = exml_query:attr(BodyElem, <<"sid">>, <<"missing">>),
-    ?DEBUG("issue=bosh_receive sid=~ts request_body=~p", [Sid, Body]),
+    ?LOG_DEBUG(#{what => bosh_receive, sid => Sid, request_body => Body}),
     %% Remember req_sid, so it can be used to print a debug message in bosh_reply
     forward_body(Req1, BodyElem, S#rstate{req_sid = Sid});
 info({bosh_reply, El}, Req, S) ->
     BEl = exml:to_binary(El),
-    ?DEBUG("issue=bosh_send sid=~ts req_sid=~ts reply_body=~p",
-           [exml_query:attr(El, <<"sid">>, <<"missing">>), S#rstate.req_sid, BEl]),
+    ?LOG_DEBUG(#{what => bosh_send, req_sid => S#rstate.req_sid, reply_body => BEl,
+                 sid => exml_query:attr(El, <<"sid">>, <<"missing">>)}),
     Headers = bosh_reply_headers(),
     Req1 = cowboy_reply(200, Headers, BEl, Req),
     {stop, Req1, S};
 
 info({close, Sid}, Req, S) ->
-    ?DEBUG("issue=bosh_close sid=~ts", [Sid]),
+    ?LOG_DEBUG(#{what => bosh_close, sid => Sid}),
     Req1 = cowboy_reply(200, [], <<>>, Req),
     {stop, Req1, S};
 info(no_body, Req, State) ->
-    ?DEBUG("issue=bosh_stop reason=missing_request_body req=~p", [Req]),
+    ?LOG_DEBUG(#{what => bosh_stop, reason => missing_request_body, req => Req}),
     Req1 = no_body_error(Req),
     {stop, Req1, State};
 info({wrong_method, Method}, Req, State) ->
-    ?DEBUG("issue=bosh_stop reason=wrong_request_method method=~p req=~p",
-           [Method, Req]),
+    ?LOG_DEBUG(#{what => bosh_stop, reason => wrong_request_method,
+                 method => Method, req => Req}),
     Req1 = method_not_allowed_error(Req),
     {stop, Req1, State};
 info(item_not_found, Req, S) ->
@@ -224,7 +225,7 @@ info(policy_violation, Req, S) ->
 
 
 terminate(_Reason, _Req, _State) ->
-    ?DEBUG("issue=bosh_terminate", []),
+    ?LOG_DEBUG(#{what => bosh_terminate}),
     ok.
 
 %%--------------------------------------------------------------------
@@ -314,8 +315,8 @@ forward_body(Req, #xmlel{} = Body, S) ->
                     handle_request(Socket, Type, Body),
                     {ok, Req, S};
                 {error, item_not_found} ->
-                    ?WARNING_MSG("issue=bosh_stop "
-                                 "reason=session_not_found sid=~ts", [Sid]),
+                    ?LOG_WARNING(#{what => bosh_stop, reason => session_not_found,
+                                   sid => Sid}),
                     Req1 = terminal_condition(<<"item-not-found">>, Req),
                     {stop, Req1, S}
             end
@@ -355,8 +356,8 @@ maybe_start_session_on_known_host(Req, Body) ->
     catch
         error:Reason ->
             %% It's here because something catch-y was here before
-            ?ERROR_MSG("issue=bosh_stop issue=undefined_condition reason=~p",
-                       [Reason]),
+            ?LOG_ERROR(#{what => bosh_stop, issue => undefined_condition,
+                         reason => Reason}),
             Req1 = terminal_condition(<<"undefined-condition">>, [], Req),
             {false, Req1}
     end.
@@ -381,7 +382,7 @@ start_session(Peer, PeerCert, Body) ->
     {ok, Socket} = mod_bosh_socket:start(Sid, Peer, PeerCert),
     store_session(Sid, Socket),
     handle_request(Socket, streamstart, Body),
-    ?DEBUG("issue=bosh_start_seassion sid=~ts", [Sid]).
+    ?LOG_DEBUG(#{what => bosh_start_session, sid => Sid}).
 
 -spec store_session(Sid :: sid(), Socket :: pid()) -> any().
 store_session(Sid, Socket) ->

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -399,8 +399,7 @@ handle_info({wait_timeout, {Rid, Pid}}, SName,
             {next_state, SName, NS}
     end;
 handle_info(Info, SName, State) ->
-    ?LOG_DEBUG(ls(#{what => unexpected_message, state_name => SName,
-                    msg => Info}, State)),
+    ?UNEXPECTED_INFO(Info),
     {next_state, SName, State}.
 
 terminate(Reason, StateName, #state{sid = Sid, handlers = Handlers} = S) ->

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -406,8 +406,7 @@ terminate(Reason, StateName, #state{sid = Sid, handlers = Handlers} = S) ->
     [Pid ! {close, Sid} || {_, _, Pid} <- lists:sort(Handlers)],
     mod_bosh_backend:delete_session(Sid),
     catch ejabberd_c2s:stop(S#state.c2s_pid),
-    ?LOG_DEBUG(ls(#{what => bosh_socket_closing_session,
-                    reason => Reason,
+    ?LOG_DEBUG(ls(#{what => bosh_socket_closing_session, reason => Reason,
                     state_name => StateName, handlers => Handlers,
                     pending => S#state.pending}, S)).
 
@@ -570,8 +569,7 @@ schedule_report(Ack, #state{sent = Sent} = S) ->
     catch
         error:{badmatch, {resp, false}} ->
             ?LOG_ERROR(ls(#{what => bosh_socket_no_cached_response,
-                            responses => Sent,
-                            rid_offender => ReportRid}, S)),
+                            responses => Sent, rid_offender => ReportRid}, S)),
             S
     end.
 

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -206,8 +206,7 @@ disco_features(Acc, From, To, Node, Lang) ->
 disco_identity(Acc, From, To, Node, Lang) ->
     case is_valid_node(Node) of
         true ->
-            mongoose_hooks:disco_local_identity(To#jid.lserver,
-                                                [],
+            mongoose_hooks:disco_local_identity(To#jid.lserver, [],
                                                 From, To, <<"">>, Lang);
         false ->
             Acc
@@ -216,23 +215,21 @@ disco_identity(Acc, From, To, Node, Lang) ->
 disco_info(Acc, Host, Module, Node, Lang) ->
     case is_valid_node(Node) of
         true ->
-            mongoose_hooks:disco_info(Host, [],
-                                      Module, <<"">>, Lang);
+            mongoose_hooks:disco_info(Host, [], Module, <<"">>, Lang);
         false ->
             Acc
     end.
 
 c2s_presence_in(C2SState,
-                {From, To, {_, _, Attrs, Els}}) ->
-    ?DEBUG("Presence to ~p from ~p with Els ~p", [To, From, Els]),
+                {From, To, Packet = #xmlel{attrs = Attrs, children = Els}}) ->
+    ?LOG_DEBUG(#{what => caps_c2s_presence_in,
+                 to => jid:to_binary(To), from => jid:to_binary(From),
+                 exml_packet => Packet, c2s_state => C2SState}),
     Type = xml:get_attr_s(<<"type">>, Attrs),
-    Subscription = ejabberd_c2s:get_subscription(From,
-                                                 C2SState),
-    ?DEBUG("Subscription ~p, type ~p", [Subscription, Type]),
+    Subscription = ejabberd_c2s:get_subscription(From, C2SState),
     Insert = ((Type == <<"">>) or (Type == <<"available">>))
         and ((Subscription == both) or (Subscription == to)),
-    Delete = (Type == <<"unavailable">>) or
-                                           (Type == <<"error">>),
+    Delete = (Type == <<"unavailable">>) or (Type == <<"error">>),
     case Insert or Delete of
         true ->
             LFrom = jid:to_lower(From),
@@ -246,7 +243,9 @@ c2s_presence_in(C2SState,
             NewRs = case Caps of
                         nothing when Insert == true -> Rs;
                         _ when Insert == true ->
-                            ?DEBUG("Set CAPS to ~p for ~p in ~p", [Caps, LFrom, To]),
+                            ?LOG_DEBUG(#{what => caps_set_caps, caps => Caps,
+                                         to => jid:to_binary(To), from => jid:to_binary(From),
+                                         exml_packet => Packet, c2s_state => C2SState}),
                             upsert_caps(LFrom, From, To, Caps, Rs);
                         _ -> gb_trees:delete_any(LFrom, Rs)
                     end,
@@ -273,7 +272,9 @@ upsert_caps(LFrom, From, To, Caps, Rs) ->
 c2s_filter_packet(InAcc, LHost, C2SState, {pep_message, Feature}, To, _Packet) ->
     case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of
         {ok, Rs} ->
-            ?DEBUG("Look for CAPS for ~p in ~p (res: ~p)", [To, C2SState, Rs]),
+            ?LOG_DEBUG(#{what => caps_lookup,
+                         text => <<"Look for CAPS for To jid">>,
+                         acc => InAcc, c2s_state => C2SState, caps_resources => Rs}),
             LTo = jid:to_lower(To),
             case gb_trees:lookup(LTo, Rs) of
                 {value, Caps} ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -272,8 +272,7 @@ upsert_caps(LFrom, From, To, Caps, Rs) ->
 c2s_filter_packet(InAcc, LHost, C2SState, {pep_message, Feature}, To, _Packet) ->
     case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of
         {ok, Rs} ->
-            ?LOG_DEBUG(#{what => caps_lookup,
-                         text => <<"Look for CAPS for To jid">>,
+            ?LOG_DEBUG(#{what => caps_lookup, text => <<"Look for CAPS for To jid">>,
                          acc => InAcc, c2s_state => C2SState, caps_resources => Rs}),
             LTo = jid:to_lower(To),
             case gb_trees:lookup(LTo, Rs) of

--- a/src/mod_cowboy.erl
+++ b/src/mod_cowboy.erl
@@ -55,9 +55,8 @@ init(Req, Opts) ->
         Class:Reason:StackTrace ->
               %% Because cowboy ignores stacktraces
               %% and we can get a cryptic error like {crash,error,undef}
-              ?ERROR_MSG("issue=init_failed "
-                          "reason=~p:~p stacktrace=~1000p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_ERROR(#{what => init_failed, class => Class,
+                           reason => Reason, stacktrace => StackTrace}),
               erlang:raise(Class, Reason, StackTrace)
     end.
 
@@ -95,9 +94,8 @@ websocket_handle(InFrame, State) ->
         Class:Reason:StackTrace ->
               %% Because cowboy ignores stacktraces
               %% and we can get a cryptic error like {crash,error,undef}
-              ?ERROR_MSG("issue=websocket_handle_failed "
-                          "reason=~p:~p stacktrace=~1000p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_ERROR(#{what => ws_handle_failed, class => Class,
+                           reason => Reason, stacktrace => StackTrace}),
               erlang:raise(Class, Reason, StackTrace)
     end.
 
@@ -124,9 +122,8 @@ websocket_info(Info, State) ->
         Class:Reason:StackTrace ->
               %% Because cowboy ignores stacktraces
               %% and we can get a cryptic error like {crash,error,undef}
-              ?ERROR_MSG("issue=websocket_info_failed "
-                          "reason=~p:~p stacktrace=~1000p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_ERROR(#{what => ws_info_failed, class => Class,
+                           reason => Reason, stacktrace => StackTrace}),
               erlang:raise(Class, Reason, StackTrace)
     end.
 

--- a/src/mod_http_notification.erl
+++ b/src/mod_http_notification.erl
@@ -11,9 +11,10 @@ deps(_Host, Opts) ->
     [{mod_event_pusher, [{backends, [{http, Opts}]}], hard}].
 
 start(_Host, _Opts) ->
-    ?WARNING_MSG("mod_http_notification is deprecated and will be removed in the future.~n"
-                 "Please use mod_event_pusher with http backend.~n"
-                 "Refer to mod_event_pusher documentation for more information.", []).
+    Text = <<"mod_http_notification is deprecated and will be removed in the future.~n"
+             "Please use mod_event_pusher with http backend.~n"
+             "Refer to mod_event_pusher documentation for more information.">>,
+    ?LOG_WARNING(#{what => module_deprecated, text => Text}).
 
 stop(_Host) ->
     ok.

--- a/src/mod_keystore.erl
+++ b/src/mod_keystore.erl
@@ -98,8 +98,9 @@ get_key(HandlerAcc, KeyID) ->
          mod_keystore_backend:get_key(KeyID) ++
          HandlerAcc)
     catch
-        E:R ->
-            ?ERROR_MSG("handler error: {~p, ~p}", [E, R]),
+        E:R:S ->
+            ?LOG_ERROR(#{what => get_key_failed,
+                         error => E, reason => R, stacktrace => S}),
             HandlerAcc
     end.
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -307,11 +307,12 @@ init([Host, Opts]) ->
 
     case gen_mod:get_module_opt(Host, mod_muc, load_permanent_rooms_at_startup, false) of
         false ->
-            ?INFO_MSG("event=load_permanent_rooms_at_startup, skip=true, "
-                      "details=\"each room is loaded when someone access the room\"", []);
+            ?LOG_INFO(#{what => load_permanent_rooms_at_startup, skip => true,
+                        text => <<"Skip loading permanent rooms at startup. "
+                                  "Each room is loaded when someone access the room">>});
         true ->
-            ?INFO_MSG("event=load_permanent_rooms_at_startup, skip=false, "
-                      "details=\"it can take some time\"", []),
+            ?LOG_INFO(#{what => load_permanent_rooms_at_startup, skip => false,
+                        text => <<"Loading permanent rooms at startup">>}),
             load_permanent_rooms(MyHost, Host,
                                  {Access, AccessCreate, AccessAdmin, AccessPersistent},
                                  HistorySize, RoomShaper, HttpAuthPool)
@@ -350,7 +351,8 @@ handle_call({create_instant, Room, From, Nick, Opts},
                    history_size = HistorySize,
                    room_shaper = RoomShaper,
                    http_auth_pool = HttpAuthPool} = State) ->
-    ?DEBUG("MUC: create new room '~s'~n", [Room]),
+    ?LOG_DEBUG(#{what => muc_create_instant,
+                 room => Room, sub_host => Host}),
     NewOpts = case Opts of
                   default -> DefOpts;
                   _ -> Opts
@@ -385,7 +387,9 @@ handle_info({mnesia_system_event, {mnesia_down, Node}}, State) ->
 handle_info(stop_hibernated_persistent_rooms,
             #state{server_host = ServerHost,
                    hibernated_room_timeout = Timeout} = State) when is_integer(Timeout) ->
-    ?INFO_MSG("Closing hibernated persistent rooms", []),
+    ?LOG_INFO(#{what => muc_stop_hibernated_persistent_rooms,
+                text => <<"Closing hibernated persistent rooms">>,
+                server => ServerHost}),
     Supervisor = gen_mod:get_module_proc(ServerHost, ejabberd_mod_muc_sup),
     Now = os:timestamp(),
     [stop_if_hibernated(Pid, Now, Timeout * 1000) ||
@@ -503,7 +507,8 @@ route_to_room(Room, Routed, #state{host=Host} = State) ->
     end.
 
 route_to_online_room(Pid, {From, To, Acc, Packet}) ->
-    ?DEBUG("MUC: send to process ~p~n", [Pid]),
+    ?LOG_DEBUG(#{what => muc_route_to_online_room,
+                 room_pid => Pid, acc => Acc}),
     {_, _, Nick} = jid:to_lower(To),
     ok = mod_muc_room:route(Pid, From, Nick, Acc, Packet).
 
@@ -539,8 +544,10 @@ get_registered_room_or_route_error_from_presence(Room, From, To, Acc, Packet,
                     register_room_or_stop_if_duplicate(Host, Room, Pid);
                 {error, {failed_to_restore, Reason}} ->
                     %% Notify user about our backend module error
-                    ?WARNING_MSG("event=send_service_unavailable room=~ts reason=~p",
-                                 [Room, Reason]),
+                    ?LOG_WARNING(#{what => muc_send_service_unavailable,
+                                   text => <<"Failed to restore room">>,
+                                   room => Room, server => ServerHost, sub_host => Host,
+                                   reason => Reason, acc => Acc}),
                     Lang = exml_query:attr(Packet, <<"xml:lang">>, <<>>),
                     ErrText = <<"Service is temporary unavailable">>,
                     {Acc1, Err} = jlib:make_error_reply(
@@ -575,8 +582,9 @@ get_registered_room_or_route_error_from_packet(Room, From, To, Acc, Packet,
             ejabberd_router:route(To, From, Acc1, Err),
             {route_error, ErrText};
         {error, Reason} ->
-            ?WARNING_MSG("event=send_service_unavailable room=~ts reason=~p",
-                         [Room, Reason]),
+            ?LOG_WARNING(#{what => muc_send_service_unavailable,
+                           room => Room, server => ServerHost, sub_host => Host,
+                           reason => Reason, acc => Acc}),
             Lang = exml_query:attr(Packet, <<"xml:lang">>, <<>>),
             ErrText = <<"Service is temporary unavailable">>,
             {Acc1, Err} = jlib:make_error_reply(
@@ -584,7 +592,8 @@ get_registered_room_or_route_error_from_packet(Room, From, To, Acc, Packet,
             ejabberd_router:route(To, From, Acc1, Err),
             {route_error, ErrText};
         {ok, Opts} ->
-            ?DEBUG("MUC: restore room '~s'~n", [Room]),
+            ?LOG_DEBUG(#{what => muc_restore_room,
+                         room => Room, room_opts => Opts}),
             #state{history_size = HistorySize,
                    room_shaper = RoomShaper,
                    http_auth_pool = HttpAuthPool} = State,
@@ -659,13 +668,11 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #state{host = Host} = State) ->
                                         children = [iq_get_unique(From)]}]},
            ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{} ->
-            ?INFO_MSG("event=ignore_unknown_iq from=~ts to=~ts packet=~1000p",
-                      [jid:to_binary(From), jid:to_binary(To), exml:to_binary(Packet)]),
+            ?LOG_INFO(#{what => muc_ignore_unknown_iq, acc => Acc}),
             {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:feature_not_implemented()),
             ejabberd_router:route(To, From, Acc1, Err);
-        _ ->
-            ?INFO_MSG("event=failed_to_parse_iq from=~ts to=~ts packet=~1000p",
-                      [jid:to_binary(From), jid:to_binary(To), exml:to_binary(Packet)]),
+        Other ->
+            ?LOG_INFO(#{what => muc_failed_to_parse_iq, acc => Acc, reason => Other}),
             ok
     end;
 route_by_type(<<"message">>, {From, To, Acc, Packet},
@@ -712,8 +719,9 @@ load_permanent_rooms(Host, ServerHost, Access, HistorySize, RoomShaper, HttpAuth
         {ok, Rs} ->
             Rs;
         {error, Reason} ->
-            ?ERROR_MSG("event=get_rooms_failed event=skip_load_permanent_rooms reason=~p",
-                       [Reason]),
+            ?LOG_ERROR(#{what => muc_get_rooms_failed,
+                         text => <<"Skip load_permanent_rooms">>,
+                         reason => Reason, server => ServerHost, sub_host => Host}),
             []
     end,
     lists:foreach(
@@ -745,7 +753,9 @@ start_new_room(Host, ServerHost, Access, Room,
                Nick, DefRoomOpts) ->
     case mod_muc_db_backend:restore_room(ServerHost, Host, Room) of
         {error, room_not_found} ->
-            ?DEBUG("MUC: open new room '~s'~n", [Room]),
+            ?LOG_DEBUG(#{what => muc_start_new_room,
+                         server => ServerHost, sub_host => Host,
+                         room => Room}),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
                                RoomShaper, HttpAuthPool, From,
@@ -753,7 +763,9 @@ start_new_room(Host, ServerHost, Access, Room,
         {error, Reason} ->
             {error, {failed_to_restore, Reason}};
         {ok, Opts} ->
-            ?DEBUG("MUC: restore room '~s'~n", [Room]),
+            ?LOG_DEBUG(#{what => muc_restore_room,
+                         server => ServerHost, sub_host => Host,
+                         room => Room, room_opts => Opts}),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
                                RoomShaper, HttpAuthPool, Opts)
@@ -879,7 +891,9 @@ get_vh_rooms(Host, #rsm_in{max=Max, direction=Direction, id=I, index=Index}) ->
         {Index, _} ->
             lists:sublist(BareSortedRooms, Index + 1, NonUndefMax);
          Input ->
-             ?ERROR_MSG("event=get_rooms_with_pagination unexpected_input=~p", [Input]),
+             ?LOG_ERROR(#{what => muc_get_rooms_with_pagination_failed,
+                          text => <<"Unexpected result in get_rooms_with_pagination">>,
+                          reason => Input}),
              []
          end,
     case L2 of
@@ -984,9 +998,10 @@ iq_set_register_info(ServerHost, Host, From, Nick, Lang) ->
             ErrText = <<"You must fill in field \"Nickname\" in the form">>,
             {error, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)};
         {error, ErrorReason} ->
-            ?ERROR_MSG("event=iq_set_register_info_failed, "
-                        "jid=~ts, nick=~p, reason=~p",
-                       [jid:to_binary(From), Nick, ErrorReason]),
+            ?LOG_ERROR(#{what => muc_iq_set_register_info_failed,
+                         server => ServerHost, sub_host => Host,
+                         from_jid => jid:to_binary(From), nick => Nick,
+                         reason => ErrorReason}),
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
@@ -998,9 +1013,10 @@ iq_set_unregister_info(ServerHost, Host, From, _Lang) ->
         ok ->
             {result, []};
         {error, ErrorReason} ->
-            ?ERROR_MSG("event=iq_set_unregister_info_failed, "
-                        "jid=~ts, reason=~p",
-                       [jid:to_binary(From), ErrorReason]),
+            ?LOG_ERROR(#{what => muc_iq_set_unregister_info_failed,
+                         server => ServerHost, sub_host => Host,
+                         from_jid => jid:to_binary(From),
+                         reason => ErrorReason}),
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -351,8 +351,7 @@ handle_call({create_instant, Room, From, Nick, Opts},
                    history_size = HistorySize,
                    room_shaper = RoomShaper,
                    http_auth_pool = HttpAuthPool} = State) ->
-    ?LOG_DEBUG(#{what => muc_create_instant,
-                 room => Room, sub_host => Host}),
+    ?LOG_DEBUG(#{what => muc_create_instant, room => Room, sub_host => Host}),
     NewOpts = case Opts of
                   default -> DefOpts;
                   _ -> Opts
@@ -387,9 +386,8 @@ handle_info({mnesia_system_event, {mnesia_down, Node}}, State) ->
 handle_info(stop_hibernated_persistent_rooms,
             #state{server_host = ServerHost,
                    hibernated_room_timeout = Timeout} = State) when is_integer(Timeout) ->
-    ?LOG_INFO(#{what => muc_stop_hibernated_persistent_rooms,
-                text => <<"Closing hibernated persistent rooms">>,
-                server => ServerHost}),
+    ?LOG_INFO(#{what => muc_stop_hibernated_persistent_rooms, server => ServerHost,
+                text => <<"Closing hibernated persistent rooms">>}),
     Supervisor = gen_mod:get_module_proc(ServerHost, ejabberd_mod_muc_sup),
     Now = os:timestamp(),
     [stop_if_hibernated(Pid, Now, Timeout * 1000) ||
@@ -507,8 +505,7 @@ route_to_room(Room, Routed, #state{host=Host} = State) ->
     end.
 
 route_to_online_room(Pid, {From, To, Acc, Packet}) ->
-    ?LOG_DEBUG(#{what => muc_route_to_online_room,
-                 room_pid => Pid, acc => Acc}),
+    ?LOG_DEBUG(#{what => muc_route_to_online_room, room_pid => Pid, acc => Acc}),
     {_, _, Nick} = jid:to_lower(To),
     ok = mod_muc_room:route(Pid, From, Nick, Acc, Packet).
 
@@ -592,8 +589,7 @@ get_registered_room_or_route_error_from_packet(Room, From, To, Acc, Packet,
             ejabberd_router:route(To, From, Acc1, Err),
             {route_error, ErrText};
         {ok, Opts} ->
-            ?LOG_DEBUG(#{what => muc_restore_room,
-                         room => Room, room_opts => Opts}),
+            ?LOG_DEBUG(#{what => muc_restore_room, room => Room, room_opts => Opts}),
             #state{history_size = HistorySize,
                    room_shaper = RoomShaper,
                    http_auth_pool = HttpAuthPool} = State,
@@ -754,8 +750,7 @@ start_new_room(Host, ServerHost, Access, Room,
     case mod_muc_db_backend:restore_room(ServerHost, Host, Room) of
         {error, room_not_found} ->
             ?LOG_DEBUG(#{what => muc_start_new_room,
-                         server => ServerHost, sub_host => Host,
-                         room => Room}),
+                         server => ServerHost, sub_host => Host, room => Room}),
             mod_muc_room:start(Host, ServerHost, Access,
                                Room, HistorySize,
                                RoomShaper, HttpAuthPool, From,
@@ -1015,8 +1010,7 @@ iq_set_unregister_info(ServerHost, Host, From, _Lang) ->
         {error, ErrorReason} ->
             ?LOG_ERROR(#{what => muc_iq_set_unregister_info_failed,
                          server => ServerHost, sub_host => Host,
-                         from_jid => jid:to_binary(From),
-                         reason => ErrorReason}),
+                         from_jid => jid:to_binary(From), reason => ErrorReason}),
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -132,8 +132,7 @@ can_use_nick_internal(MucHost, Nick, LUS) ->
         [#muc_registered{us_host = {U, _Host}}] ->
             U == LUS
     catch Class:Reason:Stacktrace ->
-        ?LOG_ERROR(#{what => muc_can_use_nick_failed,
-                     sub_host => MucHost,
+        ?LOG_ERROR(#{what => muc_can_use_nick_failed, sub_host => MucHost,
                      class => Class, reason => Reason, stacktrace => Stacktrace}),
         false
     end.
@@ -169,10 +168,9 @@ set_nick(ServerHost, MucHost, From, Nick)
         {atomic, Result} ->
             Result;
         ErrorResult ->
-            ?LOG_ERROR(#{what => muc_set_nick_failed,
+            ?LOG_ERROR(#{what => muc_set_nick_failed, reason => ErrorResult,
                          server => ServerHost, sub_host => MucHost,
-                         from_jid => jid:to_binary(From), nick => Nick,
-                         reason => ErrorResult}),
+                         from_jid => jid:to_binary(From), nick => Nick}),
             {error, ErrorResult}
     end.
 
@@ -185,8 +183,8 @@ unset_nick(ServerHost, MucHost, From) ->
         {atomic, _} ->
             ok;
         ErrorResult ->
-            ?LOG_ERROR(#{what => muc_unset_nick_failed,
+            ?LOG_ERROR(#{what => muc_unset_nick_failed, reason => ErrorResult,
                          server => ServerHost, sub_host => MucHost,
-                         from_jid => jid:to_binary(From), reason => ErrorResult}),
+                         from_jid => jid:to_binary(From)}),
             {error, ErrorResult}
     end.

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -55,7 +55,7 @@ init(_Host, _Opts) ->
 
 -spec store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
             -> ok | {error, term()}.
-store_room(_ServerHost, MucHost, RoomName, Opts) ->
+store_room(ServerHost, MucHost, RoomName, Opts) ->
     F = fun() ->
                 mnesia:write(#muc_room{name_host = {RoomName, MucHost},
                                        opts = Opts})
@@ -65,12 +65,13 @@ store_room(_ServerHost, MucHost, RoomName, Opts) ->
         {atomic, _} ->
             ok;
         _ ->
-            ?ERROR_MSG("event=store_room_failed room=~ts reason=~p",
-                       [RoomName, Result]),
+            ?LOG_ERROR(#{what => muc_store_room_failed,
+                         sub_host => MucHost, server => ServerHost,
+                         room => RoomName, reason => Result}),
             {error, Result}
     end.
 
-restore_room(_ServerHost, MucHost, RoomName) ->
+restore_room(ServerHost, MucHost, RoomName) ->
     try mnesia:dirty_read(muc_room, {RoomName, MucHost}) of
         [#muc_room{opts = Opts}] ->
             {ok, Opts};
@@ -78,15 +79,16 @@ restore_room(_ServerHost, MucHost, RoomName) ->
             {error, room_not_found};
         Other ->
             {error, Other}
-    catch Class:Reason ->
-        ?ERROR_MSG("event=restore_room_failed room=~ts reason=~p:~p",
-                   [RoomName, Class, Reason]),
+    catch Class:Reason:Stacktrace ->
+        ?LOG_ERROR(#{what => muc_restore_room_failed, room => RoomName,
+                     sub_host => MucHost, server => ServerHost,
+                     class => Class, reason => Reason, stacktrace => Stacktrace}),
         {error, {Class, Reason}}
     end.
 
 -spec forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) ->
     ok | {error, term()}.
-forget_room(_ServerHost, MucHost, RoomName) ->
+forget_room(ServerHost, MucHost, RoomName) ->
     F = fun() ->
                 mnesia:delete({muc_room, {RoomName, MucHost}})
         end,
@@ -95,20 +97,22 @@ forget_room(_ServerHost, MucHost, RoomName) ->
         {atomic, _} ->
             ok;
         _ ->
-            ?ERROR_MSG("event=forget_room_failed room=~ts reason=~p",
-                       [RoomName, Result]),
+            ?LOG_ERROR(#{what => muc_forget_room_failed,
+                         sub_host => MucHost, server => ServerHost,
+                         room => RoomName, reason => Result}),
             {error, Result}
     end.
 
-get_rooms(_Lserver, MucHost) ->
+get_rooms(ServerHost, MucHost) ->
     Query = [{#muc_room{name_host = {'_', MucHost}, _ = '_'},
              [],
              ['$_']}],
     try
         {ok, mnesia:dirty_select(muc_room, Query)}
-    catch Class:Reason ->
-        ?ERROR_MSG("event=get_rooms_failed reason=~p:~p",
-                   [Class, Reason]),
+    catch Class:Reason:Stacktrace ->
+        ?LOG_ERROR(#{what => muc_get_rooms_failed,
+                     sub_host => MucHost, server => ServerHost,
+                     class => Class, reason => Reason, stacktrace => Stacktrace}),
         {error, {Class, Reason}}
     end.
 
@@ -127,9 +131,10 @@ can_use_nick_internal(MucHost, Nick, LUS) ->
             true;
         [#muc_registered{us_host = {U, _Host}}] ->
             U == LUS
-    catch Class:Reason ->
-        ?ERROR_MSG("event=can_use_nick_failed jid=~ts nick=~ts reason=~p:~p",
-                   [jid:to_binary(LUS), Nick, Class, Reason]),
+    catch Class:Reason:Stacktrace ->
+        ?LOG_ERROR(#{what => muc_can_use_nick_failed,
+                     sub_host => MucHost,
+                     class => Class, reason => Reason, stacktrace => Stacktrace}),
         false
     end.
 
@@ -140,13 +145,14 @@ get_nick(_ServerHost, MucHost, From) ->
             {error, not_registered};
         [#muc_registered{nick = Nick}] ->
             {ok, Nick}
-    catch Class:Reason ->
-        ?ERROR_MSG("event=get_nick_failed jid=~ts reason=~p:~p",
-                   [jid:to_binary(From), Class, Reason]),
+    catch Class:Reason:Stacktrace ->
+        ?LOG_ERROR(#{what => muc_get_nick_failed,
+                     sub_host => MucHost, from_jid => jid:to_binary(From),
+                     class => Class, reason => Reason, stacktrace => Stacktrace}),
         {error, {Class, Reason}}
     end.
 
-set_nick(_ServerHost, MucHost, From, Nick)
+set_nick(ServerHost, MucHost, From, Nick)
       when is_binary(Nick), Nick =/= <<>> ->
     LUS = jid:to_lus(From),
     F = fun () ->
@@ -163,12 +169,14 @@ set_nick(_ServerHost, MucHost, From, Nick)
         {atomic, Result} ->
             Result;
         ErrorResult ->
-            ?ERROR_MSG("event=set_nick_failed jid=~ts nick=~ts reason=~1000p",
-                       [jid:to_binary(From), Nick, ErrorResult]),
+            ?LOG_ERROR(#{what => muc_set_nick_failed,
+                         server => ServerHost, sub_host => MucHost,
+                         from_jid => jid:to_binary(From), nick => Nick,
+                         reason => ErrorResult}),
             {error, ErrorResult}
     end.
 
-unset_nick(_ServerHost, MucHost, From) ->
+unset_nick(ServerHost, MucHost, From) ->
     LUS = jid:to_lus(From),
     F = fun () ->
             mnesia:delete({muc_registered, {LUS, MucHost}})
@@ -177,7 +185,8 @@ unset_nick(_ServerHost, MucHost, From) ->
         {atomic, _} ->
             ok;
         ErrorResult ->
-            ?ERROR_MSG("event=unset_nick_failed jid=~ts reason=~1000p",
-                       [jid:to_binary(From), ErrorResult]),
+            ?LOG_ERROR(#{what => muc_unset_nick_failed,
+                         server => ServerHost, sub_host => MucHost,
+                         from_jid => jid:to_binary(From), reason => ErrorResult}),
             {error, ErrorResult}
     end.

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -248,9 +248,7 @@ handle_info({'DOWN', MonitorRef, process, Pid, Info}, State) ->
         error ->
             ?LOG_WARNING(#{what => muc_unknown_monitor,
                            text => <<"Unknown monitored process is now down">>,
-                           monitor_ref => MonitorRef,
-                           monitor_pid => Pid,
-                           reason => Info}),
+                           monitor_ref => MonitorRef, monitor_pid => Pid, reason => Info}),
             {noreply, State};
         {ok, RoomJID} ->
             Monitors = maps:remove(MonitorRef, OldMonitors),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -287,8 +287,8 @@ init([Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
                                    hibernate_timeout = read_hibernate_timeout(ServerHost)
                                   }),
     State1 = set_opts(DefRoomOpts, State),
-    ?INFO_MSG("Created MUC room ~s@~s by ~s",
-              [Room, Host, jid:to_binary(Creator)]),
+    ?LOG_INFO(ls(#{what => muc_room_started,
+                   creator_jid => jid:to_binary(Creator)}, State)),
     add_to_log(room_existence, created, State1),
     case proplists:get_value(instant, DefRoomOpts, false) of
         true ->
@@ -335,7 +335,7 @@ read_hibernate_timeout(Host) ->
                    statename(), state()) -> fsm_return().
 locked_error({route, From, ToNick, Acc, #xmlel{attrs = Attrs} = Packet},
              NextState, StateData) ->
-    ?INFO_MSG("Wrong stanza: ~p", [Packet]),
+    ?LOG_INFO(ls(#{what => muc_route_to_locked_room, acc => Acc}, StateData)),
     ErrText = <<"This room is locked">>,
     Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
     {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
@@ -588,13 +588,12 @@ handle_event({destroy, Reason}, _StateName, StateData) ->
                                     [#xmlel{name = <<"reason">>,
                                             children = [#xmlcdata{content = Reason}]}]
                             end}, StateData),
-    ?INFO_MSG("Destroyed MUC room ~s with reason: ~p",
-          [jid:to_binary(StateData#state.jid), Reason]),
+    ?LOG_INFO(ls(#{what => muc_room_destroyed,
+                   text => <<"Destroyed MUC room">>,
+                   reason => Reason}, StateData)),
     add_to_log(room_existence, destroyed, StateData),
     {stop, shutdown, StateData};
 handle_event(destroy, StateName, StateData) ->
-    ?INFO_MSG("Destroyed MUC room ~s",
-          [jid:to_binary(StateData#state.jid)]),
     handle_event({destroy, none}, StateName, StateData);
 
 handle_event({set_affiliations, Affiliations},
@@ -731,15 +730,17 @@ stop_if_only_owner_is_online(_, _, State) ->
     next_normal_state(State).
 
 do_stop_persistent_room(RoomName, State) ->
-    ?INFO_MSG("Stopping persistent room's process, ~p ~p", [self(), RoomName]),
+    ?LOG_INFO(ls(#{what => muc_room_stopping_persistent,
+                   text => <<"Stopping persistent room's process">>}, State)),
     mongoose_metrics:update(global, [mod_muc, deep_hibernations], 1),
     {stop, normal, State}.
 
 %% @doc Purpose: Shutdown the fsm
 -spec terminate(any(), statename(), state()) -> 'ok'.
 terminate(Reason, _StateName, StateData) ->
-    ?INFO_MSG("Stopping MUC room ~s@~s",
-          [StateData#state.room, StateData#state.host]),
+    ?LOG_INFO(ls(#{what => muc_room_stopping,
+                   text => <<"Stopping room's process">>,
+                   reason => Reason}, StateData)),
     ReasonT = case Reason of
           shutdown -> <<"You are being removed from the room because of a system shutdown">>;
           _ -> <<"Room terminates">>
@@ -1002,8 +1003,9 @@ destroy_temporary_room_if_empty(StateData=#state{config=C=#config{}}, NextState)
     case (not C#config.persistent) andalso is_empty_room(StateData)
         andalso StateData#state.http_auth_pids =:= [] of
         true ->
-            ?INFO_MSG("Destroyed MUC room ~s because it's temporary and empty",
-                  [jid:to_binary(StateData#state.jid)]),
+            ?LOG_INFO(ls(#{what => muc_empty_room_destroyed,
+                           text => <<"Destroyed MUC room because it's temporary and empty">>},
+                         StateData)),
             add_to_log(room_existence, destroyed, StateData),
             {stop, normal, StateData};
         _ ->
@@ -2783,8 +2785,11 @@ process_admin_items_set(UJID, Items, Lang, StateData) ->
     URole = get_role(UJID, StateData),
     case find_changed_items(UJID, UAffiliation, URole, Items, Lang, StateData, []) of
         {result, Res} ->
-            ?INFO_MSG("Processing MUC admin query from ~s in room ~s:~n ~p",
-                      [jid:to_binary(UJID), jid:to_binary(StateData#state.jid), Res]),
+            %% TODO Pass Acc here
+            ?LOG_INFO(ls(#{what => muc_admin_query,
+                           text => <<"Processing MUC admin query">>,
+                           from_jid => jid:to_binary(UJID),
+                           result => Res}, StateData)),
             NSD = lists:foldl(
                     fun(ChangedItem, SD) ->
                             process_admin_item_set(ChangedItem, UJID, SD)
@@ -2804,8 +2809,11 @@ process_admin_item_set(ChangedItem, UJID, SD) ->
     try
         process_admin_item_set_unsafe(ChangedItem, UJID, SD)
     catch
-        _:Error ->
-            ?ERROR_MSG("MUC ITEMS SET ERR: ~p~n", [Error]),
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(ls(#{what => muc_admin_item_set_failed,
+                            from_jid => jid:to_binary(UJID),
+                            changed_item => ChangedItem,
+                            class => Class, reason => Reason, stacktrace => Stacktrace}, SD)),
             SD
     end.
 
@@ -3155,9 +3163,11 @@ can_change_ra(_FAffiliation, _FRole,
 safe_send_kickban_presence(JID, Reason, Code, StateData) ->
     try
         send_kickban_presence(JID, Reason, Code, StateData)
-    catch Error:Reason ->
-        ?ERROR_MSG("issue=send_kickban_presence_failed reason=~p:~p",
-                   [Error, Reason])
+    catch
+        Class:ErrorReason:Stacktrace ->
+            ?LOG_ERROR(ls(#{what => muc_send_kickban_presence_failed,
+                            kick_jid => jid:to_binary(JID), kick_reason => Reason,
+                            class => Class, reason => ErrorReason, stacktrace => Stacktrace}, StateData))
     end.
 
 -spec send_kickban_presence(jid:jid(), binary(), Code :: binary(),
@@ -3170,9 +3180,12 @@ send_kickban_presence(JID, Reason, Code, StateData) ->
 safe_send_kickban_presence(JID, Reason, Code, NewAffiliation, StateData) ->
     try
         send_kickban_presence(JID, Reason, Code, NewAffiliation, StateData)
-    catch Error:Reason ->
-        ?ERROR_MSG("issue=send_kickban_presence_failed reason=~p:~p",
-                   [Error, Reason])
+    catch
+        Class:ErrorReason:Stacktrace ->
+            ?LOG_ERROR(ls(#{what => muc_send_kickban_presence_failed,
+                            new_affiliation => NewAffiliation,
+                            kick_jid => jid:to_binary(JID), kick_reason => Reason,
+                            class => Class, reason => ErrorReason, stacktrace => Stacktrace}, StateData))
     end.
 
 -spec send_kickban_presence(jid:simple_jid() | jid:jid(),
@@ -3253,9 +3266,9 @@ process_authorized_iq_owner(From, set, Lang, SubEl, StateData, StateName) ->
                   xml:get_tag_attr_s(<<"type">>, XEl),
                   StateName} of
                 {?NS_XDATA, <<"cancel">>, locked_state} ->
-                    %% received cancel before the room was configured - destroy room
-                    ?INFO_MSG("Destroyed MUC room ~s by the owner ~s : cancelled",
-                              [jid:to_binary(StateData#state.jid), jid:to_binary(From)]),
+                    ?LOG_INFO(ls(#{what => muc_cancel_locked,
+                                   text => <<"Received cancel before the room was configured - destroy room">>,
+                                   from_jid => jid:to_binary(From)}, StateData)),
                     add_to_log(room_existence, destroyed, StateData),
                     destroy_room(XEl, StateData);
                 {?NS_XDATA, <<"cancel">>, normal_state} ->
@@ -3267,8 +3280,9 @@ process_authorized_iq_owner(From, set, Lang, SubEl, StateData, StateName) ->
                     {error, mongoose_xmpp_errors:bad_request()}
             end;
         [#xmlel{name = <<"destroy">>} = SubEl1] ->
-            ?INFO_MSG("Destroyed MUC room ~s by the owner ~s",
-                      [jid:to_binary(StateData#state.jid), jid:to_binary(From)]),
+            ?LOG_INFO(ls(#{what => muc_room_destroy,
+                           text => <<"Destroyed MUC room by the owner">>,
+                           from_jid => jid:to_binary(From)}, StateData)),
             add_to_log(room_existence, destroyed, StateData),
             destroy_room(SubEl1, StateData);
         Items ->
@@ -4649,9 +4663,10 @@ do_route_iq(Acc, Res1, #routed_iq{iq = #iq{xmlns = XMLNS, sub_el = SubEl} = IQ,
 -spec route_nick_message(routed_nick_message(), state()) -> state().
 route_nick_message(#routed_nick_message{decide = {expulse_sender, Reason},
     packet = Packet, lang = Lang, from = From}, StateData) ->
-    ?DEBUG(Reason, []),
     ErrorText = <<"This participant is kicked from the room because he",
                   "sent an error message to another participant">>,
+    ?LOG_DEBUG(ls(#{what => muc_expulse_sender, text => ErrorText,
+                    user => From#jid.luser, exml_packet => Packet}, StateData)),
     expulse_participant(Packet, From, StateData, translate:translate(Lang, ErrorText));
 route_nick_message(#routed_nick_message{decide = forget_message}, StateData) ->
     StateData;
@@ -4661,11 +4676,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
     ErrText = <<"It is not allowed to send private messages of type groupchat">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:bad_request(Lang, ErrText)),
-    ejabberd_router:route(
-        jid:replace_resource(
-       StateData#state.jid,
-       ToNick),
-        From, Err),
+    route_error(ToNick, From, Err, StateData),
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From,
@@ -4673,11 +4684,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
     ErrText = <<"Recipient is not in the conference room">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
-    ejabberd_router:route(
-        jid:replace_resource(
-       StateData#state.jid,
-       ToNick),
-        From, Err),
+    route_error(ToNick, From, Err, StateData),
     StateData;
 route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = true,
     online = true, packet = Packet, from = From, jid = ToJID}, StateData) ->
@@ -4700,8 +4707,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = f
     ErrText = <<"It is not allowed to send private messages">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:forbidden(Lang, ErrText)),
-    ejabberd_router:route(
-        jid:replace_resource(StateData#state.jid, ToNick), From, Err),
+    route_error(ToNick, From, Err, StateData),
     StateData.
 
 
@@ -4714,10 +4720,7 @@ route_nick_iq(#routed_nick_iq{allow_query = true, online = {true, _, _}, jid = f
     ErrText = <<"Recipient is not in the conference room">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:item_not_found(Lang, ErrText)),
-    ejabberd_router:route(
-        jid:replace_resource(
-       StateData#state.jid, ToNick),
-        From, Err);
+    route_error(ToNick, From, Err, StateData);
 route_nick_iq(#routed_nick_iq{allow_query = true, online = {true, NewId, FromFull},
     jid = ToJID, packet = Packet, stanza = StanzaId}, StateData) ->
     {ok, #user{nick = FromNick}} = maps:find(jid:to_lower(FromFull),
@@ -4739,8 +4742,7 @@ route_nick_iq(#routed_nick_iq{packet = Packet, lang = Lang, nick = ToNick,
     ErrText = <<"Queries to the conference members are "
                 "not allowed in this room">>,
     Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:not_allowed(Lang, ErrText)),
-    RouteFrom = jid:replace_resource(StateData#state.jid, ToNick),
-    ejabberd_router:route(RouteFrom, From, Err).
+    route_error(ToNick, From, Err, StateData).
 
 
 -spec decode_reason(exml:element()) -> binary().
@@ -4776,3 +4778,7 @@ notify_users_modified(#state{server_host = Host, jid = JID, users = Users} = Sta
     mod_muc_log:set_room_occupants(Host, self(), JID, maps:values(Users)),
     State.
 
+
+ls(LogMap, State) ->
+    maps:merge(LogMap, #{room => State#state.room,
+                         sub_host => State#state.host}).

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -588,8 +588,7 @@ handle_event({destroy, Reason}, _StateName, StateData) ->
                                     [#xmlel{name = <<"reason">>,
                                             children = [#xmlcdata{content = Reason}]}]
                             end}, StateData),
-    ?LOG_INFO(ls(#{what => muc_room_destroyed,
-                   text => <<"Destroyed MUC room">>,
+    ?LOG_INFO(ls(#{what => muc_room_destroyed, text => <<"Destroyed MUC room">>,
                    reason => Reason}, StateData)),
     add_to_log(room_existence, destroyed, StateData),
     {stop, shutdown, StateData};
@@ -738,8 +737,7 @@ do_stop_persistent_room(RoomName, State) ->
 %% @doc Purpose: Shutdown the fsm
 -spec terminate(any(), statename(), state()) -> 'ok'.
 terminate(Reason, _StateName, StateData) ->
-    ?LOG_INFO(ls(#{what => muc_room_stopping,
-                   text => <<"Stopping room's process">>,
+    ?LOG_INFO(ls(#{what => muc_room_stopping, text => <<"Stopping room's process">>,
                    reason => Reason}, StateData)),
     ReasonT = case Reason of
           shutdown -> <<"You are being removed from the room because of a system shutdown">>;
@@ -2786,10 +2784,8 @@ process_admin_items_set(UJID, Items, Lang, StateData) ->
     case find_changed_items(UJID, UAffiliation, URole, Items, Lang, StateData, []) of
         {result, Res} ->
             %% TODO Pass Acc here
-            ?LOG_INFO(ls(#{what => muc_admin_query,
-                           text => <<"Processing MUC admin query">>,
-                           from_jid => jid:to_binary(UJID),
-                           result => Res}, StateData)),
+            ?LOG_INFO(ls(#{what => muc_admin_query, text => <<"Processing MUC admin query">>,
+                           from_jid => jid:to_binary(UJID), result => Res}, StateData)),
             NSD = lists:foldl(
                     fun(ChangedItem, SD) ->
                             process_admin_item_set(ChangedItem, UJID, SD)

--- a/src/mod_privacy_rdbms.erl
+++ b/src/mod_privacy_rdbms.erl
@@ -72,17 +72,14 @@ get_default_list_name(LUser, LServer) ->
         {selected, [{DefName}]} ->
             DefName;
         Other ->
-            ?ERROR_MSG("event=get_default_list_name_failed "
-                       "user=~ts server=~ts result=~1000p",
-                       [LUser, LServer, Other]),
+            ?LOG_ERROR(#{what => privacy_get_default_list_name_failed,
+                         user => LUser, server => LServer, reason => Other}),
             none
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=get_default_list_name_failed "
-                       "user=~ts server=~ts"
-                       "reason=~p:~p stacktrace=~1000p",
-                       [LUser, LServer,
-                        Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => privacy_get_default_list_name_failed,
+                         user => LUser, server => LServer,
+                         class => Class, reason => Reason, stacktrace => StackTrace}),
             none
     end.
 
@@ -91,17 +88,14 @@ get_list_names_only(LUser, LServer) ->
         {selected, Names} ->
             [Name || {Name} <- Names];
         Other ->
-            ?ERROR_MSG("event=get_list_names_only_failed "
-                       "user=~ts server=~ts result=~1000p",
-                       [LUser, LServer, Other]),
+            ?LOG_ERROR(#{what => privacy_get_list_names_only_failed,
+                         user => LUser, server => LServer, reason => Other}),
             []
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=get_list_names_only_failed "
-                       "user=~ts server=~ts"
-                       "reason=~p:~p stacktrace=~1000p",
-                       [LUser, LServer,
-                        Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => privacy_get_list_names_only_failed,
+                         user => LUser, server => LServer,
+                         class => Class, reason => Reason, stacktrace => StackTrace}),
             []
     end.
 
@@ -114,17 +108,15 @@ get_privacy_list(LUser, LServer, Name) ->
             IntID = mongoose_rdbms:result_to_integer(ID),
             get_privacy_list_by_id(LUser, LServer, Name, IntID, LServer);
         Other ->
-            ?ERROR_MSG("event=get_privacy_list_failed "
-                       "user=~ts server=~ts listname=~ts result=~1000p",
-                       [LUser, LServer, Name, Other]),
+            ?LOG_ERROR(#{what => privacy_get_privacy_list_failed,
+                         user => LUser, server => LServer, list_name => Name,
+                         reason => Other}),
             {error, Other}
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=get_privacy_list_failed "
-                       "user=~ts server=~ts listname=~ts"
-                       "reason=~p:~p stacktrace=~1000p",
-                       [LUser, LServer, Name,
-                        Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => privacy_get_privacy_list_failed,
+                         user => LUser, server => LServer, list_name => Name,
+                         class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, Reason}
     end.
 
@@ -134,17 +126,15 @@ get_privacy_list_by_id(LUser, LServer, Name, ID, LServer) when is_integer(ID) ->
             Items = raw_to_items(RItems),
             {ok, Items};
         Other ->
-            ?ERROR_MSG("event=get_privacy_list_by_id_failed "
-                       "user=~ts server=~ts listname=~ts id=~p result=~1000p",
-                       [LUser, LServer, Name, ID, Other]),
+            ?LOG_ERROR(#{what => privacy_get_privacy_list_by_id_failed,
+                         user => LUser, server => LServer, list_name => Name, list_id => ID,
+                         reason => Other}),
             {error, Other}
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=get_privacy_list_by_id_failed "
-                       "user=~ts server=~ts listname=~ts id=~p"
-                       "reason=~p:~p stacktrace=~1000p",
-                       [LUser, LServer, Name, ID,
-                        Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => privacy_get_privacy_list_by_id_failed,
+                         user => LUser, server => LServer, list_name => Name, list_id => ID,
+                         class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, Reason}
     end.
 
@@ -157,17 +147,14 @@ forget_default_list(LUser, LServer) ->
         {updated, _} ->
             ok;
         Other ->
-            ?ERROR_MSG("event=forget_default_list_failed "
-                       "user=~ts server=~ts result=~1000p",
-                       [LUser, LServer, Other]),
+            ?LOG_ERROR(#{what => privacy_forget_default_list_failed,
+                         user => LUser, server => LServer, reason => Other}),
             {error, Other}
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=forget_default_list_failed "
-                       "user=~ts server=~ts"
-                       "reason=~p:~p stacktrace=~1000p",
-                       [LUser, LServer,
-                        Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => privacy_forget_default_list_failed,
+                         user => LUser, server => LServer,
+                         class => Class, reason => Reason, stacktrace => StackTrace}),
             {error, Reason}
     end.
 

--- a/src/mod_privacy_riak.erl
+++ b/src/mod_privacy_riak.erl
@@ -88,7 +88,8 @@ get_list_names_only(LUser, LServer) ->
         {error, {notfound, set}} ->
             [];
         Err ->
-            ?ERROR_MSG("~p", [Err]),
+            ?LOG_ERROR(#{what => privacy_get_list_names_only_failed,
+                         user => LUser, server => LServer, reason => Err}),
             []
     end.
 
@@ -99,8 +100,10 @@ get_privacy_list(LUser, LServer, Name) ->
             {ok, Val};
         {error, notfound} ->
             {error, not_found};
-        Err->
-            ?ERROR_MSG("~p", [Err]),
+        Err ->
+            ?LOG_ERROR(#{what => privacy_get_list_names_only_failed,
+                         user => LUser, server => LServer, list_name => Name,
+                         reason => Err}),
             Err
     end.
 
@@ -127,7 +130,9 @@ remove_privacy_list(LUser, LServer, Name) ->
             S2 = riakc_set:del_element(Name, S1),
             mongoose_riak:update_type(?BKT_LISTS_NAMES(LServer), LUser, riakc_set:to_op(S2));
         Err ->
-            ?ERROR_MSG("~p", [Err]),
+            ?LOG_ERROR(#{what => privacy_remove_privacy_list_failed,
+                         user => LUser, server => LServer, list_name => Name,
+                         reason => Err}),
             Err
     end.
 

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -140,12 +140,12 @@ process_sm_iq(
                 ok ->
                     IQ#iq{type = result, sub_el = [SubElem]};
                 {error, Reason} ->
-                    ?ERROR_MSG("~p:multi_set_data failed ~p for ~ts@~ts.",
-                               [mod_private_backend, Reason, LUser, LServer]),
+                    ?LOG_ERROR(#{what => multi_set_data_failed, reason => Reason,
+                                 user => LUser, server => LServer}),
                     error_iq(IQ, mongoose_xmpp_errors:internal_server_error());
                 {aborted, Reason} ->
-                    ?ERROR_MSG("~p:multi_set_data aborted ~p for ~ts@~ts.",
-                               [mod_private_backend, Reason, LUser, LServer]),
+                    ?LOG_ERROR(#{what => multi_set_data_aborted, reason => Reason,
+                                 user => LUser, server => LServer}),
                     error_iq(IQ, mongoose_xmpp_errors:internal_server_error())
             end;
         not_allowed ->

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -362,8 +362,8 @@ check_timeout(Source) ->
                 {atomic, Res} ->
                     Res;
                 {aborted, Reason} ->
-                    ?ERROR_MSG("mod_register: timeout check error: ~p~n",
-                               [Reason]),
+                    ?LOG_ERROR(#{what => reg_check_timeout_failed,
+                                 reg_source => Source, reason => Reason}),
                     true
             end;
         false ->
@@ -418,8 +418,8 @@ is_strong_password(Server, Password) ->
         Entropy when is_number(Entropy), Entropy > 0 ->
             ejabberd_auth:entropy(Password) >= Entropy;
         Wrong ->
-            ?WARNING_MSG("Wrong value for password_strength option: ~p",
-                         [Wrong]),
+            ?LOG_WARNING(#{what => reg_wrong_password_strength,
+                           host => Server, value => Wrong}),
             true
     end.
 
@@ -435,7 +435,8 @@ get_ip_access(Host) ->
                   {ok, IP, Mask} ->
                       [{Access, IP, Mask}];
                   error ->
-                      ?ERROR_MSG("mod_register: invalid network specification: ~p", [S]),
+                      ?LOG_ERROR(#{what => reg_invalid_network_specification,
+                                   specification => S}),
                       []
               end
       end, IPAccess).

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -508,7 +508,7 @@ set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2) ->
                 _ -> ok
             end;
         E ->
-            ?ERROR_MSG("event=set_roster_item_failed reason=~1000p", [E]), ok
+            ?LOG_ERROR(#{what => roster_set_item_failed, reason => E}), ok
     end.
 
 process_item_attrs(Item, [{<<"jid">>, Val} | Attrs]) ->
@@ -881,8 +881,8 @@ try_send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
         send_unsubscription_to_rosteritems(Acc, LUser, LServer)
     catch
         E:R:S ->
-            ?WARNING_MSG("event=cannot_send_unsubscription_to_rosteritems,"
-                         "class=~p,reason=~p,stacktrace=~p", [E, R, S]),
+            ?LOG_WARNING(#{what => roster_unsubcribe_failed,
+                           class => E, reason => R, stacktrace => S}),
             Acc
     end.
 

--- a/src/mod_roster_rdbms.erl
+++ b/src/mod_roster_rdbms.erl
@@ -84,9 +84,8 @@ get_roster(LUser, LServer) ->
             RItems;
         _ -> []
     catch Class:Reason:StackTrace ->
-        ?ERROR_MSG("event=get_roster_failed "
-                   "reason=~p:~p user=~ts stacktrace=~1000p",
-                   [Class, Reason, LUser, StackTrace]),
+        ?LOG_ERROR(#{what => get_roster_failed, class => Class, reason => Reason,
+                     stacktrace => StackTrace, user => LUser, host => LServer}),
         []
     end.
 
@@ -163,13 +162,13 @@ get_subscription_lists(_, LUser, LServer) ->
         {selected, Items} when is_list(Items) ->
             Items;
         Other ->
-            ?ERROR_MSG("event=get_subscription_lists_failed "
-                       "reason=~p user=~ts", [Other, LUser]),
+            ?LOG_ERROR(#{what => get_subscription_lists_failed, reason => Other,
+                        user => LUser, host => LServer}),
             []
     catch Class:Reason:StackTrace ->
-        ?ERROR_MSG("event=get_subscription_lists_failed "
-                   "reason=~p:~p user=~ts stacktrace=~1000p",
-                   [Class, Reason, LUser, StackTrace]),
+        ?LOG_ERROR(#{what => get_subscription_lists_failed, class => Class,
+                     reason => Reason, stacktrace => StackTrace,
+                     user => LUser, host => LServer}),
         []
     end.
 
@@ -260,14 +259,15 @@ read_subscription_and_groups(LUser, LServer, LJID, GSFunc, GRFunc) ->
                          {selected, JGrps} when is_list(JGrps) ->
                              [JGrp || {JGrp} <- JGrps];
                          _ ->
-                             ?ERROR_MSG("event=read_subscription_and_groups_failed "
-                                        "user=~ts result=~p", [LUser, GRResult]),
+                             ?LOG_ERROR(#{what => read_subscription_and_groups_failed,
+                                          reason => GRResult, user => LUser,
+                                          host => LServer}),
                              []
                      end,
             {Subscription, Groups};
         E ->
-           ?ERROR_MSG("event=read_subscription_and_groups_failed "
-                      "user=~ts reason=~p", [LUser, E]),
+           ?LOG_ERROR(#{what => read_subscription_and_groups_failed,
+                        reason => E, user => LUser, host => LServer}),
             error
     end.
 

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -51,7 +51,7 @@
 %%
 
 start(Host, Opts) ->
-    ?INFO_MSG("mod_stream_management starting", []),
+    ?LOG_INFO(#{what => mod_stream_management_starting}),
     ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:add(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:add(session_cleanup, Host, ?MODULE, session_cleanup, 50),
@@ -63,7 +63,7 @@ start(Host, Opts) ->
     ok.
 
 stop(Host) ->
-    ?INFO_MSG("mod_stream_management stopping", []),
+    ?LOG_INFO(#{what => mod_stream_management_stopping}),
     ejabberd_hooks:delete(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:delete(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:delete(session_cleanup, Host, ?MODULE, session_cleanup, 50),

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -51,7 +51,7 @@
 %%
 
 start(Host, Opts) ->
-    ?LOG_INFO(#{what => mod_stream_management_starting}),
+    ?LOG_INFO(#{what => stream_management_starting}),
     ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:add(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:add(session_cleanup, Host, ?MODULE, session_cleanup, 50),
@@ -63,7 +63,7 @@ start(Host, Opts) ->
     ok.
 
 stop(Host) ->
-    ?LOG_INFO(#{what => mod_stream_management_stopping}),
+    ?LOG_INFO(#{what => stream_management_stopping}),
     ejabberd_hooks:delete(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:delete(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:delete(session_cleanup, Host, ?MODULE, session_cleanup, 50),

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -163,9 +163,8 @@ get_results_limit(LServer) ->
         Val when is_integer(Val) and (Val > 0) ->
             Val;
         Val ->
-            ?ERROR_MSG("Illegal option value ~p. "
-            "Default value ~p substituted.",
-                [{matches, Val}, ?JUD_MATCHES]),
+            ?LOG_ERROR(#{what => illegal_option_error, value => {matches, Val},
+                         default_value => ?JUD_MATCHES}),
             ?JUD_MATCHES
     end.
 
@@ -265,11 +264,11 @@ handle_call(_Request, _From, State) ->
 
 handle_info({route, From, To, Acc, _El}, State) ->
     {IQ, Acc1} = mongoose_iq:info(Acc),
-    case catch do_route(State#state.host, From, To, Acc1, IQ) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("~p", [Reason]);
-        _ ->
-            ok
+    try do_route(State#state.host, From, To, Acc1, IQ)
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{what => vcard_route_failed, acc => Acc,
+                         class => Class, reason => Reason, stacktrace => Stacktrace})
     end,
     {noreply, State};
 handle_info(_, State) ->
@@ -319,23 +318,16 @@ process_sm_iq(From, To, Acc, #iq{type = set, sub_el = VCARD} = IQ) ->
                           sub_el = [VCARD, ReasonEl]
                          };
                 {error, Reason} ->
-                    ?WARNING_MSG("issue=process_sm_iq_set_failed, "
-                                 "reason=~p", [Reason]),
+                    ?LOG_WARNING(#{what => vcard_sm_iq_set_failed,
+                                   reason => Reason, acc => Acc}),
                     ReasonEl = mongoose_xmpp_errors:unexpected_request_cancel(),
                     IQ#iq{type = error,
                           sub_el = [VCARD, ReasonEl]}
             catch
                 E:R:Stack ->
-                    ?ERROR_MSG("issue=process_sm_iq_set_failed "
-                                "reason=~p:~p "
-                                "stacktrace=~1000p "
-                                "from=~ts "
-                                "to=~ts "
-                                "sub_el=~ts",
-                                [E, R, Stack,
-                                 jid:to_binary(From),
-                                 jid:to_binary(To),
-                                 exml:to_binary(VCARD)]),
+                    ?LOG_ERROR(#{what => vcard_sm_iq_set_failed,
+                                 class => E, reason => R, stacktrace => Stack,
+                                 acc => Acc}),
                     IQ#iq{type = error,
                           sub_el = [VCARD, mongoose_xmpp_errors:internal_server_error()]}
             end;
@@ -352,16 +344,9 @@ process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
         {error, Reason} ->
             IQ#iq{type = error, sub_el = [SubEl, Reason]}
         catch E:R:Stack ->
-            ?ERROR_MSG("issue=process_sm_iq_get_failed "
-                        "reason=~p:~p "
-                        "stacktrace=~1000p "
-                        "from=~ts "
-                        "to=~ts "
-                        "sub_el=~ts",
-                        [E, R, Stack,
-                         jid:to_binary(From),
-                         jid:to_binary(To),
-                         exml:to_binary(SubEl)]),
+            ?LOG_ERROR(#{what => vcard_sm_iq_get_failed,
+                         class => E, reason => R, stacktrace => Stack,
+                         acc => Acc}),
             IQ#iq{type = error,
                   sub_el = [SubEl, mongoose_xmpp_errors:internal_server_error()]}
     end,
@@ -383,16 +368,17 @@ unsafe_set_vcard(From, VCARD) ->
       VCARD :: exml:element(),
       Result :: ok | error().
 set_vcard(ok, _From, _VCARD) ->
-    ?DEBUG("hook call already handled - skipping", []),
+    ?LOG_DEBUG(#{what => hook_call_already_handled}),
     ok;
 set_vcard({error, no_handler_defined}, From, VCARD) ->
     try unsafe_set_vcard(From, VCARD) of
         ok -> ok;
         {error, Reason} ->
-            ?ERROR_MSG("unsafe set_vcard failed: ~p", [Reason]),
+            ?LOG_ERROR(#{what => unsafe_set_vcard_failed, reason => Reason}),
             {error, Reason}
     catch
-        E:R -> ?ERROR_MSG("unsafe set_vcard failed: ~p", [{E, R}]),
+        E:R:S -> ?LOG_ERROR(#{what => unsafe_set_vcard_failed, class => E,
+                              reason => R, stacktrace => S}),
                {error, {E, R}}
     end;
 set_vcard({error, _} = E, _From, _VCARD) -> E.

--- a/src/mod_vcard_mnesia.erl
+++ b/src/mod_vcard_mnesia.erl
@@ -41,7 +41,8 @@ get_vcard(LUser, LServer) ->
                             end, Rs),
             {ok, Els};
         {aborted, Reason} ->
-            ?ERROR_MSG("vCard lookup failed in process_sm_iq: ~p", [Reason]),
+            ?LOG_ERROR(#{what => process_sm_iq_vcard_lookup_failed,
+                         reason => Reason, user => LUser, server => LServer}),
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
@@ -67,7 +68,8 @@ do_search(VHost, MatchHeadIn) ->
     case catch mnesia:dirty_select(vcard_search,
         [{MatchHead, [], ['$_']}]) of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("~p", [Reason]),
+            ?LOG_ERROR(#{what => vcard_search_failed, server => VHost,
+                         reason => Reason}),
             [];
         Rs ->
             case mod_vcard:get_results_limit(VHost) of

--- a/src/mod_vcard_rdbms.erl
+++ b/src/mod_vcard_rdbms.erl
@@ -57,7 +57,10 @@ get_vcard(LUser, LServer) ->
         {selected, [{SVCARD}]} ->
             case exml:parse(SVCARD) of
                 {error, Reason} ->
-                    ?WARNING_MSG("not sending bad vcard xml ~p~n~p", [Reason, SVCARD]),
+                    ?LOG_WARNING(#{what => vcard_corrupted,
+                                   text => <<"Not sending back bad vCard XML">>,
+                                   reason => Reason, svcard => SVCARD,
+                                   user => LUser, host => LServer}),
                     {error, mongoose_xmpp_errors:service_unavailable()};
                 {ok, VCARD} ->
                     {ok, [VCARD]}
@@ -121,7 +124,8 @@ do_search(LServer, RestrictionSQL) ->
         {selected, Rs} when is_list(Rs) ->
             Rs;
         Error ->
-            ?ERROR_MSG("~p", [Error]),
+            ?LOG_ERROR(#{what => vcard_db_search_failed,
+                         reason => Error, host => LServer}),
             []
     end.
 

--- a/src/mod_vcard_riak.erl
+++ b/src/mod_vcard_riak.erl
@@ -58,7 +58,8 @@ get_vcard(LUser, LServer) ->
                 {ok, XMLEl} ->
                     {ok, [XMLEl]};
                 {error, Reason} ->
-                    ?WARNING_MSG("not sending bad vcard reason=~p, xml=~n~p", [Reason, XMLBin]),
+                    ?LOG_WARNING(#{what => vcard_lookup_failed, reason => Reason,
+                                   packet => XMLBin}),
                     {error, mongoose_xmpp_errors:service_unavailable()}
             end;
         {error, notfound} ->
@@ -83,8 +84,8 @@ do_search(YZQueryIn, VHost) ->
         {ok, #search_results{docs=R, num_found = _N}} ->
             lists:map(fun({_Index, Props}) -> doc2item(VHost, Props) end, R);
         Err ->
-            ?ERROR_MSG("Error while search vCard, index=~s, query=~s, error=~p",
-                [yz_vcard_index(VHost), YZQueryBin, Err]),
+            ?LOG_ERROR(#{what => vcard_search_failed, index => yz_vcard_index(VHost),
+                         riak_query => YZQueryBin, reason => Err}),
             []
     end.
 

--- a/src/mongoose_api_admin.erl
+++ b/src/mongoose_api_admin.erl
@@ -54,9 +54,9 @@ cowboy_router_paths(Base, Opts) ->
             Commands = mongoose_commands:list(admin),
             [handler_path(Base, Command, Opts) || Command <- Commands]
         catch
-            _:Err:StackTrace ->
-                ?ERROR_MSG("Error occured when getting the commands list: ~p~n~p",
-                           [Err, StackTrace]),
+            Class:Err:StackTrace ->
+                ?LOG_ERROR(#{what => getting_command_list_error,
+                             class => Class, reason => Err, stacktrace => StackTrace}),
                 []
         end.
 

--- a/src/mongoose_api_client.erl
+++ b/src/mongoose_api_client.erl
@@ -50,8 +50,9 @@ cowboy_router_paths(Base, _Opts) ->
         Commands = mongoose_commands:list(user),
         [handler_path(Base, Command) || Command <- Commands]
     catch
-        _:Err ->
-            ?ERROR_MSG("Error occured when getting the commands list: ~p~n", [Err]),
+        Class:Err:Stacktrace ->
+            ?LOG_ERROR(#{what => rest_getting_command_list_failed,
+                         class => Class, reason => Err, stacktrace => Stacktrace}),
             []
     end.
 

--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -180,10 +180,8 @@ parse_request_body(Req) ->
         {Params, Req2}
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("issue=parse_request_body_failed "
-                       "reason=~p:~p "
-                       "stacktrace=~1000p",
-                       [Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => parse_request_body_failed, class => Class,
+                         reason => Reason, stacktrace => StackTrace}),
             {error, Reason}
     end.
 
@@ -199,10 +197,8 @@ check_and_extract_args(ReqArgs, OptArgs, RequestArgList) ->
         maps:from_list(ConvArgs)
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("issue=check_and_extract_args_failed "
-                       "reason=~p:~p "
-                       "stacktrace=~1000p",
-                       [Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => check_and_extract_args_failed, class => Class,
+                         reason => Reason, stacktrace => StackTrace}),
             {error, bad_request, Reason}
     end.
 
@@ -217,10 +213,8 @@ execute_command(ArgMap, Command, Entity) ->
         do_execute_command(ArgMap, Command, Entity)
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("issue=execute_command_failed "
-                       "reason=~p:~p "
-                       "stacktrace=~1000p",
-                       [Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => execute_command_failed, class => Class,
+                         reason => Reason, stacktrace => StackTrace}),
             {error, bad_request, Reason}
     end.
 

--- a/src/mongoose_client_api/mongoose_client_api_contacts.erl
+++ b/src/mongoose_client_api/mongoose_client_api_contacts.erl
@@ -131,7 +131,9 @@ serve_failure(not_found, Req, State) ->
     Req2 = cowboy_req:reply(404, Req),
     {stop, Req2, State};
 serve_failure({error, ErrorType, Msg}, Req, State) ->
-    ?ERROR_MSG("Error while serving http request: ~p: ~s", [ErrorType, Msg]),
+    ?LOG_ERROR(#{what => api_contacts_error,
+                 text => <<"Error while serving http request. Return code 500">>,
+                 error_type => ErrorType, msg => Msg, req => Req}),
     Req2 = cowboy_req:reply(500, Req),
     {stop, Req2, State}.
 

--- a/src/mongoose_client_api/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms.erl
@@ -166,8 +166,9 @@ validate_room_id(RoomIDOrJID, Server) ->
             {ok, RoomID};
         #jid{luser = RoomID, lserver = MUCLightDomain, lresource = <<>>} ->
             {ok, RoomID};
-        _ ->
-            ?WARNING_MSG("issue=invalid_room_id id=~p muclight_domain=~p",
-                         [RoomIDOrJID, MUCLightDomain]),
+        Other ->
+            ?LOG_WARNING(#{what => muc_invalid_room_id,
+                           text => <<"REST received room_id field is unknown format">>,
+                           server => Server, room => RoomIDOrJID, reason => Other}),
             error
     end.

--- a/src/mongoose_client_api/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms.erl
@@ -168,7 +168,8 @@ validate_room_id(RoomIDOrJID, Server) ->
             {ok, RoomID};
         Other ->
             ?LOG_WARNING(#{what => muc_invalid_room_id,
-                           text => <<"REST received room_id field is unknown format">>,
+                           text => <<"REST received room_id field is invalid "
+                                     "or of unknown format">>,
                            server => Server, room => RoomIDOrJID, reason => Other}),
             error
     end.

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -31,14 +31,14 @@ maybe_init({false, Value}, Req, State) ->
     {shutdown, 401, Headers, <<>>, Req, State}.
 
 handle_notify(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_message, msg => Msg}),
+    ?UNEXPECTED_INFO(Msg),
     {nosend, State}.
 
 handle_info({route, _From, _To, Acc}, State) ->
     #xmlel{ name = TagName } = El = mongoose_acc:element(Acc),
     handle_msg(TagName, Acc, El, State);
 handle_info(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_message, msg => Msg}),
+    ?UNEXPECTED_INFO(Msg),
     {nosend, State}.
 
 handle_msg(<<"message">>, Acc, El, State) ->

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -11,7 +11,7 @@
 -export([terminate/3]).
 
 init(_InitArgs, _LastEvtId, Req) ->
-    ?DEBUG("issue=mongoose_client_api_sse:init", []),
+    ?LOG_DEBUG(#{what => client_api_sse_init, req => Req}),
     {cowboy_rest, Req1, State0} = mongoose_client_api:init(Req, []),
     {Authorization, Req2, State} = mongoose_client_api:is_authorized(Req1, State0),
     maybe_init(Authorization, Req2, State#{id => 1}).
@@ -30,13 +30,15 @@ maybe_init({false, Value}, Req, State) ->
     Headers = #{<<"www-authenticate">> => Value},
     {shutdown, 401, Headers, <<>>, Req, State}.
 
-handle_notify(_Msg, State) ->
+handle_notify(Msg, State) ->
+    ?LOG_WARNING(#{what => unexpected_message, msg => Msg}),
     {nosend, State}.
 
 handle_info({route, _From, _To, Acc}, State) ->
     #xmlel{ name = TagName } = El = mongoose_acc:element(Acc),
     handle_msg(TagName, Acc, El, State);
-handle_info(_Msg, State) ->
+handle_info(Msg, State) ->
+    ?LOG_WARNING(#{what => unexpected_message, msg => Msg}),
     {nosend, State}.
 
 handle_msg(<<"message">>, Acc, El, State) ->
@@ -44,7 +46,8 @@ handle_msg(<<"message">>, Acc, El, State) ->
     Type = mongoose_acc:stanza_type(Acc),
     maybe_send_message_event(Type, El, Timestamp, State).
 
-handle_error(_Msg, _Reson, State) ->
+handle_error(Msg, Reason, State) ->
+    ?LOG_WARNING(#{what => sse_handle_error, msg => Msg, reason => Reason}),
     {nosend, State}.
 
 terminate(_Reson, _Req, State) ->

--- a/src/mongoose_deprecations.erl
+++ b/src/mongoose_deprecations.erl
@@ -63,7 +63,7 @@ log(Tag, Msg, Opts) ->
     LogLvl = proplists:get_value(log_level, Opts, default_log_lvl()),
     maybe_log(Tag, Msg, LogLvl, Cooldown).
 
--spec log(deprecation_tag(), string()) -> ok.
+-spec log(deprecation_tag(), log_map()) -> ok.
 log(Tag, Msg) ->
     log(Tag, Msg, []).
 

--- a/src/mongoose_deprecations.erl
+++ b/src/mongoose_deprecations.erl
@@ -28,6 +28,7 @@
 -type deprecation_tag() :: any().              % Specifies the deprecation
 -type log_level() :: warning | error.
 -type unix_timestamp() :: mod_mam:unix_timestamp().
+-type log_map() :: map().
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -55,11 +56,10 @@ stop() ->
 %%                   It is internally represented in microseconds
 %%                   but API requires milliseconds.
 %%      * log_level - 'warning' or 'error'
--spec log(deprecation_tag(), string(), proplists:proplist()) -> ok.
+-spec log(deprecation_tag(), log_map(), proplists:proplist()) -> ok.
 log(Tag, Msg, Opts) ->
-    Cooldown = milliseconds_to_microseconds(
-                 proplists:get_value(cooldown, Opts, default_cooldown())
-                ),
+    Ms = proplists:get_value(cooldown, Opts, default_cooldown()),
+    Cooldown = milliseconds_to_microseconds(Ms),
     LogLvl = proplists:get_value(log_level, Opts, default_log_lvl()),
     maybe_log(Tag, Msg, LogLvl, Cooldown).
 
@@ -87,7 +87,7 @@ destroy_ets() ->
     ets:delete(?DEPRECATION_TAB),
     ok.
 
--spec maybe_log(deprecation_tag(), string(), log_level(), unix_timestamp()) -> ok.
+-spec maybe_log(deprecation_tag(), log_map(), log_level(), unix_timestamp()) -> ok.
 maybe_log(Tag, Msg, Lvl, Cooldown) ->
     Timestamp = case ets:lookup(?DEPRECATION_TAB, Tag) of
                              [] ->
@@ -117,11 +117,11 @@ default_cooldown() -> ?DEFAULT_COOLDOWN_HOURS * 3600000000.
 -spec default_log_lvl() -> log_level().
 default_log_lvl() -> error.
 
--spec log_with_lvl(string(), log_level()) -> ok.
+-spec log_with_lvl(log_map(), log_level()) -> ok.
 log_with_lvl(Msg, error) ->
-    ?ERROR_MSG(Msg, []);
+    ?LOG_ERROR(Msg);
 log_with_lvl(Msg, warning) ->
-    ?WARNING_MSG(Msg, []).
+    ?LOG_WARNING(Msg).
 
 -spec milliseconds_to_microseconds(Milliseconds :: integer()) 
         -> unix_timestamp().

--- a/src/mongoose_fips.erl
+++ b/src/mongoose_fips.erl
@@ -31,12 +31,15 @@ do_notify() ->
         true ->
             case crypto:info_fips() of
                 enabled ->
-                    ?WARNING_MSG("FIPS mode enabled", []);
+                    ?LOG_NOTICE(#{what => fips_mode_enabled,
+                                   text => <<"FIPS mode enabled">>});
                 _ ->
-                    ?ERROR_MSG("FIPS mode disabled although it should be enabled", [])
+                    ?LOG_ERROR(#{what => fips_mode_disabled,
+                                 text => <<"FIPS mode disabled although it should be enabled">>})
             end;
         _ ->
-            ?INFO_MSG("Used Erlang/OTP does not support FIPS mode", [])
+            ?LOG_INFO(#{what => fips_mode_not_supported,
+                        text => <<"Used Erlang/OTP does not support FIPS mode">>})
     end.
 
 status() ->

--- a/src/mongoose_iq.erl
+++ b/src/mongoose_iq.erl
@@ -39,11 +39,9 @@ try_to_handle_iq(From, To, IQ = #iq{sub_el = SubEl}, HandlerF) ->
     try
         HandlerF(From, To, IQ)
     catch Class:Reason:StackTrace ->
-        ?ERROR_MSG("event=handing_iq_failed "
-                   "from=~ts to=~ts iq=~1000p "
-                   "reason=~p:~p stacktrace=~1000p",
-                   [jid:to_binary(From), jid:to_binary(To), IQ,
-                    Class, Reason, StackTrace]),
+        ?LOG_ERROR(#{what => iq_handler_hailed,
+                     from_jid => jid:to_binary(From), to_jid => jid:to_binary(To), iq => IQ,
+                     class => Class, reason => Reason, stacktrace => StackTrace}),
         IQ#iq{type = error,
               sub_el = [SubEl, mongoose_xmpp_errors:internal_server_error()]}
     end.

--- a/src/mongoose_iq.erl
+++ b/src/mongoose_iq.erl
@@ -39,7 +39,7 @@ try_to_handle_iq(From, To, IQ = #iq{sub_el = SubEl}, HandlerF) ->
     try
         HandlerF(From, To, IQ)
     catch Class:Reason:StackTrace ->
-        ?LOG_ERROR(#{what => iq_handler_hailed,
+        ?LOG_ERROR(#{what => iq_handler_failed,
                      from_jid => jid:to_binary(From), to_jid => jid:to_binary(To), iq => IQ,
                      class => Class, reason => Reason, stacktrace => StackTrace}),
         IQ#iq{type = error,

--- a/src/mongoose_ldap_worker.erl
+++ b/src/mongoose_ldap_worker.erl
@@ -38,14 +38,14 @@ handle_call(Request, _From, State) ->
 
 -spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast(Cast, State) ->
-    ?ERROR_MSG("Invalid cast: ~p", [Cast]),
+    ?LOG_WARNING(#{what => unexpected_cast, msg => Cast}),
     {noreply, State}.
 
 -spec handle_info(any(), state()) -> {noreply, state()}.
 handle_info(connect, State) ->
     {noreply, connect(State)};
 handle_info(Info, State) ->
-    ?ERROR_MSG("Unexpected info: ~p", [Info]),
+    ?LOG_WARNING(#{what => unexpected_message, msg => Info}),
     {noreply, State}.
 
 -spec terminate(any(), state()) -> ok.
@@ -98,7 +98,9 @@ call_eldap(Request, State) ->
     case do_call_eldap(Request, State) of
         {error, Reason} when Reason =:= ldap_closed;
                              Reason =:= {gen_tcp_error, closed} ->
-            ?INFO_MSG("LDAP request failed: connection closed, reconnecting...", []),
+            ?LOG_INFO(#{what => ldap_request_failed,
+                        text => <<"LDAP request failed: connection closed, reconnecting...">>,
+                        reason => Reason}),
             eldap:close(maps:get(handle, State)),
             NewState = connect(State#{handle := none}),
             retry_call_eldap(Request, NewState);
@@ -123,16 +125,23 @@ connect(State = #{handle := none,
         {ok, Handle} ->
             case eldap:simple_bind(Handle, RootDN, Password) of
                 ok ->
-                    ?INFO_MSG("Connected to LDAP server", []),
+                    ?LOG_INFO(#{what => ldap_connected,
+                                text => <<"Connected to LDAP server">>}),
                     State#{handle := Handle};
                 Error ->
-                    ?ERROR_MSG("LDAP authentication failed: ~p", [Error]),
+                    ?LOG_ERROR(#{what => ldap_auth_failed,
+                                 text => <<"LDAP bind returns an error">>,
+                                 ldap_servers => Servers, port => Port,
+                                 reason => Error}),
                     eldap:close(Handle),
                     erlang:send_after(ConnectInterval, self(), connect),
                     State
             end;
         Error ->
-            ?ERROR_MSG("LDAP connection failed: ~p", [Error]),
+            ?LOG_ERROR(#{what => ldap_connect_failed,
+                         text => <<"LDAP open returns an error">>,
+                         ldap_servers => Servers, port => Port,
+                         reason => Error}),
             erlang:send_after(ConnectInterval, self(), connect),
             State
     end.

--- a/src/mongoose_ldap_worker.erl
+++ b/src/mongoose_ldap_worker.erl
@@ -38,14 +38,14 @@ handle_call(Request, _From, State) ->
 
 -spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast(Cast, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, msg => Cast}),
+    ?UNEXPECTED_CAST(Cast),
     {noreply, State}.
 
 -spec handle_info(any(), state()) -> {noreply, state()}.
 handle_info(connect, State) ->
     {noreply, connect(State)};
 handle_info(Info, State) ->
-    ?LOG_WARNING(#{what => unexpected_message, msg => Info}),
+    ?UNEXPECTED_INFO(Info),
     {noreply, State}.
 
 -spec terminate(any(), state()) -> ok.

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -29,15 +29,17 @@ log_if_backend_error(V, Module, Line, Args) ->
         {updated, _} -> ok; % rdbms
         L when is_list(L) -> ok; % riak
         {error, E} ->
-            make_msg("Error calling backend", E, Module, Line, Args);
+            ?LOG_ERROR(#{what => backend_error,
+                         text => <<"Error calling backend module">>,
+                         caller_module => Module, caller_line => Line,
+                         reason => E, args => Args});
         E ->
-            make_msg("Unexpected return from backend", E, Module, Line, Args)
+            ?LOG_ERROR(#{what => backend_error,
+                         text => <<"Unexpected return from backend">>,
+                         caller_module => Module, caller_line => Line,
+                         reason => E, args => Args})
     end,
     ok.
-
-make_msg(Msg, Error, Module, Line, Args) ->
-    ?ERROR_MSG("~p:~p module=~p line=~p arguments=~p",
-                  [Msg, Error, Module, Line, Args]).
 
 %% ------------------------------------------------------------------
 %% Maps

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -9,6 +9,10 @@
 %% Busy Wait
 -export([wait_until/2, wait_until/3]).
 
+%% Private, just for warning
+-export([deprecated_logging/1]).
+-deprecated({deprecated_logging, 1, eventually}).
+
 -include("mongoose.hrl").
 
 %% ------------------------------------------------------------------
@@ -96,3 +100,9 @@ do_wait_until(Fun, ExpectedValue, Opts) ->
 wait_and_continue(Fun, ExpectedValue, #{time_left := TimeLeft, sleep_time := SleepTime} = Opts) ->
     timer:sleep(SleepTime),
     do_wait_until(Fun, ExpectedValue, Opts#{time_left => TimeLeft - SleepTime}).
+
+
+deprecated_logging(Location) ->
+    Map = #{what => deprecated_logging_macro,
+            text => <<"Deprecated logging macro is used in your code">>},
+    mongoose_deprecations:log(Location, Map, [{log_level, warning}]).

--- a/src/mongoose_rabbit_worker.erl
+++ b/src/mongoose_rabbit_worker.erl
@@ -137,8 +137,8 @@ do_handle_cast({amqp_publish, Method, Payload}, State) ->
     handle_amqp_publish(Method, Payload, State).
 
 do_handle_info(Req, State) ->
-    ?WARNING_MSG("event=unexpected_request_received req=~1000p"
-                 "worker_state=~1000p", [Req, State]),
+    ?LOG_WARNING(#{what => unexpected_message,
+                   msg => Req, state => State}),
     {noreply, State}.
 
 -spec handle_amqp_publish(Method :: mongoose_amqp:method(),
@@ -153,26 +153,25 @@ handle_amqp_publish(Method, Payload, Opts = #{host := Host,
         true ->
             update_messages_published_metrics(Host, PoolTag, PublishTime,
                                               Payload),
-            ?DEBUG("event=rabbit_message_sent method=~p message=~1000p"
-                   "worker_opts=~p", [Method, Payload, Opts]),
+            ?LOG_DEBUG(#{what => rabbit_message_sent,
+                         method => Method, payload => Payload, opts => Opts}),
             {noreply, Opts};
         false ->
             update_messages_failed_metrics(Host, PoolTag),
-            ?WARNING_MSG("event=rabbit_message_sent_failed reason=negative_ack"
-                         "method=~p message=~1000p worker_opts=~p",
-                         [Method, Payload, Opts]),
+            ?LOG_WARNING(#{what => rabbit_message_sent_failed, reason => negative_ack,
+                           method => Method, payload => Payload, opts => Opts}),
             {noreply, Opts};
         {channel_exception, Error, Reason} ->
             update_messages_failed_metrics(Host, PoolTag),
-            ?WARNING_MSG("event=rabbit_message_sent_failed reason=~1000p:~1000p"
-                         "method=~p message=~1000p worker_opts=~p",
-                         [Error, Reason, Method, Payload, Opts]),
+            ?LOG_ERROR(#{what => rabbit_message_sent_failed,
+                         class => Error, reason => Reason,
+                         method => Method, payload => Payload, opts => Opts}),
             {FreshConn, FreshChann} = maybe_restart_rabbit_connection(Opts),
             {noreply, Opts#{connection := FreshConn, channel := FreshChann}};
         timeout ->
             update_messages_timeout_metrics(Host, PoolTag),
-            ?WARNING_MSG("event=rabbit_message_sent_failed reason=timeout"
-            "method=~p message=~1000p worker_opts=~p", [Method, Payload, Opts]),
+            ?LOG_ERROR(#{what => rabbit_message_sent_failed, reason => timeout,
+                         method => Method, payload => Payload, opts => Opts}),
             {noreply, Opts}
     end.
 
@@ -215,14 +214,13 @@ establish_rabbit_connection(AMQPOpts, Host, PoolTag) ->
         {ok, Connection} ->
             update_success_connections_metrics(Host, PoolTag),
             {ok, Channel} = amqp_connection:open_channel(Connection),
-            ?DEBUG("event=rabbit_connection_established host=~p pool_tag=~p"
-                   "AMQP_opts=~p", [Host, PoolTag, AMQPOpts]),
+            ?LOG_DEBUG(#{event => rabbit_connection_established,
+                         server => Host, pool_tag => PoolTag, opts => AMQPOpts}),
             {Connection, Channel};
         {error, Error} ->
             update_failed_connections_metrics(Host, PoolTag),
-            ?ERROR_MSG("event=rabbit_connection_failed reason=~1000p"
-                       "host=~p pool_tag=~p AMQP_opts=~p",
-                       [Error, Host, PoolTag, AMQPOpts]),
+            ?LOG_ERROR(#{event => rabbit_connection_failed, reason => Error,
+                         server => Host, pool_tag => PoolTag, opts => AMQPOpts}),
             exit("connection to a Rabbit server failed")
     end.
 
@@ -298,9 +296,9 @@ maybe_handle_request(Callback, Args, Reply) ->
         false ->
             apply(Callback, Args);
         true ->
-            ?WARNING_MSG("event=rabbit_worker_request_dropped "
-                         "reason=queue_message_length_limit_reached limit=~p",
-                         [Limit]),
+            ?LOG_WARNING(#{what => rabbit_worker_request_dropped,
+                           reason => queue_message_length_limit_reached,
+                           limit => Limit}),
             Reply
     end.
 

--- a/src/mongoose_rabbit_worker.erl
+++ b/src/mongoose_rabbit_worker.erl
@@ -214,12 +214,12 @@ establish_rabbit_connection(AMQPOpts, Host, PoolTag) ->
         {ok, Connection} ->
             update_success_connections_metrics(Host, PoolTag),
             {ok, Channel} = amqp_connection:open_channel(Connection),
-            ?LOG_DEBUG(#{event => rabbit_connection_established,
+            ?LOG_DEBUG(#{what => rabbit_connection_established,
                          server => Host, pool_tag => PoolTag, opts => AMQPOpts}),
             {Connection, Channel};
         {error, Error} ->
             update_failed_connections_metrics(Host, PoolTag),
-            ?LOG_ERROR(#{event => rabbit_connection_failed, reason => Error,
+            ?LOG_ERROR(#{what => rabbit_connection_failed, reason => Error,
                          server => Host, pool_tag => PoolTag, opts => AMQPOpts}),
             exit("connection to a Rabbit server failed")
     end.

--- a/src/mongoose_rabbit_worker.erl
+++ b/src/mongoose_rabbit_worker.erl
@@ -137,8 +137,7 @@ do_handle_cast({amqp_publish, Method, Payload}, State) ->
     handle_amqp_publish(Method, Payload, State).
 
 do_handle_info(Req, State) ->
-    ?LOG_WARNING(#{what => unexpected_message,
-                   msg => Req, state => State}),
+    ?UNEXPECTED_INFO(Req),
     {noreply, State}.
 
 -spec handle_amqp_publish(Method :: mongoose_amqp:method(),

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -181,7 +181,7 @@ deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
                             stored_key => StoredKey,
                             server_key => ServerKey}}};
         _ ->
-            ?LOG_WARNING(#{what => scram_serialisation_incorrect, scram_data => Serialized}),
+            ?LOG_WARNING(#{what => scram_serialisation_incorrect}),
             {error, incorrect_scram}
     end;
 deserialize(<<?MULTI_SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
@@ -194,11 +194,11 @@ deserialize(<<?MULTI_SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
                                      lists:flatten(DeserializedKeys)),
             {ok, maps:from_list(ResultList)};
         _ ->
-            ?LOG_WARNING(#{what => scram_serialisation_incorrect, scram_data => Serialized}),
+            ?LOG_WARNING(#{what => scram_serialisation_incorrect}),
             {error, incorrect_scram}
     end;
-deserialize(Bin) ->
-    ?LOG_WARNING(#{what => scram_serialisation_corrupted, scram_data => Bin}),
+deserialize(_) ->
+    ?LOG_WARNING(#{what => scram_serialisation_corrupted}),
     {error, corrupted_scram}.
 
 deserialize([], _) ->
@@ -209,7 +209,7 @@ deserialize([{Sha, Prefix} | _RemainingSha],
         [Salt, StoredKey, ServerKey] ->
             {Sha, #{salt => Salt, server_key => ServerKey, stored_key => StoredKey}};
         _ ->
-            ?LOG_WARNING(#{what => scram_serialisation_incorrect, scram_data => ShaDetails})
+            ?LOG_WARNING(#{what => scram_serialisation_incorrect})
     end;
 deserialize([_CurrentSha | RemainingSha], ShaDetails) ->
     deserialize(RemainingSha, ShaDetails).

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -181,7 +181,7 @@ deserialize(<<?SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
                             stored_key => StoredKey,
                             server_key => ServerKey}}};
         _ ->
-            ?WARNING_MSG("Incorrect serialized SCRAM: ~p", [Serialized]),
+            ?LOG_WARNING(#{what => scram_serialisation_incorrect, scram_data => Serialized}),
             {error, incorrect_scram}
     end;
 deserialize(<<?MULTI_SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
@@ -194,11 +194,11 @@ deserialize(<<?MULTI_SCRAM_SERIAL_PREFIX, Serialized/binary>>) ->
                                      lists:flatten(DeserializedKeys)),
             {ok, maps:from_list(ResultList)};
         _ ->
-            ?WARNING_MSG("Incorrect serialized SCRAM: ~p", [Serialized]),
+            ?LOG_WARNING(#{what => scram_serialisation_incorrect, scram_data => Serialized}),
             {error, incorrect_scram}
     end;
 deserialize(Bin) ->
-    ?WARNING_MSG("Corrupted serialized SCRAM: ~p", [Bin]),
+    ?LOG_WARNING(#{what => scram_serialisation_corrupted, scram_data => Bin}),
     {error, corrupted_scram}.
 
 deserialize([], _) ->
@@ -209,7 +209,7 @@ deserialize([{Sha, Prefix} | _RemainingSha],
         [Salt, StoredKey, ServerKey] ->
             {Sha, #{salt => Salt, server_key => ServerKey, stored_key => StoredKey}};
         _ ->
-            ?WARNING_MSG("Incorrect serialized SCRAM: ~p", [ShaDetails])
+            ?LOG_WARNING(#{what => scram_serialisation_incorrect, scram_data => ShaDetails})
     end;
 deserialize([_CurrentSha | RemainingSha], ShaDetails) ->
     deserialize(RemainingSha, ShaDetails).

--- a/src/mongoose_tcp_listener.erl
+++ b/src/mongoose_tcp_listener.erl
@@ -88,14 +88,16 @@ start_accept_loop(ListenSock, Module, Opts) ->
 accept_loop(ListenSocket, Module, Opts, ProxyProtocol) ->
     case do_accept(ListenSocket, ProxyProtocol) of
         {ok, Socket, ConnectionDetails} ->
-            ?INFO_MSG("event=accepted_tcp_connection, socket=~w, details=~p",
-                      [Socket, ConnectionDetails]),
+            ?LOG_INFO(#{what => tcp_accepted,
+                        socket => Socket, handler_module => Module,
+                        conn_details => ConnectionDetails}),
             ejabberd_socket:start(
               Module, gen_tcp, Socket, [{connection_details, ConnectionDetails} | Opts]),
             ?MODULE:accept_loop(ListenSocket, Module, Opts, ProxyProtocol);
         {error, Reason} ->
-            ?INFO_MSG("event=tcp_accept_failed, socket=~w, reason=~w",
-                      [ListenSocket, Reason]),
+            ?LOG_INFO(#{what => tcp_accept_failed,
+                        listen_socket => ListenSocket,
+                        reason => Reason, handler_module => Module}),
             ?MODULE:accept_loop(ListenSocket, Module, Opts, ProxyProtocol)
     end.
 

--- a/src/mongoose_udp_listener.erl
+++ b/src/mongoose_udp_listener.erl
@@ -86,6 +86,6 @@ recv_loop(Socket, Module, Opts) ->
             ?LOG_ERROR(#{what => udp_listener_recv_failed,
                          text => <<"Unexpected UDP error">>,
                          socket => Socket, handler_module => Module,
-                         reason => jabberd_listener:format_error(Reason)}),
+                         reason => ejabberd_listener:format_error(Reason)}),
             exit({error, Reason})
     end.

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -136,11 +136,10 @@ decode_iq(From, IQ = #iq{ xmlns = ?NS_MUC_OWNER, type = set, sub_el = QueryEl, i
                                                         {element, <<"field">>}])) of
                 {ok, RawConfig} ->
                     {ok, {set, #config{ id = ID, raw_config = RawConfig }}}
-                catch Class:Reason:Stacktrace ->
+            catch Class:Reason:Stacktrace ->
                     ?LOG_WARNING(#{what => muc_parse_config_failed,
                                    from_jid => jid:to_binary(From), iq => IQ,
-                                   class => Class, reason => Reason,
-                                   stacktrace => Stacktrace}),
+                                   class => Class, reason => Reason, stacktrace => Stacktrace}),
                     {error, bad_request}
             end;
         _ ->
@@ -152,7 +151,7 @@ decode_iq(From, IQ = #iq{ xmlns = ?NS_MUC_ADMIN, type = set, sub_el = QueryEl, i
     try parse_aff_users(exml_query:subelements(QueryEl, <<"item">>)) of
         {ok, AffUsers} ->
             {ok, {set, #affiliations{ id = ID, aff_users = AffUsers }}}
-        catch Class:Reason:Stacktrace ->
+    catch Class:Reason:Stacktrace ->
             ?LOG_WARNING(#{what => muc_parse_aff_users_failed,
                            from_jid => jid:to_binary(From), iq => IQ,
                            class => Class, reason => Reason, stacktrace => Stacktrace}),
@@ -169,7 +168,7 @@ decode_iq(From, IQ = #iq{ xmlns = ?NS_PRIVACY, type = set,
             try parse_blocking_list(exml_query:subelements(List, <<"item">>)) of
                 {ok, BlockingList} ->
                     {ok, {set, #blocking{ id = ID, items = BlockingList }}}
-                catch Class:Reason:Stacktrace ->
+            catch Class:Reason:Stacktrace ->
                     ?LOG_WARNING(#{what => muc_parse_blocking_list_failed,
                                    from_jid => jid:to_binary(From), iq => IQ,
                                    class => Class, reason => Reason, stacktrace => Stacktrace})

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -129,15 +129,18 @@ ensure_id({_, Id}) -> Id.
     {ok, muc_light_packet() | muc_light_disco() | jlib:iq()} | {error, bad_request} | ignore.
 decode_iq(_From, #iq{ xmlns = ?NS_MUC_OWNER, type = get, sub_el = _QueryEl, id = ID }) ->
     {ok, {get, #config{ id = ID }}};
-decode_iq(_From, #iq{ xmlns = ?NS_MUC_OWNER, type = set, sub_el = QueryEl, id = ID }) ->
+decode_iq(From, IQ = #iq{ xmlns = ?NS_MUC_OWNER, type = set, sub_el = QueryEl, id = ID }) ->
     case exml_query:subelement(QueryEl, <<"destroy">>) of
         undefined ->
-            case catch parse_config(exml_query:paths(QueryEl, [{element, <<"x">>},
-                                                               {element, <<"field">>}])) of
+            try parse_config(exml_query:paths(QueryEl, [{element, <<"x">>},
+                                                        {element, <<"field">>}])) of
                 {ok, RawConfig} ->
-                    {ok, {set, #config{ id = ID, raw_config = RawConfig }}};
-                Error ->
-                    ?WARNING_MSG("query_el=~p, error=~p", [QueryEl, Error]),
+                    {ok, {set, #config{ id = ID, raw_config = RawConfig }}}
+                catch Class:Reason:Stacktrace ->
+                    ?LOG_WARNING(#{what => muc_parse_config_failed,
+                                   from_jid => jid:to_binary(From), iq => IQ,
+                                   class => Class, reason => Reason,
+                                   stacktrace => Stacktrace}),
                     {error, bad_request}
             end;
         _ ->
@@ -145,28 +148,31 @@ decode_iq(_From, #iq{ xmlns = ?NS_MUC_OWNER, type = set, sub_el = QueryEl, id = 
     end;
 decode_iq(_From, #iq{ xmlns = ?NS_MUC_ADMIN, type = get, sub_el = _QueryEl, id = ID }) ->
     {ok, {get, #affiliations{ id = ID }}};
-decode_iq(_From, #iq{ xmlns = ?NS_MUC_ADMIN, type = set, sub_el = QueryEl, id = ID }) ->
-    case catch parse_aff_users(exml_query:subelements(QueryEl, <<"item">>)) of
+decode_iq(From, IQ = #iq{ xmlns = ?NS_MUC_ADMIN, type = set, sub_el = QueryEl, id = ID }) ->
+    try parse_aff_users(exml_query:subelements(QueryEl, <<"item">>)) of
         {ok, AffUsers} ->
-            {ok, {set, #affiliations{ id = ID, aff_users = AffUsers }}};
-        Error ->
-            ?WARNING_MSG("query_el=~p, error=~p", [QueryEl, Error]),
+            {ok, {set, #affiliations{ id = ID, aff_users = AffUsers }}}
+        catch Class:Reason:Stacktrace ->
+            ?LOG_WARNING(#{what => muc_parse_aff_users_failed,
+                           from_jid => jid:to_binary(From), iq => IQ,
+                           class => Class, reason => Reason, stacktrace => Stacktrace}),
             {error, bad_request}
     end;
 decode_iq(_From, #iq{ xmlns = ?NS_PRIVACY, type = get, id = ID }) ->
     {ok, {get, #blocking{ id = ID }}};
-decode_iq(_From, #iq{ xmlns = ?NS_PRIVACY, type = set,
+decode_iq(From, IQ = #iq{ xmlns = ?NS_PRIVACY, type = set,
                sub_el = #xmlel{ children = Lists }, id = ID }) ->
     case lists:keyfind([{<<"name">>, ?NS_MUC_LIGHT}], #xmlel.attrs, Lists) of
         false ->
             ignore;
         List ->
-            case catch parse_blocking_list(exml_query:subelements(List, <<"item">>)) of
+            try parse_blocking_list(exml_query:subelements(List, <<"item">>)) of
                 {ok, BlockingList} ->
-                    {ok, {set, #blocking{ id = ID, items = BlockingList }}};
-                Error ->
-                    ?WARNING_MSG("lists=~p, error=~p", [Lists, Error]),
-                    {error, bad_request}
+                    {ok, {set, #blocking{ id = ID, items = BlockingList }}}
+                catch Class:Reason:Stacktrace ->
+                    ?LOG_WARNING(#{what => muc_parse_blocking_list_failed,
+                                   from_jid => jid:to_binary(From), iq => IQ,
+                                   class => Class, reason => Reason, stacktrace => Stacktrace})
             end
     end;
 decode_iq(_From, #iq{ xmlns = ?NS_DISCO_ITEMS, type = get, id = ID} = IQ) ->

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -365,9 +365,12 @@ create_room_transaction({NodeCandidate, RoomS}, Config, AffUsers, Version) ->
                 [] ->
                     ok;
                 _ ->
-                    ?ERROR_MSG("event=many_ids_for_pk_select room_name=~p ids=~p aborting the transaction",
-                               [RoomU, AllIds]),
-                    throw({aborted, <<"Many IDs returned for PK select query, most probably MSSQL deadlock">>})
+                    Details = <<"Many IDs returned for PK select query, most probably MSSQL deadlock">>,
+                    ?LOG_ERROR(#{what => muc_many_ids_for_pk_select,
+                                 text => Details,
+                                 room => RoomU, sub_host => RoomS,
+                                 all_room_ids => AllIds}),
+                    throw({aborted, Details})
             end,
             lists:foreach(
               fun({{UserU, UserS}, Aff}) ->

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -497,8 +497,7 @@ offline_messages(Acc, User, Server) ->
                 compose_offline_message(R, Packet, Acc)
               end, Rs);
         {error, Reason} ->
-            ?LOG_WARNING(#{what => offline_pop_failed,
-                           user => User, server => Server, reason => Reason, acc => Acc}),
+            ?LOG_WARNING(#{what => offline_pop_failed, reason => Reason, acc => Acc}),
             []
     end.
 

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -498,8 +498,7 @@ offline_messages(Acc, User, Server) ->
               end, Rs);
         {error, Reason} ->
             ?LOG_WARNING(#{what => offline_pop_failed,
-                           user => User, server => Server, reason => Reason,
-                           acc => Acc}),
+                           user => User, server => Server, reason => Reason, acc => Acc}),
             []
     end.
 

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -290,7 +290,8 @@ handle_call({pop_offline_messages, LUser, LServer}, {Pid, _}, State) ->
     Result = mod_offline_backend:pop_messages(LUser, LServer),
     NewPoppers = monitored_map:put({LUser, LServer}, Pid, Pid, State#state.message_poppers),
     {reply, Result, State#state{message_poppers = NewPoppers}};
-handle_call(_, _, State) ->
+handle_call(Request, From, State) ->
+    ?UNEXPECTED_CALL(Request, From),
     {reply, ok, State}.
 
 %%--------------------------------------------------------------------
@@ -300,7 +301,7 @@ handle_call(_, _, State) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, msg => Msg}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -322,7 +323,7 @@ handle_info({Acc, Msg = #offline_msg{us = US}},
     end,
     {noreply, State};
 handle_info(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_message, msg => Msg}),
+    ?UNEXPECTED_INFO(Msg),
     {noreply, State}.
 
 %%--------------------------------------------------------------------

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -189,8 +189,10 @@ write_messages(LUser, LServer, Msgs) ->
             [mod_amp:check_packet(Acc, archived) || {Acc, _Msg} <- Msgs],
             ok;
         {error, Reason} ->
-            ?ERROR_MSG("~ts@~ts: write_messages failed with ~p.",
-                [LUser, LServer, Reason]),
+            ?LOG_ERROR(#{what => offline_write_failed,
+                         text => <<"Failed to write offline messages">>,
+                         reason => Reason,
+                         user => LUser, server => LServer, msgs => Msgs}),
             discard_warn_sender(Msgs)
     end.
 
@@ -298,7 +300,7 @@ handle_call(_, _, State) ->
 %% Description: Handling cast messages
 %%--------------------------------------------------------------------
 handle_cast(Msg, State) ->
-    ?WARNING_MSG("Strange message ~p.", [Msg]),
+    ?LOG_WARNING(#{what => unexpected_cast, msg => Msg}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -320,7 +322,7 @@ handle_info({Acc, Msg = #offline_msg{us = US}},
     end,
     {noreply, State};
 handle_info(Msg, State) ->
-    ?WARNING_MSG("Strange message ~p.", [Msg]),
+    ?LOG_WARNING(#{what => unexpected_message, msg => Msg}),
     {noreply, State}.
 
 %%--------------------------------------------------------------------
@@ -494,7 +496,9 @@ offline_messages(Acc, User, Server) ->
                 compose_offline_message(R, Packet, Acc)
               end, Rs);
         {error, Reason} ->
-            ?ERROR_MSG("~ts@~ts: pop_messages failed with ~p.", [LUser, LServer, Reason]),
+            ?LOG_WARNING(#{what => offline_pop_failed,
+                           user => User, server => Server, reason => Reason,
+                           acc => Acc}),
             []
     end.
 
@@ -554,11 +558,15 @@ timestamp_xml(Server, Time) ->
     jlib:timestamp_to_xml(TS, FromJID, <<"Offline Storage">>).
 
 remove_expired_messages(Host) ->
-    mod_offline_backend:remove_expired_messages(Host).
+    Result = mod_offline_backend:remove_expired_messages(Host),
+    mongoose_lib:log_if_backend_error(Result, ?MODULE, ?LINE, [Host]),
+    Result.
 
 remove_old_messages(Host, Days) ->
     Timestamp = fallback_timestamp(Days, os:timestamp()),
-    mod_offline_backend:remove_old_messages(Host, Timestamp).
+    Result = mod_offline_backend:remove_old_messages(Host, Timestamp),
+    mongoose_lib:log_if_backend_error(Result, ?MODULE, ?LINE, [Host, Timestamp]),
+    Result.
 
 %% #rh
 

--- a/src/offline/mod_offline_rdbms.erl
+++ b/src/offline/mod_offline_rdbms.erl
@@ -105,7 +105,7 @@ write_messages(LUser, LServer, Msgs) ->
 count_offline_messages(LUser, LServer, MaxArchivedMsgs) ->
     SUser = mongoose_rdbms:escape_string(LUser),
     SServer = mongoose_rdbms:escape_string(LServer),
-    count_offline_messages(LServer, SUser, SServer, MaxArchivedMsgs + 1).
+    count_offline_messages(LUser, LServer, SUser, SServer, MaxArchivedMsgs + 1).
 
 write_all_messages_t(LServer, SUser, SServer, Msgs) ->
     Rows = [record_to_row(SUser, SServer, Msg) || Msg <- Msgs],
@@ -164,12 +164,14 @@ remove_old_messages(LServer, TimeStamp) ->
             {ok, Count}
     end.
 
-count_offline_messages(LServer, SUser, SServer, Limit) ->
+count_offline_messages(LUser, LServer, SUser, SServer, Limit) ->
     case rdbms_queries:count_offline_messages(LServer, SUser, SServer, Limit) of
         {selected, [{Count}]} ->
             mongoose_rdbms:result_to_integer(Count);
         Error ->
-            ?ERROR_MSG("count_offline_messages failed ~p", [Error]),
+            ?LOG_ERROR(#{what => count_offline_messages_failed,
+                         server => LServer, user => LUser,
+                         reason => Error}),
             0
     end.
 

--- a/src/offline/mod_offline_riak.erl
+++ b/src/offline/mod_offline_riak.erl
@@ -165,9 +165,11 @@ pop_msg(Key, LUser, LServer, To) ->
                      permanent_fields = PermanentFields}
 
     catch
-        Error:Reason:StackTrace ->
-            ?WARNING_MSG("issue=~p, action=reading_key, host=~s, reason=~p, stack_trace=~p",
-                         [Error, LServer, Reason, StackTrace]),
+        Class:Reason:StackTrace ->
+            ?LOG_WARNING(#{what => offline_riak_reading_key_failed,
+                           text => <<"mod_offline_riak failed to read key">>,
+                           server => LServer, user => LUser, riak_key => Key,
+                           class => Class, reason => Reason, stacktrace => StackTrace}),
             []
     end.
 
@@ -224,9 +226,11 @@ fetch_msg(Key, LUser, LServer, To) ->
             packet = Packet}
 
     catch
-        Error:Reason:StackTrace ->
-            ?WARNING_MSG("issue=~p, action=reading_key, host=~s, reason=~p, stack_trace=~p",
-                [Error, LServer, Reason, StackTrace]),
+        Class:Reason:StackTrace ->
+            ?LOG_WARNING(#{what => offline_riak_reading_key_failed,
+                           text => <<"mod_offline_riak failed to read key">>,
+                           server => LServer, user => LUser, riak_key => Key,
+                           class => Class, reason => Reason, stacktrace => StackTrace}),
             []
     end.
 

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -83,7 +83,8 @@ convert_rdbms_response({selected, [SelectedItem]}) ->
 convert_rdbms_response({updated, _}) ->
     ok;
 convert_rdbms_response(Response) ->
-    ?LOG_ERROR(#{what => pubsub_rdbms_cache_failed, reason => Response}).
+    ?LOG_ERROR(#{what => pubsub_rdbms_cache_failed, reason => Response}),
+    {error, pubsub_rdbms_cache_failed}.
 
 esc_int(Int) ->
     mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).

--- a/src/pubsub/mod_pubsub_cache_rdbms.erl
+++ b/src/pubsub/mod_pubsub_cache_rdbms.erl
@@ -83,8 +83,7 @@ convert_rdbms_response({selected, [SelectedItem]}) ->
 convert_rdbms_response({updated, _}) ->
     ok;
 convert_rdbms_response(Response) ->
-    ?ERROR_MSG("RDBMS cache failed with: ~p", [Response]),
-    {error, pubsub_rdbms_cache_failed}.
+    ?LOG_ERROR(#{what => pubsub_rdbms_cache_failed, reason => Response}).
 
 esc_int(Int) ->
     mongoose_rdbms:use_escaped_integer(mongoose_rdbms:escape_integer(Int)).

--- a/src/pubsub/mod_pubsub_db_rdbms.erl
+++ b/src/pubsub/mod_pubsub_db_rdbms.erl
@@ -375,7 +375,7 @@ get_parentnodes_tree(Key, Node) ->
 find_nodes_with_parents(_, [], _, Acc) ->
     Acc;
 find_nodes_with_parents(_, _, 100, Acc) ->
-    ?WARNING_MSG("event=max_depth_reached, nodes=~p", [Acc]),
+    ?LOG_WARNING(#{what => pubsub_max_depth_reached, pubsub_nodes => Acc}),
     Acc;
 find_nodes_with_parents(Key, Nodes, Depth, Acc) ->
     SQL = mod_pubsub_db_rdbms_sql:select_nodes_by_key_and_names_in_list_with_parents(
@@ -421,7 +421,7 @@ get_subnodes_tree(Key, Node) ->
 find_subnodes(_Key, [], _, Acc) ->
     Acc;
 find_subnodes(_, _, 100, Acc) ->
-    ?WARNING_MSG("event=max_depth_reached, nodes=~p", [Acc]),
+    ?LOG_WARNING(#{what => pubsub_max_depth_reached, pubsub_nodes => Acc}),
     Acc;
 find_subnodes(Key, Nodes, Depth, Acc) ->
     SQL = mod_pubsub_db_rdbms_sql:select_nodes_by_key_and_names_in_list_with_children(

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -297,48 +297,48 @@ use_escaped_string({escaped_string, S}) ->
 use_escaped_string(X) ->
     %% We need to print an error, because in some places
     %% the error can be just ignored, because of too wide catches.
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped_string, X}).
 
 -spec use_escaped_binary(escaped_binary()) -> sql_query_part().
 use_escaped_binary({escaped_binary, S}) ->
     S;
 use_escaped_binary(X) ->
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped_binary, X}).
 
 -spec use_escaped_like(escaped_like()) -> sql_query_part().
 use_escaped_like({escaped_like, S}) ->
     S;
 use_escaped_like(X) ->
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped_like, X}).
 
 -spec use_escaped_integer(escaped_integer()) -> sql_query_part().
 use_escaped_integer({escaped_integer, S}) ->
     S;
 use_escaped_integer(X) ->
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped_integer, X}).
 
 -spec use_escaped_boolean(escaped_boolean()) -> sql_query_part().
 use_escaped_boolean({escaped_boolean, S}) ->
     S;
 use_escaped_boolean(X) ->
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped_boolean, X}).
 
 -spec use_escaped_null(escaped_null()) -> sql_query_part().
 use_escaped_null({escaped_null, S}) ->
     S;
 use_escaped_null(X) ->
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped_null, X}).
 
 %% Use this function, if type is unknown.
@@ -356,8 +356,8 @@ use_escaped({escaped_boolean, _}=X) ->
 use_escaped({escaped_null, _}=X) ->
     use_escaped_null(X);
 use_escaped(X) ->
-    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
-               [X, erlang:process_info(self(), current_stacktrace)]),
+    ?LOG_ERROR(#{what => rdbms_use_escaped_failure, value => X,
+        stacktrace => erlang:process_info(self(), current_stacktrace)}),
     erlang:error({use_escaped, X}).
 
 -spec escape_like_internal(binary() | string()) -> binary() | string().
@@ -444,7 +444,7 @@ handle_call(_Event, _From, State) ->
     {reply, {error, badarg}, State}.
 
 handle_cast(Request, State) ->
-    ?WARNING_MSG("unexpected cast: ~p", [Request]),
+    ?LOG_WARNING(#{what => rdbms_unexpected_cast, request => Request}),
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -461,7 +461,7 @@ handle_info(keepalive, #state{keepalive_interval = KeepaliveInterval} = State) -
 handle_info({'EXIT', _Pid, _Reason} = Reason, State) ->
     {stop, Reason, State};
 handle_info(Info, State) ->
-    ?WARNING_MSG("unexpected info: ~p", [Info]),
+    ?LOG_WARNING(#{what => rdbms_unexpected_info, info => Info}),
     {noreply, State}.
 
 -spec terminate(Reason :: term(), state()) -> any().
@@ -488,9 +488,8 @@ run_sql_cmd(Command, _From, State, Timestamp) ->
         Age when Age  < ?TRANSACTION_TIMEOUT ->
             abort_on_driver_error(outer_op(Command, State));
         Age ->
-            ?ERROR_MSG("Database was not available or too slow,"
-                       " discarding ~p milliseconds old request~n~p~n",
-                       [Age, Command]),
+            ?LOG_ERROR(#{what => rdbms_db_not_available_or_too_slow,
+                text => <<"Discarding request">>, age => Age, command => Command}),
             {reply, {error, timeout}, State}
     end.
 
@@ -551,26 +550,18 @@ outer_transaction(F, NRestarts, _Reason, State) ->
         {aborted, #{reason := Reason, sql_query := SqlQuery}}
             when NRestarts =:= 0 ->
             %% Too many retries of outer transaction.
-            ?ERROR_MSG("event=sql_transaction_restarts_exceeded "
-                       "restarts=~p "
-                       "last_abort_reason=~1000p "
-                       "last_sql_query=~1000p "
-                       "stacktrace=~1000p "
-                       "state=~1000p",
-                       [?MAX_TRANSACTION_RESTARTS, Reason,
-                        iolist_to_binary(SqlQuery),
-                        StackTrace, NewState]),
+            ?LOG_ERROR(#{what => rdbms_sql_transaction_restarts_exceeded,
+                restarts => ?MAX_TRANSACTION_RESTARTS, last_abort_reason => Reason,
+                last_sql_query => iolist_to_binary(SqlQuery),
+                stacktrace => StackTrace, state => NewState}),
             sql_query_internal([<<"rollback;">>], NewState),
             {{aborted, Reason}, NewState};
         {aborted, Reason} when NRestarts =:= 0 -> %% old format for abort
             %% Too many retries of outer transaction.
-            ?ERROR_MSG("event=sql_transaction_restarts_exceeded "
-                       "restarts=~p "
-                       "last_abort_reason=~1000p "
-                       "stacktrace=~1000p "
-                       "state=~1000p",
-                       [?MAX_TRANSACTION_RESTARTS, Reason,
-                        StackTrace, NewState]),
+            ?LOG_ERROR(#{what => rdbms_sql_transaction_restarts_exceeded,
+                restarts => ?MAX_TRANSACTION_RESTARTS,
+                last_abort_reason => Reason, stacktrace => StackTrace,
+                state => NewState}),
             sql_query_internal([<<"rollback;">>], NewState),
             {{aborted, Reason}, NewState};
         {'EXIT', Reason} ->
@@ -590,11 +581,10 @@ apply_transaction_function(F) ->
     catch
         throw:ThrowResult:StackTrace ->
             {ThrowResult, StackTrace};
-        Class:Other:StackTrace ->
-            ?ERROR_MSG("issue=outer_transaction_failed "
-                       "reason=~p:~p stacktrace=~1000p",
-                       [Class, Other, StackTrace]),
-            {{'EXIT', Other}, StackTrace}
+        Class:Reason:StackTrace ->
+            ?LOG_ERROR(#{what => rdbms_outer_transaction_failed, class => Class,
+                reason => Reason, stacktrace => StackTrace}),
+            {{'EXIT', Reason}, StackTrace}
     end.
 
 sql_query_internal(Query, #state{db_ref = DBRef}) ->
@@ -622,10 +612,9 @@ sql_execute(Name, Params, State = #state{db_ref = DBRef}) ->
     {StatementRef, NewState} = prepare_statement(Name, State),
     Res = try mongoose_rdbms_backend:execute(DBRef, StatementRef, Params, ?QUERY_TIMEOUT)
           catch Class:Reason:StackTrace ->
-            ?ERROR_MSG("event=sql_execute_failed "
-                        "statement_name=~p reason=~p:~p "
-                        "params=~1000p stacktrace=~1000p",
-                       [Name, Class, Reason, Params, StackTrace]),
+            ?LOG_ERROR(#{what => rdbms_sql_execute_failed, statement_name => Name,
+                class => Class, reason => Reason, params => Params,
+                stacktrace => StackTrace}),
             erlang:raise(Class, Reason, StackTrace)
           end,
     {Res, NewState}.
@@ -672,8 +661,8 @@ connect(Settings, Retry, RetryAfter, MaxRetryDelay) ->
         Error ->
             SleepFor = rand:uniform(RetryAfter),
             Backend = mongoose_rdbms_backend:backend_name(),
-            ?ERROR_MSG("Connection attempt to ~s resulted in ~p."
-                       " Retrying in ~p seconds.", [Backend, Error, SleepFor]),
+            ?LOG_ERROR(#{what => rdbms_connection_attempt_error, backend => Backend,
+                error => Error, sleep_for => SleepFor}),
             timer:sleep(timer:seconds(SleepFor)),
             NextRetryDelay = RetryAfter * RetryAfter,
             connect(Settings, Retry - 1, min(MaxRetryDelay, NextRetryDelay), MaxRetryDelay)
@@ -688,7 +677,7 @@ schedule_keepalive(KeepaliveInterval) ->
         undefined ->
             ok;
         Other ->
-            ?ERROR_MSG("Wrong keepalive_interval definition '~p'~n", [Other]),
+            ?LOG_ERROR(#{what => rdbms_wrong_keepalive_interval, reason => Other}),
             ok
     end.
 

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -440,11 +440,12 @@ handle_call({sql_cmd, Command, Timestamp}, From, State) ->
     run_sql_cmd(Command, From, State, Timestamp);
 handle_call(get_db_info, _, #state{db_ref = DbRef} = State) ->
     {reply, {ok, db_engine(?MYNAME), DbRef}, State};
-handle_call(_Event, _From, State) ->
+handle_call(Request, From, State) ->
+    ?UNEXPECTED_CALL(Request, From),
     {reply, {error, badarg}, State}.
 
 handle_cast(Request, State) ->
-    ?LOG_WARNING(#{what => rdbms_unexpected_cast, request => Request}),
+    ?UNEXPECTED_CAST(Request),
     {noreply, State}.
 
 code_change(_OldVsn, State, _Extra) ->
@@ -461,7 +462,7 @@ handle_info(keepalive, #state{keepalive_interval = KeepaliveInterval} = State) -
 handle_info({'EXIT', _Pid, _Reason} = Reason, State) ->
     {stop, Reason, State};
 handle_info(Info, State) ->
-    ?LOG_WARNING(#{what => rdbms_unexpected_info, info => Info}),
+    ?UNEXPECTED_INFO(Info),
     {noreply, State}.
 
 -spec terminate(Reason :: term(), state()) -> any().

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -232,7 +232,7 @@ unicode_characters_to_binary(Input, FromEncoding, ToEncoding) ->
         Result when is_binary(Result) ->
             Result;
         Other ->
-            erlang:error(#{event => parse_value_failed,
+            erlang:error(#{what => parse_value_failed,
                            from_encoding => FromEncoding,
                            to_encoding => ToEncoding,
                            input_binary => Input,

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -241,7 +241,7 @@ execute_upsert(Host, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
 prepare_upsert(Host, Name, Table, InsertFields, UpdateFields, UniqueKeyFields) ->
     SQL = upsert_query(Host, Table, InsertFields, UpdateFields, UniqueKeyFields),
     Query = iolist_to_binary(SQL),
-    ?DEBUG("event=upsert_query, query=~s", [Query]),
+    ?LOG_DEBUG(#{what => rdbms_upsert_query, query => Query}),
     Fields = prepared_upsert_fields(InsertFields, UpdateFields, UniqueKeyFields),
     mongoose_rdbms:prepare(Name, Table, Fields, Query).
 

--- a/src/sasl/cyrsasl_digest.erl
+++ b/src/sasl/cyrsasl_digest.erl
@@ -55,11 +55,12 @@ mechanism() ->
                Creds  :: mongoose_credentials:t(),
                Socket :: term()) -> {ok, state()}.
 mech_new(Host, Creds, _Socket) ->
+    Text = <<"The DIGEST-MD5 authentication mechanism is deprecated and "
+        " will be removed in the next release, please consider using"
+        " any of the SCRAM-SHA methods or equivalent instead.">>,
     mongoose_deprecations:log(
         {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
-        "The DIGEST-MD5 authentication mechanism is deprecated and "
-        " will be removed in the next release, please consider using"
-        " any of the SCRAM-SHA methods or equivalent instead.",
+        #{what => sasl_digest_md5_deprecated, text => Text},
         [{log_level, warning}]),
     {ok, #state{step = 1,
                 nonce = mongoose_bin:gen_from_crypto(),

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -179,12 +179,14 @@ custom_verification(Module, Creds) ->
             {error, Error} when is_binary(Error) ->
                 {error, Error};
             InvalidReturnValue ->
-                ?ERROR_MSG("~p:verify_cert/1 invalid return value: ~p", [Module, InvalidReturnValue]),
+                ?LOG_ERROR(#{what => sasl_external_failed, sasl_module => Module,
+                             reason => invalid_return_value, return_value => InvalidReturnValue}),
                 {error, <<"not-authorized">>}
         end
     catch
         Class:Exception ->
-            ?ERROR_MSG("~p:verify_cert/1 crashed: ~p", [Module, {Class, Exception}]),
+            ?LOG_ERROR(#{what => sasl_external_failed, sasl_module => Module,
+                         class => Class, reason => Exception}),
             {error, <<"not-authorized">>}
     end.
 

--- a/src/sasl/cyrsasl_plain.erl
+++ b/src/sasl/cyrsasl_plain.erl
@@ -65,7 +65,7 @@ authorize(Request, User) ->
         {error, {no_auth_modules, _}} ->
             {error, <<"not-authorized">>, User};
         {error, R} ->
-            ?DEBUG("authorize error: ~p", [R]),
+            ?LOG_DEBUG(#{what => unauthorized_login, reason => R, user => User}),
             {error, <<"internal-error">>}
     end.
 

--- a/src/stream_management/stream_management_stale_h.erl
+++ b/src/stream_management/stream_management_stale_h.erl
@@ -102,11 +102,11 @@ init([GCOpts]) ->
     {ok, State, RepeatAfter}.
 
 handle_call(Msg, From, State) ->
-    ?LOG_WARNING(#{what => unexpected_call, msg => Msg, call_from => From}),
+    ?UNEXPECTED_CALL(Msg, From),
     {reply, ok, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG_WARNING(#{what => unexpected_cast, msg => Msg}),
+    ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
 
 handle_info(timeout, #smgc_state{gc_repeat_after = RepeatAfter,
@@ -115,7 +115,7 @@ handle_info(timeout, #smgc_state{gc_repeat_after = RepeatAfter,
     {noreply, State, RepeatAfter};
 handle_info(Info, #smgc_state{gc_repeat_after = RepeatAfter,
                               gc_geriatric = _GeriatricAge} = State) ->
-    ?LOG_WARNING(#{what => unexpected_message, msg => Info}),
+    ?UNEXPECTED_INFO(Info),
     {noreply, State, RepeatAfter}.
 
 clear_table(GeriatricAge) ->

--- a/src/stream_management/stream_management_stale_h.erl
+++ b/src/stream_management/stream_management_stale_h.erl
@@ -74,7 +74,7 @@ maybe_start(Opts) ->
         false ->
             ok;
         true ->
-            ?INFO_MSG("event=stream_mgmt_stale_h_start", []),
+            ?LOG_INFO(#{what => stream_mgmt_stale_h_start}),
             mnesia:create_table(stream_mgmt_stale_h,
                                 [{ram_copies, [node()]},
                                  {attributes, record_info(fields, stream_mgmt_stale_h)}]),
@@ -101,12 +101,12 @@ init([GCOpts]) ->
                         gc_geriatric = GeriatricAge},
     {ok, State, RepeatAfter}.
 
-handle_call(Msg, _From, State) ->
-    ?WARNING_MSG("event=unexpected_handle_call message=~p", [Msg]),
+handle_call(Msg, From, State) ->
+    ?LOG_WARNING(#{what => unexpected_call, msg => Msg, call_from => From}),
     {reply, ok, State}.
 
 handle_cast(Msg, State) ->
-    ?WARNING_MSG("event=unexpected_handle_cast message=~p", [Msg]),
+    ?LOG_WARNING(#{what => unexpected_cast, msg => Msg}),
     {noreply, State}.
 
 handle_info(timeout, #smgc_state{gc_repeat_after = RepeatAfter,
@@ -115,7 +115,7 @@ handle_info(timeout, #smgc_state{gc_repeat_after = RepeatAfter,
     {noreply, State, RepeatAfter};
 handle_info(Info, #smgc_state{gc_repeat_after = RepeatAfter,
                               gc_geriatric = _GeriatricAge} = State) ->
-    ?WARNING_MSG("event=unexpected_handle_info info=~p", [Info]),
+    ?LOG_WARNING(#{what => unexpected_message, msg => Info}),
     {noreply, State, RepeatAfter}.
 
 clear_table(GeriatricAge) ->

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -134,9 +134,9 @@ report_transparency(Args) ->
         {____, true} -> continue;
         {____, ____} ->
             File = mongoose_system_metrics_file:location(),
-            Text = iolist_to_binary(io_lib:format(msg_accept_terms_and_conditions(), [File]),
+            Text = iolist_to_binary(io_lib:format(msg_accept_terms_and_conditions(), [File])),
             ?LOG_NOTICE(#{what => report_transparency,
-                          text => Text, report_filename => mongoose_system_metrics_file:location()}),
+                          text => Text, report_filename => File}),
             continue
     end.
 

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -36,7 +36,8 @@ verify_if_configured() ->
     Services = ejabberd_config:get_local_option_or_default(services, []),
     case proplists:is_defined(?MODULE, Services) of
         false ->
-            ?WARNING_MSG(msg_removed_from_config(), []),
+            ?LOG_NOTICE(#{what => system_metrics_disabled,
+                          text => msg_removed_from_config()}),
             ignore;
         true ->
             ok
@@ -132,7 +133,10 @@ report_transparency(Args) ->
         {true, ____} -> skip;
         {____, true} -> continue;
         {____, ____} ->
-            ?WARNING_MSG(msg_accept_terms_and_conditions(), [mongoose_system_metrics_file:location()]),
+            File = mongoose_system_metrics_file:location(),
+            Text = iolist_to_binary(io_lib:format(msg_accept_terms_and_conditions(), [File]),
+            ?LOG_NOTICE(#{what => report_transparency,
+                          text => Text, report_filename => mongoose_system_metrics_file:location()}),
             continue
     end.
 
@@ -156,20 +160,20 @@ terminate(_Reason, _State) ->
 %% Internal
 %%-----------------------------------------
 msg_removed_from_config() ->
-    "We're sorry to hear you don't want to share the system's metrics with us. "
+    <<"We're sorry to hear you don't want to share the system's metrics with us. "
     "These metrics would enable us to improve MongooseIM and know where to focus our efforts. "
     "To stop being notified, you can add this to the services section of your config file: \n"
     "    '{service_mongoose_system_metrics, [no_report]}' \n"
     "For more info on how to customise, read, enable, and disable the metrics visit: \n"
     "- MongooseIM docs - \n"
     "     https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
-    "- MongooseIM GitHub page - https://github.com/esl/MongooseIM".
+    "- MongooseIM GitHub page - https://github.com/esl/MongooseIM">>.
 
 msg_accept_terms_and_conditions() ->
-    "We are gathering the MongooseIM system's metrics to analyse the trends and needs of our users, "
+    <<"We are gathering the MongooseIM system's metrics to analyse the trends and needs of our users, "
     "improve MongooseIM, and know where to focus our efforts. "
     "For more info on how to customise, read, enable, and disable these metrics visit: \n"
     "- MongooseIM docs - \n"
     "      https://mongooseim.readthedocs.io/en/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
     "- MongooseIM GitHub page - https://github.com/esl/MongooseIM \n"
-    "The last sent report is also written to a file ~s".
+    "The last sent report is also written to a file ~s">>.

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -36,8 +36,10 @@ verify_if_configured() ->
     Services = ejabberd_config:get_local_option_or_default(services, []),
     case proplists:is_defined(?MODULE, Services) of
         false ->
-            ?LOG_NOTICE(#{what => system_metrics_disabled,
-                          text => msg_removed_from_config()}),
+            %% Technically, notice level.
+            %% Though make it louder, in case people set minimum level as warning.
+            ?LOG_WARNING(#{what => system_metrics_disabled,
+                           text => msg_removed_from_config()}),
             ignore;
         true ->
             ok
@@ -135,8 +137,8 @@ report_transparency(Args) ->
         {____, ____} ->
             File = mongoose_system_metrics_file:location(),
             Text = iolist_to_binary(io_lib:format(msg_accept_terms_and_conditions(), [File])),
-            ?LOG_NOTICE(#{what => report_transparency,
-                          text => Text, report_filename => File}),
+            ?LOG_WARNING(#{what => report_transparency,
+                           text => Text, report_filename => File}),
             continue
     end.
 

--- a/src/translate.erl
+++ b/src/translate.erl
@@ -73,7 +73,9 @@ load_translations_from_dir(Dir) ->
             MsgFiles = lists:filter(fun has_msg_extension/1, Files),
             load_translation_files(Dir, MsgFiles);
         {error, Reason} ->
-            ?ERROR_MSG("~p", [Reason])
+            ?LOG_ERROR(#{what => load_translations_from_dir_failed,
+                         directory => Dir, reason => Reason}),
+            ok
     end.
 
 -spec load_translation_files(file:filename(), [file:filename()]) -> ok.
@@ -101,15 +103,11 @@ load_file(Lang, File) ->
                                                      unicode:characters_to_binary(Orig),
                                                      unicode:characters_to_binary(Trans))
                           end, Terms);
-        %% Code copied from ejabberd_config.erl
-        {error, {_LineNumber, erl_parse, _ParseMessage} = Reason} ->
-            ExitText = lists:flatten(File ++ " approximately in the line "
-                                     ++ file:format_error(Reason)),
-            ?ERROR_MSG("Problem loading translation file ~n~s", [ExitText]),
-            exit(ExitText);
         {error, Reason} ->
-            ExitText = lists:flatten(File ++ ": " ++ file:format_error(Reason)),
-            ?ERROR_MSG("Problem loading translation file ~n~s", [ExitText]),
+            ExitText = iolist_to_binary(File ++ ": " ++ file:format_error(Reason)),
+            ?LOG_ERROR(#{what => load_translation_file_failed,
+                         text => <<"Problem loading translation file">>,
+                         filename => File, reason => ExitText}),
             exit(ExitText)
     end.
 

--- a/src/wpool/mongoose_gun_worker.erl
+++ b/src/wpool/mongoose_gun_worker.erl
@@ -82,7 +82,8 @@ handle_call(Request, From, #gun_worker_state{pid = GunPid, requests = Requests} 
     {noreply, State#gun_worker_state{requests = NewRequests}}.
 
 -spec handle_cast(any(), gun_worker_state()) -> {noreply, gun_worker_state()}.
-handle_cast(_R, State) ->
+handle_cast(M, State) ->
+    ?UNEXPECTED_CAST(M),
     {noreply, State}.
 
 %% @doc Handles gun messages.
@@ -198,7 +199,7 @@ handle_info({'DOWN', MRef, process, ConnPid, Reason},
     {noreply, NewState};
 
 handle_info(M, S) ->
-    ?LOG_ERROR(#{what => unexpected_message, msg => M}),
+    ?UNEXPECTED_INFO(M),
     {noreply, S}.
 
 terminate(_Reason, #gun_worker_state{pid = undefined}) ->

--- a/src/wpool/mongoose_gun_worker.erl
+++ b/src/wpool/mongoose_gun_worker.erl
@@ -169,23 +169,21 @@ handle_info({gun_up, ConnPid, _Protocol},
 %% It may try to reconnect, according to the `retry' and `retry_timeout' options,
 %% passed in the init options.
 handle_info({gun_down, PID, Protocol, Reason, KilledStreams, UnprocessedStreams}, State) ->
-    ?WARNING_MSG("event=mongoose_gun_worker_connection,status=down,"
-                 "protocol=~p,connection=~p,reason=\"~p\",streams_killed=~p",
-                 [Protocol, PID, Reason, length(KilledStreams) + length(UnprocessedStreams)]),
-    ?DEBUG("event=mongoose_gun_worker_connection,status=down,reason=~p,killed_streams=~p,unprocessed_streams=~p",
-           [Reason,KilledStreams, UnprocessedStreams]),
+    ?LOG_WARNING(#{what => http_connection_down, reason => Reason, protocol => Protocol,
+                   gun_pid => PID, streams_killed => length(KilledStreams) + length(UnprocessedStreams)}),
+    ?LOG_DEBUG(#{what => http_connection_down, reason => Reason, killed_streams => KilledStreams,
+                 unprocessed_streams => UnprocessedStreams}),
     {noreply, State};
 
 %% `gun_error' is a message informing about any errors concerning connections or
 %% streams handled by Gun.
 handle_info({gun_error, ConnPid, Reason},
             State = #gun_worker_state{pid = ConnPid}) ->
-    ?WARNING_MSG("event=mongoose_gun_worker_error,reason=~p", [Reason]),
+    ?LOG_WARNING(#{what => http_connection_error, reason => Reason}),
     {noreply, State};
 handle_info({gun_error, ConnPid, StreamRef, Reason},
             State = #gun_worker_state{pid = ConnPid}) ->
-    ?WARNING_MSG("event=mongoose_gun_worker_error,reason=~p,stream_reference=~p",
-                 [Reason, StreamRef]),
+    ?LOG_WARNING(#{what => http_stream_error, reason => Reason, stream_reference => StreamRef}),
     {noreply, State};
 
 %% After `retry' number of `gun_down' messages, the connection process dies.
@@ -193,13 +191,14 @@ handle_info({gun_error, ConnPid, StreamRef, Reason},
 %% connection.
 handle_info({'DOWN', MRef, process, ConnPid, Reason},
             #gun_worker_state{pid = ConnPid, monitor = MRef} = State) ->
-    ?WARNING_MSG("event=mongoose_gun_worker_connection,status=lost,worker=~p,reason=~p.", [ConnPid, Reason]),
+    ?LOG_WARNING(#{what => http_connection_lost,
+                   worker => ConnPid, reason => Reason}),
     ConnectedState = launch_connection(State),
     NewState = retry_all(ConnectedState),
     {noreply, NewState};
 
 handle_info(M, S) ->
-    ?ERROR_MSG("event=mongoose_gun_worker_message,status=unexpected,message=~p", [M]),
+    ?LOG_ERROR(#{what => unexpected_message, msg => M}),
     {noreply, S}.
 
 terminate(_Reason, #gun_worker_state{pid = undefined}) ->
@@ -237,6 +236,7 @@ launch_connection(#gun_worker_state{host = H, port = P, opts = Opts} = State) ->
 queue_request(LRequest, PID) ->
     {request, FullPath, Method, LHeaders, Query, _Retries, Timeout} = LRequest,
     StreamRef = gun:request(PID, Method, FullPath, LHeaders, Query),
+    ?LOG_DEBUG(#{what => http_request, status => submit, request => LRequest}),
     TRef = erlang:send_after(Timeout, self(), {timeout, StreamRef}),
     {StreamRef, TRef}.
 
@@ -251,11 +251,11 @@ retry_request(PID, {Req, Res}, ReqAcc) ->
     erlang:cancel_timer(Res#response_data.timeout_timer),
     case Retries of
         0 ->
-            ?DEBUG("event=mongoose_gun_worker_request,status=drop,request=~w", [Req]),
+            ?LOG_DEBUG(#{what => http_request, status => drop, request => Req}),
             gen_server:reply(Res#response_data.from, {error, request_timeout}),
             ReqAcc;
         _N ->
-            ?DEBUG("event=mongoose_gun_worker_request,status=retry,request=~w", [Req]),
+            ?LOG_DEBUG(#{what => http_request, status => retry, request => Req}),
             {NewStreamRef, TRef} = queue_request(Req, PID),
 
             ReqAcc#{NewStreamRef => {

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -165,9 +165,10 @@ stop(Type, Host, Tag) ->
         mongoose_wpool_mgr:stop(Type, Host, Tag)
     catch
         C:R:S ->
-            ?ERROR_MSG("event=cannot_stop_pool,type=~p,host=~p,tag=~p,"
-                       "class=~p,reason=~p,stack_trace=~p",
-                       [Type, Host, Tag, C, R, S])
+            ?LOG_ERROR(#{what => pool_stop_failed,
+                         pool_type => Type, server => Host, pool_tag => Tag,
+                         pool_key => {Type, Host, Tag},
+                         class => C, reason => R, stacktrace => S})
     end.
 
 -spec is_configured(type()) -> boolean().
@@ -264,8 +265,9 @@ call_callback(Name, Type, Args) ->
         CallbackModule = make_callback_module_name(Type),
         erlang:apply(CallbackModule, Name, Args)
     catch E:R:ST ->
-          ?ERROR_MSG("event=wpool_callback_error, name=~p, error=~p, reason=~p, stacktrace=~p",
-                     [Name, E, R, ST]),
+          ?LOG_ERROR(#{what => pool_callback_failed,
+                       pool_type => Type, callback_function => Name,
+                       error => E, reason => R, stacktrace => ST}),
           {error, {callback_crashed, Name, E, R, ST}}
     end.
 

--- a/test/mongoose_deprecations_SUITE.erl
+++ b/test/mongoose_deprecations_SUITE.erl
@@ -7,7 +7,7 @@
 
 -define(TEST_COOLDOWN, 50).    % ms
 -define(COOLDOWN_EPS, 3).      % ms, must be much smaller than TEST_COOLDOWN
--define(LOG_MSG, "hey, deprecated!").
+-define(LOG_MSG, #{what => cool_deprecated}).
 
 all() ->
     [


### PR DESCRIPTION
This PR addresses MIM-1034.

We can find lines, requiring attention, using:

```bash
git grep --or -e "?DEBUG" -e "MSG("
```

Show just filenames needed attention:

```bash
git grep --or -e "?DEBUG" -e "MSG(" --files-with-matches
```

Proposed changes include:
- [x] Converted c2s
- [x] Converted MAM
- [x] Converted auth
- [x] Converted event pusher
- [x] Converted Global Distrib
- [x] Converted s2s
- [x] Converted wpool and cassandra (progress, Alek)
- [x] Converted rdbms (PR ready #2825, Leszek)
- [x] Converted pubsub (PR ready #2824, Leszek)
- [x] Converted MUC and muclight (progress, Michail)
- [x] Converted config modules (PR ready #2826, Leszek)
- [x] Convert mod_bosh, mod_bosh_socket (PR ready #2823, Alex)
- [x] Files above mongoose_cleaner - PR ready #2831, Leszek
- [x] Files below mongoose_cleaner, including it - Michael
- [x] Update docs to remove old macros
- [ ] AUDIT WHERE TO USE LOG_NOTICE, INSTEAD OF LOG_WARNING (welcome from reviewers). LOG_NOTICE- normal but significant condition 
- [x] +/- Documented fields https://github.com/esl/MongooseIM/blob/structured_logging/doc/operation-and-maintenance/Logging-fields.md


# Tasks

<details><summary>Convert pubsub details</summary>
<p>

```
src/pubsub/mod_pubsub.erl:    ?DEBUG("pubsub init ~p ~p", [ServerHost, Opts]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("** tree plugin is ~p", [TreePlugin]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("** PEP Mapping : ~p~n", [PepMapping]),
src/pubsub/mod_pubsub.erl:            ?ERROR_MSG("event=pubsub_plugin_init_failed,plugin=~p,host=~s,pubsub_host=~s,opts=~p",
src/pubsub/mod_pubsub.erl:            ?DEBUG("** init ~s plugin", [Name]),
src/pubsub/mod_pubsub.erl:              ?DEBUG("** terminate ~s plugin", [Name]),
src/pubsub/mod_pubsub.erl:            ?WARNING_MSG("event=cannot_delete_pubsub_user,"
src/pubsub/mod_pubsub.erl:            ?ERROR_MSG("~s process is dead, pubsub was broken", [?LOOPNAME]);
src/pubsub/mod_pubsub.erl:            ?INFO_MSG("Bad request: ~p", [Other]),
src/pubsub/mod_pubsub.erl:            ?INFO_MSG("Too many actions: ~p", [Action]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("Couldn't process ad hoc command:~n~p", [Other]),
src/pubsub/mod_pubsub.erl:    ?INFO_MSG("Bad XForm: ~p", [XData]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("Sending pending auth events for ~s on ~s:~s",
src/pubsub/mod_pubsub.erl:            ?DEBUG("XFields: ~p", [XFields]),
src/pubsub/mod_pubsub.erl:                        ?INFO_MSG("Node ~p; bad configuration: ~p", [Node, Configuration]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("event=invalid_pubsub_subscription_options,jid=~s,nidx=~p,subid=~s,reason=~p",
src/pubsub/mod_pubsub.erl:            ?DEBUG("~p@~p has no session; can't deliver ~p to contacts",
src/pubsub/mod_pubsub.erl:    ?DEBUG("tree_call ~p ~p ~p", [Host, Function, Args]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("tree_action ~p ~p ~p", [Host, Function, Args]),
src/pubsub/mod_pubsub.erl:    ?DEBUG("node_call ~p ~p ~p", [Type, Function, Args]),
src/pubsub/mod_pubsub.erl:                   ?ERROR_MSG("event=undefined_function, node_plugin=~p, function=~p",
src/pubsub/mod_pubsub.erl:    ?DEBUG("event=node_action,pubsub_host=~p,node_type=~p,function=~p,args=~p",
src/pubsub/mod_pubsub.erl:            ?DEBUG("error=\"cant_purge_items_on_offline\" plugin=\"~p\" user=\"~s\"",
src/pubsub/mod_pubsub.erl:    ?ERROR_MSG("event=pubsub_crash,details=~p", [Error]),
src/pubsub/mod_pubsub.erl:    ?ERROR_MSG("event=pubsub_crash,details=~p", [Error]),
src/pubsub/mod_pubsub_cache_rdbms.erl:    ?ERROR_MSG("RDBMS cache failed with: ~p", [Response]),
src/pubsub/mod_pubsub_db_mnesia.erl:            ?WARNING_MSG("event=transaction_retry retries=~p reason=~p debug=~p",
src/pubsub/mod_pubsub_db_mnesia.erl:            ?WARNING_MSG("event=transaction_failed reason=~p debug=~p",
src/pubsub/mod_pubsub_db_mnesia.erl:        _ -> ?WARNING_MSG("event=cyclic_nodes_detected node=~p cyclic_names=~p", [InitialNode, CyclicNames])
src/pubsub/mod_pubsub_db_mnesia.erl:        _ -> ?WARNING_MSG("event=cyclic_nodes_detected node=~p cyclic_names=~p", [InitialNode, CyclicNames])
src/pubsub/mod_pubsub_db_rdbms.erl:    ?WARNING_MSG("event=max_depth_reached, nodes=~p", [Acc]),
src/pubsub/mod_pubsub_db_rdbms.erl:    ?WARNING_MSG("event=max_depth_reached, nodes=~p", [Acc]),
```

</p></details>

<details><summary>Convert mod_bosh, mod_bosh_socket</summary>
<p>

```
src/mod_bosh.erl:    ?DEBUG("issue=bosh_init", []),
src/mod_bosh.erl:    ?DEBUG("OPTIONS response: ~p~n", [Headers]),
src/mod_bosh.erl:    ?DEBUG("issue=bosh_receive sid=~ts request_body=~p", [Sid, Body]),
src/mod_bosh.erl:    ?DEBUG("issue=bosh_send sid=~ts req_sid=~ts reply_body=~p",
src/mod_bosh.erl:    ?DEBUG("issue=bosh_close sid=~ts", [Sid]),
src/mod_bosh.erl:    ?DEBUG("issue=bosh_stop reason=missing_request_body req=~p", [Req]),
src/mod_bosh.erl:    ?DEBUG("issue=bosh_stop reason=wrong_request_method method=~p req=~p",
src/mod_bosh.erl:    ?DEBUG("issue=bosh_terminate", []),
src/mod_bosh.erl:                    ?WARNING_MSG("issue=bosh_stop "
src/mod_bosh.erl:            ?ERROR_MSG("issue=bosh_stop issue=undefined_condition reason=~p",
src/mod_bosh.erl:    ?DEBUG("issue=bosh_start_seassion sid=~ts", [Sid]).
src/mod_bosh_socket.erl:    ?DEBUG("mod_bosh_socket started~n", []),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled event in 'accumulate' state: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled event in 'normal' state: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled event in 'closing' state: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled sync event in 'accumulate' state: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled sync event in 'normal' state: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled sync event in 'closing' state: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled all state event: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled sync all state event: ~w~n", [Event]),
src/mod_bosh_socket.erl:    ?INFO_MSG("terminating due to client inactivity~n", []),
src/mod_bosh_socket.erl:    ?INFO_MSG("'wait' limit reached for ~p~n", [Pid]),
src/mod_bosh_socket.erl:    ?DEBUG("Unhandled info in '~s' state: ~w~n", [SName, Info]),
src/mod_bosh_socket.erl:    ?DEBUG("Closing session ~p in '~s' state. Handlers: ~p Pending: ~p~n",
src/mod_bosh_socket.erl:            ?INFO_MSG("deferring (rid: ~p, expected: ~p): ~p~n",
src/mod_bosh_socket.erl:            ?ERROR_MSG("invalid rid ~p, expected ~p, difference ~p:~n~p~n",
src/mod_bosh_socket.erl:            ?INFO_MSG("request ~p repeated but no response found in cache ~p~n",
src/mod_bosh_socket.erl:            ?ERROR_MSG("no cached response for RID ~p, responses ~p~n",
src/mod_bosh_socket.erl:                    ?DEBUG("processing deferred event: ~p~n", [Event]),
src/mod_bosh_socket.erl:            ?INFO_MSG("ignoring invalid client ack on stream start~n", []),
src/mod_bosh_socket.erl:            ?DEBUG("pending stanzas, can't send stream end", []),
```

</p></details>

<details><summary>Converted wpool, cassandra and rdbms</summary>
<p>

wpool:

```
src/wpool/mongoose_gun_worker.erl:    ?WARNING_MSG("event=mongoose_gun_worker_connection,status=down,"
src/wpool/mongoose_gun_worker.erl:    ?DEBUG("event=mongoose_gun_worker_connection,status=down,reason=~p,killed_streams=~p,unprocessed_streams=~p",
src/wpool/mongoose_gun_worker.erl:    ?WARNING_MSG("event=mongoose_gun_worker_error,reason=~p", [Reason]),
src/wpool/mongoose_gun_worker.erl:    ?WARNING_MSG("event=mongoose_gun_worker_error,reason=~p,stream_reference=~p",
src/wpool/mongoose_gun_worker.erl:    ?WARNING_MSG("event=mongoose_gun_worker_connection,status=lost,worker=~p,reason=~p.", [ConnPid, Reason]),
src/wpool/mongoose_gun_worker.erl:    ?ERROR_MSG("event=mongoose_gun_worker_message,status=unexpected,message=~p", [M]),
src/wpool/mongoose_gun_worker.erl:            ?DEBUG("event=mongoose_gun_worker_request,status=drop,request=~w", [Req]),
src/wpool/mongoose_gun_worker.erl:            ?DEBUG("event=mongoose_gun_worker_request,status=retry,request=~w", [Req]),
src/wpool/mongoose_wpool.erl:            ?ERROR_MSG("event=cannot_stop_pool,type=~p,host=~p,tag=~p,"
src/wpool/mongoose_wpool.erl:          ?ERROR_MSG("event=wpool_callback_error, name=~p, error=~p, reason=~p, stacktrace=~p",
src/wpool/mongoose_wpool_mgr.erl:    ?INFO_MSG("event=starting_pool, pool=~p, host=~p, tag=~p, pool_opts=~p",
src/wpool/mongoose_wpool_mgr.erl:            ?ERROR_MSG("Pool not started: ~p", [Other]),
src/wpool/mongoose_wpool_mgr.erl:            ?ERROR_MSG("event=error_starting_type_sup, reason=~p", [Other]),
src/wpool/mongoose_wpool_mgr.erl:            ?WARNING_MSG("event=unable_to_restart_pool, pool=~p, reason=~p",
src/wpool/mongoose_wpool_mgr.erl:    ?ERROR_MSG("event=dead_pool, name=~p, reason=~p",
src/wpool/mongoose_wpool_mgr.erl:            ?WARNING_MSG("event=unknown_pool_dead, name=~p", [PoolKey]),
src/wpool/mongoose_wpool_mgr.erl:            ?WARNING_MSG("event=error_stopping_pool, pool=~p, reason=~p",
```

rdbms
```
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?ERROR_MSG("event=use_escaped_failure value=~p stacktrace=~p",
src/rdbms/mongoose_rdbms.erl:    ?WARNING_MSG("unexpected cast: ~p", [Request]),
src/rdbms/mongoose_rdbms.erl:    ?WARNING_MSG("unexpected info: ~p", [Info]),
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("Database was not available or too slow,"
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("event=sql_transaction_restarts_exceeded "
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("event=sql_transaction_restarts_exceeded "
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("issue=outer_transaction_failed "
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("event=sql_execute_failed "
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("Connection attempt to ~s resulted in ~p."
src/rdbms/mongoose_rdbms.erl:            ?ERROR_MSG("Wrong keepalive_interval definition '~p'~n", [Other]),
src/rdbms/rdbms_queries.erl:    ?DEBUG("event=upsert_query, query=~s", [Query]),
```
cassandra
```
src/cassandra/mongoose_cassandra_worker.erl:    ?WARNING_MSG("Unexpected call ~p", [Msg]),
src/cassandra/mongoose_cassandra_worker.erl:    ?WARNING_MSG("Unexpected cast ~p", [Msg]),
src/cassandra/mongoose_cassandra_worker.erl:            ?WARNING_MSG("Unexpected retry request for ~p", [ReqId]),
src/cassandra/mongoose_cassandra_worker.erl:    ?WARNING_MSG("Unexpected info ~p", [Msg]),
src/cassandra/mongoose_cassandra_worker.erl:            ?WARNING_MSG("query_type=~s, tag=~p, ~s, action=aborting, abort_reason=~s",
src/cassandra/mongoose_cassandra_worker.erl:            ?WARNING_MSG("unexpected result ~p", [R]),
src/cassandra/mongoose_cassandra_worker.erl:            ?WARNING_MSG("unexpected error ~p", [Error]),
src/cassandra/mongoose_cassandra_worker.erl:            ?WARNING_MSG("query_type=~s, tag=~p, ~s, action=aborting, abort_reason=~s",
src/cassandra/mongoose_cassandra_worker.erl:            ?WARNING_MSG("query_type=~s, tag=~p, ~s, action=retrying, retry_left=~p "
src/cassandra/mongoose_cassandra_worker.erl:        E:R -> ?INFO_MSG("error getting client: ~p retry: ~p", [{E, R}, RetryNo]),
```
</p></details>
