### PR TITLE
Further mod_disco rework

### DIFF
--- a/big_tests/tests/adhoc_SUITE.erl
+++ b/big_tests/tests/adhoc_SUITE.erl
@@ -30,8 +30,13 @@ all() ->
      {group, adhoc}].
 
 groups() ->
-    G = [{adhoc, [parallel], [disco_hidden, disco_commands, ping]},
-         {disco_visible, [parallel], [disco_visible, disco_commands]}],
+    G = [{adhoc, [parallel], [disco_hidden,
+                              disco_commands,
+                              disco_commands_info,
+                              disco_ping_info,
+                              ping]},
+         {disco_visible, [parallel], [disco_visible,
+                                      disco_commands]}],
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
@@ -106,6 +111,26 @@ disco_commands(Config) ->
                 Query = exml_query:subelement(Stanza, <<"query">>),
                 Item = exml_query:subelement_with_attr(Query, <<"node">>, <<"ping">>),
                 ?assertEqual(Server, exml_query:attr(Item, <<"jid">>)),
+                escalus:assert(is_stanza_from, [domain()], Stanza)
+        end).
+
+disco_commands_info(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                Server = escalus_client:server(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(Server, ?NS_COMMANDS)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_identity, [<<"automation">>, <<"command-list">>], Stanza),
+                escalus:assert(is_stanza_from, [domain()], Stanza)
+        end).
+
+disco_ping_info(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                Server = escalus_client:server(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(Server, <<"ping">>)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_identity, [<<"automation">>, <<"command-node">>], Stanza),
                 escalus:assert(is_stanza_from, [domain()], Stanza)
         end).
 

--- a/big_tests/tests/adhoc_SUITE.erl
+++ b/big_tests/tests/adhoc_SUITE.erl
@@ -30,14 +30,16 @@ all() ->
      {group, adhoc}].
 
 groups() ->
-    G = [{adhoc, [parallel], [disco_hidden,
-                              disco_commands,
-                              disco_commands_info,
-                              disco_ping_info,
-                              ping]},
-         {disco_visible, [parallel], [disco_visible,
-                                      disco_commands]}],
+    G = [{adhoc, [parallel], common_disco_cases() ++ [disco_items_hidden, ping]},
+         {disco_visible, [parallel], common_disco_cases() ++ [disco_items_visible]}],
     ct_helper:repeat_all_until_all_ok(G).
+
+common_disco_cases() ->
+    [disco_info,
+     disco_info_sm,
+     disco_info_commands,
+     disco_info_ping,
+     disco_items_commands].
 
 suite() ->
     escalus:suite().
@@ -78,7 +80,49 @@ restore_modules(_, Config) ->
 %%--------------------------------------------------------------------
 %% Adhoc tests
 %%--------------------------------------------------------------------
-disco_hidden(Config) ->
+
+disco_info(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                Server = escalus_client:server(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(Server)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_feature, [?NS_COMMANDS], Stanza),
+                escalus:assert(is_stanza_from, [domain()], Stanza)
+        end).
+
+disco_info_sm(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                AliceJid = escalus_client:short_jid(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(AliceJid)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_feature, [?NS_COMMANDS], Stanza),
+                escalus:assert(is_stanza_from, [AliceJid], Stanza)
+        end).
+
+disco_info_commands(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                Server = escalus_client:server(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(Server, ?NS_COMMANDS)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_identity, [<<"automation">>, <<"command-list">>], Stanza),
+                escalus:assert(is_stanza_from, [domain()], Stanza)
+        end).
+
+disco_info_ping(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                Server = escalus_client:server(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(Server, <<"ping">>)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_identity, [<<"automation">>, <<"command-node">>], Stanza),
+                escalus:assert(has_feature, [?NS_COMMANDS], Stanza),
+                escalus:assert(is_stanza_from, [domain()], Stanza)
+        end).
+
+disco_items_hidden(Config) ->
     escalus:fresh_story(Config, [{alice, 1}],
         fun(Alice) ->
                 Server = escalus_client:server(Alice),
@@ -90,7 +134,7 @@ disco_hidden(Config) ->
                 escalus:assert(is_stanza_from, [domain()], Stanza)
         end).
 
-disco_visible(Config) ->
+disco_items_visible(Config) ->
     escalus:fresh_story(Config, [{alice, 1}],
         fun(Alice) ->
                 Server = escalus_client:server(Alice),
@@ -102,7 +146,7 @@ disco_visible(Config) ->
                 escalus:assert(is_stanza_from, [domain()], Stanza)
         end).
 
-disco_commands(Config) ->
+disco_items_commands(Config) ->
     escalus:fresh_story(Config, [{alice, 1}],
         fun(Alice) ->
                 Server = escalus_client:server(Alice),
@@ -111,26 +155,6 @@ disco_commands(Config) ->
                 Query = exml_query:subelement(Stanza, <<"query">>),
                 Item = exml_query:subelement_with_attr(Query, <<"node">>, <<"ping">>),
                 ?assertEqual(Server, exml_query:attr(Item, <<"jid">>)),
-                escalus:assert(is_stanza_from, [domain()], Stanza)
-        end).
-
-disco_commands_info(Config) ->
-    escalus:fresh_story(Config, [{alice, 1}],
-        fun(Alice) ->
-                Server = escalus_client:server(Alice),
-                escalus:send(Alice, escalus_stanza:disco_info(Server, ?NS_COMMANDS)),
-                Stanza = escalus:wait_for_stanza(Alice),
-                escalus:assert(has_identity, [<<"automation">>, <<"command-list">>], Stanza),
-                escalus:assert(is_stanza_from, [domain()], Stanza)
-        end).
-
-disco_ping_info(Config) ->
-    escalus:fresh_story(Config, [{alice, 1}],
-        fun(Alice) ->
-                Server = escalus_client:server(Alice),
-                escalus:send(Alice, escalus_stanza:disco_info(Server, <<"ping">>)),
-                Stanza = escalus:wait_for_stanza(Alice),
-                escalus:assert(has_identity, [<<"automation">>, <<"command-node">>], Stanza),
                 escalus:assert(is_stanza_from, [domain()], Stanza)
         end).
 

--- a/big_tests/tests/adhoc_SUITE.erl
+++ b/big_tests/tests/adhoc_SUITE.erl
@@ -38,6 +38,7 @@ common_disco_cases() ->
     [disco_info,
      disco_info_sm,
      disco_info_commands,
+     disco_info_sm_commands,
      disco_info_ping,
      disco_items_commands].
 
@@ -117,6 +118,16 @@ disco_info_commands(Config) ->
                 Stanza = escalus:wait_for_stanza(Alice),
                 escalus:assert(has_identity, [<<"automation">>, <<"command-list">>], Stanza),
                 escalus:assert(is_stanza_from, [domain()], Stanza)
+        end).
+
+disco_info_sm_commands(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                AliceJid = escalus_client:short_jid(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(AliceJid, ?NS_COMMANDS)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_identity, [<<"automation">>, <<"command-list">>], Stanza),
+                escalus:assert(is_stanza_from, [AliceJid], Stanza)
         end).
 
 disco_info_ping(Config) ->

--- a/big_tests/tests/mod_http_upload_SUITE.erl
+++ b/big_tests/tests/mod_http_upload_SUITE.erl
@@ -173,7 +173,8 @@ advertises_max_file_size(Config) ->
 
               escalus:assert(has_type, [<<"result">>], Form),
               escalus:assert(has_ns, [?NS_XDATA], Form),
-              escalus:assert(fun has_field/4, [<<"max-file-size">>, undefined, <<"1234">>], Form)
+              escalus:assert(fun has_field/4, [<<"max-file-size">>, undefined, <<"1234">>], Form),
+              escalus:assert(has_identity, [<<"store">>, <<"file">>], Result)
       end).
 
 does_not_advertise_max_size_if_unset(Config) ->
@@ -182,7 +183,8 @@ does_not_advertise_max_size_if_unset(Config) ->
       fun(Bob) ->
               ServJID = upload_service(Bob),
               Result = escalus:send_and_wait(Bob, escalus_stanza:disco_info(ServJID)),
-              undefined = exml_query:path(Result, {element, <<"x">>})
+              undefined = exml_query:path(Result, {element, <<"x">>}),
+              escalus:assert(has_identity, [<<"store">>, <<"file">>], Result)
       end).
 
 rejects_set_iq(Config) ->

--- a/big_tests/tests/mod_http_upload_SUITE.erl
+++ b/big_tests/tests/mod_http_upload_SUITE.erl
@@ -45,6 +45,8 @@
 	 advertises_max_file_size/1,
 	 request_slot/1,
 	 rejects_set_iq/1,
+	 rejects_disco_set_iq/1,
+	 rejects_feature_discovery_with_node/1,
 	 get_url_ends_with_filename/1,
 	 urls_contain_s3_hostname/1,
 	 rejects_empty_filename/1,
@@ -75,6 +77,8 @@ groups() ->
                                    advertises_max_file_size,
                                    request_slot,
                                    rejects_set_iq,
+                                   rejects_disco_set_iq,
+                                   rejects_feature_discovery_with_node,
                                    get_url_ends_with_filename,
                                    urls_contain_s3_hostname,
                                    rejects_empty_filename,
@@ -196,6 +200,31 @@ rejects_set_iq(Config) ->
               Request = escalus_stanza:to(IQ, ServJID),
               Result = escalus:send_and_wait(Bob, Request),
               escalus_assert:is_error(Result, <<"cancel">>, <<"not-allowed">>)
+      end).
+
+rejects_disco_set_iq(Config) ->
+    escalus:story(
+      Config, [{bob, 1}],
+      fun(Bob) ->
+              ServJID = upload_service(Bob),
+              IQ = escalus_stanza:iq_set(?NS_DISCO_INFO, []),
+              Request = escalus_stanza:to(IQ, ServJID),
+              Stanza = escalus:send_and_wait(Bob, Request),
+              escalus:assert(is_iq_error, [Request], Stanza),
+              escalus:assert(is_error, [<<"cancel">>, <<"not-allowed">>], Stanza),
+              escalus:assert(is_stanza_from, [ServJID], Stanza)
+      end).
+
+rejects_feature_discovery_with_node(Config) ->
+    escalus:story(
+      Config, [{bob, 1}],
+      fun(Bob) ->
+              ServJID = upload_service(Bob),
+              Request = escalus_stanza:disco_info(ServJID, <<"bad-node">>),
+              Stanza = escalus:send_and_wait(Bob, Request),
+              escalus:assert(is_iq_error, [Request], Stanza),
+              escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Stanza),
+              escalus:assert(is_stanza_from, [ServJID], Stanza)
       end).
 
 request_slot(Config) ->

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -15,6 +15,7 @@
 
 -define(DELAY_NS, <<"urn:xmpp:delay">>).
 -define(AFFILIATION_NS, <<"urn:xmpp:muclight:0#affiliations">>).
+-define(NS_FEATURE_MSGOFFLINE,  <<"msgoffline">>).
 
 %%%===================================================================
 %%% Suite configuration
@@ -26,7 +27,8 @@ all() ->
      {group, with_groupchat}].
 
 all_tests() ->
-    [offline_message_is_stored_and_delivered_at_login,
+    [disco_info_sm,
+     offline_message_is_stored_and_delivered_at_login,
      error_message_is_not_stored,
      groupchat_message_is_not_stored,
      headline_message_is_not_stored,
@@ -100,6 +102,16 @@ end_per_testcase(Name, C) -> escalus:end_per_testcase(Name, C).
 %%%===================================================================
 %%% offline tests
 %%%===================================================================
+
+disco_info_sm(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                AliceJid = escalus_client:short_jid(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(AliceJid)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(has_feature, [?NS_FEATURE_MSGOFFLINE], Stanza),
+                escalus:assert(is_stanza_from, [AliceJid], Stanza)
+        end).
 
 offline_message_is_stored_and_delivered_at_login(Config) ->
     Story =

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -19,6 +19,7 @@
          init_per_testcase/2, end_per_testcase/2]).
 
 -export([
+         disco_test/1,
          pep_caps_test/1,
          publish_and_notify_test/1,
          publish_options_test/1,
@@ -52,6 +53,7 @@ groups() ->
     G = [
          {pep_tests, [parallel],
           [
+           disco_test,
            pep_caps_test,
            publish_and_notify_test,
            publish_options_test,
@@ -117,6 +119,18 @@ end_per_testcase(TestName, Config) ->
 %%--------------------------------------------------------------------
 
 %% Group: pep_tests (sequence)
+
+disco_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}],
+      fun(Alice) ->
+              escalus:send(Alice, escalus_stanza:disco_info(pubsub_tools:node_addr())),
+              Stanza = escalus:wait_for_stanza(Alice),
+              escalus:assert(has_identity, [<<"pubsub">>, <<"service">>], Stanza),
+              escalus:assert(has_identity, [<<"pubsub">>, <<"pep">>], Stanza),
+              escalus:assert(has_feature, [?NS_PUBSUB], Stanza)
+      end).
 
 pep_caps_test(Config) ->
     escalus:fresh_story(

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -20,6 +20,7 @@
 
 -export([
          disco_test/1,
+         disco_sm_test/1,
          pep_caps_test/1,
          publish_and_notify_test/1,
          publish_options_test/1,
@@ -54,6 +55,7 @@ groups() ->
          {pep_tests, [parallel],
           [
            disco_test,
+           disco_sm_test,
            pep_caps_test,
            publish_and_notify_test,
            publish_options_test,
@@ -130,6 +132,18 @@ disco_test(Config) ->
               escalus:assert(has_identity, [<<"pubsub">>, <<"service">>], Stanza),
               escalus:assert(has_identity, [<<"pubsub">>, <<"pep">>], Stanza),
               escalus:assert(has_feature, [?NS_PUBSUB], Stanza)
+      end).
+
+disco_sm_test(Config) ->
+    escalus:fresh_story(
+      Config,
+      [{alice, 1}],
+      fun(Alice) ->
+              AliceJid = escalus_client:short_jid(Alice),
+              escalus:send(Alice, escalus_stanza:disco_info(AliceJid)),
+              Stanza = escalus:wait_for_stanza(Alice),
+              escalus:assert(has_feature, [?NS_PUBSUB], Stanza),
+              escalus:assert(is_stanza_from, [AliceJid], Stanza)
       end).
 
 pep_caps_test(Config) ->

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -145,6 +145,8 @@ disco_sm_test(Config) ->
               AliceJid = escalus_client:short_jid(Alice),
               escalus:send(Alice, escalus_stanza:disco_info(AliceJid)),
               Stanza = escalus:wait_for_stanza(Alice),
+              ?assertNot(escalus_pred:has_identity(<<"pubsub">>, <<"service">>, Stanza)),
+              escalus:assert(has_identity, [<<"pubsub">>, <<"pep">>], Stanza),
               escalus:assert(has_feature, [?NS_PUBSUB], Stanza),
               escalus:assert(is_stanza_from, [AliceJid], Stanza)
       end).

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 -export([suite/0, all/0, groups/0]).
 -export([init_per_suite/1, end_per_suite/1,
@@ -20,6 +21,7 @@
 -export([
          discover_features_test/1,
          discover_service_features_test/1,
+         discover_sm_features_test/1,
          discover_nodes_test/1,
          create_delete_node_test/1,
          subscribe_unsubscribe_test/1,
@@ -173,6 +175,7 @@ basic_tests() ->
     [
      discover_features_test,
      discover_service_features_test,
+     discover_sm_features_test,
      discover_nodes_test,
      create_delete_node_test,
      subscribe_unsubscribe_test,
@@ -365,6 +368,17 @@ discover_service_features_test(Config) ->
               escalus:assert(has_identity, [<<"pubsub">>, <<"service">>], Stanza),
               escalus:assert(has_feature, [?NS_PUBSUB], Stanza)
       end).
+
+discover_sm_features_test(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+                AliceJid = escalus_client:short_jid(Alice),
+                escalus:send(Alice, escalus_stanza:disco_info(AliceJid)),
+                Stanza = escalus:wait_for_stanza(Alice),
+                %% The feature shouldn't be present when PEP is disabled
+                ?assertNot(escalus_pred:has_feature(?NS_PUBSUB, Stanza)),
+                escalus:assert(is_stanza_from, [AliceJid], Stanza)
+        end).
 
 discover_nodes_test(Config) ->
     escalus:fresh_story(

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -362,6 +362,7 @@ discover_service_features_test(Config) ->
       fun(Alice) ->
               escalus:send(Alice, escalus_stanza:disco_info(node_addr())),
               Stanza = escalus:wait_for_stanza(Alice),
+              escalus:assert(has_identity, [<<"pubsub">>, <<"service">>], Stanza),
               escalus:assert(has_feature, [?NS_PUBSUB], Stanza)
       end).
 

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -114,7 +114,7 @@ disco_iq_handler(_From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl} = 
     Node = xml:get_tag_attr_s(<<"node">>, SubEl),
     case Node of
         <<>> ->
-            Identity = disco_identity(Lang),
+            Identity = mongoose_disco:identities_to_xml(disco_identity(Lang)),
             Info = disco_info(LServer),
             Features = mongoose_disco:features_to_xml([?NS_HTTP_UPLOAD_030]),
             {Acc, IQ#iq{type = result,
@@ -125,7 +125,6 @@ disco_iq_handler(_From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl} = 
             Error = mongoose_xmpp_errors:item_not_found(),
             {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}}
     end.
-
 
 -spec get_urls(Host :: jid:lserver(), Filename :: binary(), Size :: pos_integer(),
                ContentType :: binary() | undefined, Timeout :: pos_integer()) ->
@@ -182,12 +181,11 @@ disco_local_items(Acc, _From, _To, _Node, _Lang) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
--spec disco_identity(ejabberd:lang()) -> [exml:element()].
+-spec disco_identity(ejabberd:lang()) -> [mongoose_disco:identity()].
 disco_identity(Lang) ->
-    [#xmlel{name = <<"identity">>,
-            attrs = [{<<"category">>, <<"store">>},
-                     {<<"type">>, <<"file">>},
-                     {<<"name">>, my_disco_name(Lang)}]}].
+    [#{category => <<"store">>,
+       type => <<"file">>,
+       name => my_disco_name(Lang)}].
 
 -spec disco_info(jid:lserver()) -> [exml:element()].
 disco_info(SubHost) ->

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -29,10 +29,10 @@
 -define(DEFAULT_MAX_FILE_SIZE, 10 * 1024 * 1024). % 10 MB
 -define(DEFAULT_SUBHOST, <<"upload.@HOST@">>).
 
--export([start/2, stop/1, iq_handler/4, get_urls/5, config_spec/0]).
+-export([start/2, stop/1, iq_handler/4, disco_iq_handler/4, get_urls/5, config_spec/0]).
 
-%% Hook implementations
--export([get_disco_identity/5, get_disco_items/5, get_disco_features/5, get_disco_info/5]).
+%% Hook handlers
+-export([disco_local_items/5]).
 
 -export([config_metrics/1]).
 
@@ -55,26 +55,20 @@ start(Host, Opts) ->
     SubHost = subhost(Host),
     mongoose_subhosts:register(Host, SubHost),
     ejabberd_router:register_route(SubHost, mongoose_packet_handler:new(ejabberd_local)),
-    ejabberd_hooks:add(disco_local_features, SubHost, ?MODULE, get_disco_features, 90),
-    ejabberd_hooks:add(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
-    ejabberd_hooks:add(disco_info, SubHost, ?MODULE, get_disco_info, 90),
-    ejabberd_hooks:add(disco_local_items, Host, ?MODULE, get_disco_items, 90),
-    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030, ?MODULE,
-                                  iq_handler, IQDisc),
+    ejabberd_hooks:add(disco_local_items, Host, ?MODULE, disco_local_items, 90),
+    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030,
+                                  ?MODULE, iq_handler, IQDisc),
     gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_DISCO_INFO,
-                                  mod_disco, process_local_iq_info, IQDisc),
+                                  ?MODULE, disco_iq_handler, IQDisc),
     gen_mod:start_backend_module(?MODULE, with_default_backend(Opts), [create_slot]).
 
 
 -spec stop(Host :: jid:server()) -> any().
 stop(Host) ->
     SubHost = subhost(Host),
+    ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, disco_local_items, 90),
     gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030),
     gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_DISCO_INFO),
-    ejabberd_hooks:delete(disco_local_items, SubHost, ?MODULE, get_disco_items, 90),
-    ejabberd_hooks:delete(disco_info, SubHost, ?MODULE, get_disco_info, 90),
-    ejabberd_hooks:delete(disco_local_identity, SubHost, ?MODULE, get_disco_identity, 90),
-    ejabberd_hooks:delete(disco_local_features, SubHost, ?MODULE, get_disco_features, 90),
     ejabberd_router:unregister_route(SubHost),
     mongoose_subhosts:unregister(SubHost).
 
@@ -109,6 +103,28 @@ iq_handler(_From, _To = #jid{lserver = SubHost}, Acc, IQ = #iq{type = get, sub_e
             IQ#iq{type = error, sub_el = [Request, mongoose_xmpp_errors:bad_request()]}
     end,
     {Acc, Res}.
+
+-spec disco_iq_handler(From :: jid:jid(), To :: jid:jid(), Acc :: mongoose_acc:t(),
+                       IQ :: jlib:iq()) ->
+          {mongoose_acc:t(), jlib:iq()}.
+disco_iq_handler(_From, _To, Acc, #iq{type = set, sub_el = SubEl} = IQ) ->
+    {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:not_allowed()]}};
+disco_iq_handler(_From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl} = IQ) ->
+    LServer = To#jid.lserver,
+    Node = xml:get_tag_attr_s(<<"node">>, SubEl),
+    case Node of
+        <<>> ->
+            Identity = disco_identity(Lang),
+            Info = disco_info(LServer),
+            Features = mongoose_disco:features_to_xml([?NS_HTTP_UPLOAD_030]),
+            {Acc, IQ#iq{type = result,
+                        sub_el = [#xmlel{name = <<"query">>,
+                                         attrs = [{<<"xmlns">>, ?NS_DISCO_INFO}],
+                                         children = Identity ++ Info ++ Features}]}};
+        _ ->
+            Error = mongoose_xmpp_errors:item_not_found(),
+            {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}}
+    end.
 
 
 -spec get_urls(Host :: jid:lserver(), Filename :: binary(), Size :: pos_integer(),
@@ -154,47 +170,35 @@ s3_spec() ->
         required = [<<"bucket_url">>, <<"region">>, <<"access_key_id">>, <<"secret_access_key">>]
     }.
 
--spec get_disco_identity(Acc :: term(), From :: jid:jid(), To :: jid:jid(),
-                         Node :: binary(), ejabberd:lang()) -> [exml:element()] | term().
-get_disco_identity(Acc, _From, _To, _Node = <<>>, Lang) ->
-    [#xmlel{name = <<"identity">>,
-            attrs = [{<<"category">>, <<"store">>},
-                     {<<"type">>, <<"file">>},
-                     {<<"name">>, my_disco_name(Lang)}]} | Acc];
-get_disco_identity(Acc, _From, _To, _Node, _Lang) ->
-    Acc.
-
--spec get_disco_items(mongoose_disco:item_acc(), jid:jid(), jid:jid(), binary(), ejabberd:lang()) ->
+-spec disco_local_items(mongoose_disco:item_acc(), jid:jid(), jid:jid(), binary(),
+                        ejabberd:lang()) ->
           mongoose_disco:item_acc().
-get_disco_items(Acc, _From, #jid{lserver = Host} = _To, <<>>, Lang) ->
+disco_local_items(Acc, _From, #jid{lserver = Host} = _To, <<>>, Lang) ->
     mongoose_disco:add_items([#{jid => subhost(Host), name => my_disco_name(Lang)}], Acc);
-get_disco_items(Acc, _From, _To, _Node, _Lang) ->
-    Acc.
-
--spec get_disco_features(Acc :: mongoose_disco:feature_acc(),
-                         From :: jid:jid(), To :: jid:jid(),
-                         Node :: binary(), ejabberd:lang()) -> mongoose_disco:feature_acc().
-get_disco_features(Acc, _From, _To, _Node = <<>>, _Lang) ->
-    mongoose_disco:add_features([?NS_HTTP_UPLOAD_030], Acc);
-get_disco_features(Acc, _From, _To, _Node, _Lang) ->
-    Acc.
-
--spec get_disco_info(Acc :: [exml:element()], jid:server(), module(), Node :: binary(),
-                     Lang :: ejabberd:lang()) -> [exml:element()].
-get_disco_info(Acc, SubHost, _Mod, _Node = <<>>, _Lang) ->
-    {ok, Host} = mongoose_subhosts:get_host(SubHost),
-    case max_file_size(Host) of
-        undefined -> Acc;
-        MaxFileSize ->
-            MaxFileSizeBin = integer_to_binary(MaxFileSize),
-            [get_disco_info_form(MaxFileSizeBin) | Acc]
-    end;
-get_disco_info(Acc, _Host, _Mod, _Node, _Lang) ->
+disco_local_items(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
+
+-spec disco_identity(ejabberd:lang()) -> [exml:element()].
+disco_identity(Lang) ->
+    [#xmlel{name = <<"identity">>,
+            attrs = [{<<"category">>, <<"store">>},
+                     {<<"type">>, <<"file">>},
+                     {<<"name">>, my_disco_name(Lang)}]}].
+
+-spec disco_info(jid:lserver()) -> [exml:element()].
+disco_info(SubHost) ->
+    {ok, Host} = mongoose_subhosts:get_host(SubHost),
+    case max_file_size(Host) of
+        undefined ->
+            [];
+        MaxFileSize ->
+            MaxFileSizeBin = integer_to_binary(MaxFileSize),
+            [get_disco_info_form(MaxFileSizeBin)]
+    end.
 
 -spec subhost(Host :: jid:server()) -> binary().
 subhost(Host) ->

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -186,17 +186,11 @@ get_local_features(Acc, _From, _To, _Node, _Lang) ->
 
 %%-------------------------------------------------------------------------
 
--spec get_sm_features(Acc :: {result, [exml:element()]} | {error, any()} | empty,
-                             From :: jid:jid(),
-                             To :: jid:jid(),
-                             NS :: binary(),
-                             ejabberd:lang()) -> {result, [exml:element()]} | {error, any()} | empty.
-get_sm_features(Acc, _From, _To, <<"">>, _Lang) ->
-    Feats = case Acc of
-                {result, I} -> I;
-                _ -> []
-            end,
-    {result, Feats ++ [?NS_COMMANDS]};
+-spec get_sm_features(mongoose_disco:feature_acc(), jid:jid(), jid:jid(), binary(),
+                         ejabberd:lang()) ->
+          mongoose_disco:feature_acc().
+get_sm_features(Acc, _From, _To, <<>>, _Lang) ->
+    mongoose_disco:add_features([?NS_COMMANDS], Acc);
 get_sm_features(_Acc, _From, _To, ?NS_COMMANDS, _Lang) ->
     %% override all lesser features...
     {result, []};

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -143,16 +143,13 @@ get_local_identity(Acc, _From, _To, _Node, _Lang) ->
 %%-------------------------------------------------------------------------
 
 %% @doc On disco info request to the ad-hoc node, return automation/command-list.
--spec get_sm_identity(Acc :: [exml:element()],
-                     From :: jid:jid(),
-                     To :: jid:jid(),
-                     NS :: binary(),
-                     ejabberd:lang()) -> [exml:element()].
+-spec get_sm_identity([mongoose_disco:identity()], jid:jid(), jid:jid(), binary(),
+                      ejabberd:lang()) ->
+          [mongoose_disco:identity()].
 get_sm_identity(Acc, _From, _To, ?NS_COMMANDS, Lang) ->
-    [#xmlel{name = <<"identity">>,
-            attrs = [{<<"category">>, <<"automation">>},
-                     {<<"type">>, <<"command-list">>},
-                     {<<"name">>, translate:translate(Lang, <<"Commands">>)}]} | Acc];
+    [#{category => <<"automation">>,
+       type => <<"command-list">>,
+       name => translate:translate(Lang, <<"Commands">>)} | Acc];
 get_sm_identity(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -138,21 +138,17 @@ get_sm_commands(Acc, _From, _To, _Node, _Lang) ->
 %%-------------------------------------------------------------------------
 
 %% @doc On disco info request to the ad-hoc node, return automation/command-list.
--spec get_local_identity(Acc :: [exml:element()],
-                         From :: jid:jid(),
-                         To :: jid:jid(),
-                         NS :: binary(),
-                         ejabberd:lang()) -> [exml:element()].
+-spec get_local_identity([mongoose_disco:identity()], jid:jid(), jid:jid(), binary(),
+                         ejabberd:lang()) ->
+          [mongoose_disco:identity()].
 get_local_identity(Acc, _From, _To, ?NS_COMMANDS, Lang) ->
-    [#xmlel{name = <<"identity">>,
-            attrs = [{<<"category">>, <<"automation">>},
-                     {<<"type">>, <<"command-list">>},
-                     {<<"name">>, translate:translate(Lang, <<"Commands">>)}]} | Acc];
+    [#{category => <<"automation">>,
+       type => <<"command-list">>,
+       name => translate:translate(Lang, <<"Commands">>)} | Acc];
 get_local_identity(Acc, _From, _To, <<"ping">>, Lang) ->
-    [#xmlel{name = <<"identity">>,
-            attrs = [{<<"category">>, <<"automation">>},
-                     {<<"type">>, <<"command-node">>},
-                     {<<"name">>, translate:translate(Lang, <<"Ping">>)}]} | Acc];
+    [#{category => <<"automation">>,
+       type => <<"command-node">>,
+       name => translate:translate(Lang, <<"Ping">>)} | Acc];
 get_local_identity(Acc, _From, _To, _Node, _Lang) ->
     Acc.
 

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -148,23 +148,21 @@ process_local_iq_info(From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl
             {Acc, IQ#iq{type = result,
                   sub_el = [#xmlel{name = <<"query">>,
                                    attrs = [{<<"xmlns">>, ?NS_DISCO_INFO} | ANode],
-                                   children = Identity ++ Info ++
-                                   mongoose_disco:features_to_xml(Features)}]}};
+                                   children = mongoose_disco:identities_to_xml(Identity) ++
+                                       Info ++
+                                       mongoose_disco:features_to_xml(Features)}]}};
         empty ->
             Error = mongoose_xmpp_errors:item_not_found(),
             {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}}
     end.
 
--spec get_local_identity(Acc :: [exml:element()],
-                        From :: jid:jid(),
-                        To :: jid:jid(),
-                        Node :: binary(),
-                        Lang :: ejabberd:lang()) -> [exml:element()].
+-spec get_local_identity([mongoose_disco:identity()], jid:jid(), jid:jid(), binary(),
+                         ejabberd:lang()) ->
+          [mongoose_disco:identity()].
 get_local_identity(Acc, _From, _To, <<>>, _Lang) ->
-    Acc ++ [#xmlel{name = <<"identity">>,
-                   attrs = [{<<"category">>, <<"server">>},
-                            {<<"type">>, <<"im">>},
-                            {<<"name">>, <<"MongooseIM">>}]}];
+    [#{category => <<"server">>,
+       type => <<"im">>,
+       name => <<"MongooseIM">>}] ++ Acc;
 get_local_identity(Acc, _From, _To, Node, _Lang) when is_binary(Node) ->
     Acc.
 

--- a/src/mongoose_disco.erl
+++ b/src/mongoose_disco.erl
@@ -4,7 +4,8 @@
          add_features/2,
          features_to_xml/1,
          add_items/2,
-         items_to_xml/1]).
+         items_to_xml/1,
+         identities_to_xml/1]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -15,7 +16,9 @@
 -type item_acc() :: empty | {result, [item()]}.
 -type item() :: #{jid := jid:lserver(), name => binary(), node => binary()}.
 
--export_type([item_acc/0, feature_acc/0, item/0, feature/0]).
+-type identity() :: #{category := binary(), type := binary(), name => binary()}.
+
+-export_type([item_acc/0, feature_acc/0, item/0, feature/0, identity/0]).
 
 %% @doc Run the 'disco_local_features' hook and unpack the results.
 %% Used by extension modules which support their own subdomains
@@ -61,3 +64,12 @@ item_to_xml(Item) ->
     #xmlel{name = <<"item">>,
            attrs = lists:map(fun({Key, Value}) -> {atom_to_binary(Key, utf8), Value} end,
                              maps:to_list(Item))}.
+
+-spec identities_to_xml([identity()]) -> [exml:element()].
+identities_to_xml(Identities) ->
+    lists:map(fun identity_to_xml/1, Identities).
+
+identity_to_xml(Identity) ->
+    #xmlel{name = <<"identity">>,
+           attrs = lists:map(fun({Key, Value}) -> {atom_to_binary(Key, utf8), Value} end,
+                             maps:to_list(Identity))}.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -9,7 +9,6 @@
 -include("mod_privacy.hrl").
 
 -export([adhoc_local_commands/4,
-         adhoc_sm_items/4,
          adhoc_sm_commands/4,
          anonymous_purge_hook/3,
          auth_failed/3,
@@ -179,16 +178,6 @@ c2s_remote_hook(HostType, Tag, Args, HandlerState, C2SState) ->
 adhoc_local_commands(LServer, From, To, AdhocRequest) ->
     ejabberd_hooks:run_for_host_type(adhoc_local_commands, LServer, empty,
                                      [From, To, AdhocRequest]).
-
--spec adhoc_sm_items(LServer, From, To, Lang) -> Result when
-    LServer :: jid:lserver(),
-    From :: jid:jid(),
-    To :: jid:jid(),
-    Lang :: ejabberd:lang(),
-    Result :: {result, [exml:element()]}.
-adhoc_sm_items(LServer, From, To, Lang) ->
-    ejabberd_hooks:run_for_host_type(adhoc_sm_items, LServer, {result, []},
-                                     [From, To, Lang]).
 
 -spec adhoc_sm_commands(LServer, From, To, AdhocRequest) -> Result when
     LServer :: jid:lserver(),
@@ -1292,8 +1281,7 @@ disco_sm_identity(Server, From, To, Node, Lang) ->
                      From :: jid:jid(),
                      To :: jid:jid(),
                      Node :: binary(),
-                     Lang :: ejabberd:lang()) ->
-    {error, any()} | {result, [exml:element()]}.
+                     Lang :: ejabberd:lang()) -> mongoose_disco:item_acc().
 disco_sm_items(Server, From, To, Node, Lang) ->
     ejabberd_hooks:run_for_host_type(disco_sm_items, Server, empty,
                                      [From, To, Node, Lang]).

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1270,9 +1270,9 @@ disco_local_identity(Server, From, To, Node, Lang) ->
     To :: jid:jid(),
     Node :: binary(),
     Lang :: ejabberd:lang(),
-    Result :: {error, any()} | {result, [exml:element()]}.
+    Result :: mongoose_disco:feature_acc().
 disco_sm_features(Server, From, To, Node, Lang) ->
-    ejabberd_hooks:run_for_host_type(disco_local_features, Server, empty,
+    ejabberd_hooks:run_for_host_type(disco_sm_features, Server, empty,
                                      [From, To, Node, Lang]).
 
 %%% @doc `disco_sm_identity' hook is called to get the identity of the

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1270,7 +1270,7 @@ disco_sm_features(Server, From, To, Node, Lang) ->
                         From :: jid:jid(),
                         To :: jid:jid(),
                         Node :: mod_pubsub:nodeId(),
-                        Lang :: ejabberd:lang()) -> [exml:element()].
+                        Lang :: ejabberd:lang()) -> [mongoose_disco:identity()].
 disco_sm_identity(Server, From, To, Node, Lang) ->
     ejabberd_hooks:run_for_host_type(disco_sm_identity, Server, [],
                                      [From, To, Node, Lang]).

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1257,7 +1257,7 @@ disco_local_items(HostType, From, To, Node, Lang) ->
     To :: jid:jid(),
     Node :: binary(),
     Lang :: ejabberd:lang(),
-    Result :: [exml:element()].
+    Result :: [mongoose_disco:identity()].
 disco_local_identity(Server, From, To, Node, Lang) ->
     ejabberd_hooks:run_for_host_type(disco_local_identity, Server, [],
                                      [From, To, Node, Lang]).

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -361,18 +361,16 @@ code_change(_OldVsn, State, _Extra) ->
 %% Handlers
 %% ------------------------------------------------------------------
 
+-spec get_sm_features(mongoose_disco:feature_acc(), jid:jid(), jid:jid(), binary(),
+                      ejabberd:lang()) ->
+          mongoose_disco:feature_acc().
 get_sm_features(Acc, _From, _To, <<"">> = _Node, _Lang) ->
-    add_feature(Acc, ?NS_FEATURE_MSGOFFLINE);
+    mongoose_disco:add_features([?NS_FEATURE_MSGOFFLINE], Acc);
 get_sm_features(_Acc, _From, _To, ?NS_FEATURE_MSGOFFLINE, _Lang) ->
     %% override all lesser features...
     {result, []};
 get_sm_features(Acc, _From, _To, _Node, _Lang) ->
     Acc.
-
-add_feature({result, Features}, Feature) ->
-    {result, Features ++ [Feature]};
-add_feature(_, Feature) ->
-    {result, [Feature]}.
 
 %% This function should be called only from a hook
 %% Calling it directly is dangerous and may store unwanted messages

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -690,21 +690,14 @@ disco_identity(Host, Node, From) ->
         _ -> []
     end.
 
--spec disco_sm_features(
-        Acc  :: empty | {result, Features::[Feature::binary()]} | {error, any()},
-          From ::jid:jid(),
-          To   ::jid:jid(),
-          Node :: mod_pubsub:nodeId(),
-          Lang :: binary())
-        -> {result, Features::[Feature::binary()]} | {error, any()}.
-disco_sm_features(empty, From, To, Node, Lang) ->
-    disco_sm_features({result, []}, From, To, Node, Lang);
-disco_sm_features({result, OtherFeatures} = _Acc, From, To, Node, _Lang) ->
-    {result,
-     OtherFeatures ++
-         disco_features(jid:to_lower(jid:to_bare(To)), Node, From)};
-disco_sm_features(Acc, _From, _To, _Node, _Lang) -> Acc.
+-spec disco_sm_features(mongoose_disco:feature_acc(), jid:jid(), jid:jid(), binary(),
+                        ejabberd:lang()) ->
+          mongoose_disco:feature_acc().
+disco_sm_features(Acc, From, To, Node, _Lang) ->
+    Features = disco_features(jid:to_lower(jid:to_bare(To)), Node, From),
+    mongoose_disco:add_features(Features, Acc).
 
+-spec disco_features(error | jid:simple_jid(), binary(), jid:jid()) -> [mongoose_disco:feature()].
 disco_features(error, _Node, _From) ->
     [];
 disco_features(Host, <<>>, _From) ->


### PR DESCRIPTION
Further preparation and cleanup of disco-related code.

Some functionality was untested (and even broken). Tests added, bugs fixed. This will help assure that after introducing host types everything is still working.

Planned for the next PR: introduce host types to `mod_disco` and all the hooks to support dynamic domains.

Skipped for now: unit tests for `mongoose_disco`. It is a simple module covered by multiple functional tests.

Not sure: more pubsub tests. It's a deep rabbit hole, so I needed to stop at some point. A few lines I touched remain untested, just as before.
