### PR TITLE
TOML: declarative specs for 'shaper', 'acl', 'access', 's2s'

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -1097,8 +1097,10 @@ format_spec(#section{format = Format}) -> Format;
 format_spec(#list{format = Format}) -> Format;
 format_spec(#option{format = Format}) -> Format.
 
-format(Path, L, {foreach, Format}) when is_atom(Format) ->
-    lists:flatmap(fun({K, V}) -> format(Path, V, {Format, K}) end, L);
+format(Path, KVs, {foreach, Format}) when is_atom(Format) ->
+    Keys = lists:map(fun({K, _}) -> K end, KVs),
+    mongoose_config_validator_toml:validate_list(Keys, unique),
+    lists:flatmap(fun({K, V}) -> format(Path, V, {Format, K}) end, KVs);
 format([Key|_] = Path, V, host_local_config) ->
     format(Path, V, {host_local_config, b2a(Key)});
 format([Key|_] = Path, V, local_config) ->

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -1,8 +1,9 @@
 -module(mongoose_config_validator_toml).
 
 -export([validate/2,
-         validate/3]).
--compile(export_all).
+         validate/3,
+         validate_section/2,
+         validate_list/2]).
 
 -include("mongoose.hrl").
 -include("ejabberd_config.hrl").
@@ -1200,9 +1201,6 @@ validate_non_empty_binary(Value) when is_binary(Value), Value =/= <<>> -> ok.
 
 validate_binary(Value) when is_binary(Value) -> ok.
 
-validate_hosts(Hosts = [_|_]) ->
-    validate_unique_items(Hosts).
-
 validate_unique_items(Items) ->
     L = sets:size(sets:from_list(Items)),
     L = length(Items).
@@ -1254,9 +1252,6 @@ validate_non_empty_atom(Value) when is_atom(Value), Value =/= '' -> ok.
 validate_non_empty_string(Value) when is_list(Value), Value =/= "" -> ok.
 
 validate_non_empty_list(Value) when is_list(Value), Value =/= [] -> ok.
-
-validate_root_or_host_config([]) -> ok;
-validate_root_or_host_config([{host, _}, <<"host_config">>]) -> ok.
 
 validate_jid(Jid) ->
     case jid:from_binary(Jid) of

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -16,12 +16,6 @@
 validate(Path, [F]) when is_function(F, 1) ->
     validate(Path, F(?HOST));
 
-%% shaper
-validate([_, <<"shaper">>|Path],
-         [#config{value = {maxrate, Value}}]) ->
-    validate_root_or_host_config(Path),
-    validate_positive_integer(Value);
-
 %% s2s
 validate([<<"timeout">>, <<"dns">>, <<"s2s">>],
          [{timeout, Value}]) ->

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -16,62 +16,6 @@
 validate(Path, [F]) when is_function(F, 1) ->
     validate(Path, F(?HOST));
 
-%% s2s
-validate([<<"timeout">>, <<"dns">>, <<"s2s">>],
-         [{timeout, Value}]) ->
-    validate_positive_integer(Value);
-validate([<<"retries">>, <<"dns">>, <<"s2s">>],
-         [{retries, Value}]) ->
-    validate_positive_integer(Value);
-validate([<<"port">>, <<"outgoing">>, <<"s2s">>],
-         [#local_config{value = Value}]) ->
-    validate_port(Value);
-validate([<<"ip_versions">>, <<"outgoing">>, <<"s2s">>],
-         [#local_config{value = Value}]) ->
-    validate_non_empty_list(Value);
-validate([<<"connection_timeout">>, <<"outgoing">>, <<"s2s">>],
-         [#local_config{value = Value}]) ->
-    validate_positive_integer_or_infinity(Value);
-validate([<<"use_starttls">>, <<"s2s">>],
-         [#local_config{value = Value}]) ->
-    validate_enum(Value, [false, optional, required, required_trusted]);
-validate([<<"certfile">>, <<"s2s">>],
-         [#local_config{value = Value}]) ->
-    validate_non_empty_string(Value);
-validate([<<"default_policy">>, <<"s2s">>|Path],
-         [#local_config{value = Value}]) ->
-    validate_root_or_host_config(Path),
-    validate_enum(Value, [allow, deny]);
-validate([<<"host">>, item, <<"host_policy">>, <<"s2s">>|Path],
-         [{host, Value}]) ->
-    validate_root_or_host_config(Path),
-    validate_non_empty_binary(Value);
-validate([<<"policy">>, item, <<"host_policy">>, <<"s2s">>|Path],
-         [{policy, Value}]) ->
-    validate_root_or_host_config(Path),
-    validate_enum(Value, [allow, deny]);
-validate([<<"host">>, item, <<"address">>, <<"s2s">>],
-         [{host, Value}]) ->
-    validate_non_empty_binary(Value);
-validate([<<"ip_address">>, item, <<"address">>, <<"s2s">>],
-         [{ip_address, Value}]) ->
-    validate_ip_address(Value);
-validate([<<"port">>, item, <<"address">>, <<"s2s">>],
-         [{port, Value}]) ->
-    validate_port(Value);
-validate([item, <<"domain_certfile">>, <<"s2s">>],
-         [#local_config{key = {domain_certfile, Domain}, value = Certfile}]) ->
-    validate_non_empty_string(Domain),
-    validate_non_empty_string(Certfile);
-validate([<<"shared">>, <<"s2s">>|Path],
-         [#local_config{value = Value}]) ->
-    validate_root_or_host_config(Path),
-    validate_non_empty_binary(Value);
-validate([<<"max_retry_delay">>, <<"s2s">>|Path],
-         [#local_config{value = Value}]) ->
-    validate_root_or_host_config(Path),
-    validate_positive_integer(Value);
-
 %% Services
 validate([item, <<"submods">>, <<"service_admin_extra">>, <<"services">>],
          [Value]) ->
@@ -1240,8 +1184,8 @@ validate(V, _, {enum, Values}) -> validate_enum(V, Values);
 validate(_V, _, any) -> ok.
 
 validate_list([_|_], non_empty) -> ok;
-validate_list(L = [_|_], unique_non_empty) ->
-    validate_unique_items(L);
+validate_list(L = [_|_], unique_non_empty) -> validate_unique_items(L);
+validate_list(L, unique) -> validate_unique_items(L);
 validate_list(L, any) when is_list(L) -> ok.
 
 validate_section([_|_], non_empty) -> ok;

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1288,7 +1288,9 @@ s2s_host_policy(_Config) ->
     err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [maps:without([<<"host">>], Policy)]}}),
     err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [maps:without([<<"policy">>], Policy)]}}),
     err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [Policy#{<<"host">> => <<>>}]}}),
-    err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [Policy#{<<"policy">> => <<"huh">>}]}}).
+    err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [Policy#{<<"policy">> => <<"huh">>}]}}),
+    err_host_config(#{<<"s2s">> => #{<<"host_policy">> => [Policy,
+                                                           Policy#{<<"policy">> => <<"deny">>}]}}).
 
 s2s_address(_Config) ->
     Addr = #{<<"host">> => <<"host1">>,
@@ -1302,7 +1304,8 @@ s2s_address(_Config) ->
     ?err(parse(#{<<"s2s">> => #{<<"address">> => [maps:without([<<"ip_address">>], Addr)]}})),
     ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"host">> => <<>>}]}})),
     ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"ip_address">> => <<"host2">>}]}})),
-    ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"port">> => <<"seaport">>}]}})).
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr#{<<"port">> => <<"seaport">>}]}})),
+    ?err(parse(#{<<"s2s">> => #{<<"address">> => [Addr, maps:remove(<<"port">>, Addr)]}})).
 
 s2s_ciphers(_Config) ->
     ?eq([#local_config{key = s2s_ciphers, value = "TLSv1.2:TLSv1.3"}],
@@ -1317,7 +1320,8 @@ s2s_domain_certfile(_Config) ->
     [?err(parse(#{<<"s2s">> => #{<<"domain_certfile">> => [maps:without([K], DomCert)]}}))
      || K <- maps:keys(DomCert)],
     [?err(parse(#{<<"s2s">> => #{<<"domain_certfile">> => [DomCert#{K := <<>>}]}}))
-     || K <- maps:keys(DomCert)].
+     || K <- maps:keys(DomCert)],
+    ?err(parse(#{<<"s2s">> => #{<<"domain_certfile">> => [DomCert, DomCert]}})).
 
 s2s_shared(_Config) ->
     eq_host_config([#local_config{key = {s2s_shared, ?HOST}, value = <<"secret">>}],

--- a/test/config_parser_SUITE_data/s2s_only.options
+++ b/test/config_parser_SUITE_data/s2s_only.options
@@ -9,9 +9,14 @@
 {local_config,{domain_certfile,"example.com"},"/path/to/example_com.pem"}.
 {local_config,{domain_certfile,"example.org"},"/path/to/example_org.pem"}.
 {local_config,{s2s_addr,<<"fed1">>},"127.0.0.1"}.
+{local_config,{s2s_addr,<<"fed2">>},{"127.0.0.1", 8765}}.
 {local_config,{s2s_default_policy,<<"dummy_host">>},allow}.
 {local_config,{s2s_default_policy,<<"localhost">>},allow}.
 {local_config,{s2s_max_retry_delay,<<"dummy_host">>},30}.
 {local_config,{s2s_max_retry_delay,<<"localhost">>},30}.
 {local_config,{s2s_shared,<<"dummy_host">>},<<"shared secret">>}.
 {local_config,{s2s_shared,<<"localhost">>},<<"shared secret">>}.
+{local_config,{{s2s_host,<<"fed1">>},<<"dummy_host">>},allow}.
+{local_config,{{s2s_host,<<"fed1">>},<<"localhost">>},allow}.
+{local_config,{{s2s_host,<<"reg1">>},<<"dummy_host">>},deny}.
+{local_config,{{s2s_host,<<"reg1">>},<<"localhost">>},deny}.

--- a/test/config_parser_SUITE_data/s2s_only.toml
+++ b/test/config_parser_SUITE_data/s2s_only.toml
@@ -3,6 +3,7 @@
     "localhost",
     "dummy_host"
   ]
+
 [s2s]
   use_starttls = "optional"
   certfile = "tools/ssl/mongooseim/server.pem"
@@ -16,9 +17,22 @@
   shared = "shared secret"
   max_retry_delay = 30
 
+  [[s2s.host_policy]]
+    host = "fed1"
+    policy = "allow"
+
+  [[s2s.host_policy]]
+    host = "reg1"
+    policy = "deny"
+
   [[s2s.address]]
     host = "fed1"
     ip_address = "127.0.0.1"
+
+  [[s2s.address]]
+    host = "fed2"
+    ip_address = "127.0.0.1"
+    port = 8765
 
   [[s2s.domain_certfile]]
     domain = "example.com"


### PR DESCRIPTION
Declarative specs for the 'shaper', 'acl', 'access' and 's2s' sections.

See the commit messages for more details.
