### PR TITLE
Support dynamic domains in mod_caps

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -15,10 +15,6 @@
 
 {suites, "tests", disco_and_caps_SUITE}.
 {skip_cases, "tests", disco_and_caps_SUITE,
- [caps_feature_is_advertised,
-  user_can_query_server_caps_via_disco],
- "at the moment mod_caps doesn't support dynamic domains"}.
-{skip_cases, "tests", disco_and_caps_SUITE,
  [user_can_query_friend_resources,
   user_can_query_friend_features,
   user_cannot_query_friend_resources_with_unknown_node],

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -406,8 +406,8 @@ maybe_sasl_mechanisms(#state{host_type = HostType} = S) ->
                     children = [ mechanism(M) || M <- Mechanisms, filter_mechanism(M,S) ]}]
     end.
 
-hook_enabled_features(#state{server = Server, host_type = HostType}) ->
-    mongoose_hooks:c2s_stream_features(HostType, Server).
+hook_enabled_features(#state{host_type = HostType, server = LServer}) ->
+    mongoose_hooks:c2s_stream_features(HostType, LServer).
 
 starttls_stanza(TLSRequired)
   when TLSRequired =:= required;

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1398,8 +1398,7 @@ privacy_list_push_iq(PrivListName) ->
                              Acc0 :: mongoose_acc:t(), StateData :: state()) -> routing_result().
 handle_routed_presence(From, To, Acc, StateData) ->
     Packet = mongoose_acc:element(Acc),
-    State = mongoose_hooks:c2s_presence_in(StateData#state.host_type,
-                                           StateData, From, To, Packet),
+    State = mongoose_hooks:c2s_presence_in(StateData, From, To, Packet),
     case mongoose_acc:stanza_type(Acc) of
         <<"probe">> ->
             {LFrom, LBFrom} = lowcase_and_bare(From),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -69,7 +69,7 @@
 -xep([{xep, 18}, {version, "0.2"}]).
 -behaviour(p1_fsm_old).
 
--export_type([broadcast/0, packet/0]).
+-export_type([broadcast/0, packet/0, state/0]).
 
 -type packet() :: {jid:jid(), jid:jid(), exml:element()}.
 
@@ -403,7 +403,7 @@ maybe_sasl_mechanisms(#state{host_type = HostType} = S) ->
         Mechanisms ->
             [#xmlel{name = <<"mechanisms">>,
                     attrs = [{<<"xmlns">>, ?NS_SASL}],
-                    children = [ mechanism(M) || M <- Mechanisms, filter_mechanism(M,S) ]}]
+                    children = [ mechanism(M) || M <- Mechanisms, filter_mechanism(M, S) ]}]
     end.
 
 hook_enabled_features(#state{host_type = HostType, server = LServer}) ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1135,13 +1135,11 @@ handle_incoming_message({route, From, To, Acc}, StateName, StateData) ->
     process_incoming_stanza_with_conflict_check(From, To, Acc, StateName, StateData);
 handle_incoming_message({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
     % this is used by pubsub and should be rewritten when someone rewrites pubsub module
-    #state{server = Server, host_type = HostType} = StateData,
     Acc = new_acc(StateData, #{location => ?LOCATION,
                                from_jid => From,
                                to_jid => To,
                                element => Packet}),
-    Drop = mongoose_hooks:c2s_filter_packet(HostType, Server, StateData,
-                                            Feature, To, Packet),
+    Drop = mongoose_hooks:c2s_filter_packet(StateData, Feature, To, Packet),
     case {Drop, StateData#state.jid} of
         {true, _} ->
             ?LOG_DEBUG(#{what => c2s_dropped_packet, acc => Acc,

--- a/src/ejabberd_c2s_state.erl
+++ b/src/ejabberd_c2s_state.erl
@@ -4,12 +4,14 @@
 
 -export([server/1, jid/1, host_type/1]).
 
+-spec server(state()) -> jid:lserver().
 server(#state{ server = Server }) ->
     Server.
 
+-spec host_type(state()) -> mongooseim:host_type().
 host_type(#state{ host_type = HostType }) ->
     HostType.
 
+-spec jid(state()) -> jid:jid().
 jid(#state{ jid = JID }) ->
     JID.
-

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -12,7 +12,7 @@
 -export([run_initial_check/2,
          check_packet/2,
          disco_local_features/1,
-         add_stream_feature/2
+         c2s_stream_features/3
         ]).
 
 -include("amp.hrl").
@@ -32,7 +32,7 @@ stop(Host) ->
     ejabberd_hooks:delete(hooks(Host)).
 
 hooks(Host) ->
-    [{c2s_stream_features, Host, ?MODULE, add_stream_feature, 50},
+    [{c2s_stream_features, Host, ?MODULE, c2s_stream_features, 50},
      {disco_local_features, Host, ?MODULE, disco_local_features, 99},
      {c2s_preprocessing_hook, Host, ?MODULE, run_initial_check, 10},
      {amp_verify_support, Host, ?AMP_RESOLVER, verify_support, 10},
@@ -64,7 +64,9 @@ disco_local_features(Acc = #{node := Node}) ->
         Features -> mongoose_disco:add_features(Features, Acc)
     end.
 
-add_stream_feature(Acc, _Host) ->
+-spec c2s_stream_features([exml:element()], mongooseim:host_type(), jid:lserver()) ->
+          [exml:element()].
+c2s_stream_features(Acc, _HostType, _Lserver) ->
     lists:keystore(<<"amp">>, #xmlel.name, Acc, ?AMP_FEATURE).
 
 %% Internal

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -362,26 +362,7 @@ init([HostType, Opts]) ->
                                timer:hours(24) div 1000),
     cache_tab:new(caps_features,
                   [{max_size, MaxSize}, {life_time, LifeTime}]),
-    ejabberd_hooks:add(c2s_presence_in, HostType, ?MODULE,
-                       c2s_presence_in, 75),
-    ejabberd_hooks:add(c2s_filter_packet, HostType, ?MODULE,
-                       c2s_filter_packet, 75),
-    ejabberd_hooks:add(c2s_broadcast_recipients, HostType,
-                       ?MODULE, c2s_broadcast_recipients, 75),
-    ejabberd_hooks:add(user_send_packet, HostType, ?MODULE,
-                       user_send_packet, 75),
-    ejabberd_hooks:add(user_receive_packet, HostType, ?MODULE,
-                       user_receive_packet, 75),
-    ejabberd_hooks:add(c2s_stream_features, HostType, ?MODULE,
-                       caps_stream_features, 75),
-    ejabberd_hooks:add(s2s_stream_features, HostType, ?MODULE,
-                       caps_stream_features, 75),
-    ejabberd_hooks:add(disco_local_features, HostType, ?MODULE,
-                       disco_local_features, 1),
-    ejabberd_hooks:add(disco_local_identity, HostType, ?MODULE,
-                       disco_local_identity, 1),
-    ejabberd_hooks:add(disco_info, HostType, ?MODULE,
-                       disco_info, 1),
+    ejabberd_hooks:add(hooks(HostType)),
     {ok, #state{host_type = HostType}}.
 
 -spec handle_call(term(), any(), state()) ->
@@ -398,29 +379,20 @@ handle_cast(_Msg, State) -> {noreply, State}.
 handle_info(_Info, State) -> {noreply, State}.
 
 -spec terminate(any(), state()) -> ok.
-terminate(_Reason, State) ->
-    HostType = State#state.host_type,
-    ejabberd_hooks:delete(c2s_presence_in, HostType, ?MODULE,
-                          c2s_presence_in, 75),
-    ejabberd_hooks:delete(c2s_filter_packet, HostType, ?MODULE,
-                          c2s_filter_packet, 75),
-    ejabberd_hooks:delete(c2s_broadcast_recipients, HostType,
-                          ?MODULE, c2s_broadcast_recipients, 75),
-    ejabberd_hooks:delete(user_send_packet, HostType, ?MODULE,
-                          user_send_packet, 75),
-    ejabberd_hooks:delete(user_receive_packet, HostType,
-                          ?MODULE, user_receive_packet, 75),
-    ejabberd_hooks:delete(c2s_stream_features, HostType,
-                          ?MODULE, caps_stream_features, 75),
-    ejabberd_hooks:delete(s2s_stream_features, HostType,
-                          ?MODULE, caps_stream_features, 75),
-    ejabberd_hooks:delete(disco_local_features, HostType,
-                          ?MODULE, disco_local_features, 1),
-    ejabberd_hooks:delete(disco_local_identity, HostType,
-                          ?MODULE, disco_local_identity, 1),
-    ejabberd_hooks:delete(disco_info, HostType, ?MODULE,
-                          disco_info, 1),
-    ok.
+terminate(_Reason, #state{host_type = HostType}) ->
+    ejabberd_hooks:delete(hooks(HostType)).
+
+hooks(HostType) ->
+    [{c2s_presence_in, HostType, ?MODULE, c2s_presence_in, 75},
+     {c2s_filter_packet, HostType, ?MODULE, c2s_filter_packet, 75},
+     {c2s_broadcast_recipients, HostType, ?MODULE, c2s_broadcast_recipients, 75},
+     {user_send_packet, HostType, ?MODULE, user_send_packet, 75},
+     {user_receive_packet, HostType, ?MODULE, user_receive_packet, 75},
+     {c2s_stream_features, HostType, ?MODULE, caps_stream_features, 75},
+     {s2s_stream_features, HostType, ?MODULE, caps_stream_features, 75},
+     {disco_local_features, HostType, ?MODULE, disco_local_features, 1},
+     {disco_local_identity, HostType, ?MODULE, disco_local_identity, 1},
+     {disco_info, HostType, ?MODULE, disco_info, 1}].
 
 -spec code_change(any(), state(), any()) -> {ok, state()}.
 code_change(_OldVsn, State, _Extra) -> {ok, State}.

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -47,7 +47,7 @@
 
 -export([user_send_packet/4, user_receive_packet/5,
          c2s_presence_in/2, c2s_filter_packet/6,
-         c2s_broadcast_recipients/6]).
+         c2s_broadcast_recipients/5]).
 
 %% for test cases
 -export([delete_caps/1, make_disco_hash/2]).
@@ -291,13 +291,17 @@ c2s_filter_packet(InAcc, LHost, C2SState, {pep_message, Feature}, To, _Packet) -
     end;
 c2s_filter_packet(Acc, _, _, _, _, _) -> Acc.
 
-c2s_broadcast_recipients(InAcc, LHost, C2SState, {pep_message, Feature}, _From, _Packet) ->
+-spec c2s_broadcast_recipients(Acc, ejabberd_c2s:state(), {atom(), binary()},
+                               jid:jid(), exml:element()) -> Acc
+              when Acc :: [jid:simple_jid()].
+c2s_broadcast_recipients(InAcc, C2SState, {pep_message, Feature}, _From, _Packet) ->
+    HostType = ejabberd_c2s_state:host_type(C2SState),
     case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of
         {ok, Rs} ->
-            filter_recipients_by_caps(InAcc, Feature, LHost, Rs);
+            filter_recipients_by_caps(InAcc, Feature, HostType, Rs);
         _ -> InAcc
     end;
-c2s_broadcast_recipients(Acc, _, _, _, _, _) -> Acc.
+c2s_broadcast_recipients(Acc, _, _, _, _) -> Acc.
 
 filter_recipients_by_caps(InAcc, Feature, LHost, Rs) ->
     gb_trees_fold(fun(USR, Caps, Acc) ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -39,14 +39,14 @@
          disco_local_features/1, disco_local_identity/1, disco_info/1]).
 
 %% gen_mod callbacks
--export([start/2, start_link/2, stop/1, config_spec/0]).
+-export([start/2, start_link/2, stop/1, config_spec/0, supported_features/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_info/2, handle_call/3,
          handle_cast/2, terminate/2, code_change/3]).
 
 -export([user_send_packet/4, user_receive_packet/5,
-         c2s_presence_in/2, c2s_filter_packet/5,
+         c2s_presence_in/4, c2s_filter_packet/5,
          c2s_broadcast_recipients/5]).
 
 %% for test cases
@@ -63,37 +63,47 @@
 
 -record(caps,
         {
-          node    = <<"">> :: binary(),
-          version = <<"">> :: binary(),
-          hash    = <<"">> :: binary(),
-          exts    = []     :: [binary()]
+          node = <<>> :: binary(),
+          version = <<>> :: binary(),
+          hash = <<>> :: binary(),
+          exts = [] :: [binary()]
         }).
 
 -type caps() :: #caps{}.
+-type caps_resources() :: gb_trees:tree(jid:simple_jid(), caps()).
 
 -export_type([caps/0]).
 
+-type features() :: [binary()].
+-type maybe_pending_features() :: features() | pos_integer().
+-type node_pair() :: {binary(), binary()}.
+
 -record(caps_features,
         {
-          node_pair = {<<"">>, <<"">>} :: {binary(), binary()},
-          features  = []               :: [binary()] | pos_integer()
+          node_pair = {<<>>, <<>>} :: node_pair(),
+          features = [] :: maybe_pending_features()
         }).
 
--record(state, {host = <<"">> :: binary()}).
+-record(state, {host_type :: mongooseim:host_type()}).
 
-start_link(Host, Opts) ->
-    Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
+-type state() :: #state{}.
+
+-spec start_link(mongooseim:host_type(), list()) -> any().
+start_link(HostType, Opts) ->
+    Proc = gen_mod:get_module_proc(HostType, ?PROCNAME),
     gen_server:start_link({local, Proc}, ?MODULE,
-                          [Host, Opts], []).
+                          [HostType, Opts], []).
 
-start(Host, Opts) ->
-    Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
-    ChildSpec = {Proc, {?MODULE, start_link, [Host, Opts]},
+-spec start(mongooseim:host_type(), list()) -> any().
+start(HostType, Opts) ->
+    Proc = gen_mod:get_module_proc(HostType, ?PROCNAME),
+    ChildSpec = {Proc, {?MODULE, start_link, [HostType, Opts]},
                  transient, 1000, worker, [?MODULE]},
     ejabberd_sup:start_child(ChildSpec).
 
-stop(Host) ->
-    Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
+-spec stop(mongooseim:host_type()) -> any().
+stop(HostType) ->
+    Proc = gen_mod:get_module_proc(HostType, ?PROCNAME),
     gen_server:call(Proc, stop),
     ejabberd_sup:stop_child(Proc).
 
@@ -107,20 +117,23 @@ config_spec() ->
                 }
       }.
 
-get_features_list(Host, Caps) ->
-    case get_features(Host, Caps) of
+supported_features() -> [dynamic_domains].
+
+-spec get_features_list(mongooseim:host_type(), nothing | caps()) -> features().
+get_features_list(HostType, Caps) ->
+    case get_features(HostType, Caps) of
         unknown -> [];
         Features -> Features
     end.
 
--spec get_features(jid:lserver(), nothing | caps()) -> unknown | list().
-get_features(_LHost, nothing) -> [];
-get_features(LHost, #caps{node = Node, version = Version, exts = Exts}) ->
+-spec get_features(mongooseim:host_type(), nothing | caps()) -> unknown | features().
+get_features(_HostType, nothing) -> [];
+get_features(HostType, #caps{node = Node, version = Version, exts = Exts}) ->
     SubNodes = [Version | Exts],
     lists:foldl(fun (SubNode, Acc) ->
                         NodePair = {Node, SubNode},
                         case cache_tab:lookup(caps_features, NodePair,
-                                              caps_read_fun(LHost, NodePair))
+                                              caps_read_fun(HostType, NodePair))
                         of
                             {ok, Features} when is_list(Features) ->
                                 Features ++ Acc;
@@ -133,7 +146,6 @@ get_features(LHost, #caps{node = Node, version = Version, exts = Exts}) ->
                 [], SubNodes).
 
 -spec read_caps([exml:element()]) -> nothing | caps().
-
 read_caps(Els) -> read_caps(Els, nothing).
 
 read_caps([#xmlel{name = <<"c">>, attrs = Attrs} | Tail], Result) ->
@@ -158,37 +170,38 @@ read_caps([], Result) -> Result.
 -spec user_send_packet(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) -> mongoose_acc:t().
 user_send_packet(Acc,
                  #jid{luser = User, lserver = LServer} = From,
-                 #jid{luser = User, lserver = LServer, lresource = <<"">>},
-                 #xmlel{name = <<"presence">>, attrs = Attrs, children = Els}) ->
+                 #jid{luser = User, lserver = LServer, lresource = <<>>},
+                 #xmlel{name = <<"presence">>, attrs = Attrs, children = Elements}) ->
     Type = xml:get_attr_s(<<"type">>, Attrs),
-    case Type == <<"">> orelse Type == <<"available">> of
-        true ->
-            case read_caps(Els) of
-                nothing -> Acc;
-                #caps{version = Version, exts = Exts} = Caps ->
-                    feature_request(Acc, LServer, From, Caps, [Version | Exts])
-            end;
-        false -> Acc
-    end;
+    handle_presence(Acc, LServer, From, Type, Elements);
 user_send_packet(Acc, _From, _To, _Pkt) ->
     Acc.
 
 -spec user_receive_packet(mongoose_acc:t(), jid:jid(), jid:jid(), jid:jid(), exml:element()) ->
           mongoose_acc:t().
 user_receive_packet(Acc, #jid{lserver = LServer}, From, _To,
-                    #xmlel{name = <<"presence">>, attrs = Attrs, children = Els}) ->
+                    #xmlel{name = <<"presence">>, attrs = Attrs, children = Elements}) ->
     Type = xml:get_attr_s(<<"type">>, Attrs),
-    case (not lists:member(From#jid.lserver, ?MYHOSTS))
-         andalso ((Type == <<"">>) or (Type == <<"available">>)) of
-        true ->
-            case read_caps(Els) of
-                nothing -> Acc;
-                #caps{version = Version, exts = Exts} = Caps ->
-                    feature_request(Acc, LServer, From, Caps, [Version | Exts])
-            end;
-        false -> Acc
+    case mongoose_domain_api:get_host_type(From#jid.lserver) of
+        {error, not_found} ->
+            handle_presence(Acc, LServer, From, Type, Elements);
+        {ok, _} ->
+            Acc %% it was already handled in 'user_send_packet'
     end;
 user_receive_packet(Acc, _JID, _From, _To, _Pkt) ->
+    Acc.
+
+-spec handle_presence(mongoose_acc:t(), jid:lserver(), jid:jid(), binary(), [exml:element()]) ->
+          mongoose_acc:t().
+handle_presence(Acc, LServer, From, Type, Elements) when Type =:= <<>>;
+                                                         Type =:= <<"available">> ->
+    case read_caps(Elements) of
+        nothing ->
+            Acc;
+        #caps{version = Version, exts = Exts} = Caps ->
+            feature_request(Acc, LServer, From, Caps, [Version | Exts])
+    end;
+handle_presence(Acc, _LServer, _From, _Type, _Elements) ->
     Acc.
 
 -spec caps_stream_features([exml:element()], mongooseim:host_type(), jid:lserver()) ->
@@ -199,9 +212,8 @@ caps_stream_features(Acc, HostType, LServer) ->
             Acc;
         Hash ->
             [#xmlel{name = <<"c">>,
-                    attrs =
-                        [{<<"xmlns">>, ?NS_CAPS}, {<<"hash">>, <<"sha-1">>},
-                         {<<"node">>, ?MONGOOSE_URI}, {<<"ver">>, Hash}],
+                    attrs = [{<<"xmlns">>, ?NS_CAPS}, {<<"hash">>, <<"sha-1">>},
+                             {<<"node">>, ?MONGOOSE_URI}, {<<"ver">>, Hash}],
                     children = []}
              | Acc]
     end.
@@ -227,9 +239,9 @@ disco_info(Acc = #{node := Node}) ->
         false -> Acc
     end.
 
--spec c2s_presence_in(ejabberd_c2s:state(), mongooseim:host_type(),
-                      jid:jid(), jid:jid(), exml:element()) -> ejabberd_c2s:state().
-c2s_presence_in(C2SState, HostType, From, To, Packet = #xmlel{attrs = Attrs, children = Els}) ->
+-spec c2s_presence_in(ejabberd_c2s:state(), jid:jid(), jid:jid(), exml:element()) ->
+          ejabberd_c2s:state().
+c2s_presence_in(C2SState, From, To, Packet = #xmlel{attrs = Attrs, children = Els}) ->
     ?LOG_DEBUG(#{what => caps_c2s_presence_in,
                  to => jid:to_binary(To), from => jid:to_binary(From),
                  exml_packet => Packet, c2s_state => C2SState}),
@@ -254,7 +266,8 @@ c2s_presence_in(C2SState, HostType, From, To, Packet = #xmlel{attrs = Attrs, chi
                             ?LOG_DEBUG(#{what => caps_set_caps, caps => Caps,
                                          to => jid:to_binary(To), from => jid:to_binary(From),
                                          exml_packet => Packet, c2s_state => C2SState}),
-                            upsert_caps(LFrom, From, To, Caps, Rs);
+                            HostType = ejabberd_c2s_state:host_type(C2SState),
+                            upsert_caps(HostType, LFrom, From, To, Caps, Rs);
                         _ -> gb_trees:delete_any(LFrom, Rs)
                     end,
             ejabberd_c2s:set_aux_field(caps_resources, NewRs,
@@ -262,16 +275,17 @@ c2s_presence_in(C2SState, HostType, From, To, Packet = #xmlel{attrs = Attrs, chi
         false -> C2SState
     end.
 
-upsert_caps(LFrom, From, To, Caps, Rs) ->
+-spec upsert_caps(mongooseim:host_type(), jid:simple_jid(), jid:jid(), jid:jid(),
+                  caps(), caps_resources()) ->
+          caps_resources().
+upsert_caps(HostType, LFrom, From, To, Caps, Rs) ->
     case gb_trees:lookup(LFrom, Rs) of
         {value, Caps} -> Rs;
         none ->
-            mongoose_hooks:caps_add(To#jid.lserver,
-                                    From, To, self(), get_features(To#jid.lserver, Caps)),
+            mongoose_hooks:caps_add(HostType, From, To, self(), get_features(HostType, Caps)),
             gb_trees:insert(LFrom, Caps, Rs);
         _ ->
-            mongoose_hooks:caps_update(To#jid.lserver,
-                                       From, To, self(), get_features(To#jid.lserver, Caps)),
+            mongoose_hooks:caps_update(HostType, From, To, self(), get_features(HostType, Caps)),
             gb_trees:update(LFrom, Caps, Rs)
     end.
 
@@ -303,21 +317,24 @@ c2s_broadcast_recipients(InAcc, C2SState, {pep_message, Feature}, _From, _Packet
     HostType = ejabberd_c2s_state:host_type(C2SState),
     case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of
         {ok, Rs} ->
-            filter_recipients_by_caps(InAcc, Feature, HostType, Rs);
+            filter_recipients_by_caps(HostType, InAcc, Feature, Rs);
         _ -> InAcc
     end;
 c2s_broadcast_recipients(Acc, _, _, _, _) -> Acc.
 
-filter_recipients_by_caps(InAcc, Feature, LHost, Rs) ->
+-spec filter_recipients_by_caps(mongooseim:host_type(), Acc,
+                                {atom(), binary()}, caps_resources()) -> Acc
+              when Acc :: [jid:simple_jid()].
+filter_recipients_by_caps(HostType, InAcc, Feature, Rs) ->
     gb_trees_fold(fun(USR, Caps, Acc) ->
-                          case lists:member(Feature, get_features_list(LHost, Caps)) of
+                          case lists:member(Feature, get_features_list(HostType, Caps)) of
                               true -> [USR | Acc];
                               false -> Acc
                           end
                   end,
                   InAcc, Rs).
 
-init_db(mnesia, _Host) ->
+init_db(mnesia) ->
     case catch mnesia:table_info(caps_features, storage_type) of
         {'EXIT', _} ->
             ok;
@@ -334,8 +351,9 @@ init_db(mnesia, _Host) ->
     mnesia:add_table_copy(caps_features, node(),
                           disc_only_copies).
 
-init([Host, Opts]) ->
-    init_db(mnesia, Host),
+-spec init(list()) -> {ok, state()}.
+init([HostType, Opts]) ->
+    init_db(db_type(HostType)),
     MaxSize = gen_mod:get_opt(cache_size, Opts,
                               fun(I) when is_integer(I), I>0 -> I end,
                               1000),
@@ -344,79 +362,85 @@ init([Host, Opts]) ->
                                timer:hours(24) div 1000),
     cache_tab:new(caps_features,
                   [{max_size, MaxSize}, {life_time, LifeTime}]),
-    ejabberd_hooks:add(c2s_presence_in, Host, ?MODULE,
+    ejabberd_hooks:add(c2s_presence_in, HostType, ?MODULE,
                        c2s_presence_in, 75),
-    ejabberd_hooks:add(c2s_filter_packet, Host, ?MODULE,
+    ejabberd_hooks:add(c2s_filter_packet, HostType, ?MODULE,
                        c2s_filter_packet, 75),
-    ejabberd_hooks:add(c2s_broadcast_recipients, Host,
+    ejabberd_hooks:add(c2s_broadcast_recipients, HostType,
                        ?MODULE, c2s_broadcast_recipients, 75),
-    ejabberd_hooks:add(user_send_packet, Host, ?MODULE,
+    ejabberd_hooks:add(user_send_packet, HostType, ?MODULE,
                        user_send_packet, 75),
-    ejabberd_hooks:add(user_receive_packet, Host, ?MODULE,
+    ejabberd_hooks:add(user_receive_packet, HostType, ?MODULE,
                        user_receive_packet, 75),
-    ejabberd_hooks:add(c2s_stream_features, Host, ?MODULE,
+    ejabberd_hooks:add(c2s_stream_features, HostType, ?MODULE,
                        caps_stream_features, 75),
-    ejabberd_hooks:add(s2s_stream_features, Host, ?MODULE,
+    ejabberd_hooks:add(s2s_stream_features, HostType, ?MODULE,
                        caps_stream_features, 75),
-    ejabberd_hooks:add(disco_local_features, Host, ?MODULE,
+    ejabberd_hooks:add(disco_local_features, HostType, ?MODULE,
                        disco_local_features, 1),
-    ejabberd_hooks:add(disco_local_identity, Host, ?MODULE,
+    ejabberd_hooks:add(disco_local_identity, HostType, ?MODULE,
                        disco_local_identity, 1),
-    ejabberd_hooks:add(disco_info, Host, ?MODULE,
+    ejabberd_hooks:add(disco_info, HostType, ?MODULE,
                        disco_info, 1),
-    {ok, #state{host = Host}}.
+    {ok, #state{host_type = HostType}}.
 
+-spec handle_call(term(), any(), state()) ->
+          {stop, normal, ok, state()} | {reply, {error, any()}, state()}.
 handle_call(stop, _From, State) ->
     {stop, normal, ok, State};
 handle_call(_Req, _From, State) ->
     {reply, {error, badarg}, State}.
 
+-spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast(_Msg, State) -> {noreply, State}.
 
+-spec handle_info(any(), state()) -> {noreply, state()}.
 handle_info(_Info, State) -> {noreply, State}.
 
+-spec terminate(any(), state()) -> ok.
 terminate(_Reason, State) ->
-    Host = State#state.host,
-    ejabberd_hooks:delete(c2s_presence_in, Host, ?MODULE,
+    HostType = State#state.host_type,
+    ejabberd_hooks:delete(c2s_presence_in, HostType, ?MODULE,
                           c2s_presence_in, 75),
-    ejabberd_hooks:delete(c2s_filter_packet, Host, ?MODULE,
+    ejabberd_hooks:delete(c2s_filter_packet, HostType, ?MODULE,
                           c2s_filter_packet, 75),
-    ejabberd_hooks:delete(c2s_broadcast_recipients, Host,
+    ejabberd_hooks:delete(c2s_broadcast_recipients, HostType,
                           ?MODULE, c2s_broadcast_recipients, 75),
-    ejabberd_hooks:delete(user_send_packet, Host, ?MODULE,
+    ejabberd_hooks:delete(user_send_packet, HostType, ?MODULE,
                           user_send_packet, 75),
-    ejabberd_hooks:delete(user_receive_packet, Host,
+    ejabberd_hooks:delete(user_receive_packet, HostType,
                           ?MODULE, user_receive_packet, 75),
-    ejabberd_hooks:delete(c2s_stream_features, Host,
+    ejabberd_hooks:delete(c2s_stream_features, HostType,
                           ?MODULE, caps_stream_features, 75),
-    ejabberd_hooks:delete(s2s_stream_features, Host,
+    ejabberd_hooks:delete(s2s_stream_features, HostType,
                           ?MODULE, caps_stream_features, 75),
-    ejabberd_hooks:delete(disco_local_features, Host,
+    ejabberd_hooks:delete(disco_local_features, HostType,
                           ?MODULE, disco_local_features, 1),
-    ejabberd_hooks:delete(disco_local_identity, Host,
+    ejabberd_hooks:delete(disco_local_identity, HostType,
                           ?MODULE, disco_local_identity, 1),
-    ejabberd_hooks:delete(disco_info, Host, ?MODULE,
+    ejabberd_hooks:delete(disco_info, HostType, ?MODULE,
                           disco_info, 1),
     ok.
 
+-spec code_change(any(), state(), any()) -> {ok, state()}.
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 -spec feature_request(mongoose_acc:t(), jid:lserver(), jid:jid(), caps(), [binary()]) ->
     mongoose_acc:t().
-feature_request(Acc, LHost, From, Caps, [SubNode | Tail] = SubNodes) ->
+feature_request(Acc, LServer, From, Caps, [SubNode | Tail] = SubNodes) ->
     Node = Caps#caps.node,
     NodePair = {Node, SubNode},
-    case cache_tab:lookup(caps_features, NodePair, caps_read_fun(LHost, NodePair)) of
+    HostType = mongoose_acc:host_type(Acc),
+    case cache_tab:lookup(caps_features, NodePair, caps_read_fun(HostType, NodePair)) of
         {ok, Fs} when is_list(Fs) ->
-            feature_request(Acc, LHost, From, Caps, Tail);
+            feature_request(Acc, LServer, From, Caps, Tail);
         Other ->
             NeedRequest = case Other of
                               {ok, TS} -> os:system_time(second) >= TS + (?BAD_HASH_LIFETIME);
                               _ -> true
                           end,
             F = fun (_From, _To, Acc1, IQReply) ->
-                        feature_response(Acc1, IQReply, LHost, From, Caps,
-                                         SubNodes)
+                        feature_response(Acc1, IQReply, LServer, From, Caps, SubNodes)
                 end,
             case NeedRequest of
                 true ->
@@ -430,27 +454,27 @@ feature_request(Acc, LHost, From, Caps, [SubNode | Tail] = SubNodes) ->
                                                  SubNode/binary>>}],
                                          children = []}]},
                     cache_tab:insert(caps_features, NodePair, os:system_time(second),
-                                     caps_write_fun(LHost, NodePair, os:system_time(second))),
-                    ejabberd_local:route_iq(jid:make_noprep(<<"">>, LHost, <<"">>), From, Acc, IQ, F),
+                                     caps_write_fun(HostType, NodePair, os:system_time(second))),
+                    ejabberd_local:route_iq(jid:make_noprep(<<>>, LServer, <<>>), From, Acc, IQ, F),
                     Acc;
-               false -> feature_request(Acc, LHost, From, Caps, Tail)
+               false -> feature_request(Acc, LServer, From, Caps, Tail)
             end
     end;
-feature_request(Acc, LHost, From, Caps, []) ->
+feature_request(Acc, _LServer, From, Caps, []) ->
     %% feature_request is never executed with empty SubNodes list
     %% so if we end up here, it means the caps are known
-    mongoose_hooks:caps_recognised(LHost, Acc,
-                            From, self(), get_features_list(LHost, Caps)).
+    HostType = mongoose_acc:host_type(Acc),
+    mongoose_hooks:caps_recognised(HostType, Acc, From, self(), get_features_list(HostType, Caps)).
 
 -spec feature_response(mongoose_acc:t(), jlib:iq(), jid:lserver(), jid:jid(), caps(), [binary()]) ->
     mongoose_acc:t().
 feature_response(Acc, #iq{type = result, sub_el = [#xmlel{children = Els}]},
-                 LHost, From, Caps, [SubNode | SubNodes]) ->
+                 LServer, From, Caps, [SubNode | SubNodes]) ->
+    HostType = mongoose_acc:host_type(Acc),
     NodePair = {Caps#caps.node, SubNode},
     case check_hash(Caps, Els) of
         true ->
-            Features = lists:flatmap(fun (#xmlel{name =
-                                                     <<"feature">>,
+            Features = lists:flatmap(fun (#xmlel{name = <<"feature">>,
                                                  attrs = FAttrs}) ->
                                              [xml:get_attr_s(<<"var">>, FAttrs)];
                                          (_) -> []
@@ -458,18 +482,20 @@ feature_response(Acc, #iq{type = result, sub_el = [#xmlel{children = Els}]},
                                      Els),
             cache_tab:insert(caps_features, NodePair,
                              Features,
-                             caps_write_fun(LHost, NodePair, Features));
+                             caps_write_fun(HostType, NodePair, Features));
         false -> ok
     end,
-    feature_request(Acc, LHost, From, Caps, SubNodes);
-feature_response(Acc, _IQResult, LHost, From, Caps, [_SubNode | SubNodes]) ->
-    feature_request(Acc, LHost, From, Caps, SubNodes).
+    feature_request(Acc, LServer, From, Caps, SubNodes);
+feature_response(Acc, _IQResult, LServer, From, Caps, [_SubNode | SubNodes]) ->
+    feature_request(Acc, LServer, From, Caps, SubNodes).
 
-caps_read_fun(LServer, Node) ->
-    DBType = db_type(LServer),
-    caps_read_fun(LServer, Node, DBType).
+-spec caps_read_fun(mongooseim:host_type(), node_pair()) ->
+          fun(() -> {ok, maybe_pending_features()} | error).
+caps_read_fun(HostType, Node) ->
+    DBType = db_type(HostType),
+    caps_read_fun(HostType, Node, DBType).
 
-caps_read_fun(_LServer, Node, mnesia) ->
+caps_read_fun(_HostType, Node, mnesia) ->
     fun () ->
             case mnesia:dirty_read({caps_features, Node}) of
                 [#caps_features{features = Features}] -> {ok, Features};
@@ -477,19 +503,23 @@ caps_read_fun(_LServer, Node, mnesia) ->
             end
     end.
 
-caps_write_fun(LServer, Node, Features) ->
-    DBType = db_type(LServer),
-    caps_write_fun(LServer, Node, Features, DBType).
+-spec caps_write_fun(mongooseim:host_type(), node_pair(), maybe_pending_features()) ->
+          fun(() -> ok).
+caps_write_fun(HostType, Node, Features) ->
+    DBType = db_type(HostType),
+    caps_write_fun(HostType, Node, Features, DBType).
 
-caps_write_fun(_LServer, Node, Features, mnesia) ->
+caps_write_fun(_HostType, Node, Features, mnesia) ->
     fun () ->
             mnesia:dirty_write(#caps_features{node_pair = Node,
                                               features = Features})
     end.
 
+-spec delete_caps(node_pair()) -> ok.
 delete_caps(Node) ->
     cache_tab:delete(caps_features, Node, caps_delete_fun(Node)).
 
+-spec caps_delete_fun(node_pair()) -> fun(() -> ok).
 caps_delete_fun(Node) ->
     fun () ->
             mnesia:dirty_delete(caps_features, Node)
@@ -507,6 +537,7 @@ make_my_disco_hash(HostType, LServer) ->
             make_disco_hash(IdentityXML ++ InfoXML ++ FeaturesXML, sha1)
     end.
 
+-spec make_disco_hash([exml:element()], HashAlgorithm :: atom()) -> binary().
 make_disco_hash(DiscoEls, Algo) ->
     Concat = list_to_binary([concat_identities(DiscoEls),
                              concat_features(DiscoEls), concat_info(DiscoEls)]),
@@ -619,5 +650,5 @@ is_valid_node(Node) ->
             false
     end.
 
-db_type(_Host) ->
+db_type(_HostType) ->
     mnesia.

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -227,17 +227,18 @@ disco_info(Acc = #{node := Node}) ->
         false -> Acc
     end.
 
-c2s_presence_in(C2SState,
-                {From, To, Packet = #xmlel{attrs = Attrs, children = Els}}) ->
+-spec c2s_presence_in(ejabberd_c2s:state(), mongooseim:host_type(),
+                      jid:jid(), jid:jid(), exml:element()) -> ejabberd_c2s:state().
+c2s_presence_in(C2SState, HostType, From, To, Packet = #xmlel{attrs = Attrs, children = Els}) ->
     ?LOG_DEBUG(#{what => caps_c2s_presence_in,
                  to => jid:to_binary(To), from => jid:to_binary(From),
                  exml_packet => Packet, c2s_state => C2SState}),
     Type = xml:get_attr_s(<<"type">>, Attrs),
     Subscription = ejabberd_c2s:get_subscription(From, C2SState),
-    Insert = ((Type == <<"">>) or (Type == <<"available">>))
-        and ((Subscription == both) or (Subscription == to)),
-    Delete = (Type == <<"unavailable">>) or (Type == <<"error">>),
-    case Insert or Delete of
+    Insert = (Type == <<>> orelse Type == <<"available">>)
+        and (Subscription == both orelse Subscription == to),
+    Delete = Type == <<"unavailable">> orelse Type == <<"error">>,
+    case Insert orelse Delete of
         true ->
             LFrom = jid:to_lower(From),
             Rs = case ejabberd_c2s:get_aux_field(caps_resources,

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -354,14 +354,9 @@ init_db(mnesia) ->
 -spec init(list()) -> {ok, state()}.
 init([HostType, Opts]) ->
     init_db(db_type(HostType)),
-    MaxSize = gen_mod:get_opt(cache_size, Opts,
-                              fun(I) when is_integer(I), I>0 -> I end,
-                              1000),
-    LifeTime = gen_mod:get_opt(cache_life_time, Opts,
-                               fun(I) when is_integer(I), I>0 -> I end,
-                               timer:hours(24) div 1000),
-    cache_tab:new(caps_features,
-                  [{max_size, MaxSize}, {life_time, LifeTime}]),
+    MaxSize = gen_mod:get_opt(cache_size, Opts, 1000),
+    LifeTime = gen_mod:get_opt(cache_life_time, Opts, timer:hours(24) div 1000),
+    cache_tab:new(caps_features, [{max_size, MaxSize}, {life_time, LifeTime}]),
     ejabberd_hooks:add(hooks(HostType)),
     {ok, #state{host_type = HostType}}.
 

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -10,7 +10,7 @@
 -export([start/2]).
 -export([stop/1]).
 -export([config_spec/0]).
--export([add_csi_feature/2]).
+-export([c2s_stream_features/3]).
 
 -include("jlib.hrl").
 -include("mongoose_config_spec.hrl").
@@ -38,13 +38,15 @@ config_spec() ->
       }.
 
 hooks() ->
-    [{c2s_stream_features, ?MODULE, add_csi_feature, 60}].
+    [{c2s_stream_features, ?MODULE, c2s_stream_features, 60}].
 
 ensure_metrics(Host) ->
     mongoose_metrics:ensure_metric(Host, [Host, modCSIInactive], spiral),
     mongoose_metrics:ensure_metric(Host, [Host, modCSIInactive], spiral).
 
-add_csi_feature(Acc, _Host) ->
+-spec c2s_stream_features([exml:element()], mongooseim:host_type(), jid:lserver()) ->
+          [exml:element()].
+c2s_stream_features(Acc, _HostType, _Lserver) ->
     lists:keystore(<<"csi">>, #xmlel.name, Acc, csi()).
 
 csi() ->

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -32,7 +32,7 @@
 -export([start/2,
          stop/1,
          config_spec/0,
-         stream_feature_register/2,
+         c2s_stream_features/3,
          unauthenticated_iq_register/4,
          try_register/5,
          process_iq/4,
@@ -50,7 +50,7 @@ start(Host, Opts) ->
     gen_iq_handler:add_iq_handler(ejabberd_sm, Host, ?NS_REGISTER,
                                   ?MODULE, process_iq, IQDisc),
     ejabberd_hooks:add(c2s_stream_features, Host,
-                       ?MODULE, stream_feature_register, 50),
+                       ?MODULE, c2s_stream_features, 50),
     ejabberd_hooks:add(c2s_unauthenticated_iq, Host,
                        ?MODULE, unauthenticated_iq_register, 50),
     mnesia:create_table(mod_register_ip,
@@ -62,7 +62,7 @@ start(Host, Opts) ->
 
 stop(Host) ->
     ejabberd_hooks:delete(c2s_stream_features, Host,
-                          ?MODULE, stream_feature_register, 50),
+                          ?MODULE, c2s_stream_features, 50),
     ejabberd_hooks:delete(c2s_unauthenticated_iq, Host,
                           ?MODULE, unauthenticated_iq_register, 50),
     gen_iq_handler:remove_iq_handler(ejabberd_local, Host, ?NS_REGISTER),
@@ -110,7 +110,9 @@ process_welcome_message(KVs) ->
     Subject = proplists:get_value(subject, KVs, ""),
     {Subject, Body}.
 
-stream_feature_register(Acc, _Host) ->
+-spec c2s_stream_features([exml:element()], mongooseim:host_type(), jid:lserver()) ->
+          [exml:element()].
+c2s_stream_features(Acc, _HostType, _LServer) ->
     [#xmlel{name = <<"register">>,
             attrs = [{<<"xmlns">>, ?NS_FEATURE_IQREGISTER}]} | Acc].
 

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -11,7 +11,7 @@
          process_buffer_and_ack/1]).
 
 %% hooks handlers
--export([add_sm_feature/2,
+-export([c2s_stream_features/3,
          remove_smid/5,
          session_cleanup/5]).
 
@@ -73,7 +73,7 @@ stop(HostType) ->
 
 hooks(HostType) ->
     [{sm_remove_connection_hook, HostType, ?MODULE, remove_smid, 50},
-     {c2s_stream_features, HostType, ?MODULE, add_sm_feature, 50},
+     {c2s_stream_features, HostType, ?MODULE, c2s_stream_features, 50},
      {session_cleanup, HostType, ?MODULE, session_cleanup, 50}].
 
 -spec config_spec() -> mongoose_config_spec:config_section().
@@ -125,7 +125,9 @@ stale_h_config_spec() ->
 %% hooks handlers
 %%
 
-add_sm_feature(Acc, _Server) ->
+-spec c2s_stream_features([exml:element()], mongooseim:host_type(), jid:lserver()) ->
+          [exml:element()].
+c2s_stream_features(Acc, _HostType, _Lserver) ->
     lists:keystore(<<"sm">>, #xmlel.name, Acc, sm()).
 
 sm() ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1186,7 +1186,7 @@ s2s_send_packet(Acc, From, To, Packet) ->
 %%% @doc `s2s_stream_features' hook is used to extract
 %%% the stream management features supported by the server.
 -spec s2s_stream_features(HostType, LServer) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     LServer :: jid:lserver(),
     Result :: [exml:element()].
 s2s_stream_features(HostType, LServer) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -43,7 +43,7 @@
          xmpp_stanza_dropped/4]).
 
 -export([c2s_broadcast_recipients/4,
-         c2s_filter_packet/6,
+         c2s_filter_packet/4,
          c2s_preprocessing_hook/3,
          c2s_presence_in/5,
          c2s_stream_features/2,
@@ -515,17 +515,16 @@ c2s_broadcast_recipients(State, Type, From, Packet) ->
     ejabberd_hooks:run_for_host_type(c2s_broadcast_recipients, HostType, [],
                                      [State, Type, From, Packet]).
 
--spec c2s_filter_packet(HostType, Server, State, Feature, To, Packet) -> Result when
-    HostType :: binary(),
-    Server :: jid:server(),
+-spec c2s_filter_packet(State, Feature, To, Packet) -> Result when
     State :: ejabberd_c2s:state(),
     Feature :: {atom(), binary()},
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: boolean().
-c2s_filter_packet(HostType, Server, State, Feature, To, Packet) ->
+c2s_filter_packet(State, Feature, To, Packet) ->
+    HostType = ejabberd_c2s_state:host_type(State),
     ejabberd_hooks:run_for_host_type(c2s_filter_packet, HostType, true,
-                                     [Server, State, Feature, To, Packet]).
+                                     [State, Feature, To, Packet]).
 
 -spec c2s_preprocessing_hook(HostType, Acc, State) -> Result when
     HostType :: binary(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -45,7 +45,7 @@
 -export([c2s_broadcast_recipients/4,
          c2s_filter_packet/4,
          c2s_preprocessing_hook/3,
-         c2s_presence_in/5,
+         c2s_presence_in/4,
          c2s_stream_features/2,
          c2s_unauthenticated_iq/4,
          c2s_update_presence/2,
@@ -534,16 +534,15 @@ c2s_filter_packet(State, Feature, To, Packet) ->
 c2s_preprocessing_hook(HostType, Acc, State) ->
     ejabberd_hooks:run_for_host_type(c2s_preprocessing_hook, HostType, Acc, [State]).
 
--spec c2s_presence_in(HostType, State, From, To, Packet) -> Result when
-    HostType :: binary(),
+-spec c2s_presence_in(State, From, To, Packet) -> Result when
     State :: ejabberd_c2s:state(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: ejabberd_c2s:state().
-c2s_presence_in(HostType, State, From, To, Packet) ->
-    ejabberd_hooks:run_for_host_type(c2s_presence_in, HostType, State,
-                                     [{From, To, Packet}]).
+c2s_presence_in(State, From, To, Packet) ->
+    HostType = ejabberd_c2s_state:host_type(State),
+    ejabberd_hooks:run_for_host_type(c2s_presence_in, HostType, State, [From, To, Packet]).
 
 -spec c2s_stream_features(HostType, LServer) -> Result when
     HostType :: mongooseim:host_type(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -546,12 +546,12 @@ c2s_presence_in(HostType, State, From, To, Packet) ->
     ejabberd_hooks:run_for_host_type(c2s_presence_in, HostType, State,
                                      [{From, To, Packet}]).
 
--spec c2s_stream_features(HostType, Server) -> Result when
-    HostType :: binary(),
-    Server :: jid:server(),
+-spec c2s_stream_features(HostType, LServer) -> Result when
+    HostType :: mongooseim:host_type(),
+    LServer :: jid:lserver(),
     Result :: [exml:element()].
-c2s_stream_features(HostType, Server) ->
-    ejabberd_hooks:run_for_host_type(c2s_stream_features, HostType, [], [Server]).
+c2s_stream_features(HostType, LServer) ->
+    ejabberd_hooks:run_for_host_type(c2s_stream_features, HostType, [], [HostType, LServer]).
 
 -spec c2s_unauthenticated_iq(HostType, Server, IQ, IP) -> Result when
     HostType :: binary(),
@@ -1194,7 +1194,7 @@ s2s_send_packet(Acc, From, To, Packet) ->
     Server :: jid:server(),
     Result :: [exml:element()].
 s2s_stream_features(HostType, Server) ->
-    ejabberd_hooks:run_for_host_type(s2s_stream_features, HostType, [], [Server]).
+    ejabberd_hooks:run_for_host_type(s2s_stream_features, HostType, [], [HostType, Server]).
 
 %%% @doc `s2s_receive_packet' hook is called when
 %%% an incoming stanza is routed by the server.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -527,7 +527,7 @@ c2s_filter_packet(State, Feature, To, Packet) ->
                                      [State, Feature, To, Packet]).
 
 -spec c2s_preprocessing_hook(HostType, Acc, State) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     Acc :: mongoose_acc:t(),
     State :: ejabberd_c2s:state(),
     Result :: mongoose_acc:t().
@@ -552,7 +552,7 @@ c2s_stream_features(HostType, LServer) ->
     ejabberd_hooks:run_for_host_type(c2s_stream_features, HostType, [], [HostType, LServer]).
 
 -spec c2s_unauthenticated_iq(HostType, Server, IQ, IP) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     Server :: jid:server(),
     IQ :: jlib:iq(),
     IP :: {inet:ip_address(), inet:port_number()} | undefined,
@@ -562,7 +562,7 @@ c2s_unauthenticated_iq(HostType, Server, IQ, IP) ->
                                      [Server, IQ, IP]).
 
 -spec c2s_update_presence(HostType, Acc) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     Acc :: mongoose_acc:t(),
     Result :: mongoose_acc:t().
 c2s_update_presence(HostType, Acc) ->
@@ -575,7 +575,7 @@ check_bl_c2s(IP) ->
     ejabberd_hooks:run_global(check_bl_c2s, false, [IP]).
 
 -spec forbidden_session_hook(HostType, Acc, JID) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
@@ -583,7 +583,7 @@ forbidden_session_hook(HostType, Acc, JID) ->
     ejabberd_hooks:run_for_host_type(forbidden_session_hook, HostType, Acc, [JID]).
 
 -spec session_opening_allowed_for_user(HostType, JID) -> Result when
-    HostType :: binary(),
+    HostType :: mongooseim:host_type(),
     JID :: jid:jid(),
     Result :: allow | any(). %% anything else than 'allow' is interpreted
                              %% as not allowed
@@ -1187,12 +1187,12 @@ s2s_send_packet(Acc, From, To, Packet) ->
 
 %%% @doc `s2s_stream_features' hook is used to extract
 %%% the stream management features supported by the server.
--spec s2s_stream_features(HostType, Server) -> Result when
+-spec s2s_stream_features(HostType, LServer) -> Result when
     HostType :: binary(),
-    Server :: jid:server(),
+    LServer :: jid:lserver(),
     Result :: [exml:element()].
-s2s_stream_features(HostType, Server) ->
-    ejabberd_hooks:run_for_host_type(s2s_stream_features, HostType, [], [HostType, Server]).
+s2s_stream_features(HostType, LServer) ->
+    ejabberd_hooks:run_for_host_type(s2s_stream_features, HostType, [], [HostType, LServer]).
 
 %%% @doc `s2s_receive_packet' hook is called when
 %%% an incoming stanza is routed by the server.
@@ -1379,37 +1379,37 @@ update_inbox_for_muc(HostType, Info) ->
 
 %% Caps related hooks
 
--spec caps_add(Server, From, To, Pid, Features) -> Result when
-    Server :: jid:server(),
+-spec caps_add(HostType, From, To, Pid, Features) -> Result when
+    HostType :: mongooseim:host_type(),
     From :: jid:jid(),
     To :: jid:jid(),
     Pid :: pid(),
     Features :: unknown | list(),
     Result :: any().
-caps_add(Server, From, To, Pid, Features) ->
-    ejabberd_hooks:run_for_host_type(caps_add, Server, ok,
+caps_add(HostType, From, To, Pid, Features) ->
+    ejabberd_hooks:run_for_host_type(caps_add, HostType, ok,
                                      [From, To, Pid, Features]).
 
--spec caps_recognised(Server, Acc, From, Pid, Features) -> Result when
-    Server :: jid:server(),
+-spec caps_recognised(HostType, Acc, From, Pid, Features) -> Result when
+    HostType :: mongooseim:host_type(),
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     Pid :: pid(),
     Features :: unknown | list(),
     Result :: mongoose_acc:t().
-caps_recognised(Server, Acc, From, Pid, Features) ->
-    ejabberd_hooks:run_for_host_type(caps_recognised, Server, Acc,
+caps_recognised(HostType, Acc, From, Pid, Features) ->
+    ejabberd_hooks:run_for_host_type(caps_recognised, HostType, Acc,
                                      [From, Pid, Features]).
 
--spec caps_update(Server, From, To, Pid, Features) -> Result when
-    Server :: jid:server(),
+-spec caps_update(HostType, From, To, Pid, Features) -> Result when
+    HostType :: mongooseim:host_type(),
     From :: jid:jid(),
     To :: jid:jid(),
     Pid :: pid(),
     Features :: unknown | list(),
     Result :: any().
-caps_update(Server, From, To, Pid, Features) ->
-    ejabberd_hooks:run_for_host_type(caps_update, Server, ok,
+caps_update(HostType, From, To, Pid, Features) ->
+    ejabberd_hooks:run_for_host_type(caps_update, HostType, ok,
                                      [From, To, Pid, Features]).
 
 %% PubSub related hooks

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -42,7 +42,7 @@
          xmpp_send_element/3,
          xmpp_stanza_dropped/4]).
 
--export([c2s_broadcast_recipients/5,
+-export([c2s_broadcast_recipients/4,
          c2s_filter_packet/6,
          c2s_preprocessing_hook/3,
          c2s_presence_in/5,
@@ -504,16 +504,16 @@ xmpp_stanza_dropped(HostType, From, To, Packet) ->
 
 %% C2S related hooks
 
--spec c2s_broadcast_recipients(Server, State, Type, From, Packet) -> Result when
-    Server :: jid:server(),
+-spec c2s_broadcast_recipients(State, Type, From, Packet) -> Result when
     State :: ejabberd_c2s:state(),
     Type :: {atom(), any()},
     From :: jid:jid(),
     Packet :: exml:element(),
-    Result :: list().
-c2s_broadcast_recipients(Server, State, Type, From, Packet) ->
-    ejabberd_hooks:run_for_host_type(c2s_broadcast_recipients, Server, [],
-                                     [Server, State, Type, From, Packet]).
+    Result :: [jid:simple_jid()].
+c2s_broadcast_recipients(State, Type, From, Packet) ->
+    HostType = ejabberd_c2s_state:host_type(State),
+    ejabberd_hooks:run_for_host_type(c2s_broadcast_recipients, HostType, [],
+                                     [State, Type, From, Packet]).
 
 -spec c2s_filter_packet(HostType, Server, State, Feature, To, Packet) -> Result when
     HostType :: binary(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -137,9 +137,7 @@
          room_packet/5,
          update_inbox_for_muc/2]).
 
--export([caps_add/5,
-         caps_recognised/5,
-         caps_update/5]).
+-export([caps_recognised/4]).
 
 -export([pubsub_create_node/5,
          pubsub_delete_node/4,
@@ -1379,38 +1377,16 @@ update_inbox_for_muc(HostType, Info) ->
 
 %% Caps related hooks
 
--spec caps_add(HostType, From, To, Pid, Features) -> Result when
-    HostType :: mongooseim:host_type(),
-    From :: jid:jid(),
-    To :: jid:jid(),
-    Pid :: pid(),
-    Features :: unknown | list(),
-    Result :: any().
-caps_add(HostType, From, To, Pid, Features) ->
-    ejabberd_hooks:run_for_host_type(caps_add, HostType, ok,
-                                     [From, To, Pid, Features]).
-
--spec caps_recognised(HostType, Acc, From, Pid, Features) -> Result when
-    HostType :: mongooseim:host_type(),
+-spec caps_recognised(Acc, From, Pid, Features) -> Result when
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     Pid :: pid(),
     Features :: unknown | list(),
     Result :: mongoose_acc:t().
-caps_recognised(HostType, Acc, From, Pid, Features) ->
+caps_recognised(Acc, From, Pid, Features) ->
+    HostType = mongoose_acc:host_type(Acc),
     ejabberd_hooks:run_for_host_type(caps_recognised, HostType, Acc,
                                      [From, Pid, Features]).
-
--spec caps_update(HostType, From, To, Pid, Features) -> Result when
-    HostType :: mongooseim:host_type(),
-    From :: jid:jid(),
-    To :: jid:jid(),
-    Pid :: pid(),
-    Features :: unknown | list(),
-    Result :: any().
-caps_update(HostType, From, To, Pid, Features) ->
-    ejabberd_hooks:run_for_host_type(caps_update, HostType, ok,
-                                     [From, To, Pid, Features]).
 
 %% PubSub related hooks
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -795,8 +795,7 @@ handle_pep_authorization_response(_, _, From, To, Acc, Packet) ->
 %%
 
 handle_remote_hook(HandlerState, pep_message, {Feature, From, Packet}, C2SState) ->
-    Host = ejabberd_c2s_state:server(C2SState),
-    Recipients = mongoose_hooks:c2s_broadcast_recipients(Host, C2SState,
+    Recipients = mongoose_hooks:c2s_broadcast_recipients(C2SState,
                                                          {pep_message, Feature},
                                                          From, Packet),
     lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,


### PR DESCRIPTION
Add support for dynamic domains to mod_caps.

Hooks handled or triggered by `mod_caps` are refactored according to the following rule:
- If c2s state or `mongoose_acc:t()` is passed as an argument, do not add host type to the hook and handlers.
- Otherwise, add host type to the hook and its handlers.

Some lines remain untested as they are quite difficult to hit in the tests. Caps are mostly needed for PEP and it does not support dynamic domains, so the coverage for `dynamic_domains` is even lower. It could be increased in the future with the conversion of PubSub and PEP.

See individual commits for more details.

