### PR TITLE
Less stringprepping in roster hooks

### DIFF
--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -420,7 +420,7 @@ rooms_in_rosters(Config) ->
                         distributed_helper:mim(),
                         mod_roster,
                         get_user_rosters_length,
-                        [AliceU, AliceS])
+                        [jid:make(AliceU, AliceS, <<>>)])
                 end, 1, #{time_left => timer:seconds(10)}),
             RosterResult = escalus:wait_for_stanza(Alice),
             escalus_assert:is_roster_result(RosterResult),

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -248,10 +248,10 @@ unsubscribe(LocalJID, RemoteJID) ->
     [jids_nick_subs_ask_grp()].
 get_roster(User, Server) ->
     UserJID = jid:make(User, Server, <<>>),
-    Acc = mongoose_acc:new(#{ location => ?LOCATION,
-                              lserver => UserJID#jid.lserver,
-                              element => undefined }),
-    Acc2 = mongoose_hooks:roster_get(Server, Acc, UserJID#jid.luser, Server),
+    Acc = mongoose_acc:new(#{location => ?LOCATION,
+                             lserver => UserJID#jid.lserver,
+                             element => undefined}),
+    Acc2 = mongoose_hooks:roster_get(Server, Acc, UserJID),
     Items = mongoose_acc:get(roster, items, [], Acc2),
     make_roster(Items).
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2054,12 +2054,10 @@ presence_track(Acc, StateData) ->
                                               StateData :: state()) -> mongoose_acc:t().
 process_presence_subscription_and_route(Acc, Type, StateData) ->
     From = mongoose_acc:from_jid(Acc),
-    User = StateData#state.user,
     Server = StateData#state.server,
     To = mongoose_acc:to_jid(Acc),
-    Acc1 = mongoose_hooks:roster_out_subscription(Server,
-                                                  Acc,
-                                                  User, To, Type),
+    Acc1 = mongoose_hooks:roster_out_subscription(
+             Server, Acc, From, To, Type),
     check_privacy_and_route(Acc1, jid:to_bare(From), StateData).
 
 -spec check_privacy_and_route(Acc :: mongoose_acc:t(),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -772,9 +772,9 @@ do_open_session(Acc, JID, StateData) ->
             end
     end.
 
-do_open_session_common(Acc, JID, #state{user = U, server = S} = NewStateData0) ->
+do_open_session_common(Acc, JID, #state{jid = JID, user = U, server = S} = NewStateData0) ->
     change_shaper(NewStateData0, JID),
-    Acc1 = mongoose_hooks:roster_get_subscription_lists(S, Acc, U),
+    Acc1 = mongoose_hooks:roster_get_subscription_lists(S, Acc, JID),
     {Fs, Ts, Pending} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc1),
     LJID = jid:to_lower(jid:to_bare(JID)),
     Fs1 = [LJID | Fs],
@@ -1978,7 +1978,7 @@ presence_update_to_available(true, Acc, _, NewPriority, From, Packet, StateData)
                   Acc3 = mongoose_hooks:roster_get_subscription_lists(
                                                  StateData#state.server,
                                                  Acc2,
-                                                 StateData#state.user),
+                                                 StateData#state.jid),
                   {_, _, Pending} = mongoose_acc:get(roster, subscription_lists,
                                                      {[], [], []}, Acc3),
                   Acc4 = resend_offline_messages(Acc3, StateData),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -38,7 +38,7 @@
          store_info/2,
          get_info/2,
          remove_info/2,
-         check_in_subscription/6,
+         check_in_subscription/5,
          bounce_offline_message/4,
          disconnect_removed_user/3,
          get_user_resources/1,
@@ -315,16 +315,14 @@ remove_info(JID, Key) ->
             end
     end.
 
--spec check_in_subscription(Acc, User, Server, JID, Type, Reason) -> any() | {stop, false} when
+-spec check_in_subscription(Acc, ToJID, FromJID, Type, Reason) -> any() | {stop, false} when
       Acc :: any(),
-      User :: jid:user(),
-      Server :: jid:server(),
-      JID :: jid:jid(),
+      ToJID :: jid:jid(),
+      FromJID :: jid:jid(),
       Type :: any(),
       Reason :: any().
-check_in_subscription(Acc, User, Server, _JID, _Type, _Reason) ->
-    JID = jid:make(User, Server, <<>>),
-    case ejabberd_auth:does_user_exist(JID) of
+check_in_subscription(Acc, ToJID, _FromJID, _Type, _Reason) ->
+    case ejabberd_auth:does_user_exist(ToJID) of
         true ->
             Acc;
         false ->
@@ -714,8 +712,7 @@ do_route_no_resource_presence_prv(From, To, Acc, Packet, Type, Reason) ->
     case is_privacy_allow(From, To, Acc, Packet) of
         true ->
             Res = mongoose_hooks:roster_in_subscription(To#jid.lserver,
-                                         Acc,
-                                         To#jid.user, To#jid.server, From, Type, Reason),
+                                         Acc, To, From, Type, Reason),
             mongoose_acc:get(hook, result, false, Res);
         false ->
             false

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -1083,10 +1083,10 @@ send_message(From, To, Mess) ->
 
 
 -spec is_jid_in_user_roster(jid:jid(), jid:jid()) -> boolean().
-is_jid_in_user_roster(#jid{lserver=LServer, luser=LUser},
+is_jid_in_user_roster(#jid{lserver = LServer} = ToJID,
                       #jid{} = RemJID) ->
     RemBareJID = jid:to_bare(RemJID),
-    {Subscription, _G} = mongoose_hooks:roster_get_jid_info(LServer, {none, []}, LUser, RemBareJID),
+    {Subscription, _G} = mongoose_hooks:roster_get_jid_info(LServer, {none, []}, ToJID, RemBareJID),
     Subscription == from orelse Subscription == both.
 
 

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -27,7 +27,7 @@
          roster_get/2,
          roster_set/4,
          roster_push/3,
-         roster_in_subscription/6,
+         roster_in_subscription/5,
          register_user/3,
          remove_user/3,
          privacy_iq_get/5,
@@ -167,14 +167,14 @@ roster_set(Acc, #jid{server = Server}, _, _) ->
     mongoose_metrics:update(Server, modRosterSets, 1),
     Acc.
 
--spec roster_in_subscription(term(), binary(), binary(), tuple(), atom(), term()) -> term().
-roster_in_subscription(Acc, _, Server, _, subscribed, _) ->
-    mongoose_metrics:update(Server, modPresenceSubscriptions, 1),
+-spec roster_in_subscription(term(), jid:jid(), jid:jid(), atom(), term()) -> term().
+roster_in_subscription(Acc, #jid{lserver = LServer}, _, subscribed, _) ->
+    mongoose_metrics:update(LServer, modPresenceSubscriptions, 1),
     Acc;
-roster_in_subscription(Acc, _, Server, _, unsubscribed, _) ->
-    mongoose_metrics:update(Server, modPresenceUnsubscriptions, 1),
+roster_in_subscription(Acc, #jid{lserver = LServer}, _, unsubscribed, _) ->
+    mongoose_metrics:update(LServer, modPresenceUnsubscriptions, 1),
     Acc;
-roster_in_subscription(Acc, _, _, _, _, _) ->
+roster_in_subscription(Acc, _, _, _, _) ->
     Acc.
 
 -spec roster_push(map(), jid:jid(), term()) -> metrics_notify_return().

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -156,9 +156,9 @@ xmpp_send_element(Acc, _El) ->
 
 %% Roster
 
--spec roster_get(list(), {_, jid:server()}) -> list().
-roster_get(Acc, {_, Server}) ->
-    mongoose_metrics:update(Server, modRosterGets, 1),
+-spec roster_get(list(), jid:jid()) -> list().
+roster_get(Acc, #jid{lserver = LServer}) ->
+    mongoose_metrics:update(LServer, modRosterGets, 1),
     Acc.
 
 -spec roster_set(Acc :: map(), JID :: jid:jid(), tuple(), tuple()) ->

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -494,17 +494,15 @@ decode_action(_) -> error.
 run_subscription(Type, CallerJid, OtherJid) ->
     StanzaType = atom_to_binary(Type, latin1),
     El = #xmlel{name = <<"presence">>, attrs = [{<<"type">>, StanzaType}]},
+    LServer = CallerJid#jid.lserver,
     Acc1 = mongoose_acc:new(#{ location => ?LOCATION,
                                from_jid => CallerJid,
                                to_jid => OtherJid,
-                               lserver => CallerJid#jid.lserver,
+                               lserver => LServer,
                                element => El }),
     % set subscription to
-    Server = CallerJid#jid.server,
-    LUser = CallerJid#jid.luser,
-    Acc2 = mongoose_hooks:roster_out_subscription(Server,
-                                                  Acc1,
-                                                  LUser, OtherJid, Type),
+    Acc2 = mongoose_hooks:roster_out_subscription(
+             LServer, Acc1, CallerJid, OtherJid, Type),
     ejabberd_router:route(CallerJid, OtherJid, Acc2),
     ok.
 

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -337,13 +337,12 @@ parse_from_to(F, T) ->
     end.
 
 list_contacts(Caller) ->
-    CallerJID = jid:from_binary(Caller),
+    CallerJID = #jid{lserver = LServer} = jid:from_binary(Caller),
     Acc0 = mongoose_acc:new(#{ location => ?LOCATION,
-                               lserver => CallerJID#jid.lserver,
+                               lserver => LServer,
                                element => undefined }),
     Acc1 = mongoose_acc:set(roster, show_full_roster, true, Acc0),
-    {User, Host} = jid:to_lus(CallerJID),
-    Acc2 = mongoose_hooks:roster_get(Host, Acc1, User, Host),
+    Acc2 = mongoose_hooks:roster_get(LServer, Acc1, CallerJID),
     Res = mongoose_acc:get(roster, items, Acc2),
     [roster_info(mod_roster:item_to_map(I)) || I <- Res].
 

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -380,12 +380,12 @@ get_sm_items(empty, From, To, _Node, _Lang) ->
 
 
 -spec is_presence_subscribed(jid:jid(), jid:jid()) -> boolean().
-is_presence_subscribed(#jid{luser = LFromUser, lserver = LFromServer} = _From,
+is_presence_subscribed(#jid{luser = LFromUser, lserver = LFromServer} = FromJID,
                        #jid{luser = LToUser, lserver = LToServer} = _To) ->
     A = mongoose_acc:new(#{ location => ?LOCATION,
                             lserver => LFromServer,
                             element => undefined }),
-    A2 = mongoose_hooks:roster_get(LFromServer, A, LFromUser, LFromServer),
+    A2 = mongoose_hooks:roster_get(LFromServer, A, FromJID),
     Roster = mongoose_acc:get(roster, items, [], A2),
     lists:any(fun({roster, _, _, JID, _, S, _, _, _, _}) ->
                       {TUser, TServer} = jid:to_lus(JID),

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -150,9 +150,7 @@ process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
     User = To#jid.luser,
     Server = To#jid.lserver,
     {Subscription, _Groups} =
-    mongoose_hooks:roster_get_jid_info(Server,
-                                       {none, []},
-                                       User, From),
+        mongoose_hooks:roster_get_jid_info(Server, {none, []}, To, From),
     MutualSubscription = Subscription == both,
     RequesterSubscribedToTarget = Subscription == from,
     QueryingSameUsersLast = (From#jid.luser == To#jid.luser) and

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -323,7 +323,7 @@ check_packet(Acc, User, Server,
     {Subscription, Groups} =
         case NeedDb of
             true ->
-                roster_get_jid_info(Server, User, LJID);
+                roster_get_jid_info(Server, jid:make(User, Server, <<>>), LJID);
             false ->
                 {[], []}
         end,
@@ -666,10 +666,10 @@ broadcast_privacy_list(LUser, LServer, Name, UserList) ->
 broadcast_privacy_list_packet(Name, UserList) ->
     {broadcast, {privacy_list, UserList, Name}}.
 
-roster_get_jid_info(Host, User, LJID) ->
+roster_get_jid_info(Host, ToJID, LJID) ->
     mongoose_hooks:roster_get_jid_info(Host,
                                        {none, []},
-                                       User, LJID).
+                                       ToJID, LJID).
 
 config_metrics(Host) ->
     OptsToReport = [{backend, mnesia}], %list of tuples {option, defualt_value}

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -40,7 +40,7 @@
          handle_info/2, terminate/2, code_change/3]).
 
 -export([get_user_roster/2, get_subscription_lists/2,
-         get_jid_info/4, process_item/2, in_subscription/5,
+         get_jid_info/3, process_item/2, in_subscription/5,
          out_subscription/4]).
 
 -export([config_change/4]).
@@ -161,13 +161,10 @@ get_subscription_lists(Acc, #jid{lserver = LServer} = JID) ->
     NewLists = {lists:usort(SRJIDs ++ F), lists:usort(SRJIDs ++ T), P},
     mongoose_acc:set(roster, subscription_lists, NewLists, Acc).
 
-get_jid_info({Subscription, Groups}, User, Server, JID) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    US = {LUser, LServer},
-    {U1, S1, _} = jid:to_lower(JID),
-    US1 = {U1, S1},
-    SRUsers = get_user_to_groups_map(US, false),
+get_jid_info({Subscription, Groups}, ToJID, JID) ->
+    ToUS = jid:to_lus(ToJID),
+    US1 = jid:to_lus(JID),
+    SRUsers = get_user_to_groups_map(ToUS, false),
     case dict:find(US1, SRUsers) of
         {ok, GroupNames} ->
             NewGroups = case Groups of

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -107,7 +107,8 @@ stop(Host) ->
 %%--------------------------------------------------------------------
 %% Hooks
 %%--------------------------------------------------------------------
-get_user_roster(Acc, {U, S} = US) ->
+get_user_roster(Acc, #jid{luser = U, lserver = S} = JID) ->
+    US = jid:to_lus(JID),
     Items = mongoose_acc:get(roster, items, [], Acc),
     SRUsers = get_user_to_groups_map(US, true),
     {NewItems1, SRUsersRest} =

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -41,7 +41,7 @@
 
 -export([get_user_roster/2, get_subscription_lists/3,
          get_jid_info/4, process_item/2, in_subscription/5,
-         out_subscription/5]).
+         out_subscription/4]).
 
 -export([config_change/4]).
 
@@ -196,13 +196,12 @@ in_subscription(Acc, ToJID, FromJID, Type, _Reason) ->
     end.
 
 -spec out_subscription(Acc:: mongoose_acc:t(),
-                      User :: binary(),
-                      Server :: binary(),
-                      JID ::jid:jid(),
-                      Type :: mod_roster:sub_presence()) ->
+                       FromJID :: jid:jid(),
+                       ToJID ::jid:jid(),
+                       Type :: mod_roster:sub_presence()) ->
     mongoose_acc:t() | {stop, mongoose_acc:t()}.
-out_subscription(Acc, User, Server, JID, Type) ->
-    case process_subscription(out, jid:make(User, Server, <<>>), JID, Type) of
+out_subscription(Acc, FromJID, ToJID, Type) ->
+    case process_subscription(out, FromJID, ToJID, Type) of
         stop ->
             {stop, Acc};
         {stop, false} ->

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -39,7 +39,7 @@
 -export([init/1, handle_call/3, handle_cast/2,
          handle_info/2, terminate/2, code_change/3]).
 
--export([get_user_roster/2, get_subscription_lists/3,
+-export([get_user_roster/2, get_subscription_lists/2,
          get_jid_info/4, process_item/2, in_subscription/5,
          out_subscription/4]).
 
@@ -149,11 +149,9 @@ process_item(RosterItem, _Host) ->
         _ -> RosterItem#roster{subscription = both, ask = none}
     end.
 
-get_subscription_lists(Acc, User, Server) ->
+get_subscription_lists(Acc, #jid{lserver = LServer} = JID) ->
     {F, T, P} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc),
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    US = {LUser, LServer},
+    US = jid:to_lus(JID),
     DisplayedGroups = get_user_displayed_groups(US),
     SRUsers = lists:usort(lists:flatmap(fun (Group) ->
                                                 get_group_users(LServer, Group)

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -68,7 +68,7 @@
          unset_presence_hook/5,
          xmpp_bounce_message/2]).
 
--export([roster_get/4,
+-export([roster_get/3,
          roster_get_jid_info/4,
          roster_get_subscription_lists/3,
          roster_get_versioning_feature/2,
@@ -781,14 +781,13 @@ xmpp_bounce_message(Server, Acc) ->
 %% Roster related hooks
 
 %%% @doc The `roster_get' hook is called to extract a user's roster.
--spec roster_get(LServer, Acc, User, UserServer) -> Result when
+-spec roster_get(LServer, Acc, JID) -> Result when
     LServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
-    User :: jid:luser(),
-    UserServer :: jid:lserver(),
+    JID :: jid:jid(),
     Result :: mongoose_acc:t().
-roster_get(LServer, Acc, User, UserServer) ->
-    ejabberd_hooks:run_fold(roster_get, LServer, Acc, [{User, UserServer}]).
+roster_get(LServer, Acc, JID) ->
+    ejabberd_hooks:run_fold(roster_get, LServer, Acc, [JID]).
 
 %%% @doc The `roster_groups' hook is called to extract roster groups.
 -spec roster_groups(LServer, Acc) -> Result when

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -816,13 +816,13 @@ roster_get_jid_info(LServer, InitialValue, LUser, RemBareJID) ->
                             [LUser, LServer, RemBareJID]).
 
 %%% @doc The `roster_get_subscription_lists' hook is called to extract user's subscription list.
--spec roster_get_subscription_lists(Server, Acc, User) -> Result when
+-spec roster_get_subscription_lists(Server, Acc, JID) -> Result when
     Server :: jid:server(),
     Acc ::mongoose_acc:t(),
-    User :: jid:user(),
+    JID :: jid:jid(),
     Result :: mongoose_acc:t().
-roster_get_subscription_lists(Server, Acc, User) ->
-    ejabberd_hooks:run_fold(roster_get_subscription_lists, Server, Acc, [User, Server]).
+roster_get_subscription_lists(Server, Acc, JID) ->
+    ejabberd_hooks:run_fold(roster_get_subscription_lists, Server, Acc, [JID]).
 
 %%% @doc The `roster_get_versioning_feature' hook is called to determine if roster versioning is enabled.
 -spec roster_get_versioning_feature(Server, Acc) -> Result when

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -805,15 +805,15 @@ roster_groups(LServer, Acc) ->
 %%% * RemoteBareJID, a bare JID of the other user.
 %%%
 %%% The arguments and the return value types correspond to the following spec.
--spec roster_get_jid_info(LServer, InitialValue, LUser, RemoteJID) -> Result when
-    LServer :: jid:lserver(),
+-spec roster_get_jid_info(LServer, InitialValue, ToJID, RemoteJID) -> Result when
+      LServer :: jid:lserver(),
       InitialValue :: {mod_roster:subscription_state(), []},
-      LUser :: jid:luser(),
+      ToJID :: jid:jid(),
       RemoteJID :: jid:jid() | jid:simple_jid(),
       Result :: {mod_roster:subscription_state(), [binary()]}.
-roster_get_jid_info(LServer, InitialValue, LUser, RemBareJID) ->
+roster_get_jid_info(LServer, InitialValue, ToJID, RemBareJID) ->
     ejabberd_hooks:run_fold(roster_get_jid_info, LServer, InitialValue,
-                            [LUser, LServer, RemBareJID]).
+                            [ToJID, RemBareJID]).
 
 %%% @doc The `roster_get_subscription_lists' hook is called to extract user's subscription list.
 -spec roster_get_subscription_lists(Server, Acc, JID) -> Result when

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -73,7 +73,7 @@
          roster_get_subscription_lists/3,
          roster_get_versioning_feature/2,
          roster_groups/2,
-         roster_in_subscription/7,
+         roster_in_subscription/6,
          roster_out_subscription/5,
          roster_process_item/2,
          roster_push/4,
@@ -834,21 +834,20 @@ roster_get_versioning_feature(Server, Acc) ->
                             Server, Acc, [Server]).
 
 %%% @doc The `roster_in_subscription' hook is called to determine if a subscription presence is routed to a user.
--spec roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) -> Result when
+-spec roster_in_subscription(LServer, Acc, To, From, Type, Reason) -> Result when
     LServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
-    User :: jid:user(),
-    Server :: jid:server(),
+    To :: jid:jid(),
     From :: jid:jid(),
     Type :: mod_roster:sub_presence(),
     Reason :: any(),
     Result :: mongoose_acc:t().
-roster_in_subscription(LServer, Acc, User, Server, From, Type, Reason) ->
+roster_in_subscription(LServer, Acc, To, From, Type, Reason) ->
     ejabberd_hooks:run_fold(
         roster_in_subscription,
         LServer,
         Acc,
-        [User, Server, From, Type, Reason]).
+        [To, From, Type, Reason]).
 
 %%% @doc The `roster_out_subscription' hook is called when a user sends out subscription.
 -spec roster_out_subscription(Server, Acc, User, To, Type) -> Result when

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -850,18 +850,18 @@ roster_in_subscription(LServer, Acc, To, From, Type, Reason) ->
         [To, From, Type, Reason]).
 
 %%% @doc The `roster_out_subscription' hook is called when a user sends out subscription.
--spec roster_out_subscription(Server, Acc, User, To, Type) -> Result when
+-spec roster_out_subscription(Server, Acc, From, To, Type) -> Result when
     Server :: jid:server(),
     Acc :: mongoose_acc:t(),
-    User :: jid:user(),
+    From :: jid:jid(),
     To :: jid:jid(),
     Type :: mod_roster:sub_presence(),
     Result :: mongoose_acc:t().
-roster_out_subscription(Server, Acc, User, To, Type) ->
+roster_out_subscription(Server, Acc, From, To, Type) ->
     ejabberd_hooks:run_fold(roster_out_subscription,
                             Server,
                             Acc,
-                            [User, Server, To, Type]).
+                            [From, To, Type]).
 
 %%% @doc The `roster_process_item' hook is called when a user's roster is set.
 -spec roster_process_item(LServer, Item) -> Result when

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -800,8 +800,7 @@ roster_groups(LServer, Acc) ->
 %%% @doc The `roster_get_jid_info' hook is called to determine the subscription state between a given pair of users.
 %%% The hook handlers need to expect following arguments:
 %%% * Acc with an initial value of {none, []},
-%%% * LUser, a stringprepd username part of the roster's owner,
-%%% * LServer, a stringprepd server part of the roster's owner (same value as HookServer),
+%%% * ToJID, a stringprepped roster's owner's jid
 %%% * RemoteBareJID, a bare JID of the other user.
 %%%
 %%% The arguments and the return value types correspond to the following spec.
@@ -822,7 +821,7 @@ roster_get_jid_info(LServer, InitialValue, ToJID, RemBareJID) ->
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
 roster_get_subscription_lists(Server, Acc, JID) ->
-    ejabberd_hooks:run_fold(roster_get_subscription_lists, Server, Acc, [JID]).
+    ejabberd_hooks:run_fold(roster_get_subscription_lists, Server, Acc, [jid:to_bare(JID)]).
 
 %%% @doc The `roster_get_versioning_feature' hook is called to determine if roster versioning is enabled.
 -spec roster_get_versioning_feature(Server, Acc) -> Result when
@@ -847,7 +846,7 @@ roster_in_subscription(LServer, Acc, To, From, Type, Reason) ->
         roster_in_subscription,
         LServer,
         Acc,
-        [To, From, Type, Reason]).
+        [jid:to_bare(To), From, Type, Reason]).
 
 %%% @doc The `roster_out_subscription' hook is called when a user sends out subscription.
 -spec roster_out_subscription(Server, Acc, From, To, Type) -> Result when
@@ -861,7 +860,7 @@ roster_out_subscription(Server, Acc, From, To, Type) ->
     ejabberd_hooks:run_fold(roster_out_subscription,
                             Server,
                             Acc,
-                            [From, To, Type]).
+                            [jid:to_bare(From), To, Type]).
 
 %%% @doc The `roster_process_item' hook is called when a user's roster is set.
 -spec roster_process_item(LServer, Item) -> Result when

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -311,9 +311,9 @@ remove_user(Acc, User, Server) ->
             Acc
     end.
 
--spec add_rooms_to_roster(Acc :: mongoose_acc:t(), UserUS :: jid:simple_bare_jid()) ->
-    mongoose_acc:t().
-add_rooms_to_roster(Acc, UserUS) ->
+-spec add_rooms_to_roster(Acc :: mongoose_acc:t(), UserJID :: jid:jid()) -> mongoose_acc:t().
+add_rooms_to_roster(Acc, UserJID) ->
+    UserUS = jid:to_lus(UserJID),
     Items = mongoose_acc:get(roster, items, [], Acc),
     RoomList = mod_muc_light_db_backend:get_user_rooms(UserUS, undefined),
     Info = get_rooms_info(lists:sort(RoomList)),

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -65,7 +65,7 @@
 
 %% exports for hooks
 -export([presence_probe/4, caps_recognised/4,
-         in_subscription/6, out_subscription/5,
+         in_subscription/5, out_subscription/5,
          on_user_offline/5, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
          disco_sm_identity/5,
@@ -818,16 +818,15 @@ out_subscription(Acc, _, _, _, _) ->
     Acc.
 
 -spec in_subscription(Acc:: mongoose_acc:t(),
-                      User :: binary(),
-                      Server :: binary(),
-                      JID ::jid:jid(),
+                      ToJID :: jid:jid(),
+                      OwnerJID ::jid:jid(),
                       Type :: mod_roster:sub_presence(),
                       _:: any()) ->
     mongoose_acc:t().
-in_subscription(Acc, User, Server, Owner, unsubscribed, _) ->
-    unsubscribe_user(jid:make(User, Server, <<>>), Owner),
+in_subscription(Acc, ToJID, OwnerJID, unsubscribed, _) ->
+    unsubscribe_user(ToJID, OwnerJID),
     Acc;
-in_subscription(Acc, _, _, _, _, _) ->
+in_subscription(Acc, _, _, _, _) ->
     Acc.
 
 unsubscribe_user(Entity, Owner) ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3242,9 +3242,10 @@ get_roster_info(_, _, {<<>>, <<>>, _}, _) ->
     {false, false};
 get_roster_info(OwnerUser, OwnerServer, {SubscriberUser, SubscriberServer, _}, AllowedGroups) ->
     LJID = {SubscriberUser, SubscriberServer, <<>>},
-    {Subscription, Groups} = mongoose_hooks:roster_get_jid_info(OwnerServer,
-                                                                {none, []},
-                                                                OwnerUser, LJID),
+    {Subscription, Groups} = mongoose_hooks:roster_get_jid_info(
+                               OwnerServer,
+                               {none, []},
+                               jid:make(OwnerUser, OwnerServer, <<>>), LJID),
     PresenceSubscription = Subscription == both orelse
         Subscription == from orelse
         {OwnerUser, OwnerServer} == {SubscriberUser, SubscriberServer},

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -65,7 +65,7 @@
 
 %% exports for hooks
 -export([presence_probe/4, caps_recognised/4,
-         in_subscription/5, out_subscription/5,
+         in_subscription/5, out_subscription/4,
          on_user_offline/5, remove_user/3,
          disco_local_identity/5, disco_local_features/5,
          disco_sm_identity/5,
@@ -799,22 +799,20 @@ notify_send_loop(ServerHost, Action) ->
 %% subscription hooks handling functions
 %%
 
--spec out_subscription(Acc:: mongoose_acc:t(),
-                       User :: binary(),
-                       Server :: binary(),
-                       JID ::jid:jid(),
+-spec out_subscription(Acc :: mongoose_acc:t(),
+                       FromJID :: jid:jid(),
+                       ToJID :: jid:jid(),
                        Type :: mod_roster:sub_presence()) ->
     mongoose_acc:t().
-out_subscription(Acc, User, Server, JID, subscribed) ->
-    Owner = jid:make(User, Server, <<>>),
-    {PUser, PServer, PResource} = jid:to_lower(JID),
+out_subscription(Acc, #jid{lserver = LServer} = FromJID, ToJID, subscribed) ->
+    {PUser, PServer, PResource} = jid:to_lower(ToJID),
     PResources = case PResource of
                      <<>> -> user_resources(PUser, PServer);
                      _ -> [PResource]
                  end,
-    notify_send_loop(Server, {send_last_items_from_owner, Owner, {PUser, PServer, PResources}}),
+    notify_send_loop(LServer, {send_last_items_from_owner, FromJID, {PUser, PServer, PResources}}),
     Acc;
-out_subscription(Acc, _, _, _, _) ->
+out_subscription(Acc, _, _, _) ->
     Acc.
 
 -spec in_subscription(Acc:: mongoose_acc:t(),

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -139,7 +139,7 @@ get_roster_old(User) ->
     Acc = mongoose_acc:new(#{ location => ?LOCATION,
                               lserver => <<"localhost">>,
                               element => undefined }),
-    Acc1 = mod_roster:get_user_roster(Acc, {User, host()}),
+    Acc1 = mod_roster:get_user_roster(Acc, jid:make(User, host(), <<>>)),
     mongoose_acc:get(roster, items, Acc1).
 
 get_full_roster() ->
@@ -147,7 +147,7 @@ get_full_roster() ->
                               lserver => <<"localhost">>,
                               element => undefined }),
     Acc1 = mongoose_acc:set(roster, show_full_roster, true, Acc0),
-    Acc2 = mod_roster:get_user_roster(Acc1, {a(), host()}),
+    Acc2 = mod_roster:get_user_roster(Acc1, alice_jid()),
     mongoose_acc:get(roster, items, Acc2).
 
 assert_state_old(Subscription, Ask) ->


### PR DESCRIPTION
This PR, like several others I've done in the past, aim to reduce the redundancy of stringprepping again and again different blocks of a jid all over the MIM code, and instead taking advantage of the `jid` record. More type-safety, less code, and a tiny slightly bit more performance.