### PR TITLE
Reduce stringprepping in mod_offline

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1207,7 +1207,7 @@ remove_old_messages_test(Config) ->
         rpc_call(mod_offline_backend, write_messages, [LUser, LServer, [OfflineOld, OfflineNew]]),
         %% when
         {_, 0} = ejabberdctl("delete_old_messages", ["1"], Config),
-        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [LUser, LServer]),
+        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [JidRecordBob]),
         %% then
         1 = length(SecondList)
     end).
@@ -1248,7 +1248,7 @@ remove_expired_messages_test(Config) ->
         rpc_call(mod_offline_backend, write_messages, [LUser, LServer, Args]),
         %% when
         {_, 0} = ejabberdctl("delete_expired_messages", [], Config),
-        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [LUser, LServer]),
+        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [JidRecordKate]),
         %% then
         2 = length(SecondList)
     end).

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2343,7 +2343,7 @@ resend_offline_messages(Acc, StateData) ->
     Acc1 = mongoose_hooks:resend_offline_messages_hook(
                                    StateData#state.server,
                                    Acc,
-                                   StateData#state.user),
+                                   StateData#state.jid),
     Rs = mongoose_acc:get(offline, messages, [], Acc1),
     Acc2 = lists:foldl(
                        fun({route, From, To, MsgAcc}, A) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -342,16 +342,16 @@ register_user(LServer, Acc, LUser) ->
 remove_user(LServer, Acc, LUser) ->
     ejabberd_hooks:run_fold(remove_user, LServer, Acc, [LUser, LServer]).
 
--spec resend_offline_messages_hook(Server, Acc, User) -> Result when
+-spec resend_offline_messages_hook(Server, Acc, JID) -> Result when
     Server :: jid:server(),
     Acc :: mongoose_acc:t(),
-    User :: jid:user(),
+    JID :: jid:jid(),
     Result :: mongoose_acc:t().
-resend_offline_messages_hook(Server, Acc, User) ->
+resend_offline_messages_hook(Server, Acc, JID) ->
     ejabberd_hooks:run_fold(resend_offline_messages_hook,
                             Server,
                             Acc,
-                            [User, Server]).
+                            [JID]).
 
 %%% @doc The `rest_user_send_packet' hook is called when a user sends a message using the REST API.
 -spec rest_user_send_packet(LServer, Acc, From, To, Packet) -> Result when

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -38,7 +38,7 @@
 
 %% Hook handlers
 -export([inspect_packet/4,
-         pop_offline_messages/3,
+         pop_offline_messages/2,
          get_sm_features/5,
          remove_expired_messages/1,
          remove_old_messages/2,
@@ -94,14 +94,12 @@
 -callback init(Host, Opts) -> ok when
     Host :: binary(),
     Opts :: list().
--callback pop_messages(LUser, LServer) -> {ok, Result} | {error, Reason} when
-    LUser :: jid:luser(),
-    LServer :: jid:lserver(),
+-callback pop_messages(JID) -> {ok, Result} | {error, Reason} when
+    JID :: jid:jid(),
     Reason :: term(),
     Result :: list(#offline_msg{}).
--callback fetch_messages(LUser, LServer) -> {ok, Result} | {error, Reason} when
-    LUser :: jid:luser(),
-    LServer :: jid:lserver(),
+-callback fetch_messages(JID) -> {ok, Result} | {error, Reason} when
+    JID :: jid:jid(),
     Reason :: term(),
     Result :: list(#offline_msg{}).
 -callback write_messages(LUser, LServer, Msgs) ->
@@ -212,7 +210,7 @@ is_message_count_threshold_reached(MaxOfflineMsgs, LUser, LServer, Len) ->
 
 
 get_max_user_messages(AccessRule, LUser, Host) ->
-    case acl:match_rule(Host, AccessRule, jid:make(LUser, Host, <<>>)) of
+    case acl:match_rule(Host, AccessRule, jid:make_noprep(LUser, Host, <<>>)) of
         Max when is_integer(Max) -> Max;
         infinity -> infinity;
         _ -> ?MAX_USER_MESSAGES
@@ -284,9 +282,9 @@ init([Host, AccessMaxOfflineMsgs]) ->
 %%                                      {stop, Reason, State}
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
-handle_call({pop_offline_messages, LUser, LServer}, {Pid, _}, State) ->
-    Result = mod_offline_backend:pop_messages(LUser, LServer),
-    NewPoppers = monitored_map:put({LUser, LServer}, Pid, Pid, State#state.message_poppers),
+handle_call({pop_offline_messages, JID}, {Pid, _}, State) ->
+    Result = mod_offline_backend:pop_messages(JID),
+    NewPoppers = monitored_map:put(jid:to_lus(JID), Pid, Pid, State#state.message_poppers),
     {reply, Result, State#state{message_poppers = NewPoppers}};
 handle_call(Request, From, State) ->
     ?UNEXPECTED_CALL(Request, From),
@@ -482,16 +480,14 @@ find_x_expire(TimeStamp, [El | Els]) ->
             find_x_expire(TimeStamp, Els)
     end.
 
-pop_offline_messages(Acc, User, Server) ->
-    mongoose_acc:append(offline, messages, offline_messages(Acc, User, Server), Acc).
+pop_offline_messages(Acc, JID) ->
+    mongoose_acc:append(offline, messages, offline_messages(Acc, JID), Acc).
 
-offline_messages(Acc, User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    case pop_messages(LUser, LServer) of
+offline_messages(Acc, #jid{lserver = LServer} = JID) ->
+    case pop_messages(JID) of
         {ok, Rs} ->
             lists:map(fun(R) ->
-                Packet = resend_offline_message_packet(Server, R),
+                Packet = resend_offline_message_packet(LServer, R),
                 compose_offline_message(R, Packet, Acc)
               end, Rs);
         {error, Reason} ->
@@ -499,8 +495,8 @@ offline_messages(Acc, User, Server) ->
             []
     end.
 
-pop_messages(LUser, LServer) ->
-    case gen_server:call(srv_name(LServer), {pop_offline_messages, LUser, LServer}) of
+pop_messages(#jid{lserver = LServer} = JID) ->
+    case gen_server:call(srv_name(LServer), {pop_offline_messages, jid:to_bare(JID)}) of
         {ok, RsAll} ->
             TimeStamp = os:timestamp(),
             Rs = skip_expired_messages(TimeStamp, lists:keysort(#offline_msg.timestamp, RsAll)),
@@ -509,8 +505,8 @@ pop_messages(LUser, LServer) ->
             Other
     end.
 
-get_personal_data(Acc, #jid{ user = User, server = Server }) ->
-    {ok, Messages} = mod_offline_backend:fetch_messages(User, Server),
+get_personal_data(Acc, #jid{} = JID) ->
+    {ok, Messages} = mod_offline_backend:fetch_messages(JID),
     [ {offline, ["timestamp", "from", "to", "packet"],
        offline_messages_to_gdpr_format(Messages)} | Acc].
 
@@ -538,19 +534,19 @@ compose_offline_message(#offline_msg{from = From, to = To, permanent_fields = Pe
     Acc = mongoose_acc:update_stanza(#{element => Packet, from_jid => From, to_jid => To}, Acc1),
     {route, From, To, Acc}.
 
-resend_offline_message_packet(Server,
+resend_offline_message_packet(LServer,
         #offline_msg{timestamp=TimeStamp, packet = Packet}) ->
-    add_timestamp(TimeStamp, Server, Packet).
+    add_timestamp(TimeStamp, LServer, Packet).
 
-add_timestamp(undefined, _Server, Packet) ->
+add_timestamp(undefined, _LServer, Packet) ->
     Packet;
-add_timestamp(TimeStamp, Server, Packet) ->
+add_timestamp(TimeStamp, LServer, Packet) ->
     Time = usec:from_now(TimeStamp),
-    TimeStampXML = timestamp_xml(Server, Time),
+    TimeStampXML = timestamp_xml(LServer, Time),
     xml:append_subtags(Packet, [TimeStampXML]).
 
-timestamp_xml(Server, Time) ->
-    FromJID = jid:make(<<>>, Server, <<>>),
+timestamp_xml(LServer, Time) ->
+    FromJID = jid:make_noprep(<<>>, LServer, <<>>),
     TS = calendar:system_time_to_rfc3339(Time, [{offset, "Z"}, {unit, microsecond}]),
     jlib:timestamp_to_xml(TS, FromJID, <<"Offline Storage">>).
 

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -40,7 +40,7 @@
 %% Hook handlers
 -export([inspect_packet/4,
          remove_user/3,
-         pop_offline_messages/3]).
+         pop_offline_messages/2]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -97,8 +97,8 @@ remove_user(Acc, User, Server) ->
     mod_offline_chatmarkers_backend:remove_user(jid:make(User, Server, <<"">>)),
     Acc.
 
-pop_offline_messages(Acc, User, Server) ->
-    mongoose_acc:append(offline, messages, offline_chatmarkers(Acc, User, Server), Acc).
+pop_offline_messages(Acc, JID) ->
+    mongoose_acc:append(offline, messages, offline_chatmarkers(Acc, JID), Acc).
 
 inspect_packet(Acc, From, To, Packet) ->
     case maybe_store_chat_marker(Acc, From, To, Packet) of
@@ -130,8 +130,7 @@ get_thread(El) ->
         _ -> undefined
     end.
 
-offline_chatmarkers(Acc, User, Server) ->
-    JID = jid:make(User, Server, <<"">>),
+offline_chatmarkers(Acc, JID) ->
     {ok, Rows} = mod_offline_chatmarkers_backend:get(JID),
     mod_offline_chatmarkers_backend:remove_user(JID),
     lists:concat([process_row(Acc, JID, R) || R <- Rows]).

--- a/src/offline/mod_offline_mnesia.erl
+++ b/src/offline/mod_offline_mnesia.erl
@@ -28,8 +28,8 @@
 -module(mod_offline_mnesia).
 -behaviour(mod_offline).
 -export([init/2,
-         pop_messages/2,
-         fetch_messages/2,
+         pop_messages/1,
+         fetch_messages/1,
          write_messages/3,
          count_offline_messages/3,
          remove_expired_messages/1,
@@ -51,8 +51,8 @@ init(_Host, _Opts) ->
     upgrade_table(),
     ok.
 
-pop_messages(LUser, LServer) ->
-    US = {LUser, LServer},
+pop_messages(To) ->
+    US = jid:to_lus(To),
     F = fun() ->
                 Rs = mnesia:wread({offline_msg, US}),
                 mnesia:delete({offline_msg, US}),
@@ -65,10 +65,8 @@ pop_messages(LUser, LServer) ->
             {error, Reason}
     end.
 
-fetch_messages(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nodeprep(Server),
-    US = {LUser, LServer},
+fetch_messages(To) ->
+    US = jid:to_lus(To),
     F = fun() -> mnesia:wread({offline_msg, US}) end,
     case mnesia:transaction(F) of
         {atomic, Rs} ->

--- a/src/offline/mod_offline_rdbms.erl
+++ b/src/offline/mod_offline_rdbms.erl
@@ -26,8 +26,8 @@
 -module(mod_offline_rdbms).
 -behaviour(mod_offline).
 -export([init/2,
-         pop_messages/2,
-         fetch_messages/2,
+         pop_messages/1,
+         fetch_messages/1,
          write_messages/3,
          count_offline_messages/3,
          remove_expired_messages/1,
@@ -43,9 +43,8 @@
 init(_Host, _Opts) ->
     ok.
 
-pop_messages(LUser, LServer) ->
-    US = {LUser, LServer},
-    To = jid:make(LUser, LServer, <<>>),
+pop_messages(#jid{} = To) ->
+    US = {LUser, LServer} = jid:to_lus(To),
     SUser = mongoose_rdbms:escape_string(LUser),
     SServer = mongoose_rdbms:escape_string(LServer),
     TimeStamp = erlang:timestamp(),
@@ -59,11 +58,8 @@ pop_messages(LUser, LServer) ->
             {error, Reason}
     end.
 
-fetch_messages(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nodeprep(Server),
-    US = {LUser, LServer},
-    To = jid:make(User, LServer, <<>>),
+fetch_messages(#jid{} = To) ->
+    US = {LUser, LServer} = jid:to_lus(To),
     TimeStamp = erlang:timestamp(),
     SUser = mongoose_rdbms:escape_string(LUser),
     SServer = mongoose_rdbms:escape_string(LServer),

--- a/src/offline/mod_offline_riak.erl
+++ b/src/offline/mod_offline_riak.erl
@@ -28,8 +28,8 @@
 -behaviour(mod_offline).
 
 -export([init/2]).
--export([pop_messages/2]).
--export([fetch_messages/2]).
+-export([pop_messages/1]).
+-export([fetch_messages/1]).
 -export([write_messages/3]).
 -export([remove_expired_messages/1]).
 -export([remove_old_messages/2]).
@@ -51,14 +51,12 @@
 init(_Host, _Opts) ->
     ok.
 
--spec pop_messages(LUser, LServer) -> {ok, Result} | {error, Reason} when
-    LUser :: jid:luser(),
-    LServer :: jid:lserver(),
+-spec pop_messages(To) -> {ok, Result} | {error, Reason} when
+    To :: jid:jid(),
     Reason :: term(),
     Result :: list(mod_offline:msg()).
-pop_messages(LUser, LServer) ->
+pop_messages(To = #jid{luser = LUser, lserver = LServer}) ->
     Keys = read_user_idx(LUser, LServer),
-    To = jid:make(LUser, LServer, <<>>),
     Msgs = [pop_msg(Key, LUser, LServer, To) || Key <- Keys],
     {ok, lists:flatten(Msgs)}.
 
@@ -200,11 +198,9 @@ maybe_decode_timestamp(TS) ->
     usec:to_now(TS).
 
 
-fetch_messages(User, Server) ->
-    LUser = jid:nodeprep(User),
-    LServer = jid:nodeprep(Server),
+fetch_messages(To) ->
+    {LUser, LServer} = jid:to_lus(To),
     Keys = read_user_idx(LUser, LServer),
-    To = jid:make({User, LServer, <<>>}),
     {ok, [fetch_msg(Key, LUser, LServer, To) || Key <- Keys]}.
 
 fetch_msg(Key, LUser, LServer, To) ->


### PR DESCRIPTION
get_max_user_messages gets its parameters from the #offline_msg record,
which when created took the jid:to_lus/1 from a full jid, hence its
arguments are already stringprepped.

resend_offline_message_packet will forward the server parameter down the
stack up to the timestamp function, which needs the stringprepped
parameter, but this was stringprepped already before, so this processed
version can be passed instead.