### PR TITLE
Upload to minio at 127.0.0.1 not localhost to avoid IPv6 / DNS issues (#2838)

### DIFF
--- a/big_tests/tests/mod_http_upload_SUITE.erl
+++ b/big_tests/tests/mod_http_upload_SUITE.erl
@@ -14,7 +14,7 @@
 -define(S3_HOSTNAME, "http://bucket.s3-eu-east-25.example.com").
 -define(S3_OPTS, ?MOD_HTTP_UPLOAD_OPTS(?S3_HOSTNAME, true)).
 
--define(MINIO_HOSTNAME, "http://localhost:9000/mybucket/").
+-define(MINIO_HOSTNAME, "http://127.0.0.1:9000/mybucket/").
 -define(MINIO_OPTS(AddAcl), ?MOD_HTTP_UPLOAD_OPTS(?MINIO_HOSTNAME, AddAcl)).
 
 -define(MINIO_TEST_DATA, "qwerty").


### PR DESCRIPTION
Closes #2838

Issue [162](https://github.com/cmullaparthi/ibrowse/issues/162) affecting ibrowse 4.4.1 means that it always resolves `localhost` to the IPv6 address `::1` rather than the IPv4 address `127.0.0.1` (because calls `inet:gethostbyname(Host, inet6)` explicitly).  This causes failures of the big test mod_http_upload_SUITE on IPv4-only systems such as docker with the default settings.

This change bypasses DNS and uploads to minio at `127.0.0.1` explicitly.  Only the big test code is affected.
