### PR TITLE
Route accumulator

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2309,9 +2309,9 @@ process_privacy_iq(Acc, set, To, StateData) ->
                                          From, To, IQ),
     case mongoose_acc:get(hook, result, undefined, Acc2) of
         {result, _, NewPrivList} ->
-            Acc3 = maybe_update_presence(Acc2, StateData, NewPrivList),
+            maybe_update_presence(Acc2, StateData, NewPrivList),
             NState = StateData#state{privacy_list = NewPrivList},
-            {Acc3, NState};
+            {Acc2, NState};
         _ -> {Acc2, StateData}
     end.
 

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -136,9 +136,10 @@ socket_type() ->
 %%%----------------------------------------------------------------------
 
 -spec process_packet(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
-    El :: exml:element(), #{pid := pid()}) -> any().
+    El :: exml:element(), #{pid := pid()}) -> mongoose_acc:t().
 process_packet(Acc, From, To, _El, #{pid := Pid}) ->
-    Pid ! {route, From, To, Acc}.
+    Pid ! {route, From, To, Acc},
+    Acc.
 
 %%%----------------------------------------------------------------------
 %%% Callback functions from gen_fsm

--- a/src/mod_dynamic_domains_test.erl
+++ b/src/mod_dynamic_domains_test.erl
@@ -3,6 +3,8 @@
 -include("mongoose_config_spec.hrl").
 -include("jlib.hrl").
 
+-behaviour(mongoose_packet_handler).
+
 %% API
 -export([start/2, stop/1,
          config_spec/0,
@@ -88,10 +90,10 @@ stop(HostType) ->
     ok.
 
 -spec process_packet(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
-                     El :: exml:element(), Extra :: map()) -> any().
-process_packet(_Acc, _From, _To, _El, _Extra) ->
+                     El :: exml:element(), Extra :: map()) -> mongoose_acc:t().
+process_packet(Acc, _From, _To, _El, _Extra) ->
     %% do nothing, just ignore the packet
-    ok.
+    Acc.
 
 -spec process_iq(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
                  IQ :: jlib:iq(), Extra :: map()) -> {NewAcc :: mongoose_acc:t(),

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -590,7 +590,7 @@ stop_supervisor(HostType) ->
                      From :: jid:jid(),
                      To :: jid:simple_jid() | jid:jid(),
                      El :: exml:element(),
-                     #{state := state()}) -> ok | mongoose_acc:t().
+                     #{state := state()}) -> mongoose_acc:t().
 process_packet(Acc, From, To, El, #{state := State}) ->
     {AccessRoute, _, _, _} = State#state.access,
     ServerHost = make_server_host(To, State),
@@ -598,7 +598,8 @@ process_packet(Acc, From, To, El, #{state := State}) ->
     case acl:match_rule_for_host_type(HostType, ServerHost, AccessRoute, From) of
         allow ->
             {Room, MucHost, _} = jid:to_lower(To),
-            route_to_room(MucHost, Room, {From, To, Acc, El}, State);
+            route_to_room(MucHost, Room, {From, To, Acc, El}, State),
+            Acc;
         _ ->
             #xmlel{attrs = Attrs} = El,
             Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
@@ -731,9 +732,9 @@ route_by_nick(_Nick, {From, To, Acc, Packet}, _State) ->
     #xmlel{attrs = Attrs} = Packet,
     case xml:get_attr_s(<<"type">>, Attrs) of
         <<"error">> ->
-            ok;
+            Acc;
         <<"result">> ->
-            ok;
+            Acc;
         _ ->
             {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:item_not_found()),
             ejabberd_router:route(To, From, Acc1, Err)

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -377,9 +377,10 @@ process_search_reported_spec(KVs) ->
 %%--------------------------------------------------------------------
 
 -spec process_packet(Acc :: mongoose_acc:t(), From ::jid:jid(), To ::jid:jid(),
-                     Packet :: exml:element(), #{pid := pid()}) -> any().
+                     Packet :: exml:element(), #{pid := pid()}) -> mongoose_acc:t().
 process_packet(Acc, From, To, Packet, #{pid := Pid}) ->
-    Pid ! {route, From, To, Acc, Packet}.
+    Pid ! {route, From, To, Acc, Packet},
+    Acc.
 
 handle_route(From, To, Acc, HostType) ->
     {IQ, Acc1} = mongoose_iq:info(Acc),

--- a/src/mongoose_local_delivery.erl
+++ b/src/mongoose_local_delivery.erl
@@ -7,7 +7,6 @@
 -module(mongoose_local_delivery).
 -author('bartlomiej.gorny@erlang-solutions.com').
 
--include("mongoose.hrl").
 -include("jlib.hrl").
 
 %% API
@@ -27,10 +26,11 @@ do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, Handler) ->
             %% This can happen e.g. for external components
             %% No handlers can be registered for filter_local_packet in this case
             Acc = mongoose_acc:strip(#{lserver => LDstDomain,
-                                        from_jid => OrigFrom,
-                                        to_jid => OrigTo,
-                                        element => OrigPacket}, OrigAcc),
-            mongoose_packet_handler:process(Handler, Acc, OrigFrom, OrigTo, OrigPacket);
+                                       from_jid => OrigFrom,
+                                       to_jid => OrigTo,
+                                       element => OrigPacket}, OrigAcc),
+            Acc1 = mongoose_packet_handler:process(Handler, Acc, OrigFrom, OrigTo, OrigPacket),
+            restore_acc_fields(OrigAcc, Acc1);
         {ok, HostType} ->
             Acc0 = mongoose_acc:strip(#{lserver => LDstDomain,
                                         host_type => HostType,
@@ -42,10 +42,16 @@ do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, Handler) ->
                     Acc1 = mongoose_acc:update_stanza(#{from_jid => From,
                                                         to_jid => To,
                                                         element => Packet}, Acc),
-                    mongoose_packet_handler:process(Handler, Acc1, From, To, Packet);
+                    Acc2 = mongoose_packet_handler:process(Handler, Acc1, From, To, Packet),
+                    restore_acc_fields(OrigAcc, Acc2);
                 drop ->
                     mongoose_hooks:xmpp_stanza_dropped(Acc0, OrigFrom,
                                                        OrigTo, OrigPacket),
                     Acc0
             end
     end.
+
+restore_acc_fields(OrigAcc, Acc) ->
+    HostType = mongoose_acc:host_type(OrigAcc),
+    LServer = mongoose_acc:lserver(OrigAcc),
+    Acc#{host_type := HostType, lserver := LServer}.

--- a/src/mongoose_local_delivery.erl
+++ b/src/mongoose_local_delivery.erl
@@ -13,7 +13,12 @@
 %% API
 -export([do_route/5]).
 
-
+-spec do_route(jid:jid(),
+               jid:jid(),
+               mongoose_acc:t(),
+               exml:element(),
+               mongoose_packet_handler:t()) ->
+    mongoose_acc:t().
 do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, Handler) ->
     % strip acc from all sender-related values, from now on we are interested in the recipient
     LDstDomain = OrigTo#jid.lserver,
@@ -41,6 +46,6 @@ do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, Handler) ->
                 drop ->
                     mongoose_hooks:xmpp_stanza_dropped(Acc0, OrigFrom,
                                                        OrigTo, OrigPacket),
-                    ok
+                    Acc0
             end
     end.

--- a/src/mongoose_packet_handler.erl
+++ b/src/mongoose_packet_handler.erl
@@ -28,7 +28,7 @@
 %%----------------------------------------------------------------------
 
 -callback process_packet(Acc :: mongoose_acc:t(), From ::jid:jid(), To ::jid:jid(),
-                         El :: exml:element(), Extra :: map()) -> any().
+                         El :: exml:element(), Extra :: map()) -> mongoose_acc:t().
 
 %%----------------------------------------------------------------------
 %% API
@@ -52,7 +52,7 @@ new(Module, Extra) when is_atom(Module), is_map(Extra) ->
               Acc :: mongoose_acc:t(),
               From ::jid:jid(),
               To ::jid:jid(),
-              El :: exml:element()) -> any().
+              El :: exml:element()) -> mongoose_acc:t().
 process(#packet_handler{ module = Module, extra = Extra }, Acc, From, To, El) ->
     Module:process_packet(Acc, From, To, El, Extra).
 

--- a/src/mongoose_router_dynamic_domains.erl
+++ b/src/mongoose_router_dynamic_domains.erl
@@ -13,9 +13,7 @@
 
 -behaviour(xmpp_router).
 
--include("mongoose.hrl").
 -include("jlib.hrl").
--include("route.hrl").
 
 %% API
 %% xmpp_router callback

--- a/src/mongoose_router_external.erl
+++ b/src/mongoose_router_external.erl
@@ -10,7 +10,6 @@
 
 -behaviour(xmpp_router).
 
--include("mongoose.hrl").
 -include("jlib.hrl").
 -include("external_component.hrl").
 %% xmpp_router callback
@@ -19,12 +18,12 @@
 filter(OrigFrom, OrigTo, OrigAcc, OrigPacket) ->
     {OrigFrom, OrigTo, OrigAcc, OrigPacket}.
 
-route(From, To, Acc, Packet) ->
+route(From, To, Acc0, Packet) ->
     LDstDomain = To#jid.lserver,
     case ejabberd_router:lookup_component(LDstDomain) of
         [] ->
-            {From, To, Acc, Packet};
+            {From, To, Acc0, Packet};
         [#external_component{handler = Handler}|_] -> %% may be multiple on various nodes
-            mongoose_local_delivery:do_route(From, To, Acc, Packet, Handler),
-            done
+            Acc1 = mongoose_local_delivery:do_route(From, To, Acc0, Packet, Handler),
+            {done, Acc1}
     end.

--- a/src/mongoose_router_external_localnode.erl
+++ b/src/mongoose_router_external_localnode.erl
@@ -8,10 +8,8 @@
 -module(mongoose_router_external_localnode).
 -author('bartlomiej.gorny@erlang-solutions.com').
 
-
 -behaviour(xmpp_router).
 
--include("mongoose.hrl").
 -include("jlib.hrl").
 -include("external_component.hrl").
 
@@ -21,12 +19,12 @@
 filter(OrigFrom, OrigTo, OrigAcc, OrigPacket) ->
     {OrigFrom, OrigTo, OrigAcc, OrigPacket}.
 
-route(From, To, Acc, Packet) ->
+route(From, To, Acc0, Packet) ->
     LDstDomain = To#jid.lserver,
     case ejabberd_router:lookup_component(LDstDomain, node()) of
         [] ->
-            {From, To, Acc, Packet};
+            {From, To, Acc0, Packet};
         [#external_component{handler = Handler}] ->
-            mongoose_local_delivery:do_route(From, To, Acc, Packet, Handler),
-            done
+            Acc1 = mongoose_local_delivery:do_route(From, To, Acc0, Packet, Handler),
+            {done, Acc1}
     end.

--- a/src/mongoose_router_global.erl
+++ b/src/mongoose_router_global.erl
@@ -10,8 +10,6 @@
 
 -behaviour(xmpp_router).
 
--include("mongoose.hrl").
-
 %% xmpp_router callback
 -export([filter/4, route/4]).
 

--- a/src/mongoose_router_localdomain.erl
+++ b/src/mongoose_router_localdomain.erl
@@ -9,7 +9,6 @@
 
 -behaviour(xmpp_router).
 
--include("mongoose.hrl").
 -include("jlib.hrl").
 -include("route.hrl").
 
@@ -20,11 +19,11 @@
 filter(From, To, Acc, Packet) ->
     {From, To, Acc, Packet}.
 
-route(From, To, Acc, Packet) ->
+route(From, To, Acc0, Packet) ->
     LDstDomain = To#jid.lserver,
     case mnesia:dirty_read(route, LDstDomain) of
-        [] -> {From, To, Acc, Packet};
+        [] -> {From, To, Acc0, Packet};
         [#route{handler = Handler}] ->
-            mongoose_local_delivery:do_route(From, To, Acc, Packet, Handler),
-            done
+            Acc1 = mongoose_local_delivery:do_route(From, To, Acc0, Packet, Handler),
+            {done, Acc1}
     end.

--- a/src/muc_light/mod_muc_light_codec.erl
+++ b/src/muc_light/mod_muc_light_codec.erl
@@ -17,7 +17,7 @@
 -ignore_xref([behaviour_info/1]).
 
 -type encoded_packet_handler() ::
-    fun((From :: jid:jid(), To :: jid:jid(), Packet :: exml:element()) -> any()).
+    fun((From :: jid:jid(), To :: jid:jid(), Packet :: exml:element()) -> mongoose_acc:t()).
 
 -type decode_result() :: {ok, muc_light_packet() | muc_light_disco() | jlib:iq()}
                        | {error, bad_request} | ignore.
@@ -35,11 +35,11 @@
 -callback encode(Request :: muc_light_encode_request(), OriginalSender :: jid:jid(),
                  RoomUS :: jid:simple_bare_jid(), % may be just service domain
                  HandleFun :: encoded_packet_handler(),
-                 Acc :: mongoose_acc:t()) -> any().
+                 Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 
 -callback encode_error(ErrMsg :: tuple(), OrigFrom :: jid:jid(), OrigTo :: jid:jid(),
                        OrigPacket :: exml:element(), HandleFun :: encoded_packet_handler()) ->
-    any().
+    mongoose_acc:t().
 
 %%====================================================================
 %% API
@@ -47,7 +47,7 @@
 
 -spec encode_error(ErrMsg :: tuple(), ExtraChildren :: [jlib:xmlch()], OrigFrom :: jid:jid(),
                    OrigTo :: jid:jid(), OrigPacket :: exml:element(),
-                   HandleFun :: encoded_packet_handler()) -> any().
+                   HandleFun :: encoded_packet_handler()) -> mongoose_acc:t().
 encode_error(ErrMsg, ExtraChildren, OrigFrom, OrigTo, OrigPacket, HandleFun) ->
     ErrorElem = make_error_elem(ErrMsg),
     ErrorPacket = jlib:make_error_reply(OrigPacket#xmlel{ children = ExtraChildren }, ErrorElem),

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -46,7 +46,7 @@ decode(_, _, _, _Acc) ->
 -spec encode(Request :: muc_light_encode_request(),
              OriginalSender :: jid:jid(), RoomUS :: jid:simple_bare_jid(),
              HandleFun :: mod_muc_light_codec:encoded_packet_handler(),
-             Acc :: mongoose_acc:t()) -> any().
+             Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc) ->
     US = jid:to_lus(Sender),
     Aff = get_sender_aff(AffUsers, US),
@@ -64,12 +64,14 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc
                   affiliation => Aff,
                   role => mod_muc_light_utils:light_aff_to_muc_role(Aff)},
     HostType = mod_muc_light_utils:acc_to_host_type(Acc),
-    #xmlel{ children = Children }
+    Packet1 = #xmlel{ children = Children }
         = mongoose_hooks:filter_room_packet(HostType, MsgForArch, EventData),
     lists:foreach(
       fun({{U, S}, _}) ->
               send_to_aff_user(RoomJID, U, S, <<"message">>, Attrs, Children, HandleFun)
-      end, AffUsers);
+      end, AffUsers),
+    mongoose_acc:update_stanza(#{from_jid => RoomJID,
+                                 element => Packet1}, Acc);
 encode(OtherCase, Sender, RoomUS, HandleFun, Acc) ->
     {RoomJID, RoomBin} = jids_from_room_with_resource(RoomUS, <<>>),
     case encode_meta(OtherCase, RoomJID, Sender, HandleFun, Acc) of
@@ -80,13 +82,13 @@ encode(OtherCase, Sender, RoomUS, HandleFun, Acc) ->
             IQRes = make_iq_result(RoomBin, jid:to_binary(Sender), ID, XMLNS, Els),
             HandleFun(RoomJID, Sender, IQRes);
         noreply ->
-            ok
+            Acc
     end.
 
 -spec encode_error(
         ErrMsg :: tuple(), OrigFrom :: jid:jid(), OrigTo :: jid:jid(),
         OrigPacket :: exml:element(), HandleFun :: mod_muc_light_codec:encoded_packet_handler()) ->
-    any().
+    mongoose_acc:t().
 encode_error(_, OrigFrom, OrigTo, #xmlel{ name = <<"presence">> } = OrigPacket, HandleFun) ->
     %% The only error case for valid presence is registration-required for room creation
     X = #xmlel{ name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_MUC}] },

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -71,6 +71,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc
               send_to_aff_user(RoomJID, U, S, <<"message">>, Attrs, Children, HandleFun)
       end, AffUsers),
     mongoose_acc:update_stanza(#{from_jid => RoomJID,
+                                 to_jid => jid:make_noprep(RoomU, RoomS, <<>>),
                                  element => Packet1}, Acc);
 encode(OtherCase, Sender, RoomUS, HandleFun, Acc) ->
     {RoomJID, RoomBin} = jids_from_room_with_resource(RoomUS, <<>>),

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -75,6 +75,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc
               msg_to_aff_user(RoomJID, U, S, Attrs, Children, HandleFun)
       end, AffUsers),
     mongoose_acc:update_stanza(#{from_jid => RoomJID,
+                                 to_jid => jid:make_noprep(RoomU, RoomS, <<>>),
                                  element => Packet1}, Acc);
 encode(OtherCase, Sender, RoomUS, HandleFun, Acc) ->
     {RoomJID, RoomBin} = jids_from_room_with_resource(RoomUS, <<>>),

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -53,7 +53,7 @@
 %%====================================================================
 
 -spec handle_request(From :: jid:jid(), RoomJID :: jid:jid(), OrigPacket :: exml:element(),
-                     Request :: muc_light_packet(), Acc :: mongoose_acc:t()) -> ok.
+                     Request :: muc_light_packet(), Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_request(From, To, OrigPacket, Request, Acc) ->
     RoomUS = jid:to_lus(To),
     AffUsersRes = mod_muc_light_db_backend:get_aff_users(RoomUS),
@@ -253,7 +253,7 @@ process_aff_set(_AffReq, _RoomUS, Error, _Acc) ->
 
 -spec send_response(From :: jid:jid(), RoomJID :: jid:jid(),
                     RoomUS :: jid:simple_bare_jid(), OrigPacket :: exml:element(),
-                    Result :: packet_processing_result(), Acc :: mongoose_acc:t()) -> ok.
+                    Result :: packet_processing_result(), Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 send_response(From, RoomJID, _RoomUS, OrigPacket, {error, _} = Err, _Acc) ->
     mod_muc_light_codec_backend:encode_error(
       Err, From, RoomJID, OrigPacket, fun ejabberd_router:route/3);

--- a/src/xmpp_router.erl
+++ b/src/xmpp_router.erl
@@ -10,14 +10,11 @@
 %%%-------------------------------------------------------------------
 -module(xmpp_router).
 
--include("mongoose.hrl").
--include("jlib.hrl").
-
 -ignore_xref([behaviour_info/1]).
 
 -callback route(From :: jid:jid(), To :: jid:jid(),
-                   Acc :: mongoose_acc:t(), Packet :: exml:element()) ->
-    done | {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
+                Acc :: mongoose_acc:t(), Packet :: exml:element()) ->
+    {done, mongoose_acc:t()} | {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
 
 -callback filter(From :: jid:jid(), To :: jid:jid(),
     Acc :: mongoose_acc:t(), Packet :: exml:element()) ->
@@ -28,10 +25,9 @@
 
 -spec call_route(Module :: module(), From :: jid:jid(),
     To :: jid:jid(), Acc :: mongoose_acc:t(), Packet :: exml:element()) ->
-    done | {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
+    {done, mongoose_acc:t()} | {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
 call_route(Module, From, To, Acc, Packet) ->
     Module:route(From, To, Acc, Packet).
-
 
 -spec call_filter(Module :: module(), From :: jid:jid(),
     To :: jid:jid(), Acc :: mongoose_acc:t(), Packet :: exml:element()) ->

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -151,9 +151,9 @@ setup_routing_module(Name, PacketToDrop, PacketToRoute) ->
 make_routing_fun(Name, all) ->
     Self = self(),
     Marker = list_to_atom([lists:last(atom_to_list(Name))]),
-    fun(_From, _To, _Acc, Packet) ->
+    fun(_From, _To, Acc, Packet) ->
         Self ! {Marker, Packet},
-        done
+        {done, Acc}
     end;
 make_routing_fun(Name, PacketToRoute) ->
     Self = self(),
@@ -162,7 +162,7 @@ make_routing_fun(Name, PacketToRoute) ->
         case msg_to_id(Packet) of
             PacketToRoute ->
                 Self ! {Marker, Packet},
-                done;
+                {done, Acc};
             _ -> {From, To, Acc, Packet}
         end
     end.
@@ -219,5 +219,5 @@ remove_component_tables() ->
 
 resend_as_error(From0, To0, Acc0, Packet0) ->
     {Acc1, Packet1} = jlib:make_error_reply(Acc0, Packet0, #xmlel{}),
-    ejabberd_router:route(To0, From0, Acc1, Packet1),
-    done.
+    Acc2 = ejabberd_router:route(To0, From0, Acc1, Packet1),
+    {done, Acc2}.


### PR DESCRIPTION
I'd like all routing to pass the accumulator along, with whatever modifications are needed like stripping it or updating the routed element. This will help with tracing the routing mechanism from start to end, if at all times the accumulator is preserved. It will also for example give me at the caller site, information about the packet handler's handling, like what muclight or pubsub did with the package. Then it is up to the caller to inspect the accumulator.