### PR TITLE
Eliminate gen_mod:get_opt_subhost

### DIFF
--- a/src/domain/mongoose_subdomain_core.erl
+++ b/src/domain/mongoose_subdomain_core.erl
@@ -257,6 +257,7 @@ remove_subdomains(SubdomainItems) ->
 
 -spec remove_subdomain(subdomain_item()) -> ok.
 remove_subdomain(#subdomain_item{subdomain = Subdomain} = SubdomainItem) ->
+    mongoose_hooks:unregister_subhost(Subdomain),
     ets:delete(?SUBDOMAINS_TABLE, Subdomain),
     SubdomainInfo = convert_subdomain_item_to_map(SubdomainItem),
     mongoose_lazy_routing:maybe_remove_subdomain(SubdomainInfo).
@@ -273,6 +274,7 @@ add_subdomain(RegItem, Domain) ->
     #subdomain_item{subdomain = Subdomain} = Item = make_subdomain_item(RegItem, Domain),
     case ets:insert_new(?SUBDOMAINS_TABLE, Item) of
         true ->
+            mongoose_hooks:register_subhost(Subdomain, false),
             check_subdomain_name(Item),
             %% even if the subdomain name check fails, it's not easy to solve this
             %% collision. so the best thing we can do is to report it and just keep

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -31,7 +31,6 @@
 -export([start/0, stop/0,
          %% Server
          status/0,
-         send_service_message_all_mucs/2,
          %% Accounts
          register/3, register/2, unregister/2,
          registered_users/1,
@@ -58,7 +57,7 @@
     get_loglevel/0, import_users/1, install_fallback_mnesia/1,
     join_cluster/1, leave_cluster/0, load_mnesia/1, mnesia_change_nodename/4,
     register/2, register/3, registered_users/1, remove_from_cluster/1,
-    restore_mnesia/1, send_service_message_all_mucs/2, set_master/1, status/0,
+    restore_mnesia/1, set_master/1, status/0,
     stop/0, unregister/2]).
 
 -include("mongoose.hrl").
@@ -279,7 +278,6 @@ do_leave_cluster() ->
             {error, {E, R}}
     end.
 
-
 -spec status() -> {'mongooseim_not_running', io_lib:chars()} | {'ok', io_lib:chars()}.
 status() ->
     {InternalStatus, ProvidedStatus} = init:get_status(),
@@ -293,18 +291,6 @@ status() ->
                 {ok, io_lib:format("mongooseim ~s is running in that node", [Version])}
         end,
     {Is_running, String1 ++ String2}.
-
-
--spec send_service_message_all_mucs(Subject :: string() | binary(),
-                              AnnouncementText :: string() | binary()) -> 'ok'.
-send_service_message_all_mucs(Subject, AnnouncementText) ->
-    Message = io_lib:format("~s~n~s", [Subject, AnnouncementText]),
-    lists:foreach(
-      fun(Host) ->
-              MUCHost = gen_mod:get_module_opt_subhost(Host, mod_muc, mod_muc:default_host()),
-              mod_muc:broadcast_service_message(MUCHost, Message)
-      end,
-      ?MYHOSTS).
 
 %%%
 %%% Account management

--- a/src/gen_mod.erl
+++ b/src/gen_mod.erl
@@ -42,7 +42,6 @@
          get_module_opt/4,
          get_module_opts/2,
          get_loaded_module_opts/2,
-         get_module_opt_subhost/3,
 
          loaded_modules/0,
          loaded_modules/1,
@@ -62,7 +61,6 @@
 -include("mongoose.hrl").
 
 -type module_feature() :: atom().
--type domain_name() :: mongooseim:domain_name().
 -type host_type() :: mongooseim:host_type().
 -type key_path() :: mongoose_config:key_path().
 -type opt_key() :: atom().
@@ -280,17 +278,6 @@ get_module_opts(HostType, Module) ->
 -spec get_loaded_module_opts(mongooseim:host_type(), module()) -> module_opts().
 get_loaded_module_opts(HostType, Module) ->
     mongoose_config:get_opt([{modules, HostType}, Module]).
-
--spec get_module_opt_subhost(domain_name(),
-                             module(),
-                             mongoose_subdomain_utils:subdomain_pattern()) ->
-    domain_name().
-get_module_opt_subhost(Host, Module, Default) ->
-    %% TODO: try to get rid of this interface
-    %% note that get_module_opt/4 requires host_type(), while
-    %% mongoose_subdomain_utils:get_fqdn/2 expects domain_name()
-    Spec = get_module_opt(Host, Module, host, Default),
-    mongoose_subdomain_utils:get_fqdn(Spec, Host).
 
 -spec loaded_modules() -> [module()].
 loaded_modules() ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -74,9 +74,9 @@
 -export([config_metrics/1]).
 
 -ignore_xref([
-    can_access_identity/4, can_access_room/4, acc_room_affiliations/2, create_instant_room/6,
-    disco_local_items/1, hibernated_rooms_number/0, is_muc_room_owner/4, remove_domain/3,
-    online_rooms_number/0, register_room/4, restore_room/3, start_link/2]).
+    broadcast_service_message/2, can_access_identity/4, can_access_room/4, acc_room_affiliations/2,
+    create_instant_room/6, disco_local_items/1, hibernated_rooms_number/0, is_muc_room_owner/4,
+    remove_domain/3, online_rooms_number/0, register_room/4, restore_room/3, start_link/2]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -492,7 +492,6 @@ init({HostType, Opts}) ->
                            text => <<"Only one MUC domain would work with this host type">>})
     end,
     mongoose_domain_api:register_subdomain(HostType, SubdomainPattern, PacketHandler),
-    register_for_global_distrib(HostType),
     %% Loading
     case LoadPermRoomsAtStartup of
         false ->
@@ -601,9 +600,7 @@ stop_if_hibernated_for_specified_time(Pid, Now, Timeout, {hibernated, LastHibern
 
 terminate(_Reason, #muc_state{host_type = HostType,
                               subdomain_pattern = SubdomainPattern}) ->
-    mongoose_domain_api:unregister_subdomain(HostType, SubdomainPattern),
-    unregister_for_global_distrib(HostType),
-    ok.
+    mongoose_domain_api:unregister_subdomain(HostType, SubdomainPattern).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -1406,12 +1403,3 @@ make_server_host(To, #muc_state{host_type = HostType,
         {fqdn, _} ->
             HostType
     end.
-
-register_for_global_distrib(HostType) ->
-    %% Would not work for multitenancy
-    SubHost = gen_mod:get_module_opt_subhost(HostType, ?MODULE, default_host()),
-    mongoose_hooks:register_subhost(SubHost, false).
-
-unregister_for_global_distrib(HostType) ->
-    SubHost = gen_mod:get_module_opt_subhost(HostType, ?MODULE, default_host()),
-    mongoose_hooks:unregister_subhost(SubHost).

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -342,7 +342,7 @@ register_command(Command) ->
     run_global_hook(register_command, Command, []).
 
 %%% @doc The `register_subhost' hook is called when a component
-%%% is registered for ejabberd_router.
+%%% is registered for ejabberd_router or a subdomain is added to mongoose_subdomain_core.
 -spec register_subhost(LDomain, IsHidden) -> Result when
     LDomain :: binary(),
     IsHidden :: boolean(),
@@ -433,7 +433,7 @@ unregister_command(Command) ->
     run_global_hook(unregister_command, Command, []).
 
 %%% @doc The `unregister_subhost' hook is called when a component
-%%% is unregistered from ejabberd_router.
+%%% is unregistered from ejabberd_router or a subdomain is removed from mongoose_subdomain_core.
 -spec unregister_subhost(LDomain) -> Result when
     LDomain :: binary(),
     Result :: any().

--- a/src/mongoose_router.erl
+++ b/src/mongoose_router.erl
@@ -35,8 +35,7 @@ unregister_route(Domain) ->
         error ->
             {error, invalid_domain, Domain};
         LDomain ->
-            ets:delete(?TABLE, LDomain),
-            mongoose_hooks:unregister_subhost(LDomain)
+            ets:delete(?TABLE, LDomain)
     end.
 
 -spec is_registered_route(jid:lserver()) -> boolean().

--- a/src/mongoose_router.erl
+++ b/src/mongoose_router.erl
@@ -25,8 +25,7 @@ register_route(Domain, Handler) ->
         error ->
             {error, invalid_domain, Domain};
         LDomain ->
-            ets:insert(?TABLE, {LDomain, Handler}),
-            mongoose_hooks:register_subhost(LDomain, false)
+            ets:insert(?TABLE, {LDomain, Handler})
     end.
 
 -spec unregister_route(jid:server()) -> any().

--- a/test/mongoose_subdomain_core_SUITE.erl
+++ b/test/mongoose_subdomain_core_SUITE.erl
@@ -39,6 +39,7 @@ init_per_testcase(TestCase, Config) ->
     %%   - one "dynamic" host type with two configured domain names
     %% initial mongoose_subdomain_core conditions:
     %%   - no subdomains configured for any host type
+    gen_hook:start_link(),
     ok = mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_HOST_TYPES),
     ok = mongoose_subdomain_core:start(),
     [mongoose_domain_core:insert(Domain, ?DYNAMIC_HOST_TYPE2, dummy_source)


### PR DESCRIPTION
This obsolete function was used in two places and both can be eliminated - see the commit messages for details.

The most important change is that the `(un)register_subhost` hooks were called only for `mod_muc` and not for other modules, which caused them to be called twice for `mod_muc` and only once (by `mongoose_lazy_routing`) for other modules. The issue is that lazy execution is too late, which would be caught if we tested global distribution e.g. with `mod_muc_light`. The solution is to simply call the hook in `mongoose_subdomain_core`.

