### PR TITLE
Set pm/muc sections to false by default for TOML in mod_mam_meta

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -622,7 +622,13 @@ service_opt([<<"tracking_id">>, <<"service_mongoose_system_metrics">>|_],  V) ->
 -spec process_module(path(), toml_section()) -> [option()].
 process_module([Mod|_] = Path, Opts) ->
     %% Sort option keys to ensure options could be matched in tests
-    [{b2a(Mod), lists:sort(parse_section(Path, Opts))}].
+    post_process_module(b2a(Mod), parse_section(Path, Opts)).
+
+post_process_module(mod_mam_meta, Opts) ->
+    %% Disable the archiving by default
+    [{mod_mam_meta, lists:sort(defined_or_false(muc, defined_or_false(pm, Opts)))}];
+post_process_module(Mod, Opts) ->
+    [{Mod, lists:sort(Opts)}].
 
 %% path: (host_config[].)modules.*.*
 -spec module_opt(path(), toml_value()) -> [option()].
@@ -719,13 +725,9 @@ module_opt([<<"ram_key_size">>, <<"mod_keystore">>|_], V) ->
 module_opt([<<"keys">>, <<"mod_keystore">>|_] = Path, V) ->
     Keys = parse_list(Path, V),
     [{keys, Keys}];
-module_opt([<<"pm">>, <<"mod_mam_meta">>|_], false) ->
-    [];
 module_opt([<<"pm">>, <<"mod_mam_meta">>|_] = Path, V) ->
     PM = parse_section(Path, V),
     [{pm, PM}];
-module_opt([<<"muc">>, <<"mod_mam_meta">>|_], false) ->
-    [];
 module_opt([<<"muc">>, <<"mod_mam_meta">>|_] = Path, V) ->
     Muc = parse_section(Path, V),
     [{muc, Muc}];
@@ -1887,3 +1889,11 @@ key(Key, _Path, _) -> Key.
 -spec item_key(path(), toml_value()) -> tuple() | item.
 item_key([<<"host_config">>], #{<<"host">> := Host}) -> {host, Host};
 item_key(_, _) -> item.
+
+defined_or_false(Key, Opts) ->
+    case proplists:is_defined(Key, Opts) of
+        true ->
+            [];
+        false ->
+            [{Key, false}]
+    end ++ Opts.


### PR DESCRIPTION
This PR addresses "consistency for mod_mam_meta" configuration.