### PR TITLE
Use wait_for_service.sh instead of netcat

### DIFF
--- a/tools/setup_minio.sh
+++ b/tools/setup_minio.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# cd to repo
+cd "$(dirname "$0")/../"
+
 ## see https://github.com/minio/minio/issues/4769 for more examples
   
 minio_docker_name="mongooseim-minio"
@@ -15,8 +18,12 @@ docker run -d -p 9000:9000 \
     -e "MINIO_SECRET_KEY=${minio_secret_key}" \
     minio/minio server /data
 
+# Pulling while waiting
+docker pull minio/mc &
+
+tools/wait_for_service.sh "${minio_docker_name}" 9000
+
 mc_cmd="$(cat <<-EOF
-  while ! nc -z minio 9000; do echo 'Wait minio to startup...' && sleep 5; done;
   mc config host add myminio http://minio:9000 "${minio_access_key}" "${minio_secret_key}" && 
   mc mb "myminio/${minio_bucket}" &&
   mc policy set download "myminio/${minio_bucket}"


### PR DESCRIPTION
This PR addresses "missing nc command in the `minio/mc` container".

Proposed changes include:
* Use `tools/wait_for_service.sh` to ensure the main minio container is started (similar the way we wait for other DB containers).