### PR TITLE
Declare fusco obviously in big tests

### DIFF
--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -15,6 +15,7 @@
         {jiffy, "1.0.8"},
         {proper, "1.4.0"},
         {gun, "1.3.3"},
+        {fusco, "0.1.1"},
         {escalus, "4.2.4"},
         {gen_fsm_compat, "0.3.0"},
         {cowboy, "2.9.0"},

--- a/big_tests/rebar.lock
+++ b/big_tests/rebar.lock
@@ -18,7 +18,7 @@
  {<<"fast_pbkdf2">>,{pkg,<<"fast_pbkdf2">>,<<"1.0.1">>},2},
  {<<"fast_scram">>,{pkg,<<"fast_scram">>,<<"0.4.1">>},1},
  {<<"fast_tls">>,{pkg,<<"fast_tls">>,<<"1.1.12">>},1},
- {<<"fusco">>,{pkg,<<"fusco">>,<<"0.1.1">>},1},
+ {<<"fusco">>,{pkg,<<"fusco">>,<<"0.1.1">>},0},
  {<<"gen_fsm_compat">>,{pkg,<<"gen_fsm_compat">>,<<"0.3.0">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"gun">>,{pkg,<<"gun">>,<<"1.3.3">>},0},

--- a/big_tests/src/ejabberd_tests.app.src
+++ b/big_tests/src/ejabberd_tests.app.src
@@ -10,6 +10,7 @@
                   gen_fsm_compat,
                   jid,
                   gun,
+                  fusco,
                   escalus
                  ]},
   {env, []}


### PR DESCRIPTION
The `fusco` is used from `escalus` but not used in `escalus`.
