### PR TITLE
GraphQL - Implement MUC category

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -28,6 +28,7 @@
 {suites, "tests", graphql_SUITE}.
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
+{suites, "tests", graphql_muc_SUITE}.
 {suites, "tests", graphql_muc_light_SUITE}.
 {suites, "tests", graphql_roster_SUITE}.
 {suites, "tests", graphql_session_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -44,6 +44,7 @@
 {suites, "tests", graphql_SUITE}.
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
+{suites, "tests", graphql_muc_SUITE}.
 {suites, "tests", graphql_muc_light_SUITE}.
 {suites, "tests", graphql_roster_SUITE}.
 {suites, "tests", graphql_session_SUITE}.

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -2,9 +2,10 @@
 
 -import(distributed_helper, [mim/0, rpc/4]).
 
--export([execute/3, execute_auth/2, get_listener_port/1, get_listener_config/1]).
+-export([execute/3, execute_auth/2, execute_user/3, get_listener_port/1, get_listener_config/1]).
 -export([init_admin_handler/1]).
--export([get_ok_value/2, get_err_msg/1, get_err_msg/2, make_creds/1]).
+-export([get_ok_value/2, get_err_msg/1, get_err_msg/2, make_creds/1,
+         user_to_bin/1, user_to_jid/1, user_to_full_bin/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("escalus/include/escalus.hrl").
@@ -28,6 +29,11 @@ execute_auth(Body, Config) ->
     User = proplists:get_value(username, Opts),
     Password = proplists:get_value(password, Opts),
     execute(Ep, Body, {User, Password}).
+
+execute_user(Body, User, Config) ->
+    Ep = ?config(schema_endpoint, Config),
+    Creds = make_creds(User),
+    execute(Ep, Body, Creds).
 
 -spec get_listener_port(binary()) -> integer().
 get_listener_port(EpName) ->
@@ -80,6 +86,15 @@ make_creds(#client{props = Props} = Client) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Client)),
     Password = proplists:get_value(password, Props),
     {JID, Password}.
+
+user_to_full_bin(#client{} = Client) -> escalus_client:full_jid(Client);
+user_to_full_bin(Bin) when is_binary(Bin) -> Bin.
+
+user_to_bin(#client{} = Client) -> escalus_client:short_jid(Client);
+user_to_bin(Bin) when is_binary(Bin) -> Bin.
+
+user_to_jid(#client{jid = JID}) -> jid:to_bare(jid:from_binary(JID));
+user_to_jid(Bin) when is_binary(Bin) -> jid:from_binary(Bin).
 
 %% Internal
 

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -1,0 +1,431 @@
+-module(graphql_muc_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(graphql_helper, [execute_user/3, execute_auth/2, get_ok_value/2, get_err_msg/1,
+                         user_to_bin/1, user_to_full_bin/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+
+suite() ->
+    require_rpc_nodes([mim]) ++ escalus:suite().
+
+all() ->
+    [{group, user_muc},
+     {group, admin_muc}].
+
+groups() ->
+    [{user_muc, [parallel], user_muc_handler()},
+     {admin_muc, [parallel], admin_muc_handler()}].
+
+user_muc_handler() ->
+    [mock].
+
+admin_muc_handler() ->
+    [admin_create_and_delete_room,
+     admin_try_create_instant_room_with_nonexistent_domain,
+     admin_try_create_instant_room_with_nonexistent_user,
+     admin_try_delete_nonexistent_room,
+     admin_try_delete_room_with_nonexistent_domain,
+     admin_list_rooms,
+     admin_list_room_users,
+     admin_try_list_users_from_nonexistent_room,
+     admin_change_room_config,
+     admin_try_change_nonexistent_room_config,
+     admin_get_room_config,
+     admin_try_get_nonexistent_room_config,
+     admin_invite_user,
+     admin_try_invite_user_to_nonexistent_room,
+     admin_kick_user,
+     admin_send_message_to_room,
+     admin_get_room_messages,
+     admin_try_get_nonexistent_room_messages].
+
+init_per_suite(Config) ->
+    HostType = domain_helper:host_type(),
+    Config2 = escalus:init_per_suite(Config),
+    Config3 = dynamic_modules:save_modules(HostType, Config2),
+    Config4 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config3),
+    dynamic_modules:restart(HostType, mod_disco,
+                            config_parser_helper:default_mod_config(mod_disco)),
+    muc_helper:load_muc(),
+    mongoose_helper:ensure_muc_clean(),
+    Config4.
+
+end_per_suite(Config) ->
+    escalus_fresh:clean(),
+    mongoose_helper:ensure_muc_clean(),
+    muc_helper:unload_muc(),
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_suite(Config).
+
+init_per_group(admin_muc, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(user_muc, Config) ->
+    [{schema_endpoint, user} | Config].
+
+end_per_group(_GN, Config) ->
+    Config.
+
+init_per_testcase(TC, Config) ->
+    rest_helper:maybe_skip_mam_test_cases(TC, [user_get_room_messages,
+                                               admin_get_room_messages], Config).
+
+end_per_testcase(TC, Config) ->
+    escalus:end_per_testcase(TC, Config).
+
+mock(_Config) ->
+    ok.
+
+-define(CREATE_INSTANT_ROOM_PATH, [data, muc, createInstantRoom]).
+-define(LIST_ROOMS_PATH, [data, muc, listRooms]).
+-define(INVITE_USER_PATH, [data, muc, inviteUser]).
+-define(KICK_USER_PATH, [data, muc, kickUser]).
+-define(DELETE_ROOM_PATH, [data, muc, deleteRoom]).
+-define(SEND_MESSAGE_PATH, [data, muc, sendMessageToRoom]).
+-define(GET_MESSAGES_PATH, [data, muc, getRoomMessages]).
+-define(LIST_ROOM_USERS_PATH, [data, muc, listRoomUsers]).
+-define(CHANGE_ROOM_CONFIG_PATH, [data, muc, changeRoomConfiguration]).
+-define(GET_ROOM_CONFIG_PATH, [data, muc, getRoomConfig]).
+
+-define(NONEXISTENT_ROOM, <<"room@room">>).
+-define(NONEXISTENT_ROOM2, <<"room@", (muc_helper:muc_host())/binary>>).
+
+admin_list_rooms(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun admin_list_rooms_story/3).
+
+admin_list_rooms_story(Config, Alice, Bob) ->
+    AliceJID = jid:from_binary(escalus_client:short_jid(Alice)),
+    BobJID = jid:from_binary(escalus_client:short_jid(Bob)),
+    AliceRoom = rand_name(),
+    BobRoom = rand_name(),
+    muc_helper:create_instant_room(AliceRoom, AliceJID, <<"Ali">>, []),
+    muc_helper:create_instant_room(BobRoom, BobJID, <<"Bob">>, [{public_list, false}]),
+    Res = execute_auth(admin_list_rooms_body(muc_helper:muc_host(), Alice, null, null), Config),
+    #{<<"rooms">> := Rooms } = get_ok_value(?LIST_ROOMS_PATH, Res),
+    ?assert(contain_room(AliceRoom, Rooms)),
+    ?assert(contain_room(BobRoom, Rooms)).
+
+admin_create_and_delete_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_create_and_delete_room_story/2).
+
+admin_create_and_delete_room_story(Config, Alice) ->
+    Name = <<"first-alice-room">>,
+    MUCServer = muc_helper:muc_host(),
+    RoomJID = jid:make_bare(Name, MUCServer),
+    % Create instant room
+    Res = execute_auth(admin_create_instant_room_body(MUCServer, Name, Alice, <<"Ali">>), Config),
+    ?assertMatch(#{<<"title">> := Name, <<"private">> := false, <<"usersNumber">> := 0},
+                 get_ok_value(?CREATE_INSTANT_ROOM_PATH, Res)),
+    Res2 = execute_auth(admin_list_rooms_body(MUCServer, Alice, null, null), Config),
+    ?assert(contain_room(Name, get_ok_value(?LIST_ROOMS_PATH, Res2))),
+    % Delete room
+    Res3 = execute_auth(delete_room_body(RoomJID, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_ROOM_PATH, Res3),
+                                          <<"successfully">>)),
+    Res4 = execute_auth(admin_list_rooms_body(MUCServer, Alice, null, null), Config),
+    ?assertNot(contain_room(Name, get_ok_value(?LIST_ROOMS_PATH, Res4))).
+
+admin_try_create_instant_room_with_nonexistent_domain(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_try_create_instant_room_with_nonexistent_domain_story/2).
+
+admin_try_create_instant_room_with_nonexistent_domain_story(Config, Alice) ->
+    Res = execute_auth(admin_create_instant_room_body(<<"unknown">>, rand_name(), Alice, <<"Ali">>),
+                       Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_try_create_instant_room_with_nonexistent_user(Config) ->
+    Name = rand_name(),
+    MUCServer = muc_helper:muc_host(),
+    JID = <<(rand_name())/binary, "@localhost">>,
+    Res = execute_auth(admin_create_instant_room_body(MUCServer, Name, JID, <<"Ali">>), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_try_delete_nonexistent_room(Config) ->
+    RoomJID = jid:make_bare(<<"unknown">>, muc_helper:muc_host()),
+    Res = execute_auth(delete_room_body(RoomJID, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res),
+                                          <<"not existing">>)).
+
+admin_try_delete_room_with_nonexistent_domain(Config) ->
+    RoomJID = jid:make_bare(<<"unknown">>, <<"unknown">>),
+    Res = execute_auth(delete_room_body(RoomJID, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res),
+                                          <<"not existing">>)).
+
+admin_invite_user(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}], fun admin_invite_user_story/3).
+
+admin_invite_user_story(Config, Alice, Bob) ->
+    RoomJIDBin = ?config(room_jid, Config),
+    RoomJID = jid:from_binary(RoomJIDBin),
+    Res = execute_auth(admin_invite_user_body(RoomJID, Alice, Bob, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?INVITE_USER_PATH, Res),
+                                          <<"successfully">>)),
+    Stanza = escalus:wait_for_stanza(Bob),
+    escalus:assert(is_message, Stanza),
+    ?assertEqual(RoomJIDBin,
+                 exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"jid">>}])).
+
+admin_try_invite_user_to_nonexistent_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_try_invite_user_to_nonexistent_room_story/3).
+
+admin_try_invite_user_to_nonexistent_room_story(Config, Alice, Bob) ->
+    Res = execute_auth(admin_invite_user_body(?NONEXISTENT_ROOM, Alice, Bob, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_kick_user(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}], fun admin_kick_user_story/3).
+
+admin_kick_user_story(Config, Alice, Bob) ->
+    RoomJIDBin = ?config(room_jid, Config),
+    RoomJID = jid:from_binary(RoomJIDBin),
+    BobNick = <<"Bobek">>,
+    Reason = <<"You are too laud">>,
+    enter_room(RoomJID, Alice, <<"ali">>),
+    enter_room(RoomJID, Bob, BobNick),
+    Res = execute_auth(kick_user_body(RoomJID, BobNick, Reason), Config),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?KICK_USER_PATH, Res),
+                                          <<"successfully">>)),
+    escalus:wait_for_stanzas(Bob, 2),
+    KickStanza = escalus:wait_for_stanza(Bob),
+    escalus:assert(is_presence_with_type, [<<"unavailable">>], KickStanza),
+    ?assertEqual(Reason,
+                 exml_query:path(KickStanza, [{element, <<"x">>}, {element, <<"item">>},
+                                              {element, <<"reason">>}, cdata])).
+
+admin_send_message_to_room(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_send_message_to_room_story/3).
+
+admin_send_message_to_room_story(Config, _Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Messsage = <<"Hello All!">>,
+    BobNick = <<"Bobek">>,
+    enter_room(RoomJID, Bob, BobNick),
+    escalus:wait_for_stanza(Bob),
+    % Send message
+    Res = execute_auth(admin_send_message_to_room_body(RoomJID, Bob, Messsage), Config),
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(?SEND_MESSAGE_PATH, Res),
+                                          <<"successfully">>)),
+    assert_is_message_correct(RoomJID, BobNick, <<"groupchat">>, Messsage,
+                              escalus:wait_for_stanza(Bob)).
+
+admin_get_room_config(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}], fun admin_get_room_config_story/2).
+
+admin_get_room_config_story(Config, _Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Res = execute_auth(get_room_config_body(RoomJID), Config),
+    assert_default_room_config(Res).
+
+admin_try_get_nonexistent_room_config(Config) ->
+    Res = execute_auth(get_room_config_body(?NONEXISTENT_ROOM), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_change_room_config(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}], fun admin_change_room_config_story/2).
+
+admin_change_room_config_story(Config, _Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Title = <<"aloes">>,
+    Description = <<"The chat about aloes">>,
+    Public = false,
+    RoomConfig = #{title => Title, description => Description, public => Public},
+    Res = execute_auth(change_room_config_body(RoomJID, RoomConfig), Config),
+    ?assertMatch(#{<<"title">> := Title,
+                   <<"description">> := Description,
+                   <<"public">> := Public}, get_ok_value(?CHANGE_ROOM_CONFIG_PATH, Res)).
+
+admin_try_change_nonexistent_room_config(Config) ->
+    RoomConfig = #{title => <<"NewTitle">>},
+    Res = execute_auth(change_room_config_body(?NONEXISTENT_ROOM, RoomConfig), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_list_room_users(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_list_room_users_story/3).
+
+admin_list_room_users_story(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Bobek">>,
+    AliceNick = <<"Ali">>,
+    enter_room(RoomJID, Bob, BobNick),
+    enter_room(RoomJID, Alice, AliceNick),
+    Res = execute_auth(list_room_users_body(RoomJID), Config),
+    ExpectedUsers = [{escalus_client:full_jid(Bob), BobNick, <<"PARTICIPANT">>},
+                     {escalus_client:full_jid(Alice), AliceNick, <<"MODERATOR">>}],
+    assert_room_users(ExpectedUsers, get_ok_value(?LIST_ROOM_USERS_PATH, Res)).
+
+admin_try_list_users_from_nonexistent_room(Config) ->
+    Res = execute_auth(list_room_users_body(?NONEXISTENT_ROOM), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_get_room_messages(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_get_room_messages_story/3).
+
+admin_get_room_messages_story(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    enter_room(RoomJID, Bob, <<"Bobek">>),
+    enter_room(RoomJID, Alice, <<"Ali">>),
+    escalus:wait_for_stanzas(Bob, 2),
+    execute_auth(admin_send_message_to_room_body(RoomJID, Bob, <<"Hi!">>), Config),
+    escalus:wait_for_stanzas(Bob, 1),
+    mam_helper:maybe_wait_for_archive(Config),
+    Res = execute_auth(get_room_messages_body(RoomJID, 50, null), Config),
+    #{<<"stanzas">> := [#{<<"stanza">> := StanzaXML}], <<"limit">> := 50} =
+        get_ok_value(?GET_MESSAGES_PATH, Res),
+    ?assertMatch({ok, #xmlel{name = <<"message">>}}, exml:parse(StanzaXML)).
+
+admin_try_get_nonexistent_room_messages(Config) ->
+    Res = execute_auth(get_room_messages_body(?NONEXISTENT_ROOM, null, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+%% Helpers
+
+rand_name() ->
+    rpc(mim(), mongoose_bin, gen_from_crypto, []).
+
+-spec assert_room_users([{jid:jid(), binary(), binary()}], [map()]) -> ok.
+assert_room_users(Expected, Actual) ->
+    lists:all(fun(#{<<"jid">> := JID, <<"role">> := Role, <<"nick">> := Nick}) ->
+                      lists:any(fun({JID2, Nick2, Role2}) ->
+                                        JID =:= JID2 andalso Nick =:= Nick2 andalso Role =:= Role2
+                                end, Expected)
+              end, Actual).
+
+assert_is_message_correct(RoomJID, SenderNick, Type, Text, ReceivedMessage) ->
+    escalus_pred:is_message(ReceivedMessage),
+    From = jid:to_binary(jid:replace_resource(RoomJID, SenderNick)),
+    From  = exml_query:attr(ReceivedMessage, <<"from">>),
+    Type  = exml_query:attr(ReceivedMessage, <<"type">>),
+    Body = #xmlel{name = <<"body">>, children = [#xmlcdata{content=Text}]},
+    Body = exml_query:subelement(ReceivedMessage, <<"body">>).
+
+enter_room(RoomJID, User, Nick) ->
+    JID = jid:to_binary(jid:replace_resource(RoomJID, Nick)),
+    %X = #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_MUC}]},
+    Pres = escalus_stanza:to(escalus_stanza:presence(<<"available">>, []), JID),
+    escalus:send(User, Pres),
+    escalus:wait_for_stanza(User).
+
+contain_room(Name, #{<<"rooms">> := Rooms}) ->
+    contain_room(Name, Rooms);
+contain_room(Name, Rooms) when is_list(Rooms) -> 
+    lists:any(fun(#{<<"title">> := T}) -> T =:= Name end, Rooms).
+
+assert_default_room_config(Response) ->
+    ?assertMatch(#{<<"title">> := <<>>,
+                   <<"description">> := <<>>,
+                   <<"allowChangeSubject">> := true,
+                   <<"allowQueryUsers">> := true,
+                   <<"allowPrivateMessages">> := true,
+                   <<"allowVisitorStatus">> := true,
+                   <<"allowVisitorNickchange">> := true,
+                   <<"public">> := true,
+                   <<"publicList">> := true,
+                   <<"persistent">> := false,
+                   <<"moderated">> := false,
+                   <<"membersByDefault">> := true,
+                   <<"membersOnly">> := false,
+                   <<"allowUserInvites">> := false,
+                   <<"allowMultipleSession">> := false,
+                   <<"passwordProtected">> := false,
+                   <<"password">> := <<>>,
+                   <<"anonymous">> := true,
+                   <<"mayGetMemberList">> := [],
+                   <<"maxUsers">> := 200,
+                   <<"logging">> := false}, get_ok_value(?GET_ROOM_CONFIG_PATH, Response)).
+
+%% Request bodies
+
+admin_create_instant_room_body(MUCDomain, Name, Owner, Nick) ->
+    Query = <<"mutation M1($mucDomain: String!, $name: String!, $owner: JID!, $nick: String!)
+              { muc { createInstantRoom(mucDomain: $mucDomain, name: $name, owner: $owner, nick: $nick)
+              { jid title private usersNumber } } }">>,
+    OpName = <<"M1">>,
+    Vars = #{mucDomain => MUCDomain, name => Name, owner => user_to_bin(Owner), nick => Nick},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_invite_user_body(Room, Sender, Recipient, Reason) ->
+    Query = <<"mutation M1($room: JID!, $sender: JID!, $recipient: JID!, $reason: String)
+              { muc { inviteUser(room: $room, sender: $sender, recipient: $recipient, reason: $reason) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), sender => user_to_bin(Sender),
+             recipient => user_to_bin(Recipient), reason => Reason},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+kick_user_body(Room, Nick, Reason) ->
+    Query = <<"mutation M1($room: JID!, $nick: String!, $reason: String)
+              { muc { kickUser(room: $room, nick: $nick, reason: $reason) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), nick => Nick, reason => Reason},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_send_message_to_room_body(Room, From, Body) ->
+    Query = <<"mutation M1($room: JID!, $from: JID!, $body: String!)
+              { muc { sendMessageToRoom(room: $room, from: $from, body: $body) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), from => user_to_full_bin(From), body => Body},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+delete_room_body(Room, Reason) ->
+    Query = <<"mutation M1($room: JID!, $reason: String)
+              { muc { deleteRoom(room: $room, reason: $reason) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), reason => Reason},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+change_room_config_body(Room, Config) ->
+    Query = <<"mutation M1($room: JID!, $config: MUCRoomConfigInput!)
+              { muc { changeRoomConfiguration(room: $room, config: $config)
+              { title description allowChangeSubject allowQueryUsers allowPrivateMessages
+                allowVisitorStatus allowVisitorNickchange public publicList persistent
+                moderated membersByDefault membersOnly allowUserInvites allowMultipleSession
+                passwordProtected password anonymous mayGetMemberList maxUsers logging } } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), config => Config},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_list_rooms_body(MUCDomain, From, Limit, Index) ->
+    Query = <<"query Q1($mucDomain: String!, $from: JID, $limit: Int, $index: Int)
+              { muc { listRooms(mucDomain: $mucDomain, from: $from, limit: $limit, index: $index)
+              { rooms { jid title private usersNumber } count index first last} } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{mucDomain => MUCDomain, from => user_to_bin(From), limit => Limit, index => Index},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+get_room_config_body(Room) ->
+    Query = <<"query Q1($room: JID!)
+              { muc { getRoomConfig(room: $room)
+              { title description allowChangeSubject allowQueryUsers allowPrivateMessages
+                allowVisitorStatus allowVisitorNickchange public publicList persistent
+                moderated membersByDefault membersOnly allowUserInvites allowMultipleSession
+                passwordProtected password anonymous mayGetMemberList maxUsers logging } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{room => jid:to_binary(Room)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+list_room_users_body(RoomJID) ->
+    Query = <<"query Q1($room: JID!)
+              { muc { listRoomUsers(room: $room)
+              { jid nick role } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{room => jid:to_binary(RoomJID)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+get_room_messages_body(RoomJID, PageSize, Before) ->
+    Query = <<"query Q1($room: JID!, $pageSize: Int, $before: DateTime)
+              { muc { getRoomMessages(room: $room, pageSize: $pageSize, before: $before)
+              { stanzas { stanza } limit } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{<<"room">> => jid:to_binary(RoomJID), <<"pageSize">> => PageSize,
+             <<"before">> => Before},
+    #{query => Query, operationName => OpName, variables => Vars}.

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -3,9 +3,9 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute/3, execute_auth/2, get_listener_port/1,
+-import(graphql_helper, [execute_user/3, execute_auth/2, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1,
-                         get_err_msg/2, make_creds/1]).
+                         get_err_msg/2, make_creds/1, user_to_jid/1, user_to_bin/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -495,11 +495,6 @@ user_add_contact(User, Contact, Config) ->
     Name = escalus_utils:get_username(Contact),
     execute_user(user_add_contact_body(Contact, Name, ?DEFAULT_GROUPS), User, Config).
 
-execute_user(Body, User, Config) ->
-    Ep = ?config(schema_endpoint, Config),
-    Creds = make_creds(User),
-    execute(Ep, Body, Creds).
-
 check_contacts(ContactClients, User) ->
     Expected = [escalus_utils:jid_to_lower(escalus_client:short_jid(Client))
                 || Client <- ContactClients],
@@ -536,12 +531,6 @@ get_roster(User, Contact) ->
          user_to_jid(User),
          jid:to_lower(user_to_jid(Contact)),
          full]).
-
-user_to_bin(#client{jid = JID} = Client) -> escalus_client:short_jid(Client);
-user_to_bin(Bin) when is_binary(Bin) -> Bin.
-
-user_to_jid(#client{jid = JID}) -> jid:to_bare(jid:from_binary(JID));
-user_to_jid(Bin) when is_binary(Bin) -> jid:from_binary(Bin).
 
 make_contact(Users) when is_list(Users) ->
     [make_contact(U) || U <- Users];

--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -18,8 +18,10 @@ type AdminQuery{
   session: SessionAdminQuery
   "Stanza management"
   stanza: StanzaAdminQuery
+  "MUC room management"
+  muc: MUCAdminQuery
   "MUC Light room management"
-  muc_light: MUCLightAdminQuery 
+  muc_light: MUCLightAdminQuery
   "Roster/Contacts management"
   roster: RosterAdminQuery 
 }
@@ -37,6 +39,8 @@ type AdminMutation @protected{
   session: SessionAdminMutation
   "Stanza management"
   stanza: StanzaAdminMutation
+  "MUC room management"
+  muc: MUCAdminMutation
   "MUC Light room management"
   muc_light: MUCLightAdminMutation
   "Roster/Contacts management"

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -1,0 +1,31 @@
+"""
+Allow admin to manage Multi-User Chat rooms.
+"""
+type MUCAdminMutation @protected{
+  "Create a MUC room under the given XMPP hostname"
+  createInstantRoom(mucDomain: String!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
+  "Invite a user to a MUC room"
+  inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
+  "Kick a user from a MUC room"
+  kickUser(room: JID!, nick: String!, reason: String): String
+  "Send a message to a MUC room"
+  sendMessageToRoom(room: JID!, from: JID!, body: String!): String
+  "Remove a MUC room"
+  deleteRoom(room: JID!, reason: String): String
+  "Change configuration of a MUC room"
+  changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+}
+
+"""
+Allow admin to get information about Multi-User Chat rooms.
+"""
+type MUCAdminQuery @protected{
+  "Get MUC rooms under the given MUC domain"
+  listRooms(mucDomain: String!, from: JID, limit: Int, index: Int): MUCRoomsPayload!
+  "Get configuration of the MUC room"
+  getRoomConfig(room: JID!): MUCRoomConfig
+  "Get users list of given MUC room"
+  listRoomUsers(room: JID!): [MUCRoomUser!]
+  "Get the MUC room archived messages"
+  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+}

--- a/priv/graphql/schemas/global/muc.gql
+++ b/priv/graphql/schemas/global/muc.gql
@@ -1,39 +1,75 @@
-enum Affiliation{
-  OWNER
-  MEMBER
+enum MUCRoomRole{
   NONE
+  VISITOR
+  PARTICIPANT
+  MODERATOR
 }
 
-input BlockingInput{
-  entityType: BlockedEntityType!
-  action: BlockingAction!
-  entity: JID!
+type MUCRoomUser{
+  jid: JID
+  nick: String!
+  role: MUCRoomRole!
 }
 
-type BlockingItem{
-  entityType: BlockedEntityType!
-  action: BlockingAction!
-  entity: JID!
-}
-
-enum BlockingAction{
-  ALLOW,
-  DENY
-}
-
-enum BlockedEntityType{
-  USER,
-  ROOM
-}
-
-type Room{
+type MUCRoomDesc{
   jid: JID!
-  name: String!
-  subject: String!
-  participants: [RoomUser!]!
+  title: String!
+  private: Boolean
+  usersNumber: Int
 }
 
-type RoomUser{
-  jid: JID!
-  affiliation: Affiliation!
+type MUCRoomConfig{
+  title: String!,
+  description: String!,
+  allowChangeSubject: Bool!,
+  allowQueryUsers: Bool!,
+  allowPrivateMessages: Bool!,
+  allowVisitorStatus: Bool!,
+  allowVisitorNickchange: Bool!,
+  public: Bool!,
+  publicList: Bool!,
+  persistent: Bool!,
+  moderated: Bool!,
+  membersByDefault: Bool!,
+  membersOnly: Bool!,
+  allowUserInvites: Bool!,
+  allowMultipleSession: Bool!,
+  passwordProtected: Bool!,
+  password: String!,
+  anonymous: Bool!,
+  mayGetMemberList: [String!]!
+  maxUsers: Int,
+  logging: Bool!,
+}
+
+input MUCRoomConfigInput{
+  title: String,
+  description: String,
+  allowChangeSubject: Bool,
+  allowQueryUsers: Bool,
+  allowPrivateMessages: Bool,
+  allowVisitorStatus: Bool,
+  allowVisitorNickchange: Bool,
+  public: Bool,
+  publicList: Bool,
+  persistent: Bool,
+  moderated: Bool,
+  membersByDefault: Bool,
+  membersOnly: Bool,
+  allowUserInvites: Bool,
+  allowMultipleSession: Bool,
+  passwordProtected: Bool,
+  password: String,
+  anonymous: Bool,
+  mayGetMemberList: [String!],
+  maxUsers: Int
+  logging: Bool,
+}
+
+type MUCRoomsPayload{
+  rooms: [MUCRoomDesc!]
+  count: Int
+  index: Int
+  first: String
+  last: String
 }

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -1,0 +1,39 @@
+enum Affiliation{
+  OWNER
+  MEMBER
+  NONE
+}
+
+input BlockingInput{
+  entityType: BlockedEntityType!
+  action: BlockingAction!
+  entity: JID!
+}
+
+type BlockingItem{
+  entityType: BlockedEntityType!
+  action: BlockingAction!
+  entity: JID!
+}
+
+enum BlockingAction{
+  ALLOW,
+  DENY
+}
+
+enum BlockedEntityType{
+  USER,
+  ROOM
+}
+
+type Room{
+  jid: JID!
+  name: String!
+  subject: String!
+  participants: [RoomUser!]!
+}
+
+type RoomUser{
+  jid: JID!
+  affiliation: Affiliation!
+}

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -24,7 +24,7 @@ type MUCUserQuery @protected{
   listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig
-  "Get users list of given MUC room"
+  "Get user list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -1,0 +1,31 @@
+"""
+Allow user to manage Multi-User Chat rooms.
+"""
+type MUCUserMutation @protected{
+  "Create a MUC room under the given XMPP hostname"
+  createInstantRoom(mucDomain: String!, name: String!, nick: String!): MUCRoomDesc
+  "Invite a user to a MUC room"
+  inviteUser(room: JID!, recipient: JID!, reason: String): String
+  "Kick a user from a MUC room"
+  kickUser(room: JID!, nick: String!, reason: String): String
+  "Send a message to a MUC room"
+  sendMessageToRoom(room: JID!, body: String!, resource: String): String
+  "Remove a MUC room"
+  deleteRoom(room: JID!, reason: String): String
+  "Change configuration of a MUC room"
+  changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+}
+
+"""
+Allow user to get information about Multi-User Chat rooms.
+"""
+type MUCUserQuery @protected{
+  "Get MUC rooms under the given MUC domain"
+  listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
+  "Get configuration of the MUC room"
+  getRoomConfig(room: JID!): MUCRoomConfig
+  "Get users list of given MUC room"
+  listRoomUsers(room: JID!): [MUCRoomUser!]
+  "Get the MUC room archived messages"
+  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+}

--- a/priv/graphql/schemas/user/user_schema.gql
+++ b/priv/graphql/schemas/user/user_schema.gql
@@ -12,6 +12,8 @@ type UserQuery{
   checkAuth: UserAuthInfo
   "Account management"
   account: AccountUserQuery
+  "MUC room management"
+  muc: MUCUserQuery
   "MUC Light room management"
   muc_light: MUCLightUserQuery
   "Session management"
@@ -29,6 +31,8 @@ Only an authenticated user can execute these mutations.
 type UserMutation @protected{
   "Account management"
   account: AccountUserMutation
+  "MUC room management"
+  muc: MUCUserMutation
   "MUC Light room management"
   muc_light: MUCLightUserMutation
   "Stanza management"

--- a/src/graphql/admin/mongoose_graphql_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_mutation.erl
@@ -11,6 +11,8 @@ execute(_Ctx, _Obj, <<"domains">>, _Args) ->
     {ok, admin};
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"muc">>, _Args) ->
+    {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
 execute(_Ctx, _Obj, <<"session">>, _Args) ->

--- a/src/graphql/admin/mongoose_graphql_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_query.erl
@@ -11,6 +11,8 @@ execute(_Ctx, _Obj, <<"domains">>, _Args) ->
     {ok, admin};
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"muc">>, _Args) ->
+    {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
 execute(_Ctx, _Obj, <<"session">>, _Args) ->

--- a/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
@@ -42,15 +42,13 @@ invite_user(#{<<"room">> := RoomJID, <<"sender">> := SenderJID,
                          sender => jid:to_binary(SenderJID)}).
 
 -spec kick_user(map()) -> {ok, binary()} | {error, resolver_error()}.
-kick_user(#{<<"room">> := RoomJID, <<"nick">> := Nick,
-              <<"reason">> := Reason}) ->
+kick_user(#{<<"room">> := RoomJID, <<"nick">> := Nick, <<"reason">> := Reason}) ->
     Reason2 = null_to_default(Reason, mongoose_graphql_muc_helper:default_kick_reason("admin")),
     Res = mod_muc_api:kick_user_from_room(RoomJID, Nick, Reason2),
     format_result(Res, #{room => jid:to_binary(RoomJID)}).
 
 -spec send_message_to_room(map()) -> {ok, binary()} | {error, resolver_error()}.
-send_message_to_room(#{<<"room">> := RoomJID, <<"from">> := SenderJID,
-              <<"body">> := Message}) ->
+send_message_to_room(#{<<"room">> := RoomJID, <<"from">> := SenderJID, <<"body">> := Message}) ->
     Res = mod_muc_api:send_message_to_room(RoomJID, SenderJID, Message),
     format_result(Res, #{room => jid:to_binary(RoomJID),
                          from => jid:to_binary(SenderJID)}).

--- a/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
@@ -1,0 +1,73 @@
+-module(mongoose_graphql_muc_admin_mutation).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+
+execute(_Ctx, _Obj, <<"createInstantRoom">>, Args) ->
+    create_instant_room(Args);
+execute(_Ctx, _Obj, <<"inviteUser">>, Args) ->
+    invite_user(Args);
+execute(_Ctx, _Obj, <<"kickUser">>, Args) ->
+    kick_user(Args);
+execute(_Ctx, _Obj, <<"sendMessageToRoom">>, Args) ->
+    send_message_to_room(Args);
+execute(_Ctx, _Obj, <<"changeRoomConfiguration">>, Args) ->
+    change_room_config(Args);
+execute(_Ctx, _Obj, <<"deleteRoom">>, Args) ->
+    delete_room(Args).
+
+-spec create_instant_room(map()) -> {ok, map()} | {error, resolver_error()}.
+create_instant_room(#{<<"mucDomain">> := MUCDomain, <<"name">> := Name,
+                      <<"owner">> := OwnerJID, <<"nick">> := Nick}) ->
+    case mod_muc_api:create_instant_room(MUCDomain, Name, OwnerJID, Nick) of
+        {ok, Room} ->
+            {ok, mongoose_graphql_muc_helper:make_room_desc(Room)};
+        Error ->
+            make_error(Error, #{mucDomain => MUCDomain,
+                                owner => jid:to_binary(OwnerJID)})
+    end.
+
+-spec invite_user(map()) -> {ok, binary()} | {error, resolver_error()}.
+invite_user(#{<<"room">> := RoomJID, <<"sender">> := SenderJID,
+              <<"recipient">>  := RecipientJID, <<"reason">> := Reason}) ->
+    Reason2 = null_to_default(Reason, mongoose_graphql_muc_helper:default_invite_reason("admin")),
+    Res = mod_muc_api:invite_to_room(RoomJID, SenderJID, RecipientJID, Reason2),
+    format_result(Res, #{room => jid:to_binary(RoomJID),
+                         sender => jid:to_binary(SenderJID)}).
+
+-spec kick_user(map()) -> {ok, binary()} | {error, resolver_error()}.
+kick_user(#{<<"room">> := RoomJID, <<"nick">> := Nick,
+              <<"reason">> := Reason}) ->
+    Reason2 = null_to_default(Reason, mongoose_graphql_muc_helper:default_kick_reason("admin")),
+    Res = mod_muc_api:kick_user_from_room(RoomJID, Nick, Reason2),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec send_message_to_room(map()) -> {ok, binary()} | {error, resolver_error()}.
+send_message_to_room(#{<<"room">> := RoomJID, <<"from">> := SenderJID,
+              <<"body">> := Message}) ->
+    Res = mod_muc_api:send_message_to_room(RoomJID, SenderJID, Message),
+    format_result(Res, #{room => jid:to_binary(RoomJID),
+                         from => jid:to_binary(SenderJID)}).
+
+-spec change_room_config(map()) -> {ok, map()} | {error, resolver_error()}.
+change_room_config(#{<<"room">> := RoomJID, <<"config">> := ConfigInput}) ->
+    Fun = fun(Config) -> mongoose_graphql_muc_helper:make_muc_room_config(ConfigInput, Config) end,
+    case mod_muc_api:modify_room_config(RoomJID, Fun) of
+        {ok, Config} ->
+            {ok, mongoose_graphql_muc_helper:muc_room_config_to_map(Config)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec delete_room(map()) -> {ok, binary()} | {error, resolver_error()}.
+delete_room(#{<<"room">> := RoomJID, <<"reason">> := Reason}) ->
+    Reason2 = null_to_default(Reason,
+                              mongoose_graphql_muc_helper:default_room_removal_reason("admin")),
+    Res = mod_muc_api:delete_room(RoomJID, Reason2),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).

--- a/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
@@ -1,0 +1,58 @@
+-module(mongoose_graphql_muc_admin_query).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_undefined/1]).
+-import(mongoose_graphql_muc_light_helper, [page_size_or_max_limit/2]).
+
+execute(_Ctx, _Obj, <<"listRooms">>, Args) ->
+    list_rooms(Args);
+execute(_Ctx, _Obj, <<"listRoomUsers">>, Args) ->
+    list_room_users(Args);
+execute(_Ctx, _Obj, <<"getRoomMessages">>, Args) ->
+    get_room_messages(Args);
+execute(_Ctx, _Obj, <<"getRoomConfig">>, Args) ->
+    get_room_config(Args).
+
+-spec list_rooms(map()) -> {ok, map()}.
+list_rooms(#{<<"mucDomain">> := MUCDomain, <<"from">> := FromJID,
+             <<"limit">> := Limit, <<"index">> := Index}) ->
+    Limit2 = null_to_undefined(Limit),
+    Index2 = null_to_undefined(Index),
+    {Rooms, RSM} = mod_muc_api:get_rooms(MUCDomain, FromJID, Limit2, Index2),
+    {ok, mongoose_graphql_muc_helper:make_rooms_payload(Rooms, RSM)}.
+
+-spec list_room_users(map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
+list_room_users(#{<<"room">> := RoomJID}) ->
+    case mod_muc_api:get_room_users(RoomJID) of
+        {ok, Users} ->
+            {ok, mongoose_graphql_muc_helper:format_users(Users)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec get_room_config(map()) -> {ok, map()} | {error, resolver_error()}.
+get_room_config(#{<<"room">> := RoomJID}) ->
+    case mod_muc_api:get_room_config(RoomJID) of
+        {ok, Config} ->
+            {ok, mongoose_graphql_muc_helper:muc_room_config_to_map(Config)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec get_room_messages(map()) -> {ok, map()} | {error, resolver_error()}.
+get_room_messages(#{<<"room">> := RoomJID, <<"pageSize">> := PageSize, <<"before">> := Before}) ->
+    Before2 = null_to_undefined(Before),
+    PageSize2 = page_size_or_max_limit(PageSize, 50),
+    case mod_muc_api:get_room_messages(RoomJID, PageSize2, Before2) of
+        {ok, Rows} ->
+            Maps = lists:map(fun mongoose_graphql_stanza_helper:row_to_map/1, Rows),
+            {ok, #{<<"stanzas">> => Maps, <<"limit">> => PageSize2}};
+        Err ->
+            make_error(Err, #{room => RoomJID})
+    end.

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
@@ -7,10 +7,9 @@
 
 -include("../mongoose_graphql_types.hrl").
 
--import(mongoose_graphql_helper, [make_error/2, format_result/2]).
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_undefined/1]).
 -import(mongoose_graphql_muc_light_helper, [make_room/1,
                                             make_ok_user/1,
-                                            null_to_undefined/1,
                                             page_size_or_max_limit/2]).
 
 execute(_Ctx, _Obj, <<"listUserRooms">>, Args) ->

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -135,6 +135,8 @@ admin_mapping_rules() ->
         'StanzaAdminQuery' => mongoose_graphql_stanza_admin_query,
         'AccountAdminQuery' => mongoose_graphql_account_admin_query,
         'AccountAdminMutation' => mongoose_graphql_account_admin_mutation,
+        'MUCAdminMutation' => mongoose_graphql_muc_admin_mutation,
+        'MUCAdminQuery' => mongoose_graphql_muc_admin_query,
         'MUCLightAdminMutation' => mongoose_graphql_muc_light_admin_mutation,
         'MUCLightAdminQuery' => mongoose_graphql_muc_light_admin_query,
         'RosterAdminQuery' => mongoose_graphql_roster_admin_query,

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -153,6 +153,8 @@ user_mapping_rules() ->
         'UserMutation' => mongoose_graphql_user_mutation,
         'AccountUserQuery' => mongoose_graphql_account_user_query,
         'AccountUserMutation' => mongoose_graphql_account_user_mutation,
+        'MUCUserMutation' => mongoose_graphql_muc_user_mutation,
+        'MUCUserQuery' => mongoose_graphql_muc_user_query,
         'MUCLightUserMutation' => mongoose_graphql_muc_light_user_mutation,
         'MUCLightUserQuery' => mongoose_graphql_muc_light_user_query,
         'RosterUserQuery' => mongoose_graphql_roster_user_query,

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -22,7 +22,11 @@ input(<<"SubAction">>, <<"ACCEPT">>) -> {ok, accept};
 input(<<"SubAction">>, <<"DECLINE">>) -> {ok, decline};
 input(<<"SubAction">>, <<"CANCEL">>) -> {ok, cancel};
 input(<<"MutualSubAction">>, <<"CONNECT">>) -> {ok, connect};
-input(<<"MutualSubAction">>, <<"DISCONNECT">>) -> {ok, disconnect}.
+input(<<"MutualSubAction">>, <<"DISCONNECT">>) -> {ok, disconnect};
+input(<<"MUCRoomRole">>, <<"NONE">>) -> {ok, none};
+input(<<"MUCRoomRole">>, <<"VISITOR">>) -> {ok, visitor};
+input(<<"MUCRoomRole">>, <<"PARTICIPANT">>) -> {ok, participant};
+input(<<"MUCRoomRole">>, <<"MODERATOR">>) -> {ok, moderator}.
 
 output(<<"PresenceShow">>, Show) ->
     {ok, list_to_binary(string:to_upper(binary_to_list(Show)))};
@@ -47,4 +51,6 @@ output(<<"ContactAsk">>, Type) when Type =:= subscrube;
                                     Type =:= out;
                                     Type =:= both;
                                     Type =:= none ->
-    {ok, list_to_binary(string:to_upper(atom_to_list(Type)))}.
+    {ok, list_to_binary(string:to_upper(atom_to_list(Type)))};
+output(<<"MUCRoomRole">>, Role) ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Role)))}.

--- a/src/graphql/mongoose_graphql_helper.erl
+++ b/src/graphql/mongoose_graphql_helper.erl
@@ -2,7 +2,9 @@
 
 -export([check_user/2]).
 
--export([format_result/2, make_error/2, make_error/3, null_to_default/2]).
+-export([null_to_default/2, null_to_undefined/1]).
+
+-export([format_result/2, make_error/2, make_error/3]).
 
 -include("jlib.hrl").
 -include("mongoose_graphql_types.hrl").
@@ -49,3 +51,6 @@ null_to_default(null, Default) ->
     Default;
 null_to_default(Value, _Default) ->
     Value.
+
+null_to_undefined(null) -> undefined;
+null_to_undefined(V) -> V.

--- a/src/graphql/mongoose_graphql_muc_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_helper.erl
@@ -1,0 +1,112 @@
+-module(mongoose_graphql_muc_helper).
+
+-export([make_rooms_payload/2, make_room_desc/1, muc_room_config_to_map/1, make_muc_room_config/2,
+         format_user/1, format_users/1, add_user_resource/2]).
+
+-export([default_kick_reason/1, default_invite_reason/1, default_room_removal_reason/1]).
+
+-ignore_xref(format_user/1).
+
+-include("mongoose_rsm.hrl").
+-include("mod_muc_room.hrl").
+
+-spec add_user_resource(jid:jid(), binary() | null) ->
+    {ok, jid:jid()} | {no_session, iolist()}.
+add_user_resource(JID, null) ->
+    case mongoose_session_api:get_user_resource(JID, 1) of
+        {ok, Resource} ->
+            {ok, jid:replace_resource(JID, Resource)};
+        {wrong_res_number, _ErrMsg}->
+            {no_session, "Given user does not have any session"}
+    end;
+add_user_resource(JID, Resource) ->
+    {ok, jid:replace_resource(JID, Resource)}.
+
+make_rooms_payload(Rooms, #rsm_out{count = Count, index = Index, first = First, last = Last}) ->
+    Rooms2 = [{ok, make_room_desc(R)} || R <- Rooms],
+    #{<<"rooms">> => Rooms2, <<"count">> => Count, <<"index">> => Index,
+      <<"first">> => First, <<"last">> => Last}.
+
+make_room_desc(#{jid := JID, title := Title} = Room) ->
+    Private = maps:get(private, Room, null),
+    UsersNumber = maps:get(users_number, Room, null),
+    #{<<"jid">> => JID, <<"title">> => Title,
+      <<"private">> => Private, <<"usersNumber">> => UsersNumber}.
+
+default_invite_reason(EndpointName) ->
+    iolist_to_binary(io_lib:format("User invited through the ~s GraphQL API", [EndpointName])).
+
+default_kick_reason(EndpointName) ->
+    iolist_to_binary(io_lib:format("User kicked through the ~s GraphQL API", [EndpointName])).
+
+default_room_removal_reason(EndpointName) ->
+    iolist_to_binary(io_lib:format("Room deleted through the ~s GraphQL API", [EndpointName])).
+
+format_users(Users) ->
+    [{ok, format_user(U)} || U <- Users].
+
+format_user(#{jid := JID, role := Role, nick := Nick}) ->
+    #{<<"jid">> => JID, <<"role">> => Role, <<"nick">> => Nick}.
+
+-spec muc_room_config_to_map(mod_muc_room:config()) -> map().
+muc_room_config_to_map(Conf) ->
+    #{<<"title">> => Conf#config.title,
+      <<"description">> => Conf#config.description,
+      <<"allowChangeSubject">> => Conf#config.allow_change_subj,
+      <<"allowQueryUsers">> => Conf#config.allow_query_users,
+      <<"allowPrivateMessages">> => Conf#config.allow_private_messages,
+      <<"allowVisitorStatus">> => Conf#config.allow_visitor_status,
+      <<"allowVisitorNickchange">> => Conf#config.allow_visitor_nickchange,
+      <<"public">> => Conf#config.public,
+      <<"publicList">> => Conf#config.public_list,
+      <<"persistent">> => Conf#config.persistent,
+      <<"moderated">> => Conf#config.persistent,
+      <<"membersByDefault">> => Conf#config.members_by_default,
+      <<"membersOnly">> => Conf#config.members_only,
+      <<"allowUserInvites">> => Conf#config.allow_user_invites,
+      <<"allowMultipleSession">> => Conf#config.allow_multiple_sessions,
+      <<"passwordProtected">> => Conf#config.password_protected,
+      <<"password">> => Conf#config.password,
+      <<"anonymous">> => Conf#config.anonymous,
+      <<"mayGetMemberList">> => format_maygetmemberlist(Conf#config.maygetmemberlist),
+      <<"maxUsers">> => Conf#config.max_users,
+      <<"logging">> => Conf#config.logging}.
+
+-spec make_muc_room_config(map(), mod_muc_room:config()) -> mod_muc_room:config().
+make_muc_room_config(Map, Conf) ->
+    #config{
+      title = maybe_value(<<"title">>, Conf#config.title, Map),
+      description = maybe_value(<<"description">>, Conf#config.description, Map),
+      allow_change_subj = maybe_value(<<"allowChangeSubject">>, Conf#config.allow_change_subj, Map),
+      allow_query_users = maybe_value(<<"allowQueryUsers">>, Conf#config.allow_query_users, Map),
+      allow_private_messages = maybe_value(<<"allowPrivateMessages">>,
+                                           Conf#config.allow_private_messages, Map),
+      allow_visitor_status = maybe_value(<<"allowVisitorStatus">>,
+                                         Conf#config.allow_visitor_status, Map),
+      allow_visitor_nickchange = maybe_value(<<"allowVisitorNickchange">>,
+                                             Conf#config.allow_visitor_nickchange, Map),
+      public = maybe_value(<<"public">>, Conf#config.public, Map),
+      public_list = maybe_value(<<"publicList">>, Conf#config.public_list, Map),
+      persistent = maybe_value(<<"persistent">>, Conf#config.persistent, Map),
+      moderated = maybe_value(<<"moderated">>, Conf#config.moderated, Map),
+      members_by_default = maybe_value(<<"membersByDefault">>, Conf#config.members_by_default, Map),
+      members_only = maybe_value(<<"membersOnly">>, Conf#config.members_only, Map),
+      allow_user_invites = maybe_value(<<"allowUserInvites">>, Conf#config.allow_user_invites, Map),
+      allow_multiple_sessions = maybe_value(<<"allowMultipleSession">>,
+                                            Conf#config.allow_multiple_sessions, Map),
+      password_protected = maybe_value(<<"passwordProtected">>,
+                                       Conf#config.password_protected, Map),
+      password = maybe_value(<<"password">>, Conf#config.password, Map),
+      anonymous = maybe_value(<<"anonymous">>, Conf#config.anonymous, Map),
+      maygetmemberlist = maybe_value(<<"mayGetMemberList">>, Conf#config.maygetmemberlist, Map),
+      max_users = maybe_value(<<"maxUsers">>, Conf#config.max_users, Map),
+      logging = maybe_value(<<"logging">>, Conf#config.logging, Map)
+     }.
+
+maybe_value(Key, Default, Map) ->
+    case maps:get(Key, Map) of
+        null -> Default;
+        Val -> Val
+    end.
+
+format_maygetmemberlist(Elements) -> [{ok, E} || E <- Elements].

--- a/src/graphql/mongoose_graphql_muc_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_helper.erl
@@ -60,7 +60,7 @@ muc_room_config_to_map(Conf) ->
       <<"public">> => Conf#config.public,
       <<"publicList">> => Conf#config.public_list,
       <<"persistent">> => Conf#config.persistent,
-      <<"moderated">> => Conf#config.persistent,
+      <<"moderated">> => Conf#config.moderated,
       <<"membersByDefault">> => Conf#config.members_by_default,
       <<"membersOnly">> => Conf#config.members_only,
       <<"allowUserInvites">> => Conf#config.allow_user_invites,

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -1,8 +1,7 @@
 -module(mongoose_graphql_muc_light_helper).
 
 -export([make_room/1, make_ok_user/1, blocking_item_to_map/1,
-         null_to_undefined/1, prepare_blocking_items/1,
-         page_size_or_max_limit/2]).
+         prepare_blocking_items/1, page_size_or_max_limit/2]).
 
 -spec page_size_or_max_limit(null | integer(), integer()) -> integer().
 page_size_or_max_limit(null, MaxLimit) ->
@@ -27,6 +26,3 @@ prepare_blocking_items(Items) ->
 
 blocking_item_to_map({What, Action, Who}) ->
     {ok, #{<<"entityType">> => What, <<"action">> => Action, <<"entity">> => Who}}.
-
-null_to_undefined(null) -> undefined;
-null_to_undefined(V) -> V.

--- a/src/graphql/user/mongoose_graphql_muc_light_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_light_user_query.erl
@@ -7,11 +7,10 @@
 
 -include("../mongoose_graphql_types.hrl").
 
--import(mongoose_graphql_helper, [make_error/2, format_result/2]).
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_undefined/1]).
 -import(mongoose_graphql_muc_light_helper, [make_room/1,
                                             make_ok_user/1,
                                             blocking_item_to_map/1,
-                                            null_to_undefined/1,
                                             page_size_or_max_limit/2]).
 
 execute(Ctx, _Obj, <<"listRooms">>, Args) ->

--- a/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
@@ -1,0 +1,80 @@
+-module(mongoose_graphql_muc_user_mutation).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+
+execute(Ctx, _Obj, <<"createInstantRoom">>, Args) ->
+    create_instant_room(Ctx, Args);
+execute(Ctx, _Obj, <<"inviteUser">>, Args) ->
+    invite_user(Ctx, Args);
+execute(Ctx, _Obj, <<"kickUser">>, Args) ->
+    kick_user(Ctx, Args);
+execute(Ctx, _Obj, <<"sendMessageToRoom">>, Args) ->
+    send_message_to_room(Ctx, Args);
+execute(Ctx, _Obj, <<"changeRoomConfiguration">>, Args) ->
+    change_room_config(Ctx, Args);
+execute(Ctx, _Obj, <<"deleteRoom">>, Args) ->
+    delete_room(Ctx, Args).
+
+-spec create_instant_room(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+create_instant_room(#{user := UserJID}, #{<<"mucDomain">> := MUCDomain, <<"name">> := Name,
+                                          <<"nick">> := Nick}) ->
+    case mod_muc_api:create_instant_room(MUCDomain, Name, UserJID, Nick) of
+        {ok, Room} ->
+            {ok, mongoose_graphql_muc_helper:make_room_desc(Room)};
+        Error ->
+            make_error(Error, #{mucDomain => MUCDomain})
+    end.
+
+-spec invite_user(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+invite_user(#{user := UserJID}, #{<<"room">> := RoomJID, <<"recipient">> := RecipientJID,
+                                  <<"reason">> := Reason}) ->
+    Reason2 = null_to_default(Reason, mongoose_graphql_muc_helper:default_invite_reason("user")),
+    Res = mod_muc_api:invite_to_room(RoomJID, UserJID, RecipientJID, Reason2),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec kick_user(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+kick_user(#{user := _UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
+                                <<"reason">> := Reason}) ->
+    Reason2 = null_to_default(Reason, mongoose_graphql_muc_helper:default_kick_reason("user")),
+    Res = mod_muc_api:kick_user_from_room(RoomJID, Nick, Reason2),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec send_message_to_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+send_message_to_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"body">> := Message,
+                                           <<"resource">> := Res}) ->
+    Result = do_send_message_to_room(RoomJID, UserJID, Message, Res),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+-spec change_room_config(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+change_room_config(#{user := UserJID}, #{<<"room">> := RoomJID, <<"config">> := ConfigInput}) ->
+    Fun = fun(Config) -> mongoose_graphql_muc_helper:make_muc_room_config(ConfigInput, Config) end,
+    case mod_muc_api:modify_room_config(RoomJID, UserJID, Fun) of
+        {ok, Config} ->
+            {ok, mongoose_graphql_muc_helper:muc_room_config_to_map(Config)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec delete_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+delete_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"reason">> := Reason}) ->
+    Reason2 = null_to_default(Reason,
+                              mongoose_graphql_muc_helper:default_room_removal_reason("user")),
+    Res = mod_muc_api:delete_room(RoomJID, UserJID, Reason2),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec do_send_message_to_room(jid:jid(), jid:jid(), binary(), binary() | null) ->
+    {ok | no_session, iolist()}.
+do_send_message_to_room(RoomJID, UserJID, Message, Res) ->
+    case mongoose_graphql_muc_helper:add_user_resource(UserJID, Res) of
+        {ok, UserJIDRes} ->
+            mod_muc_api:send_message_to_room(RoomJID, UserJIDRes, Message);
+        Error ->
+            Error
+    end.

--- a/src/graphql/user/mongoose_graphql_muc_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_query.erl
@@ -1,0 +1,59 @@
+-module(mongoose_graphql_muc_user_query).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_undefined/1]).
+-import(mongoose_graphql_muc_light_helper, [page_size_or_max_limit/2]).
+
+execute(Ctx, _Obj, <<"listRooms">>, Args) ->
+    list_rooms(Ctx, Args);
+execute(Ctx, _Obj, <<"listRoomUsers">>, Args) ->
+    list_room_users(Ctx, Args);
+execute(Ctx, _Obj, <<"getRoomMessages">>, Args) ->
+    get_room_messages(Ctx, Args);
+execute(Ctx, _Obj, <<"getRoomConfig">>, Args) ->
+    get_room_config(Ctx, Args).
+
+-spec list_rooms(map(), map()) -> {ok, map()}.
+list_rooms(#{user := UserJID}, #{<<"mucDomain">> := MUCDomain, <<"limit">> := Limit,
+                                 <<"index">> := Index}) ->
+    Limit2 = null_to_undefined(Limit),
+    Index2 = null_to_undefined(Index),
+    {Rooms, RSM} = mod_muc_api:get_rooms(MUCDomain, UserJID, Limit2, Index2),
+    {ok, mongoose_graphql_muc_helper:make_rooms_payload(Rooms, RSM)}.
+
+-spec list_room_users(map(), map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
+list_room_users(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
+    case mod_muc_api:get_room_users(RoomJID, UserJID) of
+        {ok, Users} ->
+            {ok, mongoose_graphql_muc_helper:format_users(Users)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec get_room_config(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+get_room_config(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
+    case mod_muc_api:get_room_config(RoomJID, UserJID) of
+        {ok, Config} ->
+            {ok, mongoose_graphql_muc_helper:muc_room_config_to_map(Config)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec get_room_messages(map(), map()) -> {ok, map()} | {error, resolver_error()}.
+get_room_messages(#{user := UserJID}, #{<<"room">> := RoomJID, <<"pageSize">> := PageSize,
+                                        <<"before">> := Before}) ->
+    Before2 = null_to_undefined(Before),
+    PageSize2 = page_size_or_max_limit(PageSize, 50),
+    case mod_muc_api:get_room_messages(RoomJID, UserJID, PageSize2, Before2) of
+        {ok, Rows} ->
+            Maps = lists:map(fun mongoose_graphql_stanza_helper:row_to_map/1, Rows),
+            {ok, #{<<"stanzas">> => Maps, <<"limit">> => PageSize2}};
+        Err ->
+            make_error(Err, #{room => RoomJID})
+    end.

--- a/src/graphql/user/mongoose_graphql_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_user_mutation.erl
@@ -7,6 +7,8 @@
 
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"muc">>, _Args) ->
+    {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->

--- a/src/graphql/user/mongoose_graphql_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_user_query.erl
@@ -7,6 +7,8 @@
 
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"muc">>, _Args) ->
+    {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
 execute(_Ctx, _Obj, <<"session">>, _Args) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -46,6 +46,7 @@
          broadcast_service_message/2,
          can_use_nick/4,
          room_jid_to_pid/1,
+         get_vh_rooms/2,
          default_host/0]).
 -export([server_host_to_muc_host/2]).
 
@@ -951,9 +952,9 @@ register_room(HostType, MucHost, Room, Pid) ->
 room_jid_to_pid(#jid{luser=RoomName, lserver=MucService}) ->
     case mnesia:dirty_read(muc_online_room, {RoomName, MucService}) of
         [R] ->
-        {ok, R#muc_online_room.pid};
-    [] ->
-        {error, not_found}
+            {ok, R#muc_online_room.pid};
+        [] ->
+            {error, not_found}
     end.
 
 -spec default_host() -> mongoose_subdomain_utils:subdomain_pattern().
@@ -992,7 +993,7 @@ room_to_item({{Name, _}, Pid}, MucHost, From, Lang) when is_pid(Pid) ->
          _ ->
              false
      end;
-room_to_item({{ Name, _ }, _}, MucHost, _, _) ->
+room_to_item({{Name, _}, _}, MucHost, _, _) ->
      {true,
      #xmlel{name = <<"item">>,
             attrs = [{<<"jid">>, jid:to_binary({Name, MucHost, <<>>})},

--- a/src/mod_muc_api.erl
+++ b/src/mod_muc_api.erl
@@ -1,0 +1,375 @@
+%% @doc Provide an interface for frontends (like graphql or ctl) to manage MUC rooms.
+-module(mod_muc_api).
+
+-export([get_rooms/4,
+         get_room_config/1,
+         get_room_config/2,
+         get_room_messages/3,
+         get_room_messages/4,
+         modify_room_config/2,
+         modify_room_config/3,
+         get_room_users/1,
+         get_room_users/2,
+         create_instant_room/4,
+         invite_to_room/4,
+         send_message_to_room/3,
+         kick_user_from_room/3,
+         delete_room/2,
+         delete_room/3]).
+
+-ignore_xref([get_rooms/4, get_rooms/5, delete_room/3,
+              get_room_config/2, get_room_users/2]).
+
+-include("jlib.hrl").
+-include("mongoose_rsm.hrl").
+-include("mod_muc_room.hrl").
+
+-type short_room_desc() :: #{jid := jid:jid(),
+                             title := binary(),
+                             private => boolean(),
+                             users_number => non_neg_integer()}.
+
+-type get_rooms_result() :: {[short_room_desc()], jlib:rsm_out()}.
+
+-type user_map() ::
+    #{jid := jid:jid() | null,
+      role := mod_muc:role(),
+      nick := mod_muc:nick()}.
+
+-type room_conf_mod_fun() :: fun((mod_muc_room:config()) -> mod_muc_room:config()).
+
+-export_type([user_map/0, short_room_desc/0]).
+
+-define(ROOM_DELETED_SUCC_RESULT, {ok, "Room deleted successfully"}).
+-define(USER_CANNOT_ACCESS_ROOM_RESULT,
+        {not_allowed, "Given user does not have permission to read this room"}).
+-define(ROOM_NOT_FOUND_RESULT, {room_not_found, "Room not found"}).
+-define(DELETE_NOT_EXISTING_ROOM_RESULT, {room_not_found, "Cannot remove not existing room"}).
+-define(USER_NOT_FOUND_RESULT, {user_not_found, "Given user not found"}).
+-define(MUC_SERVER_NOT_FOUND_RESULT, {muc_server_not_found, "MUC server not found"}).
+
+-spec get_rooms(jid:lserver(), jid:jid(), non_neg_integer() | undefined,
+                non_neg_integer()) -> get_rooms_result().
+get_rooms(MUCServer, From, Limit, Index) ->
+    {Rooms, RSM} = mod_muc:get_vh_rooms(MUCServer, #rsm_in{max = Limit, index = Index}),
+    Rooms2 = lists:filtermap(fun(R) -> room_to_item(R, MUCServer, From) end, Rooms),
+    {Rooms2, RSM}.
+
+-spec get_room_config(jid:jid(), jid:jid()) ->
+    {ok, mod_muc_room:config()} | {not_allowed | room_not_found, iolist()}.
+get_room_config(RoomJID, UserJID) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            case gen_fsm_compat:sync_send_all_state_event(Pid, {is_room_owner, UserJID}) of
+                {ok, true} ->
+                    {ok, Config} = gen_fsm_compat:sync_send_all_state_event(Pid, get_config),
+                    {ok, Config};
+                {ok, false} ->
+                    {not_allowed, "Given user does not have permission to read config"}
+            end;
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec get_room_config(jid:jid()) -> {ok, mod_muc_room:config()} | {room_not_found, iolist()}.
+get_room_config(RoomJID) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            {ok, Config} = gen_fsm_compat:sync_send_all_state_event(Pid, get_config),
+            {ok, Config};
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+
+-spec create_instant_room(jid:lserver(), binary(), jid:jid(), binary()) ->
+    {ok, short_room_desc()} | {internal | not_found, iolist()}.
+create_instant_room(MUCDomain, Name, OwnerJID, Nick) ->
+    %% Because these stanzas are sent on the owner's behalf through
+    %% the HTTP API, they will certainly recieve stanzas as a
+    %% consequence, even if their client(s) did not initiate this.
+    case ejabberd_auth:does_user_exist(OwnerJID) of
+        true ->
+            BareRoomJID = jid:make_bare(Name, MUCDomain),
+            UserRoomJID = jid:make(Name, MUCDomain, Nick),
+            %% Send presence to create a room.
+            ejabberd_router:route(OwnerJID, UserRoomJID,
+                                  presence(OwnerJID, UserRoomJID)),
+            %% Send IQ set to unlock the room.
+            ejabberd_router:route(OwnerJID, BareRoomJID,
+                                  declination(OwnerJID, BareRoomJID)),
+            case verify_room(BareRoomJID, OwnerJID) of
+                ok ->
+                    {ok, #{jid => BareRoomJID, title => Name, private => false, users_number => 0}};
+                Error ->
+                    Error
+            end;
+        false ->
+            ?USER_NOT_FOUND_RESULT
+    end.
+
+-spec modify_room_config(jid:jid(), jid:jid(), room_conf_mod_fun()) ->
+    {ok, mod_muc_room:config()} | {room_not_found, iolist()}.
+modify_room_config(RoomJID, UserJID, Fun) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            case gen_fsm_compat:sync_send_all_state_event(Pid, {is_room_owner, UserJID}) of
+                {ok, true} ->
+                    modify_room_config_raw(Pid, Fun);
+                {ok, false} ->
+                    {not_allowed, "Given user does not have permission to chagne the config"}
+            end;
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec modify_room_config(jid:jid(), room_conf_mod_fun()) ->
+    {ok, mod_muc_room:config()} | {room_not_found, iolist()}.
+modify_room_config(RoomJID, Fun) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            modify_room_config_raw(Pid, Fun);
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec invite_to_room(jid:jid(), jid:jid(), jid:jid(), binary()) -> {ok, iolist()}.
+invite_to_room(RoomJID, SenderJID, RecipientJID, Reason) ->
+    case verify_room(RoomJID, SenderJID) of
+        ok ->
+            %% Direct invitation: i.e. not mediated by MUC room. See XEP 0249.
+            X = #xmlel{name = <<"x">>,
+                       attrs = [{<<"xmlns">>, ?NS_CONFERENCE},
+                                {<<"jid">>, jid:to_binary(RoomJID)},
+                                {<<"reason">>, Reason}]
+            },
+            Invite = message(SenderJID, RecipientJID, <<>>, [X]),
+            ejabberd_router:route(SenderJID, RecipientJID, Invite),
+            {ok, "Invitation sent successfully"};
+        Error ->
+            Error
+    end.
+
+-spec send_message_to_room(jid:jid(), jid:jid(), binary()) -> {ok, iolist()}.
+send_message_to_room(RoomJID, SenderJID, Message) ->
+    Body = #xmlel{name = <<"body">>,
+                  children = [#xmlcdata{content = Message}]
+                 },
+    Stanza = message(SenderJID, RoomJID, <<"groupchat">>, [Body]),
+    ejabberd_router:route(SenderJID, RoomJID, Stanza),
+    {ok, "Message sent successfully"}.
+
+-spec kick_user_from_room(jid:jid(), binary(), binary()) -> {ok, iolist()}.
+kick_user_from_room(RoomJID, Nick, ReasonIn) ->
+    %% All the machinery which is already deeply embedded in the MUC
+    %% modules will perform the neccessary checking.
+    SenderJID = room_moderator(RoomJID),
+    Reason = #xmlel{name = <<"reason">>,
+                    children = [#xmlcdata{content = ReasonIn}]
+                   },
+    Item = #xmlel{name = <<"item">>,
+                  attrs = [{<<"nick">>, Nick},
+                           {<<"role">>, <<"none">>}],
+                  children = [ Reason ]
+                 },
+    IQ = iq(<<"set">>, SenderJID, RoomJID, [ query(?NS_MUC_ADMIN, [ Item ]) ]),
+    ejabberd_router:route(SenderJID, RoomJID, IQ),
+    {ok, "Kick message sent successfully"}.
+
+-spec delete_room(jid:jid(), binary()) -> {ok | room_not_found, iolist()}.
+delete_room(RoomJID, Reason) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            gen_fsm_compat:send_all_state_event(Pid, {destroy, Reason}),
+            ?ROOM_DELETED_SUCC_RESULT;
+        {error, not_found} ->
+            ?DELETE_NOT_EXISTING_ROOM_RESULT
+    end.
+
+-spec delete_room(jid:jid(), jid:jid(), binary()) ->
+    {ok | room_not_found, iolist()}.
+delete_room(RoomJID, OwnerJID, Reason) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            case gen_fsm_compat:sync_send_all_state_event(Pid, {is_room_owner, OwnerJID}) of
+                {ok, true} ->
+                    gen_fsm_compat:send_all_state_event(Pid, {destroy, Reason}),
+                    ?ROOM_DELETED_SUCC_RESULT;
+                {ok, false} ->
+                    {not_allowed, "Given user does not have permission to delete this room"}
+            end;
+        {error, not_found} ->
+            ?DELETE_NOT_EXISTING_ROOM_RESULT
+    end.
+-spec get_room_users(jid:jid()) -> {ok, [user_map()]} | {room_not_found, iolist()}.
+get_room_users(RoomJID) ->
+    case mod_muc_room:get_room_users(RoomJID) of
+        {ok, Users} ->
+            {ok, [to_user_map(U, true) || U <- Users]};
+        {error, not_found} ->
+           ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec get_room_users(jid:jid(), jid:jid()) -> {ok, [user_map()]} | {room_not_found, iolist()}.
+get_room_users(RoomJID, UserJID) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            case gen_fsm_compat:sync_send_all_state_event(Pid, {can_access_room, UserJID}) of
+                {ok, true} ->
+                    {ok, Users} = gen_fsm_compat:sync_send_all_state_event(Pid, get_room_users),
+                    WithJID = can_access_identity(Pid, UserJID),
+                    {ok, [to_user_map(U, WithJID) || U <- Users]};
+                {ok, false} ->
+                    ?USER_CANNOT_ACCESS_ROOM_RESULT
+            end;
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec get_room_messages(jid:jid(), integer() | undefined,
+                        mod_mam:unix_timestamp() | undefined) ->
+    {ok, [mod_mam:message_row()]} | {muc_server_not_found | internal, iolist()}.
+get_room_messages(RoomJID, PageSize, Before) ->
+    case mongoose_domain_api:get_subdomain_host_type(RoomJID#jid.lserver) of
+        {ok, HostType} ->
+            mod_muc_light_api:get_room_messages(HostType, RoomJID, undefined, PageSize, Before);
+        {error, not_found} ->
+            ?MUC_SERVER_NOT_FOUND_RESULT
+    end.
+
+-spec get_room_messages(jid:jid(), jid:jid(), integer() | undefined,
+                        mod_mam:unix_timestamp() | undefined) ->
+    {ok, list()} | {muc_server_not_found | room_not_found | internal | not_room_member, iolist()}.
+get_room_messages(RoomJID, UserJID, PageSize, Before) ->
+    case mongoose_domain_api:get_subdomain_host_type(RoomJID#jid.lserver) of
+        {ok, HostType} ->
+            case mod_muc_room:can_access_room(RoomJID, UserJID) of
+                {ok, true} ->
+                    mod_muc_light_api:get_room_messages(HostType, RoomJID, UserJID,
+                                                        PageSize, Before);
+                {ok, false} ->
+                    ?USER_CANNOT_ACCESS_ROOM_RESULT;
+                {error, not_found} ->
+                    ?ROOM_NOT_FOUND_RESULT
+            end;
+        {error, not_found} ->
+            ?MUC_SERVER_NOT_FOUND_RESULT
+    end.
+
+%% Internal
+
+-spec can_access_identity(pid(), jid:jid()) -> boolean().
+can_access_identity(Pid, UserJID) ->
+    {ok, WithJID} = gen_fsm_compat:sync_send_all_state_event(Pid, {can_access_identity, UserJID}),
+    WithJID.
+
+-spec modify_room_config_raw(pid(), room_conf_mod_fun()) -> {ok, mod_muc_room:config()}.
+modify_room_config_raw(Pid, Fun) ->
+    {ok, Config} = gen_fsm_compat:sync_send_all_state_event(Pid, get_config),
+    NewConfig = Fun(Config),
+    {ok, NewConfig2} =
+        gen_fsm_compat:sync_send_all_state_event(Pid, {change_config, NewConfig}),
+    {ok, NewConfig2}.
+
+-spec to_user_map(mod_muc_room:user(), boolean()) -> user_map().
+to_user_map(#user{role = Role, nick = Nick}, false = _WithJID) ->
+    #{jid => null, role => Role, nick => Nick};
+to_user_map(#user{jid = JID, role = Role, nick = Nick}, true) ->
+    #{jid => JID, role => Role, nick => Nick}.
+
+-spec room_to_item(tuple(), jid:lserver(), jid:jid()) -> {true, short_room_desc()} | false.
+room_to_item({{Name, _}, Pid}, MUCServer, From) ->
+     case catch gen_fsm_compat:sync_send_all_state_event(
+                  Pid, {get_disco_item, From, <<"en">>}, 100) of
+         {item, Desc} ->
+             Map = room_desc_to_map(Desc),
+             {true, Map#{jid => jid:to_binary({Name, MUCServer, <<>>})}};
+         _ ->
+             false
+     end.
+
+-spec room_desc_to_map(binary()) -> #{title := binary(), private => boolean(),
+                                      users_number => non_neg_integer()}.
+room_desc_to_map(Desc) ->
+    MP = "(\\S+)( \\((private, )?(\\d+)\\))?",
+    {match, [TitlePos, _, PrivatePos, NumberPos]} = re:run(Desc, MP, [{capture, [1, 2, 3, 4]}]),
+    Title = binary:part(Desc, TitlePos),
+    case NumberPos of
+        {-1, 0} ->
+            #{title => Title};
+        _ ->
+            Private = {-1, 0} =/= PrivatePos,
+            Number = binary_to_integer(binary:part(Desc, NumberPos)),
+            #{title => Title, private => Private, users_number => Number}
+    end.
+
+-spec verify_room(jid:jid(), jid:jid()) ->
+    ok | {internal | not_found, term()}.
+verify_room(BareRoomJID, OwnerJID) ->
+    case mod_muc_room:can_access_room(BareRoomJID, OwnerJID) of
+        {ok, true} ->
+            ok;
+        {ok, false} ->
+            {internal, "Room is locked"};
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+iq(Type, Sender, Recipient, Children)
+  when is_binary(Type), is_list(Children) ->
+    Addresses = address_attributes(Sender, Recipient),
+    #xmlel{name = <<"iq">>,
+           attrs = Addresses ++ [{<<"type">>, Type}],
+           children = Children
+          }.
+
+message(Sender, Recipient, Type, Contents)
+  when is_binary(Type), is_list(Contents) ->
+    Addresses = address_attributes(Sender, Recipient),
+    Attributes = case Type of
+                     <<>> -> Addresses;
+                     _ -> [{<<"type">>, Type} | Addresses]
+                 end,
+    #xmlel{name = <<"message">>,
+           attrs = Attributes,
+           children = Contents
+          }.
+
+query(XMLNameSpace, Children)
+  when is_binary(XMLNameSpace), is_list(Children) ->
+    #xmlel{name = <<"query">>,
+           attrs = [{<<"xmlns">>, XMLNameSpace}],
+           children = Children
+          }.
+
+presence(Sender, Recipient) ->
+    #xmlel{name = <<"presence">>,
+           attrs = address_attributes(Sender, Recipient),
+           children = [#xmlel{name = <<"x">>,
+                              attrs = [{<<"xmlns">>, ?NS_MUC}]}]
+          }.
+
+declination(Sender, Recipient) ->
+    iq(<<"set">>, Sender, Recipient, [ data_submission() ]).
+
+data_submission() ->
+    query(?NS_MUC_OWNER, [#xmlel{name = <<"x">>,
+                              attrs = [{<<"xmlns">>, ?NS_XDATA},
+                                       {<<"type">>, <<"submit">>}]}]).
+
+address_attributes(Sender, Recipient) ->
+    [
+     {<<"from">>, jid:to_binary(jid:to_lower(Sender))},
+     {<<"to">>, jid:to_binary(jid:to_lower(Recipient))}
+    ].
+
+room_moderator(RoomJID) ->
+    [JIDStruct|_] =
+        [ UserJID
+          || #user{ jid = UserJID,
+                    role = moderator } <- room_users(RoomJID) ],
+    JIDStruct.
+
+room_users(RoomJID) ->
+    {ok, Affiliations} = mod_muc_room:get_room_users(RoomJID),
+    Affiliations.


### PR DESCRIPTION
This PR addresses [MIM-1619](https://erlangsolutions.atlassian.net/browse/MIM-1619) and implements the admin and user queries for the MUC category. This implementation is only a subset of all commands indicated to be added and focuses to be similar to the API offered by the MUC Light category.

The other useful commands could be added in the next PR.

### Implementation scope
Both user and admin share the same subset of commends.

#### Mutations
  - createInstantRoom
  - inviteUser
  - kickUser
  - sendMessageToRoom
  - deleteRoom
  - changeRoomConfiguration
  
#### Queries
 - listRooms
 - getRoomConfig
 - listRoomUsers
 - getRoomMessages