### PR TITLE
Unify checks for chat markers

### DIFF
--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -133,16 +133,7 @@ if_chat_marker_get_id(Packet, Marker) ->
 
 -spec has_chat_marker(Packet :: exml:element()) -> boolean().
 has_chat_marker(Packet) ->
-    has_chat_marker(Packet, all_chat_markers()).
-
--spec has_chat_marker(Packet :: exml:element(), list(marker())) -> boolean().
-has_chat_marker(Packet, Markers) ->
-    case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS, no_marker) of
-        no_marker ->
-            false;
-        #xmlel{name = Marker} ->
-            lists:member(Marker, Markers)
-    end.
+    mongoose_chat_markers:has_chat_markers(Packet).
 
 -spec maybe_write_to_inbox(Host, User, Remote, Packet, TS, WriteF) -> ok | {ok, integer()} when
       Host :: host(),
@@ -204,9 +195,6 @@ extract_attr_jid(ResetStanza) ->
                 JID -> JID
             end
     end.
-
-all_chat_markers() ->
-    [<<"received">>, <<"displayed">>, <<"acknowledged">>].
 
 -spec maybe_binary_to_positive_integer(binary()) -> non_neg_integer() | {error, atom()}.
 maybe_binary_to_positive_integer(Bin) ->

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -347,12 +347,7 @@ has_any(Elements) ->
     lists:any(fun(El) -> El =/= false end, Elements).
 
 has_chat_marker(Packet) ->
-    case exml_query:subelement_with_ns(Packet, ?NS_CHAT_MARKERS) of
-        #xmlel{name = <<"received">>}     -> true;
-        #xmlel{name = <<"displayed">>}    -> true;
-        #xmlel{name = <<"acknowledged">>} -> true;
-        _                                 -> false
-    end.
+    mongoose_chat_markers:has_chat_markers(Packet).
 
 get_retract_id(true = _Enabled, Packet) ->
     get_retract_id(Packet);

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -72,14 +72,13 @@
 %%--------------------------------------------------------------------
 %% Type declarations
 %%--------------------------------------------------------------------
--type maybe_thread() :: undefined|binary().
--type chat_marker_type() :: received | displayed | acknowledged.
+-type maybe_thread() :: undefined | binary().
 -type chat_type() :: one2one | groupchat.
 
 -type chat_marker() :: #{from := jid:jid(),
                          to := jid:jid(),
                          thread := maybe_thread(), %%it is not optional!!!
-                         type := chat_marker_type(),
+                         type := mongoose_chat_markers:chat_marker_type(),
                          timestamp := integer(), %microsecond
                          id := binary()}.
 
@@ -166,34 +165,12 @@ update_chat_markers(Acc, Host, Markers) ->
                            Packet :: exml:element(),
                            TS :: integer()) -> [chat_marker()].
 extract_chat_markers(From, To, Packet, TS) ->
-    case get_chat_markers(Packet) of
+    case mongoose_chat_markers:list_chat_markers(Packet) of
         [] -> [];
         ChatMarkers ->
             CM = #{from => From, to => To, thread => get_thread(Packet), timestamp => TS},
             [CM#{type => Type, id => Id} || {Type, Id} <- ChatMarkers]
     end.
-
--spec get_chat_markers(exml:element()) -> [{chat_marker_type(), Id :: binary()}].
-get_chat_markers(#xmlel{children = Children}) ->
-    lists:filtermap(fun is_chat_marker_element/1, Children).
-
--spec is_chat_marker_element(exml:element()) ->
-    false | {true, {chat_marker_type(), Id :: binary}}.
-is_chat_marker_element(#xmlel{name = <<"received">>} = El) ->
-    check_chat_marker_attributes(received, El);
-is_chat_marker_element(#xmlel{name = <<"displayed">>} = El) ->
-    check_chat_marker_attributes(displayed, El);
-is_chat_marker_element(#xmlel{name = <<"acknowledged">>} = El) ->
-    check_chat_marker_attributes(acknowledged, El);
-is_chat_marker_element(_) ->
-    false.
-
--spec check_chat_marker_attributes(chat_marker_type(), exml:element()) ->
-    false | {true, {chat_marker_type(), Id :: binary()}}.
-check_chat_marker_attributes(Type, El) ->
-    NS = exml_query:attr(El, <<"xmlns">>),
-    Id = exml_query:attr(El, <<"id">>),
-    ?NS_CHAT_MARKERS =:= NS andalso Id =/= undefined andalso {true, {Type, Id}}.
 
 -spec get_thread(exml:element()) -> maybe_thread().
 get_thread(El) ->

--- a/src/mongoose_chat_markers.erl
+++ b/src/mongoose_chat_markers.erl
@@ -1,0 +1,46 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2021, Erlang-Solutions
+%%% @doc
+%%% This module implements [XEP-0333: Chat Markers] helper functions
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mongoose_chat_markers).
+
+-include("mongoose_ns.hrl").
+-include_lib("exml/include/exml.hrl").
+
+%% Markers
+-export([has_chat_markers/1]).
+-export([list_chat_markers/1]).
+
+-type id() :: binary().
+-type chat_marker_type() :: received | displayed | acknowledged.
+-type chat_marker_element() :: {chat_marker_type(), id()}.
+-export_type([chat_marker_type/0]).
+-export_type([chat_marker_element/0]).
+
+-spec has_chat_markers(exml:element()) -> boolean().
+has_chat_markers(Packet) ->
+    [] =/= list_chat_markers(Packet).
+
+-spec list_chat_markers(exml:element()) -> [chat_marker_element()].
+list_chat_markers(#xmlel{children = Children}) ->
+    lists:filtermap(fun is_chat_marker_element/1, Children).
+
+-spec is_chat_marker_element(exml:element()) ->
+    false | {true, {chat_marker_type(), Id :: binary}}.
+is_chat_marker_element(#xmlel{name = <<"received">>} = El) ->
+    check_chat_marker_attributes(received, El);
+is_chat_marker_element(#xmlel{name = <<"displayed">>} = El) ->
+    check_chat_marker_attributes(displayed, El);
+is_chat_marker_element(#xmlel{name = <<"acknowledged">>} = El) ->
+    check_chat_marker_attributes(acknowledged, El);
+is_chat_marker_element(_) ->
+    false.
+
+-spec check_chat_marker_attributes(chat_marker_type(), exml:element()) ->
+    false | {true, chat_marker_element()}.
+check_chat_marker_attributes(Type, El) ->
+    NS = exml_query:attr(El, <<"xmlns">>),
+    Id = exml_query:attr(El, <<"id">>),
+    ?NS_CHAT_MARKERS =:= NS andalso Id =/= undefined andalso {true, {Type, Id}}.


### PR DESCRIPTION
Currently checking if a stanza contains a chat markers is triplicated in
three different modules. Implement all of it in mod_smart_markers and
make the other two places simply call this one.