### PR TITLE
MIM-1535 Extend /commands endpoint with more information

### DIFF
--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -202,13 +202,13 @@ auth_always_passes_blank_creds(_Config) ->
 commands_are_listed(_C) ->
     {?OK, Lcmds} = gett(admin, <<"/commands">>),
     DecCmds = decode_maplist(Lcmds),
-    ListCmd = #{action => <<"read">>, args => #{},
+    ListCmd = #{action => <<"read">>, method => <<"GET">>, args => #{},
                 category => <<"commands">>,
                 desc => <<"List commands">>,
                 name => <<"list_methods">>,
                 path => <<"/commands">>},
     %% Check that path and args are listed using a command with args
-    RosterCmd = #{action => <<"read">>,
+    RosterCmd = #{action => <<"read">>, method => <<"GET">>,
                   args => #{caller => <<"binary">>},
                   category => <<"contacts">>,
                   desc => <<"Get roster">>,

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -209,7 +209,7 @@ commands_are_listed(_C) ->
                 path => <<"/commands">>},
     %% Check that path and args are listed using a command with args
     RosterCmd = #{action => <<"read">>, method => <<"GET">>,
-                  args => #{caller => <<"binary">>},
+                  args => #{caller => <<"string">>},
                   category => <<"contacts">>,
                   desc => <<"Get roster">>,
                   name => <<"list_contacts">>,

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -68,7 +68,7 @@ assert_inlist(Pattern, L) ->
         [] ->
             ct:fail(io_lib:format("Fail: ~p not in [~p...]", [Pattern, H]));
         _ ->
-            ok
+            Fl
     end.
 
 assert_notinlist(Pattern, L) when is_map(Pattern) ->
@@ -87,7 +87,7 @@ assert_inmaplist([], Map, L, [H|_]) ->
         [] ->
             ct:fail(io_lib:format("Fail: ~p not in [~p...]", [Map, H]));
         _ ->
-            ok
+            L
     end;
 assert_inmaplist([K|Keys], Map, L, Orig) ->
     V = maps:get(K, Map),
@@ -316,9 +316,9 @@ is_roles_config(_, _) -> false.
 
 mapfromlist(L) ->
     Nl = lists:map(fun({K, {V}}) when is_list(V) ->
-                           {binary_to_existing_atom(K, utf8), mapfromlist(V)};
+                           {binary_to_atom(K, utf8), mapfromlist(V)};
                       ({K, V}) ->
-                           {binary_to_existing_atom(K, utf8), V}
+                           {binary_to_atom(K, utf8), V}
                    end, L),
     maps:from_list(Nl).
 

--- a/doc/rest-api/Administration-backend.md
+++ b/doc/rest-api/Administration-backend.md
@@ -30,7 +30,7 @@ section of the [listeners](../configuration/listen.md) documentation.
 To get a list of commands, you can use `/api/commands` endpoint.
 Use `jq` utility for pretty-printing JSON.
 
-Each command have the fields:
+Each command has the fields:
 
 - `path` - URL path for this command
 - `method` - HTTP method to use for this command

--- a/doc/rest-api/Administration-backend.md
+++ b/doc/rest-api/Administration-backend.md
@@ -25,6 +25,57 @@ You also have to hook the `mongoose_api_admin` module to an HTTP endpoint as des
 in the [admin REST API handlers configuration](../configuration/listen.md#handler-types-rest-api-admin-mongoose_api_admin)
 section of the [listeners](../configuration/listen.md) documentation.
 
+## Listing commands
+
+To get a list of commands, you can use `/api/commands` endpoint.
+Use `jq` utility for pretty-printing JSON.
+
+Each command have the fields:
+
+- `path` - URL path for this command
+- `method` - HTTP method to use for this command
+- `args` - arguments to provide inside a path or as POST arguments
+- `category` - a name used for grouping similar commands
+- `name` - a command name
+- `desc` - description text
+- `action` - a type of a command, similar to `method`
+
+`path`, `method` and `args` are useful to figuring out how the request should
+look like (you can use Swagger instead).
+
+`name`, `desc` and `category` are used just as metadata (they are not part of
+any request).
+
+`action` is used internally.
+
+```json
+curl -v "http://localhost:8088/api/commands" | jq
+[
+  {
+    "path": "/commands",
+    "name": "list_methods",
+    "method": "GET",
+    "desc": "List commands",
+    "category": "commands",
+    "args": {},
+    "action": "read"
+  },
+  {
+    "path": "/contacts",
+    "name": "add_contact",
+    "method": "POST",
+    "desc": "Add a contact to roster",
+    "category": "contacts",
+    "args": {
+      "jid": "binary",
+      "caller": "binary"
+    },
+    "action": "create"
+  },
+...
+```
+
+
 ## OpenAPI specifications
 
 Read the beautiful [Swagger documentation](https://esl.github.io/MongooseDocs/latest/swagger/index.html) for more information.

--- a/doc/rest-api/Administration-backend.md
+++ b/doc/rest-api/Administration-backend.md
@@ -38,7 +38,7 @@ Each command has the fields:
 - `category` - a name used for grouping similar commands
 - `name` - a command name
 - `desc` - description text
-- `action` - a type of a command, similar to `method`
+- `action` - a type of a command, corresponding to `method`
 
 `path`, `method` and `args` are useful to figuring out how the request should
 look like (you can use Swagger instead).

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -44,7 +44,7 @@
 
 -include("mongoose.hrl").
 -type options()  :: [any()].
--type path() :: iodata().
+-type path() :: binary().
 -type paths() :: [path()].
 -type route() :: {path() | paths(), module(), options()}.
 -type implemented_result() :: [route()].

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -410,9 +410,17 @@ registered_commands() ->
     [#{name => mongoose_commands:name(C),
        category => mongoose_commands:category(C),
        action => mongoose_commands:action(C),
-       desc => mongoose_commands:desc(C)
+       desc => mongoose_commands:desc(C),
+       args => format_args(mongoose_commands:args(C)),
+       path => mongoose_api_common:create_admin_url_path(C)
       } || C <- mongoose_commands:list(admin)].
 
+format_args(Args) ->
+    maps:from_list([{term_as_binary(Name), term_as_binary(Type)}
+                    || {Name, Type} <- Args]).
+
+term_as_binary(X) ->
+    iolist_to_binary(io_lib:format("~p", [X])).
 
 get_recent_messages(Caller, Before, Limit) ->
     get_recent_messages(Caller, undefined, Before, Limit).

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -429,8 +429,12 @@ collect_commands() ->
       } || C <- mongoose_commands:list(admin)].
 
 format_args(Args) ->
-    maps:from_list([{term_as_binary(Name), term_as_binary(Type)}
+    maps:from_list([{term_as_binary(Name), term_as_binary(rewrite_type(Type))}
                     || {Name, Type} <- Args]).
+
+%% binary is useful internally, but could confuse a regular user
+rewrite_type(binary) -> string;
+rewrite_type(Type) -> Type.
 
 term_as_binary(X) ->
     iolist_to_binary(io_lib:format("~p", [X])).

--- a/src/mod_commands.erl
+++ b/src/mod_commands.erl
@@ -355,7 +355,7 @@ list_contacts(Caller) ->
     Acc1 = mongoose_acc:set(roster, show_full_roster, true, Acc0),
     Acc2 = mongoose_hooks:roster_get(Acc1, CallerJID),
     Res = mongoose_acc:get(roster, items, Acc2),
-   [roster_info(mod_roster:item_to_map(I)) || I <- Res].
+    [roster_info(mod_roster:item_to_map(I)) || I <- Res].
 
 roster_info(M) ->
     Jid = jid:to_binary(maps:get(jid, M)),

--- a/src/mongoose_api_common.erl
+++ b/src/mongoose_api_common.erl
@@ -95,11 +95,17 @@ reload_dispatches(_Command) ->
 
 -spec create_admin_url_path(mongoose_commands:t()) -> ejabberd_cowboy:path().
 create_admin_url_path(Command) ->
+    iolist_to_binary(create_admin_url_path_iodata(Command)).
+
+create_admin_url_path_iodata(Command) ->
     ["/", mongoose_commands:category(Command),
           maybe_add_bindings(Command, admin), maybe_add_subcategory(Command)].
 
 -spec create_user_url_path(mongoose_commands:t()) -> ejabberd_cowboy:path().
 create_user_url_path(Command) ->
+    iolist_to_binary(create_user_url_path_iodata(Command)).
+
+create_user_url_path_iodata(Command) ->
     ["/", mongoose_commands:category(Command), maybe_add_bindings(Command, user)].
 
 -spec process_request(Method :: method(),

--- a/test/mongoose_api_common_SUITE.erl
+++ b/test/mongoose_api_common_SUITE.erl
@@ -17,17 +17,17 @@ all() ->
 url_is_correct_for_create_command(_) ->
     Cmd = create_cmd(),
     Url = mongoose_api_common:create_admin_url_path(Cmd),
-    ?aq(["/",<<"users">>,["/:host"], []], Url).
+    ?aq(<<"/users/:host">>, Url).
 
 url_is_correct_for_read_command(_) ->
     Cmd = read_cmd(),
     Url = mongoose_api_common:create_admin_url_path(Cmd),
-    ?aq(["/",<<"users">>,["/:host"],[]], Url).
+    ?aq(<<"/users/:host">>, Url).
 
 url_is_correct_for_read_command_with_subcategory(_) ->
     Cmd = read_cmd2(),
     Url = mongoose_api_common:create_admin_url_path(Cmd),
-    ?aq(["/",<<"users">>,["/:host"],["/", <<"rosters">>]], Url).
+    ?aq(<<"/users/:host/rosters">>, Url).
 
 create_cmd() ->
     Props = [


### PR DESCRIPTION
This PR addresses MIM-1535

Proposed changes include:
* New fields `path`, `method`, `args`
* Sort commands by path
* Add a test
* Replace ct:pal with ct:log to reduce noise to the shell