### PR TITLE
Enable metrics_session_SUITE for dynamic domains

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -43,6 +43,8 @@
 
 {suites, "tests", metrics_register_SUITE}.
 
+{suites, "tests", metrics_session_SUITE}.
+
 {suites, "tests", mod_blocking_SUITE}.
 
 {suites, "tests", mod_http_upload_SUITE}.

--- a/big_tests/tests/metrics_session_SUITE.erl
+++ b/big_tests/tests/metrics_session_SUITE.erl
@@ -36,12 +36,11 @@ all() ->
      {group, session_global}].
 
 groups() ->
-    G = [{session, [sequence], [login_one,
-                                login_many,
-                                auth_failed]},
-         {session_global, [sequence], [session_global,
-                                       session_unique]}],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{session, [sequence], [login_one,
+                            login_many,
+                            auth_failed]},
+     {session_global, [sequence], [session_global,
+                                   session_unique]}].
 
 suite() ->
     [{require, ejabberd_node} | escalus:suite()].


### PR DESCRIPTION
Enable metrics_session_SUITE for dynamic domains.

