### PR TITLE
Run muclight inbox tests one by one instead of parallel

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -112,8 +112,8 @@ tests() ->
     ].
 
 groups() ->
-    [
-     {generic, [parallel],
+    Gs = [
+     {generic, [],
       [
        disco_service,
        returns_valid_form,
@@ -126,7 +126,7 @@ groups() ->
        returns_error_when_no_reset_field_jid,
        returns_error_when_unknown_field_sent
       ]},
-     {one_to_one, [parallel],
+     {one_to_one, [],
       [
        user_has_empty_inbox,
        msg_sent_stored_in_inbox,
@@ -148,7 +148,7 @@ groups() ->
        check_total_unread_count_when_there_are_no_active_conversations,
        total_unread_count_and_active_convs_are_zero_at_no_activity
       ]},
-     {muclight, [], %% These could be parallel but it seems like mssql CI can't handle the load
+     {muclight, [],
       [
        simple_groupchat_stored_in_all_inbox,
        advanced_groupchat_stored_in_all_inbox,
@@ -168,7 +168,7 @@ groups() ->
        no_stored_and_remain_after_kicked,
        system_message_is_correctly_avoided
       ]},
-     {muc, [parallel],
+     {muc, [],
       [
        simple_groupchat_stored_in_all_inbox_muc,
        simple_groupchat_stored_in_offline_users_inbox_muc,
@@ -178,7 +178,7 @@ groups() ->
        unread_count_is_reset_after_sending_reset_stanza,
        private_messages_are_handled_as_one2one
       ]},
-     {timestamps, [parallel],
+     {timestamps, [],
       [
        timestamp_is_updated_on_new_message,
        order_by_timestamp_ascending,
@@ -186,7 +186,8 @@ groups() ->
        get_with_start_timestamp,
        get_with_end_timestamp
       ]}
-    ].
+    ],
+    inbox_helper:maybe_run_in_parallel(Gs).
 
 suite() ->
     escalus:suite().

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -83,18 +83,21 @@
 
 
 all() ->
-    inbox_helper:skip_or_run_inbox_tests([{group, inbox_extensions}]).
+    inbox_helper:skip_or_run_inbox_tests(tests()).
+
+tests() ->
+    [
+     {group, generic},
+     {group, one_to_one},
+     {group, muclight}
+    ].
 
 suite() ->
     escalus:suite().
 
 groups() ->
-    G = [{inbox_extensions, [], inbox_extensions_tests()}],
-    ct_helper:repeat_all_until_all_ok(G).
-
-inbox_extensions_tests() ->
-    [
-     {generic, [parallel], [
+    Gs = [
+     {generic, [], [
         % General errors
         returns_error_when_no_jid_provided,
         returns_error_when_invalid_jid_provided,
@@ -113,7 +116,7 @@ inbox_extensions_tests() ->
         returns_error_when_archive_field_is_invalid,
         returns_error_when_max_is_not_a_number
       ]},
-     {one_to_one, [parallel], [
+     {one_to_one, [], [
         % read
         read_unread_entry_set_to_read,
         read_read_entry_set_to_unread,
@@ -138,10 +141,11 @@ inbox_extensions_tests() ->
         max_queries_can_fetch_ahead,
         timestamp_is_not_reset_with_setting_properties
       ]},
-     {muclight, [sequence], [
+     {muclight, [], [
         groupchat_setunread_stanza_sets_inbox
       ]}
-    ].
+    ],
+    inbox_helper:maybe_run_in_parallel(Gs).
 
 init_per_suite(Config) ->
     ok = dynamic_modules:ensure_modules(domain_helper:host_type(mim), inbox_modules()),


### PR DESCRIPTION
Seems like mssql has big trouble to handle the load here, judging from
the immense amount of failures it has on CircleCI.

This PR addresses #3360
This partially undoes the work it #3227 
Note https://circleci-mim-results.s3.eu-central-1.amazonaws.com/branch/master/83654/odbc_mssql_mnesia.24.0-1/big/ct_run.test@default-90812e16-c290-4c8e-8657-ef40fbf82325.2021-10-27_15.33.54/mongooseim@localhost.log.html#L861