### PR TITLE
TOML: test and validate s2s options

### DIFF
--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -313,7 +313,7 @@
   {{{s2s_use_starttls}}}
   {{{s2s_certfile}}}
   default_policy = {{{s2s_default_policy}}}
-  outgoing_port = {{{outgoing_s2s_port}}}
+  outgoing.port = {{{outgoing_s2s_port}}}
 
   {{{s2s_addr}}}
 

--- a/src/config/mongoose_config_parser_cfg.erl
+++ b/src/config/mongoose_config_parser_cfg.erl
@@ -247,7 +247,8 @@ process_term(Term, State) ->
         {outgoing_s2s_port, Port} ->
             add_option(outgoing_s2s_port, Port, State);
         {outgoing_s2s_options, Methods, Timeout} ->
-            add_option(outgoing_s2s_options, {Methods, Timeout}, State);
+            State1 = add_option(outgoing_s2s_families, Methods, State),
+            add_option(outgoing_s2s_timeout, Timeout, State1);
         {{s2s_addr, Host}, Addr} ->
             add_option({s2s_addr, list_to_binary(Host)}, Addr, State);
         {{global_distrib_addr, Host}, Addr} ->

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -227,6 +227,51 @@ validate([_, <<"shaper">>],
          [#config{value = {maxrate, Value}}]) ->
     validate_positive_integer(Value);
 
+%% s2s
+validate([<<"timeout">>, <<"dns">>, <<"s2s">>],
+         [{timeout, Value}]) ->
+    validate_positive_integer(Value);
+validate([<<"retries">>, <<"dns">>, <<"s2s">>],
+         [{retries, Value}]) ->
+    validate_positive_integer(Value);
+validate([<<"port">>, <<"outgoing">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_port(Value);
+validate([<<"ip_versions">>, <<"outgoing">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_non_empty_list(Value);
+validate([<<"connection_timeout">>, <<"outgoing">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_timeout(Value);
+validate([<<"use_starttls">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_enum(Value, [false, optional, required, required_trusted]);
+validate([<<"certfile">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_non_empty_string(Value);
+validate([<<"default_policy">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_enum(Value, [allow, deny]);
+validate([<<"host">>, item, <<"address">>, <<"s2s">>],
+         [{host, Value}]) ->
+    validate_non_empty_binary(Value);
+validate([<<"ip_address">>, item, <<"address">>, <<"s2s">>],
+         [{ip_address, Value}]) ->
+    validate_ip_address(Value);
+validate([<<"port">>, item, <<"address">>, <<"s2s">>],
+         [{port, Value}]) ->
+    validate_port(Value);
+validate([item, <<"domain_certfile">>, <<"s2s">>],
+         [#local_config{key = {domain_certfile, Domain}, value = Certfile}]) ->
+    validate_non_empty_string(Domain),
+    validate_non_empty_string(Certfile);
+validate([<<"shared">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_non_empty_binary(Value);
+validate([<<"max_retry_delay">>, <<"s2s">>],
+         [#local_config{value = Value}]) ->
+    validate_positive_integer(Value);
+
 validate(_, _) ->
     ok.
 
@@ -261,6 +306,9 @@ validate_non_negative_integer_or_infinity(infinity) -> ok.
 
 validate_enum(Value, Values) ->
     true = lists:member(Value, Values).
+
+validate_ip_address(Value) ->
+    {ok, _} = inet:parse_address(Value).
 
 validate_port(Value) when is_integer(Value), Value >= 0, Value =< 65535 -> ok.
 

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -1078,8 +1078,8 @@ outgoing_s2s_port() ->
 
 -spec outgoing_s2s_families() -> ['ipv4' | 'ipv6', ...].
 outgoing_s2s_families() ->
-    case ejabberd_config:get_local_option(outgoing_s2s_options) of
-        {Families, _} when is_list(Families) ->
+    case ejabberd_config:get_local_option(outgoing_s2s_families) of
+        Families when is_list(Families) ->
             Families;
         undefined ->
             %% DISCUSSION: Why prefer IPv4 first?
@@ -1099,10 +1099,10 @@ outgoing_s2s_families() ->
 
 -spec outgoing_s2s_timeout() -> non_neg_integer() | infinity.
 outgoing_s2s_timeout() ->
-    case ejabberd_config:get_local_option(outgoing_s2s_options) of
-        {_, Timeout} when is_integer(Timeout) ->
+    case ejabberd_config:get_local_option(outgoing_s2s_timeout) of
+        Timeout when is_integer(Timeout) ->
             Timeout;
-        {_, infinity} ->
+        infinity ->
             infinity;
         undefined ->
             %% 10 seconds

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -889,6 +889,8 @@ compare_values({auth_method, _}, V1, V2) when is_atom(V1) ->
     ?eq([V1], V2);
 compare_values({s2s_addr, _}, {_, _, _, _} = IP1, IP2) ->
     ?eq(inet:ntoa(IP1), IP2);
+compare_values(s2s_dns_options, V1, V2) ->
+    compare_unordered_lists(V1, V2);
 compare_values(services, V1, V2) ->
     MetricsOpts1 = proplists:get_value(service_mongoose_system_metrics, V1),
     MetricsOpts2 = proplists:get_value(service_mongoose_system_metrics, V2),

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -20,7 +20,8 @@ all() ->
      {group, listen},
      {group, auth},
      {group, pool},
-     {group, shaper_acl_access}].
+     {group, shaper_acl_access},
+     {group, s2s}].
 
 groups() ->
     [{equivalence, [parallel], [sample_pgsql,
@@ -104,7 +105,20 @@ groups() ->
                          pool_rdbms_tls]},
      {shaper_acl_access, [parallel], [shaper,
                                       acl,
-                                      access]}
+                                      access]},
+     {s2s, [parallel], [s2s_dns_timeout,
+                        s2s_dns_retries,
+                        s2s_outgoing_port,
+                        s2s_outgoing_ip_versions,
+                        s2s_outgoing_timeout,
+                        s2s_use_starttls,
+                        s2s_certfile,
+                        s2s_default_policy,
+                        s2s_address,
+                        s2s_ciphers,
+                        s2s_domain_certfile,
+                        s2s_shared,
+                        s2s_max_retry_delay]}
     ].
 
 init_per_suite(Config) ->
@@ -819,7 +833,91 @@ access(_Config) ->
     ?err(parse(#{<<"access">> => #{<<"max_user_sessions">> => [#{<<"acl">> => 10,
                                                                  <<"value">> => 10}]}})).
 
-%% helpers for 'listen' tests
+%% tests: s2s
+
+s2s_dns_timeout(_Config) ->
+    ?eq([#local_config{key = s2s_dns_options, value = [{timeout, 5}]}],
+        parse(#{<<"s2s">> => #{<<"dns">> => #{<<"timeout">> => 5}}})),
+    ?err(parse(#{<<"s2s">> => #{<<"dns">> => #{<<"timeout">> => 0}}})).
+
+s2s_dns_retries(_Config) ->
+    ?eq([#local_config{key = s2s_dns_options, value = [{retries, 1}]}],
+        parse(#{<<"s2s">> => #{<<"dns">> => #{<<"retries">> => 1}}})),
+    ?err(parse(#{<<"s2s">> => #{<<"dns">> => #{<<"retries">> => 0}}})).
+
+s2s_outgoing_port(_Config) ->
+    ?eq([#local_config{key = outgoing_s2s_port, value = 5270}],
+        parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"port">> => 5270}}})),
+    ?err(parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"port">> => <<"http">>}}})).
+
+s2s_outgoing_ip_versions(_Config) ->
+    ?eq([#local_config{key = outgoing_s2s_families, value = [ipv6, ipv4]}],
+        parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"ip_versions">> => [6, 4]}}})),
+    ?err(parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"ip_versions">> => []}}})),
+    ?err(parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"ip_versions">> => [<<"http">>]}}})).
+
+s2s_outgoing_timeout(_Config) ->
+    ?eq([#local_config{key = outgoing_s2s_timeout, value = 5}],
+        parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"connection_timeout">> => 5}}})),
+    ?eq([#local_config{key = outgoing_s2s_timeout, value = infinity}],
+        parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"connection_timeout">> => <<"infinity">>}}})),
+    ?err(parse(#{<<"s2s">> => #{<<"outgoing">> => #{<<"connection_timeout">> => 0}}})).
+
+s2s_use_starttls(_Config) ->
+    ?eq([#local_config{key = s2s_use_starttls, value = required}],
+        parse(#{<<"s2s">> => #{<<"use_starttls">> => <<"required">>}})),
+    ?err(parse(#{<<"s2s">> => #{<<"use_starttls">> => <<"unnecessary">>}})).
+
+s2s_certfile(_Config) ->
+    ?eq([#local_config{key = s2s_certfile, value = "cert.pem"}],
+        parse(#{<<"s2s">> => #{<<"certfile">> => <<"cert.pem">>}})),
+    ?err(parse(#{<<"s2s">> => #{<<"certfile">> => []}})).
+
+s2s_default_policy(_Config) ->
+    [F] = parse(#{<<"s2s">> => #{<<"default_policy">> => <<"deny">>}}),
+    ?eq([#local_config{key = {s2s_default_policy, ?HOST}, value = deny}], F(?HOST)),
+    ?err(parse(#{<<"s2s">> => #{<<"default_policy">> => <<"ask">>}})).
+
+s2s_address(_Config) ->
+    Addr = #{<<"host">> => <<"host1">>,
+             <<"ip_address">> => <<"192.168.1.2">>,
+             <<"port">> => 5321},
+    ?eq([#local_config{key = {s2s_addr, <<"host1">>}, value = {"192.168.1.2", 5321}}],
+        parse(#{<<"s2s">> => #{<<"address">> => [Addr]}})),
+    ?eq([#local_config{key = {s2s_addr, <<"host1">>}, value = "192.168.1.2"}],
+        parse(#{<<"s2s">> => #{<<"address">> => [maps:without([<<"port">>], Addr)]}})),
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [maps:without([<<"host">>], Addr)]}})),
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [maps:without([<<"ip_address">>], Addr)]}})),
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"host">> => <<>>}]}})),
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"ip_address">> => <<"host2">>}]}})),
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"port">> => <<"seaport">>}]}})).
+
+s2s_ciphers(_Config) ->
+    ?eq([#local_config{key = s2s_ciphers, value = "TLSv1.2:TLSv1.3"}],
+        parse(#{<<"s2s">> => #{<<"ciphers">> => <<"TLSv1.2:TLSv1.3">>}})),
+    ?err(parse(#{<<"s2s">> => #{<<"ciphers">> => [<<"cipher1">>, <<"cipher2">>]}})).
+
+s2s_domain_certfile(_Config) ->
+    DomCert = #{<<"domain">> => <<"myxmpp.com">>,
+                <<"certfile">> => <<"mycert.pem">>},
+    ?eq([#local_config{key = {domain_certfile, "myxmpp.com"}, value = "mycert.pem"}],
+        parse(#{<<"s2s">> => #{<<"domain_certfile">> => [DomCert]}})),
+    [?err(parse(#{<<"s2s">> => #{<<"domain_certfile">> => [maps:without([K], DomCert)]}}))
+     || K <- maps:keys(DomCert)],
+    [?err(parse(#{<<"s2s">> => #{<<"domain_certfile">> => [DomCert#{K := <<>>}]}}))
+     || K <- maps:keys(DomCert)].
+
+s2s_shared(_Config) ->
+    [F] = parse(#{<<"s2s">> => #{<<"shared">> => <<"secret">>}}),
+    ?eq([#local_config{key = {s2s_shared, ?HOST}, value = <<"secret">>}], F(?HOST)),
+    ?err(parse(#{<<"s2s">> => #{<<"shared">> => 536837}})).
+
+s2s_max_retry_delay(_Config) ->
+    [F] = parse(#{<<"s2s">> => #{<<"max_retry_delay">> => 120}}),
+    ?eq([#local_config{key = {s2s_max_retry_delay, ?HOST}, value = 120}], F(?HOST)),
+    ?err(parse(#{<<"s2s">> => #{<<"max_retry_delay">> => 0}})).
+
+%% Helpers for 'listen' tests
 
 listener_config(Mod, Opts) ->
     [#local_config{key = listen,

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -358,7 +358,7 @@
   use_starttls = "optional"
   certfile = "tools/ssl/mongooseim/server.pem"
   default_policy = "allow"
-  outgoing_port = 5299
+  outgoing.port = 5299
 
   [[s2s.address]]
     host = "fed1"

--- a/test/config_parser_SUITE_data/s2s_only.toml
+++ b/test/config_parser_SUITE_data/s2s_only.toml
@@ -7,13 +7,13 @@
   use_starttls = "optional"
   certfile = "tools/ssl/mongooseim/server.pem"
   default_policy = "allow"
-  outgoing_port = 5299
   ciphers = "TLSv1.2:TLSv1.3"
-  connection_timeout = 10000
-  preferred_ip_version = 4
+  outgoing.port = 5299
+  outgoing.connection_timeout = 10000
+  outgoing.ip_versions = [4, 6]
+  dns.timeout = 30
+  dns.retries = 1
   shared = "shared secret"
-  dns_timeout = 30
-  dns_retries = 1
   max_retry_delay = 30
 
   [[s2s.address]]
@@ -23,7 +23,7 @@
   [[s2s.domain_certfile]]
     domain = "example.com"
     certfile = "/path/to/example_com.pem"
-  
+
   [[s2s.domain_certfile]]
     domain = "example.org"
     certfile = "/path/to/example_org.pem"


### PR DESCRIPTION
Validate and test the `s2s` options.

Some fixes and improvements to this section:
- Make subsections out of the `dns` and `outgoing` option groups
- Clean up the parsing logic, use the `handler` where possible
- Decouple the internal representation of the IP versions (address families) and the connection timeout to improve code structure.

See the individual commits for more details.

Note: the `domain_certfiles` options should be moved out of the s2s section, preferably to `host_config`, as it also affects c2s listeners. This is not urgent, but it would be good to create a story for it.