### PR TITLE
Less MIM compiler warnings

### DIFF
--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -377,7 +377,7 @@ choose_pid(From, Pids) ->
             end,
     % Use sticky connections based on the JID of the sender
     % (without the resource to ensure that a muc room always uses the same connection)
-    Pid = lists:nth(erlang:phash(jid:to_bare(From), length(Pids1)), Pids1),
+    Pid = lists:nth(erlang:phash2(jid:to_bare(From), length(Pids1)) + 1, Pids1),
     ?LOG_DEBUG(#{what => s2s_choose_pid, from => From, s2s_pid => Pid}),
     Pid.
 

--- a/src/event_pusher/mod_event_pusher_sns.erl
+++ b/src/event_pusher/mod_event_pusher_sns.erl
@@ -266,4 +266,5 @@ calc_backoff_time(Host, Retry) ->
     MaxRetry = opt(Host, publish_retry_count, ?PUBLISH_RETRY_COUNT_DEFAULT),
     BaseTime = opt(Host, publish_retry_time_ms, 50),
     BackoffMaxTime = round(math:pow(2, MaxRetry - Retry)) * BaseTime,
-    crypto:rand_uniform(BackoffMaxTime - BaseTime, BackoffMaxTime).
+    Random = rand:uniform(BaseTime),
+    BackoffMaxTime - Random.

--- a/src/event_pusher/mod_event_pusher_sns.erl
+++ b/src/event_pusher/mod_event_pusher_sns.erl
@@ -21,6 +21,7 @@
 %%%===================================================================
 
 -define(TOPIC_BASE, ["arn", "aws", "sns"]).
+-define(PUBLISH_RETRY_COUNT_DEFAULT, 2).
 
 -type user_guid() :: binary().
 -type topic_arn() :: string(). %% Full topic ARN in format arn:aws:sns:{REGION}:{ACCOUNT_ID}:{TOPIC}
@@ -151,7 +152,7 @@ handle_packet(From = #jid{lserver = Host}, To, Packet) ->
 -spec async_publish(Host :: jid:lserver(), topic_arn(), Content :: jiffy:json_value(),
               attributes()) -> ok.
 async_publish(Host, TopicARN, Content, Attributes) ->
-    Retry = opt(Host, publish_retry_count, 2),
+    Retry = opt(Host, publish_retry_count, ?PUBLISH_RETRY_COUNT_DEFAULT),
     mongoose_wpool:cast(generic, Host, pusher_sns,
                         {?MODULE, try_publish, [Host, TopicARN, Content, Attributes, Retry]}).
 
@@ -262,7 +263,7 @@ message_attributes(Host, TopicARN, From, To, MessageType, Packet) ->
 
 -spec calc_backoff_time(Host :: jid:lserver(), integer()) -> integer().
 calc_backoff_time(Host, Retry) ->
-    MaxRetry = opt(Host, publish_retry_count),
+    MaxRetry = opt(Host, publish_retry_count, ?PUBLISH_RETRY_COUNT_DEFAULT),
     BaseTime = opt(Host, publish_retry_time_ms, 50),
     BackoffMaxTime = round(math:pow(2, MaxRetry - Retry)) * BaseTime,
     crypto:rand_uniform(BackoffMaxTime - BaseTime, BackoffMaxTime).

--- a/src/http_upload/aws_signature_v4.erl
+++ b/src/http_upload/aws_signature_v4.erl
@@ -164,7 +164,7 @@ uri_encode_char(C, _) when C >= $a, C =< $z -> <<C>>;
 uri_encode_char(C, _) when C >= $0, C =< $9 -> <<C>>;
 uri_encode_char(C, _) when C == $_; C == $-; C == $~; C == $. -> <<C>>;
 uri_encode_char($/, false) -> <<$/>>;
-uri_encode_char(C, _) -> list_to_binary([$% | httpd_util:integer_to_hexlist(C)]).
+uri_encode_char(C, _) -> list_to_binary([$% | integer_to_list(C, 16)]).
 
 
 -spec hex(Data :: binary()) -> HexEncoded :: binary().

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -114,7 +114,7 @@ translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary) ->
 
     {reply, ringing}.
 
-sip_reinvite_unsafe(Req, Call) ->
+sip_reinvite_unsafe(Req, _Call) ->
     ?LOG_INFO(#{what => sip_reinvite, sip_req => Req}),
     {FromJID, FromBinary} = get_user_from_sip_msg(from, Req),
     {ToJID, ToBinary} = get_user_from_sip_msg(to, Req),
@@ -153,12 +153,6 @@ get_action_name_from_sdp(Attrs, Default) ->
 
 
 sip_info(Req, _Call) ->
-    {FromJID, FromBinary} = get_user_from_sip_msg(from, Req),
-    {ToJID, ToBinary} = get_user_from_sip_msg(to, Req),
-
-    CallID = nksip_sipmsg:header(<<"call-id">>, Req),
-    Body = nksip_sipmsg:meta(body, Req),
-
     ?LOG_INFO(#{what => sip_info, sip_req => Req}),
     noreply.
 
@@ -209,10 +203,6 @@ sip_dialog_update(start, Dialog, Call) ->
         _ ->
             ok
     end,
-    noreply;
-sip_dialog_update(stop, Dialog, _) ->
-    {ok, CallID} = nksip_dialog:call_id(Dialog),
-
     noreply;
 sip_dialog_update(_, _, _) ->
     noreply.

--- a/src/p1_fsm_old.erl
+++ b/src/p1_fsm_old.erl
@@ -810,7 +810,7 @@ format_status(Opt, StatusData) ->
                       Name
               end,
     Header = lists:concat(["Status for state machine ", NameTag]),
-    Log = sys:get_debug(log, Debug, []),
+    Log = sys:get_log(Debug),
     Specfic =
         case erlang:function_exported(Mod, format_status, 2) of
             true ->

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -164,9 +164,9 @@ get_config(Args, _) ->
 -spec report_transparency(proplists:proplist()) -> skip | continue.
 report_transparency(Args) ->
     case {explicit_no_report(Args), explicit_gathering_agreement(Args)} of
-        {true, ____} -> skip;
-        {____, true} -> continue;
-        {____, ____} ->
+        {true, _} -> skip;
+        {_, true} -> continue;
+        {_, _} ->
             File = mongoose_system_metrics_file:location(),
             Text = iolist_to_binary(io_lib:format(msg_accept_terms_and_conditions(), [File])),
             ?LOG_WARNING(#{what => report_transparency,

--- a/src/wpool/mongoose_wpool_mgr.erl
+++ b/src/wpool/mongoose_wpool_mgr.erl
@@ -130,15 +130,13 @@ handle_info({'DOWN', MRef, process, _Pid, Reason}, #state{monitors = Monitors} =
             NewState = restart_pool(Reason, Details, State#state{monitors = NewMonitors0}),
             {noreply, NewState}
     end;
-handle_info({restart, PoolKey}, #state{pools = Pools, monitors = Monitors} = State) ->
+handle_info({restart, PoolKey}, #state{pools = Pools} = State) ->
     case maps:get(PoolKey, Pools, undefined) of
         undefined -> %% The pool was stopped in the meantime, no need to restart it
             {noreply, State};
         Pool ->
             start_or_schedule_another_restart(PoolKey, Pool, State)
     end.
-
-
 
 terminate(_Reason, _State) ->
     ok.


### PR DESCRIPTION
This PR fixes some compiler warnings for MIM. This includes deprecated functions for example, which should mean less work when upgrading OTP versions.

There are two warnings left:
- `mod_http_upload_s3` uses `http_uri`, which is deprecated and will be removed with OTP25. It would probably be best to refactor this module to make the best of the new `uri_string` module, which has a bit different API, but I'd rather do this in a separate PR.
- conflicting behaviours of `mod_cowboy` when it comes to `init/2` and `terminate/3`. I've left it because from what I understand it shouldn't cause problems, and I'm not sure if this module is even used.

