### PR TITLE
Add support for miscellaneous opts

### DIFF
--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -10,6 +10,7 @@
 -export([new_state/0,
          allow_override_all/1,
          allow_override_local_only/1,
+         override/2,
          override_global/1,
          override_local/1,
          override_acls/1,
@@ -81,7 +82,13 @@ allow_override_local_only(State = #state{}) ->
     State#state{override_global = false,
                 override_local  = true,
                 override_acls   = false}.
-
+-spec override(Scope :: atom(), state()) -> state().
+override(global, State) ->
+    override_global(State);
+override(local, State) ->
+    override_local(State);
+override(acls, State) ->
+    override_acls(State).
 -spec override_global(state()) -> state().
 override_global(State) ->
     State#state{override_global = true}.

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -82,13 +82,12 @@ allow_override_local_only(State = #state{}) ->
     State#state{override_global = false,
                 override_local  = true,
                 override_acls   = false}.
+
 -spec override(Scope :: atom(), state()) -> state().
-override(global, State) ->
-    override_global(State);
-override(local, State) ->
-    override_local(State);
-override(acls, State) ->
-    override_acls(State).
+override(global, State) -> override_global(State);
+override(local, State) -> override_local(State);
+override(acls, State) -> override_acls(State).
+
 -spec override_global(state()) -> state().
 override_global(State) ->
     State#state{override_global = true}.

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -44,7 +44,6 @@ miscellaneous(Config) ->
     Hosts2 = mongoose_config_parser:state_to_host_opts(State2),
     Opts2 = mongoose_config_parser:state_to_opts(State2),
 
-    % ?eq([], Opts1),
     ?eq(Hosts1, Hosts2),
     compare_unordered_lists(lists:filter(fun filter_config/1, Opts1), Opts2,
                             fun handle_config_option/2).
@@ -78,6 +77,10 @@ compare_values({auth_method, _}, V1, V2) when is_atom(V1) ->
     ?eq([V1], V2);
 compare_values({s2s_addr, _}, {_, _, _, _} = IP1, IP2) ->
     ?eq(inet:ntoa(IP1), IP2);
+compare_values(services, V1, V2) ->
+    V1_m = proplists:get_value(service_mongoose_system_metrics, V1),
+    V2_m = proplists:get_value(service_mongoose_system_metrics, V2),
+    compare_unordered_lists(V1_m, V2_m);
 compare_values(K, V1, V2) ->
     ?eq({K, V1}, {K, V2}).
 

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -78,9 +78,9 @@ compare_values({auth_method, _}, V1, V2) when is_atom(V1) ->
 compare_values({s2s_addr, _}, {_, _, _, _} = IP1, IP2) ->
     ?eq(inet:ntoa(IP1), IP2);
 compare_values(services, V1, V2) ->
-    V1_m = proplists:get_value(service_mongoose_system_metrics, V1),
-    V2_m = proplists:get_value(service_mongoose_system_metrics, V2),
-    compare_unordered_lists(V1_m, V2_m);
+    MetricsOpts1 = proplists:get_value(service_mongoose_system_metrics, V1),
+    MetricsOpts2 = proplists:get_value(service_mongoose_system_metrics, V2),
+    compare_unordered_lists(MetricsOpts1, MetricsOpts2);
 compare_values(K, V1, V2) ->
     ?eq({K, V1}, {K, V2}).
 

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -9,7 +9,7 @@
 -define(eq(Expected, Actual), ?assertEqual(Expected, Actual)).
 
 all() ->
-    [equivalence].
+    [equivalence, miscellaneous].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(jid),
@@ -29,6 +29,22 @@ equivalence(Config) ->
     Hosts2 = mongoose_config_parser:state_to_host_opts(State2),
     Opts2 = mongoose_config_parser:state_to_opts(State2),
 
+    ?eq(Hosts1, Hosts2),
+    compare_unordered_lists(lists:filter(fun filter_config/1, Opts1), Opts2,
+                            fun handle_config_option/2).
+
+miscellaneous(Config) ->
+    CfgPath = ejabberd_helper:data(Config, "miscellaneous.cfg"),
+    State1 = mongoose_config_parser_cfg:parse_file(CfgPath),
+    Hosts1 = mongoose_config_parser:state_to_host_opts(State1),
+    Opts1 = mongoose_config_parser:state_to_opts(State1),
+
+    TOMLPath = ejabberd_helper:data(Config, "miscellaneous.toml"),
+    State2 = mongoose_config_parser_toml:parse_file(TOMLPath),
+    Hosts2 = mongoose_config_parser:state_to_host_opts(State2),
+    Opts2 = mongoose_config_parser:state_to_opts(State2),
+
+    % ?eq([], Opts1),
     ?eq(Hosts1, Hosts2),
     compare_unordered_lists(lists:filter(fun filter_config/1, Opts1), Opts2,
                             fun handle_config_option/2).

--- a/test/config_parser_SUITE_data/miscellaneous.cfg
+++ b/test/config_parser_SUITE_data/miscellaneous.cfg
@@ -12,6 +12,7 @@ override_acls.
 {replaced_wait_timeout, 2000}.
 {hide_service_name, true}.
 {extauth_instances, 1}.
+{auth_opts, []}. % required because the 'auth' section is defined in 'miscellaneous.toml'
 
 {listen,
  [

--- a/test/config_parser_SUITE_data/miscellaneous.cfg
+++ b/test/config_parser_SUITE_data/miscellaneous.cfg
@@ -11,3 +11,21 @@ override_acls.
 {routing_modules, [mongoose_router_global, mongoose_router_localdomain]}.
 {replaced_wait_timeout, 2000}.
 {hide_service_name, true}.
+{extauth_instances, 1}.
+
+{listen,
+ [
+  { 5280, ejabberd_cowboy, [
+                            {transport_options, [{num_acceptors, 10}, {max_connections, 1024}]},
+                            {modules, [
+                                       {"_", "/ws-xmpp", mod_websockets, [{ejabberd_service, [
+                                                                                              {access, all},
+                                                                                              {shaper_rule, fast},
+                                                                                              {password, "secret"},
+                                                                                              {max_fsm_queue, 1000}]}
+                                                                         ]}
+                                      ]}
+                           ]}]}.
+{services, [
+    {service_mongoose_system_metrics, [report, {initial_report, 300000}, {periodic_report, 10800000}, {tracking_id, "UA-123456789"}]}
+]}.

--- a/test/config_parser_SUITE_data/miscellaneous.cfg
+++ b/test/config_parser_SUITE_data/miscellaneous.cfg
@@ -1,0 +1,13 @@
+{hosts, ["localhost",
+         "anonymous.localhost"
+        ] }.
+
+override_global.
+override_local.
+override_acls.
+{pgsql_users_number_estimate, true}.
+{route_subdomain, s2s}.
+{mongooseimctl_access_commands, [{local, ["join_cluster"], [{"mongooseim@host", "mongooseim@prime"}]}]}.
+{routing_modules, [mongoose_router_global, mongoose_router_localdomain]}.
+{replaced_wait_timeout, 2000}.
+{hide_service_name, true}.

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -1,0 +1,20 @@
+[general]
+  hosts = [
+    "localhost",
+    "anonymous.localhost"
+  ]
+  override_global = true
+  override_local = true
+  override_acls = true
+  pgsql_users_number_estimate = true
+  route_subdomain = "s2s"
+  routing_modules = [
+      "mongoose_router_global",
+      "mongoose_router_localdomain"
+  ]
+  replaced_wait_timeout = 2000
+  hide_service_name = true
+[[general.mongooseimctl_access_commands]]
+    access_rule = "local"
+    commands = ["join_cluster"]
+    argument_restrictions = ["mongooseim@host", "mongooseim@prime"]

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -3,9 +3,7 @@
     "localhost",
     "anonymous.localhost"
   ]
-  override_global = true
-  override_local = true
-  override_acls = true
+  override = ["local", "global", "acls"]
   pgsql_users_number_estimate = true
   route_subdomain = "s2s"
   routing_modules = [
@@ -14,7 +12,8 @@
   ]
   replaced_wait_timeout = 2000
   hide_service_name = true
-[[general.mongooseimctl_access_commands]]
+
+  [[general.mongooseimctl_access_commands]]
     access_rule = "local"
     commands = ["join_cluster"]
     argument_restrictions = ["mongooseim@host", "mongooseim@prime"]

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -18,3 +18,27 @@
     access_rule = "local"
     commands = ["join_cluster"]
     argument_restrictions = ["mongooseim@host", "mongooseim@prime"]
+
+[auth]
+  extauth_instances = 1
+
+[[listen.http]]
+  port = 5280
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mod_websockets]]
+    host = "_"
+    path = "/ws-xmpp"
+
+    [listen.http.handlers.mod_websockets.ejabberd_service]
+      access = "all"
+      shaper_rule = "fast"
+      password = "secret"
+      max_fsm_queue = 1000
+
+[services.service_mongoose_system_metrics]
+  report = true
+  initial_report = 300_000
+  periodic_report = 10_800_000
+  tracking_id = "UA-123456789"

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.cfg
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.cfg
@@ -109,8 +109,7 @@
             ]}.
 {host_config, "anonymous.localhost", [{auth_method, anonymous},
                                       {allow_multiple_connections, true},
-                                      {anonymous_protocol, both},
-                                      {auth_opts, []}]}.
+                                      {anonymous_protocol, both}]}.
 {outgoing_pools, [
                   {redis, <<"localhost">>, global_distrib, [{workers, 10}], []},
                   {rdbms, global, default, [{workers, 5}],

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.cfg
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.cfg
@@ -109,7 +109,8 @@
             ]}.
 {host_config, "anonymous.localhost", [{auth_method, anonymous},
                                       {allow_multiple_connections, true},
-                                      {anonymous_protocol, both}]}.
+                                      {anonymous_protocol, both},
+                                      {auth_opts, []}]}.
 {outgoing_pools, [
                   {redis, <<"localhost">>, global_distrib, [{workers, 10}], []},
                   {rdbms, global, default, [{workers, 5}],


### PR DESCRIPTION
This PR adds support for missing options in the following sections:
* general
* auth
* listen
* services

Additionally, a few changes had to be made in the existing code to accomodate for some of the new options.

