### PR TITLE
Inbox-muclight: fix system messages

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -112,82 +112,81 @@ tests() ->
     ].
 
 groups() ->
-    G = [
-         {generic, [parallel],
-          [
-           disco_service,
-           returns_valid_form,
-           returns_error_when_first_bad_form_field_encountered,
-           returns_error_when_bad_form_field_start_sent,
-           returns_error_when_bad_form_field_end_sent,
-           returns_error_when_bad_form_field_order_sent,
-           returns_error_when_bad_form_field_hidden_read_sent,
-           returns_error_when_bad_reset_field_jid,
-           returns_error_when_no_reset_field_jid,
-           returns_error_when_unknown_field_sent
-          ]},
-         {one_to_one, [parallel],
-          [
-           user_has_empty_inbox,
-           msg_sent_stored_in_inbox,
-           msg_with_no_store_is_not_stored_in_inbox,
-           msg_with_store_hint_is_always_stored,
-           carbons_are_not_stored,
-           user_has_two_conversations,
-           msg_sent_to_offline_user,
-           msg_sent_to_not_existing_user,
-           user_has_two_unread_messages,
-           other_resources_do_not_interfere,
-           reset_unread_counter_with_reset_chat_marker,
-           reset_unread_counter_with_reset_stanza,
-           try_to_reset_unread_counter_with_bad_marker,
-           non_reset_marker_should_not_affect_inbox,
-           user_has_only_unread_messages_or_only_read,
-           reset_unread_counter_and_show_only_unread,
-           check_total_unread_count_and_active_conv_count,
-           check_total_unread_count_when_there_are_no_active_conversations,
-           total_unread_count_and_active_convs_are_zero_at_no_activity
-          ]},
-         {muclight, [parallel],
-          [
-           simple_groupchat_stored_in_all_inbox,
-           advanced_groupchat_stored_in_all_inbox,
-           groupchat_markers_one_reset,
-           non_reset_marker_should_not_affect_muclight_inbox,
-           groupchat_reset_stanza_resets_inbox,
-           create_groupchat,
-           leave_and_remove_conversation,
-           groupchat_markers_one_reset_room_created,
-           groupchat_markers_all_reset_room_created
-          ]},
-         {muclight_config, [sequence],
-          [
-           create_groupchat_no_affiliation_stored,
-           leave_and_store_conversation,
-           no_aff_stored_and_remove_on_kicked,
-           no_stored_and_remain_after_kicked,
-           system_message_is_correctly_avoided
-          ]},
-         {muc, [parallel],
-          [
-           simple_groupchat_stored_in_all_inbox_muc,
-           simple_groupchat_stored_in_offline_users_inbox_muc,
-           unread_count_is_the_same_after_going_online_again,
-           unread_count_is_reset_after_sending_chatmarker,
-           non_reset_marker_should_not_affect_muc_inbox,
-           unread_count_is_reset_after_sending_reset_stanza,
-           private_messages_are_handled_as_one2one
-          ]},
-         {timestamps, [parallel],
-          [
-           timestamp_is_updated_on_new_message,
-           order_by_timestamp_ascending,
-           get_by_timestamp_range,
-           get_with_start_timestamp,
-           get_with_end_timestamp
-          ]}
-        ],
-    ct_helper:repeat_all_until_all_ok(G).
+    [
+     {generic, [parallel],
+      [
+       disco_service,
+       returns_valid_form,
+       returns_error_when_first_bad_form_field_encountered,
+       returns_error_when_bad_form_field_start_sent,
+       returns_error_when_bad_form_field_end_sent,
+       returns_error_when_bad_form_field_order_sent,
+       returns_error_when_bad_form_field_hidden_read_sent,
+       returns_error_when_bad_reset_field_jid,
+       returns_error_when_no_reset_field_jid,
+       returns_error_when_unknown_field_sent
+      ]},
+     {one_to_one, [parallel],
+      [
+       user_has_empty_inbox,
+       msg_sent_stored_in_inbox,
+       msg_with_no_store_is_not_stored_in_inbox,
+       msg_with_store_hint_is_always_stored,
+       carbons_are_not_stored,
+       user_has_two_conversations,
+       msg_sent_to_offline_user,
+       msg_sent_to_not_existing_user,
+       user_has_two_unread_messages,
+       other_resources_do_not_interfere,
+       reset_unread_counter_with_reset_chat_marker,
+       reset_unread_counter_with_reset_stanza,
+       try_to_reset_unread_counter_with_bad_marker,
+       non_reset_marker_should_not_affect_inbox,
+       user_has_only_unread_messages_or_only_read,
+       reset_unread_counter_and_show_only_unread,
+       check_total_unread_count_and_active_conv_count,
+       check_total_unread_count_when_there_are_no_active_conversations,
+       total_unread_count_and_active_convs_are_zero_at_no_activity
+      ]},
+     {muclight, [parallel],
+      [
+       simple_groupchat_stored_in_all_inbox,
+       advanced_groupchat_stored_in_all_inbox,
+       groupchat_markers_one_reset,
+       non_reset_marker_should_not_affect_muclight_inbox,
+       groupchat_reset_stanza_resets_inbox,
+       create_groupchat,
+       leave_and_remove_conversation,
+       groupchat_markers_one_reset_room_created,
+       groupchat_markers_all_reset_room_created
+      ]},
+     {muclight_config, [sequence],
+      [
+       create_groupchat_no_affiliation_stored,
+       leave_and_store_conversation,
+       no_aff_stored_and_remove_on_kicked,
+       no_stored_and_remain_after_kicked,
+       system_message_is_correctly_avoided
+      ]},
+     {muc, [parallel],
+      [
+       simple_groupchat_stored_in_all_inbox_muc,
+       simple_groupchat_stored_in_offline_users_inbox_muc,
+       unread_count_is_the_same_after_going_online_again,
+       unread_count_is_reset_after_sending_chatmarker,
+       non_reset_marker_should_not_affect_muc_inbox,
+       unread_count_is_reset_after_sending_reset_stanza,
+       private_messages_are_handled_as_one2one
+      ]},
+     {timestamps, [parallel],
+      [
+       timestamp_is_updated_on_new_message,
+       order_by_timestamp_ascending,
+       get_by_timestamp_range,
+       get_with_start_timestamp,
+       get_with_end_timestamp
+      ]}
+    ].
 
 suite() ->
     escalus:suite().

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -199,7 +199,7 @@ init_per_suite(Config) ->
     ok = dynamic_modules:ensure_modules(
            domain_helper:host_type(mim), inbox_modules()),
     ok = dynamic_modules:ensure_modules(
-           ct:get_config({hosts, mim, secondary_domain}),
+           ct:get_config({hosts, mim, secondary_host_type}),
            [{mod_inbox,
              [{aff_changes, false},
               {remove_on_kicked, true},
@@ -213,7 +213,7 @@ end_per_suite(Config) ->
     dynamic_modules:stop(
       domain_helper:host_type(mim), mod_inbox),
     dynamic_modules:stop(
-      ct:get_config({hosts, mim, secondary_domain}), mod_inbox),
+      ct:get_config({hosts, mim, secondary_host_type}), mod_inbox),
     escalus:end_per_suite(Config).
 
 init_per_group(one_to_one, Config) ->

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -145,10 +145,6 @@ write_to_inbox(HostType, RoomUser, Remote, _Sender, Packet, Acc) ->
 is_system_message(_HostType, #jid{lresource = <<>>}, _Receiver, _Packet) ->
     true;
 is_system_message(_HostType, #jid{lresource = _RoomUser}, _Receiver, _Packet) ->
-    false;
-is_system_message(_HostType, Sender, Receiver, Packet) ->
-    ?LOG_WARNING(#{what => inbox_muclight_unknown_message, packet => Packet,
-                   sender => jid:to_binary(Sender), receiver => jid:to_binary(Receiver)}),
     false.
 
 -spec is_change_aff_message(jid:jid(), exml:element(), role()) -> boolean().

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -142,19 +142,14 @@ write_to_inbox(HostType, RoomUser, Remote, _Sender, Packet, Acc) ->
                          Sender :: jid:jid(),
                          Receiver :: jid:jid(),
                          Packet :: exml:element()) -> boolean().
-is_system_message(HostType, Sender, Receiver, Packet) ->
-    ReceiverDomain = Receiver#jid.lserver,
-    MUCLightDomain = mod_muc_light:server_host_to_muc_host(HostType, ReceiverDomain),
-    case {Sender#jid.lserver, Sender#jid.lresource} of
-        {MUCLightDomain, <<>>} ->
-            true;
-        {MUCLightDomain, _RoomUser} ->
-            false;
-        _Other ->
-            ?LOG_WARNING(#{what => inbox_muclight_unknown_message, packet => Packet,
-                           sender => jid:to_binary(Sender), receiver => jid:to_binary(Receiver)})
-    end.
-
+is_system_message(_HostType, #jid{lresource = <<>>}, _Receiver, _Packet) ->
+    true;
+is_system_message(_HostType, #jid{lresource = _RoomUser}, _Receiver, _Packet) ->
+    false;
+is_system_message(_HostType, Sender, Receiver, Packet) ->
+    ?LOG_WARNING(#{what => inbox_muclight_unknown_message, packet => Packet,
+                   sender => jid:to_binary(Sender), receiver => jid:to_binary(Receiver)}),
+    false.
 
 -spec is_change_aff_message(jid:jid(), exml:element(), role()) -> boolean().
 is_change_aff_message(User, Packet, Role) ->
@@ -176,7 +171,7 @@ system_message_type(User, Packet) ->
             kick;
        true ->
             other
-            end.
+    end.
 
 -spec is_invitation_message(jid:jid(), exml:element()) -> boolean().
 is_invitation_message(User, Packet) ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -84,7 +84,7 @@
     default_config/1, default_schema_definition/0, disco_local_items/1,
     force_clear_from_ct/0, is_muc_room_owner/4, prevent_service_unavailable/4,
     process_iq_get/5, process_iq_set/4, remove_domain/3, remove_user/3,
-    set_module_opt_from_ct/3
+    set_module_opt_from_ct/3, server_host_to_muc_host/2
 ]).
 
 -type muc_server() :: jid:lserver().


### PR DESCRIPTION
This solution seems to be too simple to be true, but this is how I understand system messages in muclight. The other option is matching on them having a `<x>` subelement.