### PR TITLE
Take the accumulator in the room hooks

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -63,7 +63,7 @@
 -export([is_muc_room_owner/4,
          can_access_room/4,
          remove_domain/3,
-         get_room_affiliations/2,
+         acc_room_affiliations/2,
          can_access_identity/4,
          disco_local_items/1]).
 
@@ -74,7 +74,7 @@
 -export([config_metrics/1]).
 
 -ignore_xref([
-    can_access_identity/4, can_access_room/4, get_room_affiliations/2, create_instant_room/6,
+    can_access_identity/4, can_access_room/4, acc_room_affiliations/2, create_instant_room/6,
     disco_local_items/1, hibernated_rooms_number/0, is_muc_room_owner/4, remove_domain/3,
     online_rooms_number/0, register_room/4, restore_room/3, start_link/2
 ]).
@@ -1246,21 +1246,18 @@ remove_domain(Acc, HostType, Domain) ->
     mod_muc_backend:remove_domain(HostType, MUCHost, Domain),
     Acc.
 
--spec get_room_affiliations(mongoose_acc:t(), jid:jid()) ->
-    {mongoose_acc:t(), any()}.
-get_room_affiliations(Acc1, Room) ->
-    case mongoose_acc:get(?MODULE, affiliations, undefined, Acc1) of
-        undefined ->
+-spec acc_room_affiliations(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
+acc_room_affiliations(Acc1, Room) ->
+    case mongoose_acc:get(?MODULE, affiliations, {error, not_found}, Acc1) of
+        {error, _} ->
             case mod_muc_room:get_room_users(Room) of
                 {error, not_found} ->
-                    Acc2 = mongoose_acc:set(?MODULE, affiliations, {error, not_found}, Acc1),
-                    {Acc2, {error, not_found}};
+                    Acc1;
                 {ok, _Affs} = Res ->
-                    Acc2 = mongoose_acc:set_permanent(?MODULE, affiliations, Res, Acc1),
-                    {Acc2, Res}
+                    mongoose_acc:set_permanent(?MODULE, affiliations, Res, Acc1)
             end;
-        Affs ->
-            {Acc1, Affs}
+        _Affs ->
+            Acc1
     end.
 
 -spec can_access_identity(Acc :: boolean(), HostType :: mongooseim:host_type(),
@@ -1335,7 +1332,7 @@ hooks(HostType) ->
     [{is_muc_room_owner, HostType, ?MODULE, is_muc_room_owner, 50},
      {can_access_room, HostType, ?MODULE, can_access_room, 50},
      {remove_domain, HostType, ?MODULE, remove_domain, 50},
-     {get_room_affiliations, HostType, ?MODULE, get_room_affiliations, 50},
+     {acc_room_affiliations, HostType, ?MODULE, acc_room_affiliations, 50},
      {can_access_identity, HostType, ?MODULE, can_access_identity, 50},
      {disco_local_items, HostType, ?MODULE, disco_local_items, 250}].
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1254,7 +1254,7 @@ acc_room_affiliations(Acc1, Room) ->
                 {error, not_found} ->
                     Acc1;
                 {ok, _Affs} = Res ->
-                    mongoose_acc:set_permanent(?MODULE, affiliations, Res, Acc1)
+                    mongoose_acc:set(?MODULE, affiliations, Res, Acc1)
             end;
         _Affs ->
             Acc1

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1220,19 +1220,19 @@ clean_table_from_bad_node(Node, HostType) ->
 %% Hooks handlers
 %%====================================================================
 
--spec is_muc_room_owner(Acc :: boolean(), HostType :: mongooseim:host_type(),
+-spec is_muc_room_owner(Acc :: boolean(), Acc :: mongoose_acc:t(),
                         Room :: jid:jid(), User :: jid:jid()) -> boolean().
-is_muc_room_owner(true, _HostType, _Room, _User) ->
+is_muc_room_owner(true, _Acc, _Room, _User) ->
     true;
-is_muc_room_owner(_, _HostType, Room, User) ->
+is_muc_room_owner(_, _Acc, Room, User) ->
     mod_muc_room:is_room_owner(Room, User) =:= {ok, true}.
 
--spec can_access_room(Acc :: boolean(), HostType :: mongooseim:host_type(),
+-spec can_access_room(Acc :: boolean(), Acc :: mongoose_acc:t(),
                       Room :: jid:jid(), User :: jid:jid()) ->
     boolean().
-can_access_room(true, _HostType, _Room, _User) ->
+can_access_room(true, _Acc, _Room, _User) ->
     true;
-can_access_room(_, _HostType, Room, User) ->
+can_access_room(_, _Acc, Room, User) ->
     case mod_muc_room:can_access_room(Room, User) of
         {error, _} -> false;
         {ok, CanAccess} -> CanAccess

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -9,8 +9,6 @@
 -include("mod_privacy.hrl").
 -include("mongoose.hrl").
 
--ignore_xref([acc_room_affiliations/2]).
-
 -export([adhoc_local_commands/4,
          adhoc_sm_commands/4,
          anonymous_purge_hook/3,

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -84,9 +84,9 @@
          roster_push/3,
          roster_set/4]).
 
--export([is_muc_room_owner/3,
+-export([is_muc_room_owner/4,
          can_access_identity/3,
-         can_access_room/3,
+         can_access_room/4,
          get_room_affiliations/2]).
 
 -export([mam_archive_id/2,
@@ -873,13 +873,14 @@ roster_set(HostType, From, To, SubEl) ->
 %%% `Acc', `Room', `User'.
 %%% The arguments and the return value types correspond to the
 %%% following spec.
--spec is_muc_room_owner(HostType, Room, User) -> Result when
+-spec is_muc_room_owner(HostType, Acc, Room, User) -> Result when
       HostType :: mongooseim:host_type(),
+      Acc :: mongoose_acc:t(),
       Room :: jid:jid(),
       User :: jid:jid(),
       Result :: boolean().
-is_muc_room_owner(HostType, Room, User) ->
-    run_hook_for_host_type(is_muc_room_owner, HostType, false, [HostType, Room, User]).
+is_muc_room_owner(HostType, Acc, Room, User) ->
+    run_hook_for_host_type(is_muc_room_owner, HostType, false, [Acc, Room, User]).
 
 %%% @doc The `can_access_identity' hook is called to determine if
 %%% a given user can see the real identity of the people in a room.
@@ -893,13 +894,14 @@ can_access_identity(HostType, Room, User) ->
 
 %%% @doc The `can_access_room' hook is called to determine
 %%% if a given user can access a room.
--spec can_access_room(HostType, Room, User) -> Result when
+-spec can_access_room(HostType, Acc, Room, User) -> Result when
       HostType :: mongooseim:host_type(),
+      Acc :: mongoose_acc:t(),
       Room :: jid:jid(),
       User :: jid:jid(),
       Result :: boolean().
-can_access_room(HostType, Room, User) ->
-    run_hook_for_host_type(can_access_room, HostType, false, [HostType, Room, User]).
+can_access_room(HostType, Acc, Room, User) ->
+    run_hook_for_host_type(can_access_room, HostType, false, [Acc, Room, User]).
 
 -spec get_room_affiliations(Acc, Room) -> Result when
       Acc :: mongoose_acc:t(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -9,7 +9,7 @@
 -include("mod_privacy.hrl").
 -include("mongoose.hrl").
 
--ignore_xref([get_room_affiliations/2]).
+-ignore_xref([acc_room_affiliations/2]).
 
 -export([adhoc_local_commands/4,
          adhoc_sm_commands/4,
@@ -87,7 +87,7 @@
 -export([is_muc_room_owner/4,
          can_access_identity/3,
          can_access_room/4,
-         get_room_affiliations/2]).
+         acc_room_affiliations/2]).
 
 -export([mam_archive_id/2,
          mam_archive_size/3,
@@ -903,13 +903,13 @@ can_access_identity(HostType, Room, User) ->
 can_access_room(HostType, Acc, Room, User) ->
     run_hook_for_host_type(can_access_room, HostType, false, [Acc, Room, User]).
 
--spec get_room_affiliations(Acc, Room) -> Result when
+-spec acc_room_affiliations(Acc, Room) -> NewAcc when
       Acc :: mongoose_acc:t(),
       Room :: jid:jid(),
-      Result :: {mongoose_acc:t(), term()}.
-get_room_affiliations(Acc, Room) ->
+      NewAcc :: mongoose_acc:t().
+acc_room_affiliations(Acc, Room) ->
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(get_room_affiliations, HostType, Acc, [Room]).
+    run_hook_for_host_type(acc_room_affiliations, HostType, Acc, [Room]).
 
 %% MAM related hooks
 

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -499,7 +499,7 @@ acc_room_affiliations(Acc1, Room) ->
                 {error, not_exists} ->
                     Acc1;
                 {ok, _Affs, _Version} = Res ->
-                    mongoose_acc:set_permanent(?MODULE, affiliations, Res, Acc1)
+                    mongoose_acc:set(?MODULE, affiliations, Res, Acc1)
             end;
         _Affs ->
             Acc1

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -53,8 +53,8 @@
          is_muc_room_owner/4,
          can_access_room/4,
          acc_room_affiliations/2,
-         get_room_affiliations_from_acc/2,
          can_access_identity/4]).
+-export([get_room_affiliations_from_acc/1]).
 
 %% For propEr
 -export([apply_rsm/3]).
@@ -504,6 +504,11 @@ acc_room_affiliations(Acc1, Room) ->
         _Affs ->
             Acc1
     end.
+
+-spec get_room_affiliations_from_acc(mongoose_acc:t()) ->
+    {ok, aff_users(), binary()} | {error, not_exists}.
+get_room_affiliations_from_acc(Acc) ->
+    mongoose_acc:get(?MODULE, affiliations, {error, not_exists}, Acc).
 
 -spec get_room_affiliations_from_acc(mongoose_acc:t(), jid:jid()) ->
     {mongoose_acc:t(), {ok, aff_users(), binary()} | {error, not_exists}}.

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -52,7 +52,8 @@
          process_iq_set/4,
          is_muc_room_owner/4,
          can_access_room/4,
-         get_room_affiliations/2,
+         acc_room_affiliations/2,
+         get_room_affiliations_from_acc/2,
          can_access_identity/4]).
 
 %% For propEr
@@ -68,7 +69,7 @@
 
 -ignore_xref([
     add_rooms_to_roster/2, apply_rsm/3, can_access_identity/4, can_access_room/4,
-    default_schema/0, disco_local_items/1,
+    default_schema/0, disco_local_items/1, acc_room_affiliations/2,
     force_clear_from_ct/1, is_muc_room_owner/4, prevent_service_unavailable/4,
     process_iq_get/5, process_iq_set/4, remove_domain/3, remove_user/3,
     server_host_to_muc_host/2
@@ -147,7 +148,7 @@ try_to_create_room(CreatorJid, RoomJID, #create{raw_config = RawConfig} = Creati
     | {error, validation_error() | bad_request | not_allowed}.
 change_room_config(UserJid, RoomID, MUCLightDomain, ConfigReq, Acc1) ->
     RoomJID = jid:make(RoomID, MUCLightDomain, <<>>),
-    {Acc2, AffUsersRes} = get_room_affiliations(Acc1, RoomJID),
+    {Acc2, AffUsersRes} = get_room_affiliations_from_acc(Acc1, RoomJID),
     case mod_muc_light_room:process_request(UserJid, RoomJID, {set, ConfigReq}, AffUsersRes, Acc2) of
         {set, ConfigResp, _} ->
             {ok, RoomJID, ConfigResp};
@@ -258,7 +259,7 @@ hooks(HostType) ->
     Roster = gen_mod:get_module_opt(HostType, ?MODULE, rooms_in_rosters, ?DEFAULT_ROOMS_IN_ROSTERS),
     [{is_muc_room_owner, HostType, ?MODULE, is_muc_room_owner, 50},
      {can_access_room, HostType, ?MODULE, can_access_room, 50},
-     {get_room_affiliations, HostType, ?MODULE, get_room_affiliations, 50},
+     {acc_room_affiliations, HostType, ?MODULE, acc_room_affiliations, 50},
      {can_access_identity, HostType, ?MODULE, can_access_identity, 50},
       %% Prevent sending service-unavailable on groupchat messages
      {offline_groupchat_message_hook, HostType, ?MODULE, prevent_service_unavailable, 90},
@@ -489,23 +490,26 @@ can_access_room(true, _Acc, _Room, _User) ->
 can_access_room(_, Acc, Room, User) ->
     none =/= get_affiliation(Acc, Room, User).
 
--spec get_room_affiliations(mongoose_acc:t(), jid:jid()) ->
-    {mongoose_acc:t(), {ok, aff_users(), binary()} | {error, not_exists}}.
-get_room_affiliations(Acc1, Room) ->
-    case mongoose_acc:get(?MODULE, affiliations, undefined, Acc1) of
-        undefined ->
+-spec acc_room_affiliations(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
+acc_room_affiliations(Acc1, Room) ->
+    case mongoose_acc:get(?MODULE, affiliations, {error, not_exists}, Acc1) of
+        {error, _} ->
             HostType = mongoose_acc:host_type(Acc1),
             case mod_muc_light_db_backend:get_aff_users(HostType, jid:to_lus(Room)) of
                 {error, not_exists} ->
-                    Acc2 = mongoose_acc:set(?MODULE, affiliations, {error, not_exists}, Acc1),
-                    {Acc2, {error, not_exists}};
+                    Acc1;
                 {ok, _Affs, _Version} = Res ->
-                    Acc2 = mongoose_acc:set_permanent(?MODULE, affiliations, Res, Acc1),
-                    {Acc2, Res}
+                    mongoose_acc:set_permanent(?MODULE, affiliations, Res, Acc1)
             end;
-        Affs ->
-            {Acc1, Affs}
+        _Affs ->
+            Acc1
     end.
+
+-spec get_room_affiliations_from_acc(mongoose_acc:t(), jid:jid()) ->
+    {mongoose_acc:t(), {ok, aff_users(), binary()} | {error, not_exists}}.
+get_room_affiliations_from_acc(Acc1, RoomJid) ->
+    Acc2 = acc_room_affiliations(Acc1, RoomJid),
+    {Acc2, mongoose_acc:get(?MODULE, affiliations, {error, not_exists}, Acc2)}.
 
 -spec can_access_identity(Acc :: boolean(), HostType :: mongooseim:host_type(),
                           Room :: jid:jid(), User :: jid:jid()) ->
@@ -542,7 +546,7 @@ max_occupants(HostType) ->
     gen_mod:get_module_opt(HostType, ?MODULE, max_occupants, ?DEFAULT_MAX_OCCUPANTS).
 
 get_affiliation(Acc, Room, User) ->
-    case get_room_affiliations(Acc, Room) of
+    case get_room_affiliations_from_acc(Acc, Room) of
         {_, {ok, AffUsers, _}} ->
             case lists:keyfind(jid:to_lus(User), 1, AffUsers) of
                 {_, Aff} -> Aff;

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -54,7 +54,8 @@
 -spec handle_request(From :: jid:jid(), RoomJID :: jid:jid(), OrigPacket :: exml:element(),
                      Request :: muc_light_packet(), Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_request(From, Room, OrigPacket, Request, Acc1) ->
-    {Acc2, AffUsersRes} = mod_muc_light:get_room_affiliations_from_acc(Acc1, Room),
+    Acc2 = mongoose_hooks:acc_room_affiliations(Acc1, Room),
+    AffUsersRes = mod_muc_light:get_room_affiliations_from_acc(Acc2),
     Response = process_request(From, Room, Request, AffUsersRes, Acc2),
     send_response(From, Room, OrigPacket, Response, Acc2).
 

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -54,7 +54,7 @@
 -spec handle_request(From :: jid:jid(), RoomJID :: jid:jid(), OrigPacket :: exml:element(),
                      Request :: muc_light_packet(), Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 handle_request(From, Room, OrigPacket, Request, Acc1) ->
-    {Acc2, AffUsersRes} = mod_muc_light:get_room_affiliations(Acc1, Room),
+    {Acc2, AffUsersRes} = mod_muc_light:get_room_affiliations_from_acc(Acc1, Room),
     Response = process_request(From, Room, Request, AffUsersRes, Acc2),
     send_response(From, Room, OrigPacket, Response, Acc2).
 


### PR DESCRIPTION
This allows to have the accumulator in hooks like is_muc_room_owner and
can_access_room, so that if affiliations where already fetched, they
will be present in the accumulator, and we then move forwards in
preserving the consistency of a message processing pipeline: we want to
avoid the case when, during this pipeline, a subsystem fetches the
affiliations, take some action, and before the next subsystem acts, a
concurrent process modifies the affiliations: then the following
subsystem may find out that the user has been removed from the room and
reject the request, therefore getting into an inconsistent state.

This also helps preventing more duplicate, and usually idempotent, DB
queries.

This also gives more fine-grained control over other new handlers to this hook that I can implement, where information stored in the accumulator can provide more powerful decisions 😉