### PR TITLE
GraphQL - Implement roster category

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -29,6 +29,7 @@
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
 {suites, "tests", graphql_muc_light_SUITE}.
+{suites, "tests", graphql_roster_SUITE}.
 {suites, "tests", graphql_session_SUITE}.
 {suites, "tests", graphql_stanza_SUITE}.
 {suites, "tests", inbox_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -45,6 +45,7 @@
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
 {suites, "tests", graphql_muc_light_SUITE}.
+{suites, "tests", graphql_roster_SUITE}.
 {suites, "tests", graphql_session_SUITE}.
 {suites, "tests", graphql_stanza_SUITE}.
 

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -4,7 +4,7 @@
 
 -export([execute/3, execute_auth/2, get_listener_port/1, get_listener_config/1]).
 -export([init_admin_handler/1]).
--export([get_ok_value/2, get_err_msg/1, make_creds/1]).
+-export([get_ok_value/2, get_err_msg/1, get_err_msg/2, make_creds/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("escalus/include/escalus.hrl").
@@ -64,11 +64,15 @@ get_listener_opts(EpName) ->
 
 -spec get_err_msg(#{errors := [#{message := binary()}]}) -> binary().
 get_err_msg(Resp) ->
-    get_ok_value([errors, message], Resp).
+    get_ok_value([errors, 1, message], Resp).
+
+-spec get_err_msg(pos_integer(), #{errors := [#{message := binary()}]}) -> binary().
+get_err_msg(N, Resp) ->
+    get_ok_value([errors, N, message], Resp).
 
 -spec get_ok_value([atom()], {tuple(), map()}) -> binary().
-get_ok_value([errors | Path], {{<<"200">>, <<"OK">>}, #{<<"errors">> := [Error]}}) ->
-    get_value(Path, Error);
+get_ok_value([errors, N | Path], {{<<"200">>, <<"OK">>}, #{<<"errors">> := Errors}}) ->
+    get_value(Path, lists:nth(N, Errors));
 get_ok_value(Path, {{<<"200">>, <<"OK">>}, Data}) ->
     get_value(Path, Data).
 

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -1,0 +1,460 @@
+-module(graphql_roster_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(graphql_helper, [execute/3, execute_auth/2, get_listener_port/1,
+                         get_listener_config/1, get_ok_value/2, get_err_msg/1,
+                         get_err_msg/2, make_creds/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("../../include/mod_roster.hrl").
+
+suite() ->
+    require_rpc_nodes([mim]) ++ escalus:suite().
+
+all() ->
+    [{group, user_roster},
+     {group, admin_roster}].
+
+groups() ->
+    [{user_roster, [], user_roster_handler()},
+     {admin_roster, [], admin_roster_handler()}].
+
+user_roster_handler() ->
+    [mock].
+
+admin_roster_handler() ->
+    [admin_add_and_delete_contact,
+     admin_try_add_nonexistent_contact,
+     admin_try_add_contact_to_nonexistent_user,
+     admin_try_add_contact_with_unknown_domain,
+     admin_add_contacts,
+     admin_try_delete_nonexistent_contact,
+     admin_try_delete_contact_with_unknown_domain,
+     admin_delete_contacts,
+     admin_invite_accept_and_cancel_subscription,
+     admin_decline_subscription_ask,
+     admin_try_subscribe_with_unknown_domain,
+     admin_set_mutual_subscription,
+     admin_set_mutual_subscription_try_connect_nonexistent_users,
+     admin_set_mutual_subscription_try_disconnect_nonexistent_users,
+     admin_subscribe_to_all,
+     admin_subscribe_to_all_with_wrong_user,
+     admin_subscribe_all_to_all,
+     admin_subscribe_all_to_all_with_wrong_user,
+     admin_list_contacts,
+     admin_list_contacts_wrong_user,
+     admin_get_contact,
+     admin_get_contact_wrong_user
+    ].
+
+init_per_suite(Config) ->
+    Config2 = escalus:init_per_suite(Config),
+    dynamic_modules:save_modules(domain_helper:host_type(), Config2).
+
+end_per_suite(Config) ->
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_suite(Config).
+
+init_per_group(admin_roster, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(user_roster, Config) ->
+    [{schema_endpoint, user} | Config].
+
+end_per_group(admin_roster, _Config) ->
+    escalus_fresh:clean();
+end_per_group(user_roster, _Config) ->
+    escalus_fresh:clean().
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+-define(ADD_CONTACT_PATH, [data, roster, addContact]).
+-define(ADD_CONTACTS_PATH, [data, roster, addContacts]).
+-define(DELETE_CONTACT_PATH, [data, roster, deleteContact]).
+-define(DELETE_CONTACTS_PATH, [data, roster, deleteContacts]).
+-define(LIST_CONTACTS_PATH, [data, roster, listContacts]).
+-define(GET_CONTACT_PATH, [data, roster, getContact]).
+-define(SUBSCRIBE_ALL_TO_ALL_PATH, [data, roster, subscribeAllToAll]).
+-define(SUBSCRIBE_TO_ALL_PATH, [data, roster, subscribeToAll]).
+
+-define(NONEXISTENT_DOMAIN_USER, <<"abc@abc">>).
+-define(NONEXISTENT_USER, <<"abc@", (domain_helper:domain())/binary>>).
+-define(DEFAULT_GROUPS, [<<"Family">>]).
+
+admin_add_and_delete_contact(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_add_and_delete_contact_story/3).
+
+%% Admin test cases
+
+admin_add_and_delete_contact_story(Config, Alice, Bob) ->
+    Res = execute_auth(admin_add_contact_body(Alice, Bob, null, null), Config),
+
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?ADD_CONTACT_PATH, Res),
+                                          <<"successfully">>)),
+    ?assertMatch(#roster{}, get_roster(Alice, Bob)),
+
+    Res2 = execute_auth(admin_delete_contact_body(Alice, Bob), Config),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_CONTACT_PATH, Res2),
+                                          <<"successfully">>)),
+    ?assertMatch(does_not_exist, get_roster(Alice, Bob)).
+
+admin_try_add_nonexistent_contact(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_try_add_nonexistent_contact/2).
+
+admin_try_add_nonexistent_contact(Config, Alice) ->
+    Contact = ?NONEXISTENT_DOMAIN_USER,
+    Res = execute_auth(admin_add_contact_body(Alice, Contact, null, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), Contact)),
+    ?assertMatch(does_not_exist, get_roster(Alice, Contact)).
+
+admin_try_add_contact_to_nonexistent_user(Config) ->
+    Domain = domain_helper:domain(),
+    User = <<"abc@", Domain/binary>>,
+    Contact = <<"abc2@", Domain/binary>>,
+    Res = execute_auth(admin_add_contact_body(User, Contact, null, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), User)),
+    ?assertMatch(does_not_exist, get_roster(User, Contact)).
+
+admin_try_add_contact_with_unknown_domain(Config) ->
+    User = ?NONEXISTENT_DOMAIN_USER,
+    Res = execute_auth(admin_add_contact_body(User, User, null, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_try_delete_nonexistent_contact(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_try_delete_nonexistent_contact_story/3).
+
+admin_try_delete_nonexistent_contact_story(Config, Alice, Bob) ->
+    Res = execute_auth(admin_delete_contact_body(Alice, Bob), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not exist">>)).
+
+admin_try_delete_contact_with_unknown_domain(Config) ->
+    User = ?NONEXISTENT_DOMAIN_USER,
+    Res = execute_auth(admin_delete_contact_body(User, User), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_add_contacts(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_add_contacts_story/3).
+
+admin_add_contacts_story(Config, Alice, Bob) ->
+    Res = execute_auth(admin_add_contacts_body(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER]), Config),
+    [R1, null] = get_ok_value(?ADD_CONTACTS_PATH, Res),
+    ?assertNotEqual(nomatch, binary:match(R1, <<"successfully">>)),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
+
+admin_delete_contacts(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_delete_contacts_story/3).
+
+admin_delete_contacts_story(Config, Alice, Bob) ->
+    execute_auth(admin_add_contacts_body(Alice, [Bob]), Config),
+    Res = execute_auth(admin_delete_contacts_body(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER]), Config),
+    [R1, null] = get_ok_value(?DELETE_CONTACTS_PATH, Res),
+    ?assertNotEqual(nomatch, binary:match(R1, <<"successfully">>)),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
+
+admin_invite_accept_and_cancel_subscription(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_invite_accept_and_cancel_subscription_story/3).
+
+admin_invite_accept_and_cancel_subscription_story(Config, Alice, Bob) ->
+    % Add contacts
+    execute_auth(admin_add_contact_body(Alice, Bob, <<"Bobek">>, null), Config),
+    execute_auth(admin_add_contact_body(Bob, Alice, <<"Ali">>, null), Config),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob, 1)),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice, 1)),
+    % Send invitation to subscribe 
+    execute_auth(admin_subscription_body(Alice, Bob, <<"INVITE">>), Config),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
+    escalus:assert(is_presence_with_type, [<<"subscribe">>],
+                           escalus:wait_for_stanza(Bob)),
+    ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Alice, Bob)),
+    % Accept invitation 
+    execute_auth(admin_subscription_body(Bob, Alice, <<"ACCEPT">>), Config),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob)),
+    IsSub = fun(S) -> escalus_pred:is_presence_with_type(<<"subscribed">>, S) end,
+    escalus:assert_many([is_roster_set, IsSub, is_presence],
+                        escalus:wait_for_stanzas(Alice, 3)),
+    ?assertMatch(#roster{ask = none, subscription = from}, get_roster(Bob, Alice)),
+    % Cancel subscription
+    execute_auth(admin_subscription_body(Alice, Bob, <<"CANCEL">>), Config),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
+    ?assertMatch(#roster{ask = none, subscription = none}, get_roster(Alice, Bob)).
+
+admin_decline_subscription_ask(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_decline_subscription_ask_story/3).
+
+admin_decline_subscription_ask_story(Config, Alice, Bob) ->
+    % Add contacts
+    execute_auth(admin_add_contact_body(Alice, Bob, null, null), Config),
+    execute_auth(admin_add_contact_body(Bob, Alice, null, null), Config),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob, 1)),
+    escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice, 1)),
+    % Send invitation to subscribe 
+    execute_auth(admin_subscription_body(Bob, Alice, <<"INVITE">>), Config),
+    ?assertMatch(#roster{ask = in, subscription = none}, get_roster(Alice, Bob)),
+    ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Bob, Alice)),
+    % Decline the invitation 
+    execute_auth(admin_subscription_body(Alice, Bob, <<"DECLINE">>), Config),
+    ?assertMatch(does_not_exist, get_roster(Alice, Bob)),
+    ?assertMatch(#roster{ask = none, subscription = none}, get_roster(Bob, Alice)).
+
+admin_try_subscribe_with_unknown_domain(Config) ->
+    Bob = ?NONEXISTENT_DOMAIN_USER,
+    Alice = ?NONEXISTENT_USER,
+    Res = execute_auth(admin_subscription_body(Bob, Alice, <<"INVITE">>), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_set_mutual_subscription(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_set_mutual_subscription_story/3).
+
+admin_set_mutual_subscription_story(Config, Alice, Bob) ->
+    execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"CONNECT">>), Config),
+    ?assertMatch(#roster{ask = none, subscription = both}, get_roster(Alice, Bob)),
+    ?assertMatch(#roster{ask = none, subscription = both}, get_roster(Bob, Alice)),
+
+    execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"DISCONNECT">>), Config),
+    ?assertMatch(does_not_exist, get_roster(Alice, Bob)),
+    ?assertMatch(does_not_exist, get_roster(Bob, Alice)).
+
+admin_set_mutual_subscription_try_connect_nonexistent_users(Config) ->
+    Alice = ?NONEXISTENT_DOMAIN_USER,
+    Bob = ?NONEXISTENT_USER,
+    Res = execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"CONNECT">>), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_set_mutual_subscription_try_disconnect_nonexistent_users(Config) ->
+    Alice = ?NONEXISTENT_DOMAIN_USER,
+    Bob = ?NONEXISTENT_USER,
+    Res = execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"DISCONNECT">>), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_subscribe_to_all(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
+                                    fun admin_subscribe_to_all_story/4).
+
+admin_subscribe_to_all_story(Config, Alice, Bob, Kate) ->
+    Res = execute_auth(admin_subscribe_to_all_body(Alice, [Bob, Kate]), Config),
+    check_if_created_succ(?SUBSCRIBE_TO_ALL_PATH, Res),
+
+    check_contacts([Bob, Kate], Alice, Config),
+    check_contacts([Alice], Bob, Config),
+    check_contacts([Alice], Kate, Config).
+
+admin_subscribe_to_all_with_wrong_user(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_subscribe_to_all_with_wrong_user_story/3).
+
+admin_subscribe_to_all_with_wrong_user_story(Config, Alice, Bob) ->
+    Kate = ?NONEXISTENT_DOMAIN_USER,
+    Res = execute_auth(admin_subscribe_to_all_body(Alice, [Bob, Kate]), Config),
+    check_if_created_succ(?SUBSCRIBE_TO_ALL_PATH, Res, [true, false]),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)),
+
+    check_contacts([Bob], Alice, Config),
+    check_contacts([Alice], Bob, Config).
+
+admin_subscribe_all_to_all(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
+                                    fun admin_subscribe_all_to_all_story/4).
+
+admin_subscribe_all_to_all_story(Config, Alice, Bob, Kate) ->
+    Res = execute_auth(admin_subscribe_all_to_all_body([Alice, Bob, Kate]), Config),
+    check_if_created_succ(?SUBSCRIBE_ALL_TO_ALL_PATH, Res),
+
+    check_contacts([Bob, Kate], Alice, Config),
+    check_contacts([Alice, Kate], Bob, Config),
+    check_contacts([Alice, Bob], Kate, Config).
+
+admin_subscribe_all_to_all_with_wrong_user(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_subscribe_all_to_all_with_wrong_user_story/3).
+
+admin_subscribe_all_to_all_with_wrong_user_story(Config, Alice, Bob) ->
+    Kate = ?NONEXISTENT_DOMAIN_USER,
+    Res = execute_auth(admin_subscribe_all_to_all_body([Alice, Bob, Kate]), Config),
+    check_if_created_succ(?SUBSCRIBE_ALL_TO_ALL_PATH, Res, [true, false, false]),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(1, Res), <<"does not exist">>)),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(2, Res), <<"does not exist">>)),
+
+    check_contacts([Bob], Alice, Config),
+    check_contacts([Alice], Bob, Config).
+
+admin_list_contacts(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_list_contacts_story/3).
+
+admin_list_contacts_story(Config, Alice, Bob) ->
+    BobBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
+    Name = <<"Bobek">>,
+    execute_auth(admin_add_contact_body(Alice, Bob, Name, ?DEFAULT_GROUPS), Config),
+    Res = execute_auth(admin_list_contacts_body(Alice), Config),
+    [#{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
+       <<"name">> := Name, <<"groups">> := ?DEFAULT_GROUPS}] =
+        get_ok_value([data, roster, listContacts], Res).
+
+admin_list_contacts_wrong_user(Config) ->
+    % User with a non-existent domain
+    Res = execute_auth(admin_list_contacts_body(?NONEXISTENT_DOMAIN_USER), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
+    % Non-existent user with existent domain
+    Res2 = execute_auth(admin_list_contacts_body(?NONEXISTENT_USER), Config),
+    ?assertEqual([], get_ok_value(?LIST_CONTACTS_PATH, Res2)).
+
+admin_get_contact(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_list_contacts_story/3).
+
+admin_get_contact_story(Config, Alice, Bob) ->
+    BobBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
+    Name = <<"Bobek">>,
+    execute_auth(admin_add_contact_body(Alice, Bob, Name, ?DEFAULT_GROUPS), Config),
+    Res = execute_auth(admin_get_contact_body(Alice, Bob), Config),
+    #{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
+      <<"name">> := Name, <<"groups">> := ?DEFAULT_GROUPS} =
+        get_ok_value([data, roster, getContact], Res).
+
+admin_get_contact_wrong_user(Config) ->
+    % User with a non-existent domain
+    Res = execute_auth(admin_get_contact_body(?NONEXISTENT_DOMAIN_USER, ?NONEXISTENT_USER), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
+    % Non-existent user with existent domain
+    Res2 = execute_auth(admin_get_contact_body(?NONEXISTENT_USER, ?NONEXISTENT_USER), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"does not exist">>)).
+
+mock(Config) ->
+    ok.
+
+% Helpers
+
+check_contacts(ContactClients, User, Config) ->
+    Res = execute_auth(admin_list_contacts_body(User), Config),
+    Expected = [escalus_utils:jid_to_lower(escalus_client:short_jid(Client))
+                || Client <- ContactClients],
+    ExpectedNames = [escalus_client:username(Client) || Client <- ContactClients],
+    ActualContacts = get_ok_value(?LIST_CONTACTS_PATH, Res),
+    Actual = [ JID || #{<<"jid">> := JID} <- ActualContacts],
+    ActualNames = [ Name || #{<<"name">> := Name} <- ActualContacts],
+    ?assertEqual(lists:sort(Expected), lists:sort(Actual)),
+    ?assertEqual(lists:sort(ExpectedNames), lists:sort(ActualNames)),
+    [?assertEqual(?DEFAULT_GROUPS, Groups) || #{<<"groups">> := Groups} <- ActualContacts].
+
+check_if_created_succ(Path, Res) ->
+    check_if_created_succ(Path, Res, null).
+
+check_if_created_succ(Path, Res, ExpectedOkValue) ->
+    OkList = get_ok_value(Path, Res),
+
+    OkList2 = case ExpectedOkValue of
+                  null ->
+                      [{Msg, true} || Msg <- OkList];
+                  _ when is_list(ExpectedOkValue) ->
+                      lists:zip(OkList, ExpectedOkValue)
+              end,
+    [?assertNotEqual(nomatch, binary:match(Msg, <<"created successfully">>))
+     || {Msg, ShouldHasValue} <- OkList2, ShouldHasValue].
+
+get_roster(User, Contact) ->
+    rpc(mim(), mod_roster, get_roster_entry,
+        [domain_helper:host_type(),
+         user_to_jid(User),
+         jid:to_lower(user_to_jid(Contact)),
+         full]).
+
+user_to_bin(#client{jid = JID} = Client) -> escalus_client:short_jid(Client);
+user_to_bin(Bin) when is_binary(Bin) -> Bin.
+
+user_to_jid(#client{jid = JID}) -> jid:to_bare(jid:from_binary(JID));
+user_to_jid(Bin) when is_binary(Bin) -> jid:from_binary(Bin).
+
+make_contact(Users) when is_list(Users) ->
+    [make_contact(U) || U <- Users];
+make_contact(U) ->
+    #{jid => user_to_bin(U), name => escalus_utils:get_username(U), groups => ?DEFAULT_GROUPS}.
+
+%% Request bodies
+
+admin_add_contact_body(User, Contact, Name, Groups) ->
+    Query = <<"mutation M1($user: JID!, $contact: JID!, $name: String, $groups: [String!])
+              { roster { addContact(user: $user, contact: $contact, name: $name, groups: $groups) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact),
+             name => Name, groups => Groups},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_add_contacts_body(User, Contacts) ->
+    Query = <<"mutation M1($user: JID!, $contacts: [ContactInput!]!)
+              { roster { addContacts(user: $user, contacts: $contacts) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => user_to_bin(User), contacts => make_contact(Contacts)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_delete_contact_body(User, Contact) ->
+    Query = <<"mutation M1($user: JID!, $contact: JID!)
+              { roster { deleteContact(user: $user, contact: $contact) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_delete_contacts_body(User, Contacts) ->
+    Query = <<"mutation M1($user: JID!, $contacts: [JID!]!)
+              { roster { deleteContacts(user: $user, contacts: $contacts) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => user_to_bin(User), contacts => [user_to_bin(C) || C <- Contacts]},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_subscription_body(User, Contact, Action) ->
+    Query = <<"mutation M1($user: JID!, $contact: JID!, $action: SubAction!)
+              { roster { subscription(user: $user, contact: $contact, action: $action) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact), action => Action},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_mutual_subscription_body(User, Contact, Action) ->
+    Query = <<"mutation M1($userA: JID!, $userB: JID!, $action: MutualSubAction!)
+              { roster { setMutualSubscription(userA: $userA, userB: $userB, action: $action) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{userA => user_to_bin(User), userB => user_to_bin(Contact), action => Action},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_subscribe_to_all_body(User, Contacts) ->
+    Query = <<"mutation M1($user: ContactInput!, $contacts: [ContactInput!]!)
+              { roster { subscribeToAll(user: $user, contacts: $contacts) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => make_contact(User), contacts => make_contact(Contacts)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_subscribe_all_to_all_body(Users) ->
+    Query = <<"mutation M1($contacts: [ContactInput!]!)
+              { roster { subscribeAllToAll(contacts: $contacts) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{contacts => make_contact(Users)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_list_contacts_body(User) ->
+    Query = <<"query Q1($user: JID!)
+              { roster { listContacts(user: $user)
+              { jid subscription ask name groups} } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{user => user_to_bin(User)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_get_contact_body(User, Contact) ->
+    Query = <<"query Q1($user: JID!, $contact: JID!)
+              { roster { getContact(user: $user, contact: $contact)
+              { jid subscription ask name groups} } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact)},
+    #{query => Query, operationName => OpName, variables => Vars}.

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -99,11 +99,11 @@ end_per_testcase(CaseName, Config) ->
 -define(NONEXISTENT_USER, <<"abc@", (domain_helper:domain())/binary>>).
 -define(DEFAULT_GROUPS, [<<"Family">>]).
 
+%% Admin test cases
+
 admin_add_and_delete_contact(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
                                     fun admin_add_and_delete_contact_story/3).
-
-%% Admin test cases
 
 admin_add_and_delete_contact_story(Config, Alice, Bob) ->
     Res = execute_auth(admin_add_contact_body(Alice, Bob, null, null), Config),
@@ -186,8 +186,7 @@ admin_invite_accept_and_cancel_subscription_story(Config, Alice, Bob) ->
     % Send invitation to subscribe 
     execute_auth(admin_subscription_body(Alice, Bob, <<"INVITE">>), Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
-    escalus:assert(is_presence_with_type, [<<"subscribe">>],
-                           escalus:wait_for_stanza(Bob)),
+    escalus:assert(is_presence_with_type, [<<"subscribe">>], escalus:wait_for_stanza(Bob)),
     ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Alice, Bob)),
     % Accept invitation 
     execute_auth(admin_subscription_body(Bob, Alice, <<"ACCEPT">>), Config),
@@ -413,8 +412,7 @@ user_invite_accept_and_cancel_subscription_story(Config, Alice, Bob) ->
     % Send invitation to subscribe 
     execute_user(user_subscription_body(Bob, <<"INVITE">>), Alice, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
-    escalus:assert(is_presence_with_type, [<<"subscribe">>],
-                           escalus:wait_for_stanza(Bob)),
+    escalus:assert(is_presence_with_type, [<<"subscribe">>], escalus:wait_for_stanza(Bob)),
     ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Alice, Bob)),
     % Accept invitation 
     execute_user(user_subscription_body(Alice, <<"ACCEPT">>), Bob, Config),
@@ -513,7 +511,7 @@ check_if_created_succ(Path, Res, ExpectedOkValue) ->
                       lists:zip(OkList, ExpectedOkValue)
               end,
     [?assertNotEqual(nomatch, binary:match(Msg, <<"created successfully">>))
-     || {Msg, ShouldHasValue} <- OkList2, ShouldHasValue].
+     || {Msg, ShouldHaveValue} <- OkList2, ShouldHaveValue].
 
 get_roster(User, Contact) ->
     rpc(mim(), mod_roster, get_roster_entry,

--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -20,6 +20,8 @@ type AdminQuery{
   stanza: StanzaAdminQuery
   "MUC Light room management"
   muc_light: MUCLightAdminQuery 
+  "Roster/Contacts management"
+  roster: RosterAdminQuery 
 }
 
 """
@@ -37,4 +39,6 @@ type AdminMutation @protected{
   stanza: StanzaAdminMutation
   "MUC Light room management"
   muc_light: MUCLightAdminMutation
+  "Roster/Contacts management"
+  roster: RosterAdminMutation
 }

--- a/priv/graphql/schemas/admin/roster.gql
+++ b/priv/graphql/schemas/admin/roster.gql
@@ -1,0 +1,31 @@
+"""
+Allow admin to manage user rester/contacts.
+"""
+type RosterAdminMutation @protected{
+  "Add a new contact to a user's roster without subscription"
+  addContact(user: JID!, contact: JID!, name: String, groups: [String!]): String
+  "Add new contacts to a user's roster without subscription"
+  addContacts(user: JID!, contacts: [ContactInput!]!) : [String]!
+  "Manage the user's subscription to the contact"
+  subscription(user: JID!, contact: JID!, action: SubAction): String
+  "Delete user's contact"
+  deleteContact(user: JID!, contact: JID!): String
+  "Delete user's contacts"
+  deleteContacts(user: JID!, contacts: [JID!]!): [String]!
+  "Manage mutual subscription between given users"
+  setMutualSubscription(userA: JID!, userB: JID!, action: MutualSubAction!): String
+  "Set both subscritpion of user to users from contact list"
+  subscribeToAll(user: ContactInput!, contacts: [ContactInput!]!): [String]!
+  "Subscibe all users to all users from the given contacts list"
+  subscribeAllToAll(contacts: [ContactInput!]): [String]!
+}
+
+"""
+Allow admin to get information about user roster/contacts.
+"""
+type RosterAdminQuery @protected{
+  "Get the user's roster/contacts"
+  listContacts(user: JID!): [Contact!] 
+  "Get the user's contact"
+  getContact(user: JID!, contact: JID!): Contact
+}

--- a/priv/graphql/schemas/admin/roster.gql
+++ b/priv/graphql/schemas/admin/roster.gql
@@ -14,9 +14,9 @@ type RosterAdminMutation @protected{
   deleteContacts(user: JID!, contacts: [JID!]!): [String]!
   "Manage mutual subscription between given users"
   setMutualSubscription(userA: JID!, userB: JID!, action: MutualSubAction!): String
-  "Set both subscritpion of user to users from contact list"
+  "Set mutual subscriptions between the user and each of the given contacts"
   subscribeToAll(user: ContactInput!, contacts: [ContactInput!]!): [String]!
-  "Subscibe all users to all users from the given contacts list"
+  "Set mutual subscriptions between all of the given contacts"
   subscribeAllToAll(contacts: [ContactInput!]): [String]!
 }
 

--- a/priv/graphql/schemas/global/roster.gql
+++ b/priv/graphql/schemas/global/roster.gql
@@ -14,11 +14,11 @@ type Contact{
   jid: JID!
   "The contact name"
   name: String
-  "The list of the groups the contact belongs"
+  "The list of the groups the contact belongs to"
   groups: [String!]
   "The type of the subscription"
   subscription: ContactSub 
-  "The type of the subscription"
+  "The type of the ask"
   ask: ContactAsk
 }
 

--- a/priv/graphql/schemas/global/roster.gql
+++ b/priv/graphql/schemas/global/roster.gql
@@ -1,0 +1,74 @@
+"The contact input data"
+input ContactInput{
+  "The contact jid"
+  jid: JID!
+  "The contact name"
+  name: String!
+  "The contact groups"
+  groups: [String!]
+}
+
+"The contact or roster item"
+type Contact{
+  "The contact jid"
+  jid: JID!
+  "The contact name"
+  name: String
+  "The list of the groups the contact belongs"
+  groups: [String!]
+  "The type of the subscription"
+  subscription: ContactSub 
+  "The type of the subscription"
+  ask: ContactAsk
+}
+
+"The contact subscription types"
+enum ContactSub{
+  """
+  The user does not have a subscription to the contact's presence,
+  and the contact does not have a subscription to the user's presence
+  """
+  NONE
+  "The user and the contact have subscriptions to each other's presence"
+  BOTH
+  """
+  The contact has a subscription to the user's presence, but the user
+  does not have a subscription to the contact's presence
+  """
+  FROM
+  """
+  The user has a subscription to the contact's presence, but the contact
+  does not have a subscription to the user's presence
+  """
+  TO
+}
+
+"The contact ask types"
+enum ContactAsk{
+  SUBSCRIBE
+  UNSUBSCRIBE
+  IN
+  OUT
+  BOTH
+  NONE
+}
+
+"The subscription actions"
+enum SubAction{
+  "Send the subscription request to a user. Presence type: subscribe"
+  INVITE
+  "Accept the subscription request. Presence type: subscribed"
+  ACCEPT
+  "Decline the subscription's request. Presence type: unsubscribed"
+  DECLINE
+  "Cancel the user's subscription. Presence type: unsubscribe"
+  CANCEL
+}
+
+"The mutual subscription actions"
+enum MutualSubAction{
+  "Add users to contacts with a `both` subscription type"
+  CONNECT
+  "Delete contacts"
+  DISCONNECT
+}

--- a/priv/graphql/schemas/user/roster.gql
+++ b/priv/graphql/schemas/user/roster.gql
@@ -1,0 +1,25 @@
+"""
+Allow user to manage user rester/contacts.
+"""
+type RosterUserMutation @protected{
+  "Add a new contact to a user's roster without subscription"
+  addContact(contact: JID!, name: String, groups: [String!]): String
+  "Add new contacts to a user's roster without subscription"
+  addContacts(contacts: [ContactInput!]!) : [String]!
+  "Manage the user subscription to the contact"
+  subscription(contact: JID!, action: SubAction!): String
+  "Delete user's contact"
+  deleteContact(contact: JID!): String
+  "Delete user's contacts"
+  deleteContacts(contacts: [JID!]!): [String]!
+}
+
+"""
+Allow user to get information about user roster/contacts.
+"""
+type RosterUserQuery @protected{
+  "Get the user's roster/contacts"
+  listContacts: [Contact!] 
+  "Get the user's contact"
+  getContact(contact: JID!): Contact
+}

--- a/priv/graphql/schemas/user/user_schema.gql
+++ b/priv/graphql/schemas/user/user_schema.gql
@@ -18,6 +18,8 @@ type UserQuery{
   session: SessionUserQuery
   "Stanza management"
   stanza: StanzaUserQuery
+  "Roster/Contacts management"
+  roster: RosterUserQuery
 }
 
 """
@@ -31,4 +33,6 @@ type UserMutation @protected{
   muc_light: MUCLightUserMutation
   "Stanza management"
   stanza: StanzaUserMutation
+  "Roster/Contacts management"
+  roster: RosterUserMutation
 }

--- a/src/admin_extra/service_admin_extra_roster.erl
+++ b/src/admin_extra/service_admin_extra_roster.erl
@@ -242,7 +242,7 @@ delete_rosteritem(LocalUser, LocalServer, User, Server) ->
 unsubscribe(LocalJID, RemoteJID) ->
     ItemEl = build_roster_item(RemoteJID, remove),
     QueryEl = #xmlel{ name = <<"query">>,
-              attrs = [{<<"xmlns">>, <<"jabber:iq:roster">>}],
+              attrs = [{<<"xmlns">>, ?NS_ROSTER}],
               children = [ItemEl]},
     {ok, HostType} = mongoose_domain_api:get_domain_host_type(LocalJID#jid.lserver),
     mod_roster:set_items(HostType, LocalJID, QueryEl).

--- a/src/graphql/admin/mongoose_graphql_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_mutation.erl
@@ -16,4 +16,6 @@ execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
 execute(_Ctx, _Obj, <<"session">>, _Args) ->
     {ok, session};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, #{}}.
+    {ok, #{}};
+execute(_Ctx, _Obj, <<"roster">>, _Args) ->
+    {ok, roster}.

--- a/src/graphql/admin/mongoose_graphql_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_mutation.erl
@@ -16,6 +16,6 @@ execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
 execute(_Ctx, _Obj, <<"session">>, _Args) ->
     {ok, session};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, #{}};
+    {ok, stanza};
 execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster}.

--- a/src/graphql/admin/mongoose_graphql_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_query.erl
@@ -17,6 +17,8 @@ execute(_Ctx, _Obj, <<"session">>, _Args) ->
     {ok, session};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
     {ok, #{}};
+execute(_Ctx, _Obj, <<"roster">>, _Args) ->
+    {ok, roster};
 execute(#{authorized := Authorized}, _Obj, <<"checkAuth">>, _Args) ->
     case Authorized of
         true ->

--- a/src/graphql/admin/mongoose_graphql_roster_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_roster_admin_mutation.erl
@@ -1,0 +1,90 @@
+-module(mongoose_graphql_roster_admin_mutation).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+
+execute(_Ctx, _Obj, <<"addContact">>, Args) ->
+    add_contact(Args);
+execute(_Ctx, _Obj, <<"addContacts">>, Args) ->
+    add_contacts(Args);
+execute(_Ctx, _Obj, <<"subscription">>, Args) ->
+    subscription(Args);
+execute(_Ctx, _Obj, <<"setMutualSubscription">>, Args) ->
+    set_mutual_subscription(Args);
+execute(_Ctx, _Obj, <<"deleteContact">>, Args) ->
+    delete_contact(Args);
+execute(_Ctx, _Obj, <<"deleteContacts">>, Args) ->
+    delete_contacts(Args);
+execute(_Ctx, _Obj, <<"subscribeToAll">>, Args) ->
+    subscribe_to_all(Args);
+execute(_Ctx, _Obj, <<"subscribeAllToAll">>, Args) ->
+    subscribe_all_to_all(Args).
+
+-spec add_contact(mongoose_graphql:args()) -> mongoose_graphql_roster:binary_result().
+add_contact(#{<<"user">> := UserJID, <<"contact">> := ContactJID,
+              <<"name">> := Name, <<"groups">> := Groups}) ->
+    mongoose_graphql_roster:add_contact(UserJID, ContactJID, Name, Groups).
+
+-spec add_contacts(mongoose_graphql:args()) -> mongoose_graphql_roster:list_binary_result().
+add_contacts(#{<<"user">> := UserJID, <<"contacts">> := Contacts}) ->
+    {ok, [mongoose_graphql_roster:add_contact(UserJID, ContactJID, Name, Groups)
+          || #{<<"jid">> := ContactJID, <<"name">> := Name, <<"groups">> := Groups} <- Contacts]}.
+
+-spec subscription(mongoose_graphql:args()) -> mongoose_graphql_roster:binary_result().
+subscription(#{<<"user">> := UserJID, <<"contact">> := ContactJID, <<"action">> := Action}) ->
+    Type = mongoose_graphql_roster:translate_sub_action(Action),
+    Res = mod_roster_api:subscription(UserJID, ContactJID, Type),
+    format_result(Res, #{user => jid:to_binary(UserJID),
+                         contact => jid:to_binary(ContactJID)}).
+
+-spec set_mutual_subscription(mongoose_graphql:args()) -> mongoose_graphql_roster:binary_result().
+set_mutual_subscription(#{<<"userA">> := UserAJID, <<"userB">> := UserBJID,
+                          <<"action">> := Action}) ->
+    Res = mod_roster_api:set_mutual_subscription(UserAJID, UserBJID, Action),
+    format_result(Res, #{userA => jid:to_binary(UserAJID),
+                         userB => jid:to_binary(UserBJID)}).
+
+-spec delete_contact(mongoose_graphql:args()) -> mongoose_graphql_roster:binary_result().
+delete_contact(#{<<"user">> := UserJID, <<"contact">> := ContactJID}) ->
+    mongoose_graphql_roster:delete_contact(UserJID, ContactJID).
+
+-spec delete_contacts(mongoose_graphql:args()) -> mongoose_graphql_roster:list_binary_result().
+delete_contacts(#{<<"user">> := UserJID, <<"contacts">> := ContactJIDs}) ->
+    {ok, [mongoose_graphql_roster:delete_contact(UserJID, ContactJID)
+          || ContactJID <- ContactJIDs]}.
+
+-spec subscribe_to_all(mongoose_graphql:args()) -> mongoose_graphql_roster:list_binary_result().
+subscribe_to_all(#{<<"user">> := User, <<"contacts">> := Contacts}) ->
+    {ok, do_subscribe_to_all(User, Contacts)}.
+
+-spec subscribe_all_to_all(mongoose_graphql:args()) -> mongoose_graphql_roster:list_binary_result().
+subscribe_all_to_all(#{<<"contacts">> := Contacts}) ->
+    {ok, do_subscribe_all_to_all(Contacts)}.
+
+-spec do_subscribe_to_all(mongoose_graphql_roster:contact_input(),
+                          [mongoose_graphql_roster:contact_input()]) ->
+    [mongoose_graphql_roster:binary_result()].
+do_subscribe_to_all(User, Contacts) ->
+    UserTuple = contact_input_map_to_tuple(User),
+    lists:map(fun(Contact) ->
+                      ContactTuple = contact_input_map_to_tuple(Contact),
+                      Res = mod_roster_api:subscribe_both(UserTuple, ContactTuple),
+                      format_result(Res, #{user => jid:to_binary(element(1, UserTuple)),
+                                           contact => jid:to_binary(element(1, ContactTuple))})
+              end, Contacts).
+
+-spec do_subscribe_all_to_all([mongoose_graphql_roster:contact_input()]) ->
+    [mongoose_graphql_roster:binary_result()].
+do_subscribe_all_to_all([_]) ->
+    [];
+do_subscribe_all_to_all([User | Contacts]) ->
+    do_subscribe_to_all(User, Contacts) ++ do_subscribe_all_to_all(Contacts).
+
+contact_input_map_to_tuple(#{<<"jid">> := JID, <<"name">> := Name, <<"groups">> := Groups}) ->
+    {JID, Name, Groups}.

--- a/src/graphql/admin/mongoose_graphql_roster_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_roster_admin_query.erl
@@ -1,0 +1,36 @@
+-module(mongoose_graphql_roster_admin_query).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2]).
+
+execute(_Ctx, _Obj, <<"listContacts">>, Args) ->
+    list_contacts(Args);
+execute(_Ctx, _Obj, <<"getContact">>, Args) ->
+    get_contact(Args).
+
+-spec list_contacts(mongoose_graphql:args()) ->
+    {ok, mongoose_graphql_roster:contact_list()} | {error, resolver_error()}.
+list_contacts(#{<<"user">> := UserJID}) ->
+    case mod_roster_api:list_contacts(UserJID) of
+        {ok, Contacts} ->
+            {ok, [mongoose_graphql_roster:make_ok_roster(C) || C <- Contacts]};
+        Error ->
+            make_error(Error, #{user => jid:to_binary(UserJID)})
+    end.
+
+-spec get_contact(mongoose_graphql:args()) ->
+    {ok, mongoose_graphql_roster:contact()} | {error, resolver_error()}.
+get_contact(#{<<"user">> := UserJID, <<"contact">> := ContactJID}) ->
+    case mod_roster_api:get_contact(UserJID, ContactJID) of
+        {ok, Contact} ->
+            mongoose_graphql_roster:make_ok_roster(Contact);
+        Error ->
+            make_error(Error, #{contact => jid:to_binary(ContactJID),
+                                user => jid:to_binary(UserJID)})
+    end.

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -153,6 +153,8 @@ user_mapping_rules() ->
         'AccountUserMutation' => mongoose_graphql_account_user_mutation,
         'MUCLightUserMutation' => mongoose_graphql_muc_light_user_mutation,
         'MUCLightUserQuery' => mongoose_graphql_muc_light_user_query,
+        'RosterUserQuery' => mongoose_graphql_roster_user_query,
+        'RosterUserMutation' => mongoose_graphql_roster_user_mutation,
         'SessionUserQuery' => mongoose_graphql_session_user_query,
         'StanzaUserMutation' => mongoose_graphql_stanza_user_mutation,
         'StanzaUserQuery' => mongoose_graphql_stanza_user_query,

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -137,6 +137,8 @@ admin_mapping_rules() ->
         'AccountAdminMutation' => mongoose_graphql_account_admin_mutation,
         'MUCLightAdminMutation' => mongoose_graphql_muc_light_admin_mutation,
         'MUCLightAdminQuery' => mongoose_graphql_muc_light_admin_query,
+        'RosterAdminQuery' => mongoose_graphql_roster_admin_query,
+        'RosterAdminMutation' => mongoose_graphql_roster_admin_mutation,
         'Domain' => mongoose_graphql_domain,
         default => mongoose_graphql_default},
       interfaces => #{default => mongoose_graphql_default},

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -16,7 +16,13 @@ input(<<"Affiliation">>, <<"NONE">>) -> {ok, none};
 input(<<"BlockingAction">>, <<"ALLOW">>) -> {ok, allow};
 input(<<"BlockingAction">>, <<"DENY">>) -> {ok, deny};
 input(<<"BlockedEntityType">>, <<"USER">>) -> {ok, user};
-input(<<"BlockedEntityType">>, <<"ROOM">>) -> {ok, room}.
+input(<<"BlockedEntityType">>, <<"ROOM">>) -> {ok, room};
+input(<<"SubAction">>, <<"INVITE">>) -> {ok, invite};
+input(<<"SubAction">>, <<"ACCEPT">>) -> {ok, accept};
+input(<<"SubAction">>, <<"DECLINE">>) -> {ok, decline};
+input(<<"SubAction">>, <<"CANCEL">>) -> {ok, cancel};
+input(<<"MutualSubAction">>, <<"CONNECT">>) -> {ok, connect};
+input(<<"MutualSubAction">>, <<"DISCONNECT">>) -> {ok, disconnect}.
 
 output(<<"PresenceShow">>, Show) ->
     {ok, list_to_binary(string:to_upper(binary_to_list(Show)))};
@@ -29,4 +35,16 @@ output(<<"Affiliation">>, Aff) ->
 output(<<"BlockingAction">>, Action) ->
     {ok, list_to_binary(string:to_upper(atom_to_list(Action)))};
 output(<<"BlockedEntityType">>, What) ->
-    {ok, list_to_binary(string:to_upper(atom_to_list(What)))}.
+    {ok, list_to_binary(string:to_upper(atom_to_list(What)))};
+output(<<"ContactSub">>, Type) when Type =:= both;
+                                    Type =:= from;
+                                    Type =:= to;
+                                    Type =:= none ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Type)))};
+output(<<"ContactAsk">>, Type) when Type =:= subscrube;
+                                    Type =:= unsubscribe;
+                                    Type =:= in;
+                                    Type =:= out;
+                                    Type =:= both;
+                                    Type =:= none ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Type)))}.

--- a/src/graphql/mongoose_graphql_helper.erl
+++ b/src/graphql/mongoose_graphql_helper.erl
@@ -2,7 +2,7 @@
 
 -export([check_user/2]).
 
--export([format_result/2, make_error/2, make_error/3]).
+-export([format_result/2, make_error/2, make_error/3, null_to_default/2]).
 
 -include("jlib.hrl").
 -include("mongoose_graphql_types.hrl").
@@ -44,3 +44,8 @@ check_auth(HostType, Jid, true) ->
        false ->
            {error, #{what => unknown_user, jid => jid:to_binary(Jid)}}
     end.
+
+null_to_default(null, Default) ->
+    Default;
+null_to_default(Value, _Default) ->
+    Value.

--- a/src/graphql/mongoose_graphql_roster.erl
+++ b/src/graphql/mongoose_graphql_roster.erl
@@ -1,0 +1,41 @@
+-module(mongoose_graphql_roster).
+
+-export([make_ok_roster/1, translate_sub_action/1]).
+
+-export([add_contact/4, delete_contact/2]).
+
+-include("mod_roster.hrl").
+-include("mongoose_graphql_types.hrl").
+
+-type binary_result() :: {ok, binary()} | {error, resolver_error()}.
+-type list_binary_result() :: {ok, [{ok, binary()} | {error, resolver_error()}]}.
+-type contact_input() :: map().
+-type contact() :: map().
+-type contact_list() :: [{ok, contact()}].
+
+-export_type([binary_result/0, list_binary_result/0, contact_input/0,
+              contact/0, contact_list/0]).
+
+-spec add_contact(jid:jid(), jid:jid(), binary(), [binary()]) -> binary_result().
+add_contact(UserJID, ContactJID, Name, Groups) ->
+    DefaultName =  mongoose_graphql_helper:null_to_default(Name, <<>>),
+    DefaultGroups = mongoose_graphql_helper:null_to_default(Groups, []),
+    Res = mod_roster_api:add_contact(UserJID, ContactJID, DefaultName, DefaultGroups),
+    mongoose_graphql_helper:format_result(Res, #{user => jid:to_binary(UserJID),
+                                                 contact => jid:to_binary(ContactJID)}).
+
+-spec delete_contact(jid:jid(), jid:jid()) -> binary_result().
+delete_contact(UserJID, ContactJID) ->
+    Res = mod_roster_api:delete_contact(UserJID, ContactJID),
+    mongoose_graphql_helper:format_result(Res, #{user => jid:to_binary(UserJID),
+                                                 contact => jid:to_binary(ContactJID)}).
+
+-spec make_ok_roster(mod_roster:roster()) -> {ok, map()}.
+make_ok_roster(#roster{subscription = Sub, ask = Ask, jid = JID, name = Name, groups = Groups}) ->
+    {ok, #{<<"jid">> => JID, <<"subscription">> => Sub, <<"ask">> => Ask,
+           <<"name">> => Name, <<"groups">> => [{ok, Group} || Group <- Groups]}}.
+
+translate_sub_action(invite) -> subscribe;
+translate_sub_action(accept) -> subscribed;
+translate_sub_action(cancel) -> unsubscribe;
+translate_sub_action(decline) -> unsubscribed.

--- a/src/graphql/user/mongoose_graphql_roster_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_roster_user_mutation.erl
@@ -1,0 +1,50 @@
+-module(mongoose_graphql_roster_user_mutation).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+
+execute(Ctx, _Obj, <<"addContact">>, Args) ->
+    add_contact(Ctx, Args);
+execute(Ctx, _Obj, <<"addContacts">>, Args) ->
+    add_contacts(Ctx, Args);
+execute(Ctx, _Obj, <<"subscription">>, Args) ->
+    subscription(Ctx, Args);
+execute(Ctx, _Obj, <<"deleteContact">>, Args) ->
+    delete_contact(Ctx, Args);
+execute(Ctx, _Obj, <<"deleteContacts">>, Args) ->
+    delete_contacts(Ctx, Args).
+
+-spec add_contact(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    mongoose_graphql_roster:binary_result().
+add_contact(#{user := UserJID}, #{<<"contact">> := ContactJID,
+                                  <<"name">> := Name,
+                                  <<"groups">> := Groups}) ->
+    mongoose_graphql_roster:add_contact(UserJID, ContactJID, Name, Groups).
+
+-spec add_contacts(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    mongoose_graphql_roster:list_binary_result().
+add_contacts(#{user := UserJID}, #{<<"contacts">> := Contacts}) ->
+    {ok, [mongoose_graphql_roster:add_contact(UserJID, ContactJID, Name, Groups)
+          || #{<<"jid">> := ContactJID, <<"name">> := Name, <<"groups">> := Groups} <- Contacts]}.
+
+-spec subscription(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    mongoose_graphql_roster:binary_result().
+subscription(#{user := UserJID}, #{<<"contact">> := ContactJID, <<"action">> := Action}) ->
+    Type = mongoose_graphql_roster:translate_sub_action(Action),
+    Res = mod_roster_api:subscription(UserJID, ContactJID, Type),
+    format_result(Res, #{contact => jid:to_binary(ContactJID)}).
+
+-spec delete_contact(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    mongoose_graphql_roster:binary_result().
+delete_contact(#{user := UserJID}, #{<<"contact">> := ContactJID}) ->
+    mongoose_graphql_roster:delete_contact(UserJID, ContactJID).
+
+-spec delete_contacts(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    mongoose_graphql_roster:list_binary_result().
+delete_contacts(#{user := UserJID}, #{<<"contacts">> := ContactJIDs}) ->
+    {ok, [mongoose_graphql_roster:delete_contact(UserJID, ContactJID)
+          || ContactJID <- ContactJIDs]}.

--- a/src/graphql/user/mongoose_graphql_roster_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_roster_user_query.erl
@@ -1,0 +1,31 @@
+-module(mongoose_graphql_roster_user_query).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2]).
+
+execute(Ctx, _Obj, <<"listContacts">>, Args) ->
+    list_contacts(Ctx, Args);
+execute(Ctx, _Obj, <<"getContact">>, Args) ->
+    get_contact(Ctx, Args).
+
+-spec list_contacts(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    {ok, mongoose_graphql_roster:contact_list()} | {error, resolver_error()}.
+list_contacts(#{user := UserJID}, #{}) ->
+    {ok, Contacts} = mod_roster_api:list_contacts(UserJID),
+    {ok, [mongoose_graphql_roster:make_ok_roster(C) || C <- Contacts]}.
+
+-spec get_contact(mongoose_graphql:context(), mongoose_graphql:args()) ->
+    {ok, mongoose_graphql_roster:contact()} | {error, resolver_error()}.
+get_contact(#{user := UserJID}, #{<<"contact">> := ContactJID}) ->
+    case mod_roster_api:get_contact(UserJID, ContactJID) of
+        {ok, Contact} ->
+            mongoose_graphql_roster:make_ok_roster(Contact);
+        Error ->
+            make_error(Error, #{contact => jid:to_binary(ContactJID)})
+    end.

--- a/src/graphql/user/mongoose_graphql_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_user_mutation.erl
@@ -10,4 +10,6 @@ execute(_Ctx, _Obj, <<"account">>, _Args) ->
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, stanza}.
+    {ok, stanza};
+execute(_Ctx, _Obj, <<"roster">>, _Args) ->
+    {ok, roster}.

--- a/src/graphql/user/mongoose_graphql_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_user_query.erl
@@ -14,4 +14,6 @@ execute(_Ctx, _Obj, <<"session">>, _Args) ->
 execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
     {ok, user};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, stanza}.
+    {ok, stanza};
+execute(_Ctx, _Obj, <<"roster">>, _Args) ->
+    {ok, roster}.

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -844,7 +844,7 @@ send_presence_type(From, To, Type) ->
 -spec remove_domain(mongoose_hooks:simple_acc(),
                     mongooseim:host_type(), jid:lserver()) ->
     mongoose_hooks:simple_acc().
-remove_domain(Acc, HostType, Domain) -> 
+remove_domain(Acc, HostType, Domain) ->
     case backend_module:is_exported(mod_roster_backend, remove_domain_t, 2) of
          true ->
             F = fun() -> mod_roster_backend:remove_domain_t(HostType, Domain) end,

--- a/src/mod_roster_api.erl
+++ b/src/mod_roster_api.erl
@@ -1,0 +1,165 @@
+%% @doc Provide an interface for frontends (like graphql or ctl) to manage roster.
+-module(mod_roster_api).
+
+-export([list_contacts/1,
+         get_contact/2,
+         add_contact/4,
+         delete_contact/2,
+         subscription/3,
+         subscribe_both/2,
+         set_mutual_subscription/3]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+-include("mod_roster.hrl").
+
+-type sub_mutual_action() :: connect | disconnect.
+
+-define(UNKNOWN_DOMAIN_RESULT, {unknown_domain, "Domain not found"}).
+-define(INTERNAL_ERROR_RESULT(Error, Operation),
+        {internal, io_lib:format("Cannot ~p a contact because: ~p", [Operation, Error])}).
+
+-spec add_contact(jid:jid(), jid:jid(), binary(), [binary()]) ->
+    {ok | internal | user_not_exist | unknown_domain, iolist()}.
+add_contact(#jid{lserver = LServer} = CallerJID, ContactJID, Name, Groups) ->
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            case does_users_exist(CallerJID, ContactJID) of
+                ok ->
+                    case mod_roster:set_roster_entry(HostType, CallerJID, ContactJID,
+                                                     Name, Groups) of
+                        ok ->
+                            {ok, "Contact added successfully"};
+                        {error, Error} ->
+                            ?INTERNAL_ERROR_RESULT(Error, create)
+                    end;
+                Error ->
+                    Error
+            end;
+        {error, not_found} ->
+            ?UNKNOWN_DOMAIN_RESULT
+    end.
+
+-spec list_contacts(jid:jid()) -> {ok, [mod_roster:roster()]} | {unknown_domain, iolist()}.
+list_contacts(#jid{lserver = LServer} = CallerJID) ->
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            Acc0 = mongoose_acc:new(#{ location => ?LOCATION,
+                                       host_type => HostType,
+                                       lserver => LServer,
+                                       element => undefined }),
+            Acc1 = mongoose_acc:set(roster, show_full_roster, true, Acc0),
+            Acc2 = mongoose_hooks:roster_get(Acc1, CallerJID),
+            {ok, mongoose_acc:get(roster, items, Acc2)};
+        {error, not_found} ->
+            ?UNKNOWN_DOMAIN_RESULT
+    end.
+
+-spec get_contact(jid:jid(), jid:jid()) ->
+    {ok, mod_roster:roster()} | {contact_not_found | internal | unknown_domain, iolist()}.
+get_contact(#jid{lserver = LServer} = UserJID, ContactJID) ->
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            ContactL = jid:to_lower(ContactJID),
+            case mod_roster:get_roster_entry(HostType, UserJID, ContactL, full) of
+                #roster{} = R ->
+                    {ok, R};
+                does_not_exist ->
+                    {contact_not_found, "Given contact does not exist"};
+                error ->
+                    ?INTERNAL_ERROR_RESULT(error, get)
+            end;
+        {error, not_found} ->
+            ?UNKNOWN_DOMAIN_RESULT
+    end.
+
+-spec delete_contact(jid:jid(), jid:jid()) ->
+    {ok | contact_not_found | internal | unknown_domain, iolist()}.
+delete_contact(#jid{lserver = LServer} = CallerJID, ContactJID) ->
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            case mod_roster:remove_from_roster(HostType, CallerJID, ContactJID) of
+                ok ->
+                    {ok, io_lib:format("Contact ~s deleted successfully",
+                                       [jid:to_binary(ContactJID)])};
+                {error, does_not_exist} ->
+                    ErrMsg = io_lib:format("Cannot remove ~s contact that does not exist",
+                                           [jid:to_binary(ContactJID)]),
+                    {contact_not_found, ErrMsg};
+                {error, Error} ->
+                    ?INTERNAL_ERROR_RESULT(Error, delete)
+            end;
+        {error, not_found} ->
+            ?UNKNOWN_DOMAIN_RESULT
+    end.
+
+-spec subscription(jid:jid(), jid:jid(), mod_roster:sub_presence()) ->
+    {ok | unknown_domain, iolist()}.
+subscription(#jid{lserver = LServer} = CallerJID, ContactJID, Type) ->
+    StanzaType = atom_to_binary(Type, latin1),
+    El = #xmlel{name = <<"presence">>, attrs = [{<<"type">>, StanzaType}]},
+    case mongoose_domain_api:get_domain_host_type(LServer) of
+        {ok, HostType} ->
+            Acc1 = mongoose_acc:new(#{ location => ?LOCATION,
+                                       from_jid => CallerJID,
+                                       to_jid => ContactJID,
+                                       host_type => HostType,
+                                       lserver => LServer,
+                                       element => El }),
+            Acc2 = mongoose_hooks:roster_out_subscription(Acc1, CallerJID, ContactJID, Type),
+            ejabberd_router:route(CallerJID, ContactJID, Acc2),
+            {ok, io_lib:format("Subscription stanza with type ~s sent successfully", [StanzaType])};
+        {error, not_found} ->
+            ?UNKNOWN_DOMAIN_RESULT
+    end.
+
+-spec set_mutual_subscription(jid:jid(), jid:jid(), sub_mutual_action()) -> {ok, iolist()}.
+set_mutual_subscription(UserA, UserB, connect) ->
+    subscribe_both({UserA, <<>>, []}, {UserB, <<>>, []});
+set_mutual_subscription(UserA, UserB, disconnect) ->
+    Seq = [fun() -> delete_contact(UserA, UserB) end,
+           fun() -> delete_contact(UserB, UserA) end],
+    case run_seq(Seq, ok) of
+        ok ->
+            {ok, "Mututal subscription removed successfully"};
+        Error ->
+            Error
+    end.
+
+-spec subscribe_both({jid:jid(), binary(), [binary()]}, {jid:jid(), binary(), [binary()]}) ->
+    {ok, iolist()}.
+subscribe_both({UserA, NameA, GroupsA}, {UserB, NameB, GroupsB}) ->
+    Seq = [fun() -> add_contact(UserA, UserB, NameB, GroupsB) end,
+           fun() -> add_contact(UserB, UserA, NameA, GroupsA) end,
+           fun() -> subscription(UserA, UserB, subscribe) end,
+           fun() -> subscription(UserB, UserA, subscribe) end,
+           fun() -> subscription(UserA, UserB, subscribed) end,
+           fun() -> subscription(UserB, UserA, subscribed) end],
+    case run_seq(Seq, ok) of
+        ok ->
+            {ok, io_lib:format("Subscription between users ~p and ~p created successfully",
+                               [jid:to_binary(UserA), jid:to_binary(UserB)])};
+        Error ->
+           Error
+    end.
+
+%% Internal
+
+-spec does_users_exist(jid:jid(), jid:jid()) -> ok | {user_not_exist, iolist()}.
+does_users_exist(User, Contact) ->
+    case lists:filter(fun(U) -> not ejabberd_auth:does_user_exist(U) end, [User, Contact]) of
+        [] ->
+            ok;
+        [NotExist | _]->
+            {user_not_exist, io_lib:format("The user ~s does not exist",
+                                           [jid:to_binary(NotExist)])}
+    end.
+
+-spec run_seq([fun(() -> any())], term()) -> ok | {atom(), iolist()}.
+run_seq([Cmd | Seq], ok) ->
+    run_seq(Seq, Cmd());
+run_seq([Cmd | Seq], {ok, _}) ->
+    run_seq(Seq, Cmd());
+run_seq([], _) -> ok;
+run_seq(_, {_, _} = Error) ->
+    Error.

--- a/src/mod_roster_api.erl
+++ b/src/mod_roster_api.erl
@@ -140,7 +140,7 @@ subscribe_both({UserA, NameA, GroupsA}, {UserB, NameB, GroupsB}) ->
             {ok, io_lib:format("Subscription between users ~p and ~p created successfully",
                                [jid:to_binary(UserA), jid:to_binary(UserB)])};
         Error ->
-           Error
+            Error
     end.
 
 %% Internal


### PR DESCRIPTION
This PR addresses [MIM-1605](https://erlangsolutions.atlassian.net/browse/MIM-1605) and implements roster category for both user and admin.

This implementation reuse roster commands from `mod_commands` (used by admin and user Rest API) and extracts those functions to the new `mod_roster_api` module. 

There is also a `service_admin_extra_roster` module that delivers commands for CTL, and I tried to implement the most useful functionality in GraphQL with the use of functions proposed by Rest API. The roster functions used by extra roster commands are undocumented and seem to be older. Also, the extra roster API is a little bit different from the Rest API, so I left it unchanged.

