### PR TITLE
Fix config key type definition and an s2s option

### DIFF
--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -35,10 +35,10 @@
 -include("mongoose.hrl").
 -include("ejabberd_config.hrl").
 
--type key() :: atom()
-             | {key(), jid:server() | atom() | list()}
-             | {atom(), atom(), atom()}
-             | binary(). % TODO: binary is questionable here
+-type key() :: atom() | host_type_key() | host_type_or_global_key().
+-type s2s_domain_key() :: {atom(), jid:lserver()}.
+-type host_type_key() :: {atom() | s2s_domain_key(), mongooseim:host_type() | global}.
+-type host_type_or_global_key() :: {shaper | access, atom(), mongooseim:host_type() | global}.
 
 -type value() :: atom()
                | binary()

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -1275,8 +1275,7 @@ get_acc_with_new_tls(_, _, Acc) ->
 
 get_tls_opts_with_certfile(StateData) ->
     case ejabberd_config:get_local_option(
-           {domain_certfile,
-            binary_to_list(StateData#state.myname)}) of
+           {domain_certfile, StateData#state.myname}) of
         undefined ->
             StateData#state.tls_options;
         CertFile ->


### PR DESCRIPTION
The previous type got out of date and caused dialyzer to discard some success paths and miss the issue with the s2s option.

Moreover, dialyzer started failing for me when reworking the config options because of this outdated type.
