### PR TITLE
Safer CT hook error handling

### DIFF
--- a/big_tests/src/ct_tty_hook.erl
+++ b/big_tests/src/ct_tty_hook.erl
@@ -81,9 +81,12 @@ post_end_per_group(Group,_Config,Return,State) ->
     {Return, State}.
 
 %% @doc Called before each test case.
-pre_init_per_testcase(TC,Config,State) ->
+pre_init_per_testcase(TC,Config,State = #state{suite_total = Total})
+      when is_integer(Total) ->
     print_case_enter(TC, State, "Starting"),
-    {Config, State#state{ ts = os:timestamp(), total = State#state.suite_total + 1 } }.
+    {Config, State#state{ ts = os:timestamp(), total = Total + 1 } };
+pre_init_per_testcase(TC, Config, State) ->
+    {Config, State}.
 
 %% @doc Called after each test case.
 post_end_per_testcase(TC, _Config, Return, State) ->


### PR DESCRIPTION
When I was testing suites, I was generating errors from all/0 and groups/0 callbacks. And CT works really strange and not informative.

Two problems:
- it does not print the error, just "location is unknown"
- it passes that error to CT hooks, and that's why this PR.


Before CTH was crashing when handling SUITE crash during the init:

```
*** CT 2021-05-24 12:32:43.391 *** Suite Hook
Call to CTH failed: error:{{test_case_failed,
                               {open_file_failed,'test@Mikhails-MacBook-Pro',
                                   "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/ct_report/ct_run.test@Mikhails-MacBook-Pro.2021-05-24_12.32.42/undefined/../../../mongooseim@localhost.log.html",
                                   {error,enoent}}},
                           [{ct_mongoose_log_hook,ensure_initialized,2,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/src/ct_mongoose_log_hook.erl"},
                                 {line,176}]},
                            {ct_mongoose_log_hook,pre_init_per_testcase,3,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/src/ct_mongoose_log_hook.erl"},
                                 {line,81}]},
                            {ct_hooks,catch_apply,3,
                                [{file,"ct_hooks.erl"},{line,491}]},
                            {ct_hooks,do_call_generic,4,
                                [{file,"ct_hooks.erl"},{line,247}]},
                            {ct_hooks,call,4,
                                [{file,"ct_hooks.erl"},{line,301}]},
                            {ct_hooks,call,4,
                                [{file,"ct_hooks.erl"},{line,304}]},
                            {ct_hooks,call,3,
                                [{file,"ct_hooks.erl"},{line,257}]}]}

*** CT 2021-05-24 12:32:43.391 *** Suite Hook
Call to CTH failed: error:{function_clause,
                           [{proplists,get_value,
                             [priv_dir,
                              {fail,
                               "ct_mongoose_log_hook:pre_init_per_testcase/3 CTH call failed"},
                              undefined],
                             [{file,"proplists.erl"},{line,215}]},
                            {ct_mongoose_log_hook,keep_priv_dir,2,
                             [{file,
                               "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/src/ct_mongoose_log_hook.erl"},
                              {line,193}]},
                            {ct_mongoose_log_hook,pre_init_per_testcase,3,
                             [{file,
                               "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/src/ct_mongoose_log_hook.erl"},
                              {line,80}]},
                            {ct_hooks,catch_apply,3,
                             [{file,"ct_hooks.erl"},{line,491}]},
                            {ct_hooks,do_call_generic,4,
                             [{file,"ct_hooks.erl"},{line,247}]},
                            {ct_hooks,call,4,
                             [{file,"ct_hooks.erl"},{line,301}]},
                            {ct_hooks,call,4,
                             [{file,"ct_hooks.erl"},{line,304}]},
                            {ct_hooks,call,3,
                             [{file,"ct_hooks.erl"},{line,257}]}]}

*** CT Error Notification 2021-05-24 12:32:43.391 ***
Error detected: 'mam_SUITE:groups/0 failed'

Full error description and stacktrace

=== Ended at 2021-05-24 12:32:43
=== Location: unknown
=== === Reason: 'mam_SUITE:groups/0 failed'
```

After it is not crashing in the handler. Theoretically, it allows CT to fail with the origin SUITE error, but CT is broken, so it just **eats the original error location anyway.** We should go and fix it in otp upstream, probably it got broken during introducing line numbering.
