### PR TITLE
Added mongoose_metrics:ensure_subscribed_metric/3

### DIFF
--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -53,25 +53,7 @@ binary_to_metric_atom(Binary) ->
     list_to_atom(List).
 
 ensure_metric(Metric, Type) ->
-    case mongoose_metrics:ensure_metric(global, Metric, Type) of
-        ok ->
-            Reporters = exometer_report:list_reporters(),
-            Interval = mongoose_metrics:get_report_interval(),
-            lists:foreach(
-              fun(Reporter) ->
-                      mongoose_metrics:subscribe_metric(Reporter, {[global | Metric], Type, []},
-                                                        Interval)
-              end,
-              Reporters);
-        {ok, already_present} ->
-            ?LOG_DEBUG(#{what => metric_already_present,
-                         metric => Metric, type => Type}),
-            ok;
-        Other ->
-            ?LOG_WARNING(#{what => cannot_create_metric,
-                           metric => Metric, type => Type, reason => Other}),
-            Other
-    end.
+    mongoose_metrics:ensure_subscribed_metric(global, Metric, Type).
 
 -spec any_binary_to_atom(binary()) -> atom().
 any_binary_to_atom(Binary) ->

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -56,7 +56,7 @@
 -type use_or_skip() :: use | skip.
 -type hook_name() :: atom().
 -type metric_name() :: atom() | list(atom() | binary()).
--type short_metric_type() :: spiral | histogram | counter.
+-type short_metric_type() :: spiral | histogram | counter | gauge.
 -type metric_type() :: tuple() | short_metric_type().
 -type host_type_or_global() :: mongooseim:host_type() | global.
 

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -43,13 +43,13 @@
          get_mnesia_running_db_nodes_count/0,
          remove_host_type_metrics/1,
          remove_all_metrics/0,
-         get_report_interval/0,
-         subscribe_metric/3
+         get_report_interval/0
         ]).
 
 -ignore_xref([create_global_metrics/0, get_dist_data_stats/0, get_mnesia_running_db_nodes_count/0,
               get_rdbms_data_stats/0, get_rdbms_data_stats/1, get_up_time/0,
-              init_subscriptions/0, make_host_type_name/1, remove_host_type_metrics/1]).
+              init_subscriptions/0, make_host_type_name/1, remove_host_type_metrics/1,
+              get_report_interval/0]).
 
 -define(DEFAULT_REPORT_INTERVAL, 60000). %%60s
 

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -27,7 +27,8 @@ all_metrics_list() ->
      tcp_connections_detected,
      tcp_metric_varies_with_tcp_variations,
      up_time_positive,
-     queued_messages_increase
+     queued_messages_increase,
+     function_ensure_subscribed_metric_subscribes
     ].
 
 init_per_suite(C) ->
@@ -113,6 +114,11 @@ end_per_testcase(_N, C) ->
 up_time_positive(_C) ->
     {ok, [{value, X}]} = mongoose_metrics:get_metric_value(global, nodeUpTime),
     ?assert(X > 0).
+
+function_ensure_subscribed_metric_subscribes(_C) ->
+    Metric = [cool_metric],
+    mongoose_metrics:ensure_subscribed_metric(global, Metric, spiral),
+    ct:fail(exometer_reporter:list_subscriptions(exometer_report_graphite)).
 
 get_new_tcp_metric_value(OldValue) ->
     Validator = fun(NewValue) -> OldValue =/= NewValue end,


### PR DESCRIPTION
This PR addresses "mod_global_distrib_utls:ensure_metric/3 does not actually subscribe anything".

Proposed changes include:
* Added mongoose_metrics:ensure_subscribed_metric/3
* Added logging of errors from exometer_report:subscribe
* test