### PR TITLE
Remove int_or_inf_or_atom from mod_stream_management

### DIFF
--- a/doc/modules/mod_stream_management.md
+++ b/doc/modules/mod_stream_management.md
@@ -7,12 +7,26 @@ while the management of the session tables and configuration is implemented in
 
 ## Options
 
+### `modules.mod_stream_management.buffer`
+* **Syntax:** boolean
+* **Default:** true
+* **Example:** `buffer = false`
+
+Enables buffer for messages to be acknowledged.
+
 ### `modules.mod_stream_management.buffer_max`
 * **Syntax:** positive integer or string `"infinity"` or string `"no_buffer"`
 * **Default:** `100`
 * **Example:** `buffer_max = "no_buffer"`
 
 Buffer size for messages yet to be acknowledged.
+
+### `modules.mod_stream_management.ack`
+* **Syntax:** boolean
+* **Default:** true
+* **Example:** `ack = false`
+
+Enables ack requests to be sent from the server to the client.
 
 ### `modules.mod_stream_management.ack_freq`
 * **Syntax:** positive integer or string `"never"`

--- a/doc/modules/mod_stream_management.md
+++ b/doc/modules/mod_stream_management.md
@@ -15,9 +15,9 @@ while the management of the session tables and configuration is implemented in
 Enables buffer for messages to be acknowledged.
 
 ### `modules.mod_stream_management.buffer_max`
-* **Syntax:** positive integer or string `"infinity"` or string `"no_buffer"`
+* **Syntax:** positive integer or string `"infinity"`
 * **Default:** `100`
-* **Example:** `buffer_max = "no_buffer"`
+* **Example:** `buffer_max = 500`
 
 Buffer size for messages yet to be acknowledged.
 
@@ -29,9 +29,9 @@ Buffer size for messages yet to be acknowledged.
 Enables ack requests to be sent from the server to the client.
 
 ### `modules.mod_stream_management.ack_freq`
-* **Syntax:** positive integer or string `"never"`
+* **Syntax:** positive integer
 * **Default:** `1`
-* **Example:** `ack_freq = "never"`
+* **Example:** `ack_freq = 3`
 
 Frequency of ack requests sent from the server to the client, e.g. 1 means a request after each stanza, 3 means a request after each 3 stanzas.
 

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -272,9 +272,6 @@ convert(V, string) -> binary_to_list(V);
 convert(V, atom) -> b2a(V);
 convert(<<"infinity">>, int_or_infinity) -> infinity; %% TODO maybe use TOML '+inf'
 convert(V, int_or_infinity) when is_integer(V) -> V;
-convert(<<"infinity">>, int_or_infinity_or_atom) -> infinity;
-convert(<<"no_buffer">>, int_or_infinity_or_atom) -> no_buffer;
-convert(V, int_or_infinity_or_atom) when is_integer(V) -> V;
 convert(V, int_or_atom) when is_integer(V) -> V;
 convert(V, int_or_atom) -> b2a(V);
 convert(V, integer) when is_integer(V) -> V;

--- a/src/config/mongoose_config_validator_toml.erl
+++ b/src/config/mongoose_config_validator_toml.erl
@@ -31,10 +31,6 @@ validate(V, integer, positive) -> validate_positive_integer(V);
 validate(V, integer, port) -> validate_port(V);
 validate(V, int_or_infinity, non_negative) -> validate_non_negative_integer_or_infinity(V);
 validate(V, int_or_infinity, positive) -> validate_positive_integer_or_infinity(V);
-validate(V, int_or_infinity_or_atom, positive) ->
-    validate_positive_integer_or_infinity_or_atom(V, no_buffer);
-validate(V, int_or_atom, positive) ->
-    validate_positive_integer_or_atom(V, never);
 validate(V, string, url) -> validate_url(V);
 validate(V, string, domain) -> validate_domain(V);
 validate(V, string, domain_template) -> validate_domain_template(V);
@@ -91,13 +87,6 @@ validate_non_negative_integer_or_infinity(infinity) -> ok.
 
 validate_positive_integer_or_infinity(Value) when is_integer(Value), Value > 0 -> ok;
 validate_positive_integer_or_infinity(infinity) -> ok.
-
-validate_positive_integer_or_atom(Value, Atom) when is_atom(Value), Value == Atom -> ok;
-validate_positive_integer_or_atom(Value, _) when is_integer(Value), Value > 0 -> ok.
-
-validate_positive_integer_or_infinity_or_atom(Value, _) when is_integer(Value), Value > 0 -> ok;
-validate_positive_integer_or_infinity_or_atom(infinity, _) -> ok;
-validate_positive_integer_or_infinity_or_atom(Value, Atom) when is_atom(Value), Value == Atom -> ok.
 
 validate_enum(Value, Values) ->
     case lists:member(Value, Values) of

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2605,13 +2605,15 @@ mod_stream_management(_Config) ->
     T = fun(Opts) -> #{<<"modules">> => #{<<"mod_stream_management">> => Opts}} end,
     M = fun(Cfg) -> modopts(mod_stream_management, Cfg) end,
     ?eqf(M([{buffer_max, no_buffer}]),  T(#{<<"buffer">> => false})),
-    ?eqf(M([{ack_freq, never}]), T(#{<<"ack">> => false})),
     ?eqf(M([{buffer_max, 10}]),  T(#{<<"buffer_max">> => 10})),
+    ?eqf(M([{ack_freq, never}]), T(#{<<"ack">> => false})),
     ?eqf(M([{ack_freq, 1}]), T(#{<<"ack_freq">> => 1})),
     ?eqf(M([{resume_timeout, 600}]), T(#{<<"resume_timeout">> => 600})),
 
+    ?errf(T(#{<<"buffer">> => 0})),
     ?errf(T(#{<<"buffer_max">> => -1})),
-    ?errf(T(#{<<"ack_freq">> => false})),
+    ?errf(T(#{<<"ack">> => <<"false">>})),
+    ?errf(T(#{<<"ack_freq">> => 0})),
     ?errf(T(#{<<"resume_timeout">> => true})).
 
 mod_stream_management_stale_h(_Config) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2604,12 +2604,14 @@ mod_sic(_Config) ->
 mod_stream_management(_Config) ->
     T = fun(Opts) -> #{<<"modules">> => #{<<"mod_stream_management">> => Opts}} end,
     M = fun(Cfg) -> modopts(mod_stream_management, Cfg) end,
-    ?eqf(M([{buffer_max, no_buffer}]),  T(#{<<"buffer_max">> => <<"no_buffer">>})),
+    ?eqf(M([{buffer_max, no_buffer}]),  T(#{<<"buffer">> => false})),
+    ?eqf(M([{ack_freq, never}]), T(#{<<"ack">> => false})),
+    ?eqf(M([{buffer_max, 10}]),  T(#{<<"buffer_max">> => 10})),
     ?eqf(M([{ack_freq, 1}]), T(#{<<"ack_freq">> => 1})),
     ?eqf(M([{resume_timeout, 600}]), T(#{<<"resume_timeout">> => 600})),
 
     ?errf(T(#{<<"buffer_max">> => -1})),
-    ?errf(T(#{<<"ack_freq">> => <<"one">>})),
+    ?errf(T(#{<<"ack_freq">> => false})),
     ?errf(T(#{<<"resume_timeout">> => true})).
 
 mod_stream_management_stale_h(_Config) ->


### PR DESCRIPTION
This PR removes `int_or_infinity_or_atom` option type from TOML config spec. The idea is to introduce additional boolean options to the config of the module. 

|  Before                                | After               |
| -------------------------- | -------------- |
| buffer_max = "no_buffer"  | buffer = false  |
| ack_freq = "never"             | ack = false      |
