### PR TITLE
Fix async metrics test

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -3084,10 +3084,12 @@ metric_incremented_on_archive_request(ConfigIn) ->
     escalus_fresh:story(Config, [{alice, 1}], F).
 
 metrics_incremented_for_async_pools(Config) ->
-    Val0 = get_mongoose_async_metrics(),
+    OldValue = get_mongoose_async_metrics(),
     archived(Config),
-    Val1 = get_mongoose_async_metrics(),
-    ?assert_equal(false, Val0 =:= Val1).
+    Validator = fun(NewValue) -> OldValue =/= NewValue end,
+    mongoose_helper:wait_until(
+      fun get_mongoose_async_metrics/0,
+      true, #{validator => Validator, name => ?FUNCTION_NAME}).
 
 get_mongoose_async_metrics() ->
     HostType = domain_helper:host_type(mim),

--- a/src/mongoose_batch_worker.erl
+++ b/src/mongoose_batch_worker.erl
@@ -46,7 +46,10 @@ init({HostType, PoolId, Interval, MaxSize, FlushCallback, FlushExtra}) ->
                 flush_extra = FlushExtra}}.
 
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
-handle_call(sync, _From, State = #state{flush_queue = [_|_]}) ->
+handle_call(sync, _From, State = #state{host_type = HostType,
+                                        pool_id = PoolId,
+                                        flush_queue = [_|_]}) ->
+    mongoose_metrics:update(HostType, [mongoose_async_pools, PoolId, timed_flushes], 1),
     {reply, ok, run_flush(State)};
 handle_call(sync, _From, State = #state{flush_queue = []}) ->
     {reply, skipped, State};


### PR DESCRIPTION
Often flushes happen either because of a timeout, or because of explicit
requests to flush the queue. Add an asynchronous wait for the metric to
change, and add a metric increment of explicit flush requests.