### PR TITLE
Fix repository not signed error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ commands:
         command: |
           sudo killall -9 apt-get || true && \
           echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4 && \
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D208507CA14F4FCA && \
           wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
           sudo dpkg -i erlang-solutions_2.0_all.deb && \
           sudo apt-get update && \


### PR DESCRIPTION
The repository 'http://binaries.erlang-solutions.com/debian focal Release' is not signed.
W: GPG error: http://binaries.erlang-solutions.com/debian focal Release:
The following signatures were invalid:
BADSIG D208507CA14F4FCA Erlang Solutions Ltd. <packages@erlang-solutions.com>

This PR addresses https://app.circleci.com/pipelines/github/esl/MongooseIM/6226/workflows/eb25b19e-5980-43c4-9960-d436b997b0c8/jobs/86416


Changes:
- some googling to find a solution
- I have no idea why it stopped working 


NAH, otp24 job passes but presets jobs are failing there instead. 