### PR TITLE
Test domain removal in mod_cache_users

### DIFF
--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -9,6 +9,7 @@
          host_types/1,
          host_type/0,
          host_type/1,
+         domain_to_host_type/2,
          domain/0,
          domain/1,
          secondary_host_type/0,
@@ -30,6 +31,10 @@ domain() ->
 
 host_type(NodeKey) ->
     get_or_fail({hosts, NodeKey, host_type}).
+
+domain_to_host_type(Node, Domain) ->
+    {ok, HostType} = rpc(Node, mongoose_domain_core, get_host_type, [Domain]),
+    HostType.
 
 domain(NodeKey) ->
     get_or_fail({hosts, NodeKey, domain}).

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -68,6 +68,8 @@ end_per_group(_Groupname, Config) ->
     end,
     ok.
 
+group_to_modules(auth_removal) ->
+    [];
 group_to_modules(cache_removal) ->
     [{mod_cache_users, []},
      {mod_mam_meta, [{backend, rdbms}, {pm, []}]}];
@@ -84,8 +86,6 @@ group_to_modules(private_removal) ->
     [{mod_private, [{backend, rdbms}]}];
 group_to_modules(roster_removal) ->
     [{mod_roster, [{backend, rdbms}]}];
-group_to_modules(auth_removal) ->
-    [];
 group_to_modules(offline_removal) ->
     [{mod_offline, [{backend, rdbms}]}].
 

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -116,10 +116,6 @@ auth_removal(Config) ->
     connect_and_disconnect(AliceBisSpec), % different domain - not removed
     ?assertEqual([], rpc(mim(), ejabberd_auth, get_vh_registered_users, [domain()])).
 
-connect_and_disconnect(Spec) ->
-    {ok, Client, _} = escalus_connection:start(Spec),
-    escalus_connection:stop(Client).
-
 mam_pm_removal(Config) ->
     F = fun(Alice, Bob) ->
         escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
@@ -259,6 +255,12 @@ roster_removal(Config) ->
         ?assertMatch([], select_from_roster("rostergroups")),
         ?assertMatch([], select_from_roster("roster_version"))
     end).
+
+%% Helpers
+
+connect_and_disconnect(Spec) ->
+    {ok, Client, _} = escalus_connection:start(Spec),
+    escalus_connection:stop(Client).
 
 select_from_roster(Table) ->
     Query = "SELECT * FROM " ++ Table ++ " WHERE server='" ++ binary_to_list(domain()) ++ "'",


### PR DESCRIPTION
This module caches the users for quicker MAM and Inbox operations. It implements `remove_domain`, but a test was missing.

The test calls an API function for host types of two different domains, which have different host type configurations in different test specs:
- One host type in `dynamic_domains.spec`
- Two host types in `default.spec`

This required determining the host type dynamically, so a helper function was added with this functionality.

**Note:** we might want to eventually redesign the test suite to always use dynamic domains, because it is counter-intuitive to test domain removal hooks for static domains, which are never removed. This might require adding more users to `default.spec` and `dynamic_domain.spec`. Alternatively, we might just enable `dynamic_domains` for more DB backends (we should do that anyway) and simply remove this test suite from `default.spec`.
