### PR TITLE
Change mongooseim_lock_dir specified for big tests so it's not /var/lock

### DIFF
--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -37,5 +37,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -37,5 +37,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
+{mongooseim_lock_dir, "$MIM_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -94,5 +94,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/mim1.vars.config
+++ b/rel/mim1.vars.config
@@ -94,5 +94,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
+{mongooseim_lock_dir, "$MIM_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -64,5 +64,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/mim2.vars.config
+++ b/rel/mim2.vars.config
@@ -64,5 +64,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
+{mongooseim_lock_dir, "$MIM_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -57,5 +57,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/mim3.vars.config
+++ b/rel/mim3.vars.config
@@ -57,5 +57,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
+{mongooseim_lock_dir, "$MIM_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -48,5 +48,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/reg1.vars.config
+++ b/rel/reg1.vars.config
@@ -48,5 +48,5 @@
 {mongooseim_log_dir, "log"}.
 {mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 {mongooseim_mdb_dir_toggle, "%"}.
-{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
+{mongooseim_lock_dir, "$MIM_DIR/var/lock"}.
 {mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -79,5 +79,5 @@
 %{mongooseim_log_dir, "log"}.
 %{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 %{mongooseim_mdb_dir_toggle, "%"}.
-%{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
+%{mongooseim_lock_dir, "$MIM_DIR/var/lock"}.
 %{mongooseim_nodetool_etc_dir, "etc"}.

--- a/rel/vars.config.in
+++ b/rel/vars.config.in
@@ -79,5 +79,5 @@
 %{mongooseim_log_dir, "log"}.
 %{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 %{mongooseim_mdb_dir_toggle, "%"}.
-%{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+%{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 %{mongooseim_nodetool_etc_dir, "etc"}.

--- a/tools/configure
+++ b/tools/configure
@@ -18,7 +18,7 @@
                log_dir          = "log",
                mdb_dir          = "$RUNNER_BASE_DIR/Mnesia.$NODE",
                mdb_dir_toggle   = "%",
-               lock_dir         = "$EJABBERD_DIR/var/lock",
+               lock_dir         = "$RUNNER_BASE_DIR/var/lock",
                pid_dir          = "$RUNNER_BASE_DIR/var",
                status_dir       = "$RUNNER_BASE_DIR/var",
                nodetool_etc_dir = "etc",


### PR DESCRIPTION
Closes #2832

In `mim1.vars.config`, `mim2.vars.config` etc., the `mongooseim_lock_dir` setting is configured as follows:
```
{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
```
But nothing sets `EJABBERD_DIR` during the build process, so the big tests end up writing the lock file in `/var/lock`, which fails if the big tests are running as a user that doesn't have permission to write to that directory.

I've changed it to:
```
{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
```
Please let me know if I've missed something and there is some reason that it should be different, or some process that would set `EJABBERD_DIR` for the build.