### PR TITLE
Retry insert MAM prefs on deadlock

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -526,9 +526,10 @@ suite() ->
 
 init_per_suite(Config) ->
     muc_helper:load_muc(),
-    increase_limits(
-      delete_users([{escalus_user_db, {module, escalus_ejabberd}}
-                  | escalus:init_per_suite(Config)])).
+    mam_helper:prepare_for_suite(
+      increase_limits(
+        delete_users([{escalus_user_db, {module, escalus_ejabberd}}
+                  | escalus:init_per_suite(Config)]))).
 
 end_per_suite(Config) ->
     muc_helper:unload_muc(),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1176,16 +1176,20 @@ run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate,
     escalus:send(Alice, escalus_stanza:chat_to(Bob, lists:nth(2, Messages))),
     escalus:send(Kate, escalus_stanza:chat_to(Alice, lists:nth(3, Messages))),
     escalus:send(Alice, escalus_stanza:chat_to(Kate, lists:nth(4, Messages))),
-    escalus:wait_for_stanzas(Bob, 1, 5000),
-    escalus:wait_for_stanzas(Kate, 1, 5000),
-    escalus:wait_for_stanzas(Alice, 2, 5000),
+    [M1] = escalus:wait_for_stanzas(Bob, 1, 5000),
+    [M2] = escalus:wait_for_stanzas(Kate, 1, 5000),
+    [M3, M4] = escalus:wait_for_stanzas(Alice, 2, 5000),
+    [escalus:assert(is_message, Message) || Message <- [M1, M2, M3, M4]],
     %% Delay check
     fun(Bodies) ->
         ActualMessageStates = [lists:member(M, Bodies) || M <- Messages],
         Debug = make_debug_prefs(ExpectedMessageStates, ActualMessageStates),
         ?_assert_equal_extra(ExpectedMessageStates, ActualMessageStates,
                              #{prefs_state => PrefsState,
-                               debug => Debug})
+                               debug => Debug,
+                               bob_receives => [M1],
+                               kate_receives => [M2],
+                               alice_receives => [M3, M4]})
     end.
 
 make_debug_prefs(ExpectedMessageStates, ActualMessageStates) ->

--- a/src/mam/mod_mam_rdbms_prefs.erl
+++ b/src/mam/mod_mam_rdbms_prefs.erl
@@ -154,7 +154,7 @@ set_prefs1(HostType, UserID, DefaultMode, AlwaysJIDs, NeverJIDs) ->
     mongoose_rdbms:transaction_with_delayed_retry(HostType, fun() ->
             {updated, _} =
                 mongoose_rdbms:execute(HostType, mam_prefs_delete, [UserID]),
-            [mongoose_rdbms:execute(HostType, mam_prefs_insert, Row) || Row <- Rows],
+            [{updated, 1} = mongoose_rdbms:execute(HostType, mam_prefs_insert, Row) || Row <- Rows],
             ok
         end, #{user_id => UserID, retries => 5, delay => 100}),
     ok.


### PR DESCRIPTION
This PR addresses "CI stability".

Proposed changes include:
* Detect deadlock in prefs code


Before:
nothing in logs, deadlock is just ignored

Now:
logs updated, prefs insertion retried
```
_build/mim1/rel/mongooseim/log/mongooseim.log.1:when=2021-11-29T16:01:05.129505+00:00 level=error what=rdbms_outer_transaction_failed 
reason="{badmatch,{error,\"Deadlock found when trying to get lock; try restarting transaction\"}}" pid=<0.22061.0> 
at=mongoose_rdbms:apply_transaction_function/1:669 
stacktrace="mod_mam_rdbms_prefs:'-set_prefs1/5-lc$^0/1-0-'/2:157 mod_mam_rdbms_prefs:'-set_prefs1/5-fun-1-'/3:157 mongoose_rdbms:apply_transaction_function/1:664 mongoose_rdbms:outer_transaction/4:627 mongoose_rdbms:run_sql_cmd/4:573 wpool_process:handle_call/3:246 gen_server:try_handle_call/4:706 gen_server:handle_msg/6:735"
```