### PR TITLE
Tag nksip apps as load-only for relx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all: rel
 clean:
 	-rm -rf asngen
 	-rm -rf _build
+	-rm configure.out
 	-rm rel/configure.vars.config
 	-rm rel/vars.config
 	-rm rel/vars-toml.config

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -67,7 +67,7 @@ start(#{node := Node}, Domain, Mod, Args) ->
     start(Node, Domain, Mod, Args);
 start(Node, Domain, Mod, Args) ->
     Cookie = escalus_ct:get_config(ejabberd_cookie),
-    case escalus_rpc:call(Node, gen_mod, start_module, [Domain, Mod, Args], 5000, Cookie) of
+    case escalus_rpc:call(Node, gen_mod, start_module, [Domain, Mod, Args], 15000, Cookie) of
         {badrpc, Reason} ->
             ct:fail("Cannot start module ~p reason ~p", [Mod, Reason]);
         R -> R

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -43,17 +43,38 @@ fun() ->
         end
 end,
 
-RequiredApps = fun() -> [mongooseim, inets, tools, compiler] end,
+FirstApps = [kernel, lager],
+RequiredApps = [mongooseim, inets, tools, compiler],
+AlwaysOptional = [nksip, nkservice, nkpacket, nklib],
+
 EnvApps = GetEnvApps(),
+
+LoadAndStartApps =
+fun(Apps) ->
+        AlwaysStopped = ordsets:from_list(AlwaysOptional),
+        StartedApps = ordsets:subtract(Apps, AlwaysStopped),
+        ordsets:to_list(StartedApps)
+end,
+
+OnlyLoadApps =
+fun(Apps) ->
+        AlwaysStopped = ordsets:from_list(AlwaysOptional),
+        StoppedApps = ordsets:intersection(Apps, AlwaysStopped),
+        OptionalApps = ordsets:to_list(StoppedApps),
+        %% If Type = load, the application is only loaded.
+        LoadApps = [{App, load} || App <- OptionalApps]
+end,
 
 SetupIncludedApps =
 fun(Config, EnvApps) ->
         RelxCfg = proplists:get_value(relx, Config),
         {release, Desc, _Apps} = lists:keyfind(release, 1, RelxCfg),
         EnvAppsToInclude = [ list_to_atom(App) || App <- string:tokens(EnvApps, " \n\r") ],
-        AppsToIncludeIn = RequiredApps() ++ DevAppsToInclude() ++ EnvAppsToInclude,
-        AppsToInclude = ordsets:to_list(ordsets:from_list(AppsToIncludeIn)),
-        NewReleaseCfg = {release, Desc, AppsToInclude},
+        AppsToIncludeIn = ordsets:from_list(RequiredApps ++ DevAppsToInclude() ++ EnvAppsToInclude),
+        Apps = ordsets:subtract(AppsToIncludeIn, ordsets:from_list(FirstApps)),
+        StartApps = LoadAndStartApps(Apps),
+        LoadApps = OnlyLoadApps(Apps),
+        NewReleaseCfg = {release, Desc, FirstApps ++ lists:sort(StartApps ++ LoadApps)},
         NewRelxCfg = lists:keyreplace(release, 1, RelxCfg, NewReleaseCfg),
         lists:keyreplace(relx, 1, Config, {relx, NewRelxCfg})
 end,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -45,24 +45,18 @@ end,
 
 FirstApps = [kernel, lager],
 RequiredApps = [mongooseim, inets, tools, compiler],
-AlwaysOptional = [nksip, nkservice, nkpacket, nklib],
+OptionalApps = [{nksip, [nkservice, nkpacket, nklib]}],
 
 EnvApps = GetEnvApps(),
 
-LoadAndStartApps =
-fun(Apps) ->
-        AlwaysStopped = ordsets:from_list(AlwaysOptional),
-        StartedApps = ordsets:subtract(Apps, AlwaysStopped),
-        ordsets:to_list(StartedApps)
-end,
-
-OnlyLoadApps =
-fun(Apps) ->
-        AlwaysStopped = ordsets:from_list(AlwaysOptional),
-        StoppedApps = ordsets:intersection(Apps, AlwaysStopped),
-        OptionalApps = ordsets:to_list(StoppedApps),
-        %% If Type = load, the application is only loaded.
-        LoadApps = [{App, load} || App <- OptionalApps]
+PrepareApp =
+fun(App) ->
+        case lists:keyfind(App, 1, OptionalApps) of
+            false ->
+                [App];
+            {App, DepsOfApp} ->
+                lists:map(fun(V) -> {V, load} end, [App | DepsOfApp])
+        end
 end,
 
 SetupIncludedApps =
@@ -70,11 +64,9 @@ fun(Config, EnvApps) ->
         RelxCfg = proplists:get_value(relx, Config),
         {release, Desc, _Apps} = lists:keyfind(release, 1, RelxCfg),
         EnvAppsToInclude = [ list_to_atom(App) || App <- string:tokens(EnvApps, " \n\r") ],
-        AppsToIncludeIn = ordsets:from_list(RequiredApps ++ DevAppsToInclude() ++ EnvAppsToInclude),
-        Apps = ordsets:subtract(AppsToIncludeIn, ordsets:from_list(FirstApps)),
-        StartApps = LoadAndStartApps(Apps),
-        LoadApps = OnlyLoadApps(Apps),
-        NewReleaseCfg = {release, Desc, FirstApps ++ lists:sort(StartApps ++ LoadApps)},
+        AppsToIncludeIn = lists:usort(RequiredApps ++ DevAppsToInclude() ++ EnvAppsToInclude),
+        Apps = lists:subtract(AppsToIncludeIn, FirstApps),
+        NewReleaseCfg = {release, Desc, FirstApps ++ lists:flatmap(PrepareApp, Apps)},
         NewRelxCfg = lists:keyreplace(release, 1, RelxCfg, NewReleaseCfg),
         lists:keyreplace(relx, 1, Config, {relx, NewRelxCfg})
 end,

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -57,7 +57,7 @@ start(Host, Opts) ->
     ok.
 
 start_nksip_service_or_error(Opts) ->
-    application:ensure_all_started(nksip),
+    {ok, _} = application:ensure_all_started(nksip),
     ListenPort = gen_mod:get_opt(listen_port, Opts, 5600),
     NkSipBasicOpts = #{sip_listen => "sip:all:" ++ integer_to_list(ListenPort),
                        callback => jingle_sip_callbacks,


### PR DESCRIPTION
The trick is to tell `relx` that certain apps are to be only included in the runtime and their code loaded, but don't need to be started. This is done using the trick
```erlang
         LoadApps = [{App, load} || App <- OptionalApps]
```
That is, for example, in the `relx` app list, doing `[..., {nksip, load}, ...]` instead of [..., nksip, ...].

`nksip` is nevertheless loaded in `mod_jingle_sip` doing the typical `application:ensure_all_started/1` and pattern-matching that it returns ok.

Co-authored-by Mikhail Uvarov