### PR TITLE
Test config parsing with post-processing

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -6,7 +6,7 @@
 -export([parse_file/1]).
 
 -ifdef(TEST).
--export([parse/1,
+-export([process/1,
          extract_errors/1]).
 -endif.
 


### PR DESCRIPTION
Call `process` instead of `parse` in `config_parser_SUITE`

This makes it possible to test config post-processing, i.e.
- Repeating global options for each host (type)
- Module dependencies (no tests yet, but they can be easily added now)
- Aggregation of acl's and access rules (planned in my next PR)

Related changes:
- Module options are checked selectively because deps are now present (only one module is checked instead of all).
- New function `compare_nodes/3` is used for more organized comparison of config tree nodes
- `HOST_TYPE` is changed to `HOST` because some modules don't support dynamic domains yet. Before it was working only because it referred to an undefined host type and thus it managed to circumvent the check.

Note:
- The `host_key` helper will be simplified in the upcoming PR, removing the `HostType` argument as it is only required for shaper/acl/access now - only these options have this host-or-global resulting format, others are stored only per host type.