### PR TITLE
Implement domain removal in mod_roster

### DIFF
--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -95,9 +95,15 @@ group_to_modules(roster_removal) ->
 %%% Testcase specific setup/teardown
 %%%===================================================================
 
+init_per_testcase(roster_removal, ConfigIn) ->
+    Config = roster_helper:set_versioning(true, true, ConfigIn),
+    escalus:init_per_testcase(roster_removal, Config);
 init_per_testcase(TestCase, Config) ->
     escalus:init_per_testcase(TestCase, Config).
 
+end_per_testcase(roster_removal, Config) ->
+    roster_helper:restore_versioning(Config),
+    escalus:end_per_testcase(roster_removal, Config);
 end_per_testcase(TestCase, Config) ->
     escalus:end_per_testcase(TestCase, Config).
 
@@ -202,15 +208,10 @@ private_removal(Config) ->
         ?assert_equal_extra(<<>>, Val2, #{stanza => Res2})
       end).
 
-bobs_default_groups() -> [<<"friends">>].
-
-bobs_default_name() -> <<"Bobby">>.
-
 roster_removal(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         %% add contact
-        Stanza = escalus_stanza:roster_add_contact(Bob, bobs_default_groups(),
-                                                   bobs_default_name()),
+        Stanza = escalus_stanza:roster_add_contact(Bob, [<<"friends">>], <<"Bobby">>),
         escalus:send(Alice, Stanza),
         Received = escalus:wait_for_stanzas(Alice, 2),
         escalus:assert_many([is_roster_set, is_iq_result], Received),

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -15,7 +15,8 @@
          inbox_removal/1,
          muc_light_removal/1,
          muc_light_blocking_removal/1,
-         private_removal/1]).
+         private_removal/1,
+         roster_removal/1]).
 
 -import(distributed_helper, [mim/0, rpc/4, subhost_pattern/1]).
 -import(domain_helper, [host_type/0, domain/0]).
@@ -30,7 +31,8 @@ all() ->
     [{group, mam_removal},
      {group, inbox_removal},
      {group, muc_light_removal},
-     {group, private_removal}].
+     {group, private_removal},
+     {group, roster_removal}].
 
 groups() ->
     [
@@ -39,7 +41,8 @@ groups() ->
      {inbox_removal, [], [inbox_removal]},
      {muc_light_removal, [], [muc_light_removal,
                               muc_light_blocking_removal]},
-     {private_removal, [], [private_removal]}
+     {private_removal, [], [private_removal]},
+     {roster_removal, [], [roster_removal]}
     ].
 
 %%%===================================================================
@@ -84,7 +87,9 @@ group_to_modules(muc_light_removal) ->
 group_to_modules(inbox_removal) ->
     [{mod_inbox, []}];
 group_to_modules(private_removal) ->
-    [{mod_private, [{backend, rdbms}]}].
+    [{mod_private, [{backend, rdbms}]}];
+group_to_modules(roster_removal) ->
+    [{mod_roster, [{backend, rdbms}]}].
 
 %%%===================================================================
 %%% Testcase specific setup/teardown
@@ -196,6 +201,33 @@ private_removal(Config) ->
         ?assert_equal_extra(<<"banana">>, Val1, #{stanza => Res1}),
         ?assert_equal_extra(<<>>, Val2, #{stanza => Res2})
       end).
+
+bobs_default_groups() -> [<<"friends">>].
+
+bobs_default_name() -> <<"Bobby">>.
+
+roster_removal(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        %% add contact
+        Stanza = escalus_stanza:roster_add_contact(Bob, bobs_default_groups(),
+                                                   bobs_default_name()),
+        escalus:send(Alice, Stanza),
+        Received = escalus:wait_for_stanzas(Alice, 2),
+        escalus:assert_many([is_roster_set, is_iq_result], Received),
+
+        %% check roster
+        BobJid = escalus_client:short_jid(Bob),
+        Received2 = escalus:send_iq_and_wait_for_result(Alice, escalus_stanza:roster_get()),
+        escalus:assert(is_roster_result, Received2),
+        escalus:assert(roster_contains, [BobJid], Received2),
+        escalus:assert(count_roster_items, [1], Received2),
+
+        %% remove domain and check roster
+        run_remove_domain(),
+        Received3 = escalus:send_iq_and_wait_for_result(Alice, escalus_stanza:roster_get()),
+        escalus:assert(is_roster_result, Received3),
+        escalus:assert(count_roster_items, [0], Received3)
+        end).
 
 run_remove_domain() ->
     rpc(mim(), mongoose_hooks, remove_domain, [host_type(), domain()]).

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -26,6 +26,8 @@
 
 -import(domain_helper, [host_type/0]).
 
+-import(roster_helper, [set_versioning/3, restore_versioning/1]).
+
 %%--------------------------------------------------------------------
 %% Suite configuration
 %%--------------------------------------------------------------------
@@ -732,23 +734,6 @@ remove_roster(Config, UserSpec) ->
                     throw(roster_not_loaded)
             end
     end.
-
-set_versioning(Versioning, VersionStore, Config) ->
-    RosterVersioning = rpc(mim(), gen_mod, get_module_opt,
-                           [host_type(), mod_roster, versioning, false]),
-    RosterVersionOnDb = rpc(mim(), gen_mod, get_module_opt,
-                            [host_type(), mod_roster, store_current_id, false]),
-    rpc(mim(), gen_mod, set_module_opt, [host_type(), mod_roster, versioning, Versioning]),
-    rpc(mim(), gen_mod, set_module_opt, [host_type(), mod_roster, store_current_id, VersionStore]),
-    [{versioning, RosterVersioning},
-     {store_current_id, RosterVersionOnDb} | Config].
-
-restore_versioning(Config) ->
-    RosterVersioning = proplists:get_value(versioning, Config),
-    RosterVersionOnDb = proplists:get_value(store_current_id, Config),
-    rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, versioning, RosterVersioning]),
-    rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, store_current_id, RosterVersionOnDb]).
-
 
 check_roster_count(User, ExpectedCount) ->
     % the user sends get_roster iq

--- a/big_tests/tests/roster_helper.erl
+++ b/big_tests/tests/roster_helper.erl
@@ -1,0 +1,23 @@
+-module(roster_helper).
+-export([set_versioning/3, restore_versioning/1]).
+
+-import(distributed_helper, [mim/0, rpc/4]).
+-import(domain_helper, [host_type/0]).
+
+-spec set_versioning(boolean(), boolean(), escalus_config:config()) -> escalus_config:config(). 
+set_versioning(Versioning, VersionStore, Config) ->
+    RosterVersioning = rpc(mim(), gen_mod, get_module_opt,
+                           [host_type(), mod_roster, versioning, false]),
+    RosterVersionOnDb = rpc(mim(), gen_mod, get_module_opt,
+                            [host_type(), mod_roster, store_current_id, false]),
+    rpc(mim(), gen_mod, set_module_opt, [host_type(), mod_roster, versioning, Versioning]),
+    rpc(mim(), gen_mod, set_module_opt, [host_type(), mod_roster, store_current_id, VersionStore]),
+    [{versioning, RosterVersioning},
+     {store_current_id, RosterVersionOnDb} | Config].
+
+-spec restore_versioning(escalus_config:config()) -> escalus_config:config().
+restore_versioning(Config) ->
+    RosterVersioning = proplists:get_value(versioning, Config),
+    RosterVersionOnDb = proplists:get_value(store_current_id, Config),
+    rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, versioning, RosterVersioning]),
+    rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, store_current_id, RosterVersionOnDb]).

--- a/src/auth/mongoose_gen_auth.erl
+++ b/src/auth/mongoose_gen_auth.erl
@@ -20,6 +20,8 @@
 
 -ignore_xref([behaviour_info/1]).
 
+-import(backend_module, [is_exported/3]).
+
 %% Mandatory callbacks
 
 -callback start(HostType :: mongooseim:host_type()) -> ok.
@@ -232,9 +234,3 @@ check_password(Mod, HostType, LUser, LServer, Password, Digest, DigestGen) ->
         true -> Mod:check_password(HostType, LUser, LServer, Password, Digest, DigestGen);
         false -> false
     end.
-
-%% Internal functions
-
-is_exported(Mod, F, Arity) ->
-    code:ensure_loaded(Mod),
-    erlang:function_exported(Mod, F, Arity).

--- a/src/backend_module.erl
+++ b/src/backend_module.erl
@@ -26,7 +26,7 @@
 -author('alexey@process-one.net').
 -author('konrad.zemek@erlang-solutions.com').
 
--export([create/2, backend_module/2, create/3]).
+-export([create/2, backend_module/2, create/3, is_exported/3]).
 
 -ignore_xref([create/2, backend_module/2, behaviour_info/1]).
 
@@ -55,6 +55,12 @@ create(Module, Backend, TrackedFuns) ->
             code:load_binary(Mod, ProxyModuleStr ++ ".erl", Code),
             {ok, ProxyModule}
     end.
+
+-spec is_exported(Module :: module(), Function :: atom(), 
+                  Arity :: integer()) -> boolean().
+is_exported(Module, Function, Arity) ->
+    code:ensure_loaded(Module),
+    erlang:function_exported(Module, Function, Arity).
 
 %% Internal functions
 

--- a/src/mod_roster_rdbms.erl
+++ b/src/mod_roster_rdbms.erl
@@ -28,7 +28,8 @@
          roster_subscribe_t/2,
          update_roster_t/2,
          del_roster_t/4,
-         remove_user_t/3]).
+         remove_user_t/3,
+         remove_domain_t/2]).
 
 %% mod_roster backend API
 
@@ -114,6 +115,13 @@ remove_user_t(HostType, LUser, LServer) ->
     mongoose_rdbms:execute_successfully(HostType, roster_group_delete, [LServer, LUser]),
     ok.
 
+-spec remove_domain_t(mongooseim:host_type(), jid:lserver()) -> ok.
+remove_domain_t(HostType, Domain) ->
+    mongoose_rdbms:execute_successfully(HostType, rosterusers_remove_domain, [Domain]),
+    mongoose_rdbms:execute_successfully(HostType, rostergroups_remove_domain, [Domain]),
+    mongoose_rdbms:execute_successfully(HostType, roster_version_remove_domain, [Domain]),
+    ok.
+
 %% Query preparation
 
 prepare_queries(HostType) ->
@@ -144,6 +152,12 @@ prepare_queries(HostType) ->
     mongoose_rdbms:prepare(roster_group_delete_by_jid, rostergroups, [server, username, jid],
                            <<"DELETE FROM rostergroups"
                              " WHERE server = ? AND username = ? AND jid = ?">>),
+    mongoose_rdbms:prepare(rosterusers_remove_domain, rosterusers, [server],
+                          <<"DELETE FROM rosterusers WHERE server = ?">>),
+    mongoose_rdbms:prepare(rostergroups_remove_domain, rostergroups, [server],
+                           <<"DELETE FROM rostergroups WHERE server = ?">>),
+    mongoose_rdbms:prepare(roster_version_remove_domain, roster_version, [server],
+                           <<"DELETE FROM roster_version WHERE server = ?">>),
     prepare_roster_upsert(HostType),
     prepare_version_upsert(HostType),
     ok.


### PR DESCRIPTION
This PR implements domain removal in mod_roster (only rdbms).

Proposed changes include:
* extracting some functions to allow reuse,
* handling domain removal in mod_roster_rdbms,
* implementation of domain_removal hook in the mod_roster,
* adding a test case to the domain_removal_SUITE.

