### PR TITLE
Room EventData is map now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Use a map instead of a proplist in the `room_event_data` hook
+  for the event data information.
 - `room_send_packet` hook removed.
    Use `filter_room_packet` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-- Use a map instead of a proplist in the `room_event_data` hook
-  for the event data information.
-- `room_send_packet` hook removed.
-   Use `filter_room_packet` instead.
-
 # [MongooseIM 4.2.0](https://github.com/esl/MongooseIM/releases/tag/4.2.0) - 2021-04-20
 
 ## Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- `room_send_packet` hook removed.
+   Use `filter_room_packet` instead.
+
 # [MongooseIM 4.2.0](https://github.com/esl/MongooseIM/releases/tag/4.2.0) - 2021-04-20
 
 ## Highlights

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -244,7 +244,6 @@ This is the perfect place to plug in custom security control.
 * resend_offline_messages_hook
 * rest_user_send_packet
 * room_packet
-* room_send_packet
 * roster_get
 * roster_get_jid_info
 * roster_get_subscription_lists

--- a/doc/developers-guide/mod_muc_light_developers_guide.md
+++ b/doc/developers-guide/mod_muc_light_developers_guide.md
@@ -121,8 +121,6 @@ Callbacks that provide essential data for the `mod_mam_muc` extension.
 
 Allows `mod_mam_muc` to archive groupchat messages.
 
-* `room_send_packet` by codecs
-
 * `forget_room` by `mod_muc_light_db_mnesia` and `mod_muc_light_room`
 
 It is a part of `mod_mam_muc` integration as well.

--- a/doc/migrations/4.2.0_4.3.0.md
+++ b/doc/migrations/4.2.0_4.3.0.md
@@ -78,3 +78,10 @@ GO
 DROP INDEX i_muc_light_blocking ON muc_light_blocking;
 GO
 ```
+
+
+## Groupchat hook migrations
+
+- `filter_room_packet` hook uses a map insted of a proplist
+  for the event data information.
+- `room_send_packet` hook has been removed. Use `filter_room_packet` instead.

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -177,8 +177,9 @@ stop(Host) ->
 %% @doc Handle public MUC-message.
 -spec filter_room_packet(Packet :: packet(),
                          EventData :: mod_muc:room_event_data()) -> packet().
-filter_room_packet(Packet, EventData) ->
-    {room_jid, #jid{lserver = LServer}} = lists:keyfind(room_jid, 1, EventData),
+filter_room_packet(Packet, EventData = #{
+                             room_jid := #jid{lserver = LServer}
+                            }) ->
     ?LOG_DEBUG(#{what => mam_room_packet, text => <<"Incoming room packet">>,
                  packet => Packet, event_data => EventData}),
     IsArchivable = is_archivable_message(LServer, incoming, Packet),

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -175,7 +175,8 @@ stop(Host) ->
 %% hooks and handlers for MUC
 
 %% @doc Handle public MUC-message.
--spec filter_room_packet(Packet :: packet(), EventData :: list()) -> packet().
+-spec filter_room_packet(Packet :: packet(),
+                         EventData :: mod_muc:room_event_data()) -> packet().
 filter_room_packet(Packet, EventData) ->
     {room_jid, #jid{lserver = LServer}} = lists:keyfind(room_jid, 1, EventData),
     ?LOG_DEBUG(#{what => mam_room_packet, text => <<"Incoming room packet">>,
@@ -183,11 +184,8 @@ filter_room_packet(Packet, EventData) ->
     IsArchivable = is_archivable_message(LServer, incoming, Packet),
     case IsArchivable of
         true ->
-            {_, FromNick} = lists:keyfind(from_nick, 1, EventData),
-            {_, FromJID} = lists:keyfind(from_jid, 1, EventData),
-            {_, RoomJID} = lists:keyfind(room_jid, 1, EventData),
-            {_, Role} = lists:keyfind(role, 1, EventData),
-            {_, Affiliation} = lists:keyfind(affiliation, 1, EventData),
+            #{from_nick := FromNick, from_jid := FromJID, room_jid := RoomJID,
+              role := Role, affiliation := Affiliation} = EventData,
             archive_room_packet(Packet, FromNick, FromJID, RoomJID, Role, Affiliation);
         false -> Packet
     end.

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -111,6 +111,15 @@
                              nick       :: nick()
                             }.
 
+-type room_event_data() :: #{
+                  from_nick := nick(),
+                  from_jid := jid:jid(),
+                  room_jid := jid:jid(),
+                  affiliation := affiliation(),
+                  role := role()
+       }.
+-export_type([room_event_data/0]).
+
 -record(state, {host                :: jid:server(),
                 server_host         :: jid:literal_jid(),
                 access,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -883,7 +883,6 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
                  {role, Role},
                  {affiliation, Affiliation}],
     FilteredPacket = mongoose_hooks:filter_room_packet(StateData#state.host, Packet, EventData),
-    mongoose_hooks:room_send_packet(StateData#state.host, FilteredPacket, EventData),
     RouteFrom = jid:replace_resource(StateData#state.jid,
                                      FromNick),
     RoomJid = StateData#state.jid,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -877,11 +877,9 @@ can_send_broadcasts(Role, StateData) ->
 
 broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
     Affiliation = get_affiliation(From, StateData),
-    EventData = [{from_nick, FromNick},
-                 {from_jid, From},
-                 {room_jid, StateData#state.jid},
-                 {role, Role},
-                 {affiliation, Affiliation}],
+    EventData = #{from_nick => FromNick, from_jid => From,
+                  room_jid => StateData#state.jid, role => Role,
+                  affiliation => Affiliation},
     FilteredPacket = mongoose_hooks:filter_room_packet(StateData#state.host, Packet, EventData),
     RouteFrom = jid:replace_resource(StateData#state.jid,
                                      FromNick),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -138,7 +138,6 @@
          join_room/5,
          leave_room/5,
          room_packet/5,
-         room_send_packet/3,
          update_inbox_for_muc/2]).
 
 -export([caps_add/5,
@@ -1403,7 +1402,7 @@ amp_verify_support(Server, Rules) ->
 -spec filter_room_packet(Server, Packet, EventData) -> Result when
     Server :: jid:lserver(),
     Packet :: exml:element(),
-    EventData :: [{atom(), any()}],
+    EventData :: mod_muc:room_event_data(),
     Result :: exml:element().
 filter_room_packet(Server, Packet, EventData) ->
     ejabberd_hooks:run_for_host_type(filter_room_packet, Server, Packet, [EventData]).
@@ -1464,15 +1463,6 @@ leave_room(HookServer, Room, Host, JID, MucJID) ->
 room_packet(Server, FromNick, FromJID, JID, Packet) ->
     ejabberd_hooks:run_for_host_type(room_packet, Server, ok,
                                      [FromNick, FromJID, JID, Packet]).
-
-%%% @doc The `room_send_packet' hook is called when a message is sent to a room.
--spec room_send_packet(Server, Packet, EventData) -> Result when
-    Server :: jid:lserver(),
-    Packet :: exml:element(),
-    EventData :: [{atom(), any()}],
-    Result :: exml:element().
-room_send_packet(Server, Packet, EventData) ->
-    ejabberd_hooks:run_for_host_type(room_send_packet, Server, Packet, [EventData]).
 
 -spec update_inbox_for_muc(Server, Info) -> Result when
     Server :: jid:server(),

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -56,13 +56,12 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
              {<<"from">>, RoomBin}
             ],
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs, children = Msg#msg.children },
-    EventData = [{from_nick, FromNick},
-                 {from_jid, Sender},
-                 {room_jid, jid:make_noprep({RoomU, RoomS, <<>>})},
-                 {affiliation, Aff},
-                 {role, mod_muc_light_utils:light_aff_to_muc_role(Aff)}
-    ],
-    FilteredPacket = #xmlel{ children = Children }
+    EventData = #{from_nick => FromNick,
+                  from_jid => Sender,
+                  room_jid => jid:make_noprep({RoomU, RoomS, <<>>}),
+                  affiliation => Aff,
+                  role => mod_muc_light_utils:light_aff_to_muc_role(Aff)},
+    #xmlel{ children = Children }
         = mongoose_hooks:filter_room_packet(RoomS, MsgForArch, EventData),
     lists:foreach(
       fun({{U, S}, _}) ->

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -64,7 +64,6 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
     ],
     FilteredPacket = #xmlel{ children = Children }
         = mongoose_hooks:filter_room_packet(RoomS, MsgForArch, EventData),
-    mongoose_hooks:room_send_packet(RoomS, FilteredPacket, EventData),
     lists:foreach(
       fun({{U, S}, _}) ->
               send_to_aff_user(RoomJID, U, S, <<"message">>, Attrs, Children, HandleFun)

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -58,7 +58,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs, children = Msg#msg.children },
     EventData = #{from_nick => FromNick,
                   from_jid => Sender,
-                  room_jid => jid:make_noprep({RoomU, RoomS, <<>>}),
+                  room_jid => jid:make_noprep(RoomU, RoomS, <<>>),
                   affiliation => Aff,
                   role => mod_muc_light_utils:light_aff_to_muc_role(Aff)},
     #xmlel{ children = Children }
@@ -439,7 +439,7 @@ msg_to_leaving_user(Room, {ToU, ToS} = User, HandleFun) ->
                        Children :: [jlib:xmlch()],
                        HandleFun :: mod_muc_light_codec:encoded_packet_handler()) -> ok.
 send_to_aff_user(From, ToU, ToS, Name, Attrs, Children, HandleFun) ->
-    To = jid:make_noprep({ToU, ToS, <<>>}),
+    To = jid:make_noprep(ToU, ToS, <<>>),
     ToBin = jid:to_binary({ToU, ToS, <<>>}),
     Packet = #xmlel{ name = Name, attrs = [{<<"to">>, ToBin} | Attrs],
                      children = Children },
@@ -449,7 +449,7 @@ send_to_aff_user(From, ToU, ToS, Name, Attrs, Children, HandleFun) ->
     {jid:jid(), binary()}.
 jids_from_room_with_resource({RoomU, RoomS}, Resource) ->
     FromBin = jid:to_binary({RoomU, RoomS, Resource}),
-    From = jid:make_noprep({RoomU, RoomS, Resource}),
+    From = jid:make_noprep(RoomU, RoomS, Resource),
     {From, FromBin}.
 
 -spec make_iq_result(FromBin :: binary(), ToBin :: binary(), ID :: binary(),

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -60,7 +60,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs, children = Msg#msg.children },
     EventData = #{from_nick =>FromNick,
                   from_jid => Sender,
-                  room_jid => jid:make_noprep({RoomU, RoomS, <<>>}),
+                  room_jid => jid:make_noprep(RoomU, RoomS, <<>>),
                   affiliation => Aff,
                   role => mod_muc_light_utils:light_aff_to_muc_role(Aff)},
     #xmlel{ children = Children }
@@ -455,7 +455,7 @@ msg_to_leaving_user(From, {ToU, ToS} = User, Attrs, HandleFun) ->
                       Attrs :: [{binary(), binary()}], Children :: [jlib:xmlch()],
                       HandleFun :: mod_muc_light_codec:encoded_packet_handler()) -> ok.
 msg_to_aff_user(From, ToU, ToS, Attrs, Children, HandleFun) ->
-    To = jid:make_noprep({ToU, ToS, <<>>}),
+    To = jid:make_noprep(ToU, ToS, <<>>),
     ToBin = jid:to_binary({ToU, ToS, <<>>}),
     Packet = #xmlel{ name = <<"message">>, attrs = [{<<"to">>, ToBin} | Attrs],
                      children = Children },
@@ -465,7 +465,7 @@ msg_to_aff_user(From, ToU, ToS, Attrs, Children, HandleFun) ->
     {jid:jid(), binary()}.
 jids_from_room_with_resource({RoomU, RoomS}, Resource) ->
     FromBin = jid:to_binary({RoomU, RoomS, Resource}),
-    From = jid:make_noprep({RoomU, RoomS, Resource}),
+    From = jid:make_noprep(RoomU, RoomS, Resource),
     {From, FromBin}.
 
 -spec make_iq_result(FromBin :: binary(), ToBin :: binary(), ID :: binary(),

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -64,9 +64,8 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
                  {affiliation, Aff},
                  {role, mod_muc_light_utils:light_aff_to_muc_role(Aff)}
                 ],
-    FilteredPacket = #xmlel{ children = Children }
+    #xmlel{ children = Children }
                      = mongoose_hooks:filter_room_packet(RoomS, MsgForArch, EventData),
-    mongoose_hooks:room_send_packet(RoomS, FilteredPacket, EventData),
     lists:foreach(
       fun({{U, S}, _}) ->
               msg_to_aff_user(RoomJID, U, S, Attrs, Children, HandleFun)
@@ -309,9 +308,8 @@ encode_iq({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers}, _Sender, Room
                          children = msg_envelope(?NS_MUC_LIGHT_AFFILIATIONS,
                                                  NotifForCurrentNoPrevVersion) },
     EventData = room_event(RoomJID),
-    FilteredPacket = #xmlel{children = FinalChildrenForCurrentNoPrevVersion}
+    #xmlel{children = FinalChildrenForCurrentNoPrevVersion}
         = mongoose_hooks:filter_room_packet(RoomJID#jid.lserver, MsgForArch, EventData),
-    mongoose_hooks:room_send_packet(RoomJID#jid.lserver, FilteredPacket, EventData),
     FinalChildrenForCurrent = inject_prev_version(FinalChildrenForCurrentNoPrevVersion,
                                                   Affs#affiliations.prev_version),
     bcast_aff_messages(RoomJID, OldAffUsers, NewAffUsers, Attrs, VersionEl,
@@ -337,8 +335,7 @@ encode_iq({set, #create{} = Create, UniqueRequested}, _Sender, RoomJID, RoomBin,
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_AFFILIATIONS, AllAffsEls) },
     EventData = room_event(RoomJID),
-    FilteredPacket = mongoose_hooks:filter_room_packet(RoomJID#jid.lserver, MsgForArch, EventData),
-    mongoose_hooks:room_send_packet(RoomJID#jid.lserver, FilteredPacket, EventData),
+    mongoose_hooks:filter_room_packet(RoomJID#jid.lserver, MsgForArch, EventData),
 
     %% IQ reply "from"
     %% Sent from service JID when unique room was requested
@@ -380,9 +377,8 @@ encode_iq({set, #config{} = Config, AffUsers}, _Sender, RoomJID, RoomBin, Handle
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_CONFIGURATION, ConfigNotif) },
     EventData = room_event(RoomJID),
-    FilteredPacket = #xmlel{ children = FinalConfigNotif }
+    #xmlel{ children = FinalConfigNotif }
         = mongoose_hooks:filter_room_packet(RoomJID#jid.lserver, MsgForArch, EventData),
-    mongoose_hooks:room_send_packet(RoomJID#jid.lserver, FilteredPacket, EventData),
 
     lists:foreach(
       fun({{U, S}, _}) ->

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -515,5 +515,5 @@ room_event(RoomJID) ->
     #{from_nick => <<>>,
       from_jid => RoomJID,
       room_jid => RoomJID,
-      role => owner,
+      role => moderator,
       affiliation => owner}.

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -58,12 +58,11 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun) ->
              {<<"from">>, RoomBin}
             ],
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs, children = Msg#msg.children },
-    EventData = [{from_nick, FromNick},
-                 {from_jid, Sender},
-                 {room_jid, jid:make_noprep({RoomU, RoomS, <<>>})},
-                 {affiliation, Aff},
-                 {role, mod_muc_light_utils:light_aff_to_muc_role(Aff)}
-                ],
+    EventData = #{from_nick =>FromNick,
+                  from_jid => Sender,
+                  room_jid => jid:make_noprep({RoomU, RoomS, <<>>}),
+                  affiliation => Aff,
+                  role => mod_muc_light_utils:light_aff_to_muc_role(Aff)},
     #xmlel{ children = Children }
                      = mongoose_hooks:filter_room_packet(RoomS, MsgForArch, EventData),
     lists:foreach(
@@ -511,9 +510,10 @@ b2what(<<"room">>) -> room.
 what2b(user) -> <<"user">>;
 what2b(room) -> <<"room">>.
 
+-spec room_event(jid:jid()) -> mod_muc:room_event_data().
 room_event(RoomJID) ->
-    [{from_nick, <<>>},
-     {from_jid, RoomJID},
-     {room_jid, RoomJID},
-     {role, owner},
-     {affiliation, owner}].
+    #{from_nick => <<>>,
+      from_jid => RoomJID,
+      room_jid => RoomJID,
+      role => owner,
+      affiliation => owner}.


### PR DESCRIPTION
This PR addresses "some tech debt".

Proposed changes include:
* room_event_data is now map (was a proplist)
* Remove room_send_packet hook

