### PR TITLE
Ubuntu20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ orbs:
       build:
         parallelism: 1
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202010-01
         parameters:
           otp_package:
             type: string
@@ -96,7 +96,7 @@ orbs:
       dialyzer:
         parallelism: 1
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202010-01
         working_directory: ~/app
         parameters:
           otp_package:
@@ -115,7 +115,7 @@ orbs:
       small_tests:
         parallelism: 1
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202010-01
         working_directory: ~/app
         parameters:
           otp_package:
@@ -161,7 +161,7 @@ orbs:
       package:
         parallelism: 1
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202010-01
         working_directory: ~/app
         parameters:
           platform:
@@ -184,7 +184,7 @@ orbs:
       big_tests:
         parallelism: 1
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202010-01
         working_directory: ~/app
         parameters:
           otp_package:
@@ -266,7 +266,7 @@ orbs:
       docker_image:
         parallelism: 1
         machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202010-01
         working_directory: ~/app
         parameters:
           otp_package:
@@ -301,24 +301,24 @@ workflows:
       - mim/package:
           name: centos_7
           platform: centos_7
-          otp_package: 22.1.8-2
+          otp_package: 22.3.4.9-1
           context: mongooseim-org
           filters: *all_tags
       - mim/package:
           name: debian_stretch
           platform: debian_stretch
-          otp_package: 22.1.8-1
+          otp_package: 22.3.4.9-1
           context: mongooseim-org
           filters: *all_tags
       # ============= BASE BUILDS =============
       - mim/build:
           name: otp_21_3
-          otp_package: 21.3.8.6-1
+          otp_package: 21.3.8.17-1
           context: mongooseim-org
           filters: *all_tags
       - mim/build:
           name: otp_22
-          otp_package: 22.1.8-1
+          otp_package: 22.3.4.9-1
           build_prod: true
           context: mongooseim-org
           filters: *all_tags
@@ -331,14 +331,14 @@ workflows:
       # ============= SMALL TESTS =============
       - mim/small_tests:
           name: small_tests_21_3
-          otp_package: 21.3.8.6-1
+          otp_package: 21.3.8.17-1
           context: mongooseim-org
           requires:
             - otp_21_3
           filters: *all_tags
       - mim/small_tests:
           name: small_tests_22
-          otp_package: 22.1.8-1
+          otp_package: 22.3.4.9-1
           context: mongooseim-org
           requires:
             - otp_22
@@ -424,7 +424,7 @@ workflows:
       # ============= 1 VERSION OLDER TESTS =============
       - mim/big_tests:
           name: ldap_mnesia_22
-          otp_package: 22.1.8-1
+          otp_package: 22.3.4.9-1
           preset: ldap_mnesia
           db: mnesia
           context: mongooseim-org
@@ -434,7 +434,7 @@ workflows:
       # ============= 2 VERSIONS OLDER TESTS =============
       - mim/big_tests:
           name: ldap_mnesia_21
-          otp_package: 21.3.8.6-1
+          otp_package: 21.3.8.17-1
           preset: ldap_mnesia
           db: mnesia
           context: mongooseim-org

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,7 @@ orbs:
               sudo apt-get update && \
               sudo apt-get install unixodbc-dev -y && \
               sudo apt-get install unixodbc -y && \
-              sudo apt-get install tdsodbc -y && \
-              sudo apt-get install python-pip -y && \
-              sudo pip install --upgrade pip
+              sudo apt-get install tdsodbc -y
     jobs:
       build:
         parallelism: 1
@@ -147,7 +145,7 @@ orbs:
               when: on_success
               command: |
                 echo "Success!"
-                sudo pip install codecov && codecov
+                pip3 install codecov && codecov
                 ./rebar3 codecov analyze
                 codecov --disable=gcov --env PRESET
           - run:
@@ -245,7 +243,7 @@ orbs:
               when: on_success
               command: |
                 echo "Success!"
-                sudo pip install codecov && codecov
+                pip3 install codecov && codecov
                 ./rebar3 codecov analyze
                 codecov --disable=gcov --env PRESET
           - run:

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -33,7 +33,7 @@ IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
-git checkout 318e1ee6582e7473303a2cd0b4baca0c9c09a1be
+git checkout d4c0956b5038778d301d1de56cb2833c16c6f34a
 
 cp ../${MONGOOSE_TGZ} member
 

--- a/tools/circleci-upload-to-s3.sh
+++ b/tools/circleci-upload-to-s3.sh
@@ -20,18 +20,9 @@ FILE_COUNT=$(find "${CT_REPORTS}" -type f | wc -l)
 echo "Uploading $FILE_COUNT files"
 ls $CT_REPORTS
 
-S3PP_COMMIT=6fd430a54e976d2d580042efdf82ac2fb66d5e57
-wget -O tools/s3-parallel-put https://raw.githubusercontent.com/arcusfelis/s3-parallel-put/$S3PP_COMMIT/s3-parallel-put
-chmod +x tools/s3-parallel-put
-
-sudo pip install boto python-magic
-sudo pip install awscli --upgrade --user
 aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 aws configure set default.region $AWS_DEFAULT_REGION
+aws configure set default.s3.max_concurrent_requests 64
 
-sudo tools/s3-parallel-put --quiet --processes=64 --put=stupid \
-                    --host=s3.$AWS_DEFAULT_REGION.amazonaws.com  --bucket_region=$AWS_DEFAULT_REGION \
-                    --bucket=circleci-mim-results --prefix=${CT_REPORTS} ${CT_REPORTS} --grant=public-read
-
-
+time aws s3 cp ${CT_REPORTS} s3://circleci-mim-results/${CT_REPORTS} --acl public-read --recursive --quiet


### PR DESCRIPTION
Ubuntu machines in CircleCI are updated to use 20.04, python2 and pip2 are not used anymore, and the docker image is built with `phusion/focal-1.0.0-alpha1-amd64` (needs https://github.com/esl/mongooseim-docker/pull/40 be merged first).