### PR TITLE
Make MAM return timestamps in microseconds

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -219,7 +219,7 @@ wait_for_complete_archive_response(P, Alice, ExpectedCompleteValue)
                         #{mam_props => P, parsed_iq => ParsedIQ}).
 
 make_iso_time(Micro) ->
-    calendar:system_time_to_rfc3339(erlang:convert_time_unit(Micro, microsecond, second), [{offset, "Z"}]).
+    calendar:system_time_to_rfc3339(Micro, [{offset, "Z"}, {unit, microsecond}]).
 
 generate_message_text(N) when is_integer(N) ->
     <<"Message #", (list_to_binary(integer_to_list(N)))/binary>>.

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -663,8 +663,7 @@ archive_message(HostType, Params) ->
 message_row_to_xml(MamNs, #{id := MessID, jid := SrcJID, packet := Packet},
                    QueryID, SetClientNs)  ->
     {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
-    Secs = erlang:convert_time_unit(Microseconds, microsecond, second),
-    TS = calendar:system_time_to_rfc3339(Secs, [{offset, "Z"}]),
+    TS = calendar:system_time_to_rfc3339(Microseconds, [{offset, "Z"}, {unit, microsecond}]),
     BExtMessID = mess_id_to_external_binary(MessID),
     Packet1 = mod_mam_utils:maybe_set_client_xmlns(SetClientNs, Packet),
     wrap_message(MamNs, Packet1, QueryID, BExtMessID, TS, SrcJID).

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -538,7 +538,7 @@ archive_message(HostType, Params) ->
 message_row_to_xml(MamNs, ReceiverJID, HideUser, SetClientNs,
                    #{id := MessID, jid := SrcJID, packet := Packet}, QueryID) ->
     {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
-    TS = calendar:system_time_to_rfc3339(erlang:convert_time_unit(Microseconds, microsecond, second), [{offset, "Z"}]),
+    TS = calendar:system_time_to_rfc3339(Microseconds, [{offset, "Z"}, {unit, microsecond}]),
     BExtMessID = mess_id_to_external_binary(MessID),
     Packet1 = maybe_delete_x_user_element(HideUser, ReceiverJID, Packet),
     Packet2 = mod_mam_utils:maybe_set_client_xmlns(SetClientNs, Packet1),


### PR DESCRIPTION
No need to convert any of these TS to seconds, XMPP admits microseconds just fine, and client devices this way can ensure they'll display the messages in the right order, otherwise there's a risk of messages arriving within the same 1s window and therefore having the same timestamp.

Also, inbox show timestamps in microseconds, so it is just consistent.