### PR TITLE
Pipeline support for bind, presense and carbons

### DIFF
--- a/big_tests/src/trace_helper.erl
+++ b/big_tests/src/trace_helper.erl
@@ -1,0 +1,34 @@
+-module(trace_helper).
+-export([run/2]).
+-export([flush/0]).
+-export([stop/1]).
+
+run(Parent, Patterns) when is_pid(Parent) ->
+    spawn(fun() ->
+            erlang:monitor(process, Parent),
+            erlang:trace(all, true, [call]),
+            [erlang:trace_pattern(Pattern, true, []) || Pattern <- Patterns],
+            cycle(Parent)
+        end).
+
+stop(Pid) ->
+    Pid ! stop,
+    Mon = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Mon, _, _, _} -> ok
+    after 5000 -> erlang:error(timeout)
+    end.
+
+cycle(Parent) ->
+    receive
+        stop ->
+            ok;
+        {'DOWN', _, _, _, _} ->
+            ok;
+        M ->
+            Parent ! M,
+            cycle(Parent)
+    end.
+
+flush() ->
+    receive M -> [M | flush()] after 0 -> [] end.

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -139,6 +139,7 @@ As a result it makes more sense to maintain a list of the most relevant or usefu
 | `[HostType, xmppStanzaReceived]` | spiral | A stanza is sent to a client. |
 | `[HostType, xmppStanzaCount]` | spiral | A stanza is sent to a client. |
 | `[HostType, xmppStanzaDropped]` | spiral | A stanza is dropped due to an AMP rule or a `filter_packet` processing flow. |
+| `[HostType, c2sPredictedPresencePriority]` | spiral | An initial presence pipelined. |
 
 ### Extension-specific metrics
 

--- a/include/ejabberd_c2s.hrl
+++ b/include/ejabberd_c2s.hrl
@@ -76,7 +76,9 @@
                 hibernate_after = 0 :: non_neg_integer(),
                 replaced_pids = [] :: [{MonitorRef :: reference(), ReplacedPid :: pid()}],
                 handlers = #{} :: #{ term() => {module(), atom(), term()} },
-                cred_opts :: mongoose_credentials:opts()
+                cred_opts :: mongoose_credentials:opts(),
+                priority :: undefined | closed | integer(),
+                session_info = #{} :: map()
                 }).
 -type aux_key() :: atom().
 -type aux_value() :: any().

--- a/src/metrics/mongoose_metrics_definitions.hrl
+++ b/src/metrics/mongoose_metrics_definitions.hrl
@@ -1,4 +1,5 @@
 -define(GENERAL_SPIRALS, [
+    c2sPredictedPresencePriority,
     sessionSuccessfulLogins,
     sessionAuthFails,
     sessionLogouts,

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -51,6 +51,7 @@
          c2s_stream_features/2,
          c2s_unauthenticated_iq/4,
          c2s_update_presence/2,
+         c2s_get_initial_info/3,
          check_bl_c2s/1,
          forbidden_session_hook/3,
          session_opening_allowed_for_user/2]).
@@ -590,6 +591,9 @@ c2s_unauthenticated_iq(HostType, Server, IQ, IP) ->
     Result :: mongoose_acc:t().
 c2s_update_presence(HostType, Acc) ->
     run_hook_for_host_type(c2s_update_presence, HostType, Acc, []).
+
+c2s_get_initial_info(HostType, Info, PendingMessages) ->
+    run_hook_for_host_type(c2s_get_initial_info, HostType, Info, [HostType, PendingMessages]).
 
 -spec check_bl_c2s(IP) -> Result when
     IP ::  inet:ip_address(),


### PR DESCRIPTION
Proposed changes include:
* C2S remembers what it writes into SessionManager now
* This means that store_info always goes though c2s

* c2s can look into the message box now. When opening session, we check if there is presence stanza pending to be process (and we extract priority from it).
* same with carbons (we use c2s_get_initial_info hook)


TODO:
* check that presence type is available in predict_priority