### PR TITLE
updating mod_stream_management module

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -77,6 +77,23 @@
   disco_rooms_rsm],
  "at the moment mod_disco doesn't support dynamic domains"}.
 
+{suites, "tests", sm_SUITE}.
+{skip_cases, "tests", sm_SUITE,
+ [basic_ack,
+  h_ok_after_session_enabled_after_session,
+  subscription_requests_are_buffered_properly],
+ "at the moment mod_roster doesn't support dynamic domains"}.
+{skip_cases, "tests", sm_SUITE,
+ [resend_unacked_on_reconnection,
+  session_established,
+  wait_for_resumption,
+  resume_session_kills_old_C2S_gracefully,
+  resend_unacked_after_resume_timeout,
+  resend_more_offline_messages_than_buffer_size,
+  resume_expired_session_returns_correct_h,
+  unacknowledged_message_hook_offline],
+ "at the moment mod_offline doesn't support dynamic domains"}.
+
 {config, ["dynamic_domains.config", "test.config"]}.
 
 {logdir, "ct_report"}.

--- a/big_tests/tests/ct_helper.erl
+++ b/big_tests/tests/ct_helper.erl
@@ -1,8 +1,9 @@
 -module(ct_helper).
 -export([is_ct_running/0,
-        repeat_all_until_all_ok/1,
-        repeat_all_until_all_ok/2
-        ]).
+         repeat_all_until_all_ok/1,
+         repeat_all_until_all_ok/2,
+         repeat_all_until_any_fail/1,
+         repeat_all_until_any_fail/2]).
 
 -type group_name() :: atom().
 
@@ -27,6 +28,11 @@ is_ct_running() ->
 repeat_all_until_all_ok(GroupDefs) ->
     repeat_all_until_all_ok(GroupDefs, 3).
 
+-spec repeat_all_until_any_fail([group_def() | group_def_dirty() | group_def_incomplete()]) ->
+    [group_def()].
+repeat_all_until_any_fail(GroupDefs) ->
+    repeat_all_until_any_fail(GroupDefs, 100).
+
 %% @doc repeat_all_until_all_ok/2 will rewrite your group definitions so that
 %% the `{repeat_until_all_ok, Retries}` property is added to all of them.
 %% For example, for the following definitions:
@@ -49,6 +55,13 @@ repeat_all_until_all_ok(GroupDefs) ->
     [group_def()].
 repeat_all_until_all_ok(GroupDefs, Retries) ->
     [ {Name, maybe_add_repeat_type(repeat_until_all_ok, Retries, Properties), Tests}
+      || {Name, Properties, Tests} <- prepare_group_defs(GroupDefs) ].
+
+-spec repeat_all_until_any_fail([group_def() | group_def_dirty() | group_def_incomplete()],
+                                 repeat_num()) ->
+    [group_def()].
+repeat_all_until_any_fail(GroupDefs, Retries) ->
+    [ {Name, maybe_add_repeat_type(repeat_until_any_fail, Retries, Properties), Tests}
       || {Name, Properties, Tests} <- prepare_group_defs(GroupDefs) ].
 
 -spec maybe_add_repeat_type(repeat_type(), repeat_num(), group_props()) -> group_props().

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -44,7 +44,7 @@ groups() ->
          {stream_mgmt_disabled, [], stream_mgmt_disabled_cases()},
          {manual_ack_freq_long_session_timeout, [parallel], [preserve_order]},
          {unacknowledged_message_hook, [parallel], unacknowledged_message_hook()}],
-    ct_helper:repeat_all_until_any_fail(G).
+    ct_helper:repeat_all_until_all_ok(G).
 
 
 parallel_test_cases() ->
@@ -717,7 +717,7 @@ resume_session_state_send_message(Config) ->
     %% send some messages and check if c2s can handle it
     escalus_connection:send(Bob, escalus_stanza:chat_to(common_helper:get_bjid(AliceSpec), <<"msg-2">>)),
     escalus_connection:send(Bob, escalus_stanza:chat_to(common_helper:get_bjid(AliceSpec), <<"msg-3">>)),
-    %% suspend the process to ensure that Alice have enough time to reconnect,
+    %% suspend the process to ensure that Alice has enough time to reconnect,
     %% before resumption timeout occurs.
     ok = rpc(mim(), sys, suspend, [C2SPid]),
 
@@ -772,7 +772,7 @@ resume_session_state_stop_c2s(Config) ->
     1 = length(get_user_alive_resources(AliceSpec)),
     rpc(mim(), ejabberd_c2s, stop, [C2SPid] ),
     wait_for_c2s_state_change(C2SPid, resume_session),
-    %% suspend the process to ensure that Alice have enough time to reconnect,
+    %% suspend the process to ensure that Alice has enough time to reconnect,
     %% before resumption timeout occurs.
     ok = rpc(mim(), sys, suspend, [C2SPid]),
 
@@ -1077,7 +1077,6 @@ buffer_unacked_messages_and_die(Config, AliceSpec, Bob, Messages) ->
     %% Alice receives them, but doesn't ack.
     Stanzas = [escalus_connection:get_stanza(Alice, {msg, I})
                || I <- lists:seq(1, 3)],
-    ct:pal("!!!~p~n",[Stanzas]),
     [escalus:assert(is_chat_message, [Msg], Stanza)
      || {Msg, Stanza} <- lists:zip(Messages, Stanzas)],
     %% Alice's connection is violently terminated.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -22,7 +22,8 @@
   auth.methods = [\"dummy\"]
   auth.dummy.base_time = 1
   auth.dummy.variance = 5
-  [host_config.modules.mod_carboncopy]"}.
+  [host_config.modules.mod_carboncopy]
+  [host_config.modules.mod_stream_management]"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
 {scram_iterations, 64}.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2757,7 +2757,7 @@ bounce_csi_buffer(#state{csi_buffer = Buffer}) ->
 %%%----------------------------------------------------------------------
 %%% XEP-0198: Stream Management
 %%%----------------------------------------------------------------------
-maybe_enable_stream_mgmt(NextState, El, StateData = #state{server = LServer}) ->
+maybe_enable_stream_mgmt(NextState, El, StateData = #state{host_type = HostType}) ->
     case {xml:get_tag_attr_s(<<"xmlns">>, El),
           StateData#state.stream_mgmt,
           xml:get_tag_attr_s(<<"resume">>, El)}
@@ -2771,9 +2771,9 @@ maybe_enable_stream_mgmt(NextState, El, StateData = #state{server = LServer}) ->
                                          enable_stream_resumption(StateData)
                                  end,
             send_element_from_server_jid(NewSD, EnabledEl),
-            BufferMax = get_buffer_max(LServer),
-            AckFreq = get_ack_freq(LServer),
-            ResumeTimeout = get_resume_timeout(LServer),
+            BufferMax = get_buffer_max(HostType),
+            AckFreq = get_ack_freq(HostType),
+            ResumeTimeout = get_resume_timeout(HostType),
             fsm_next_state(NextState,
                            NewSD#state{stream_mgmt = true,
                                        stream_mgmt_buffer_max = BufferMax,
@@ -2958,17 +2958,17 @@ drop_last(N, List) ->
                                   end, {N, []}, List),
     {N - ToDrop, List2}.
 
--spec get_buffer_max(jid:lserver()) -> pos_integer() | infinity.
-get_buffer_max(LServer) ->
-    mod_stream_management:get_buffer_max(LServer, ?STREAM_MGMT_CACHE_MAX).
+-spec get_buffer_max(mongooseim:host_type()) -> pos_integer() | infinity.
+get_buffer_max(HostType) ->
+    mod_stream_management:get_buffer_max(HostType, ?STREAM_MGMT_CACHE_MAX).
 
--spec get_ack_freq(jid:lserver()) -> pos_integer().
-get_ack_freq(LServer) ->
-    mod_stream_management:get_ack_freq(LServer, ?STREAM_MGMT_ACK_FREQ).
+-spec get_ack_freq(mongooseim:host_type()) -> pos_integer().
+get_ack_freq(HostType) ->
+    mod_stream_management:get_ack_freq(HostType, ?STREAM_MGMT_ACK_FREQ).
 
--spec get_resume_timeout(jid:lserver()) -> pos_integer().
-get_resume_timeout(LServer) ->
-    mod_stream_management:get_resume_timeout(LServer, ?STREAM_MGMT_RESUME_TIMEOUT).
+-spec get_resume_timeout(mongooseim:host_type()) -> pos_integer().
+get_resume_timeout(HostType) ->
+    mod_stream_management:get_resume_timeout(HostType, ?STREAM_MGMT_RESUME_TIMEOUT).
 
 maybe_send_ack_request(Acc, #state{stream_mgmt = StreamMgmt})
   when StreamMgmt =:= false; StreamMgmt =:= disabled ->
@@ -3043,11 +3043,11 @@ maybe_enter_resume_session(_SMID, #state{} = SD) ->
           end,
     {next_state, resume_session, NSD, hibernate()}.
 
-maybe_resume_session(NextState, El, StateData = #state{server = LServer}) ->
+maybe_resume_session(NextState, El, StateData = #state{host_type = HostType}) ->
     case {xml:get_tag_attr_s(<<"xmlns">>, El),
           xml:get_tag_attr_s(<<"previd">>, El)} of
         {?NS_STREAM_MGNT_3, SMID} ->
-            FromSMID = mod_stream_management:get_session_from_smid(LServer, SMID),
+            FromSMID = mod_stream_management:get_session_from_smid(HostType, SMID),
             do_resume_session(SMID, El, FromSMID, StateData);
         {InvalidNS, _} ->
             ?LOG_INFO(#{what => c2s_ignores_resume,

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -49,15 +49,15 @@
          sid :: ejabberd_sm:sid()
         }).
 
+-type buffer_max() :: pos_integer() | infinity | no_buffer.
+-type ack_freq() :: pos_integer() | never.
 %%
 %% `gen_mod' callbacks
 %%
 
-start(Host, Opts) ->
+start(HostType, Opts) ->
     ?LOG_INFO(#{what => stream_management_starting}),
-    ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
-    ejabberd_hooks:add(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
-    ejabberd_hooks:add(session_cleanup, Host, ?MODULE, session_cleanup, 50),
+    ejabberd_hooks:add(hooks(HostType)),
     mnesia:create_table(sm_session, [{ram_copies, [node()]},
                                      {attributes, record_info(fields, sm_session)}]),
     mnesia:add_table_index(sm_session, sid),
@@ -65,12 +65,15 @@ start(Host, Opts) ->
     stream_management_stale_h:maybe_start(Opts),
     ok.
 
-stop(Host) ->
+stop(HostType) ->
     ?LOG_INFO(#{what => stream_management_stopping}),
-    ejabberd_hooks:delete(sm_remove_connection_hook, Host, ?MODULE, remove_smid, 50),
-    ejabberd_hooks:delete(c2s_stream_features, Host, ?MODULE, add_sm_feature, 50),
-    ejabberd_hooks:delete(session_cleanup, Host, ?MODULE, session_cleanup, 50),
+    ejabberd_hooks:delete(hooks(HostType)),
     ok.
+
+hooks(HostType) ->
+    [{sm_remove_connection_hook, HostType, ?MODULE, remove_smid, 50},
+     {c2s_stream_features, HostType, ?MODULE, add_sm_feature, 50},
+     {session_cleanup, HostType, ?MODULE, session_cleanup, 50}].
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
@@ -133,16 +136,19 @@ sm() ->
       Info :: undefined | [any()],
       Reason :: undefined | ejabberd_sm:close_reason(),
       Acc1 :: mongoose_acc:t().
-remove_smid(Acc, SID, #jid{lserver = LServer}, _Info, _Reason) ->
-    do_remove_smid(Acc, LServer, SID).
+remove_smid(Acc, SID, _JID, _Info, _Reason) ->
+    HostType = mongoose_acc:host_type(Acc),
+    do_remove_smid(Acc, HostType, SID).
 
 -spec session_cleanup(Acc :: map(), LUser :: jid:luser(), LServer :: jid:lserver(),
                       LResource :: jid:lresource(), SID :: ejabberd_sm:sid()) -> any().
-session_cleanup(Acc, _LUser, LServer, _LResource, SID) ->
-    do_remove_smid(Acc, LServer, SID).
+session_cleanup(Acc, _LUser, _LServer, _LResource, SID) ->
+    HostType = mongoose_acc:host_type(Acc),
+    do_remove_smid(Acc, HostType, SID).
 
--spec do_remove_smid(mongoose_acc:t(), jid:lserver(), ejabberd_sm:sid()) -> mongoose_acc:t().
-do_remove_smid(Acc, LServer, SID) ->
+-spec do_remove_smid(mongoose_acc:t(), mongooseim:host_type(), ejabberd_sm:sid()) ->
+    mongoose_acc:t().
+do_remove_smid(Acc, HostType, SID) ->
     H = mongoose_acc:get(stream_mgmt, h, undefined, Acc),
     MaybeSMID = case mnesia:dirty_index_read(sm_session, SID, #sm_session.sid) of
         [] -> {error, smid_not_found};
@@ -150,7 +156,7 @@ do_remove_smid(Acc, LServer, SID) ->
             mnesia:dirty_delete(sm_session, SMID),
             case H of
                 undefined -> ok;
-                _ -> register_stale_smid_h(LServer, SMID, H)
+                _ -> register_stale_smid_h(HostType, SMID, H)
             end,
             {ok, SMID}
     end,
@@ -160,75 +166,73 @@ do_remove_smid(Acc, LServer, SID) ->
 %% `mongooseim.toml' options (don't use outside of tests)
 %%
 
--spec get_buffer_max(jid:lserver(), pos_integer() | infinity | no_buffer)
-    -> pos_integer() | infinity | no_buffer.
-get_buffer_max(LServer, Default) ->
-    gen_mod:get_module_opt(LServer, ?MODULE, buffer_max, Default).
+-spec get_buffer_max(mongooseim:host_type(), buffer_max()) -> buffer_max().
+get_buffer_max(HostType, Default) ->
+    gen_mod:get_module_opt(HostType, ?MODULE, buffer_max, Default).
 
 %% Return true if succeeded, false otherwise.
--spec set_buffer_max(jid:lserver(), pos_integer() | infinity | no_buffer | undefined)
-    -> boolean().
-set_buffer_max(LServer, undefined) ->
-    del_module_opt(LServer, ?MODULE, buffer_max);
-set_buffer_max(LServer, infinity) ->
-    set_module_opt(LServer, ?MODULE, buffer_max, infinity);
-set_buffer_max(LServer, no_buffer) ->
-    set_module_opt(LServer, ?MODULE, buffer_max, no_buffer);
-set_buffer_max(LServer, Seconds) when is_integer(Seconds), Seconds > 0 ->
-    set_module_opt(LServer, ?MODULE, buffer_max, Seconds).
+-spec set_buffer_max(mongooseim:host_type(), buffer_max() | undefined) -> boolean().
+set_buffer_max(HostType, undefined) ->
+    del_module_opt(HostType, ?MODULE, buffer_max);
+set_buffer_max(HostType, infinity) ->
+    set_module_opt(HostType, ?MODULE, buffer_max, infinity);
+set_buffer_max(HostType, no_buffer) ->
+    set_module_opt(HostType, ?MODULE, buffer_max, no_buffer);
+set_buffer_max(HostType, Seconds) when is_integer(Seconds), Seconds > 0 ->
+    set_module_opt(HostType, ?MODULE, buffer_max, Seconds).
 
--spec get_ack_freq(jid:lserver(), pos_integer() | never) -> pos_integer() | never.
-get_ack_freq(LServer, Default) ->
-    gen_mod:get_module_opt(LServer, ?MODULE, ack_freq, Default).
+-spec get_ack_freq(mongooseim:host_type(), ack_freq()) -> ack_freq().
+get_ack_freq(HostType, Default) ->
+    gen_mod:get_module_opt(HostType, ?MODULE, ack_freq, Default).
 
 %% Return true if succeeded, false otherwise.
--spec set_ack_freq(jid:lserver(), pos_integer() | never | undefined) -> boolean().
-set_ack_freq(LServer, undefined) ->
-    del_module_opt(LServer, ?MODULE, ack_freq);
-set_ack_freq(LServer, never) ->
-    set_module_opt(LServer, ?MODULE, ack_freq, never);
-set_ack_freq(LServer, Freq) when is_integer(Freq), Freq > 0 ->
-    set_module_opt(LServer, ?MODULE, ack_freq, Freq).
+-spec set_ack_freq(mongooseim:host_type(), ack_freq() | undefined) -> boolean().
+set_ack_freq(HostType, undefined) ->
+    del_module_opt(HostType, ?MODULE, ack_freq);
+set_ack_freq(HostType, never) ->
+    set_module_opt(HostType, ?MODULE, ack_freq, never);
+set_ack_freq(HostType, Freq) when is_integer(Freq), Freq > 0 ->
+    set_module_opt(HostType, ?MODULE, ack_freq, Freq).
 
--spec get_resume_timeout(jid:lserver(), pos_integer()) -> pos_integer().
-get_resume_timeout(LServer, Default) ->
-    gen_mod:get_module_opt(LServer, ?MODULE, resume_timeout, Default).
+-spec get_resume_timeout(mongooseim:host_type(), pos_integer()) -> pos_integer().
+get_resume_timeout(HostType, Default) ->
+    gen_mod:get_module_opt(HostType, ?MODULE, resume_timeout, Default).
 
--spec set_resume_timeout(jid:lserver(), pos_integer()) -> boolean().
-set_resume_timeout(LServer, ResumeTimeout) ->
-    set_module_opt(LServer, ?MODULE, resume_timeout, ResumeTimeout).
+-spec set_resume_timeout(mongooseim:host_type(), pos_integer()) -> boolean().
+set_resume_timeout(HostType, ResumeTimeout) ->
+    set_module_opt(HostType, ?MODULE, resume_timeout, ResumeTimeout).
 
 
--spec get_stale_h_opt(LServer :: jid:lserver(), Opt :: atom(), Def :: pos_integer()) -> pos_integer().
-get_stale_h_opt(LServer, Option, Default) ->
-    MaybeModOpts = gen_mod:get_module_opt(LServer, ?MODULE, stale_h, []),
+-spec get_stale_h_opt(mongooseim:host_type(), atom(), pos_integer()) -> pos_integer().
+get_stale_h_opt(HostType, Option, Default) ->
+    MaybeModOpts = gen_mod:get_module_opt(HostType, ?MODULE, stale_h, []),
     proplists:get_value(Option, MaybeModOpts, Default).
 
--spec get_stale_h_repeat_after(jid:lserver(), pos_integer()) -> pos_integer().
-get_stale_h_repeat_after(LServer, Default) ->
-    get_stale_h_opt(LServer, stale_h_repeat_after, Default).
+-spec get_stale_h_repeat_after(mongooseim:host_type(), pos_integer()) -> pos_integer().
+get_stale_h_repeat_after(HostType, Default) ->
+    get_stale_h_opt(HostType, stale_h_repeat_after, Default).
 
--spec get_stale_h_geriatric(jid:lserver(), pos_integer()) -> pos_integer().
-get_stale_h_geriatric(LServer, Default) ->
-    get_stale_h_opt(LServer, stale_h_geriatric, Default).
+-spec get_stale_h_geriatric(mongooseim:host_type(), pos_integer()) -> pos_integer().
+get_stale_h_geriatric(HostType, Default) ->
+    get_stale_h_opt(HostType, stale_h_geriatric, Default).
 
--spec set_stale_h_opt(LServer :: jid:lserver(), Option :: atom(), Value :: pos_integer()) -> boolean().
-set_stale_h_opt(LServer, Option, Value) ->
-    MaybeModOpts = gen_mod:get_module_opt(LServer, ?MODULE, stale_h, []),
+-spec set_stale_h_opt(mongooseim:host_type(), atom(), pos_integer()) -> boolean().
+set_stale_h_opt(HostType, Option, Value) ->
+    MaybeModOpts = gen_mod:get_module_opt(HostType, ?MODULE, stale_h, []),
     case MaybeModOpts of
         [] -> false;
         GCOpts ->
             NewGCOpts = lists:keystore(Option, 1, GCOpts, {Option, Value}),
-            set_module_opt(LServer, ?MODULE, stale_h, NewGCOpts)
+            set_module_opt(HostType, ?MODULE, stale_h, NewGCOpts)
     end.
 
--spec set_stale_h_repeat_after(jid:lserver(), pos_integer()) -> boolean().
-set_stale_h_repeat_after(LServer, ResumeTimeout) ->
-    set_stale_h_opt(LServer, stale_h_repeat_after, ResumeTimeout).
+-spec set_stale_h_repeat_after(mongooseim:host_type(), pos_integer()) -> boolean().
+set_stale_h_repeat_after(HostType, ResumeTimeout) ->
+    set_stale_h_opt(HostType, stale_h_repeat_after, ResumeTimeout).
 
--spec set_stale_h_geriatric(jid:lserver(), pos_integer()) -> boolean().
-set_stale_h_geriatric(LServer, GeriatricAge) ->
-    set_stale_h_opt(LServer, stale_h_geriatric, GeriatricAge).
+-spec set_stale_h_geriatric(mongooseim:host_type(), pos_integer()) -> boolean().
+set_stale_h_geriatric(HostType, GeriatricAge) ->
+    set_stale_h_opt(HostType, stale_h_geriatric, GeriatricAge).
 
 %%
 %% API for `ejabberd_c2s'
@@ -239,12 +243,12 @@ make_smid() ->
     base64:encode(crypto:strong_rand_bytes(21)).
 
 %% Getters
--spec get_session_from_smid(jid:lserver(), smid()) ->
+-spec get_session_from_smid(mongooseim:host_type(), smid()) ->
     {sid, ejabberd_sm:sid()} | {stale_h, non_neg_integer()} | {error, smid_not_found}.
-get_session_from_smid(LServer, SMID) ->
+get_session_from_smid(HostType, SMID) ->
     case get_sid(SMID) of
         {sid, SID} -> {sid, SID};
-        {error, smid_not_found} -> get_stale_h(LServer, SMID)
+        {error, smid_not_found} -> get_stale_h(HostType, SMID)
     end.
 
 -spec get_sid(smid()) ->
@@ -255,10 +259,10 @@ get_sid(SMID) ->
         [] -> {error, smid_not_found}
     end.
 
--spec get_stale_h(LServer :: jid:lserver(), SMID :: smid()) ->
+-spec get_stale_h(mongooseim:host_type(), SMID :: smid()) ->
     {stale_h, non_neg_integer()} | {error, smid_not_found}.
-get_stale_h(LServer, SMID) ->
-    MaybeModOpts = gen_mod:get_module_opt(LServer, ?MODULE, stale_h, []),
+get_stale_h(HostType, SMID) ->
+    MaybeModOpts = gen_mod:get_module_opt(HostType, ?MODULE, stale_h, []),
     case proplists:get_value(enabled, MaybeModOpts, false) of
         false -> {error, smid_not_found};
         true -> stream_management_stale_h:read_stale_h(SMID)
@@ -274,15 +278,15 @@ register_smid(SMID, SID) ->
               {error, Reason}
     end.
 
-register_stale_smid_h(LServer, SMID, H) ->
-    MaybeModOpts = gen_mod:get_module_opt(LServer, ?MODULE, stale_h, []),
+register_stale_smid_h(HostType, SMID, H) ->
+    MaybeModOpts = gen_mod:get_module_opt(HostType, ?MODULE, stale_h, []),
     case proplists:get_value(enabled, MaybeModOpts, false) of
         false -> ok;
         true -> stream_management_stale_h:write_stale_h(SMID, H)
     end.
 
-remove_stale_smid_h(LServer, SMID) ->
-    MaybeModOpts = gen_mod:get_module_opt(LServer, ?MODULE, stale_h, []),
+remove_stale_smid_h(HostType, SMID) ->
+    MaybeModOpts = gen_mod:get_module_opt(HostType, ?MODULE, stale_h, []),
     case proplists:get_value(enabled, MaybeModOpts, false) of
         false -> ok;
         true -> stream_management_stale_h:delete_stale_h(SMID)
@@ -294,12 +298,11 @@ remove_stale_smid_h(LServer, SMID) ->
 set_module_opt(Host, Module, Opt, Value) ->
     mod_module_opt(Host, Module, Opt, Value, fun set_opt/3).
 
-del_module_opt(Host, Module, Opt) ->
-    mod_module_opt(Host, Module, Opt, undefined, fun del_opt/3).
+del_module_opt(HostType, Module, Opt) ->
+    mod_module_opt(HostType, Module, Opt, undefined, fun del_opt/3).
 
--spec mod_module_opt(_Host, _Module, _Opt, _Value, _Modify) -> boolean().
-mod_module_opt(Host, Module, Opt, Value, Modify) ->
-    Key = {Module, Host},
+mod_module_opt(HostType, Module, Opt, Value, Modify) ->
+    Key = {Module, HostType},
     OptsList = ets:lookup(ejabberd_modules, Key),
     case OptsList of
         [] ->

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -7,6 +7,7 @@
 -export([start/2,
          stop/1,
          config_spec/0,
+         supported_features/0,
          process_buffer_and_ack/1]).
 
 %% hooks handlers
@@ -90,6 +91,8 @@ config_spec() ->
                  },
         process = fun ?MODULE:process_buffer_and_ack/1
       }.
+
+supported_features() -> [dynamic_domains].
 
 process_buffer_and_ack(KVs) ->
     {[Buffer, Ack], Opts} = proplists:split(KVs, [buffer, ack]),


### PR DESCRIPTION
This PR introduces dynamic domains support for `mod_stream_management`.
Some tests in sm_SUITE are disabled for dynamic domains because they depend on another modules that do not support dynamic domains yet.

