### PR TITLE
system_time in sid

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1339,11 +1339,12 @@ match_user_status2([User | UserR], Statuses) ->
 
 match_user_info(Users, UsersTxt) ->
     UsersInfo = string:tokens(UsersTxt, "\n"),
-
-    case (length(Users) == length(UsersInfo)) of
-        true -> ok;
-        false ->ct:fail(#{what => match_user_info_failed,
-                          users => Users, user_info => UsersInfo})
+    case length(Users) == length(UsersInfo) of
+        true ->
+            ok;
+        false ->
+            ct:fail(#{what => match_user_info_failed,
+                      users => Users, user_info => UsersInfo})
     end,
     match_user_info2(Users, UsersInfo).
 

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1340,7 +1340,11 @@ match_user_status2([User | UserR], Statuses) ->
 match_user_info(Users, UsersTxt) ->
     UsersInfo = string:tokens(UsersTxt, "\n"),
 
-    true = (length(Users) == length(UsersInfo)),
+    case (length(Users) == length(UsersInfo)) of
+        true -> ok;
+        false ->ct:fail(#{what => match_user_info_failed,
+                          users => Users, user_info => UsersInfo})
+    end,
     match_user_info2(Users, UsersInfo).
 
 match_user_info2([], _) ->

--- a/src/admin_extra/service_admin_extra_sessions.erl
+++ b/src/admin_extra/service_admin_extra_sessions.erl
@@ -50,18 +50,18 @@
 -type u_s_r_p_st() :: { User    :: jid:user(),
                         Server  :: jid:server(),
                         Res     :: jid:resource(),
-                        Prio    :: integer(),
+                        Prio    :: ejabberd_sm:priority(),
                         Status  :: status()}.
 -type formatted_user_info() :: {USR :: string(),
                                 Conn :: string(),
                                 IPS :: string(),
                                 Port :: inet:port_number(),
-                                Prio :: integer(),
+                                Prio :: ejabberd_sm:priority(),
                                 NodeS :: string(),
                                 Uptime :: integer()}.
 -type usr_sid_prio_info() :: {jid:simple_jid(),
-                           {SessionStart :: mongoose_types:microseconds(), Pid :: identifier()},
-                           Prio :: integer(),
+                           ejabberd_sm:sid(),
+                           Prio :: ejabberd_sm:priority(),
                            Info :: string()}.
 
 %%%

--- a/src/admin_extra/service_admin_extra_sessions.erl
+++ b/src/admin_extra/service_admin_extra_sessions.erl
@@ -60,9 +60,9 @@
                                 NodeS :: string(),
                                 Uptime :: integer()}.
 -type usr_sid_prio_info() :: {jid:simple_jid(),
-                           ejabberd_sm:sid(),
-                           Prio :: ejabberd_sm:priority(),
-                           Info :: string()}.
+                              ejabberd_sm:sid(),
+                              Prio :: ejabberd_sm:priority(),
+                              Info :: string()}.
 
 %%%
 %%% Register commands

--- a/src/admin_extra/service_admin_extra_sessions.erl
+++ b/src/admin_extra/service_admin_extra_sessions.erl
@@ -59,8 +59,8 @@
                                 Prio :: integer(),
                                 NodeS :: string(),
                                 Uptime :: integer()}.
--type usr_nowpid_p_i() :: {jid:simple_jid(),
-                           {Now :: erlang:timestamp(), Pid :: identifier()},
+-type usr_sid_prio_info() :: {jid:simple_jid(),
+                           {SessionStart :: mongoose_types:microseconds(), Pid :: identifier()},
                            Prio :: integer(),
                            Info :: string()}.
 
@@ -292,17 +292,11 @@ user_sessions_info(User, Host) ->
         end, [], Resources).
 
 
--spec format_user_info(usr_nowpid_p_i()) -> formatted_user_info().
-format_user_info(Usr) ->
-    format_user_info(Usr, calendar:datetime_to_gregorian_seconds({date(), time()})).
-
-
--spec format_user_info(usr_nowpid_p_i(), CurrentSec :: non_neg_integer()) -> formatted_user_info().
-format_user_info({{U, S, R}, {Now, Pid}, Priority, Info}, CurrentSec) ->
+-spec format_user_info(usr_sid_prio_info()) -> formatted_user_info().
+format_user_info({{U, S, R}, {Microseconds, Pid}, Priority, Info}) ->
     Conn = proplists:get_value(conn, Info),
     {Ip, Port} = proplists:get_value(ip, Info),
     IPS = inet_parse:ntoa(Ip),
     NodeS = atom_to_list(node(Pid)),
-    Uptime = CurrentSec - calendar:datetime_to_gregorian_seconds(
-            calendar:now_to_local_time(Now)),
+    Uptime = (erlang:system_time(microsecond) - Microseconds) div 1000000,
     {[U, $@, S, $/, R], atom_to_list(Conn), IPS, Port, Priority, NodeS, Uptime}.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3381,5 +3381,6 @@ strip_c2s_fields(Acc) ->
     %% TODO: verify if we really need to strip down these 2 fields
     mongoose_acc:delete_many(c2s, [origin_jid, origin_sid], Acc).
 
+-spec make_new_sid() -> ejabberd_sm:sid().
 make_new_sid() ->
     {erlang:system_time(microsecond), self()}.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -780,7 +780,7 @@ do_open_session_common(Acc, JID, #state{user = U, server = S} = NewStateData0) -
     Fs1 = [LJID | Fs],
     Ts1 = [LJID | Ts],
     PrivList = mongoose_hooks:privacy_get_user_list(S, #userlist{}, U),
-    SID = make_new_sid(),
+    SID = ejabberd_sm:make_new_sid(),
     Conn = get_conn_type(NewStateData0),
     Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
             {auth_module, NewStateData0#state.auth_module}],
@@ -2815,7 +2815,7 @@ maybe_enable_stream_mgmt(NextState, El, StateData) ->
 enable_stream_resumption(SD) ->
     SMID = mod_stream_management:make_smid(),
     SID = case SD#state.sid of
-              undefined -> make_new_sid();
+              undefined -> ejabberd_sm:make_new_sid();
               RSID -> RSID
           end,
     ok = mod_stream_management:register_smid(SMID, SID),
@@ -3089,7 +3089,7 @@ maybe_resume_session(NextState, El, StateData) ->
 do_resume_session(SMID, El, {sid, {_, Pid}}, StateData) ->
     try
         {ok, OldState} = p1_fsm_old:sync_send_event(Pid, resume),
-        SID = make_new_sid(),
+        SID = ejabberd_sm:make_new_sid(),
         Conn = get_conn_type(StateData),
         MergedState = merge_state(OldState,
                                   StateData#state{sid = SID, conn = Conn}),
@@ -3380,7 +3380,3 @@ update_stanza(From, To, #xmlel{} = Element, Acc) ->
 strip_c2s_fields(Acc) ->
     %% TODO: verify if we really need to strip down these 2 fields
     mongoose_acc:delete_many(c2s, [origin_jid, origin_sid], Acc).
-
--spec make_new_sid() -> ejabberd_sm:sid().
-make_new_sid() ->
-    {erlang:system_time(microsecond), self()}.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -780,7 +780,7 @@ do_open_session_common(Acc, JID, #state{user = U, server = S} = NewStateData0) -
     Fs1 = [LJID | Fs],
     Ts1 = [LJID | Ts],
     PrivList = mongoose_hooks:privacy_get_user_list(S, #userlist{}, U),
-    SID = {erlang:timestamp(), self()},
+    SID = make_new_sid(),
     Conn = get_conn_type(NewStateData0),
     Info = [{ip, NewStateData0#state.ip}, {conn, Conn},
             {auth_module, NewStateData0#state.auth_module}],
@@ -2815,7 +2815,7 @@ maybe_enable_stream_mgmt(NextState, El, StateData) ->
 enable_stream_resumption(SD) ->
     SMID = mod_stream_management:make_smid(),
     SID = case SD#state.sid of
-              undefined -> {erlang:timestamp(), self()};
+              undefined -> make_new_sid();
               RSID -> RSID
           end,
     ok = mod_stream_management:register_smid(SMID, SID),
@@ -3089,7 +3089,7 @@ maybe_resume_session(NextState, El, StateData) ->
 do_resume_session(SMID, El, {sid, {_, Pid}}, StateData) ->
     try
         {ok, OldState} = p1_fsm_old:sync_send_event(Pid, resume),
-        SID = {erlang:timestamp(), self()},
+        SID = make_new_sid(),
         Conn = get_conn_type(StateData),
         MergedState = merge_state(OldState,
                                   StateData#state{sid = SID, conn = Conn}),
@@ -3380,3 +3380,6 @@ update_stanza(From, To, #xmlel{} = Element, Acc) ->
 strip_c2s_fields(Acc) ->
     %% TODO: verify if we really need to strip down these 2 fields
     mongoose_acc:delete_many(c2s, [origin_jid, origin_sid], Acc).
+
+make_new_sid() ->
+    {erlang:system_time(microsecond), self()}.

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -871,12 +871,12 @@ route_message_by_type(_, From, To, Acc, Packet) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec clean_session_list([sid()]) -> [sid()].
+-spec clean_session_list([session()]) -> [session()].
 clean_session_list(Ss) ->
     clean_session_list(lists:keysort(#session.usr, Ss), []).
 
 
--spec clean_session_list([sid()], [sid()]) -> [sid()].
+-spec clean_session_list([session()], [session()]) -> [session()].
 clean_session_list([], Res) ->
     Res;
 clean_session_list([S], Res) ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -32,6 +32,7 @@
          start_link/0,
          route/3,
          route/4,
+         make_new_sid/0,
          open_session/3, open_session/4,
          close_session/4,
          store_info/2,
@@ -217,6 +218,10 @@ route(From, To, Acc, El) ->
                            acc => Acc}),
               Acc
     end.
+
+-spec make_new_sid() -> ejabberd_sm:sid().
+make_new_sid() ->
+    {erlang:system_time(microsecond), self()}.
 
 -spec open_session(SID, JID, Info) -> ReplacedPids when
       SID :: 'undefined' | sid(),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -118,7 +118,7 @@
 -record(state, {}).
 -type state() :: #state{}.
 
--type sid() :: {mongoose_types:microseconds(), pid()}.
+-type sid() :: {mongoose_lib:microseconds(), pid()}.
 -type priority() :: integer() | undefined.
 
 -type session() :: #session{

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -117,7 +117,7 @@
 -record(state, {}).
 -type state() :: #state{}.
 
--type sid() :: tuple().
+-type sid() :: {mongoose_types:microseconds(), pid()}.
 -type priority() :: integer() | undefined.
 
 -type session() :: #session{

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -142,6 +142,7 @@
 
 -export_type([session/0,
               sid/0,
+              priority/0,
               ses_tuple/0,
               backend/0,
               close_reason/0,

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -17,7 +17,7 @@ init(_InitArgs, _LastEvtId, Req) ->
     maybe_init(Authorization, Req2, State#{id => 1}).
 
 maybe_init(true, Req, #{jid := JID} = State) ->
-    SID = make_new_sid(),
+    SID = ejabberd_sm:make_new_sid(),
     UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
     Resource = <<"sse-", UUID/binary>>,
     NewJid = jid:replace_resource(JID, Resource),
@@ -74,7 +74,3 @@ maybe_send_message_event(<<"groupchat">>, Packet, Timestamp, #{id := ID} = State
     {send, Event, State#{id := ID + 1}};
 maybe_send_message_event(_, _, _, State) ->
     {nosend, State}.
-
--spec make_new_sid() -> ejabberd_sm:sid().
-make_new_sid() ->
-    {erlang:system_time(microsecond), self()}.

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -17,7 +17,7 @@ init(_InitArgs, _LastEvtId, Req) ->
     maybe_init(Authorization, Req2, State#{id => 1}).
 
 maybe_init(true, Req, #{jid := JID} = State) ->
-    SID = {os:timestamp(), self()},
+    SID = make_new_sid(),
     UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
     Resource = <<"sse-", UUID/binary>>,
     NewJid = jid:replace_resource(JID, Resource),
@@ -74,3 +74,7 @@ maybe_send_message_event(<<"groupchat">>, Packet, Timestamp, #{id := ID} = State
     {send, Event, State#{id := ID + 1}};
 maybe_send_message_event(_, _, _, State) ->
     {nosend, State}.
+
+-spec make_new_sid() -> ejabberd_sm:sid().
+make_new_sid() ->
+    {erlang:system_time(microsecond), self()}.

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -13,7 +13,11 @@
 -export([deprecated_logging/1]).
 -deprecated({deprecated_logging, 1, eventually}).
 
+-export_type([microseconds/0]).
+
 -include("mongoose.hrl").
+
+-type microseconds() :: integer().
 
 %% ------------------------------------------------------------------
 %% Logging

--- a/src/mongoose_types.erl
+++ b/src/mongoose_types.erl
@@ -1,4 +1,0 @@
--module(mongoose_types).
--export_type([microseconds/0]).
-
--type microseconds() :: integer().

--- a/src/mongoose_types.erl
+++ b/src/mongoose_types.erl
@@ -1,0 +1,4 @@
+-module(mongoose_types).
+-export_type([microseconds/0]).
+
+-type microseconds() :: integer().

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -3,6 +3,8 @@
 
 setup() ->
     meck:new(ejabberd_sm),
+    meck:expect(ejabberd_sm, make_new_sid,
+                fun() -> {erlang:system_time(microsecond), self()} end),
     meck:expect(ejabberd_sm, close_session,
                 fun(Acc, _SID, _JID, _Reason) -> Acc end),
     meck:expect(ejabberd_sm, open_session, fun(_, _, _) -> [] end),


### PR DESCRIPTION
This PR addresses "I don't want to bring back now_to_microseconds/1".

Proposed changes include:
* Shorter byte size for SIDs.
* We don't really need nanoseconds.
* `ejabberd_sm:sid/0` is now defined!
* `ejabberd_sm:clean_session_list/1` spec fixed.
* `mongoose_types` - new file for cool types.