### PR TITLE
adding mongoose_subdomain_core

### DIFF
--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -198,6 +198,7 @@ handle_delete(Domain) ->
             ok;
         [{Domain, HostType, _Source}] ->
             ets:delete(?TABLE, Domain),
+            mongoose_subdomain_core:remove_domain(HostType, Domain),
             mongoose_hooks:disable_domain(HostType, Domain),
             ok
     end.
@@ -212,6 +213,7 @@ handle_insert(Domain, HostType, Source) ->
                     {error, static};
                 [] ->
                     ets:insert_new(?TABLE, new_object(Domain, HostType, {dynamic, Source})),
+                    mongoose_subdomain_core:add_domain(HostType, Domain),
                     ok;
                 [{Domain, HT, _Source}] when HT =:= HostType ->
                     ets:insert(?TABLE, new_object(Domain, HostType, {dynamic, Source})),

--- a/src/domain/mongoose_subdomain_core.erl
+++ b/src/domain/mongoose_subdomain_core.erl
@@ -1,0 +1,289 @@
+%% Generally, you should not call anything from this module.
+%% Use mongoose_domain_api module instead.
+-module(mongoose_subdomain_core).
+
+-include("mongoose_logger.hrl").
+
+%% API
+-export([start/0, stop/0]).
+-export([start_link/0]).
+
+-export([register_subdomain/3,
+         unregister_subdomain/2,
+         add_domain/2,
+         remove_domain/2,
+         sync/0]).
+
+-export([get_host_type/1,
+         get_subdomain_info/1,
+         get_all_subdomains_for_domain/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2]).
+
+-define(SUBDOMAINS_TABLE, ?MODULE).
+-define(REGISTRATION_TABLE, mongoose_subdomain_reg).
+
+-type host_type() :: mongooseim:host_type().
+-type domain() :: mongooseim:domain_name().
+-type subdomain_pattern() :: mongoose_subdomain_utils:subdomain_pattern().
+-type maybe_domain() :: domain() | undefined.
+
+-type reg_item() :: {{host_type(), subdomain_pattern()}, %% table key
+                     Type :: fqdn | subdomain,
+                     mongoose_packet_handler:t()}.
+
+-record(subdomain_item, {host_type :: host_type() | '_',
+                         subdomain :: domain() | '_', %% table key
+                         subdomain_pattern :: subdomain_pattern() | '_',
+                         parent_domain :: maybe_domain() | '_', %% undefined for FQDNs
+                         packet_handler :: mongoose_packet_handler:t() | '_'}).
+
+-type subdomain_item() :: #subdomain_item{}.
+
+%% corresponds to the fields in #subdomain_item{} record
+-type subdomain_info() :: #{host_type := host_type(),
+                            subdomain := domain(),
+                            subdomain_pattern := subdomain_pattern(),
+                            parent_domain := maybe_domain(),
+                            packet_handler := mongoose_packet_handler:t()}.
+
+-export_type([subdomain_info/0]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+-ifdef(TEST).
+%% required for unit tests
+start() ->
+    just_ok(gen_server:start({local, ?MODULE}, ?MODULE, [], [])).
+
+stop() ->
+    gen_server:stop(?MODULE).
+
+-else.
+
+start() ->
+    ChildSpec = {?MODULE, {?MODULE, start_link, []},
+                 permanent, infinity, worker, [?MODULE]},
+    just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
+
+%% required for integration tests
+stop() ->
+    supervisor:terminate_child(ejabberd_sup, ?MODULE),
+    supervisor:delete_child(ejabberd_sup, ?MODULE),
+    ok.
+
+-endif.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec register_subdomain(host_type(), subdomain_pattern(),
+                         mongoose_packet_handler:t()) ->
+    ok | {error, already_registered}.
+register_subdomain(HostType, SubdomainPattern, PacketHandler) ->
+    gen_server:call(?MODULE, {register, HostType, SubdomainPattern, PacketHandler}).
+
+-spec unregister_subdomain(host_type(), subdomain_pattern()) -> ok.
+unregister_subdomain(HostType, SubdomainPattern) ->
+    gen_server:call(?MODULE, {unregister, HostType, SubdomainPattern}).
+
+-spec sync() -> ok.
+sync() ->
+    gen_server:call(?MODULE, sync).
+
+-spec add_domain(host_type(), domain()) -> ok.
+add_domain(HostType, Domain) ->
+    gen_server:cast(?MODULE, {add_domain, HostType, Domain}).
+
+-spec remove_domain(host_type(), domain()) -> ok.
+remove_domain(HostType, Domain) ->
+    gen_server:cast(?MODULE, {remove_domain, HostType, Domain}).
+
+-spec get_host_type(Subdomain :: domain()) -> {ok, host_type()} | {error, not_found}.
+get_host_type(Subdomain) ->
+    case ets:lookup(?SUBDOMAINS_TABLE, Subdomain) of
+        [] ->
+            {error, not_found};
+        [#subdomain_item{host_type = HostType}] ->
+            {ok, HostType}
+    end.
+
+-spec get_subdomain_info(Subdomain :: domain()) -> {ok, subdomain_info()} | {error, not_found}.
+get_subdomain_info(Subdomain) ->
+    case ets:lookup(?SUBDOMAINS_TABLE, Subdomain) of
+        [] ->
+            {error, not_found};
+        [Item] ->
+            {ok, convert_subdomain_item_to_map(Item)}
+    end.
+
+-spec get_all_subdomains_for_domain(Domain :: domain() | undefined) -> [subdomain_info()].
+%% if Domain param is set to undefined, this function returns all the FQDN "subdomains".
+get_all_subdomains_for_domain(Domain) ->
+    Pattern = #subdomain_item{parent_domain = Domain, _ = '_'},
+    Match = ets:match_object(?SUBDOMAINS_TABLE, Pattern),
+    [convert_subdomain_item_to_map(Item) || Item <- Match].
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+init([]) ->
+    ets:new(?SUBDOMAINS_TABLE, [set, named_table, protected,
+                                {keypos, #subdomain_item.subdomain},
+                                {read_concurrency, true}]),
+    %% ?REGISTRATION_TABLE is protected only for traceability purposes
+    ets:new(?REGISTRATION_TABLE, [set, named_table, protected]),
+    %% no need for state, everything is kept in ETS tables
+    {ok, ok}.
+
+handle_call({register, HostType, SubdomainPattern, PacketHandler}, _From, State) ->
+    Result = handle_register(HostType, SubdomainPattern, PacketHandler),
+    {reply, Result, State};
+handle_call({unregister, HostType, SubdomainPattern}, _From, State) ->
+    Result = handle_unregister(HostType, SubdomainPattern),
+    {reply, Result, State};
+handle_call(sync, _From, State) ->
+    {reply, ok, State};
+handle_call(Request, From, State) ->
+    ?UNEXPECTED_CALL(Request, From),
+    {reply, ok, State}.
+
+handle_cast({add_domain, HostType, Domain}, State) ->
+    handle_add_domain(HostType, Domain),
+    {noreply, State};
+handle_cast({remove_domain, HostType, Domain}, State) ->
+    handle_remove_domain(HostType, Domain),
+    {noreply, State};
+handle_cast(Msg, State) ->
+    ?UNEXPECTED_CAST(Msg),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    ?UNEXPECTED_INFO(Info),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% local functions
+%%--------------------------------------------------------------------
+just_ok({ok, _}) -> ok;
+just_ok(Other) -> Other.
+
+-spec handle_register(host_type(), subdomain_pattern(), mongoose_packet_handler:t()) ->
+    ok | {error, already_registered}.
+handle_register(HostType, SubdomainPattern, PacketHandler) ->
+    SubdomainType = mongoose_subdomain_utils:subdomain_type(SubdomainPattern),
+    RegItem = {{HostType, SubdomainPattern}, SubdomainType, PacketHandler},
+    case ets:insert_new(?REGISTRATION_TABLE, RegItem) of
+        true ->
+            case SubdomainType of
+                subdomain ->
+                    Fn = fun(_HostType, Subdomain) ->
+                             add_subdomain(RegItem, Subdomain)
+                         end,
+                    mongoose_domain_core:for_each_domain(HostType,Fn);
+                fqdn ->
+                    add_subdomain(RegItem, undefined)
+            end;
+        false ->
+            {error, already_registered}
+    end.
+
+-spec handle_unregister(host_type(), subdomain_pattern()) -> ok.
+handle_unregister(HostType, SubdomainPattern) ->
+    Pattern = #subdomain_item{subdomain_pattern = SubdomainPattern,
+                              host_type = HostType, _ = '_'},
+    Match = ets:match_object(?SUBDOMAINS_TABLE, Pattern),
+    remove_subdomains(Match),
+    ets:delete(?REGISTRATION_TABLE, {HostType, SubdomainPattern}),
+    ok.
+
+-spec handle_add_domain(host_type(), domain()) -> ok.
+handle_add_domain(HostType, Domain) ->
+    mongoose_subdomain_utils:check_domain_name(HostType, Domain),
+    %% even if the domain name check fails, it's not easy to solve this
+    %% collision. so the best thing we can do is to report it and just keep
+    %% the data in both ETS tables (domains and subdomains) for further
+    %% troubleshooting.
+    Match = ets:match_object(?REGISTRATION_TABLE, {{HostType, '_'}, subdomain, '_'}),
+    add_subdomains(Match, Domain).
+
+-spec handle_remove_domain(host_type(), domain()) -> ok.
+handle_remove_domain(HostType, Domain) ->
+    Pattern = #subdomain_item{parent_domain = Domain, host_type = HostType, _ = '_'},
+    Match = ets:match_object(?SUBDOMAINS_TABLE, Pattern),
+    remove_subdomains(Match).
+
+-spec remove_subdomains([subdomain_item()]) -> ok.
+remove_subdomains(SubdomainItems) ->
+    Fn = fun(#subdomain_item{host_type = HostType, subdomain = Subdomain}) ->
+             remove_subdomain(HostType, Subdomain)
+         end,
+    lists:foreach(Fn, SubdomainItems).
+
+-spec remove_subdomain(host_type(), domain()) -> true.
+remove_subdomain(HostType, Subdomain) ->
+    mongoose_hooks:disable_subdomain(HostType, Subdomain),
+    ets:delete(?SUBDOMAINS_TABLE, Subdomain).
+
+-spec add_subdomains([reg_item()], domain()) -> ok.
+add_subdomains(RegItems, Domain) ->
+    Fn = fun(RegItem) ->
+             add_subdomain(RegItem, Domain)
+         end,
+    lists:foreach(Fn, RegItems).
+
+-spec add_subdomain(reg_item(), maybe_domain()) -> ok | {error, already_registered}.
+add_subdomain(RegItem, Domain) ->
+    #subdomain_item{subdomain = Subdomain} = Item = make_subdomain_item(RegItem, Domain),
+    Info = convert_subdomain_item_to_map(Item),
+    case ets:insert_new(?SUBDOMAINS_TABLE, Item) of
+        true ->
+            mongoose_subdomain_utils:check_subdomain_name(Info),
+            %% even if the subdomain name check fails, it's not easy to solve this
+            %% collision. so the best thing we can do is to report it and just keep
+            %% the data in both ETS tables (domains and subdomains) for further
+            %% troubleshooting.
+            ok;
+        false ->
+            [ExistingItem] = ets:lookup(?SUBDOMAINS_TABLE, Subdomain),
+            if
+                ExistingItem =:= Item ->
+                    ok; %% exactly the same item is already inserted, it's fine.
+                true ->
+                    ExistingInfo = convert_subdomain_item_to_map(ExistingItem),
+                    mongoose_subdomain_utils:report_subdomains_collision(ExistingInfo, Info),
+                    {error, subdomain_already_exists}
+            end
+    end.
+
+-spec make_subdomain_item(reg_item(), maybe_domain()) -> subdomain_item().
+make_subdomain_item({{HostType, SubdomainPattern}, Type, PacketHandler}, Domain) ->
+    Subdomain = case {Type, Domain} of
+                    {fqdn, undefined} ->
+                        %% not a subdomain, but FQDN
+                        mongoose_subdomain_utils:get_fqdn(SubdomainPattern, <<"">>);
+                    {subdomain, Domain} when is_binary(Domain) ->
+                        mongoose_subdomain_utils:get_fqdn(SubdomainPattern, Domain)
+                end,
+    #subdomain_item{host_type = HostType, subdomain = Subdomain, parent_domain = Domain,
+                    subdomain_pattern = SubdomainPattern, packet_handler = PacketHandler}.
+
+-spec convert_subdomain_item_to_map(subdomain_item()) -> subdomain_info().
+convert_subdomain_item_to_map(#subdomain_item{} = Item) ->
+    Fields = record_info(fields, subdomain_item),
+    [_ | Values] = tuple_to_list(Item),
+    KVList = lists:zip(Fields, Values),
+    maps:from_list(KVList).

--- a/src/domain/mongoose_subdomain_utils.erl
+++ b/src/domain/mongoose_subdomain_utils.erl
@@ -1,8 +1,14 @@
 -module(mongoose_subdomain_utils).
 
+-include("mongoose_logger.hrl").
+
 %% API
 -export([make_subdomain_pattern/1,
          get_fqdn/2,
+         subdomain_type/1,
+         check_domain_name/2,
+         check_subdomain_name/1,
+         report_subdomains_collision/2,
          is_subdomain/3]).
 
 -type subdomain_pattern() :: {fqdn | prefix, binary()}.
@@ -27,6 +33,42 @@ make_subdomain_pattern(ConfigOpt) when is_binary(ConfigOpt) ->
     Subdomain :: mongooseim:domain_name().
 get_fqdn({fqdn, Subdomain}, _Domain) -> Subdomain;
 get_fqdn({prefix, Prefix}, Domain)   -> <<Prefix/binary, Domain/binary>>.
+
+-spec subdomain_type(subdomain_pattern()) -> fqdn | subdomain.
+subdomain_type({fqdn, _}) -> fqdn;
+subdomain_type({prefix, _}) -> subdomain.
+
+-spec check_domain_name(mongooseim:host_type(), mongooseim:domain_name()) ->
+    boolean().
+check_domain_name(_HostType, Domain) ->
+    case mongoose_subdomain_core:get_subdomain_info(Domain) of
+        {error, not_found} -> true;
+        {ok, _Info} ->
+            %% TODO: this is critical collision, and it must be reported properly
+            %% think about adding some metric, so devops can set some alarm for it
+            ?LOG_ERROR(#{what => check_domain_name_failed, domain => Domain}),
+            false
+    end.
+
+-spec check_subdomain_name(mongoose_subdomain_core:subdomain_info()) -> boolean().
+check_subdomain_name(#{subdomain := Subdomain} = _SubdomainInfo) ->
+    case mongoose_domain_core:get_host_type(Subdomain) of
+        {error, not_found} -> true;
+        {ok, _HostType} ->
+            %% TODO: this is critical collision, and it must be reported properly
+            %% think about adding some metric, so devops can set some alarm for it
+            ?LOG_ERROR(#{what => check_subdomain_name_failed, subdomain => Subdomain}),
+            false
+    end.
+
+-spec report_subdomains_collision(mongoose_subdomain_core:subdomain_info(),
+                                  mongoose_subdomain_core:subdomain_info()) -> ok.
+report_subdomains_collision(#{subdomain := Subdomain} = _ExistingSubdomainInfo,
+                            _NewSubdomainInfo) ->
+    %% TODO: this is critical collision, and it must be reported properly
+    %% think about adding some metric, so devops can set some alarm for it
+    ?LOG_ERROR(#{what => subdomains_collision, subdomain => Subdomain}),
+    ok.
 
 -spec is_subdomain(subdomain_pattern(),
                    Domain :: mongooseim:domain_name(),

--- a/src/domain/mongoose_subdomain_utils.erl
+++ b/src/domain/mongoose_subdomain_utils.erl
@@ -1,14 +1,9 @@
 -module(mongoose_subdomain_utils).
 
--include("mongoose_logger.hrl").
-
 %% API
 -export([make_subdomain_pattern/1,
          get_fqdn/2,
          subdomain_type/1,
-         check_domain_name/2,
-         check_subdomain_name/1,
-         report_subdomains_collision/2,
          is_subdomain/3]).
 
 -type subdomain_pattern() :: {fqdn | prefix, binary()}.
@@ -37,38 +32,6 @@ get_fqdn({prefix, Prefix}, Domain)   -> <<Prefix/binary, Domain/binary>>.
 -spec subdomain_type(subdomain_pattern()) -> fqdn | subdomain.
 subdomain_type({fqdn, _}) -> fqdn;
 subdomain_type({prefix, _}) -> subdomain.
-
--spec check_domain_name(mongooseim:host_type(), mongooseim:domain_name()) ->
-    boolean().
-check_domain_name(_HostType, Domain) ->
-    case mongoose_subdomain_core:get_subdomain_info(Domain) of
-        {error, not_found} -> true;
-        {ok, _Info} ->
-            %% TODO: this is critical collision, and it must be reported properly
-            %% think about adding some metric, so devops can set some alarm for it
-            ?LOG_ERROR(#{what => check_domain_name_failed, domain => Domain}),
-            false
-    end.
-
--spec check_subdomain_name(mongoose_subdomain_core:subdomain_info()) -> boolean().
-check_subdomain_name(#{subdomain := Subdomain} = _SubdomainInfo) ->
-    case mongoose_domain_core:get_host_type(Subdomain) of
-        {error, not_found} -> true;
-        {ok, _HostType} ->
-            %% TODO: this is critical collision, and it must be reported properly
-            %% think about adding some metric, so devops can set some alarm for it
-            ?LOG_ERROR(#{what => check_subdomain_name_failed, subdomain => Subdomain}),
-            false
-    end.
-
--spec report_subdomains_collision(mongoose_subdomain_core:subdomain_info(),
-                                  mongoose_subdomain_core:subdomain_info()) -> ok.
-report_subdomains_collision(#{subdomain := Subdomain} = _ExistingSubdomainInfo,
-                            _NewSubdomainInfo) ->
-    %% TODO: this is critical collision, and it must be reported properly
-    %% think about adding some metric, so devops can set some alarm for it
-    ?LOG_ERROR(#{what => subdomains_collision, subdomain => Subdomain}),
-    ok.
 
 -spec is_subdomain(subdomain_pattern(),
                    Domain :: mongooseim:domain_name(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -235,7 +235,7 @@ auth_failed(HostType, Server, Username) ->
     ejabberd_hooks:run_for_host_type(auth_failed, HostType, ok, [Username, Server]).
 
 -spec disable_domain(HostType, Domain) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     Domain :: jid:lserver(),
     Result :: ok.
 disable_domain(HostType, Domain) ->
@@ -243,7 +243,7 @@ disable_domain(HostType, Domain) ->
 
 
 -spec disable_subdomain(HostType, Subdomain) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     Subdomain :: jid:lserver(),
     Result :: ok.
 disable_subdomain(HostType, Subdomain) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -155,6 +155,7 @@
 -export([c2s_remote_hook/5]).
 
 -export([disable_domain/2,
+         disable_subdomain/2,
          remove_domain/2,
          node_cleanup/1]).
 
@@ -239,6 +240,14 @@ auth_failed(HostType, Server, Username) ->
     Result :: ok.
 disable_domain(HostType, Domain) ->
     ejabberd_hooks:run_global(disable_domain, ok, [HostType, Domain]).
+
+
+-spec disable_subdomain(HostType, Subdomain) -> Result when
+    HostType :: binary(),
+    Subdomain :: jid:lserver(),
+    Result :: ok.
+disable_subdomain(HostType, Subdomain) ->
+    ejabberd_hooks:run_global(disable_subdomain, ok, [HostType, Subdomain]).
 
 -spec remove_domain(HostType, Domain) -> Result when
     HostType :: binary(),

--- a/test/mongoose_subdomain_core_SUITE.erl
+++ b/test/mongoose_subdomain_core_SUITE.erl
@@ -68,11 +68,11 @@ can_register_and_unregister_subdomain_for_static_host_type(_Config) ->
     %% check that ETS table contains expected subdomain and nothing else.
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?STATIC_HOST_TYPE,
                                                                 Pattern, Handler)),
-    ?assertEqualLists(get_all_subdomains(), [Subdomain]),
+    ?assertEqual([Subdomain], get_all_subdomains()),
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?STATIC_HOST_TYPE,
                                                                   Pattern)),
-    ?assertEqual(0, get_subdomains_table_size()),
-    ?assertEqualLists([Subdomain], get_list_of_disabled_subdomains()),
+    ?assertEqual([], get_all_subdomains()),
+    ?assertEqual([Subdomain], get_list_of_disabled_subdomains()),
     no_collisions().
 
 can_register_and_unregister_subdomain_for_dynamic_host_type_with_domains(_Config) ->
@@ -88,16 +88,13 @@ can_register_and_unregister_subdomain_for_dynamic_host_type_with_domains(_Config
     %% make a snapshot of subdomains ETS table and check its size.
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                 Pattern1, Handler)),
-    ?assertEqualLists(get_all_subdomains(), Subdomains1),
-    TableSnapshot = get_subdomains_table(),
-    ?assertEqual(length(?DYNAMIC_DOMAINS), get_subdomains_table_size()),
+    ?assertEqualLists(Subdomains1, get_all_subdomains()),
     %% register one more "prefix" subdomain for dynamic host type with 2 domains.
     %% check that ETS table contains all the expected subdomains and nothing else.
     %% check ETS table size.
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                 Pattern2, Handler)),
-    ?assertEqualLists(get_all_subdomains(), Subdomains1 ++ Subdomains2),
-    ?assertEqual(2 * length(?DYNAMIC_DOMAINS), get_subdomains_table_size()),
+    ?assertEqualLists(Subdomains1 ++ Subdomains2, get_all_subdomains()),
     %% check mongoose_subdomain_core:get_all_subdomains_for_domain/1 interface.
     [DynamicDomain | _] = ?DYNAMIC_DOMAINS,
     ?assertEqualLists(
@@ -112,10 +109,10 @@ can_register_and_unregister_subdomain_for_dynamic_host_type_with_domains(_Config
     %% check that ETS table rolls back to the previously made snapshot.
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                   Pattern2)),
-    ?assertEqualLists(TableSnapshot, get_subdomains_table()),
+    ?assertEqualLists(Subdomains1, get_all_subdomains()),
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                   Pattern1)),
-    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqual([], get_all_subdomains()),
     ?assertEqualLists(Subdomains1 ++ Subdomains2, get_list_of_disabled_subdomains()),
     no_collisions().
 
@@ -129,14 +126,14 @@ can_register_and_unregister_subdomain_for_dynamic_host_type_without_domains(_Con
                                                                 Pattern1, Handler)),
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
                                                                 Pattern2, Handler)),
-    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqual([], get_all_subdomains()),
     %% unregister (previously registered) subdomains one by one.
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE1,
                                                                   Pattern1)),
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE1,
                                                                   Pattern2)),
-    ?assertEqual(0, get_subdomains_table_size()),
-    ?assertEqualLists([], get_list_of_disabled_subdomains()),
+    ?assertEqual([], get_all_subdomains()),
+    ?assertEqual([], get_list_of_disabled_subdomains()),
     no_collisions().
 
 can_register_and_unregister_fqdn_for_static_host_type(_Config) ->
@@ -146,12 +143,12 @@ can_register_and_unregister_fqdn_for_static_host_type(_Config) ->
     %% check that ETS table contains the only expected subdomain.
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?STATIC_HOST_TYPE,
                                                                 Pattern, Handler)),
-    ?assertEqualLists(get_all_subdomains(), [<<"some.fqdn">>]),
+    ?assertEqual([<<"some.fqdn">>], get_all_subdomains()),
     %% unregister subdomain.
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?STATIC_HOST_TYPE,
                                                                   Pattern)),
-    ?assertEqual(0, get_subdomains_table_size()),
-    ?assertEqualLists([<<"some.fqdn">>], get_list_of_disabled_subdomains()),
+    ?assertEqual([], get_all_subdomains()),
+    ?assertEqual([<<"some.fqdn">>], get_list_of_disabled_subdomains()),
     no_collisions().
 
 can_register_and_unregister_fqdn_for_dynamic_host_type_without_domains(_Config) ->
@@ -161,12 +158,12 @@ can_register_and_unregister_fqdn_for_dynamic_host_type_without_domains(_Config) 
     %% check that ETS table contains the only expected subdomain.
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
                                                                 Pattern, Handler)),
-    ?assertEqualLists(get_all_subdomains(), [<<"some.fqdn">>]),
+    ?assertEqual([<<"some.fqdn">>], get_all_subdomains()),
     %% unregister subdomain.
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE1,
                                                                   Pattern)),
-    ?assertEqual(0, get_subdomains_table_size()),
-    ?assertEqualLists([<<"some.fqdn">>], get_list_of_disabled_subdomains()),
+    ?assertEqual([], get_all_subdomains()),
+    ?assertEqual([<<"some.fqdn">>], get_list_of_disabled_subdomains()),
     no_collisions().
 
 can_register_and_unregister_fqdn_for_dynamic_host_type_with_domains(_Config) ->
@@ -178,8 +175,7 @@ can_register_and_unregister_fqdn_for_dynamic_host_type_with_domains(_Config) ->
     %% make a snapshot of subdomains ETS table.
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                 Pattern1, Handler)),
-    ?assertEqualLists(get_all_subdomains(), [<<"some.fqdn">>]),
-    TableSnapshot = get_subdomains_table(),
+    ?assertEqual([<<"some.fqdn">>], get_all_subdomains()),
     %% register one more "fqdn" subdomain for dynamic host type with 2 domains.
     %% check mongoose_subdomain_core:get_all_subdomains_for_domain/1 interface
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
@@ -197,10 +193,10 @@ can_register_and_unregister_fqdn_for_dynamic_host_type_with_domains(_Config) ->
     %% check that ETS table rolls back to the previously made snapshot.
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                   Pattern2)),
-    ?assertEqualLists(TableSnapshot, get_subdomains_table()),
+    ?assertEqual([<<"some.fqdn">>], get_all_subdomains()),
     ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                   Pattern1)),
-    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqual([], get_all_subdomains()),
     ?assertEqualLists([<<"some.fqdn">>, <<"another.fqdn">>],
                       get_list_of_disabled_subdomains()),
     no_collisions().
@@ -214,7 +210,7 @@ can_add_and_remove_domain(_Config) ->
                    || Domain <- ?DYNAMIC_DOMAINS],
     Subdomains2 = [mongoose_subdomain_utils:get_fqdn(Pattern2, Domain)
                    || Domain <- ?DYNAMIC_DOMAINS],
-    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqual([], get_all_subdomains()),
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
                                                                 Pattern1, Handler)),
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
@@ -223,7 +219,6 @@ can_add_and_remove_domain(_Config) ->
                                                                 Pattern3, Handler)),
     ?assertEqualLists([<<"some.fqdn">> | Subdomains1 ++ Subdomains2],
                       get_all_subdomains()),
-    TableSnapshot = get_subdomains_table(),
     [DynamicDomain | _] = ?DYNAMIC_DOMAINS,
     mongoose_domain_core:delete(DynamicDomain),
     mongoose_subdomain_core:sync(),
@@ -233,7 +228,8 @@ can_add_and_remove_domain(_Config) ->
                       get_list_of_disabled_subdomains()),
     mongoose_domain_core:insert(DynamicDomain, ?DYNAMIC_HOST_TYPE2, dummy_source),
     mongoose_subdomain_core:sync(),
-    ?assertEqualLists(TableSnapshot, get_subdomains_table()),
+    ?assertEqualLists([<<"some.fqdn">> | Subdomains1 ++ Subdomains2],
+                      get_all_subdomains()),
     no_collisions().
 
 can_get_host_type_and_subdomain_details(_Config) ->
@@ -294,18 +290,19 @@ handles_domain_removal_during_subdomain_registration(_Config) ->
     %% some domains are removed during subdomain registration, see make_wrapper_fn/2
     ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
                                                                 Pattern1, Handler)),
-    mongoose_subdomain_core:sync(),
-    ?assertEqual(NumOfDomains - NumOfDomainsToRemove, get_subdomains_table_size()),
+
+    %% try to add some domains second time, as this is also possible during
+    %% subdomain registration
     AllDomains = mongoose_domain_core:get_domains_by_host_type(?DYNAMIC_HOST_TYPE1),
-    AllExpectedSubDomains = [mongoose_subdomain_utils:get_fqdn(Pattern1, Domain)
-                             || Domain <- AllDomains],
-    %% also try to add some domains second time, as this is also possible
-    %% during subdomain_registration
     [RegisteredDomain1, RegisteredDomain2 | _] = AllDomains,
     mongoose_subdomain_core:add_domain(?DYNAMIC_HOST_TYPE1, RegisteredDomain1),
     mongoose_subdomain_core:add_domain(?DYNAMIC_HOST_TYPE1, RegisteredDomain2),
     mongoose_subdomain_core:sync(),
-    ?assertEqualLists(AllExpectedSubDomains, get_all_subdomains()),
+    Subdomains = get_all_subdomains(),
+    ?assertEqual(NumOfDomains - NumOfDomainsToRemove, length(Subdomains)),
+    AllExpectedSubDomains = [mongoose_subdomain_utils:get_fqdn(Pattern1, Domain)
+                             || Domain <- AllDomains],
+    ?assertEqualLists(AllExpectedSubDomains, Subdomains),
     ?assertEqual(NumOfDomainsToRemove,
                  meck:num_calls(mongoose_hooks, disable_subdomain, 2)),
 
@@ -351,7 +348,7 @@ prevents_subdomain_overriding(_Config) ->
     mongoose_domain_core:insert(<<"test">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
     mongoose_domain_core:insert(<<"domain.test">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
     mongoose_subdomain_core:sync(),
-    ?assertEqual(3, get_subdomains_table_size()),
+    ?assertEqual(3, length(get_all_subdomains())),
     ExpectedSubdomainInfo =
         #{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern2,
           parent_domain => <<"test">>, packet_handler => Handler,
@@ -375,7 +372,7 @@ prevents_subdomain_overriding(_Config) ->
                  mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
                                                             Pattern3, Handler)),
 
-    ?assertEqual(4, get_subdomains_table_size()),
+    ?assertEqual(4, length(get_all_subdomains())),
     ?assertEqual({ok,#{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern3,
                        parent_domain => no_parent_domain, packet_handler => Handler,
                        subdomain => <<"sub.domain.fqdn">>}},
@@ -385,7 +382,7 @@ prevents_subdomain_overriding(_Config) ->
     %%------------------------------------------
     mongoose_domain_core:insert(<<"fqdn">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
     mongoose_subdomain_core:sync(),
-    ?assertEqual(5, get_subdomains_table_size()),
+    ?assertEqual(5, length(get_all_subdomains())),
     ?assertEqual({ok, #{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern3,
                         parent_domain => no_parent_domain, packet_handler => Handler,
                         subdomain => <<"sub.domain.fqdn">>}},
@@ -497,12 +494,6 @@ detects_domain_subdomain_collisions(_Config) ->
 %%-------------------------------------------------------------------
 %% internal functions
 %%-------------------------------------------------------------------
-get_subdomains_table() ->
-    ets:tab2list(mongoose_subdomain_core).
-
-get_subdomains_table_size() ->
-    ets:info(mongoose_subdomain_core, size).
-
 get_all_subdomains() ->
     %% mongoose_subdomain_core table is indexed by subdomain name field
     KeyPos = ets:info(mongoose_subdomain_core, keypos),

--- a/test/mongoose_subdomain_core_SUITE.erl
+++ b/test/mongoose_subdomain_core_SUITE.erl
@@ -1,0 +1,567 @@
+-module(mongoose_subdomain_core_SUITE).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(STATIC_HOST_TYPE, <<"static type">>).
+-define(STATIC_DOMAIN, <<"example.com">>).
+-define(DYNAMIC_HOST_TYPE1, <<"dynamic type #1">>).
+-define(DYNAMIC_HOST_TYPE2, <<"dynamic type #2">>).
+-define(DYNAMIC_DOMAINS, [<<"localhost">>, <<"local.host">>]).
+-define(STATIC_PAIRS, [{?STATIC_DOMAIN, ?STATIC_HOST_TYPE}]).
+-define(ALLOWED_HOST_TYPES, [?DYNAMIC_HOST_TYPE1, ?DYNAMIC_HOST_TYPE2]).
+
+-define(assertEqualLists(L1, L2), ?assertEqual(lists:sort(L1), lists:sort(L2))).
+
+all() ->
+    [can_register_and_unregister_subdomain,
+     can_register_and_unregister_fqdn,
+     can_add_and_remove_domain,
+     can_get_host_type_and_subdomain_details,
+     handles_domains_removal_during_subdomain_registration,
+     prevents_subdomain_overriding,
+     detects_domain_subdomain_collisions].
+
+init_per_suite(Config) ->
+    meck:new(mongoose_hooks, [no_link]),
+    meck:new(mongoose_subdomain_utils, [no_link, passthrough]),
+    meck:expect(mongoose_hooks, disable_domain, fun(_, _) -> ok end),
+    meck:expect(mongoose_hooks, disable_subdomain, fun(_, _) -> ok end),
+    Config.
+
+end_per_suite(Config) ->
+    meck:unload(),
+    Config.
+
+init_per_testcase(_, Config) ->
+    %% mongoose_domain_core preconditions:
+    %%   - one "static" host type with only one configured domain name
+    %%   - one "dynamic" host type without any configured domain names
+    %%   - one "dynamic" host type with two configured domain names
+    %% initial mongoose_subdomain_core conditions:
+    %%   - no subdomains configured for any host type
+    ok = mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_HOST_TYPES),
+    ok = mongoose_subdomain_core:start(),
+    [mongoose_domain_core:insert(Domain, ?DYNAMIC_HOST_TYPE2, dummy_source)
+     || Domain <- ?DYNAMIC_DOMAINS],
+    [meck:reset(M) || M <- [mongoose_hooks, mongoose_subdomain_utils]],
+    Config.
+
+end_per_testcase(_, Config) ->
+    mongoose_domain_core:stop(),
+    mongoose_subdomain_core:stop(),
+    Config.
+
+%%-------------------------------------------------------------------
+%% tests cases
+%%-------------------------------------------------------------------
+can_register_and_unregister_subdomain(_Config) ->
+    ?assertEqual(0, get_subdomains_table_size()),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain.@HOST@"),
+    Pattern2 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain2.@HOST@"),
+    Subdomains1 = [mongoose_subdomain_utils:get_fqdn(Pattern1, Domain)
+                          || Domain <- [?STATIC_DOMAIN | ?DYNAMIC_DOMAINS]],
+    Subdomains2 = [mongoose_subdomain_utils:get_fqdn(Pattern2, Domain)
+                          || Domain <- ?DYNAMIC_DOMAINS],
+    %% register one "prefix" subdomain for static host type.
+    %% check that ETS table contains all the expected subdomains and nothing else.
+    %% make a snapshot of subdomains ETS table and check its size.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?STATIC_HOST_TYPE,
+                                                                Pattern1, Handler)),
+    ?assertEqualLists(get_all_subdomains(), [hd(Subdomains1)]),
+    TableSnapshot1 = get_subdomains_table(),
+    ?assertEqual(1, get_subdomains_table_size()),
+    %% register one "prefix" subdomain for dynamic host type with 2 domains.
+    %% check that ETS table contains all the expected subdomains and nothing else.
+    %% make a snapshot of subdomains ETS table and check its size.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern1, Handler)),
+    ?assertEqualLists(get_all_subdomains(), Subdomains1),
+    TableSnapshot2 = get_subdomains_table(),
+    ?assertEqual(1 + length(?DYNAMIC_DOMAINS), get_subdomains_table_size()),
+    %% register one more "prefix" subdomain for dynamic host type with 2 domains.
+    %% check that ETS table contains all the expected subdomains and nothing else.
+    %% make a snapshot of subdomains ETS table and check its size.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern2, Handler)),
+    ?assertEqualLists(get_all_subdomains(), Subdomains1 ++ Subdomains2),
+    TableSnapshot3 = get_subdomains_table(),
+    ?assertEqual(1 + 2 * length(?DYNAMIC_DOMAINS), get_subdomains_table_size()),
+    %% check mongoose_subdomain_core:get_all_subdomains_for_domain/1 interface.
+    [DynamicDomain | _] = ?DYNAMIC_DOMAINS,
+    ?assertEqualLists(
+        [#{host_type => ?DYNAMIC_HOST_TYPE2, subdomain_pattern => Pattern1,
+           parent_domain => DynamicDomain, packet_handler => Handler,
+           subdomain => mongoose_subdomain_utils:get_fqdn(Pattern1, DynamicDomain)},
+         #{host_type => ?DYNAMIC_HOST_TYPE2, subdomain_pattern => Pattern2,
+           parent_domain => DynamicDomain, packet_handler => Handler,
+           subdomain => mongoose_subdomain_utils:get_fqdn(Pattern2, DynamicDomain)}],
+        mongoose_subdomain_core:get_all_subdomains_for_domain(DynamicDomain)),
+    %% register two "prefix" subdomains for dynamic host type with 0 domains.
+    %% check that ETS table doesn't contain any new subdomains.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern1, Handler)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern2, Handler)),
+    ?assertEqualLists(TableSnapshot3, get_subdomains_table()),
+    %% unregister (previously registered) subdomains one by one.
+    %% check that ETS table rolls back to the previously made snapshots.
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                  Pattern2)),
+    ?assertEqualLists(TableSnapshot2, get_subdomains_table()),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                  Pattern1)),
+    ?assertEqualLists(TableSnapshot1, get_subdomains_table()),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?STATIC_HOST_TYPE,
+                                                                  Pattern1)),
+    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                  Pattern1)),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                  Pattern2)),
+    ?assertEqualLists(Subdomains1 ++ Subdomains2, get_list_of_disabled_subdomains()),
+    no_collisions().
+
+can_register_and_unregister_fqdn(_Config) ->
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("some.fqdn"),
+    Pattern2 = mongoose_subdomain_utils:make_subdomain_pattern("another.fqdn"),
+    Pattern3 = mongoose_subdomain_utils:make_subdomain_pattern("yet.another.fqdn"),
+    Pattern4 = mongoose_subdomain_utils:make_subdomain_pattern("one.more.fqdn"),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    ?assertEqual(0, get_subdomains_table_size()),
+    %% register one "fqdn" subdomain for static host type.
+    %% check that ETS table contains all the expected subdomains and nothing else.
+    %% make a snapshot of subdomains ETS table.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?STATIC_HOST_TYPE,
+                                                                Pattern1, Handler)),
+    ?assertEqualLists(get_all_subdomains(), [<<"some.fqdn">>]),
+    TableSnapshot1 = get_subdomains_table(),
+    %% register one "fqdn" subdomain for dynamic host type with 0 domains.
+    %% make a snapshot of subdomains ETS table and check its size.
+    %% check mongoose_subdomain_core:get_all_subdomains_for_domain/1 interface.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern2, Handler)),
+    TableSnapshot2 = get_subdomains_table(),
+    ?assertEqual(2, get_subdomains_table_size()),
+    ?assertEqualLists([#{host_type => ?STATIC_HOST_TYPE, parent_domain => undefined,
+                         subdomain_pattern => Pattern1, packet_handler => Handler,
+                         subdomain => <<"some.fqdn">>},
+                       #{host_type => ?DYNAMIC_HOST_TYPE1, parent_domain => undefined,
+                         subdomain_pattern => Pattern2, packet_handler => Handler,
+                         subdomain => <<"another.fqdn">>}],
+                      mongoose_subdomain_core:get_all_subdomains_for_domain(undefined)),
+    %% register one "fqdn" subdomain for dynamic host type with 2 domains.
+    %% check that ETS table contains all the expected subdomains and nothing else.
+    %% make a snapshot of subdomains ETS table.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern3, Handler)),
+    ?assertEqualLists(get_all_subdomains(), [<<"some.fqdn">>, <<"another.fqdn">>,
+                                             <<"yet.another.fqdn">>]),
+    TableSnapshot3 = get_subdomains_table(),
+    %% register one more "fqdn" subdomain for dynamic host type with 2 domains.
+    %% check that ETS table contains all the expected subdomains and nothing else.
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern4, Handler)),
+    ?assertEqualLists(get_all_subdomains(), [<<"some.fqdn">>, <<"yet.another.fqdn">>,
+                                             <<"another.fqdn">>, <<"one.more.fqdn">>]),
+    %% unregister (previously registered) subdomains one by one.
+    %% check that ETS table rolls back to the previously made snapshots.
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                  Pattern4)),
+    ?assertEqualLists(TableSnapshot3, get_subdomains_table()),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                  Pattern3)),
+    ?assertEqualLists(TableSnapshot2, get_subdomains_table()),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                  Pattern2)),
+    ?assertEqualLists(TableSnapshot1, get_subdomains_table()),
+    ?assertEqual(ok, mongoose_subdomain_core:unregister_subdomain(?STATIC_HOST_TYPE,
+                                                                  Pattern1)),
+    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqualLists([<<"some.fqdn">>, <<"yet.another.fqdn">>,
+                       <<"another.fqdn">>, <<"one.more.fqdn">>],
+                      get_list_of_disabled_subdomains()),
+    no_collisions().
+
+can_add_and_remove_domain(_Config) ->
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain.@HOST@"),
+    Pattern2 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain2.@HOST@"),
+    Pattern3 = mongoose_subdomain_utils:make_subdomain_pattern("some.fqdn"),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    Subdomains1 = [mongoose_subdomain_utils:get_fqdn(Pattern1, Domain)
+                   || Domain <- ?DYNAMIC_DOMAINS],
+    Subdomains2 = [mongoose_subdomain_utils:get_fqdn(Pattern2, Domain)
+                   || Domain <- ?DYNAMIC_DOMAINS],
+    ?assertEqual(0, get_subdomains_table_size()),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern1, Handler)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern2, Handler)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern3, Handler)),
+    ?assertEqualLists([<<"some.fqdn">> | Subdomains1 ++ Subdomains2],
+                      get_all_subdomains()),
+    TableSnapshot = get_subdomains_table(),
+    [DynamicDomain | _] = ?DYNAMIC_DOMAINS,
+    mongoose_domain_core:delete(DynamicDomain),
+    mongoose_subdomain_core:sync(),
+    ?assertEqualLists([<<"some.fqdn">> | tl(Subdomains1) ++ tl(Subdomains2)],
+                      get_all_subdomains()),
+    mongoose_domain_core:insert(DynamicDomain, ?DYNAMIC_HOST_TYPE2, dummy_source),
+    mongoose_subdomain_core:sync(),
+    ?assertEqualLists(TableSnapshot, get_subdomains_table()),
+    ?assertEqualLists([hd(Subdomains1), hd(Subdomains2)],
+                      get_list_of_disabled_subdomains()),
+    no_collisions().
+
+can_get_host_type_and_subdomain_details(_Config) ->
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain.@HOST@"),
+    Pattern2 = mongoose_subdomain_utils:make_subdomain_pattern("some.fqdn"),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    Subdomain1 = mongoose_subdomain_utils:get_fqdn(Pattern1, ?STATIC_DOMAIN),
+    Subdomain2 = mongoose_subdomain_utils:get_fqdn(Pattern1, hd(?DYNAMIC_DOMAINS)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?STATIC_HOST_TYPE,
+                                                                Pattern1, Handler)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                                Pattern1, Handler)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern2, Handler)),
+    ?assertEqual({ok, ?STATIC_HOST_TYPE},
+                 mongoose_subdomain_core:get_host_type(Subdomain1)),
+    ?assertEqual({ok, ?DYNAMIC_HOST_TYPE1},
+                 mongoose_subdomain_core:get_host_type(<<"some.fqdn">>)),
+    ?assertEqual({ok, ?DYNAMIC_HOST_TYPE2},
+                 mongoose_subdomain_core:get_host_type(Subdomain2)),
+    ?assertEqual({error, not_found},
+                 mongoose_subdomain_core:get_host_type(<<"unknown.subdomain">>)),
+    ?assertEqual({ok, #{host_type => ?STATIC_HOST_TYPE, subdomain_pattern => Pattern1,
+                        parent_domain => ?STATIC_DOMAIN, packet_handler => Handler,
+                        subdomain => Subdomain1}},
+                 mongoose_subdomain_core:get_subdomain_info(Subdomain1)),
+    ?assertEqual({ok, #{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern2,
+                        parent_domain => undefined, packet_handler => Handler,
+                        subdomain => <<"some.fqdn">>}},
+                 mongoose_subdomain_core:get_subdomain_info(<<"some.fqdn">>)),
+    ?assertEqual({ok, #{host_type => ?DYNAMIC_HOST_TYPE2, subdomain_pattern => Pattern1,
+                        parent_domain => hd(?DYNAMIC_DOMAINS), packet_handler => Handler,
+                        subdomain => Subdomain2}},
+                 mongoose_subdomain_core:get_subdomain_info(Subdomain2)),
+    ?assertEqual({error, not_found},
+                 mongoose_subdomain_core:get_subdomain_info(<<"unknown.subdomain">>)),
+    ok.
+
+handles_domains_removal_during_subdomain_registration(_Config) ->
+    %% NumOfDomains is just some big non-round number to ensure that more than 2 ets
+    %% selections are done during the call to mongoose_domain_core:for_each_domain/2.
+    %% currently max selection size is 100 domains.
+    NumOfDomains = 1234,
+    NumOfDomainsToRemove = 1234 div 4,
+    NewDomains = [<<"dummy_domain_", (integer_to_binary(N))/binary, ".localhost">>
+                  || N <- lists:seq(1, NumOfDomains)],
+    [mongoose_domain_core:insert(Domain, ?DYNAMIC_HOST_TYPE1, dummy_src)
+     || Domain <- NewDomains],
+    meck:new(mongoose_domain_core, [passthrough]),
+    WrapperFn = make_wrapper_fn(NumOfDomainsToRemove * 2, NumOfDomainsToRemove),
+    meck:expect(mongoose_domain_core, for_each_domain,
+                fun(HostType, Fn) ->
+                    meck:passthrough([HostType, WrapperFn(Fn)])
+                end),
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain.@HOST@"),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern1, Handler)),
+    mongoose_subdomain_core:sync(),
+    ?assertEqual(NumOfDomains - NumOfDomainsToRemove, get_subdomains_table_size()),
+    AllDomains = mongoose_domain_core:get_domains_by_host_type(?DYNAMIC_HOST_TYPE1),
+    AllExpectedSubDomains = [mongoose_subdomain_utils:get_fqdn(Pattern1, Domain)
+                             || Domain <- AllDomains],
+    %% also try to add some domains second time, as this is also possible
+    %% during subdomain_registration
+    [RegisteredDomain1, RegisteredDomain2 | _] = AllDomains,
+    mongoose_subdomain_core:add_domain(?DYNAMIC_HOST_TYPE1, RegisteredDomain1),
+    mongoose_subdomain_core:add_domain(?DYNAMIC_HOST_TYPE1, RegisteredDomain2),
+    mongoose_subdomain_core:sync(),
+    ?assertEqualLists(AllExpectedSubDomains, get_all_subdomains()),
+    ?assertEqual(NumOfDomainsToRemove,
+                 meck:num_calls(mongoose_hooks, disable_subdomain, 2)),
+
+    no_collisions(),
+    meck:unload(mongoose_domain_core).
+
+prevents_subdomain_overriding(_Config) ->
+    %% there are three possible subdomain names collisions:
+    %%   1) different domain/subdomain_pattern pairs produce one and the same subdomain
+    %%   2) attempt to register the same FQDN subdomain for 2 different host types
+    %%   3) domain/subdomain_pattern pair produces the same subdomain name as another
+    %%      FQDN subdomain
+    %%
+    %% collisions of the first type can eliminated by allowing only one level subdomains,
+    %% e.g. ensuring that subdomain template corresponds to this regex "^[^.]*\.@HOST@$".
+    %%
+    %% collisions of the second type are less critical as they can be detected during
+    %% init phase - they result in {error, subdomain_already_exists} return code, so
+    %% modules can detect it and crash at ?MODULE:start/2
+    %%
+    %% third type is hard to resolve in automatic way. one of the options is to ensure
+    %% that FQDN subdomains don't start with the same "prefix" as subdomain patterns.
+    %%
+    %% it's good idea to create a metric for such collisions, so devops can set some
+    %% alarm and react on it.
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("sub.@HOST@"),
+    Pattern2 = mongoose_subdomain_utils:make_subdomain_pattern("sub.domain.@HOST@"),
+    Pattern3 = mongoose_subdomain_utils:make_subdomain_pattern("sub.domain.fqdn"),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    %%----------------------------------------------------------------
+    %% testing type #1 subdomain names collision + double registration
+    %%----------------------------------------------------------------
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern1, Handler)),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern2, Handler)),
+    ?assertEqual({error, already_registered},
+                 mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                            Pattern2, Handler)),
+    mongoose_domain_core:insert(<<"test">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
+    mongoose_domain_core:insert(<<"domain.test">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
+    mongoose_subdomain_core:sync(),
+    ?assertEqual(3, get_subdomains_table_size()),
+    ExpectedSubdomainInfo1 =
+        #{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern2,
+          parent_domain => <<"test">>, packet_handler => Handler,
+          subdomain => <<"sub.domain.test">>},
+    ?assertEqual({ok,ExpectedSubdomainInfo1} ,
+                 mongoose_subdomain_core:get_subdomain_info(<<"sub.domain.test">>)),
+    %% check that removal of "domain.test" doesn't affect "sub.domain.test" subdomain
+    mongoose_domain_core:delete("domain.test"),
+    mongoose_subdomain_core:sync(),
+    ?assertEqual({ok, ExpectedSubdomainInfo1},
+                 mongoose_subdomain_core:get_subdomain_info(<<"sub.domain.test">>)),
+    %%----------------------------------------------------------------
+    %% testing type #2 subdomain names collision + double registration
+    %%----------------------------------------------------------------
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern3, Handler)),
+    ?assertEqual({error, already_registered},
+                 mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                            Pattern3, Handler)),
+    ?assertEqual({error, subdomain_already_exists},
+                 mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE2,
+                                                            Pattern3, Handler)),
+
+    ?assertEqual(4, get_subdomains_table_size()),
+    ExpectedSubdomainInfo2 =
+        #{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern3,
+          parent_domain => undefined, packet_handler => Handler,
+          subdomain => <<"sub.domain.fqdn">>},
+    ?assertEqual({ok,ExpectedSubdomainInfo2},
+                 mongoose_subdomain_core:get_subdomain_info(<<"sub.domain.fqdn">>)),
+    %%------------------------------------------
+    %% testing type #3 subdomain names collision
+    %%------------------------------------------
+    mongoose_domain_core:insert(<<"fqdn">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
+    mongoose_subdomain_core:sync(),
+    ?assertEqual(5, get_subdomains_table_size()),
+    ExpectedSubdomainInfo3 =
+        #{host_type => ?DYNAMIC_HOST_TYPE1, subdomain_pattern => Pattern3,
+          parent_domain => undefined, packet_handler => Handler,
+          subdomain => <<"sub.domain.fqdn">>},
+    ?assertEqual({ok, ExpectedSubdomainInfo3},
+                 mongoose_subdomain_core:get_subdomain_info(<<"sub.domain.fqdn">>)),
+    %%---------------------------------------
+    %% check that all collisions are detected
+    %%---------------------------------------
+    ?assertEqual([[ExpectedSubdomainInfo1,
+                   ExpectedSubdomainInfo1#{subdomain_pattern := Pattern1,
+                                           parent_domain => <<"domain.test">>}],
+                  [ExpectedSubdomainInfo2,
+                   ExpectedSubdomainInfo2#{host_type := ?DYNAMIC_HOST_TYPE2}],
+                  [ExpectedSubdomainInfo3,
+                   ExpectedSubdomainInfo3#{subdomain_pattern := Pattern2,
+                                           parent_domain := <<"fqdn">>}]],
+                 get_list_of_subdomain_collisions()),
+    no_domain_collisions().
+
+detects_domain_subdomain_collisions(_Config) ->
+    %% there are two possible domain/subdomain names collisions:
+    %%   1) domain/subdomain_pattern pair produces the same subdomain name as another
+    %%      existing domain
+    %%   2) FQDN subdomain is the same as some registered domain
+    %%
+    %% the naive domain/subdomain registration rejection is probably a bad option:
+    %%   * domains and subdomains ETS tables are managed asynchronously, in addition to
+    %%     that subdomains patterns registration is done async as well. this all leaves
+    %%     room for a various race conditions if try to just make a verification and
+    %%     prohibit domain/subdomain registration in case of any collisions.
+    %%   * the only way to avoid such race conditions is to block all async. ETSs
+    %%     editing during the validation process, but this can result in big delays
+    %%     during the MIM initialisation phase.
+    %%   * also it's not clear how to interpret registration of the "prefix" based
+    %%     subdomain patterns, should we block the registration of the whole pattern
+    %%     or just only conflicting subdomains registration. blocking of the whloe
+    %%     pattern requires generation and verification of all the subdomains (with
+    %%     ETS blocking during that process), which depends on domains ETS size and
+    %%     might take too long.
+    %%   * and the last big issue with simple registration rejection approach, different
+    %%     nodes in the cluster might have different registration sequence, so we may
+    %%     end up in a situation when some nodes registered domain name as a subdomain,
+    %%     while other nodes registered it as a top level domain.
+    %%
+    %% the better way is to prohibit registration of top level domain if they are equal
+    %% to any of the FQDN subdomains or if beginning of domain name matches the prefix
+    %% of any subdomain template. in this case we don't need to verify subdomains at all,
+    %% verification of domain names against some limit number of subdomains patterns is
+    %% enough. and the only problem that we need to solve - mongooseim_domain_core must
+    %% be aware of all the subdomain patterns before it registers the first dynamic
+    %% domain. this would require minor configuration rework, e.g. tracking of subdomain
+    %% templates preprocessing (mongoose_subdomain_utils:make_subdomain_pattern/1 calls)
+    %% during toml config parsing.
+    Pattern1 = mongoose_subdomain_utils:make_subdomain_pattern("subdomain.@HOST@"),
+    Pattern2 = mongoose_subdomain_utils:make_subdomain_pattern("some.fqdn"),
+    Pattern3 = mongoose_subdomain_utils:make_subdomain_pattern("another.fqdn"),
+    Handler = mongoose_packet_handler:new(?MODULE),
+    %%------------------------------------------
+    %% testing type #1 subdomain names collision
+    %%------------------------------------------
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern1, Handler)),
+    mongoose_domain_core:insert(<<"example.net">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
+    %% without this sync call "subdomain.example.net" collision can be detected twice,
+    %% one time by mongoose_subdomain_utils:check_subdomain_name/1 function and then
+    %% second time by mongoose_subdomain_utils:check_domain_name/2.
+    mongoose_subdomain_core:sync(),
+    mongoose_domain_core:insert(<<"subdomain.example.net">>, ?DYNAMIC_HOST_TYPE2,
+                                dummy_src),
+    mongoose_domain_core:insert(<<"subdomain.example.org">>, ?DYNAMIC_HOST_TYPE2,
+                                dummy_src),
+    mongoose_domain_core:insert(<<"example.org">>, ?DYNAMIC_HOST_TYPE1, dummy_src),
+    mongoose_subdomain_core:sync(),
+    ?assertEqualLists([<<"subdomain.example.org">>, <<"subdomain.example.net">>],
+                      get_all_subdomains()),
+    ?assertEqualLists(
+        [<<"subdomain.example.org">>, <<"subdomain.example.net">> | ?DYNAMIC_DOMAINS],
+        mongoose_domain_core:get_domains_by_host_type(?DYNAMIC_HOST_TYPE2)),
+    no_subdomain_collisions(),
+    {ok, SubdomainInfo1} =
+        mongoose_subdomain_core:get_subdomain_info(<<"subdomain.example.org">>),
+    ?assertEqual(
+        [{check_domain_name, [?DYNAMIC_HOST_TYPE2, <<"subdomain.example.net">>]},
+         {check_subdomain_name, [SubdomainInfo1]}],
+        get_list_of_domain_collisions()),
+    %% cleanup
+    meck:reset(mongoose_subdomain_utils),
+    Domains = [<<"subdomain.example.net">>, <<"subdomain.example.org">>,
+               <<"example.net">>, <<"example.org">>],
+    [mongoose_domain_core:delete(Domain) || Domain <- Domains],
+    %%------------------------------------------
+    %% testing type #2 subdomain names collision
+    %%------------------------------------------
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern2, Handler)),
+    mongoose_domain_core:insert(<<"some.fqdn">>, ?DYNAMIC_HOST_TYPE2, dummy_src),
+    mongoose_domain_core:insert(<<"another.fqdn">>, ?DYNAMIC_HOST_TYPE2, dummy_src),
+    ?assertEqual(ok, mongoose_subdomain_core:register_subdomain(?DYNAMIC_HOST_TYPE1,
+                                                                Pattern3, Handler)),
+    ?assertEqualLists([<<"some.fqdn">>, <<"another.fqdn">>], get_all_subdomains()),
+    ?assertEqualLists(
+        [<<"some.fqdn">>, <<"another.fqdn">> | ?DYNAMIC_DOMAINS],
+        mongoose_domain_core:get_domains_by_host_type(?DYNAMIC_HOST_TYPE2)),
+    no_subdomain_collisions(),
+    {ok, SubdomainInfo2} =
+        mongoose_subdomain_core:get_subdomain_info(<<"another.fqdn">>),
+    ?assertEqual(
+        [{check_domain_name, [?DYNAMIC_HOST_TYPE2, <<"some.fqdn">>]},
+         {check_subdomain_name, [SubdomainInfo2]}],
+        get_list_of_domain_collisions()).
+
+%%-------------------------------------------------------------------
+%% internal functions
+%%-------------------------------------------------------------------
+get_subdomains_table() ->
+    ets:tab2list(mongoose_subdomain_core).
+
+get_subdomains_table_size() ->
+    ets:info(mongoose_subdomain_core, size).
+
+get_all_subdomains() ->
+    %% mongoose_subdomain_core table is indexed by subdomain name field
+    KeyPos = ets:info(mongoose_subdomain_core, keypos),
+    [element(KeyPos, Item) || Item <- ets:tab2list(mongoose_subdomain_core)].
+
+make_wrapper_fn(N, M) when N > M ->
+    %% the wrapper function generates a new loop processing function
+    %% that pauses after after processing N domains, removes M of the
+    %% already processed domains and resumes after that.
+    fun(Fn) ->
+        put(number_of_iterations, 0),
+        fun(HostType, DomainName) ->
+            NumberOfIterations = get(number_of_iterations),
+            if
+                NumberOfIterations =:= N -> remove_some_domains_asyn(M);
+                true -> ok
+            end,
+            put(number_of_iterations, NumberOfIterations + 1),
+            Fn(HostType, DomainName)
+        end
+    end.
+
+remove_some_domains_asyn(N) ->
+    {Pid, Ref} = spawn_monitor(fun() -> remove_some_domains(N) end),
+    receive
+        {'DOWN', Ref, process, Pid, _Info} -> ok
+    end.
+
+remove_some_domains(N) ->
+    AllSubdomains = get_all_subdomains(),
+    IndexesToRemove = list_of_rand_unique_ints(N,length(AllSubdomains)),
+    DomainsToRemove =
+        [begin
+             Subdomain = lists:nth(I, AllSubdomains),
+             {ok, Info} = mongoose_subdomain_core:get_subdomain_info(Subdomain),
+             maps:get(parent_domain, Info)
+         end || I <- IndexesToRemove],
+    [mongoose_domain_core:delete(Domain) || Domain<-DomainsToRemove].
+
+list_of_rand_unique_ints(Length, Max) when Max > Length ->
+    list_of_rand_unique_ints(Length, Max, []).
+
+list_of_rand_unique_ints(Length, Max, List) when Length > 0 ->
+    N = rand:uniform(Max),
+    case lists:member(N, List) of
+        true -> list_of_rand_unique_ints(Length, Max, List);
+        false -> list_of_rand_unique_ints(Length - 1, Max, [N | List])
+    end;
+list_of_rand_unique_ints(_, _, List) -> List.
+
+no_collisions() ->
+    no_domain_collisions(),
+    no_subdomain_collisions().
+
+no_domain_collisions() ->
+    Hist = meck:history(mongoose_subdomain_utils),
+    Calls = [Call || {_Pid, {_Mod, Func, _Args}, false = _Result} = Call <- Hist,
+                     Func =:= check_subdomain_name orelse Func =:= check_domain_name],
+    ?assertEqual([], Calls).
+
+get_list_of_domain_collisions() ->
+    Hist = meck:history(mongoose_subdomain_utils),
+    [{Func, Args} || {_Pid, {_Mod, Func, Args}, false = _Result} <- Hist,
+                     Func =:= check_subdomain_name orelse Func =:= check_domain_name].
+
+no_subdomain_collisions() ->
+    Hist = meck:history(mongoose_subdomain_utils),
+    Calls = [Call || {_P, {_M, report_subdomains_collision, _A}, _R} = Call <- Hist],
+    ?assertEqual([], Calls).
+
+get_list_of_subdomain_collisions() ->
+    Hist = meck:history(mongoose_subdomain_utils),
+    %% Args is a list of 2 mongoose_subdomain_core:subdomain_info() elements:
+    %%   * the first one - info map for the existing subdomain.
+    %%   * the second one - info map for the new subdomain that we've failed to add.
+    [Args || {_P, {_M, report_subdomains_collision = _F, Args}, _R} <- Hist].
+
+get_list_of_disabled_subdomains() ->
+    History = meck:history(mongoose_hooks),
+    [lists:nth(2, Args) %% Subdomain is the second argument
+     || {_Pid, {_Mod, disable_subdomain = _Func, Args}, _Result} <- History].


### PR DESCRIPTION
Initial implementation of subdomains management subsystem.
Note that it detects but doesn't solve subdomains or domain/subdomain names collisions:
for more information see comment in the corresponding test cases:
 * [subdomain names collissions](https://github.com/esl/MongooseIM/pull/3116/files#diff-903da31c5ca7d77683c10c87e043e34f12c76d0bb06e1ff86317b96092f8ea54R293)
 * [domain/subdomain names collisions](https://github.com/esl/MongooseIM/pull/3116/files#diff-903da31c5ca7d77683c10c87e043e34f12c76d0bb06e1ff86317b96092f8ea54R386)