### PR TITLE
TOML: validate host config

### DIFF
--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -24,7 +24,7 @@ The file is divided into the following sections:
 * **acl** - Access control lists, defining access groups to which connecting users are classified.
 * **access** - Access rules, specifying the privileges of the defined access groups.
 * **s2s** - Server-to-server connection options, used for connecting federated XMPP servers.
-* **host_config** - Configuration options that need to be different for a specific XMPP domain. May contain the following subsections: **general**, **auth**, **modules**, **shaper**, **acl**, **access**.
+* **host_config** - Configuration options that need to be different for a specific XMPP domain. May contain the following subsections: **general**, **auth**, **modules**, **shaper**, **acl**, **access**, **s2s**.
 
 ## Options
 

--- a/test/config_parser_SUITE_data/miscellaneous.cfg
+++ b/test/config_parser_SUITE_data/miscellaneous.cfg
@@ -2,6 +2,8 @@
          "anonymous.localhost"
         ] }.
 
+{cowboy_server_name, "Apache"}.
+{rdbms_server_type, mssql}.
 override_global.
 override_local.
 override_acls.

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -3,6 +3,8 @@
     "localhost",
     "anonymous.localhost"
   ]
+  http_server_name = "Apache"
+  rdbms_server_type = "mssql"
   override = ["local", "global", "acls"]
   pgsql_users_number_estimate = true
   route_subdomains = "s2s"


### PR DESCRIPTION
Test host config: each allowed option is now validated and tested for both cases: per-host and globally.

Handling of host config was also reworked - see the individual commits for details.
The main motivation was to avoid having two separate clauses in the parser for handling the global and per-host option.
