### PR TITLE
Document dynamic domains

### DIFF
--- a/doc/Differentiators.md
+++ b/doc/Differentiators.md
@@ -4,13 +4,14 @@ MongooseIM provides:
 
 * Massive scalability: for greater and faster growth, costs-effectiveness as well as resource utilisation
 * Platform approach: designed with consistency, end-to-end battle testing across the whole ecosystem (all server and client components, and tools)
+* Dynamic domains: thanks to the support for multi-tenancy, it is possible to set up thousands of domains dynamically without a noticeable performance overhead.
 * Code quality: extensive refactoring, substantial optimisations, continuous integration and deployment
 * Extensive testing: automated continuous functional code coverage, integration testing, end-to-end testing with real clients
 * Continuous load testing
 * Unique version: no proprietary extensions, fully open source, fully open standards
 * Contributions to ([XMPP Standards Foundation](https://xmpp.org/)): implementations of XEPs, innovations contributed
 * Professional support, and flexible customer service
-* Contributions to third party open source codebases: strenghthening the ecosystem
+* Contributions to third party open source codebases: strengthening the ecosystem
 
 ## Initial differences from the parent project
 

--- a/doc/advanced-configuration/Modules.md
+++ b/doc/advanced-configuration/Modules.md
@@ -193,25 +193,25 @@ This module provides the functionality specified in [XEP-0092: Software Version]
 
 These modules can be enabled when using host types in `modules` or [`host_config.modules`](./host_config.md#host_configmodules) sections:
 
-* mod_blocking
-* mod_caps
-* mod_cache_users
-* mod_carboncopy
-* mod_commands
-* mod_disco
-* mod_domain_isolation
-* mod_inbox
-* mod_last
-* mod_mam
-* mod_muc
-* mod_muc_log
-* mod_muc_light
-* mod_muc_light_commands
-* mod_offline
-* mod_offline_stub
-* mod_ping
-* mod_privacy
-* mod_private
-* mod_roster
-* mod_stream_management
-* mod_vcard
+* [mod_blocking](../modules/mod_blocking.md)
+* [mod_caps](../modules/mod_caps.md)
+* [mod_cache_users](../modules/mod_cache_users.md)
+* [mod_carboncopy](../modules/mod_carboncopy.md)
+* [mod_commands](../modules/mod_commands.md)
+* [mod_disco](../modules/mod_disco.md)
+* [mod_domain_isolation](../modules/mod_domain_isolation.md)
+* [mod_inbox](../modules/mod_inbox.md)
+* [mod_last](../modules/mod_last.md)
+* [mod_mam](../modules/mod_mam.md)
+* [mod_muc](../modules/mod_muc.md)
+* [mod_muc_log](../modules/mod_muc_log.md)
+* [mod_muc_light](../modules/mod_muc_light.md)
+* [mod_muc_light_commands](../modules/mod_muc_light_commands.md)
+* [mod_offline](../modules/mod_offline.md)
+* [mod_offline_stub](../modules/mod_offline_stub.md)
+* [mod_ping](../modules/mod_ping.md)
+* [mod_privacy](../modules/mod_privacy.md)
+* [mod_private](../modules/mod_private.md)
+* [mod_roster](../modules/mod_roster.md)
+* [mod_stream_management](../modules/mod_stream_management.md)
+* [mod_vcard](../modules/mod_vcard.md)

--- a/doc/advanced-configuration/Modules.md
+++ b/doc/advanced-configuration/Modules.md
@@ -30,7 +30,7 @@ The server may use one of the following strategies to handle incoming IQ stanzas
 * **Syntax:** positive integer
 * **Example:** `iqdisc.workers = 50`
 
-Their semantics works as follow:
+Their semantics works as follows:
 
 * `no_queue` registers a new IQ handler, which will be called in the
   context of the process serving the connection on which the IQ arrives.
@@ -188,3 +188,30 @@ Provides support for vCards, as specified in [XEP-0054: vcard-temp](http://xmpp.
 
 ### [mod_version](../modules/mod_version.md)
 This module provides the functionality specified in [XEP-0092: Software Version](https://xmpp.org/extensions/xep-0092.html).
+
+## Modules supporting dynamic domains
+
+These modules can be enabled when using host types in `modules` or [`host_config.modules`](./host_config.md#host_configmodules) sections:
+
+* mod_blocking
+* mod_caps
+* mod_cache_users
+* mod_carboncopy
+* mod_commands
+* mod_disco
+* mod_domain_isolation
+* mod_inbox
+* mod_last
+* mod_mam
+* mod_muc
+* mod_muc_log
+* mod_muc_light
+* mod_muc_light_commands
+* mod_offline
+* mod_offline_stub
+* mod_ping
+* mod_privacy
+* mod_private
+* mod_roster
+* mod_stream_management
+* mod_vcard

--- a/doc/advanced-configuration/configuration-files.md
+++ b/doc/advanced-configuration/configuration-files.md
@@ -22,7 +22,7 @@ The file is divided into the following sections:
 * [**acl**](acl.md) - Access classes to which connecting users are assigned.
 * [**access**](access.md) - Access rules, specifying the privileges of the defined access classes.
 * [**s2s**](s2s.md) - Server-to-server connection options, used for XMPP federation.
-* [**host_config**](host_config.md) - Configuration options that need to be different for a specific XMPP domain.
+* [**host_config**](host_config.md) - Configuration options for different XMPP domains or host types (groups of domains).
 
 The section names above are links to the detailed documentation of each section.
 

--- a/doc/advanced-configuration/general.md
+++ b/doc/advanced-configuration/general.md
@@ -1,10 +1,11 @@
 The `general` section contains basic settings as well as some miscellaneous options.
-You can start with providing only the basic options, configuring the loglevel, a single host (XMPP domain) and setting the default server language:
+You can start with providing only the basic options, for example configuring the loglevel, a single host (XMPP domain) as the default, and setting the server language:
 
 ```toml
 [general]
   loglevel = "warning"
   hosts = ["my-xmpp-domain.com"]
+  default_server_domain = "my-xmpp-domain.com"
   language = "en"
 ```
 
@@ -25,12 +26,44 @@ Verbosity level of the logger. Values recommended for production systems are `"e
 ### `general.hosts`
 * **Scope:** global
 * **Syntax:** array of strings representing the domain names.
-* **Default:** there is no default, you have to provide at least one host name.
+* **Default:** none. If omitted, at least one host type has to be defined in `general.host_types`.
 * **Example:** `hosts = ["localhost", "domain2"]`
 
-Mandatory option, specifying the XMPP domains served by this cluster.
+This option specifies the statically defined XMPP domains served by this cluster.
+In order to configure these hosts independently, use the [`host_config` section](./host_config.md).
 
-**Warning:** Extension modules and database backends will be started separately for every domain. When increasing the number of domains, please make sure you have enough resources available (e.g. connection limit set in the DBMS).
+**Note:** At least one of `general.hosts` or `general.host_types` have to be provided.
+
+**Warning:** Extension modules and database backends will be started separately for every domain from this list.
+When increasing the number of domains, please make sure you have enough resources available (e.g. connection limit set in the DBMS).
+
+### `general.host_types`
+* **Scope:** global
+* **Syntax:** array of strings the names for host types.
+* **Default:** none. If omitted, at least one hast has to be defined in `general.hosts`.
+* **Example:** `host_types = ["first type", "second type"]`
+
+This is the list of names for the types of hosts that will serve dynamic XMPP domains.
+Each host type can be seen as a label for a group of independent domains that use the same server configuration.
+In order to configure these host types independently, use the [`host_config` section](./host_config.md).
+The domains can be added or removed dynamically via the [dynamic domains REST API](../rest-api/Dynamic-domains.md).
+
+If you use the host type mechanism, make sure you only configure modules which support it in the [`modules`](./Modules.md) or [`host_config.modules`](./host_config.md#host_configmodules) sections.
+MongooseIM will not start otherwise.
+In order to see which modules support dynamic domains, please check the [modules list](./Modules.md#modules-supporting-dynamic-domains).
+
+**Note:** At least one of `general.hosts` or `general.host_types` have to be provided.
+
+**Warning:** Extension modules and database backends will be started separately for every host type from this list.
+When increasing the number of host types, please make sure you have enough resources available (e.g. connection limit set in the DBMS).
+
+### `general.default_server_domain`
+* **Scope:** global
+* **Syntax:** a string
+* **Default:** none, this option is mandatory.
+* **Example:** `default_server_domain = "my-xmpp-domain.com"`
+
+This domain is used as a default when one cannot be determined, for example in some cases when serving multiple XMPP domains. 
 
 ### `general.language`
 * **Scope:** global
@@ -61,10 +94,10 @@ User access rules are configured mainly in the [`acl`](acl.md) and [`access`](ac
 * **Scope:** local
 * **Syntax:** TOML table, whose **keys** are the names of the access rules defined in the [`access`](access.md) config section and **values** specify allowed administration commands. Each value is a table with the following nested options:
     * `commands`: optional, a list of strings representing the allowed commands. When not specified, all commands are allowed.
-    * `argument_restrictions`: optional, a table whose keys are the argument names and the values are strings representing the allowed values. When not specified, there are no restrictions.
+    * `argument_restrictions`: optional, a table whose keys are the argument names, and the values are strings representing the allowed values. When not specified, there are no restrictions.
 * **Default:** not set
 
-By default all admin operations are permitted with the `mongooseimctl` command without authentication. You can change that by setting this option for a specific access rule. When the rule returns the value `"allow"`, the user is permitted to use the specified commands with the optional restrictions.
+By default, all admin operations are permitted with the `mongooseimctl` command without authentication. You can change that by setting this option for a specific access rule. When the rule returns the value `"allow"`, the user is permitted to use the specified commands with the optional restrictions.
 
 **Example 1.** Allow administrators to execute all commands without any restrictions:
 
@@ -180,7 +213,7 @@ Replaces [Cowboy](https://github.com/ninenines/cowboy)'s default name returned i
 * **Default:** not set
 * **Example:** `override = ["global", "local"]`
 
-Will cause MongooseIM to erase all global/local/acl configuration options in database respectively. This ensures that ALL settings of a specific type will be reloaded on startup.
+Will cause MongooseIM to erase all global/local/acl configuration options in the database respectively. This ensures that ALL settings of a specific type will be reloaded on the startup.
 
 ### `general.max_fsm_queue`
 * **Scope:** local

--- a/doc/advanced-configuration/general.md
+++ b/doc/advanced-configuration/general.md
@@ -63,7 +63,7 @@ When increasing the number of host types, please make sure you have enough resou
 * **Default:** none, this option is mandatory.
 * **Example:** `default_server_domain = "my-xmpp-domain.com"`
 
-This domain is used as a default when one cannot be determined, for example in some cases when serving multiple XMPP domains. 
+This domain is used as a default when one cannot be determined, for example when sending XMPP stream errors to unauthenticated clients.
 
 ### `general.language`
 * **Scope:** global

--- a/doc/advanced-configuration/host_config.md
+++ b/doc/advanced-configuration/host_config.md
@@ -1,5 +1,5 @@
-The `host_config` section is used to configure options for specific XMPP domains.
-For each domain requiring such options, a `host_config` section needs to be created with the following format:
+The `host_config` section is used to configure options for specific XMPP domains or for host types, which are used to group multiple domains.
+For each domain or host type requiring such options, a `host_config` section needs to be created with the following format:
 
 * **Scope:** for each option the scope is the same as for the corresponding top-level option.
 * **Syntax:** domain subsection starts with `[[host_config]]` and contains the options listed below.
@@ -7,16 +7,25 @@ For each domain requiring such options, a `host_config` section needs to be crea
 * **Example:** see the examples for each section below.
 
 **Note:** Each hosted domain needs to be included in the list of [`hosts`](general.md#generalhosts) in the `general` section.
+Similarly, each host type needs to be included in [`general.host_types`](general.md#generalhost_types).
 
 ## General options
 
 ### `host_config.host`
 
 * **Syntax:** string, domain name
-* **Default:** no default, this option is mandatory
+* **Default:** no default, either this option or `host_config.host_type` is mandatory
 * **Example:** `host = "my-xmpp-server.com"`
 
 This option specifies the XMPP domain that this section refers to.
+
+### `host_config.host_type`
+
+* **Syntax:** string, host type name
+* **Default:** no default, either this option or `host_config.host` is mandatory
+* **Example:** `host_type = "first type"`
+
+This option specifies the host type that this section refers to.
 
 ## Configuration sections
 
@@ -101,7 +110,9 @@ The last section would work the same without `methods`:
 
 ### `host_config.modules`
 
-This section completely overrides the top-level [`modules`](../Modules) section. All options are allowed.
+This section completely overrides the top-level [`modules`](../Modules) section.
+Remember that only the modules supporting dynamic domains are allowed if you are specifying options for a host type.
+These can be found in the [modules list](./Modules.md#modules-supporting-dynamic-domains).
 
 #### Example
 

--- a/doc/advanced-configuration/listen.md
+++ b/doc/advanced-configuration/listen.md
@@ -516,6 +516,26 @@ To enable the REST API for clients, several handlers need to be added:
 The recommended configuration is shown in [Example 3](#example-3-client-api) below.
 Please refer to [REST interface](../rest-api/Client-frontend.md) documentation for more information.
 
+### Handler types: REST API - Domain management - `mongoose_domain_handler`
+
+This handler enables dynamic domain management for different host types.
+For more information about the API, see the [REST interface](../rest-api/Dynamic-domains.md) documentation.
+The following options are supported for this handler:
+
+#### `listen.http.handlers.mongoose_domain_handler.username`
+* **Syntax:** string
+* **Default:** not set
+* **Example:** `username = "admin"`
+
+When set, enables authentication to access this endpoint. Requires setting password.
+
+#### `listen.http.handlers.mongoose_domain_handler.password`
+* **Syntax:** string
+* **Default:** not set
+* **Example:** `password = "secret"`
+
+Required to enable authentication for this endpoint.
+
 ### Handler types: Metrics API (obsolete) - `mongoose_api`
 
 REST API for accessing the internal MongooseIM metrics.
@@ -727,3 +747,20 @@ REST API for clients.
     content_path = "swagger"
 ```
 
+#### Example 4. Domain API
+
+REST API for domain management.
+
+```toml
+[[listen.http]]
+  ip_address = "127.0.0.1"
+  port = 8088
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mongoose_domain_handler]]
+    host = "localhost"
+    path = "/api"
+    username = "admin"
+    password = "secret"
+```

--- a/doc/advanced-configuration/outgoing-connections.md
+++ b/doc/advanced-configuration/outgoing-connections.md
@@ -26,9 +26,10 @@ This allows you to create multiple dedicated pools of the same type.
 * **Example:** `host = "anotherhost.com"`
 
 `scope` can be set to:
-* `global` - meaning that the pool will started once no matter how many XMPP hosts are served by MongooseIM
-* `host` - the pool will be started for each XMPP host served by MongooseIM
-* `single_host` - the pool will be started for the selected host only (you must provide a host name).
+
+* `global` - meaning that the pool will be started once no matter how many XMPP hosts are served by MongooseIM
+* `host` - the pool will be started for each XMPP host or host type served by MongooseIM
+* `single_host` - the pool will be started for the selected host or host type only (you must provide the name).
 
 ## Worker pool options
 
@@ -40,7 +41,7 @@ Available options are:
 * **Default:** `"best_worker"`
 * **Example:** `strategy = "available_worker"`
 
-Defines worker seletion strategy. Consult worker_pool documentation for details.
+Defines worker selection strategy. Consult worker_pool documentation for details.
 
 ### `outgoing_pools.*.*.workers`
 * **Syntax:** positive integer
@@ -76,7 +77,7 @@ For example:
 * **Syntax:** string, one of `"pgsql"`, `"mysql"` or `"odbc"` (a supported driver)
 * **Example:** `driver = "psgql"`
 
-Selects driver for RDBMS connection. The choice of driver impacts the set of available options.
+Selects the driver for RDBMS connection. The choice of a driver impacts the set of available options.
 
 #### `outgoing_pools.rdbms.*.connection.call_timeout`
 * **Syntax:** positive integer

--- a/doc/developers-guide/Basic-iq-handler.md
+++ b/doc/developers-guide/Basic-iq-handler.md
@@ -47,11 +47,11 @@ detailed information on the topic.
 %% IQ handlers
 -export([process_iq/4]).
 
-start(Host, _Opts) ->
-    gen_iq_handler:add_iq_handler(ejabberd_sm, Host, <<"erlang-solutions.com:example">>,
-                                  ?MODULE, process_iq, no_queue).
-stop(Host) ->
-    gen_iq_handler:remove_iq_handler(ejabberd_sm, Host, <<"erlang-solutions.com:example">>).
+start(HostType, _Opts) ->
+    gen_iq_handler:add_iq_handler_for_domain(HostType, <<"erlang-solutions.com:example">>,
+                                  ejabberd_sm, process_iq, #{}, no_queue).
+stop(HostType) ->
+    gen_iq_handler:remove_iq_handler_for_domain(HostType, <<"erlang-solutions.com:example">>, ejabberd_sm).
 
 process_iq(_From, _To, Acc, IQ) ->
     IQRes = IQ#iq{type = result},

--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -37,7 +37,7 @@ The extra level of indirection introduced by this call gives the flexibility to 
 `From`, `To` and `Packet` are the arguments passed to the handler just as they would in case of the function being called directly;
 `HostType` is [the host type of the XMPP domain for which this hook is signalled](#sidenote-multiple-domains).
 
-**Notice:** For the clarity of the explanation of the hooks' mechanism, the provided code snippets are not exactly taken from the current code.
+**Notice:** For the clarity of the explanation of the hooks mechanism, the provided code snippets are not exactly taken from the current code.
 The reasons for it will be described [later](#creating-your-own-hooks).
 
 ### Getting results from handlers

--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -27,7 +27,7 @@ To avoid that coupling and also to enable other ([possibly yet to be written](#s
 
 ```erlang
 Acc1 = ejabberd_hooks:run_fold(offline_message_hook,
-                               LServer,
+                               HostType,
                                Acc,
                                [From, To, Packet])
 ```
@@ -35,9 +35,9 @@ Acc1 = ejabberd_hooks:run_fold(offline_message_hook,
 The extra level of indirection introduced by this call gives the flexibility to determine at runtime what code actually gets run at this point.
 `offline_message_hook` is just the name of the hook (in other words of the event that is being signalled);
 `From`, `To` and `Packet` are the arguments passed to the handler just as they would in case of the function being called directly;
-`LServer` is [the XMPP domain for which this hook is signalled](#sidenote-multiple-domains).
+`HostType` is [the host type of the XMPP domain for which this hook is signalled](#sidenote-multiple-domains).
 
-**Notice:** For the clarity of the explanation of the hooks mechanism, the provided code snippets are not exactly taken from the current code.
+**Notice:** For the clarity of the explanation of the hooks' mechanism, the provided code snippets are not exactly taken from the current code.
 The reasons for it will be described [later](#creating-your-own-hooks).
 
 ### Getting results from handlers
@@ -122,13 +122,15 @@ That's usually done in, respectively, `start/2` and `stop/1` functions.
 Here is the relevant snippet from `mod_offline:start/2`:
 
 ```erlang
-ejabberd_hooks:add(offline_message_hook, Host,
+ejabberd_hooks:add(offline_message_hook, HostType,
                    ?MODULE, store_packet, 50)
 ```
 
 It is clearly visible that the handler is added to the `offline_message_hook`.
 
-`Host` corresponds to the `LServer` used in the aforementioned call to the `ejabberd_hooks:run_fold`, i.e. it's the XMPP domain for which the handler is to be executed.
+`HostType` corresponds to the one used in the aforementioned call to the `ejabberd_hooks:run_fold`.
+That is, it's the host type for which the handler is to be executed.
+In the case of statically defined domains, it is the same as the host, as configured in the [`general.hosts` section](../advanced-configuration/general.md#generalhosts).
 
 The handler itself is specified as a module-function pair;
 the arity of the function is not specified at the registration nor verified when calling the handler.
@@ -147,7 +149,7 @@ For that purpose there's the option to unregister a hook handler.
 It's done in `mod_offline:stop/1` in a similar fashion to:
 
 ```erlang
-ejabberd_hooks:delete(offline_message_hook, Host,
+ejabberd_hooks:delete(offline_message_hook, HostType,
                       ?MODULE, store_packet, 50)
 ```
 

--- a/doc/modules/mod_domain_isolation.md
+++ b/doc/modules/mod_domain_isolation.md
@@ -1,3 +1,15 @@
 ## Module Description
 
 This module limits message passing between domains.
+When it is enabled, users won't be able to contact each other if they are registered in different domains.
+
+## Options
+
+This module has no configuration.
+Putting the following entry in the config file is enough.
+
+## Example configuration
+
+```toml
+[modules.mod_domain_isolation]
+```

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -315,25 +315,25 @@ If you'd like to learn more about metrics in MongooseIM, please visit [MongooseI
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| `[Host, modMamArchiveRemoved]` | spiral | User's entire archive is removed. |
-| `[Host, modMamArchived]` | spiral | A message is stored in user's archive. |
-| `[Host, modMamDropped]` | spiral | A message couldn't be stored in the DB (and got dropped). |
-| `[Host, modMamDroppedIQ]` | spiral | MAM IQ has been dropped due to: high query frequency/invalid syntax or type. |
-| `[Host, modMamFlushed]` | spiral | Message was stored in a DB asynchronously. |
-| `[Host, modMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result. |
-| `[Host, modMamLookups]` | spiral | A MAM lookup is performed. |
-| `[Host, modMamPrefsGets]` | spiral | Archiving preferences have been requested by a client. |
-| `[Host, modMamPrefsSets]` | spiral | Archiving preferences have been updated by a client. |
-| `[Host, modMucMamArchiveRemoved]` | spiral | Room's entire archive is removed. |
-| `[Host, modMucMamArchived]` | spiral | A message is stored in room's archive. |
-| `[Host, modMucMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result from MUC room. |
-| `[Host, modMucMamLookups]` | spiral | A MAM lookup in MUC room is performed. |
-| `[Host, modMucMamPrefsGets]` | spiral | MUC archiving preferences have been requested by a client. |
-| `[Host, modMucMamPrefsSets]` | spiral | MUC archiving preferences have been updated by a client. |
-| `[Host, mod_mam_rdbms_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MAM worker. |
-| `[Host, mod_mam_rdbms_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MAM worker. |
-| `[Host, mod_mam_muc_rdbms_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MUC MAM worker. |
-| `[Host, mod_mam_muc_rdbms_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MUC MAM worker. |
+| `[HostType, modMamArchiveRemoved]` | spiral | User's entire archive is removed. |
+| `[HostType, modMamArchived]` | spiral | A message is stored in user's archive. |
+| `[HostType, modMamDropped]` | spiral | A message couldn't be stored in the DB (and got dropped). |
+| `[HostType, modMamDroppedIQ]` | spiral | MAM IQ has been dropped due to: high query frequency/invalid syntax or type. |
+| `[HostType, modMamFlushed]` | spiral | Message was stored in a DB asynchronously. |
+| `[HostType, modMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result. |
+| `[HostType, modMamLookups]` | spiral | A MAM lookup is performed. |
+| `[HostType, modMamPrefsGets]` | spiral | Archiving preferences have been requested by a client. |
+| `[HostType, modMamPrefsSets]` | spiral | Archiving preferences have been updated by a client. |
+| `[HostType, modMucMamArchiveRemoved]` | spiral | Room's entire archive is removed. |
+| `[HostType, modMucMamArchived]` | spiral | A message is stored in room's archive. |
+| `[HostType, modMucMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result from MUC room. |
+| `[HostType, modMucMamLookups]` | spiral | A MAM lookup in MUC room is performed. |
+| `[HostType, modMucMamPrefsGets]` | spiral | MUC archiving preferences have been requested by a client. |
+| `[HostType, modMucMamPrefsSets]` | spiral | MUC archiving preferences have been updated by a client. |
+| `[HostType, mod_mam_rdbms_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MAM worker. |
+| `[HostType, mod_mam_rdbms_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MAM worker. |
+| `[HostType, mod_mam_muc_rdbms_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MUC MAM worker. |
+| `[HostType, mod_mam_muc_rdbms_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MUC MAM worker. |
 
 | Backend action | Description (when it gets incremented) |
 | -------------- | ---------------------------------------|

--- a/doc/modules/mod_ping.md
+++ b/doc/modules/mod_ping.md
@@ -55,6 +55,6 @@ If you'd like to learn more about metrics in MongooseIM, please visit [MongooseI
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| ``[Host, mod_ping, ping_response]`` | spiral | Client responds to a ping. |
-| ``[Host, mod_ping, ping_response_timeout]`` | spiral | Ping request timeouts without a response from client. |
-| ``[Host, mod_ping, ping_response_time]`` | histogram | Response times (doesn't include timeouts). |
+| ``[HostType, mod_ping, ping_response]`` | spiral | Client responds to a ping. |
+| ``[HostType, mod_ping, ping_response_timeout]`` | spiral | Ping request timeouts without a response from client. |
+| ``[HostType, mod_ping, ping_response_time]`` | histogram | Response times (doesn't include timeouts). |

--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -276,8 +276,9 @@ paths:
               stanza:
                 description: the complete stanza
                 type: string
-                required: true
                 example: "<message from=\"alice@wonderlant.lit\" to=\"bob@wonderlant.lit\"><body>whatever</body></message>"
+            required:
+              - stanza
       description: Send an arbitrary stanza (attributes `from` and `to` are required).
       responses:
         204:
@@ -318,6 +319,11 @@ paths:
                 format: JID
                 description: Contact's jid
                 example: "alice@wonderlant.lit"
+        - name: user
+          in: path
+          description: User's JID (f.e. alice@wonderland.lit)
+          required: true
+          type: string
       responses:
         204:
           description: "The user was added to a contacts list."
@@ -534,7 +540,7 @@ paths:
     parameters:
       - $ref: '#/parameters/MUCServer'
       - $ref: '#/parameters/roomName'
-      - user: owner
+      - name: user
         in: path
         description: User's JID (f.e. alice@wonderland.lit)
         required: true

--- a/doc/rest-api/Dynamic-domains.md
+++ b/doc/rest-api/Dynamic-domains.md
@@ -13,70 +13,25 @@ documentation of the [listeners](../advanced-configuration/listen.md),
 in particular the [`mongoose_domain_handler`](../advanced-configuration/listen.md#handler-types-rest-api---domain-management---mongoose_domain_handler)
 section.
 
-## Services
+## OpenAPI specifications
 
-### Add domain
+Read our [Swagger documentation](https://esl.github.io/MongooseDocs/latest/swagger/index.html?domains=true) for more information.
 
-```bash
-curl -v -X PUT "http://localhost:8088/api/domains/example.db" \
-    --user admin:secret \
-    -H 'content-type: application/json' \
-    -d '{"host_type": "type1"}'
-```
+[![Swagger](https://nordicapis.com/wp-content/uploads/swagger-Top-Specification-Formats-for-REST-APIs-nordic-apis-sandoval-e1441412425742-300x170.png)](https://esl.github.io/MongooseDocs/latest/swagger/index.html?domains=true)
 
-Result codes:
+<iframe src="https://esl.github.io/MongooseDocs/latest/swagger/index.html?domains=true"
+height="800" width="800" id="swagger-ui-iframe"></iframe>
 
-* 204 - inserted.
-* 409 - domain already exists with a different host type.
-* 403 - DB service disabled.
-* 403 - unknown host type.
-* 500 - other errors.
+<script>
 
-Example of the result body with a failure reason:
+$(document).ready(function() {
+  if (window.location.host.match("github")){
+    path = window.location.pathname.match("(.*)/rest-api/Dynamic-domains")[1]
+    url = window.location.protocol + "//" + window.location.hostname
+    finalURL = url + path + "/swagger/index.html?domains=true"
+    $('a[href$="swagger/index.html?domains=true"]').attr('href', finalURL)
+    $('#swagger-ui-iframe').attr('src', finalURL)
+  }
+})
 
-```
-{"what":"unknown host type"}
-```
-
-Check the `src/domain/mongoose_domain_handler.erl` file for the exact values of the `what` field if needed.
-
-
-### Delete domain
-
-You must provide the domain's host type inside the body:
-
-```bash
-curl -v -X DELETE "http://localhost:8088/api/domains/example.db" \
-    --user admin:secret \
-    -H 'content-type: application/json' \
-    -d '{"host_type": "type1"}'
-```
-
-Result codes:
-
-* 204 - the domain is removed or not found.
-* 403 - the domain is static.
-* 403 - the DB service is disabled.
-* 403 - the host type is wrong (does not match the host type in the database).
-* 403 - the host type is unknown.
-* 500 - other errors.
-
-
-### Enable/disable domain
-
-Provide `{"enabled": true}` as a body to enable a domain.
-Provide `{"enabled": false}` as a body to disable a domain.
-
-```bash
-curl -v -X PATCH "http://localhost:8088/api/domains/example.db" \
-    --user admin:secret \
-    -H 'content-type: application/json' \
-    -d '{"enabled": true}'
-```
-
-Result codes:
-
-* 204 - updated.
-* 404 - domain not found;
-* 403 - domain is static;
-* 403 - service disabled.
+</script>

--- a/doc/rest-api/Dynamic-domains.md
+++ b/doc/rest-api/Dynamic-domains.md
@@ -1,0 +1,82 @@
+# MongooseIM's REST API for dynamic domain management
+
+Provides API for adding/removing and enabling/disabling domains over HTTP.
+Implemented by `mongoose_domain_handler` module.
+
+## Configuration
+
+`mongoose_domain_handler` has to be configured as shown in the [REST API configuration example](../advanced-configuration/listen.md#example-4-domain-api)
+to enable the REST API.
+
+For details about possible configuration parameters please see the relevant
+documentation of the [listeners](../advanced-configuration/listen.md),
+in particular the [`mongoose_domain_handler`](../advanced-configuration/listen.md#handler-types-rest-api---domain-management---mongoose_domain_handler)
+section.
+
+## Services
+
+### Add domain
+
+```bash
+curl -v -X PUT "http://localhost:8088/api/domains/example.db" \
+    --user admin:secret \
+    -H 'content-type: application/json' \
+    -d '{"host_type": "type1"}'
+```
+
+Result codes:
+
+* 204 - inserted.
+* 409 - domain already exists with a different host type.
+* 403 - DB service disabled.
+* 403 - unknown host type.
+* 500 - other errors.
+
+Example of the result body with a failure reason:
+
+```
+{"what":"unknown host type"}
+```
+
+Check the `src/domain/mongoose_domain_handler.erl` file for the exact values of the `what` field if needed.
+
+
+### Delete domain
+
+You must provide the domain's host type inside the body:
+
+```bash
+curl -v -X DELETE "http://localhost:8088/api/domains/example.db" \
+    --user admin:secret \
+    -H 'content-type: application/json' \
+    -d '{"host_type": "type1"}'
+```
+
+Result codes:
+
+* 204 - the domain is removed or not found.
+* 403 - the domain is static.
+* 403 - the DB service is disabled.
+* 403 - the host type is wrong (does not match the host type in the database).
+* 403 - the host type is unknown.
+* 500 - other errors.
+
+
+### Enable/disable domain
+
+Provide `{"enabled": true}` as a body to enable a domain.
+Provide `{"enabled": false}` as a body to disable a domain.
+
+```bash
+curl -v -X PATCH "http://localhost:8088/api/domains/example.db" \
+    --user admin:secret \
+    -H 'content-type: application/json' \
+    -d '{"enabled": true}'
+```
+
+Result codes:
+
+* 204 - updated.
+* 404 - domain not found;
+* 403 - domain is static;
+* 403 - service disabled.

--- a/doc/rest-api/Dynamic-domains_swagger.yml
+++ b/doc/rest-api/Dynamic-domains_swagger.yml
@@ -1,0 +1,103 @@
+swagger: '2.0'
+info:
+  version: "1.0.0"
+  title: "MongooseIM's domain management REST API"
+  description: |
+    Explore MongooseIM features using our REST API.
+
+    Please keep in mind that all requests require authentication. This is to make sure the server can identify who sent the request and if it comes from an authorized user.
+    Currently the only supported method is **Basic Auth**.
+
+basePath: /api
+schemes:
+  - http
+produces:
+  - application/json
+consumes:
+  - application/json
+host: "localhost:8088"
+paths:
+  /domains/{domain}:
+    put:
+      description: Adds a domain.
+      parameters:
+        - in: path
+          name: domain
+          required: true
+          type: string
+        - in: body
+          name: host_type
+          description: The host type of the domain.
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Domain was successfully inserted.
+        409:
+          description: Domain already exists with a different host type.
+        403:
+          description: DB service disabled or the host type is unknown.
+        500:
+          description: Other errors.
+    patch:
+      description: Enables/disables a domain.
+      parameters:
+        - in: path
+          name: domain
+          required: true
+          type: string
+        - in: body
+          name: enabled
+          description: Whether to enable or to disable a domain.
+          required: true
+          schema:
+            type: boolean
+      responses:
+        204:
+          description: Domain was sucessfully updated.
+        404:
+          description: Domain not found.
+        403:
+          description: Domain is static, or the service is disabled.
+        500:
+          description: Other errors.
+    get:
+      description: Returns information about the domain.
+      parameters:
+        - name: domain
+          type: string
+          in: path
+          required: true
+      responses:
+        200:
+          description: Successful response.
+        404:
+          description: Domain not found.
+    delete:
+      description: "Removes a domain"
+      parameters:
+        - in: path
+          name: domain
+          required: true
+          type: string
+        - in: body
+          name: host_type
+          description: The host type of the domain.
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: "The domain is removed or not found."
+        403:
+          description: |
+            One of:
+              * the domain is static.
+              * the DB service is disabled.
+              * the host type is wrong (does not match the host type in the database).
+              * the host type is unknown.
+        404:
+          description: "There was no such contact."
+        500:
+          description: "Other errors"

--- a/doc/swagger/index.html
+++ b/doc/swagger/index.html
@@ -40,25 +40,20 @@
         return "https://raw.githubusercontent.com/esl/MongooseIM/master/doc/rest-api/" + SpecFile
       }
 
-      var determine_client_mode = function(Search) {
-        var client = Search.match(/client=([^&]+)/)
-        if (client && client.length > 1) {
-          return client[1] == "true"
-        } else {
-          return false
-        }
-      }
-      var backend_or_client_spec = function(CurrentLocation) {
-        var clientMode = determine_client_mode(CurrentLocation.search)
-        if (clientMode) {
+      var determine_spec = function(CurrentLocation) {
+        var searchParams = new URLSearchParams(CurrentLocation.search);
+
+        if (searchParams.has('client')) {
           return "Client-frontend_swagger.yml"
-        } else{
-          return "Administration-backend_swagger.yml"
         }
+        if (searchParams.has('domains')) {
+          return "Dynamic-domains_swagger.yml"
+        }
+        return "Administration-backend_swagger.yml"
       }
 
       var get_spec_url = function(CurrentLocation){
-        var SpecFile = backend_or_client_spec(CurrentLocation)
+        var SpecFile = determine_spec(CurrentLocation)
         if (CurrentLocation.host.match("github")){
           return make_spec_url(CurrentLocation, SpecFile)
         }

--- a/doc/user-guide/ABCs-of-MongooseIM.md
+++ b/doc/user-guide/ABCs-of-MongooseIM.md
@@ -48,6 +48,12 @@ Erlang Solutions also provides [WombatOAM](https://www.erlang-solutions.com/prod
 
 For load testing consider [Tide](http://tide.erlang-solutions.com/), another Erlang Solutions' tool that enables devs and ops to validate their scalability, given the clients scenarios.
 
+## Multi-tenancy (dynamic domains)
+
+MongooseIM supports multi-tenancy.
+This makes it possible to set up thousands of domains dynamically without a noticeable performance overhead.
+On more information on how to set up this feature, see [dynamic domains configuration](../advanced-configuration/general.md#generalhost_types) and [REST API for dynamic domains](../rest-api/Dynamic-domains.md).
+
 ## Client side
 
 In order to build client applications, the MoongooseIM team recommends the following libraries:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - 'Client/frontend': 'rest-api/Client-frontend.md'
       - 'Metrics backend': 'rest-api/Metrics-backend.md'
       - 'Administration backend': 'rest-api/Administration-backend.md'
+      - 'Dynamic domains': 'rest-api/Dynamic-domains.md'
   - 'Operation and maintenance':
       - 'GDPR considerations': 'operation-and-maintenance/gdpr-considerations.md'
       - 'Cluster management considerations': 'operation-and-maintenance/Cluster-management-considerations.md'

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -189,7 +189,7 @@ general() ->
                                                            validate = non_empty},
                                            validate = unique,
                                            format = config},
-                 <<"default_server_domain">> =># option{type = binary,
+                 <<"default_server_domain">> => #option{type = binary,
                                                         validate = non_empty,
                                                         process = fun ?MODULE:process_host/1,
                                                         format = config},


### PR DESCRIPTION
This PR documents the changes made for multi-tenancy.

- The REST API page is updated with a Swagger example, however I am not so familiar with Swagger so it's rather rudimentary. It was not automatically generated as I wasn't sure how to do it (it seemed to require Trails which the domains handler didn't use).
- `mod_domain_isolation` is documented.
- Domain management file in the developers guide is updated as it has some information (like the CLI) that is useful. Some of the parts have been moved to more relevant sections of the documentation.
- Outside the scope of this PR: Hooks documentation has to be updated not only to reflect multi-tenancy but also their recent updates (Hooks-and-handlers.md, hooks_description.md) - a ticket was created.
- General changes everywhere in the documentation.
- Some modules don't support dynamic domains, and their documentation is left as is. 


