### PR TITLE
Multi tenancy pm

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -185,7 +185,7 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(close_connection_if_service_type_is_hidden = CN, Config) ->
-    OptName = {hide_service_name, <<"localhost">>},
+    OptName = hide_service_name,
     mongoose_helper:successful_rpc(ejabberd_config, add_local_option, [OptName, true]),
     escalus:init_per_testcase(CN, Config);
 init_per_testcase(replaced_session_cannot_terminate = CN, Config) ->
@@ -197,7 +197,7 @@ init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
 end_per_testcase(close_connection_if_service_type_is_hidden = CN, Config) ->
-    OptName = {hide_service_name, <<"localhost">>},
+    OptName = hide_service_name,
     mongoose_helper:successful_rpc(ejabberd_config, del_local_option, [OptName]),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(replaced_session_cannot_terminate = CN, Config) ->

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -4,22 +4,26 @@
 -compile(export_all).
 -import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4]).
 
--define(TEST_NODES, [mim(), mim2()]).
+-define(TEST_NODES, [mim() | ?CLUSTER_NODES]).
+-define(CLUSTER_NODES, [mim2()]).
 -define(DOMAINS, [<<"example.com">>, <<"example.org">>]).
 
 suite() ->
     require_rpc_nodes([mim, mim2]).
 
 all() ->
-    [can_authenticate].
+    [can_authenticate,
+     pm_messages].
 
-init_per_suite(Config) ->
+init_per_suite(Config0) ->
+    Config = cluster_nodes(?CLUSTER_NODES, Config0),
     insert_domains(?TEST_NODES, ?DOMAINS),
     escalus:init_per_suite(Config).
 
-end_per_suite(Config) ->
+end_per_suite(Config0) ->
+    Config = escalus:end_per_suite(Config0),
     remove_domains(?TEST_NODES, ?DOMAINS),
-    escalus:end_per_suite(Config).
+    uncluster_nodes(?CLUSTER_NODES, Config).
 
 init_per_testcase(CN, Config) ->
     escalus:init_per_testcase(CN, Config).
@@ -35,6 +39,16 @@ can_authenticate(Config) ->
     escalus_connection:stop(ClientA),
     escalus_connection:stop(ClientB).
 
+pm_messages(Config) ->
+    StoryFn =
+        fun(Alice, Bob) ->
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
+            escalus:assert(is_chat_message, [<<"OH, HAI!">>], escalus:wait_for_stanza(Bob)),
+            escalus:send(Bob, escalus_stanza:chat_to(Alice, <<"Hello there!">>)),
+            escalus:assert(is_chat_message, [<<"Hello there!">>], escalus:wait_for_stanza(Alice))
+        end,
+    escalus:story(Config, [{alice3, 1}, {bob3, 1}], StoryFn).
+
 %% helper functions
 insert_domains(Nodes, Domains) ->
     Source = dummy_source, %% can be anything, we don't care about it
@@ -45,3 +59,13 @@ insert_domains(Nodes, Domains) ->
 remove_domains(Nodes, Domains) ->
     [ok = rpc(Node, mongoose_domain_core, delete, [Domain]) ||
         Node <- Nodes, Domain <- Domains].
+
+cluster_nodes([], Config) -> Config;
+cluster_nodes([Node | T], Config) ->
+    NewConfig = distributed_helper:add_node_to_cluster(Node, Config),
+    cluster_nodes(T, NewConfig).
+
+uncluster_nodes([], Config) -> Config;
+uncluster_nodes([Node | T], Config) ->
+    NewConfig = distributed_helper:remove_node_from_cluster(Node, Config),
+    cluster_nodes(T, NewConfig).

--- a/big_tests/tests/dynamic_domains_pm_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_pm_SUITE.erl
@@ -13,7 +13,8 @@ suite() ->
 
 all() ->
     [can_authenticate,
-     pm_messages].
+     pm_messages,
+     disconnected_on_domain_disabling].
 
 init_per_suite(Config0) ->
     Config = cluster_nodes(?CLUSTER_NODES, Config0),
@@ -46,6 +47,16 @@ pm_messages(Config) ->
             escalus:assert(is_chat_message, [<<"OH, HAI!">>], escalus:wait_for_stanza(Bob)),
             escalus:send(Bob, escalus_stanza:chat_to(Alice, <<"Hello there!">>)),
             escalus:assert(is_chat_message, [<<"Hello there!">>], escalus:wait_for_stanza(Alice))
+        end,
+    escalus:story(Config, [{alice3, 1}, {bob3, 1}], StoryFn).
+
+disconnected_on_domain_disabling(Config) ->
+    StoryFn =
+        fun(Alice, Bob) ->
+            remove_domains(?TEST_NODES, ?DOMAINS),
+            escalus_connection:wait_for_close(Alice, timer:seconds(5)),
+            escalus_connection:wait_for_close(Bob, timer:seconds(5)),
+            insert_domains(?TEST_NODES, ?DOMAINS)
         end,
     escalus:story(Config, [{alice3, 1}, {bob3, 1}], StoryFn).
 

--- a/doc/advanced-configuration/host_config.md
+++ b/doc/advanced-configuration/host_config.md
@@ -30,24 +30,22 @@ The following options are allowed:
 * [`pgsql_users_number_estimate`](general.md#generalpgsql_users_number_estimate)
 * [`route_subdomains`](general.md#generalroute_subdomains)
 * [`replaced_wait_timeout`](general.md#generalreplaced_wait_timeout)
-* [`hide_service_name`](general.md#generalhide_service_name)
 
 #### Example
 
-The `hide_service_name` option is set to `false` only for `domain2.com`.
+The `replaced_wait_timeout` option is set to `2000` only for `domain2.com`.
 
 ```toml
 [general]
   hosts = ["domain1.com", "domain2.com", "domain3.com"]
   loglevel = "info"
-  hide_service_name = true
   replaced_wait_timeout = 1000
 
 [[host_config]]
   host = "domain2.com"
 
   [host_config.general]
-    hide_service_name = false
+    replaced_wait_timeout = 2000
 ```
 
 ### `host_config.auth`

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -29,7 +29,7 @@
                 tls_options = [],
                 tls_verify            :: verify_none | verify_peer,
                 authenticated = false :: authenticated_state(),
-                host_type = <<>>      :: binary(),
+                host_type             :: binary() | undefined,
                 jid                   :: jid:jid() | undefined,
                 user = <<>>           :: jid:user(),
                 server = <<>>         :: jid:server(),

--- a/include/mongoose.hrl
+++ b/include/mongoose.hrl
@@ -25,7 +25,7 @@
 -define(MYHOSTS, ejabberd_config:get_global_option(hosts)).
 -define(ALL_HOST_TYPES, ejabberd_config:get_global_option_or_default(hosts, []) ++
                         ejabberd_config:get_global_option_or_default(host_types, [])).
--define(MYNAME,  hd(ejabberd_config:get_global_option(hosts))).
+-define(MYNAME,  ejabberd_config:get_global_option(default_server_domain)).
 -define(MYLANG,  ejabberd_config:get_global_option(language)).
 
 -define(CONFIG_PATH, "etc/mongooseim.toml").

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -11,6 +11,7 @@
 %% This node is for s2s testing.
 %% "localhost" host should NOT be defined.
 {hosts, "\"fed1\""}.
+{default_server_domain, "\"fed1\""}.
 
 {s2s_addr, "[[s2s.address]]
     host = \"localhost\"

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -2,6 +2,7 @@
   loglevel = "warning"
   hosts = [{{{hosts}}}]
   host_types = [{{{host_types}}}]
+  default_server_domain = {{{default_server_domain}}}
   registration_timeout = "infinity"
   language = "en"
   all_metrics_are_global = {{{all_metrics_are_global}}}

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -6,6 +6,7 @@
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 {host_types, "\"test type\""}.
+{default_server_domain, "\"localhost\""}.
 
 {host_config,
   "[[host_config]]

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -11,6 +11,7 @@
 {service_port, 8899}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
+{default_server_domain, "\"localhost\""}.
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"
     ip_address = \"127.0.0.1\""}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -11,6 +11,7 @@
 {http_api_client_endpoint_port, 8093}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
+{default_server_domain, "\"localhost\""}.
 
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -15,6 +15,7 @@
 %% "localhost" is a global host.
 %% "reg1" is a local host.
 {hosts, "\"reg1\", \"localhost\""}.
+{default_server_domain, "\"reg1\""}.
 {s2s_addr, "[[s2s.address]]
     host = \"localhost\"
     ip_address = \"127.0.0.1\"

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -11,6 +11,7 @@
 
 % TOML config
 {hosts, "\"localhost\""}.
+{default_server_domain, "\"localhost\""}.
 {s2s_default_policy, "\"deny\""}.
 {listen_service, "[[listen.service]]
   port = 8888

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -233,7 +233,7 @@ general() ->
                                                         validate = positive,
                                                         format = host_local_config},
                  <<"hide_service_name">> => #option{type = boolean,
-                                                    format = host_local_config}
+                                                    format = local_config}
                 },
        format = none
       }.

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -118,7 +118,8 @@
 root() ->
     General = general(),
     #section{
-       items = #{<<"general">> => General#section{process = fun ?MODULE:process_general/1},
+       items = #{<<"general">> => General#section{required = [<<"default_server_domain">>],
+                                                  process = fun ?MODULE:process_general/1},
                  <<"listen">> => listen(),
                  <<"auth">> => auth(),
                  <<"outgoing_pools">> => outgoing_pools(),
@@ -188,6 +189,10 @@ general() ->
                                                            validate = non_empty},
                                            validate = unique,
                                            format = config},
+                 <<"default_server_domain">> =># option{type = binary,
+                                                        validate = non_empty,
+                                                        process = fun ?MODULE:process_host/1,
+                                                        format = config},
                  <<"registration_timeout">> => #option{type = int_or_infinity,
                                                        validate = positive,
                                                        format = local_config},

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -271,7 +271,7 @@ wait_for_stream(closed, StateData) ->
     {stop, normal, StateData};
 wait_for_stream(_UnexpectedItem, #state{ server = Server,
                                          host_type = HostType } = StateData) ->
-    case ejabberd_config:get_local_option(hide_service_name, HostType) of
+    case ejabberd_config:get_local_option(hide_service_name) of
         true ->
             {stop, normal, StateData};
         _ ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -269,8 +269,9 @@ wait_for_stream(timeout, StateData) ->
     {stop, normal, StateData};
 wait_for_stream(closed, StateData) ->
     {stop, normal, StateData};
-wait_for_stream(_UnexpectedItem, #state{ server = Server } = StateData) ->
-    case ejabberd_config:get_local_option(hide_service_name, Server) of
+wait_for_stream(_UnexpectedItem, #state{ server = Server,
+                                         host_type = HostType } = StateData) ->
+    case ejabberd_config:get_local_option(hide_service_name, HostType) of
         true ->
             {stop, normal, StateData};
         _ ->
@@ -519,7 +520,7 @@ wait_for_feature_before_auth({xmlstreamelement, El}, StateData) ->
                                        TLSEnabled == false,
                                        SockMod == gen_tcp ->
             TLSOpts = case ejabberd_config:get_local_option(
-                             {domain_certfile, StateData#state.server}) of
+                             {domain_certfile, StateData#state.host_type}) of
                           undefined ->
                               StateData#state.tls_options;
                           CertFile ->
@@ -773,7 +774,8 @@ do_open_session(Acc, JID, StateData) ->
             end
     end.
 
-do_open_session_common(Acc, JID, #state{jid = JID, server = S} = NewStateData0) ->
+do_open_session_common(Acc, JID, #state{jid = JID, server = S,
+                                        host_type = HostType} = NewStateData0) ->
     change_shaper(NewStateData0, JID),
     Acc1 = mongoose_hooks:roster_get_subscription_lists(S, Acc, JID),
     {Fs, Ts, Pending} = mongoose_acc:get(roster, subscription_lists, {[], [], []}, Acc1),
@@ -792,7 +794,7 @@ do_open_session_common(Acc, JID, #state{jid = JID, server = S} = NewStateData0) 
         [] ->
             ok;
         _ ->
-            Timeout = get_replaced_wait_timeout(S),
+            Timeout = get_replaced_wait_timeout(HostType),
             erlang:send_after(Timeout, self(), replaced_wait_timeout)
     end,
 
@@ -806,8 +808,8 @@ do_open_session_common(Acc, JID, #state{jid = JID, server = S} = NewStateData0) 
                         privacy_list = PrivList},
     {established, Acc1, NewStateData}.
 
-get_replaced_wait_timeout(S) ->
-    ejabberd_config:get_local_option_or_default({replaced_wait_timeout, S},
+get_replaced_wait_timeout(HostType) ->
+    ejabberd_config:get_local_option_or_default({replaced_wait_timeout, HostType},
                                                 default_replaced_wait_timeout()).
 
 default_replaced_wait_timeout() ->

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -503,6 +503,7 @@ default_routing_modules() ->
      mongoose_router_localdomain,
      mongoose_router_external_localnode,
      mongoose_router_external,
+     mongoose_router_dynamic_domains,
      ejabberd_s2s].
 
 make_routing_module_source(Mods) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -151,6 +151,9 @@
 
 -export([c2s_remote_hook/5]).
 
+-export([disable_domain/2,
+         remove_domain/2]).
+
 -spec c2s_remote_hook(LServer, Tag, Args, HandlerState, C2SState) -> Result when
     LServer :: jid:lserver(),
     Tag :: atom(),
@@ -196,6 +199,20 @@ anonymous_purge_hook(LServer, Acc, LUser) ->
     Result :: ok.
 auth_failed(Server, Username) ->
     ejabberd_hooks:run_fold(auth_failed, Server, ok, [Username, Server]).
+
+-spec disable_domain(HostType, Domain) -> Result when
+    HostType :: binary(),
+    Domain :: jid:lserver(),
+    Result :: ok.
+disable_domain(HostType, Domain) ->
+    ejabberd_hooks:run(disable_domain, [HostType, Domain]).
+
+-spec remove_domain(HostType, Domain) -> Result when
+    HostType :: binary(),
+    Domain :: jid:lserver(),
+    Result :: ok.
+remove_domain(HostType, Domain) ->
+    ejabberd_hooks:run(remove_domain, [HostType, Domain]).
 
 -spec ejabberd_ctl_process(Acc, Args) -> Result when
     Acc :: any(),

--- a/src/mongoose_router_dynamic_domains.erl
+++ b/src/mongoose_router_dynamic_domains.erl
@@ -1,0 +1,36 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% this router should be tried in the very end, but before s2s.
+%%% it checks if destination domain is configured dynamically,
+%%% if it is so - the router adds domain fo the routing table,
+%%% and retries local routing.
+%%%
+%%% this ensures lazy dynamic domains registration in the routing
+%%% table.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mongoose_router_dynamic_domains).
+-author('bartlomiej.gorny@erlang-solutions.com').
+
+-behaviour(xmpp_router).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+-include("route.hrl").
+
+%% API
+%% xmpp_router callback
+-export([filter/4, route/4]).
+
+filter(From, To, Acc, Packet) ->
+    {From, To, Acc, Packet}.
+
+route(From, To, Acc, Packet) ->
+    LDstDomain = To#jid.lserver,
+    case mongoose_domain_api:get_host_type(LDstDomain) of
+        {ok, _} ->
+            ejabberd_local:register_host(LDstDomain),
+            mongoose_router_localdomain:route(From, To, Acc, Packet);
+        {error, not_found} -> {From, To, Acc, Packet}
+    end.
+

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -358,6 +358,7 @@ hosts(_Config) ->
     ?err(parse(#{<<"general">> => #{<<"hosts">> => [<<>>]}})),
     ?err(parse(#{<<"general">> => #{<<"hosts">> => [<<"host1">>, <<"host1">>]}})),
     % either hosts or host_types must be provided
+    ?err(mongoose_config_parser_toml:parse(#{<<"general">> => #{}})),
     ?err(mongoose_config_parser_toml:parse(#{<<"general">> => GenM})),
     ?err(mongoose_config_parser_toml:parse(#{<<"general">> => GenM#{<<"host">> => [],
                                                                     <<"host_types">> => []}})),
@@ -3013,7 +3014,7 @@ parse(M0) ->
 maybe_insert_dummy_domain(M, DomainName) ->
     DummyGenM = #{<<"default_server_domain">> => DomainName,
                   <<"hosts">> => [DomainName]},
-    OldGenM = maps:get(<<"general">> ,M, #{}),
+    OldGenM = maps:get(<<"general">>, M, #{}),
     NewGenM = maps:merge(DummyGenM,OldGenM),
     M#{<<"general">> => NewGenM}.
 

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -490,9 +490,9 @@ replaced_wait_timeout(_Config) ->
     err_host_config(#{<<"general">> => #{<<"replaced_wait_timeout">> => 0}}).
 
 hide_service_name(_Config) ->
-    eq_host_config([#local_config{key = {hide_service_name, ?HOST}, value = false}],
-                  #{<<"general">> => #{<<"hide_service_name">> => false}}),
-    err_host_config(#{<<"general">> => #{<<"hide_service_name">> => []}}).
+    compare_config([#local_config{key = hide_service_name, value = false}],
+                   parse(#{<<"general">> => #{<<"hide_service_name">> => false}})),
+    ?err(parse(#{<<"general">> => #{<<"hide_service_name">> => []}})).
 
 %% tests: listen
 

--- a/test/config_parser_SUITE_data/host_types.options
+++ b/test/config_parser_SUITE_data/host_types.options
@@ -1,3 +1,4 @@
+{config,default_server_domain,<<"localhost">>}.
 {config,host_types,
         [<<"this is host type">>,<<"some host type">>,<<"another host type">>,
          <<"yet another host type">>]}.

--- a/test/config_parser_SUITE_data/host_types.toml
+++ b/test/config_parser_SUITE_data/host_types.toml
@@ -7,6 +7,7 @@
     ]
 
   hosts = ["localhost"]
+  default_server_domain = "localhost"
 
 [auth]
   methods = ["test1", "test2"]

--- a/test/config_parser_SUITE_data/miscellaneous.options
+++ b/test/config_parser_SUITE_data/miscellaneous.options
@@ -1,3 +1,4 @@
+{config,default_server_domain,<<"localhost">>}.
 {config,hosts,[<<"localhost">>,<<"anonymous.localhost">>]}.
 {local_config,cowboy_server_name,"Apache"}.
 {local_config,listen,

--- a/test/config_parser_SUITE_data/miscellaneous.options
+++ b/test/config_parser_SUITE_data/miscellaneous.options
@@ -1,6 +1,7 @@
 {config,default_server_domain,<<"localhost">>}.
 {config,hosts,[<<"localhost">>,<<"anonymous.localhost">>]}.
 {local_config,cowboy_server_name,"Apache"}.
+{local_config,hide_service_name,true}.
 {local_config,listen,
     [{{5280,{0,0,0,0},tcp},
       ejabberd_cowboy,
@@ -59,8 +60,6 @@
                {bucket_type,<<"user_bucket">>}]}.
 {local_config,{extauth_instances,<<"anonymous.localhost">>},1}.
 {local_config,{extauth_instances,<<"localhost">>},1}.
-{local_config,{hide_service_name,<<"anonymous.localhost">>},true}.
-{local_config,{hide_service_name,<<"localhost">>},true}.
 {local_config,{pgsql_users_number_estimate,<<"anonymous.localhost">>},true}.
 {local_config,{pgsql_users_number_estimate,<<"localhost">>},true}.
 {local_config,{replaced_wait_timeout,<<"anonymous.localhost">>},2000}.

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -3,6 +3,7 @@
     "localhost",
     "anonymous.localhost"
   ]
+  default_server_domain = "localhost"
   http_server_name = "Apache"
   rdbms_server_type = "mssql"
   override = ["local", "global", "acls"]

--- a/test/config_parser_SUITE_data/modules.options
+++ b/test/config_parser_SUITE_data/modules.options
@@ -1,3 +1,4 @@
+{config,default_server_domain,<<"localhost">>}.
 {config,hosts,[<<"localhost">>,<<"dummy_host">>]}.
 {local_config,
     {modules,<<"dummy_host">>},

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -3,6 +3,7 @@
     "localhost",
     "dummy_host"
   ]
+  default_server_domain = "localhost"
 
 [modules.mod_adhoc]
   iqdisc.type = "one_queue"

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.options
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.options
@@ -1,3 +1,4 @@
+{config,default_server_domain,<<"localhost">>}.
 {acl,{local,global},{user_regexp,<<>>}}.
 {config,hosts,[<<"localhost">>,<<"anonymous.localhost">>,<<"localhost.bis">>]}.
 {config,language,<<"en">>}.

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -5,6 +5,7 @@
     "anonymous.localhost",
     "localhost.bis"
   ]
+  default_server_domain = "localhost"
   registration_timeout = "infinity"
   language = "en"
   all_metrics_are_global = false

--- a/test/config_parser_SUITE_data/outgoing_pools.options
+++ b/test/config_parser_SUITE_data/outgoing_pools.options
@@ -1,3 +1,4 @@
+{config,default_server_domain,<<"localhost">>}.
 {config,hosts,[<<"localhost">>,<<"anonymous.localhost">>,<<"localhost.bis">>]}.
 {local_config,outgoing_pools,
     [{cassandra,global,default,[],

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -4,6 +4,7 @@
     "anonymous.localhost",
     "localhost.bis"
   ]
+  default_server_domain = "localhost"
 
 [outgoing_pools.redis.global_distrib]
   scope = "single_host"

--- a/test/config_parser_SUITE_data/s2s_only.options
+++ b/test/config_parser_SUITE_data/s2s_only.options
@@ -1,3 +1,4 @@
+{config,default_server_domain,<<"localhost">>}.
 {config,hosts,[<<"localhost">>,<<"dummy_host">>]}.
 {local_config,outgoing_s2s_families,[ipv4,ipv6]}.
 {local_config,outgoing_s2s_port,5299}.

--- a/test/config_parser_SUITE_data/s2s_only.toml
+++ b/test/config_parser_SUITE_data/s2s_only.toml
@@ -3,6 +3,7 @@
     "localhost",
     "dummy_host"
   ]
+  default_server_domain = "localhost"
 
 [s2s]
   use_starttls = "optional"

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -66,7 +66,7 @@ teardown() ->
 
 default_local_option(max_fsm_queue) -> 100.
 
-default_global_option(hosts) ->  [<<"localhost">>];
+default_global_option(default_server_domain) ->  <<"localhost">>;
 default_global_option({access, c2s_shaper, global}) ->  [];
 default_global_option(language) ->  <<"en">>.
 

--- a/test/ejabberd_config_SUITE_data/mongooseim.minimal.toml
+++ b/test/ejabberd_config_SUITE_data/mongooseim.minimal.toml
@@ -1,2 +1,3 @@
 [general]
   hosts = ["localhost"]
+  default_server_domain = "localhost"

--- a/test/ejabberd_listener_SUITE_data/mongooseim.basic.toml
+++ b/test/ejabberd_listener_SUITE_data/mongooseim.basic.toml
@@ -1,5 +1,6 @@
 [general]
   hosts = ["localhost"]
+  default_server_domain = "localhost"
 
 [[listen.http]]
   port = 5280


### PR DESCRIPTION
this PR introduces:
* a new router `mongoose_router_dynamic_domains` that is responcible for a lazy adding (on the first routing attempt) of dynamic domains. removal of dynamic domains happens synchronously on `disable_domain` hook.
* a new mandatory configuration item `default_server_domain` - it must be used for reporting stream errors before user clarifies the domain name he wants to use (before user sets up the stream).
