### PR TITLE
Fix mod_event_pusher_push MUC Light error

### DIFF
--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -48,18 +48,18 @@ stop(Host) ->
 %%--------------------------------------------------------------------
 %% Hook callbacks
 %%--------------------------------------------------------------------
--type routing_data() :: {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
 -spec filter_local_packet(drop) -> drop;
-                         (routing_data()) -> routing_data().
+                         (mongoose_hooks:filter_packet_acc()) -> mongoose_hooks:filter_packet_acc().
 filter_local_packet(drop) ->
     drop;
-filter_local_packet({From, To = #jid{lserver = Host}, Acc0, Packet}) ->
+filter_local_packet({From, To, Acc0, Packet}) ->
     Acc = case chat_type(Acc0) of
               false -> Acc0;
               Type ->
                   Event = #chat_event{type = Type, direction = out,
                                       from = From, to = To, packet = Packet},
-                  NewAcc = mod_event_pusher:push_event(Acc0, Host, Event),
+                  HostType = mongoose_acc:host_type(Acc0),
+                  NewAcc = mod_event_pusher:push_event(Acc0, HostType, Event),
                   merge_acc(Acc0, NewAcc)
           end,
     {From, To, Acc, Packet}.


### PR DESCRIPTION
When a stanza was addressed to a room, there were errors in the log and no notifications due to a failed hook (`mod_event_pusher:push_event/3` failed on the ETS lookup, because the name was expecting a Host, not a MUC Light host).
