### PR TITLE
Hook funs

### DIFF
--- a/src/safely.erl
+++ b/src/safely.erl
@@ -12,7 +12,7 @@
 -export([apply/2, apply/3]).
 -export([apply_and_log/3, apply_and_log/4]).
 -compile({no_auto_import, [apply/2, apply/3]}).
--ignore_xref([apply/2, apply_and_log/4]).
+-ignore_xref([apply/3, apply_and_log/4]).
 
 -type error_class() :: error | exit | throw.
 -type catch_result(A) :: A | {error_class(), term()}.

--- a/test/ejabberd_hooks_SUITE.erl
+++ b/test/ejabberd_hooks_SUITE.erl
@@ -38,10 +38,10 @@ a_module_fun_can_be_added(_) ->
     % when
     ejabberd_hooks:add(test_run_hook, ?HOST, hook_mod, fun_a, 1),
 
+    FunEjabberdHooksWrapper = fun ejabberd_hooks:gen_hook_fn_wrapper/3,
     % then
-    [{{test_run_hook,<<"localhost">>},
-      [{hook_handler, 1,
-        ejabberd_hooks, gen_hook_fn_wrapper,
+    [{{test_run_hook, <<"localhost">>},
+      [{hook_handler, 1, FunEjabberdHooksWrapper,
         #{function := fun_a, module := hook_mod}}]}] = get_hooks().
 
 a_module_fun_can_be_removed(_) ->

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -60,13 +60,13 @@ single_handler_can_be_added_and_removed(_) ->
                                           #{id => 1}, 1)),
     %% check that hook handlers are added
     Tag1Handlers = [%% this list must be sorted by priority
-                    {hook_handler, 1, mod1, plus,
+                    {hook_handler, 1, PlusHandlerFn,
                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1, id => 1}},
-                    {hook_handler, 2, mod2, multiply,
+                    {hook_handler, 2, MultiplyHandlerFn,
                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1, id => 2}}],
     AllHandlers = [{{calculate, ?HOOK_TAG1}, Tag1Handlers},
                    {{calculate, ?HOOK_TAG2},
-                    [{hook_handler, 1, mod1, plus,
+                    [{hook_handler, 1, PlusHandlerFn,
                       #{hook_name => calculate, hook_tag => ?HOOK_TAG2,
                         host_type =>?HOOK_TAG2, id => 1}}]}],
     ?assertEqualLists(AllHandlers, get_handlers_for_all_hooks()),
@@ -108,13 +108,13 @@ multiple_handlers_can_be_added_and_removed(_) ->
     ?assertEqual(ok, gen_hook:add_handlers(HookHandlers)),
     %% check that hook handlers are added
     Tag1Handlers = [%% this list must be sorted by priority
-                    {hook_handler, 1, mod1, plus,
+                    {hook_handler, 1, PlusHandlerFn,
                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1, id => 1}},
-                    {hook_handler, 2, mod2, multiply,
+                    {hook_handler, 2, MultiplyHandlerFn,
                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1, id => 2}}],
     AllHandlers = [{{calculate, ?HOOK_TAG1}, Tag1Handlers},
                    {{calculate, ?HOOK_TAG2},
-                    [{hook_handler, 1, mod1, plus,
+                    [{hook_handler, 1, PlusHandlerFn,
                       #{hook_name => calculate, hook_tag => ?HOOK_TAG2,
                         host_type =>?HOOK_TAG2, id => 1}}]}],
     ?assertEqualLists(AllHandlers, get_handlers_for_all_hooks()),
@@ -146,7 +146,7 @@ local_fun_references_causes_error(_) ->
                  gen_hook:add_handlers(HookHandlers)),
     %% check that handlers in the list are partially added (till error occurs)
     ?assertEqual([{{calculate, ?HOOK_TAG1},
-                   [{hook_handler, 2, mod2, multiply,
+                   [{hook_handler, 2, MultiplyHandlerFn,
                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1, id => 2}}]}],
                  get_handlers_for_all_hooks()),
     %% try to remove the same list of handlers
@@ -288,7 +288,7 @@ errors_in_handlers_are_reported_but_ignored(_) ->
     %% check that error is reported
     ?assertEqual(true, meck:called(gen_hook, error_running_hook,
                                    [{error, {some_error, '_'}},
-                                    {hook_handler, 3, mod1, error,
+                                    {hook_handler, 3, ErrorHandlerFn,
                                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1}},
                                     6, #{n => 2}, {calculate, ?HOOK_TAG1}])),
     %% check hook handlers execution sequence


### PR DESCRIPTION
It's a bit pointless to be passing to gen_hook a function reference, even as to make gen_hook throw an error and prevent altogether the registration of a hook if the given fun is not strictly external, only to then extract the module and function atoms and use them to call the function through an `erlang:apply/3` proxied through another module. Instead we can store the function reference, have the hook record that will be stored in the ets table be a word smaller (one field less in the tuple), and use the ref to call the function, which has a theoretical performance advantage.
In line with this, get rid of the `safely` module, that is being barely used anywhere.