### PR TITLE
ejabberd_auth takes full jids instead of plain binaries

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -167,7 +167,7 @@ admin_notify(Config) ->
     [Username2, _Server2, _Pass2] = escalus_users:get_usp(Config, UserSpec2),
     [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
 
-    rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+    rpc(mim(), ejabberd_auth, try_register, [mongoose_helper:make_jid(AdminU, AdminS), AdminP]),
     escalus:story(Config, [{admin, 1}], fun(Admin) ->
         escalus:create_users(Config, escalus:get_users([Name1, Name2])),
 
@@ -198,12 +198,12 @@ null_password(Config) ->
     {username, Name} = lists:keyfind(username, 1, Details),
     {server, Server} = lists:keyfind(server, 1, Details),
     escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Response),
-    false = rpc(mim(), ejabberd_auth, does_user_exist, [Name, Server]).
+    false = rpc(mim(), ejabberd_auth, does_user_exist, [mongoose_helper:make_jid(Name, Server)]).
 
 check_unregistered(Config) ->
     [{_, UserSpec}] = escalus_users:get_users([bob]),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),
-    false = rpc(mim(), ejabberd_auth, does_user_exist, [Username, Server]).
+    false = rpc(mim(), ejabberd_auth, does_user_exist, [mongoose_helper:make_jid(Username, Server)]).
 
 bad_request_registration_cancelation(Config) ->
 
@@ -373,7 +373,7 @@ bad_cancelation_stanza() ->
 user_exists(Name, Config) ->
     {Name, Client} = escalus_users:get_user_by_name(Name),
     [Username, Server, _Pass] = escalus_users:get_usp(Config, Client),
-    rpc(mim(), ejabberd_auth, does_user_exist, [Username, Server]).
+    rpc(mim(), ejabberd_auth, does_user_exist, [mongoose_helper:make_jid(Username, Server)]).
 
 reload_mod_register_option(Config, Key, Value) ->
     Host = domain(),

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -306,7 +306,8 @@ end_per_testcase(delete_old_users, Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),
     lists:foreach(fun({_User, UserSpec}) ->
                 {Username, Domain, Pass} = get_user_data(UserSpec, Config),
-                rpc(mim(), ejabberd_auth, try_register, [Username, Domain, Pass])
+                JID = mongoose_helper:make_jid(Username, Domain),
+                rpc(mim(), ejabberd_auth, try_register, [JID, Pass])
         end, Users),
     escalus:end_per_testcase(delete_old_users, Config);
 end_per_testcase(check_password_hash, Config) ->
@@ -1310,7 +1311,8 @@ set_last(User, Domain, TStamp) ->
 delete_users(Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),
     lists:foreach(fun({User, Domain}) ->
-                rpc(mim(), ejabberd_auth, remove_user, [User, Domain])
+                JID = mongoose_helper:make_jid(User, Domain),
+                rpc(mim(), ejabberd_auth, remove_user, [JID])
         end, get_registered_users()).
 
 %%-----------------------------------------------------------------

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -430,8 +430,8 @@ verify_format(GroupName, {_User, Props}) ->
     Username = escalus_utils:jid_to_lower(proplists:get_value(username, Props)),
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
-
-    SPassword = rpc(mim(), ejabberd_auth, get_password, [Username, Server]),
+    JID = mongoose_helper:make_jid(Username, Server),
+    SPassword = rpc(mim(), ejabberd_auth, get_password, [JID]),
     do_verify_format(GroupName, Password, SPassword).
 
 

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2990,13 +2990,14 @@ check_user_exist(Config) ->
   %% when
   [{_, AdminSpec}] = escalus_users:get_users([admin]),
   [AdminU, AdminS, AdminP] = escalus_users:get_usp(Config, AdminSpec),
-  ok = rpc(mim(), ejabberd_auth, try_register, [AdminU, AdminS, AdminP]),
+  JID = mongoose_helper:make_jid(AdminU, AdminS),
+  ok = rpc(mim(), ejabberd_auth, try_register, [JID, AdminP]),
   %% admin user already registered
-  true = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, AdminS]),
-  false = rpc(mim(), ejabberd_users, does_user_exist, [<<"fake-user">>, AdminS]),
-  false = rpc(mim(), ejabberd_users, does_user_exist, [AdminU, <<"fake-domain">>]),
+  true = rpc(mim(), ejabberd_users, does_user_exist, [JID]),
+  false = rpc(mim(), ejabberd_users, does_user_exist, [mongoose_helper:make_jid(<<"fake-user">>, AdminS)]),
+  false = rpc(mim(), ejabberd_users, does_user_exist, [mongoose_helper:make_jid(AdminU, <<"fake-domain">>)]),
   %% cleanup
-  ok = rpc(mim(), ejabberd_auth, remove_user, [AdminU, AdminS]).
+  ok = rpc(mim(), ejabberd_auth, remove_user, [JID]).
 
 %% This function supports only one device, one user.
 %% We don't send initial presence to avoid presence broadcasts between resources

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -26,6 +26,7 @@
 -export([wait_until/2, wait_until/3, wait_for_user/3]).
 
 -export([inject_module/1, inject_module/2, inject_module/3]).
+-export([make_jid/2]).
 -export([make_jid/3]).
 -export([make_jid_noprep/3]).
 -export([get_session_pid/2]).
@@ -372,6 +373,9 @@ inject_module(Node, Module, reload) ->
 
 make_jid_noprep(User, Server, Resource) ->
     jid:make_noprep(User, Server, Resource).
+
+make_jid(User, Server) ->
+    jid:make(User, Server, <<>>).
 
 make_jid(User, Server, Resource) ->
     jid:make(User, Server, Resource).

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -371,7 +371,8 @@ verify_format(GroupName, {_User, Props}) ->
     Username = escalus_utils:jid_to_lower(proplists:get_value(username, Props)),
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
-    SPassword = rpc(mim(), ejabberd_auth, get_password, [Username, Server]),
+    JID = mongoose_helper:make_jid(Username, Server),
+    SPassword = rpc(mim(), ejabberd_auth, get_password, [JID]),
     do_verify_format(GroupName, Password, SPassword).
 
 do_verify_format(login_scram, _Password, SPassword) ->

--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -41,6 +41,7 @@
 
 -include("mongoose.hrl").
 -include("ejabberd_commands.hrl").
+-include("jlib.hrl").
 
 %%%
 %%% Register commands
@@ -101,9 +102,10 @@ commands() ->
 -spec set_password(jid:user(), jid:server(), binary()) ->
     {error, string()} | {ok, string()}.
 set_password(User, Host, Password) ->
-    case ejabberd_auth:set_password(User, Host, Password) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:set_password(JID, Password) of
         ok ->
-            {ok, io_lib:format("Password for user ~s@~s successfully changed", [User, Host])};
+            {ok, io_lib:format("Password for user ~s successfully changed", [jid:to_binary(JID)])};
         {error, Reason} ->
             {error, Reason}
     end.
@@ -111,28 +113,30 @@ set_password(User, Host, Password) ->
 -spec check_password(jid:user(), jid:server(), binary()) ->  {Res, string()} when
     Res :: ok | incorrect | user_does_not_exist.
 check_password(User, Host, Password) ->
-    case ejabberd_auth:does_user_exist(User, Host) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            case ejabberd_auth:check_password(User, Host, Password) of
+            case ejabberd_auth:check_password(JID, Password) of
                 true ->
-                    {ok, io_lib:format("Password '~s' for user ~s@~s is correct",
-                                       [Password, User, Host])};
+                    {ok, io_lib:format("Password '~s' for user ~s is correct",
+                                       [Password, jid:to_binary(JID)])};
                 false ->
-                    {incorrect, io_lib:format("Password '~s' for user ~s@~s is incorrect",
-                                              [Password, User, Host])}
+                    {incorrect, io_lib:format("Password '~s' for user ~s is incorrect",
+                                              [Password, jid:to_binary(JID)])}
             end;
         false ->
             {user_does_not_exist,
-            io_lib:format("Password '~s' for user ~s@~s is incorrect because this user does not"
+            io_lib:format("Password '~s@~s' for user ~s is incorrect because this user does not"
                           " exist", [Password, User, Host])}
     end.
 
 -spec check_account(jid:user(), jid:server()) -> {Res, string()} when
     Res :: ok | user_does_not_exist.
 check_account(User, Host) ->
-    case ejabberd_auth:does_user_exist(User, Host) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            {ok, io_lib:format("User ~s@~s exists", [User, Host])};
+            {ok, io_lib:format("User ~s exists", [jid:to_binary(JID)])};
         false ->
             {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [User, Host])}
     end.
@@ -142,7 +146,7 @@ check_account(User, Host) ->
                           Hash :: binary(), Method :: string()) ->
     {error, string()} | {ok, string()} | {incorrect, string()}.
 check_password_hash(User, Host, PasswordHash, HashMethod) ->
-    AccountPass = ejabberd_auth:get_password_s(User, Host),
+    AccountPass = ejabberd_auth:get_password_s(jid:make(User, Host, <<>>)),
     AccountPassHash = case HashMethod of
         "md5" -> get_md5(AccountPass);
         "sha" -> get_sha(AccountPass);
@@ -219,15 +223,15 @@ delete_old_user({LUser, LServer}, TimeStampNow, SecOlder) ->
     %% Check if the user is logged
     JID = jid:make(LUser, LServer, <<>>),
     case ejabberd_sm:get_user_resources(JID) of
-        [] -> delete_old_user_if_nonactive_long_enough(LUser, LServer, TimeStampNow, SecOlder);
+        [] -> delete_old_user_if_nonactive_long_enough(JID, TimeStampNow, SecOlder);
         _ -> false
     end.
 
--spec delete_old_user_if_nonactive_long_enough(LUser :: jid:luser(),
-                                               LServer :: jid:lserver(),
+-spec delete_old_user_if_nonactive_long_enough(JID :: jid:jid(),
                                                TimeStampNow :: non_neg_integer(),
                                                SecOlder :: non_neg_integer()) -> boolean().
-delete_old_user_if_nonactive_long_enough(LUser, LServer, TimeStampNow, SecOlder) ->
+delete_old_user_if_nonactive_long_enough(JID, TimeStampNow, SecOlder) ->
+    {LUser, LServer} = jid:to_lus(JID),
     case mod_last:get_last_info(LUser, LServer) of
         {ok, TimeStamp, _Status} ->
             %% get his age
@@ -240,45 +244,45 @@ delete_old_user_if_nonactive_long_enough(LUser, LServer, TimeStampNow, SecOlder)
                 %% older:
                 false ->
                     %% remove the user
-                    ejabberd_auth:remove_user(LUser, LServer),
+                    ejabberd_auth:remove_user(JID),
                     true
             end;
         not_found ->
-            ejabberd_auth:remove_user(LUser, LServer),
+            ejabberd_auth:remove_user(JID),
             true
     end.
 
 -spec ban_account(jid:user(), jid:server(), binary() | string()) ->
     {ok, string()} | {error, string()}.
 ban_account(User, Host, ReasonText) ->
+    JID = jid:make(User, Host, <<>>),
     Reason = service_admin_extra_sessions:prepare_reason(ReasonText),
-    kick_sessions(User, Host, Reason),
-    case set_random_password(User, Host, Reason) of
+    kick_sessions(JID, Reason),
+    case set_random_password(JID, Reason) of
         ok ->
-            {ok, io_lib:format("User ~s@~s successfully banned with reason: ~s",
-                               [User, Host, ReasonText])};
+            {ok, io_lib:format("User ~s successfully banned with reason: ~s",
+                               [jid:to_binary(JID), ReasonText])};
         {error, ErrorReason} ->
             {error, ErrorReason}
     end.
 
--spec kick_sessions(jid:user(), jid:server(), binary()) -> [ok].
-kick_sessions(User, Server, Reason) ->
-    JID = jid:make(User, Server, <<>>),
+-spec kick_sessions(jid:jid(), binary()) -> [ok].
+kick_sessions(JID, Reason) ->
     lists:map(
         fun(Resource) ->
-                service_admin_extra_sessions:kick_session(User, Server, Resource, Reason)
+                service_admin_extra_sessions:kick_session(
+                  jid:replace_resource(JID, Resource), Reason)
         end,
         ejabberd_sm:get_user_resources(JID)).
 
 
--spec set_random_password(User, Server, Reason) -> Result when
-      User :: jid:user(),
-      Server :: jid:server(),
+-spec set_random_password(JID, Reason) -> Result when
+      JID :: jid:jid(),
       Reason :: binary(),
       Result :: 'ok' | {error, any()}.
-set_random_password(User, Server, Reason) ->
+set_random_password(JID, Reason) ->
     NewPass = build_random_password(Reason),
-    ejabberd_auth:set_password(User, Server, NewPass).
+    ejabberd_auth:set_password(JID, NewPass).
 
 
 -spec build_random_password(Reason :: binary()) -> binary().

--- a/src/admin_extra/service_admin_extra_gdpr.erl
+++ b/src/admin_extra/service_admin_extra_gdpr.erl
@@ -25,9 +25,10 @@ commands() -> [
 
 -spec retrieve_all(jid:user(), jid:server(), Path :: binary()) -> ok | {error, Reason :: any()}.
 retrieve_all(Username, Domain, ResultFilePath) ->
-    case user_exists(Username, Domain) of
+    JID = jid:make(Username, Domain, <<>>),
+    case user_exists(JID) of
         true ->
-            DataFromModules = get_data_from_modules(Username, Domain),
+            DataFromModules = get_data_from_modules(JID),
             % The contract is that we create personal data files only when there are any items
             % returned for the data group.
             DataToWrite = lists:filter(fun({_, _, Items}) -> Items /= [] end, DataFromModules),
@@ -60,6 +61,10 @@ retrieve_all(Username, Domain, ResultFilePath) ->
 -spec get_data_from_modules(jid:user(), jid:server()) -> gdpr:personal_data().
 get_data_from_modules(Username, Domain) ->
     JID = jid:make(Username, Domain, <<>>),
+    get_data_from_modules(JID).
+
+-spec get_data_from_modules(jid:jid()) -> gdpr:personal_data().
+get_data_from_modules(JID) ->
     mongoose_hooks:get_personal_data(JID#jid.lserver, [], JID).
 
 -spec to_csv_file(CsvFilename :: binary(), gdpr:schema(), gdpr:entities(), file:name()) -> ok.
@@ -70,9 +75,9 @@ to_csv_file(Filename, DataSchema, DataRows, TmpDir) ->
     lists:foreach(fun(Row) -> csv_gen:row(File, Row) end, DataRows),
     file:close(File).
 
--spec user_exists(gdpr:username(), gdpr:domain()) -> boolean().
-user_exists(Username, Domain) ->
-    ejabberd_auth:does_user_exist(Username, Domain).
+-spec user_exists(jid:jid()) -> boolean().
+user_exists(JID) ->
+    ejabberd_auth:does_user_exist(JID).
 
 -spec make_tmp_dir() -> file:name().
 make_tmp_dir() ->

--- a/src/admin_extra/service_admin_extra_last.erl
+++ b/src/admin_extra/service_admin_extra_last.erl
@@ -61,11 +61,12 @@ commands() ->
 -spec set_last(jid:user(), jid:server(), _, _) -> {Res, string()} when
     Res :: ok | user_does_not_exist.
 set_last(User, Server, Timestamp, Status) ->
-    case ejabberd_auth:does_user_exist(User, Server) of
+    JID = jid:make(User, Server, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            mod_last:store_last_info(jid:nodeprep(User), jid:nameprep(Server), Timestamp, Status),
-            {ok, io_lib:format("Last activity for user ~s@~s is set as ~B with status ~s",
-                               [User, Server, Timestamp, Status])};
+            mod_last:store_last_info(JID#jid.luser, JID#jid.lserver, Timestamp, Status),
+            {ok, io_lib:format("Last activity for user ~s is set as ~B with status ~s",
+                               [jid:to_binary(JID), Timestamp, Status])};
         false ->
             String = io_lib:format("User ~s@~s does not exist", [User, Server]),
             {user_does_not_exist, String}

--- a/src/admin_extra/service_admin_extra_private.erl
+++ b/src/admin_extra/service_admin_extra_private.erl
@@ -68,16 +68,16 @@ commands() ->
 -spec private_get(jid:user(), jid:server(), binary(), binary()) ->
     {error, string()} | string().
 private_get(Username, Host, Element, Ns) ->
-    case ejabberd_auth:does_user_exist(Username, Host) of
+    JID = jid:make(Username, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            do_private_get(Username, Host, Element, Ns);
+            do_private_get(JID, Element, Ns);
         false ->
             {error, io_lib:format("User ~s@~s does not exist", [Username, Host])}
     end.
 
-do_private_get(Username, Host, Element, Ns) ->
-    From = jid:make(Username, Host, <<"">>),
-    To = jid:make(Username, Host, <<"">>),
+do_private_get(JID, Element, Ns) ->
+    From = To = JID,
     IQ = {iq, <<"">>, get, ?NS_PRIVATE, <<"">>,
           #xmlel{ name = <<"query">>,
                   attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
@@ -108,18 +108,18 @@ private_set(Username, Host, ElementString) ->
 
 
 private_set2(Username, Host, Xml) ->
-    case ejabberd_auth:does_user_exist(Username, Host) of
+    JID = jid:make(Username, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            do_private_set2(Username, Host, Xml);
+            do_private_set2(JID, Xml);
         false ->
-            {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [Username, Host])}
+            {user_does_not_exist, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
     end.
 
-do_private_set2(Username, Host, Xml) ->
+do_private_set2(#jid{lserver = Host} = JID, Xml) ->
     case is_private_module_loaded(Host) of
         true ->
-            From = jid:make(Username, Host, <<"">>),
-            To = jid:make(Username, Host, <<"">>),
+            From = To = JID,
             IQ = {iq, <<"">>, set, ?NS_PRIVATE, <<"">>,
                   #xmlel{ name = <<"query">>,
                           attrs = [{<<"xmlns">>, ?NS_PRIVATE}],

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -164,7 +164,8 @@ commands() ->
                      Subs :: subs()) -> {Res, string()} when
     Res :: user_doest_not_exist | error | bad_subs | ok.
 add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
-    case ejabberd_auth:does_user_exist(LocalUser, LocalServer) of
+    JID = jid:make(LocalUser, LocalServer, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
             case subscribe(LocalUser, LocalServer, User, Server, Nick, Group, Subs, []) of
                 {atomic, _} ->
@@ -213,7 +214,8 @@ subscribe(LU, LS, User, Server, Nick, Group, SubscriptionS, _Xattrs) ->
                         Server :: jid:server()) -> {Res, string()} when
     Res :: ok | error | user_does_not_exist.
 delete_rosteritem(LocalUser, LocalServer, User, Server) ->
-    case ejabberd_auth:does_user_exist(LocalUser, LocalServer) of
+    JID = jid:make(LocalUser, LocalServer, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
             case unsubscribe(LocalUser, LocalServer, User, Server) of
                 {atomic, ok} ->

--- a/src/admin_extra/service_admin_extra_sessions.erl
+++ b/src/admin_extra/service_admin_extra_sessions.erl
@@ -31,6 +31,7 @@
 
     num_resources/2,
     resource_num/3,
+    kick_session/2,
     kick_session/4,
     prepare_reason/1,
     status_num/2, status_num/1,
@@ -187,12 +188,14 @@ resource_num(User, Host, Num) ->
     end.
 
 
--spec kick_session(jid:user(), jid:server(), jid:resource(),
-        ReasonText :: binary() | list()) -> 'ok'.
-kick_session(User, Server, Resource, ReasonText) ->
-    ejabberd_c2s:terminate_session(jid:make(User, Server, Resource),
-                                   prepare_reason(ReasonText)),
+-spec kick_session(jid:jid(), binary() | list()) -> ok.
+kick_session(JID, ReasonText) ->
+    ejabberd_c2s:terminate_session(JID, prepare_reason(ReasonText)),
     ok.
+
+-spec kick_session(jid:user(), jid:server(), jid:resource(), list() | binary()) -> ok.
+kick_session(User, Server, Resource, ReasonText) ->
+    kick_session(jid:make(User, Server, Resource), prepare_reason(ReasonText)).
 
 
 -spec prepare_reason(binary() | string()) -> binary().

--- a/src/admin_extra/service_admin_extra_vcard.erl
+++ b/src/admin_extra/service_admin_extra_vcard.erl
@@ -123,9 +123,10 @@ commands() ->
 -spec get_vcard(jid:user(), jid:server(), any())
                -> {error, string()} | [binary()].
 get_vcard(User, Host, Name) ->
-    case ejabberd_auth:does_user_exist(User, Host) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            get_vcard_content(User, Host, [Name]);
+            get_vcard_content(JID, [Name]);
         false ->
             {error, io_lib:format("User ~s@~s does not exist", [User, Host])}
     end.
@@ -133,9 +134,10 @@ get_vcard(User, Host, Name) ->
 -spec get_vcard(jid:user(), jid:server(), any(), any())
                -> {error, string()} | [binary()].
 get_vcard(User, Host, Name, Subname) ->
-    case ejabberd_auth:does_user_exist(User, Host) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            get_vcard_content(User, Host, [Name, Subname]);
+            get_vcard_content(JID, [Name, Subname]);
         false ->
             {error, io_lib:format("User ~s@~s does not exist", [User, Host])}
     end.
@@ -143,9 +145,10 @@ get_vcard(User, Host, Name, Subname) ->
 -spec set_vcard(jid:user(), jid:server(), [binary()],
                 binary() | [binary()]) -> {ok, string()} | {user_does_not_exist, string()}.
 set_vcard(User, Host, Name, SomeContent) ->
-    case ejabberd_auth:does_user_exist(User, Host) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            set_vcard_content(User, Host, [Name], SomeContent);
+            set_vcard_content(JID, [Name], SomeContent);
         false ->
             {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [User, Host])}
     end.
@@ -153,9 +156,10 @@ set_vcard(User, Host, Name, SomeContent) ->
 -spec set_vcard(jid:user(), jid:server(), [binary()], [binary()],
                 binary() | [binary()]) -> {ok, string()} | {user_does_not_exist, string()}.
 set_vcard(User, Host, Name, Subname, SomeContent) ->
-    case ejabberd_auth:does_user_exist(User, Host) of
+    JID = jid:make(User, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            set_vcard_content(User, Host, [Name, Subname], SomeContent);
+            set_vcard_content(JID, [Name, Subname], SomeContent);
         false ->
             {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [User, Host])}
     end.
@@ -172,10 +176,10 @@ get_module_resource(Server) ->
     end.
 
 
--spec get_vcard_content(jid:user(), jid:server(), any())
-                       -> {error, string()} | list(binary()).
-get_vcard_content(User, Server, Data) ->
-    JID = jid:make(User, Server, list_to_binary(get_module_resource(Server))),
+-spec get_vcard_content(jid:jid(), any()) ->
+    {error, string()} | list(binary()).
+get_vcard_content(#jid{lserver = LServer} = NoResJID, Data) ->
+    JID = jid:replace_resource(NoResJID, list_to_binary(get_module_resource(LServer))),
     IQ = #iq{type = get, xmlns = ?NS_VCARD, sub_el = []},
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               from_jid => JID,
@@ -203,12 +207,11 @@ get_vcard([Data1, Data2], A1) ->
 get_vcard([Data], A1) ->
     exml_query:subelements(A1, Data).
 
--spec set_vcard_content(jid:user(), jid:server(), Data :: [binary()],
+-spec set_vcard_content(jid:jid(), Data :: [binary()],
                         ContentList :: binary() | [binary()]) -> {ok, string()}.
-set_vcard_content(U, S, D, SomeContent) when is_binary(SomeContent) ->
-    set_vcard_content(U, S, D, [SomeContent]);
-set_vcard_content(User, Server, Data, ContentList) ->
-    JID = jid:make(User, Server, <<>>),
+set_vcard_content(JID, D, SomeContent) when is_binary(SomeContent) ->
+    set_vcard_content(JID, D, [SomeContent]);
+set_vcard_content(JID, Data, ContentList) ->
     IQ = #iq{type = get, xmlns = ?NS_VCARD, sub_el = []},
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               from_jid => JID,

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -33,22 +33,21 @@
          get_opt/3,
          get_opt/2,
          authorize/1,
-         set_password/3,
-         check_password/3,
-         check_password/5,
-         try_register/3,
+         set_password/2,
+         check_password/2,
+         check_password/4,
+         try_register/2,
          dirty_get_registered_users/0,
          get_vh_registered_users/1,
          get_vh_registered_users/2,
          get_vh_registered_users_number/1,
          get_vh_registered_users_number/2,
-         get_password/2,
-         get_password_s/2,
-         get_passterm_with_authmodule/2,
+         get_password/1,
+         get_password_s/1,
+         get_passterm_with_authmodule/1,
          does_user_exist/1,
-         does_user_exist/2,
-         is_user_exists_in_other_modules/3,
-         remove_user/2,
+         is_user_exists_in_other_modules/2,
+         remove_user/1,
          supports_sasl_module/2,
          entropy/1
         ]).
@@ -154,44 +153,24 @@ do_authorize_loop([M | Modules], Creds) ->
 
 
 %% @doc Check if the user and password can login in server.
--spec check_password(User :: jid:user(),
-                     Server :: jid:server(),
-                     Password :: binary() ) -> boolean().
-check_password(User, Server, Password) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_check_password(LUser, LServer, Password).
-
--spec do_check_password(jid:luser(), jid:lserver(), binary()) -> boolean().
-do_check_password(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+-spec check_password(JID :: jid:jid() | error, Password :: binary()) -> boolean().
+check_password(error, _Password) ->
     false;
-do_check_password(LUser, LServer, Password) ->
-    case check_password_with_authmodule(LUser, LServer, Password) of
+check_password(#jid{} = JID, Password) ->
+    case check_password_with_authmodule(JID, Password) of
         {true, _AuthModule} -> true;
         false -> false
     end.
 
 %% @doc Check if the user and password can login in server.
--spec check_password(User :: jid:user(),
-                     Server :: jid:server(),
+-spec check_password(JID :: jid:jid() | error,
                      Password :: binary(),
                      Digest :: binary(),
-                     DigestGen :: fun()) -> boolean().
-check_password(User, Server, Password, Digest, DigestGen) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_check_password(LUser, LServer, Password, Digest, DigestGen).
-
--spec do_check_password(User :: jid:luser(),
-                     Server :: jid:lserver(),
-                     Password :: binary(),
-                     Digest :: binary(),
-                     DigestGen :: fun()) -> boolean().
-do_check_password(LUser, LServer, _, _, _)
-    when LUser =:= error; LServer =:= error ->
+                     DigestGen :: fun((binary()) -> binary())) -> boolean().
+check_password(error, _, _, _) ->
     false;
-do_check_password(LUser, LServer, Password, Digest, DigestGen) ->
-    case check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen) of
+check_password(#jid{} = JID, Password, Digest, DigestGen) ->
+    case check_password_with_authmodule(JID, Password, Digest, DigestGen) of
         {true, _AuthModule} -> true;
         false -> false
     end.
@@ -199,46 +178,17 @@ do_check_password(LUser, LServer, Password, Digest, DigestGen) ->
 %% @doc Check if the user and password can login in server.
 %% The user can login if at least an authentication method accepts the user
 %% and the password.
--spec check_password_with_authmodule(User :: binary(),
-                                     Server :: binary(),
-                                     Password :: binary()
-                                     ) -> 'false' | {'true', authmodule()}.
-check_password_with_authmodule(User, Server, Password) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_check_password_with_authmodule(LUser, LServer, Password).
-
--spec do_check_password_with_authmodule(LUser :: jid:luser(),
-                                        LServer :: jid:lserver(),
-                                        Password :: binary()
-                                       ) -> 'false' | {'true', authmodule()}.
-do_check_password_with_authmodule(LUser, LServer, _)
-    when LUser =:= error; LServer =:= error ->
-    false;
-do_check_password_with_authmodule(LUser, LServer, Password) ->
+-spec check_password_with_authmodule(JID :: jid:jid(), Password :: binary()) ->
+    false | {true, authmodule()}.
+check_password_with_authmodule(#jid{luser = LUser, lserver = LServer}, Password) ->
     check_password_loop(auth_modules(LServer), [LUser, LServer, Password]).
 
--spec check_password_with_authmodule(User :: binary(),
-                                     Server :: binary(),
+-spec check_password_with_authmodule(JID :: jid:jid(),
                                      Password :: binary(),
                                      Digest :: binary(),
-                                     DigestGen :: fun()
+                                     DigestGen :: fun((binary()) -> binary())
                                      ) -> 'false' | {'true', authmodule()}.
-check_password_with_authmodule(User, Server, Password, Digest, DigestGen) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen).
-
--spec do_check_password_with_authmodule(LUser :: jid:luser(),
-                                        LServer :: jid:lserver(),
-                                        Password :: binary(),
-                                        Digest :: binary(),
-                                        DigestGen :: fun()
-                                     ) -> 'false' | {'true', authmodule()}.
-do_check_password_with_authmodule(LUser, LServer, _, _, _)
-    when LUser =:= error; LServer =:= error ->
-    false;
-do_check_password_with_authmodule(LUser, LServer, Password, Digest, DigestGen) ->
+check_password_with_authmodule(#jid{luser = LUser, lserver = LServer}, Password, Digest, DigestGen) ->
     check_password_loop(auth_modules(LServer), [LUser, LServer, Password,
                                                Digest, DigestGen]).
 
@@ -260,26 +210,19 @@ do_check_password_loop([AuthModule | AuthModules], Args) ->
             do_check_password_loop(AuthModules, Args)
     end.
 
--spec check_digest(binary(), fun(), binary(), binary()) -> boolean().
+-spec check_digest(binary(), fun((binary()) -> binary()), binary(), binary()) -> boolean().
 check_digest(<<>>, _, <<>>, _) ->
     false; %%empty digest and password
 check_digest(Digest, DigestGen, _Password, Passwd) ->
     Digest == DigestGen(Passwd).
 
--spec set_password(User :: jid:user(),
-                   Server :: jid:server(),
-                   Password :: binary()
-                  ) -> ok | {error, empty_password | not_allowed | invalid_jid}.
-set_password(_, _, <<"">>) ->
+-spec set_password(jid:jid() | error, binary()) ->
+    ok | {error, empty_password | not_allowed | invalid_jid}.
+set_password(_, <<"">>) ->
     {error, empty_password};
-set_password(User, Server, Password) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nodeprep(Server),
-    do_set_password(LUser, LServer, Password).
-
-do_set_password(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+set_password(error, _) ->
     {error, invalid_jid};
-do_set_password(LUser, LServer, Password) ->
+set_password(#jid{luser = LUser, lserver = LServer}, Password) ->
     lists:foldl(
       fun(M, {error, _}) ->
               M:set_password(LUser, LServer, Password);
@@ -288,28 +231,22 @@ do_set_password(LUser, LServer, Password) ->
       end, {error, not_allowed}, auth_modules(LServer)).
 
 
--spec try_register(User :: jid:user(),
-                   Server :: jid:server(),
-                   Password :: binary()
-                   ) -> ok | {error, exists | not_allowed | invalid_jid | null_password}.
-try_register(_, _, <<"">>) ->
+-spec try_register(jid:jid() | error, binary()) ->
+    ok | {error, exists | not_allowed | invalid_jid | null_password}.
+try_register(_, <<"">>) ->
     {error, null_password};
-try_register(User, Server, Password) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nodeprep(Server),
-    do_try_register(LUser, LServer, Password).
-
--spec do_try_register(jid:luser(), jid:lserver(), binary())
-        -> ok | {error, exists | not_allowed | invalid_jid}.
-do_try_register(LUser, LServer, _) when LUser =:= error; LServer =:= error ->
+try_register(error, _) ->
     {error, invalid_jid};
-do_try_register(LUser, LServer, Password) ->
-    Exists = does_user_exist(LUser, LServer),
-    do_try_register_if_does_not_exist(Exists, LUser, LServer, Password).
+try_register(JID, Password) ->
+    Exists = does_user_exist(JID),
+    do_try_register_if_does_not_exist(Exists, JID, Password).
 
-do_try_register_if_does_not_exist(true, _, _, _) ->
+-spec do_try_register_if_does_not_exist(boolean(), jid:jid(), binary()) ->
+    ok | {error, exists | not_allowed | invalid_jid | null_password}.
+do_try_register_if_does_not_exist(true, _, _) ->
     {error, exists};
-do_try_register_if_does_not_exist(_, LUser, LServer, Password) ->
+do_try_register_if_does_not_exist(_, JID, Password) ->
+    {LUser, LServer} = jid:to_lus(JID),
     case lists:member(LServer, ?MYHOSTS) of
         true ->
             timed_call(LServer, try_register,
@@ -342,8 +279,7 @@ dirty_get_registered_users() ->
 
 
 %% @doc Registered users list do not include anonymous users logged
--spec get_vh_registered_users(Server :: jid:server()
-                             ) -> [jid:simple_bare_jid()].
+-spec get_vh_registered_users(Server :: jid:server()) -> [jid:simple_bare_jid()].
 get_vh_registered_users(Server) ->
     LServer = jid:nameprep(Server),
     do_get_vh_registered_users(LServer).
@@ -357,8 +293,8 @@ do_get_vh_registered_users(LServer) ->
       end, auth_modules(LServer)).
 
 
--spec get_vh_registered_users(Server :: jid:server(),
-                              Opts :: [any()]) -> [jid:simple_bare_jid()].
+-spec get_vh_registered_users(Server :: jid:server(), Opts :: [any()]) ->
+    [jid:simple_bare_jid()].
 get_vh_registered_users(Server, Opts) ->
     LServer = jid:nameprep(Server),
     do_get_vh_registered_users(LServer, Opts).
@@ -372,8 +308,7 @@ do_get_vh_registered_users(LServer, Opts) ->
         end, auth_modules(LServer)).
 
 
--spec get_vh_registered_users_number(Server :: jid:server()
-                                    ) -> integer().
+-spec get_vh_registered_users_number(Server :: jid:server()) -> integer().
 get_vh_registered_users_number(Server) ->
     LServer = jid:nameprep(Server),
     do_get_vh_registered_users_number(LServer).
@@ -388,8 +323,7 @@ do_get_vh_registered_users_number(LServer) ->
             end, auth_modules(LServer))).
 
 
--spec get_vh_registered_users_number(Server :: jid:server(),
-                                     Opts :: list()) -> integer().
+-spec get_vh_registered_users_number(Server :: jid:server(), Opts :: list()) -> integer().
 get_vh_registered_users_number(Server, Opts) ->
     LServer = jid:nameprep(Server),
     do_get_vh_registered_users_number(LServer, Opts).
@@ -405,68 +339,42 @@ do_get_vh_registered_users_number(LServer, Opts) ->
 
 
 %% @doc Get the password of the user.
--spec get_password(User :: jid:user(),
-                   Server :: jid:server()) -> ejabberd_auth:passterm() | false.
-get_password(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_get_password(LUser, LServer).
-
-do_get_password(LUser, LServer) when LUser =:= error; LServer =:= error ->
-    false;
-do_get_password(LUser, LServer) ->
+-spec get_password(JID :: jid:jid() | error) -> ejabberd_auth:passterm() | false.
+get_password(#jid{luser = LUser, lserver = LServer}) ->
     lists:foldl(
         fun(M, false) ->
             M:get_password(LUser, LServer);
             (_M, Password) ->
                 Password
-        end, false, auth_modules(LServer)).
+        end, false, auth_modules(LServer));
+get_password(error) ->
+    false.
 
 
--spec get_password_s(User :: jid:user(),
-                     Server :: jid:server()) -> binary().
-get_password_s(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_get_password_s(LUser, LServer).
-
-do_get_password_s(LUser, LServer) when LUser =:= error; LServer =:= error ->
-    <<"">>;
-do_get_password_s(LUser, LServer) ->
+-spec get_password_s(JID :: jid:jid() | error) -> binary().
+get_password_s(#jid{luser = LUser, lserver = LServer}) ->
     lists:foldl(
         fun(M, <<"">>) ->
             M:get_password_s(LUser, LServer);
             (_M, Password) ->
                 Password
-        end, <<"">>, auth_modules(LServer)).
+        end, <<"">>, auth_modules(LServer));
+get_password_s(error) ->
+    <<"">>.
 
 %% @doc Get the password(like thing) of the user and the auth module.
--spec get_passterm_with_authmodule(jid:user(), jid:server()) -> R when
-      R :: {passterm(), authmodule()}
-         | {'false', 'none'}.
-get_passterm_with_authmodule(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_get_passterm_with_authmodule(LUser, LServer).
-
-do_get_passterm_with_authmodule(LUser, LServer)
-    when LUser =:= error; LServer =:= error ->
-    {false, none};
-do_get_passterm_with_authmodule(LUser, LServer) ->
+-spec get_passterm_with_authmodule(error | jid:jid()) -> R when
+      R :: {passterm(), authmodule()} | {false, none}.
+get_passterm_with_authmodule(#jid{luser = LUser, lserver = LServer}) ->
     lists:foldl(
         fun(M, {false, _}) ->
-            {M:get_password(LUser, LServer), M};
+                {M:get_password(LUser, LServer), M};
            (_M, {Password, AuthModule}) ->
                 {Password, AuthModule}
         end, {false, none}, auth_modules(LServer)).
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
--spec does_user_exist(User :: jid:user(), Server :: jid:server()) -> boolean().
-does_user_exist(<<>>, _) ->
-    false;
-does_user_exist(User, Server) ->
-    does_user_exist(jid:make(User, Server, <<>>)).
 
 -spec does_user_exist(JID :: jid:jid() | error) -> boolean().
 does_user_exist(#jid{luser = LUser, lserver = LServer}) ->
@@ -480,15 +388,13 @@ does_user_exist_timed(LUser, LServer) ->
 
 %% Check if the user exists in all authentications module
 %% except the module passed as parameter
--spec is_user_exists_in_other_modules(Module :: authmodule(),
-                                      User :: jid:user(),
-                                      Server :: jid:server()
-                                     ) -> boolean() | maybe.
-is_user_exists_in_other_modules(Module, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
+-spec is_user_exists_in_other_modules(Module :: authmodule(), JID :: jid:jid() | error) ->
+    boolean() | maybe.
+is_user_exists_in_other_modules(Module, #jid{luser = LUser, lserver = LServer}) ->
     Modules = auth_modules(LServer) -- [Module],
-    does_user_exist_in_given_modules(Modules, LUser, LServer, maybe).
+    does_user_exist_in_given_modules(Modules, LUser, LServer, maybe);
+is_user_exists_in_other_modules(_M, error) ->
+    false.
 
 does_user_exist_in_given_modules([], _, _, _) ->
     false;
@@ -510,16 +416,9 @@ does_user_exist_in_given_modules([Mod | Modules], LUser, LServer, Default) ->
 
 %% @doc Remove user.
 %% Note: it may return ok even if there was some problem removing the user.
--spec remove_user(User :: jid:user(),
-                  Server :: jid:server()) -> ok | error | {error, not_allowed}.
-remove_user(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    do_remove_user(LUser, LServer).
-
-do_remove_user(LUser, LServer) when LUser =:= error; LServer =:= error ->
-    error;
-do_remove_user(LUser, LServer) ->
+-spec remove_user(JID :: jid:jid()) -> ok | {error, not_allowed};
+                 (error) -> error.
+remove_user(#jid{luser = LUser, lserver = LServer}) ->
     AuthModules = auth_modules(LServer),
     RemoveResult = [M:remove_user(LUser, LServer) || M <- AuthModules ],
     case lists:any(fun(El) -> El == ok end, RemoveResult) of
@@ -534,7 +433,8 @@ do_remove_user(LUser, LServer) ->
                          user => LUser, server => LServer,
                          auth_modules => AuthModules}),
             {error, not_allowed}
-    end.
+    end;
+remove_user(error) -> error.
 
 %% @doc Calculate informational entropy.
 -spec entropy(iolist()) -> float().

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -216,11 +216,12 @@ authorize(Creds) ->
                      Password :: binary()) -> boolean().
 check_password(LUser, LServer, Password) ->
     check_password(LUser, LServer, Password, undefined, undefined).
+
 check_password(LUser, LServer, _Password, _Digest, _DigestGen) ->
     %% We refuse login for registered accounts (They cannot logged but
     %% they however are "reserved")
-    case ejabberd_auth:is_user_exists_in_other_modules(?MODULE,
-                                                       LUser, LServer) of
+    case ejabberd_auth:is_user_exists_in_other_modules(
+           ?MODULE, jid:make_noprep(LUser, LServer, <<>>)) of
         %% If user exists in other module, reject anonymous authentication
         true  -> false;
         %% If we are not sure whether the user exists in other module, reject anon auth

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2439,8 +2439,8 @@ process_unauthenticated_stanza(StateData, El) ->
                     ResIQ = IQ#iq{type = error,
                                   sub_el = [mongoose_xmpp_errors:service_unavailable()]},
                     Res1 = jlib:replace_from_to(
-                             jid:make(<<>>, StateData#state.server, <<>>),
-                             jid:make(<<>>, <<>>, <<>>),
+                             jid:make_noprep(<<>>, StateData#state.server, <<>>),
+                             jid:make_noprep(<<>>, <<>>, <<>>),
                              jlib:iq_to_xml(ResIQ)),
                     send_element_from_server_jid(StateData, jlib:remove_attr(<<"to">>, Res1));
                 _ ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -323,7 +323,8 @@ remove_info(JID, Key) ->
       Type :: any(),
       Reason :: any().
 check_in_subscription(Acc, User, Server, _JID, _Type, _Reason) ->
-    case ejabberd_auth:does_user_exist(User, Server) of
+    JID = jid:make(User, Server, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
             Acc;
         false ->

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -4,7 +4,7 @@
 -export([start/1,
          stop/1,
          start_link/2,
-         does_user_exist/2]).
+         does_user_exist/1]).
 
 %% Hooks.
 -export([remove_user/3]).
@@ -70,13 +70,12 @@ start_link(ProcName, Host) ->
     gen_server:start_link({local, ProcName}, ?MODULE, [Host], []).
 
 
--spec does_user_exist(LUser :: jid:luser(),
-                     LServer :: jid:lserver() | string()) -> boolean().
-does_user_exist(LUser, LServer) ->
+-spec does_user_exist(JID :: jid:jid()) -> boolean().
+does_user_exist(#jid{luser = LUser, lserver = LServer} = JID) ->
     case does_cached_user_exist(LUser, LServer) of
         true -> true;
         false ->
-            case does_stored_user_exist(LUser, LServer) of
+            case does_stored_user_exist(JID) of
                 true ->
                     put_user_into_cache(LUser, LServer),
                     true;
@@ -172,14 +171,13 @@ code_change(_OldVsn, State, _Extra) ->
 %% Helpers
 %%====================================================================
 
--spec does_stored_user_exist(jid:luser(), jid:lserver()) -> boolean().
-does_stored_user_exist(LUser, LServer) ->
-    ejabberd_auth:does_user_exist(LUser, LServer)
-    andalso not is_anonymous_user(LUser, LServer).
+-spec does_stored_user_exist(jid:jid()) -> boolean().
+does_stored_user_exist(JID) ->
+    ejabberd_auth:does_user_exist(JID)
+    andalso not is_anonymous_user(JID).
 
-
--spec is_anonymous_user(jid:luser(), jid:lserver()) -> boolean().
-is_anonymous_user(LUser, LServer) ->
+-spec is_anonymous_user(jid:jid()) -> boolean().
+is_anonymous_user(#jid{luser = LUser, lserver = LServer} = _JID) ->
     case lists:member(ejabberd_auth_anonymous, ejabberd_auth:auth_modules(LServer)) of
         true ->
             ejabberd_auth_anonymous:does_user_exist(LUser, LServer);

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -78,8 +78,8 @@ publish_notification(Acc, _, Payload, Services) ->
 %%--------------------------------------------------------------------
 
 -spec should_publish(To :: jid:jid()) -> boolean().
-should_publish(#jid{luser = LUser, lserver = LServer} = To) ->
-    try ejabberd_users:does_user_exist(LUser, LServer) of
+should_publish(#jid{} = To) ->
+    try ejabberd_users:does_user_exist(To) of
         false ->
             false;
         true ->
@@ -146,10 +146,10 @@ publish_via_pubsub(Host, To, {PubsubJID, Node, Form}, PushPayload) ->
                               to_jid => PubsubJID }),
 
     ResponseHandler =
-    fun(_From, _To, Acc, Response) ->
+    fun(_From, _To, FAcc, Response) ->
             mod_event_pusher_push:cast(Host, fun handle_publish_response/4,
                                        [To, PubsubJID, Node, Response]),
-            Acc
+            FAcc
     end,
     %% The IQ is routed from the recipient's server JID to pubsub JID
     %% This is recommended in the XEP and also helps process replies to this IQ

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -275,9 +275,9 @@ maybe_process_message(Host, From, To, Msg, Dir) ->
                          To :: jid:jid(),
                          Dir :: outgoing | incoming) -> boolean().
 inbox_owner_exists(From, _To, outgoing) ->
-    ejabberd_users:does_user_exist(From#jid.luser, From#jid.lserver);
+    ejabberd_users:does_user_exist(From);
 inbox_owner_exists(_From, To, incoming) ->
-    ejabberd_users:does_user_exist(To#jid.luser, To#jid.lserver).
+    ejabberd_users:does_user_exist(To).
 
 maybe_process_acceptable_message(Host, From, To, Msg, Dir, one2one) ->
             process_message(Host, From, To, Msg, Dir, one2one);

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -300,10 +300,10 @@ user_send_packet(Acc, From, To, Packet) ->
 -spec filter_packet(Value :: fpacket() | drop) -> fpacket() | drop.
 filter_packet(drop) ->
     drop;
-filter_packet({From, To=#jid{luser=LUser, lserver=LServer}, Acc, Packet}) ->
+filter_packet({From, To = #jid{lserver = LServer}, Acc, Packet}) ->
     ?LOG_DEBUG(#{what => mam_user_receive_packet, acc => Acc}),
     {AmpEvent, PacketAfterArchive} =
-        case ejabberd_users:does_user_exist(LUser, LServer) of
+        case ejabberd_users:does_user_exist(To) of
             false ->
                 {mam_failed, Packet};
             true ->

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -380,19 +380,19 @@ get_sm_items(empty, From, To, _Node, _Lang) ->
 
 
 -spec is_presence_subscribed(jid:jid(), jid:jid()) -> boolean().
-is_presence_subscribed(#jid{luser=User, lserver=Server} = From,
-                       #jid{luser=LUser, lserver=LServer} = _To) ->
+is_presence_subscribed(#jid{luser = LFromUser, lserver = LFromServer} = _From,
+                       #jid{luser = LToUser, lserver = LToServer} = _To) ->
     A = mongoose_acc:new(#{ location => ?LOCATION,
-                            lserver => From#jid.lserver,
+                            lserver => LFromServer,
                             element => undefined }),
-    A2 = mongoose_hooks:roster_get(Server, A, User, Server),
+    A2 = mongoose_hooks:roster_get(LFromServer, A, LFromUser, LFromServer),
     Roster = mongoose_acc:get(roster, items, [], A2),
     lists:any(fun({roster, _, _, JID, _, S, _, _, _, _}) ->
                       {TUser, TServer} = jid:to_lus(JID),
-                      LUser == TUser andalso LServer == TServer andalso S /= none
+                      LToUser == TUser andalso LToServer == TServer andalso S /= none
               end,
               Roster)
-    orelse User == LUser andalso Server == LServer.
+    orelse LFromUser == LToUser andalso LFromServer == LToServer.
 
 
 -spec process_sm_iq_info(jid:jid(), jid:jid(), mongoose_acc:t(), jlib:iq()) ->

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -168,22 +168,21 @@ register_or_change_password(Credentials, ClientJID, #jid{lserver = ServerDomain}
             error_response(IQ, mongoose_xmpp_errors:forbidden())
     end.
 
-attempt_cancelation(ClientJID, #jid{lserver = ServerDomain}, #iq{} = IQ) ->
-    #jid{user = Username, lserver = UserDomain} = ClientJID,
+attempt_cancelation(#jid{} = ClientJID, #jid{lserver = ServerDomain}, #iq{} = IQ) ->
     case inband_registration_and_cancelation_allowed(ServerDomain, ClientJID) of
         true ->
             %% The response must be sent *before* the
             %% XML stream is closed (the call to
-            %% `ejabberd_auth:remove_user/2' does
+            %% `ejabberd_auth:remove_user/1' does
             %% this): as it is, when canceling a
             %% registration, there is no way to deal
             %% with failure.
             ResIQ = IQ#iq{type = result, sub_el = []},
             ejabberd_router:route(
-              jid:make(<<>>, <<>>, <<>>),
+              jid:make_noprep(<<>>, <<>>, <<>>),
               ClientJID,
               jlib:iq_to_xml(ResIQ)),
-            ejabberd_auth:remove_user(Username, UserDomain),
+            ejabberd_auth:remove_user(ClientJID),
             ignore;
         false ->
             error_response(IQ, mongoose_xmpp_errors:not_allowed())
@@ -222,9 +221,9 @@ process_iq_get(From, _To, #iq{lang = Lang, sub_el = Child} = IQ, _Source) ->
                                        #xmlel{name = <<"password">>}
                                        | QuerySubels]}]}.
 
-try_register_or_set_password(User, Server, Password, #jid{ user = User, lserver = Server },
+try_register_or_set_password(User, Server, Password, #jid{user = User, lserver = Server} = UserJID,
                              IQ, SubEl, _Source, Lang) ->
-    try_set_password(User, Server, Password, IQ, SubEl, Lang);
+    try_set_password(UserJID, Password, IQ, SubEl, Lang);
 try_register_or_set_password(User, Server, Password, _From, IQ, SubEl, Source, Lang) ->
     case check_timeout(Source) of
         true ->
@@ -240,10 +239,10 @@ try_register_or_set_password(User, Server, Password, _From, IQ, SubEl, Source, L
     end.
 
 %% @doc Try to change password and return IQ response
-try_set_password(User, Server, Password, IQ, SubEl, Lang) ->
-    case is_strong_password(Server, Password) of
+try_set_password(#jid{lserver = LServer} = UserJID, Password, IQ, SubEl, Lang) ->
+    case is_strong_password(LServer, Password) of
         true ->
-            case ejabberd_auth:set_password(User, Server, Password) of
+            case ejabberd_auth:set_password(UserJID, Password) of
                 ok ->
                     IQ#iq{type = result, sub_el = [SubEl]};
                 {error, empty_password} ->
@@ -277,11 +276,10 @@ try_register(User, Server, Password, SourceRaw, Lang) ->
             end
     end.
 
-verify_password_and_register(#jid{ user = User, server = Server } = JID,
-                             Password, SourceRaw, Lang) ->
-    case is_strong_password(Server, Password) of
+verify_password_and_register(#jid{lserver = LServer} = JID, Password, SourceRaw, Lang) ->
+    case is_strong_password(LServer, Password) of
         true ->
-            case ejabberd_auth:try_register(User, Server, Password) of
+            case ejabberd_auth:try_register(JID, Password) of
                 {error, exists} ->
                     {error, mongoose_xmpp_errors:conflict()};
                 {error, invalid_jid} ->
@@ -300,14 +298,13 @@ verify_password_and_register(#jid{ user = User, server = Server } = JID,
             {error, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)}
     end.
 
-send_welcome_message(JID) ->
-    Host = JID#jid.lserver,
+send_welcome_message(#jid{lserver = Host} = JID) ->
     case gen_mod:get_module_opt(Host, ?MODULE, welcome_message, {"", ""}) of
         {"", ""} ->
             ok;
         {Subj, Body} ->
             ejabberd_router:route(
-              jid:make(<<>>, Host, <<>>),
+              jid:make_noprep(<<>>, Host, <<>>),
               JID,
               #xmlel{name = <<"message">>, attrs = [{<<"type">>, <<"normal">>}],
                      children = [#xmlel{name = <<"subject">>,
@@ -318,8 +315,7 @@ send_welcome_message(JID) ->
             ok
     end.
 
-send_registration_notifications(UJID, Source) ->
-    Host = UJID#jid.lserver,
+send_registration_notifications(#jid{lserver = Host} = UJID, Source) ->
     case gen_mod:get_module_opt(Host, ?MODULE, registration_watchers, []) of
         [] -> ok;
         JIDs when is_list(JIDs) ->
@@ -342,7 +338,7 @@ send_registration_notification(JIDBin, Host, Body) ->
                              attrs = [{<<"type">>, <<"chat">>}],
                              children = [#xmlel{name = <<"body">>,
                                                 children = [#xmlcdata{content = Body}]}]},
-            ejabberd_router:route(jid:make(<<>>, Host, <<>>), JID, Message)
+            ejabberd_router:route(jid:make_noprep(<<>>, Host, <<>>), JID, Message)
     end.
 
 check_timeout(undefined) ->
@@ -410,8 +406,7 @@ write_time({{Y, Mo, D}, {H, Mi, S}}) ->
     io_lib:format("~w-~.2.0w-~.2.0w ~.2.0w:~.2.0w:~.2.0w",
                   [Y, Mo, D, H, Mi, S]).
 
-is_strong_password(Server, Password) ->
-    LServer = jid:nameprep(Server),
+is_strong_password(LServer, Password) ->
     case gen_mod:get_module_opt(LServer, ?MODULE, password_strength, 0) of
         Entropy when is_number(Entropy), Entropy == 0 ->
             true;
@@ -419,7 +414,7 @@ is_strong_password(Server, Password) ->
             ejabberd_auth:entropy(Password) >= Entropy;
         Wrong ->
             ?LOG_WARNING(#{what => reg_wrong_password_strength,
-                           host => Server, value => Wrong}),
+                           host => LServer, value => Wrong}),
             true
     end.
 

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -411,7 +411,7 @@ search_group_info(State, Group) ->
                         end
                 end,
     AuthChecker = case State#state.auth_check of
-                      true -> fun ejabberd_auth:does_user_exist/2;
+                      true -> fun ejabberd_auth:does_user_exist/1;
                       _ -> fun (_U, _S) -> true end
                   end,
     Host = State#state.host,
@@ -458,7 +458,8 @@ check_and_accumulate_member({ok, UID}, AuthChecker, Host, JIDsAcc) ->
         error ->
             JIDsAcc;
         _ ->
-            case AuthChecker(PUID, Host) of
+            JID = jid:make(PUID, Host, <<>>),
+            case AuthChecker(JID) of
                 true ->
                     [{PUID, Host} | JIDsAcc];
                 _ ->

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -129,7 +129,7 @@
 %%--------------------------------------------------------------------
 
 -spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ luser = LUser, lserver = LServer }) ->
+get_personal_data(Acc, #jid{luser = LUser, lserver = LServer}) ->
     Jid = jid:to_binary({LUser, LServer}),
     Schema = ["jid", "vcard"],
     Entries = case mod_vcard_backend:get_vcard(LUser, LServer) of

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -148,7 +148,8 @@ get_vcard(LUser, LServer) ->
     Proc = gen_mod:get_module_proc(LServer, ?PROCNAME),
     {ok, State} = gen_server:call(Proc, get_state),
     LServer = State#state.serverhost,
-    case ejabberd_auth:does_user_exist(LUser, LServer) of
+    JID = jid:make(LUser, LServer, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
             VCardMap = State#state.vcard_map,
             case find_ldap_user(LUser, State) of
@@ -408,7 +409,8 @@ attrs_to_item_xml(Attrs, #state{uids = UIDs} = State) ->
 make_user_item_if_exists(Username, Attrs,
                          #state{serverhost = LServer, search_reported = SearchReported,
                                 vcard_map = VCardMap, binary_search_fields = BinFields}) ->
-    case ejabberd_auth:does_user_exist(Username, LServer) of
+    JID = jid:make(Username, LServer, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
             RFields = lists:map(fun ({_, VCardName}) ->
                                         {VCardName, map_vcard_attr(VCardName, Attrs, VCardMap,

--- a/src/mongoose_api_client.erl
+++ b/src/mongoose_api_client.erl
@@ -30,7 +30,6 @@
 
 -import(mongoose_api_common, [action_to_method/1,
                               method_to_action/1,
-                              error_code/1,
                               process_request/4,
                               error_response/4,
                               parse_request_body/1]).
@@ -154,9 +153,8 @@ do_authorize({basic, User, Password}, Req, State) ->
 do_authorize(_, Req, State) ->
     make_unauthorized_response(Req, State).
 
-do_check_password(#jid{luser = User, lserver = Server} = JID,
-    Password, Req, State) ->
-    case ejabberd_auth:check_password(User, Server, Password) of
+do_check_password(#jid{} = JID, Password, Req, State) ->
+    case ejabberd_auth:check_password(JID, Password) of
         true ->
             {true, Req, State#http_api_state{entity = jid:to_binary(JID)}};
         _ ->

--- a/src/mongoose_api_users.erl
+++ b/src/mongoose_api_users.erl
@@ -82,9 +82,10 @@ put_user(Data, Bindings) ->
 delete_user(Bindings) ->
     Host = gen_mod:get_opt(host, Bindings),
     Username = gen_mod:get_opt(username, Bindings),
-    case ejabberd_auth:does_user_exist(Username, Host) of
+    JID = jid:make(Username, Host, <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true ->
-            maybe_delete_user(Username, Host);
+            maybe_delete_user(JID);
         false ->
             {error, not_found}
     end.
@@ -93,25 +94,26 @@ delete_user(Bindings) ->
 %% internal functions
 %%--------------------------------------------------------------------
 maybe_register_user(Username, Host, Password) ->
-    case ejabberd_auth:try_register(Username, Host, Password) of
+    JID = jid:make(Username, Host, <<>>),
+    case ejabberd_auth:try_register(JID, Password) of
         {error, not_allowed} ->
             ?ERROR;
         {error, exists} ->
-            maybe_change_password(Username, Host, Password);
+            maybe_change_password(JID, Password);
         _ ->
             ok
     end.
 
-maybe_change_password(Username, Host, Password) ->
-    case ejabberd_auth:set_password(Username, Host, Password) of
+maybe_change_password(JID, Password) ->
+    case ejabberd_auth:set_password(JID, Password) of
         {error, _} ->
             ?ERROR;
         ok ->
             ok
     end.
 
-maybe_delete_user(Username, Host) ->
-    case ejabberd_auth:remove_user(Username, Host) of
+maybe_delete_user(JID) ->
+    case ejabberd_auth:remove_user(JID) of
         ok ->
             ok;
         _ ->

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -22,13 +22,9 @@
                            %% Each backend may require different values to be present.
                            extra :: [proplists:property()] }.
 
--spec new(jid:server()) -> mongoose_credentials:t().
-new(Server) ->
-    case jid:nameprep(Server) of
-        error -> error(nameprep_failed, [Server]);
-        LServer when is_binary(LServer) ->
-            #mongoose_credentials{lserver = LServer}
-    end.
+-spec new(jid:lserver()) -> mongoose_credentials:t().
+new(LServer) when is_binary(LServer) ->
+    #mongoose_credentials{lserver = LServer}.
 
 -spec lserver(t()) -> jid:lserver().
 lserver(#mongoose_credentials{lserver = S}) -> S.

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -252,8 +252,7 @@ srv_name(Host) ->
 
 determine_amp_strategy(Strategy = #amp_strategy{deliver = [none]},
                        _FromJID, ToJID, _Packet, initial_check) ->
-    ShouldBeStored = ejabberd_auth:does_user_exist(ToJID),
-    case ShouldBeStored of
+    case ejabberd_auth:does_user_exist(ToJID) of
         true -> Strategy#amp_strategy{deliver = [stored, none]};
         false -> Strategy
     end;

--- a/src/sasl/cyrsasl_anonymous.erl
+++ b/src/sasl/cyrsasl_anonymous.erl
@@ -49,7 +49,8 @@ mech_step(#state{creds = Creds}, _ClientIn) ->
     User = <<(mongoose_bin:gen_from_crypto())/binary,
              (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
     %% Checks that the username is available
-    case ejabberd_auth:does_user_exist(User, mongoose_credentials:lserver(Creds)) of
+    JID = jid:make(User, mongoose_credentials:lserver(Creds), <<>>),
+    case ejabberd_auth:does_user_exist(JID) of
         true  -> {error, <<"not-authorized">>};
         false -> {ok, mongoose_credentials:extend(Creds, [{username, User},
                                                           {auth_module, ?MODULE}])}

--- a/src/sasl/cyrsasl_digest.erl
+++ b/src/sasl/cyrsasl_digest.erl
@@ -109,7 +109,8 @@ authorize_if_uri_valid(State, KeyVals, Nonce) ->
 maybe_authorize(UserName, KeyVals, Nonce, State) ->
     AuthzId = xml:get_attr_s(<<"authzid">>, KeyVals),
     LServer = mongoose_credentials:lserver(State#state.creds),
-    case ejabberd_auth:get_passterm_with_authmodule(UserName, LServer) of
+    JID = jid:make(UserName, LServer, <<>>),
+    case ejabberd_auth:get_passterm_with_authmodule(JID) of
         {false, _} ->
             {error, <<"not-authorized">>, UserName};
         {Passwd, AuthModule} ->

--- a/test/commands_backend_SUITE.erl
+++ b/test/commands_backend_SUITE.erl
@@ -671,7 +671,7 @@ do_request(Path, Method, Body, {headers, Headers}) ->
 
 request(Path, Method, BodyData, {{_User, _Pass} = Auth, Authorized}) ->
     setup(client_module()),
-    meck:expect(ejabberd_auth, check_password, fun(_, _, _) -> Authorized end),
+    meck:expect(ejabberd_auth, check_password, fun(_, _) -> Authorized end),
     Body = maybe_add_body(BodyData),
     AuthHeader = maybe_add_auth_header(Auth),
     AcceptHeader = maybe_add_accepted_headers(Method),

--- a/test/ejabberd_admin_SUITE.erl
+++ b/test/ejabberd_admin_SUITE.erl
@@ -3,6 +3,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("jlib.hrl").
 
 -import(ejabberd_helper, [data/2]).
 
@@ -24,21 +25,17 @@ end_per_suite(_Config) ->
 init_per_group(_, Config) ->
     meck:new(ejabberd_auth, [no_link]),
     meck:expect(ejabberd_auth, try_register,
-                fun(<<"existing_user">>, _, _) -> {error, exists};
-                   (<<"null_password_user">>, _, _) -> {error, null_password};
-                   (_, <<"not_allowed_domain">>, _) -> {error, not_allowed};
-                   (<<"invalid_jid_user">>, _, _) -> {error, invalid_jid};
-                   (_, _, _) -> ok
+                fun(#jid{user = <<"existing_user">>}, _) -> {error, exists};
+                   (#jid{user = <<"null_password_user">>}, _) -> {error, null_password};
+                   (#jid{server = <<"not_allowed_domain">>}, _) -> {error, not_allowed};
+                   (#jid{user = <<"invalid_jid_user">>}, _) -> {error, invalid_jid};
+                   (_, _) -> ok
                 end),
-    Config;
-
-init_per_group(_, Config) -> Config.
+    Config.
 
 end_per_group(_, _Config) ->
     meck:unload(ejabberd_auth),
-    ok;
-
-end_per_group(_, _) -> ok.
+    ok.
 
 init_per_testcase(_TestCase, Config) ->
     Config.
@@ -73,7 +70,7 @@ import_users_from_valid_csv_with_quoted_fields(Config) ->
     ?assertEqual([{ok, <<"username,with,commas">>}],
                  Result).
 
-import_from_invalid_csv(Config) ->
+import_from_invalid_csv(_Config) ->
     % given
     NonExistingPath = "",
     % then


### PR DESCRIPTION
PROBLEM: if we pass forward an “untyped” binary for the user, server, and/or resource of a jid, we don’t know if it has been stringprepped or not, so we are always stringprepping again and again things that probably were stringprepped already, wasting CPU time. This was seen in profiles when working on the ejabberd_sm (#2582) case.

SOLUTION: Rewrite function calls to pass a #jid{} record, which is clear about its pieces, and extract the stringprepped chunks only on the place where it is used.