### PR TITLE
Remove ?MYNAME macros

### DIFF
--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -848,8 +848,8 @@ inactivity() ->
 
 inactivity(Value) ->
     {inactivity,
-     fun() -> rpc(mim(), mod_bosh, get_inactivity, []) end,
-     fun(V) -> rpc(mim(), mod_bosh, set_inactivity, [V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_inactivity, [domain()]) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_inactivity, [domain(), V]) end,
      Value}.
 
 max_wait() ->
@@ -857,14 +857,14 @@ max_wait() ->
 
 max_wait(Value) ->
     {max_wait,
-     fun() -> rpc(mim(), mod_bosh, get_max_wait, []) end,
-     fun(V) -> rpc(mim(), mod_bosh, set_max_wait, [V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_max_wait, [domain()]) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_max_wait, [domain(), V]) end,
      Value}.
 
 server_acks_opt() ->
     {server_acks,
-     fun() -> rpc(mim(), mod_bosh, get_server_acks, []) end,
-     fun(V) -> rpc(mim(), mod_bosh, set_server_acks, [V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_server_acks, [domain()]) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_server_acks, [domain(), V]) end,
      true}.
 
 is_session_alive(Sid) ->

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1206,7 +1206,7 @@ remove_old_messages_test(Config) ->
         {jid, _, _, _, LUser, LServer, _} = JidRecordBob,
         rpc_call(mod_offline_backend, write_messages, [LUser, LServer, [OfflineOld, OfflineNew]]),
         %% when
-        {_, 0} = ejabberdctl("delete_old_messages", ["1"], Config),
+        {_, 0} = ejabberdctl("delete_old_messages", [LServer, "1"], Config),
         {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [JidRecordBob]),
         %% then
         1 = length(SecondList)
@@ -1243,7 +1243,7 @@ remove_expired_messages_test(Config) ->
         Args = [OfflineOld, OfflineNow, OfflineFuture, OfflineFuture2],
         rpc_call(mod_offline_backend, write_messages, [LUser, LServer, Args]),
         %% when
-        {_, 0} = ejabberdctl("delete_expired_messages", [], Config),
+        {_, 0} = ejabberdctl("delete_expired_messages", [LServer], Config),
         {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [JidRecordKate]),
         %% then
         2 = length(SecondList)

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -198,13 +198,15 @@ init_per_group_generic(Config0) ->
                   OldMods = save_modules(NodeName, VirtHosts),
 
                   rpc(NodeName, gen_mod_deps, start_modules,
-                      [<<"localhost">>, [{mod_global_distrib, Opts}]]),
+                      [domain(), [{mod_global_distrib, Opts}]]),
 
                   [rpc(NodeName, gen_mod, stop_module, [VirtHost, Mod])
                    || Mod <- ModulesToStop, VirtHost <- VirtHosts],
 
-                  ResumeTimeout = rpc(NodeName, mod_stream_management, get_resume_timeout, [1]),
-                  true = rpc(NodeName, mod_stream_management, set_resume_timeout, [1]),
+                  ResumeTimeout = rpc(NodeName, mod_stream_management, get_resume_timeout,
+                                      [domain(), 1]),
+                  true = rpc(NodeName, mod_stream_management, set_resume_timeout,
+                             [domain(), 1]),
 
                   OldMods ++
                   [
@@ -243,7 +245,7 @@ end_per_group_generic(Config) ->
               [restore_modules(NodeName, VirtHost, Config) || VirtHost <- VirtHosts],
 
               rpc(NodeName, mod_stream_management, set_resume_timeout,
-                  [?config({resume_timeout, NodeName}, Config)])
+                  [domain(), ?config({resume_timeout, NodeName}, Config)])
       end,
       get_hosts()).
 
@@ -342,7 +344,13 @@ generic_end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
 virtual_hosts() ->
-    [ct:get_config({hosts, mim, domain}), ct:get_config({hosts, mim, secondary_domain})].
+    [domain(), secondary_domain()].
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+secondary_domain() ->
+    ct:get_config({hosts, mim, secondary_domain}).
 
 %% Refresher is not started at all or stopped for some test cases
 -spec pause_refresher(NodeName :: atom(), CaseName :: atom()) -> ok.

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -141,11 +141,11 @@ end_per_suite(Config) ->
 
 init_per_group(G, Config) when G =:= unacknowledged_message_hook;
                                G =:= manual_ack_freq_long_session_timeout ->
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [1]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), 1]),
     escalus_users:update_userspec(Config, alice, manual_ack, true);
 init_per_group(parallel_manual_ack_freq_1, Config) ->
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [1]),
-    rpc(mim(), ?MOD_SM, set_resume_timeout, [?SHORT_RESUME_TIMEOUT]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), 1]),
+    rpc(mim(), ?MOD_SM, set_resume_timeout, [domain(), ?SHORT_RESUME_TIMEOUT]),
     escalus_users:update_userspec(Config, alice, manual_ack, true);
 init_per_group(stale_h, Config) ->
     escalus_users:update_userspec(Config, alice, manual_ack, true);
@@ -161,11 +161,11 @@ end_per_group(stream_mgmt_disabled, Config) ->
     dynamic_modules:restore_modules(domain(), Config);
 end_per_group(G, Config) when G =:= unacknowledged_message_hook;
                               G =:= manual_ack_freq_long_session_timeout ->
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [never]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), never]),
     Config;
 end_per_group(parallel_manual_ack_freq_1, Config) ->
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [never]),
-    rpc(mim(), ?MOD_SM, set_resume_timeout, [600]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), never]),
+    rpc(mim(), ?MOD_SM, set_resume_timeout, [domain(), 600]),
     Config;
 end_per_group(_GroupName, Config) ->
     Config.
@@ -179,7 +179,7 @@ set_gc_parameters(RepeatAfter, Geriatric, Config) ->
 
 register_smid(IntSmidId) ->
     S = {SMID = make_smid(), IntSmidId},
-    ok = rpc(mim(), ?MOD_SM, register_stale_smid_h, [SMID, IntSmidId]),
+    ok = rpc(mim(), ?MOD_SM, register_stale_smid_h, [domain(), SMID, IntSmidId]),
     S.
 
 register_some_smid_h(Config) ->
@@ -188,8 +188,8 @@ register_some_smid_h(Config) ->
 
 init_per_testcase(resume_expired_session_returns_correct_h = CN, Config) ->
     Config2 = set_gc_parameters(?BIG_BIG_BIG_TIMEOUT, ?BIG_BIG_BIG_TIMEOUT, Config),
-    rpc(mim(), ?MOD_SM, set_resume_timeout, [?SHORT_RESUME_TIMEOUT]),
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [1]),
+    rpc(mim(), ?MOD_SM, set_resume_timeout, [domain(), ?SHORT_RESUME_TIMEOUT]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), 1]),
     escalus:init_per_testcase(CN, Config2);
 init_per_testcase(gc_repeat_after_never_means_no_cleaning = CN, Config) ->
     Config2 = set_gc_parameters(?BIG_BIG_BIG_TIMEOUT, ?SHORT_RESUME_TIMEOUT, Config),
@@ -200,7 +200,7 @@ init_per_testcase(gc_repeat_after_timeout_does_clean = CN, Config) ->
     Config3 = register_some_smid_h(Config2),
     escalus:init_per_testcase(CN, Config3);
 init_per_testcase(server_requests_ack_freq_2 = CN, Config) ->
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [2]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), 2]),
     escalus:init_per_testcase(CN, Config);
 init_per_testcase(replies_are_processed_by_resumed_session = CN, Config) ->
     register_handler(<<"localhost">>),
@@ -217,7 +217,7 @@ end_per_testcase(CN, Config) when CN =:= resume_expired_session_returns_correct_
     dynamic_modules:restore_modules(domain(), Config),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(server_requests_ack_freq_2 = CN, Config) ->
-    true = rpc(mim(), ?MOD_SM, set_ack_freq, [never]),
+    true = rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), never]),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(replies_are_processed_by_resumed_session = CN, Config) ->
     unregister_handler(<<"localhost">>),
@@ -676,15 +676,15 @@ resume_expired_session_returns_correct_h(Config) ->
     escalus_connection:stop(NewAlice).
 
 gc_repeat_after_never_means_no_cleaning(Config) ->
-    true = rpc(mim(), ?MOD_SM, set_stale_h_repeat_after, [?BIG_BIG_BIG_TIMEOUT]),
+    true = rpc(mim(), ?MOD_SM, set_stale_h_repeat_after, [domain(), ?BIG_BIG_BIG_TIMEOUT]),
     [{SMID1, _}, {SMID2, _}, {SMID3, _}] = ?config(smid_test, Config),
-    {stale_h, 1} = rpc(mim(), ?MOD_SM, get_session_from_smid, [SMID1]),
-    {stale_h, 2} = rpc(mim(), ?MOD_SM, get_session_from_smid, [SMID2]),
-    {stale_h, 3} = rpc(mim(), ?MOD_SM, get_session_from_smid, [SMID3]).
+    {stale_h, 1} = rpc(mim(), ?MOD_SM, get_session_from_smid, [domain(), SMID1]),
+    {stale_h, 2} = rpc(mim(), ?MOD_SM, get_session_from_smid, [domain(), SMID2]),
+    {stale_h, 3} = rpc(mim(), ?MOD_SM, get_session_from_smid, [domain(), SMID3]).
 gc_repeat_after_timeout_does_clean(Config) ->
     [{SMID1, _} | _ ] = ?config(smid_test, Config),
     mongoose_helper:wait_until(fun() ->
-                                       rpc(mim(), ?MOD_SM, get_stale_h, [SMID1])
+                                       rpc(mim(), ?MOD_SM, get_stale_h, [domain(), SMID1])
                                end,
                                {error, smid_not_found},
                                #{name => smid_garbage_collected}).
@@ -1373,26 +1373,26 @@ discard_offline_messages(Config, User, H) ->
 buffer_max(BufferMax) ->
     {buffer_max,
      fun () ->
-             rpc(mim(), ?MOD_SM, get_buffer_max, [unset])
+             rpc(mim(), ?MOD_SM, get_buffer_max, [domain(), unset])
      end,
      fun (unset) ->
              ct:pal("buffer_max was not set - setting to 'undefined'"),
-             rpc(mim(), ?MOD_SM, set_buffer_max, [undefined]);
+             rpc(mim(), ?MOD_SM, set_buffer_max, [domain(), undefined]);
          (V) ->
-             rpc(mim(), ?MOD_SM, set_buffer_max, [V])
+             rpc(mim(), ?MOD_SM, set_buffer_max, [domain(), V])
      end,
      BufferMax}.
 
 ack_freq(AckFreq) ->
     {ack_freq,
      fun () ->
-             rpc(mim(), ?MOD_SM, get_ack_freq, [unset])
+             rpc(mim(), ?MOD_SM, get_ack_freq, [domain(), unset])
      end,
      fun (unset) ->
              ct:pal("ack_freq was not set - setting to 'undefined'"),
-             rpc(mim(), ?MOD_SM, set_ack_freq, [undefined]);
+             rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), undefined]);
          (V) ->
-             rpc(mim(), ?MOD_SM, set_ack_freq, [V])
+             rpc(mim(), ?MOD_SM, set_ack_freq, [domain(), V])
      end,
      AckFreq}.
 

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -70,6 +70,7 @@
          get_module_opt_by_subhost/4,
          set_module_opt_by_subhost/4,
 
+         loaded_modules/0,
          loaded_modules/1,
          loaded_modules_with_opts/1,
          opts_for_module/2,
@@ -403,6 +404,13 @@ get_opt_subhost(Host, OptName, Opts, Default) ->
 get_module_opt_subhost(Host, Module, Default) ->
     Spec = get_module_opt(Host, Module, host, Default),
     make_subhost(Spec, Host).
+
+-spec loaded_modules() -> [module()].
+loaded_modules() ->
+    ModSet = ets:foldl(fun(#ejabberd_module{module_host = {Mod, _}}, Set) ->
+                               gb_sets:add_element(Mod, Set)
+                       end, gb_sets:new(), ejabberd_modules),
+    gb_sets:to_list(ModSet).
 
 -spec loaded_modules(jid:server()) -> [module()].
 loaded_modules(Host) ->

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -414,7 +414,7 @@ make_user_item_if_exists(Username, Attrs,
         true ->
             RFields = lists:map(fun ({_, VCardName}) ->
                                         {VCardName, map_vcard_attr(VCardName, Attrs, VCardMap,
-                                                                   {Username, ?MYNAME})}
+                                                                   {Username, LServer})}
                                 end,
                                 SearchReported),
             Result = [?FIELD(<<"jid">>, <<Username/binary, "@", LServer/binary>>)] ++

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -530,7 +530,7 @@ init(Opts) ->
 handle_call({sql_cmd, Command, Timestamp}, From, State) ->
     run_sql_cmd(Command, From, State, Timestamp);
 handle_call(get_db_info, _, #state{db_ref = DbRef} = State) ->
-    {reply, {ok, db_engine(?MYNAME), DbRef}, State};
+    {reply, {ok, db_engine(global), DbRef}, State};
 handle_call(Request, From, State) ->
     ?UNEXPECTED_CALL(Request, From),
     {reply, {error, badarg}, State}.

--- a/src/stream_management/stream_management_stale_h.erl
+++ b/src/stream_management/stream_management_stale_h.erl
@@ -21,9 +21,7 @@
          clear_table/1
         ]).
 
--export([maybe_start/1,
-         stop/0
-        ]).
+-export([maybe_start/1]).
 
 %% Internal exports
 -export([start_link/1]).
@@ -87,9 +85,6 @@ start_cleaner(Opts) ->
                  {?MODULE, start_link, [Opts]},
                  permanent, 5000, worker, [?MODULE]},
     ejabberd_sup:start_child(ChildSpec).
-
-stop() ->
-    ok.
 
 start_link(Opts) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [Opts], []).


### PR DESCRIPTION
Remove all occurences of `?MYNAME` except stream errors and the initial value in `ejabberd_c2s`. These are the only expected uses of this macro.

