### PR TITLE
Put accumulator instead of atom ok for xmpp_stanza_dropped

### DIFF
--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -500,14 +500,15 @@ xmpp_send_element(HostType, Acc, El) ->
 
 %%% @doc The `xmpp_stanza_dropped' hook is called to inform that
 %%% an xmpp stanza has been dropped.
--spec xmpp_stanza_dropped(HostType, From, To, Packet) -> Result when
-    HostType :: binary(),
+-spec xmpp_stanza_dropped(Acc, From, To, Packet) -> Result when
+    Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: any().
-xmpp_stanza_dropped(HostType, From, To, Packet) ->
-    ejabberd_hooks:run_for_host_type(xmpp_stanza_dropped, HostType, ok,
+xmpp_stanza_dropped(Acc, From, To, Packet) ->
+    HostType = mongoose_acc:host_type(Acc),
+    ejabberd_hooks:run_for_host_type(xmpp_stanza_dropped, HostType, Acc,
                                      [From, To, Packet]).
 
 %% C2S related hooks

--- a/src/mongoose_local_delivery.erl
+++ b/src/mongoose_local_delivery.erl
@@ -39,7 +39,7 @@ do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, Handler) ->
                                                         element => Packet}, Acc),
                     mongoose_packet_handler:process(Handler, Acc1, From, To, Packet);
                 drop ->
-                    mongoose_hooks:xmpp_stanza_dropped(mongoose_acc:host_type(Acc0), OrigFrom,
+                    mongoose_hooks:xmpp_stanza_dropped(Acc0, OrigFrom,
                                                        OrigTo, OrigPacket),
                     ok
             end


### PR DESCRIPTION
Fix error:
```erlang
when=2021-07-13T11:29:28.721597+00:00 level=error what=hook_failed reason="{function_clause,[{mongoose_acc,host_type, 
 
[ok],[{file,/src/mongoose_acc.erl"},{line,161}]},{mongoose_metrics_hooks,xmpp_stanza_dropped,4,[{file,"/src/metrics  

/mongoose_metrics_hooks.erl"},{line,131}]},{safely,apply,3,[{file,"/src/safely.erl"},{line,19}]},  

{ejabberd_hooks,run_hook,4,
```

