### PR TITLE
Inbox/refactoring – add hooks and clean redundant code

### DIFF
--- a/include/mod_inbox.hrl
+++ b/include/mod_inbox.hrl
@@ -6,8 +6,6 @@
 
 -type id() :: binary().
 
--type get_inbox_res() :: list(inbox_res()).
-
 -type inbox_res() :: #{remote_jid := binary(),
                        msg := exml:element(),
                        unread_count := integer(),

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -54,7 +54,7 @@
 -type write_res() :: ok | {error, any()}.
 
 -export_type([entry_key/0, get_inbox_params/0]).
--export_type([count_res/0, write_res/0]).
+-export_type([count_res/0, write_res/0, inbox_res/0]).
 
 %%--------------------------------------------------------------------
 %% gdpr callbacks
@@ -169,7 +169,7 @@ process_iq(Acc, From, _To, #iq{type = set, id = IqId, sub_el = QueryEl} = IQ, _E
     end.
 
 -spec forward_messages(Acc :: mongoose_acc:t(),
-                       List :: list(inbox_res()),
+                       List :: [inbox_res()],
                        QueryId :: id(),
                        To :: jid:jid()) -> list(mongoose_acc:t()).
 forward_messages(Acc, List, QueryId, To) when is_list(List) ->
@@ -323,7 +323,7 @@ build_result_el(Msg, QueryId, Count, Timestamp, Archive, MutedUntil, AccTS) ->
                     {<<"unread">>, integer_to_binary(Count)} | QueryAttr],
            children = [Forwarded | Properties]}.
 
--spec build_result_iq(get_inbox_res()) -> exml:element().
+-spec build_result_iq([inbox_res()]) -> exml:element().
 build_result_iq(List) ->
     AllUnread = [ N || #{unread_count := N} <- List, N =/= 0],
     Result = #{<<"count">> => length(List),

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -153,7 +153,7 @@ process_iq(Acc, _From, _To, #iq{type = get, sub_el = SubEl} = IQ, _Extra) ->
     Form = build_inbox_form(),
     SubElWithForm = SubEl#xmlel{ children = [Form] },
     {Acc, IQ#iq{type = result, sub_el = SubElWithForm}};
-process_iq(Acc, From, _To, #iq{type = set, id = IqId, sub_el = QueryEl} = IQ, _Extra) ->
+process_iq(Acc, From, _To, #iq{type = set, sub_el = QueryEl} = IQ, _Extra) ->
     HostType = mongoose_acc:host_type(Acc),
     LUser = From#jid.luser,
     LServer = From#jid.lserver,
@@ -162,20 +162,18 @@ process_iq(Acc, From, _To, #iq{type = set, id = IqId, sub_el = QueryEl} = IQ, _E
             {Acc, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:bad_request(<<"en">>, Msg)]}};
         Params ->
             List = mod_inbox_backend:get_inbox(HostType, LUser, LServer, Params),
-            QueryId = exml_query:attr(QueryEl, <<"queryid">>, IqId),
-            forward_messages(Acc, List, QueryId, From),
+            forward_messages(Acc, List, IQ, From),
             Res = IQ#iq{type = result, sub_el = [build_result_iq(List)]},
             {Acc, Res}
     end.
 
 -spec forward_messages(Acc :: mongoose_acc:t(),
                        List :: [inbox_res()],
-                       QueryId :: id(),
+                       QueryId :: jlib:iq(),
                        To :: jid:jid()) -> list(mongoose_acc:t()).
-forward_messages(Acc, List, QueryId, To) when is_list(List) ->
-    AccTS = mongoose_acc:timestamp(Acc),
-    Msgs = [build_inbox_message(El, QueryId, AccTS) || El <- List],
-    [send_message(Acc, To, Msg) || Msg <- Msgs].
+forward_messages(Acc, List, QueryEl, To) when is_list(List) ->
+    Msgs = [ build_inbox_message(Acc, El, QueryEl) || El <- List],
+    [ send_message(Acc, To, Msg) || Msg <- Msgs].
 
 -spec send_message(mongoose_acc:t(), jid:jid(), exml:element()) -> mongoose_acc:t().
 send_message(Acc, To = #jid{lserver = LServer}, Msg) ->
@@ -304,24 +302,27 @@ process_message(HostType, From, To, Message, _TS, Dir, Type) ->
 
 %%%%%%%%%%%%%%%%%%%
 %% Stanza builders
--spec build_inbox_message(inbox_res(), id(), integer()) -> exml:element().
-build_inbox_message(#{msg := Content,
-                      unread_count := Count,
-                      timestamp := Timestamp,
-                      archive := Archive,
-                      muted_until := MutedUntil}, QueryId, AccTS) ->
+-spec build_inbox_message(mongoose_acc:t(), inbox_res(), jlib:iq()) -> exml:element().
+build_inbox_message(Acc, InboxRes, IQ) ->
     #xmlel{name = <<"message">>, attrs = [{<<"id">>, mod_inbox_utils:wrapper_id()}],
-        children = [build_result_el(Content, QueryId, Count, Timestamp, Archive, MutedUntil, AccTS)]}.
+           children = [build_result_el(Acc, InboxRes, IQ)]}.
 
--spec build_result_el(exml:element(), id(), integer(), integer(), boolean(), integer(), integer()) -> exml:element().
-build_result_el(Msg, QueryId, Count, Timestamp, Archive, MutedUntil, AccTS) ->
+-spec build_result_el(mongoose_acc:t(), inbox_res(), jlib:iq()) -> exml:element().
+build_result_el(Acc, #{msg := Msg,
+                       unread_count := Count,
+                       timestamp := Timestamp,
+                       archive := Archive,
+                       muted_until := MutedUntil} = InboxRes, #iq{id = IqId, sub_el = QueryEl} = IQ) ->
+    QueryId = exml_query:attr(QueryEl, <<"queryid">>, IqId),
+    AccTS = mongoose_acc:timestamp(Acc),
+    Extensions = mongoose_hooks:extend_inbox_message(Acc, InboxRes, IQ),
     Forwarded = mod_inbox_utils:build_forward_el(Msg, Timestamp),
     Properties = mod_inbox_entries:extensions_result(Archive, MutedUntil, AccTS),
     QueryAttr = [{<<"queryid">>, QueryId} || QueryId =/= undefined, QueryId =/= <<>>],
     #xmlel{name = <<"result">>,
            attrs = [{<<"xmlns">>, ?NS_ESL_INBOX},
                     {<<"unread">>, integer_to_binary(Count)} | QueryAttr],
-           children = [Forwarded | Properties]}.
+           children = [Forwarded | Properties] ++ Extensions}.
 
 -spec build_result_iq([inbox_res()]) -> exml:element().
 build_result_iq(List) ->
@@ -330,13 +331,10 @@ build_result_iq(List) ->
                <<"unread-messages">> => lists:sum(AllUnread),
                <<"active-conversations">> => length(AllUnread)},
     ResultBinary = maps:map(fun(K, V) ->
-                        build_result_el(K, integer_to_binary(V))  end, Result),
+                                    #xmlel{name = K, children = [#xmlcdata{content = integer_to_binary(V)}]}
+                            end, Result),
     #xmlel{name = <<"fin">>, attrs = [{<<"xmlns">>, ?NS_ESL_INBOX}],
            children = maps:values(ResultBinary)}.
-
--spec build_result_el(name_bin(), count_bin()) -> exml:element().
-build_result_el(Name, CountBin) ->
-    #xmlel{name = Name, children = [#xmlcdata{content = CountBin}]}.
 
 %%%%%%%%%%%%%%%%%%%
 %% iq-get

--- a/src/inbox/mod_inbox_backend.erl
+++ b/src/inbox/mod_inbox_backend.erl
@@ -23,7 +23,7 @@
     HostType :: mongooseim:host_type(),
     Opts :: gen_mod:module_opts().
 
--callback get_inbox(HostType, LUser, LServer, Params) -> mod_inbox:get_inbox_res() when
+-callback get_inbox(HostType, LUser, LServer, Params) -> [mod_inbox:inbox_res()] when
     HostType :: mongooseim:host_type(),
     LUser :: jid:luser(),
     LServer :: jid:lserver(),
@@ -92,7 +92,7 @@ init(HostType, Opts) ->
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec get_inbox(HostType, LUser, LServer, Params) -> mod_inbox:get_inbox_res() when
+-spec get_inbox(HostType, LUser, LServer, Params) -> [mod_inbox:inbox_res()] when
     HostType :: mongooseim:host_type(),
     LUser :: jid:luser(),
     LServer :: jid:lserver(),

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -90,7 +90,7 @@ init(HostType, _Options) ->
 -spec get_inbox(HostType :: mongooseim:host_type(),
                 LUser :: jid:luser(),
                 LServer :: jid:lserver(),
-                Params :: mod_inbox:get_inbox_params()) -> get_inbox_res().
+                Params :: mod_inbox:get_inbox_params()) -> [mod_inbox:inbox_res()].
 get_inbox(HostType, LUser, LServer, Params) ->
     case get_inbox_rdbms(HostType, LUser, LServer, Params) of
         {selected, []} ->

--- a/src/inbox/mod_inbox_rdbms_async.erl
+++ b/src/inbox/mod_inbox_rdbms_async.erl
@@ -118,7 +118,7 @@ remove_inbox_row(HostType, Entry) ->
 
 %% synchronous callbacks
 -spec get_inbox(mongooseim:host_type(), jid:luser(), jid:lserver(), mod_inbox:get_inbox_params()) ->
-    get_inbox_res().
+    [mod_inbox:inbox_res()].
 get_inbox(HostType, LUser, LServer, Params) ->
     mod_inbox_rdbms:get_inbox(HostType, LUser, LServer, Params).
 

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -19,6 +19,7 @@
          filter_local_packet/1,
          filter_packet/1,
          inbox_unread_count/3,
+         extend_inbox_message/3,
          get_key/2,
          packet_to_component/3,
          presence_probe_hook/5,
@@ -284,6 +285,13 @@ filter_packet(Acc) ->
     Result :: mongoose_acc:t().
 inbox_unread_count(LServer, Acc, User) ->
     run_hook_for_host_type(inbox_unread_count, LServer, Acc, [User]).
+
+-spec extend_inbox_message(mongoose_acc:t(), mod_inbox:inbox_res(), jlib:iq()) ->
+    [exml:element()].
+extend_inbox_message(MongooseAcc, InboxRes, IQ) ->
+    HostType = mongoose_acc:host_type(MongooseAcc),
+    HookParams = #{mongoose_acc => MongooseAcc, inbox_res => InboxRes, iq => IQ},
+    run_fold(extend_inbox_message, HostType, [], HookParams).
 
 %%% @doc The `get_key' hook is called to extract a key from `mod_keystore'.
 -spec get_key(HostType, KeyName) -> Result when


### PR DESCRIPTION
Custom code might want to add metadata to each inbox entry, as they
fetch it, like for example markers, or information about how to display
the entry. In order to avoid multiple round-trips between client and
server, this metadata could be added in the inbox query already. For
that, we insert a hook that takes the accumulator, the inbox row as
returned from the DB, and the IQ that initiated the query to begin with.

That way, custom xml elements can be added to the inbox iqs in the same
way they can be added to the mam queries, and hooks can parse extra
flags and generate more xml elements to append to the inbox response.