### PR TITLE
Extend safely API

### DIFF
--- a/src/domain/mongoose_domain_core.erl
+++ b/src/domain/mongoose_domain_core.erl
@@ -174,9 +174,13 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 for_each_selected_domain('$end_of_table', _) -> ok;
 for_each_selected_domain({MatchList, Continuation}, Func) ->
-    [safely:apply(Func, Args) || Args <- MatchList],
+    [safely:apply_and_log(Func, Args, log_context(Args)) || Args <- MatchList],
     Selection = ets:select(Continuation),
     for_each_selected_domain(Selection, Func).
+
+log_context(Args) ->
+    #{what => domain_operation_failed,
+      args => Args}.
 
 insert_initial(Tab, Pairs) ->
     lists:foreach(fun({Domain, HostType}) ->

--- a/src/domain/mongoose_subdomain_core.erl
+++ b/src/domain/mongoose_subdomain_core.erl
@@ -211,7 +211,7 @@ handle_register(HostType, SubdomainPattern, PacketHandler, From) ->
                     Fn = fun(_HostType, Subdomain) ->
                              add_subdomain(RegItem, Subdomain)
                          end,
-                    %% mongoose_domain_core:for_each_domain/2 can take quite a long,
+                    %% mongoose_domain_core:for_each_domain/2 can take quite long,
                     %% reply before running it.
                     gen_server:reply(From, ok),
                     mongoose_domain_core:for_each_domain(HostType, Fn);

--- a/src/safely.erl
+++ b/src/safely.erl
@@ -1,22 +1,56 @@
 -module(safely).
-%% This module preserves the return types of a `catch` statement,
-%% but doesn't silently convert `throw`s to normal values.
+%% This module preserves the return types of a `catch' statement,
+%% but doesn't silently convert `throw's to normal values.
+%% The issue is that throws have different semantics than errors:
+%% https://erlang.org/doc/reference_manual/expressions.html#catch-and-throw,
+%% so a throw is actually a control flow escape, while an error is an actual crash.
+%% If it is an error, we want the stacktrace, if not, we don't.
+%% For more information, see usage in test/safely_SUITE.erl
 
--export([apply/2,
-         apply/3]).
+-include_lib("kernel/include/logger.hrl").
 
--type catch_result(A) :: A | {'EXIT', term()}.
+-export([apply/2, apply/3]).
+-export([apply_and_log/3, apply_and_log/4]).
+-compile({no_auto_import, [apply/2, apply/3]}).
+-ignore_xref([apply/2, apply_and_log/4]).
+
+-type error_class() :: error | exit | throw.
+-type catch_result(A) :: A | {error_class(), term()}.
+
+-define(MATCH_EXCEPTIONS_DO_LOG(F, Context),
+        try F catch
+            error:R:S ->
+                ?LOG_ERROR(Context#{class => error, reason => R, stacktrace => S}),
+                {error, {R, S}};
+            throw:R ->
+                ?LOG_ERROR(Context#{class => throw, reason => R}),
+                {throw, R};
+            exit:R ->
+                ?LOG_ERROR(Context#{class => exit, reason => R}),
+                {exit, R}
+        end).
+
+-define(MATCH_EXCEPTIONS(F),
+        try F catch
+            error:R:S -> {error, {R, S}};
+            throw:R -> {throw, R};
+            exit:R -> {exit, R}
+        end).
 
 -spec apply(fun((...) -> A), [term()]) -> catch_result(A).
 apply(Function, Args) when is_function(Function), is_list(Args) ->
-    try erlang:apply(Function, Args)
-    catch error:R:S -> {'EXIT', {R, S}};
-          _:R -> {'EXIT', R}
-    end.
+    ?MATCH_EXCEPTIONS(erlang:apply(Function, Args)).
 
 -spec apply(atom(), atom(), [term()]) -> catch_result(any()).
 apply(Module, Function, Args) when is_atom(Function), is_list(Args) ->
-    try erlang:apply(Module, Function, Args)
-    catch error:R:S -> {'EXIT', {R, S}};
-          _:R -> {'EXIT', R}
-    end.
+    ?MATCH_EXCEPTIONS(erlang:apply(Module, Function, Args)).
+
+% -spec apply_and_log(fun((...) -> A), [term()], map()) -> catch_result(A).
+apply_and_log(Function, Args, Context)
+  when is_function(Function), is_list(Args), is_map(Context) ->
+    ?MATCH_EXCEPTIONS_DO_LOG(erlang:apply(Function, Args), Context).
+
+% -spec apply_and_log(atom(), atom(), [term()], map()) -> catch_result(any()).
+apply_and_log(Module, Function, Args, Context)
+  when is_atom(Function), is_list(Args), is_map(Context) ->
+    ?MATCH_EXCEPTIONS_DO_LOG(erlang:apply(Module, Function, Args), Context).

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -287,7 +287,7 @@ errors_in_handlers_are_reported_but_ignored(_) ->
     ?assertEqual({ok, N}, gen_hook:run_fold(calculate, ?HOOK_TAG1, 0, #{n => 2})),
     %% check that error is reported
     ?assertEqual(true, meck:called(gen_hook, error_running_hook,
-                                   [{some_error, '_'},
+                                   [{error, {some_error, '_'}},
                                     {hook_handler, {calculate, ?HOOK_TAG1}, 3, mod1, error,
                                      #{hook_name => calculate, hook_tag => ?HOOK_TAG1}},
                                     6, #{n => 2}])),

--- a/test/safely_SUITE.erl
+++ b/test/safely_SUITE.erl
@@ -3,19 +3,18 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [ handles_errors_like_catch,
-      handles_exits_like_catch,
+    [ handles_errors_similar_to_catch,
+      handles_exits_similar_to_errors,
       handles_throws_unlike_catch,
       handles_success_like_catch
     ].
 
-
-handles_errors_like_catch(_) ->
+handles_errors_similar_to_catch(_) ->
     {SafeRes, CatchRes} =
         %% These two must be on the same line for the stacktraces to be equal.
         {safely:apply(lists, min, [[]]),(catch apply(lists, min, [[]]))},
 
-    {'EXIT', {function_clause, SafeST}} = SafeRes,
+    {error, {function_clause, SafeST}} = SafeRes,
     {'EXIT', {function_clause, CatchST}} = CatchRes,
 
     true = (hd(CatchST) == hd(SafeST)),
@@ -24,15 +23,15 @@ handles_errors_like_catch(_) ->
 
     true = (tl(CatchST) == tl(tl(SafeST))).
 
-handles_exits_like_catch(_) ->
+handles_exits_similar_to_errors(_) ->
     ExitF = fun() -> exit(i_quit) end,
-    {'EXIT', i_quit} = safely:apply(ExitF,[]),
+    {exit, i_quit} = safely:apply(ExitF,[]),
     {'EXIT', i_quit} = (catch apply(ExitF,[])),
     ok.
 
 handles_throws_unlike_catch(_) ->
     ThrowF = fun() -> throw(up) end,
-    {'EXIT', up} = safely:apply(ThrowF,[]),
+    {throw, up} = safely:apply(ThrowF,[]),
     up = (catch apply(ThrowF,[])),
     ok.
 


### PR DESCRIPTION
This PR extends the behaviour of the module `safely`, adding logging, distinguishing the exception class, and adding some comments explaining the purpose of this module.