### PR TITLE
Add a newline after module options to improve config readability

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -255,12 +255,12 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.server_name_indication = false"},
       {service_domain_db, ""},
-      {mod_last, "  backend = \"rdbms\""},
-      {mod_privacy, "  backend = \"rdbms\""},
-      {mod_private, "  backend = \"rdbms\""},
+      {mod_last, "  backend = \"rdbms\"\n"},
+      {mod_privacy, "  backend = \"rdbms\"\n"},
+      {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
-  host = \"vjud.@HOST@\""},
+  host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
     {odbc_mssql_mnesia,
      [{dbs, [redis, mssql]},
@@ -275,12 +275,12 @@
   connection.driver = \"odbc\"
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
       {service_domain_db, ""},
-      {mod_last, "  backend = \"rdbms\""},
-      {mod_privacy, "  backend = \"rdbms\""},
-      {mod_private, "  backend = \"rdbms\""},
+      {mod_last, "  backend = \"rdbms\"\n"},
+      {mod_privacy, "  backend = \"rdbms\"\n"},
+      {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
-  host = \"vjud.@HOST@\""},
+  host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
     {mysql_redis,
      [{dbs, [redis, mysql, rmq]},
@@ -305,12 +305,12 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.versions = [\"tlsv1.2\"]"},
       {service_domain_db, ""},
-      {mod_last, "  backend = \"rdbms\""},
-      {mod_privacy, "  backend = \"rdbms\""},
-      {mod_private, "  backend = \"rdbms\""},
+      {mod_last, "  backend = \"rdbms\"\n"},
+      {mod_privacy, "  backend = \"rdbms\"\n"},
+      {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
-  host = \"vjud.@HOST@\""},
+  host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
     {ldap_mnesia,
      [{dbs, [redis, ldap]},
@@ -346,7 +346,7 @@
       {mod_vcard, "  backend = \"ldap\"
   host = \"vjud.@HOST@\"
   ldap_base = \"ou=Users,dc=esl,dc=com\"
-  ldap_filter = \"(objectClass=inetOrgPerson)\""}]},
+  ldap_filter = \"(objectClass=inetOrgPerson)\"\n"}]},
     {riak_mnesia,
      [{dbs, [redis, riak]},
       {auth_method, "\"riak\""},
@@ -369,12 +369,12 @@
   connection.tls.ciphers = \"AES256-SHA:DHE-RSA-AES128-SHA256\"
   connection.tls.server_name_indication = false
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
-      {mod_last, "  backend = \"riak\""},
-      {mod_privacy, "  backend = \"riak\""},
-      {mod_private, "  backend = \"riak\""},
+      {mod_last, "  backend = \"riak\"\n"},
+      {mod_privacy, "  backend = \"riak\"\n"},
+      {mod_private, "  backend = \"riak\"\n"},
       {mod_offline, "  backend = \"riak\"\n"},
       {mod_vcard, "  backend = \"riak\"
-  host = \"vjud.@HOST@\""},
+  host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"riak\"\n"}
      ]},
     {elasticsearch_and_cassandra_mnesia,

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -254,7 +254,6 @@
 {{#mod_private}}
 [modules.mod_private]
 {{{mod_private}}}
-
 {{/mod_private}}
 [modules.mod_register]
   welcome_message = {body = "", subject = ""}

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -81,7 +81,7 @@
   password = \"secret\""}.
 
 {mod_cache_users, "  time_to_live = 2
-  number_of_segments = 5"}.
+  number_of_segments = 5\n"}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -28,7 +28,7 @@
 {mod_blocking, ""}.
 {mod_private, ""}.
 {mod_roster, ""}.
-{mod_vcard, "  host = \"vjud.@HOST@\""}.
+{mod_vcard, "  host = \"vjud.@HOST@\"\n"}.
 {sm_backend, "\"mnesia\""}.
 {auth_method, "\"internal\""}.
 {cyrsasl_external, "\"standard\""}.


### PR DESCRIPTION
The resulting config for prod, dev nodes and all test presets should have a single newline between modules in `mongooseim.toml`. Previously some newlines were missing if there was at least one option as each option is in its separate line and there was no newline after the last option. Maybe for tests it's not that important but for `prod` it affects the initial configuration file, which had a bit broken layout, leading to worse initial impression.

I chose to use '\n' as literal newlines could make the config spec less readable.

I checked the result manually for `mim1`, `prod` and finally for `mim1` with the `pgsql_mnesia` preset enabled.