### PR TITLE
Add support for all s2s options

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -88,7 +88,9 @@ process_section(<<"access">>, Content) ->
 process_section(<<"s2s">>, Content) ->
     DNS_Opts = s2s_dns_opts(Content),
     Out = s2s_outgoing_opts(Content),
-    Opts = maps:without([<<"dns_timeout">>, <<"dns_retries">>, <<"preferred_ip_version">>, <<"connection_timeout">>], Content),
+    Opts = maps:without(
+        [<<"dns_timeout">>, <<"dns_retries">>, 
+            <<"preferred_ip_version">>, <<"connection_timeout">>], Content),
     S2s_opts = parse_map(fun process_s2s_option/2, Opts),
     Out ++ DNS_Opts ++ S2s_opts;
 process_section(<<"host_config">>, Content) ->
@@ -523,16 +525,16 @@ process_s2s_option(<<"preferred_ip_version">>, V) ->
         value = s2s_preferred_address_family(V)}];
 process_s2s_option(<<"shared">>, V) ->
     ?HOST_F([#local_config{key = {s2s_shared, Host}, value = V}]);
-
 process_s2s_option(<<"max_retry_delay">>, V) ->
     ?HOST_F([#local_config{key = {s2s_max_retry_delay, Host}, value = V}]).
 
-
-s2s_outgoing_opts(_Content = #{<<"connection_timeout">> := Timeout, <<"preferred_ip_version">> := IPV}) ->
-    [#local_config{key = outgoing_s2s_options, value = {s2s_preferred_address_family(IPV), Timeout}}];
-s2s_outgoing_opts(_Content = #{<<"connection_timeout">> := Timeout}) ->
+-spec s2s_outgoing_opts(toml_section()) -> [option()].
+s2s_outgoing_opts(#{<<"connection_timeout">> := Timeout, <<"preferred_ip_version">> := IPV}) ->
+    [#local_config{key = outgoing_s2s_options, 
+        value = {s2s_preferred_address_family(IPV), Timeout}}];
+s2s_outgoing_opts(#{<<"connection_timeout">> := Timeout}) ->
     [#local_config{key = outgoing_s2s_options, value = Timeout}];
-s2s_outgoing_opts(_Content = #{<<"preferred_ip_version">> := IPV}) ->
+s2s_outgoing_opts(#{<<"preferred_ip_version">> := IPV}) ->
     [#local_config{key = outgoing_s2s_options, value = s2s_preferred_address_family(IPV)}];
 s2s_outgoing_opts(_) -> [].
 

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -67,6 +67,12 @@ process_section(<<"general">>, Content) ->
 process_section(<<"listen">>, Content) ->
     Listeners = parse_map(fun process_listener_type/2, Content),
     [#local_config{key = listen, value = Listeners}];
+process_section(<<"auth">>, Content) ->
+    AuthOpts = parse_map(fun auth_option/2, Content),
+    ?HOST_F(partition_auth_opts(AuthOpts, Host));
+process_section(<<"outgoing_pools">>, Content) ->
+    Pools = parse_map(fun process_pool_type/2, Content),
+    [#local_config{key = outgoing_pools, value = Pools}];
 process_section(<<"services">>, Content) ->
     Services = parse_map(fun process_service/2, Content),
     [#local_config{key = services, value = Services}];
@@ -497,7 +503,7 @@ process_s2s_option(<<"use_starttls">>, V) ->
 process_s2s_option(<<"certfile">>, V) ->
     [#local_config{key = s2s_certfile, value = b2l(V)}];
 process_s2s_option(<<"default_policy">>, V) ->
-    [?HOST_F(#local_config{key = {s2s_default_policy, Host}, value = b2a(V)})];
+    ?HOST_F([#local_config{key = {s2s_default_policy, Host}, value = b2a(V)}]);
 process_s2s_option(<<"outgoing_port">>, V) ->
     [#local_config{key = outgoing_s2s_port, value = V}];
 process_s2s_option(<<"address">>, Addrs) ->
@@ -516,10 +522,10 @@ process_s2s_option(<<"preferred_ip_version">>, V) ->
     [#local_config{key = preferred_address_family, 
         value = s2s_preferred_address_family(V)}];
 process_s2s_option(<<"shared">>, V) ->
-    [?HOST_F(#local_config{key = {s2s_shared, Host}, value = V})];
+    ?HOST_F([#local_config{key = {s2s_shared, Host}, value = V}]);
 
 process_s2s_option(<<"max_retry_delay">>, V) ->
-    [?HOST_F(#local_config{key = {s2s_max_retry_delay, Host}, value = V})].
+    ?HOST_F([#local_config{key = {s2s_max_retry_delay, Host}, value = V}]).
 
 
 s2s_outgoing_opts(_Content = #{<<"connection_timeout">> := Timeout, <<"preferred_ip_version">> := IPV}) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -37,7 +37,6 @@ s2s(Config) ->
     State1 = mongoose_config_parser_cfg:parse_file(Cfg_Path),
     Opts1 = mongoose_config_parser:state_to_opts(State1),
 
-
     TOML_path = ejabberd_helper:data(Config, "s2s_only.toml"),
     State2 = mongoose_config_parser_toml:parse_file(TOML_path),
     Opts2 = mongoose_config_parser:state_to_opts(State2),

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -9,7 +9,7 @@
 -define(eq(Expected, Actual), ?assertEqual(Expected, Actual)).
 
 all() ->
-    [equivalence].
+    [equivalence, s2s].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(jid),
@@ -28,8 +28,19 @@ equivalence(Config) ->
     State2 = mongoose_config_parser_toml:parse_file(TOMLPath),
     Hosts2 = mongoose_config_parser:state_to_host_opts(State2),
     Opts2 = mongoose_config_parser:state_to_opts(State2),
-
     ?eq(Hosts1, Hosts2),
+    compare_unordered_lists(lists:filter(fun filter_config/1, Opts1), Opts2,
+                            fun handle_config_option/2).
+
+s2s(Config) ->
+    Cfg_Path = ejabberd_helper:data(Config, "s2s_only.cfg"),
+    State1 = mongoose_config_parser_cfg:parse_file(Cfg_Path),
+    Opts1 = mongoose_config_parser:state_to_opts(State1),
+
+
+    TOML_path = ejabberd_helper:data(Config, "s2s_only.toml"),
+    State2 = mongoose_config_parser_toml:parse_file(TOML_path),
+    Opts2 = mongoose_config_parser:state_to_opts(State2),
     compare_unordered_lists(lists:filter(fun filter_config/1, Opts1), Opts2,
                             fun handle_config_option/2).
 

--- a/test/config_parser_SUITE_data/s2s_only.cfg
+++ b/test/config_parser_SUITE_data/s2s_only.cfg
@@ -1,6 +1,6 @@
 {hosts, [
     "localhost",
-    "grubalubadubdub"
+    "dummy_host"
 ]}.
 
 {s2s_use_starttls, optional}.

--- a/test/config_parser_SUITE_data/s2s_only.cfg
+++ b/test/config_parser_SUITE_data/s2s_only.cfg
@@ -1,0 +1,17 @@
+{hosts, [
+    "localhost",
+    "grubalubadubdub"
+]}.
+
+{s2s_use_starttls, optional}.
+{s2s_certfile, "tools/ssl/mongooseim/server.pem"}.
+{s2s_default_policy, allow }.
+{outgoing_s2s_port, 5299 }.
+{ {s2s_addr, "fed1"}, {127,0,0,1} }.
+{s2s_ciphers, "TLSv1.2:TLSv1.3"}.
+{domain_certfile, "example.org", "/path/to/example_org.pem"}.
+{domain_certfile, "example.com", "/path/to/example_com.pem"}.
+{outgoing_s2s_options, [ipv4, ipv6], 10000}.
+{s2s_shared, <<"shared secret">>}.
+{s2s_dns_options, [{timeout, 30}, {retries, 1}]}.
+{s2s_max_retry_delay, 30}.

--- a/test/config_parser_SUITE_data/s2s_only.toml
+++ b/test/config_parser_SUITE_data/s2s_only.toml
@@ -1,0 +1,29 @@
+[general]
+  hosts = [
+    "localhost",
+    "grubalubadubdub"
+  ]
+[s2s]
+  use_starttls = "optional"
+  certfile = "tools/ssl/mongooseim/server.pem"
+  default_policy = "allow"
+  outgoing_port = 5299
+  ciphers = "TLSv1.2:TLSv1.3"
+  connection_timeout = 10000
+  preferred_ip_version = 4
+  shared = "shared secret"
+  dns_timeout = 30
+  dns_retries = 1
+  max_retry_delay = 30
+
+  [[s2s.address]]
+    host = "fed1"
+    ip_address = "127.0.0.1"
+
+  [[s2s.domain_certfile]]
+    domain = "example.com"
+    certfile = "/path/to/example_com.pem"
+  
+  [[s2s.domain_certfile]]
+    domain = "example.org"
+    certfile = "/path/to/example_org.pem"

--- a/test/config_parser_SUITE_data/s2s_only.toml
+++ b/test/config_parser_SUITE_data/s2s_only.toml
@@ -1,7 +1,7 @@
 [general]
   hosts = [
     "localhost",
-    "grubalubadubdub"
+    "dummy_host"
   ]
 [s2s]
   use_starttls = "optional"


### PR DESCRIPTION
This PR adds support for all s2s options in the TOML config file

* Introduced new variable names in the config file (not documented yet!)
* Updated parser to properly use new options
* Added separate test for s2s options only

