### PR TITLE
Fix error in cleanup of registration_timeout big test

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -293,7 +293,7 @@ registration_timeout(Config) ->
     escalus:assert(is_error, [<<"wait">>, <<"resource-constraint">>], Stanza),
 
     %% After timeout, the user should be registered successfully
-    wait_for_user(Config, Alice, erlang:round(?REGISTRATION_TIMEOUT * 1.5 * 1000)).
+    wait_for_user(Config, Bob, erlang:round(?REGISTRATION_TIMEOUT * 1.5 * 1000)).
 
 registration_failure_timeout(Config) ->
     timer:sleep(timer:seconds(?REGISTRATION_TIMEOUT + 1)),


### PR DESCRIPTION
Trivial fix. The cleanup stage of the registration_timeout test was hitting an error because it tried to delete Alice and Bob, but user Bob was never created by the test. This is because the test was creating Alice twice, instead of creating Bob. 

The test now does not hit an error in cleanup.