### PR TITLE
Test roster metrics with dynamic domains

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -53,6 +53,8 @@
 
 {suites, "tests", metrics_register_SUITE}.
 
+{suites, "tests", metrics_roster_SUITE}.
+
 {suites, "tests", metrics_session_SUITE}.
 
 {suites, "tests", mod_blocking_SUITE}.

--- a/big_tests/tests/metrics_roster_SUITE.erl
+++ b/big_tests/tests/metrics_roster_SUITE.erl
@@ -37,9 +37,8 @@ all() ->
     ].
 
 groups() ->
-    G = [{roster, [sequence], roster_tests()},
-         {subscriptions, [sequence], subscription_tests()}],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{roster, [sequence], roster_tests()},
+     {subscriptions, [sequence], subscription_tests()}].
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
@@ -296,8 +295,8 @@ add_sample_contact(Alice, Bob, Groups, Name) ->
 
 remove_roster(Config, UserSpec) ->
     [Username, Server, _Pass] = escalus_users:get_usp(Config, UserSpec),
-    rpc(mim(), mod_roster_rdbms, remove_user, [Username, Server]),
-    rpc(mim(), mod_roster, remove_user, [Username, Server]).
+    Acc = mongoose_helper:new_mongoose_acc(Server),
+    rpc(mim(), mod_roster, remove_user, [Acc, Username, Server]).
 
 mongoose_metrics(ConfigIn, Metrics) ->
     Predefined = proplists:get_value(mongoose_metrics, ConfigIn, []),

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -26,7 +26,7 @@
          xmpp_send_element/2,
          roster_get/2,
          roster_set/4,
-         roster_push/3,
+         roster_push/4,
          roster_in_subscription/5,
          register_user/3,
          remove_user/3,
@@ -38,7 +38,7 @@
 
 -ignore_xref([auth_failed/3, privacy_check_packet/5, privacy_iq_get/5, privacy_iq_set/4,
              privacy_list_push/5, register_user/3, remove_user/3, roster_get/2,
-             roster_in_subscription/5, roster_push/3, roster_set/4,
+             roster_in_subscription/5, roster_push/4, roster_set/4,
              sm_register_connection_hook/5, sm_remove_connection_hook/5,
              user_receive_packet/5, user_send_packet/4, xmpp_bounce_message/1,
              xmpp_send_element/2, xmpp_stanza_dropped/4]).
@@ -186,11 +186,10 @@ roster_in_subscription(Acc, _, _, unsubscribed, _) ->
 roster_in_subscription(Acc, _, _, _, _) ->
     Acc.
 
--spec roster_push(any(), jid:jid(), term()) -> any().
-roster_push(Acc, #jid{lserver = LServer}, _) ->
-    {ok, HostType} = mongoose_domain_api:get_host_type(LServer),
+-spec roster_push(any(), mongooseim:host_type(), jid:jid(), mod_roster:roster()) -> any().
+roster_push(HookAcc, HostType, _JID, _Item) ->
     mongoose_metrics:update(HostType, modRosterPush, 1),
-    Acc.
+    HookAcc.
 
 %% Register
 

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -539,13 +539,13 @@ push_item(HostType, JID, From, Item) ->
             push_item_version(JID, From, Item, roster_version(HostType, JID));
         false ->
             lists:foreach(fun(Resource) ->
-                                  push_item_without_version(JID, Resource, From, Item)
+                                  push_item_without_version(HostType, JID, Resource, From, Item)
                           end,
                           ejabberd_sm:get_user_resources(JID))
     end.
 
-push_item_without_version(#jid{lserver = Server} = JID, Resource, From, Item) ->
-    mongoose_hooks:roster_push(Server, From, Item),
+push_item_without_version(HostType, JID, Resource, From, Item) ->
+    mongoose_hooks:roster_push(HostType, From, Item),
     push_item_final(jid:replace_resource(JID, Resource), From, Item, not_found).
 
 push_item_version(JID, From, Item, RosterVersion) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -845,13 +845,13 @@ roster_process_item(HostType, LServer, Item) ->
 
 %%% @doc The `roster_push' hook is called when a roster item is
 %%% being pushed and roster versioning is not enabled.
--spec roster_push(LServer, From, Item) -> Result when
-    LServer :: jid:lserver(),
+-spec roster_push(HostType, From, Item) -> Result when
+    HostType :: mongooseim:host_type(),
     From :: jid:jid(),
     Item :: mod_roster:roster(),
     Result :: any().
-roster_push(LServer, From, Item) ->
-    run_hook_for_host_type(roster_push, LServer, ok, [From, Item]).
+roster_push(HostType, From, Item) ->
+    run_hook_for_host_type(roster_push, HostType, ok, [HostType, From, Item]).
 
 %%% @doc The `roster_set' hook is called when a user's roster is set through an IQ.
 -spec roster_set(HostType, From, To, SubEl) -> Result when


### PR DESCRIPTION
- Bug fix: call roster_push hook for host type (not for domain)
- Adapt and enable `roster_push_SUITE`

