### PR TITLE
Fix Swagger docs rendering

### DIFF
--- a/doc/rest-api/Administration-backend.md
+++ b/doc/rest-api/Administration-backend.md
@@ -32,7 +32,7 @@ Read the beautiful [Swagger documentation](https://esl.github.io/MongooseDocs/la
 [![Swagger](https://nordicapis.com/wp-content/uploads/swagger-Top-Specification-Formats-for-REST-APIs-nordic-apis-sandoval-e1441412425742-300x170.png)](https://esl.github.io/MongooseDocs/latest/swagger/index.html)
 
 <iframe src="https://esl.github.io/MongooseDocs/latest/swagger/index.html"
-height="800" width="800" style="margin-left: -45px;" id="swagger-ui-iframe"></iframe>
+height="800" width="800" id="swagger-ui-iframe"></iframe>
 
 <script>
 

--- a/doc/rest-api/Client-frontend.md
+++ b/doc/rest-api/Client-frontend.md
@@ -85,7 +85,7 @@ See the beautiful [Swagger documentation](https://esl.github.io/MongooseDocs/lat
 [![Swagger](https://nordicapis.com/wp-content/uploads/swagger-Top-Specification-Formats-for-REST-APIs-nordic-apis-sandoval-e1441412425742-300x170.png)](https://esl.github.io/MongooseDocs/latest/swagger/index.html?client=true)
 
 <iframe src="https://esl.github.io/MongooseDocs/latest/swagger/index.html?client=true"
-height="800" width="800" style="margin-left: -45px;" id="swagger-ui-iframe"></iframe>
+height="800" width="800" id="swagger-ui-iframe"></iframe>
 
 <script>
 


### PR DESCRIPTION
My first front-end PR. The Swagger part was obscured on the left side and could not even be scrolled to see the content. Affected places: https://esl.github.io/MongooseDocs/latest/rest-api/Client-frontend/ and https://esl.github.io/MongooseDocs/latest/rest-api/Administration-backend/. I think this should be the fix but I have no idea what I am doing.

Before:
![Screenshot_2021-04-27 Administration backend - MongooseIM](https://user-images.githubusercontent.com/34194983/116250979-84221780-a76e-11eb-9c6e-3b4b19973354.png)
After:
![Screenshot_2021-04-27 Administration backend - MongooseIM(1)](https://user-images.githubusercontent.com/34194983/116251007-8a17f880-a76e-11eb-8f1b-556487edb75c.png)




