### PR TITLE
Correctly pass connection options to Fusco

### DIFF
--- a/src/wpool/mongoose_wpool_http.erl
+++ b/src/wpool/mongoose_wpool_http.erl
@@ -68,6 +68,6 @@ get_params(HostType, Tag) ->
 wpool_spec(WpoolOptsIn, ConnOpts) ->
     TargetServer = gen_mod:get_opt(server, ConnOpts),
     HttpOpts = gen_mod:get_opt(http_opts, ConnOpts, []),
-    Worker = {fusco, {TargetServer, HttpOpts}},
+    Worker = {fusco, {TargetServer, [{connect_options, HttpOpts}]}},
     [{worker, Worker} | WpoolOptsIn].
 


### PR DESCRIPTION
The options are not used currently, which is critical when configuring TLS for HTTP auth.
Fusco did not complain, as the wpool library did not call the exported start/start_link functions, which verified options (https://github.com/inaka/worker_pool/blob/main/src/wpool_process.erl#L45, https://github.com/esl/fusco/blob/master/src/fusco.erl#L84).

Tested manually, without the patch, TLS is silently not verified and connection (if the MIM client certs are not rejected by the auth service) is established. With the patch, errors appear in logs when connecting to a service which has incorrect certificate.
