### PR TITLE
Change how reporters subscribe to metrics

### DIFF
--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -52,15 +52,7 @@ binary_to_metric_atom(Binary) ->
 
 ensure_metric(Metric, Type) ->
     case mongoose_metrics:ensure_metric(global, Metric, Type) of
-        ok ->
-            Reporters = exometer_report:list_reporters(),
-            Interval = mongoose_metrics:get_report_interval(),
-            lists:foreach(
-              fun(Reporter) ->
-                      mongoose_metrics:subscribe_metric(Reporter, {[global | Metric], Type, []},
-                                                        Interval)
-              end,
-              Reporters);
+        ok -> ok;
         {ok, already_present} ->
             ?LOG_DEBUG(#{what => metric_already_present,
                          metric => Metric, type => Type}),


### PR DESCRIPTION
Now every call to `ensure_metric/3` also subscribes all reporters to it, which I think is a less surprising API. This makes `init_subscriptions/0` redundant. The benefit is that some metrics started after the call to mongoose_metrics:init were not reported (`global.unregister_command`), thus not visible in Graphite for example, and now such situation is impossible.

This PR is just a proposition to solve the problem. The upside is that if you _ensure_ a metric exists, it is also reported (if any reporters are set). The downside is that there is less flexibility in adding reporters, or for example using some reporters for some metrics, and not subscribing them to others.

