### PR TITLE
Enable cover for big tests

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -6,7 +6,7 @@ references:
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3
-  - &DEPS_CACHE_KEY deps-cache-{{ checksum "rebar.lock" }}-{{ checksum "big_tests/rebar.lock" }}-{{ checksum "otp_version" }}-v4
+  - &DEPS_CACHE_KEY deps-cache-{{ checksum "rebar.lock" }}-{{ checksum "big_tests/rebar.lock" }}-{{ checksum "otp_version" }}-v5
   - &BUILD_CACHE_KEY build-cache-{{ .Branch }}-{{ .Revision }}-{{ checksum "otp_version" }}-v5
 
 # list of references to be used inside executors block

--- a/rebar.config
+++ b/rebar.config
@@ -176,7 +176,8 @@
  [
   {pc, "1.11.0"},
   {provider_asn1, "0.2.3"},
-  {rebar3_codecov, "0.2.0"},
+% {rebar3_codecov, "0.2.0"},
+  {rebar3_codecov, {git, "https://github.com/esl/rebar3_codecov.git", {branch, "mu-configurable-src-dir"}}},
   {rebar3_lint, "0.1.11"}
  ]}.
 
@@ -213,7 +214,8 @@
 {codecov_opts,
  [
   %% Assuming /tmp/mongoose_combined.coverdata
-  {path, ["/tmp", "_build/test/cover"]}
+  {path, ["/tmp", "_build/test/cover"]},
+  {source_paths, ["src/**", "big_tests/tests/**", "big_tests/src/**"]}
  ]}.
 
 {edoc_opts, [{preprocess, true}, {dir, "edoc"}]}.

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -12,6 +12,9 @@
 # Fail on errors
 set -e
 
+# Because rebar3 compiles tests anyway
+export SKIP_AUTO_COMPILE=true
+
 USAGE=$(cat <<-END
 This script runs small and big tests for MongooseIM
 


### PR DESCRIPTION
To find the dead code

This PR addresses curiosity.

Changes:
- cover compile tests themself
- `code:is_loaded` does not return `true`, it returns `{file,_}`...