### PR TITLE
Less stringprepping in privacy modules

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2108,7 +2108,7 @@ privacy_check_packet(#xmlel{} = Packet, From, To, Dir, StateData) ->
 privacy_check_packet(Acc, To, Dir, StateData) ->
     mongoose_privacy:privacy_check_packet(Acc,
                                           StateData#state.server,
-                                          StateData#state.user,
+                                          StateData#state.jid,
                                           StateData#state.privacy_list,
                                           To,
                                           Dir).
@@ -2122,7 +2122,7 @@ privacy_check_packet(Acc, To, Dir, StateData) ->
 privacy_check_packet(Acc, Packet, From, To, Dir, StateData) ->
     mongoose_privacy:privacy_check_packet({Acc, Packet},
                                           StateData#state.server,
-                                          StateData#state.user,
+                                          StateData#state.jid,
                                           StateData#state.privacy_list,
                                           From,
                                           To,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -772,14 +772,14 @@ do_open_session(Acc, JID, StateData) ->
             end
     end.
 
-do_open_session_common(Acc, JID, #state{jid = JID, user = U, server = S} = NewStateData0) ->
+do_open_session_common(Acc, JID, #state{jid = JID, server = S} = NewStateData0) ->
     change_shaper(NewStateData0, JID),
     Acc1 = mongoose_hooks:roster_get_subscription_lists(S, Acc, JID),
     {Fs, Ts, Pending} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc1),
     LJID = jid:to_lower(jid:to_bare(JID)),
     Fs1 = [LJID | Fs],
     Ts1 = [LJID | Ts],
-    PrivList = mongoose_hooks:privacy_get_user_list(S, #userlist{}, U),
+    PrivList = mongoose_hooks:privacy_get_user_list(S, #userlist{}, JID),
     SID = ejabberd_sm:make_new_sid(),
     Conn = get_conn_type(NewStateData0),
     Info = [{ip, NewStateData0#state.ip}, {conn, Conn},

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -802,9 +802,8 @@ do_route_offline(_, _, _, _, Acc, _) ->
       Acc :: mongoose_acc:t(),
       Packet :: exml:element() | mongoose_acc:t().
 is_privacy_allow(From, To, Acc, Packet) ->
-    User = To#jid.user,
     Server = To#jid.server,
-    PrivacyList = mongoose_hooks:privacy_get_user_list(Server, #userlist{}, User),
+    PrivacyList = mongoose_hooks:privacy_get_user_list(Server, #userlist{}, To),
     is_privacy_allow(From, To, Acc, Packet, PrivacyList).
 
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -816,10 +816,8 @@ is_privacy_allow(From, To, Acc, Packet) ->
       Packet :: exml:element(),
       PrivacyList :: mongoose_privacy:userlist().
 is_privacy_allow(_From, To, Acc, _Packet, PrivacyList) ->
-    User = To#jid.user,
     Server = To#jid.lserver,
-    {_, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, User, PrivacyList,
-                                                     To, in),
+    {_, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, To, PrivacyList, To, in),
     allow == Res.
 
 

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -32,7 +32,7 @@
          remove_user/3,
          privacy_iq_get/5,
          privacy_iq_set/4,
-         privacy_check_packet/6,
+         privacy_check_packet/5,
          privacy_list_push/5
         ]).
 
@@ -230,10 +230,9 @@ privacy_list_push(Acc, _From, #jid{server = Server} = _To, _Broadcast, SessionCo
 
 
 -spec privacy_check_packet(Acc :: mongoose_acc:t(),
-                          binary(),
-                          Server :: jid:server(),
+                          JID :: jid:jid(),
                           term(), term(), term()) -> mongoose_acc:t().
-privacy_check_packet(Acc, _, Server, _, {_, _, _, _}, _) ->
+privacy_check_packet(Acc, #jid{lserver = Server}, _, {_, _, _, _}, _) ->
     mongoose_metrics:update(Server, modPrivacyStanzaAll, 1),
     case mongoose_acc:get(privacy, check, allow, Acc) of
         deny ->

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -147,7 +147,6 @@ get_node_uptime() ->
 process_sm_iq(_From, _To, Acc, #iq{type = set, sub_el = SubEl} = IQ) ->
     {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:not_allowed()]}};
 process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
-    User = To#jid.luser,
     Server = To#jid.lserver,
     {Subscription, _Groups} =
         mongoose_hooks:roster_get_jid_info(Server, {none, []}, To, From),
@@ -161,7 +160,7 @@ process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
                                                                   #userlist{},
                                                                   To),
             ok,
-            {Acc1, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, User,
+            {Acc1, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, To,
                                                              UserListRecord, To, From,
                                                              out),
             {Acc1, make_response(IQ, SubEl, To, Res)};

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -159,7 +159,7 @@ process_sm_iq(From, To, Acc, #iq{type = get, sub_el = SubEl} = IQ) ->
         true ->
             UserListRecord = mongoose_hooks:privacy_get_user_list(Server,
                                                                   #userlist{},
-                                                                  User),
+                                                                  To),
             ok,
             {Acc1, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, User,
                                                              UserListRecord, To, From,

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -35,7 +35,7 @@
          process_iq_set/4,
          process_iq_get/5,
          get_user_list/2,
-         check_packet/6,
+         check_packet/5,
          remove_user/3,
          updated_list/3]).
 
@@ -308,9 +308,9 @@ get_user_list(_, #jid{luser = LUser, lserver = LServer}) ->
 %% From is the sender, To is the destination.
 %% If Dir = out, User@Server is the sender account (From).
 %% If Dir = in, User@Server is the destination account (To).
-check_packet(Acc, _User, _Server, #userlist{list = []}, _, _Dir) ->
+check_packet(Acc, _JID, #userlist{list = []}, _, _Dir) ->
     mongoose_acc:set(hook, result, allow, Acc);
-check_packet(Acc, User, Server,
+check_packet(Acc, #jid{lserver = LServer} = JID,
              #userlist{list = List, needdb = NeedDb},
              {From, To, Name, Type}, Dir) ->
     PType = packet_directed_type(Dir, packet_type(Name, Type)),
@@ -321,7 +321,7 @@ check_packet(Acc, User, Server,
     {Subscription, Groups} =
         case NeedDb of
             true ->
-                roster_get_jid_info(Server, jid:make(User, Server, <<>>), LJID);
+                roster_get_jid_info(LServer, JID, LJID);
             false ->
                 {[], []}
         end,

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -34,7 +34,7 @@
          stop/1,
          process_iq_set/4,
          process_iq_get/5,
-         get_user_list/3,
+         get_user_list/2,
          check_packet/6,
          remove_user/3,
          updated_list/3]).
@@ -296,9 +296,7 @@ is_item_needdb(#listitem{type = subscription}) -> true;
 is_item_needdb(#listitem{type = group})        -> true;
 is_item_needdb(_)                              -> false.
 
-get_user_list(_, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
+get_user_list(_, #jid{luser = LUser, lserver = LServer}) ->
     case mod_privacy_backend:get_default_list(LUser, LServer) of
         {ok, {Default, List}} ->
             NeedDb = is_list_needdb(List),

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -200,19 +200,18 @@ process_list_get(_LUser, _LServer, false) ->
     {error, mongoose_xmpp_errors:bad_request()}.
 
 process_iq_set(Acc, From, _To, #iq{xmlns = ?NS_PRIVACY, sub_el = SubEl}) ->
-    #jid{luser = LUser, lserver = LServer} = From,
     #xmlel{children = Els} = SubEl,
     Res = case xml:remove_cdata(Els) of
               [#xmlel{name = Name, attrs = Attrs, children = SubEls}] ->
                   ListName = xml:get_attr(<<"name">>, Attrs),
                   case Name of
                       <<"list">> ->
-                          process_list_set(LUser, LServer, ListName,
+                          process_list_set(From, ListName,
                                    xml:remove_cdata(SubEls));
                       <<"active">> ->
-                          process_active_set(LUser, LServer, ListName);
+                          process_active_set(From, ListName);
                       <<"default">> ->
-                          process_default_set(LUser, LServer, ListName);
+                          process_default_set(From, ListName);
                       _ ->
                           {error, mongoose_xmpp_errors:bad_request()}
                   end;
@@ -223,7 +222,7 @@ process_iq_set(Acc, From, _To, #iq{xmlns = ?NS_PRIVACY, sub_el = SubEl}) ->
 process_iq_set(Val, _, _, _) ->
     Val.
 
-process_default_set(LUser, LServer, {value, Name}) ->
+process_default_set(#jid{luser = LUser, lserver = LServer}, {value, Name}) ->
     case mod_privacy_backend:set_default_list(LUser, LServer, Name) of
         ok ->
             {result, []};
@@ -232,7 +231,7 @@ process_default_set(LUser, LServer, {value, Name}) ->
         {error, _Reason} ->
             {error, mongoose_xmpp_errors:internal_server_error()}
     end;
-process_default_set(LUser, LServer, false) ->
+process_default_set(#jid{luser = LUser, lserver = LServer}, false) ->
     case mod_privacy_backend:forget_default_list(LUser, LServer) of
         ok ->
             {result, []};
@@ -240,7 +239,7 @@ process_default_set(LUser, LServer, false) ->
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
-process_active_set(LUser, LServer, {value, Name}) ->
+process_active_set(#jid{luser = LUser, lserver = LServer}, {value, Name}) ->
     case mod_privacy_backend:get_privacy_list(LUser, LServer, Name) of
         {ok, List} ->
             NeedDb = is_list_needdb(List),
@@ -250,26 +249,26 @@ process_active_set(LUser, LServer, {value, Name}) ->
         {error, _Reason} ->
             {error, mongoose_xmpp_errors:internal_server_error()}
     end;
-process_active_set(_LUser, _LServer, false) ->
+process_active_set(_UserJID, false) ->
     {result, [], #userlist{}}.
 
-process_list_set(LUser, LServer, {value, Name}, Els) ->
+process_list_set(UserJID, {value, Name}, Els) ->
     case parse_items(Els) of
         false ->
             {error, mongoose_xmpp_errors:bad_request()};
         remove ->
-            remove_privacy_list(LUser, LServer, Name);
+            remove_privacy_list(UserJID, Name);
         List ->
-            replace_privacy_list(LUser, LServer, Name, List)
+            replace_privacy_list(UserJID, Name, List)
     end;
-process_list_set(_LUser, _LServer, false, _Els) ->
+process_list_set(_UserJID, false, _Els) ->
     {error, mongoose_xmpp_errors:bad_request()}.
 
-remove_privacy_list(LUser, LServer, Name) ->
+remove_privacy_list(#jid{luser = LUser, lserver = LServer} = UserJID, Name) ->
     case mod_privacy_backend:remove_privacy_list(LUser, LServer, Name) of
         ok ->
             UserList = #userlist{name = Name, list = []},
-            broadcast_privacy_list(LUser, LServer, Name, UserList),
+            broadcast_privacy_list(UserJID, Name, UserList),
             {result, []};
         %% TODO if Name == Active -> conflict
         {error, conflict} ->
@@ -278,12 +277,12 @@ remove_privacy_list(LUser, LServer, Name) ->
             {error, mongoose_xmpp_errors:internal_server_error()}
     end.
 
-replace_privacy_list(LUser, LServer, Name, List) ->
+replace_privacy_list(#jid{luser = LUser, lserver = LServer} = UserJID, Name, List) ->
     case mod_privacy_backend:replace_privacy_list(LUser, LServer, Name, List) of
         ok ->
             NeedDb = is_list_needdb(List),
             UserList = #userlist{name = Name, list = List, needdb = NeedDb},
-            broadcast_privacy_list(LUser, LServer, Name, UserList),
+            broadcast_privacy_list(UserJID, Name, UserList),
             {result, []};
         {error, _Reason} ->
             {error, mongoose_xmpp_errors:internal_server_error()}
@@ -656,9 +655,9 @@ binary_to_order_s(Order) ->
 %% Ejabberd
 %% ------------------------------------------------------------------
 
-broadcast_privacy_list(LUser, LServer, Name, UserList) ->
-    UserJID = jid:make(LUser, LServer, <<>>),
-    ejabberd_sm:route(UserJID, UserJID, broadcast_privacy_list_packet(Name, UserList)).
+broadcast_privacy_list(UserJID, Name, UserList) ->
+    JID = jid:to_bare(UserJID),
+    ejabberd_sm:route(JID, JID, broadcast_privacy_list_packet(Name, UserList)).
 
 %% TODO this is dirty
 broadcast_privacy_list_packet(Name, UserList) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -633,14 +633,14 @@ privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) ->
                              FromToNameType,
                              Dir]).
 
--spec privacy_get_user_list(Server, UserList, User) -> Result when
+-spec privacy_get_user_list(Server, UserList, JID) -> Result when
     Server :: jid:server(),
     UserList :: mongoose_privacy:userlist(),
-    User :: jid:user(),
+    JID :: jid:jid(),
     Result :: mongoose_privacy:userlist().
-privacy_get_user_list(Server, UserList, User) ->
+privacy_get_user_list(Server, UserList, JID) ->
     ejabberd_hooks:run_fold(privacy_get_user_list, Server,
-                            UserList, [User, Server]).
+                            UserList, [JID]).
 
 -spec privacy_iq_get(Server, Acc, From, To, IQ, PrivList) -> Result when
     Server :: jid:server(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -617,18 +617,17 @@ session_opening_allowed_for_user(Server, Allow, JID) ->
 
 %% Privacy related hooks
 
--spec privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) -> Result when
-    LServer :: jid:lserver(), Acc :: mongoose_acc:t(), User :: jid:luser(),
+-spec privacy_check_packet(LServer, Acc, JID, PrivacyList, FromToNameType, Dir) -> Result when
+    LServer :: jid:lserver(), Acc :: mongoose_acc:t(), JID :: jid:jid(),
     PrivacyList :: mongoose_privacy:userlist(),
     FromToNameType :: {jid:jid(), jid:jid(), binary(), binary()},
     Dir :: in | out,
     Result :: mongoose_acc:t().
-privacy_check_packet(LServer, Acc, User, PrivacyList, FromToNameType, Dir) ->
+privacy_check_packet(LServer, Acc, JID, PrivacyList, FromToNameType, Dir) ->
     ejabberd_hooks:run_fold(privacy_check_packet,
                             LServer,
                             mongoose_acc:set(hook, result, allow, Acc),
-                            [User,
-                             LServer,
+                            [JID,
                              PrivacyList,
                              FromToNameType,
                              Dir]).

--- a/src/mongoose_privacy.erl
+++ b/src/mongoose_privacy.erl
@@ -30,29 +30,29 @@
 %% {Acc, El} for cases where one acc triggers sending many messages which have to be checked
 -spec privacy_check_packet(Acc :: mongoose_acc:t() | {mongoose_acc:t(), exml:element()},
                            Server :: binary(),
-                           User :: binary(),
+                           JID :: jid:jid(),
                            PrivacyList :: userlist(),
                            To :: jid:jid(),
                            Dir :: 'in' | 'out') -> {mongoose_acc:t(), decision()}.
-privacy_check_packet(Acc0, Server, User, PrivacyList, To, Dir) ->
+privacy_check_packet(Acc0, Server, JID, PrivacyList, To, Dir) ->
     Acc1 = case Acc0 of
            {Acc, #xmlel{}} -> Acc;
             _ -> Acc0
         end,
     From = mongoose_acc:from_jid(Acc1),
-    privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir).
+    privacy_check_packet(Acc0, Server, JID, PrivacyList, From, To, Dir).
 
 %% @doc check packet, store result in accumulator, return acc and result for quick check
 %% Acc can be either a single argument (an Accumulator) or a tuple of {Acc, Stanza}
 %% in the latter case name and type to check against privacy lists are taken from the Stanza
 -spec privacy_check_packet(Acc :: mongoose_acc:t() | {mongoose_acc:t(), exml:element()},
                            Server :: binary(),
-                           User :: binary(),
+                           JID :: jid:jid(),
                            PrivacyList :: userlist(),
                            From :: jid:jid(),
                            To :: jid:jid(),
                            Dir :: 'in' | 'out') -> {mongoose_acc:t(), decision()}.
-privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir) ->
+privacy_check_packet(Acc0, Server, #jid{luser = User} = JID, PrivacyList, From, To, Dir) ->
     % see if we have just Acc or also stanza to check - may have different name/type
     {Acc, Name, Type} = case Acc0 of
                        {A, #xmlel{name = SName} = Stanza} ->
@@ -65,11 +65,10 @@ privacy_check_packet(Acc0, Server, User, PrivacyList, From, To, Dir) ->
     Key = {cached_check, Server, User, From, To, Name, Type, Dir},
     case mongoose_acc:get(privacy, Key, undefined, Acc) of
         undefined ->
-            Acc1 = mongoose_hooks:privacy_check_packet(Server, Acc, User, PrivacyList,
+            Acc1 = mongoose_hooks:privacy_check_packet(Server, Acc, JID, PrivacyList,
                                                        {From, To, Name, Type}, Dir),
             Res = mongoose_acc:get(hook, result, Acc1),
             {mongoose_acc:set(privacy, Key, Res, Acc1), Res};
         Res ->
             {Acc, Res}
     end.
-

--- a/test/privacy_SUITE.erl
+++ b/test/privacy_SUITE.erl
@@ -143,7 +143,7 @@ check_with_changing_stanza(_C) ->
 make_check(Acc, PList, To, Dir, Exp) ->
     Server = <<"localhost">>,
     User = <<"alice">>,
-    {Acc1, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, User,
+    {Acc1, Res} = mongoose_privacy:privacy_check_packet(Acc, Server, jid:make(User, Server, <<>>),
         PList, To, Dir),
     ?assertEqual(Exp, Res),
     Acc1.


### PR DESCRIPTION
A few less stringprepps in another module that comes up on every once in a while, like on opening sessions, when the privacy lists is queried the first time (then it's cached) for a message delivery, or when the privacy list is modified and then broadcasted.