### PR TITLE
Fix run hook(xmpp_send_element) with undefined host_type for c2s

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1651,6 +1651,9 @@ send_element_from_server_jid(Acc, StateData, #xmlel{} = El) ->
 
 %% @doc This is the termination point - from here stanza is sent to the user
 -spec send_element(mongoose_acc:t(), exml:element(), state()) -> mongoose_acc:t().
+send_element(Acc, El, #state{host_type = undefined} = StateData) ->
+    Res = do_send_element(El, StateData),
+    mongoose_acc:set(c2s, send_result, Res, Acc);
 send_element(Acc, El, #state{host_type = HostType} = StateData) ->
     Acc1 = mongoose_hooks:xmpp_send_element(HostType, Acc, El),
     Res = do_send_element(El, StateData),

--- a/test/ejabberd_c2s_SUITE.erl
+++ b/test/ejabberd_c2s_SUITE.erl
@@ -44,10 +44,14 @@ c2s_start_stop_test(_) ->
 
 
 stream_error_when_invalid_domain(_) ->
+    ok = meck:new(mongoose_hooks, [passthrough]),
     {ok, C2SPid} = given_c2s_started(),
 
     C2Sactions = when_stream_is_opened(C2SPid, stream_header(<<"badhost">>)),
     [StreamStart, StreamError, StreamEnd, CloseSocket] = C2Sactions,
+    History = meck:history(mongoose_hooks),
+    HookRes = [ok || {_, {mongoose_hooks, xmpp_send_element, [undefined, #{host_type := undefined} | _]}, _} <- History],
+    ?am([], HookRes),
     ?am({send, [_P,
          <<"<?xml version='1.0'?>",
              "<stream:stream xmlns='jabber:client' ",


### PR DESCRIPTION
When hook runs for an undefined host type, which causes the following error:
```erlang
when=2021-08-10T08:10:43.253721+00:00 level=error what=undefined_host_type pid=<0.18221.0> at=mongoose_hooks:run_hook_for_host_type/4:1465 text="Running hook for an undefined host type" hook_name=xmpp_send_element hook_args="[{xmlel,<<\"stream:error\">>,[],[{xmlel,<<\"host-unknown\">>,[{<<\"xmlns\">>,<<\"urn:ietf:params:xml:ns:xmpp-streams\">>}],[]}]}]" hook_acc_timestamp=1628583043253572 hook_acc_stanza_type=undefined hook_acc_stanza_to_jid=undefined hook_acc_stanza_ref=#Ref<0.2319972469.246677507.66886> hook_acc_stanza_name=stream:error hook_acc_stanza_from_jid="{jid,<<>>,<<\"test-domain-50005\">>,<<>>,<<>>,<<\"test-domain-50005\">>,<<>>}" hook_acc_stanza_element="{xmlel,<<\"stream:error\">>,[],[{xmlel,<<\"host-unknown\">>,[{<<\"xmlns\">>,<<\"urn:ietf:params:xml:ns:xmpp-streams\">>}],[]}]}" hook_acc_ref=#Ref<0.2319972469.246677507.66887> hook_acc_origin_stanza="<stream:error><host-unknown xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>" hook_acc_origin_pid=<0.18221.0> hook_acc_origin_location_mfa={ejabberd_c2s,send_element_from_server_jid,3} hook_acc_origin_location_line=1643 hook_acc_origin_location_file=/home/circleci/app/src/ejabberd_c2s.erl hook_acc_non_strippable= hook_acc_mongoose_acc=true hook_acc_lserver=test-domain-50005 hook_acc_host_type=undefined
```