### PR TITLE
Keep ACL conditions as maps

### DIFF
--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -449,7 +449,7 @@ set_acl_for_blocking(Config, Spec) ->
     User = proplists:get_value(username, Spec),
     LUser = jid:nodeprep(User),
     mongoose_helper:backup_and_set_config_option(Config, {acl, blocked, host_type()},
-                                                 [{user, LUser}]).
+                                                 [#{user => LUser, match => current_domain}]).
 
 unset_acl_for_blocking(Config) ->
     mongoose_helper:restore_config_option(Config, {acl, blocked, host_type()}).

--- a/doc/configuration/access.md
+++ b/doc/configuration/access.md
@@ -47,7 +47,7 @@ It has the following logic:
 * if the access class is `blocked`, the returned value is `"deny"`,
 * otherwise, the returned value is `"allow"`.
 
-The `blocked` access class can be defined in the `acl` section and match blacklisted users.
+The `blocked` access class can be defined in the [`acl` section](acl.md) and match blacklisted users.
 
 For this rule to take effect, it needs to be referenced in the options of a [C2S listener](listen.md#listenc2saccess).
 

--- a/doc/configuration/acl.md
+++ b/doc/configuration/acl.md
@@ -5,29 +5,29 @@ The `acl` section is used to define **access classes** to which the connecting u
     * Key is the name of the access class,
     * Value is a TOML array of patterns - TOML tables, whose format is described below.
 * **Default:** no default - each access class needs to be specified explicitly.
-* **Example:** the `local` access class is used for the regular users connecting to the [C2S listener](listen.md#client-to-server-c2s-listenc2s).
+* **Example:** the `local` access class is used for the regular users connecting to the [C2S listener](listen.md#client-to-server-c2s-listenc2s). The pattern `{}` matches all users from the current server, because it is equivalent to `{match = "current_domain}"` (see below).
 
 ```toml
-  local = [
-    {user_regexp = ""}
-  ]
+  local = [{}]
 ```
 
 When there are multiple patterns listed, the resulting pattern will be the union of all of them.
 
 ## Patterns
 
-The options listed below are used to assign the users to the access class. There are no default values for any of them.
-
-!!! Note
-    The options can NOT be combined with each other unless the description says otherwise.
+Each pattern consists of one or more conditions, specified with the options listed below.
+All defined conditions need to be satisfied for the pattern to be matched successfully.
 
 ### `acl.*.match`
 
-* **Syntax:** string, one of: `"all"`, `"none"`
+* **Syntax:** string, one of: `"all"`, `"current_domain"`, `"none"`
+* **Default:** `"current_domain"`
 * **Example:** `match = "all"`
 
-Matches either all users or none of them. The latter is useful for disabling access to some services.
+By default only users from the *current domain* (the one of the server) are matched.
+You can set this option to `"all"`, extending the pattern to users from other domains.
+This makes a difference for some [access rules](access.md), e.g. MAM, MUC and registration ones.
+Setting the option to `"none"` makes the pattern never match.
 
 ```toml
   everyone = [
@@ -83,6 +83,13 @@ The following class includes `alice@localhost/mobile`, but not `alice@localhost/
 ```toml
   mobile_users = [
     {resource = "mobile"}
+  ]
+```
+This option can be combined with `user` and `server` - only `alice@localhost/mobile` belongs to the following class:
+
+```toml
+  admin = [
+    {user = "alice", server = "localhost", resource = "mobile"}
   ]
 ```
 

--- a/doc/migrations/5.0.0_5.1.0.md
+++ b/doc/migrations/5.0.0_5.1.0.md
@@ -2,6 +2,11 @@
 
 The configuration format has slightly changed and you might need to amend `mongooseim.toml`.
 
+### Section `acl`
+
+The implicit check for user's domain in patterns is now configurable and the default behaviour (previously undocumented) is more consistent - the check is always performed unless disabled with `match = "all"`.
+See the description of [`current_domain`](../configuration/acl.md#aclmatch) for more details.
+
 ### Section `auth`
 
 * Each authentication method needs a TOML section, e.g. if you have the `rdbms` method enabled, you need to have the `[auth.rdbms]` section in the configuration file, even if it is empty. The `methods` option is not required anymore and especially if you are using only one method, you can remove it.

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -293,9 +293,7 @@
   max_rate = 1000
 
 [acl]
-  local = [
-    {user_regexp = ""}
-  ]
+  local = [{}]
 
 [access]
   max_user_sessions = [

--- a/src/acl.erl
+++ b/src/acl.erl
@@ -26,7 +26,7 @@
 -module(acl).
 -author('alexey@process-one.net').
 
--export([match_rule/4, match_rule/5]).
+-export([match_rule/3, match_rule/4, match_rule/5]).
 
 -include("jlib.hrl").
 -include("mongoose.hrl").
@@ -41,6 +41,11 @@
                       | resource | resource_regexp | resource_glob.
 
 -type acl_result() :: allow | deny | term().
+
+%% Skips the domain check for the 'match => current_domain' condition
+-spec match_rule(mongooseim:host_type_or_global(), rule(), jid:jid()) -> acl_result().
+match_rule(HostType, Rule, JID) ->
+    match_rule(HostType, JID#jid.lserver, Rule, JID).
 
 -spec match_rule(mongooseim:host_type_or_global(), jid:lserver(), rule(), jid:jid()) ->
           acl_result().

--- a/src/acl.erl
+++ b/src/acl.erl
@@ -26,87 +26,42 @@
 -module(acl).
 -author('alexey@process-one.net').
 
--export([match_rule/3,
-         match_rule/4,
-         match_rule_for_host_type/4,
-         match_rule_for_host_type/5]).
+-export([match_rule/4, match_rule/5]).
 
--ignore_xref([add/3, delete/3, match_rule/4]).
-
+-include("jlib.hrl").
 -include("mongoose.hrl").
 
--export_type([rule/0, domain_or_global/0, host_type_or_global/0]).
+-export_type([rule/0]).
 
--type rule() :: 'all' | 'none' | atom().
--type domain_or_global() :: jid:lserver() | global.
--type host_type_or_global() :: mongooseim:host_type() | global.
--type regexp() :: iolist() | binary().
--type aclspec() :: all
-                | none
-                | {user, jid:user()}
-                | {user, jid:user(), jid:server()}
-                | {server, jid:server()}
-                | {resource, jid:resource()}
-                | {user_regexp, regexp()}
-                | {user_regexp, regexp(), jid:server()}
-                | {server_regexp, regexp()}
-                | {resource_regexp, regexp()}
-                | {node_regexp, regexp(), regexp()}
-                | {user_glob, regexp()}
-                | {user_glob, regexp(), jid:server()}
-                | {server_glob, regexp()}
-                | {resource_glob, regexp()}
-                | {node_glob, regexp(), regexp()}.
+-type rule() :: atom().
+-type acl_spec() :: #{match := all | none | current_domain,
+                      acl_spec_key() => binary()}.
+-type acl_spec_key() :: user | user_regexp | user_glob
+                      | server | server_regexp | server_glob
+                      | resource | resource_regexp | resource_glob.
 
 -type acl_result() :: allow | deny | term().
 
-%% legacy API, use match_rule_for_host_type instead
--spec match_rule(Domain :: domain_or_global(),
-                 Rule :: rule(),
-                 JID :: jid:jid()) -> acl_result().
-match_rule(Domain, Rule, JID) ->
-    match_rule(Domain, Rule, JID, deny).
-
--spec match_rule_for_host_type(HostType :: host_type_or_global(),
-                               Domain :: domain_or_global(),
-                               Rule :: rule(),
-                               JID :: jid:jid()) -> acl_result().
-match_rule_for_host_type(HostType, Domain, Rule, JID) ->
-    match_rule_for_host_type(HostType, Domain, Rule, JID, deny).
-
-%% legacy API, use match_rule_for_host_type instead
--spec match_rule(Domain :: domain_or_global(),
-                 Rule :: rule(),
-                 JID :: jid:jid(),
-                 Default :: acl_result()) -> acl_result().
-match_rule(Domain, Rule, JID, Default) ->
-    %% We don't want to cast Domain to HostType here.
-    %% Developers should start using match_rule_for_host_type explicitly.
-    match_rule_for_host_type(Domain, Domain, Rule, JID, Default).
-
-%% HostType determines which rules and ACLs are checked:
-%%   - 'global' - only global ones
-%%   - a specific host type - both global and per-host-type ones
-%% Domain is only used for validating the user's domain name in the {user, U} pattern:
-%%   - 'global' - any domain is accepted
-%%   - a specific domain name - only the provided name is accepted
--spec match_rule_for_host_type(HostType :: host_type_or_global(),
-                               Domain :: domain_or_global(),
-                               Rule :: rule(),
-                               JID :: jid:jid(),
-                               Default :: acl_result()) -> acl_result().
-match_rule_for_host_type(_HostType, _, all, _, _Default) ->
+-spec match_rule(mongooseim:host_type_or_global(), jid:lserver(), rule(), jid:jid()) ->
+          acl_result().
+match_rule(_HostType, _Domain, all, _JID) ->
     allow;
-match_rule_for_host_type(_HostType, _, none, _, _Default) ->
+match_rule(_HostType, _Domain, none, _JID) ->
     deny;
-match_rule_for_host_type(global, Domain, Rule, JID, Default) ->
+match_rule(HostType, Domain, Rule, JID) ->
+    match_rule(HostType, Domain, Rule, JID, deny).
+
+-spec match_rule(mongooseim:host_type_or_global(), jid:lserver(), rule(), jid:jid(),
+                 Default :: acl_result()) ->
+          acl_result().
+match_rule(global, Domain, Rule, JID, Default) ->
     case mongoose_config:lookup_opt({access, Rule, global}) of
         {error, not_found} ->
             Default;
-        {ok, GACLs} ->
-            match_acls(GACLs, JID, global, Domain)
+        {ok, ACLs} ->
+            match_acls(ACLs, JID, global, Domain)
     end;
-match_rule_for_host_type(HostType, Domain, Rule, JID, Default) ->
+match_rule(HostType, Domain, Rule, JID, Default) ->
     case {mongoose_config:lookup_opt({access, Rule, global}),
           mongoose_config:lookup_opt({access, Rule, HostType})} of
         {{error, not_found}, {error, not_found}} ->
@@ -128,10 +83,9 @@ merge_acls(Global, HostLocal) ->
             Global ++ HostLocal
     end.
 
--spec match_acls(ACLs :: [{any(), rule()}],
-                 JID :: jid:jid(),
-                 HostType :: host_type_or_global(),
-                 Domain :: domain_or_global()) -> deny | term().
+-spec match_acls(ACLs :: [{any(), rule()}], jid:jid(), mongooseim:host_type_or_global(),
+                 jid:lserver()) ->
+          acl_result().
 match_acls([], _, _HostType, _Domain) ->
     deny;
 match_acls([{Value, Rule} | ACLs], JID, HostType, Domain) ->
@@ -142,79 +96,48 @@ match_acls([{Value, Rule} | ACLs], JID, HostType, Domain) ->
             match_acls(ACLs, JID, HostType, Domain)
     end.
 
--spec match_acl(Rule :: rule(),
-                JID :: jid:jid(),
-                HostType :: host_type_or_global(),
-                Domain :: domain_or_global()) -> boolean().
+-spec match_acl(rule(), jid:jid(), mongooseim:host_type_or_global(), jid:lserver()) -> boolean().
 match_acl(all, _JID, _HostType, _Domain) ->
     true;
 match_acl(none, _JID, _HostType, _Domain) ->
     false;
 match_acl(Rule, JID, HostType, Domain) ->
-    LJID = jid:to_lower(JID),
     AllSpecs = case HostType of
                    global -> get_acl_specs(Rule, global);
                    _ -> get_acl_specs(Rule, HostType) ++ get_acl_specs(Rule, global)
                end,
-    Pred = fun(ACLSpec) -> match(ACLSpec, LJID, Domain) end,
+    Pred = fun(ACLSpec) -> match(ACLSpec, Domain, JID) end,
     lists:any(Pred, AllSpecs).
 
--spec get_acl_specs(rule(), host_type_or_global()) -> [aclspec()].
+-spec get_acl_specs(rule(), mongooseim:host_type_or_global()) -> [acl_spec()].
 get_acl_specs(Rule, HostType) ->
     mongoose_config:get_opt({acl, Rule, HostType}, []).
 
--spec is_server_valid(domain_or_global(), jid:lserver()) -> boolean().
-is_server_valid(Domain, Domain) ->
-    true;
-is_server_valid(global, JIDServer) ->
-    case mongoose_domain_api:get_domain_host_type(JIDServer) of
-        {ok, _HostType} ->
-            true;
-        _ ->
-            false
-    end;
-is_server_valid(_Domain, _JIDServer) ->
-    false.
+%% @doc Check if all conditions from ACLSpec are satisfied by JID
+-spec match(acl_spec(), jid:lserver(), jid:jid()) -> boolean().
+match(ACLSpec, Domain, JID) ->
+    match_step(maps:next(maps:iterator(ACLSpec)), Domain, JID).
 
--spec match(aclspec(), jid:simple_jid(), domain_or_global()) -> boolean().
-match(all, _LJID, _Domain) ->
-    true;
-match({user, U}, {User, Server, _Resource}, Domain) ->
-    U == User andalso is_server_valid(Domain, Server);
-match({user, U, S}, {User, Server, _Resource}, _Domain) ->
-    U == User andalso S == Server;
-match({server, S}, {_User, Server, _Resource}, _Domain) ->
-    S == Server;
-match({resource, Res}, {_User, _Server, Resource}, _Domain) ->
-    Resource == Res;
-match({user_regexp, UserReg}, {User, Server, _Resource}, Domain) ->
-    is_server_valid(Domain, Server) andalso is_regexp_match(User, UserReg);
-match({user_regexp, UserReg, MServer}, {User, Server, _Resource}, _Domain) ->
-    MServer == Server andalso is_regexp_match(User, UserReg);
-match({server_regexp, ServerReg}, {_User, Server, _Resource}, _Domain) ->
-    is_regexp_match(Server, ServerReg);
-match({resource_regexp, ResourceReg}, {_User, _Server, Resource}, _Domain) ->
-    is_regexp_match(Resource, ResourceReg);
-match({node_regexp, UserReg, ServerReg}, {User, Server, _Resource}, _Domain) ->
-    is_regexp_match(Server, ServerReg) andalso
-    is_regexp_match(User, UserReg);
-match({user_glob, UserGlob}, {User, Server, _Resource}, Domain) ->
-    is_server_valid(Domain, Server) andalso is_glob_match(User, UserGlob);
-match({user_glob, UserGlob, MServer}, {User, Server, _Resource}, _Domain) ->
-    MServer == Server andalso is_glob_match(User, UserGlob);
-match({server_glob, ServerGlob}, {_User, Server, _Resource}, _Domain) ->
-    is_glob_match(Server, ServerGlob);
-match({resource_glob, ResourceGlob}, {_User, _Server, Resource}, _Domain) ->
-    is_glob_match(Resource, ResourceGlob);
-match({node_glob, UserGlob, ServerGlob}, {User, Server, _Resource}, _Domain) ->
-    is_glob_match(Server, ServerGlob) andalso is_glob_match(User, UserGlob);
-match(WrongSpec, _LJID, _Domain) ->
-    ?LOG_ERROR(#{what => wrong_acl_expression,
-                 text => <<"Wrong ACL expression in the configuration file">>,
-                 wrong_spec => WrongSpec}),
-    false.
+match_step({K, V, I}, Domain, JID) ->
+    check(K, V, Domain, JID) andalso match_step(maps:next(I), Domain, JID);
+match_step(none, _Domain, _JID) ->
+    true.
 
--spec is_regexp_match(binary(), Regex :: regexp()) -> boolean().
+-spec check(acl_spec_key(), binary(), jid:lserver(), jid:jid()) -> boolean().
+check(match, all, _, _) -> true;
+check(match, none, _, _) -> false;
+check(match, current_domain, Domain, JID) -> JID#jid.lserver =:= Domain;
+check(user, User, _, JID) -> JID#jid.luser =:= User;
+check(user_regexp, Regexp, _, JID) -> is_regexp_match(JID#jid.luser, Regexp);
+check(user_glob, Glob, _, JID) -> is_glob_match(JID#jid.luser, Glob);
+check(server, Server, _, JID) -> JID#jid.lserver =:= Server;
+check(server_regexp, Regexp, _, JID) -> is_regexp_match(JID#jid.lserver, Regexp);
+check(server_glob, Glob, _, JID) -> is_glob_match(JID#jid.lserver, Glob);
+check(resource, Resource, _, JID) -> JID#jid.lresource =:= Resource;
+check(resource_regexp, Regexp, _, JID) -> is_regexp_match(JID#jid.lresource, Regexp);
+check(resource_glob, Glob, _, JID) -> is_glob_match(JID#jid.lresource, Glob).
+
+-spec is_regexp_match(binary(), RegExp :: iodata()) -> boolean().
 is_regexp_match(String, RegExp) ->
     try re:run(String, RegExp, [{capture, none}]) of
         nomatch ->
@@ -227,6 +150,6 @@ is_regexp_match(String, RegExp) ->
             false
     end.
 
--spec is_glob_match(binary(), Glob :: regexp()) -> boolean().
+-spec is_glob_match(binary(), Glob :: binary()) -> boolean().
 is_glob_match(String, Glob) ->
     is_regexp_match(String, xmerl_regexp:sh_to_awk(binary_to_list(Glob))).

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1612,11 +1612,10 @@ generate_random_resource() ->
     <<(mongoose_bin:gen_from_crypto())/binary, (mongoose_bin:gen_from_timestamp())/binary>>.
 
 -spec change_shaper(state(), jid:jid()) -> any().
-change_shaper(StateData, JID) ->
-    Shaper = acl:match_rule(StateData#state.server,
-                            StateData#state.shaper, JID),
-    (StateData#state.sockmod):change_shaper(StateData#state.socket, Shaper).
-
+change_shaper(#state{host_type = HostType, server = Server, shaper = ShaperRule,
+                     socket = Socket, sockmod = SockMod}, JID) ->
+    Shaper = acl:match_rule(HostType, Server, ShaperRule, JID),
+    SockMod:change_shaper(Socket, Shaper).
 
 -spec send_text(state(), Text :: binary()) -> any().
 send_text(StateData, Text) ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3316,7 +3316,7 @@ handle_sasl_step(#state{host_type = HostType, server = Server, socket = Sock} = 
     end.
 
 user_allowed(JID, #state{host_type = HostType, server = Server, access = Access}) ->
-    case acl:match_rule_for_host_type(HostType, Server, Access, JID)  of
+    case acl:match_rule(HostType, Server, Access, JID)  of
         allow ->
             open_session_allowed_hook(HostType, JID);
         deny ->

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -447,7 +447,8 @@ check_access(Access, Auth) ->
     {ok, JID} = check_auth(Auth),
     %% Check this user has access permission
     {_, LServer} = jid:to_lus(JID),
-    case acl:match_rule(LServer, Access, JID) of
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(LServer),
+    case acl:match_rule(HostType, LServer, Access, JID) of
         allow -> true;
         deny -> false
     end.

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -434,19 +434,18 @@ new_connection(MyServer, Server, From, FromTo = {FromServer, ToServer},
     end,
     TRes.
 
-
 -spec max_s2s_connections_number(fromto()) -> pos_integer().
 max_s2s_connections_number({From, To}) ->
-    case acl:match_rule(
-           From, max_s2s_connections, jid:make(<<"">>, To, <<"">>)) of
+    {ok, HostType} = mongoose_domain_api:get_host_type(From),
+    case acl:match_rule(HostType, max_s2s_connections, jid:make(<<"">>, To, <<"">>)) of
         Max when is_integer(Max) -> Max;
         _ -> ?DEFAULT_MAX_S2S_CONNECTIONS_NUMBER
     end.
 
 -spec max_s2s_connections_number_per_node(fromto()) -> pos_integer().
 max_s2s_connections_number_per_node({From, To}) ->
-    case acl:match_rule(
-           From, max_s2s_connections_per_node, jid:make(<<"">>, To, <<"">>)) of
+    {ok, HostType} = mongoose_domain_api:get_host_type(From),
+    case acl:match_rule(HostType, max_s2s_connections_per_node, jid:make(<<"">>, To, <<"">>)) of
         Max when is_integer(Max) -> Max;
         _ -> ?DEFAULT_MAX_S2S_CONNECTIONS_NUMBER_PER_NODE
     end.

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -586,9 +586,10 @@ stream_features(Domain) ->
         {error, not_found} -> []
     end.
 
--spec change_shaper(state(), Host :: 'global' | binary(), jid:jid()) -> any().
+-spec change_shaper(state(), jid:lserver(), jid:jid()) -> any().
 change_shaper(StateData, Host, JID) ->
-    Shaper = acl:match_rule(Host, StateData#state.shaper, JID),
+    {ok, HostType} = mongoose_domain_api:get_host_type(Host),
+    Shaper = acl:match_rule(HostType, StateData#state.shaper, JID),
     (StateData#state.sockmod):change_shaper(StateData#state.socket, Shaper).
 
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -971,7 +971,7 @@ check_max_sessions(HostType, LUser, LServer, ReplacedPIDs) ->
       Result :: infinity | pos_integer().
 get_max_user_sessions(HostType, LUser, LServer) ->
     JID = jid:make_noprep(LUser, LServer, <<>>),
-    case acl:match_rule_for_host_type(HostType, LServer, max_user_sessions, JID) of
+    case acl:match_rule(HostType, LServer, max_user_sessions, JID) of
         Max when is_integer(Max) -> Max;
         infinity -> infinity;
         _ -> ?MAX_USER_SESSIONS

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -362,7 +362,7 @@ acc_to_host_type(Acc) ->
                         Action :: mam_iq:action(), From :: jid:jid(),
                         To :: jid:jid()) -> boolean().
 is_action_allowed(HostType, Action, From, To) ->
-    case acl:match_rule_for_host_type(HostType, To#jid.lserver, Action, From, default) of
+    case acl:match_rule(HostType, To#jid.lserver, Action, From, default) of
         allow   -> true;
         deny    -> false;
         default -> is_action_allowed_by_default(Action, From, To)

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -277,7 +277,7 @@ forget_room(Acc, _HostType, MucServer, RoomName) ->
 -spec check_action_allowed(host_type(), mongoose_acc:t(), jid:lserver(), mam_iq:action(), muc_action(),
                         jid:jid(), jid:jid()) -> ok | {error, binary()}.
 check_action_allowed(HostType, Acc, Domain, Action, MucAction, From, To) ->
-    case acl:match_rule_for_host_type(HostType, Domain, MucAction, From, default) of
+    case acl:match_rule(HostType, Domain, MucAction, From, default) of
         allow -> ok;
         deny -> {false, <<"Blocked by service policy.">>};
         default -> check_room_action_allowed_by_default(HostType, Acc, Action, From, To)

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -582,7 +582,7 @@ process_packet(Acc, From, To, El, #{state := State}) ->
     {AccessRoute, _, _, _} = State#state.access,
     ServerHost = make_server_host(To, State),
     HostType = State#state.host_type,
-    case acl:match_rule_for_host_type(HostType, ServerHost, AccessRoute, From) of
+    case acl:match_rule(HostType, ServerHost, AccessRoute, From) of
         allow ->
             {Room, MucHost, _} = jid:to_lower(To),
             route_to_room(MucHost, Room, {From, To, Acc, El}, State),
@@ -797,7 +797,7 @@ route_by_type(<<"message">>, {From, To, Acc, Packet},
         <<"error">> ->
             ok;
         _ ->
-            case acl:match_rule_for_host_type(HostType, ServerHost, AccessAdmin, From) of
+            case acl:match_rule(HostType, ServerHost, AccessAdmin, From) of
                 allow ->
                     Msg = xml:get_path_s(Packet, [{elem, <<"body">>}, cdata]),
                     broadcast_service_message(MucHost, Msg);
@@ -815,7 +815,7 @@ route_by_type(<<"presence">>, _Routed, _State) ->
 -spec check_user_can_create_room(host_type(), jid:lserver(),
         allow | atom(), jid:jid(), room()) -> ok | {error, term()}.
 check_user_can_create_room(HostType, ServerHost, AccessCreate, From, RoomID) ->
-    case acl:match_rule_for_host_type(HostType, ServerHost, AccessCreate, From) of
+    case acl:match_rule(HostType, ServerHost, AccessCreate, From) of
         allow ->
             MaxLen = gen_mod:get_module_opt(HostType, mod_muc,
                                             max_room_id, infinity),

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -234,8 +234,7 @@ init([Host, Opts]) ->
         From :: any(), logstate()) -> {'reply', 'allow' | 'deny', logstate()}
                                     | {'stop', 'normal', 'ok', _}.
 handle_call({check_access_log, HostType, ServerHost, FromJID}, _From, State) ->
-    Reply = acl:match_rule_for_host_type(HostType, ServerHost,
-                                         State#logstate.access, FromJID),
+    Reply = acl:match_rule(HostType, ServerHost, State#logstate.access, FromJID),
     {reply, Reply, State};
 handle_call(stop, _From, State) ->
     {stop, normal, ok, State}.

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1397,8 +1397,7 @@ set_affiliation_and_reason(JID, Affiliation, Reason, StateData)
 -spec get_affiliation(jid:jid(), state()) -> mod_muc:affiliation().
 get_affiliation(JID, StateData) ->
     AccessAdmin = access_admin(StateData),
-    case acl:match_rule_for_host_type(StateData#state.host_type,
-                                      StateData#state.server_host, AccessAdmin, JID) of
+    case acl:match_rule(StateData#state.host_type, StateData#state.server_host, AccessAdmin, JID) of
         allow ->
             owner;
         _ ->
@@ -1424,8 +1423,7 @@ lookup_affiliation([], _Affiliations) ->
 -spec get_service_affiliation(jid:jid(), state()) -> mod_muc:affiliation().
 get_service_affiliation(JID, StateData) ->
     AccessAdmin = access_admin(StateData),
-    case acl:match_rule_for_host_type(StateData#state.host_type,
-                                      StateData#state.server_host, AccessAdmin, JID) of
+    case acl:match_rule(StateData#state.host_type, StateData#state.server_host, AccessAdmin, JID) of
     allow ->
         owner;
     _ ->
@@ -3321,9 +3319,8 @@ is_allowed_persistent_change(XEl, StateData, From) ->
         true;
     true ->
         AccessPersistent = access_persistent(StateData),
-        (allow == acl:match_rule_for_host_type(StateData#state.host_type,
-                                               StateData#state.server_host,
-                                               AccessPersistent, From))
+        (allow == acl:match_rule(StateData#state.host_type, StateData#state.server_host,
+                                 AccessPersistent, From))
     end.
 
 
@@ -3418,9 +3415,8 @@ get_config(Lang, StateData, From) ->
                <<"muc#roomconfig_roomdesc">>,
                 Config#config.description, Lang)
     ] ++
-     case acl:match_rule_for_host_type(StateData#state.host_type,
-                                       StateData#state.server_host,
-                                       AccessPersistent, From) of
+     case acl:match_rule(StateData#state.host_type, StateData#state.server_host,
+                         AccessPersistent, From) of
         allow ->
             [boolxfield(<<"Make room persistent">>,
              <<"muc#roomconfig_persistentroom">>,

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -260,7 +260,7 @@ inband_registration_and_cancelation_allowed(_HostType, _ServerDomain, no_JID) ->
     true;
 inband_registration_and_cancelation_allowed(HostType, ServerDomain, JID) ->
     Rule = gen_mod:get_module_opt(HostType, ?MODULE, access, none),
-    allow =:= acl:match_rule_for_host_type(HostType, ServerDomain,  Rule, JID).
+    allow =:= acl:match_rule(HostType, ServerDomain,  Rule, JID).
 
 process_iq_get(_HostType, From, _To, #iq{lang = Lang, sub_el = Child} = IQ, _Source) ->
     true = is_query_element(Child),
@@ -333,7 +333,7 @@ try_register(HostType, User, Server, Password, SourceRaw, Lang) ->
             JID = jid:make(User, Server, <<>>),
             Access = gen_mod:get_module_opt(HostType, ?MODULE, access, all),
             IPAccess = get_ip_access(HostType),
-            case {acl:match_rule_for_host_type(HostType, Server, Access, JID),
+            case {acl:match_rule(HostType, Server, Access, JID),
                   check_ip_access(SourceRaw, IPAccess)} of
                 {deny, _} ->
                     {error, mongoose_xmpp_errors:forbidden()};

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -209,7 +209,7 @@ is_message_count_threshold_reached(HostType, MaxOfflineMsgs, LUser, LServer, Len
 
 
 get_max_user_messages(HostType, AccessRule, LUser, LServer) ->
-    case acl:match_rule(HostType, AccessRule, jid:make_noprep(LUser, LServer, <<>>)) of
+    case acl:match_rule(HostType, LServer, AccessRule, jid:make_noprep(LUser, LServer, <<>>)) of
         Max when is_integer(Max) -> Max;
         infinity -> infinity;
         _ -> ?MAX_USER_MESSAGES

--- a/src/pubsub/node_flat.erl
+++ b/src/pubsub/node_flat.erl
@@ -146,7 +146,8 @@ create_node_permission(Host, ServerHost, _Node, _ParentNode, Owner, Access) ->
         {<<"">>, Host, <<"">>} ->
             true; % pubsub service always allowed
         _ ->
-            acl:match_rule(ServerHost, Access, Owner) =:= allow
+            {ok, HostType} = mongoose_domain_api:get_domain_host_type(ServerHost),
+            acl:match_rule(HostType, ServerHost, Access, Owner) =:= allow
     end,
     {result, Allowed}.
 

--- a/src/pubsub/node_hometree.erl
+++ b/src/pubsub/node_hometree.erl
@@ -66,7 +66,8 @@ create_node_permission(Host, _ServerHost, _Node, _ParentNode,
     {result, true}; % pubsub service always allowed
 create_node_permission(_Host, ServerHost, Node, _ParentNode,
                        #jid{ luser = LUser, lserver = LServer } = Owner, Access) ->
-    case acl:match_rule(ServerHost, Access, Owner) of
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(ServerHost),
+    case acl:match_rule(HostType, ServerHost, Access, Owner) of
         allow ->
             case node_to_path(Node) of
                 [<<"home">>, LServer, LUser | _] -> {result, true};

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -97,7 +97,8 @@ create_node_permission(Host, _ServerHost, _Node, _ParentNode,
     {result, true}; % pubsub service always allowed
 create_node_permission(Host, ServerHost, _Node, _ParentNode,
                        #jid{ luser = User, lserver = Server } = Owner, Access) ->
-    case acl:match_rule(ServerHost, Access, Owner) of
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(ServerHost),
+    case acl:match_rule(HostType, ServerHost, Access, Owner) of
         allow ->
             case Host of
                 {User, Server, _} -> {result, true};

--- a/src/shaper_srv.erl
+++ b/src/shaper_srv.erl
@@ -204,7 +204,7 @@ default_shaper() ->
                       Action :: atom(), jid:jid(),
                       Default :: 'none') -> 'allow' | 'none'.
 get_shaper_name(HostType, Domain, Action, FromJID, Default) ->
-    case acl:match_rule_for_host_type(HostType, Domain, Action, FromJID) of
+    case acl:match_rule(HostType, Domain, Action, FromJID) of
         deny -> Default;
         Value -> Value
     end.

--- a/test/commands_SUITE.erl
+++ b/test/commands_SUITE.erl
@@ -85,7 +85,7 @@ end_per_testcase(_, _C) ->
 opts() ->
     [{{auth, <<"localhost">>}, #{methods => [dummy]}},
      {{access, experts_only, <<"localhost">>}, [{allow, coder}, {allow, manager}, {deny, all}]},
-     {{acl, coder, <<"localhost">>}, [{user, <<"zenek">>}]}].
+     {{acl, coder, <<"localhost">>}, [#{user => <<"zenek">>, match => current_domain}]}].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% test methods

--- a/test/config_parser_helper.erl
+++ b/test/config_parser_helper.erl
@@ -290,7 +290,7 @@ options("mongooseim-pgsql") ->
      {{access, muc_create, global}, [{allow, local}]},
      {{access, register, global}, [{allow, all}]},
      {{access, s2s_shaper, global}, [{fast, all}]},
-     {{acl, local, global}, [{user_regexp, <<>>}]},
+     {{acl, local, global}, [#{user_regexp => <<>>, match => current_domain}]},
      {{shaper, fast, global}, {maxrate, 50000}},
      {{shaper, mam_global_shaper, global}, {maxrate, 1000}},
      {{shaper, mam_shaper, global}, {maxrate, 1}},

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -40,7 +40,7 @@ setup() ->
 
     [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
 
-    meck:expect(acl, match_rule_for_host_type, fun(_, _, _, _) -> allow end),
+    meck:expect(acl, match_rule, fun(_, _, _, _) -> allow end),
 
     meck:new(mongoose_bin, [passthrough]),
     meck:expect(mongoose_bin, gen_from_crypto, fun() -> <<"57">> end),

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -372,7 +372,7 @@ unload_meck() ->
 
 set_test_case_meck(MaxUserSessions) ->
     meck:new(acl, []),
-    meck:expect(acl, match_rule_for_host_type, fun(_, _, _, _) -> MaxUserSessions end),
+    meck:expect(acl, match_rule, fun(_, _, _, _) -> MaxUserSessions end),
     meck:new(gen_hook, []),
     meck:expect(gen_hook, run_fold, fun(_, _, Acc, _) -> {ok, Acc} end),
     meck:new(mongoose_domain_api, []),

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -38,27 +38,27 @@ init_per_suite(Config) ->
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
     [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_domain_api:init(),
     Config.
 
 end_per_suite(Config) ->
+    mongoose_domain_api:stop(),
     [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     Config.
 
 opts() ->
-    [{hosts, []},
+    [{hosts, [?HOST]},
      {host_types, []},
      {all_metrics_are_global, false}].
 
 init_per_testcase(T, Config) ->
     {ok, _HooksServer} = gen_hook:start_link(),
-    ok = mongoose_lazy_routing:start(),
     setup_meck(meck_mods(T)),
     Config.
 
 end_per_testcase(T, Config) ->
-    mongoose_lazy_routing:stop(),
     unload_meck(meck_mods(T)),
     Config.
 


### PR DESCRIPTION
The goal is to simplify and unify the internal ACL format and the ACL matching logic.

Main changes:
- Patterns are not converted from maps to tuples. By avoiding enumerating all allowed combinations, there are new possibilities, in particular `{user = "alice", server = "localhost", resource = "res"}`, which was unsupported before.
- There was an implicit check for the domain performed only for arbitrarily chosen patterns, e.g. for `{user = "alice"}` but not for `{resource = "res"}`, which was counter-intuitive and undocumented. Now the check is called `match = "current_domain"` and it is enabled by default unless the user disables it with `match = "all"`.
- The API is now unified and simplified. The host type (which can be global) is mandatory and the domain is optional. The domain-less version is used only for corner cases: s2s and components. In these cases the check for "current_domain" is omitted because it would always fail.
  - In the previous code that check would be replaced with a check if the user's domain matches any locally hosted domain, but this one was also implicit. It's not supported in the new code atm. The ponly place where it could be useful would be to decide what users can connect to a component - either all of them or the ones from any local domain. I could add this in a new PR.

Not changed:
- Condition values (including regular expressions) are still converted with `nodeprep`. It is sketchy, but it passes the tests, so I left it unchanged for the sake of brevity.