### PR TITLE
Enable `rdbms_SUITE` and `persistent_cluster_id_SUITE` for dynamic domains

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -87,6 +87,8 @@
 
 {suites, "tests", race_conditions_SUITE}.
 
+{suites, "tests", rdbms_SUITE}.
+
 {suites, "tests", rest_SUITE}.
 
 {suites, "tests", rest_client_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -79,6 +79,8 @@
 
 {suites, "tests", offline_stub_SUITE}.
 
+{suites, "tests", persistent_cluster_id_SUITE}.
+
 {suites, "tests", presence_SUITE}.
 
 {suites, "tests", privacy_SUITE}.

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -49,9 +49,9 @@
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
--spec is_rdbms_enabled(Host :: binary()) -> boolean().
-is_rdbms_enabled(Host) ->
-    case rpc(mim(), mongoose_rdbms, sql_transaction, [Host, fun erlang:yield/0]) of
+-spec is_rdbms_enabled(HostType :: binary()) -> boolean().
+is_rdbms_enabled(HostType) ->
+    case rpc(mim(), mongoose_rdbms, sql_transaction, [HostType, fun erlang:yield/0]) of
         {atomic, _} -> true;
         _ -> false
     end.

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -25,6 +25,8 @@
 
 -import(distributed_helper, [mim/0, mim2/0]).
 
+-import(domain_helper, [host_type/0]).
+
 all() ->
     [
      {group, mnesia},
@@ -62,12 +64,12 @@ group(_Groupname) ->
     [].
 
 init_per_group(mnesia, Config) ->
-    case not mongoose_helper:is_rdbms_enabled(domain()) of
+    case not mongoose_helper:is_rdbms_enabled(host_type()) of
         true -> Config;
         false -> {skip, require_no_rdbms}
     end;
 init_per_group(_Groupname, Config) ->
-    case mongoose_helper:is_rdbms_enabled(domain()) of
+    case mongoose_helper:is_rdbms_enabled(host_type()) of
         true -> Config;
         false -> {skip, require_rdbms}
     end.
@@ -142,7 +144,3 @@ cluster_id_is_restored_to_mnesia_from_rdbms_if_mnesia_lost(_Config) ->
     {ok, SecondID} = mongoose_helper:successful_rpc(
                Node, mongoose_cluster_id, get_cached_cluster_id, []),
     ?assertEqual(FirstID, SecondID).
-
-
-domain() ->
-    ct:get_config({hosts, mim, domain}).

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -24,6 +24,8 @@
 %% We need assert from it
 -include("mam_helper.hrl").
 
+-import(domain_helper, [host_type/0]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -32,8 +34,7 @@ all() ->
     [{group, rdbms_queries}].
 
 groups() ->
-    G = [{rdbms_queries, [], rdbms_queries_cases()}],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{rdbms_queries, [], rdbms_queries_cases()}].
 
 rdbms_queries_cases() ->
     [select_one_works_case,
@@ -74,7 +75,8 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
-    case not ct_helper:is_ct_running() orelse mongoose_helper:is_rdbms_enabled(host()) of
+    case not ct_helper:is_ct_running()
+         orelse mongoose_helper:is_rdbms_enabled(host_type()) of
         false -> {skip, rdbms_or_ct_not_running};
         true -> escalus:init_per_suite(Config)
     end.
@@ -340,17 +342,14 @@ select_like_prep_case(Config) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
-host() ->
-    ct:get_config({hosts, mim, domain}).
-
 sql_query(_Config, Query) ->
-    slow_rpc(mongoose_rdbms, sql_query, [host(), Query]).
+    slow_rpc(mongoose_rdbms, sql_query, [host_type(), Query]).
 
 sql_prepare(_Config, Name, Table, Fields, Query) ->
     escalus_ejabberd:rpc(mongoose_rdbms, prepare, [Name, Table, Fields, Query]).
 
 sql_execute(_Config, Name, Parameters) ->
-    slow_rpc(mongoose_rdbms, execute, [host(), Name, Parameters]).
+    slow_rpc(mongoose_rdbms, execute, [host_type(), Name, Parameters]).
 
 escape_null(_Config) ->
     escalus_ejabberd:rpc(mongoose_rdbms, escape_null, []).
@@ -359,7 +358,7 @@ escape_string(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, escape_string, [Value]).
 
 escape_binary(_Config, Value) ->
-    slow_rpc(mongoose_rdbms, escape_binary, [host(), Value]).
+    slow_rpc(mongoose_rdbms, escape_binary, [host_type(), Value]).
 
 escape_boolean(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, escape_boolean, [Value]).
@@ -371,7 +370,7 @@ escape_prepared_like(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, escape_prepared_like, [Value]).
 
 unescape_binary(_Config, Value) ->
-    escalus_ejabberd:rpc(mongoose_rdbms, unescape_binary, [host(), Value]).
+    escalus_ejabberd:rpc(mongoose_rdbms, unescape_binary, [host_type(), Value]).
 
 use_escaped(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, use_escaped, [Value]).
@@ -817,10 +816,10 @@ drop_common_prefix(Pos, SelValue, Value) ->
       expected_suffix => safe_binary(100, Value)}.
 
 is_odbc() ->
-    escalus_ejabberd:rpc(mongoose_rdbms, db_engine, [host()]) == odbc.
+    escalus_ejabberd:rpc(mongoose_rdbms, db_engine, [host_type()]) == odbc.
 
 is_pgsql() ->
-    escalus_ejabberd:rpc(mongoose_rdbms, db_engine, [host()]) == pgsql.
+    escalus_ejabberd:rpc(mongoose_rdbms, db_engine, [host_type()]) == pgsql.
 
 slow_rpc(M, F, A) ->
     Node = ct:get_config({hosts, mim, node}),


### PR DESCRIPTION
This PR:
-  adapts and enables rdbms_SUITE and persistent_cluster_id_SUITE for dynamic domains. 
- replaces `host` with `host_type` in mongoose_rdbms and mongoose_helper
