### PR TITLE
Fix FTBFS on implicit declaration of function 'erts_exit'

### DIFF
--- a/c_src/ejabberd_zlib_drv.c
+++ b/c_src/ejabberd_zlib_drv.c
@@ -46,6 +46,7 @@ void *ejabberd_zlib_drv_alloc(ErlDrvSizeT size);
 ErlDrvBinary *ejabberd_zlib_drv_alloc_binary(ErlDrvSizeT size);
 ErlDrvBinary *ejabberd_zlib_drv_realloc_binary(ErlDrvBinary *bin,
     ErlDrvSizeT size);
+void erts_exit(int n, char*, ...);
 
 void *ejabberd_zlib_drv_alloc(ErlDrvSizeT size) {
     void *p = driver_alloc(size);


### PR DESCRIPTION
This PR addresses the master branch and also #2921.