### PR TITLE
Mkdocs needs this to build the sitemap

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ docs_dir: doc
 theme:
   name: material
   favicon: favicon.ico
+site_url: https://esl.github.io/MongooseDocs/
 extra_templates: []
 extra_css: [css/custom.css, css/version-select.css]
 extra_javascript: [js/version-select.js]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,18 @@ docs_dir: doc
 theme:
   name: material
   favicon: favicon.ico
+extra:
+  version:
+    provider: mike
+  social:
+    - icon: fontawesome/brands/docker
+      link: https://hub.docker.com/r/mongooseim/mongooseim/
+    - icon: fontawesome/brands/github
+      link: https://github.com/esl/MongooseIM
+plugins:
+  - search:
+      lang: en
+repo_url: https://github.com/esl/MongooseIM
 site_url: https://esl.github.io/MongooseDocs/
 extra_templates: []
 extra_css: [css/custom.css, css/version-select.css]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ plugins:
   - search:
       lang: en
 repo_url: https://github.com/esl/MongooseIM
+edit_uri: edit/master/doc/
 site_url: https://esl.github.io/MongooseDocs/
 extra_templates: []
 extra_css: [css/custom.css, css/version-select.css]


### PR DESCRIPTION
Like all sites, it needs a sitemap, and mkdocs needs the site_url to be given to build so.

Also, add some links to general pages like our dockerhub or github.