### PR TITLE
Tests/enable db modules only when used

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -255,7 +255,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.server_name_indication = false"},
       {service_domain_db, ""},
-      {mod_privacy, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
@@ -273,7 +272,6 @@
   connection.driver = \"odbc\"
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
       {service_domain_db, ""},
-      {mod_privacy, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
@@ -301,7 +299,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.versions = [\"tlsv1.2\"]"},
       {service_domain_db, ""},
-      {mod_privacy, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
@@ -363,7 +360,6 @@
   connection.tls.ciphers = \"AES256-SHA:DHE-RSA-AES128-SHA256\"
   connection.tls.server_name_indication = false
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
-      {mod_privacy, "  backend = \"riak\"\n"},
       {mod_offline, "  backend = \"riak\"\n"},
       {mod_vcard, "  backend = \"riak\"
   host = \"vjud.@HOST@\"\n"},

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -255,7 +255,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.server_name_indication = false"},
       {service_domain_db, ""},
-      {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
@@ -272,7 +271,6 @@
   connection.driver = \"odbc\"
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
       {service_domain_db, ""},
-      {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
@@ -299,7 +297,6 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.versions = [\"tlsv1.2\"]"},
       {service_domain_db, ""},
-      {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"rdbms\"\n"}]},
@@ -360,7 +357,6 @@
   connection.tls.ciphers = \"AES256-SHA:DHE-RSA-AES128-SHA256\"
   connection.tls.server_name_indication = false
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
-      {mod_offline, "  backend = \"riak\"\n"},
       {mod_vcard, "  backend = \"riak\"
   host = \"vjud.@HOST@\"\n"},
       {mod_roster, "  backend = \"riak\"\n"}

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -256,7 +256,6 @@
   connection.tls.server_name_indication = false"},
       {service_domain_db, ""},
       {mod_privacy, "  backend = \"rdbms\"\n"},
-      {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
@@ -275,7 +274,6 @@
   connection.settings = \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\""},
       {service_domain_db, ""},
       {mod_privacy, "  backend = \"rdbms\"\n"},
-      {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
@@ -304,7 +302,6 @@
   connection.tls.versions = [\"tlsv1.2\"]"},
       {service_domain_db, ""},
       {mod_privacy, "  backend = \"rdbms\"\n"},
-      {mod_private, "  backend = \"rdbms\"\n"},
       {mod_offline, "  backend = \"rdbms\"\n"},
       {mod_vcard, "  backend = \"rdbms\"
   host = \"vjud.@HOST@\"\n"},
@@ -367,7 +364,6 @@
   connection.tls.server_name_indication = false
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\""},
       {mod_privacy, "  backend = \"riak\"\n"},
-      {mod_private, "  backend = \"riak\"\n"},
       {mod_offline, "  backend = \"riak\"\n"},
       {mod_vcard, "  backend = \"riak\"
   host = \"vjud.@HOST@\"\n"},

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -979,11 +979,11 @@ is_module_loaded(Mod) ->
     rpc(mim(), gen_mod, is_loaded, [host_type(), Mod]).
 
 required_modules(basic) ->
-    mam_modules(off) ++ offline_modules(off);
+    mam_modules(off) ++ offline_modules(off) ++ privacy_modules(on);
 required_modules(mam) ->
-    mam_modules(on) ++ offline_modules(off);
+    mam_modules(on) ++ offline_modules(off) ++ privacy_modules(off);
 required_modules(offline) ->
-    mam_modules(off) ++ offline_modules(on);
+    mam_modules(off) ++ offline_modules(on) ++ privacy_modules(on);
 required_modules(_) ->
     [].
 
@@ -1000,3 +1000,10 @@ offline_modules(on) ->
 offline_modules(off) ->
     [{mod_offline, stopped},
      {mod_offline_stub, []}].
+
+privacy_modules(on) ->
+    [{mod_privacy, []},
+     {mod_blocking, []}];
+privacy_modules(off) ->
+    [{mod_privacy, stopped},
+     {mod_blocking, stopped}].

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -240,7 +240,8 @@ init_per_testcase(retrieve_logs = CN, Config) ->
         false -> {skip, not_running_in_distributed};
         _ -> escalus:init_per_testcase(CN, Config)
     end;
-init_per_testcase(remove_offline = CN, Config) ->
+init_per_testcase(CN, Config) when CN =:= remove_offline;
+                                   CN =:= retrieve_offline ->
     offline_started(),
     escalus:init_per_testcase(CN, Config);
 init_per_testcase(CN, Config) when
@@ -314,7 +315,7 @@ init_per_testcase(CN, Config) ->
 end_per_testcase(CN, Config) when CN =:= retrieve_mam_muc_light;
                                   CN =:= retrieve_mam_pm_and_muc_light_interfere;
                                   CN =:= retrieve_mam_pm_and_muc_light_dont_interfere ->
-    muc_light_helper:clear_db(),
+    muc_light_helper:clear_db(host_type()),
     escalus:end_per_testcase(CN, Config);
 %% mod_inbox
 end_per_testcase(CN, Config) when
@@ -322,7 +323,7 @@ end_per_testcase(CN, Config) when
       CN =:= retrieve_inbox;
       CN =:= remove_inbox_muclight;
       CN =:= retrieve_inbox_muclight ->
-    muc_light_helper:clear_db(),
+    muc_light_helper:clear_db(host_type()),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(CN, Config) when CN =:= retrieve_inbox_muc;
                                   CN =:= remove_inbox_muc ->

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -214,6 +214,9 @@ init_per_group(retrieve_personal_data_inbox = GN, Config) ->
     init_inbox(GN, Config, muclight);
 init_per_group(remove_personal_data_inbox = GN, Config) ->
     init_inbox(GN, Config, muclight);
+init_per_group(retrieve_personal_data_private_xml, Config) ->
+    private_started(),
+    Config;
 init_per_group(_GN, Config) ->
     Config.
 

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -191,8 +191,8 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     delete_files(),
-    dynamic_modules:restore_modules(host_type(), Config),
     escalus_fresh:clean(),
+    dynamic_modules:restore_modules(host_type(), Config),
     escalus:end_per_suite(Config).
 
 init_per_group(GN, Config) when GN =:= remove_personal_data_mam_rdbms;

--- a/big_tests/tests/last_SUITE.erl
+++ b/big_tests/tests/last_SUITE.erl
@@ -44,7 +44,7 @@ suite() ->
 init_per_suite(Config0) ->
     HostType = domain_helper:host_type(),
     Config1 = dynamic_modules:save_modules(HostType, Config0),
-    Backend = get_configured_backend(HostType),
+    Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
     dynamic_modules:ensure_modules(HostType, required_modules(Backend)),
     escalus:init_per_suite([{backend, Backend} | Config1]).
 
@@ -161,13 +161,6 @@ get_last_activity(Stanza) ->
 
 get_last_status(Stanza) ->
     exml_query:path(Stanza, [{element, <<"query">>}, cdata]).
-
-get_configured_backend(HostType) ->
-    case {mongoose_helper:is_rdbms_enabled(HostType), mam_helper:is_riak_enabled(HostType)} of
-        {false, false} -> mnesia;
-        {true, false} -> rdbms;
-        {false, true} -> riak
-    end.
 
 required_modules(Backend) ->
     [{mod_last, [{backend, Backend}]}].

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -97,13 +97,18 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
-init_per_suite(Config) ->
-    escalus:init_per_suite(Config).
-%%    [{escalus_no_stanzas_after_story, true} |
-%%     escalus:init_per_suite(Config)].
+init_per_suite(Config0) ->
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config0),
+    Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
+    ModConfig = mongoose_helper:backend_for_module(mod_blocking, Backend),
+    dynamic_modules:ensure_modules(HostType, ModConfig),
+    [{backend, Backend} |
+     escalus:init_per_suite(Config1)].
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -6,6 +6,7 @@
 %% API
 
 -export([is_rdbms_enabled/1,
+         get_backend_mnesia_rdbms_riak/1,
          mnesia_or_rdbms_backend/0,
          get_backend_name/2]).
 
@@ -62,6 +63,13 @@ mnesia_or_rdbms_backend() ->
     case mongoose_helper:is_rdbms_enabled(Host) of
         true -> rdbms;
         false -> mnesia
+    end.
+
+get_backend_mnesia_rdbms_riak(HostType) ->
+    case {is_rdbms_enabled(HostType), mam_helper:is_riak_enabled(HostType)} of
+        {false, false} -> mnesia;
+        {true, false} -> rdbms;
+        {false, true} -> riak
     end.
 
 -spec auth_modules() -> [atom()].

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -7,6 +7,7 @@
 
 -export([is_rdbms_enabled/1,
          get_backend_mnesia_rdbms_riak/1,
+         backend_for_module/2,
          mnesia_or_rdbms_backend/0,
          get_backend_name/2]).
 
@@ -71,6 +72,9 @@ get_backend_mnesia_rdbms_riak(HostType) ->
         {true, false} -> rdbms;
         {false, true} -> riak
     end.
+
+backend_for_module(Module, Backend) ->
+    [{Module, [{backend, Backend}]}].
 
 -spec auth_modules() -> [atom()].
 auth_modules() ->

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -215,6 +215,9 @@ end_per_suite(Config) ->
     dynamic_modules:stop(domain_helper:secondary_host_type(), mod_last),
     escalus:end_per_suite(Config1).
 
+init_per_group(private, Config) ->
+    dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_private, []}]),
+    Config;
 init_per_group(vcard, Config) ->
     case rpc(mim(), gen_mod, get_module_opt, [host_type(), mod_vcard, backend, mnesia]) of
         ldap ->
@@ -238,6 +241,9 @@ init_per_group(upload_with_acl, Config) ->
 init_per_group(_GroupName, Config) ->
     Config.
 
+end_per_group(private, Config) ->
+    dynamic_modules:stop(domain_helper:host_type(), mod_private),
+    Config;
 end_per_group(Rosters, Config) when (Rosters == roster) or (Rosters == roster_advanced) ->
     TemplatePath = escalus_config:get_config(roster_template, Config),
     RegUsers = [atom_to_list(U) || {U, _} <- escalus_config:get_config(escalus_users, Config)],

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -215,6 +215,9 @@ end_per_suite(Config) ->
     dynamic_modules:stop(domain_helper:secondary_host_type(), mod_last),
     escalus:end_per_suite(Config1).
 
+init_per_group(basic, Config) ->
+    dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_offline, []}]),
+    Config;
 init_per_group(private, Config) ->
     dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_private, []}]),
     Config;
@@ -241,6 +244,9 @@ init_per_group(upload_with_acl, Config) ->
 init_per_group(_GroupName, Config) ->
     Config.
 
+end_per_group(basic, Config) ->
+    dynamic_modules:stop(domain_helper:host_type(), mod_offline),
+    Config;
 end_per_group(private, Config) ->
     dynamic_modules:stop(domain_helper:host_type(), mod_private),
     Config;

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -55,8 +55,19 @@ suite() ->
 %%% Init & teardown
 %%%===================================================================
 
-init_per_suite(C) -> escalus:init_per_suite(C).
-end_per_suite(C) -> escalus_fresh:clean(), escalus:end_per_suite(C).
+init_per_suite(Config0) ->
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config0),
+    Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
+    ModConfig = mongoose_helper:backend_for_module(mod_offline, Backend),
+    dynamic_modules:ensure_modules(HostType, ModConfig),
+    [{backend, Backend} |
+     escalus:init_per_suite(Config1)].
+
+end_per_suite(Config) ->
+    escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_suite(Config).
 
 init_per_group(with_groupchat, C) ->
     Config = dynamic_modules:save_modules(host_type(), C),

--- a/big_tests/tests/privacy_SUITE.erl
+++ b/big_tests/tests/privacy_SUITE.erl
@@ -89,12 +89,19 @@ suite() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
-init_per_suite(Config) ->
-    [{escalus_no_stanzas_after_story, true} |
-     escalus:init_per_suite(Config)].
+init_per_suite(Config0) ->
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config0),
+    Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
+    ModConfig = mongoose_helper:backend_for_module(mod_privacy, Backend),
+    dynamic_modules:ensure_modules(HostType, ModConfig),
+    [{escalus_no_stanzas_after_story, true},
+     {backend, Backend} |
+     escalus:init_per_suite(Config1)].
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->

--- a/big_tests/tests/private_SUITE.erl
+++ b/big_tests/tests/private_SUITE.erl
@@ -48,7 +48,8 @@ init_per_suite(Config0) ->
     HostType = domain_helper:host_type(),
     Config1 = dynamic_modules:save_modules(HostType, Config0),
     Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
-    dynamic_modules:ensure_modules(HostType, required_modules(Backend)),
+    ModConfig = mongoose_helper:backend_for_module(mod_privacy, Backend),
+    dynamic_modules:ensure_modules(HostType, ModConfig),
     escalus:init_per_suite([{backend, Backend} | Config1]).
 
 end_per_suite(Config) ->

--- a/big_tests/tests/private_SUITE.erl
+++ b/big_tests/tests/private_SUITE.erl
@@ -48,7 +48,7 @@ init_per_suite(Config0) ->
     HostType = domain_helper:host_type(),
     Config1 = dynamic_modules:save_modules(HostType, Config0),
     Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
-    ModConfig = mongoose_helper:backend_for_module(mod_privacy, Backend),
+    ModConfig = mongoose_helper:backend_for_module(mod_private, Backend),
     dynamic_modules:ensure_modules(HostType, ModConfig),
     escalus:init_per_suite([{backend, Backend} | Config1]).
 

--- a/big_tests/tests/private_SUITE.erl
+++ b/big_tests/tests/private_SUITE.erl
@@ -44,10 +44,15 @@ negative_test_cases() ->
 suite() ->
     escalus:suite().
 
-init_per_suite(Config) ->
-    escalus:init_per_suite(Config).
+init_per_suite(Config0) ->
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config0),
+    Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
+    dynamic_modules:ensure_modules(HostType, required_modules(Backend)),
+    escalus:init_per_suite([{backend, Backend} | Config1]).
 
 end_per_suite(Config) ->
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->
@@ -167,3 +172,5 @@ check_body_rec(Element, [Name | Names]) ->
     Name = Child#xmlel.name,
     check_body_rec(Child, Names).
 
+required_modules(Backend) ->
+    [{mod_private, [{backend, Backend}]}].

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -964,7 +964,9 @@ mongoose_push_api_for_group(_) ->
     "v3".
 
 required_modules_for_group(pm_notifications_with_inbox, API, PubSubHost) ->
-    [{mod_inbox, inbox_opts()} | required_modules(API, PubSubHost)];
+    [{mod_inbox, inbox_opts()},
+     {mod_offline, []} |
+     required_modules(API, PubSubHost)];
 required_modules_for_group(groupchat_notifications_with_inbox, API, PubSubHost)->
     [{mod_inbox, inbox_opts()}, {mod_muc_light, muc_light_opts()}
      | required_modules(API, PubSubHost)];

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -120,8 +120,8 @@ init_per_suite(Config) ->
     escalus:init_per_suite(NewConfigWithSM).
 
 end_per_suite(Config) ->
-    dynamic_modules:restore_modules(Config),
     escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(Group, Config) when Group =:= unacknowledged_message_hook;
@@ -178,7 +178,7 @@ required_modules(Scope, Name) ->
                    stopped -> stopped;
                    ExtraOpts -> common_sm_opts() ++ ExtraOpts
                end,
-    [{mod_stream_management, SMConfig}].
+    [{mod_stream_management, SMConfig}, {mod_offline, []}].
 
 required_sm_opts(group, parallel) ->
     [{ack_freq, never}];

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -33,12 +33,14 @@ suite() ->
     escalus:suite().
 
 init_per_suite(Config) ->
-    dynamic_modules:start(host_type(), mod_csi, [{buffer_max, ?CSI_BUFFER_MAX}]),
-    [{escalus_user_db, {module, escalus_ejabberd}} | escalus:init_per_suite(Config)].
+    NewConfig = dynamic_modules:save_modules(host_type(), Config),
+    dynamic_modules:ensure_modules(
+      host_type(), [{mod_offline, []}, {mod_csi, [{buffer_max, ?CSI_BUFFER_MAX}]}]),
+    [{escalus_user_db, {module, escalus_ejabberd}} | escalus:init_per_suite(NewConfig)].
 
 end_per_suite(Config) ->
-    dynamic_modules:stop(host_type(), mod_csi),
     escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(_, Config) ->

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -55,3 +55,4 @@
 {mod_private, false}.
 {mod_privacy, false}.
 {mod_blocking, false}.
+{mod_offline, false}.

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -52,3 +52,4 @@
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
 {mod_last, false}.
+{mod_private, false}.

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -53,3 +53,5 @@
 
 {mod_last, false}.
 {mod_private, false}.
+{mod_privacy, false}.
+{mod_blocking, false}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -8,8 +8,6 @@
 {host_types, "\"test type\", \"dummy auth\", \"anonymous\""}.
 {default_server_domain, "\"localhost\""}.
 
-{mod_privacy, ""}.
-{mod_blocking, ""}.
 {mod_amp, ""}.
 {host_config,
   "[[host_config]]
@@ -84,6 +82,8 @@
   number_of_segments = 5\n"}.
 {mod_last, false}.
 {mod_private, false}.
+{mod_privacy, false}.
+{mod_blocking, false}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -83,6 +83,7 @@
 {mod_cache_users, "  time_to_live = 2
   number_of_segments = 5\n"}.
 {mod_last, false}.
+{mod_private, false}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -84,6 +84,7 @@
 {mod_private, false}.
 {mod_privacy, false}.
 {mod_blocking, false}.
+{mod_offline, false}.
 {zlib, "10_000"}.
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -62,3 +62,5 @@
 {mod_cache_users, false}.
 {mod_last, false}.
 {mod_private, false}.
+{mod_privacy, false}.
+{mod_blocking, false}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -61,3 +61,4 @@
 
 {mod_cache_users, false}.
 {mod_last, false}.
+{mod_private, false}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -64,3 +64,4 @@
 {mod_private, false}.
 {mod_privacy, false}.
 {mod_blocking, false}.
+{mod_offline, false}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -47,3 +47,4 @@
 
 {mod_cache_users, false}.
 {mod_last, false}.
+{mod_private, false}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -48,3 +48,5 @@
 {mod_cache_users, false}.
 {mod_last, false}.
 {mod_private, false}.
+{mod_privacy, false}.
+{mod_blocking, false}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -50,3 +50,4 @@
 {mod_private, false}.
 {mod_privacy, false}.
 {mod_blocking, false}.
+{mod_offline, false}.

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -47,3 +47,5 @@
 
 {mod_last, false}.
 {mod_private, false}.
+{mod_privacy, false}.
+{mod_blocking, false}.

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -49,3 +49,4 @@
 {mod_private, false}.
 {mod_privacy, false}.
 {mod_blocking, false}.
+{mod_offline, false}.

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -46,3 +46,4 @@
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
 {mod_last, false}.
+{mod_private, false}.


### PR DESCRIPTION
Not that I have a proof of the crime, but, in line with #3413, there's all these modules that are enabled by default, that run queries when a user is deleted on the `remove_user` hook, which we run very very often, basically at the end of every test that spawns fresh users. So even if the `remove_user` hook will find nothing to remove because any of these tables was not actually used, there's still plenty of round-trips to the DB I'm just thinking rather unnecessary.