### PR TITLE
MAM config in maps

### DIFF
--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -988,12 +988,10 @@ required_modules(_) ->
     [].
 
 mam_modules(on) ->
-    [{mod_mam_rdbms_user, [pm]},
-     {mod_mam_rdbms_prefs, [pm]},
-     {mod_mam_rdbms_arch, []},
-     {mod_mam, []}];
+    [{mod_mam_meta, mam_helper:config_opts(#{pm => #{},
+                                             async_writer => #{enabled => false}})}];
 mam_modules(off) ->
-    [{mod_mam, stopped}].
+    [{mod_mam_meta, stopped}].
 
 offline_modules(on) ->
     [{mod_offline, [{access_max_user_messages, max_user_offline_messages}]}];

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -83,10 +83,10 @@ group_to_modules(auth_removal) ->
     [];
 group_to_modules(cache_removal) ->
     [{mod_cache_users, []},
-     {mod_mam_meta, [{backend, rdbms}, {pm, []}]}];
+     {mod_mam_meta, mam_helper:config_opts(#{pm => #{}})}];
 group_to_modules(mam_removal) ->
     MucHost = subhost_pattern(muc_light_helper:muc_host_pattern()),
-    [{mod_mam_meta, [{backend, rdbms}, {pm, []}, {muc, [{host, MucHost}]}]},
+    [{mod_mam_meta, mam_helper:config_opts(#{pm => #{}, muc => #{host => MucHost}})},
      {mod_muc_light, [{backend, rdbms}, {host, MucHost}]}];
 group_to_modules(muc_light_removal) ->
     MucHost = subhost_pattern(muc_light_helper:muc_host_pattern()),

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -115,8 +115,28 @@
          generate_msg_for_date_user/3,
          generate_msg_for_date_user/4,
          random_text/0,
-         put_msg/1
+         put_msg/1,
+         config_opts/1
         ]).
+
+-import(config_parser_helper, [config/2, mod_config/2]).
+
+config_opts(ExtraOpts) ->
+    lists:foldl(fun(Step, OptsIn) -> set_opts(Step, OptsIn) end,
+                ExtraOpts, [defaults, backend, pm, muc, async_writer]).
+
+set_opts(defaults, Opts) ->
+    mod_config(mod_mam_meta, Opts);
+set_opts(backend, #{backend := riak} = Opts) ->
+    Opts#{riak => config([modules, mod_mam_meta, riak], maps:get(riak, Opts, #{}))};
+set_opts(pm, #{pm := PMExtra} = Opts) ->
+    Opts#{pm := config([modules, mod_mam_meta, pm], PMExtra)};
+set_opts(muc, #{muc := MUCExtra} = Opts) ->
+    Opts#{muc := config([modules, mod_mam_meta, muc], MUCExtra)};
+set_opts(async_writer, #{async_writer := AsyncExtra} = Opts) ->
+    Opts#{async_writer := config([modules, mod_mam_meta, async_writer], AsyncExtra)};
+set_opts(_, Opts) ->
+    Opts.
 
 rpc_apply(M, F, Args) ->
     case rpc_call(M, F, Args) of
@@ -1012,7 +1032,7 @@ nick_to_jid(UserName, Config) when is_atom(UserName) ->
 make_jid(U, S, R) ->
     mongoose_helper:make_jid(U, S, R).
 
--spec backend() -> rdbms | riak | cassandra | false.
+-spec backend() -> rdbms | riak | cassandra | disabled.
 backend() ->
     Funs = [fun maybe_rdbms/1, fun maybe_riak/1, fun maybe_cassandra/1],
     determine_backend(host(), Funs).

--- a/big_tests/tests/mam_send_message_SUITE.erl
+++ b/big_tests/tests/mam_send_message_SUITE.erl
@@ -76,8 +76,9 @@ end_per_group(_Groupname, Config) ->
 
 group_to_modules(send_message) ->
     MH = subhost_pattern(muc_light_helper:muc_host_pattern()),
-    [{mod_mam_meta, [{backend, rdbms}, {pm, []}, {muc, [{host, MH}]},
-                     {send_message, mam_send_message_example}]},
+    [{mod_mam_meta, mam_helper:config_opts(#{pm => #{},
+                                             muc => #{host => MH},
+                                             send_message => mam_send_message_example})},
      {mod_muc_light, [{host, subhost_pattern(muc_light_helper:muc_host_pattern())},
                       {backend, mongoose_helper:mnesia_or_rdbms_backend()}]},
      {mam_send_message_example, []}].

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -101,13 +101,14 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    Config1 = rest_helper:maybe_enable_mam(mam_helper:backend(), host_type(), Config),
-    Config2 = ejabberd_node_utils:init(Config1),
-    escalus:init_per_suite(Config2).
+    Config1 = dynamic_modules:save_modules(host_type(), Config),
+    Config2 = rest_helper:maybe_enable_mam(mam_helper:backend(), host_type(), Config1),
+    Config3 = ejabberd_node_utils:init(Config2),
+    escalus:init_per_suite(Config3).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    rest_helper:maybe_disable_mam(mam_helper:backend(), host_type()),
+    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(auth, Config) ->

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -21,7 +21,6 @@
     simple_request/3,
     simple_request/4,
     maybe_enable_mam/3,
-    maybe_disable_mam/2,
     maybe_skip_mam_test_cases/3,
     fill_archive/2,
     fill_room_archive/3,
@@ -326,48 +325,21 @@ to_list(V) when is_list(V) ->
     V.
 
 maybe_enable_mam(rdbms, HostType, Config) ->
-    maybe_disable_mam(rdbms, HostType),
-    MucPattern = subhost_pattern(muc_light_helper:muc_host_pattern()),
-    init_module(HostType, mod_mam_rdbms_arch, []),
-    init_module(HostType, mod_mam_muc_rdbms_arch, []),
-    init_module(HostType, mod_mam_rdbms_prefs, [muc, pm]),
-    init_module(HostType, mod_mam_rdbms_user, [muc, pm]),
-    init_module(HostType, mod_mam, [{archive_chat_markers, true}]),
-    init_module(HostType, mod_mam_muc, [{host, MucPattern},
-                                    {archive_chat_markers, true}]),
+    dynamic_modules:ensure_modules(HostType, required_mam_modules(rdbms)),
     [{mam_backend, rdbms} | Config];
-maybe_enable_mam(riak, HostType,  Config) ->
-    maybe_disable_mam(riak, HostType),
-    MucPattern = subhost_pattern(muc_light_helper:muc_host_pattern()),
-    init_module(HostType, mod_mam_riak_timed_arch_yz, [pm, muc]),
-    init_module(HostType, mod_mam_mnesia_prefs, [pm, muc]),
-    init_module(HostType, mod_mam, [{archive_chat_markers, true}]),
-    init_module(HostType, mod_mam_muc, [{host, MucPattern},
-                                    {archive_chat_markers, true}]),
+maybe_enable_mam(riak, HostType, Config) ->
+    dynamic_modules:ensure_modules(HostType, required_mam_modules(riak)),
     [{mam_backend, riak}, {archive_wait, 2500} | Config];
 maybe_enable_mam(_, _, C) ->
     [{mam_backend, disabled} | C].
 
-init_module(HostType, Mod, Opts) ->
-    dynamic_modules:start(HostType, Mod, Opts).
-
-maybe_disable_mam(rdbms, HostType) ->
-    stop_module(HostType, mod_mam_muc_rdbms_arch),
-    stop_module(HostType, mod_mam_rdbms_arch),
-    stop_module(HostType, mod_mam_rdbms_prefs),
-    stop_module(HostType, mod_mam_rdbms_user),
-    stop_module(HostType, mod_mam),
-    stop_module(HostType, mod_mam_muc);
-maybe_disable_mam(riak, HostType) ->
-    stop_module(HostType, mod_mam_riak_timed_arch_yz),
-    stop_module(HostType, mod_mam_mnesia_prefs),
-    stop_module(HostType, mod_mam),
-    stop_module(HostType, mod_mam_muc);
-maybe_disable_mam(_, _) ->
-    ok.
-
-stop_module(Host, Mod) ->
-    dynamic_modules:stop(Host, Mod).
+required_mam_modules(Backend) ->
+    MucPattern = subhost_pattern(muc_light_helper:muc_host_pattern()),
+    [{mod_mam_meta, mam_helper:config_opts(#{backend => Backend,
+                                             pm => #{},
+                                             muc => #{host => MucPattern},
+                                             async_writer => #{enabled => false},
+                                             archive_chat_markers => true})}].
 
 maybe_skip_mam_test_cases(CaseName, CasesRequireingMAM, Config) ->
     case lists:member(CaseName, CasesRequireingMAM) of

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -273,7 +273,7 @@ end_per_testcase(TestcaseName, Config) ->
 init_per_testcase2(TestcaseName, Config)
     when TestcaseName =:= rest_delete_domain_cleans_data_from_mam ->
     HostType = dummy_auth_host_type(),
-    Mods = [{mod_mam_meta, [{backend, rdbms}, {pm, []}]}],
+    Mods = [{mod_mam_meta, mam_helper:config_opts(#{pm => #{}})}],
     dynamic_modules:ensure_modules(HostType, Mods),
     escalus:init_per_testcase(TestcaseName, Config);
 init_per_testcase2(_, Config) ->

--- a/doc/migrations/5.0.0_5.1.0.md
+++ b/doc/migrations/5.0.0_5.1.0.md
@@ -27,6 +27,7 @@ The rules for overriding global options in the `host_config` section have been s
 ### Extension modules
 
 * `mod_auth_token` has a new configuration format - if you are using this module, amend the [`validity_period`](../modules/mod_auth_token.md#modulesmod_auth_tokenvalidity_period) option.
+* `mod_mam_meta` does not have the `rdbms_message_format` and `simple` options anymore. Use [`db_jid_format`](../modules/mod_mam.md#modulesmod_mam_metadb_jid_format) and [`db_message_format`](../modules/mod_mam.md#modulesmod_mam_metadb_message_format) instead.
 
 ## Async workers
 

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -190,7 +190,7 @@ The MUC host that will be archived if MUC archiving is enabled.
 #### Example
 
 The example below presents how to override common option for `muc` module specifically.
-Please note that you can override all common options in similar way.
+Please note that you can override all common options (except `cache`) in a similar way.
 
 ```toml
 [modules.mod_mam_meta]
@@ -224,17 +224,6 @@ modules.mod_mam_meta.cache.number_of_segments
 * **Example:** `modules.mod_mam_meta.cache.module = "mod_cache_users"`
 
 Configures which cache to use, either start an internal instance, or reuse the cache created by `mod_cache_users`, if such module was enabled. Note that if reuse is desired – that is, `cache.module = "mod_cache_users"`, other cache configuration parameters are not allowed.
-
-#### `modules.mod_mam_meta.rdbms_message_format`
-* **Syntax:** string, one of `"internal"` and `"simple"`
-* **Default:** `"internal"`
-* **Example:** `modules.mod_mam_meta.rdbms_message_format = "simple"`
-
-!!! Warning
-    Archive MUST be empty to change this option
-
-When set to `simple`, stores messages in XML and full JIDs.
-When set to `internal`, stores messages and JIDs in internal format.
 
 #### `modules.mod_mam_meta.async_writer.enabled`
 * **Syntax:** boolean
@@ -366,32 +355,24 @@ This sets the maximum page size of returned results.
 #### `modules.mod_mam_meta.db_jid_format`
 
 * **Syntax:** string, one of `"mam_jid_rfc"`, `"mam_jid_mini"` or a module implementing `mam_jid` behaviour
-* **Default:** `"mam_jid_rfc"` for `mod_mam_muc_rdbms_arch`, `"mam_jid_mini"` for `mod_mam_rdbms_arch`
+* **Default:** `"mam_jid_rfc"` for MUC archive, `"mam_jid_mini"` for PM archive
 * **Example:** `modules.mod_mam_meta.db_jid_format = "mam_jid_mini"`
 
 Sets the internal MAM jid encoder/decoder module for RDBMS.
-It is set to `"mam_jid_rfc"` when [`rdbms_message_format`](#modulesmod_mam_metardbms_message_format) is set to `"simple"`.
+
+!!! Warning
+    Archive MUST be empty to change this option
 
 #### `modules.mod_mam_meta.db_message_format`
 
 * **Syntax:** string, one of `"mam_message_xml"`, `"mam_message_eterm"`, `"mam_message_compressed_eterm"` or a module implementing `mam_message` behaviour
-* **Default:** different values for different backends, described below.
+* **Default:** `"mam_message_compressed_eterm"` for RDBMS, `"mam_message_xml"` for Riak and Cassandra
 * **Example:** `modules.mod_mam_meta.db_message_format = "mam_message_compressed_eterm"`
 
 Sets the internal MAM message encoder/decoder module.
-Default values for:
 
-* RDBMS: `"mam_message_compressed_eterm"` by default, and `"mam_message_xml"` when [`rdbms_message_format`](#modulesmod_mam_metardbms_message_format) is set to `"simple"`
-* Riak: `"mam_message_xml"`
-* Cassandra: `"mam_message_compressed_eterm"`  by default, and `"mam_message_xml"` when [`simple`](#modulesmod_mam_metasimple) is set to `true`
-
-#### `modules.mod_mam_meta.simple`
-
-* **Syntax:** boolean
-* **Default:** `false`
-* **Example:** `modules.mod_mam_meta.simple = true`
-
-Sets `db_message_format` to `"mam_message_xml"` for Cassandra.
+!!! Warning
+    Archive MUST be empty to change this option
 
 #### `modules.mod_mam_meta.extra_fin_element`
 
@@ -420,7 +401,7 @@ This module can be used to add extra lookup parameters to MAM lookup queries.
   pm.user_prefs_store = "rdbms"
 
   muc.host = "muc.example.com"
-  muc.rdbms_message_format = "simple"
+  muc.db_message_format = "mam_message_xml"
   muc.async_writer.enabled = false
   muc.user_prefs_store = "mnesia"
 

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -536,7 +536,7 @@ handle_package(Dir, ReturnMessID,
     end.
 
 should_archive_if_groupchat(HostType, <<"groupchat">>) ->
-    gen_mod:get_module_opt(HostType, ?MODULE, archive_groupchats, false);
+    gen_mod:get_module_opt(HostType, ?MODULE, archive_groupchats);
 should_archive_if_groupchat(_, _) ->
     true.
 
@@ -549,7 +549,7 @@ return_external_message_id_if_ok(_, _, _MessID) -> undefined.
 return_acc_with_mam_id_if_configured(undefined, _, Acc) ->
     Acc;
 return_acc_with_mam_id_if_configured(ExtMessId, HostType, Acc) ->
-    case gen_mod:get_module_opt(HostType, ?MODULE, same_mam_id_for_peers, false) of
+    case gen_mod:get_module_opt(HostType, ?MODULE, same_mam_id_for_peers) of
         false -> mongoose_acc:set(mam, mam_id, ExtMessId, Acc);
         true -> mongoose_acc:set_permanent(mam, mam_id, ExtMessId, Acc)
     end.
@@ -713,9 +713,9 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver=LServer, luser=LUser}, IQ) 
                             Dir :: incoming | outgoing,
                             Packet :: exml:element()) -> boolean().
 is_archivable_message(HostType, Dir, Packet) ->
-    {M, F} = mod_mam_params:is_archivable_message_fun(?MODULE, HostType),
+    M = mod_mam_params:is_archivable_message_module(?MODULE, HostType),
     ArchiveChatMarkers = mod_mam_params:archive_chat_markers(?MODULE, HostType),
-    erlang:apply(M, F, [?MODULE, Dir, Packet, ArchiveChatMarkers]).
+    erlang:apply(M, is_archivable_message, [?MODULE, Dir, Packet, ArchiveChatMarkers]).
 
 config_metrics(HostType) ->
     OptsToReport = [{backend, rdbms}], %list of tuples {option, default_value}

--- a/src/mam/mod_mam_cache_user.erl
+++ b/src/mam/mod_mam_cache_user.erl
@@ -29,8 +29,8 @@
 %%====================================================================
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
-start(HostType, Opts) ->
-    start_cache(HostType, Opts),
+start(HostType, Opts = #{cache := CacheOpts}) ->
+    start_cache(HostType, CacheOpts),
     ejabberd_hooks:add(hooks(HostType, Opts)),
     ok.
 

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -77,40 +77,24 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
-start(HostType, Opts) ->
-    start_pm(HostType, Opts).
+-spec start(host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, _Opts) ->
+    ejabberd_hooks:add(hooks(HostType)).
 
+-spec stop(host_type()) -> ok.
 stop(HostType) ->
-    stop_pm(HostType).
+    ejabberd_hooks:delete(hooks(HostType)).
 
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam
 
-start_pm(HostType, _Opts) ->
-    case gen_mod:get_module_opt(HostType, ?MODULE, no_writer, false) of
-        true ->
-            ok;
-        false ->
-            ejabberd_hooks:add(mam_archive_message, HostType, ?MODULE, archive_message, 50)
-    end,
-    ejabberd_hooks:add(mam_archive_size, HostType, ?MODULE, archive_size, 50),
-    ejabberd_hooks:add(mam_lookup_messages, HostType, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:add(mam_remove_archive, HostType, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:add(get_mam_pm_gdpr_data, HostType, ?MODULE, get_mam_pm_gdpr_data, 50),
-    ok.
-
-stop_pm(HostType) ->
-    case gen_mod:get_module_opt(HostType, ?MODULE, no_writer, false) of
-        true ->
-            ok;
-        false ->
-            ejabberd_hooks:delete(mam_archive_message, HostType, ?MODULE, archive_message, 50)
-    end,
-    ejabberd_hooks:delete(mam_archive_size, HostType, ?MODULE, archive_size, 50),
-    ejabberd_hooks:delete(mam_lookup_messages, HostType, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:delete(mam_remove_archive, HostType, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:delete(get_mam_pm_gdpr_data, HostType, ?MODULE, get_mam_pm_gdpr_data, 50),
-    ok.
+-spec hooks(host_type()) -> [ejabberd_hooks:hook()].
+hooks(HostType) ->
+    [{mam_archive_message, HostType, ?MODULE, archive_message, 50},
+     {mam_archive_size, HostType, ?MODULE, archive_size, 50},
+     {mam_lookup_messages, HostType, ?MODULE, lookup_messages, 50},
+     {mam_remove_archive, HostType, ?MODULE, remove_archive, 50},
+     {get_mam_pm_gdpr_data, HostType, ?MODULE, get_mam_pm_gdpr_data, 50}].
 
 %% ----------------------------------------------------------------------
 %% mongoose_cassandra_worker callbacks
@@ -755,8 +739,8 @@ stored_binary_to_packet(HostType, Bin) ->
 
 -spec db_message_format(HostType :: host_type()) -> module().
 db_message_format(HostType) ->
-    gen_mod:get_module_opt(HostType, ?MODULE, db_message_format, mam_message_xml).
+    gen_mod:get_module_opt(HostType, ?MODULE, db_message_format).
 
 -spec pool_name(HostType :: host_type()) -> term().
-pool_name(HostType) ->
-    gen_mod:get_module_opt(HostType, ?MODULE, pool_name, default).
+pool_name(_HostType) ->
+    default.

--- a/src/mam/mod_mam_cassandra_prefs.erl
+++ b/src/mam/mod_mam_cassandra_prefs.erl
@@ -34,38 +34,33 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(host_type(), _) -> ok.
-start(HostType, _Opts) ->
-    ejabberd_hooks:add(hooks(HostType)).
+-spec start(host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, Opts) ->
+    ejabberd_hooks:add(hooks(HostType, Opts)).
 
 -spec stop(host_type()) -> ok.
 stop(HostType) ->
-    ejabberd_hooks:delete(hooks(HostType)).
+    Opts = gen_mod:get_loaded_module_opts(HostType, ?MODULE),
+    ejabberd_hooks:delete(hooks(HostType, Opts)).
 
 %% ----------------------------------------------------------------------
 %% Hooks
 
-hooks(HostType) ->
-    case gen_mod:get_module_opt(HostType, ?MODULE, pm, false) of
-        true -> pm_hooks(HostType);
-        false -> []
-    end ++
-    case gen_mod:get_module_opt(HostType, ?MODULE, muc, false) of
-        true -> muc_hooks(HostType);
-        false -> []
-    end.
+hooks(HostType, Opts) ->
+    lists:flatmap(fun(Type) -> hooks(HostType, Type, Opts) end, [pm, muc]).
 
-pm_hooks(HostType) ->
+hooks(HostType, pm, #{pm := true}) ->
     [{mam_get_behaviour, HostType, ?MODULE, get_behaviour, 50},
      {mam_get_prefs, HostType, ?MODULE, get_prefs, 50},
      {mam_set_prefs, HostType, ?MODULE, set_prefs, 50},
-     {mam_remove_archive, HostType, ?MODULE, remove_archive, 50}].
-
-muc_hooks(HostType) ->
+     {mam_remove_archive, HostType, ?MODULE, remove_archive, 50}];
+hooks(HostType, muc, #{muc := true}) ->
     [{mam_muc_get_behaviour, HostType, ?MODULE, get_behaviour, 50},
      {mam_muc_get_prefs, HostType, ?MODULE, get_prefs, 50},
      {mam_muc_set_prefs, HostType, ?MODULE, set_prefs, 50},
-     {mam_muc_remove_archive, HostType, ?MODULE, remove_archive, 50}].
+     {mam_muc_remove_archive, HostType, ?MODULE, remove_archive, 50}];
+hooks(_HostType, _Opt, _Opts) ->
+    [].
 
 %% ----------------------------------------------------------------------
 
@@ -222,5 +217,5 @@ decode_prefs_rows([#{remote_jid := JID, behaviour := <<"N">>} | Rows],
 %% Params getters
 
 -spec pool_name(HostType :: host_type()) -> term().
-pool_name(HostType) ->
-    gen_mod:get_module_opt(HostType, ?MODULE, pool_name, default).
+pool_name(_HostType) ->
+    default.

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -48,14 +48,14 @@
 %% gen_mod callbacks
 %%-------------------------------------------------------------------
 
--spec start(jid:server(), list()) -> ok.
-start(Host, _Opts) ->
-    ejabberd_hooks:add(hooks(Host)),
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, _Opts) ->
+    ejabberd_hooks:add(hooks(HostType)),
     ok.
 
--spec stop(jid:server()) -> ok.
-stop(Host) ->
-    ejabberd_hooks:delete(hooks(Host)),
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    ejabberd_hooks:delete(hooks(HostType)),
     ok.
 
 -spec get_mam_pm_gdpr_data(ejabberd_gen_mam_archive:mam_pm_gdpr_data(),

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -18,11 +18,12 @@
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 
--type deps() :: #{module() => proplists:proplist()}.
+-type module_opts() :: gen_mod:module_opts().
+-type module_map() :: gen_mod_deps:module_map().
 
--export([start/2, stop/1, config_spec/0, supported_features/0, deps/2]).
+-export([start/2, stop/1, config_spec/0, supported_features/0, deps/2, config_metrics/1]).
 
--export([config_metrics/1]).
+-export([remove_unused_backend_opts/1]).
 
 -include("mongoose_config_spec.hrl").
 
@@ -38,21 +39,52 @@ supported_features() ->
 start(_Host, _Opts) ->
     ok.
 
-
 -spec stop(Host :: jid:server()) -> any().
 stop(_Host) ->
     ok.
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
-    Items = config_items(),
+    Items = maps:merge(common_config_items(), root_config_items()),
     #section{
-       items = Items#{<<"pm">> => #section{items = maps:merge(Items, pm_config_items())},
-                      <<"muc">> => #section{items = maps:merge(Items, muc_config_items())},
-                      <<"riak">> => riak_config_spec()}
+       items = Items#{<<"pm">> => pm_config_spec(),
+                      <<"muc">> => muc_config_spec(),
+                      <<"riak">> => riak_config_spec()},
+       defaults = #{<<"backend">> => rdbms,
+                    <<"no_stanzaid_element">> => false,
+                    <<"is_archivable_message">> => mod_mam_utils,
+                    <<"send_message">> => mod_mam_utils,
+                    <<"archive_chat_markers">> => false,
+                    <<"message_retraction">> => true,
+                    <<"full_text_search">> => true,
+                    <<"cache_users">> => true,
+                    <<"default_result_limit">> => 50,
+                    <<"max_result_limit">> => 50},
+       format_items = map,
+       process = fun ?MODULE:remove_unused_backend_opts/1
       }.
 
-config_items() ->
+remove_unused_backend_opts(Opts = #{backend := riak}) -> Opts;
+remove_unused_backend_opts(Opts) -> maps:remove(riak, Opts).
+
+pm_config_spec() ->
+    #section{items = maps:merge(common_config_items(), pm_config_items()),
+             format_items = map,
+             defaults = #{<<"archive_groupchats">> => false,
+                          <<"same_mam_id_for_peers">> => false}}.
+
+muc_config_spec() ->
+    #section{items = maps:merge(common_config_items(), muc_config_items()),
+             format_items = map,
+             defaults = #{<<"host">> => mod_muc:default_host()}}.
+
+root_config_items() ->
+    Cache = mongoose_user_cache:config_spec(),
+    AsyncWriter = mod_mam_rdbms_arch_async:config_spec(),
+    #{<<"cache">> => Cache#section{include = always},
+      <<"async_writer">> => AsyncWriter#section{include = always}}.
+
+common_config_items() ->
     #{%% General options
       <<"backend">> => #option{type = atom,
                                validate = {enum, [rdbms, riak, cassandra, elasticsearch]}},
@@ -71,10 +103,6 @@ config_items() ->
 
       %% RDBMS-specific options
       <<"cache_users">> => #option{type = boolean},
-      <<"cache">> => mongoose_user_cache:config_spec(),
-      <<"rdbms_message_format">> => #option{type = atom,
-                                            validate = {enum, [simple, internal]}},
-      <<"async_writer">> => mod_mam_rdbms_arch_async:config_spec(),
 
       %% Low-level options
       <<"default_result_limit">> => #option{type = integer,
@@ -85,7 +113,6 @@ config_items() ->
                                      validate = module},
       <<"db_message_format">> => #option{type = atom,
                                          validate = module},
-      <<"simple">> => #option{type = boolean},
       <<"extra_fin_element">> => #option{type = atom,
                                          validate = module},
       <<"extra_lookup_params">> => #option{type = atom,
@@ -93,11 +120,13 @@ config_items() ->
      }.
 
 pm_config_items() ->
-    #{<<"archive_groupchats">> => #option{type = boolean},
+    #{<<"async_writer">> => mod_mam_rdbms_arch_async:config_spec(),
+      <<"archive_groupchats">> => #option{type = boolean},
       <<"same_mam_id_for_peers">> => #option{type = boolean}}.
 
 muc_config_items() ->
-    #{<<"host">> => #option{type = string,
+    #{<<"async_writer">> => mod_mam_rdbms_arch_async:config_spec(),
+      <<"host">> => #option{type = string,
                             validate = subdomain_template,
                             process = fun mongoose_subdomain_utils:make_subdomain_pattern/1}}.
 
@@ -107,61 +136,54 @@ riak_config_spec() ->
                                                validate = non_empty},
                  <<"bucket_type">> => #option{type = binary,
                                               validate = non_empty}},
-       wrap = none
+       defaults = #{<<"search_index">> => <<"mam">>,
+                    <<"bucket_type">> => <<"mam_yz">>},
+       format_items = map,
+       include = always
       }.
 
--spec deps(_Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
-deps(_Host, Opts0) ->
-    Opts = normalize(Opts0),
+-spec deps(mongooseim:host_type(), module_opts()) -> gen_mod_deps:deps().
+deps(_HostType, Opts) ->
+    DepsWithPm = handle_nested_opts(pm, Opts, #{}),
+    DepsWithPmAndMuc = handle_nested_opts(muc, Opts, DepsWithPm),
 
-    DepsWithPm = handle_nested_opts(pm, Opts, false, #{}),
-    DepsWithPmAndMuc = handle_nested_opts(muc, Opts, false, DepsWithPm),
-
-    [{Dep, Args, hard} || {Dep, Args} <- maps:to_list(DepsWithPmAndMuc)].
+    [{DepMod, DepOpts, hard} || {DepMod, DepOpts} <- maps:to_list(DepsWithPmAndMuc)].
 
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
 
--spec handle_nested_opts(Key :: atom(), RootOpts :: proplists:proplist(),
-                         Default :: term(), deps()) -> deps().
-handle_nested_opts(Key, RootOpts, Default, Deps) ->
-    case proplists:get_value(Key, RootOpts, Default) of
-        false -> Deps;
-        Opts0 ->
-            Opts = normalize(Opts0),
-            FullOpts = lists:ukeymerge(1, Opts, RootOpts),
+-type mam_type() :: pm | muc.
+-type mam_backend() :: rdbms | riak | cassandra | elasticsearch.
+
+-spec handle_nested_opts(mam_type(), module_opts(), module_map()) -> module_map().
+handle_nested_opts(Key, RootOpts, Deps) ->
+    case maps:find(Key, RootOpts) of
+        error -> Deps;
+        {ok, Opts} ->
+            FullOpts = maps:merge(maps:without([pm, muc], RootOpts), Opts),
             parse_opts(Key, FullOpts, Deps)
     end.
 
--spec parse_opts(Type :: pm | muc, Opts :: proplists:proplist(), deps()) -> deps().
+-spec parse_opts(mam_type(), module_opts(), module_map()) -> module_map().
 parse_opts(Type, Opts, Deps) ->
     %% Opts are merged root options with options inside pm or muc section
     CoreMod = mam_type_to_core_mod(Type),
-    CoreModOpts = filter_opts(Opts, valid_core_mod_opts(CoreMod)),
+    CoreModOpts = maps:with(valid_core_mod_opts(CoreMod), Opts),
     WithCoreDeps = add_dep(CoreMod, CoreModOpts, Deps),
-    Backend = proplists:get_value(backend, Opts, rdbms),
-    parse_backend_opts(Backend, Type, Opts, WithCoreDeps).
+    {Backend, BackendOpts} = maps:take(backend, Opts),
+    WithPrefs = add_prefs_store_module(Backend, Type, Opts, WithCoreDeps),
+    parse_backend_opts(Backend, Type, BackendOpts, WithPrefs).
 
--spec mam_type_to_core_mod(atom()) -> module().
+-spec mam_type_to_core_mod(mam_type()) -> module().
 mam_type_to_core_mod(pm) -> mod_mam;
 mam_type_to_core_mod(muc) -> mod_mam_muc.
 
-filter_opts(Opts, ValidOpts) ->
-    lists:filtermap(
-        fun(Key) ->
-            case proplists:lookup(Key, Opts) of
-                none -> false;
-                Opt -> {true, Opt}
-            end
-        end, ValidOpts).
-
 %% Get a list of options to pass into the two modules.
-%% They don't required to be defined in pm or muc sections,
-%% the root section is enough.
+%% They don't have to be defined in pm or muc sections, the root section is enough.
 -spec valid_core_mod_opts(module()) -> [atom()].
 valid_core_mod_opts(mod_mam) ->
-    [no_stanzaid_element, archive_groupchats, same_mam_id_for_peers] ++ common_opts();
+    [archive_groupchats, same_mam_id_for_peers] ++ common_opts();
 valid_core_mod_opts(mod_mam_muc) ->
     [host] ++ common_opts().
 
@@ -175,138 +197,89 @@ common_opts() ->
      full_text_search,
      message_retraction,
      default_result_limit,
-     max_result_limit].
+     max_result_limit,
+     no_stanzaid_element].
 
--spec parse_backend_opts(rdbms | cassandra | riak | elasticsearch, Type :: pm | muc,
-                         Opts :: proplists:proplist(), deps()) -> deps().
-parse_backend_opts(cassandra, Type, Opts, Deps0) ->
-    ModArch =
-        case Type of
-            pm -> mod_mam_cassandra_arch;
-            muc -> mod_mam_muc_cassandra_arch
-        end,
+-spec add_prefs_store_module(mam_backend(), mam_type(), module_opts(), module_map()) -> module_map().
+add_prefs_store_module(Backend, Type, #{user_prefs_store := Store}, Deps) ->
+    PrefsModule = prefs_module(Backend, Store),
+    add_dep(PrefsModule, #{Type => true}, Deps);
+add_prefs_store_module(_Backend, _Type, _Opts, Deps) ->
+    Deps.
 
-    Opts1 = filter_opts(Opts, [db_message_format, pool_name, simple]),
-    Deps = add_dep(ModArch, Opts1, Deps0),
+-spec parse_backend_opts(mam_backend(), mam_type(), module_opts(), module_map()) -> module_map().
+parse_backend_opts(cassandra, Type, Opts, Deps) ->
+    Opts1 = maps:with([db_message_format], Opts),
+    add_dep(cassandra_arch_module(Type), maps:merge(arch_defaults(), Opts1), Deps);
+parse_backend_opts(riak, Type, Opts, Deps) ->
+    Opts1 = maps:with([db_message_format, riak], Opts),
+    add_dep(mod_mam_riak_timed_arch_yz, maps:merge(arch_defaults(), Opts1#{Type => true}), Deps);
+parse_backend_opts(rdbms, Type, Opts, Deps) ->
+    lists:foldl(fun(OptionGroup, DepsIn) -> add_rdbms_deps(OptionGroup, Type, Opts, DepsIn) end,
+                Deps, [basic, user_cache, async_writer]);
+parse_backend_opts(elasticsearch, Type, _Opts, Deps0) ->
+    add_dep(elasticsearch_arch_module(Type), Deps0).
 
-    case proplists:get_value(user_prefs_store, Opts, false) of
-        cassandra -> add_dep(mod_mam_cassandra_prefs, [Type], Deps);
-        mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        _ -> Deps
-    end;
-
-parse_backend_opts(riak, Type, Opts, Deps0) ->
-    Opts1 = filter_opts(Opts, [db_message_format, search_index, bucket_type]),
-    Deps = add_dep(mod_mam_riak_timed_arch_yz, [Type | Opts1], Deps0),
-
-    case proplists:get_value(user_prefs_store, Opts, false) of
-        mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        _ -> Deps
-    end;
-
-parse_backend_opts(rdbms, Type, Opts0, Deps0) ->
-    Opts1 = add_rdbms_async_opts(Opts0),
-    Opts = add_rdbms_cache_opts(Opts1),
-
-    {ModRDBMSArch, ModAsyncWriter} =
-        case Type of
-            pm -> {mod_mam_rdbms_arch, mod_mam_rdbms_arch_async};
-            muc -> {mod_mam_muc_rdbms_arch, mod_mam_rdbms_arch_async}
-        end,
-
-    Deps1 = add_dep(ModRDBMSArch, [Type], Deps0),
-    Deps = add_dep(mod_mam_rdbms_user, user_db_types(Type), Deps1),
-
-    lists:foldl(
-      pa:bind(fun parse_rdbms_opt/5, Type, ModRDBMSArch, ModAsyncWriter),
-      Deps, Opts);
-
-parse_backend_opts(elasticsearch, Type, Opts, Deps0) ->
-    ModArch =
-        case Type of
-            pm -> mod_mam_elasticsearch_arch;
-            muc -> mod_mam_muc_elasticsearch_arch
-        end,
-
-    Deps = add_dep(ModArch, Deps0),
-
-    case proplists:get_value(user_prefs_store, Opts, false) of
-        mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        _ -> Deps
-    end.
+-spec add_rdbms_deps(basic | user_cache | async_writer,
+                     mam_type(), module_opts(), module_map()) -> module_map().
+add_rdbms_deps(basic, Type, Opts, Deps) ->
+    Opts1 = maps:with([db_message_format, db_jid_format], Opts),
+    Deps1 = add_dep(rdbms_arch_module(Type), maps:merge(rdbms_arch_defaults(Type), Opts1), Deps),
+    add_dep(mod_mam_rdbms_user, user_db_types(Type), Deps1);
+add_rdbms_deps(user_cache, Type, #{cache_users := true, cache := CacheOpts}, Deps) ->
+    Deps1 = case gen_mod:get_opt(module, CacheOpts, internal) of
+                internal -> Deps;
+                mod_cache_users -> add_dep(mod_cache_users, Deps)
+            end,
+    add_dep(mod_mam_cache_user, #{Type => true, cache => CacheOpts}, Deps1);
+add_rdbms_deps(async_writer, Type, #{async_writer := AsyncOpts = #{enabled := true}}, Deps) ->
+    Deps1 = add_dep(rdbms_arch_module(Type), #{no_writer => true}, Deps),
+    add_dep(mod_mam_rdbms_arch_async, #{Type => AsyncOpts}, Deps1);
+add_rdbms_deps(_, _Type, _Opts, Deps) ->
+    Deps.
 
 % muc backend requires both pm and muc user DB to populate sender_id column
--spec user_db_types(pm | muc) -> [pm | muc].
-user_db_types(pm) -> [pm];
-user_db_types(muc) -> [pm, muc].
+-spec user_db_types(mam_type()) -> module_opts().
+user_db_types(pm) -> #{pm => true};
+user_db_types(muc) -> #{pm => true, muc => true}.
 
--spec normalize(proplists:proplist()) -> [{atom(), term()}].
-normalize(Opts) ->
-    lists:ukeysort(1, proplists:unfold(Opts)).
+cassandra_arch_module(pm) -> mod_mam_cassandra_arch;
+cassandra_arch_module(muc) -> mod_mam_muc_cassandra_arch.
 
+arch_defaults() -> #{db_message_format => mam_message_xml}.
 
--spec add_dep(Dep :: module(), deps()) -> deps().
+rdbms_arch_defaults(pm) ->
+    maps:merge(rdbms_arch_defaults(), #{db_jid_format => mam_jid_mini});
+rdbms_arch_defaults(muc) ->
+    maps:merge(rdbms_arch_defaults(), #{db_jid_format => mam_jid_rfc}).
+
+rdbms_arch_defaults() ->
+    #{db_message_format => mam_message_compressed_eterm,
+      no_writer => false}.
+
+rdbms_arch_module(pm) -> mod_mam_rdbms_arch;
+rdbms_arch_module(muc) -> mod_mam_muc_rdbms_arch.
+
+elasticsearch_arch_module(pm) -> mod_mam_elasticsearch_arch;
+elasticsearch_arch_module(muc) -> mod_mam_muc_elasticsearch_arch.
+
+prefs_module(rdbms, rdbms) -> mod_mam_rdbms_prefs;
+prefs_module(cassandra, cassandra) -> mod_mam_cassandra_prefs;
+prefs_module(_, mnesia) -> mod_mam_mnesia_prefs;
+prefs_module(Backend, PrefsStore) ->
+    error(#{what => invalid_mam_user_prefs_store,
+            backend => Backend,
+            user_prefs_store => PrefsStore}).
+
+-spec add_dep(module(), module_map()) -> module_map().
 add_dep(Dep, Deps) ->
-    add_dep(Dep, [], Deps).
+    add_dep(Dep, #{}, Deps).
 
-
--spec add_dep(Dep :: module(), Args :: proplists:proplist(), deps()) -> deps().
-add_dep(Dep, Args, Deps) ->
-    PrevArgs = maps:get(Dep, Deps, []),
-    NewArgs = lists:usort(Args ++ PrevArgs),
-    maps:put(Dep, NewArgs, Deps).
-
-
--spec add_rdbms_async_opts(proplists:proplist()) -> proplists:proplist().
-add_rdbms_async_opts(Opts) ->
-    case lists:keyfind(async_writer, 1, Opts) of
-        {async_writer, AsyncOpts} ->
-            case lists:keyfind(enabled, 1, AsyncOpts) of
-                {enabled, false} -> lists:keydelete(async_writer, 1, Opts);
-                _ -> Opts
-            end;
-        false ->
-            [{async_writer, []} | Opts]
-    end.
-
-
-add_rdbms_cache_opts(Opts) ->
-    case {lists:keyfind(cache_users, 1, Opts), lists:keyfind(cache, 1, Opts)} of
-        {{cache_users, false}, _} ->
-            lists:keydelete(cache, 1, Opts);
-        {{cache_users, true}, false} ->
-            [{cache, []} | Opts];
-        {false, false} ->
-            [{cache, []} | Opts];
-        {false, {cache, _}} ->
-            Opts
-    end.
-
--spec parse_rdbms_opt(Type :: pm | muc, module(), module(),
-                      Option :: {module(), term()}, deps()) -> deps().
-parse_rdbms_opt(Type, ModRDBMSArch, ModAsyncWriter, Option, Deps) ->
-    case Option of
-        {cache, CacheOpts} ->
-            Deps1 = case gen_mod:get_opt(module, CacheOpts, internal) of
-                        internal -> Deps;
-                        mod_cache_users -> add_dep(mod_cache_users, Deps)
-                    end,
-            add_dep(mod_mam_cache_user, [Type | CacheOpts], Deps1);
-        {user_prefs_store, rdbms} ->
-            add_dep(mod_mam_rdbms_prefs, [Type], Deps);
-        {user_prefs_store, mnesia} ->
-            add_dep(mod_mam_mnesia_prefs, [Type], Deps);
-        {rdbms_message_format, simple} ->
-            add_dep(ModRDBMSArch, rdbms_simple_opts(), Deps);
-        {async_writer, Opts} ->
-            DepsWithNoWriter = add_dep(ModRDBMSArch, [no_writer], Deps),
-            add_dep(ModAsyncWriter, [{Type, Opts}], DepsWithNoWriter);
-        _ -> Deps
-    end.
-
--spec rdbms_simple_opts() -> list().
-rdbms_simple_opts() -> [{db_jid_format, mam_jid_rfc}, {db_message_format, mam_message_xml}].
+-spec add_dep(module(), module_opts(), module_map()) -> module_map().
+add_dep(Dep, Opts, Deps) ->
+    PrevOpts = maps:get(Dep, Deps, #{}),
+    NewOpts = maps:merge(PrevOpts, Opts),
+    maps:put(Dep, NewOpts, Deps).
 
 config_metrics(Host) ->
-    OptsToReport = [{backend, rdbms}], %list of tuples {option, defualt_value}
-    mongoose_module_metrics:opts_for_module(Host, ?MODULE, OptsToReport).
+    mongoose_module_metrics:opts_for_module(Host, ?MODULE, [backend]).

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -616,9 +616,9 @@ report_issue(Reason, Stacktrace, Issue, #jid{lserver = LServer, luser = LUser}, 
                             Dir :: incoming | outgoing,
                             Packet :: exml:element()) -> boolean().
 is_archivable_message(HostType, Dir, Packet) ->
-    {M, F} = mod_mam_params:is_archivable_message_fun(?MODULE, HostType),
+    M = mod_mam_params:is_archivable_message_module(?MODULE, HostType),
     ArchiveChatMarkers = mod_mam_params:archive_chat_markers(?MODULE, HostType),
-    erlang:apply(M, F, [?MODULE, Dir, Packet, ArchiveChatMarkers]).
+    erlang:apply(M, is_archivable_message, [?MODULE, Dir, Packet, ArchiveChatMarkers]).
 
 -spec hooks(host_type()) -> [ejabberd_hooks:hook()].
 hooks(HostType) ->
@@ -630,8 +630,7 @@ hooks(HostType) ->
 
 add_iq_handlers(HostType, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, parallel),
-    MUCSubdomainPattern = gen_mod:get_module_opt(HostType, ?MODULE, host,
-                                                 mod_muc:default_host()),
+    MUCSubdomainPattern = gen_mod:get_module_opt(HostType, ?MODULE, host),
 
     gen_iq_handler:add_iq_handler_for_subdomain(HostType, MUCSubdomainPattern,
                                                 ?NS_MAM_04, mod_muc_iq,
@@ -644,8 +643,7 @@ add_iq_handlers(HostType, Opts) ->
     ok.
 
 remove_iq_handlers(HostType) ->
-    MUCSubdomainPattern = gen_mod:get_module_opt(HostType, ?MODULE, host,
-                                                 mod_muc:default_host()),
+    MUCSubdomainPattern = gen_mod:get_module_opt(HostType, ?MODULE, host),
     gen_iq_handler:remove_iq_handler_for_subdomain(HostType, MUCSubdomainPattern,
                                                    ?NS_MAM_04, mod_muc_iq),
     gen_iq_handler:remove_iq_handler_for_subdomain(HostType, MUCSubdomainPattern,

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -72,7 +72,7 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(host_type(), _) -> ok.
+-spec start(host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, _Opts) ->
     ejabberd_hooks:add(hooks(HostType)).
 
@@ -84,14 +84,8 @@ stop(HostType) ->
 %% Add hooks for mod_mam_muc
 
 hooks(HostType) ->
-    NoWriter = gen_mod:get_module_opt(HostType, ?MODULE, no_writer, false),
-    case NoWriter of
-        true ->
-            [];
-        false ->
-            [{mam_muc_archive_message, HostType, ?MODULE, archive_message, 50}]
-    end ++
-    [{mam_muc_archive_size, HostType, ?MODULE, archive_size, 50},
+    [{mam_muc_archive_message, HostType, ?MODULE, archive_message, 50},
+     {mam_muc_archive_size, HostType, ?MODULE, archive_size, 50},
      {mam_muc_lookup_messages, HostType, ?MODULE, lookup_messages, 50},
      {mam_muc_remove_archive, HostType, ?MODULE, remove_archive, 50},
      {get_mam_muc_gdpr_data, HostType, ?MODULE, get_mam_muc_gdpr_data, 50}].
@@ -760,8 +754,8 @@ stored_binary_to_packet(HostType, Bin) ->
 
 -spec db_message_format(HostType :: host_type()) -> module().
 db_message_format(HostType) ->
-    gen_mod:get_module_opt(HostType, ?MODULE, db_message_format, mam_message_xml).
+    gen_mod:get_module_opt(HostType, ?MODULE, db_message_format).
 
 -spec pool_name(HostType :: host_type()) -> mongoose_wpool:pool_name().
 pool_name(HostType) ->
-    gen_mod:get_module_opt(HostType, ?MODULE, pool_name, default).
+    default.

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -48,14 +48,14 @@
 %% gen_mod callbacks
 %%-------------------------------------------------------------------
 
--spec start(jid:server(), list()) -> ok.
-start(Host, _Opts) ->
-    ejabberd_hooks:add(hooks(Host)),
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, _Opts) ->
+    ejabberd_hooks:add(hooks(HostType)),
     ok.
 
--spec stop(jid:server()) -> ok.
-stop(Host) ->
-    ejabberd_hooks:delete(hooks(Host)),
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    ejabberd_hooks:delete(hooks(HostType)),
     ok.
 
 %%-------------------------------------------------------------------

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -53,7 +53,7 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(host_type(), _) -> ok.
+-spec start(host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, _Opts) ->
     start_hooks(HostType),
     register_prepared_queries(),
@@ -93,8 +93,7 @@ stop_hooks(HostType) ->
     ejabberd_hooks:delete(hooks(HostType)).
 
 hooks(HostType) ->
-    NoWriter = gen_mod:get_module_opt(HostType, ?MODULE, no_writer, false),
-    case NoWriter of
+    case gen_mod:get_module_opt(HostType, ?MODULE, no_writer) of
         true ->
             [];
         false ->
@@ -199,11 +198,11 @@ column_names(Mappings) ->
 
 -spec db_jid_codec(host_type(), module()) -> module().
 db_jid_codec(HostType, Module) ->
-    gen_mod:get_module_opt(HostType, Module, db_jid_format, mam_jid_rfc).
+    gen_mod:get_module_opt(HostType, Module, db_jid_format).
 
 -spec db_message_codec(host_type(), module()) -> module().
 db_message_codec(HostType, Module) ->
-    gen_mod:get_module_opt(HostType, Module, db_message_format, mam_message_compressed_eterm).
+    gen_mod:get_module_opt(HostType, Module, db_message_format).
 
 -spec get_retract_id(exml:element(), env_vars()) -> none | mod_mam_utils:retraction_id().
 get_retract_id(Packet, #{has_message_retraction := Enabled}) ->

--- a/src/mam/mod_mam_params.erl
+++ b/src/mam/mod_mam_params.erl
@@ -19,7 +19,7 @@
 -type mam_module() :: mod_mam | mod_mam_muc.
 
 -export([extra_params_module/2, max_result_limit/2, default_result_limit/2,
-         has_full_text_search/2, is_archivable_message_fun/2, send_message_mod/2,
+         has_full_text_search/2, is_archivable_message_module/2, send_message_mod/2,
          archive_chat_markers/2, add_stanzaid_element/2, extra_fin_element_module/2]).
 
 %%--------------------------------------------------------------------
@@ -28,56 +28,37 @@
 
 -spec extra_params_module(mam_module(), mongooseim:host_type()) -> module() | undefined.
 extra_params_module(Module, HostType) ->
-    param(Module, HostType, extra_lookup_params, undefined).
+    gen_mod:get_module_opt(HostType, Module, extra_lookup_params, undefined).
 
 -spec max_result_limit(mam_module(), mongooseim:host_type()) -> pos_integer().
 max_result_limit(Module, HostType) ->
-    param(Module, HostType, max_result_limit, 50).
+    gen_mod:get_module_opt(HostType, Module, max_result_limit).
 
 -spec default_result_limit(mam_module(), mongooseim:host_type()) -> pos_integer().
 default_result_limit(Module, HostType) ->
-    param(Module, HostType, default_result_limit, 50).
+    gen_mod:get_module_opt(HostType, Module, default_result_limit).
 
 
 -spec has_full_text_search(Module :: mod_mam | mod_mam_muc, mongooseim:host_type()) -> boolean().
 has_full_text_search(Module, HostType) ->
-    param(Module, HostType, full_text_search, true).
+    gen_mod:get_module_opt(HostType, Module, full_text_search).
 
--spec is_archivable_message_fun(mam_module(), mongooseim:host_type()) ->
-                                       MF :: {module(), atom()}.
-is_archivable_message_fun(Module, HostType) ->
-    {IsArchivableModule, IsArchivableFunction} =
-        case param(Module, HostType, is_archivable_message, undefined) of
-            undefined ->
-                case param(Module, HostType, is_complete_message, undefined) of
-                    undefined -> {mod_mam_utils, is_archivable_message};
-                    OldStyleMod -> {OldStyleMod, is_complete_message}
-                end;
-
-            Mod -> {Mod, is_archivable_message}
-        end,
-    {IsArchivableModule, IsArchivableFunction}.
+-spec is_archivable_message_module(mam_module(), mongooseim:host_type()) -> module().
+is_archivable_message_module(Module, HostType) ->
+    gen_mod:get_module_opt(HostType, Module, is_archivable_message).
 
 -spec send_message_mod(mam_module(), mongooseim:host_type()) -> module().
 send_message_mod(Module, HostType) ->
-    param(Module, HostType, send_message, mod_mam_utils).
+    gen_mod:get_module_opt(HostType, Module, send_message).
 
 -spec archive_chat_markers(mam_module(), mongooseim:host_type()) -> boolean().
 archive_chat_markers(Module, HostType) ->
-    param(Module, HostType, archive_chat_markers, false).
+    gen_mod:get_module_opt(HostType, Module, archive_chat_markers).
 
 -spec add_stanzaid_element(mam_module(), mongooseim:host_type()) -> boolean().
 add_stanzaid_element(Module, HostType) ->
-    not param(Module, HostType, no_stanzaid_element, false).
+    not gen_mod:get_module_opt(HostType, Module, no_stanzaid_element).
 
 -spec extra_fin_element_module(mam_module(), mongooseim:host_type()) -> module() | undefined.
 extra_fin_element_module(Module, HostType) ->
-    param(Module, HostType, extra_fin_element, undefined).
-
-%%--------------------------------------------------------------------
-%% Internal functions
-%%--------------------------------------------------------------------
-
--spec param(mam_module(), mongooseim:host_type(), Opt :: term(), Default :: term()) -> term().
-param(Module, HostType, Opt, Default) ->
-    gen_mod:get_module_opt(HostType, Module, Opt, Default).
+    gen_mod:get_module_opt(HostType, Module, extra_fin_element, undefined).

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -68,9 +68,9 @@
 %% gen_mod callbacks
 %% Starting and stopping functions for users' archives
 
--spec start(host_type(), _) -> ok.
-start(HostType, Opts) ->
-    start_hooks(HostType, Opts),
+-spec start(host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, _Opts) ->
+    start_hooks(HostType),
     register_prepared_queries(),
     ok.
 
@@ -103,8 +103,8 @@ uniform_to_gdpr(#{id := MessID, jid := RemoteJID, packet := Packet}) ->
 %% ----------------------------------------------------------------------
 %% Add hooks for mod_mam
 
--spec start_hooks(host_type(), _) -> ok.
-start_hooks(HostType, _Opts) ->
+-spec start_hooks(host_type()) -> ok.
+start_hooks(HostType) ->
     ejabberd_hooks:add(hooks(HostType)).
 
 -spec stop_hooks(host_type()) -> ok.
@@ -112,8 +112,7 @@ stop_hooks(HostType) ->
     ejabberd_hooks:delete(hooks(HostType)).
 
 hooks(HostType) ->
-    NoWriter = gen_mod:get_module_opt(HostType, ?MODULE, no_writer, false),
-    case NoWriter of
+    case gen_mod:get_module_opt(HostType, ?MODULE, no_writer) of
         true ->
             [];
         false ->
@@ -231,11 +230,11 @@ column_names(Mappings) ->
 
 -spec db_jid_codec(host_type(), module()) -> module().
 db_jid_codec(HostType, Module) ->
-    gen_mod:get_module_opt(HostType, Module, db_jid_format, mam_jid_mini).
+    gen_mod:get_module_opt(HostType, Module, db_jid_format).
 
 -spec db_message_codec(host_type(), module()) -> module().
 db_message_codec(HostType, Module) ->
-    gen_mod:get_module_opt(HostType, Module, db_message_format, mam_message_compressed_eterm).
+    gen_mod:get_module_opt(HostType, Module, db_message_format).
 
 -spec get_retract_id(exml:element(), env_vars()) -> none | mod_mam_utils:retraction_id().
 get_retract_id(Packet, #{has_message_retraction := Enabled}) ->

--- a/src/mam/mod_mam_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_rdbms_arch_async.erl
@@ -43,14 +43,14 @@ mam_muc_archive_sync(Result, HostType) ->
     Result.
 
 %%% gen_mod callbacks
--spec start(mongooseim:host_type(), [{writer_type(), gen_mod:module_opts()}]) -> any().
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
 start(HostType, Opts) ->
-    [ start_pool(HostType, Mod) || Mod <- Opts ].
+    [ start_pool(HostType, Mod) || Mod <- maps:to_list(Opts) ].
 
 -spec stop(mongooseim:host_type()) -> any().
 stop(HostType) ->
-    Opts = gen_mod:get_module_opts(HostType, ?MODULE),
-    [ stop_pool(HostType, Mod) || Mod <- Opts ].
+    Opts = gen_mod:get_loaded_module_opts(HostType, ?MODULE),
+    [ stop_pool(HostType, Mod) || Mod <- maps:to_list(Opts) ].
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
@@ -73,8 +73,7 @@ start_pool(HostType, {Type, Opts}) ->
 -spec make_pool_opts(writer_type(), gen_mod:module_opts()) ->
           {mongoose_async_pools:pool_opts(), mongoose_async_pools:pool_extra()}.
 make_pool_opts(Type, Opts) ->
-    Merge = maps:merge(defaults(), maps:from_list(Opts)),
-    Extra = add_batch_name(Type, Merge),
+    Extra = add_batch_name(Type, Opts),
     PoolOpts = Extra#{flush_callback => flush_callback(Type),
                       flush_extra => Extra},
     {PoolOpts, Extra}.
@@ -88,11 +87,6 @@ add_batch_name(muc, #{batch_size := MaxSize} = Opts) ->
 
 flush_callback(pm) -> fun ?MODULE:flush_pm/2;
 flush_callback(muc) -> fun ?MODULE:flush_muc/2.
-
-defaults() ->
-    #{flush_interval => 2000,
-      batch_size => 30,
-      pool_size => 4 * erlang:system_info(schedulers_online)}.
 
 prepare_insert_queries(pm, #{batch_size := MaxSize, batch_name := BatchName}) ->
     mod_mam_rdbms_arch:prepare_insert(insert_mam_message, 1),

--- a/src/mam/mod_mam_rdbms_user.erl
+++ b/src/mam/mod_mam_rdbms_user.erl
@@ -48,6 +48,7 @@ hooks(HostType) ->
      || {true, Hook, Fun, N} <- hooks2(HostType)].
 
 hooks2(HostType) ->
+    %% FIXME the auto_remove option is missing from the config spec
     AR = gen_mod:get_module_opt(HostType, ?MODULE, auto_remove, false),
     PM = gen_mod:get_module_opt(HostType, ?MODULE, pm, false),
     MUC = gen_mod:get_module_opt(HostType, ?MODULE, muc, false),

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -60,69 +60,38 @@
 %% - `muc' option starts multichat archives
 %%
 %% Use both options `pm, muc' to archive both MUC and private messages
-start(Host, Opts) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
-        true ->
-            start_chat_archive(Host, Opts);
-        false ->
-            ok
-    end,
-    case gen_mod:get_module_opt(Host, ?MODULE, muc, false) of
-        true ->
-            start_muc_archive(Host, Opts);
-        false ->
-            ok
-    end.
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, Opts) ->
+    ejabberd_hooks:add(hooks(HostType, Opts)).
 
-start_chat_archive(Host, _Opts) ->
-    ejabberd_hooks:add(mam_archive_message, Host, ?MODULE, archive_message, 50),
-    ejabberd_hooks:add(mam_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:add(mam_lookup_messages, Host, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:add(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:add(get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50).
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    Opts = gen_mod:get_loaded_module_opts(HostType, ?MODULE),
+    ejabberd_hooks:delete(hooks(HostType, Opts)).
 
-start_muc_archive(Host, _Opts) ->
-    ejabberd_hooks:add(mam_muc_archive_message, Host, ?MODULE, archive_message_muc, 50),
-    ejabberd_hooks:add(mam_muc_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:add(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages_muc, 50),
-    ejabberd_hooks:add(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:add(get_mam_muc_gdpr_data, Host, ?MODULE, get_mam_muc_gdpr_data, 50).
+hooks(HostType, Opts) ->
+    lists:flatmap(fun(Type) -> hooks(HostType, Type, Opts) end, [pm, muc]).
 
-stop(Host) ->
-    case gen_mod:get_module_opt(Host, ?MODULE, pm, false) of
-        true ->
-            stop_chat_archive(Host);
-        false ->
-            ok
-    end,
-    case gen_mod:get_module_opt(Host, ?MODULE, muc, false) of
-        true ->
-            stop_muc_archive(Host);
-        false ->
-            ok
-    end.
-
-stop_chat_archive(Host) ->
-    ejabberd_hooks:delete(mam_archive_message, Host, ?MODULE, archive_message_muc, 50),
-    ejabberd_hooks:delete(mam_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:delete(mam_lookup_messages, Host, ?MODULE, lookup_messages_muc, 50),
-    ejabberd_hooks:delete(mam_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:delete(get_mam_pm_gdpr_data, Host, ?MODULE, get_mam_pm_gdpr_data, 50),
-    ok.
-
-stop_muc_archive(Host) ->
-    ejabberd_hooks:delete(mam_muc_archive_message, Host, ?MODULE, archive_message, 50),
-    ejabberd_hooks:delete(mam_muc_archive_size, Host, ?MODULE, archive_size, 50),
-    ejabberd_hooks:delete(mam_muc_lookup_messages, Host, ?MODULE, lookup_messages, 50),
-    ejabberd_hooks:delete(mam_muc_remove_archive, Host, ?MODULE, remove_archive, 50),
-    ejabberd_hooks:delete(get_mam_muc_gdpr_data, Host, ?MODULE, get_mam_muc_gdpr_data, 50),
-    ok.
+hooks(HostType, pm, #{pm := true}) ->
+    [{mam_archive_message, HostType, ?MODULE, archive_message, 50},
+     {mam_archive_size, HostType, ?MODULE, archive_size, 50},
+     {mam_lookup_messages, HostType, ?MODULE, lookup_messages, 50},
+     {mam_remove_archive, HostType, ?MODULE, remove_archive, 50},
+     {get_mam_pm_gdpr_data, HostType, ?MODULE, get_mam_pm_gdpr_data, 50}];
+hooks(HostType, muc, #{muc := true}) ->
+    [{mam_muc_archive_message, HostType, ?MODULE, archive_message_muc, 50},
+     {mam_muc_archive_size, HostType, ?MODULE, archive_size, 50},
+     {mam_muc_lookup_messages, HostType, ?MODULE, lookup_messages_muc, 50},
+     {mam_muc_remove_archive, HostType, ?MODULE, remove_archive, 50},
+     {get_mam_muc_gdpr_data, HostType, ?MODULE, get_mam_muc_gdpr_data, 50}];
+hooks(_HostType, _Opt, _Opts) ->
+    [].
 
 yz_search_index(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, search_index, <<"mam">>).
+    gen_mod:get_module_opt(Host, ?MODULE, [riak, search_index]).
 
 mam_bucket_type(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, bucket_type, <<"mam_yz">>).
+    gen_mod:get_module_opt(Host, ?MODULE, [riak, bucket_type]).
 
 %% LocJID - archive owner's JID
 %% RemJID - interlocutor's JID
@@ -535,4 +504,4 @@ stored_binary_to_packet(Host, Bin) ->
 
 -spec db_message_codec(Host :: jid:server()) -> module().
 db_message_codec(Host) ->
-    gen_mod:get_module_opt(Host, ?MODULE, db_message_format, mam_message_xml).
+    gen_mod:get_module_opt(Host, ?MODULE, db_message_format).

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -836,14 +836,14 @@ packet_to_search_body(false, _Packet) ->
 -spec has_full_text_search(Module :: mod_mam | mod_mam_muc,
                            HostType :: mongooseim:host_type()) -> boolean().
 has_full_text_search(Module, HostType) ->
-    gen_mod:get_module_opt(HostType, Module, full_text_search, true).
+    gen_mod:get_module_opt(HostType, Module, full_text_search).
 
 %% Message retraction
 
 -spec has_message_retraction(Module :: mod_mam | mod_mam_muc,
                              HostType :: mongooseim:host_type()) -> boolean().
 has_message_retraction(Module, HostType) ->
-    gen_mod:get_module_opt(HostType, Module, message_retraction, true).
+    gen_mod:get_module_opt(HostType, Module, message_retraction).
 
 %% -----------------------------------------------------------------------
 %% JID serialization

--- a/src/mongoose_async_pools.erl
+++ b/src/mongoose_async_pools.erl
@@ -43,7 +43,12 @@ config_spec() ->
        items = #{<<"enabled">> => #option{type = boolean},
                  <<"flush_interval">> => #option{type = integer, validate = non_negative},
                  <<"batch_size">> => #option{type = integer, validate = non_negative},
-                 <<"pool_size">> => #option{type = integer, validate = non_negative}}
+                 <<"pool_size">> => #option{type = integer, validate = non_negative}},
+       defaults = #{<<"enabled">> => true,
+                    <<"flush_interval">> => 2000,
+                    <<"batch_size">> => 30,
+                    <<"pool_size">> => 4 * erlang:system_info(schedulers_online)},
+       format_items = map
       }.
 
 -spec pool_name(mongooseim:host_type(), pool_id()) -> pool_name().
@@ -112,9 +117,9 @@ gen_pool_name(HostType, PoolId) ->
 
 -spec make_wpool_opts(mongooseim:host_type(), pool_id(), pool_opts()) -> any().
 make_wpool_opts(HostType, PoolId, Opts) ->
-    Interval = maps:get(flush_interval, Opts, 1000),
-    MaxSize = maps:get(batch_size, Opts, 100),
-    NumWorkers = maps:get(pool_size, Opts, 4 * erlang:system_info(schedulers_online)),
+    Interval = maps:get(flush_interval, Opts),
+    MaxSize = maps:get(batch_size, Opts),
+    NumWorkers = maps:get(pool_size, Opts),
     FlushCallback = maps:get(flush_callback, Opts),
     FlushExtra = make_extra(HostType, PoolId, Opts),
     ProcessOpts = [{message_queue_data, off_heap}],

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -156,9 +156,9 @@
   archive_chat_markers = true
   full_text_search = true
   pm.user_prefs_store = "rdbms"
-  pm.full_text_search =  false
+  pm.full_text_search = false
   muc.host = "muc.example.com"
-  muc.rdbms_message_format = "simple"
+  muc.db_message_format = "mam_message_xml"
   muc.async_writer.enabled = false
   muc.user_prefs_store = "mnesia"
 


### PR DESCRIPTION
Use maps for configuration of all MAM modules.

Main changes:
- Use maps with defaults for MAM options, and pass selected options to the backends.
- The low-level message-format options are the only ones that have different default values per backend, so their defaults are not included in the spec.
- Removed some unused code, e.g. handling of async Cassandra workers, that don't exist.

Other changes:
- Elasticsearch tests were skipped in `mam_SUITE`, this is fixed now.
- Some MUC tests were enabled only for RDBMS, they support other backends now.
- Use `dynamic_modules` to set up `mod_mam_meta` for all MAM big tests (instead of starting backend modules separately). Supply defaults with new helpers in `mam_helper`.


