### PR TITLE
Remove archive_groupchats warning

### DIFF
--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -116,7 +116,6 @@ To disable archive for one-to-one messages please remove PM section or any PM re
 * **Example:** `modules.mod_mam_meta.pm.archive_groupchats = true`
 
 When enabled, MAM will store groupchat messages in recipients' individual archives. **USE WITH CAUTION!** May increase archive size significantly. Disabling this option for existing installation will neither remove such messages from MAM storage, nor will filter out them from search results.
-MongooseIM will print a warning on startup if `pm` MAM is enabled without `archive_groupchats` being explicitly set to a specific value. In one of the future MongooseIM releases this option will default to `false` (as it's more common use case and less DB-consuming) and the warning message will be removed.
 
 #### Enable MUC message archive
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -197,12 +197,6 @@ archive_id(Server, User)
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(Host, Opts) ->
     ?LOG_INFO(#{what => mam_starting}),
-    ?LOG_IF(warning, gen_mod:get_opt(archive_groupchats, Opts, undefined) == undefined,
-                    #{what => mam_configuration, text =>
-     <<"mod_mam is enabled without explicit archive_groupchats option value."
-       " It will default to `false` in one of future releases."
-       " Please check the mod_mam documentation for more details.">>,
-     host => Host, mam_opts => Opts}),
 
     %% `parallel' is the only one recommended here.
     IQDisc = gen_mod:get_opt(iqdisc, Opts, parallel), %% Type


### PR DESCRIPTION
The warning has been removed altogether with its mention in documentation.
