### PR TITLE
GraphQL - Support global types

### DIFF
--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -3,8 +3,6 @@ schema{
   mutation: AdminMutation
 }
 
-directive @protected on FIELD_DEFINITION | OBJECT
-
 """
 Contains all admin available queries.
 Only an authenticated admin can execute these queries.

--- a/priv/graphql/schemas/global/jid.gql
+++ b/priv/graphql/schemas/global/jid.gql
@@ -1,0 +1,11 @@
+"""
+Jabber Identifiers (JIDs) uniquely identify individual entities in the xmpp network.
+"""
+type JID{
+  "The user identifier"
+  user: String
+  "The server identifier"
+  server: String!
+  "The resource identifier"
+  resource: String
+}

--- a/priv/graphql/schemas/global/protected_dir.gql
+++ b/priv/graphql/schemas/global/protected_dir.gql
@@ -1,0 +1,2 @@
+"Marks the resource to be accessed only by authorized requests"
+directive @protected on FIELD_DEFINITION | OBJECT

--- a/priv/graphql/schemas/user/user_schema.gql
+++ b/priv/graphql/schemas/user/user_schema.gql
@@ -3,8 +3,6 @@ schema{
   mutation: UserMutation
 }
 
-directive @protected on FIELD_DEFINITION | OBJECT
-
 """
 Contains all user available queries.
 Only authenticated user can execute this queries.

--- a/src/mongoose_graphql.erl
+++ b/src/mongoose_graphql.erl
@@ -88,12 +88,15 @@ execute(Ep, OpName, Doc)  ->
 
 % Internal
 
+-spec schema_global_patterns(file:name_all()) -> [file:filename_all()].
 schema_global_patterns(SchemaDir) ->
-    [schema_pattern(SchemaDir), schema_pattern(global)].
+    [schema_pattern(SchemaDir), schema_pattern("global")].
 
+-spec schema_pattern(file:name_all()) -> file:filename_all().
 schema_pattern(DirName) ->
     schema_pattern(DirName, "*.gql").
 
+-spec schema_pattern(file:name_all(), file:name_all()) -> file:filename_all().
 schema_pattern(DirName, Pattern) ->
     filename:join([code:priv_dir(mongooseim), "graphql/schemas", DirName, Pattern]).
 

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -9,7 +9,7 @@
 all() ->
     [can_create_endpoint,
      can_load_split_schema,
-     admin_and_user_loads_global_types,
+     admin_and_user_load_global_types,
      {group, unprotected_graphql},
      {group, protected_graphql},
      {group, errors_handling}].
@@ -84,7 +84,7 @@ can_load_split_schema(Config) ->
     ?assertMatch(#object_type{id = <<"Query">>}, graphql_schema:get(Ep, <<"Query">>)),
     ?assertMatch(#object_type{id = <<"Mutation">>}, graphql_schema:get(Ep, <<"Mutation">>)).
 
-admin_and_user_loads_global_types(_Config) ->
+admin_and_user_load_global_types(_Config) ->
     mongoose_graphql:init(),
     AdminEp = mongoose_graphql:get_endpoint(admin),
     ?assertMatch(#object_type{id = <<"JID">>}, graphql_schema:get(AdminEp, <<"JID">>)),


### PR DESCRIPTION
This PR addresses [MIM-1559](https://erlangsolutions.atlassian.net/browse/MIM-1559) and adds support for global types.
In addition, it moves the `protected` directive to a global directory and adds the `JID` global type.

