### PR TITLE
Test dynamic domains on CircleCI with MySQL and MSSQL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,7 +664,7 @@ workflows:
             - otp_23
           filters: *all_tags
       - big_tests:
-          name: dynamic_domains_23
+          name: dynamic_domains_pgsql_mnesia_23
           otp_package: 23.3.1-1
           spec: dynamic_domains.spec
           preset: pgsql_mnesia
@@ -734,11 +734,31 @@ workflows:
             - otp_24
           filters: *all_tags
       - big_tests:
-          name: dynamic_domains_24
+          name: dynamic_domains_pgsql_mnesia_24
           otp_package: 24.0-1
           spec: dynamic_domains.spec
           preset: pgsql_mnesia
           db: pgsql
+          context: mongooseim-org
+          requires:
+            - otp_24
+          filters: *all_tags
+      - big_tests:
+          name: dynamic_domains_mysql_redis_24
+          otp_package: 24.0-1
+          spec: dynamic_domains.spec
+          preset: mysql_redis
+          db: mysql
+          context: mongooseim-org
+          requires:
+            - otp_24
+          filters: *all_tags
+      - big_tests:
+          name: dynamic_domains_mssql_mnesia_24
+          otp_package: 24.0-1
+          spec: dynamic_domains.spec
+          preset: odbc_mssql_mnesia
+          db: mssql
           context: mongooseim-org
           requires:
             - otp_24
@@ -752,7 +772,7 @@ workflows:
             - small_tests_23
             - ldap_mnesia_23
             - pgsql_mnesia_23
-            - dynamic_domains_23
+            - dynamic_domains_pgsql_mnesia_23
 
             - small_tests_24
             - internal_mnesia_24
@@ -762,7 +782,9 @@ workflows:
             - ldap_mnesia_24
             - riak_mnesia_24
             - elasticsearch_and_cassandra_24
-            - dynamic_domains_24
+            - dynamic_domains_pgsql_mnesia_24
+            - dynamic_domains_mysql_redis_24
+            - dynamic_domains_mssql_mnesia_24
 
             - dialyzer
             - xref

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -274,6 +274,7 @@
   workers = 5
   connection.driver = \"odbc\"
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
+      {service_domain_db, ""},
       {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
       {mod_private, "  backend = \"rdbms\""},
@@ -303,6 +304,7 @@
   connection.tls.verify_peer = true
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.versions = [\"tlsv1.2\"]"},
+      {service_domain_db, ""},
       {mod_last, "  backend = \"rdbms\""},
       {mod_privacy, "  backend = \"rdbms\""},
       {mod_private, "  backend = \"rdbms\""},

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -64,7 +64,8 @@
          get_raw_sessions/1,
          is_offline/1,
          get_user_present_pids/2,
-         sync/0
+         sync/0,
+         run_session_cleanup_hook/1
         ]).
 
 %% Hook handlers
@@ -457,6 +458,16 @@ sync() ->
 unregister_iq_handler(Host, XMLNS) ->
     ejabberd_sm ! {unregister_iq_handler, Host, XMLNS},
     ok.
+
+-spec run_session_cleanup_hook(#session{}) -> mongoose_acc:t().
+run_session_cleanup_hook(#session{usr = {U, S, R}, sid = SID}) ->
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(S),
+    Acc = mongoose_acc:new(
+            #{location => ?LOCATION,
+              host_type => HostType,
+              lserver => S,
+              element => undefined}),
+    mongoose_hooks:session_cleanup(S, Acc, U, R, SID).
 
 %%====================================================================
 %% Hook handlers


### PR DESCRIPTION
Enable jobs for dynamic domains with all SQL databases for Erlang 24, leave one with Erlang 23 to keep the number of jobs in control.

