### PR TITLE
Trying to fix pagerank for readthedocs

### DIFF
--- a/doc_custom_theme/main.html
+++ b/doc_custom_theme/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<link rel="canonical" href="https://esl.github.io/MongooseDocs/latest/{{ page.url }}" />
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,11 @@
 site_name: MongooseIM
 docs_dir: doc
-theme: readthedocs
+theme:
+  name: readthedocs
+  custom_dir: doc_custom_theme/
 site_favicon: favicon.ico
 extra_templates: []
 extra_css: ["custom.css"]
 extra_javascript: []
-
 pages:
   - Home: 'index.md'


### PR DESCRIPTION
It adds canonical meta, telling Google where to find the original. Otherwise Google thinks, that our new cool docs is just a pathetic mirror, so it gets an extra kick and our docs are smashhed in the pagerank calculation. Which is not cool for everyone, who likes to google for docs ;)   

Working Example: https://supergooseim--82.org.readthedocs.build/en/82/Contributions/
It has  new cool header tag:

```html
<link rel="canonical" href="https://esl.github.io/MongooseDocs/latest/Contributions/" />
```

Google is confused:

![Screen Shot 2021-10-26 at 7 34 19 PM](https://user-images.githubusercontent.com/639796/138931185-6c08ef18-752c-4055-a08c-6cd83728236e.png)