### PR TITLE
Reject publish to non-existent pubsub node with nodeid-required

### DIFF
--- a/big_tests/tests/pubsub_s2s_SUITE.erl
+++ b/big_tests/tests/pubsub_s2s_SUITE.erl
@@ -109,7 +109,7 @@ publish_test(Config) ->
               Node = pubsub_tools:pubsub_node(),
               pubsub_tools:create_node(Alice, Node, []),
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
-              pubsub_tools:publish(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),
+              pubsub_tools:publish(Alice2, <<"item2">>, Node, [{expected_error_type, <<"auth">>}]),
               pubsub_tools:delete_node(Alice, Node, [])
       end).
 
@@ -121,7 +121,7 @@ publish_without_node_attr_test(Config) ->
               Node = pubsub_tools:pubsub_node(),
               pubsub_tools:create_node(Alice, Node, []),
               pubsub_tools:publish(Alice, <<"item1">>, Node, []),
-              pubsub_tools:publish_without_node_attr(Alice2, <<"item2">>, Node, [{expected_error_type, <<"cancel">>}]),
+              pubsub_tools:publish_without_node_attr(Alice2, <<"item2">>, Node, [{expected_error_type, <<"modify">>}]),
               pubsub_tools:delete_node(Alice, Node, [])
       end).
 

--- a/rel/fed1.vars.config
+++ b/rel/fed1.vars.config
@@ -14,7 +14,7 @@
 {hosts, "[ \"fed1\" ]"}.
 {sm_backend, "{mnesia, []}"}.
 {auth_method, "internal"}.
-{s2s_addr, "{ {s2s_addr, \"localhost\"}, {127,0,0,1} }. { {s2s_addr, \"localhost.bis\"}, {127,0,0,1} }."}.
+{s2s_addr, "{ {s2s_addr, \"localhost\"}, {127,0,0,1} }. { {s2s_addr, \"pubsub.localhost\"}, {127,0,0,1} }. { {s2s_addr, \"muc.localhost\"}, {127,0,0,1} }. { {s2s_addr, \"localhost.bis\"}, {127,0,0,1} }."}.
 {s2s_default_policy, allow}.
 {highload_vm_args, ""}.
 {ejabberd_service, ""}.

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1389,6 +1389,8 @@ iq_pubsub_set_create(Host, Node, From,
             create_node(Host, ServerHost, Node, From, Type, Access, Config)
     end.
 
+iq_pubsub_set_publish(_Host, <<>>, _From, _ExtraArgs) ->
+    {error, extended_error(mongoose_xmpp_errors:bad_request(), <<"nodeid-required">>)};
 iq_pubsub_set_publish(Host, Node, From, #{server_host := ServerHost, access := Access,
                                           action_el := ActionEl, query_el := QueryEl}) ->
     case xml:remove_cdata(ActionEl#xmlel.children) of


### PR DESCRIPTION
Closes #2779 

Change the response to a publish stanza that lacks a `node` attribute.  Currently, a node with a random name will be auto-created.  But [XEP-0060](https://xmpp.org/extensions/xep-0060.html#publisher-publish-request) states:
> The element MUST possess a 'node' attribute, specifying the NodeID of the node.

XEP-0060 is not clear on what error should be returned if the node attribute is missing, so I've implemented the same response that it specifies for [retract](https://xmpp.org/extensions/xep-0060.html#publisher-delete-error-nodeid) and [configure](https://xmpp.org/extensions/xep-0060.html#owner-configure-error-nodeid) stanzas that lack NodeIDs:
```
  <error type='modify'>
    <bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
    <nodeid-required xmlns='http://jabber.org/protocol/pubsub#errors'/>
  </error>
```
The unit tests in pubsub_s2s_SUITE need corresponding changes.  Currently in the public test results for [publish_test](http://mongooseim-ct-results.s3-eu-west-1.amazonaws.com/branch/master/8347/riak_mnesia.22.0/big/ct_run.test@travis-job-69d20e69-77a8-4c80-bfc9-f01354d0aaf7.2020-06-24_07.07.36/big_tests.tests.pubsub_s2s_SUITE.logs/run.2020-06-24_07.19.12/pubsub_s2s_suite.publish_test.7971.html) and the [publish_without_node_test](http://mongooseim-ct-results.s3-eu-west-1.amazonaws.com/branch/master/8347/riak_mnesia.22.0/big/ct_run.test@travis-job-69d20e69-77a8-4c80-bfc9-f01354d0aaf7.2020-06-24_07.07.36/big_tests.tests.pubsub_s2s_SUITE.logs/run.2020-06-24_07.19.12/pubsub_s2s_suite.publish_without_node_attr_test.9266.html), the server is responding with a remote-server-not-found response:
```
	<error code='404' type='cancel'>
		<remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
	</error>
```
In my local testing, I was getting that result intermittently.  The cause seems to be DNS resolution of the host `pubsub.localhost`.  I've configured the big_test fed1 instance to bypass DNS for `pubsub.localhost` (it was already configured to bypass DNS for `localhost`, but that configuration did not affect subdomains).  While making this change, I also configured it to bypass DNS for subdomain `muc.localhost` as well, because I saw intermittent failures of `muc_SUITE:register_over_s2s` for DNS-related reasons; while this doesn't seem to be a problem in the public test results, it seems like a good change anyway.

Once the DNS was bypassed, I get the following responses in the big tests:

`pubsub_s2s_SUITE:publish_test`
```
	<error code='403' type='auth'>
		<forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
	</error>
```

`pubsub_s2s_SUITE:publish_without_node_attr_test`
```
	<error code='400' type='modify'>
		<bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
		<nodeid-required xmlns='http://jabber.org/protocol/pubsub#errors'/>
	</error>
```

These responses seem correct (certainly more correct than `remote-server-not-found`) so I have updated the big test expectations to match.