### PR TITLE
Fix MAM cache name

### DIFF
--- a/src/mam/mod_mam_cache_user.erl
+++ b/src/mam/mod_mam_cache_user.erl
@@ -29,8 +29,8 @@
 %%====================================================================
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
-start(HostType, Opts = #{cache := CacheOpts}) ->
-    start_cache(HostType, CacheOpts),
+start(HostType, Opts) ->
+    start_cache(HostType, Opts),
     ejabberd_hooks:add(hooks(HostType, Opts)),
     ok.
 

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -244,7 +244,7 @@ add_rdbms_deps(user_cache, Type, #{cache_users := true, cache := CacheOpts}, Dep
                 internal -> Deps;
                 mod_cache_users -> add_dep(mod_cache_users, Deps)
             end,
-    add_dep(mod_mam_cache_user, #{Type => true, cache => CacheOpts}, Deps1);
+    add_dep(mod_mam_cache_user, CacheOpts#{Type => true}, Deps1);
 add_rdbms_deps(async_writer, Type, #{async_writer := AsyncOpts = #{enabled := true}}, Deps) ->
     Deps1 = add_dep(rdbms_arch_module(Type), #{no_writer => true}, Deps),
     add_dep(rdbms_async_arch_module(Type), AsyncOpts, Deps1);

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -399,7 +399,7 @@ all_modules() ->
                        host => {fqdn, <<"muc.example.com">>},
                        no_stanzaid_element => true}),
       mod_caps => [{cache_life_time, 86}, {cache_size, 1000}],
-      mod_mam_cache_user => #{cache => default_config([modules, mod_mam_meta, cache]), muc => true, pm => true},
+      mod_mam_cache_user => (default_config([modules, mod_mam_meta, cache]))#{muc => true, pm => true},
       mod_offline =>
           [{access_max_user_messages, max_user_offline_messages},
            {backend, riak},

--- a/test/mod_mam_meta_SUITE.erl
+++ b/test/mod_mam_meta_SUITE.erl
@@ -76,7 +76,7 @@ produces_valid_configurations(_Config) ->
     check_equal_opts(mod_mam_muc_rdbms_arch, mod_config(mod_mam_muc_rdbms_arch,
                                                         MUCArchOpts#{no_writer => true}), Deps),
     check_equal_opts(mod_mam_rdbms_user, #{pm => true, muc => true}, Deps),
-    check_equal_opts(mod_mam_cache_user, #{pm => true, muc => true, cache => Cache}, Deps),
+    check_equal_opts(mod_mam_cache_user, Cache#{pm => true, muc => true}, Deps),
     check_equal_opts(mod_mam_mnesia_prefs, #{muc => true}, Deps),
     check_equal_opts(mod_mam_rdbms_prefs, #{pm => true}, Deps),
     check_equal_opts(mod_mam_muc_rdbms_arch_async, AsyncOpts, Deps).
@@ -116,7 +116,7 @@ example_muc_only_no_pref_good_performance(_Config) ->
 
     check_equal_deps(
       [{mod_mam_rdbms_user, #{muc => true, pm => true}},
-       {mod_mam_cache_user, #{muc => true, cache => Cache}},
+       {mod_mam_cache_user, Cache#{muc => true}},
        {mod_mam_muc_rdbms_arch, mod_config(mod_mam_muc_rdbms_arch, #{no_writer => true})},
        {mod_mam_muc_rdbms_arch_async, AsyncOpts},
        {mod_mam_muc, mod_config(mod_mam_muc, mod_config(mod_mam_muc, MUCOpts))}
@@ -130,7 +130,7 @@ example_pm_only_good_performance(_Config) ->
 
     check_equal_deps(
       [{mod_mam_rdbms_user, #{pm => true}},
-       {mod_mam_cache_user, #{pm => true, cache => Cache}},
+       {mod_mam_cache_user, Cache#{pm => true}},
        {mod_mam_mnesia_prefs, #{pm => true}},
        {mod_mam_rdbms_arch, mod_config(mod_mam_rdbms_arch, #{no_writer => true})},
        {mod_mam_rdbms_arch_async, AsyncOpts},


### PR DESCRIPTION
When mod_mam_cache_user checks its cache, it gives its own module name
to mongoose_user_cache so that this one fetches the config to see if it
has configured its own cache or is reusing some other module's cache.
The problem is that mongoose_user_cache will check for the module key,
but it the current implementation, we are hiding it behind a cache key
to contain the cache config.

So by just moving the config a level up, mongoose_user_cache can find it.
