### PR TITLE
rest endpoint for sending stanzas

### DIFF
--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -278,7 +278,7 @@ paths:
                 type: string
                 required: true
                 example: "<message from=\"alice@wonderlant.lit\" to=\"bob@wonderlant.lit\"><body>whatever</body></message>"
-      description: Send an arbitrary stanza (attributes from and two are required).
+      description: Send an arbitrary stanza (attributes `from` and `to` are required).
       responses:
         204:
           description: Stanza was sent

--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -260,6 +260,28 @@ paths:
           description: The messages archived for the given user and the other party.
           schema:
             $ref: '#/definitions/messageList'
+  /stanzas:
+    post:
+      tags:
+        - "One-to-one messages"
+      parameters:
+        - name: message
+          in: body
+          description: The chat stanza
+          required: true
+          schema:
+            title: message
+            type: object
+            properties:
+              stanza:
+                description: the complete stanza
+                type: string
+                required: true
+                example: "<message from=\"alice@wonderlant.lit\" to=\"bob@wonderlant.lit\"><body>whatever</body></message>"
+      description: Send an arbitrary stanza (attributes from and two are required).
+      responses:
+        204:
+          description: Stanza was sent
   /contacts/{user}:
     get:
       description: "Returns all contacts from the user's roster"

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -194,7 +194,6 @@ commands() ->
       {module, ?MODULE},
       {function, send_stanza},
       {action, create},
-      {security_policy, [user]},
       {args, [{stanza, binary}]},
       {result, ok}
      ],

--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -163,6 +163,8 @@ handle_result(<<"PUT">>, {ok, Res}, Req, State) ->
     {stop, Req3, State};
 handle_result(_, {error, Error, Reason}, Req, State) when is_binary(Reason) ->
     error_response(Error, Reason, Req, State);
+handle_result(_, {error, Error, Reason}, Req, State) when is_list(Reason) ->
+    error_response(Error, list_to_binary(Reason), Req, State);
 handle_result(_, {error, Error, _R}, Req, State) ->
     error_response(Error, Req, State);
 % handle_result(_, {error, Error}, Req, State) ->


### PR DESCRIPTION
This PR addresses a need for more advanced integrations - current messaging endpoint requires a client to submit a message body and nothing else, while some clients want to use some extensions and want to define the whole contents of a message, or send some other arbitrary stanzas.

Proposed changes include:
* a rest endpoint for admin user which accepts any stanza, provided it has from and to attributes
* updated rest suite
* updated swagger docs

