### PR TITLE
MIM-1539 Allow global to be passed into mongoose_backend as an arg

### DIFF
--- a/src/ejabberd_gen_sm.erl
+++ b/src/ejabberd_gen_sm.erl
@@ -1,3 +1,6 @@
+%% Generic module to access SM backend modules
+%% Pass HostType to the functions as an argument, if you can
+%% Pass global, when you cannot
 -module(ejabberd_gen_sm).
 
 -callback start(list()) ->
@@ -32,78 +35,76 @@
          get_sessions/4, create_session/5, update_session/5, delete_session/5, cleanup/2,
          total_count/1, unique_count/1]).
 
--ignore_xref([behaviour_info/1, cleanup/2]).
+-ignore_xref([cleanup/2, behaviour_info/1]).
 
--spec start(module(), list()) -> any().
-start(Mod, Opts) ->
-    Mod:start(Opts).
+-define(MAIN_MODULE, ejabberd_sm).
+-type host_type() :: mongooseim:host_type() | global.
 
--spec get_sessions(module()) -> [ejabberd_sm:sessions()].
-get_sessions(Mod) ->
-    Mod:get_sessions().
+-spec start(host_type(), list()) -> any().
+start(_HostType, Opts) ->
+    Args = [Opts],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_sessions(module(), jid:server()) -> [ejabberd_sm:sessions()].
-get_sessions(Mod, Server) ->
-    Mod:get_sessions(Server).
+-spec get_sessions(host_type()) -> [ejabberd_sm:sessions()].
+get_sessions(_HostType) ->
+    Args = [],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_sessions(module(), jid:user(), jid:server()) ->
+-spec get_sessions(host_type(), jid:server()) -> [ejabberd_sm:sessions()].
+get_sessions(_HostType, Server) ->
+    Args = [Server],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec get_sessions(host_type(), jid:user(), jid:server()) ->
     [ejabberd_sm:session()].
-get_sessions(Mod, User, Server) ->
-    Mod:get_sessions(User, Server).
+get_sessions(_HostType, User, Server) ->
+    Args = [User, Server],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_sessions(module(),
+-spec get_sessions(host_type(),
                    jid:user(),
                    jid:server(),
                    jid:resource()) ->
     [ejabberd_sm:session()].
-get_sessions(Mod, User, Server, Resource) ->
-    Mod:get_sessions(User, Server, Resource).
+get_sessions(_HostType, User, Server, Resource) ->
+    Args = [User, Server, Resource],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec create_session(Mod :: module(), User :: jid:user(),
+-spec create_session(HostType :: host_type(), User :: jid:user(),
                      Server :: jid:server(),
                      Resource :: jid:resource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(Mod, User, Server, Resource, Session) ->
-    Mod:create_session(User, Server, Resource, Session).
+create_session(_HostType, User, Server, Resource, Session) ->
+    Args = [User, Server, Resource, Session],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec update_session(Mod :: module(), User :: jid:luser(),
+-spec update_session(HostType :: host_type(), User :: jid:luser(),
                      Server :: jid:lserver(),
                      Resource :: jid:lresource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-update_session(Mod, User, Server, Resource, Session) ->
-    Mod:update_session(User, Server, Resource, Session).
+update_session(_HostType, User, Server, Resource, Session) ->
+    Args = [User, Server, Resource, Session],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec delete_session(Mod :: module(), Sid :: ejabberd_sm:sid(),
+-spec delete_session(HostType :: host_type(), Sid :: ejabberd_sm:sid(),
                      User :: jid:user(),
                      Server :: jid:server(),
                      Resource :: jid:resource()) -> ok.
-delete_session(Mod, Sid, User, Server, Resource) ->
-    Mod:delete_session(Sid, User, Server, Resource).
+delete_session(_HostType, Sid, User, Server, Resource) ->
+    Args = [Sid, User, Server, Resource],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec cleanup(Mod :: module(), Node :: atom()) -> any().
-cleanup(Mod, Node) ->
-    Mod:cleanup(Node).
+-spec cleanup(HostType :: host_type(), Node :: atom()) -> any().
+cleanup(_HostType, Node) ->
+    Args = [Node],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec total_count(module()) -> integer().
-total_count(Mod) ->
-    Mod:total_count().
+-spec total_count(host_type()) -> integer().
+total_count(_HostType) ->
+    Args = [],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec unique_count(module()) -> integer().
-unique_count(Mod) ->
-    Mod:unique_count().
-
-%% -export([behaviour_info/1]).
-%% -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-%% behaviour_info(callbacks) ->
-%%     [{start, 1},
-%%      {get_sessions, 0},
-%%      {get_sessions, 1},
-%%      {get_sessions, 2},
-%%      {get_sessions, 3},
-%%      {create_session, 4},
-%%      {delete_session, 4},
-%%      {cleanup, 1},
-%%      {total_count, 0},
-%%      {unique_count, 0}];
-%% behaviour_info(_Other) ->
-%%     undefined.
+-spec unique_count(host_type()) -> integer().
+unique_count(_HostType) ->
+    Args = [],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -497,7 +497,7 @@ init([]) ->
                           undefined -> {mnesia, []};
                           Value -> Value
                       end,
-    mongoose_backend:init_per_host_type(global, ?MODULE, [], [{backend, Backend}]),
+    mongoose_backend:init(global, ?MODULE, [], [{backend, Backend}]),
 
     ets:new(sm_iqtable, [named_table, protected, {read_concurrency, true}]),
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -235,13 +235,13 @@ open_session(HostType, SID, JID, Priority, Info) ->
 close_session(Acc, SID, JID, Reason) ->
     HostType = mongoose_acc:host_type(Acc),
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
-    Info = case ejabberd_gen_sm:get_sessions(HostType, LUser, LServer, LResource) of
+    Info = case ejabberd_sm_backend:get_sessions(HostType, LUser, LServer, LResource) of
                [Session] ->
                    Session#session.info;
                _ ->
                    []
            end,
-    ejabberd_gen_sm:delete_session(HostType, SID, LUser, LServer, LResource),
+    ejabberd_sm_backend:delete_session(HostType, SID, LUser, LServer, LResource),
     mongoose_hooks:sm_remove_connection_hook(Acc, SID, JID, Info, Reason).
 
 -spec store_info(jid:jid(), info_key(), any()) ->
@@ -333,7 +333,7 @@ disconnect_removed_user(Acc, User, Server) ->
 -spec get_user_resources(JID :: jid:jid()) -> [binary()].
 get_user_resources(JID) ->
     #jid{luser = LUser, lserver = LServer} = JID,
-    Ss = ejabberd_gen_sm:get_sessions(global, LUser, LServer),
+    Ss = ejabberd_sm_backend:get_sessions(global, LUser, LServer),
     [element(3, S#session.usr) || S <- clean_session_list(Ss)].
 
 
@@ -353,7 +353,7 @@ get_session_ip(JID) ->
       JID :: jid:jid().
 get_session(JID) ->
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
-    case ejabberd_gen_sm:get_sessions(global, LUser, LServer, LResource) of
+    case ejabberd_sm_backend:get_sessions(global, LUser, LServer, LResource) of
         [] ->
             offline;
         Ss ->
@@ -363,7 +363,7 @@ get_session(JID) ->
 -spec get_raw_sessions(jid:jid()) -> [session()].
 get_raw_sessions(#jid{luser = LUser, lserver = LServer}) ->
     clean_session_list(
-      ejabberd_gen_sm:get_sessions(global, LUser, LServer)).
+      ejabberd_sm_backend:get_sessions(global, LUser, LServer)).
 
 -spec set_presence(Acc, SID, JID, Prio, Presence, Info) -> Acc1 when
       Acc :: mongoose_acc:t(),
@@ -413,7 +413,7 @@ get_session_pid(JID) ->
 -spec get_unique_sessions_number() -> integer().
 get_unique_sessions_number() ->
     try
-        C = ejabberd_gen_sm:unique_count(global),
+        C = ejabberd_sm_backend:unique_count(global),
         mongoose_metrics:update(global, ?UNIQUE_COUNT_CACHE, C),
         C
     catch
@@ -424,17 +424,17 @@ get_unique_sessions_number() ->
 
 -spec get_total_sessions_number() -> integer().
 get_total_sessions_number() ->
-    ejabberd_gen_sm:total_count(global).
+    ejabberd_sm_backend:total_count(global).
 
 
 -spec get_vh_session_number(jid:server()) -> non_neg_integer().
 get_vh_session_number(Server) ->
-    length(ejabberd_gen_sm:get_sessions(global, Server)).
+    length(ejabberd_sm_backend:get_sessions(global, Server)).
 
 
 -spec get_vh_session_list(jid:server()) -> [session()].
 get_vh_session_list(Server) ->
-    ejabberd_gen_sm:get_sessions(global, Server).
+    ejabberd_sm_backend:get_sessions(global, Server).
 
 
 -spec get_node_sessions_number() -> non_neg_integer().
@@ -446,7 +446,7 @@ get_node_sessions_number() ->
 
 -spec get_full_session_list() -> [session()].
 get_full_session_list() ->
-    ejabberd_gen_sm:get_sessions(global).
+    ejabberd_sm_backend:get_sessions(global).
 
 
 register_iq_handler(Host, XMLNS, IQHandler) ->
@@ -507,7 +507,7 @@ init([]) ->
 
     ejabberd_commands:register_commands(commands()),
 
-    ejabberd_gen_sm:start(global, Opts),
+    ejabberd_sm_backend:start(global, Opts),
 
     {ok, #state{}}.
 
@@ -529,7 +529,7 @@ hooks(HostType) ->
 %% Description: Handling call messages
 %%--------------------------------------------------------------------
 handle_call({node_cleanup, Node}, _From, State) ->
-    {TimeDiff, _R} = timer:tc(fun ejabberd_gen_sm:cleanup/2, [global, Node]),
+    {TimeDiff, _R} = timer:tc(fun ejabberd_sm_backend:cleanup/2, [global, Node]),
     ?LOG_INFO(#{what => sm_node_cleanup,
                 text => <<"Cleaning after a node that went down">>,
                 cleanup_node => Node,
@@ -624,7 +624,7 @@ set_session(SID, JID, Priority, Info) ->
                        us = US,
                        priority = Priority,
                        info = Info},
-    ejabberd_gen_sm:create_session(global, LUser, LServer, LResource, Session).
+    ejabberd_sm_backend:create_session(global, LUser, LServer, LResource, Session).
 
 -spec update_session(SID, JID, Prio, Info) -> ok | {error, any()} when
       SID :: sid() | 'undefined',
@@ -640,7 +640,7 @@ update_session(SID, JID, Priority, Info) ->
                        us = US,
                        priority = Priority,
                        info = Info},
-    ejabberd_gen_sm:update_session(global, LUser, LServer, LResource, Session).
+    ejabberd_sm_backend:update_session(global, LUser, LServer, LResource, Session).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -893,13 +893,13 @@ clean_session_list([S1, S2 | Rest], Res) ->
       LUser :: jid:luser(),
       LServer :: jid:lserver().
 get_user_present_pids(LUser, LServer) ->
-    Ss = ejabberd_gen_sm:get_sessions(global, LUser, LServer),
+    Ss = ejabberd_sm_backend:get_sessions(global, LUser, LServer),
     [{S#session.priority, element(2, S#session.sid)} ||
      S <- clean_session_list(Ss), is_integer(S#session.priority)].
 
 -spec get_user_present_resources(jid:jid()) -> [{priority(), binary()}].
 get_user_present_resources(#jid{luser = LUser, lserver = LServer}) ->
-    Ss = ejabberd_gen_sm:get_sessions(global, LUser, LServer),
+    Ss = ejabberd_sm_backend:get_sessions(global, LUser, LServer),
     [{S#session.priority, element(3, S#session.usr)} ||
         S <- clean_session_list(Ss), is_integer(S#session.priority)].
 
@@ -937,7 +937,7 @@ check_for_sessions_to_replace(HostType, JID) ->
       ReplacedSessionsPIDs :: ordsets:ordset(pid()).
 check_existing_resources(_HostType, LUser, LServer, LResource) ->
     %% A connection exist with the same resource. We replace it:
-    Sessions = ejabberd_gen_sm:get_sessions(global, LUser, LServer, LResource),
+    Sessions = ejabberd_sm_backend:get_sessions(global, LUser, LServer, LResource),
     case [S#session.sid || S <- Sessions] of
         [] -> [];
         SIDs ->
@@ -961,7 +961,7 @@ check_max_sessions(HostType, LUser, LServer, ReplacedPIDs) ->
                         false -> {true, SID}
                     end
                 end,
-                ejabberd_gen_sm:get_sessions(global, LUser, LServer)),
+                ejabberd_sm_backend:get_sessions(global, LUser, LServer)),
     MaxSessions = get_max_user_sessions(HostType, LUser, LServer),
     case length(SIDs) =< MaxSessions of
         true -> ordsets:to_list(ReplacedPIDs);
@@ -1018,7 +1018,7 @@ process_iq(_, From, To, Acc, Packet) ->
 
 -spec force_update_presence(mongooseim:host_type(), {jid:luser(), jid:lserver()}) -> 'ok'.
 force_update_presence(_HostType, {LUser, LServer}) ->
-    Ss = ejabberd_gen_sm:get_sessions(global, LUser, LServer),
+    Ss = ejabberd_sm_backend:get_sessions(global, LUser, LServer),
     lists:foreach(fun(#session{sid = {_, Pid}}) ->
                           Pid ! {force_update_presence, LUser}
                   end, Ss).

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -496,13 +496,12 @@ init([]) ->
                           undefined -> {mnesia, []};
                           Value -> Value
                       end,
-    mongoose_backend:init(global, ?MODULE, [], [{backend, Backend}]),
+    ejabberd_sm_backend:init([{backend, Backend}|Opts]),
     ets:new(sm_iqtable, [named_table, protected, {read_concurrency, true}]),
     ejabberd_hooks:add(node_cleanup, global, ?MODULE, node_cleanup, 50),
     lists:foreach(fun(HostType) -> ejabberd_hooks:add(hooks(HostType)) end,
                   ?ALL_HOST_TYPES),
     ejabberd_commands:register_commands(commands()),
-    ejabberd_sm_backend:start(Opts),
     {ok, #state{}}.
 
 hooks(HostType) ->

--- a/src/ejabberd_sm_backend.erl
+++ b/src/ejabberd_sm_backend.erl
@@ -1,6 +1,4 @@
 %% Generic module to access SM backend modules
-%% Pass HostType to the functions as an argument, if you can
-%% Pass global, when you cannot
 -module(ejabberd_sm_backend).
 
 -callback start(list()) ->
@@ -31,80 +29,76 @@
 -callback total_count() -> integer().
 -callback unique_count() -> integer().
 
--export([start/2, get_sessions/1, get_sessions/2, get_sessions/3,
-         get_sessions/4, create_session/5, update_session/5, delete_session/5, cleanup/2,
-         total_count/1, unique_count/1]).
+-export([start/1, 
+         get_sessions/0, get_sessions/1, get_sessions/2, get_sessions/3,
+         create_session/4, update_session/4, delete_session/4, cleanup/1,
+         total_count/0, unique_count/0]).
 
--ignore_xref([cleanup/2, behaviour_info/1]).
+-ignore_xref([cleanup/1, behaviour_info/1]).
 
 -define(MAIN_MODULE, ejabberd_sm).
--type host_type() :: mongooseim:host_type() | global.
 
--spec start(host_type(), list()) -> any().
-start(_HostType, Opts) ->
+-spec start(list()) -> any().
+start(Opts) ->
     Args = [Opts],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_sessions(host_type()) -> [ejabberd_sm:sessions()].
-get_sessions(_HostType) ->
-    Args = [],
-    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+-spec get_sessions() -> [ejabberd_sm:sessions()].
+get_sessions() ->
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, []).
 
--spec get_sessions(host_type(), jid:server()) -> [ejabberd_sm:sessions()].
-get_sessions(_HostType, Server) ->
+-spec get_sessions(jid:server()) -> [ejabberd_sm:sessions()].
+get_sessions(Server) ->
     Args = [Server],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_sessions(host_type(), jid:user(), jid:server()) ->
+-spec get_sessions(jid:user(), jid:server()) ->
     [ejabberd_sm:session()].
-get_sessions(_HostType, User, Server) ->
+get_sessions(User, Server) ->
     Args = [User, Server],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_sessions(host_type(),
-                   jid:user(),
+-spec get_sessions(jid:user(),
                    jid:server(),
                    jid:resource()) ->
     [ejabberd_sm:session()].
-get_sessions(_HostType, User, Server, Resource) ->
+get_sessions(User, Server, Resource) ->
     Args = [User, Server, Resource],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec create_session(HostType :: host_type(), User :: jid:user(),
+-spec create_session(User :: jid:user(),
                      Server :: jid:server(),
                      Resource :: jid:resource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(_HostType, User, Server, Resource, Session) ->
+create_session(User, Server, Resource, Session) ->
     Args = [User, Server, Resource, Session],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec update_session(HostType :: host_type(), User :: jid:luser(),
+-spec update_session(User :: jid:luser(),
                      Server :: jid:lserver(),
                      Resource :: jid:lresource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-update_session(_HostType, User, Server, Resource, Session) ->
+update_session(User, Server, Resource, Session) ->
     Args = [User, Server, Resource, Session],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec delete_session(HostType :: host_type(), Sid :: ejabberd_sm:sid(),
+-spec delete_session(Sid :: ejabberd_sm:sid(),
                      User :: jid:user(),
                      Server :: jid:server(),
                      Resource :: jid:resource()) -> ok.
-delete_session(_HostType, Sid, User, Server, Resource) ->
+delete_session(Sid, User, Server, Resource) ->
     Args = [Sid, User, Server, Resource],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec cleanup(HostType :: host_type(), Node :: atom()) -> any().
-cleanup(_HostType, Node) ->
+-spec cleanup(Node :: atom()) -> any().
+cleanup(Node) ->
     Args = [Node],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec total_count(host_type()) -> integer().
-total_count(_HostType) ->
-    Args = [],
-    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+-spec total_count() -> integer().
+total_count() ->
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, []).
 
--spec unique_count(host_type()) -> integer().
-unique_count(_HostType) ->
-    Args = [],
-    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+-spec unique_count() -> integer().
+unique_count() ->
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, []).

--- a/src/ejabberd_sm_backend.erl
+++ b/src/ejabberd_sm_backend.erl
@@ -1,7 +1,7 @@
 %% Generic module to access SM backend modules
 -module(ejabberd_sm_backend).
 
--callback start(list()) ->
+-callback init(list()) ->
     any().
 -callback get_sessions() ->
     [ejabberd_sm:session()].
@@ -29,7 +29,7 @@
 -callback total_count() -> integer().
 -callback unique_count() -> integer().
 
--export([start/1, 
+-export([init/1, 
          get_sessions/0, get_sessions/1, get_sessions/2, get_sessions/3,
          create_session/4, update_session/4, delete_session/4, cleanup/1,
          total_count/0, unique_count/0]).
@@ -38,9 +38,10 @@
 
 -define(MAIN_MODULE, ejabberd_sm).
 
--spec start(list()) -> any().
-start(Opts) ->
+-spec init(list()) -> any().
+init(Opts) ->
     Args = [Opts],
+    mongoose_backend:init(global, ?MAIN_MODULE, [], Opts),
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 -spec get_sessions() -> [ejabberd_sm:sessions()].

--- a/src/ejabberd_sm_backend.erl
+++ b/src/ejabberd_sm_backend.erl
@@ -1,7 +1,7 @@
 %% Generic module to access SM backend modules
 %% Pass HostType to the functions as an argument, if you can
 %% Pass global, when you cannot
--module(ejabberd_gen_sm).
+-module(ejabberd_sm_backend).
 
 -callback start(list()) ->
     any().

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -8,7 +8,7 @@
 %%%-------------------------------------------------------------------
 -module(ejabberd_sm_mnesia).
 
--behavior(ejabberd_gen_sm).
+-behavior(ejabberd_sm_backend).
 
 -include("mongoose.hrl").
 -include("session.hrl").

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -13,7 +13,7 @@
 -include("mongoose.hrl").
 -include("session.hrl").
 
--export([start/1,
+-export([init/1,
          get_sessions/0,
          get_sessions/1,
          get_sessions/2,
@@ -25,8 +25,8 @@
          total_count/0,
          unique_count/0]).
 
--spec start(list()) -> any().
-start(_Opts) ->
+-spec init(list()) -> any().
+init(_Opts) ->
     mnesia:create_table(session,
                         [{ram_copies, [node()]},
                          {attributes, record_info(fields, session)}]),

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -11,7 +11,7 @@
 -include("mongoose.hrl").
 -include("session.hrl").
 
--behavior(ejabberd_gen_sm).
+-behavior(ejabberd_sm_backend).
 -export([start/1,
          get_sessions/0,
          get_sessions/1,

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -12,7 +12,7 @@
 -include("session.hrl").
 
 -behavior(ejabberd_sm_backend).
--export([start/1,
+-export([init/1,
          get_sessions/0,
          get_sessions/1,
          get_sessions/2,
@@ -27,8 +27,8 @@
 
 -ignore_xref([maybe_initial_cleanup/2]).
 
--spec start(list()) -> any().
-start(_Opts) ->
+-spec init(list()) -> any().
+init(_Opts) ->
     %% Clean current node's sessions from previous life
     {Elapsed, RetVal} = timer:tc(?MODULE, maybe_initial_cleanup, [node(), true]),
     ?LOG_NOTICE(#{what => sm_cleanup_initial,

--- a/src/event_pusher/mod_event_pusher_push_backend.erl
+++ b/src/event_pusher/mod_event_pusher_push_backend.erl
@@ -40,7 +40,7 @@
 -spec init(Host :: jid:server(), Opts :: list()) -> ok.
 init(Host, Opts) ->
     TrackedFuns = [enable, disable, get_publish_services],
-    mongoose_backend:init_per_host_type(Host, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(Host, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [Host, Opts],
     mongoose_backend:call(Host, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/http_upload/mod_http_upload_backend.erl
+++ b/src/http_upload/mod_http_upload_backend.erl
@@ -16,7 +16,7 @@
 
 -spec init(HostType :: mongooseim:host_type(), Opts :: gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, [create_slot], Opts).
+    mongoose_backend:init(HostType, ?MAIN_MODULE, [create_slot], Opts).
 
 -spec create_slot(HostType::mongooseim:host_type(),
                   UTCDateTime :: calendar:datetime(),

--- a/src/inbox/mod_inbox_backend.erl
+++ b/src/inbox/mod_inbox_backend.erl
@@ -80,7 +80,7 @@
     HostType :: mongooseim:host_type(),
     Opts :: list().
 init(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, callback_funs(), Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, callback_funs(), Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mod_auth_token_backend.erl
+++ b/src/mod_auth_token_backend.erl
@@ -28,7 +28,7 @@
 
 -spec start(HostType :: mongooseim:host_type(), Opts :: gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, [], [{backend, rdbms} | Opts]),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, [], [{backend, rdbms} | Opts]),
     Args = [HostType],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mod_keystore_backend.erl
+++ b/src/mod_keystore_backend.erl
@@ -20,7 +20,7 @@
 
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, [], Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, [], Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mod_last_backend.erl
+++ b/src/mod_last_backend.erl
@@ -35,7 +35,7 @@
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
     TrackedFuns = [get_last, set_last_info],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mod_muc_backend.erl
+++ b/src/mod_muc_backend.erl
@@ -67,7 +67,7 @@
 init(HostType, Opts) ->
     TrackedFuns = [store_room, restore_room, forget_room, get_rooms,
                      can_use_nick, get_nick, set_nick, unset_nick],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mod_private_backend.erl
+++ b/src/mod_private_backend.erl
@@ -61,7 +61,7 @@
     Opts :: list().
 init(HostType, Opts) ->
     TrackedFuns = [multi_get_data, multi_set_data],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mod_roster_backend.erl
+++ b/src/mod_roster_backend.erl
@@ -61,7 +61,7 @@ init(HostType, Opts) ->
                    roster_subscribe_t,
                    update_roster_t,
                    del_roster_t],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/mongoose_backend.erl
+++ b/src/mongoose_backend.erl
@@ -20,7 +20,7 @@
 -type function_name() :: atom().
 -type main_module() :: module().
 -type backend_module() :: module().
--type host_type_or_global() :: host_type_or_global() | global.
+-type host_type_or_global() :: mongooseim:host_type_or_global().
 
 -spec init(HostType :: host_type_or_global(),
                          MainModule :: main_module(),

--- a/src/mongoose_backend.erl
+++ b/src/mongoose_backend.erl
@@ -1,7 +1,7 @@
 -module(mongoose_backend).
 
 %% API
--export([init_per_host_type/4,
+-export([init/4,
          call/4,
          call_tracked/4,
          is_exported/4,
@@ -22,11 +22,11 @@
 -type backend_module() :: module().
 -type host_type_or_global() :: host_type_or_global() | global.
 
--spec init_per_host_type(HostType :: host_type_or_global(),
+-spec init(HostType :: host_type_or_global(),
                          MainModule :: main_module(),
                          TrackedFuns :: [function_name()],
                          Opts :: gen_mod:module_opts()) -> ok.
-init_per_host_type(HostType, MainModule, TrackedFuns, Opts) ->
+init(HostType, MainModule, TrackedFuns, Opts) ->
     ensure_backend_metrics(MainModule, TrackedFuns),
     Backend = gen_mod:get_opt(backend, Opts, mnesia),
     BackendModule = backend_module(MainModule, Backend),
@@ -65,7 +65,7 @@ persist_backend_name(HostType, MainModule, Backend, BackendModule) ->
     NameKey = backend_name_key(HostType, MainModule),
     persistent_term:put(NameKey, Backend).
 
-%% @doc Get a backend module, stored in init_per_host_type.
+%% @doc Get a backend module, stored in init.
 -spec get_backend_module(HostType :: host_type_or_global(),
                          MainModule :: main_module()) ->
     BackendModule :: backend_module().
@@ -73,7 +73,7 @@ get_backend_module(HostType, MainModule) ->
     ModuleKey = backend_key(HostType, MainModule),
     persistent_term:get(ModuleKey).
 
-%% @doc Get a backend name, like `pgsql', stored in init_per_host_type.
+%% @doc Get a backend name, like `pgsql', stored in init.
 -spec get_backend_name(HostType :: host_type_or_global(),
                        MainModule :: main_module()) -> BackendName :: atom().
 get_backend_name(HostType, MainModule) ->

--- a/src/mongoose_backend.erl
+++ b/src/mongoose_backend.erl
@@ -20,8 +20,9 @@
 -type function_name() :: atom().
 -type main_module() :: module().
 -type backend_module() :: module().
+-type host_type_or_global() :: host_type_or_global() | global.
 
--spec init_per_host_type(HostType :: mongooseim:host_type(),
+-spec init_per_host_type(HostType :: host_type_or_global(),
                          MainModule :: main_module(),
                          TrackedFuns :: [function_name()],
                          Opts :: gen_mod:module_opts()) -> ok.
@@ -65,7 +66,7 @@ persist_backend_name(HostType, MainModule, Backend, BackendModule) ->
     persistent_term:put(NameKey, Backend).
 
 %% @doc Get a backend module, stored in init_per_host_type.
--spec get_backend_module(HostType :: mongooseim:host_type(),
+-spec get_backend_module(HostType :: host_type_or_global(),
                          MainModule :: main_module()) ->
     BackendModule :: backend_module().
 get_backend_module(HostType, MainModule) ->
@@ -73,13 +74,13 @@ get_backend_module(HostType, MainModule) ->
     persistent_term:get(ModuleKey).
 
 %% @doc Get a backend name, like `pgsql', stored in init_per_host_type.
--spec get_backend_name(HostType :: mongooseim:host_type(),
+-spec get_backend_name(HostType :: host_type_or_global(),
                        MainModule :: main_module()) -> BackendName :: atom().
 get_backend_name(HostType, MainModule) ->
     Key = backend_name_key(HostType, MainModule),
     persistent_term:get(Key).
 
--spec call(HostType :: mongooseim:host_type(),
+-spec call(HostType :: host_type_or_global(),
            MainModule :: main_module(),
            FunName :: function_name(),
            Args :: [term()]) -> term().
@@ -87,7 +88,7 @@ call(HostType, MainModule, FunName, Args) ->
     BackendModule = get_backend_module(HostType, MainModule),
     erlang:apply(BackendModule, FunName, Args).
 
--spec call_tracked(HostType :: mongooseim:host_type(),
+-spec call_tracked(HostType :: host_type_or_global(),
                    MainModule :: main_module(),
                    FunName :: function_name(),
                    Args :: [term()]) -> term().
@@ -100,7 +101,7 @@ call_tracked(HostType, MainModule, FunName, Args) ->
     mongoose_metrics:update(global, TM, Time),
     Result.
 
--spec is_exported(HostType :: mongooseim:host_type(),
+-spec is_exported(HostType :: host_type_or_global(),
                   MainModule :: main_module(),
                   FunName :: function_name(),
                   Arity :: integer()) -> boolean().

--- a/src/mongoose_backend.erl
+++ b/src/mongoose_backend.erl
@@ -23,9 +23,9 @@
 -type host_type_or_global() :: mongooseim:host_type_or_global().
 
 -spec init(HostType :: host_type_or_global(),
-                         MainModule :: main_module(),
-                         TrackedFuns :: [function_name()],
-                         Opts :: gen_mod:module_opts()) -> ok.
+           MainModule :: main_module(),
+           TrackedFuns :: [function_name()],
+           Opts :: gen_mod:module_opts()) -> ok.
 init(HostType, MainModule, TrackedFuns, Opts) ->
     ensure_backend_metrics(MainModule, TrackedFuns),
     Backend = gen_mod:get_opt(backend, Opts, mnesia),

--- a/src/mongooseim.erl
+++ b/src/mongooseim.erl
@@ -16,8 +16,9 @@
 -module(mongooseim).
 
 -type host_type() :: binary().
+-type host_type_or_global() :: host_type() | global.
 -type domain_name() :: jid:lserver().
--export_type([host_type/0, domain_name/0]).
+-export_type([host_type/0, host_type_or_global/0, domain_name/0]).
 
 %% API
 -export([start/0]).

--- a/src/muc_light/mod_muc_light_codec_backend.erl
+++ b/src/muc_light/mod_muc_light_codec_backend.erl
@@ -61,7 +61,7 @@
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, [], Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, [], Opts),
     ok.
 
 -spec stop(mongooseim:host_type()) -> ok.

--- a/src/muc_light/mod_muc_light_db_backend.erl
+++ b/src/muc_light/mod_muc_light_db_backend.erl
@@ -150,7 +150,7 @@ start(HostType, Opts) ->
                    get_config, set_config,
                    get_blocking, set_blocking,
                    get_aff_users, modify_aff_users],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/offline/mod_offline_backend.erl
+++ b/src/offline/mod_offline_backend.erl
@@ -42,7 +42,7 @@
 
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, [pop_messages, write_messages], Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, [pop_messages, write_messages], Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/offline/mod_offline_chatmarkers_backend.erl
+++ b/src/offline/mod_offline_chatmarkers_backend.erl
@@ -24,7 +24,7 @@
 
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, [get, maybe_store], Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, [get, maybe_store], Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/privacy/mod_privacy_backend.erl
+++ b/src/privacy/mod_privacy_backend.erl
@@ -97,7 +97,7 @@
 init(HostType, Opts) ->
     TrackedFuns = [get_privacy_list, get_list_names, set_default_list, forget_default_list,
                    remove_privacy_list, replace_privacy_list, get_default_list],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/pubsub/mod_pubsub_cache_backend.erl
+++ b/src/pubsub/mod_pubsub_cache_backend.erl
@@ -36,7 +36,7 @@
 -spec start(jid:lserver(), gen_mod:module_opts()) -> ok.
 start(ServerHost, Opts) ->
     TrackedFuns = [upsert_last_item, delete_last_item, get_last_item],
-    mongoose_backend:init_per_host_type(ServerHost, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(ServerHost, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [ServerHost],
     mongoose_backend:call(ServerHost, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/smart_markers/mod_smart_markers_backend.erl
+++ b/src/smart_markers/mod_smart_markers_backend.erl
@@ -30,7 +30,7 @@
 init(HostType, Opts) ->
     FOpts = add_default_backend(Opts),
     TrackedFuns = [get_chat_markers, update_chat_marker],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, FOpts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, FOpts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/vcard/mod_vcard_backend.erl
+++ b/src/vcard/mod_vcard_backend.erl
@@ -71,7 +71,7 @@
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
     TrackedFuns = [set_vcard, get_vcard, search],
-    mongoose_backend:init_per_host_type(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -48,7 +48,7 @@
 
 %% Config scope
 -type scope() :: global | host | mongooseim:host_type().
--type host_type_or_global() :: mongooseim:host_type() | global.
+-type host_type_or_global() :: mongooseim:host_type_or_global().
 
 -type tag() :: atom().
 %% Name of a process
@@ -86,7 +86,6 @@
 -export_type([proc_name/0]).
 -export_type([pool_opts/0]).
 -export_type([conn_opts/0]).
--export_type([host_type_or_global/0]).
 
 -type callback_fun() :: init | start | default_opts | is_supported_strategy | stop.
 

--- a/src/wpool/mongoose_wpool_http.erl
+++ b/src/wpool/mongoose_wpool_http.erl
@@ -51,7 +51,7 @@ stop(HostType, Tag) ->
 
 %% --------------------------------------------------------------
 %% Other API functions
--spec get_params(HostType :: mongoose_wpool:host_type_or_global(),
+-spec get_params(HostType :: mongooseim:host_type_or_global(),
                  Tag :: mongoose_wpool:tag()) ->
     {ok, PathPrefix :: path_prefix(), RequestTimeout :: request_timeout()}
     | {error, pool_not_started}.


### PR DESCRIPTION
This PR addresses MIM-1539

Proposed changes include:
* Removed behaviour_info, idk why it is commented out.
* Renamed init_per_host_type (so many files to change).