### PR TITLE
Use more full jids and avoid to_lus conversions

### DIFF
--- a/src/muc_light/mod_muc_light_codec.erl
+++ b/src/muc_light/mod_muc_light_codec.erl
@@ -33,7 +33,7 @@
     decode_result().
 
 -callback encode(Request :: muc_light_encode_request(), OriginalSender :: jid:jid(),
-                 RoomUS :: jid:simple_bare_jid(), % may be just service domain
+                 RoomJid :: jid:jid(), % may be just service domain
                  HandleFun :: encoded_packet_handler(),
                  Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 
@@ -76,4 +76,3 @@ make_error_elem({error, registration_required}) ->
     mongoose_xmpp_errors:registration_required();
 make_error_elem({error, _}) ->
     mongoose_xmpp_errors:bad_request().
-

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -44,14 +44,14 @@ decode(_, _, _, _Acc) ->
     {error, bad_request}.
 
 -spec encode(Request :: muc_light_encode_request(),
-             OriginalSender :: jid:jid(), RoomUS :: jid:simple_bare_jid(),
+             OriginalSender :: jid:jid(), RoomUS :: jid:jid(),
              HandleFun :: mod_muc_light_codec:encoded_packet_handler(),
              Acc :: mongoose_acc:t()) -> mongoose_acc:t().
-encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc) ->
+encode({#msg{} = Msg, AffUsers}, Sender, RoomBareJid, HandleFun, Acc) ->
     US = jid:to_lus(Sender),
     Aff = get_sender_aff(AffUsers, US),
     FromNick = jid:to_binary(jid:to_lus(Sender)),
-    {RoomJID, RoomBin} = jids_from_room_with_resource(RoomUS, FromNick),
+    {RoomJID, RoomBin} = jids_from_room_with_resource(RoomBareJid, FromNick),
     Attrs = [
              {<<"id">>, Msg#msg.id},
              {<<"type">>, <<"groupchat">>},
@@ -60,7 +60,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs, children = Msg#msg.children },
     EventData = #{from_nick => FromNick,
                   from_jid => Sender,
-                  room_jid => jid:make_noprep(RoomU, RoomS, <<>>),
+                  room_jid => RoomBareJid,
                   affiliation => Aff,
                   role => mod_muc_light_utils:light_aff_to_muc_role(Aff)},
     HostType = mod_muc_light_utils:acc_to_host_type(Acc),
@@ -71,10 +71,10 @@ encode({#msg{} = Msg, AffUsers}, Sender, {RoomU, RoomS} = RoomUS, HandleFun, Acc
               send_to_aff_user(RoomJID, U, S, <<"message">>, Attrs, Children, HandleFun)
       end, AffUsers),
     mongoose_acc:update_stanza(#{from_jid => RoomJID,
-                                 to_jid => jid:make_noprep(RoomU, RoomS, <<>>),
+                                 to_jid => RoomBareJid,
                                  element => Packet1}, Acc);
-encode(OtherCase, Sender, RoomUS, HandleFun, Acc) ->
-    {RoomJID, RoomBin} = jids_from_room_with_resource(RoomUS, <<>>),
+encode(OtherCase, Sender, RoomBareJid, HandleFun, Acc) ->
+    {RoomJID, RoomBin} = jids_from_room_with_resource(RoomBareJid, <<>>),
     case encode_meta(OtherCase, RoomJID, Sender, HandleFun, Acc) of
         {iq_reply, ID} ->
             IQRes = make_iq_result(RoomBin, jid:to_binary(Sender), ID, <<>>, undefined),
@@ -297,7 +297,7 @@ encode_meta({set, #blocking{ id = ID }}, _RoomJID, _SenderJID, _HandleFun, _Acc)
 encode_meta({set, #create{} = Create, _UniqueRequested}, RoomJID, _SenderJID, HandleFun, _Acc) ->
     [{{ToU, ToS}, CreatorAff}] = Create#create.aff_users,
     ToBin = jid:to_binary({ToU, ToS, <<>>}),
-    {From, FromBin} = jids_from_room_with_resource({RoomJID#jid.luser, RoomJID#jid.lserver}, ToBin),
+    {From, FromBin} = jids_from_room_with_resource(RoomJID, ToBin),
     Attrs = [{<<"from">>, FromBin}],
     {AffBin, RoleBin} = case CreatorAff of
                             owner -> {<<"owner">>, <<"moderator">>};
@@ -406,7 +406,7 @@ bcast_aff_messages(Room, [{{ToU, ToS} = User, _} | ROldAffUsers], [{User, _} | R
     lists:foreach(
       fun({{ChangedU, ChangedS}, NewAff} = ChangedAffUser) ->
               ChangedUserBin = jid:to_binary({ChangedU, ChangedS, <<>>}),
-              {From, FromBin} = jids_from_room_with_resource({Room#jid.luser, Room#jid.lserver},
+              {From, FromBin} = jids_from_room_with_resource(Room,
                                                              ChangedUserBin),
               Attrs0 = [{<<"from">>, FromBin}],
               ElToEnvelope0 = aff_user_to_item(ChangedAffUser),
@@ -438,7 +438,7 @@ bcast_aff_messages(Room, OldAffUsers, [{{ToU, ToS}, _} | RNewAffUsers],
                           HandleFun :: mod_muc_light_codec:encoded_packet_handler()) -> ok.
 msg_to_leaving_user(Room, {ToU, ToS} = User, HandleFun) ->
     UserBin = jid:to_binary({ToU, ToS, <<>>}),
-    {From, FromBin} = jids_from_room_with_resource({Room#jid.luser, Room#jid.lserver}, UserBin),
+    {From, FromBin} = jids_from_room_with_resource(Room, UserBin),
     Attrs = [{<<"from">>, FromBin},
              {<<"type">>, <<"unavailable">>}],
     NotifForLeaving = envelope(?NS_MUC_USER, [ aff_user_to_item({User, none}), status(<<"321">>) ]),
@@ -455,11 +455,11 @@ send_to_aff_user(From, ToU, ToS, Name, Attrs, Children, HandleFun) ->
                      children = Children },
     HandleFun(From, To, Packet).
 
--spec jids_from_room_with_resource(RoomUS :: jid:simple_bare_jid(), binary()) ->
+-spec jids_from_room_with_resource(Room :: jid:jid(), binary()) ->
     {jid:jid(), binary()}.
-jids_from_room_with_resource({RoomU, RoomS}, Resource) ->
-    FromBin = jid:to_binary({RoomU, RoomS, Resource}),
-    From = jid:make_noprep(RoomU, RoomS, Resource),
+jids_from_room_with_resource(RoomJID, Resource) ->
+    From = jid:replace_resource(RoomJID, Resource),
+    FromBin = jid:to_binary(jid:to_lower(From)),
     {From, FromBin}.
 
 -spec make_iq_result(FromBin :: binary(), ToBin :: binary(), ID :: binary(),

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -252,12 +252,12 @@ create_room(Domain, RoomId, RoomTitle, Creator, Subject) ->
     LServer = jid:nameprep(Domain),
     HostType = mod_muc_light_utils:server_host_to_host_type(LServer),
     MUCLightDomain = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
-    CreatorUS = jid:to_lus(jid:from_binary(Creator)),
+    CreatorJid = jid:from_binary(Creator),
     MUCServiceJID = jid:make(RoomId, MUCLightDomain, <<>>),
     Config = make_room_config(RoomTitle, Subject),
-    case mod_muc_light:try_to_create_room(CreatorUS, MUCServiceJID, Config) of
-        {ok, RoomUS, _} ->
-            jid:to_binary(RoomUS);
+    case mod_muc_light:try_to_create_room(CreatorJid, MUCServiceJID, Config) of
+        {ok, RoomJid, _} ->
+            jid:to_binary(RoomJid);
         {error, exists} ->
             {error, denied, "Room already exists"};
         {error, Reason} ->

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -94,10 +94,10 @@ light_aff_to_muc_role(owner) -> moderator;
 light_aff_to_muc_role(member) -> participant;
 light_aff_to_muc_role(none) -> none.
 
--spec room_limit_reached(UserUS :: jid:simple_bare_jid(), HostType :: mongooseim:host_type()) ->
+-spec room_limit_reached(UserJid :: jid:jid(), HostType :: mongooseim:host_type()) ->
     boolean().
-room_limit_reached(UserUS, HostType) ->
-    check_room_limit_reached(UserUS, HostType, rooms_per_user(HostType)).
+room_limit_reached(UserJid, HostType) ->
+    check_room_limit_reached(jid:to_lus(UserJid), HostType, rooms_per_user(HostType)).
 
 rooms_per_user(HostType) ->
     gen_mod:get_module_opt(HostType, mod_muc_light,
@@ -129,8 +129,8 @@ filter_out_prevented(HostType, FromUS, {RoomU, MUCServer} = RoomUS, AffUsers) ->
 %% ---------------- Checks ----------------
 
 -spec check_room_limit_reached(UserUS :: jid:simple_bare_jid(),
-                         HostType :: mongooseim:host_type(),
-                         RoomsPerUser :: infinity | pos_integer()) ->
+                               HostType :: mongooseim:host_type(),
+                               RoomsPerUser :: infinity | pos_integer()) ->
     boolean().
 check_room_limit_reached(_UserUS, _HostType, infinity) ->
     false;

--- a/test/muc_light_SUITE.erl
+++ b/test/muc_light_SUITE.erl
@@ -115,7 +115,7 @@ rsm_disco_item_not_found(_Config) ->
 codec_calls(_Config) ->
     AffUsers = [{{<<"alice">>, <<"localhost">>}, member}, {{<<"bob">>, <<"localhost">>}, member}],
     Sender = jid:from_binary(<<"bob@localhost/bbb">>),
-    RoomUS = {<<"pokoik">>, <<"localhost">>},
+    RoomJid = jid:make(<<"pokoik">>, <<"muc.localhost">>, <<>>),
     HandleFun = fun(_, _, _) -> count_call(handler) end,
     gen_hook:add_handler(filter_room_packet,
                          <<"localhost">>,
@@ -133,23 +133,23 @@ codec_calls(_Config) ->
                               from_jid => jid:make_noprep(<<"a">>, <<"localhost">>, <<>>),
                               to_jid => jid:make_noprep(<<>>, <<"muc.localhost">>, <<>>) }),
     mod_muc_light_codec_modern:encode({#msg{id = <<"ajdi">>}, AffUsers},
-                                      Sender, RoomUS, HandleFun, Acc),
+                                      Sender, RoomJid, HandleFun, Acc),
     % 1 filter packet, sent 1 msg to 2 users
     check_count(1, 2),
     mod_muc_light_codec_modern:encode({set, #affiliations{}, [], []},
-                                      Sender, RoomUS, HandleFun, Acc),
+                                      Sender, RoomJid, HandleFun, Acc),
     % 1 filter packet, sent 1 IQ response to Sender
     check_count(1, 1),
     mod_muc_light_codec_modern:encode({set, #create{id = <<"ajdi">>, aff_users = AffUsers}, false},
-                                      Sender, RoomUS, HandleFun, Acc),
+                                      Sender, RoomJid, HandleFun, Acc),
     % 1 filter, 1 IQ response to Sender, 1 notification to 2 users
     check_count(1, 3),
     mod_muc_light_codec_modern:encode({set, #config{id = <<"ajdi">>}, AffUsers},
-        Sender, RoomUS, HandleFun, Acc),
+        Sender, RoomJid, HandleFun, Acc),
     % 1 filter, 1 IQ response to Sender, 1 notification to 2 users
     check_count(1, 3),
     mod_muc_light_codec_legacy:encode({#msg{id = <<"ajdi">>}, AffUsers},
-        Sender, RoomUS, HandleFun, Acc),
+        Sender, RoomJid, HandleFun, Acc),
     % 1 filter, 1 msg to 2 users
     check_count(1, 2),
     ok.


### PR DESCRIPTION
The biggest benefit is in the codec modules, I think so many jid formats is a bad and very confusing design.

Also routing handlers can reuse the already available accumulators, hence preserving the original timestamps and unique references -> again, better tracing.