### PR TITLE
Restart db service once domain core is down

### DIFF
--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -243,7 +243,9 @@ setup_service(Opts, Config) ->
     Pairs1 = [{<<"example.cfg">>, <<"type1">>},
              {<<"erlang-solutions.com">>, <<"type2">>},
              {<<"erlang-solutions.local">>, <<"type2">>}],
-    CommonTypes = [<<"type1">>, <<"type2">>, <<"dbgroup">>, <<"dbgroup2">>, <<"cfggroup">>],
+    %% <<"test type">> is the default type
+    CommonTypes = [<<"type1">>, <<"type2">>, <<"dbgroup">>, <<"dbgroup2">>, <<"cfggroup">>,
+                   <<"test type">>],
     Types2 = [<<"mim2only">>|CommonTypes],
     init_with(mim(), Pairs1, CommonTypes),
     init_with(mim2(), [], Types2),

--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -130,6 +130,7 @@ get_start_args() ->
 %% gen_server callbacks
 %%--------------------------------------------------------------------
 init([Pairs, AllowedHostTypes]) ->
+    service_domain_db:reset_last_event_id(),
     ets:new(?TABLE, [set, named_table, protected, {read_concurrency, true}]),
     ets:new(?HOST_TYPE_TABLE, [set, named_table, protected, {read_concurrency, true}]),
     insert_host_types(?HOST_TYPE_TABLE, AllowedHostTypes),

--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -56,12 +56,12 @@ start(Pairs, AllowedHostTypes) ->
         {?MODULE,
          {?MODULE, start_link, [Pairs, AllowedHostTypes]},
          permanent, infinity, worker, [?MODULE]},
-    just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
+    just_ok(supervisor:start_child(mongoose_domain_sup, ChildSpec)).
 
 %% required for integration tests
 stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
+    supervisor:terminate_child(mongoose_domain_sup, ?MODULE),
+    supervisor:delete_child(mongoose_domain_sup, ?MODULE),
     ok.
 
 -endif.

--- a/src/domain/mongoose_domain_db_cleaner.erl
+++ b/src/domain/mongoose_domain_db_cleaner.erl
@@ -30,12 +30,12 @@ start(Opts) ->
         {?MODULE,
          {?MODULE, start_link, [Opts]},
          permanent, infinity, worker, [?MODULE]},
-    supervisor:start_child(ejabberd_sup, ChildSpec),
+    supervisor:start_child(mongoose_domain_sup, ChildSpec),
     ok.
 
 stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
+    supervisor:terminate_child(mongoose_domain_sup, ?MODULE),
+    supervisor:delete_child(mongoose_domain_sup, ?MODULE),
     ok.
 
 start_link(Opts) ->

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -148,6 +148,7 @@ select_from(FromId, Limit) ->
     Pool = get_db_pool(),
     Args = rdbms_queries:add_limit_arg(Limit, [FromId]),
     {selected, Rows} = execute_successfully(Pool, domain_select_from, Args),
+    ?LOG_ERROR(#{what => select_from, rows => Rows, from_id => FromId, limit => Limit}),
     Rows.
 
 -spec select_updates_from(event_id(), limit()) -> [row()].

--- a/src/domain/mongoose_domain_sup.erl
+++ b/src/domain/mongoose_domain_sup.erl
@@ -1,0 +1,17 @@
+-module(mongoose_domain_sup).
+-export([start_link/0]).
+-export([init/1]).
+
+-ignore_xref([start_link/0]).
+
+-spec(start_link() ->
+    {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => rest_for_one,
+                 intensity => 100, period => 5,
+                 shutdown => 1000},
+    ChildSpecs = [],
+    {ok, { SupFlags, ChildSpecs }}.

--- a/src/domain/mongoose_domain_sup.erl
+++ b/src/domain/mongoose_domain_sup.erl
@@ -2,7 +2,7 @@
 -export([start_link/0]).
 -export([init/1]).
 
--ignore_xref([start_link/0]).
+-ignore_xref([start_link/0, init/1]).
 
 -spec(start_link() ->
     {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).

--- a/src/domain/mongoose_lazy_routing.erl
+++ b/src/domain/mongoose_lazy_routing.erl
@@ -80,12 +80,12 @@ stop() ->
 start() ->
     ChildSpec = {?MODULE, {?MODULE, start_link, []},
                  permanent, infinity, worker, [?MODULE]},
-    just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
+    just_ok(supervisor:start_child(mongoose_domain_sup, ChildSpec)).
 
 %% required for integration tests
 stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
+    supervisor:terminate_child(mongoose_domain_sup, ?MODULE),
+    supervisor:delete_child(mongoose_domain_sup, ?MODULE),
     ok.
 
 -endif.

--- a/src/domain/mongoose_subdomain_core.erl
+++ b/src/domain/mongoose_subdomain_core.erl
@@ -85,12 +85,12 @@ log_error(_Function, _Error) -> ok.
 start() ->
     ChildSpec = {?MODULE, {?MODULE, start_link, []},
                  permanent, infinity, worker, [?MODULE]},
-    just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
+    just_ok(supervisor:start_child(mongoose_domain_sup, ChildSpec)).
 
 %% required for integration tests
 stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
+    supervisor:terminate_child(mongoose_domain_sup, ?MODULE),
+    supervisor:delete_child(mongoose_domain_sup, ?MODULE),
     ok.
 
 -endif.

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -109,7 +109,7 @@ handle_cast(initial_loading, State) ->
     ?LOG_INFO(#{what => domains_loaded, last_event_id => LastEventId}),
     NewState = State#{last_event_id => LastEventId,
                       check_for_updates_interval => 30000},
-    {noreply, handle_check_for_updates(NewState)};
+    {noreply, handle_check_for_updates(NewState, true)};
 handle_cast(reset_and_shutdown, State) ->
     %% to ensure that domains table is re-read from
     %% scratch, we must reset the last event id.
@@ -120,7 +120,7 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(check_for_updates, State) ->
-    {noreply, handle_check_for_updates(State)};
+    {noreply, handle_check_for_updates(State, false)};
 handle_info(Info, State) ->
     ?UNEXPECTED_INFO(Info),
     {noreply, State}.
@@ -148,19 +148,22 @@ initial_load(LastEventId) when is_integer(LastEventId) ->
     LastEventId. %% Skip initial init
 
 handle_check_for_updates(State = #{last_event_id := LastEventId,
-                                   check_for_updates_interval := Interval}) ->
-    maybe_cancel_timer(State),
+                                   check_for_updates_interval := Interval},
+                         IsInitial) ->
+    maybe_cancel_timer(IsInitial, State),
     receive_all_check_for_updates(),
     PageSize = 1000,
     LastEventId2 = mongoose_domain_loader:check_for_updates(LastEventId, PageSize),
     maybe_set_last_event_id(LastEventId, LastEventId2),
     TRef = erlang:send_after(Interval, self(), check_for_updates),
-    State#{last_event_id => LastEventId2, check_for_updates => TRef}.
+    State#{last_event_id => LastEventId2, check_for_updates_tref => TRef}.
 
-maybe_cancel_timer(#{check_for_updates_tref := TRef}) ->
-    erlang:cancel_timer(TRef);
-maybe_cancel_timer(_) ->
-    ok.
+maybe_cancel_timer(IsInitial, State) ->
+    TRef = maps:get(check_for_updates_tref, State, undefined),
+    case {IsInitial, TRef} of
+        {true, undefined} -> ok; %% TRef is not set the first time
+        {false, _} -> erlang:cancel_timer(TRef)
+    end.
 
 receive_all_check_for_updates() ->
     receive check_for_updates -> receive_all_check_for_updates() after 0 -> ok end.

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -153,6 +153,10 @@ init([]) ->
         {ejabberd_shaper_sup,
           {ejabberd_shaper_sup, start_link, []},
           permanent, infinity, supervisor, [ejabberd_shaper_sup]},
+    DomainSup =
+        {mongoose_domain_sup,
+         {mongoose_domain_sup, start_link, []},
+         permanent, infinity, supervisor, [mongoose_domain_sup]},
     {ok, {{one_for_one, 10, 1},
           [Hooks,
            Cleaner,
@@ -170,7 +174,8 @@ init([]) ->
            Listener,
            MucIQ,
            MAM,
-           ShaperSup]}}.
+           ShaperSup,
+           DomainSup]}}.
 
 start_child(ChildSpec) ->
     case supervisor:start_child(ejabberd_sup, ChildSpec) of


### PR DESCRIPTION
This PR addresses MIM-1470

Proposed changes include:
- Restart db service once domain core is down
- Add logging for initial sync
-  Add test demonstrating that Core process is restarted, but domain service is not


