### PR TITLE
Don't set cluster_id if not needed

### DIFF
--- a/src/mongoose_cluster_id.erl
+++ b/src/mongoose_cluster_id.erl
@@ -31,7 +31,7 @@ start() ->
       ListOfFuns :: [fun(() -> maybe_cluster_id())],
       MaybeCID :: maybe_cluster_id().
 run_steps(_, {ok, ID}) when is_binary(ID) ->
-    store_cluster_id(ID);
+    {ok, ID};
 run_steps([Fun | NextFuns], {error, _}) ->
     run_steps(NextFuns, Fun());
 run_steps([], {error, _} = E) ->
@@ -133,7 +133,7 @@ set_new_cluster_id(ID, mnesia) ->
 -spec get_backend_cluster_id(mongoose_backend()) -> maybe_cluster_id().
 get_backend_cluster_id(rdbms) ->
     try mongoose_rdbms:execute_successfully(global, cluster_select, []) of
-        {selected, [{Row}]} -> {ok, Row};
+        {selected, [{ID}]} -> {ok, ID};
         {selected, []} -> {error, no_value_in_backend}
     catch
         Class:Reason:Stacktrace ->


### PR DESCRIPTION
This PR addresses "MIM-1396 Prepared query in mongoose_cluster_id causes errors on startup"

Proposed changes include:
* Don't insert, if not needed.
* Insert only when we generate a new ID.

Basically, we implement "select and just use it. If not found, create new and insert" logic.

It is a bit less robust: 
- if a cluster got started without RDBMS, but after it got a new node with RDBMS, we would not get an update in DB.
- but this use case is _pretty weird_

There is still a race condition possible, when we try to insert, but someone has already inserted a ClusterID. we could handle it and retry, but it makes logic less clean. And I am pretty sure it's a rare case when two nodes go live for the first time. Could be avoided by adding retries, but nothing bad would happen anyway (we would see a warning in this case in logs, but that's it).