### PR TITLE
Load some applications on demand [WIP]

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+% vi:syntax=erlang
+
 {erl_opts, [debug_info,
             {i, ["include"]},
             {d, xml_nif}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,3 +1,4 @@
+% vi:syntax=erlang
 os:putenv("EXOMETER_PACKAGES", "(minimal)"),
 
 MaybeReadFromConfig =
@@ -44,6 +45,12 @@ fun() ->
 end,
 
 RequiredApps = fun() -> [mongooseim, inets, tools, compiler] end,
+
+%% Could be included, but should not be started automatically
+AlwaysOptional = [mnesia, recon, nksip, nkservice, nkpacket, nklib, cqerl, tirerl, rabbit_common, amqp_client, riakc, riak_pb, eodbc, erlcloud],
+FirstApplications = [kernel, lager],
+
+
 EnvApps = GetEnvApps(),
 
 SetupIncludedApps =
@@ -52,8 +59,16 @@ fun(Config, EnvApps) ->
         {release, Desc, _Apps} = lists:keyfind(release, 1, RelxCfg),
         EnvAppsToInclude = [ list_to_atom(App) || App <- string:tokens(EnvApps, " \n\r") ],
         AppsToIncludeIn = RequiredApps() ++ DevAppsToInclude() ++ EnvAppsToInclude,
-        AppsToInclude = ordsets:to_list(ordsets:from_list(AppsToIncludeIn)),
-        NewReleaseCfg = {release, Desc, AppsToInclude},
+        Apps = ordsets:subtract(ordsets:from_list(AppsToIncludeIn), ordsets:from_list(FirstApplications)),
+        AlwaysStopped = ordsets:from_list(AlwaysOptional),
+        StartedApps = ordsets:subtract(Apps, AlwaysStopped),
+        StoppedApps = ordsets:intersection(Apps, AlwaysStopped),
+        OptionalApps = ordsets:to_list(StoppedApps),
+        AppsToInclude = ordsets:to_list(StartedApps),
+        %% If Type = load, the application is only loaded.
+        LoadApps = [{App, load} || App <- OptionalApps],
+        NewReleaseCfg = {release, Desc, FirstApplications ++ lists:sort(AppsToInclude ++ LoadApps)},
+        io:format("~p", [NewReleaseCfg]),
         NewRelxCfg = lists:keyreplace(release, 1, RelxCfg, NewReleaseCfg),
         lists:keyreplace(relx, 1, Config, {relx, NewRelxCfg})
 end,

--- a/src/mongooseim.app.src
+++ b/src/mongooseim.app.src
@@ -42,7 +42,6 @@
 %%                  syslogger, % uncomment to enable a logger handler for syslog
                   jid,
                   fast_tls,
-                  tirerl,
                   usec,
                   uuid,
                   xmerl,

--- a/tools/configure
+++ b/tools/configure
@@ -46,13 +46,21 @@ app_opts() ->
      {"odbc",          ["eodbc"],           "include alternative version of ODBC driver"},
      {"pgsql",         ["epgsql"],          include_driver("pgsql")},
      {"redis",         ["eredis"],            include_driver("redis")},
-     {"riak",          ["riakc"],           include_driver("riak")},
-     {"jingle-sip",    ["nksip"],           include_driver("nksip")},
+     {"riak",          ["riakc"],           riakc_apps()},
+     {"jingle-sip",    ["nksip"],           nksip_apps()},
      {"cassandra",     ["cqerl"],           include_driver("cassandra")},
      {"elasticsearch", ["tirerl"],          include_driver("elasticsearch")},
      {"aws",           ["erlcloud"],        "include support for AWS services"},
-     {"amqp_client",   ["amqp_client"],     "include AMQP client"},
+     {"amqp_client",   ["amqp_client"],     amqp_apps()},
      {"templates",     ["eini", "bbmustache"], "include applications for templating"}].
+
+%% All deps should be specified, so {optional_app, load} is set for all of them,
+%% not just main application.
+%% If not specified here, MIM would still work, just an optional application,
+%% not specified here, would be started.
+riakc_apps() -> ["riakc", "riak_pb"].
+nksip_apps() -> ["nksip", "nklib", "nkservice", "nkpacket"].
+amqp_apps()  -> ["amqp_client", "rabbit_common"].
 
 opts() ->
     [{"prefix",  (#opts{})#opts.prefix,  "Installation PREFIX directory"},

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -38,7 +38,7 @@ all: mongooseim/cert.pem mongooseim/key.pem \
 # So, let's remove the option for now.
 # https://bugs.launchpad.net/ubuntu/+source/openldap/+bug/1724285
 %/dh_server.pem:
-	openssl dhparam -outform PEM -out $@ 2048
+	openssl dhparam -outform PEM -out $@ 1024
 
 %/index.txt:
 	mkdir -p $(@D)


### PR DESCRIPTION
You want to compare application:loaded_applications() with application:which_applications()

This PR addresses "not always start apps".

Proposed changes include:
* Be aware, that for this to work, the apps should be a clear dependency.

`AlwaysOptional = [mnesia, recon, nksip, nkservice, nkpacket, nklib, cqerl, tirerl, rabbit_common, amqp_client, riakc, riak_pb, eodbc, erlcloud],`

We do `AlwaysOptional` logic BEFORE relx makes a dependancy tree.

This means that if we need to add the apps we want to be optional into `configure` (see what I did with `nksip_apps()`).

