### PR TITLE
Make dummy auth delays configurable

### DIFF
--- a/doc/authentication-methods/dummy.md
+++ b/doc/authentication-methods/dummy.md
@@ -2,12 +2,36 @@
 
 The purpose of this method is to make it possible to authenticate a user without
 the need for real authentication. In other words, using this module allows to
-connect any user to the server without providing any password,
-certificate, etc.
+connect any user to the server without providing any password, certificate, etc.
 
-From a more detailed perspective, the backend just accepts every
-authentication attempt and introduces a random delay (50-500ms) to
-an authorization response.
+This kind of authorization sometimes really comes in handy, especially during development and testing.
 
-This kind of authorization sometimes really comes in handy, especially during
-development and testing.
+The backend just accepts every authentication attempt and introduces a random delay (50-500ms) to an authorization response. The delay works like
+```erlang
+    timer:sleep(Base + rand:uniform(Variance)),
+```
+where `Base` is `base_time` and `Variance` is `variance`, as configured below.
+
+## Configuration
+
+### `auth.dummy.base_time`
+* **Scope:** local
+* **Syntax:** integer
+* **Default:** 50
+* **Example:** `base_time = 5`
+
+### `auth.dummy.variance`
+* **Scope:** local
+* **Syntax:** integer
+* **Default:** 450
+* **Example:** `variance = 10`
+
+### Example
+
+```toml
+[auth]
+  methods = ["dummy"]
+  dummy.base = 5
+  dummy.variance = 10
+```
+

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -19,7 +19,9 @@
 
 [[host_config]]
   host_type = \"test type\"
-  auth = { methods = [\"dummy\"] }
+  auth.methods = [\"dummy\"]
+  auth.dummy.base_time = 1
+  auth.dummy.variance = 5
   [host_config.modules.mod_carboncopy]"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -36,7 +36,10 @@ stop(_HostType) ->
     ok.
 
 authorize(Creds) ->
-    timer:sleep(50 + rand:uniform(450)),
+    HostType = mongoose_credentials:host_type(Creds),
+    Base = ejabberd_auth:get_opt(HostType, dummy_base_timeout, 50),
+    Variance = ejabberd_auth:get_opt(HostType, dummy_variance, 450),
+    timer:sleep(Base + rand:uniform(Variance)),
     {ok, mongoose_credentials:set(Creds, auth_module, ?MODULE)}.
 
 check_password(_HostType, _User, _Server, _Password) ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -490,7 +490,8 @@ auth() ->
                  <<"jwt">> => auth_jwt(),
                  <<"ldap">> => auth_ldap(),
                  <<"riak">> => auth_riak(),
-                 <<"rdbms">> => auth_rdbms()},
+                 <<"rdbms">> => auth_rdbms(),
+                 <<"dummy">> => auth_dummy()},
        process = fun ?MODULE:process_auth/1,
        format = {foreach, host_local_config}
       }.
@@ -642,6 +643,17 @@ auth_rdbms() ->
     #section{
        items = #{<<"users_number_estimate">> => #option{type = boolean,
                                                         format = {kv, rdbms_users_number_estimate}}
+                },
+       format = none
+      }.
+
+%% path: (host_config[].)auth.dummy
+auth_dummy() ->
+    #section{
+       items = #{<<"base_time">> => #option{type = integer,
+                                            format = {kv, dummy_base_timeout}},
+                 <<"variance">> => #option{type = integer,
+                                           format = {kv, dummy_variance}}
                 },
        format = none
       }.


### PR DESCRIPTION
This makes the delays configurable, which by default are too long and that's something that can be noticed in CI.