### PR TITLE
Identify only stored users on offline routing

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -846,7 +846,8 @@ route_message_by_type(<<"headline">>, From, To, Acc, Packet) ->
     {stop, Acc1} = bounce_offline_message(Acc, From, To, Packet),
     Acc1;
 route_message_by_type(_, From, To, Acc, Packet) ->
-    case ejabberd_auth:does_user_exist(To) of
+    HostType = mongoose_acc:host_type(Acc),
+    case ejabberd_auth:does_user_exist(HostType, To, stored) of
         true ->
             case is_privacy_allow(From, To, Acc, Packet) of
                 true ->


### PR DESCRIPTION
When we arrive at this point, it is because the user we're sending a
message to has not been found to be online, so here the routing mech
needs to verify if the user actually exists, to know if it should go
the 'offline_message_hook' or the 'service_unavailable' way. But, it
would actually be incorrect to verify for anonymous users at this point:
first, we have already verified that the receiver is not online, and
anonymous accounts are ephemeral, they only exist as long as the user is
online, so checking for anonymous accounts is unnecessary and redundant.
To make things worse, there's then a race condition here, where the
anonymous account that wasn't connected before, is connected by the time
we check again, and then this code takes the wrong path!

This fix not only curates all that Anonymous mess, but also gives a
chance to use the users cache at this point more opportunistically.