### PR TITLE
MIM-1536 Return error 404 instead of 500 if GET command not found

### DIFF
--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -80,6 +80,7 @@ blank_auth_testcases() ->
 test_cases() ->
     [commands_are_listed,
      non_existent_command_returns404,
+     existent_command_with_missing_arguments_returns404,
      user_can_be_registered_and_removed,
      sessions_are_listed,
      session_can_be_kicked,
@@ -205,6 +206,9 @@ commands_are_listed(_C) ->
 
 non_existent_command_returns404(_C) ->
     {?NOT_FOUND, _} = gett(admin, <<"/isitthereornot">>).
+
+existent_command_with_missing_arguments_returns404(_C) ->
+    {?NOT_FOUND, _} = gett(admin, <<"/contacts/">>).
 
 user_can_be_registered_and_removed(_Config) ->
     % list users

--- a/src/mongoose_api_admin.erl
+++ b/src/mongoose_api_admin.erl
@@ -161,8 +161,12 @@ to_json(Req, #http_api_state{command_category = Category,
                              bindings = B} = State) ->
     Cmds = mongoose_commands:list(admin, Category, method_to_action(<<"GET">>), SubCategory),
     Arity = length(B),
-    [Command] = [C || C <- Cmds, mongoose_commands:arity(C) == Arity],
-    process_request(<<"GET">>, Command, Req, State).
+    case [C || C <- Cmds, mongoose_commands:arity(C) == Arity] of
+        [Command] ->
+            process_request(<<"GET">>, Command, Req, State);
+        [] ->
+            error_response(not_found, ?ARGS_LEN_ERROR, Req, State)
+    end.
 
 %% @doc Called for a method of type "POST" and "PUT"
 from_json(Req, #http_api_state{command_category = Category,


### PR DESCRIPTION
This PR addresses MIM-1536

Proposed changes include:
* This is already done for POST commands
* This is kinda different from `non_existent_command_returns404` testcase :) 


This command:
`curl -v "http://localhost:8088/api/contacts/"`

should return error 404, not 500.

This command is a valid working command fyi:
`curl -v "http://localhost:8088/api/contacts/alice@localhost"`

It's already done for POST commands.