### PR TITLE
Filter out only used users in mam_helper:serv_users/1

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -703,8 +703,8 @@ clean_room_archive(Config) ->
     Config.
 
 serv_users(Config) ->
-    [serv_user(Config, UserSpec)
-     || {_, UserSpec} <- escalus_users:get_users(all)].
+    Users = ?config(escalus_users, Config),
+    [serv_user(Config, UserSpec) || {_Tag, UserSpec} <- Users].
 
 serv_user(Config, UserSpec) ->
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),


### PR DESCRIPTION
So, we don't call remove_user if not needed

Proposed changes include:
* it does not call remove_user for non-existing test users. 
* Should be a bit faster to execute tests in mam_SUITE too.

This user gets filtered out, for example:

```
    {astrid, [
        {username, <<"astrid">>},
        {server, <<"sogndal">>},
        {host, <<"localhost">>},
        {password, <<"doctor">>}]},
```