### PR TITLE
fix mongoose_api_admin and mongoose_api_client opts

### DIFF
--- a/test/config_parser_SUITE_data/mongooseim-pgsql.cfg
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.cfg
@@ -25,10 +25,11 @@
                                          {timeout, infinity},
                                          {ping_rate, none},
                                          {max_stanza_size, 100}
-                                                                         ]}
-                                      ]},
-                            {"localhost", "/api", mongoose_api_admin, [{auth, {<<"ala">>, <<"makotaipsa">>}}]},
-                            {"localhost", "/api/contacts/{:jid}", mongoose_api_client_contacts, []}
+                                                                         ]},
+                                       {"localhost", "/api", mongoose_api_admin, [{auth, {<<"ala">>, <<"makotaipsa">>}}]},
+                                       {"localhost", "/api/contacts/{:jid}", mongoose_api_client, []}
+                                      ]}
+                           
                            ]},
   { { 8088, "127.0.0.1"} , ejabberd_cowboy, [
                                              {transport_options, [{num_acceptors, 10}, {max_connections, 1024}]},

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -36,13 +36,17 @@
   tls.certfile = "tools/ssl/mongooseim/cert.pem"
   tls.keyfile = "tools/ssl/mongooseim/key.pem"
   tls.password = ""
-  mongoose_api_admin.host = "localhost"
-  mongoose_api_admin.path = "/api"
-  mongoose_api_admin.username = "ala"
-  mongoose_api_admin.password = "makotaipsa"
-  mongoose_api_client.host = "localhost"
-  mongoose_api_client.path = "/api/contacts/{:jid}"
 
+  [[listen.http.handlers.mongoose_api_admin]]
+    host = "localhost"
+    path = "/api"
+    username = "ala"
+    password = "makotaipsa"
+
+  [[listen.http.handlers.mongoose_api_client]]
+    host = "localhost"
+    path = "/api/contacts/{:jid}"
+  
   [[listen.http.handlers.mod_bosh]]
     host = "_"
     path = "/http-bind"


### PR DESCRIPTION
This PR fixes the way we parsed `mongoose_api_client` and `mongoose_api_admin` options. They are moved to `listen.http.handlers` subsection
