### PR TITLE
Require dynamic_domains before building docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,6 +518,7 @@ workflows:
             - small_tests_22
             - small_tests_21_3
             - small_tests_23
+            - dynamic_domains
           filters: *all_tags
       # ============= DOCUMENTATION =============
       - docs_build_deploy:


### PR DESCRIPTION
Why not
