### PR TITLE
Test commands with dynamic domains

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -53,6 +53,8 @@
 
 {suites, "tests", race_conditions_SUITE}.
 
+{suites, "tests", rest_SUITE}.
+
 {suites, "tests", rest_client_SUITE}.
 {skip_cases, "tests", rest_client_SUITE,
  [non_default_http_server_name_is_returned_if_configured],

--- a/big_tests/tests/dynamic_domains_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_SUITE.erl
@@ -11,7 +11,7 @@
 -define(TEST_NODES, [mim() | ?CLUSTER_NODES]).
 -define(CLUSTER_NODES, [mim2()]).
 -define(DOMAINS, [<<"example.com">>, <<"example.org">>]).
--define(HOST_TYPE, <<"test type">>). %% preconfigured in the toml file
+-define(HOST_TYPE, <<"dummy auth">>). %% preconfigured in the toml file
 
 suite() ->
     require_rpc_nodes([mim, mim2]).

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -27,14 +27,12 @@
          assert_notinlist/2,
          decode_maplist/1,
          gett/2,
-         post/2,
-         putt/2,
-         delete/1,
          gett/3,
          post/3,
          putt/3,
          delete/2]
     ).
+-import(domain_helper, [host_type/0]).
 
 -define(PRT(X, Y), ct:pal("~p: ~p", [X, Y])).
 -define(OK, {<<"200">>, <<"OK">>}).
@@ -101,17 +99,14 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
-host() ->
-    ct:get_config({hosts, mim, domain}).
-
 init_per_suite(Config) ->
-    Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host(), Config),
+    Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host_type(), Config),
     Config2 = ejabberd_node_utils:init(Config1),
     escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    rest_helper:maybe_disable_mam(mam_helper:backend(), host()),
+    rest_helper:maybe_disable_mam(mam_helper:backend(), host_type()),
     escalus:end_per_suite(Config).
 
 init_per_group(auth, Config) ->
@@ -131,14 +126,14 @@ end_per_group(_GroupName, Config) ->
 init_per_testcase(types_are_checked_separately_for_args_and_return = CaseName, Config) ->
     {Mod, Code} = rpc(dynamic_compile, from_string, [custom_module_code()]),
     rpc(code, load_binary, [Mod, "mod_commands_test.erl", Code]),
-    rpc(gen_mod, start_module, [<<"localhost">>, mod_commands_test, []]),
+    rpc(gen_mod, start_module, [host_type(), mod_commands_test, []]),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) ->
     MAMTestCases = [messages_are_archived, messages_can_be_paginated],
     rest_helper:maybe_skip_mam_test_cases(CaseName, MAMTestCases, Config).
 
 end_per_testcase(types_are_checked_separately_for_args_and_return = CaseName, Config) ->
-    rpc(gen_mod, stop_module, [<<"localhost">>, mod_commands_test]),
+    rpc(gen_mod, stop_module, [host_type(), mod_commands_test]),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
@@ -148,11 +143,12 @@ rpc(M, F, A) ->
 
 custom_module_code() ->
     "-module(mod_commands_test).
-     -export([start/0, stop/0, start/2, stop/1, test_arg/1, test_return/1]).
+     -export([start/0, stop/0, start/2, stop/1, test_arg/1, test_return/1, supported_features/0]).
      start() -> mongoose_commands:register(commands()).
      stop() -> mongoose_commands:unregister(commands()).
      start(_,_) -> start().
      stop(_) -> stop().
+     supported_features() -> [dynamic_domains].
      commands() ->
          [
           [
@@ -212,31 +208,31 @@ non_existent_command_returns404(_C) ->
 
 user_can_be_registered_and_removed(_Config) ->
     % list users
-    {?OK, Lusers} = gett(admin, <<"/users/localhost">>),
+    {?OK, Lusers} = gett(admin, path("users")),
     Domain = domain(),
     assert_inlist(<<"alice@", Domain/binary>>, Lusers),
     % create user
     CrUser = #{username => <<"mike">>, password => <<"nicniema">>},
-    {?CREATED, _} = post(admin, <<"/users/localhost">>, CrUser),
-    {?OK, Lusers1} = gett(admin, <<"/users/localhost">>),
+    {?CREATED, _} = post(admin, path("users"), CrUser),
+    {?OK, Lusers1} = gett(admin, path("users")),
     assert_inlist(<<"mike@", Domain/binary>>, Lusers1),
     % try to create the same user
-    {?FORBIDDEN, _} = post(admin, <<"/users/localhost">>, CrUser),
+    {?FORBIDDEN, _} = post(admin, path("users"), CrUser),
     % delete user
-    {?NOCONTENT, _} = delete(admin, <<"/users/localhost/mike">>),
-    {?OK, Lusers2} = gett(admin, <<"/users/localhost">>),
+    {?NOCONTENT, _} = delete(admin, path("users", ["mike"])),
+    {?OK, Lusers2} = gett(admin, path("users")),
     assert_notinlist(<<"mike@", Domain/binary>>, Lusers2),
     % invalid jid
     CrBadUser = #{username => <<"m@ke">>, password => <<"nicniema">>},
-    {?BAD_REQUEST, <<"Invalid jid", _/binary>>} = post(admin, <<"/users/localhost">>, CrBadUser),
-    {?BAD_REQUEST, <<"Invalid jid", _/binary>>} = delete(admin, <<"/users/localhost/@mike">>),
-%%    {?FORBIDDEN, _} = delete(admin, <<"/users/localhost/mike">>), % he's already gone, but we
+    {?BAD_REQUEST, <<"Invalid jid", _/binary>>} = post(admin, path("users"), CrBadUser),
+    {?BAD_REQUEST, <<"Invalid jid", _/binary>>} = delete(admin, path("users", ["@mike"])),
+%%    {?FORBIDDEN, _} = delete(admin, path("users", ["mike"])), % he's already gone, but we
 %%    can't test it because ejabberd_auth_internal:remove_user/2 always returns ok, grrrr
     ok.
 
 sessions_are_listed(_) ->
     % no session
-    {?OK, Sessions} = gett(admin, "/sessions/localhost"),
+    {?OK, Sessions} = gett(admin, path("sessions")),
     true = is_list(Sessions).
 
 session_can_be_kicked(Config) ->
@@ -246,13 +242,13 @@ session_can_be_kicked(Config) ->
         AliceSessionPath = <<"/sessions/", (escalus_client:server(Alice))/binary,
                              "/", (escalus_client:username(Alice))/binary,
                              "/", (escalus_client:resource(Alice))/binary>>,
-        {?OK, Sessions1} = gett(admin, "/sessions/localhost"),
+        {?OK, Sessions1} = gett(admin, path("sessions")),
         assert_inlist(AliceJid, Sessions1),
         % kick alice
         {?NOCONTENT, _} = delete(admin, AliceSessionPath),
         escalus:wait_for_stanza(Alice),
         true = escalus_connection:wait_for_close(Alice, timer:seconds(1)),
-        {?OK, Sessions2} = gett(admin, "/sessions/localhost"),
+        {?OK, Sessions2} = gett(admin, path("sessions")),
         assert_notinlist(AliceJid, Sessions2),
         {?NOT_FOUND, <<"no active session">>} = delete(admin, AliceSessionPath),
         ok
@@ -360,7 +356,7 @@ password_can_be_changed(Config) ->
     end),
     % we change password
     NewPass = <<"niemakrolika">>,
-    {?NOCONTENT, _} = putt(admin, "/users/localhost/bob",
+    {?NOCONTENT, _} = putt(admin, path("users", ["bob"]),
                            #{newpass => NewPass}),
     % he logs with his alternative password
     ConfigWithBobsAltPass = escalus_users:update_userspec(Config, bob, password, NewPass),
@@ -374,17 +370,17 @@ password_can_be_changed(Config) ->
         ok
     end,
     % we change it back
-    {?NOCONTENT, _} = putt(admin, "/users/localhost/bob",
+    {?NOCONTENT, _} = putt(admin, path("users", ["bob"]),
                            #{newpass => <<"makrolika">>}),
     % now he logs again with the regular one
     escalus:story(Config, [{bob, 1}], fun(#client{} = _Bob) ->
         just_dont_do_anything
     end),
     % test invalid calls
-    Res1 = putt(admin, "/users/localhost/bob",
+    Res1 = putt(admin, path("users", ["bob"]),
                            #{newpass => <<>>}),
     {?BAD_REQUEST, <<"empty password">>} = Res1,
-    Res2 = putt(admin, "/users/localhost/b@b",
+    Res2 = putt(admin, path("users", ["b@b"]),
                 #{newpass => NewPass}),
     {?BAD_REQUEST, <<"invalid jid">>} = Res2,
     ok.
@@ -658,9 +654,9 @@ stop_start_command_module(_) ->
     %% described above we test both transition from `started' to
     %% `stopped' and from `stopped' to `started'.
     {?OK, _} = gett(admin, <<"/commands">>),
-    {ok, _Opts} = dynamic_modules:stop(host(), mod_commands),
+    {ok, _Opts} = dynamic_modules:stop(host_type(), mod_commands),
     {?NOT_FOUND, _} = gett(admin, <<"/commands">>),
-    {ok, _} = dynamic_modules:start(host(), mod_commands, []),
+    {ok, _} = dynamic_modules:start(host_type(), mod_commands, []),
     timer:sleep(200), %% give the server some time to build the paths again
     {?OK, _} = gett(admin, <<"/commands">>).
 
@@ -668,9 +664,6 @@ to_list(V) when is_binary(V) ->
     binary_to_list(V);
 to_list(V) when is_list(V) ->
     V.
-
-domain() ->
-    ct:get_config({hosts, mim, domain}).
 
 add_sample_contact(Bob, Alice) ->
     escalus:send(Bob, escalus_stanza:roster_add_contact(Alice,
@@ -709,3 +702,13 @@ does_push_match(Iq, ExpectedSub, ExpectedAsk) ->
     ESub = atom_to_binary(ExpectedSub, latin1),
     EAsk = atom_to_binary(ExpectedAsk, latin1),
     {Subs, Ask} == {ESub, EAsk}.
+
+path(Category) ->
+    path(Category, []).
+
+path(Category, Items) ->
+    DomainStr = binary_to_list(domain()),
+    string:join(["", Category, DomainStr | Items], "/").
+
+domain() ->
+    ct:get_config({hosts, mim, domain}).

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -63,15 +63,14 @@ all() ->
     ].
 
 groups() ->
-    G = [{admin, [parallel], test_cases()},
-         {auth, [parallel], auth_test_cases()},
-         {blank_auth, [parallel], blank_auth_testcases()},
-         {roster, [parallel], [list_contacts,
-                               befriend_and_alienate,
-                               befriend_and_alienate_auto,
-                               invalid_roster_operations]},
-         {dynamic_module, [], [stop_start_command_module]}],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{admin, [parallel], test_cases()},
+     {auth, [parallel], auth_test_cases()},
+     {blank_auth, [parallel], blank_auth_testcases()},
+     {roster, [parallel], [list_contacts,
+                           befriend_and_alienate,
+                           befriend_and_alienate_auto,
+                           invalid_roster_operations]},
+     {dynamic_module, [], [stop_start_command_module]}].
 
 auth_test_cases() ->
     [auth_passes_correct_creds,

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -179,7 +179,7 @@ init_per_suite(Config) ->
     prepare_test_queries(mim2()),
     erase_database(mim()),
     Config1 = ejabberd_node_utils:init(mim(), Config),
-    Config2 = dynamic_modules:save_modules(<<"test type">>, Config1),
+    Config2 = dynamic_modules:save_modules(dummy_auth_host_type(), Config1),
     escalus:init_per_suite([{mim_conf1, Conf1},
                             {mim_conf2, Conf2},
                             {service_setup, per_testcase} | Config2]).
@@ -195,7 +195,7 @@ end_per_suite(Config) ->
     Conf2 = proplists:get_value(mim_conf2, Config),
     restore_conf(mim(), Conf1),
     restore_conf(mim2(), Conf2),
-    dynamic_modules:restore_modules(<<"test type">>, Config),
+    dynamic_modules:restore_modules(dummy_auth_host_type(), Config),
     escalus:end_per_suite(Config).
 
 %%--------------------------------------------------------------------
@@ -262,7 +262,7 @@ end_per_testcase(TestcaseName, Config) ->
 
 init_per_testcase2(TestcaseName, Config)
     when TestcaseName =:= rest_delete_domain_cleans_data_from_mam ->
-    HostType = <<"test type">>,
+    HostType = dummy_auth_host_type(),
     Mods = [{mod_mam_meta, [{backend, rdbms}, {pm, []}]}],
     rpc(mim(), gen_mod_deps, start_modules, [HostType, Mods]),
     escalus:init_per_testcase(TestcaseName, Config);
@@ -280,7 +280,7 @@ setup_service(Opts, Config) ->
     Pairs1 = [{<<"example.cfg">>, <<"type1">>},
              {<<"erlang-solutions.com">>, <<"type2">>},
              {<<"erlang-solutions.local">>, <<"type2">>}],
-    CommonTypes = [<<"type1">>, <<"type2">>, <<"test type">>,
+    CommonTypes = [<<"type1">>, <<"type2">>, dummy_auth_host_type(),
                    <<"dbgroup">>, <<"dbgroup2">>, <<"cfggroup">>],
     Types2 = [<<"mim2only">>|CommonTypes],
     init_with(mim(), Pairs1, CommonTypes),
@@ -583,7 +583,7 @@ db_restarts_properly(_) ->
     mongoose_helper:wait_until(F, true, #{time_left => timer:seconds(15)}).
 
 db_keeps_syncing_after_cluster_join(Config) ->
-    HostType = <<"test type">>,
+    HostType = dummy_auth_host_type(),
     %% GIVING mim1 and mim2 are not clustered.
     %% Ask mim1 to join mim2's cluster
     %% (and mongooseim application gets restarted on mim1)
@@ -940,7 +940,7 @@ rest_cannot_enable_domain_when_it_is_static(Config) ->
         rest_patch_enabled(Config, <<"example.cfg">>, true).
 
 rest_delete_domain_cleans_data_from_mam(Config) ->
-    HostType = <<"test type">>,
+    HostType = dummy_auth_host_type(),
     rest_put_domain(Config, <<"example.com">>, HostType), %% alice3
     rest_put_domain(Config, <<"example.org">>, HostType), %% bob3
     sync(),
@@ -1111,3 +1111,6 @@ assert_domains_are_equal(HostType) ->
         true -> ok;
         false -> ct:fail({Domains1, Domains2})
     end.
+
+dummy_auth_host_type() ->
+    <<"dummy auth">>. %% specified in the TOML config file

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -22,9 +22,6 @@
 
 [[host_config]]
   host_type = \"test type\"
-  auth.methods = [\"dummy\"]
-  auth.dummy.base_time = 1
-  auth.dummy.variance = 5
 
   [host_config.modules.mod_cache_users]
 

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -5,7 +5,7 @@
 {hidden_service_port, 8189}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
-{host_types, "\"test type\""}.
+{host_types, "\"test type\", \"dummy auth\""}.
 {default_server_domain, "\"localhost\""}.
 
 {mod_privacy, ""}.
@@ -60,7 +60,17 @@
   {{#mod_vcard}}
   [host_config.modules.mod_vcard]
   {{{mod_vcard}}}
-  {{/mod_vcard}}"}.
+  {{/mod_vcard}}
+
+[[host_config]]
+  host_type = \"dummy auth\"
+
+  auth.methods = [\"dummy\"]
+  auth.dummy.base_time = 1
+  auth.dummy.variance = 5
+
+  modules = {}
+"}.
 {password_format, "password.format = \"scram\"
   password.hash = [\"sha256\"]"}.
 {scram_iterations, 64}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -27,6 +27,8 @@
 
   [host_config.modules.mod_carboncopy]
 
+  [host_config.modules.mod_commands]
+
   [host_config.modules.mod_stream_management]
 
   [host_config.modules.mod_disco]

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -52,11 +52,11 @@
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
-{host_types, "\"test type\""}.
+{host_types, "\"dummy auth\""}.
 {host_config,
   "[[host_config]]
-  host_type = \"test type\"
-  modules = { }
-  auth = { methods = [\"dummy\"] }"}.
+  host_type = \"dummy auth\"
+  auth.methods = [\"dummy\"]
+  modules = { }"}.
 
 {mod_cache_users, false}.

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -471,8 +471,9 @@ lookup_recent_messages(ArcJID, With, Before, Limit) when is_binary(ArcJID) ->
 lookup_recent_messages(ArcJID, With, Before, Limit) when is_binary(With) ->
     lookup_recent_messages(ArcJID, jid:from_binary(With), Before, Limit);
 lookup_recent_messages(ArcJID, WithJID, Before, Limit) ->
-    Host = ArcJID#jid.server,
-    Params = #{archive_id => mod_mam:archive_id(Host, ArcJID#jid.user),
+    #jid{luser = LUser, lserver = LServer} = ArcJID,
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(LServer),
+    Params = #{archive_id => mod_mam:archive_id(LServer, LUser),
                owner_jid => ArcJID,
                borders => undefined,
                rsm => #rsm_in{direction = before, id = undefined}, % last msgs
@@ -485,7 +486,7 @@ lookup_recent_messages(ArcJID, WithJID, Before, Limit) ->
                limit_passed => false,
                max_result_limit => 1,
                is_simple => true},
-    R = mod_mam:lookup_messages(Host, Params),
+    R = mod_mam:lookup_messages(HostType, Params),
     {ok, {_, _, L}} = R,
     L.
 


### PR DESCRIPTION
- Enable tests for `mod_commands` (`rest_SUITE`)
- Fix a bug discovered by the tests
- Use the configured auth backend with `rest_SUITE` - this is required by the tests
- Change the tests relying on the dummy auth to use a separate host type for now 
- Disable test repetition in `rest_SUITE` - we are moving away from this practice and this is in line with the recent changes in other test suites