### PR TITLE
adding multitenancy support for mod_carboncopy

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -11,7 +11,12 @@
 
 {suites, "tests", acc_e2e_SUITE}.
 
+{suites, "tests", carboncopy_SUITE}.
+{skip_cases, "tests", carboncopy_SUITE, [discovering_support],
+ "at the moment mod_disco doesn't support dynamic domains"}.
+
 {config, ["dynamic_domains.config", "test.config"]}.
+
 {logdir, "ct_report"}.
 
 %% ct_tty_hook will log CT failures to TTY verbosely

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -19,8 +19,8 @@
 
 [[host_config]]
   host_type = \"test type\"
-  modules = { }
-  auth = { methods = [\"dummy\"] }"}.
+  auth = { methods = [\"dummy\"] }
+  [host_config.modules.mod_carboncopy]"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
 {scram_iterations, 64}.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -129,7 +129,7 @@ start_modules() ->
                   Modules ->
                       gen_mod_deps:start_modules(Host, Modules)
               end
-      end, ?MYHOSTS).
+      end, ?ALL_HOST_TYPES).
 
 %% Stop all the modules in all the hosts
 -spec stop_modules() -> 'ok'.
@@ -146,7 +146,7 @@ stop_modules() ->
               Modules ->
                   lists:foreach(StopModuleFun, Modules)
           end
-      end, ?MYHOSTS).
+      end, ?ALL_HOST_TYPES).
 
 -spec start_services() -> ok.
 start_services() ->

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -39,8 +39,8 @@
 %% Hooks
 -export([user_send_packet/4,
          user_receive_packet/5,
-         iq_handler2/4,
-         iq_handler1/4,
+         iq_handler2/5,
+         iq_handler1/5,
          remove_connection/5
         ]).
 
@@ -67,34 +67,38 @@ is_carbon_copy(Packet) ->
         _ -> false
     end.
 
-start(Host, Opts) ->
+start(HostType, Opts) ->
     %% execute disable/enable actions in the c2s process itself
     IQDisc = gen_mod:get_opt(iqdisc, Opts, no_queue),
-    mod_disco:register_feature(Host, ?NS_CC_1),
-    mod_disco:register_feature(Host, ?NS_CC_2),
-    mod_disco:register_feature(Host, ?NS_CC_RULES),
-    ejabberd_hooks:add(unset_presence_hook, Host, ?MODULE, remove_connection, 10),
-    ejabberd_hooks:add(user_send_packet, Host, ?MODULE, user_send_packet, 89),
-    ejabberd_hooks:add(user_receive_packet, Host, ?MODULE, user_receive_packet, 89),
-    gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_CC_2, ?MODULE, iq_handler2, IQDisc),
-    gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_CC_1, ?MODULE, iq_handler1, IQDisc).
+    %% TODO: update code related to mod_disco
+    mod_disco:register_feature(HostType, ?NS_CC_1),
+    mod_disco:register_feature(HostType, ?NS_CC_2),
+    mod_disco:register_feature(HostType, ?NS_CC_RULES),
+    ejabberd_hooks:add(unset_presence_hook, HostType, ?MODULE, remove_connection, 10),
+    ejabberd_hooks:add(user_send_packet, HostType, ?MODULE, user_send_packet, 89),
+    ejabberd_hooks:add(user_receive_packet, HostType, ?MODULE, user_receive_packet, 89),
+    gen_iq_handler:add_iq_handler_for_domain(HostType, ?NS_CC_2, ejabberd_sm,
+                                             fun ?MODULE:iq_handler2/5, #{}, IQDisc),
+    gen_iq_handler:add_iq_handler_for_domain(HostType, ?NS_CC_1, ejabberd_sm,
+                                             fun ?MODULE:iq_handler1/5, #{}, IQDisc).
 
-stop(Host) ->
-    gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_CC_1),
-    gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, ?NS_CC_2),
-    mod_disco:unregister_feature(Host, ?NS_CC_2),
-    mod_disco:unregister_feature(Host, ?NS_CC_1),
-    ejabberd_hooks:delete(user_send_packet, Host, ?MODULE, user_send_packet, 89),
-    ejabberd_hooks:delete(user_receive_packet, Host, ?MODULE, user_receive_packet, 89),
-    ejabberd_hooks:delete(unset_presence_hook, Host, ?MODULE, remove_connection, 10).
+stop(HostType) ->
+    gen_iq_handler:remove_iq_handler_for_domain(HostType, ?NS_CC_1, ejabberd_sm),
+    gen_iq_handler:remove_iq_handler_for_domain(HostType, ?NS_CC_2, ejabberd_sm),
+    %% TODO: update code related to mod_disco
+    mod_disco:unregister_feature(HostType, ?NS_CC_2),
+    mod_disco:unregister_feature(HostType, ?NS_CC_1),
+    ejabberd_hooks:delete(user_send_packet, HostType, ?MODULE, user_send_packet, 89),
+    ejabberd_hooks:delete(user_receive_packet, HostType, ?MODULE, user_receive_packet, 89),
+    ejabberd_hooks:delete(unset_presence_hook, HostType, ?MODULE, remove_connection, 10).
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc()}}.
 
-iq_handler2(From, _To, Acc, IQ) ->
+iq_handler2(Acc, From, _To, IQ, _Extra) ->
     iq_handler(Acc, From, IQ, ?NS_CC_2).
-iq_handler1(From, _To, Acc, IQ) ->
+iq_handler1(Acc, From, _To, IQ, _Extra) ->
     iq_handler(Acc, From, IQ, ?NS_CC_1).
 
 iq_handler(Acc, From, #iq{type = set,

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -33,6 +33,7 @@
 %% API
 -export([start/2,
          stop/1,
+         supported_features/0,
          config_spec/0,
          is_carbon_copy/1]).
 
@@ -55,6 +56,8 @@
 -include("mongoose_config_spec.hrl").
 
 -type direction() :: sent | received.
+
+supported_features() -> [dynamic_domains].
 
 is_carbon_copy(Packet) ->
     case xml:get_subtag(Packet, <<"sent">>) of


### PR DESCRIPTION
This PR introduces dynamic domains support for mod_carboncopy.
Service discovery doesn't work for dynamic domains (as mod_disco doesn't support it yet), but still works correctly for statically configured domains

for a local testing you can use this command:
```
test-runner.sh --skip-small-tests --skip-cover --spec dynamic_domains.spec --preset pgsql_mnesia -- carboncopy
test-runner.sh --skip-small-tests --skip-cover --preset pgsql_mnesia -- carboncopy
```