### PR TITLE
Implement GraphQL MUC Light user queries

### DIFF
--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -4,9 +4,10 @@
 
 -export([execute/3, execute_auth/2, get_listener_port/1, get_listener_config/1]).
 -export([init_admin_handler/1]).
--export([get_ok_value/2, get_err_msg/1]).
+-export([get_ok_value/2, get_err_msg/1, make_creds/1]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("escalus/include/escalus.hrl").
 
 -spec execute(atom(), binary(), {binary(), binary()} | undefined) ->
     {Status :: tuple(), Data :: map()}.
@@ -70,6 +71,11 @@ get_ok_value([errors | Path], {{<<"200">>, <<"OK">>}, #{<<"errors">> := [Error]}
     get_value(Path, Error);
 get_ok_value(Path, {{<<"200">>, <<"OK">>}, Data}) ->
     get_value(Path, Data).
+
+make_creds(#client{props = Props} = Client) ->
+    JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Client)),
+    Password = proplists:get_value(password, Props),
+    {JID, Password}.
 
 %% Internal
 

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -167,7 +167,7 @@ user_change_room_config_story(Config, Alice) ->
     MUCServer = ?config(muc_light_host, Config),
     Creds = make_creds(Alice),
     % Create a new room
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, <<"ornithology">>, <<"birds">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, <<"ornithology">>, <<"birds">>, AliceBin),
     % Try to change the room configuration
     Name2 = <<"changed room">>,
     Subject2 = <<"not testing">>,
@@ -187,7 +187,7 @@ user_change_room_config_errors_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     RoomName = <<"first room">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+        create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     % Try to change the config with a non-existing domain
     Res = execute(Ep, user_change_room_configuration_body(
                         make_bare_jid(RoomID, ?UNKNOWN_DOMAIN), RoomName, <<"subject2">>), CredsAlice),
@@ -218,7 +218,7 @@ user_invite_user_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     Domain = escalus_client:server(Alice),
     Name = <<"first room">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, Name, <<"subject2">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, Name, <<"subject2">>, AliceBin),
     % Room owner can invite a user
     Res = execute(Ep, user_invite_user_body(jid:to_binary(RoomJID), BobBin), CredsAlice),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?INVITE_USER_PATH, Res),
@@ -242,7 +242,7 @@ user_invite_user_errors_story(Config, Alice, Bob) ->
     AliceBin = escalus_client:short_jid(Alice),
     BobBin = escalus_client:short_jid(Bob),
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, <<"first room">>, <<"subject">>, AliceBin),
+        create_room(MUCServer, <<"first room">>, <<"subject">>, AliceBin),
     % Try to invite a user to not existing room
     Res = execute(Ep, user_invite_user_body(
                         make_bare_jid(?UNKNOWN, MUCServer), BobBin), CredsAlice),
@@ -268,7 +268,7 @@ user_delete_room_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     Name = <<"first room">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, Name, <<"subject">>, AliceBin),
+        create_room(MUCServer, Name, <<"subject">>, AliceBin),
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     % Member cannot delete room
     Res = execute(Ep, delete_room_body(jid:to_binary(RoomJID)), CredsBob),
@@ -297,7 +297,7 @@ user_kick_user_story(Config, Alice, Bob) ->
     AliceBin = escalus_client:short_jid(Alice),
     BobBin = escalus_client:short_jid(Bob),
     RoomName = <<"first room">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     % Member kicks himself from a room
     ?assertEqual(2, length(get_room_aff(RoomJID))),
@@ -324,7 +324,7 @@ user_send_message_to_room_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     RoomName = <<"first room">>,
     MsgBody = <<"Hello there!">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     Res = execute(Ep, user_send_message_to_room_body(jid:to_binary(RoomJID), MsgBody), CredsAlice),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?SEND_MESSAGE_PATH, Res),
@@ -345,7 +345,7 @@ user_send_message_to_room_errors_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     MsgBody = <<"Hello there!">>,
     {ok, #{jid := #jid{luser = ARoomID} = ARoomJID}} =
-        create_room(<<>>, MUCServer, <<"alice room">>, <<"subject">>, AliceBin),
+        create_room(MUCServer, <<"alice room">>, <<"subject">>, AliceBin),
     % Try with a non-existing domain
     Res = execute(Ep, user_send_message_to_room_body(
                         make_bare_jid(ARoomID, ?UNKNOWN_DOMAIN), MsgBody), CredsAlice),
@@ -355,7 +355,7 @@ user_send_message_to_room_errors_story(Config, Alice, Bob) ->
                          jid:to_binary(ARoomJID), MsgBody), CredsBob),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not occupy this room">>)),
     % Try with a room not occupied by this user
-    {ok, #{jid := _RoomJID2}} = create_room(<<>>, MUCServer, <<"bob room">>, <<"subject">>, BobBin),
+    {ok, #{jid := _RoomJID2}} = create_room(MUCServer, <<"bob room">>, <<"subject">>, BobBin),
     Res3 = execute(Ep, user_send_message_to_room_body(
                          jid:to_binary(ARoomJID), MsgBody), CredsBob),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not occupy this room">>)).
@@ -370,7 +370,7 @@ user_get_room_messages_story(Config, Alice, Bob) ->
     CredsBob = make_creds(Bob),
     AliceBin = escalus_client:short_jid(Alice),
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, <<"first room">>, <<"subject">>, AliceBin),
+        create_room(MUCServer, <<"first room">>, <<"subject">>, AliceBin),
     Message = <<"Hello friends">>,
     send_message_to_room(RoomJID, jid:from_binary(AliceBin), Message),
     mam_helper:maybe_wait_for_archive(Config),
@@ -404,8 +404,8 @@ user_list_rooms_story(Config, Alice) ->
     MUCServer = ?config(muc_light_host, Config),
     CredsAlice = make_creds(Alice),
     AliceBin = escalus_client:short_jid(Alice),
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, <<"room a">>, <<"subject">>, AliceBin),
-    {ok, #{jid := RoomJID2}} = create_room(<<>>, MUCServer, <<"room b">>, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, <<"room a">>, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID2}} = create_room(MUCServer, <<"room b">>, <<"subject">>, AliceBin),
     Res = execute(Ep, user_list_rooms_body(), CredsAlice),
     ?assertEqual(lists:sort([jid:to_binary(RoomJID), jid:to_binary(RoomJID2)]),
                  lists:sort(get_ok_value(?USER_LIST_ROOMS_PATH, Res))).
@@ -421,7 +421,7 @@ user_list_room_users_story(Config, Alice, Bob) ->
     AliceBin = escalus_client:short_jid(Alice),
     BobBin = escalus_client:short_jid(Bob),
     AliceLower = escalus_utils:jid_to_lower(AliceBin),
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, <<"room a">>, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, <<"room a">>, <<"subject">>, AliceBin),
     % Owner can list rooms
     Res = execute(Ep, list_room_users_body(jid:to_binary(RoomJID)), CredsAlice),
     ?assertEqual([#{<<"jid">> => AliceLower, <<"affiliation">> => <<"OWNER">>}],
@@ -458,7 +458,7 @@ user_get_room_config_story(Config, Alice, Bob) ->
     RoomName = <<"first room">>,
     RoomSubject = <<"Room about nothing">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, RoomName, RoomSubject, AliceBin),
+        create_room(MUCServer, RoomName, RoomSubject, AliceBin),
     RoomJIDBin = jid:to_binary(RoomJID),
     Res = execute(Ep, get_room_config_body(jid:to_binary(RoomJID)), CredsAlice),
     % Owner can get a config
@@ -493,7 +493,7 @@ user_blocking_list_story(Config, Alice, Bob) ->
     CredsAlice = make_creds(Alice),
     BobBin = escalus_client:full_jid(Bob),
     BobShortBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
-    {ok, #{jid := RoomJID}} = create_room(<<>>, ?config(muc_light_host, Config),
+    {ok, #{jid := RoomJID}} = create_room(?config(muc_light_host, Config),
                                           <<"room">>, <<"subject">>, BobBin),
     RoomBin = jid:to_binary(RoomJID),
     Res = execute(Ep, user_get_blocking_body(), CredsAlice),
@@ -600,7 +600,7 @@ admin_change_room_config_story(Config, Alice) ->
     Name = <<"first room">>,
     Subject = <<"testing">>,
     % Create a new room
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, Name, Subject, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, Name, Subject, AliceBin),
     % Try to change the room configuration
     Name2 = <<"changed room">>,
     Subject2 = <<"not testing">>,
@@ -619,7 +619,7 @@ admin_change_room_config_errors_story(Config, Alice, Bob) ->
     MUCServer = ?config(muc_light_host, Config),
     RoomName = <<"first room">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+        create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     % Try to change the config with a non-existing domain
     Res = execute_auth(admin_change_room_configuration_body(
@@ -650,7 +650,7 @@ admin_invite_user_story(Config, Alice, Bob) ->
     Domain = escalus_client:server(Alice),
     MUCServer = ?config(muc_light_host, Config),
     Name = <<"first room">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, Name, <<"subject2">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, Name, <<"subject2">>, AliceBin),
 
     Res = execute_auth(admin_invite_user_body(jid:to_binary(RoomJID), AliceBin, BobBin), Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?INVITE_USER_PATH, Res),
@@ -670,7 +670,7 @@ admin_invite_user_errors_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     MUCServer = ?config(muc_light_host, Config),
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, <<"first room">>, <<"subject">>, AliceBin),
+        create_room(MUCServer, <<"first room">>, <<"subject">>, AliceBin),
     % Try to invite a user to not existing room
     Res = execute_auth(admin_invite_user_body(
                          make_bare_jid(?UNKNOWN, MUCServer), AliceBin, BobBin), Config),
@@ -692,7 +692,7 @@ admin_delete_room_story(Config, Alice) ->
     MUCServer = ?config(muc_light_host, Config),
     Name = <<"first room">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, Name, <<"subject">>, AliceBin),
+        create_room(MUCServer, Name, <<"subject">>, AliceBin),
     Res = execute_auth(delete_room_body(jid:to_binary(RoomJID)), Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_ROOM_PATH, Res),
                                           <<"successfully">>)),
@@ -712,8 +712,7 @@ admin_kick_user_story(Config, Alice, Bob) ->
     BobBin = escalus_client:short_jid(Bob),
     MUCServer = ?config(muc_light_host, Config),
     RoomName = <<"first room">>,
-    RoomID = <<"kick_user_test_room">>,
-    {ok, #{jid := RoomJID}} = create_room(RoomID, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     ?assertEqual(2, length(get_room_aff(RoomJID))),
     Res = execute_auth(admin_kick_user_body(jid:to_binary(RoomJID), BobBin), Config),
@@ -731,7 +730,7 @@ admin_send_message_to_room_story(Config, Alice, Bob) ->
     MUCServer = ?config(muc_light_host, Config),
     RoomName = <<"first room">>,
     MsgBody = <<"Hello there!">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     Res = execute_auth(admin_send_message_to_room_body(
                          jid:to_binary(RoomJID), AliceBin, MsgBody), Config),
@@ -750,7 +749,7 @@ admin_send_message_to_room_errors_story(Config, Alice, Bob) ->
     MUCServer = ?config(muc_light_host, Config),
     MsgBody = <<"Hello there!">>,
     {ok, #{jid := #jid{luser = ARoomID} = ARoomJID}} =
-        create_room(<<>>, MUCServer, <<"alice room">>, <<"subject">>, AliceBin),
+        create_room(MUCServer, <<"alice room">>, <<"subject">>, AliceBin),
     % Try with a non-existing domain
     Res2 = execute_auth(admin_send_message_to_room_body(
                           make_bare_jid(ARoomID, ?UNKNOWN_DOMAIN), AliceBin, MsgBody), Config),
@@ -760,7 +759,7 @@ admin_send_message_to_room_errors_story(Config, Alice, Bob) ->
                           jid:to_binary(ARoomJID), BobBin, MsgBody), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"does not occupy this room">>)),
     % Try with a room not occupied by this user
-    {ok, #{jid := _RoomJID2}} = create_room(<<>>, MUCServer, <<"bob room">>, <<"subject">>, BobBin),
+    {ok, #{jid := _RoomJID2}} = create_room(MUCServer, <<"bob room">>, <<"subject">>, BobBin),
     Res4 = execute_auth(admin_send_message_to_room_body(
                           jid:to_binary(ARoomJID), BobBin, MsgBody), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res4), <<"does not occupy this room">>)).
@@ -775,8 +774,8 @@ admin_get_room_messages_story(Config, Alice) ->
     RoomName = <<"first room">>,
     RoomName2 = <<"second room">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
-    {ok, _} = create_room(<<>>, MUCServer, RoomName2, <<"subject">>, AliceBin),
+        create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, _} = create_room(MUCServer, RoomName2, <<"subject">>, AliceBin),
     Message = <<"Hello friends">>,
     send_message_to_room(RoomJID, jid:from_binary(AliceBin), Message),
     mam_helper:maybe_wait_for_archive(Config),
@@ -807,8 +806,8 @@ admin_list_user_rooms_story(Config, Alice) ->
     MUCServer = ?config(muc_light_host, Config),
     RoomName = <<"first room">>,
     RoomName2 = <<"second room">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
-    {ok, #{jid := RoomJID2}} = create_room(<<>>, MUCServer, RoomName2, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID2}} = create_room(MUCServer, RoomName2, <<"subject">>, AliceBin),
     Res = execute_auth(admin_list_user_rooms_body(AliceBin), Config),
     ?assertEqual(lists:sort([jid:to_binary(RoomJID), jid:to_binary(RoomJID2)]),
                  lists:sort(get_ok_value(?LIST_USER_ROOMS_PATH, Res))),
@@ -827,7 +826,7 @@ admin_list_room_users_story(Config, Alice) ->
     AliceLower = escalus_utils:jid_to_lower(AliceBin),
     MUCServer = ?config(muc_light_host, Config),
     RoomName = <<"first room">>,
-    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(MUCServer, RoomName, <<"subject">>, AliceBin),
     Res = execute_auth(list_room_users_body(jid:to_binary(RoomJID)), Config),
     ?assertEqual([#{<<"jid">> => AliceLower, <<"affiliation">> => <<"OWNER">>}],
                  get_ok_value(?LIST_ROOM_USERS_PATH, Res)),
@@ -850,7 +849,7 @@ admin_get_room_config_story(Config, Alice) ->
     RoomName = <<"first room">>,
     RoomSubject = <<"Room about nothing">>,
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
-        create_room(<<>>, MUCServer, RoomName, RoomSubject, AliceBin),
+        create_room(MUCServer, RoomName, RoomSubject, AliceBin),
     RoomJIDBin = jid:to_binary(RoomJID),
     Res = execute_auth(get_room_config_body(jid:to_binary(RoomJID)), Config),
     ?assertEqual(#{<<"jid">> => RoomJIDBin, <<"subject">> => RoomSubject, <<"name">> => RoomName,
@@ -877,9 +876,9 @@ get_room_messages(ID, Domain) ->
     {ok, Messages} = rpc(mim(), mod_muc_light_api, get_room_messages, [Domain, ID]),
     Messages.
 
-create_room(Id, Domain, Name, Subject, CreatorBin) ->
+create_room(Domain, Name, Subject, CreatorBin) ->
     CreatorJID = jid:from_binary(CreatorBin),
-    rpc(mim(), mod_muc_light_api, create_room, [Domain, Id, Name, CreatorJID, Subject]).
+    rpc(mim(), mod_muc_light_api, create_room, [Domain, CreatorJID, Name, Subject]).
 
 invite_user(RoomJID, SenderBin, RecipientBin) ->
     SenderJID = jid:from_binary(SenderBin),

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -4,7 +4,8 @@
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
 -import(graphql_helper, [execute/3, execute_auth/2, get_listener_port/1,
-                         get_listener_config/1, get_ok_value/2, get_err_msg/1]).
+                         get_listener_config/1, get_ok_value/2, get_err_msg/1,
+                         make_creds/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("jid/include/jid.hrl").
@@ -14,6 +15,21 @@
 -define(UNKNOWN_DOMAIN, <<"not-existing-domain">>).
 -define(UNKNOWN, <<"not-existing">>).
 
+%% GraphQL Paths
+-define(CREATE_ROOM_PATH, [data, muc_light, createRoom]).
+-define(CHANGE_CONFIG_PATH, [data, muc_light, changeRoomConfiguration]).
+-define(INVITE_USER_PATH, [data, muc_light, inviteUser]).
+-define(KICK_USER_PATH, [data, muc_light, kickUser]).
+-define(DELETE_ROOM_PATH, [data, muc_light, deleteRoom]).
+-define(SEND_MESSAGE_PATH, [data, muc_light, sendMessageToRoom]).
+-define(GET_MESSAGES_PATH, [data, muc_light, getRoomMessages]).
+-define(LIST_USER_ROOMS_PATH, [data, muc_light, listUserRooms]).
+-define(USER_LIST_ROOMS_PATH, [data, muc_light, listRooms]).
+-define(LIST_ROOM_USERS_PATH, [data, muc_light, listRoomUsers]).
+-define(GET_ROOM_CONFIG_PATH, [data, muc_light, getRoomConfig]).
+-define(GET_BLOCKING_LIST_PATH, [data, muc_light, getBlockingList]).
+-define(SET_BLOCKING_LIST_PATH, [data, muc_light, setBlockingList]).
+
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
@@ -22,11 +38,25 @@ all() ->
      {group, admin_muc_light}].
 
 groups() ->
-    [{user_muc_light, [], user_muc_light_handler()},
-     {admin_muc_light, [], admin_muc_light_handler()}].
+    [{user_muc_light, [parallel], user_muc_light_handler()},
+     {admin_muc_light, [parallel], admin_muc_light_handler()}].
 
 user_muc_light_handler() ->
-    [mock].
+    [user_create_room,
+     user_create_identified_room,
+     user_change_room_config,
+     user_change_room_config_errors,
+     user_invite_user,
+     user_invite_user_errors,
+     user_delete_room,
+     user_kick_user,
+     user_send_message_to_room,
+     user_send_message_to_room_errors,
+     user_get_room_messages,
+     user_list_rooms,
+     user_list_room_users,
+     user_get_room_config
+    ].
 
 admin_muc_light_handler() ->
     [admin_create_room,
@@ -72,20 +102,388 @@ common_muc_light_opts() ->
 
 init_per_group(admin_muc_light, Config) ->
     graphql_helper:init_admin_handler(Config);
-init_per_group(_GN, Config) ->
-    Config.
+init_per_group(user_muc_light, Config) ->
+    [{schema_endpoint, user} | Config].
 
 end_per_group(_GN, Config) ->
     Config.
 
 init_per_testcase(TC, Config) ->
-    rest_helper:maybe_skip_mam_test_cases(TC, [admin_get_room_messages], Config).
+    rest_helper:maybe_skip_mam_test_cases(TC, [user_get_room_messages,
+                                               admin_get_room_messages], Config).
 
 end_per_testcase(TC, Config) ->
     escalus:end_per_testcase(TC, Config).
 
-mock(_Config) ->
-    ok.
+%% User test cases
+
+user_create_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_create_room_story/2).
+
+user_create_room_story(Config, Alice) ->
+    Ep = ?config(schema_endpoint, Config),
+    MucServer = ?config(muc_light_host, Config),
+    AliceBinLower = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
+    Creds = make_creds(Alice),
+    Name = <<"first room">>,
+    Subject = <<"testing">>,
+    Res = execute(Ep, user_create_room_body(MucServer, Name, Subject, null), Creds),
+    #{<<"jid">> := JID, <<"name">> := Name, <<"subject">> := Subject,
+      <<"participants">> := Participants} = get_ok_value(?CREATE_ROOM_PATH, Res),
+    ?assertMatch(#jid{server = MucServer}, jid:from_binary(JID)),
+    ?assertEqual([#{<<"jid">> => AliceBinLower, <<"affiliation">> => <<"OWNER">>}], Participants),
+    % Try with a non-existing domain
+    Res2 = execute(Ep, user_create_room_body(?UNKNOWN_DOMAIN, Name, Subject, null), Creds),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)).
+
+user_create_identified_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_create_identified_room_story/2).
+
+user_create_identified_room_story(Config, Alice) ->
+    Ep = ?config(schema_endpoint, Config),
+    MucServer = ?config(muc_light_host, Config),
+    Creds = make_creds(Alice),
+    Name = <<"first room">>,
+    Subject = <<"testing">>,
+    Id = <<"my_user_room">>,
+    Res = execute(Ep, user_create_room_body(MucServer, Name, Subject, Id), Creds),
+    #{<<"jid">> := JID, <<"name">> := Name, <<"subject">> := Subject} = get_ok_value(?CREATE_ROOM_PATH, Res),
+    ?assertMatch(#jid{user = Id, server = MucServer}, jid:from_binary(JID)),
+    % Create a room with an existing ID
+    Res2 = execute(Ep, user_create_room_body(MucServer, <<"snd room">>, Subject, Id), Creds),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"already exists">>)),
+    % Try with a non-existing domain
+    Res3 = execute(Ep, user_create_room_body(?UNKNOWN_DOMAIN, <<"name">>, Subject, Id), Creds),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)).
+
+user_change_room_config(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_change_room_config_story/2).
+
+user_change_room_config_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    Creds = make_creds(Alice),
+    % Create a new room
+    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, <<"ornithology">>, <<"birds">>, AliceBin),
+    % Try to change the room configuration
+    Name2 = <<"changed room">>,
+    Subject2 = <<"not testing">>,
+    Res = execute(Ep, user_change_room_configuration_body(jid:to_binary(RoomJID), Name2, Subject2), Creds),
+    ?assertMatch(#{<<"name">> := Name2, <<"subject">> := Subject2}, get_ok_value(?CHANGE_CONFIG_PATH, Res)).
+
+user_change_room_config_errors(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun user_change_room_config_errors_story/3).
+
+user_change_room_config_errors_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    RoomName = <<"first room">>,
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
+        create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    % Try to change the config with a non-existing domain
+    Res = execute(Ep, user_change_room_configuration_body(
+                        make_bare_jid(RoomID, ?UNKNOWN_DOMAIN), RoomName, <<"subject2">>), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
+    % Try to change the config of the non-existing room
+    Res2 = execute(Ep, user_change_room_configuration_body(
+                         make_bare_jid(?UNKNOWN, MUCServer), RoomName, <<"subject2">>), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)),
+    % Try to change the config by the user that not occupy this room
+    Res3 = execute(Ep, user_change_room_configuration_body(
+                         jid:to_binary(RoomJID), RoomName, <<"subject2">>), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not occupy this room">>)),
+    % Try to change a config by the user without permission
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    Res4 = execute(Ep, user_change_room_configuration_body(
+                         jid:to_binary(RoomJID), RoomName, <<"subject2">>), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res4),
+                                          <<"does not have permission to change">>)).
+
+user_invite_user(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun user_invite_user_story/3).
+
+user_invite_user_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    Domain = escalus_client:server(Alice),
+    Name = <<"first room">>,
+    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, Name, <<"subject2">>, AliceBin),
+    % Room owner can invite a user
+    Res = execute(Ep, user_invite_user_body(jid:to_binary(RoomJID), BobBin), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?INVITE_USER_PATH, Res),
+                                          <<"successfully">>)),
+    escalus:wait_for_stanza(Bob),
+    BobName = escalus_utils:jid_to_lower(escalus_client:username(Bob)),
+    AliceName = escalus_utils:jid_to_lower(escalus_client:username(Alice)),
+    ExpectedAff = lists:sort([{{AliceName, Domain}, owner},
+                              {{BobName, Domain}, member}]),
+    ?assertMatch(ExpectedAff, lists:sort(get_room_aff(RoomJID))).
+
+user_invite_user_errors(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun user_invite_user_errors_story/3).
+
+user_invite_user_errors_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
+        create_room(<<>>, MUCServer, <<"first room">>, <<"subject">>, AliceBin),
+    % Try to invite a user to not existing room
+    Res = execute(Ep, user_invite_user_body(
+                        make_bare_jid(?UNKNOWN, MUCServer), BobBin), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not occupy this room">>)),
+    % User without rooms tries to invite a user
+    Res2 = execute(Ep, user_invite_user_body(
+                         jid:to_binary(RoomJID), AliceBin), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"does not occupy this room">>)),
+    % Try with a non-existing domain
+    Res3 = execute(Ep, user_invite_user_body(
+                         make_bare_jid(RoomID, ?UNKNOWN_DOMAIN), BobBin), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)).
+
+user_delete_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun user_delete_room_story/3).
+
+user_delete_room_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    Name = <<"first room">>,
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
+        create_room(<<>>, MUCServer, Name, <<"subject">>, AliceBin),
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    % Member cannot delete room
+    Res = execute(Ep, delete_room_body(jid:to_binary(RoomJID)), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res),
+                                          <<"cannot delete this room">>)),
+    % Owner can delete own room
+    Res2 = execute(Ep, delete_room_body(jid:to_binary(RoomJID)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_ROOM_PATH, Res2),
+                                          <<"successfully">>)),
+    ?assertEqual({error, not_exists}, get_room_info(jid:from_binary(RoomJID))),
+    % Try with a non-existing domain
+    Res3 = execute(Ep, delete_room_body(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)),
+    % Try with a non-existing room
+    Res4 = execute(Ep, delete_room_body(make_bare_jid(?UNKNOWN, MUCServer)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res4), <<"not existing room">>)).
+
+user_kick_user(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun user_kick_user_story/3).
+
+user_kick_user_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    RoomName = <<"first room">>,
+    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    % Member kicks himself from a room
+    ?assertEqual(2, length(get_room_aff(RoomJID))),
+    Res = execute(Ep, user_kick_user_body(jid:to_binary(RoomJID), null), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?KICK_USER_PATH, Res),
+                                          <<"successfully">>)),
+    ?assertEqual(1, length(get_room_aff(RoomJID))),
+    % Owner kicks the member from a room
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    Res2 = execute(Ep, user_kick_user_body(jid:to_binary(RoomJID), BobBin), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?KICK_USER_PATH, Res2),
+                                          <<"successfully">>)),
+    ?assertEqual(1, length(get_room_aff(RoomJID))).
+
+user_send_message_to_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun user_send_message_to_room_story/3).
+
+user_send_message_to_room_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    RoomName = <<"first room">>,
+    MsgBody = <<"Hello there!">>,
+    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    Res = execute(Ep, user_send_message_to_room_body(jid:to_binary(RoomJID), MsgBody), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?SEND_MESSAGE_PATH, Res),
+                                          <<"successfully">>)),
+    [_, Msg] = escalus:wait_for_stanzas(Bob, 2),
+    escalus:assert(is_message, Msg).
+
+user_send_message_to_room_errors(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun user_send_message_to_room_errors_story/3).
+
+user_send_message_to_room_errors_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    MsgBody = <<"Hello there!">>,
+    {ok, #{jid := #jid{luser = ARoomID} = ARoomJID}} =
+        create_room(<<>>, MUCServer, <<"alice room">>, <<"subject">>, AliceBin),
+    % Try with a non-existing domain
+    Res = execute(Ep, user_send_message_to_room_body(
+                        make_bare_jid(ARoomID, ?UNKNOWN_DOMAIN), MsgBody), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
+    % Try with a user without rooms
+    Res2 = execute(Ep, user_send_message_to_room_body(
+                         jid:to_binary(ARoomJID), MsgBody), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not occupy this room">>)),
+    % Try with a room not occupied by this user
+    {ok, #{jid := _RoomJID2}} = create_room(<<>>, MUCServer, <<"bob room">>, <<"subject">>, BobBin),
+    Res3 = execute(Ep, user_send_message_to_room_body(
+                         jid:to_binary(ARoomJID), MsgBody), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not occupy this room">>)).
+
+user_get_room_messages(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun user_get_room_messages_story/3).
+
+user_get_room_messages_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
+        create_room(<<>>, MUCServer, <<"first room">>, <<"subject">>, AliceBin),
+    Message = <<"Hello friends">>,
+    send_message_to_room(RoomJID, jid:from_binary(AliceBin), Message),
+    mam_helper:maybe_wait_for_archive(Config),
+    % Get messages so far
+    Limit = 40,
+    Res = execute(Ep, get_room_messages_body(jid:to_binary(RoomJID), Limit, null), CredsAlice),
+    #{<<"stanzas">> :=[#{<<"stanza">> := StanzaXML}], <<"limit">> := Limit} =
+        get_ok_value(?GET_MESSAGES_PATH, Res),
+    ?assertMatch({ok, #xmlel{name = <<"message">>}}, exml:parse(StanzaXML)),
+    % Get messages before the given date and time
+    Before = <<"2022-02-17T04:54:13+00:00">>,
+    Res2 = execute(Ep, get_room_messages_body(jid:to_binary(RoomJID), null, Before), CredsAlice),
+    ?assertMatch(#{<<"stanzas">> := [], <<"limit">> := 50}, get_ok_value(?GET_MESSAGES_PATH, Res2)),
+    % Try to pass too big page size value
+    Res3 = execute(Ep, get_room_messages_body(jid:to_binary(RoomJID), 51, Before), CredsAlice),
+    ?assertMatch(#{<<"limit">> := 50}, get_ok_value(?GET_MESSAGES_PATH, Res3)),
+    % Try with a non-existing domain
+    Res4 = execute(Ep, get_room_messages_body(
+                          make_bare_jid(RoomID, ?UNKNOWN_DOMAIN), Limit, null), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res4), <<"not found">>)),
+    % Try with a user that is not a room member
+    Res5 = execute(Ep, get_room_messages_body(
+                          jid:to_binary(RoomJID), Limit, null), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res5), <<"not occupy this room">>)).
+
+user_list_rooms(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_list_rooms_story/2).
+
+user_list_rooms_story(Config, Alice) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    AliceBin = escalus_client:short_jid(Alice),
+    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, <<"room a">>, <<"subject">>, AliceBin),
+    {ok, #{jid := RoomJID2}} = create_room(<<>>, MUCServer, <<"room b">>, <<"subject">>, AliceBin),
+    Res = execute(Ep, user_list_rooms_body(), CredsAlice),
+    ?assertEqual(lists:sort([jid:to_binary(RoomJID), jid:to_binary(RoomJID2)]),
+                 lists:sort(get_ok_value(?USER_LIST_ROOMS_PATH, Res))).
+
+user_list_room_users(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun user_list_room_users_story/3).
+
+user_list_room_users_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    AliceLower = escalus_utils:jid_to_lower(AliceBin),
+    {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, <<"room a">>, <<"subject">>, AliceBin),
+    % Owner can list rooms
+    Res = execute(Ep, list_room_users_body(jid:to_binary(RoomJID)), CredsAlice),
+    ?assertEqual([#{<<"jid">> => AliceLower, <<"affiliation">> => <<"OWNER">>}],
+                 get_ok_value(?LIST_ROOM_USERS_PATH, Res)),
+    % Try with a non-existing domain
+    Res2 = execute(Ep, list_room_users_body(
+                         make_bare_jid(RoomJID#jid.luser, ?UNKNOWN_DOMAIN)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)),
+    % Try with a non-existing room
+    Res3 = execute(Ep, list_room_users_body(
+                         make_bare_jid(?UNKNOWN, MUCServer)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)),
+    % User that is not a member cannot get aff
+    Res4 = execute(Ep, list_room_users_body(jid:to_binary(RoomJID)), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res4), <<"not occupy this room">>)),
+    % Member can get aff
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    escalus:wait_for_stanza(Bob),
+    Res5 = execute(Ep, list_room_users_body(jid:to_binary(RoomJID)), CredsBob),
+    ?assertMatch([_, _], get_ok_value(?LIST_ROOM_USERS_PATH, Res5)).
+
+user_get_room_config(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun user_get_room_config_story/3).
+
+user_get_room_config_story(Config, Alice, Bob) ->
+    Ep = ?config(schema_endpoint, Config),
+    MUCServer = ?config(muc_light_host, Config),
+    CredsAlice = make_creds(Alice),
+    CredsBob = make_creds(Bob),
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    AliceLower = escalus_utils:jid_to_lower(AliceBin),
+    BobLower = escalus_utils:jid_to_lower(BobBin),
+    RoomName = <<"first room">>,
+    RoomSubject = <<"Room about nothing">>,
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
+        create_room(<<>>, MUCServer, RoomName, RoomSubject, AliceBin),
+    RoomJIDBin = jid:to_binary(RoomJID),
+    Res = execute(Ep, get_room_config_body(jid:to_binary(RoomJID)), CredsAlice),
+    % Owner can get a config
+    ?assertEqual(#{<<"jid">> => RoomJIDBin, <<"subject">> => RoomSubject, <<"name">> => RoomName,
+                    <<"participants">> => [#{<<"jid">> => AliceLower,
+                                             <<"affiliation">> => <<"OWNER">>}]},
+                 get_ok_value(?GET_ROOM_CONFIG_PATH, Res)),
+    % Try with a non-existing domain
+    Res2 = execute(Ep, get_room_config_body(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)),
+    % Try with a non-existing room
+    Res3 = execute(Ep, get_room_config_body(make_bare_jid(?UNKNOWN, MUCServer)), CredsAlice),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)),
+    % User that is not a member cannot get a room config
+    Res4 = execute(Ep, get_room_config_body(jid:to_binary(RoomJID)), CredsBob),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res4), <<"not occupy this room">>)),
+    % Member can get a config
+    {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
+    Res5 = execute(Ep, get_room_config_body(jid:to_binary(RoomJID)), CredsAlice),
+    ?assertEqual(#{<<"jid">> => RoomJIDBin, <<"subject">> => RoomSubject, <<"name">> => RoomName,
+                    <<"participants">> => [#{<<"jid">> => AliceLower,
+                                             <<"affiliation">> => <<"OWNER">>},
+                                           #{<<"jid">> => BobLower,
+                                             <<"affiliation">> => <<"MEMBER">>}]},
+                 get_ok_value(?GET_ROOM_CONFIG_PATH, Res5)).
+
+%% Admin test cases
 
 admin_create_room(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_create_room_story/2).
@@ -207,7 +605,7 @@ admin_invite_user_errors_story(Config, Alice, Bob) ->
     AliceBin = escalus_client:short_jid(Alice),
     BobBin = escalus_client:short_jid(Bob),
     MUCServer = ?config(muc_light_host, Config),
-    {ok, #{jid := #jid{luser = RoomID}}} =
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
         create_room(<<>>, MUCServer, <<"first room">>, <<"subject">>, AliceBin),
     % Try to invite a user to not existing room
     Res = execute_auth(admin_invite_user_body(
@@ -215,7 +613,7 @@ admin_invite_user_errors_story(Config, Alice, Bob) ->
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not occupy this room">>)),
     % User without rooms tries to invite a user
     Res2 = execute_auth(admin_invite_user_body(
-                          make_bare_jid(?UNKNOWN, MUCServer), BobBin, AliceBin), Config),
+                          jid:to_binary(RoomJID), BobBin, AliceBin), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"does not occupy this room">>)),
     % Try with a non-existing domain
     Res3 = execute_auth(admin_invite_user_body(
@@ -229,17 +627,17 @@ admin_delete_room_story(Config, Alice) ->
     AliceBin = escalus_client:short_jid(Alice),
     MUCServer = ?config(muc_light_host, Config),
     Name = <<"first room">>,
-    RoomID = <<"delete_room_id">>,
-    {ok, #{jid := RoomJID}} = create_room(RoomID, MUCServer, Name, <<"subject">>, AliceBin),
-    Res = execute_auth(admin_delete_room_body(jid:to_binary(RoomJID)), Config),
-    ?assertNotEqual(nomatch, binary:match(get_ok_value([data, muc_light, deleteRoom], Res),
+    {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
+        create_room(<<>>, MUCServer, Name, <<"subject">>, AliceBin),
+    Res = execute_auth(delete_room_body(jid:to_binary(RoomJID)), Config),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_ROOM_PATH, Res),
                                           <<"successfully">>)),
     ?assertEqual({error, not_exists}, get_room_info(jid:from_binary(RoomJID))),
     % Try with a non-existing domain
-    Res2 = execute_auth(admin_delete_room_body(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN)), Config),
+    Res2 = execute_auth(delete_room_body(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN)), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)),
     % Try with a non-existing room
-    Res3 = execute_auth(admin_delete_room_body(make_bare_jid(?UNKNOWN, MUCServer)), Config),
+    Res3 = execute_auth(delete_room_body(make_bare_jid(?UNKNOWN, MUCServer)), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)).
 
 admin_kick_user(Config) ->
@@ -273,8 +671,10 @@ admin_send_message_to_room_story(Config, Alice, Bob) ->
     {ok, _} = invite_user(RoomJID, AliceBin, BobBin),
     Res = execute_auth(admin_send_message_to_room_body(
                          jid:to_binary(RoomJID), AliceBin, MsgBody), Config),
-    ?assertNotEqual(nomatch, binary:match(get_ok_value([data, muc_light, sendMessageToRoom], Res),
-                                          <<"successfully">>)).
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?SEND_MESSAGE_PATH, Res),
+                                          <<"successfully">>)),
+    [_, Msg] = escalus:wait_for_stanzas(Bob, 2),
+    escalus:assert(is_message, Msg).
 
 admin_send_message_to_room_errors(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -318,15 +718,15 @@ admin_get_room_messages_story(Config, Alice) ->
     send_message_to_room(RoomJID, jid:from_binary(AliceBin), Message),
     mam_helper:maybe_wait_for_archive(Config),
     % Get messages so far
-    Res = execute_auth(admin_get_room_messages_body(jid:to_binary(RoomJID), 50, null), Config),
+    Res = execute_auth(get_room_messages_body(jid:to_binary(RoomJID), 50, null), Config),
     [#{<<"stanza">> := StanzaXML}] = get_ok_value(Path, Res),
     ?assertMatch({ok, #xmlel{name = <<"message">>}}, exml:parse(StanzaXML)),
     % Get messages before the given date and time
     Before = <<"2022-02-17T04:54:13+00:00">>,
-    Res2 = execute_auth(admin_get_room_messages_body(jid:to_binary(RoomJID), 50, Before), Config),
+    Res2 = execute_auth(get_room_messages_body(jid:to_binary(RoomJID), 50, Before), Config),
     ?assertMatch([], get_ok_value(Path, Res2)),
     % Try with a non-existing domain
-    Res3 = execute_auth(admin_get_room_messages_body(
+    Res3 = execute_auth(get_room_messages_body(
                           make_bare_jid(RoomID, ?UNKNOWN_DOMAIN), 50, null), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)).
 
@@ -361,15 +761,15 @@ admin_list_room_users_story(Config, Alice) ->
     MUCServer = ?config(muc_light_host, Config),
     RoomName = <<"first room">>,
     {ok, #{jid := RoomJID}} = create_room(<<>>, MUCServer, RoomName, <<"subject">>, AliceBin),
-    Res = execute_auth(admin_list_room_users_body(jid:to_binary(RoomJID)), Config),
+    Res = execute_auth(list_room_users_body(jid:to_binary(RoomJID)), Config),
     ?assertEqual([#{<<"jid">> => AliceLower, <<"affiliation">> => <<"OWNER">>}],
                  get_ok_value([data, muc_light, listRoomUsers], Res)),
     % Try with a non-existing domain
-    Res2 = execute_auth(admin_list_room_users_body(
+    Res2 = execute_auth(list_room_users_body(
                           make_bare_jid(RoomJID#jid.luser, ?UNKNOWN_DOMAIN)), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)),
     % Try with a non-existing room
-    Res3 = execute_auth(admin_list_room_users_body(
+    Res3 = execute_auth(list_room_users_body(
                           make_bare_jid(?UNKNOWN, MUCServer)), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)).
 
@@ -385,16 +785,16 @@ admin_get_room_config_story(Config, Alice) ->
     {ok, #{jid := #jid{luser = RoomID} = RoomJID}} =
         create_room(<<>>, MUCServer, RoomName, RoomSubject, AliceBin),
     RoomJIDBin = jid:to_binary(RoomJID),
-    Res = execute_auth(admin_get_room_config_body(jid:to_binary(RoomJID)), Config),
+    Res = execute_auth(get_room_config_body(jid:to_binary(RoomJID)), Config),
     ?assertEqual(#{<<"jid">> => RoomJIDBin, <<"subject">> => RoomSubject, <<"name">> => RoomName,
                     <<"participants">> => [#{<<"jid">> => AliceLower,
                                              <<"affiliation">> => <<"OWNER">>}]},
                  get_ok_value([data, muc_light, getRoomConfig], Res)),
     % Try with a non-existing domain
-    Res2 = execute_auth(admin_get_room_config_body(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN)), Config),
+    Res2 = execute_auth(get_room_config_body(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN)), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"not found">>)),
     % Try with a non-existing room
-    Res3 = execute_auth(admin_get_room_config_body(make_bare_jid(?UNKNOWN, MUCServer)), Config),
+    Res3 = execute_auth(get_room_config_body(make_bare_jid(?UNKNOWN, MUCServer)), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)).
 
 %% Helpers
@@ -455,13 +855,6 @@ admin_invite_user_body(RoomJID, Sender, Recipient) ->
     Vars = #{<<"room">> => RoomJID, <<"sender">> => Sender, <<"recipient">> => Recipient},
     #{query => Query, operationName => OpName, variables => Vars}.
 
-admin_delete_room_body(RoomJID) ->
-    Query = <<"mutation M1($room: JID!)
-              { muc_light { deleteRoom(room: $room) } }">>,
-    OpName = <<"M1">>,
-    Vars = #{<<"room">> => RoomJID},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
 admin_kick_user_body(RoomJID, User) ->
     Query = <<"mutation M1($room: JID!, $user: JID!)
               { muc_light { kickUser(room: $room, user: $user)} }">>,
@@ -476,14 +869,6 @@ admin_send_message_to_room_body(RoomJID, From, Body) ->
     Vars = #{<<"room">> => RoomJID, <<"from">> => From, <<"body">> => Body},
     #{query => Query, operationName => OpName, variables => Vars}.
 
-admin_get_room_messages_body(RoomJID, PageSize, Before) ->
-    Query = <<"query Q1($room: JID!, $pageSize: Int!, $before: DateTime)
-              { muc_light { getRoomMessages(room: $room, pageSize: $pageSize, before: $before)
-              { stanzas { stanza } } } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"room">> => RoomJID, <<"pageSize">> => PageSize, <<"before">> => Before},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
 admin_list_user_rooms_body(User) ->
     Query = <<"query Q1($user: JID!)
               { muc_light { listUserRooms(user: $user) } }">>,
@@ -491,7 +876,64 @@ admin_list_user_rooms_body(User) ->
     Vars = #{<<"user">> => User},
     #{query => Query, operationName => OpName, variables => Vars}.
 
-admin_list_room_users_body(RoomJID) ->
+user_create_room_body(MUCDomain, Name, Subject, Id) ->
+    Query = <<"mutation M1($mucDomain: String!, $name: String!, $subject: String!, $id: String)
+              { muc_light { createRoom(mucDomain: $mucDomain, name: $name, subject: $subject, id: $id)
+              { jid name subject participants {jid affiliation} } } }">>,
+    OpName = <<"M1">>,
+    Vars = #{<<"mucDomain">> => MUCDomain, <<"name">> => Name, <<"subject">> => Subject,
+             <<"id">> => Id},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_change_room_configuration_body(RoomJID, Name, Subject) ->
+    Query = <<"mutation M1($room: JID!, $name: String!, $subject: String!)
+              { muc_light { changeRoomConfiguration(room: $room, name: $name, subject: $subject)
+              { jid name subject participants {jid affiliation} } } }">>,
+    OpName = <<"M1">>,
+    Vars = #{<<"room">> => RoomJID, <<"name">> => Name, <<"subject">> => Subject},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_invite_user_body(RoomJID, Recipient) ->
+    Query = <<"mutation M1($room: JID!, $recipient: JID!)
+              { muc_light { inviteUser(room: $room, recipient: $recipient) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{<<"room">> => RoomJID, <<"recipient">> => Recipient},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+delete_room_body(RoomJID) ->
+    Query = <<"mutation M1($room: JID!)
+              { muc_light { deleteRoom(room: $room) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{<<"room">> => RoomJID},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_kick_user_body(RoomJID, User) ->
+    Query = <<"mutation M1($room: JID!, $user: JID)
+              { muc_light { kickUser(room: $room, user: $user)} }">>,
+    OpName = <<"M1">>,
+    Vars = #{<<"room">> => RoomJID, <<"user">> => User},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_send_message_to_room_body(RoomJID, Body) ->
+    Query = <<"mutation M1($room: JID!, $body: String!)
+              { muc_light { sendMessageToRoom(room: $room, body: $body)} }">>,
+    OpName = <<"M1">>,
+    Vars = #{<<"room">> => RoomJID, <<"body">> => Body},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+get_room_messages_body(RoomJID, PageSize, Before) ->
+    Query = <<"query Q1($room: JID!, $pageSize: Int, $before: DateTime)
+              { muc_light { getRoomMessages(room: $room, pageSize: $pageSize, before: $before)
+              { stanzas { stanza } limit } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{<<"room">> => RoomJID, <<"pageSize">> => PageSize, <<"before">> => Before},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_list_rooms_body() ->
+    Query = <<"query Q1 { muc_light { listRooms } }">>,
+    #{query => Query, operationName => <<"Q1">>, variables => #{}}.
+
+list_room_users_body(RoomJID) ->
     Query = <<"query Q1($room: JID!)
               { muc_light { listRoomUsers(room: $room)
               { jid affiliation} } }">>,
@@ -499,7 +941,7 @@ admin_list_room_users_body(RoomJID) ->
     Vars = #{<<"room">> => RoomJID},
     #{query => Query, operationName => OpName, variables => Vars}.
 
-admin_get_room_config_body(RoomJID) ->
+get_room_config_body(RoomJID) ->
     Query = <<"query Q1($room: JID!)
               { muc_light { getRoomConfig(room: $room)
               { jid name subject participants {jid affiliation} } } }">>,

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -14,6 +14,8 @@ type MUCLightAdminMutation @protected{
   kickUser(room: JID!, user: JID!): String
   "Send a message to a MUC Light room"
   sendMessageToRoom(room: JID!, from: JID!, body: String!): String
+  "Set the user blocking list"
+  setBlockingList(user: JID!, items: [BlockingInput!]!): String
 }
 
 """
@@ -28,4 +30,6 @@ type MUCLightAdminQuery @protected{
   listRoomUsers(room: JID!): [RoomUser!]
   "Get the list of MUC Light rooms that the user participates in"
   listUserRooms(user: JID!): [JID!]
+  "Get the user blocking list"
+  getBlockingList(user: JID!): [BlockingItem!]
 }

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -23,7 +23,7 @@ Allow admin to get information about Multi-User Chat Light rooms.
 """
 type MUCLightAdminQuery @protected{
   "Get the MUC Light room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int!, before: DateTime): StanzasPayload
+  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
   "Get configuration of the MUC Light room"
   getRoomConfig(room: JID!): Room
   "Get users list of given MUC Light room"

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -3,7 +3,7 @@ Allow admin to manage Multi-User Chat Light rooms.
 """
 type MUCLightAdminMutation @protected{
   "Create a MUC light room under the given XMPP hostname"
-  createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: String): Room
+  createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: NonEmptyString): Room
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!): Room
   "Invite a user to a MUC Light room"

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -29,15 +29,3 @@ type MUCLightAdminQuery @protected{
   "Get the list of MUC Light rooms that the user participates in"
   listUserRooms(user: JID!): [JID!]
 }
-
-type Room{
-  jid: JID!
-  name: String!
-  subject: String!
-  participants: [RoomUser!]!
-}
-
-type RoomUser{
-  jid: JID!
-  affiliation: Affiliation!
-}

--- a/priv/graphql/schemas/global/muc.gql
+++ b/priv/graphql/schemas/global/muc.gql
@@ -4,6 +4,28 @@ enum Affiliation{
   NONE
 }
 
+input BlockingInput{
+  what: BlockingWhat!
+  action: BlockingAction!
+  who: JID!
+}
+
+type BlockingItem{
+  what: BlockingWhat!
+  action: BlockingAction!
+  who: JID!
+}
+
+enum BlockingAction{
+  ALLOW,
+  DENY
+}
+
+enum BlockingWhat{
+  USER,
+  ROOM
+}
+
 type Room{
   jid: JID!
   name: String!

--- a/priv/graphql/schemas/global/muc.gql
+++ b/priv/graphql/schemas/global/muc.gql
@@ -5,15 +5,15 @@ enum Affiliation{
 }
 
 input BlockingInput{
-  what: BlockingWhat!
+  entityType: BlockedEntityType!
   action: BlockingAction!
-  who: JID!
+  entity: JID!
 }
 
 type BlockingItem{
-  what: BlockingWhat!
+  entityType: BlockedEntityType!
   action: BlockingAction!
-  who: JID!
+  entity: JID!
 }
 
 enum BlockingAction{
@@ -21,7 +21,7 @@ enum BlockingAction{
   DENY
 }
 
-enum BlockingWhat{
+enum BlockedEntityType{
   USER,
   ROOM
 }

--- a/priv/graphql/schemas/global/muc.gql
+++ b/priv/graphql/schemas/global/muc.gql
@@ -3,3 +3,15 @@ enum Affiliation{
   MEMBER
   NONE
 }
+
+type Room{
+  jid: JID!
+  name: String!
+  subject: String!
+  participants: [RoomUser!]!
+}
+
+type RoomUser{
+  jid: JID!
+  affiliation: Affiliation!
+}

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -1,3 +1,4 @@
 scalar DateTime
 scalar Stanza
 scalar JID
+scalar NonEmptyString

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -3,7 +3,7 @@ Allow user to manage Multi-User Chat Light rooms.
 """
 type MUCLightUserMutation @protected{
   "Create a MUC light room under the given XMPP hostname"
-  createRoom(mucDomain: String!, name: String!, subject: String!, id: String): Room
+  createRoom(mucDomain: String!, name: String!, subject: String!, id: NonEmptyString): Room
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, name: String!, subject: String!): Room
   "Invite a user to a MUC Light room"

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -14,6 +14,8 @@ type MUCLightUserMutation @protected{
   kickUser(room: JID!, user: JID): String
   "Send a message to a MUC Light room"
   sendMessageToRoom(room: JID!, body: String!): String
+  "Set the user blocking list"
+  setBlockingList(items: [BlockingInput!]!): String
 }
 
 """
@@ -28,4 +30,6 @@ type MUCLightUserQuery @protected{
   listRoomUsers(room: JID!): [RoomUser!]
   "Get the list of MUC Light rooms that the user participates in"
   listRooms: [JID!]
+  "Get the user blocking list"
+  getBlockingList: [BlockingItem!]
 }

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -1,0 +1,31 @@
+"""
+Allow user to manage Multi-User Chat Light rooms.
+"""
+type MUCLightUserMutation @protected{
+  "Create a MUC light room under the given XMPP hostname"
+  createRoom(mucDomain: String!, name: String!, subject: String!, id: String): Room
+  "Change configuration of a MUC Light room"
+  changeRoomConfiguration(room: JID!, name: String!, subject: String!): Room
+  "Invite a user to a MUC Light room"
+  inviteUser(room: JID!, recipient: JID!): String
+  "Remove a MUC Light room"
+  deleteRoom(room: JID!): String
+  "Kick a user from a MUC Light room"
+  kickUser(room: JID!, user: JID): String
+  "Send a message to a MUC Light room"
+  sendMessageToRoom(room: JID!, body: String!): String
+}
+
+"""
+Allow user to get information about Multi-User Chat Light rooms.
+"""
+type MUCLightUserQuery @protected{
+  "Get the MUC Light room archived messages"
+  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+  "Get configuration of the MUC Light room"
+  getRoomConfig(room: JID!): Room
+  "Get users list of given MUC Light room"
+  listRoomUsers(room: JID!): [RoomUser!]
+  "Get the list of MUC Light rooms that the user participates in"
+  listRooms: [JID!]
+}

--- a/priv/graphql/schemas/user/user_schema.gql
+++ b/priv/graphql/schemas/user/user_schema.gql
@@ -12,6 +12,8 @@ type UserQuery{
   checkAuth: UserAuthInfo
   "Account management"
   account: AccountUserQuery
+  "MUC Light room management"
+  muc_light: MUCLightUserQuery
   "Session management"
   session: SessionUserQuery
 }
@@ -23,4 +25,6 @@ Only an authenticated user can execute these mutations.
 type UserMutation @protected{
   "Account management"
   account: AccountUserMutation
+  "MUC Light room management"
+  muc_light: MUCLightUserMutation
 }

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
@@ -26,11 +26,17 @@ execute(_Ctx, _Obj, <<"setBlockingList">>, Args) ->
     set_blocking_list(Args).
 
 -spec create_room(map()) -> {ok, map()} | {error, resolver_error()}.
-create_room(#{<<"id">> := null} = Args) ->
-    create_room(Args#{<<"id">> => <<>>});
+create_room(#{<<"id">> := null, <<"mucDomain">> := MUCDomain, <<"name">> := RoomName,
+              <<"owner">> := CreatorJID, <<"subject">> := Subject}) ->
+    case mod_muc_light_api:create_room(MUCDomain, CreatorJID, RoomName, Subject) of
+        {ok, Room} ->
+            {ok, make_room(Room)};
+        Err ->
+            make_error(Err, #{mucDomain => MUCDomain, creator => CreatorJID})
+    end;
 create_room(#{<<"id">> := RoomID, <<"mucDomain">> := MUCDomain, <<"name">> := RoomName,
               <<"owner">> := CreatorJID, <<"subject">> := Subject}) ->
-    case mod_muc_light_api:create_room(MUCDomain, RoomID, RoomName, CreatorJID, Subject) of
+    case mod_muc_light_api:create_room(MUCDomain, RoomID, CreatorJID, RoomName, Subject) of
         {ok, Room} ->
             {ok, make_room(Room)};
         Err ->

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
@@ -20,7 +20,9 @@ execute(_Ctx, _Obj, <<"deleteRoom">>, Args) ->
 execute(_Ctx, _Obj, <<"kickUser">>, Args) ->
     kick_user(Args);
 execute(_Ctx, _Obj, <<"sendMessageToRoom">>, Args) ->
-    send_msg_to_room(Args).
+    send_msg_to_room(Args);
+execute(_Ctx, _Obj, <<"setBlockingList">>, Args) ->
+    set_blocking_list(Args).
 
 -spec create_room(map()) -> {ok, map()} | {error, resolver_error()}.
 create_room(#{<<"id">> := null} = Args) ->
@@ -65,3 +67,13 @@ kick_user(#{<<"room">> := RoomJID, <<"user">> := UserJID}) ->
 send_msg_to_room(#{<<"room">> := RoomJID, <<"from">> := FromJID, <<"body">> := Message}) ->
     Result = mod_muc_light_api:send_message(RoomJID, FromJID, Message),
     format_result(Result, #{room => jid:to_binary(RoomJID), from => jid:to_binary(FromJID)}).
+
+-spec set_blocking_list(map()) -> {ok, binary()} | {error, resolver_error()}.
+set_blocking_list(#{<<"user">> := UserJID, <<"items">> := Items}) ->
+    Items2 = prepare_blocking_items(Items),
+    Result = mod_muc_light_api:set_blocking(UserJID, Items2),
+    format_result(Result, #{user => jid:to_binary(UserJID)}).
+
+prepare_blocking_items(Items) ->
+    [{What, Action, jid:to_lus(Who)} || #{<<"who">> := Who, <<"what">> := What,
+                                          <<"action">> := Action} <- Items].

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
@@ -7,7 +7,8 @@
 -include("../mongoose_graphql_types.hrl").
 
 -import(mongoose_graphql_helper, [make_error/2, format_result/2]).
--import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1]).
+-import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1,
+                                            prepare_blocking_items/1]).
 
 execute(_Ctx, _Obj, <<"createRoom">>, Args) ->
     create_room(Args);
@@ -73,7 +74,3 @@ set_blocking_list(#{<<"user">> := UserJID, <<"items">> := Items}) ->
     Items2 = prepare_blocking_items(Items),
     Result = mod_muc_light_api:set_blocking(UserJID, Items2),
     format_result(Result, #{user => jid:to_binary(UserJID)}).
-
-prepare_blocking_items(Items) ->
-    [{What, Action, jid:to_lus(Who)} || #{<<"who">> := Who, <<"what">> := What,
-                                          <<"action">> := Action} <- Items].

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
@@ -7,7 +7,8 @@
 -include("../mongoose_graphql_types.hrl").
 
 -import(mongoose_graphql_helper, [make_error/2, format_result/2]).
--import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1]).
+-import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1,
+                                            null_to_undefined/1]).
 
 execute(_Ctx, _Obj, <<"listUserRooms">>, Args) ->
     list_user_rooms(Args);
@@ -63,16 +64,8 @@ get_room_messages(#{<<"room">> := RoomJID, <<"pageSize">> := PageSize,
 get_blocking_list(#{<<"user">> := UserJID}) ->
     case mod_muc_light_api:get_blocking_list(UserJID) of
         {ok, Items} ->
-            Items2 = lists:map(fun blocking_item_to_map/1, Items),
+            Items2 = lists:map(fun mongoose_graphql_muc_light_helper:blocking_item_to_map/1, Items),
             {ok, Items2};
         Err ->
             make_error(Err, #{user => UserJID})
     end.
-
-%% Helpers
-
-blocking_item_to_map({What, Action, Who}) ->
-    {ok, #{<<"what">> => What, <<"action">> => Action, <<"who">> => Who}}.
-
-null_to_undefined(null) -> undefined;
-null_to_undefined(V) -> V.

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -141,6 +141,8 @@ user_mapping_rules() ->
         'UserMutation' => mongoose_graphql_user_mutation,
         'AccountUserQuery' => mongoose_graphql_account_user_query,
         'AccountUserMutation' => mongoose_graphql_account_user_mutation,
+        'MUCLightUserMutation' => mongoose_graphql_muc_light_user_mutation,
+        'MUCLightUserQuery' => mongoose_graphql_muc_light_user_query,
         'SessionUserQuery' => mongoose_graphql_session_user_query,
         'UserAuthInfo' => mongoose_graphql_user_auth_info,
         default => mongoose_graphql_default},

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -15,8 +15,8 @@ input(<<"Affiliation">>, <<"MEMBER">>) -> {ok, member};
 input(<<"Affiliation">>, <<"NONE">>) -> {ok, none};
 input(<<"BlockingAction">>, <<"ALLOW">>) -> {ok, allow};
 input(<<"BlockingAction">>, <<"DENY">>) -> {ok, deny};
-input(<<"BlockingWhat">>, <<"USER">>) -> {ok, user};
-input(<<"BlockingWhat">>, <<"ROOM">>) -> {ok, room}.
+input(<<"BlockedEntityType">>, <<"USER">>) -> {ok, user};
+input(<<"BlockedEntityType">>, <<"ROOM">>) -> {ok, room}.
 
 output(<<"PresenceShow">>, Show) ->
     {ok, list_to_binary(string:to_upper(binary_to_list(Show)))};
@@ -28,5 +28,5 @@ output(<<"Affiliation">>, Aff) ->
     {ok, list_to_binary(string:to_upper(atom_to_list(Aff)))};
 output(<<"BlockingAction">>, Action) ->
     {ok, list_to_binary(string:to_upper(atom_to_list(Action)))};
-output(<<"BlockingWhat">>, What) ->
+output(<<"BlockedEntityType">>, What) ->
     {ok, list_to_binary(string:to_upper(atom_to_list(What)))}.

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -12,7 +12,11 @@ input(<<"AuthStatus">>, <<"AUTHORIZED">>) -> {ok, 'AUTHORIZED'};
 input(<<"AuthStatus">>, <<"UNAUTHORIZED">>)  -> {ok, 'UNAUTHORIZED'};
 input(<<"Affiliation">>, <<"OWNER">>) -> {ok, owner};
 input(<<"Affiliation">>, <<"MEMBER">>) -> {ok, member};
-input(<<"Affiliation">>, <<"NONE">>) -> {ok, none}.
+input(<<"Affiliation">>, <<"NONE">>) -> {ok, none};
+input(<<"BlockingAction">>, <<"ALLOW">>) -> {ok, allow};
+input(<<"BlockingAction">>, <<"DENY">>) -> {ok, deny};
+input(<<"BlockingWhat">>, <<"USER">>) -> {ok, user};
+input(<<"BlockingWhat">>, <<"ROOM">>) -> {ok, room}.
 
 output(<<"PresenceShow">>, Show) ->
     {ok, list_to_binary(string:to_upper(binary_to_list(Show)))};
@@ -21,4 +25,8 @@ output(<<"PresenceType">>, Type) ->
 output(<<"AuthStatus">>, Status) ->
     {ok, atom_to_binary(Status, utf8)};
 output(<<"Affiliation">>, Aff) ->
-    {ok, list_to_binary(string:to_upper(atom_to_list(Aff)))}.
+    {ok, list_to_binary(string:to_upper(atom_to_list(Aff)))};
+output(<<"BlockingAction">>, Action) ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Action)))};
+output(<<"BlockingWhat">>, What) ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(What)))}.

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -1,6 +1,13 @@
 -module(mongoose_graphql_muc_light_helper).
 
--export([make_room/1, make_ok_user/1]).
+-export([make_room/1, make_ok_user/1, page_size_or_max_limit/2]).
+
+page_size_or_max_limit(null, MaxLimit) ->
+    MaxLimit;
+page_size_or_max_limit(PageSize, MaxLimit) when PageSize > MaxLimit ->
+    MaxLimit;
+page_size_or_max_limit(PageSize, _MaxLimit) ->
+    PageSize.
 
 -spec make_room(mod_muc_light_api:room()) -> map().
 make_room(#{jid := JID, name := Name, subject := Subject, aff_users := Users}) ->

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -22,11 +22,11 @@ make_ok_user({JID, Aff}) ->
     {ok, #{<<"jid">> => JID, <<"affiliation">> => Aff}}.
 
 prepare_blocking_items(Items) ->
-    [{What, Action, jid:to_lus(Who)} || #{<<"who">> := Who, <<"what">> := What,
+    [{What, Action, jid:to_lus(Who)} || #{<<"entity">> := Who, <<"entityType">> := What,
                                           <<"action">> := Action} <- Items].
 
 blocking_item_to_map({What, Action, Who}) ->
-    {ok, #{<<"what">> => What, <<"action">> => Action, <<"who">> => Who}}.
+    {ok, #{<<"entityType">> => What, <<"action">> => Action, <<"entity">> => Who}}.
 
 null_to_undefined(null) -> undefined;
 null_to_undefined(V) -> V.

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -1,7 +1,10 @@
 -module(mongoose_graphql_muc_light_helper).
 
--export([make_room/1, make_ok_user/1, page_size_or_max_limit/2]).
+-export([make_room/1, make_ok_user/1, blocking_item_to_map/1,
+         null_to_undefined/1, prepare_blocking_items/1,
+         page_size_or_max_limit/2]).
 
+-spec page_size_or_max_limit(null | integer(), integer()) -> integer().
 page_size_or_max_limit(null, MaxLimit) ->
     MaxLimit;
 page_size_or_max_limit(PageSize, MaxLimit) when PageSize > MaxLimit ->
@@ -17,3 +20,13 @@ make_room(#{jid := JID, name := Name, subject := Subject, aff_users := Users}) -
 
 make_ok_user({JID, Aff}) ->
     {ok, #{<<"jid">> => JID, <<"affiliation">> => Aff}}.
+
+prepare_blocking_items(Items) ->
+    [{What, Action, jid:to_lus(Who)} || #{<<"who">> := Who, <<"what">> := What,
+                                          <<"action">> := Action} <- Items].
+
+blocking_item_to_map({What, Action, Who}) ->
+    {ok, #{<<"what">> => What, <<"action">> => Action, <<"who">> => Who}}.
+
+null_to_undefined(null) -> undefined;
+null_to_undefined(V) -> V.

--- a/src/graphql/mongoose_graphql_scalar.erl
+++ b/src/graphql/mongoose_graphql_scalar.erl
@@ -11,6 +11,7 @@
 input(<<"DateTime">>, DT) -> binary_to_microseconds(DT);
 input(<<"Stanza">>, Value) -> exml:parse(Value);
 input(<<"JID">>, Jid) -> jid_from_binary(Jid);
+input(<<"NonEmptyString">>, Value) -> non_empty_string_to_binary(Value);
 input(Ty, V) ->
     error_logger:info_report({coercing_generic_scalar, Ty, V}),
     {ok, V}.
@@ -24,6 +25,7 @@ input(Ty, V) ->
 output(<<"DateTime">>, DT) -> {ok, microseconds_to_binary(DT)};
 output(<<"Stanza">>, Elem) -> {ok, exml:to_binary(Elem)};
 output(<<"JID">>, Jid) -> {ok, jid:to_binary(Jid)};
+output(<<"NonEmptyString">>, Value) -> binary_to_non_empty_string(Value);
 output(Ty, V) ->
     error_logger:info_report({output_generic_scalar, Ty, V}),
     {ok, V}.
@@ -43,6 +45,16 @@ binary_to_microseconds(DT) ->
         Microseconds ->
             {ok, Microseconds}
     end.
+
+non_empty_string_to_binary(<<>>) ->
+    {error, "Given string is empty"};
+non_empty_string_to_binary(String) ->
+    {ok, String}.
+
+binary_to_non_empty_string(<<>>) ->
+    {error, "Empty binary cannot be converted to NonEmptyString"};
+binary_to_non_empty_string(Val) ->
+    {ok, Val}.
 
 microseconds_to_binary(Microseconds) ->
     Opts = [{offset, "Z"}, {unit, microsecond}],

--- a/src/graphql/user/mongoose_graphql_muc_light_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_muc_light_user_mutation.erl
@@ -25,11 +25,17 @@ execute(Ctx, _Obj, <<"setBlockingList">>, Args) ->
     set_blocking_list(Ctx, Args).
 
 -spec create_room(map(), map()) -> {ok, map()} | {error, resolver_error()}.
-create_room(Ctx, #{<<"id">> := null} = Args) ->
-    create_room(Ctx, Args#{<<"id">> => <<>>});
+create_room(#{user := UserJID}, #{<<"id">> := null, <<"mucDomain">> := MUCDomain,
+                                  <<"name">> := RoomName, <<"subject">> := Subject}) ->
+    case mod_muc_light_api:create_room(MUCDomain, UserJID, RoomName, Subject) of
+        {ok, Room} ->
+            {ok, make_room(Room)};
+        Err ->
+            make_error(Err, #{mucDomain => MUCDomain})
+    end;
 create_room(#{user := UserJID}, #{<<"id">> := RoomID, <<"mucDomain">> := MUCDomain,
                                   <<"name">> := RoomName, <<"subject">> := Subject}) ->
-    case mod_muc_light_api:create_room(MUCDomain, RoomID, RoomName, UserJID, Subject) of
+    case mod_muc_light_api:create_room(MUCDomain, RoomID, UserJID, RoomName, Subject) of
         {ok, Room} ->
             {ok, make_room(Room)};
         Err ->

--- a/src/graphql/user/mongoose_graphql_muc_light_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_muc_light_user_mutation.erl
@@ -1,0 +1,74 @@
+-module(mongoose_graphql_muc_light_user_mutation).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2]).
+-import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1]).
+
+execute(Ctx, _Obj, <<"createRoom">>, Args) ->
+    create_room(Ctx, Args);
+execute(Ctx, _Obj, <<"changeRoomConfiguration">>, Args) ->
+    change_room_config(Ctx, Args);
+execute(Ctx, _Obj, <<"inviteUser">>, Args) ->
+    invite_user(Ctx, Args);
+execute(Ctx, _Obj, <<"deleteRoom">>, Args) ->
+    delete_room(Ctx, Args);
+execute(Ctx, _Obj, <<"kickUser">>, Args) ->
+    kick_user(Ctx, Args);
+execute(Ctx, _Obj, <<"sendMessageToRoom">>, Args) ->
+    send_msg_to_room(Ctx, Args).
+
+-spec create_room(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+create_room(Ctx, #{<<"id">> := null} = Args) ->
+    create_room(Ctx, Args#{<<"id">> => <<>>});
+create_room(#{user := UserJID}, #{<<"id">> := RoomID, <<"mucDomain">> := MUCDomain,
+                                  <<"name">> := RoomName, <<"subject">> := Subject}) ->
+    case mod_muc_light_api:create_room(MUCDomain, RoomID, RoomName, UserJID, Subject) of
+        {ok, Room} ->
+            {ok, make_room(Room)};
+        Err ->
+            make_error(Err, #{mucDomain => MUCDomain, id => RoomID})
+    end.
+
+-spec change_room_config(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+change_room_config(#{user := UserJID}, #{<<"room">> := RoomJID, <<"name">> := RoomName,
+                                         <<"subject">> := Subject}) ->
+    case mod_muc_light_api:change_room_config(RoomJID, UserJID, RoomName, Subject) of
+        {ok, Room} ->
+            {ok, make_room(Room)};
+        Err ->
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec delete_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+delete_room(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
+    Result = mod_muc_light_api:delete_room(RoomJID, UserJID),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+-spec invite_user(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+invite_user(#{user := UserJID}, #{<<"room">> := RoomJID, <<"recipient">> := RecipientJID}) ->
+    Result = mod_muc_light_api:invite_to_room(RoomJID, UserJID, RecipientJID),
+    format_result(Result, #{room => jid:to_binary(RoomJID),
+                            recipient => jid:to_binary(RecipientJID)}).
+
+-spec kick_user(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+kick_user(#{user := UserJID}, #{<<"room">> := RoomJID, <<"user">> := UserToKickJID}) ->
+    Result = mod_muc_light_api:remove_user_from_room(RoomJID, UserJID,
+                                                     null_to_default(UserToKickJID, UserJID)),
+    format_result(Result, #{user => UserToKickJID}).
+
+-spec send_msg_to_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+send_msg_to_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"body">> := Message}) ->
+    Result = mod_muc_light_api:send_message(RoomJID, UserJID, Message),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+%% Helpers
+
+null_to_default(null, Default) ->
+    Default;
+null_to_default(Value, _Default) ->
+    Value.

--- a/src/graphql/user/mongoose_graphql_muc_light_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_light_user_query.erl
@@ -1,0 +1,61 @@
+-module(mongoose_graphql_muc_light_user_query).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2]).
+-import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1,
+                                            page_size_or_max_limit/2]).
+
+execute(Ctx, _Obj, <<"listRooms">>, Args) ->
+    list_user_rooms(Ctx, Args);
+execute(Ctx, _Obj, <<"listRoomUsers">>, Args) ->
+    list_room_users(Ctx, Args);
+execute(Ctx, _Obj, <<"getRoomConfig">>, Args) ->
+    get_room_config(Ctx, Args);
+execute(Ctx, _Obj, <<"getRoomMessages">>, Args) ->
+    get_room_messages(Ctx, Args).
+
+-spec list_user_rooms(map(), map()) -> {ok, [{ok, jid:simple_bare_jid()}]}.
+list_user_rooms(#{user := UserJID}, #{}) ->
+    {ok, Rooms} = mod_muc_light_api:get_user_rooms(UserJID),
+    {ok, [{ok, R} || R <- Rooms]}.
+
+-spec list_room_users(map(), map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
+list_room_users(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
+    case mod_muc_light_api:get_room_aff(RoomJID, UserJID) of
+        {ok, Affs} ->
+            {ok, [make_ok_user(A) || A <- Affs]};
+        Err ->
+            make_error(Err, #{room => RoomJID})
+    end.
+
+-spec get_room_config(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+get_room_config(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
+    case mod_muc_light_api:get_room_info(RoomJID, UserJID) of
+        {ok, Room} ->
+            {ok, make_room(Room)};
+        Err ->
+            make_error(Err, #{room => RoomJID})
+    end.
+
+-spec get_room_messages(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+get_room_messages(#{user := UserJID}, #{<<"room">> := RoomJID, <<"pageSize">> := PageSize,
+                                        <<"before">> := Before}) ->
+    Before2 = null_to_undefined(Before),
+    PageSize2 = page_size_or_max_limit(PageSize, 50),
+    case mod_muc_light_api:get_room_messages(RoomJID, UserJID, PageSize2, Before2) of
+        {ok, Rows} ->
+            Maps = lists:map(fun mongoose_graphql_stanza_helper:row_to_map/1, Rows),
+            {ok, #{<<"stanzas">> => Maps, <<"limit">> => PageSize2}};
+        Err ->
+            make_error(Err, #{room => RoomJID})
+    end.
+
+%% Helpers
+
+null_to_undefined(null) -> undefined;
+null_to_undefined(V) -> V.

--- a/src/graphql/user/mongoose_graphql_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_user_mutation.erl
@@ -5,4 +5,6 @@
 -ignore_xref([execute/4]).
 
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
-    {ok, account}.
+    {ok, account};
+execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
+    {ok, muc_light}.

--- a/src/graphql/user/mongoose_graphql_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_user_query.erl
@@ -6,6 +6,8 @@
 
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
+    {ok, muc_light};
 execute(_Ctx, _Obj, <<"session">>, _Args) ->
     {ok, session};
 execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->

--- a/src/mongoose_client_api/mongoose_client_api_messages.erl
+++ b/src/mongoose_client_api/mongoose_client_api_messages.erl
@@ -17,7 +17,8 @@
 -export([maybe_integer/1]).
 -export([maybe_before_to_us/2]).
 
--ignore_xref([send_message/2, to_json/2, trails/0]).
+-ignore_xref([send_message/2, to_json/2, trails/0,
+              maybe_before_to_us/2]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").

--- a/src/mongoose_client_api/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms.erl
@@ -144,13 +144,13 @@ handle_request_by_method(<<"POST">>, JSONData, _Req,
                          #{jid := #jid{lserver = LServer} = UserJID}) ->
     #{<<"name">> := RoomName, <<"subject">> := Subject} = JSONData,
     MUCServer = muc_light_domain(LServer),
-    mod_muc_light_api:create_room(MUCServer, <<>>, RoomName, UserJID, Subject);
+    mod_muc_light_api:create_room(MUCServer, UserJID, RoomName, Subject);
 handle_request_by_method(<<"PUT">>, JSONData, Req, State) ->
     assert_room_id_set(Req, State),
     #{jid := #jid{lserver = LServer} = UserJID, room_id := RoomID} = State,
     #{<<"name">> := RoomName, <<"subject">> := Subject} = JSONData,
     MUCServer = muc_light_domain(LServer),
-    mod_muc_light_api:create_room(MUCServer, RoomID, RoomName, UserJID, Subject).
+    mod_muc_light_api:create_room(MUCServer, RoomID, UserJID, RoomName, Subject).
 
 assert_room_id_set(_Req, #{room_id := _} = _State) ->
     ok.

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -214,8 +214,8 @@ get_room_messages(RoomJID, PageSize, Before) ->
                         integer() | undefined, mod_mam:unix_timestamp() | undefined) ->
     {ok, list()} | {muc_server_not_found | internal, iolist()}.
 get_room_messages(HostType, RoomJID, CallerJID, PageSize, Before) ->
-    Now = os:system_time(microsecond),
     ArchiveID = mod_mam_muc:archive_id_int(HostType, RoomJID),
+    Now = os:system_time(microsecond),
     End = maybe_before(Before, Now),
     RSM = #rsm_in{direction = before, id = undefined},
     Params = #{archive_id => ArchiveID,

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -121,7 +121,7 @@ change_affiliation(RoomJID, SenderJID, RecipientJID, Affiliation) ->
     {ok, iolist()}.
 remove_user_from_room(RoomJID, SenderJID, RecipientJID) ->
     ok = change_affiliation(RoomJID, SenderJID, RecipientJID, <<"none">>),
-    {ok, io_lib:format("User ~s kicked successfully", [jid:to_binary(RecipientJID)])}.
+    {ok, io_lib:format("Stanza kicking user ~s sent successfully", [jid:to_binary(RecipientJID)])}.
 
 -spec send_message(jid:jid(), jid:jid(), binary()) ->
     {ok | not_room_member | muc_server_not_found, iolist()}.
@@ -208,7 +208,7 @@ get_room_messages(RoomJID, PageSize, Before) ->
 
 -spec get_room_messages(mongooseim:host_type(), jid:jid(), jid:jid() | undefined,
                         integer() | undefined, mod_mam:unix_timestamp() | undefined) ->
-    {ok, list()} | {muc_server_not_found | internal, iolist()}.
+    {ok, list()} | {internal, iolist()}.
 get_room_messages(HostType, RoomJID, CallerJID, PageSize, Before) ->
     ArchiveID = mod_mam_muc:archive_id_int(HostType, RoomJID),
     Now = os:system_time(microsecond),

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -163,7 +163,7 @@ commands() ->
     jid:literal_jid() | {error, not_found | denied, iolist()}.
 create_unique_room(MUCServer, RoomName, Creator, Subject) ->
     CreatorJID = jid:from_binary(Creator),
-    case mod_muc_light_api:create_room(MUCServer, <<>>, RoomName, CreatorJID, Subject) of
+    case mod_muc_light_api:create_room(MUCServer, CreatorJID, RoomName, Subject) of
         {ok, #{jid := JID}} -> jid:to_binary(JID);
         Error -> format_err_result(Error)
     end.
@@ -173,7 +173,7 @@ create_unique_room(MUCServer, RoomName, Creator, Subject) ->
     jid:literal_jid() | {error, not_found | denied, iolist()}.
 create_identifiable_room(MUCServer, Identifier, RoomName, Creator, Subject) ->
     CreatorJID = jid:from_binary(Creator),
-    case mod_muc_light_api:create_room(MUCServer, Identifier, RoomName, CreatorJID, Subject) of
+    case mod_muc_light_api:create_room(MUCServer, Identifier, CreatorJID, RoomName, Subject) of
         {ok, #{jid := JID}} -> jid:to_binary(JID);
         Error -> format_err_result(Error)
     end.


### PR DESCRIPTION
This PR implements the user part of the MUC Light category. The user API is basically the admin API without a `user` argument in queries and the user is taken from the context. User tests are mostly adapted admin tests.

In addition, this PR introduces a blocking list management API both for users and admin. It also adds a `NonEmptyString` scalar that validates if the given string is not empty.

I also provide here some admin part improvements:
- Return passed page size as a limit field in the `StanzaPayload` type.
- Use macro paths in admin tests.
- Other minor fixes.