### PR TITLE
Support dynamic domains in mod_offline

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -14,17 +14,10 @@
 {suites, "tests", carboncopy_SUITE}.
 
 {suites, "tests", disco_and_caps_SUITE}.
-{skip_cases, "tests", disco_and_caps_SUITE,
- [user_can_query_friend_features],
- "at the moment neither mod_offline nor mod_adhoc supports dynamic domains"
- " and this test requires at least one of them to be enabled"
- " to have a non-empty feature list"}.
 
 {suites, "tests", domain_isolation_SUITE}.
 
 {suites, "tests", inbox_SUITE}.
-{skip_cases, "tests", inbox_SUITE, [msg_sent_to_offline_user],
- "at the moment mod_offline doesn't support dynamic domains"}.
 
 {suites, "tests", inbox_extensions_SUITE}.
 
@@ -39,11 +32,6 @@
  "(requires mod_register creating CT users)"}.
 
 {suites, "tests", muc_light_SUITE}.
-{skip_cases, "tests", muc_light_SUITE,
- [rooms_in_rosters_doesnt_break_disco_info],
- "at the moment neither mod_offline nor mod_adhoc supports dynamic domains"
- " and this test requires at least one of them to be enabled"
- " to have a non-empty feature list"}.
 
 {suites, "tests", muc_light_legacy_SUITE}.
 
@@ -59,16 +47,6 @@
  "at the moment mim2 node is not configured for dynamic domains"}.
 
 {suites, "tests", sm_SUITE}.
-{skip_cases, "tests", sm_SUITE,
- [resend_unacked_on_reconnection,
-  session_established,
-  wait_for_resumption,
-  resume_session_kills_old_C2S_gracefully,
-  resend_unacked_after_resume_timeout,
-  resend_more_offline_messages_than_buffer_size,
-  resume_expired_session_returns_correct_h,
-  unacknowledged_message_hook_offline],
- "at the moment mod_offline doesn't support dynamic domains"}.
 
 {config, ["dynamic_domains.config", "test.config"]}.
 

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -35,6 +35,10 @@
 
 {suites, "tests", muc_light_legacy_SUITE}.
 
+{suites, "tests", offline_SUITE}.
+{skip_groups, "tests", offline_SUITE, [chatmarkers],
+ "at the moment mod_offline_chatmarkers does not support dynamic domains"}.
+
 {suites, "tests", offline_stub_SUITE}.
 
 {suites, "tests", presence_SUITE}.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -231,8 +231,7 @@
      [{dbs, [redis, minio]},
       {outgoing_pools, "[outgoing_pools.redis.global_distrib]
   scope = \"global\"
-  workers = 10"},
-      {mod_offline, "[modules.mod_offline]"}]},
+  workers = 10"}]},
     {pgsql_mnesia,
      [{dbs, [redis, pgsql]},
       {auth_method, "\"rdbms\""},
@@ -257,13 +256,11 @@
   backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
-      {mod_offline, "[modules.mod_offline]
-  backend = \"rdbms\""},
+      {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "[modules.mod_vcard]
   backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
-      {mod_roster, "
-  backend = \"rdbms\""}]},
+      {mod_roster, "  backend = \"rdbms\"\n"}]},
     {odbc_mssql_mnesia,
      [{dbs, [redis, mssql]},
       {auth_method, "\"rdbms\""},
@@ -282,13 +279,11 @@
   backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
-      {mod_offline, "[modules.mod_offline]
-  backend = \"rdbms\""},
+      {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "[modules.mod_vcard]
   backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
-      {mod_roster, "
-  backend = \"rdbms\""}]},
+      {mod_roster, "  backend = \"rdbms\"\n"}]},
     {mysql_redis,
      [{dbs, [redis, mysql, rmq]},
       {sm_backend, "\"redis\""},
@@ -317,13 +312,11 @@
   backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
-      {mod_offline, "[modules.mod_offline]
-  backend = \"rdbms\""},
+      {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "[modules.mod_vcard]
   backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
-      {mod_roster, "
-  backend = \"rdbms\""}]},
+      {mod_roster, "  backend = \"rdbms\"\n"}]},
     {ldap_mnesia,
      [{dbs, [redis, ldap]},
       {auth_method, "\"ldap\""},
@@ -352,7 +345,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.certfile = \"priv/ssl/fake_cert.pem\"
   connection.tls.keyfile = \"priv/ssl/fake_key.pem\""},
-      {mod_offline, "[modules.mod_offline]"},
       {password_format, "password.format = \"scram\""},
       {auth_ldap, "ldap.base = \"ou=Users,dc=esl,dc=com\"
   ldap.filter = \"(objectClass=inetOrgPerson)\""},
@@ -389,13 +381,11 @@
   backend = \"riak\""},
       {mod_private, "[modules.mod_private]
   backend = \"riak\""},
-      {mod_offline, "[modules.mod_offline]
-  backend = \"riak\""},
+      {mod_offline, "  backend = \"riak\"\n"},
       {mod_vcard, "[modules.mod_vcard]
   backend = \"riak\"
   host = \"vjud.@HOST@\""},
-      {mod_roster, "
-  backend = \"riak\""}
+      {mod_roster, "  backend = \"riak\"\n"}
      ]},
     {elasticsearch_and_cassandra_mnesia,
      [{dbs, [redis, elasticsearch, cassandra]},
@@ -408,8 +398,7 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.verify_peer = true
 [outgoing_pools.elastic.default]
-  scope = \"global\""},
-      {mod_offline, "[modules.mod_offline]"}
+  scope = \"global\""}
      ]}
    ]}
  ]}.

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -155,7 +155,7 @@ setup_meck(suite) ->
 setup_meck(mam_failure) ->
     ok = rpc(mim(), meck, expect, [mod_mam_rdbms_arch, archive_message, 3, {error, simulated}]);
 setup_meck(offline_failure) ->
-    ok = rpc(mim(), meck, expect, [mod_offline_mnesia, write_messages, 3, {error, simulated}]);
+    ok = rpc(mim(), meck, expect, [mod_offline_mnesia, write_messages, 4, {error, simulated}]);
 setup_meck(_) -> ok.
 
 save_offline_status(mam_success, Config) -> [{offline_storage, mam} | Config];

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1201,10 +1201,11 @@ remove_old_messages_test(Config) ->
         OfflineOld = generate_offline_message(JidRecordAlice, JidRecordBob, Msg1, OldTimestamp),
         OfflineNew = generate_offline_message(JidRecordAlice, JidRecordBob, Msg2, os:system_time(microsecond)),
         {jid, _, _, _, LUser, LServer, _} = JidRecordBob,
-        rpc_call(mod_offline_backend, write_messages, [LUser, LServer, [OfflineOld, OfflineNew]]),
+        HostType = domain_helper:host_type(),
+        rpc_call(mod_offline_backend, write_messages, [HostType, LUser, LServer, [OfflineOld, OfflineNew]]),
         %% when
         {_, 0} = ejabberdctl("delete_old_messages", [LServer, "1"], Config),
-        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [JidRecordBob]),
+        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [HostType, JidRecordBob]),
         %% then
         1 = length(SecondList)
     end).
@@ -1238,10 +1239,11 @@ remove_expired_messages_test(Config) ->
                                                           ExpirationTimeFuture),
         {jid, _, _, _, LUser, LServer, _} = JidRecordKate,
         Args = [OfflineOld, OfflineNow, OfflineFuture, OfflineFuture2],
-        rpc_call(mod_offline_backend, write_messages, [LUser, LServer, Args]),
+        HostType = domain_helper:host_type(),
+        rpc_call(mod_offline_backend, write_messages, [HostType, LUser, LServer, Args]),
         %% when
         {_, 0} = ejabberdctl("delete_expired_messages", [LServer], Config),
-        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [JidRecordKate]),
+        {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [HostType, JidRecordKate]),
         %% then
         2 = length(SecondList)
     end).

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -942,10 +942,11 @@ retrieve_offline(Config) ->
             %% Well, jid_to_lower works for any binary :)
             AliceU = escalus_utils:jid_to_lower(escalus_client:username(Alice)),
             AliceS = escalus_utils:jid_to_lower(escalus_client:server(Alice)),
+            HostType = domain_helper:host_type(),
             mongoose_helper:wait_until(
               fun() ->
                       mongoose_helper:successful_rpc(mod_offline_backend, count_offline_messages,
-                                                     [AliceU, AliceS, 10])
+                                                     [HostType, AliceU, AliceS, 10])
               end, 3),
 
             BobJid = escalus_client:full_jid(Bob),
@@ -977,10 +978,11 @@ remove_offline(Config) ->
             %% Well, jid_to_lower works for any binary :)
             AliceU = escalus_utils:jid_to_lower(escalus_client:username(Alice)),
             AliceS = escalus_utils:jid_to_lower(escalus_client:server(Alice)),
+            HostType = domain_helper:host_type(),
             mongoose_helper:wait_until(
               fun() ->
                       mongoose_helper:successful_rpc(mod_offline_backend, count_offline_messages,
-                                                     [AliceU, AliceS, 10])
+                                                     [HostType, AliceU, AliceS, 10])
               end, 3),
 
             {0, _} = unregister(Alice, Config),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -761,9 +761,8 @@ delete_room_archive(Server, Username) ->
     rpc_apply(mod_mam_muc, delete_archive, [Server, Username]).
 
 delete_offline_messages(Server, Username) ->
-    %% Do not care
-    catch rpc_apply(mod_offline, remove_user, [Username, Server]),
-    ok.
+    HostType = domain_helper:host_type(),
+    rpc_apply(mod_offline_backend, remove_user, [HostType, Username, Server]).
 
 wait_message_range(Client, FromN, ToN) ->
     wait_message_range(Client, 15, FromN-1, FromN, ToN).

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -155,7 +155,8 @@ get_backend_name(Module) ->
     end.
 
 generic_count(mod_offline_backend, {LUser, LServer}) ->
-    rpc(mim(), mod_offline_backend, count_offline_messages, [LUser, LServer, 100]).
+    HostType = domain_helper:host_type(),
+    rpc(mim(), mod_offline_backend, count_offline_messages, [HostType, LUser, LServer, 100]).
 
 generic_count(Module) ->
     case get_backend(Module) of

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -17,6 +17,8 @@
 -define(AFFILIATION_NS, <<"urn:xmpp:muclight:0#affiliations">>).
 -define(NS_FEATURE_MSGOFFLINE,  <<"msgoffline">>).
 
+-import(domain_helper, [host_type/0]).
+
 %%%===================================================================
 %%% Suite configuration
 %%%===================================================================
@@ -57,16 +59,16 @@ init_per_suite(C) -> escalus:init_per_suite(C).
 end_per_suite(C) -> escalus_fresh:clean(), escalus:end_per_suite(C).
 
 init_per_group(with_groupchat, C) ->
-    Config = dynamic_modules:save_modules(domain(), C),
-    dynamic_modules:ensure_modules(domain(), with_groupchat_modules()),
+    Config = dynamic_modules:save_modules(host_type(), C),
+    dynamic_modules:ensure_modules(host_type(), with_groupchat_modules()),
     Config;
 init_per_group(chatmarkers, C) ->
-    case mongoose_helper:is_rdbms_enabled(domain()) of
+    case mongoose_helper:is_rdbms_enabled(host_type()) of
         false ->
             {skip, require_rdbms};
         true ->
-            Config = dynamic_modules:save_modules(domain(), C),
-            dynamic_modules:ensure_modules(domain(), chatmarkers_modules()),
+            Config = dynamic_modules:save_modules(host_type(), C),
+            dynamic_modules:ensure_modules(host_type(), chatmarkers_modules()),
             Config
     end;
 init_per_group(_, C) -> C.
@@ -89,12 +91,9 @@ chatmarkers_modules() ->
 
 end_per_group(Group, C) when Group =:= chatmarkers;
                              Group =:= with_groupchat ->
-    dynamic_modules:restore_modules(domain(), C),
+    dynamic_modules:restore_modules(host_type(), C),
     C;
 end_per_group(_, C) -> C.
-
-domain() ->
-    ct:get_config({hosts, mim, domain}).
 
 init_per_testcase(Name, C) -> escalus:init_per_testcase(Name, C).
 end_per_testcase(Name, C) -> escalus:end_per_testcase(Name, C).
@@ -402,5 +401,5 @@ make_message_with_expiry(Target, Expiry, Text) ->
                                  {<<"seconds">>, ExpiryBin}]},
     Stanza#xmlel{children = [ExpiryElem | Children]}.
 
-repeat(L,0) -> [];
-repeat(L,N) -> L ++ repeat(L, N-1).
+repeat(_L, 0) -> [];
+repeat(L, N) -> L ++ repeat(L, N-1).

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -211,46 +211,46 @@
   periodic_report = 10_800_000
 
 [modules.mod_adhoc]
+
 {{#mod_amp}}
-
 {{{mod_amp}}}
-{{/mod_amp}}
 
+{{/mod_amp}}
 [modules.mod_disco]
   users_can_see_hidden_services = false
 
 [modules.mod_commands]
+
 {{#mod_cache_users}}
-
-[modules.mod_cache_users]{{{mod_cache_users}}}
+[modules.mod_cache_users]
+{{{mod_cache_users}}}
 {{/mod_cache_users}}
-
 [modules.mod_muc_commands]
 
 [modules.mod_muc_light_commands]
+
 {{#mod_last}}
-
 {{{mod_last}}}
+
 {{/mod_last}}
-
 [modules.mod_stream_management]
-{{#mod_offline}}
 
+{{#mod_offline}}
+[modules.mod_offline]
 {{{mod_offline}}}
 {{/mod_offline}}
 {{#mod_privacy}}
-
 {{{mod_privacy}}}
+
 {{/mod_privacy}}
 {{#mod_blocking}}
-
 {{{mod_blocking}}}
+
 {{/mod_blocking}}
 {{#mod_private}}
-
 {{{mod_private}}}
-{{/mod_private}}
 
+{{/mod_private}}
 [modules.mod_register]
   welcome_message = {body = "", subject = ""}
   ip_access = [
@@ -258,17 +258,17 @@
     {address = "0.0.0.0/0", policy = "deny"}
   ]
   access = "register"
+
 {{#mod_roster}}
-
-[modules.mod_roster]{{{mod_roster}}}
+[modules.mod_roster]
+{{{mod_roster}}}
 {{/mod_roster}}
-
 [modules.mod_sic]
+
 {{#mod_vcard}}
-
 {{{mod_vcard}}}
-{{/mod_vcard}}
 
+{{/mod_vcard}}
 [modules.mod_bosh]
 
 [modules.mod_carboncopy]

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -22,12 +22,22 @@
   auth.methods = [\"dummy\"]
   auth.dummy.base_time = 1
   auth.dummy.variance = 5
+
   [host_config.modules.mod_cache_users]
+
   [host_config.modules.mod_carboncopy]
+
   [host_config.modules.mod_stream_management]
+
   [host_config.modules.mod_disco]
+
+  {{#mod_offline}}
+  [host_config.modules.mod_offline]
+  {{{mod_offline}}}
+  {{/mod_offline}}
   {{#mod_roster}}
-  [host_config.modules.mod_roster]{{{mod_roster}}}
+  [host_config.modules.mod_roster]
+  {{{mod_roster}}}
   {{/mod_roster}}"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
@@ -73,9 +83,9 @@
 
 {mod_amp, "[modules.mod_amp]"}.
 {mod_private, "[modules.mod_private]"}.
-{mod_cache_users, "
-  time_to_live = 2
-  number_of_segments = 5"}.
+{mod_cache_users, "  time_to_live = 2
+  number_of_segments = 5
+"}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -20,12 +20,11 @@
   ip_address = \"127.0.0.1\"
   password = \"secret\""}.
 {mod_last, "[modules.mod_last]"}.
-{mod_offline, "[modules.mod_offline]
-  access_max_user_messages = \"max_user_offline_messages\""}.
+{mod_offline, ""}. % enabled, no options
 {mod_privacy, "[modules.mod_privacy]"}.
 {mod_blocking, "[modules.mod_blocking]"}.
 {mod_private, "[modules.mod_private]"}.
-{mod_roster, ""}.
+{mod_roster, ""}. % enabled, no options
 {mod_vcard, "[modules.mod_vcard]
   host = \"vjud.@HOST@\""}.
 {sm_backend, "\"mnesia\""}.

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -442,7 +442,7 @@ get_loglevel() ->
 %%% Purge DB
 %%%
 
--spec delete_expired_messages(mongooseim:host_type()) -> {ok, iolist()} | {error, iolist()}.
+-spec delete_expired_messages(jid:lserver()) -> {ok, iolist()} | {error, iolist()}.
 delete_expired_messages(LServer) ->
     case mongoose_domain_api:get_domain_host_type(LServer) of
         {ok, HostType} ->
@@ -456,8 +456,7 @@ delete_expired_messages(LServer) ->
             {error, "Unknown domain"}
     end.
 
--spec delete_old_messages(mongooseim:host_type(), Days :: integer()) ->
-          {ok, iolist()} | {error, iolist()}.
+-spec delete_old_messages(jid:lserver(), Days :: integer()) -> {ok, iolist()} | {error, iolist()}.
 delete_old_messages(LServer, Days) ->
     case mongoose_domain_api:get_domain_host_type(LServer) of
         {ok, HostType} ->

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -442,22 +442,33 @@ get_loglevel() ->
 %%% Purge DB
 %%%
 
--spec delete_expired_messages(jid:lserver()) -> {ok, iolist()} | {error, iolist()}.
+-spec delete_expired_messages(mongooseim:host_type()) -> {ok, iolist()} | {error, iolist()}.
 delete_expired_messages(LServer) ->
-    case mod_offline:remove_expired_messages(LServer) of
-        {ok, C} ->
-            {ok, io_lib:format("Removed ~p messages", [C])};
-        {error, Reason} ->
-            {error, io_lib:format("Can't delete expired messages: ~n~p", [Reason])}
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            case mod_offline:remove_expired_messages(HostType, LServer) of
+                {ok, C} ->
+                    {ok, io_lib:format("Removed ~p messages", [C])};
+                {error, Reason} ->
+                    {error, io_lib:format("Can't delete expired messages: ~n~p", [Reason])}
+            end;
+        {error, not_found} ->
+            {error, "Unknown domain"}
     end.
 
--spec delete_old_messages(jid:lserver(), Days :: integer()) -> {ok, iolist()} | {error, iolist()}.
+-spec delete_old_messages(mongooseim:host_type(), Days :: integer()) ->
+          {ok, iolist()} | {error, iolist()}.
 delete_old_messages(LServer, Days) ->
-    case mod_offline:remove_old_messages(LServer, Days) of
-        {ok, C} ->
-            {ok, io_lib:format("Removed ~p messages", [C])};
-        {error, Reason} ->
-            {error, io_lib:format("Can't remove old messages: ~n~p", [Reason])}
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            case mod_offline:remove_old_messages(HostType, LServer, Days) of
+                {ok, C} ->
+                    {ok, io_lib:format("Removed ~p messages", [C])};
+                {error, Reason} ->
+                    {error, io_lib:format("Can't remove old messages: ~n~p", [Reason])}
+            end;
+        {error, not_found} ->
+            {error, "Unknown domain"}
     end.
 
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2314,10 +2314,7 @@ process_privacy_iq(Acc, set, To, StateData) ->
 resend_offline_messages(Acc, StateData) ->
     ?LOG_DEBUG(#{what => resend_offline_messages,
                  acc => Acc, c2s_state => StateData}),
-    Acc1 = mongoose_hooks:resend_offline_messages_hook(
-                                   StateData#state.host_type,
-                                   Acc,
-                                   StateData#state.jid),
+    Acc1 = mongoose_hooks:resend_offline_messages_hook(Acc, StateData#state.jid),
     Rs = mongoose_acc:get(offline, messages, [], Acc1),
     Acc2 = lists:foldl(
                        fun({route, From, To, MsgAcc}, A) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -26,7 +26,7 @@
          register_subhost/2,
          register_user/3,
          remove_user/3,
-         resend_offline_messages_hook/3,
+         resend_offline_messages_hook/2,
          rest_user_send_packet/4,
          session_cleanup/5,
          set_vcard/3,
@@ -349,12 +349,12 @@ remove_user(Acc, LServer, LUser) ->
     HostType = mongoose_acc:host_type(Acc),
     ejabberd_hooks:run_for_host_type(remove_user, HostType, Acc, [LUser, LServer]).
 
--spec resend_offline_messages_hook(HostType, Acc, JID) -> Result when
-    HostType :: binary(),
+-spec resend_offline_messages_hook(Acc, JID) -> Result when
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-resend_offline_messages_hook(HostType, Acc, JID) ->
+resend_offline_messages_hook(Acc, JID) ->
+    HostType = mongoose_acc:host_type(Acc),
     ejabberd_hooks:run_for_host_type(resend_offline_messages_hook, HostType, Acc, [JID]).
 
 %%% @doc The `rest_user_send_packet' hook is called when a user sends

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -34,7 +34,7 @@
 -behaviour(mongoose_module_metrics).
 
 %% gen_mod handlers
--export([start/2, stop/1, config_spec/0]).
+-export([start/2, stop/1, config_spec/0, supported_features/0]).
 
 %% Hook handlers
 -export([inspect_packet/4,
@@ -157,6 +157,8 @@ riak_config_spec() ->
                                                      validate = non_empty}},
              format = none
             }.
+
+supported_features() -> [dynamic_domains].
 
 hooks(HostType) ->
     DefaultHooks = [

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -210,9 +210,9 @@ write_messages(HostType, LUser, LServer, Msgs) ->
             discard_warn_sender(Msgs)
     end.
 
--spec is_message_count_threshold_reached(host_type(), integer(), jid:luser(), jid:lserver(),
-                                         integer()) ->
-    boolean().
+-spec is_message_count_threshold_reached(host_type(), integer() | infinity,
+                                         jid:luser(), jid:lserver(), integer()) ->
+          boolean().
 is_message_count_threshold_reached(_HostType, infinity, _LUser, _LServer, _Len) ->
     false;
 is_message_count_threshold_reached(_HostType, MaxOfflineMsgs, _LUser, _LServer, Len)

--- a/src/offline/mod_offline_mnesia.erl
+++ b/src/offline/mod_offline_mnesia.erl
@@ -50,7 +50,8 @@ init(_HostType, _Opts) ->
     upgrade_table(),
     ok.
 
--spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+-spec pop_messages(mongooseim:host_type(), jid:jid()) ->
+          {ok, [mod_offline:msg()]} | {error, any()}.
 pop_messages(_HostType, To) ->
     US = jid:to_lus(To),
     F = fun() ->
@@ -65,7 +66,8 @@ pop_messages(_HostType, To) ->
             {error, Reason}
     end.
 
--spec fetch_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+-spec fetch_messages(mongooseim:host_type(), jid:jid()) ->
+          {ok, [mod_offline:msg()]} | {error, any()}.
 fetch_messages(_HostType, To) ->
     US = jid:to_lus(To),
     F = fun() -> mnesia:wread({offline_msg, US}) end,
@@ -99,7 +101,8 @@ write_all_messages_t(Len, Msgs) ->
     [mnesia:write(M) || M <- Msgs],
     ok.
 
--spec count_offline_messages(mongooseim:host_type(), jid:luser(), jid:lserver(), mod_offline:msg_count()) ->
+-spec count_offline_messages(mongooseim:host_type(), jid:luser(), jid:lserver(),
+                             mod_offline:msg_count()) ->
           mod_offline:msg_count().
 count_offline_messages(_HostType, LUser, LServer, _MaxNeeded) ->
     US = {LUser, LServer},

--- a/src/offline/mod_offline_mnesia.erl
+++ b/src/offline/mod_offline_mnesia.erl
@@ -28,21 +28,20 @@
 -module(mod_offline_mnesia).
 -behaviour(mod_offline).
 -export([init/2,
-         pop_messages/1,
-         fetch_messages/1,
-         write_messages/3,
-         count_offline_messages/3,
-         remove_expired_messages/1,
-         remove_old_messages/2,
-         remove_user/2]).
+         pop_messages/2,
+         fetch_messages/2,
+         write_messages/4,
+         count_offline_messages/4,
+         remove_expired_messages/2,
+         remove_old_messages/3,
+         remove_user/3]).
 
--include("mongoose.hrl").
--include("jlib.hrl").
 -include("mod_offline.hrl").
 
 -define(OFFLINE_TABLE_LOCK_THRESHOLD, 1000).
 
-init(_Host, _Opts) ->
+-spec init(mongoooseim:host_type(), gen_mod:module_opts()) -> ok.
+init(_HostType, _Opts) ->
     mnesia:create_table(offline_msg,
                         [{disc_only_copies, [node()]},
                          {type, bag},
@@ -51,7 +50,8 @@ init(_Host, _Opts) ->
     upgrade_table(),
     ok.
 
-pop_messages(To) ->
+-spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+pop_messages(_HostType, To) ->
     US = jid:to_lus(To),
     F = fun() ->
                 Rs = mnesia:wread({offline_msg, US}),
@@ -65,7 +65,8 @@ pop_messages(To) ->
             {error, Reason}
     end.
 
-fetch_messages(To) ->
+-spec fetch_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+fetch_messages(_HostType, To) ->
     US = jid:to_lus(To),
     F = fun() -> mnesia:wread({offline_msg, US}) end,
     case mnesia:transaction(F) of
@@ -75,7 +76,9 @@ fetch_messages(To) ->
             {error, Reason}
     end.
 
-write_messages(_LUser, _LServer, Msgs) ->
+-spec write_messages(mongooseim:host_type(), jid:luser(), jid:lserver(), [mod_offline:msg()]) ->
+          ok | {error, any()}.
+write_messages(_HostType, _LUser, _LServer, Msgs) ->
     F = fun() -> write_messages_t(Msgs) end,
     case mnesia:transaction(F) of
         {atomic, Result} ->
@@ -96,7 +99,9 @@ write_all_messages_t(Len, Msgs) ->
     [mnesia:write(M) || M <- Msgs],
     ok.
 
-count_offline_messages(LUser, LServer, _MaxNeeded) ->
+-spec count_offline_messages(mongooseim:host_type(), jid:luser(), jid:lserver(), mod_offline:msg_count()) ->
+          mod_offline:msg_count().
+count_offline_messages(_HostType, LUser, LServer, _MaxNeeded) ->
     US = {LUser, LServer},
     F = fun () ->
         Result = mnesia:read(offline_msg, US, read),
@@ -107,22 +112,15 @@ count_offline_messages(LUser, LServer, _MaxNeeded) ->
         _ -> 0
     end.
 
-remove_user(LUser, LServer) ->
-    US = {LUser, LServer},
-    F = fun() ->
-                mnesia:delete({offline_msg, US})
-        end,
-    mnesia:transaction(F).
-
--spec remove_expired_messages(jid:lserver()) -> {error, term()} | {ok, HowManyRemoved} when
-    HowManyRemoved :: integer().
-remove_expired_messages(_Host) ->
+-spec remove_expired_messages(mongooseim:host_type(), jid:lserver()) ->
+          {ok, mod_offline:msg_count()} | {error, any()}.
+remove_expired_messages(_HostType, LServer) ->
     TimeStamp = erlang:system_time(microsecond),
     F = fun() ->
                 mnesia:write_lock_table(offline_msg),
                 mnesia:foldl(
                   fun(Rec, Acc) ->
-              Acc + remove_expired_message(TimeStamp, Rec)
+                          Acc + remove_expired_message(LServer, TimeStamp, Rec)
                   end, 0, offline_msg)
         end,
     case mnesia:transaction(F) of
@@ -132,15 +130,14 @@ remove_expired_messages(_Host) ->
             {ok, Result}
     end.
 
--spec remove_old_messages(jid:lserver(), integer()) ->
-    {error, term()} | {ok, HowManyRemoved} when
-    HowManyRemoved :: integer().
-remove_old_messages(_Host, TimeStamp) ->
+-spec remove_old_messages(mongooseim:host_type(), jid:lserver(), mod_offline:timestamp()) ->
+          {ok, mod_offline:msg_count()} | {error, any()}.
+remove_old_messages(_HostType, LServer, TimeStamp) ->
     F = fun() ->
                 mnesia:write_lock_table(offline_msg),
                 mnesia:foldl(
                   fun(Rec, Acc) ->
-                          Acc + remove_old_message(TimeStamp, Rec)
+                          Acc + remove_old_message(LServer, TimeStamp, Rec)
                   end, 0, offline_msg)
         end,
     case mnesia:transaction(F) of
@@ -150,26 +147,37 @@ remove_old_messages(_Host, TimeStamp) ->
             {ok, Result}
     end.
 
-remove_expired_message(TimeStamp, Rec) ->
+remove_expired_message(LServer, TimeStamp, Rec = #offline_msg{us = {_, LServer}}) ->
     case mod_offline:is_expired_message(TimeStamp, Rec) of
         true ->
             mnesia:delete_object(Rec),
             1;
         false ->
             0
-    end.
+    end;
+remove_expired_message(_, _, _) -> 0.
 
-remove_old_message(TimeStamp, Rec) ->
+remove_old_message(LServer, TimeStamp, Rec = #offline_msg{us = {_, LServer}}) ->
     case is_old_message(TimeStamp, Rec) of
         true ->
             mnesia:delete_object(Rec),
             1;
         false ->
             0
-    end.
+    end;
+remove_old_message(_, _, _) -> 0.
 
 is_old_message(MaxAllowedTimeStamp, #offline_msg{timestamp=TimeStamp}) ->
     TimeStamp < MaxAllowedTimeStamp.
+
+-spec remove_user(mongooseim:host_type(), jid:luser(), jid:lserver()) -> ok.
+remove_user(_HostType, LUser, LServer) ->
+    US = {LUser, LServer},
+    F = fun() ->
+                mnesia:delete({offline_msg, US})
+        end,
+    mnesia:transaction(F),
+    ok.
 
 upgrade_table() ->
     Fields = record_info(fields, offline_msg),
@@ -182,4 +190,3 @@ upgrade_table() ->
 
 transform_from_3_5_0_to_next(Record) ->
     erlang:append_element(Record, []).
-

--- a/src/offline/mod_offline_rdbms.erl
+++ b/src/offline/mod_offline_rdbms.erl
@@ -128,7 +128,7 @@ push_offline_messages(HostType, Rows) ->
 
 %% API functions
 
--spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+-spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]} | {error, any()}.
 pop_messages(HostType, #jid{} = To) ->
     US = {LUser, LServer} = jid:to_lus(To),
     ExtTimeStamp = os:system_time(microsecond),

--- a/src/offline/mod_offline_rdbms.erl
+++ b/src/offline/mod_offline_rdbms.erl
@@ -26,23 +26,21 @@
 -module(mod_offline_rdbms).
 -behaviour(mod_offline).
 -export([init/2,
-         pop_messages/1,
-         fetch_messages/1,
-         write_messages/3,
-         count_offline_messages/3,
-         remove_expired_messages/1,
-         remove_old_messages/2,
-         remove_user/2]).
+         pop_messages/2,
+         fetch_messages/2,
+         write_messages/4,
+         count_offline_messages/4,
+         remove_expired_messages/2,
+         remove_old_messages/3,
+         remove_user/3]).
 
 -import(mongoose_rdbms, [prepare/4, execute_successfully/3]).
 
--include("mongoose.hrl").
 -include("jlib.hrl").
 -include("mod_offline.hrl").
 
--define(OFFLINE_TABLE_LOCK_THRESHOLD, 1000).
-
-init(_Host, _Opts) ->
+-spec init(mongoooseim:host_type(), gen_mod:module_opts()) -> ok.
+init(_HostType, _Opts) ->
     prepare_queries(),
     ok.
 
@@ -72,52 +70,69 @@ prepare_queries() ->
             <<"DELETE FROM offline_message "
               "WHERE server = ? AND username = ?">>),
     prepare(offline_delete_old, offline_message,
-            [timestamp],
-            <<"DELETE FROM offline_message WHERE timestamp < ?">>),
+            [server, timestamp],
+            <<"DELETE FROM offline_message WHERE server = ? AND timestamp < ?">>),
     prepare(offline_delete_expired, offline_message,
-            [expire],
+            [server, expire],
             <<"DELETE FROM offline_message "
-              "WHERE expire IS NOT null AND expire < ?">>).
+              "WHERE server = ? AND expire IS NOT null AND expire < ?">>).
 
-execute_count_offline_messages(LUser, LServer, Limit) ->
+-spec execute_count_offline_messages(mongooseim:host_type(), jid:luser(), jid:lserver(),
+                                     pos_integer()) ->
+          mongoose_rdbms:query_result().
+execute_count_offline_messages(HostType, LUser, LServer, Limit) ->
     Args = rdbms_queries:add_limit_arg(Limit, [LServer, LUser]),
-    execute_successfully(LServer, offline_count_limit, Args).
+    execute_successfully(HostType, offline_count_limit, Args).
 
-execute_fetch_offline_messages(LServer, LUser, ExtTimeStamp) ->
-    execute_successfully(LServer, offline_select, [LServer, LUser, ExtTimeStamp]).
+-spec execute_fetch_offline_messages(mongooseim:host_type(), jid:luser(), jid:lserver(),
+                                     integer()) ->
+          mongoose_rdbms:query_result().
+execute_fetch_offline_messages(HostType, LUser, LServer, ExtTimeStamp) ->
+    execute_successfully(HostType, offline_select, [LServer, LUser, ExtTimeStamp]).
 
-execute_remove_expired_offline_messages(LServer, ExtTimeStamp) ->
-    execute_successfully(LServer, offline_delete_expired, [ExtTimeStamp]).
+-spec execute_remove_expired_offline_messages(mongooseim:host_type(), jid:lserver(), integer()) ->
+          mongoose_rdbms:query_result().
+execute_remove_expired_offline_messages(HostType, LServer, ExtTimeStamp) ->
+    execute_successfully(HostType, offline_delete_expired, [LServer, ExtTimeStamp]).
 
-execute_remove_old_offline_messages(LServer, ExtTimeStamp) ->
-    execute_successfully(LServer, offline_delete_old, [ExtTimeStamp]).
+-spec execute_remove_old_offline_messages(mongooseim:host_type(), jid:lserver(), integer()) ->
+          mongoose_rdbms:query_result().
+execute_remove_old_offline_messages(HostType, LServer, ExtTimeStamp) ->
+    execute_successfully(HostType, offline_delete_old, [LServer, ExtTimeStamp]).
 
-execute_offline_delete(LServer, LUser) ->
-    execute_successfully(LServer, offline_delete, [LServer, LUser]).
+-spec execute_offline_delete(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
+          mongoose_rdbms:query_result().
+execute_offline_delete(HostType, LUser, LServer) ->
+    execute_successfully(HostType, offline_delete, [LServer, LUser]).
 
 %% Transactions
 
-pop_offline_messages(LServer, LUser, ExtTimeStamp) ->
+-spec pop_offline_messages(mongooseim:host_type(), jid:luser(), jid:server(), integer()) ->
+          mongoose_rdbms:transaction_result().
+pop_offline_messages(HostType, LUser, LServer, ExtTimeStamp) ->
     F = fun() ->
-            Res = execute_fetch_offline_messages(LServer, LUser, ExtTimeStamp),
-            execute_offline_delete(LServer, LUser),
+            Res = execute_fetch_offline_messages(HostType, LUser, LServer, ExtTimeStamp),
+            execute_offline_delete(HostType, LUser, LServer),
             Res
         end,
     mongoose_rdbms:sql_transaction(LServer, F).
 
-push_offline_messages(LServer, Rows) ->
+-spec push_offline_messages(mongooseim:host_type(), [list()]) ->
+          mongoose_rdbms:transaction_result().
+push_offline_messages(HostType, Rows) ->
     F = fun() ->
-            [execute_successfully(LServer, offline_insert, Row)
+            [execute_successfully(HostType, offline_insert, Row)
              || Row <- Rows], ok
         end,
-    mongoose_rdbms:sql_transaction(LServer, F).
+    mongoose_rdbms:sql_transaction(HostType, F).
 
 %% API functions
 
-pop_messages(#jid{} = To) ->
+-spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+pop_messages(HostType, #jid{} = To) ->
     US = {LUser, LServer} = jid:to_lus(To),
     ExtTimeStamp = os:system_time(microsecond),
-    case pop_offline_messages(LServer, LUser, ExtTimeStamp) of
+    case pop_offline_messages(HostType, LUser, LServer, ExtTimeStamp) of
         {atomic, {selected, Rows}} ->
             {ok, rows_to_records(US, To, Rows)};
         {aborted, Reason} ->
@@ -127,43 +142,47 @@ pop_messages(#jid{} = To) ->
     end.
 
 %% Fetch messages for GDPR
-fetch_messages(#jid{} = To) ->
+-spec fetch_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
+fetch_messages(HostType, #jid{} = To) ->
     US = {LUser, LServer} = jid:to_lus(To),
     ExtTimeStamp = os:system_time(microsecond),
-    {selected, Rows} = execute_fetch_offline_messages(LServer, LUser, ExtTimeStamp),
+    {selected, Rows} = execute_fetch_offline_messages(HostType, LUser, LServer, ExtTimeStamp),
     {ok, rows_to_records(US, To, Rows)}.
 
-write_messages(LUser, LServer, Msgs) ->
+-spec write_messages(mongooseim:host_type(), jid:luser(), jid:lserver(), [mod_offline:msg()]) ->
+          ok | {error, any()}.
+write_messages(HostType, LUser, LServer, Msgs) ->
     Rows = [record_to_row(LUser, LServer, Msg) || Msg <- Msgs],
-    case push_offline_messages(LServer, Rows) of
+    case push_offline_messages(HostType, Rows) of
         {atomic, ok} ->
             ok;
         Other ->
             {error, Other}
     end.
 
-count_offline_messages(LUser, LServer, MaxArchivedMsgs) ->
-    Result = execute_count_offline_messages(LUser, LServer, MaxArchivedMsgs + 1),
+-spec count_offline_messages(mongooseim:host_type(), jid:luser(), jid:lserver(),
+                             mod_offline:msg_count()) ->
+          mod_offline:msg_count().
+count_offline_messages(HostType, LUser, LServer, Limit) ->
+    Result = execute_count_offline_messages(HostType, LUser, LServer, Limit),
     mongoose_rdbms:selected_to_integer(Result).
 
-remove_user(LUser, LServer) ->
-    execute_offline_delete(LServer, LUser).
-
--spec remove_expired_messages(jid:lserver()) ->
-    {error, term()} | {ok, HowManyRemoved :: non_neg_integer()}.
-remove_expired_messages(LServer) ->
+-spec remove_expired_messages(mongooseim:host_type(), jid:lserver()) -> {ok, mod_offline:msg_count()}.
+remove_expired_messages(HostType, LServer) ->
     TimeStamp = os:system_time(microsecond),
-    Result = execute_remove_expired_offline_messages(LServer, TimeStamp),
+    Result = execute_remove_expired_offline_messages(HostType, LServer, TimeStamp),
     updated_ok(Result).
 
--spec remove_old_messages(LServer, Timestamp) ->
-    {error, term()} | {ok, HowManyRemoved} when
-    LServer :: jid:lserver(),
-    Timestamp :: integer(),
-    HowManyRemoved :: integer().
-remove_old_messages(LServer, TimeStamp) ->
-    Result = execute_remove_old_offline_messages(LServer, TimeStamp),
+-spec remove_old_messages(mongooseim:host_type(), jid:lserver(), mod_offline:timestamp()) ->
+          {ok, mod_offline:msg_count()}.
+remove_old_messages(HostType, LServer, TimeStamp) ->
+    Result = execute_remove_old_offline_messages(HostType, LServer, TimeStamp),
     updated_ok(Result).
+
+-spec remove_user(mongooseim:host_type(), jid:luser(), jid:lserver()) -> ok.
+remove_user(HostType, LUser, LServer) ->
+    execute_offline_delete(HostType, LUser, LServer),
+    ok.
 
 %% Pure helper functions
 record_to_row(LUser, LServer,

--- a/src/offline/mod_offline_riak.erl
+++ b/src/offline/mod_offline_riak.erl
@@ -51,7 +51,7 @@
 init(_Host, _Opts) ->
     ok.
 
--spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]} | {error, any()}.
+-spec pop_messages(mongooseim:host_type(), jid:jid()) -> {ok, [mod_offline:msg()]}.
 pop_messages(HostType, To = #jid{luser = LUser, lserver = LServer}) ->
     Keys = read_user_idx(HostType, LUser, LServer),
     Msgs = [pop_msg(HostType, Key, LUser, LServer, To) || Key <- Keys],


### PR DESCRIPTION
**Main changes:**
- Support host types in `mod_offline` and its backends.
- Enable offline-related tests for dynamic domains.
- Change module templating to make the template and the resulting config readable at the same time. There are some whitespace manipulations, but they don't change the functionality. This can be still improved, I have ideas (e.g. mustache lists), but it would be a separate story. Right now the resulting config file always has a single empty line separating module sections. All module templates should be unified in the near future.

**Side changes:**
- Unify the implementation of `remove_*_messages` to only remove messages for the domain that was provided. The backends were behaving inconsistently before (it worked as expected only for Riak).

**Not included in this PR:**
- DB Query optimization with indexes. It does not seem to be required now, but message removal per domain could be sped up by using indexes.
- Support for dynamic domains in `mod_offline_chatmarkers`. This is an undocumented module which is disabled by default.
- Better error handling in backends. Sometimes DB errors can be missed and `ok` is returned. I didn't want to change too much and these issues don't seem to be critical. It's a bit out of scope as well.