### PR TITLE
Use dynamic_modules in big tests

### DIFF
--- a/big_tests/tests/adhoc_SUITE.erl
+++ b/big_tests/tests/adhoc_SUITE.erl
@@ -84,7 +84,7 @@ init_modules(_, Config) ->
     Config.
 
 restore_modules(disco_visible, Config) ->
-    dynamic_modules:restore_modules(host_type(), Config);
+    dynamic_modules:restore_modules(Config);
 restore_modules(_, _Config) ->
     ok.
 

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -167,7 +167,7 @@ save_offline_status(_GN, Config) -> Config.
 end_per_group(GroupName, Config) ->
     teardown_meck(GroupName),
     case lists:member(GroupName, main_group_names()) of
-        true -> dynamic_modules:restore_modules(host_type(), Config);
+        true -> dynamic_modules:restore_modules(Config);
         false -> ok
     end.
 

--- a/big_tests/tests/disco_and_caps_SUITE.erl
+++ b/big_tests/tests/disco_and_caps_SUITE.erl
@@ -45,7 +45,7 @@ init_per_group(Name, C) ->
     C2.
 
 end_per_group(_Name, C) ->
-    dynamic_modules:restore_modules(host_type(), C).
+    dynamic_modules:restore_modules(C).
 
 init_per_testcase(Name, C) ->
     escalus:init_per_testcase(Name, C).

--- a/big_tests/tests/domain_isolation_SUITE.erl
+++ b/big_tests/tests/domain_isolation_SUITE.erl
@@ -45,7 +45,7 @@ modules() ->
      {mod_muc_light, [{host, MucHost}]}].
 
 init_per_group(two_domains, Config) ->
-    Config2 = dynamic_modules:save_modules_for_host_types(host_types(), Config),
+    Config2 = dynamic_modules:save_modules(host_types(), Config),
     [dynamic_modules:ensure_modules(HostType, modules()) || HostType <- host_types()],
     Config2.
 

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -58,7 +58,7 @@ init_per_group(Group, Config) ->
     case mongoose_helper:is_rdbms_enabled(host_type()) of
         true ->
             HostTypes = domain_helper:host_types(),
-            Config2 = dynamic_modules:save_modules_for_host_types(HostTypes, Config),
+            Config2 = dynamic_modules:save_modules(HostTypes, Config),
             [dynamic_modules:ensure_modules(HostType, group_to_modules(Group)) ||
                 HostType <- HostTypes],
             Config2;

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -2,36 +2,46 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--export([save_modules_for_host_types/2,
-         save_modules/2, get_saved_config/3, ensure_modules/2, ensure_stopped/2,
-         restore_modules/2, restore_modules/1]).
--export([stop/2, stop/3, start/3, start/4, restart/3, stop_running/2, start_running/1]).
+-compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0,
-                             rpc/4]).
+-import(distributed_helper, [mim/0, rpc/4]).
 
-save_modules_for_host_types([HostType|HostTypes], Config) ->
-    Config2 = save_modules(HostType, Config),
-    save_modules_for_host_types(HostTypes, Config2);
-save_modules_for_host_types([], Config) ->
-    Config.
+save_modules_for_host_types(HostTypes, Config) ->
+    save_modules(mim(), HostTypes, Config).
 
 save_modules(HostType, Config) ->
-    [{{saved_modules, HostType}, get_current_modules(HostType)} | Config].
+    save_modules(mim(), [HostType], Config).
+
+%% Save modules from Node for HostTypes, overwriting previously saved modules
+save_modules(Node = #{node := NodeName}, HostTypes, Config) ->
+    lists:foldl(fun(HostType, ConfigIn) ->
+                        Key = {saved_modules, NodeName, HostType},
+                        Value = get_current_modules(Node, HostType),
+                        lists:keystore(Key, 1, ConfigIn, {Key, Value})
+                end, Config, HostTypes).
 
 get_saved_config(HostType, Module, Config) ->
-    SavedModules = proplists:get_value({saved_modules, HostType}, Config),
+    get_saved_config(mim(), HostType, Module, Config).
+
+get_saved_config(#{node := NodeName}, HostType, Module, Config) ->
+    SavedModules = proplists:get_value({saved_modules, NodeName, HostType}, Config),
     proplists:get_value(Module, SavedModules).
 
 ensure_modules(HostType, RequiredModules) ->
-    CurrentModules = get_current_modules(HostType),
+    ensure_modules(mim(), HostType, RequiredModules).
+
+ensure_modules(Node, HostType, RequiredModules) ->
+    CurrentModules = get_current_modules(Node, HostType),
     {ToReplace, ReplaceWith} = to_replace(RequiredModules, CurrentModules, [], []),
-    ok = rpc(mim(), gen_mod_deps, replace_modules, [HostType, ToReplace, ReplaceWith]).
+    ok = rpc(Node, gen_mod_deps, replace_modules, [HostType, ToReplace, ReplaceWith]).
 
 ensure_stopped(HostType, ModulesToStop) ->
+    ensure_stopped(mim(), HostType, ModulesToStop).
+
+ensure_stopped(Node, HostType, ModulesToStop) ->
     CurrentModules = get_current_modules(HostType),
-    [stop(HostType, Mod) || {Mod, _Opts} <- CurrentModules,
-                            lists:member(Mod, ModulesToStop)].
+    [stop(Node, HostType, Mod) || {Mod, _Opts} <- CurrentModules,
+                                  lists:member(Mod, ModulesToStop)].
 
 to_replace([], _CurrentModules, ReplaceAcc, ReplaceWithAcc) ->
     {lists:usort(ReplaceAcc), ReplaceWithAcc};
@@ -47,51 +57,46 @@ to_replace([RequiredModule | Rest], CurrentModules, ReplaceAcc, ReplaceWithAcc) 
         end,
     to_replace(Rest, CurrentModules, NewReplaceAcc, NewReplaceWithAcc).
 
-restore_modules(HostType, Config) ->
-    SavedModules = ?config({saved_modules, HostType}, Config),
-    CurrentModules = get_current_modules(HostType),
-    rpc(mim(), gen_mod_deps, replace_modules, [HostType, CurrentModules, SavedModules]).
-
 restore_modules(Config) ->
-    [restore_modules(HostType, Config)
-     || {{saved_modules, HostType}, _SavedModules} <- Config],
+    restore_modules(#{}, Config).
+
+restore_modules(RPCSpec, Config) when is_map(RPCSpec) ->
+    [restore_modules(RPCSpec#{node => NodeName}, HostType, SavedModules)
+     || {{saved_modules, NodeName, HostType}, SavedModules} <- Config],
     Config.
 
+restore_modules(Node, HostType, SavedModules) ->
+    CurrentModules = get_current_modules(Node, HostType),
+    rpc(Node, gen_mod_deps, replace_modules, [HostType, CurrentModules, SavedModules]).
+
 get_current_modules(HostType) ->
-    rpc(mim(), gen_mod, loaded_modules_with_opts, [HostType]).
+    get_current_modules(mim(), HostType).
+
+get_current_modules(Node, HostType) ->
+    rpc(Node, gen_mod, loaded_modules_with_opts, [HostType]).
 
 stop(HostType, Mod) ->
-    Node = escalus_ct:get_config(ejabberd_node),
-    stop(Node, HostType, Mod).
+    stop(mim(), HostType, Mod).
 
-stop(#{node := Node}, HostType, Mod) ->
-    stop(Node, HostType, Mod);
 stop(Node, HostType, Mod) ->
-    Cookie = escalus_ct:get_config(ejabberd_cookie),
-    IsLoaded = escalus_rpc:call(Node, gen_mod, is_loaded, [HostType, Mod], 5000, Cookie),
+    IsLoaded = rpc(Node, gen_mod, is_loaded, [HostType, Mod]),
     case IsLoaded of
-        true -> unsafe_stop(Node, Cookie, HostType, Mod);
+        true -> unsafe_stop(Node, HostType, Mod);
         false -> {error, stopped}
     end.
 
-unsafe_stop(Node, Cookie, HostType, Mod) ->
-    case escalus_rpc:call(Node, gen_mod, stop_module, [HostType, Mod], 5000, Cookie) of
+unsafe_stop(Node, HostType, Mod) ->
+    case rpc(Node, gen_mod, stop_module, [HostType, Mod]) of
         {badrpc, Reason} ->
             ct:fail("Cannot stop module ~p reason ~p", [Mod, Reason]);
         R -> R
     end.
 
 start(HostType, Mod, Args) ->
-    Node = escalus_ct:get_config(ejabberd_node),
-    start(Node, HostType, Mod, Args).
+    start(mim(), HostType, Mod, Args).
 
-start(#{node := Node}, HostType, Mod, Args) ->
-    start(Node, HostType, Mod, Args);
 start(Node, HostType, Mod, Args) ->
-    Cookie = escalus_ct:get_config(ejabberd_cookie),
-    case escalus_rpc:call(Node, gen_mod, start_module, [HostType, Mod, Args], 5000, Cookie) of
-        {badrpc, Reason} ->
-            ct:fail("Cannot start module ~p reason ~p", [Mod, Reason]);
+    case rpc(Node, gen_mod, start_module, [HostType, Mod, Args]) of
         {ok, _} = R ->
             R;
         Reason ->
@@ -99,15 +104,18 @@ start(Node, HostType, Mod, Args) ->
     end.
 
 restart(HostType, Mod, Args) ->
-    stop(HostType, Mod),
+    restart(mim(), HostType, Mod, Args).
+
+restart(Node, HostType, Mod, Args) ->
+    stop(Node, HostType, Mod),
     ModStr = atom_to_list(Mod),
     case lists:reverse(ModStr) of
         "smbdr_" ++ Str -> %%check if we need to start rdbms module or regular
-            stop(HostType, list_to_atom(lists:reverse(Str)));
+            stop(Node, HostType, list_to_atom(lists:reverse(Str)));
         Str ->
-            stop(HostType, list_to_atom(lists:reverse(Str)++"_rdbms"))
+            stop(Node, HostType, list_to_atom(lists:reverse(Str)++"_rdbms"))
     end,
-    start(HostType, Mod, Args).
+    start(Node, HostType, Mod, Args).
 
 start_running(Config) ->
     HostType = domain_helper:host_type(mim),

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -116,32 +116,3 @@ restart(Node, HostType, Mod, Args) ->
             stop(Node, HostType, list_to_atom(lists:reverse(Str)++"_rdbms"))
     end,
     start(Node, HostType, Mod, Args).
-
-start_running(Config) ->
-    HostType = domain_helper:host_type(mim),
-    case ?config(running, Config) of
-        List when is_list(List) ->
-            _ = [start(HostType, Mod, Args) || {Mod, Args} <- List];
-        _ ->
-            ok
-    end.
-
-stop_running(Mod, Config) ->
-    ModL = atom_to_list(Mod),
-    HostType = domain_helper:host_type(mim),
-    Modules = rpc(mim(), mongoose_config, get_opt, [{modules, HostType}]),
-    Filtered = lists:filter(fun({Module, _}) ->
-                    ModuleL = atom_to_list(Module),
-                    case lists:sublist(ModuleL, 1, length(ModL)) of
-                        ModL -> true;
-                        _ -> false
-                    end;
-                (_) -> false
-            end, Modules),
-    case Filtered of
-        [] ->
-            Config;
-        [{Module,_Args}=Head|_] ->
-            stop(HostType, Module),
-            [{running, [Head]} | Config]
-    end.

--- a/big_tests/tests/dynamic_modules.erl
+++ b/big_tests/tests/dynamic_modules.erl
@@ -1,15 +1,12 @@
 -module(dynamic_modules).
 
--include_lib("common_test/include/ct.hrl").
-
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
-save_modules_for_host_types(HostTypes, Config) ->
-    save_modules(mim(), HostTypes, Config).
-
-save_modules(HostType, Config) ->
+save_modules(HostTypes, Config) when is_list(HostTypes) ->
+    save_modules(mim(), HostTypes, Config);
+save_modules(HostType, Config) when is_binary(HostType) ->
     save_modules(mim(), [HostType], Config).
 
 %% Save modules from Node for HostTypes, overwriting previously saved modules

--- a/big_tests/tests/extdisco_SUITE.erl
+++ b/big_tests/tests/extdisco_SUITE.erl
@@ -320,9 +320,7 @@ set_external_services(Opts, Config) ->
     Config.
 
 remove_external_services(Config) ->
-    OldModules = rpc(mim(), gen_mod, loaded_modules_with_opts, [domain()]),
-    NewModules = lists:keydelete(mod_extdisco, 1, OldModules),
-    ok = rpc(mim(), gen_mod_deps, replace_modules, [domain(), OldModules, NewModules]),
+    dynamic_modules:ensure_stopped(domain(), [mod_extdisco]),
     Config.
 
 request_external_services(To) ->

--- a/big_tests/tests/extdisco_SUITE.erl
+++ b/big_tests/tests/extdisco_SUITE.erl
@@ -93,13 +93,13 @@ init_per_testcase(Name, Config) ->
 end_per_testcase(Name, Config) when
     Name == external_services_discovery_not_supported;
     Name == no_external_services_configured_no_services_returned ->
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_testcase(Name, Config);
 end_per_testcase(Name, Config) ->
     escalus:end_per_testcase(Name, Config).
 
 end_per_group(_GroupName, Config) ->
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     Config.
 
 end_per_suite(Config) ->

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -192,7 +192,7 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     delete_files(),
     escalus_fresh:clean(),
-    dynamic_modules:restore_modules(host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(GN, Config) when GN =:= remove_personal_data_mam_rdbms;
@@ -290,7 +290,7 @@ init_per_testcase(CN, Config) when CN =:= retrieve_mam_muc;
         skip ->
             {skip, no_mam_backend_configured};
         Backend ->
-            dynamic_modules:restore_modules(host_type(), Config),
+            dynamic_modules:restore_modules(Config),
             RequiredModules = mam_required_modules(CN, Backend),
             dynamic_modules:ensure_modules(host_type(), RequiredModules),
             ct:log("required modules: ~p~n", [RequiredModules]),

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -148,7 +148,7 @@ init_per_suite(Config0) ->
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     dynamic_modules:stop(ct:get_config({hosts, mim, secondary_host_type}), mod_inbox),
-    dynamic_modules:restore_modules(domain_helper:host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(one_to_one, Config) ->

--- a/big_tests/tests/jingle_SUITE.erl
+++ b/big_tests/tests/jingle_SUITE.erl
@@ -85,20 +85,14 @@ wait_for_process_to_stop(Pid) ->
               ct:fail(wait_for_process_to_stop_timeout)
     end.
 
-start_nskip_in_parallel(RPCSpec, ExtraOpts) ->
+start_nskip_in_parallel(NodeSpec, ExtraOpts) ->
     Domain = domain(),
-    proc_lib:spawn_link(
-      fun() ->
-              {ok, _} = rpc(RPCSpec#{timeout => timer:seconds(60)}, gen_mod, start_module,
-                            [
-                             Domain, mod_jingle_sip,
-                             [{proxy_host, "localhost"},
-                              {proxy_port, 12345},
-                              {username_to_phone,[{<<"2000006168">>, <<"+919177074440">>}]}
-                              | ExtraOpts]
-                            ])
-      end).
-
+    Opts = [{proxy_host, "localhost"},
+            {proxy_port, 12345},
+            {username_to_phone,[{<<"2000006168">>, <<"+919177074440">>}]}
+           | ExtraOpts],
+    RPCSpec = NodeSpec#{timeout => timer:seconds(60)},
+    proc_lib:spawn_link(dynamic_modules, start, [RPCSpec, Domain, mod_jingle_sip, Opts]).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -836,7 +836,7 @@ end_modules(C, muc_light, Config) ->
     dynamic_modules:stop(host_type(), mod_muc_light),
     Config;
 end_modules(_, _, Config) ->
-    [stop_module(host_type(), M) || M <- mam_modules()],
+    dynamic_modules:ensure_stopped(host_type(), mam_modules()),
     Config.
 
 muc_domain(Config) ->
@@ -1166,24 +1166,7 @@ required_modules(_, _) ->
 
 init_module(Host, Mod, Args) ->
     lists:member(Mod, mam_modules()) orelse ct:fail("Unknown module ~p", [Mod]),
-    stop_module(Host, Mod),
-    {ok, _} = start_module(Host, Mod, Args).
-
-is_loaded_module(Host, Mod) ->
-    rpc_apply(gen_mod, is_loaded, [Host, Mod]).
-
-start_module(Host, Mod, Args) ->
-    rpc_apply(gen_mod, start_module, [Host, Mod, Args]).
-
-stop_module(Host, Mod) ->
-    case is_loaded_module(Host, Mod) of
-        non_existing -> ok;
-        false        -> ok;
-        true         -> just_stop_module(Host, Mod)
-    end.
-
-just_stop_module(Host, Mod) ->
-    {ok, _Opts} = rpc_apply(gen_mod, stop_module, [Host, Mod]).
+    dynamic_modules:ensure_modules(Host, [{Mod, Args}]).
 
 %%--------------------------------------------------------------------
 %% Group name helpers

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -310,10 +310,9 @@ tests() ->
         not is_skipped(C, G)].
 
 groups() ->
-    Gs = [{full_group(C, G), Props, Tests}
-          || C <- configurations(), {G, Props, Tests} <- basic_groups(),
-             not is_skipped(C, G)],
-    ct_helper:repeat_all_until_all_ok(Gs).
+    [{full_group(C, G), Props, Tests}
+     || C <- configurations(), {G, Props, Tests} <- basic_groups(),
+        not is_skipped(C, G)].
 
 is_skipped(_, _) ->
     false.

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -752,7 +752,10 @@ init_modules(BackendType, muc_light, Config) ->
     case BackendType of
         cassandra -> ok;
         elasticsearch -> ok;
-        _ -> init_module(host_type(), mod_mam_rdbms_user, [muc, pm])
+        _ ->
+            init_module(host_type(), mod_mam_rdbms_arch_async, [{muc, [{flush_interval, 1}]},
+                                                                {pm, [{flush_interval, 1}]}]),
+            init_module(host_type(), mod_mam_rdbms_user, [muc, pm])
     end,
     Config1;
 init_modules(rdbms, C, Config) ->
@@ -1162,12 +1165,6 @@ required_modules(retract_message_on_stanza_id, _Config) ->
 required_modules(_, _) ->
     [].
 
-init_module(Host, mod_mam_rdbms_arch_async, Args) ->
-    OldOpts = case stop_module(Host, mod_mam_rdbms_arch_async) of
-                  {ok, O} -> O;
-                  ok -> []
-              end,
-    {ok, _} = start_module(Host, mod_mam_rdbms_arch_async, lists:ukeymerge(1, OldOpts, Args));
 init_module(Host, Mod, Args) ->
     lists:member(Mod, mam_modules()) orelse ct:fail("Unknown module ~p", [Mod]),
     stop_module(Host, Mod),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -638,10 +638,10 @@ end_per_group(G, Config) when G == rsm_all; G == nostore;
     G == archived; G == mam_metrics ->
       Config;
 end_per_group(muc_configurable_archiveid, Config) ->
-    dynamic_modules:restore_modules(host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     Config;
 end_per_group(configurable_archiveid, Config) ->
-    dynamic_modules:restore_modules(host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     Config;
 end_per_group(muc_rsm_all, Config) ->
     destroy_room(Config);

--- a/big_tests/tests/mam_send_message_SUITE.erl
+++ b/big_tests/tests/mam_send_message_SUITE.erl
@@ -59,7 +59,7 @@ init_per_group(Group, Config) ->
         true ->
             load_custom_module(),
             Config2 = dynamic_modules:save_modules(host_type(), Config),
-            rpc(mim(), gen_mod_deps, start_modules, [host_type(), group_to_modules(Group)]),
+            dynamic_modules:ensure_modules(host_type(), group_to_modules(Group)),
             [{props, mam_helper:mam06_props()}|Config2];
         false ->
             {skip, require_rdbms}

--- a/big_tests/tests/mam_send_message_SUITE.erl
+++ b/big_tests/tests/mam_send_message_SUITE.erl
@@ -68,7 +68,7 @@ init_per_group(Group, Config) ->
 end_per_group(_Groupname, Config) ->
     case mongoose_helper:is_rdbms_enabled(host_type()) of
         true ->
-            dynamic_modules:restore_modules(host_type(), Config);
+            dynamic_modules:restore_modules(Config);
         false ->
             ok
     end,

--- a/big_tests/tests/metrics_c2s_SUITE.erl
+++ b/big_tests/tests/metrics_c2s_SUITE.erl
@@ -60,11 +60,13 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    Config1 = dynamic_modules:stop_running(mod_offline, Config),
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config),
+    dynamic_modules:ensure_stopped(HostType, [mod_offline]),
     escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
-    dynamic_modules:start_running(Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(_GroupName, Config) ->

--- a/big_tests/tests/mod_aws_sns_SUITE.erl
+++ b/big_tests/tests/mod_aws_sns_SUITE.erl
@@ -91,8 +91,7 @@ init_per_group(_, Config0) ->
     Config.
 
 end_per_group(_, Config) ->
-    Domain = domain(),
-    dynamic_modules:restore_modules(Domain, Config),
+    dynamic_modules:restore_modules(Config),
     escalus:delete_users(Config, escalus:get_users([bob, alice])).
 
 init_per_testcase(muc_messages = C, Config0) ->

--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -63,7 +63,7 @@ init_per_group(with_prefix, Config) ->
     set_modules(Config, [{path, "/prefix"}]).
 
 end_per_group(_GroupName, Config) ->
-    dynamic_modules:restore_modules(host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     ok.
 
 init_per_testcase(CaseName, Config) ->

--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -156,7 +156,7 @@ end_per_group(_, Config) ->
     delete_exchanges(),
     Domain = domain(),
     dynamic_modules:stop(Domain, mod_event_pusher),
-    dynamic_modules:restore_modules(Domain, Config),
+    dynamic_modules:restore_modules(Config),
     escalus:delete_users(Config, escalus:get_users([bob, alice])).
 
 init_per_testcase(rabbit_pool_starts_with_default_config, Config) ->

--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -623,10 +623,10 @@ get_decoded_message_from_rabbit(RoutingKey) ->
 %%--------------------------------------------------------------------
 
 start_mod_event_pusher_rabbit(Config) ->
-    rpc(mim(), gen_mod, start_module, [domain(), mod_event_pusher_rabbit, Config]).
+    dynamic_modules:start(domain(), mod_event_pusher_rabbit, Config).
 
 stop_mod_event_pusher_rabbit() ->
-    rpc(mim(), gen_mod, stop_module, [domain(), mod_event_pusher_rabbit]).
+    dynamic_modules:stop(domain(), mod_event_pusher_rabbit).
 
 start_rabbit_wpool(Host) ->
     start_rabbit_wpool(Host, ?WPOOL_CFG).

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -331,7 +331,7 @@ end_per_suite(Config) ->
     escalus_fresh:clean(),
     mongoose_helper:ensure_muc_clean(),
     unload_muc(),
-    dynamic_modules:restore_modules(host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 
@@ -448,7 +448,7 @@ end_per_group(G, Config) when G =:= http_auth_no_server;
         _ -> ok
     end,
     ejabberd_node_utils:call_fun(mongoose_wpool, stop, [http, global, muc_http_auth_test]),
-    dynamic_modules:restore_modules(host_type(), Config);
+    dynamic_modules:restore_modules(Config);
 end_per_group(hibernation, Config) ->
     case mam_helper:backend() of
         rdbms ->

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -103,7 +103,7 @@ chatmarkers_modules() ->
 
 end_per_group(Group, C) when Group =:= chatmarkers;
                              Group =:= with_groupchat ->
-    dynamic_modules:restore_modules(host_type(), C),
+    dynamic_modules:restore_modules(C),
     C;
 end_per_group(_, C) -> C.
 

--- a/big_tests/tests/offline_stub_SUITE.erl
+++ b/big_tests/tests/offline_stub_SUITE.erl
@@ -36,7 +36,7 @@ init_per_testcase(Name, Config0) ->
 
 end_per_testcase(Name, Config) ->
     HostType = domain_helper:host_type(),
-    dynamic_modules:restore_modules(HostType, Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_testcase(Name, Config).
 
 %%%===================================================================

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -95,7 +95,7 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(cache_tests, Config) ->
@@ -109,7 +109,7 @@ init_per_group(_GroupName, Config) ->
     Config.
 
 end_per_group(cache_tests, Config) ->
-    dynamic_modules:restore_modules(domain(), Config);
+    dynamic_modules:restore_modules(Config);
 
 end_per_group(_GroupName, Config) ->
     Config.

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -316,7 +316,7 @@ plugin_by_nodetree(<<"dag">>) -> <<"dag">>;
 plugin_by_nodetree(<<"tree">>) -> <<"flat">>.
 
 end_per_group(_GroupName, Config) ->
-    dynamic_modules:restore_modules(domain(), Config).
+    dynamic_modules:restore_modules(Config).
 
 init_per_testcase(notify_unavailable_user_test, _Config) ->
     {skip, "mod_offline does not store events"};

--- a/big_tests/tests/pubsub_s2s_SUITE.erl
+++ b/big_tests/tests/pubsub_s2s_SUITE.erl
@@ -83,7 +83,7 @@ plugin_by_nodetree(<<"dag">>) -> <<"dag">>;
 plugin_by_nodetree(<<"tree">>) -> <<"flat">>.
 
 end_per_group(_GroupName, Config) ->
-    dynamic_modules:restore_modules(domain(), Config).
+    dynamic_modules:restore_modules(Config).
 
 init_per_testcase(_TestName, Config) ->
     escalus:init_per_testcase(_TestName, Config).

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -170,7 +170,7 @@ ensure_pusher_module_and_save_old_mods(Config) ->
     [{push_opts, PushOpts} | Config1].
 
 restore_modules(Config) ->
-    dynamic_modules:restore_modules(domain_helper:host_type(), Config).
+    dynamic_modules:restore_modules(Config).
 
 %%--------------------------------------------------------------------
 %% GROUP disco

--- a/big_tests/tests/push_http_SUITE.erl
+++ b/big_tests/tests/push_http_SUITE.erl
@@ -56,7 +56,7 @@ init_per_group(GroupName, Config) ->
     escalus:create_users(Config2, escalus:get_users([alice, bob])).
 
 end_per_group(_, Config) ->
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:delete_users(Config, escalus:get_users([alice, bob])).
 
 init_per_testcase(CaseName, Config) ->

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -169,7 +169,7 @@ init_per_group(G, Config) ->
     C.
 
 end_per_group(_, Config) ->
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     Config.
 
 init_per_testcase(CaseName, Config) ->

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -60,7 +60,7 @@ init_per_suite(Config) ->
     escalus:create_users(Config3, escalus:get_users([bob, alice])).
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus:delete_users(Config, escalus:get_users([bob, alice])),
     escalus:end_per_suite(Config).
 
@@ -440,6 +440,6 @@ required_modules(APIVersion) ->
      ]}].
 
 restart_modules(Config, APIVersion) ->
-    dynamic_modules:restore_modules(domain(), Config),
+    dynamic_modules:restore_modules(Config),
     dynamic_modules:ensure_modules(domain(), required_modules(APIVersion)),
     Config.

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -127,14 +127,15 @@ end_per_group(_GroupName, Config) ->
 init_per_testcase(types_are_checked_separately_for_args_and_return = CaseName, Config) ->
     {Mod, Code} = rpc(dynamic_compile, from_string, [custom_module_code()]),
     rpc(code, load_binary, [Mod, "mod_commands_test.erl", Code]),
-    rpc(gen_mod, start_module, [host_type(), mod_commands_test, []]),
-    escalus:init_per_testcase(CaseName, Config);
+    Config1 = dynamic_modules:save_modules(host_type(), Config),
+    dynamic_modules:ensure_modules(host_type(), [{mod_commands_test, []}]),
+    escalus:init_per_testcase(CaseName, Config1);
 init_per_testcase(CaseName, Config) ->
     MAMTestCases = [messages_are_archived, messages_can_be_paginated],
     rest_helper:maybe_skip_mam_test_cases(CaseName, MAMTestCases, Config).
 
 end_per_testcase(types_are_checked_separately_for_args_and_return = CaseName, Config) ->
-    rpc(gen_mod, stop_module, [host_type(), mod_commands_test]),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -205,7 +205,7 @@ end_per_suite(Config) ->
     restore_conf(mim2(), Conf2),
     restore_conf(mim3(), Conf3),
     domain_helper:insert_configured_domains(),
-    dynamic_modules:restore_modules(dummy_auth_host_type(), Config),
+    dynamic_modules:restore_modules(Config),
     escalus_fresh:clean(),
     escalus:end_per_suite(Config).
 

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -275,7 +275,7 @@ init_per_testcase2(TestcaseName, Config)
     when TestcaseName =:= rest_delete_domain_cleans_data_from_mam ->
     HostType = dummy_auth_host_type(),
     Mods = [{mod_mam_meta, [{backend, rdbms}, {pm, []}]}],
-    rpc(mim(), gen_mod_deps, start_modules, [HostType, Mods]),
+    dynamic_modules:ensure_modules(HostType, Mods),
     escalus:init_per_testcase(TestcaseName, Config);
 init_per_testcase2(_, Config) ->
     Config.

--- a/big_tests/tests/sic_SUITE.erl
+++ b/big_tests/tests/sic_SUITE.erl
@@ -1,14 +1,12 @@
 %%%===================================================================
 %%% @copyright (C) 2011, Erlang Solutions Ltd.
-%%% @doc Suite for testing mod_offline* modules
+%%% @doc Suite for testing mod_sic module
 %%% @end
 %%%===================================================================
 
 -module(sic_SUITE).
 -compile([export_all, nowarn_export_all]).
 
--include_lib("escalus/include/escalus.hrl").
--include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
 
 -define(NS_SIC, <<"urn:xmpp:sic:1">>).
@@ -47,14 +45,15 @@ end_per_suite(Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, bob])),
     escalus:end_per_suite(Config).
 
-init_per_group(mod_offline_tests, Config) ->
-    start_module(mod_sic, []),
-    Config;
+init_per_group(mod_sic_tests, Config) ->
+    Config1 = dynamic_modules:save_modules(host_type(), Config),
+    dynamic_modules:ensure_modules(host_type(), [{mod_sic, []}]),
+    Config1;
 init_per_group(_GroupName, Config) ->
     Config.
 
-end_per_group(mod_offline_tests, _Config) ->
-    stop_module(mod_sic);
+end_per_group(mod_sic_tests, Config) ->
+    dynamic_modules:restore_modules(Config);
 end_per_group(_GroupName, _Config) ->
     ok.
 
@@ -106,14 +105,6 @@ is_sic_response() ->
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
-
-start_module(ModuleName, Options) ->
-    Args = [host_type(), ModuleName, Options],
-    rpc(mim(), gen_mod, start_module, Args).
-
-stop_module(ModuleName) ->
-    Args = [host_type(), ModuleName],
-    rpc(mim(), gen_mod, stop_module, Args).
 
 sic_iq_get() ->
     escalus_stanza:iq(<<"get">>, [#xmlel{

--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -1154,7 +1154,7 @@ restart_mod(HostType, Params) ->
 
 prepare_vcard_module(Config) ->
     %% Keep the old config, so we can undo our changes, once finished testing
-    Config1 = dynamic_modules:save_modules_for_host_types(host_types(), Config),
+    Config1 = dynamic_modules:save_modules(host_types(), Config),
     %% Get a list of options, we can use as a prototype to start new modules
     _HostType = domain_helper:host_type(),
     VCardOpts = dynamic_modules:get_saved_config(host_type(), mod_vcard, Config1),

--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -467,7 +467,7 @@ ensure_started(HostType, Opts) ->
 
 prepare_vcard_module(Config) ->
     %% Keep the old config, so we can undo our changes, once finished testing
-    Config1 = dynamic_modules:save_modules_for_host_types(host_types(), Config),
+    Config1 = dynamic_modules:save_modules(host_types(), Config),
     %% Get a list of options, we can use as a prototype to start new modules
     VCardOpts = dynamic_modules:get_saved_config(host_type(), mod_vcard, Config1),
     [{mod_vcard_opts, VCardOpts} | Config1].


### PR DESCRIPTION
Do not use `gen_mod` directly to start and stop modules in tests.
Use the `dynamic_modules` API instead.

These changes make it possible to modify the module management logic without any changes in the test suites - only the `dynamic_domains` helper will be modified.
