### PR TITLE
Catch log formatter errors to avoid death spiral of logging (issue #2967)

### DIFF
--- a/src/logger/mongoose_flatlog_formatter.erl
+++ b/src/logger/mongoose_flatlog_formatter.erl
@@ -1,10 +1,36 @@
 -module(mongoose_flatlog_formatter).
 -export([format/2]).
 
-format(Map, UsrConfig) ->
+
+-spec format(logger:log_event(), logger:formatter_config()) -> unicode:chardata().
+format(Event, FConfig) ->
+    try do_format(Event, FConfig)
+    catch
+        %% Errors during log formatting can lead to a death spiral of recursive error logging, so
+        %% format the formatter error in a safe way and don't allow the exception to propagate.
+        error:Reason:Stacktrace -> format_log_formatter_error(error, Reason, Stacktrace, Event, FConfig)
+    end.
+
+
+format_log_formatter_error(Class, Reason, Stacktrace, #{meta := Meta} = Event, FConfig) ->
+    flatlog:format(
+        #{
+            level => error,
+            msg => {report, #{
+                class => Class, reason => Reason, stacktrace => Stacktrace,
+                formatter_module => ?MODULE,
+                original_event => unicode:characters_to_binary(io_lib:format("~0p", [Event]))
+            }},
+            meta => Meta#{what => log_format_failed}
+        },
+        FConfig#{template => template()}
+    ).
+
+
+do_format(Map, UsrConfig) ->
     Map2 = mongoose_log_filter:fill_metadata_filter(Map, fields()),
     flatlog:format(Map2, UsrConfig#{template => template()}).
-    
+
 fields() ->
     [what, text, user, from_jid, to_jid,
      class, reason, stacktrace].


### PR DESCRIPTION
This PR addresses #2967 

Instead of allowing an error during log line formatting to propagate into `formatter_crashed`, which can then lead to a death spiral of formatters crashing as they try to format the `formatter_crashed` error, safely format a log message about the formatter crash.

This avoids the big tests failing at debug log level, and will also be safer for production use - any undiscovered bugs in log formatting won't be able to bring down the MongooseIM process.

Example of formatted log line produced by the modified JSON formatter in case of an error during formatting:

```
{"when":"2020-12-04T09:16:33.003295+00:00","what":"log_format_failed","reason":"badarg","level":"error","formatter_module":"mongoose_json_formatter","class":"error","cause_mfa":"{ejabberd_router,route,4}","cause_line":144,"cause_file":"/data/developer/code/esl/MongooseIM/src/ejabberd_router.erl"}
```

Closes #2967 