### PR TITLE
Use host_type/HostType names in mod_mam_rdbms_arch/mod_mam_muc_rdbms_arch

### DIFF
--- a/doc/migrations/4.2.0_4.3.0.md
+++ b/doc/migrations/4.2.0_4.3.0.md
@@ -80,7 +80,7 @@ GO
 ```
 
 
-## Groupchat hook migrations
+## Hook migrations
 
 - `filter_room_packet` hook uses a map instead of a proplist
   for the event data information.
@@ -98,6 +98,7 @@ GO
 - `get_mam_muc_gdpr_data` is called for HostType.
 - `get_mam_pm_gdpr_data` is called for HostType.
 - `get_personal_data` handlers take an extra argument: `HostType` as the second parameter.
+- `get_mam_pm_gdpr_data` and `get_mam_muc_gdpr_data` take `HostType` argument.
 
 ## Metrics REST API (obsolete)
 

--- a/src/mam/ejabberd_gen_mam_archive.erl
+++ b/src/mam/ejabberd_gen_mam_archive.erl
@@ -16,7 +16,9 @@
 -callback get_mam_muc_gdpr_data(mam_muc_gdpr_data(), mongooseim:host_type(), jid:jid()) -> mam_muc_gdpr_data().
 
 -optional_callbacks([get_mam_pm_gdpr_data/3,
-                     get_mam_muc_gdpr_data/3]).
+                     get_mam_muc_gdpr_data/3,
+                     archive_size/4,
+                     lookup_messages/3]).
 
 -type mam_pm_gdpr_data() :: [{MessageID :: bitstring(), FromJID :: bitstring(), Message :: bitstring()}].
 

--- a/src/mam/ejabberd_gen_mam_archive.erl
+++ b/src/mam/ejabberd_gen_mam_archive.erl
@@ -11,12 +11,12 @@
                           Params :: map()) -> Result when
       Result :: {ok, mod_mam:lookup_result()} | {error, 'policy-violation'}.
 
--callback get_mam_pm_gdpr_data(mam_pm_gdpr_data(), jid:jid()) -> mam_pm_gdpr_data().
+-callback get_mam_pm_gdpr_data(mam_pm_gdpr_data(), mongooseim:host_type(), jid:jid()) -> mam_pm_gdpr_data().
 
--callback get_mam_muc_gdpr_data(mam_muc_gdpr_data(), jid:jid()) -> mam_muc_gdpr_data().
+-callback get_mam_muc_gdpr_data(mam_muc_gdpr_data(), mongooseim:host_type(), jid:jid()) -> mam_muc_gdpr_data().
 
--optional_callbacks([get_mam_pm_gdpr_data/2,
-                     get_mam_muc_gdpr_data/2]).
+-optional_callbacks([get_mam_pm_gdpr_data/3,
+                     get_mam_muc_gdpr_data/3]).
 
 -type mam_pm_gdpr_data() :: [{MessageID :: bitstring(), FromJID :: bitstring(), Message :: bitstring()}].
 

--- a/src/mam/mam_decoder.erl
+++ b/src/mam/mam_decoder.erl
@@ -49,5 +49,5 @@ decode_packet(ExtBin, Env = #{db_message_codec := Codec}) ->
     mam_message:decode(Codec, Bin).
 
 -spec unescape_binary(binary(), env_vars()) -> binary().
-unescape_binary(Bin, #{host := Host}) ->
-    mongoose_rdbms:unescape_binary(Host, Bin).
+unescape_binary(Bin, #{host_type := HostType}) ->
+    mongoose_rdbms:unescape_binary(HostType, Bin).

--- a/src/mam/mam_lookup_sql.erl
+++ b/src/mam/mam_lookup_sql.erl
@@ -20,8 +20,8 @@
 
 %% The ONLY usage of Env is in these functions:
 %% The rest of code should treat Env as opaque (i.e. the code just passes Env around).
--spec host(env_vars()) -> jid:lserver().
-host(#{host := Host}) -> Host.
+-spec host_type(env_vars()) -> mongooseim:host_type().
+host_type(#{host_type := HostType}) -> HostType.
 
 -spec table(env_vars()) -> atom().
 table(#{table := Table}) -> Table.
@@ -37,7 +37,7 @@ column_to_id(#{column_to_id_fn := F}, Col) -> F(Col).
 
 
 %% This function uses some fields from Env:
-%% - host
+%% - host_type
 %% - table
 %% - index_hint_fn
 %% - columns_sql_fn
@@ -49,7 +49,7 @@ column_to_id(#{column_to_id_fn := F}, Col) -> F(Col).
                    Order :: atom(), OffsetLimit :: offset_limit()) -> term().
 lookup_query(QueryType, Env, Filters, Order, OffsetLimit) ->
     Table = table(Env),
-    Host = host(Env),
+    HostType = host_type(Env),
     StmtName = filters_to_statement_name(Env, QueryType, Table, Filters, Order, OffsetLimit),
     case mongoose_rdbms:prepared(StmtName) of
         false ->
@@ -61,7 +61,7 @@ lookup_query(QueryType, Env, Filters, Order, OffsetLimit) ->
             ok
     end,
     Args = filters_to_args(Filters, OffsetLimit),
-    mongoose_rdbms:execute_successfully(Host, StmtName, Args).
+    mongoose_rdbms:execute_successfully(HostType, StmtName, Args).
 
 lookup_sql_binary(QueryType, Table, Env, Filters, Order, OffsetLimit) ->
     iolist_to_binary(lookup_sql(QueryType, Table, Env, Filters, Order, OffsetLimit)).

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -26,7 +26,7 @@
 -export([prepared_queries/0]).
 
 %gdpr
--export([get_mam_pm_gdpr_data/2]).
+-export([get_mam_pm_gdpr_data/3]).
 
 %% ----------------------------------------------------------------------
 %% Imports
@@ -435,9 +435,10 @@ row_to_uniform_format(#{from_jid := FromJID, message := Msg, id := MsgID}) ->
 row_to_message_id(#{id := MsgID}) ->
     MsgID.
 
--spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(), jid:jid()) ->
+-spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
+                           mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_pm_gdpr_data().
-get_mam_pm_gdpr_data(Acc, JID) ->
+get_mam_pm_gdpr_data(Acc, _HostType, JID) ->
     BinJID = jid:to_binary(jid:to_lower(JID)),
     FilterMap = #{user_jid => BinJID, with_jid => <<"">>},
     Rows = fetch_user_messages(pool_name(), JID, FilterMap),

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -32,7 +32,7 @@
 -export([remove_archive/4]).
 -export([archive_size/4]).
 
--export([get_mam_pm_gdpr_data/2]).
+-export([get_mam_pm_gdpr_data/3]).
 
 -include("mongoose.hrl").
 -include("mongoose_rsm.hrl").
@@ -56,9 +56,10 @@ stop(Host) ->
     ejabberd_hooks:delete(hooks(Host)),
     ok.
 
--spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(), jid:jid()) ->
+-spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
+                           mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_pm_gdpr_data().
-get_mam_pm_gdpr_data(Acc, Owner) ->
+get_mam_pm_gdpr_data(Acc, _HostType, Owner) ->
     BinOwner = mod_mam_utils:bare_jid(Owner),
     Filter = #{term => #{owner => BinOwner}},
     Sorting = #{mam_id => #{order => asc}},

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -18,7 +18,7 @@
          remove_archive/4]).
 
 %% mongoose_cassandra callbacks
--export([prepared_queries/0, get_mam_muc_gdpr_data/2]).
+-export([prepared_queries/0, get_mam_muc_gdpr_data/3]).
 
 %% ----------------------------------------------------------------------
 %% Imports
@@ -438,9 +438,10 @@ row_to_uniform_format(#{nick_name := BNick, message := Data, id := MessID}, Room
 row_to_message_id(#{id := MsgID}) ->
     MsgID.
 
--spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(), jid:jid()) ->
+-spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(),
+                            mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_muc_gdpr_data().
-get_mam_muc_gdpr_data(Acc, Jid) ->
+get_mam_muc_gdpr_data(Acc, _HostType, Jid) ->
     BinJid = jid:to_binary(jid:to_lower(Jid)),
     PoolName = mod_mam_muc_cassandra_arch_params:pool_name(),
     FilterMap = #{from_jid  => BinJid},

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -32,7 +32,7 @@
 -export([archive_size/4]).
 
 %gdpr
--export([get_mam_muc_gdpr_data/2]).
+-export([get_mam_muc_gdpr_data/3]).
 
 -include("mongoose.hrl").
 -include("mongoose_rsm.hrl").
@@ -59,9 +59,10 @@ stop(Host) ->
 %%-------------------------------------------------------------------
 %% ejabberd_gen_mam_archive callbacks
 %%-------------------------------------------------------------------
--spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(), jid:jid()) ->
+-spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(),
+                            mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_muc_gdpr_data().
-get_mam_muc_gdpr_data(Acc, Source) ->
+get_mam_muc_gdpr_data(Acc, _HostType, Source) ->
     BinSource = mod_mam_utils:bare_jid(Source),
     Filter = #{term => #{from_jid => BinSource}},
     Sorting = #{mam_id => #{order => asc}},

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -254,7 +254,7 @@ get_retraction_info(HostType, ArcID, SenderID, OriginID, Env) ->
         execute_select_messages_to_retract(HostType, ArcID, SenderID, OriginID),
     mam_decoder:decode_retraction_info(Env, Rows).
 
-make_tombstone(_Host, ArcID, OriginID, skip, _Env) ->
+make_tombstone(_HostType, ArcID, OriginID, skip, _Env) ->
     ?LOG_INFO(#{what => make_tombstone_failed,
                 text => <<"Message to retract was not found by origin id">>,
                 user_id => ArcID, origin_id => OriginID});
@@ -321,7 +321,7 @@ extract_gdpr_messages(HostType, SenderID) ->
 %% Lookup logic
 -spec lookup_messages(Result :: any(), HostType :: mongooseim:host_type(), Params :: map()) ->
                              {ok, mod_mam:lookup_result()}.
-lookup_messages({error, _Reason} = Result, _Host, _Params) ->
+lookup_messages({error, _Reason} = Result, _HostType, _Params) ->
     Result;
 lookup_messages(_Result, HostType, Params = #{owner_jid := ArcJID}) ->
     Env = env_vars(HostType, ArcJID),

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -52,7 +52,7 @@
 %% Starting and stopping functions for users' archives
 
 -spec start(host_type(), _) -> ok.
-start(HostType, Opts) ->
+start(HostType, _Opts) ->
     start_hooks(HostType),
     register_prepared_queries(),
     ok.

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -45,23 +45,24 @@
 %% Types
 
 -type env_vars() :: mod_mam_rdbms_arch:env_vars().
+-type host_type() :: mongooseim:host_type().
 
 %% ----------------------------------------------------------------------
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(jid:server(), _) -> ok.
-start(Host, Opts) ->
-    start_hooks(Host, Opts),
+-spec start(host_type(), _) -> ok.
+start(HostType, Opts) ->
+    start_hooks(HostType),
     register_prepared_queries(),
     ok.
 
--spec stop(jid:server()) -> ok.
-stop(Host) ->
-    stop_hooks(Host).
+-spec stop(host_type()) -> ok.
+stop(HostType) ->
+    stop_hooks(HostType).
 
 -spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
-                            mongooseim:host_type(), jid:jid()) ->
+                            host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_muc_gdpr_data().
 get_mam_muc_gdpr_data(Acc, HostType, #jid{luser = LUser, lserver = LServer} = _UserJID) ->
     case mod_mam:archive_id(LServer, LUser) of
@@ -77,27 +78,27 @@ get_mam_muc_gdpr_data(Acc, HostType, #jid{luser = LUser, lserver = LServer} = _U
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam
 
--spec start_hooks(jid:server(), _) -> ok.
-start_hooks(Host, _Opts) ->
-    ejabberd_hooks:add(hooks(Host)).
+-spec start_hooks(host_type()) -> ok.
+start_hooks(HostType) ->
+    ejabberd_hooks:add(hooks(HostType)).
 
--spec stop_hooks(jid:server()) -> ok.
-stop_hooks(Host) ->
-    ejabberd_hooks:delete(hooks(Host)).
+-spec stop_hooks(host_type()) -> ok.
+stop_hooks(HostType) ->
+    ejabberd_hooks:delete(hooks(HostType)).
 
-hooks(Host) ->
-    NoWriter = gen_mod:get_module_opt(Host, ?MODULE, no_writer, false),
+hooks(HostType) ->
+    NoWriter = gen_mod:get_module_opt(HostType, ?MODULE, no_writer, false),
     case NoWriter of
         true ->
             [];
         false ->
-            [{mam_muc_archive_message, Host, ?MODULE, archive_message, 50}]
+            [{mam_muc_archive_message, HostType, ?MODULE, archive_message, 50}]
     end ++
-    [{mam_muc_archive_size, Host, ?MODULE, archive_size, 50},
-     {mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 50},
-     {mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50},
-     {remove_domain, Host, ?MODULE, remove_domain, 50},
-     {get_mam_muc_gdpr_data, Host, ?MODULE, get_mam_muc_gdpr_data, 50}].
+    [{mam_muc_archive_size, HostType, ?MODULE, archive_size, 50},
+     {mam_muc_lookup_messages, HostType, ?MODULE, lookup_messages, 50},
+     {mam_muc_remove_archive, HostType, ?MODULE, remove_archive, 50},
+     {remove_domain, HostType, ?MODULE, remove_domain, 50},
+     {get_mam_muc_gdpr_data, HostType, ?MODULE, get_mam_muc_gdpr_data, 50}].
 
 %% ----------------------------------------------------------------------
 %% SQL queries
@@ -146,10 +147,11 @@ lookup_fields() ->
      #lookup_field{op = equal, column = nick_name, param = remote_resource},
      #lookup_field{op = like, column = search_body, param = norm_search_text, value_maker = search_words}].
 
-env_vars(Host, ArcJID) ->
+-spec env_vars(host_type(), jid:jid()) -> env_vars().
+env_vars(HostType, ArcJID) ->
     %% Please, minimize the usage of the host field.
     %% It's only for passing into RDBMS.
-    #{host => Host,
+    #{host_type => HostType,
       archive_jid => ArcJID,
       table => mam_muc_message,
       index_hint_fn => fun index_hint_sql/1,
@@ -157,10 +159,10 @@ env_vars(Host, ArcJID) ->
       column_to_id_fn => fun column_to_id/1,
       lookup_fn => fun lookup_query/5,
       decode_row_fn => fun row_to_uniform_format/2,
-      has_message_retraction => mod_mam_utils:has_message_retraction(mod_mam_muc, Host),
-      has_full_text_search => mod_mam_utils:has_full_text_search(mod_mam_muc, Host),
-      db_jid_codec => db_jid_codec(Host, ?MODULE),
-      db_message_codec => db_message_codec(Host, ?MODULE)}.
+      has_message_retraction => mod_mam_utils:has_message_retraction(mod_mam_muc, HostType),
+      has_full_text_search => mod_mam_utils:has_full_text_search(mod_mam_muc, HostType),
+      db_jid_codec => db_jid_codec(HostType, ?MODULE),
+      db_message_codec => db_message_codec(HostType, ?MODULE)}.
 
 row_to_uniform_format(Row, Env) ->
     mam_decoder:decode_muc_row(Row, Env).
@@ -182,13 +184,13 @@ column_names(Mappings) ->
 %% ----------------------------------------------------------------------
 %% Options
 
--spec db_jid_codec(jid:server(), module()) -> module().
-db_jid_codec(Host, Module) ->
-    gen_mod:get_module_opt(Host, Module, db_jid_format, mam_jid_rfc).
+-spec db_jid_codec(host_type(), module()) -> module().
+db_jid_codec(HostType, Module) ->
+    gen_mod:get_module_opt(HostType, Module, db_jid_format, mam_jid_rfc).
 
--spec db_message_codec(jid:server(), module()) -> module().
-db_message_codec(Host, Module) ->
-    gen_mod:get_module_opt(Host, Module, db_message_format, mam_message_compressed_eterm).
+-spec db_message_codec(host_type(), module()) -> module().
+db_message_codec(HostType, Module) ->
+    gen_mod:get_module_opt(HostType, Module, db_message_format, mam_message_compressed_eterm).
 
 -spec get_retract_id(exml:element(), env_vars()) -> none | binary().
 get_retract_id(Packet, #{has_message_retraction := Enabled}) ->
@@ -197,81 +199,82 @@ get_retract_id(Packet, #{has_message_retraction := Enabled}) ->
 %% ----------------------------------------------------------------------
 %% Internal functions and callbacks
 
--spec archive_size(Size :: integer(), Host :: jid:server(),
+-spec archive_size(Size :: integer(), HostType :: mongooseim:host_type(),
                    ArcId :: mod_mam:archive_id(), ArcJID :: jid:jid()) -> integer().
-archive_size(Size, Host, ArcID, ArcJID) when is_integer(Size) ->
+archive_size(Size, HostType, ArcID, ArcJID) when is_integer(Size) ->
     Filter = [{equal, room_id, ArcID}],
-    Env = env_vars(Host, ArcJID),
+    Env = env_vars(HostType, ArcJID),
     Result = lookup_query(count, Env, Filter, unordered, all),
     mongoose_rdbms:selected_to_integer(Result).
 
-extend_params_with_sender_id(Host, Params = #{remote_jid := SenderJID}) ->
+extend_params_with_sender_id(HostType, Params = #{remote_jid := SenderJID}) ->
     BareSenderJID = jid:to_bare(SenderJID),
-    SenderID = mod_mam:archive_id_int(Host, BareSenderJID),
+    SenderID = mod_mam:archive_id_int(HostType, BareSenderJID),
     Params#{sender_id => SenderID}.
 
--spec archive_message(_Result, jid:server(), mod_mam:archive_message_params()) -> ok.
-archive_message(_Result, Host, Params0 = #{local_jid := ArcJID}) ->
+-spec archive_message(_Result, HostType :: mongooseim:host_type(),
+                      mod_mam:archive_message_params()) -> ok.
+archive_message(_Result, HostType, Params0 = #{local_jid := ArcJID}) ->
     try
-        Params = extend_params_with_sender_id(Host, Params0),
-        Env = env_vars(Host, ArcJID),
-        do_archive_message(Host, Params, Env),
-        retract_message(Host, Params, Env),
+        Params = extend_params_with_sender_id(HostType, Params0),
+        Env = env_vars(HostType, ArcJID),
+        do_archive_message(HostType, Params, Env),
+        retract_message(HostType, Params, Env),
         ok
     catch error:Reason:StackTrace ->
               ?LOG_ERROR(#{what => archive_message_failed,
-                           host => Host, mam_params => Params0,
+                           host_type => HostType, mam_params => Params0,
                            reason => Reason, stacktrace => StackTrace}),
               erlang:raise(error, Reason, StackTrace)
     end.
 
-do_archive_message(Host, Params, Env) ->
+do_archive_message(HostType, Params, Env) ->
     Row = mam_encoder:encode_message(Params, Env, db_mappings()),
-    {updated, 1} = mongoose_rdbms:execute_successfully(Host, insert_mam_muc_message, Row).
+    {updated, 1} = mongoose_rdbms:execute_successfully(HostType, insert_mam_muc_message, Row).
 
 %% Retraction logic
 %% Called after inserting a new message
--spec retract_message(jid:server(), mod_mam:archive_message_params()) -> ok.
-retract_message(Host, #{local_jid := ArcJID} = Params)  ->
-    Env = env_vars(Host, ArcJID),
-    retract_message(Host, Params, Env).
+-spec retract_message(mongooseim:host_type(), mod_mam:archive_message_params()) -> ok.
+retract_message(HostType, #{local_jid := ArcJID} = Params)  ->
+    Env = env_vars(HostType, ArcJID),
+    retract_message(HostType, Params, Env).
 
--spec retract_message(jid:server(), mod_mam:archive_message_params(), env_vars()) -> ok.
-retract_message(Host, #{archive_id := ArcID, sender_id := SenderID,
+-spec retract_message(mongooseim:host_type(), mod_mam:archive_message_params(), env_vars()) -> ok.
+retract_message(HostType, #{archive_id := ArcID, sender_id := SenderID,
                         packet := Packet}, Env) ->
     case get_retract_id(Packet, Env) of
         none -> ok;
         OriginIDToRetract ->
-            Info = get_retraction_info(Host, ArcID, SenderID, OriginIDToRetract, Env),
-            make_tombstone(Host, ArcID, OriginIDToRetract, Info, Env)
+            Info = get_retraction_info(HostType, ArcID, SenderID, OriginIDToRetract, Env),
+            make_tombstone(HostType, ArcID, OriginIDToRetract, Info, Env)
     end.
 
-get_retraction_info(Host, ArcID, SenderID, OriginID, Env) ->
+get_retraction_info(HostType, ArcID, SenderID, OriginID, Env) ->
     {selected, Rows} =
-        execute_select_messages_to_retract(Host, ArcID, SenderID, OriginID),
+        execute_select_messages_to_retract(HostType, ArcID, SenderID, OriginID),
     mam_decoder:decode_retraction_info(Env, Rows).
 
 make_tombstone(_Host, ArcID, OriginID, skip, _Env) ->
     ?LOG_INFO(#{what => make_tombstone_failed,
                 text => <<"Message to retract was not found by origin id">>,
                 user_id => ArcID, origin_id => OriginID});
-make_tombstone(Host, ArcID, OriginID, #{packet := Packet, message_id := MessID}, Env) ->
+make_tombstone(HostType, ArcID, OriginID, #{packet := Packet, message_id := MessID}, Env) ->
     Tombstone = mod_mam_utils:tombstone(Packet, OriginID),
     TombstoneData = mam_encoder:encode_packet(Tombstone, Env),
-    execute_make_tombstone(Host, TombstoneData, ArcID, MessID).
+    execute_make_tombstone(HostType, TombstoneData, ArcID, MessID).
 
-execute_select_messages_to_retract(Host, ArcID, SenderID, OriginID) ->
-    mongoose_rdbms:execute_successfully(Host, mam_muc_select_messages_to_retract,
+execute_select_messages_to_retract(HostType, ArcID, SenderID, OriginID) ->
+    mongoose_rdbms:execute_successfully(HostType, mam_muc_select_messages_to_retract,
                                       [ArcID, SenderID, OriginID]).
 
-execute_make_tombstone(Host, TombstoneData, ArcID, MessID) ->
-    mongoose_rdbms:execute_successfully(Host, mam_muc_make_tombstone,
+execute_make_tombstone(HostType, TombstoneData, ArcID, MessID) ->
+    mongoose_rdbms:execute_successfully(HostType, mam_muc_make_tombstone,
                                       [TombstoneData, ArcID, MessID]).
 
 %% Insert logic
--spec prepare_message(jid:server(), mod_mam:archive_message_params()) -> list().
-prepare_message(Host, Params = #{local_jid := ArcJID}) ->
-    Env = env_vars(Host, ArcJID),
+-spec prepare_message(mongooseim:host_type(), mod_mam:archive_message_params()) -> list().
+prepare_message(HostType, Params = #{local_jid := ArcJID}) ->
+    Env = env_vars(HostType, ArcJID),
     mam_encoder:encode_message(Params, Env, db_mappings()).
 
 -spec prepare_insert(Name :: atom(), NumRows :: pos_integer()) -> ok.
@@ -283,11 +286,11 @@ prepare_insert(Name, NumRows) ->
     ok.
 
 %% Removal logic
--spec remove_archive(Acc :: mongoose_acc:t(), Host :: jid:server(),
+-spec remove_archive(Acc :: mongoose_acc:t(), HostType :: mongooseim:host_type(),
                      ArcID :: mod_mam:archive_id(),
                      ArcJID :: jid:jid()) -> mongoose_acc:t().
-remove_archive(Acc, Host, ArcID, _ArcJID) ->
-    mongoose_rdbms:execute_successfully(Host, mam_muc_archive_remove, [ArcID]),
+remove_archive(Acc, HostType, ArcID, _ArcJID) ->
+    mongoose_rdbms:execute_successfully(HostType, mam_muc_archive_remove, [ArcID]),
     Acc.
 
 -spec remove_domain(mongoose_hooks:simple_acc(),
@@ -316,12 +319,12 @@ extract_gdpr_messages(HostType, SenderID) ->
     mongoose_rdbms:execute_successfully(HostType, mam_muc_extract_gdpr_messages, [SenderID]).
 
 %% Lookup logic
--spec lookup_messages(Result :: any(), Host :: jid:server(), Params :: map()) ->
+-spec lookup_messages(Result :: any(), HostType :: mongooseim:host_type(), Params :: map()) ->
                              {ok, mod_mam:lookup_result()}.
 lookup_messages({error, _Reason} = Result, _Host, _Params) ->
     Result;
-lookup_messages(_Result, Host, Params = #{owner_jid := ArcJID}) ->
-    Env = env_vars(Host, ArcJID),
+lookup_messages(_Result, HostType, Params = #{owner_jid := ArcJID}) ->
+    Env = env_vars(HostType, ArcJID),
     ExdParams = mam_encoder:extend_lookup_params(Params, Env),
     Filter = mam_filter:produce_filter(ExdParams, lookup_fields()),
     mam_lookup:lookup(Env, Filter, ExdParams).

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -14,10 +14,7 @@
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_archive).
--export([archive_size/4,
-         archive_message/3,
-         lookup_messages/3,
-         remove_archive/4]).
+-export([archive_message/3]).
 
 %% Helpers for debugging
 -export([queue_length/1,
@@ -201,23 +198,6 @@ worker_queue_length(SrvName) ->
             {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
             Len
     end.
-
-
--spec archive_size(integer(), mongooseim:host_type(), mod_mam:archive_id(),
-                   jid:jid()) -> integer().
-archive_size(Size, HostType, ArcID, _ArcJID) when is_integer(Size) ->
-    Size.
-
-
--spec lookup_messages(Result :: any(), HostType :: mongooseim:host_type(), Params :: map()) ->
-    {ok, mod_mam:lookup_result()}.
-lookup_messages(Result, HostType, #{archive_id := ArcID, end_ts := End, now := Now}) ->
-    Result.
-
-%% #rh
--spec remove_archive(map(), mongooseim:host_type(), mod_mam:archive_id(), jid:jid()) -> map().
-remove_archive(Acc, HostType, ArcID, _ArcJID) ->
-    Acc.
 
 %%====================================================================
 %% Internal functions

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -45,7 +45,7 @@
 -export([create_obj/6, read_archive/8, bucket/2,
          list_mam_buckets/1, remove_bucket/1]).
 
--export([get_mam_muc_gdpr_data/2, get_mam_pm_gdpr_data/2]).
+-export([get_mam_muc_gdpr_data/3, get_mam_pm_gdpr_data/3]).
 
 -type yearweeknum() :: {non_neg_integer(), 1..53}.
 
@@ -374,15 +374,17 @@ get_message2(Host, MsgId, Bucket, Key) ->
         _ ->
             []
     end.
--spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(), jid:jid()) ->
+-spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
+                           mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_pm_gdpr_data().
-get_mam_pm_gdpr_data(Acc, OwnerJid) ->
+get_mam_pm_gdpr_data(Acc, HostType, OwnerJid) ->
     Messages = get_mam_gdpr_data(OwnerJid, <<"pm">>),
     [{Id, jid:to_binary(Jid), exml:to_binary(Packet)} || #{id := Id, jid := Jid, packet := Packet} <- Messages] ++ Acc.
 
--spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(), jid:jid()) ->
+-spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(),
+                            mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_muc_gdpr_data().
-get_mam_muc_gdpr_data(Acc, JID) ->
+get_mam_muc_gdpr_data(Acc, _HosType, JID) ->
     Messages = get_mam_gdpr_data(JID, <<"muc">>),
     [{MsgId, exml:to_binary(Packet)} || #{id := MsgId, packet := Packet} <- Messages] ++ Acc.
 

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -377,14 +377,14 @@ get_message2(Host, MsgId, Bucket, Key) ->
 -spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
                            mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_pm_gdpr_data().
-get_mam_pm_gdpr_data(Acc, HostType, OwnerJid) ->
+get_mam_pm_gdpr_data(Acc, _HostType, OwnerJid) ->
     Messages = get_mam_gdpr_data(OwnerJid, <<"pm">>),
     [{Id, jid:to_binary(Jid), exml:to_binary(Packet)} || #{id := Id, jid := Jid, packet := Packet} <- Messages] ++ Acc.
 
 -spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_muc_gdpr_data(),
                             mongooseim:host_type(), jid:jid()) ->
     ejabberd_gen_mam_archive:mam_muc_gdpr_data().
-get_mam_muc_gdpr_data(Acc, _HosType, JID) ->
+get_mam_muc_gdpr_data(Acc, _HostType, JID) ->
     Messages = get_mam_gdpr_data(JID, <<"muc">>),
     [{MsgId, exml:to_binary(Packet)} || #{id := MsgId, packet := Packet} <- Messages] ++ Acc.
 

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -765,15 +765,17 @@ packet_to_search_body(true, Packet) ->
 packet_to_search_body(false, _Packet) ->
     <<>>.
 
--spec has_full_text_search(Module :: mod_mam | mod_mam_muc, Host :: jid:server()) -> boolean().
-has_full_text_search(Module, Host) ->
-    gen_mod:get_module_opt(Host, Module, full_text_search, true).
+-spec has_full_text_search(Module :: mod_mam | mod_mam_muc,
+                           HostType :: mongooseim:host_type()) -> boolean().
+has_full_text_search(Module, HostType) ->
+    gen_mod:get_module_opt(HostType, Module, full_text_search, true).
 
 %% Message retraction
 
--spec has_message_retraction(Module :: mod_mam | mod_mam_muc, Host :: jid:server()) -> boolean().
-has_message_retraction(Module, Host) ->
-    gen_mod:get_module_opt(Host, Module, message_retraction, true).
+-spec has_message_retraction(Module :: mod_mam | mod_mam_muc,
+                             HostType :: mongooseim:host_type()) -> boolean().
+has_message_retraction(Module, HostType) ->
+    gen_mod:get_module_opt(HostType, Module, message_retraction, true).
 
 %% -----------------------------------------------------------------------
 %% JID serialization

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -911,14 +911,14 @@ mam_archive_id(HostType, OwnerJID) ->
 
 %%% @doc The `mam_archive_size' hook is called to determine the size
 %%% of the archive for a given JID
--spec mam_archive_size(HookServer, ArchiveID, OwnerJID) -> Result when
-      HookServer :: jid:lserver(),
+-spec mam_archive_size(HostType, ArchiveID, OwnerJID) -> Result when
+      HostType :: mongooseim:host_type(),
       ArchiveID :: undefined | mod_mam:archive_id(),
       OwnerJID :: jid:jid(),
       Result :: integer().
-mam_archive_size(HookServer, ArchiveID, OwnerJID) ->
-    ejabberd_hooks:run_for_host_type(mam_archive_size, HookServer, 0,
-                                     [HookServer, ArchiveID, OwnerJID]).
+mam_archive_size(HostType, ArchiveID, OwnerJID) ->
+    ejabberd_hooks:run_for_host_type(mam_archive_size, HostType, 0,
+                                     [HostType, ArchiveID, OwnerJID]).
 
 %%% @doc The `mam_get_behaviour' hooks is called to determine if a message
 %%% should be archived or not based on a given pair of JIDs.
@@ -1020,14 +1020,14 @@ mam_muc_archive_id(HookServer, OwnerJID) ->
 
 %%% @doc The `mam_muc_archive_size' hook is called to determine
 %%% the archive size for a given room.
--spec mam_muc_archive_size(HookServer, ArchiveID, RoomJID) -> Result when
-      HookServer :: jid:lserver(),
+-spec mam_muc_archive_size(HostType, ArchiveID, RoomJID) -> Result when
+      HostType :: mongooseim:host_type(),
       ArchiveID :: undefined | mod_mam:archive_id(),
       RoomJID :: jid:jid(),
       Result :: integer().
-mam_muc_archive_size(HookServer, ArchiveID, RoomJID) ->
-    ejabberd_hooks:run_for_host_type(mam_muc_archive_size, HookServer, 0,
-                                     [HookServer, ArchiveID, RoomJID]).
+mam_muc_archive_size(HostType, ArchiveID, RoomJID) ->
+    ejabberd_hooks:run_for_host_type(mam_muc_archive_size, HostType, 0,
+                                     [HostType, ArchiveID, RoomJID]).
 
 %%% @doc The `mam_muc_get_behaviour' hooks is called to determine if a message should
 %%% be archived or not based on the given room and user JIDs.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1123,7 +1123,8 @@ mam_muc_flush_messages(HookServer, MessageCount) ->
       JID :: jid:jid(),
       Result :: ejabberd_gen_mam_archive:mam_pm_gdpr_data().
 get_mam_pm_gdpr_data(HostType, JID) ->
-    ejabberd_hooks:run_for_host_type(get_mam_pm_gdpr_data, HostType, [], [JID]).
+    ejabberd_hooks:run_for_host_type(get_mam_pm_gdpr_data, HostType, [],
+                                     [HostType, JID]).
 
 %%% @doc `get_mam_muc_gdpr_data' hook is called to provide
 %%% a user's archive for GDPR purposes.
@@ -1132,7 +1133,8 @@ get_mam_pm_gdpr_data(HostType, JID) ->
       JID :: jid:jid(),
       Result :: ejabberd_gen_mam_archive:mam_muc_gdpr_data().
 get_mam_muc_gdpr_data(HostType, JID) ->
-    ejabberd_hooks:run_for_host_type(get_mam_muc_gdpr_data, HostType, [], [JID]).
+    ejabberd_hooks:run_for_host_type(get_mam_muc_gdpr_data, HostType, [],
+                                     [HostType, JID]).
 
 %%% @doc `get_personal_data' hook is called to retrieve
 %%% a user's personal data for GDPR purposes.


### PR DESCRIPTION
This PR addresses "more pretty".

Proposed changes include:
* Use host_type/HostType names in mod_mam_rdbms_arch/mod_mam_muc_rdbms_arch
* No functional changes (it's just about variable names)
* mod_mam_rdbms_prefs is untouched to make the PR small (ok, it also fixes GDPR message extraction)