### PR TITLE
Fix the Cassandra connections

### DIFF
--- a/src/cassandra/mongoose_cassandra_worker.erl
+++ b/src/cassandra/mongoose_cassandra_worker.erl
@@ -509,7 +509,7 @@ is_finished(_Req = #request{action = #read_action{}}, Result) ->
                         {abort, AbortReason :: term(), worker_state()} |
                         {retry, Timeout :: non_neg_integer(), worker_state()}.
 retry_info(_, _, #request{retry_left = 0} = _Req, State) ->
-    {abort, retry_limit_exeeded, State};
+    {abort, retry_limit_exceeded, State};
 retry_info({down, cqerl_client}, _Reason, _Req, State) ->
     {retry, 5 + rand:uniform(20), State};
 retry_info(cqerl_error, {16#1100 = _WriteTimout, _, _}, _Req, State) ->


### PR DESCRIPTION
Three main changes:
- The fix in MongooseIM makes it reconnect after the cqerl supervision (sub)tree including `cqerl_cluster` is restarted.
- The fix in cqerl (https://github.com/esl/cqerl/pull/8) prevents escalation of the crash and bringing down the whole node when the fix mentioned above enabled cqerl to reconnect many times in a row and the network remains unreliable.
- The fix in tests prevents them from failing randomly (even though it's less likely after the two fixes listed above). Now the failures are simulated in a more predictable way. It's still possible to run the full stress test manually.

