### PR TITLE
Move auth config spec to auth backend modules

### DIFF
--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -46,7 +46,8 @@
          does_method_support/2,
          remove_user/1,
          supports_sasl_module/2,
-         entropy/1
+         entropy/1,
+         config_spec/1
         ]).
 
 -export([check_digest/4]).
@@ -388,6 +389,10 @@ entropy(IOList) ->
                     end, [0, 0, 0, 0, 0], InputList),
             length(InputList) * math:log(lists:sum(Set))/math:log(2)
     end.
+
+-spec config_spec(atom()) -> mongoose_config_spec:config_section().
+config_spec(Method) ->
+    mongoose_gen_auth:config_spec(auth_method_to_module(Method)).
 
 %%%----------------------------------------------------------------------
 %%% Internal functions

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -28,6 +28,7 @@
 
 -export([start/1,
          stop/1,
+         config_spec/0,
          register_connection/5,
          unregister_connection/5,
          session_cleanup/5
@@ -56,6 +57,8 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include("session.hrl").
+-include("mongoose_config_spec.hrl").
+
 -record(anonymous, {us  :: jid:simple_bare_jid(),
                     sid :: ejabberd_sm:sid()
                    }).
@@ -81,6 +84,16 @@ stop(HostType) ->
     ejabberd_hooks:delete(sm_remove_connection_hook, HostType, ?MODULE, unregister_connection, 100),
     ejabberd_hooks:delete(session_cleanup, HostType, ?MODULE, session_cleanup, 50),
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"allow_multiple_connections">> => #option{type = boolean},
+                 <<"protocol">> => #option{type = atom,
+                                           validate = {enum, [sasl_anon, login_anon, both]}}
+                },
+       format_items = map
+      }.
 
 %% @doc Return true if multiple connections have been allowed in the config file
 %% defaults to false

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -3,6 +3,7 @@
 %% API
 -export([start/1,
          stop/1,
+         config_spec/0,
          check_password/4,
          check_password/6,
          authorize/1,
@@ -24,6 +25,7 @@
 -ignore_xref([scram_passwords/0]).
 
 -include("mongoose.hrl").
+-include("mongoose_config_spec.hrl").
 
 %%%----------------------------------------------------------------------
 %%% API
@@ -36,6 +38,16 @@ start(_HostType) ->
 -spec stop(HostType :: mongooseim:host_type()) -> ok.
 stop(_HostType) ->
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"base_time">> => #option{type = integer,
+                                            validate = non_negative},
+                 <<"variance">> => #option{type = integer,
+                                           validate = positive}},
+       format_items = map
+      }.
 
 authorize(Creds) ->
     HostType = mongoose_credentials:host_type(Creds),

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -31,6 +31,7 @@
 
 -export([start/1,
          stop/1,
+         config_spec/0,
          set_password/4,
          authorize/1,
          try_register/4,
@@ -49,6 +50,7 @@
          check_password/6]).
 
 -include("mongoose.hrl").
+-include("mongoose_config_spec.hrl").
 
 %%%----------------------------------------------------------------------
 %%% API
@@ -65,9 +67,21 @@ start(HostType) ->
             ok
     end.
 
+-spec stop(mongooseim:host_type()) -> ok.
 stop(HostType) ->
     extauth:stop(HostType).
 
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"instances">> => #option{type = integer,
+                                            validate = positive},
+                 <<"program">> => #option{type = string,
+                                          validate = non_empty}
+                },
+       required = [<<"program">>],
+       format_items = map
+      }.
 
 -spec check_cache_last_options(mongooseim:host_type()) -> 'cache' | 'no_cache'.
 check_cache_last_options(HostType) ->

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -13,6 +13,7 @@
 %% External exports
 -export([start/1,
          stop/1,
+         config_spec/0,
          supports_sasl_module/2,
          set_password/4,
          authorize/1,
@@ -28,7 +29,7 @@
          check_password/6]).
 
 -include("mongoose.hrl").
--include("scram.hrl").
+-include("mongoose_config_spec.hrl").
 
 -type http_error_atom() :: conflict | not_found | not_authorized | not_allowed.
 -type params() :: #{luser := jid:luser(),
@@ -47,6 +48,13 @@ start(_HostType) ->
 -spec stop(moongooseim:host_type()) -> ok.
 stop(_HostType) ->
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"basic_auth">> => #option{type = string}},
+       format_items = map
+      }.
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_HostType, cyrsasl_plain) -> true;

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -31,6 +31,7 @@
 
 -export([start/1,
          stop/1,
+         config_spec/0,
          authorize/1,
          set_password/4,
          try_register/4,
@@ -56,7 +57,7 @@
 -import(mongoose_rdbms, [prepare/4, execute_successfully/3]).
 
 -include("mongoose.hrl").
--include("scram.hrl").
+-include("mongoose_config_spec.hrl").
 
 -define(DEFAULT_SCRAMMIFY_COUNT, 10000).
 -define(DEFAULT_SCRAMMIFY_INTERVAL, 1000).
@@ -74,12 +75,21 @@
 %%% API
 %%%----------------------------------------------------------------------
 
+-spec start(moongooseim:host_type()) -> ok.
 start(HostType) ->
     prepare_queries(HostType),
     ok.
 
+-spec stop(moongooseim:host_type()) -> ok.
 stop(_HostType) ->
     ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"users_number_estimate">> => #option{type = boolean}},
+       format_items = map
+      }.
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_HostType, cyrsasl_plain) -> true;

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -18,11 +18,13 @@
 -behaviour(mongoose_gen_auth).
 
 -include("mongoose.hrl").
+-include("mongoose_config_spec.hrl").
 -include("scram.hrl").
 
 %% API
 -export([start/1,
          stop/1,
+         config_spec/0,
          supports_sasl_module/2,
          supported_features/0,
          set_password/4,
@@ -46,7 +48,15 @@ start(_HostType) ->
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(_HostType) ->
-ok.
+    ok.
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+       items = #{<<"bucket_type">> => #option{type = binary,
+                                              validate = non_empty}},
+       format_items = map
+      }.
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_HostType, cyrsasl_plain) -> true;

--- a/src/auth/mongoose_gen_auth.erl
+++ b/src/auth/mongoose_gen_auth.erl
@@ -3,6 +3,7 @@
 
 -export([start/2,
          stop/2,
+         config_spec/1,
          supports_sasl_module/3,
          authorize/2,
          check_password/5,
@@ -27,6 +28,8 @@
 -callback start(HostType :: mongooseim:host_type()) -> ok.
 
 -callback stop(HostType :: mongooseim:host_type()) -> ok.
+
+-callback config_spec() -> mongoose_config_spec:config_section().
 
 -callback supports_sasl_module(HostType :: mongooseim:host_type(),
                                Module :: cyrsasl:sasl_module()) ->
@@ -103,7 +106,8 @@
                          DigestGen :: fun()) -> boolean().
 
 %% See the API function definitions below for default values
--optional_callbacks([try_register/4,
+-optional_callbacks([config_spec/0,
+                     try_register/4,
                      get_registered_users/3,
                      get_registered_users_number/3,
                      get_password/3,
@@ -115,6 +119,8 @@
                      check_password/4,
                      check_password/6]).
 
+-include("mongoose_config_spec.hrl").
+
 %% API
 
 -spec start(ejabberd_auth:authmodule(), mongooseim:host_type()) -> ok.
@@ -124,6 +130,13 @@ start(Mod, HostType) ->
 -spec stop(ejabberd_auth:authmodule(), mongooseim:host_type()) -> ok.
 stop(Mod, HostType) ->
     Mod:stop(HostType).
+
+-spec config_spec(ejabberd_auth:authmodule()) -> mongoose_config_spec:config_section().
+config_spec(Mod) ->
+    case is_exported(Mod, config_spec, 0) of
+        true -> Mod:config_spec();
+        false -> #section{items = #{}}
+    end.
 
 -spec supports_sasl_module(ejabberd_auth:authmodule(), mongooseim:host_type(),
                            cyrsasl:sasl_module()) -> boolean().

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -5,8 +5,7 @@
 
 %% spec parts used by modules and services
 -export([wpool_items/0,
-         iqdisc/0,
-         ldap_uids/0]).
+         iqdisc/0]).
 
 %% callbacks for the 'process' step
 -export([process_host/1,
@@ -504,16 +503,6 @@ auth_password() ->
                 },
        process = fun ?MODULE:process_auth_password/1,
        wrap = {kv, password_format}
-      }.
-
-%% path: (host_config[].)auth.ldap.uids
-ldap_uids() ->
-    #section{
-       items = #{<<"attr">> => #option{type = binary},
-                 <<"format">> => #option{type = binary}},
-       process = fun ?MODULE:process_ldap_uids/1,
-       required = [<<"attr">>],
-       format_items = map
       }.
 
 %% path: outgoing_pools
@@ -1120,9 +1109,6 @@ process_auth_password(KVs) ->
         {[{format, scram}], [{hash, Hashes}]} -> {scram, Hashes};
         {[], [{hash, Hashes}]} -> {scram, Hashes}
     end.
-
-process_ldap_uids(#{attr := Attr, format := Format}) -> {Attr, Format};
-process_ldap_uids(#{attr := Attr}) -> Attr.
 
 process_pool([Tag, Type|_], KVs) ->
     {[ScopeOpts, HostOpts, ConnOpts], Opts} = proplists:split(KVs, [scope, host, connection]),

--- a/src/mongoose_ldap_config.erl
+++ b/src/mongoose_ldap_config.erl
@@ -1,0 +1,57 @@
+-module(mongoose_ldap_config).
+
+%% Config spec
+-export([uids/0,
+         dn_filter/0,
+         local_filter/0]).
+
+%% Config spec callbacks
+-export([process_uids/1,
+         process_dn_filter/1,
+         process_local_filter/1]).
+
+-include("mongoose_config_spec.hrl").
+
+uids() ->
+    #section{
+       items = #{<<"attr">> => #option{type = binary},
+                 <<"format">> => #option{type = binary}},
+       process = fun ?MODULE:process_uids/1,
+       required = [<<"attr">>],
+       format_items = map
+      }.
+
+dn_filter() ->
+    #section{
+       items = #{<<"filter">> => #option{type = binary,
+                                         validate = ldap_filter},
+                 <<"attributes">> => #list{items = #option{type = binary}}
+                },
+       required = [<<"filter">>],
+       defaults = #{<<"attributes">> => []},
+       process = fun ?MODULE:process_dn_filter/1,
+       format_items = map
+      }.
+
+local_filter() ->
+    #section{
+       items = #{<<"operation">> => #option{type = atom,
+                                            validate = {enum, [equal, notequal]}},
+                 <<"attribute">> => #option{type = string,
+                                            validate = non_empty},
+                 <<"values">> => #list{items = #option{type = string},
+                                       validate = non_empty}
+                },
+       required = all,
+       process = fun ?MODULE:process_local_filter/1,
+       format_items = map
+      }.
+
+process_uids(#{attr := Attr, format := Format}) -> {Attr, Format};
+process_uids(#{attr := Attr}) -> Attr.
+
+process_dn_filter(#{filter := Filter, attributes := Attrs}) ->
+    {Filter, Attrs}.
+
+process_local_filter(#{operation := Op, attribute := Attr, values := Values}) ->
+    {Op, {Attr, Values}}.

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -234,7 +234,7 @@ config_spec() ->
                  <<"ldap_pool_tag">> => #option{type = atom,
                                                 validate = pool_name},
                  <<"ldap_base">> => #option{type = string},
-                 <<"ldap_uids">> => #list{items = mongoose_config_spec:ldap_uids()},
+                 <<"ldap_uids">> => #list{items = mongoose_ldap_config:uids()},
                  <<"ldap_filter">> => #option{type = binary},
                  <<"ldap_deref">> => #option{type = atom,
                                              validate = {enum, [never, always, finding, searching]}},


### PR DESCRIPTION
Just like for modules and services, this keeps it more organized and simplifies future changes of auth handling, e.g. introducing defaults.

