### PR TITLE
Async rdbms order

### DIFF
--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -11,7 +11,9 @@ To use it, enable mod\_inbox in the config file.
 * **Default:** `"rdbms"`
 * **Example:** `backend = "rdbms_async"`
 
-Only RDBMS storage is supported, but `rdbms` means flushes to inbox are synchronous with each message, while `rdbms_async` is instead asynchronous. For performance reasons, `rdbms_async` is almost always preferred, but, it doesn't ensure the same consistency characteristics, as different MongooseIM nodes might race on updates.
+Only RDBMS storage is supported, but `rdbms` means flushes to DB are synchronous with each message, while `rdbms_async` is instead asynchronous.
+
+Regular `rdbms` has worse performance characteristics, but it has better consistency properties, as events aren't lost nor reordered. `rdbms_async` processes events asynchronously and potentially unloading a lot of aggregation from the DB. Like the case of the asynchronous workers for MAM, it is the preferred method, with the risk messages being lost on an ungraceful shutdown.
 
 #### `modules.mod_inbox.async_writer.pool_size`
 * **Syntax:** non-negative integer

--- a/doc/modules/mod_smart_markers.md
+++ b/doc/modules/mod_smart_markers.md
@@ -12,9 +12,13 @@ Strategy to handle incoming IQ requests. For details, please refer to
 [IQ processing policies](../configuration/Modules.md#iq-processing-policies).
 
 ### `modules.mod_smart_markers.backend`
-* **Syntax:** string, only `"rdbms"` is supported at the moment.
+* **Syntax:** string, one of `"rdbms"`, `"rdbms_async"`
 * **Default:** `"rdbms"`
-* **Example:** `backend = "rdbms"`
+* **Example:** `backend = "rdbms_async"`
+
+Only RDBMS storage is supported, but `rdbms` means flushes to DB are synchronous with each message, while `rdbms_async` is instead asynchronous.
+
+Regular `rdbms` has worse performance characteristics, but it has better consistency properties, as events aren't lost nor reordered. `rdbms_async` processes events asynchronously and potentially unloading a lot of aggregation from the DB. Like the case of the asynchronous workers for MAM, it is the preferred method, with the risk messages being lost on an ungraceful shutdown.
 
 ### `modules.mod_smart_markers.keep_private`
 * **Syntax:** boolean

--- a/src/inbox/mod_inbox_rdbms_async.erl
+++ b/src/inbox/mod_inbox_rdbms_async.erl
@@ -58,14 +58,14 @@ request(Task, _Extra = #{host_type := HostType}) ->
 
 request_one(HostType, {set_inbox, {LUser, LServer, LToBareJid}, Content, Count, MsgId, Timestamp}) ->
     Unique = [LUser, LServer, LToBareJid],
-    Update = [MsgId, Content, Timestamp, Count],
-    Insert = [LUser, LServer, LToBareJid, MsgId, Content, Timestamp, Count],
+    Update = [MsgId, Content, Count, Timestamp],
+    Insert = [LUser, LServer, LToBareJid, MsgId, Content, Count, Timestamp],
     rdbms_queries:request_upsert(HostType, inbox_upsert, Insert, Update, Unique);
 
 request_one(HostType, {set_inbox_incr_unread, {LUser, LServer, LToBareJid}, Content, MsgId, Timestamp, Incrs}) ->
     Unique = [LUser, LServer, LToBareJid],
-    Update = [MsgId, Content, Timestamp, Incrs],
-    Insert = [LUser, LServer, LToBareJid, MsgId, Content, Timestamp, Incrs],
+    Update = [MsgId, Content, Incrs, Timestamp],
+    Insert = [LUser, LServer, LToBareJid, MsgId, Content, Incrs, Timestamp],
     rdbms_queries:request_upsert(HostType, inbox_upsert_incr_unread, Insert, Update, Unique);
 
 request_one(HostType, {remove_inbox_row, {LUser, LServer, LToBareJid}}) ->

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -46,8 +46,7 @@
          request_upsert/5]).
 
 -ignore_xref([
-    request_upsert/5, count_records_where/3,
-    get_db_specific_limits/1, get_db_specific_offset/2, get_db_type/0
+    count_records_where/3, get_db_specific_limits/1, get_db_specific_offset/2, get_db_type/0
 ]).
 
 %% We have only two compile time options for db queries:
@@ -55,7 +54,6 @@
 %%-define(mssql, true).
 -ifndef(mssql).
 -undef(generic).
--define(generic, true).
 -endif.
 
 -define(RDBMS_TYPE, (mongoose_rdbms:db_type())).

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -42,6 +42,7 @@
 
 -export([join/2,
          prepare_upsert/6,
+         prepare_upsert/7,
          execute_upsert/5,
          request_upsert/5]).
 
@@ -114,11 +115,22 @@ request_upsert(Host, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
                      QueryName :: atom(),
                      TableName :: atom(),
                      InsertFields :: [binary()],
-                     Updates :: [binary() | {binary(), binary()}],
+                     Updates :: [binary() | {assignment | expression, binary(), binary()}],
                      UniqueKeyFields :: [binary()]) ->
     {ok, QueryName :: atom()} | {error, already_exists}.
 prepare_upsert(Host, Name, Table, InsertFields, Updates, UniqueKeyFields) ->
-    SQL = upsert_query(Host, Table, InsertFields, Updates, UniqueKeyFields),
+    prepare_upsert(Host, Name, Table, InsertFields, Updates, UniqueKeyFields, none).
+
+-spec prepare_upsert(Host :: mongoose_rdbms:server(),
+                     QueryName :: atom(),
+                     TableName :: atom(),
+                     InsertFields :: [ColumnName :: binary()],
+                     Updates :: [binary() | {assignment | expression, binary(), binary()}],
+                     UniqueKeyFields :: [binary()],
+                     IncrementalField :: none | binary()) ->
+    {ok, QueryName :: atom()} | {error, already_exists}.
+prepare_upsert(Host, Name, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
+    SQL = upsert_query(Host, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField),
     Query = iolist_to_binary(SQL),
     ?LOG_DEBUG(#{what => rdbms_upsert_query, name => Name, query => Query}),
     Fields = prepared_upsert_fields(InsertFields, Updates, UniqueKeyFields),
@@ -132,12 +144,12 @@ prepared_upsert_fields(InsertFields, Updates, UniqueKeyFields) ->
         _ -> InsertFields ++ UpdateFields
     end.
 
-upsert_query(Host, Table, InsertFields, Updates, UniqueKeyFields) ->
+upsert_query(Host, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
     case {mongoose_rdbms:db_engine(Host), mongoose_rdbms:db_type()} of
         {mysql, _} ->
-            upsert_mysql_query(Table, InsertFields, Updates, UniqueKeyFields);
+            upsert_mysql_query(Table, InsertFields, Updates, UniqueKeyFields, IncrementalField);
         {pgsql, _} ->
-            upsert_pgsql_query(Table, InsertFields, Updates, UniqueKeyFields);
+            upsert_pgsql_query(Table, InsertFields, Updates, UniqueKeyFields, IncrementalField);
         {odbc, mssql} ->
             upsert_mssql_query(Table, InsertFields, Updates, UniqueKeyFields);
         NotSupported -> erlang:error({rdbms_not_supported, NotSupported})
@@ -152,22 +164,39 @@ mysql_and_pgsql_insert(Table, Columns) ->
      join(Placeholders, ", "),
      ")"].
 
-upsert_mysql_query(Table, InsertFields, Updates, [Key | _]) ->
+upsert_mysql_query(Table, InsertFields, Updates, [Key | _], IncrementalField) ->
     Insert = mysql_and_pgsql_insert(Table, InsertFields),
-    OnConflict = mysql_on_conflict(Updates, Key),
+    OnConflict = mysql_on_conflict(Table, Updates, Key, IncrementalField),
     [Insert, OnConflict].
 
-upsert_pgsql_query(Table, InsertFields, Updates, UniqueKeyFields) ->
+upsert_pgsql_query(Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
     Insert = mysql_and_pgsql_insert(Table, InsertFields),
     OnConflict = pgsql_on_conflict(Updates, UniqueKeyFields),
-    [Insert, OnConflict].
+    WhereIncrements = pgsql_ensure_increments(Table, IncrementalField),
+    [Insert, OnConflict, WhereIncrements].
 
-mysql_on_conflict([], Key) ->
+mysql_on_conflict(_Table, [], Key, _) ->
     %% Update field to itself (no-op), there is no 'DO NOTHING' in MySQL
     [" ON DUPLICATE KEY UPDATE ", Key, " = ", Key];
-mysql_on_conflict(UpdateFields, _) ->
+mysql_on_conflict(_Table, UpdateFields, _, none) ->
     [" ON DUPLICATE KEY UPDATE ",
-     update_fields_on_conflict(UpdateFields)].
+     update_fields_on_conflict(UpdateFields)];
+mysql_on_conflict(Table, UpdateFields, _, IncrementalField) ->
+    TableName = atom_to_list(Table),
+    FieldsWithPlaceHolders = [mysql_fields_with_placeholders(TableName, Update, IncrementalField)
+                              || Update <- UpdateFields],
+    IncrUpdates = join(FieldsWithPlaceHolders, ", "),
+    [" AS alias ON DUPLICATE KEY UPDATE ", IncrUpdates].
+
+mysql_fields_with_placeholders(TableName, UpdateField, IncrementalField) ->
+    Alternatives = case UpdateField of
+                       {Op, Column, Expression} when Op =:= assignment; Op =:= expression ->
+                           [Expression, ", ", TableName, ".", Column, ")"];
+                       Column ->
+                           ["? , ", TableName, ".", Column, ")"]
+                   end,
+    [ Column, " = IF(", TableName, ".", IncrementalField, " < alias.", IncrementalField, ", "
+      | Alternatives].
 
 pgsql_on_conflict([], UniqueKeyFields) ->
     JoinedKeys = join(UniqueKeyFields, ", "),
@@ -179,8 +208,14 @@ pgsql_on_conflict(UpdateFields, UniqueKeyFields) ->
      update_fields_on_conflict(UpdateFields)].
 
 update_fields_on_conflict(Updates) ->
-    FieldsWithPlaceHolders = [update_field_expression(Update) || Update <- Updates],
+    FieldsWithPlaceHolders = [get_field_expression(Update) || Update <- Updates],
     join(FieldsWithPlaceHolders, ", ").
+
+pgsql_ensure_increments(_Table, none) ->
+    [];
+pgsql_ensure_increments(Table, IncrementalField) ->
+    TableName = atom_to_list(Table),
+    [" WHERE ", TableName, ".", IncrementalField, " < EXCLUDED.", IncrementalField].
 
 upsert_mssql_query(Table, InsertFields, Updates, UniqueKeyFields) ->
     UniqueKeysInSelect = [[" ? AS ", Key] || Key <- UniqueKeyFields],
@@ -200,28 +235,17 @@ mssql_on_conflict([]) -> ";";
 mssql_on_conflict(Updates) ->
      [" WHEN MATCHED THEN UPDATE SET ", update_fields_on_conflict(Updates), ";"].
 
-update_field_expression(Update) ->
-    case get_field_expression(Update) of
-        {true, Expr} -> Expr;
-        true -> [Update, " = ?"];
-        false -> Update
-    end.
+get_field_expression({Op, ColumnName, Expr}) when Op =:= assignment; Op =:= expression ->
+    [ColumnName, " = ", Expr];
+get_field_expression(Field) when is_binary(Field) ->
+    [Field, " = ?"].
 
-get_field_expression({_, FieldExpr}) ->
-    case binary:match(FieldExpr, <<"=">>) of
-        nomatch -> false;
-        _ -> {true, FieldExpr}
-    end;
-get_field_expression(FieldExpr) ->
-    binary:match(FieldExpr, <<"=">>) =:= nomatch.
-
-get_field_name({Field, _}) ->
-    case binary:match(Field, <<"=">>) of
-        nomatch -> {true, Field};
-        _ -> false
-    end;
-get_field_name(FieldExpr) ->
-    binary:match(FieldExpr, <<"=">>) =:= nomatch.
+get_field_name({assignment, Field, _}) when is_binary(Field) ->
+    false;
+get_field_name({expression, Field, _}) when is_binary(Field) ->
+    {true, Field};
+get_field_name(Field) when is_binary(Field) ->
+    true.
 
 %% F can be either a fun or a list of queries
 %% TODO: We should probably move the list of queries transaction

--- a/src/smart_markers/mod_smart_markers_rdbms.erl
+++ b/src/smart_markers/mod_smart_markers_rdbms.erl
@@ -24,7 +24,7 @@ init(HostType, _) ->
     UpdateFields = [<<"msg_id">>, <<"timestamp">>],
     InsertFields = KeyFields ++ UpdateFields,
     rdbms_queries:prepare_upsert(HostType, smart_markers_upsert, smart_markers,
-                                 InsertFields, UpdateFields, KeyFields),
+                                 InsertFields, UpdateFields, KeyFields, <<"timestamp">>),
     mongoose_rdbms:prepare(smart_markers_select_conv, smart_markers,
         [lserver, luser, to_jid, thread, timestamp],
         <<"SELECT lserver, luser, to_jid, thread, type, msg_id, timestamp FROM smart_markers "

--- a/src/smart_markers/mod_smart_markers_rdbms_async.erl
+++ b/src/smart_markers/mod_smart_markers_rdbms_async.erl
@@ -113,4 +113,3 @@ verify(Answer, Marker, _Extra) ->
                            marker => Marker});
         _ -> ok
     end.
-


### PR DESCRIPTION
If we have asynchronous inserts for inbox or smart_markers, there's a risk of different nodes aggregating different data, and then inserting it in undefined orders, so an earlier event could be flushed by one node _after_ a latter event from another node. For example in the case of a conversation between Alice and Bob, when Alice and Bob are connected to different nodes on a cluster.

So what we want here, is for the DB to ignore updates, if the timestamp of such update is not strictly higher than the timestamp from the previous update.

For this, we add one more parameter to the preparing of queries, that constructs the appropriate query for Postgres and MySQL. This is currently not implemented for MSSQL.

With this, now the asynchronous backends for inbox and markers are much closer to being production ready, the only thing missing is the remove events, which don't have a timestamp so they won't be reordered correctly with updates. I plan to make removals tagged updates instead, like in the case of inbox, moving them to a hidden box instead.

Note the commit message for f8876363762640c7a0b78cce8ff42c735df49fc5 for how the trick works for MySQL.