### PR TITLE
Change readthedocs theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: MongooseIM
 docs_dir: doc
-theme: readthedocs
+theme: material
 site_favicon: favicon.ico
 extra_templates: []
 extra_css: ["custom.css"]


### PR DESCRIPTION
This PR addresses [MIM-1238](https://erlangsolutions.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=MIM&modal=detail&selectedIssue=MIM-1238)

It seems that most of the issues we had with the docs can be solved by finding an appropriate theme and this is the one that best suits our preferences. 
Left to do after merge -> upload new version of the docs to `readthedocs` 

