### PR TITLE
Toml/doc dev guides

### DIFF
--- a/doc/developers-guide/Basic-iq-handler.md
+++ b/doc/developers-guide/Basic-iq-handler.md
@@ -193,7 +193,7 @@ Go to `$REPO/_build/mim1/rel/mongooseim` and start one MongooseIM node.
 ```bash
 $ bin/mongooseim live
 ```
-Open up a new terminal window, go to `$REPO` and use the [test runner](Testing-MongooseIM).
+Open up a new terminal window, go to `$REPO` and use the [test runner](Testing-MongooseIM.md).
 Run single suite with the already started `mim1` node.
 
 ```bash

--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -39,6 +39,9 @@ The extra level of indirection introduced by this call gives the flexibility to 
 `From`, `To` and `Packet` are the arguments passed to the handler just as they would in case of the function being called directly;
 `LServer` is [the XMPP domain for which this hook is signalled](#sidenote-multiple-domains).
 
+**Notice:** For the clarity of the explanation of the hooks mechanism, the provided code snippets are not exactly taken from the current code.
+The reasons for it will be described [later](#creating-your-own-hooks).
+
 ### Getting results from handlers
 
 Hook handlers are called by "folding".
@@ -253,10 +256,13 @@ $0 ~ /ejabberd_hooks:run/ {
 ## Creating your own hooks
 
 There's no special function or any setup necessary to create a new hook.
-The only thing that needs to be done is calling `ejabberd_hooks:run/3` or `ejabberd_hooks:run_fold/4` with the name of the new hook and relevant arguments.
-If you want static code analysis though, you should put the new hook inside `mongoose_hooks` with a correct type specification.
+The only thing that needs to be done is calling `ejabberd_hooks:run_fold/4` with the name of the new hook and relevant arguments.
 
-Of course, as long as no module registers handlers for this hook just running, it won't have any effects.
+However, if you want static code analysis, you should put the new hook inside `mongoose_hooks` with a correct type specification.
+We've added this module to provide some security and type checking in places where the hooks are run.
+This is the way all hooks are called in MongooseIM (see the examples in the [hooks description](hooks_description.md)).gen_iq_handler
+
+Of course, as long as no module registers handlers for a hook, running a `run_fold` won't have any effects.
 
 Similar is the case when a module registers handlers for some hook, but that hook is never run in the code.
 That won't have an effect either.

--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -25,7 +25,7 @@ mod_offline:store_packet(From, To, Packet)
 
 Note that in this example `ejabberd_sm` is coupled with `mod_offline`.
 I.e. if `mod_offline` was not available, the code would simply crash; if it was misconfigured or turned off, the behaviour would be undefined.
-To avoid that coupling and also to enable other ([possibly yet to be written](#sidenote-yet-to-be-written)) code to carry out some action at this particular moment, `ejabberd_sm` instead calls:
+To avoid that coupling and also to enable other ([possibly yet to be written](#sidenote-code-yet-to-be-written)) code to carry out some action at this particular moment, `ejabberd_sm` would instead call:
 
 ```erlang
 Acc1 = ejabberd_hooks:run_fold(offline_message_hook,

--- a/doc/developers-guide/OpenSSL-and-FIPS.md
+++ b/doc/developers-guide/OpenSSL-and-FIPS.md
@@ -62,6 +62,7 @@ mongoose_fips:status().
 ```
 
 The function returns:
+
 * not_enabled - fips_mode is not set to true in etc/app.config
 * enabled - fips_mode is set to true in etc/app.config
 * not_supported - erlang compiled without fips support

--- a/doc/developers-guide/SCRAM-serialization.md
+++ b/doc/developers-guide/SCRAM-serialization.md
@@ -22,7 +22,7 @@ In order to learn more about the meaning of the Stored Key, Server Key, Salt and
 
 * *Password:* `padthai`
 * *Erlang map:*
-```
+```erlang
 #{iteration_count => 4096,
   sha =>
       #{salt => <<"QClQsw/sfPEnwj4AEp6E1w==">>,

--- a/doc/developers-guide/accumulators.md
+++ b/doc/developers-guide/accumulators.md
@@ -26,11 +26,11 @@ The stanza should always be packed into an accumulator and passed on, so that in
 
 There are three main benefits from this approach:
 
-a) performance - if we need to do something involving inspecting a stanza or more complicated operations (e.g. privacy check) we don't need to do it multiple times on various stages of processing - instead we can do it once and store the result in an accumulator
+1. Performance - if we need to do something involving inspecting a stanza or more complicated operations (e.g. privacy check) we don't need to do it multiple times on various stages of processing - instead we can do it once and store the result in an accumulator.
 
-b) debugging - it is now very easy to produce an exact track record of a stanza
+2. Debugging - it is now very easy to produce an exact track record of a stanza.
 
-c) simplified implementation of modules which inherently involve multi-stage processing (e.g. `mod_amp`)
+3. Simplified implementation of modules which inherently involve multi-stage processing (e.g. `mod_amp`).
 
 ## API
 
@@ -90,7 +90,7 @@ Accumulator is used mostly to cache values for reuse within a c2s process; when 
 
 If you want it to carry some additional values along with it, please use a dedicated api for setting "permanent" fields:
 
-```
+```erlang
 Acc2 = mongoose_acc:set_permanent(myns, myprop, 123, Acc1),
 ```
 
@@ -152,4 +152,3 @@ There are many places in the server, where an accumulator may be created, so `or
 ### Performance measurement
 
 Given that each accumulator has a timestamp denoting its creation time, it is now very easy to implement a metric showing the stanza processing time, or even multiple metrics splitting it into stages.
-

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -152,7 +152,7 @@ Handler function are expected to return:
 In the default implementation the hook is not used, built-in user control methods are supported elsewhere.
 This is the perfect place to plug in custom security control.
 
-## other hooks
+## Other hooks
 
 * adhoc_local_items
 * adhoc_sm_items

--- a/doc/developers-guide/message_routing.md
+++ b/doc/developers-guide/message_routing.md
@@ -3,7 +3,7 @@
 Let's examine the flow of a message sent from user A to user B, both of whom are served by the same domain.
 
 Note that hooks are called at various stages of routing - they perform many tasks, in fact, many MongooseIM functionalities are implemented through hooks & handlers. 
-For a general introduction to hooks, see [Hooks and Handlers](Hooks-and-handlers.md); to get a closer look at a core few, see [hooks description](hooks_description.md).
+For a general introduction to hooks, see [Hooks and Handlers](Hooks-and-handlers.md); to get a closer look at a core few, see the [hooks description](hooks_description.md).
 
 **1. Receiving the stanza**
 
@@ -46,14 +46,14 @@ The default behaviour is the following:
 An external component and a local route are obtained by looking up `external_component` and `route` mnesia tables, respectively. 
 The items stored in the tables provide funs to call and MFs to apply:
 
-    ```erlang
-    (ejabberd@localhost)2> ets:tab2list(route).
-    [{route,<<"vjud.localhost">>,
-            {apply_fun,#Fun<ejabberd_router.2.123745223>}},
-     {route,<<"muc.localhost">>,
-            {apply_fun,#Fun<mod_muc.2.63726579>}},
-     {route,<<"localhost">>,{apply,ejabberd_local,route}}]
-    ```
+```erlang
+(ejabberd@localhost)2> ets:tab2list(route).
+[{route,<<"vjud.localhost">>,
+        {apply_fun,#Fun<ejabberd_router.2.123745223>}},
+ {route,<<"muc.localhost">>,
+        {apply_fun,#Fun<mod_muc.2.63726579>}},
+ {route,<<"localhost">>,{apply,ejabberd_local,route}}]
+```
 
 Here we see that for a domain "localhost" `ejabberd_local:route()`is called.
 Routing the stanza there means calling `mongoose_local_delivery:do_route/5`, which calls `filter_local_packet` hook and, if passed, runs the fun or applies the handler.

--- a/doc/developers-guide/mod_amp_developers_guide.md
+++ b/doc/developers-guide/mod_amp_developers_guide.md
@@ -43,7 +43,7 @@ Hooks for Other Modules
 -----------------------
 
 If your module would like to have some say in the amp decision making process, please refer to the hooks: `amp_determine_strategy` and `amp_check_condition`.
-Remeber that the hook for check_condition is a fold on a boolean(), and should behave like a variadic `or`. 
+Remember that the hook for check_condition is a fold on a boolean(), and should behave like a variadic `or`. 
 I.e: once a rule is deemed to apply, other hooks SHOULD NOT revert this value to false.
 
 Cf. this code from `amp_resolver`:

--- a/doc/developers-guide/mod_muc_light_developers_guide.md
+++ b/doc/developers-guide/mod_muc_light_developers_guide.md
@@ -6,7 +6,7 @@ This is an in-depth guide on `mod_muc_light` design decisions and implementation
 Source, header and test suite files
 -------------------------------
 
-All source files can be found in `src/`.
+All source files can be found in `src/muc_light/`.
 
 * `mod_muc_light.erl`
   Main module.

--- a/doc/developers-guide/xep_tool.md
+++ b/doc/developers-guide/xep_tool.md
@@ -12,7 +12,7 @@ For example `mod_privacy` file implements [XEP-0016: Privacy Lists](http://xmpp.
 
 #### Mandatory `xep` and `version`
 
-In order to let the XEP-tool know about your module, we add a special attribute `xep` at the begining of the `mod_privacy` module:
+In order to let the XEP-tool know about your module, we add a special attribute `xep` at the beginning of the `mod_privacy` module:
 
 ```
 -xep([{xep, 16}, {version, "1.6"}]).


### PR DESCRIPTION
This PR fixes minor issues found in the dev guide docs, and rewords parts of the hooks description.
Many files were only checked for obvious issues and may need to be revisited and updated in the future (e.g. the `xep-tool` description).
