### PR TITLE
Use the latest mongooseim-docker

### DIFF
--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -33,7 +33,7 @@ IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
-git checkout aeeeef12ea64a00aa72da88472aff8c4f0e049a6
+git checkout 318e1ee6582e7473303a2cd0b4baca0c9c09a1be
 
 cp ../${MONGOOSE_TGZ} member
 


### PR DESCRIPTION
- Config file updated to 'mongooseim.toml'
- Ubuntu version fixed at 18.04

This PR attempts to fix the issue of building MongooseIM on CircleCI with Ubuntu 16.04 and using the resulting tarball to build a docker image based on Ubuntu 20.04 - these two had incompatible library versions and recent MongooseIM docker images were not starting at all.

The two still don't align completely (16.04 and 18.04), but the image for [this PR](https://hub.docker.com/layers/mongooseim/mongooseim/PR-2926/) does not crash on startup.

Possibilities:

1. Run CircleCI on Ubuntu 20.04, upgrade Docker image to 20.04 - needs fixing multiple issues, see https://github.com/esl/MongooseIM/pull/2925
2. Run CircleCI on Ubuntu 18.04 in Docker (no machine for 18.04) - most likely even more difficult, but we could reduce the duplication between CI and Docker-related shell scripts and make them unified. Not sure about the performance.
3. Downgrade Docker image to use Ubuntu 16.04 - it might require least work, but it's a very short-term solution and the image for 16.04 does not have a nice tag at `phusion/baseimage`.
4. For now, make the `circle-build-and-push-docker` script build MongooseIM on the `builder` docker image. This would increase the duration of the CircleCI job by about 5 minutes (or more...)

