### PR TITLE
Toml/doc db-backends conf update

### DIFF
--- a/doc/advanced-configuration/Services.md
+++ b/doc/advanced-configuration/Services.md
@@ -12,7 +12,7 @@ Eventually the modules which are not host-specific will be refactored to be serv
 Typical services are already specified in the example configuration file.
 * **Example:** A configuration of the `service_admin_extra` service.
 
-```
+```toml
 [services.service_admin_extra]
   submods = ["node", "account", "sessions", "vcard", "gdpr", "upload", "roster",
              "last", "private", "stanza", "stats"]
@@ -91,7 +91,7 @@ The notification can be silenced by setting the `no_report` option explicitly.
 
 ### Example configuration
 
-```
+```toml
 [services.service_admin_extra]
   submods = ["node", "account", "sessions", "vcard", "gdpr", "upload", "roster",
              "last", "private", "stanza", "stats"]

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -83,7 +83,7 @@ mysql -h localhost -u user -p -e 'create database mongooseim'
 mysql -h localhost -u user -p mongooseim < mysql.sql
 ```
 
-You should also configure MySQL database in the `mongooseim.toml` file.
+You should also configure the MySQL database in the `mongooseim.toml` file.
 Please refer to the [RDBMS options](../advanced-configuration/outgoing-connections.md#rdbms-options) for more information.
 
 **Version notice**
@@ -120,8 +120,10 @@ You can use the following command to apply it on localhost:
 psql -h localhost -U user -c "CREATE DATABASE mongooseim;"
 psql -h localhost -U user -q -d mongooseim -f pg.sql
 ```
-You should also configure Postgres database in `mongooseim.toml` file.
-Please refer to the [RDBMS options](../advanced-configuration/outgoing-connections.md#rdbms-options) for more information.
+You should also configure the Postgres database in the `mongooseim.toml` file.
+Please refer to the [RDBMS options](../advanced-configuration/outgoing-connections.md#rdbms-options)
+and [general database options](general.md#database-settings)
+for more information.
 
 ## Microsoft SQL Server
 
@@ -185,7 +187,7 @@ MongooseIM is built with ODBC support by default.
 
 **Deadlocks notice**
 
-If muc_light's backend is set to ODBC and in your system there is many rooms created in parallel,
+If muc_light's backend is set to ODBC and there are many rooms created in parallel in your system,
 there may be some deadlocks due to the `READ_COMMITTED_SNAPSHOT` set to `OFF` by default.
 In this case we recommend to set this database property to `ON`, this will enable row level locking which significantly reduces
 deadlock chances around muc_light operations.
@@ -207,6 +209,13 @@ isql mongoose-mssql username password -b
 ```
 
 The final step is to configure ``mongooseim.toml`` appropriately.
+Set the following option in the `general` section:
+
+```toml
+[general]
+  rdbms_server_type = "mssql"
+```
+
 Configure the `outgoing_pools.rdbms` section as follows:
 
 ```toml
@@ -339,7 +348,7 @@ curl -X PUT $ELASTICSEARCH_URL/muc_messages -d '@priv/elasticsearch/muc.json'
 
 where `$ELASTICSEARCH_URL` is a URL pointing to your ElasticSearch node's HTTP API endpoint.
 
-Please refer to [advanced configuration](../advanced-configuration/outgoing-connections.md#elasticsearch-options) page to check how to configure MongooseIM to connect to ElasticSearch node.
+Please refer to the [advanced configuration](../advanced-configuration/outgoing-connections.md#elasticsearch-options) page to check how to configure MongooseIM to connect to ElasticSearch node.
 
 ## Redis
 

--- a/doc/advanced-configuration/database-backends-configuration.md
+++ b/doc/advanced-configuration/database-backends-configuration.md
@@ -22,7 +22,7 @@ Subsequent sections go into more depth on each database: what they are suitable 
 Transient data:
 
 * Mnesia - we highly recommend Mnesia (a highly available and distributed database) over Redis for storing **transient** data.
- Being an Erlang-based database, it's the default persistance option for most modules in MongooseIM.
+ Being an Erlang-based database, it's the default persistence option for most modules in MongooseIM.
  **Warning**: we **strongly recommend** keeping **persistent** data in an external DB (RDBMS or Riak) for production.
  Mnesia is not suitable for the volumes of **persistent** data which some modules may require.
  Sooner or later a migration will be needed which may be painful.
@@ -42,7 +42,7 @@ Persistent Data:
  Use MySQL, MariaDB, PostgreSQL, or MS SQL Server.
 
 * Riak KV - If you're planning to deploy a massive cluster, consider Riak KV as a potential storage backend solution.
- It offers high availability and fault tolerance which is excatly what you need for your distributed MongooseIM architecture.
+ It offers high availability and fault tolerance which is exactly what you need for your distributed MongooseIM architecture.
  Use Riak KV with `privacy lists`, `vcards`, `roster`, `private storage`, `last activity` and `message archive`.
  Erlang Solutions commercially supports Riak KV.
 
@@ -83,8 +83,8 @@ mysql -h localhost -u user -p -e 'create database mongooseim'
 mysql -h localhost -u user -p mongooseim < mysql.sql
 ```
 
-You should also configure MySQL database in the `mongooseim.cfg` file.
-Please refer to the [Advanced configuration/Database setup](../Advanced-configuration.md) for more information.
+You should also configure MySQL database in the `mongooseim.toml` file.
+Please refer to the [RDBMS options](../advanced-configuration/outgoing-connections.md#rdbms-options) for more information.
 
 **Version notice**
 
@@ -120,8 +120,8 @@ You can use the following command to apply it on localhost:
 psql -h localhost -U user -c "CREATE DATABASE mongooseim;"
 psql -h localhost -U user -q -d mongooseim -f pg.sql
 ```
-You should also configure Postgres database in `mongooseim.cfg` file.
-Please refer to the [Advanced configuration/Database setup](../Advanced-configuration.md) for more information.
+You should also configure Postgres database in `mongooseim.toml` file.
+Please refer to the [RDBMS options](../advanced-configuration/outgoing-connections.md#rdbms-options) for more information.
 
 ## Microsoft SQL Server
 
@@ -206,15 +206,16 @@ cat azuresql.sql | tr -d '\r' | tr '\n' ' ' | sed 's/GO/\n/g' |
 isql mongoose-mssql username password -b
 ```
 
-The final step is to configure ``mongooseim.cfg`` appropriately.
-Configure the database section as follows:
+The final step is to configure ``mongooseim.toml`` appropriately.
+Configure the `outgoing_pools.rdbms` section as follows:
 
-```erlang
-{rdbms_server_type, mssql}.
-{outgoing_pools, [
- {rdbms, global, default, [{workers, 5}],
-  [{server, "DSN=mongoose-mssql;UID=username;PWD=password"}]}
-]}.
+```toml
+[outgoing_pools.rdbms.default]
+  workers = 5  
+  
+  [outgoing_pools.rdbms.default.connection]
+    driver = "odbc"
+    settings = "DSN=mongoose-mssql;UID=username;PWD=password"
 ```
 
 # NOSQL
@@ -304,8 +305,9 @@ riak-admin bucket-type activate privacy_lists
 
 This will create bucket types, search schemas and indexes required for storing the above persitent data and it will activate them.
 
-You should also configure Riak in the `mongooseim.cfg` file.
-Please refer to [Advanced configuration/Database setup](../Advanced-configuration.md) for more information.
+You should also configure Riak in the `mongooseim.toml` file.
+Please refer to the [RDBMS options](../advanced-configuration/outgoing-connections.md#rdbms-options)
+and [Riak options](../advanced-configuration/outgoing-connections.md#riak-options) for more information.
 
 ## Cassandra
 
@@ -337,7 +339,7 @@ curl -X PUT $ELASTICSEARCH_URL/muc_messages -d '@priv/elasticsearch/muc.json'
 
 where `$ELASTICSEARCH_URL` is a URL pointing to your ElasticSearch node's HTTP API endpoint.
 
-Please refer to [advanced configuration](../Advanced-configuration.md#elasticsearch-connection-setup) page to check how to configure MongooseIM to connect to ElasticSearch node.
+Please refer to [advanced configuration](../advanced-configuration/outgoing-connections.md#elasticsearch-options) page to check how to configure MongooseIM to connect to ElasticSearch node.
 
 ## Redis
 
@@ -347,7 +349,7 @@ Please refer to [advanced configuration](../Advanced-configuration.md#elasticsea
 
 **Setup**
 
-No additional steps required.
+Please refer to the [Redis options](../advanced-configuration/outgoing-connections.md#redis-specific-options) for more information.
 
 # LDAP
 
@@ -359,4 +361,4 @@ No additional steps required.
 
 **Setup**
 
-No additional steps required, the modules that are using LDAP are very customizable, so they can be configured to support existsing schemas.d
+Please refer to the [LDAP options](../advanced-configuration/outgoing-connections.md#ldap-options) for more information.

--- a/doc/advanced-configuration/outgoing-connections.md
+++ b/doc/advanced-configuration/outgoing-connections.md
@@ -73,13 +73,13 @@ For example:
 
 ## RDBMS options
 
-#### `outgoing_pools.rdbms.*.driver`
+#### `outgoing_pools.rdbms.*.connection.driver`
 * **Syntax:** string, one of `"pgsql"`, `"mysql"` or `"odbc"` (a supported driver)
 * **Example:** `driver = "psgql"`
 
 Selects driver for RDBMS connection. The choice of driver impacts the set of available options.
 
-#### `outgoing_pools.rdbms.*.call_timeout`
+#### `outgoing_pools.rdbms.*.connection.call_timeout`
 * **Syntax:** positive integer
 * **Default:** 60000 (msec)
 * **Example:** `call_timeout = 60000`
@@ -88,7 +88,7 @@ RDBMS pool sets its own default value of this option.
 
 ### ODBC options
 
-#### `outgoing_pools.rdbms.*.settings`
+#### `outgoing_pools.rdbms.*.connection.settings`
 * **Syntax:** string
 * **Default:** no default; required if the `"odbc"` driver is specified
 * **Example:** `settings = "DSN=mydb"`

--- a/doc/modules/mod_shared_roster_ldap.md
+++ b/doc/modules/mod_shared_roster_ldap.md
@@ -3,7 +3,7 @@
 This module, when enabled, will inject roster entries fetched from LDAP. 
 It might get quite complicated to configure it properly, so fasten your seatbelts and prepare for a ride. 
 
-When a default value for an option is defined with "top-level/XXX", it means that the default value is equal to a top-level parameter in `mongooseim.cfg` of the same name. 
+When a default value for an option is defined with "top-level/XXX", it means that the default value is equal to a top-level parameter in `mongooseim.toml` of the same name. 
 If it is not defined, XXX becomes the default value.
 
 ### Options: general

--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -9,7 +9,7 @@ info:
     The response objects are modeled on the `ejabberd_commands` entries and print-outs from `mongooseimctl`.
 
     Please note that many of the fields such as **username** or **caller** expect a **JID** (jabber identifier, f.e. **alice@wonderland.com**). There are two types of **JIDs**:
-      * **bare JID** - consists of **username** and **domain name** (XMPP host, usually the one set in your `mongooseim.cfg` file).
+      * **bare JID** - consists of **username** and **domain name** (XMPP host, usually the one set in your `mongooseim.toml` file).
       * **full JID** - is a **bare JID** with online user's resource to uniquely identify user's connection (f.e. **alice@wonderland.com/resource**).
 schemes:
   - http


### PR DESCRIPTION
This PR updates the `doc/advanced-configuration/database-backends-configuration.md `.
I also think there was an error in the listeners docs concerning the path.
I'm not sure if the provided configuration for MS SQL is correct