### PR TITLE
Fix EUnit test in mod_mam_utils.erl (Issue esl#2844)

### DIFF
--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -871,9 +871,9 @@ check_stringprep() ->
     is_loaded_application(jid) orelse start_stringprep().
 
 start_stringprep() ->
-    EJ = code:lib_dir(ejabberd),
+    EJ = code:lib_dir(mongooseim),
     code:add_path(filename:join([EJ, "..", "..", "deps", "jid", "ebin"])),
-    ok = application:start(jid).
+    {ok, _} = application:ensure_all_started(jid).
 
 is_loaded_application(AppName) when is_atom(AppName) ->
     lists:keymember(AppName, 1, application:loaded_applications()).


### PR DESCRIPTION
Fix the `start_stringprep` function in the EUnit test code in `mod_mam_utils.erl` so that `rebar3 eunit` doesn't fail.

No changes outside EUnit test code.

Closes #2844.