### PR TITLE
Reduce stringprepping for roster modules

### DIFF
--- a/include/mod_roster.hrl
+++ b/include/mod_roster.hrl
@@ -18,12 +18,12 @@
 %%%
 %%%----------------------------------------------------------------------
 
--record(roster, {usj,
-                 us,
-                 jid,
-                 name = <<>>,
+-record(roster, {usj :: {jid:luser(), jid:lserver(), jid:simple_jid()},
+                 us :: {jid:luser(), jid:lserver()},
+                 jid :: jid:simple_jid(),
+                 name = <<>> :: binary(),
                  subscription = none :: both | from | to | none | remove,
-                 ask = none,
+                 ask = none :: subscribe | unsubscribe | in | out | both | none,
                  groups = [],
                  askmessage = <<>>,
                  xs = []}).

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -164,9 +164,9 @@ commands() ->
     Res :: user_doest_not_exist | error | bad_subs | ok.
 add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
     LocalJID = jid:make(LocalUser, LocalServer, <<>>),
-    RemoteJID = jid:make(User, Server, <<>>),
     case ejabberd_auth:does_user_exist(LocalJID) of
         true ->
+            RemoteJID = jid:make(User, Server, <<>>),
             case subscribe(LocalJID, RemoteJID, Nick, Group, Subs, []) of
                 {atomic, _} ->
                     do_add_rosteritem(LocalJID, RemoteJID, Nick, Group, Subs);
@@ -213,9 +213,9 @@ subscribe(LocalJID, RemoteJID, Nick, Group, SubscriptionS, _Xattrs) ->
     Res :: ok | error | user_does_not_exist.
 delete_rosteritem(LocalUser, LocalServer, User, Server) ->
     LocalJID = jid:make(LocalUser, LocalServer, <<>>),
-    RemoteJID = jid:make(User, Server, <<>>),
     case ejabberd_auth:does_user_exist(LocalJID) of
         true ->
+            RemoteJID = jid:make(User, Server, <<>>),
             case unsubscribe(LocalJID, RemoteJID) of
                 {atomic, ok} ->
                     push_roster_item(LocalJID, RemoteJID, remove),

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -26,16 +26,15 @@
 -module(service_admin_extra_roster).
 -author('badlop@process-one.net').
 -export([
-    commands/0,
-
-    add_rosteritem/7,
-    delete_rosteritem/4,
-    process_rosteritems/5,
-    get_roster/2,
-    push_roster/3,
-    push_roster_all/1,
-    push_alltoall/2
-    ]).
+         commands/0,
+         add_rosteritem/7,
+         delete_rosteritem/4,
+         process_rosteritems/5,
+         get_roster/2,
+         push_roster/3,
+         push_roster_all/1,
+         push_alltoall/2
+        ]).
 
 -include("mongoose.hrl").
 -include("ejabberd_commands.hrl").

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -163,12 +163,13 @@ commands() ->
                      Subs :: subs()) -> {Res, string()} when
     Res :: user_doest_not_exist | error | bad_subs | ok.
 add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
-    JID = jid:make(LocalUser, LocalServer, <<>>),
-    case ejabberd_auth:does_user_exist(JID) of
+    LocalJID = jid:make(LocalUser, LocalServer, <<>>),
+    RemoteJID = jid:make(User, Server, <<>>),
+    case ejabberd_auth:does_user_exist(LocalJID) of
         true ->
-            case subscribe(LocalUser, LocalServer, User, Server, Nick, Group, Subs, []) of
+            case subscribe(LocalJID, RemoteJID, Nick, Group, Subs, []) of
                 {atomic, _} ->
-                    do_add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs);
+                    do_add_rosteritem(LocalJID, RemoteJID, Nick, Group, Subs);
                 Other ->
                     {error, io_lib:format("~p", [Other])}
             end;
@@ -178,11 +179,11 @@ add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
                            [LocalUser, LocalServer])}
     end.
 
-do_add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
+do_add_rosteritem(LocalJID, RemoteJID, Nick, Group, Subs) ->
     case lists:member(Subs, possible_subs_binary()) of
         true ->
-            push_roster_item(LocalUser, LocalServer, User, Server, {add, Nick, Subs, Group}),
-            {ok, io_lib:format("Added the item to the roster of ~s@~s", [LocalUser, LocalServer])};
+            push_roster_item(LocalJID, RemoteJID, {add, Nick, Subs, Group}),
+            {ok, io_lib:format("Added the item to the roster of ~s", [jid:to_binary(LocalJID)])};
         false ->
             {bad_subs, io_lib:format("Sub ~s is incorrect."
                                      " Choose one of the following:~nnone~nfrom~nto~nboth",
@@ -191,20 +192,18 @@ do_add_rosteritem(LocalUser, LocalServer, User, Server, Nick, Group, Subs) ->
 
 
 %% @doc returns result of mnesia or rdbms transaction
--spec subscribe(LocalUser :: jid:user(),
-                LocalServer :: jid:server(),
-                User :: jid:user(),
-                Server :: jid:server(),
+-spec subscribe(LocalJID :: jid:jid(),
+                RemoteJID :: jid:jid(),
                 Nick :: binary(),
                 Group :: binary() | string(),
                 Subs :: subs(),
                 _Xattrs :: [jlib:binary_pair()]) -> any().
-subscribe(LU, LS, User, Server, Nick, Group, SubscriptionS, _Xattrs) ->
-    ItemEl = build_roster_item(User, Server, {add, Nick, SubscriptionS, Group}),
+subscribe(LocalJID, RemoteJID, Nick, Group, SubscriptionS, _Xattrs) ->
+    ItemEl = build_roster_item(RemoteJID, {add, Nick, SubscriptionS, Group}),
     QueryEl = #xmlel{ name = <<"query">>,
                       attrs = [{<<"xmlns">>, <<"jabber:iq:roster">>}],
                       children = [ItemEl]},
-    mod_roster:set_items(LU, LS, QueryEl).
+    mod_roster:set_items(LocalJID, QueryEl).
 
 
 -spec delete_rosteritem(LocalUser :: jid:user(),
@@ -213,14 +212,15 @@ subscribe(LU, LS, User, Server, Nick, Group, SubscriptionS, _Xattrs) ->
                         Server :: jid:server()) -> {Res, string()} when
     Res :: ok | error | user_does_not_exist.
 delete_rosteritem(LocalUser, LocalServer, User, Server) ->
-    JID = jid:make(LocalUser, LocalServer, <<>>),
-    case ejabberd_auth:does_user_exist(JID) of
+    LocalJID = jid:make(LocalUser, LocalServer, <<>>),
+    RemoteJID = jid:make(User, Server, <<>>),
+    case ejabberd_auth:does_user_exist(LocalJID) of
         true ->
-            case unsubscribe(LocalUser, LocalServer, User, Server) of
+            case unsubscribe(LocalJID, RemoteJID) of
                 {atomic, ok} ->
-                    push_roster_item(LocalUser, LocalServer, User, Server, remove),
-                    {ok, io_lib:format("The item removed from roster of ~s@~s",
-                                       [LocalUser, LocalServer])};
+                    push_roster_item(LocalJID, RemoteJID, remove),
+                    {ok, io_lib:format("The item removed from roster of ~s",
+                                       [jid:to_binary(LocalJID)])};
                 Other ->
                     {error, io_lib:format("~p", [Other])}
             end;
@@ -232,16 +232,13 @@ delete_rosteritem(LocalUser, LocalServer, User, Server) ->
 
 
 %% @doc returns result of mnesia or rdbms transaction
--spec unsubscribe(LocalUser :: jid:user(),
-                  LocalServer :: jid:server(),
-                  User :: jid:user(),
-                  Server :: jid:server()) -> any().
-unsubscribe(LU, LS, User, Server) ->
-    ItemEl = build_roster_item(User, Server, remove),
+-spec unsubscribe(LocalJID :: jid:jid(), RemoteJID :: jid:jid()) -> any().
+unsubscribe(LocalJID, RemoteJID) ->
+    ItemEl = build_roster_item(RemoteJID, remove),
     QueryEl = #xmlel{ name = <<"query">>,
               attrs = [{<<"xmlns">>, <<"jabber:iq:roster">>}],
               children = [ItemEl]},
-    mod_roster:set_items(LU, LS, QueryEl).
+    mod_roster:set_items(LocalJID, QueryEl).
 
 %% -----------------------------
 %% Get Roster
@@ -324,7 +321,9 @@ subscribe_roster({Name, Server, Group, Nick}, [{Name, Server, _, _} | Roster]) -
     subscribe_roster({Name, Server, Group, Nick}, Roster);
 %% Subscribe Name2 to Name1
 subscribe_roster({Name1, Server1, Group1, Nick1}, [{Name2, Server2, Group2, Nick2} | Roster]) ->
-    subscribe(Name1, Server1, Name2, Server2, Nick2, Group2, <<"both">>, []),
+    subscribe(jid:make(Name1, Server1, <<>>),
+              jid:make(Name2, Server2, <<>>),
+              Nick2, Group2, <<"both">>, []),
     subscribe_roster({Name1, Server1, Group1, Nick1}, Roster).
 
 
@@ -345,42 +344,35 @@ build_list_users(Group, [{User, Server}|Users], Res) ->
     build_list_users(Group, Users, [{User, Server, Group, User}|Res]).
 
 
-%% @spec(LU, LS, U, S, Action) -> ok
+%% @spec(LocalJID, RemoteJID, Action) -> ok
 %%       Action = {add, Nick, Subs, Group} | remove
 %% @doc Push to the roster of account LU@LS the contact U@S.
 %% The specific action to perform is defined in Action.
--spec push_roster_item(jid:luser(), jid:lserver(), jid:user(),
-        jid:server(), Action :: push_action()) -> 'ok'.
-push_roster_item(LU, LS, U, S, Action) ->
-    JID = jid:make(LU, LS, <<>>),
+-spec push_roster_item(jid:jid(), jid:jid(), Action :: push_action()) -> 'ok'.
+push_roster_item(JID, #jid{luser = U, lserver = S} = RemJID, Action) ->
     lists:foreach(fun(R) ->
                 RJID = jid:replace_resource(JID, R),
-                push_roster_item(RJID, U, S, Action)
+                BroadcastEl = build_broadcast(U, S, Action),
+                ejabberd_sm:route(RJID, RJID, BroadcastEl),
+                Item = build_roster_item(RemJID, Action),
+                ResIQ = build_iq_roster_push(Item),
+                ejabberd_router:route(RJID, RJID, ResIQ)
         end, ejabberd_sm:get_user_resources(JID)).
 
-
--spec push_roster_item(jid:jid(), jid:user(), jid:server(), Action :: push_action()) ->
-    mongoose_acc:t().
-push_roster_item(JID, U, S, Action) ->
-    BroadcastEl = build_broadcast(U, S, Action),
-    ejabberd_sm:route(JID, JID, BroadcastEl),
-    Item = build_roster_item(U, S, Action),
-    ResIQ = build_iq_roster_push(Item),
-    ejabberd_router:route(JID, JID, ResIQ).
-
--spec build_roster_item(jid:user(), jid:server(), push_action()
-                       ) -> exml:element().
-build_roster_item(U, S, {add, Nick, Subs, Group}) ->
+-spec build_roster_item(jid:jid(), push_action()) -> exml:element().
+build_roster_item(#jid{resource = <<>>} = JID, {add, Nick, Subs, Group}) ->
     #xmlel{ name = <<"item">>,
-       attrs = [{<<"jid">>, jid:to_binary(jid:make(U, S, <<"">>))},
+       attrs = [{<<"jid">>, jid:to_binary(JID)},
                 {<<"name">>, Nick},
                 {<<"subscription">>, Subs}],
        children = [#xmlel{name = <<"group">>, children = [#xmlcdata{content = Group}]}]
       };
-build_roster_item(U, S, remove) ->
+build_roster_item(#jid{resource = <<>>} = JID, remove) ->
     #xmlel{ name = <<"item">>,
-       attrs = [{<<"jid">>, jid:to_binary(jid:make(U, S, <<"">>))},
-                {<<"subscription">>, <<"remove">>}]}.
+       attrs = [{<<"jid">>, jid:to_binary(JID)},
+                {<<"subscription">>, <<"remove">>}]};
+build_roster_item(#jid{} = JID, Action) ->
+    build_roster_item(jid:replace_resource(JID, <<>>), Action).
 
 
 -spec build_iq_roster_push(jlib:xmlcdata() | exml:element()) -> exml:element().

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -375,7 +375,6 @@ get_passterm_with_authmodule(#jid{luser = LUser, lserver = LServer}) ->
 
 %% @doc Returns true if the user exists in the DB or if an anonymous user is
 %% logged under the given name
-
 -spec does_user_exist(JID :: jid:jid() | error) -> boolean().
 does_user_exist(#jid{luser = LUser, lserver = LServer}) ->
     timed_call(LServer, does_user_exist, fun does_user_exist_timed/2, [LUser, LServer]);

--- a/src/mongoose_client_api/mongoose_client_api_contacts.erl
+++ b/src/mongoose_client_api/mongoose_client_api_contacts.erl
@@ -193,6 +193,6 @@ to_binary(S) ->
 
 -spec jid_exists(binary(), binary()) -> boolean().
 jid_exists(CJid, Jid) ->
-    FJid = jid:from_binary(CJid),
-    Res = mod_roster:get_roster_entry(FJid#jid.luser, FJid#jid.lserver, Jid),
+    #jid{} = FJid = jid:from_binary(CJid),
+    Res = mod_roster:get_roster_entry(FJid, Jid),
     Res =/= does_not_exist.

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -319,8 +319,11 @@ add_rooms_to_roster(Acc, UserUS) ->
     Info = get_rooms_info(lists:sort(RoomList)),
     NewItems = lists:foldl(
       fun({{RoomU, RoomS}, RoomName, RoomVersion}, Items0) ->
+              JID = jid:make_noprep(RoomU, RoomS, <<>>),
               Item = #roster{
-                        jid = jid:make_noprep(RoomU, RoomS, <<>>),
+                        usj = {RoomU, RoomS, jid:to_lower(JID)},
+                        us = {RoomU, RoomS},
+                        jid = jid:to_lower(JID),
                         name = RoomName,
                         subscription = to,
                         groups = [?NS_MUC_LIGHT],

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -67,7 +67,7 @@ end_per_testcase(_TC, C) ->
 roster_old(_C) ->
     R1 = get_roster_old(),
     ?assertEqual(length(R1), 0),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     subscription(out, subscribe),
     assert_state_old(none, out),
@@ -76,7 +76,7 @@ roster_old(_C) ->
 roster_old_with_filter(_C) ->
     R1 = get_roster_old(),
     ?assertEqual(0, length(R1)),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     subscription(in, subscribe),
     R2 = get_roster_old(),
@@ -86,29 +86,29 @@ roster_old_with_filter(_C) ->
     ok.
 
 roster_new(_C) ->
-    R1 = mod_roster:get_roster_entry(a(), host(), bob()),
+    R1 = mod_roster:get_roster_entry(alice_jid(), bob()),
     ?assertEqual(does_not_exist, R1),
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     assert_state_old(none, none),
     ct:pal("get_roster_old(): ~p", [get_roster_old()]),
-    R2 = mod_roster:get_roster_entry(a(), host(), bob()),
+    R2 = mod_roster:get_roster_entry(alice_jid(), bob()),
     ?assertMatch(#roster{}, R2), % is not guaranteed to contain full info
-    R3 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
     subscription(out, subscribe),
-    R4 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R4 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R4, none, out, [<<"friends">>]).
 
 
 roster_case_insensitive(_C) ->
-    mod_roster:set_items(a(), host(), addbob_stanza()),
+    mod_roster:set_items(alice_jid(), addbob_stanza()),
     R1 = get_roster_old(),
     ?assertEqual(1, length(R1)),
     R2 = get_roster_old(ae()),
     ?assertEqual(1, length(R2)),
-    R3 = mod_roster:get_roster_entry(a(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alice_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
-    R3 = mod_roster:get_roster_entry(ae(), host(), bob(), full),
+    R3 = mod_roster:get_roster_entry(alicE_jid(), bob(), full),
     assert_state(R3, none, none, [<<"friends">>]),
     ok.
 
@@ -125,8 +125,7 @@ assert_state(Rentry, Subscription, Ask, Groups) ->
 subscription(Direction, Type) ->
     LBob = jid:to_lower(jid:from_binary(bob())),
     TFun = fun() -> mod_roster:process_subscription_transaction(Direction,
-                                                                a(),
-                                                                host(),
+                                                                alice_jid(),
                                                                 LBob,
                                                                 Type,
                                                                 <<"">>)
@@ -165,6 +164,12 @@ delete_ets() ->
     catch ets:delete(local_config),
     catch ets:delete(mongoose_services),
     ok.
+
+alice_jid() ->
+    jid:make(a(), host(), <<>>).
+
+alicE_jid() ->
+    jid:make(ae(), host(), <<>>).
 
 a() -> <<"alice">>.
 ae() -> <<"alicE">>.

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -123,10 +123,10 @@ assert_state(Rentry, Subscription, Ask, Groups) ->
     ?assertEqual(Groups, Rentry#roster.groups).
 
 subscription(Direction, Type) ->
-    LBob = jid:to_lower(jid:from_binary(bob())),
+    BobJID = jid:from_binary(bob()),
     TFun = fun() -> mod_roster:process_subscription_transaction(Direction,
                                                                 alice_jid(),
-                                                                LBob,
+                                                                BobJID,
                                                                 Type,
                                                                 <<"">>)
            end,


### PR DESCRIPTION
PROBLEM: if we pass forward an “untyped” binary for the user, server, and/or resource of a jid, we don’t know if it has been stringprepped or not, so we are always stringprepping again and again things that probably were stringprepped already, wasting CPU time. This was seen in profiles when working on the ejabberd_sm (#2582) case.

SOLUTION: Rewrite function calls to pass a #jid{} record, which is clear about its pieces, and extract the stringprepped chunks only on the place where it is used.

TO BE DONE: This is not changing any of the hooks, so it still doesn't introduce any incompatibilities. A subsequent work will do so.