### PR TITLE
Fix correctly detecting no origin-id

### DIFF
--- a/src/mam/mam_decoder.erl
+++ b/src/mam/mam_decoder.erl
@@ -10,10 +10,6 @@
 -type db_muc_row() :: {ext_mess_id(), Nick :: binary(), ExtData :: binary()}.
 -type db_muc_gdpr_row() :: {ext_mess_id(), ExtData :: binary()}.
 -type decoded_muc_gdpr_row() :: {ext_mess_id(), exml:element()}.
--type retraction_info() :: #{retract_on := origin_id | stanza_id,
-                             packet := exml:element(),
-                             message_id := mod_mam:message_id(),
-                             origin_id := null | binary()}.
 
 -spec decode_row(db_row(), env_vars()) -> mod_mam:message_row().
 decode_row({ExtMessID, ExtSrcJID, ExtData}, Env) ->
@@ -37,7 +33,7 @@ decode_muc_gdpr_row({ExtMessID, ExtData}, Env) ->
 -spec decode_retraction_info(env_vars(),
                              [{binary(), mod_mam:message_id(), binary()}],
                              mod_mam_utils:retraction_id()) ->
-    skip | retraction_info().
+    skip | mod_mam_utils:retraction_info().
 decode_retraction_info(_Env, [], _) -> skip;
 decode_retraction_info(Env, [{ResMessID, Data}], {origin_id, OriginID}) ->
     Packet = decode_packet(Data, Env),

--- a/src/mam/mam_decoder.erl
+++ b/src/mam/mam_decoder.erl
@@ -13,7 +13,7 @@
 -type retraction_info() :: #{retract_on := origin_id | stanza_id,
                              packet := exml:element(),
                              message_id := mod_mam:message_id(),
-                             origin_id := binary()}.
+                             origin_id := null | binary()}.
 
 -spec decode_row(db_row(), env_vars()) -> mod_mam:message_row().
 decode_row({ExtMessID, ExtSrcJID, ExtData}, Env) ->

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -427,10 +427,10 @@ retracted_element(#{retract_on := stanza_id,
                        MaybeOriginId
                       ]}.
 
-maybe_append_origin_id(#{origin_id := <<>>}) ->
-    [];
-maybe_append_origin_id(#{origin_id := OriginID}) ->
-    [#xmlel{name = <<"origin-id">>, attrs = [{<<"xmlns">>, ?NS_STANZAID}, {<<"id">>, OriginID}]}].
+maybe_append_origin_id(#{origin_id := OriginID}) when is_binary(OriginID), <<>> =/= OriginID ->
+    [#xmlel{name = <<"origin-id">>, attrs = [{<<"xmlns">>, ?NS_STANZAID}, {<<"id">>, OriginID}]}];
+maybe_append_origin_id(_) ->
+    [].
 
 %% @doc Forms `<forwarded/>' element, according to the XEP.
 -spec wrap_message(MamNs :: binary(), Packet :: exml:element(), QueryID :: binary(),


### PR DESCRIPTION
A lack of origin-id wasn't expressed using an empty binary, but rather a null. What we actually care is to drop the case when the origin-id is not there, not how its absence is expressed. My bug 😅 