### PR TITLE
Fix user cache

### DIFF
--- a/src/mongoose_users.erl
+++ b/src/mongoose_users.erl
@@ -86,7 +86,7 @@ remove_user(Acc, LUser, LServer) ->
     mongoose_hooks:simple_acc().
 remove_domain(Acc, HostType, Domain) ->
     Tab = tbl_name(HostType),
-    ets:match_delete(Tab, {Domain, '_'}),
+    ets:match_delete(Tab, {{Domain, '_'}}),
     Acc.
 
 %%====================================================================
@@ -107,7 +107,7 @@ does_cached_user_exist(HostType, LServer, LUser) ->
 put_user_into_cache(HostType, LServer, LUser) ->
     Key = key(LUser, LServer),
     Tab = tbl_name(HostType),
-    ets:insert(Tab, Key),
+    ets:insert(Tab, {Key}),
     ok.
 
 -spec delete_user(mongooseim:host_type(), jid:lserver(), jid:luser()) -> ok.


### PR DESCRIPTION
As the tables are created per-host-type, a table can have more than one
domain within, and so there's no unique key properly defined,
considering that the same namepart can be used in two different domains,
and the same domain contains many nameparts.

The cache was broken because, as a set where the domain is the key, inserted users would always override previous. If namepart is the key, two users with the same namepart in different domains would also override each other. So the whole pair needed to be made the key as a 1-tuple.