### PR TITLE
Added support for all outgoing_pools options

### DIFF
--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -23,7 +23,8 @@ groups() ->
     [{equivalence, [parallel], [sample_pgsql,
                                 miscellaneous,
                                 s2s,
-                                modules]},
+                                modules,
+                                outgoing_pools]},
      {general, [parallel], [loglevel,
                             hosts,
                             registration_timeout,
@@ -91,6 +92,9 @@ s2s(Config) ->
 
 modules(Config) ->
     test_equivalence_between_files(Config,  "modules.cfg",  "modules.toml").
+
+outgoing_pools(Config) ->
+    test_equivalence_between_files(Config,  "outgoing_pools.cfg",  "outgoing_pools.toml").
 
 %% tests: general
 loglevel(_Config) ->

--- a/test/config_parser_SUITE_data/outgoing_pools.cfg
+++ b/test/config_parser_SUITE_data/outgoing_pools.cfg
@@ -1,0 +1,45 @@
+{hosts, ["localhost",
+         "anonymous.localhost",
+         "localhost.bis"
+        ] }.
+
+{outgoing_pools, [
+                  {redis, <<"localhost">>, global_distrib, [{workers, 10}], []},
+                  {rdbms, global, default, [{workers, 5}],
+                   [{server, {pgsql, "localhost", "ejabberd", "ejabberd", "mongooseim_secret",
+                              [{ssl, required}, {ssl_opts, [{verify, verify_peer},
+                                                            {cacertfile, "priv/ssl/cacert.pem"}, {server_name_indication, disable}]}]}},
+                    {keepalive_interval, 30}]},
+                  {http, global, mongoose_push_http,
+                    [{workers, 50}],
+                    [{server, "https://localhost:8443"},
+                    {http_opts, #{
+                                        retry => 1,
+                                        retry_timeout => 1000
+                                    }},
+                    {path_prefix, "/"},
+                    {request_timeout, 2000}
+                    ]},
+                  {riak, global, default, [{workers, 20}, {strategy, next_worker}],
+                        [{address, "127.0.0.1"}, {port, 8087},
+                            {credentials, "username", "pass"},
+                            {cacertfile, "path/to/cacert.pem"}]},
+                  {cassandra, global, default, [],
+                    [
+                    {servers, [{"cassandra_server1.example.com", 9042}, {"cassandra_server2.example.com", 9042}] },
+                    {keyspace, "big_mongooseim"}
+                    ]},
+                   {elastic, global, default, [], [{host, "localhost"}]},
+                   {rabbit, host, event_pusher, [{workers, 20}],
+                        [{amqp_host, "localhost"},
+                        {amqp_port, 5672},
+                        {amqp_username, "guest"},
+                        {amqp_password, "guest"},
+                        {confirms_enabled, true},
+                        {max_worker_queue_len, 100}]},
+                    {ldap, host, default, [{workers, 5}],
+                        [{servers, ["ldap-server.example.com"]},
+                        {rootdn, "cn=admin,dc=example,dc=com"},
+                        {password, "ldap-admin-password"}]
+                        }
+                 ]}.

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -1,0 +1,77 @@
+[general]
+  hosts = [
+    "localhost",
+    "anonymous.localhost",
+    "localhost.bis"
+  ]
+
+[outgoing_pools.redis.global_distrib]
+  scope = "single_host"
+  host = "localhost"
+  workers = 10
+
+[outgoing_pools.rdbms.default]
+  scope = "global"
+  workers = 5
+
+  [outgoing_pools.rdbms.default.connection]
+    driver = "pgsql"
+    host = "localhost"
+    database = "ejabberd"
+    username = "ejabberd"
+    password = "mongooseim_secret"
+    keepalive_interval = 30
+    tls.required = true
+    tls.verify_peer = true
+    tls.cacertfile = "priv/ssl/cacert.pem"
+    tls.server_name_indication = false
+
+[outgoing_pools.http.mongoose_push_http]
+  scope = "global"
+  workers = 50
+
+  [outgoing_pools.http.mongoose_push_http.connection]
+    host = "https://localhost:8443"
+    path_prefix = "/"
+    request_timeout = 2000
+    http_opts.retry = 1
+    http_opts.retry_timeout = 1000
+
+[outgoing_pools.riak.default]
+    scope = "global"
+    workers = 20 
+    strategy = "next_worker"
+    connection.address = "127.0.0.1"
+    connection.port = 8087
+    connection.credentials = {user = "username", password = "pass"}
+    connection.cacertfile = "path/to/cacert.pem"
+
+[outgoing_pools.cassandra.default]
+    scope = "global"
+    connection.servers = [
+        {ip_address = "cassandra_server1.example.com", port = 9042}, 
+        {ip_address = "cassandra_server2.example.com", port =  9042}
+        ]
+    connection.keyspace = "big_mongooseim"
+
+
+[outgoing_pools.elastic.default]
+    scope = "global"
+    connection.host = "localhost"
+
+[outgoing_pools.rabbit.event_pusher]
+    scope = "host"
+    workers = 20
+    connection.amqp_host = "localhost"
+    connection.amqp_port = 5672
+    connection.amqp_username = "guest"
+    connection.amqp_password = "guest"
+    connection.confirms_enabled = true
+    connection.max_worker_queue_len = 100
+
+[outgoing_pools.ldap.default]
+    scope = "host"
+    workers = 5
+    connection.servers = ["ldap-server.example.com"]
+    connection.rootdn = "cn=admin,dc=example,dc=com"
+    connection.password = "ldap-admin-password"


### PR DESCRIPTION
This PR addresses [MIM-1110](https://erlangsolutions.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=MIM&modal=detail&selectedIssue=MIM-1110)

* Added support for new connection types (http, rabbit)
* Added support for missing options for already existing connection types

Note:
There are still pool options that are not parsed. We decided to only add them when needed because most of them are never used anywhere. Full list of these options is [here](https://github.com/inaka/worker_pool#starting-a-pool)

