### PR TITLE
Implement domain removal in mod_muc

### DIFF
--- a/src/mod_muc_db.erl
+++ b/src/mod_muc_db.erl
@@ -49,3 +49,7 @@
 %% Unregistered nicks can be used by someone else
 -callback unset_nick(server_host(), muc_host(), client_jid()) ->
     ok | {error, term()}.
+
+-callback remove_domain(mongooseim:host_type(), muc_host(), jid:lserver()) -> ok.
+
+-optional_callbacks([remove_domain/3]).


### PR DESCRIPTION
Proposed changes include:
* Add `remove_domain` callback to mod_muc_db behavior.
* Support `remove_domain` hook in mod_muc.
* Implement  `remove_domain` callback for RDBMS backend.
* Extract some helper functions from muc_SUITE to muc_helper module to make them available for reuse from domain_removal_SUITE.
* Add test case for mod_muc domain removal.

