### PR TITLE
Add remove_domain handler for MAM

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -84,6 +84,7 @@
 {suites, "tests", xep_0352_csi_SUITE}.
 {suites, "tests", service_domain_db_SUITE}.
 {suites, "tests", domain_isolation_SUITE}.
+{suites, "tests", domain_removal_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -111,6 +111,4 @@ mam_muc_removal(Config0) ->
     escalus_fresh:story_with_config(Config0, [{alice, 1}], F).
 
 run_remove_domain() ->
-    Acc = #{},
-    rpc(mim(), ejabberd_hooks, run_fold,
-        [remove_domain, domain(), Acc, [domain(), domain()]]).
+    rpc(mim(), mongoose_hooks, remove_domain, [domain(), domain()]).

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -1,0 +1,127 @@
+-module(domain_removal_SUITE).
+
+%% API
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2]).
+
+-export([mam_pm_removal/1,
+         mam_muc_removal/1]).
+
+-import(mam_helper,
+        [stanza_archive_request/2,
+         wait_archive_respond/1,
+         assert_respond_size/2,
+         respond_messages/1,
+         parse_forwarded_message/1]).
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
+-include("mam_helper.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("exml/include/exml_stream.hrl").
+
+all() ->
+    [{group, mam_removal}].
+
+groups() ->
+    [
+     {mam_removal, [], [mam_pm_removal,
+                        mam_muc_removal]}
+    ].
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).
+
+%%%===================================================================
+%%% Overall setup/teardown
+%%%===================================================================
+init_per_suite(Config) ->
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+%%%===================================================================
+%%% Group specific setup/teardown
+%%%===================================================================
+init_per_group(Group, Config) ->
+    case mongoose_helper:is_rdbms_enabled(domain()) of
+        true ->
+            Config2 = dynamic_modules:save_modules(domain(), Config),
+            rpc(mim(), gen_mod_deps, start_modules, [domain(), group_to_modules(Group)]),
+            Config2;
+        false ->
+            {skip, require_rdbms}
+    end.
+
+end_per_group(_Groupname, Config) ->
+    case mongoose_helper:is_rdbms_enabled(domain()) of
+        true ->
+            dynamic_modules:restore_modules(domain(), Config);
+        false ->
+            ok
+    end,
+    ok.
+
+group_to_modules(mam_removal) ->
+    MH = muc_light_helper:muc_host(),
+    [{mod_mam_meta, [{backend, rdbms}, {pm, []}, {muc, [{host, MH}]}]},
+     {mod_muc_light, []}].
+
+%%%===================================================================
+%%% Testcase specific setup/teardown
+%%%===================================================================
+
+init_per_testcase(TestCase, Config) ->
+    escalus:init_per_testcase(TestCase, Config).
+
+end_per_testcase(TestCase, Config) ->
+    escalus:end_per_testcase(TestCase, Config).
+
+%%%===================================================================
+%%% Test Cases
+%%%===================================================================
+
+mam_pm_removal(Config) ->
+    P = ?config(props, Config),
+    F = fun(Alice, Bob) ->
+        escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
+        escalus:wait_for_stanza(Bob),
+        mam_helper:wait_for_archive_size(Alice, 1),
+        mam_helper:wait_for_archive_size(Bob, 1),
+        run_remove_domain(),
+        mam_helper:wait_for_archive_size(Alice, 0),
+        mam_helper:wait_for_archive_size(Bob, 0)
+        end,
+    escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
+
+mam_muc_removal(Config0) ->
+    F = fun(Config, Alice) ->
+        Room = muc_helper:fresh_room_name(),
+        MucHost = muc_light_helper:muc_host(),
+        muc_light_helper:create_room(Room, MucHost, alice,
+                                     [alice], Config, muc_light_helper:ver(1)),
+        RoomAddr = <<Room/binary, "@", MucHost/binary>>,
+        escalus:send(Alice, escalus_stanza:groupchat_to(RoomAddr, <<"text">>)),
+        escalus:wait_for_stanza(Alice),
+        mam_helper:wait_for_room_archive_size(MucHost, Room, 1),
+        run_remove_domain(),
+        mam_helper:wait_for_room_archive_size(MucHost, Room, 0),
+        ok
+        end,
+    escalus_fresh:story_with_config(Config0, [{alice, 1}], F).
+
+run_remove_domain() ->
+    Acc = #{},
+    rpc(mim(), ejabberd_hooks, run_fold,
+        [remove_domain, domain(), Acc, [domain(), domain()]]).

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -13,16 +13,7 @@
 -export([mam_pm_removal/1,
          mam_muc_removal/1]).
 
--import(mam_helper,
-        [stanza_archive_request/2,
-         wait_archive_respond/1,
-         assert_respond_size/2,
-         respond_messages/1,
-         parse_forwarded_message/1]).
-
--import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
-                             rpc/4]).
+-import(distributed_helper, [mim/0, rpc/4]).
 
 -include("mam_helper.hrl").
 -include_lib("escalus/include/escalus.hrl").
@@ -93,7 +84,6 @@ end_per_testcase(TestCase, Config) ->
 %%%===================================================================
 
 mam_pm_removal(Config) ->
-    P = ?config(props, Config),
     F = fun(Alice, Bob) ->
         escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
         escalus:wait_for_stanza(Bob),
@@ -116,8 +106,7 @@ mam_muc_removal(Config0) ->
         escalus:wait_for_stanza(Alice),
         mam_helper:wait_for_room_archive_size(MucHost, Room, 1),
         run_remove_domain(),
-        mam_helper:wait_for_room_archive_size(MucHost, Room, 0),
-        ok
+        mam_helper:wait_for_room_archive_size(MucHost, Room, 0)
         end,
     escalus_fresh:story_with_config(Config0, [{alice, 1}], F).
 

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -265,6 +265,7 @@ CREATE TABLE mam_config(
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 
+-- The server field is a MUC host for MUC rooms
 CREATE TABLE mam_server_user(
   id INT UNSIGNED NOT NULL AUTO_INCREMENT,
   server    varchar(250) CHARACTER SET binary NOT NULL,

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -60,6 +60,9 @@
 %% Library functions for reuse in ejabberd_auth_* modules
 -export([authorize_with_check_password/2]).
 
+%% Hook handlers
+-export([remove_domain/3]).
+
 -include("mongoose.hrl").
 -include("jlib.hrl").
 

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -81,7 +81,7 @@ start() ->
 -spec start(HostType :: binary()) -> 'ok'.
 start(HostType) ->
     ensure_metrics(HostType),
-    ejabberd_hooks:add(remove_domain, global, fun remove_domain/3, 50),
+    ejabberd_hooks:add(remove_domain, HostType, ?MODULE, remove_domain, 50),
     lists:foreach(
       fun(M) ->
               M:start(HostType)
@@ -89,7 +89,7 @@ start(HostType) ->
 
 -spec stop(HostType :: binary()) -> 'ok'.
 stop(HostType) ->
-    ejabberd_hooks:delete(remove_domain, global, fun remove_domain/3, 50),
+    ejabberd_hooks:delete(remove_domain, HostType, ?MODULE, remove_domain, 50),
     lists:foreach(
       fun(M) ->
               M:stop(HostType)

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -78,34 +78,25 @@ get_mam_muc_gdpr_data(Acc, #jid{luser = User, lserver = Host} = _UserJID) ->
 
 -spec start_hooks(jid:server(), _) -> ok.
 start_hooks(Host, _Opts) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
-        true ->
-            ok;
-        false ->
-            ejabberd_hooks:add(mam_muc_archive_message, Host, ?MODULE, archive_message, 50)
-    end,
-    ejabberd_hooks:add(mam_muc_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:add(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:add(remove_domain, Host, ?MODULE, remove_domain, 50),
-    ejabberd_hooks:add(get_mam_muc_gdpr_data, Host, ?MODULE, get_mam_muc_gdpr_data, 50),
-    ok.
-
+    ejabberd_hooks:add(hooks(Host)).
 
 -spec stop_hooks(jid:server()) -> ok.
 stop_hooks(Host) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
+    ejabberd_hooks:delete(hooks(Host)).
+
+hooks(Host) ->
+    NoWriter = gen_mod:get_module_opt(Host, ?MODULE, no_writer, false),
+    case NoWriter of
         true ->
-            ok;
+            [];
         false ->
-            ejabberd_hooks:delete(mam_muc_archive_message, Host, ?MODULE, archive_message, 50)
-    end,
-    ejabberd_hooks:delete(mam_muc_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:delete(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:delete(remove_domain, Host, ?MODULE, remove_domain, 50),
-    ejabberd_hooks:delete(get_mam_muc_gdpr_data, Host, ?MODULE, get_mam_muc_gdpr_data, 50),
-    ok.
+            [{mam_muc_archive_message, Host, ?MODULE, archive_message, 50}]
+    end ++
+    [{mam_muc_archive_size, Host, ?MODULE, archive_size, 50},
+     {mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 50},
+     {mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50},
+     {remove_domain, Host, ?MODULE, remove_domain, 50},
+     {get_mam_muc_gdpr_data, Host, ?MODULE, get_mam_muc_gdpr_data, 50}].
 
 %% ----------------------------------------------------------------------
 %% SQL queries

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -94,34 +94,25 @@ uniform_to_gdpr({MessID, RemoteJID, Packet}) ->
 
 -spec start_hooks(jid:server(), _) -> ok.
 start_hooks(Host, _Opts) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
-        true ->
-            ok;
-        false ->
-            ejabberd_hooks:add(mam_archive_message, Host, ?MODULE, archive_message, 50)
-    end,
-    ejabberd_hooks:add(mam_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:add(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:add(remove_domain, Host, ?MODULE, remove_domain, 50),
-    ejabberd_hooks:add(get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50),
-    ok.
-
+    ejabberd_hooks:add(hooks(Host)).
 
 -spec stop_hooks(jid:server()) -> ok.
 stop_hooks(Host) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, no_writer, false) of
+    ejabberd_hooks:delete(hooks(Host)).
+
+hooks(Host) ->
+    NoWriter = gen_mod:get_module_opt(Host, ?MODULE, no_writer, false),
+    case NoWriter of
         true ->
-            ok;
+            [];
         false ->
-            ejabberd_hooks:delete(mam_archive_message, Host, ?MODULE, archive_message, 50)
-    end,
-    ejabberd_hooks:delete(mam_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:delete(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:delete(remove_domain, Host, ?MODULE, remove_domain, 50),
-    ejabberd_hooks:delete(get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50),
-    ok.
+            [{mam_archive_message, Host, ?MODULE, archive_message, 50}]
+    end ++
+    [{mam_archive_size, Host, ?MODULE, archive_size, 50},
+     {mam_lookup_messages, Host, ?MODULE, lookup_messages, 50},
+     {mam_remove_archive, Host, ?MODULE, remove_archive, 50},
+     {remove_domain, Host, ?MODULE, remove_domain, 50},
+     {get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50}].
 
 %% ----------------------------------------------------------------------
 %% SQL queries

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -23,7 +23,8 @@
 -export([archive_size/4,
          archive_message/3,
          lookup_messages/3,
-         remove_archive/4]).
+         remove_archive/4,
+         remove_domain/3]).
 
 -export([get_mam_pm_gdpr_data/2]).
 
@@ -102,6 +103,7 @@ start_hooks(Host, _Opts) ->
     ejabberd_hooks:add(mam_archive_size, Host, ?MODULE, archive_size, 50),
     ejabberd_hooks:add(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
     ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
+    ejabberd_hooks:add(remove_domain, Host, ?MODULE, remove_domain, 50),
     ejabberd_hooks:add(get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50),
     ok.
 
@@ -117,6 +119,7 @@ stop_hooks(Host) ->
     ejabberd_hooks:delete(mam_archive_size, Host, ?MODULE, archive_size, 50),
     ejabberd_hooks:delete(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
     ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
+    ejabberd_hooks:delete(remove_domain, Host, ?MODULE, remove_domain, 50),
     ejabberd_hooks:delete(get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50),
     ok.
 
@@ -128,6 +131,12 @@ register_prepared_queries() ->
     mongoose_rdbms:prepare(mam_archive_remove, mam_message, [user_id],
                            <<"DELETE FROM mam_message "
                              "WHERE user_id = ?">>),
+    mongoose_rdbms:prepare(mam_remove_domain, mam_message, ['mam_server_user.server'],
+                           <<"DELETE FROM mam_message "
+                             "WHERE user_id IN "
+                             "(SELECT id from mam_server_user WHERE server = ?)">>),
+    mongoose_rdbms:prepare(mam_remove_domain_users, mam_server_user, [server],
+                           <<"DELETE FROM mam_server_user WHERE server = ?">>),
     mongoose_rdbms:prepare(mam_make_tombstone, mam_message, [message, user_id, id],
                            <<"UPDATE mam_message SET message = ?, search_body = '' "
                              "WHERE user_id = ? AND id = ?">>),
@@ -312,6 +321,14 @@ prepare_insert(Name, NumRows) ->
                      RoomJID :: jid:jid()) -> mongoose_acc:t().
 remove_archive(Acc, Host, ArcID, _ArcJID) ->
     mongoose_rdbms:execute_successfully(Host, mam_archive_remove, [ArcID]),
+    Acc.
+
+-spec remove_domain(mongoose_acc:t(), binary(), jid:lserver()) -> mongoose_acc:t().
+remove_domain(Acc, HostType, Domain) ->
+    {atomic, _} = mongoose_rdbms:sql_transaction(HostType, fun() ->
+            mongoose_rdbms:execute_successfully(HostType, mam_remove_domain, [Domain]),
+            mongoose_rdbms:execute_successfully(HostType, mam_remove_domain_users, [Domain])
+        end),
     Acc.
 
 %% GDPR logic

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -126,6 +126,10 @@ register_prepared_queries() ->
                            <<"DELETE FROM mam_message "
                              "WHERE user_id IN "
                              "(SELECT id from mam_server_user WHERE server = ?)">>),
+    mongoose_rdbms:prepare(mam_remove_domain_prefs, mam_config, ['mam_server_user.server'],
+                           <<"DELETE FROM mam_config "
+                             "WHERE user_id IN "
+                             "(SELECT id from mam_server_user WHERE server = ?)">>),
     mongoose_rdbms:prepare(mam_remove_domain_users, mam_server_user, [server],
                            <<"DELETE FROM mam_server_user WHERE server = ?">>),
     mongoose_rdbms:prepare(mam_make_tombstone, mam_message, [message, user_id, id],
@@ -318,6 +322,7 @@ remove_archive(Acc, Host, ArcID, _ArcJID) ->
 remove_domain(Acc, HostType, Domain) ->
     {atomic, _} = mongoose_rdbms:sql_transaction(HostType, fun() ->
             mongoose_rdbms:execute_successfully(HostType, mam_remove_domain, [Domain]),
+            mongoose_rdbms:execute_successfully(HostType, mam_remove_domain_prefs, [Domain]),
             mongoose_rdbms:execute_successfully(HostType, mam_remove_domain_users, [Domain])
         end),
     Acc.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -238,7 +238,7 @@ disable_domain(HostType, Domain) ->
     Domain :: jid:lserver(),
     Result :: ok.
 remove_domain(HostType, Domain) ->
-    ejabberd_hooks:run_global(remove_domain, ok, [HostType, Domain]).
+    ejabberd_hooks:run_for_host_type(remove_domain, HostType, #{}, [HostType, Domain]).
 
 -spec node_cleanup(Node :: node()) -> Acc :: map().
 node_cleanup(Node) ->


### PR DESCRIPTION
This PR addresses "Ensure efficient indexing and removal of persistent data by domain name".
MAM already have proper indexes in the mam_server_user table. We should just LEFT JOIN it. OK, we can't LEFT JOIN in DELETEs. But we can use `WHERE IN` instead.

Proposed changes include:
* remove_domain/3 handler for MAM/MUC MAM.
* nobody runs this hook in this PR. @DenysGonchar will code that part.
* a tip in schema. Because we use the same table to track MAM archive IDs for both MAM and MUC MAM.
