### PR TITLE
Ensure maybe_restart_rabbit_connection/1 returns two pids in the tuple.

### DIFF
--- a/src/mongoose_rabbit_worker.erl
+++ b/src/mongoose_rabbit_worker.erl
@@ -202,7 +202,8 @@ maybe_restart_rabbit_connection(#{connection := Conn, host := Host,
                                   amqp_client_opts := AMQPOpts}) ->
     case is_process_alive(Conn) of
         true ->
-            {Conn, amqp_connection:open_channel(Conn)};
+            {ok, Channel} = amqp_connection:open_channel(Conn),
+            {Conn, Channel};
         false ->
             establish_rabbit_connection(AMQPOpts, Host, PoolTag)
     end.


### PR DESCRIPTION
When the rabbit connection is still alive the return will be `{pid(), {ok, pid()}}`. The worker will encounter the error when the next `amqp_channel:call/2`.

This PR ensures the return is the correct data format and adds a test for that.