### PR TITLE
Support maps in gen_mod_deps

### DIFF
--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -55,11 +55,11 @@ push_event(Acc, Host, Event) ->
 %% gen_mod API
 %%--------------------------------------------------------------------
 
--spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(_Host, Opts) ->
     Backends = get_backends(Opts),
     BackendDeps = [{B, DepOpts, hard} || {B, DepOpts} <- Backends],
-    [{mod_event_pusher_hook_translator, hard} | BackendDeps].
+    [{mod_event_pusher_hook_translator, [], hard} | BackendDeps].
 
 -spec start(Host :: jid:server(), Opts :: proplists:proplist()) -> any().
 start(Host, Opts) ->

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -26,21 +26,7 @@
 -module(gen_mod).
 -author('alexey@process-one.net').
 
--type dep_arguments() :: proplists:proplist().
--type deps_list() :: [
-                      {module(), dep_arguments(), gen_mod_deps:hardness()} |
-                      {module(), gen_mod_deps:hardness()} |
-                      {service, mongoose_service:service()}
-                     ].
-
--type module_deps_list() :: [
-                              {module(), dep_arguments(), gen_mod_deps:hardness()} |
-                              {module(), gen_mod_deps:hardness()}
-                             ].
-
--type service_deps_list() :: [atom()].
-
--export_type([deps_list/0, opt_key/0, opt_value/0, module_opts/0]).
+-export_type([opt_key/0, opt_value/0, module_opts/0]).
 
 -export([
          % Modules start & stop, do NOT use in the tests, use mongoose_modules API instead
@@ -109,7 +95,7 @@
 %% TODO: think about getting rid of HostType param for deps/2 interface, currently
 %% it's used only by global_distrib modules (see mod_global_distrib_utils:deps/4
 %% function).
--callback deps(HostType :: host_type(), Opts :: proplists:list()) -> deps_list().
+-callback deps(host_type(), module_opts()) -> gen_mod_deps:deps().
 
 -optional_callbacks([config_spec/0, supported_features/0, deps/2]).
 
@@ -399,8 +385,7 @@ assert_loaded(HostType, Module) ->
 is_loaded(HostType, Module) ->
     maps:is_key(Module, loaded_modules_with_opts(HostType)).
 
--spec get_deps(HostType :: host_type(), Module :: module(),
-               Opts :: proplists:proplist()) -> module_deps_list().
+-spec get_deps(host_type(), module(), module_opts()) -> gen_mod_deps:module_deps().
 get_deps(HostType, Module, Opts) ->
     %% the module has to be loaded,
     %% otherwise the erlang:function_exported/3 returns false
@@ -413,8 +398,7 @@ get_deps(HostType, Module, Opts) ->
             []
     end.
 
--spec get_required_services(host_type(), module(), proplists:proplist()) ->
-    service_deps_list().
+-spec get_required_services(host_type(), module(), module_opts()) -> [mongoose_service:service()].
 get_required_services(HostType, Module, Options) ->
     %% the module has to be loaded,
     %% otherwise the erlang:function_exported/3 returns false

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -38,7 +38,7 @@
 %% See "gen_mod logic" block below in this file
 %%--------------------------------------------------------------------
 
--spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(Host, Opts) ->
     mod_global_distrib_utils:deps(?MODULE, Host, Opts, fun deps/1).
 
@@ -306,7 +306,7 @@ get_bound_connection(Server, GDID, Pid) when is_pid(Pid) ->
 %% gen_mod logic
 %%--------------------------------------------------------------------
 
--spec deps(Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(Opts) ->
     ConnectionsOpts =
         lists:ukeysort(1, proplists:get_value(connections, Opts, []) ++ default_conn_opts()),

--- a/src/global_distrib/mod_global_distrib_hosts_refresher.erl
+++ b/src/global_distrib/mod_global_distrib_hosts_refresher.erl
@@ -72,7 +72,7 @@ start(Host, Opts0) ->
 stop(Host) ->
     mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
 
--spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(Host, Opts) ->
     mod_global_distrib_utils:deps(?MODULE, Host, Opts, fun deps/1).
 
@@ -127,7 +127,7 @@ code_change(_, State, _) -> {ok, State}.
 %%--------------------------------------------------------------------
 
 
--spec deps(Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(Opts) ->
     [{mod_global_distrib_mapping, Opts, hard}].
 

--- a/src/global_distrib/mod_global_distrib_mapping.erl
+++ b/src/global_distrib/mod_global_distrib_mapping.erl
@@ -174,7 +174,7 @@ start(Host, Opts0) ->
 stop(Host) ->
     mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
 
--spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(Host, Opts) ->
     mod_global_distrib_utils:deps(?MODULE, Host, Opts, fun deps/1).
 
@@ -229,9 +229,9 @@ unregister_subhost(_, SubHost) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
--spec deps(proplists:proplist()) -> gen_mod:deps_list().
+-spec deps(proplists:proplist()) -> gen_mod_deps:deps().
 deps(_Opts) ->
-    [{mod_global_distrib_receiver, hard}].
+    [{mod_global_distrib_receiver, [], hard}].
 
 -spec start() -> any().
 start() ->

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -87,8 +87,8 @@ stop(Module, Host, StopFun) ->
     end.
 
 -spec deps(module(), Host :: jid:lserver(), Opts :: proplists:proplist(),
-           DepsFun :: fun((proplists:proplist()) -> gen_mod:deps_list())) ->
-                           gen_mod:deps_list().
+           DepsFun :: fun((proplists:proplist()) -> gen_mod_deps:deps())) ->
+                           gen_mod_deps:deps().
 deps(_Module, Host, Opts, DepsFun) ->
     {global_host, GlobalHostList} = lists:keyfind(global_host, 1, Opts),
     case unicode:characters_to_binary(GlobalHostList) of

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -83,7 +83,7 @@ process_entry(#{remote_jid := RemJID,
 %%--------------------------------------------------------------------
 %% gen_mod callbacks
 %%--------------------------------------------------------------------
--spec deps(jid:lserver(), list()) -> gen_mod:deps_list().
+-spec deps(jid:lserver(), list()) -> gen_mod_deps:deps().
 deps(_Host, Opts) ->
     Groupchats = gen_mod:get_opt(groupchat, Opts),
     muclight_dep(Groupchats) ++ muc_dep(Groupchats).
@@ -536,13 +536,13 @@ config_metrics(HostType) ->
 
 muclight_dep(List) ->
     case lists:member(muclight, List) of
-        true -> [{mod_muc_light, hard}];
+        true -> [{mod_muc_light, [], hard}];
         false -> []
     end.
 
 muc_dep(List) ->
     case lists:member(muc, List) of
-        true -> [{mod_muc, hard}];
+        true -> [{mod_muc, [], hard}];
         false -> []
     end.
 

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -110,8 +110,7 @@ riak_config_spec() ->
        wrap = none
       }.
 
--spec deps(_Host :: jid:server(), Opts :: proplists:proplist()) ->
-                  gen_mod:deps_list().
+-spec deps(_Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
 deps(_Host, Opts0) ->
     Opts = normalize(Opts0),
 

--- a/src/mongoose_modules.erl
+++ b/src/mongoose_modules.erl
@@ -10,8 +10,8 @@
 -ignore_xref([replace_modules/3, ensure_stopped/2, ensure_started/3]).
 
 -type module_opts() :: gen_mod:module_opts().
--type module_map() :: #{module() => gen_mod:module_opts()}.
--type module_list() :: [{module(), gen_mod:module_opts()}].
+-type module_map() :: gen_mod_deps:module_map().
+-type module_list() :: gen_mod_deps:module_list().
 
 %% @doc Start all configured modules in the dependency order.
 -spec start() -> 'ok'.

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -188,7 +188,7 @@ stop(HostType) ->
     mod_muc_light_db_backend:stop(HostType),
     ok.
 
--spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod:deps_list().
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
 deps(_HostType, Opts) ->
     case gen_mod:get_opt(cache_affs, Opts, undefined) of
         undefined ->

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -60,9 +60,9 @@
 supported_features() ->
     [dynamic_domains].
 
--spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod:deps_list().
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
 deps(_,_)->
-    [{mod_smart_markers, hard}].
+    [{mod_smart_markers, [], hard}].
 
 start(HostType, Opts) ->
     mod_offline_chatmarkers_backend:init(HostType, add_default_backend(Opts)),

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -252,7 +252,7 @@ start_link(Host, Opts) ->
     gen_server:start_link({local, Proc}, ?MODULE, [Host, Opts], []).
 
 deps(_Host, _Opts) ->
-    [{mod_caps, optional}].
+    [{mod_caps, [], optional}].
 
 start(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),

--- a/test/gen_mod_deps_SUITE.erl
+++ b/test/gen_mod_deps_SUITE.erl
@@ -14,12 +14,12 @@ all() ->
      fails_on_dependency_cycle,
      succeeds_on_cycle_with_soft_dep_in_path,
      succeeds_on_adding_soft_dependency_cycle_edge,
-     forces_dependency_args,
-     appends_dependencies_args,
+     forces_dependency_opts,
+     appends_dependencies_opts,
      optional_dependencies_are_not_started_by_themselves,
-     optional_dependencies_add_arguments,
-     overrides_dependency_args,
-     merges_dependency_args
+     optional_dependencies_add_opts,
+     overrides_dependency_opts,
+     merges_dependency_opts
     ].
 
 %% Fixtures
@@ -34,64 +34,67 @@ end_per_testcase(_, _C) ->
 %% Tests
 
 no_dependencies(_Config) ->
-    Modules = #{mod_a => [], mod_b => []},
+    Modules = #{mod_a => #{}, mod_b => #{}},
     ?assertEqual(Modules, maps:from_list(add_deps(Modules))).
 
 dependency(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}]}),
-    ?assertMatch([{mod_b, _}, {mod_a, _}], add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, hard}]}),
+    ?assertMatch([{mod_b, _}, {mod_a, _}], add_deps(#{mod_a => #{}})).
 
 dependency_chain(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}], mod_b => [{mod_c, hard}]}),
-    ?assertMatch([{mod_c, _}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, hard}], mod_b => [{mod_c, #{}, hard}]}),
+    ?assertMatch([{mod_c, _}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => #{}})).
 
 dependency_dag(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, hard}],
-               mod_b => [{mod_c, hard}]}),
-    ?assertMatch([{mod_c, _}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, hard}, {mod_c, #{}, hard}],
+               mod_b => [{mod_c, #{}, hard}]}),
+    ?assertMatch([{mod_c, _}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => #{}})).
 
 fails_on_dependency_cycle(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}],
-               mod_b => [{mod_c, hard}],
-               mod_c => [{mod_a, hard}]}),
-    ?assertError(_, add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, hard}],
+               mod_b => [{mod_c, #{}, hard}],
+               mod_c => [{mod_a, #{}, hard}]}),
+    ?assertError(_, add_deps(#{mod_a => #{}})).
 
 succeeds_on_cycle_with_soft_dep_in_path(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}],
-               mod_b => [{mod_c, soft}],
-               mod_c => [{mod_a, hard}]}),
-    ?assertMatch([{mod_b, _}, {mod_a, _}, {mod_c, _}], add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, hard}],
+               mod_b => [{mod_c, #{}, soft}],
+               mod_c => [{mod_a, #{}, hard}]}),
+    ?assertMatch([{mod_b, _}, {mod_a, _}, {mod_c, _}], add_deps(#{mod_a => #{}})).
 
 succeeds_on_adding_soft_dependency_cycle_edge(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}], mod_b => [{mod_a, soft}]}),
-    ?assertMatch([{mod_b, _}, {mod_a, _}], add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, hard}], mod_b => [{mod_a, #{}, soft}]}),
+    ?assertMatch([{mod_b, _}, {mod_a, _}], add_deps(#{mod_a => #{}})).
 
-forces_dependency_args(_Config) ->
-    set_deps(#{mod_a => [{mod_b, [arg1, arg2], hard}]}),
-    ?assertEqual([{mod_b, [arg1, arg2]}, {mod_a, []}], add_deps(#{mod_a => []})).
+forces_dependency_opts(_Config) ->
+    set_deps(#{mod_a => [{mod_b, #{opt1 => 1, opt2 => 2}, hard}]}),
+    ?assertEqual([{mod_b, #{opt1 => 1, opt2 => 2}}, {mod_a, #{}}], add_deps(#{mod_a => #{}})).
 
-appends_dependencies_args(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, [arg1], hard}],
-               mod_b => [{mod_c, [arg2], hard}]}),
-    ?assertEqual([{mod_c, [arg1, arg2]}, {mod_b, []}, {mod_a, []}], add_deps(#{mod_a => []})).
+appends_dependencies_opts(_Config) ->
+    set_deps(#{mod_a => [{mod_b, #{}, hard}, {mod_c, #{opt1 => 1}, hard}],
+               mod_b => [{mod_c, #{opt2 => 2}, hard}]}),
+    ?assertEqual([{mod_c, #{opt1 => 1, opt2 => 2}}, {mod_b, #{}}, {mod_a, #{}}],
+                 add_deps(#{mod_a => #{}})).
 
 optional_dependencies_are_not_started_by_themselves(_Config) ->
-    set_deps(#{mod_a => [{mod_b, optional}]}),
-    ?assertMatch([{mod_a, _}], add_deps(#{mod_a => []})).
+    set_deps(#{mod_a => [{mod_b, #{}, optional}]}),
+    ?assertMatch([{mod_a, _}], add_deps(#{mod_a => #{}})).
 
-optional_dependencies_add_arguments(_Config) ->
-    set_deps(#{mod_a => [{mod_b, [arg1], optional}], mod_c => [{mod_b, hard}]}),
-    ?assertMatch([{mod_b, [arg1]}, {mod_a, _}, {mod_c, _}], add_deps(#{mod_a => [], mod_c => []})).
+optional_dependencies_add_opts(_Config) ->
+    set_deps(#{mod_a => [{mod_b, #{opt1 => 1}, optional}], mod_c => [{mod_b, #{}, hard}]}),
+    ?assertMatch([{mod_b, #{opt1 := 1}}, {mod_a, _}, {mod_c, _}],
+                 add_deps(#{mod_a => #{}, mod_c => #{}})).
 
-overrides_dependency_args(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, [{arg, a}], hard}],
-               mod_b => [{mod_c, [{arg, b}], hard}]}),
-    ?assertMatch([{mod_c, [{arg, a}]}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => []})).
+overrides_dependency_opts(_Config) ->
+    set_deps(#{mod_a => [{mod_b, #{}, hard}, {mod_c, #{opt1 => 2}, hard}],
+               mod_b => [{mod_c, #{opt1 => 1}, hard}]}),
+    ?assertMatch([{mod_c, #{opt1 := 2}}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => #{}})).
 
-merges_dependency_args(_Config) ->
-    set_deps(#{mod_a => [{mod_b, hard}, {mod_c, [{arg, a}], hard}],
-               mod_b => [{mod_c, [{arg, a}, arg2], hard}]}),
-    ?assertMatch([{mod_c, [{arg, a}, arg2]}, {mod_b, _}, {mod_a, _}], add_deps(#{mod_a => []})).
+merges_dependency_opts(_Config) ->
+    set_deps(#{mod_a => [{mod_b, #{}, hard}, {mod_c, #{opt1 => 1}, hard}],
+               mod_b => [{mod_c, #{opt1 => 1, opt2 => 2}, hard}]}),
+    ?assertMatch([{mod_c, #{opt1 := 1, opt2 := 2}}, {mod_b, _}, {mod_a, _}],
+                 add_deps(#{mod_a => #{}})).
 
 %% Helpers
 


### PR DESCRIPTION
Prepare module deps for module opts in maps - now modules using maps can be deps of other modules.
- Update dependency processing and resolution.
- Update dependency format - options are mandatory as both `[]` and `#{}` are possible now. This does not seem to be worse in any way, so I think it is a permanent change.
- Update type specs, improve type reuse.
- Update small tests to check the opts in maps. The transitional phase should be short and I see no reason to keep both formats in tests - it would be complicated.

Minor changes:
- Use host types.
- Call module options `opts`, not `args` or `params`.

