### PR TITLE
Support dynamic domains in mod_last

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -21,6 +21,8 @@
 
 {suites, "tests", inbox_extensions_SUITE}.
 
+{suites, "tests", last_SUITE}.
+
 {suites, "tests", mam_SUITE}.
 
 {suites, "tests", mod_ping_SUITE}.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -250,8 +250,7 @@
   connection.tls.verify_peer = true
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.server_name_indication = false"},
-      {mod_last, "[modules.mod_last]
-  backend = \"rdbms\""},
+      {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
@@ -272,8 +271,7 @@
   workers = 5
   connection.driver = \"odbc\"
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
-      {mod_last, "[modules.mod_last]
-  backend = \"rdbms\""},
+      {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
@@ -304,8 +302,7 @@
   connection.tls.verify_peer = true
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.versions = [\"tlsv1.2\"]"},
-      {mod_last, "[modules.mod_last]
-  backend = \"rdbms\""},
+      {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
@@ -372,8 +369,7 @@
   connection.tls.ciphers = \"AES256-SHA:DHE-RSA-AES128-SHA256\"
   connection.tls.server_name_indication = false
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
-      {mod_last, "[modules.mod_last]
-  backend = \"riak\""},
+      {mod_last, "  backend = \"riak\""},
       {mod_privacy, "  backend = \"riak\""},
       {mod_private, "[modules.mod_private]
   backend = \"riak\""},

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -1289,8 +1289,9 @@ get_sha(AccountPass) ->
                    || X <- binary_to_list(crypto:hash(sha, AccountPass))]).
 
 set_last(User, Domain, TStamp) ->
+    HostType = domain_helper:host_type(),
     rpc(mim(), mod_last, store_last_info,
-        [escalus_utils:jid_to_lower(User), Domain, TStamp, <<>>]).
+        [HostType, escalus_utils:jid_to_lower(User), Domain, TStamp, <<>>]).
 
 delete_users(Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -127,14 +127,12 @@ do_clear_last_activity(_Config, User) when is_binary(User) ->
 do_clear_last_activity(Config, Users) when is_list(Users) ->
     lists:foreach(fun(User) -> do_clear_last_activity(Config, User) end, Users).
 
-new_mongoose_acc(Location, Server) ->
-    successful_rpc(mongoose_acc, new, [#{ location => Location,
-                                          lserver => Server,
-                                          element => undefined }]).
-
 new_mongoose_acc(Server) ->
+    new_mongoose_acc(?LOCATION, Server).
+
+new_mongoose_acc(Location, Server) ->
     {ok, HostType} = rpc(mim(), mongoose_domain_core, get_host_type, [Server]),
-    successful_rpc(mongoose_acc, new, [#{ location => ?LOCATION,
+    successful_rpc(mongoose_acc, new, [#{ location => Location,
                                           lserver => Server,
                                           host_type => HostType,
                                           element => undefined }]).

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -314,10 +314,12 @@ arguments_from_two_tables(Config) ->
                 <<"SELECT users.username from users "
                   " LEFT JOIN last ON (last.username = users.username) "
                   " WHERE users.password = ? AND last.seconds > ?">>),
-    sql_query(Config, "INSERT INTO users (username, server, password) VALUES ('alice', 'domain', 'secret')"),
-    sql_query(Config, "INSERT INTO users (username, server, password) VALUES ('bob', 'domain', 'billy')"),
-    sql_query(Config, "INSERT INTO last (username, seconds, state) VALUES ('alice', 1615368268, 'ok')"),
-    sql_query(Config, "INSERT INTO last (username, seconds, state) VALUES ('bob', 1610000000, 'cool')"),
+    UserInsert = "INSERT INTO users (username, server, password) VALUES ",
+    sql_query(Config, UserInsert ++ "('alice', 'domain', 'secret')"),
+    sql_query(Config, UserInsert ++ "('bob', 'domain', 'billy')"),
+    LastInsert = "INSERT INTO last (username, server, seconds, state) VALUES ",
+    sql_query(Config, LastInsert ++ "('alice', 'domain', 1615368268, 'ok')"),
+    sql_query(Config, LastInsert ++ "('bob', 'domain', 1610000000, 'cool')"),
     SelectResult = sql_execute(Config, select_multi_args, [<<"secret">>, 1611000000]),
     ?assert_equal({selected, [{<<"alice">>}]}, SelectResult),
     erase_users(Config),

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -23,14 +23,20 @@ GO
 SET ANSI_PADDING ON
 GO
 CREATE TABLE [dbo].[last](
+	[server] [nvarchar](250) NOT NULL,
 	[username] [nvarchar](250) NOT NULL,
 	[seconds] [int] NOT NULL,
 	[state] [nvarchar](max) NOT NULL,
  CONSTRAINT [PK_last_username] PRIMARY KEY CLUSTERED
 (
+	[server] ASC,
 	[username] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+
+CREATE INDEX i_last_server_seconds ON last (server, seconds);
+GO
 
 GO
 SET ANSI_PADDING OFF

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -46,17 +46,16 @@ CREATE TABLE users (
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 
-
 CREATE TABLE last (
-    username varchar(250) PRIMARY KEY,
+    server varchar(250),
+    username varchar(250),
     seconds int NOT NULL,
-
-    state text NOT NULl
+    state text NOT NULL,
+    PRIMARY KEY (server, username)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 
-CREATE INDEX i_last_seconds ON last(seconds);
-
+CREATE INDEX i_last_server_seconds ON last (server, seconds);
 
 CREATE TABLE rosterusers (
     server varchar(250) NOT NULL,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -43,12 +43,14 @@ CREATE TABLE users (
 
 
 CREATE TABLE last (
-    username varchar(250) PRIMARY KEY,
+    server varchar(250),
+    username varchar(250),
     seconds integer NOT NULL,
-    state text NOT NULL
+    state text NOT NULL,
+    PRIMARY KEY (server, username)
 );
 
-CREATE INDEX i_last_seconds ON last USING btree (seconds);
+CREATE INDEX i_last_server_seconds ON last USING btree (server, seconds);
 
 
 CREATE TABLE rosterusers (

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -230,8 +230,8 @@
 [modules.mod_muc_light_commands]
 
 {{#mod_last}}
+[modules.mod_last]
 {{{mod_last}}}
-
 {{/mod_last}}
 [modules.mod_stream_management]
 

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -32,6 +32,10 @@
 
   [host_config.modules.mod_disco]
 
+  {{#mod_last}}
+  [host_config.modules.mod_last]
+  {{{mod_last}}}
+  {{/mod_last}}
   {{#mod_offline}}
   [host_config.modules.mod_offline]
   {{{mod_offline}}}

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -19,13 +19,15 @@
   shaper_rule = \"fast\"
   ip_address = \"127.0.0.1\"
   password = \"secret\""}.
-{mod_cache_users, ""}. % enabled, no options
-{mod_last, "[modules.mod_last]"}.
-{mod_offline, ""}. % enabled, no options
+
+%% "" means that the module is enabled without any options
+{mod_cache_users, ""}.
+{mod_last, ""}.
+{mod_offline, ""}.
 {mod_privacy, ""}.
 {mod_blocking, "[modules.mod_blocking]"}.
 {mod_private, "[modules.mod_private]"}.
-{mod_roster, ""}. % enabled, no options
+{mod_roster, ""}.
 {mod_vcard, "[modules.mod_vcard]
   host = \"vjud.@HOST@\""}.
 {sm_backend, "\"mnesia\""}.

--- a/src/admin_extra/service_admin_extra_last.erl
+++ b/src/admin_extra/service_admin_extra_last.erl
@@ -66,11 +66,11 @@ set_last(User, Server, Timestamp, Status) ->
     JID = jid:make(User, Server, <<>>),
     case ejabberd_auth:does_user_exist(JID) of
         true ->
-            mod_last:store_last_info(JID#jid.luser, JID#jid.lserver, Timestamp, Status),
+            {ok, HostType} = mongoose_domain_api:get_host_type(JID#jid.lserver),
+            mod_last:store_last_info(HostType, JID#jid.luser, JID#jid.lserver, Timestamp, Status),
             {ok, io_lib:format("Last activity for user ~s is set as ~B with status ~s",
                                [jid:to_binary(JID), Timestamp, Status])};
         false ->
             String = io_lib:format("User ~s@~s does not exist", [User, Server]),
             {user_does_not_exist, String}
     end.
-

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -351,7 +351,7 @@ is_fresh_enough(TimeStampLast, CacheTime) ->
 -spec get_last_access(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
           online | never | mod_last_required | integer().
 get_last_access(HostType, LUser, LServer) ->
-    JID = jid:make(LUser, LServer, <<>>),
+    JID = jid:make_noprep(LUser, LServer, <<>>),
     case ejabberd_sm:get_user_resources(JID) of
         [] ->
             case get_last_info(HostType, LUser, LServer) of
@@ -365,7 +365,6 @@ get_last_access(HostType, LUser, LServer) ->
         _ ->
             online
     end.
-
 
 -spec get_last_info(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
           {ok, mod_last:timestamp(), mod_last:status()} | not_found | mod_last_required.

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -368,7 +368,7 @@ get_last_access(HostType, LUser, LServer) ->
 
 
 -spec get_last_info(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
-          {ok, Timestamp :: integer(), Status :: binary()} | not_found | mod_last_required.
+          {ok, mod_last:timestamp(), mod_last:status()} | not_found | mod_last_required.
 get_last_info(HostType, LUser, LServer) ->
     case gen_mod:is_loaded(HostType, mod_last) of
         true -> mod_last:get_last_info(HostType, LUser, LServer);

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -234,7 +234,7 @@ check_password_extauth(HostType, LUser, LServer, Password) ->
                            Password :: binary(),
                            CacheTime :: integer()) -> boolean().
 check_password_cache(HostType, LUser, LServer, Password, CacheTime) ->
-    case get_last_access(LUser, LServer) of
+    case get_last_access(HostType, LUser, LServer) of
         online ->
             check_password_internal(HostType, LUser, LServer, Password);
         never ->
@@ -272,7 +272,7 @@ get_password_internal(HostType, LUser, LServer) ->
                          LServer :: jid:lserver(),
                          CacheTime :: integer()) -> false | binary().
 get_password_cache(HostType, LUser, LServer, CacheTime) ->
-    case get_last_access(LUser, LServer) of
+    case get_last_access(HostType, LUser, LServer) of
         online ->
             get_password_internal(HostType, LUser, LServer);
         never ->
@@ -348,14 +348,13 @@ is_fresh_enough(TimeStampLast, CacheTime) ->
 
 %% @doc Code copied from mod_configure.erl
 %% Code copied from web/ejabberd_web_admin.erl
--spec get_last_access(User :: jid:user(),
-                      Server :: jid:server()
-                      ) -> online | never | mod_last_required | integer().
-get_last_access(User, Server) ->
-    JID = jid:make(User, Server, <<>>),
+-spec get_last_access(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
+          online | never | mod_last_required | integer().
+get_last_access(HostType, LUser, LServer) ->
+    JID = jid:make(LUser, LServer, <<>>),
     case ejabberd_sm:get_user_resources(JID) of
         [] ->
-            case get_last_info(User, Server) of
+            case get_last_info(HostType, LUser, LServer) of
                 mod_last_required ->
                     mod_last_required;
                 not_found ->
@@ -368,13 +367,11 @@ get_last_access(User, Server) ->
     end.
 
 
--spec get_last_info(User :: jid:user(),
-                    Server :: jid:server()
-                    ) -> {ok, Timestamp :: integer(), Status :: binary()}
-                         | not_found | mod_last_required.
-get_last_info(User, Server) ->
-    case gen_mod:is_loaded(Server, mod_last) of
-        true -> mod_last:get_last_info(User, Server);
+-spec get_last_info(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
+          {ok, Timestamp :: integer(), Status :: binary()} | not_found | mod_last_required.
+get_last_info(HostType, LUser, LServer) ->
+    case gen_mod:is_loaded(HostType, mod_last) of
+        true -> mod_last:get_last_info(HostType, LUser, LServer);
         _ -> mod_last_required
     end.
 

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -70,31 +70,25 @@
 %% ------------------------------------------------------------------
 %% Backend callbacks
 
--callback init(Host, Opts) -> ok when
-    Host    :: jid:server(),
-    Opts    :: list().
+-type host_type() :: mongooseim:host_type().
+-type timestamp() :: non_neg_integer().
+-type status() :: binary().
 
--callback get_last(LUser, LServer) -> Result when
-    LUser   :: jid:luser(),
-    LServer :: jid:lserver(),
-    Reason  :: term(),
-    Result  :: {ok, non_neg_integer(), binary()} | {error, Reason} | not_found.
+-export_type([host_type/0, timestamp/0, status/0]).
 
--callback count_active_users(LServer, Timestamp) -> Result when
-    LServer :: jid:lserver(),
-    Timestamp :: non_neg_integer(),
-    Result :: non_neg_integer().
+-callback init(host_type(), gen_mod:module_opts()) -> ok.
 
--callback set_last_info(LUser, LServer, Timestamp, Status) -> Result when
-    LUser   :: jid:luser(),
-    LServer :: jid:lserver(),
-    Timestamp :: non_neg_integer(),
-    Status  :: binary(),
-    Result  :: ok | {error, term()}.
+-callback get_last(host_type(), jid:luser(), jid:lserver()) ->
+    {ok, timestamp(), status()} | {error, term()} | not_found.
 
--callback remove_user(LUser, LServer) -> ok | {error, term()} when
-    LUser   :: jid:luser(),
-    LServer :: jid:lserver().
+-callback count_active_users(host_type(), jid:lserver(), timestamp()) ->
+    non_neg_integer().
+
+-callback set_last_info(host_type(), jid:luser(), jid:lserver(), timestamp(), status()) ->
+    ok | {error, term()}.
+
+-callback remove_user(host_type(), jid:luser(), jid:lserver()) ->
+    ok | {error, term()}.
 
 -spec start(mongooseim:host_type(), list()) -> 'ok'.
 start(HostType, Opts) ->

--- a/src/mod_last_mnesia.erl
+++ b/src/mod_last_mnesia.erl
@@ -35,7 +35,7 @@ init(_HostType, _Opts) ->
     ok.
 
 -spec get_last(host_type(), jid:luser(), jid:lserver()) ->
-    {ok, non_neg_integer(), binary()} | {error, term()} | not_found.
+    {ok, mod_last:timestamp(), mod_last:status()} | {error, term()} | not_found.
 get_last(_HostType, LUser, LServer) ->
     case catch mnesia:dirty_read(last_activity, {LUser, LServer}) of
         {'EXIT', Reason} -> {error, Reason};
@@ -45,7 +45,7 @@ get_last(_HostType, LUser, LServer) ->
             {ok, TimeStamp, Status}
     end.
 
--spec count_active_users(host_type(), jid:lserver(), non_neg_integer()) -> non_neg_integer().
+-spec count_active_users(host_type(), jid:lserver(), mod_last:timestamp()) -> non_neg_integer().
 count_active_users(_HostType, LServer, TimeStamp) ->
     MS = [{{last_activity, {'_', LServer}, '$1', '_'},
         [{'>', '$1', TimeStamp}],
@@ -53,7 +53,7 @@ count_active_users(_HostType, LServer, TimeStamp) ->
     ets:select_count(last_activity, MS).
 
 -spec set_last_info(host_type(), jid:luser(), jid:lserver(),
-                    non_neg_integer(), binary()) -> ok | {error, term()}.
+                    mod_last:timestamp(), mod_last:status()) -> ok | {error, term()}.
 set_last_info(_HostType, LUser, LServer, TimeStamp, Status) ->
     US = {LUser, LServer},
     F = fun() ->

--- a/src/mod_last_mnesia.erl
+++ b/src/mod_last_mnesia.erl
@@ -19,22 +19,24 @@
 
 %% API
 -export([init/2,
-         get_last/2,
-         count_active_users/2,
-         set_last_info/4,
-         remove_user/2]).
+         get_last/3,
+         count_active_users/3,
+         set_last_info/5,
+         remove_user/3]).
 
--spec init(jid:server(), list()) -> ok.
-init(_Host, _Opts) ->
+-type host_type() :: mongooseim:host_type().
+
+-spec init(host_type(), gen_mod:module_opts()) -> ok.
+init(_HostType, _Opts) ->
     mnesia:create_table(last_activity,
                         [{disc_copies, [node()]},
                          {attributes,
                           record_info(fields, last_activity)}]),
     ok.
 
--spec get_last(jid:luser(), jid:lserver()) ->
+-spec get_last(host_type(), jid:luser(), jid:lserver()) ->
     {ok, non_neg_integer(), binary()} | {error, term()} | not_found.
-get_last(LUser, LServer) ->
+get_last(_HostType, LUser, LServer) ->
     case catch mnesia:dirty_read(last_activity, {LUser, LServer}) of
         {'EXIT', Reason} -> {error, Reason};
         [] -> not_found;
@@ -43,16 +45,16 @@ get_last(LUser, LServer) ->
             {ok, TimeStamp, Status}
     end.
 
--spec count_active_users(jid:lserver(), non_neg_integer()) -> non_neg_integer().
-count_active_users(LServer, TimeStamp) ->
+-spec count_active_users(host_type(), jid:lserver(), non_neg_integer()) -> non_neg_integer().
+count_active_users(_HostType, LServer, TimeStamp) ->
     MS = [{{last_activity, {'_', LServer}, '$1', '_'},
         [{'>', '$1', TimeStamp}],
         [true]}],
     ets:select_count(last_activity, MS).
 
--spec set_last_info(jid:luser(), jid:lserver(),
+-spec set_last_info(host_type(), jid:luser(), jid:lserver(),
                     non_neg_integer(), binary()) -> ok | {error, term()}.
-set_last_info(LUser, LServer, TimeStamp, Status) ->
+set_last_info(_HostType, LUser, LServer, TimeStamp, Status) ->
     US = {LUser, LServer},
     F = fun() ->
         mnesia:write(#last_activity{us = US,
@@ -61,8 +63,8 @@ set_last_info(LUser, LServer, TimeStamp, Status) ->
     end,
     wrap_transaction_result(mnesia:transaction(F)).
 
--spec remove_user(jid:luser(), jid:lserver()) -> ok.
-remove_user(LUser, LServer) ->
+-spec remove_user(host_type(), jid:luser(), jid:lserver()) -> ok.
+remove_user(_HostType, LUser, LServer) ->
     US = {LUser, LServer},
     F = fun() -> mnesia:delete({last_activity, US}) end,
     wrap_transaction_result(mnesia:transaction(F)).

--- a/src/mod_last_rdbms.erl
+++ b/src/mod_last_rdbms.erl
@@ -14,69 +14,79 @@
 
 -behaviour(mod_last).
 
--include("mod_last.hrl").
 -include("mongoose.hrl").
 
 %% API
 -export([init/2,
-         get_last/2,
-         count_active_users/2,
-         set_last_info/4,
-         remove_user/2]).
+         get_last/3,
+         count_active_users/3,
+         set_last_info/5,
+         remove_user/3]).
 
--spec init(jid:server(), list()) -> ok.
-init(Host, _Opts) ->
-    prepare_queries(Host),
+-type host_type() :: mongooseim:host_type().
+
+-spec init(host_type(), gen_mod:module_opts()) -> ok.
+init(HostType, _Opts) ->
+    prepare_queries(HostType),
     ok.
 
 %% Prepared query functions
-prepare_queries(Host) ->
-    mongoose_rdbms:prepare(last_select, last, [username],
-                           <<"SELECT seconds, state FROM last WHERE username=?">>),
-    mongoose_rdbms:prepare(last_count_active, last, [seconds],
-                           <<"SELECT COUNT(*) FROM last WHERE seconds > ?">>),
-    mongoose_rdbms:prepare(last_delete, last, [username],
-                           <<"delete from last where username=?">>),
-    rdbms_queries:prepare_upsert(Host, last_upsert, last,
-                                 [<<"username">>, <<"seconds">>, <<"state">>],
+prepare_queries(HostType) ->
+    mongoose_rdbms:prepare(last_select, last, [server, username],
+                           <<"SELECT seconds, state FROM last WHERE server = ? AND username = ?">>),
+    mongoose_rdbms:prepare(last_count_active, last, [server, seconds],
+                           <<"SELECT COUNT(*) FROM last WHERE server = ? AND seconds > ?">>),
+    mongoose_rdbms:prepare(last_delete, last, [server, username],
+                           <<"DELETE FROM last WHERE server = ? AND username = ?">>),
+    rdbms_queries:prepare_upsert(HostType, last_upsert, last,
+                                 [<<"server">>, <<"username">>, <<"seconds">>, <<"state">>],
                                  [<<"seconds">>, <<"state">>],
-                                 [<<"username">>]).
+                                 [<<"server">>, <<"username">>]).
 
-execute_get_last(LServer, LUser) ->
-    mongoose_rdbms:execute_successfully(LServer, last_select, [LUser]).
+-spec execute_get_last(host_type(), jid:lserver(), jid:luser()) -> mongoose_rdbms:query_result().
+execute_get_last(HostType, LServer, LUser) ->
+    mongoose_rdbms:execute_successfully(HostType, last_select, [LServer, LUser]).
 
-execute_count_active_users(LServer, Seconds) ->
-    mongoose_rdbms:execute_successfully(LServer, last_count_active, [Seconds]).
+-spec execute_count_active_users(host_type(), jid:lserver(), mod_last:timestamp()) ->
+          mongoose_rdbms:query_result().
+execute_count_active_users(HostType, LServer, Seconds) ->
+    mongoose_rdbms:execute_successfully(HostType, last_count_active, [LServer, Seconds]).
 
-execute_remove_user(LServer, LUser) ->
-    mongoose_rdbms:execute_successfully(LServer, last_delete, [LUser]).
+-spec execute_remove_user(host_type(), jid:lserver(), jid:luser()) -> mongoose_rdbms:query_result().
+execute_remove_user(HostType, LServer, LUser) ->
+    mongoose_rdbms:execute_successfully(HostType, last_delete, [LServer, LUser]).
 
-execute_upsert_last(Host, LUser, Seconds, State) ->
-    InsertParams = [LUser, Seconds, State],
+-spec execute_upsert_last(host_type(), jid:lserver(), jid:luser(),
+                          mod_last:timestamp(), mod_last:status()) ->
+          mongoose_rdbms:query_result().
+execute_upsert_last(HostType, LServer, LUser, Seconds, State) ->
+    InsertParams = [LServer, LUser, Seconds, State],
     UpdateParams = [Seconds, State],
-    UniqueKeyValues = [LUser],
-    rdbms_queries:execute_upsert(Host, last_upsert, InsertParams, UpdateParams, UniqueKeyValues).
+    UniqueKeyValues = [LServer, LUser],
+    rdbms_queries:execute_upsert(HostType, last_upsert,
+                                 InsertParams, UpdateParams, UniqueKeyValues).
 
 %% API functions
--spec get_last(jid:luser(), jid:lserver()) ->
-    {ok, non_neg_integer(), binary()} | not_found.
-get_last(LUser, LServer) ->
-    Result = execute_get_last(LServer, LUser),
+-spec get_last(host_type(), jid:luser(), jid:lserver()) ->
+    {ok, mod_last:timestamp(), mod_last:status()} | not_found.
+get_last(HostType, LUser, LServer) ->
+    Result = execute_get_last(HostType, LServer, LUser),
     decode_last_result(Result).
 
--spec count_active_users(jid:lserver(), non_neg_integer()) -> non_neg_integer().
-count_active_users(LServer, Seconds) ->
-    Result = execute_count_active_users(LServer, Seconds),
+-spec count_active_users(host_type(), jid:lserver(), mod_last:timestamp()) -> non_neg_integer().
+count_active_users(HostType, LServer, Seconds) ->
+    Result = execute_count_active_users(HostType, LServer, Seconds),
     mongoose_rdbms:selected_to_integer(Result).
 
--spec set_last_info(jid:luser(), jid:lserver(),
-                    non_neg_integer(), binary()) -> ok | {error, term()}.
-set_last_info(LUser, LServer, Seconds, State) ->
-    wrap_rdbms_result(execute_upsert_last(LServer, LUser, Seconds, State)).
+-spec set_last_info(host_type(), jid:luser(), jid:lserver(),
+                    mod_last:timestamp(), mod_last:status()) ->
+          ok | {error, term()}.
+set_last_info(HostType, LUser, LServer, Seconds, State) ->
+    wrap_rdbms_result(execute_upsert_last(HostType, LServer, LUser, Seconds, State)).
 
--spec remove_user(jid:luser(), jid:lserver()) -> ok | {error, term()}.
-remove_user(LUser, LServer) ->
-    wrap_rdbms_result(execute_remove_user(LServer, LUser)).
+-spec remove_user(host_type(), jid:luser(), jid:lserver()) -> ok | {error, term()}.
+remove_user(HostType, LUser, LServer) ->
+    wrap_rdbms_result(execute_remove_user(HostType, LServer, LUser)).
 
 %% Helper functions
 decode_last_result({selected, []}) ->

--- a/src/mod_last_riak.erl
+++ b/src/mod_last_riak.erl
@@ -66,7 +66,7 @@ init(_VHost, _Opts) ->
     ok.
 
 -spec get_last(host_type(), jid:luser(), jid:lserver()) ->
-    {ok, mod_last:timestamp(), mod_last:status()} | not_found.
+    {ok, mod_last:timestamp(), mod_last:status()} | {error, term()} | not_found.
 get_last(HostType, LUser, LServer) ->
     case mongoose_riak:get(bucket_type(HostType, LServer), LUser) of
         {ok, Obj} ->

--- a/src/mod_last_riak.erl
+++ b/src/mod_last_riak.erl
@@ -47,27 +47,28 @@
 
 -behaviour(mod_last).
 
--include("mod_last.hrl").
 -include("mongoose.hrl").
 
 -define(TIMESTAMP_IDX, {integer_index, "timestamp"}).
 
 %% API
 -export([init/2,
-         get_last/2,
-         count_active_users/2,
-         set_last_info/4,
-         remove_user/2]).
+         get_last/3,
+         count_active_users/3,
+         set_last_info/5,
+         remove_user/3]).
 
--spec init(jid:server(), list()) ->ok.
+-type host_type() :: mongooseim:host_type().
+
+-spec init(host_type(), gen_mod:module_opts()) -> ok.
 init(_VHost, _Opts) ->
     %% we are using common riak pool
     ok.
 
--spec get_last(jid:luser(), jid:lserver()) ->
-    {ok, non_neg_integer(), binary()} | {error, term()} | not_found.
-get_last(LUser, LServer) ->
-    case mongoose_riak:get(bucket_type(LServer), LUser) of
+-spec get_last(host_type(), jid:luser(), jid:lserver()) ->
+    {ok, mod_last:timestamp(), mod_last:status()} | not_found.
+get_last(HostType, LUser, LServer) ->
+    case mongoose_riak:get(bucket_type(HostType, LServer), LUser) of
         {ok, Obj} ->
             Status = riakc_obj:get_value(Obj),
             MD = riakc_obj:get_update_metadata(Obj),
@@ -79,30 +80,32 @@ get_last(LUser, LServer) ->
             {error, Reason}
     end.
 
--spec count_active_users(jid:lserver(), non_neg_integer()) -> non_neg_integer().
-count_active_users(LServer, TimeStamp) ->
-    Idx = {index, bucket_type(LServer), ?TIMESTAMP_IDX, TimeStamp+1, infinity()},
+-spec count_active_users(host_type(), jid:lserver(), mod_last:timestamp()) -> non_neg_integer().
+count_active_users(HostType, LServer, TimeStamp) ->
+    Idx = {index, bucket_type(HostType, LServer), ?TIMESTAMP_IDX, TimeStamp+1, infinity()},
     RedMF = {modfun, riak_kv_mapreduce, reduce_count_inputs},
     Red = [{reduce, RedMF, [{reduce_phase_batch_size, 1000}], true}],
     {ok, [{0, [Count]}]}  = mongoose_riak:mapred(Idx, Red),
     Count.
 
--spec set_last_info(jid:luser(), jid:lserver(), non_neg_integer(),
-                    binary()) -> ok | {error, term()}.
-set_last_info(LUser, LServer, Timestamp, Status) ->
-    Obj = riakc_obj:new(bucket_type(LServer), LUser, Status),
+-spec set_last_info(host_type(), jid:luser(), jid:lserver(),
+                    mod_last:timestamp(), mod_last:status()) ->
+          ok | {error, term()}.
+set_last_info(HostType, LUser, LServer, Timestamp, Status) ->
+    Obj = riakc_obj:new(bucket_type(HostType, LServer), LUser, Status),
     MD = riakc_obj:get_update_metadata(Obj),
     MDWithIndex = riakc_obj:set_secondary_index(MD, [{?TIMESTAMP_IDX, [Timestamp]}]),
     FinalObj = riakc_obj:update_metadata(Obj, MDWithIndex),
 
     mongoose_riak:put(FinalObj).
 
--spec remove_user(jid:luser(), jid:lserver())  -> ok.
-remove_user(LUser, LServer) ->
-    mongoose_riak:delete(bucket_type(LServer), LUser).
+-spec remove_user(host_type(), jid:luser(), jid:lserver()) -> ok | {error, term()}.
+remove_user(HostType, LUser, LServer) ->
+    mongoose_riak:delete(bucket_type(HostType, LServer), LUser).
 
-bucket_type(LServer) ->
-    {gen_mod:get_module_opt(LServer, mod_last, bucket_type, <<"last">>), LServer}.
+-spec bucket_type(host_type(), jid:lserver()) -> riakc_obj:bucket().
+bucket_type(HostType, LServer) ->
+    {gen_mod:get_module_opt(HostType, mod_last, bucket_type, <<"last">>), LServer}.
 
 -spec infinity() -> non_neg_integer().
 infinity() ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -624,7 +624,6 @@ privacy_check_packet(Acc, JID, PrivacyList, FromToNameType, Dir) ->
     JID :: jid:jid(),
     Result :: mongoose_privacy:userlist().
 privacy_get_user_list(HostType, JID) ->
-    %% TODO: ejabberd_c2s calls this hook with host type, fix other places.
     run_hook_for_host_type(privacy_get_user_list, HostType, #userlist{}, [HostType, JID]).
 
 -spec privacy_iq_get(HostType, Acc, From, To, IQ, PrivList) -> Result when

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -87,32 +87,35 @@ notify_self_hook(Acc, #{node := Node}, #{self := Self}) ->
     {ok, Acc}.
 
 auth_anonymous(_Config) ->
+    HostType = host_type(),
     {U, S, R, JID, SID} = get_fake_session(),
-    ejabberd_auth_anonymous:start(S),
+    ejabberd_auth_anonymous:start(HostType),
     Info = [{auth_module, ejabberd_auth_anonymous}],
-    ejabberd_auth_anonymous:register_connection(#{}, S, SID, JID, Info),
-    true = ejabberd_auth_anonymous:does_user_exist(host_type(), U, S),
+    ejabberd_auth_anonymous:register_connection(#{}, HostType, SID, JID, Info),
+    true = ejabberd_auth_anonymous:does_user_exist(HostType, U, S),
     mongoose_hooks:session_cleanup(S, new_acc(S), U, R, SID),
-    false = ejabberd_auth_anonymous:does_user_exist(host_type(), U, S).
+    false = ejabberd_auth_anonymous:does_user_exist(HostType, U, S).
 
 last(_Config) ->
+    HostType = host_type(),
     {U, S, R, _JID, SID} = get_fake_session(),
-    mod_last:start(S, [{backend, mnesia}, {iqdisc, no_queue}]),
-    not_found = mod_last:get_last_info(U, S),
+    mod_last:start(HostType, [{backend, mnesia}, {iqdisc, no_queue}]),
+    not_found = mod_last:get_last_info(HostType, U, S),
     Status1 = <<"status1">>,
-    #{} = mod_last:on_presence_update(#{}, U, S, R, Status1),
-    {ok, TS1, Status1} = mod_last:get_last_info(U, S),
+    #{} = mod_last:on_presence_update(new_acc(S), U, S, R, Status1),
+    {ok, TS1, Status1} = mod_last:get_last_info(HostType, U, S),
     async_helper:wait_until(
       fun() ->
               mongoose_hooks:session_cleanup(S, new_acc(S), U, R, SID),
-              {ok, TS2, <<>>} = mod_last:get_last_info(U, S),
+              {ok, TS2, <<>>} = mod_last:get_last_info(HostType, U, S),
               TS2 - TS1 > 0
       end,
       true).
 
 stream_management(_Config) ->
+    HostType = host_type(),
     {U, S, R, _JID, SID} = get_fake_session(),
-    mod_stream_management:start(S, []),
+    mod_stream_management:start(HostType, []),
     SMID = <<"123">>,
     mod_stream_management:register_smid(SMID, SID),
     {sid, SID} = mod_stream_management:get_sid(SMID),
@@ -221,7 +224,7 @@ get_fake_session() ->
 new_acc(Server) ->
     mongoose_acc:new(#{location => ?LOCATION,
                        lserver => Server,
-                       host_type => Server,
+                       host_type => host_type(),
                        element => undefined}).
 
 host_type() ->

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -46,10 +46,12 @@ end_per_suite(Config) ->
 
 init_per_testcase(T, Config) ->
     {ok, _HooksServer} = gen_hook:start_link(),
+    ok = mongoose_lazy_routing:start(),
     setup_meck(meck_mods(T)),
     Config.
 
 end_per_testcase(T, Config) ->
+    mongoose_lazy_routing:stop(),
     unload_meck(meck_mods(T)),
     Config.
 


### PR DESCRIPTION
Add support for dynamic domains to `mod_last` and its backends.

Side changes:
- Fix error handling when updating last info. Previously the error tuple would result in `badmatch` as `Acc` was expected in both hooks.

This PR does **not** include:
- Supporting `remove_domain`.
- Migration guide.

Both tasks will be done separately.

