### PR TITLE
Enable service_domain_db_SUITE for CI

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -80,6 +80,7 @@
 {suites, "tests", vcard_simple_SUITE}.
 {suites, "tests", websockets_SUITE}.
 {suites, "tests", xep_0352_csi_SUITE}.
+{suites, "tests", service_domain_db_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.


### PR DESCRIPTION
This PR addresses "it's not running on CI"

Proposed changes include:
* running on CI now