### PR TITLE
Fix harmless ct hook error

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -7,6 +7,7 @@
 %%       See s2s_SUITE for example on using `hosts` to RPC into nodes (uses CT "require").
 %% the Erlang node name of tested ejabberd/MongooseIM
 {ejabberd_node, 'mongooseim@localhost'}.
+{ejabberd2_node, 'ejabberd2@localhost'}.
 {ejabberd_cookie, ejabberd}.
 {ejabberd_string_format, bin}.
 


### PR DESCRIPTION
It wasn't finding the node to rpc to, hence the rpc to load the ct logger was failing.

A quick fix for errors like
```erlang
issue="Failed to init ct_mongoose_log_hook", node=undefined, reason={error,
                                                                     {bad_absname,
                                                                      {badrpc,
                                                                       nodedown}}}
```
