### PR TITLE
TOML declarative modules (1/4)

### DIFF
--- a/doc/modules/mod_bosh.md
+++ b/doc/modules/mod_bosh.md
@@ -30,10 +30,10 @@ Please note that a long-polling request is not considered to be an inactivity.
  
 Enables/disables [acks](http://xmpp.org/extensions/xep-0124.html#ack-request) sent by server.
 
-#### `modules.mod_bosh.maxpause`
+#### `modules.mod_bosh.max_pause`
  * **Syntax:** positive integer
  * **Default:** `120`
- * **Example:** `maxpause = 30`
+ * **Example:** `max_pause = 30`
 
 Maximum allowed pause in seconds (e.g. to switch between pages and then resume connection) to request by client-side.
 
@@ -56,5 +56,5 @@ In the module section:
   inactivity = 20
   max_wait = "infinity"
   server_acks = true
-  maxpause = 120 
+  max_pause = 120
 ```

--- a/doc/modules/mod_caps.md
+++ b/doc/modules/mod_caps.md
@@ -8,16 +8,16 @@ It is not this module's responsibility to intercept and answer disco requests ro
 This module expects two optional arguments that apply to [cache tab](https://github.com/processone/cache_tab):
 
 #### `modules.mod_caps.cache_size`
-* **Syntax:** non-negative integer
+* **Syntax:** positive integer
 * **Default:** `1000`
 * **Example:** `cache_size = 2000`
 
 The size of a cache_tab (the amount of entries) holding the information about capabilities of each user. 
 
 #### `modules.mod_caps.cache_life_time`
-* **Syntax:** non-negative integer or the string `"infinity"`
-* **Default:** `86`
-* **Example:** `cache_life_time = 30`
+* **Syntax:** positive integer
+* **Default:** `86_400` (24 hours)
+* **Example:** `cache_life_time = 10_000`
 
 Time (in seconds) after which entries will be removed.
 
@@ -26,5 +26,5 @@ Time (in seconds) after which entries will be removed.
 ```toml
 [modules.mod_caps]
   cache_size = 2000
-  cache_life_time = 86
+  cache_life_time = 10_000
 ```

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -92,16 +92,6 @@ parse_root(Path, Content) ->
     ensure_keys([<<"general">>], Content),
     parse_section(Path, Content).
 
-%% path: *
--spec process_section(path(), toml_section() | [toml_section()]) -> config_list().
-process_section([<<"modules">>|_] = Path, Content) ->
-    Mods = parse_section(Path, Content),
-    ?HOST_F([#local_config{key = {modules, Host}, value = Mods}]);
-process_section([<<"host_config">>] = Path, Content) ->
-    parse_list(Path, Content);
-process_section(Path, Content) ->
-    parse_section(Path, Content).
-
 %% path: (host_config[].)modules.mod_event_pusher.backend.push.wpool.*
 -spec pool_option(path(), toml_value()) -> [option()].
 pool_option([<<"workers">>|_], V) -> [{workers, V}];
@@ -122,8 +112,6 @@ post_process_module(Mod, Opts) ->
 
 %% path: (host_config[].)modules.*.*
 -spec module_opt(path(), toml_value()) -> [option()].
-module_opt([<<"report_commands_node">>, <<"mod_adhoc">>|_], V) ->
-    [{report_commands_node, V}];
 module_opt([<<"validity_period">>, <<"mod_auth_token">>|_] = Path, V) ->
     parse_list(Path, V);
 module_opt([<<"inactivity">>, <<"mod_bosh">>|_], V) ->
@@ -1153,16 +1141,17 @@ node_to_string({host, _}) -> [];
 node_to_string({tls, TLSAtom}) -> [atom_to_list(TLSAtom)];
 node_to_string(Node) -> [binary_to_list(Node)].
 
+-define(HAS_NO_SPEC(Mod), Mod =/= <<"mod_adhoc">>). % TODO temporary, remove with 'handler/1'
+
 -spec handler(path()) ->
           fun((path(), toml_value()) -> option()) | mongoose_config_spec:config_node().
 handler([]) -> fun parse_root/2;
-handler([Section]) when Section =:= <<"modules">>;
-                        Section =:= <<"host_config">> -> fun process_section/2;
+handler([<<"host_config">>]) -> fun parse_list/2;
 
 %% modules
-handler([_, <<"modules">>]) -> fun process_module/2;
-handler([_, _, <<"modules">>]) -> fun module_opt/2;
-handler([_, <<"riak">>, _, <<"modules">>]) ->
+handler([Mod, <<"modules">>]) when ?HAS_NO_SPEC(Mod) -> fun process_module/2;
+handler([_, Mod, <<"modules">>]) when ?HAS_NO_SPEC(Mod) -> fun module_opt/2;
+handler([_, <<"riak">>, Mod, <<"modules">>]) when ?HAS_NO_SPEC(Mod) ->
     fun riak_opts/2;
 handler([_, <<"ip_access">>, <<"mod_register">>, <<"modules">>]) ->
     fun mod_register_ip_access_rule/2;
@@ -1271,7 +1260,7 @@ handler([_, <<"ldap_binary_search_fields">>, <<"mod_vcard">>, <<"modules">>]) ->
 handler([_, <<"host_config">>]) -> fun process_host_item/2;
 handler([<<"auth">>, _, <<"host_config">>] = P) -> handler_for_host(P);
 handler([<<"modules">>, _, <<"host_config">>] = P) -> handler_for_host(P);
-handler([_, _, <<"host_config">>]) -> fun process_section/2;
+handler([<<"general">>, _, <<"host_config">>]) -> fun parse_section/2;
 handler([_, <<"general">>, _, <<"host_config">>] = P) -> handler_for_host(P);
 handler([_, <<"s2s">>, _, <<"host_config">>] = P) -> handler_for_host(P);
 handler(Path) ->

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -112,14 +112,6 @@ post_process_module(Mod, Opts) ->
 
 %% path: (host_config[].)modules.*.*
 -spec module_opt(path(), toml_value()) -> [option()].
-module_opt([<<"inactivity">>, <<"mod_bosh">>|_], V) ->
-    [{inactivity, int_or_infinity(V)}];
-module_opt([<<"max_wait">>, <<"mod_bosh">>|_], V) ->
-    [{max_wait, int_or_infinity(V)}];
-module_opt([<<"server_acks">>, <<"mod_bosh">>|_], V) ->
-    [{server_acks, V}];
-module_opt([<<"maxpause">>, <<"mod_bosh">>|_], V) ->
-    [{maxpause, V}];
 module_opt([<<"cache_size">>, <<"mod_caps">>|_], V) ->
     [{cache_size, V}];
 module_opt([<<"cache_life_time">>, <<"mod_caps">>|_], V) ->
@@ -1136,7 +1128,8 @@ node_to_string(Node) -> [binary_to_list(Node)].
 
 -define(HAS_NO_SPEC(Mod),
         Mod =/= <<"mod_adhoc">>,
-        Mod =/= <<"mod_auth_token">>). % TODO temporary, remove with 'handler/1'
+        Mod =/= <<"mod_auth_token">>,
+        Mod =/= <<"mod_bosh">>). % TODO temporary, remove with 'handler/1'
 
 -spec handler(path()) ->
           fun((path(), toml_value()) -> option()) | mongoose_config_spec:config_node().

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -112,10 +112,6 @@ post_process_module(Mod, Opts) ->
 
 %% path: (host_config[].)modules.*.*
 -spec module_opt(path(), toml_value()) -> [option()].
-module_opt([<<"cache_size">>, <<"mod_caps">>|_], V) ->
-    [{cache_size, V}];
-module_opt([<<"cache_life_time">>, <<"mod_caps">>|_], V) ->
-    [{cache_life_time, V}];
 module_opt([<<"buffer_max">>, <<"mod_csi">>|_], V) ->
     [{buffer_max, int_or_infinity(V)}];
 module_opt([<<"extra_domains">>, <<"mod_disco">>|_] = Path, V) ->
@@ -1129,7 +1125,8 @@ node_to_string(Node) -> [binary_to_list(Node)].
 -define(HAS_NO_SPEC(Mod),
         Mod =/= <<"mod_adhoc">>,
         Mod =/= <<"mod_auth_token">>,
-        Mod =/= <<"mod_bosh">>). % TODO temporary, remove with 'handler/1'
+        Mod =/= <<"mod_bosh">>,
+        Mod =/= <<"mod_caps">>). % TODO temporary, remove with 'handler/1'
 
 -spec handler(path()) ->
           fun((path(), toml_value()) -> option()) | mongoose_config_spec:config_node().

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -1126,7 +1126,8 @@ node_to_string(Node) -> [binary_to_list(Node)].
         Mod =/= <<"mod_adhoc">>,
         Mod =/= <<"mod_auth_token">>,
         Mod =/= <<"mod_bosh">>,
-        Mod =/= <<"mod_caps">>). % TODO temporary, remove with 'handler/1'
+        Mod =/= <<"mod_caps">>,
+        Mod =/= <<"mod_carboncopy">>). % TODO temporary, remove with 'handler/1'
 
 -spec handler(path()) ->
           fun((path(), toml_value()) -> option()) | mongoose_config_spec:config_node().

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -112,8 +112,6 @@ post_process_module(Mod, Opts) ->
 
 %% path: (host_config[].)modules.*.*
 -spec module_opt(path(), toml_value()) -> [option()].
-module_opt([<<"buffer_max">>, <<"mod_csi">>|_], V) ->
-    [{buffer_max, int_or_infinity(V)}];
 module_opt([<<"extra_domains">>, <<"mod_disco">>|_] = Path, V) ->
     Domains = parse_list(Path, V),
     [{extra_domains, Domains}];
@@ -1127,7 +1125,8 @@ node_to_string(Node) -> [binary_to_list(Node)].
         Mod =/= <<"mod_auth_token">>,
         Mod =/= <<"mod_bosh">>,
         Mod =/= <<"mod_caps">>,
-        Mod =/= <<"mod_carboncopy">>). % TODO temporary, remove with 'handler/1'
+        Mod =/= <<"mod_carboncopy">>,
+        Mod =/= <<"mod_csi">>). % TODO temporary, remove with 'handler/1'
 
 -spec handler(path()) ->
           fun((path(), toml_value()) -> option()) | mongoose_config_spec:config_node().

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -112,8 +112,6 @@ post_process_module(Mod, Opts) ->
 
 %% path: (host_config[].)modules.*.*
 -spec module_opt(path(), toml_value()) -> [option()].
-module_opt([<<"validity_period">>, <<"mod_auth_token">>|_] = Path, V) ->
-    parse_list(Path, V);
 module_opt([<<"inactivity">>, <<"mod_bosh">>|_], V) ->
     [{inactivity, int_or_infinity(V)}];
 module_opt([<<"max_wait">>, <<"mod_bosh">>|_], V) ->
@@ -473,11 +471,6 @@ riak_opts([<<"search_index">>|_], V) ->
 -spec mod_register_ip_access_rule(path(), toml_section()) -> [option()].
 mod_register_ip_access_rule(_, #{<<"address">> := Addr, <<"policy">> := Policy}) ->
     [{b2a(Policy), b2l(Addr)}].
-
--spec mod_auth_token_validity_periods(path(), toml_section()) -> [option()].
-mod_auth_token_validity_periods(_,
-    #{<<"token">> := Token, <<"value">> := Value, <<"unit">> := Unit}) ->
-        [{{validity_period, b2a(Token)}, {Value, b2a(Unit)}}].
 
 -spec mod_disco_server_info(path(), toml_section()) -> [option()].
 mod_disco_server_info(Path, #{<<"module">> := <<"all">>, <<"name">> := Name, <<"urls">> := Urls}) ->
@@ -1141,7 +1134,9 @@ node_to_string({host, _}) -> [];
 node_to_string({tls, TLSAtom}) -> [atom_to_list(TLSAtom)];
 node_to_string(Node) -> [binary_to_list(Node)].
 
--define(HAS_NO_SPEC(Mod), Mod =/= <<"mod_adhoc">>). % TODO temporary, remove with 'handler/1'
+-define(HAS_NO_SPEC(Mod),
+        Mod =/= <<"mod_adhoc">>,
+        Mod =/= <<"mod_auth_token">>). % TODO temporary, remove with 'handler/1'
 
 -spec handler(path()) ->
           fun((path(), toml_value()) -> option()) | mongoose_config_spec:config_node().
@@ -1159,8 +1154,6 @@ handler([_, <<"registration_watchers">>, <<"mod_register">>, <<"modules">>]) ->
     fun(_, V) -> [V] end;
 handler([_, <<"welcome_message">>, <<"mod_register">>, <<"modules">>]) ->
     fun welcome_message/2;
-handler([_, <<"validity_period">>, <<"mod_auth_token">>, <<"modules">>]) ->
-    fun mod_auth_token_validity_periods/2;
 handler([_, <<"extra_domains">>, <<"mod_disco">>, <<"modules">>]) ->
     fun(_, V) -> [V] end;
 handler([_, <<"server_info">>, <<"mod_disco">>, <<"modules">>]) ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -730,8 +730,8 @@ all_modules() ->
      mod_auth_token,
      mod_bosh,
      mod_caps,
-     mod_carboncopy%%,
-     %% mod_csi,
+     mod_carboncopy,
+     mod_csi%%,
      %% mod_disco,
      %% mod_event_pusher
     ].

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -727,8 +727,8 @@ modules() ->
 
 all_modules() ->
     [mod_adhoc,
-     mod_auth_token%%,
-     %% mod_bosh,
+     mod_auth_token,
+     mod_bosh%%,
      %% mod_caps,
      %% mod_csi,
      %% mod_disco,

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -729,7 +729,8 @@ all_modules() ->
     [mod_adhoc,
      mod_auth_token,
      mod_bosh,
-     mod_caps%%,
+     mod_caps,
+     mod_carboncopy%%,
      %% mod_csi,
      %% mod_disco,
      %% mod_event_pusher

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -728,8 +728,8 @@ modules() ->
 all_modules() ->
     [mod_adhoc,
      mod_auth_token,
-     mod_bosh%%,
-     %% mod_caps,
+     mod_bosh,
+     mod_caps%%,
      %% mod_csi,
      %% mod_disco,
      %% mod_event_pusher

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -37,6 +37,7 @@ root() ->
                  <<"auth">> => auth(),
                  <<"outgoing_pools">> => outgoing_pools(),
                  <<"services">> => services(),
+                 <<"modules">> => modules(),
                  <<"shaper">> => shaper(),
                  <<"acl">> => acl(),
                  <<"access">> => access(),
@@ -715,6 +716,35 @@ services() ->
 all_services() ->
     [service_admin_extra,
      service_mongoose_system_metrics].
+
+%% path: (host_config[].)modules
+modules() ->
+    Modules = [{a2b(Module), gen_mod:config_spec(Module)} || Module <- all_modules()],
+    #section{
+       items = maps:from_list(Modules),
+       format = host_local_config
+      }.
+
+all_modules() ->
+    [mod_adhoc].
+
+%% path: (host_config[].)modules.*.iqdisc
+iqdisc() ->
+    #section{
+       items = #{<<"type">> => #option{type = atom,
+                                       validate = {enum, [no_queue, one_queue, parallel, queues]}},
+                 <<"workers">> => #option{type = integer,
+                                          validate = positive}},
+       required = [<<"type">>],
+       process = fun ?MODULE:format_iqdisc/1
+      }.
+
+format_iqdisc(KVs) ->
+    {[[{type, Type}]], WorkersOpts} = proplists:split(KVs, [type]),
+    iqdisc(Type, WorkersOpts).
+
+iqdisc(queues, [{workers, N}]) -> {queues, N};
+iqdisc(Type, []) -> Type.
 
 %% path: (host_config[].)shaper
 shaper() ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -726,7 +726,14 @@ modules() ->
       }.
 
 all_modules() ->
-    [mod_adhoc].
+    [mod_adhoc,
+     mod_auth_token%%,
+     %% mod_bosh,
+     %% mod_caps,
+     %% mod_csi,
+     %% mod_disco,
+     %% mod_event_pusher
+    ].
 
 %% path: (host_config[].)modules.*.iqdisc
 iqdisc() ->

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -356,12 +356,6 @@ validate([<<"body">>, <<"welcome_message">>, <<"mod_register">>, <<"modules">>|_
 validate([<<"subject">>, <<"welcome_message">>, <<"mod_register">>, <<"modules">>|_],
          [{subject, V}]) ->
     validate_string(V);
-validate([<<"iqdisc">>, <<"mod_adhoc">>, <<"modules">>|_],
-         [{iqdisc, V}]) ->
-    validate_iqdisc(V);
-validate([<<"report_commands_node">>, <<"mod_adhoc">>, <<"modules">>|_],
-         [{report_commands_node, V}]) ->
-    validate_boolean(V);
 validate([<<"cache_life_time">>, <<"mod_caps">>, <<"modules">>|_],
          [{cache_life_time, V}]) ->
     validate_non_negative_integer_or_infinity(V);

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -644,11 +644,6 @@ validate([<<"simple">>, <<"mod_mam_meta">>, <<"modules">>|_],
 validate([<<"user_prefs_store">>, <<"mod_mam_meta">>, <<"modules">>|_],
          [{user_prefs_store, V}]) ->
     validate_enum(V, [false,rdbms,cassandra,mnesia]);
-validate([<<"iqdisc">>, <<"mod_auth_token">>, <<"modules">>|_],
-         [{iqdisc, V}]) ->
-    validate_iqdisc(V);
-validate([<<"validity_period">>,<<"mod_auth_token">>,<<"modules">>|_], Vs) ->
-    lists:foreach(fun validate_validity_period/1, Vs);
 validate([<<"listen_port">>, <<"mod_jingle_sip">>, <<"modules">>|_],
          [{listen_port, V}]) ->
     validate_network_port(V);
@@ -1241,18 +1236,6 @@ validate_iqdisc(no_queue) -> ok;
 validate_iqdisc(one_queue) -> ok;
 validate_iqdisc(parallel) -> ok;
 validate_iqdisc({queues, N}) when is_integer(N), N > 0 -> ok.
-
--spec validate_auth_token_domain(mod_auth_token:token_type()) -> ok.
-validate_auth_token_domain(Type) ->
-    validate_enum(Type, [access, refresh, provision]).
-
-validate_validity_period({{validity_period, Token}, {Value, Unit}}) ->
-    validate_auth_token_domain(Token),
-    validate_non_negative_integer(Value),
-    validate_period_unit(Unit).
-
-validate_period_unit(Unit) ->
-    validate_enum(Unit, [days, hours, minutes, seconds]).
 
 validate_ip_access({Access, IPMask}) ->
     validate_enum(Access, [allow, deny]),

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -809,9 +809,6 @@ validate([<<"rooms_in_rosters">>, <<"mod_muc_light">>, <<"modules">>|_],
 validate([<<"rooms_per_page">>, <<"mod_muc_light">>, <<"modules">>|_],
          [{rooms_per_page, V}]) ->
     validate_positive_integer_or_infinity(V);
-validate([<<"iqdisc">>, <<"mod_carboncopy">>, <<"modules">>|_],
-         [{iqdisc, V}]) ->
-    validate_iqdisc(V);
 validate([<<"access_max_user_messages">>, <<"mod_offline">>, <<"modules">>|_],
          [{access_max_user_messages, V}]) ->
     validate_access_rule(V);

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -356,12 +356,6 @@ validate([<<"body">>, <<"welcome_message">>, <<"mod_register">>, <<"modules">>|_
 validate([<<"subject">>, <<"welcome_message">>, <<"mod_register">>, <<"modules">>|_],
          [{subject, V}]) ->
     validate_string(V);
-validate([<<"cache_life_time">>, <<"mod_caps">>, <<"modules">>|_],
-         [{cache_life_time, V}]) ->
-    validate_non_negative_integer_or_infinity(V);
-validate([<<"cache_size">>, <<"mod_caps">>, <<"modules">>|_],
-         [{cache_size, V}]) ->
-    validate_non_negative_integer(V);
 validate([<<"type">>, _, <<"service">>, <<"mod_extdisco">>, <<"modules">>|_],
          [{type, V}]) ->
     validate_non_empty_atom(V);

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -749,15 +749,6 @@ validate([<<"iqdisc">>, <<"mod_private">>, <<"modules">>|_],
 validate([<<"bucket_type">>, <<"riak">>, <<"mod_private">>, <<"modules">>|_],
          [{bucket_type, V}]) ->
     validate_non_empty_binary(V);
-validate([<<"inactivity">>, <<"mod_bosh">>, <<"modules">>|_],
-         [{inactivity, V}]) ->
-    validate_non_negative_integer_or_infinity(V);
-validate([<<"max_wait">>, <<"mod_bosh">>, <<"modules">>|_],
-         [{max_wait, V}]) ->
-    validate_non_negative_integer_or_infinity(V);
-validate([<<"server_acks">>, <<"mod_bosh">>, <<"modules">>|_],
-         [{server_acks, V}]) ->
-    validate_boolean(V);
 validate([<<"aff_changes">>, <<"mod_inbox">>, <<"modules">>|_],
          [{aff_changes, V}]) ->
     validate_boolean(V);

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -653,9 +653,6 @@ validate([<<"proxy_port">>, <<"mod_jingle_sip">>, <<"modules">>|_],
 validate([<<"sdp_origin">>, <<"mod_jingle_sip">>, <<"modules">>|_],
          [{sdp_origin, V}]) ->
     validate_ip_address(V);
-validate([<<"buffer_max">>, <<"mod_csi">>, <<"modules">>|_],
-         [{buffer_max, V}]) ->
-    validate_non_negative_integer_or_infinity(V);
 validate([<<"iqdisc">>, <<"mod_sic">>, <<"modules">>|_],
          [{iqdisc, V}]) ->
     validate_iqdisc(V);

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -51,6 +51,7 @@
          stop_module/2,
          stop_module_keep_config/2,
          reload_module/3,
+         config_spec/1,
          % Get/set opts by host or from a list
          get_opt/2,
          get_opt/3,
@@ -93,6 +94,8 @@
 %%     undefined.
 -callback start(Host :: jid:server(), Opts :: list()) -> any().
 -callback stop(Host :: jid:server()) -> any().
+-callback config_spec() -> mongoose_config_spec:config_section().
+-optional_callbacks([config_spec/0]).
 
 %% Optional callback specifying module dependencies.
 %% The dependent module can specify parameters with which the dependee should be
@@ -249,6 +252,10 @@ stop_module_keep_config(Host, Module) ->
 reload_module(Host, Module, Opts) ->
     stop_module_keep_config(Host, Module),
     start_module(Host, Module, Opts).
+
+-spec config_spec(module()) -> mongoose_config_spec:config_section().
+config_spec(Module) ->
+    Module:config_spec().
 
 -spec wait_for_process(atom() | pid() | {atom(), atom()}) -> 'ok'.
 wait_for_process(Process) ->

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -30,6 +30,7 @@
 
 -export([start/2,
          stop/1,
+         config_spec/0,
          process_local_iq/4,
          process_sm_iq/4,
          get_local_commands/5,
@@ -44,6 +45,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include("adhoc.hrl").
+-include("ejabberd_config.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
@@ -69,6 +71,14 @@ hooks(Host) ->
      {disco_sm_items, Host, ?MODULE, get_sm_commands, 99},
      {adhoc_local_items, Host, ?MODULE, ping_item, 100},
      {adhoc_local_commands, Host, ?MODULE, ping_command, 100}].
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"report_commands_node">> => #option{type = boolean},
+                 <<"iqdisc">> => mongoose_config_spec:iqdisc()}
+      }.
+
 %%-------------------------------------------------------------------------
 
 -spec get_local_commands(Acc :: {result, [exml:element()]} | {error, any()} | empty,

--- a/src/mod_auth_token.erl
+++ b/src/mod_auth_token.erl
@@ -7,10 +7,15 @@
 -include("ejabberd_commands.hrl").
 -include("jlib.hrl").
 -include("mod_auth_token.hrl").
+-include("ejabberd_config.hrl").
 
 %% gen_mod callbacks
 -export([start/2,
-         stop/1]).
+         stop/1,
+         config_spec/0]).
+
+%% Config spec callbacks
+-export([process_validity_period/1]).
 
 %% Hook handlers
 -export([clean_tokens/3]).
@@ -91,6 +96,33 @@ stop(Domain) ->
     [ ejabberd_hooks:delete(Hook, Domain, ?MODULE, Handler, Priority)
       || {Hook, Handler, Priority} <- hook_handlers() ],
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"validity_period">> => #list{items = validity_period_spec(),
+                                                format = none},
+                 <<"iqdisc">> => mongoose_config_spec:iqdisc()
+                }
+      }.
+
+validity_period_spec() ->
+    #section{
+       items = #{<<"token">> => #option{type = atom,
+                                        validate = {enum, [access, refresh, provision]}},
+                 <<"value">> => #option{type = integer,
+                                        validate = non_negative},
+                 <<"unit">> => #option{type = atom,
+                                       validate = {enum, [days, hours, minutes, seconds]}}
+                },
+       required = all,
+       process = fun ?MODULE:process_validity_period/1
+      }.
+
+process_validity_period(KVs) ->
+    {[[{token, Token}], [{value, Value}], [{unit, Unit}]], []} =
+        proplists:split(KVs, [token, value, unit]),
+    {{validity_period, Token}, {Value, Unit}}.
 
 default_opts(Opts) ->
     [{backend, rdbms} || not proplists:is_defined(backend, Opts)] ++ Opts.

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -21,7 +21,8 @@
 
 %% gen_mod callbacks
 -export([start/2,
-         stop/1]).
+         stop/1,
+         config_spec/0]).
 
 %% cowboy_loop_handler callbacks
 -export([init/2,
@@ -40,6 +41,7 @@
 -include("jlib.hrl").
 -include_lib("exml/include/exml_stream.hrl").
 -include("mod_bosh.hrl").
+-include("ejabberd_config.hrl").
 
 -define(DEFAULT_MAX_AGE, 1728000).  %% 20 days in seconds
 -define(DEFAULT_INACTIVITY, 30).  %% seconds
@@ -146,6 +148,21 @@ start(_Host, Opts) ->
 
 stop(_Host) ->
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"inactivity">> => #option{type = int_or_infinity,
+                                             validate = non_negative},
+                 <<"max_wait">> => #option{type = int_or_infinity,
+                                           validate = non_negative},
+                 <<"server_acks">> => #option{type = boolean},
+                 <<"max_pause">> => #option{type = integer,
+                                            validate = positive,
+                                            format = {kv, maxpause}}
+                }
+      }.
+
 %%--------------------------------------------------------------------
 %% Hooks handlers
 %%--------------------------------------------------------------------

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -39,7 +39,7 @@
          disco_features/5, disco_identity/5, disco_info/5]).
 
 %% gen_mod callbacks
--export([start/2, start_link/2, stop/1]).
+-export([start/2, start_link/2, stop/1, config_spec/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_info/2, handle_call/3,
@@ -53,6 +53,7 @@
 -export([delete_caps/1, make_disco_hash/2]).
 
 -include("mongoose.hrl").
+-include("ejabberd_config.hrl").
 
 -include("jlib.hrl").
 
@@ -95,6 +96,16 @@ stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
     ejabberd_sup:stop_child(Proc).
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"cache_size">> => #option{type = integer,
+                                             validate = positive},
+                 <<"cache_life_time">> => #option{type = integer,
+                                                  validate = positive}
+                }
+      }.
 
 get_features_list(Host, Caps) ->
     case get_features(Host, Caps) of

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -32,6 +32,7 @@
 %% API
 -export([start/2,
          stop/1,
+         config_spec/0,
          is_carbon_copy/1,
          classify_packet/1]).
 
@@ -51,7 +52,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include_lib("session.hrl").
-
+-include("ejabberd_config.hrl").
 
 -type classification() :: 'ignore' | 'forward'.
 
@@ -85,6 +86,10 @@ stop(Host) ->
     ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 89),
     ejabberd_hooks:delete(user_receive_packet, Host, ?MODULE, user_receive_packet, 89),
     ejabberd_hooks:delete(unset_presence_hook, Host, ?MODULE, remove_connection, 10).
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc()}}.
 
 iq_handler2(From, To, Acc, IQ) ->
     iq_handler(From, To, Acc, IQ, ?NS_CC_2).

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -9,9 +9,11 @@
 
 -export([start/2]).
 -export([stop/1]).
+-export([config_spec/0]).
 -export([add_csi_feature/2]).
 
 -include("jlib.hrl").
+-include("ejabberd_config.hrl").
 
 -type state() :: active | inactive.
 
@@ -26,6 +28,13 @@ stop(Host) ->
     [ejabberd_hooks:delete(Name, Host, Module, Function, Priority) ||
      {Name, Module, Function, Priority} <- hooks()],
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"buffer_max">> => #option{type = int_or_infinity,
+                                             validate = non_negative}}
+      }.
 
 hooks() ->
     [{c2s_stream_features, ?MODULE, add_csi_feature, 60}].

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1394,14 +1394,11 @@ mod_carboncopy(_Config) ->
     check_iqdisc(mod_carboncopy).
 
 mod_csi(_Config) ->
-    run_multi(mod_csi_cases()).
-
-mod_csi_cases() ->
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_csi">> => #{K => V}}} end,
     M = fun(K, V) -> modopts(mod_csi, [{K, V}]) end,
-    [?_eqf(M(buffer_max, 10), T(<<"buffer_max">>, 10)),
-     ?_eqf(M(buffer_max, infinity), T(<<"buffer_max">>, <<"infinity">>)),
-     ?_errf(T(<<"buffer_max">>, -1))].
+    ?eqf(M(buffer_max, 10), T(<<"buffer_max">>, 10)),
+    ?eqf(M(buffer_max, infinity), T(<<"buffer_max">>, <<"infinity">>)),
+    ?errf(T(<<"buffer_max">>, -1)).
 
 mod_disco(_Config) ->
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_disco">> => #{K => V}}} end,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1381,17 +1381,14 @@ mod_bosh(_Config) ->
     ?errf(T(<<"maxpause">>, 0)).
 
 mod_caps(_Config) ->
-    run_multi(mod_caps_cases()).
-
-mod_caps_cases() ->
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_caps">> => #{K => V}}} end,
     M = fun(K, V) -> modopts(mod_caps, [{K, V}]) end,
-    [?_eqf(M(cache_size, 10), T(<<"cache_size">>, 10)),
-     ?_eqf(M(cache_life_time, 10), T(<<"cache_life_time">>, 10)),
-     ?_errf(T(<<"cache_size">>, -1)),
-     ?_errf(T(<<"cache_size">>, <<"infinity">>)),
-     ?_errf(T(<<"cache_life_time">>, -1)),
-     ?_errf(T(<<"cache_life_time">>, <<"cache_life_time">>))].
+    ?eqf(M(cache_size, 10), T(<<"cache_size">>, 10)),
+    ?eqf(M(cache_life_time, 10), T(<<"cache_life_time">>, 10)),
+    ?errf(T(<<"cache_size">>, 0)),
+    ?errf(T(<<"cache_size">>, <<"infinity">>)),
+    ?errf(T(<<"cache_life_time">>, 0)),
+    ?errf(T(<<"cache_life_time">>, <<"infinity">>)).
 
 mod_carboncopy(_Config) ->
     check_iqdisc(mod_carboncopy).

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1346,24 +1346,21 @@ mod_adhoc(_Config) ->
 
 mod_auth_token(_Config) ->
     check_iqdisc(mod_auth_token),
-    run_multi(mod_auth_token_cases()).
-
-mod_auth_token_cases() ->
     P = fun(X) ->
-                     Opts = #{<<"validity_period">> => X},
-                     #{<<"modules">> => #{<<"mod_auth_token">> => Opts}}
-             end,
-    [?_eqf(modopts(mod_auth_token, [{{validity_period,access},  {13,minutes}},
-                                    {{validity_period,refresh}, {31,days}}]),
-           P([#{<<"token">> => <<"access">>,  <<"value">> => 13, <<"unit">> => <<"minutes">>},
-              #{<<"token">> => <<"refresh">>, <<"value">> => 31, <<"unit">> => <<"days">>}])),
-     ?_errf(P([#{<<"token">> => <<"access">>,  <<"value">> => <<"13">>, <<"unit">> => <<"minutes">>}])),
-     ?_errf(P([#{<<"token">> => <<"access">>,  <<"value">> => 13, <<"unit">> => <<"minute">>}])),
-     ?_errf(P([#{<<"token">> => <<"Access">>,  <<"value">> => 13, <<"unit">> => <<"minutes">>}])),
-     ?_errf(P([#{<<"value">> => 13, <<"unit">> => <<"minutes">>}])),
-     ?_errf(P([#{<<"token">> => <<"access">>,  <<"unit">> => <<"minutes">>}])),
-     ?_errf(P([#{<<"token">> => <<"access">>,  <<"value">> => 13}]))].
-
+                Opts = #{<<"validity_period">> => X},
+                #{<<"modules">> => #{<<"mod_auth_token">> => Opts}}
+        end,
+    ?eqf(modopts(mod_auth_token, [{{validity_period, access}, {13, minutes}},
+                                  {{validity_period, refresh}, {31, days}}]),
+         P([#{<<"token">> => <<"access">>, <<"value">> => 13, <<"unit">> => <<"minutes">>},
+            #{<<"token">> => <<"refresh">>, <<"value">> => 31, <<"unit">> => <<"days">>}])),
+    ?errf(P([#{<<"token">> => <<"access">>, <<"value">> => <<"13">>,
+               <<"unit">> => <<"minutes">>}])),
+    ?errf(P([#{<<"token">> => <<"access">>, <<"value">> => 13, <<"unit">> => <<"minute">>}])),
+    ?errf(P([#{<<"token">> => <<"Access">>, <<"value">> => 13, <<"unit">> => <<"minutes">>}])),
+    ?errf(P([#{<<"value">> => 13, <<"unit">> => <<"minutes">>}])),
+    ?errf(P([#{<<"token">> => <<"access">>, <<"unit">> => <<"minutes">>}])),
+    ?errf(P([#{<<"token">> => <<"access">>, <<"value">> => 13}])).
 
 mod_bosh(_Config) ->
     run_multi(mod_bosh_cases()).

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1363,23 +1363,22 @@ mod_auth_token(_Config) ->
     ?errf(P([#{<<"token">> => <<"access">>, <<"value">> => 13}])).
 
 mod_bosh(_Config) ->
-    run_multi(mod_bosh_cases()).
-
-mod_bosh_cases() ->
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_bosh">> => #{K => V}}} end,
     M = fun(K, V) -> modopts(mod_bosh, [{K, V}]) end,
-    [?_eqf(M(inactivity, 10), T(<<"inactivity">>, 10)),
-     ?_eqf(M(inactivity, infinity), T(<<"inactivity">>, <<"infinity">>)),
-     ?_eqf(M(inactivity, 10), T(<<"inactivity">>, 10)),
-     ?_eqf(M(max_wait, infinity), T(<<"max_wait">>, <<"infinity">>)),
-     ?_eqf(M(server_acks, true), T(<<"server_acks">>, true)),
-     ?_eqf(M(server_acks, false), T(<<"server_acks">>, false)),
-     ?errf(T(<<"inactivity">>, -1)),
-     ?errf(T(<<"inactivity">>, <<"10">>)),
-     ?errf(T(<<"inactivity">>, <<"inactivity">>)),
-     ?errf(T(<<"max_wait">>, <<"10">>)),
-     ?errf(T(<<"max_wait">>, -1)),
-     ?errf(T(<<"server_acks">>, -1))].
+    ?eqf(M(inactivity, 10), T(<<"inactivity">>, 10)),
+    ?eqf(M(inactivity, infinity), T(<<"inactivity">>, <<"infinity">>)),
+    ?eqf(M(inactivity, 10), T(<<"inactivity">>, 10)),
+    ?eqf(M(max_wait, infinity), T(<<"max_wait">>, <<"infinity">>)),
+    ?eqf(M(server_acks, true), T(<<"server_acks">>, true)),
+    ?eqf(M(server_acks, false), T(<<"server_acks">>, false)),
+    ?eqf(M(maxpause, 10), T(<<"max_pause">>, 10)),
+    ?errf(T(<<"inactivity">>, -1)),
+    ?errf(T(<<"inactivity">>, <<"10">>)),
+    ?errf(T(<<"inactivity">>, <<"inactivity">>)),
+    ?errf(T(<<"max_wait">>, <<"10">>)),
+    ?errf(T(<<"max_wait">>, -1)),
+    ?errf(T(<<"server_acks">>, -1)),
+    ?errf(T(<<"maxpause">>, 0)).
 
 mod_caps(_Config) ->
     run_multi(mod_caps_cases()).

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -16,8 +16,7 @@
 -define(add_loc(X), {X, #{line => ?LINE}}).
 
 -define(eqf(Expected, Actual), eq_host_config(Expected, Actual)).
--define(errf(Config),
-        begin ?err(parse_with_host(Config)), ?err(parse_host_config(Config)) end).
+-define(errf(Config), err_host_config(Config)).
 
 %% Constructs HOF to pass into run_multi/1 function
 %% It's a HOF, so it would always pass if not passed into run_multi/1
@@ -3154,10 +3153,6 @@ compare_ordered_lists([H1|T1], [H2|T2], F) ->
     compare_ordered_lists(T1, T2, F);
 compare_ordered_lists([], [], _) ->
     ok.
-
-parse_with_host(Config) ->
-    [F] = parse(Config),
-    apply(F, [?HOST]).
 
 set_pl(K, V, List) ->
     lists:keyreplace(K, 1, List, {K, V}).

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1336,16 +1336,13 @@ s2s_max_retry_delay(_Config) ->
 
 mod_adhoc(_Config) ->
     check_iqdisc(mod_adhoc),
-    run_multi(mod_adhoc_cases()).
-
-mod_adhoc_cases() ->
     M = fun(K, V) -> modopts(mod_adhoc, [{K, V}]) end,
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_adhoc">> => #{K => V}}} end,
     %% report_commands_node is boolean
-    [?_eqf(M(report_commands_node, true), T(<<"report_commands_node">>, true)),
-     ?_eqf(M(report_commands_node, false), T(<<"report_commands_node">>, false)),
-     %% not boolean
-     ?_errf(T(<<"report_commands_node">>, <<"hello">>))].
+    ?eqf(M(report_commands_node, true), T(<<"report_commands_node">>, true)),
+    ?eqf(M(report_commands_node, false), T(<<"report_commands_node">>, false)),
+    %% not boolean
+    ?errf(T(<<"report_commands_node">>, <<"hello">>)).
 
 mod_auth_token(_Config) ->
     check_iqdisc(mod_auth_token),

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -18,7 +18,7 @@
   inactivity = 20
   max_wait = "infinity"
   server_acks = true
-  maxpause = 120
+  max_pause = 120
 
 [modules.mod_caps]
   cache_size = 1000


### PR DESCRIPTION
Modules covered in this PR:
- [x] mod_adhoc
- [x] mod_auth_token
- [x] mod_bosh
- [x] mod_caps
- [x] mod_carboncopy
- [x] mod_csi

To be continued in the next PR:
- mod_disco
- mod_event_pusher

Checklist for each module:
- Write the new spec in the module as a callback function: `config_spec/0`. Some cases need reworking the options, e.g. when the same value can be a primitive (e.g. string or atom) or a nested section/list
- Add the module to `mongoose_config_spec:all_modules/0` and `HAS_NO_SPEC`
- Double check with the docs: `https://esl.github.io/MongooseDocs` that the options and their format, validator etc are correct
- Remove `module_opt` and `handler` clauses from `mongoose_config_parser_toml` as well as module-specific functions for nested options
- Remove `validate` clauses from `mongoose_config_validator_toml`
- Make sure this passes locally: `./rebar3 ct --suite=config_parser_SUITE` before pushing anything, also check `./rebar3 dialyzer`
- Check test coverage after pushing, there might be some options not covered by tests, you can do it by looking at the test cases as well
- Regarding tests, it's good to simplify them and fix indentation/maximum line length of 100 character, see the change for `mod_adhoc` or `mod_auth_token`.
- Sanity check: grep for the module name in `src/config`