### PR TITLE
Do not post-process config when starting modules

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -329,7 +329,7 @@ build_state(Hosts, HostTypes, Opts) ->
                  fun(S) -> mongoose_config_parser:set_host_types(HostTypes, S) end,
                  fun(S) -> mongoose_config_parser:set_opts(Opts, S) end,
                  fun mongoose_config_parser:dedup_state_opts/1,
-                 fun mongoose_config_parser:add_dep_modules/1]).
+                 fun mongoose_config_parser:post_process_modules/1]).
 
 %% Any nested config_part() may be a config_error() - this function extracts them all recursively
 -spec extract_errors([config()]) -> [config_error()].

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -132,9 +132,8 @@ start_module(HostType, Module, Opts) ->
         false -> start_module_for_host_type(HostType, Module, Opts)
     end.
 
-start_module_for_host_type(HostType, Module, Opts0) ->
+start_module_for_host_type(HostType, Module, Opts) ->
     {links, LinksBefore} = erlang:process_info(self(), links),
-    Opts = proplists:unfold(Opts0),
     ets:insert(ejabberd_modules, #ejabberd_module{module_host_type = {Module, HostType},
                                                   opts = Opts}),
     try

--- a/src/mongoose_modules.erl
+++ b/src/mongoose_modules.erl
@@ -67,7 +67,8 @@ ensure_stopped(HostType, Module) ->
 %% @doc Make sure the module is running with the provided options.
 -spec ensure_started(mongooseim:host_type(), module(), module_opts()) ->
           already_started | {started, term()} | {restarted, module_opts(), term()}.
-ensure_started(HostType, Module, Opts) ->
+ensure_started(HostType, Module, RawOpts) ->
+    Opts = proplists:unfold(RawOpts),
     Modules = get_modules(HostType),
     case maps:find(Module, Modules) of
         error ->

--- a/test/config_parser_helper.erl
+++ b/test/config_parser_helper.erl
@@ -393,7 +393,7 @@ options("s2s_only") ->
                                           <<"reg1">> => deny}}].
 
 all_modules() ->
-    #{mod_mam_rdbms_user => [muc, pm],
+    #{mod_mam_rdbms_user => [{muc, true}, {pm, true}],
       mod_event_pusher_hook_translator => [],
       mod_mam_muc =>
           [{archive_chat_markers, true},
@@ -402,7 +402,7 @@ all_modules() ->
            {host, {fqdn, <<"muc.example.com">>}},
            {is_archivable_message, mod_mam_utils}],
       mod_caps => [{cache_life_time, 86}, {cache_size, 1000}],
-      mod_mam_cache_user => [muc, pm],
+      mod_mam_cache_user => [{muc, true}, {pm, true}],
       mod_offline =>
           [{access_max_user_messages, max_user_offline_messages},
            {backend, riak},
@@ -510,14 +510,14 @@ all_modules() ->
            {ldap_rfilter, "(objectClass=inetOrgPerson)"},
            {ldap_user_cache_validity, 1},
            {ldap_userdesc, "cn"}],
-      mod_mam_mnesia_prefs => [muc],
+      mod_mam_mnesia_prefs => [{muc, true}],
       mod_jingle_sip =>
           [{listen_port, 5600},
            {local_host, "localhost"},
            {proxy_host, "localhost"},
            {proxy_port, 5600},
            {sdp_origin, "127.0.0.1"}],
-      mod_mam_rdbms_prefs => [pm],
+      mod_mam_rdbms_prefs => [{pm, true}],
       mod_extdisco =>
           [[{host, "stun1"},
             {password, "password"},
@@ -606,7 +606,7 @@ all_modules() ->
            {password_strength, 32},
            {registration_watchers, [<<"JID1">>, <<"JID2">>]},
            {welcome_message, {"Subject", "Body"}}],
-      mod_mam_rdbms_arch => [no_writer, pm],
+      mod_mam_rdbms_arch => [{no_writer, true}, {pm, true}],
       mod_event_pusher_rabbit =>
           [{chat_msg_exchange,
             [{name, <<"chat_msg">>},
@@ -641,7 +641,7 @@ all_modules() ->
            {matches, 1},
            {search, true}],
       mod_mam_muc_rdbms_arch =>
-          [muc, {db_jid_format, mam_jid_rfc}, {db_message_format, mam_message_xml}],
+          [{muc, true}, {db_jid_format, mam_jid_rfc}, {db_message_format, mam_message_xml}],
       mod_stream_management =>
           [{ack_freq, 1},
            {buffer_max, 30},


### PR DESCRIPTION
Follow-up to #3469 
The config should remain constant since it is stored in the persistent term.
This way it will be possible for modules to read config opts from the persistent term - this change will be done in the next PR.

We will most likely get rid of the unfolding altogether when converting all module options to maps.
