### PR TITLE
BOSH with dynamic domains

### DIFF
--- a/big_tests/dynamic_domains.config
+++ b/big_tests/dynamic_domains.config
@@ -60,6 +60,15 @@
         {transport, escalus_bosh},
         {path, <<"/http-bind">>},
         {port, 5280}]},
+    {carol_s, [
+        {username, <<"carol_s">>},
+        {server, <<"domain.example.com">>},
+        {host, <<"localhost">>},
+        {password, <<"jinglebells_s">>},
+        {transport, escalus_bosh},
+        {ssl, true},
+        {path, <<"/http-bind">>},
+        {port, 5285}]},
     {kate, [
         {username, <<"kate">>},
         {server, <<"domain.example.com">>},
@@ -70,6 +79,14 @@
         {server, <<"domain.example.com">>},
         {host, <<"localhost">>},
         {password, <<"nicniema">>}]},
+    {geralt, [
+        {username, <<"geralt">>},
+        {server, <<"domain.example.com">>},
+        {host, <<"localhost">>},
+        {password, <<"witcher">>},
+        {transport, escalus_ws},
+        {port, 5280},
+        {wspath, <<"/ws-xmpp">>}]},
     {admin, [
         {username, <<"admin">>},
         {server, <<"localhost">>},

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -13,6 +13,8 @@
 
 {suites, "tests", acc_e2e_SUITE}.
 
+{suites, "tests", bosh_SUITE}.
+
 {suites, "tests", carboncopy_SUITE}.
 
 {suites, "tests", disco_and_caps_SUITE}.

--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -24,6 +24,7 @@
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
                              rpc/4]).
+-import(domain_helper, [host_type/0]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -44,7 +45,7 @@ all() ->
      {group, essential_https},
      {group, chat_https},
      {group, interleave_requests_statem}
-     ].
+    ].
 
 groups() ->
     [
@@ -185,10 +186,10 @@ do_not_accept_0_hold_value(Config) ->
 
 
 send_specific_hold(Config, HoldValue) ->
-    {Server, Path, Client} = get_fusco_connection(Config),
+    {Domain, Path, Client} = get_fusco_connection(Config),
 
     Rid = rand:uniform(1000000),
-    Body0 = escalus_bosh:session_creation_body(2, <<"1.0">>, <<"en">>, Rid, Server, nil),
+    Body0 = escalus_bosh:session_creation_body(2, <<"1.0">>, <<"en">>, Rid, Domain, nil),
     #xmlel{attrs = Attrs0} = Body0,
     Attrs = lists:keyreplace(<<"hold">>, 1, Attrs0, {<<"hold">>, HoldValue}),
     Body = Body0#xmlel{attrs = Attrs},
@@ -258,10 +259,11 @@ get_fusco_connection(Config) ->
     NamedSpecs = escalus_config:get_config(escalus_users, Config),
     CarolSpec = proplists:get_value(?config(user, Config), NamedSpecs),
     Server = proplists:get_value(server, CarolSpec),
+    Host = proplists:get_value(host, CarolSpec, Server),
     Path = proplists:get_value(path, CarolSpec),
     Port = proplists:get_value(port, CarolSpec),
     UseSSL = proplists:get_value(ssl, CarolSpec, false),
-    {ok, Client} = fusco_cp:start_link({binary_to_list(Server), Port, UseSSL}, [], 1),
+    {ok, Client} = fusco_cp:start_link({binary_to_list(Host), Port, UseSSL}, [], 1),
     {Server, Path, Client}.
 
 stream_error(Config) ->
@@ -847,8 +849,8 @@ inactivity() ->
 
 inactivity(Value) ->
     {inactivity,
-     fun() -> rpc(mim(), mod_bosh, get_inactivity, [domain()]) end,
-     fun(V) -> rpc(mim(), mod_bosh, set_inactivity, [domain(), V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_inactivity, [host_type()]) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_inactivity, [host_type(), V]) end,
      Value}.
 
 max_wait() ->
@@ -856,14 +858,14 @@ max_wait() ->
 
 max_wait(Value) ->
     {max_wait,
-     fun() -> rpc(mim(), mod_bosh, get_max_wait, [domain()]) end,
-     fun(V) -> rpc(mim(), mod_bosh, set_max_wait, [domain(), V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_max_wait, [host_type()]) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_max_wait, [host_type(), V]) end,
      Value}.
 
 server_acks_opt() ->
     {server_acks,
-     fun() -> rpc(mim(), mod_bosh, get_server_acks, [domain()]) end,
-     fun(V) -> rpc(mim(), mod_bosh, set_server_acks, [domain(), V]) end,
+     fun() -> rpc(mim(), mod_bosh, get_server_acks, [host_type()]) end,
+     fun(V) -> rpc(mim(), mod_bosh, set_server_acks, [host_type(), V]) end,
      true}.
 
 is_session_alive(Sid) ->

--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -47,16 +47,15 @@ all() ->
      ].
 
 groups() ->
-    G = [
-         {essential, [shuffle], essential_test_cases()},
-         {essential_https, [shuffle], essential_test_cases()},
-         {chat, [shuffle], chat_test_cases()},
-         {chat_https, [shuffle], chat_test_cases()},
-         {time, [parallel], time_test_cases()},
-         {acks, [shuffle], acks_test_cases()},
-         {interleave_requests_statem, [parallel], [interleave_requests_statem]}
-        ],
-    ct_helper:repeat_all_until_all_ok(G).
+    [
+     {essential, [shuffle], essential_test_cases()},
+     {essential_https, [shuffle], essential_test_cases()},
+     {chat, [shuffle], chat_test_cases()},
+     {chat_https, [shuffle], chat_test_cases()},
+     {time, [parallel], time_test_cases()},
+     {acks, [shuffle], acks_test_cases()},
+     {interleave_requests_statem, [parallel], [interleave_requests_statem]}
+    ].
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -23,6 +23,8 @@
 [[host_config]]
   host_type = \"test type\"
 
+  [host_config.modules.mod_bosh]
+
   [host_config.modules.mod_cache_users]
 
   [host_config.modules.mod_carboncopy]

--- a/src/system_metrics/mongoose_module_metrics.erl
+++ b/src/system_metrics/mongoose_module_metrics.erl
@@ -4,18 +4,19 @@
 
 -ignore_xref([behaviour_info/1]).
 
--callback config_metrics(string()) -> any().
+-callback config_metrics(mongooseim:host_type()) -> any().
 
 -optional_callbacks([config_metrics/1]).
 
-opts_for_module(Host, Module, OptsToReport) ->
+-spec opts_for_module(mongooseim:host_type(), module(), list()) -> list() | tuple().
+opts_for_module(HostType, Module, OptsToReport) ->
     try
-        Opts = gen_mod:get_module_opts(Host, Module),
+        Opts = gen_mod:get_module_opts(HostType, Module),
         lists:map(
             fun({OptToReport, DefaultValue}) ->
                     Value = proplists:get_value(OptToReport, Opts, DefaultValue),
                     {OptToReport, Value}
-            end,OptsToReport)
+            end, OptsToReport)
     catch
         _:_ -> {none, none}
     end.


### PR DESCRIPTION
Update `mod_bosh` and the corresponding big tests to work with dynamic domains.

Also: fix some type specs related to system metrics.