### PR TITLE
Refactor async writer for MAM

### DIFF
--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -317,8 +317,7 @@ If you'd like to learn more about metrics in MongooseIM, please visit [MongooseI
 | ---- | ---- | -------------------------------------- |
 | `[Host, modMamArchiveRemoved]` | spiral | User's entire archive is removed. |
 | `[Host, modMamArchived]` | spiral | A message is stored in user's archive. |
-| `[Host, modMamDropped]` | spiral | A message couldn't be enqueued due to an overloaded async worker. |
-| `[Host, modMamDropped2]` | spiral | A message couldn't be stored in the DB (and got dropped). |
+| `[Host, modMamDropped]` | spiral | A message couldn't be stored in the DB (and got dropped). |
 | `[Host, modMamDroppedIQ]` | spiral | MAM IQ has been dropped due to: high query frequency/invalid syntax or type. |
 | `[Host, modMamFlushed]` | spiral | Message was stored in a DB asynchronously. |
 | `[Host, modMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result. |

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -750,5 +750,4 @@ spirals() ->
      modMamArchived,
      modMamFlushed,
      modMamDropped,
-     modMamDropped2,
      modMamDroppedIQ].


### PR DESCRIPTION
This PR addresses "some old ugly code is a bit prettier now".

Proposed changes include:
* No message_queue_len call on each archived message
* Just do cast
* Store messages off the heap
* Remove modMamDropped2 metric

