### PR TITLE
Introduce config defaults for the 'general' section

### DIFF
--- a/include/mongoose.hrl
+++ b/include/mongoose.hrl
@@ -22,10 +22,10 @@
 %% If the ejabberd application description isn't loaded, returns atom: undefined
 -define(MONGOOSE_VERSION, element(2, application:get_key(mongooseim,vsn))).
 
--define(MYHOSTS, mongoose_config:get_opt(hosts, [])).
--define(ALL_HOST_TYPES, mongoose_config:get_opt(hosts, []) ++ mongoose_config:get_opt(host_types, [])).
+-define(MYHOSTS, mongoose_config:get_opt(hosts)).
+-define(ALL_HOST_TYPES, mongoose_config:get_opt(hosts) ++ mongoose_config:get_opt(host_types)).
 -define(MYNAME, mongoose_config:get_opt(default_server_domain)).
--define(MYLANG, mongoose_config:get_opt(language, <<"en">>)).
+-define(MYLANG, mongoose_config:get_opt(language)).
 
 -define(CONFIG_PATH, "etc/mongooseim.toml").
 

--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -7,7 +7,9 @@
                   required = [] :: [mongoose_config_parser_toml:toml_key()] | all,
                   validate = any :: mongoose_config_validator:section_validator(),
                   process :: undefined | mongoose_config_parser_toml:list_processor(),
-                  format = default :: mongoose_config_spec:format()}).
+                  format = default :: mongoose_config_spec:format(),
+                  defaults = #{} :: #{mongoose_config_parser_toml:toml_key() =>
+                                         mongoose_config_parser_toml:config_part()}}).
 
 -record(list, {items :: mongoose_config_spec:config_node(),
                validate = any :: mongoose_config_validator:list_validator(),

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -115,7 +115,8 @@ root() ->
     General = general(),
     #section{
        items = #{<<"general">> => General#section{required = [<<"default_server_domain">>],
-                                                  process = fun ?MODULE:process_general/1},
+                                                  process = fun ?MODULE:process_general/1,
+                                                  defaults = general_defaults()},
                  <<"listen">> => listen(),
                  <<"auth">> => auth(),
                  <<"outgoing_pools">> => outgoing_pools(),
@@ -225,6 +226,20 @@ general() ->
                 },
        format = none
       }.
+
+general_defaults() ->
+    #{<<"loglevel">> => warning,
+      <<"hosts">> => [],
+      <<"host_types">> => [],
+      <<"registration_timeout">> => 600,
+      <<"language">> => <<"en">>,
+      <<"all_metrics_are_global">> => false,
+      <<"sm_backend">> => {mnesia, []},
+      <<"rdbms_server_type">> => generic,
+      <<"mongooseimctl_access_commands">> => [],
+      <<"routing_modules">> => ejabberd_router:default_routing_modules(),
+      <<"replaced_wait_timeout">> => 2000,
+      <<"hide_service_name">> => false}.
 
 ctl_access_rule() ->
     #section{

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -34,7 +34,7 @@
 -spec init() -> ok | {error, term()}.
 init() ->
     Pairs = get_static_pairs(),
-    AllowedHostTypes = mongoose_config:get_opt(host_types, []),
+    AllowedHostTypes = mongoose_config:get_opt(host_types),
     mongoose_domain_core:start(Pairs, AllowedHostTypes),
     mongoose_subdomain_core:start(),
     mongoose_lazy_routing:start().
@@ -177,7 +177,7 @@ check_domain(Domain, HostType) ->
 %% Domains should be nameprepped using `jid:nameprep'
 -spec get_static_pairs() -> [pair()].
 get_static_pairs() ->
-    [{H, H} || H <- mongoose_config:get_opt(hosts, [])].
+    [{H, H} || H <- mongoose_config:get_opt(hosts)].
 
 -spec register_subdomain(host_type(), subdomain_pattern(),
                          mongoose_packet_handler:t()) ->

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -54,7 +54,7 @@ start(normal, _Args) ->
     mongoose_service:start(),
     gen_mod:start(),
     mongoose_config:start(),
-    mongoose_logs:set_global_loglevel(mongoose_config:get_opt(loglevel, warning)),
+    mongoose_logs:set_global_loglevel(mongoose_config:get_opt(loglevel)),
     mongoose_deprecations:start(),
     {ok, _} = Sup = ejabberd_sup:start_link(),
     mongoose_domain_api:init(),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -806,10 +806,7 @@ do_open_session_common(Acc, JID, #state{host_type = HostType,
     {established, Acc1, NewStateData}.
 
 get_replaced_wait_timeout(HostType) ->
-    mongoose_config:get_opt({replaced_wait_timeout, HostType}, default_replaced_wait_timeout()).
-
-default_replaced_wait_timeout() ->
-    2000.
+    mongoose_config:get_opt({replaced_wait_timeout, HostType}).
 
 -spec session_established(Item :: ejabberd:xml_stream_item(),
                           State :: state()) -> fsm_return().

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -247,7 +247,7 @@ process2(Args, Auth, AccessCommands) ->
 
 -spec get_accesscommands() -> [char() | tuple()].
 get_accesscommands() ->
-    mongoose_config:get_opt(mongooseimctl_access_commands, []).
+    mongoose_config:get_opt(mongooseimctl_access_commands).
 
 
 %%-----------------------------

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -52,7 +52,8 @@
          unregister_component/1,
          unregister_component/2,
          unregister_components/1,
-         unregister_components/2
+         unregister_components/2,
+         default_routing_modules/0
         ]).
 
 -export([start_link/0]).
@@ -509,7 +510,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 routing_modules_list() ->
-    mongoose_config:get_opt(routing_modules, default_routing_modules()).
+    mongoose_config:get_opt(routing_modules).
 
 default_routing_modules() ->
     [mongoose_router_global,

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -521,7 +521,7 @@ unregister_routes(StateData) ->
     ejabberd_router:unregister_components(Routes).
 
 get_routes(#state{host=Subdomain, is_subdomain=true}) ->
-    Hosts = mongoose_config:get_opt(hosts, []),
+    Hosts = mongoose_config:get_opt(hosts),
     component_routes(Subdomain, Hosts);
 get_routes(#state{host=Host}) ->
     [Host].

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -492,7 +492,7 @@ node_cleanup(Acc, Node) ->
 %%--------------------------------------------------------------------
 -spec init(_) -> {ok, state()}.
 init([]) ->
-    {Backend, Opts} = mongoose_config:get_opt(sm_backend, {mnesia, []}),
+    {Backend, Opts} = mongoose_config:get_opt(sm_backend),
     ejabberd_sm_backend:init([{backend, Backend}|Opts]),
 
     ets:new(sm_iqtable, [named_table, protected, {read_concurrency, true}]),

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -189,12 +189,12 @@ remove_all_metrics() ->
 
 -spec all_metrics_are_global() -> boolean().
 all_metrics_are_global() ->
-    mongoose_config:get_opt(all_metrics_are_global, false).
+    mongoose_config:get_opt(all_metrics_are_global).
 
 pick_by_all_metrics_are_global(WhenGlobal, WhenNot) ->
     case all_metrics_are_global() of
         true -> WhenGlobal;
-        _ -> WhenNot
+        false -> WhenNot
     end.
 
 -spec name_by_all_metrics_are_global(HostType :: mongooseim:host_type() | global,

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -412,7 +412,7 @@ send_registration_notification(JIDBin, Domain, Body) ->
 check_timeout(undefined) ->
     true;
 check_timeout(Source) ->
-    Timeout = mongoose_config:get_opt(registration_timeout, 600),
+    Timeout = mongoose_config:get_opt(registration_timeout),
     case is_integer(Timeout) of
         true ->
             Priority = -(erlang:system_time(second)),

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -744,7 +744,7 @@ db_engine(_HostType) ->
 %% Also, this parameter should not be global, but pool-name parameterized
 -spec db_type() -> mssql | generic.
 db_type() ->
-    case mongoose_config:get_opt(rdbms_server_type, undefined) of
+    case mongoose_config:get_opt(rdbms_server_type) of
         mssql -> mssql;
         _ -> generic
     end.

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -239,7 +239,7 @@ map_param(Param, Mapper) ->
 
 -spec server_type() -> atom().
 server_type() ->
-    mongoose_config:get_opt(rdbms_server_type, generic).
+    mongoose_config:get_opt(rdbms_server_type).
 
 -spec escape_binary(ServerType :: atom(), binary()) -> iodata().
 escape_binary(pgsql, Bin) ->

--- a/test/component_reg_SUITE.erl
+++ b/test/component_reg_SUITE.erl
@@ -13,7 +13,7 @@ init_per_suite(C) ->
     {ok, _} = application:ensure_all_started(jid),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
-    mongoose_config:set_opt(routing_modules, [xmpp_router_a, xmpp_router_b, xmpp_router_c]),
+    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
     meck:new(mongoose_domain_api, [no_link]),
     meck:expect(mongoose_domain_api, get_host_type,
                 fun(_) -> {error, not_found} end),
@@ -30,8 +30,12 @@ end_per_suite(_C) ->
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     meck:unload(),
-    mongoose_config:unset_opt(routing_modules),
+    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
     ok.
+
+opts() ->
+    [{all_metrics_are_global, false},
+     {routing_modules, [xmpp_router_a, xmpp_router_b, xmpp_router_c]}].
 
 registering(_C) ->
     Dom = <<"aaa.bbb.com">>,

--- a/test/config_parser_SUITE_data/host_types.options
+++ b/test/config_parser_SUITE_data/host_types.options
@@ -1,8 +1,20 @@
+{local_config,all_metrics_are_global,false}.
 {local_config,default_server_domain,<<"localhost">>}.
+{local_config,hide_service_name,false}.
 {local_config,host_types,
-        [<<"this is host type">>,<<"some host type">>,<<"another host type">>,
-         <<"yet another host type">>]}.
+              [<<"this is host type">>,<<"some host type">>,
+               <<"another host type">>,<<"yet another host type">>]}.
 {local_config,hosts,[<<"localhost">>]}.
+{local_config,language,<<"en">>}.
+{local_config,loglevel,warning}.
+{local_config,mongooseimctl_access_commands,[]}.
+{local_config,rdbms_server_type,generic}.
+{local_config,registration_timeout,600}.
+{local_config,routing_modules,
+              [mongoose_router_global,mongoose_router_localdomain,
+               mongoose_router_external_localnode,mongoose_router_external,
+               mongoose_router_dynamic_domains,ejabberd_s2s]}.
+{local_config,sm_backend,{mnesia,[]}}.
 {local_config,{auth_method,<<"another host type">>},[]}.
 {local_config,{auth_method,<<"localhost">>},[test3]}.
 {local_config,{auth_method,<<"some host type">>},[test2]}.
@@ -18,3 +30,8 @@
 {local_config,{modules,<<"some host type">>},[]}.
 {local_config,{modules,<<"this is host type">>},[]}.
 {local_config,{modules,<<"yet another host type">>},[{test_mim_module1,[]}]}.
+{local_config,{replaced_wait_timeout,<<"another host type">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost">>},2000}.
+{local_config,{replaced_wait_timeout,<<"some host type">>},2000}.
+{local_config,{replaced_wait_timeout,<<"this is host type">>},2000}.
+{local_config,{replaced_wait_timeout,<<"yet another host type">>},2000}.

--- a/test/config_parser_SUITE_data/miscellaneous.options
+++ b/test/config_parser_SUITE_data/miscellaneous.options
@@ -1,7 +1,10 @@
-{local_config,default_server_domain,<<"localhost">>}.
-{local_config,hosts,[<<"localhost">>,<<"anonymous.localhost">>]}.
+{local_config,all_metrics_are_global,false}.
 {local_config,cowboy_server_name,"Apache"}.
+{local_config,default_server_domain,<<"localhost">>}.
 {local_config,hide_service_name,true}.
+{local_config,host_types,[]}.
+{local_config,hosts,[<<"localhost">>,<<"anonymous.localhost">>]}.
+{local_config,language,<<"en">>}.
 {local_config,listen,
     [{{5280,{0,0,0,0},tcp},
       ejabberd_cowboy,
@@ -13,9 +16,11 @@
                    {password,"secret"},
                    {shaper_rule,fast}]}]}]},
        {transport_options,[{max_connections,1024},{num_acceptors,10}]}]}]}.
+{local_config,loglevel,warning}.
 {local_config,mongooseimctl_access_commands,
               [{local,["join_cluster"],[{node,"mongooseim@prime"}]}]}.
 {local_config,rdbms_server_type,mssql}.
+{local_config,registration_timeout,600}.
 {local_config,routing_modules,
               [mongoose_router_global,mongoose_router_localdomain]}.
 {local_config,services,
@@ -24,6 +29,7 @@
           {periodic_report,10800000},
           report,
           {tracking_id,"UA-123456789"}]}]}.
+{local_config,sm_backend,{mnesia,[]}}.
 {local_config,{allow_multiple_connections,<<"anonymous.localhost">>},true}.
 {local_config,{allow_multiple_connections,<<"localhost">>},true}.
 {local_config,{anonymous_protocol,<<"anonymous.localhost">>},sasl_anon}.

--- a/test/config_parser_SUITE_data/modules.options
+++ b/test/config_parser_SUITE_data/modules.options
@@ -1,5 +1,18 @@
+{local_config,all_metrics_are_global,false}.
 {local_config,default_server_domain,<<"localhost">>}.
+{local_config,hide_service_name,false}.
+{local_config,host_types,[]}.
 {local_config,hosts,[<<"localhost">>,<<"dummy_host">>]}.
+{local_config,language,<<"en">>}.
+{local_config,loglevel,warning}.
+{local_config,mongooseimctl_access_commands,[]}.
+{local_config,rdbms_server_type,generic}.
+{local_config,registration_timeout,600}.
+{local_config,routing_modules,
+              [mongoose_router_global,mongoose_router_localdomain,
+               mongoose_router_external_localnode,mongoose_router_external,
+               mongoose_router_dynamic_domains,ejabberd_s2s]}.
+{local_config,sm_backend,{mnesia,[]}}.
 {local_config,
     {modules,<<"dummy_host">>},
     [{mod_jingle_sip,
@@ -197,8 +210,8 @@
           {host,{fqdn,<<"muclight.example.com">>}},
           {equal_occupants,true},
           {config_schema,
-              [{<<"roomname">>,<<"The Room">>,roomname,binary},
-               {<<"display-lines">>,30,display_lines,integer}]},
+              [{<<"display-lines">>,30,display_lines,integer},
+               {<<"roomname">>,<<"The Room">>,roomname,binary}]},
           {blocking,false},
           {all_can_invite,true},
           {all_can_configure,true}]},
@@ -461,8 +474,8 @@
           {host,{fqdn,<<"muclight.example.com">>}},
           {equal_occupants,true},
           {config_schema,
-              [{<<"roomname">>,<<"The Room">>,roomname,binary},
-               {<<"display-lines">>,30,display_lines,integer}]},
+              [{<<"display-lines">>,30,display_lines,integer},
+               {<<"roomname">>,<<"The Room">>,roomname,binary}]},
           {blocking,false},
           {all_can_invite,true},
           {all_can_configure,true}]},
@@ -528,3 +541,5 @@
                     {sns_host,"sns.eu-west-1.amazonaws.com"}]}]}]},
      {mod_carboncopy,[{iqdisc,no_queue}]},
      {mod_version,[{os_info,true}]}]}.
+{local_config,{replaced_wait_timeout,<<"dummy_host">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost">>},2000}.

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.options
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.options
@@ -1,33 +1,10 @@
-{local_config,{acl,local,global},[{user_regexp,<<>>}]}.
-{local_config,default_server_domain,<<"localhost">>}.
-{local_config,hosts,[<<"localhost">>,<<"anonymous.localhost">>,<<"localhost.bis">>]}.
-{local_config,language,<<"en">>}.
-{local_config,sm_backend,{mnesia,[]}}.
-{local_config,{access,c2s,global},[{deny,blocked},{allow,all}]}.
-{local_config,{access,c2s_shaper,global},[{none,admin},{normal,all}]}.
-{local_config,{access,local,global},[{allow,local}]}.
-{local_config,{access,mam_get_prefs,global},[{default,all}]}.
-{local_config,{access,mam_get_prefs_global_shaper,global},[{mam_global_shaper,all}]}.
-{local_config,{access,mam_get_prefs_shaper,global},[{mam_shaper,all}]}.
-{local_config,{access,mam_lookup_messages,global},[{default,all}]}.
-{local_config,{access,mam_lookup_messages_global_shaper,global},
-        [{mam_global_shaper,all}]}.
-{local_config,{access,mam_lookup_messages_shaper,global},[{mam_shaper,all}]}.
-{local_config,{access,mam_set_prefs,global},[{default,all}]}.
-{local_config,{access,mam_set_prefs_global_shaper,global},[{mam_global_shaper,all}]}.
-{local_config,{access,mam_set_prefs_shaper,global},[{mam_shaper,all}]}.
-{local_config,{access,max_user_offline_messages,global},[{5000,admin},{100,all}]}.
-{local_config,{access,max_user_sessions,global},[{10,all}]}.
-{local_config,{access,muc,global},[{allow,all}]}.
-{local_config,{access,muc_admin,global},[{allow,admin}]}.
-{local_config,{access,muc_create,global},[{allow,local}]}.
-{local_config,{access,register,global},[{allow,all}]}.
-{local_config,{access,s2s_shaper,global},[{fast,all}]}.
-{local_config,{shaper,fast,global},{maxrate,50000}}.
-{local_config,{shaper,mam_global_shaper,global},{maxrate,1000}}.
-{local_config,{shaper,mam_shaper,global},{maxrate,1}}.
-{local_config,{shaper,normal,global},{maxrate,1000}}.
 {local_config,all_metrics_are_global,false}.
+{local_config,default_server_domain,<<"localhost">>}.
+{local_config,hide_service_name,false}.
+{local_config,host_types,[]}.
+{local_config,hosts,
+              [<<"localhost">>,<<"anonymous.localhost">>,<<"localhost.bis">>]}.
+{local_config,language,<<"en">>}.
 {local_config,listen,
     [{{5222,{0,0,0,0},tcp},
       ejabberd_c2s,
@@ -119,6 +96,7 @@
        {shaper_rule,fast}]}]}.
 {local_config,loglevel,warning}.
 {local_config,max_fsm_queue,1000}.
+{local_config,mongooseimctl_access_commands,[]}.
 {local_config,outgoing_pools,
     [{rdbms,global,default,
          [{workers,5}],
@@ -131,7 +109,12 @@
                         {verify,verify_peer}]}]}}]},
      {redis,<<"localhost">>,global_distrib,[{workers,10}],[]}]}.
 {local_config,outgoing_s2s_port,5299}.
+{local_config,rdbms_server_type,generic}.
 {local_config,registration_timeout,infinity}.
+{local_config,routing_modules,
+              [mongoose_router_global,mongoose_router_localdomain,
+               mongoose_router_external_localnode,mongoose_router_external,
+               mongoose_router_dynamic_domains,ejabberd_s2s]}.
 {local_config,s2s_certfile,"tools/ssl/mongooseim/server.pem"}.
 {local_config,s2s_use_starttls,optional}.
 {local_config,services,
@@ -141,6 +124,7 @@
                stanza,stats]}]},
      {service_mongoose_system_metrics,
          [{initial_report,300000},{periodic_report,10800000}]}]}.
+{local_config,sm_backend,{mnesia,[]}}.
 {local_config,{allow_multiple_connections,<<"anonymous.localhost">>},true}.
 {local_config,{anonymous_protocol,<<"anonymous.localhost">>},both}.
 {local_config,{auth_method,<<"anonymous.localhost">>},[anonymous]}.
@@ -224,7 +208,38 @@
      {mod_muc_commands,[]},
      {mod_stream_management,[]},
      {mod_carboncopy,[]}]}.
+{local_config,{replaced_wait_timeout,<<"anonymous.localhost">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost.bis">>},2000}.
 {local_config,{s2s_addr,<<"fed1">>},"127.0.0.1"}.
 {local_config,{s2s_default_policy,<<"anonymous.localhost">>},allow}.
 {local_config,{s2s_default_policy,<<"localhost">>},allow}.
 {local_config,{s2s_default_policy,<<"localhost.bis">>},allow}.
+{local_config,{access,c2s,global},[{deny,blocked},{allow,all}]}.
+{local_config,{access,c2s_shaper,global},[{none,admin},{normal,all}]}.
+{local_config,{access,local,global},[{allow,local}]}.
+{local_config,{access,mam_get_prefs,global},[{default,all}]}.
+{local_config,{access,mam_get_prefs_global_shaper,global},
+              [{mam_global_shaper,all}]}.
+{local_config,{access,mam_get_prefs_shaper,global},[{mam_shaper,all}]}.
+{local_config,{access,mam_lookup_messages,global},[{default,all}]}.
+{local_config,{access,mam_lookup_messages_global_shaper,global},
+              [{mam_global_shaper,all}]}.
+{local_config,{access,mam_lookup_messages_shaper,global},[{mam_shaper,all}]}.
+{local_config,{access,mam_set_prefs,global},[{default,all}]}.
+{local_config,{access,mam_set_prefs_global_shaper,global},
+              [{mam_global_shaper,all}]}.
+{local_config,{access,mam_set_prefs_shaper,global},[{mam_shaper,all}]}.
+{local_config,{access,max_user_offline_messages,global},
+              [{5000,admin},{100,all}]}.
+{local_config,{access,max_user_sessions,global},[{10,all}]}.
+{local_config,{access,muc,global},[{allow,all}]}.
+{local_config,{access,muc_admin,global},[{allow,admin}]}.
+{local_config,{access,muc_create,global},[{allow,local}]}.
+{local_config,{access,register,global},[{allow,all}]}.
+{local_config,{access,s2s_shaper,global},[{fast,all}]}.
+{local_config,{acl,local,global},[{user_regexp,<<>>}]}.
+{local_config,{shaper,fast,global},{maxrate,50000}}.
+{local_config,{shaper,mam_global_shaper,global},{maxrate,1000}}.
+{local_config,{shaper,mam_shaper,global},{maxrate,1}}.
+{local_config,{shaper,normal,global},{maxrate,1000}}.

--- a/test/config_parser_SUITE_data/outgoing_pools.options
+++ b/test/config_parser_SUITE_data/outgoing_pools.options
@@ -1,5 +1,12 @@
+{local_config,all_metrics_are_global,false}.
 {local_config,default_server_domain,<<"localhost">>}.
-{local_config,hosts,[<<"localhost">>,<<"anonymous.localhost">>,<<"localhost.bis">>]}.
+{local_config,hide_service_name,false}.
+{local_config,host_types,[]}.
+{local_config,hosts,
+              [<<"localhost">>,<<"anonymous.localhost">>,<<"localhost.bis">>]}.
+{local_config,language,<<"en">>}.
+{local_config,loglevel,warning}.
+{local_config,mongooseimctl_access_commands,[]}.
 {local_config,outgoing_pools,
     [{cassandra,global,default,[],
          [{keyspace,"big_mongooseim"},
@@ -46,3 +53,13 @@
                {keyfile,"path/to/key.pem"},
                {verify,verify_peer}]},
           {cacertfile,"path/to/cacert.pem"}]}]}.
+{local_config,rdbms_server_type,generic}.
+{local_config,registration_timeout,600}.
+{local_config,routing_modules,
+              [mongoose_router_global,mongoose_router_localdomain,
+               mongoose_router_external_localnode,mongoose_router_external,
+               mongoose_router_dynamic_domains,ejabberd_s2s]}.
+{local_config,sm_backend,{mnesia,[]}}.
+{local_config,{replaced_wait_timeout,<<"anonymous.localhost">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost.bis">>},2000}.

--- a/test/config_parser_SUITE_data/s2s_only.options
+++ b/test/config_parser_SUITE_data/s2s_only.options
@@ -1,16 +1,31 @@
+{local_config,all_metrics_are_global,false}.
 {local_config,default_server_domain,<<"localhost">>}.
+{local_config,hide_service_name,false}.
+{local_config,host_types,[]}.
 {local_config,hosts,[<<"localhost">>,<<"dummy_host">>]}.
+{local_config,language,<<"en">>}.
+{local_config,loglevel,warning}.
+{local_config,mongooseimctl_access_commands,[]}.
 {local_config,outgoing_s2s_families,[ipv4,ipv6]}.
 {local_config,outgoing_s2s_port,5299}.
 {local_config,outgoing_s2s_timeout,10000}.
+{local_config,rdbms_server_type,generic}.
+{local_config,registration_timeout,600}.
+{local_config,routing_modules,
+              [mongoose_router_global,mongoose_router_localdomain,
+               mongoose_router_external_localnode,mongoose_router_external,
+               mongoose_router_dynamic_domains,ejabberd_s2s]}.
 {local_config,s2s_certfile,"tools/ssl/mongooseim/server.pem"}.
 {local_config,s2s_ciphers,"TLSv1.2:TLSv1.3"}.
 {local_config,s2s_dns_options,[{retries,1},{timeout,30}]}.
 {local_config,s2s_use_starttls,optional}.
+{local_config,sm_backend,{mnesia,[]}}.
 {local_config,{domain_certfile,<<"example.com">>},"/path/to/example_com.pem"}.
 {local_config,{domain_certfile,<<"example.org">>},"/path/to/example_org.pem"}.
+{local_config,{replaced_wait_timeout,<<"dummy_host">>},2000}.
+{local_config,{replaced_wait_timeout,<<"localhost">>},2000}.
 {local_config,{s2s_addr,<<"fed1">>},"127.0.0.1"}.
-{local_config,{s2s_addr,<<"fed2">>},{"127.0.0.1", 8765}}.
+{local_config,{s2s_addr,<<"fed2">>},{"127.0.0.1",8765}}.
 {local_config,{s2s_default_policy,<<"dummy_host">>},allow}.
 {local_config,{s2s_default_policy,<<"localhost">>},allow}.
 {local_config,{s2s_max_retry_delay,<<"dummy_host">>},30}.

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -61,7 +61,8 @@ teardown() ->
 
 opts() ->
     [{max_fsm_queue, 100},
-     {default_server_domain, <<"localhost">>}].
+     {default_server_domain, <<"localhost">>},
+     {language, <<"en">>}].
 
 mcred_get(dummy_creds, username) -> <<"cosmic_hippo">>;
 mcred_get(dummy_creds, auth_module) -> auuuthmodule.

--- a/test/ejabberd_hooks_SUITE.erl
+++ b/test/ejabberd_hooks_SUITE.erl
@@ -25,10 +25,12 @@ all() ->
     ].
 
 init_per_suite(C) ->
-    Res = application:ensure_all_started(exometer_core),
+    application:ensure_all_started(exometer_core),
+    mongoose_config:set_opt(all_metrics_are_global, false),
     C.
 
 end_per_suite(_C) ->
+    mongoose_config:unset_opt(all_metrics_are_global),
     application:stop(exometer_core).
 
 a_module_fun_can_be_added(_) ->

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -107,7 +107,7 @@ end_per_testcase(_, Config) ->
     clean_sessions(Config),
     terminate_sm(),
     unload_meck(),
-    unset_opts().
+    unset_opts(Config).
 
 open_session(C) ->
     {Sid, USR} = generate_random_user(<<"localhost">>),
@@ -596,8 +596,16 @@ terminate_sm() ->
     gen_server:stop(ejabberd_sm).
 
 set_opts(Config) ->
-    mongoose_config:set_opt(hosts, [<<"localhost">>]),
-    mongoose_config:set_opt(sm_backend, sm_backend(?config(backend, Config))).
+    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts(Config)].
+
+unset_opts(Config) ->
+    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts(Config)].
+
+opts(Config) ->
+    [{hosts, [<<"localhost">>]},
+     {host_types, []},
+     {all_metrics_are_global, false},
+     {sm_backend, sm_backend(?config(backend, Config))}].
 
 sm_backend(ejabberd_sm_redis) ->
     {redis, [{pool_size, 3}, {worker_config, [{host, "localhost"}, {port, 6379}]}]};
@@ -610,7 +618,3 @@ set_meck() ->
     meck:expect(ejabberd_commands, register_commands, fun(_) -> ok end),
     meck:expect(ejabberd_commands, unregister_commands, fun(_) -> ok end),
     ok.
-
-unset_opts() ->
-    mongoose_config:unset_opt(hosts),
-    mongoose_config:unset_opt(sm_backend).

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -24,9 +24,11 @@ all() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(exometer_core),
+    mongoose_config:set_opt(all_metrics_are_global, false),
     Config.
 
 end_per_suite(Config) ->
+    mongoose_config:unset_opt(all_metrics_are_global),
     application:stop(exometer_core),
     Config.
 

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -37,12 +37,19 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(jid),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
+    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
     Config.
 
 end_per_suite(Config) ->
+    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     Config.
+
+opts() ->
+    [{hosts, []},
+     {host_types, []},
+     {all_metrics_are_global, false}].
 
 init_per_testcase(T, Config) ->
     {ok, _HooksServer} = gen_hook:start_link(),

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -107,17 +107,33 @@ cluster_load_from_file(Config) ->
 check_loaded_config(State) ->
     Opts = lists:sort(mongoose_config_parser:state_to_opts(State)),
     ExpectedOpts = minimal_config_opts(),
-    ?assertEqual(ExpectedOpts, Opts),
-    [?assertEqual(Val, mongoose_config:get_opt(Key)) || {{_, Key}, Val} <- ExpectedOpts].
+    ?assertEqual([{local_config, Key, Val} || {Key, Val} <- ExpectedOpts], Opts),
+    [?assertEqual(Val, mongoose_config:get_opt(Key)) || {Key, Val} <- ExpectedOpts].
 
 check_removed_config() ->
     Opts = minimal_config_opts(),
     ?assertError(badarg, mongoose_config:config_state()),
-    [?assertError(badarg, mongoose_config:get_opt(Key)) || {{_, Key}, _} <- Opts].
+    [?assertError(badarg, mongoose_config:get_opt(Key)) || {Key, _} <- Opts].
 
 minimal_config_opts() ->
-    [{local_config, default_server_domain, <<"localhost">>},
-     {local_config, hosts, [<<"localhost">>]}].
+    [{all_metrics_are_global, false},
+     {default_server_domain, <<"localhost">>},
+     {hide_service_name, false},
+     {host_types, []},
+     {hosts, [<<"localhost">>]},
+     {language, <<"en">>},
+     {loglevel, warning},
+     {mongooseimctl_access_commands, []},
+     {rdbms_server_type, generic},
+     {registration_timeout, 600},
+     {routing_modules, [mongoose_router_global,
+                        mongoose_router_localdomain,
+                        mongoose_router_external_localnode,
+                        mongoose_router_external,
+                        mongoose_router_dynamic_domains,
+                        ejabberd_s2s]},
+     {sm_backend, {mnesia, []}},
+     {{replaced_wait_timeout, <<"localhost">>}, 2000}].
 
 start_slave_node(Config) ->
     SlaveNode = do_start_slave_node(),

--- a/test/mongoose_deprecations_SUITE.erl
+++ b/test/mongoose_deprecations_SUITE.erl
@@ -21,7 +21,7 @@ all() ->
 
 init_per_suite(C) ->
     C.
-    
+
 end_per_suite(C) ->
     C.
 

--- a/test/mongoose_rdbms_SUITE.erl
+++ b/test/mongoose_rdbms_SUITE.erl
@@ -133,10 +133,14 @@ meck_unload_rand() ->
     meck:unload(rand).
 
 set_opts() ->
-    mongoose_config:set_opt(max_fsm_queue, 1024).
+    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()].
 
 unset_opts() ->
-    mongoose_config:unset_opt(max_fsm_queue).
+    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()].
+
+opts() ->
+    [{all_metrics_are_global, false},
+     {max_fsm_queue, 1024}].
 
 meck_db(odbc) ->
     meck:new(eodbc, [no_link]),

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -159,6 +159,7 @@ wait_for_update({ok, [{count,0}]}, N) ->
 
 opts(Group) ->
     [{hosts, [<<"localhost">>]},
+     {host_types, []},
      {all_metrics_are_global, Group =:= all_metrics_are_global}].
 
 get_reporters_cfg(Port) ->

--- a/test/muc_light_SUITE.erl
+++ b/test/muc_light_SUITE.erl
@@ -54,8 +54,8 @@ init_per_testcase(codec_calls, Config) ->
     meck_mongoose_subdomain_core(),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
+    mongoose_config:set_opt(all_metrics_are_global, false),
     {ok, _} = application:ensure_all_started(exometer_core),
-    ets:new(local_config, [named_table]),
     gen_hook:start_link(),
     ejabberd_router:start_link(),
     mim_ct_sup:start_link(ejabberd_sup),
@@ -70,6 +70,7 @@ init_per_testcase(_, Config) ->
 
 end_per_testcase(codec_calls, Config) ->
     mod_muc_light:stop(?DOMAIN),
+    mongoose_config:unset_opt(all_metrics_are_global),
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     application:stop(exometer_core),

--- a/test/privacy_SUITE.erl
+++ b/test/privacy_SUITE.erl
@@ -37,15 +37,16 @@ init_per_suite(C) ->
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
     {ok, _} = application:ensure_all_started(exometer_core),
+    mongoose_config:set_opt(all_metrics_are_global, false),
     C.
 
 init_per_testcase(_, C) ->
-    catch ets:new(local_config, [named_table]),
     gen_hook:start_link(),
     mod_privacy:start(<<"localhost">>, []),
     C.
 
 end_per_suite(_C) ->
+    mongoose_config:unset_opt(all_metrics_are_global),
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     application:stop(exometer_core),

--- a/test/translate_SUITE.erl
+++ b/test/translate_SUITE.erl
@@ -4,7 +4,6 @@
 
 all() ->
     [
-     test_undefined_translation,
      test_english_translation,
      test_polish_translation,
      test_portuguese_translation
@@ -14,15 +13,6 @@ all() ->
 end_per_testcase(_, C) ->
     mongoose_config:unset_opt(language),
     C.
-
-test_undefined_translation(_Config) ->
-    %% given - no language set, defaults to English
-    given_loaded_translations(),
-    %% then
-    ?assertEqual(<<"undef">>, translate:translate(<<"en">>, <<"undef">>)),
-    ?assertEqual(<<"undef2">>, translate:translate(<<"klingon">>, <<"undef2">>)),
-
-    ok.
 
 test_english_translation(_Config) ->
     %% given


### PR DESCRIPTION
This is the starting point for introducing defaults to the config spec.

As the converted section contains the most important options, they needed to be set explicitly in small tests. It seems the right way to go - now it is clear which ones are required by each test suite.

Most of the added lines contain the expected default values for converted config files - these might grow further when more defaults are introduced, but other sections are not mandatory, so it should only be a minor increase or verbosity.

See commit messages for more details.

