### PR TITLE
Metrics per host type

### DIFF
--- a/big_tests/tests/metrics_helper.erl
+++ b/big_tests/tests/metrics_helper.erl
@@ -28,7 +28,7 @@ get_counter_value(HostType, Metric) ->
     end.
 
 assert_counter(Value, CounterName) ->
-    assert_counter(ct:get_config({hosts, mim, domain}), Value, CounterName).
+    assert_counter(domain_helper:host_type(mim), Value, CounterName).
 
 assert_counter(HostType, Value, CounterName) ->
     HostTypeName = make_host_type_name(HostType),
@@ -90,7 +90,7 @@ user_ids(Config) ->
     end.
 
 wait_for_counter(ExpectedValue, Counter) ->
-        wait_for_counter(ct:get_config({hosts, mim, domain}), ExpectedValue, Counter).
+        wait_for_counter(domain_helper:host_type(mim), ExpectedValue, Counter).
 
 wait_for_counter(HostType, ExpectedValue, Counter) ->
     mongoose_helper:wait_until(fun() ->

--- a/doc/migrations/4.2.0_4.3.0.md
+++ b/doc/migrations/4.2.0_4.3.0.md
@@ -82,6 +82,15 @@ GO
 
 ## Groupchat hook migrations
 
-- `filter_room_packet` hook uses a map insted of a proplist
+- `filter_room_packet` hook uses a map instead of a proplist
   for the event data information.
 - `room_send_packet` hook has been removed. Use `filter_room_packet` instead.
+
+## Metrics REST API (obsolete)
+
+The API is still considered obsolete so if you are using it,
+please consider using [WombatOAM](https://www.erlang-solutions.com/capabilities/wombatoam/)
+or metrics reporters as described in [Logging and monitoring](../operation-and-maintenance/Logging-&-monitoring.md).
+
+In each endpoint, `host` has been changed to `host_type`.
+This is because the metrics are now collected per host type rather than host.

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -6,7 +6,7 @@ MongooseIM uses [ESL's fork of this project](https://github.com/esl/exometer/tre
 
 All metrics are divided into the following groups:
 
-* Per host metrics: Gathered separately for every XMPP host supported by the cluster.
+* Per host type metrics: Gathered separately for every host type supported by the cluster.
  **Warning:** If a cluster supports many (thousands or more) domains, performance issues might occur.
  To avoid this, use global equivalents of the metrics with `all_metrics_are_global` config option.
     * Hook metrics.
@@ -60,7 +60,7 @@ A histogram collects values over a sliding window of 60s and exposes the followi
 * `median`
 * `50`, `75`, `90`, `95`, `99`, `999` - 50th, 75th, 90th, 95th, 99th and 99.9th percentile
 
-## Per host metrics
+## Per host type metrics
 
 ### Hook metrics
 
@@ -69,72 +69,72 @@ As a result it makes more sense to maintain a list of the most relevant or usefu
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| `[Host, anonymous_purge_hook]` | spiral | An anonymous user disconnects. |
-| `[Host, c2s_unauthenticated_iq]` | spiral | An IQ sent from a user to a server without authentication. |
-| `[Host, disco_info]` | spiral | An information about the server has been requested via Disco protocol. |
-| `[Host, disco_local_features]` | spiral | A list of server features is gathered. |
-| `[Host, disco_local_identity]` | spiral | A list of server identities is gathered. |
-| `[Host, disco_local_items]` | spiral | A list of server's items (e.g. services) is gathered. |
-| `[Host, disco_sm_features]` | spiral | A list of user's features is gathered. |
-| `[Host, disco_sm_identity]` | spiral | A list of user's identities is gathered. |
-| `[Host, disco_sm_items]` | spiral | A list of user's items is gathered. |
-| `[Host, mam_lookup_messages]` | spiral | An archive lookup is performed. |
-| `[Host, offline_message_hook]` | spiral | A message was sent to an offline user. (Except for "error", "headline" and "groupchat" message types.) |
-| `[Host, offline_groupchat_message_hook]` | spiral | A groupchat message was sent to an offline user. |
-| `[Host, privacy_updated_list]` | spiral | User's privacy list is updated. |
-| `[Host, resend_offline_messages_hook]` | spiral | A list of offline messages is gathered for delivery to a user's new connection. |
-| `[Host, roster_get_subscription_lists]` |  spiral | Presence subscription lists (based on which presence updates are broadcasted) are gathered. |
-| `[Host, roster_in_subscription]` | spiral | A presence with subscription update is processed. |
-| `[Host, roster_out_subscription]` | spiral | A presence with subscription update is received from a client. |
-| `[Host, sm_broadcast]` | spiral | A stanza is broadcasted to all of user's resources. |
-| `[Host, unset_presence_hook]` | spiral | A user disconnects or sends an `unavailable` presence. |
+| `[HostType, anonymous_purge_hook]` | spiral | An anonymous user disconnects. |
+| `[HostType, c2s_unauthenticated_iq]` | spiral | An IQ sent from a user to a server without authentication. |
+| `[HostType, disco_info]` | spiral | An information about the server has been requested via Disco protocol. |
+| `[HostType, disco_local_features]` | spiral | A list of server features is gathered. |
+| `[HostType, disco_local_identity]` | spiral | A list of server identities is gathered. |
+| `[HostType, disco_local_items]` | spiral | A list of server's items (e.g. services) is gathered. |
+| `[HostType, disco_sm_features]` | spiral | A list of user's features is gathered. |
+| `[HostType, disco_sm_identity]` | spiral | A list of user's identities is gathered. |
+| `[HostType, disco_sm_items]` | spiral | A list of user's items is gathered. |
+| `[HostType, mam_lookup_messages]` | spiral | An archive lookup is performed. |
+| `[HostType, offline_message_hook]` | spiral | A message was sent to an offline user. (Except for "error", "headline" and "groupchat" message types.) |
+| `[HostType, offline_groupchat_message_hook]` | spiral | A groupchat message was sent to an offline user. |
+| `[HostType, privacy_updated_list]` | spiral | User's privacy list is updated. |
+| `[HostType, resend_offline_messages_hook]` | spiral | A list of offline messages is gathered for delivery to a user's new connection. |
+| `[HostType, roster_get_subscription_lists]` |  spiral | Presence subscription lists (based on which presence updates are broadcasted) are gathered. |
+| `[HostType, roster_in_subscription]` | spiral | A presence with subscription update is processed. |
+| `[HostType, roster_out_subscription]` | spiral | A presence with subscription update is received from a client. |
+| `[HostType, sm_broadcast]` | spiral | A stanza is broadcasted to all of user's resources. |
+| `[HostType, unset_presence_hook]` | spiral | A user disconnects or sends an `unavailable` presence. |
 
 ### Presences & rosters
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| `[Host, modPresenceSubscriptions]` | spiral | Presence subscription is processed. |
-| `[Host, modPresenceUnsubscriptions]` | spiral | Presence unsubscription is processed. |
-| `[Host, modRosterGets]` | spiral | User's roster is fetched. |
-| `[Host, modRosterPush]` | spiral | A roster update is pushed to a single session. |
-| `[Host, modRosterSets]` | spiral | User's roster is updated. |
+| `[HostType, modPresenceSubscriptions]` | spiral | Presence subscription is processed. |
+| `[HostType, modPresenceUnsubscriptions]` | spiral | Presence unsubscription is processed. |
+| `[HostType, modRosterGets]` | spiral | User's roster is fetched. |
+| `[HostType, modRosterPush]` | spiral | A roster update is pushed to a single session. |
+| `[HostType, modRosterSets]` | spiral | User's roster is updated. |
 
 ### Privacy lists
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| `[Host, modPrivacyGets]` | spiral | IQ privacy `get` is processed. |
-| `[Host, modPrivacyPush]` | spiral | Privacy list update is sent to a single session. |
-| `[Host, modPrivacySets]` | spiral | IQ privacy `set` is processed. |
-| `[Host, modPrivacySetsActive]` | spiral | Active privacy list is changed. |
-| `[Host, modPrivacySetsDefault]` | spiral | Default privacy list is changed. |
-| `[Host, modPrivacyStanzaAll]` | spiral | A packet is checked against the privacy list. |
-| `[Host, modPrivacyStanzaDenied]` | spiral | Privacy list check resulted in `deny`. |
-| `[Host, modPrivacyStanzaBlocked]` | spiral | Privacy list check resulted in `block`. |
+| `[HostType, modPrivacyGets]` | spiral | IQ privacy `get` is processed. |
+| `[HostType, modPrivacyPush]` | spiral | Privacy list update is sent to a single session. |
+| `[HostType, modPrivacySets]` | spiral | IQ privacy `set` is processed. |
+| `[HostType, modPrivacySetsActive]` | spiral | Active privacy list is changed. |
+| `[HostType, modPrivacySetsDefault]` | spiral | Default privacy list is changed. |
+| `[HostType, modPrivacyStanzaAll]` | spiral | A packet is checked against the privacy list. |
+| `[HostType, modPrivacyStanzaDenied]` | spiral | Privacy list check resulted in `deny`. |
+| `[HostType, modPrivacyStanzaBlocked]` | spiral | Privacy list check resulted in `block`. |
 
 ### Other
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| `[Host, sessionAuthFails]` | spiral | A client failed to authenticate. |
-| `[Host, sessionCount]` | counter | Number of active sessions. |
-| `[Host, sessionLogouts]` | spiral | A client session is closed. |
-| `[Host, sessionSuccessfulLogins]` | spiral | A client session is opened. |
-| `[Host, xmppErrorIq]` | spiral | An `error` IQ is sent to a client. |
-| `[Host, xmppErrorMessage]` | spiral | An `error` message is sent to a client. |
-| `[Host, xmppErrorPresence]` | spiral | An `error` presence is sent to a client. |
-| `[Host, xmppErrorTotal]` | spiral | A stanza with `error` type is routed. |
-| `[Host, xmppMessageBounced]` | spiral | A `service-unavailable` error is sent, because the message recipient if offline. |
-| `[Host, xmppIqSent]` | spiral | An IQ is sent by a client. |
-| `[Host, xmppMessageSent]` | spiral | A message is sent by a client |
-| `[Host, xmppPresenceSent]` | spiral | A presence is sent by a client. |
-| `[Host, xmppStanzaSent]` | spiral | A stanza is sent by a client. |
-| `[Host, xmppIqReceived]` | spiral | An IQ is sent to a client. |
-| `[Host, xmppMessageReceived]` | spiral | A message is sent to a client. |
-| `[Host, xmppPresenceReceived]` | spiral | A presence is sent to a client. |
-| `[Host, xmppStanzaReceived]` | spiral | A stanza is sent to a client. |
-| `[Host, xmppStanzaCount]` | spiral | A stanza is sent to a client. |
-| `[Host, xmppStanzaDropped]` | spiral | A stanza is dropped due to an AMP rule or a `filter_packet` processing flow. |
+| `[HostType, sessionAuthFails]` | spiral | A client failed to authenticate. |
+| `[HostType, sessionCount]` | counter | Number of active sessions. |
+| `[HostType, sessionLogouts]` | spiral | A client session is closed. |
+| `[HostType, sessionSuccessfulLogins]` | spiral | A client session is opened. |
+| `[HostType, xmppErrorIq]` | spiral | An `error` IQ is sent to a client. |
+| `[HostType, xmppErrorMessage]` | spiral | An `error` message is sent to a client. |
+| `[HostType, xmppErrorPresence]` | spiral | An `error` presence is sent to a client. |
+| `[HostType, xmppErrorTotal]` | spiral | A stanza with `error` type is routed. |
+| `[HostType, xmppMessageBounced]` | spiral | A `service-unavailable` error is sent, because the message recipient if offline. |
+| `[HostType, xmppIqSent]` | spiral | An IQ is sent by a client. |
+| `[HostType, xmppMessageSent]` | spiral | A message is sent by a client |
+| `[HostType, xmppPresenceSent]` | spiral | A presence is sent by a client. |
+| `[HostType, xmppStanzaSent]` | spiral | A stanza is sent by a client. |
+| `[HostType, xmppIqReceived]` | spiral | An IQ is sent to a client. |
+| `[HostType, xmppMessageReceived]` | spiral | A message is sent to a client. |
+| `[HostType, xmppPresenceReceived]` | spiral | A presence is sent to a client. |
+| `[HostType, xmppStanzaReceived]` | spiral | A stanza is sent to a client. |
+| `[HostType, xmppStanzaCount]` | spiral | A stanza is sent to a client. |
+| `[HostType, xmppStanzaDropped]` | spiral | A stanza is dropped due to an AMP rule or a `filter_packet` processing flow. |
 
 ### Extension-specific metrics
 
@@ -185,10 +185,10 @@ The latter is a number of calls (spiral metric), incremented for *every* call (e
 
 Besides these, following authentication metrics are always available:
 
-* `[Host, backends, auth, authorize]`
-* `[Host, backends, auth, check_password]`
-* `[Host, backends, auth, try_register]`
-* `[Host, backends, auth, does_user_exist]`
+* `[HostType, backends, auth, authorize]`
+* `[HostType, backends, auth, check_password]`
+* `[HostType, backends, auth, try_register]`
+* `[HostType, backends, auth, does_user_exist]`
 
 These are **total** times of respective operations.
 One operation usually requires only a single call to an auth backend but sometimes with e.g. 3 backends configured, the operation may fail for first 2 backends.
@@ -196,5 +196,5 @@ In such case, these metrics will be updated with combined time of 2 failed and 1
 
 Additionally, the RDBMS layer in MongooseIM exposes two more metrics, if RDBMS is configured:
 
-* `[global, backends, mongoose_rdbms, query]` - Execution time of a "simple"" (not prepared) query by a DB driver.
+* `[global, backends, mongoose_rdbms, query]` - Execution time of a "simple" (not prepared) query by a DB driver.
 * `[global, backends, mongoose_rdbms, execute]` - Execution time of a prepared query by a DB driver.

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -7,11 +7,11 @@ MongooseIM uses [ESL's fork of this project](https://github.com/esl/exometer/tre
 All metrics are divided into the following groups:
 
 * Per host type metrics: Gathered separately for every host type supported by the cluster.
- **Warning:** If a cluster supports many (thousands or more) domains, performance issues might occur.
+ **Warning:** If a cluster supports many (thousands or more) host types, performance issues might occur.
  To avoid this, use global equivalents of the metrics with `all_metrics_are_global` config option.
     * Hook metrics.
     They are created for every [hook](../developers-guide/Hooks-and-handlers.md) and incremented on every call to it.
-* Global metrics: Metrics common for all XMPP hosts.
+* Global metrics: Metrics common for all host types.
     * Data metrics.
     These are misc. metrics related to data transfers (e.g. sent and received stanza size statistics).
     * VM metrics. Basic Erlang VM statistics.

--- a/doc/rest-api/Metrics-backend.md
+++ b/doc/rest-api/Metrics-backend.md
@@ -1,12 +1,12 @@
 ## Introduction
 
 **Warning:** This API is considered obsolete.
-Please use WombatOAM for monitoring or one of the [exometer reporters](../operation-and-maintenance/Logging-&-monitoring.md#monitoring) and your favourite statistics service.
+Please use [WombatOAM](https://www.erlang-solutions.com/capabilities/wombatoam/) for monitoring or one of the [exometer reporters](../operation-and-maintenance/Logging-&-monitoring.md#monitoring) and your favourite statistics service.
 
 To expose MongooseIM metrics, an adequate endpoint must be included in the [listen](../advanced-configuration/listen.md)
 section of `mongooseim.toml`. The specific configuration options are described in
 the [metrics API handlers](../advanced-configuration/listen.md#handler-types-metrics-api-obsolete-mongoose_api)
-section. 
+section.
 
 An example configuration:
 

--- a/doc/rest-api/Metrics-backend.md
+++ b/doc/rest-api/Metrics-backend.md
@@ -61,7 +61,7 @@ Example response:
 
 Returns ```200 OK``` and two elements:
 
-* `hosts` - A list of XMPP host names available on the server.
+* `host_types` - A list of host type names available on the server.
 * `metrics` - A list of per-host metrics.
 * `global` - A list of global metrics.
 
@@ -69,31 +69,31 @@ Returns ```200 OK``` and two elements:
 
 Returns ```200 OK``` and an element:
 
-* `metrics` - A list of aggregated (sum of all domains) per-host metrics with their values.
+* `metrics` - A list of aggregated (sum of all domains) per host type metrics with their values.
 
 ### GET /api/metrics/all/:metric
 
 On success returns ```200 OK``` and an element:
 
-* `metric` - An aggregated (sum of all domains) per-host metric.
+* `metric` - An aggregated (sum of all domains) per host type metric.
 
 Returns ```404 Not Found``` when metric `:metric` doesn't exist.
 
-### GET /api/metrics/host/:host
+### GET /api/metrics/host_type/:host_type
 
 On success returns ```200 OK``` and an element:
 
-* `metrics` - A list of per-host metrics and their values for host `:host`.
+* `metrics` - A list of per host type metrics and their values for host_type `:host_type`.
 
-Returns ```404 Not Found``` when host `:host` doesn't exist.
+Returns ```404 Not Found``` when host_type `:host_type` doesn't exist.
 
-### GET /api/metrics/host/:host/:metric
+### GET /api/metrics/host_type/:host_type/:metric
 
 On success returns ```200 OK``` and an element:
 
-* `metric` - A per-host metric `:metric` and its value for host `:host`.
+* `metric` - A per host type metric `:metric` and its value for host_type `:host_type`.
 
-Returns ```404 Not Found``` when the pair (host `:host`, metric `:metric`) doesn't exist.
+Returns ```404 Not Found``` when the pair (host_type `:host_type`, metric `:metric`) doesn't exist.
 
 ### GET /api/metrics/global
 

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -292,11 +292,9 @@ handle_call({unregister_host, Host}, _From, State) ->
      || #session{sid = {_, Pid}} <- ejabberd_sm:get_vh_session_list(Host),
         node(Pid) =:= Node],
     do_unregister_host(Host),
-    mongoose_metrics:remove_host_metrics(Host),
     {reply, ok, State};
 handle_call({register_host, Host}, _From, State) ->
     do_register_host(Host),
-    mongoose_metrics:init_predefined_host_metrics(Host),
     {reply, ok, State};
 handle_call(sync, _From, State) ->
     {reply, ok, State};

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -43,6 +43,7 @@
 binary_to_metric_atom(Binary) ->
     List = lists:filtermap(fun
                                ($.) -> {true, $_};
+                               ($ ) -> {true, $_};
                                (C) when C > 31, C < 127 -> {true, C};
                                (_) -> false
                            end,

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -60,7 +60,7 @@ init() ->
     lists:foreach(
         fun(Host) ->
             mongoose_metrics:init_predefined_host_metrics(Host)
-        end, ?MYHOSTS),
+        end, ?ALL_HOST_TYPES),
     init_subscriptions().
 
 create_global_metrics() ->
@@ -411,7 +411,7 @@ subscribe_metric(Reporter, {Name, _, _}, Interval) ->
     exometer_report:subscribe(Reporter, Name, default, Interval).
 
 subscribe_to_all(Reporter, Interval) ->
-    HostPrefixes = pick_by_all_metrics_are_global([], ?MYHOSTS),
+    HostPrefixes = pick_by_all_metrics_are_global([], ?ALL_HOST_TYPES),
     lists:foreach(
       fun(Prefix) ->
               start_metrics_subscriptions(Reporter, [Prefix], Interval)

--- a/test/carbon_cache_server.erl
+++ b/test/carbon_cache_server.erl
@@ -7,7 +7,7 @@
 start() ->
     case gen_tcp:listen(0,[{active, false},{packet,2}]) of
         {ok, ListenSock} ->
-            spawn(?MODULE,server,[ListenSock, self()]),
+            spawn(?MODULE, server, [ListenSock, self()]),
             {ok, Port} = inet:port(ListenSock),
             {Port, ListenSock};
         {error,Reason} ->

--- a/test/carbon_cache_server.erl
+++ b/test/carbon_cache_server.erl
@@ -1,24 +1,18 @@
 -module(carbon_cache_server).
 
--export([start/2]).
+-export([start/0]).
 -export([server/2]).
 -export([wait_for_accepting/0]).
 
-start(Num,LPort) ->
-    case gen_tcp:listen(LPort,[{active, false},{packet,2}]) of
+start() ->
+    case gen_tcp:listen(0,[{active, false},{packet,2}]) of
         {ok, ListenSock} ->
-            start_servers(Num,ListenSock),
+            spawn(?MODULE,server,[ListenSock, self()]),
             {ok, Port} = inet:port(ListenSock),
             {Port, ListenSock};
         {error,Reason} ->
             {error,Reason}
     end.
-
-start_servers(0,_) ->
-    ok;
-start_servers(Num,LS) ->
-    spawn(?MODULE,server,[LS, self()]),
-    start_servers(Num-1,LS).
 
 server(LS, Parent) ->
     Parent ! {accepting, self()},

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -81,8 +81,8 @@ init_per_group(Group, C) ->
     C.
 
 end_per_group(_Name, C) ->
-    mongoose_metrics:remove_host_metrics(<<"localhost">>),
-    mongoose_metrics:remove_host_metrics(global),
+    mongoose_metrics:remove_host_type_metrics(<<"localhost">>),
+    mongoose_metrics:remove_host_type_metrics(global),
     meck:unload(),
     C.
 

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -33,7 +33,7 @@ all_metrics_list() ->
 init_per_suite(C) ->
     application:load(exometer_core),
     application:set_env(exometer_core, mongooseim_report_interval, 1000),
-    {Port, Socket} = carbon_cache_server:start(1, 0),
+    {Port, Socket} = carbon_cache_server:start(),
     Sup = spawn(fun() ->
                         mim_ct_sup:start_link(ejabberd_sup),
                         Hooks =
@@ -159,6 +159,10 @@ wait_for_update({ok, [{count,0}]}, N) ->
 setup_meck(Group) ->
     meck:new(ejabberd_config, [no_link]),
     meck:expect(ejabberd_config, get_global_option, fun(hosts) -> [<<"localhost">>] end),
+    meck:expect(ejabberd_config, get_global_option_or_default,
+                fun (hosts, _Def) -> [<<"localhost">>];
+                    (_, _) -> []
+                end),
     meck:expect(ejabberd_config, get_local_option,
                 fun (all_metrics_are_global) -> Group =:= all_metrics_are_global;
                     (_) -> undefined

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -60,6 +60,7 @@ init_per_suite(C) ->
     Reporters = get_reporters_cfg(Port),
     application:set_env(exometer_core, report, Reporters),
     PortServer = carbon_cache_server:wait_for_accepting(),
+    gen_tcp:controlling_process(Socket, PortServer),
     {ok, _Apps} = application:ensure_all_started(exometer_core),
     exometer:new([carbon, packets], spiral),
     [{carbon_port, Port}, {test_sup, Sup}, {carbon_server, PortServer}, {carbon_socket, Socket} | C].

--- a/tools/summarise-ct-results
+++ b/tools/summarise-ct-results
@@ -52,9 +52,11 @@ verify_results_with_groups(OkGroups, FailedGroups, EventuallyOkTests,
         AutoSkipped > 0 ->
             io:format("Failing the test due to auto skipped cases~n"),
             erlang:halt(AutoSkipped);
+        FailedGroups + FailedTests - EventuallyOkTests > 0 ->
+            io:format("Failing the test due to failed rerun groups~n"),
+            erlang:halt(FailedGroups + FailedTests - EventuallyOkTests);
         true ->
-            io:format("Failing the test due failed rerun groups~n"),
-            erlang:halt(FailedGroups + FailedTests - EventuallyOkTests)
+            erlang:halt(0)
     end.
 
 suite_summaries(Directories) ->


### PR DESCRIPTION
This PR updates the metrics to use host types instead of hosts. There are still some places left that use host types and should be updated when the modules are updated (for example `mongoose_wpool_rdbms`).

Because the host type may be any string, the spaces `" "` are changed to underscores `"_"` in the metrics modules in a simple manner on every call. Because of that, when calling functions like `mongoose_metrics:get_metric_value/1`, which expect the _metric name_, one has to provide a sanitized name - this is not needed when calling the metrics API expecting host types.

There are also some small fixes, like a bugfix for a test suite that occurred seemingly only on my computer, and getting rid of the "Failing the test due failed rerun groups" message that was printed even if the tests were successful.

