### PR TITLE
Fix crash during handover session

### DIFF
--- a/src/p1_fsm_old.erl
+++ b/src/p1_fsm_old.erl
@@ -724,6 +724,8 @@ terminate(Reason, Name, Msg, Mod, StateName, StateData, Debug, Queue) ->
                     %% Priority shutdown should be considered as
                     %% shutdown by SASL
                     exit(shutdown);
+                {handover_session, _From} ->
+                    exit(normal);
                 {process_limit, _Limit} ->
                     exit(Reason);
                 {migrated, _Clone} ->


### PR DESCRIPTION
This PR addresses #
Fix issue crash during handover_session https://github.com/esl/MongooseIM/issues/2933.

Issue summary:
`ejabberd_c2s:handover_session` terminate with `{stop, {handover_session, From}, SD}.` which `p1_fsm_old:terminate` did not handle, so it goes to end of the case of `_` that generates an error info.

During handover_session, its last line call `p1_fsm_old` to terminate:
https://github.com/esl/MongooseIM/blob/135fec226fa3be355dcac6be5536821c78b34bb4/src/ejabberd_c2s.erl#L3183-L3192

in `p1_fsm_old`, there is no case to handle stop_reason `handover_session` hence it generates error:
https://github.com/esl/MongooseIM/blob/135fec226fa3be355dcac6be5536821c78b34bb4/src/p1_fsm_old.erl#L711-L735

Proposed changes include:
added a `{handover_session, _From}` as `Reason` to exit normally 

