### PR TITLE
Multitenancy for the Client REST API for MAM and MUC-light

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -94,6 +94,11 @@
   unacknowledged_message_hook_offline],
  "at the moment mod_offline doesn't support dynamic domains"}.
 {suites, "tests", rest_client_SUITE}.
+{skip_groups, "tests", rest_client_SUITE, [roster],
+ "at the moment mod_roster doesn't support dynamic domains"}.
+{skip_cases, "tests", rest_client_SUITE,
+ [non_default_http_server_name_is_returned_if_configured],
+ "at the moment mim2 node is not configured for dynamic domains"}.
 
 {config, ["dynamic_domains.config", "test.config"]}.
 

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -93,6 +93,7 @@
   resume_expired_session_returns_correct_h,
   unacknowledged_message_hook_offline],
  "at the moment mod_offline doesn't support dynamic domains"}.
+{suites, "tests", rest_client_SUITE}.
 
 {config, ["dynamic_domains.config", "test.config"]}.
 

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -115,14 +115,9 @@ security_test_cases() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(shotgun),
-    HostType = host_type(),
-    Config1 = dynamic_modules:save_modules(HostType, Config),
-    Config2 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config1),
-    MucPattern = distributed_helper:subhost_pattern(muc_light_helper:muc_host_pattern()),
-    dynamic_modules:restart(HostType, mod_muc_light,
-                          [{host, MucPattern},
-                           {rooms_in_rosters, true}]),
-    [{muc_light_host, muc_light_helper:muc_host()} | escalus:init_per_suite(Config2)].
+    Config1 = init_modules(Config),
+    [{muc_light_host, muc_light_helper:muc_host()}
+     | escalus:init_per_suite(Config1)].
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
@@ -130,6 +125,19 @@ end_per_suite(Config) ->
     application:stop(shotgun),
     dynamic_modules:restore_modules(HostType, Config),
     escalus:end_per_suite(Config).
+
+modules() ->
+    MucPattern = distributed_helper:subhost_pattern(muc_light_helper:muc_host_pattern()),
+    MucLight = {mod_muc_light, [{host, MucPattern},
+                                {rooms_in_rosters, true}]},
+    [MucLight].
+
+init_modules(Config) ->
+    HostType = host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config),
+    Config2 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config1),
+    dynamic_modules:ensure_modules(HostType, modules()),
+    Config2.
 
 init_per_group(_GN, C) ->
     C.

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -119,7 +119,7 @@ init_per_suite(Config) ->
     Config1 = dynamic_modules:save_modules(HostType, Config),
     Config2 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config1),
     MucPattern = distributed_helper:subhost_pattern(muc_light_helper:muc_host_pattern()),
-    dynamic_modules:start(HostType, mod_muc_light,
+    dynamic_modules:restart(HostType, mod_muc_light,
                           [{host, MucPattern},
                            {rooms_in_rosters, true}]),
     [{muc_light_host, muc_light_helper:muc_host()} | escalus:init_per_suite(Config2)].

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -329,44 +329,44 @@ to_list(V) when is_binary(V) ->
 to_list(V) when is_list(V) ->
     V.
 
-maybe_enable_mam(rdbms, Host, Config) ->
-    maybe_disable_mam(rdbms, Host),
+maybe_enable_mam(rdbms, HostType, Config) ->
+    maybe_disable_mam(rdbms, HostType),
     MucPattern = subhost_pattern(muc_light_helper:muc_host_pattern()),
-    init_module(Host, mod_mam_rdbms_arch, []),
-    init_module(Host, mod_mam_muc_rdbms_arch, []),
-    init_module(Host, mod_mam_rdbms_prefs, [muc, pm]),
-    init_module(Host, mod_mam_rdbms_user, [muc, pm]),
-    init_module(Host, mod_mam, [{archive_chat_markers, true}]),
-    init_module(Host, mod_mam_muc, [{host, MucPattern},
+    init_module(HostType, mod_mam_rdbms_arch, []),
+    init_module(HostType, mod_mam_muc_rdbms_arch, []),
+    init_module(HostType, mod_mam_rdbms_prefs, [muc, pm]),
+    init_module(HostType, mod_mam_rdbms_user, [muc, pm]),
+    init_module(HostType, mod_mam, [{archive_chat_markers, true}]),
+    init_module(HostType, mod_mam_muc, [{host, MucPattern},
                                     {archive_chat_markers, true}]),
     [{mam_backend, rdbms} | Config];
-maybe_enable_mam(riak, Host,  Config) ->
-    maybe_disable_mam(riak, Host),
+maybe_enable_mam(riak, HostType,  Config) ->
+    maybe_disable_mam(riak, HostType),
     MucPattern = subhost_pattern(muc_light_helper:muc_host_pattern()),
-    init_module(Host, mod_mam_riak_timed_arch_yz, [pm, muc]),
-    init_module(Host, mod_mam_mnesia_prefs, [pm, muc]),
-    init_module(Host, mod_mam, [{archive_chat_markers, true}]),
-    init_module(Host, mod_mam_muc, [{host, MucPattern},
+    init_module(HostType, mod_mam_riak_timed_arch_yz, [pm, muc]),
+    init_module(HostType, mod_mam_mnesia_prefs, [pm, muc]),
+    init_module(HostType, mod_mam, [{archive_chat_markers, true}]),
+    init_module(HostType, mod_mam_muc, [{host, MucPattern},
                                     {archive_chat_markers, true}]),
     [{mam_backend, riak}, {archive_wait, 2500} | Config];
 maybe_enable_mam(_, _, C) ->
     [{mam_backend, disabled} | C].
 
-init_module(Host, Mod, Opts) ->
-    dynamic_modules:start(Host, Mod, Opts).
+init_module(HostType, Mod, Opts) ->
+    dynamic_modules:start(HostType, Mod, Opts).
 
-maybe_disable_mam(rdbms, Host) ->
-    stop_module(Host, mod_mam_muc_rdbms_arch),
-    stop_module(Host, mod_mam_rdbms_arch),
-    stop_module(Host, mod_mam_rdbms_prefs),
-    stop_module(Host, mod_mam_rdbms_user),
-    stop_module(Host, mod_mam),
-    stop_module(Host, mod_mam_muc);
-maybe_disable_mam(riak, Host) ->
-    stop_module(Host, mod_mam_riak_timed_arch_yz),
-    stop_module(Host, mod_mam_mnesia_prefs),
-    stop_module(Host, mod_mam),
-    stop_module(Host, mod_mam_muc);
+maybe_disable_mam(rdbms, HostType) ->
+    stop_module(HostType, mod_mam_muc_rdbms_arch),
+    stop_module(HostType, mod_mam_rdbms_arch),
+    stop_module(HostType, mod_mam_rdbms_prefs),
+    stop_module(HostType, mod_mam_rdbms_user),
+    stop_module(HostType, mod_mam),
+    stop_module(HostType, mod_mam_muc);
+maybe_disable_mam(riak, HostType) ->
+    stop_module(HostType, mod_mam_riak_timed_arch_yz),
+    stop_module(HostType, mod_mam_mnesia_prefs),
+    stop_module(HostType, mod_mam),
+    stop_module(HostType, mod_mam_muc);
 maybe_disable_mam(_, _) ->
     ok.
 

--- a/src/mongoose_client_api/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms.erl
@@ -157,7 +157,8 @@ user_to_json({UserServer, Role}) ->
       role => Role}.
 
 muc_light_domain(Server) ->
-    gen_mod:get_module_opt_subhost(Server, mod_muc_light, mod_muc_light:default_host()).
+    HostType = mod_muc_light_utils:server_host_to_host_type(Server),
+    mod_muc_light_utils:server_host_to_muc_host(HostType, Server).
 
 determine_role(US, Users) ->
     case lists:keyfind(US, 1, Users) of

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -183,8 +183,9 @@ invite_to_room(Domain, RoomName, Sender, Recipient0) ->
 
 change_affiliation(Domain, RoomID, Sender, Recipient0, Affiliation) ->
     Recipient1 = jid:binary_to_bare(Recipient0),
-    MUCLightDomain = gen_mod:get_module_opt_subhost(Domain, mod_muc_light,
-                                                    mod_muc_light:default_host()),
+    LServer = jid:nameprep(Domain),
+    HostType = mod_muc_light_utils:server_host_to_host_type(LServer),
+    MUCLightDomain = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
     R = jid:make(RoomID, MUCLightDomain, <<>>),
     S = jid:binary_to_bare(Sender),
     Changes = query(?NS_MUC_LIGHT_AFFILIATIONS,
@@ -195,8 +196,8 @@ change_affiliation(Domain, RoomID, Sender, Recipient0, Affiliation) ->
 change_room_config(Domain, RoomID, RoomName, User, Subject) ->
     LServer = jid:nameprep(Domain),
     HostType = lserver_to_host_type(LServer),
-    MUCLightDomain = gen_mod:get_module_opt_subhost(
-                       Domain, mod_muc_light, mod_muc_light:default_host()),
+    HostType = mod_muc_light_utils:server_host_to_host_type(LServer),
+    MUCLightDomain = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
     UserUS = jid:binary_to_bare(User),
     ConfigReq = #config{ raw_config =
                          [{<<"roomname">>, RoomName}, {<<"subject">>, Subject}]},
@@ -252,13 +253,14 @@ delete_room(DomainName, RoomName, Owner) ->
 %% Ancillary
 %%--------------------------------------------------------------------
 
-create_room(Domain, Identifier, RoomName, Creator, Subject) ->
-    C = jid:to_lus(jid:from_binary(Creator)),
-    MUCLightDomain = gen_mod:get_module_opt_subhost(
-                       Domain, mod_muc_light, mod_muc_light:default_host()),
-    MUCService = jid:make(Identifier, MUCLightDomain, <<>>),
-    Config = make_room_config(RoomName, Subject),
-    case mod_muc_light:try_to_create_room(C, MUCService, Config) of
+create_room(Domain, RoomId, RoomTitle, Creator, Subject) ->
+    LServer = jid:nameprep(Domain),
+    HostType = mod_muc_light_utils:server_host_to_host_type(LServer),
+    MUCLightDomain = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
+    CreatorUS = jid:to_lus(jid:from_binary(Creator)),
+    MUCServiceJID = jid:make(RoomId, MUCLightDomain, <<>>),
+    Config = make_room_config(RoomTitle, Subject),
+    case mod_muc_light:try_to_create_room(CreatorUS, MUCServiceJID, Config) of
         {ok, RoomUS, _} ->
             jid:to_binary(RoomUS);
         {error, exists} ->

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -195,7 +195,6 @@ change_affiliation(Domain, RoomID, Sender, Recipient0, Affiliation) ->
 
 change_room_config(Domain, RoomID, RoomName, User, Subject) ->
     LServer = jid:nameprep(Domain),
-    HostType = lserver_to_host_type(LServer),
     HostType = mod_muc_light_utils:server_host_to_host_type(LServer),
     MUCLightDomain = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
     UserUS = jid:binary_to_bare(User),
@@ -207,14 +206,6 @@ change_room_config(Domain, RoomID, RoomName, User, Subject) ->
             ok;
         {error, Reason} ->
             {error, internal, Reason}
-    end.
-
-lserver_to_host_type(LServer) ->
-    case mongoose_domain_api:get_domain_host_type(LServer) of
-        {ok, HostType} ->
-            HostType;
-        {error, not_found} ->
-            LServer
     end.
 
 send_message(Domain, RoomName, Sender, Message) ->

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -34,6 +34,7 @@
 -export([room_jid_to_server_host/1]).
 -export([muc_host_to_host_type/1]).
 -export([server_host_to_host_type/1]).
+-export([server_host_to_muc_host/2]).
 -export([run_forget_room_hook/1]).
 
 -include("jlib.hrl").
@@ -311,6 +312,12 @@ muc_host_to_host_type(MucHost) ->
         Other ->
             error({muc_host_to_host_type_failed, MucHost, Other})
     end.
+
+subdomain_pattern(HostType) ->
+    gen_mod:get_module_opt(HostType, mod_muc_light, host, mod_muc_light:default_host()).
+
+server_host_to_muc_host(HostType, ServerHost) ->
+    mongoose_subdomain_utils:get_fqdn(subdomain_pattern(HostType), ServerHost).
 
 run_forget_room_hook({Room, MucHost}) ->
     case mongoose_domain_api:get_subdomain_host_type(MucHost) of


### PR DESCRIPTION
This PR addresses "Multitenancy for the Client REST API for MAM and MUC-light".

Proposed changes include:
* rooms and messages endpoints

* roster not included, because roster does not support MT yet.

* We also log more in rest_helper in tests now (similar to the way we log stanzas).