### PR TITLE
Migrate segmented cache to maps

### DIFF
--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -82,7 +82,7 @@ end_per_group(_Groupname, Config) ->
 group_to_modules(auth_removal) ->
     [];
 group_to_modules(cache_removal) ->
-    [{mod_cache_users, []},
+    [{mod_cache_users, config_parser_helper:default_mod_config(mod_cache_users)},
      {mod_mam_meta, mam_helper:config_opts(#{pm => #{}})}];
 group_to_modules(mam_removal) ->
     MucHost = subhost_pattern(muc_light_helper:muc_host_pattern()),

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -300,10 +300,10 @@ schema_opts(CaseName) ->
 common_muc_light_opts() ->
     [{host, subhost_pattern(muc_light_helper:muc_host_pattern())},
      {backend, mongoose_helper:mnesia_or_rdbms_backend()},
-     {cache_affs, [{module, internal},
-                   {strategy, fifo},
-                   {time_to_live, 2},
-                   {number_of_segments, 3}]},
+     {cache_affs, #{module => internal,
+                    strategy => fifo,
+                    time_to_live => 2,
+                    number_of_segments => 3}},
      {rooms_in_rosters, true}].
 
 %%--------------------------------------------------------------------

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -223,7 +223,7 @@ modules.mod_mam_meta.cache.number_of_segments
 * **Default:** `internal`
 * **Example:** `modules.mod_mam_meta.cache.module = "mod_cache_users"`
 
-Configures which cache to use, either start an internal instance, or reuse the cache created by `mod_cache_users`, if such module was enabled. Note that if reuse is desired – that is, `cache.module = "mod_cache_users"`, other cache configuration parameters are not allowed.
+Configures which cache to use, either start an internal instance, or reuse the cache created by `mod_cache_users`, if such module was enabled. Note that if reuse is desired – that is, `cache.module = "mod_cache_users"`, other cache configuration parameters will be ignored.
 
 #### `modules.mod_mam_meta.async_writer.enabled`
 * **Syntax:** boolean

--- a/src/mod_cache_users.erl
+++ b/src/mod_cache_users.erl
@@ -33,8 +33,10 @@ stop(HostType) ->
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
-    Sec = #section{items = Items} = mongoose_user_cache:config_spec(),
-    Sec#section{items = maps:remove(<<"module">>, Items)}.
+    #section{items = Items,
+             defaults = Defaults} = Sec = mongoose_user_cache:config_spec(),
+    Sec#section{items = maps:remove(<<"module">>, Items),
+                defaults = maps:remove(<<"module">>, Defaults)}.
 
 -spec supported_features() -> [atom()].
 supported_features() ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -218,7 +218,7 @@ config_spec() ->
     #section{
        items = #{<<"backend">> => #option{type = atom,
                                           validate = {module, mod_muc_light_db}},
-                 <<"cache_affs">> => mongoose_user_cache:config_spec(),
+                 <<"cache_affs">> => cache_config_spec(),
                  <<"host">> => #option{type = string,
                                        validate = subdomain_template,
                                        process = fun mongoose_subdomain_utils:make_subdomain_pattern/1},
@@ -238,6 +238,10 @@ config_spec() ->
                                               process = fun ?MODULE:process_config_schema/1}
                 }
       }.
+
+cache_config_spec() ->
+    Sec = mongoose_user_cache:config_spec(),
+    Sec#section{defaults = #{}}.
 
 config_schema_spec() ->
     #section{

--- a/src/muc_light/mod_muc_light_cache.erl
+++ b/src/muc_light/mod_muc_light_cache.erl
@@ -123,7 +123,7 @@ force_clear(HostType) ->
 %%====================================================================
 -spec start_cache(mongooseim:host_type(), gen_mod:module_opts()) -> any().
 start_cache(HostType, Opts) ->
-    FinalOpts = maps:to_list(maps:merge(defaults(), maps:from_list(Opts))),
+    FinalOpts = maps:merge(defaults(), Opts),
     mongoose_user_cache:start_new_cache(HostType, ?MODULE, FinalOpts).
 
 defaults() ->

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -399,7 +399,7 @@ all_modules() ->
                        host => {fqdn, <<"muc.example.com">>},
                        no_stanzaid_element => true}),
       mod_caps => [{cache_life_time, 86}, {cache_size, 1000}],
-      mod_mam_cache_user => #{cache => [], muc => true, pm => true},
+      mod_mam_cache_user => #{cache => default_config([modules, mod_mam_meta, cache]), muc => true, pm => true},
       mod_offline =>
           [{access_max_user_messages, max_user_offline_messages},
            {backend, riak},
@@ -822,6 +822,8 @@ default_pool_conn_opts(_Type) ->
 mod_config(Module, ExtraOpts) ->
     maps:merge(default_mod_config(Module), ExtraOpts).
 
+default_mod_config(mod_cache_users) ->
+    #{strategy => fifo, time_to_live => 480, number_of_segments => 3};
 default_mod_config(mod_adhoc) ->
     #{iqdisc => one_queue, report_commands_node => false};
 default_mod_config(mod_auth_token) ->
@@ -907,7 +909,8 @@ default_mod_config(mod_vcard) ->
 default_mod_config(mod_version) ->
     #{iqdisc => no_queue, os_info => false};
 default_mod_config(mod_mam_meta) ->
-    (common_mam_config())#{backend => rdbms, cache_users => true, cache => []};
+    (common_mam_config())#{backend => rdbms, cache_users => true,
+                           cache => default_config([modules, mod_mam_meta, cache])};
 default_mod_config(mod_mam) ->
     maps:merge(common_mam_config(), default_config([modules, mod_mam_meta, pm]));
 default_mod_config(mod_mam_muc) ->
@@ -927,6 +930,9 @@ default_config([modules, mod_mam_meta, pm]) ->
     #{archive_groupchats => false, same_mam_id_for_peers => false};
 default_config([modules, mod_mam_meta, muc]) ->
     #{host => {prefix, <<"conference.">>}};
+default_config([modules, mod_mam_meta, cache]) ->
+    #{module => internal, strategy => fifo,
+      time_to_live => 480, number_of_segments => 3};
 default_config([modules, mod_mam_meta, async_writer]) ->
     #{batch_size => 30, enabled => true, flush_interval => 2000,
       pool_size => 4 * erlang:system_info(schedulers_online)};

--- a/test/mod_mam_meta_SUITE.erl
+++ b/test/mod_mam_meta_SUITE.erl
@@ -68,6 +68,7 @@ produces_valid_configurations(_Config) ->
     MUC = config([modules, mod_mam_meta, muc],
                  maps:merge(MUCCoreOpts, MUCArchOpts#{user_prefs_store => mnesia})),
     Deps = deps(#{pm => PM, muc => MUC}),
+    Cache = default_config([modules, mod_mam_meta, cache]),
 
     check_equal_opts(mod_mam, mod_config(mod_mam, PMCoreOpts), Deps),
     check_equal_opts(mod_mam_muc, mod_config(mod_mam_muc, MUCCoreOpts), Deps),
@@ -75,7 +76,7 @@ produces_valid_configurations(_Config) ->
     check_equal_opts(mod_mam_muc_rdbms_arch, mod_config(mod_mam_muc_rdbms_arch,
                                                         MUCArchOpts#{no_writer => true}), Deps),
     check_equal_opts(mod_mam_rdbms_user, #{pm => true, muc => true}, Deps),
-    check_equal_opts(mod_mam_cache_user, #{pm => true, muc => true, cache => []}, Deps),
+    check_equal_opts(mod_mam_cache_user, #{pm => true, muc => true, cache => Cache}, Deps),
     check_equal_opts(mod_mam_mnesia_prefs, #{muc => true}, Deps),
     check_equal_opts(mod_mam_rdbms_prefs, #{pm => true}, Deps),
     check_equal_opts(mod_mam_muc_rdbms_arch_async, AsyncOpts, Deps).
@@ -111,10 +112,11 @@ example_muc_only_no_pref_good_performance(_Config) ->
     MUC = config([modules, mod_mam_meta, muc], MUCOpts),
     Deps = deps(#{muc => MUC}),
     AsyncOpts = default_config([modules, mod_mam_meta, async_writer]),
+    Cache = default_config([modules, mod_mam_meta, cache]),
 
     check_equal_deps(
       [{mod_mam_rdbms_user, #{muc => true, pm => true}},
-       {mod_mam_cache_user, #{muc => true, cache => []}},
+       {mod_mam_cache_user, #{muc => true, cache => Cache}},
        {mod_mam_muc_rdbms_arch, mod_config(mod_mam_muc_rdbms_arch, #{no_writer => true})},
        {mod_mam_muc_rdbms_arch_async, AsyncOpts},
        {mod_mam_muc, mod_config(mod_mam_muc, mod_config(mod_mam_muc, MUCOpts))}
@@ -124,10 +126,11 @@ example_pm_only_good_performance(_Config) ->
     PM = default_config([modules, mod_mam_meta, pm]),
     Deps = deps(#{pm => PM, user_prefs_store => mnesia}),
     AsyncOpts = default_config([modules, mod_mam_meta, async_writer]),
+    Cache = default_config([modules, mod_mam_meta, cache]),
 
     check_equal_deps(
       [{mod_mam_rdbms_user, #{pm => true}},
-       {mod_mam_cache_user, #{pm => true, cache => []}},
+       {mod_mam_cache_user, #{pm => true, cache => Cache}},
        {mod_mam_mnesia_prefs, #{pm => true}},
        {mod_mam_rdbms_arch, mod_config(mod_mam_rdbms_arch, #{no_writer => true})},
        {mod_mam_rdbms_arch_async, AsyncOpts},


### PR DESCRIPTION
Muclight still takes lists as opts, so in the small tests there's a bit of duplication that will need to be removed when muclight is migrated, so that mam caches and muclight caches test similarly. Otherwise, this does the job.