### PR TITLE
Better error reporting

### DIFF
--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -287,7 +287,7 @@ room_is_created(Config) ->
 
 room_is_created_with_given_identifier(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        GivenRoomID = <<"just_an_id">>,
+        GivenRoomID = muc_helper:fresh_room_name(),
         GivenRoomID = given_new_room({alice, Alice}, GivenRoomID),
         RoomInfo = get_room_info({alice, Alice}, GivenRoomID),
         assert_room_info(Alice, RoomInfo)
@@ -295,7 +295,7 @@ room_is_created_with_given_identifier(Config) ->
 
 config_can_be_changed_by_owner(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        RoomID = <<"som_othere_id">>,
+        RoomID = muc_helper:fresh_room_name(),
         RoomJID = room_jid(RoomID, Config),
         RoomID = given_new_room({alice, Alice}, RoomJID, <<"old_name">>),
         RoomInfo = get_room_info({alice, Alice}, RoomID),
@@ -522,7 +522,7 @@ messages_can_be_paginated_in_room(Config) ->
 
 room_is_created_with_given_jid(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        RoomID = <<"some_id">>,
+        RoomID = muc_helper:fresh_room_name(),
         RoomJID = room_jid(RoomID, Config),
         RoomID = given_new_room({alice, Alice}, RoomJID),
         RoomInfo = get_room_info({alice, Alice}, RoomID),
@@ -531,7 +531,7 @@ room_is_created_with_given_jid(Config) ->
 
 room_is_not_created_with_jid_not_matching_hostname(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        RoomID = <<"some_id">>,
+        RoomID = muc_helper:fresh_room_name(),
         RoomJID = <<RoomID/binary, "@muclight.wrongdomain">>,
         Creds = credentials({alice, Alice}),
         {{Status, _}, _} = create_room_with_id_request(Creds,
@@ -543,7 +543,7 @@ room_is_not_created_with_jid_not_matching_hostname(Config) ->
 
 room_can_be_fetched_by_jid(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        RoomID = <<"yet_another_id">>,
+        RoomID = muc_helper:fresh_room_name(),
         RoomJID = room_jid(RoomID, Config),
         RoomID = given_new_room({alice, Alice}, RoomJID),
         RoomInfo = get_room_info({alice, Alice}, RoomJID),

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -216,7 +216,7 @@ random_request_id() ->
 
 report_errors(Client, Path, Method, Headers, Body,
               {{CodeBin, _} = RCode, _RHeaders, _RBody, _, _} = Result) ->
-    Code = list_to_integer(binary_to_list(CodeBin)),
+    Code = binary_to_integer(CodeBin),
     case Code >= 400 of
         true ->
             Req = {Client, Path, Method, Headers, Body},

--- a/doc/operation-and-maintenance/Logging-fields.md
+++ b/doc/operation-and-maintenance/Logging-fields.md
@@ -49,12 +49,13 @@ Timestamp should be ordered first when possible, so that sorting is automatic.
 | port          | integer | TCP/UDP port number                                 | 5222                                |                                    |
 | peer          | tuple   | `peer() :: {inet:ip_address(), inet:port_number()}` | `{{127,0,0,1},5222}`                |                                    |
 | req           | map     | Cowboy request                                      |                                     | Provide when available             |
+| reply_body    | binary  | Body reply                                          | <<"ok">>                            |                                    |
 
 ## XMPP
 
 | Name          | Type    | Description                                         | Examples                            | Notes                              |
 |---------------|---------|-----------------------------------------------------|-------------------------------------|------------------------------------|
-| acc           | map     | Accumulator, that would be used by formatter        | `#{...}`                            |                                    |
+| acc           | map     | mongoose_acc, used to extract fields                | `#{...}`                            |                                    |
 | user          | binary  | Local Username                                      | `<<"alice">>`                       | Use `#jid.luser` when available    |
 | server        | binary  | Local Server (host) name                            | `<<"localhost">>`                   | Use `#jid.lserver` when available  |
 | sub_host      | binary  | Subhost when MUC or pubsub are used                 | `<<"muc.localhost">>`               | It's not the same as `server`      |

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -10,8 +10,8 @@
     {filters, log, [
            %% If we want to see complete accumulator in logs
         %  {preserve_acc_filter, {fun mongoose_log_filter:preserve_acc_filter/2, no_state}},
-           %% Cowboy acc can leak some privacy data. So, we drop it from logs by default.
-           {remove_fields_filter, {fun mongoose_log_filter:remove_fields_filter/2, [cowboy_acc]}},
+           %% cowboy_req can leak some privacy data. So, we drop it from logs by default.
+           {remove_fields_filter, {fun mongoose_log_filter:remove_fields_filter/2, [req, reply_body]}},
            {format_packet_filter, {fun mongoose_log_filter:format_packet_filter/2, no_state}},
            {format_acc_filter, {fun mongoose_log_filter:format_acc_filter/2, no_state}},
            {format_c2s_state_filter, {fun mongoose_log_filter:format_c2s_state_filter/2, no_state}},

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -10,6 +10,8 @@
     {filters, log, [
            %% If we want to see complete accumulator in logs
         %  {preserve_acc_filter, {fun mongoose_log_filter:preserve_acc_filter/2, no_state}},
+           %% Cowboy acc can leak some privacy data. So, we drop it from logs by default.
+           {remove_fields_filter, {fun mongoose_log_filter:remove_fields_filter/2, [cowboy_acc]}},
            {format_packet_filter, {fun mongoose_log_filter:format_packet_filter/2, no_state}},
            {format_acc_filter, {fun mongoose_log_filter:format_acc_filter/2, no_state}},
            {format_c2s_state_filter, {fun mongoose_log_filter:format_c2s_state_filter/2, no_state}},

--- a/src/domain/mongoose_lazy_routing.erl
+++ b/src/domain/mongoose_lazy_routing.erl
@@ -408,9 +408,12 @@ check_that_domain_and_iq_match({#iq_table_key{host_type = HostType,
                                {_, {HostType, Pattern}}) when is_binary(Namespace),
                                                               Component =/= '_' ->
     true;
-check_that_domain_and_iq_match(IQ, Domain) ->
+check_that_domain_and_iq_match({Key = #iq_table_key{}, _} = IQEntry, Domain) ->
     %% we should not get here, log error
-    ?LOG_ERROR(#{what => domain_and_iq_doesnt_match, domain => Domain, iq => IQ}),
+    ?LOG_ERROR(#{what => domain_and_iq_doesnt_match, domain => Domain,
+                 iq_entry => IQEntry,
+                 iq_key_record => mongoose_record_pp:format(Key,
+                    iq_table_key, record_info(fields, iq_table_key))}),
     false.
 
 -spec register_iq(iq_entry(), domain_entry()) -> ok.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2276,7 +2276,8 @@ process_privacy_iq(Acc1, To, StateData) ->
             From = mongoose_acc:from_jid(Acc2),
             {Acc3, NewStateData} = process_privacy_iq(Acc2, Type, To, StateData),
             Res = mongoose_acc:get(hook, result,
-                                   {error, mongoose_xmpp_errors:feature_not_implemented()}, Acc3),
+                                   {error, mongoose_xmpp_errors:feature_not_implemented(
+                                             <<"en">>, <<"Failed to handle the privacy IQ request in c2s">>)}, Acc3),
             IQRes = case Res of
                         {result, Result} ->
                             IQ#iq{type = result, sub_el = Result};

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -114,7 +114,9 @@ process_iq(#iq{ xmlns = XMLNS } = IQ, Acc, From, To, _El) ->
         [{_, IQHandler}] ->
             gen_iq_component:handle(IQHandler, Acc, From, To, IQ);
         [] ->
-            ejabberd_router:route_error_reply(To, From, Acc, mongoose_xmpp_errors:feature_not_implemented())
+            T = <<"Local server does not implement this feature">>,
+            ejabberd_router:route_error_reply(To, From, Acc,
+                mongoose_xmpp_errors:feature_not_implemented(<<"en">>, T))
     end;
 process_iq(_, Acc, From, To, El) ->
     {Acc1, Err} = jlib:make_error_reply(Acc, El, mongoose_xmpp_errors:bad_request()),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -306,7 +306,8 @@ check_in_subscription(Acc, ToJID, _FromJID, _Type, _Reason) ->
       Packet :: exml:element().
 bounce_offline_message(Acc, From, To, Packet) ->
     Acc1 = mongoose_hooks:xmpp_bounce_message(Acc),
-    {Acc2, Err} = jlib:make_error_reply(Acc1, Packet, mongoose_xmpp_errors:service_unavailable()),
+    E = mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Bounce offline message">>),
+    {Acc2, Err} = jlib:make_error_reply(Acc1, Packet, E),
     Acc3 = ejabberd_router:route(To, From, Acc2, Err),
     {stop, Acc3}.
 
@@ -750,7 +751,8 @@ do_route_offline(<<"iq">>, <<"error">>, _From, _To, Acc, _Packet) ->
 do_route_offline(<<"iq">>, <<"result">>, _From, _To, Acc, _Packet) ->
     Acc;
 do_route_offline(<<"iq">>, _, From, To, Acc, Packet) ->
-    {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
+    E = mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Route offline">>),
+    {Acc1, Err} = jlib:make_error_reply(Acc, Packet, E),
     ejabberd_router:route(To, From, Acc1, Err);
 do_route_offline(_, _, _, _, Acc, _) ->
     ?LOG_DEBUG(#{what => sm_packet_dropped, acc => Acc}),
@@ -830,8 +832,8 @@ route_message_by_type(_, From, To, Acc, Packet) ->
                     mongoose_hooks:failed_to_store_message(Acc)
             end;
         _ ->
-            {Acc1, Err} = jlib:make_error_reply(
-                Acc, Packet, mongoose_xmpp_errors:service_unavailable()),
+            E = mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"User not found">>),
+            {Acc1, Err} = jlib:make_error_reply(Acc, Packet, E),
             ejabberd_router:route(To, From, Acc1, Err)
     end.
 
@@ -972,8 +974,8 @@ process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
         [{_, IQHandler}] ->
             gen_iq_component:handle(IQHandler, Acc, From, To, IQ);
         [] ->
-            {Acc1, Err} = jlib:make_error_reply(
-                    Acc, Packet, mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Unknown xmlns">>)),
+            E = mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Unknown xmlns">>),
+            {Acc1, Err} = jlib:make_error_reply(Acc, Packet, E),
             ejabberd_router:route(To, From, Acc1, Err)
     end;
 process_iq(_, From, To, Acc, Packet) ->

--- a/src/logger/mongoose_log_filter.erl
+++ b/src/logger/mongoose_log_filter.erl
@@ -6,6 +6,7 @@
 -export([format_stacktrace_filter/2]).
 -export([format_term_filter/2]).
 -export([preserve_acc_filter/2]).
+-export([remove_fields_filter/2]).
 -export([filter_module/2]).
 
 -include("mongoose.hrl").
@@ -90,6 +91,12 @@ format_stanza_map(_) ->
 preserve_acc_filter(Event=#{msg := {report, Msg=#{acc := Acc}}}, _) ->
     Event#{msg => {report, Msg#{acc_original => format_term(Acc)}}};
 preserve_acc_filter(Event, _) ->
+    Event.
+
+remove_fields_filter(Event=#{msg := {report, Msg=#{}}}, FieldNames) ->
+    Msg2 = maps:without(FieldNames, Msg),
+    Event#{msg => {report, Msg2}};
+remove_fields_filter(Event, _) ->
     Event.
 
 

--- a/src/logger/mongoose_record_pp.erl
+++ b/src/logger/mongoose_record_pp.erl
@@ -1,0 +1,19 @@
+-module(mongoose_record_pp).
+-export([format/3]).
+
+format(Record, Name, FieldDefs) when element(1, Record) =:= Name ->
+    FieldVals = tl(tuple_to_list(Record)),
+    FieldKV = print_pairs(FieldVals, FieldDefs),
+    iolist_to_binary(["#", atom_to_list(Name), "{", FieldKV, "}"]);
+format(Other, _, _) ->
+    iolist_to_binary(io_lib:format("~500p", [Other])).
+
+print_pairs([Val], [Def]) ->
+    %% trailing comma
+    [pair(Val, Def)];
+print_pairs([Val | VRest], [Def | DRest]) ->
+    [pair(Val, Def), ", " | print_pairs(VRest, DRest)];
+print_pairs([], []) -> [].
+
+pair(Val, Def) ->
+    io_lib:format("~p = ~500p", [Def, Val]).

--- a/src/logger/mongoose_record_pp.erl
+++ b/src/logger/mongoose_record_pp.erl
@@ -1,6 +1,13 @@
+%% Pretty prints a record including field names.
+%% It's useful to print records with many fields.
 -module(mongoose_record_pp).
 -export([format/3]).
 
+%% Takes a record tuple, record name, and record_info(fields, Name)
+%% Returns `#state{field1 = Value, field2 = Value2}'.
+%% usage:
+%% `mongoose_record_pp:format(State, state, record_info(fields, state))'
+-spec format(tuple(), atom(), [atom()]) -> binary().
 format(Record, Name, FieldDefs) when element(1, Record) =:= Name ->
     FieldVals = tl(tuple_to_list(Record)),
     FieldKV = print_pairs(FieldVals, FieldDefs),

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -546,11 +546,11 @@ handle_error_iq(Acc, _Host, _To, _Action, IQ) ->
 return_error_iq(IQ, {Reason, {stacktrace, _Stacktrace}}) ->
     return_error_iq(IQ, Reason);
 return_error_iq(IQ, timeout) ->
-    {error, timeout, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:service_unavailable()]}};
+    {error, timeout, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Timeout in mod_mam_muc">>)]}};
 return_error_iq(IQ, item_not_found) ->
     {error, item_not_found, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:item_not_found()]}};
 return_error_iq(IQ, not_implemented) ->
-    {error, not_implemented, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:feature_not_implemented()]}};
+    {error, not_implemented, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:feature_not_implemented(<<"en">>, <<"From mod_mam_muc">>)]}};
 return_error_iq(IQ, missing_with_jid) ->
     Error =  mongoose_xmpp_errors:bad_request(<<"en">>,
                                <<"Limited set of queries allowed in the conversation mode.",

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -781,7 +781,8 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #state{host = Host} = State) ->
            ejabberd_router:route(To, From, jlib:iq_to_xml(Res));
         #iq{} ->
             ?LOG_INFO(#{what => muc_ignore_unknown_iq, acc => Acc}),
-            {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:feature_not_implemented()),
+            {Acc1, Err} = jlib:make_error_reply(Acc, Packet,
+                mongoose_xmpp_errors:feature_not_implemented(<<"en">>, <<"From mod_muc">>)),
             ejabberd_router:route(To, From, Acc1, Err);
         Other ->
             ?LOG_INFO(#{what => muc_failed_to_parse_iq, acc => Acc, reason => Other}),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4603,7 +4603,8 @@ route_iq(Acc, #routed_iq{iq = IQ = #iq{}, packet = Packet, from = From},
     %% Custom IQ, addressed to this room's JID.
     case mod_muc_iq:process_iq(Host, From, RoomJID, Acc, IQ) of
         {Acc1, error} ->
-            {Acc2, Err} = jlib:make_error_reply(Acc1, Packet, mongoose_xmpp_errors:feature_not_implemented()),
+            {Acc2, Err} = jlib:make_error_reply(Acc1, Packet,
+                mongoose_xmpp_errors:feature_not_implemented(<<"en">>, <<"From mod_muc_room">>)),
             ejabberd_router:route(RoomJID, From, Acc2, Err);
         _ -> ok
     end,

--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -328,7 +328,7 @@ error_response(ErrorType, Reason, Req, State) ->
                     Other -> list_to_binary(io_lib:format("~p", [Other]))
                 end,
     ?LOG_ERROR(#{what => rest_common_error,
-                 error_type => ErrorType, reason => Reason, cowboy_req => Req}),
+                 error_type => ErrorType, reason => Reason, req => Req}),
     Req1 = cowboy_req:reply(error_code(ErrorType), #{}, BinReason, Req),
     {stop, Req1, State}.
 

--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -327,6 +327,8 @@ error_response(ErrorType, Reason, Req, State) ->
                     L when is_list(L) -> list_to_binary(L);
                     Other -> list_to_binary(io_lib:format("~p", [Other]))
                 end,
+    ?LOG_ERROR(#{what => rest_common_error,
+                 error_type => ErrorType, reason => Reason, cowboy_req => Req}),
     Req1 = cowboy_req:reply(error_code(ErrorType), #{}, BinReason, Req),
     {stop, Req1, State}.
 

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -53,7 +53,7 @@ to_json(Req, User) ->
     {<<"{}">>, Req, User}.
 
 bad_request(Req, State) ->
-    bad_request(Req, <<"Bad request without a reason">>, State).
+    bad_request(Req, <<"Bad request. The details are unknown.">>, State).
 
 bad_request(Req, Reason, State) ->
     reply(400, Req, Reason, State).

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -81,8 +81,7 @@ set_resp_body_if_missing(Body, Req) ->
 maybe_report_error(StatusCode, Req, Body) when StatusCode >= 400 ->
     ?LOG_WARNING(#{what => reply_error,
                    stacktrace => element(2, erlang:process_info(self(), current_stacktrace)),
-                   status_code => StatusCode,
-                   cowboy_req => Req, body => Body});
+                   code => StatusCode, req => Req, reply_body => Body});
 maybe_report_error(_StatusCode, _Req, _Body) ->
     ok.
 

--- a/src/mongoose_client_api/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms.erl
@@ -181,6 +181,6 @@ validate_room_id(RoomIDOrJID, Server, Req) ->
                            text => <<"REST received room_id field is invalid "
                                      "or of unknown format">>,
                            server => Server, room => RoomIDOrJID, reason => Other,
-                           cowboy_req => Req}),
+                           req => Req}),
             error
     end.


### PR DESCRIPTION
This PR addresses "We have too many places that can return 503 error".

Proposed changes include:
* Add text to errors, so we can know where it comes from.
* REST API logs the errors. We are not concerned with cleaning up creds from cowboy_req in this PR, it's a big task on its own and can be done in one log filter.
* debugging helpers for gen_mod.