### PR TITLE
Fix cowboy_static options

### DIFF
--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -824,6 +824,11 @@ listen_http_handlers_static(_Config) ->
          http_handler_raw(<<"cowboy_static">>, #{<<"type">> => <<"priv_dir">>,
                                                  <<"app">> => <<"cowboy_swagger">>,
                                                  <<"content_path">> => <<"swagger">>})),
+    ?cfg(listener_config(ejabberd_cowboy, #{modules => [{"localhost", "/api", cowboy_static,
+                                                         {file, "swagger", [{mimetypes, cow_mimetypes, all}]}
+                                                        }]}),
+         http_handler_raw(<<"cowboy_static">>, #{<<"type">> => <<"file">>,
+                                                 <<"content_path">> => <<"swagger">>})),
     ?err(http_handler_raw(<<"cowboy_static">>, #{<<"type">> => <<"priv_dir">>,
                                                  <<"app">> => <<"cowboy_swagger">>})).
 


### PR DESCRIPTION
It should be possible not to provide the `app` argument for some types, so config_parser cannot require `all`.
See for example how the `file` type is handled: https://github.com/ninenines/cowboy/blob/2.9.0/src/cowboy_static.erl#L61

Should fix #3428.

