### PR TITLE
add mod_extdisco in TOML format

### DIFF
--- a/big_tests/tests/extdisco_SUITE.erl
+++ b/big_tests/tests/extdisco_SUITE.erl
@@ -73,7 +73,7 @@ init_per_group(multiple_extdisco_configured, Config) ->
     ExternalServices = [stun_service(), stun_service(), turn_service()],
     set_external_services(ExternalServices, Config);
 init_per_group(external_service_required_elements_configured, Config) ->
-    ExternalServices = [{ftp, [{host, "3.3.3.3"}]}],
+    ExternalServices = [[{type, ftp},{host, "3.3.3.3"}]],
     set_external_services(ExternalServices, Config);
 init_per_group(_GroupName, Config) ->
    Config.
@@ -297,22 +297,20 @@ external_service_required_elements_configured(Config) ->
 %%-----------------------------------------------------------------
 
 stun_service() ->
-    {stun, [
+      [{type, stun},
        {host, "1.1.1.1"},
-       {port, "3478"},
+       {port, 3478},
        {transport, "udp"},
        {username, "username"},
-       {password, "secret"}
-    ]}.
+       {password, "secret"}].
 
 turn_service() ->
-    {turn, [
+       [{type, turn},
         {host, "2.2.2.2"},
-        {port, "3478"},
+        {port, 3478},
         {transport, "tcp"},
         {username, "username"},
-        {password, "secret"}
-    ]}.
+        {password, "secret"}].
 
 domain() ->
     ct:get_config({hosts, mim, domain}).

--- a/doc/modules/mod_extdisco.md
+++ b/doc/modules/mod_extdisco.md
@@ -3,9 +3,7 @@ Implements [XEP-0215: External Service Discovery](http://xmpp.org/extensions/xep
 The main use-case is to help discover STUN/TURN servers to allow for negotiating media exchanges.
 
 ### Options
-* **type** (atom, default: unset) - service type
-
-#### Service Options
+* **type** (atom, default: unset) - Service type.
 * **host** (string, required, default: unset): Hostname or an IP address where the service is hosted.
 * **port** (string, recommended, default: unset): The communications port to be used at the host.
 * **transport** (string, optional, default: unset): The underlying transport protocol to be used when communicating with the service.
@@ -18,17 +16,15 @@ The main use-case is to help discover STUN/TURN servers to allow for negotiating
 
 ```Erlang
 {mod_extdisco, [
-    {stun, [
-        {host, "127.0.0.1"},
-        {port, "3478"},
-        {transport, "udp"},
-        {username, "username"},
-        {password, "secret"}
-    ]},
-    {turn, [
-        {host, "hostname"},
-        {port, "3478"},
-        {transport, "tcp"},
-    ]}
+    [{type, stun},
+     {host, "127.0.0.1"},
+     {port, "3478"},
+     {transport, "udp"},
+     {username, "username"},
+     {password, "secret"}],
+    [{type, turn},
+     {host, "hostname"},
+     {port, "3478"},
+     {transport, "tcp"}]
 ]}.
 ```

--- a/doc/modules/mod_extdisco.md
+++ b/doc/modules/mod_extdisco.md
@@ -3,28 +3,68 @@ Implements [XEP-0215: External Service Discovery](http://xmpp.org/extensions/xep
 The main use-case is to help discover STUN/TURN servers to allow for negotiating media exchanges.
 
 ### Options
-* **type** (atom, default: unset) - Service type.
-* **host** (string, required, default: unset): Hostname or an IP address where the service is hosted.
-* **port** (string, recommended, default: unset): The communications port to be used at the host.
-* **transport** (string, optional, default: unset): The underlying transport protocol to be used when communicating with the service.
-     * **Valid values:** `udp, tcp`
-* **username** (string, optional, default: unset): A service-generated username for use at the service.
-* **password** (string, optional, default: unset): A service-generated password for use at the service.
 
+#### `modules.mod_extdisco.service.type`
+* **Syntax:** string
+* **Default:** none, this option is required
+* **Example:** `type = "stun"`
+
+Service type, common values are `"stun"`, `"turn"`, `"ftp"`.
+
+#### `modules.mod_extdisco.service.host`
+* **Syntax:** string
+* **Default:** none, this option is required
+* **Example:** `host = "192.168.0.2"`
+
+Hostname or an IP address where the service is hosted.
+
+#### `modules.mod_extdisco.service.port`
+* **Syntax:** string
+* **Default:** none, this option is recommended
+* **Example:** `port = "3478"`
+
+The communications port to be used at the host.
+
+#### `modules.mod_extdisco.service.transport`
+* **Syntax:** string, one of `"udp"`, `"tcp"`
+* **Default:** none, this option is optional
+* **Example:** `transport = "udp"`
+
+The underlying transport protocol to be used when communicating with the service.
+
+#### `modules.mod_extdisco.service.username`
+* **Syntax:** string
+* **Default:** none, this option is optional
+* **Example:** `username = "username"`
+
+A service-generated username for use at the service.
+
+#### `modules.mod_extdisco.service.password`
+* **Syntax:** string
+* **Default:** none, this option is optional
+* **Example:** `password = "password"`
+
+A service-generated password for use at the service.
 
 ### Example Configuration
 
-```Erlang
-{mod_extdisco, [
-    [{type, stun},
-     {host, "127.0.0.1"},
-     {port, "3478"},
-     {transport, "udp"},
-     {username, "username"},
-     {password, "secret"}],
-    [{type, turn},
-     {host, "hostname"},
-     {port, "3478"},
-     {transport, "tcp"}]
-]}.
+```toml
+[modules.mod_extdisco]
+  [[modules.mod_extdisco.service]]
+    type = "stun"
+    host = "127.0.0.1"
+    port = 3478
+    transport = "udp"
+    username = "username"
+    password = "password"
+  [[modules.mod_extdisco.service]]
+    type = "stun"
+    host = "stun.host.com"
+    port = 3478
+    transport = "tcp"
+    username = "username2"
+    password = "password2"
+  [[modules.mod_extdisco.service]]
+    type = "turn"
+    host = "turn.host.com"
 ```

--- a/rel/files/mongooseim.cfg
+++ b/rel/files/mongooseim.cfg
@@ -692,13 +692,12 @@
   {{{mod_amp}}}
   {mod_disco, [{users_can_see_hidden_services, false}]},
 % {mod_extdisco, [
-%     {stun, [
+%        [{type, stun},
 %         {host, "127.0.0.1"},
 %         {port, "3478"},
 %         {transport, "udp"},
 %         {username, "username"},
-%         {password, "secret"}
-%         ]}
+%         {password, "secret"}]
 %   ]},
   {mod_commands, []},
   {mod_muc_commands, []},

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -1,6 +1,6 @@
 -module(mongoose_config_validator_toml).
 
--export([validate/2]).
+-export([validate/2, validate_port/1]).
 
 -include("mongoose.hrl").
 -include("ejabberd_config.hrl").
@@ -779,6 +779,24 @@ validate([<<"cache_life_time">>, <<"mod_caps">>, <<"modules">>|_],
 validate([<<"cache_size">>, <<"mod_caps">>, <<"modules">>|_],
          [{cache_size, V}]) ->
     validate_non_negative_integer(V);
+validate([<<"type">>, _, <<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
+         [{type, V}]) ->
+    validate_non_empty_atom(V);
+validate([<<"host">>, _,<<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
+         [{host, V}]) ->
+    validate_non_empty_list(V);
+validate([<<"port">>, _,<<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
+         [{port, V}]) ->
+    validate_port(V);
+validate([<<"transport">>,_, <<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
+         [{transport, V}]) ->
+    validate_non_empty_list(V);
+validate([<<"username">>, _,<<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
+         [{username, V}]) ->
+    validate_non_empty_list(V);
+validate([<<"password">>, _,<<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
+         [{password, V}]) ->
+    validate_non_empty_list(V);
 validate([<<"backend">>, <<"mod_http_upload">>, <<"modules">>|_],
          [{backend, V}]) ->
     validate_backend(mod_http_upload, V);

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -1,6 +1,6 @@
 -module(mongoose_config_validator_toml).
 
--export([validate/2, validate_port/1]).
+-export([validate/2]).
 
 -include("mongoose.hrl").
 -include("ejabberd_config.hrl").

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -3082,8 +3082,6 @@ handle_db_server_opt(V1, V2) -> ?eq(V1, V2).
 
 handle_modules({Name, Opts}, {Name2, Opts2}) ->
     ?eq(Name, Name2),
-    ct:log("N1:~p~nN2:~p", [Name, Name2]),
-    ct:log("O1:~p~nO2:~p", [Opts, Opts2]),
     compare_unordered_lists(Opts, Opts2, fun handle_module_options/2).
 
 handle_module_options({configs, [Configs1]}, {configs, [Configs2]}) ->
@@ -3101,13 +3099,11 @@ compare_unordered_lists(L1, L2) ->
 compare_unordered_lists(L1, L2, F) ->
     SL1 = lists:sort(L1),
     SL2 = lists:sort(L2),
-    ct:log("SL1:~p~nSL2:~p", [SL1, SL2]),
     compare_ordered_lists(SL1, SL2, F).
 
 compare_ordered_lists([H1|T1], [H1|T2], F) ->
     compare_ordered_lists(T1, T2, F);
 compare_ordered_lists([H1|T1], [H2|T2], F) ->
-    ct:log("H1:~p~nH2:~p", [H1, H2]),
     try F(H1, H2)
     catch C:R:S ->
             ct:fail({C, R, S})
@@ -3127,7 +3123,6 @@ test_equivalence_between_files(Config, File1, File2) ->
     Hosts2 = mongoose_config_parser:state_to_host_opts(State2),
     Opts2 = mongoose_config_parser:state_to_opts(State2),
     ?eq(Hosts1, Hosts2),
-    % ct:log("Opts1:~p~nOpts2:~p", [Opts1, Opts2]),
     compare_unordered_lists(lists:filter(fun filter_config/1, Opts1), Opts2,
                             fun handle_config_option/2).
 

--- a/test/config_parser_SUITE_data/modules.cfg
+++ b/test/config_parser_SUITE_data/modules.cfg
@@ -63,6 +63,22 @@
         ]}
     ]}
   ]},
+  {mod_extdisco, [
+      [{host, "stun1"},
+       {password, "password"},
+       {port, 3478},
+       {transport, "udp"},
+       {type, stun},
+       {username, "username"}],
+      [{host, "stun2"},
+       {password, "password"},
+       {port, 2222},
+       {transport, "tcp"},
+       {type, stun},
+       {username, "username"}],
+      [{host, "192.168.0.1"},
+       {type, turn}]
+  ]},
   {mod_http_upload, [
         {host, "upload.@HOST@"},
         {backend, s3},
@@ -223,7 +239,7 @@
                                       {stale_h_repeat_after, 1800},
                                       {stale_h_geriatric, 3600}]}
                           ]},
-    {mod_vcard, [ 
+    {mod_vcard, [
               {matches, 1},
               {search, true},
               {host, "directory.example.com"},

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -39,7 +39,7 @@
     {module = ["mod_muc", "mod_disco"], name = "friendly-spirits", urls = ["spirit1@localhost", "spirit2@localhost"]}
   ]
   users_can_see_hidden_services = true
-  
+
 [modules.mod_event_pusher]
   backend.sns.access_key_id = "AKIAIOSFODNN7EXAMPLE"
   backend.sns.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
@@ -59,7 +59,7 @@
   backend.push.wpool.workers = 200
   backend.push.plugin_module = "mod_event_pusher_push_plugin_defaults"
   backend.push.virtual_pubsub_hosts = ["host1", "host2"]
-  
+
   backend.http.pool_name = "http_pool"
   backend.http.path = "/notifications"
   backend.http.callback_module = "mod_event_pusher_http_defaults"
@@ -73,13 +73,32 @@
   backend.rabbit.groupchat_msg_exchange.sent_topic = "groupchat_msg_sent"
   backend.rabbit.groupchat_msg_exchange.recv_topic = "groupchat_msg_recv"
 
+[modules.mod_extdisco]
+  [[modules.mod_extdisco.service]]
+    type = "stun"
+    host = "stun1"
+    port = 3478
+    transport = "udp"
+    username = "username"
+    password = "password"
+  [[modules.mod_extdisco.service]]
+    type = "stun"
+    host = "stun2"
+    port = 2222
+    transport = "tcp"
+    username = "username"
+    password = "password"
+  [[modules.mod_extdisco.service]]
+    type = "turn"
+    host = "192.168.0.1"
+
 [modules.mod_http_upload]
   host = "upload.@HOST@"
   backend = "s3"
   expiration_time = 120
   s3.bucket_url = "https://s3-eu-west-1.amazonaws.com/mybucket"
   s3.region = "eu-west-1"
-  s3.add_acl = true     
+  s3.add_acl = true
   s3.access_key_id = "AKIAIOSFODNN7EXAMPLE"
   s3.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
@@ -112,7 +131,7 @@
 
 [modules.mod_keystore]
   ram_key_size = 1000
-  
+
   [[modules.mod_keystore.keys]]
     name = "access_secret"
     type = "ram"
@@ -150,7 +169,7 @@
   access_create = "muc_create"
   http_auth_pool = "my_auth_pool"
   default_room.password_protected = true
-  
+
   [[modules.mod_muc.default_room.affiliations]]
     user = "alice"
     server = "localhost"
@@ -181,12 +200,12 @@
   max_occupants = 50
   rooms_per_page = 5
   rooms_in_rosters = true
-  
-  [[modules.mod_muc_light.config_schema]] 
+
+  [[modules.mod_muc_light.config_schema]]
     field = "roomname"
     value = "The Room"
-  
-  [[modules.mod_muc_light.config_schema]] 
+
+  [[modules.mod_muc_light.config_schema]]
     field = "display-lines"
     value = 30
     internal_key = "display_lines"
@@ -219,7 +238,7 @@
   pool_name = "mongoose_push_http"
   api_version = "v3"
   max_http_connections = 100
-   
+
 [modules.mod_register]
   welcome_message = {subject = "Subject", body = "Body"}
   access = "all"
@@ -228,10 +247,10 @@
 
   [[modules.mod_revproxy.routes]]
     host = "www.erlang-solutions.com"
-    path = "/admin" 
+    path = "/admin"
     method = "_"
     upstream = "https://www.erlang-solutions.com/"
-    
+
   [[modules.mod_revproxy.routes]]
     host = ":var.com"
     path = "/:var"
@@ -265,7 +284,7 @@
   stale_h.repeat_after = 1800
   stale_h.geriatric = 3600
 
-[modules.mod_vcard] 
+[modules.mod_vcard]
   matches = 1
   search = true
   host = "directory.example.com"
@@ -283,7 +302,7 @@
   [[modules.mod_vcard.ldap_search_fields]]
     search_field = "User"
     ldap_field = "%u"
-  
+
   [[modules.mod_vcard.ldap_search_fields]]
     search_field = "Full Name"
     ldap_field = "displayName"


### PR DESCRIPTION
This PR adds `mod_extdisco` in TOML format. The changes include:
* adding module in parser and validator
* modify the config format in cfg
* tests for config_parser_SUITE
* documentation update to TOML format

