### PR TITLE
GDPR get data takes host type as a parameter

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -1553,10 +1553,7 @@ data_is_not_retrieved_for_missing_user(Config) ->
 %% -------------------------------------------------------------
 
 domain() ->
-    <<"localhost">>. % TODO: Make dynamic?
-
-muc_domain() ->
-    muc_helper:muc_host().
+    ct:get_config({hosts, mim, domain}).
 
 assert_personal_data_via_rpc(Client, ExpectedPersonalDataEntries) ->
     ExpectedKeys = [ Key || {Key, _, _} <- ExpectedPersonalDataEntries ],

--- a/doc/migrations/4.2.0_4.3.0.md
+++ b/doc/migrations/4.2.0_4.3.0.md
@@ -94,6 +94,10 @@ GO
 - `muc_room_pid` hook removed.
 - `load_permanent_rooms_at_startup` option is ignored now.
 - `gen_mod:get_module_opt_by_subhost` API removed.
+- `update_inbox_for_muc` is called for HostType.
+- `get_mam_muc_gdpr_data` is called for HostType.
+- `get_mam_pm_gdpr_data` is called for HostType.
+- `get_personal_data` handlers take an extra argument: `HostType` as the second parameter.
 
 ## Metrics REST API (obsolete)
 

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -19,7 +19,7 @@
 -include("mongoose_logger.hrl").
 -include("mongoose_ns.hrl").
 
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 %% gen_mod
 -export([start/2]).
@@ -118,8 +118,9 @@
 %%--------------------------------------------------------------------
 %% gdpr callbacks
 %%--------------------------------------------------------------------
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ luser = LUser, lserver = LServer }) ->
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) ->
+    gdpr:personal_data().
+get_personal_data(Acc, _HostType, #jid{luser = LUser, lserver = LServer}) ->
     Schema = ["jid", "content", "unread_count", "timestamp"],
     InboxParams = #{
         start => 0,

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -53,7 +53,7 @@
          sm_filter_offline_message/4]).
 
 %% gdpr callbacks
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 %%private
 -export([archive_message_from_ct/1]).
@@ -160,9 +160,9 @@
 %% ----------------------------------------------------------------------
 %% API
 
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{} = ArcJID) ->
-    HostType = jid_to_host_type(ArcJID),
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) ->
+    gdpr:personal_data().
+get_personal_data(Acc, HostType, ArcJID) ->
     Schema = ["id", "from", "message"],
     Entries = mongoose_hooks:get_mam_pm_gdpr_data(HostType, ArcJID),
     [{mam_pm, Schema, Entries} | Acc].

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -48,7 +48,7 @@
          forget_room/4]).
 
 %% gdpr callback
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 %% private
 -export([archive_message_for_ct/1]).
@@ -109,10 +109,11 @@
 %% ----------------------------------------------------------------------
 %% API
 
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ lserver = LServer } = JID) ->
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) ->
+    gdpr:personal_data().
+get_personal_data(Acc, HostType, ArcJID) ->
     Schema = ["id", "message"],
-    Entries = mongoose_hooks:get_mam_muc_gdpr_data(LServer, JID),
+    Entries = mongoose_hooks:get_mam_muc_gdpr_data(HostType, ArcJID),
     [{mam_muc, Schema, Entries} | Acc].
 
 -spec delete_archive(jid:server(), jid:user()) -> ok.

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -462,10 +462,10 @@ handle_call({create_instant, ServerHost, MucHost, Room, From, Nick, Opts},
               end,
     try
         {ok, Pid} = mod_muc_room:start_new(HostType,
-                  MucHost, ServerHost, Access,
-                  Room, HistorySize,
-                  RoomShaper, HttpAuthPool, From,
-          Nick, [{instant, true}|NewOpts]),
+                                           MucHost, ServerHost, Access,
+                                           Room, HistorySize,
+                                           RoomShaper, HttpAuthPool, From,
+                                           Nick, [{instant, true}|NewOpts]),
         register_room_or_stop_if_duplicate(HostType, MucHost, Room, Pid),
         {reply, ok, State}
     catch Class:Reason:Stacktrace ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -131,6 +131,7 @@
 
 
 -type update_inbox_for_muc_payload() :: #{
+        host_type := mongooseim:host_type(),
         room_jid := jid:jid(),
         from_jid := jid:jid(),
         from_room_jid := jid:jid(),
@@ -880,12 +881,13 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
     RouteFrom = jid:replace_resource(StateData#state.jid,
                                      FromNick),
     RoomJid = StateData#state.jid,
-    HookInfo = #{room_jid => RoomJid,
+    HookInfo = #{host_type => StateData#state.host_type,
+                 room_jid => RoomJid,
                  from_jid => From,
                  from_room_jid => RouteFrom,
                  packet => FilteredPacket,
                  affiliations_map => StateData#state.affiliations},
-    run_update_inbox_for_muc_hook(StateData#state.server_host, HookInfo),
+    run_update_inbox_for_muc_hook(StateData#state.host_type, HookInfo),
     maps_foreach(fun(_LJID, Info) ->
                           ejabberd_router:route(RouteFrom,
                                                 Info#user.jid,
@@ -897,10 +899,10 @@ broadcast_room_packet(From, FromNick, Role, Packet, StateData) ->
                                            StateData),
     next_normal_state(NewStateData2).
 
--spec run_update_inbox_for_muc_hook(jid:server(),
+-spec run_update_inbox_for_muc_hook(mongooseim:host_type(),
                                     update_inbox_for_muc_payload()) -> ok.
-run_update_inbox_for_muc_hook(ServerHost, HookInfo) ->
-    mongoose_hooks:update_inbox_for_muc(ServerHost, HookInfo),
+run_update_inbox_for_muc_hook(HostType, HookInfo) ->
+    mongoose_hooks:update_inbox_for_muc(HostType, HookInfo),
     ok.
 
 change_subject_error(From, FromNick, Packet, Lang, StateData) ->

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -35,7 +35,7 @@
          process_sm_iq/4,
          remove_user/3]).
 
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 -export([config_metrics/1]).
 
@@ -81,8 +81,8 @@
 %% gdpr callback
 %%--------------------------------------------------------------------
 
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ luser = LUser, lserver = LServer }) ->
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) -> gdpr:personal_data().
+get_personal_data(Acc, _HostType, #jid{ luser = LUser, lserver = LServer }) ->
     Schema = ["ns", "xml"],
     NSs = mod_private_backend:get_all_nss(LUser, LServer),
     Entries = lists:map(

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -65,7 +65,7 @@
          remove_user/2, % for tests
          remove_user/3,
          get_versioning_feature/2,
-         get_personal_data/2
+         get_personal_data/3
         ]).
 
 % Deprecated Hooks
@@ -213,8 +213,8 @@
 %% gdpr callback
 %%--------------------------------------------------------------------
 
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ luser = LUser, lserver = LServer }) ->
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) -> gdpr:personal_data().
+get_personal_data(Acc, _HostType, #jid{ luser = LUser, lserver = LServer }) ->
     Schema = ["jid", "name", "subscription", "ask", "groups", "askmessage", "xs"],
     Records = mod_roster_backend:get_roster(LUser, LServer),
     SerializedRecords = lists:map(fun roster_record_to_gdpr_entry/1, Records),

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -80,7 +80,7 @@
 -export([config_change/4]).
 
 %% GDPR related
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 -export([config_metrics/1]).
 
@@ -135,8 +135,8 @@
 %% gdpr callback
 %%--------------------------------------------------------------------
 
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{luser = LUser, lserver = LServer}) ->
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) -> gdpr:personal_data().
+get_personal_data(Acc, _HostType, #jid{luser = LUser, lserver = LServer}) ->
     Jid = jid:to_binary({LUser, LServer}),
     Schema = ["jid", "vcard"],
     Entries = case mod_vcard_backend:get_vcard(LUser, LServer) of

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1140,21 +1140,21 @@ mam_muc_flush_messages(HookServer, MessageCount) ->
 
 %%% @doc `get_mam_pm_gdpr_data' hook is called to provide
 %%% a user's archive for GDPR purposes.
--spec get_mam_pm_gdpr_data(HookServer, JID) -> Result when
-      HookServer :: jid:lserver(),
+-spec get_mam_pm_gdpr_data(HostType, JID) -> Result when
+      HostType :: mongooseim:host_type(),
       JID :: jid:jid(),
       Result :: ejabberd_gen_mam_archive:mam_pm_gdpr_data().
-get_mam_pm_gdpr_data(HookServer, JID) ->
-    ejabberd_hooks:run_for_host_type(get_mam_pm_gdpr_data, HookServer, [], [JID]).
+get_mam_pm_gdpr_data(HostType, JID) ->
+    ejabberd_hooks:run_for_host_type(get_mam_pm_gdpr_data, HostType, [], [JID]).
 
 %%% @doc `get_mam_muc_gdpr_data' hook is called to provide
 %%% a user's archive for GDPR purposes.
--spec get_mam_muc_gdpr_data(HookServer, JID) -> Result when
-      HookServer :: jid:lserver(),
+-spec get_mam_muc_gdpr_data(HostType, JID) -> Result when
+      HostType :: mongooseim:host_type(),
       JID :: jid:jid(),
       Result :: ejabberd_gen_mam_archive:mam_muc_gdpr_data().
-get_mam_muc_gdpr_data(HookServer, JID) ->
-    ejabberd_hooks:run_for_host_type(get_mam_muc_gdpr_data, HookServer, [], [JID]).
+get_mam_muc_gdpr_data(HostType, JID) ->
+    ejabberd_hooks:run_for_host_type(get_mam_muc_gdpr_data, HostType, [], [JID]).
 
 %%% @doc `get_personal_data' hook is called to retrieve
 %%% a user's personal data for GDPR purposes.
@@ -1163,7 +1163,7 @@ get_mam_muc_gdpr_data(HookServer, JID) ->
     JID :: jid:jid(),
     Result :: gdpr:personal_data().
 get_personal_data(HostType, JID) ->
-    ejabberd_hooks:run_for_host_type(get_personal_data, HostType, [], [JID]).
+    ejabberd_hooks:run_for_host_type(get_personal_data, HostType, [], [HostType, JID]).
 
 %% S2S related hooks
 
@@ -1430,12 +1430,12 @@ room_packet(Server, FromNick, FromJID, JID, Packet) ->
     ejabberd_hooks:run_for_host_type(room_packet, Server, ok,
                                      [FromNick, FromJID, JID, Packet]).
 
--spec update_inbox_for_muc(Server, Info) -> Result when
-    Server :: jid:server(),
+-spec update_inbox_for_muc(HostType, Info) -> Result when
+    HostType :: mongooseim:host_type(),
     Info :: mod_muc_room:update_inbox_for_muc_payload(),
     Result :: mod_muc_room:update_inbox_for_muc_payload().
-update_inbox_for_muc(Server, Info) ->
-    ejabberd_hooks:run_for_host_type(update_inbox_for_muc, Server, Info, []).
+update_inbox_for_muc(HostType, Info) ->
+    ejabberd_hooks:run_for_host_type(update_inbox_for_muc, HostType, Info, []).
 
 %% Caps related hooks
 

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -58,7 +58,7 @@
 -export([is_expired_message/2]).
 
 %% GDPR related
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 -export([config_metrics/1]).
 
@@ -520,7 +520,7 @@ pop_messages(#jid{lserver = LServer} = JID) ->
             Other
     end.
 
-get_personal_data(Acc, #jid{} = JID) ->
+get_personal_data(Acc, _HostType, #jid{} = JID) ->
     {ok, Messages} = mod_offline_backend:fetch_messages(JID),
     [ {offline, ["timestamp", "from", "to", "packet"],
        offline_messages_to_gdpr_format(Messages)} | Acc].

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -101,7 +101,7 @@
 
 -export([default_host/0]).
 
--export([get_personal_data/2]).
+-export([get_personal_data/3]).
 
 %% packet handler export
 -export([process_packet/5]).
@@ -334,8 +334,8 @@ process_packet(_Acc, From, To, El, #{state := State}) ->
 %% GDPR callback
 %%====================================================================
 
--spec get_personal_data(gdpr:personal_data(), jid:jid()) -> gdpr:personal_data().
-get_personal_data(Acc, #jid{ luser = LUser, lserver = LServer }) ->
+-spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) -> gdpr:personal_data().
+get_personal_data(Acc, _HostType, #jid{ luser = LUser, lserver = LServer }) ->
      Payloads = mod_pubsub_db_backend:get_user_payloads(LUser, LServer),
      Nodes = mod_pubsub_db_backend:get_user_nodes(LUser, LServer),
      Subscriptions = mod_pubsub_db_backend:get_user_subscriptions(LUser, LServer),


### PR DESCRIPTION
This will be needed in order to correctly query the correct pools where is needed. We can see that it was already done for `mod_mam` in #3123, which in-place queries the host_type. We can just use it as a parameter to the function.