### PR TITLE
Mam inbox unification

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -29,6 +29,8 @@
          returns_error_when_unknown_field_sent/1
         ]).
 -export([msg_sent_stored_in_inbox/1,
+         msg_with_no_store_is_not_stored_in_inbox/1,
+         carbons_are_not_stored/1,
          user_has_empty_inbox/1,
          user_has_two_unread_messages/1,
          other_resources_do_not_interfere/1,
@@ -130,6 +132,8 @@ groups() ->
           [
            user_has_empty_inbox,
            msg_sent_stored_in_inbox,
+           msg_with_no_store_is_not_stored_in_inbox,
+           carbons_are_not_stored,
            user_has_two_conversations,
            msg_sent_to_offline_user,
            msg_sent_to_not_existing_user,
@@ -425,6 +429,31 @@ msg_sent_stored_in_inbox(Config) ->
         %% Both check inbox
         check_inbox(Alice, AliceConvs),
         check_inbox(Bob, BobConvs)
+      end).
+
+msg_with_no_store_is_not_stored_in_inbox(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        %% Alice sends a message to Bob with a no-store hint
+        Body = <<"test">>,
+        Msg1 = escalus_stanza:chat_to(Bob, Body),
+        Msg2 = escalus_stanza:set_id(Msg1, escalus_stanza:id()),
+        Msg3 = mam_helper:add_nostore_hint(Msg2),
+        escalus:send(Alice, Msg3),
+        MsgSent = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_chat_message, MsgSent),
+        %% Bob has no unread messages in conversation with Alice
+        check_inbox(Bob, []),
+        %% Alice has no conv in her inbox either
+        check_inbox(Alice, [])
+      end).
+
+carbons_are_not_stored(Config) ->
+    escalus:fresh_story(Config, [{alice, 2}, {bob, 2}], fun(Alice1, Alice2, Bob1, Bob2) ->
+        mongoose_helper:enable_carbons([Alice1, Alice2, Bob1, Bob2]),
+        #{ Alice1 := AliceConvs, Bob1 := BobConvs } = given_conversations_between(Alice1, [Bob1]),
+        %% Both check inbox and carbons aren't there
+        check_inbox(Alice1, AliceConvs),
+        check_inbox(Bob1, BobConvs)
       end).
 
 user_has_two_conversations(Config) ->

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -193,7 +193,7 @@ process_inbox_message(Client, Message, #conv{unread = Unread, from = From, to = 
     [InnerMsg] = get_inner_msg(Message),
     JIDVerifyFun(InnerMsg, FromJid, <<"from">>),
     JIDVerifyFun(InnerMsg, ToJid, <<"to">>),
-    InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], []),
+    InnerContent = exml_query:path(InnerMsg, [{element, <<"body">>}, cdata], <<>>),
     Content = InnerContent,
     case Fun of
         F when is_function(F, 2) ->

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2439,7 +2439,7 @@ dont_archive_chat_markers(Config) ->
                 escalus_stanza:chat_marker(Alice, <<"received">>, MessageID),
             ResultEl = #xmlel{name = <<"result">>},
             DelayEl = #xmlel{name = <<"delay">>},
-            NoStoreEl = #xmlel{name = <<"no-store">>},
+            NoStoreEl = mam_helper:hint_elem(no_store),
 
             escalus:send(Bob, Marker#xmlel{children = [ResultEl|Children]}),
             escalus:send(Bob, Marker#xmlel{children = [DelayEl|Children]}),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -72,6 +72,7 @@
          assert_only_one_of_many_is_equal/2,
          add_store_hint/1,
          add_nostore_hint/1,
+         hint_elem/1,
          assert_not_stored/2,
          has_x_user_element/1,
          stanza_date_range_archive_request/1,

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -70,6 +70,7 @@
          parse_forwarded_message/1,
          login_send_presence/2,
          assert_only_one_of_many_is_equal/2,
+         add_store_hint/1,
          add_nostore_hint/1,
          assert_not_stored/2,
          has_x_user_element/1,
@@ -1216,10 +1217,15 @@ maybe_binary_to_integer(B) when is_binary(B) ->
 maybe_binary_to_integer(undefined) ->
     undefined.
 
-add_nostore_hint(#xmlel{children=Children}=Elem) ->
-    Elem#xmlel{children=Children ++ [nostore_hint_elem()]}.
+add_store_hint(#xmlel{children=Children}=Elem) ->
+    Elem#xmlel{children=Children ++ [hint_elem(store)]}.
 
-nostore_hint_elem() ->
+add_nostore_hint(#xmlel{children=Children}=Elem) ->
+    Elem#xmlel{children=Children ++ [hint_elem(no_store)]}.
+
+hint_elem(store) ->
+    #xmlel{name = <<"store">>, attrs = [{<<"xmlns">>, <<"urn:xmpp:hints">>}]};
+hint_elem(no_store) ->
     #xmlel{name = <<"no-store">>, attrs = [{<<"xmlns">>, <<"urn:xmpp:hints">>}]}.
 
 has_x_user_element(ArcMsg) ->

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -323,6 +323,7 @@ is_archivable_message(Mod, Dir, Packet=#xmlel{name = <<"message">>}, ArchiveChat
 is_archivable_message(_, _, _, _) ->
     false.
 
+is_valid_message_type(mod_inbox, _, <<"groupchat">>) -> true;
 is_valid_message_type(_, _, <<"normal">>) -> true;
 is_valid_message_type(_, _, <<"chat">>) -> true;
 is_valid_message_type(_, incoming, <<"groupchat">>) -> true;

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -99,7 +99,7 @@
                    rsm_ns_binary/0,
                    mam_ns_binary/0,
                    is_archived_elem_for/2,
-                   is_valid_message/3,
+                   is_valid_message/4,
                    is_valid_message_type/3,
                    is_valid_message_children/3,
                    encode_compact_uuid/2,
@@ -340,9 +340,11 @@ is_valid_message(_Mod, _Dir, Packet, ArchiveChatMarkers) ->
     %% Used in mod_offline
     Delay      = exml_query:subelement(Packet, <<"delay">>, false),
     %% Message Processing Hints (XEP-0334)
-    NoStore    = exml_query:subelement(Packet, <<"no-store">>, false),
+    NoStore    = exml_query:path(Packet, [{element_with_ns, <<"no-store">>, ?NS_HINTS}], false),
+    %% Message Processing Hints (XEP-0334)
+    Store      = exml_query:path(Packet, [{element_with_ns, <<"store">>, ?NS_HINTS}], false),
 
-    has_any([Body, ChatMarker, Retract]) andalso not has_any([Result, Delay, NoStore]).
+    has_any([Store, Body, ChatMarker, Retract]) andalso not has_any([Result, Delay, NoStore]).
 
 has_any(Elements) ->
     lists:any(fun(El) -> El =/= false end, Elements).


### PR DESCRIPTION
If inbox is nothing more than a low-cost summary of mam, we can expect inbox to store pretty much what is stored in mam, and nothing else.

This is currently not true, as inbox is not taking into account `no-store` hints for example, and it is storing body-less messages, like for example it would store carbon copies.

Additionally, make both take the `<store>` hint as enforcing storage.