### PR TITLE
Flaky tests: enable mod_last only on its test suite

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -255,7 +255,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.server_name_indication = false"},
       {service_domain_db, ""},
-      {mod_last, "  backend = \"rdbms\"\n"},
       {mod_privacy, "  backend = \"rdbms\"\n"},
       {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
@@ -275,7 +274,6 @@
   connection.driver = \"odbc\"
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
       {service_domain_db, ""},
-      {mod_last, "  backend = \"rdbms\"\n"},
       {mod_privacy, "  backend = \"rdbms\"\n"},
       {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
@@ -305,7 +303,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.versions = [\"tlsv1.2\"]"},
       {service_domain_db, ""},
-      {mod_last, "  backend = \"rdbms\"\n"},
       {mod_privacy, "  backend = \"rdbms\"\n"},
       {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
@@ -369,7 +366,6 @@
   connection.tls.ciphers = \"AES256-SHA:DHE-RSA-AES128-SHA256\"
   connection.tls.server_name_indication = false
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
-      {mod_last, "  backend = \"riak\"\n"},
       {mod_privacy, "  backend = \"riak\"\n"},
       {mod_private, "  backend = \"riak\"\n"},
       {mod_offline, "  backend = \"riak\"\n"},

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -193,6 +193,8 @@ init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(Node, Config),
     Config2 = escalus:init_per_suite([{ctl_auth_mods, AuthMods},
                                       {roster_template, TemplatePath} | Config1]),
+    dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_last, []}]),
+    dynamic_modules:ensure_modules(domain_helper:secondary_host_type(), [{mod_last, []}]),
     prepare_roster_template(TemplatePath, domain()),
     %% dump_and_load requires at least one mnesia table
     %% ensure, that passwd table is available
@@ -209,6 +211,8 @@ prepare_roster_template(TemplatePath, Domain) ->
 end_per_suite(Config) ->
     Config1 = lists:keydelete(ctl_auth_mods, 1, Config),
     delete_users(Config1),
+    dynamic_modules:stop(domain_helper:host_type(), mod_last),
+    dynamic_modules:stop(domain_helper:secondary_host_type(), mod_last),
     escalus:end_per_suite(Config1).
 
 init_per_group(vcard, Config) ->

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -50,3 +50,5 @@
 
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+
+{mod_last, false}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -82,6 +82,7 @@
 
 {mod_cache_users, "  time_to_live = 2
   number_of_segments = 5\n"}.
+{mod_last, false}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -60,3 +60,4 @@
   modules = { }"}.
 
 {mod_cache_users, false}.
+{mod_last, false}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -46,3 +46,4 @@
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
 {mod_cache_users, false}.
+{mod_last, false}.

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -45,3 +45,4 @@
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
+{mod_last, false}.


### PR DESCRIPTION
This module triggers an rdbms query every time a user disconnects, which in some suites that generate lots of fresh users in parallel, can mean lots of rdbms queries being triggered, when they are not needed. I've seen this deadlocking on MSSQL for the carboncopies suite:
https://app.circleci.com/pipelines/github/esl/MongooseIM/6374/workflows/ddf85703-70fe-456f-a55d-6834979f998f/jobs/88946
https://app.circleci.com/pipelines/github/esl/MongooseIM/6078/workflows/35ac57e9-75ee-45af-8f4b-ac3d974a3c96/jobs/83656
https://app.circleci.com/pipelines/github/esl/MongooseIM/6417/workflows/4416466d-9882-464e-8e83-f49ba455f53f/jobs/89920
https://app.circleci.com/pipelines/github/esl/MongooseIM/6411/workflows/2e7f8cd1-8414-40f2-8d6f-67ba8be8b7b7/jobs/89790