### PR TITLE
Change http_opts config from gun to fusco

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -471,13 +471,6 @@ connection_options([_, _, <<"riak">>|_] = Path, Options = #{<<"username">> := Us
                                                             <<"password">> := Password}) ->
     M = maps:without([<<"username">>, <<"password">>], Options),
     [{credentials, b2l(UserName), b2l(Password)} | parse_section(Path, M)];
-connection_options([_, _, <<"http">>|_] = Path, M) ->
-    HttpOpts = parse_section(Path, maps:with([<<"retry">>, <<"retry_timeout">>], M)),
-    Opts = parse_section(Path, maps:without([<<"retry">>, <<"retry_timeout">>], M)),
-    case HttpOpts of
-        [] -> Opts;
-        V -> [{http_opts, maps:from_list(V)} | Opts]
-    end;
 connection_options(Path, Options) ->
     parse_section(Path, Options).
 
@@ -532,9 +525,7 @@ rdbms_option([<<"driver">>|_], _V) -> [].
 -spec http_option(path(), toml_value()) -> [option()].
 http_option([<<"host">>|_], V) -> [{server, b2l(V)}];
 http_option([<<"path_prefix">>|_], V) -> [{path_prefix, b2l(V)}];
-http_option([<<"request_timeout">>|_], V) -> [{request_timeout, V}];
-http_option([<<"retry">>|_], V) -> [{retry, V}];
-http_option([<<"retry_timeout">>|_], V) -> [{retry_timeout, V}].
+http_option([<<"request_timeout">>|_], V) -> [{request_timeout, V}].
 
 %% path: outgoing_pools.redis.*.connection.*
 -spec redis_option(path(), toml_value()) -> [option()].

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -260,12 +260,6 @@ validate([<<"path_prefix">>, _Conn, _Tag, <<"http">>, <<"outgoing_pools">>],
 validate([<<"request_timeout">>, _Conn, _Tag, <<"http">>, <<"outgoing_pools">>],
          [{request_timeout, Value}]) ->
     validate_non_negative_integer(Value);
-validate([<<"retry">>, _Conn, _Tag, <<"http">>, <<"outgoing_pools">>],
-         [{retry, Value}]) ->
-    validate_non_negative_integer(Value);
-validate([<<"retry_timeout">>, _Conn, _Tag, <<"http">>, <<"outgoing_pools">>],
-         [{retry_timeout, Value}]) ->
-    validate_positive_integer(Value);
 validate([<<"host">>, _Conn, _Tag, <<"redis">>, <<"outgoing_pools">>],
          [{host, Value}]) ->
     validate_non_empty_string(Value);

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -111,7 +111,6 @@ groups() ->
                          pool_http_host,
                          pool_http_path_prefix,
                          pool_http_request_timeout,
-                         pool_http_opts,
                          pool_redis_host,
                          pool_redis_port,
                          pool_redis_database,
@@ -894,13 +893,6 @@ pool_http_request_timeout(_Config) ->
         parse_pool_conn(<<"http">>, #{<<"request_timeout">> => 2000})),
     ?err(parse_pool_conn(<<"http">>, #{<<"request_timeout">> => -1000})),
     ?err(parse_pool_conn(<<"http">>, #{<<"request_timeout">> => <<"infinity">>})).
-
-pool_http_opts(_Config) ->
-    ?eq(pool_config({http, global, default, [], 
-        [{http_opts, #{retry => 1, retry_timeout => 1000}}]}),
-        parse_pool_conn(<<"http">>, #{<<"retry">> => 1, <<"retry_timeout">> => 1000})),
-    ?err(parse_pool_conn(<<"http">>, #{<<"retry">> => <<"infinity">>})),
-    ?err(parse_pool_conn(<<"http">>, #{<<"retry_timeout">> => 0})).
 
 pool_redis_host(_Config) ->
     ?eq(pool_config({redis, global, default, [], [{host, "localhost"}]}),

--- a/test/config_parser_SUITE_data/outgoing_pools.cfg
+++ b/test/config_parser_SUITE_data/outgoing_pools.cfg
@@ -13,10 +13,6 @@
                   {http, global, mongoose_push_http,
                     [{workers, 50}],
                     [{server, "https://localhost:8443"},
-                    {http_opts, #{
-                                        retry => 1,
-                                        retry_timeout => 1000
-                                    }},
                     {path_prefix, "/"},
                     {request_timeout, 2000}
                     ]},

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -34,12 +34,10 @@
     host = "https://localhost:8443"
     path_prefix = "/"
     request_timeout = 2000
-    retry = 1
-    retry_timeout = 1000
 
 [outgoing_pools.riak.default]
     scope = "global"
-    workers = 20 
+    workers = 20
     strategy = "next_worker"
     connection.address = "127.0.0.1"
     connection.port = 8087


### PR DESCRIPTION
Follow-up on https://github.com/esl/MongooseIM/pull/2872/ in order to remove configuration related to gun, as we've reverted back to fusco. Custom fusco opts are not allowed.