### PR TITLE
Reduce execution time by 20% for simple prepared queries in postgres

### DIFF
--- a/src/rdbms/mongoose_rdbms_pgsql.erl
+++ b/src/rdbms/mongoose_rdbms_pgsql.erl
@@ -65,7 +65,7 @@ prepare(Connection, Name, _Table, _Fields, Statement) ->
     BinName = [atom_to_binary(Name, latin1)],
     ReplacedStatement = replace_question_marks(Statement),
     case epgsql:parse(Connection, BinName, ReplacedStatement, []) of
-        {ok, _} -> {ok, BinName};
+        {ok, _} -> epgsql:describe(Connection, statement, BinName);
         Error   -> Error
     end.
 


### PR DESCRIPTION
This PR addresses slow simple prepared queries:

Before:

```
> load_test(legacy, 100).
{417789,ok}

> load_test(upsert, 100).
{514556,ok}
```

```after
> load_test(legacy, 100).
{417789,ok}

> load_test(upsert, 100).
{417433,ok}
```

Both upsert and update_first versions consume same amount of time.


Proposed changes include:
* One less roundtrip to **postres** on execute.
* Do `epgsql:describe` in the prepare step, not in the execute step, because it goes to the server to get data.




Code for micro-banchmarking:

```erlang
load_test(Method, Times) ->
    timer:tc(fun() -> test_xml_times(Method, Times) end).

test_xml_times(_Method, 0) ->
   ok;
test_xml_times(Method, Times) ->
   mod_private_rdbms:multi_set_data(Method, <<"alice">>, <<"localhost">>,
                [{<<"alice:private:ns">>, test_xml(Times)}]),
   test_xml_times(Method, Times - 1).


init(Host, _) ->
    mongoose_rdbms:prepare(private_data_update, private_storage,
                           [namespace, data, username],
                           <<"UPDATE private_storage SET namespace=?, data=? WHERE username=?">>),
    mongoose_rdbms:prepare(private_data_insert, private_storage,
                           [namespace, data, username],
                           <<"INSERT INTO private_storage (namespace, data, username) VALUES (?,?,?)">>),
    rdbms_queries:prepare_upsert(Host, private_upsert, private_storage,
                                 [<<"username">>, <<"namespace">>, <<"data">>],
                                 [<<"data">>],
                                 [<<"username">>, <<"namespace">>]).

multi_set_data(Method, LUser, LServer, NS2XML) ->
    NS2BinXML = make_xml_binary(NS2XML),
    F = fun() -> multi_set_data_t(Method, LUser, LServer, NS2BinXML) end,
    case rdbms_queries:sql_transaction(LServer, F) of
        {atomic, ok} -> ok;
        {aborted, Reason} -> {aborted, Reason};
        {error, Reason} -> {error, Reason}
    end.

multi_set_data_t(update_first, LUser, LServer, NS2XML) ->
    [update_data_t(LUser, LServer, NS, XML) || {NS, XML} <- NS2XML],
    ok;
multi_set_data_t(upsert, LUser, LServer, NS2XML) ->
    [upsert_data_t(LUser, LServer, NS, XML) || {NS, XML} <- NS2XML],
    ok;
multi_set_data_t(legacy, LUser, LServer, NS2XML) ->
    SLUser = mongoose_rdbms:escape_string(LUser),
    [set_data_t(SLUser, LServer, NS, XML) || {NS, XML} <- NS2XML],
    ok.

upsert_data_t(LUser, Host, NS, XML) ->
    InsertParams = [LUser, NS, XML],
    UpdateParams = [XML],
    UniqueKeyValues = [LUser, NS],
    rdbms_queries:execute_upsert(Host, private_upsert, InsertParams, UpdateParams, UniqueKeyValues).

update_data_t(LUser, Host, NS, XML) ->
    Res = mongoose_rdbms:execute(Host, private_data_update, [NS, XML, LUser]),
    case Res of
        {updated, 1} ->
            ok;
        {updated, 0} ->
            mongoose_rdbms:execute(Host, private_data_insert, [NS, XML, LUser])
    end.

```

