### PR TITLE
Add server_name_indication_host config option

### DIFF
--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -445,4 +445,4 @@ Enables SNI extension to TLS protocol. If set to `true`, the `server_name_indica
 * **Default:** not set
 * **Example:** `tls.server_name_indication_host = "domain.com"`
 
-Domain against which the certificates will be checked, using SNI.
+Domain against which the certificates will be checked, using SNI. It can be specified only when `server_name_indication` is set to `true`.

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -195,7 +195,7 @@ Logical database index (zero-based).
 
 ## Riak options
 
-Currently only one Riak connection pool can exist for each supported XMPP host (the default pool).
+Currently, only one Riak connection pool can exist for each supported XMPP host (the default pool).
 
 !!! WARNING
     `riak` backend is not compatible with `available_worker` strategy.
@@ -245,7 +245,7 @@ Cassandra also supports all TLS-specific options described in the TLS section.
 
 ## Elasticsearch options
 
-Currently only one pool tagged `default` can be used.
+Currently, only one pool tagged `default` can be used.
 
 ### `outgoing_pools.elastic.default.connection.host`
 * **Syntax:** string
@@ -363,7 +363,7 @@ Reconnect interval after a failed connection.
 * **Default:** `"none"`
 * **Example:** `encrypt = "tls"`
 
-LDAP  also supports all TLS-specific options described in the TLS section (provided `encrypt` is set to `tls`).
+LDAP also supports all TLS-specific options described in the TLS section (provided `encrypt` is set to `tls`).
 
 ## TLS options
 
@@ -435,7 +435,14 @@ Cipher suites to use. For allowed values, see the [Erlang/OTP SSL documentation]
 
 ### `outgoing_pools.*.*.connection.tls.server_name_indication`
 * **Syntax:** boolean
-* **Default:** `true`
+* **Default:** `false`, but enabled if the `verify_peer` option is set to `true`
 * **Example:** `tls.server_name_indication = false`
 
-Enables SNI extension to TLS protocol.
+Enables SNI extension to TLS protocol. If set to `true`, the `server_name_indication_host` option should be provided.
+
+### `outgoing_pools.*.*.connection.tls.server_name_indication_host`
+* **Syntax:** string
+* **Default:** not set
+* **Example:** `tls.server_name_indication_host = "domain.com"`
+
+Domain against which the certificates will be checked, using SNI.

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -1060,7 +1060,8 @@ process_xmpp_tls(KVs) ->
     end.
 
 tls_keys(just_tls) ->
-    [verify_mode, disconnect_on_failure, crlfiles, password, server_name_indication, server_name_indication_host, versions];
+    [verify_mode, disconnect_on_failure, crlfiles, password, server_name_indication,
+     server_name_indication_host, versions];
 tls_keys(fast_tls) ->
     [protocol_options].
 
@@ -1231,7 +1232,8 @@ riak_ssl(Opts) -> [{ssl_opts, Opts}].
 process_tls_sni(KVs) ->
     % the SSL library expects either the atom `disable` or a string with the SNI host
     % as value for `server_name_indication`
-    {[SNIOpt, SNIHostOpt], SSLOpts} = proplists:split(KVs, [server_name_indication, server_name_indication_host]),
+    SNIKeys = [server_name_indication, server_name_indication_host],
+    {[SNIOpt, SNIHostOpt], SSLOpts} = proplists:split(KVs, SNIKeys),
     case {SNIOpt, SNIHostOpt} of
         {[], []} ->
             SSLOpts;


### PR DESCRIPTION
The SNI options are formatted to be useful to OTP's `ssl` library, so in any place where they are passed down to it in the end, this should work.

This PR makes the option `server_name_indication` sensible - one can set it to either `true` OR `false`. And when using `verify_peer` SNI is (in most cases) needed, so there needs to be a way to pass the domain in the config. Because of the awkward way `ssl` expects an atom `disable` or the domain name, there is a need for a new option `server_name_indication_host` in TOML, and the subsequent parsing.

In the future could be used by other places where TLS can be set, but it's a can of worms, we have like five different ways to configure TLS in TOML, and quite a few libraries/abstractions, which all expect a little bit different options passed to them.
