### PR TITLE
Multi tenancy auth

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -191,7 +191,18 @@
         {password, <<"scramshaplus">>},
         {starttls, required},
         {tls_module, fast_tls}
-    ]}
+    ]},
+    {alice3, [ %% used in dynamic_domains_pm_SUITE
+        {username, <<"alice">>},
+        {server, <<"example.com">>},
+        {host, <<"localhost">>},
+        {password, <<"makota2">>}]},
+    {bob3, [
+        {username, <<"bob">>},
+        {server, <<"example.com">>},
+        {host, <<"localhost">>},
+        {password, <<"makota3">>},
+        {port, 5232}]}
 ]}.
 
 {escalus_anon_users, [

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -199,7 +199,7 @@
         {password, <<"makota2">>}]},
     {bob3, [
         {username, <<"bob">>},
-        {server, <<"example.com">>},
+        {server, <<"example.org">>},
         {host, <<"localhost">>},
         {password, <<"makota3">>},
         {port, 5232}]}

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -4,7 +4,7 @@
 -compile(export_all).
 -import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4]).
 
--define(TEST_NODES, [mim(),mim2()]).
+-define(TEST_NODES, [mim(), mim2()]).
 -define(DOMAINS, [<<"example.com">>, <<"example.org">>]).
 
 suite() ->

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -15,15 +15,25 @@ init_per_suite(Config) ->
     Domain = <<"example.com">>,
     HostType = <<"test type">>,
     Source = dummy_source,
-    rpc(mim(), mongoose_domain_core, insert, [Domain, HostType, Source]),
-    rpc(mim2(), mongoose_domain_core, insert, [Domain, HostType, Source]),
-    Config.
+    ok = rpc(mim(), mongoose_domain_core, insert, [Domain, HostType, Source]),
+    ok = rpc(mim2(), mongoose_domain_core, insert, [Domain, HostType, Source]),
+    escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
-    rpc(mim(), mongoose_domain_core, delete, [<<"example.com">>]),
-    rpc(mim2(), mongoose_domain_core, delete, [<<"example.com">>]),
-    Config.
+    ok = rpc(mim(), mongoose_domain_core, delete, [<<"example.com">>]),
+    ok = rpc(mim2(), mongoose_domain_core, delete, [<<"example.com">>]),
+    escalus:end_per_suite(Config).
+
+init_per_testcase(CN, Config) ->
+    escalus:init_per_testcase(CN, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
 
 can_authenticate(Config) ->
-    %% TODO: implement later
-    ok.
+    UserSpecA = escalus_users:get_userspec(Config, alice3),
+    {ok, ClientA, _} = escalus_connection:start(UserSpecA),
+    UserSpecB = escalus_users:get_userspec(Config, bob3),
+    {ok, ClientB, _} = escalus_connection:start(UserSpecB),
+    escalus_connection:stop(ClientA),
+    escalus_connection:stop(ClientB).

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -4,31 +4,28 @@
 -compile(export_all).
 -import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4]).
 
+-define(TEST_NODES, [mim(),mim2()]).
+-define(DOMAINS, [<<"example.com">>, <<"example.org">>]).
+
 suite() ->
     require_rpc_nodes([mim, mim2]).
-
 
 all() ->
     [can_authenticate].
 
 init_per_suite(Config) ->
-    Domain = <<"example.com">>,
-    HostType = <<"test type">>,
-    Source = dummy_source,
-    ok = rpc(mim(), mongoose_domain_core, insert, [Domain, HostType, Source]),
-    ok = rpc(mim2(), mongoose_domain_core, insert, [Domain, HostType, Source]),
+    insert_domains(?TEST_NODES, ?DOMAINS),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
-    ok = rpc(mim(), mongoose_domain_core, delete, [<<"example.com">>]),
-    ok = rpc(mim2(), mongoose_domain_core, delete, [<<"example.com">>]),
+    remove_domains(?TEST_NODES, ?DOMAINS),
     escalus:end_per_suite(Config).
 
 init_per_testcase(CN, Config) ->
     escalus:init_per_testcase(CN, Config).
 
-end_per_testcase(CaseName, Config) ->
-    escalus:end_per_testcase(CaseName, Config).
+end_per_testcase(CN, Config) ->
+    escalus:end_per_testcase(CN, Config).
 
 can_authenticate(Config) ->
     UserSpecA = escalus_users:get_userspec(Config, alice3),
@@ -37,3 +34,14 @@ can_authenticate(Config) ->
     {ok, ClientB, _} = escalus_connection:start(UserSpecB),
     escalus_connection:stop(ClientA),
     escalus_connection:stop(ClientB).
+
+%% helper functions
+insert_domains(Nodes, Domains) ->
+    Source = dummy_source, %% can be anything, we don't care about it
+    HostType = <<"test type">>, %% preconfigured in the toml file
+    [ok = rpc(Node, mongoose_domain_core, insert, [Domain, HostType, Source]) ||
+        Node <- Nodes, Domain <- Domains].
+
+remove_domains(Nodes, Domains) ->
+    [ok = rpc(Node, mongoose_domain_core, delete, [Domain]) ||
+        Node <- Nodes, Domain <- Domains].

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -431,7 +431,7 @@ verify_format(GroupName, {_User, Props}) ->
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
     JID = mongoose_helper:make_jid(Username, Server),
-    SPassword = rpc(mim(), ejabberd_auth, get_password, [JID]),
+    {SPassword, _} = rpc(mim(), ejabberd_auth, get_passterm_with_authmodule, [JID]),
     do_verify_format(GroupName, Password, SPassword).
 
 

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -372,7 +372,7 @@ verify_format(GroupName, {_User, Props}) ->
     Server = proplists:get_value(server, Props),
     Password = proplists:get_value(password, Props),
     JID = mongoose_helper:make_jid(Username, Server),
-    SPassword = rpc(mim(), ejabberd_auth, get_password, [JID]),
+    {SPassword, _} = rpc(mim(), ejabberd_auth, get_passterm_with_authmodule, [JID]),
     do_verify_format(GroupName, Password, SPassword).
 
 do_verify_format(login_scram, _Password, SPassword) ->

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -29,6 +29,7 @@
                 tls_options = [],
                 tls_verify            :: verify_none | verify_peer,
                 authenticated = false :: authenticated_state(),
+                host_type = <<>>      :: binary(),
                 jid                   :: jid:jid() | undefined,
                 user = <<>>           :: jid:user(),
                 server = <<>>         :: jid:server(),

--- a/include/mongoose.hrl
+++ b/include/mongoose.hrl
@@ -23,6 +23,8 @@
 -define(MONGOOSE_VERSION, element(2, application:get_key(mongooseim,vsn))).
 
 -define(MYHOSTS, ejabberd_config:get_global_option(hosts)).
+-define(ALL_HOST_TYPES, ejabberd_config:get_global_option_or_default(hosts, []) ++
+                        ejabberd_config:get_global_option_or_default(host_types, [])).
 -define(MYNAME,  hd(ejabberd_config:get_global_option(hosts))).
 -define(MYLANG,  ejabberd_config:get_global_option(language)).
 

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -384,7 +384,9 @@ does_method_support(AuthMethod, Feature) ->
 
 -spec get_supported_features(Module :: authmodule()) -> [Feature :: atom()].
 get_supported_features(Module) ->
-    %% if module is not loaded, erlang:function_exported/3 returns false
+    %% if module is not loaded, erlang:function_exported/3 returns false.
+    %% we can safely ignore any error returned from code:ensure_loaded/1.
+    code:ensure_loaded(Module),
     case erlang:function_exported(Module, supported_features, 0) of
         true -> apply(Module, supported_features, []);
         false -> []

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -42,11 +42,11 @@
          get_vh_registered_users/2,
          get_vh_registered_users_number/1,
          get_vh_registered_users_number/2,
-         get_password/1,
          get_password_s/1,
          get_passterm_with_authmodule/1,
          does_user_exist/1,
-         is_user_exists_in_other_modules/2,
+         does_user_exist_in_other_modules/3,
+         does_method_support/2,
          remove_user/1,
          supports_sasl_module/2,
          entropy/1
@@ -78,36 +78,36 @@
 start() ->
     lists:foreach(fun start/1, ?ALL_HOST_TYPES).
 
--spec start(Host :: jid:server()) -> 'ok'.
-start(Host) ->
-    ensure_metrics(Host),
+-spec start(HostType :: binary()) -> 'ok'.
+start(HostType) ->
+    ensure_metrics(HostType),
     lists:foreach(
       fun(M) ->
-              M:start(Host)
-      end, auth_modules(Host)).
+              M:start(HostType)
+      end, auth_modules_for_host_type(HostType)).
 
--spec stop(Host :: jid:server()) -> 'ok'.
-stop(Host) ->
+-spec stop(HostType :: binary()) -> 'ok'.
+stop(HostType) ->
     lists:foreach(
       fun(M) ->
-              M:stop(Host)
-      end, auth_modules(Host)).
+              M:stop(HostType)
+      end, auth_modules_for_host_type(HostType)).
 
--spec set_opts(Host :: jid:server(),
+-spec set_opts(HostType :: binary(),
                KVs :: [tuple()]) ->  {atomic|aborted, _}.
-set_opts(Host, KVs) ->
-    OldOpts = ejabberd_config:get_local_option(auth_opts, Host),
+set_opts(HostType, KVs) ->
+    OldOpts = ejabberd_config:get_local_option(auth_opts, HostType),
     AccFunc = fun({K, V}, Acc) ->
                   lists:keystore(K, 1, Acc, {K, V})
               end,
     NewOpts = lists:foldl(AccFunc, OldOpts, KVs),
-    ejabberd_config:add_local_option({auth_opts, Host}, NewOpts).
+    ejabberd_config:add_local_option({auth_opts, HostType}, NewOpts).
 
--spec get_opt(Host :: jid:server(),
+-spec get_opt(HostType :: binary(),
               Opt :: atom(),
               Default :: ejabberd:value()) -> undefined | ejabberd:value().
-get_opt(Host, Opt, Default) ->
-    case ejabberd_config:get_local_option(auth_opts, Host) of
+get_opt(HostType, Opt, Default) ->
+    case ejabberd_config:get_local_option(auth_opts, HostType) of
         undefined ->
             Default;
         Opts ->
@@ -119,8 +119,8 @@ get_opt(Host, Opt, Default) ->
             end
     end.
 
-get_opt(Host, Opt) ->
-    get_opt(Host, Opt, undefined).
+get_opt(HostType, Opt) ->
+    get_opt(HostType, Opt, undefined).
 
 -spec supports_sasl_module(binary(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(HostType, Module) ->
@@ -130,9 +130,9 @@ supports_sasl_module(HostType, Module) ->
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                            | {error, any()}.
 authorize(Creds) ->
-    LServer = mongoose_credentials:lserver(Creds),
-    timed_call(LServer, authorize, fun authorize_loop/2,
-               [auth_modules(LServer), Creds]).
+    HostType = mongoose_credentials:host_type(Creds),
+    timed_call(HostType, authorize, fun authorize_loop/2,
+               [ auth_modules_for_host_type(HostType), Creds]).
 
 -spec authorize_loop([AuthM], Creds) -> {ok, R}
                                       | {error, any()} when
@@ -224,12 +224,16 @@ set_password(_, <<"">>) ->
 set_password(error, _) ->
     {error, invalid_jid};
 set_password(#jid{luser = LUser, lserver = LServer}, Password) ->
-    lists:foldl(
-      fun(M, {error, _}) ->
-              M:set_password(LUser, LServer, Password);
-         (_M, Res) ->
-              Res
-      end, {error, not_allowed}, auth_modules(LServer)).
+    case mongoose_domain_api:get_host_type(LServer) of
+        {ok, HostType} ->
+            lists:foldl(
+                fun(M, {error, _}) ->
+                    M:set_password(HostType, LUser, LServer, Password);
+                   (_M, Res) ->
+                       Res
+                end, {error, not_allowed}, auth_modules_for_host_type(HostType));
+        {error, not_found} -> {error, not_allowed}
+    end.
 
 
 -spec try_register(jid:jid() | error, binary()) ->
@@ -251,23 +255,23 @@ do_try_register_if_does_not_exist(_, JID, Password) ->
     case mongoose_domain_api:get_host_type(LServer) of
         {ok, HostType} ->
             timed_call(HostType, try_register,
-                       fun do_try_register_if_does_not_exist_timed/3, [LUser, LServer, Password]);
+                       fun do_try_register_if_does_not_exist_timed/4, [HostType, LUser, LServer, Password]);
         {error, not_found} ->
             {error, not_allowed}
     end.
 
-do_try_register_if_does_not_exist_timed(LUser, LServer, Password) ->
-    Backends = auth_modules(LServer),
-    do_try_register_in_backend(Backends, LUser, LServer, Password).
+do_try_register_if_does_not_exist_timed(HostType, LUser, LServer, Password) ->
+    Backends = auth_modules_for_host_type(HostType),
+    do_try_register_in_backend(Backends, HostType, LUser, LServer, Password).
 
-do_try_register_in_backend([], _, _, _) ->
+do_try_register_in_backend([], _, _, _, _) ->
     {error, not_allowed};
-do_try_register_in_backend([M | Backends], LUser, LServer, Password) ->
-    case M:try_register(LUser, LServer, Password) of
+do_try_register_in_backend([M | Backends], HostType, LUser, LServer, Password) ->
+    case M:try_register(HostType, LUser, LServer, Password) of
         ok ->
             mongoose_hooks:register_user(LServer, ok, LUser);
         _ ->
-            do_try_register_in_backend(Backends, LUser, LServer, Password)
+            do_try_register_in_backend(Backends, HostType, LUser, LServer, Password)
     end.
 
 %% @doc Registered users list do not include anonymous users logged
@@ -339,19 +343,6 @@ do_get_vh_registered_users_number(LServer, Opts) ->
             end, auth_modules(LServer))).
 
 
-%% @doc Get the password of the user.
--spec get_password(JID :: jid:jid() | error) -> ejabberd_auth:passterm() | false.
-get_password(#jid{luser = LUser, lserver = LServer}) ->
-    lists:foldl(
-        fun(M, false) ->
-            M:get_password(LUser, LServer);
-            (_M, Password) ->
-                Password
-        end, false, auth_modules(LServer));
-get_password(error) ->
-    false.
-
-
 -spec get_password_s(JID :: jid:jid() | error) -> binary().
 get_password_s(#jid{luser = LUser, lserver = LServer}) ->
     lists:foldl(
@@ -386,14 +377,29 @@ does_user_exist_timed(LUser, LServer) ->
     Modules = auth_modules(LServer),
     does_user_exist_in_given_modules(Modules, LUser, LServer, false).
 
+-spec does_method_support(AuthMethod :: atom(), Feature :: atom()) -> boolean().
+does_method_support(AuthMethod, Feature) ->
+    Module = auth_method_to_module(AuthMethod),
+    lists:member(Feature, get_supported_features(Module)).
+
+-spec get_supported_features(Module :: authmodule()) -> [Feature :: atom()].
+get_supported_features(Module) ->
+    %% if module is not loaded, erlang:function_exported/3 returns false
+    case erlang:function_exported(Module, supported_features, 0) of
+        true -> apply(Module, supported_features, []);
+        false -> []
+    end.
+
 %% Check if the user exists in all authentications module
 %% except the module passed as parameter
--spec is_user_exists_in_other_modules(Module :: authmodule(), JID :: jid:jid() | error) ->
+-spec does_user_exist_in_other_modules(HostType :: binary(),
+                                       Module :: authmodule(),
+                                       JID :: jid:jid() | error) ->
     boolean() | maybe.
-is_user_exists_in_other_modules(Module, #jid{luser = LUser, lserver = LServer}) ->
-    Modules = auth_modules(LServer) -- [Module],
+does_user_exist_in_other_modules(HostType, Module, #jid{luser = LUser, lserver = LServer}) ->
+    Modules = auth_modules_for_host_type(HostType) -- [Module],
     does_user_exist_in_given_modules(Modules, LUser, LServer, maybe);
-is_user_exists_in_other_modules(_M, error) ->
+does_user_exist_in_other_modules(_HostType, _M, error) ->
     false.
 
 does_user_exist_in_given_modules([], _, _, _) ->
@@ -464,6 +470,10 @@ auth_modules() ->
         end, ?ALL_HOST_TYPES)).
 
 %% Return the list of authenticated modules for a given domain
+%% TODO: rework is_anonymous_user/1 at ejabberd_users module,
+%% so there is no need for exporting auth_modules/1 function.
+%% after that completely get rid of this interface, we should
+%% use auth_modules_for_host_type/1 function instead.
 -spec auth_modules(Server :: jid:lserver()) -> [authmodule()].
 auth_modules(LServer) ->
     case mongoose_domain_api:get_host_type(LServer) of
@@ -475,12 +485,16 @@ auth_modules(LServer) ->
 -spec auth_modules_for_host_type(HostType :: binary()) -> [authmodule()].
 auth_modules_for_host_type(HostType) ->
     Methods = auth_methods(HostType),
-    [list_to_atom("ejabberd_auth_" ++ atom_to_list(M)) || M <- Methods].
+    [auth_method_to_module(M) || M <- Methods].
 
 -spec auth_methods(binary()) -> [atom()].
 auth_methods(HostType) ->
     Method = ejabberd_config:get_local_option({auth_method, HostType}),
     get_auth_method_as_a_list(Method).
+
+-spec auth_method_to_module(atom()) -> authmodule().
+auth_method_to_module(Method) ->
+    list_to_atom("ejabberd_auth_" ++ atom_to_list(Method)).
 
 get_auth_method_as_a_list(undefined) -> [];
 get_auth_method_as_a_list(AuthMethod) when is_list(AuthMethod) -> AuthMethod;
@@ -507,14 +521,15 @@ authorize_with_check_password(Module, Creds) ->
     LUser     = jid:nodeprep(User),
     LUser == error andalso error({nodeprep_error, User}),
     LServer   = mongoose_credentials:lserver(Creds),
+    HostType  = mongoose_credentials:host_type(Creds),
     Password  = mongoose_credentials:get(Creds, password),
     Digest    = mongoose_credentials:get(Creds, digest, undefined),
     DigestGen = mongoose_credentials:get(Creds, digest_gen, undefined),
     Args = case {Digest, DigestGen} of
                _ when Digest /= undefined andalso DigestGen /= undefined ->
-                   [LUser, LServer, Password, Digest, DigestGen];
+                   [HostType, LUser, LServer, Password, Digest, DigestGen];
                _  ->
-                   [LUser, LServer, Password]
+                   [HostType, LUser, LServer, Password]
            end,
     case erlang:apply(Module, check_password, Args) of
         true -> {ok, mongoose_credentials:set(Creds, auth_module, Module)};

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -45,7 +45,6 @@
          dirty_get_registered_users/0,
          get_vh_registered_users/1,
          get_password/2,
-         %get_password/3,
          does_user_exist/2,
          remove_user/2,
          supports_sasl_module/2,

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -3,6 +3,8 @@
 %% API
 -export([start/1,
          stop/1,
+         check_password/4,
+         check_password/6,
          authorize/1,
          remove_domain/1,
          supported_features/0]).
@@ -40,6 +42,15 @@ stop(_HostType) ->
 authorize(Creds) ->
     timer:sleep(50 + rand:uniform(450)),
     {ok, mongoose_credentials:set(Creds, auth_module, ?MODULE)}.
+
+check_password(_HostType, _User, _Server, _Password) ->
+    true.
+
+check_password(_HostType, User, Server, _Password, _Digest, _DigestGen) ->
+    ?LOG_DEBUG(#{what => digest_auth_unsupported,
+                 text => <<"no support for digest authentication">>,
+                 user => User, server => Server}),
+    false.
 
 %% @spec (User::string(), Server::string(), Password::string()) ->
 %%       ok | {error, invalid_jid}

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -3,15 +3,15 @@
 %% API
 -export([start/1,
          stop/1,
-         check_password/3,
-         check_password/5,
          authorize/1,
-         plain_password_required/0]).
+         plain_password_required/0,
+         remove_domain/1,
+         supported_features/0]).
 
 %% ejabberd_auth compatibility layer - not supported features
 -behaviour(ejabberd_gen_auth).
--export([set_password/3,
-         try_register/3,
+-export([set_password/4,
+         try_register/4,
          dirty_get_registered_users/0,
          get_vh_registered_users/1,
          get_vh_registered_users/2,
@@ -30,12 +30,12 @@
 %%% API
 %%%----------------------------------------------------------------------
 
--spec start(Domain :: jid:server()) -> ok.
-start(_Domain) ->
+-spec start(HostType :: binary()) -> ok.
+start(_HostType) ->
     ok.
 
--spec stop(Domain :: jid:server()) -> ok.
-stop(_Domain) ->
+-spec stop(HostType :: binary()) -> ok.
+stop(_HostType) ->
     ok.
 
 authorize(Creds) ->
@@ -45,22 +45,13 @@ authorize(Creds) ->
 plain_password_required() ->
     true.
 
-check_password(_User, _Server, _Password) ->
-    true.
-
-check_password(User, Server, _Password, _Digest, _DigestGen) ->
-    ?LOG_DEBUG(#{what => digest_auth_unsupported,
-                 text => <<"no support for digest authentication">>,
-                 user => User, server => Server}),
-    false.
-
 %% @spec (User::string(), Server::string(), Password::string()) ->
 %%       ok | {error, invalid_jid}
-set_password(_User, _Server, _Password) ->
+set_password(_HostType, _User, _Server, _Password) ->
     ok.
 
 %% @spec (User, Server, Password) -> {atomic, ok} | {atomic, exists} | {error, invalid_jid} | {aborted, Reason}
-try_register(_User, _Server, _Password) ->
+try_register(_HostType, _User, _Server, _Password) ->
     ok.
 
 dirty_get_registered_users() ->
@@ -93,6 +84,10 @@ does_user_exist(_User, _Server) ->
 %% Note: it returns ok even if there was some problem removing the user.
 remove_user(_User, _Server) ->
     ok.
+
+remove_domain(_Server) -> ok.
+
+supported_features() -> [dynamic_domains].
 
 supports_sasl_module(_, cyrsasl_plain) -> true;
 supports_sasl_module(_, _) -> false.

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -4,7 +4,6 @@
 -export([start/1,
          stop/1,
          authorize/1,
-         plain_password_required/0,
          remove_domain/1,
          supported_features/0]).
 
@@ -41,9 +40,6 @@ stop(_HostType) ->
 authorize(Creds) ->
     timer:sleep(50 + rand:uniform(450)),
     {ok, mongoose_credentials:set(Creds, auth_module, ?MODULE)}.
-
-plain_password_required() ->
-    true.
 
 %% @spec (User::string(), Server::string(), Password::string()) ->
 %%       ok | {error, invalid_jid}

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -38,6 +38,9 @@
          remove_user/2
         ]).
 
+-export([check_password/4,
+         check_password/6]).
+
 -spec start(HostType :: binary()) -> ok.
 start(_) -> ok.
 
@@ -57,6 +60,10 @@ set_password(_, _, _, _) -> {error, not_allowed}.
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()} | {error, any()}.
 authorize(Creds) ->
     {ok, mongoose_credentials:extend(Creds, [{auth_module, ?MODULE}])}.
+
+check_password(_, _, _, _) -> false.
+
+check_password(_, _, _, _, _, _) -> false.
 
 -spec try_register( HostType :: binary(),
                     User :: jid:luser(),

--- a/src/auth/ejabberd_auth_pki.erl
+++ b/src/auth/ejabberd_auth_pki.erl
@@ -24,9 +24,9 @@
 -export([start/1,
          stop/1,
          supports_sasl_module/2,
-         set_password/3,
+         set_password/4,
          authorize/1,
-         try_register/3,
+         try_register/4,
          dirty_get_registered_users/0,
          get_vh_registered_users/1,
          get_vh_registered_users/2,
@@ -38,33 +38,32 @@
          remove_user/2
         ]).
 
--export([check_password/3,
-         check_password/5]).
-
--spec start(Host :: jid:lserver()) -> ok.
+-spec start(HostType :: binary()) -> ok.
 start(_) -> ok.
 
--spec stop(Host :: jid:lserver()) -> ok.
+-spec stop(HostType :: binary()) -> ok.
 stop(_) -> ok.
 
--spec supports_sasl_module(jid:lserver(), cyrsasl:sasl_module()) -> boolean().
+-spec supports_sasl_module(binary(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_, Module) -> Module =:= cyrsasl_external.
 
--spec set_password( User :: jid:luser(),
+-spec set_password( HostType :: binary(),
+                    User :: jid:luser(),
                     Server :: jid:lserver(),
                     Password :: binary()
                   ) -> ok | {error, not_allowed | invalid_jid}.
-set_password(_, _, _) -> {error, not_allowed}.
+set_password(_, _, _, _) -> {error, not_allowed}.
 
 -spec authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()} | {error, any()}.
 authorize(Creds) ->
-            {ok, mongoose_credentials:extend(Creds, [{auth_module, ?MODULE}])}.
+    {ok, mongoose_credentials:extend(Creds, [{auth_module, ?MODULE}])}.
 
--spec try_register( User :: jid:luser(),
+-spec try_register( HostType :: binary(),
+                    User :: jid:luser(),
                     Server :: jid:lserver(),
                     Password :: binary()
                   ) -> ok | {error, exists | not_allowed | term()}.
-try_register(_, _, _) -> {error, not_allowed}.
+try_register(_, _, _, _) -> {error, not_allowed}.
 
 -spec dirty_get_registered_users() -> [jid:simple_bare_jid()].
 dirty_get_registered_users() -> [].
@@ -104,12 +103,3 @@ does_user_exist(_, _) -> true.
                    Server :: jid:lserver()
                  ) -> ok | {error, not_allowed}.
 remove_user(_, _) -> {error, not_allowed}.
-
-check_password(_, _, _) -> false.
-
-check_password(_, _, _, _, _) -> false.
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% internal functions
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/auth/ejabberd_gen_auth.erl
+++ b/src/auth/ejabberd_gen_auth.erl
@@ -7,22 +7,25 @@
 %%%-------------------------------------------------------------------
 -module(ejabberd_gen_auth).
 
--callback start(Host :: jid:lserver()) -> ok.
+-callback start(HostType :: binary()) -> ok.
 
--callback stop(Host :: jid:lserver()) -> ok.
+-callback stop(HostType :: binary()) -> ok.
 
--callback supports_sasl_module(Host :: jid:lserver(),
+-callback supports_sasl_module(HostType :: binary(),
                                Module :: cyrsasl:sasl_module()) -> boolean().
 
--callback set_password(User :: jid:luser(),
+-callback set_password(HostType :: binary(),
+                       User :: jid:luser(),
                        Server :: jid:lserver(),
                        Password :: binary()
                       ) -> ok | {error, not_allowed | invalid_jid}.
 
+%% credentials already contain host type
 -callback authorize(mongoose_credentials:t()) -> {ok, mongoose_credentials:t()}
                                                | {error, any()}.
 
--callback try_register(User :: jid:luser(),
+-callback try_register(HostType :: binary(),
+                       User :: jid:luser(),
                        Server :: jid:lserver(),
                        Password :: binary()
                        ) -> ok | {error, exists | not_allowed | term()}.
@@ -51,6 +54,29 @@
 -callback remove_user(User :: jid:luser(),
                       Server :: jid:lserver()
                       ) -> ok | {error, not_allowed}.
+
+-callback remove_domain(Server :: jid:lserver()) -> ok | {error, term()}.
+
+-callback supported_features() -> [Feature::atom()].
+
+
+%% implementation of check_password callbacks is required only if
+%% auth module uses ejabberd_auth:authorize_with_check_password/2
+%% helper interface.
+-callback check_password(HostType :: binary(),
+                         LUser :: jid:luser(),
+                         LServer :: jid:lserver(),
+                         Password :: binary()) -> boolean().
+
+-callback check_password(HostType :: binary(),
+                         LUser :: jid:luser(),
+                         LServer :: jid:lserver(),
+                         Password :: binary(),
+                         Digest :: binary(),
+                         DigestGen :: fun()) -> boolean().
+
+-optional_callbacks([remove_domain/1, supported_features/0,
+                     check_password/4, check_password/6]).
 
 -export_type([t/0]).
 

--- a/src/auth/ejabberd_gen_auth.erl
+++ b/src/auth/ejabberd_gen_auth.erl
@@ -60,9 +60,12 @@
 -callback supported_features() -> [Feature::atom()].
 
 
-%% implementation of check_password callbacks is required only if
-%% auth module uses ejabberd_auth:authorize_with_check_password/2
-%% helper interface.
+%% implementation of check_password callbacks is required for the
+%% corresponding check_password interfaces of ejabberd_auth module.
+%%
+%% with the help of ejabberd_auth:authorize_with_check_password/2
+%% function, these callbacks can be reused to simplify implementation
+%% of the M:authorize/1 interface.
 -callback check_password(HostType :: binary(),
                          LUser :: jid:luser(),
                          LServer :: jid:lserver(),
@@ -75,8 +78,7 @@
                          Digest :: binary(),
                          DigestGen :: fun()) -> boolean().
 
--optional_callbacks([remove_domain/1, supported_features/0,
-                     check_password/4, check_password/6]).
+-optional_callbacks([remove_domain/1, supported_features/0]).
 
 -export_type([t/0]).
 

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -1209,7 +1209,11 @@ process_auth(Opts) ->
     %% some options need to be wrapped in 'auth_opts' - this needs simplifying in the future
     OuterKeys = [auth_method, allow_multiple_connections, anonymous_protocol, sasl_mechanisms,
                  extauth_instances],
-    {OuterOpts, InnerOpts} = lists:partition(fun({K, _}) -> lists:member(K, OuterKeys) end, Opts),
+    PartitionFn = fun
+                      ({K, _}) -> lists:member(K, OuterKeys);
+                      (_) -> false %% e.g. error maps
+                  end,
+    {OuterOpts, InnerOpts} = lists:partition(PartitionFn, Opts),
     [{auth_opts, InnerOpts} | OuterOpts].
 
 process_sasl_external(V) when V =:= standard;

--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -34,7 +34,7 @@
 -ifdef(TEST).
 %% required for unit tests
 start(Pairs, AllowedHostTypes) ->
-    gen_server:start({local, ?MODULE}, ?MODULE, [Pairs, AllowedHostTypes], []).
+    just_ok(gen_server:start({local, ?MODULE}, ?MODULE, [Pairs, AllowedHostTypes], [])).
 
 stop() ->
     gen_server:stop(?MODULE).

--- a/src/ejabberd_users.erl
+++ b/src/ejabberd_users.erl
@@ -178,6 +178,9 @@ does_stored_user_exist(JID) ->
 
 -spec is_anonymous_user(jid:jid()) -> boolean().
 is_anonymous_user(#jid{luser = LUser, lserver = LServer} = _JID) ->
+    %% TODO: check if we make this check in a more efficient way, MB we
+    %% can just make  a call to ejabberd_auth_anonymous:does_user_exist/2
+    %% without verification if ejabberd_auth_anonymous is configured 
     case lists:member(ejabberd_auth_anonymous, ejabberd_auth:auth_modules(LServer)) of
         true ->
             ejabberd_auth_anonymous:does_user_exist(LUser, LServer);

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -117,12 +117,16 @@ check_password(error, _) ->
     false;
 check_password(JID, Password) ->
     {LUser, LServer} = jid:to_lus(JID),
-    Creds0 = mongoose_credentials:new(LServer),
-    Creds1 = mongoose_credentials:set(Creds0, username, LUser),
-    Creds2 = mongoose_credentials:set(Creds1, password, Password),
-    case ejabberd_auth:authorize(Creds2) of
-        {ok, _} -> true;
-        _ -> false
+    case mongoose_domain_api:get_host_type(LServer) of
+        {ok, HostType} ->
+            Creds0 = mongoose_credentials:new(LServer, HostType),
+            Creds1 = mongoose_credentials:set(Creds0, username, LUser),
+            Creds2 = mongoose_credentials:set(Creds1, password, Password),
+            case ejabberd_auth:authorize(Creds2) of
+                {ok, _} -> true;
+                _ -> false
+            end;
+        {error, not_found} -> false
     end.
 
 % Constraints

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -1,7 +1,6 @@
 -module(mongoose_credentials).
 
--export([new/1,
-         new/2,
+-export([new/2,
          lserver/1,
          host_type/1,
          get/2, get/3,
@@ -18,23 +17,18 @@
 -opaque t() ::
     #mongoose_credentials{ %% These values are always present.
                            lserver :: jid:lserver(),
-                           host_type :: {ok, binary()} | {error, not_found},
+                           host_type :: binary(),
                            %% Authorization success / failure registry.
                            registry :: [{ejabberd_gen_auth:t(), auth_event()}],
                            %% These values are dependent on the ejabberd_auth backend in use.
                            %% Each backend may require different values to be present.
                            extra :: [proplists:property()] }.
 
--spec new(jid:lserver()) -> mongoose_credentials:t().
-new(LServer) when is_binary(LServer) ->
-    Ret = mongoose_domain_api:get_host_type(LServer),
-    new_creds(LServer, Ret).
-
 -spec new(jid:lserver(), binary()) -> mongoose_credentials:t().
 new(LServer, HostType) when is_binary(LServer), is_binary(HostType) ->
-    new_creds(LServer, {ok, HostType}).
+    #mongoose_credentials{lserver = LServer, host_type = HostType}.
 
--spec host_type(t()) -> {ok, binary()} | {error, not_found}.
+-spec host_type(t()) -> binary().
 host_type(#mongoose_credentials{host_type = HostType}) -> HostType.
 
 -spec lserver(t()) -> jid:lserver().
@@ -80,8 +74,3 @@ extend(#mongoose_credentials{} = C, KVPairs) ->
 register(#mongoose_credentials{} = C, Mod, Event) ->
     #mongoose_credentials{registry = R} = C,
     C#mongoose_credentials{registry = [{Mod, Event} | R]}.
-
--spec new_creds(jid:lserver(), {ok, binary()} | {error, not_found}) ->
-    mongoose_credentials:t().
-new_creds(LServer, HostType) ->
-    #mongoose_credentials{lserver = LServer, host_type = HostType}.

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -1,7 +1,9 @@
 -module(mongoose_credentials).
 
 -export([new/1,
+         new/2,
          lserver/1,
+         host_type/1,
          get/2, get/3,
          set/3,
          extend/2,
@@ -9,13 +11,14 @@
 
 -export_type([t/0]).
 
--record(mongoose_credentials, {lserver, registry = [], extra = []}).
+-record(mongoose_credentials, {lserver, host_type, registry = [], extra = []}).
 
 -type auth_event() :: any().
 
 -opaque t() ::
     #mongoose_credentials{ %% These values are always present.
                            lserver :: jid:lserver(),
+                           host_type :: {ok, binary()} | {error, not_found},
                            %% Authorization success / failure registry.
                            registry :: [{ejabberd_gen_auth:t(), auth_event()}],
                            %% These values are dependent on the ejabberd_auth backend in use.
@@ -24,7 +27,15 @@
 
 -spec new(jid:lserver()) -> mongoose_credentials:t().
 new(LServer) when is_binary(LServer) ->
-    #mongoose_credentials{lserver = LServer}.
+    Ret = mongoose_domain_api:get_host_type(LServer),
+    new_creds(LServer, Ret).
+
+-spec new(jid:lserver(), binary()) -> mongoose_credentials:t().
+new(LServer, HostType) when is_binary(LServer), is_binary(HostType) ->
+    new_creds(LServer, {ok, HostType}).
+
+-spec host_type(t()) -> {ok, binary()} | {error, not_found}.
+host_type(#mongoose_credentials{host_type = HostType}) -> HostType.
 
 -spec lserver(t()) -> jid:lserver().
 lserver(#mongoose_credentials{lserver = S}) -> S.
@@ -69,3 +80,8 @@ extend(#mongoose_credentials{} = C, KVPairs) ->
 register(#mongoose_credentials{} = C, Mod, Event) ->
     #mongoose_credentials{registry = R} = C,
     C#mongoose_credentials{registry = [{Mod, Event} | R]}.
+
+-spec new_creds(jid:lserver(), {ok, binary()} | {error, not_found}) ->
+    mongoose_credentials:t().
+new_creds(LServer, HostType) ->
+    #mongoose_credentials{lserver = LServer, host_type = HostType}.

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -52,27 +52,27 @@
 salted_password(Sha, Password, Salt, IterationCount) ->
     fast_scram:salted_password(Sha, jid:resourceprep(Password), Salt, IterationCount).
 
-enabled(Host) ->
-    case ejabberd_auth:get_opt(Host, password_format, scram) of
+enabled(HostType) ->
+    case ejabberd_auth:get_opt(HostType, password_format, scram) of
         plain -> false;
         {scram, _Sha} -> true;
         scram -> true
     end.
 
-enabled(Host, cyrsasl_scram_sha1)   -> is_password_format_allowed(Host, sha);
-enabled(Host, cyrsasl_scram_sha224) -> is_password_format_allowed(Host, sha224);
-enabled(Host, cyrsasl_scram_sha256) -> is_password_format_allowed(Host, sha256);
-enabled(Host, cyrsasl_scram_sha384) -> is_password_format_allowed(Host, sha384);
-enabled(Host, cyrsasl_scram_sha512) -> is_password_format_allowed(Host, sha512);
-enabled(Host, cyrsasl_scram_sha1_plus) -> is_password_format_allowed(Host, sha);
-enabled(Host, cyrsasl_scram_sha224_plus) -> is_password_format_allowed(Host, sha224);
-enabled(Host, cyrsasl_scram_sha256_plus) -> is_password_format_allowed(Host, sha256);
-enabled(Host, cyrsasl_scram_sha384_plus) -> is_password_format_allowed(Host, sha384);
-enabled(Host, cyrsasl_scram_sha512_plus) -> is_password_format_allowed(Host, sha512);
-enabled(_Host, _Mechanism) -> false.
+enabled(HostType, cyrsasl_scram_sha1)   -> is_password_format_allowed(HostType, sha);
+enabled(HostType, cyrsasl_scram_sha224) -> is_password_format_allowed(HostType, sha224);
+enabled(HostType, cyrsasl_scram_sha256) -> is_password_format_allowed(HostType, sha256);
+enabled(HostType, cyrsasl_scram_sha384) -> is_password_format_allowed(HostType, sha384);
+enabled(HostType, cyrsasl_scram_sha512) -> is_password_format_allowed(HostType, sha512);
+enabled(HostType, cyrsasl_scram_sha1_plus) -> is_password_format_allowed(HostType, sha);
+enabled(HostType, cyrsasl_scram_sha224_plus) -> is_password_format_allowed(HostType, sha224);
+enabled(HostType, cyrsasl_scram_sha256_plus) -> is_password_format_allowed(HostType, sha256);
+enabled(HostType, cyrsasl_scram_sha384_plus) -> is_password_format_allowed(HostType, sha384);
+enabled(HostType, cyrsasl_scram_sha512_plus) -> is_password_format_allowed(HostType, sha512);
+enabled(_HostType, _Mechanism) -> false.
 
-is_password_format_allowed(Host, Sha) ->
-    case ejabberd_auth:get_opt(Host, password_format, scram) of
+is_password_format_allowed(HostType, Sha) ->
+    case ejabberd_auth:get_opt(HostType, password_format, scram) of
         plain -> true;
         scram -> true;
         {scram, ConfiguredSha} -> lists:member(Sha, ConfiguredSha)
@@ -81,17 +81,17 @@ is_password_format_allowed(Host, Sha) ->
 %% This function is exported and used from other modules
 iterations() -> ?SCRAM_DEFAULT_ITERATION_COUNT.
 
-iterations(Host) ->
-    ejabberd_auth:get_opt(Host, scram_iterations, ?SCRAM_DEFAULT_ITERATION_COUNT).
+iterations(HostType) ->
+    ejabberd_auth:get_opt(HostType, scram_iterations, ?SCRAM_DEFAULT_ITERATION_COUNT).
 
-password_to_scram(Host, Password) ->
-    password_to_scram(Host, Password, ?SCRAM_DEFAULT_ITERATION_COUNT).
+password_to_scram(HostType, Password) ->
+    password_to_scram(HostType, Password, ?SCRAM_DEFAULT_ITERATION_COUNT).
 
 password_to_scram(_, #scram{} = Password, _) ->
     scram_record_to_map(Password);
-password_to_scram(Host, Password, IterationCount) ->
+password_to_scram(HostType, Password, IterationCount) ->
     ServerStoredKeys = [do_password_to_scram(Password, IterationCount, HashType)
-                            || {HashType, _Prefix} <- configured_sha_types(Host)],
+                            || {HashType, _Prefix} <- configured_sha_types(HostType)],
     ResultList = lists:merge([{iteration_count, IterationCount}], ServerStoredKeys),
     maps:from_list(ResultList).
 
@@ -219,8 +219,8 @@ supported_sha_types() ->
      {sha384,   <<?SCRAM_SHA384_PREFIX>>},
      {sha512,   <<?SCRAM_SHA512_PREFIX>>}].
 
-configured_sha_types(Host) ->
-    case catch ejabberd_auth:get_opt(Host, password_format) of
+configured_sha_types(HostType) ->
+    case catch ejabberd_auth:get_opt(HostType, password_format) of
         {scram, ScramSha} when length(ScramSha) > 0 ->
             lists:filter(fun({Sha, _Prefix}) ->
                             lists:member(Sha, ScramSha) end, supported_sha_types());

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -86,8 +86,7 @@ maybe_add_auth_id(Creds, User) ->
     mongoose_credentials:set(Creds, auth_id, User).
 
 do_mech_step(Creds) ->
-    Server = mongoose_credentials:lserver(Creds),
-    VerificationList = get_verification_list(Server),
+    VerificationList = get_verification_list(Creds),
     case verification_loop(VerificationList, Creds) of
         {error, Error} ->
             {error, Error};
@@ -102,8 +101,9 @@ authorize(Creds) ->
         {error, not_authorized} -> {error, <<"not-authorized">>}
     end.
 
-get_verification_list(Server) ->
-    case ejabberd_auth:get_opt(Server, cyrsasl_external, [standard]) of
+get_verification_list(Creds) ->
+    HostType = mongoose_credentials:host_type(Creds),
+    case ejabberd_auth:get_opt(HostType, cyrsasl_external, [standard]) of
         [] -> [standard];
         List when is_list(List) -> List;
         standard -> [standard];

--- a/test/auth_dummy_SUITE.erl
+++ b/test/auth_dummy_SUITE.erl
@@ -21,40 +21,19 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(DOMAIN, <<"localhost">>).
+-define(HOST_TYPE, ?DOMAIN).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
 
-all() ->
-    [
-     check_password_3,
-     check_password_5,
-     authorize,
-     plain_password_required
-    ].
+all() -> [authorize].
 
 %%--------------------------------------------------------------------
 %% Authentication tests
 %%--------------------------------------------------------------------
 
-check_password_3(_Config) ->
-    true = ejabberd_auth_dummy:check_password(<<"alice">>, ?DOMAIN, <<"makota">>),
-    true = ejabberd_auth_dummy:check_password(<<"alice">>, ?DOMAIN, <<"niemakota">>),
-    true = ejabberd_auth_dummy:check_password(<<"kate">>, ?DOMAIN, <<"mapsa">>).
-
-check_password_5(_Config) ->
-    false = ejabberd_auth_dummy:check_password(<<"alice">>, ?DOMAIN, <<"makota">>,
-                                               <<"digest">>, fun() -> true end),
-    false = ejabberd_auth_dummy:check_password(<<"alice">>, ?DOMAIN, <<"niemakota">>,
-                                               <<"digest">>, fun() -> true end),
-    false = ejabberd_auth_dummy:check_password(<<"kate">>, ?DOMAIN, <<"mapsa">>,
-                                               <<"digest">>, fun() -> true end).
-
 authorize(_Config) ->
     {ok, _} = application:ensure_all_started(jid),
-    Creds = mongoose_credentials:new(?DOMAIN, ?DOMAIN),
+    Creds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
     {ok, _Creds2} = ejabberd_auth_dummy:authorize(Creds).
-
-plain_password_required(_Config) ->
-    true = ejabberd_auth_dummy:plain_password_required().

--- a/test/auth_dummy_SUITE.erl
+++ b/test/auth_dummy_SUITE.erl
@@ -27,7 +27,10 @@
 %% Suite configuration
 %%--------------------------------------------------------------------
 
-all() -> [authorize].
+all() -> [
+    authorize,
+    supports_dynamic_domains
+].
 
 %%--------------------------------------------------------------------
 %% Authentication tests
@@ -37,3 +40,8 @@ authorize(_Config) ->
     {ok, _} = application:ensure_all_started(jid),
     Creds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
     {ok, _Creds2} = ejabberd_auth_dummy:authorize(Creds).
+
+supports_dynamic_domains(_) ->
+    true = ejabberd_auth:does_method_support(dummy, dynamic_domains),
+    false = ejabberd_auth:does_method_support(invalid_method, dynamic_domains),
+    false = ejabberd_auth:does_method_support(dummy, invalid_feature).

--- a/test/auth_dummy_SUITE.erl
+++ b/test/auth_dummy_SUITE.erl
@@ -53,7 +53,7 @@ check_password_5(_Config) ->
 
 authorize(_Config) ->
     {ok, _} = application:ensure_all_started(jid),
-    Creds = mongoose_credentials:new(?DOMAIN),
+    Creds = mongoose_credentials:new(?DOMAIN, ?DOMAIN),
     {ok, _Creds2} = ejabberd_auth_dummy:authorize(Creds).
 
 plain_password_required(_Config) ->

--- a/test/auth_external_SUITE.erl
+++ b/test/auth_external_SUITE.erl
@@ -41,19 +41,19 @@ end_per_group(G, Config) ->
 
 try_register_ok(_C) ->
     {U, P} = given_user_registered(),
-    true = ?AUTH_MOD:check_password(U, domain(), P).
+    true = ?AUTH_MOD:check_password(host_type(), U, domain(), P).
 
 remove_user_ok(_C) ->
     {U, P} = given_user_registered(),
     ok = ?AUTH_MOD:remove_user(U, domain()),
-    false = ?AUTH_MOD:check_password(U, domain(), P).
+    false = ?AUTH_MOD:check_password(host_type(), U, domain(), P).
 
 set_password_ok(_C) ->
     {U, P} = given_user_registered(),
     NewP = random_binary(7),
-    ok = ?AUTH_MOD:set_password(U, domain(), NewP),
-    false = ?AUTH_MOD:check_password(U, domain(), P),
-    true = ?AUTH_MOD:check_password(U, domain(), NewP).
+    ok = ?AUTH_MOD:set_password(host_type(), U, domain(), NewP),
+    false = ?AUTH_MOD:check_password(host_type(), U, domain(), P),
+    true = ?AUTH_MOD:check_password(host_type(), U, domain(), NewP).
 
 does_user_exist(_C) ->
     {U, _P} = given_user_registered(),
@@ -74,13 +74,14 @@ supported_sasl_mechanisms(_C) ->
 
 given_user_registered() ->
     {U, P} = UP = gen_user(),
-    ok = ?AUTH_MOD:try_register(U, domain(), P),
+    ok = ?AUTH_MOD:try_register(host_type(), U, domain(), P),
     UP.
 
 
 domain() ->
     <<"mim1.esl.com">>.
 
+host_type() -> domain().
 
 setup_meck(_G, Config) ->
     DataDir = ?config(data_dir, Config),

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -78,7 +78,7 @@ init_per_suite(Config) ->
               Pool = {http, host, auth,
                       [{strategy, random_worker}, {call_timeout, 5000}, {workers, 20}],
                       [{path_prefix, "/auth/"}, {http_opts, []}, {server, ?AUTH_HOST}]},
-              Hosts = [?DOMAIN],
+              Hosts = [?DOMAIN, <<"another.domain">>],
               mongoose_wpool:start_configured_pools([Pool], Hosts),
               mongoose_wpool_http:init(),
               ejabberd_auth_http:start(?HOST_TYPE)

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -234,7 +234,7 @@ cert_auth_nonexistent(Config) ->
 %%--------------------------------------------------------------------
 creds_with_cert(Config, Username) ->
     Cert = proplists:get_value(der_cert, Config),
-    NewCreds = mongoose_credentials:new(?DOMAIN1),
+    NewCreds = mongoose_credentials:new(?DOMAIN1, ?DOMAIN1),
     mongoose_credentials:extend(NewCreds, [{der_cert, Cert},
                                            {username, Username}]).
 

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -3,7 +3,8 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--define(DOMAIN1, <<"localhost">>).
+-define(DOMAIN, <<"localhost">>).
+-define(HOST_TYPE, ?DOMAIN).
 -define(USERNAME, <<"10857839">>).
 -define(WRONG_USERNAME, <<"alice">>).
 -define(JWT_KEY, <<"testtesttest">>).
@@ -68,15 +69,15 @@ init_per_group(public_key, Config) ->
     PubkeyPath = filename:join([Root, "tools", "ssl", "mongooseim", "pubkey.pem"]),
     {ok, PrivKey} = file:read_file(PrivkeyPath),
     set_auth_opts(PubkeyPath, undefined, "RS256", bookingNumber),
-    ok = ejabberd_auth_jwt:start(?DOMAIN1),
+    ok = ejabberd_auth_jwt:start(?DOMAIN),
     [{priv_key, PrivKey} | Config];
 init_per_group(_, Config) ->
     set_auth_opts(undefined, ?JWT_KEY, "HS256", bookingNumber),
-    ok = ejabberd_auth_jwt:start(?DOMAIN1),
+    ok = ejabberd_auth_jwt:start(?HOST_TYPE),
     Config.
 
 end_per_group(_, Config) ->
-    ok = ejabberd_auth_jwt:stop(?DOMAIN1),
+    ok = ejabberd_auth_jwt:stop(?HOST_TYPE),
     Config.
 
 
@@ -91,19 +92,19 @@ end_per_testcase(_CaseName, Config) ->
 %%--------------------------------------------------------------------
 
 check_password_succeeds_for_correct_token(_Config) ->
-    true = ejabberd_auth_jwt:check_password(?USERNAME, ?DOMAIN1,
+    true = ejabberd_auth_jwt:check_password(?HOST_TYPE, ?USERNAME, ?DOMAIN,
                                             generate_token(hs256, 0, ?JWT_KEY)).
 
 check_password_fails_for_wrong_token(_C) ->
-    false = ejabberd_auth_jwt:check_password(?USERNAME, ?DOMAIN1,
+    false = ejabberd_auth_jwt:check_password(?HOST_TYPE, ?USERNAME, ?DOMAIN,
                                              generate_token(hs256, 60, ?JWT_KEY)).
 
 check_password_fails_for_correct_token_but_wrong_username(_C) ->
-    false = ejabberd_auth_jwt:check_password(?WRONG_USERNAME, ?DOMAIN1,
+    false = ejabberd_auth_jwt:check_password(?HOST_TYPE, ?WRONG_USERNAME, ?DOMAIN,
                                              generate_token(hs256, 0, ?JWT_KEY)).
 
 authorize(_C) ->
-    Creds0 = mongoose_credentials:new(?DOMAIN1, ?DOMAIN1),
+    Creds0 = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
     Creds = mongoose_credentials:extend(Creds0, [{username, ?USERNAME},
                                                  {password, generate_token(hs256, 0, ?JWT_KEY)},
                                                  {digest, fake},
@@ -112,42 +113,45 @@ authorize(_C) ->
     ejabberd_auth_jwt = mongoose_credentials:get(Creds2, auth_module).
 
 set_password(_Config) ->
-    {error, not_allowed} = ejabberd_auth_jwt:set_password(?USERNAME, ?DOMAIN1, <<"mialakota">>).
+    {error, not_allowed} = ejabberd_auth_jwt:set_password(?HOST_TYPE, ?USERNAME,
+                                                          ?DOMAIN, <<"mialakota">>).
 
 try_register(_Config) ->
-    {error, not_allowed} = ejabberd_auth_jwt:try_register(?USERNAME, ?DOMAIN1, <<"newpass">>).
+    {error, not_allowed} = ejabberd_auth_jwt:try_register(?HOST_TYPE, ?USERNAME,
+                                                          ?DOMAIN, <<"newpass">>).
 
 % get_password + get_password_s
 get_password(_Config) ->
-    false = ejabberd_auth_jwt:get_password(<<"anaking">>, ?DOMAIN1),
-    <<>> = ejabberd_auth_jwt:get_password_s(<<"anakin">>, ?DOMAIN1).
+    false = ejabberd_auth_jwt:get_password(<<"anaking">>, ?DOMAIN),
+    <<>> = ejabberd_auth_jwt:get_password_s(<<"anakin">>, ?DOMAIN).
 
 does_user_exist(_Config) ->
-    true = ejabberd_auth_jwt:does_user_exist(<<"madhatter">>, ?DOMAIN1).
+    true = ejabberd_auth_jwt:does_user_exist(<<"madhatter">>, ?DOMAIN).
 
 % remove_user/2,3
 remove_user(_Config) ->
-    ok = ejabberd_auth_jwt:remove_user(<<"toremove3">>, ?DOMAIN1).
+    ok = ejabberd_auth_jwt:remove_user(<<"toremove3">>, ?DOMAIN).
 
 get_vh_registered_users_number(_C) ->
-    0 = ejabberd_auth_jwt:get_vh_registered_users_number(?DOMAIN1, []).
+    0 = ejabberd_auth_jwt:get_vh_registered_users_number(?DOMAIN, []).
 
 get_vh_registered_users(_C) ->
-    [] = ejabberd_auth_jwt:get_vh_registered_users(?DOMAIN1, []).
+    [] = ejabberd_auth_jwt:get_vh_registered_users(?DOMAIN, []).
 
 supported_sasl_mechanisms(_C) ->
     Modules = [cyrsasl_plain, cyrsasl_digest, cyrsasl_external,
                cyrsasl_scram_sha1, cyrsasl_scram_sha224, cyrsasl_scram_sha256,
                cyrsasl_scram_sha384, cyrsasl_scram_sha512],
     [true, false, false, false, false, false, false, false] =
-        [ejabberd_auth_jwt:supports_sasl_module(?DOMAIN1, Mod) || Mod <- Modules].
+        [ejabberd_auth_jwt:supports_sasl_module(?DOMAIN, Mod) || Mod <- Modules].
 
 dirty_get_registered_users(_C) ->
     [] = ejabberd_auth_jwt:dirty_get_registered_users().
 
 check_password_succeeds_for_pubkey_signed_token(C) ->
     Key = proplists:get_value(priv_key, C),
-    true = ejabberd_auth_jwt:check_password(?USERNAME, ?DOMAIN1, generate_token(rs256, 0, Key)).
+    true = ejabberd_auth_jwt:check_password(?HOST_TYPE, ?USERNAME, ?DOMAIN,
+                                            generate_token(rs256, 0, Key)).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -103,7 +103,7 @@ check_password_fails_for_correct_token_but_wrong_username(_C) ->
                                              generate_token(hs256, 0, ?JWT_KEY)).
 
 authorize(_C) ->
-    Creds0 = mongoose_credentials:new(?DOMAIN1),
+    Creds0 = mongoose_credentials:new(?DOMAIN1, ?DOMAIN1),
     Creds = mongoose_credentials:extend(Creds0, [{username, ?USERNAME},
                                                  {password, generate_token(hs256, 0, ?JWT_KEY)},
                                                  {digest, fake},

--- a/test/commands_SUITE.erl
+++ b/test/commands_SUITE.erl
@@ -91,11 +91,12 @@ init_per_testcase(_, C) ->
     meck:expect(ejabberd_config, get_global_option, fun ggo/1),
     meck:new(ejabberd_auth_dummy, [non_strict]),
     meck:expect(ejabberd_auth_dummy, get_password_s, fun(_, _) -> <<"">> end),
+    meck:new(mongoose_domain_api),
+    meck:expect(mongoose_domain_api, get_host_type, fun(H) -> {ok, H} end),
     C.
 
 end_per_testcase(_, C) ->
-    meck:unload(ejabberd_config),
-    meck:unload(ejabberd_auth_dummy),
+    meck:unload(),
     C.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -32,15 +32,15 @@ all() ->
      {group, shaper_acl_access},
      {group, s2s},
      {group, modules},
-     {group, services}].
+     {group, services},
+     {group, host_types_group}].
 
 groups() ->
     [{file, [parallel], [sample_pgsql,
                          miscellaneous,
                          s2s,
                          modules,
-                         outgoing_pools,
-                         {group, host_types_group}]},
+                         outgoing_pools]},
      {host_types_group, [], [host_types_file,
                              host_types_missing_auth_methods_and_modules,
                              host_types_unsupported_modules,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -299,6 +299,8 @@ host_types_unsupported_modules(Config) ->
     FN = fun() -> [dynamic_domains] end,
     [meck:expect(M, supported_features, FN) || M <- Modules],
     ?assertError({config_error, "Invalid host type configuration",
+                  %% please note that the sequence of these errors is not
+                  %% guarantied and may change in the future
                   [#{reason := not_supported_module, module := test_mim_module1,
                      host_type := <<"yet another host type">>},
                    #{reason := not_supported_module, module := test_mim_module2,
@@ -310,6 +312,8 @@ host_types_unsupported_auth_methods(Config) ->
     FN = fun() -> [dynamic_domains] end,
     [meck:expect(M, supported_features, FN) || M <- Modules],
     ?assertError({config_error, "Invalid host type configuration",
+                  %% please note that the sequence of these errors is not
+                  %% guarantied and may change in the future
                   [#{reason := not_supported_auth_method, auth_method := test2,
                      host_type := <<"yet another host type">>},
                    #{reason := not_supported_auth_method, auth_method := test2,
@@ -321,6 +325,8 @@ host_types_unsupported_auth_methods_and_modules(Config) ->
     FN = fun() -> [dynamic_domains] end,
     [meck:expect(M, supported_features, FN) || M <- Modules],
     ?assertError({config_error, "Invalid host type configuration",
+                  %% please note that the sequence of these errors is not
+                  %% guarantied and may change in the future
                   [#{reason := not_supported_auth_method, auth_method := test2,
                      host_type := <<"yet another host type">>},
                    #{reason := not_supported_module, module := test_mim_module2,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -42,8 +42,7 @@ groups() ->
                          outgoing_pools,
                          {group, host_types_group}]},
      {host_types_group, [], [host_types_file,
-                             host_types_missing_modules,
-                             host_types_missing_auth_methods,
+                             host_types_missing_auth_methods_and_modules,
                              host_types_unsupported_modules,
                              host_types_unsupported_auth_methods,
                              host_types_unsupported_auth_methods_and_modules]},
@@ -287,24 +286,18 @@ host_types_file(Config) ->
     [meck:expect(M, supported_features, FN) || M <- Modules],
     test_config_file(Config, "host_types").
 
-host_types_missing_modules(Config) ->
-    Modules = [test_mim_module1, test_mim_module2],
-    [meck:unload(M) || M <- Modules],
-    ?assertError({config_error, "Could not read the TOML configuration file",
-                  [#{reason := module_not_found, module := test_mim_module2,
-                     toml_path := "host_config.modules"},
-                   #{reason := module_not_found, module := test_mim_module1,
-                     toml_path := "modules"}]},
-                 test_config_file(Config, "host_types")).
-
-host_types_missing_auth_methods(Config) ->
-    Modules = [ejabberd_auth_test1, ejabberd_auth_test2],
+host_types_missing_auth_methods_and_modules(Config) ->
+    Modules = [ejabberd_auth_test1, test_mim_module1, test_mim_module2],
     [meck:unload(M) || M <- Modules],
     ?assertError({config_error, "Could not read the TOML configuration file",
                   [#{reason := module_not_found, module := ejabberd_auth_test1,
-                     toml_path := "host_config.auth.methods", toml_value := <<"test1">>},
-                   #{reason := module_not_found, module := ejabberd_auth_test2,
-                     toml_path := "host_config.auth.methods", toml_value := <<"test2">>}]},
+                     toml_path := "auth.methods"},
+                   #{reason := module_not_found, module := ejabberd_auth_test1,
+                     toml_path := "host_config.auth.methods"},
+                   #{reason := module_not_found, module := test_mim_module2,
+                     toml_path := "host_config.modules"},
+                   #{reason := module_not_found, module := test_mim_module1,
+                     toml_path := "modules"}]},
                  test_config_file(Config, "host_types")).
 
 host_types_unsupported_modules(Config) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -289,16 +289,10 @@ host_types_file(Config) ->
 host_types_missing_auth_methods_and_modules(Config) ->
     Modules = [ejabberd_auth_test1, test_mim_module1, test_mim_module2],
     [meck:unload(M) || M <- Modules],
-    ?assertError({config_error, "Could not read the TOML configuration file",
-                  [#{reason := module_not_found, module := ejabberd_auth_test1,
-                     toml_path := "auth.methods"},
-                   #{reason := module_not_found, module := ejabberd_auth_test1,
-                     toml_path := "host_config.auth.methods"},
-                   #{reason := module_not_found, module := test_mim_module2,
-                     toml_path := "host_config.modules"},
-                   #{reason := module_not_found, module := test_mim_module1,
-                     toml_path := "modules"}]},
-                 test_config_file(Config, "host_types")).
+    {'EXIT', {{config_error, "Could not read the TOML configuration file", ErrorList}, _}}
+        = (catch test_config_file(Config, "host_types")),
+    MissingModules = [M || #{reason := module_not_found, module := M} <- ErrorList],
+    ?assertEqual(lists:sort(Modules), lists:usort(MissingModules)).
 
 host_types_unsupported_modules(Config) ->
     Modules = [ejabberd_auth_test1, ejabberd_auth_test2],

--- a/test/config_parser_SUITE_data/host_types.options
+++ b/test/config_parser_SUITE_data/host_types.options
@@ -2,8 +2,18 @@
         [<<"this is host type">>,<<"some host type">>,<<"another host type">>,
          <<"yet another host type">>]}.
 {config,hosts,[<<"localhost">>]}.
-{local_config,{modules,<<"another host type">>},[{another_dummy_module,[]}]}.
-{local_config,{modules,<<"localhost">>},[{yet_another_dummy_module,[]}]}.
+{local_config,{auth_method,<<"another host type">>},[]}.
+{local_config,{auth_method,<<"localhost">>},[test3]}.
+{local_config,{auth_method,<<"some host type">>},[test2]}.
+{local_config,{auth_method,<<"this is host type">>},[test1]}.
+{local_config,{auth_method,<<"yet another host type">>},[test1,test2]}.
+{local_config,{auth_opts,<<"another host type">>},[]}.
+{local_config,{auth_opts,<<"localhost">>},[]}.
+{local_config,{auth_opts,<<"some host type">>},[]}.
+{local_config,{auth_opts,<<"this is host type">>},[]}.
+{local_config,{auth_opts,<<"yet another host type">>},[]}.
+{local_config,{modules,<<"another host type">>},[{test_mim_module2,[]}]}.
+{local_config,{modules,<<"localhost">>},[{test_mim_module3,[]}]}.
 {local_config,{modules,<<"some host type">>},[]}.
 {local_config,{modules,<<"this is host type">>},[]}.
-{local_config,{modules,<<"yet another host type">>},[{dummy_module,[]}]}.
+{local_config,{modules,<<"yet another host type">>},[{test_mim_module1,[]}]}.

--- a/test/config_parser_SUITE_data/host_types.toml
+++ b/test/config_parser_SUITE_data/host_types.toml
@@ -1,32 +1,43 @@
 [general]
-host_types = [
-    "this is host type",
-    "some host type",
-    "another host type",
-    "yet another host type"
-]
+  host_types = [
+      "this is host type",
+      "some host type",
+      "another host type",
+      "yet another host type"
+    ]
 
-hosts = ["localhost"]
+  hosts = ["localhost"]
 
-[modules.dummy_module]
+[auth]
+  methods = ["test1", "test2"]
 
-[[host_config]]
-host_type = "this is host type"
-## this resets the modules for this host
-modules ={}
+[modules.test_mim_module1]
 
 [[host_config]]
-## host is just synonym for host_type now
-host = "some host type"
-## another syntax for reseting the modules for this host type
-[host_config.modules]
+  host_type = "this is host type"
+  ## this resets the modules for this host
+  modules = {}
+  [host_config.auth]
+    methods = ["test1"]
 
 [[host_config]]
-host_type = "another host type"
-## reseting the modules for this host type
-[host_config.modules.another_dummy_module]
+  ## host is just synonym for host_type now
+  host = "some host type"
+  ## another syntax for reseting the modules for this host type
+  [host_config.modules]
+  [host_config.auth]
+    methods = ["test2"]
 
 [[host_config]]
-host_type = "localhost"
-## reseting the modules for this host type
-[host_config.modules.yet_another_dummy_module]
+  host_type = "another host type"
+  ## reseting the modules for this host type
+  [host_config.modules.test_mim_module2]
+  [host_config.auth]
+    methods = []
+
+[[host_config]]
+  host_type = "localhost"
+  ## reseting the modules for this host type
+  [host_config.modules.test_mim_module3]
+  [host_config.auth]
+    methods = ["test3"]

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -29,7 +29,7 @@ setup() ->
     meck:expect(cyrsasl, listmech, fun(_) -> [] end),
 
     meck:new(mongoose_credentials),
-    meck:expect(mongoose_credentials, new, fun(_) -> ok end),
+    meck:expect(mongoose_credentials, new, fun(_, _) -> ok end),
     meck:expect(mongoose_credentials, get,
                 fun(dummy_creds, sasl_success_response, undefined) ->
                     undefined end),

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -24,7 +24,7 @@ setup() ->
     meck:expect(ejabberd_socket, get_socket, fun(_) -> ok end),
 
     meck:new(cyrsasl),
-    meck:expect(cyrsasl, server_new, fun(_, _, _, _, _) -> saslstate end),
+    meck:expect(cyrsasl, server_new, fun(_, _, _, _, _, _) -> saslstate end),
     meck:expect(cyrsasl, server_start, fun(_, _, _, _) -> {ok, dummy_creds} end),
     meck:expect(cyrsasl, listmech, fun(_) -> [] end),
 
@@ -55,7 +55,10 @@ setup() ->
     meck:expect(mongoose_metrics, update, fun (_, _, _) -> ok end),
 
     meck:new(gen_mod),
-    meck:expect(gen_mod, is_loaded, fun (_, _) -> true end).
+    meck:expect(gen_mod, is_loaded, fun (_, _) -> true end),
+
+    meck:new(mongoose_domain_api),
+    meck:expect(mongoose_domain_api, get_host_type, fun get_host_type/1).
 
 
 teardown() ->
@@ -79,3 +82,6 @@ hookfold(session_opening_allowed_for_user, _, _, _) -> allow;
 hookfold(c2s_stream_features, _, _, _) -> [];
 hookfold(xmpp_send_element, _, A, _) -> A;
 hookfold(privacy_check_packet, _, _, _) -> allow.
+
+get_host_type(<<"localhost">>) -> {ok, <<"localhost">>};
+get_host_type(_) -> {error, not_found}.

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -26,7 +26,7 @@ all() ->
      can_get_outdated_domains].
 
 init_per_testcase(_, Config) ->
-    mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_TYPES),
+    ok = mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_TYPES),
     Config.
 
 end_per_testcase(_, Config) ->


### PR DESCRIPTION
This PR introduces the new callback supported_features/0 for auth backends:
  * for now there is the only one optional feature - dynamic_domains.
  * currently only ejabberd_auth_dummy supports dynamic_domains feature.
  * all other auth modules must be rechecked and adopted in order to
    support this feature.
  * the following things must be done per auth module:
       - recheck that ejabberd_auth set_opts and get_opt interfaces are
         used with host type, not domain name.
       - recheck that mongoose_scram interfaces are used with host type,
         not domain name.
       - recheck that ejabberd_config get_local_option interfaces are
         used with host type, not domain name.
       - create proper tests to ensure that auth module works correctly
         with dynamic domains.

In order to reduce the number of calls to `mongoose_domain_api:get_host_type/1` HostType parameter is added to some callbacks of ejabberd_gen_auth behaviour.