### PR TITLE
Use prepared queries in ejabberd_auth_rdbms

### DIFF
--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -179,14 +179,22 @@ ascii_char_values() ->
 enum_char_values() ->
     [<<"A">>, <<"B">>, <<"C">>].
 
-like_texts() ->
+simple_like_texts() ->
     [#{text => <<"hello user!">>,
        not_matching => [<<"hi">>, <<"help">>],
        matching => [<<"hello">>, <<"user">>, <<"hell">>]},
      #{text => <<60,79,67,32,59,48,63,58,48>>,
        not_matching => [<<62,66,64,48,65,66,53,66>>],
-       matching => [<<60,79,67>>]}
-    ].
+       matching => [<<60,79,67>>]}].
+
+like_texts() ->
+    simple_like_texts() ++
+        [#{text => <<"abc%">>,
+           not_matching => [<<"ab%">>, <<"%bc%">>],
+           matching => [<<"abc%">>, <<"abc">>]},
+         #{text => <<"żółć_"/utf8>>,
+           not_matching => [<<"_ółć_"/utf8>>],
+           matching => [<<"żół"/utf8>>, <<"ółć_"/utf8>>]}].
 
 %%--------------------------------------------------------------------
 %% Test cases
@@ -303,7 +311,8 @@ safe_binary(_Len, Bin) ->
 %%--------------------------------------------------------------------
 
 select_like_case(Config) ->
-    [check_like(Config, TextMap) || TextMap <- like_texts()].
+    %% Non-prepared queries don't support proper LIKE escaping
+    [check_like(Config, TextMap) || TextMap <- simple_like_texts()].
 
 select_like_prep_case(Config) ->
     [check_like_prep(Config, TextMap) || TextMap <- like_texts()].
@@ -338,6 +347,9 @@ escape_boolean(_Config, Value) ->
 
 escape_like(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, escape_like, [Value]).
+
+escape_prepared_like(_Config, Value) ->
+    escalus_ejabberd:rpc(mongoose_rdbms, escape_prepared_like, [Value]).
 
 unescape_binary(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, unescape_binary, [host(), Value]).
@@ -807,7 +819,7 @@ check_like_prep(Config, TextMap = #{text := TextValue,
     Table = test_types,
     Fields = [<<"unicode">>],
     InsertQuery = <<"INSERT INTO test_types (unicode) VALUES (?)">>,
-    SelectQuery = <<"SELECT unicode FROM test_types WHERE unicode LIKE ?">>,
+    SelectQuery = <<"SELECT unicode FROM test_types WHERE unicode LIKE ? ESCAPE '$'">>,
     PrepareResult = sql_prepare(Config, Name, Table, Fields, InsertQuery),
     PrepareSelResult = sql_prepare(Config, SelName, Table, Fields, SelectQuery),
     Parameters = [TextValue],
@@ -824,7 +836,8 @@ check_like_prep(Config, TextMap = #{text := TextValue,
      || NotMatching <- NotMatchingList].
 
 check_like_matching_prep(SelName, Config, TextValue, Matching, Info) ->
-    Parameters = [<<"%", Matching/binary, "%">>],
+    SMatching = escape_prepared_like(Config, Matching),
+    Parameters = [<<"%", SMatching/binary, "%">>],
     SelectResult = sql_execute(Config, SelName, Parameters),
     %% Compare as binaries
     ?assert_equal_extra({selected, [{TextValue}]},
@@ -832,8 +845,9 @@ check_like_matching_prep(SelName, Config, TextValue, Matching, Info) ->
                         Info#{pattern => Matching,
                               select_result => SelectResult}).
 
-check_like_not_matching_prep(SelName, Config, TextValue, NotMatching, Info) ->
-    Parameters = [<<"%", NotMatching/binary, "%">>],
+check_like_not_matching_prep(SelName, Config, _TextValue, NotMatching, Info) ->
+    SNotMatching = escape_prepared_like(Config, NotMatching),
+    Parameters = [<<"%", SNotMatching/binary, "%">>],
     SelectResult = sql_execute(Config, SelName, Parameters),
     %% Compare as binaries
     ?assert_equal_extra({selected, []},

--- a/doc/advanced-configuration/auth.md
+++ b/doc/advanced-configuration/auth.md
@@ -126,6 +126,7 @@ However, for production systems other methods like `rdbms` are recommended, as u
 
 See the links below for options related to the particular methods:
 
+* [RDBMS method options](../authentication-methods/rdbms.md#configuration-options)
 * [Anonymous method options](../authentication-methods/anonymous.md#configuration-options)
 * [External method options](../authentication-methods/external.md#configuration-options)
 * [LDAP method options](../authentication-methods/ldap.md#configuration-options)

--- a/doc/advanced-configuration/general.md
+++ b/doc/advanced-configuration/general.md
@@ -53,15 +53,6 @@ There are some additional options that influence all database connections in the
 
 When using MSSQL or PostgreSQL databases, this option allows MongooseIM to optimize some queries for these DBs (e.g. `mod_mam_rdbms_user` uses different queries for `mssql`).
 
-### `general.pgsql_users_number_estimate`
-* **Scope:** local
-* **Syntax:** boolean
-* **Default:** false
-* **Example:** `pgsql_users_number_estimate = true`
-
-PostgreSQL's internal structure can make row counting slow.
-Enabling this option uses an alternative query instead of `SELECT COUNT`, that might be not as accurate, but is always fast.
-
 ## Access management
 
 User access rules are configured mainly in the [`acl`](acl.md) and [`access`](access.md) sections. Here you can find some additional options.

--- a/doc/advanced-configuration/host_config.md
+++ b/doc/advanced-configuration/host_config.md
@@ -27,7 +27,6 @@ The following sections are accepted in `host_config`:
 The options defined here override the ones defined in the top-level [`general`](general.md) section.
 The following options are allowed:
 
-* [`pgsql_users_number_estimate`](general.md#generalpgsql_users_number_estimate)
 * [`route_subdomains`](general.md#generalroute_subdomains)
 * [`replaced_wait_timeout`](general.md#generalreplaced_wait_timeout)
 * [`hide_service_name`](general.md#generalhide_service_name)
@@ -60,6 +59,7 @@ It is recommended to repeat all top-level options in the domain-specific section
     - [`password.*`](auth.md#password-related-options)
     - [`scram_iterations`](auth.md#authscram_iterations)
     - [`external.program`](../../authentication-methods/external/#authexternalprogram)
+    - [`rdbms.*`](../../authentication-methods/rdbms)
     - [`ldap.*`](../../authentication-methods/ldap)
     - [`jwt.*`](../../authentication-methods/jwt)
     - [`riak.*`](../../authentication-methods/riak)

--- a/doc/authentication-methods/rdbms.md
+++ b/doc/authentication-methods/rdbms.md
@@ -6,6 +6,17 @@ This authentication method stores user accounts in a relational database, e.g. M
 
 The `rdbms` method uses an outgoing connection pool of type `rdbms` with the `default` tag - it has to be defined in the `outgoing_pools` section.
 
+### `auth.rdbms.users_number_estimate`
+* **Scope:** local
+* **Syntax:** boolean
+* **Default:** false
+* **Example:** `users_number_estimate = true`
+
+By default querying MongooseIM for the number of registered users uses the `SELECT COUNT` query, which might be slow.
+Enabling this option makes MongooseIM use an alternative query that might be not as accurate, but is always fast.
+
+**Note:** this option is effective only for MySQL and PostgreSQL.
+
 ### Example
 
 Authentication:
@@ -13,6 +24,9 @@ Authentication:
 ```toml
 [auth]
   methods = ["rdbms"]
+
+  [auth.rdbms]
+    users_number_estimate = true
 ```
 
 Outgoing pools:

--- a/doc/migrations/4.1.0_4.x.x.md
+++ b/doc/migrations/4.1.0_4.x.x.md
@@ -1,0 +1,3 @@
+## Minor changes in the `TOML` config format
+
+* The `pgsql_users_number_estimate` option was moved to [`auth.rdbms.users_number_estimate`](../../authentication-methods/rdbms#authrdbmsusers_number_estimate). The new option supports PostgreSQL and MySQL.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - '3.7.0 to 4.0.0': 'migrations/3.7.0_4.0.0.md'
       - '4.0.0 to 4.0.1': 'migrations/4.0.0_4.0.1.md'
       - '4.0.1 to 4.1.0': 'migrations/4.0.1_4.1.0.md'
+      - '4.1.0 to 4.x.x': 'migrations/4.1.0_4.x.x.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - Platform:
       - 'Contributions to ecosystem': 'Contributions.md'

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -433,7 +433,8 @@ prepare_count_users(LServer) ->
                       "WHERE table_name = 'users'">>);
         {true, pgsql} ->
             prepare(auth_count_users_estimate, pg_class, [],
-                    <<"SELECT reltuples FROM pg_class WHERE oid = 'users'::regclass::oid">>);
+                    <<"SELECT reltuples::numeric FROM pg_class "
+                      "WHERE oid = 'users'::regclass::oid">>);
         _ ->
             prepare_count_users()
     end.

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -196,8 +196,6 @@ general() ->
                                                          format = override},
                                          validate = unique_non_empty,
                                          format = none},
-                 <<"pgsql_users_number_estimate">> => #option{type = boolean,
-                                                              format = host_local_config},
                  <<"route_subdomains">> => #option{type = atom,
                                                    validate = {enum, [s2s]},
                                                    format = host_local_config},
@@ -469,7 +467,8 @@ auth() ->
                  <<"http">> => auth_http(),
                  <<"jwt">> => auth_jwt(),
                  <<"ldap">> => auth_ldap(),
-                 <<"riak">> => auth_riak()},
+                 <<"riak">> => auth_riak(),
+                 <<"rdbms">> => auth_rdbms()},
        process = fun ?MODULE:process_auth/1,
        format = {foreach, host_local_config}
       }.
@@ -613,6 +612,15 @@ auth_riak() ->
     #section{
        items = #{<<"bucket_type">> => #option{type = binary,
                                               validate = non_empty}},
+       format = none
+      }.
+
+%% path: (host_config[].)auth.rdbms
+auth_rdbms() ->
+    #section{
+       items = #{<<"users_number_estimate">> => #option{type = boolean,
+                                                        format = {kv, rdbms_users_number_estimate}}
+                },
        format = none
       }.
 

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -36,11 +36,6 @@
          limit_offset_sql/0,
          limit_offset_args/2,
          sql_transaction/2,
-         get_password/2,
-         set_password_t/3,
-         add_user/3,
-         del_user/2,
-         del_user_return_password/3,
          list_users/1,
          list_users/2,
          users_number/1,
@@ -80,31 +75,6 @@ join([H|T], Sep) ->
 
 get_db_type() ->
     ?RDBMS_TYPE.
-
-
-%% Safe atomic update.
--spec update_t(Table, Fields, Vals, Where) -> term() when
-    Table :: binary(),
-    Fields :: list(binary()),
-    Vals :: list(mongoose_rdbms:escaped_value()),
-    Where :: mongoose_rdbms:sql_query_part().
-update_t(Table, Fields, Vals, Where) ->
-    UPairs = lists:zipwith(fun(A, B) -> [A, "=", mongoose_rdbms:use_escaped(B)] end,
-                           Fields, Vals),
-    case mongoose_rdbms:sql_query_t(
-           [<<"update ">>, Table, <<" set ">>,
-            join(UPairs, ", "),
-            <<" where ">>, Where, ";"]) of
-        {updated, 1} ->
-            ok;
-        _ ->
-            mongoose_rdbms:sql_query_t(
-              [<<"insert into ">>, Table, "(", join(Fields, ", "),
-               <<") values (">>, join_escaped(Vals), ");"])
-    end.
-
-join_escaped(Vals) ->
-    join([mongoose_rdbms:use_escaped(X) || X <- Vals], ", ").
 
 -spec execute_upsert(Host :: mongoose_rdbms:server(),
                      Name :: atom(),
@@ -217,58 +187,6 @@ begin_trans(mssql) ->
     rdbms_queries_mssql:begin_trans();
 begin_trans(_) ->
     [<<"BEGIN;">>].
-
-get_password(LServer, Username) ->
-    mongoose_rdbms:sql_query(
-      LServer,
-      [<<"select password, pass_details from users "
-       "where username=">>, mongoose_rdbms:use_escaped_string(Username), <<";">>]).
-
-set_password_t(LServer, Username, #{password := Pass, details := PassDetails}) ->
-    mongoose_rdbms:sql_transaction(
-      LServer,
-      fun() ->
-              update_t(<<"users">>, [<<"password">>, <<"pass_details">>],
-                       [Pass, PassDetails],
-                       [<<"username=">>, mongoose_rdbms:use_escaped_string(Username)])
-      end);
-set_password_t(LServer, Username, Pass) ->
-    mongoose_rdbms:sql_transaction(
-      LServer,
-      fun() ->
-              update_t(<<"users">>, [<<"username">>, <<"password">>],
-                       [Username, Pass],
-                       [<<"username=">>, mongoose_rdbms:use_escaped_string(Username)])
-      end).
-
-add_user(LServer, Username, #{password := Pass, details := PassDetails}) ->
-    mongoose_rdbms:sql_query(
-      LServer,
-      [<<"insert into users(username, password, pass_details) "
-       "values (">>, mongoose_rdbms:use_escaped_string(Username),
-           <<", ">>, mongoose_rdbms:use_escaped_string(Pass),
-           <<", ">>, mongoose_rdbms:use_escaped_string(PassDetails), <<");">>]);
-add_user(LServer, Username, Pass) ->
-    mongoose_rdbms:sql_query(
-      LServer,
-      [<<"insert into users(username, password) "
-         "values (">>, mongoose_rdbms:use_escaped_string(Username),
-           <<", ">>, mongoose_rdbms:use_escaped_string(Pass), <<");">>]).
-
-del_user(LServer, Username) ->
-    mongoose_rdbms:sql_query(
-      LServer,
-      [<<"delete from users where username=">>,
-           mongoose_rdbms:use_escaped_string(Username), ";"]).
-
-del_user_return_password(_LServer, Username, Pass) ->
-    P = mongoose_rdbms:sql_query_t(
-          [<<"select password from users where username=">>,
-           mongoose_rdbms:use_escaped_string(Username), ";"]),
-    mongoose_rdbms:sql_query_t([<<"delete from users "
-           "where username=">>, mongoose_rdbms:use_escaped_string(Username),
-           <<" and password=">>, mongoose_rdbms:use_escaped_string(Pass), ";"]),
-    P.
 
 list_users(LServer) ->
     mongoose_rdbms:sql_query(

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -50,7 +50,6 @@ groups() ->
                             http_server_name,
                             rdbms_server_type,
                             override,
-                            pgsql_users_number_estimate,
                             route_subdomains,
                             mongooseimctl_access_commands,
                             routing_modules,
@@ -111,7 +110,8 @@ groups() ->
                          auth_external_program,
                          auth_http_basic_auth,
                          auth_jwt,
-                         auth_riak_bucket_type]},
+                         auth_riak_bucket_type,
+                         auth_rdbms_users_number_estimate]},
      {pool, [parallel], [pool_type,
                          pool_tag,
                          pool_scope,
@@ -314,11 +314,6 @@ override(_Config) ->
         parse(#{<<"general">> => #{<<"override">> => [<<"local">>, <<"global">>, <<"acls">>]}})),
     ?err(parse(#{<<"general">> => #{<<"override">> => [<<"local">>, <<"global">>, <<"local">>]}})),
     ?err(parse(#{<<"general">> => #{<<"override">> => [<<"pingpong">>]}})).
-
-pgsql_users_number_estimate(_Config) ->
-    eq_host_config([#local_config{key = {pgsql_users_number_estimate, ?HOST}, value = true}],
-                  #{<<"general">> => #{<<"pgsql_users_number_estimate">> => true}}),
-    err_host_config(#{<<"general">> => #{<<"pgsql_users_number_estimate">> => 1200}}).
 
 route_subdomains(_Config) ->
     eq_host_config([#local_config{key = {route_subdomains, ?HOST}, value = s2s}],
@@ -894,6 +889,12 @@ auth_riak_bucket_type(_Config) ->
                                   value = [{bucket_type, <<"buckethead">>}]}],
                    auth_config(<<"riak">>, #{<<"bucket_type">> => <<"buckethead">>})),
     err_host_config(auth_config(<<"riak">>, #{<<"bucket_type">> => <<>>})).
+
+auth_rdbms_users_number_estimate(_Config) ->
+    eq_host_config([#local_config{key = {auth_opts, ?HOST},
+                                  value = [{rdbms_users_number_estimate, true}]}],
+                   auth_config(<<"rdbms">>, #{<<"users_number_estimate">> => true})),
+    err_host_config(auth_config(<<"rdbms">>, #{<<"users_number_estimate">> => 1200})).
 
 %% tests: outgoing_pools
 

--- a/test/config_parser_SUITE_data/miscellaneous.options
+++ b/test/config_parser_SUITE_data/miscellaneous.options
@@ -40,7 +40,8 @@
                {ldap_local_filter,{equal,{"accountStatus",["enabled"]}}},
                {ldap_pool_tag,default},
                {ldap_uids,["uid",{"uid2","%u"}]},
-               {bucket_type,<<"user_bucket">>}]}.
+               {bucket_type,<<"user_bucket">>},
+               {rdbms_users_number_estimate,true}]}.
 {local_config,{auth_opts,<<"localhost">>},
               [{extauth_program,"/usr/bin/authenticator"},
                {basic_auth,"admin:admin"},
@@ -55,13 +56,12 @@
                {ldap_local_filter,{equal,{"accountStatus",["enabled"]}}},
                {ldap_pool_tag,default},
                {ldap_uids,["uid",{"uid2","%u"}]},
-               {bucket_type,<<"user_bucket">>}]}.
+               {bucket_type,<<"user_bucket">>},
+               {rdbms_users_number_estimate,true}]}.
 {local_config,{extauth_instances,<<"anonymous.localhost">>},1}.
 {local_config,{extauth_instances,<<"localhost">>},1}.
 {local_config,{hide_service_name,<<"anonymous.localhost">>},true}.
 {local_config,{hide_service_name,<<"localhost">>},true}.
-{local_config,{pgsql_users_number_estimate,<<"anonymous.localhost">>},true}.
-{local_config,{pgsql_users_number_estimate,<<"localhost">>},true}.
 {local_config,{replaced_wait_timeout,<<"anonymous.localhost">>},2000}.
 {local_config,{replaced_wait_timeout,<<"localhost">>},2000}.
 {local_config,{route_subdomains,<<"anonymous.localhost">>},s2s}.

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -6,7 +6,6 @@
   http_server_name = "Apache"
   rdbms_server_type = "mssql"
   override = ["local", "global", "acls"]
-  pgsql_users_number_estimate = true
   route_subdomains = "s2s"
   routing_modules = [
       "mongoose_router_global",
@@ -54,6 +53,9 @@
     [[auth.ldap.uids]]
       attr = "uid2"
       format = "%u"
+
+  [auth.rdbms]
+    users_number_estimate = true
 
 [[listen.http]]
   port = 5280


### PR DESCRIPTION
**This PR includes the following changes:**
- Replace all plain queries in `ejabberd_auth_rdbms.erl` with their prepared equivalents
- Refactor code as it is already changed
- Improve and test Erlang-shell-only utilities for obtaining list and number of registered users.
- New tests revealed the following issues:
  - There were bugs in the corresponding functions in `ejabberd_auth_internal`- this is fixed now.
  - Prepared statements with `LIKE` were missing escaping. This is fixed and tested now.
  - The option `pgsql_users_number_estimate` was working for Postgres, but for MySQL an estimate was used by default, causing confusion and test failures. This is unified now and a new option `auth.rdbms.users_number_estimate` supports both Postgres and MySQL.

**Out of scope:**
- Change error handling in auth backends not to fabricate results in case of DB errors. It would require significant changes in multiple auth backends as they need to have consistent behaviour.
- Use prepared `LIKE` escaping in other places in the code base. This needs to be done later.
- `LIKE` escaping seems to be incomplete for MSSQL, even for plain queries. This might be investigated in the future.
- `LIKE` escaping is (and was) broken for plain queries, as shown by the new tests, but we are getting rid of such queries.
