### PR TITLE
Fix anonymous login and test it for dynamic domains

### DIFF
--- a/big_tests/dynamic_domains.config
+++ b/big_tests/dynamic_domains.config
@@ -6,7 +6,8 @@
                  {host_type, <<"test type">>},
                  {secondary_domain, <<"domain.example.org">>},
                  {secondary_host_type, <<"test type">>},
-                 {dynamic_domains, [<<"domain.example.com">>, <<"domain.example.org">>]},
+                 {dynamic_domains, [{<<"test type">>, [<<"domain.example.com">>, <<"domain.example.org">>]},
+                                    {<<"anonymous">>, [<<"anonymous.example.com">>]}]},
                  {muc_service, <<"groupchats.domain.example.com">>},
                  {muc_service_pattern, <<"groupchats.@HOST@">>},
                  {muc_light_service, <<"muclight2.domain.example.com">>},
@@ -107,4 +108,12 @@
         {server, <<"domain.example.com">>},
         {host, <<"localhost">>},
         {password, <<"cosontuma">>}]}
+]}.
+
+{escalus_anon_users, [
+    {jon, [
+        {username, <<"jon">>},
+        {server, <<"anonymous.example.com">>},
+        {host, <<"localhost">>},
+        {auth_method, <<"SASL-ANON">>}]}
 ]}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -11,6 +11,8 @@
 
 {suites, "tests", accounts_SUITE}.
 
+{suites, "tests", anonymous_SUITE}.
+
 {suites, "tests", acc_e2e_SUITE}.
 
 {suites, "tests", bosh_SUITE}.

--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -48,6 +48,7 @@ delete_domain(Node, Domain) ->
     ok = rpc(Node, mongoose_domain_core, delete, [Domain]).
 
 for_each_configured_domain(F) ->
-    [F(#{node => proplists:get_value(node, Opts)}, Domain, proplists:get_value(host_type, Opts)) ||
+    [F(#{node => proplists:get_value(node, Opts)}, Domain, HostType) ||
         {_, Opts} <- ct:get_config(hosts),
-        Domain <- proplists:get_value(dynamic_domains, Opts, [])].
+        {HostType, Domains} <- proplists:get_value(dynamic_domains, Opts, []),
+        Domain <- Domains].

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -5,7 +5,7 @@
 {hidden_service_port, 8189}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
-{host_types, "\"test type\", \"dummy auth\""}.
+{host_types, "\"test type\", \"dummy auth\", \"anonymous\""}.
 {default_server_domain, "\"localhost\""}.
 
 {mod_privacy, ""}.
@@ -14,6 +14,15 @@
 {host_config,
   "[[host_config]]
   host = \"anonymous.localhost\"
+
+  [host_config.auth]
+    methods = [\"anonymous\"]
+    anonymous.allow_multiple_connections = true
+    anonymous.protocol = \"both\"
+
+[[host_config]]
+  host_type = \"anonymous\"
+  modules = { }
 
   [host_config.auth]
     methods = [\"anonymous\"]

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -90,7 +90,7 @@ auth_anonymous(_Config) ->
     HostType = host_type(),
     {U, S, R, JID, SID} = get_fake_session(),
     ejabberd_auth_anonymous:start(HostType),
-    Info = [{auth_module, ejabberd_auth_anonymous}],
+    Info = #{auth_module => cyrsasl_anonymous},
     ejabberd_auth_anonymous:register_connection(#{}, HostType, SID, JID, Info),
     true = ejabberd_auth_anonymous:does_user_exist(HostType, U, S),
     mongoose_hooks:session_cleanup(S, new_acc(S), U, R, SID),


### PR DESCRIPTION
- Fix two bugs in one function (!) that completely disabled anonymous connection registration
- Add tests for the fixed function
- Test anonymous login with dynamic domains. To do so, a separate host type needed to be added.
