### PR TITLE
TOML docs: host_config

### DIFF
--- a/doc/Advanced-configuration.md
+++ b/doc/Advanced-configuration.md
@@ -1,12 +1,10 @@
 For advanced configuration use the following files:
 
-* `mongooseim.cfg` for pure MongooseIM settings,
+* `mongooseim.toml` for pure MongooseIM settings,
 
 * `vm.args` to affect the Erlang VM behaviour (performance tuning, node name),
 
 * `app.config` to change low-level logging parameters and settings of other Erlang applications.
-
-Since you've gotten this far, we assume you're already familiar with Erlang syntax.
 
 # mongooseim.toml
 
@@ -24,19 +22,18 @@ The file is divided into the following sections:
 * [**acl**](advanced-configuration/acl.md) - Access classes to which connecting users are assigned.
 * [**access**](advanced-configuration/access.md) - Access rules, specifying the privileges of the defined access classes.
 * [**s2s**](advanced-configuration/s2s.md) - Server-to-server connection options, used for XMPP federation.
-* **host_config** - Configuration options that need to be different for a specific XMPP domain. May contain the following subsections: **general**, **auth**, **modules**, **shaper**, **acl**, **access**, **s2s**.
+* [**host_config**](advanced-configuration/host_config.md) - Configuration options that need to be different for a specific XMPP domain.
 
-## Options
+The section names above are links to the detailed documentation of each section.
 
-* All options except `hosts`, `host`, `host_config`, `listen` and `outgoing_connections` may be used in the `host_config` tuple.
+## Option scope
 
-* There are two kinds of local options - those that are kept separately for each domain in the config file (defined inside `host_config`) and the options local for a node in the cluster.
+Each configuration option has its **scope**, which is one of the following:
 
-* "global" options are shared by all cluster nodes and all domains.
+* **local** - configured separately for each node in the cluster - each node can have a different value,
+* **global** - configured for the entire cluster - all nodes share the same value.
 
-* Options labeled as "multi" (in this page) can be declared multiple times in a row, e.g. one per domain.
-
-* Section names below correspond with the ones in the file.
+The scope of each option is defined in the documentation above - either at the top of the section page or for each option individually.
 
 ### Outgoing connections setup
 
@@ -63,13 +60,6 @@ For a specific configuration, please refer to [Services](advanced-configuration/
 
 * **services** (local)
     * **Description:** List of enabled services with their options.
-
-### Per-domain configuration
-
-The `host_config` allows configuring most options separately for specific domains served by the cluster. It is best to put `host_config` tuple right after the global section it overrides/complements or even at the end of `mongooseim.cfg`.
-
-* **host_config** (multi, local)
-    * **Syntax:** `{host_config, Domain, [ {{add, modules}, [{mod_some, Opts}]}, {access, c2s, [{deny, local}]}, ... ]}.`
 
 # vm.args
 

--- a/doc/advanced-configuration/access.md
+++ b/doc/advanced-configuration/access.md
@@ -206,28 +206,6 @@ It has the following logic:
 This means that the admin users can have 5000 messages stored offline, while the others can have at most 100.
 The `admin` access class can be defined in the [`acl` section](acl.md).
 
-## Domain-specific access rules
-
-By default, access rules apply to all domains available on the server.
-However, with the `host_config` section it is possible to override selected rules for a particular XMPP domain.
-
-```toml
-[[host_config]]
-  host = "localhost"
-
-  [host_config.access]
-    c2s = [
-      {acl = "admin", value = "allow"},
-      {acl = "all", value = "deny"}
-    ]
-
-    register = [
-      {acl = "all", value = "deny"}
-    ]
-```
-
-The global rule has the highest priority, however if the global rule ends with `{acl = "all", value = "allow"}`, the domain-specific rule is taken into account.
-
 ## For developers
 
 To access the rule functionality, one has to use the `acl:match_rule/3` function.

--- a/doc/advanced-configuration/host_config.md
+++ b/doc/advanced-configuration/host_config.md
@@ -1,0 +1,229 @@
+The `host_config` section is used to configure options for specific XMPP domains.
+For each domain requiring such options, a `host_config` section needs to be created with the following format:
+
+* **Scope:** for each option the scope is the same as for the corresponding top-level option.
+* **Syntax:** domain subsection starts with `[[host_config]]` and contains the options listed below.
+* **Default:** none - all domain-level options need to be specified explicitly.
+* **Example:** see the examples for each section below.
+
+**Note:** Each hosted domain needs to be included in the list of [`hosts`](general.md#generalhosts) in the `general` section.
+
+# General options
+
+### `host_config.host`
+
+* **Syntax:** string, domain name
+* **Default:** no default, this option is mandatory
+* **Example:** `host = "my-xmpp-server.com"`
+
+This option specifies the XMPP domain that this section refers to.
+
+# Configuration sections
+
+The following sections are accepted in `host_config`:
+
+## `host_config.general`
+
+The options defined here override the ones defined in the top-level [`general`](general.md) section.
+The following options are allowed:
+
+* [`pgsql_users_number_estimate`](general.md#generalpgsql_users_number_estimate)
+* [`route_subdomains`](general.md#generalroute_subdomains)
+* [`replaced_wait_timeout`](general.md#generalreplaced_wait_timeout)
+* [`hide_service_name`](general.md#generalhide_service_name)
+
+#### Example
+
+The `hide_service_name` option is set to `false` only for `domain2.com`.
+
+```toml
+[general]
+  hosts = ["domain1.com", "domain2.com", "domain3.com"]
+  loglevel = "info"
+  hide_service_name = true
+  replaced_wait_timeout = 1000
+
+[[host_config]]
+  host = "domain2.com"
+
+  [host_config.general]
+    hide_service_name = false
+```
+
+## `host_config.auth`
+
+This section completely overrides the top-level [`auth`](auth.md) section. All options are allowed.
+
+#### Example
+
+The intention here is to enable only the `SASL PLAIN` mechanism for `domain2.com`.
+To do this, we need to specify `methods` as well - otherwise there would be no authentication methods
+enabled for `domain2.com` as the entire `auth` section is replaced.
+
+```toml
+[general]
+  hosts = ["domain1.com", "domain2.com", "domain3.com"]
+
+[auth]
+  methods = ["internal"]
+
+[[host_config]]
+  host = "domain2.com"
+
+  [host_config.auth]
+    methods = ["internal"]
+    sasl_mechanisms = ["plain"]
+```
+
+## `host_config.modules`
+
+This section completely overrides the top-level [`modules`](modules.md) section. All options are allowed.
+
+#### Example
+
+The modules enabled for `domain2.com` will be `mod_disco` and `mod_stream_management`.
+If we wanted to enable `mod_roster`, it would need to be repeated in `host_config`.
+
+```toml
+[general]
+  hosts = ["domain1.com", "domain2.com", "domain3.com"]
+
+[modules.mod_disco]
+  users_can_see_hidden_services = false
+
+[modules.mod_roster]
+  backend = "rdbms"
+
+[[host_config]]
+  host = "domain2.com"
+
+  [host_config.modules.mod_disco]
+    users_can_see_hidden_services = false
+
+  [host_config.modules.mod_stream_management]
+```
+
+## `host_config.acl`
+
+The access classes defined here are merged with the ones defined in the top-level [`acl`](acl.md) section - when a class is defined in both places, the result is a union of both classes.
+
+#### Example
+
+The `blocked` access class is extended for `host_config` by adding `hacker2`.
+
+```toml
+[general]
+  hosts = ["domain1.com", "domain2.com", "domain3.com"]
+
+[acl]
+  blocked = [
+    {user = "spammer"},
+    {user = "hacker1"}
+  ]
+
+[[host_config]]
+  host = "domain2.com"
+
+  [host_config.acl]
+    blocked = [
+      {user = "hacker2"}
+    ]
+```
+
+## `host_config.access`
+
+The access rules defined here are merged with the ones defined in the top-level [`access`](access.md) section:
+When a rule is defined in both places:
+
+* If the top-level rule ends with a catch-all clause `{acl = "all", value = "allow"}`, the resulting domain-specific rule has the clauses from **both** rules with the domain-specific clauses inserted after the top-level ones, but before the catch-all clause.
+* If the top-level rule does not end with a catch-all clause, the resulting domain-specific rule has the clauses from **both** rules with the domain-specific clauses inserted after the top-level ones.
+
+#### Example
+
+The `c2s` access rule defined at the top level allows anyone to connect.
+However, the rule for `domain2.com` is extended to prevent the `blocked` users from connecting:
+
+```toml
+[general]
+  hosts = ["domain1.com", "domain2.com", "domain3.com"]
+
+[access]
+  c2s = [
+    {acl = "admin", value = "allow"},
+    {acl = "all", value = "allow"}
+  ]
+
+[[host_config]]
+  host = "domain2.com"
+
+  [host_config.access]
+    c2s = [
+      {acl = "blocked", value = "deny"}
+    ]
+
+    register = [
+      {acl = "all", value = "deny"}
+    ]
+```
+
+The resulting rule for `domain2.com` could be written as:
+
+```toml
+c2s = [
+  {acl = "admin", value = "allow"},
+  {acl = "blocked", value = "deny"},
+  {acl = "all", value = "allow"}
+]
+```
+
+The `register` rule is defined only for `domain2.com`.
+
+**Note:** some access rules are checked outside of the context of any domain, e.g. the [access rule for external components](listen.md#listenserviceaccess) - defining them in `host_config` would have no effect.
+
+## `host_config.s2s`
+
+The options defined here override the ones defined in the top-level [`s2s`](s2s.md) section.
+The following options are allowed:
+
+* [`default_policy`](s2s.md#s2sdefault_policy)
+* [`host_policy`](s2s.md#s2shost_policy) - overrides the top-level setting host by host
+* [`shared`](s2s.md#s2sshared)
+* [`max_retry_delay`](s2s.md#s2smax_retry_delay)
+
+#### Example
+
+The `host_policy` option is changed for `domain2.com`:
+
+```toml
+[general]
+  hosts = ["domain1.com", "domain2.com", "domain3.com"]
+
+[s2s]
+  default_policy = "deny"
+
+  host_policy = [
+    {host = "good-xmpp.org", policy = "allow"},
+    {host = "bad-xmpp.org", policy = "deny"}
+  ]
+
+[[host_config]]
+  host = "domain2.com"
+
+  [host_config.s2s]
+    host_policy = [
+      {host = "bad-xmpp.org", policy = "allow"},
+      {host = "evil-xmpp.org", policy = "deny"}
+    ]
+```
+
+The resulting `host_policy` for `domain2.com` is the following:
+
+```toml
+host_policy = [
+  {host = "good-xmpp.org", policy = "allow"},
+  {host = "bad-xmpp.org", policy = "allow"},
+  {host = "evil-xmpp.org", policy = "deny"}
+]
+```
+
+The `default_policy` is still `deny`.

--- a/doc/advanced-configuration/host_config.md
+++ b/doc/advanced-configuration/host_config.md
@@ -52,27 +52,53 @@ The `hide_service_name` option is set to `false` only for `domain2.com`.
 
 ## `host_config.auth`
 
-This section completely overrides the top-level [`auth`](auth.md) section. All options are allowed.
+This section overrides the top-level [`auth`](auth.md) section, all options are allowed.
+It is recommended to repeat all top-level options in the domain-specific section as the rule is quite complicated:
+
+- If you specify any of the following options, **all** of the following options will be overridden:
+    - [`sasl_external`](auth.md#authsasl_external)
+    - [`password.*`](auth.md#password-related-options)
+    - [`scram_iterations`](auth.md#authscram_iterations)
+    - [`external.program`](../../authentication-methods/external/#authexternalprogram)
+    - [`ldap.*`](../../authentication-methods/ldap)
+    - [`jwt.*`](../../authentication-methods/jwt)
+    - [`riak.*`](../../authentication-methods/riak)
+    - [`http.*`](../../authentication-methods/http)
+- If you specify any of the following options, only these options will be overridden:
+    - [`methods`](auth.md#authmethods)
+    - [`sasl_mechanisms`](auth.md#authsasl_mechanisms)
+    - [`external.instances`](../../authentication-methods/external/#authexternalinstances)
+    - [`anonymous.*`](../../authentication-methods/anonymous)
 
 #### Example
 
-The intention here is to enable only the `SASL PLAIN` mechanism for `domain2.com`.
-To do this, we need to specify `methods` as well - otherwise there would be no authentication methods
-enabled for `domain2.com` as the entire `auth` section is replaced.
+In the example below the number of `scram_iterations` is increased for `domain2`.
+It is necessary to put the `password.hash` there as well, as otherwise it would be replaced with the default setting.
+However, specifying `methods` is not necessary as this value will not be changed.
 
 ```toml
 [general]
   hosts = ["domain1.com", "domain2.com", "domain3.com"]
 
 [auth]
-  methods = ["internal"]
+  methods = ["rdbms"]
+  password.hash = ["sha256"]
 
 [[host_config]]
   host = "domain2.com"
 
   [host_config.auth]
-    methods = ["internal"]
-    sasl_mechanisms = ["plain"]
+    methods = ["rdbms"]
+    password.hash = ["sha256"]
+    scram_iterations = 40_000
+```
+
+The last section would work the same without `methods`:
+
+```toml
+  [host_config.auth]
+    password.hash = ["sha256"]
+    scram_iterations = 40_000
 ```
 
 ## `host_config.modules`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ pages:
       - 'Options: Acl': 'advanced-configuration/acl.md'
       - 'Options: Access': 'advanced-configuration/access.md'
       - 'Options: S2S': 'advanced-configuration/s2s.md'
+      - 'Options: Host config': 'advanced-configuration/host_config.md'
       - 'TLS hardening': 'advanced-configuration/TLS-hardening.md'
       - 'Database backends configuration': 'advanced-configuration/database-backends-configuration.md'
       - 'Outgoing connections': 'advanced-configuration/outgoing-connections.md'

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -1921,8 +1921,8 @@ handler_for_host(Path) ->
     [<<"host_config">>, {host, Host} | Rest] = lists:reverse(Path),
     Handler = handler(lists:reverse(Rest)),
     fun(PathArg, ValueArg) ->
-            [F] = Handler(PathArg, ValueArg),
-            F(Host)
+            ConfigFunctions = Handler(PathArg, ValueArg),
+            lists:flatmap(fun(F) -> F(Host) end, ConfigFunctions)
     end.
 
 -spec key(toml_key(), path(), toml_value()) -> tuple() | toml_key().

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1258,6 +1258,10 @@ s2s_host_policy(_Config) ->
                <<"policy">> => <<"allow">>},
     eq_host_config([#local_config{key = {{s2s_host, <<"host1">>}, ?HOST}, value = allow}],
                   #{<<"s2s">> => #{<<"host_policy">> => [Policy]}}),
+    eq_host_config([#local_config{key = {{s2s_host, <<"host1">>}, ?HOST}, value = allow},
+                    #local_config{key = {{s2s_host, <<"host2">>}, ?HOST}, value = deny}],
+                  #{<<"s2s">> => #{<<"host_policy">> => [Policy, #{<<"host">> => <<"host2">>,
+                                                                   <<"policy">> => <<"deny">>}]}}),
     err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [maps:without([<<"host">>], Policy)]}}),
     err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [maps:without([<<"policy">>], Policy)]}}),
     err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [Policy#{<<"host">> => <<>>}]}}),
@@ -2899,8 +2903,8 @@ rdbms_opts() ->
 %% helpers for 'host_config' tests
 
 eq_host_config(Result, Config) ->
-    [F] = parse(Config), % check for all hosts
-    compare_config(Result, F(?HOST)),
+    ConfigFunctions = parse(Config), % check for all hosts
+    compare_config(Result, lists:flatmap(fun(F) -> F(?HOST) end, ConfigFunctions)),
     compare_config(Result, parse_host_config(Config)). % Check for a single host
 
 eq_host_or_global(ResultF, Config) ->


### PR DESCRIPTION
Document the `host_config` section.

Fix the 'scope' definition in the docs as well.