### PR TITLE
Allow to customize auth module list per listener

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -89,6 +89,7 @@
 {suites, "tests", domain_removal_SUITE}.
 {suites, "tests", mam_send_message_SUITE}.
 {suites, "tests", dynamic_domains_SUITE}.
+{suites, "tests", auth_methods_for_c2s_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -131,6 +131,7 @@
 {suites, "tests", xep_0352_csi_SUITE}.
 
 {suites, "tests", domain_removal_SUITE}.
+{suites, "tests", auth_methods_for_c2s_SUITE}.
 
 {config, ["dynamic_domains.config", "test.config"]}.
 

--- a/big_tests/tests/auth_methods_for_c2s_SUITE.erl
+++ b/big_tests/tests/auth_methods_for_c2s_SUITE.erl
@@ -1,0 +1,82 @@
+-module(auth_methods_for_c2s_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+
+-import(distributed_helper, [mim/0, rpc/4]).
+
+all() ->
+    [{group, two_methods_enabled}].
+
+groups() ->
+    [{two_methods_enabled, [parallel],
+      [can_login_with_allowed_method,
+       cannot_login_with_not_allowed_method,
+       can_login_to_another_listener]}].
+
+init_per_suite(Config) ->
+    Config0 = escalus:init_per_suite(Config),
+    Config1 = ejabberd_node_utils:init(Config0),
+    ejabberd_node_utils:backup_config_file(Config1),
+    Config1.
+
+end_per_suite(Config) ->
+    ejabberd_node_utils:restore_config_file(Config),
+    ejabberd_node_utils:restart_application(mongooseim),
+    escalus:end_per_suite(Config).
+
+init_per_group(_, Config) ->
+    modify_config_and_restart(Config),
+    escalus_cleaner:start(Config).
+
+end_per_group(_, _Config) ->
+    escalus_fresh:clean().
+
+init_per_testcase(TC, Config) ->
+    Spec = escalus_fresh:freshen_spec(Config, alice),
+    Clean = register_internal_user(Spec),
+    [{clean_fn, Clean}, {spec, Spec}|escalus:init_per_testcase(TC, Config)].
+
+end_per_testcase(TC, Config) ->
+    Clean = proplists:get_value(clean_fn, Config),
+    Clean(),
+    escalus:end_per_testcase(TC, Config).
+
+modify_config_and_restart(Config) ->
+    NewConfigValues = [{auth_method, "internal]\n  [auth.dummy"},
+                       {auth_method_opts, false},
+                       {allowed_auth_methods, "\"internal\""}],
+    ejabberd_node_utils:modify_config_file(NewConfigValues, Config),
+    ejabberd_node_utils:restart_application(mongooseim).
+
+can_login_with_allowed_method(Config) ->
+    Spec = proplists:get_value(spec, Config),
+    {ok, _, _} = escalus_connection:start(Spec).
+
+cannot_login_with_not_allowed_method(Config) ->
+    Spec = proplists:get_value(spec, Config),
+    {error, _} = escalus_connection:start([{password, <<"wrong">>}|Spec]).
+
+can_login_to_another_listener(Config) ->
+    Spec = proplists:get_value(spec, Config),
+    Spec2 = [{port, ct:get_config({hosts, mim, c2s_tls_port})},
+             {password, <<"wrong">>}|Spec],
+    {ok, _, _} = escalus_connection:start(Spec2).
+
+%% Helpers
+
+%% If dummy backend is enabled, it is not possible to create new users
+%% (we check if an user does exist before registering the user).
+register_internal_user(Spec) ->
+    #{username := User, server := Server,
+      password := Password} = maps:from_list(Spec),
+    LUser = jid:nodeprep(User),
+    LServer = escalus_utils:jid_to_lower(Server),
+    HostType = domain_helper:host_type(),
+    rpc(mim(), ejabberd_auth_internal, try_register,
+        [HostType, LUser, LServer, Password]),
+    fun() -> rpc(mim(), ejabberd_auth_internal, remove_user,
+                 [HostType, LUser, LServer]) end.

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -130,6 +130,17 @@ The value of the access rule needs to be either the shaper name or the string `"
 
 Enables ZLIB support, the integer value is a limit for a decompressed output size in bytes (to prevent a successful [ZLIB bomb attack](https://xmpp.org/community/security-notices/uncontrolled-resource-consumption-with-highly-compressed-xmpp-stanzas.html)).
 
+### `listen.c2s.allowed_auth_methods`
+
+* **Syntax:** array of strings. Allowed values: `"internal"`, `"rdbms"`, `"external"`, `"anonymous"`, `"ldap"`, `"jwt"`, `"riak"`, `"http"`, `"pki"`, `"dummy"`
+* **Default:** not set
+* **Example:** `allowed_auth_methods = ["internal"]`
+
+A subset of enabled methods to login with for this listener.
+This option allows to enable only some backends.
+It is useful, if you want to have several listeners for different type of users (for example, some users use PKI while other users use LDAP auth).
+Same syntax as for `auth.methods` option.
+
 ## TLS options for C2S
 
 The following options allow enabling and configuring TLS which makes the client-to-server conenctions secure.

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -78,7 +78,8 @@
                 csi_buffer = [] :: [mongoose_acc:t()],
                 hibernate_after = 0 :: non_neg_integer(),
                 replaced_pids = [] :: [{MonitorRef :: reference(), ReplacedPid :: pid()}],
-                handlers = #{} :: #{ term() => {module(), atom(), term()} }
+                handlers = #{} :: #{ term() => {module(), atom(), term()} },
+                cred_opts :: mongoose_credentials:opts()
                 }).
 -type aux_key() :: atom().
 -type aux_value() :: any().

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -144,6 +144,9 @@
   {{#c2s_dhfile}}
   tls.dhfile = {{{c2s_dhfile}}}
   {{/c2s_dhfile}}
+  {{#allowed_auth_methods}}
+  allowed_auth_methods = [{{{allowed_auth_methods}}}]
+  {{/allowed_auth_methods}}
 {{#secondary_c2s}}
 
 {{{secondary_c2s}}}

--- a/src/auth/ejabberd_auth.erl
+++ b/src/auth/ejabberd_auth.erl
@@ -54,7 +54,8 @@
 
 -export([auth_modules/1,
          auth_methods/1,
-         auth_modules_for_host_type/1]).
+         auth_modules_for_host_type/1,
+         methods_to_modules/1]).
 
 %% Library functions for reuse in ejabberd_auth_* modules
 -export([authorize_with_check_password/2]).
@@ -413,6 +414,10 @@ auth_modules(LServer) ->
 -spec auth_modules_for_host_type(HostType :: mongooseim:host_type()) -> [authmodule()].
 auth_modules_for_host_type(HostType) ->
     Methods = auth_methods(HostType),
+    methods_to_modules(Methods).
+
+-spec methods_to_modules([atom()]) -> [authmodule()].
+methods_to_modules(Methods) ->
     [auth_method_to_module(M) || M <- Methods].
 
 -spec auth_methods(mongooseim:host_type()) -> [atom()].

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -310,6 +310,8 @@ xmpp_listener_items(<<"c2s">>) ->
                             validate = positive},
       <<"max_fsm_queue">> => #option{type = integer,
                                      validate = positive},
+      <<"allowed_auth_methods">> => #list{items = #option{type = atom,
+                                                          validate = {module, ejabberd_auth}}},
       <<"tls">> => c2s_tls()};
 xmpp_listener_items(<<"s2s">>) ->
     #{<<"shaper">> => #option{type = atom,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -344,8 +344,9 @@ stream_start_negotiate_features(#state{} = S) ->
     end.
 
 stream_start_features_before_auth(#state{server = Server,
-                                         host_type = HostType} = S) ->
-    Creds0 = mongoose_credentials:new(Server, HostType),
+                                         host_type = HostType,
+                                         cred_opts = CredOpts} = S) ->
+    Creds0 = mongoose_credentials:new(Server, HostType, CredOpts),
     Creds = maybe_add_cert(Creds0, S),
     SASLState = cyrsasl:server_new(<<"jabber">>, Server, HostType, <<>>, [], Creds),
     SockMod = (S#state.sockmod):get_sockmod(S#state.socket),

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -78,23 +78,26 @@
 -export_type([broadcast/0, packet/0, state/0]).
 
 -type packet() :: {jid:jid(), jid:jid(), exml:element()}.
+-type sock_data() :: term().
+-type start_result() :: {error, _}
+    | {ok, undefined | pid()}
+    | {ok, undefined | pid(), _}.
 
 %%%----------------------------------------------------------------------
 %%% API
 %%%----------------------------------------------------------------------
 
--spec start(_, list())
--> {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
+-spec start(sock_data(), ejabberd_listener:opts()) -> start_result().
 start(SockData, Opts) ->
     ?SUPERVISOR_START(SockData, Opts).
 
+-spec start_link(sock_data(), ejabberd_listener:opts()) -> start_result().
 start_link(SockData, Opts) ->
-    p1_fsm_old:start_link(
-      ejabberd_c2s, [SockData, Opts], ?FSMOPTS ++ fsm_limit_opts(Opts)).
+    p1_fsm_old:start_link(ejabberd_c2s, {SockData, Opts},
+                          ?FSMOPTS ++ fsm_limit_opts(Opts)).
 
 socket_type() ->
     xml_stream.
-
 
 %% @doc Return Username, Resource and presence information
 get_presence(FsmRef) ->
@@ -174,14 +177,9 @@ run_remote_hook_after(Delay, Pid, HandlerName, Args) ->
 %%% Callback functions from gen_fsm
 %%%----------------------------------------------------------------------
 
-%%----------------------------------------------------------------------
-%% Func: init/1
-%% Returns: {ok, StateName, StateData}          |
-%%          {ok, StateName, StateData, Timeout} |
-%%          ignore                              |
-%%          {stop, StopReason}
-%%----------------------------------------------------------------------
-init([{SockMod, Socket}, Opts]) ->
+-spec init({sock_data(), ejabberd_listener:opts()}) ->
+        {stop, normal} | {ok, wait_for_stream, state(), non_neg_integer()}.
+init({{SockMod, Socket}, Opts}) ->
     Access = case lists:keyfind(access, 1, Opts) of
                  {_, A} -> A;
                  _ -> all
@@ -238,6 +236,7 @@ init([{SockMod, Socket}, Opts]) ->
                 false -> Socket
             end,
             SocketMonitor = mongoose_transport:monitor(SockMod, Socket1),
+            CredOpts = mongoose_credentials:make_opts(Opts),
             {ok, wait_for_stream, #state{server         = ?MYNAME,
                                          socket         = Socket1,
                                          sockmod        = SockMod,
@@ -254,7 +253,8 @@ init([{SockMod, Socket}, Opts]) ->
                                          shaper         = Shaper,
                                          ip             = IP,
                                          lang           = ?MYLANG,
-                                         hibernate_after= HibernateAfter
+                                         hibernate_after= HibernateAfter,
+                                         cred_opts      = CredOpts
                                         },
              ?C2S_OPEN_TIMEOUT}
     end.

--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -38,6 +38,10 @@
 -export([format_error/1, socket_error/6]).
 
 -ignore_xref([start_link/0, init/1, start_listener/1, stop_listener/1]).
+-export_type([opts/0, mod/0]).
+
+-type opts() :: list().
+-type mod() :: module().
 
 -include("mongoose.hrl").
 

--- a/src/ejabberd_socket.erl
+++ b/src/ejabberd_socket.erl
@@ -66,8 +66,8 @@
 %% Function:
 %% Description:
 %%--------------------------------------------------------------------
--spec start(atom() | tuple(), ejabberd:sockmod(),
-            Socket :: port(), Opts :: [{atom(), _}]) -> ok.
+-spec start(ejabberd_listener:mod(), ejabberd:sockmod(),
+            Socket :: port(), Opts :: ejabberd_listener:opts()) -> ok.
 start(Module, SockMod, Socket, Opts) ->
     case Module:socket_type() of
         xml_stream ->
@@ -78,8 +78,8 @@ start(Module, SockMod, Socket, Opts) ->
             start_raw_stream(Module, SockMod, Socket, Opts)
     end.
 
--spec start_raw_stream(atom() | tuple(), ejabberd:sockmod(),
-                       Socket :: port(), Opts :: [{atom(), _}]) -> ok.
+-spec start_raw_stream(ejabberd_listener:mod(), ejabberd:sockmod(),
+                       Socket :: port(), Opts :: ejabberd_listener:opts()) -> ok.
 start_raw_stream(Module, SockMod, Socket, Opts) ->
     case Module:start({SockMod, Socket}, Opts) of
         {ok, Pid} ->

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -130,7 +130,7 @@ check_password(JID, Password) ->
     {LUser, LServer} = jid:to_lus(JID),
     case mongoose_domain_api:get_domain_host_type(LServer) of
         {ok, HostType} ->
-            Creds0 = mongoose_credentials:new(LServer, HostType),
+            Creds0 = mongoose_credentials:new(LServer, HostType, #{}),
             Creds1 = mongoose_credentials:set(Creds0, username, LUser),
             Creds2 = mongoose_credentials:set(Creds1, password, Password),
             case ejabberd_auth:authorize(Creds2) of

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -3,6 +3,7 @@
 -export([new/2,
          lserver/1,
          host_type/1,
+         auth_modules/1,
          get/2, get/3,
          set/3,
          extend/2,
@@ -10,7 +11,7 @@
 
 -export_type([t/0]).
 
--record(mongoose_credentials, {lserver, host_type, registry = [], extra = []}).
+-record(mongoose_credentials, {lserver, host_type, registry = [], extra = [], modules}).
 
 -type auth_event() :: any().
 
@@ -22,17 +23,23 @@
                            registry :: [{ejabberd_gen_auth:t(), auth_event()}],
                            %% These values are dependent on the ejabberd_auth backend in use.
                            %% Each backend may require different values to be present.
-                           extra :: [proplists:property()] }.
+                           extra :: [proplists:property()],
+                           modules :: [ejabberd_auth:authmodule()] }.
 
 -spec new(jid:lserver(), binary()) -> mongoose_credentials:t().
 new(LServer, HostType) when is_binary(LServer), is_binary(HostType) ->
-    #mongoose_credentials{lserver = LServer, host_type = HostType}.
+    Modules = ejabberd_auth:auth_modules_for_host_type(HostType),
+    #mongoose_credentials{lserver = LServer, host_type = HostType,
+                          modules = Modules}.
 
 -spec host_type(t()) -> mongooseim:host_type().
 host_type(#mongoose_credentials{host_type = HostType}) -> HostType.
 
 -spec lserver(t()) -> jid:lserver().
 lserver(#mongoose_credentials{lserver = S}) -> S.
+
+-spec auth_modules(t()) -> [ejabberd_auth:authmodule()].
+auth_modules(#mongoose_credentials{modules = Modules}) -> Modules.
 
 %% @doc Calls erlang:error/2 when Key is not found!
 -spec get(t(), Key) -> Value when

--- a/src/mongoose_credentials.erl
+++ b/src/mongoose_credentials.erl
@@ -1,6 +1,7 @@
 -module(mongoose_credentials).
 
--export([new/2,
+-export([make_opts/1,
+         new/2,
          lserver/1,
          host_type/1,
          auth_modules/1,
@@ -9,7 +10,7 @@
          extend/2,
          register/3]).
 
--export_type([t/0]).
+-export_type([t/0, opts/0]).
 
 -record(mongoose_credentials, {lserver, host_type, registry = [], extra = [], modules}).
 
@@ -25,6 +26,12 @@
                            %% Each backend may require different values to be present.
                            extra :: [proplists:property()],
                            modules :: [ejabberd_auth:authmodule()] }.
+
+-type opts() :: #{}.
+
+-spec make_opts(ejabberd_listener:opts()) -> opts().
+make_opts(Opts) ->
+    #{}.
 
 -spec new(jid:lserver(), binary()) -> mongoose_credentials:t().
 new(LServer, HostType) when is_binary(LServer), is_binary(HostType) ->

--- a/src/mongoose_listener_config.erl
+++ b/src/mongoose_listener_config.erl
@@ -53,7 +53,7 @@ verify_unique_listeners(Listeners) ->
     end.
 
 %% @doc Convert listener configuration to options that can be passed to listener modules
--spec prepare_opts(listener()) -> proplists:proplist().
+-spec prepare_opts(listener()) -> ejabberd_listener:opts().
 prepare_opts(Listener) ->
     lists:flatmap(fun prepare_opt/1, maps:to_list(Listener)).
 

--- a/src/mongoose_tcp_listener.erl
+++ b/src/mongoose_tcp_listener.erl
@@ -76,16 +76,16 @@ init({Id, Module, Opts, SockOpts, Port, IPS}) ->
 %%--------------------------------------------------------------------
 
 -spec start_accept_loop(Socket :: port(),
-                        Module :: atom(),
-                        Opts :: [any(), ...]) -> {ok, pid()}.
+                        Module :: ejabberd_listener:mod(),
+                        Opts :: ejabberd_listener:opts()) -> {ok, pid()}.
 start_accept_loop(ListenSock, Module, Opts) ->
     ProxyProtocol = proplists:get_value(proxy_protocol, Opts, false),
     Pid = proc_lib:spawn_link(?MODULE, accept_loop, [ListenSock, Module, Opts, ProxyProtocol]),
     {ok, Pid}.
 
 -spec accept_loop(Socket :: port(),
-                  Module :: atom(),
-                  Opts :: [any(), ...],
+                  Module :: ejabberd_listener:mod(),
+                  Opts :: ejabberd_listener:opts(),
                   ProxyProtocol :: boolean()) -> no_return().
 accept_loop(ListenSocket, Module, Opts, ProxyProtocol) ->
     case do_accept(ListenSocket, ProxyProtocol) of

--- a/test/auth_dummy_SUITE.erl
+++ b/test/auth_dummy_SUITE.erl
@@ -48,7 +48,7 @@ end_per_suite(_C) ->
 %%--------------------------------------------------------------------
 
 authorize(_Config) ->
-    Creds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
+    Creds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE, #{}),
     {ok, Creds2} = ejabberd_auth_dummy:authorize(Creds),
     ejabberd_auth_dummy = mongoose_credentials:get(Creds2, auth_module).
 
@@ -61,7 +61,7 @@ ejabberd_auth_interfaces(_Config) ->
                 fun(?DOMAIN) -> {ok, ?HOST_TYPE} end),
     meck:expect(mongoose_metrics, update, fun(_, _, _) -> ok end),
 
-    Creds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
+    Creds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE, #{}),
     {ok, Creds2} = ejabberd_auth:authorize(Creds),
     ejabberd_auth_dummy = mongoose_credentials:get(Creds2, auth_module),
 

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -231,7 +231,7 @@ cert_auth_nonexistent(Config) ->
 %%--------------------------------------------------------------------
 creds_with_cert(Config, Username) ->
     Cert = proplists:get_value(der_cert, Config),
-    NewCreds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
+    NewCreds = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE, #{}),
     mongoose_credentials:extend(NewCreds, [{der_cert, Cert},
                                            {username, Username}]).
 

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -45,10 +45,14 @@ suite() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(jid),
+    meck:new(ejabberd_auth, [no_link, passthrough]),
+    meck:expect(ejabberd_auth, auth_modules_for_host_type,
+                fun(_) -> [] end),
     Config.
 
 end_per_suite(Config) ->
     unset_auth_opts(),
+    meck:unload(ejabberd_auth),
     Config.
 
 init_per_group(public_key, Config) ->

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -96,7 +96,7 @@ check_password_fails_for_correct_token_but_wrong_username(_C) ->
                                              generate_token(hs256, 0, ?JWT_KEY)).
 
 authorize(_C) ->
-    Creds0 = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE),
+    Creds0 = mongoose_credentials:new(?DOMAIN, ?HOST_TYPE, #{}),
     Creds = mongoose_credentials:extend(Creds0, [{username, ?USERNAME},
                                                  {password, generate_token(hs256, 0, ?JWT_KEY)},
                                                  {digest, fake},

--- a/test/ejabberd_c2s_SUITE_mocks.erl
+++ b/test/ejabberd_c2s_SUITE_mocks.erl
@@ -28,8 +28,8 @@ setup() ->
     meck:expect(cyrsasl, server_start, fun(_, _, _, _) -> {ok, dummy_creds} end),
     meck:expect(cyrsasl, listmech, fun(_) -> [] end),
 
-    meck:new(mongoose_credentials),
-    meck:expect(mongoose_credentials, new, fun(_, _) -> ok end),
+    meck:new(mongoose_credentials, [passthrough]),
+    meck:expect(mongoose_credentials, new, fun(_, _, _) -> ok end),
     meck:expect(mongoose_credentials, get,
                 fun(dummy_creds, sasl_success_response, undefined) ->
                     undefined end),


### PR DESCRIPTION
This PR addresses "Allow to specify auth modules per a listener".

Proposed changes include:
* Calculate a list of auth modules once on creds initialization
* Added type for listener options
* Added a new option `allowed_auth_methods`