### PR TITLE
Use ini syntax on github for mongooseim.toml [ci skip]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,7 @@ examples/websockets/jsjac/jsjac.js      binary
 doc/swagger/swagger-ui.min.js           binary
 doc/swagger/lib/*.js                    binary
 doc/open-extensions/prettify.js         binary
+
+# Ask GitHub to format template as INI file
+# Github's TOML syntax highlighter does not like the template variables
+rel/files/mongooseim.toml linguist-language=INI


### PR DESCRIPTION
This PR addresses just addition to https://github.com/esl/MongooseIM/pull/2801/files
Github displays config file as whole red.


Before: https://github.com/esl/MongooseIM/pull/2801/files#diff-25da832ca9aacd1087d38f615c464abb
After: https://github.com/arcusfelis/MongooseIM/pull/77/files#diff-25da832ca9aacd1087d38f615c464abb

Whole file before: https://github.com/esl/MongooseIM/blob/214f9821e2820acc20fb0ba513a0b220b320a6e2/rel/files/mongooseim.toml
Whole file after: https://github.com/esl/MongooseIM/blob/fix-syntax-formatter/rel/files/mongooseim.toml

Still a bit ugly formatting arrays on github, but yeah...