### PR TITLE
Do not use gen_mod:set_module_opt(s) in big tests

### DIFF
--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -121,9 +121,6 @@ end_per_testcase(muc_removal, Config) ->
     mongoose_helper:ensure_muc_clean(),
     muc_helper:unload_muc(),
     escalus:end_per_testcase(muc_removal, Config);
-end_per_testcase(roster_removal, Config) ->
-    roster_helper:restore_versioning(Config),
-    escalus:end_per_testcase(roster_removal, Config);
 end_per_testcase(TestCase, Config) ->
     escalus:end_per_testcase(TestCase, Config).
 

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -76,9 +76,15 @@ end_per_suite(Config) ->
     escalus_fresh:clean(),
     escalus:end_per_suite(Config).
 
+init_per_group(roster_versioning, Config) ->
+    Config0 = dynamic_modules:save_modules(host_type(), Config),
+    escalus:create_users(Config0, escalus:get_users([alice, bob]));
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
+end_per_group(roster_versioning, Config) ->
+    dynamic_modules:restore_modules(Config),
+    escalus:delete_users(Config, escalus:get_users([alice, bob]));
 end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
@@ -103,7 +109,6 @@ end_per_testcase(unsubscribe, Config) ->
     end_rosters_remove(Config);
 end_per_testcase(VersionCases, Config)
       when VersionCases =:= versioning; VersionCases =:= versioning_no_store ->
-    restore_versioning(Config),
     end_rosters_remove(Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).

--- a/big_tests/tests/roster_helper.erl
+++ b/big_tests/tests/roster_helper.erl
@@ -1,23 +1,12 @@
 -module(roster_helper).
--export([set_versioning/3, restore_versioning/1]).
+-export([set_versioning/3]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 -import(domain_helper, [host_type/0]).
 
 -spec set_versioning(boolean(), boolean(), escalus_config:config()) -> escalus_config:config(). 
 set_versioning(Versioning, VersionStore, Config) ->
-    RosterVersioning = rpc(mim(), gen_mod, get_module_opt,
-                           [host_type(), mod_roster, versioning, false]),
-    RosterVersionOnDb = rpc(mim(), gen_mod, get_module_opt,
-                            [host_type(), mod_roster, store_current_id, false]),
-    rpc(mim(), gen_mod, set_module_opt, [host_type(), mod_roster, versioning, Versioning]),
-    rpc(mim(), gen_mod, set_module_opt, [host_type(), mod_roster, store_current_id, VersionStore]),
-    [{versioning, RosterVersioning},
-     {store_current_id, RosterVersionOnDb} | Config].
-
--spec restore_versioning(escalus_config:config()) -> escalus_config:config().
-restore_versioning(Config) ->
-    RosterVersioning = proplists:get_value(versioning, Config),
-    RosterVersionOnDb = proplists:get_value(store_current_id, Config),
-    rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, versioning, RosterVersioning]),
-    rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_roster, store_current_id, RosterVersionOnDb]).
+    Opts = dynamic_modules:get_saved_config(host_type(), mod_roster, Config),
+    dynamic_modules:ensure_modules(host_type(), [{mod_roster, [{versioning, Versioning},
+                                                               {store_current_id, VersionStore} | Opts]}]),
+    Config.


### PR DESCRIPTION
This PR addresses [MIM-1547](https://erlangsolutions.atlassian.net/browse/MIM-1547) and removes usage of gen_mod:set_module_opt(s) in modules:
- mam_SUITE
- roster_helper(presence_SUITE and domain_removal_SUITE)

