### PR TITLE
Set archive_groupchats to false by default

### DIFF
--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -512,7 +512,7 @@ handle_package(Dir, ReturnMessID,
     end.
 
 should_archive_if_groupchat(Host, <<"groupchat">>) ->
-    gen_mod:get_module_opt(Host, ?MODULE, archive_groupchats, true);
+    gen_mod:get_module_opt(Host, ?MODULE, archive_groupchats, false);
 should_archive_if_groupchat(_, _) ->
     true.
 


### PR DESCRIPTION
Proposed changes include:
* Set archive_groupchats to false by default


#### `modules.mod_mam_meta.pm.archive_groupchats`
* **Syntax:** boolean
* **Default:** `false` (yes, now)
* **Example:** `modules.mod_mam_meta.pm.archive_groupchats = true`

