### PR TITLE
validate mod_event_pusher_push.virtual_pubsub_hosts properly

### DIFF
--- a/src/config/mongoose_config_validator.erl
+++ b/src/config/mongoose_config_validator.erl
@@ -11,7 +11,8 @@
 -type validator() ::
         any | non_empty | non_negative | positive | module | {module, Prefix :: atom()}
       | jid | domain | domain_template | url | ip_address | ip_mask | network_address | port
-      | filename | dirname | loglevel | pool_name | shaper | access_rule | {enum, list()}.
+      | filename | dirname | loglevel | pool_name | shaper | access_rule | {enum, list()}
+      | {domain_template, string()}.
 
 -type section_validator() :: any | non_empty.
 
@@ -33,7 +34,8 @@ validate(V, int_or_infinity, non_negative) -> validate_non_negative_integer_or_i
 validate(V, int_or_infinity, positive) -> validate_positive_integer_or_infinity(V);
 validate(V, string, url) -> validate_url(V);
 validate(V, string, domain) -> validate_domain(V);
-validate(V, string, domain_template) -> validate_domain_template(V);
+validate(V, string, {domain_template, Pattern}) -> validate_domain_template(V, Pattern);
+validate(V, string, domain_template) -> validate_domain_template(V, "@HOST@");
 validate(V, string, ip_address) -> validate_ip_address(V);
 validate(V, string, ip_mask) -> validate_ip_mask_string(V);
 validate(V, string, network_address) -> validate_network_address(V);
@@ -141,8 +143,8 @@ validate_binary_domain(Domain) when is_binary(Domain) ->
     #jid{luser = <<>>, lresource = <<>>} = jid:from_binary(Domain),
     validate_domain_res(binary_to_list(Domain)).
 
-validate_domain_template(Domain) ->
-    validate_binary_domain(gen_mod:make_subhost(Domain, <<"example.com">>)).
+validate_domain_template(Domain, Pattern) ->
+    validate_binary_domain(re:replace(Domain, Pattern, <<"example.com">>, [{return, binary}])).
 
 validate_url(Url) ->
     validate_non_empty_string(Url).

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -118,7 +118,7 @@ config_spec() ->
                  <<"plugin_module">> => #option{type = atom,
                                                 validate = module},
                  <<"virtual_pubsub_hosts">> => #list{items = #option{type = string,
-                                                                     validate = domain_template}}
+                                                                     validate = {domain_template, "@HOSTS@"}}}
                 }
       }.
 

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -427,7 +427,7 @@ process_sm_iq(From, To, Acc, #iq{type = set, sub_el = VCARD} = IQ) ->
             vcard_error(IQ, mongoose_xmpp_errors:not_allowed())
     end,
     {Acc, Res};
-process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
+process_sm_iq(_, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
     #jid{luser = LUser, lserver = LServer} = To,
     Res = try mod_vcard_backend:get_vcard(LUser, LServer) of
         {ok, VCARD} ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1724,6 +1724,8 @@ mod_event_pusher_push(_Config) ->
          T(#{<<"plugin_module">> => <<"mod_event_pusher_push_plugin_defaults">>})),
     ?eqf(M([{virtual_pubsub_hosts, ["host1", "host2"]}]),
          T(#{<<"virtual_pubsub_hosts">> => [<<"host1">>, <<"host2">>]})),
+    ?eqf(M([{virtual_pubsub_hosts, ["pubsub.@HOSTS@"]}]),
+         T(#{<<"virtual_pubsub_hosts">> => [<<"pubsub.@HOSTS@">>]})),
     ?errf(T(#{<<"backend">> => <<"redis">>})),
     ?errf(T(#{<<"wpool">> => true})),
     ?errf(T(#{<<"wpool">> => #{<<"workers">> => <<"500">>}})),


### PR DESCRIPTION
In case of `@HOSTS@` wildcard usage, there were validation errors reported. For more details, please see [MIM-1330](https://erlangsolutions.atlassian.net/browse/MIM-1330) description.