### PR TITLE
TOML config cleanup - parser simplification

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -162,9 +162,8 @@ handle_step(validate, {ParsedValue, Spec}) ->
             {ParsedValue, Spec}
     end;
 handle_step(validate, ParsedValue) ->
-    fun(Path, _Value) ->
-            mongoose_config_validator_toml:validate(Path, ParsedValue),
-            ParsedValue
+    fun(_Path, _Value) ->
+            ParsedValue %% no validation here, this will be removed very soon
     end;
 handle_step(process, {ParsedValue, Spec}) ->
     fun(Path, _Value) ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -711,25 +711,29 @@ tls_items() ->
 
 %% path: (host_config[].)services
 services() ->
-    Services = [{a2b(Service), mongoose_service:config_spec(Service)} || Service <- all_services()],
+    Services = [{a2b(Service), mongoose_service:config_spec(Service)}
+                || Service <- configurable_services()],
     #section{
        items = maps:from_list(Services),
        format = local_config
       }.
 
-all_services() ->
+configurable_services() ->
     [service_admin_extra,
      service_mongoose_system_metrics].
 
 %% path: (host_config[].)modules
 modules() ->
-    Modules = [{a2b(Module), gen_mod:config_spec(Module)} || Module <- all_modules()],
+    Modules = [{a2b(Module), gen_mod:config_spec(Module)}
+               || Module <- configurable_modules()],
+    Items = maps:from_list(Modules),
     #section{
-       items = maps:from_list(Modules),
+       items = Items#{default => #section{items = #{}}},
+       validate_keys = module,
        format = host_local_config
       }.
 
-all_modules() ->
+configurable_modules() ->
     [mod_adhoc,
      mod_auth_token,
      mod_bosh,

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -11,20 +11,6 @@
 
 -export_type([config_node/0, config_section/0, config_list/0, config_option/0]).
 
-handler(Path) ->
-    handler(Path, root()).
-
-handler([Node|Rest], #section{items = Items}) when is_binary(Node) ->
-    Item = case maps:is_key(Node, Items) of
-               true -> maps:get(Node, Items);
-               false -> maps:get(default, Items)
-           end,
-    handler(Rest, Item);
-handler([item|Rest], #list{items = Item}) ->
-    handler(Rest, Item);
-handler([], Node) ->
-    Node.
-
 %% Config processing functions are annotated with TOML paths
 %% Path syntax: dotted, like TOML keys with the following additions:
 %%   - '[]' denotes an element in a list

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -14,25 +14,38 @@
 handler(Path) ->
     handler(Path, root()).
 
-handler([Node], #section{items = Items}) when is_binary(Node) ->
-    case maps:is_key(Node, Items) of
-        true -> maps:get(Node, Items);
-        false -> maps:get(default, Items)
-    end;
-handler([item], #list{items = Item}) ->
-    Item;
 handler([Node|Rest], #section{items = Items}) when is_binary(Node) ->
     Item = case maps:is_key(Node, Items) of
                true -> maps:get(Node, Items);
                false -> maps:get(default, Items)
            end,
     handler(Rest, Item);
-handler([item|Rest], #list{items = Items}) ->
-    handler(Rest, Items).
+handler([item|Rest], #list{items = Item}) ->
+    handler(Rest, Item);
+handler([], Node) ->
+    Node.
+
+%% Config processing functions are annotated with TOML paths
+%% Path syntax: dotted, like TOML keys with the following additions:
+%%   - '[]' denotes an element in a list
+%%   - '( ... )' encloses an optional prefix
+%%   - '*' is a wildcard for names - usually that name is passed as an argument
+%% If the path is the same as for the previous function, it is not repeated.
+%%
+%% Example: (host_config[].)access.*
+%% Meaning: either a key in the 'access' section, e.g.
+%%            [access]
+%%              local = ...
+%%          or the same, but prefixed for a specific host, e.g.
+%%            [[host_config]]
+%%              host = "myhost"
+%%              host_config.access
+%%                local = ...
 
 root() ->
+    General = general(),
     #section{
-       items = #{<<"general">> => general(),
+       items = #{<<"general">> => General#section{required = [<<"hosts">>]},
                  <<"listen">> => listen(),
                  <<"auth">> => auth(),
                  <<"outgoing_pools">> => outgoing_pools(),
@@ -41,9 +54,38 @@ root() ->
                  <<"shaper">> => shaper(),
                  <<"acl">> => acl(),
                  <<"access">> => access(),
-                 <<"s2s">> => s2s()
+                 <<"s2s">> => s2s(),
+                 <<"host_config">> => #list{items = host_config(),
+                                            format = none}
                 },
        required = [<<"general">>],
+       format = none
+      }.
+
+%% path: host_config[]
+host_config() ->
+    #section{
+       items = #{%% Host is only validated here - it is stored in the path,
+                 %%   see mongoose_config_parser_toml:item_key/1
+                 <<"host">> => #option{type = binary,
+                                       validate = non_empty,
+                                       format = skip},
+
+                 %% Sections below are allowed in host_config,
+                 %% but only options with these formats are accepted:
+                 %%  - host_local_config
+                 %%  - host_or_global_config
+                 %%  - host_or_global_acl
+                 %% Any other options would be caught by
+                 %%   mongoose_config_parser_toml:format/3
+                 <<"general">> => general(),
+                 <<"auth">> => auth(),
+                 <<"modules">> => modules(),
+                 <<"shaper">> => shaper(),
+                 <<"acl">> => acl(),
+                 <<"access">> => access(),
+                 <<"s2s">> => s2s()
+                },
        format = none
       }.
 
@@ -100,7 +142,6 @@ general() ->
                  <<"hide_service_name">> => #option{type = boolean,
                                                     format = host_local_config}
                 },
-       required = [<<"hosts">>],
        format = none
       }.
 

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -1,25 +1,12 @@
 -module(mongoose_config_validator_toml).
 
--export([validate/2,
-         validate/3,
+-export([validate/3,
          validate_section/2,
          validate_list/2]).
 
 -include("mongoose.hrl").
 -include("mongoose_config_spec.hrl").
 -include_lib("jid/include/jid.hrl").
-
--define(HOST, 'HOST').
-
--spec validate(mongoose_config_parser_toml:path(),
-               mongoose_config_parser_toml:option() | mongoose_config_parser_toml:config_list()) ->
-          any().
-validate(Path, [F]) when is_function(F, 1) ->
-    validate(Path, F(?HOST));
-
-%% Modules
-validate(_Path, _Value) ->
-    ok.
 
 validate(V, binary, domain) -> validate_binary_domain(V);
 validate(V, binary, non_empty) -> validate_non_empty_binary(V);

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -222,7 +222,8 @@ groups() ->
                             mod_vcard_ldap_vcard_map,
                             mod_vcard_ldap_search_fields,
                             mod_vcard_ldap_search_reported,
-                            mod_version]},
+                            mod_version,
+                            modules_without_config]},
      {services, [parallel], [service_admin_extra,
                              service_mongoose_system_metrics]}
     ].
@@ -2738,6 +2739,10 @@ mod_version(_Config) ->
     ?eqf(modopts(mod_version, [{os_info, false}]), T(#{<<"os_info">> => false})),
     ?errf(T(#{<<"os_info">> => 1})),
     check_iqdisc(mod_version).
+
+modules_without_config(_Config) ->
+    ?eqf(modopts(mod_amp, []), #{<<"modules">> => #{<<"mod_amp">> => #{}}}),
+    ?errf(#{<<"modules">> => #{<<"mod_wrong">> => #{}}}).
 
 %% Services
 


### PR DESCRIPTION
The goal of this pull request is to:
- Extend the declarative spec to the whole config tree.
- Remove code that handled the imperative part of the parser.
- Simplify and optimize declarative parsing.

See commit messages for details.