### PR TITLE
Make pool_name configurable for service_domain_db

### DIFF
--- a/doc/developers-guide/domain_management.md
+++ b/doc/developers-guide/domain_management.md
@@ -103,18 +103,18 @@ Configure host-type first to delete such domains.
 
 ```toml
 [services.service_domain_db]
-  pool_name = "global"
+  db_pool = "global"
   event_cleaning_interval = 1800
   event_max_age = 7200
 ```
 
-### `pool_name`
+### `db_pool`
+By default, this service uses the RDBMS connection pool configured with the scope `"global"`.
+You can put a specific host type there to use the pool with the `"host"` or `"single_host"` scope for that particular host type. See [outgoing connections docs](../advanced-configuration/outgoing-connections.md) for more information about pool scopes.
 
-Pool name to use for a database connection.
-
-* **Syntax:** atom
+* **Syntax:** string
 * **Default:** `global`
-* **Example:** `pool_name = "global"`
+* **Example:** `db_pool = "my_host_type"`
 
 ### `event_cleaning_interval`
 The number of seconds between cleaning attempts of the `domain_events` table.

--- a/doc/developers-guide/domain_management.md
+++ b/doc/developers-guide/domain_management.md
@@ -101,6 +101,21 @@ Configure host-type first to delete such domains.
 
 ## Service options
 
+```toml
+[services.service_domain_db]
+  pool_name = "global"
+  event_cleaning_interval = 1800
+  event_max_age = 7200
+```
+
+### `pool_name`
+
+Pool name to use for a database connection.
+
+* **Syntax:** atom
+* **Default:** `global`
+* **Example:** `pool_name = "global"`
+
 ### `event_cleaning_interval`
 The number of seconds between cleaning attempts of the `domain_events` table.
 * **Syntax:** positive integer

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -260,7 +260,10 @@ row_to_map({HostType, Enabled}) ->
     #{host_type => HostType, enabled => mongoose_rdbms:to_bool(Enabled)}.
 
 get_db_pool() ->
-    hd(ejabberd_config:get_global_option(hosts)).
+    proplists:get_value(pool_name, get_service_opts(), global).
+
+get_service_opts() ->
+    mongoose_service:get_service_opts(service_domain_db).
 
 transaction(F) ->
     Pool = get_db_pool(),

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -260,7 +260,7 @@ row_to_map({HostType, Enabled}) ->
     #{host_type => HostType, enabled => mongoose_rdbms:to_bool(Enabled)}.
 
 get_db_pool() ->
-    proplists:get_value(pool_name, get_service_opts(), global).
+    proplists:get_value(db_pool, get_service_opts(), global).
 
 get_service_opts() ->
     mongoose_service:get_service_opts(service_domain_db).

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -57,7 +57,9 @@ config_spec() ->
                <<"event_cleaning_interval">> => #option{type = integer,
                                                         validate = positive},
                <<"event_max_age">> => #option{type = integer,
-                                              validate = positive}
+                                              validate = positive},
+               <<"pool_name">> => #option{type = atom,
+                                          validate = pool_name}
               }}.
 
 start_link() ->

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -58,8 +58,8 @@ config_spec() ->
                                                         validate = positive},
                <<"event_max_age">> => #option{type = integer,
                                               validate = positive},
-               <<"pool_name">> => #option{type = atom,
-                                          validate = pool_name}
+               <<"db_pool">> => #option{type = atom,
+                                        validate = pool_name}
               }}.
 
 start_link() ->


### PR DESCRIPTION
This PR addresses MIM-1451

Proposed changes include:
* Use global as a default pool
* Make this option configurable