### PR TITLE
Increase meck timeout to 10s to prevent timeouts

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -459,20 +459,20 @@ domain() ->
     ct:get_config({hosts, mim, domain}).
 
 init_per_testcase(CaseName = load_already_registered_permanent_rooms, Config) ->
-    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
+    meck_room(),
     meck_room_start(),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName = create_already_registered_room, Config) ->
-    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
+    meck_room(),
     meck_room_start(),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName = check_presence_route_to_offline_room, Config) ->
-    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
+    meck_room(),
     meck_room_start(),
     meck_room_route(),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName = check_message_route_to_offline_room, Config) ->
-    ok = rpc(mim(), meck, new, [mod_muc_room, [no_link, passthrough]]),
+    meck_room(),
     meck_room_start(),
     meck_room_route(),
     escalus:init_per_testcase(CaseName, Config);
@@ -533,6 +533,10 @@ init_per_testcase(CaseName, Config) when CaseName =:= disco_features_with_mam;
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
+
+meck_room() ->
+    RPCSpec = (mim())#{timeout => timer:seconds(10)}, % it takes long to compile this module
+    ok = rpc(RPCSpec, meck, new, [mod_muc_room, [no_link, passthrough]]).
 
 %% Meck will register a fake room right before a 'real' room is started
 meck_room_start() ->


### PR DESCRIPTION
It takes about 4s to compile 'mod_muc_room' on CI, so it is likely that long compilation causes random failures like [this one](https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/2903/34413/riak_mnesia.23.0.3-1/big/ct_run.test@default-c3abfa5b-16b9-48fe-ab56-a53b143e6468.2020-10-08_07.30.10/big_tests.tests.muc_SUITE.logs/run.2020-10-08_07.41.54/suite.log.html)
