### PR TITLE
Replace ejabberd:server() with jid:server(), also lserver, [l]user and [l]resource

### DIFF
--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -30,11 +30,11 @@
 %%% API
 %%%----------------------------------------------------------------------
 
--spec start(Domain :: ejabberd:server()) -> ok.
+-spec start(Domain :: jid:server()) -> ok.
 start(_Domain) ->
     ok.
 
--spec stop(Domain:: ejabberd:server()) -> ok.
+-spec stop(Domain :: jid:server()) -> ok.
 stop(_Domain) ->
     ok.
 

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -41,17 +41,17 @@
 -export([check_password/3,
          check_password/5]).
 
--spec start(Host :: ejabberd:lserver()) -> ok.
+-spec start(Host :: jid:lserver()) -> ok.
 start(_) -> ok.
 
--spec stop(Host :: ejabberd:lserver()) -> ok.
+-spec stop(Host :: jid:lserver()) -> ok.
 stop(_) -> ok.
 
 -spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, Module) -> Module =:= cyrsasl_external.
 
--spec set_password( User :: ejabberd:luser(),
-                    Server :: ejabberd:lserver(),
+-spec set_password( User :: jid:luser(),
+                    Server :: jid:lserver(),
                     Password :: binary()
                   ) -> ok | {error, not_allowed | invalid_jid}.
 set_password(_, _, _) -> {error, not_allowed}.
@@ -60,8 +60,8 @@ set_password(_, _, _) -> {error, not_allowed}.
 authorize(Creds) ->
             {ok, mongoose_credentials:extend(Creds, [{auth_module, ?MODULE}])}.
 
--spec try_register( User :: ejabberd:luser(),
-                    Server :: ejabberd:lserver(),
+-spec try_register( User :: jid:luser(),
+                    Server :: jid:lserver(),
                     Password :: binary()
                   ) -> ok | {error, exists | not_allowed | term()}.
 try_register(_, _, _) -> {error, not_allowed}.
@@ -69,39 +69,39 @@ try_register(_, _, _) -> {error, not_allowed}.
 -spec dirty_get_registered_users() -> [jid:simple_bare_jid()].
 dirty_get_registered_users() -> [].
 
--spec get_vh_registered_users(Server :: ejabberd:lserver()) -> [jid:simple_bare_jid()].
+-spec get_vh_registered_users(Server :: jid:lserver()) -> [jid:simple_bare_jid()].
 get_vh_registered_users(_) -> [].
 
--spec get_vh_registered_users( Server :: ejabberd:lserver(),
+-spec get_vh_registered_users( Server :: jid:lserver(),
                                Opts :: list()
                              ) -> [jid:simple_bare_jid()].
 get_vh_registered_users(_, _) -> [].
 
--spec get_vh_registered_users_number(Server :: ejabberd:lserver()) -> integer().
+-spec get_vh_registered_users_number(Server :: jid:lserver()) -> integer().
 get_vh_registered_users_number(_) -> 0.
 
--spec get_vh_registered_users_number( Server :: ejabberd:lserver(),
+-spec get_vh_registered_users_number( Server :: jid:lserver(),
                                       Opts :: list()
                                     ) -> integer().
 get_vh_registered_users_number(_, _) -> 0.
 
--spec get_password( User :: ejabberd:luser(),
-                    Server :: ejabberd:lserver()
+-spec get_password( User :: jid:luser(),
+                    Server :: jid:lserver()
                   ) -> ejabberd_auth:passterm() | false.
 get_password(_, _) -> false.
 
--spec get_password_s( User :: ejabberd:luser(),
-                      Server :: ejabberd:lserver()
+-spec get_password_s( User :: jid:luser(),
+                      Server :: jid:lserver()
                     ) -> binary().
 get_password_s(_, _) -> <<"">>.
 
--spec does_user_exist( User :: ejabberd:luser(),
-                       Server :: ejabberd:lserver()
+-spec does_user_exist( User :: jid:luser(),
+                       Server :: jid:lserver()
                      ) -> boolean() | {error, atom()}.
 does_user_exist(_, _) -> true.
 
--spec remove_user( User :: ejabberd:luser(),
-                   Server :: ejabberd:lserver()
+-spec remove_user( User :: jid:luser(),
+                   Server :: jid:lserver()
                  ) -> ok | {error, not_allowed}.
 remove_user(_, _) -> {error, not_allowed}.
 

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -350,7 +350,7 @@ set_module_opt(Host, Module, Opt, Value) ->
 
 
 %% @doc Replaces all module options
--spec set_module_opts(ejabberd:server(), module(), _Opts) -> true.
+-spec set_module_opts(jid:server(), module(), _Opts) -> true.
 set_module_opts(Host, Module, Opts0) ->
     Opts = proplists:unfold(Opts0),
     ets:insert(ejabberd_modules,
@@ -412,7 +412,7 @@ loaded_modules_with_opts(Host) ->
                  [],
                  [{{'$1', '$2'}}]}]).
 
--spec opts_for_module(ejabberd:server(), module()) -> list().
+-spec opts_for_module(jid:server(), module()) -> list().
 opts_for_module(Host, Module) ->
     case ets:select(ejabberd_modules,
                     [{#ejabberd_module{_ = '_',

--- a/src/global_distrib/mod_global_distrib_hosts_refresher.erl
+++ b/src/global_distrib/mod_global_distrib_hosts_refresher.erl
@@ -61,16 +61,16 @@ unpause() ->
 %% gen_mod callbacks
 %%--------------------------------------------------------------------
 
--spec start(Host :: ejabberd:lserver(), Opts :: proplists:proplist()) -> any().
+-spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
 start(Host, Opts0) ->
     Opts = [{hosts_refresh_interval, default_refresh_interval()} | Opts0],
     mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).
 
--spec stop(Host :: ejabberd:lserver()) -> any().
+-spec stop(Host :: jid:lserver()) -> any().
 stop(Host) ->
     mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
 
--spec deps(Host :: ejabberd:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
 deps(Host, Opts) ->
     mod_global_distrib_utils:deps(?MODULE, Host, Opts, fun deps/1).
 

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -49,7 +49,7 @@
 %%--------------------------------------------------------------------
 %%
 
--spec start(ejabberd:server(), list()) -> ok.
+-spec start(jid:server(), list()) -> ok.
 start(Host, Opts) ->
     start_nksip_service_or_error(Opts),
     mod_jingle_sip_backend:init(Host, Opts),
@@ -80,7 +80,7 @@ maybe_add_udp_max_size(NkSipOpts, Opts) ->
             NkSipOpts#{sip_udp_max_size => Size}
     end.
 
--spec stop(ejabberd:server()) -> ok.
+-spec stop(jid:server()) -> ok.
 stop(Host) ->
     ejabberd_hooks:delete(hooks(Host)),
     ok.

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -679,7 +679,7 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver=LServer, luser=LUser}, IQ) 
                  issue => Issue, server => LServer, user => LUser,
                  reason => Reason, iq => IQ, stacktrace => Stacktrace}).
 
--spec is_archivable_message(Host :: ejabberd:lserver(), Dir :: incoming | outgoing,
+-spec is_archivable_message(Host :: jid:lserver(), Dir :: incoming | outgoing,
                             Packet :: exml:element()) -> boolean().
 is_archivable_message(Host, Dir, Packet) ->
     {M, F} = mod_mam_params:is_archivable_message_fun(?MODULE, Host),

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -599,7 +599,7 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver = LServer, luser = LUser}, 
     ?LOG_ERROR(#{what => mam_muc_error, issue => Issue, reason => Reason,
                  user => LUser, server => LServer, iq => IQ, stacktrace => Stacktrace}).
 
--spec is_archivable_message(MUCHost :: ejabberd:lserver(), Dir :: incoming | outgoing,
+-spec is_archivable_message(MUCHost :: jid:lserver(), Dir :: incoming | outgoing,
                             Packet :: exml:element()) -> boolean().
 is_archivable_message(MUCHost, Dir, Packet) ->
     {ok, Host} = mongoose_subhosts:get_host(MUCHost),

--- a/src/mam/mod_mam_params.erl
+++ b/src/mam/mod_mam_params.erl
@@ -26,24 +26,24 @@
 %% API
 %%--------------------------------------------------------------------
 
--spec extra_params_module(mam_module(), Host :: ejabberd:lserver()) -> module() | undefined.
+-spec extra_params_module(mam_module(), Host :: jid:lserver()) -> module() | undefined.
 extra_params_module(Module, Host) ->
     param(Module, Host, extra_lookup_params, undefined).
 
--spec max_result_limit(mam_module(), Host :: ejabberd:lserver()) -> pos_integer().
+-spec max_result_limit(mam_module(), Host :: jid:lserver()) -> pos_integer().
 max_result_limit(Module, Host) ->
     param(Module, Host, max_result_limit, 50).
 
--spec default_result_limit(mam_module(), Host :: ejabberd:lserver()) -> pos_integer().
+-spec default_result_limit(mam_module(), Host :: jid:lserver()) -> pos_integer().
 default_result_limit(Module, Host) ->
     param(Module, Host, default_result_limit, 50).
 
 
--spec has_full_text_search(Module :: mod_mam | mod_mam_muc, Host :: ejabberd:server()) -> boolean().
+-spec has_full_text_search(Module :: mod_mam | mod_mam_muc, Host :: jid:server()) -> boolean().
 has_full_text_search(Module, Host) ->
     param(Module, Host, full_text_search, true).
 
--spec is_archivable_message_fun(mam_module(), Host :: ejabberd:lserver()) ->
+-spec is_archivable_message_fun(mam_module(), Host :: jid:lserver()) ->
                                        MF :: {module(), atom()}.
 is_archivable_message_fun(Module, Host) ->
     {IsArchivableModule, IsArchivableFunction} =
@@ -58,11 +58,11 @@ is_archivable_message_fun(Module, Host) ->
         end,
     {IsArchivableModule, IsArchivableFunction}.
 
--spec archive_chat_markers(mam_module(), Host :: ejabberd:lserver()) -> boolean().
+-spec archive_chat_markers(mam_module(), Host :: jid:lserver()) -> boolean().
 archive_chat_markers(Module, Host) ->
     param(Module, Host, archive_chat_markers, false).
 
--spec add_stanzaid_element(mam_module(), Host :: ejabberd:lserver()) -> boolean().
+-spec add_stanzaid_element(mam_module(), Host :: jid:lserver()) -> boolean().
 add_stanzaid_element(Module, Host) ->
     not param(Module, Host, no_stanzaid_element, false).
 
@@ -70,6 +70,6 @@ add_stanzaid_element(Module, Host) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 
--spec param(mam_module(), Host :: ejabberd:lserver(), Opt :: term(), Default :: term()) -> term().
+-spec param(mam_module(), Host :: jid:lserver(), Opt :: term(), Default :: term()) -> term().
 param(Module, Host, Opt, Default) ->
     gen_mod:get_module_opt(Host, Module, Opt, Default).

--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -3,10 +3,10 @@
 
 %% Defines which RDBMS pool to use
 %% Parent host of the MUC service
--type server_host() :: ejabberd:server().
+-type server_host() :: jid:server().
 
 %% Host of MUC service
--type muc_host() :: ejabberd:server().
+-type muc_host() :: jid:server().
 
 %% User's JID. Can be on another domain accessable over FED.
 %% Only bare part (user@host) is important.

--- a/src/mod_muc_db_mnesia.erl
+++ b/src/mod_muc_db_mnesia.erl
@@ -53,7 +53,7 @@ init(_Host, _Opts) ->
     mnesia:add_table_index(muc_registered, nick),
     ok.
 
--spec store_room(ejabberd:server(), ejabberd:server(), mod_muc:room(), list())
+-spec store_room(jid:server(), jid:server(), mod_muc:room(), list())
             -> ok | {error, term()}.
 store_room(ServerHost, MucHost, RoomName, Opts) ->
     F = fun() ->
@@ -86,7 +86,7 @@ restore_room(ServerHost, MucHost, RoomName) ->
         {error, {Class, Reason}}
     end.
 
--spec forget_room(ejabberd:server(), ejabberd:server(), mod_muc:room()) ->
+-spec forget_room(jid:server(), jid:server(), mod_muc:room()) ->
     ok | {error, term()}.
 forget_room(ServerHost, MucHost, RoomName) ->
     F = fun() ->
@@ -116,7 +116,7 @@ get_rooms(ServerHost, MucHost) ->
         {error, {Class, Reason}}
     end.
 
--spec can_use_nick(ejabberd:server(), ejabberd:server(),
+-spec can_use_nick(jid:server(), jid:server(),
                    ejabberd:jid(), mod_muc:nick()) -> boolean().
 can_use_nick(_ServerHost, MucHost, JID, Nick) ->
     LUS = jid:to_lus(JID),

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -39,7 +39,7 @@
 mechanism() ->
     <<"EXTERNAL">>.
 
--spec mech_new(Host   :: ejabberd:server(),
+-spec mech_new(Host   :: jid:server(),
                Creds  :: mongoose_credentials:t(),
                Socket :: term()) -> {ok, sasl_external_state()}.
 mech_new(_Host, Creds, _Socket) ->


### PR DESCRIPTION
I spotted a few places where types that used to be in `ejabberd` but are now only in `jid` were still being referred to as members of the `ejabberd` module.  This means dialyzer is not checking type safety for these functions.  I've done a find/replace on the code.

Once resolved, dialyzer still found no type safety issues.