### PR TITLE
Fixed the name of the protocol variable

### DIFF
--- a/doc/authentication-methods/anonymous.md
+++ b/doc/authentication-methods/anonymous.md
@@ -14,7 +14,7 @@ When set to true, allows multiple connections from the same JID using the `anony
 ### `auth.anonymous.protocol`
 * **Syntax:** string, one of `"sasl_anon"`, `"login_anon"`, `"both"`
 * **Default:** `sasl_anon`
-* **Example:** `anonymous_protocol = "both"`
+* **Example:** `protocol = "both"`
 
 Specifies the SASL mechanisms supported by the `anonymous` authentication method:
 

--- a/doc/authentication-methods/anonymous.md
+++ b/doc/authentication-methods/anonymous.md
@@ -30,5 +30,5 @@ Specifies the SASL mechanisms supported by the `anonymous` authentication method
 
   [auth.anonymous]
     allow_multiple_connections = true
-    anonymous_protocol = "both"
+    protocol = "both"
 ```


### PR DESCRIPTION
Fixed the name of the ``protocol`` variable in the example.

