### PR TITLE
Unify big test config templating for modules

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -256,8 +256,7 @@
   connection.tls.server_name_indication = false"},
       {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
-      {mod_private, "[modules.mod_private]
-  backend = \"rdbms\""},
+      {mod_private, "  backend = \"rdbms\""},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
@@ -276,8 +275,7 @@
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
       {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
-      {mod_private, "[modules.mod_private]
-  backend = \"rdbms\""},
+      {mod_private, "  backend = \"rdbms\""},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
@@ -306,8 +304,7 @@
   connection.tls.versions = [\"tlsv1.2\"]"},
       {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
-      {mod_private, "[modules.mod_private]
-  backend = \"rdbms\""},
+      {mod_private, "  backend = \"rdbms\""},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
@@ -371,8 +368,7 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
       {mod_last, "  backend = \"riak\""},
       {mod_privacy, "  backend = \"riak\""},
-      {mod_private, "[modules.mod_private]
-  backend = \"riak\""},
+      {mod_private, "  backend = \"riak\""},
       {mod_offline, "  backend = \"riak\"\n"},
       {mod_vcard, "  backend = \"riak\"
   host = \"vjud.@HOST@\""},

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -259,8 +259,7 @@
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
       {mod_offline, "  backend = \"rdbms\"\n"},
-      {mod_vcard, "[modules.mod_vcard]
-  backend = \"rdbms\"
+      {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
     {odbc_mssql_mnesia,
@@ -280,8 +279,7 @@
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
       {mod_offline, "  backend = \"rdbms\"\n"},
-      {mod_vcard, "[modules.mod_vcard]
-  backend = \"rdbms\"
+      {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
     {mysql_redis,
@@ -311,8 +309,7 @@
       {mod_private, "[modules.mod_private]
   backend = \"rdbms\""},
       {mod_offline, "  backend = \"rdbms\"\n"},
-      {mod_vcard, "[modules.mod_vcard]
-  backend = \"rdbms\"
+      {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\""},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
     {ldap_mnesia,
@@ -346,8 +343,7 @@
       {password_format, "password.format = \"scram\""},
       {auth_ldap, "ldap.base = \"ou=Users,dc=esl,dc=com\"
   ldap.filter = \"(objectClass=inetOrgPerson)\""},
-      {mod_vcard, "[modules.mod_vcard]
-  backend = \"ldap\"
+      {mod_vcard, "  backend = \"ldap\"
   host = \"vjud.@HOST@\"
   ldap_base = \"ou=Users,dc=esl,dc=com\"
   ldap_filter = \"(objectClass=inetOrgPerson)\""}]},
@@ -378,8 +374,7 @@
       {mod_private, "[modules.mod_private]
   backend = \"riak\""},
       {mod_offline, "  backend = \"riak\"\n"},
-      {mod_vcard, "[modules.mod_vcard]
-  backend = \"riak\"
+      {mod_vcard, "  backend = \"riak\"
   host = \"vjud.@HOST@\""},
       {mod_roster, "  backend = \"riak\"\n"}
      ]},

--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -5,12 +5,20 @@
          insert_domain/3,
          delete_domain/2,
          make_metrics_prefix/1,
+         host_types/0,
+         host_types/1,
          host_type/0,
          host_type/1,
          secondary_host_type/0,
          secondary_host_type/1]).
 
 -import(distributed_helper, [get_or_fail/1, rpc/4, mim/0]).
+
+host_types() ->
+    host_types(mim).
+
+host_types(NodeKey) ->
+    lists:usort([host_type(NodeKey), secondary_host_type(NodeKey)]).
 
 host_type() ->
     host_type(mim).

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -2,8 +2,8 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--export([save_modules_for_host_types/2]).
--export([save_modules/2, ensure_modules/2, ensure_stopped/2,
+-export([save_modules_for_host_types/2,
+         save_modules/2, get_saved_config/3, ensure_modules/2, ensure_stopped/2,
          restore_modules/2, restore_modules/1]).
 -export([stop/2, stop/3, start/3, start/4, restart/3, stop_running/2, start_running/1]).
 
@@ -18,6 +18,10 @@ save_modules_for_host_types([], Config) ->
 
 save_modules(HostType, Config) ->
     [{{saved_modules, HostType}, get_current_modules(HostType)} | Config].
+
+get_saved_config(HostType, Module, Config) ->
+    SavedModules = proplists:get_value({saved_modules, HostType}, Config),
+    proplists:get_value(Module, SavedModules).
 
 ensure_modules(HostType, RequiredModules) ->
     CurrentModules = get_current_modules(HostType),

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -46,7 +46,6 @@
 -export([should_minio_be_running/1]).
 -export([new_mongoose_acc/1]).
 -export([print_debug_info_for_module/1]).
--export([get_vcard_config/1]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
@@ -513,13 +512,8 @@ should_minio_be_running(Config) ->
 
 %% It is useful to debug dynamic IQ handler registration
 print_debug_info_for_module(Module) ->
-    ModConfig = rpc(mim(), gen_mod, hosts_and_opts_with_module, [mod_vcard]),
+    ModConfig = rpc(mim(), gen_mod, hosts_and_opts_with_module, [Module]),
     IqConfig = rpc(mim(), ets, tab2list, [sm_iqtable]),
     ct:pal("hosts_and_opts=~p~n iq_handlers=~p~n",
            [ModConfig, IqConfig]).
 
-get_vcard_config(Config) ->
-    HostType = domain_helper:host_type(),
-    CurrentConfigs = rpc(mim(), gen_mod, loaded_modules_with_opts, [HostType]),
-    {mod_vcard, CurrentVcardConfig} = lists:keyfind(mod_vcard, 1, CurrentConfigs),
-    CurrentVcardConfig.

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -519,19 +519,7 @@ print_debug_info_for_module(Module) ->
            [ModConfig, IqConfig]).
 
 get_vcard_config(Config) ->
-    Preset = proplists:get_value(preset, Config, undefined),
-    Backend = preset_to_vcard_backend(Preset),
-    [{backend, Backend}, {host, {prefix, <<"vjud.">>}}]
-    ++ vcard_backend_specific_options(Backend).
-
-vcard_backend_specific_options(ldap) ->
-    [{ldap_base, "ou=Users,dc=esl,dc=com"},
-     {ldap_filter, "(objectClass=inetOrgPerson)"}];
-vcard_backend_specific_options(_) ->
-    [].
-
-preset_to_vcard_backend("ldap_mnesia") -> ldap;
-preset_to_vcard_backend("riak_mnesia") -> riak;
-preset_to_vcard_backend("internal_mnesia") -> mnesia;
-preset_to_vcard_backend("elasticsearch_and_cassandra_mnesia") -> mnesia;
-preset_to_vcard_backend(_) -> rdbms.
+    HostType = domain_helper:host_type(),
+    CurrentConfigs = rpc(mim(), gen_mod, loaded_modules_with_opts, [HostType]),
+    {mod_vcard, CurrentVcardConfig} = lists:keyfind(mod_vcard, 1, CurrentConfigs),
+    CurrentVcardConfig.

--- a/big_tests/tests/private_SUITE.erl
+++ b/big_tests/tests/private_SUITE.erl
@@ -45,8 +45,6 @@ suite() ->
     escalus:suite().
 
 init_per_suite(Config) ->
-    HostType = domain_helper:host_type(mim),
-    ok = dynamic_modules:ensure_modules(HostType, private_modules(HostType)),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
@@ -63,19 +61,6 @@ init_per_testcase(CaseName, Config) ->
 
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
-
-private_modules(HostType) ->
-    [{mod_private, [{backend, mod_private_backend(HostType)}]}].
-
-mod_private_backend(HostType) ->
-    case mam_helper:is_riak_enabled(HostType) of
-        true -> riak;
-        false ->
-            case mongoose_helper:is_rdbms_enabled(HostType) of
-                true -> rdbms;
-                false -> mnesia
-            end
-    end.
 
 %%--------------------------------------------------------------------
 %% Private storage tests

--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -35,6 +35,8 @@
                              require_rpc_nodes/1,
                              subhost_pattern/1,
                              rpc/4]).
+-import(domain_helper, [host_type/0,
+                        host_types/0]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -466,12 +468,9 @@ prepare_vcard_module(Config) ->
     %% Keep the old config, so we can undo our changes, once finished testing
     Config1 = dynamic_modules:save_modules_for_host_types(host_types(), Config),
     %% Get a list of options, we can use as a prototype to start new modules
-    [{mod_vcard_opts, mongoose_helper:get_vcard_config(Config)} | Config1].
-
-host_types() ->
-    HostType = ct:get_config({hosts, mim, host_type}),
-    SecHostType = ct:get_config({hosts, mim, secondary_host_type}),
-    lists:usort([HostType, SecHostType]).
+    HostType = domain_helper:host_type(),
+    VCardOpts = dynamic_modules:get_saved_config(host_type(), mod_vcard, Config1),
+    [{mod_vcard_opts, VCardOpts} | Config1].
 
 restore_vcard_module(Config) ->
     dynamic_modules:restore_modules(Config).

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -248,6 +248,7 @@
 {{{mod_blocking}}}
 {{/mod_blocking}}
 {{#mod_private}}
+[modules.mod_private]
 {{{mod_private}}}
 
 {{/mod_private}}

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -266,8 +266,8 @@
 [modules.mod_sic]
 
 {{#mod_vcard}}
+[modules.mod_vcard]
 {{{mod_vcard}}}
-
 {{/mod_vcard}}
 [modules.mod_bosh]
 

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -213,8 +213,8 @@
 [modules.mod_adhoc]
 
 {{#mod_amp}}
+[modules.mod_amp]
 {{{mod_amp}}}
-
 {{/mod_amp}}
 [modules.mod_disco]
   users_can_see_hidden_services = false

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -52,7 +52,11 @@
   {{#mod_blocking}}
   [host_config.modules.mod_blocking]
   {{{mod_blocking}}}
-  {{/mod_blocking}}"}.
+  {{/mod_blocking}}
+  {{#mod_vcard}}
+  [host_config.modules.mod_vcard]
+  {{{mod_vcard}}}
+  {{/mod_vcard}}"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
 {scram_iterations, 64}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -105,8 +105,7 @@
 
 {mod_amp, "[modules.mod_amp]"}.
 {mod_cache_users, "  time_to_live = 2
-  number_of_segments = 5
-"}.
+  number_of_segments = 5"}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -49,6 +49,10 @@
   [host_config.modules.mod_privacy]
   {{{mod_privacy}}}
   {{/mod_privacy}}
+  {{#mod_private}}
+  [host_config.modules.mod_private]
+  {{{mod_private}}}
+  {{/mod_private}}
   {{#mod_blocking}}
   [host_config.modules.mod_blocking]
   {{{mod_blocking}}}
@@ -100,7 +104,6 @@
   password = \"secret\""}.
 
 {mod_amp, "[modules.mod_amp]"}.
-{mod_private, "[modules.mod_private]"}.
 {mod_cache_users, "  time_to_live = 2
   number_of_segments = 5
 "}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -10,6 +10,7 @@
 
 {mod_privacy, ""}.
 {mod_blocking, ""}.
+{mod_amp, ""}.
 {host_config,
   "[[host_config]]
   host = \"anonymous.localhost\"
@@ -103,7 +104,6 @@
   ip_address = \"127.0.0.1\"
   password = \"secret\""}.
 
-{mod_amp, "[modules.mod_amp]"}.
 {mod_cache_users, "  time_to_live = 2
   number_of_segments = 5"}.
 {zlib, "10_000"}.

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -28,8 +28,7 @@
 {mod_blocking, ""}.
 {mod_private, "[modules.mod_private]"}.
 {mod_roster, ""}.
-{mod_vcard, "[modules.mod_vcard]
-  host = \"vjud.@HOST@\""}.
+{mod_vcard, "  host = \"vjud.@HOST@\""}.
 {sm_backend, "\"mnesia\""}.
 {auth_method, "\"internal\""}.
 {cyrsasl_external, "\"standard\""}.

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -26,7 +26,7 @@
 {mod_offline, ""}.
 {mod_privacy, ""}.
 {mod_blocking, ""}.
-{mod_private, "[modules.mod_private]"}.
+{mod_private, ""}.
 {mod_roster, ""}.
 {mod_vcard, "  host = \"vjud.@HOST@\""}.
 {sm_backend, "\"mnesia\""}.


### PR DESCRIPTION
Improve the consistency of the module config templates used for tests.

Use `test.config` options for static and dynamic domains and do not repeat the same configuration in test suites.
This applies to two modules recently converted to use dynamic domains: `mod_private` and `mod_vcard`.
