### PR TITLE
TOML config cleanup: type specs

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -392,8 +392,5 @@ enable_watcher(Config, Watcher) ->
 disable_watcher(Config) ->
     restore_mod_register_options(Config).
 
-watcher(Watcher) ->
-    {registration_watchers, [binary_to_list(Watcher)]}.
-
 domain() ->
     ct:get_config({hosts, mim, domain}).

--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -1,19 +1,22 @@
 -ifndef(MONGOOSEIM_CONFIG_SPEC_HRL).
 -define(MONGOOSEIM_CONFIG_SPEC_HRL, true).
 
--record(section, {items,
-                  validate_keys = any,
-                  required = [],
-                  validate = any,
-                  process,
-                  format = default}).
--record(list, {items,
-               validate = any,
-               process,
-               format = default}).
--record(option, {type,
-                 validate = any,
-                 process,
-                 format = default}).
+-record(section, {items :: #{mongoose_config_parser_toml:toml_key() | default =>
+                                 mongoose_config_spec:config_node()},
+                  validate_keys = any :: mongoose_config_validator:validator(),
+                  required = [] :: [mongoose_config_parser_toml:toml_key()] | all,
+                  validate = any :: mongoose_config_validator:section_validator(),
+                  process :: undefined | mongoose_config_parser_toml:list_processor(),
+                  format = default :: mongoose_config_spec:format()}).
+
+-record(list, {items :: mongoose_config_spec:config_node(),
+               validate = any :: mongoose_config_validator:list_validator(),
+               process :: undefined | mongoose_config_parser_toml:list_processor(),
+               format = default :: mongoose_config_spec:format()}).
+
+-record(option, {type :: mongoose_config_spec:option_type(),
+                 validate = any :: mongoose_config_validator:validator(),
+                 process :: undefined | mongoose_config_parser_toml:processor(),
+                 format = default :: mongoose_config_spec:format()}).
 
 -endif.

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -149,15 +149,15 @@ check_required_keys(#section{required = Required}, Section) ->
 validate_keys(#section{validate_keys = undefined}, _Section) -> ok;
 validate_keys(#section{validate_keys = Validator}, Section) ->
     lists:foreach(fun(Key) ->
-                          mongoose_config_validator_toml:validate(b2a(Key), atom, Validator)
+                          mongoose_config_validator:validate(b2a(Key), atom, Validator)
                   end, maps:keys(Section)).
 
 validate(Value, #section{validate = Validator}) ->
-    mongoose_config_validator_toml:validate_section(Value, Validator);
+    mongoose_config_validator:validate_section(Value, Validator);
 validate(Value, #list{validate = Validator}) ->
-    mongoose_config_validator_toml:validate_list(Value, Validator);
+    mongoose_config_validator:validate_list(Value, Validator);
 validate(Value, #option{type = Type, validate = Validator}) ->
-    mongoose_config_validator_toml:validate(Value, Type, Validator).
+    mongoose_config_validator:validate(Value, Type, Validator).
 
 process_spec(#section{process = Process}) -> Process;
 process_spec(#list{process = Process}) -> Process;
@@ -184,7 +184,7 @@ format_spec(#option{format = Format}) -> Format.
 
 format(Path, KVs, {foreach, Format}) when is_atom(Format) ->
     Keys = lists:map(fun({K, _}) -> K end, KVs),
-    mongoose_config_validator_toml:validate_list(Keys, unique),
+    mongoose_config_validator:validate_list(Keys, unique),
     lists:flatmap(fun({K, V}) -> format(Path, V, {Format, K}) end, KVs);
 format([Key|_] = Path, V, host_local_config) ->
     format(Path, V, {host_local_config, b2a(Key)});

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -1098,7 +1098,7 @@ process_sasl_external(V) when V =:= standard;
                               V =:= auth_id ->
     V;
 process_sasl_external(M) ->
-    mongoose_config_validator_toml:validate(M, atom, module),
+    mongoose_config_validator:validate(M, atom, module),
     {mod, M}.
 
 process_sasl_mechanism(V) ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -1,6 +1,46 @@
 -module(mongoose_config_spec).
 
--compile(export_all).
+%% entry point - returns the entire spec
+-export([root/0]).
+
+%% spec parts used by modules and services
+-export([wpool_items/0,
+         iqdisc/0,
+         ldap_uids/0]).
+
+%% callbacks for the 'process' step
+-export([process_host/1,
+         process_sm_backend/1,
+         process_ctl_access_rule/1,
+         process_ip_version/1,
+         process_listener/2,
+         process_verify_peer/1,
+         process_sni/1,
+         process_xmpp_tls/1,
+         process_fast_tls/1,
+         process_http_handler/2,
+         process_sasl_external/1,
+         process_sasl_mechanism/1,
+         process_auth/1,
+         process_auth_password/1,
+         process_jwt_secret/1,
+         process_ldap_uids/1,
+         process_ldap_dn_filter/1,
+         process_ldap_local_filter/1,
+         process_pool/2,
+         process_cassandra_auth/1,
+         process_rdbms_connection/1,
+         process_riak_tls/1,
+         process_cassandra_server/1,
+         process_riak_credentials/1,
+         process_iqdisc/1,
+         process_shaper/1,
+         process_acl_item/1,
+         process_access_rule_item/1,
+         process_s2s_address_family/1,
+         process_s2s_host_policy/1,
+         process_s2s_address/1,
+         process_s2s_domain_cert/1]).
 
 -include("mongoose_config_spec.hrl").
 
@@ -128,7 +168,7 @@ general() ->
                                            format = local_config},
                  <<"hosts">> => #list{items = #option{type = binary,
                                                       validate = non_empty,
-                                                      process = fun ?MODULE:prepare_host/1},
+                                                      process = fun ?MODULE:process_host/1},
                                       validate = unique_non_empty,
                                       format = config},
                  <<"registration_timeout">> => #option{type = int_or_infinity,
@@ -848,10 +888,10 @@ iqdisc() ->
                  <<"workers">> => #option{type = integer,
                                           validate = positive}},
        required = [<<"type">>],
-       process = fun ?MODULE:format_iqdisc/1
+       process = fun ?MODULE:process_iqdisc/1
       }.
 
-format_iqdisc(KVs) ->
+process_iqdisc(KVs) ->
     {[[{type, Type}]], WorkersOpts} = proplists:split(KVs, [type]),
     iqdisc(Type, WorkersOpts).
 
@@ -1033,16 +1073,13 @@ process_ctl_access_rule(KVs) ->
 process_sm_backend(Backend) ->
     {Backend, []}.
 
-prepare_host(Host) ->
+process_host(Host) ->
     Node = jid:nodeprep(Host),
     true = Node =/= error,
     Node.
 
 process_sni(false) ->
     disable.
-
-process_lasse_handler([{module, Module}]) ->
-    [Module].
 
 process_verify_peer(false) -> verify_none;
 process_verify_peer(true) -> verify_peer.

--- a/src/config/mongoose_config_validator.erl
+++ b/src/config/mongoose_config_validator.erl
@@ -1,4 +1,4 @@
--module(mongoose_config_validator_toml).
+-module(mongoose_config_validator).
 
 -export([validate/3,
          validate_section/2,

--- a/src/config/mongoose_config_validator.erl
+++ b/src/config/mongoose_config_validator.erl
@@ -8,6 +8,19 @@
 -include("mongoose_config_spec.hrl").
 -include_lib("jid/include/jid.hrl").
 
+-type validator() ::
+        any | non_empty | non_negative | positive | module | {module, Prefix :: atom()}
+      | jid | domain | domain_template | url | ip_address | ip_mask | network_address | port
+      | filename | dirname | loglevel | pool_name | shaper | access_rule | {enum, list()}.
+
+-type section_validator() :: any | non_empty.
+
+-type list_validator() :: any | non_empty | unique | unique_non_empty.
+
+-export_type([validator/0, section_validator/0, list_validator/0]).
+
+-spec validate(mongoose_config_parser_toml:option_value(),
+               mongoose_config_spec:option_type(), validator()) -> any().
 validate(V, binary, domain) -> validate_binary_domain(V);
 validate(V, binary, non_empty) -> validate_non_empty_binary(V);
 validate(V, binary, {module, Prefix}) ->
@@ -38,11 +51,13 @@ validate(V, atom, non_empty) -> validate_non_empty_atom(V);
 validate(V, _, {enum, Values}) -> validate_enum(V, Values);
 validate(_V, _, any) -> ok.
 
+-spec validate_list([mongoose_config_parser_toml:config_part()], list_validator()) -> any().
 validate_list([_|_], non_empty) -> ok;
 validate_list(L = [_|_], unique_non_empty) -> validate_unique_items(L);
 validate_list(L, unique) -> validate_unique_items(L);
 validate_list(L, any) when is_list(L) -> ok.
 
+-spec validate_section([mongoose_config_parser_toml:config_part()], section_validator()) -> any().
 validate_section([_|_], non_empty) -> ok;
 validate_section(L, any) when is_list(L) -> ok.
 

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -126,7 +126,7 @@ start_module(Host, Module, Opts) ->
 
 start_module_for_host(Host, Module, Opts0) ->
     {links, LinksBefore} = erlang:process_info(self(), links),
-    Opts = clear_opts(Module, Opts0),
+    Opts = proplists:unfold(Opts0),
     set_module_opts_mnesia(Host, Module, Opts),
     ets:insert(ejabberd_modules, #ejabberd_module{module_host = {Module, Host}, opts = Opts}),
     try
@@ -472,20 +472,6 @@ get_module_proc(Host, Base) ->
 -spec is_loaded(Host :: binary(), Module :: atom()) -> boolean().
 is_loaded(Host, Module) ->
     ets:member(ejabberd_modules, {Module, Host}).
-
-
--spec clear_opts(atom(), list()) -> list().
-clear_opts(Module, Opts0) ->
-    Opts = proplists:unfold(Opts0),
-    %% the module has to be loaded,
-    %% otherwise the erlang:function_exported/3 returns false
-    code:ensure_loaded(Module),
-    case erlang:function_exported(Module, clean_opts, 1) of
-        true ->
-            Module:clean_opts(Opts);
-        _ ->
-            Opts
-    end.
 
 -spec get_deps(Host :: jid:server(), Module :: module(),
                Opts :: proplists:proplist()) -> module_deps_list().

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -32,7 +32,6 @@
 -export([start/2,
          stop/1,
          config_spec/0,
-         clean_opts/1,
          stream_feature_register/2,
          unauthenticated_iq_register/4,
          try_register/5,
@@ -110,15 +109,6 @@ process_welcome_message(KVs) ->
     Body = proplists:get_value(body, KVs, ""),
     Subject = proplists:get_value(subject, KVs, ""),
     {Subject, Body}.
-
-clean_opts(Opts) ->
-    lists:map(fun clean_opt/1, Opts).
-
-clean_opt({registration_watchers, Watchers}) ->
-    CleanWatchers = lists:map(fun mongoose_bin:string_to_binary/1, Watchers),
-    {registration_watchers, CleanWatchers};
-clean_opt(Item) ->
-    Item.
 
 stream_feature_register(Acc, _Host) ->
     [#xmlel{name = <<"register">>,


### PR DESCRIPTION
Add missing type specs, comments and exports.
Also: remove some obsolete code.

See the commit messages for more information.

