### PR TITLE
GraphQL - Better error messages formatting 

### DIFF
--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -148,27 +148,31 @@ invalid_json_body_error(Config) ->
     Body = <<"">>,
     {Status, Data} = execute(Ep, Body, undefined),
     ?assertEqual({<<"400">>,<<"Bad Request">>}, Status),
-    ?assertMatch(#{<<"errors">> := [#{<<"message">> := <<"invalid_json_body">>}]}, Data).
+    assert_code(invalid_json_body, Data).
 
 no_query_supplied_error(Config) ->
     Ep = ?config(schema_endpoint, Config),
     Body = #{},
     {Status, Data} = execute(Ep, Body, undefined),
     ?assertEqual({<<"400">>,<<"Bad Request">>}, Status),
-    ?assertMatch(#{<<"errors">> := [#{<<"message">> := <<"no_query_supplied">>}]}, Data).
+    assert_code(no_query_supplied, Data).
 
 variables_invalid_json_error(Config) ->
     Ep = ?config(schema_endpoint, Config),
     Body = #{<<"query">> => <<"{ field }">>, <<"variables">> => <<"{1: 2}">>},
     {Status, Data} = execute(Ep, Body, undefined),
     ?assertEqual({<<"400">>,<<"Bad Request">>}, Status),
-    ?assertMatch(#{<<"errors">> := [#{<<"message">> := <<"variables_invalid_json">>}]}, Data).
+    assert_code(variables_invalid_json, Data).
 
 %% Helpers
 
+assert_code(Code, Data) ->
+    BinCode = atom_to_binary(Code),
+    ?assertMatch(#{<<"errors">> := [#{<<"extensions">> := #{<<"code">> := BinCode}}]}, Data).
+
 assert_no_permissions(Status, Data) ->
     ?assertEqual({<<"400">>,<<"Bad Request">>}, Status),
-    ?assertMatch(#{<<"errors">> := [#{<<"message">> := <<"no_permissions">>}]}, Data).
+    ?assertMatch(#{<<"errors">> := [#{<<"extensions">> := #{<<"code">> := <<"no_permissions">>}}]}, Data).
 
 assert_access_granted(Status, Data) ->
     ?assertEqual({<<"200">>,<<"OK">>}, Status),

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -111,6 +111,7 @@ malformed_auth_header_error(Config) ->
         headers => [{<<"Authorization">>, <<"Basic YWRtaW46c2VjcmV">>}],
         return_maps => true,
         path => "/graphql"},
+    % The encoded credentials value is malformed and cannot be decoded.
     {Status, Data} = rest_helper:make_request(Request),
     assert_no_permissions(request_error, Status, Data).
 

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -87,6 +87,7 @@ unauth_cannot_access_protected_types(Config) ->
     Ep = ?config(schema_endpoint, Config),
     Body = #{query => "{ field }"},
     {Status, Data} = execute(Ep, Body, undefined),
+    ?assertMatch(#{<<"errors">> := [#{<<"path">> := [<<"ROOT">>]}]}, Data),
     assert_no_permissions(no_permissions, Status, Data).
 
 unauth_can_access_unprotected_types(Config) ->

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -1133,7 +1133,7 @@ can_handle_execution_error(Config) ->
     Res = mongooseimctl("graphql", [Query], Config),
     ?assertMatch({_, 0}, Res),
     Data = element(1, Res),
-    ?assertNotEqual(nomatch, string:find(Data, "{error,{parser_error")).
+    ?assertNotEqual(nomatch, string:find(Data, "parser_error")).
 
 graphql_wrong_arguments_number(Config) ->
     ExpectedFragment = "This command requires",

--- a/src/mongoose_graphql.erl
+++ b/src/mongoose_graphql.erl
@@ -72,7 +72,13 @@ execute(Ep, #{document := Doc,
         {ok, graphql:execute(Ep, Ctx2, Ast2)}
     catch
         throw:{error, Err} ->
-            {error, Err}
+            {error, Err};
+        Class:Reason:Stacktrace ->
+            Err = #{what => graphql_internal_crash,
+                    class => Class, reason => Reason,
+                    stacktrace => Stacktrace},
+            ?LOG_ERROR(Err),
+            {error, internal_crash}
     end.
 
 %% @doc Execute selected operation on a given endpoint with authorization.

--- a/src/mongoose_graphql.erl
+++ b/src/mongoose_graphql.erl
@@ -104,8 +104,8 @@ graphql_parse(Doc) ->
     case graphql:parse(Doc) of
         {ok, _} = Ok ->
             Ok;
-        {error, _} = Err ->
-            throw(Err)
+        {error, Err} ->
+            graphql_err:abort([], parse, Err)
     end.
 
 admin_mapping_rules() ->

--- a/src/mongoose_graphql/mongoose_graphql_errors.erl
+++ b/src/mongoose_graphql/mongoose_graphql_errors.erl
@@ -65,7 +65,7 @@ simplify(T) when is_tuple(T) -> element(1, T).
 err_msg(parse, Result) ->
     parse_err_msg(Result);
 err_msg(decode, Result) ->
-    decode_err_mgs(Result);
+    decode_err_msg(Result);
 err_msg(authorize, Result) ->
     authorize_err_msg(Result).
 
@@ -82,12 +82,12 @@ parse_err_msg({scanner_error, {Line, graphql_scanner, Msg}}) ->
     Formatted = lists:flatten(graphql_scanner:format_error(Msg)),
     io_lib:format("Cannot scan line ~B because of ~s", [Line, Formatted]).
 
-decode_err_mgs(no_query_supplied) ->
-    "The query was not supplied in request body";
-decode_err_mgs(invalid_json_body) ->
-    "The request json body is invalid";
-decode_err_mgs(variables_invalid_json) ->
-    "The variables' json is invalid".
+decode_err_msg(no_query_supplied) ->
+    "The query was not supplied in the request body";
+decode_err_msg(invalid_json_body) ->
+    "The request JSON body is invalid";
+decode_err_msg(variables_invalid_json) ->
+    "The variables' JSON is invalid".
 
 add_path(#{path := Path}, ErrMsg) ->
     ErrMsg#{path => Path};

--- a/src/mongoose_graphql/mongoose_graphql_errors.erl
+++ b/src/mongoose_graphql/mongoose_graphql_errors.erl
@@ -5,45 +5,55 @@
 
 -ignore_xref([format_error/1, format_errors/1, err/2, crash/2]).
 
-% callback invoked when resolver returns error tuple
+%% callback invoked when resolver returns error tuple
 err(_Ctx, domain_not_found) ->
     #{message => <<"Given domain does not exist">>, extensions => #{code => resolver_error}};
 err(_Ctx, ErrorTerm) ->
     #{message => iolist_to_binary(io_lib:format("~p", [ErrorTerm])),
       extensions => #{code => resolver_error}}.
 
-% callback invoked when resolver crashes
+%% callback invoked when resolver crashes
 crash(_Ctx, #{type := Type}) ->
     #{message => <<"Unexpected ", Type/binary, " resolver crash">>,
       extensions => #{code => resolver_crash}}.
 
+%% @doc Format errors that occured in any phase.
 format_errors(Errors) ->
     [format_error(E) || E <- Errors].
 
+%% @doc Format error that occurred in any phase including HTTP request decoding.
 format_error(#{phase := Phase, error_term := Term}) when Phase =:= authorize;
+                                                         Phase =:= decode;
                                                          Phase =:= parse ->
     #{extensions => #{code => err_code(Phase, Term)},
       message => iolist_to_binary(err_msg(Phase, Term))};
-format_error(#{error_term := _} = Err) ->
+format_error(#{error_term := _, phase := Phase} = Err) when Phase =:= execute;
+                                                            Phase =:= type_check;
+                                                            Phase =:= validate;
+                                                            Phase =:= uncategorized ->
     graphql:format_errors(#{}, [Err]);
 format_error(Err) ->
-    #{extensions => #{code => uncathegorized_error},
-      message => iolist_to_binary(io_lib:format("~p", Err))}.
+    #{extensions => #{code => uncathegorized},
+      message => iolist_to_binary(io_lib:format("~p", [Err]))}.
 
 %% Internal
 
-err_code(authorize, _Term) ->
-    authorization_error;
-err_code(parse, Term) ->
-    element(1, Term).
+err_code(_, Term) ->
+    simplify(Term).
+
+simplify(A) when is_atom(A) -> A;
+simplify(B) when is_binary(B) -> B;
+simplify(T) when is_tuple(T) -> element(1, T).
 
 err_msg(parse, Result) ->
     parse_err_msg(Result);
+err_msg(decode, Result) ->
+    decode_err_mgs(Result);
 err_msg(authorize, Result) ->
     authorize_err_msg(Result).
 
 authorize_err_msg({request_error, {header, <<"authorization">>}, _}) ->
-    "Malformed authorization header.Please consult the relevant specification.";
+    "Malformed authorization header. Please consult the relevant specification";
 authorize_err_msg({no_permissions, Op}) ->
     io_lib:format("Cannot execute query ~s without permissions", [Op]).
 
@@ -52,3 +62,10 @@ parse_err_msg({parser_error, {Line, graphql_parser, Msg}}) ->
 parse_err_msg({scanner_error, {Line, graphql_scanner, Msg}}) ->
     Formatted = lists:flatten(graphql_scanner:format_error(Msg)),
     io_lib:format("Cannot scan line ~B because of ~s", [Line, Formatted]).
+
+decode_err_mgs(no_query_supplied) ->
+    "The query was not supplied in request body";
+decode_err_mgs(invalid_json_body) ->
+    "The request json body is invalid";
+decode_err_mgs(variables_invalid_json) ->
+    "The variables' json is invalid".

--- a/src/mongoose_graphql/mongoose_graphql_errors.erl
+++ b/src/mongoose_graphql/mongoose_graphql_errors.erl
@@ -33,14 +33,15 @@ format_error(#{error_term := _, phase := Phase} = Err) when Phase =:= execute;
                                                             Phase =:= type_check;
                                                             Phase =:= validate;
                                                             Phase =:= uncategorized ->
-    [ErrMsg] = graphql:format_errors(#{}, [Err]),
+    Err2 = maps:merge(#{path => []}, Err),
+    [ErrMsg] = graphql:format_errors(#{}, [Err2]),
     {400, ErrMsg};
 format_error(internal_crash) ->
     Msg = #{message => <<"GraphQL Internal Server Error">>,
             extensions => #{code => internal_server_error}},
     {500, Msg};
 format_error(Err) ->
-    Msg = #{extensions => #{code => uncathegorized},
+    Msg = #{extensions => #{code => uncategorized},
             message => iolist_to_binary(io_lib:format("~p", [Err]))},
     {400, Msg}.
 

--- a/src/mongoose_graphql/mongoose_graphql_errors.erl
+++ b/src/mongoose_graphql/mongoose_graphql_errors.erl
@@ -54,6 +54,8 @@ err_msg(authorize, Result) ->
 
 authorize_err_msg({request_error, {header, <<"authorization">>}, _}) ->
     "Malformed authorization header. Please consult the relevant specification";
+authorize_err_msg(wrong_credentials) ->
+    "The provided credentials are wrong";
 authorize_err_msg({no_permissions, Op}) ->
     io_lib:format("Cannot execute query ~s without permissions", [Op]).
 

--- a/src/mongoose_graphql/mongoose_graphql_errors.erl
+++ b/src/mongoose_graphql/mongoose_graphql_errors.erl
@@ -1,9 +1,9 @@
 %% @doc Implements callbacks that format custom errors returned from resolvers or crashes. 
 -module(mongoose_graphql_errors).
 
--export([err/2, crash/2]).
+-export([format_error/1, format_errors/1, err/2, crash/2]).
 
--ignore_xref([err/2, crash/2]).
+-ignore_xref([format_error/1, format_errors/1, err/2, crash/2]).
 
 % callback invoked when resolver returns error tuple
 err(_Ctx, domain_not_found) ->
@@ -16,3 +16,39 @@ err(_Ctx, ErrorTerm) ->
 crash(_Ctx, #{type := Type}) ->
     #{message => <<"Unexpected ", Type/binary, " resolver crash">>,
       extensions => #{code => resolver_crash}}.
+
+format_errors(Errors) ->
+    [format_error(E) || E <- Errors].
+
+format_error(#{phase := Phase, error_term := Term}) when Phase =:= authorize;
+                                                         Phase =:= parse ->
+    #{extensions => #{code => err_code(Phase, Term)},
+      message => iolist_to_binary(err_msg(Phase, Term))};
+format_error(#{error_term := _} = Err) ->
+    graphql:format_errors(#{}, [Err]);
+format_error(Err) ->
+    #{extensions => #{code => uncathegorized_error},
+      message => iolist_to_binary(io_lib:format("~p", Err))}.
+
+%% Internal
+
+err_code(authorize, _Term) ->
+    authorization_error;
+err_code(parse, Term) ->
+    element(1, Term).
+
+err_msg(parse, Result) ->
+    parse_err_msg(Result);
+err_msg(authorize, Result) ->
+    authorize_err_msg(Result).
+
+authorize_err_msg({request_error, {header, <<"authorization">>}, _}) ->
+    "Malformed authorization header.Please consult the relevant specification.";
+authorize_err_msg({no_permissions, Op}) ->
+    io_lib:format("Cannot execute query ~s without permissions", [Op]).
+
+parse_err_msg({parser_error, {Line, graphql_parser, Msg}}) ->
+    io_lib:format("Cannot parse line ~B because of ~s", [Line, Msg]);
+parse_err_msg({scanner_error, {Line, graphql_scanner, Msg}}) ->
+    Formatted = lists:flatten(graphql_scanner:format_error(Msg)),
+    io_lib:format("Cannot scan line ~B because of ~s", [Line, Formatted]).

--- a/src/mongoose_graphql/mongoose_graphql_permissions.erl
+++ b/src/mongoose_graphql/mongoose_graphql_permissions.erl
@@ -50,7 +50,7 @@ check_permissions(OpName, false, #document{definitions = Definitions}) ->
                         true ->
                             ok;
                         false ->
-                            throw({error, no_permissions})
+                            graphql_err:abort([], authorize, {no_permissions, op_name(OpName)})
                     end;
                 false ->
                     ok
@@ -62,6 +62,11 @@ check_permissions(_, true, _) ->
     ok.
 
 % Internal
+
+op_name(undefined) ->
+    <<"ROOT">>;
+op_name(Name) ->
+    Name.
 
 is_req_operation(#op{id = 'ROOT'}, undefined) ->
     true;

--- a/src/mongoose_graphql/mongoose_graphql_permissions.erl
+++ b/src/mongoose_graphql/mongoose_graphql_permissions.erl
@@ -50,7 +50,8 @@ check_permissions(OpName, false, #document{definitions = Definitions}) ->
                         true ->
                             ok;
                         false ->
-                            graphql_err:abort([], authorize, {no_permissions, op_name(OpName)})
+                            OpName2 = op_name(OpName),
+                            graphql_err:abort([OpName2], authorize, {no_permissions, OpName2})
                     end;
                 false ->
                     ok

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -150,13 +150,13 @@ unauth_cannot_execute_protected_query(Config) ->
     Ep = ?config(endpoint, Config),
     Doc = <<"{ field }">>,
     Res = mongoose_graphql:execute(Ep, request(Doc, false)),
-    ?assertEqual({error, no_permissions}, Res).
+    ?assertMatch({error, #{error_term := {no_permissions, <<"ROOT">>}}}, Res).
 
 unauth_cannot_execute_protected_mutation(Config) ->
     Ep = ?config(endpoint, Config),
     Doc = <<"mutation { field }">>,
     Res = mongoose_graphql:execute(Ep, request(Doc, false)),
-    ?assertEqual({error, no_permissions}, Res).
+    ?assertMatch({error, #{error_term := {no_permissions, <<"ROOT">>}}}, Res).
 
 unauth_can_access_introspection(Config) ->
     Ep = ?config(endpoint, Config),

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -7,7 +7,7 @@
 -include_lib("graphql/src/graphql_schema.hrl").
 
 -define(assertPermissionsFailed(Config, Doc),
-        ?assertThrow({error, no_permissions},
+        ?assertThrow({error, #{error_term := {no_permissions, _}}},
                      check_permissions(Config, Doc))).
 -define(assertPermissionsSuccess(Config, Doc),
         ?assertMatch(ok, check_permissions(Config, Doc))).

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -338,12 +338,13 @@ format_decode_errors(_Config) ->
 format_authorize_error(_Config) ->
     {401, Msg1} = mongoose_graphql_errors:format_error(make_error(authorize, wrong_credentials)),
     {401, Msg2} = mongoose_graphql_errors:format_error(
-                    make_error(authorize, {no_permissions, <<"ROOT">>})),
+                    make_error([<<"ROOT">>], authorize, {no_permissions, <<"ROOT">>})),
     {401, Msg3} = mongoose_graphql_errors:format_error(
                     make_error(authorize, {request_error, {header, <<"authorization">>}, 'msg'})),
 
     ?assertErrMsg(wrong_credentials, <<"provided credentials are wrong">>, Msg1),
     ?assertErrMsg(no_permissions, <<"without permissions">>, Msg2),
+    ?assertMatch(#{path := [<<"ROOT">>]}, Msg2),
     ?assertErrMsg(request_error, <<"Malformed authorization header">>, Msg3).
 
 format_validate_error(_Config) ->
@@ -388,6 +389,9 @@ assert_err_msg(Code, MsgContains, #{message := Msg} = ErrorMsg) ->
 
 make_error(Phase, Term) ->
     #{phase => Phase, error_term => Term}.
+
+make_error(Path, Phase, Term) ->
+    #{path => Path, phase => Phase, error_term => Term}.
 
 check_permissions(Config, Doc) ->
     Ep = ?config(endpoint, Config),


### PR DESCRIPTION
This PR addresses [MIM-1569](https://erlangsolutions.atlassian.net/browse/MIM-1569) and solves wrongly formatted messages returned to the user from the webserver.

Proposed changes include:
* Unification of the error messages format.
* Introducing more information to authorization errors.
* Testing produced messages.
* Adding a catch that should handle all unexpected internal errors.

