### PR TITLE
Add fallback to queryid in inbox

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -356,7 +356,7 @@ test_msg_stored_in_inbox(Config, QueryId) ->
         check_inbox(Bob, BobConvs, maybe_make_queryid(QueryId))
       end).
 
-maybe_make_queryid(undefined) -> #{};
+maybe_make_queryid(undefined) -> #{iq_id => base16:encode(crypto:strong_rand_bytes(16))};
 maybe_make_queryid(queryid) -> #{queryid => base16:encode(crypto:strong_rand_bytes(16))}.
 
 msg_with_no_store_is_not_stored_in_inbox(Config) ->

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -143,7 +143,7 @@ process_iq(Acc, _From, _To, #iq{type = get, sub_el = SubEl} = IQ, _Extra) ->
     Form = build_inbox_form(),
     SubElWithForm = SubEl#xmlel{ children = [Form] },
     {Acc, IQ#iq{type = result, sub_el = SubElWithForm}};
-process_iq(Acc, From, _To, #iq{type = set, sub_el = QueryEl} = IQ, _Extra) ->
+process_iq(Acc, From, _To, #iq{type = set, id = IqId, sub_el = QueryEl} = IQ, _Extra) ->
     HostType = mongoose_acc:host_type(Acc),
     LUser = From#jid.luser,
     LServer = From#jid.lserver,
@@ -152,7 +152,7 @@ process_iq(Acc, From, _To, #iq{type = set, sub_el = QueryEl} = IQ, _Extra) ->
             {Acc, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:bad_request(<<"en">>, Msg)]}};
         Params ->
             List = mod_inbox_backend:get_inbox(HostType, LUser, LServer, Params),
-            QueryId = exml_query:attr(QueryEl, <<"queryid">>),
+            QueryId = exml_query:attr(QueryEl, <<"queryid">>, IqId),
             forward_messages(Acc, List, QueryId, From),
             Res = IQ#iq{type = result, sub_el = [build_result_iq(List)]},
             {Acc, Res}

--- a/src/inbox/mod_inbox_entries.erl
+++ b/src/inbox/mod_inbox_entries.erl
@@ -67,12 +67,12 @@ get_properties_for_jid(Acc, IQ, From, EntryJID) ->
 -spec process_iq_conversation_set(mongoose_acc:t(), jlib:iq(), jid:jid(), exml:element()) ->
     {mongoose_acc:t(), jlib:iq()}.
 process_iq_conversation_set(
-  Acc, IQ, From, #xmlel{name = <<"query">>, children = Requests} = Query) ->
+  Acc, #iq{id = IqId} = IQ, From, #xmlel{name = <<"query">>, children = Requests} = Query) ->
     case mod_inbox_utils:extract_attr_jid(Query) of
         {error, Msg} ->
             return_error(Acc, IQ, Msg);
         EntryJID ->
-            extract_requests(Acc, IQ, From, EntryJID, Requests, exml_query:attr(Query, <<"queryid">>))
+            extract_requests(Acc, IQ, From, EntryJID, Requests, exml_query:attr(Query, <<"queryid">>, IqId))
     end.
 
 -spec extract_requests(mongoose_acc:t(), jlib:iq(), jid:jid(), jid:jid(), [exml:element()], binary() | undefined) ->


### PR DESCRIPTION
As we fixed the usage of the queryid, we broke the protocol in the sense
that now, if queryid is not provided, the answer will not use any id
now. We need to add the old iq-id as a fallback.