### PR TITLE
Simplify stream management suite

### DIFF
--- a/big_tests/tests/ct_helper.erl
+++ b/big_tests/tests/ct_helper.erl
@@ -3,7 +3,8 @@
          repeat_all_until_all_ok/1,
          repeat_all_until_all_ok/2,
          repeat_all_until_any_fail/1,
-         repeat_all_until_any_fail/2]).
+         repeat_all_until_any_fail/2,
+         groups_to_all/1]).
 
 -type group_name() :: atom().
 
@@ -110,3 +111,25 @@ sensible_maximum_repeats() ->
 
 is_ct_started() ->
     lists:keymember(common_test, 1, application:which_applications()).
+
+groups_to_all(Groups) ->
+    [{group, Name} || {Name, _Opts, _Cases} <- Groups].
+<<<<<<< HEAD
+
+%% Module needs to be compiled with export_helper
+make_groups(Module) ->
+    Info = Module:groups_info(),
+    [prepare_group(GroupAndCases) || GroupAndCases <- Info].
+
+prepare_group({Group, Cases}) ->
+    {Group, group_name_to_props(Group), Cases}.
+
+group_name_to_props(Group) ->
+    case lists:prefix("parallel", atom_to_list(Group)) of
+        true ->
+            [parallel];
+        false ->
+            []
+    end.
+=======
+>>>>>>> c9bce834d... x

--- a/big_tests/tests/ct_helper.erl
+++ b/big_tests/tests/ct_helper.erl
@@ -114,22 +114,3 @@ is_ct_started() ->
 
 groups_to_all(Groups) ->
     [{group, Name} || {Name, _Opts, _Cases} <- Groups].
-<<<<<<< HEAD
-
-%% Module needs to be compiled with export_helper
-make_groups(Module) ->
-    Info = Module:groups_info(),
-    [prepare_group(GroupAndCases) || GroupAndCases <- Info].
-
-prepare_group({Group, Cases}) ->
-    {Group, group_name_to_props(Group), Cases}.
-
-group_name_to_props(Group) ->
-    case lists:prefix("parallel", atom_to_list(Group)) of
-        true ->
-            [parallel];
-        false ->
-            []
-    end.
-=======
->>>>>>> c9bce834d... x

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -48,6 +48,7 @@
 -export([print_debug_info_for_module/1]).
 -export([backup_and_set_config/2, backup_and_set_config_option/3, change_config_option/3]).
 -export([restore_config/1, restore_config_option/2]).
+-export([wait_for_n_offline_messages/2]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
@@ -562,3 +563,9 @@ do_restore_config_option(Option, {ok, Value}) ->
     rpc(mim(), mongoose_config, set_opt, [Option, Value]);
 do_restore_config_option(Option, {error, not_found}) ->
     rpc(mim(), mongoose_config, unset_opt, [Option]).
+
+wait_for_n_offline_messages(Client, N) ->
+    LUser = escalus_utils:jid_to_lower(escalus_client:username(Client)),
+    LServer = escalus_utils:jid_to_lower(escalus_client:server(Client)),
+    WaitFn = fun() -> mongoose_helper:total_offline_messages({LUser, LServer}) end,
+    mongoose_helper:wait_until(WaitFn, N).

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -382,8 +382,8 @@ do_wait_until(Fun, #{validator := Validator} = Opts) ->
                      true -> {ok, Value};
                      _ -> wait_and_continue(Fun, Value, Opts)
                  end
-    catch Error:Reason ->
-              wait_and_continue(Fun, {Error, Reason}, Opts)
+    catch Error:Reason:Stacktrace ->
+              wait_and_continue(Fun, {Error, Reason, Stacktrace}, Opts)
     end.
 
 simplify_history([H|[H|_]=T], Times) ->

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -64,7 +64,7 @@ is_rdbms_enabled(HostType) ->
 -spec mnesia_or_rdbms_backend() -> atom().
 mnesia_or_rdbms_backend() ->
     Host = ct:get_config({hosts, mim, domain}),
-    case mongoose_helper:is_rdbms_enabled(Host) of
+    case is_rdbms_enabled(Host) of
         true -> rdbms;
         false -> mnesia
     end.
@@ -462,7 +462,7 @@ get_session_info(RpcDetails, User) ->
     Info.
 
 wait_for_route_message_count(C2sPid, ExpectedCount) when is_pid(C2sPid), is_integer(ExpectedCount) ->
-    mongoose_helper:wait_until(fun() -> count_route_messages(C2sPid) end, ExpectedCount, #{name => has_route_message}).
+    wait_until(fun() -> count_route_messages(C2sPid) end, ExpectedCount, #{name => has_route_message}).
 
 count_route_messages(C2sPid) when is_pid(C2sPid) ->
      {messages, Messages} = rpc:pinfo(C2sPid, messages),
@@ -572,7 +572,7 @@ do_restore_config_option(Option, {error, not_found}) ->
 wait_for_n_offline_messages(Client, N) ->
     LUser = escalus_utils:jid_to_lower(escalus_client:username(Client)),
     LServer = escalus_utils:jid_to_lower(escalus_client:server(Client)),
-    WaitFn = fun() -> mongoose_helper:total_offline_messages({LUser, LServer}) end,
+    WaitFn = fun() -> total_offline_messages({LUser, LServer}) end,
     wait_until(WaitFn, N).
 
 wait_for_c2s_state_name(C2SPid, NewStateName) ->

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -35,6 +35,7 @@
 -export([make_jid/2]).
 -export([make_jid/3]).
 -export([make_jid_noprep/3]).
+-export([get_session_pid/1]).
 -export([get_session_pid/2]).
 -export([get_session_info/2]).
 -export([wait_for_route_message_count/2]).
@@ -440,6 +441,9 @@ make_jid(User, Server) ->
 
 make_jid(User, Server, Resource) ->
     jid:make(User, Server, Resource).
+
+get_session_pid(User, Node) ->
+    get_session_pid(User, mim()).
 
 get_session_pid(User, Node) ->
     Resource = escalus_client:resource(User),

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -577,7 +577,7 @@ wait_for_n_offline_messages(Client, N) ->
 
 wait_for_c2s_state_name(C2SPid, NewStateName) ->
     wait_until(fun() -> get_c2s_state_name(C2SPid) end, NewStateName,
-                #{name => get_c2s_state_name, time_left => timer:seconds(5)}).
+                #{name => get_c2s_state_name}).
 
 get_c2s_state_name(C2SPid) when is_pid(C2SPid) ->
     SysStatus = rpc(mim(), sys, get_status, [C2SPid]),

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -18,6 +18,7 @@
 -define(NS_FEATURE_MSGOFFLINE,  <<"msgoffline">>).
 
 -import(domain_helper, [host_type/0]).
+-import(mongoose_helper, [wait_for_n_offline_messages/2]).
 
 %%%===================================================================
 %%% Suite configuration
@@ -370,12 +371,6 @@ has_element_with_ns(Stanza, Element, NS) ->
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
-wait_for_n_offline_messages(Client, N) ->
-    LUser = escalus_utils:jid_to_lower(escalus_client:username(Client)),
-    LServer = escalus_utils:jid_to_lower(escalus_client:server(Client)),
-    WaitFn = fun() -> mongoose_helper:total_offline_messages({LUser, LServer}) end,
-    mongoose_helper:wait_until(WaitFn, N).
-
 logout(Config, User) ->
     mongoose_helper:logout_user(Config, User).
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -274,7 +274,7 @@ session_resumed_then_old_session_is_closed_gracefully_with_correct_error_stanza(
                    escalus_connection:get_stanza(Alice, close_old_stream)),
     escalus:assert(is_stream_end,
                    escalus_connection:get_stanza(Alice, close_old_stream)),
-    true = escalus_connection:wait_for_close(Alice,timer:seconds(5)),
+    true = escalus_connection:wait_for_close(Alice, timer:seconds(5)),
     true = escalus_connection:is_connected(Alice2),
     escalus_connection:stop(Alice2).
 
@@ -364,7 +364,7 @@ h_non_given_closes_stream_gracefully(ConfigIn) ->
                        escalus:wait_for_stanza(Alice)),
         mongoose_helper:wait_for_pid_to_die(C2SPid),
         escalus:assert(is_stream_end, escalus_connection:get_stanza(Alice, stream_end)),
-        true = escalus_connection:wait_for_close(Alice,timer:seconds(5))
+        true = escalus_connection:wait_for_close(Alice, timer:seconds(5))
     end).
 
 client_acks_more_than_sent(Config) ->
@@ -1207,7 +1207,7 @@ assert_no_offline_msgs_spec(Spec) ->
 
 wait_for_c2s_unacked_count(C2SPid, Count) ->
     mongoose_helper:wait_until(fun() -> get_c2s_unacked_count(C2SPid) end, Count,
-                                #{name => get_c2s_unacked_count, time_left => timer:seconds(5)}).
+                                #{name => get_c2s_unacked_count}).
 
 get_c2s_unacked_count(C2SPid) ->
      Info = rpc(mim(), ejabberd_c2s, get_info, [C2SPid]),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -1042,9 +1042,9 @@ messages_are_properly_flushed_during_resumption(Config) ->
         SMH = escalus_connection:get_sm_h(Alice),
         escalus_client:kill_connection(Config, Alice),
         %% The receiver process would stop now
-        wait_for_c2s_state(Alice, resume_session),
-
         C2SPid = mongoose_helper:get_session_pid(Alice),
+        wait_for_c2s_state_change(C2SPid, resume_session),
+
         wait_for_queue_length(C2SPid, 0),
         ok = rpc(mim(), sys, suspend, [C2SPid]),
 
@@ -1081,8 +1081,8 @@ messages_are_properly_flushed_during_resumption_p1_fsm_old(Config) ->
         Alice = connect_fresh(Config, alice, sr_presence),
         SMH = escalus_connection:get_sm_h(Alice),
         escalus_client:kill_connection(Config, Alice),
-        wait_for_c2s_state(Alice, resume_session),
         C2SPid = mongoose_helper:get_session_pid(Alice),
+        wait_for_c2s_state_change(C2SPid, resume_session),
         ok = rpc(mim(), sys, suspend, [C2SPid]),
 
         %% send some dummy event. ignored by c2s but ensures that
@@ -1357,10 +1357,6 @@ stop_client_and_wait_for_termination(Alice) ->
     C2SRef = monitor_session(Alice),
     escalus_connection:stop(Alice),
     ok = wait_for_process_termination(C2SRef).
-
-wait_for_c2s_state(Alice, StateName) ->
-    C2SPid = mongoose_helper:get_session_pid(Alice),
-    mongoose_helper:wait_until(fun() -> get_c2s_state(C2SPid) end, StateName).
 
 kill_and_connect_with_resume_session_without_waiting_for_result(Alice) ->
     SMH = escalus_connection:get_sm_h(Alice),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -344,22 +344,18 @@ server_enables_sm_after_session(Config) ->
     connect_fresh(Config, alice, sm_after_session).
 
 server_returns_failed_after_start(Config) ->
-    server_returns_failed(Config, []).
+    Alice = connect_fresh(Config, alice, before_auth),
+    server_returns_failed(Alice).
 
 server_returns_failed_after_auth(Config) ->
-    server_returns_failed(Config, [authenticate]).
+    Alice = connect_fresh(Config, alice, auth),
+    server_returns_failed(Alice).
 
 server_enables_resumption(Config) ->
     Alice = connect_fresh(Config, alice, sr_presence),
     escalus_connection:stop(Alice).
 
-server_returns_failed(Config, ConnActions) ->
-    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    {ok, Alice, _} = escalus_connection:start(AliceSpec,
-                                                 [start_stream,
-                                                  stream_features,
-                                                  maybe_use_ssl]
-                                                 ++ ConnActions),
+server_returns_failed(Alice) ->
     escalus_connection:send(Alice, escalus_stanza:enable_sm()),
     escalus:assert(is_sm_failed, [<<"unexpected-request">>],
                    escalus_connection:get_stanza(Alice, enable_sm_failed)).

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -42,8 +42,7 @@ groups() ->
          {stream_mgmt_disabled, [], stream_mgmt_disabled_cases()},
          {manual_ack_freq_long_session_timeout, [parallel], [preserve_order]},
          {unacknowledged_message_hook, [parallel], unacknowledged_message_hook()}],
-%   ct_helper:repeat_all_until_all_ok(G).
-    G.
+    ct_helper:repeat_all_until_all_ok(G).
 
 
 parallel_test_cases() ->
@@ -261,7 +260,7 @@ client_enables_sm_twice_fails_with_correct_error_stanza(Config) ->
                    escalus_connection:get_stanza(Alice, enable_sm_failed)),
     escalus:assert(is_stream_end,
                    escalus_connection:get_stanza(Alice, enable_sm_failed)),
-    true = escalus_connection:wait_for_close(Alice,timer:seconds(5)).
+    true = escalus_connection:wait_for_close(Alice, timer:seconds(5)).
 
 session_resumed_then_old_session_is_closed_gracefully_with_correct_error_stanza(Config) ->
     %% GIVEN USER WITH STREAM RESUMPTION ENABLED
@@ -1344,8 +1343,7 @@ stop_client_and_wait_for_termination(Alice) ->
 
 kill_and_connect_with_resume_session_without_waiting_for_result(Alice) ->
     SMH = escalus_connection:get_sm_h(Alice),
-    AliceSpec = client_to_spec(Alice),
-    {ok, NewAlice, _} = escalus_connection:start(AliceSpec, connection_steps_to_authenticate()),
+    NewAlice = connect_same(Alice, auth),
     SMID = client_to_smid(Alice),
     %% kill alice connection
     escalus_connection:kill(Alice),

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -229,14 +229,10 @@ server_announces_sm(Config) ->
 
 
 server_enables_sm_before_session(Config) ->
-    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    Steps = connection_steps_to_enable_stream_mgmt(after_bind),
-    {ok, _, _} = escalus_connection:start(AliceSpec, Steps).
+    connect_fresh(Config, alice, sm_after_bind).
 
 server_enables_sm_after_session(Config) ->
-    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    Steps = connection_steps_to_enable_stream_mgmt(after_session),
-    {ok, _, _} = escalus_connection:start(AliceSpec, Steps).
+    connect_fresh(Config, alice, sm_after_session).
 
 server_returns_failed_after_start(Config) ->
     server_returns_failed(Config, []).
@@ -245,10 +241,7 @@ server_returns_failed_after_auth(Config) ->
     server_returns_failed(Config, [authenticate]).
 
 server_enables_resumption(Config) ->
-    AliceSpec = escalus_fresh:create_fresh_user(Config, alice),
-    %% Assert matches {ok, _, _, _}
-    Steps = connection_steps_to_enable_stream_resumption(),
-    {ok, Alice, _} = escalus_connection:start(AliceSpec, Steps),
+    Alice = connect_fresh(Config, alice, sr_presence),
     escalus_connection:stop(Alice).
 
 server_returns_failed(Config, ConnActions) ->

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -484,23 +484,23 @@ preserve_order(Config) ->
     Bob = connect_fresh(Config, bob, presence),
     Alice = connect_fresh(Config, alice, sr_presence),
     AliceSpec = client_to_spec(Alice),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"1">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"1">>)),
 
     %% kill alice connection
     escalus_connection:kill(Alice),
     wait_until_disconnected(Alice),
 
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"2">>)),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"3">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"2">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"3">>)),
 
     NewAlice = connect_spec(AliceSpec, session),
     escalus_connection:send(NewAlice, escalus_stanza:enable_sm([resume])),
 
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"4">>)),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"5">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"4">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"5">>)),
 
     escalus_connection:send(NewAlice, escalus_stanza:presence(<<"available">>)),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"6">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"6">>)),
 
     receive_all_ordered(NewAlice, 1, 6),
 
@@ -538,7 +538,7 @@ resend_unacked_after_resume_timeout(Config) ->
     Alice = connect_fresh(Config, alice, sr_presence),
     AliceSpec = client_to_spec(Alice),
 
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-1">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-1">>)),
     %% kill alice connection
     escalus_connection:kill(Alice),
 
@@ -560,7 +560,7 @@ resume_expired_session_returns_correct_h(Config) ->
     Bob = connect_fresh(Config, bob, sr_presence),
     Alice = connect_fresh(Config, alice, sr_presence),
     %% Bob sends a message to Alice, and Alice receives it but doesn't acknowledge
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-1">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-1">>)),
     escalus:wait_for_stanza(Alice),
     %% alice comes back, but too late, so resumption doesn't work,
     %% but she receives the previous h = 1 anyway
@@ -596,7 +596,7 @@ resume_session_state_send_message(Config) ->
     Alice = connect_fresh(Config, alice, sr_presence, manual),
     ack_initial_presence(Alice),
 
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-1">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-1">>)),
     %% kill alice connection
     C2SPid = mongoose_helper:get_session_pid(Alice),
     escalus_connection:kill(Alice),
@@ -604,8 +604,8 @@ resume_session_state_send_message(Config) ->
     assert_alive_resources(Alice, 1),
 
     %% send some messages and check if c2s can handle it
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-2">>)),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-3">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-2">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-3">>)),
     %% suspend the process to ensure that Alice has enough time to reconnect,
     %% before resumption timeout occurs.
     ok = rpc(mim(), sys, suspend, [C2SPid]),
@@ -636,7 +636,7 @@ resume_session_state_stop_c2s(Config) ->
     get_ack(Alice),
     ack_initial_presence(Alice),
 
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-1">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-1">>)),
     escalus:assert(is_chat_message, [<<"msg-1">>], escalus_connection:get_stanza(Alice, msg)),
 
     %% get pid of c2s
@@ -739,8 +739,8 @@ unacknowledged_message_hook_common(RestartConnectionFN, Config) ->
 
     SMID = client_to_smid(Alice),
 
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-1">>)),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-2">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-1">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-2">>)),
     %% kill alice connection
     C2SPid = mongoose_helper:get_session_pid(Alice),
     escalus_connection:kill(Alice),
@@ -752,8 +752,8 @@ unacknowledged_message_hook_common(RestartConnectionFN, Config) ->
     ?assertEqual(timeout, wait_for_unacked_msg_hook(0, Resource, 100)),
 
     %% send some messages and check if c2s can handle it
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-3">>)),
-    escalus_connection:send(Bob, escalus_stanza:chat_to(Alice, <<"msg-4">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-3">>)),
+    escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"msg-4">>)),
     escalus:assert(is_chat_message, [<<"msg-3">>], wait_for_unacked_msg_hook(0, Resource, 100)),
     escalus:assert(is_chat_message, [<<"msg-4">>], wait_for_unacked_msg_hook(0, Resource, 100)),
     ?assertEqual(timeout, wait_for_unacked_msg_hook(0, Resource, 100)),

--- a/big_tests/tests/sm_helper.erl
+++ b/big_tests/tests/sm_helper.erl
@@ -1,0 +1,299 @@
+%% Session Management helpers
+-module(sm_helper).
+
+-export([client_to_spec0/1,
+         client_to_spec/1,
+         client_to_smid/1,
+         get_sid_by_stream_id/1]).
+
+%% Connection helpers
+-export([connect_fresh/3,
+         connect_fresh/4,
+         connect_spec/2,
+         connect_spec/3,
+         connect_same/2,
+         connect_same/3,
+         connect_resume/2]).
+
+%% Waiting and introspection helpers
+-export([wait_until_disconnected/1,
+         try_to_resume_stream/3,
+         kill_and_connect_with_resume_session_without_waiting_for_result/1,
+         stop_client_and_wait_for_termination/1,
+         assert_alive_resources/2,
+         get_user_present_resources/1,
+         wait_for_c2s_unacked_count/2,
+         wait_for_resource_count/2,
+         wait_for_process_termination/1,
+         process_initial_stanza/1,
+         kill_and_connect_resume/1,
+         monitor_session/1,
+         wait_for_process_termination/1,
+         wait_for_queue_length/2]).
+
+%% Stanza helpers
+-export([send_initial_presence/1,
+         send_messages/3,
+         wait_for_messages/2,
+         get_ack/1,
+         ack_initial_presence/1]).
+
+-include_lib("escalus/include/escalus.hrl").
+
+-import(distributed_helper, [mim/0,
+                             rpc/4]).
+
+-define(MOD_SM, mod_stream_management).
+
+client_to_smid(#client{props = Props}) ->
+    proplists:get_value(smid, Props).
+
+client_to_spec(#client{props = Props}) ->
+    Props.
+
+%% Returns the original spec, without the dynamically added fields
+client_to_spec0(#client{props = Props}) ->
+    lists:foldl(fun proplists:delete/2, Props, [stream_id, resource]).
+
+get_sid_by_stream_id(SMID) ->
+    rpc(mim(), ?MOD_SM, get_sid, [SMID]).
+
+
+%% Connection helpers
+
+final_step_to_steps(auth) ->
+    connection_steps_to_authenticate();
+final_step_to_steps(session) ->
+    connection_steps_to_session();
+final_step_to_steps(presence) ->
+    connection_steps_to_presence();
+final_step_to_steps(sr_session) ->
+    connection_steps_to_enable_stream_resumption();
+final_step_to_steps(sr_presence) ->
+    connection_steps_to_enable_stream_resumption_and_presence();
+final_step_to_steps(sm_presence) ->
+    connection_steps_to_enable_stream_mgmt_and_presence();
+final_step_to_steps(sm_after_session) ->
+    connection_steps_to_enable_stream_mgmt(after_session);
+final_step_to_steps(sm_after_bind) ->
+    connection_steps_to_enable_stream_mgmt(after_bind);
+final_step_to_steps(sm_before_session) ->
+    connection_steps_to_enable_stream_mgmt(after_bind) ++ [session];
+final_step_to_steps({resume, SMID, H}) ->
+    connection_steps_to_stream_resumption(SMID, H).
+
+%% Connection steps
+connection_steps_to_authenticate() ->
+    [start_stream,
+     stream_features,
+     maybe_use_ssl,
+     authenticate].
+
+connection_steps_to_bind() ->
+    connection_steps_to_authenticate() ++ [bind].
+
+connection_steps_to_session() ->
+    connection_steps_to_bind() ++ [session].
+
+connection_steps_to_enable_stream_mgmt(after_session) ->
+    connection_steps_to_session() ++ [stream_management];
+connection_steps_to_enable_stream_mgmt(after_bind) ->
+    connection_steps_to_bind() ++ [stream_management].
+
+connection_steps_to_enable_stream_resumption() ->
+    connection_steps_to_session() ++ [stream_resumption].
+
+connection_steps_to_enable_stream_resumption_and_presence() ->
+    connection_steps_to_enable_stream_resumption() ++ [fun initial_presence_step/2].
+
+connection_steps_to_presence() ->
+    connection_steps_to_session() ++ [fun initial_presence_step/2].
+
+connection_steps_to_enable_stream_mgmt_and_presence() ->
+    connection_steps_to_enable_stream_mgmt(after_session) ++ [fun initial_presence_step/2].
+
+connection_steps_to_stream_resumption(SMID, H) ->
+    connection_steps_to_authenticate() ++ [mk_resume_stream(SMID, H)].
+
+mk_resume_stream(SMID, PrevH) ->
+    fun (Conn = #client{props = Props}, Features) ->
+            Resumed = try_to_resume_stream(Conn, SMID, PrevH),
+            true = escalus_pred:is_sm_resumed(SMID, Resumed),
+            {Conn#client{props = [{smid, SMID} | Props]}, Features}
+    end.
+
+try_to_resume_stream(Conn, SMID, PrevH) ->
+    escalus_connection:send(Conn, escalus_stanza:resume(SMID, PrevH)),
+    escalus_connection:get_stanza(Conn, get_resumed).
+
+initial_presence_step(Conn, Features) ->
+    process_initial_stanza(Conn),
+    {Conn, Features}.
+
+%% Making connections with different set of steps is a common procedure in sm_SUITE
+%% This group of functions helps to keep code short and clean
+connect_fresh(Config, Name, FinalStep) ->
+    connect_fresh(Config, Name, FinalStep, auto).
+
+connect_fresh(Config, Name, FinalStep, Ack) ->
+    Spec = escalus_fresh:create_fresh_user(Config, Name),
+    connect_spec(Spec, FinalStep, Ack).
+
+connect_spec(Spec, FinalStep) ->
+    connect_spec(Spec, FinalStep, auto).
+
+connect_spec(Spec, FinalStep, Ack) ->
+    Steps = final_step_to_steps(FinalStep),
+    ExtraOpts = ack_to_extra_opts(Ack),
+    {ok, Client, _} = escalus_connection:start(ExtraOpts ++ Spec, Steps),
+    Client.
+
+connect_same(Client, FinalStep) ->
+    connect_same(Client, FinalStep, auto).
+
+connect_same(Client, FinalStep, Ack) ->
+    connect_spec(client_to_spec0(Client), FinalStep, Ack).
+
+ack_to_extra_opts(auto) -> [];
+ack_to_extra_opts(manual) -> [{manual_ack, true}].
+
+kill_and_connect_resume(Client) ->
+    %% Get SMH before killing the old connection
+    SMH = escalus_connection:get_sm_h(Client),
+    escalus_connection:kill(Client),
+    connect_resume(Client, SMH).
+
+connect_resume(Client, SMH) ->
+    SMID = client_to_smid(Client),
+    Spec = client_to_spec(Client),
+    C2SPid = mongoose_helper:get_session_pid(Client),
+    Steps = connection_steps_to_stream_resumption(SMID, SMH),
+    try
+        {ok, Client2, _} = escalus_connection:start(Spec, Steps),
+        Client2
+    catch Class:Error:Stacktrace ->
+        ct:pal("C2S info ~p", [rpc:pinfo(C2SPid, [messages, current_stacktrace])]),
+        erlang:raise(Class, Error, Stacktrace)
+    end.
+
+kill_and_connect_with_resume_session_without_waiting_for_result(Alice) ->
+    SMH = escalus_connection:get_sm_h(Alice),
+    NewAlice = connect_same(Alice, auth),
+    SMID = client_to_smid(Alice),
+    %% kill alice connection
+    escalus_connection:kill(Alice),
+    %% ensure there is no session
+    wait_until_disconnected(Alice),
+    escalus_connection:send(NewAlice, escalus_stanza:resume(SMID, SMH)),
+    NewAlice.
+
+stop_client_and_wait_for_termination(Alice) ->
+    C2SRef = monitor_session(Alice),
+    escalus_connection:stop(Alice),
+    ok = wait_for_process_termination(C2SRef).
+
+
+%% Waiting and introspection helpers
+
+monitor_session(Client) ->
+    C2SPid = mongoose_helper:get_session_pid(Client),
+    erlang:monitor(process, C2SPid).
+
+-spec wait_for_process_termination(MRef :: reference()) -> ok.
+wait_for_process_termination(MRef) ->
+    receive
+        {'DOWN', MRef, _Type, _C2SPid, _Info} ->
+            ok
+    after 5000 ->
+              ct:fail(wait_for_process_termination_timeout)
+    end,
+    ok.
+
+wait_for_queue_length(Pid, Length) ->
+    F = fun() ->
+                case rpc(mim(), erlang, process_info, [Pid, messages]) of
+                    {messages, List} when length(List) =:= Length ->
+                        ok;
+                    {messages, List} ->
+                        {messages, length(List), List};
+                    Other ->
+                        Other
+                end
+        end,
+    mongoose_helper:wait_until(F, ok, #{name => {wait_for_queue_length, Length}}).
+
+wait_for_c2s_unacked_count(C2SPid, Count) ->
+    mongoose_helper:wait_until(fun() -> get_c2s_unacked_count(C2SPid) end, Count,
+                                #{name => get_c2s_unacked_count}).
+
+get_c2s_unacked_count(C2SPid) ->
+     Info = rpc(mim(), ejabberd_c2s, get_info, [C2SPid]),
+     maps:get(stream_mgmt_buffer_size, Info).
+
+wait_until_disconnected(Client) ->
+    wait_for_resource_count(Client, 0).
+
+wait_for_resource_count(Client, N) ->
+    mongoose_helper:wait_until(fun() -> length(get_user_alive_resources(Client)) end,
+                               N, #{name => get_user_alive_resources}).
+
+assert_alive_resources(Alice, N) ->
+    N = length(get_user_alive_resources(Alice)).
+
+get_user_alive_resources(Client) ->
+    UserSpec = client_to_spec(Client),
+    {U, S} = get_us_from_spec(UserSpec),
+    JID = mongoose_helper:make_jid(U, S, <<>>),
+    rpc(mim(), ejabberd_sm, get_user_resources, [JID]).
+
+get_user_present_resources(Client) ->
+    UserSpec = client_to_spec(Client),
+    {U, S} = get_us_from_spec(UserSpec),
+    JID = mongoose_helper:make_jid(U, S, <<>>),
+    rpc(mim(), ejabberd_sm, get_user_present_resources, [JID]).
+
+get_us_from_spec(UserSpec) ->
+    U = proplists:get_value(username, UserSpec),
+    S = proplists:get_value(server, UserSpec),
+    {U, S}.
+
+
+%% Cleaning helpers
+
+clear_session_table() ->
+    Node = ct:get_config({hosts, mim, node}),
+    SessionBackend  = rpc(mim(), ejabberd_sm, sm_backend, []),
+    rpc(mim(), SessionBackend, cleanup, [Node]).
+
+clear_sm_session_table() ->
+    rpc(mim(), mnesia, clear_table, [sm_session]).
+
+
+%% Stanza helpers
+
+send_initial_presence(User) ->
+    InitialPresence = escalus_stanza:presence(<<"available">>),
+    escalus_connection:send(User, InitialPresence).
+
+process_initial_stanza(User) ->
+    send_initial_presence(User),
+    escalus:assert(is_presence, escalus:wait_for_stanza(User)).
+
+send_messages(Bob, Alice, Texts) ->
+    [escalus:send(Bob, escalus_stanza:chat_to(Alice, Text))
+     || Text <- Texts].
+
+wait_for_messages(Alice, Texts) ->
+    Stanzas = escalus:wait_for_stanzas(Alice, length(Texts)),
+    assert_same_length(Stanzas, Texts),
+    [escalus:assert(is_chat_message, [Text], Stanza)
+     || {Text, Stanza} <- lists:zip(Texts, Stanzas)],
+    ok.
+
+assert_same_length(List1, List2) when length(List1) =:= length(List2) -> ok.
+
+get_ack(Client) ->
+    escalus:assert(is_sm_ack_request, escalus_connection:get_stanza(Client, ack)).
+
+ack_initial_presence(Client) ->
+    escalus_connection:send(Client, escalus_stanza:sm_ack(1)).

--- a/big_tests/tests/sm_helper.erl
+++ b/big_tests/tests/sm_helper.erl
@@ -280,15 +280,18 @@ wait_for_messages(Alice, Texts) ->
     assert_messages(Stanzas, Texts).
 
 assert_messages(Stanzas, Texts) ->
-    assert_same_length(Stanzas, Texts),
-    Checks = [escalus_pred:is_chat_message(Text, Stanza)
-              || {Text, Stanza} <- lists:zip(Texts, Stanzas)],
-    case lists:usort(Checks) of
-        [true] ->
+    Bodies = lists:map(fun get_body/1, Stanzas),
+    case Bodies of
+        Texts ->
             ok;
         _ ->
-            ct:fail({assert_messages_failed, Checks, Stanzas, Texts})
+            ct:fail({assert_messages_failed, Stanzas,
+                     {expected, Texts},
+                     {received, Bodies}})
     end.
+
+get_body(Stanza) ->
+      exml_query:path(Stanza, [{element, <<"body">>}, cdata]).
 
 get_ack(Client) ->
     escalus:assert(is_sm_ack_request, escalus_connection:get_stanza(Client, ack)).

--- a/big_tests/tests/sm_helper.erl
+++ b/big_tests/tests/sm_helper.erl
@@ -61,6 +61,8 @@ get_sid_by_stream_id(SMID) ->
 
 %% Connection helpers
 
+final_step_to_steps(before_auth) ->
+    connection_steps_before_auth();
 final_step_to_steps(auth) ->
     connection_steps_to_authenticate();
 final_step_to_steps(session) ->
@@ -83,11 +85,12 @@ final_step_to_steps({resume, SMID, H}) ->
     connection_steps_to_stream_resumption(SMID, H).
 
 %% Connection steps
-connection_steps_to_authenticate() ->
+connection_steps_before_auth() ->
     [start_stream,
      stream_features,
-     maybe_use_ssl,
-     authenticate].
+     maybe_use_ssl].
+connection_steps_to_authenticate() ->
+    connection_steps_before_auth() ++ [authenticate].
 
 connection_steps_to_bind() ->
     connection_steps_to_authenticate() ++ [bind].

--- a/big_tests/tests/sm_helper.erl
+++ b/big_tests/tests/sm_helper.erl
@@ -22,14 +22,13 @@
          stop_client_and_wait_for_termination/1,
          assert_alive_resources/2,
          get_user_present_resources/1,
-         wait_for_c2s_unacked_count/2,
+         wait_for_queue_length/2,
          wait_for_resource_count/2,
+         wait_for_c2s_unacked_count/2,
          wait_for_process_termination/1,
          process_initial_stanza/1,
          kill_and_connect_resume/1,
-         monitor_session/1,
-         wait_for_process_termination/1,
-         wait_for_queue_length/2]).
+         monitor_session/1]).
 
 %% Stanza helpers
 -export([send_initial_presence/1,
@@ -259,17 +258,6 @@ get_us_from_spec(UserSpec) ->
     U = proplists:get_value(username, UserSpec),
     S = proplists:get_value(server, UserSpec),
     {U, S}.
-
-
-%% Cleaning helpers
-
-clear_session_table() ->
-    Node = ct:get_config({hosts, mim, node}),
-    SessionBackend  = rpc(mim(), ejabberd_sm, sm_backend, []),
-    rpc(mim(), SessionBackend, cleanup, [Node]).
-
-clear_sm_session_table() ->
-    rpc(mim(), mnesia, clear_table, [sm_session]).
 
 
 %% Stanza helpers


### PR DESCRIPTION
Proposed changes include:
* Remove code duplication by introducing a function connect_fresh and connect_spec.
* Explicitly specify which cases use manual_ack, when creating a connection
* Make sm_helper module with helpers
* No export_all, so we can remove unused functions.
* export_helper parse transform, so we don't specify cases three times... just two.

Motivation:
- that suite contains a lot of escalus_connection:connect calls. And 3 lines syntax makes harder to compare test cases.

Reduce complexity to keep in mind that:
- sm is enabled in test.config, unless we provide steps separately.
- manual_ack could be specified in the group settings or in test cases. Once we starting to pass Spec, it is harder to keep in mind which connections need manual acking.
- `connections_steps_to_something` is harder to read comparing to just `something`.
- a separate sm_helper allows to focus just on test cases and CT init logic.