### PR TITLE
Do not call the obsolete backend API in CT hook

### DIFF
--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -160,19 +160,11 @@ clear_caps_cache(CapsNode) ->
 get_backend(HostType, Module) ->
     try rpc(mim(), mongoose_backend, get_backend_module, [HostType, Module])
     catch
-        error:{badrpc, _Reason} ->
-            % TODO: get rid of this after dynamically compiled modules are gone
-            get_backend_old(Module)
+        error:{badrpc, _Reason} -> false
     end.
 
 get_backend_name(HostType, Module) ->
     rpc(mim(), mongoose_backend, get_backend_name, [HostType, Module]).
-
-get_backend_old(Module) ->
-    case rpc(mim(), Module, backend, []) of
-        {badrpc, _Reason} -> false;
-        Backend -> Backend
-    end.
 
 generic_count(mod_offline_backend, {LUser, LServer}) ->
     HostType = domain_helper:host_type(),


### PR DESCRIPTION
The `case` expression failed, because it should be a `try` instead.
However, all modules used in the CT hook are already converted, so it makes no sense to support the obsolete dynamic modules.

Verified manually - the error message (previously present in every `end_per_suite` log) showed below is not present anymore.

```*** User 2022-03-03 18:12:18.717 ***
Suite: domain_isolation_SUITE finished dirty. Other suites may fail because of that. Details:
{'EXIT',{{badrpc,{'EXIT',{undef,[{mod_offline_backend,backend,[],[]}]}}},
         [{distributed_helper,rpc,
                              [#{node => mongooseim@localhost},
                               mod_offline_backend,backend,[]],
                              [{file,"distributed_helper.erl"},{line,117}]},
          {mongoose_helper,get_backend_old,1,
                           [{file,"mongoose_helper.erl"},{line,172}]},
          {mongoose_helper,generic_count_per_host_type,2,
                           [{file,"mongoose_helper.erl"},{line,185}]},
          {mongoose_helper,'-generic_count/1-lc$^0/1-0-',2,
                           [{file,"mongoose_helper.erl"},{line,182}]},
          {mongoose_helper,generic_count,1,
                           [{file,"mongoose_helper.erl"},{line,182}]},
          {ct_mongoose_hook,generic_via_mongoose_helper,1,
                            [{file,"/Users/pawelchrzaszcz/dev/mongoose/big_tests/src/ct_mongoose_hook.erl"},
                             {line,190}]},
          {lists,flatmap,2,[{file,"lists.erl"},{line,1254}]},
          {lists,flatmap,2,[{file,"lists.erl"},{line,1254}]}]}}
```
