### PR TITLE
Reset last_event_id once mongoose_domain_core starts

### DIFF
--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -130,6 +130,7 @@ get_start_args() ->
 %% gen_server callbacks
 %%--------------------------------------------------------------------
 init([Pairs, AllowedHostTypes]) ->
+    service_domain_db:reset_last_event_id(),
     ets:new(?TABLE, [set, named_table, protected, {read_concurrency, true}]),
     ets:new(?HOST_TYPE_TABLE, [set, named_table, protected, {read_concurrency, true}]),
     insert_host_types(?HOST_TYPE_TABLE, AllowedHostTypes),


### PR DESCRIPTION
This tells to the service, that it needs to read the complete database.
But it assumes that the service process is down, so it would not
overwrite the last_event_id we set here.

To ensure that the service is down if the core is down,
the core and service processes should be supervised with rest_for_one strategy.

Which should be done in a separate PR. Though, it does not required to fix the "join cluster" issue.

This PR addresses MIM-1470


