### PR TITLE
Acc muc affs

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1340,6 +1340,7 @@ config_metrics(HostType) ->
 hooks(HostType) ->
     [{is_muc_room_owner, HostType, ?MODULE, is_muc_room_owner, 50},
      {can_access_room, HostType, ?MODULE, can_access_room, 50},
+     {get_room_affiliations, HostType, ?MODULE, get_room_affiliations, 50},
      {can_access_identity, HostType, ?MODULE, can_access_identity, 50},
      {disco_local_items, HostType, ?MODULE, disco_local_items, 250}].
 

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -9,6 +9,8 @@
 -include("mod_privacy.hrl").
 -include("mongoose.hrl").
 
+-ignore_xref([get_room_affiliations/2]).
+
 -export([adhoc_local_commands/4,
          adhoc_sm_commands/4,
          anonymous_purge_hook/3,
@@ -84,7 +86,8 @@
 
 -export([is_muc_room_owner/3,
          can_access_identity/3,
-         can_access_room/3]).
+         can_access_room/3,
+         get_room_affiliations/2]).
 
 -export([mam_archive_id/2,
          mam_archive_size/3,
@@ -898,6 +901,14 @@ can_access_identity(HostType, Room, User) ->
       Result :: boolean().
 can_access_room(HostType, Room, User) ->
     run_hook_for_host_type(can_access_room, HostType, false, [HostType, Room, User]).
+
+-spec get_room_affiliations(Acc, Room) -> Result when
+      Acc :: mongoose_acc:t(),
+      Room :: jid:jid(),
+      Result :: {mongoose_acc:t(), term()}.
+get_room_affiliations(Acc, Room) ->
+    HostType = mongoose_acc:host_type(Acc),
+    run_hook_for_host_type(get_room_affiliations, HostType, Acc, [Room]).
 
 %% MAM related hooks
 

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -171,13 +171,12 @@ try_to_create_room(CreatorUS, RoomJID, #create{raw_config = RawConfig} = Creatio
                          Acc :: mongoose_acc:t()) ->
     {ok, jid:jid(), config_req_props()}
     | {error, validation_error() | bad_request | not_allowed}.
-change_room_config(UserJid, RoomID, MUCLightDomain, ConfigReq, Acc) ->
+change_room_config(UserJid, RoomID, MUCLightDomain, ConfigReq, Acc1) ->
     R = {RoomID, MUCLightDomain},
     RoomJID = jid:make(RoomID, MUCLightDomain, <<>>),
     RoomUS = jid:to_lus(RoomJID),
-    AffUsersRes = mod_muc_light_db_backend:get_aff_users(RoomUS),
-
-    case mod_muc_light_room:process_request(UserJid, R, {set, ConfigReq}, AffUsersRes, Acc) of
+    {Acc2, AffUsersRes} = mod_muc_light:get_room_affiliations(Acc1, RoomJID),
+    case mod_muc_light_room:process_request(UserJid, RoomUS, {set, ConfigReq}, AffUsersRes, Acc2) of
         {set, ConfigResp, _} ->
             {ok, RoomJID, ConfigResp};
         {error, _Reason} = E ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -300,6 +300,7 @@ hooks(HostType) ->
     Roster = gen_mod:get_module_opt(HostType, ?MODULE, rooms_in_rosters, ?DEFAULT_ROOMS_IN_ROSTERS),
     [{is_muc_room_owner, HostType, ?MODULE, is_muc_room_owner, 50},
      {can_access_room, HostType, ?MODULE, can_access_room, 50},
+     {get_room_affiliations, HostType, ?MODULE, get_room_affiliations, 50},
      {can_access_identity, HostType, ?MODULE, can_access_identity, 50},
       %% Prevent sending service-unavailable on groupchat messages
      {offline_groupchat_message_hook, HostType, ?MODULE, prevent_service_unavailable, 90},

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -37,7 +37,6 @@
     {?MOD_MUC_LIGHT_DB_BACKEND_BACKEN, modify_aff_users, 4},
     {?MOD_MUC_LIGHT_DB_BACKEND_BACKEN, set_config, 3},
     {?MOD_MUC_LIGHT_DB_BACKEND_BACKEN, destroy_room, 1},
-    {?MOD_MUC_LIGHT_DB_BACKEND_BACKEN, get_aff_users, 1},
     {?MOD_MUC_LIGHT_CODEC_BACKEND_BACKEN, encode, 5},
     {?MOD_MUC_LIGHT_CODEC_BACKEND_BACKEN, encode_error, 5}
 ]).
@@ -54,11 +53,11 @@
 
 -spec handle_request(From :: jid:jid(), RoomJID :: jid:jid(), OrigPacket :: exml:element(),
                      Request :: muc_light_packet(), Acc :: mongoose_acc:t()) -> mongoose_acc:t().
-handle_request(From, To, OrigPacket, Request, Acc) ->
+handle_request(From, To, OrigPacket, Request, Acc1) ->
     RoomUS = jid:to_lus(To),
-    AffUsersRes = mod_muc_light_db_backend:get_aff_users(RoomUS),
-    Response = process_request(From, RoomUS, Request, AffUsersRes, Acc),
-    send_response(From, To, RoomUS, OrigPacket, Response, Acc).
+    {Acc2, AffUsersRes} = mod_muc_light:get_room_affiliations(Acc1, To),
+    Response = process_request(From, RoomUS, Request, AffUsersRes, Acc2),
+    send_response(From, To, RoomUS, OrigPacket, Response, Acc2).
 
 -spec maybe_forget(Acc :: mongoose_acc:t(),
                    RoomUS :: jid:simple_bare_jid(), NewAffUsers :: aff_users()) -> any().


### PR DESCRIPTION
As explained in the first commit:

Very often, the affiliations of a room will need to be checked many
times. Imagine a room of a thousand people, and one sending a message:
if any handler on user_send_packet needs to know the affiliations, they
would be then queried again when the router triggers the process_packet
callback for muclight.

Such a handler happens often when we're checking if we can access the
room, like in the case of smart_markers: then we could be introducing a
race condition, when a user can react in a certain way in his
user_send_packet hook, but then muclight finds out the user has just
been kicked out.

This can also be used as an optimisation: inbox is making a DB query for
each user when muc_light routes the package to them, but we could be
making a single DB call in the context of the sender with all the
receivers queries at once, hence reducing round-trips considerably.