### PR TITLE
Move config spec records to a separate header file

### DIFF
--- a/include/ejabberd_config.hrl
+++ b/include/ejabberd_config.hrl
@@ -27,19 +27,4 @@
                        value :: mongoose_config_parser:value()
                       }).
 
--record(section, {items,
-                  validate_keys = any,
-                  required = [],
-                  validate = any,
-                  process,
-                  format = default}).
--record(list, {items,
-               validate = any,
-               process,
-               format = default}).
--record(option, {type,
-                 validate = any,
-                 process,
-                 format = default}).
-
 -endif.

--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -1,0 +1,19 @@
+-ifndef(MONGOOSEIM_CONFIG_SPEC_HRL).
+-define(MONGOOSEIM_CONFIG_SPEC_HRL, true).
+
+-record(section, {items,
+                  validate_keys = any,
+                  required = [],
+                  validate = any,
+                  process,
+                  format = default}).
+-record(list, {items,
+               validate = any,
+               process,
+               format = default}).
+-record(option, {type,
+                 validate = any,
+                 process,
+                 format = default}).
+
+-endif.

--- a/src/admin_extra/service_admin_extra.erl
+++ b/src/admin_extra/service_admin_extra.erl
@@ -28,7 +28,7 @@
 
 -behaviour(mongoose_service).
 
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -export([start/1, stop/0, config_spec/0]).
 

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -11,6 +11,7 @@
 -endif.
 
 -include("mongoose.hrl").
+-include("mongoose_config_spec.hrl").
 -include("ejabberd_config.hrl").
 
 %% Used to create per-host config when the list of hosts is not known yet

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -2,7 +2,7 @@
 
 -compile(export_all).
 
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -type config_node() :: config_section() | config_list() | config_option().
 -type config_section() :: #section{}.

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -6,7 +6,7 @@
          validate_list/2]).
 
 -include("mongoose.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 -include_lib("jid/include/jid.hrl").
 
 -define(HOST, 'HOST').

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -22,7 +22,7 @@
 
 -include("jlib.hrl").
 -include("mod_event_pusher_events.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -type event() :: #user_status_event{} | #chat_event{} | #unack_msg_event{}.
 -export_type([event/0]).

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -41,7 +41,7 @@
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -define(DEFAULT_POOL_NAME, http_pool).
 -define(DEFAULT_PATH, "").

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -19,7 +19,7 @@
 -include("mod_event_pusher_events.hrl").
 -include("mongoose.hrl").
 -include("jlib.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -define(SESSION_KEY, publish_service).
 

--- a/src/event_pusher/mod_event_pusher_rabbit.erl
+++ b/src/event_pusher/mod_event_pusher_rabbit.erl
@@ -23,7 +23,7 @@
 
 -include_lib("mongooseim/include/mongoose.hrl").
 -include_lib("mongooseim/include/mod_event_pusher_events.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).

--- a/src/event_pusher/mod_event_pusher_sns.erl
+++ b/src/event_pusher/mod_event_pusher_sns.erl
@@ -7,7 +7,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -callback user_guid(UserJID :: jid:jid()) -> user_guid().
 -callback message_attributes(TopicARN :: topic_arn(), UserJID :: jid:jid(),

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -45,7 +45,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include("adhoc.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),

--- a/src/mod_auth_token.erl
+++ b/src/mod_auth_token.erl
@@ -7,7 +7,7 @@
 -include("ejabberd_commands.hrl").
 -include("jlib.hrl").
 -include("mod_auth_token.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 %% gen_mod callbacks
 -export([start/2,

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -41,7 +41,7 @@
 -include("jlib.hrl").
 -include_lib("exml/include/exml_stream.hrl").
 -include("mod_bosh.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -define(DEFAULT_MAX_AGE, 1728000).  %% 20 days in seconds
 -define(DEFAULT_INACTIVITY, 30).  %% seconds

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -53,7 +53,7 @@
 -export([delete_caps/1, make_disco_hash/2]).
 
 -include("mongoose.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -include("jlib.hrl").
 

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -52,7 +52,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include_lib("session.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -type classification() :: 'ignore' | 'forward'.
 

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -13,7 +13,7 @@
 -export([add_csi_feature/2]).
 
 -include("jlib.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -type state() :: active | inactive.
 

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -54,7 +54,7 @@
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -type feature() :: any().
 

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -4,7 +4,7 @@
 -behaviour(mongoose_service).
 -behaviour(gen_server).
 
--include("ejabberd_config.hrl").
+-include("mongoose_config_spec.hrl").
 
 -define(DEFAULT_INITIAL_REPORT, timer:minutes(5)).
 -define(DEFAULT_REPORT_AFTER, timer:hours(3)).


### PR DESCRIPTION
Reasons:
 - avoid record name conflicts in modules
 - do not include unnecessary records to modules

