### PR TITLE
add vcard to the list of MUC room features

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -2956,7 +2956,8 @@ muc_namespaces() ->
      <<"muc_open">>,
      <<"muc_semianonymous">>,
      <<"muc_moderated">>,
-     <<"muc_unsecured">>].
+     <<"muc_unsecured">>,
+     <<"vcard-temp">>].
 
 disco_items(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
@@ -3109,7 +3110,8 @@ disco_info_locked_room(Config) ->
 
         %% THEN receives MUC features
         Namespaces = [?NS_MUC, <<"muc_public">>, <<"muc_temporary">>, <<"muc_open">>,
-                     <<"muc_semianonymous">>, <<"muc_moderated">>, <<"muc_unsecured">>],
+                     <<"muc_semianonymous">>, <<"muc_moderated">>, <<"muc_unsecured">>,
+                     <<"vcard-temp">>],
         has_features(Stanza, Namespaces)
     end).
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3975,7 +3975,8 @@ process_iq_disco_info(From, get, Lang, StateData) ->
               config_opt_to_feature((Config#config.moderated),
                          <<"muc_moderated">>, <<"muc_unmoderated">>),
               config_opt_to_feature((Config#config.password_protected),
-                         <<"muc_passwordprotected">>, <<"muc_unsecured">>)
+                         <<"muc_passwordprotected">>, <<"muc_unsecured">>),
+              #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_VCARD}]}
              ] ++ iq_disco_info_extras(Lang, StateData) ++ RegisteredFeaturesXML, StateData}.
 
 


### PR DESCRIPTION
This PR addresses the reason for one of the compliance tests failing. The list of supported features advertised by a specific MUC room didn't include `vcard-temp` whereas the MUC host did.  This discrepancy resulted in the test failing when checking for this feature by querying MUC room instead of MUC host. 

