### PR TITLE
[OS] fix type declaration

### DIFF
--- a/include/mod_muc_light.hrl
+++ b/include/mod_muc_light.hrl
@@ -119,6 +119,7 @@
                                   | {set, #create{}, UniqueRequested :: boolean()}
                                   | {set, #destroy{}, AffUsers :: aff_users()}
                                   | {set, #config{}, AffUsers :: aff_users()}
+                                  | {#msg{}, AffUsers :: aff_users()}
                                   | {error, bad_request}.
 
 -type msg() :: #msg{}.


### PR DESCRIPTION
In case I’m mixing up some type, I’m sharing this error dialyzer should have complained about:

https://github.com/esl/MongooseIM/blob/3ce2355ed0dc8b217dacdbfaf9e1cc1ce30177f0/src/muc_light/mod_muc_light_codec.erl#L32 says that encode’s first parameter is a muc_light_encode_request()

https://github.com/esl/MongooseIM/blob/3ce2355ed0dc8b217dacdbfaf9e1cc1ce30177f0/src/muc_light/mod_muc_light_codec_modern.erl#L50 the first head of encode in the actual implementation takes a {msg(), aff_users()}

https://github.com/esl/MongooseIM/blob/3ce2355ed0dc8b217dacdbfaf9e1cc1ce30177f0/include/mod_muc_light.hrl#L115-L122 does not define {msg(), aff_users()} as any of the possibilities for this type

This arose when writing a custom codec for a client that would modify a couple of requests but just forward everything else to the _modern_ codec, only when calling encode directly with an actual value, dialyzer complained.