### PR TITLE
TOML improved config templates

### DIFF
--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -294,7 +294,7 @@ enable_preset_on_node(Node, PresetVars, HostVarsFilePrefix) ->
     ok.
 
 template_config(Template, Vars) ->
-    MergedVars = merge_vars(Vars),
+    MergedVars = ensure_binary_strings(merge_vars(Vars)),
     %% Render twice to replace variables in variables
     Tmp = bbmustache:render(Template, MergedVars, [{key_type, atom}]),
     bbmustache:render(Tmp, MergedVars, [{key_type, atom}]).
@@ -305,6 +305,13 @@ merge_vars([Vars1, Vars2|Rest]) ->
                        end, Vars1, Vars2),
     merge_vars([Vars|Rest]);
 merge_vars([Vars]) -> Vars.
+
+%% bbmustache tries to iterate over lists, so we need to make them binaries
+ensure_binary_strings(Vars) ->
+    lists:map(fun({dbs, V}) -> {dbs, V};
+                 ({K, V}) when is_list(V) -> {K, list_to_binary(V)};
+                 ({K, V}) -> {K, V}
+              end, Vars).
 
 call(Node, M, F, A) ->
     case rpc:call(Node, M, F, A) of

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -245,7 +245,7 @@
     {odbc_mssql_mnesia,
      [{dbs, [redis, mssql]},
       {auth_method, "\"rdbms\""},
-      {rdbms_server_type, "rdbms_server_type = \"mssql\""},
+      {rdbms_server_type, "\"mssql\""},
       {outgoing_pools, "[outgoing_pools.redis.global_distrib]
   scope = \"global\"
   workers = 10

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -150,12 +150,12 @@ modify_config_and_restart(CyrsaslExternalConfig, Config) ->
     AuthMethods = escalus_config:get_config(auth_methods, Config, [{auth_method, "\"pki\""}]),
     CACertFile = filename:join([path_helper:repo_dir(Config),
                                 "tools", "ssl", "ca-clients", "cacert.pem"]),
-    NewConfigValues = [{tls_config, "tls.certfile = \"priv/ssl/fake_server.pem\"\n"
+    NewConfigValues = [{tls_config, "tls.module = \"" ++ TLSModule ++ "\"\n"
+                                    "  tls.certfile = \"priv/ssl/fake_server.pem\"\n"
                                     "  tls.mode = \"starttls\"\n"
                                     "  tls.verify_peer = true\n"
                                     "  tls.cacertfile = \"" ++ CACertFile ++ "\""
                                     ++ SSLOpts},
-		       {tls_module, "tls.module = \"" ++ TLSModule ++ "\""},
 		       {https_config, "tls.certfile = \"priv/ssl/fake_cert.pem\"\n"
                                       "  tls.keyfile = \"priv/ssl/fake_key.pem\"\n"
                                       "  tls.password = \"\"\n"
@@ -163,7 +163,7 @@ modify_config_and_restart(CyrsaslExternalConfig, Config) ->
                                       "  tls.cacertfile = \"" ++ CACertFile ++ "\""
                                       ++ VerifyMode},
                        {cyrsasl_external, CyrsaslExternalConfig},
-		       {sasl_mechanisms, "sasl_mechanisms = [\"external\"]"} | AuthMethods],
+		       {sasl_mechanisms, "\"external\""} | AuthMethods],
     ejabberd_node_utils:modify_config_file(NewConfigValues, Config),
     ejabberd_node_utils:restart_application(mongooseim).
 

--- a/doc/advanced-configuration/release-options.md
+++ b/doc/advanced-configuration/release-options.md
@@ -195,7 +195,7 @@ These options are inserted into the `rel/files/mongooseim.toml` template.
 * **Type:** parameter
 * **Option:** [`general.sm_backend`](../../advanced-configuration/general#generalsm_backend)
 * **Syntax:** string
-* **Example:** `{sm_backend, \""redis\""}.`
+* **Example:** `{sm_backend, "\"redis\""}.`
 
 ## tls_config
 
@@ -220,7 +220,7 @@ These options are inserted into the `rel/files/mongooseim.toml` template.
 
 ## zlib
 
-* **Type:** block
+* **Type:** parameter
 * **Option:** [`listen.c2s.zlib`](../../advanced-configuration/listen#listenc2szlib)
-* **Syntax:** TOML key-value pair
-* **Example:** `{zlib, "zlib = 10_000"}.`
+* **Syntax:** positive integer
+* **Example:** `{zlib, "10_000"}.`

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -15,23 +15,25 @@
 {s2s_addr, "[[s2s.address]]
     host = \"localhost\"
     ip_address = \"127.0.0.1\"
+
   [[s2s.address]]
     host = \"pubsub.localhost\"
     ip_address = \"127.0.0.1\"
+
   [[s2s.address]]
     host = \"muc.localhost\"
     ip_address = \"127.0.0.1\"
+
   [[s2s.address]]
     host = \"localhost.bis\"
     ip_address = \"127.0.0.1\""}.
 {s2s_default_policy, "\"allow\""}.
 {highload_vm_args, ""}.
-{listen_service, ""}.
+{listen_service, false}.
 
 {tls_config, "tls.certfile = \"priv/ssl/fake_server.pem\"
   tls.mode = \"starttls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
-{secondary_c2s, ""}.
 
 {http_api_old_endpoint, "ip_address = \"127.0.0.1\"
   port = {{ http_api_old_endpoint_port }}"}.
@@ -39,6 +41,5 @@
   port = {{ http_api_endpoint_port }}"}.
 {http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 
-{c2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
-{s2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
-
+{c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -148,8 +148,8 @@
 
 {{#secondary_c2s}}
 {{{secondary_c2s}}}
-{{/secondary_c2s}}
 
+{{/secondary_c2s}}
 [[listen.s2s]]
   port = {{{incoming_s2s_port}}}
   shaper = "s2s_shaper"
@@ -160,8 +160,8 @@
 
 {{#listen_service}}
 {{{listen_service}}}
-{{/listen_service}}
 
+{{/listen_service}}
 [auth]
   {{#auth_ldap}}
   {{{auth_ldap}}}
@@ -181,6 +181,7 @@
 {{#outgoing_pools}}
 {{{outgoing_pools}}}
 {{/outgoing_pools}}
+{{^outgoing_pools}}
 #[outgoing_pools.redis.global_distrib]
 #  scope = "single_host"
 #  host = "localhost"
@@ -200,6 +201,7 @@
 #    tls.verify_peer = true
 #    tls.cacertfile = "priv/ssl/cacert.pem"
 #    tls.server_name_indication = false
+{{/outgoing_pools}}
 
 [services.service_admin_extra]
   submods = ["node", "accounts", "sessions", "vcard", "gdpr", "upload",
@@ -213,8 +215,8 @@
 
 {{#mod_amp}}
 {{{mod_amp}}}
-{{/mod_amp}}
 
+{{/mod_amp}}
 [modules.mod_disco]
   users_can_see_hidden_services = false
 
@@ -226,26 +228,26 @@
 
 {{#mod_last}}
 {{{mod_last}}}
-{{/mod_last}}
 
+{{/mod_last}}
 [modules.mod_stream_management]
 
 {{#mod_offline}}
 {{{mod_offline}}}
-{{/mod_offline}}
 
+{{/mod_offline}}
 {{#mod_privacy}}
 {{{mod_privacy}}}
-{{/mod_privacy}}
 
+{{/mod_privacy}}
 {{#mod_blocking}}
 {{{mod_blocking}}}
-{{/mod_blocking}}
 
+{{/mod_blocking}}
 {{#mod_private}}
 {{{mod_private}}}
-{{/mod_private}}
 
+{{/mod_private}}
 [modules.mod_register]
   welcome_message = {body = "", subject = ""}
   ip_access = [
@@ -256,14 +258,14 @@
 
 {{#mod_roster}}
 {{{mod_roster}}}
-{{/mod_roster}}
 
+{{/mod_roster}}
 [modules.mod_sic]
 
 {{#mod_vcard}}
 {{{mod_vcard}}}
-{{/mod_vcard}}
 
+{{/mod_vcard}}
 [modules.mod_bosh]
 
 [modules.mod_carboncopy]
@@ -374,7 +376,6 @@
   {{/s2s_certfile}}
   default_policy = {{{s2s_default_policy}}}
   outgoing.port = {{{outgoing_s2s_port}}}
-
   {{#s2s_addr}}
   {{{s2s_addr}}}
   {{/s2s_addr}}
@@ -382,6 +383,7 @@
 {{#host_config}}
 {{{host_config}}}
 {{/host_config}}
+{{^host_config}}
 #[[host_config]]
 #  host = "anonymous.localhost"
 #
@@ -389,3 +391,4 @@
 #    methods = ["anonymous"]
 #    anonymous.allow_multiple_connections = true
 #    anonymous.protocol = "both"
+{{/host_config}}

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -6,8 +6,12 @@
   all_metrics_are_global = {{{all_metrics_are_global}}}
   sm_backend = {{{sm_backend}}}
   max_fsm_queue = 1000
+  {{#http_server_name}}
   {{{http_server_name}}}
+  {{/http_server_name}}
+  {{#rdbms_server_type}}
   {{{rdbms_server_type}}}
+  {{/rdbms_server_type}}
 
 [[listen.http]]
   port = {{{http_port}}}
@@ -31,7 +35,9 @@
   port = {{{https_port}}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
+  {{#https_config}}
   {{{https_config}}}
+  {{/https_config}}
 
   [[listen.http.handlers.mod_bosh]]
     host = "_"
@@ -42,7 +48,9 @@
     path = "/ws-xmpp"
 
 [[listen.http]]
+  {{#http_api_endpoint}}
   {{{http_api_endpoint}}}
+  {{/http_api_endpoint}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
@@ -51,11 +59,15 @@
     path = "/api"
 
 [[listen.http]]
+  {{#http_api_client_endpoint}}
   {{{http_api_client_endpoint}}}
+  {{/http_api_client_endpoint}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
   protocol.compress = true
+  {{#https_config}}
   {{{https_config}}}
+  {{/https_config}}
 
   [[listen.http.handlers.lasse_handler]]
     host = "_"
@@ -102,7 +114,9 @@
     content_path = "swagger"
 
 [[listen.http]]
+  {{#http_api_old_endpoint}}
   {{{http_api_old_endpoint}}}
+  {{/http_api_old_endpoint}}
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
@@ -113,34 +127,60 @@
 
 [[listen.c2s]]
   port = {{{c2s_port}}}
+  {{#tls_config}}
   {{{tls_config}}}
+  {{/tls_config}}
+  {{#tls_module}}
   {{{tls_module}}}
+  {{/tls_module}}
+  {{#proxy_protocol}}
   {{{proxy_protocol}}}
+  {{/proxy_protocol}}
+  {{#zlib}}
   {{{zlib}}}
+  {{/zlib}}
   access = "c2s"
   shaper = "c2s_shaper"
   max_stanza_size = 65536
+  {{#c2s_dhfile}}
   {{{c2s_dhfile}}}
+  {{/c2s_dhfile}}
 
+{{#secondary_c2s}}
 {{{secondary_c2s}}}
+{{/secondary_c2s}}
 
 [[listen.s2s]]
   port = {{{incoming_s2s_port}}}
   shaper = "s2s_shaper"
   max_stanza_size = 131072
+  {{#s2s_dhfile}}
   {{{s2s_dhfile}}}
+  {{/s2s_dhfile}}
 
+{{#listen_service}}
 {{{listen_service}}}
+{{/listen_service}}
 
 [auth]
+  {{#auth_ldap}}
   {{{auth_ldap}}}
+  {{/auth_ldap}}
   methods = [{{{auth_method}}}]
+  {{#password_format}}
   {{{password_format}}}
+  {{/password_format}}
+  {{#scram_iterations}}
   {{{scram_iterations}}}
+  {{/scram_iterations}}
   sasl_external = [{{{cyrsasl_external}}}]
+  {{#sasl_mechanisms}}
   {{{sasl_mechanisms}}}
+  {{/sasl_mechanisms}}
 
+{{#outgoing_pools}}
 {{{outgoing_pools}}}
+{{/outgoing_pools}}
 #[outgoing_pools.redis.global_distrib]
 #  scope = "single_host"
 #  host = "localhost"
@@ -171,7 +211,9 @@
 
 [modules.mod_adhoc]
 
+{{#mod_amp}}
 {{{mod_amp}}}
+{{/mod_amp}}
 
 [modules.mod_disco]
   users_can_see_hidden_services = false
@@ -182,17 +224,27 @@
 
 [modules.mod_muc_light_commands]
 
+{{#mod_last}}
 {{{mod_last}}}
+{{/mod_last}}
 
 [modules.mod_stream_management]
 
+{{#mod_offline}}
 {{{mod_offline}}}
+{{/mod_offline}}
 
+{{#mod_privacy}}
 {{{mod_privacy}}}
+{{/mod_privacy}}
 
+{{#mod_blocking}}
 {{{mod_blocking}}}
+{{/mod_blocking}}
 
+{{#mod_private}}
 {{{mod_private}}}
+{{/mod_private}}
 
 [modules.mod_register]
   welcome_message = {body = "", subject = ""}
@@ -202,11 +254,15 @@
   ]
   access = "register"
 
+{{#mod_roster}}
 {{{mod_roster}}}
+{{/mod_roster}}
 
 [modules.mod_sic]
 
+{{#mod_vcard}}
 {{{mod_vcard}}}
+{{/mod_vcard}}
 
 [modules.mod_bosh]
 
@@ -310,14 +366,22 @@
   ]
 
 [s2s]
+  {{#s2s_use_starttls}}
   {{{s2s_use_starttls}}}
+  {{/s2s_use_starttls}}
+  {{#s2s_certfile}}
   {{{s2s_certfile}}}
+  {{/s2s_certfile}}
   default_policy = {{{s2s_default_policy}}}
   outgoing.port = {{{outgoing_s2s_port}}}
 
+  {{#s2s_addr}}
   {{{s2s_addr}}}
+  {{/s2s_addr}}
 
+{{#host_config}}
 {{{host_config}}}
+{{/host_config}}
 #[[host_config]]
 #  host = "anonymous.localhost"
 #

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -7,10 +7,10 @@
   sm_backend = {{{sm_backend}}}
   max_fsm_queue = 1000
   {{#http_server_name}}
-  {{{http_server_name}}}
+  http_server_name = {{{http_server_name}}}
   {{/http_server_name}}
   {{#rdbms_server_type}}
-  {{{rdbms_server_type}}}
+  rdbms_server_type = {{{rdbms_server_type}}}
   {{/rdbms_server_type}}
 
 [[listen.http]]
@@ -127,41 +127,35 @@
 
 [[listen.c2s]]
   port = {{{c2s_port}}}
-  {{#tls_config}}
-  {{{tls_config}}}
-  {{/tls_config}}
-  {{#tls_module}}
-  {{{tls_module}}}
-  {{/tls_module}}
-  {{#proxy_protocol}}
-  {{{proxy_protocol}}}
-  {{/proxy_protocol}}
   {{#zlib}}
-  {{{zlib}}}
+  zlib = {{{zlib}}}
   {{/zlib}}
   access = "c2s"
   shaper = "c2s_shaper"
   max_stanza_size = 65536
+  {{#tls_config}}
+  {{{tls_config}}}
+  {{/tls_config}}
   {{#c2s_dhfile}}
-  {{{c2s_dhfile}}}
+  tls.dhfile = {{{c2s_dhfile}}}
   {{/c2s_dhfile}}
-
 {{#secondary_c2s}}
-{{{secondary_c2s}}}
 
+{{{secondary_c2s}}}
 {{/secondary_c2s}}
+
 [[listen.s2s]]
   port = {{{incoming_s2s_port}}}
   shaper = "s2s_shaper"
   max_stanza_size = 131072
   {{#s2s_dhfile}}
-  {{{s2s_dhfile}}}
+  tls.dhfile = {{{s2s_dhfile}}}
   {{/s2s_dhfile}}
-
 {{#listen_service}}
-{{{listen_service}}}
 
+{{{listen_service}}}
 {{/listen_service}}
+
 [auth]
   {{#auth_ldap}}
   {{{auth_ldap}}}
@@ -171,11 +165,11 @@
   {{{password_format}}}
   {{/password_format}}
   {{#scram_iterations}}
-  {{{scram_iterations}}}
+  scram_iterations = {{{scram_iterations}}}
   {{/scram_iterations}}
   sasl_external = [{{{cyrsasl_external}}}]
   {{#sasl_mechanisms}}
-  {{{sasl_mechanisms}}}
+  sasl_mechanisms = [{{{sasl_mechanisms}}}]
   {{/sasl_mechanisms}}
 
 {{#outgoing_pools}}
@@ -212,11 +206,11 @@
   periodic_report = 10_800_000
 
 [modules.mod_adhoc]
-
 {{#mod_amp}}
-{{{mod_amp}}}
 
+{{{mod_amp}}}
 {{/mod_amp}}
+
 [modules.mod_disco]
   users_can_see_hidden_services = false
 
@@ -225,29 +219,29 @@
 [modules.mod_muc_commands]
 
 [modules.mod_muc_light_commands]
-
 {{#mod_last}}
+
 {{{mod_last}}}
-
 {{/mod_last}}
+
 [modules.mod_stream_management]
-
 {{#mod_offline}}
-{{{mod_offline}}}
 
+{{{mod_offline}}}
 {{/mod_offline}}
 {{#mod_privacy}}
-{{{mod_privacy}}}
 
+{{{mod_privacy}}}
 {{/mod_privacy}}
 {{#mod_blocking}}
-{{{mod_blocking}}}
 
+{{{mod_blocking}}}
 {{/mod_blocking}}
 {{#mod_private}}
-{{{mod_private}}}
 
+{{{mod_private}}}
 {{/mod_private}}
+
 [modules.mod_register]
   welcome_message = {body = "", subject = ""}
   ip_access = [
@@ -255,17 +249,17 @@
     {address = "0.0.0.0/0", policy = "deny"}
   ]
   access = "register"
-
 {{#mod_roster}}
+
 {{{mod_roster}}}
-
 {{/mod_roster}}
+
 [modules.mod_sic]
-
 {{#mod_vcard}}
-{{{mod_vcard}}}
 
+{{{mod_vcard}}}
 {{/mod_vcard}}
+
 [modules.mod_bosh]
 
 [modules.mod_carboncopy]
@@ -369,14 +363,15 @@
 
 [s2s]
   {{#s2s_use_starttls}}
-  {{{s2s_use_starttls}}}
+  use_starttls = {{{s2s_use_starttls}}}
   {{/s2s_use_starttls}}
   {{#s2s_certfile}}
-  {{{s2s_certfile}}}
+  certfile = {{{s2s_certfile}}}
   {{/s2s_certfile}}
   default_policy = {{{s2s_default_policy}}}
   outgoing.port = {{{outgoing_s2s_port}}}
   {{#s2s_addr}}
+
   {{{s2s_addr}}}
   {{/s2s_addr}}
 

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -4,10 +4,7 @@
 {kicking_service_port, 8666}.
 {hidden_service_port, 8189}.
 
-{hosts, "\"localhost\",
-         \"anonymous.localhost\",
-         \"localhost.bis\"
-        "}.
+{hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 {host_config,
   "[[host_config]]
   host = \"anonymous.localhost\"
@@ -18,7 +15,7 @@
     anonymous.protocol = \"both\""}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
-{scram_iterations, "scram_iterations = 64"}.
+{scram_iterations, 64}.
 {s2s_addr, "[[s2s.address]]
     host = \"fed1\"
     ip_address = \"127.0.0.1\""}.
@@ -60,6 +57,6 @@
 
 {mod_amp, "[modules.mod_amp]"}.
 {mod_private, "[modules.mod_private]"}.
-{zlib, "zlib = 10_000"}.
-{c2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
-{s2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{zlib, "10_000"}.
+{c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -10,10 +10,7 @@
 {http_api_client_endpoint_port, 8091}.
 {service_port, 8899}.
 
-{hosts, "\"localhost\",
-         \"anonymous.localhost\",
-         \"localhost.bis\"
-         "}.
+{hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"
     ip_address = \"127.0.0.1\""}.
@@ -49,7 +46,7 @@
   password = \"secret\""}.
 {all_metrics_are_global, "true"}.
 
-{http_server_name, "http_server_name = \"Classified\""}.
+{http_server_name, "\"Classified\""}.
 
-{c2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
-{s2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -10,9 +10,7 @@
 {http_api_endpoint_port, 8092}.
 {http_api_client_endpoint_port, 8093}.
 
-{hosts, "\"localhost\",
-         \"anonymous.localhost\",
-          \"localhost.bis\""}.
+{hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"
@@ -43,5 +41,5 @@
   port = {{ http_api_endpoint_port }}"}.
 {http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 
-{c2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
-{s2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -41,6 +41,6 @@
   port = {{ http_api_endpoint_port }}"}.
 {http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 
-{c2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
-{s2s_dhfile, "tls.dhfile = \"priv/ssl/fake_dh_server.pem\""}.
+{c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+{s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -11,11 +11,7 @@
 
 % TOML config
 {hosts, "\"localhost\""}.
-{host_config, ""}.
-{auth_ldap, ""}.
-{s2s_addr, ""}.
 {s2s_default_policy, "\"deny\""}.
-{mod_amp, ""}.
 {listen_service, "[[listen.service]]
   port = 8888
   access = \"all\"
@@ -36,12 +32,9 @@
 {cyrsasl_external, "\"standard\""}.
 {tls_config, "tls.certfile = \"priv/ssl/fake_server.pem\"
   tls.mode = \"starttls\""}.
-{tls_module, ""}.
 {https_config, "tls.certfile = \"priv/ssl/fake_cert.pem\"
   tls.keyfile = \"priv/ssl/fake_key.pem\"
   tls.password =  \"\""}.
-{zlib, ""}.
-{outgoing_pools, ""}.
 {http_api_old_endpoint, "ip_address = \"127.0.0.1\"
   port = 5288"}.
 {http_api_endpoint, "ip_address = \"127.0.0.1\"
@@ -49,7 +42,6 @@
 {http_api_client_endpoint, "port = 8089"}.
 {s2s_use_starttls, "use_starttls = \"optional\""}.
 {s2s_certfile, "certfile = \"priv/ssl/fake_server.pem\""}.
-{sasl_mechanisms, ""}.
 {all_metrics_are_global, "false"}.
 
 %% Defined in Makefile by appending configure.vars.config

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -40,8 +40,8 @@
 {http_api_endpoint, "ip_address = \"127.0.0.1\"
   port = 8088"}.
 {http_api_client_endpoint, "port = 8089"}.
-{s2s_use_starttls, "use_starttls = \"optional\""}.
-{s2s_certfile, "certfile = \"priv/ssl/fake_server.pem\""}.
+{s2s_use_starttls, "\"optional\""}.
+{s2s_certfile, "\"priv/ssl/fake_server.pem\""}.
 {all_metrics_are_global, "false"}.
 
 %% Defined in Makefile by appending configure.vars.config

--- a/tools/test_runner/apply_templates.erl
+++ b/tools/test_runner/apply_templates.erl
@@ -23,7 +23,13 @@ overlay_vars(Node) ->
     Vars = consult_map("rel/vars-toml.config"),
     NodeVars = consult_map("rel/" ++ atom_to_list(Node) ++ ".vars-toml.config"),
     %% NodeVars overrides Vars
-    maps:merge(Vars, NodeVars).
+    ensure_binary_strings(maps:merge(Vars, NodeVars)).
+
+%% bbmustache tries to iterate over lists, so we need to make them binaries
+ensure_binary_strings(Vars) ->
+    maps:map(fun(_K, V) when is_list(V) -> list_to_binary(V);
+                (_K, V) -> V
+             end, Vars).
 
 consult_map(File) ->
     {ok, Vars} = file:consult(File),


### PR DESCRIPTION
The main change is to introduce [Mustache sections](http://mustache.github.io/mustache.5.html) to remove whitespaces occuring in the templated config files, including the default `prod` config file.

**Example.** The block below has the following semantics: if `var` is defined and not `false`, render an empty line followed by its contents.

```
  {{#var}}     

  {{{var}}}
  {{/var}}
```

There is one caveat for `bbmustache` - strings are lists and would be treated as Mustache lists, so they need to be binarized in tests (rebar3 does this already when processing the overlays, but tests call bbmustache separately). Alternatively, all template variables could be converted to binaries, but I think it could make them a bit less readable.