### PR TITLE
Support dynamic domains in mod_http_upload

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -37,6 +37,8 @@
 
 {suites, "tests", mod_blocking_SUITE}.
 
+{suites, "tests", mod_http_upload_SUITE}.
+
 {suites, "tests", mod_ping_SUITE}.
 
 {suites, "tests", mod_time_SUITE}.

--- a/src/admin_extra/service_admin_extra_upload.erl
+++ b/src/admin_extra/service_admin_extra_upload.erl
@@ -26,20 +26,20 @@ commands() -> [
     }
 ].
 
--spec get_urls(Host :: binary(), Filename :: binary(), Size :: pos_integer(),
+-spec get_urls(HostType :: mongooseim:host_type(), Filename :: binary(), Size :: pos_integer(),
                ContentType :: binary() | undefined, Timeout :: pos_integer()) ->
         {ok, string()} | {error, string()}.
-get_urls(_Host, _Filename, Size, _ContentType, _Timeout) when Size =< 0->
+get_urls(_HostType, _Filename, Size, _ContentType, _Timeout) when Size =< 0->
     {error, "size must be positive integer"};
-get_urls(_Host, _Filename, _Size, _ContentType, Timeout) when Timeout =< 0->
+get_urls(_HostType, _Filename, _Size, _ContentType, Timeout) when Timeout =< 0->
     {error, "timeout must be positive integer"};
-get_urls(Host, Filename, Size, <<"">>, Timeout) ->
-    get_urls(Host, Filename, Size, undefined, Timeout);
-get_urls(Host, Filename, Size, ContentType, Timeout) ->
-    case gen_mod:is_loaded(Host, mod_http_upload) of
+get_urls(HostType, Filename, Size, <<"">>, Timeout) ->
+    get_urls(HostType, Filename, Size, undefined, Timeout);
+get_urls(HostType, Filename, Size, ContentType, Timeout) ->
+    case gen_mod:is_loaded(HostType, mod_http_upload) of
         true ->
             {PutURL, GetURL, Header} =
-                mod_http_upload:get_urls(Host, Filename, Size, ContentType, Timeout),
+                mod_http_upload:get_urls(HostType, Filename, Size, ContentType, Timeout),
             {ok, generate_output_message(PutURL, GetURL, Header)};
         false ->
             {error, "mod_http_upload is not loaded for this host"}

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -29,15 +29,25 @@
 -define(DEFAULT_MAX_FILE_SIZE, 10 * 1024 * 1024). % 10 MB
 -define(DEFAULT_SUBHOST, <<"upload.@HOST@">>).
 
--export([start/2, stop/1, process_iq/4, process_disco_iq/4, get_urls/5, config_spec/0]).
+%% gen_mod callbacks
+-export([start/2, 
+         stop/1, 
+         config_spec/0, 
+         supported_features/0]).
 
-%% Hook handlers
--export([disco_local_items/1]).
+%% IQ and hooks handlers
+-export([process_iq/5, 
+         process_disco_iq/5,
+         disco_local_items/1]).
 
+%% API
+-export([get_urls/5]).
+
+%% mongoose_module_metrics callbacks
 -export([config_metrics/1]).
 
 -ignore_xref([{mod_http_upload_backend, create_slot, 6},
-              behaviour_info/1, disco_local_items/1, process_disco_iq/4, process_iq/4]).
+              behaviour_info/1, disco_local_items/1, process_disco_iq/5, process_iq/5]).
 
 %%--------------------------------------------------------------------
 %% Callbacks
@@ -52,100 +62,42 @@
 %% API
 %%--------------------------------------------------------------------
 
--spec start(Host :: jid:server(), Opts :: list()) -> any().
-start(Host, Opts) ->
+-spec start(HostType :: mongooseim:host_type(), Opts :: gen_mod:module_opts()) -> ok.
+start(HostType, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, one_queue),
-    SubHost = subhost(Host),
-    %% TODO: Conversion of this module is not done, it doesn't support dynamic
-    %%       domains yet. Only subdomain registration is done properly.
-    SubdomainPattern = subdomain_pattern(Host),
+    SubdomainPattern = subdomain_pattern(HostType),
     PacketHandler = mongoose_packet_handler:new(ejabberd_local),
-    mongoose_domain_api:register_subdomain(Host, SubdomainPattern, PacketHandler),
-    ejabberd_hooks:add(disco_local_items, Host, ?MODULE, disco_local_items, 90),
-    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030,
-                                  ?MODULE, process_iq, IQDisc),
-    gen_iq_handler:add_iq_handler(ejabberd_local, SubHost, ?NS_DISCO_INFO,
-                                  ?MODULE, process_disco_iq, IQDisc),
-    gen_mod:start_backend_module(?MODULE, with_default_backend(Opts), [create_slot]).
 
+    mongoose_domain_api:register_subdomain(HostType, SubdomainPattern, PacketHandler),
+    [gen_iq_handler:add_iq_handler_for_subdomain(HostType, SubdomainPattern, Namespace, 
+                                                 Component, Fn, #{}, IQDisc) ||
+        {Component, Namespace, Fn} <- iq_handlers()],
+    gen_mod:start_backend_module(?MODULE, with_default_backend(Opts), [create_slot]),
+    ejabberd_hooks:add(hooks(HostType)),
+    ok.
 
--spec stop(Host :: jid:server()) -> any().
-stop(Host) ->
-    SubHost = subhost(Host),
-    ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, disco_local_items, 90),
-    gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_HTTP_UPLOAD_030),
-    gen_iq_handler:remove_iq_handler(ejabberd_local, SubHost, ?NS_DISCO_INFO),
-    SubdomainPattern = subdomain_pattern(Host),
-    mongoose_domain_api:unregister_subdomain(Host, SubdomainPattern).
+-spec stop(HostType :: mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    SubdomainPattern = subdomain_pattern(HostType),
 
+    ejabberd_hooks:delete(hooks(HostType)),
+    [gen_iq_handler:remove_iq_handler_for_subdomain(HostType, SubdomainPattern, Namespace, 
+                                                    Component) ||
+        {Component, Namespace, _Fn} <- iq_handlers()],
 
--spec process_iq(From :: jid:jid(), To :: jid:jid(), Acc :: mongoose_acc:t(),
-                 IQ :: jlib:iq()) ->
-    {mongoose_acc:t(), jlib:iq() | ignore}.
-process_iq(_From, _To, Acc, IQ = #iq{type = set, lang = Lang, sub_el = SubEl}) ->
-    Error = mongoose_xmpp_errors:not_allowed(Lang, <<"IQ set is not allowed for HTTP upload">>),
-    {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
-process_iq(_From, _To = #jid{lserver = SubHost}, Acc, IQ = #iq{type = get, sub_el = Request}) ->
-    {ok, HostType} = mongoose_domain_api:get_subdomain_host_type(SubHost),
-    Res = case parse_request(Request) of
-        {Filename, Size, ContentType} ->
-            MaxFileSize = max_file_size(HostType),
-            case MaxFileSize =:= undefined orelse Size =< MaxFileSize of
-                true ->
-                    UTCDateTime = calendar:universal_time(),
-                    Token = generate_token(HostType),
-                    Opts = module_opts(HostType),
+    mongoose_domain_api:unregister_subdomain(HostType, SubdomainPattern),
+    ok.
 
-                    {PutUrl, GetUrl, Headers} =
-                        mod_http_upload_backend:create_slot(UTCDateTime, Token, Filename,
-                                                            ContentType, Size, Opts),
+iq_handlers() ->
+    [{ejabberd_local, ?NS_HTTP_UPLOAD_030, fun ?MODULE:process_iq/5},
+     {ejabberd_local, ?NS_DISCO_INFO, fun ?MODULE:process_disco_iq/5}].
 
-                    compose_iq_reply(IQ, PutUrl, GetUrl, Headers);
+hooks(HostType) ->
+    [{disco_local_items, HostType, ?MODULE, disco_local_items, 90}].
 
-                false ->
-                    IQ#iq{type = error, sub_el = [file_too_large_error(MaxFileSize)]}
-            end;
-
-        bad_request ->
-            IQ#iq{type = error, sub_el = [Request, mongoose_xmpp_errors:bad_request()]}
-    end,
-    {Acc, Res}.
-
--spec process_disco_iq(From :: jid:jid(), To :: jid:jid(), Acc :: mongoose_acc:t(),
-                       IQ :: jlib:iq()) ->
-          {mongoose_acc:t(), jlib:iq()}.
-process_disco_iq(_From, _To, Acc, #iq{type = set, lang = Lang, sub_el = SubEl} = IQ) ->
-    ErrorMsg = <<"IQ set is not allowed for service discovery">>,
-    Error = mongoose_xmpp_errors:not_allowed(Lang, ErrorMsg),
-    {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
-process_disco_iq(_From, To, Acc, #iq{type = get, lang = Lang, sub_el = SubEl} = IQ) ->
-    LServer = To#jid.lserver,
-    Node = xml:get_tag_attr_s(<<"node">>, SubEl),
-    case Node of
-        <<>> ->
-            Identity = mongoose_disco:identities_to_xml(disco_identity(Lang)),
-            Info = disco_info(LServer),
-            Features = mongoose_disco:features_to_xml([?NS_HTTP_UPLOAD_030]),
-            {Acc, IQ#iq{type = result,
-                        sub_el = [#xmlel{name = <<"query">>,
-                                         attrs = [{<<"xmlns">>, ?NS_DISCO_INFO}],
-                                         children = Identity ++ Info ++ Features}]}};
-        _ ->
-            ErrorMsg = <<"Node is not supported by HTTP upload">>,
-            Error = mongoose_xmpp_errors:item_not_found(Lang, ErrorMsg),
-            {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}}
-    end.
-
--spec get_urls(Host :: jid:lserver(), Filename :: binary(), Size :: pos_integer(),
-               ContentType :: binary() | undefined, Timeout :: pos_integer()) ->
-                  {PutURL :: binary(), GetURL :: binary(), Headers :: #{binary() => binary()}}.
-get_urls(Host, Filename, Size, ContentType, Timeout) ->
-    UTCDateTime = calendar:universal_time(),
-    Token = generate_token(Host),
-    Opts = module_opts(Host),
-    NewOpts = gen_mod:set_opt(expiration_time, Opts, Timeout),
-    mod_http_upload_backend:create_slot(UTCDateTime, Token, Filename,
-                                        ContentType, Size, NewOpts).
+%%--------------------------------------------------------------------
+%% config_spec
+%%--------------------------------------------------------------------
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
@@ -179,11 +131,86 @@ s3_spec() ->
         required = [<<"bucket_url">>, <<"region">>, <<"access_key_id">>, <<"secret_access_key">>]
     }.
 
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
+
+%%--------------------------------------------------------------------
+%% IQ and hook handlers
+%%--------------------------------------------------------------------
+ 
+-spec process_iq(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(), 
+                 IQ :: jlib:iq(), map()) ->
+    {mongoose_acc:t(), jlib:iq() | ignore}.
+process_iq(Acc, _From, _To, IQ = #iq{type = set, lang = Lang, sub_el = SubEl}, _Extra) ->
+    Error = mongoose_xmpp_errors:not_allowed(Lang, <<"IQ set is not allowed for HTTP upload">>),
+    {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
+process_iq(Acc,  _From, _To, IQ = #iq{type = get, sub_el = Request}, _Extra) ->
+    HostType = mongoose_acc:host_type(Acc),
+    Res = case parse_request(Request) of
+        {Filename, Size, ContentType} ->
+            MaxFileSize = max_file_size(HostType),
+            case MaxFileSize =:= undefined orelse Size =< MaxFileSize of
+                true ->
+                    UTCDateTime = calendar:universal_time(),
+                    Token = generate_token(HostType),
+                    Opts = module_opts(HostType),
+
+                    {PutUrl, GetUrl, Headers} =
+                        mod_http_upload_backend:create_slot(UTCDateTime, Token, Filename,
+                                                            ContentType, Size, Opts),
+
+                    compose_iq_reply(IQ, PutUrl, GetUrl, Headers);
+
+                false ->
+                    IQ#iq{type = error, sub_el = [file_too_large_error(MaxFileSize)]}
+            end;
+
+        bad_request ->
+            IQ#iq{type = error, sub_el = [Request, mongoose_xmpp_errors:bad_request()]}
+    end,
+    {Acc, Res}.
+
+-spec process_disco_iq(Acc :: mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(), 
+                       IQ :: jlib:iq(), map()) ->
+          {mongoose_acc:t(), jlib:iq()}.
+process_disco_iq(Acc, _From, _To, #iq{type = set, lang = Lang, sub_el = SubEl} = IQ, _Extra) ->
+    ErrorMsg = <<"IQ set is not allowed for service discovery">>,
+    Error = mongoose_xmpp_errors:not_allowed(Lang, ErrorMsg),
+    {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
+process_disco_iq(Acc, _From, _To, #iq{type = get, lang = Lang, sub_el = SubEl} = IQ, _Extra) ->
+    Node = xml:get_tag_attr_s(<<"node">>, SubEl),
+    case Node of
+        <<>> ->
+            Identity = mongoose_disco:identities_to_xml(disco_identity(Lang)),
+            Info = disco_info(mongoose_acc:host_type(Acc)),
+            Features = mongoose_disco:features_to_xml([?NS_HTTP_UPLOAD_030]),
+            {Acc, IQ#iq{type = result,
+                        sub_el = [#xmlel{name = <<"query">>,
+                                         attrs = [{<<"xmlns">>, ?NS_DISCO_INFO}],
+                                         children = Identity ++ Info ++ Features}]}};
+        _ ->
+            ErrorMsg = <<"Node is not supported by HTTP upload">>,
+            Error = mongoose_xmpp_errors:item_not_found(Lang, ErrorMsg),
+            {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}}
+    end.
+
 -spec disco_local_items(mongoose_disco:item_acc()) -> mongoose_disco:item_acc().
-disco_local_items(Acc = #{to_jid := #jid{lserver = Host}, node := <<>>, lang := Lang}) ->
-    mongoose_disco:add_items([#{jid => subhost(Host), name => my_disco_name(Lang)}], Acc);
+disco_local_items(Acc = #{host_type := HostType, to_jid := #jid{lserver = Domain}, node := <<>>, lang := Lang}) ->
+    mongoose_disco:add_items([#{jid => subdomain(HostType, Domain), name => my_disco_name(Lang)}], Acc);
 disco_local_items(Acc) ->
     Acc.
+
+-spec get_urls(HostType :: mongooseim:host_type(), Filename :: binary(), Size :: pos_integer(),
+               ContentType :: binary() | undefined, Timeout :: pos_integer()) ->
+                  {PutURL :: binary(), GetURL :: binary(), Headers :: #{binary() => binary()}}.
+get_urls(HostType, Filename, Size, ContentType, Timeout) ->
+    UTCDateTime = calendar:universal_time(),
+    Token = generate_token(HostType),
+    Opts = module_opts(HostType),
+    NewOpts = gen_mod:set_opt(expiration_time, Opts, Timeout),
+    mod_http_upload_backend:create_slot(UTCDateTime, Token, Filename,
+                                        ContentType, Size, NewOpts).
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -195,9 +222,8 @@ disco_identity(Lang) ->
        type => <<"file">>,
        name => my_disco_name(Lang)}].
 
--spec disco_info(jid:lserver()) -> [exml:element()].
-disco_info(SubHost) ->
-    {ok, HostType} = mongoose_domain_api:get_subdomain_host_type(SubHost),
+-spec disco_info(mongooseim:host_type()) -> [exml:element()].
+disco_info(HostType) ->
     case max_file_size(HostType) of
         undefined ->
             [];
@@ -206,12 +232,10 @@ disco_info(SubHost) ->
             [get_disco_info_form(MaxFileSizeBin)]
     end.
 
--spec subhost(mongooseim:host_type()) -> mongooseim:domain_name().
-subhost(HostType) ->
-    %% TODO: this works only for statically configured hosts, when HostType =:= Domain.
-    DefaultSubdomainPattern =
-        mongoose_subdomain_utils:make_subdomain_pattern(?DEFAULT_SUBHOST),
-    gen_mod:get_module_opt_subhost(HostType, ?MODULE, DefaultSubdomainPattern).
+-spec subdomain(mongooseim:host_type(), mongooseim:domain_name()) -> mongooseim:domain_name().
+subdomain(HostType, Domain) ->
+    SubdomainPattern = subdomain_pattern(HostType),
+    mongoose_subdomain_utils:get_fqdn(SubdomainPattern, Domain).
 
 -spec subdomain_pattern(mongooseim:host_type()) ->
     mongoose_subdomain_utils:subdomain_pattern().
@@ -239,14 +263,14 @@ compose_iq_reply(IQ, PutUrl, GetUrl, Headers) ->
     IQ#iq{type = result, sub_el =[Slot]}.
 
 
--spec token_bytes(jid:server()) -> pos_integer().
-token_bytes(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, token_bytes, ?DEFAULT_TOKEN_BYTES).
+-spec token_bytes(mongooseim:host_type()) -> pos_integer().
+token_bytes(HostType) ->
+    gen_mod:get_module_opt(HostType, ?MODULE, token_bytes, ?DEFAULT_TOKEN_BYTES).
 
 
--spec max_file_size(jid:server()) -> pos_integer() | undefined.
-max_file_size(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, max_file_size, ?DEFAULT_MAX_FILE_SIZE).
+-spec max_file_size(mongooseim:host_type()) -> pos_integer() | undefined.
+max_file_size(HostType) ->
+    gen_mod:get_module_opt(HostType, ?MODULE, max_file_size, ?DEFAULT_MAX_FILE_SIZE).
 
 
 -spec with_default_backend(Opts :: proplists:proplist()) -> proplists:proplist().
@@ -257,14 +281,14 @@ with_default_backend(Opts) ->
     end.
 
 
--spec module_opts(jid:server()) -> proplists:proplist().
-module_opts(Host) ->
-    gen_mod:get_module_opts(Host, ?MODULE).
+-spec module_opts(mongooseim:host_type())-> proplists:proplist().
+module_opts(HostType) ->
+    gen_mod:get_module_opts(HostType, ?MODULE).
 
 
--spec generate_token(jid:server()) -> binary().
-generate_token(Host) ->
-    base16:encode(crypto:strong_rand_bytes(token_bytes(Host))).
+-spec generate_token(mongooseim:host_type()) -> binary().
+generate_token(HostType) ->
+    base16:encode(crypto:strong_rand_bytes(token_bytes(HostType))).
 
 
 -spec file_too_large_error(MaxFileSize :: non_neg_integer()) -> exml:element().
@@ -322,6 +346,6 @@ is_nonempty_binary(_) -> false.
 is_positive_integer(X) when is_integer(X) -> X > 0;
 is_positive_integer(_) -> false.
 
-config_metrics(Host) ->
+config_metrics(HostType) ->
     OptsToReport = [{backend, s3}], % list of tuples {option, default_value}
-    mongoose_module_metrics:opts_for_module(Host, ?MODULE, OptsToReport).
+    mongoose_module_metrics:opts_for_module(HostType, ?MODULE, OptsToReport).


### PR DESCRIPTION
This PR adds missing support for dynamic domains in `mod_http_upload` and adapts tests. It also replaces `host` with `host_type` in `service_admin_extra_upload`.