### PR TITLE
Support domain removal in the RDBMS auth backend

### DIFF
--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -455,6 +455,8 @@ get_auth_method_as_a_list(undefined) -> [];
 get_auth_method_as_a_list(AuthMethod) when is_list(AuthMethod) -> AuthMethod;
 get_auth_method_as_a_list(AuthMethod) when is_atom(AuthMethod) -> [AuthMethod].
 
+-spec remove_domain(mongoose_hooks:simple_acc(), mongooseim:host_type(), jid:lserver()) ->
+          mongoose_hooks:simple_acc().
 remove_domain(Acc, HostType, Domain) ->
     F = fun(Mod) -> mongoose_gen_auth:remove_domain(Mod, HostType, Domain) end,
     call_auth_modules_for_host_type(HostType, F, #{op => map}),

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -40,6 +40,7 @@
          get_password_s/3,
          does_user_exist/3,
          remove_user/3,
+         remove_domain/2,
          supports_sasl_module/2,
          supported_features/0
         ]).
@@ -285,6 +286,11 @@ remove_user(HostType, LUser, LServer) ->
     end,
     ok.
 
+-spec remove_domain(mongooseim:host_type(), jid:lserver()) -> ok.
+remove_domain(HostType, Domain) ->
+    execute_successfully(HostType, auth_remove_domain, [Domain]),
+    ok.
+
 -spec supported_features() -> [atom()].
 supported_features() -> [dynamic_domains].
 
@@ -420,7 +426,9 @@ prepare_queries(HostType) ->
             <<"SELECT COUNT(*) FROM users WHERE server = ? AND username LIKE ? ESCAPE '$'">>),
     prepare_count_users(HostType),
     prepare(auth_count_users_without_scram, users, [server],
-            <<"SELECT COUNT(*) FROM users WHERE server = ? AND pass_details is NULL">>).
+            <<"SELECT COUNT(*) FROM users WHERE server = ? AND pass_details is NULL">>),
+    prepare(auth_remove_domain, users, [server],
+            <<"DELETE FROM users WHERE server = ?">>).
 
 prepare_count_users(HostType) ->
     case {ejabberd_auth:get_opt(HostType, rdbms_users_number_estimate),


### PR DESCRIPTION
Implement callback, add tests.

Also: export all functions from the test suite for easier debugging. We are doing this for most test suites.

