### PR TITLE
Fix metrics in mam suite

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -40,10 +40,6 @@
 {skip_cases, "tests", mam_SUITE,
  [messages_filtered_when_prefs_default_policy_is_roster],
  "at the moment mod_roster doesn't support dynamic domains"}.
-{skip_cases, "tests", mam_SUITE,
- [metric_incremented_when_store_message,
-  metric_incremented_on_archive_request],
- "this test is broken in PR #3120"}.
 
 {skip_groups, "tests", muc_SUITE,
  [disco, disco_non_parallel, disco_rsm, disco_rsm_with_offline],

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2998,7 +2998,9 @@ metric_incremented_on_archive_request(ConfigIn) ->
         assert_respond_query_id(P, <<"metric_q1">>, parse_result_iq(Res)),
         ok
         end,
-    MongooseMetrics = [{[host_type(), backends, mod_mam, lookup], changed}],
+    HostType = domain_helper:host_type(mim),
+    HostTypePrefix = domain_helper:make_metrics_prefix(HostType),
+    MongooseMetrics = [{[HostTypePrefix, backends, mod_mam, lookup], changed}],
     Config = [{mongoose_metrics, MongooseMetrics} | ConfigIn],
     escalus_fresh:story(Config, [{alice, 1}], F).
 


### PR DESCRIPTION
This should fix the tests using metrics. Because we allow any string to be a host type, and in testing its `<<"test type">>` one has to ensure that the metrics are checked against a sanitised host type prefix, because metrics cannot contain spaces in their names.

