### PR TITLE
Update migration guide with TOML changes

### DIFF
--- a/doc/migrations/4.0.1_4.x.x.md
+++ b/doc/migrations/4.0.1_4.x.x.md
@@ -6,46 +6,30 @@ Currently, only the `urn:xmpp:http:upload:0` XMLNS is served.
 All major, modern client libraries and applications support the 0.3.0+ specification.
 If you experience any issues with making requests to the HTTP File Upload service, please update your client.
 
-## Retirement of old `*.cfg` format
+## Retirement of the old `*.cfg` format
 
-Since ____ release, we are no longer supporting `*.cfg` MongooseIM configuration format. For further application's usage, please use `TOML` format.
+Since release 4.x.x, we are no longer supporting the `*.cfg` MongooseIM configuration format. Please use the `TOML` format instead.
 
-## Minor changes in `TOML` config format
+## Minor changes in the `TOML` config format
 
 * [`mod_bosh.max_pause`](../../modules/mod_bosh/#modulesmod_boshmax_pause) instead of `maxpause`
 
-* [`mod_caps.cache_life_time`](../../modules/mod_caps/#modulesmod_capscache_life_time): the value should be provided milliseconds
-
 * [`mod_disco.server_info.module`](../../modules/mod_disco/#modulesmod_discoserver_info): the field is optional, no longer required
-
-* [`mod_register`](../../modules/mod_register/#modulesmod_registeriqdisctype), [`mod_vcard`](../../modules/mod_vcard/#modulesmod_vcardiqdisctype) & [`mod_version`](../../modules/mod_version/#modulesmod_versioniqdisctype): `iqdisc.type` default value was changed from `"no_queue"` to `"one_queue"`
-
-* [`mod_event_pusher_push.virtual_pubsub_hosts`](../../modules/mod_event_pusher_push/#modulesmod_event_pusher_pushvirtual_pubsub_hosts): the default value was changed to `[]`
-
-* [`mod_event_pusher_sns.presence_updates_topic`](../../modules/mod_event_pusher_sns/#modulesmod_event_pusher_snspresence_updates_topic): default not set
-
-* `mod_event_pusher_sns.muc_host`: the option was removed
 
 * [`mod_global_distrib.connections.advertised_endpoints`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionsadvertised_endpoints): default not set (`false` is no longer accepted)
 
-* `mod_global_distrib.connections.tls.enabled`: flag was removed, TLS is enabled by providing [`cacertfile`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionstlscacertfile) and [`certfile`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionstlscertfile) options
+* `mod_global_distrib.connections.tls.enabled`: the flag was removed, TLS is enabled by providing the [`cacertfile`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionstlscacertfile) and [`certfile`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionstlscertfile) options
 
-* [`mod_http_upload.s3`](../../modules/mod_http_upload/#s3-backend-options): the section is mandatory
+* [`mod_http_upload.max_file_size`](../../modules/mod_http_upload/#modulesmod_http_uploadmax_file_size): `undefined` is no longer allowed
 
-* [`mod_mam_meta.user_prefs_store`](../../modules/mod_mam/#modulesmod_mam_metauser_prefs_store): `false` value is no longer allowed
+* [`mod_mam_meta.user_prefs_store`](../../modules/mod_mam/#modulesmod_mam_metauser_prefs_store): `false` is no longer allowed
 
-* [`mod_muc_light.config_schema`](../../modules/mod_muc_light/#modulesmod_muc_lightconfig_schema): minor config fields simplification
+* [`mod_muc_light.config_schema`](../../modules/mod_muc_light/#modulesmod_muc_lightconfig_schema): the usage of `value` and `type` fields was replaced with one of the following fields: `string_value`, `integer_value` or `float_value`
 
-* `mod_muc_log`: change of default values for [`css_file`](../../modules/mod_muc_log/#modulesmod_muc_logcss_file) and [`top_link`](../../modules/mod_muc_log/#modulesmod_muc_logtop_link)
-
-* `mod_ping`: [`ping_interval`](../../modules/mod_ping/#modulesmod_pingping_interval) and [`ping_req_timeout`](../../modules/mod_ping/#modulesmod_pingping_req_timeout) explicitly said to be in seconds
-
-* [`mod_push_service_mongoosepush.api_version`](../../modules/mod_push_service_mongoosepush/#modulesmod_push_service_mongoosepushapi_version): the value is now limited to be `"v2"` or `"v3"`
+* [`mod_muc_log.css_file`](../../modules/mod_muc_log/#modulesmod_muc_logcss_file): the default value was changed from `"false"` to `not set`
 
 * `mod_stream_management`: minor adjustments of [`buffer_max`](../../modules/mod_stream_management/#modulesmod_stream_managementbuffer_max) and [`ack_freq`](../../modules/mod_stream_management/#modulesmod_stream_managementack_freq) options, [`buffer`](../../modules/mod_stream_management/#modulesmod_stream_managementbuffer) and [`ack`](../../modules/mod_stream_management/#modulesmod_stream_managementack) booleans were added
 
 * [`listen.c2s.tls.ciphers`](../../advanced-configuration/listen/#listenc2stlsciphers), [`listen.http.tls.ciphers`](../../advanced-configuration/listen/#listenhttptlsciphers) and [`outgoing_pools.*.*.connection.tls.ciphers`](../../advanced-configuration/outgoing-connections/#outgoing_poolsconnectiontlsciphers): the ciphers should now be formatted as a specification string
 
-* [listen.http.handlers.mod_websockets.ping_rate](../../advanced-configuration/listen/#listenhttphandlersmod_websocketsping_rate): `none` value is no longer allowed
-
-* `outgoing_pools.generic`: the option was removed
+* [listen.http.handlers.mod_websockets.ping_rate](../../advanced-configuration/listen/#listenhttphandlersmod_websocketsping_rate): `none` is no longer allowed

--- a/doc/migrations/4.0.1_4.x.x.md
+++ b/doc/migrations/4.0.1_4.x.x.md
@@ -6,3 +6,46 @@ Currently, only the `urn:xmpp:http:upload:0` XMLNS is served.
 All major, modern client libraries and applications support the 0.3.0+ specification.
 If you experience any issues with making requests to the HTTP File Upload service, please update your client.
 
+## Retirement of old `*.cfg` format
+
+Since ____ release, we are no longer supporting `*.cfg` MongooseIM configuration format. For further application's usage, please use `TOML` format.
+
+## Minor changes in `TOML` config format
+
+* [`mod_bosh.max_pause`](../../modules/mod_bosh/#modulesmod_boshmax_pause) instead of `maxpause`
+
+* [`mod_caps.cache_life_time`](../../modules/mod_caps/#modulesmod_capscache_life_time): the value should be provided milliseconds
+
+* [`mod_disco.server_info.module`](../../modules/mod_disco/#modulesmod_discoserver_info): the field is optional, no longer required
+
+* [`mod_register`](../../modules/mod_register/#modulesmod_registeriqdisctype), [`mod_vcard`](../../modules/mod_vcard/#modulesmod_vcardiqdisctype) & [`mod_version`](../../modules/mod_version/#modulesmod_versioniqdisctype): `iqdisc.type` default value was changed from `"no_queue"` to `"one_queue"`
+
+* [`mod_event_pusher_push.virtual_pubsub_hosts`](../../modules/mod_event_pusher_push/#modulesmod_event_pusher_pushvirtual_pubsub_hosts): the default value was changed to `[]`
+
+* [`mod_event_pusher_sns.presence_updates_topic`](../../modules/mod_event_pusher_sns/#modulesmod_event_pusher_snspresence_updates_topic): default not set
+
+* `mod_event_pusher_sns.muc_host`: the option was removed
+
+* [`mod_global_distrib.connections.advertised_endpoints`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionsadvertised_endpoints): default not set (`false` is no longer accepted)
+
+* `mod_global_distrib.connections.tls.enabled`: flag was removed, TLS is enabled by providing [`cacertfile`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionstlscacertfile) and [`certfile`](../../modules/mod_global_distrib/#modulesmod_global_distribconnectionstlscertfile) options
+
+* [`mod_http_upload.s3`](../../modules/mod_http_upload/#s3-backend-options): the section is mandatory
+
+* [`mod_mam_meta.user_prefs_store`](../../modules/mod_mam/#modulesmod_mam_metauser_prefs_store): `false` value is no longer allowed
+
+* [`mod_muc_light.config_schema`](../../modules/mod_muc_light/#modulesmod_muc_lightconfig_schema): minor config fields simplification
+
+* `mod_muc_log`: change of default values for [`css_file`](../../modules/mod_muc_log/#modulesmod_muc_logcss_file) and [`top_link`](../../modules/mod_muc_log/#modulesmod_muc_logtop_link)
+
+* `mod_ping`: [`ping_interval`](../../modules/mod_ping/#modulesmod_pingping_interval) and [`ping_req_timeout`](../../modules/mod_ping/#modulesmod_pingping_req_timeout) explicitly said to be in seconds
+
+* [`mod_push_service_mongoosepush.api_version`](../../modules/mod_push_service_mongoosepush/#modulesmod_push_service_mongoosepushapi_version): the value is now limited to be `"v2"` or `"v3"`
+
+* `mod_stream_management`: minor adjustments of [`buffer_max`](../../modules/mod_stream_management/#modulesmod_stream_managementbuffer_max) and [`ack_freq`](../../modules/mod_stream_management/#modulesmod_stream_managementack_freq) options, [`buffer`](../../modules/mod_stream_management/#modulesmod_stream_managementbuffer) and [`ack`](../../modules/mod_stream_management/#modulesmod_stream_managementack) booleans were added
+
+* [`listen.c2s.tls.ciphers`](../../advanced-configuration/listen/#listenc2stlsciphers), [`listen.http.tls.ciphers`](../../advanced-configuration/listen/#listenhttptlsciphers) and [`outgoing_pools.*.*.connection.tls.ciphers`](../../advanced-configuration/outgoing-connections/#outgoing_poolsconnectiontlsciphers): the ciphers should now be formatted as a specification string
+
+* [listen.http.handlers.mod_websockets.ping_rate](../../advanced-configuration/listen/#listenhttphandlersmod_websocketsping_rate): `none` value is no longer allowed
+
+* `outgoing_pools.generic`: the option was removed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - '3.6.0 to 3.7.0': 'migrations/3.6.0_3.7.0.md'
       - '3.7.0 to 4.0.0': 'migrations/3.7.0_4.0.0.md'
       - '4.0.0 to 4.0.1': 'migrations/4.0.0_4.0.1.md'
+      - '4.0.1 to 4.x.x': 'migrations/4.0.1_4.x.x.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - Platform:
       - 'Contributions to ecosystem': 'Contributions.md'


### PR DESCRIPTION
Basically I went through the output of `git diff master toml-config doc/` command and wrote it down, already excluding couple of type alignments. I also added missing link to the newest migration guide's chapter.