### PR TITLE
Fix formatter crashes due to format strings

### DIFF
--- a/src/logger/mongoose_log_filter.erl
+++ b/src/logger/mongoose_log_filter.erl
@@ -18,8 +18,9 @@ fill_metadata_filter(Event=#{msg := {report, Msg}, meta := Meta}, Fields) ->
     FieldMap = maps:with(Fields, Msg),
     %% Remove the fields to not print them twice
     Msg2 = maps:without(Fields, Msg),
-    Event#{meta => maps:merge(FieldMap, Meta), msg => {report, Msg2}}.
-
+    Event#{meta => maps:merge(FieldMap, Meta), msg => {report, Msg2}};
+fill_metadata_filter(Event, _) ->
+    Event.
 
 format_c2s_state_filter(Event=#{msg := {report, Msg=#{c2s_state := State}}}, _) ->
     StateMap = filter_undefined(c2s_state_to_map(State)),


### PR DESCRIPTION
This PR addresses an issue I noticed with the logfmt logger.
 
Calling logger macros like this:
```
?LOG_ERROR("Supervisor received unexpected message: ~tp~n",[{'ETS-TRANSFER',mod_global_distrib_bounce_message_store_by_target,self(),testing}],
               #{domain=>[otp],
                 error_logger=>#{tag=>error}}),
```
resulted in crashes like this:
```
2020-09-07T17:46:08.318748+00:00 error: FORMATTER CRASH: {"Supervisor received unexpected message: ~tp~n",[{'ETS-TRANSFER',mod_global_distrib_bounce_message_store_by_target,<0.31591.1>,testing}]}
```
This example is derived from OTP's Supervisor way of logging ([line in source](https://github.com/erlang/otp/blob/62280d6952150805788025fe0da0343a60dd1f69/lib/stdlib/src/supervisor.erl#L587))
Such crashes can be observed for example [here](http://esl.github.io/mongooseim-ct-reports/s3_reports.html?prefix=branch/master/8537/internal_mnesia.23.0.3/logs/2020-09-07_17.47.21/mim1/log/) in our CI.

These crashes seem to come from using macros with strings or formatted strings as arguments and not fully structured logs.
Proposed quick fix would result in something like this reaching logs in the example case:
```
when=2020-09-08T11:19:58.454983+00:00 level=error pid=<0.390.0> at=ejabberd_app:start/2:79 unstructured_log="Supervisor received unexpected message: {'ETS-TRANSFER',\
                                         mod_global_distrib_bounce_message_store_by_target,\
                                         <0.390.0>,testing}\
" 
```
