### PR TITLE
TOML config: declarative spec for 'listen'

### DIFF
--- a/doc/advanced-configuration/listen.md
+++ b/doc/advanced-configuration/listen.md
@@ -182,26 +182,19 @@ Path to the X509 PEM file with a CA chain that will be used to verify clients. I
 
 Path to the Diffie-Hellman parameter file.
 
+#### `listen.c2s.tls.ciphers`
+* **Syntax:** string with the OpenSSL cipher suite specification
+* **Default:** for `fast_tls` the default is`"TLSv1.2:TLSv1.3"`. For `just_tls` this option is not set by default - all supported suites are accepted.
+* **Example:** `tls.ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"`
+
+Cipher suites to use with StartTLS or TLS. Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format. For `fast_tls`, this string can be used to specify versions as well. For `just_tls`, see the [Erlang/OTP SSL documentation](https://erlang.org/doc/man/ssl.html#type-ciphers) for allowed values.
+
 #### `listen.c2s.tls.protocol_options` - only for `fast_tls`
 * **Syntax:** array of strings
 * **Default:** `["no_sslv2", "no_sslv3", "no_tlsv1", "no_tlsv1_1"]`
 * **Example:** `tls.protocol_options = ["no_tlsv1", "no_tlsv1_1"]`
 
 A list of OpenSSL options for FastTLS. You can find the mappings between supported options and actual OpenSSL flags in the `fast_tls` [source code](https://github.com/processone/fast_tls/blob/master/c_src/options.h).
-
-#### `listen.c2s.tls.ciphers` - for `fast_tls`
-* **Syntax:** string with the OpenSSL cipher suite specification
-* **Default:** `"TLSv1.2:TLSv1.3"`
-* **Example:** `tls.ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"`
-
-Cipher suites to use with StartTLS or TLS. Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format.
-
-#### `listen.c2s.tls.ciphers` - for `just_tls`
-* **Syntax:** array of tables with the following keys: `cipher`, `key_exchange`, `mac`, `prf` and string values.
-* **Default:** not set, all supported cipher suites are accepted
-* **Example:** `tls.ciphers = "[{cipher = "aes_25_gcm", key_exchange = "any", mac = "aead", "prf = sha384"}]"`
-
-Cipher suites to use with StartTLS or TLS. For allowed values, see the [Erlang/OTP SSL documentation](https://erlang.org/doc/man/ssl.html#type-ciphers)
 
 #### `listen.c2s.tls.verify_mode` - only for `just_tls`
 * **Syntax:** string, one of `"peer"`, `"selfsigned_peer"`, `"none"`
@@ -464,8 +457,8 @@ You can pass the following optional parameters:
 The time (in milliseconds) after which an inactive user is disconnected.
 
 #### `listen.http.handlers.mod_websockets.ping_rate`
-* **Syntax:** positive integer or the string `"none"`
-* **Default:** `"none"`
+* **Syntax:** positive integer
+* **Default:** not set - pings disabled
 * **Example:** `ping_rate = 10_000`
 
 The time between pings sent by server. By setting this option you enable server-side pinging.
@@ -600,11 +593,11 @@ Path to the X509 PEM file with a CA chain that will be used to verify clients. I
 Path to the Diffie-Hellman parameter file.
 
 #### `listen.http.tls.ciphers`
-* **Syntax:** array of tables with the following keys: `cipher`, `key_exchange`, `mac`, `prf` and string values.
+* **Syntax:** string with the OpenSSL cipher suite specification
 * **Default:** not set, all supported cipher suites are accepted
-* **Example:** `tls.ciphers = "[{cipher = "aes_25_gcm", key_exchange = "any", mac = "aead", "prf = sha384"}]"`
+* **Example:** `tls.ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"`
 
-Cipher suites to use. For allowed values, see the [Erlang/OTP SSL documentation](https://erlang.org/doc/man/ssl.html#type-ciphers)
+Cipher suites to use. Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html) for the cipher string format. For allowed values, see the [Erlang/OTP OpenSSL documentation](http://www.openssl.org/docs/man1.0.2/apps/ciphers.html).
 
 #### `listen.http.tls.versions`
 * **Syntax:** array of strings

--- a/include/ejabberd_config.hrl
+++ b/include/ejabberd_config.hrl
@@ -28,6 +28,8 @@
                       }).
 
 -record(section, {items,
+                  validate_keys = any,
+                  required = [],
                   validate = any,
                   process,
                   format = default}).

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -35,12 +35,7 @@
   tls.certfile = \"priv/ssl/fake_server.pem\"
   tls.mode = \"tls\"
   tls.module = \"just_tls\"
-
-  [[listen.c2s.tls.ciphers]]
-    cipher = \"aes_256_gcm\"
-    key_exchange = \"ecdhe_rsa\"
-    mac = \"aead\"
-    prf = \"sha384\""}.
+  tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
 {http_api_old_endpoint, "ip_address = \"127.0.0.1\"
   port = {{ http_api_old_endpoint_port }}"}.

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -60,7 +60,13 @@
 -spec parse_file(FileName :: string()) -> state().
 parse_file(FileName) ->
     ParserModule = parser_module(filename:extension(FileName)),
-    ParserModule:parse_file(FileName).
+    try
+        ParserModule:parse_file(FileName)
+    catch
+        error:{config_error, ExitMsg, Errors} ->
+            [?LOG_ERROR(Error) || Error <- Errors],
+            mongoose_config_utils:exit_or_halt(ExitMsg)
+    end.
 
 %% Only the TOML format is supported
 parser_module(".toml") -> mongoose_config_parser_toml.

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -27,10 +27,13 @@ handler([item|Rest], #list{items = Items}) ->
 
 root() ->
     #section{
-       items = #{<<"general">> => general()},
-       process = fun ?MODULE:process_root/1
+       items = #{<<"general">> => general(),
+                 <<"listen">> => listen()
+                },
+       required = [<<"general">>]
       }.
 
+%% path: general
 general() ->
     #section{
        items = #{<<"loglevel">> => #option{type = atom,
@@ -42,7 +45,7 @@ general() ->
                                       validate = unique_non_empty,
                                       format = config},
                  <<"registration_timeout">> => #option{type = int_or_infinity,
-                                                       validate = timeout,
+                                                       validate = positive,
                                                        format = local_config},
                  <<"language">> => #option{type = binary,
                                            validate = non_empty,
@@ -82,7 +85,8 @@ general() ->
                                                         format = host_local_config},
                  <<"hide_service_name">> => #option{type = boolean,
                                                     format = host_local_config}
-                }
+                },
+       required = [<<"hosts">>]
       }.
 
 ctl_access_rule() ->
@@ -96,11 +100,242 @@ ctl_access_rule() ->
        format = prepend_key
       }.
 
-process_root(KVs) ->
-    true = lists:any(fun(#local_config{key = hosts}) -> true;
-                        (_) -> false
-                     end, KVs),
-    KVs.
+%% path: listen
+listen() ->
+    Keys = [<<"http">>, <<"c2s">>, <<"s2s">>, <<"service">>],
+    #section{
+       items = maps:from_list([{Key, #list{items = listener(Key),
+                                           format = none}} || Key <- Keys]),
+       format = local_config
+      }.
+
+%% path: listen.*[]
+listener(Type) ->
+    ExtraItems = listener_items(Type),
+    #section{
+       items = ExtraItems#{<<"port">> => #option{type = integer,
+                                                 validate = port},
+                           <<"ip_address">> => #option{type = string,
+                                                       validate = ip_address},
+                           <<"proto">> => #option{type = atom,
+                                                  validate = {enum, [tcp, udp, ws, wss]}},
+                           <<"ip_version">> => #option{type = integer,
+                                                       validate = {enum, [4, 6]},
+                                                       process = fun ?MODULE:process_ip_version/1,
+                                                       format = item}},
+       required = [<<"port">>],
+       process = fun ?MODULE:process_listener/2
+      }.
+
+listener_items(<<"http">>) ->
+    #{<<"tls">> => http_listener_tls(),
+      <<"transport">> => http_transport(),
+      <<"protocol">> => http_protocol(),
+      <<"handlers">> => http_handlers()
+     };
+listener_items(Type) ->
+    ExtraItems = xmpp_listener_items(Type),
+    ExtraItems#{<<"hibernate_after">> => #option{type = integer,
+                                                 validate = non_negative},
+                <<"max_stanza_size">> => #option{type = integer,
+                                                 validate = positive},
+                <<"backlog">> => #option{type = integer,
+                                         validate = non_negative},
+                <<"proxy_protocol">> => #option{type = boolean},
+                <<"num_acceptors">> => #option{type = integer,
+                                               validate = positive,
+                                               format = {kv, acceptors_num}}
+               }.
+
+xmpp_listener_items(<<"c2s">>) ->
+    #{<<"access">> => #option{type = atom,
+                              validate = non_empty},
+      <<"shaper">> => #option{type = atom,
+                              validate = non_empty},
+      <<"xml_socket">> => #option{type = boolean},
+      <<"zlib">> => #option{type = integer,
+                            validate = positive},
+      <<"max_fsm_queue">> => #option{type = integer,
+                                     validate = positive},
+      <<"tls">> => c2s_tls()};
+xmpp_listener_items(<<"s2s">>) ->
+    #{<<"shaper">> => #option{type = atom,
+                              validate = non_empty},
+      <<"tls">> => s2s_tls()};
+xmpp_listener_items(<<"service">>) ->
+    #{<<"access">> => #option{type = atom,
+                              validate = non_empty},
+      <<"shaper_rule">> => #option{type = atom,
+                                   validate = non_empty},
+      <<"check_from">> => #option{type = boolean,
+                                  format = {kv, service_check_from}},
+      <<"hidden_components">> => #option{type = boolean},
+      <<"conflict_behaviour">> => #option{type = atom,
+                                          validate = {enum, [kick_old, disconnect]}},
+      <<"password">> => #option{type = string,
+                                validate = non_empty},
+      <<"max_fsm_queue">> => #option{type = integer,
+                                     validate = positive}}.
+
+%% path: listen.c2s[].tls
+c2s_tls() ->
+    #section{
+       items = #{
+                 %% common
+                 <<"module">> => #option{type = atom,
+                                         validate = {enum, [fast_tls, just_tls]}},
+                 <<"mode">> => #option{type = atom,
+                                       validate = {enum, [tls, starttls, starttls_required]}},
+                 <<"verify_peer">> => #option{type = boolean,
+                                              process = fun ?MODULE:process_verify_peer/1},
+                 <<"certfile">> => #option{type = string,
+                                           validate = non_empty},
+                 <<"cacertfile">> => #option{type = string,
+                                             validate = non_empty},
+                 <<"dhfile">> => #option{type = string,
+                                         validate = non_empty},
+                 <<"ciphers">> => #option{type = string},
+
+                 %% fast_tls
+                 <<"protocol_options">> => #list{items = #option{type = string,
+                                                                 validate = non_empty}},
+
+                 %% just_tls
+                 <<"verify_mode">> => #option{type = atom,
+                                              validate = {enum, [peer, selfsigned_peer, none]}},
+                 <<"disconnect_on_failure">> => #option{type = boolean},
+                 <<"crl_files">> => #list{items = #option{type = string,
+                                                          validate = non_empty},
+                                          format = {kv, crlfiles}},
+                 <<"password">> => #option{type = string},
+                 <<"server_name_indication">> => #option{type = boolean,
+                                                         process = fun ?MODULE:process_sni/1},
+                 <<"versions">> => #list{items = #option{type = atom}}
+                },
+       process = fun ?MODULE:process_xmpp_tls/1,
+       format = none
+      }.
+
+%% path: listen.s2s[].tls
+s2s_tls() ->
+    #section{
+       items = #{<<"cacertfile">> => #option{type = string,
+                                             validate = non_empty},
+                 <<"dhfile">> => #option{type = string,
+                                         validate = non_empty},
+                 <<"ciphers">> => #option{type = string},
+                 <<"protocol_options">> => #list{items = #option{type = string,
+                                                                 validate = non_empty}}
+                },
+       process = fun ?MODULE:process_fast_tls/1,
+       format = none
+      }.
+
+%% path: listen.http[].tls
+http_listener_tls() ->
+    #section{
+       items = #{<<"verify_peer">> => #option{type = boolean,
+                                              process = fun ?MODULE:process_verify_peer/1,
+                                              format = {kv, verify}},
+                 <<"certfile">> => #option{type = string,
+                                           validate = non_empty},
+                 <<"cacertfile">> => #option{type = string,
+                                             validate = non_empty},
+                 <<"dhfile">> => #option{type = string,
+                                         validate = non_empty},
+                 <<"keyfile">> => #option{type = string,
+                                          validate = non_empty},
+                 <<"password">> => #option{type = string},
+                 <<"server_name_indication">> => #option{type = boolean,
+                                                         process = fun ?MODULE:process_sni/1},
+                 <<"ciphers">> => #option{type = string},
+                 <<"versions">> => #list{items = #option{type = atom}},
+                 <<"verify_mode">> => #option{type = atom,
+                                              validate = {enum, [peer, selfsigned_peer, none]}}
+                },
+       format = {kv, ssl}
+      }.
+
+%% path: listen.http[].transport
+http_transport() ->
+    #section{
+       items = #{<<"num_acceptors">> => #option{type = integer,
+                                                validate = positive},
+                 <<"max_connections">> => #option{type = int_or_infinity,
+                                                  validate = non_negative}
+                },
+       format = {kv, transport_options}
+      }.
+
+%% path: listen.http[].protocol
+http_protocol() ->
+    #section{
+       items = #{<<"compress">> => #option{type = boolean}},
+       format = {kv, protocol_options}
+      }.
+
+%% path: listen.http[].handlers
+http_handlers() ->
+    Keys = [<<"mod_websockets">>,
+            <<"lasse_handler">>,
+            <<"cowboy_static">>,
+            <<"mongoose_api">>,
+            <<"mongoose_api_admin">>,
+            default],
+    #section{
+       items = maps:from_list([{Key, #list{items = http_handler(Key),
+                                           format = none}} || Key <- Keys]),
+       validate_keys = module,
+       format = {kv, modules}
+      }.
+
+%% path: listen.http[].handlers.*[]
+http_handler(Key) ->
+    ExtraItems = http_handler_items(Key),
+    RequiredKeys = case http_handler_required(Key) of
+                       all -> all;
+                       [] -> [<<"host">>, <<"path">>]
+                   end,
+    #section{
+       items = ExtraItems#{<<"host">> => #option{type = string,
+                                                 validate = non_empty},
+                           <<"path">> => #option{type = string}
+                          },
+       required = RequiredKeys,
+       process = fun ?MODULE:process_http_handler/2
+      }.
+
+http_handler_items(<<"mod_websockets">>) ->
+    #{<<"timeout">> => #option{type = int_or_infinity,
+                               validate = non_negative},
+      <<"ping_rate">> => #option{type = integer,
+                                 validate = positive},
+      <<"max_stanza_size">> => #option{type = int_or_infinity,
+                                       validate = positive},
+      <<"service">> => #section{items = xmpp_listener_items(<<"service">>),
+                                format = {kv, ejabberd_service}}};
+http_handler_items(<<"lasse_handler">>) ->
+    #{<<"module">> => #option{type = atom,
+                              validate = module}};
+http_handler_items(<<"cowboy_static">>) ->
+    #{<<"type">> => #option{type = atom},
+      <<"app">> => #option{type = atom},
+      <<"content_path">> => #option{type = string}};
+http_handler_items(<<"mongoose_api">>) ->
+    #{<<"handlers">> => #list{items = #option{type = atom,
+                                              validate = module}}};
+http_handler_items(<<"mongoose_api_admin">>) ->
+    #{<<"username">> => #option{type = binary},
+      <<"password">> => #option{type = binary}};
+http_handler_items(_) ->
+    #{}.
+
+http_handler_required(<<"lasse_handler">>) -> all;
+http_handler_required(<<"cowboy_static">>) -> all;
+http_handler_required(<<"mongoose_api">>) -> all;
+http_handler_required(_) -> [].
+
+%% Callbacks for 'process'
 
 process_ctl_access_rule(KVs) ->
     Commands = proplists:get_value(commands, KVs, all),
@@ -114,3 +349,96 @@ prepare_host(Host) ->
     Node = jid:nodeprep(Host),
     true = Node =/= error,
     Node.
+
+process_sni(false) ->
+    disable.
+
+process_lasse_handler([{module, Module}]) ->
+    [Module].
+
+process_verify_peer(false) -> verify_none;
+process_verify_peer(true) -> verify_peer.
+
+process_xmpp_tls(KVs) ->
+    Module = proplists:get_value(module, KVs, fast_tls),
+    case proplists:get_keys(KVs) -- (tls_keys(Module) ++ common_tls_keys()) of
+        [] -> strip_tls_keys(process_xmpp_tls(Module, proplists:delete(module, KVs)));
+        ExcessKeys -> error(#{what => {unexpected_tls_options, Module, ExcessKeys}})
+    end.
+
+tls_keys(just_tls) ->
+    [verify_mode, disconnect_on_failure, crlfiles, password, server_name_indication, versions];
+tls_keys(fast_tls) ->
+    [protocol_options].
+
+common_tls_keys() ->
+    [module, mode, verify_peer, certfile, cacertfile, dhfile, ciphers].
+
+process_xmpp_tls(just_tls, KVs) ->
+    {[VM, DoF], Opts} = proplists:split(KVs, [verify_mode, disconnect_on_failure]),
+    {External, Internal} = lists:partition(fun is_external_tls_opt/1, Opts),
+    SSLOpts = ssl_opts(verify_fun(VM, DoF) ++ Internal),
+    [{tls_module, just_tls}] ++ SSLOpts ++ External;
+process_xmpp_tls(fast_tls, KVs) ->
+    process_fast_tls(KVs).
+
+process_fast_tls(KVs) ->
+    proplists:substitute_aliases([{cacertfile, cafile}], KVs).
+
+strip_tls_keys(Opts) ->
+    lists:map(fun strip_tls_key/1, Opts).
+
+strip_tls_key({mode, V}) -> V;
+strip_tls_key({verify_peer, V}) -> V;
+strip_tls_key(KV) -> KV.
+
+verify_fun([], []) -> [];
+verify_fun([{verify_mode, VM}], []) -> [{verify_fun, {VM, true}}];
+verify_fun([{verify_mode, VM}], [{disconnect_on_failure, DoF}]) -> [{verify_fun, {VM, DoF}}].
+
+is_external_tls_opt({mode, _}) -> true;
+is_external_tls_opt({verify_peer, _}) -> true;
+is_external_tls_opt({crlfiles, _}) -> true;
+is_external_tls_opt({_, _}) -> false.
+
+ssl_opts([]) -> [];
+ssl_opts(Opts) -> [{ssl_options, Opts}].
+
+process_ip_version(4) -> inet;
+process_ip_version(6) -> inet6.
+
+process_listener([item, Type | _], KVs) ->
+    {[PortOpts, IPOpts], Opts} = proplists:split(KVs, [port, ip_address]),
+    PortIP = listener_portip(PortOpts, IPOpts),
+    {Port, IPT, _, _, Proto, OptsClean} =
+        ejabberd_listener:parse_listener_portip(PortIP, Opts),
+    {{Port, IPT, Proto}, listener_module(Type), OptsClean}.
+
+listener_portip([{port, Port}], []) -> Port;
+listener_portip([{port, Port}], [{ip_address, Addr}]) -> {Port, Addr}.
+
+listener_module(<<"http">>) -> ejabberd_cowboy;
+listener_module(<<"c2s">>) -> ejabberd_c2s;
+listener_module(<<"s2s">>) -> ejabberd_s2s_in;
+listener_module(<<"service">>) -> ejabberd_service.
+
+process_http_handler([item, Type | _], KVs) ->
+    {[[{host, Host}], [{path, Path}]], Opts} = proplists:split(KVs, [host, path]),
+    HandlerOpts = process_http_handler_opts(Type, Opts),
+    {Host, Path, binary_to_atom(Type, utf8), HandlerOpts}.
+
+process_http_handler_opts(<<"lasse_handler">>, [{module, Module}]) ->
+    [Module];
+process_http_handler_opts(<<"cowboy_static">>, Opts) ->
+    {[[{type, Type}], [{app, App}], [{content_path, Path}]], []} =
+        proplists:split(Opts, [type, app, content_path]),
+    {Type, App, Path, [{mimetypes, cow_mimetypes, all}]};
+process_http_handler_opts(<<"mongoose_api_admin">>, Opts) ->
+    {[UserOpts, PassOpts], []} = proplists:split(Opts, [username, password]),
+    case {UserOpts, PassOpts} of
+        {[], []} -> [];
+        {[{username, User}], [{password, Pass}]} -> [{auth, {User, Pass}}]
+    end;
+process_http_handler_opts(<<"cowboy_swagger_redirect_handler">>, []) -> #{};
+process_http_handler_opts(<<"cowboy_swagger_json_handler">>, []) -> #{};
+process_http_handler_opts(_, Opts) -> Opts.

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -371,9 +371,7 @@ listen_proto(_Config) ->
     ?eq([#local_config{key = listen,
                        value = [{{5222, {0, 0, 0, 0}, udp}, ejabberd_c2s, [{proto, udp}]}]}],
         parse_listener(<<"c2s">>, #{<<"proto">> => <<"udp">>})),
-    %% 'ejabberd_listener:normalize_proto/1' shows a warning message and falls back to 'tcp'
-    ?eq(listener_config(ejabberd_c2s, [{proto, pigeon}]),
-        parse_listener(<<"c2s">>, #{<<"proto">> => <<"pigeon">>})).
+    ?err(parse_listener(<<"c2s">>, #{<<"proto">> => <<"pigeon">>})).
 
 listen_ip_version(_Config) ->
     ?eq(listener_config(ejabberd_c2s, [inet]),
@@ -553,35 +551,23 @@ listen_tls_dhfile(_Config) ->
         parse_listener(<<"http">>, #{<<"tls">> => #{<<"dhfile">> => <<"dh.pem">>}})),
     ?err(parse_listener(<<"c2s">>, #{<<"tls">> => #{<<"dhfile">> => <<>>}})).
 
-
 listen_tls_ciphers(_Config) ->
-    %% fast_tls ciphers may contain versions as well
-    ?eq(listener_config(ejabberd_c2s, [{ciphers, "TLSv1.2:TLSv1.3"}]),
+    ?eq(listener_config(ejabberd_c2s, [{ciphers, "TLS_AES_256_GCM_SHA384"}]),
         parse_listener(<<"c2s">>,
-                       #{<<"tls">> => #{<<"ciphers">> => <<"TLSv1.2:TLSv1.3">>}})),
-    ?eq(listener_config(ejabberd_s2s_in, [{ciphers, "TLSv1.2:TLSv1.3"}]),
+                       #{<<"tls">> => #{<<"ciphers">> => <<"TLS_AES_256_GCM_SHA384">>}})),
+    ?eq(listener_config(ejabberd_c2s, [{tls_module, just_tls},
+                                       {ssl_options, [{ciphers, "TLS_AES_256_GCM_SHA384"}]}]),
+        parse_listener(<<"c2s">>,
+                       #{<<"tls">> => #{<<"module">> => <<"just_tls">>,
+                                        <<"ciphers">> => <<"TLS_AES_256_GCM_SHA384">>}})),
+    ?eq(listener_config(ejabberd_s2s_in, [{ciphers, "TLS_AES_256_GCM_SHA384"}]),
         parse_listener(<<"s2s">>,
-                       #{<<"tls">> => #{<<"ciphers">> => <<"TLSv1.2:TLSv1.3">>}})),
-    ?eq(listener_config(ejabberd_c2s, [{tls_module, just_tls},
-                                       {ssl_options, [{ciphers, ["TLS_AES_256_GCM_SHA384"]}]}]),
-        parse_listener(<<"c2s">>,
-                       #{<<"tls">> => #{<<"module">> => <<"just_tls">>,
-                                        <<"ciphers">> => [<<"TLS_AES_256_GCM_SHA384">>]}})),
-    ?eq(listener_config(ejabberd_c2s, [{tls_module, just_tls},
-                                       {ssl_options, [{ciphers, [#{cipher => aes_256_gcm,
-                                                                   key_exchange => any,
-                                                                   mac => aead,
-                                                                   prf => sha384}]}]}]),
-        parse_listener(<<"c2s">>,
-                       #{<<"tls">> => #{<<"module">> => <<"just_tls">>,
-                                        <<"ciphers">> => [#{<<"cipher">> => <<"aes_256_gcm">>,
-                                                            <<"key_exchange">> => <<"any">>,
-                                                            <<"mac">> => <<"aead">>,
-                                                            <<"prf">> => <<"sha384">>}]}})),
+                       #{<<"tls">> => #{<<"ciphers">> => <<"TLS_AES_256_GCM_SHA384">>}})),
+    ?eq(listener_config(ejabberd_cowboy, [{ssl, [{ciphers, "TLS_AES_256_GCM_SHA384"}]}]),
+        parse_listener(<<"http">>,
+                       #{<<"tls">> => #{<<"ciphers">> => <<"TLS_AES_256_GCM_SHA384">>}})),
     ?err(parse_listener(<<"c2s">>,
-                        #{<<"tls">> =>
-                              #{<<"module">> => <<"just_tls">>,
-                                <<"ciphers">> => [#{<<"cipher">> => <<"aes_256_gcm">>}]}})).
+                        #{<<"tls">> => #{<<"ciphers">> => [<<"TLS_AES_256_GCM_SHA384">>]}})).
 
 listen_tls_versions(_Config) ->
     ?eq(listener_config(ejabberd_c2s, [{tls_module, just_tls},

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.options
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.options
@@ -53,7 +53,7 @@
       [{modules,
            [{"_","/http-bind",mod_bosh,[]},
             {"_","/ws-xmpp",mod_websockets,
-             [{max_stanza_size,100},{ping_rate,none},{timeout,infinity}]},
+             [{max_stanza_size,100},{ping_rate,120000},{timeout,infinity}]},
             {"localhost","/api",mongoose_api_admin,
              [{auth,{<<"ala">>,<<"makotaipsa">>}}]},
             {"localhost","/api/contacts/{:jid}",mongoose_api_client,[]}]},

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -55,7 +55,7 @@
     host = "_"
     path = "/ws-xmpp"
     timeout = "infinity"
-    ping_rate = "none"
+    ping_rate = 120_000
     max_stanza_size = 100
 
 [[listen.http]]


### PR DESCRIPTION
Declarative specification for the 'listen' configuration section.

See the commit messages for more details.

- Still using `export_all`
- Still no specs, they will come soon
- Record fields will also be documented soon

