### PR TITLE
Inbox/extend queries

### DIFF
--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -1,4 +1,5 @@
 -module(inbox_extensions_SUITE).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
@@ -22,62 +23,6 @@
          end_per_group/2,
          init_per_testcase/2,
          end_per_testcase/2]).
-
-%% ERRORS
--export([
-         % General
-         returns_error_when_no_jid_provided/1,
-         returns_error_when_invalid_jid_provided/1,
-         returns_error_when_valid_jid_but_no_property/1,
-         % Set-unread errors
-         returns_error_when_read_invalid_value/1,
-         returns_error_when_read_valid_request_but_not_in_inbox/1,
-         % Archiving errors
-         returns_error_when_archive_invalid_value/1,
-         returns_error_when_archive_valid_request_but_not_in_inbox/1,
-         % Muting errors
-         returns_error_when_mute_invalid_value/1,
-         returns_error_when_mute_invalid_seconds/1,
-         returns_error_when_mute_valid_request_but_not_in_inbox/1,
-         % Form errors
-         returns_error_when_archive_field_is_invalid/1,
-         returns_error_when_max_is_not_a_number/1
-        ]).
-%% SUCCESSES
--export([
-         % read
-         read_unread_entry_set_to_read/1,
-         read_unread_entry_set_to_read_iq_id_as_fallback/1,
-         read_unread_entry_set_to_read_queryid/1,
-         read_read_entry_set_to_unread/1,
-         read_unread_entry_with_two_messages_when_set_unread_then_unread_count_stays_in_two/1,
-         % archive
-         archive_active_entry_gets_archived/1,
-         archive_archived_entry_gets_active_on_request/1,
-         archive_archived_entry_gets_active_for_the_sender_on_new_message/1,
-         archive_archived_entry_gets_active_for_the_receiver_on_new_message/1,
-         archive_active_unread_entry_gets_archived_and_still_unread/1,
-         archive_full_archive_can_be_fetched/1,
-         archive_full_archive_can_be_fetched_queryid/1,
-         % mute
-         mute_unmuted_entry_gets_muted/1,
-         mute_muted_entry_gets_unmuted/1,
-         mute_after_timestamp_gets_unmuted/1,
-         mute_muted_conv_restarts_timestamp/1,
-         % other
-         returns_valid_properties_form/1,
-         properties_can_be_get/1,
-         properties_many_can_be_set/1,
-         properties_many_can_be_set_queryid/1,
-         max_queries_can_be_limited/1,
-         max_queries_can_fetch_ahead/1,
-         timestamp_is_not_reset_with_setting_properties/1
-        ]).
-%% Groupchats
--export([
-         groupchat_setunread_stanza_sets_inbox/1 % muclight
-        ]).
-
 
 all() ->
     inbox_helper:skip_or_run_inbox_tests(tests()).

--- a/doc/open-extensions/inbox.md
+++ b/doc/open-extensions/inbox.md
@@ -200,6 +200,29 @@ To which the server will reply, just like before, with:
 </iq>
 ```
 
+If an entire entry wanted to be queried, and not only its attributes, a `complete='true'` can be provided:
+```xml
+<iq id='some_unique_id' type='get'>
+  <query xmlns='erlang-solutions.com:xmpp:inbox:0#conversation' jid='bob@localhost' complete='true'/>
+</iq>
+```
+To which the server will reply, just like before, with:
+```xml
+<iq id='some_unique_id' to='alice@localhost/res1' type='result'>
+  <query xmlns='erlang-solutions.com:xmpp:inbox:0#conversation'>
+    <forwarded xmlns="urn:xmpp:forward:0">
+      <delay xmlns="urn:xmpp:delay" stamp="2018-07-10T23:08:25.123456Z"/>
+      <message xml:lang="en" type="chat" to="bob@localhost/res1" from="alice@localhost/res1" id=”123”>
+        <body>Hello</body>
+      </message>
+    </forwarded>
+    <archive>false</archive>
+    <mute>0</mute>
+    <read>true</read>
+  </query>
+</iq>
+```
+
 
 ## Setting properties
 Setting properties is done using the standard XMPP pattern of `iq-query` and `iq-result`, as below:
@@ -217,7 +240,7 @@ where `Property` and `Value` are a list of key-value pairs as follows:
 - `mute`: number of _seconds_ to mute for. Choose `0` for unmuting.
 - `read` (adjective, not verb): `true` or `false`. Setting to true essentially sets the unread-count to `0`, `false` sets the unread-count to `1` (if it was equal to `0`, otherwise it lefts it unchanged). No other possibilities are offered, to reduce the risk of inconsistencies or problems induced by a faulty client.
 
-*Note* that resetting the inbox count will not be forwarded. While a chat marker will be forwarded to the interlocutor(s), (including the case of a big groupchat with thousands of participants), this reset stanza will not.  
+*Note* that resetting the inbox count will not be forwarded. While a chat marker will be forwarded to the interlocutor(s), (including the case of a big groupchat with thousands of participants), this reset stanza will not.
 
 If the query was successful, the server will answer with two stanzas, following the classic pattern of broadcasting state changes. First, it would send a message with a `<x>` children containing all new configuration, to the bare-jid of the user: this facilitates broadcasting to all online resources to successfully synchronise their interfaces.
 ```xml

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -315,7 +315,7 @@ build_inbox_message(#{msg := Content,
 
 -spec build_result_el(exml:element(), id(), integer(), integer(), boolean(), integer(), integer()) -> exml:element().
 build_result_el(Msg, QueryId, Count, Timestamp, Archive, MutedUntil, AccTS) ->
-    Forwarded = build_forward_el(Msg, Timestamp),
+    Forwarded = mod_inbox_utils:build_forward_el(Msg, Timestamp),
     Properties = mod_inbox_entries:extensions_result(Archive, MutedUntil, AccTS),
     QueryAttr = [{<<"queryid">>, QueryId} || QueryId =/= undefined, QueryId =/= <<>>],
     #xmlel{name = <<"result">>,
@@ -337,17 +337,6 @@ build_result_iq(List) ->
 -spec build_result_el(name_bin(), count_bin()) -> exml:element().
 build_result_el(Name, CountBin) ->
     #xmlel{name = Name, children = [#xmlcdata{content = CountBin}]}.
-
--spec build_forward_el(exml:element(), integer()) -> exml:element().
-build_forward_el(Content, Timestamp) ->
-    Delay = build_delay_el(Timestamp),
-    #xmlel{name = <<"forwarded">>, attrs = [{<<"xmlns">>, ?NS_FORWARD}],
-           children = [Delay, Content]}.
-
--spec build_delay_el(Timestamp :: integer()) -> exml:element().
-build_delay_el(Timestamp) ->
-    TS = calendar:system_time_to_rfc3339(Timestamp, [{offset, "Z"}, {unit, microsecond}]),
-    jlib:timestamp_to_xml(TS, undefined, undefined).
 
 %%%%%%%%%%%%%%%%%%%
 %% iq-get

--- a/src/inbox/mod_inbox_backend.erl
+++ b/src/inbox/mod_inbox_backend.erl
@@ -2,6 +2,8 @@
 %% the backend modules (i.e. mod_inbox_rdbms).
 -module(mod_inbox_backend).
 
+-include("mod_inbox.hrl").
+
 -export([init/2,
          get_inbox/4,
          clear_inbox/3,
@@ -39,7 +41,7 @@
     mod_inbox:write_res() when
     HostType :: mongooseim:host_type(),
     InboxEntryKey :: mod_inbox:entry_key(),
-    Content :: binary(),
+    Content :: content(),
     Count :: integer(),
     MsgId :: binary(),
     Timestamp :: integer().
@@ -52,7 +54,7 @@
     mod_inbox:count_res() when
     HostType :: mongooseim:host_type(),
     InboxEntryKey :: mod_inbox:entry_key(),
-    Content :: binary(),
+    Content :: content(),
     MsgId :: binary(),
     Timestamp :: integer().
 
@@ -112,7 +114,7 @@ remove_domain(HostType, LServer) ->
     mod_inbox:write_res() when
     HostType :: mongooseim:host_type(),
     InboxEntryKey :: mod_inbox:entry_key(),
-    Content :: binary(),
+    Content :: content(),
     Count :: integer(),
     MsgId :: binary(),
     Timestamp :: integer().
@@ -131,7 +133,7 @@ remove_inbox_row(HostType, InboxEntryKey) ->
     mod_inbox:count_res() when
     HostType :: mongooseim:host_type(),
     InboxEntryKey :: mod_inbox:entry_key(),
-    Content :: binary(),
+    Content :: content(),
     MsgId :: binary(),
     Timestamp :: integer().
 set_inbox_incr_unread(HostType, InboxEntryKey, Content, MsgId, Timestamp) ->

--- a/src/inbox/mod_inbox_backend.erl
+++ b/src/inbox/mod_inbox_backend.erl
@@ -12,6 +12,7 @@
          remove_inbox_row/2,
          set_inbox_incr_unread/5,
          get_inbox_unread/2,
+         get_full_entry/2,
          get_entry_properties/2,
          set_entry_properties/3,
          reset_unread/3]).
@@ -66,6 +67,11 @@
 -callback get_inbox_unread(HostType, InboxEntryKey) -> {ok, integer()} when
     HostType :: mongooseim:host_type(),
     InboxEntryKey :: mod_inbox:entry_key().
+
+-callback get_full_entry(HostType, InboxEntryKey) -> Ret when
+    HostType :: mongooseim:host_type(),
+    InboxEntryKey :: mod_inbox:entry_key(),
+    Ret :: inbox_res() | nil().
 
 -callback get_entry_properties(HostType, InboxEntryKey) -> Ret when
     HostType :: mongooseim:host_type(),
@@ -155,6 +161,14 @@ get_inbox_unread(HostType, InboxEntryKey) ->
     Args = [HostType, InboxEntryKey],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
+-spec get_full_entry(HostType, InboxEntryKey) -> Ret when
+    HostType :: mongooseim:host_type(),
+    InboxEntryKey :: mod_inbox:entry_key(),
+    Ret :: inbox_res() | nil().
+get_full_entry(HostType, InboxEntryKey) ->
+    Args = [HostType, InboxEntryKey],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
 -spec get_entry_properties(HostType, InboxEntryKey) -> Ret when
     HostType :: mongooseim:host_type(),
     InboxEntryKey :: mod_inbox:entry_key(),
@@ -175,4 +189,4 @@ set_entry_properties(HostType, InboxEntryKey, Params) ->
 callback_funs() ->
   [get_inbox, set_inbox, set_inbox_incr_unread,
    reset_unread, remove_inbox_row, clear_inbox, get_inbox_unread,
-   get_entry_properties, set_entry_properties, remove_domain].
+   get_full_entry, get_entry_properties, set_entry_properties, remove_domain].

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -153,7 +153,7 @@ set_inbox_incr_unread(HostType, {LUser, LServer, LToBareJid}, Content, MsgId, Ti
                                        InsertParams, UpdateParams, UniqueKeyValues),
     check_result(Res).
 
--spec reset_unread(HosType :: mongooseim:host_type(),
+-spec reset_unread(HostType :: mongooseim:host_type(),
                    InboxEntryKey :: mod_inbox:entry_key(),
                    MsgId :: binary() | undefined) -> mod_inbox:write_res().
 reset_unread(HostType, {LUser, LServer, LToBareJid}, MsgId) ->
@@ -167,7 +167,7 @@ clear_inbox(HostType, LUser, LServer) ->
     Res = execute_delete(HostType, LUser, LServer),
     check_result(Res).
 
--spec get_entry_properties(HosType :: mongooseim:host_type(),
+-spec get_entry_properties(HostType :: mongooseim:host_type(),
                            InboxEntryKey :: mod_inbox:entry_key()) ->
     entry_properties() | nil().
 get_entry_properties(HostType, {LUser, LServer, RemBareJID}) ->
@@ -175,7 +175,7 @@ get_entry_properties(HostType, {LUser, LServer, RemBareJID}) ->
         {selected, []} ->
             [];
         {selected, [Selected]} ->
-            decode_entries(Selected)
+            decode_properties(Selected)
     end.
 
 -spec set_entry_properties(HostType :: mongooseim:host_type(),
@@ -191,16 +191,8 @@ set_entry_properties(HostType, {LUser, LServer, RemBareJID}, Properties) ->
         {updated, 0} ->
             {error, <<"item-not-found">>};
         {selected, [Result]} ->
-            decode_entries(Result)
+            decode_properties(Result)
     end.
-
-decode_entries({BArchive, BCount, BMutedUntil}) ->
-    Archive = mongoose_rdbms:to_bool(BArchive),
-    Count = mongoose_rdbms:result_to_integer(BCount),
-    MutedUntil = mongoose_rdbms:result_to_integer(BMutedUntil),
-    #{archive => Archive,
-      unread_count => Count,
-      muted_until => MutedUntil}.
 
 %% ----------------------------------------------------------------------
 %% Internal functions
@@ -433,6 +425,14 @@ decode_row(HostType, {Username, Content, Count, MsgId, Timestamp, Archive, Muted
       timestamp => NumericTimestamp,
       archive => BoolArchive,
       muted_until => NumericMutedUntil}.
+
+decode_properties({BArchive, BCount, BMutedUntil}) ->
+    Archive = mongoose_rdbms:to_bool(BArchive),
+    Count = mongoose_rdbms:result_to_integer(BCount),
+    MutedUntil = mongoose_rdbms:result_to_integer(BMutedUntil),
+    #{archive => Archive,
+      unread_count => Count,
+      muted_until => MutedUntil}.
 
 -spec check_result_is_expected(_, list()) -> mod_inbox:write_res().
 check_result_is_expected({updated, Val}, ValList) when is_list(ValList) ->

--- a/src/inbox/mod_inbox_rdbms_async.erl
+++ b/src/inbox/mod_inbox_rdbms_async.erl
@@ -22,6 +22,7 @@
          clear_inbox/3,
          get_inbox/4,
          get_inbox_unread/2,
+         get_full_entry/2,
          get_entry_properties/2,
          set_entry_properties/3]).
 -export([stop/1]).
@@ -134,6 +135,11 @@ remove_domain(HostType, LServer) ->
     mod_inbox:write_res().
 clear_inbox(HostType, LUser, LServer) ->
     mod_inbox_rdbms:clear_inbox(HostType, LUser, LServer).
+
+-spec get_full_entry(mongooseim:host_type(), mod_inbox:entry_key()) ->
+    inbox_res() | nil().
+get_full_entry(HostType, Entry) ->
+    mod_inbox_rdbms:get_full_entry(HostType, Entry).
 
 -spec get_entry_properties(mongooseim:host_type(), mod_inbox:entry_key()) ->
     entry_properties() | nil().

--- a/src/inbox/mod_inbox_utils.erl
+++ b/src/inbox/mod_inbox_utils.erl
@@ -36,7 +36,8 @@
          maybe_muted_until/2,
          binary_to_bool/1,
          bool_to_binary/1,
-         build_inbox_entry_key/2
+         build_inbox_entry_key/2,
+         build_forward_el/2
         ]).
 
 -ignore_xref([
@@ -221,3 +222,14 @@ build_inbox_entry_key(FromJid, ToJid) ->
     {LUser, LServer} = jid:to_lus(FromJid),
     ToBareJid = jid:nameprep(jid:to_binary(jid:to_lus(ToJid))),
     {LUser, LServer, ToBareJid}.
+
+-spec build_forward_el(exml:element(), integer()) -> exml:element().
+build_forward_el(Content, Timestamp) ->
+    Delay = build_delay_el(Timestamp),
+    #xmlel{name = <<"forwarded">>, attrs = [{<<"xmlns">>, ?NS_FORWARD}],
+           children = [Delay, Content]}.
+
+-spec build_delay_el(Timestamp :: integer()) -> exml:element().
+build_delay_el(Timestamp) ->
+    TS = calendar:system_time_to_rfc3339(Timestamp, [{offset, "Z"}, {unit, microsecond}]),
+    jlib:timestamp_to_xml(TS, undefined, undefined).


### PR DESCRIPTION
This is useful for example when a conversation is entered, through some
link, to any point in the far past of the conversation, instead of at
the bottom. The inbox might be desired in a two-column layout, like in
many phone apps when displayed horizontally, but if loading from MAM at
some point far in the past, in a conversation whose inbox entry wasn't
already loaded (old conversation, pagination), building the right inbox
snippet would take many round-trips.