### PR TITLE
GraphQL - Implement more commands for MUC

### DIFF
--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -5,7 +5,7 @@
 -export([execute/3, execute_auth/2, execute_user/3, get_listener_port/1, get_listener_config/1]).
 -export([init_admin_handler/1]).
 -export([get_ok_value/2, get_err_msg/1, get_err_msg/2, make_creds/1,
-         user_to_bin/1, user_to_jid/1, user_to_full_bin/1]).
+         user_to_bin/1, user_to_full_bin/1, user_to_jid/1, user_to_lower_jid/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("escalus/include/escalus.hrl").
@@ -94,7 +94,12 @@ user_to_bin(#client{} = Client) -> escalus_client:short_jid(Client);
 user_to_bin(Bin) when is_binary(Bin) -> Bin.
 
 user_to_jid(#client{jid = JID}) -> jid:to_bare(jid:from_binary(JID));
-user_to_jid(Bin) when is_binary(Bin) -> jid:from_binary(Bin).
+user_to_jid(Bin) when is_binary(Bin) -> jid:to_bare(jid:from_binary(Bin)).
+
+user_to_lower_jid(#client{} = C) ->
+    jid:from_binary(escalus_utils:jid_to_lower(escalus_client:short_jid(C)));
+user_to_lower_jid(Bin) when is_binary(Bin) ->
+    jid:to_bare(jid:from_binary(escalus_utils:jid_to_lower(Bin))).
 
 %% Internal
 

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -48,13 +48,16 @@ user_muc_handler() ->
      user_owner_set_user_affiliation,
      user_admin_set_user_affiliation,
      user_member_set_user_affiliation,
+     user_try_set_nonexistent_room_affiliation,
      user_moderator_set_user_role,
      user_participant_set_user_role,
+     user_try_set_nonexistent_room_role,
      user_can_enter_room,
      user_can_enter_room_with_password,
      user_can_exit_room,
      user_list_room_affiliation,
-     user_try_list_room_affiliation_without_permission
+     user_try_list_room_affiliation_without_permission,
+     user_try_list_nonexistent_room_affiliations
     ].
 
 admin_muc_handler() ->
@@ -895,6 +898,14 @@ user_member_set_user_affiliation(Config, Alice, Bob, Kate) ->
     Res3 = execute_user(set_user_affiliation_body(RoomJID, Kate, none), Bob, Config),
     assert_no_permission(Res3).
 
+user_try_set_nonexistent_room_affiliation(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_try_set_nonexistent_room_affiliation/2).
+
+user_try_set_nonexistent_room_affiliation(Config, Alice) ->
+    Res = execute_user(set_user_affiliation_body(?NONEXISTENT_ROOM, Alice, none), Alice, Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
 user_moderator_set_user_role(Config) ->
     muc_helper:story_with_room(Config, [{anonymous, false}, {persistent, true}],
                                [{alice, 1}, {bob, 1}],
@@ -939,6 +950,14 @@ user_participant_set_user_role(Config, _Alice, Bob, Kate) ->
     % Try change from participant to moderator 
     Res2 = execute_user(set_user_role_body(RoomJID, KateNick, moderator), Bob, Config),
     assert_no_permission(Res2).
+
+user_try_set_nonexistent_room_role(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_try_set_nonexistent_room_role/2).
+
+user_try_set_nonexistent_room_role(Config, Alice) ->
+    Res = execute_user(set_user_role_body(?NONEXISTENT_ROOM, <<"Ali">>, participant), Alice, Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 user_can_enter_room(Config) ->
     muc_helper:story_with_room(Config, [], [{alice, 1}], fun user_can_enter_room/2).
@@ -1022,6 +1041,14 @@ user_try_list_room_users_without_permission(Config, _Alice, Bob) ->
     RoomJID = jid:from_binary(?config(room_jid, Config)),
     Res = execute_user(list_room_affiliations_body(RoomJID, null), Bob, Config),
     assert_no_permission(Res).
+
+user_try_list_nonexistent_room_affiliations(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_try_list_nonexistent_room_affiliations/2).
+
+user_try_list_nonexistent_room_affiliations(Config, Alice) ->
+    Res = execute_user(list_room_affiliations_body(?NONEXISTENT_ROOM, null), Alice, Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 %% Helpers
 

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -4,7 +4,7 @@
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
 -import(graphql_helper, [execute_user/3, execute_auth/2, get_ok_value/2, get_err_msg/1,
-                         user_to_bin/1, user_to_full_bin/1]).
+                         user_to_bin/1, user_to_full_bin/1, user_to_jid/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
@@ -40,10 +40,22 @@ user_muc_handler() ->
      user_kick_user,
      user_send_message_to_room,
      user_send_message_to_room_with_specified_res,
+     user_send_private_message,
      user_without_session_send_message_to_room,
      user_get_room_messages,
      user_try_get_nonexistent_room_messages,
-     user_try_get_room_messages_without_permission].
+     user_try_get_room_messages_without_permission,
+     user_owner_set_user_affiliation,
+     user_admin_set_user_affiliation,
+     user_member_set_user_affiliation,
+     user_moderator_set_user_role,
+     user_participant_set_user_role,
+     user_can_enter_room,
+     user_can_enter_room_with_password,
+     user_can_exit_room,
+     user_list_room_affiliation,
+     user_try_list_room_affiliation_without_permission
+    ].
 
 admin_muc_handler() ->
     [admin_create_and_delete_room,
@@ -59,11 +71,23 @@ admin_muc_handler() ->
      admin_get_room_config,
      admin_try_get_nonexistent_room_config,
      admin_invite_user,
+     admin_invite_user_with_password,
      admin_try_invite_user_to_nonexistent_room,
      admin_kick_user,
      admin_send_message_to_room,
+     admin_send_private_message,
      admin_get_room_messages,
-     admin_try_get_nonexistent_room_messages].
+     admin_try_get_nonexistent_room_messages,
+     admin_set_user_affiliation,
+     admin_try_set_nonexistent_room_user_affiliation,
+     admin_set_user_role,
+     admin_try_set_nonexistent_room_user_role,
+     admin_make_user_enter_room,
+     admin_make_user_enter_room_with_password,
+     admin_make_user_exit_room,
+     admin_list_room_affiliation,
+     admin_try_list_nonexistent_room_affiliation
+    ].
 
 init_per_suite(Config) ->
     HostType = domain_helper:host_type(),
@@ -104,13 +128,20 @@ end_per_testcase(TC, Config) ->
 -define(KICK_USER_PATH, [data, muc, kickUser]).
 -define(DELETE_ROOM_PATH, [data, muc, deleteRoom]).
 -define(SEND_MESSAGE_PATH, [data, muc, sendMessageToRoom]).
+-define(SEND_PRIV_MESG_PATH, [data, muc, sendPrivateMessage]).
 -define(GET_MESSAGES_PATH, [data, muc, getRoomMessages]).
 -define(LIST_ROOM_USERS_PATH, [data, muc, listRoomUsers]).
+-define(LIST_ROOM_AFFILIATIONS_PATH, [data, muc, listRoomAffiliations]).
 -define(CHANGE_ROOM_CONFIG_PATH, [data, muc, changeRoomConfiguration]).
 -define(GET_ROOM_CONFIG_PATH, [data, muc, getRoomConfig]).
+-define(SET_AFFILIATION_PATH, [data, muc, setUserAffiliation]).
+-define(SET_ROLE_PATH, [data, muc, setUserRole]).
+-define(ENTER_ROOM_PATH, [data, muc, enterRoom]).
+-define(EXIT_ROOM_PATH, [data, muc, exitRoom]).
 
 -define(NONEXISTENT_ROOM, <<"room@room">>).
 -define(NONEXISTENT_ROOM2, <<"room@", (muc_helper:muc_host())/binary>>).
+-define(PASSWORD, <<"pa5sw0rd">>).
 
 admin_list_rooms(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun admin_list_rooms_story/3).
@@ -185,7 +216,23 @@ admin_invite_user_story(Config, Alice, Bob) ->
     Stanza = escalus:wait_for_stanza(Bob),
     escalus:assert(is_message, Stanza),
     ?assertEqual(RoomJIDBin,
-                 exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"jid">>}])).
+                 exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"jid">>}])),
+    ?assertEqual(undefined, exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"password">>}])).
+
+admin_invite_user_with_password(Config) ->
+    muc_helper:story_with_room(Config, [{password_protected, true}, {password, ?PASSWORD}],
+                               [{alice, 1}, {bob, 1}], fun admin_invite_user_with_password/3).
+
+admin_invite_user_with_password(Config, Alice, Bob) ->
+    RoomJIDBin = ?config(room_jid, Config),
+    RoomJID = jid:from_binary(RoomJIDBin),
+    Res = execute_auth(admin_invite_user_body(RoomJID, Alice, Bob, null), Config),
+    assert_success(?INVITE_USER_PATH, Res),
+    Stanza = escalus:wait_for_stanza(Bob),
+    escalus:assert(is_message, Stanza),
+    ?assertEqual(RoomJIDBin,
+                 exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"jid">>}])),
+    ?assertEqual(?PASSWORD, exml_query:path(Stanza, [{element, <<"x">>}, {attr, <<"password">>}])).
 
 admin_try_invite_user_to_nonexistent_room(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -230,6 +277,24 @@ admin_send_message_to_room_story(Config, _Alice, Bob) ->
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?SEND_MESSAGE_PATH, Res),
                                           <<"successfully">>)),
     assert_is_message_correct(RoomJID, BobNick, <<"groupchat">>, Message,
+                              escalus:wait_for_stanza(Bob)).
+
+admin_send_private_message(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_send_private_message/3).
+
+admin_send_private_message(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Message = <<"Hello Bob!">>,
+    BobNick = <<"Bobek">>,
+    AliceNick = <<"Ali">>,
+    enter_room(RoomJID, Alice, AliceNick),
+    enter_room(RoomJID, Bob, BobNick),
+    escalus:wait_for_stanzas(Bob, 2),
+    % Send message
+    Res = execute_auth(admin_send_private_message_body(RoomJID, Alice, BobNick, Message), Config),
+    assert_success(?SEND_PRIV_MESG_PATH, Res),
+    assert_is_message_correct(RoomJID, AliceNick, <<"chat">>, Message,
                               escalus:wait_for_stanza(Bob)).
 
 admin_get_room_config(Config) ->
@@ -301,6 +366,144 @@ admin_get_room_messages_story(Config, Alice, Bob) ->
 
 admin_try_get_nonexistent_room_messages(Config) ->
     Res = execute_auth(get_room_messages_body(?NONEXISTENT_ROOM, null, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+
+admin_set_user_affiliation(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_set_user_affiliation/3).
+
+admin_set_user_affiliation(Config, _Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    % Grant member affiliation
+    Res = execute_auth(set_user_affiliation_body(RoomJID, Bob, member), Config),
+    assert_success(?SET_AFFILIATION_PATH, Res),
+    assert_user_affiliation(RoomJID, Bob, member),
+    % Grant admin affiliation
+    Res1 = execute_auth(set_user_affiliation_body(RoomJID, Bob, admin), Config),
+    assert_success(?SET_AFFILIATION_PATH, Res1),
+    assert_user_affiliation(RoomJID, Bob, admin),
+    % Grant owner affiliation
+    Res2 = execute_auth(set_user_affiliation_body(RoomJID, Bob, owner), Config),
+    assert_success(?SET_AFFILIATION_PATH, Res2),
+    assert_user_affiliation(RoomJID, Bob, owner),
+    % Revoke affiliation
+    Res3 = execute_auth(set_user_affiliation_body(RoomJID, Bob, none), Config),
+    assert_success(?SET_AFFILIATION_PATH, Res3),
+    assert_user_affiliation(RoomJID, Bob, none),
+    % Ban user
+    Res4 = execute_auth(set_user_affiliation_body(RoomJID, Bob, outcast), Config),
+    assert_success(?SET_AFFILIATION_PATH, Res4),
+    assert_user_affiliation(RoomJID, Bob, outcast).
+
+
+admin_try_set_nonexistent_room_user_affiliation(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_try_set_nonexistent_room_user_affiliation/2).
+
+admin_try_set_nonexistent_room_user_affiliation(Config, Alice) ->
+    Res = execute_auth(set_user_affiliation_body(?NONEXISTENT_ROOM, Alice, admin), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_set_user_role(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}], fun admin_set_user_role/3).
+
+admin_set_user_role(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Boobek">>,
+    enter_room(RoomJID, Alice, escalus_client:username(Alice)),
+    enter_room(RoomJID, Bob, BobNick),
+    % Change from participant to visitor
+    Res = execute_auth(set_user_role_body(RoomJID, BobNick, visitor), Config),
+    assert_success(?SET_ROLE_PATH, Res),
+    assert_user_role(RoomJID, Bob, visitor),
+    % Change from visitor to participant
+    Res1 = execute_auth(set_user_role_body(RoomJID, BobNick, participant), Config),
+    assert_success(?SET_ROLE_PATH, Res1),
+    assert_user_role(RoomJID, Bob, participant),
+    % Change from participant to moderator
+    Res2 = execute_auth(set_user_role_body(RoomJID, BobNick, moderator), Config),
+    assert_success(?SET_ROLE_PATH, Res2),
+    assert_user_role(RoomJID, Bob, moderator).
+
+admin_try_set_nonexistent_room_user_role(Config) ->
+    Res = execute_auth(set_user_role_body(?NONEXISTENT_ROOM, <<"Alice">>, moderator), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_make_user_enter_room(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}], fun admin_make_user_enter_room/2).
+
+admin_make_user_enter_room(Config, Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Nick = <<"ali">>,
+    JID = jid:from_binary(escalus_client:full_jid(Alice)),
+    % Alice enter room with password
+    Res = execute_auth(admin_enter_room_body(RoomJID, Alice, Nick, null), Config),
+    assert_success(?ENTER_ROOM_PATH, Res),
+    ?assertMatch([#{nick := Nick, jid := JID}], get_room_users(RoomJID)).
+
+admin_make_user_enter_room_with_password(Config) ->
+    muc_helper:story_with_room(Config, [{password_protected, true}, {password, ?PASSWORD}],
+                               [{alice, 1}, {bob, 1}],
+                               fun admin_make_user_enter_room_with_password/3).
+
+admin_make_user_enter_room_with_password(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Nick = <<"ali">>,
+    JID = jid:from_binary(escalus_client:full_jid(Alice)),
+    % Alice enter room with password
+    Res = execute_auth(admin_enter_room_body(RoomJID, Alice, Nick, ?PASSWORD), Config),
+    assert_success(?ENTER_ROOM_PATH, Res),
+    ?assertMatch([#{nick := Nick, jid := JID}], get_room_users(RoomJID)),
+    % Bob try enter room without password 
+    Res1 = execute_auth(admin_enter_room_body(RoomJID, Bob, <<"Bobek">>, null), Config),
+    assert_success(?ENTER_ROOM_PATH, Res1),
+    ?assertMatch([_], get_room_users(RoomJID)),
+    % Bob enter room with password
+    Res2 = execute_auth(admin_enter_room_body(RoomJID, Bob, <<"Bobek">>, ?PASSWORD), Config),
+    assert_success(?ENTER_ROOM_PATH, Res2),
+    ?assertMatch([_, _], get_room_users(RoomJID)).
+
+admin_make_user_exit_room(Config) ->
+    muc_helper:story_with_room(Config, [{persistent, true}], [{alice, 1}],
+                               fun admin_make_user_exit_room/2).
+
+admin_make_user_exit_room(Config, Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Nick = <<"ali">>,
+    enter_room(RoomJID, Alice, Nick),
+    ?assertMatch([_], get_room_users(RoomJID)),
+    Res = execute_auth(admin_exit_room_body(RoomJID, Alice, Nick), Config),
+    assert_success(?EXIT_ROOM_PATH, Res),
+    ?assertMatch([], get_room_users(RoomJID)).
+
+admin_list_room_affiliation(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_list_room_affiliation/3).
+
+admin_list_room_affiliation(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Bobek">>,
+    AliceNick = <<"Ali">>,
+    enter_room(RoomJID, Bob, BobNick),
+    enter_room(RoomJID, Alice, AliceNick),
+    AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
+    BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
+    % List all owners
+    Res = execute_auth(list_room_affiliations_body(RoomJID, owner), Config),
+    ?assertMatch([#{<<"jid">> := AliceJID, <<"affiliation">> := <<"OWNER">>}],
+                 get_ok_value(?LIST_ROOM_AFFILIATIONS_PATH, Res)),
+    % List all members
+    execute_auth(set_user_affiliation_body(RoomJID, Bob, member), Config),
+    Res1 = execute_auth(list_room_affiliations_body(RoomJID, member), Config),
+    ?assertMatch([#{<<"jid">> := BobJID, <<"affiliation">> := <<"MEMBER">>}],
+                 get_ok_value(?LIST_ROOM_AFFILIATIONS_PATH, Res1)),
+    % List all
+    Res2 = execute_auth(list_room_affiliations_body(RoomJID, null), Config),
+    ?assertMatch([_, _], get_ok_value(?LIST_ROOM_AFFILIATIONS_PATH, Res2)).
+
+admin_try_list_nonexistent_room_affiliation(Config) ->
+    Res = execute_auth(list_room_affiliations_body(?NONEXISTENT_ROOM, null), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 %% User test cases
@@ -435,6 +638,44 @@ user_send_message_to_room_with_specified_res_story(Config, _Alice, Bob, Bob2) ->
                                           <<"successfully">>)),
     assert_is_message_correct(RoomJID, BobNick, <<"groupchat">>, Message,
                               escalus:wait_for_stanza(Bob2)).
+
+user_send_private_message(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun user_send_private_message/3).
+
+user_send_private_message(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Message = <<"Hello Bob!">>,
+    BobNick = <<"Bobek">>,
+    AliceNick = <<"Ali">>,
+    enter_room(RoomJID, Bob, BobNick),
+    enter_room(RoomJID, Alice, AliceNick),
+    escalus:wait_for_stanzas(Bob, 2),
+    % Send message
+    Res = execute_user(user_send_private_message_body(RoomJID, Message, BobNick, null),
+                       Alice, Config),
+    assert_success(?SEND_PRIV_MESG_PATH, Res),
+    assert_is_message_correct(RoomJID, AliceNick, <<"chat">>, Message,
+                              escalus:wait_for_stanza(Bob)).
+
+user_send_private_message_with_specified_res(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 2}, {bob, 1}],
+                               fun user_send_private_message/3).
+
+user_send_private_message_with_specified_res(Config, Alice, Alice2, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Message = <<"Hello Bob!">>,
+    BobNick = <<"Bobek">>,
+    AliceNick = <<"Ali">>,
+    enter_room(RoomJID, Bob, BobNick),
+    enter_room(RoomJID, Alice2, AliceNick),
+    escalus:wait_for_stanzas(Bob, 2),
+    % Send message
+    Res = execute_user(user_send_private_message_body(RoomJID, Message, BobNick, <<"res2">>),
+                       Alice, Config),
+    assert_success(?SEND_PRIV_MESG_PATH, Res),
+    assert_is_message_correct(RoomJID, AliceNick, <<"chat">>, Message,
+                              escalus:wait_for_stanza(Bob)).
 
 user_without_session_send_message_to_room(Config) ->
     muc_helper:story_with_room(Config, [], [{alice, 1}],
@@ -580,7 +821,242 @@ user_try_get_room_messages_without_permission(Config, _Alice, Bob) ->
     Res = execute_user(get_room_messages_body(RoomJID, null, null), Bob, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not have permission">>)).
 
+user_owner_set_user_affiliation(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun user_owner_set_user_affiliation/3).
+
+user_owner_set_user_affiliation(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    % Grant a member affiliation 
+    Res = execute_user(set_user_affiliation_body(RoomJID, Bob, member), Alice, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res),
+    assert_user_affiliation(RoomJID, Bob, member),
+    % Grant a member affiliation 
+    Res1 = execute_user(set_user_affiliation_body(RoomJID, Bob, admin), Alice, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res1),
+    assert_user_affiliation(RoomJID, Bob, admin),
+    % Grant a owner affiliation
+    Res2 = execute_user(set_user_affiliation_body(RoomJID, Bob, owner), Alice, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res2),
+    assert_user_affiliation(RoomJID, Bob, owner),
+    % Revoke affiliation 
+    Res3 = execute_user(set_user_affiliation_body(RoomJID, Bob, none), Alice, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res3),
+    assert_user_affiliation(RoomJID, Bob, none),
+    % Ban user
+    Res4 = execute_user(set_user_affiliation_body(RoomJID, Bob, outcast), Alice, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res4),
+    assert_user_affiliation(RoomJID, Bob, outcast).
+
+
+user_admin_set_user_affiliation(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}, {kate, 1}],
+                               fun user_admin_set_user_affiliation/4).
+
+user_admin_set_user_affiliation(Config, Alice, Bob, Kate) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    execute_user(set_user_affiliation_body(RoomJID, Bob, admin), Alice, Config),
+    % Grant member affiliation
+    Res = execute_user(set_user_affiliation_body(RoomJID, Kate, member), Bob, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res),
+    assert_user_affiliation(RoomJID, Kate, member),
+    % Revoke affiliation
+    Res1 = execute_user(set_user_affiliation_body(RoomJID, Kate, none), Bob, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res1),
+    assert_user_affiliation(RoomJID, Kate, none),
+    % Admin cannot grant admin affiliation
+    Res2 = execute_user(set_user_affiliation_body(RoomJID, Kate, admin), Bob, Config),
+    assert_no_permission(Res2),
+    % Admin cannot grant owner affiliation
+    Res3 = execute_user(set_user_affiliation_body(RoomJID, Kate, owner), Bob, Config),
+    assert_no_permission(Res3),
+    % Admin can ban member
+    Res4 = execute_user(set_user_affiliation_body(RoomJID, Kate, outcast), Bob, Config),
+    assert_success(?SET_AFFILIATION_PATH, Res4),
+    assert_user_affiliation(RoomJID, Kate, outcast),
+    % Admin cannot ban owner
+    Res5 = execute_user(set_user_affiliation_body(RoomJID, Alice, outcast), Bob, Config),
+    assert_no_permission(Res5).
+
+user_member_set_user_affiliation(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}, {kate, 1}],
+                               fun user_member_set_user_affiliation/4).
+
+user_member_set_user_affiliation(Config, Alice, Bob, Kate) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    execute_user(set_user_affiliation_body(RoomJID, Bob, member), Alice, Config),
+    Res = execute_user(set_user_affiliation_body(RoomJID, Kate, member), Bob, Config),
+    assert_no_permission(Res),
+    Res1 = execute_user(set_user_affiliation_body(RoomJID, Kate, admin), Bob, Config),
+    assert_no_permission(Res1),
+    Res2 = execute_user(set_user_affiliation_body(RoomJID, Kate, owner), Bob, Config),
+    assert_no_permission(Res2),
+    execute_user(set_user_affiliation_body(RoomJID, Kate, member), Alice, Config),
+    Res3 = execute_user(set_user_affiliation_body(RoomJID, Kate, none), Bob, Config),
+    assert_no_permission(Res3).
+
+user_moderator_set_user_role(Config) ->
+    muc_helper:story_with_room(Config, [{anonymous, false}, {persistent, true}],
+                               [{alice, 1}, {bob, 1}],
+                               fun user_moderator_set_user_role/3).
+
+user_moderator_set_user_role(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Boobek">>,
+    enter_room(RoomJID, Alice, escalus_client:username(Alice)),
+    enter_room(RoomJID, Bob, BobNick),
+    % Change from participant to visitor 
+    Res = execute_user(set_user_role_body(RoomJID, BobNick, visitor), Alice, Config),
+    assert_success(?SET_ROLE_PATH, Res),
+    assert_user_role(RoomJID, Bob, visitor),
+    % Change from visitor to moderator 
+    Res1 = execute_user(set_user_role_body(RoomJID, BobNick, participant), Alice, Config),
+    assert_success(?SET_ROLE_PATH, Res1),
+    assert_user_role(RoomJID, Bob, participant),
+    % Change from participant to moderator 
+    Res2 = execute_user(set_user_role_body(RoomJID, BobNick, moderator), Alice, Config),
+    assert_success(?SET_ROLE_PATH, Res2),
+    assert_user_role(RoomJID, Bob, moderator).
+
+user_participant_set_user_role(Config) ->
+    muc_helper:story_with_room(Config, [{anonymous, false}, {persistent, true}],
+                               [{alice, 1}, {bob, 1}, {kate, 1}],
+                               fun user_participant_set_user_role/4).
+
+user_participant_set_user_role(Config, _Alice, Bob, Kate) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Boobek">>,
+    KateNick = <<"Katek">>,
+    enter_room(RoomJID, Bob, BobNick),
+    enter_room(RoomJID, Kate, KateNick),
+    % Try change from participant to visitor
+    Res = execute_user(set_user_role_body(RoomJID, KateNick, visitor), Bob, Config),
+    assert_no_permission(Res),
+    % Change from participant to participant with success response
+    Res1 = execute_user(set_user_role_body(RoomJID, KateNick, participant), Bob, Config),
+    assert_success(?SET_ROLE_PATH, Res1),
+    assert_user_role(RoomJID, Bob, participant),
+    % Try change from participant to moderator 
+    Res2 = execute_user(set_user_role_body(RoomJID, KateNick, moderator), Bob, Config),
+    assert_no_permission(Res2).
+
+user_can_enter_room(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}], fun user_can_enter_room/2).
+
+user_can_enter_room(Config, Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Nick = <<"ali">>,
+    JID = jid:from_binary(escalus_utils:jid_to_lower(escalus_client:full_jid(Alice))),
+    Resource = escalus_client:resource(Alice),
+    Res = execute_user(user_enter_room_body(RoomJID, Nick, Resource, null), Alice, Config),
+    assert_success(?ENTER_ROOM_PATH, Res),
+    ?assertMatch([#{nick := Nick, jid := JID}], get_room_users(RoomJID)).
+    
+user_can_enter_room_with_password(Config) ->
+    muc_helper:story_with_room(Config, [{password_protected, true}, {password, ?PASSWORD}],
+                               [{alice, 1}, {bob, 1}],
+                               fun user_can_enter_room_with_password/3).
+
+user_can_enter_room_with_password(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Nick = <<"ali">>,
+    JID = jid:from_binary(escalus_utils:jid_to_lower(escalus_client:full_jid(Alice))),
+    Resource = escalus_client:resource(Alice),
+    % Alice enter room with password
+    Res = execute_user(user_enter_room_body(RoomJID, Nick, Resource, ?PASSWORD), Alice, Config),
+    assert_success(?ENTER_ROOM_PATH, Res),
+    ?assertMatch([#{nick := Nick, jid := JID}], get_room_users(RoomJID)),
+    % Bob try enter room without password
+    Res1 = execute_user(user_enter_room_body(RoomJID, <<"Bobek">>, Resource, null), Bob, Config),
+    assert_success(?ENTER_ROOM_PATH, Res1),
+    ?assertMatch([_], get_room_users(RoomJID)),
+    % Bob enter room with password
+    Res2 = execute_user(user_enter_room_body(RoomJID, <<"Bobek">>, Resource, ?PASSWORD), Bob, Config),
+    assert_success(?ENTER_ROOM_PATH, Res2),
+    ?assertMatch([_, _], get_room_users(RoomJID)).
+
+user_can_exit_room(Config) ->
+    muc_helper:story_with_room(Config, [{persistent, true}], [{alice, 1}],
+                               fun user_can_exit_room/2).
+
+user_can_exit_room(Config, Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Nick = <<"ali">>,
+    Resource = escalus_client:resource(Alice),
+    enter_room(RoomJID, Alice, Nick),
+    ?assertMatch([_], get_room_users(RoomJID)),
+    Res = execute_user(user_exit_room_body(RoomJID, Nick, Resource), Alice, Config),
+    assert_success(?EXIT_ROOM_PATH, Res),
+    ?assertMatch([], get_room_users(RoomJID)).
+
+user_list_room_affiliation(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun user_list_room_affiliation/3).
+
+user_list_room_affiliation(Config, Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Bobek">>,
+    AliceNick = <<"Ali">>,
+    enter_room(RoomJID, Bob, BobNick),
+    enter_room(RoomJID, Alice, AliceNick),
+    AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
+    BobJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
+    % List all owners
+    Res = execute_user(list_room_affiliations_body(RoomJID, owner), Alice, Config),
+    ?assertMatch([#{<<"jid">> := AliceJID, <<"affiliation">> := <<"OWNER">>}],
+                 get_ok_value(?LIST_ROOM_AFFILIATIONS_PATH, Res)),
+    % List all members
+    execute_user(set_user_affiliation_body(RoomJID, Bob, member), Alice, Config),
+    Res1 = execute_user(list_room_affiliations_body(RoomJID, member), Alice, Config),
+    ?assertMatch([#{<<"jid">> := BobJID, <<"affiliation">> := <<"MEMBER">>}],
+                 get_ok_value(?LIST_ROOM_AFFILIATIONS_PATH, Res1)),
+    % List all
+    Res2 = execute_user(list_room_affiliations_body(RoomJID, null), Alice, Config),
+    ?assertMatch([_, _], get_ok_value(?LIST_ROOM_AFFILIATIONS_PATH, Res2)).
+
+user_try_list_room_affiliation_without_permission(Config) ->
+    muc_helper:story_with_room(Config, [{members_only, true}], [{alice, 1}, {bob, 1}],
+                               fun user_try_list_room_users_without_permission/3).
+
+user_try_list_room_users_without_permission(Config, _Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    Res = execute_user(list_room_affiliations_body(RoomJID, null), Bob, Config),
+    assert_no_permission(Res).
+
 %% Helpers
+
+assert_no_permission(Res) ->
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not have permission">>)).
+
+assert_success(Path, Res) ->
+    ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Res), <<"successfully">>)).
+
+get_room_affiliation(RoomJID, Aff) ->
+    {ok, Affs} = rpc(mim(), mod_muc_api, get_room_affiliation, [RoomJID, Aff]),
+    Affs.
+
+get_room_users(RoomJID) ->
+    {ok, Users} = rpc(mim(), mod_muc_api, get_room_users, [RoomJID]),
+    Users.
+
+assert_user_role(RoomJID, User, none) ->
+    UserJID = jid:from_binary(escalus_client:full_jid(User)),
+    ?assertNot(lists:any(fun(#{jid := JID}) -> jid:are_bare_equal(JID, UserJID) end,
+                         get_room_users(RoomJID)));
+assert_user_role(RoomJID, User, Role) ->
+    UserJID = jid:from_binary(escalus_client:full_jid(User)),
+    ?assert(lists:any(fun(#{jid := JID, role := Role2}) ->
+                              Role =:= Role2 andalso jid:are_bare_equal(JID, UserJID) end,
+                      get_room_users(RoomJID))).
+
+assert_user_affiliation(RoomJID, User, none) ->
+    Affs = get_room_affiliation(RoomJID, undefined),
+    UserSimpleJID = jid:to_lower(user_to_jid(User)),
+    ?assertNot(lists:any(fun({U, _}) -> U == UserSimpleJID end, Affs));
+assert_user_affiliation(RoomJID, User, Aff) ->
+    Affs = get_room_affiliation(RoomJID, Aff),
+    Elem = {jid:to_lower(user_to_jid(User)), Aff},
+    ?assert(lists:member(Elem, Affs)).
 
 rand_name() ->
     rpc(mim(), mongoose_bin, gen_from_crypto, []).
@@ -632,6 +1108,9 @@ assert_default_room_config(Response) ->
                    <<"maxUsers">> := 200,
                    <<"logging">> := false}, get_ok_value(?GET_ROOM_CONFIG_PATH, Response)).
 
+atom_to_enum_item(null) -> null;
+atom_to_enum_item(Atom) -> list_to_binary(string:to_upper(atom_to_list(Atom))).
+
 %% Request bodies
 
 admin_create_instant_room_body(MUCDomain, Name, Owner, Nick) ->
@@ -662,6 +1141,29 @@ admin_send_message_to_room_body(Room, From, Body) ->
               { muc { sendMessageToRoom(room: $room, from: $from, body: $body) } }">>,
     OpName = <<"M1">>,
     Vars = #{room => jid:to_binary(Room), from => user_to_full_bin(From), body => Body},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_send_private_message_body(Room, From, ToNick, Body) ->
+    Query = <<"mutation M1($room: JID!, $from: JID!, $toNick: String!, $body: String!)
+              { muc { sendPrivateMessage(room: $room, from: $from, toNick: $toNick, body: $body) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), from => user_to_full_bin(From),
+             toNick => ToNick, body => Body},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+
+admin_enter_room_body(Room, User, Nick, Password) ->
+    Query = <<"mutation M1($room: JID!, $user: JID!, $nick: String! $password: String)
+               { muc { enterRoom(room: $room, user: $user, nick: $nick, password: $password) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), user => user_to_full_bin(User), nick => Nick, password => Password},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_exit_room_body(Room, User, Nick) ->
+    Query = <<"mutation M1($room: JID!, $user: JID!, $nick: String!)
+               { muc { exitRoom(room: $room, user: $user, nick: $nick) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), user => user_to_full_bin(User), nick => Nick},
     #{query => Query, operationName => OpName, variables => Vars}.
 
 delete_room_body(Room, Reason) ->
@@ -733,6 +1235,14 @@ user_send_message_to_room_body(Room, Body, Resource) ->
     Vars = #{room => jid:to_binary(Room), body => Body, resource => Resource},
     #{query => Query, operationName => OpName, variables => Vars}.
 
+user_send_private_message_body(Room, Body, ToNick, Resource) ->
+    Query = <<"mutation M1($room: JID!, $body: String!, $toNick: String!, $resource: String)
+              { muc { sendPrivateMessage(room: $room, body: $body, toNick: $toNick, resource: $resource) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), body => Body, toNick => ToNick, resource => Resource},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+
 user_create_instant_room_body(MUCDomain, Name, Nick) ->
     Query = <<"mutation M1($mucDomain: String!, $name: String!, $nick: String!)
               { muc { createInstantRoom(mucDomain: $mucDomain, name: $name, nick: $nick)
@@ -746,4 +1256,42 @@ user_invite_user_body(Room, Recipient, Reason) ->
               { muc { inviteUser(room: $room, recipient: $recipient, reason: $reason) } }">>,
     OpName = <<"M1">>,
     Vars = #{room => jid:to_binary(Room), recipient => user_to_bin(Recipient), reason => Reason},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+set_user_affiliation_body(Room, User, Aff) ->
+    Query = <<"mutation M1($room: JID!, $user: JID!, $affiliation: MUCAffiliation!)
+               { muc { setUserAffiliation(room: $room, user: $user, affiliation: $affiliation) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), user => user_to_bin(User),
+             affiliation => atom_to_enum_item(Aff)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+set_user_role_body(Room, User, Role) ->
+    Query = <<"mutation M1($room: JID!, $nick: String!, $role: MUCRole!)
+               { muc { setUserRole(room: $room, nick: $nick, role: $role) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), nick => user_to_bin(User),
+             role => atom_to_enum_item(Role)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_enter_room_body(Room, Nick, Resource, Password) ->
+    Query = <<"mutation M1($room: JID!, $nick: String!, $resource: String!, $password: String)
+               { muc { enterRoom(room: $room, nick: $nick, resource: $resource, password: $password) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), resource => Resource, password => Password, nick => Nick},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_exit_room_body(Room, Nick, Resource) ->
+    Query = <<"mutation M1($room: JID!, $nick: String!, $resource: String!)
+               { muc { exitRoom(room: $room, nick: $nick, resource: $resource) } }">>,
+    OpName = <<"M1">>,
+    Vars = #{room => jid:to_binary(Room), resource => Resource, nick => Nick},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+list_room_affiliations_body(Room, Aff) ->
+    Query = <<"query Q1($room: JID!, $affiliation: MUCAffiliation)
+               { muc { listRoomAffiliations(room: $room, affiliation: $affiliation)
+               { jid affiliation } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{room => jid:to_binary(Room), affiliation => atom_to_enum_item(Aff)},
     #{query => Query, operationName => OpName, variables => Vars}.

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -87,6 +87,7 @@ admin_muc_handler() ->
      admin_try_set_nonexistent_room_user_affiliation,
      admin_set_user_role,
      admin_try_set_nonexistent_room_user_role,
+     admin_try_set_user_role_in_room_without_moderators,
      admin_make_user_enter_room,
      admin_make_user_enter_room_with_password,
      admin_make_user_enter_room_bare_jid,
@@ -451,6 +452,16 @@ admin_set_user_role(Config, Alice, Bob) ->
     Res2 = execute_auth(set_user_role_body(RoomJID, BobNick, moderator), Config),
     assert_success(?SET_ROLE_PATH, Res2),
     assert_user_role(RoomJID, Bob, moderator).
+
+admin_try_set_user_role_in_room_without_moderators(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}], fun admin_try_set_user_role_in_room_without_moderators/3).
+
+admin_try_set_user_role_in_room_without_moderators(Config, _Alice, Bob) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    BobNick = <<"Boobek">>,
+    enter_room(RoomJID, Bob, BobNick),
+    Res = execute_auth(set_user_role_body(RoomJID, BobNick, visitor), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_try_set_nonexistent_room_user_role(Config) ->
     Res = execute_auth(set_user_role_body(?NONEXISTENT_ROOM, <<"Alice">>, moderator), Config),

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -89,6 +89,7 @@ admin_muc_handler() ->
      admin_try_set_nonexistent_room_user_affiliation,
      admin_set_user_role,
      admin_try_set_nonexistent_room_user_role,
+     admin_try_set_nonexistent_nick_role,
      admin_try_set_user_role_in_room_without_moderators,
      admin_make_user_enter_room,
      admin_make_user_enter_room_with_password,
@@ -458,6 +459,15 @@ admin_set_user_role(Config, Alice, Bob) ->
     Res2 = execute_auth(set_user_role_body(RoomJID, BobNick, moderator), Config),
     assert_success(?SET_ROLE_PATH, Res2),
     assert_user_role(RoomJID, Bob, moderator).
+
+admin_try_set_nonexistent_nick_role(Config) ->
+    muc_helper:story_with_room(Config, [], [{alice, 1}], fun admin_try_set_nonexistent_nick_role/2).
+
+admin_try_set_nonexistent_nick_role(Config, Alice) ->
+    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    enter_room(RoomJID, Alice, escalus_client:username(Alice)),
+    Res = execute_auth(set_user_role_body(RoomJID, <<"kik">>, visitor), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
 
 admin_try_set_user_role_in_room_without_moderators(Config) ->
     muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -38,6 +38,7 @@ user_muc_handler() ->
      user_try_get_nonexistent_room_config,
      user_invite_user,
      user_kick_user,
+     user_try_kick_user_from_nonexistent_room,
      user_try_kick_user_without_moderator_resource,
      user_send_message_to_room,
      user_send_message_to_room_with_specified_res,
@@ -78,6 +79,7 @@ admin_muc_handler() ->
      admin_invite_user_with_password,
      admin_try_invite_user_to_nonexistent_room,
      admin_kick_user,
+     admin_try_kick_user_from_nonexistent_room,
      admin_try_kick_user_in_room_without_moderators,
      admin_send_message_to_room,
      admin_send_private_message,
@@ -281,6 +283,10 @@ admin_try_kick_user_in_room_without_moderators(Config, _Alice, Bob) ->
     Res = execute_auth(kick_user_body(RoomJID, BobNick, null), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
+admin_try_kick_user_from_nonexistent_room(Config) ->
+    Res = execute_auth(kick_user_body(?NONEXISTENT_ROOM, <<"ali">>, null), Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
 admin_send_message_to_room(Config) ->
     muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
                                fun admin_send_message_to_room_story/3).
@@ -454,7 +460,8 @@ admin_set_user_role(Config, Alice, Bob) ->
     assert_user_role(RoomJID, Bob, moderator).
 
 admin_try_set_user_role_in_room_without_moderators(Config) ->
-    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}], fun admin_try_set_user_role_in_room_without_moderators/3).
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun admin_try_set_user_role_in_room_without_moderators/3).
 
 admin_try_set_user_role_in_room_without_moderators(Config, _Alice, Bob) ->
     RoomJID = jid:from_binary(?config(room_jid, Config)),
@@ -663,7 +670,8 @@ user_kick_user_story(Config, Alice, Bob) ->
                                               {element, <<"reason">>}, cdata])).
 
 user_try_kick_user_without_moderator_resource(Config) ->
-    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}], fun user_try_kick_user_without_moderator_resource/3).
+    muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
+                               fun user_try_kick_user_without_moderator_resource/3).
 
 user_try_kick_user_without_moderator_resource(Config, Alice, Bob) ->
     RoomJIDBin = ?config(room_jid, Config),
@@ -671,6 +679,14 @@ user_try_kick_user_without_moderator_resource(Config, Alice, Bob) ->
     BobNick = <<"Bobek">>,
     enter_room(RoomJID, Bob, BobNick),
     Res = execute_user(kick_user_body(RoomJID, BobNick, null), Alice, Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+user_try_kick_user_from_nonexistent_room(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_try_kick_user_from_nonexistent_room/2).
+
+user_try_kick_user_from_nonexistent_room(Config, Alice) ->
+    Res = execute_user(kick_user_body(?NONEXISTENT_ROOM, <<"bobi">>, null), Alice, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 user_send_message_to_room(Config) ->

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -80,7 +80,7 @@ admin_muc_handler() ->
      admin_try_invite_user_to_nonexistent_room,
      admin_kick_user,
      admin_try_kick_user_from_nonexistent_room,
-     admin_try_kick_user_in_room_without_moderators,
+     admin_try_kick_user_from_room_without_moderators,
      admin_send_message_to_room,
      admin_send_private_message,
      admin_get_room_messages,
@@ -273,11 +273,11 @@ admin_kick_user_story(Config, Alice, Bob) ->
                  exml_query:path(KickStanza, [{element, <<"x">>}, {element, <<"item">>},
                                               {element, <<"reason">>}, cdata])).
 
-admin_try_kick_user_in_room_without_moderators(Config) ->
+admin_try_kick_user_from_room_without_moderators(Config) ->
     muc_helper:story_with_room(Config, [], [{alice, 1}, {bob, 1}],
-                               fun admin_try_kick_user_in_room_without_moderators/3).
+                               fun admin_try_kick_user_from_room_without_moderators/3).
 
-admin_try_kick_user_in_room_without_moderators(Config, _Alice, Bob) ->
+admin_try_kick_user_from_room_without_moderators(Config, _Alice, Bob) ->
     RoomJID = jid:from_binary(?config(room_jid, Config)),
     BobNick = <<"Bobek">>,
     enter_room(RoomJID, Bob, BobNick),

--- a/big_tests/tests/muc_http_api_SUITE.erl
+++ b/big_tests/tests/muc_http_api_SUITE.erl
@@ -126,7 +126,7 @@ invite_online_user_to_room(Config) ->
         Body = #{sender => escalus_client:short_jid(Alice),
                  recipient => escalus_client:short_jid(Bob),
                  reason => Reason},
-        {{<<"404">>, _}, <<"room does not exist">>} = rest_helper:post(admin, Path, Body),
+        {{<<"404">>, _}, <<"Room not found">>} = rest_helper:post(admin, Path, Body),
         set_up_room(Config, Alice),
         {{<<"204">>, _}, <<"">>} = rest_helper:post(admin, Path, Body),
         Stanza = escalus:wait_for_stanza(Bob),
@@ -280,7 +280,7 @@ failed_invites(Config) ->
         BAlice = escalus_client:short_jid(Alice),
         BBob = escalus_client:short_jid(Bob),
         % non-existing room
-        {{<<"404">>, _}, <<"room does not exist">>} = send_invite(<<"thisroomdoesnotexist">>, BAlice, BBob),
+        {{<<"404">>, _}, <<"Room not found">>} = send_invite(<<"thisroomdoesnotexist">>, BAlice, BBob),
         % invite with bad jid
         {{<<"400">>, _}, <<"Invalid jid:", _/binary>>} = send_invite(Name, BAlice, <<"@badjid">>),
         {{<<"400">>, _}, <<"Invalid jid:", _/binary>>} = send_invite(Name, <<"@badjid">>, BBob),
@@ -293,7 +293,7 @@ failed_messages(Config) ->
         % non-existing room
         BAlice = escalus_client:short_jid(Alice),
         BBob = escalus_client:short_jid(Bob),
-        {{<<"404">>, _}, <<"room does not exist">>} = send_invite(<<"thisroomdoesnotexist">>, BAlice, BBob),
+        {{<<"404">>, _}, <<"Room not found">>} = send_invite(<<"thisroomdoesnotexist">>, BAlice, BBob),
         % invite with bad jid
         {{<<"400">>, _}, <<"Invalid jid:", _/binary>>} = send_invite(Name, BAlice, <<"@badjid">>),
         {{<<"400">>, _}, <<"Invalid jid:", _/binary>>} = send_invite(Name, <<"@badjid">>, BBob),

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -8,12 +8,22 @@ type MUCAdminMutation @protected{
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
   "Kick a user from a MUC room"
   kickUser(room: JID!, nick: String!, reason: String): String
-  "Send a message to a MUC room"
+  "Send a message to a MUC room, from with res"
   sendMessageToRoom(room: JID!, from: JID!, body: String!): String
+  "Send a private message to a MUC room user, from with res"
+  sendPrivateMessage(room: JID!, from: JID!, toNick: String!, body: String!): String
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String
   "Change configuration of a MUC room"
   changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+  "Change a user role"
+  setUserRole(room: JID!, nick: String!, role: MUCRole!): String
+  "Change a user affiliation"
+  setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
+  "Make a user enter the room with given nick"
+  enterRoom(room: JID!, user: JID!, nick: String!, password: String): String
+  "Make a user with the given nick exit the room"
+  exitRoom(room: JID!, user: JID!, nick: String!): String
 }
 
 """
@@ -26,6 +36,8 @@ type MUCAdminQuery @protected{
   getRoomConfig(room: JID!): MUCRoomConfig
   "Get users list of given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
+  "Get affiliations list of given MUC room"
+  listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
 }

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -34,9 +34,9 @@ type MUCAdminQuery @protected{
   listRooms(mucDomain: String!, from: JID, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig
-  "Get users list of given MUC room"
+  "Get the user list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
-  "Get affiliations list of given MUC room"
+  "Get the affiliation list of given MUC room"
   listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -8,10 +8,10 @@ type MUCAdminMutation @protected{
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
   "Kick a user from a MUC room"
   kickUser(room: JID!, nick: String!, reason: String): String
-  "Send a message to a MUC room, from with res"
-  sendMessageToRoom(room: JID!, from: JID!, body: String!): String
-  "Send a private message to a MUC room user, from with res"
-  sendPrivateMessage(room: JID!, from: JID!, toNick: String!, body: String!): String
+  "Send a message to a MUC room"
+  sendMessageToRoom(room: JID!, from: FullJID!, body: String!): String
+  "Send a private message to a MUC room user"
+  sendPrivateMessage(room: JID!, from: FullJID!, toNick: String!, body: String!): String
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String
   "Change configuration of a MUC room"
@@ -20,10 +20,10 @@ type MUCAdminMutation @protected{
   setUserRole(room: JID!, nick: String!, role: MUCRole!): String
   "Change a user affiliation"
   setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
-  "Make a user enter the room with given nick"
-  enterRoom(room: JID!, user: JID!, nick: String!, password: String): String
+  "Make a user enter the room with a given nick"
+  enterRoom(room: JID!, user: FullJID!, nick: String!, password: String): String
   "Make a user with the given nick exit the room"
-  exitRoom(room: JID!, user: JID!, nick: String!): String
+  exitRoom(room: JID!, user: FullJID!, nick: String!): String
 }
 
 """

--- a/priv/graphql/schemas/global/muc.gql
+++ b/priv/graphql/schemas/global/muc.gql
@@ -1,5 +1,12 @@
-enum MUCRoomRole{
+enum MUCAffiliation{
+  OWNER
+  ADMIN
+  MEMBER
+  OUTCAST
   NONE
+}
+
+enum MUCRole{
   VISITOR
   PARTICIPANT
   MODERATOR
@@ -8,7 +15,12 @@ enum MUCRoomRole{
 type MUCRoomUser{
   jid: JID
   nick: String!
-  role: MUCRoomRole!
+  role: MUCRole!
+}
+
+type MUCRoomAffiliation{
+  jid: JID!
+  affiliation: MUCAffiliation!
 }
 
 type MUCRoomDesc{

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -1,4 +1,6 @@
 scalar DateTime
 scalar Stanza
 scalar JID
+"The JID with resource e.g. alice@localhost/res1"
+scalar FullJID
 scalar NonEmptyString

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -10,10 +10,20 @@ type MUCUserMutation @protected{
   kickUser(room: JID!, nick: String!, reason: String): String
   "Send a message to a MUC room"
   sendMessageToRoom(room: JID!, body: String!, resource: String): String
+  "Send a private message to a MUC room user, from with res"
+  sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: String): String
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String
   "Change configuration of a MUC room"
   changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+  "Change a user role"
+  setUserRole(room: JID!, nick: String!, role: MUCRole!): String
+  "Change a user affiliation"
+  setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
+  "Enter the room with given resource and nick"
+  enterRoom(room: JID!, nick: String!, resource: String!, password: String): String
+  "Exit the room with given resource and nick"
+  exitRoom(room: JID!, nick: String!, resource: String!): String
 }
 
 """
@@ -24,8 +34,10 @@ type MUCUserQuery @protected{
   listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig
-  "Get user list of a given MUC room"
+  "Get users list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
+  "Get affiliations list of given MUC room"
+  listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
 }

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -34,7 +34,7 @@ type MUCUserQuery @protected{
   listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig
-  "Get users list of a given MUC room"
+  "Get the user list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
   "Get the affiliation list of given MUC room"
   listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -10,7 +10,7 @@ type MUCUserMutation @protected{
   kickUser(room: JID!, nick: String!, reason: String): String
   "Send a message to a MUC room"
   sendMessageToRoom(room: JID!, body: String!, resource: String): String
-  "Send a private message to a MUC room user, from with res"
+  "Send a private message to a MUC room user from the given resource"
   sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: String): String
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String
@@ -36,7 +36,7 @@ type MUCUserQuery @protected{
   getRoomConfig(room: JID!): MUCRoomConfig
   "Get users list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
-  "Get affiliations list of given MUC room"
+  "Get the affiliation list of given MUC room"
   listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload

--- a/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
@@ -7,7 +7,8 @@
 
 -include("../mongoose_graphql_types.hrl").
 
--import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2,
+                                  null_to_undefined/1]).
 
 execute(_Ctx, _Obj, <<"createInstantRoom">>, Args) ->
     create_instant_room(Args);
@@ -17,10 +18,20 @@ execute(_Ctx, _Obj, <<"kickUser">>, Args) ->
     kick_user(Args);
 execute(_Ctx, _Obj, <<"sendMessageToRoom">>, Args) ->
     send_message_to_room(Args);
+execute(_Ctx, _Obj, <<"sendPrivateMessage">>, Args) ->
+    send_private_message(Args);
 execute(_Ctx, _Obj, <<"changeRoomConfiguration">>, Args) ->
     change_room_config(Args);
 execute(_Ctx, _Obj, <<"deleteRoom">>, Args) ->
-    delete_room(Args).
+    delete_room(Args);
+execute(_Ctx, _Obj, <<"setUserRole">>, Args) ->
+    set_user_role(Args);
+execute(_Ctx, _Obj, <<"setUserAffiliation">>, Args) ->
+    set_user_affiliation(Args);
+execute(_Ctx, _Obj, <<"enterRoom">>, Args) ->
+    enter_room(Args);
+execute(_Ctx, _Obj, <<"exitRoom">>, Args) ->
+    exit_room(Args).
 
 -spec create_instant_room(map()) -> {ok, map()} | {error, resolver_error()}.
 create_instant_room(#{<<"mucDomain">> := MUCDomain, <<"name">> := Name,
@@ -53,6 +64,13 @@ send_message_to_room(#{<<"room">> := RoomJID, <<"from">> := SenderJID, <<"body">
     format_result(Res, #{room => jid:to_binary(RoomJID),
                          from => jid:to_binary(SenderJID)}).
 
+-spec send_private_message(map()) -> {ok, binary()} | {error, resolver_error()}.
+send_private_message(#{<<"room">> := RoomJID, <<"from">> := SenderJID,
+                       <<"toNick">> := ToNick, <<"body">> := Message}) ->
+    Res = mod_muc_api:send_private_message(RoomJID, SenderJID, ToNick, Message),
+    format_result(Res, #{room => jid:to_binary(RoomJID),
+                         from => jid:to_binary(SenderJID)}).
+
 -spec change_room_config(map()) -> {ok, map()} | {error, resolver_error()}.
 change_room_config(#{<<"room">> := RoomJID, <<"config">> := ConfigInput}) ->
     Fun = fun(Config) -> mongoose_graphql_muc_helper:make_muc_room_config(ConfigInput, Config) end,
@@ -69,3 +87,27 @@ delete_room(#{<<"room">> := RoomJID, <<"reason">> := Reason}) ->
                               mongoose_graphql_muc_helper:default_room_removal_reason("admin")),
     Res = mod_muc_api:delete_room(RoomJID, Reason2),
     format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec set_user_role(map()) -> {ok, binary()} | {error, resolver_error()}.
+set_user_role(#{<<"room">> := RoomJID, <<"nick">> := Nick, <<"role">> := Role}) ->
+    Result = mod_muc_api:set_role(RoomJID, Nick, Role),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+-spec set_user_affiliation(map()) -> {ok, binary()} | {error, resolver_error()}.
+set_user_affiliation(#{<<"room">> := RoomJID, <<"user">> := UserJID, <<"affiliation">> := Aff}) ->
+    Result = mod_muc_api:set_affiliation(RoomJID, UserJID, Aff),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+-spec enter_room(map()) -> {ok, binary()} | {error, resolver_error()}.
+enter_room(#{<<"room">> := RoomJID, <<"user">> := UserJID, <<"nick">> := Nick,
+             <<"password">> := Password}) ->
+    RoomJIDRes = jid:replace_resource(RoomJID, Nick),
+    Password2 = null_to_undefined(Password),
+    Result = mod_muc_api:enter_room(RoomJIDRes, UserJID, Password2),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+-spec exit_room(map()) -> {ok, binary()} | {error, resolver_error()}.
+exit_room(#{<<"room">> := RoomJID, <<"user">> := UserJID, <<"nick">> := Nick}) ->
+    RoomJIDRes = jid:replace_resource(RoomJID, Nick),
+    Result = mod_muc_api:exit_room(RoomJIDRes, UserJID),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).

--- a/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
@@ -14,6 +14,8 @@ execute(_Ctx, _Obj, <<"listRooms">>, Args) ->
     list_rooms(Args);
 execute(_Ctx, _Obj, <<"listRoomUsers">>, Args) ->
     list_room_users(Args);
+execute(_Ctx, _Obj, <<"listRoomAffiliations">>, Args) ->
+    list_room_affiliations(Args);
 execute(_Ctx, _Obj, <<"getRoomMessages">>, Args) ->
     get_room_messages(Args);
 execute(_Ctx, _Obj, <<"getRoomConfig">>, Args) ->
@@ -32,6 +34,16 @@ list_room_users(#{<<"room">> := RoomJID}) ->
     case mod_muc_api:get_room_users(RoomJID) of
         {ok, Users} ->
             {ok, mongoose_graphql_muc_helper:format_users(Users)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec list_room_affiliations(map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
+list_room_affiliations(#{<<"room">> := RoomJID, <<"affiliation">> := Aff}) ->
+    Aff2 = null_to_undefined(Aff),
+    case mod_muc_api:get_room_affiliation(RoomJID, Aff2) of
+        {ok, Affs} ->
+            {ok, mongoose_graphql_muc_helper:format_affs(Affs)};
         Error ->
             make_error(Error, #{room => jid:to_binary(RoomJID)})
     end.

--- a/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
@@ -41,7 +41,7 @@ list_room_users(#{<<"room">> := RoomJID}) ->
 -spec list_room_affiliations(map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
 list_room_affiliations(#{<<"room">> := RoomJID, <<"affiliation">> := Aff}) ->
     Aff2 = null_to_undefined(Aff),
-    case mod_muc_api:get_room_affiliation(RoomJID, Aff2) of
+    case mod_muc_api:get_room_affiliations(RoomJID, Aff2) of
         {ok, Affs} ->
             {ok, mongoose_graphql_muc_helper:format_affs(Affs)};
         Error ->

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -23,10 +23,14 @@ input(<<"SubAction">>, <<"DECLINE">>) -> {ok, decline};
 input(<<"SubAction">>, <<"CANCEL">>) -> {ok, cancel};
 input(<<"MutualSubAction">>, <<"CONNECT">>) -> {ok, connect};
 input(<<"MutualSubAction">>, <<"DISCONNECT">>) -> {ok, disconnect};
-input(<<"MUCRoomRole">>, <<"NONE">>) -> {ok, none};
-input(<<"MUCRoomRole">>, <<"VISITOR">>) -> {ok, visitor};
-input(<<"MUCRoomRole">>, <<"PARTICIPANT">>) -> {ok, participant};
-input(<<"MUCRoomRole">>, <<"MODERATOR">>) -> {ok, moderator}.
+input(<<"MUCRole">>, <<"VISITOR">>) -> {ok, visitor};
+input(<<"MUCRole">>, <<"PARTICIPANT">>) -> {ok, participant};
+input(<<"MUCRole">>, <<"MODERATOR">>) -> {ok, moderator};
+input(<<"MUCAffiliation">>, <<"NONE">>) -> {ok, none};
+input(<<"MUCAffiliation">>, <<"MEMBER">>) -> {ok, member};
+input(<<"MUCAffiliation">>, <<"OUTCAST">>) -> {ok, outcast};
+input(<<"MUCAffiliation">>, <<"ADMIN">>) -> {ok, admin};
+input(<<"MUCAffiliation">>, <<"OWNER">>) -> {ok, owner}.
 
 output(<<"PresenceShow">>, Show) ->
     {ok, list_to_binary(string:to_upper(binary_to_list(Show)))};
@@ -52,5 +56,7 @@ output(<<"ContactAsk">>, Type) when Type =:= subscrube;
                                     Type =:= both;
                                     Type =:= none ->
     {ok, list_to_binary(string:to_upper(atom_to_list(Type)))};
-output(<<"MUCRoomRole">>, Role) ->
-    {ok, list_to_binary(string:to_upper(atom_to_list(Role)))}.
+output(<<"MUCRole">>, Role) ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Role)))};
+output(<<"MUCAffiliation">>, Aff) ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Aff)))}.

--- a/src/graphql/mongoose_graphql_muc_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_helper.erl
@@ -1,7 +1,7 @@
 -module(mongoose_graphql_muc_helper).
 
 -export([make_rooms_payload/2, make_room_desc/1, muc_room_config_to_map/1, make_muc_room_config/2,
-         format_user/1, format_users/1, add_user_resource/2]).
+         format_user/1, format_users/1, add_user_resource/2, format_affs/1]).
 
 -export([default_kick_reason/1, default_invite_reason/1, default_room_removal_reason/1]).
 
@@ -47,6 +47,12 @@ format_users(Users) ->
 
 format_user(#{jid := JID, role := Role, nick := Nick}) ->
     #{<<"jid">> => JID, <<"role">> => Role, <<"nick">> => Nick}.
+
+format_affs(Affs) ->
+    [{ok, format_aff(A)} || A <- Affs].
+
+format_aff({JID, Aff}) ->
+    #{<<"jid">> => JID, <<"affiliation">> => Aff}.
 
 -spec muc_room_config_to_map(mod_muc_room:config()) -> map().
 muc_room_config_to_map(Conf) ->

--- a/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
@@ -7,7 +7,8 @@
 
 -include("../mongoose_graphql_types.hrl").
 
--import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2,
+                                  null_to_undefined/1]).
 
 execute(Ctx, _Obj, <<"createInstantRoom">>, Args) ->
     create_instant_room(Ctx, Args);
@@ -17,10 +18,37 @@ execute(Ctx, _Obj, <<"kickUser">>, Args) ->
     kick_user(Ctx, Args);
 execute(Ctx, _Obj, <<"sendMessageToRoom">>, Args) ->
     send_message_to_room(Ctx, Args);
+execute(Ctx, _Obj, <<"sendPrivateMessage">>, Args) ->
+    send_private_message(Ctx, Args);
 execute(Ctx, _Obj, <<"changeRoomConfiguration">>, Args) ->
     change_room_config(Ctx, Args);
 execute(Ctx, _Obj, <<"deleteRoom">>, Args) ->
-    delete_room(Ctx, Args).
+    delete_room(Ctx, Args);
+execute(Ctx, _Obj, <<"setUserRole">>, Args) ->
+    set_user_role(Ctx, Args);
+execute(Ctx, _Obj, <<"setUserAffiliation">>, Args) ->
+    set_user_affiliation(Ctx, Args);
+execute(Ctx, _Obj, <<"enterRoom">>, Args) ->
+    enter_room(Ctx, Args);
+execute(Ctx, _Obj, <<"exitRoom">>, Args) ->
+    exit_room(Ctx, Args).
+
+-spec enter_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+enter_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
+                                 <<"resource">> := Resource, <<"password">> := Password}) ->
+    UserJIDRes = jid:replace_resource(UserJID, Resource),
+    RoomJIDRes = jid:replace_resource(RoomJID, Nick),
+    Password2 = null_to_undefined(Password),
+    Res = mod_muc_api:enter_room(RoomJIDRes, UserJIDRes, Password2),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec exit_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+exit_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
+                                <<"resource">> := Resource}) ->
+    UserJIDRes = jid:replace_resource(UserJID, Resource),
+    RoomJIDRes = jid:replace_resource(RoomJID, Nick),
+    Res = mod_muc_api:exit_room(RoomJIDRes, UserJIDRes),
+    format_result(Res, #{room => jid:to_binary(RoomJID)}).
 
 -spec create_instant_room(map(), map()) -> {ok, map()} | {error, resolver_error()}.
 create_instant_room(#{user := UserJID}, #{<<"mucDomain">> := MUCDomain, <<"name">> := Name,
@@ -52,6 +80,17 @@ send_message_to_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"body">> := 
     Result = do_send_message_to_room(RoomJID, UserJID, Message, Res),
     format_result(Result, #{room => jid:to_binary(RoomJID)}).
 
+-spec send_private_message(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+send_private_message(#{user := UserJID}, #{<<"room">> := RoomJID, <<"body">> := Message,
+                                           <<"toNick">> := ToNick, <<"resource">> := Res}) ->
+    Result = case mongoose_graphql_muc_helper:add_user_resource(UserJID, Res) of
+                 {ok, UserJIDRes} ->
+                     mod_muc_api:send_private_message(RoomJID, UserJIDRes, ToNick, Message);
+                 Error ->
+                     Error
+             end,
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
 -spec change_room_config(map(), map()) -> {ok, map()} | {error, resolver_error()}.
 change_room_config(#{user := UserJID}, #{<<"room">> := RoomJID, <<"config">> := ConfigInput}) ->
     Fun = fun(Config) -> mongoose_graphql_muc_helper:make_muc_room_config(ConfigInput, Config) end,
@@ -68,6 +107,18 @@ delete_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"reason">> := Reason}
                               mongoose_graphql_muc_helper:default_room_removal_reason("user")),
     Res = mod_muc_api:delete_room(RoomJID, UserJID, Reason2),
     format_result(Res, #{room => jid:to_binary(RoomJID)}).
+
+-spec set_user_role(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+set_user_role(#{user := UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
+                                    <<"role">> := Role}) ->
+    Result = mod_muc_api:set_role(RoomJID, UserJID, Nick, Role),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
+
+-spec set_user_affiliation(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
+set_user_affiliation(#{user := FromJID}, #{<<"room">> := RoomJID, <<"user">> := UserJID,
+                                           <<"affiliation">> := Aff}) ->
+    Result = mod_muc_api:set_affiliation(RoomJID, FromJID, UserJID, Aff),
+    format_result(Result, #{room => jid:to_binary(RoomJID)}).
 
 -spec do_send_message_to_room(jid:jid(), jid:jid(), binary(), binary() | null) ->
     {ok | no_session, iolist()}.

--- a/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
@@ -68,10 +68,10 @@ invite_user(#{user := UserJID}, #{<<"room">> := RoomJID, <<"recipient">> := Reci
     format_result(Res, #{room => jid:to_binary(RoomJID)}).
 
 -spec kick_user(map(), map()) -> {ok, binary()} | {error, resolver_error()}.
-kick_user(#{user := _UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
+kick_user(#{user := UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
                                 <<"reason">> := Reason}) ->
     Reason2 = null_to_default(Reason, mongoose_graphql_muc_helper:default_kick_reason("user")),
-    Res = mod_muc_api:kick_user_from_room(RoomJID, Nick, Reason2),
+    Res = mod_muc_api:kick_user_from_room(RoomJID, UserJID, Nick, Reason2),
     format_result(Res, #{room => jid:to_binary(RoomJID)}).
 
 -spec send_message_to_room(map(), map()) -> {ok, binary()} | {error, resolver_error()}.

--- a/src/graphql/user/mongoose_graphql_muc_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_query.erl
@@ -14,6 +14,8 @@ execute(Ctx, _Obj, <<"listRooms">>, Args) ->
     list_rooms(Ctx, Args);
 execute(Ctx, _Obj, <<"listRoomUsers">>, Args) ->
     list_room_users(Ctx, Args);
+execute(Ctx, _Obj, <<"listRoomAffiliations">>, Args) ->
+    list_room_affiliations(Ctx, Args);
 execute(Ctx, _Obj, <<"getRoomMessages">>, Args) ->
     get_room_messages(Ctx, Args);
 execute(Ctx, _Obj, <<"getRoomConfig">>, Args) ->
@@ -32,6 +34,16 @@ list_room_users(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
     case mod_muc_api:get_room_users(RoomJID, UserJID) of
         {ok, Users} ->
             {ok, mongoose_graphql_muc_helper:format_users(Users)};
+        Error ->
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
+    end.
+
+-spec list_room_affiliations(map(), map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
+list_room_affiliations(#{user := UserJID}, #{<<"room">> := RoomJID, <<"affiliation">> := Aff}) ->
+    Aff2 = null_to_undefined(Aff),
+    case mod_muc_api:get_room_affiliation(RoomJID, UserJID, Aff2) of
+        {ok, Affs} ->
+            {ok, mongoose_graphql_muc_helper:format_affs(Affs)};
         Error ->
             make_error(Error, #{room => jid:to_binary(RoomJID)})
     end.

--- a/src/graphql/user/mongoose_graphql_muc_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_query.erl
@@ -41,7 +41,7 @@ list_room_users(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
 -spec list_room_affiliations(map(), map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
 list_room_affiliations(#{user := UserJID}, #{<<"room">> := RoomJID, <<"affiliation">> := Aff}) ->
     Aff2 = null_to_undefined(Aff),
-    case mod_muc_api:get_room_affiliation(RoomJID, UserJID, Aff2) of
+    case mod_muc_api:get_room_affiliations(RoomJID, UserJID, Aff2) of
         {ok, Affs} ->
             {ok, mongoose_graphql_muc_helper:format_affs(Affs)};
         Error ->

--- a/src/mod_muc_api.erl
+++ b/src/mod_muc_api.erl
@@ -10,10 +10,19 @@
          modify_room_config/3,
          get_room_users/1,
          get_room_users/2,
+         get_room_affiliation/2,
+         get_room_affiliation/3,
          create_instant_room/4,
          invite_to_room/4,
          send_message_to_room/3,
+         send_private_message/4,
          kick_user_from_room/3,
+         set_affiliation/3,
+         set_affiliation/4,
+         enter_room/3,
+         exit_room/2,
+         set_role/4,
+         set_role/3,
          delete_room/2,
          delete_room/3]).
 
@@ -37,6 +46,8 @@
       nick := mod_muc:nick()}.
 
 -type room_conf_mod_fun() :: fun((mod_muc_room:config()) -> mod_muc_room:config()).
+
+-type aff_item() :: {jid:simple_jid(), mod_muc:affiliation()}.
 
 -export_type([user_map/0, short_room_desc/0]).
 
@@ -94,7 +105,7 @@ create_instant_room(MUCDomain, Name, OwnerJID, Nick) ->
             UserRoomJID = jid:make(Name, MUCDomain, Nick),
             %% Send presence to create a room.
             ejabberd_router:route(OwnerJID, UserRoomJID,
-                                  presence(OwnerJID, UserRoomJID)),
+                                  presence(OwnerJID, UserRoomJID, undefined)),
             %% Send IQ set to unlock the room.
             ejabberd_router:route(OwnerJID, BareRoomJID,
                                   declination(OwnerJID, BareRoomJID)),
@@ -137,11 +148,17 @@ modify_room_config(RoomJID, Fun) ->
 invite_to_room(RoomJID, SenderJID, RecipientJID, Reason) ->
     case verify_room(RoomJID, SenderJID) of
         ok ->
+            Attrs = case get_room_config(RoomJID) of
+                        {ok, #config{password_protected = true, password = Pass}} ->
+                            [{<<"password">>, Pass}];
+                        _ ->
+                            []
+                       end,
             %% Direct invitation: i.e. not mediated by MUC room. See XEP 0249.
             X = #xmlel{name = <<"x">>,
                        attrs = [{<<"xmlns">>, ?NS_CONFERENCE},
                                 {<<"jid">>, jid:to_binary(RoomJID)},
-                                {<<"reason">>, Reason}]
+                                {<<"reason">>, Reason} | Attrs]
             },
             Invite = message(SenderJID, RecipientJID, <<>>, [X]),
             ejabberd_router:route(SenderJID, RecipientJID, Invite),
@@ -153,10 +170,19 @@ invite_to_room(RoomJID, SenderJID, RecipientJID, Reason) ->
 -spec send_message_to_room(jid:jid(), jid:jid(), binary()) -> {ok, iolist()}.
 send_message_to_room(RoomJID, SenderJID, Message) ->
     Body = #xmlel{name = <<"body">>,
-                  children = [#xmlcdata{content = Message}]
-                 },
+                  children = [#xmlcdata{content = Message}]},
     Stanza = message(SenderJID, RoomJID, <<"groupchat">>, [Body]),
     ejabberd_router:route(SenderJID, RoomJID, Stanza),
+    {ok, "Message sent successfully"}.
+
+-spec send_private_message(jid:jid(), jid:jid(), binary(), binary()) -> {ok, iolist()}.
+send_private_message(RoomJID, SenderJID, ToNick, Message) ->
+    RoomJIDRes = jid:replace_resource(RoomJID, ToNick),
+    Body = #xmlel{name = <<"body">>,
+                  children = [#xmlcdata{content = Message}]},
+    X = #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_MUC}]},
+    Stanza = message(SenderJID, RoomJID, <<"chat">>, [Body, X]),
+    ejabberd_router:route(SenderJID, RoomJIDRes, Stanza),
     {ok, "Message sent successfully"}.
 
 -spec kick_user_from_room(jid:jid(), binary(), binary()) -> {ok, iolist()}.
@@ -256,7 +282,117 @@ get_room_messages(RoomJID, UserJID, PageSize, Before) ->
             ?MUC_SERVER_NOT_FOUND_RESULT
     end.
 
+-spec get_room_affiliation(jid:jid(), jid:jid(), mod_muc:affiliation()  | undefined) ->
+    {ok, [aff_item()]} | {not_allowed | room_not_found, iolist()}.
+get_room_affiliation(RoomJID, UserJID, AffType) ->
+    case mod_muc_room:can_access_room(RoomJID, UserJID) of
+        {ok, true} ->
+            get_room_affiliation(RoomJID, AffType);
+        {ok, false} ->
+            ?USER_CANNOT_ACCESS_ROOM_RESULT;
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec get_room_affiliation(jid:jid(), mod_muc:affiliation()  | undefined) ->
+    {ok, [aff_item()]} | {room_not_found, iolist()}.
+get_room_affiliation(RoomJID, AffType) ->
+    case room_users_aff(RoomJID) of
+        {ok, Affiliations} ->
+            Res = filter_affs_by_type(AffType, Affiliations),
+            {ok, Res};
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec set_affiliation(jid:jid(), jid:jid(), mod_muc:affiliation()) ->
+    {ok | room_not_found | not_allowed, iolist()}.
+set_affiliation(RoomJID, UserJID, Affiliation) ->
+    case room_users_aff(RoomJID) of
+        {ok, Affs} ->
+            {OwnerJID, owner} = hd(filter_affs_by_type(owner, Affs)),
+                set_affiliation(RoomJID, OwnerJID, UserJID, Affiliation);
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec set_affiliation(jid:jid(), jid:jid(), jid:jid(), mod_muc:affiliation()) ->
+    {ok | room_not_found | not_allowed, iolist()}.
+set_affiliation(RoomJID, FromJID, UserJID, Affiliation) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            AffItem = affiliation_item(UserJID, Affiliation),
+            case gen_fsm_compat:sync_send_event(Pid, {set_admin_items, FromJID, [AffItem]}) of
+                ok ->
+                    {ok, "Affiliation set successfully"};
+                {error, Error} ->
+                    format_xml_error(Error, Affiliation, <<"affiliation">>)
+            end;
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec set_role(jid:jid(), binary(), mod_muc:role()) ->
+    {ok | room_not_found | not_allowed, iolist()}.
+set_role(RoomJID, Nick, Role) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            ModJID = room_moderator(RoomJID),
+            set_role(Pid, ModJID, Nick, Role);
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+-spec set_role(jid:jid() | pid(), jid:jid(), binary(), mod_muc:role()) ->
+    {ok | room_not_found | not_allowed, iolist()}.
+set_role(#jid{} = RoomJID, ModJID, Nick, Role) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            set_role(Pid, ModJID, Nick, Role);
+        {error, not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end;
+set_role(Pid, ModJID, Nick, Role) when is_pid(Pid) ->
+    RoleItem = role_item(Nick, Role),
+    ModJIDRes = try_add_role_res(Pid, ModJID, moderator),
+    case gen_fsm_compat:sync_send_event(Pid, {set_admin_items, ModJIDRes, [RoleItem]}) of
+        ok ->
+            {ok, "Role set successfully"};
+        {error, Error} ->
+            format_xml_error(Error, Role, <<"role">>)
+    end.
+
+-spec enter_room(jid:jid(), jid:jid(), binary() | undefined) -> {ok, iolist()}.
+enter_room(RoomJID, UserJID, Password) ->
+    Presence = presence(UserJID, RoomJID, Password),
+    ejabberd_router:route(UserJID, RoomJID, Presence),
+    {ok, "Entering room message sent successfully"}.
+
+-spec exit_room(jid:jid(), jid:jid()) -> {ok, iolist()}.
+exit_room(RoomJID, UserJID) ->
+    Presence = exit_room_presence(UserJID, RoomJID),
+    ejabberd_router:route(UserJID, RoomJID, Presence),
+    {ok, "Exiting room message sent successfully"}.
+
 %% Internal
+
+-spec try_add_role_res(jid:jid() | pid(), jid:jid(), mod_muc:role()) -> jid:jid().
+try_add_role_res(Room, InUserJID, Role) ->
+    Res = [UserJID || #user{jid = UserJID, role = Role2} <- room_users(Room),
+                      jid:are_bare_equal(InUserJID, UserJID), Role =:= Role2],
+    case Res of
+        [UserJID | _] ->
+            UserJID;
+        _ ->
+            InUserJID
+    end.
+
+filter_affs_by_type(undefined, Affs) -> Affs;
+filter_affs_by_type(Type, Affs) -> [Aff || Aff = {_, T} <- Affs, T =:= Type].
+
+format_xml_error(#xmlel{name = <<"error">>}, Aff, Op) ->
+    Msg = io_lib:format("Given user does not have permission to set the ~p ~s", [Aff, Op]),
+    {not_allowed, Msg}.
 
 -spec can_access_identity(pid(), jid:jid()) -> boolean().
 can_access_identity(Pid, UserJID) ->
@@ -314,6 +450,13 @@ verify_room(BareRoomJID, OwnerJID) ->
             ?ROOM_NOT_FOUND_RESULT
     end.
 
+role_item(Nick, Role) ->
+    #xmlel{name = <<"item">>, attrs = [{<<"nick">>, Nick}, {<<"role">>, atom_to_binary(Role)}]}.
+
+affiliation_item(JID, Aff) ->
+    #xmlel{name = <<"item">>, attrs = [{<<"jid">>, jid:to_binary(JID)},
+                                       {<<"affiliation">>, atom_to_binary(Aff)}]}.
+
 iq(Type, Sender, Recipient, Children) when is_binary(Type), is_list(Children) ->
     Addresses = address_attributes(Sender, Recipient),
     #xmlel{name = <<"iq">>,
@@ -337,11 +480,22 @@ query(XMLNameSpace, Children)
            attrs = [{<<"xmlns">>, XMLNameSpace}],
            children = Children}.
 
-presence(Sender, Recipient) ->
+presence(Sender, Recipient, Password) ->
+    Children = case Password of
+                    undefined -> [];
+                    _ -> [#xmlel{name = <<"password">>,
+                                 children = [#xmlcdata{content = Password}]}]
+                end,
     #xmlel{name = <<"presence">>,
            attrs = address_attributes(Sender, Recipient),
            children = [#xmlel{name = <<"x">>,
-                              attrs = [{<<"xmlns">>, ?NS_MUC}]}]}.
+                              attrs = [{<<"xmlns">>, ?NS_MUC}],
+                              children = Children}]}.
+
+exit_room_presence(Sender, Recipient) ->
+    #xmlel{name = <<"presence">>,
+           attrs = [{<<"type">>, <<"unavailable">>} | address_attributes(Sender, Recipient)],
+           children = [#xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_MUC}]}]}.
 
 declination(Sender, Recipient) ->
     iq(<<"set">>, Sender, Recipient, [data_submission()]).
@@ -361,6 +515,23 @@ room_moderator(RoomJID) ->
                           role = moderator} <- room_users(RoomJID)],
     JIDStruct.
 
-room_users(RoomJID) ->
+room_users(#jid{} = RoomJID) ->
     {ok, Affiliations} = mod_muc_room:get_room_users(RoomJID),
+    Affiliations;
+room_users(RoomPID) when is_pid(RoomPID)->
+    {ok, Affiliations} = gen_fsm_compat:sync_send_all_state_event(RoomPID, get_room_users),
     Affiliations.
+
+room_users_aff(RoomJID) ->
+    case mod_muc_room:get_room_affiliations(RoomJID) of
+        {ok, Affs} ->
+            {ok, format_affs(Affs)};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+format_affs(AffsMap) ->
+    lists:map(fun
+                  ({K, {V, <<>>}}) -> {K, V};
+                  ({K, V}) -> {K, V}
+              end, maps:to_list(AffsMap)).

--- a/src/mod_muc_api.erl
+++ b/src/mod_muc_api.erl
@@ -10,8 +10,8 @@
          modify_room_config/3,
          get_room_users/1,
          get_room_users/2,
-         get_room_affiliation/2,
-         get_room_affiliation/3,
+         get_room_affiliations/2,
+         get_room_affiliations/3,
          create_instant_room/4,
          invite_to_room/4,
          send_message_to_room/3,
@@ -282,21 +282,21 @@ get_room_messages(RoomJID, UserJID, PageSize, Before) ->
             ?MUC_SERVER_NOT_FOUND_RESULT
     end.
 
--spec get_room_affiliation(jid:jid(), jid:jid(), mod_muc:affiliation()  | undefined) ->
+-spec get_room_affiliations(jid:jid(), jid:jid(), mod_muc:affiliation()  | undefined) ->
     {ok, [aff_item()]} | {not_allowed | room_not_found, iolist()}.
-get_room_affiliation(RoomJID, UserJID, AffType) ->
+get_room_affiliations(RoomJID, UserJID, AffType) ->
     case mod_muc_room:can_access_room(RoomJID, UserJID) of
         {ok, true} ->
-            get_room_affiliation(RoomJID, AffType);
+            get_room_affiliations(RoomJID, AffType);
         {ok, false} ->
             ?USER_CANNOT_ACCESS_ROOM_RESULT;
         {error, not_found} ->
             ?ROOM_NOT_FOUND_RESULT
     end.
 
--spec get_room_affiliation(jid:jid(), mod_muc:affiliation()  | undefined) ->
+-spec get_room_affiliations(jid:jid(), mod_muc:affiliation()  | undefined) ->
     {ok, [aff_item()]} | {room_not_found, iolist()}.
-get_room_affiliation(RoomJID, AffType) ->
+get_room_affiliations(RoomJID, AffType) ->
     case room_users_aff(RoomJID) of
         {ok, Affiliations} ->
             Res = filter_affs_by_type(AffType, Affiliations),


### PR DESCRIPTION
This PR refers to [MIM-1629](https://erlangsolutions.atlassian.net/browse/MIM-1629) and extends the GraphQL MUC category about new commands.

### Extended commands

#### Command `inviteUser`
When the room is password secured, then this command attaches the password to the invitation.

### The new commands

#### Command `setAffiliation`
- grant member aff,
- grant admin aff,
- grant owner aff,
- ban user (set outcast aff)
- revoke aff

#### Command `setRole`
- grant voice (participant role),
- revoke voice (visitant role),
- grant moderator role

#### Command `listUserAffiliations`
Allows listing all users with given affiliation or list all room affiliations.

#### Commands `enterRoom` and `exitRoom`
Allows entering/exiting room per user session with the given nickname.
It is possible to enter the password-secured room.

#### Command `sendPrivateMesssage`
The user can send a private message to the other room occupant. The message is sent to the given nickname.

### Small GraphQL Bug
When working on this PR I found a bug in graphql_erlang causing a crash when the user passes the wrong type value, and that value is present in more than one enum. The PR with a fix https://github.com/Premwoik/graphql-erlang/pull/1