### PR TITLE
Multitenancy/inbox

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -10,32 +10,22 @@
 {include, "tests"}.
 
 {suites, "tests", acc_e2e_SUITE}.
-{suites, "tests", domain_isolation_SUITE}.
-{suites, "tests", muc_SUITE}.
-{suites, "tests", muc_light_SUITE}.
-{suites, "tests", muc_light_legacy_SUITE}.
-{suites, "tests", mam_SUITE}.
 
 {suites, "tests", carboncopy_SUITE}.
 {skip_cases, "tests", carboncopy_SUITE, [discovering_support],
  "at the moment mod_disco doesn't support dynamic domains"}.
 
-{suites, "tests", mod_ping_SUITE}.
-{skip_cases, "tests", mod_ping_SUITE, [disco],
- "at the moment mod_disco doesn't support dynamic domains"}.
+{suites, "tests", domain_isolation_SUITE}.
 
 {suites, "tests", inbox_SUITE}.
 {skip_cases, "tests", inbox_SUITE, [disco_service],
  "at the moment mod_disco doesn't support dynamic domains"}.
 {skip_cases, "tests", inbox_SUITE, [msg_sent_to_offline_user],
  "at the moment mod_offline doesn't support dynamic domains"}.
-{skip_groups, "tests", inbox_SUITE, [muclight, muc],
- "at the moment muc/muclight doesn't support dynamic domains"}.
 
 {suites, "tests", inbox_extensions_SUITE}.
-{skip_groups, "tests", inbox_extensions_SUITE, [muclight],
- "at the moment muclight doesn't support dynamic domains"}.
 
+{suites, "tests", mam_SUITE}.
 {skip_cases, "tests", mam_SUITE,
  [muc_service_discovery, mam_service_discovery],
  "at the moment mod_disco doesn't support dynamic domains"}.
@@ -43,6 +33,11 @@
  [messages_filtered_when_prefs_default_policy_is_roster],
  "at the moment mod_roster doesn't support dynamic domains"}.
 
+{suites, "tests", mod_ping_SUITE}.
+{skip_cases, "tests", mod_ping_SUITE, [disco],
+ "at the moment mod_disco doesn't support dynamic domains"}.
+
+{suites, "tests", muc_SUITE}.
 {skip_groups, "tests", muc_SUITE,
  [disco, disco_non_parallel, disco_rsm, disco_rsm_with_offline],
  "at the moment mod_disco doesn't support dynamic domains"}.
@@ -51,6 +46,7 @@
  "at the moment S2S doesn't support dynamic domains "
  "(requires mod_register creating CT users)"}.
 
+{suites, "tests", muc_light_SUITE}.
 {skip_cases, "tests", muc_light_SUITE,
  [disco_service,
   disco_features,
@@ -70,6 +66,7 @@
   no_roomname_in_schema_doesnt_break_disco_and_roster],
  "at the moment mod_roster doesn't support dynamic domains"}.
 
+{suites, "tests", muc_light_legacy_SUITE}.
 {skip_cases, "tests", muc_light_legacy_SUITE,
  [disco_service,
   disco_features,

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -74,7 +74,6 @@
 
 -import(muc_light_helper, [room_bin_jid/1]).
 -import(inbox_helper, [
-                       muclight_domain/0,
                        inbox_modules/0,
                        muclight_modules/0,
                        inbox_opts/0,
@@ -208,7 +207,7 @@ init_per_group(one_to_one, Config) ->
 init_per_group(muclight, Config) ->
     ok = dynamic_modules:ensure_modules(domain_helper:host_type(mim), muclight_modules()),
     inbox_helper:reload_inbox_option(Config, groupchat, [muclight]),
-    muc_light_helper:create_room(?ROOM, muclight_domain(), alice,
+    muc_light_helper:create_room(?ROOM, muc_light_helper:muc_host(), alice,
                                  [bob, kate], Config, muc_light_helper:ver(1));
 init_per_group(muc, Config) ->
     muc_helper:load_muc(),
@@ -231,22 +230,22 @@ init_per_testcase(create_groupchat_no_affiliation_stored, Config) ->
     escalus:init_per_testcase(create_groupchat_no_affiliation_stored, Config);
 init_per_testcase(groupchat_markers_one_reset, Config) ->
     clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM_MARKERS, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM_MARKERS, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(groupchat_markers_one_reset, Config);
 init_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config) ->
     clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM_MARKERS2, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM_MARKERS2, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(non_reset_marker_should_not_affect_muclight_inbox, Config);
 init_per_testcase(groupchat_reset_stanza_resets_inbox, Config) ->
     clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM_MARKERS_RESET, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM_MARKERS_RESET, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(groupchat_reset_stanza_resets_inbox, Config);
 init_per_testcase(leave_and_remove_conversation, Config) ->
     clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM2, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM2, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(leave_and_remove_conversation, Config);
 init_per_testcase(leave_and_store_conversation, Config) ->
@@ -255,13 +254,13 @@ init_per_testcase(leave_and_store_conversation, Config) ->
     escalus:init_per_testcase(leave_and_store_conversation, Config);
 init_per_testcase(no_aff_stored_and_remove_on_kicked, Config) ->
     clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM3, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM3, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     inbox_helper:reload_inbox_option(Config, [{remove_on_kicked, true}, {aff_changes, false}]),
     escalus:init_per_testcase(no_aff_stored_and_remove_on_kicked, Config);
 init_per_testcase(no_stored_and_remain_after_kicked, Config) ->
     clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM4, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM4, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     inbox_helper:reload_inbox_option(Config, [{remove_on_kicked, false}, {aff_changes, true}]),
     escalus:init_per_testcase(no_stored_and_remain_after_kicked, Config);
@@ -306,7 +305,8 @@ end_per_testcase(no_stored_and_remain_after_kicked, Config) ->
     inbox_helper:restore_inbox_option(Config),
     escalus:end_per_testcase(no_stored_and_remain_after_kicked, Config);
 end_per_testcase(msg_sent_to_not_existing_user, Config) ->
-    escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [<<"not_existing_user">>,<<"localhost">>]),
+    HostType = domain_helper:host_type(mim),
+    escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [HostType, <<"not_existing_user">>,<<"localhost">>]),
     escalus:end_per_testcase(msg_sent_to_not_existing_user, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -76,7 +76,6 @@
 
 
 -import(inbox_helper, [
-                       muclight_domain/0,
                        inbox_modules/0,
                        muclight_modules/0,
                        inbox_opts/0
@@ -175,7 +174,7 @@ end_per_group(_GroupName, Config) ->
 
 init_per_testcase(groupchat_setunread_stanza_sets_inbox, Config) ->
     inbox_helper:clear_inbox_all(),
-    muc_light_helper:create_room(?ROOM_MARKERS_RESET, muclight_domain(), alice, [bob, kate],
+    muc_light_helper:create_room(?ROOM_MARKERS_RESET, muc_light_helper:muc_host(), alice, [bob, kate],
                                  Config, muc_light_helper:ver(1)),
     escalus:init_per_testcase(groupchat_setunread_stanza_sets_inbox, Config);
 init_per_testcase(TestCase, Config) ->

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -139,7 +139,7 @@ inbox_modules() ->
 
 muclight_modules() ->
     [
-     {mod_muc_light, [{host, subhost_pattern(muclight_config_domain())},
+     {mod_muc_light, [{host, subhost_pattern(muc_light_helper:muc_host_pattern())},
                       {backend, rdbms}]}
     ].
 

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -249,10 +249,11 @@ clear_inbox_all() ->
     clear_inboxes([alice, bob, kate, mike]).
 
 clear_inboxes(UserList) ->
+    HostType = domain_helper:host_type(mim),
     Usernames = [{escalus_users:get_username(escalus_users:get_users(UserList),U),
                   escalus_users:get_server(escalus_users:get_users(UserList),U)}
                  || U <- UserList],
-    [escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [User, Server]) || {User, Server} <- Usernames].
+    [escalus_ejabberd:rpc(mod_inbox_utils, clear_inbox, [HostType, User, Server]) || {User, Server} <- Usernames].
 
 reload_inbox_option(Config, KeyValueList) ->
     HostType = domain_helper:host_type(mim),

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -148,7 +148,7 @@ generate_rpc_jid({_,User}) ->
 create_instant_room(Room, From, Nick, Opts) ->
     ServerHost = ct:get_config({hosts, mim, domain}),
     assert_valid_server(ServerHost),
-    Room1 = rpc(mim(), jid, nodeprep, [Room]),
+    Room1 = jid:nodeprep(Room),
     ok = rpc(mim(), mod_muc, create_instant_room,
         [ServerHost, muc_host(), Room1, From, Nick, Opts]).
 

--- a/include/mod_inbox.hrl
+++ b/include/mod_inbox.hrl
@@ -28,4 +28,3 @@
 -type inbox_write_res() :: ok | {error, any()}.
 
 -type marker() :: binary().
-

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -39,72 +39,9 @@
 
 -export([config_metrics/1]).
 
--callback init(Host, Opts) -> ok when
-               Host :: jid:lserver(),
-               Opts :: list().
-
--callback get_inbox(LUsername, LServer, Params) -> get_inbox_res() when
-                    LUsername :: jid:luser(),
-                    LServer :: jid:lserver(),
-                    Params :: get_inbox_params().
-
--callback set_inbox(LUsername, LServer, ToBareJid,
-                    Content, Count, MsgId, Timestamp) -> inbox_write_res() when
-                    LUsername :: jid:luser(),
-                    LServer :: jid:lserver(),
-                    ToBareJid :: binary(),
-                    Content :: binary(),
-                    Count :: integer(),
-                    MsgId :: binary(),
-                    Timestamp :: integer().
-
--callback remove_inbox_row(LUsername, LServer, ToBareJid) -> inbox_write_res() when
-                           LUsername :: jid:luser(),
-                           LServer :: jid:lserver(),
-                           ToBareJid :: binary().
-
--callback set_inbox_incr_unread(LUsername, LServer, ToBareJid,
-                                Content, MsgId, Timestamp) -> {ok, integer()} | ok when
-                                LUsername :: jid:luser(),
-                                LServer :: jid:lserver(),
-                                ToBareJid :: binary(),
-                                Content :: binary(),
-                                MsgId :: binary(),
-                                Timestamp :: integer().
-
--callback reset_unread(LUsername, LServer, BareJid, MsgId) -> inbox_write_res() when
-                       LUsername :: jid:luser(),
-                       LServer :: jid:lserver(),
-                       BareJid :: binary(),
-                       MsgId :: binary().
-
--callback clear_inbox(LServer) -> inbox_write_res() when
-                      LServer :: jid:lserver().
-
--callback clear_inbox(LUsername, LServer) -> inbox_write_res() when
-                      LUsername :: jid:luser(),
-                      LServer :: jid:lserver().
-
--callback get_inbox_unread(LUsername, LServer, InterlocutorJID) -> {ok, integer()} when
-                      LUsername :: jid:luser(),
+-type entry_key() :: {LUser :: jid:luser(),
                       LServer :: jid:lserver(),
-                      InterlocutorJID :: jid:literal_jid().
-
--callback get_entry_properties(LUsername, LServer, EntryJID) -> Ret when
-                      LUsername :: jid:luser(),
-                      LServer :: jid:lserver(),
-                      EntryJID :: jid:literal_jid(),
-                      Ret :: entry_properties().
-
--callback set_entry_properties(LUsername, LServer, EntryJID, Params) -> Ret when
-                      LUsername :: jid:luser(),
-                      LServer :: jid:lserver(),
-                      EntryJID :: jid:literal_jid(),
-                      Params :: entry_properties(),
-                      Ret :: entry_properties() | {error, binary()}.
-
--callback remove_domain(HostType :: mongooseim:host_type(),
-                        LServer :: jid:lserver()) -> ok.
+                      ToBareJid :: jid:literal_jid()}.
 
 -type get_inbox_params() :: #{
         start => integer(),
@@ -114,14 +51,74 @@
         archive => boolean()
        }.
 
--export_type([get_inbox_params/0]).
+-export_type([entry_key/0, get_inbox_params/0]).
+
+-callback init(Host, Opts) -> ok when
+      Host :: mongooseim:host_type(),
+      Opts :: list().
+
+-callback get_inbox(HostType, LUser, LServer, Params) -> get_inbox_res() when
+      HostType :: mongooseim:host_type(),
+      LUser :: jid:luser(),
+      LServer :: jid:lserver(),
+      Params :: get_inbox_params().
+
+-callback clear_inbox(HostType, LUser, LServer) -> inbox_write_res() when
+      HostType :: mongooseim:host_type(),
+      LUser :: jid:luser(),
+      LServer :: jid:lserver().
+
+-callback remove_domain(HostType, LServer) -> ok when
+      HostType :: mongooseim:host_type(),
+      LServer :: jid:lserver().
+
+-callback set_inbox(HostType, InboxEntryKey, Content, Count, MsgId, Timestamp) ->
+    inbox_write_res() when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key(),
+      Content :: binary(),
+      Count :: integer(),
+      MsgId :: binary(),
+      Timestamp :: integer().
+
+-callback remove_inbox_row(HostType, InboxEntryKey) -> inbox_write_res() when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key().
+
+-callback set_inbox_incr_unread(HostType, InboxEntryKey, Content, MsgId, Timestamp) ->
+    {ok, integer()} | ok when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key(),
+      Content :: binary(),
+      MsgId :: binary(),
+      Timestamp :: integer().
+
+-callback reset_unread(HostType, InboxEntryKey, MsgId) -> inbox_write_res() when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key(),
+      MsgId :: binary().
+
+-callback get_inbox_unread(HostType, InboxEntryKey) -> {ok, integer()} when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key().
+
+-callback get_entry_properties(HostType, InboxEntryKey) -> Ret when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key(),
+      Ret :: entry_properties().
+
+-callback set_entry_properties(HostType, InboxEntryKey, Params) -> Ret when
+      HostType :: mongooseim:host_type(),
+      InboxEntryKey :: entry_key(),
+      Params :: entry_properties(),
+      Ret :: entry_properties() | {error, binary()}.
 
 %%--------------------------------------------------------------------
 %% gdpr callbacks
 %%--------------------------------------------------------------------
 -spec get_personal_data(gdpr:personal_data(), mongooseim:host_type(), jid:jid()) ->
     gdpr:personal_data().
-get_personal_data(Acc, _HostType, #jid{luser = LUser, lserver = LServer}) ->
+get_personal_data(Acc, HostType, #jid{luser = LUser, lserver = LServer}) ->
     Schema = ["jid", "content", "unread_count", "timestamp"],
     InboxParams = #{
         start => 0,
@@ -129,7 +126,7 @@ get_personal_data(Acc, _HostType, #jid{luser = LUser, lserver = LServer}) ->
         order => asc,
         hidden_read => false
        },
-    Entries = mod_inbox_backend:get_inbox(LUser, LServer, InboxParams),
+    Entries = mod_inbox_backend:get_inbox(HostType, LUser, LServer, InboxParams),
     ProcessedEntries = lists:map(fun process_entry/1, Entries),
     [{inbox, Schema, ProcessedEntries} | Acc].
 
@@ -203,13 +200,14 @@ process_iq(Acc, _From, _To, #iq{type = get, sub_el = SubEl} = IQ, _Extra) ->
     SubElWithForm = SubEl#xmlel{ children = [Form] },
     {Acc, IQ#iq{type = result, sub_el = SubElWithForm}};
 process_iq(Acc, From, _To, #iq{type = set, id = QueryId, sub_el = QueryEl} = IQ, _Extra) ->
-    Username = From#jid.luser,
-    Host = From#jid.lserver,
+    HostType = mongoose_acc:host_type(Acc),
+    LUser = From#jid.luser,
+    LServer = From#jid.lserver,
     case query_to_params(QueryEl) of
         {error, bad_request, Msg} ->
             {Acc, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:bad_request(<<"en">>, Msg)]}};
         Params ->
-            List = mod_inbox_backend:get_inbox(Username, Host, Params),
+            List = mod_inbox_backend:get_inbox(HostType, LUser, LServer, Params),
             forward_messages(Acc, List, QueryId, From),
             Res = IQ#iq{type = result, sub_el = [build_result_iq(List)]},
             {Acc, Res}
@@ -244,8 +242,7 @@ send_message(Acc, To = #jid{lserver = LServer}, Msg) ->
                        To :: jid:jid(),
                        Packet :: exml:element()) -> map().
 user_send_packet(Acc, From, To, #xmlel{name = <<"message">>} = Msg) ->
-    Host = From#jid.lserver,
-    maybe_process_message(Acc, Host, From, To, Msg, outgoing),
+    maybe_process_message(Acc, From, To, Msg, outgoing),
     Acc;
 user_send_packet(Acc, _From, _To, _Packet) ->
     Acc.
@@ -263,12 +260,11 @@ inbox_unread_count(Acc, To) ->
 filter_packet(drop) ->
     drop;
 filter_packet({From, To, Acc, Msg = #xmlel{name = <<"message">>}}) ->
-    Host = To#jid.lserver,
     %% In case of PgSQL we can we can update inbox and obtain unread_count in one query,
     %% so we put it in accumulator here.
     %% In case of MySQL/MsSQL it costs an extra query, so we fetch it only if necessary
     %% (when push notification is created)
-    Acc0 = case maybe_process_message(Acc, Host, From, To, Msg, incoming) of
+    Acc0 = case maybe_process_message(Acc, From, To, Msg, incoming) of
                {ok, UnreadCount} ->
                    mongoose_acc:set(inbox, unread_count, UnreadCount, Acc);
                _ ->
@@ -280,7 +276,8 @@ filter_packet({From, To, Acc, Packet}) ->
     {From, To, Acc, Packet}.
 
 remove_user(Acc, User, Server) ->
-    mod_inbox_utils:clear_inbox(User, Server),
+    HostType = mongoose_acc:host_type(Acc),
+    mod_inbox_utils:clear_inbox(HostType, User, Server),
     Acc.
 
 -spec remove_domain(mongoose_hooks:simple_acc(),
@@ -299,16 +296,16 @@ add_local_features(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
 -spec maybe_process_message(Acc :: mongoose_acc:t(),
-                            Host :: host(),
                             From :: jid:jid(),
                             To :: jid:jid(),
                             Msg :: exml:element(),
                             Dir :: outgoing | incoming) -> ok | {ok, integer()}.
-maybe_process_message(Acc, Host, From, To, Msg, Dir) ->
+maybe_process_message(Acc, From, To, Msg, Dir) ->
+    HostType = mongoose_acc:host_type(Acc),
     case should_be_stored_in_inbox(Msg) andalso inbox_owner_exists(Acc, From, To, Dir) of
         true ->
             Type = get_message_type(Msg),
-            maybe_process_acceptable_message(Host, From, To, Msg, Acc, Dir, Type);
+            maybe_process_acceptable_message(HostType, From, To, Msg, Acc, Dir, Type);
         false ->
             ok
     end.
@@ -324,33 +321,33 @@ inbox_owner_exists(Acc, _From, To, incoming) ->
     HostType = mongoose_acc:host_type(Acc),
     mongoose_users:does_user_exist(HostType, To).
 
-maybe_process_acceptable_message(Host, From, To, Msg, Acc, Dir, one2one) ->
-            process_message(Host, From, To, Msg, Acc, Dir, one2one);
-maybe_process_acceptable_message(Host, From, To, Msg, Acc, Dir, groupchat) ->
-            muclight_enabled(Host) andalso
-            process_message(Host, From, To, Msg, Acc, Dir, groupchat).
+maybe_process_acceptable_message(HostType, From, To, Msg, Acc, Dir, one2one) ->
+            process_message(HostType, From, To, Msg, Acc, Dir, one2one);
+maybe_process_acceptable_message(HostType, From, To, Msg, Acc, Dir, groupchat) ->
+            muclight_enabled(HostType) andalso
+            process_message(HostType, From, To, Msg, Acc, Dir, groupchat).
 
--spec process_message(Host :: host(),
+-spec process_message(HostType :: host(),
                       From :: jid:jid(),
                       To :: jid:jid(),
                       Message :: exml:element(),
                       Acc :: mongoose_acc:t(),
                       Dir :: outgoing | incoming,
                       Type :: one2one | groupchat) -> ok | {ok, integer()}.
-process_message(Host, From, To, Message, Acc, outgoing, one2one) ->
-    mod_inbox_one2one:handle_outgoing_message(Host, From, To, Message, Acc);
-process_message(Host, From, To, Message, Acc, incoming, one2one) ->
-    mod_inbox_one2one:handle_incoming_message(Host, From, To, Message, Acc);
-process_message(Host, From, To, Message, Acc, outgoing, groupchat) ->
-    mod_inbox_muclight:handle_outgoing_message(Host, From, To, Message, Acc);
-process_message(Host, From, To, Message, Acc, incoming, groupchat) ->
-    mod_inbox_muclight:handle_incoming_message(Host, From, To, Message, Acc);
-process_message(Host, From, To, Message, _TS, Dir, Type) ->
+process_message(HostType, From, To, Message, Acc, outgoing, one2one) ->
+    mod_inbox_one2one:handle_outgoing_message(HostType, From, To, Message, Acc);
+process_message(HostType, From, To, Message, Acc, incoming, one2one) ->
+    mod_inbox_one2one:handle_incoming_message(HostType, From, To, Message, Acc);
+process_message(HostType, From, To, Message, Acc, outgoing, groupchat) ->
+    mod_inbox_muclight:handle_outgoing_message(HostType, From, To, Message, Acc);
+process_message(HostType, From, To, Message, Acc, incoming, groupchat) ->
+    mod_inbox_muclight:handle_incoming_message(HostType, From, To, Message, Acc);
+process_message(HostType, From, To, Message, _TS, Dir, Type) ->
     ?LOG_WARNING(#{what => inbox_unknown_message,
                    text => <<"Unknown message was not written into inbox">>,
                    exml_packet => Message,
                    from_jid => jid:to_binary(From), to_jid => jid:to_binary(To),
-                   server => Host, dir => Dir, inbox_message_type => Type}),
+                   host_type => HostType, dir => Dir, inbox_message_type => Type}),
     ok.
 
 
@@ -570,11 +567,11 @@ invalid_field_value(Field, Value) ->
 get_inbox_unread(Value, Acc, _) when is_integer(Value) ->
     Acc;
 get_inbox_unread(undefined, Acc, To) ->
-%% TODO this value should be bound to a stanza reference inside Acc
-    {User, Host} = jid:to_lus(To),
+    %% TODO this value should be bound to a stanza reference inside Acc
     InterlocutorJID = mongoose_acc:from_jid(Acc),
-    RemBareJIDBin = jid:to_binary(jid:to_lus(InterlocutorJID)),
-    {ok, Count} = mod_inbox_backend:get_inbox_unread(User, Host, RemBareJIDBin),
+    InboxEntryKey = mod_inbox_utils:build_inbox_entry_key(To, InterlocutorJID),
+    HostType = mongoose_acc:host_type(Acc),
+    {ok, Count} = mod_inbox_backend:get_inbox_unread(HostType, InboxEntryKey),
     mongoose_acc:set(inbox, unread_count, Count, Acc).
 
 hooks(HostType) ->
@@ -594,18 +591,18 @@ add_default_backend(Opts) ->
         _ -> Opts
     end.
 
-get_groupchat_types(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, groupchat, [muclight]).
+get_groupchat_types(HostType) ->
+    gen_mod:get_module_opt(HostType, ?MODULE, groupchat, [muclight]).
 
-config_metrics(Host) ->
+config_metrics(HostType) ->
     OptsToReport = [{backend, rdbms}], %list of tuples {option, defualt_value}
-    mongoose_module_metrics:opts_for_module(Host, ?MODULE, OptsToReport).
+    mongoose_module_metrics:opts_for_module(HostType, ?MODULE, OptsToReport).
 
--spec store_bin_reset_markers(Host :: host(), Opts :: list()) -> boolean().
-store_bin_reset_markers(Host, Opts) ->
+-spec store_bin_reset_markers(HostType :: mongooseim:host_type(), Opts :: list()) -> boolean().
+store_bin_reset_markers(HostType, Opts) ->
     ResetMarkers = gen_mod:get_opt(reset_markers, Opts, [displayed]),
     ResetMarkersBin = [mod_inbox_utils:reset_marker_to_bin(Marker) || Marker <- ResetMarkers ],
-    gen_mod:set_module_opt(Host, ?MODULE, reset_markers, ResetMarkersBin).
+    gen_mod:set_module_opt(HostType, ?MODULE, reset_markers, ResetMarkersBin).
 
 groupchat_deps(Opts) ->
     case lists:keyfind(groupchat, 1, Opts) of
@@ -630,11 +627,11 @@ muc_dep(List) ->
 callback_funs() ->
     [get_inbox, set_inbox, set_inbox_incr_unread,
      reset_unread, remove_inbox_row, clear_inbox, get_inbox_unread,
-     get_entry_properties, set_entry_properties].
+     get_entry_properties, set_entry_properties, remove_domain].
 
--spec muclight_enabled(Host :: binary()) -> boolean().
-muclight_enabled(Host) ->
-    Groupchats = get_groupchat_types(Host),
+-spec muclight_enabled(HostType :: mongooseim:host_type()) -> boolean().
+muclight_enabled(HostType) ->
+    Groupchats = get_groupchat_types(HostType),
     lists:member(muclight, Groupchats).
 
 -spec get_message_type(Msg :: exml:element()) -> groupchat | one2one.

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -120,4 +120,6 @@ write_to_receiver_inbox(Server, User, Remote, Packet, Acc) ->
 %% A local host can be used to fire hooks or write into database on this node.
 -spec is_local_xmpp_host(jid:lserver()) -> boolean().
 is_local_xmpp_host(LServer) ->
-    lists:member(LServer, ?MYHOSTS).
+    F = fun mongoose_domain_api:get_domains_by_host_type/1,
+    ServedDomains = lists:flatmap(F, ?ALL_HOST_TYPES),
+    lists:member(LServer, ServedDomains).

--- a/src/inbox/mod_inbox_muc.erl
+++ b/src/inbox/mod_inbox_muc.erl
@@ -15,27 +15,26 @@
 
 %% User jid example is "alice@localhost"
 -type user_jid() :: jid:jid().
-%% Receiver's host in lowercase
--type receiver_host() :: jid:lserver().
 -type receiver_bare_user_jid() :: user_jid().
 -type room_bare_jid() :: jid:jid().
 -type packet() :: exml:element().
 
-start(Host) ->
-    ejabberd_hooks:add(update_inbox_for_muc, Host, ?MODULE, update_inbox_for_muc, 90),
+start(HostType) ->
+    ejabberd_hooks:add(update_inbox_for_muc, HostType, ?MODULE, update_inbox_for_muc, 90),
     % TODO check ooptions: if system messages stored ->
     % add hook handler for system messages on hook ie. invitation_sent
     ok.
 
-stop(Host) ->
-    ejabberd_hooks:delete(update_inbox_for_muc, Host, ?MODULE, update_inbox_for_muc, 90),
+stop(HostType) ->
+    ejabberd_hooks:delete(update_inbox_for_muc, HostType, ?MODULE, update_inbox_for_muc, 90),
     ok.
 
 
 -spec update_inbox_for_muc(Acc) -> Acc when
       Acc :: mod_muc_room:update_inbox_for_muc_payload().
 update_inbox_for_muc(
-    #{room_jid := Room,
+    #{host_type := HostType,
+      room_jid := Room,
       from_jid := From,
       from_room_jid := FromRoomJid,
       packet := Packet,
@@ -46,9 +45,8 @@ update_inbox_for_muc(
                     To = jid:to_bare(jid:make(AffLJID)),
                     %% Guess direction based on user JIDs
                     Direction = direction(From, To),
-                    Host = To#jid.lserver,
                     Packet2 = jlib:replace_from_to(FromRoomJid, To, Packet),
-                    update_inbox_for_user(Direction, Host, Room, To, Packet2);
+                    update_inbox_for_user(HostType, Direction, Room, To, Packet2);
                 false ->
                     ok
             end
@@ -60,18 +58,19 @@ update_inbox_for_muc(
 is_allowed_affiliation(outcast) -> false;
 is_allowed_affiliation(_)       -> true.
 
--spec update_inbox_for_user(Direction, Host, Room, To, Packet) -> term() when
+-spec update_inbox_for_user(HostType, Direction, Room, To, Packet) -> term() when
+      HostType :: mongooseim:host_type(),
       Direction :: incoming | outgoing,
-      Host :: receiver_host(),
       Room :: room_bare_jid(),
       To :: receiver_bare_user_jid(),
       Packet :: packet().
-update_inbox_for_user(Direction, Host, Room, To, Packet) ->
+update_inbox_for_user(HostType, Direction, Room, To, Packet) ->
+    Host = To#jid.lserver,
     case {is_local_xmpp_host(Host), Direction} of
         {true, outgoing} ->
-            handle_outgoing_message(Host, Room, To, Packet);
+            handle_outgoing_message(HostType, Room, To, Packet);
         {true, incoming} ->
-            handle_incoming_message(Host, Room, To, Packet);
+            handle_incoming_message(HostType, Room, To, Packet);
         _ ->
             %% We ignore inbox for users on the remote (s2s) hosts
             %% We ignore inbox for components (also known as services or bots)
@@ -86,30 +85,30 @@ direction(From, To) ->
     end.
 
 %% Sender and receiver is the same user
--spec handle_outgoing_message(Host, Room, To, Packet) -> term() when
-      Host :: receiver_host(),
+-spec handle_outgoing_message(HostType, Room, To, Packet) -> term() when
+      HostType :: mongooseim:host_type(),
       Room :: room_bare_jid(),
       To :: receiver_bare_user_jid(),
       Packet :: packet().
-handle_outgoing_message(Host, Room, To, Packet) ->
-    maybe_reset_unread_count(Host, To, Room, Packet),
-    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host}),
-    maybe_write_to_inbox(Host, To, Room, Packet, Acc, fun write_to_sender_inbox/5).
+handle_outgoing_message(HostType, Room, To, Packet) ->
+    maybe_reset_unread_count(HostType, To, Room, Packet),
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => To#jid.lserver, host_type => HostType}),
+    maybe_write_to_inbox(HostType, To, Room, Packet, Acc, fun write_to_sender_inbox/5).
 
--spec handle_incoming_message(Host, Room, To, Packet) -> term() when
-      Host :: receiver_host(),
+-spec handle_incoming_message(HostType, Room, To, Packet) -> term() when
+      HostType :: mongooseim:host_type(),
       Room :: room_bare_jid(),
       To :: receiver_bare_user_jid(),
       Packet :: packet().
-handle_incoming_message(Host, Room, To, Packet) ->
-    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => Host}),
-    maybe_write_to_inbox(Host, Room, To, Packet, Acc, fun write_to_receiver_inbox/5).
+handle_incoming_message(HostType, Room, To, Packet) ->
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => To#jid.lserver, host_type => HostType}),
+    maybe_write_to_inbox(HostType, Room, To, Packet, Acc, fun write_to_receiver_inbox/5).
 
-maybe_reset_unread_count(Host, User, Room, Packet) ->
-    mod_inbox_utils:maybe_reset_unread_count(Host, User, Room, Packet).
+maybe_reset_unread_count(HostType, User, Room, Packet) ->
+    mod_inbox_utils:maybe_reset_unread_count(HostType, User, Room, Packet).
 
-maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF) ->
-    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF).
+maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, WriteF) ->
+    mod_inbox_utils:maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, WriteF).
 
 write_to_sender_inbox(Server, User, Remote, Packet, Acc) ->
     mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet, Acc).

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -53,7 +53,7 @@ maybe_reset_unread_count(HostType, User, Room, Packet) ->
                                   Packet :: exml:element(),
                                   Acc :: mongoose_acc:t()) -> ok.
 maybe_handle_system_message(HostType, RoomOrUser, Receiver, Packet, Acc) ->
-    case is_system_message(RoomOrUser, Receiver, Packet) of
+    case is_system_message(HostType, RoomOrUser, Receiver, Packet) of
         true ->
             handle_system_message(HostType, RoomOrUser, Receiver, Packet, Acc);
         _ ->
@@ -136,13 +136,13 @@ write_to_inbox(HostType, RoomUser, Remote, _Sender, Packet, Acc) ->
 
 %% @doc Check if sender is just 'roomname@muclight.domain' with no resource
 %% TODO: Replace sender domain check with namespace check - current logic won't handle all cases!
--spec  is_system_message(Sender :: jid:jid(),
+-spec  is_system_message(HostType :: mongooseim:host_type(),
+                         Sender :: jid:jid(),
                          Receiver :: jid:jid(),
                          Packet :: exml:element()) -> boolean().
-is_system_message(Sender, Receiver, Packet) ->
+is_system_message(HostType, Sender, Receiver, Packet) ->
     ReceiverDomain = Receiver#jid.lserver,
-    MUCLightDomain = gen_mod:get_module_opt_subhost(ReceiverDomain, mod_muc_light,
-                                                    mod_muc_light:default_host()),
+    MUCLightDomain = mod_muc_light:server_host_to_muc_host(HostType, ReceiverDomain),
     case {Sender#jid.lserver, Sender#jid.lresource} of
         {MUCLightDomain, <<>>} ->
             true;

--- a/src/inbox/mod_inbox_one2one.erl
+++ b/src/inbox/mod_inbox_one2one.erl
@@ -16,31 +16,31 @@
 
 -type packet() :: exml:element().
 
--spec handle_outgoing_message(Host :: jid:server(),
+-spec handle_outgoing_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
                               Acc :: mongoose_acc:t()) -> ok.
-handle_outgoing_message(Host, User, Remote, Packet, Acc) ->
-    maybe_reset_unread_count(Host, User, Remote, Packet),
-    maybe_write_to_inbox(Host, User, Remote, Packet, Acc, fun write_to_sender_inbox/5).
+handle_outgoing_message(HostType, User, Remote, Packet, Acc) ->
+    maybe_reset_unread_count(HostType, User, Remote, Packet),
+    maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, fun write_to_sender_inbox/5).
 
--spec handle_incoming_message(Host :: jid:server(),
+-spec handle_incoming_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
                               Acc :: mongoose_acc:t()) -> ok | {ok, integer()}.
-handle_incoming_message(Host, User, Remote, Packet, Acc) ->
-    maybe_write_to_inbox(Host, User, Remote, Packet, Acc, fun write_to_receiver_inbox/5).
+handle_incoming_message(HostType, User, Remote, Packet, Acc) ->
+    maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, fun write_to_receiver_inbox/5).
 
-maybe_reset_unread_count(Host, User, Remote, Packet) ->
-    mod_inbox_utils:maybe_reset_unread_count(Host, User, Remote, Packet).
+maybe_reset_unread_count(HostType, User, Remote, Packet) ->
+    mod_inbox_utils:maybe_reset_unread_count(HostType, User, Remote, Packet).
 
-maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF) ->
-    mod_inbox_utils:maybe_write_to_inbox(Host, User, Remote, Packet, Acc, WriteF).
+maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, WriteF) ->
+    mod_inbox_utils:maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, WriteF).
 
-write_to_sender_inbox(Server, User, Remote, Packet, Acc) ->
-    mod_inbox_utils:write_to_sender_inbox(Server, User, Remote, Packet, Acc).
+write_to_sender_inbox(HostType, User, Remote, Packet, Acc) ->
+    mod_inbox_utils:write_to_sender_inbox(HostType, User, Remote, Packet, Acc).
 
-write_to_receiver_inbox(Server, User, Remote, Packet, Acc) ->
-    mod_inbox_utils:write_to_receiver_inbox(Server, User, Remote, Packet, Acc).
+write_to_receiver_inbox(HostType, User, Remote, Packet, Acc) ->
+    mod_inbox_utils:write_to_receiver_inbox(HostType, User, Remote, Packet, Acc).

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -46,6 +46,7 @@
          can_use_nick/4,
          room_jid_to_pid/1,
          default_host/0]).
+-export([server_host_to_muc_host/2]).
 
 %% For testing purposes only
 -export([register_room/4]).

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -25,6 +25,7 @@
 
 %% API
 -export([default_schema_definition/0, default_host/0]).
+-export([server_host_to_muc_host/2]).
 -export([config_schema/1, default_config/1]).
 
 %% For Administration API


### PR DESCRIPTION
This PR most importantly enables (and fixes) muc/muclight tests for inbox and dynamic domains.

It also migrates inbox's backend to HostTypes in an orderly manner, following the pattern of the auth modules. As a side-note, some functions started taking too many parameters, so I made a type `{LUser, LServer, RemBareJid}`, which replicates the primary key that identifies inbox entries.