### PR TITLE
Toml/doc REST API update

### DIFF
--- a/doc/advanced-configuration/listen.md
+++ b/doc/advanced-configuration/listen.md
@@ -419,7 +419,7 @@ There are the following options for each of the HTTP listeners:
     These types are described below in more detail.
     The double-bracket syntax is used because there can be multiple handlers of a given type, so for each type there is a TOML array of one or more tables (subsections).
 
-* **Default:** there is no default, all handlers need to be specified explicitely.
+* **Default:** there is no default, all handlers need to be specified explicitly.
 * **Example:** two handlers, one for BOSH and one for WebSockets
 ```toml
   [[listen.http.handlers.mod_bosh]]

--- a/doc/rest-api/Administration-backend.md
+++ b/doc/rest-api/Administration-backend.md
@@ -10,7 +10,7 @@ Commands used by the REST API are provided by modules:
 
 `mod_muc_light_commands` - same but for rooms based on the muc-light protocol.
 
-To activate those commands, put modules you need into the `mongooseim.toml` file:
+To activate those commands, put the modules you need into the `mongooseim.toml` file:
 
 ```toml
   [modules.mod_commands]
@@ -21,7 +21,7 @@ To activate those commands, put modules you need into the `mongooseim.toml` file
 
 ```
 
-You also have to hook `mongoose_api_admin` module to an HTTP endpoint as described
+You also have to hook the `mongoose_api_admin` module to an HTTP endpoint as described
 in the [admin REST API handlers configuration](../advanced-configuration/listen.md#handler-types-rest-api-admin-mongoose_api_admin)
 section of the [listeners](../advanced-configuration/listen.md) documentation.
 

--- a/doc/rest-api/Administration-backend.md
+++ b/doc/rest-api/Administration-backend.md
@@ -4,32 +4,26 @@
 
 Commands used by the REST API are provided by modules:
 
-`mod_commands` - provides general purpose commands: both user-like (f.e. sending a message and retrieving messages from the archive) and administration-like (f.e. create/delete a user and change the password)
+`mod_commands` - provides general purpose commands: both user-like (e.g. sending a message and retrieving messages from the archive) and administration-like (e.g. create/delete a user and change the password).
 
 `mod_muc_commands` - commands related to Multi-user Chat rooms: create a room, invite users, send a message etc.
 
 `mod_muc_light_commands` - same but for rooms based on the muc-light protocol.
 
-To activate those commands, put modules you need into the mongooseim.cfg file:
+To activate those commands, put modules you need into the `mongooseim.toml` file:
+
+```toml
+  [modules.mod_commands]
+
+  [modules.mod_muc_commands]
+
+  [modules.mod_muc_light_commands]
 
 ```
-  {mod_commands, []},
-  {mod_muc_commands, []},
-  {mod_muc_light_commands, []},
 
-```
-
-You also have to hook `mongoose_api_admin` module to an HTTP endpoint:
-
-```
-  { {8088, "127.0.0.1"} , ejabberd_cowboy, [
-      {num_acceptors, 10},
-      {transport_options, [{max_connections, 1024}]},
-      {modules, [
-          {"localhost", "/api", mongoose_api_admin, []}
-      ]}
-  ]},
-```
+You also have to hook `mongoose_api_admin` module to an HTTP endpoint as described
+in the [admin REST API handlers configuration](../advanced-configuration/listen.md#handler-types-rest-api-admin-mongoose_api_admin)
+section of the [listeners](../advanced-configuration/listen.md) documentation.
 
 ## OpenAPI specifications
 

--- a/doc/rest-api/Client-frontend.md
+++ b/doc/rest-api/Client-frontend.md
@@ -7,74 +7,63 @@ WebSockets and BOSH, MongooseIM provides parts of its functionality over a REST 
 
 1. Every request has to be authenticated.
 Please see the [Authentication](#authentication) section for more details.
-1. We advise that this API is served over HTTPS.
+1. We strongly advise that this API is served over HTTPS.
 1. User registration has to be done via other methods (f.e. using the
 [REST API for backend services](Administration-backend.md)).
 1. The relevant endpoint has to be configured on the server side.
 See the [configuration section](#configuration).
 1. A list of provided actions is documented with Swagger.
-See the beatiful [specification](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true).
+See the beautiful [specification](http://mongooseim.readthedocs.io/en/latest/swagger/index.html?client=true).
 
 ## Authentication
 
-The only possible authentication method for the time being is *Basic Authentication*.
-The *userid* part is user's *bare JID* and the password is the same as that used to
-register the user's account.
+MongooseIM uses *Basic Authentication* as an authentication method for the REST API.
 
-### Bare JID
+*Basic authentication* is a simple authentication scheme built into the HTTP protocol.
+Each HTTP request to the client REST API has to contain the Authorization header
+with the word `Basic` followed by a space and a base64-encoded string
+`username@host:password`, where:
 
-To ilustrate what bare JIDs are, let's assume your MongooseIM server's hostname is
-*wonderland.com* and the user is *alice*.
-In this case the bare JID for her is just: *alice@wonderland.com*.
-This value should be used as the *userid* in the Basic Authentication method for all the REST API calls.
+- `username@host` is the user's *bare JID*,
+- `password` is the password used to register the user's account.
+
+For example, to authorize as `alice@localhost` with the password `secret`, the
+client would send a header:
+
+```
+Authorization: Basic YWxpY2VAbG9jYWxob3N0OnNlY3JldA==
+```
 
 ## Configuration
 
-In order to enable the REST API, the following configuration should be added to the
-*listen* section in *mongooseim.cfg* file.
+Handlers have to be configured as shown in the [REST API configuration example](../advanced-configuration/listen.md#example-3-client-api)
+to enable REST API.
 
-```erlang
-  { 8089 , ejabberd_cowboy, [
-      {num_acceptors, 10},
-      {max_connections, 1024},
-      {compress, true},
-      {ssl, [{certfile, "priv/ssl/fake_cert.pem"}, {keyfile, "priv/ssl/fake_key.pem"}, {password, ""}]},
-      {modules, [
-          {"_", "/api/messages/[:with]", mongoose_client_api_messages, []},
-          {"_", "/api/rooms/:id/messages",    mongoose_client_api_rooms_messages, []},
-          {"_", "/api/rooms/:id/users/[:user]",    mongoose_client_api_rooms_users, []},
-          {"_", "/api/rooms/[:id]",    mongoose_client_api_rooms, []}
-      ]}
-  ]}
-```
-
-The most important part of the above example is the *modules* lists where the relevant
-REST API functionalities are enabled and exposed on the given paths.
-By default the REST API is exposed on port 8089 but this can be changed to whatever is more convenient.
-
-For more details about possible `ejabberd_cowboy` configuration parameters please
-see the relevant documentation in the [Listener modules](../advanced-configuration/Listener-modules.md#http-based-services-bosh-websocket-rest-ejabberd_cowboy).
-
+In order to get the client REST API up and running simply copy the provided example.
+For more details about possible configuration parameters please see the relevant
+ documentation of the [listeners](../advanced-configuration/listen.md),
+in particular the [client REST API handlers](../advanced-configuration/listen.md#handler-types-rest-api-client)
+section.
 
 ## Smack library support
 REST API can fetch messages for [Smack](https://github.com/igniterealtime/Smack/blob/master/documentation/extensions/properties.md#stanza-properties) Stanza Properties.
 
 For example if we have properties in the stanza like:
-  ```
-      <message xml:lang='en' to='alice@localhost' id='123' type='chat'>
-        <body xml:lang='en_US'>Hi!</body>
-        <properties xmlns="http://www.jivesoftware.com/xmlns/xmpp/properties"
-            <property>
-                <name>some_number</name>
-                <value type='integer'>123</value>
-            <property>
-            <property>
-                <name>some_string</name>
-                <value type='string'>abc</value>
-            <property>
-        </properties>
-      </message>
-  ```
+```xml
+    <message xml:lang='en' to='alice@localhost' id='123' type='chat'>
+      <body xml:lang='en_US'>Hi!</body>
+      <properties xmlns="http://www.jivesoftware.com/xmlns/xmpp/properties"
+          <property>
+              <name>some_number</name>
+              <value type='integer'>123</value>
+          <property>
+          <property>
+              <name>some_string</name>
+              <value type='string'>abc</value>
+          <property>
+      </properties>
+    </message>
+```
 then in the final json message these properties will be converted to json map without tag names and all types will be taken as string:
 ```
     {   "to": "alice@localhost",

--- a/doc/rest-api/Client-frontend.md
+++ b/doc/rest-api/Client-frontend.md
@@ -41,7 +41,7 @@ to enable REST API.
 
 In order to get the client REST API up and running simply copy the provided example.
 For more details about possible configuration parameters please see the relevant
- documentation of the [listeners](../advanced-configuration/listen.md),
+documentation of the [listeners](../advanced-configuration/listen.md),
 in particular the [client REST API handlers](../advanced-configuration/listen.md#handler-types-rest-api-client)
 section.
 

--- a/doc/rest-api/Metrics-backend.md
+++ b/doc/rest-api/Metrics-backend.md
@@ -3,18 +3,23 @@
 **Warning:** This API is considered obsolete.
 Please use WombatOAM for monitoring or one of the [exometer reporters](../operation-and-maintenance/Logging-&-monitoring.md#monitoring) and your favourite statistics service.
 
-To expose MongooseIM metrics, an adequate endpoint must be included in the [Cowboy HTTP listener](../advanced-configuration/Listener-modules.md#http-based-services-bosh-websocket-rest-ejabberd_cowboy) section.
+To expose MongooseIM metrics, an adequate endpoint must be included in the [listen](../advanced-configuration/listen.md)
+section of `mongooseim.toml`. The specific configuration options are described in
+the [metrics API handlers](../advanced-configuration/listen.md#handler-types-metrics-api-obsolete-mongoose_api)
+section. 
 
-Here's an example:
-```
-...
-{ {5288, "127.0.0.1"}, ejabberd_cowboy, [
-    ...
-    {modules, [
-        {"localhost", "/api", [{handlers, [mongoose_api_metrics]}]}
-    ]}
-]}
-...
+An example configuration:
+
+```toml
+[[listen.http]]
+  port = 5288
+  transport.num_acceptors = 5
+  transport.max_connections = 10  
+
+  [[listen.http.handlers.mongoose_api]]
+    host = "localhost"
+    path = "/api"
+    handlers = ["mongoose_api_metrics"]
 ```
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/Mongoose-metrics.md) page.

--- a/doc/rest-api/README.md
+++ b/doc/rest-api/README.md
@@ -1,6 +1,0 @@
-How to render the `swagger.{yml,json}`
-====
-
-Go to: http://editor.swagger.io/
-
-Then: file > Import File


### PR DESCRIPTION
This PR updates the documentation of REST API to use the TOML config format.
I also found some typos and deleted a file (`doc/rest-api/README.md`) that seemed to be not needed and was popping up when starting the docs as not included in the site navigation.

