### PR TITLE
Add an option to format a section/list as a map

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -92,7 +92,7 @@ init_per_group(change_account_details, Config) ->
     [{escalus_user_db,  {module, escalus_ejabberd}} |Config];
 init_per_group(change_account_details_store_plain, Config) ->
     AuthOpts = mongoose_helper:auth_opts_with_password_format(plain),
-    Config1 = mongoose_helper:backup_and_set_config_option(Config, auth_opts, AuthOpts),
+    Config1 = mongoose_helper:backup_and_set_config_option(Config, auth, AuthOpts),
     [{escalus_user_db,  {module, escalus_ejabberd}} |Config1];
 init_per_group(registration_timeout, Config) ->
     set_registration_timeout(Config);
@@ -100,8 +100,7 @@ init_per_group(utilities, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob]));
 init_per_group(users_number_estimate, Config) ->
     AuthOpts = get_auth_opts(),
-    Key = rdbms_users_number_estimate,
-    NewAuthOpts = lists:keystore(Key, 1, AuthOpts, {Key, true}),
+    NewAuthOpts = AuthOpts#{rdbms => #{users_number_estimate => true}},
     set_auth_opts(Config, NewAuthOpts);
 init_per_group(_GroupName, Config) ->
     Config.
@@ -125,12 +124,11 @@ end_per_group(_GroupName, Config) ->
     Config.
 
 get_auth_opts() ->
-    rpc(mim(), mongoose_config, get_opt, [{auth_opts, host_type()}]).
+    rpc(mim(), mongoose_config, get_opt, [{auth, host_type()}]).
 
 set_auth_opts(Config, AuthOpts) ->
     rpc(mim(), ejabberd_auth, stop, [host_type()]),
-    Config1 = mongoose_helper:backup_and_set_config_option(Config, {auth_opts, host_type()},
-                                                           AuthOpts),
+    Config1 = mongoose_helper:backup_and_set_config_option(Config, {auth, host_type()}, AuthOpts),
     rpc(mim(), ejabberd_auth, start, [host_type()]),
     Config1.
 

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -165,16 +165,15 @@ init_per_group(GroupName, ConfigIn) ->
     escalus:create_users(Config, escalus:get_users([alice, bob])).
 
 backup_and_set_options(GroupName, Config) ->
-    Options = config_options(GroupName),
-    mongoose_helper:backup_and_set_config(Config, Options).
+    mongoose_helper:backup_and_set_config_option(Config, {auth, host_type()}, auth_opts(GroupName)).
 
-config_options(login_digest) ->
-    #{{auth_opts, host_type()} => mongoose_helper:auth_opts_with_password_format(plain),
-      {sasl_mechanisms, host_type()} => [cyrsasl_digest]};
-config_options(login_scram_store_plain) ->
-    #{{auth_opts, host_type()} => mongoose_helper:auth_opts_with_password_format(plain)};
-config_options(_GroupName) ->
-    #{{auth_opts, host_type()} => mongoose_helper:auth_opts_with_password_format(scram)}.
+auth_opts(login_digest) ->
+    AuthOpts = mongoose_helper:auth_opts_with_password_format(plain),
+    AuthOpts#{sasl_mechanisms => [cyrsasl_digest]};
+auth_opts(login_scram_store_plain) ->
+    mongoose_helper:auth_opts_with_password_format(plain);
+auth_opts(_GroupName) ->
+    mongoose_helper:auth_opts_with_password_format(scram).
 
 end_per_group(login_digest, Config) ->
     mongoose_helper:restore_config(Config),
@@ -481,7 +480,7 @@ configure_scram_plus_and_fail_log_scram(Config, Sha, Mech) ->
 
 set_scram_sha(Config, Sha) ->
     NewAuthOpts = mongoose_helper:auth_opts_with_password_format({scram, [Sha]}),
-    mongoose_helper:change_config_option(Config, {auth_opts, host_type()}, NewAuthOpts),
+    mongoose_helper:change_config_option(Config, {auth, host_type()}, NewAuthOpts),
     assert_password_format({scram, Sha}, Config).
 
 fail_log_one(Config) ->

--- a/big_tests/tests/metrics_register_SUITE.erl
+++ b/big_tests/tests/metrics_register_SUITE.erl
@@ -67,10 +67,10 @@ init_per_testcase(unregister, Config) ->
     escalus_users:create_user(Config, Alice),
     Config;
 init_per_testcase(registered_users, Config) ->
-    case rpc(mim(), mongoose_config, lookup_opt, [{auth_method, host_type()}]) of
-        {ok, external} ->
+    case rpc(mim(), mongoose_config, get_opt, [[{auth, host_type()}, methods], []]) of
+        [external] ->
             {skip, "counter not supported with ejabberd_auth_external"};
-        {ok, anonymous} ->
+        [anonymous] ->
             {skip, "counter not supported with anonymous authentication"};
         _ ->
             Config

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -472,14 +472,13 @@ supports_sasl_module(Module) ->
 
 auth_opts_with_password_format(Type) ->
     HostType = domain_helper:host_type(mim),
-    AuthOpts = rpc(mim(), mongoose_config, get_opt, [{auth_opts, HostType}]),
+    AuthOpts = rpc(mim(), mongoose_config, get_opt, [{auth, HostType}]),
     build_new_auth_opts(Type, AuthOpts).
 
 build_new_auth_opts(scram, AuthOpts) ->
-    NewAuthOpts0 = lists:keystore(password_format, 1, AuthOpts, {password_format, scram}),
-    lists:keystore(scram_iterations, 1, NewAuthOpts0, {scram_iterations, 64});
+    AuthOpts#{password_format => scram, scram_iterations => 64};
 build_new_auth_opts(Type, AuthOpts) ->
-    lists:keystore(password_format, 1, AuthOpts, {password_format, Type}).
+    AuthOpts#{password_format => Type}.
 
 get_listener_opts(#{} = Spec, Port) ->
     Listeners = rpc(Spec, mongoose_config, get_opt, [listen]),

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -293,7 +293,7 @@ init_per_testcase(check_password_hash, Config) ->
             {skip, not_fully_supported_with_ldap};
         false ->
             AuthOpts = mongoose_helper:auth_opts_with_password_format(plain),
-            Config1 = mongoose_helper:backup_and_set_config_option(Config, {auth_opts, host_type()},
+            Config1 = mongoose_helper:backup_and_set_config_option(Config, {auth, host_type()},
                                                                    AuthOpts),
             Config2 = escalus:create_users(Config1, escalus:get_users([carol])),
             escalus:init_per_testcase(check_password_hash, Config2)

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -115,7 +115,7 @@ init_per_group(GroupName, Config0) ->
              end,
     AuthOpts = mongoose_helper:auth_opts_with_password_format(password_format(GroupName)),
     HostType = domain_helper:host_type(),
-    Config1 = mongoose_helper:backup_and_set_config_option(Config, {auth_opts, HostType}, AuthOpts),
+    Config1 = mongoose_helper:backup_and_set_config_option(Config, {auth, HostType}, AuthOpts),
     Config2 = escalus:create_users(Config1, escalus:get_users([bob, alice])),
     assert_password_format(GroupName, Config2).
 

--- a/big_tests/tests/shared_roster_SUITE.erl
+++ b/big_tests/tests/shared_roster_SUITE.erl
@@ -165,7 +165,7 @@ stop_roster_module(_) ->
 
 get_auth_method() ->
     XMPPDomain = domain(),
-    case rpc(mim(), mongoose_config, get_opt, [{auth_method, XMPPDomain}]) of
+    case rpc(mim(), mongoose_config, get_opt, [[{auth, XMPPDomain}, methods], []]) of
         [Method|_] ->
             Method;
         _ ->

--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -456,7 +456,7 @@ configure_mod_vcard(Config) ->
 ldap_opts() ->
     [{backend,ldap}, {host, subhost_pattern("vjud.@HOST@")},
      {ldap_uids, [{<<"uid">>}]}, %% equivalent to {<<"uid">>, <<"%u">>}
-     {ldap_filter,"(objectClass=inetOrgPerson)"},
+     {ldap_filter,<<"(objectClass=inetOrgPerson)">>},
      {ldap_base,"ou=Users,dc=esl,dc=com"},
      {ldap_search_fields, [{"Full Name","cn"},{"User","uid"}]},
      {ldap_vcard_map,[{"FN","%s",["cn"]}]}].

--- a/doc/authentication-methods/dummy.md
+++ b/doc/authentication-methods/dummy.md
@@ -16,13 +16,13 @@ where `Base` is `base_time` and `Variance` is `variance`, as configured below.
 
 ### `auth.dummy.base_time`
 * **Scope:** local
-* **Syntax:** integer
+* **Syntax:** non-negative integer
 * **Default:** 50
 * **Example:** `base_time = 5`
 
 ### `auth.dummy.variance`
 * **Scope:** local
-* **Syntax:** integer
+* **Syntax:** positive integer
 * **Default:** 450
 * **Example:** `variance = 10`
 
@@ -34,4 +34,3 @@ where `Base` is `base_time` and `Variance` is `variance`, as configured below.
   dummy.base = 5
   dummy.variance = 10
 ```
-

--- a/doc/configuration/host_config.md
+++ b/doc/configuration/host_config.md
@@ -59,30 +59,12 @@ The `replaced_wait_timeout` option is set to `2000` only for `domain2.com`.
 
 ### `host_config.auth`
 
-This section overrides the top-level [`auth`](auth.md) section, all options are allowed.
-It is recommended to repeat all top-level options in the domain-specific section as the rule is quite complicated:
-
-- If you specify any of the following options, **all** of the following options will be overridden:
-    - [`sasl_external`](auth.md#authsasl_external)
-    - [`password.*`](auth.md#password-related-options)
-    - [`scram_iterations`](auth.md#authscram_iterations)
-    - [`external.program`](../authentication-methods/external.md#authexternalprogram)
-    - [`rdbms.*`](../authentication-methods/rdbms.md)
-    - [`ldap.*`](../authentication-methods/ldap.md)
-    - [`jwt.*`](../authentication-methods/jwt.md)
-    - [`riak.*`](../authentication-methods/riak.md)
-    - [`http.*`](../authentication-methods/http.md)
-- If you specify any of the following options, only these options will be overridden:
-    - [`methods`](auth.md#authmethods)
-    - [`sasl_mechanisms`](auth.md#authsasl_mechanisms)
-    - [`external.instances`](../authentication-methods/external.md#authexternalinstances)
-    - [`anonymous.*`](../authentication-methods/anonymous.md)
+This section completely overrides the top-level [`auth`](auth.md) section, all options are allowed.
 
 #### Example
 
 In the example below the number of `scram_iterations` is increased for `domain2`.
-It is necessary to put the `password.hash` there as well, as otherwise it would be replaced with the default setting.
-However, specifying `methods` is not necessary as this value will not be changed.
+It is necessary to put `methods` and `password.hash` and there as well, as otherwise they would not be set for `domain2`.
 
 ```toml
 [general]
@@ -97,14 +79,6 @@ However, specifying `methods` is not necessary as this value will not be changed
 
   [host_config.auth]
     methods = ["rdbms"]
-    password.hash = ["sha256"]
-    scram_iterations = 40_000
-```
-
-The last section would work the same without `methods`:
-
-```toml
-  [host_config.auth]
     password.hash = ["sha256"]
     scram_iterations = 40_000
 ```
@@ -223,7 +197,7 @@ The options defined here override the ones defined in the top-level [`s2s`](s2s.
 The following options are allowed:
 
 * [`default_policy`](s2s.md#s2sdefault_policy)
-* [`host_policy`](s2s.md#s2shost_policy) - overrides the top-level setting host by host
+* [`host_policy`](s2s.md#s2shost_policy)
 * [`shared`](s2s.md#s2sshared)
 * [`max_retry_delay`](s2s.md#s2smax_retry_delay)
 
@@ -251,16 +225,6 @@ The `host_policy` option is changed for `domain2.com`:
       {host = "bad-xmpp.org", policy = "allow"},
       {host = "evil-xmpp.org", policy = "deny"}
     ]
-```
-
-The resulting `host_policy` for `domain2.com` is the following:
-
-```toml
-host_policy = [
-  {host = "good-xmpp.org", policy = "allow"},
-  {host = "bad-xmpp.org", policy = "allow"},
-  {host = "evil-xmpp.org", policy = "deny"}
-]
 ```
 
 The `default_policy` is still `deny`.

--- a/doc/configuration/s2s.md
+++ b/doc/configuration/s2s.md
@@ -94,7 +94,7 @@ The options listed below affect only the outgoing S2S connections.
     * `host` - string, mandatory, host name
     * `ip_address` - string, mandatory, IP address
     * `port` - integer, optional, port number
-* **Default:** `"allow"`
+* **Default:** not set
 * **Example:**
 
 ```toml

--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -6,6 +6,7 @@
                   validate_keys = any :: mongoose_config_validator:validator(),
                   required = [] :: [mongoose_config_parser_toml:toml_key()] | all,
                   validate = any :: mongoose_config_validator:section_validator(),
+                  format_items = none :: mongoose_config_spec:format_items(),
                   process :: undefined | mongoose_config_parser_toml:list_processor(),
                   format = default :: mongoose_config_spec:format(),
                   defaults = #{} :: #{mongoose_config_parser_toml:toml_key() =>
@@ -13,6 +14,7 @@
 
 -record(list, {items :: mongoose_config_spec:config_node(),
                validate = any :: mongoose_config_validator:list_validator(),
+               format_items = none :: mongoose_config_spec:format_items(),
                process :: undefined | mongoose_config_parser_toml:list_processor(),
                format = default :: mongoose_config_spec:format()}).
 

--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -8,7 +8,7 @@
                   validate = any :: mongoose_config_validator:section_validator(),
                   format_items = none :: mongoose_config_spec:format_items(),
                   process :: undefined | mongoose_config_parser_toml:list_processor(),
-                  format = default :: mongoose_config_spec:format(),
+                  wrap = default :: mongoose_config_spec:wrapper(),
                   defaults = #{} :: #{mongoose_config_parser_toml:toml_key() =>
                                          mongoose_config_parser_toml:config_part()}}).
 
@@ -16,11 +16,11 @@
                validate = any :: mongoose_config_validator:list_validator(),
                format_items = none :: mongoose_config_spec:format_items(),
                process :: undefined | mongoose_config_parser_toml:list_processor(),
-               format = default :: mongoose_config_spec:format()}).
+               wrap = default :: mongoose_config_spec:wrapper()}).
 
 -record(option, {type :: mongoose_config_spec:option_type(),
                  validate = any :: mongoose_config_validator:validator(),
                  process :: undefined | mongoose_config_parser_toml:processor(),
-                 format = default :: mongoose_config_spec:format()}).
+                 wrap = default :: mongoose_config_spec:wrapper()}).
 
 -endif.

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -29,8 +29,6 @@
 -export([start/0,
          start/1,
          stop/1,
-         get_opt/3,
-         get_opt/2,
          authorize/1,
          set_password/2,
          check_password/2,
@@ -119,25 +117,6 @@ hooks(HostType) ->
      %% It is important that this handler happens _before_ all other modules
      {remove_domain, HostType, ?MODULE, remove_domain, 10}
     ].
-
--spec get_opt(HostType :: mongooseim:host_type(),
-              Opt :: atom(),
-              Default :: ejabberd:value()) -> undefined | ejabberd:value().
-get_opt(HostType, Opt, Default) ->
-    case mongoose_config:lookup_opt({auth_opts, HostType}) of
-        {error, not_found} ->
-            Default;
-        {ok, Opts} ->
-            case lists:keyfind(Opt, 1, Opts) of
-                {Opt, Value} ->
-                    Value;
-                false ->
-                    Default
-            end
-    end.
-
-get_opt(HostType, Opt) ->
-    get_opt(HostType, Opt, undefined).
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(HostType, SASLModule) ->
@@ -433,7 +412,7 @@ auth_modules_for_host_type(HostType) ->
 
 -spec auth_methods(mongooseim:host_type()) -> [atom()].
 auth_methods(HostType) ->
-    mongoose_config:get_opt({auth_method, HostType}, []).
+    mongoose_config:get_opt([{auth, HostType}, methods], []).
 
 -spec auth_method_to_module(atom()) -> authmodule().
 auth_method_to_module(Method) ->

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -86,7 +86,7 @@ stop(HostType) ->
 %% defaults to false
 -spec allow_multiple_connections(mongooseim:host_type()) -> boolean().
 allow_multiple_connections(HostType) ->
-    mongoose_config:get_opt({allow_multiple_connections, HostType}, false).
+    mongoose_config:get_opt([{auth, HostType}, anonymous, allow_multiple_connections], false).
 
 does_user_exist(_, LUser, LServer) ->
     does_anonymous_user_exist(LUser, LServer).
@@ -274,7 +274,7 @@ is_protocol_enabled(HostType, Protocol) ->
 %% @doc Returns the anonymous protocol to use, defaults to sasl_anon
 -spec anonymous_protocol(mongooseim:host_type()) -> sasl_anon | login_anon | both.
 anonymous_protocol(HostType) ->
-    mongoose_config:get_opt({anonymous_protocol, HostType}, sasl_anon).
+    mongoose_config:get_opt([{auth, HostType}, anonymous, protocol], sasl_anon).
 
 -spec supported_features() -> [atom()].
 supported_features() -> [dynamic_domains].

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -39,8 +39,9 @@ stop(_HostType) ->
 
 authorize(Creds) ->
     HostType = mongoose_credentials:host_type(Creds),
-    Base = ejabberd_auth:get_opt(HostType, dummy_base_timeout, 50),
-    Variance = ejabberd_auth:get_opt(HostType, dummy_variance, 450),
+    Opts = mongoose_config:get_opt([{auth, HostType}, dummy], #{}),
+    Base = maps:get(base_time, Opts, 50),
+    Variance = maps:get(variance, Opts, 450),
     timer:sleep(Base + rand:uniform(Variance)),
     {ok, mongoose_credentials:set(Creds, auth_module, ?MODULE)}.
 

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -56,8 +56,8 @@
 
 -spec start(HostType :: mongooseim:host_type()) -> 'ok'.
 start(HostType) ->
-    ExtauthProgram = ejabberd_auth:get_opt(HostType, extauth_program),
-    extauth:start(HostType, ExtauthProgram),
+    Program = mongoose_config:get_opt([{auth, HostType}, external, program]),
+    extauth:start(HostType, Program),
     case check_cache_last_options(HostType) of
         cache ->
             ok = ejabberd_auth_internal:start(HostType);

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -190,10 +190,10 @@ make_req(Method, Path, Params = #{luser := LUser, lserver := LServer, host_type 
     Query = uri_string:compose_query([{<<"user">>, LUser},
                                       {<<"server">>, LServer},
                                       {<<"pass">>, Password}]),
-    Header = case ejabberd_auth:get_opt(HostType, basic_auth) of
-                 undefined ->
+    Header = case mongoose_config:lookup_opt([{auth, HostType}, http, basic_auth]) of
+                 {error, not_found} ->
                      [];
-                 BasicAuth ->
+                 {ok, BasicAuth} ->
                      BasicAuth64 = base64:encode(BasicAuth),
                      [{<<"Authorization">>, <<"Basic ", BasicAuth64/binary>>}]
              end,

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -431,7 +431,7 @@ prepare_queries(HostType) ->
             <<"DELETE FROM users WHERE server = ?">>).
 
 prepare_count_users(HostType) ->
-    case {ejabberd_auth:get_opt(HostType, rdbms_users_number_estimate),
+    case {mongoose_config:get_opt([{auth, HostType}, rdbms, users_number_estimate], false),
           mongoose_rdbms:db_engine(HostType)} of
         {true, mysql} ->
             prepare(auth_count_users_estimate, 'information_schema.tables', [],
@@ -502,7 +502,7 @@ execute_count_users(HostType, LServer, #{prefix := Prefix}) ->
     Args = [LServer, prefix_to_like(Prefix)],
     execute_successfully(HostType, auth_count_users_prefix, Args);
 execute_count_users(HostType, LServer, #{}) ->
-    case {ejabberd_auth:get_opt(LServer, rdbms_users_number_estimate),
+    case {mongoose_config:get_opt([{auth, HostType}, rdbms, users_number_estimate], false),
           mongoose_rdbms:db_engine(LServer)} of
         {true, mysql} ->
             execute_successfully(HostType, auth_count_users_estimate, []);

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -172,7 +172,7 @@ remove_user(HostType, LUser, LServer) ->
 
 -spec bucket_type(mongooseim:host_type(), jid:lserver()) -> {binary(), jid:lserver()}.
 bucket_type(HostType, LServer) ->
-    BucketType = ejabberd_auth:get_opt(HostType, bucket_type, <<"users">>),
+    BucketType = mongoose_config:get_opt([{auth, HostType}, riak, bucket_type], <<"users">>),
     {BucketType, LServer}.
 
 %% -----------------------------------------------------------------------------

--- a/src/auth/extauth.erl
+++ b/src/auth/extauth.erl
@@ -131,7 +131,7 @@ random_instance(MaxNum) ->
 
 -spec get_instances(mongooseim:host_type()) -> integer().
 get_instances(HostType) ->
-    mongoose_config:get_opt({extauth_instances, HostType}, 1).
+    mongoose_config:get_opt([{auth, HostType}, external, instances], 1).
 
 
 -spec loop(port(), integer(), atom(), any()) -> no_return().

--- a/src/config/mongoose_config.erl
+++ b/src/config/mongoose_config.erl
@@ -20,19 +20,17 @@
 
 -include("mongoose.hrl").
 
--type key() :: atom() | host_type_key() | host_type_or_global_key().
--type s2s_domain_key() :: {atom(), jid:lserver()}.
--type host_type_key() :: {atom() | s2s_domain_key(), mongooseim:host_type_or_global()}.
--type host_type_or_global_key() :: {shaper | access | acl, atom(), mongooseim:host_type_or_global()}.
+-type key() :: atom() | host_type_key() | tagged_host_type_key().
+-type host_type_key() :: {atom(), mongooseim:host_type_or_global()}.
+-type tagged_host_type_key() :: {shaper | access | acl, atom(), mongooseim:host_type_or_global()}.
 
--type value() :: atom()
-               | binary()
-               | integer()
-               | string()
-               | [value()]
-               | tuple().
+%% Top-level key() followed by inner_key() for each of the nested maps
+-type key_path() :: [key() | inner_key()].
+-type inner_key() :: atom() | binary() | integer() | string() | tuple().
 
--export_type([key/0, value/0]).
+-type value() :: atom() | binary() | integer() | string() | [value()] | tuple() | map().
+
+-export_type([key/0, key_path/0, value/0]).
 
 -spec start() -> ok.
 start() ->

--- a/src/config/mongoose_config.erl
+++ b/src/config/mongoose_config.erl
@@ -5,8 +5,8 @@
          stop/0,
          get_config_path/0,
          lookup_opt/1,
-         get_opt/1,
-         get_opt/2]).
+         get_opt/2,
+         get_opt/1]).
 
 %% Test API, do not use outside of test suites, options set here are not cleaned up by stop/0
 -export([set_opt/2,
@@ -84,22 +84,32 @@ unset_opt(Key) ->
     persistent_term:erase({?MODULE, Key}).
 
 %% @doc Use instead of get_opt(Key, undefined)
--spec lookup_opt(key()) -> {ok, value()} | {error, not_found}.
+-spec lookup_opt(key() | key_path()) -> {ok, value()} | {error, not_found}.
 lookup_opt(Key) ->
-    try persistent_term:get({?MODULE, Key}) of
+    try get_opt(Key) of
         Value -> {ok, Value}
     catch
-        error:_ -> {error, not_found}
+        error:badarg -> {error, not_found}; % missing persistent term
+        error:{badkey, _} -> {error, not_found} % missing map key
+    end.
+
+% @doc Returns Default if the option does not exist
+-spec get_opt(key() | key_path(), value()) -> value().
+get_opt(Key, Default) ->
+    try
+        get_opt(Key)
+    catch
+        error:badarg -> Default; % missing persistent term
+        error:{badkey, _} -> Default % missing map key
     end.
 
 %% @doc Fails if the option does not exist
--spec get_opt(key()) -> value().
+-spec get_opt(key() | key_path()) -> value().
+get_opt([Key | Rest]) ->
+    Config = persistent_term:get({?MODULE, Key}),
+    lists:foldl(fun maps:get/2, Config, Rest);
 get_opt(Key) ->
     persistent_term:get({?MODULE, Key}).
-
--spec get_opt(key(), value()) -> value().
-get_opt(Key, Default) ->
-    persistent_term:get({?MODULE, Key}, Default).
 
 -spec config_state() -> mongoose_config_parser:state().
 config_state() ->

--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -195,12 +195,12 @@ invalid_modules_for_host_type(HostType, Modules) ->
             end,
     lists:map(MapFN, Modules).
 
-maybe_check_auth_methods_for_host_types({{auth_method, HostOrHostType}, ListOfMethods},
+maybe_check_auth_methods_for_host_types({{auth, HostOrHostType}, #{methods := Methods}},
                                         HostTypes) ->
     case lists:member(HostOrHostType, HostTypes) of
         false -> [];
         true ->
-            BadModules = check_auth_methods_for_host_type(ListOfMethods),
+            BadModules = check_auth_methods_for_host_type(Methods),
             invalid_auth_methods_for_host_type(HostOrHostType, BadModules)
     end;
 maybe_check_auth_methods_for_host_types(_, _) -> [].

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -228,10 +228,6 @@ format_spec(#list{format = Format}) -> Format;
 format_spec(#option{format = Format}) -> Format.
 
 -spec format(path(), config_part(), mongoose_config_spec:format()) -> [config_part()].
-format(Path, KVs, {foreach, Format}) when is_atom(Format) ->
-    Keys = lists:map(fun({K, _}) -> K end, KVs),
-    mongoose_config_validator:validate_list(Keys, unique),
-    lists:flatmap(fun({K, V}) -> format(Path, V, {Format, K}) end, KVs);
 format([Key|_] = Path, V, host_config) ->
     format(Path, V, {host_config, b2a(Key)});
 format([Key|_] = Path, V, global_config) ->

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -30,7 +30,18 @@
 -type processor() :: fun((path(), config_part()) -> config_part())
                    | fun((config_part()) -> config_part()).
 
--type step() :: parse | validate | format_items | process | format.
+-type step() ::
+        parse        % Recursive processing (section/list) or type conversion (leaf option)
+
+      | validate     % Value check with one of the predefined validators
+
+      | format_items % Optional formatting of section/list items as a map
+
+      | process      % Optional processing of the value with a custom function
+
+      | wrap.        % Wrapping the value into a list, which will be concatenated
+                     % with other items of the parent node.
+                     % In case of a KV pair the key is also added here.
 
 %% Path from the currently processed config node to the root
 %%   - toml_key(): key in a toml_section()
@@ -124,11 +135,11 @@ parse_list(Path, L, #list{items = ItemSpec}) ->
 
 -spec handle(path(), toml_value(), mongoose_config_spec:config_node()) -> [config_part()].
 handle(Path, Value, Spec) ->
-    handle(Path, Value, Spec, [parse, validate, format_items, process, format]).
+    handle(Path, Value, Spec, [parse, validate, format_items, process, wrap]).
 
 -spec handle_default(path(), toml_value(), mongoose_config_spec:config_node()) -> [config_part()].
 handle_default(Path, Value, Spec) ->
-    handle(Path, Value, Spec, [format]).
+    handle(Path, Value, Spec, [wrap]).
 
 -spec handle(path(), toml_value(), mongoose_config_spec:config_node(), [step()]) -> [config_part()].
 handle(Path, Value, Spec, Steps) ->
@@ -162,8 +173,8 @@ handle_step(validate, _Path, ParsedValue, Spec) ->
     ParsedValue;
 handle_step(process, Path, ParsedValue, Spec) ->
     process(Path, ParsedValue, process_spec(Spec));
-handle_step(format, Path, ProcessedValue, Spec) ->
-    format(Path, ProcessedValue, format_spec(Spec)).
+handle_step(wrap, Path, ProcessedValue, Spec) ->
+    wrap(Path, ProcessedValue, wrap_spec(Spec)).
 
 -spec check_required_keys(mongoose_config_spec:config_section(), toml_section()) -> any().
 check_required_keys(#section{required = all, items = Items}, Section) ->
@@ -222,37 +233,37 @@ convert(V, int_or_atom) -> b2a(V);
 convert(V, integer) when is_integer(V) -> V;
 convert(V, float) when is_float(V) -> V.
 
--spec format_spec(mongoose_config_spec:config_node()) -> mongoose_config_spec:format().
-format_spec(#section{format = Format}) -> Format;
-format_spec(#list{format = Format}) -> Format;
-format_spec(#option{format = Format}) -> Format.
+-spec wrap_spec(mongoose_config_spec:config_node()) -> mongoose_config_spec:wrapper().
+wrap_spec(#section{wrap = Wrap}) -> Wrap;
+wrap_spec(#list{wrap = Wrap}) -> Wrap;
+wrap_spec(#option{wrap = Wrap}) -> Wrap.
 
--spec format(path(), config_part(), mongoose_config_spec:format()) -> [config_part()].
-format([Key|_] = Path, V, host_config) ->
-    format(Path, V, {host_config, b2a(Key)});
-format([Key|_] = Path, V, global_config) ->
-    format(Path, V, {global_config, b2a(Key)});
-format(Path, V, {host_config, Key}) ->
+-spec wrap(path(), config_part(), mongoose_config_spec:wrapper()) -> [config_part()].
+wrap([Key|_] = Path, V, host_config) ->
+    wrap(Path, V, {host_config, b2a(Key)});
+wrap([Key|_] = Path, V, global_config) ->
+    wrap(Path, V, {global_config, b2a(Key)});
+wrap(Path, V, {host_config, Key}) ->
     [{{Key, get_host(Path)}, V}];
-format(Path, V, {global_config, Key}) ->
+wrap(Path, V, {global_config, Key}) ->
     global = get_host(Path),
     [{Key, V}];
-format([Key|_] = Path, V, {host_or_global_config, Tag}) ->
+wrap([Key|_] = Path, V, {host_or_global_config, Tag}) ->
     [{{Tag, b2a(Key), get_host(Path)}, V}];
-format([item|_] = Path, V, default) ->
-    format(Path, V, item);
-format([Key|_] = Path, V, default) ->
-    format(Path, V, {kv, b2a(Key)});
-format(_Path, V, {kv, Key}) ->
+wrap([item|_] = Path, V, default) ->
+    wrap(Path, V, item);
+wrap([Key|_] = Path, V, default) ->
+    wrap(Path, V, {kv, b2a(Key)});
+wrap(_Path, V, {kv, Key}) ->
     [{Key, V}];
-format(_Path, V, item) ->
+wrap(_Path, V, item) ->
     [V];
-format(_Path, _V, skip) ->
+wrap(_Path, _V, remove) ->
     [];
-format([Key|_], V, prepend_key) ->
+wrap([Key|_], V, prepend_key) ->
     L = [b2a(Key) | tuple_to_list(V)],
     [list_to_tuple(L)];
-format(_Path, V, none) when is_list(V) ->
+wrap(_Path, V, none) when is_list(V) ->
     V.
 
 -spec get_host(path()) -> jid:server() | global.
@@ -271,7 +282,7 @@ try_step(Step, Path, Value, Acc, Spec) ->
             BasicFields = #{what => toml_processing_failed,
                             class => error,
                             stacktrace => Stacktrace,
-                            text => error_text(Step),
+                            text => "TOML configuration error: " ++ error_text(Step),
                             toml_path => path_to_string(Path),
                             toml_value => Value},
             ErrorFields = error_fields(Reason),
@@ -279,10 +290,11 @@ try_step(Step, Path, Value, Acc, Spec) ->
     end.
 
 -spec error_text(step()) -> string().
-error_text(parse) -> "Malformed option in the TOML configuration file";
-error_text(validate) -> "Incorrect option value in the TOML configuration file";
-error_text(process) -> "Unable to process a value the TOML configuration file";
-error_text(format) -> "Unable to format an option in the TOML configuration file".
+error_text(parse) -> "Malformed node";
+error_text(validate) -> "Invalid node value";
+error_text(format_items) -> "List or section has invalid key-value pairs";
+error_text(process) -> "Node could not be processed";
+error_text(wrap) -> "Node could not be wrapped in a config option".
 
 -spec error_fields(any()) -> map().
 error_fields(#{what := Reason} = M) -> maps:remove(what, M#{reason => Reason});

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -83,12 +83,17 @@
         default      % {Key, Value} for section items, Value for list items
       | item         % only Value
       | skip         % nothing - the item is ignored
-      | none         % no formatting - Value must be a list and is injected into the parent list
+      | none         % elements of Value are injected into the parent section/list
       | {kv, NewKey :: term()} % {NewKey, Value} - replaces the key with NewKey
       | prepend_key. % {Key, V1, ..., Vn} when Value = {V1, ..., Vn}
 
+%% This option allows to put list/section items in a map
+-type format_items() ::
+        none         % keep the processed items unchanged
+      | map.         % convert the processed items (which have to be a KV list) to a map
+
 -export_type([config_node/0, config_section/0, config_list/0, config_option/0,
-              format/0, option_type/0]).
+              format/0, format_items/0, option_type/0]).
 
 %% Config processing functions are annotated with TOML paths
 %% Path syntax: dotted, like TOML keys with the following additions:

--- a/src/config/mongoose_config_validator.erl
+++ b/src/config/mongoose_config_validator.erl
@@ -27,6 +27,7 @@ validate(V, binary, non_empty) -> validate_non_empty_binary(V);
 validate(V, binary, {module, Prefix}) ->
     validate_module(list_to_atom(atom_to_list(Prefix) ++ "_" ++ binary_to_list(V)));
 validate(V, binary, jid) -> validate_jid(V);
+validate(V, binary, ldap_filter) -> validate_ldap_filter(V);
 validate(V, integer, non_negative) -> validate_non_negative_integer(V);
 validate(V, integer, positive) -> validate_positive_integer(V);
 validate(V, integer, port) -> validate_port(V);
@@ -117,6 +118,9 @@ validate_jid(Jid) ->
         _ ->
             error(#{what => validate_jid_failed, value => Jid})
     end.
+
+validate_ldap_filter(Value) ->
+    {ok, _} = eldap_filter:parse(Value).
 
 validate_domain(Domain) when is_list(Domain) ->
     #jid{luser = <<>>, lresource = <<>>} = jid:from_binary(list_to_binary(Domain)),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -518,7 +518,7 @@ wait_for_feature_before_auth({xmlstreamelement, El}, StateData) ->
         {?NS_TLS, <<"starttls">>} when TLS == true,
                                        TLSEnabled == false,
                                        SockMod == gen_tcp ->
-            TLSOpts = case mongoose_config:lookup_opt({domain_certfile, StateData#state.host_type}) of
+            TLSOpts = case mongoose_config:lookup_opt([domain_certfile, StateData#state.host_type]) of
                           {error, not_found} ->
                               StateData#state.tls_options;
                           {ok, CertFile} ->

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -550,7 +550,7 @@ allow_host(MyServer, S2SHost) ->
     end.
 
 allow_host1(MyHost, S2SHost) ->
-    case mongoose_config:lookup_opt({{s2s_host, S2SHost}, MyHost}) of
+    case mongoose_config:lookup_opt([{s2s_host_policy, MyHost}, S2SHost]) of
         {ok, deny} ->
             false;
         {ok, allow} ->

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -250,8 +250,8 @@ wait_for_feature_request({xmlstreamelement, El}, StateData) ->
                                    TLSEnabled == false,
                                    SockMod == gen_tcp ->
             ?LOG_DEBUG(#{what => s2s_starttls}),
-            Socket = StateData#state.socket,
-            TLSOpts = case mongoose_config:lookup_opt({domain_certfile, StateData#state.server}) of
+            #state{socket = Socket, server = Server} = StateData,
+            TLSOpts = case mongoose_config:lookup_opt([domain_certfile, Server]) of
                           {error, not_found} ->
                               StateData#state.tls_options;
                           {ok, CertFile} ->

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -1188,7 +1188,7 @@ get_addr_list(Server) ->
 %% @doc Get IPs predefined for a given s2s domain in the configuration
 -spec get_predefined_addresses(jid:server()) -> [{inet:ip_address(), inet:port_number()}].
 get_predefined_addresses(Server) ->
-    case mongoose_config:lookup_opt({s2s_addr, Server}) of
+    case mongoose_config:lookup_opt([s2s_address, Server]) of
         {error, not_found} -> [];
         {ok, S2SAddr} -> do_get_predefined_addresses(S2SAddr)
     end.
@@ -1246,7 +1246,7 @@ get_acc_with_new_tls(_, _, Acc) ->
     Acc.
 
 get_tls_opts_with_certfile(StateData) ->
-    case mongoose_config:lookup_opt({domain_certfile, StateData#state.myname}) of
+    case mongoose_config:lookup_opt([domain_certfile, StateData#state.myname]) of
         {error, not_found} ->
             StateData#state.tls_options;
         {ok, CertFile} ->

--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -34,8 +34,6 @@
          make_filter/3,
          get_state/2,
          case_insensitive_match/2,
-         get_mod_opt/2,
-         get_mod_opt/3,
          get_mod_opt/4,
          get_base/1,
          get_deref_aliases/1,
@@ -44,15 +42,13 @@
          get_user_filter/2,
          process_user_filter/2,
          get_search_filter/1,
-         get_dn_filter_with_attrs/1,
          decode_octet_string/3,
          uids_domain_subst/2,
          singleton_value/1,
          maybe_list2b/1,
          maybe_b2list/1]).
 
--ignore_xref([decode_octet_string/3, generate_subfilter/1, get_mod_opt/3,
-              make_filter/2, uids_domain_subst/2]).
+-ignore_xref([decode_octet_string/3, generate_subfilter/1, make_filter/2, uids_domain_subst/2]).
 
 -include("mongoose.hrl").
 -include("eldap.hrl").
@@ -225,14 +221,6 @@ uids_domain_subst(Host, UIDs) ->
               end,
               UIDs).
 
--spec get_mod_opt(atom(), list()) -> any().
-get_mod_opt(Key, Opts) ->
-    get_mod_opt(Key, Opts, fun(Val) -> Val end).
-
--spec get_mod_opt(atom(), list(), fun()) -> any().
-get_mod_opt(Key, Opts, F) ->
-    get_mod_opt(Key, Opts, F, undefined).
-
 
 -spec get_mod_opt(atom(), list(), fun(), any()) -> any().
 get_mod_opt(Key, Opts, F, Default) ->
@@ -242,7 +230,6 @@ get_mod_opt(Key, Opts, F, Default) ->
         Val ->
             prepare_opt_val(Key, Val, F, Default)
     end.
-
 
 -type check_fun() :: fun((any()) -> any()) | {module(), atom()}.
 -spec prepare_opt_val(any(), any(), check_fun(), any()) -> any().
@@ -292,9 +279,6 @@ process_user_filter(UIDs, RawUserFilter) ->
 
 get_search_filter(UserFilter) ->
     eldap_filter:do_sub(UserFilter, [{<<"%u">>, <<"*">>}]).
-
-get_dn_filter_with_attrs(Opts) ->
-    get_mod_opt(ldap_dn_filter, Opts, fun(DNF) -> DNF end, {undefined, []}).
 
 -spec singleton_value(list()) -> {binary(), binary()} | false.
 singleton_value([{K, [V]}]) ->

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -77,7 +77,7 @@ config_spec() ->
                      (translate_backend(B)):config_spec()} || B <- all_backends()],
     #section{
        items = #{<<"backend">> => #section{items = maps:from_list(BackendItems),
-                                           format = {kv, backends}}
+                                           wrap = {kv, backends}}
                 }
       }.
 

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -103,13 +103,13 @@ tls_spec() ->
                                             validate = filename},
                   <<"cacertfile">> => #option{type = string,
                                               validate = filename,
-                                              format = {kv, cafile}},
+                                              wrap = {kv, cafile}},
                   <<"ciphers">> => #option{type = string},
                   <<"dhfile">> => #option{type = string,
                                           validate = filename}
         },
         required = [<<"certfile">>, <<"cacertfile">>],
-        format = {kv, tls_opts}
+        wrap = {kv, tls_opts}
     }.
 
 redis_spec() ->

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -115,7 +115,7 @@ riak_config_spec() ->
                                                validate = non_empty},
                  <<"bucket_type">> => #option{type = binary,
                                               validate = non_empty}},
-       format = none
+       wrap = none
       }.
 
 -spec deps(_Host :: jid:server(), Opts :: proplists:proplist()) ->

--- a/src/mod_auth_token.erl
+++ b/src/mod_auth_token.erl
@@ -107,7 +107,7 @@ supported_features() ->
 config_spec() ->
     #section{
        items = #{<<"validity_period">> => #list{items = validity_period_spec(),
-                                                format = none},
+                                                wrap = none},
                  <<"iqdisc">> => mongoose_config_spec:iqdisc()
                 }
       }.

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -143,7 +143,7 @@ config_spec() ->
                  <<"server_acks">> => #option{type = boolean},
                  <<"max_pause">> => #option{type = integer,
                                             validate = positive,
-                                            format = {kv, maxpause}}
+                                            wrap = {kv, maxpause}}
                 }
       }.
 

--- a/src/mod_extdisco.erl
+++ b/src/mod_extdisco.erl
@@ -44,7 +44,7 @@ stop(Host) ->
 config_spec() ->
     #section{
         items = #{<<"service">> => #list{items = service_config_spec(),
-                                         format = none}}
+                                         wrap = none}}
         }.
 
 service_config_spec() ->

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -117,7 +117,7 @@ riak_config_spec() ->
     #section{items = #{<<"bucket_type">> => #option{type = binary,
                                                     validate = non_empty}
                       },
-             format = none
+             wrap = none
             }.
 
 supported_features() -> [dynamic_domains].

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -278,7 +278,7 @@ default_room_config_spec() ->
                  <<"subject">> => #option{type = binary},
                  <<"subject_author">> => #option{type = binary}
                 },
-       format = {kv, default_room_options}
+       wrap = {kv, default_room_options}
       }.
 
 default_room_affiliations_spec() ->

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -141,7 +141,7 @@ config_spec() ->
                                               validate = {enum, [html, plaintext]}},
                  <<"css_file">> => #option{type = binary,
                                            validate = non_empty,
-                                           format = {kv, cssfile}},
+                                           wrap = {kv, cssfile}},
                  <<"timezone">> => #option{type = atom,
                                            validate = {enum, [local, universal]}},
                  <<"top_link">> => top_link_config_spec(),

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -102,7 +102,7 @@ riak_config_spec() ->
        items = #{<<"bucket_type">> => #option{type = binary,
                                               validate = non_empty}
                 },
-       format = none
+       wrap = none
       }.
 
 %% ------------------------------------------------------------------

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -163,7 +163,7 @@ riak_config_spec() ->
                                                     validate = non_empty},
                        <<"version_bucket_type">> => #option{type = binary,
                                                             validate = non_empty}},
-             format = none
+             wrap = none
             }.
 
 supported_features() -> [dynamic_domains].

--- a/src/mod_stream_management.erl
+++ b/src/mod_stream_management.erl
@@ -107,10 +107,10 @@ stale_h_config_spec() ->
         items = #{<<"enabled">> => #option{type = boolean},
                   <<"repeat_after">> => #option{type = integer,
                                                 validate = positive,
-                                                format = {kv, stale_h_repeat_after}},
+                                                wrap = {kv, stale_h_repeat_after}},
                   <<"geriatric">> => #option{type = integer,
                                              validate = positive,
-                                             format = {kv, stale_h_geriatric}}
+                                             wrap = {kv, stale_h_geriatric}}
         }
     }.
 

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -132,7 +132,7 @@ config_spec() ->
 riak_config_spec() ->
     #section{items = #{<<"bucket_type">> => #option{type = binary,
                                                      validate = non_empty}},
-             format = none
+             wrap = none
             }.
 
 supported_features() -> [dynamic_domains].

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -92,7 +92,7 @@ riak_config_spec() ->
                  <<"bucket_type">> => #option{type = binary,
                                               validate = non_empty}
                 },
-       format = none
+       wrap = none
       }.
 
 -spec supported_features() -> [atom()].

--- a/src/sasl/cyrsasl.erl
+++ b/src/sasl/cyrsasl.erl
@@ -143,7 +143,7 @@ server_step(State, ClientIn) ->
 
 -spec get_modules(binary()) -> [sasl_module()].
 get_modules(HostType) ->
-    mongoose_config:get_opt({sasl_mechanisms, HostType}, default_modules()).
+    mongoose_config:get_opt([{auth, HostType}, sasl_mechanisms], default_modules()).
 
 default_modules() ->
     [cyrsasl_scram_sha512_plus,

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -105,7 +105,7 @@ authorize(Creds) ->
 
 get_verification_list(Creds) ->
     HostType = mongoose_credentials:host_type(Creds),
-    case ejabberd_auth:get_opt(HostType, cyrsasl_external, [standard]) of
+    case mongoose_config:get_opt([{auth, HostType}, sasl_external], [standard]) of
         [] -> [standard];
         List when is_list(List) -> List;
         standard -> [standard];

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -75,7 +75,7 @@ config_spec() ->
                                                   validate = non_negative},
                  <<"report">> => #option{type = boolean,
                                          process = fun ?MODULE:process_report_option/1,
-                                         format = item},
+                                         wrap = item},
                  <<"tracking_id">> => #option{type = string,
                                               validate = non_empty}
                 }

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -291,7 +291,7 @@ riak_config_spec() ->
                   <<"search_index">> => #option{type = binary,
                                                 validate = non_empty}
                 },
-        format = none
+        wrap = none
     }.
 
 process_map_spec(KVs) ->

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -235,7 +235,7 @@ config_spec() ->
                                                 validate = pool_name},
                  <<"ldap_base">> => #option{type = string},
                  <<"ldap_uids">> => #list{items = mongoose_config_spec:ldap_uids()},
-                 <<"ldap_filter">> => #option{type = string},
+                 <<"ldap_filter">> => #option{type = binary},
                  <<"ldap_deref">> => #option{type = atom,
                                              validate = {enum, [never, always, finding, searching]}},
                  <<"ldap_vcard_map">> => #list{items = ldap_vcard_map_spec()},

--- a/test/auth_dummy_SUITE.erl
+++ b/test/auth_dummy_SUITE.erl
@@ -35,14 +35,13 @@ all() -> [
 
 init_per_suite(C) ->
     {ok, _} = application:ensure_all_started(jid),
-    mongoose_config:set_opt({auth_method, ?HOST_TYPE}, [dummy]),
-    mongoose_config:set_opt({auth_opts, ?HOST_TYPE}, [{dummy_base_timeout, 5},
-                                                      {dummy_variance, 10}]),
+    mongoose_config:set_opt({auth, ?HOST_TYPE}, #{methods => [dummy],
+                                                  dummy_base_timeout => 5,
+                                                  dummy_variance => 10}),
     C.
 
 end_per_suite(_C) ->
-    mongoose_config:unset_opt({auth_method, ?HOST_TYPE}),
-    mongoose_config:unset_opt({auth_opts, ?HOST_TYPE}).
+    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
 
 %%--------------------------------------------------------------------
 %% Authentication tests

--- a/test/auth_external_SUITE.erl
+++ b/test/auth_external_SUITE.erl
@@ -79,11 +79,11 @@ given_user_registered() ->
 
 set_opts(Config) ->
     DataDir = ?config(data_dir, Config),
-    mongoose_config:set_opt({auth_opts, ?HOST_TYPE},
-                            [{extauth_program, DataDir ++ "sample_external_auth.py"}]).
+    mongoose_config:set_opt({auth, ?HOST_TYPE},
+                            #{external => #{program => DataDir ++ "sample_external_auth.py"}}).
 
 unset_opts() ->
-    mongoose_config:unset_opt({auth_opts, ?HOST_TYPE}).
+    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
 
 gen_user() ->
     U = random_binary(5),

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -236,17 +236,15 @@ creds_with_cert(Config, Username) ->
                                            {username, Username}]).
 
 set_opts(Config) ->
-    ScramOpts = case lists:keyfind(scram_group, 1, Config) of
-                    {_, false} -> [{password_format, plain}];
-                    _ -> []
+    AuthOpts = case lists:keyfind(scram_group, 1, Config) of
+                    {_, false} -> #{password_format => plain};
+                    _ -> #{}
                 end,
-    mongoose_config:set_opt({auth_opts, ?HOST_TYPE},
-                            [{host, ?AUTH_HOST},
-                             {path_prefix, "/auth/"},
-                             {basic_auth, ?BASIC_AUTH}] ++ ScramOpts).
+    HttpOpts = #{basic_auth => ?BASIC_AUTH},
+    mongoose_config:set_opt({auth, ?HOST_TYPE}, AuthOpts#{http => HttpOpts}).
 
 unset_opts() ->
-    mongoose_config:unset_opt({auth_opts, ?HOST_TYPE}).
+    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
 
 do_scram(Pass, Config) ->
     case lists:keyfind(scram_group, 1, Config) of

--- a/test/auth_internal_SUITE.erl
+++ b/test/auth_internal_SUITE.erl
@@ -47,8 +47,6 @@ passwords_in_plain_can_be_converted_to_scram(_C) ->
     OldScramFormat = old_password_to_scram(P2, 340),
     UserRecord2 = {passwd, {U2, S2}, OldScramFormat},
     mnesia:dirty_write(UserRecord2),
-    meck:new(ejabberd_auth),
-    meck:expect(ejabberd_auth, get_opt, fun(_, scram_iterations, D) -> D end),
     %% when the migration function is run
     ejabberd_auth_internal:scram_passwords(),
     AfterMigrationPlain = mnesia:dirty_read({passwd, {U, S}}),
@@ -76,8 +74,7 @@ passwords_in_plain_can_be_converted_to_scram(_C) ->
                  #{iteration_count := _,
                    sha := #{salt       := _,
                             server_key := _,
-                            stored_key := _}}}], AfterMigrationScram),
-    meck:unload().
+                            stored_key := _}}}], AfterMigrationScram).
 
 gen_user() ->
     {base64:encode(crypto:strong_rand_bytes(5)),

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -56,11 +56,11 @@ init_per_group(public_key, Config) ->
     PrivkeyPath = filename:join([Root, "tools", "ssl", "mongooseim", "privkey.pem"]),
     PubkeyPath = filename:join([Root, "tools", "ssl", "mongooseim", "pubkey.pem"]),
     {ok, PrivKey} = file:read_file(PrivkeyPath),
-    set_auth_opts(PubkeyPath, undefined, "RS256", bookingNumber),
+    set_auth_opts({file, PubkeyPath}, "RS256", bookingNumber),
     ok = ejabberd_auth_jwt:start(?HOST_TYPE),
     [{priv_key, PrivKey} | Config];
 init_per_group(_, Config) ->
-    set_auth_opts(undefined, ?JWT_KEY, "HS256", bookingNumber),
+    set_auth_opts({value, ?JWT_KEY}, "HS256", bookingNumber),
     ok = ejabberd_auth_jwt:start(?HOST_TYPE),
     Config.
 
@@ -119,15 +119,13 @@ check_password_succeeds_for_pubkey_signed_token(C) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
-set_auth_opts(SecretSource, Secret, Algorithm, Key) ->
-    mongoose_config:set_opt({auth_opts, ?HOST_TYPE},
-                            [{jwt_secret_source, SecretSource},
-                             {jwt_secret, Secret},
-                             {jwt_algorithm, Algorithm},
-                             {jwt_username_key, Key}]).
+set_auth_opts(Secret, Algorithm, Key) ->
+    mongoose_config:set_opt({auth, ?HOST_TYPE}, #{jwt => #{secret => Secret,
+                                                           algorithm => Algorithm,
+                                                           username_key => Key}}).
 
 unset_auth_opts() ->
-    mongoose_config:unset_opt({auth_opts, ?HOST_TYPE}).
+    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
 
 generate_token(Alg, NbfDelta, Key) ->
     Now = erlang:system_time(second),

--- a/test/commands_SUITE.erl
+++ b/test/commands_SUITE.erl
@@ -83,7 +83,7 @@ end_per_testcase(_, _C) ->
     meck:unload().
 
 opts() ->
-    [{{auth_method, <<"localhost">>}, [dummy]},
+    [{{auth, <<"localhost">>}, #{methods => [dummy]}},
      {{access, experts_only, <<"localhost">>}, [{allow, coder}, {allow, manager}, {deny, all}]},
      {{acl, coder, <<"localhost">>}, [{user, <<"zenek">>}]}].
 

--- a/test/config_parser_SUITE_data/host_types.options
+++ b/test/config_parser_SUITE_data/host_types.options
@@ -15,16 +15,11 @@
   mongoose_router_external_localnode,mongoose_router_external,
   mongoose_router_dynamic_domains,ejabberd_s2s]}.
 {sm_backend,{mnesia,[]}}.
-{{auth_method,<<"another host type">>},[]}.
-{{auth_method,<<"localhost">>},[test3]}.
-{{auth_method,<<"some host type">>},[test2]}.
-{{auth_method,<<"this is host type">>},[test1]}.
-{{auth_method,<<"yet another host type">>},[test1,test2]}.
-{{auth_opts,<<"another host type">>},[]}.
-{{auth_opts,<<"localhost">>},[]}.
-{{auth_opts,<<"some host type">>},[]}.
-{{auth_opts,<<"this is host type">>},[]}.
-{{auth_opts,<<"yet another host type">>},[]}.
+{{auth,<<"another host type">>},#{methods => []}}.
+{{auth,<<"localhost">>},#{methods => [test3]}}.
+{{auth,<<"some host type">>},#{methods => [test2]}}.
+{{auth,<<"this is host type">>},#{methods => [test1]}}.
+{{auth,<<"yet another host type">>},#{methods => [test1,test2]}}.
 {{modules,<<"another host type">>},[{test_mim_module2,[]}]}.
 {{modules,<<"localhost">>},[{test_mim_module3,[]}]}.
 {{modules,<<"some host type">>},[]}.

--- a/test/config_parser_SUITE_data/miscellaneous.options
+++ b/test/config_parser_SUITE_data/miscellaneous.options
@@ -30,44 +30,44 @@
     report,
     {tracking_id,"UA-123456789"}]}]}.
 {sm_backend,{mnesia,[]}}.
-{{allow_multiple_connections,<<"anonymous.localhost">>},true}.
-{{allow_multiple_connections,<<"localhost">>},true}.
-{{anonymous_protocol,<<"anonymous.localhost">>},sasl_anon}.
-{{anonymous_protocol,<<"localhost">>},sasl_anon}.
-{{auth_opts,<<"anonymous.localhost">>},
- [{extauth_program,"/usr/bin/authenticator"},
-  {basic_auth,"admin:admin"},
-  {jwt_algorithm,<<"RS256">>},
-  {jwt_secret,"secret123"},
-  {jwt_username_key,user},
-  {ldap_base,"ou=Users,dc=esl,dc=com"},
-  {ldap_bind_pool_tag,bind},
-  {ldap_deref,never},
-  {ldap_dn_filter,{"(&(name=%s)(owner=%D)(user=%u@%d))",["sn"]}},
-  {ldap_filter,"(&(objectClass=shadowAccount)(memberOf=Jabber Users))"},
-  {ldap_local_filter,{equal,{"accountStatus",["enabled"]}}},
-  {ldap_pool_tag,default},
-  {ldap_uids,["uid",{"uid2","%u"}]},
-  {rdbms_users_number_estimate,true},
-  {bucket_type,<<"user_bucket">>}]}.
-{{auth_opts,<<"localhost">>},
- [{extauth_program,"/usr/bin/authenticator"},
-  {basic_auth,"admin:admin"},
-  {jwt_algorithm,<<"RS256">>},
-  {jwt_secret,"secret123"},
-  {jwt_username_key,user},
-  {ldap_base,"ou=Users,dc=esl,dc=com"},
-  {ldap_bind_pool_tag,bind},
-  {ldap_deref,never},
-  {ldap_dn_filter,{"(&(name=%s)(owner=%D)(user=%u@%d))",["sn"]}},
-  {ldap_filter,"(&(objectClass=shadowAccount)(memberOf=Jabber Users))"},
-  {ldap_local_filter,{equal,{"accountStatus",["enabled"]}}},
-  {ldap_pool_tag,default},
-  {ldap_uids,["uid",{"uid2","%u"}]},
-  {rdbms_users_number_estimate,true},
-  {bucket_type,<<"user_bucket">>}]}.
-{{extauth_instances,<<"anonymous.localhost">>},1}.
-{{extauth_instances,<<"localhost">>},1}.
+{{auth,<<"anonymous.localhost">>},
+ #{anonymous => #{allow_multiple_connections => true,
+                  protocol => sasl_anon},
+   http => #{basic_auth => "admin:admin"},
+   external => #{instances => 1,
+                 program => "/usr/bin/authenticator"},
+   jwt => #{algorithm => <<"RS256">>,
+            secret => {value,"secret123"},
+            username_key => user},
+   ldap => #{base => <<"ou=Users,dc=esl,dc=com">>,
+             bind_pool_tag => bind,
+             deref => never,
+             dn_filter => {<<"(&(name=%s)(owner=%D)(user=%u@%d))">>,[<<"sn">>]},
+             filter => <<"(&(objectClass=shadowAccount)(memberOf=Jabber Users))">>,
+             local_filter => {equal,{"accountStatus",["enabled"]}},
+             pool_tag => default,
+             uids => [<<"uid">>,{<<"uid2">>,<<"%u">>}]},
+   rdbms => #{users_number_estimate => true},
+   riak => #{bucket_type => <<"user_bucket">>}}}.
+{{auth,<<"localhost">>},
+ #{anonymous => #{allow_multiple_connections => true,
+                  protocol => sasl_anon},
+   http => #{basic_auth => "admin:admin"},
+   external => #{instances => 1,
+                 program => "/usr/bin/authenticator"},
+   jwt => #{algorithm => <<"RS256">>,
+            secret => {value,"secret123"},
+            username_key => user},
+   ldap => #{base => <<"ou=Users,dc=esl,dc=com">>,
+             bind_pool_tag => bind,
+             deref => never,
+             dn_filter => {<<"(&(name=%s)(owner=%D)(user=%u@%d))">>,[<<"sn">>]},
+             filter => <<"(&(objectClass=shadowAccount)(memberOf=Jabber Users))">>,
+             local_filter => {equal,{"accountStatus",["enabled"]}},
+             pool_tag => default,
+             uids => [<<"uid">>,{<<"uid2">>,<<"%u">>}]},
+   rdbms => #{users_number_estimate => true},
+   riak => #{bucket_type => <<"user_bucket">>}}}.
 {{replaced_wait_timeout,<<"anonymous.localhost">>},2000}.
 {{replaced_wait_timeout,<<"localhost">>},2000}.
 {{route_subdomains,<<"anonymous.localhost">>},s2s}.

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.options
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.options
@@ -125,20 +125,20 @@
   {service_mongoose_system_metrics,
    [{initial_report,300000},{periodic_report,10800000}]}]}.
 {sm_backend,{mnesia,[]}}.
-{{allow_multiple_connections,<<"anonymous.localhost">>},true}.
-{{anonymous_protocol,<<"anonymous.localhost">>},both}.
-{{auth_method,<<"anonymous.localhost">>},[anonymous]}.
-{{auth_method,<<"localhost">>},[rdbms]}.
-{{auth_method,<<"localhost.bis">>},[rdbms]}.
-{{auth_opts,<<"anonymous.localhost">>},[]}.
-{{auth_opts,<<"localhost">>},
- [{password_format,{scram,[sha256]}},
-  {cyrsasl_external,[standard]},
-  {scram_iterations,64}]}.
-{{auth_opts,<<"localhost.bis">>},
- [{password_format,{scram,[sha256]}},
-  {cyrsasl_external,[standard]},
-  {scram_iterations,64}]}.
+{{auth,<<"anonymous.localhost">>},
+ #{anonymous => #{allow_multiple_connections => true,
+                  protocol => both},
+   methods => [anonymous]}}.
+{{auth,<<"localhost">>},
+ #{methods => [rdbms],
+   sasl_external => [standard],
+   password_format => {scram,[sha256]},
+   scram_iterations => 64}}.
+{{auth,<<"localhost.bis">>},
+ #{methods => [rdbms],
+   sasl_external => [standard],
+   password_format => {scram,[sha256]},
+   scram_iterations => 64}}.
 {
  {modules,<<"anonymous.localhost">>},
  [{mod_register,
@@ -211,7 +211,7 @@
 {{replaced_wait_timeout,<<"anonymous.localhost">>},2000}.
 {{replaced_wait_timeout,<<"localhost">>},2000}.
 {{replaced_wait_timeout,<<"localhost.bis">>},2000}.
-{{s2s_addr,<<"fed1">>},"127.0.0.1"}.
+{s2s_address,#{<<"fed1">> => "127.0.0.1"}}.
 {{s2s_default_policy,<<"anonymous.localhost">>},allow}.
 {{s2s_default_policy,<<"localhost">>},allow}.
 {{s2s_default_policy,<<"localhost.bis">>},allow}.

--- a/test/config_parser_SUITE_data/s2s_only.options
+++ b/test/config_parser_SUITE_data/s2s_only.options
@@ -20,19 +20,19 @@
 {s2s_dns_options,[{retries,1},{timeout,30}]}.
 {s2s_use_starttls,optional}.
 {sm_backend,{mnesia,[]}}.
-{{domain_certfile,<<"example.com">>},"/path/to/example_com.pem"}.
-{{domain_certfile,<<"example.org">>},"/path/to/example_org.pem"}.
+{domain_certfile,#{<<"example.com">> => "/path/to/example_com.pem",
+                   <<"example.org">> => "/path/to/example_org.pem"}}.
 {{replaced_wait_timeout,<<"dummy_host">>},2000}.
 {{replaced_wait_timeout,<<"localhost">>},2000}.
-{{s2s_addr,<<"fed1">>},"127.0.0.1"}.
-{{s2s_addr,<<"fed2">>},{"127.0.0.1",8765}}.
+{s2s_address,#{<<"fed1">> => "127.0.0.1",
+               <<"fed2">> => {"127.0.0.1",8765}}}.
 {{s2s_default_policy,<<"dummy_host">>},allow}.
 {{s2s_default_policy,<<"localhost">>},allow}.
 {{s2s_max_retry_delay,<<"dummy_host">>},30}.
 {{s2s_max_retry_delay,<<"localhost">>},30}.
 {{s2s_shared,<<"dummy_host">>},<<"shared secret">>}.
 {{s2s_shared,<<"localhost">>},<<"shared secret">>}.
-{{{s2s_host,<<"fed1">>},<<"dummy_host">>},allow}.
-{{{s2s_host,<<"fed1">>},<<"localhost">>},allow}.
-{{{s2s_host,<<"reg1">>},<<"dummy_host">>},deny}.
-{{{s2s_host,<<"reg1">>},<<"localhost">>},deny}.
+{{s2s_host_policy,<<"dummy_host">>},#{<<"fed1">> => allow,
+                                      <<"reg1">> => deny}}.
+{{s2s_host_policy,<<"localhost">>},#{<<"fed1">> => allow,
+                                     <<"reg1">> => deny}}.


### PR DESCRIPTION
Introduce the new `format_items` field to allow conversion of selected config sections to maps. In the future, when we convert enough sections, we could make `format_items = map` default for sections. For now it would mean too many changes.

Another important change is the ability to call `get_opt` and `lookup_opt` in `mongoose_config` with the complete path for a nested option, e.g. `[{auth, HostType}, riak, bucket_type]`. The path might look cleaner with `HostType` passed as a separate argument, but this would increase the complexity of `mongoose_config`, which is quite clean and simple right now.

The conversion to maps is done for the `auth` section and for selected `s2s` options. The main motivation for choosing these particular options was that their processing used the `foreach` format, which was a  temporary hack.

Other changes and notes:
- Option names are simplified.
- Dummy auth method has better config validation and tests.
- LDAP auth-related options are simplified to use less custom processing, but the changes are limited to `auth` for now. This should be finished when converting modules using LDAP.
- It is possible to inject a sub-section into the parent section with `format = none` just like before.
- Putting the `format_items` step before `process` allows simpler processing functions, taking a map as an argument.
- Putting the `format_items` step after `validate` allows validation of lists just like before, improving steps separation.

Some further polishing could be done later, e.g. regarding the dafaults and password format.

