### PR TITLE
Add mongoose_rdbms_backend

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,6 @@
 {xref_ignores, [
     eldap_filter_yecc, 'XmppAddr', mongoose_xmpp_errors,
     %% *_backend
-    mongoose_rdbms_backend,
     mod_bosh_backend,
     mod_global_distrib_mapping_backend,
     mod_mam_cassandra_arch_params,

--- a/src/mam/mod_mam_rdbms_prefs.erl
+++ b/src/mam/mod_mam_rdbms_prefs.erl
@@ -21,12 +21,7 @@
 
 -ignore_xref([remove_archive/4, start/2, stop/1, supported_features/0]).
 
--import(mongoose_rdbms,
-        [prepare/4,
-         escape_string/1,
-         escape_integer/1,
-         use_escaped_string/1,
-         use_escaped_integer/1]).
+-import(mongoose_rdbms, [prepare/4]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").

--- a/src/rdbms/mongoose_rdbms_backend.erl
+++ b/src/rdbms/mongoose_rdbms_backend.erl
@@ -1,0 +1,82 @@
+%%%-------------------------------------------------------------------
+%%% @copyright 2021, Erlang Solutions Ltd.
+%%% @doc Proxy module for rdbms backends.
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+-module(mongoose_rdbms_backend).
+-export([escape_binary/1,
+         escape_string/1,
+         unescape_binary/1,
+         connect/2,
+         disconnect/1,
+         query/3,
+         prepare/5,
+         execute/4]).
+
+-define(MAIN_MODULE, mongoose_rdbms).
+
+
+-callback escape_binary(binary()) -> mongoose_rdbms:sql_query_part().
+-callback escape_string(binary()|list()) -> mongoose_rdbms:sql_query_part().
+
+-callback unescape_binary(binary()) -> binary().
+-callback connect(Args :: any(), QueryTimeout :: non_neg_integer()) ->
+    {ok, Connection :: term()} | {error, Reason :: any()}.
+-callback disconnect(Connection :: term()) -> any().
+-callback query(Connection :: term(), Query :: any(), Timeout :: infinity | non_neg_integer()) ->
+    mongoose_rdbms:query_result().
+-callback prepare(Connection :: term(), Name :: atom(),
+                  Table :: binary(), Fields :: [binary()], Statement :: iodata()) ->
+                     {ok, Ref :: term()} | {error, Reason :: any()}.
+-callback execute(Connection :: term(), Ref :: term(), Parameters :: [term()],
+                  Timeout :: infinity | non_neg_integer()) -> mongoose_rdbms:query_result().
+
+%% If not defined, generic escaping is used
+-optional_callbacks([escape_string/1]).
+
+
+-spec escape_binary(binary()) -> mongoose_rdbms:sql_query_part().
+escape_binary(Binary) ->
+    Args = [Binary],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec escape_string(binary() | list()) -> mongoose_rdbms:sql_query_part().
+escape_string(String) ->
+    Args = [String],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec unescape_binary(binary()) -> binary().
+unescape_binary(Binary) ->
+    Args = [Binary],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec connect(Settings :: any(), QueryTimeout :: non_neg_integer()) ->
+    {ok, Connection :: term()} | {error, Reason :: any()}.
+connect(Settings, QueryTimeout) ->
+    Args = [Settings, QueryTimeout],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec disconnect(Connection :: term()) -> any().
+disconnect(Connection) ->
+    Args = [Connection],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec query(Connection :: term(), Query :: any(), Timeout :: infinity | non_neg_integer()) ->
+    mongoose_rdbms:query_result().
+query(Connection, Query, Timeout) ->
+    Args = [Connection, Query, Timeout],
+    mongoose_backend:call_tracked(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec prepare(Connection :: term(), Name :: atom(),
+              Table :: binary(), Fields :: [binary()], Statement :: iodata()) ->
+                 {ok, Ref :: term()} | {error, Reason :: any()}.
+prepare(Connection, Name, Table, Fields, Statement) ->
+    Args = [Connection, Name, Table, Fields, Statement],
+    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec execute(Connection :: term(), Ref :: term(), Parameters :: [term()],
+              Timeout :: infinity | non_neg_integer()) -> mongoose_rdbms:query_result().
+execute(Connection, Ref, Parameters, Timeout) ->
+    Args = [Connection, Ref, Parameters, Timeout],
+    mongoose_backend:call_tracked(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/rdbms/mongoose_rdbms_mysql.erl
+++ b/src/rdbms/mongoose_rdbms_mysql.erl
@@ -16,7 +16,7 @@
 
 -module(mongoose_rdbms_mysql).
 -author('konrad.zemek@erlang-solutions.com').
--behaviour(mongoose_rdbms).
+-behaviour(mongoose_rdbms_backend).
 
 -include("mongoose.hrl").
 

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -16,7 +16,7 @@
 
 -module(mongoose_rdbms_odbc).
 -author('konrad.zemek@erlang-solutions.com').
--behaviour(mongoose_rdbms).
+-behaviour(mongoose_rdbms_backend).
 -include("mongoose_logger.hrl").
 
 -export([escape_binary/1, escape_string/1,

--- a/src/rdbms/mongoose_rdbms_pgsql.erl
+++ b/src/rdbms/mongoose_rdbms_pgsql.erl
@@ -16,7 +16,7 @@
 
 -module(mongoose_rdbms_pgsql).
 -author('konrad.zemek@erlang-solutions.com').
--behaviour(mongoose_rdbms).
+-behaviour(mongoose_rdbms_backend).
 
 -include_lib("epgsql/include/epgsql.hrl").
 

--- a/test/mongoose_rdbms_SUITE.erl
+++ b/test/mongoose_rdbms_SUITE.erl
@@ -39,28 +39,30 @@ tests() ->
 init_per_group(odbc, Config) ->
     case code:ensure_loaded(eodbc) of
         {module, eodbc} ->
+            mongoose_backend:init(global, mongoose_rdbms, [], [{backend, odbc}]),
             [{db_type, odbc} | Config];
         _ ->
             {skip, no_odbc_application}
     end;
 init_per_group(Group, Config) ->
+    mongoose_backend:init(global, mongoose_rdbms, [], [{backend, Group}]),
     [{db_type, Group} | Config].
 
 end_per_group(_, Config) ->
+    % clean up after mongoose_backend:init
+    persistent_term:erase({backend_module, global, mongoose_rdbms}),
     Config.
 
 init_per_testcase(does_backoff_increase_to_a_point, Config) ->
     DbType = ?config(db_type, Config),
-    backend_module:create(mongoose_rdbms, DbType, []),
-    meck_config(DbType),
+    meck_config(),
     meck_db(DbType),
     meck_connection_error(DbType),
     meck_rand(),
     [{db_opts, [{server, server(DbType)}, {keepalive_interval, 2}, {start_interval, 10}]} | Config];
 init_per_testcase(_, Config) ->
     DbType = ?config(db_type, Config),
-    backend_module:create(mongoose_rdbms, DbType, []),
-    meck_config(DbType),
+    meck_config(),
     meck_db(DbType),
     [{db_opts, [{server, server(DbType)}, {keepalive_interval, ?KEEPALIVE_INTERVAL},
                 {start_interval, ?MAX_INTERVAL}]} | Config].
@@ -95,11 +97,11 @@ keepalive_exit(Config) ->
         ct:fail(no_down_message)
     end.
 
-%% 5 retries. Max retry 10. Iniitial retry 2.
+%% 5 retries. Max retry 10. Initial retry 2.
 %% We should get a sequence: 2 -> 4 -> 10 -> 10 -> 10.
 does_backoff_increase_to_a_point(Config) ->
     {error, _} = gen_server:start(mongoose_rdbms, ?config(db_opts, Config), []),
-    % We expect to have 2 at the begininng, then values up to 10 and 10 three times in total
+    % We expect to have 2 at the beginning, then values up to 10 and 10 three times in total
     receive_backoffs(2, 10, 3).
 
 receive_backoffs(InitialValue, MaxValue, MaxCount) ->
@@ -128,7 +130,7 @@ meck_rand() ->
 meck_unload_rand() ->
     meck:unload(rand).
 
-meck_config(Server) ->
+meck_config() ->
     meck:new(ejabberd_config, [no_link]),
     meck:expect(ejabberd_config, get_local_option,
                 fun(max_fsm_queue) -> 1024;


### PR DESCRIPTION
With the changes done in #3386, this turned out to be really easy. Before that, I tried to make `mongoose_rdbms_backend` expose its API with `HostType`s, but it was a bit messy. I think it's better to do it in a separate PR (after the whole `without-dynamic-backend-modules` branch is merged), to keep this already big diff smaller and more focused.
Other issue is that `mongoose_rdbms` has many functions exported, which seem to be not used, mainly for escaping different types. This could be revisited, but, in similar fashion, I left this as is for now.
What's left to do is remove dynamic `mongoose_rdbms_type`, but it will be done in a separate PR.

