### PR TITLE
Fix 'is_configured' in async pools

### DIFF
--- a/src/mongoose_service.erl
+++ b/src/mongoose_service.erl
@@ -45,6 +45,8 @@
 -type service() :: atom().
 -type options() :: [term()].
 
+-export_type([service/0]).
+
 -callback start(Opts :: list()) -> any().
 -callback stop() -> any().
 -callback config_spec() -> mongoose_config_spec:config_section().

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -226,7 +226,7 @@ stop(PoolType, HostType, Tag) ->
 -spec is_configured(pool_type()) -> boolean().
 is_configured(PoolType) ->
     Pools = mongoose_config:get_opt(outgoing_pools, []),
-    lists:any(fun(M) -> maps:is_key(PoolType, M) end, Pools).
+    lists:any(fun(#{type := Type}) -> Type =:= PoolType end, Pools).
 
 -spec get_worker(pool_type()) -> worker_result().
 get_worker(PoolType) ->


### PR DESCRIPTION
The `is_configured` function always returned false, so some tests were skipped.

Now both the function and the tests are fixed.

Also: a minor missing exported type is added.

