### PR TITLE
Allow to use podman instead of docker

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -53,8 +53,6 @@ containers:
   - &ldap_container
     image: osixia/openldap:__LDAP_VERSION__
     environment:
-      - SQL_TEMP_DIR: /tmp/sql
-      - POSTGRES_PASSWORD: password
       - LDAP_DOMAIN: "esl.com"
       - LDAP_ADMIN_PASSWORD: "mongooseim_secret"
       - LDAP_ORGANISATION: "Erlang Solutions"

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -6,7 +6,15 @@ The test runner script is used to compile MongooseIM and run tests.
 
 ### Docker
 
-Docker must be installed on the local system, and the user executing the tests must have privileges to start new containers (usually achieved by adding the user to the `docker` group).
+Docker could be installed on the local system, and the user executing the tests must have privileges to start new containers (usually achieved by adding the user to the `docker` group).
+
+Alternatively, you can use Podman. Here is how to install it on Mac:
+
+```bash
+brew install podman
+podman machine init
+podman machine start
+```
 
 ### FreeTDS for MSSQL connectivity
 

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -14,6 +14,14 @@ Alternatively, you can use Podman. Here is how to install it on Mac:
 brew install podman
 podman machine init
 podman machine start
+ln -s /usr/local/bin/podman /usr/local/bin/docker
+```
+
+You can also specify which container supervisor you want to use by defining
+an environment variable in your `~/.bashrc`:
+
+```bash
+export DOCKER=podman
 ```
 
 ### FreeTDS for MSSQL connectivity

--- a/tools/circle-generate-config.sh
+++ b/tools/circle-generate-config.sh
@@ -40,9 +40,6 @@ MIM_DHSERVER=$(cat32 tools/ssl/mongooseim/dh_server.pem)
 INJECT_FILES=$(cat32 tools/inject-files.sh)
 CACERT=$(cat32 tools/ssl/ca/cacert.pem)
 
-PYTHON2_BASE32_DEC="python2 -c 'import base64; import sys; sys.stdout.write(base64.b32decode(sys.stdin.readline().strip()))'"
-PYTHON3_BASE32_DEC="python3 -c 'import base64; import sys; sys.stdout.buffer.write(base64.b32decode(sys.stdin.readline().strip()))'"
-
 CERTS_CACHE_KEY=$(cat certs_cache_key)
 
 sed -e "s/__MYSQL_CNF__/${MYSQL_CNF}/" \

--- a/tools/circle-generate-config.sh
+++ b/tools/circle-generate-config.sh
@@ -2,21 +2,9 @@
 
 OUT_FILE="$1"
 
-echo | base32 -w0 > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-      # GNU coreutils base32, '-w' supported
-      ENCODER="base32 -w0"
-    else
-      # Openssl base32, no wrapping by default
-      ENCODER="base32"
-fi
-
 set -e
+source tools/common-vars.sh
 source tools/db-versions.sh
-
-function cat32 {
-    cat "$1" | $ENCODER
-}
 
 MYSQL_CNF=$(cat32 tools/db_configs/mysql/mysql.cnf)
 MYSQL_SQL=$(cat32 priv/mysql.sql)

--- a/tools/common-vars.sh
+++ b/tools/common-vars.sh
@@ -14,13 +14,11 @@ function cat32 {
     cat "$1" | $ENCODER
 }
 
-DOCKER=docker
-DOCKER_HEALTH=Health
+DOCKER=${DOCKER:-docker}
 
-# There is no smart way to choose between podman and docker
-# By default, if both are available, we choose podman
-if hash podman; then
-    DOCKER=podman
+DOCKER_HEALTH=Health
+if [[ "$DOCKER" == *"podman"* ]]; then
+    # Overrides for podman
     DOCKER_HEALTH=Healthcheck
 fi
 

--- a/tools/common-vars.sh
+++ b/tools/common-vars.sh
@@ -44,40 +44,16 @@ DEV_NODES="${DEV_NODES-$DEFAULT_DEV_NODES}"
 # Create a bash array DEFAULT_DEV_NODES with node names
 IFS=' ' read -r -a DEV_NODES_ARRAY <<< "$DEV_NODES"
 
-# Linux volumes are faster than layer fs.
-# Mac volumes are actually slower than layer fs.
-case "$(uname -s)" in
-    Darwin*)    DEFAULT_DATA_ON_VOLUME=false;;
-    *)          DEFAULT_DATA_ON_VOLUME=true
-esac
-DATA_ON_VOLUME=${DATA_ON_VOLUME:-$DEFAULT_DATA_ON_VOLUME}
-
-# Returns its arguments if data on volume is enabled
-function data_on_volume
-{
-    if [ "$DATA_ON_VOLUME" = 'true' ]; then
-        echo "$@"
-    fi
-}
-
-# Example: mktempdir "PREFIX"
-#
-# MAC OS X and docker specific:
-#   Docker for Mac limits where mounts can be.
-#   Mounts can be in /tmp, /Users, /Volumes but not in /var/folders/cd/
-#   Default behaviour of mktemp on Mac is to create a directory like
-#   /var/folders/cd/qgvc26bj6hg1kgr41q96zydh0000gp/T/tmp.Sa9w8Xp3
-function mktempdir
-{
-    mktemp -d "/tmp/$1.XXXXXXXXX"
-}
-
-function mount_ro_volume
-{
-    echo "-v $1:$2:ro"
-}
-
 function db_name
 {
     echo mongooseim-$1
 }
+
+function entrypoint
+{
+    INJECT_FILES=$(cat32 tools/inject-files.sh)
+    echo 'eval ${INSTALL_DEPS_CMD:-echo} && echo '${INJECT_FILES}' | eval ${BASE32DEC:-base32 --decode} | bash'
+}
+
+PYTHON2_BASE32_DEC="python2 -c 'import base64; import sys; sys.stdout.write(base64.b32decode(sys.stdin.readline().strip()))'"
+PYTHON3_BASE32_DEC="python3 -c 'import base64; import sys; sys.stdout.buffer.write(base64.b32decode(sys.stdin.readline().strip()))'"

--- a/tools/common-vars.sh
+++ b/tools/common-vars.sh
@@ -2,6 +2,28 @@
 
 TOOLS=`dirname $0`
 
+if echo | base32 -w0 > /dev/null 2>&1; then
+      # GNU coreutils base32, '-w' supported
+      ENCODER="base32 -w0"
+    else
+      # Openssl base32, no wrapping by default
+      ENCODER="base32"
+fi
+
+function cat32 {
+    cat "$1" | $ENCODER
+}
+
+DOCKER=docker
+DOCKER_HEALTH=Health
+
+# There is no smart way to choose between podman and docker
+# By default, if both are available, we choose podman
+if hash podman; then
+    DOCKER=podman
+    DOCKER_HEALTH=Healthcheck
+fi
+
 if [ `uname` = "Darwin" ]; then
     BASE=$(cd "$TOOLS/.."; pwd -P)
     # Don't forget to install gsed command using "brew install gnu-sed"

--- a/tools/db_configs/cassandra/proxy/replace-ip.sh
+++ b/tools/db_configs/cassandra/proxy/replace-ip.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [ ! -z "$CASSANDRA_IP" ]; then
+    sed -i "s/\"service-hostname\": \".*\"/\"service-hostname\": \"$CASSANDRA_IP\"/g" "/data/zazkia-routes.json"
+fi

--- a/tools/mssql-shell.sh
+++ b/tools/mssql-shell.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-docker exec -it mongoose-mssql /opt/mssql-tools/bin/sqlcmd \
-    -d ejabberd \
-    -S localhost \
-    -U SA \
-    -P "mongooseim_secret+ESL123"

--- a/tools/open-test-database-shell.sh
+++ b/tools/open-test-database-shell.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 
+cd "$(dirname "$0")/../"
+source tools/common-vars.sh
 db=$1
 
 case $db in
     mysql)
-        docker exec -e MYSQL_PWD=secret -it mongooseim-mysql mysql -h localhost -u root -D ejabberd
+        $DOCKER exec -e MYSQL_PWD=secret -it mongooseim-mysql mysql -h localhost -u root -D ejabberd
     ;;
     pgsql)
-        docker exec -e PGPASSWORD=password -it mongooseim-pgsql psql -U postgres -d ejabberd -h 127.0.0.1
+        $DOCKER exec -e PGPASSWORD=password -it mongooseim-pgsql psql -U postgres -d ejabberd -h 127.0.0.1
     ;;
     mssql-sqlcmd)
-        docker exec -it mongooseim-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mongooseim_secret+ESL123 -d ejabberd
+        $DOCKER exec -it mongooseim-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mongooseim_secret+ESL123 -d ejabberd
     ;;
     mssql)
-        docker run --link mongooseim-mssql -it --rm shellmaster/sql-cli mssql --server mongooseim-mssql --user sa --pass mongooseim_secret+ESL123 --database ejabberd
+        $DOCKER run --link mongooseim-mssql -it --rm shellmaster/sql-cli mssql --server mongooseim-mssql --user sa --pass mongooseim_secret+ESL123 --database ejabberd
     ;;
     *)
         echo "Unknown argument $db"

--- a/tools/setup-db.sh
+++ b/tools/setup-db.sh
@@ -19,36 +19,17 @@ PGSQL_ODBC_CERT_DIR=~/.postgresql
 
 SSLDIR=${TOOLS}/ssl
 
-# DATA_ON_VOLUME variable and data_on_volume function come from common-vars.sh
-echo "DATA_ON_VOLUME is $DATA_ON_VOLUME"
-
 function riak_solr_is_up
 {
     $DOCKER exec $1 curl 'http://localhost:8093/internal_solr/mam/admin/ping?wt=json' | grep '"status":"OK"'
 }
-
-# Stores all the data needed by the container
-SQL_ROOT_DIR="$(mktempdir mongoose_sql_root)"
-echo "SQL_ROOT_DIR is $SQL_ROOT_DIR"
-
-# A directory, that contains resources that needed to bootstrap a container
-# i.e. certificates and config files
-SQL_TEMP_DIR="$SQL_ROOT_DIR/temp"
-
-# A directory, that contains database server data files
-# It's good to keep it outside of a container, on a volume
-SQL_DATA_DIR="$SQL_ROOT_DIR/data"
-mkdir -p "$SQL_TEMP_DIR" "$SQL_DATA_DIR"
 
 function setup_db(){
 db=${1:-none}
 echo "Setting up db: $db"
 DB_CONF_DIR=${TOOLS}/db_configs/$db
 
-PYTHON2_BASE32_DEC="python2 -c 'import base64; import sys; sys.stdout.write(base64.b32decode(sys.stdin.readline().strip()))'"
-PYTHON3_BASE32_DEC="python3 -c 'import base64; import sys; sys.stdout.buffer.write(base64.b32decode(sys.stdin.readline().strip()))'"
-INJECT_FILES=$(cat32 tools/inject-files.sh)
-ENTRYPOINT='eval ${INSTALL_DEPS_CMD:-echo} && echo '${INJECT_FILES}' | eval ${BASE32DEC:-base32 --decode} | bash'
+ENTRYPOINT=$(entrypoint)
 
 if [ "$db" = 'mysql' ]; then
     NAME=$(db_name mysql)

--- a/tools/setup-redis.sh
+++ b/tools/setup-redis.sh
@@ -5,8 +5,8 @@ source tools/db-versions.sh
 NAME=$(db_name redis)
 REDIS_PORT=${REDIS_PORT:-6379}
 
-docker rm -v -f $NAME || echo "Skip removing the previous container"
-docker run -d --name $NAME \
+$DOCKER rm -v -f $NAME || echo "Skip removing the previous container"
+$DOCKER run -d --name $NAME \
     -p $REDIS_PORT:6379 \
     --health-cmd='redis-cli -h "127.0.0.1" ping' \
     redis:$REDIS_VERSION

--- a/tools/setup-rmq.sh
+++ b/tools/setup-rmq.sh
@@ -5,8 +5,8 @@ source tools/db-versions.sh
 NAME=$(db_name rmq)
 RMQ_PORT=5672
 
-docker rm -v -f $NAME || echo "Skip removing the previous container"
-docker run -d \
+$DOCKER rm -v -f $NAME || echo "Skip removing the previous container"
+$DOCKER run -d \
        --name $NAME \
        -p $RMQ_PORT:5672 \
        rabbitmq:$RMQ_VERSION

--- a/tools/setup_minio.sh
+++ b/tools/setup_minio.sh
@@ -2,6 +2,7 @@
 
 # cd to repo
 cd "$(dirname "$0")/../"
+source tools/common-vars.sh
 
 source tools/db-versions.sh
 
@@ -12,12 +13,12 @@ minio_access_key="AKIAIAOAONIULXQGMOUA"
 minio_secret_key="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"
 minio_bucket="mybucket"
 
-docker rm -v -f "${minio_docker_name}" || echo "Skip removing previous container"
+$DOCKER rm -v -f "${minio_docker_name}" || echo "Skip removing previous container"
 
 IMAGE="minio/minio:$MINIO_VERSION"
 MC_IMAGE="minio/mc:$MINIO_MC_VERSION"
 
-docker run -d -p 9000:9000 \
+$DOCKER run -d -p 9000:9000 \
     --name "${minio_docker_name}" \
     -e "MINIO_ACCESS_KEY=${minio_access_key}" \
     -e "MINIO_SECRET_KEY=${minio_secret_key}" \
@@ -37,4 +38,4 @@ EOF
 
 # The config script in ${mc_cmd} needs to be run in `minio/mc` container
 # because `minio/server` container doesn't have the `mc` command.
-docker run --rm --entrypoint sh $MC_IMAGE -c "${mc_cmd}"
+$DOCKER run --rm --entrypoint sh $MC_IMAGE -c "${mc_cmd}"

--- a/tools/wait_for_healthcheck.sh
+++ b/tools/wait_for_healthcheck.sh
@@ -33,6 +33,7 @@
 # TIMEOUT=1 ./tools/wait_for_healthcheck.sh "$CONTAINER"
 
 set -e
+source tools/common-vars.sh
 
 if [ "$#" -ne 1 ]; then
     exit "Illegal number of parameters"
@@ -47,7 +48,7 @@ TIMEOUT="${TIMEOUT:-60}"
 # health_status "$CONTAINER"
 function health_status
 {
-    docker inspect --format '{{json .State.Health.Status }}' "$1"
+    $DOCKER inspect --format '{{json .State.'${DOCKER_HEALTH}'.Status }}' "$1"
 }
 
 for i in $(seq 0 ${TIMEOUT}); do

--- a/tools/wait_for_service.sh
+++ b/tools/wait_for_service.sh
@@ -2,6 +2,8 @@
 # We cannot just connect to 127.0.0.1:9042 because Docker is very "smart" and
 # exposes ports before the service is ready
 
+source tools/common-vars.sh
+
 if [ "$#" -ne 2 ]; then
     exit "Illegal number of parameters"
 fi
@@ -10,18 +12,18 @@ set -e
 
 CONTAINER="$1"
 PORT="$2"
-IP=$(docker inspect -f {{.NetworkSettings.IPAddress}} "$CONTAINER")
+IP=$($DOCKER inspect -f {{.NetworkSettings.IPAddress}} "$CONTAINER")
 echo "$CONTAINER IP is $IP"
 
 if [ `uname` = "Darwin" ]; then
   # Direct access to IPs is not supported on Mac
   # https://docs.docker.com/docker-for-mac/networking/
   # But we can run wait-for-it from another container
-  docker run --rm -d --name wait-helper ubuntu sleep infinity || echo "We can continue if the wait-helper exists"
-  docker start wait-helper || echo "ok"
-  docker cp tools/wait-for-it.sh wait-helper:/wait-for-it.sh
+  $DOCKER run --rm -d --name wait-helper ubuntu sleep infinity || echo "We can continue if the wait-helper exists"
+  $DOCKER start wait-helper || echo "ok"
+  $DOCKER cp tools/wait-for-it.sh wait-helper:/wait-for-it.sh
   echo "Wait for $IP:$PORT"
-  docker exec -t wait-helper /wait-for-it.sh -h "$IP" -p "$PORT"
+  $DOCKER exec -t wait-helper /wait-for-it.sh -h "$IP" -p "$PORT"
 else
   tools/wait-for-it.sh -h "$IP" -p "$PORT"
 fi


### PR DESCRIPTION
This PR addresses "Desktop docker license change" MIM-1598.

Proposed changes include:
* allows to use podman instead of docker
* podman does not support mounting volumes from the host machine yet
* But we already are not using volumes for circleci, so it makes sense to make circleci and setup-db code more similar.

And you can put `alias docker=podman` into your bash init script.
https://podman.io/whatis.html

What's else? It takes one hour to compile qemu (a dependency of podman) :D 

_One more thing, by default, podman machine takes 2GB of memory.
This means that after starting all other databases (i.e. primarily cassandra and elastic), starting mssql would fail (i.e. "podman ps" would not respond for some time, but after a minute, mssql container just stops and everything is fine). The solution is simple - just stop other containers in this case - it would release memory and make MSSQL happy (after that you can start these containers again, apparently)._