### PR TITLE
Add `sasl_SUITE` and `sasl_external_SUITE` to dynamic domains testing 

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -82,6 +82,7 @@
 {suites, "tests", rest_client_SUITE}.
 
 {suites, "tests", sasl_SUITE}.
+{suites, "tests", sasl_external_SUITE}.
 
 {suites, "tests", service_domain_db_SUITE}.
 

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -81,6 +81,8 @@
 
 {suites, "tests", rest_client_SUITE}.
 
+{suites, "tests", sasl_SUITE}.
+
 {suites, "tests", service_domain_db_SUITE}.
 
 {suites, "tests", sic_SUITE}.

--- a/big_tests/tests/sasl_SUITE.erl
+++ b/big_tests/tests/sasl_SUITE.erl
@@ -39,9 +39,8 @@ all() ->
      {group, node_config}].
 
 groups() ->
-    G = [{domain_config, [sequence], all_tests()},
-         {node_config, [sequence], all_tests()}],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{domain_config, [sequence], all_tests()},
+     {node_config, [sequence], all_tests()}].
 
 all_tests() ->
     [text_response].
@@ -90,8 +89,8 @@ text_response(Config) ->
 %%--------------------------------------------------------------------
 
 mech_option_key(domain_config) ->
-    Domain = ct:get_config({hosts, mim, domain}),
-    {sasl_mechanisms, Domain};
+    HostType = domain_helper:host_type(),
+    {sasl_mechanisms, HostType};
 mech_option_key(node_config) ->
     sasl_mechanisms.
 

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -482,4 +482,4 @@ add_domain_str(User) ->
 
 -spec add_domain(User :: binary()) -> binary().
 add_domain(User) ->
-    <<User/binary, <<"@">>/binary, (domain())/binary>>.
+    <<User/binary, "@", (domain())/binary>>.

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -343,13 +343,13 @@ self_signed_cert_is_allowed_with(EscalusTransport, C) ->
 
 no_cert_fails_to_authenticate(_C) ->
     UserSpec = [{username, <<"no_cert_user">>},
-		{server, domain()},
-		{host, <<"localhost">>},
-        {port, ct:get_config({hosts, mim, c2s_port})},
-		{password, <<"break_me">>},
-		{resource, <<>>}, %% Allow the server to generate the resource
-		{auth, {escalus_auth, auth_sasl_external}},
-		{starttls, required}],
+                {server, domain()},
+                {host, <<"localhost">>},
+                {port, ct:get_config({hosts, mim, c2s_port})},
+                {password, <<"break_me">>},
+                {resource, <<>>}, %% Allow the server to generate the resource
+                {auth, {escalus_auth, auth_sasl_external}},
+                {starttls, required}],
 
     Result = escalus_connection:start(UserSpec),
     ?assertMatch({error, {connection_step_failed, _, _}}, Result),
@@ -421,14 +421,14 @@ generate_user(C, User, Transport) ->
     UserCert = maps:get(User, Certs),
 
     Common = [{username, list_to_binary(User)},
-	      {server, domain()},
-          {host, <<"localhost">>},
-	      {password, <<"break_me">>},
-	      {resource, <<>>}, %% Allow the server to generate the resource
-	      {auth, {escalus_auth, auth_sasl_external}},
-	      {transport, Transport},
-	      {ssl_opts, [{certfile, maps:get(cert, UserCert)},
-			  {keyfile, maps:get(key, UserCert)}]}],
+              {server, domain()},
+              {host, <<"localhost">>},
+              {password, <<"break_me">>},
+              {resource, <<>>}, %% Allow the server to generate the resource
+              {auth, {escalus_auth, auth_sasl_external}},
+              {transport, Transport},
+              {ssl_opts, [{certfile, maps:get(cert, UserCert)},
+                          {keyfile, maps:get(key, UserCert)}]}],
     Common ++ transport_specific_options(Transport)
     ++ [{port, ct:get_config({hosts, mim, c2s_port})}].
 
@@ -472,7 +472,7 @@ replace_addrs(Addresses) ->
     lists:map( fun(Addr) -> [User, Hostname] = binary:split(list_to_binary(Addr), <<"@">>),
                             binary_to_list(<<User/binary, <<"-self-signed@">>/binary, Hostname/binary>>) end, Addresses).
 
--spec domain() -> mongooseim:domain_name().
+-spec domain() -> jid:lserver().
 domain() ->
     ct:get_config({hosts, mim, domain}).
 


### PR DESCRIPTION
Enable sasl_SUITE and sasl_external_SUITE for dynamic domains.