### PR TITLE
Pass the accumulator along

### DIFF
--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -93,8 +93,8 @@ direction(From, To) ->
       Packet :: packet().
 handle_outgoing_message(Host, Room, To, Packet) ->
     maybe_reset_unread_count(Host, To, Room, Packet),
-    TS = erlang:system_time(microsecond),
-    maybe_write_to_inbox(Host, To, Room, Packet, TS, fun write_to_sender_inbox/5).
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host}),
+    maybe_write_to_inbox(Host, To, Room, Packet, Acc, fun write_to_sender_inbox/5).
 
 -spec handle_incoming_message(Host, Room, To, Packet) -> term() when
       Host :: receiver_host(),
@@ -102,20 +102,20 @@ handle_outgoing_message(Host, Room, To, Packet) ->
       To :: receiver_bare_user_jid(),
       Packet :: packet().
 handle_incoming_message(Host, Room, To, Packet) ->
-    TS = erlang:system_time(microsecond),
-    maybe_write_to_inbox(Host, Room, To, Packet, TS, fun write_to_receiver_inbox/5).
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host}),
+    maybe_write_to_inbox(Host, Room, To, Packet, Acc, fun write_to_receiver_inbox/5).
 
 maybe_reset_unread_count(Host, User, Room, Packet) ->
     mod_inbox_utils:maybe_reset_unread_count(Host, User, Room, Packet).
 
-maybe_write_to_inbox(Host, User, Remote, Packet, TS, WriteF) ->
-    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, TS, WriteF).
+maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF) ->
+    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF).
 
-write_to_sender_inbox(Server, User, Remote, Packet, TS) ->
-    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet, TS).
+write_to_sender_inbox(Server, User, Remote, Packet, Acc) ->
+    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet, Acc).
 
-write_to_receiver_inbox(Server, User, Remote, Packet, TS) ->
-    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet, TS).
+write_to_receiver_inbox(Server, User, Remote, Packet, Acc) ->
+    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet, Acc).
 
 %% @doc Check, that the host is served by MongooseIM.
 %% A local host can be used to fire hooks or write into database on this node.

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -93,7 +93,7 @@ direction(From, To) ->
       Packet :: packet().
 handle_outgoing_message(Host, Room, To, Packet) ->
     maybe_reset_unread_count(Host, To, Room, Packet),
-    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host}),
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host, host_type => undefined}),
     maybe_write_to_inbox(Host, To, Room, Packet, Acc, fun write_to_sender_inbox/5).
 
 -spec handle_incoming_message(Host, Room, To, Packet) -> term() when
@@ -102,7 +102,7 @@ handle_outgoing_message(Host, Room, To, Packet) ->
       To :: receiver_bare_user_jid(),
       Packet :: packet().
 handle_incoming_message(Host, Room, To, Packet) ->
-    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host}),
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host, host_type => undefined}),
     maybe_write_to_inbox(Host, Room, To, Packet, Acc, fun write_to_receiver_inbox/5).
 
 maybe_reset_unread_count(Host, User, Room, Packet) ->

--- a/src/inbox/mod_inbox_one2one.erl
+++ b/src/inbox/mod_inbox_one2one.erl
@@ -20,27 +20,27 @@
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
-                              TS :: integer()) -> ok.
-handle_outgoing_message(Host, User, Remote, Packet, TS) ->
+                              Acc :: mongoose_acc:t()) -> ok.
+handle_outgoing_message(Host, User, Remote, Packet, Acc) ->
     maybe_reset_unread_count(Host, User, Remote, Packet),
-    maybe_write_to_inbox(Host, User, Remote, Packet, TS, fun write_to_sender_inbox/5).
+    maybe_write_to_inbox(Host, User, Remote, Packet, Acc, fun write_to_sender_inbox/5).
 
 -spec handle_incoming_message(Host :: jid:server(),
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
-                              TS :: integer()) -> ok | {ok, integer()}.
-handle_incoming_message(Host, User, Remote, Packet, TS) ->
-    maybe_write_to_inbox(Host, User, Remote, Packet, TS, fun write_to_receiver_inbox/5).
+                              Acc :: mongoose_acc:t()) -> ok | {ok, integer()}.
+handle_incoming_message(Host, User, Remote, Packet, Acc) ->
+    maybe_write_to_inbox(Host, User, Remote, Packet, Acc, fun write_to_receiver_inbox/5).
 
 maybe_reset_unread_count(Host, User, Remote, Packet) ->
     mod_inbox_utils:maybe_reset_unread_count(Host, User, Remote, Packet).
 
-maybe_write_to_inbox(Host, User, Remote, Packet, TS, WriteF) ->
-    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, TS, WriteF).
+maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF) ->
+    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF).
 
-write_to_sender_inbox(Server, User, Remote, Packet, TS) ->
-    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet, TS).
+write_to_sender_inbox(Server, User, Remote, Packet, Acc) ->
+    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet, Acc).
 
-write_to_receiver_inbox(Server, User, Remote, Packet, TS) ->
-    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet, TS).
+write_to_receiver_inbox(Server, User, Remote, Packet, Acc) ->
+    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet, Acc).


### PR DESCRIPTION
There could be more important data in this, like the mam-id, that we
might prefer rather than the message's attribute id.

For MUC, well, inbox with regular muc is not the most common use case.