### PR TITLE
Performance and metrics touches on async workers

### DIFF
--- a/src/mongoose_async_pools.erl
+++ b/src/mongoose_async_pools.erl
@@ -14,6 +14,11 @@
 -type pool_id() :: atom().
 -type pool_name() :: atom().
 -type pool_opts() :: gen_mod:module_opts().
+-type pool_extra() :: #{host_type := mongooseim:host_type(),
+                        queue_length := non_neg_integer(),
+                        _ => _}.
+
+-export_type([pool_id/0, pool_extra/0]).
 
 %%% API functions
 -spec start_pool(mongooseim:host_type(), pool_id(), pool_opts()) ->
@@ -120,12 +125,13 @@ make_wpool_opts(HostType, PoolId, Opts) ->
      {worker_opt, ProcessOpts},
      {worker_shutdown, 10000}].
 
--spec make_extra(mongooseim:host_type(), pool_id(), pool_opts()) -> any().
+-spec make_extra(mongooseim:host_type(), pool_id(), pool_opts()) -> pool_extra().
 make_extra(HostType, PoolId, Opts) ->
+    DefExtra = #{host_type => HostType, queue_length => 0},
     case {gen_mod:get_opt(init_callback, Opts, undefined),
           gen_mod:get_opt(flush_extra, Opts,
-                          fun(Val) -> Val#{host_type => HostType} end,
-                          #{host_type => HostType})} of
+                          fun(Val) -> maps:merge(Val, DefExtra) end,
+                          DefExtra)} of
         {undefined, Extra} ->
             Extra;
         {InitFun, Extra} when is_function(InitFun, 3) ->

--- a/src/mongoose_batch_worker.erl
+++ b/src/mongoose_batch_worker.erl
@@ -21,20 +21,21 @@
           flush_interval_tref :: undefined | reference(),
           flush_callback = fun(_, _) -> ok end :: flush_callback(),
           flush_queue = [] :: list() | censored, % see format_status/2 for censored
+          flush_queue_length = 0 :: non_neg_integer(),
           flush_extra = #{} :: map()
          }).
 -type state() :: #state{}.
--type flush_callback() :: fun((list(), map()) -> ok | {error, term()}).
+-type flush_callback() :: fun((list(), mongoose_async_pools:pool_extra()) -> ok | {error, term()}).
 
 -export_type([flush_callback/0]).
 
 %% gen_server callbacks
 -spec init({mongooseim:host_type(),
-            atom(),
+            mongoose_async_pools:pool_id(),
             pos_integer(),
             pos_integer(),
             flush_callback(),
-            map()}) -> {ok, state()}.
+            mongoose_async_pools:pool_extra()}) -> {ok, state()}.
 init({HostType, PoolId, Interval, MaxSize, FlushCallback, FlushExtra}) ->
     ?LOG_DEBUG(#{what => batch_worker_start, host_type => HostType, pool_id => PoolId}),
     {ok, #state{host_type = HostType,
@@ -90,8 +91,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 % Don't leak the tasks to logs, can contain private information
 format_status(_Opt, [_PDict, State | _]) ->
-    [{data, [{"State", State#state{flush_queue = censored}},
-             {"Task Queue Length", length(State#state.flush_queue)}]}].
+    [{data, [{"State", State#state{flush_queue = censored}}]}].
 
 %% Batched tasks callbacks
 handle_task(Task, State = #state{host_type = HostType,
@@ -99,11 +99,13 @@ handle_task(Task, State = #state{host_type = HostType,
                                  batch_size = MaxSize,
                                  flush_interval = Interval,
                                  flush_interval_tref = TRef0,
-                                 flush_queue = Acc0}) ->
-    Length = length(Acc0),
+                                 flush_queue = Acc0,
+                                 flush_queue_length = Length}) ->
     TRef1 = maybe_schedule_flush(TRef0, Length, Interval),
     State1 = State#state{flush_interval_tref = TRef1,
-                         flush_queue = [Task | Acc0]},
+                         flush_queue = [Task | Acc0],
+                         flush_queue_length = Length + 1
+                        },
     case Length + 1 >= MaxSize of
         false -> State1;
         true ->
@@ -129,19 +131,19 @@ cancel_and_flush_timer(TRef) ->
     catch erlang:cancel_timer(TRef, [{async, true}]).
 
 do_run_flush(State = #state{flush_callback = FlushCallback,
+                            flush_queue_length = Length,
                             flush_queue = Queue,
                             flush_extra = Extra}) ->
-    case FlushCallback(lists:reverse(Queue), Extra) of
-        ok -> ok;
+    case FlushCallback(lists:reverse(Queue), Extra#{queue_length := Length}) of
+        ok ->
+            State#state{flush_queue = [], flush_queue_length = 0};
         {error, Reason} ->
             ?LOG_ERROR(log_fields(State,
                        #{what => batch_worker_flush_queue_failed, reason => Reason,
                          text => <<"flush_callback failed">>})),
-            ok
-    end,
-    State#state{flush_queue = []}.
+            State#state{flush_queue = [], flush_queue_length = 0}
+    end.
 
 log_fields(State, LogMessage) ->
-    LogMessage#{host_type => State#state.host_type,
-                flush_queue_len => length(State#state.flush_queue),
-                flush_callback => State#state.flush_callback}.
+    LogMessage#{host_type => State#state.host_type, pool_id => State#state.pool_id,
+                flush_queue_length => State#state.flush_queue_length}.


### PR DESCRIPTION
Right now, when using send_after, we're sending a single atom to the
process, which means, that we then don't know how to match the flush
request when it arrives, and therefore we need to act on all of them, or
explore the entire message queue to drop them when we do the selective
receive in `cancel_and_flush_timer`.

But that selective receive can potentially be expensive, when the batch
worker is really loaded and its queues are growing faster than it can
process, the code becomes really critical. Even more so when these
workers are enabled with message_queue_data=off_heap, which means that a
selective receive will go out of its heap, screwing cache locality, and
take all those heap fragments into its heap, which is all more
expensive.

To solve this, we can use start_timer instead of send_after, which will
then send a message that contains the TimerRef we get, so we know then
exactly which timeout is the active one, where we to receive any. This
way, cancel_timer doesn't need to worry about whether the timer actually
arrived or not: if it didn't, it's canceled, if it did, we won't attend
to it next time, it is simply ignored when the mailbox view arrives to
it.

One more tiny optimisation: we run cancel_timer asynchronously:
https://www.erlang.org/doc/man/erlang.html#cancel_timer-2

> The timer service that manages the timer can be co-located with
another scheduler than the scheduler that the calling process is
executing on. If so, communication with the timer service takes much
longer time than if it is located locally. If the calling process is in
critical path, and can do other things while waiting for the result of
this operation, or is not interested in the result of the operation, you
want to use option {async, true}. If using option {async, false}, the
calling process blocks until the operation has been performed.

There's other code, see commits for details.