### PR TITLE
Fix print-dots for Mac OS Monterey

### DIFF
--- a/tools/print-dots.sh
+++ b/tools/print-dots.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PIDFILE=/tmp/print-dots.pid
-SLEEPTIME=10s
+SLEEPTIME=10
 
 loop () {
     while true; do


### PR DESCRIPTION
It gets stuck in an infinite busy loop, printing `usage: sleep seconds`
Apparently it accepts only integers now and nothing else, as `man sleep` tells me.


