### PR TITLE
eunit execution in CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ orbs:
           - run:
               name: Run Small Tests
               command: |
-                SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p small_tests -s true
+                SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/travis-test.sh -p small_tests -s true -e true
           - run:
               name: Coverage
               when: on_success

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ compile_commands.json
 Mnesia.mongooseim@*
 compile.log
 ct.log
+eunit.log
 deps.log
 dialyzer
 configure.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
         - if [ $PRESET = 'ldap_mnesia' ]; then sudo tools/travis-setup-ldap.sh; fi
         - if [ $PRESET = 'mysql_redis' ]; then sudo tools/travis-setup-rmq.sh; fi
 script:
-    - SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET -s $RUN_SMALL_TESTS
+    - SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 tools/travis-test.sh -p $PRESET -s $RUN_SMALL_TESTS -e $RUN_SMALL_TESTS
 
 after_failure:
         - if [ -s _build/mim1/rel/mongooseim/log/crash.log ]; then cat _build/mim1/rel/mongooseim/log/crash.log; fi

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ ct:
 		then $(RUN) $(REBAR) ct --dir test --suite $(SUITE) ; \
 		else $(RUN) $(REBAR) ct $(REBAR_CT_EXTRA_ARGS); fi)
 
+eunit:
+	@$(RUN) $(REBAR) eunit
+
 rel: certs configure.out rel/vars.config
 	. ./configure.out && $(REBAR) as prod release
 

--- a/tools/print-dots.sh
+++ b/tools/print-dots.sh
@@ -34,7 +34,13 @@ start_countdown)
     echo $! > $PIDFILE
     ;;
 stop)
-    [ -s $PIDFILE ] && (kill $(cat $PIDFILE) 2>/dev/null; rm $PIDFILE)
+    if [ -s $PIDFILE ]; then
+        PID="$(cat $PIDFILE)"
+        rm $PIDFILE
+        kill "$PID" 2>/dev/null
+        wait "$PID" 2>/dev/null
+        echo #just an line break after printed dots
+    fi
     ;;
 loop)
     loop

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -2,6 +2,7 @@
 #
 # Env variables:
 # - SMALL_TESTS
+# - EUNIT_TESTS
 # - COVER_ENABLED
 # - STOP_NODES (default false)
 set -o pipefail
@@ -10,9 +11,10 @@ IFS=$'\n\t'
 DEFAULT_PRESET=internal_mnesia
 PRESET="${PRESET-$DEFAULT_PRESET}"
 SMALL_TESTS="${SMALL_TESTS:-true}"
+EUNIT_TESTS="${EUNIT_TESTS:-false}"
 COVER_ENABLED="${COVER_ENABLED:-true}"
 
-while getopts ":p::s::e::c:" opt; do
+while getopts ":p:s:e:c:" opt; do
   case $opt in
     p)
       PRESET=$OPTARG
@@ -22,6 +24,9 @@ while getopts ":p::s::e::c:" opt; do
       ;;
     c)
       COVER_ENABLED=$OPTARG
+      ;;
+    e)
+      EUNIT_TESTS=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -82,19 +87,39 @@ run_small_tests() {
   ${TOOLS}/summarise-ct-results ${SMALL_SUMMARIES_DIR}
 }
 
+run_eunit_tests() {
+  tools/print-dots.sh start
+  tools/print-dots.sh monitor $$
+  make eunit
+  RESULT="$?"
+  tools/print-dots.sh stop
+  ## print execution results w/o compilation log
+  sed -n '/===> Performing EUnit tests.../,$p' "${BASE}/eunit.log"
+  return "$RESULT"
+}
+
 maybe_run_small_tests() {
   if [ "$SMALL_TESTS" = "true" ]; then
     echo "############################"
     echo "Running small tests (test/)"
     echo "############################"
-    echo "Advice: "
-    echo "    Add option \"-s false\" to skip embeded common tests"
-    echo "Example: "
-    echo "    ./tools/travis-test.sh -s false"
     run_small_tests
   else
     echo "############################"
     echo "Small tests skipped"
+    echo "############################"
+  fi
+}
+
+maybe_run_eunit_tests() {
+  if [ "$EUNIT_TESTS" = "true" ]; then
+    echo "############################"
+    echo "Running eunit tests"
+    echo "############################"
+    run_eunit_tests
+  else
+    echo "############################"
+    echo "Eunit tests skipped"
     echo "############################"
   fi
 }
@@ -143,6 +168,10 @@ run_tests() {
   SMALL_STATUS=$?
   echo "SMALL_STATUS=$SMALL_STATUS"
   echo ""
+  maybe_run_eunit_tests
+  EUNIT_STATUS=$?
+  echo "EUNIT_STATUS=$EUNIT_STATUS"
+  echo ""
   echo "############################"
   echo "Running big tests (big_tests)"
   echo "############################"
@@ -170,14 +199,15 @@ run_tests() {
   test $? -eq 1
   LOG_STATUS=$?
 
-  if [ $SMALL_STATUS -eq 0 -a $BIG_STATUS -eq 0 -a $BIG_STATUS_BY_SUMMARY -eq 0 -a $LOG_STATUS -eq 0 ]
-  then
+  if [ $SMALL_STATUS -eq 0 ] && [ $EUNIT_STATUS -eq 0 ] && [ $BIG_STATUS -eq 0 ] &&
+     [ $BIG_STATUS_BY_SUMMARY -eq 0 ] && [ $LOG_STATUS -eq 0 ]; then
     RESULT=0
     echo "Build succeeded"
   else
     RESULT=1
     echo "Build failed:"
     [ $SMALL_STATUS -ne 0 ] && echo "    small tests failed"
+    [ $EUNIT_STATUS -ne 0 ] && echo "    eunit tests failed"
     [ $BIG_STATUS_BY_SUMMARY -ne 0 ]   && echo "    big tests failed"
     [ $BIG_STATUS -ne 0 ]   && echo "    big tests failed - missing suites (error code: $BIG_STATUS)"
     [ $LOG_STATUS -ne 0 ]   && echo "    log contains errors"
@@ -256,9 +286,13 @@ if [ "$PRESET" == "dialyzer_only" ]; then
 elif [ "$PRESET" == "pkg" ]; then
   build_pkg $pkg_PLATFORM $ESL_ERLANG_PKG_VER
 elif [ "$PRESET" == "small_tests" ]; then
-  time run_small_tests
-  RESULT=$?
-  exit ${RESULT}
+  time maybe_run_eunit_tests
+  EUNIT_RESULT=$?
+  time maybe_run_small_tests
+  SMALL_RESULT=$?
+  if [ "$SMALL_RESULT" -ne 0 ] || [ "$EUNIT_RESULT" -ne 0 ]; then
+    exit 1
+  fi
 else
   [ x"$TLS_DIST" == xtrue ] && enable_tls_dist
   run_tests

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -286,10 +286,10 @@ if [ "$PRESET" == "dialyzer_only" ]; then
 elif [ "$PRESET" == "pkg" ]; then
   build_pkg $pkg_PLATFORM $ESL_ERLANG_PKG_VER
 elif [ "$PRESET" == "small_tests" ]; then
-  time maybe_run_eunit_tests
-  EUNIT_RESULT=$?
   time maybe_run_small_tests
   SMALL_RESULT=$?
+  time maybe_run_eunit_tests
+  EUNIT_RESULT=$?
   if [ "$SMALL_RESULT" -ne 0 ] || [ "$EUNIT_RESULT" -ne 0 ]; then
     exit 1
   fi


### PR DESCRIPTION
This PR is done in a context of this issue https://github.com/esl/MongooseIM/issues/2844

There is no integration of eunit execution into `test-runner.sh` script (no dedicated options to control it).  to run eunit tests you can use `make eunit` or `./rebar3 eunit` command

However, `test-runner.sh` can be used for quick manual testing of the changes in `travis-test.sh`. For that you have set  `EUNIT_TESTS` env variable. 
```
EUNIT_TESTS=true test-runner.sh --skip-big-tests --skip-small-tests --skip-build-mim --skip-build-tests
```

eunit tests are triggered for `small_tests` CI jobs on Travis and CircrleCI. the summary of execution is printed in the console.

the full log is uploaded to AWS in the `logs` directory (e.g. see `eunit.log` file [here](http://esl.github.io/mongooseim-ct-reports/s3_reports.html?prefix=PR/2860/8528/small_tests.23.0.3/logs/2020-09-04_18.07.34/)). no changes were required for log uploading, it's done automatically for all `*.log` files in the git repo root directory (see `travis-prepare-log-dir.sh` & `circleci-prepare-log-dir.sh` and scripts).