### PR TITLE
gen_mod:stop_module touches

### DIFF
--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -231,6 +231,8 @@ is_app_running(AppName) ->
 
 
 %% @doc Stop the module for host type, and forget its configuration.
+%% NOTE: this is not supposed to be done in a production environment.
+%% It will probably "work", but unexpected side-effects haven't been carefully ruled-out.
 -spec stop_module(host_type(), module()) ->
     {ok, list()} | {error, not_loaded} | {error, term()}.
 stop_module(HostType, Module) ->


### PR DESCRIPTION
This idea comes from when I was working on multitenancy for `mod_privacy` and `mod_blocking`, and we realised that certain tests where stopping `mod_privacy` without stopping `mod_blocking`, and therefore they where leaving `mod_blocking` broken without notice.