### PR TITLE
Global distribution opts in a map

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -122,8 +122,7 @@
 -import(config_parser_helper, [config/2, mod_config/2]).
 
 config_opts(ExtraOpts) ->
-    lists:foldl(fun(Step, OptsIn) -> set_opts(Step, OptsIn) end,
-                ExtraOpts, [defaults, backend, pm, muc, async_writer]).
+    lists:foldl(fun set_opts/2, ExtraOpts, [defaults, backend, pm, muc, async_writer]).
 
 set_opts(defaults, Opts) ->
     mod_config(mod_mam_meta, Opts);

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -123,10 +123,7 @@ init_per_suite(Config) ->
             ok = rpc(europe_node2, mongoose_cluster, join, [ct:get_config(europe_node1)]),
 
             enable_logging(),
-            % We have to pass [no_opts] because [] is treated as string and converted
-            % automatically to <<>>
-            escalus:init_per_suite([{add_advertised_endpoints, []},
-                                    {extra_config, #{}} | Config]);
+            escalus:init_per_suite([{add_advertised_endpoints, []}, {extra_config, #{}} | Config]);
         Result ->
             ct:pal("Redis check result: ~p", [Result]),
             {skip, "GD Redis default pool not available"}
@@ -207,8 +204,7 @@ init_modules_per_node({NodeName, LocalHost, ReceiverPort}, Config0) ->
     Config1.
 
 module_opts(ExtraOpts) ->
-    lists:foldl(fun(Step, OptsIn) -> set_opts(Step, OptsIn) end,
-                ExtraOpts, [common, defaults, connections, redis, bounce]).
+    lists:foldl(fun set_opts/2, ExtraOpts, [common, defaults, connections, redis, bounce]).
 
 set_opts(common, Opts) ->
     maps:merge(#{global_host => <<"localhost">>,

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -27,6 +27,7 @@
 -define(HOSTS_REFRESH_INTERVAL, 200). %% in ms
 
 -import(domain_helper, [domain/0]).
+-import(config_parser_helper, [config/2, mod_config/2]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -45,11 +46,11 @@ all() ->
     ].
 
 groups() ->
-    G = [{mod_global_distrib, [],
+    [{mod_global_distrib, [],
           [
            test_pm_between_users_at_different_locations,
            test_pm_between_users_before_available_presence,
-           test_component_disconnect,
+           test_component_disconnect ,
            test_component_on_one_host,
            test_components_in_different_regions,
            test_hidden_component_disco_in_different_region,
@@ -103,8 +104,7 @@ groups() ->
            test_advertised_endpoints_override_endpoints,
            test_pm_between_users_at_different_locations
           ]}
-        ],
-    ct_helper:repeat_all_until_all_ok(G).
+    ].
 
 suite() ->
     [{require, europe_node1, {hosts, mim, node}},
@@ -127,7 +127,7 @@ init_per_suite(Config) ->
             % We have to pass [no_opts] because [] is treated as string and converted
             % automatically to <<>>
             escalus:init_per_suite([{add_advertised_endpoints, []},
-                                    {extra_config, []}, {redis_extra_config, [no_opts]} | Config]);
+                                    {extra_config, #{}} | Config]);
         Result ->
             ct:pal("Redis check result: ~p", [Result]),
             {skip, "GD Redis default pool not available"}
@@ -140,12 +140,16 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(start_checks, Config) ->
-    Config;
+    NodeName = europe_node1,
+    NodeSpec = node_spec(NodeName),
+    Config1 = dynamic_modules:save_modules(NodeSpec, [domain()], Config),
+    dynamic_modules:ensure_modules(NodeSpec, domain(), [{mod_global_distrib, stopped}]),
+    Config1;
 init_per_group(multi_connection, Config) ->
-    ExtraConfig = [{resend_after_ms, 20000},
-                   %% Disable unused feature to avoid interferance
-                   {disabled_gc_interval, 10000},
-                   {connections_per_endpoint, 100}],
+    ExtraConfig = #{bounce => #{resend_after_ms => 20000},
+                    connections => #{%% Disable unused feature to avoid interference
+                                     connections_per_endpoint => 100,
+                                     disabled_gc_interval => 10000}},
     init_per_group_generic([{extra_config, ExtraConfig} | Config]);
 init_per_group(invalidation, Config) ->
     Config1 = init_per_group(invalidation_generic, Config),
@@ -154,12 +158,11 @@ init_per_group(invalidation, Config) ->
 init_per_group(rebalancing, Config) ->
     %% We need to prevent automatic refreshes, because they may interfere with tests
     %% and we need early disabled garbage collection to check its validity
-    ExtraConfig = [{endpoint_refresh_interval, 3600},
-                   {endpoint_refresh_interval_when_empty, 3600},
-                   {disabled_gc_interval, 1}],
-    RedisExtraConfig = [{refresh_after, 3600}],
-    init_per_group_generic([{extra_config, ExtraConfig},
-                            {redis_extra_config, RedisExtraConfig} | Config]);
+    ExtraConfig = #{connections => #{endpoint_refresh_interval => 3600,
+                                     endpoint_refresh_interval_when_empty => 3600,
+                                     disabled_gc_interval => 1},
+                    redis => #{refresh_after => 3600}},
+    init_per_group_generic([{extra_config, ExtraConfig} | Config]);
 init_per_group(advertised_endpoints, Config) ->
     lists:foreach(fun({NodeName, _, _}) ->
                           Node = ct:get_config(NodeName),
@@ -171,52 +174,60 @@ init_per_group(advertised_endpoints, Config) ->
                  [{asia_node, advertised_endpoints()}]} | Config]);
 init_per_group(mod_global_distrib, Config) ->
     %% Disable mod_global_distrib_mapping_redis refresher
-    RedisExtraConfig = [{refresh_after, 3600}],
-    init_per_group_generic([{redis_extra_config, RedisExtraConfig} | Config]);
+    ExtraConfig = #{redis => #{refresh_after => 3600}},
+    init_per_group_generic([{extra_config, ExtraConfig} | Config]);
 init_per_group(_, Config) ->
     init_per_group_generic(Config).
 
 init_per_group_generic(Config0) ->
-    Config2 =
-        lists:foldl(
-          fun({NodeName, LocalHost, ReceiverPort}, Config1) ->
-                  Opts0 = (?config(extra_config, Config1) ++
-                           [{local_host, LocalHost},
-                            {hosts_refresh_interval, ?HOSTS_REFRESH_INTERVAL},
-                            {global_host, "localhost"},
-                            {endpoints, [listen_endpoint(ReceiverPort)]},
-                            {tls_opts, [
-                                        {certfile, "priv/ssl/fake_server.pem"},
-                                        {cafile, "priv/ssl/ca/cacert.pem"}
-                                       ]},
-                            {redis, ?config(redis_extra_config, Config1)},
-                            {resend_after_ms, 500}]),
-                  Opts = maybe_add_advertised_endpoints(NodeName, Opts0, Config1),
-
-                  VirtHosts = virtual_hosts(NodeName),
-                  Node = node_spec(NodeName),
-                  Config2 = dynamic_modules:save_modules(Node, VirtHosts, Config1),
-
-                  %% To reduce load when sending many messages
-                  ModulesToStop = [mod_offline, mod_blocking, mod_privacy, mod_roster, mod_last,
-                                   mod_stream_management],
-                  [dynamic_modules:ensure_stopped(Node, VirtHost, ModulesToStop) ||
-                      VirtHost <- VirtHosts],
-
-                  SMOpts = config_parser_helper:mod_config(mod_stream_management, #{resume_timeout => 1}),
-                  dynamic_modules:ensure_modules(Node, domain(),
-                                                 [{mod_global_distrib, Opts},
-                                                  {mod_stream_management, SMOpts}]),
-                  Config2
-          end,
-          Config0,
-          get_hosts()),
-
+    Config2 = lists:foldl(fun init_modules_per_node/2, Config0, get_hosts()),
     wait_for_listeners_to_appear(),
-
     {SomeNode, _, _} = hd(get_hosts()),
     NodesKey = rpc(SomeNode, mod_global_distrib_mapping_redis, nodes_key, []),
     [{nodes_key, NodesKey}, {escalus_user_db, xmpp} | Config2].
+
+init_modules_per_node({NodeName, LocalHost, ReceiverPort}, Config0) ->
+    Extra0 = module_opts(?config(extra_config, Config0)),
+    EndpointOpts = endpoint_opts(NodeName, ReceiverPort, Config0),
+    ConnExtra = maps:merge(EndpointOpts, maps:get(connections, Extra0, #{})),
+    Extra = Extra0#{local_host => LocalHost, connections => ConnExtra},
+    Opts = module_opts(Extra),
+
+    VirtHosts = virtual_hosts(NodeName),
+    Node = node_spec(NodeName),
+    Config1 = dynamic_modules:save_modules(Node, VirtHosts, Config0),
+
+    %% To reduce load when sending many messages
+    ModulesToStop = [mod_offline, mod_blocking, mod_privacy, mod_roster, mod_last,
+                     mod_stream_management],
+    [dynamic_modules:ensure_stopped(Node, VirtHost, ModulesToStop) || VirtHost <- VirtHosts],
+
+    SMOpts = config_parser_helper:mod_config(mod_stream_management, #{resume_timeout => 1}),
+    dynamic_modules:ensure_modules(Node, domain(), [{mod_global_distrib, Opts},
+                                                    {mod_stream_management, SMOpts}]),
+    Config1.
+
+module_opts(ExtraOpts) ->
+    lists:foldl(fun(Step, OptsIn) -> set_opts(Step, OptsIn) end,
+                ExtraOpts, [common, defaults, connections, redis, bounce]).
+
+set_opts(common, Opts) ->
+    maps:merge(#{global_host => <<"localhost">>,
+                 hosts_refresh_interval => ?HOSTS_REFRESH_INTERVAL}, Opts);
+set_opts(defaults, Opts) ->
+    mod_config(mod_global_distrib, Opts);
+set_opts(connections, #{connections := ConnExtra} = Opts) ->
+    TLSOpts = config([modules, mod_global_distrib, connections, tls],
+                     #{certfile => "priv/ssl/fake_server.pem",
+                       cafile => "priv/ssl/ca/cacert.pem"}),
+    Opts#{connections := config([modules, mod_global_distrib, connections],
+                                maps:merge(#{tls => TLSOpts}, ConnExtra))};
+set_opts(redis, #{redis := RedisExtra} = Opts) ->
+    Opts#{redis := config([modules, mod_global_distrib, redis], RedisExtra)};
+set_opts(bounce, #{bounce := BounceExtra} = Opts) ->
+    Opts#{bounce := config([modules, mod_global_distrib, bounce], BounceExtra)};
+set_opts(_, Opts) ->
+    Opts.
 
 end_per_group(advertised_endpoints, Config) ->
     Pids = ?config(meck_handlers, Config),
@@ -234,7 +245,7 @@ end_per_group(_, Config) ->
     end_per_group_generic(Config).
 
 end_per_group_generic(Config) ->
-    dynamic_modules:restore_modules(#{timeout => timer:seconds(30)},  Config).
+    dynamic_modules:restore_modules(#{timeout => timer:seconds(30)}, Config).
 
 init_per_testcase(CaseName, Config)
   when CaseName == test_muc_conversation_on_one_host; CaseName == test_global_disco;
@@ -246,7 +257,7 @@ init_per_testcase(CaseName, Config)
     %% There would be no new connections to europe_node2, but there can be some old ones.
     %% We need to disconnect previous connections.
     {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
-    trigger_rebalance(asia_node, list_to_binary(EuropeHost)),
+    trigger_rebalance(asia_node, EuropeHost),
     %% Load muc on mim node
     muc_helper:load_muc(),
     RegNode = ct:get_config({hosts, reg, node}),
@@ -367,7 +378,7 @@ test_advertised_endpoints_override_endpoints(_Config) ->
     Endps = execute_on_each_node(mod_global_distrib_mapping_redis, get_endpoints, [<<"reg1">>]),
     true = lists:all(
              fun(E) ->
-                     lists:sort(iptuples_to_string(E)) =:= lists:sort(advertised_endpoints())
+                     lists:sort(E) =:= lists:sort(advertised_endpoints())
              end, Endps).
 
 %% @doc Verifies that hosts refresher will restart the outgoing connection pool if
@@ -379,7 +390,7 @@ test_host_refreshing(_Config) ->
                                #{name => trees_for_connections_present}),
     ConnectionSups = out_connection_sups(asia_node),
     {europe_node1, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
-    EuropeSup = rpc(asia_node, mod_global_distrib_utils, server_to_sup_name, [list_to_binary(EuropeHost)]),
+    EuropeSup = rpc(asia_node, mod_global_distrib_utils, server_to_sup_name, [EuropeHost]),
     {_, EuropePid, supervisor, _} = lists:keyfind(EuropeSup, 1, ConnectionSups),
     erlang:exit(EuropePid, kill), % it's ok to kill temporary process
     mongoose_helper:wait_until(fun() -> tree_for_sup_present(asia_node, EuropeSup) end, true,
@@ -784,10 +795,11 @@ test_component_unregister(_Config) ->
                             [<<"test_service.localhost">>])).
 
 test_error_on_wrong_hosts(_Config) ->
-    Opts = [{cookie, "cookie"}, {local_host, "no_such_host"}, {global_host, "localhost"}],
-    ?assertException(error, {badrpc, {'EXIT', {"no_such_host is not a member of the host list", _}}},
-                     dynamic_modules:start(node_spec(europe_node1), <<"localhost">>,
-                                           mod_global_distrib, Opts)).
+    Opts = module_opts(#{local_host => <<"no_such_host">>}),
+    ?assertException(error, {badrpc, {'EXIT', {#{what := check_host_failed,
+                                                 domain := <<"no_such_host">>}, _}}},
+                     dynamic_modules:ensure_modules(node_spec(europe_node1), <<"localhost">>,
+                                                    [{mod_global_distrib, Opts}])).
 
 refresh_nodes(Config) ->
     NodesKey = ?config(nodes_key, Config),
@@ -917,7 +929,7 @@ test_update_senders_host_by_ejd_service(Config) ->
 
               hide_node(europe_node1, Config),
               {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
-              trigger_rebalance(asia_node, list_to_binary(EuropeHost)),
+              trigger_rebalance(asia_node, EuropeHost),
 
               escalus:send(Eve, escalus_stanza:chat_to(Addr, <<"hi">>)),
               escalus:wait_for_stanza(Comp),
@@ -934,7 +946,8 @@ enable_new_endpoint_on_refresh(Config) ->
     {Enabled1, _Disabled1, Pools1} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
     ExtraPort = get_port(reg, gd_extra_endpoint_port),
-    NewEndpoint = enable_extra_endpoint(asia_node, europe_node1, ExtraPort, Config),
+    NewEndpoint = resolved_endpoint(ExtraPort),
+    enable_extra_endpoint(asia_node, europe_node1, ExtraPort, Config),
 
     {Enabled2, _Disabled2, Pools2} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
@@ -946,6 +959,7 @@ enable_new_endpoint_on_refresh(Config) ->
 
 disable_endpoint_on_refresh(Config) ->
     ExtraPort = get_port(reg, gd_extra_endpoint_port),
+    NewEndpoint = resolved_endpoint(ExtraPort),
     enable_extra_endpoint(asia_node, europe_node1, ExtraPort, Config),
 
     get_connection(europe_node1, <<"reg1">>),
@@ -1007,7 +1021,7 @@ closed_connection_is_removed_from_disabled(_Config) ->
     {[], [_], [_]} = get_outgoing_connections(europe_node1, <<"reg1">>),
 
     % Will drop connections and prevent them from reconnecting
-    restart_receiver(asia_node, [listen_endpoint(get_port(reg, gd_supplementary_endpoint_port))]),
+    restart_receiver(asia_node, [get_port(reg, gd_supplementary_endpoint_port)]),
 
     mongoose_helper:wait_until(fun() -> get_outgoing_connections(europe_node1, <<"reg1">>) end,
                                {[], [], []},
@@ -1028,16 +1042,23 @@ get_port(Host, Param) ->
 
 get_hosts() ->
     [
-     {europe_node1, "localhost.bis", get_port(mim, gd_endpoint_port)},
-     {europe_node2, "localhost.bis", get_port(mim2, gd_endpoint_port)},
-     {asia_node, "reg1", get_port(reg, gd_endpoint_port)}
+     {europe_node1, <<"localhost.bis">>, get_port(mim, gd_endpoint_port)},
+     {europe_node2, <<"localhost.bis">>, get_port(mim2, gd_endpoint_port)},
+     {asia_node, <<"reg1">>, get_port(reg, gd_endpoint_port)}
     ].
 
-listen_endpoint(NodeName) when is_atom(NodeName) ->
+listen_endpoint(NodeName) ->
+    endpoint(listen_port(NodeName)).
+
+listen_port(NodeName) ->
     {_, _, Port} = lists:keyfind(NodeName, 1, get_hosts()),
-    listen_endpoint(Port);
-listen_endpoint(Port) when is_integer(Port) ->
+    Port.
+
+resolved_endpoint(Port) when is_integer(Port) ->
     {{127, 0, 0, 1}, Port}.
+
+endpoint(Port) when is_integer(Port) ->
+    {"127.0.0.1", Port}.
 
 %% For dynamic_modules
 node_spec(NodeName) ->
@@ -1137,19 +1158,13 @@ iptuples_to_string([{Addr, Port} | Endps]) when is_tuple(Addr) ->
 iptuples_to_string([E | Endps]) ->
     [E | iptuples_to_string(Endps)].
 
-maybe_add_advertised_endpoints(NodeName, Opts, Config) ->
-    Endpoints = proplists:get_value(NodeName, ?config(add_advertised_endpoints, Config), []),
-    case Endpoints of
-        [] ->
-            Opts;
-        E ->
-            Connections = case lists:keyfind(connections, 1, Opts) of
-                              false -> [];
-                              C -> C
-                          end,
-            NewConnections = {connections, [{advertised_endpoints, E} | Connections]},
-            [NewConnections | Opts]
-    end.
+endpoint_opts(NodeName, ReceiverPort, Config) ->
+    Endpoints = [endpoint(ReceiverPort)],
+    AdvertisedEndpoints =
+        proplists:get_value(NodeName, ?config(add_advertised_endpoints, Config), Endpoints),
+    #{endpoints => Endpoints,
+      resolved_endpoints => [resolved_endpoint(ReceiverPort)],
+      advertised_endpoints => AdvertisedEndpoints}.
 
 mock_inet_on_each_node() ->
     Nodes = lists:map(fun({NodeName, _, _}) -> ct:get_config(NodeName) end, get_hosts()),
@@ -1193,22 +1208,18 @@ spawn_connection_getter(SenderNode) ->
           end).
 
 enable_extra_endpoint(ListenNode, SenderNode, Port, _Config) ->
-    OriginalEndpoint = listen_endpoint(ListenNode),
-    NewEndpoint = {{127, 0, 0, 1}, Port},
-
-    restart_receiver(ListenNode, [NewEndpoint, OriginalEndpoint]),
-    refresh_mappings(ListenNode, "by_enable_extra_endpoint,port=" ++ integer_to_list(Port)),
-    trigger_rebalance(SenderNode, <<"reg1">>),
-
-    NewEndpoint.
+    restart_receiver(ListenNode, [Port, listen_port(ListenNode)]),
+    set_endpoints(ListenNode, [Port, listen_port(ListenNode)]),
+    trigger_rebalance(SenderNode, <<"reg1">>).
 
 get_connection(SenderNode, ToDomain) ->
     rpc(SenderNode, mod_global_distrib_outgoing_conns_sup, get_connection, [ToDomain]).
 
 hide_extra_endpoint(ListenNode) ->
-    set_endpoints(ListenNode, [listen_endpoint(ListenNode)]).
+    set_endpoints(ListenNode, [listen_port(ListenNode)]).
 
-set_endpoints(ListenNode, Endpoints) ->
+set_endpoints(ListenNode, Ports) ->
+    Endpoints = [endpoint(Port) || Port <- Ports],
     {ok, _} = rpc(ListenNode, mod_global_distrib_mapping_redis, set_endpoints, [Endpoints]).
 
 get_outgoing_connections(NodeName, DestinationDomain) ->
@@ -1223,12 +1234,14 @@ get_outgoing_connections(NodeName, DestinationDomain) ->
     {Enabled, Disabled, Pools}.
 
 restart_receiver(NodeName) ->
-    restart_receiver(NodeName, [listen_endpoint(NodeName)]).
+    restart_receiver(NodeName, [listen_port(NodeName)]).
 
-restart_receiver(NodeName, NewEndpoints) ->
-    OldOpts = rpc(NodeName, gen_mod, get_module_opts,
-                  [<<"localhost">>, mod_global_distrib_receiver]),
-    NewOpts = lists:keyreplace(endpoints, 1, OldOpts, {endpoints, NewEndpoints}),
+restart_receiver(NodeName, NewPorts) ->
+    OldOpts = #{connections := OldConnOpts} = rpc(NodeName, gen_mod, get_module_opts,
+                                                  [<<"localhost">>, mod_global_distrib_receiver]),
+    NewConnOpts = OldConnOpts#{endpoints := [endpoint(Port) || Port <- NewPorts],
+                               resolved_endpoints := [resolved_endpoint(Port) || Port <- NewPorts]},
+    NewOpts = OldOpts#{connections := NewConnOpts},
     Node = node_spec(NodeName),
     dynamic_modules:restart(Node, <<"localhost">>, mod_global_distrib_receiver, NewOpts).
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -66,7 +66,6 @@ groups() ->
            %% with node 2 disabled
            test_muc_conversation_on_one_host,
            test_global_disco
-           %% TODO: Add test case fo global_distrib_addr option
           ]},
          {hosts_refresher, [],
           [test_host_refreshing]},

--- a/doc/modules/mod_global_distrib.md
+++ b/doc/modules/mod_global_distrib.md
@@ -153,10 +153,10 @@ The endpoint list will be shared with other datacenters via the replicated backe
 
 #### `modules.mod_global_distrib.connections.advertised_endpoints`
 * **Syntax:** Array of TOML tables with the following keys: `host` and `port`, and the following values: {host = `string`, port = `non_negative_integer`}
-* **Default:** not set
+* **Default:** not set, the value of `endpoints` is used (without resolution).
 * **Example:** `advertised_endpoints = [{host = "172.16.0.2", port = 5555}]`
 
-A list of endpoints which will be advertised in Redis and therefore used to establish connection with this node by other nodes. If not specified, `endpoints` value (after resolution) is considered `advertised_endpoints`. The host may be either IP or domain, just like in case of endpoints. The difference is, the domain name won't be resolved but inserted directly to the mappings backend instead.
+A list of endpoints which will be advertised in Redis and therefore used to establish connection with this node by other nodes. The host may be either IP or domain, just like in case of endpoints. The difference is, the domain name won't be resolved but inserted directly to the mappings backend instead.
 
 #### `modules.mod_global_distrib.connections.connections_per_endpoint`
 * **Syntax:** non-negative integer
@@ -208,7 +208,7 @@ These options will be passed to the `fast_tls` driver.
 
 #### `modules.mod_global_distrib.connections.tls.ciphers`
 * **Syntax:** string
-* **Default:** not set
+* **Default:** `"TLSv1.2:TLSv1.3"`
 * **Example:** `ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"`
 
 Cipher suites to use with StartTLS or TLS. Please refer to the [OpenSSL documentation](https://www.openssl.org/docs/man1.0.2/man1/ciphers.html) for the cipher string format.

--- a/doc/modules/mod_global_distrib.md
+++ b/doc/modules/mod_global_distrib.md
@@ -302,11 +302,6 @@ Number of times message delivery will be retried in case of errors.
 
 `mod_global_distrib` extension relies on [`mod_disco`](mod_disco.md)'s option `users_can_see_hidden_services`, when provided. If it is not configured, the default value is `true`. `mod_disco` does not have to be enabled for `mod_global_distrib` to work, as this parameter is used only for processing Disco requests by Global Distribution.
 
-## Overriding remote datacenter endpoints
-
-There may be cases when the endpoint list given via **endpoints** option does not accurately specify endpoints on which the node may be reached from other datacenters; e.g. in case the node is behind NAT, or in testing environment.
-The endpoints used for connection to a remote datacenter may be overridden by global option `{ {global_distrib_addr, Host}, [{IP, Port}] }`.
-
 ## Example configuration
 
 ### Configuring mod_global_distrib
@@ -324,12 +319,6 @@ The endpoints used for connection to a remote datacenter may be overridden by gl
   bounce.resend_after_ms = 300
   bounce.max_retries = 3
   redis.pool = "global_distrib"
-```
-
-### Overriding endpoints to a remote datacenter
-
-```erlang
-{ {global_distrib_addr, "datacenter2.example.com"}, [{"124.12.4.3", 5556}, {"182.172.23.55", 5555}] }.
 ```
 
 ### Configuring Dynomite

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -26,7 +26,7 @@
 -module(gen_mod).
 -author('alexey@process-one.net').
 
--export_type([opt_key/0, opt_value/0, module_opts/0]).
+-export_type([key_path/0, opt_key/0, opt_value/0, module_opts/0]).
 
 -export([
          % Modules start & stop, do NOT use in the tests, use mongoose_modules API instead

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -29,34 +29,52 @@
 -export([deps/2, start/2, stop/1, config_spec/0]).
 -export([find_metadata/2, get_metadata/3, remove_metadata/2, put_metadata/3]).
 -export([maybe_reroute/1]).
--export([process_endpoints/1, process_bounce/1]).
+-export([process_opts/1, process_endpoint/1]).
 
 -ignore_xref([maybe_reroute/1, remove_metadata/2]).
 
 %%--------------------------------------------------------------------
 %% gen_mod API
-%% See "gen_mod logic" block below in this file
 %%--------------------------------------------------------------------
 
--spec deps(Host :: jid:server(), Opts :: proplists:proplist()) -> gen_mod_deps:deps().
-deps(Host, Opts) ->
-    mod_global_distrib_utils:deps(?MODULE, Host, Opts, fun deps/1).
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
+deps(HostType, Opts = #{global_host := HostType, bounce := BounceOpts}) ->
+    %% Start each required module with the same opts for simplicity
+    [{Mod, Opts, hard} || Mod <- dep_modules() ++ bounce_modules(BounceOpts)];
+deps(_HostType, #{}) ->
+    [].
 
--spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
-start(Host, Opts0) ->
-    Opts = [{message_ttl, 4} | Opts0],
-    mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).
+dep_modules() ->
+    [mod_global_distrib_utils, mod_global_distrib_mapping, mod_global_distrib_disco,
+     mod_global_distrib_receiver, mod_global_distrib_hosts_refresher].
 
--spec stop(Host :: jid:lserver()) -> any().
-stop(Host) ->
-    mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
+bounce_modules(#{enabled := true}) -> [mod_global_distrib_bounce];
+bounce_modules(#{enabled := false}) -> [].
+
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start(HostType, #{global_host := HostType}) ->
+    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_DELIVERED_WITH_TTL, histogram),
+    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, spiral),
+    ejabberd_hooks:add(hooks());
+start(_HostType, #{}) ->
+    ok.
+
+-spec stop(mongooseim:host_type()) -> any().
+stop(HostType) ->
+    case gen_mod:get_module_opt(HostType, ?MODULE, global_host) of
+        HostType -> ejabberd_hooks:delete(hooks());
+        _ -> ok
+    end.
+
+hooks() ->
+    [{filter_packet, global, ?MODULE, maybe_reroute, 99}].
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{
-        items = #{<<"global_host">> => #option{type = string,
+        items = #{<<"global_host">> => #option{type = binary,
                                                validate = domain},
-                  <<"local_host">> => #option{type = string,
+                  <<"local_host">> => #option{type = binary,
                                               validate = domain},
                   <<"message_ttl">> => #option{type = integer,
                                                validate = non_negative},
@@ -67,13 +85,17 @@ config_spec() ->
                   <<"cache">> => cache_spec(),
                   <<"bounce">> => bounce_spec()
         },
-        required = [<<"global_host">>, <<"local_host">>]
+        required = [<<"global_host">>, <<"local_host">>],
+        defaults = #{<<"message_ttl">> => 4,
+                     <<"hosts_refresh_interval">> => 3000},
+        format_items = map,
+        process = fun ?MODULE:process_opts/1
     }.
 
 connections_spec() ->
     #section{
-        items = #{<<"endpoints">> => #list{items = endpoints_spec()},
-                  <<"advertised_endpoints">> => #list{items = endpoints_spec()},
+        items = #{<<"endpoints">> => #list{items = endpoint_spec()},
+                  <<"advertised_endpoints">> => #list{items = endpoint_spec()},
                   <<"connections_per_endpoint">> => #option{type = integer,
                                                             validate = non_negative},
                   <<"endpoint_refresh_interval">> => #option{type = integer,
@@ -83,10 +105,16 @@ connections_spec() ->
                   <<"disabled_gc_interval">> => #option{type = integer,
                                                         validate = positive},
                   <<"tls">> => tls_spec()
-        }
+                 },
+        defaults = #{<<"connections_per_endpoint">> => 1,
+                     <<"endpoint_refresh_interval">> => 60,
+                     <<"endpoint_refresh_interval_when_empty">> => 3,
+                     <<"disabled_gc_interval">> => 60},
+        format_items = map,
+        include = always
     }.
 
-endpoints_spec() ->
+endpoint_spec() ->
     #section{
         items = #{<<"host">> => #option{type = string,
                                         validate = network_address},
@@ -94,7 +122,8 @@ endpoints_spec() ->
                                         validate = port}
         },
         required = all,
-        process = fun ?MODULE:process_endpoints/1
+        format_items = map,
+        process = fun ?MODULE:process_endpoint/1
     }.
 
 tls_spec() ->
@@ -109,7 +138,8 @@ tls_spec() ->
                                           validate = filename}
         },
         required = [<<"certfile">>, <<"cacertfile">>],
-        wrap = {kv, tls_opts}
+        defaults = #{<<"ciphers">> => "TLSv1.2:TLSv1.3"},
+        format_items = map
     }.
 
 redis_spec() ->
@@ -120,7 +150,12 @@ redis_spec() ->
                                                 validate = positive},
                   <<"refresh_after">> => #option{type = integer,
                                                  validate = non_negative}
-        }
+                 },
+        defaults = #{<<"pool">> => global_distrib,
+                     <<"expire_after">> => 120,
+                     <<"refresh_after">> => 60},
+        format_items = map,
+        include = always
     }.
 
 cache_spec() ->
@@ -132,7 +167,14 @@ cache_spec() ->
                                                         validate = non_negative},
                   <<"max_jids">> => #option{type = integer,
                                             validate = non_negative}
-        }
+                 },
+        defaults = #{<<"cache_missed">> => true,
+                     <<"domain_lifetime_seconds">> => 600,
+                     <<"jid_lifetime_seconds">> => 5,
+                     <<"max_jids">> => 10000
+                    },
+        format_items = map,
+        include = always
     }.
 
 bounce_spec() ->
@@ -142,20 +184,29 @@ bounce_spec() ->
                                                    validate = non_negative},
                   <<"max_retries">> => #option{type = integer,
                                                validate = non_negative}
-        },
-        process = fun ?MODULE:process_bounce/1
+                 },
+        defaults = #{<<"enabled">> => true,
+                     <<"resend_after_ms">> => 200,
+                     <<"max_retries">> => 4},
+        format_items = map,
+        include = always
     }.
 
-process_endpoints(KV) ->
-    {[[{host, Host}], [{port, Port}]], []} = proplists:split(KV, [host, port]),
+-spec process_opts(gen_mod:module_opts()) -> gen_mod:module_opts().
+process_opts(Opts = #{local_host := LocalHost, connections := Connections}) ->
+    Opts#{connections := process_connections(LocalHost, Connections)}.
+
+process_connections(_LocalHost, Opts = #{advertised_endpoints := _,
+                                         endpoints := Endpoints}) ->
+    Opts#{resolved_endpoints => mod_global_distrib_utils:resolve_endpoints(Endpoints)};
+process_connections(LocalHost, Opts = #{endpoints := Endpoints}) ->
+    process_connections(LocalHost, Opts#{advertised_endpoints => Endpoints});
+process_connections(LocalHost, Opts) ->
+    process_connections(LocalHost, Opts#{endpoints => [{binary_to_list(LocalHost), 5555}]}).
+
+-spec process_endpoint(map()) -> mod_global_distrib_utils:endpoint().
+process_endpoint(#{host := Host, port := Port}) ->
     {Host, Port}.
-
-process_bounce(KVs) ->
-    {[EnabledOpts], Opts} = proplists:split(KVs, [enabled]),
-    bounce_value(EnabledOpts, Opts).
-
-bounce_value([{enabled, false}], _) -> false;
-bounce_value(_, Opts) -> Opts.
 
 %%--------------------------------------------------------------------
 %% public functions
@@ -301,42 +352,6 @@ get_bound_connection(Server, GDID, Pid) when is_pid(Pid) ->
                          server => Server, gd_id => GDID, gd_pid => Pid}),
             Pid
     end.
-
-%%--------------------------------------------------------------------
-%% gen_mod logic
-%%--------------------------------------------------------------------
-
--spec deps(Opts :: proplists:proplist()) -> gen_mod_deps:deps().
-deps(Opts) ->
-    ConnectionsOpts =
-        lists:ukeysort(1, proplists:get_value(connections, Opts, []) ++ default_conn_opts()),
-    CacheOpts = proplists:get_value(cache, Opts, []),
-    BounceOpts = proplists:get_value(bounce, Opts, []),
-
-    Deps0 = [{mod_global_distrib_mapping, CacheOpts ++ Opts, hard},
-             {mod_global_distrib_disco, Opts, hard},
-             {mod_global_distrib_receiver, ConnectionsOpts ++ Opts, hard},
-             {mod_global_distrib_sender, ConnectionsOpts ++ Opts, hard},
-             {mod_global_distrib_hosts_refresher, Opts, hard}],
-    case BounceOpts of
-        false -> Deps0;
-        _ -> [{mod_global_distrib_bounce, BounceOpts ++ Opts, hard} | Deps0]
-    end.
-
-default_conn_opts() ->
-    [{tls_opts, false}].
-
--spec start() -> any().
-start() ->
-    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_DELIVERED_WITH_TTL, histogram),
-    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, spiral),
-    ejabberd_hooks:add(filter_packet, global, ?MODULE, maybe_reroute, 99).
-
--spec stop() -> any().
-stop() ->
-    ejabberd_hooks:delete(filter_packet, global, ?MODULE, maybe_reroute, 99).
-
-%%--------------------------------------------------------------------
 
 -spec lookup_recipients_host(TargetHost :: binary() | undefined,
                              To :: jid:jid(),

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -37,6 +37,10 @@
 %% gen_mod API
 %%--------------------------------------------------------------------
 
+%% Note: while this module should be enabled for all hosts,
+%% it needs to be started only once - this is why deps/2 and start/2
+%% do nothing for hosts other than global_host
+
 -spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
 deps(HostType, Opts = #{global_host := HostType, bounce := BounceOpts}) ->
     %% Start each required module with the same opts for simplicity

--- a/src/global_distrib/mod_global_distrib_bounce.erl
+++ b/src/global_distrib/mod_global_distrib_bounce.erl
@@ -28,7 +28,7 @@
 -define(MESSAGE_STORE, mod_global_distrib_bounce_message_store).
 -define(MS_BY_TARGET, mod_global_distrib_bounce_message_store_by_target).
 
--export([start_link/0, start/2, stop/1]).
+-export([start_link/0, start/2, stop/1, deps/2]).
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3, code_change/3, terminate/2]).
 -export([maybe_store_message/1, reroute_messages/4]).
 -export([bounce_queue_size/0]).
@@ -39,16 +39,31 @@
 %% gen_mod API
 %%--------------------------------------------------------------------
 
--spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
-start(Host, Opts0) ->
-    ResendAfterMs = proplists:get_value(resend_after_ms, Opts0, 200),
-    ResendAfter = erlang:convert_time_unit(ResendAfterMs, millisecond, native),
-    Opts = [{resend_after, ResendAfter}, {max_retries, 4} | Opts0],
-    mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start(HostType, _Opts) ->
+    mod_global_distrib_utils:create_ets(?MESSAGE_STORE, ordered_set),
+    mod_global_distrib_utils:create_ets(?MS_BY_TARGET, bag),
+    EvalDef = {[{l, [{t, [value, {v, 'Value'}]}]}], [value]},
+    QueueSizeDef = {function, ?MODULE, bounce_queue_size, [], eval, EvalDef},
+    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_BOUNCE_QUEUE_SIZE, QueueSizeDef),
+    ejabberd_hooks:add(hooks(HostType)),
+    ChildSpec = {?MODULE, {?MODULE, start_link, []}, permanent, 1000, worker, [?MODULE]},
+    ejabberd_sup:start_child(ChildSpec).
 
--spec stop(Host :: jid:lserver()) -> any().
-stop(Host) ->
-    mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
+-spec stop(mongooseim:host_type()) -> any().
+stop(HostType) ->
+    ejabberd_sup:stop_child(?MODULE),
+    ejabberd_hooks:delete(hooks(HostType)),
+    ets:delete(?MS_BY_TARGET),
+    ets:delete(?MESSAGE_STORE).
+
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
+deps(_HostType, Opts) ->
+    [{mod_global_distrib_utils, Opts, hard}].
+
+hooks(HostType) ->
+    [{mod_global_distrib_unknown_recipient, HostType, ?MODULE, maybe_store_message, 80},
+     {mod_global_distrib_known_recipient, HostType, ?MODULE, reroute_messages, 80}].
 
 -spec start_link() -> {ok, pid()} | {error, any()}.
 start_link() ->
@@ -91,7 +106,8 @@ maybe_store_message(drop) -> drop;
 maybe_store_message({From, To, Acc0, Packet} = FPacket) ->
     LocalHost = opt(local_host),
     {ok, ID} = mod_global_distrib:find_metadata(Acc0, id),
-    case mod_global_distrib:get_metadata(Acc0, {bounce_ttl, LocalHost}, opt(max_retries)) of
+    case mod_global_distrib:get_metadata(Acc0, {bounce_ttl, LocalHost},
+                                         opt([bounce, max_retries])) of
         0 ->
             ?LOG_DEBUG(#{what => gd_skip_store_message,
                          text => <<"Not storing global message">>,
@@ -102,12 +118,14 @@ maybe_store_message({From, To, Acc0, Packet} = FPacket) ->
             mongoose_metrics:update(global, ?GLOBAL_DISTRIB_STOP_TTL_ZERO, 1),
             FPacket;
         OldTTL ->
+            ResendAfterMs = opt([bounce, resend_after_ms]),
             ?LOG_DEBUG(#{what => gd_store_message,
                          text => <<"Storing global message">>,
                          gd_id => ID, acc => Acc0, bounce_ttl => OldTTL,
-                         resend_after_ms => erlang:convert_time_unit(opt(resend_after), native, millisecond)}),
+                         resend_after_ms => ResendAfterMs}),
             Acc = mod_global_distrib:put_metadata(Acc0, {bounce_ttl, LocalHost}, OldTTL - 1),
-            ResendAt = erlang:monotonic_time() + opt(resend_after),
+            ResendAfter = erlang:convert_time_unit(ResendAfterMs, millisecond, native),
+            ResendAt = erlang:monotonic_time() + ResendAfter,
             do_insert_in_store(ResendAt, {From, To, Acc, Packet}),
             drop
     end.
@@ -156,28 +174,6 @@ reroute_message(TargetHost, {From, To, Acc0, Packet}) ->
     Acc = mod_global_distrib:put_metadata(Acc0, target_host_override, TargetHost),
     ejabberd_router:route(From, To, Acc, Packet).
 
--spec start() -> any().
-start() ->
-    Host = opt(global_host),
-    mod_global_distrib_utils:create_ets(?MESSAGE_STORE, ordered_set),
-    mod_global_distrib_utils:create_ets(?MS_BY_TARGET, bag),
-    EvalDef = {[{l, [{t, [value, {v, 'Value'}]}]}],[value]},
-    QueueSizeDef = {function, ?MODULE, bounce_queue_size, [], eval, EvalDef},
-    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_BOUNCE_QUEUE_SIZE, QueueSizeDef),
-    ejabberd_hooks:add(mod_global_distrib_unknown_recipient, Host, ?MODULE, maybe_store_message, 80),
-    ejabberd_hooks:add(mod_global_distrib_known_recipient, Host, ?MODULE, reroute_messages, 80),
-    ChildSpec = {?MODULE, {?MODULE, start_link, []}, permanent, 1000, worker, [?MODULE]},
-    ejabberd_sup:start_child(ChildSpec).
-
--spec stop() -> any().
-stop() ->
-    Host = opt(global_host),
-    ejabberd_sup:stop_child(?MODULE),
-    ejabberd_hooks:delete(mod_global_distrib_known_recipient, Host, ?MODULE, reroute_messages, 80),
-    ejabberd_hooks:delete(mod_global_distrib_unknown_recipient, Host, ?MODULE, maybe_store_message, 80),
-    ets:delete(?MS_BY_TARGET),
-    ets:delete(?MESSAGE_STORE).
-
 add_index(ResendAt, {From, To, _Acc, _Packet} = FPacket) ->
     Key = get_index_key(From, To),
     ets:insert(?MS_BY_TARGET, {Key, {ResendAt, FPacket}}).
@@ -189,7 +185,8 @@ delete_index(ResendAt, {From, To, _Acc, _Packet} = FPacket) ->
 get_index_key(From, To) ->
     {jid:to_lower(From), jid:to_lower(To)}.
 
--spec do_insert_in_store(ResendAt :: integer(), {jid:jid(), jid:jid(), mongoose_acc:t(), exml:packet()}) -> any().
+-spec do_insert_in_store(ResendAt :: integer(),
+                         {jid:jid(), jid:jid(), mongoose_acc:t(), exml:packet()}) -> any().
 do_insert_in_store(ResendAt, FPacket) ->
     case ets:insert_new(?MESSAGE_STORE, {ResendAt, FPacket}) of
         true -> add_index(ResendAt, FPacket);
@@ -204,7 +201,8 @@ resend_messages(Now) ->
                 [{Key, {From, To, _Acc, _Packet} = FPacket}] ->
                     delete_index(Key, FPacket),
                     mod_global_distrib_mapping:clear_cache(To),
-                    WorkerKey = mod_global_distrib_utils:recipient_to_worker_key(From, opt(global_host)),
+                    WorkerKey = mod_global_distrib_utils:recipient_to_worker_key(
+                                  From, opt(global_host)),
                     Worker = mod_global_distrib_worker_sup:get_worker(WorkerKey),
                     gen_server:cast(Worker, {route, FPacket});
                 _ ->
@@ -215,6 +213,6 @@ resend_messages(Now) ->
             ok
     end.
 
--spec opt(Key :: atom()) -> term().
+-spec opt(gen_mod:opt_key() | gen_mod:key_path()) -> gen_mod:opt_value().
 opt(Key) ->
     mod_global_distrib_utils:opt(?MODULE, Key).

--- a/src/global_distrib/mod_global_distrib_connection.erl
+++ b/src/global_distrib/mod_global_distrib_connection.erl
@@ -62,7 +62,7 @@ init([{Addr, Port}, Server]) ->
       ?GLOBAL_DISTRIB_OUTGOING_CLOSED(MetricServer), spiral),
     try
         {ok, RawSocket} = gen_tcp:connect(Addr, Port, [binary, {active, false}]),
-        {ok, Socket} = mod_global_distrib_transport:wrap(RawSocket, [connect | opt(tls_opts)]),
+        {ok, Socket} = mod_global_distrib_transport:wrap(RawSocket, opt(connections), [connect]),
         GdStart = gd_start(Server, ConnID),
         ok = mod_global_distrib_transport:send(Socket, <<(byte_size(GdStart)):32, GdStart/binary>>),
         mod_global_distrib_transport:setopts(Socket, [{active, once}]),
@@ -128,7 +128,7 @@ terminate(Reason, State) ->
 
 -spec opt(Key :: atom()) -> term().
 opt(Key) ->
-    mod_global_distrib_utils:opt(mod_global_distrib_sender, Key).
+    mod_global_distrib_utils:opt(mod_global_distrib, Key).
 
 gd_start(Server, ConnID) ->
     Attrs = [{<<"server">>, Server}, {<<"conn_id">>, ConnID}],

--- a/src/global_distrib/mod_global_distrib_disco.erl
+++ b/src/global_distrib/mod_global_distrib_disco.erl
@@ -23,7 +23,7 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
--export([start/2, stop/1, disco_local_items/1]).
+-export([start/2, stop/1, deps/2, disco_local_items/1]).
 
 -ignore_xref([disco_local_items/1]).
 
@@ -31,21 +31,25 @@
 %% API
 %%--------------------------------------------------------------------
 
--spec start(Host :: jid:server(), Opts :: list()) -> any().
-start(Host, Opts) ->
-    mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start(HostType, _Opts) ->
+    ejabberd_hooks:add(hooks(HostType)).
 
--spec stop(Host :: jid:server()) -> any().
-stop(Host) ->
-    mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
+-spec stop(mongooseim:host_type()) -> any().
+stop(HostType) ->
+    ejabberd_hooks:delete(hooks(HostType)).
+
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
+deps(_HostType, Opts) ->
+    [{mod_global_distrib_utils, Opts, hard}].
 
 %%--------------------------------------------------------------------
 %% Hooks implementation
 %%--------------------------------------------------------------------
 
 -spec disco_local_items(mongoose_disco:item_acc()) -> mongoose_disco:item_acc().
-disco_local_items(Acc = #{from_jid := From, to_jid := To, node := <<>>}) ->
-    Domains = domains_for_disco(To#jid.lserver, From),
+disco_local_items(Acc = #{host_type := HostType, from_jid := From, node := <<>>}) ->
+    Domains = domains_for_disco(HostType, From),
     ?LOG_DEBUG(#{what => gd_domains_fetched_for_disco, domains => Domains}),
     Items = [#{jid => Domain} || Domain <- Domains],
     mongoose_disco:add_items(Items, Acc);
@@ -56,29 +60,18 @@ disco_local_items(Acc) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
--spec start() -> any().
-start() ->
-    Host = opt(global_host),
-    ejabberd_hooks:add(disco_local_items, Host, ?MODULE, disco_local_items, 99).
+hooks(HostType) ->
+    [{disco_local_items, HostType, ?MODULE, disco_local_items, 99}].
 
--spec stop() -> any().
-stop() ->
-    Host = opt(global_host),
-    ejabberd_hooks:delete(disco_local_items, Host, ?MODULE, disco_local_items, 99).
-
--spec opt(Key :: atom()) -> term().
-opt(Key) ->
-    mod_global_distrib_utils:opt(?MODULE, Key).
-
--spec domains_for_disco(Host :: jid:lserver(), From :: jid:jid()) -> Domains :: [binary()].
-domains_for_disco(_Host, #jid{ luser = <<>> } = _From) ->
+-spec domains_for_disco(mongooseim:host_type(), From :: jid:jid()) -> Domains :: [binary()].
+domains_for_disco(_HostType, #jid{ luser = <<>> } = _From) ->
     %% Currently all non-user entities may discover all services
     mod_global_distrib_mapping:all_domains();
-domains_for_disco(Host, _From) ->
-    case gen_mod:get_module_opt(Host, mod_disco, users_can_see_hidden_services, true) of
+domains_for_disco(HostType, _From) ->
+    %% mod_disco is running because it is the only caller of 'disco_local_items'
+    case gen_mod:get_module_opt(HostType, mod_disco, users_can_see_hidden_services) of
         true ->
             mod_global_distrib_mapping:all_domains();
         false ->
             mod_global_distrib_mapping:public_domains()
     end.
-

--- a/src/global_distrib/mod_global_distrib_outgoing_conns_sup.erl
+++ b/src/global_distrib/mod_global_distrib_outgoing_conns_sup.erl
@@ -84,4 +84,3 @@ ensure_server_started(Server) ->
 init(_) ->
     SupFlags = #{ strategy => one_for_one, intensity => 5, period => 5 },
     {ok, {SupFlags, []}}.
-

--- a/src/global_distrib/mod_global_distrib_receiver.erl
+++ b/src/global_distrib/mod_global_distrib_receiver.erl
@@ -26,8 +26,8 @@
 -include("jlib.hrl").
 -include("global_distrib_metrics.hrl").
 
--export([endpoints/0, start_link/4]).
--export([start/2, stop/1]).
+-export([start_link/4]).
+-export([start/2, stop/1, deps/2]).
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3, code_change/3, terminate/2]).
 
 -define(LISTEN_RETRIES, 5). %% Number of retries in case of eaddrinuse
@@ -58,14 +58,25 @@ start_link(Ref, Socket, ranch_tcp, Opts) ->
 %% gen_mod API
 %%--------------------------------------------------------------------
 
--spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
-start(Host, Opts0) ->
-    Opts = prepare_opts(Opts0),
-    mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start(_HostType, _Opts) ->
+    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_RECV_QUEUE_TIME, histogram),
+    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_INCOMING_ESTABLISHED, spiral),
+    mod_global_distrib_utils:ensure_metric(?GLOBAL_DISTRIB_INCOMING_ERRORED(undefined), spiral),
+    mod_global_distrib_utils:ensure_metric(?GLOBAL_DISTRIB_INCOMING_CLOSED(undefined), spiral),
+    ChildMod = mod_global_distrib_worker_sup,
+    Child = {ChildMod, {ChildMod, start_link, []}, permanent, 10000, supervisor, [ChildMod]},
+    ejabberd_sup:start_child(Child),
+    start_listeners().
 
--spec stop(Host :: jid:lserver()) -> any().
-stop(Host) ->
-    mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
+-spec stop(mongooseim:host_type()) -> any().
+stop(_HostType) ->
+    stop_listeners(),
+    ejabberd_sup:stop_child(mod_global_distrib_worker_sup).
+
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
+deps(_HostType, Opts) ->
+    [{mod_global_distrib_utils, Opts, hard}].
 
 %%--------------------------------------------------------------------
 %% ranch_protocol API
@@ -74,7 +85,8 @@ stop(Host) ->
 init({Ref, RawSocket, _Opts}) ->
     process_flag(trap_exit, true),
     ok = ranch:accept_ack(Ref),
-    {ok, Socket} = mod_global_distrib_transport:wrap(RawSocket, opt(tls_opts)),
+    ConnOpts = opt(connections),
+    {ok, Socket} = mod_global_distrib_transport:wrap(RawSocket, ConnOpts),
     ok = mod_global_distrib_transport:setopts(Socket, [{active, once}]),
     mongoose_metrics:update(global, ?GLOBAL_DISTRIB_INCOMING_ESTABLISHED, 1),
     State = #state{socket = Socket, waiting_for = header,
@@ -120,34 +132,7 @@ terminate(Reason, State) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
-prepare_opts(Opts0) ->
-    case lists:keyfind(local_host, 1, Opts0) of
-        {local_host, LocalHost} ->
-            [{endpoints, [{LocalHost, 5555}]} | Opts0];
-        _ ->
-            error({missing_option, local_host}, [Opts0])
-    end.
-
--spec start() -> any().
-start() ->
-    opt(tls_opts), %% Check for required tls_opts
-    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_RECV_QUEUE_TIME, histogram),
-    mongoose_metrics:ensure_metric(global, ?GLOBAL_DISTRIB_INCOMING_ESTABLISHED, spiral),
-    mod_global_distrib_utils:ensure_metric(?GLOBAL_DISTRIB_INCOMING_ERRORED(undefined), spiral),
-    mod_global_distrib_utils:ensure_metric(?GLOBAL_DISTRIB_INCOMING_CLOSED(undefined), spiral),
-    ChildMod = mod_global_distrib_worker_sup,
-    Child = {ChildMod, {ChildMod, start_link, []}, permanent, 10000, supervisor, [ChildMod]},
-    ejabberd_sup:start_child(Child),
-    Endpoints = mod_global_distrib_utils:resolve_endpoints(opt(endpoints)),
-    ets:insert(?MODULE, {endpoints, Endpoints}),
-    start_listeners().
-
--spec stop() -> any().
-stop() ->
-    stop_listeners(),
-    ejabberd_sup:stop_child(mod_global_distrib_worker_sup).
-
--spec opt(Key :: atom()) -> term().
+-spec opt(gen_mod:opt_key() | gen_mod:key_path()) -> gen_mod:opt_value().
 opt(Key) ->
     mod_global_distrib_utils:opt(?MODULE, Key).
 
@@ -210,10 +195,6 @@ handle_buffered(#state{waiting_for = Size, buffer = Buffer} = State)
 handle_buffered(State) ->
     State.
 
--spec endpoints() -> [mod_global_distrib_utils:endpoint()].
-endpoints() ->
-    opt(endpoints).
-
 -spec start_listeners() -> any().
 start_listeners() ->
     [start_listener(Endpoint, ?LISTEN_RETRIES) || Endpoint <- endpoints()],
@@ -235,3 +216,7 @@ start_listener({Addr, Port} = Ref, RetriesLeft) ->
 -spec stop_listeners() -> any().
 stop_listeners() ->
     lists:foreach(fun ranch:stop_listener/1, endpoints()).
+
+-spec endpoints() -> [mod_global_distrib_utils:endpoint()].
+endpoints() ->
+    opt([connections, resolved_endpoints]).

--- a/src/global_distrib/mod_global_distrib_sender.erl
+++ b/src/global_distrib/mod_global_distrib_sender.erl
@@ -16,19 +16,15 @@
 -module(mod_global_distrib_sender).
 -author('konrad.zemek@erlang-solutions.com').
 
--behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 
 -include("mongoose.hrl").
--include("jlib.hrl").
--include("global_distrib_metrics.hrl").
 
--export([start/2, stop/1, send/2, get_process_for/1]).
+-export([send/2, get_process_for/1]).
 
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
-
 
 -spec send(jid:lserver() | pid(), {jid:jid(), jid:jid(), mongoose_acc:t(), xmlel:packet()}) -> ok.
 send(Server, {_,_, Acc, _} = Packet) when is_binary(Server) ->
@@ -48,33 +44,8 @@ send(Worker, {From, _To, _Acc, _Packet} = FPacket) ->
     ok = mod_global_distrib_utils:cast_or_call(Worker, {data, Stamp, Data}).
 
 %%--------------------------------------------------------------------
-%% gen_mod API
-%%--------------------------------------------------------------------
-
--spec start(Host :: jid:lserver(), Opts :: proplists:proplist()) -> any().
-start(Host, Opts0) ->
-    Opts = [{listen_port, 5555},
-            {connections_per_endpoint, 1},
-            {endpoint_refresh_interval_when_empty, 3},
-            {endpoint_refresh_interval, 60},
-            {disabled_gc_interval, 60} | Opts0],
-    mod_global_distrib_utils:start(?MODULE, Host, Opts, fun start/0).
-
--spec stop(Host :: jid:lserver()) -> any().
-stop(Host) ->
-    mod_global_distrib_utils:stop(?MODULE, Host, fun stop/0).
-
-%%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
-
--spec start() -> any().
-start() ->
-    opt(tls_opts). %% Check for required tls_opts
-
--spec stop() -> any().
-stop() ->
-    ok.
 
 -spec get_process_for(jid:lserver()) -> pid().
 get_process_for(Server) ->
@@ -82,4 +53,4 @@ get_process_for(Server) ->
 
 -spec opt(Key :: atom()) -> term().
 opt(Key) ->
-    mod_global_distrib_utils:opt(?MODULE, Key).
+    mod_global_distrib_utils:opt(mod_global_distrib, Key).

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -58,7 +58,8 @@
           %% Listeners are notified only once and then this list is cleared.
           pending_endpoints_listeners = [] :: [pid()],
           %% Containts last result of get_endpoints
-          last_endpoints :: [endpoint()] | undefined
+          last_endpoints :: [endpoint()] | undefined,
+          conn_opts :: map()
          }).
 
 -type state() :: #state{}.
@@ -119,11 +120,12 @@ get_disabled_endpoints(Server) ->
 init([Server, Supervisor]) ->
     process_flag(trap_exit, true),
 
-    RefreshInterval = mod_global_distrib_utils:opt(mod_global_distrib_sender,
-                                                   endpoint_refresh_interval),
-    DisRefreshInterval = mod_global_distrib_utils:opt(mod_global_distrib_sender,
-                                                      endpoint_refresh_interval_when_empty),
-    GCInterval = mod_global_distrib_utils:opt(mod_global_distrib_sender, disabled_gc_interval),
+    HostType = mod_global_distrib_utils:host_type(),
+    ConnOpts = gen_mod:get_module_opt(HostType, mod_global_distrib_hosts_refresher, connections),
+    #{endpoint_refresh_interval := RefreshInterval,
+      endpoint_refresh_interval_when_empty := DisRefreshInterval,
+      disabled_gc_interval := GCInterval} = ConnOpts,
+
     State = #state{
                server = Server,
                supervisor = Supervisor,
@@ -133,7 +135,8 @@ init([Server, Supervisor]) ->
                pending_gets = queue:new(),
                refresh_interval = RefreshInterval,
                refresh_interval_when_disconnected = DisRefreshInterval,
-               gc_interval = GCInterval
+               gc_interval = GCInterval,
+               conn_opts = ConnOpts
               },
 
     State2 = refresh_connections(State),
@@ -406,6 +409,7 @@ refresh_connections(#state{ server = Server, pending_endpoints = PendingEndpoint
 -spec get_endpoints(Server :: jid:lserver()) -> [mod_global_distrib_utils:endpoint()].
 get_endpoints(Server) ->
     EndpointsToResolve =
+        %% FIXME this option does not exist
         case mongoose_config:lookup_opt({global_distrib_addr, Server}) of
             {error, not_found} -> mod_global_distrib_mapping:endpoints(Server);
             {ok, Endpoints} -> Endpoints
@@ -437,10 +441,11 @@ log_endpoints_changes(Server, EndpointsChanges, State) ->
 
 -spec enable(Endpoint :: endpoint(), State :: state()) -> {ok, state()} | {error, any()}.
 enable(Endpoint, #state{ disabled = Disabled, supervisor = Supervisor,
-                         enabled = Enabled, server = Server } = State) ->
+                         enabled = Enabled, server = Server, conn_opts = ConnOpts } = State) ->
     case lists:keytake(Endpoint, #endpoint_info.endpoint, Disabled) of
         false ->
-            case catch mod_global_distrib_server_sup:start_pool(Supervisor, Endpoint, Server) of
+            case catch mod_global_distrib_server_sup:start_pool(Supervisor, Endpoint,
+                                                                Server, ConnOpts) of
                 {ok, ConnPoolRef, ConnPoolPid} ->
                     MonitorRef = monitor(process, ConnPoolPid),
                     EndpointInfo = #endpoint_info{

--- a/src/global_distrib/mod_global_distrib_server_mgr.erl
+++ b/src/global_distrib/mod_global_distrib_server_mgr.erl
@@ -408,12 +408,7 @@ refresh_connections(#state{ server = Server, pending_endpoints = PendingEndpoint
 
 -spec get_endpoints(Server :: jid:lserver()) -> [mod_global_distrib_utils:endpoint()].
 get_endpoints(Server) ->
-    EndpointsToResolve =
-        %% FIXME this option does not exist
-        case mongoose_config:lookup_opt({global_distrib_addr, Server}) of
-            {error, not_found} -> mod_global_distrib_mapping:endpoints(Server);
-            {ok, Endpoints} -> Endpoints
-        end,
+    EndpointsToResolve = mod_global_distrib_mapping:endpoints(Server),
     mod_global_distrib_utils:resolve_endpoints(EndpointsToResolve).
 
 -spec resolve_pending(NewEndpointList :: [mod_global_distrib_utils:endpoint()],

--- a/src/global_distrib/mod_global_distrib_server_sup.erl
+++ b/src/global_distrib/mod_global_distrib_server_sup.erl
@@ -22,7 +22,7 @@
 
 -export([start_link/1, init/1]).
 -export([get_connection/1, is_available/1]).
--export([start_pool/3, stop_pool/2]).
+-export([start_pool/4, stop_pool/2]).
 
 -ignore_xref([start_link/1]).
 
@@ -65,15 +65,15 @@ is_available(Server) ->
 
 -spec start_pool(Supervisor :: pid(),
                  Endpoint :: mod_global_distrib_utils:endpoint(),
-                 Server :: jid:lserver()) ->
+                 Server :: jid:lserver(),
+                 ConnOpts :: map()) ->
     {ok, atom(), pid()} | {error, any()}.
-start_pool(Supervisor, Endpoint, Server) ->
+start_pool(Supervisor, Endpoint, Server, #{connections_per_endpoint := PoolSize}) ->
     PoolRef = endpoint_to_atom(Endpoint),
     PoolParams = [
                   PoolRef,
                   {mod_global_distrib_connection, start_link, [Endpoint, Server]},
-                  [{pool_size, mod_global_distrib_utils:opt(mod_global_distrib_sender,
-                                                            connections_per_endpoint)}]
+                  [{pool_size, PoolSize}]
                  ],
     PoolSpec = #{
       id => Endpoint,


### PR DESCRIPTION
Highlights:
- Simplified deps, because modules are using each other's options anyway - there is no clear separation. Having the same opts is most straightforward option.
- Removed the complicated way of starting and stopping module, involving the utils module and callbacks.
- Removed the ETS tables storing options. The only extra parameter to store is the host type (equal to the global host now, as there is no support for dynamic domains), which is stored in a persistent term.
- Separate resolved endpoints from the original ones to avoid having a mixup of both endpoint types.

All changes are described in details in the commit messages.
