### PR TITLE
Run MSSQL as root again

### DIFF
--- a/tools/setup-db.sh
+++ b/tools/setup-db.sh
@@ -278,6 +278,7 @@ elif [ "$db" = 'mssql' ]; then
     # Otherwise we get an error in logs
     # Error 87(The parameter is incorrect.) occurred while opening file '/var/opt/mssql/data/master.mdf'
     docker run -d -p $MSSQL_PORT:1433                           \
+               --user root                                      \
                --name=$NAME                                     \
                -e "ACCEPT_EULA=Y"                               \
                -e "SA_PASSWORD=mongooseim_secret+ESL123"        \


### PR DESCRIPTION
This should fix an error on Linux with permissions (and Github Actions CI).
We used to have it there.
Circle CI does not need this. Mac does not need it too (weird)


Testing:
- Get some linux and run
```
DB=mssql tools/setup-db.sh
```