### PR TITLE
Unify does_user_exist API

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -198,12 +198,12 @@ null_password(Config) ->
     {username, Name} = lists:keyfind(username, 1, Details),
     {server, Server} = lists:keyfind(server, 1, Details),
     escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Response),
-    false = rpc(mim(), ejabberd_auth, is_user_exists, [Name, Server]).
+    false = rpc(mim(), ejabberd_auth, does_user_exist, [Name, Server]).
 
 check_unregistered(Config) ->
     [{_, UserSpec}] = escalus_users:get_users([bob]),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),
-    false = rpc(mim(), ejabberd_auth, is_user_exists, [Username, Server]).
+    false = rpc(mim(), ejabberd_auth, does_user_exist, [Username, Server]).
 
 bad_request_registration_cancelation(Config) ->
 
@@ -373,7 +373,7 @@ bad_cancelation_stanza() ->
 user_exists(Name, Config) ->
     {Name, Client} = escalus_users:get_user_by_name(Name),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, Client),
-    rpc(mim(), ejabberd_auth, is_user_exists, [Username, Server]).
+    rpc(mim(), ejabberd_auth, does_user_exist, [Username, Server]).
 
 reload_mod_register_option(Config, Key, Value) ->
     Host = domain(),

--- a/doc/modules/mod_offline_stub.md
+++ b/doc/modules/mod_offline_stub.md
@@ -1,7 +1,7 @@
 ### Module Description
 
 RFC 6121 requires a `<service-unavailable/>` stanza error to be sent to a user messaging an unavailable recipient if the message is not stored for delayed delivery (i.e. as an "offline message").
-If the recipient exists (i.e. auth module returns `true` from `is_user_exists`), `mod_mam` stores the message, but <service-unavailable/> is still returned. This is not compliant with the RFC.
+If the recipient exists (i.e. auth module returns `true` from `does_user_exist`), `mod_mam` stores the message, but <service-unavailable/> is still returned. This is not compliant with the RFC.
 This module prevents returning <service-unavailable/>.
 Please note that `mod_offline_stub` is not tightly coupled with `mod_mam`. It can be used as a standalone extension, if the specific application requires it.
 

--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -111,7 +111,7 @@ set_password(User, Host, Password) ->
 -spec check_password(jid:user(), jid:server(), binary()) ->  {Res, string()} when
     Res :: ok | incorrect | user_does_not_exist.
 check_password(User, Host, Password) ->
-    case ejabberd_auth:is_user_exists(User, Host) of
+    case ejabberd_auth:does_user_exist(User, Host) of
         true ->
             case ejabberd_auth:check_password(User, Host, Password) of
                 true ->
@@ -130,7 +130,7 @@ check_password(User, Host, Password) ->
 -spec check_account(jid:user(), jid:server()) -> {Res, string()} when
     Res :: ok | user_does_not_exist.
 check_account(User, Host) ->
-    case ejabberd_auth:is_user_exists(User, Host) of
+    case ejabberd_auth:does_user_exist(User, Host) of
         true ->
             {ok, io_lib:format("User ~s@~s exists", [User, Host])};
         false ->

--- a/src/admin_extra/service_admin_extra_gdpr.erl
+++ b/src/admin_extra/service_admin_extra_gdpr.erl
@@ -72,7 +72,7 @@ to_csv_file(Filename, DataSchema, DataRows, TmpDir) ->
 
 -spec user_exists(gdpr:username(), gdpr:domain()) -> boolean().
 user_exists(Username, Domain) ->
-    ejabberd_auth:is_user_exists(Username, Domain).
+    ejabberd_auth:does_user_exist(Username, Domain).
 
 -spec make_tmp_dir() -> file:name().
 make_tmp_dir() ->

--- a/src/admin_extra/service_admin_extra_last.erl
+++ b/src/admin_extra/service_admin_extra_last.erl
@@ -61,7 +61,7 @@ commands() ->
 -spec set_last(jid:user(), jid:server(), _, _) -> {Res, string()} when
     Res :: ok | user_does_not_exist.
 set_last(User, Server, Timestamp, Status) ->
-    case ejabberd_auth:is_user_exists(User, Server) of
+    case ejabberd_auth:does_user_exist(User, Server) of
         true ->
             mod_last:store_last_info(jid:nodeprep(User), jid:nameprep(Server), Timestamp, Status),
             {ok, io_lib:format("Last activity for user ~s@~s is set as ~B with status ~s",

--- a/src/admin_extra/service_admin_extra_private.erl
+++ b/src/admin_extra/service_admin_extra_private.erl
@@ -68,7 +68,7 @@ commands() ->
 -spec private_get(jid:user(), jid:server(), binary(), binary()) ->
     {error, string()} | string().
 private_get(Username, Host, Element, Ns) ->
-    case ejabberd_auth:is_user_exists(Username, Host) of
+    case ejabberd_auth:does_user_exist(Username, Host) of
         true ->
             do_private_get(Username, Host, Element, Ns);
         false ->
@@ -108,7 +108,7 @@ private_set(Username, Host, ElementString) ->
 
 
 private_set2(Username, Host, Xml) ->
-    case ejabberd_auth:is_user_exists(Username, Host) of
+    case ejabberd_auth:does_user_exist(Username, Host) of
         true ->
             do_private_set2(Username, Host, Xml);
         false ->

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -164,7 +164,7 @@ commands() ->
                      Subs :: subs()) -> {Res, string()} when
     Res :: user_doest_not_exist | error | bad_subs | ok.
 add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
-    case ejabberd_auth:is_user_exists(LocalUser, LocalServer) of
+    case ejabberd_auth:does_user_exist(LocalUser, LocalServer) of
         true ->
             case subscribe(LocalUser, LocalServer, User, Server, Nick, Group, Subs, []) of
                 {atomic, _} ->
@@ -213,7 +213,7 @@ subscribe(LU, LS, User, Server, Nick, Group, SubscriptionS, _Xattrs) ->
                         Server :: jid:server()) -> {Res, string()} when
     Res :: ok | error | user_does_not_exist.
 delete_rosteritem(LocalUser, LocalServer, User, Server) ->
-    case ejabberd_auth:is_user_exists(LocalUser, LocalServer) of
+    case ejabberd_auth:does_user_exist(LocalUser, LocalServer) of
         true ->
             case unsubscribe(LocalUser, LocalServer, User, Server) of
                 {atomic, ok} ->

--- a/src/admin_extra/service_admin_extra_vcard.erl
+++ b/src/admin_extra/service_admin_extra_vcard.erl
@@ -123,7 +123,7 @@ commands() ->
 -spec get_vcard(jid:user(), jid:server(), any())
                -> {error, string()} | [binary()].
 get_vcard(User, Host, Name) ->
-    case ejabberd_auth:is_user_exists(User, Host) of
+    case ejabberd_auth:does_user_exist(User, Host) of
         true ->
             get_vcard_content(User, Host, [Name]);
         false ->
@@ -133,7 +133,7 @@ get_vcard(User, Host, Name) ->
 -spec get_vcard(jid:user(), jid:server(), any(), any())
                -> {error, string()} | [binary()].
 get_vcard(User, Host, Name, Subname) ->
-    case ejabberd_auth:is_user_exists(User, Host) of
+    case ejabberd_auth:does_user_exist(User, Host) of
         true ->
             get_vcard_content(User, Host, [Name, Subname]);
         false ->
@@ -143,7 +143,7 @@ get_vcard(User, Host, Name, Subname) ->
 -spec set_vcard(jid:user(), jid:server(), [binary()],
                 binary() | [binary()]) -> {ok, string()} | {user_does_not_exist, string()}.
 set_vcard(User, Host, Name, SomeContent) ->
-    case ejabberd_auth:is_user_exists(User, Host) of
+    case ejabberd_auth:does_user_exist(User, Host) of
         true ->
             set_vcard_content(User, Host, [Name], SomeContent);
         false ->
@@ -153,7 +153,7 @@ set_vcard(User, Host, Name, SomeContent) ->
 -spec set_vcard(jid:user(), jid:server(), [binary()], [binary()],
                 binary() | [binary()]) -> {ok, string()} | {user_does_not_exist, string()}.
 set_vcard(User, Host, Name, Subname, SomeContent) ->
-    case ejabberd_auth:is_user_exists(User, Host) of
+    case ejabberd_auth:does_user_exist(User, Host) of
         true ->
             set_vcard_content(User, Host, [Name, Subname], SomeContent);
         false ->

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -193,7 +193,7 @@ get_password_s(LUser, LServer) ->
 -spec does_user_exist(LUser :: jid:luser(),
                      LServer :: jid:lserver()) -> boolean() | {error, atom()}.
 does_user_exist(LUser, LServer) ->
-    try extauth:is_user_exists(LUser, LServer) of
+    try extauth:does_user_exist(LUser, LServer) of
         Res -> Res
     catch
         _:Error -> {error, Error}

--- a/src/auth/extauth.erl
+++ b/src/auth/extauth.erl
@@ -33,7 +33,7 @@
          set_password/3,
          try_register/3,
          remove_user/2,
-         is_user_exists/2]).
+         does_user_exist/2]).
 
 -include("mongoose.hrl").
 
@@ -90,8 +90,8 @@ check_password(User, Server, Password) ->
     call_port(Server, [<<"auth">>, User, Server, Password]).
 
 
--spec is_user_exists(jid:user(), jid:server()) -> boolean().
-is_user_exists(User, Server) ->
+-spec does_user_exist(jid:user(), jid:server()) -> boolean().
+does_user_exist(User, Server) ->
     call_port(Server, [<<"isuser">>, User, Server]).
 
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -323,7 +323,7 @@ remove_info(JID, Key) ->
       Type :: any(),
       Reason :: any().
 check_in_subscription(Acc, User, Server, _JID, _Type, _Reason) ->
-    case ejabberd_auth:is_user_exists(User, Server) of
+    case ejabberd_auth:does_user_exist(User, Server) of
         true ->
             Acc;
         false ->

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -174,7 +174,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 -spec does_stored_user_exist(jid:luser(), jid:lserver()) -> boolean().
 does_stored_user_exist(LUser, LServer) ->
-    ejabberd_auth:is_user_exists(LUser, LServer)
+    ejabberd_auth:does_user_exist(LUser, LServer)
     andalso not is_anonymous_user(LUser, LServer).
 
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -465,10 +465,10 @@ handle_get_message_form(_From=#jid{lserver = Host}, _ArcJID=#jid{}, IQ=#iq{}) ->
 
 determine_amp_strategy(Strategy = #amp_strategy{deliver = Deliver},
                        FromJID, ToJID, Packet, initial_check) ->
-    #jid{luser = LUser, lserver = LServer} = ToJID,
+    #jid{lserver = LServer} = ToJID,
     ShouldBeStored = is_archivable_message(LServer, incoming, Packet)
         andalso is_interesting(ToJID, FromJID)
-        andalso ejabberd_auth:is_user_exists(LUser, LServer),
+        andalso ejabberd_auth:does_user_exist(ToJID),
     case ShouldBeStored of
         true -> Strategy#amp_strategy{deliver = amp_deliver_strategy(Deliver)};
         false -> Strategy

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -430,8 +430,8 @@ process_sm_iq_info(From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl} =
                       To :: jid:jid(),
                       Node :: binary(),
                       Lang :: ejabberd:lang()) -> [exml:element()].
-get_sm_identity(Acc, _From, #jid{luser = LUser, lserver = LServer}, _Node, _Lang) ->
-    Acc ++ case ejabberd_auth:is_user_exists(LUser, LServer) of
+get_sm_identity(Acc, _From, JID = #jid{}, _Node, _Lang) ->
+    Acc ++ case ejabberd_auth:does_user_exist(JID) of
                true ->
                    [#xmlel{name = <<"identity">>,
                            attrs = [{<<"category">>, <<"account">>},

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -199,8 +199,8 @@ process_iq_get(From, _To, #iq{lang = Lang, sub_el = Child} = IQ, _Source) ->
     true = is_query_element(Child),
     {_IsRegistered, UsernameSubels, QuerySubels} =
         case From of
-            #jid{user = User, lserver = Server} ->
-                case ejabberd_auth:is_user_exists(User, Server) of
+            JID = #jid{user = User} ->
+                case ejabberd_auth:does_user_exist(JID) of
                     true ->
                         {true, [#xmlcdata{content = User}],
                          [#xmlel{name = <<"registered">>}]};

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -411,7 +411,7 @@ search_group_info(State, Group) ->
                         end
                 end,
     AuthChecker = case State#state.auth_check of
-                      true -> fun ejabberd_auth:is_user_exists/2;
+                      true -> fun ejabberd_auth:does_user_exist/2;
                       _ -> fun (_U, _S) -> true end
                   end,
     Host = State#state.host,

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -148,7 +148,7 @@ get_vcard(LUser, LServer) ->
     Proc = gen_mod:get_module_proc(LServer, ?PROCNAME),
     {ok, State} = gen_server:call(Proc, get_state),
     LServer = State#state.serverhost,
-    case ejabberd_auth:is_user_exists(LUser, LServer) of
+    case ejabberd_auth:does_user_exist(LUser, LServer) of
         true ->
             VCardMap = State#state.vcard_map,
             case find_ldap_user(LUser, State) of
@@ -408,7 +408,7 @@ attrs_to_item_xml(Attrs, #state{uids = UIDs} = State) ->
 make_user_item_if_exists(Username, Attrs,
                          #state{serverhost = LServer, search_reported = SearchReported,
                                 vcard_map = VCardMap, binary_search_fields = BinFields}) ->
-    case ejabberd_auth:is_user_exists(Username, LServer) of
+    case ejabberd_auth:does_user_exist(Username, LServer) of
         true ->
             RFields = lists:map(fun ({_, VCardName}) ->
                                         {VCardName, map_vcard_attr(VCardName, Attrs, VCardMap,

--- a/src/mongoose_api_users.erl
+++ b/src/mongoose_api_users.erl
@@ -82,7 +82,7 @@ put_user(Data, Bindings) ->
 delete_user(Bindings) ->
     Host = gen_mod:get_opt(host, Bindings),
     Username = gen_mod:get_opt(username, Bindings),
-    case ejabberd_auth:is_user_exists(Username, Host) of
+    case ejabberd_auth:does_user_exist(Username, Host) of
         true ->
             maybe_delete_user(Username, Host);
         false ->

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -252,8 +252,7 @@ srv_name(Host) ->
 
 determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
                        _FromJID, ToJID, _Packet, initial_check) ->
-    #jid{luser = LUser, lserver = LServer} = ToJID,
-    ShouldBeStored = ejabberd_auth:is_user_exists(LUser, LServer),
+    ShouldBeStored = ejabberd_auth:does_user_exist(ToJID),
     case ShouldBeStored of
         true -> Strategy#amp_strategy{deliver = [stored, none]};
         false -> Strategy

--- a/src/offline/mod_offline_stub.erl
+++ b/src/offline/mod_offline_stub.erl
@@ -10,7 +10,7 @@
 %%%           if the message is not stored for delayed delivery
 %%%           (i.e. as an "offline message").
 %%%           If the recipient exists (i.e. auth module returns `true`
-%%%           from `is_user_exists`) mod_mam stores the message,
+%%%           from `does_user_exist`) mod_mam stores the message,
 %%%           but <service-unavailable/> is still returned,
 %%%           what is not compliant with the RFC.
 %%%

--- a/src/sasl/cyrsasl_anonymous.erl
+++ b/src/sasl/cyrsasl_anonymous.erl
@@ -49,7 +49,7 @@ mech_step(#state{creds = Creds}, _ClientIn) ->
     User = <<(mongoose_bin:gen_from_crypto())/binary,
              (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
     %% Checks that the username is available
-    case ejabberd_auth:is_user_exists(User, mongoose_credentials:lserver(Creds)) of
+    case ejabberd_auth:does_user_exist(User, mongoose_credentials:lserver(Creds)) of
         true  -> {error, <<"not-authorized">>};
         false -> {ok, mongoose_credentials:extend(Creds, [{username, User},
                                                           {auth_module, ?MODULE}])}

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -45,7 +45,7 @@ all_tests() ->
      set_password,
      try_register,
      get_password,
-     is_user_exists,
+     does_user_exist,
      remove_user,
      supported_sasl_mechanisms
     ].
@@ -196,7 +196,7 @@ get_password(_Config) ->
     false = ejabberd_auth_http:get_password(<<"anakin">>, ?DOMAIN1),
     <<>> = ejabberd_auth_http:get_password_s(<<"anakin">>, ?DOMAIN1).
 
-is_user_exists(_Config) ->
+does_user_exist(_Config) ->
     true = ejabberd_auth_http:does_user_exist(<<"alice">>, ?DOMAIN1),
     false = ejabberd_auth_http:does_user_exist(<<"madhatter">>, ?DOMAIN1).
 

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -29,7 +29,7 @@ generic_tests() ->
      set_password,
      try_register,
      get_password,
-     is_user_exists,
+     does_user_exist,
      remove_user,
      get_vh_registered_users_number,
      get_vh_registered_users,
@@ -122,7 +122,7 @@ get_password(_Config) ->
     false = ejabberd_auth_jwt:get_password(<<"anaking">>, ?DOMAIN1),
     <<>> = ejabberd_auth_jwt:get_password_s(<<"anakin">>, ?DOMAIN1).
 
-is_user_exists(_Config) ->
+does_user_exist(_Config) ->
     true = ejabberd_auth_jwt:does_user_exist(<<"madhatter">>, ?DOMAIN1).
 
 % remove_user/2,3


### PR DESCRIPTION
Up to now, in ejabberd_auth, we've had two almost identical functions,
`is_user_exists` and `does_user_exist`. This is redundant and confusing,
so I've just default back to an overloaded `does_user_exist`, where one
takes a full JID, and the other takes a username and server and creates
a JID and calls the first. The goal would be to eventually get rid of
the non-JID one and use only typed data-structures.