### PR TITLE
Fix missing "/" for make_request

### DIFF
--- a/src/mongoose_http_client.erl
+++ b/src/mongoose_http_client.erl
@@ -51,7 +51,8 @@ make_request(Host, PoolTag, Path, Method, Headers, Query) ->
     end.
 
 make_request(Host, PoolTag, PathPrefix, RequestTimeout, Path, Method, Headers, Query) ->
-    FullPath = <<PathPrefix/binary, "/", Path/binary>>,
+    FixedPath = fix_path(Path),
+    FullPath = <<PathPrefix/binary, FixedPath/binary>>,
     Req = {request, FullPath, Method, Headers, Query, 2, RequestTimeout},
     try mongoose_wpool:call(http, Host, PoolTag, Req) of
         {ok, {{Code, _Reason}, _RespHeaders, RespBody, _, _}} ->
@@ -70,3 +71,8 @@ make_request(Host, PoolTag, PathPrefix, RequestTimeout, Path, Method, Headers, Q
         Type:Error ->
             {error, {Type, Error}}
     end.
+
+fix_path(<<"/", _/binary>> = Path) ->
+    Path;
+fix_path(R) ->
+    <<"/", R/binary>>.

--- a/src/mongoose_http_client.erl
+++ b/src/mongoose_http_client.erl
@@ -51,7 +51,7 @@ make_request(Host, PoolTag, Path, Method, Headers, Query) ->
     end.
 
 make_request(Host, PoolTag, PathPrefix, RequestTimeout, Path, Method, Headers, Query) ->
-    FullPath = <<PathPrefix/binary, Path/binary>>,
+    FullPath = <<PathPrefix/binary, "/", Path/binary>>,
     Req = {request, FullPath, Method, Headers, Query, 2, RequestTimeout},
     try mongoose_wpool:call(http, Host, PoolTag, Req) of
         {ok, {{Code, _Reason}, _RespHeaders, RespBody, _, _}} ->


### PR DESCRIPTION
Currently, `FullPath` is missing '/' in MongooseIM/src/mongoose_http_client.erl, because fix_path has removed '\'.
A prefix like `localhost:5005` and a path of `/notification` will be `localhost:5005notification` instead of `localhost:5005/notification`
Here are the flow:
https://github.com/esl/MongooseIM/blob/0497dd8d632baa357af2b4655c7afcd32ca768d7/src/event_pusher/mod_event_pusher_http.erl#L97-L98

request path is stripped. 
https://github.com/esl/MongooseIM/blob/0497dd8d632baa357af2b4655c7afcd32ca768d7/src/event_pusher/mod_event_pusher_http.erl#L138-L139

but it is missing the '/' at
https://github.com/esl/MongooseIM/blob/0497dd8d632baa357af2b4655c7afcd32ca768d7/src/mongoose_http_client.erl#L53-L54

Do we need to remove the strip_path or add '/' to make_request like:
`FullPath = <<PathPrefix/binary, "/", Path/binary>>,`


