### PR TITLE
Format stacktrace args properly

### DIFF
--- a/src/logger/mongoose_log_filter.erl
+++ b/src/logger/mongoose_log_filter.erl
@@ -53,7 +53,11 @@ format_stacktrace_filter(Event=#{msg := {report, Msg=#{stacktrace := S}}}, _) ->
                <<>> -> Msg;
                _ -> Msg#{stacktrace_args => FmtArgs}
            end,
-    Event#{msg => {report, Msg2#{stacktrace => format_stacktrace(S)} }};
+    Msg3 = case format_stacktrace(S) of
+               <<>> -> Msg2;
+               FmtStack -> Msg2#{stacktrace => FmtStack}
+           end,
+    Event#{msg => {report, Msg3 }};
 format_stacktrace_filter(Event, _) ->
     Event.
 


### PR DESCRIPTION
This PR addresses ugly stacktraces.
Before:
```
"stacktrace":"ets:lookup/[prepared_statements,auth_list_users]:0 mongoose_rdbms:query_name_to_string/1:225 mongoose_rdbms:execute_successfully/3:217 ejabberd_auth_rdbms:get_vh_registered_users/2:206 lists:flatmap/2:1250 lists:flatmap/2:1250 rpc:'-handle_call_call/6-fun-0-'/5:197"
```

After:
```
"stacktrace_args":"[prepared_statements,auth_list_users]",
"stacktrace":"ets:lookup/2:0 mongoose_rdbms:query_name_to_string/1:225 mongoose_rdbms:execute_successfully/3:217 ejabberd_auth_rdbms:get_vh_registered_users/2:206 lists:flatmap/2:1250 lists:flatmap/2:1250 rpc:'-handle_call_call/6-fun-0-'/5:197"
```