### PR TITLE
Use host_type instead of domain in metrics_register_SUITE

### DIFF
--- a/big_tests/tests/metrics_register_SUITE.erl
+++ b/big_tests/tests/metrics_register_SUITE.erl
@@ -30,6 +30,7 @@
 -import(metrics_helper, [assert_counter/2,
                          get_counter_value/1]).
 
+-import(domain_helper, [host_type/0]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -66,8 +67,7 @@ init_per_testcase(unregister, Config) ->
     escalus_users:create_user(Config, Alice),
     Config;
 init_per_testcase(registered_users, Config) ->
-    XMPPDomain = ct:get_config({hosts, mim, domain}),
-    case rpc(mim(), ejabberd_config, get_local_option, [{auth_method, XMPPDomain}]) of
+    case rpc(mim(), ejabberd_config, get_local_option, [{auth_method, host_type()}]) of
         external ->
             {skip, "counter not supported with ejabberd_auth_external"};
         anonymous ->


### PR DESCRIPTION
Related to this [PR](https://github.com/esl/MongooseIM/pull/3275#pullrequestreview-756270786) and adds the suggestions from Paweł to use `host_type` instead of `domain`.