### PR TITLE
Correctly detect minio in CI

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -295,7 +295,7 @@ init_per_testcase(delete_old_users, Config) ->
     end;
 init_per_testcase(CaseName, Config) when CaseName == real_upload_without_content_type;
                                          CaseName == real_upload_with_content_type ->
-    case is_minio_running(Config) of
+    case mongoose_helper:should_minio_be_running(Config) of
         true -> escalus:init_per_testcase(CaseName, Config);
         false -> {skip, "minio is not running"}
     end;
@@ -391,15 +391,6 @@ signed_headers_regex(false, "") -> ?S3_SIGNED_HEADERS;
 signed_headers_regex(false, _)  -> ?S3_SIGNED_HEADERS_WITH_CONTENT_TYPE;
 signed_headers_regex(true, "")  -> ?S3_SIGNED_HEADERS_WITH_ACL;
 signed_headers_regex(true, _)   -> ?S3_SIGNED_HEADERS_WITH_CONTENT_TYPE_AND_ACL.
-
-is_minio_running(Config) ->
-    case proplists:get_value(preset, Config, undefined) of
-        undefined -> false;
-        Preset ->
-            PresetAtom = list_to_existing_atom(Preset),
-            DBs = ct:get_config({ejabberd_presets, PresetAtom, dbs}, []),
-            lists:member(minio, DBs)
-    end.
 
 real_upload(Config, ContentType) ->
     #{node := Node} = mim(),

--- a/big_tests/tests/mod_http_upload_SUITE.erl
+++ b/big_tests/tests/mod_http_upload_SUITE.erl
@@ -105,14 +105,14 @@ init_per_group(unset_size, Config) ->
     dynamic_modules:start(host(), mod_http_upload, [{max_file_size, undefined} | ?S3_OPTS]),
     escalus:create_users(Config, escalus:get_users([bob]));
 init_per_group(real_upload_without_acl, Config) ->
-    case is_minio_running(Config) of
+    case mongoose_helper:should_minio_be_running(Config) of
         true ->
             dynamic_modules:start(host(), mod_http_upload, ?MINIO_OPTS(false)),
             escalus:create_users(Config, escalus:get_users([bob]));
         false -> {skip, "minio is not running"}
     end;
 init_per_group(real_upload_with_acl, Config) ->
-    case is_minio_running(Config) of
+    case mongoose_helper:should_minio_be_running(Config) of
         true ->
             dynamic_modules:start(host(), mod_http_upload, ?MINIO_OPTS(true)),
             [{with_acl, true} | escalus:create_users(Config, escalus:get_users([bob]))];
@@ -328,15 +328,6 @@ escapes_urls_once(Config) ->
 %%--------------------------------------------------------------------
 %% Test helpers
 %%--------------------------------------------------------------------
-is_minio_running(Config) ->
-    case proplists:get_value(preset, Config, undefined) of
-        undefined -> false;
-        Preset ->
-            PresetAtom = list_to_existing_atom(Preset),
-            DBs = ct:get_config({ejabberd_presets, PresetAtom, dbs}, []),
-            lists:member(minio, DBs)
-    end.
-
 create_slot_request_stanza(Server, Filename, Size, ContentType) when is_integer(Size) ->
     create_slot_request_stanza(Server, Filename, integer_to_binary(Size), ContentType);
 create_slot_request_stanza(Server, Filename, BinSize, ContentType) ->

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -40,6 +40,7 @@
 -export([set_store_password/1]).
 -export([get_listener_opts/2]).
 -export([restart_listener_with_opts/3]).
+-export([should_minio_be_running/1]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
@@ -466,4 +467,13 @@ restart_listener_with_opts(Spec, Listener, NewOpts) ->
     {PortIPProto, Module, _Opts} = Listener,
     rpc(Spec, ejabberd_listener, stop_listener, [PortIPProto, Module]),
     rpc(Spec, ejabberd_listener, start_listener, [PortIPProto, Module, NewOpts]).
+
+should_minio_be_running(Config) ->
+    case proplists:get_value(preset, Config, undefined) of
+        undefined -> false;
+        Preset ->
+            PresetAtom = list_to_existing_atom(Preset),
+            DBs = ct:get_config({presets, toml, PresetAtom, dbs}, []),
+            lists:member(minio, DBs)
+    end.
 


### PR DESCRIPTION
Big tests are checking if minio should be running, that is, if the preset in the ct specs says it should, and not if it is _actually_ running. And the way this was checked wasn't correct, the keyword to check for was changed and also some nesting was added, during the toml epic.

We can see that minio wasn't being tested here: https://circleci-mim-results.s3.eu-central-1.amazonaws.com/branch/master/42088/internal_mnesia.23.0.3-1/big/ct_run.test@default-85d626ba-85ec-463e-892e-37d6f216922c.2021-01-05_15.00.49/big_tests.tests.mod_http_upload_SUITE.logs/run.2021-01-05_15.08.13/suite.log.html