### PR TITLE
Allow to skip cover compilation for small tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
       - run:
           name: Run Small Tests
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p small_tests -s true -e true
+            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 REBAR_CT_EXTRA_ARGS=" -c " ./tools/test.sh -p small_tests -s true -e true
       - run_coverage_analysis
       - upload_results_to_aws
       - publish_github_comment
@@ -462,7 +462,7 @@ jobs:
       - run:
           name: Run Small Tests
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p small_tests -s true -e true
+            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 REBAR_CT_EXTRA_ARGS=" -c " ./tools/test.sh -p small_tests -s true -e true
       - run_coverage_analysis
       - upload_results_to_aws
       - publish_github_comment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,8 @@ jobs:
         description: Version of the Erlang package to install
     environment:
       PRESET: small_tests
+      SKIP_AUTO_COMPILE: true
+      KEEP_COVER_RUNNING: 1
     steps:
       - checkout
       - fetch_packages
@@ -277,7 +279,7 @@ jobs:
       - run:
           name: Run Small Tests
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 REBAR_CT_EXTRA_ARGS=" -c " ./tools/test.sh -p small_tests -s true -e true
+            ./tools/test.sh -p small_tests -s true -e true
       - run_coverage_analysis
       - upload_results_to_aws
       - publish_github_comment
@@ -318,6 +320,8 @@ jobs:
       CASSANDRA_VERSION: 3.9
       TESTSPEC: <<parameters.spec>>
       REDIS_VERSION: 3.2.10
+      SKIP_AUTO_COMPILE: true
+      KEEP_COVER_RUNNING: 1
     steps:
       - checkout
       - fetch_packages
@@ -338,7 +342,7 @@ jobs:
       - run:
           name: Run Big Tests
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p $PRESET -s false
+            ./tools/test.sh -p $PRESET -s false
           no_output_timeout: 40m
       - run_coverage_analysis
       - run:
@@ -455,6 +459,8 @@ jobs:
     parallelism: 1
     environment:
       PRESET: small_tests
+      SKIP_AUTO_COMPILE: true
+      KEEP_COVER_RUNNING: 1
     steps:
       - restore_workspace
       - install_dockerize
@@ -462,7 +468,7 @@ jobs:
       - run:
           name: Run Small Tests
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 REBAR_CT_EXTRA_ARGS=" -c " ./tools/test.sh -p small_tests -s true -e true
+            ./tools/test.sh -p small_tests -s true -e true
       - run_coverage_analysis
       - upload_results_to_aws
       - publish_github_comment
@@ -494,6 +500,8 @@ jobs:
       ELASTICSEARCH_VERSION: 5.6.9
       CASSANDRA_VERSION: 3.9
       REDIS_VERSION: 3.2.10
+      SKIP_AUTO_COMPILE: true
+      KEEP_COVER_RUNNING: 1
     steps:
       - restore_workspace
       - install_dockerize
@@ -504,7 +512,7 @@ jobs:
       - run:
           name: Run Big Tests
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p $PRESET -s false
+            ./tools/test.sh -p $PRESET -s false
           no_output_timeout: 40m
       - run_coverage_analysis
       - run:
@@ -528,7 +536,7 @@ jobs:
       - run:
           name: Run Dialyzer
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p dialyzer_only -s false
+            ./tools/test.sh -p dialyzer_only -s false
 
   xref:
     executor: << parameters.executor >>
@@ -541,7 +549,7 @@ jobs:
       - run:
           name: Run Xref
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p xref_only -s false
+            ./tools/test.sh -p xref_only -s false
   edoc:
     executor: << parameters.executor >>
     parameters:
@@ -553,7 +561,7 @@ jobs:
       - run:
           name: Run Edoc
           command: |
-            SKIP_AUTO_COMPILE=true KEEP_COVER_RUNNING=1 ./tools/test.sh -p edoc_only -s false
+            ./tools/test.sh -p edoc_only -s false
 
   package:
     parallelism: 1
@@ -578,7 +586,7 @@ jobs:
       - run:
           name: Build package
           command: |
-            KEEP_COVER_RUNNING=1 ./tools/test.sh -p pkg -s false
+            ./tools/test.sh -p pkg -s false
 
 filters: &all_tags
   tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,6 @@ jobs:
     environment:
       PRESET: small_tests
       SKIP_AUTO_COMPILE: true
-      KEEP_COVER_RUNNING: 1
     steps:
       - checkout
       - fetch_packages
@@ -460,7 +459,6 @@ jobs:
     environment:
       PRESET: small_tests
       SKIP_AUTO_COMPILE: true
-      KEEP_COVER_RUNNING: 1
     steps:
       - restore_workspace
       - install_dockerize

--- a/rebar.config
+++ b/rebar.config
@@ -210,7 +210,6 @@
 
 {dialyzer, [{plt_extra_apps, [jid, cowboy, lasse, p1_utils, ranch, gen_fsm_compat, epgsql]}]}.
 
-{cover_enabled, true}.
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.
 {coveralls_coverdata, "/tmp/*.coverdata"}.

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -596,6 +596,16 @@ TEST_HOSTS_DEFAULT="${TEST_HOSTS_ARRAY[@]}"
 
 ./tools/configure with-all
 
+# Pass extra arguments from tools/test_runner/selected-tests-to-test-spec.sh
+# to rebar3 in Makefile
+if [[ -f "auto_small_tests.spec" ]]; then
+    REBAR_CT_EXTRA_ARGS=" --spec \"$(pwd)/auto_small_tests.spec\" $REBAR_CT_EXTRA_ARGS"
+fi
+
+if [ "$COVER_ENABLED" = true ]; then
+    REBAR_CT_EXTRA_ARGS=" -c "
+fi
+
 # Allow user to pass PRESET and DB as an env variable
 # (or use default value)
 # "${parameter-word}" means:
@@ -612,13 +622,7 @@ export TEST_HOSTS="${TEST_HOSTS-$TEST_HOSTS_DEFAULT}"
 export BUILD_TESTS="$BUILD_TESTS"
 export BUILD_MIM="$BUILD_MIM"
 export TLS_DIST="$TLS_DIST"
-# Pass extra arguments from tools/test_runner/selected-tests-to-test-spec.sh
-# to rebar3 in Makefile
-if [[ -f "auto_small_tests.spec" ]]; then
-    export REBAR_CT_EXTRA_ARGS=" --spec \"$(pwd)/auto_small_tests.spec\" "
-else
-    export REBAR_CT_EXTRA_ARGS=""
-fi
+export REBAR_CT_EXTRA_ARGS="$REBAR_CT_EXTRA_ARGS"
 export SRC_TESTSPEC="$SRC_TESTSPEC"
 export TESTSPEC="auto_big_tests.spec"
 export START_NODES="$START_NODES"

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -598,6 +598,7 @@ TEST_HOSTS_DEFAULT="${TEST_HOSTS_ARRAY[@]}"
 
 # Pass extra arguments from tools/test_runner/selected-tests-to-test-spec.sh
 # to rebar3 in Makefile
+REBAR_CT_EXTRA_ARGS=""
 if [[ -f "auto_small_tests.spec" ]]; then
     REBAR_CT_EXTRA_ARGS=" --spec \"$(pwd)/auto_small_tests.spec\" $REBAR_CT_EXTRA_ARGS"
 fi

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -602,10 +602,6 @@ if [[ -f "auto_small_tests.spec" ]]; then
     REBAR_CT_EXTRA_ARGS=" --spec \"$(pwd)/auto_small_tests.spec\" $REBAR_CT_EXTRA_ARGS"
 fi
 
-if [ "$COVER_ENABLED" = true ]; then
-    REBAR_CT_EXTRA_ARGS=" -c "
-fi
-
 # Allow user to pass PRESET and DB as an env variable
 # (or use default value)
 # "${parameter-word}" means:

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -14,6 +14,7 @@ PRESET="${PRESET-$DEFAULT_PRESET}"
 SMALL_TESTS="${SMALL_TESTS:-true}"
 EUNIT_TESTS="${EUNIT_TESTS:-false}"
 COVER_ENABLED="${COVER_ENABLED:-true}"
+REBAR_CT_EXTRA_ARGS="${REBAR_CT_EXTRA_ARGS:-}"
 
 while getopts ":p:s:e:c:" opt; do
   case $opt in
@@ -81,6 +82,10 @@ choose_newest_directory() {
 run_small_tests() {
   tools/print-dots.sh start
   tools/print-dots.sh monitor $$
+  if [ "$COVER_ENABLED" = true ]; then
+    REBAR_CT_EXTRA_ARGS=" -c $REBAR_CT_EXTRA_ARGS "
+  fi
+  export REBAR_CT_EXTRA_ARGS="$REBAR_CT_EXTRA_ARGS"
   make ct
   tools/print-dots.sh stop
   SMALL_SUMMARIES_DIRS=${BASE}/_build/test/logs/ct_run*


### PR DESCRIPTION
This PR addresses "small tests are slooow while on dev machine".

Proposed changes include:
* --skip-cover flag works now
* no changes in how CI works

That is finally fast:
```
./tools/test-runner.sh --skip-big-tests --skip-cover --verbose router:routing
```

How to test the change:
```
# that is fast
./tools/test-runner.sh --skip-big-tests --skip-cover --verbose router:routing

# that is two minutes long
./tools/test-runner.sh --skip-big-tests --verbose router:routing
```