### PR TITLE
Cache muclight affs

### DIFF
--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -283,6 +283,10 @@ schema_opts(CaseName) ->
 common_muc_light_opts() ->
     [{host, subhost_pattern(muc_light_helper:muc_host_pattern())},
      {backend, mongoose_helper:mnesia_or_rdbms_backend()},
+     {cache_affs, [{module, internal},
+                   {strategy, fifo},
+                   {time_to_live, 2},
+                   {number_of_segments, 3}]},
      {rooms_in_rosters, true}].
 
 mam_muc_config(CaseName) when CaseName =:= disco_features_with_mam;

--- a/src/mod_cache_users.erl
+++ b/src/mod_cache_users.erl
@@ -79,7 +79,7 @@ remove_domain(Acc, HostType, Domain) ->
                              HostType :: mongooseim:host_type(),
                              Jid :: jid:jid(),
                              RequestType :: ejabberd_auth:exist_type()) ->
-    boolean().
+    boolean() | {stop, true}.
 does_cached_user_exist(false, HostType, Jid, stored) ->
     case mongoose_user_cache:is_member(HostType, ?MODULE, Jid) of
         true -> {stop, true};
@@ -94,6 +94,7 @@ does_cached_user_exist(Status, _, _, _) ->
                                 RequestType :: ejabberd_auth:exist_type()) ->
     boolean().
 maybe_put_user_into_cache(true, HostType, Jid, stored) ->
-    mongoose_user_cache:merge_entry(HostType, ?MODULE, Jid, #{});
+    mongoose_user_cache:merge_entry(HostType, ?MODULE, Jid, #{}),
+    true;
 maybe_put_user_into_cache(Status, _, _, _) ->
     Status.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -86,7 +86,8 @@
          can_access_identity/3,
          can_access_room/4,
          acc_room_affiliations/2,
-         room_new_affiliations/4]).
+         room_new_affiliations/4,
+         room_exists/2]).
 
 -export([mam_archive_id/2,
          mam_archive_size/3,
@@ -913,6 +914,13 @@ can_access_room(HostType, Acc, Room, User) ->
 acc_room_affiliations(Acc, Room) ->
     HostType = mod_muc_light_utils:acc_to_host_type(Acc),
     run_hook_for_host_type(acc_room_affiliations, HostType, Acc, [Room]).
+
+-spec room_exists(HostType, Room) -> Result when
+      HostType :: mongooseim:host_type(),
+      Room :: jid:jid(),
+      Result :: boolean().
+room_exists(HostType, Room) ->
+    run_hook_for_host_type(room_exists, HostType, false, [HostType, Room]).
 
 -spec room_new_affiliations(Acc, Room, NewAffs, Version) -> NewAcc when
       Acc :: mongoose_acc:t(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1334,7 +1334,7 @@ filter_room_packet(HostType, Packet, EventData) ->
     Room :: jid:luser(),
     Result :: any().
 forget_room(HostType, MucHost, Room) ->
-    run_hook_for_host_type(forget_room, HostType, ok, [HostType, MucHost, Room]).
+    run_hook_for_host_type(forget_room, HostType, #{}, [HostType, MucHost, Room]).
 
 -spec invitation_sent(HookServer, Host, RoomJID, From, To, Reason) -> Result when
     HookServer :: jid:server(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -910,7 +910,7 @@ can_access_room(HostType, Acc, Room, User) ->
       Room :: jid:jid(),
       NewAcc :: mongoose_acc:t().
 acc_room_affiliations(Acc, Room) ->
-    HostType = mongoose_acc:host_type(Acc),
+    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
     run_hook_for_host_type(acc_room_affiliations, HostType, Acc, [Room]).
 
 %% MAM related hooks

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -85,7 +85,8 @@
 -export([is_muc_room_owner/4,
          can_access_identity/3,
          can_access_room/4,
-         acc_room_affiliations/2]).
+         acc_room_affiliations/2,
+         room_new_affiliations/4]).
 
 -export([mam_archive_id/2,
          mam_archive_size/3,
@@ -912,6 +913,16 @@ can_access_room(HostType, Acc, Room, User) ->
 acc_room_affiliations(Acc, Room) ->
     HostType = mod_muc_light_utils:acc_to_host_type(Acc),
     run_hook_for_host_type(acc_room_affiliations, HostType, Acc, [Room]).
+
+-spec room_new_affiliations(Acc, Room, NewAffs, Version) -> NewAcc when
+      Acc :: mongoose_acc:t(),
+      Room :: jid:jid(),
+      NewAffs :: mod_muc_light:aff_users(),
+      Version :: binary(),
+      NewAcc :: mongoose_acc:t().
+room_new_affiliations(Acc, Room, NewAffs, Version) ->
+    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    run_hook_for_host_type(room_new_affiliations, HostType, Acc, [Room, NewAffs, Version]).
 
 %% MAM related hooks
 

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -109,6 +109,7 @@ config_schema_for_host_type(HostType) ->
     gen_mod:get_module_opt(HostType, ?MODULE, config_schema, default_schema()).
 
 force_clear_from_ct(HostType) ->
+    catch mod_muc_light_cache:force_clear(HostType),
     mod_muc_light_db_backend:force_clear(HostType).
 
 %%====================================================================

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -388,7 +388,7 @@ remove_user(Acc, User, Server) ->
             Acc;
         AffectedRooms ->
             bcast_removed_user(Acc, UserJid, AffectedRooms, Version),
-            maybe_forget_rooms(Acc, AffectedRooms),
+            maybe_forget_rooms(Acc, AffectedRooms, Version),
             Acc
     end.
 
@@ -789,12 +789,13 @@ bcast_removed_user(Acc, UserJID, [{{RoomU, RoomS} = _RoomUS, Error} | RAffected]
     bcast_removed_user(Acc, UserJID, RAffected, Version, ID).
 
 -spec maybe_forget_rooms(Acc :: mongoose_acc:t(),
-                         AffectedRooms :: mod_muc_light_db_backend:remove_user_return()) -> ok.
-maybe_forget_rooms(_Acc, []) ->
+                         AffectedRooms :: mod_muc_light_db_backend:remove_user_return(),
+                         Version :: binary()) -> ok.
+maybe_forget_rooms(_Acc, [], _) ->
     ok;
-maybe_forget_rooms(Acc, [{RoomUS, {ok, _, NewAffUsers, _, _}} | RAffectedRooms]) ->
-    mod_muc_light_room:maybe_forget(Acc, RoomUS, NewAffUsers),
-    maybe_forget_rooms(Acc, RAffectedRooms).
+maybe_forget_rooms(Acc, [{RoomUS, {ok, _, NewAffUsers, _, _}} | RAffectedRooms], Version) ->
+    mod_muc_light_room:maybe_forget(Acc, RoomUS, NewAffUsers, Version),
+    maybe_forget_rooms(Acc, RAffectedRooms, Version).
 
 make_handler_fun(Acc) ->
     fun(From, To, Packet) -> ejabberd_router:route(From, To, Acc, Packet) end.

--- a/src/muc_light/mod_muc_light_cache.erl
+++ b/src/muc_light/mod_muc_light_cache.erl
@@ -14,6 +14,9 @@
               pre_room_exists/3, post_room_exists/3,
               forget_room/4, remove_domain/3, room_new_affiliations/4]).
 
+%% For tests
+-export([force_clear/1]).
+
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
     start_cache(HostType, Opts),
@@ -108,6 +111,12 @@ room_new_affiliations(Acc, RoomJid, NewAffs, NewVersion) ->
     mongoose_user_cache:delete_user(HostType, ?MODULE, RoomJid),
     mongoose_user_cache:merge_entry(HostType, ?MODULE, RoomJid, #{affs => {ok, NewAffs, NewVersion}}),
     Acc.
+
+-spec force_clear(mongooseim:host_type()) -> ok.
+force_clear(HostType) ->
+    CacheName = gen_mod:get_module_proc(HostType, ?MODULE),
+    segmented_cache:delete_pattern(CacheName, {'_', '_'}),
+    ok.
 
 %%====================================================================
 %% internal

--- a/src/muc_light/mod_muc_light_cache.erl
+++ b/src/muc_light/mod_muc_light_cache.erl
@@ -1,0 +1,119 @@
+-module(mod_muc_light_cache).
+
+-behaviour(gen_mod).
+-define(FRONTEND, mod_muc_light).
+
+%% gen_mod callbacks
+-export([start/2, stop/1, supported_features/0]).
+
+%% Hook handlers
+-export([pre_acc_room_affiliations/2, post_acc_room_affiliations/2,
+         pre_room_exists/3, post_room_exists/3,
+         forget_room/4, remove_domain/3, room_new_affiliations/4]).
+-ignore_xref([pre_acc_room_affiliations/2, post_acc_room_affiliations/2,
+              pre_room_exists/3, post_room_exists/3,
+              forget_room/4, remove_domain/3, room_new_affiliations/4]).
+
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, Opts) ->
+    start_cache(HostType, Opts),
+    ejabberd_hooks:add(hooks(HostType)),
+    ok.
+
+-spec stop(HostType :: mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    ejabberd_hooks:delete(hooks(HostType)),
+    stop_cache(HostType),
+    ok.
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
+
+-spec hooks(mongooseim:host_type()) -> [ejabberd_hooks:hook()].
+hooks(HostType) ->
+    [
+     {acc_room_affiliations, HostType, ?MODULE, pre_acc_room_affiliations, 40},
+     {acc_room_affiliations, HostType, ?MODULE, post_acc_room_affiliations, 60},
+     {room_exists, HostType, ?MODULE, pre_room_exists, 40},
+     {room_exists, HostType, ?MODULE, post_room_exists, 60},
+     {forget_room, HostType, ?MODULE, forget_room, 80},
+     {remove_domain, HostType, ?MODULE, remove_domain, 20},
+     {room_new_affiliations, HostType, ?MODULE, room_new_affiliations, 50}
+    ].
+
+-spec pre_acc_room_affiliations(mongoose_acc:t(), jid:jid()) ->
+    mongoose_acc:t() | {stop, mongoose_acc:t()}.
+pre_acc_room_affiliations(Acc, RoomJid) ->
+    case mongoose_acc:get(?FRONTEND, affiliations, {error, not_exists}, Acc) of
+        {error, _} ->
+            HostType = mongoose_acc:host_type(Acc),
+            case mongoose_user_cache:get_entry(HostType, ?MODULE, RoomJid) of
+                #{affs := Res} ->
+                    mongoose_acc:set(?FRONTEND, affiliations, Res, Acc);
+                _ ->
+                    Acc
+            end;
+        _Res ->
+            {stop, Acc}
+    end.
+
+-spec post_acc_room_affiliations(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
+post_acc_room_affiliations(Acc, RoomJid) ->
+    case mongoose_acc:get(?FRONTEND, affiliations, {error, not_exists}, Acc) of
+        {error, _} ->
+            Acc;
+        Res ->
+            HostType = mongoose_acc:host_type(Acc),
+            mongoose_user_cache:merge_entry(HostType, ?MODULE, RoomJid, #{affs => Res}),
+            Acc
+    end.
+
+-spec pre_room_exists(boolean(), mongooseim:host_type(), jid:jid()) ->
+    boolean() | {stop, true}.
+pre_room_exists(false, HostType, RoomJid) ->
+    case mongoose_user_cache:is_member(HostType, ?MODULE, RoomJid) of
+        true -> {stop, true};
+        false -> false
+    end;
+pre_room_exists(Status, _, _) ->
+    Status.
+
+-spec post_room_exists(boolean(), mongooseim:host_type(), jid:jid()) ->
+    boolean().
+post_room_exists(true, HostType, RoomJid) ->
+    mongoose_user_cache:merge_entry(HostType, ?MODULE, RoomJid, #{}),
+    true;
+post_room_exists(Status, _, _) ->
+    Status.
+
+-spec forget_room(mongoose_hooks:simple_acc(), mongooseim:host_type(), jid:lserver(), binary()) ->
+    mongoose_hooks:simple_acc().
+forget_room(Acc, HostType, RoomS, RoomU) ->
+    mongoose_user_cache:delete_user(HostType, ?MODULE, jid:make_noprep(RoomU, RoomS, <<>>)),
+    Acc.
+
+-spec remove_domain(mongoose_hooks:simple_acc(), mongooseim:host_type(), jid:lserver()) ->
+    mongoose_hooks:simple_acc().
+remove_domain(Acc, HostType, Domain) ->
+    MUCHost = mod_muc_light:server_host_to_muc_host(HostType, Domain),
+    mongoose_user_cache:delete_domain(HostType, ?MODULE, MUCHost),
+    Acc.
+
+-spec room_new_affiliations(mongoose_acc:t(), jid:jid(), mod_muc_light:aff_users(), binary()) ->
+    mongoose_acc:t().
+room_new_affiliations(Acc, RoomJid, NewAffs, NewVersion) ->
+    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    mongoose_user_cache:merge_entry(HostType, ?MODULE, RoomJid, #{affs => {ok, NewAffs, NewVersion}}),
+    Acc.
+
+%%====================================================================
+%% internal
+%%====================================================================
+-spec start_cache(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start_cache(HostType, Opts) ->
+    mongoose_user_cache:start_new_cache(HostType, ?MODULE, Opts).
+
+-spec stop_cache(mongooseim:host_type()) -> any().
+stop_cache(HostType) ->
+    mongoose_user_cache:stop_cache(HostType, ?MODULE).

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2076,24 +2076,27 @@ test_mod_mam_meta(T, M) ->
 test_cache_config(T, M) ->
     ?cfgh(M([{cache_users, false}]),
           T(#{<<"cache_users">> => false})),
-    ?cfgh(M([{cache, [{module, internal}]}]),
-          T(#{<<"cache">> => #{<<"module">> => <<"internal">>}})),
-    ?cfgh(M([{cache, [{time_to_live, 8600}]}]),
-          T(#{<<"cache">> => #{<<"time_to_live">> => 8600}})),
-    ?cfgh(M([{cache, [{time_to_live, infinity}]}]),
-          T(#{<<"cache">> => #{<<"time_to_live">> => <<"infinity">>}})),
-    ?cfgh(M([{cache, [{number_of_segments, 10}]}]),
-          T(#{<<"cache">> => #{<<"number_of_segments">> => 10}})),
-    ?cfgh(M([{cache, [{strategy, fifo}]}]),
-          T(#{<<"cache">> => #{<<"strategy">> => <<"fifo">>}})),
     ?errh(T(#{<<"cache_users">> => []})),
-    ?errh(T(#{<<"cache">> => #{<<"module">> => <<"mod_wrong_cache">>}})),
-    ?errh(T(#{<<"cache">> => #{<<"module">> => <<"mod_cache_users">>,
+    test_segmented_cache_config(<<"cache">>, cache, T, M).
+
+test_segmented_cache_config(NameK, NameV, T, M) ->
+    ?cfgh(M([{NameV, [{module, internal}]}]),
+          T(#{NameK => #{<<"module">> => <<"internal">>}})),
+    ?cfgh(M([{NameV, [{time_to_live, 8600}]}]),
+          T(#{NameK => #{<<"time_to_live">> => 8600}})),
+    ?cfgh(M([{NameV, [{time_to_live, infinity}]}]),
+          T(#{NameK => #{<<"time_to_live">> => <<"infinity">>}})),
+    ?cfgh(M([{NameV, [{number_of_segments, 10}]}]),
+          T(#{NameK => #{<<"number_of_segments">> => 10}})),
+    ?cfgh(M([{NameV, [{strategy, fifo}]}]),
+          T(#{NameK => #{<<"strategy">> => <<"fifo">>}})),
+    ?errh(T(#{NameK => #{<<"module">> => <<"mod_wrong_cache">>}})),
+    ?errh(T(#{NameK => #{<<"module">> => <<"mod_cache_users">>,
                                <<"time_to_live">> => 8600}})),
-    ?errh(T(#{<<"cache">> => #{<<"time_to_live">> => 0}})),
-    ?errh(T(#{<<"cache">> => #{<<"strategy">> => <<"lifo">>}})),
-    ?errh(T(#{<<"cache">> => #{<<"number_of_segments">> => 0}})),
-    ?errh(T(#{<<"cache">> => #{<<"number_of_segments">> => <<"infinity">>}})).
+    ?errh(T(#{NameK => #{<<"time_to_live">> => 0}})),
+    ?errh(T(#{NameK => #{<<"strategy">> => <<"lifo">>}})),
+    ?errh(T(#{NameK => #{<<"number_of_segments">> => 0}})),
+    ?errh(T(#{NameK => #{<<"number_of_segments">> => <<"infinity">>}})).
 
 test_async_worker(T, M) ->
     ?cfgh(M([{async_writer, [{flush_interval, 1500}]}]),
@@ -2324,6 +2327,7 @@ mod_muc_log_top_link(_Config) ->
 mod_muc_light(_Config) ->
     T = fun(Opts) -> #{<<"modules">> => #{<<"mod_muc_light">> => Opts}} end,
     M = fun(Cfg) -> modopts(mod_muc_light, Cfg) end,
+    test_segmented_cache_config(<<"cache_affs">>, cache_affs, T, M),
     ?cfgh(M([{backend, mnesia}]),
           T(#{<<"backend">> => <<"mnesia">>})),
     ?cfgh(M([{host, {prefix, <<"muclight.">>}}]),


### PR DESCRIPTION
As usual, details on the commits. Some snippets from commit messages below:

3debe70427bf356b895781108dadca401b4e2402
```
It happens easily that querying the affiliations for a room becomes a
global bottleneck on a loaded server: note that every c2s process
fetches this information on their own and individually send the messages
to the given affiliated users, but when in a room of many users all send
a message at once, these affiliations are fetched as many times as users
sent a message, which is a potentially redundant overload of the DB,
more so when this operation is synchronous.

For this, we add new subscribers to the acc_room_affiliations hook: when
affiliations are to be fetched, first a cache handler is run, and if it
returns the value, the hook stops there. Otherwise, after the call to
the real DB handler, another cache handler will insert this record in
the cache, for future calls to it.

Note that we implement here other specially important hooks:
remove_domain clears up the cache on that important event, but also very
importantly forget_room and room_new_affiliations respond to the room
being removed or the affiliations changing, to keep the cache
consistent.

This has now the usual challenge: distribution, on a clustered node. The
events that keep the cache consistent, i.e., forget_room and
room_new_affiliations, are local to a single node. So either we keep
very low ttls on the cache for a fast eventual consistency, or, we
ensure the hooks are run on the whole cluster rapidly.
```

636e780035fe3b8cf7b71221a6b463a0e6bef2d9
```
First of all, on affiliations updates, ask the cache to delete the
record from all other nodes. This will, using pg (so keep in mind the
consistency guarantees), make all other caches delete the record, to
prevent the case where other nodes will work on invalid affiliation
lists.

Then, we also add defaults, to keep the affiliations cache a live of 6
minutes. This might hopefully be a good compromise between responding to
sudden peaks in load, and reducing the risk of an inconsistent
affiliation list on some node.
```