### PR TITLE
Wait for async writers to flush messages in tests

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -31,6 +31,7 @@
 {suites, "tests", last_SUITE}.
 {suites, "tests", login_SUITE}.
 {suites, "tests", mam_SUITE}.
+{suites, "tests", mam_proper_SUITE}.
 {suites, "tests", metrics_api_SUITE}.
 {suites, "tests", metrics_c2s_SUITE}.
 {suites, "tests", metrics_register_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -49,6 +49,8 @@
 
 {suites, "tests", mam_SUITE}.
 
+{suites, "tests", mam_proper_SUITE}.
+
 {suites, "tests", mam_send_message_SUITE}.
 
 {suites, "tests", metrics_c2s_SUITE}.

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -198,7 +198,8 @@
          parse_messages/1,
          run_set_and_get_prefs_case/4,
          muc_light_host/0,
-         host_type/0
+         host_type/0,
+         set_wait_for_parallel_writer/2
         ]).
 
 -import(muc_light_helper,
@@ -698,7 +699,7 @@ init_modules(rdbms_async_pool, C, Config) when C =:= muc_all;
     init_module(host_type(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host_type(), mod_mam_muc, [{host, subhost_pattern(muc_domain(Config))}] ++
                                      addin_mam_options(C, Config)),
-    [{wait_for_parallel_writer, [muc]}|Config];
+    set_wait_for_parallel_writer(muc, Config);
 init_modules(rdbms_mnesia, C, Config) when C =:= muc_all;
                                            C =:= muc_disabled_retraction ->
     init_module(host_type(), mod_mam_muc_rdbms_arch, []),
@@ -725,7 +726,7 @@ init_modules(rdbms_async_cache, C, Config) when C =:= muc_all;
     init_module(host_type(), mod_mam_cache_user, [muc]),
     init_module(host_type(), mod_mam_muc, [{host, subhost_pattern(muc_domain(Config))}] ++
                                      addin_mam_options(C, Config)),
-    [{wait_for_parallel_writer, [muc]}|Config];
+    set_wait_for_parallel_writer(muc, Config);
 init_modules(rdbms_mnesia_muc_cache, C, Config) when C =:= muc_all;
                                                      C =:= muc_disabled_retraction ->
     init_module(host_type(), mod_mam_muc_rdbms_arch, []),
@@ -790,7 +791,7 @@ init_modules(rdbms_async_pool, C, Config) ->
     init_module(host_type(), mod_mam_rdbms_arch_async, [{pm, [{flush_interval, 1}]}]), %% 1ms
     init_module(host_type(), mod_mam_rdbms_prefs, [pm]),
     init_module(host_type(), mod_mam_rdbms_user, [pm]),
-    [{wait_for_parallel_writer, [pm]}|Config];
+    set_wait_for_parallel_writer(pm, Config);
 init_modules(rdbms_mnesia, C, Config) ->
     init_module(host_type(), mod_mam, addin_mam_options(C, Config)),
     init_module(host_type(), mod_mam_rdbms_arch, []),
@@ -811,7 +812,7 @@ init_modules(rdbms_async_cache, C, Config) ->
     init_module(host_type(), mod_mam_rdbms_prefs, [pm]),
     init_module(host_type(), mod_mam_rdbms_user, [pm]),
     init_module(host_type(), mod_mam_cache_user, [pm]),
-    [{wait_for_parallel_writer, [pm]}|Config];
+    set_wait_for_parallel_writer(pm, Config);
 init_modules(rdbms_mnesia_cache, C, Config) ->
     init_module(host_type(), mod_mam, addin_mam_options(C, Config)),
     init_module(host_type(), mod_mam_rdbms_arch, []),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -629,7 +629,7 @@ do_init_per_group(C, ConfigIn) ->
         elasticsearch ->
             [{archive_wait, 2500} | Config0];
         _ ->
-            [{archive_wait, 200} | Config0]
+            Config0
     end.
 
 end_per_group(G, Config) when G == rsm_all; G == nostore;
@@ -698,7 +698,7 @@ init_modules(rdbms_async_pool, C, Config) when C =:= muc_all;
     init_module(host_type(), mod_mam_rdbms_user, [muc, pm]),
     init_module(host_type(), mod_mam_muc, [{host, subhost_pattern(muc_domain(Config))}] ++
                                      addin_mam_options(C, Config)),
-    Config;
+    [{wait_for_parallel_writer, [muc]}|Config];
 init_modules(rdbms_mnesia, C, Config) when C =:= muc_all;
                                            C =:= muc_disabled_retraction ->
     init_module(host_type(), mod_mam_muc_rdbms_arch, []),
@@ -725,7 +725,7 @@ init_modules(rdbms_async_cache, C, Config) when C =:= muc_all;
     init_module(host_type(), mod_mam_cache_user, [muc]),
     init_module(host_type(), mod_mam_muc, [{host, subhost_pattern(muc_domain(Config))}] ++
                                      addin_mam_options(C, Config)),
-    Config;
+    [{wait_for_parallel_writer, [muc]}|Config];
 init_modules(rdbms_mnesia_muc_cache, C, Config) when C =:= muc_all;
                                                      C =:= muc_disabled_retraction ->
     init_module(host_type(), mod_mam_muc_rdbms_arch, []),
@@ -790,7 +790,7 @@ init_modules(rdbms_async_pool, C, Config) ->
     init_module(host_type(), mod_mam_rdbms_arch_async, [{pm, [{flush_interval, 1}]}]), %% 1ms
     init_module(host_type(), mod_mam_rdbms_prefs, [pm]),
     init_module(host_type(), mod_mam_rdbms_user, [pm]),
-    Config;
+    [{wait_for_parallel_writer, [pm]}|Config];
 init_modules(rdbms_mnesia, C, Config) ->
     init_module(host_type(), mod_mam, addin_mam_options(C, Config)),
     init_module(host_type(), mod_mam_rdbms_arch, []),
@@ -811,7 +811,7 @@ init_modules(rdbms_async_cache, C, Config) ->
     init_module(host_type(), mod_mam_rdbms_prefs, [pm]),
     init_module(host_type(), mod_mam_rdbms_user, [pm]),
     init_module(host_type(), mod_mam_cache_user, [pm]),
-    Config;
+    [{wait_for_parallel_writer, [pm]}|Config];
 init_modules(rdbms_mnesia_cache, C, Config) ->
     init_module(host_type(), mod_mam, addin_mam_options(C, Config)),
     init_module(host_type(), mod_mam_rdbms_arch, []),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -56,6 +56,7 @@
          start_alice_protected_room/1,
          start_alice_anonymous_room/1,
          maybe_wait_for_archive/1,
+         set_wait_for_parallel_writer/2,
          stanza_archive_request/2,
          stanza_text_search_archive_request/3,
          stanza_date_range_archive_request_not_empty/3,
@@ -1091,6 +1092,11 @@ maybe_wait_for_archive(Config) ->
         Value ->
             timer:sleep(Value)
     end.
+
+set_wait_for_parallel_writer(Type, Config) ->
+    Old = proplists:get_value(wait_for_parallel_writer, Config, []),
+    Config2 = proplists:delete(wait_for_parallel_writer, Config),
+    [{wait_for_parallel_writer, lists:usort([Type] ++ Old)}|Config2].
 
 wait_for_parallel_writer(Config) ->
     case ?config(wait_for_parallel_writer, Config) of

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1084,12 +1084,27 @@ login_send_presence(Config, User) ->
     Client.
 
 maybe_wait_for_archive(Config) ->
+    wait_for_parallel_writer(Config),
     case ?config(archive_wait, Config) of
         undefined ->
             ok;
         Value ->
             timer:sleep(Value)
     end.
+
+wait_for_parallel_writer(Config) ->
+    case ?config(wait_for_parallel_writer, Config) of
+        undefined ->
+            ok;
+        Types ->
+            HostType = domain_helper:host_type(),
+            [wait_for_parallel_writer(Type, HostType) || Type <- Types]
+    end.
+
+wait_for_parallel_writer(pm, HostType) ->
+    rpc(mim(), mongoose_hooks, mam_archive_sync, [HostType]);
+wait_for_parallel_writer(muc, HostType) ->
+    rpc(mim(), mongoose_hooks, mam_muc_archive_sync, [HostType]).
 
 %% Bob and Alice are friends.
 %% Kate and Alice are not friends.

--- a/big_tests/tests/mam_proper_SUITE.erl
+++ b/big_tests/tests/mam_proper_SUITE.erl
@@ -1,0 +1,151 @@
+-module(mam_proper_SUITE).
+-compile([export_all, nowarn_export_all]).
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-import(distributed_helper, [mim/0,
+                             require_rpc_nodes/1,
+                             rpc/4]).
+
+suite() ->
+    require_rpc_nodes([mim]) ++ escalus:suite().
+
+all() ->
+    [{group, async_writer}].
+
+groups() ->
+    [{async_writer, [], [async_writer_store]}].
+
+init_per_suite(C) ->
+    application:ensure_all_started(jid),
+    escalus:init_per_suite(C).
+
+end_per_suite(C) ->
+    escalus:end_per_suite(C).
+
+init_per_group(_G, C) ->
+    case mongoose_helper:is_rdbms_enabled(domain_helper:host_type()) of
+        true -> C;
+        false -> {skip, "rdbms not enabled"}
+    end.
+
+end_per_group(_G, C) ->
+    C.
+
+init_per_testcase(Name, C) ->
+    escalus:init_per_testcase(Name, C).
+
+end_per_testcase(Name, C) ->
+    escalus:end_per_testcase(Name, C).
+
+usernames() ->
+   [<<"alice">>, <<"bob">>, <<"bob.1">>, <<"bob44">>, <<"a">>, <<"xd">>,
+    <<"admin">>].
+
+resources() ->
+    [<<"res1">>, <<"PICKLE">>, <<"1">>, <<"xdxd">>].
+
+origin_id() ->
+    oneof([none, <<"orig_id">>, proper_types:non_empty(proper_unicode:utf8(5))]).
+
+username() ->
+    ?SUCHTHAT(U, proper_types:non_empty(oneof(usernames())),
+              jid:nodeprep(U) =/= error).
+
+hostname() ->
+    proper_types:oneof([<<"localhost">>, <<"otherhost">>, <<"example.com">>]).
+
+resource() ->
+    ?SUCHTHAT(R, proper_types:non_empty(oneof(resources())),
+              jid:resourceprep(R) =/= error).
+
+jid() ->
+    ?SUCHTHAT(Jid, maybe_invalid_jid(), Jid =/= error).
+
+maybe_invalid_jid() ->
+    ?LET({U, S, R},
+         {username(), hostname(), resource()},
+         make_jid(U, S, R)).
+
+make_jid(U, S, R) when is_binary(U), is_binary(S), is_binary(R) ->
+    mongoose_helper:make_jid(U, S, R).
+
+direction() ->
+    proper_types:oneof([incoming, outgoing]).
+
+body() ->
+    proper_unicode:utf8(1000).
+
+packet(To, Body) ->
+    escalus_stanza:chat_to(jid:to_binary(To), Body).
+
+%% Generates mod_mam:archive_message_params()
+params() ->
+    ?LET({MessId, ArcId, LocalJid, RemoteJid,
+          OriginId, Dir, Body, SenderId},
+         {non_neg_integer(), non_neg_integer(), jid(), jid(),
+          origin_id(), direction(), body(), non_neg_integer()},
+         #{message_id => MessId, archive_id => ArcId,
+           local_jid => LocalJid, remote_jid => RemoteJid,
+           source_jid => choose_source_jid(Dir, LocalJid, RemoteJid),
+           origin_id => OriginId, direction => Dir,
+           packet => packet(choose_dest_jid(Dir, LocalJid, RemoteJid), Body),
+           sender_id => SenderId}).
+
+choose_source_jid(incoming, _LocalJid, RemoteJid) -> RemoteJid;
+choose_source_jid(outgoing, LocalJid, _RemoteJid) -> LocalJid.
+
+choose_dest_jid(outgoing, _LocalJid, RemoteJid) -> RemoteJid;
+choose_dest_jid(incoming, LocalJid, _RemoteJid) -> LocalJid.
+
+params_list() ->
+    ?LET(ParamsList, proper_types:non_empty(proper_types:list(params())),
+         with_unique_message_id(ParamsList)).
+
+with_unique_message_id(ParamsList) ->
+    Pairs = [{MessId, Params} || #{message_id := MessId} = Params <- ParamsList],
+    %% Removes duplicates
+    maps:values(maps:from_list(Pairs)).
+
+async_writer_store(C) ->
+    run_prop(async_writer_store, async_writer_store_prop(C)).
+
+async_writer_store_prop(_C) ->
+    HostType = domain_helper:host_type(),
+    ?FORALL(ParamsList, params_list(), async_writer_store_check(HostType, ParamsList)).
+
+async_writer_store_check(HostType, ParamsList) ->
+    clean_db(HostType),
+    Name = prepare_insert(length(ParamsList)),
+    Rows = [prepare_message(HostType, Params) || Params <- ParamsList],
+    case execute(HostType, Name, lists:append(Rows)) of
+        {updated, _} -> true;
+        Other ->
+            ct:pal("ParamsList ~p~nOther ~p", [ParamsList, Other]),
+            false
+    end.
+
+prepare_insert(Len) ->
+    Name = multi_name(insert_mam_message_prop, Len),
+    rpc(mim(), mod_mam_rdbms_arch, prepare_insert, [Name, Len]),
+    Name.
+
+multi_name(Name, Times) ->
+    list_to_atom(atom_to_list(Name) ++ integer_to_list(Times)).
+
+prepare_message(HostType, Params) ->
+    rpc(mim(), mod_mam_rdbms_arch, prepare_message, [HostType, Params]).
+
+execute(HostType, BatchName, Args) ->
+    rpc(mim(), mongoose_rdbms, execute, [HostType, BatchName, Args]).
+
+clean_db(HostType) ->
+    Q = <<"DELETE FROM mam_message">>,
+    rpc(mim(), mongoose_rdbms, sql_query, [HostType, Q]).
+
+run_prop(PropName, Property) ->
+    Opts = [verbose, long_result, {numtests, 30}],
+    ?assertEqual(true, quickcheck(PropName, Property, Opts)).
+
+quickcheck(PropName, Property, Opts) ->
+    proper:quickcheck(proper:conjunction([{PropName, Property}]), Opts).

--- a/src/mam/mod_mam_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_rdbms_arch_async.erl
@@ -17,6 +17,7 @@
 -type writer_type() :: pm | muc.
 
 -ignore_xref([archive_pm_message/3, archive_muc_message/3]).
+-ignore_xref([mam_archive_sync/2, mam_muc_archive_sync/2]).
 
 -spec archive_pm_message(_Result, mongooseim:host_type(), mod_mam:archive_message_params()) ->
           ok | {error, timeout}.

--- a/src/mam/mod_mam_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_rdbms_arch_async.erl
@@ -167,9 +167,6 @@ do_flush_pm(Acc, #{host_type := HostType, batch_size := MaxSize, batch_name := B
         {updated, _Count} -> ok;
         {error, Reason} ->
             mongoose_metrics:update(HostType, modMamDropped, MessageCount),
-            [?LOG_ERROR(#{what => archive_message_dropped,
-                          sensitive => true, params => Params})
-             || Params <- Acc],
             ?LOG_ERROR(#{what => archive_message_failed,
                          text => <<"archive_message query failed">>,
                          message_count => MessageCount, reason => Reason}),
@@ -197,9 +194,6 @@ do_flush_muc(Acc, #{host_type := HostType, batch_size := MaxSize, batch_name := 
         {updated, _Count} -> ok;
         {error, Reason} ->
             mongoose_metrics:update(HostType, modMucMamDropped, MessageCount),
-            [?LOG_ERROR(#{what => archive_muc_message_dropped,
-                          sensitive => true, params => Params})
-             || Params <- Acc],
             ?LOG_ERROR(#{what => archive_message_query_failed,
                          text => <<"archive_message query failed, modMucMamDropped metric updated">>,
                          message_count => MessageCount, reason => Reason}),

--- a/src/mam/mod_mam_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_rdbms_arch_async.erl
@@ -64,17 +64,25 @@ supported_features() ->
 -spec start_pool(mongooseim:host_type(), {writer_type(), gen_mod:module_opts()}) ->
     supervisor:startchild_ret().
 start_pool(HostType, {Type, Opts}) ->
-    Opts1 = extend_opts(Type, Opts),
-    prepare_insert_queries(Type, Opts1),
+    {Opts1, Extra} = extend_opts(Type, Opts),
+    prepare_insert_queries(Type, Extra),
     ensure_metrics(Type, HostType),
     register_hooks(Type, HostType),
     start_pool(Type, HostType, Opts1).
 
 extend_opts(Type, Opts) ->
     Merge = maps:merge(defaults(), maps:from_list(Opts)),
-    Opts1 = maps:to_list(Merge),
-    Opts2 = gen_mod:set_opt(flush_extra, Opts1, Merge),
-    add_callback(Type, Opts2).
+    Extra = add_batch_name(Type, Merge),
+    Opts1 = maps:to_list(Extra),
+    Opts2 = gen_mod:set_opt(flush_extra, Opts1, Extra),
+    {add_callback(Type, Opts2), Extra}.
+
+%% Put batch_size into a statement name, so we could survive the module restarts
+%% with different batch sizes
+add_batch_name(pm, #{batch_size := MaxSize} = Opts) ->
+    Opts#{batch_name => multi_name(insert_mam_messages, MaxSize)};
+add_batch_name(muc, #{batch_size := MaxSize} = Opts) ->
+    Opts#{batch_name => multi_name(insert_mam_muc_messages, MaxSize)}.
 
 add_callback(pm, Opts) ->
     gen_mod:set_opt(flush_callback, Opts, fun ?MODULE:flush_pm/2);
@@ -86,14 +94,15 @@ defaults() ->
       batch_size => 30,
       pool_size => 4 * erlang:system_info(schedulers_online)}.
 
-prepare_insert_queries(pm, Opts) ->
-    MaxSize = gen_mod:get_opt(batch_size, Opts, 30),
+prepare_insert_queries(pm, #{batch_size := MaxSize, batch_name := BatchName}) ->
     mod_mam_rdbms_arch:prepare_insert(insert_mam_message, 1),
-    mod_mam_rdbms_arch:prepare_insert(insert_mam_messages, MaxSize);
-prepare_insert_queries(muc, Opts) ->
-    MaxSize = gen_mod:get_opt(batch_size, Opts, 30),
+    mod_mam_rdbms_arch:prepare_insert(BatchName, MaxSize);
+prepare_insert_queries(muc, #{batch_size := MaxSize, batch_name := BatchName}) ->
     mod_mam_muc_rdbms_arch:prepare_insert(insert_mam_muc_message, 1),
-    mod_mam_muc_rdbms_arch:prepare_insert(insert_mam_muc_messages, MaxSize).
+    mod_mam_muc_rdbms_arch:prepare_insert(BatchName, MaxSize).
+
+multi_name(Name, Times) ->
+    list_to_atom(atom_to_list(Name) ++ integer_to_list(Times)).
 
 ensure_metrics(pm, HostType) ->
     mongoose_metrics:ensure_metric(HostType, ?PM_PER_MESSAGE_FLUSH_TIME, histogram),
@@ -140,13 +149,13 @@ flush_muc(Acc, Extra = #{host_type := HostType}) ->
     Result.
 
 %% mam workers callbacks
-do_flush_pm(Acc, #{host_type := HostType, batch_size := MaxSize}) ->
+do_flush_pm(Acc, #{host_type := HostType, batch_size := MaxSize, batch_name := BatchName}) ->
     MessageCount = length(Acc),
     Rows = [mod_mam_rdbms_arch:prepare_message(HostType, Params) || Params <- Acc],
     InsertResult =
         case MessageCount of
             MaxSize ->
-                mongoose_rdbms:execute(HostType, insert_mam_messages, lists:append(Rows));
+                mongoose_rdbms:execute(HostType, BatchName, lists:append(Rows));
             OtherSize ->
                 Results = [mongoose_rdbms:execute(HostType, insert_mam_message, Row) || Row <- Rows],
                 case lists:keyfind(error, 1, Results) of
@@ -158,6 +167,9 @@ do_flush_pm(Acc, #{host_type := HostType, batch_size := MaxSize}) ->
         {updated, _Count} -> ok;
         {error, Reason} ->
             mongoose_metrics:update(HostType, modMamDropped, MessageCount),
+            [?LOG_ERROR(#{what => archive_message_dropped,
+                          sensitive => true, params => Params})
+             || Params <- Acc],
             ?LOG_ERROR(#{what => archive_message_failed,
                          text => <<"archive_message query failed">>,
                          message_count => MessageCount, reason => Reason}),
@@ -167,13 +179,13 @@ do_flush_pm(Acc, #{host_type := HostType, batch_size := MaxSize}) ->
     mongoose_hooks:mam_flush_messages(HostType, MessageCount),
     ok.
 
-do_flush_muc(Acc, #{host_type := HostType, batch_size := MaxSize}) ->
+do_flush_muc(Acc, #{host_type := HostType, batch_size := MaxSize, batch_name := BatchName}) ->
     MessageCount = length(Acc),
     Rows = [mod_mam_muc_rdbms_arch:prepare_message(HostType, Params) || Params <- Acc],
     InsertResult =
         case MessageCount of
             MaxSize ->
-                mongoose_rdbms:execute(HostType, insert_mam_muc_messages, lists:append(Rows));
+                mongoose_rdbms:execute(HostType, BatchName, lists:append(Rows));
             OtherSize ->
                 Results = [mongoose_rdbms:execute(HostType, insert_mam_muc_message, Row) || Row <- Rows],
                 case lists:keyfind(error, 1, Results) of
@@ -185,6 +197,9 @@ do_flush_muc(Acc, #{host_type := HostType, batch_size := MaxSize}) ->
         {updated, _Count} -> ok;
         {error, Reason} ->
             mongoose_metrics:update(HostType, modMucMamDropped, MessageCount),
+            [?LOG_ERROR(#{what => archive_muc_message_dropped,
+                          sensitive => true, params => Params})
+             || Params <- Acc],
             ?LOG_ERROR(#{what => archive_message_query_failed,
                          text => <<"archive_message query failed, modMucMamDropped metric updated">>,
                          message_count => MessageCount, reason => Reason}),

--- a/src/mam/mod_mam_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_rdbms_arch_async.erl
@@ -11,6 +11,7 @@
 -export([start/2, stop/1, config_spec/0, supported_features/0]).
 
 -export([archive_pm_message/3, archive_muc_message/3]).
+-export([mam_archive_sync/2, mam_muc_archive_sync/2]).
 -export([flush_pm/2, flush_muc/2]).
 
 -type writer_type() :: pm | muc.
@@ -29,6 +30,16 @@ archive_muc_message(_Result, HostType, Params0 = #{archive_id := RoomID}) ->
     Params = mod_mam_muc_rdbms_arch:extend_params_with_sender_id(HostType, Params0),
     PoolName = mongoose_async_pools:pool_name(HostType, muc_mam),
     wpool:cast(PoolName, {task, Params}, {hash_worker, RoomID}).
+
+-spec mam_archive_sync(term(), mongooseim:host_type()) -> term().
+mam_archive_sync(Result, HostType) ->
+    mongoose_async_pools:sync(HostType, pm_mam),
+    Result.
+
+-spec mam_muc_archive_sync(term(), mongooseim:host_type()) -> term().
+mam_muc_archive_sync(Result, HostType) ->
+    mongoose_async_pools:sync(HostType, muc_mam),
+    Result.
 
 %%% gen_mod callbacks
 -spec start(mongooseim:host_type(), [{writer_type(), gen_mod:module_opts()}]) -> any().
@@ -91,8 +102,10 @@ ensure_metrics(muc, HostType) ->
     mongoose_metrics:ensure_metric(HostType, ?MUC_FLUSH_TIME, histogram).
 
 register_hooks(pm, HostType) ->
+    ejabberd_hooks:add(mam_archive_sync, HostType, ?MODULE, mam_archive_sync, 50),
     ejabberd_hooks:add(mam_archive_message, HostType, ?MODULE, archive_pm_message, 50);
 register_hooks(muc, HostType) ->
+    ejabberd_hooks:add(mam_muc_archive_sync, HostType, ?MODULE, mam_muc_archive_sync, 50),
     ejabberd_hooks:add(mam_muc_archive_message, HostType, ?MODULE, archive_muc_message, 50).
 
 start_pool(pm, HostType, Opts) ->
@@ -103,8 +116,10 @@ start_pool(muc, HostType, Opts) ->
 -spec stop_pool(mongooseim:host_type(), {writer_type(), term()}) -> ok.
 stop_pool(HostType, {pm, _}) ->
     ejabberd_hooks:delete(mam_archive_message, HostType, ?MODULE, archive_pm_message, 50),
+    ejabberd_hooks:delete(mam_archive_sync, HostType, ?MODULE, mam_archive_sync, 50),
     mongoose_async_pools:stop_pool(HostType, pm_mam);
 stop_pool(HostType, {muc, _}) ->
+    ejabberd_hooks:delete(mam_muc_archive_sync, HostType, ?MODULE, mam_muc_archive_sync, 50),
     ejabberd_hooks:delete(mam_muc_archive_message, HostType, ?MODULE, archive_muc_message, 50),
     mongoose_async_pools:stop_pool(HostType, muc_mam).
 

--- a/src/mongoose_async_pools.erl
+++ b/src/mongoose_async_pools.erl
@@ -9,8 +9,7 @@
 
 % API
 -export([start_pool/3, stop_pool/2, pool_name/2, config_spec/0]).
--export([get_workers/2, sync/2]).
--ignore_xref([get_workers/2]).
+-export([sync/2]).
 
 -type pool_id() :: atom().
 -type pool_name() :: atom().
@@ -48,7 +47,7 @@ pool_name(HostType, PoolId) ->
 
 -spec sync(mongooseim:host_type(), pool_id()) -> term().
 sync(HostType, PoolId) ->
-    Pids = mongoose_async_pools:get_workers(HostType, PoolId),
+    Pids = get_workers(HostType, PoolId),
     Context = #{what => sync_failed, host_type => HostType, pool_id => PoolId},
     F = fun(Pid) -> 
                 safely:apply_and_log(gen_server, call, [Pid, sync], Context)

--- a/src/mongoose_async_pools.erl
+++ b/src/mongoose_async_pools.erl
@@ -9,6 +9,12 @@
 
 % API
 -export([start_pool/3, stop_pool/2, pool_name/2, config_spec/0]).
+-export([get_workers/2, sync/2]).
+-ignore_xref([get_workers/2]).
+
+%% Callback
+-export([call_sync/2]).
+-ignore_xref([call_sync/2]).
 
 -type pool_id() :: atom().
 -type pool_name() :: atom().
@@ -43,6 +49,27 @@ config_spec() ->
 -spec pool_name(mongooseim:host_type(), pool_id()) -> pool_name().
 pool_name(HostType, PoolId) ->
     persistent_term:get({?MODULE, HostType, PoolId}).
+
+-spec sync(mongooseim:host_type(), pool_id()) -> [pid()].
+sync(HostType, PoolId) ->
+    Pids = mongoose_async_pools:get_workers(HostType, PoolId),
+    rpc:pmap({?MODULE, call_sync}, [HostType], Pids).
+
+call_sync(Pid, HostType) ->
+    try
+        gen_server:call(Pid, sync)
+    catch C:E:S ->
+              ?LOG_ERROR(#{what => async_sync_failed,
+                           host_type => HostType,
+                           class => C, reason => E, stacktrace => S}),
+              erlang:raise(C, E, S)
+    end.
+
+-spec get_workers(mongooseim:host_type(), pool_id()) -> [pid()].
+get_workers(HostType, PoolId) ->
+    Pool = pool_name(HostType, PoolId),
+    [Sup] = [Pid || {_Name, Pid, supervisor, _Mods} <- supervisor:which_children(Pool)],
+    [Pid || {_Name, Pid, worker, _Mods} <- supervisor:which_children(Sup)].
 
 %%% Supervisor callbacks
 -spec start_link(mongooseim:host_type(), pool_id(), pool_opts()) ->

--- a/src/mongoose_batch_worker.erl
+++ b/src/mongoose_batch_worker.erl
@@ -42,6 +42,10 @@ init({HostType, Interval, MaxSize, FlushCallback, FlushExtra}) ->
                 flush_extra = FlushExtra}}.
 
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
+handle_call(sync, _From, State = #state{flush_queue = [_|_]}) ->
+    {reply, ok, run_flush(State)};
+handle_call(sync, _From, State = #state{flush_queue = []}) ->
+    {reply, skipped, State};
 handle_call(Msg, From, State) ->
     ?UNEXPECTED_CALL(Msg, From),
     {reply, unexpected_call, State}.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -95,7 +95,8 @@
          mam_remove_archive/3,
          mam_lookup_messages/2,
          mam_archive_message/2,
-         mam_flush_messages/2]).
+         mam_flush_messages/2,
+         mam_archive_sync/1]).
 
 -export([mam_muc_archive_id/2,
          mam_muc_archive_size/3,
@@ -105,7 +106,8 @@
          mam_muc_remove_archive/3,
          mam_muc_lookup_messages/2,
          mam_muc_archive_message/2,
-         mam_muc_flush_messages/2]).
+         mam_muc_flush_messages/2,
+         mam_muc_archive_sync/1]).
 
 -export([get_mam_pm_gdpr_data/2,
          get_mam_muc_gdpr_data/2,
@@ -154,6 +156,7 @@
          node_cleanup/1]).
 
 -ignore_xref([node_cleanup/1, remove_domain/2]).
+-ignore_xref([mam_archive_sync/1, mam_muc_archive_sync/1]).
 
 %% Just a map, used by some hooks as a first argument.
 %% Not mongoose_acc:t().
@@ -1017,6 +1020,11 @@ mam_flush_messages(HookServer, MessageCount) ->
     run_hook_for_host_type(mam_flush_messages, HookServer, ok,
                            [HookServer, MessageCount]).
 
+%% @doc Waits until all pending messages are written
+-spec mam_archive_sync(HostType :: mongooseim:host_type()) -> ok.
+mam_archive_sync(HostType) ->
+    run_hook_for_host_type(mam_archive_sync, HostType, ok, [HostType]).
+
 
 %% MAM MUC related hooks
 
@@ -1132,6 +1140,11 @@ mam_muc_archive_message(HostType, Params) ->
 mam_muc_flush_messages(HookServer, MessageCount) ->
     run_hook_for_host_type(mam_muc_flush_messages, HookServer, ok,
                            [HookServer, MessageCount]).
+
+%% @doc Waits until all pending messages are written
+-spec mam_muc_archive_sync(HostType :: mongooseim:host_type()) -> ok.
+mam_muc_archive_sync(HostType) ->
+    run_hook_for_host_type(mam_muc_archive_sync, HostType, ok, [HostType]).
 
 %% GDPR related hooks
 

--- a/src/mongoose_lib.erl
+++ b/src/mongoose_lib.erl
@@ -171,9 +171,6 @@ does_local_user_exist(HostType, To, groupchat) ->
 does_local_user_exist(HostType, To, _) ->
     ejabberd_auth:does_user_exist(HostType, To, stored).
 
-%% ------------------------------------------------------------------
-%% parallel map
-%% ------------------------------------------------------------------
 %% WHY: filter_local_packet is executed twice in the pipeline of muc messages. in two routing steps:
 %%  - From the sender to the room: runs filter_local_packet with From=Sender, To=Room
 %%  - For each member of the room:
@@ -183,6 +180,10 @@ does_local_user_exist(HostType, To, _) ->
 -spec is_to_room(jid:jid()) -> boolean().
 is_to_room(Jid) ->
     {error, not_found} =:= mongoose_domain_api:get_domain_host_type(Jid#jid.lserver).
+
+%% ------------------------------------------------------------------
+%% parallel map
+%% ------------------------------------------------------------------
 
 %% Runs a function for each element on the same node
 pmap(F, Es) ->

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -192,8 +192,8 @@ tabcol_to_odbc_type(TabCol = {Table, Column}, TableDesc) ->
     end.
 
 %% Null should be encoded with the a correct type.
-%% Otherwice inserting two records, where one value is null and another is
-%% not null, would case:
+%% Otherwise when inserting two records, where one value is null
+%% and another is not null, would case:
 %% [FreeTDS][SQL Server]Conversion failed when converting the nvarchar value
 %% 'orig_id' to data type int. SQLSTATE IS: 22018
 unicode_mapper(null) ->

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -178,7 +178,7 @@ tabcol_to_mapper(_ServerType, TableDesc, TabCol) ->
         bigint ->
             fun(P) -> bigint_mapper(P) end;
         _ ->
-            fun(P) -> {ODBCType, [P]} end
+            fun(P) -> generic_mapper(ODBCType, P) end
     end.
 
 tabcol_to_odbc_type(TabCol = {Table, Column}, TableDesc) ->
@@ -191,19 +191,37 @@ tabcol_to_odbc_type(TabCol = {Table, Column}, TableDesc) ->
             ODBCType
     end.
 
+%% Null should be encoded with the a correct type.
+%% Otherwice inserting two records, where one value is null and another is
+%% not null, would case:
+%% [FreeTDS][SQL Server]Conversion failed when converting the nvarchar value
+%% 'orig_id' to data type int. SQLSTATE IS: 22018
+unicode_mapper(null) ->
+    {{sql_wlongvarchar, 0}, [null]};
 unicode_mapper(P) ->
     Utf16 = unicode_characters_to_binary(iolist_to_binary(P), utf8, {utf16, little}),
     Len = byte_size(Utf16) div 2,
     {{sql_wlongvarchar, Len}, [Utf16]}.
 
+bigint_mapper(null) ->
+    Type = {'sql_varchar', 0},
+    {Type, [null]};
 bigint_mapper(P) when is_integer(P) ->
     B = integer_to_binary(P),
     Type = {'sql_varchar', byte_size(B)},
     {Type, [B]}.
 
+binary_mapper(null) ->
+    Type = {'sql_longvarbinary', 0},
+    {Type, [null]};
 binary_mapper(P) ->
     Type = {'sql_longvarbinary', byte_size(P)},
     {Type, [P]}.
+
+generic_mapper(ODBCType, null) ->
+    {ODBCType, [null]};
+generic_mapper(ODBCType, P) ->
+    {ODBCType, [P]}.
 
 
 simple_type('SQL_BINARY')           -> binary;
@@ -226,10 +244,8 @@ map_params([Param|Params], [Mapper|Mappers]) ->
 map_params([], []) ->
     [].
 
-map_param(undefined, _Mapper) ->
-    {sql_integer, [null]}; %% some code uses "undefined" instead of "null"
-map_param(null, _Mapper) ->
-    {sql_integer, [null]}; %% Yeah, just random type for null
+map_param(undefined, Mapper) ->
+    map_param(null, Mapper);
 map_param(true, _Mapper) ->
     {sql_integer, [1]};
 map_param(false, _Mapper) ->

--- a/src/safely.erl
+++ b/src/safely.erl
@@ -25,16 +25,16 @@
             throw:R ->
                 ?LOG_ERROR(Context#{class => throw, reason => R}),
                 {throw, R};
-            exit:R ->
-                ?LOG_ERROR(Context#{class => exit, reason => R}),
-                {exit, R}
+            exit:R:S ->
+                ?LOG_ERROR(Context#{class => exit, reason => R, stacktrace => S}),
+                {exit, {R, S}}
         end).
 
 -define(MATCH_EXCEPTIONS(F),
         try F catch
             error:R:S -> {error, {R, S}};
             throw:R -> {throw, R};
-            exit:R -> {exit, R}
+            exit:R:S -> {exit, {R, S}}
         end).
 
 -spec apply(fun((...) -> A), [term()]) -> catch_result(A).

--- a/test/mongoose_lib_SUITE.erl
+++ b/test/mongoose_lib_SUITE.erl
@@ -1,0 +1,22 @@
+-module(mongoose_lib_SUITE).
+-include_lib("eunit/include/eunit.hrl").
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [pmap_works].
+
+init_per_suite(C) ->
+    C.
+
+end_per_suite(C) ->
+    C.
+
+pmap_works(_C) ->
+    ?assertEqual([{ok, 1}, {ok, 2}, {ok, 3}],
+                 mongoose_lib:pmap(fun(X) -> X end, [1, 2, 3])),
+    ?assertMatch([{ok, 1}, {error, {oops, _}}, {ok, 3}],
+                 mongoose_lib:pmap(fun(2) -> error(oops); (X) -> X end,
+                                   [1, 2, 3])),
+    ?assertMatch([_, {error, timeout}, _],
+                 mongoose_lib:pmap(fun(2) -> timer:sleep(50000); (X) -> X end,
+                                   [1, 2, 3], 10)).

--- a/test/safely_SUITE.erl
+++ b/test/safely_SUITE.erl
@@ -25,7 +25,7 @@ handles_errors_similar_to_catch(_) ->
 
 handles_exits_similar_to_errors(_) ->
     ExitF = fun() -> exit(i_quit) end,
-    {exit, i_quit} = safely:apply(ExitF,[]),
+    {exit, {i_quit, _S}} = safely:apply(ExitF,[]),
     {'EXIT', i_quit} = (catch apply(ExitF,[])),
     ok.
 


### PR DESCRIPTION
This PR addresses failures in mam_SUITE.

Proposed changes include:
* New hooks: mam_archive_sync, mam_muc_archive_sync
* New function mongoose_async_pools:sync/2
* Extended mam_helper:maybe_wait_for_archive/1