### PR TITLE
Force cert cache renewal

### DIFF
--- a/tools/make-certs-cache-key.sh
+++ b/tools/make-certs-cache-key.sh
@@ -5,4 +5,4 @@ week=$(date "+%V")
 year=$(date "+%Y")
 makefile_sum=$(sha1sum tools/ssl/Makefile | cut -d " " -f1)
 
-echo "${year}-week${num}-${makefile_sum}"
+echo "${year}-week${num}-${makefile_sum}-1"


### PR DESCRIPTION
CircleCI jobs started failing and the cache has one-week retention time. Changing the key forces it to be rebuilt now.

