### PR TITLE
Routing shouldnt create new accs if ones are already available

### DIFF
--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -292,7 +292,7 @@ send_copies(Acc, JID, To, Packet, Direction) ->
                                        resource => JID#jid.lresource, exml_packet => Packet}),
                           Sender = jid:to_bare(JID),
                           New = build_forward_packet(Acc, JID, Packet, Sender, Dest, Direction, Version),
-                          ejabberd_router:route(Sender, Dest, New)
+                          ejabberd_router:route(Sender, Dest, Acc, New)
                   end, Targets).
 
 build_forward_packet(Acc, JID, Packet, Sender, Dest, Direction, Version) ->

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -328,8 +328,8 @@ do_send_packet(From, To, Packet) ->
                                       host_type => HostType,
                                       lserver => From#jid.lserver,
                                       element => Packet}),
-            mongoose_hooks:user_send_packet(Acc, From, To, Packet),
-            ejabberd_router:route(From, To, Packet),
+            Acc1 = mongoose_hooks:user_send_packet(Acc, From, To, Packet),
+            ejabberd_router:route(From, To, Acc1),
             ok;
         {error, not_found} ->
             {error, unknown_domain}


### PR DESCRIPTION
Again, those accs might contain useful data we don't want to calculate again. In the case of carbons for example, hostypes, lservers, and timestamps, are the same for all copies, no need to recalculate again.