### PR TITLE
convert files above mongoose_cleaner for structured logging

### DIFF
--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -251,13 +251,8 @@ prepare_opt_val(Opt, Val, F, Default) ->
           end,
     case Res of
         {'EXIT', _} ->
-            ?ERROR_MSG("Configuration problem:~n"
-                      "** Option: ~p~n"
-                      "** Invalid value: ~p~n"
-                      "** Using as fallback: ~p",
-                      [ Opt,
-                        Val,
-                        Default]),
+            ?LOG_ERROR(#{what => configuration_error, option => Opt,
+                         value => Val, default => Default}),
             Default;
         _ ->
             Res

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -141,8 +141,8 @@ handle(Host, Module, Function, Opts, From, To, Acc, IQ) ->
 process_iq(_Host, Module, Function, From, To, Acc, IQ) ->
     case catch Module:Function(From, To, Acc, IQ) of
         {'EXIT', {Reason, StackTrace}} ->
-            ?WARNING_MSG("event=process_iq_error,reason=~p,stack_trace=~p",
-                         [Reason, StackTrace]),
+            ?LOG_WARNING(#{what => process_iq_error, reason => Reason,
+                           stacktrace => StackTrace}),
             Acc;
         {Acc1, ignore} ->
             Acc1;

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -136,11 +136,10 @@ start_module_for_host(Host, Module, Opts0) ->
                 %% Note for programmers:
                 %% Never call start_link directly from your_module:start/2 function!
                 %% The process will be killed if we start modules remotely or in shell
-                ?ERROR_MSG("msg=unexpected_links ~s"
-                            " links_before=~p links_after=~p",
-                           [TravisInfo, LinksBefore, LinksAfter])
+                ?LOG_ERROR(#{what => unexpected_links, travis_info => TravisInfo,
+                             links_before => LinksBefore, links_after => LinksAfter})
         end,
-        ?DEBUG("Module ~p started for ~p.", [Module, Host]),
+        ?LOG_DEBUG(#{what => module_started, module => Module, server => Host}),
         % normalise result
         case Res of
             {ok, R} -> {ok, R};
@@ -154,14 +153,18 @@ start_module_for_host(Host, Module, Opts0) ->
                                       "host ~p~n options: ~p~n ~p: ~p~n~p",
                                       [Module, Host, Opts, Class, Reason,
                                        StackTrace]),
-            ?CRITICAL_MSG(ErrorText, []),
+            ?LOG_CRITICAL(#{what => starting_module_failed, module => Module,
+                            server => Host, opts => Opts, class => Class,
+                            reason => Reason, stacktrace => StackTrace}),
             case is_mim_or_ct_running() of
                 true ->
                     erlang:raise(Class, Reason, StackTrace);
                 false ->
-                    ?CRITICAL_MSG("mongooseim initialization was aborted "
-                                  "because a module start failed.~n"
-                                  "The trace is ~p.", [StackTrace]),
+                    Msg1 = <<"mongooseim initialization was aborted ">>,
+                    Msg2 = <<"because a module start failed.">>,
+                    ?LOG_CRITICAL(#{what => mim_initialization_aborted,
+                                    text => <<Msg1/binary, Msg2/binary>>,
+                                    stacktrace => StackTrace}),
                     timer:sleep(3000),
                     erlang:halt(string:substr(lists:flatten(ErrorText),
                                               1, 199))
@@ -224,7 +227,7 @@ stop_module_keep_config(Host, Module) ->
     Opts = opts_for_module(Host, Module),
     case catch Module:stop(Host) of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("~p", [Reason]),
+            ?LOG_ERROR(#{what => module_stopping_failed, reason => Reason}),
             {error, Reason};
         {wait, ProcList} when is_list(ProcList) ->
             lists:foreach(fun wait_for_process/1, ProcList),

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -130,7 +130,8 @@ make_error_reply(Acc, Error) ->
 make_error_reply(Acc, Packet, Error) ->
     case mongoose_acc:get(flag, error, false, Acc) of
         true ->
-            ?ERROR_MSG("event=error_reply_to_error,stanza=~p,error=~p", [Packet, Error]),
+            ?LOG_ERROR(#{what => error_reply_to_error, exml_packet => Packet,
+                         reason => Error}),
             {Acc, {error, {already_an_error, Packet, Error}}};
         _ ->
             {mongoose_acc:set(flag, error, true, Acc),

--- a/src/metrics/mongoose_metrics_probe.erl
+++ b/src/metrics/mongoose_metrics_probe.erl
@@ -87,7 +87,8 @@ probe_setopts(_Entry, _Opts, _S) ->
 probe_handle_msg({'DOWN', Ref, _, _, {sample, Data}}, #state{ref = Ref} = S) ->
     {ok, S#state{ref = undefined, data = Data}};
 probe_handle_msg({'DOWN', Ref, _, _, Reason}, #state{callback_module = Mod, ref = Ref} = S) ->
-    ?WARNING_MSG("Probe callback_module ~p died with reason ~p: ", [Mod, Reason]),
+    ?LOG_WARNING(#{what => probe_callback_module_died, module => Mod,
+                   reason => Reason}),
     {ok, S#state{ref = undefined}};
 probe_handle_msg(_, S) ->
     {ok, S}.

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -224,7 +224,7 @@ process_sm_iq(From, To, Acc, IQ) ->
 -spec process_adhoc_request(jid:jid(), jid:jid(), jlib:iq(),
         Hook :: atom()) -> ignore | jlib:iq().
 process_adhoc_request(From, To, #iq{sub_el = SubEl} = IQ, Hook) ->
-    ?DEBUG("About to parse ~p...", [IQ]),
+    ?LOG_DEBUG(#{what => about_to_parse, exml_packet => IQ}),
     case adhoc:parse_request(IQ) of
         {error, Error} ->
             IQ#iq{type = error, sub_el = [SubEl, Error]};

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -194,8 +194,9 @@ send_error_and_drop(Packet, From, AmpError, MatchedRule) ->
 
 -spec send_errors_and_drop(exml:element(), jid:jid(), [{amp_error(), amp_rule()}]) -> drop.
 send_errors_and_drop(Packet, From, []) ->
-    ?ERROR_MSG("~p from ~p generated an empty list of errors. This shouldn't happen!",
-               [Packet, From]),
+    ?LOG_ERROR(#{what => empty_list_of_errors_generated,
+                 text => <<"This shouldn't happen!">>,
+                 exml_packet => Packet, from => From}),
     update_metric_and_drop(Packet, From);
 send_errors_and_drop(Packet, From, ErrorRules) ->
     Host = host(From),

--- a/src/mod_auth_token_rdbms.erl
+++ b/src/mod_auth_token_rdbms.erl
@@ -38,7 +38,7 @@ revoke(#jid{lserver = LServer} = JID) ->
     EBareJID = mongoose_rdbms:escape_string(BBareJID),
     RevokeQuery = revoke_query(EBareJID),
     QueryResult = mongoose_rdbms:sql_query(LServer, RevokeQuery),
-    ?DEBUG("result ~p", [QueryResult]),
+    ?LOG_DEBUG(#{what => revoke_query, result => QueryResult}),
     case QueryResult of
         {updated, 1} -> ok;
         {updated, 0} -> not_found

--- a/src/mod_aws_sns.erl
+++ b/src/mod_aws_sns.erl
@@ -29,9 +29,11 @@ deps(_Host, Opts) ->
 
 -spec start(Host :: jid:server(), Opts :: proplists:proplist()) -> any().
 start(_Host, _Opts) ->
-    ?WARNING_MSG("mod_aws_sns is deprecated and will be removed in the future.~n"
-                 "Please use mod_event_pusher with sns backend.~n"
-                 "Refer to mod_event_pusher documentation for more information.", []).
+    Msg1 = <<"mod_aws_sns is deprecated and will be removed in the future.~n">>,
+    Msg2 = <<"Please use mod_event_pusher with sns backend.~n">>,
+    Msg3 = <<"Refer to mod_event_pusher documentation for more information.">>,
+    ?LOG_WARNING(#{what => module_deprecated,
+                   text => <<Msg1/binary, Msg2/binary, Msg3/binary>>}).
 
 -spec stop(Host :: jid:server()) -> ok.
 stop(_Host) ->

--- a/src/mod_cowboy.erl
+++ b/src/mod_cowboy.erl
@@ -55,9 +55,8 @@ init(Req, Opts) ->
         Class:Reason:StackTrace ->
               %% Because cowboy ignores stacktraces
               %% and we can get a cryptic error like {crash,error,undef}
-              ?ERROR_MSG("issue=init_failed "
-                          "reason=~p:~p stacktrace=~1000p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_ERROR(#{what => init_failed, class => Class,
+                           reason => Reason, stacktrace => StackTrace}),
               erlang:raise(Class, Reason, StackTrace)
     end.
 
@@ -95,9 +94,8 @@ websocket_handle(InFrame, State) ->
         Class:Reason:StackTrace ->
               %% Because cowboy ignores stacktraces
               %% and we can get a cryptic error like {crash,error,undef}
-              ?ERROR_MSG("issue=websocket_handle_failed "
-                          "reason=~p:~p stacktrace=~1000p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_ERROR(#{what => websocket_handle_failed, class => Class,
+                           reason => Reason, stacktrace => StackTrace}),
               erlang:raise(Class, Reason, StackTrace)
     end.
 
@@ -124,9 +122,8 @@ websocket_info(Info, State) ->
         Class:Reason:StackTrace ->
               %% Because cowboy ignores stacktraces
               %% and we can get a cryptic error like {crash,error,undef}
-              ?ERROR_MSG("issue=websocket_info_failed "
-                          "reason=~p:~p stacktrace=~1000p",
-                         [Class, Reason, StackTrace]),
+              ?LOG_ERROR(#{what => websocket_info_failed, class => Class,
+                           reason => Reason, stacktrace => StackTrace}),
               erlang:raise(Class, Reason, StackTrace)
     end.
 

--- a/src/mod_http_notification.erl
+++ b/src/mod_http_notification.erl
@@ -11,9 +11,11 @@ deps(_Host, Opts) ->
     [{mod_event_pusher, [{backends, [{http, Opts}]}], hard}].
 
 start(_Host, _Opts) ->
-    ?WARNING_MSG("mod_http_notification is deprecated and will be removed in the future.~n"
-                 "Please use mod_event_pusher with http backend.~n"
-                 "Refer to mod_event_pusher documentation for more information.", []).
+    Msg1 = <<"mod_http_notification is deprecated and will be removed in the future.~n">>,
+    Msg2 = <<"Please use mod_event_pusher with http backend.~n">>,
+    Msg3 = <<"Refer to mod_event_pusher documentation for more information.">>,
+    ?LOG_WARNING(#{what => module_deprecated,
+                   text => <<Msg1/binary, Msg2/binary, Msg3/binary>>}).
 
 stop(_Host) ->
     ok.

--- a/src/mod_keystore.erl
+++ b/src/mod_keystore.erl
@@ -98,8 +98,9 @@ get_key(HandlerAcc, KeyID) ->
          mod_keystore_backend:get_key(KeyID) ++
          HandlerAcc)
     catch
-        E:R ->
-            ?ERROR_MSG("handler error: {~p, ~p}", [E, R]),
+        E:R:S ->
+            ?LOG_ERROR(#{what => mod_keystore_handler_error,
+                         error => E, reason => R, stacktrace => S}),
             HandlerAcc
     end.
 

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -140,12 +140,12 @@ process_sm_iq(
                 ok ->
                     IQ#iq{type = result, sub_el = [SubElem]};
                 {error, Reason} ->
-                    ?ERROR_MSG("~p:multi_set_data failed ~p for ~ts@~ts.",
-                               [mod_private_backend, Reason, LUser, LServer]),
+                    ?LOG_ERROR(#{what => multi_set_data_failed, reason => Reason,
+                                 user => LUser, server => LServer}),
                     error_iq(IQ, mongoose_xmpp_errors:internal_server_error());
                 {aborted, Reason} ->
-                    ?ERROR_MSG("~p:multi_set_data aborted ~p for ~ts@~ts.",
-                               [mod_private_backend, Reason, LUser, LServer]),
+                    ?LOG_ERROR(#{what => multi_set_data_aborted, reason => Reason,
+                                 user => LUser, server => LServer}),
                     error_iq(IQ, mongoose_xmpp_errors:internal_server_error())
             end;
         not_allowed ->

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -79,7 +79,8 @@ stop(Host) ->
                          Options :: #{binary() => binary()}) ->
     ok | {error, Reason :: term()}.
 push_notifications(_AccIn, Host, Notifications, Options) ->
-    ?DEBUG("push_notifications ~p", [{Notifications, Options}]),
+    ?LOG_DEBUG(#{what => push_notifications, notifications => Notifications,
+                 opts => Options}),
 
     DeviceId = maps:get(<<"device_id">>, Options),
     ProtocolVersionOpt = gen_mod:get_module_opt(Host, ?MODULE, api_version, ?DEFAULT_API_VERSION),
@@ -127,20 +128,22 @@ http_notification(Host, Method, URL, ReqHeaders, Payload) ->
                 StatusCode when StatusCode >= 200 andalso StatusCode < 300 ->
                     ok;
                 410 ->
-                    ?WARNING_MSG("issue=unable_to_submit_push_notification, https_status=410, reason=device_not_registered", []),
+                    ?LOG_WARNING(#{what => unable_to_submit_push_notification,
+                                   https_status => 410, reason => device_not_registered}),
                     {error, device_not_registered};
                 StatusCode when StatusCode >= 400 andalso StatusCode < 500  ->
-                    ?ERROR_MSG("issue=unable_to_submit_push_notification, http_status=~p, url=~p, response=~p, "
-                               "details=\"Possible API mismatch\", payload=~p",
-                               [StatusCode, URL, Body, Payload]),
+                    ?LOG_ERROR(#{what => unable_to_submit_push_notification,
+                                 text => <<"Possible API mismatch">>,
+                                 http_status => StatusCode, url => URL,
+                                 response => Body, payload => Payload}),
                     {error, {invalid_status_code, StatusCode}};
                 StatusCode ->
-                    ?ERROR_MSG("issue=unable_to_submit_push_notification, http_status=~p, response=~p",
-                               [StatusCode, Body]),
+                    ?LOG_ERROR(#{what => unable_to_submit_push_notification,
+                                 http_status => StatusCode, response => Body}),
                     {error, {invalid_status_code, StatusCode}}
             end;
         {error, Reason} ->
-            ?ERROR_MSG("Unable to communicate to MongoosePush service due to ~p", [Reason]),
+            ?LOG_ERROR(#{what => connection_error, reason => Reason}),
             {error, Reason}
     end.
 

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -362,8 +362,8 @@ check_timeout(Source) ->
                 {atomic, Res} ->
                     Res;
                 {aborted, Reason} ->
-                    ?ERROR_MSG("mod_register: timeout check error: ~p~n",
-                               [Reason]),
+                    ?LOG_ERROR(#{what => mod_register_timeout_check_error,
+                                 reason => Reason}),
                     true
             end;
         false ->
@@ -418,8 +418,8 @@ is_strong_password(Server, Password) ->
         Entropy when is_number(Entropy), Entropy > 0 ->
             ejabberd_auth:entropy(Password) >= Entropy;
         Wrong ->
-            ?WARNING_MSG("Wrong value for password_strength option: ~p",
-                         [Wrong]),
+            ?LOG_WARNING(#{what => mod_register_wrong_password_strength,
+                           value => Wrong}),
             true
     end.
 
@@ -435,7 +435,8 @@ get_ip_access(Host) ->
                   {ok, IP, Mask} ->
                       [{Access, IP, Mask}];
                   error ->
-                      ?ERROR_MSG("mod_register: invalid network specification: ~p", [S]),
+                      ?LOG_ERROR(#{what => mod_register_invalid_network_specification,
+                                   specification => S}),
                       []
               end
       end, IPAccess).

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -508,7 +508,7 @@ set_roster_item(User, LUser, LServer, LJID, From, To, MakeItem2) ->
                 _ -> ok
             end;
         E ->
-            ?ERROR_MSG("event=set_roster_item_failed reason=~1000p", [E]), ok
+            ?LOG_ERROR(#{what => set_roster_item_failed, reason => E}), ok
     end.
 
 process_item_attrs(Item, [{<<"jid">>, Val} | Attrs]) ->
@@ -881,8 +881,8 @@ try_send_unsubscription_to_rosteritems(Acc, LUser, LServer) ->
         send_unsubscription_to_rosteritems(Acc, LUser, LServer)
     catch
         E:R:S ->
-            ?WARNING_MSG("event=cannot_send_unsubscription_to_rosteritems,"
-                         "class=~p,reason=~p,stacktrace=~p", [E, R, S]),
+            ?LOG_WARNING(#{what => cannot_send_unsubscription_to_rosteritems,
+                           class => E, reason => R, stacktrace => S}),
             Acc
     end.
 

--- a/src/mod_roster_rdbms.erl
+++ b/src/mod_roster_rdbms.erl
@@ -84,9 +84,8 @@ get_roster(LUser, LServer) ->
             RItems;
         _ -> []
     catch Class:Reason:StackTrace ->
-        ?ERROR_MSG("event=get_roster_failed "
-                   "reason=~p:~p user=~ts stacktrace=~1000p",
-                   [Class, Reason, LUser, StackTrace]),
+        ?LOG_ERROR(#{what => get_roster_failed, class => Class, reason => Reason,
+                     stacktrace => StackTrace, user => LUser, host => LServer}),
         []
     end.
 
@@ -163,13 +162,13 @@ get_subscription_lists(_, LUser, LServer) ->
         {selected, Items} when is_list(Items) ->
             Items;
         Other ->
-            ?ERROR_MSG("event=get_subscription_lists_failed "
-                       "reason=~p user=~ts", [Other, LUser]),
+            ?LOG_ERROR(#{what => get_subscription_lists_failed, reason => Other,
+                        user => LUser, host => LServer}),
             []
     catch Class:Reason:StackTrace ->
-        ?ERROR_MSG("event=get_subscription_lists_failed "
-                   "reason=~p:~p user=~ts stacktrace=~1000p",
-                   [Class, Reason, LUser, StackTrace]),
+        ?LOG_ERROR(#{what => get_subscription_lists_failed, class => Class,
+                     reason => Reason, stacktrace => StackTrace,
+                     user => LUser, host => LServer}),
         []
     end.
 
@@ -260,14 +259,15 @@ read_subscription_and_groups(LUser, LServer, LJID, GSFunc, GRFunc) ->
                          {selected, JGrps} when is_list(JGrps) ->
                              [JGrp || {JGrp} <- JGrps];
                          _ ->
-                             ?ERROR_MSG("event=read_subscription_and_groups_failed "
-                                        "user=~ts result=~p", [LUser, GRResult]),
+                             ?LOG_ERROR(#{what => read_subscription_and_groups_failed,
+                                          reason => GRResult, user => LUser,
+                                          host => LServer}),
                              []
                      end,
             {Subscription, Groups};
         E ->
-           ?ERROR_MSG("event=read_subscription_and_groups_failed "
-                      "user=~ts reason=~p", [LUser, E]),
+           ?LOG_ERROR(#{what => read_subscription_and_groups_failed,
+                        reason => E, user => LUser, host => LServer}),
             error
     end.
 

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -51,7 +51,7 @@
 %%
 
 start(Host, Opts) ->
-    ?INFO_MSG("mod_stream_management starting", []),
+    ?LOG_INFO(#{what => mod_stream_management_starting}),
     ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:add(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:add(session_cleanup, Host, ?MODULE, session_cleanup, 50),
@@ -63,7 +63,7 @@ start(Host, Opts) ->
     ok.
 
 stop(Host) ->
-    ?INFO_MSG("mod_stream_management stopping", []),
+    ?LOG_INFO(#{what => mod_stream_management_stopping}),
     ejabberd_hooks:delete(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
     ejabberd_hooks:delete(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
     ejabberd_hooks:delete(session_cleanup, Host, ?MODULE, session_cleanup, 50),

--- a/src/mod_vcard_mnesia.erl
+++ b/src/mod_vcard_mnesia.erl
@@ -41,7 +41,8 @@ get_vcard(LUser, LServer) ->
                             end, Rs),
             {ok, Els};
         {aborted, Reason} ->
-            ?ERROR_MSG("vCard lookup failed in process_sm_iq: ~p", [Reason]),
+            ?LOG_ERROR(#{what => process_sm_iq_vcard_lookup_failed,
+                reason => Reason, user => LUser, host => LServer}),
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
@@ -67,7 +68,7 @@ do_search(VHost, MatchHeadIn) ->
     case catch mnesia:dirty_select(vcard_search,
         [{MatchHead, [], ['$_']}]) of
         {'EXIT', Reason} ->
-            ?ERROR_MSG("~p", [Reason]),
+            ?LOG_ERROR(#{what => vcard_search_failed, reason => Reason}),
             [];
         Rs ->
             case mod_vcard:get_results_limit(VHost) of

--- a/src/mod_vcard_rdbms.erl
+++ b/src/mod_vcard_rdbms.erl
@@ -57,7 +57,9 @@ get_vcard(LUser, LServer) ->
         {selected, [{SVCARD}]} ->
             case exml:parse(SVCARD) of
                 {error, Reason} ->
-                    ?WARNING_MSG("not sending bad vcard xml ~p~n~p", [Reason, SVCARD]),
+                    ?LOG_WARNING(#{what => not_sending_back_bad_vcard_xml,
+                        reason => Reason, svcard => SVCARD,
+                        user => LUser, host => LServer}),
                     {error, mongoose_xmpp_errors:service_unavailable()};
                 {ok, VCARD} ->
                     {ok, [VCARD]}
@@ -121,7 +123,8 @@ do_search(LServer, RestrictionSQL) ->
         {selected, Rs} when is_list(Rs) ->
             Rs;
         Error ->
-            ?ERROR_MSG("~p", [Error]),
+            ?LOG_ERROR(#{what => db_search_error, reason => Error,
+                         host => LServer}),
             []
     end.
 

--- a/src/mod_vcard_riak.erl
+++ b/src/mod_vcard_riak.erl
@@ -58,7 +58,8 @@ get_vcard(LUser, LServer) ->
                 {ok, XMLEl} ->
                     {ok, [XMLEl]};
                 {error, Reason} ->
-                    ?WARNING_MSG("not sending bad vcard reason=~p, xml=~n~p", [Reason, XMLBin]),
+                    ?LOG_WARNING(#{what => vcard_lookup_error, reason => Reason,
+                                   exml_packet => XMLBin}),
                     {error, mongoose_xmpp_errors:service_unavailable()}
             end;
         {error, notfound} ->
@@ -83,8 +84,8 @@ do_search(YZQueryIn, VHost) ->
         {ok, #search_results{docs=R, num_found = _N}} ->
             lists:map(fun({_Index, Props}) -> doc2item(VHost, Props) end, R);
         Err ->
-            ?ERROR_MSG("Error while search vCard, index=~s, query=~s, error=~p",
-                [yz_vcard_index(VHost), YZQueryBin, Err]),
+            ?LOG_ERROR(#{what => vcard_search_error, index => yz_vcard_index(VHost),
+                         'query' => YZQueryBin, reason => Err}),
             []
     end.
 

--- a/src/mongoose_api_admin.erl
+++ b/src/mongoose_api_admin.erl
@@ -54,9 +54,9 @@ cowboy_router_paths(Base, Opts) ->
             Commands = mongoose_commands:list(admin),
             [handler_path(Base, Command, Opts) || Command <- Commands]
         catch
-            _:Err:StackTrace ->
-                ?ERROR_MSG("Error occured when getting the commands list: ~p~n~p",
-                           [Err, StackTrace]),
+            Class:Err:StackTrace ->
+                ?LOG_ERROR(#{what => getting_command_list_error,
+                             class => Class, reason => Err, stacktrace => StackTrace}),
                 []
         end.
 

--- a/src/mongoose_api_client.erl
+++ b/src/mongoose_api_client.erl
@@ -50,8 +50,9 @@ cowboy_router_paths(Base, _Opts) ->
         Commands = mongoose_commands:list(user),
         [handler_path(Base, Command) || Command <- Commands]
     catch
-        _:Err ->
-            ?ERROR_MSG("Error occured when getting the commands list: ~p~n", [Err]),
+        Class:Err:Stacktrace ->
+            ?LOG_ERROR(#{what => getting_command_list_error,
+                         class => Class, reason => Err, stacktrace => Stacktrace}),
             []
     end.
 

--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -180,10 +180,8 @@ parse_request_body(Req) ->
         {Params, Req2}
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("issue=parse_request_body_failed "
-                       "reason=~p:~p "
-                       "stacktrace=~1000p",
-                       [Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => parse_request_body_failed, class => Class,
+                         reason => Reason, stacktrace => StackTrace}),
             {error, Reason}
     end.
 
@@ -199,10 +197,8 @@ check_and_extract_args(ReqArgs, OptArgs, RequestArgList) ->
         maps:from_list(ConvArgs)
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("issue=check_and_extract_args_failed "
-                       "reason=~p:~p "
-                       "stacktrace=~1000p",
-                       [Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => check_and_extract_args_failed, class => Class,
+                         reason => Reason, stacktrace => StackTrace}),
             {error, bad_request, Reason}
     end.
 
@@ -217,10 +213,8 @@ execute_command(ArgMap, Command, Entity) ->
         do_execute_command(ArgMap, Command, Entity)
     catch
         Class:Reason:StackTrace ->
-            ?ERROR_MSG("issue=execute_command_failed "
-                       "reason=~p:~p "
-                       "stacktrace=~1000p",
-                       [Class, Reason, StackTrace]),
+            ?LOG_ERROR(#{what => execute_command_failed, class => Class,
+                         reason => Reason, stacktrace => StackTrace}),
             {error, bad_request, Reason}
     end.
 


### PR DESCRIPTION
I tried to cover the following modules:
```
src/eldap_utils.erl
src/gen_iq_handler.erl
src/gen_mod.erl
src/gen_mod_deps.erl
src/jlib.erl
src/metrics/mongoose_metrics_probe.erl
src/mod_adhoc.erl
src/mod_amp.erl
src/mod_auth_token_rdbms.erl
src/mod_aws_sns.erl
src/mod_cowboy.erl
src/mod_http_notification.erl
src/mod_keystore.erl
src/mod_private.erl
src/mod_push_service_mongoosepush.erl
src/mod_register.erl
src/mod_roster.erl
src/mod_roster_rdbms.erl
src/mod_stream_management.erl
src/mod_vcard.erl
src/mod_vcard_mnesia.erl
src/mod_vcard_rdbms.erl
src/mod_vcard_riak.erl
src/mongoose_api_admin.erl
src/mongoose_api_client.erl
src/mongoose_api_common.erl
```