### PR TITLE
cleaning up some issues with multitenancy support

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -50,6 +50,8 @@
 
 {suites, "tests", offline_stub_SUITE}.
 
+{suites, "tests", domain_isolation_SUITE}.
+
 {suites, "tests", sm_SUITE}.
 {skip_cases, "tests", sm_SUITE,
  [basic_ack,

--- a/doc/modules/mod_domain_isolation.md
+++ b/doc/modules/mod_domain_isolation.md
@@ -1,14 +1,3 @@
 ## Module Description
 
 This module limits message passing between domains.
-
-## Options
-
-### `modules.mod_domain_isolation.extra_domains`
-
-Allows to specify more domains, the rules are applied to.
-No filtering is done to subdomains, unless they are specified in the `extra_domains` list.
-
- * **Syntax:** a list of domain templates (as lists)
- * **Default:** `[]`
- * **Example:** `extra_domains = ["muclight.@HOST@"]`

--- a/include/mongoose.hrl
+++ b/include/mongoose.hrl
@@ -22,7 +22,7 @@
 %% If the ejabberd application description isn't loaded, returns atom: undefined
 -define(MONGOOSE_VERSION, element(2, application:get_key(mongooseim,vsn))).
 
--define(MYHOSTS, ejabberd_config:get_global_option(hosts)).
+-define(MYHOSTS, ejabberd_config:get_global_option_or_default(hosts, [])).
 -define(ALL_HOST_TYPES, ejabberd_config:get_global_option_or_default(hosts, []) ++
                         ejabberd_config:get_global_option_or_default(host_types, [])).
 -define(MYNAME,  ejabberd_config:get_global_option(default_server_domain)).

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -192,9 +192,7 @@ check_dynamic_domains_support(HostType, Module) ->
             case gen_mod:does_module_support(Module, dynamic_domains) of
                 true -> ok;
                 false ->
-                    ErrorMsg = io_lib:format("dynamic_domains_feature_is_not_supported: ~p ~p", [Module, HostType]),
-                    error_logger:error_msg(lists:flatten(ErrorMsg)),
-                    ok
+                    error({Module, HostType, dynamic_domains_feature_is_not_supported})
             end
     end.
 

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -192,7 +192,9 @@ check_dynamic_domains_support(HostType, Module) ->
             case gen_mod:does_module_support(Module, dynamic_domains) of
                 true -> ok;
                 false ->
-                    error({Module, HostType, dynamic_domains_feature_is_not_supported})
+                    ErrorMsg = io_lib:format("dynamic_domains_feature_is_not_supported: ~p ~p", [Module, HostType]),
+                    error_logger:error_msg(lists:flatten(ErrorMsg)),
+                    ok
             end
     end.
 

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -138,6 +138,7 @@ start_module_for_host_type(HostType, Module, Opts0) ->
     try
         lists:map(fun mongoose_service:assert_loaded/1,
                   get_required_services(HostType, Module, Opts)),
+        check_dynamic_domains_support(HostType, Module),
         Res = Module:start(HostType, Opts),
         {links, LinksAfter} = erlang:process_info(self(), links),
         case lists:sort(LinksBefore) =:= lists:sort(LinksAfter) of
@@ -181,6 +182,17 @@ start_module_for_host_type(HostType, Module, Opts0) ->
                     timer:sleep(3000),
                     erlang:halt(string:substr(lists:flatten(ErrorText),
                                               1, 199))
+            end
+    end.
+
+check_dynamic_domains_support(HostType, Module) ->
+    case lists:member(HostType, ?MYHOSTS) of
+        true -> ok;
+        false ->
+            case gen_mod:does_module_support(Module, dynamic_domains) of
+                true -> ok;
+                false ->
+                    error({Module, HostType, dynamic_domains_feature_is_not_supported})
             end
     end.
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -42,7 +42,7 @@
          archive_id/2]).
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% ejabberd handlers
 -export([disco_local_features/1,
@@ -210,6 +210,10 @@ stop(HostType) ->
     ejabberd_hooks:delete(hooks(HostType)),
     remove_iq_handlers(HostType),
     ok.
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% hooks and handlers

--- a/src/mam/mod_mam_cache_user.erl
+++ b/src/mam/mod_mam_cache_user.erl
@@ -17,7 +17,7 @@
 -behaviour(mongoose_module_metrics).
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% ejabberd handlers
 -export([cached_archive_id/3,
@@ -90,6 +90,10 @@ stop(Host) ->
         false ->
             ok
     end.
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 writer_child_spec() ->
     {?MODULE,

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -20,7 +20,7 @@
 
 -type deps() :: #{module() => proplists:proplist()}.
 
--export([start/2, stop/1, config_spec/0,
+-export([start/2, stop/1, config_spec/0, supported_features/0,
          deps/2, get_mam_module_configuration/3, get_mam_module_opt/4]).
 
 -export([config_metrics/1]).
@@ -30,6 +30,10 @@
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 -spec start(Host :: jid:server(), Opts :: list()) -> any().
 start(_Host, _Opts) ->

--- a/src/mam/mod_mam_mnesia_prefs.erl
+++ b/src/mam/mod_mam_mnesia_prefs.erl
@@ -13,7 +13,7 @@
 %% Exports
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_prefs).
@@ -73,6 +73,9 @@ stop(Host) ->
             ok
     end.
 
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -40,7 +40,7 @@
          archive_id/2]).
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% ejabberd room handlers
 -export([disco_muc_features/1,
@@ -157,6 +157,10 @@ stop(HostType) ->
     ejabberd_hooks:delete(hooks(HostType)),
     remove_iq_handlers(HostType),
     ok.
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% hooks and handlers for MUC

--- a/src/mam/mod_mam_muc_cache_user.erl
+++ b/src/mam/mod_mam_muc_cache_user.erl
@@ -1,7 +1,7 @@
 -module(mod_mam_muc_cache_user).
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% ejabberd handlers
 -export([cached_archive_id/3,
@@ -48,6 +48,10 @@ stop(HostType) ->
     stop_server(HostType),
     clean_mnesia(HostType),
     ok.
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% Init

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -10,7 +10,7 @@
 %% Exports
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_archive).
@@ -60,6 +60,10 @@ start(HostType, _Opts) ->
 -spec stop(host_type()) -> ok.
 stop(HostType) ->
     stop_hooks(HostType).
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 -spec get_mam_muc_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
                             host_type(), jid:jid()) ->

--- a/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_muc_rdbms_async_pool_writer.erl
@@ -10,7 +10,7 @@
 %% Exports
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_archive).
@@ -94,6 +94,10 @@ start(HostType, Opts) ->
 stop(HostType) ->
     stop_muc(HostType),
     stop_workers(HostType).
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam_muc

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -10,7 +10,7 @@
 %% Exports
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_archive).
@@ -75,6 +75,10 @@ start(HostType, Opts) ->
 -spec stop(host_type()) -> ok.
 stop(HostType) ->
     stop_hooks(HostType).
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 -spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),
                            host_type(), jid:jid()) ->

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -21,7 +21,7 @@
 %% Exports
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_archive).
@@ -118,6 +118,10 @@ stop(HostType) ->
             ok
     end,
     stop_workers(HostType).
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam

--- a/src/mam/mod_mam_rdbms_prefs.erl
+++ b/src/mam/mod_mam_rdbms_prefs.erl
@@ -10,7 +10,7 @@
 %% Exports
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% MAM hook handlers
 -behaviour(ejabberd_gen_mam_prefs).
@@ -66,6 +66,9 @@ stop(Host) ->
             ok
     end.
 
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% Prepared queries
 prepare_queries(Host) ->

--- a/src/mam/mod_mam_rdbms_user.erl
+++ b/src/mam/mod_mam_rdbms_user.erl
@@ -11,7 +11,7 @@
 -module(mod_mam_rdbms_user).
 
 %% gen_mod handlers
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 %% ejabberd handlers
 -export([archive_id/3,
@@ -58,6 +58,9 @@ stop(Host) ->
             ok
     end.
 
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -4,7 +4,7 @@
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 
--export([start/0, stop/0,
+-export([start/0, stop/0, supported_features/0,
          start/2, stop/1,
          register/3,
          unregister/2,
@@ -42,6 +42,10 @@ stop() ->
 
 start(_, _) -> start().
 stop(_) -> stop().
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %%%
 %%% mongoose commands
@@ -504,8 +508,8 @@ run_subscription(Type, CallerJid, OtherJid) ->
                                lserver => LServer,
                                element => El }),
     % set subscription to
-    Acc2 = mongoose_hooks:roster_out_subscription(
-             LServer, Acc1, CallerJid, OtherJid, Type),
+    Acc2 = mongoose_hooks:roster_out_subscription(HostType, Acc1, CallerJid,
+                                                  OtherJid, Type),
     ejabberd_router:route(CallerJid, OtherJid, Acc2),
     ok.
 

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -45,6 +45,9 @@ stop(_) -> stop().
 
 -spec supported_features() -> [atom()].
 supported_features() ->
+    %% TODO: this module should be reworked into service
+    %% from the quick look it seems that the conversion for dynamic domains is done,
+    %% but there's no testing for this module enabled at dynamic_domains.spec yet.
     [dynamic_domains].
 
 %%%

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -35,6 +35,7 @@
 -export([start_link/2,
          start/2,
          stop/1,
+         supported_features/0,
          config_spec/0,
          process_room_affiliation/1,
          room_destroyed/4,
@@ -170,6 +171,10 @@ stop(HostType) ->
     stop_supervisor(HostType),
     stop_gen_server(HostType),
     ok.
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 start_server(HostType, Opts) ->
     Proc = gen_mod:get_module_proc(HostType, ?PROCNAME),

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -34,6 +34,7 @@
 -export([start_link/2,
          start/2,
          stop/1,
+         supported_features/0,
          check_access_log/3,
          add_to_log/5,
          set_room_occupants/4]).
@@ -98,7 +99,6 @@ start_link(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
-
 -spec start(jid:server(), _) -> {'error', _}
                                   | {'ok', 'undefined' | pid()}
                                   | {'ok', 'undefined' | pid(), _}.
@@ -113,13 +113,16 @@ start(Host, Opts) ->
          [?MODULE]},
     ejabberd_sup:start_child(ChildSpec).
 
-
 -spec stop(jid:server()) -> 'ok'
     | {'error', 'not_found' | 'restarting' | 'running' | 'simple_one_for_one'}.
 stop(Host) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     gen_server:call(Proc, stop),
     ejabberd_sup:stop_child(Proc).
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -34,7 +34,7 @@
          delete_room/1]).
 
 %% gen_mod callbacks
--export([start/2, stop/1, config_spec/0]).
+-export([start/2, stop/1, config_spec/0, supported_features/0]).
 
 %% config processing callback
 -export([process_config_schema/1]).
@@ -71,6 +71,10 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 -spec default_schema_definition() -> mod_muc_light_room_config:user_defined_schema().
 default_schema_definition() ->

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -50,6 +50,9 @@ stop(_) ->
 
 -spec supported_features() -> [atom()].
 supported_features() ->
+    %% TODO: this module should be reworked into service
+    %% from the quick look it seems that the conversion for dynamic domains is done,
+    %% but there's no testing for this module enabled at dynamic_domains.spec yet.
     [dynamic_domains].
 
 %%--------------------------------------------------------------------

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -22,7 +22,7 @@
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 
--export([start/2, stop/1]).
+-export([start/2, stop/1, supported_features/0]).
 
 -export([create_unique_room/4]).
 -export([create_identifiable_room/5]).
@@ -48,6 +48,9 @@ start(_, _) ->
 stop(_) ->
     mongoose_commands:unregister(commands()).
 
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %%--------------------------------------------------------------------
 %% Interface descriptions

--- a/test/gen_mod_SUITE.erl
+++ b/test/gen_mod_SUITE.erl
@@ -30,6 +30,8 @@ all() ->
 
 init_per_testcase(_, Config) ->
     meck:new(ejabberd_config, [passthrough]),
+    meck:expect(ejabberd_config, get_global_option_or_default,
+                fun(hosts, _) -> [<<"localhost">>, <<"localhost.bis">>] end),
     meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     meck:expect(ejabberd_config, add_local_option, fun(_, _) -> {atomic, ok} end),
     meck:expect(ejabberd_config, del_local_option, fun(_) -> {atomic, ok} end),

--- a/test/mod_global_distrib_SUITE.erl
+++ b/test/mod_global_distrib_SUITE.erl
@@ -130,8 +130,8 @@ fake_acc_to_component(From) ->
 
 set_meck() ->
     meck:new(ejabberd_config, []),
-    meck:expect(ejabberd_config, get_global_option,
-                fun(hosts) -> [global_host(), local_host()] end),
+    meck:expect(ejabberd_config, get_global_option_or_default,
+                fun(hosts, _) -> [global_host(), local_host()] end),
     meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
 
     meck:new(mongoose_metrics, []),

--- a/test/mongoose_service_SUITE.erl
+++ b/test/mongoose_service_SUITE.erl
@@ -55,7 +55,7 @@ init_per_testcase(misconfigured, C) ->
     mongoose_service:start(),
     meck:new(ejabberd_config, [passthrough]),
     meck:expect(ejabberd_config, get_local_option_or_default,
-        fun(services, _) -> [{service_a, []}] end),
+                fun(services, _) -> [{service_a, []}] end),
     meck:new(service_a, [non_strict]),
     meck:expect(service_a, deps, fun() -> [service_b] end),
     C;
@@ -64,6 +64,8 @@ init_per_testcase(module_deps, C) ->
     init_per_testcase(generic, C),
     meck:expect(ejabberd_config, get_local_option, fun(_) -> undefined end),
     meck:expect(ejabberd_config, add_local_option, fun(_, _) -> ok end),
+    meck:expect(ejabberd_config, get_global_option_or_default,
+                fun(hosts, _) -> [<<"localhost">>] end),
     gen_mod:start(),
     meck:new(module_a, [non_strict]),
     meck:expect(module_a, deps, fun(_, _) -> [{service, service_d}, {service, service_h}] end),

--- a/test/mongoose_wpool_SUITE.erl
+++ b/test/mongoose_wpool_SUITE.erl
@@ -49,8 +49,8 @@ init_per_suite(Config) ->
     ok = meck:new(wpool, [no_link, passthrough]),
     ok = meck:new(mongoose_wpool, [no_link, passthrough]),
     ok = meck:new(ejabberd_config, [no_link]),
-    meck:expect(ejabberd_config, get_global_option,
-                fun(hosts) -> [<<"a.com">>, <<"b.com">>, <<"c.eu">>] end),
+    meck:expect(ejabberd_config, get_global_option_or_default,
+                fun(hosts, _) -> [<<"a.com">>, <<"b.com">>, <<"c.eu">>] end),
     Self = self(),
     spawn(fun() ->
                   register(test_helper, self()),

--- a/tools/travis-setup-db.sh
+++ b/tools/travis-setup-db.sh
@@ -140,7 +140,7 @@ elif [ "$db" = 'pgsql' ]; then
     # make clean && make
     # Than rerun the script to create a new docker container.
     echo "Configuring postgres with SSL"
-    sudo -n service postgresql stop || echo "Failed to stop psql"
+    sudo -n service postgresql stop || echo "Failed to stop pgsql"
     docker rm -v -f $NAME || echo "Skip removing previous container"
     cp ${SSLDIR}/mongooseim/cert.pem ${SQL_TEMP_DIR}/fake_cert.pem
     cp ${SSLDIR}/mongooseim/key.pem ${SQL_TEMP_DIR}/fake_key.pem


### PR DESCRIPTION
this PR introduces the following changes:

1. add verification of `dynamic_domains` feature support at gen_mod
2. Add dynamic_domains support declaration for the modules tested with dynamic_domains.spec. Please note that these modules are dynamically enabled during the integration tests, there is no warranty that they are fully converted and tested properly with the current dynamic_domains.spec. We must create a follow-up ticket to recheck all of that modules, here is the list of them:
     * mod_mam
     * mod_mam_cache_user
     * mod_mam_meta - this one is not tested, but it's required for a normal MAM configuration through the TOML file
     * mod_mam_mnesia_prefs
     * mod_mam_muc
     * mod_mam_muc_cache_user
     * mod_mam_muc_rdbms_arch
     * mod_mam_muc_rdbms_async_pool_writer
     * mod_mam_rdbms_arch
     * mod_mam_rdbms_async_pool_writer
     * mod_mam_rdbms_prefs
     * mod_mam_rdbms_user
     * mod_muc
     * mod_muc_light
     * mod_muc_log
3. minor fix for mod_domain_isolation.
4. declaration of `dynamic_domains` support for 'mod_commands' and 'mod_muc_light_commands' modules. Quick check shows that these modules are converted, however there is no proper testing done for them. these 2 modules are changed mostly for alignment with bkpr's codebase.

