### PR TITLE
Exrternal Service Discovery - XEP-0215

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -80,6 +80,7 @@
 {suites, "tests", mongoose_elasticsearch_SUITE}.
 {suites, "tests", sasl_external_SUITE}.
 {suites, "tests", persistent_cluster_id_SUITE}.
+{suites, "tests", extdisco_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -11,9 +11,6 @@
 %% do not remove below SUITE if testing mongoose
 {suites, "tests", mongoose_sanity_checks_SUITE}.
 
-{suites, "tests", service_mongoose_system_metrics_SUITE}.
-{suites, "tests", rdbms_SUITE}.
-{suites, "tests", race_conditions_SUITE}.
 {suites, "tests", acc_e2e_SUITE}.
 {suites, "tests", accounts_SUITE}.
 {suites, "tests", adhoc_SUITE}.
@@ -22,11 +19,12 @@
 {suites, "tests", bosh_SUITE}.
 {suites, "tests", carboncopy_SUITE}.
 {suites, "tests", cluster_commands_SUITE}.
+{suites, "tests", component_SUITE}.
 {suites, "tests", conf_reload_SUITE}.
 {suites, "tests", connect_SUITE}.
-{suites, "tests", component_SUITE}.
 {suites, "tests", disco_and_caps_SUITE}.
 {suites, "tests", ejabberdctl_SUITE}.
+{suites, "tests", extdisco_SUITE}.
 {suites, "tests", gdpr_SUITE}.
 {suites, "tests", inbox_SUITE}.
 {suites, "tests", jingle_SUITE}.
@@ -35,25 +33,29 @@
 {suites, "tests", mam_SUITE}.
 {suites, "tests", metrics_api_SUITE}.
 {suites, "tests", metrics_c2s_SUITE}.
-{suites, "tests", metrics_roster_SUITE}.
 {suites, "tests", metrics_register_SUITE}.
+{suites, "tests", metrics_roster_SUITE}.
 {suites, "tests", metrics_session_SUITE}.
 {suites, "tests", mod_aws_sns_SUITE}.
 {suites, "tests", mod_blocking_SUITE}.
 {suites, "tests", mod_event_pusher_rabbit_SUITE}.
+{suites, "tests", mod_global_distrib_SUITE}.
 {suites, "tests", mod_http_notification_SUITE}.
 {suites, "tests", mod_http_upload_SUITE}.
 {suites, "tests", mod_ping_SUITE}.
 {suites, "tests", mod_time_SUITE}.
 {suites, "tests", mod_version_SUITE}.
+{suites, "tests", mongoose_cassandra_SUITE}.
+{suites, "tests", mongoose_elasticsearch_SUITE}.
 {suites, "tests", muc_SUITE}.
-{suites, "tests", muc_light_SUITE}.
-{suites, "tests", muc_light_legacy_SUITE}.
 {suites, "tests", muc_http_api_SUITE}.
+{suites, "tests", muc_light_SUITE}.
 {suites, "tests", muc_light_http_api_SUITE}.
+{suites, "tests", muc_light_legacy_SUITE}.
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
 {suites, "tests", pep_SUITE}.
+{suites, "tests", persistent_cluster_id_SUITE}.
 {suites, "tests", presence_SUITE}.
 {suites, "tests", privacy_SUITE}.
 {suites, "tests", private_SUITE}.
@@ -63,24 +65,22 @@
 {suites, "tests", push_http_SUITE}.
 {suites, "tests", push_integration_SUITE}.
 {suites, "tests", push_pubsub_SUITE}.
+{suites, "tests", race_conditions_SUITE}.
+{suites, "tests", rdbms_SUITE}.
 {suites, "tests", rest_SUITE}.
 {suites, "tests", rest_client_SUITE}.
 {suites, "tests", s2s_SUITE}.
 {suites, "tests", sasl_SUITE}.
+{suites, "tests", sasl_external_SUITE}.
+{suites, "tests", service_mongoose_system_metrics_SUITE}.
 {suites, "tests", shared_roster_SUITE}.
 {suites, "tests", sic_SUITE}.
 {suites, "tests", sm_SUITE}.
 {suites, "tests", users_api_SUITE}.
-{suites, "tests", vcard_simple_SUITE}.
 {suites, "tests", vcard_SUITE}.
+{suites, "tests", vcard_simple_SUITE}.
 {suites, "tests", websockets_SUITE}.
 {suites, "tests", xep_0352_csi_SUITE}.
-{suites, "tests", mod_global_distrib_SUITE}.
-{suites, "tests", mongoose_cassandra_SUITE}.
-{suites, "tests", mongoose_elasticsearch_SUITE}.
-{suites, "tests", sasl_external_SUITE}.
-{suites, "tests", persistent_cluster_id_SUITE}.
-{suites, "tests", extdisco_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/tests/extdisco_SUITE.erl
+++ b/big_tests/tests/extdisco_SUITE.erl
@@ -1,0 +1,338 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(extdisco_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
+-define(EXT_DISCO, <<"urn:xmpp:extdisco:2">>).
+
+-compile([export_all]).
+
+all() ->
+    [{group, extdisco_not_configured},
+     {group, extdisco_configured},
+     {group, multiple_extdisco_configured}].
+
+groups() ->
+    G = [{extdisco_not_configured, [sequence], extdisco_not_configured_tests()},
+         {extdisco_configured, [sequence], extdisco_configured_tests()},
+         {multiple_extdisco_configured, [sequence], multiple_extdisco_configured_tests()}],
+    ct_helper:repeat_all_until_all_ok(G).
+
+extdisco_not_configured_tests() ->
+    [ external_services_discovery_not_supported,
+      no_external_services_configured_no_services_returned ].
+
+extdisco_configured_tests() ->
+    tests().
+
+multiple_extdisco_configured_tests() ->
+    tests().
+
+tests() ->
+    [ external_services_discovery_supported,
+      external_services_configured_all_returned,
+      external_services_configured_only_matching_by_type_returned,
+      external_services_configured_no_matching_services_no_returned,
+      external_services_configured_credentials_returned,
+      external_services_configured_no_matching_credentials_no_returned,
+      external_services_configured_incorrect_request_no_returned ].
+
+init_per_suite(C) ->
+    Config = dynamic_modules:save_modules(domain(), C),
+    escalus:init_per_suite(Config).
+
+init_per_group(extdisco_configured, C) ->
+    ExternalServices = [{stun, [
+                            {host, "1.1.1.1"},
+                            {port, "3478"},
+                            {transport, "udp"},
+                            {username, "username"},
+                            {password, "secret"}
+                            ]}],
+    set_external_services(ExternalServices, C);
+init_per_group(multiple_extdisco_configured, C) ->
+    ExternalServices = [{stun, [
+                            {host, "1.1.1.1"},
+                            {port, "3478"},
+                            {transport, "udp"},
+                            {username, "username"},
+                            {password, "secret"}
+                            ]},
+                        {turn, [
+                            {host, "2.2.2.2"},
+                            {port, "3478"},
+                            {transport, "tcp"},
+                            {username, "username"},
+                            {password, "secret"}
+                            ]}],
+    set_external_services(ExternalServices, C);
+init_per_group(_GroupName, Config) ->
+   Config.
+
+init_per_testcase(external_services_discovery_not_supported = Name, C) ->
+    Config = remove_external_services(C),
+    escalus:init_per_testcase(Name, Config);
+init_per_testcase(no_external_services_configured_no_services_returned = Name, C) ->
+    ExternalServices = [],
+    Config = set_external_services(ExternalServices, C),
+    escalus:init_per_testcase(Name, Config);
+init_per_testcase(Name, C) ->
+    escalus:init_per_testcase(Name, C).
+
+end_per_group(_GroupName, Config) ->
+    dynamic_modules:restore_modules(domain(), Config),
+    Config.
+
+end_per_suite(C) ->
+    escalus_fresh:clean(),
+    escalus:end_per_suite(C).
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+external_services_discovery_not_supported(Config) ->
+    % Given external service discovery is not configured
+    Test = fun(Alice) ->
+
+       % When requesting for disco_info
+       IqGet = escalus_stanza:disco_info(domain()),
+       escalus_client:send(Alice, IqGet),
+
+       % Then extdisco feature is not listed as supported feature
+       Result = escalus_client:wait_for_stanza(Alice),
+       escalus:assert(is_iq_result, [IqGet], Result),
+       escalus:assert(fun(Stanza) ->
+           not escalus_pred:has_feature(?EXT_DISCO, Stanza)
+           end, Result)
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+no_external_services_configured_no_services_returned(Config) ->
+    % Given external service discovery is configured with empty list
+    Test = fun(Alice) ->
+
+        % When requesting for external services
+        Iq = request_external_services(domain()),
+        escalus_client:send(Alice, Iq),
+
+        % Then serivces but no serivce element is in the iq result,
+        % which means that empty serivces element got returned
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(true, has_subelement_with_ns(Result, <<"services">>, ?EXT_DISCO)),
+        ?assertEqual([], get_service_element(Result))
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_discovery_supported(Config) ->
+    % Given external service discovery is configured
+    Test = fun(Alice) ->
+
+        % When requesting for disco_info
+        IqGet = escalus_stanza:disco_info(domain()),
+        escalus_client:send(Alice, IqGet),
+
+        % Then extdisco feature is listed as supported feature
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [IqGet], Result),
+        escalus:assert(has_feature, [?EXT_DISCO], Result)
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_configured_all_returned(Config) ->
+    % Given external service discovery is configured
+    Test = fun(Alice) ->
+
+        % When requesting for external services
+        Iq = request_external_services(domain()),
+        escalus_client:send(Alice, Iq),
+
+        % Then list of external services with containing all
+        % supported_elements() is returned
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(true, has_subelement_with_ns(Result, <<"services">>, ?EXT_DISCO)),
+        [all_services_are_returned(Service) || Service <- get_service_element(Result)]
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_configured_only_matching_by_type_returned(Config) ->
+    % Given external service discovery is configured
+    Test = fun(Alice) ->
+
+        % When requesting for external service of specified type
+        Type = <<"stun">>,
+        Iq = request_external_services_with_type(domain(), Type),
+        escalus_client:send(Alice, Iq),
+
+        % Then the list of external services of the specified type is returned
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(true, has_subelement_with_ns(Result, <<"services">>, ?EXT_DISCO)),
+        [all_services_are_returned(Service, Type) || Service <- get_service_element(Result)]
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_configured_no_matching_services_no_returned(Config) ->
+    % Given external service discovery is configured
+    Test = fun(Alice) ->
+
+        % When requesting for external service of unknown or unconfigured type
+        Type = <<"unknown_type">>,
+        Iq = request_external_services_with_type(domain(), Type),
+        escalus_client:send(Alice, Iq),
+
+        % Then the serivces but no serivce element is in the iq result,
+        % which means that empty serivces element got returned
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(true, has_subelement_with_ns(Result, <<"services">>, ?EXT_DISCO)),
+        ?assertEqual([], get_service_element(Result))
+    end,
+escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_configured_credentials_returned(Config) ->
+    % Given external service discovery is configured with credentials
+    Test = fun(Alice) ->
+
+        % When requesting for credentials of external service of given type
+        % and specified host
+        Type = <<"stun">>,
+        Host = <<"1.1.1.1">>,
+        Iq = request_external_services_credentials(domain(), Type, Host),
+        escalus_client:send(Alice, Iq),
+
+        % Then the list of external services of the specified type and host
+        % is returned together with STUN/TURN login credentials
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(true, has_subelement_with_ns(Result, <<"credentials">>, ?EXT_DISCO)),
+        Services = get_service_element(Result),
+        ?assertNotEqual([], Services),
+        [all_services_are_returned(Service, Type) || Service <- Services]
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_configured_no_matching_credentials_no_returned(Config) ->
+    % Given external service discovery is configured with credentials
+    Test = fun(Alice) ->
+
+        % When requesting for credentials of external service of unknown type
+        % and unknown host
+        Type = <<"unknown_type">>,
+        Host = <<"unknown_host">>,
+        Iq = request_external_services_credentials(domain(), Type, Host),
+        escalus_client:send(Alice, Iq),
+
+        % Then the credentials but no serivce element is in the iq result,
+        % which means that empty credentials element got returned
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(true, has_subelement_with_ns(Result, <<"credentials">>, ?EXT_DISCO)),
+        ?assertEqual([], get_service_element(Result))
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+external_services_configured_incorrect_request_no_returned(Config) ->
+    % Given external service discovery is configured
+    Test = fun(Alice) ->
+
+        % When sending request with incorrect elements
+        Iq = request_external_services_incorrect(domain()),
+        escalus_client:send(Alice, Iq),
+
+        % Then empty iq_result is returned
+        Result = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [Iq], Result),
+        ?assertEqual(false, has_subelement_with_ns(Result, <<"incorrect">>, ?EXT_DISCO))
+    end,
+    escalus:fresh_story(Config, [{alice, 1}], Test).
+
+%%-----------------------------------------------------------------
+%% Helpers
+%%-----------------------------------------------------------------
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+set_external_services(Opts, C) ->
+    Module = [{mod_extdisco, Opts}],
+    Config = dynamic_modules:save_modules(domain(), C),
+    ok = dynamic_modules:ensure_modules(domain(), Module),
+    Config.
+
+remove_external_services(C) ->
+    OldModules = rpc(mim(), gen_mod, loaded_modules_with_opts, [domain()]),
+    NewModules = lists:keydelete(mod_extdisco, 1, OldModules),
+    ok = rpc(mim(), gen_mod_deps, replace_modules, [domain(), OldModules, NewModules]),
+    C.
+
+request_external_services(To) ->
+    escalus_stanza:iq(To, <<"get">>,
+        [#xmlel{name = <<"services">>,
+                attrs = [{<<"xmlns">>, <<"urn:xmpp:extdisco:2">>}]}]).
+
+request_external_services_with_type(To, Type) ->
+    escalus_stanza:iq(To, <<"get">>,
+        [#xmlel{name = <<"services">>,
+                attrs = [{<<"xmlns">>, <<"urn:xmpp:extdisco:2">>},
+                         {<<"type">>, Type}]}]).
+
+request_external_services_credentials(To, Type, Host) ->
+    escalus_stanza:iq(To, <<"get">>,
+        [#xmlel{name = <<"credentials">>,
+                attrs = [{<<"xmlns">>, <<"urn:xmpp:extdisco:2">>}],
+                children = [#xmlel{name = <<"service">>,
+                                   attrs = [{<<"host">>, Host},
+                                            {<<"type">>, Type}]}]}]).
+
+request_external_services_incorrect(To) ->
+    escalus_stanza:iq(To, <<"get">>,
+        [#xmlel{name = <<"incorrect">>,
+                attrs = [{<<"xmlns">>, <<"urn:xmpp:extdisco:2">>}]}]).
+
+get_service_element(Result) ->
+    Services = exml_query:subelement_with_ns(Result, ?EXT_DISCO),
+    exml_query:subelements(Services, <<"service">>).
+
+supported_elements() ->
+    [<<"host">>, <<"type">>, <<"port">>, <<"username">>, <<"password">>].
+
+all_services_are_returned(Service) ->
+    [?assertEqual(true, has_subelement(Service, E)) || E <- supported_elements()].
+
+all_services_are_returned(Service, Type) ->
+    ?assertEqual(true, has_attr_with_value(Service, <<"type">>, Type)),
+    all_services_are_returned(Service).
+
+no_services_are_returned(Service) ->
+    [?assertEqual(false, has_subelement(Service, E)) || E <- supported_elements()].
+
+has_subelement(Stanza, Element) ->
+    undefined =/= exml_query:attr(Stanza, Element).
+
+has_attr_with_value(Stanza, Element, Value) ->
+    Value ==  exml_query:attr(Stanza, Element).
+
+has_subelement_with_ns(Stanza, Element, NS) ->
+    [] =/= exml_query:subelements_with_name_and_ns(Stanza, Element, NS).

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -5,6 +5,7 @@
 -define(NS_CONFERENCE,          <<"jabber:x:conference">>).
 -define(NS_DISCO_ITEMS,         <<"http://jabber.org/protocol/disco#items">>).
 -define(NS_DISCO_INFO,          <<"http://jabber.org/protocol/disco#info">>).
+-define(NS_EXTDISCO,            <<"urn:xmpp:extdisco:2">>).
 -define(NS_VCARD,               <<"vcard-temp">>).
 -define(NS_VCARD_UPDATE,        <<"vcard-temp:x:update">>).
 -define(NS_OAUTH_0,             <<"urn:xmpp:oauth:0">>).% Defined by XEP-0235: Authorization Tokens.

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -694,10 +694,18 @@
 %     {secret_access_key, "CG5fGqG0/n6NCPJ10FylpdgRnuV52j8IZvU7BSj8"}
 %   ]}
 % ]},
-
   {mod_adhoc, []},
   {{{mod_amp}}}
   {mod_disco, [{users_can_see_hidden_services, false}]},
+% {mod_extdisco, [
+%     {stun, [
+%         {host, "127.0.0.1"},
+%         {port, "3478"},
+%         {transport, "udp"},
+%         {username, "username"},
+%         {password, "secret"}
+%         ]}
+%   ]},
   {mod_commands, []},
   {mod_muc_commands, []},
   {mod_muc_light_commands, []},

--- a/src/mod_extdisco.erl
+++ b/src/mod_extdisco.erl
@@ -1,0 +1,132 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module (mod_extdisco).
+-author('jan.ciesla@erlang-solutions.com').
+
+-xep([{xep, 215}, {version, "0.7"}]).
+-behaviour(gen_mod).
+
+%% gen_mod callbacks.
+-export([start/2, stop/1]).
+
+-export([process_iq/4]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+
+-define(EXT_DISCO, <<"urn:xmpp:extdisco:2">>).
+
+-spec start(jid:server(), list()) -> ok.
+start(Host, Opts) ->
+    IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
+    mod_disco:register_feature(Host, ?EXT_DISCO),
+    gen_iq_handler:add_iq_handler(ejabberd_local, Host,
+        ?EXT_DISCO, ?MODULE, process_iq, IQDisc).
+
+-spec stop(jid:server()) -> ok.
+stop(Host) ->
+    mod_disco:unregister_feature(Host, ?EXT_DISCO),
+    gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?EXT_DISCO).
+
+-spec process_iq(jid:jid(), jid:jid(), mongoose_acc:t(), jlib:iq()) ->
+    {mongoose_acc:t(), jlib:iq()}.
+process_iq(_From, _To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
+    Response = case request_type(SubEl) of
+        all_services ->
+            RequestedServices = get_external_services(),
+            create_iq_response(RequestedServices);
+        {credentials, {Type, Host}} ->
+            Services = get_external_services([Type], []),
+            RequestedServices = lists:filter(fun({_, Opts}) ->
+                gen_mod:get_opt(host, Opts, undefined) == binary_to_list(Host)
+                end, Services),
+            create_iq_response_credentials(RequestedServices);
+        {selected_services, Type} ->
+            RequestedServices = get_external_services([Type], []),
+            create_iq_response_services(RequestedServices, Type);
+        _ ->
+            []
+    end,
+    {Acc, IQ#iq{type = result, sub_el = Response}}.
+
+request_type(#xmlel{name = <<"services">>} = Element) ->
+    case exml_query:attr(Element, <<"type">>) of
+        undefined -> all_services;
+        Services -> {selected_services, binary_to_atom(Services, utf8)}
+    end;
+request_type(#xmlel{name = <<"credentials">>, children = [C]}) ->
+    Host = exml_query:attr(C, <<"host">>),
+    Type = exml_query:attr(C, <<"type">>),
+    {credentials, {binary_to_atom(Type, utf8), Host}};
+request_type(_) ->
+    {error, unknown_request}.
+
+create_iq_response(Services) ->
+    #xmlel{name = <<"services">>,
+        attrs = [{<<"xmlns">>, ?EXT_DISCO}],
+        children = prepare_services_element(Services, [])}.
+
+create_iq_response_services(Services, Type) ->
+    #xmlel{name = <<"services">>,
+        attrs = [{<<"xmlns">>, ?EXT_DISCO}, {<<"type">>, atom_to_binary(Type, utf8)}],
+        children = prepare_services_element(Services, [])}.
+
+create_iq_response_credentials(Services) ->
+    #xmlel{name = <<"credentials">>,
+        attrs = [{<<"xmlns">>, ?EXT_DISCO}],
+        children = prepare_services_element(Services, [])}.
+
+get_external_services() ->
+    get_external_services([stun, turn], []).
+get_external_services([], ServicesWithOpts) ->
+    ServicesWithOpts;
+get_external_services([Type | Types], ServicesWithOpts) ->
+    case gen_mod:get_module_opt(?MYNAME, ?MODULE, Type, []) of
+        [] -> get_external_services(Types, ServicesWithOpts);
+        Opts -> get_external_services(Types, [{Type, Opts} | ServicesWithOpts])
+    end.
+
+prepare_services_element([], Result) ->
+    Result;
+prepare_services_element([{Type, Opts} | Services], Result) ->
+    RequiredElements = required_elements(Type, Opts),
+    OptionalElements = optional_elements(Opts),
+    NewResult = [#xmlel{name = <<"service">>,
+                        attrs = RequiredElements ++ OptionalElements}],
+    prepare_services_element(Services, Result ++ NewResult).
+
+required_elements(Type, Opts) ->
+    Host = gen_mod:get_opt(host, Opts, <<"">>),
+    [{<<"type">>, atom_to_binary(Type, utf8)}, {<<"host">>, Host}].
+
+optional_elements(Opts) ->
+    Port = gen_mod:get_opt(port, Opts, undefined),
+    Transport = gen_mod:get_opt(transport, Opts, undefined),
+    Password = gen_mod:get_opt(password, Opts, undefined),
+    Username = gen_mod:get_opt(username, Opts, undefined),
+    Elements = [{<<"port">>, Port},
+                {<<"transport">>, Transport},
+                {<<"password">>, Password},
+                {<<"username">>, Username}],
+    filter_undefined_elements(Elements).
+
+filter_undefined_elements(Elements) ->
+    lists:filter(fun(Element) ->
+        case Element of
+            {_, undefined} -> false;
+            _ -> true
+        end
+    end, Elements).


### PR DESCRIPTION
This PR adds support for [XEP-0215 External Service Discovery](https://xmpp.org/extensions/xep-0215.html). An XMPP client or other entity might need to discover services external to the XMPP network in order to complete certain XMPP-related use cases. One example is the discovery of STUN servers and TURN relays.

Connecting MongooseIM+MongooseICE duet to client applications like `Conversations` or `Movim` and allow for video/voice calling requires support for XEP-0215.

It is implemented as an `iq_handler` for `urn:xmpp:extdisco:2` namespace and returning details of an external service that are specified in the configuration file. 

There are three types of requests that are supported:
* get all services with all their details (host, type, port, transport, username, password)
* get services of specific type (STUN/TURN) with all their details
* get credentials for external service of specified type (STUN/TURN) and specified host (IP or hostname)

Documentation is included in separate PR #2871 

The implementation was tested with MongooseIM+MongooseICE and allowed for voice and video calls using `Converstaion` as client application.
