### PR TITLE
Insert only a diff of privacy_data

### DIFF
--- a/priv/azuresql.sql
+++ b/priv/azuresql.sql
@@ -262,7 +262,7 @@ CREATE TABLE [dbo].[privacy_list_data](
 	[t] [char](1) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[value] [varchar](max) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
 	[action] [char](1) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
-	[ord] [bigint] NOT NULL,
+	[ord] [int] NOT NULL,
 	[match_all] [smallint] NOT NULL,
 	[match_iq] [smallint] NOT NULL,
 	[match_message] [smallint] NOT NULL,

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -220,7 +220,7 @@ CREATE TABLE [dbo].[privacy_list_data](
 	[t] [char](1) NOT NULL,
 	[value] [nvarchar](max) NOT NULL,
 	[action] [char](1) NOT NULL,
-	[ord] [bigint] NOT NULL,
+	[ord] [int] NOT NULL,
 	[match_all] [smallint] NOT NULL,
 	[match_iq] [smallint] NOT NULL,
 	[match_message] [smallint] NOT NULL,

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -157,7 +157,7 @@ CREATE TABLE privacy_list_data (
     t character(1) NOT NULL,
     value text NOT NULL,
     action character(1) NOT NULL,
-    ord bigint NOT NULL,
+    ord INT NOT NULL,
     match_all boolean NOT NULL,
     match_iq boolean NOT NULL,
     match_message boolean NOT NULL,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -143,7 +143,7 @@ CREATE TABLE privacy_list_data (
     t character(1) NOT NULL,
     value text NOT NULL,
     action character(1) NOT NULL,
-    ord NUMERIC NOT NULL,
+    ord INT NOT NULL,
     match_all boolean NOT NULL,
     match_iq boolean NOT NULL,
     match_message boolean NOT NULL,

--- a/rebar.lock
+++ b/rebar.lock
@@ -26,7 +26,7 @@
  {<<"eini">>,{pkg,<<"eini">>,<<"1.2.7">>},1},
  {<<"eodbc">>,
   {git,"https://github.com/arcusfelis/eodbc.git",
-       {ref,"612461e4d8e12c0947a67e0bfdeb854010db0b2d"}},
+       {ref,"1823d8fe6f5fbe2d8724a9649b75ebd5b8738661"}},
   0},
  {<<"eper">>,
   {git,"http://github.com/basho/eper.git",


### PR DESCRIPTION
This PR addresses "Deadlock occurring in MySQL from time to time in the prepared queries branch".

Proposed changes include:
* Insert only a diff of privacy_data
* Retry privacy update transaction
* Update eodbc. Return bigints as numbers, not binaries now
* Also NUMERIC type is overkill in pgsql, it's at least 10 bytes variable encoding. New installations would benefit from a smaller data type.