### PR TITLE
TLS and Ubuntu

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -755,7 +755,7 @@ ciphers_working_with_ssl_clients(Config) ->
 openssl_client_can_use_cipher(Cipher, Port) ->
     PortStr = integer_to_list(Port),
     Cmd = "echo '' | openssl s_client -connect localhost:" ++ PortStr ++
-          " -cipher " "\"" ++ Cipher ++ "\" 2>&1",
+          " -cipher " "\"" ++ Cipher ++ "\" -tls1_2 2>&1",
     {done, ReturnCode, _Result} = erlsh:oneliner(Cmd),
     0 == ReturnCode.
 

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -61,10 +61,9 @@ groups() ->
           {starttls, [], [should_fail_to_authenticate_without_starttls,
                           should_not_send_other_features_with_starttls_required,
                           auth_bind_pipelined_starttls_skipped_error | protocol_test_cases()]},
-          {tls, [parallel], [auth_bind_pipelined_session,
-                             auth_bind_pipelined_auth_failure,
-                             should_pass_with_tlsv1_2
-                             | protocol_test_cases() ++ cipher_test_cases()]},
+          {tls, [parallel], auth_bind_pipelined_cases() ++
+                            protocol_test_cases() ++
+                            cipher_test_cases()},
           {feature_order, [parallel], [stream_features_test,
                                        tls_authenticate,
                                        tls_compression_fail,
@@ -98,6 +97,12 @@ tls_groups()->
      {group, c2s_noproc},
      {group, feature_order},
      {group, tls}].
+
+auth_bind_pipelined_cases() ->
+    [
+     auth_bind_pipelined_session,
+     auth_bind_pipelined_auth_failure
+    ].
 
 protocol_test_cases() ->
     [

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -38,7 +38,7 @@ all: mongooseim/cert.pem mongooseim/key.pem \
 # So, let's remove the option for now.
 # https://bugs.launchpad.net/ubuntu/+source/openldap/+bug/1724285
 %/dh_server.pem:
-	openssl dhparam -outform PEM -out $@ 1024
+	openssl dhparam -outform PEM -out $@ 2048
 
 %/index.txt:
 	mkdir -p $(@D)


### PR DESCRIPTION
So there are two important fixes here.

The first thing is that the cipher `ECDHE-RSA-AES256-GCM-SHA384` belongs strictly to the tls 1.2 version, so in order to pass the test called `clients_can_connect_with_ECDHE-RSA-AES256-GCM-SHA384_only` needs to request using this version alone, otherwise the client will be able to connect with many more ciphers and this test would fail.

The second thing is that, in ubuntu, Diffie-Hellman keys that are known to be to small are disallowed by default, due to the Logjam vulnerability, so the dh size parameter needed to be incremented in the makefile for the ssl certificates. Why this is not an issue in the latest MacOS, I don't know.

But with this, TLS issues for the latest ubuntu are fixed.

The first two commits are from https://github.com/esl/MongooseIM/pull/2925, @chrzaszcz let me know if we want to rebase them out before merging this to master (I guess we'll want to, right?)