### PR TITLE
Remove redundant loglevel setting

### DIFF
--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -54,7 +54,6 @@ start(normal, _Args) ->
     mongoose_service:start(),
     gen_mod:start(),
     ejabberd_config:start(),
-    mongoose_logs:set_global_loglevel(ejabberd_config:get_local_option_or_default(loglevel, warning)),
     connect_nodes(),
     mongoose_deprecations:start(),
     {ok, _} = Sup = ejabberd_sup:start_link(),


### PR DESCRIPTION
It is really redundant as the correct key in config for OTP's logger's logging level is `logger_level` and not `loglevel`. 
This line was effectively discarding config and always setting the loglevel to `warning`.
The default loglevel for OTP's logger is `notice` and it will be set even if no such key exists in the config.