### PR TITLE
Retry apt-get on Circle CI

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -245,8 +245,8 @@ commands:
           command: |
             sudo pkill -9 apt-get || true && \
             echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4 && \
-            sudo apt-get update && \
-            sudo apt-get install libssl-dev unixodbc-dev unixodbc tdsodbc rsync zlib1g-dev -y
+            sudo ./tools/retry.sh apt-get update && \
+            sudo ./tools/retry.sh apt-get install libssl-dev unixodbc-dev unixodbc tdsodbc rsync zlib1g-dev -y
   maybe_build_deps_and_cache:
     steps:
       - restore_cache:
@@ -297,8 +297,8 @@ commands:
           command: |
             sudo pkill -9 apt-get || true && \
             echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4 && \
-            sudo apt-get update && \
-            sudo apt-get install python3-pip -y && \
+            sudo ./tools/retry.sh apt-get update && \
+            sudo ./tools/retry.sh apt-get install python3-pip -y && \
             pip3 install codecov && codecov
   run_coverage_analysis:
     steps:
@@ -384,8 +384,8 @@ commands:
           name: Install odbc.ini and packages
           command: |
             if [[ "$DB" == *mssql* ]]; then
-                sudo apt-get update
-                sudo apt-get -y install unixodbc tdsodbc
+                sudo ./tools/retry.sh apt-get update
+                sudo ./tools/retry.sh apt-get -y install unixodbc tdsodbc
                 ./tools/install_odbc_ini.sh
             fi
 

--- a/tools/retry.sh
+++ b/tools/retry.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+n=1
+max=5
+delay=3
+while true; do
+  "$@" && break || {
+    if [[ $n -lt $max ]]; then
+      ((n++))
+      echo "Command failed. Attempt $n/$max:"
+      sleep $delay;
+    else
+      echo "The command has failed after $n attempts."
+      exit 1
+    fi
+  }
+done


### PR DESCRIPTION
This PR addresses "apt-get sometimes fails, we have to retry".
Example of a failure https://app.circleci.com/pipelines/github/esl/MongooseIM/7176/workflows/721ea437-c95b-4eca-8b27-279e20b33333/jobs/104484

Proposed changes include:
* Retry apt-get