### PR TITLE
[WIP] accumulate inbox queries in a single request

### DIFF
--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -9,10 +9,10 @@
 -module(mod_inbox_muclight).
 -author("ludwikbukowski").
 -include("mod_muc_light.hrl").
--include("mod_inbox.hrl").
 -include("jlib.hrl").
--include("mongoose_ns.hrl").
 -include("mongoose.hrl").
+% -include("mod_inbox.hrl").
+% -include("mongoose_ns.hrl").
 
 -export([handle_outgoing_message/5, handle_incoming_message/5]).
 
@@ -24,36 +24,63 @@
 -type r_owner() :: binary().
 -type r_none() :: binary().
 
+funfun(_HostType, false, false) ->
+    ok;
+funfun(HostType, {true, SenderKey, Id}, DoWriteToInbox) ->
+    ok = mod_inbox_backend:reset_unread(HostType, SenderKey, Id),
+    funfun(HostType, false, DoWriteToInbox);
+funfun(HostType, DoResetUnread, {true, Affs, Sender, From, Packet, Acc}) ->
+    lists:foreach(
+      fun({{U, S}, _}) ->
+              Receiver = jid:make_noprep(U, S, <<>>),
+              Attrs1 = lists:keydelete(<<"to">>, 1, Packet#xmlel.attrs),
+              Packet1 = Packet#xmlel{attrs = [{<<"to">>, jid:to_binary(Receiver)} | Attrs1]},
+              write_to_inbox(HostType, From, Receiver, Sender, Packet1, Acc)
+      end, Affs),
+    funfun(HostType, DoResetUnread, false).
+
 -spec handle_outgoing_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),
                               Room :: jid:jid(),
                               Packet :: packet(),
-                              Acc :: mongoose_acc:t()) -> any().
-handle_outgoing_message(HostType, User, Room, Packet, _TS) ->
-    maybe_reset_unread_count(HostType, User, Room, Packet).
+                              Acc :: mongoose_acc:t()) -> mongoose_acc:t().
+handle_outgoing_message(HostType, User, Room, Packet, Acc1) ->
+    ResetMarkers = mod_inbox_utils:get_reset_markers(HostType),
+    SenderKey = mod_inbox_utils:build_inbox_entry_key(User, Room),
+    {Acc2, {ok, Affs, _Version}} = mod_muc_light:get_room_affiliations(Acc1, Room),
+    DoResetUnread = case mod_inbox_utils:if_chat_marker_get_id(Packet, ResetMarkers) of
+                        undefined -> false;
+                        Id -> {true, SenderKey, Id}
+                    end,
+    DoWriteToInbox = case mod_inbox_utils:has_chat_marker(Packet) of
+                         true -> false;
+                         false ->
+                             From = jid:replace_resource(Room, jid:to_binary(jid:to_lus(User))),
+                             Packet2 = mod_inbox_utils:fill_from_attr(Packet, From),
+                             {true, Affs, User, From, Packet2, Acc2}
+                     end,
+    F = fun() -> funfun(HostType, DoResetUnread, DoWriteToInbox) end,
+    mongoose_rdbms:sql_dirty(HostType, F),
+    mongoose_acc:set_permanent(inbox, stored, true, Acc2).
 
 -spec handle_incoming_message(HostType :: mongooseim:host_type(),
                               RoomUser :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
-                              Acc :: mongoose_acc:t()) -> any().
+                              Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_incoming_message(HostType, RoomUser, Remote, Packet, Acc) ->
     case mod_inbox_utils:has_chat_marker(Packet) of
         true ->
-            %% don't store chat markers in inbox
-            ok;
+            Acc; %% don't store chat markers in inbox
         false ->
             maybe_handle_system_message(HostType, RoomUser, Remote, Packet, Acc)
     end.
-
-maybe_reset_unread_count(HostType, User, Room, Packet) ->
-    mod_inbox_utils:maybe_reset_unread_count(HostType, User, Room, Packet).
 
 -spec maybe_handle_system_message(HostType :: mongooseim:host_type(),
                                   RoomOrUser :: jid:jid(),
                                   Receiver :: jid:jid(),
                                   Packet :: exml:element(),
-                                  Acc :: mongoose_acc:t()) -> ok.
+                                  Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 maybe_handle_system_message(HostType, RoomOrUser, Receiver, Packet, Acc) ->
     case is_system_message(HostType, RoomOrUser, Receiver, Packet) of
         true ->
@@ -67,7 +94,7 @@ maybe_handle_system_message(HostType, RoomOrUser, Receiver, Packet, Acc) ->
                             Room :: jid:jid(),
                             Remote :: jid:jid(),
                             Packet :: exml:element(),
-                            Acc :: mongoose_acc:t()) -> ok.
+                            Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_system_message(HostType, Room, Remote, Packet, Acc) ->
     case system_message_type(Remote, Packet) of
         kick ->
@@ -77,14 +104,14 @@ handle_system_message(HostType, Room, Remote, Packet, Acc) ->
         other ->
             ?LOG_DEBUG(#{what => irrelevant_system_message_for_mod_inbox_muclight,
                          room => Room, exml_packet => Packet}),
-            ok
+            Acc
     end.
 
 -spec handle_invitation_message(HostType :: mongooseim:host_type(),
                                 Room :: jid:jid(),
                                 Remote :: jid:jid(),
                                 Packet :: exml:element(),
-                                Acc :: mongoose_acc:t()) -> ok.
+                                Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_invitation_message(HostType, Room, Remote, Packet, Acc) ->
     maybe_store_system_message(HostType, Room, Remote, Packet, Acc).
 
@@ -92,24 +119,25 @@ handle_invitation_message(HostType, Room, Remote, Packet, Acc) ->
                             Room :: jid:jid(),
                             Remote :: jid:jid(),
                             Packet :: exml:element(),
-                            Acc :: mongoose_acc:t()) -> ok.
+                            Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_kicked_message(HostType, Room, Remote, Packet, Acc) ->
     CheckRemove = mod_inbox_utils:get_option_remove_on_kicked(HostType),
     maybe_store_system_message(HostType, Room, Remote, Packet, Acc),
-    maybe_remove_inbox_row(HostType, Room, Remote, CheckRemove).
+    maybe_remove_inbox_row(HostType, Room, Remote, CheckRemove),
+    Acc.
 
 -spec maybe_store_system_message(HostType :: mongooseim:host_type(),
                                  Room :: jid:jid(),
                                  Remote :: jid:jid(),
                                  Packet :: exml:element(),
-                                 Acc :: mongoose_acc:t()) -> ok.
+                                 Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 maybe_store_system_message(HostType, Room, Remote, Packet, Acc) ->
     WriteAffChanges = mod_inbox_utils:get_option_write_aff_changes(HostType),
     case WriteAffChanges of
         true ->
             write_to_inbox(HostType, Room, Remote, Room, Packet, Acc);
         false ->
-            ok
+            Acc
     end.
 
 -spec maybe_remove_inbox_row(HostType :: mongooseim:host_type(),
@@ -127,11 +155,14 @@ maybe_remove_inbox_row(HostType, Room, Remote, true) ->
                      Remote :: jid:jid(),
                      Sender :: jid:jid(),
                      Packet :: exml:element(),
-                     Acc :: mongoose_acc:t()) -> ok.
-write_to_inbox(HostType, RoomUser, Remote, Remote, Packet, Acc) ->
-    mod_inbox_utils:write_to_sender_inbox(HostType, Remote, RoomUser, Packet, Acc);
-write_to_inbox(HostType, RoomUser, Remote, _Sender, Packet, Acc) ->
-    mod_inbox_utils:write_to_receiver_inbox(HostType, RoomUser, Remote, Packet, Acc).
+                     Acc :: mongoose_acc:t()) -> mongoose_acc:t().
+write_to_inbox(HostType, RoomUser, Remote, Sender, Packet, Acc) ->
+    case jid:are_bare_equal(Remote, Sender) of
+        true ->
+            mod_inbox_utils:write_to_sender_inbox(HostType, Remote, RoomUser, Packet, Acc);
+        false ->
+            mod_inbox_utils:write_to_receiver_inbox(HostType, RoomUser, Remote, Packet, Acc)
+    end.
 
 %%%%%%%
 %% Predicate funs

--- a/src/inbox/mod_inbox_one2one.erl
+++ b/src/inbox/mod_inbox_one2one.erl
@@ -8,39 +8,57 @@
 %%%-------------------------------------------------------------------
 -module(mod_inbox_one2one).
 -author("ludwikbukowski").
--include("mod_inbox.hrl").
--include("jlib.hrl").
--include("mongoose_ns.hrl").
 
 -export([handle_outgoing_message/5, handle_incoming_message/5]).
 
 -type packet() :: exml:element().
 
+funfun(_HostType, false, false) ->
+    ok;
+funfun(HostType, {true, SenderKey, Id}, DoWriteToInbox) ->
+    ok = mod_inbox_backend:reset_unread(HostType, SenderKey, Id),
+    funfun(HostType, false, DoWriteToInbox);
+funfun(HostType, DoResetUnread, {true, SenderKey, ReceiverKey, MsgId, Content, Timestamp, Count}) ->
+    ok = mod_inbox_backend:set_inbox(HostType, SenderKey, Content, Count, MsgId, Timestamp),
+    ok = mod_inbox_backend:set_inbox_incr_unread(HostType, ReceiverKey, Content, MsgId, Timestamp),
+    funfun(HostType, DoResetUnread, false).
+
 -spec handle_outgoing_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
-                              Acc :: mongoose_acc:t()) -> ok.
+                              Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_outgoing_message(HostType, User, Remote, Packet, Acc) ->
-    maybe_reset_unread_count(HostType, User, Remote, Packet),
-    maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, fun write_to_sender_inbox/5).
+    ResetMarkers = mod_inbox_utils:get_reset_markers(HostType),
+    SenderKey = mod_inbox_utils:build_inbox_entry_key(User, Remote),
+    DoResetUnread = case mod_inbox_utils:if_chat_marker_get_id(Packet, ResetMarkers) of
+        undefined -> false;
+        Id -> {true, SenderKey, Id}
+    end,
+    DoWriteToInbox = case mod_inbox_utils:has_chat_marker(Packet) of
+        true ->
+            false;
+        false ->
+            MsgId = mod_inbox_utils:get_msg_id(Packet),
+            Packet2 = mod_inbox_utils:fill_from_attr(Packet, User),
+            Content = exml:to_binary(Packet2),
+            Timestamp = mongoose_acc:timestamp(Acc),
+            Count = 0, %% no unread for a user because he writes new messages which assumes he read all previous messages.
+            ReceiverKey = mod_inbox_utils:build_inbox_entry_key(Remote, User),
+            {true, SenderKey, ReceiverKey, MsgId, Content, Timestamp, Count}
+    end,
+    F = fun () -> funfun(HostType, DoResetUnread, DoWriteToInbox) end,
+    mongoose_rdbms:sql_dirty(HostType, F),
+    mongoose_acc:set_permanent(inbox, stored, true, Acc).
 
 -spec handle_incoming_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),
                               Remote :: jid:jid(),
                               Packet :: packet(),
-                              Acc :: mongoose_acc:t()) -> ok | {ok, integer()}.
+                              Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_incoming_message(HostType, User, Remote, Packet, Acc) ->
-    maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, fun write_to_receiver_inbox/5).
-
-maybe_reset_unread_count(HostType, User, Remote, Packet) ->
-    mod_inbox_utils:maybe_reset_unread_count(HostType, User, Remote, Packet).
+    maybe_write_to_inbox(HostType, User, Remote, Packet, Acc,
+                         fun mod_inbox_utils:write_to_receiver_inbox/5).
 
 maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, WriteF) ->
     mod_inbox_utils:maybe_write_to_inbox(HostType, User, Remote, Packet, Acc, WriteF).
-
-write_to_sender_inbox(HostType, User, Remote, Packet, Acc) ->
-    mod_inbox_utils:write_to_sender_inbox(HostType, User, Remote, Packet, Acc).
-
-write_to_receiver_inbox(HostType, User, Remote, Packet, Acc) ->
-    mod_inbox_utils:write_to_receiver_inbox(HostType, User, Remote, Packet, Acc).


### PR DESCRIPTION
This branch attempts to run all of the inbox processing in a single request. For this, when a message is sent, in the `user_send_packet` hook we build a closure for the DB worker to execute, which contains all the data it needs to write for all the related rows. In the case of 1:1 messages, this doesn't make that big of a difference, but in the case of big muc_light rooms, say 100 participants, instead of running a hundred requests with repeated calculations, we run a single one with all the calculation cached. This mostly means sending a single, albeit bigger, erlang message to the DB worker, which will then run the entire inbox update.

The only thing to fix is then federation: this will still run the `filter_local_packet` message. The trick is in setting an `{inbox, stored}` flag as permanent in the accumulator. If the routing was local, this flag would be seen in such accumulator, so we can then know when do we need to run the hook or not.