### PR TITLE
Fix rest_client_SUITE:muc:messages_can_be_paginated_in_room

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -111,6 +111,7 @@
          wait_for_room_archive_size/3,
          generate_msg_for_date_user/3,
          generate_msg_for_date_user/4,
+         random_text/0,
          put_msg/1
         ]).
 
@@ -890,12 +891,13 @@ generate_msgs_for_day(Day, OwnerJID, OtherUsers) ->
      || RemoteJID <- OtherUsers].
 
 generate_msg_for_date_user(Owner, Remote, DateTime) ->
-    generate_msg_for_date_user(Owner, Remote, DateTime, base16:encode(crypto:strong_rand_bytes(4))).
+    generate_msg_for_date_user(Owner, Remote, DateTime, random_text()).
+
+random_text() ->
+    base16:encode(crypto:strong_rand_bytes(4)).
 
 generate_msg_for_date_user(Owner, {RemoteBin, _, _} = Remote, DateTime, Content) ->
-    MicrosecDateTime = datetime_to_microseconds(DateTime),
-    NowMicro = rpc_apply(erlang, system_time, [microsecond]),
-    Microsec = min(NowMicro, MicrosecDateTime),
+    Microsec = datetime_to_microseconds(DateTime),
     MsgIdOwner = rpc_apply(mod_mam_utils, encode_compact_uuid, [Microsec, rand:uniform(20)]),
     MsgIdRemote = rpc_apply(mod_mam_utils, encode_compact_uuid, [Microsec+1, rand:uniform(20)]),
     Packet = escalus_stanza:chat_to(RemoteBin, Content),

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -525,7 +525,9 @@ get_room_messages(Caller, RoomID) ->
 messages_can_be_paginated_in_room(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         RoomID = given_new_room_with_users({alice, Alice}, [{bob, Bob}]),
-        [GenMsgs1, GenMsgs2 | _] = rest_helper:fill_room_archive(RoomID, [Alice, Bob]),
+        %% GenMsgs1 is older than GenMsgs2
+        %% One message is already in the archive
+        [GenMsgs1, GenMsgs2 | _] = rest_helper:fill_room_archive(RoomID, [Alice, Bob], 1),
         mam_helper:maybe_wait_for_archive(Config),
         Msgs10 = get_room_messages({alice, Alice}, RoomID, 10),
         Msgs10Len = length(Msgs10),

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -24,7 +24,7 @@
     maybe_disable_mam/2,
     maybe_skip_mam_test_cases/3,
     fill_archive/2,
-    fill_room_archive/2,
+    fill_room_archive/3,
     make_timestamp/2,
     change_admin_creds/1,
     make_msg_stanza_with_props/2,
@@ -419,10 +419,12 @@ make_arc_id(Client) ->
     Jid = mongoose_helper:make_jid(User, Server, <<>>),
     {Bin, Jid, mam_helper:rpc_apply(mod_mam, archive_id, [Server, User])}.
 
-fill_room_archive(RoomID, Users) ->
+fill_room_archive(RoomID, Users, AlreadyArchivedCount) ->
     {TodayDate, _} = calendar:local_time(),
     Today = calendar:date_to_gregorian_days(TodayDate),
-    Days = [Today - I || I <- lists:seq(0, 3)],
+    DayOffsets = [I || I <- lists:seq(0, 3)],
+    %% Days = [Today, Yesterday, ...]
+    Days = [Today - I || I <- DayOffsets],
     HostType = host_type(),
     MUCLight = ct:get_config({hosts, mim, muc_light_service}),
     RoomJID = mongoose_helper:make_jid(RoomID, MUCLight, <<>>),
@@ -430,15 +432,45 @@ fill_room_archive(RoomID, Users) ->
     RoomArcID = mam_helper:rpc_apply(mod_mam_muc, archive_id_int, [HostType, RoomJID]),
     Room = {RoomBinJID, RoomJID, RoomArcID},
     UserArcIDs = [make_room_arc_id(Room, User) || User <- Users],
-    [put_room_msgs_in_day(Room, UserArcIDs, Day) || Day <- lists:reverse(Days)].
+    %% Returns tuples the oldest first
+    %% We add numbering for day_offset and user_num here for simple debugging
+    %% We check, that we didn't archived several messages under the same message id
+    Result = [put_room_msgs_in_day(Room, UserArcIDs, Day, DayOffset) ||
+         {Day, DayOffset} <- lists:zip(lists:reverse(Days), lists:reverse(DayOffsets))],
+    assert_unique_ids(Result),
+    mam_helper:wait_for_room_archive_size(MUCLight, RoomID,
+                                          length(result_to_ids(Result)) + AlreadyArchivedCount),
+    Result.
 
-put_room_msgs_in_day(RoomJID, Users, Day) ->
-    [put_room_msg_in_day(RoomJID, User, Day) || User <- Users].
+%% To avoid duplicates errors
+%% This check is explicit to avoid strange bugs, when one message is missing
+assert_unique_ids(Result) ->
+    assert_unique_list(result_to_ids(Result)).
 
-put_room_msg_in_day(RoomArcID, FromArcID, Day) ->
+assert_unique_list(List) ->
+    ?assertEqual(lists:usort(List), lists:sort(List)).
+
+result_to_ids(Result) ->
+    [MsgID || PerDay <- Result, {MsgID, _, _} <- PerDay].
+
+put_room_msgs_in_day(RoomJID, Users, Day, DayOffset) ->
     {_, Time} = calendar:local_time(),
-    DateTime = {calendar:gregorian_days_to_date(Day), Time},
-    Msg = mam_helper:generate_msg_for_date_user(FromArcID, RoomArcID, DateTime),
+    [put_room_msg_in_day(RoomJID, User, UserNum, Day, DayOffset, Time)
+     || {User, UserNum} <- lists:zip(Users, lists:seq(1, length(Users)))].
+
+offset_time(Time, Offset) ->
+    calendar:seconds_to_time(calendar:time_to_seconds(Time) + Offset).
+
+put_room_msg_in_day(RoomArcID, FromArcID, UserNum, Day, DayOffset, Time) ->
+    %% Make sure messages are sorted and with unique ids by making predictable
+    %% datetime.
+    %% So, first user sends first message, second user sends second message...
+    Time2 = offset_time(Time, UserNum),
+    DateTime = {calendar:gregorian_days_to_date(Day), Time2},
+    Content = <<(mam_helper:random_text())/binary,
+                 " day_offset=", (integer_to_binary(DayOffset))/binary,
+                 " user_num=", (integer_to_binary(UserNum))/binary>>,
+    Msg = mam_helper:generate_msg_for_date_user(FromArcID, RoomArcID, DateTime, Content),
     put_room_msg(Msg).
 
 put_room_msg({{_, MsgID},


### PR DESCRIPTION
This PR addresses [failing rest_client_SUITE:muc:messages_can_be_paginated_in_room testcase](https://circleci-mim-results.s3.eu-central-1.amazonaws.com/branch/master/82448/pgsql_mnesia.23.3.1-1/big/ct_run.test@default-0cf6453d-1703-4c86-8b6a-72557f98c4f2.2021-10-25_12.36.51/big_tests.tests.rest_client_SUITE.logs/run.2021-10-25_12.50.45/rest_client_suite.messages_can_be_paginated_in_room.html)

Proposed changes include:
* Add day_offset and user_num into message body for debugging
* Wait for messages to be in the archive in rest_helper:fill_room_archive
* Ensure we generate messages with unique ids in rest_helper:fill_room_archive


#3360 with fail infos