### PR TITLE
Build packages without using volumes

### DIFF
--- a/tools/pkg/build.sh
+++ b/tools/pkg/build.sh
@@ -81,7 +81,11 @@ docker build -t mongooseim-${platform}:${version}-${revision} \
     -f ${dockerfile_path} \
     $context_path
 
+docker rm -f mongooseim-pkg-container &>/dev/null || echo "ok"
+
 # Run ready docker image with tested mongooseim package and move it to
 # built packages directory
-docker run --rm -v "${built_packages_directory}:/built_packages" \
-    "mongooseim-${platform}:${version}-${revision}"
+docker run --name=mongooseim-pkg-container "mongooseim-${platform}:${version}-${revision}"
+# Dot is like /*, but for docker.
+# Moves all files in the directory.
+docker cp "mongooseim-pkg-container:/built_packages/." "${built_packages_directory}/"


### PR DESCRIPTION
This PR addresses "podman support". Also useful if you build on a remote machine.

Proposed changes include:
* Use copy to extract a built package, instead of volumes.