### PR TITLE
Clean before install

### DIFF
--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -15,11 +15,13 @@ apt-get update
 
 rm -rf /usr/lib/erlang/man/man3/cerff.3.gz /usr/lib/erlang/man/man3/cerfl.3.gz /usr/lib/erlang/man/man3/cerfcl.3.gz /usr/lib/erlang/man/man3/cerfcf.3.gz /usr/lib/erlang/man/man3/cerfcf.3.gz /usr/lib/erlang/man/man1/x86_64-linux-gnu-gcov-tool.1.gz  /usr/lib/erlang/man/man1/ocamlbuild.native.1.gz  /usr/lib/erlang/man/man1/gcov-tool.1.gz /usr/lib/erlang/man/man1/ocamlbuild.byte.1.gz
 
+make clean
 sed -i '1 s/^.*$/\#\!\/bin\/bash/' tools/install
 ./tools/configure with-all user=mongooseim prefix="" system=yes
 sed -i 's#PREFIX=""#PREFIX="mongooseim"#' configure.out
 source configure.out
 export GIT_SSL_NO_VERIFY=1
+
 make install
 cp -r ../deb/debian mongooseim/DEBIAN
 mkdir -p mongooseim/etc/systemd/system/

--- a/tools/pkg/scripts/rpm/mongooseim.spec
+++ b/tools/pkg/scripts/rpm/mongooseim.spec
@@ -36,6 +36,7 @@ scale in need of more capacity (by just adding a box/VM).
 cp %{SOURCE0} .
 
 %install
+make clean
 ./tools/configure with-all user=root prefix=/ system=yes
 sed -i 's#PREFIX=\"/\"#PREFIX=\"%{buildroot}\"#' configure.out
 make install


### PR DESCRIPTION
Removes `_build` and `asngen` before  `make install` to remove any
locally compiled artifacts before making RPMs and Debian packages.
For local development this prevents compiled artifacts from your
your local operating system sneaking into the packages.
