### PR TITLE
Implement multitenancy for mod_blocking

### DIFF
--- a/big_tests/dynamic_domains.config
+++ b/big_tests/dynamic_domains.config
@@ -84,5 +84,10 @@
         {server, <<"example.org">>},
         {host, <<"localhost">>},
         {password, <<"makota3">>},
-        {port, 5232}]}
+        {port, 5232}]},
+    {john, [
+        {username, <<"john">>},
+        {server, <<"domain.example.com">>},
+        {host, <<"localhost">>},
+        {password, <<"cosontuma">>}]}
 ]}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -25,6 +25,8 @@
 
 {suites, "tests", mam_SUITE}.
 
+{suites, "tests", mod_blocking_SUITE}.
+
 {suites, "tests", mod_ping_SUITE}.
 
 {suites, "tests", muc_SUITE}.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -129,6 +129,10 @@
         {username, <<"mike">>},
         {server, <<"localhost">>},
         {password, <<"nicniema">>}]},
+    {john, [
+        {username, <<"john">>},
+        {server, <<"localhost">>},
+        {password, <<"cosontuma">>}]},
     {geralt, [
         {username, <<"geralt">>},
         {server, <<"localhost">>},

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -231,6 +231,7 @@ messages_from_blocked_user_dont_arrive(Config) ->
         fun(User1, User2) ->
             user_blocks(User1, [User2]),
             message(User2, User1, <<"Hi!">>),
+            ct:sleep(100),
             escalus_assert:has_no_stanzas(User1),
             privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>)
         end).
@@ -259,7 +260,9 @@ messages_from_any_blocked_resource_dont_arrive(Config) ->
             message_is_not_delivered(User1b, [User2], <<"woof!">>),
             privacy_helper:gets_error(User1b, <<"cancel">>, <<"service-unavailable">>),
             message_is_not_delivered(User1c, [User2], <<"grrr!">>),
-            privacy_helper:gets_error(User1c, <<"cancel">>, <<"service-unavailable">>)
+            privacy_helper:gets_error(User1c, <<"cancel">>, <<"service-unavailable">>),
+            ct:sleep(100),
+            escalus_assert:has_no_stanzas(User2)
         end).
 
 blocking_doesnt_interfere(Config) ->

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -107,10 +107,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
-    escalus:create_users(Config, escalus:get_users([alice, bob, carol, mike, geralt])).
+    escalus_fresh:create_users(Config, escalus:get_users([alice, bob, kate, mike, john])).
 
 end_per_group(_GroupName, Config) ->
-    escalus:delete_users(Config, escalus:get_users([alice, bob, carol, mike, geralt])).
+    Config.
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -176,7 +176,7 @@ add_another_user_to_blocklist(Config) ->
 
 add_many_users_to_blocklist(Config) ->
     escalus:fresh_story(
-        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike, 1}],
+        Config, [{alice, 1}, {bob, 1}, {kate, 1}, {mike, 1}],
         fun(User1, User2, User3, User4) ->
             user_blocks(User1, [User2, User3, User4]),
             BlockList = get_blocklist(User1),
@@ -197,7 +197,7 @@ remove_user_from_blocklist(Config) ->
 
 remove_many_user_from_blocklist(Config) ->
     escalus:fresh_story(
-        Config, [{alice, 1}, {bob, 1}, {geralt, 1}],
+        Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(User1, User2, User3) ->
             user_blocks(User1, [User2, User3]),
             user_unblocks(User1, [User2, User3]),
@@ -208,7 +208,7 @@ remove_many_user_from_blocklist(Config) ->
 
 clear_blocklist(Config) ->
     escalus:fresh_story(
-        Config, [{alice, 1}, {bob, 1}, {geralt, 1}],
+        Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(User1, User2, User3) ->
             user_blocks(User1, [User2, User3]),
             user_unblocks_all(User1),
@@ -231,7 +231,7 @@ messages_from_blocked_user_dont_arrive(Config) ->
         fun(User1, User2) ->
             user_blocks(User1, [User2]),
             message(User2, User1, <<"Hi!">>),
-            client_gets_nothing(User1),
+            escalus_assert:has_no_stanzas(User1),
             privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>)
         end).
 
@@ -255,18 +255,22 @@ messages_from_any_blocked_resource_dont_arrive(Config) ->
             user_blocks(User2, [User1a]),
             %% then
             message_is_not_delivered(User1a, [User2], <<"roar!">>),
+            privacy_helper:gets_error(User1a, <<"cancel">>, <<"service-unavailable">>),
             message_is_not_delivered(User1b, [User2], <<"woof!">>),
-            message_is_not_delivered(User1c, [User2], <<"grrr!">>)
+            privacy_helper:gets_error(User1b, <<"cancel">>, <<"service-unavailable">>),
+            message_is_not_delivered(User1c, [User2], <<"grrr!">>),
+            privacy_helper:gets_error(User1c, <<"cancel">>, <<"service-unavailable">>)
         end).
 
 blocking_doesnt_interfere(Config) ->
     escalus:fresh_story(
-        Config, [{alice, 1}, {bob, 1}, {geralt, 1}],
+        Config, [{alice, 1}, {bob, 1}, {kate, 1}],
         fun(User1, User2, User3) ->
             %% given
             user_blocks(User1, [User2]),
             %% then
             message_is_not_delivered(User2, [User1], <<"!@#@$@#$%">>),
+            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>),
             message_is_delivered(User3, [User1], <<"Ni hao.">>)
         end).
 
@@ -285,11 +289,13 @@ blocking_propagates_to_resources(Config) ->
             client_gets_blocking_error(User1b),
             % Bob can't send to any of Alice's resources
             message_is_not_delivered(User2, [User1a], <<"hau!">>),
-            message_is_not_delivered(User2, [User1b], <<"miau!">>)
+            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>),
+            message_is_not_delivered(User2, [User1b], <<"miau!">>),
+            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>)
         end).
 
 iq_reply_doesnt_crash_user_process(Config) ->
-    escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
 
         QueryWithBlockingNS = escalus_stanza:query_el(?NS_BLOCKING, []),
         %% Send IQ reply with blocking ns
@@ -367,7 +373,7 @@ blocking_and_relogin_many(Config) ->
 
 simple_story(Config, Fun) ->
     escalus:story(
-        Config, [{alice, 1}, {bob, 1}, {carol, 1}, {mike, 1}, {geralt, 1}],
+        Config, [{alice, 1}, {bob, 1}, {kate, 1}, {mike, 1}, {john, 1}],
         Fun
     ).
 
@@ -630,10 +636,6 @@ user_unblocks_all(User) ->
 message(From, To, MsgTxt) ->
     escalus_client:send(From, escalus_stanza:chat_to(To, MsgTxt)).
 
-client_gets_nothing(Client) ->
-    ct:sleep(500),
-    escalus_assert:has_no_stanzas(Client).
-
 message_is_delivered(From, [To|_] = Tos, MessageText) ->
     BareTo = escalus_utils:jid_to_lower(escalus_client:short_jid(To)),
     escalus:send(From, escalus_stanza:chat_to(BareTo, MessageText)),
@@ -647,7 +649,6 @@ message_is_delivered(From, To, MessageText) ->
 message_is_not_delivered(From, [To|_] = Tos, MessageText) ->
     BareTo = escalus_utils:jid_to_lower(escalus_client:short_jid(To)),
     escalus:send(From, escalus_stanza:chat_to(BareTo, MessageText)),
-    timer:sleep(300),
     clients_have_no_messages(Tos).
 
 clients_have_no_messages(Cs) when is_list (Cs) -> [ client_has_no_messages(C) || C <- Cs ].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -193,7 +193,7 @@ init_per_group_generic(Config0) ->
 
                   %% To reduce load when sending many messages
                   VirtHosts = virtual_hosts(),
-                  ModulesToStop = [mod_offline, mod_privacy, mod_roster, mod_last],
+                  ModulesToStop = [mod_offline, mod_blocking, mod_privacy, mod_roster, mod_last],
 
                   OldMods = save_modules(NodeName, VirtHosts),
 

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -244,8 +244,8 @@
 {{{mod_privacy}}}
 {{/mod_privacy}}
 {{#mod_blocking}}
+[modules.mod_blocking]
 {{{mod_blocking}}}
-
 {{/mod_blocking}}
 {{#mod_private}}
 {{{mod_private}}}

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -9,6 +9,7 @@
 {default_server_domain, "\"localhost\""}.
 
 {mod_privacy, ""}.
+{mod_blocking, ""}.
 {host_config,
   "[[host_config]]
   host = \"anonymous.localhost\"
@@ -47,7 +48,11 @@
   {{#mod_privacy}}
   [host_config.modules.mod_privacy]
   {{{mod_privacy}}}
-  {{/mod_privacy}}"}.
+  {{/mod_privacy}}
+  {{#mod_blocking}}
+  [host_config.modules.mod_blocking]
+  {{{mod_blocking}}}
+  {{/mod_blocking}}"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
 {scram_iterations, 64}.

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -25,7 +25,7 @@
 {mod_last, ""}.
 {mod_offline, ""}.
 {mod_privacy, ""}.
-{mod_blocking, "[modules.mod_blocking]"}.
+{mod_blocking, ""}.
 {mod_private, "[modules.mod_private]"}.
 {mod_roster, ""}.
 {mod_vcard, "[modules.mod_vcard]


### PR DESCRIPTION
This PR makes `mod_blocking` depend on `mod_privacy` on the `gen_mod` level, as it should have been. As such, `mod_privacy` is removed from the default config, as the privacy xep is deprecated, and instead the blocking xep is promoted: hence we leave `mod_blocking` enabled.
I also had a few changes to the test suite. Users are created fresh, and we don't need websockets users to test blocking functionality, so `geralt` and `carol` are changed in favour of `kate` and `john`. Also a few sleeps are removed, and some answers are now asserted. This makes the test-suite run in half the time, and also asserts more tightly.