### PR TITLE
Module opts map for mod_adhoc

### DIFF
--- a/big_tests/tests/adhoc_SUITE.erl
+++ b/big_tests/tests/adhoc_SUITE.erl
@@ -34,7 +34,7 @@ all() ->
 
 groups() ->
     [{adhoc, [parallel], common_disco_cases() ++ hidden_disco_cases() ++ [ping]},
-         {disco_visible, [parallel], common_disco_cases() ++ visible_disco_cases()}].
+     {disco_visible, [parallel], common_disco_cases() ++ visible_disco_cases()}].
 
 common_disco_cases() ->
     [disco_info,
@@ -76,17 +76,18 @@ init_per_testcase(CaseName, Config) ->
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
-init_modules(disco_visible, Config) ->
+init_modules(GroupName, Config) ->
     Config1 = escalus:init_per_suite(dynamic_modules:save_modules(host_type(), Config)),
-    dynamic_modules:ensure_modules(host_type(), [{mod_adhoc, [{report_commands_node, true}]}]),
-    Config1;
-init_modules(_, Config) ->
-    Config.
+    dynamic_modules:ensure_modules(host_type(), [{mod_adhoc, adhoc_opts(GroupName)}]),
+    Config1.
 
-restore_modules(disco_visible, Config) ->
-    dynamic_modules:restore_modules(Config);
-restore_modules(_, _Config) ->
-    ok.
+restore_modules(_GroupName, Config) ->
+    dynamic_modules:restore_modules(Config).
+
+adhoc_opts(disco_visible) ->
+    #{iqdisc => one_queue, report_commands_node => true};
+adhoc_opts(_GroupName) ->
+    #{iqdisc => one_queue, report_commands_node => false}.
 
 %%--------------------------------------------------------------------
 %% Adhoc tests

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1575,23 +1575,24 @@ s2s_max_retry_delay(_Config) ->
 %% modules
 
 mod_adhoc(_Config) ->
-    check_iqdisc(mod_adhoc),
-    M = fun(K, V) -> modopts(mod_adhoc, [{K, V}]) end,
+    check_module_defaults(mod_adhoc),
+    check_iqdisc_map(mod_adhoc),
+    P = [modules, mod_adhoc],
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_adhoc">> => #{K => V}}} end,
     %% report_commands_node is boolean
-    ?cfgh(M(report_commands_node, true), T(<<"report_commands_node">>, true)),
-    ?cfgh(M(report_commands_node, false), T(<<"report_commands_node">>, false)),
+    ?cfgh(P ++ [report_commands_node], true, T(<<"report_commands_node">>, true)),
+    ?cfgh(P ++ [report_commands_node], false, T(<<"report_commands_node">>, false)),
     %% not boolean
     ?errh(T(<<"report_commands_node">>, <<"hello">>)).
 
 mod_auth_token(_Config) ->
+    check_module_defaults(mod_auth_token),
     check_iqdisc_map(mod_auth_token),
+    P = [modules, mod_auth_token, validity_period],
     T = fun(X) ->
                 Opts = #{<<"validity_period">> => X},
                 #{<<"modules">> => #{<<"mod_auth_token">> => Opts}}
         end,
-    check_module_defaults(mod_auth_token),
-    P = [modules, mod_auth_token, validity_period],
     ?cfgh(P ++ [access], #{unit => minutes, value => 13},
           T(#{<<"access">> => #{<<"value">> => 13, <<"unit">> => <<"minutes">>}})),
     ?cfgh(P ++ [refresh], #{unit => days, value => 31},
@@ -1692,13 +1693,13 @@ mod_disco(_Config) ->
     ?errh(T(<<"server_info">>, [maps:remove(<<"urls">>, Info)])).
 
 mod_extdisco(_Config) ->
+    check_module_defaults(mod_extdisco),
     check_iqdisc_map(mod_extdisco),
+    P = [modules, mod_extdisco, service],
     T = fun(Opts) -> #{<<"modules">> =>
                            #{<<"mod_extdisco">> =>
                                  #{<<"service">> => [Opts]}}}
         end,
-    check_module_defaults(mod_extdisco),
-    P = [modules, mod_extdisco, service],
     RequiredOpts = #{<<"type">> => <<"stun">>, <<"host">> => <<"stun1">>},
     Service = #{type => stun, host => <<"stun1">>},
     ?cfgh(P, [Service], T(RequiredOpts)),

--- a/test/config_parser_helper.erl
+++ b/test/config_parser_helper.erl
@@ -448,7 +448,7 @@ all_modules() ->
            {plugin_module, mod_event_pusher_push_plugin_defaults},
            {virtual_pubsub_hosts, [{fqdn, <<"host1">>}, {fqdn, <<"host2">>}]},
            {wpool, [{workers, 200}]}],
-      mod_adhoc => [{iqdisc, one_queue}, {report_commands_node, true}],
+      mod_adhoc => #{iqdisc => one_queue, report_commands_node => true},
       mod_mam_rdbms_arch_async => [{pm, []}],
       mod_keystore =>
           [{keys,
@@ -642,7 +642,8 @@ all_modules() ->
              {stale_h_repeat_after, 1800}]}]}.
 
 pgsql_modules() ->
-    #{mod_adhoc => [], mod_amp => [], mod_blocking => [], mod_bosh => [],
+    #{mod_adhoc => default_mod_config(mod_adhoc),
+      mod_amp => [], mod_blocking => [], mod_bosh => [],
       mod_carboncopy => [], mod_commands => [],
       mod_disco => [{users_can_see_hidden_services, false}],
       mod_last => [{backend, rdbms}],
@@ -750,6 +751,9 @@ pgsql_access() ->
       register => [#{acl => all, value => allow}],
       s2s_shaper => [#{acl => all, value => fast}]}.
 
+default_mod_config(mod_adhoc) ->
+    #{iqdisc => one_queue,
+      report_commands_node => false};
 default_mod_config(mod_auth_token) ->
     #{iqdisc => no_queue,
       validity_period => #{access => #{unit => hours, value => 1},


### PR DESCRIPTION
- [x] Put module options in a map
- [x] Set defaults in the config spec, verify docs
- [x] Update config parser tests
- [x] Update module tests

Also: require the tested module explicitly in big tests instead of relying on the initial state.
