### PR TITLE
Clean before install

### DIFF
--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -20,7 +20,7 @@ sed -i '1 s/^.*$/\#\!\/bin\/bash/' tools/install
 sed -i 's#PREFIX=""#PREFIX="mongooseim"#' configure.out
 source configure.out
 export GIT_SSL_NO_VERIFY=1
-make install
+make clean install
 cp -r ../deb/debian mongooseim/DEBIAN
 mkdir -p mongooseim/etc/systemd/system/
 cp -r ../deb/mongooseim.service mongooseim/etc/systemd/system/

--- a/tools/pkg/scripts/rpm/mongooseim.spec
+++ b/tools/pkg/scripts/rpm/mongooseim.spec
@@ -38,7 +38,7 @@ cp %{SOURCE0} .
 %install
 ./tools/configure with-all user=root prefix=/ system=yes
 sed -i 's#PREFIX=\"/\"#PREFIX=\"%{buildroot}\"#' configure.out
-make install
+make clean install
 sed -i 's#RUNNER_USER=\"root\"#RUNNER_USER=\"mongooseim\"#' %{buildroot}/usr/bin/mongooseimctl
 sed -i 's#RUNNER_USER=\"root\"#RUNNER_USER=\"mongooseim\"#' %{buildroot}/usr/lib/mongooseim/bin/mongooseimctl
 sed -i 's#RUNNER_USER=root#RUNNER_USER=\"mongooseim\"#' %{buildroot}/usr/lib/mongooseim/bin/mongooseim


### PR DESCRIPTION
Calls `make clean install` to remove any `_build` files while generating
RPMs and Debian packages. For local development this prevents compiled
artifacts from your local operating system sneaking into the packages.