### PR TITLE
Tag should be an atom, it's binary in ldap types

### DIFF
--- a/src/auth/mongoose_gen_auth.erl
+++ b/src/auth/mongoose_gen_auth.erl
@@ -69,7 +69,7 @@
                        User :: jid:luser(),
                        Server :: jid:lserver(),
                        Password :: binary()) ->
-    ok | {error, not_allowed | invalid_jid}.
+    ok | {error, not_allowed | invalid_jid | user_not_found}.
 
 -callback remove_user(HostType :: mongooseim:host_type(),
                       User :: jid:luser(),

--- a/src/eldap_pool.erl
+++ b/src/eldap_pool.erl
@@ -78,6 +78,7 @@ delete(PoolName, DN) ->
     R -> R
   end.
 
+%% Applies eldap:add/3
 add(PoolName, DN, Attrs) ->
   do_request(PoolName, {add, [maybe_b2list(DN), parse_add_atrs(Attrs)]}).
 
@@ -92,5 +93,7 @@ parse_add_attr({N, List}) ->
 %% Internal functions
 %%====================================================================
 
-do_request({Host, PoolTag}, Request) ->
+%% Calls mongoose_ldap_worker
+%% Which calls eldap:F
+do_request({Host, PoolTag}, {_F, _Args} = Request) ->
     mongoose_wpool:call(ldap, Host, PoolTag, Request).

--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -52,6 +52,16 @@
 -include("mongoose.hrl").
 -include("eldap.hrl").
 
+-type dn() :: binary().
+-type deref() :: neverDerefAliases | derefInSearching
+                 | derefFindingBaseObj | derefAlways.
+%% Used to access mongoose_wpool
+-type eldap_id() :: {HostType :: mongooseim:host_type(), Tag :: mongoose_wpool:tag()}.
+
+-export_type([dn/0,
+              deref/0,
+              eldap_id/0]).
+
 %% @doc Generate an 'or' LDAP query on one or several attributes
 %% If there is only one attribute
 -spec generate_subfilter([{binary()} | {binary(), binary()}]) -> binary().

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -61,24 +61,21 @@
 -define(LDAP_SEARCH_TIMEOUT, 5).
 
 -record(state,
-        {host = <<"">>                                :: binary(),
-         eldap_id                                     :: {jid:lserver(), binary()},
-         base = <<"">>                                :: binary(),
-         uid = <<"">>                                 :: binary(),
-         deref =                                         neverDerefAliases  :: neverDerefAliases |
-                                                         derefInSearching |
-                                                         derefFindingBaseObj |
-                                                         derefAlways,
-         group_attr = <<"">>                          :: binary(),
-         group_desc = <<"">>                          :: binary(),
-         user_desc = <<"">>                           :: binary(),
-         user_uid = <<"">>                            :: binary(),
-         uid_format = <<"">>                          :: binary(),
-         uid_format_re = <<"">>                       :: binary(),
-         filter = <<"">>                              :: binary(),
-         ufilter = <<"">>                             :: binary(),
-         rfilter = <<"">>                             :: binary(),
-         gfilter = <<"">>                             :: binary(),
+        {host = <<>>                                  :: binary(),
+         eldap_id                                     :: eldap_utils:eldap_id(),
+         base = <<>>                                  :: binary(),
+         uid = <<>>                                   :: binary(),
+         deref = neverDerefAliases                    :: eldap_utils:deref(),
+         group_attr = <<>>                            :: binary(),
+         group_desc = <<>>                            :: binary(),
+         user_desc = <<>>                             :: binary(),
+         user_uid = <<>>                              :: binary(),
+         uid_format = <<>>                            :: binary(),
+         uid_format_re = <<>>                         :: binary(),
+         filter = <<>>                                :: binary(),
+         ufilter = <<>>                               :: binary(),
+         rfilter = <<>>                               :: binary(),
+         gfilter = <<>>                               :: binary(),
          auth_check = true                            :: boolean(),
          user_cache_size = ?CACHE_SIZE                :: non_neg_integer(),
          group_cache_size = ?CACHE_SIZE               :: non_neg_integer(),
@@ -189,7 +186,7 @@ get_subscription_lists(Acc, #jid{lserver = LServer} = JID) ->
                                                 get_group_users(LServer, Group)
                                         end,
                                         DisplayedGroups)),
-    SRJIDs = [{U1, S1, <<"">>} || {U1, S1} <- SRUsers],
+    SRJIDs = [{U1, S1, <<>>} || {U1, S1} <- SRUsers],
     NewLists = {lists:usort(SRJIDs ++ F), lists:usort(SRJIDs ++ T), P},
     mongoose_acc:set(roster, subscription_lists, NewLists, Acc).
 
@@ -351,13 +348,8 @@ get_user_to_groups_map({_, Server} = US, SkipUS) ->
 eldap_search(State, FilterParseArgs, AttributesList) ->
     case apply(eldap_filter, parse, FilterParseArgs) of
         {ok, EldapFilter} ->
-            case eldap_pool:search(State#state.eldap_id,
-                                   [{base, State#state.base},
-                                    {filter, EldapFilter},
-                                    {timeout, ?LDAP_SEARCH_TIMEOUT},
-                                    {deref, State#state.deref},
-                                    {attributes, AttributesList}])
-            of
+            SearchOpts = search_opts(EldapFilter, AttributesList, State),
+            case eldap_pool:search(State#state.eldap_id, SearchOpts) of
                 #eldap_search_result{entries = Es} ->
                     %% A result with entries. Return their list.
                     Es;
@@ -369,6 +361,13 @@ eldap_search(State, FilterParseArgs, AttributesList) ->
             %% Filter parsing failed. Pretend we got no results.
             []
     end.
+
+search_opts(EldapFilter, AttributesList, State) ->
+    [{base, State#state.base},
+     {filter, EldapFilter},
+     {timeout, ?LDAP_SEARCH_TIMEOUT},
+     {deref, State#state.deref},
+     {attributes, AttributesList}].
 
 get_user_displayed_groups({User, Host}) ->
     {ok, State} = eldap_utils:get_state(Host, ?MODULE),

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -59,7 +59,7 @@
 -record(state,
         {serverhost = <<>>          :: binary(),
          myhost = <<>>              :: binary(),
-         eldap_id                   :: mongoose_utils:eldap_id(),
+         eldap_id                   :: eldap_utils:eldap_id(),
          base = <<>>                :: binary(),
          password = <<>>            :: binary(),
          uids = []                  :: [{binary()} | {binary(), binary()}],
@@ -72,7 +72,7 @@
          search_reported_attrs = [] :: [binary()],
          search_operator            :: 'or' | 'and',
          binary_search_fields       :: [binary()],
-         deref = neverDerefAliases  :: mongoose_utils:deref(),
+         deref = neverDerefAliases  :: eldap_utils:deref(),
          matches = 0                :: non_neg_integer() | infinity}).
 
 -define(VCARD_MAP,

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -57,23 +57,22 @@
 -define(PROCNAME, ejabberd_mod_vcard_ldap).
 
 -record(state,
-        {serverhost = <<"">>        :: binary(),
-         myhost = <<"">>            :: binary(),
-         eldap_id                   :: {jid:lserver(), binary()},
-         base = <<"">>              :: binary(),
-         password = <<"">>          :: binary(),
+        {serverhost = <<>>          :: binary(),
+         myhost = <<>>              :: binary(),
+         eldap_id                   :: mongoose_utils:eldap_id(),
+         base = <<>>                :: binary(),
+         password = <<>>            :: binary(),
          uids = []                  :: [{binary()} | {binary(), binary()}],
          vcard_map = []             :: [{binary(), binary(), [binary()]}],
          vcard_map_attrs = []       :: [binary()],
-         user_filter = <<"">>       :: binary(),
+         user_filter = <<>>         :: binary(),
          search_filter              :: eldap:filter(),
          search_fields = []         :: [{binary(), binary()}],
          search_reported = []       :: [{binary(), binary()}],
          search_reported_attrs = [] :: [binary()],
          search_operator            :: 'or' | 'and',
          binary_search_fields       :: [binary()],
-         deref = neverDerefAliases  :: neverDerefAliases | derefInSearching
-                                     | derefFindingBaseObj | derefAlways,
+         deref = neverDerefAliases  :: mongoose_utils:deref(),
          matches = 0                :: non_neg_integer() | infinity}).
 
 -define(VCARD_MAP,
@@ -244,15 +243,15 @@ find_ldap_user(User, State) ->
     end.
 
 eldap_pool_search(EldapID, Base, EldapFilter, Deref, Attrs, NoResultRes) ->
-  case eldap_pool:search(EldapID,
+    SearchOpts = search_opts(Base, EldapFilter, Deref, Attrs),
+    case eldap_pool:search(EldapID, SearchOpts) of
+        #eldap_search_result{entries = E} -> E;
+        _ -> NoResultRes
+    end.
+
+search_opts(Base, EldapFilter, Deref, Attrs) ->
     [{base, Base}, {filter, EldapFilter},
-      {deref, Deref},
-      {attributes, Attrs}])
-  of
-    #eldap_search_result{entries = E} -> E;
-    _ ->
-      NoResultRes
-  end.
+     {deref, Deref}, {attributes, Attrs}].
 
 ldap_attributes_to_vcard(Attributes, VCardMap, UD) ->
     Attrs = lists:map(fun ({VCardName, _, _}) ->


### PR DESCRIPTION
Also, made some ldap types in eldap_utils


```erlang
===> Analyzing 405 files with "/Users/mikhailuvarov/erlang/esl/MongooseIM/_build/default/rebar3_22.3.4.10_plt"...                                                                                  [14/2732]

src/auth/ejabberd_auth_ldap.erl
 150: Invalid type specification for function ejabberd_auth_ldap:set_password/4. The success typing is (binary(),binary(),binary(),_) -> {'error','user_not_found'}
 155: The inferred return type of set_password/4 ({'error','user_not_found'}) has nothing in common with 'ok' | {'error','invalid_jid' | 'not_allowed'}, which is the expected return type for the callback
of mongoose_gen_auth behaviour
 159: The variable DN can never match since previous clauses completely covered the type 'false'
 168: Function try_register/4 has no local return
 177: The call eldap_pool:add({binary(),binary()}, DN::[byte(),...], Attrs::[{[1..255,...],[[byte()],...]},...]) will never return since it differs in the 1st argument from the success typing arguments: (
{'global' | binary(),atom()}, any(), [{_,[any()]}])
 216: The variable DN can never match since previous clauses completely covered the type 'false'
 251: The variable DN can never match since previous clauses completely covered the type 'false'
 267: The call eldap_pool:search(EldapID::{binary(),binary()}, [{'attributes',maybe_improper_list()} | {'base',binary()} | {'deref','derefAlways' | 'derefFindingBaseObj' | 'derefInSearching' | 'neverDeref
Aliases'} | {'filter',_} | {'timeout',5},...]) will never return since it differs in the 1st argument from the success typing arguments: ({'global' | binary(),atom()}, [{_,_}])
 315: The variable _DN can never match since previous clauses completely covered the type 'false'
 335: The call eldap_pool:search({binary(),binary()}, [{'attributes',maybe_improper_list()} | {'base',binary()} | {'deref','derefAlways' | 'derefFindingBaseObj' | 'derefInSearching' | 'neverDerefAliases'}
 | {'filter',_},...]) will never return since it differs in the 1st argument from the success typing arguments: ({'global' | binary(),atom()}, [{_,_}])
 390: The call eldap_pool:search({binary(),binary()}, [{'attributes',[<<_:16>>,...]} | {'base',binary()} | {'deref','derefAlways' | 'derefFindingBaseObj' | 'derefInSearching' | 'neverDerefAliases'} | {'fi
lter',_},...]) will never return since it differs in the 1st argument from the success typing arguments: ({'global' | binary(),atom()}, [{_,_}])

src/mod_shared_roster_ldap.erl
 192: The pattern [{U1, S1} | _] can never match the type []
 218: The pattern 'stop' can never match the type 'false'
 220: The pattern {'stop', 'false'} can never match the type 'false'
 232: The pattern 'stop' can never match the type 'false'
 234: The pattern {'stop', 'false'} can never match the type 'false'
 250: The pattern 'true' can never match the type 'false'
 354: The call eldap_pool:search({binary(),binary()}, [{'attributes',[binary(),...]} | {'base',binary()} | {'deref','derefAlways' | 'derefFindingBaseObj' | 'derefInSearching' | 'neverDerefAliases'} | {'fi
lter',_} | {'timeout',5},...]) will never return since it differs in the 1st argument from the success typing arguments: ({'global' | binary(),atom()}, [{_,_}])
 449: The variable LDAPEntries can never match since previous clauses completely covered the type []
 455: Function ldap_entries_to_group/6 will never be called
 458: Function ldap_entries_to_group/7 will never be called
 479: Function check_and_accumulate_member/4 will never be called
 502: The pattern [{'eldap_entry', _, Attrs} | _] can never match the type []

 src/mod_vcard_ldap.erl
 156: Matching of pattern {'eldap_entry', _, Attributes} tagged with a record name violates the declared type of 'false'
 246: Function eldap_pool_search/6 has no local return
 247: The call eldap_pool:search(EldapID::{binary(),binary()}, [{'attributes',[binary()]} | {'base',binary()} | {'deref','derefAlways' | 'derefFindingBaseObj' | 'derefInSearching' | 'neverDerefAliases'} | {'filter',_},...]) will never return since it differs in the 1st argument from the success typing arguments: ({'global' | binary(),atom()}, [{_,_}])
 257: Function ldap_attributes_to_vcard/3 will never be called
 284: Function ldap_attribute_to_vcard/2 will never be called
 387: Function limited_results/2 will never be called
 394: Function search_items/2 will never be called
 398: Function attrs_to_item_xml/2 will never be called
 409: Function make_user_item_if_exists/3 will never be called
 429: Function search_item_value/3 will never be called
 435: Function map_vcard_attr/4 will never be called
 449: Function process_pattern/3 will never be called
 ```
