### PR TITLE
Extend ACL conditions with match = "any_hosted_domain"

### DIFF
--- a/doc/configuration/acl.md
+++ b/doc/configuration/acl.md
@@ -20,13 +20,14 @@ All defined conditions need to be satisfied for the pattern to be matched succes
 
 ### `acl.*.match`
 
-* **Syntax:** string, one of: `"all"`, `"current_domain"`, `"none"`
+* **Syntax:** string, one of: `"all"`, `"current_domain"`, `"any_hosted_domain"`, `"none"`
 * **Default:** `"current_domain"`
 * **Example:** `match = "all"`
 
 By default only users from the *current domain* (the one of the server) are matched.
-You can set this option to `"all"`, extending the pattern to users from other domains.
-This makes a difference for some [access rules](access.md), e.g. MAM, MUC and registration ones.
+Setting it to `"any_hosted_domain"` results in matching users from all domains hosted by this server.
+You can also set this option to `"all"`, extending the pattern to users from external domains.
+This option makes a difference for some [access rules](access.md), e.g. MAM, MUC and registration ones.
 Setting the option to `"none"` makes the pattern never match.
 
 ```toml

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -314,7 +314,7 @@ The `s2s_shaper` access rule is used, which requires a definition in the `access
 Interface for external services acting as XMPP components ([XEP-0114: Jabber Component Protocol](http://xmpp.org/extensions/xep-0114.html)), enabling communication between MongooseIM and external services over the XMPP network. The recommended port number for a component listener is 8888.
 
 According to [XEP-0114: Jabber Component Protocol](http://xmpp.org/extensions/xep-0114.html) the component's hostname should be given in the <stream:stream> element.
-    
+
 !!! warning
     This interface does not support [dynamic domains](../configuration/general.md#generalhost_types).
     Do not use them both at the same time.
@@ -324,7 +324,7 @@ According to [XEP-0114: Jabber Component Protocol](http://xmpp.org/extensions/xe
 * **Default:** `"all"`
 * **Example:** `access = "component"`
 
-Determines who is allowed to connect to the listener. By default the rule is `all`, which means that any external component can connect. The access rule referenced here needs to be defined in the `access` configuration section.
+Determines who is allowed to send data to external components. By default the rule is `all`, which means that anyone can communicate with the components.
 
 ### `listen.service.password`
 * **Syntax:** string

--- a/src/acl.erl
+++ b/src/acl.erl
@@ -34,7 +34,7 @@
 -export_type([rule/0]).
 
 -type rule() :: atom().
--type acl_spec() :: #{match := all | none | current_domain,
+-type acl_spec() :: #{match := all | none | current_domain | any_hosted_domain,
                       acl_spec_key() => binary()}.
 -type acl_spec_key() :: user | user_regexp | user_glob
                       | server | server_regexp | server_glob
@@ -131,6 +131,8 @@ match_step(none, _Domain, _JID) ->
 -spec check(acl_spec_key(), binary(), jid:lserver(), jid:jid()) -> boolean().
 check(match, all, _, _) -> true;
 check(match, none, _, _) -> false;
+check(match, any_hosted_domain, _, JID) ->
+    mongoose_domain_api:get_host_type(JID#jid.lserver) =/= {error, not_found};
 check(match, current_domain, Domain, JID) -> JID#jid.lserver =:= Domain;
 check(user, User, _, JID) -> JID#jid.luser =:= User;
 check(user_regexp, Regexp, _, JID) -> is_regexp_match(JID#jid.luser, Regexp);

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -825,11 +825,12 @@ acl() ->
 
 %% path: (host_config[].)acl.*[]
 acl_item() ->
+    Match = #option{type = atom,
+                    validate = {enum, [all, none, current_domain, any_hosted_domain]}},
     Cond = #option{type = binary,
                    process = fun ?MODULE:process_acl_condition/1},
     #section{
-       items = #{<<"match">> => #option{type = atom,
-                                        validate = {enum, [all, none, current_domain]}},
+       items = #{<<"match">> => Match,
                  <<"user">> => Cond,
                  <<"server">> => Cond,
                  <<"resource">> => Cond,

--- a/test/acl_SUITE.erl
+++ b/test/acl_SUITE.erl
@@ -179,19 +179,22 @@ all_and_none_specs(Config) ->
     ok.
 
 match_domain(Config) ->
-    given_registered_domains(Config, [<<"zakopane">>]),
+    given_registered_domains(Config, [<<"zakopane">>, <<"gdansk">>]),
 
     UserZa = jid:make(<<"pawel">>, <<"zakopane">>, <<"test">>),
     UserGd = jid:make(<<"pawel">>, <<"gdansk">>, <<"test">>),
-    UserGb = jid:make(<<"pawel">>, <<"gdansk">>, <<"best">>),
+    UserTo = jid:make(<<"pawel">>, <<"torun">>, <<"test">>),
+    UserZb = jid:make(<<"pawel">>, <<"zakopane">>, <<"best">>),
 
     set_acl(global, a_users, #{resource => <<"test">>}),
+    set_acl(global, b_users, #{match => any_hosted_domain, resource => <<"test">>}),
     set_acl(global, c_users, #{match => all, resource => <<"test">>}),
 
-    set_global_rule(rule, [{allow, a_users}, {deny, c_users}, {default, all}]),
-    ?assertEqual(allow, acl:match_rule(global, <<"zakopane">>, rule, UserZa)),
-    ?assertEqual(deny, acl:match_rule(global, <<"zakopane">>, rule, UserGd)),
-    ?assertEqual(default, acl:match_rule(global, <<"zakopane">>, rule, UserGb)),
+    set_global_rule(rule, [{a, a_users}, {b, b_users}, {c, c_users}, {d, all}]),
+    ?assertEqual(a, acl:match_rule(global, <<"zakopane">>, rule, UserZa)),
+    ?assertEqual(b, acl:match_rule(global, <<"zakopane">>, rule, UserGd)),
+    ?assertEqual(c, acl:match_rule(global, <<"zakopane">>, rule, UserTo)),
+    ?assertEqual(d, acl:match_rule(global, <<"zakopane">>, rule, UserZb)),
     ok.
 
 match_host_specific_rule_for_host_type(Config) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1329,6 +1329,8 @@ shaper(_Config) ->
 acl(_Config) ->
     ?cfgh({acl, local}, [#{match => all}],
           #{<<"acl">> => #{<<"local">> => [#{<<"match">> => <<"all">>}]}}),
+    ?cfgh({acl, local}, [#{match => any_hosted_domain}],
+          #{<<"acl">> => #{<<"local">> => [#{<<"match">> => <<"any_hosted_domain">>}]}}),
     ?cfgh({acl, local}, [#{match => current_domain,
                            user_regexp => <<>>}],
           #{<<"acl">> => #{<<"local">> => [#{<<"user_regexp">> => <<>>}]}}),
@@ -1343,6 +1345,7 @@ acl(_Config) ->
           #{<<"acl">> => #{<<"alice">> => [#{<<"user">> => <<"alice">>,
                                              <<"server">> => <<"localhost">>}]}}),
     ?errh(#{<<"acl">> => #{<<"local">> => <<"everybody">>}}),
+    ?errh(#{<<"acl">> => #{<<"local">> => [#{<<"match">> => <<"lit">>}]}}),
     ?errh(#{<<"acl">> => #{<<"alice">> => [#{<<"user_glob">> => <<"a*">>,
                                              <<"server_blog">> => <<"bloghost">>}]}}),
     ?errh([#{reason := incorrect_acl_condition_value}],


### PR DESCRIPTION
This condition makes it possible to allow access for all locally hosted domains and deny access for all external domains.

This was possible before #3501, but undocumented and very implicit, e.g. it was used when checking if a user could send data to an external component, but only if user(regexp) was set in the pattern.

 Now it is back, but this time is fully controllable by the user in a predicatable way.