### PR TITLE
Avoid a race condition in sm_SUITE:resume_session_state_stop_c2s

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -735,6 +735,7 @@ resume_session_state_stop_c2s(Config) ->
     escalus_connection:send(Alice, escalus_stanza:sm_ack(1)),
 
     escalus_connection:send(Bob, escalus_stanza:chat_to(common_helper:get_bjid(AliceSpec), <<"msg-1">>)),
+    escalus:assert(is_chat_message, [<<"msg-1">>], escalus_connection:get_stanza(Alice, msg)),
 
     %% get pid of c2s
     {ok, C2SPid} = get_session_pid(AliceSpec, escalus_client:resource(Alice)),
@@ -746,7 +747,7 @@ resume_session_state_stop_c2s(Config) ->
     escalus_connection:kill(Alice),
     % session should be alive
     1 = length(get_user_alive_resources(AliceSpec)),
-    rpc(mim(), ejabberd_c2s, stop, [C2SPid] ),
+    rpc(mim(), ejabberd_c2s, stop, [C2SPid]),
     wait_for_c2s_state_change(C2SPid, resume_session),
     %% suspend the process to ensure that Alice has enough time to reconnect,
     %% before resumption timeout occurs.
@@ -759,8 +760,6 @@ resume_session_state_stop_c2s(Config) ->
     %% now we can resume c2s process of the old connection
     %% and let it process session resumption timeout
     ok = rpc(mim(), sys, resume, [C2SPid]),
-
-    escalus:assert(is_chat_message, [<<"msg-1">>], escalus_connection:get_stanza(Alice, msg)),
 
     escalus_connection:stop(NewAlice),
     escalus_connection:stop(Bob).


### PR DESCRIPTION
This PR addresses MIM-1537 (investigate flaky tests)

Proposed changes include:

* msg-1 arrives usually before we do stop
* And that stanza is buffered on the escalus side
* Unless we manage to hit a race condition by stopping c2s before msg-1 gets routed (and it gets stuck on the c2s process side and we get a receive stanza timeout)

Fix for the timeout https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/3443/93940/riak_mnesia.24.0.5/big/ct_run.test%408fd9df8d5854.2021-12-10_11.01.05/big_tests.tests.sm_SUITE.logs/run.2021-12-10_11.16.03/sm_suite.resume_session_state_stop_c2s.62339.html#end
