### PR TITLE
allow delete_room in mod_muc_light_commands when equal occupants is true

### DIFF
--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -31,7 +31,8 @@
 %% For Administration API
 -export([try_to_create_room/3,
          change_room_config/5,
-         delete_room/1]).
+         delete_room/1,
+         equal_occupants/1]).
 
 %% gen_mod callbacks
 -export([start/2, stop/1, config_spec/0, supported_features/0]).

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -239,10 +239,11 @@ delete_room(DomainName, RoomName, Owner) ->
     OwnerJID = jid:binary_to_bare(Owner),
     case muc_light_room_name_to_jid_and_aff(OwnerJID, RoomName, DomainName) of
         {ok, RoomJID, owner} -> mod_muc_light:delete_room(jid:to_lus(RoomJID));
-        {ok, RoomJID, _} -> case mod_muc_light:equal_occupants(mod_muc_light_utils:room_jid_to_host_type(RoomJID)) of
-                            true -> mod_muc_light:delete_room(jid:to_lus(RoomJID));
-                            false -> {error, denied, "you can not delete this room"}
-                          end;
+        {ok, RoomJID, _} ->
+            case mod_muc_light:equal_occupants(mod_muc_light_utils:room_jid_to_host_type(RoomJID)) of
+                true -> mod_muc_light:delete_room(jid:to_lus(RoomJID));
+                false -> {error, denied, "you can not delete this room"}
+            end;
         {error, given_user_does_not_occupy_any_room} -> {error, denied, "given user does not occupy this room"};
         {error, not_found} -> {error, not_found, "room does not exist"}
     end.

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -239,7 +239,10 @@ delete_room(DomainName, RoomName, Owner) ->
     OwnerJID = jid:binary_to_bare(Owner),
     case muc_light_room_name_to_jid_and_aff(OwnerJID, RoomName, DomainName) of
         {ok, RoomJID, owner} -> mod_muc_light:delete_room(jid:to_lus(RoomJID));
-        {ok, _, _} -> {error, denied, "you can not delete this room"};
+        {ok, RoomJID, _} -> case mod_muc_light:equal_occupants(mod_muc_light_utils:room_jid_to_host_type(RoomJID)) of
+                            true -> mod_muc_light:delete_room(jid:to_lus(RoomJID));
+                            false -> {error, denied, "you can not delete this room"}
+                          end;
         {error, given_user_does_not_occupy_any_room} -> {error, denied, "given user does not occupy this room"};
         {error, not_found} -> {error, not_found, "room does not exist"}
     end.


### PR DESCRIPTION
This PR addresses #3472

Proposed changes include:
* allowing members to delete muc_light rooms when equal_occupants is set to true
* no tests updated
* no doc updated

