### PR TITLE
integer_to_binary/2 is available since OTP17

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2278,11 +2278,10 @@ get_priority_from_presence(PresencePacket) ->
         false ->
             0;
         SubEl ->
-            case catch list_to_integer(binary_to_list(xml:get_tag_cdata(SubEl))) of
-                P when is_integer(P) ->
-                    P;
-                _ ->
-                    0
+            try binary_to_integer(xml:get_tag_cdata(SubEl)) of
+                P when is_integer(P) -> P
+            catch
+                error:badarg -> 0
             end
     end.
 

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -188,7 +188,7 @@ decode_compact_uuid(Id) ->
 %% @doc Encode a message ID to pass it to the user.
 -spec mess_id_to_external_binary(integer()) -> binary().
 mess_id_to_external_binary(MessID) when is_integer(MessID) ->
-    list_to_binary(integer_to_list(MessID, 32)).
+    integer_to_binary(MessID, 32).
 
 
 -spec maybe_external_binary_to_mess_id(binary()) -> undefined | integer().

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3574,7 +3574,7 @@ maxusers_field(Lang, StateData) ->
                                               children = [#xmlcdata{content = <<"none">>}]}]}]
            end ++
            [#xmlel{name = <<"option">>,
-                   attrs = [{<<"label">>, list_to_binary(integer_to_list(N))}],
+                   attrs = [{<<"label">>, integer_to_binary(N)}],
                    children = [#xmlel{name = <<"value">>,
                                       children = [#xmlcdata{content = integer_to_binary(N)}]}]} ||
             N <- lists:usort([ServiceMaxUsers, DefaultRoomMaxUsers, MaxUsersRoomInteger |
@@ -4007,7 +4007,7 @@ iq_disco_info_extras(Lang, StateData) ->
                         rfield(<<"Room description">>, <<"muc#roominfo_description">>,
                             RoomDescription, Lang),
                         rfield(<<"Number of occupants">>, <<"muc#roominfo_occupants">>,
-                            (list_to_binary(integer_to_list(Len))), Lang)
+                            (integer_to_binary(Len)), Lang)
                        ]}].
 
 

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -606,10 +606,10 @@ action_to_binary(Action) ->
     end.
 
 order_to_binary(Order) ->
-    list_to_binary(integer_to_list(Order)).
+    integer_to_binary(Order).
 
 binary_to_order(Binary) ->
-    list_to_integer(binary_to_list(Binary)).
+    binary_to_integer(Binary).
 
 type_to_binary(Type) ->
     case Type of

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -466,9 +466,7 @@ find_x_expire(TimeStamp, [El | Els]) ->
     case exml_query:attr(El, <<"xmlns">>, <<>>) of
         ?NS_EXPIRE ->
             Val = exml_query:attr(El, <<"seconds">>, <<>>),
-            case catch list_to_integer(binary_to_list(Val)) of
-                {'EXIT', _} ->
-                    never;
+            try binary_to_integer(Val) of
                 Int when Int > 0 ->
                     {MegaSecs, Secs, MicroSecs} = TimeStamp,
                     S = MegaSecs * 1000000 + Secs + Int,
@@ -477,6 +475,8 @@ find_x_expire(TimeStamp, [El | Els]) ->
                     {MegaSecs1, Secs1, MicroSecs};
                 _ ->
                     never
+            catch
+                error:badarg -> never
             end;
         _ ->
             find_x_expire(TimeStamp, Els)


### PR DESCRIPTION
And `list_to_integer` or `binary_to_integer` have the same API, throwing the same errors and so on.
Also, `try-of-catch` is better than `case catch`, errors are clearer and it doesn't build a stacktrace.