### PR TITLE
Test mongooseimctl with dynamic domains

### DIFF
--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -115,20 +115,19 @@ all() ->
     ].
 
 groups() ->
-    G = [{accounts, [sequence], accounts()},
-         {sessions, [sequence], sessions()},
-         {vcard, [sequence], vcard()},
-         {roster, [sequence], roster()},
-         {last, [sequence], last()},
-         {private, [sequence], private()},
-         {stanza, [sequence], stanza()},
-         {roster_advanced, [sequence], roster_advanced()},
-         {basic, [sequence], basic()},
-         {stats, [sequence], stats()},
-         {upload, [], upload()},
-         {upload_with_acl, [], upload_enabled()},
-         {upload_without_acl, [], upload_enabled()}],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{accounts, [sequence], accounts()},
+     {sessions, [sequence], sessions()},
+     {vcard, [sequence], vcard()},
+     {roster, [sequence], roster()},
+     {last, [sequence], last()},
+     {private, [sequence], private()},
+     {stanza, [sequence], stanza()},
+     {roster_advanced, [sequence], roster_advanced()},
+     {basic, [sequence], basic()},
+     {stats, [sequence], stats()},
+     {upload, [], upload()},
+     {upload_with_acl, [], upload_enabled()},
+     {upload_without_acl, [], upload_enabled()}].
 
 basic() ->
     [simple_register,

--- a/big_tests/tests/ejabberdctl_SUITE.erl
+++ b/big_tests/tests/ejabberdctl_SUITE.erl
@@ -26,6 +26,7 @@
 -import(distributed_helper, [mim/0,
                              require_rpc_nodes/1,
                              rpc/4]).
+-import(domain_helper, [host_type/0]).
 
 -define(HTTP_UPLOAD_FILENAME, "tmp.txt").
 -define(HTTP_UPLOAD_FILESIZE, "5").
@@ -39,7 +40,7 @@
 -define(HTTP_UPLOAD_PARAMS_WITH_TIMEOUT(X), ?HTTP_UPLOAD_PARAMS(?HTTP_UPLOAD_FILENAME,
                                                                 ?HTTP_UPLOAD_FILESIZE, "", X)).
 -define(HTTP_UPLOAD_PARAMS(FileName, FileSize, ContentType, Timeout),
-    [ct:get_config({hosts, mim, domain}), FileName, FileSize, ContentType, Timeout]).
+    [domain(), FileName, FileSize, ContentType, Timeout]).
 
 -define(CTL_ERROR(Messsage), "Error: \"" ++ Messsage ++ "\"\n").
 -define(HTTP_UPLOAD_NOT_ENABLED_ERROR, ?CTL_ERROR("mod_http_upload is not loaded for this host")).
@@ -195,8 +196,7 @@ init_per_suite(Config) ->
     prepare_roster_template(TemplatePath, domain()),
     %% dump_and_load requires at least one mnesia table
     %% ensure, that passwd table is available
-    Host = ct:get_config({hosts, mim, domain}),
-    catch rpc_call(ejabberd_auth_internal, start, [Host]),
+    catch rpc_call(ejabberd_auth_internal, start, [host_type()]),
     escalus:create_users(Config2, escalus:get_users([alice, mike, bob, kate])).
 
 prepare_roster_template(TemplatePath, Domain) ->
@@ -212,30 +212,24 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config1).
 
 init_per_group(vcard, Config) ->
-    case rpc(mim(), gen_mod, get_module_opt,
-             [ct:get_config({hosts, mim, domain}), mod_vcard, backend, mnesia])
-    of
+    case rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_vcard, backend, mnesia]) of
         ldap ->
             {skip, vcard_set_not_supported_with_ldap};
         _ ->
             Config
     end;
 init_per_group(roster_advanced, Config) ->
-    case rpc(mim(), gen_mod, get_module_opt,
-             [ct:get_config({hosts, mim, domain}), mod_roster, backend, mnesia])
-    of
+    case rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, backend, mnesia]) of
         mnesia ->
             Config;
         _ ->
             {skip, command_process_rosteritems_supports_only_mnesia}
     end;
 init_per_group(upload_without_acl, Config) ->
-    Host = ct:get_config({hosts, mim, domain}),
-    dynamic_modules:start(Host, mod_http_upload, ?MINIO_OPTS(false)),
+    dynamic_modules:start(host_type(),  mod_http_upload, ?MINIO_OPTS(false)),
     [{with_acl, false} | Config];
 init_per_group(upload_with_acl, Config) ->
-    Host = ct:get_config({hosts, mim, domain}),
-    dynamic_modules:start(Host, mod_http_upload, ?MINIO_OPTS(true)),
+    dynamic_modules:start(host_type(), mod_http_upload, ?MINIO_OPTS(true)),
     [{with_acl, true} | Config];
 init_per_group(_GroupName, Config) ->
     Config.
@@ -259,25 +253,21 @@ end_per_group(Rosters, Config) when (Rosters == roster) or (Rosters == roster_ad
     Config;
 end_per_group(UploadGroup, Config) when UploadGroup =:= upload_without_acl;
                                         UploadGroup =:= upload_with_acl ->
-    Host = ct:get_config({hosts, mim, domain}),
-    dynamic_modules:stop(Host, mod_http_upload),
+    dynamic_modules:stop(host_type(), mod_http_upload),
     Config;
 end_per_group(_GroupName, Config) ->
     Config.
 
 get_registered_users() ->
-    Host = ct:get_config({hosts, mim, domain}),
-    Users = rpc(mim(), ejabberd_auth, get_vh_registered_users, [Host]).
+    rpc(mim(), ejabberd_auth, get_vh_registered_users, [domain()]).
 
 init_per_testcase(CaseName, Config)
-  % these cases are incompatible with domainless rdbms schema
   when CaseName == delete_old_users_vhost
        orelse CaseName == stats_global
        orelse CaseName == stats_host ->
     {_, AuthMods} = lists:keyfind(ctl_auth_mods, 1, Config),
-    case lists:member(ejabberd_auth_rdbms, AuthMods) orelse
-         lists:member(ejabberd_auth_ldap, AuthMods) of
-        true -> {skip, vhost_rdbms_incompatible};
+    case lists:member(ejabberd_auth_ldap, AuthMods) of
+        true -> {skip, "not supported for LDAP"};
         false -> escalus:init_per_testcase(CaseName, Config)
     end;
 init_per_testcase(check_password_hash, Config) ->
@@ -1093,7 +1083,7 @@ stats_host(Config) ->
 
 simple_register(Config) ->
     %% given
-    Domain = ct:get_config({hosts, mim, domain}),
+    Domain = domain(),
     {Name, Password} = {<<"tyler">>, <<"durden">>},
     %% when
     {R1, 0} = ejabberdctl("registered_users", [Domain], Config),
@@ -1108,7 +1098,7 @@ simple_register(Config) ->
 
 simple_unregister(Config) ->
     %% given
-    Domain = ct:get_config({hosts, mim, domain}),
+    Domain = domain(),
     {Name, _} = {<<"tyler">>, <<"durden">>},
     %% when
     {_, 0} = ejabberdctl("unregister", [Name, Domain], Config),
@@ -1118,7 +1108,7 @@ simple_unregister(Config) ->
 
 register_twice(Config) ->
     %% given
-    Domain = ct:get_config({hosts, mim, domain}),
+    Domain = domain(),
     {Name,  Password} = {<<"tyler">>, <<"durden">>},
     %% when
     {_, 0} = ejabberdctl("register_identified", [Name, Domain, Password], Config),
@@ -1208,8 +1198,8 @@ remove_old_messages_test(Config) ->
         OfflineOld = generate_offline_message(JidRecordAlice, JidRecordBob, Msg1, OldTimestamp),
         OfflineNew = generate_offline_message(JidRecordAlice, JidRecordBob, Msg2, os:system_time(microsecond)),
         {jid, _, _, _, LUser, LServer, _} = JidRecordBob,
-        HostType = domain_helper:host_type(),
-        rpc_call(mod_offline_backend, write_messages, [HostType, LUser, LServer, [OfflineOld, OfflineNew]]),
+        HostType = host_type(),
+        rpc_call(mod_offline_backend, write_messages, [host_type(), LUser, LServer, [OfflineOld, OfflineNew]]),
         %% when
         {_, 0} = ejabberdctl("delete_old_messages", [LServer, "1"], Config),
         {ok, SecondList} = rpc_call(mod_offline_backend, pop_messages, [HostType, JidRecordBob]),
@@ -1246,7 +1236,7 @@ remove_expired_messages_test(Config) ->
                                                           ExpirationTimeFuture),
         {jid, _, _, _, LUser, LServer, _} = JidRecordKate,
         Args = [OfflineOld, OfflineNow, OfflineFuture, OfflineFuture2],
-        HostType = domain_helper:host_type(),
+        HostType = host_type(),
         rpc_call(mod_offline_backend, write_messages, [HostType, LUser, LServer, Args]),
         %% when
         {_, 0} = ejabberdctl("delete_expired_messages", [LServer], Config),
@@ -1296,9 +1286,8 @@ get_sha(AccountPass) ->
                    || X <- binary_to_list(crypto:hash(sha, AccountPass))]).
 
 set_last(User, Domain, TStamp) ->
-    HostType = domain_helper:host_type(),
     rpc(mim(), mod_last, store_last_info,
-        [HostType, escalus_utils:jid_to_lower(User), Domain, TStamp, <<>>]).
+        [host_type(), escalus_utils:jid_to_lower(User), Domain, TStamp, <<>>]).
 
 delete_users(Config) ->
     Users = escalus_users:get_users([alice, bob, kate, mike]),

--- a/big_tests/tests/ejabberdctl_SUITE_data/roster.template
+++ b/big_tests/tests/ejabberdctl_SUITE_data/roster.template
@@ -1,7 +1,0 @@
-[
-    {"alice", "localhost", "Group", "Alice"},
-    {"bob", "localhost", "Group", "Bob"},
-    {"kate", "localhost", "Group", "Kate"},
-    {"mike", "localhost", "Group", "Mike"},
-    {"unicoder-иии", "localhost", "Group-иии", "Unicoder-иии"}
-].

--- a/big_tests/tests/ejabberdctl_SUITE_data/roster.template.in
+++ b/big_tests/tests/ejabberdctl_SUITE_data/roster.template.in
@@ -1,0 +1,7 @@
+[
+    {"alice", "Group", "Alice"},
+    {"bob", "Group", "Bob"},
+    {"kate", "Group", "Kate"},
+    {"mike", "Group", "Mike"},
+    {"unicoder-иии", "Group-иии", "Unicoder-иии"}
+].

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -462,11 +462,10 @@ backup_sasl_mechanisms_config(Config) ->
     [{global_sasl_mechanisms, GlobalSASLMechanisms},
      {host_sasl_mechanisms, HostSASLMechanisms} | Config].
 
-
 restore_auth_config(Config) ->
-    XMPPDomain = escalus_ejabberd:unify_str_arg(ct:get_config({hosts, mim, domain})),
+    HostType = domain_helper:host_type(),
     AuthOpts = proplists:get_value(auth_opts, Config),
-    rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, XMPPDomain}, AuthOpts]).
+    rpc(mim(), ejabberd_config, add_local_option, [{auth_opts, HostType}, AuthOpts]).
 
 restore_sasl_mechanisms_config(Config) ->
     XMPPDomain = escalus_ejabberd:unify_str_arg(ct:get_config({hosts, mim, domain})),

--- a/src/admin_extra/service_admin_extra_stats.erl
+++ b/src/admin_extra/service_admin_extra_stats.erl
@@ -69,9 +69,9 @@ stats(Name) ->
         <<"uptimeseconds">> ->
             trunc(element(1, erlang:statistics(wall_clock))/1000);
         <<"registeredusers">> ->
-            lists:sum([
-                    ejabberd_auth:get_vh_registered_users_number(Server)
-                    || Server <- ejabberd_config:get_global_option(hosts) ]);
+            Domains = lists:flatmap(fun mongoose_domain_api:get_domains_by_host_type/1,
+                                    ?ALL_HOST_TYPES),
+            lists:sum([ejabberd_auth:get_vh_registered_users_number(Domain) || Domain <- Domains]);
         <<"onlineusersnode">> ->
             ejabberd_sm:get_node_sessions_number();
         <<"onlineusers">> ->

--- a/src/admin_extra/service_admin_extra_upload.erl
+++ b/src/admin_extra/service_admin_extra_upload.erl
@@ -26,16 +26,17 @@ commands() -> [
     }
 ].
 
--spec get_urls(HostType :: mongooseim:host_type(), Filename :: binary(), Size :: pos_integer(),
+-spec get_urls(Domain :: jid:lserver(), Filename :: binary(), Size :: pos_integer(),
                ContentType :: binary() | undefined, Timeout :: pos_integer()) ->
         {ok, string()} | {error, string()}.
-get_urls(_HostType, _Filename, Size, _ContentType, _Timeout) when Size =< 0->
+get_urls(_Domain, _Filename, Size, _ContentType, _Timeout) when Size =< 0->
     {error, "size must be positive integer"};
-get_urls(_HostType, _Filename, _Size, _ContentType, Timeout) when Timeout =< 0->
+get_urls(_Domain, _Filename, _Size, _ContentType, Timeout) when Timeout =< 0->
     {error, "timeout must be positive integer"};
-get_urls(HostType, Filename, Size, <<"">>, Timeout) ->
-    get_urls(HostType, Filename, Size, undefined, Timeout);
-get_urls(HostType, Filename, Size, ContentType, Timeout) ->
+get_urls(Domain, Filename, Size, <<"">>, Timeout) ->
+    get_urls(Domain, Filename, Size, undefined, Timeout);
+get_urls(Domain, Filename, Size, ContentType, Timeout) ->
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(Domain),
     case gen_mod:is_loaded(HostType, mod_http_upload) of
         true ->
             {PutURL, GetURL, Header} =


### PR DESCRIPTION
Enable the CLI tests for dynamic domains. Some bugs were discovered and fixed along the way:

- There was a faulty check if `mod_private` was running (per domain, not per host type)
- Total number of users was calculated only for static domains.
- HTTP upload URLs were supposed to be created domain, but the domain was interpreted as a host type.

Some tests were also skipped for RDBMS, but they shouldn't be.


