### PR TITLE
Validate the 'shaper', 'acl' and 'access' sections

### DIFF
--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -222,6 +222,11 @@ validate([<<"port">>, {connection, _}, _Tag, _Type, <<"outgoing_pools">>],
          [{port, Value}]) ->
     validate_port(Value);
 
+%% shaper
+validate([_, <<"shaper">>],
+         [#config{value = {maxrate, Value}}]) ->
+    validate_positive_integer(Value);
+
 validate(_, _) ->
     ok.
 


### PR DESCRIPTION
Parse the 'acl' section in a more structured way,
matching exact rules from the 'acl' module.

