### PR TITLE
Make smart_markers multitenancy ready

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -40,8 +40,6 @@
 {suites, "tests", muc_light_legacy_SUITE}.
 
 {suites, "tests", offline_SUITE}.
-{skip_groups, "tests", offline_SUITE, [chatmarkers],
- "at the moment mod_offline_chatmarkers does not support dynamic domains"}.
 
 {suites, "tests", offline_stub_SUITE}.
 

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -172,9 +172,9 @@ update_chat_markers(Acc, HostType, Markers) ->
 -spec has_valid_markers(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->
     false | {true, mongooseim:host_type(), Markers :: [chat_marker()]}.
 has_valid_markers(Acc, From, To, Packet) ->
-    case is_valid_markers(Acc, From, To, Packet) of
-        false -> false;
-        {true, Markers} ->
+    case extract_chat_markers(Acc, From, To, Packet) of
+        [] -> false;
+        Markers ->
             case is_valid_host(Acc, From, To) of
                 false -> false;
                 {true, HostType} -> {true, HostType, Markers}
@@ -187,15 +187,6 @@ is_valid_host(Acc, From, To) ->
     case mongoose_acc:stanza_type(Acc) of
         <<"groupchat">> -> get_host(groupchat, From, To);
         _ -> get_host(one2one, From, To)
-    end.
-
--spec is_valid_markers(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->
-    false | {true, [chat_marker()]}.
-is_valid_markers(Acc, From, To, Packet) ->
-    case extract_chat_markers(Acc, From, To, Packet) of
-        [] -> false;
-        ChatMarkers ->
-            {true, ChatMarkers}
     end.
 
 -spec extract_chat_markers(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->

--- a/src/mod_smart_markers.erl
+++ b/src/mod_smart_markers.erl
@@ -61,10 +61,12 @@
 -behaviour(gen_mod).
 
 %% gen_mod API
--export([start/2, stop/1]).
+-export([start/2]).
+-export([stop/1]).
+-export([supported_features/0]).
 
 %% gen_mod API
--export([get_chat_markers/4]).
+-export([get_chat_markers/3]).
 
 %% Hook handlers
 -export([user_send_packet/4]).
@@ -85,9 +87,9 @@
 
 -type chat_marker() :: #{from := jid:jid(),
                          to := jid:jid(),
-                         thread := maybe_thread(), %%it is not optional!!!
+                         thread := maybe_thread(), % it is not optional!
                          type := mongoose_chat_markers:chat_marker_type(),
-                         timestamp := integer(), %microsecond
+                         timestamp := integer(), % microsecond
                          id := binary()}.
 
 -export_type([chat_marker/0]).
@@ -95,48 +97,53 @@
 %%--------------------------------------------------------------------
 %% DB backend behaviour definition
 %%--------------------------------------------------------------------
--callback init(Host :: jid:lserver(), Opts :: proplists:proplist()) -> ok.
+-callback init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 
 %%% 'from', 'to', 'thread' and 'type' keys of the ChatMarker map serve
 %%% as a composite database key. If key is not available in the database,
 %%% then chat marker must be added. Otherwise this function must update
 %%% chat marker record for that composite key.
--callback update_chat_marker(Host :: jid:lserver(), ChatMarker :: chat_marker()) -> ok.
+-callback update_chat_marker(mongooseim:host_type(), chat_marker()) -> ok.
 
 %%% This function must return the latest chat markers sent to the
 %%% user/room (with or w/o thread) later than provided timestamp.
--callback get_chat_markers(Host :: jid:lserver(), To :: jid:jid(),
-                           Thread :: maybe_thread(), Timestamp :: integer()) ->
-                              [chat_marker()].
+-callback get_chat_markers(HostType :: mongooseim:host_type(),
+                           To :: jid:jid(),
+                           Thread :: maybe_thread(),
+                           Timestamp :: integer()) ->
+    [chat_marker()].
 
 %%--------------------------------------------------------------------
 %% gen_mod API
 %%--------------------------------------------------------------------
--spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
-start(Host, Opts) ->
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start(HostType, Opts) ->
     gen_mod:start_backend_module(?MODULE, add_default_backend(Opts),
                                  [get_chat_markers, update_chat_marker]),
-    mod_smart_markers_backend:init(Host, Opts),
-    ejabberd_hooks:add(hooks(Host)).
+    mod_smart_markers_backend:init(HostType, Opts),
+    ejabberd_hooks:add(hooks(HostType)).
 
--spec stop(Host :: jid:lserver()) -> ok.
-stop(Host) ->
-    ejabberd_hooks:delete(hooks(Host)).
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    ejabberd_hooks:delete(hooks(HostType)).
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
 
 %%--------------------------------------------------------------------
 %% Hook handlers
 %%--------------------------------------------------------------------
--spec hooks(Host :: jid:lserver()) -> [ejabberd_hooks:hook()].
-hooks(Host) ->
-    [{user_send_packet, Host, ?MODULE, user_send_packet, 90}].
+-spec hooks(mongooseim:host_type()) -> [ejabberd_hooks:hook()].
+hooks(HostType) ->
+    [{user_send_packet, HostType, ?MODULE, user_send_packet, 90}].
 
--spec user_send_packet(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
-                       Packet :: exml:element()) -> mongoose_acc:t().
+-spec user_send_packet(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->
+	mongoose_acc:t().
 user_send_packet(Acc, From, To, Packet = #xmlel{name = <<"message">>}) ->
-    TS = mongoose_acc:timestamp(Acc),
-    case has_valid_markers(From, To, Packet, TS) of
-        {true, Host, Markers} ->
-            update_chat_markers(Acc, Host, Markers);
+    case has_valid_markers(Acc, From, To, Packet) of
+        {true, HostType, Markers} ->
+            update_chat_markers(Acc, HostType, Markers);
         false -> Acc
     end;
 user_send_packet(Acc, _From, _To, _Packet) ->
@@ -145,33 +152,56 @@ user_send_packet(Acc, _From, _To, _Packet) ->
 %%--------------------------------------------------------------------
 %% Other API
 %%--------------------------------------------------------------------
--spec get_chat_markers(ChatType :: chat_type(), To :: jid:jid(),
-                       Thread :: maybe_thread(), TS :: os:timestamp()) -> [chat_marker()].
-get_chat_markers(ChatType, #jid{lserver = LServer} = To, Thread, TS) ->
+-spec get_chat_markers(jid:jid(), maybe_thread(), integer()) ->
+    [chat_marker()].
+get_chat_markers(#jid{lserver = LServer} = To, Thread, TS) ->
     %% internal API, no room access rights verification here!
-    Host = case ChatType of
-               one2one -> LServer;
-               groupchat ->
-                   mod_muc_light_utils:muc_host_to_host_type(LServer)
-           end,
-    mod_smart_markers_backend:get_chat_markers(Host, To, Thread, TS).
+    {ok, HostType} = mongoose_domain_api:get_host_type(LServer),
+    mod_smart_markers_backend:get_chat_markers(HostType, To, Thread, TS).
 
 %%--------------------------------------------------------------------
 %% Local functions
 %%--------------------------------------------------------------------
--spec update_chat_markers(Acc :: mongoose_acc:t(),
-                          Host :: jid:lserver(),
-                          Markers :: [chat_marker()]) -> mongoose_acc:t().
-update_chat_markers(Acc, Host, Markers) ->
+-spec update_chat_markers(mongoose_acc:t(), mongooseim:host_type(), [chat_marker()]) ->
+    mongoose_acc:t().
+update_chat_markers(Acc, HostType, Markers) ->
     TS = mongoose_acc:timestamp(Acc),
-    [mod_smart_markers_backend:update_chat_marker(Host, CM) || CM <- Markers],
+    [mod_smart_markers_backend:update_chat_marker(HostType, CM) || CM <- Markers],
     mongoose_acc:set_permanent(?MODULE, timestamp, TS, Acc).
 
--spec extract_chat_markers(From :: jid:jid(),
-                           To :: jid:jid(),
-                           Packet :: exml:element(),
-                           TS :: integer()) -> [chat_marker()].
-extract_chat_markers(From, To, Packet, TS) ->
+-spec has_valid_markers(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->
+    false | {true, mongooseim:host_type(), Markers :: [chat_marker()]}.
+has_valid_markers(Acc, From, To, Packet) ->
+    case is_valid_markers(Acc, From, To, Packet) of
+        false -> false;
+        {true, Markers} ->
+            case is_valid_host(Acc, From, To) of
+                false -> false;
+                {true, HostType} -> {true, HostType, Markers}
+            end
+    end.
+
+-spec is_valid_host(mongoose_acc:t(), jid:jid(), jid:jid()) ->
+    false | {true, mongooseim:host_type()}.
+is_valid_host(Acc, From, To) ->
+    case mongoose_acc:stanza_type(Acc) of
+        <<"groupchat">> -> get_host(groupchat, From, To);
+        _ -> get_host(one2one, From, To)
+    end.
+
+-spec is_valid_markers(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->
+    false | {true, [chat_marker()]}.
+is_valid_markers(Acc, From, To, Packet) ->
+    case extract_chat_markers(Acc, From, To, Packet) of
+        [] -> false;
+        ChatMarkers ->
+            {true, ChatMarkers}
+    end.
+
+-spec extract_chat_markers(mongoose_acc:t(), jid:jid(), jid:jid(), exml:element()) ->
+	[chat_marker()].
+extract_chat_markers(Acc, From, To, Packet) ->
+    TS = mongoose_acc:timestamp(Acc),
     case mongoose_chat_markers:list_chat_markers(Packet) of
         [] -> [];
         ChatMarkers ->
@@ -186,52 +216,16 @@ get_thread(El) ->
         _ -> undefined
     end.
 
--spec has_valid_markers(From :: jid:jid(),
-                        To :: jid:jid(),
-                        Packet :: exml:element(),
-                        TS :: integer()) ->
-    false | {true, Host :: jid:lserver(), Markers :: [chat_marker()]}.
-has_valid_markers(From, To, Packet, TS) ->
-    case is_valid_markers(From, To, Packet, TS) of
-        false -> false;
-        {true, Markers} ->
-            case is_valid_host(From, To, Packet) of
-                false -> false;
-                {true, Host} ->
-                    {true, Host, Markers}
-            end
-    end.
-
--spec is_valid_host(jid:jid(), jid:jid(), exml:element()) ->
-    false | {true, jid:lserver()}.
-is_valid_host(From, To, Packet) ->
+-spec get_host(chat_type(), jid:jid(), jid:jid()) ->
+    false | {true, mongooseim:host_type()}.
+get_host(groupchat, From, To) ->
+    HostType = mod_muc_light_utils:room_jid_to_host_type(To),
+    can_access_room(HostType, From, To) andalso {true, HostType};
+get_host(one2one, _From, To) ->
     LServer = To#jid.lserver,
-    case exml_query:attr(Packet, <<"type">>, undefined) of
-        <<"groupchat">> -> get_host(groupchat, LServer, From, To);
-        _ -> get_host(one2one, LServer, From, To)
-    end.
-
--spec is_valid_markers(jid:jid(), jid:jid(), exml:element(), integer()) ->
-    false | {true, [chat_marker()]}.
-is_valid_markers(From, To, Packet, TS) ->
-    case extract_chat_markers(From, To, Packet, TS) of
-        [] -> false;
-        ChatMarkers ->
-            {true, ChatMarkers}
-    end.
-
--spec get_host(chat_type(), jid:lserver(), jid:jid(), jid:jid()) ->
-    false | {true, jid:lserver()}.
-get_host(groupchat, SubHost, From, To) ->
-    case mongoose_domain_api:get_subdomain_info(SubHost) of
-        {ok, #{host_type := HostType}} ->
-            can_access_room(HostType, From, To) andalso {true, HostType}
-    end;
-get_host(one2one, Host, _, _) ->
-    Hosts = ejabberd_config:get_global_option(hosts),
-    case lists:member(Host, Hosts) of
-        false -> false;
-        _ -> {true, Host}
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} -> {true, HostType};
+        {error, not_found} -> false
     end.
 
 -spec can_access_room(HostType :: mongooseim:host_type(),

--- a/src/offline/mod_offline_chatmarkers_rdbms.erl
+++ b/src/offline/mod_offline_chatmarkers_rdbms.erl
@@ -9,48 +9,45 @@
 -behaviour(mod_offline_chatmarkers).
 
 -export([init/2,
-         get/1,
-         maybe_store/4,
-         remove_user/1]).
+         get/2,
+         maybe_store/5,
+         remove_user/2]).
 
--include("mongoose.hrl").
--include("jlib.hrl").
-
--spec init(Host :: jid:lserver(), Opts :: list()) -> ok.
-init(Host, _Opts) ->
+-spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+init(HostType, _Opts) ->
     mongoose_rdbms:prepare(offline_chatmarkers_select, offline_markers, [jid],
         <<"SELECT thread, room, timestamp FROM offline_markers WHERE jid = ?">>),
     mongoose_rdbms:prepare(offline_chatmarkers_delete, offline_markers, [jid],
         <<"DELETE FROM offline_markers WHERE jid = ?">>),
-    rdbms_queries:prepare_upsert(Host, offline_chatmarkers_upsert, offline_markers,
+    rdbms_queries:prepare_upsert(HostType, offline_chatmarkers_upsert, offline_markers,
                                  [<<"jid">>, <<"thread">>, <<"room">>, <<"timestamp">>],
                                  [],
                                  [<<"jid">>, <<"thread">>, <<"room">>]),
     ok.
 
--spec get(Jid :: jid:jid()) -> {ok, [{Thread :: undefined | binary(),
-                                      Room :: undefined | jid:jid(),
-                                      Timestamp :: integer()}]}.
-get(#jid{lserver = Host} = Jid) ->
-    {selected, Rows} = execute_select(Host, encode_jid(Jid)),
+-spec get(mongooseim:host_type(), jid:jid()) -> {ok, [{Thread :: undefined | binary(),
+                                                       Room :: undefined | jid:jid(),
+                                                       Timestamp :: integer()}]}.
+get(HostType, Jid) ->
+    {selected, Rows} = execute_select(HostType, encode_jid(Jid)),
     decode(Rows).
 
--spec execute_select(Host :: jid:lserver(), Jid :: binary()) -> mongoose_rdbms:query_result().
-execute_select(Host, Jid) ->
-    mongoose_rdbms:execute_successfully(Host, offline_chatmarkers_select, [Jid]).
+-spec execute_select(mongooseim:host_type(), binary()) -> mongoose_rdbms:query_result().
+execute_select(HostType, Jid) ->
+    mongoose_rdbms:execute_successfully(HostType, offline_chatmarkers_select, [Jid]).
 
--spec execute_delete_user(Host :: jid:lserver(), Jid :: binary()) -> mongoose_rdbms:query_result().
-execute_delete_user(Host, Jid) ->
-    mongoose_rdbms:execute_successfully(Host, offline_chatmarkers_delete, [Jid]).
+-spec execute_delete_user(mongooseim:host_type(), binary()) -> mongoose_rdbms:query_result().
+execute_delete_user(HostType, Jid) ->
+    mongoose_rdbms:execute_successfully(HostType, offline_chatmarkers_delete, [Jid]).
 
--spec execute_maybe_store(Host :: jid:lserver(),
+-spec execute_maybe_store(mongooseim:host_type(),
                           Jid :: binary(),
                           Thread :: binary(),
                           Room :: binary(),
                           Timestamp :: integer()) ->
-                              mongoose_rdbms:query_result().
-execute_maybe_store(Host, Jid, Thread, Room, Timestamp) ->
-    rdbms_queries:execute_upsert(Host, offline_chatmarkers_upsert,
+    mongoose_rdbms:query_result().
+execute_maybe_store(HostType, Jid, Thread, Room, Timestamp) ->
+    rdbms_queries:execute_upsert(HostType, offline_chatmarkers_upsert,
                                  [Jid, Thread, Room, Timestamp],
                                  [],
                                  [Jid, Thread, Room]).
@@ -60,23 +57,23 @@ execute_maybe_store(Host, Jid, Thread, Room, Timestamp) ->
 %%% corresponding timestamp. Otherwise this function does nothing, the stored
 %%% timestamp for the composite key MUST remain unchanged!
 %%% @end
--spec maybe_store(Jid :: jid:jid(), Thread :: undefined | binary(),
+-spec maybe_store(mongooseim:host_type(), Jid :: jid:jid(), Thread :: undefined | binary(),
                   Room :: undefined | jid:jid(), Timestamp :: integer()) -> ok.
-maybe_store(#jid{lserver = Host} = Jid, Thread, Room, Timestamp) ->
-    execute_maybe_store(Host, encode_jid(Jid), encode_thread(Thread),
+maybe_store(HostType, Jid, Thread, Room, Timestamp) ->
+    execute_maybe_store(HostType, encode_jid(Jid), encode_thread(Thread),
                         encode_jid(Room), Timestamp),
     ok.
 
--spec remove_user(Jid :: jid:jid()) -> ok.
-remove_user(#jid{lserver = Host} = Jid) ->
-    execute_delete_user(Host, encode_jid(Jid)),
+-spec remove_user(mongooseim:host_type(), jid:jid()) -> ok.
+remove_user(HostType, Jid) ->
+    execute_delete_user(HostType, encode_jid(Jid)),
     ok.
 
-encode_jid(undefined) -> <<"">>;
-encode_jid(JID)       -> jid:to_binary(jid:to_lus(JID)).
+encode_jid(undefined) -> <<>>;
+encode_jid(JID) -> jid:to_binary(jid:to_lus(JID)).
 
-encode_thread(undefined) -> <<"">>;
-encode_thread(Thread)    -> Thread.
+encode_thread(undefined) -> <<>>;
+encode_thread(Thread) -> Thread.
 
 decode(Rows) ->
     {ok, [decode_row(R) || R <- Rows]}.
@@ -84,12 +81,11 @@ decode(Rows) ->
 decode_row({Thread, Room, TS}) ->
     {decode_thread(Thread), decode_jid(Room), decode_timestamp(TS)}.
 
-decode_jid(<<"">>)     -> undefined;
+decode_jid(<<>>) -> undefined;
 decode_jid(EncodedJID) -> jid:from_binary(EncodedJID).
 
-decode_thread(<<"">>)        -> undefined;
+decode_thread(<<>>) -> undefined;
 decode_thread(EncodedThread) -> EncodedThread.
 
 decode_timestamp(EncodedTS) ->
     mongoose_rdbms:result_to_integer(EncodedTS).
-


### PR DESCRIPTION
Mainly makes smart_markers multitenancy ready. This also moves around some formatting like removing variable names in spec declarations or reordering some variables.