### PR TITLE
Adjust ets tables parameters

### DIFF
--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -277,8 +277,8 @@ node_cleanup(Acc, Node) ->
 %% Description: Initiates the server
 %%--------------------------------------------------------------------
 init([]) ->
-    catch ets:new(?IQTABLE, [named_table, protected]),
-    catch ets:new(?NSTABLE, [named_table, bag, protected]),
+    catch ets:new(?IQTABLE, [named_table, protected, {read_concurrency, true}]),
+    catch ets:new(?NSTABLE, [named_table, bag, protected, {read_concurrency, true}]),
     update_table(),
     mnesia:create_table(iq_response,
                         [{ram_copies, [node()]},

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -487,7 +487,7 @@ init([]) ->
     {Mod, Code} = dynamic_compile:from_string(sm_backend(Backend)),
     code:load_binary(Mod, "ejabberd_sm_backend.erl", Code),
 
-    ets:new(sm_iqtable, [named_table]),
+    ets:new(sm_iqtable, [named_table, protected, {read_concurrency, true}]),
 
     ejabberd_hooks:add(node_cleanup, global, ?MODULE, node_cleanup, 50),
     lists:foreach(fun(HostType) -> ejabberd_hooks:add(hooks(HostType)) end,


### PR DESCRIPTION
These IQ tables are accessed concurrently by all c2s process,
potentially it tight loops, but they're rarely modified and then only
by their process owner, so it really makes sense to have them as
read_concurrency and protected.