### PR TITLE
Fix @HOSTS@ to @HOST@

### DIFF
--- a/doc/modules/mod_event_pusher_push.md
+++ b/doc/modules/mod_event_pusher_push.md
@@ -80,7 +80,7 @@ option. `"pubsub.@HOSTS@"` is the default domain for `mod_pubsub`.
   backend.push.backend = "mnesia" # optional
   backend.push.wpool.workers = 200 # optional
   backend.push.plugin_module = "mod_event_pusher_push_plugin_defaults" # optional
-  backend.push.virtual_pubsub_hosts = ["pubsub.@HOSTS@"]
+  backend.push.virtual_pubsub_hosts = ["pubsub.@HOST@"]
 ```
 
 #### Advantages


### PR DESCRIPTION
Changes of documentation `virutal_pubsub_hosts` from @HOSTS@ to @HOST@

This PR addresses #

Proposed changes include:
* fix: typo for virtual_pubsub_hosts = ["vpubsub.@HOSTS@"] to ["vpubsub.@HOST@"] 

