### PR TITLE
Remove check_carboncopy CT hook

### DIFF
--- a/big_tests/src/ct_mongoose_hook.erl
+++ b/big_tests/src/ct_mongoose_hook.erl
@@ -141,8 +141,7 @@ do_check_server_purity(_Suite) ->
             fun check_privacy/0,
             fun check_private/0,
             fun check_vcard/0,
-            fun check_roster/0,
-            fun check_carboncopy/0],
+            fun check_roster/0],
     lists:flatmap(fun(F) -> F() end, Funs).
 
 check_sessions() ->
@@ -187,26 +186,11 @@ check_vcard() ->
 check_roster() ->
     generic_via_mongoose_helper(total_roster_items).
 
-check_carboncopy() ->
-    D = ct:get_config({hosts, mim, domain}),
-    case rpc(mim(), gen_mod, is_loaded, [D, mod_carboncopy]) of
-        true ->
-            do_check_carboncopy();
-        _ ->
-            []
-    end.
-
 generic_via_mongoose_helper(Function) ->
     case mongoose_helper:Function() of
         0 -> [];
         false -> [];
         N -> [{Function, N}]
-    end.
-
-do_check_carboncopy() ->
-    case rpc(mim(), ets, tab2list, [carboncopy]) of
-        [] -> [];
-        L -> [{remaining_carbon_copy_settings, L}]
     end.
 
 mim_domains() ->


### PR DESCRIPTION
This PR removes the `Suite ... finished dirty.` messages appearing when running the tests. They appeared because of a failing common test hook.
This hook is a leftover from when `mod_carboncopy` was using its own mnesia table. See commit e0b1d9d8746e2de3ef137a21772f4bacf20d85f3 in which it was removed for details. It is safe to remove this hook, as other hooks like `check_sessions` or `check_registered_users` together with using escalus fresh stories should already ensure that no user configuration leaks between the test groups.

