### PR TITLE
Reconfigure supervision flags in pools

### DIFF
--- a/src/wpool/mongoose_wpool_mgr.erl
+++ b/src/wpool/mongoose_wpool_mgr.erl
@@ -38,7 +38,6 @@
 
 -ignore_xref([start_link/1]).
 
--include("mongoose.hrl").
 -include("mongoose_logger.hrl").
 
 -record(state, {type, pools, monitors}).

--- a/src/wpool/mongoose_wpool_sup.erl
+++ b/src/wpool/mongoose_wpool_sup.erl
@@ -72,14 +72,14 @@ init([]) ->
     #{id := mongoose_wpool:proc_name(),
       start := {mongoose_wpool_type_sup, start_link, [mongoose_wpool:pool_type()]},
       restart => transient,
-      shutdown => brutal_kill,
+      shutdown => infinity,
       type => supervisor,
       modules => [module()]}.
 child_spec(Type) ->
     #{id => mongoose_wpool_type_sup:name(Type),
       start => {mongoose_wpool_type_sup, start_link, [Type]},
       restart => transient,
-      shutdown => brutal_kill,
+      shutdown => infinity,
       type => supervisor,
       modules => [mongoose_wpool_type_sup]
      }.


### PR DESCRIPTION
Children of type `supervisor` should not have a shutdown flag other than
`infinity` according to the official documentation.