### PR TITLE
Multi tenancy init

### DIFF
--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -1,13 +1,4 @@
-%%%-------------------------------------------------------------------
-%%% @author denysgonchar
-%%% @copyright (C) 2021, <COMPANY>
-%%% @doc
-%%%
-%%% @end
-%%% Created : 22. Mar 2021 19:38
-%%%-------------------------------------------------------------------
 -module(dynamic_domains_pm_SUITE).
--author("denysgonchar").
 
 %% API
 -compile(export_all).

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -1,0 +1,35 @@
+%%%-------------------------------------------------------------------
+%%% @author denysgonchar
+%%% @copyright (C) 2021, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 22. Mar 2021 19:38
+%%%-------------------------------------------------------------------
+-module(dynamic_domains_pm_SUITE).
+-author("denysgonchar").
+
+%% API
+-compile(export_all).
+-import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4]).
+
+suite() ->
+    require_rpc_nodes([mim, mim2]).
+
+
+all() ->
+    [can_authenticate].
+
+init_per_suite(Config) ->
+    rpc(mim(), mongoose_domain_core, insert, [<<"example.com">>, <<"test type">>]),
+    rpc(mim2(), mongoose_domain_core, insert, [<<"example.com">>, <<"test type">>]),
+    Config.
+
+end_per_suite(Config) ->
+    rpc(mim(), mongoose_domain_core, delete, [<<"example.com">>]),
+    rpc(mim2(), mongoose_domain_core, delete, [<<"example.com">>]),
+    Config.
+
+can_authenticate(Config) ->
+    %% TODO: implement later
+    ok.

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -12,8 +12,11 @@ all() ->
     [can_authenticate].
 
 init_per_suite(Config) ->
-    rpc(mim(), mongoose_domain_core, insert, [<<"example.com">>, <<"test type">>]),
-    rpc(mim2(), mongoose_domain_core, insert, [<<"example.com">>, <<"test type">>]),
+    Domain = <<"example.com">>,
+    HostType = <<"test type">>,
+    Source = dummy_source,
+    rpc(mim(), mongoose_domain_core, insert, [Domain, HostType, Source]),
+    rpc(mim2(), mongoose_domain_core, insert, [Domain, HostType, Source]),
     Config.
 
 end_per_suite(Config) ->

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -11,14 +11,13 @@ suite() ->
 
 all() ->
     [
-     core_lookup_works,
-     core_lookup_not_found,
-     core_static_domain,
-     core_cannot_insert_static,
-     core_cannot_disable_static,
-     core_cannot_enable_static,
-     core_get_all_static,
-     core_get_domains_by_host_type,
+     api_lookup_works,
+     api_lookup_not_found,
+     api_cannot_insert_static,
+     api_cannot_disable_static,
+     api_cannot_enable_static,
+     api_get_all_static,
+     api_get_domains_by_host_type,
      {group, db}
     ].
 
@@ -150,39 +149,36 @@ end_per_testcase(_TestcaseName, Config) ->
 %% Tests
 %%--------------------------------------------------------------------
 
-core_lookup_works(_) ->
+api_lookup_works(_) ->
     {ok, <<"type1">>} = get_host_type(mim(), <<"example.cfg">>).
 
-core_lookup_not_found(_) ->
+api_lookup_not_found(_) ->
     {error, not_found} = get_host_type(mim(), <<"example.missing">>).
 
-core_static_domain(_) ->
-    true = is_static(<<"example.cfg">>).
-
-core_cannot_insert_static(_) ->
+api_cannot_insert_static(_) ->
     {error, static} = insert_domain(mim(), <<"example.cfg">>, <<"type1">>).
 
-core_cannot_disable_static(_) ->
+api_cannot_disable_static(_) ->
     {error, static} = disable_domain(mim(), <<"example.cfg">>).
 
-core_cannot_enable_static(_) ->
+api_cannot_enable_static(_) ->
     {error, static} = enable_domain(mim(), <<"example.cfg">>).
 
 %% See also db_get_all_static
-core_get_all_static(_) ->
+api_get_all_static(_) ->
     %% Could be in any order
     [{<<"erlang-solutions.com">>, <<"type2">>},
      {<<"erlang-solutions.local">>, <<"type2">>},
      {<<"example.cfg">>, <<"type1">>}] =
         lists:sort(get_all_static(mim())).
 
-core_get_domains_by_host_type(_) ->
+api_get_domains_by_host_type(_) ->
     [<<"erlang-solutions.com">>, <<"erlang-solutions.local">>] =
         lists:sort(get_domains_by_host_type(mim(), <<"type2">>)),
     [<<"example.cfg">>] = get_domains_by_host_type(mim(), <<"type1">>),
     [] = get_domains_by_host_type(mim(), <<"type6">>).
 
-%% Similar to as core_get_all_static, just with DB service enabled
+%% Similar to as api_get_all_static, just with DB service enabled
 db_get_all_static(_) ->
     ok = insert_domain(mim(), <<"example.db">>, <<"type1">>),
     sync(),
@@ -475,9 +471,6 @@ disable_domain(Node, Domain) ->
 
 enable_domain(Node, Domain) ->
     rpc(Node, mongoose_domain_api, enable_domain, [Domain]).
-
-is_static(Domain) ->
-    rpc(mim(), mongoose_domain_core, is_static, [Domain]).
 
 %% Call sync before get_host_type, if there are some async changes expected
 sync() ->

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -318,7 +318,7 @@ db_events_table_gets_truncated(_) ->
     ok = insert_domain(mim(), <<"example.net">>, <<"dbgroup">>),
     ok = insert_domain(mim(), <<"example.org">>, <<"dbgroup">>),
     ok = insert_domain(mim(), <<"example.beta">>, <<"dbgroup">>),
-    Max = get_max_event_id(mim()),
+    Max = get_max_event_id_or_set_dummy(mim()),
     true = is_integer(Max),
     true = Max > 0,
     %% The events table is not empty and the size of 1, eventually.
@@ -396,7 +396,7 @@ db_out_of_sync_crashes_node(_) ->
     ok = insert_domain(mim2(), <<"example4.com">>, <<"type1">>),
     sync_local(mim2()),
     %% Truncate events table, keep only one event
-    MaxId = get_max_event_id(mim2()),
+    MaxId = get_max_event_id_or_set_dummy(mim2()),
     {updated, _} = delete_events_older_than(mim2(), MaxId),
     {error, not_found} = get_host_type(mim(), <<"example3.com">>),
     %% Resume processing events on one node
@@ -453,8 +453,8 @@ prepare_test_queries(Node) ->
 get_min_event_id(Node) ->
     rpc(Node, mongoose_domain_sql, get_min_event_id, []).
 
-get_max_event_id(Node) ->
-    rpc(Node, mongoose_domain_sql, get_max_event_id, []).
+get_max_event_id_or_set_dummy(Node) ->
+    rpc(Node, mongoose_domain_sql, get_max_event_id_or_set_dummy, []).
 
 delete_events_older_than(Node, Id) ->
     rpc(Node, mongoose_domain_sql, delete_events_older_than, [Id]).

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -68,8 +68,8 @@ init_per_suite(Config) ->
     ensure_nodes_know_each_other(),
     service_disabled(mim()),
     service_disabled(mim2()),
-    prepare_erase(mim()),
-    prepare_erase(mim2()),
+    prepare_test_queries(mim()),
+    prepare_test_queries(mim2()),
     erase_database(mim()),
     escalus:init_per_suite([{mim_conf1, Conf1}, {mim_conf2, Conf2}|Config]).
 
@@ -446,9 +446,9 @@ erase_database(Node) ->
         false -> ok
     end.
 
-prepare_erase(Node) ->
+prepare_test_queries(Node) ->
     case mongoose_helper:is_rdbms_enabled(domain()) of
-        true -> rpc(Node, mongoose_domain_sql, prepare_erase, []);
+        true -> rpc(Node, mongoose_domain_sql, prepare_test_queries, []);
         false -> ok
     end.
 
@@ -506,10 +506,10 @@ setup_meck(db_initial_load_crashes_node) ->
     ok = rpc(mim(), meck, new, [mongoose_domain_sql, [passthrough, no_link]]),
     ok = rpc(mim(), meck, expect, [mongoose_domain_sql, select_from, 2, something_strange]),
     ok = rpc(mim(), meck, new, [mongoose_domain_utils, [passthrough, no_link]]),
-    ok = rpc(mim(), meck, expect, [mongoose_domain_utils, halt_node, 1, ok]);
+    ok = rpc(mim(), meck, expect, [mongoose_domain_utils, halt_node, 1, []]);
 setup_meck(db_out_of_sync_crashes_node) ->
     ok = rpc(mim(), meck, new, [mongoose_domain_utils, [passthrough, no_link]]),
-    ok = rpc(mim(), meck, expect, [mongoose_domain_utils, halt_node, 1, ok]).
+    ok = rpc(mim(), meck, expect, [mongoose_domain_utils, halt_node, 1, []]).
 
 teardown_meck() ->
     rpc(mim(), meck, unload, []).

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -33,8 +33,8 @@ db_cases() -> [
      db_deleted_domain_from_core,
      db_disabled_domain_is_in_db,
      db_disabled_domain_not_in_core,
-     db_reanabled_domain_is_in_db,
-     db_reanabled_domain_is_in_core,
+     db_reenabled_domain_is_in_db,
+     db_reenabled_domain_is_in_core,
      db_can_insert_domain_twice_with_the_same_host_type,
      db_cannot_insert_domain_twice_with_the_another_host_type,
      db_cannot_insert_domain_with_unknown_host_type,
@@ -233,14 +233,14 @@ db_disabled_domain_not_in_core(_) ->
     sync(),
     {error, not_found} = get_host_type(mim(), <<"example.db">>).
 
-db_reanabled_domain_is_in_db(_) ->
+db_reenabled_domain_is_in_db(_) ->
     ok = insert_domain(mim(), <<"example.db">>, <<"type1">>),
     ok = disable_domain(mim(), <<"example.db">>),
     ok = enable_domain(mim(), <<"example.db">>),
     {ok, #{host_type := <<"type1">>, enabled := true}} =
        select_domain(mim(), <<"example.db">>).
 
-db_reanabled_domain_is_in_core(_) ->
+db_reenabled_domain_is_in_core(_) ->
     ok = insert_domain(mim(), <<"example.db">>, <<"type1">>),
     ok = disable_domain(mim(), <<"example.db">>),
     ok = enable_domain(mim(), <<"example.db">>),

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -429,7 +429,7 @@ service_disabled(Node) ->
 
 init_with(Node, Pairs, AllowedHostTypes) ->
     rpc(Node, mongoose_domain_core, stop, []),
-    rpc(Node, mongoose_domain_api, init, [Pairs, AllowedHostTypes]).
+    rpc(Node, mongoose_domain_core, start, [Pairs, AllowedHostTypes]).
 
 insert_domain(Node, Domain, HostType) ->
     rpc(Node, mongoose_domain_api, insert_domain, [Domain, HostType]).

--- a/doc/developers-guide/domain_management.md
+++ b/doc/developers-guide/domain_management.md
@@ -14,7 +14,7 @@ It must provide the following interfaces:
   Any of these lists can be empty, initial list of domain/host\_type pairs can
   have some unique host\_types not mentioned in the host\_types list.
   The component must be initialised by the main MIM supervisor.
-  Implemented in `mongoose_domain_api:init(Pairs)`.
+  Implemented in `mongoose_domain_api:init()`.
 - Insert - adding new domain/host\_type pair.
   This function must be **idempotent**, it must return success on attempt to
   insert the existing data, but it must fail if ETS already has the domain

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -1,6 +1,7 @@
 [general]
   loglevel = "warning"
   hosts = [{{{hosts}}}]
+  host_types = ["test type"]
   registration_timeout = "infinity"
   language = "en"
   all_metrics_are_global = {{{all_metrics_are_global}}}
@@ -12,6 +13,11 @@
   {{#rdbms_server_type}}
   rdbms_server_type = {{{rdbms_server_type}}}
   {{/rdbms_server_type}}
+
+[[host_config]]
+  host_type = "test type"
+  modules = { }
+  auth = { methods = ["dummy"] }
 
 [[listen.http]]
   port = {{{http_port}}}

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -1,7 +1,7 @@
 [general]
   loglevel = "warning"
   hosts = [{{{hosts}}}]
-  host_types = ["test type"]
+  host_types = [{{{host_types}}}]
   registration_timeout = "infinity"
   language = "en"
   all_metrics_are_global = {{{all_metrics_are_global}}}
@@ -13,11 +13,6 @@
   {{#rdbms_server_type}}
   rdbms_server_type = {{{rdbms_server_type}}}
   {{/rdbms_server_type}}
-
-[[host_config]]
-  host_type = "test type"
-  modules = { }
-  auth = { methods = ["dummy"] }
 
 [[listen.http]]
   port = {{{http_port}}}

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -5,6 +5,8 @@
 {hidden_service_port, 8189}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
+{host_types, "\"test type\""}.
+
 {host_config,
   "[[host_config]]
   host = \"anonymous.localhost\"
@@ -12,7 +14,12 @@
   [host_config.auth]
     methods = [\"anonymous\"]
     anonymous.allow_multiple_connections = true
-    anonymous.protocol = \"both\""}.
+    anonymous.protocol = \"both\"
+
+[[host_config]]
+  host_type = \"test type\"
+  modules = { }
+  auth = { methods = [\"dummy\"] }"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
 {scram_iterations, 64}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -50,3 +50,10 @@
 
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+
+{host_types, "\"test type\""}.
+{host_config,
+  "[[host_config]]
+  host_type = \"test type\"
+  modules = { }
+  auth = { methods = [\"dummy\"] }"}.

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -108,7 +108,7 @@ check_domain(Domain, HostType) ->
     Locked = mongoose_domain_core:is_static(Domain),
     Allowed = mongoose_domain_core:is_host_type_allowed(HostType),
     HasDb = service_domain_db:enabled(),
-    if 
+    if
         Locked ->
            {error, static};
        not Allowed ->

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -96,7 +96,7 @@ get_host_type(Domain) ->
 get_all_static() ->
     mongoose_domain_core:get_all_static().
 
-%% Get the list of the host\_types provided during initialisation
+%% Get the list of the host_types provided during initialisation
 %% This has complexity N, where N is the number of online domains.
 -spec get_domains_by_host_type(host_type()) -> [domain()].
 get_domains_by_host_type(HostType) ->

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -2,7 +2,7 @@
 %% management.
 -module(mongoose_domain_api).
 
--export([init/2,
+-export([init/0,
          insert_domain/2,
          delete_domain/2,
          disable_domain/1,
@@ -15,9 +15,11 @@
 -type host_type() :: binary().
 -type pair() :: {domain(), host_type()}.
 
-%% Domains should be nameprepped using `jid:nameprep'
--spec init([pair()], [host_type()]) -> ok | {error, term()}.
-init(Pairs, AllowedHostTypes) ->
+
+-spec init() -> ok | {error, term()}.
+init() ->
+    Pairs = get_static_pairs(),
+    AllowedHostTypes = ejabberd_config:get_global_option_or_default(host_types, []),
     mongoose_domain_core:start(Pairs, AllowedHostTypes).
 
 %% Domain should be nameprepped using `jid:nameprep'.
@@ -116,3 +118,8 @@ check_domain(Domain, HostType) ->
        true ->
             ok
     end.
+
+%% Domains should be nameprepped using `jid:nameprep'
+-spec get_static_pairs() -> [{domain(), host_type()}].
+get_static_pairs() ->
+    [{H, H} || H <- ejabberd_config:get_global_option_or_default(hosts, [])].

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -105,17 +105,17 @@ get_domains_by_host_type(HostType) ->
     mongoose_domain_core:get_domains_by_host_type(HostType).
 
 check_domain(Domain, HostType) ->
-    Locked = mongoose_domain_core:is_static(Domain),
+    Static = mongoose_domain_core:is_static(Domain),
     Allowed = mongoose_domain_core:is_host_type_allowed(HostType),
     HasDb = service_domain_db:enabled(),
     if
-        Locked ->
-           {error, static};
-       not Allowed ->
-           {error, unknown_host_type};
-       not HasDb ->
-           {error, service_disabled};
-       true ->
+        Static ->
+            {error, static};
+        not Allowed ->
+            {error, unknown_host_type};
+        not HasDb ->
+            {error, service_disabled};
+        true ->
             ok
     end.
 

--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -171,7 +171,7 @@ insert_initial_pair(Tab, Domain, HostType) ->
 new_object(Domain, HostType, Source) ->
     {Domain, HostType, Source}.
 
-just_ok({ok,_}) -> ok;
+just_ok({ok, _}) -> ok;
 just_ok(Other) -> Other.
 
 insert_host_types(Tab, AllowedHostTypes) ->

--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -167,11 +167,12 @@ handle_delete(Domain) ->
     case is_static(Domain) of
         true ->
             %% Ignore any static domains
-            ?LOG_ERROR(#{what => domain_static_but_was_in_db, domain => Domain});
+            ?LOG_ERROR(#{what => domain_static_but_was_in_db, domain => Domain}),
+            {error, static};
         false ->
-            ets:delete(?TABLE, Domain)
-    end,
-    ok.
+            ets:delete(?TABLE, Domain),
+            ok
+    end.
 
 handle_insert(Domain, HostType, Source) ->
     case is_host_type_allowed(HostType) of

--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -30,6 +30,16 @@
 -define(TABLE, ?MODULE).
 -define(HOST_TYPE_TABLE, mongoose_domain_core_host_types).
 
+-ifdef(TEST).
+%% required for unit tests
+start(Pairs, AllowedHostTypes) ->
+    gen_server:start({local, ?MODULE}, ?MODULE, [Pairs, AllowedHostTypes], []).
+
+stop() ->
+    gen_server:stop(?MODULE).
+
+-else.
+
 start(Pairs, AllowedHostTypes) ->
     ChildSpec =
         {?MODULE,
@@ -37,11 +47,13 @@ start(Pairs, AllowedHostTypes) ->
          permanent, infinity, worker, [?MODULE]},
     just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
 
-%% For tests
+%% required for integration tests
 stop() ->
     supervisor:terminate_child(ejabberd_sup, ?MODULE),
     supervisor:delete_child(ejabberd_sup, ?MODULE),
     ok.
+
+-endif.
 
 start_link(Pairs, AllowedHostTypes) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [Pairs, AllowedHostTypes], []).

--- a/src/domain/mongoose_domain_db_cleaner.erl
+++ b/src/domain/mongoose_domain_db_cleaner.erl
@@ -76,7 +76,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% Server helpers
 
 schedule_removal(State = #{max_age := MaxAge}) ->
-    LastEventId = mongoose_domain_sql:get_max_event_id(),
+    LastEventId = mongoose_domain_sql:get_max_event_id_or_set_dummy(),
     Msg = {do_removal, LastEventId},
     erlang:start_timer(timer:seconds(MaxAge), self(), Msg),
     State.

--- a/src/domain/mongoose_domain_db_cleaner.erl
+++ b/src/domain/mongoose_domain_db_cleaner.erl
@@ -77,13 +77,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 schedule_removal(State = #{max_age := MaxAge}) ->
     LastEventId = mongoose_domain_sql:get_max_event_id(),
-    case LastEventId of
-        0 ->
-            ok; %% Ignore an empty event table
-        _ ->
-            Msg = {do_removal, LastEventId},
-            erlang:start_timer(timer:seconds(MaxAge), self(), Msg)
-    end,
+    Msg = {do_removal, LastEventId},
+    erlang:start_timer(timer:seconds(MaxAge), self(), Msg),
     State.
 
 handle_timeout(_TimerRef, {do_removal, LastEventId}, State) ->

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -1,7 +1,7 @@
 -module(mongoose_domain_loader).
 -export([load_data_from_base/2,
          check_for_updates/2,
-         remove_outdated_domains/0]).
+         remove_outdated_domains_from_core/0]).
 
 -include("mongoose_logger.hrl").
 
@@ -28,7 +28,7 @@ load_data_from_base_loop(FromId, PageSize) ->
             load_data_from_base_loop(PageMaxId, PageSize)
     end.
 
-remove_outdated_domains() ->
+remove_outdated_domains_from_core() ->
     OutdatedDomains = mongoose_domain_core:get_all_outdated(),
     remove_domains(OutdatedDomains).
 
@@ -106,7 +106,7 @@ maybe_insert_to_core(Domain, HostType) ->
 remove_domains(DomainsWithHostTypes) ->
     lists:foreach(fun remove_domain/1, DomainsWithHostTypes).
 
-remove_domain({Domain,_HostType}) ->
+remove_domain({Domain, _HostType}) ->
     mongoose_domain_core:delete(Domain).
 
 row_to_id({Id, _Domain, _HostType}) ->

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -55,6 +55,8 @@ check_for_updates(FromId, PageSize) ->
 
 check_if_id_is_still_relevant(FromId, Rows) ->
     MinId = row_to_id(hd(Rows)),
+    %% FromID should be always equal or less than MinID,
+    %% see check_for_updates/2 function for more details
     if
         FromId =:= MinId ->
             tl(Rows);
@@ -62,7 +64,7 @@ check_if_id_is_still_relevant(FromId, Rows) ->
             %% looks like someone completely erased the events table
             %% this should not happen, but we are still fine.
             Rows;
-        true ->
+        FromId < MinId - 1 ->
             %% Looks like this node has no DB connection for a long time.
             %% But the event log in the DB has been truncated by some other node
             %% meanwhile. We have to load the whole set of data from DB.

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -15,7 +15,7 @@ load_data_from_base(FromId, PageSize) ->
                               from_id => FromId,
                               class => Class, reason => Reason,
                               stacktrace => Stacktrace}),
-              service_domain_db:reset()
+              service_domain_db:restart()
     end.
 
 load_data_from_base_loop(FromId, PageSize) ->
@@ -70,7 +70,7 @@ check_if_id_is_still_relevant(FromId, Rows) ->
                      " which we have not applied yet. Have to crash.">>,
             ?LOG_CRITICAL(#{what => events_log_out_of_sync,
                             text => Text, min_db => MinId, from_id => FromId}),
-            service_domain_db:reset(),
+            service_domain_db:restart(),
             []
     end.
 

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -1,6 +1,7 @@
 -module(mongoose_domain_loader).
--export([load_data_from_base/2]).
--export([check_for_updates/2]).
+-export([load_data_from_base/2,
+         check_for_updates/2,
+         remove_outdated_domains/0]).
 
 -include("mongoose_logger.hrl").
 
@@ -26,6 +27,10 @@ load_data_from_base_loop(FromId, PageSize) ->
             insert_rows_to_core(Rows),
             load_data_from_base_loop(PageMaxId, PageSize)
     end.
+
+remove_outdated_domains() ->
+    OutdatedDomains = mongoose_domain_core:get_all_outdated(),
+    remove_domains(OutdatedDomains).
 
 check_for_updates(FromId, PageSize) ->
     %% Ordered by the earliest events first
@@ -86,6 +91,12 @@ insert_rows_to_core(Rows) ->
 
 insert_row_to_core({_Id, Domain, HostType}) ->
     mongoose_domain_core:insert(Domain, HostType).
+
+remove_domains(DomainsWithHostTypes) ->
+    lists:foreach(fun remove_domain/1, DomainsWithHostTypes).
+
+remove_domain({Domain,_HostType}) ->
+    mongoose_domain_core:delete(Domain).
 
 row_to_id({Id, _Domain, _HostType}) ->
     Id.

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -28,8 +28,8 @@ load_data_from_base_loop(FromId, PageSize) ->
     end.
 
 check_for_updates(FromId, PageSize) ->
-    check_if_from_num_still_relevant(FromId),
-    %% Ordered by the earlist events first
+    check_if_id_is_still_relevant(FromId),
+    %% Ordered by the earliest events first
     try mongoose_domain_sql:select_updates_from(FromId, PageSize) of
         [] -> FromId;
         Rows ->
@@ -47,9 +47,9 @@ check_for_updates(FromId, PageSize) ->
 
 %% Be aware that for this check to work, the cleaner should keep at least
 %% one record in domain_events table.
-check_if_from_num_still_relevant(0) ->
+check_if_id_is_still_relevant(0) ->
     ok;
-check_if_from_num_still_relevant(FromId) ->
+check_if_id_is_still_relevant(FromId) ->
     Min = mongoose_domain_sql:get_min_event_id(),
     if Min =:= 0 ->
             %% Nothing to do, there were no updates done ever in the DB

--- a/src/domain/mongoose_domain_utils.erl
+++ b/src/domain/mongoose_domain_utils.erl
@@ -1,6 +1,0 @@
--module(mongoose_domain_utils).
--export([halt_node/1]).
-
-halt_node(ExitText) ->
-    timer:sleep(1000),
-    halt(string:substr(ExitText, 1, 199)).

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -110,12 +110,11 @@ code_change(_OldVsn, State, _Extra) ->
 %% Server helpers
 
 initial_load(undefined) ->
-    link(whereis(mongoose_domain_core)),
     LastEventId = mongoose_domain_sql:get_max_event_id(),
     PageSize = 10000,
     mongoose_domain_loader:load_data_from_base(0, PageSize),
+    mongoose_domain_loader:remove_outdated_domains(),
     mongoose_domain_core:set_last_event_id(LastEventId),
-    unlink(whereis(mongoose_domain_core)),
     LastEventId;
 initial_load(LastEventId) when is_integer(LastEventId) ->
     LastEventId. %% Skip initial init

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -81,7 +81,7 @@ sync_local() ->
 init([]) ->
     pg2:create(?GROUP),
     pg2:join(?GROUP, self()),
-    gen_server:cast(self(),initial_loading),
+    gen_server:cast(self(), initial_loading),
     %% initial state will be set on initial_loading processing
     {ok, #{}}.
 
@@ -121,10 +121,10 @@ code_change(_OldVsn, State, _Extra) ->
 %% Server helpers
 
 initial_load(undefined) ->
-    LastEventId = mongoose_domain_sql:get_max_event_id(),
+    LastEventId = mongoose_domain_sql:get_max_event_id_or_set_dummy(),
     PageSize = 10000,
     mongoose_domain_loader:load_data_from_base(0, PageSize),
-    mongoose_domain_loader:remove_outdated_domains(),
+    mongoose_domain_loader:remove_outdated_domains_from_core(),
     mongoose_domain_core:set_last_event_id(LastEventId),
     LastEventId;
 initial_load(LastEventId) when is_integer(LastEventId) ->

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -58,8 +58,7 @@ start(normal, _Args) ->
     connect_nodes(),
     mongoose_deprecations:start(),
     {ok, _} = Sup = ejabberd_sup:start_link(),
-    %% TODO provide Pairs and AllowedHostTypes arguments
-    mongoose_domain_api:init([], []),
+    mongoose_domain_api:init(),
     mongoose_wpool:ensure_started(),
     mongoose_wpool:start_configured_pools(),
     %% ejabberd_sm is started separately because it may use one of the outgoing_pools

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -30,6 +30,7 @@
          load_file/1,
          add_global_option/2,
          get_global_option/1,
+         get_global_option_or_default/2,
          add_local_option/2,
          get_local_option/1,
          get_local_option/2,
@@ -190,6 +191,15 @@ get_global_option(Opt) ->
             Val;
         _ ->
             undefined
+    end.
+
+-spec get_global_option_or_default(key(), value()) -> value().
+get_global_option_or_default(Opt, DefaultValue) ->
+    case ets:lookup(config, Opt) of
+        [#config{value = Val}] ->
+            Val;
+        _ ->
+            DefaultValue
     end.
 
 -spec get_local_option(key()) -> value() | undefined.

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -2,50 +2,123 @@
 
 -compile(export_all).
 
-all() ->
-    [
-        core_lookup_works,
-        core_lookup_not_found,
-        core_static_domain,
-        core_cannot_insert_static,
-        core_get_all_static,
-        core_get_domains_by_host_type
-    ].
+-include_lib("eunit/include/eunit.hrl").
 
-init_per_suite(Config) ->
-    Pairs = [{<<"example.cfg">>, <<"type1">>},
-              {<<"erlang-solutions.com">>, <<"type2">>},
-              {<<"erlang-solutions.local">>, <<"type2">>}],
-    CommonTypes = [<<"type1">>, <<"type2">>, <<"dbgroup">>, <<"dbgroup2">>, <<"cfggroup">>],
-    mongoose_domain_core:start(Pairs, CommonTypes),
+-define(STATIC_PAIRS, [{<<"example.cfg">>, <<"type #1">>},
+                       {<<"erlang-solutions.com">>, <<"type #2">>},
+                       {<<"erlang-solutions.local">>, <<"static type">>}, %% not allowed type
+                       {<<"example.org">>, <<"type #2">>}]).
+-define(ALLOWED_TYPES, [<<"type #1">>, <<"type #2">>, <<"type #3">>]).
+
+-define(assertEqualLists(L1, L2), ?assertEqual(lists:sort(L1), lists:sort(L2))).
+
+all() ->
+    [can_get_init_arguments,
+     lookup_works,
+     double_insert_double_remove_works,
+     static_domain_check,
+     cannot_delete_static,
+     cannot_insert_static_domain,
+     cannot_insert_if_host_type_not_configured,
+     get_all_static,
+     get_domains_by_host_type,
+     host_type_check,
+     can_get_outdated_domains].
+
+init_per_testcase(_, Config) ->
+    mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_TYPES),
     Config.
 
-end_per_suite(Config) ->
+end_per_testcase(_, Config) ->
     mongoose_domain_core:stop(),
     Config.
 
-core_lookup_works(_) ->
-    {ok, <<"type1">>} = mongoose_domain_core:get_host_type(<<"example.cfg">>).
+can_get_init_arguments(_) ->
+    [?STATIC_PAIRS, ?ALLOWED_TYPES] = mongoose_domain_core:get_start_args().
 
-core_lookup_not_found(_) ->
-    {error, not_found} = mongoose_domain_core:get_host_type(<<"example.missing">>).
+lookup_works(_) ->
+    {ok, <<"type #1">>} = mongoose_domain_core:get_host_type(<<"example.cfg">>),
+    {ok, <<"static type">>} = mongoose_domain_core:get_host_type(<<"erlang-solutions.local">>),
+    {error, not_found} = mongoose_domain_core:get_host_type(<<"some.domain">>),
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #3">>, dummy_src),
+    {ok, <<"type #3">>} = mongoose_domain_core:get_host_type(<<"some.domain">>),
+    ok = mongoose_domain_core:delete(<<"some.domain">>),
+    {error, not_found} = mongoose_domain_core:get_host_type(<<"some.domain">>).
 
-core_static_domain(_) ->
-    true = mongoose_domain_core:is_static(<<"example.cfg">>).
+double_insert_double_remove_works(_) ->
+    {error, not_found} = mongoose_domain_core:get_host_type(<<"some.domain">>),
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #3">>, dummy_src),
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #3">>, dummy_src),
+    {ok, <<"type #3">>} = mongoose_domain_core:get_host_type(<<"some.domain">>),
+    ok = mongoose_domain_core:delete(<<"some.domain">>),
+    ok = mongoose_domain_core:delete(<<"some.domain">>),
+    {error, not_found} = mongoose_domain_core:get_host_type(<<"some.domain">>).
 
-core_cannot_insert_static(_) ->
-    {error, static} = mongoose_domain_core:insert(<<"example.cfg">>, <<"type1">>, dummy_src).
+static_domain_check(_) ->
+    true = mongoose_domain_core:is_static(<<"example.cfg">>),
+    false = mongoose_domain_core:is_static(<<"some.domain">>), %% not configured yet
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #1">>, dummy_src),
+    false = mongoose_domain_core:is_static(<<"some.domain">>).
+
+cannot_delete_static(_) ->
+    {error, static} = mongoose_domain_core:delete(<<"example.cfg">>),
+    {error, static} = mongoose_domain_core:delete(<<"erlang-solutions.local">>).
+
+cannot_insert_static_domain(_) ->
+    {error, static} = mongoose_domain_core:insert(<<"example.cfg">>, <<"type #1">>, dummy_src),
+    {error, static} = mongoose_domain_core:insert(<<"erlang-solutions.local">>, <<"type #3">>,
+                                                  dummy_src).
+
+cannot_insert_if_host_type_not_configured(_) ->
+    {ok, StaticHostType} = mongoose_domain_core:get_host_type(<<"erlang-solutions.local">>),
+    {error, unknown_host_type} = mongoose_domain_core:insert(<<"erlang-solutions.local">>,
+                                                             StaticHostType, dummy_src),
+    {error, unknown_host_type} = mongoose_domain_core:insert(<<"erlang-solutions.local">>,
+                                                             <<"invalid type">>, dummy_src).
 
 %% See also db_get_all_static
-core_get_all_static(_) ->
-    %% Could be in any order
-    [{<<"erlang-solutions.com">>, <<"type2">>},
-     {<<"erlang-solutions.local">>, <<"type2">>},
-     {<<"example.cfg">>, <<"type1">>}] =
-        lists:sort(mongoose_domain_core:get_all_static()).
+get_all_static(_) ->
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #1">>, dummy_src),
+    ?assertEqualLists(?STATIC_PAIRS, mongoose_domain_core:get_all_static()).
 
-core_get_domains_by_host_type(_) ->
-    [<<"erlang-solutions.com">>, <<"erlang-solutions.local">>] =
-    lists:sort(mongoose_domain_core:get_domains_by_host_type(<<"type2">>)),
-    [<<"example.cfg">>] = mongoose_domain_core:get_domains_by_host_type(<<"type1">>),
-    [] = mongoose_domain_core:get_domains_by_host_type(<<"type6">>).
+get_domains_by_host_type(_) ->
+    ?assertEqualLists([<<"erlang-solutions.com">>, <<"example.org">>],
+                      lists:sort(mongoose_domain_core:get_domains_by_host_type(<<"type #2">>))),
+    [<<"example.cfg">>] = mongoose_domain_core:get_domains_by_host_type(<<"type #1">>),
+    [<<"erlang-solutions.local">>] = mongoose_domain_core:get_domains_by_host_type(<<"static type">>),
+    [] = mongoose_domain_core:get_domains_by_host_type(<<"invalid type">>),
+    %% just no configured domains for this host type
+    [] = mongoose_domain_core:get_domains_by_host_type(<<"type #3">>),
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #3">>, dummy_src),
+    [<<"some.domain">>] = mongoose_domain_core:get_domains_by_host_type(<<"type #3">>).
+
+host_type_check(_) ->
+    {ok, StaticHostType} = mongoose_domain_core:get_host_type(<<"erlang-solutions.local">>),
+    false = mongoose_domain_core:is_host_type_allowed(StaticHostType),
+    true = mongoose_domain_core:is_host_type_allowed(<<"type #1">>),
+    true = mongoose_domain_core:is_host_type_allowed(<<"type #3">>),
+    false = mongoose_domain_core:is_host_type_allowed(<<"invalid_type">>).
+
+can_get_outdated_domains(_) ->
+    [] = mongoose_domain_core:get_all_outdated(dummy_src),
+    [] = mongoose_domain_core:get_all_outdated(another_dummy_src),
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #3">>, dummy_src),
+    ok = mongoose_domain_core:insert(<<"another.domain">>, <<"type #3">>, dummy_src),
+    [] = mongoose_domain_core:get_all_outdated(dummy_src),
+    ?assertEqualLists([{<<"some.domain">>, <<"type #3">>}, {<<"another.domain">>, <<"type #3">>}],
+                      mongoose_domain_core:get_all_outdated(another_dummy_src)),
+    %% reinserting record with another source
+    ok = mongoose_domain_core:insert(<<"another.domain">>, <<"type #3">>, another_dummy_src),
+    [{<<"another.domain">>, <<"type #3">>}] = mongoose_domain_core:get_all_outdated(dummy_src),
+    [{<<"some.domain">>, <<"type #3">>}] = mongoose_domain_core:get_all_outdated(another_dummy_src),
+    ok = mongoose_domain_core:insert(<<"some.domain">>, <<"type #3">>, another_dummy_src),
+    [] = mongoose_domain_core:get_all_outdated(another_dummy_src),
+    ?assertEqualLists([{<<"some.domain">>, <<"type #3">>}, {<<"another.domain">>, <<"type #3">>}],
+                      mongoose_domain_core:get_all_outdated(dummy_src)),
+    %% try to remove domains
+    ok = mongoose_domain_core:delete(<<"some.domain">>),
+    [{<<"another.domain">>, <<"type #3">>}] = mongoose_domain_core:get_all_outdated(dummy_src),
+    [] = mongoose_domain_core:get_all_outdated(another_dummy_src),
+    ok = mongoose_domain_core:delete(<<"another.domain">>),
+    [] = mongoose_domain_core:get_all_outdated(dummy_src),
+    [] = mongoose_domain_core:get_all_outdated(another_dummy_src).

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -48,4 +48,4 @@ core_get_domains_by_host_type(_) ->
     [<<"erlang-solutions.com">>, <<"erlang-solutions.local">>] =
     lists:sort(mongoose_domain_core:get_domains_by_host_type(<<"type2">>)),
     [<<"example.cfg">>] = mongoose_domain_core:get_domains_by_host_type(<<"type1">>),
-    [] = mongoose_domain_core:get_domains_by_host_type( <<"type6">>).
+    [] = mongoose_domain_core:get_domains_by_host_type(<<"type6">>).

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -34,7 +34,7 @@ core_static_domain(_) ->
     true = mongoose_domain_core:is_static(<<"example.cfg">>).
 
 core_cannot_insert_static(_) ->
-    {error, static} = mongoose_domain_core:insert(<<"example.cfg">>, <<"type1">>).
+    {error, static} = mongoose_domain_core:insert(<<"example.cfg">>, <<"type1">>, dummy_src).
 
 %% See also db_get_all_static
 core_get_all_static(_) ->

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -1,0 +1,51 @@
+-module(mongoose_domain_core_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+        core_lookup_works,
+        core_lookup_not_found,
+        core_static_domain,
+        core_cannot_insert_static,
+        core_get_all_static,
+        core_get_domains_by_host_type
+    ].
+
+init_per_suite(Config) ->
+    Pairs = [{<<"example.cfg">>, <<"type1">>},
+              {<<"erlang-solutions.com">>, <<"type2">>},
+              {<<"erlang-solutions.local">>, <<"type2">>}],
+    CommonTypes = [<<"type1">>, <<"type2">>, <<"dbgroup">>, <<"dbgroup2">>, <<"cfggroup">>],
+    mongoose_domain_core:start(Pairs, CommonTypes),
+    Config.
+
+end_per_suite(Config) ->
+    mongoose_domain_core:stop(),
+    Config.
+
+core_lookup_works(_) ->
+    {ok, <<"type1">>} = mongoose_domain_core:get_host_type(<<"example.cfg">>).
+
+core_lookup_not_found(_) ->
+    {error, not_found} = mongoose_domain_core:get_host_type(<<"example.missing">>).
+
+core_static_domain(_) ->
+    true = mongoose_domain_core:is_static(<<"example.cfg">>).
+
+core_cannot_insert_static(_) ->
+    {error, static} = mongoose_domain_core:insert(<<"example.cfg">>, <<"type1">>).
+
+%% See also db_get_all_static
+core_get_all_static(_) ->
+    %% Could be in any order
+    [{<<"erlang-solutions.com">>, <<"type2">>},
+     {<<"erlang-solutions.local">>, <<"type2">>},
+     {<<"example.cfg">>, <<"type1">>}] =
+        lists:sort(mongoose_domain_core:get_all_static()).
+
+core_get_domains_by_host_type(_) ->
+    [<<"erlang-solutions.com">>, <<"erlang-solutions.local">>] =
+    lists:sort(mongoose_domain_core:get_domains_by_host_type(<<"type2">>)),
+    [<<"example.cfg">>] = mongoose_domain_core:get_domains_by_host_type(<<"type1">>),
+    [] = mongoose_domain_core:get_domains_by_host_type( <<"type6">>).


### PR DESCRIPTION
this PR introduces the next changes:

- solves race condition at `check_for_updates/2` function
- eliminates the need to restart `mongoose_domain_core` if `service_domain_db` crashes on initial loading
- eliminates the need to halt the node if `service_domain_db` goes out of sync
- ensures proper init of the mongoose_domain_core
- introduces 2 dummy test suites for the future development.

Also now it's possible to implement "hooks" for domains adding/removing if there's such a need