### PR TITLE
Unfold global options without the temporary functions

### DIFF
--- a/src/config/mongoose_config.erl
+++ b/src/config/mongoose_config.erl
@@ -23,8 +23,8 @@
 
 -type key() :: atom() | host_type_key() | host_type_or_global_key().
 -type s2s_domain_key() :: {atom(), jid:lserver()}.
--type host_type_key() :: {atom() | s2s_domain_key(), mongooseim:host_type()}.
--type host_type_or_global_key() :: {shaper | access | acl, atom(), mongooseim:host_type() | global}.
+-type host_type_key() :: {atom() | s2s_domain_key(), mongooseim:host_type_or_global()}.
+-type host_type_or_global_key() :: {shaper | access | acl, atom(), mongooseim:host_type_or_global()}.
 
 -type value() :: atom()
                | binary()

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1330,55 +1330,43 @@ pool_ldap_tls(_Config) ->
 
 %% tests: shaper, acl, access
 shaper(_Config) ->
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {shaper, normal, Host}, value = {maxrate, 1000}}] end,
-      #{<<"shaper">> => #{<<"normal">> => #{<<"max_rate">> => 1000}}}),
-    err_host_or_global(#{<<"shaper">> => #{<<"unlimited">> =>
-                                               #{<<"max_rate">> => <<"infinity">>}}}),
-    err_host_or_global(#{<<"shaper">> => #{<<"fast">> => #{}}}).
+    ?eqh([#local_config{key = {shaper, normal, Host}, value = {maxrate, 1000}}],
+         #{<<"shaper">> => #{<<"normal">> => #{<<"max_rate">> => 1000}}}),
+    ?errh(#{<<"shaper">> => #{<<"unlimited">> => #{<<"max_rate">> => <<"infinity">>}}}),
+    ?errh(#{<<"shaper">> => #{<<"fast">> => #{}}}).
 
 acl(_Config) ->
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {acl, local, Host}, value = [all]}] end,
-      #{<<"acl">> => #{<<"local">> => [#{<<"match">> => <<"all">>}]}}),
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {acl, local, Host}, value = [{user_regexp, <<>>}]}] end,
-      #{<<"acl">> => #{<<"local">> => [#{<<"user_regexp">> => <<>>}]}}),
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {acl, alice, Host},
-                                  value = [{node_regexp, <<"ali.*">>, <<".*host">>}]}] end,
-      #{<<"acl">> => #{<<"alice">> => [#{<<"user_regexp">> => <<"ali.*">>,
-                                         <<"server_regexp">> => <<".*host">>}]}}),
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {acl, alice, Host},
-                                  value = [{user, <<"alice">>, <<"localhost">>}]}] end,
-      #{<<"acl">> => #{<<"alice">> => [#{<<"user">> => <<"alice">>,
-                                         <<"server">> => <<"localhost">>}]}}),
-    err_host_or_global(#{<<"acl">> => #{<<"local">> => <<"everybody">>}}),
-    err_host_or_global(#{<<"acl">> => #{<<"alice">> => [#{<<"user_glob">> => <<"a*">>,
-                                                          <<"server_blog">> => <<"bloghost">>}]}}).
+    ?eqh([#local_config{key = {acl, local, Host}, value = [all]}],
+         #{<<"acl">> => #{<<"local">> => [#{<<"match">> => <<"all">>}]}}),
+    ?eqh([#local_config{key = {acl, local, Host}, value = [{user_regexp, <<>>}]}],
+         #{<<"acl">> => #{<<"local">> => [#{<<"user_regexp">> => <<>>}]}}),
+    ?eqh([#local_config{key = {acl, alice, Host},
+                        value = [{node_regexp, <<"ali.*">>, <<".*host">>}]}],
+         #{<<"acl">> => #{<<"alice">> => [#{<<"user_regexp">> => <<"ali.*">>,
+                                            <<"server_regexp">> => <<".*host">>}]}}),
+    ?eqh([#local_config{key = {acl, alice, Host},
+                        value = [{user, <<"alice">>, <<"localhost">>}]}],
+         #{<<"acl">> => #{<<"alice">> => [#{<<"user">> => <<"alice">>,
+                                            <<"server">> => <<"localhost">>}]}}),
+    ?errh(#{<<"acl">> => #{<<"local">> => <<"everybody">>}}),
+    ?errh(#{<<"acl">> => #{<<"alice">> => [#{<<"user_glob">> => <<"a*">>,
+                                             <<"server_blog">> => <<"bloghost">>}]}}).
 
 access(_Config) ->
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {access, c2s, Host}, value = [{deny, blocked},
-                                                                      {allow, all}]}]
-      end,
-      #{<<"access">> => #{<<"c2s">> => [#{<<"acl">> => <<"blocked">>,
-                                          <<"value">> => <<"deny">>},
-                                        #{<<"acl">> => <<"all">>,
-                                          <<"value">> => <<"allow">>}]}}),
-    eq_host_or_global(
-      fun(Host) -> [#local_config{key = {access, max_user_sessions, Host},
-                                  value = [{10, all}]}] end,
-      #{<<"access">> => #{<<"max_user_sessions">> => [#{<<"acl">> => <<"all">>,
-                                                        <<"value">> => 10}]}}),
-    err_host_or_global(#{<<"access">> => #{<<"max_user_sessions">> =>
-                                               [#{<<"acl">> => <<"all">>}]}}),
-    err_host_or_global(#{<<"access">> => #{<<"max_user_sessions">> =>
-                                               [#{<<"value">> => 10}]}}),
-    err_host_or_global(#{<<"access">> => #{<<"max_user_sessions">> =>
-                                               [#{<<"acl">> => 10,
-                                                  <<"value">> => 10}]}}).
+    ?eqh([#local_config{key = {access, c2s, Host}, value = [{deny, blocked},
+                                                            {allow, all}]}],
+         #{<<"access">> => #{<<"c2s">> => [#{<<"acl">> => <<"blocked">>,
+                                             <<"value">> => <<"deny">>},
+                                           #{<<"acl">> => <<"all">>,
+                                             <<"value">> => <<"allow">>}]}}),
+    ?eqh([#local_config{key = {access, max_user_sessions, Host},
+                        value = [{10, all}]}],
+         #{<<"access">> => #{<<"max_user_sessions">> => [#{<<"acl">> => <<"all">>,
+                                                           <<"value">> => 10}]}}),
+    ?errh(#{<<"access">> => #{<<"max_user_sessions">> => [#{<<"acl">> => <<"all">>}]}}),
+    ?errh(#{<<"access">> => #{<<"max_user_sessions">> => [#{<<"value">> => 10}]}}),
+    ?errh(#{<<"access">> => #{<<"max_user_sessions">> => [#{<<"acl">> => 10,
+                                                            <<"value">> => 10}]}}).
 
 %% tests: s2s
 


### PR DESCRIPTION
The goal of this PR is to simplify the config processing so that no temporary functions are inserted into the option list.

This makes it easier to rework the internal structure (e.g. using maps) and to maintain and understand the unit tests.
It also simplifies the subsequent unit test rework needed to support config defaults.

Another advantage of the new unit test macros is that we could rework the config not to unfold the global options and most of the unit tests would stay the same.
