### PR TITLE
Prototype for fragmented SM table

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -233,6 +233,7 @@
     {internal_mnesia,
      %% dbs variable is used by ./tools/test_runner/presets_to_dbs.sh script
      [{dbs, [redis, minio]},
+      {sm_backend, "\"mnesia_frag\""},
       {outgoing_pools, "[outgoing_pools.redis.global_distrib]
   scope = \"global\"
   workers = 10"}]},

--- a/src/ejabberd_sm_mnesia_frag.erl
+++ b/src/ejabberd_sm_mnesia_frag.erl
@@ -1,0 +1,149 @@
+%% Mnesia SM backend with fragments support.
+%% Does not use indexes.
+%% Uses fragments:
+%% - 20% slower reads and writes
+%% - smaller table sizes - this means the table could be synced even under
+%%   heavy load (less number of locks, because locks are per segment.
+%%   Less time for each fragment to be locked during the sync).
+%% - If a node crashes, each other node would clean up locally
+%%   (reduces traffic in the cluster, giving a chance that the cluster
+%%    would not overload itself and crash).
+-module(ejabberd_sm_mnesia_frag).
+
+-behavior(ejabberd_sm_backend).
+
+-include("mongoose.hrl").
+-include("session.hrl").
+
+-export([init/1,
+         get_sessions/0,
+         get_sessions/1,
+         get_sessions/2,
+         get_sessions/3,
+         create_session/4,
+         update_session/4,
+         delete_session/4,
+         cleanup/1,
+         total_count/0,
+         unique_count/0]).
+
+%% Called from mongoose_frag_hash
+-export([simple_key/1]).
+
+-record(mnesia_session, {sur_sid, priority, info}).
+
+simple_key({Server, User, _Resource, _Sid}) ->
+    {Server, User}.
+
+-spec init(list()) -> any().
+init(_Opts) ->
+    FragOpts = [{n_fragments, 32},
+                {hash_module, mongoose_frag_hash},
+                {hash_state, [{simple_hash_module, ?MODULE}]}],
+    mnesia:create_table(mnesia_session,
+                        [{ram_copies, [node()]},
+                         %% Ordered for each fragment
+                         {type, ordered_set},
+                         {frag_properties, FragOpts},
+                         {attributes, record_info(fields, mnesia_session)}]),
+    mnesia:add_table_copy(mnesia_session, node(), ram_copies).
+
+-spec get_sessions() -> [ejabberd_sm:session()].
+get_sessions() ->
+    match_sessions(#mnesia_session{_ = '_'}).
+
+-spec get_sessions(jid:lserver()) -> [ejabberd_sm:session()].
+get_sessions(Server) ->
+    match_sessions(#mnesia_session{_ = '_', sur_sid = {Server, '_', '_', '_'}}).
+
+-spec get_sessions(jid:luser(), jid:lserver()) -> [ejabberd_sm:session()].
+get_sessions(User, Server) ->
+    match_sessions(#mnesia_session{_ = '_', sur_sid = {Server, User, '_', '_'}}).
+
+-spec get_sessions(jid:luser(), jid:lserver(), jid:lresource()
+                  ) -> [ejabberd_sm:session()].
+get_sessions(User, Server, Resource) ->
+    match_sessions(#mnesia_session{_ = '_', sur_sid = {Server, User, Resource, '_'}}).
+
+-spec create_session(_User :: jid:luser(),
+                     _Server :: jid:lserver(),
+                     _Resource :: jid:lresource(),
+                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+create_session(User, Server, Resource, Session) ->
+    case get_sessions(User, Server, Resource) of
+        [] ->
+            write_session(Session);
+        Sessions when is_list(Sessions) ->
+            %% Fix potential race condition during XMPP bind, where
+            %% multiple calls (> 2) to ejabberd_sm:open_session
+            %% have been made, resulting in >1 sessions for this resource
+            MergedSession = mongoose_session:merge_info
+                              (Session, hd(lists:sort(Sessions))),
+            write_session(MergedSession)
+    end.
+
+-spec update_session(_User :: jid:luser(),
+                     _Server :: jid:lserver(),
+                     _Resource :: jid:lresource(),
+                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+update_session(_User, _Server, _Resource, Session) ->
+    write_session(Session).
+
+write_session(Session) ->
+    F = fun(_) -> mnesia:write(from_session(Session)) end,
+    mnesia:activity(sync_dirty, F, [frag_dist], mnesia_frag).
+
+-spec delete_session(ejabberd_sm:sid(),
+                     User :: jid:luser(),
+                     Server :: jid:lserver(),
+                     Resource :: jid:lresource()) -> ok.
+delete_session(SID, User, Server, Resource) ->
+    F = fun(_) -> mnesia:delete({mnesia_session, {Server, User, Resource, SID}}) end,
+    mnesia:activity(sync_dirty, F, [frag_dist], mnesia_frag).
+
+-spec cleanup(atom()) -> any().
+cleanup(Node) ->
+    Pattern = #mnesia_session{_ = '_', sur_sid = {'_', '_', '_', {'_', Node}}},
+    Sessions = match_sessions(Pattern),
+    %% TODO Ideally, we don't want to run that hook
+    lists:map(fun ejabberd_sm:run_session_cleanup_hook/1, Sessions),
+    [ets:match_delete(Tab, Pattern) || Tab <- all_frag_tables(mnesia_session)].
+
+all_frag_tables(Tab) ->
+    Props = mnesia:table_info(mnesia_session, frag_properties),
+    {n_fragments, Count} = lists:keyfind(n_fragments, 1, Props),
+    Rest = [list_to_atom(atom_to_list(Tab) ++ "frag" ++ integer_to_list(N))
+            || N <- lists:seq(2, Count)],
+    [Tab|Rest].
+
+-spec total_count() -> integer().
+total_count() ->
+    mnesia:table_info(mnesia_session, size).
+
+-spec unique_count() -> integer().
+unique_count() ->
+    compute_unique(mnesia:dirty_first(mnesia_session), 0).
+
+-spec compute_unique(term(), non_neg_integer()) -> non_neg_integer().
+compute_unique('$end_of_table', Sum) ->
+    Sum;
+compute_unique({S, U, _R, _Sid} = Key, Sum) ->
+    F = fun(_) -> mnesia:dirty_next(session, Key) end,
+    Key2 = mnesia:activity(sync_dirty, F, [frag_dist], mnesia_frag),
+    case Key2 of
+        {S, U, _, _} ->
+            compute_unique(Key2, Sum);
+        _ ->
+            compute_unique(Key2, Sum + 1)
+    end.
+
+match_sessions(Pattern) ->
+    F = fun(_) -> mnesia:match_object(Pattern) end,
+    Recs = mnesia:activity(sync_dirty, F, [frag_dist], mnesia_frag),
+    lists:map(fun to_session/1, Recs).
+
+to_session(#mnesia_session{sur_sid = {S, U, R, Sid}, priority = Priority, info = Info}) ->
+    #session{usr = {U, S, R}, us = {U, S}, priority = Priority, info = Info, sid = Sid}.
+
+from_session(#session{usr = {U, S, R}, priority = Priority, sid = Sid, info = Info}) ->
+    #mnesia_session{sur_sid = {S, U, R, Sid}, priority = Priority, info = Info}.

--- a/src/mongoose_cleaner.erl
+++ b/src/mongoose_cleaner.erl
@@ -17,7 +17,7 @@
 
 -include("mongoose.hrl").
 
--define(NODE_CLEANUP_LOCK(Node), {node_cleanup_lock, Node}).
+-define(NODE_CLEANUP_LOCK(_Node), node_cleanup_lock).
 -define(SERVER, ?MODULE).
 
 -record(state, {}).

--- a/src/mongoose_cluster.erl
+++ b/src/mongoose_cluster.erl
@@ -224,4 +224,4 @@ with_app_stopped(App, F) ->
     end.
 
 node_trans(F) ->
-    global:trans({{mongoose_cluster_op, node()}, self()}, F).
+    global:trans({mongoose_cluster_op, self()}, F).

--- a/src/mongoose_frag_hash.erl
+++ b/src/mongoose_frag_hash.erl
@@ -1,0 +1,94 @@
+%% Based on mnesia_frag_hash
+%% But allows to pass simple_hash_module option
+-module(mongoose_frag_hash).
+-behaviour(mnesia_frag_hash).
+
+-export([init_state/2,
+         add_frag/1,
+         del_frag/1,
+         key_to_frag_number/2,
+         match_spec_to_frag_numbers/2]).
+
+-record(hash_state, {n_fragments, next_n_to_split, n_doubles, simple_hash_module}).
+
+%% State is hash_state from docs
+init_state(_Tab, State) when is_list(State) ->
+    {simple_hash_module, SimpleHashModule} = lists:keyfind(simple_hash_module, 1, State),
+    #hash_state{n_fragments = 1,
+        next_n_to_split = 1,
+        n_doubles = 0,
+        simple_hash_module = SimpleHashModule}.
+
+add_frag(State = #hash_state{}) ->
+    SplitN = State#hash_state.next_n_to_split,
+    P = SplitN + 1,
+    L = State#hash_state.n_doubles,
+    NewN = State#hash_state.n_fragments + 1,
+    State2 = case trunc(math:pow(2, L)) + 1 of
+         P2 when P2 == P ->
+             State#hash_state{n_fragments = NewN,
+                      n_doubles = L + 1,
+                      next_n_to_split = 1};
+         _ ->
+             State#hash_state{n_fragments = NewN,
+                      next_n_to_split = P}
+         end,
+    {State2, [SplitN], [NewN]}.
+
+del_frag(State = #hash_state{}) ->
+    P = State#hash_state.next_n_to_split - 1,
+    L = State#hash_state.n_doubles,
+    N = State#hash_state.n_fragments,
+    if
+    P < 1 ->
+        L2 = L - 1,
+        MergeN = trunc(math:pow(2, L2)),
+        State2 = State#hash_state{n_fragments = N - 1,
+                      next_n_to_split = MergeN,
+                      n_doubles = L2},
+        {State2, [N], [MergeN]};
+    true ->
+        MergeN = P,
+        State2 = State#hash_state{n_fragments = N - 1,
+                      next_n_to_split = MergeN},
+        {State2, [N], [MergeN]}
+    end.
+
+key_to_frag_number(State = #hash_state{simple_hash_module = SimpleHashModule}, Key) ->
+    SimpleKey = SimpleHashModule:simple_key(Key),
+    L = State#hash_state.n_doubles,
+    A = erlang:phash(SimpleKey, trunc(math:pow(2, L))),
+    P = State#hash_state.next_n_to_split,
+    if
+    A < P ->
+        erlang:phash(SimpleKey, trunc(math:pow(2, L + 1)));
+    true ->
+        A
+    end.
+
+%% [{{mnesia_session,{<<"localhost">>,<<"test50">>,<<>>,'_'},'_','_'},[],['$_']}]
+match_spec_to_frag_numbers(State = #hash_state{simple_hash_module = SimpleHashModule}, MatchSpec) ->
+    case MatchSpec of
+    [{HeadPat, _, _}] when is_tuple(HeadPat), size(HeadPat) > 2 ->
+        KeyPat = element(2, HeadPat),
+        if
+            is_tuple(KeyPat) ->
+                SimpleKeyPat = SimpleHashModule:simple_key(KeyPat),
+                case has_var(SimpleKeyPat) of
+                false ->
+                    [key_to_frag_number(State, KeyPat)];
+                true ->
+                    all_segments(State)
+                end;
+            true ->
+                all_segments(State)
+        end;
+    _ ->
+        all_segments(State)
+    end.
+
+all_segments(State) ->
+    lists:seq(1, State#hash_state.n_fragments).
+
+has_var(Pat) ->
+    mnesia:has_var(Pat).

--- a/src/mongoose_progress.erl
+++ b/src/mongoose_progress.erl
@@ -1,0 +1,25 @@
+%% Reports slow tasks
+-module(mongoose_progress).
+-export([run/2]).
+
+-include("mongoose.hrl").
+
+run(F, Info) ->
+    ProgressPid = spawn_link(fun() -> report_progress(Info, 0) end),
+    try
+        F()
+    after
+        ProgressPid ! stop
+    end.
+
+report_progress(Info, Total) ->
+    receive
+        stop -> ok
+    after 5000 ->
+              Info2 = apply_info(Info),
+              ?LOG_WARNING(Info2#{what => report_progress, total_time => Total}),
+              report_progress(Info, Total + 5000)
+    end.
+
+apply_info(Info) when is_map(Info) -> Info;
+apply_info(Info) when is_function(Info) -> Info().


### PR DESCRIPTION
This PR addresses "prototype for fragmented SM table". Once upon a time fragmented MUC table was actually pretty nice behaving in one of my projects. Let's try to do something with SM table here.

Proposed changes include:
* Properly form keys for global transactions
* Report the table load progress (useful to know why the start gets stuck)
* Use fragments for the mnesia table

Something to load test, of course.