### PR TITLE
Fix race condition when inserting into domain_event table

### DIFF
--- a/src/domain/mongoose_domain_gaps.erl
+++ b/src/domain/mongoose_domain_gaps.erl
@@ -1,0 +1,36 @@
+-module(mongoose_domain_gaps).
+-export([init/0]).
+-export([handle_gaps/1]).
+
+-include("mongoose_logger.hrl").
+
+-define(TABLE, ?MODULE).
+
+init() ->
+    ets:new(?TABLE, [set, named_table, public]).
+
+handle_gaps(Gaps) ->
+    remember_gaps(Gaps),
+    Now = erlang:monotonic_time(seconds),
+    MaxTimeToWait = 30, %% seconds
+    case [Gap || Gap <- Gaps, not is_expired_gap(Gap, Now, MaxTimeToWait)] of
+        [] ->
+            skip;
+        [_|_] = WaitingGaps ->
+            ?LOG_WARNING(#{what => wait_for_gaps, gaps => WaitingGaps}),
+            wait
+    end.
+
+remember_gaps(Gaps) ->
+    Now = erlang:monotonic_time(seconds),
+    [ets:insert_new(?TABLE, {Gap, Now}) || Gap <- Gaps],
+    ok.
+
+is_expired_gap(Gap, Now, MaxTimeToWait) ->
+    case ets:lookup(?TABLE, Gap) of
+        [] ->
+            ?LOG_WARNING(#{what => gap_not_found, gap => Gap}),
+            true;
+        [{Gap, Inserted}] ->
+            (Now - Inserted) > MaxTimeToWait
+    end.

--- a/src/domain/mongoose_domain_gaps.erl
+++ b/src/domain/mongoose_domain_gaps.erl
@@ -69,9 +69,13 @@ handle_gaps(Gaps, Now) ->
         [] ->
             ok; %% Skip any gaps checking
         [_|_] = WaitingGaps ->
-            ?LOG_WARNING(#{what => wait_for_gaps, gaps => WaitingGaps}),
+            ?LOG_WARNING(#{what => wait_for_gaps,
+                           gaps => format_gaps(WaitingGaps)}),
             wait
     end.
+
+format_gaps(Gaps) ->
+    iolist_to_binary(io_lib:format("~w", [Gaps])).
 
 remember_gaps(Gaps, Now) ->
     [ets:insert_new(?TABLE, {Gap, Now}) || Gap <- Gaps],

--- a/src/domain/mongoose_domain_gaps.erl
+++ b/src/domain/mongoose_domain_gaps.erl
@@ -5,6 +5,9 @@
 -export([gaps_limit_before_restart/0]).
 -export([check_for_gaps/2]).
 
+%% These are used in the small tests
+-ignore_xref([gaps_limit_before_restart/0, max_time_to_wait/0]).
+
 -include("mongoose_logger.hrl").
 
 -define(TABLE, ?MODULE).

--- a/src/domain/mongoose_domain_gaps.erl
+++ b/src/domain/mongoose_domain_gaps.erl
@@ -1,6 +1,6 @@
 -module(mongoose_domain_gaps).
 -export([init/0]).
--export([handle_gaps/1]).
+-export([check_for_gaps/1]).
 
 -include("mongoose_logger.hrl").
 
@@ -9,13 +9,49 @@
 init() ->
     ets:new(?TABLE, [set, named_table, public]).
 
+-spec check_for_gaps([tuple()]) -> ok | restart | wait.
+check_for_gaps(Rows) ->
+    Ids = rows_to_ids(Rows),
+    case find_gaps(Ids, 10000) of
+        too_many_gaps ->
+            ?LOG_ERROR(#{what => domain_check_for_gaps_failed,
+                         reason => too_many_gaps,
+                         rows => Rows}),
+            restart;
+        [] -> %% No gaps, good
+            ok;
+        Gaps ->
+            handle_gaps(Gaps)
+    end.
+
+rows_to_ids(Rows) ->
+    [element(1, Row) || Row <- Rows].
+
+find_gaps(Ids, MaxGaps) ->
+    find_gaps(Ids, [], MaxGaps).
+
+find_gaps(_, _Missing, _MaxGaps = 0) ->
+    too_many_gaps;
+find_gaps([H|T], Missing, MaxGaps) ->
+    Expected = H + 1,
+    case T of
+        [Expected|_] ->
+            find_gaps(T, Missing, MaxGaps);
+         [_|_] ->
+            find_gaps([Expected|T], [Expected|Missing], MaxGaps - 1);
+         [] ->
+             Missing
+     end;
+find_gaps([], Missing, _MaxGaps) ->
+     Missing.
+
 handle_gaps(Gaps) ->
     remember_gaps(Gaps),
     Now = erlang:monotonic_time(seconds),
     MaxTimeToWait = 30, %% seconds
     case [Gap || Gap <- Gaps, not is_expired_gap(Gap, Now, MaxTimeToWait)] of
         [] ->
-            skip;
+            ok; %% Skip any gaps checking
         [_|_] = WaitingGaps ->
             ?LOG_WARNING(#{what => wait_for_gaps, gaps => WaitingGaps}),
             wait

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -41,7 +41,8 @@ check_for_updates(FromId, PageSize) ->
                            from_id => FromId}),
             FromId;
         Rows ->
-            case mongoose_domain_gaps:check_for_gaps(Rows) of
+            Now = mongoose_domain_gaps:new_timestamp(),
+            case mongoose_domain_gaps:check_for_gaps(Rows, Now) of
                 ok ->
                     case check_if_id_is_still_relevant(FromId, Rows) of
                         [] -> FromId;

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -24,6 +24,12 @@
 
 -import(mongoose_rdbms, [prepare/4, execute_successfully/3]).
 
+-type event_id() :: non_neg_integer().
+-type limit() :: non_neg_integer().
+-type domain() :: binary().
+-type row() :: {event_id(), domain(), mongooseim:host_type() | null}.
+-export_type([row/0]).
+
 start(_Opts) ->
     {LimitSQL, LimitMSSQL} = rdbms_queries:get_db_specific_limits_binaries(),
     Pool = get_db_pool(),
@@ -144,6 +150,7 @@ select_from(FromId, Limit) ->
     {selected, Rows} = execute_successfully(Pool, domain_select_from, Args),
     Rows.
 
+-spec select_updates_from(event_id(), limit()) -> [row()].
 select_updates_from(FromId, Limit) ->
     select_updates_from(FromId, Limit, 2).
 

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -58,6 +58,8 @@ start(_Opts) ->
             <<"INSERT INTO domain_events (domain) VALUES (?)">>),
     prepare(domain_events_max, domain_events, [],
             <<"SELECT MAX(id) FROM domain_events">>),
+    prepare(domain_event_exist, domain_events, [id],
+            <<"SELECT 1 FROM domain_events WHERE id=?">>),
     prepare(domain_events_delete_older_than, domain_events, [id],
             <<"DELETE FROM domain_events WHERE id < ?">>),
     prepare(domain_select_events_from, domain_events,
@@ -145,7 +147,7 @@ select_from(FromId, Limit) ->
     Rows.
 
 select_updates_from(FromId, Limit) ->
-    select_updates_from(FromId, Limit, 2).
+    select_updates_from(FromId, Limit, 10).
 
 select_updates_from(_FromId, _Limit, 0) ->
     %% this should never happen, but just in case returning
@@ -171,8 +173,94 @@ select_updates_from(FromId, Limit, NoOfRetries) ->
                     service_domain_db:restart(),
                     []
             end;
-        {selected, Rows} -> Rows
+        {selected, Rows} ->
+            check_for_gaps_and_retry(FromId, Limit, NoOfRetries, Rows)
     end.
+
+check_for_gaps_and_retry(FromId, Limit, NoOfRetries, Rows) ->
+    Ids = [element(1, Row) || Row <- Rows],
+    case find_gaps(Ids) of
+        [] ->
+            Rows;
+        Gaps ->
+            %% Entries do not appear in any particular order in the events table.
+            %% So, if some record is missing, we should wait for it.
+            %% The autoincrement key is incremented before the transaction is committed.
+            ?LOG_WARNING(#{what => select_updates_from_retry,
+                           text => <<"Gaps found">>,
+                           limit => Limit, retries => NoOfRetries,
+                           from_id => FromId, rows => Rows, gaps => Gaps}),
+            Started = erlang:monotonic_time(seconds),
+            case wait_for_gaps(Gaps, Started) of
+                true ->
+                    select_updates_from(FromId, Limit, NoOfRetries - 1);
+                false ->
+                    ?LOG_ERROR(#{what => select_updates_from_failed,
+                                 text => <<"Missing events">>,
+                                 limit => Limit, retries => NoOfRetries,
+                                 gaps => Gaps, rows => Rows,
+                                 from_id => FromId}),
+                    service_domain_db:restart(),
+                    []
+            end;
+        false ->
+            Rows
+    end.
+
+%% Returns false if still have some gaps.
+%% Waits maximum 60 seconds.
+wait_for_gaps([Id|Ids], Started) ->
+    case wait_for_gap(Id, 10) of
+        true ->
+            Now = erlang:monotonic_time(seconds),
+            case (Now - Started) > 60 of
+                true ->
+                    ?LOG_ERROR(#{what => wait_for_gaps_timeout}),
+                    false;
+                false ->
+                    wait_for_gaps(Ids, Started)
+            end;
+        false ->
+            false
+    end;
+wait_for_gaps([], _Started) ->
+    true.
+
+wait_for_gap(Id, Retries) ->
+    Pool = get_db_pool(),
+    case execute_successfully(Pool, domain_event_exist, [Id]) of
+        {selected, [{_}]} ->
+            true;
+        {selected, []} ->
+            timer:sleep(1000),
+            wait_for_gap(Id, Retries - 1)
+    end.
+
+find_gaps(Ids) ->
+    find_gaps(Ids, []).
+
+find_gaps([H|T], Missing) ->
+    Expected = H + 1,
+    case T of
+        [Expected|_] ->
+            find_gaps(T, Missing);
+        [_|_] ->
+            find_gaps([Expected|T], [Expected|Missing]);
+        [] ->
+            Missing
+    end;
+find_gaps([], Missing) ->
+    Missing.
+
+
+has_gaps([A| [B|_] = T]) when A =:= (B - 1) ->
+    has_gaps(T);
+has_gaps([_]) ->
+    false;
+has_gaps([]) ->
+    false;
+has_gaps(_) ->
+    true.
 
 get_max_event_id_or_set_dummy() ->
     get_max_event_id_or_set_dummy(2).

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -95,6 +95,7 @@ sync_local() ->
 %% Server callbacks
 
 init([]) ->
+    mongoose_domain_gaps:init(),
     ?PG_JOIN(?GROUP, self()),
     gen_server:cast(self(), initial_loading),
     %% initial state will be set on initial_loading processing

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -24,7 +24,9 @@ all() ->
      get_domains_by_host_type,
      host_type_check,
      can_get_outdated_domains,
-     run_for_each_domain].
+     run_for_each_domain,
+     gap_gets_detected,
+     too_many_gaps_lead_to_restart].
 
 init_per_suite(Config) ->
     meck:new(mongoose_lazy_routing, [no_link]),
@@ -189,3 +191,35 @@ add_domain_mock_fn(HostType, Domain) ->
     {ok, HostType} = mongoose_domain_core:get_host_type(Domain),
     true = self() =:= whereis(mongoose_domain_core),
     ok.
+
+gap_gets_detected(_) ->
+    mongoose_domain_gaps:init(),
+    Now = -576460752,
+    MaxTime = mongoose_domain_gaps:max_time_to_wait(),
+    Rows = [
+                {1, <<"d1">>, <<"t1">>},
+                {2, <<"d2">>, <<"t1">>},
+                {4, <<"d4">>, <<"t1">>},
+                {5, <<"d5">>, <<"t1">>}
+            ],
+    %% This inserts a gap into an ETS gap table
+    wait = mongoose_domain_gaps:check_for_gaps(Rows, Now),
+    %% Still waiting
+    wait = mongoose_domain_gaps:check_for_gaps(Rows, Now + MaxTime - 1),
+    %% Can continue
+    ok = mongoose_domain_gaps:check_for_gaps(Rows, Now + MaxTime + 1),
+    ok.
+
+too_many_gaps_lead_to_restart(_) ->
+    mongoose_domain_gaps:init(),
+    Now = -576460752,
+    MaxTime = mongoose_domain_gaps:max_time_to_wait(),
+    Rows = [
+                {1, <<"d1">>, <<"t1">>},
+                {2, <<"d2">>, <<"t1">>},
+                {4 + mongoose_domain_gaps:gaps_limit_before_restart(), <<"d4">>, <<"t1">>}
+            ],
+    %% Too many gaps to expand
+    restart = mongoose_domain_gaps:check_for_gaps(Rows, Now),
+    ok.
+


### PR DESCRIPTION
This PR addresses MIM-1459 "Inconsistent values in mongoose_domain_core".

Proposed changes include:
* Fix for a race condition in PgSQL when allocating IDs.


# Example

Node mim:

```erlang
f().
recon_trace:calls({mongoose_domain_sql, select_updates_from, fun(_) -> return_trace() end}, 5000, [{scope, local}]).
From = 20000.
timer:sleep(6000).
[spawn(fun() -> mongoose_domain_api:insert_domain(<<"test", (integer_to_binary(N))/binary>>, <<"test type">>) end) || N <- lists:seq(From, From + 2000, 2)].
```

Node mim2:
```erlang
f().
recon_trace:calls({mongoose_domain_sql, select_updates_from, fun(_) -> return_trace() end}, 5000, [{scope, local}]).
From = 20000.
timer:sleep(4000).
[spawn(fun() -> mongoose_domain_api:insert_domain(<<"test", (integer_to_binary(N))/binary>>, <<"test type">>) end) || N <- lists:seq(From + 1, From + 2001, 2)].
```

Do the check:

```
Nodes = [node()|nodes()].
List = [rpc:call(Node, mongoose_domain_api, get_domains_by_host_type, [<<"test type">>]) || Node <- Nodes].
[A,B|_] = List.
rp(lists:sort(A -- B)).
rp(lists:sort(B -- A)).
```

Not empty lists of difference in domains from two nodes.

# Why does it happen?

PG assigns auto increment ids outside of a transaction. So, we could have to wait for records to be committed sometimes (rarely, usually 1 second waiting would be enough, once a missing event is detected).

# What is the fix?

We check that ids we get from DB are incrementing without any gaps 1,2,3,4,5...
If a gap is detected (i.e. something like 1,2,4,5), we just wait and retry.


Domain_settings table has the same issue, but it would be triggered only at the load time, which is rare.
But what we can do is to maybe start rolling event updates not from the last event at the moment, but from an event, which is at least 10 (or 30?) seconds old.


# Alternative fix

Don't use auto-increments. Always do in a transaction:

```
SELECT max(id) + 1 FROM domain_events;
```

to get an ID for a new event. If a transaction fails - just restart it.
This could be a bit slower on insertion, but could be a cleaner solution ;) 

The alt fix would not work under intensive domain insertion rate though.



# Logging

Will print

```
when=2021-08-11T15:54:49.286084+00:00 level=warning what=wait_for_gaps pid=<0.3267.0> at=mongoose_domain_gaps:handle_gaps/1:20 gaps=[1981]
```