### PR TITLE
Toml/doc Operation and Maintenance update

### DIFF
--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -115,10 +115,10 @@ When enabled, rooms the user occupies are included in their roster.
  Allowed `config_schema` items are (may be mixed):
 
 * Field name and a default value. The value has to be a string. An example:
-    ```
-    field = "field_name"
-    value = "default_value"
-    ```
+    
+        field = "field_name"
+        value = "default_value"
+    
 * Field name, a default value, an internal key representation string and a type.
 Valid config field types are:
 
@@ -127,18 +127,18 @@ Valid config field types are:
     * `float`
 
     Useful only for debugging or custom applications. An example:
-    ```
-    field = "display-lines"
-    value = 30
-    internal_key = "display_lines"
-    type = "integer"
-    ```
+    
+        field = "display-lines"
+        value = 30
+        internal_key = "display_lines"
+        type = "integer"
+    
 **WARNING!** Lack of the `roomname` field will cause room names in Disco results and Roster items be set to the room username.
 
 
 ### Example Configuration
 
-```
+```toml
 [modules.mod_muc_light]
   host = "muclight.example.com"
   equal_occupants = true

--- a/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
+++ b/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
@@ -115,7 +115,7 @@ Similarly to `join_cluster` a warning and a question will be displayed unless th
 The successful output from the above command may look like the following:
 
 ```text
-You have successfully left the node mongooseim2@localhost from the cluster
+The node mongooseim2@localhost has successfully left the cluster
 ```
 
 ### Removing a node from the cluster

--- a/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
+++ b/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
@@ -23,18 +23,20 @@ If you are using **Ubuntu**, all `/etc/pam.d/common-session*` files should inclu
 
 ### `vm.args` file
 
-This file contains erlang options used when starting the VM.
-It is located in `REL_ROOT/etc/vm.args` where `REL_ROOT` is the path to a MonoogseIM release
+This file contains Erlang options used when starting the VM.
+It is located in `REL_ROOT/etc/vm.args` where `REL_ROOT` is the path to a MongooseIM release
 (ie. `_build/prod/rel/mongooseim` if you build MongooseIM from source).
 
 When using an SSL/TLS connection we advise to increase `ERL_MAX_PORTS` to `350000`.
-This value specifies how many ports (files, drivers, sockets etc) can be used by Erlang VM.
+This value specifies how many ports (files, drivers, sockets etc) can be used by the Erlang VM.
 Be cautious - it preallocates some structures inside the VM and will have impact on the memory usage.
 We suggest 350000 for 100 k users when using an SSL/TLS connection or 250000 in other cases.
 
 To check how memory consumption changes depending on `ERL_MAX_PORTS`, use the following command:
 
-`env ERL_MAX_PORTS=[given value] erl -noinput -eval 'io:format("~p~n",[erlang:memory(system)]).' -s erlang halt`
+```bash
+env ERL_MAX_PORTS=[given value] erl -noinput -eval 'io:format("~p~n",[erlang:memory(system)]).' -s erlang halt
+```
 
 Another change you need to make when building a MongooseIM cluster is setting the `-sname`.
 To do it, just set the `-sname` option in `vm.args` with node's hostname,
@@ -46,12 +48,14 @@ To connect to other nodes, a freshly started node uses a port from the range `in
 
 To enable this, add the following line to the `vm.args` file:
 
-`-kernel inet_dist_listen_min 50000 inet_dist_listen_max 50010`
+```
+-kernel inet_dist_listen_min 50000 inet_dist_listen_max 50010
+```
 
 Make sure that the range you set provides enough ports for all the nodes in the cluster.
 
 Remember to keep an epmd port open (port 4369) if any firewall restrictions are required.
-Epmd keeps track of which erlang node is using which ports on the local machine.
+Epmd keeps track of which Erlang node is using which ports on the local machine.
 
 ## Connecting nodes
 
@@ -80,16 +84,16 @@ mongooseimctl join_cluster ClusterMember
 `ClusterMember` is the name of a running node set in `vm.args` file, for example `mongooseim@localhost`.
 This node has to be part of the cluster we'd like to join.
 
-First MongooseIM will display a warning and a question if the operation should proceed:
+First, MongooseIM will display a warning and a question if the operation should proceed:
 
-```
+```text
 Warning. This will drop all current connections and will discard all persistent data from Mnesia. Do you want to continue? (yes/no)
 ```
 
 If you type `yes` MongooseIM will start joining the cluster.
 Successful output may look like the following:
 
-```
+```text
 You have successfully joined the node mongooseim2@localhost to the cluster with node member mongooseim@localhost
 ```
 
@@ -110,7 +114,9 @@ Similarly to `join_cluster` a warning and a question will be displayed unless th
 
 The successful output from the above command may look like the following:
 
-`You have successfully left the node mongooseim2@localhost from the cluster`.
+```text
+You have successfully left the node mongooseim2@localhost from the cluster
+```
 
 ### Removing a node from the cluster
 
@@ -124,7 +130,9 @@ where `RemoteNodeName` is a name of the node that we'd like to remove from our c
 This command could be useful when the node is dead and not responding and we'd like to remove it remotely.
 The successful output from the above command may look like the following:
 
-`The node mongooseim2@localhost has been removed from the cluster`
+```text
+The node mongooseim2@localhost has been removed from the cluster
+```
 
 ### Cluster status
 
@@ -167,11 +175,8 @@ Load balancing can be performed on a DNS level.
 A DNS response can have a number of IP addresses that can be returned to the client side in a random order.
 
 On the AWS stack this type of balancing is provided by Route53.
-The description of their service can be found at:
-
-http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/WeightedResourceRecordSets.html
+The description of their service can be found [here](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/WeightedResourceRecordSets.html).
 
 ### Other
 
 The approaches described above can be mixed - we can use DNS load balancing to pick a software load balancer which will select one of the nodes.
-

--- a/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
+++ b/doc/operation-and-maintenance/Cluster-configuration-and-node-management.md
@@ -175,7 +175,7 @@ Load balancing can be performed on a DNS level.
 A DNS response can have a number of IP addresses that can be returned to the client side in a random order.
 
 On the AWS stack this type of balancing is provided by Route53.
-The description of their service can be found [here](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/WeightedResourceRecordSets.html).
+The description of their service can be found in the [Route53 Developer's Guide](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/WeightedResourceRecordSets.html).
 
 ### Other
 

--- a/doc/operation-and-maintenance/Cluster-management-considerations.md
+++ b/doc/operation-and-maintenance/Cluster-management-considerations.md
@@ -1,10 +1,10 @@
-This applies to bare metal, virtualization, hypervisor, containers and other technologies.
+These apply to bare metal, virtualization, hypervisor, containers and other technologies.
 
 ## Single-node MongooseIM
 
 With a single-node MongooseIM, one can set up a vertically scalable system, that is a function of the server resources. MongooseIM can scale from hundreds to tens of thousands of concurrent users.
 
-Note that in a single-node MongooseIM, there is no load distribution, and no fallback or failover in case of failure.
+Note that in a single-node MongooseIM, there is no load distribution, and no fallback or failover in case of a failure.
 
 This architecture is suitable for low-scale deployments, such as testing and development environments on embedded devices, personal computers, or servers.
 
@@ -38,14 +38,14 @@ With a multi-datacenter MongooseIM, one can set up a system that is highly scala
 
 This applies to large and very large-scale deployments.
 
-Contact us.
+We advise [contacting us](https://www.erlang-solutions.com/contact.html) in case of such a big deployment.
 
 ## Summary table
 
 **Setup**: reflects the number of nodes in your cluster. <br/>
 **Purpose**: is the goal and use of this cluster. <br/>
-**Low-end**: number of concurent users on low-power machines, such as laptops, embedded devides, entry-level cloud or bare metal.<br/>
-**High-end**: number of concurent users on powerful machines, with lots of memory, multi-core CPU, whether they or cloud or bare metal.
+**Low-end**: number of concurrent users on low-power machines, such as laptops, embedded devices, entry-level cloud or bare metal.<br/>
+**High-end**: number of concurrent users on powerful machines, with lots of memory, multi-core CPU, whether in cloud or bare metal.
 
 Setup | Purpose | Low-end  | High-end
 ------|---------|---------:|---------:
@@ -70,7 +70,7 @@ Scalability highly depends on variables such as:
     * MUC light
     * PubSub
     * Presences
-    * HTTP notifications (with queuing systems such as RabbitMQ or Kafka)
+    * HTTP notifications (with may include queuing systems such as RabbitMQ or Kafka)
 * latency of messaging, both real-time and archived messages
 
 #### OS configuration

--- a/doc/operation-and-maintenance/Cluster-management-considerations.md
+++ b/doc/operation-and-maintenance/Cluster-management-considerations.md
@@ -70,7 +70,7 @@ Scalability highly depends on variables such as:
     * MUC light
     * PubSub
     * Presences
-    * HTTP notifications (with may include queuing systems such as RabbitMQ or Kafka)
+    * HTTP notifications (may include queuing systems such as RabbitMQ or Kafka)
 * latency of messaging, both real-time and archived messages
 
 #### OS configuration

--- a/doc/operation-and-maintenance/Logging-&-monitoring.md
+++ b/doc/operation-and-maintenance/Logging-&-monitoring.md
@@ -101,12 +101,12 @@ By default, the resolution is set to 60 seconds.
 
 ### Run Graphite & Grafana in Docker - quick start
 
-The following commands will download the latest version of `kamon/grafana_graphite` docker image that contains both Grafana and Graphite, and start them while mounting local directory `./docker-grafana-graphite-master/data` for metrics persistence:
+The following commands will download the latest version of `kamon/grafana_graphite` docker image that contains both Grafana and Graphite, and start them while mounting the local directory `./docker-grafana-graphite-master/data` for metric persistence:
 
     $ curl -SL https://github.com/kamon-io/docker-grafana-graphite/archive/master.tar.gz | tar -xzf -
     $ make -C docker-grafana-graphite-master up
 
-Go to http://localhost:80 to view Grafana dashboard that's already set up to use metrics from Graphite.
+Go to http://localhost:80 to view the Grafana dashboard that's already set up to use metrics from Graphite.
 
 ### Add metrics to Grafana dashboard
 

--- a/doc/operation-and-maintenance/Logging-&-monitoring.md
+++ b/doc/operation-and-maintenance/Logging-&-monitoring.md
@@ -11,7 +11,7 @@ To activate it you have to add `syslogger` to the applications section in `src/m
 
     %% syslogger, % uncomment to enable a logger handler for syslog
 
-You also need to edit `rel/files/app.config` and uncomment the line:
+You also need to edit `rel/files/app.config` and uncomment the lines:
 
      % Uncomment these lines to enable logging to syslog.
      % Remember to add syslogger as a dependency in mongooseim.app.src.
@@ -30,7 +30,7 @@ in the `syslogger's` [GitHub page](https://github.com/NelsonVides/syslogger/):
 * `facility` -  the facility to log to (see the syslog documentation).
 * `log_opts` - see the syslog documentation for the description.
 
-Depending on the system platform you use, remember also to add the appropriate line in the syslog config file.
+Depending on the system you use, remember also to add the appropriate line in the syslog config file.
 For example, if the facility `local0` is set:
 
     local0.info                     /var/log/mongooseim.log
@@ -45,7 +45,7 @@ Example log (e.g `tail -f /var/log/mongooseim.log`):
 
 For more advanced processing and analysis of logs, including gathering logs from multiple machines,
 you can use one of the many available systems (e.g. logstash/elasticsearch/kibana, graylog, splunk),
-by redirecting mongoose logs to such service with an appropriate [Logger](Logger)'s handler.
+by redirecting mongoose logs to such service with an appropriate [Logger][Logger]'s handler.
 
 Check [Logging](Logging.md) for more information.
 
@@ -71,8 +71,8 @@ To monitor MongooseIM during load testing, we recommend the following open sourc
 
 MongooseIM uses [a fork of Exometer library](https://github.com/esl/exometer_core) for collecting metrics.
 Exometer has many plug-in reporters that can send metrics to external services. We maintain [exometer_report_graphite](https://github.com/esl/exometer_report_graphite) and [exometer_report_statsd](https://github.com/esl/exometer_report_statsd) for Graphite and StatsD respectively.
-It is possible to enable them in MoongooseIM via the `app.config` file.
-The file sits next to the `mongooseim.cfg` file in the `rel/files` and `_REL_DIR_/etc` directories.
+It is possible to enable them in MongooseIM via the `app.config` file.
+The file sits next to the `mongooseim.toml` file in the `rel/files` and `_REL_DIR_/etc` directories.
 
 Below you can find a sample configuration.
 It shows setting up a reporter connecting to graphite running on localhost.
@@ -101,16 +101,16 @@ By default, the resolution is set to 60 seconds.
 
 ### Run Graphite & Grafana in Docker - quick start
 
-The following commands will download the latest version of `kamon/grafana_graphite` docker image that contains both Grafana and Graphite, and start them while mounting local directory `./docker-grafana-graphite-master/data` for metrics persistance:
+The following commands will download the latest version of `kamon/grafana_graphite` docker image that contains both Grafana and Graphite, and start them while mounting local directory `./docker-grafana-graphite-master/data` for metrics persistence:
 
     $ curl -SL https://github.com/kamon-io/docker-grafana-graphite/archive/master.tar.gz | tar -xzf -
     $ make -C docker-grafana-graphite-master up
 
-Go to http://localhost to view Grafana dashboard that's already set up to use metrics from Graphite.
+Go to http://localhost:80 to view Grafana dashboard that's already set up to use metrics from Graphite.
 
 ### Add metrics to Grafana dashboard
 
-We recommend the following metrics as a baseling for tracking your MongooseIM installation.
+We recommend the following metrics as a baseline for tracking your MongooseIM installation.
 For time-based metrics, you can choose to display multiple calculated values for a reporting period - we recommend tracking at least `max`, `median` and `mean`.
 
 ```

--- a/doc/operation-and-maintenance/Logging-&-monitoring.md
+++ b/doc/operation-and-maintenance/Logging-&-monitoring.md
@@ -30,7 +30,7 @@ in the `syslogger's` [GitHub page](https://github.com/NelsonVides/syslogger/):
 * `facility` -  the facility to log to (see the syslog documentation).
 * `log_opts` - see the syslog documentation for the description.
 
-Depending on the system you use, remember also to add the appropriate line in the syslog config file.
+Depending on the system you use, remember to also add the appropriate line in the syslog config file.
 For example, if the facility `local0` is set:
 
     local0.info                     /var/log/mongooseim.log

--- a/doc/operation-and-maintenance/Logging.md
+++ b/doc/operation-and-maintenance/Logging.md
@@ -19,7 +19,7 @@ Primary log level, that is used before MongooseIM config is loaded:
 ].
 ```
 
-Once MongooseIM config is loaded, [`loglevel`](../advanced-configuration/general.md#generalloglevel) option from `mongooseim.toml` is used instead.
+Once MongooseIM config is loaded, the [`loglevel`](../advanced-configuration/general.md#generalloglevel) option from `mongooseim.toml` is used instead.
 
 # Primary filters
 

--- a/doc/operation-and-maintenance/Logging.md
+++ b/doc/operation-and-maintenance/Logging.md
@@ -3,7 +3,6 @@
 The main configuration for logging is in the Application Config file.
 You can find it in `mongooseim/etc/app.config` in the release directory.
 
-
 # Primary log level
 
 Primary log level sets maximum log level in the system.
@@ -20,8 +19,7 @@ Primary log level, that is used before MongooseIM config is loaded:
 ].
 ```
 
-Once MongooseIM config is loaded, `loglevel` option is used instead.
-
+Once MongooseIM config is loaded, [`loglevel`](../advanced-configuration/general.md#generalloglevel) option from `mongooseim.toml` is used instead.
 
 # Primary filters
 
@@ -48,8 +46,7 @@ unless you are planning to extend the filtering logic.
 ```
 
 `preserve_acc_filter` filter is disabled by default, but could be enabled,
-if you are interested in debugging the accumulator logic (`mongoose_acc` module).
-
+if you are interested in debugging the accumulator logic (see the `mongoose_acc` module).
 
 # Shell log handler
 
@@ -67,7 +64,6 @@ if you are interested in debugging the accumulator logic (`mongoose_acc` module)
          }}
     }},
 ```
-
 
 # File log handler
 
@@ -102,7 +98,6 @@ if you are interested in debugging the accumulator logic (`mongoose_acc` module)
     }},
 ```
 
-
 # Logfmt file log handler
 
 Wrapper around the [flatlog](https://github.com/ferd/flatlog) library with
@@ -124,7 +119,6 @@ Options:
            term_depth => 50
          }}
 ```
-
 
 # JSON file log handler
 
@@ -152,7 +146,6 @@ Options:
          }}
 ```
 
-
 # Different log level for a specific module
 
 Motivation:
@@ -173,7 +166,6 @@ Changes:
     %% Module log level
     {module_level, debug, [ejabberd_c2s]},
 ```
-
 
 # Separate log for module debugging
  

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -195,7 +195,7 @@ These are **total** times of respective operations.
 One operation usually requires only a single call to an auth backend but sometimes with e.g. 3 backends configured, the operation may fail for first 2 backends.
 In such case, these metrics will be updated with combined time of 2 failed and 1 successful request.
 
-Additionally, RDBMS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
+Additionally, the RDBMS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
 
 * `[global, backends, mongoose_rdbms, query]` - Execution time of a "simple"" (not prepared) query by a DB driver.
 * `[global, backends, mongoose_rdbms, execute]` - Execution time of a prepared query by a DB driver.

--- a/doc/operation-and-maintenance/Mongoose-metrics.md
+++ b/doc/operation-and-maintenance/Mongoose-metrics.md
@@ -35,7 +35,7 @@ It is actually a one-element proplist: `[{value, N}]`.
 
 ### `gauge`
 
-It is similiar to a `value` type but consists of two properties:
+It is similar to a `value` type but consists of two properties:
 
 * `value`
 * `ms_since_reset` - Time in milliseconds elapsed from the last metric update.
@@ -195,7 +195,7 @@ These are **total** times of respective operations.
 One operation usually requires only a single call to an auth backend but sometimes with e.g. 3 backends configured, the operation may fail for first 2 backends.
 In such case, these metrics will be updated with combined time of 2 failed and 1 successful request.
 
-Additionaly, RDBMS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
+Additionally, RDBMS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
 
 * `[global, backends, mongoose_rdbms, query]` - Execution time of a "simple"" (not prepared) query by a DB driver.
 * `[global, backends, mongoose_rdbms, execute]` - Execution time of a prepared query by a DB driver.

--- a/doc/operation-and-maintenance/Reloading-configuration-on-a-running-system.md
+++ b/doc/operation-and-maintenance/Reloading-configuration-on-a-running-system.md
@@ -27,154 +27,16 @@ Useful for debugging.
 Some options require restarting the server in order to be reloaded.
 The following options' changes will be ignored when using `mongooseimctl` tool:
 
-* domain_certfile
-* s2s_\*
-* all_metrics_are_global
-* rdbms_\*
+* s2s.\*
+* general.all_metrics_are_global
+* \*.rdbms.\*
 
 
 ### Node-specific options
 
-Usually all nodes in cluster share the same configuration.
+This option is deprecated and not available when using a config file in the TOML
+format.
 
-But sometimes we want different configs for each node in a cluster.
-
-By default in such cases `reload_cluster` would detect a configuration
-inconsistency and would not allow configuration updates.
-
-To tell `reload_cluster` to ignore such options, extra information should be
-provided in `mongooseim.cfg`.
-
-It's called `node_specific_options`.
-
-They are defined on top level of the configuration file using
-`node_specific_options` tuple. This tuple should be the same for all configs
-in a cluster.
-
-`node_specific_options` contains a list of match patterns. If you are familiar
-with ETS tables or Mnesia tuple matching - it's the same thing.
-Match patterns are documented in
-[Erlang/OTP docs](http://erlang.org/doc/apps/erts/match_spec.html).
-
-The pattern mechanism is also documented in
-[Learn you some Erlang book](http://learnyousomeerlang.com/ets).
-
-Basically, it allows you to put `'_'` to match every possible host.
-
-`[h,'_',module_opt,mod_muc_log, outdir]` would match
-`[h,<<"localhost">>,module_opt,mod_muc_log, outdir]` and
-`[h,<<"any.other.host">>,module_opt,mod_muc_log, outdir]`.
-
-Example showing where to put `node_specific_options`.
-
-```erlang
-{hosts, ["localhost"]}.
-{node_specific_options, [
-    [h,'_',module_opt,mod_muc_log, outdir]
- ]}.
-{modules, [....]}.
-```
-
-The `node_specific_options` patterns are matched against flat configuration
-options. To print your config in a flat form, use the command with a running
-node `mongooseimctl print_flat_config`.
-
-Example:
-
-```erlang
-_build/mim1/rel/mongooseim/bin/mongooseimctl print_flat_config
-Flat options:
-{[l,listen],'FLAT'}.
-{[l,listener,{5280,{0,0,0,0},tcp},ejabberd_cowboy],'FLAT'}.
-{[l,listener_opt,{5280,{0,0,0,0},tcp},ejabberd_cowboy,num_acceptors],10}.
-{[l,listener_opt,{5280,{0,0,0,0},tcp},ejabberd_cowboy,transport_options],
- [{max_connections,1024}]}.
-...
-{[h,<<"anonymous.localhost">>,auth_method],anonymous}.
-{[h,<<"localhost.bis">>,modules],'FLAT'}.
-{[h,<<"localhost.bis">>,module,mod_carboncopy],'FLAT'}.
-{[h,<<"localhost.bis">>,module,mod_stream_management],'FLAT'}.
-{[h,<<"localhost.bis">>,module,mod_muc_commands],'FLAT'}.
-{[h,<<"localhost.bis">>,module,mod_amp],'FLAT'}.
-{[h,<<"localhost.bis">>,module,mod_offline],'FLAT'}.
-{[h,<<"localhost.bis">>,module_opt,mod_offline,access_max_user_messages],
- max_user_offline_messages}.
-...
-```
-
-[More information about flat options format](../developers-guide/flat_options.md)
-
-#### Node-specific options for Global Distribution
-
-Node-specific options mechanism was designed to allow `mod_global_distrib`
-to be configured with different parameters for each node.
-
-Real life configuration example:
-
-```erlang
-{node_specific_options, [
-    [h,'_',module_opt,mod_global_distrib,endpoints],
-    [h,'_',module_opt,mod_global_distrib,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib,connections,endpoints],
-    [h,'_',module_subopt,mod_global_distrib,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib,redis,server],
-    [h,'_',module_subopt,mod_global_distrib_bounce,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_bounce,connections,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_bounce,connections,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_bounce,connections,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_disco,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_disco,connections,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_hosts_refresher,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_hosts_refresher,connections,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_hosts_refresher,connections,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_hosts_refresher,connections,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_hosts_refresher,redis,server],
-    [h,'_',module_subopt,mod_global_distrib_mapping,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_mapping,connections,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_mapping,connections,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_mapping,connections,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_mapping,redis,server],
-    [h,'_',module_subopt,mod_global_distrib_receiver,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_receiver,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_receiver,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_receiver,connections,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_receiver,connections,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_receiver,connections,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_receiver,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_receiver,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_receiver,redis,server],
-    [h,'_',module_subopt,mod_global_distrib_sender,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_sender,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_sender,connections,advertised_endpoints],
-    [h,'_',module_subopt,mod_global_distrib_sender,connections,advertised_endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_sender,connections,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_sender,connections,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_sender,endpoints],
-    [h,'_',module_subopt,mod_global_distrib_sender,endpoints,'_'],
-    [h,'_',module_subopt,mod_global_distrib_sender,redis,server]
-]}.
-```
-
-`'_'` means that any value can be there.
-
-Usually, all modules are configured using just one level of option nesting.
-`module_subopt` means that we are interested in a nested option.
-
-`node_specific_options` can be used with any module, not just
-`mod_global_distrib` (but usually you want all options to be the same on all
-nodes!).
-
-Any flat option can be used in `node_specific_options`.
-
-
-#### Node-specific modules
-
-We don't compare options of node-specific modules for configuration consistency
-check. We also don't check, if all nodes run these modules (it's fine to run
-them only on some nodes in a cluster).
-
-```erlang
-{node_specific_options, [
-    [h,'_',module,mod_global_distrib]
-]}.
-```
+For the documentation of this option for the `cfg` config format please refer to
+the [MIM 3.7.1 documentation](https://mongooseim.readthedocs.io/en/3.7.1/operation-and-maintenance/Reloading-configuration-on-a-running-system/)
+or older.

--- a/doc/operation-and-maintenance/Reloading-configuration-on-a-running-system.md
+++ b/doc/operation-and-maintenance/Reloading-configuration-on-a-running-system.md
@@ -26,10 +26,11 @@ Useful for debugging.
 ### Non-reloadable options
 Some options require restarting the server in order to be reloaded.
 The following options' changes will be ignored when using `mongooseimctl` tool:
+
 * domain_certfile
-* s2s_*
+* s2s_\*
 * all_metrics_are_global
-* rdbms_*
+* rdbms_\*
 
 
 ### Node-specific options

--- a/doc/operation-and-maintenance/System-Metrics-Privacy-Policy.md
+++ b/doc/operation-and-maintenance/System-Metrics-Privacy-Policy.md
@@ -29,19 +29,19 @@ The full list of information that is being gathered can be seen below:
 These values are derived from the IP address the data was sent from.
 See [About Geographical Data](https://support.google.com/analytics/answer/6160484?hl=en) for more details.
 
-# How the information is being used?
+# How is the information being used?
 The information collected is automatically anonymised before it is being processed any further.
 Each MongooseIM is randomly generating a Client ID that is being attached to the reports.
 The collected data has only statistical relevance and aims to help us understand the needs of our users.
 Knowing how our product is used will allow us to identify the core value it brings to the users. It will point out the direction in which to expand it and show us how to target our further efforts developing it.
 
-# How a report looks like?
+# How does a report look like?
 A sample report showing metrics for the mod_vcard backends from Google Analytics can be found below.
 ![System metrics sample report][system_metrics_report]
 
 Based on such report we can see the frequency of different backends being used with mod_vcard.
 
-# How often the metrics are reported?
+# How often are the metrics reported?
 Metrics are reported first shortly after the system startup and later at regular intervals.
 These timers are configurable using the `initial_report` and `periodic_report` parameters.
 The default values are 5 minutes for the initial report and 3 hours for the periodic one.
@@ -49,7 +49,7 @@ These reporting intervals can be changed depending on the configuration paramete
 
 # How to configure this service?
 This functionality is provided as a "service".
-For more details regarding service configuration, please see [Services](../advanced-configuration/Services.md) section.
+For more details regarding service configuration, please see the [Services](../advanced-configuration/Services.md) section.
 
 # How to configure additional and private Tracking ID in Google Analytics?
 The data is gathered and forwarded to Google Analytics.
@@ -68,7 +68,7 @@ To create a new Tracking ID, please follow the steps below:
 
 ## Example configuration
 New Tracking ID can be added to the list of options
-```
+```toml
 [services.service_mongoose_system_metrics]
   initial_report = 300_000
   periodic_report = 10_800_000
@@ -81,7 +81,7 @@ For more details regarding service configuration, please see [Services](../advan
 For more information on how Google Analytics collects and processes data, please see [Google Privacy & Terms](https://policies.google.com/technologies/partner-sites).
 Google Analytics is being used due to the ease of host and display reporting information.
 We will not share any user specific information with further third parties not mentioned in this document.
-Insight of statistical significance regarding our findings from bulk data collected will be shared as a blog post on our website [Erlang-Solutions](https://www.erlang-solutions.com/blog.html).
+Insight of statistical significance regarding our findings from bulk data collected has been shared as a [blog post](https://www.erlang-solutions.com/blog/how-data-drives-mongooseim.html) on our website.
 
 [system_metrics_report]: system_metrics_report.png
 [how-to-configure-tracking-id]: #how-to-configure-additional-and-private-tracking-id-in-google-analytics

--- a/doc/operation-and-maintenance/System-Metrics-Privacy-Policy.md
+++ b/doc/operation-and-maintenance/System-Metrics-Privacy-Policy.md
@@ -81,7 +81,7 @@ For more details regarding service configuration, please see [Services](../advan
 For more information on how Google Analytics collects and processes data, please see [Google Privacy & Terms](https://policies.google.com/technologies/partner-sites).
 Google Analytics is being used due to the ease of host and display reporting information.
 We will not share any user specific information with further third parties not mentioned in this document.
-Insight of statistical significance regarding our findings from bulk data collected has been shared as a [blog post](https://www.erlang-solutions.com/blog/how-data-drives-mongooseim.html) on our website.
+Some insight into the statistical significance regarding our findings from the bulk data collected, has been shared as a [blog post](https://www.erlang-solutions.com/blog/how-data-drives-mongooseim.html) on our website.
 
 [system_metrics_report]: system_metrics_report.png
 [how-to-configure-tracking-id]: #how-to-configure-additional-and-private-tracking-id-in-google-analytics

--- a/doc/operation-and-maintenance/gdpr-considerations.md
+++ b/doc/operation-and-maintenance/gdpr-considerations.md
@@ -16,7 +16,7 @@ This page describes what GDPR implies in terms of server management.
 
 ## GDPR CLI commands
 
-All CLI commands are accessible via `mongooseimctl` command, located in `bin/` inside MIM release.
+All CLI commands are accessible via the `mongooseimctl` command, located in the `bin/` directory inside the MIM release.
 
 Personal data retrieval requires `service_admin_extra` with `gdpr` group enabled.
 

--- a/doc/operation-and-maintenance/known-issues.md
+++ b/doc/operation-and-maintenance/known-issues.md
@@ -1,5 +1,5 @@
 This document provides a list of all known issues with MongooseIM operation and configuration.
-You may also find proposed workarounds if any is available.
+You may also find proposed workarounds if any are available.
 
 ## Missing MUC Light room config fields with RDBMS backend
 
@@ -8,12 +8,14 @@ These options couldn't be re-added later by changing the room config via request
 
 It happened when the default config was a subset of the schema and the client hasn't provided these values when a room was created.
 
+Please note that this issue was resolved from MIM 3.6.0 onwards as the `default_config` option was deleted.
+
 ### How to fix this?
 
 You have to iterate over all rooms in the DB (`muc_light_rooms` table) and add missing entries to the `muc_light_config` table.
 Every option is inserted as a separate row and is stored as plain text, so it should be straightforward.
 
-Let's say you were using the following config:
+Let's say you were using the following config in `mongooseim.cfg`:
 
 ```
 {config_schema, [

--- a/doc/operation-and-maintenance/tls-distribution.md
+++ b/doc/operation-and-maintenance/tls-distribution.md
@@ -4,7 +4,7 @@ It's possible to use TLS for communication between MongooseIM cluster nodes.
 To enable it, find the directory of your release, below it look for `etc/vm.dist.args` and, inside the file, the section about
 the distribution protocol:
 
-```
+```bash
 ## Use TLS for connections between Erlang cluster members.
 ## Don't forget to override the paths to point to your certificate(s) and key(s)!
 ## Once a connection is established, Erlang doesn't differentiate between

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -177,7 +177,7 @@ help ()
     echo "  foreground      Start MongooseIM node in foreground (non-interactive) mode"
     echo "MongooseIM cluster management commands:"
     echo "  join_cluster other_node_name                Add current node to cluster"
-    echo "  leave_cluster                               Leave current node from the cluster"
+    echo "  leave_cluster                               Make the current node leave the cluster"
     echo "  remove_from_cluster other_node_name         Remove dead node from the cluster"
     echo "Extra Commands:"
     echo "  bootstrap           Executes MongooseIM init scripts (used for initial configuration)"

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -177,7 +177,7 @@ commands() ->
                         args = [{node, string}],
                         result = {res, restuple}},
      #ejabberd_commands{name = leave_cluster, tags = [server],
-                        desc = "Leave a node from the cluster. Call it from the node that is going to leave.
+                        desc = "Leave a cluster. Call it from the node that is going to leave.
                                 Use `-f` or `--force` flag to avoid question prompt and force leave the node from cluster",
                         module = ?MODULE, function = leave_cluster,
                         args = [],
@@ -279,7 +279,7 @@ leave_cluster() ->
 do_leave_cluster() ->
     try mongoose_cluster:leave() of
         ok ->
-            String = io_lib:format("You have successfully left the node ~p from the cluster~n", [node()]),
+            String = io_lib:format("The node ~p has successfully left the cluster~n", [node()]),
             {ok, String}
     catch
         E:R ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -98,7 +98,7 @@ start() ->
 
 %% @doc Get the filename of the ejabberd configuration file.
 %% The filename can be specified with: erl -config "/path/to/mongooseim.toml".
-%% It can also be specified with the environtment variable EJABBERD_CONFIG_PATH.
+%% It can also be specified with the environment variable EJABBERD_CONFIG_PATH.
 %% If not specified, the default value 'mongooseim.toml' is assumed.
 -spec get_config_path() -> string().
 get_config_path() ->


### PR DESCRIPTION
This PR updates the Operation and Maintenance part of the documentation to reflect the TOML configuration. It also contains many general fixes, like typos, grammar, etc (sometimes in files located outside the O&A part of the docs).
I did **not** touch the `Reloading-configuration-on-a-running-system.md` file as I'm not sure what to do with it. It seems to not really be reflected in the new TOML config (e.g. no `node_specific_options` in the TOML config). I hesitated from adding something like "This functionality is only available if you are using the older, `cfg` config format" but this may be the best way to deal with this issue for now. I'd be happy to hear reviewers opinions on this topic.

