### PR TITLE
GraphQL - Support admin per domain

### DIFF
--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -4,6 +4,8 @@
          delete_configured_domains/0,
          insert_domain/3,
          delete_domain/2,
+         set_domain_password/3,
+         delete_domain_password/2,
          make_metrics_prefix/1,
          host_types/0,
          host_types/1,
@@ -65,6 +67,12 @@ insert_persistent_domain(Node, Domain, HostType) ->
 
 delete_persistent_domain(Node, Domain, HostType) ->
     ok = rpc(Node, mongoose_domain_api, delete_domain, [Domain, HostType]).
+
+set_domain_password(Node, Domain, Password) ->
+    ok = rpc(Node, mongoose_domain_api, set_domain_password, [Domain, Password]).
+
+delete_domain_password(Node, Domain) ->
+    ok = rpc(Node, mongoose_domain_api, delete_domain_password, [Domain]).
 
 for_each_configured_domain(F) ->
     [for_each_configured_domain(F, Opts) || {_, Opts} <- ct:get_config(hosts)],

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -7,28 +7,33 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute/3]).
+-import(graphql_helper, [execute/3, execute_auth/2, execute_domain_auth/2, execute_user/3]).
 
--define(assertAdminAuth(Auth, Data), assert_auth(atom_to_binary(Auth), Data)).
+-define(assertAdminAuth(Domain, Type, Auth, Data),
+        assert_auth(#{<<"domain">> => Domain,
+                      <<"authStatus">> => atom_to_binary(Auth),
+                      <<"authType">> => maybe_atom_to_bin(Type)}, Data)).
 -define(assertUserAuth(Username, Auth, Data),
         assert_auth(#{<<"username">> => Username,
                       <<"authStatus">> => atom_to_binary(Auth)}, Data)).
-
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
     [{group, cowboy_handler},
      {group, admin_handler},
+     {group, domain_admin_handler},
      {group, user_handler}].
 
 groups() ->
     [{cowboy_handler, [parallel], cowboy_handler()},
      {user_handler, [parallel], user_handler()},
+     {domain_admin_handler, [parallel], domain_admin_handler()},
      {admin_handler, [parallel], admin_handler()}].
 
 cowboy_handler() ->
     [can_connect_to_admin,
+     can_connect_to_domain_admin,
      can_connect_to_user].
 
 user_handler() ->
@@ -37,6 +42,9 @@ user_handler() ->
 admin_handler() ->
     [admin_checks_auth,
      auth_admin_checks_auth | common_tests()].
+domain_admin_handler() ->
+    [domain_admin_checks_auth,
+     auth_domain_admin_checks_auth | common_tests()].
 
 common_tests() ->
     [can_load_graphiql].
@@ -52,14 +60,23 @@ end_per_suite(Config) ->
 
 init_per_group(admin_handler, Config) ->
     graphql_helper:init_admin_handler(Config);
+init_per_group(domain_admin_handler, Config) ->
+    case mongoose_helper:is_rdbms_enabled(domain_helper:host_type()) of
+        true ->
+            graphql_helper:init_domain_admin_handler(Config);
+        false ->
+            {skip, require_rdbms}
+    end;
 init_per_group(user_handler, Config) ->
     Config1 = escalus:create_users(Config, escalus:get_users([alice])),
     [{schema_endpoint, user} | Config1];
-init_per_group(_, Config) ->
+init_per_group(cowboy_handler, Config) ->
     Config.
 
 end_per_group(user_handler, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice]));
+end_per_group(domain_admin_handler, Config) ->
+    graphql_helper:end_domain_admin_handler(Config);
 end_per_group(_, _Config) ->
     ok.
 
@@ -72,6 +89,9 @@ end_per_testcase(CaseName, Config) ->
 can_connect_to_admin(_Config) ->
     ?assertMatch({{<<"400">>, <<"Bad Request">>}, _}, execute(admin, #{}, undefined)).
 
+can_connect_to_domain_admin(_Config) ->
+    ?assertMatch({{<<"400">>, <<"Bad Request">>}, _}, execute(domain_admin, #{}, undefined)).
+
 can_connect_to_user(_Config) ->
     ?assertMatch({{<<"400">>, <<"Bad Request">>}, _}, execute(user, #{}, undefined)).
 
@@ -83,46 +103,43 @@ can_load_graphiql(Config) ->
 
 user_checks_auth(Config) ->
     Ep = ?config(schema_endpoint, Config),
-    Body = #{query => "{ checkAuth { username authStatus } }"},
-    StatusData = execute(Ep, Body, undefined),
+    StatusData = execute(Ep, user_check_auth_body(), undefined),
     ?assertUserAuth(null, 'UNAUTHORIZED', StatusData).
 
 auth_user_checks_auth(Config) ->
     escalus:fresh_story(
         Config, [{alice, 1}],
         fun(Alice) ->
-            Password = user_password(alice),
-            AliceJID = escalus_client:short_jid(Alice),
-            Ep = ?config(schema_endpoint, Config),
-            Body = #{query => "{ checkAuth { username authStatus } }"},
-            StatusData = execute(Ep, Body, {AliceJID, Password}),
+            AliceJID = escalus_utils:jid_to_lower(escalus_client:short_jid(Alice)),
+            StatusData = execute_user(user_check_auth_body(), Alice, Config),
             ?assertUserAuth(AliceJID, 'AUTHORIZED', StatusData)
         end).
 
 admin_checks_auth(Config) ->
     Ep = ?config(schema_endpoint, Config),
-    Body = #{query => "{ checkAuth }"},
-    StatusData = execute(Ep, Body, undefined),
-    ?assertAdminAuth('UNAUTHORIZED', StatusData).
+    StatusData = execute(Ep, admin_check_auth_body(), undefined),
+    ?assertAdminAuth(null, null, 'UNAUTHORIZED', StatusData).
 
 auth_admin_checks_auth(Config) ->
+    StatusData = execute_auth(admin_check_auth_body(), Config),
+    ?assertAdminAuth(null, 'ADMIN', 'AUTHORIZED', StatusData).
+
+domain_admin_checks_auth(Config) ->
     Ep = ?config(schema_endpoint, Config),
-    Opts = ?config(listener_opts, Config),
-    User = proplists:get_value(username, Opts),
-    Password = proplists:get_value(password, Opts),
-    Body = #{query => "{ checkAuth }"},
-    StatusData = execute(Ep, Body, {User, Password}),
-    ?assertAdminAuth('AUTHORIZED', StatusData).
+    Res = execute(Ep, admin_check_auth_body(), undefined),
+    ?assertAdminAuth(null, null, 'UNAUTHORIZED', Res).
+
+auth_domain_admin_checks_auth(Config) ->
+    {Username, _} = ?config(domain_admin, Config),
+    Domain = escalus_utils:get_server(Username),
+    Res = execute_domain_auth(admin_check_auth_body(), Config),
+    ?assertAdminAuth(Domain, 'DOMAIN_ADMIN', 'AUTHORIZED', Res).
 
 %% Helpers
 
 assert_auth(Auth, {Status, Data}) ->
     ?assertEqual({<<"200">>, <<"OK">>}, Status),
     ?assertMatch(#{<<"data">> := #{<<"checkAuth">> := Auth}}, Data).
-
-user_password(User) ->
-    [{User, Props}] = escalus:get_users([User]),
-    proplists:get_value(password, Props).
 
 get_graphiql_website(EpName) ->
     Request =
@@ -133,3 +150,12 @@ get_graphiql_website(EpName) ->
         return_maps => true,
         path => "/graphql"},
     rest_helper:make_request(Request).
+
+maybe_atom_to_bin(null) -> null;
+maybe_atom_to_bin(X) -> atom_to_binary(X).
+
+admin_check_auth_body() ->
+    #{query => "{ checkAuth { domain authType authStatus } }"}.
+
+user_check_auth_body() ->
+    #{query => "{ checkAuth { username authStatus } }"}.

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -16,6 +16,7 @@
 -define(assertUserAuth(Username, Auth, Data),
         assert_auth(#{<<"username">> => Username,
                       <<"authStatus">> => atom_to_binary(Auth)}, Data)).
+
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -1120,7 +1120,7 @@ stats_host(Config) ->
 %%--------------------------------------------------------------------
 
 can_execute_admin_queries_with_permissions(Config) ->
-    Query = "query { checkAuth }",
+    Query = "query { checkAuth { authStatus } }",
     Res = mongooseimctl("graphql", [Query], Config),
     ?assertMatch({_, 0}, Res),
     Data = element(1, Res),

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -70,6 +70,12 @@ db_cases() -> [
      db_cannot_enable_domain_with_unknown_host_type,
      db_cannot_disable_domain_with_unknown_host_type,
      db_domains_with_unknown_host_type_are_ignored_by_core,
+     db_can_insert_update_delete_dynamic_domain_password,
+     db_can_insert_update_delete_static_domain_password,
+     db_cannot_set_password_for_unknown_domain,
+     db_can_check_domain_password,
+     db_cannot_check_password_for_unknown_domain,
+     db_deleting_domain_deletes_domain_admin,
      sql_select_from,
      sql_find_gaps_between,
      db_records_are_restored_on_mim_restart,
@@ -450,6 +456,46 @@ db_domains_with_unknown_host_type_are_ignored_by_core(_) ->
     sync(),
     {ok, <<"type1">>} = get_host_type(mim(), <<"example.org">>), %% Counter-case
     {error, not_found} = get_host_type(mim(), <<"example.com">>).
+
+db_can_insert_update_delete_dynamic_domain_password(_) ->
+    Domain = <<"password-example.com">>,
+    ok = insert_domain(mim(), Domain, <<"type1">>),
+    sync(),
+    ok = set_domain_password(mim(), Domain, <<"rocky1">>),
+    ok = check_domain_password(mim(), Domain, <<"rocky1">>),
+    ok = set_domain_password(mim(), Domain, <<"rocky2">>),
+    ok = check_domain_password(mim(), Domain, <<"rocky2">>),
+    ok = delete_domain_password(mim(), Domain),
+    {error, not_found} = select_domain_admin(mim(), Domain).
+
+db_can_insert_update_delete_static_domain_password(_) ->
+    StaticDomain = <<"example.cfg">>,
+    ok = set_domain_password(mim(), StaticDomain, <<"rocky1">>),
+    ok = check_domain_password(mim(), StaticDomain, <<"rocky1">>),
+    ok = set_domain_password(mim(), StaticDomain, <<"rocky2">>),
+    ok = check_domain_password(mim(), StaticDomain, <<"rocky2">>),
+    ok = delete_domain_password(mim(), StaticDomain),
+    {error, not_found} = select_domain_admin(mim(), StaticDomain).
+
+db_cannot_set_password_for_unknown_domain(_) ->
+    {error, not_found} = set_domain_password(mim(), <<"unknown_domain">>, <<>>).
+
+db_can_check_domain_password(_) ->
+    StaticDomain = <<"example.cfg">>,
+    ok = set_domain_password(mim(), StaticDomain, <<"myrock">>),
+    ok = check_domain_password(mim(), StaticDomain, <<"myrock">>),
+    {error, wrong_password} = check_domain_password(mim(), StaticDomain, <<"wrongrock">>).
+
+db_cannot_check_password_for_unknown_domain(_) ->
+    {error, not_found} = check_domain_password(mim(), <<"unknown_domain">>, <<>>).
+
+db_deleting_domain_deletes_domain_admin(_) ->
+    Domain = <<"password-del-example.db">>,
+    ok = insert_domain(mim(), Domain, <<"type1">>),
+    sync(),
+    ok = set_domain_password(mim(), Domain, <<"deleteme">>),
+    ok = delete_domain(mim(), Domain, <<"type1">>),
+    {error, not_found} = select_domain_admin(mim(), Domain).
 
 sql_select_from(_) ->
     ok = insert_domain(mim(), <<"example.db">>, <<"type1">>),
@@ -1064,6 +1110,18 @@ delete_domain(Node, Domain, HostType) ->
 
 select_domain(Node, Domain) ->
     rpc(Node, mongoose_domain_sql, select_domain, [Domain]).
+
+check_domain_password(Node, Domain, Password) ->
+    rpc(Node, mongoose_domain_api, check_domain_password, [Domain, Password]).
+
+set_domain_password(Node, Domain, Password) ->
+    rpc(Node, mongoose_domain_api, set_domain_password, [Domain, Password]).
+
+delete_domain_password(Node, Domain) ->
+    rpc(Node, mongoose_domain_api, delete_domain_password, [Domain]).
+
+select_domain_admin(Node, Domain) ->
+    rpc(Node, mongoose_domain_sql, select_domain_admin, [Domain]).
 
 insert_full_event(Node, EventId, Domain) ->
     rpc(Node, mongoose_domain_sql, insert_full_event, [EventId, Domain]).

--- a/priv/graphql/schemas/admin/admin_auth_status.gql
+++ b/priv/graphql/schemas/admin/admin_auth_status.gql
@@ -1,4 +1,4 @@
-"Inforamtion about user request authorization"
+"Information about user request authorization"
 type AdminAuthInfo{
   "Authorized for a domain"
   domain: String

--- a/priv/graphql/schemas/admin/admin_auth_status.gql
+++ b/priv/graphql/schemas/admin/admin_auth_status.gql
@@ -1,0 +1,18 @@
+"Inforamtion about user request authorization"
+type AdminAuthInfo{
+  "Authorized for a domain"
+  domain: String
+  "Authorization status"
+  authStatus: AuthStatus!
+  "Authorization as a "
+  authType: AuthType
+}
+
+enum AuthType{
+  ""
+  DOMAIN_ADMIN
+  ""
+  ADMIN
+  ""
+  UNAUTHORIZED
+}

--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -9,7 +9,7 @@ Only an authenticated admin can execute these queries.
 """
 type AdminQuery{
   "Check authorization status"
-  checkAuth: AuthStatus
+  checkAuth: AdminAuthInfo
   "Domain management"
   domains: DomainAdminQuery
   "Account management"

--- a/priv/graphql/schemas/admin/domain.gql
+++ b/priv/graphql/schemas/admin/domain.gql
@@ -14,6 +14,10 @@ type DomainAdminMutation @protected{
   enableDomain(domain: String!): Domain
   "Disable domain"
   disableDomain(domain: String!): Domain
+  "Create or update domain admin password"
+  setDomainPassword(domain: String!, password: String!): String
+  "Delete domain admin password"
+  deleteDomainPassword(domain: String!): String
 }
 
 "A result of domain removal"

--- a/priv/graphql/schemas/global/protected_dir.gql
+++ b/priv/graphql/schemas/global/protected_dir.gql
@@ -1,2 +1,7 @@
 "Marks the resource to be accessed only by authorized requests"
-directive @protected on FIELD_DEFINITION | OBJECT | INTERFACE
+directive @protected (type: String = ALL, args: [String!] = []) on FIELD_DEFINITION | OBJECT | INTERFACE
+
+enum ProtectedType{
+  DOMAIN
+  ALL
+}

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -730,7 +730,7 @@ CREATE TABLE offline_markers (
 
 CREATE INDEX i_offline_markers ON offline_markers(jid);
 
-CREATE TABLE domain_admin(
+CREATE TABLE domain_admins(
      domain VARCHAR(250) NOT NULL PRIMARY KEY,
      password VARCHAR(250) NOT NULL
 );

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -730,6 +730,10 @@ CREATE TABLE offline_markers (
 
 CREATE INDEX i_offline_markers ON offline_markers(jid);
 
+CREATE TABLE domain_admin(
+     domain VARCHAR(250) NOT NULL PRIMARY KEY,
+     password VARCHAR(250) NOT NULL
+);
 
 -- Mapping from domain hostname to host_type.
 -- Column id is used for ordering only.

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -521,7 +521,7 @@ CREATE TABLE offline_markers (
 
 CREATE INDEX i_offline_markers ON offline_markers(jid);
 
-CREATE TABLE domain_admin(
+CREATE TABLE domain_admins(
      domain VARCHAR(250) NOT NULL,
      password VARCHAR(250) NOT NULL,
      PRIMARY KEY(domain)

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -521,6 +521,12 @@ CREATE TABLE offline_markers (
 
 CREATE INDEX i_offline_markers ON offline_markers(jid);
 
+CREATE TABLE domain_admin(
+     domain VARCHAR(250) NOT NULL,
+     password VARCHAR(250) NOT NULL,
+     PRIMARY KEY(domain)
+);
+
 -- Mapping from domain hostname to host_type.
 -- Column id is used for ordering only.
 CREATE TABLE domain_settings (

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -478,6 +478,12 @@ CREATE TABLE offline_markers (
 
 CREATE INDEX i_offline_markers ON offline_markers(jid);
 
+CREATE TABLE domain_admin(
+     domain VARCHAR(250) NOT NULL,
+     password VARCHAR(250) NOT NULL,
+     PRIMARY KEY(domain)
+);
+
 -- Mapping from domain hostname to host_type.
 -- Column id is used for ordering only.
 CREATE TABLE domain_settings (

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -478,7 +478,7 @@ CREATE TABLE offline_markers (
 
 CREATE INDEX i_offline_markers ON offline_markers(jid);
 
-CREATE TABLE domain_admin(
+CREATE TABLE domain_admins(
      domain VARCHAR(250) NOT NULL,
      password VARCHAR(250) NOT NULL,
      PRIMARY KEY(domain)

--- a/rebar.lock
+++ b/rebar.lock
@@ -49,7 +49,7 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"graphql">>,
   {git,"https://github.com/Premwoik/graphql-erlang.git",
-       {ref,"469728e9126f132450ad0b8239bd2ad12ee7b605"}},
+       {ref,"72bf290d50b4b5e2f462e06ccfdc5645a6d6401a"}},
   0},
  {<<"gun">>,{pkg,<<"gun">>,<<"1.3.3">>},0},
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.13.0">>},1},

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -7,7 +7,8 @@
 {http_api_endpoint_port, 5294}.
 {http_api_old_endpoint_port, 5293}.
 {http_api_client_endpoint_port, 8095}.
-{http_qraphql_api_admin_endpoint_port, 5556}.
+{http_graphql_api_admin_endpoint_port, 5556}.
+{http_graphql_api_domain_admin_endpoint_port, 5546}.
 {http_graphql_api_user_endpoint_port, 5566}.
 
 %% This node is for s2s testing.
@@ -50,7 +51,9 @@
   port = {{ http_api_endpoint_port }}"}.
 {http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 {http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_qraphql_api_admin_endpoint_port}}"}.
+  port = {{http_graphql_api_admin_endpoint_port}}"}.
+{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
+  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
 {http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
   port = {{http_graphql_api_user_endpoint_port}}"}.
 

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -133,6 +133,18 @@
     password = "secret"
 
 [[listen.http]]
+  {{#http_graphql_api_domain_admin_endpoint}}
+  {{{http_graphql_api_domain_admin_endpoint}}}
+  {{/http_graphql_api_domain_admin_endpoint}}
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+    host = "_"
+    path = "/api/graphql"
+    schema_endpoint = "domain_admin"
+
+[[listen.http]]
   {{#http_graphql_api_user_endpoint}}
   {{{http_graphql_api_user_endpoint}}}
   {{/http_graphql_api_user_endpoint}}

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -9,7 +9,8 @@
 {http_api_endpoint_port, 8090}.
 {http_api_client_endpoint_port, 8091}.
 {service_port, 8899}.
-{http_qraphql_api_admin_endpoint_port, 5552}.
+{http_graphql_api_admin_endpoint_port, 5552}.
+{http_graphql_api_domain_admin_endpoint_port, 5542}.
 {http_graphql_api_user_endpoint_port, 5562}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
@@ -22,7 +23,9 @@
 {highload_vm_args, ""}.
 
 {http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_qraphql_api_admin_endpoint_port}}"}.
+  port = {{http_graphql_api_admin_endpoint_port}}"}.
+{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
+  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
 {http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
   port = {{http_graphql_api_user_endpoint_port}}"}.
 {http_api_old_endpoint, "ip_address = \"127.0.0.1\"

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -9,7 +9,8 @@
 {http_api_old_endpoint_port, 5292}.
 {http_api_endpoint_port, 8092}.
 {http_api_client_endpoint_port, 8193}.
-{http_qraphql_api_admin_endpoint_port, 5553}.
+{http_graphql_api_admin_endpoint_port, 5553}.
+{http_graphql_api_domain_admin_endpoint_port, 5543}.
 {http_graphql_api_user_endpoint_port, 5563}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
@@ -39,7 +40,9 @@
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
 {http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_qraphql_api_admin_endpoint_port}}"}.
+  port = {{http_graphql_api_admin_endpoint_port}}"}.
+{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
+  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
 {http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
   port = {{http_graphql_api_user_endpoint_port}}"}.
 {http_api_old_endpoint, "ip_address = \"127.0.0.1\"

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -9,6 +9,7 @@
 {http_api_old_endpoint_port, 5273}.
 {http_api_client_endpoint_port, 8075}.
 {http_qraphql_api_admin_endpoint_port, 5554}.
+{http_graphql_api_domain_admin_endpoint_port, 5544}.
 {http_graphql_api_user_endpoint_port, 5564}.
 
 %% This node is for global distribution testing.
@@ -40,6 +41,8 @@
 
 {http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
   port = {{http_qraphql_api_admin_endpoint_port}}"}.
+{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
+  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
 {http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
   port = {{http_graphql_api_user_endpoint_port}}"}.
 {http_api_old_endpoint, "ip_address = \"127.0.0.1\"

--- a/rel/vars-toml.config.in
+++ b/rel/vars-toml.config.in
@@ -6,6 +6,7 @@
 {http_port, 5280}.
 {https_port, 5285}.
 {http_graphql_api_admin_endpoint_port, 5551}.
+{http_graphql_api_domain_admin_endpoint_port, 5541}.
 {http_graphql_api_user_endpoint_port, 5561}.
 
 % vm.args
@@ -42,6 +43,8 @@
   port = 5288"}.
 {http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
   port = {{http_graphql_api_admin_endpoint_port}}"}.
+{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
+  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
 {http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
   port = {{http_graphql_api_user_endpoint_port}}"}.
 {http_api_endpoint, "ip_address = \"127.0.0.1\"

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -15,6 +15,11 @@
          get_all_static/0,
          get_domains_by_host_type/1]).
 
+%% domain admin API
+-export([check_domain_password/2,
+         set_domain_password/2,
+         delete_domain_password/1]).
+
 %% subdomain API
 -export([register_subdomain/3,
          unregister_subdomain/2,
@@ -72,6 +77,7 @@ delete_domain(Domain, HostType) ->
             Res = check_db(mongoose_domain_sql:delete_domain(Domain, HostType)),
             case Res of
                 ok ->
+                    delete_domain_password(Domain),
                     mongoose_hooks:remove_domain(HostType, Domain);
                 _ ->
                     ok
@@ -179,6 +185,33 @@ check_domain(Domain, HostType) ->
         true ->
             ok
     end.
+
+-type password() :: binary().
+
+-spec check_domain_password(domain(), password()) -> ok | {error, wrong_password | not_found}.
+check_domain_password(Domain, Password) ->
+    case mongoose_domain_sql:select_domain_admin(Domain) of
+        {ok, {Domain, Password}} ->
+            ok;
+        {ok, _} ->
+            {error, wrong_password};
+        {error, not_found} ->
+            {error, not_found}
+    end.
+
+-spec set_domain_password(domain(), password()) -> ok | {error, not_found}.
+set_domain_password(Domain, Password) ->
+    HostType = get_host_type(Domain),
+    case HostType of
+        {ok, _} ->
+            mongoose_domain_sql:set_domain_admin(Domain, Password);
+        {error, not_found} ->
+            {error, not_found}
+    end.
+
+-spec delete_domain_password(domain()) -> ok.
+delete_domain_password(Domain) ->
+    mongoose_domain_sql:delete_domain_admin(Domain).
 
 -spec register_subdomain(host_type(), subdomain_pattern(),
                          mongoose_packet_handler:t()) ->

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -85,21 +85,23 @@ start(#{db_pool := Pool}) ->
               " WHERE domain_events.id >= ? AND domain_events.id <= ? "
               " ORDER BY domain_events.id ">>),
     %% Admins
-    prepare(domain_insert_admin, domain_admin, [domain, password],
-            <<"INSERT INTO domain_admin (domain, password) VALUES (?, ?)">>),
-    prepare(domain_update_admin, domain_admin, [password, domain],
-            <<"UPDATE domain_admin"
+    prepare(domain_insert_admin, domain_admins, [domain, password],
+            <<"INSERT INTO domain_admins (domain, password) VALUES (?, ?)">>),
+    prepare(domain_update_admin, domain_admins, [password, domain],
+            <<"UPDATE domain_admins"
               " SET password = ? "
               " WHERE domain = ?">>),
-    prepare(domain_delete_admin, domain_admin, [domain],
-            <<"DELETE FROM domain_admin WHERE domain = ?">>),
-    prepare(domain_select_admin, domain_admin, [domain],
+    prepare(domain_delete_admin, domain_admins, [domain],
+            <<"DELETE FROM domain_admins WHERE domain = ?">>),
+    prepare(domain_select_admin, domain_admins, [domain],
             <<"SELECT domain, password"
-              " FROM domain_admin WHERE domain = ?">>),
+              " FROM domain_admins WHERE domain = ?">>),
     ok.
 
 prepare_test_queries(Pool) ->
     True = sql_true(Pool),
+    prepare(domain_erase_admins, domain_admins, [],
+            <<"DELETE FROM domain_admins">>),
     prepare(domain_erase_settings, domain_settings, [],
             <<"DELETE FROM domain_settings">>),
     prepare(domain_erase_events, domain_events, [],
@@ -200,7 +202,7 @@ insert_domain_admin(Pool, Domain, Password) ->
     execute_successfully(Pool, domain_insert_admin, [Domain, Password]).
 
 update_domain_admin(Pool, Domain, Password) ->
-    execute_successfully(Pool, domain_update_admin, [Domain, Password]).
+    execute_successfully(Pool, domain_update_admin, [Password, Domain]).
 
 delete_domain_admin(Pool, Domain) ->
     execute_successfully(Pool, domain_delete_admin, [Domain]).
@@ -287,7 +289,8 @@ insert_full_event_mssql(EventId, Domain) ->
 
 erase_database(Pool) ->
     execute_successfully(Pool, domain_erase_events, []),
-    execute_successfully(Pool, domain_erase_settings, []).
+    execute_successfully(Pool, domain_erase_settings, []),
+    execute_successfully(Pool, domain_erase_admins, []).
 
 insert_domain_settings_without_event(Domain, HostType) ->
     Pool = get_db_pool(),

--- a/src/graphql/admin/mongoose_graphql_admin_auth_info.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_auth_info.erl
@@ -1,0 +1,27 @@
+-module(mongoose_graphql_admin_auth_info).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include_lib("jid/include/jid.hrl").
+
+execute(#{authorized := Authorized}, admin, <<"authStatus">>, _Args) ->
+    case Authorized of
+        true ->
+            {ok, 'AUTHORIZED'};
+        false ->
+            {ok, 'UNAUTHORIZED'}
+    end;
+execute(Ctx, admin, <<"domain">>, _Args) ->
+    case maps:get(admin, Ctx, null) of
+        null -> {ok, null};
+        #jid{lserver = Domain} -> {ok, Domain}
+    end;
+execute(Ctx, admin, <<"authType">>, _Args) ->
+    case maps:get(authorized_as, Ctx, null) of
+        null -> {ok, null};
+        domain_admin -> {ok, domain_admin};
+        admin -> {ok, admin}
+    end.

--- a/src/graphql/admin/mongoose_graphql_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_query.erl
@@ -21,10 +21,5 @@ execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
     {ok, #{}};
 execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster};
-execute(#{authorized := Authorized}, _Obj, <<"checkAuth">>, _Args) ->
-    case Authorized of
-        true ->
-            {ok, 'AUTHORIZED'};
-        false ->
-            {ok, 'UNAUTHORIZED'}
-    end.
+execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
+    {ok, admin}.

--- a/src/graphql/admin/mongoose_graphql_domain_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_domain_admin_mutation.erl
@@ -27,14 +27,14 @@ execute(_Ctx, admin, <<"enableDomain">>, #{<<"domain">> := Domain}) ->
         ok ->
             {ok, #domain{enabled = true, domain = Domain}};
         {error, Error} ->
-            error_handler(Error, Domain, <<"">>)
+            error_handler(Error, Domain, <<>>)
     end;
 execute(_Ctx, admin, <<"disableDomain">>, #{<<"domain">> := Domain}) ->
     case mongoose_domain_api:disable_domain(Domain) of
         ok ->
             {ok, #domain{enabled = false, domain = Domain}};
         {error, Error} ->
-            error_handler(Error, Domain, <<"">>)
+            error_handler(Error, Domain, <<>>)
     end;
 execute(_Ctx, admin, <<"setDomainPassword">>,
         #{<<"domain">> := Domain, <<"password">> := Password}) ->
@@ -42,7 +42,7 @@ execute(_Ctx, admin, <<"setDomainPassword">>,
         ok ->
             {ok, <<"Domain password set successfully">>};
         {error, Error} ->
-            error_handler(Error, Domain, <<"">>)
+            error_handler(Error, Domain, <<>>)
     end;
 execute(_Ctx, admin, <<"deleteDomainPassword">>, #{<<"domain">> := Domain}) ->
     ok = mongoose_domain_api:delete_domain_password(Domain),

--- a/src/graphql/admin/mongoose_graphql_domain_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_domain_admin_mutation.erl
@@ -35,7 +35,18 @@ execute(_Ctx, admin, <<"disableDomain">>, #{<<"domain">> := Domain}) ->
             {ok, #domain{enabled = false, domain = Domain}};
         {error, Error} ->
             error_handler(Error, Domain, <<"">>)
-    end.
+    end;
+execute(_Ctx, admin, <<"setDomainPassword">>,
+        #{<<"domain">> := Domain, <<"password">> := Password}) ->
+    case mongoose_domain_api:set_domain_password(Domain, Password) of
+        ok ->
+            {ok, <<"Domain password set successfully">>};
+        {error, Error} ->
+            error_handler(Error, Domain, <<"">>)
+    end;
+execute(_Ctx, admin, <<"deleteDomainPassword">>, #{<<"domain">> := Domain}) ->
+    ok = mongoose_domain_api:delete_domain_password(Domain),
+    {ok, <<"Domain admin deleted successfully">>}.
 
 error_handler(Error, Domain, HostType) ->
     case {error, Error} of

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -128,6 +128,7 @@ graphql_parse(Doc) ->
 admin_mapping_rules() ->
     #{objects => #{
         'AdminQuery' => mongoose_graphql_admin_query,
+        'AdminAuthInfo' => mongoose_graphql_admin_auth_info,
         'DomainAdminQuery' => mongoose_graphql_domain_admin_query,
         'AdminMutation' => mongoose_graphql_admin_mutation,
         'DomainAdminMutation' => mongoose_graphql_domain_admin_mutation,

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -44,6 +44,8 @@ init() ->
 -spec get_endpoint(atom()) -> graphql:endpoint_context().
 get_endpoint(admin) ->
     graphql_schema:get_endpoint_ctx(?ADMIN_EP_NAME);
+get_endpoint(domain_admin) ->
+    graphql_schema:get_endpoint_ctx(?ADMIN_EP_NAME);
 get_endpoint(user) ->
     graphql_schema:get_endpoint_ctx(?USER_EP_NAME);
 get_endpoint(Name) ->
@@ -72,12 +74,12 @@ execute(Ep, #{document := Doc,
         {ok, #{ast := Ast2,
                fun_env := FunEnv}} = graphql:type_check(Ep, Ast),
         ok = graphql:validate(Ast2),
-        ok = mongoose_graphql_permissions:check_permissions(OpName, AuthStatus, Ast2),
         Coerced = graphql:type_check_params(Ep, FunEnv, OpName, Vars),
         Ctx2 = Ctx#{params => Coerced,
                     operation_name => OpName,
                     authorized => AuthStatus,
                     error_module => mongoose_graphql_errors},
+        ok = mongoose_graphql_permissions:check_permissions(Ctx2, Ast2),
         {ok, graphql:execute(Ep, Ctx2, Ast2)}
     catch
         throw:{error, Err} ->

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -8,10 +8,6 @@ input(<<"PresenceShow">>, Show) ->
     {ok, list_to_binary(string:to_lower(binary_to_list(Show)))};
 input(<<"PresenceType">>, Type) ->
     {ok, list_to_binary(string:to_lower(binary_to_list(Type)))};
-input(<<"AuthStatus">>, <<"AUTHORIZED">>) -> {ok, 'AUTHORIZED'};
-input(<<"AuthStatus">>, <<"UNAUTHORIZED">>)  -> {ok, 'UNAUTHORIZED'};
-input(<<"AuthType">>, <<"ADMIN">>) -> {ok, admin};
-input(<<"AuthType">>, <<"DOMAIN_ADMIN">>)  -> {ok, domain_admin};
 input(<<"Affiliation">>, <<"OWNER">>) -> {ok, owner};
 input(<<"Affiliation">>, <<"MEMBER">>) -> {ok, member};
 input(<<"Affiliation">>, <<"NONE">>) -> {ok, none};

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -10,6 +10,8 @@ input(<<"PresenceType">>, Type) ->
     {ok, list_to_binary(string:to_lower(binary_to_list(Type)))};
 input(<<"AuthStatus">>, <<"AUTHORIZED">>) -> {ok, 'AUTHORIZED'};
 input(<<"AuthStatus">>, <<"UNAUTHORIZED">>)  -> {ok, 'UNAUTHORIZED'};
+input(<<"AuthType">>, <<"ADMIN">>) -> {ok, admin};
+input(<<"AuthType">>, <<"DOMAIN_ADMIN">>)  -> {ok, domain_admin};
 input(<<"Affiliation">>, <<"OWNER">>) -> {ok, owner};
 input(<<"Affiliation">>, <<"MEMBER">>) -> {ok, member};
 input(<<"Affiliation">>, <<"NONE">>) -> {ok, none};
@@ -34,6 +36,8 @@ output(<<"PresenceType">>, Type) ->
     {ok, list_to_binary(string:to_upper(binary_to_list(Type)))};
 output(<<"AuthStatus">>, Status) ->
     {ok, atom_to_binary(Status, utf8)};
+output(<<"AuthType">>, Type) ->
+    {ok, list_to_binary(string:to_upper(atom_to_list(Type)))};
 output(<<"Affiliation">>, Aff) ->
     {ok, list_to_binary(string:to_upper(atom_to_list(Aff)))};
 output(<<"BlockingAction">>, Action) ->

--- a/src/graphql/mongoose_graphql_errors.erl
+++ b/src/graphql/mongoose_graphql_errors.erl
@@ -98,7 +98,12 @@ authorize_err_msg({request_error, {header, <<"authorization">>}, _}) ->
 authorize_err_msg(wrong_credentials) ->
     "The provided credentials are wrong";
 authorize_err_msg({no_permissions, Op}) ->
-    io_lib:format("Cannot execute query ~s without permissions", [Op]).
+    io_lib:format("Cannot execute query ~s without permissions", [Op]);
+authorize_err_msg({no_permissions, Op, Res, InvalidArgs}) ->
+    InvalidArgs2 = lists:join(", ", InvalidArgs),
+    Format = "Cannot execute query ~s without permissions to the given ~s. "
+                ++ "Args with invalid value: ~s",
+    io_lib:format(Format, [Op, Res, InvalidArgs2]).
 
 parse_err_msg({parser_error, {Line, graphql_parser, Msg}}) ->
     io_lib:format("Cannot parse line ~B because of ~s", [Line, Msg]);

--- a/src/graphql/mongoose_graphql_permissions.erl
+++ b/src/graphql/mongoose_graphql_permissions.erl
@@ -22,20 +22,45 @@
 %% @end
 -module(mongoose_graphql_permissions).
 
--export([check_permissions/3]).
+-export([check_permissions/2]).
 
 -include_lib("graphql/src/graphql_schema.hrl").
 -include_lib("graphql/src/graphql_internal.hrl").
 -include_lib("graphql/include/graphql.hrl").
+-include_lib("jid/include/jid.hrl").
 
 -type auth_status() :: boolean().
+-type auth_role() :: user | admin | domain_admin.
+-type params() :: map().
+-type auth_ctx() :: #{operation_name := binary(),
+                      params := params(),
+                      authorized := auth_status(),
+                      authorized_as => auth_role(),
+                      user => jid:jid(),
+                      admin => jid:jid(),
+                      atom() => any()}.
+-type fail_acc() :: #{path := [binary()],
+                      type := atom(),
+                      invalid := [binary()]}.
 -type document() :: #document{}.
+-type definitions() :: [any()].
 
 %% @doc Checks if query can be executed by unauthorized request. If not, throws
 %% an error. When request is authorized, just skip.
 %% @end
--spec check_permissions(binary(), auth_status(), document()) -> ok.
-check_permissions(OpName, false, #document{definitions = Definitions}) ->
+-spec check_permissions(auth_ctx(), document()) -> ok.
+check_permissions(#{operation_name := OpName, authorized := false},
+                  #document{definitions = Definitions}) ->
+    check_unauthorized_request_permissions(OpName, Definitions);
+check_permissions(#{operation_name := OpName, authorized_as := domain_admin,
+                    admin := #jid{lserver = Domain}, params := Params},
+                  #document{definitions = Definitions}) ->
+    check_domain_authorized_request_permissions(OpName, Domain, Params, Definitions);
+check_permissions(#{authorized := true}, _) ->
+    ok.
+
+-spec check_unauthorized_request_permissions(binary(), definitions()) -> ok.
+check_unauthorized_request_permissions(OpName, Definitions) ->
     Op = lists:filter(fun(D) -> is_req_operation(D, OpName) end, Definitions),
     case Op of
         [#op{schema = Schema, selection_set = Set} = Op1] ->
@@ -58,11 +83,89 @@ check_permissions(OpName, false, #document{definitions = Definitions}) ->
             end;
         _ ->
             ok
-    end;
-check_permissions(_, true, _) ->
-    ok.
+    end.
+
+-spec check_domain_authorized_request_permissions(binary(), binary(),
+                                                  params(), definitions()) -> ok.
+check_domain_authorized_request_permissions(OpName, Domain, Params, Definitions) ->
+    Op = lists:filter(fun(D) -> is_req_operation(D, OpName) end, Definitions),
+    case Op of
+        [#op{selection_set = Set}] ->
+            case check_fields(#{domain => Domain}, Params, Set) of
+                [] ->
+                    ok;
+                [#{invalid := Args, path := Path, type := Type}| _] ->
+                    OpName2 = op_name(OpName),
+                    Error = {no_permissions, OpName2, Type, Args},
+                    Path2 = lists:reverse([OpName2 | Path]),
+                    graphql_err:abort(Path2, authorize, Error)
+            end;
+        _ ->
+            ok
+    end.
 
 % Internal
+
+-spec check_fields(map(), map(), [field()]) -> [fail_acc()].
+check_fields(Ctx, Params, Fields) ->
+    % Return empty list when permissions are valid.
+    lists:flatten(lists:filtermap(fun(F) -> check_field(F, Ctx, Params) end, Fields)).
+
+-spec check_field(field(), map(), params()) -> false | {true, fail_acc() | [fail_acc()]}.
+check_field(#field{id = Name, selection_set = Set, args = Args,
+                   schema = #schema_field{directives = Directives}}, Ctx, Params) ->
+    Args2 = maps:from_list([prepare_arg(ArgName, Type, Params) || {ArgName, Type} <- Args]),
+    Res =
+        case lists:filter(fun is_protected_directive/1, Directives) of
+            [#directive{} = Dir] ->
+                #{type := Type, args := PArgs} = protected_dir_args_to_map(Dir),
+                Acc = check_field_args(Type, Ctx, PArgs, Args2),
+                acc_path(name(Name), Acc);
+            _ ->
+               false
+        end,
+    check_field_type(Res, Ctx, Params, Set, Name).
+
+check_field_type(false, Ctx, Params, Set, Name) ->
+    case check_fields(Ctx, Params, Set) of
+        [] -> false;
+        Invalid -> {true, [acc_path(Name, Acc) || Acc <- Invalid]}
+    end;
+check_field_type(Acc, _, _, _, _) ->
+    Acc.
+
+prepare_arg(ArgName, #{value := #var{id = Name}}, Vars) ->
+    {ArgName, maps:get(name(Name), Vars)};
+prepare_arg(ArgName, #{value := Val}, _) ->
+    {ArgName, Val}.
+
+check_field_args({enum, <<"DOMAIN">>}, #{domain := Domain}, ProtectedArgs, Params) ->
+    Res = lists:filter(fun(Arg) -> not arg_eq(maps:get(Arg, Params), Domain) end, ProtectedArgs),
+    acc(Res, domain);
+check_field_args({enum, <<"DEFAULT">>}, _AuthCtx, _ProtectedArgs, _Args) ->
+    acc([], default).
+
+arg_eq(Domain, Domain) -> true;
+arg_eq(#jid{lserver = Domain}, Domain) ->  true;
+arg_eq(_, _) ->  false.
+
+acc([], Type) when is_atom(Type) -> false;
+acc(Invalid, Type) when is_atom(Type) -> {true, #{type => Type, path => [], invalid => Invalid}}.
+
+acc_path(_Field, false) -> false;
+acc_path(Field, {true, Acc}) -> {true, acc_path(Field, Acc)};
+acc_path(Field, #{path := Path} = Acc) ->
+    Acc#{path => [Field | Path]}.
+%acc_path(Field, Acc) ->
+    %Acc#{path => [Field]}.
+
+protected_dir_args_to_map(#directive{args = Args}) ->
+    Default = #{type => {enum, <<"DEFAULT">>}, args => []},
+    ArgsMap = maps:from_list([{binary_to_atom(name(N)), V} || {N, V} <- Args]),
+    maps:merge(Default, ArgsMap).
+
+name({name, _, N}) -> N;
+name(N) when is_binary(N) -> N.
 
 op_name(undefined) ->
     <<"ROOT">>;

--- a/src/graphql/mongoose_graphql_permissions.erl
+++ b/src/graphql/mongoose_graphql_permissions.erl
@@ -39,14 +39,21 @@
                       user => jid:jid(),
                       admin => jid:jid(),
                       atom() => any()}.
--type fail_acc() :: #{path := [binary()],
-                      type := atom(),
-                      invalid := [binary()]}.
+-type no_access_info() :: #{path := [binary()],
+                            type := atom(),
+                            invalid := [binary()]}.
+-type field_check_result() :: ok | no_access_info().
 -type document() :: #document{}.
 -type definitions() :: [any()].
 
-%% @doc Checks if query can be executed by unauthorized request. If not, throws
-%% an error. When request is authorized, just skip.
+%% @doc Checks if query can be executed by unauthorized request or authorized as one
+%% of the roles (USER, ADMIN, DOMAIN_ADMIN). If not, throw an error.
+%%
+%% The USER and ADMIN can execute each query because they are on separated GraphQL
+%% instances that serves different queries.
+%%
+%% The DOMAIN_ADMIN use the same GraphQL instance as ADMIN, but have permissions
+%% only to administrate own domain.
 %% @end
 -spec check_permissions(auth_ctx(), document()) -> ok.
 check_permissions(#{operation_name := OpName, authorized := false},
@@ -92,9 +99,9 @@ check_domain_authorized_request_permissions(OpName, Domain, Params, Definitions)
     case Op of
         [#op{selection_set = Set}] ->
             case check_fields(#{domain => Domain}, Params, Set) of
-                [] ->
+                ok ->
                     ok;
-                [#{invalid := Args, path := Path, type := Type}| _] ->
+                #{invalid := Args, path := Path, type := Type} ->
                     OpName2 = op_name(OpName),
                     Error = {no_permissions, OpName2, Type, Args},
                     Path2 = lists:reverse([OpName2 | Path]),
@@ -106,56 +113,63 @@ check_domain_authorized_request_permissions(OpName, Domain, Params, Definitions)
 
 % Internal
 
--spec check_fields(map(), map(), [field()]) -> [fail_acc()].
+-spec check_fields(map(), map(), [any()]) -> field_check_result().
 check_fields(Ctx, Params, Fields) ->
-    % Return empty list when permissions are valid.
-    lists:flatten(lists:filtermap(fun(F) -> check_field(F, Ctx, Params) end, Fields)).
+    Fun = fun(F, ok) -> check_field(F, Ctx, Params);
+             (_, NoAccessInfo) -> NoAccessInfo
+          end,
+    lists:foldl(Fun, ok, Fields).
 
--spec check_field(field(), map(), params()) -> false | {true, fail_acc() | [fail_acc()]}.
+-spec check_field(field() | any(), map(), map()) -> field_check_result().
 check_field(#field{id = Name, selection_set = Set, args = Args,
                    schema = #schema_field{directives = Directives}}, Ctx, Params) ->
     Args2 = maps:from_list([prepare_arg(ArgName, Type, Params) || {ArgName, Type} <- Args]),
-    Res =
-        case lists:filter(fun is_protected_directive/1, Directives) of
-            [#directive{} = Dir] ->
-                #{type := Type, args := PArgs} = protected_dir_args_to_map(Dir),
-                Acc = check_field_args(Type, Ctx, PArgs, Args2),
-                acc_path(name(Name), Acc);
-            [] ->
-               false
-        end,
-    check_field_type(Res, Ctx, Params, Set, Name).
+    Res = check_field_args(Ctx, Args2, Directives),
+    Res2 = check_field_type(Res, Ctx, Params, Set),
+    add_path(Res2, name(Name));
+check_field(_, _, _) -> ok.
 
-check_field_type(false, Ctx, Params, Set, Name) ->
-    case check_fields(Ctx, Params, Set) of
-        [] -> false;
-        Invalid -> {true, [acc_path(Name, Acc) || Acc <- Invalid]}
-    end;
-check_field_type(Acc, _, _, _, _) ->
-    Acc.
+-spec check_field_args(map(), map(), [graphql:directive()]) -> field_check_result().
+check_field_args(Ctx, Args, Directives) ->
+    case lists:filter(fun is_protected_directive/1, Directives) of
+        [#directive{} = Dir] ->
+            #{type := {enum, Type}, args := PArgs} = protected_dir_args_to_map(Dir),
+            check_field_args(Type, Ctx, PArgs, Args);
+        [] ->
+            ok
+    end.
+
+-spec check_field_args(binary(), map(), [binary()], map()) -> field_check_result().
+check_field_args(<<"DOMAIN">>, #{domain := Domain}, ProtectedArgs, Args) ->
+    InvalidArgs =
+        lists:filter(fun(N) -> not arg_eq(maps:get(N, Args), Domain) end, ProtectedArgs),
+    make_result(InvalidArgs, domain);
+check_field_args(<<"DEFAULT">>, _Ctx, _ProtectedArgs, _Args) ->
+    ok.
+
+-spec check_field_type(field_check_result(), map(), map(), [any()]) -> field_check_result().
+check_field_type(ok, Ctx, Params, Set) ->
+    check_fields(Ctx, Params, Set);
+check_field_type(NoAccessInfo, _, _, _) ->
+    NoAccessInfo.
 
 prepare_arg(ArgName, #{value := #var{id = Name}}, Vars) ->
     {ArgName, maps:get(name(Name), Vars)};
 prepare_arg(ArgName, #{value := Val}, _) ->
     {ArgName, Val}.
 
-check_field_args({enum, <<"DOMAIN">>}, #{domain := Domain}, ProtectedArgs, Params) ->
-    Res = lists:filter(fun(Arg) -> not arg_eq(maps:get(Arg, Params), Domain) end, ProtectedArgs),
-    acc(Res, domain);
-check_field_args({enum, <<"DEFAULT">>}, _AuthCtx, _ProtectedArgs, _Args) ->
-    acc([], default).
-
 arg_eq(Domain, Domain) -> true;
 arg_eq(#jid{lserver = Domain}, Domain) ->  true;
 arg_eq(_, _) ->  false.
 
-acc([], Type) when is_atom(Type) -> false;
-acc(Invalid, Type) when is_atom(Type) -> {true, #{type => Type, path => [], invalid => Invalid}}.
+make_result([], _) ->
+    ok;
+make_result(InvalidArgs, Type) when is_atom(Type) ->
+    #{type => Type, path => [], invalid => InvalidArgs}.
 
-acc_path(_Field, false) -> false;
-acc_path(Field, {true, Acc}) -> {true, acc_path(Field, Acc)};
-acc_path(Field, #{path := Path} = Acc) ->
-    Acc#{path => [Field | Path]}.
+add_path(ok, _) -> ok;
+add_path(#{path := Path} = Acc, FieldName) ->
+    Acc#{path => [FieldName | Path]}.
 
 protected_dir_args_to_map(#directive{args = Args}) ->
     Default = #{type => {enum, <<"DEFAULT">>}, args => []},

--- a/src/graphql/mongoose_graphql_permissions.erl
+++ b/src/graphql/mongoose_graphql_permissions.erl
@@ -121,7 +121,7 @@ check_field(#field{id = Name, selection_set = Set, args = Args,
                 #{type := Type, args := PArgs} = protected_dir_args_to_map(Dir),
                 Acc = check_field_args(Type, Ctx, PArgs, Args2),
                 acc_path(name(Name), Acc);
-            _ ->
+            [] ->
                false
         end,
     check_field_type(Res, Ctx, Params, Set, Name).
@@ -156,8 +156,6 @@ acc_path(_Field, false) -> false;
 acc_path(Field, {true, Acc}) -> {true, acc_path(Field, Acc)};
 acc_path(Field, #{path := Path} = Acc) ->
     Acc#{path => [Field | Path]}.
-%acc_path(Field, Acc) ->
-    %Acc#{path => [Field]}.
 
 protected_dir_args_to_map(#directive{args = Args}) ->
     Default = #{type => {enum, <<"DEFAULT">>}, args => []},

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -93,8 +93,8 @@ permissions() ->
 
 domain_permissions() ->
     [check_field_domain_permissions,
-     check_child_object_field_domain_permissions,
-     check_interface_field_domain_permissions
+     check_child_object_field_domain_permissions
+     %check_interface_field_domain_permissions TODO
     ].
 
 user_listener() ->

--- a/test/mongoose_graphql_SUITE_data/listener_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/listener_schema.gql
@@ -3,7 +3,6 @@ schema{
   mutation: Mutation
 }
 
-#directive @protected on FIELD_DEFINITION | OBJECT
 directive @protected (type: ProtectionType = DEFAULT, args: [String!] = [])
   on FIELD_DEFINITION | OBJECT
 

--- a/test/mongoose_graphql_SUITE_data/listener_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/listener_schema.gql
@@ -3,13 +3,21 @@ schema{
   mutation: Mutation
 }
 
-directive @protected on FIELD_DEFINITION | OBJECT
+#directive @protected on FIELD_DEFINITION | OBJECT
+directive @protected (type: ProtectionType = DEFAULT, args: [String!] = [])
+  on FIELD_DEFINITION | OBJECT
+
+enum ProtectionType{
+  DOMAIN
+  DEFAULT
+}
 
 """
 Contains all available queries.
 """
 type Query @protected{
   field: String
+  fieldDP(argA: String): String @protected(type: DOMAIN, args: ["argA"])
 }
 
 """

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -3,11 +3,20 @@ schema{
   mutation: UserMutation
 }
 
-directive @protected on FIELD_DEFINITION | OBJECT | INTERFACE
+#directive @protected on FIELD_DEFINITION | OBJECT | INTERFACE
+directive @protected (type: ProtectionType = DEFAULT, args: [String!] = [])
+  on FIELD_DEFINITION | OBJECT | INTERFACE
+
+enum ProtectionType{
+  DOMAIN
+  DEFAULT
+}
 
 type UserQuery{
   field: String
   protectedField: String @protected
+  domainProtectedField(argA: String, argB: String):
+    String @protected(type: DOMAIN, args: ["argA"])
   interface: Interface
   union: UnionT
   obj: Object
@@ -35,6 +44,8 @@ type Object implements Interface{
   otherName: String @protected
   protectedName: String
   protectedField: String @protected
+  domainProtectedField(argA: String, argB: String):
+    String @protected(type: DOMAIN, args: ["argA"])
   field: String
 }
 

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -3,7 +3,6 @@ schema{
   mutation: UserMutation
 }
 
-#directive @protected on FIELD_DEFINITION | OBJECT | INTERFACE
 directive @protected (type: ProtectionType = DEFAULT, args: [String!] = [])
   on FIELD_DEFINITION | OBJECT | INTERFACE
 

--- a/test/mongoose_graphql_default_resolver.erl
+++ b/test/mongoose_graphql_default_resolver.erl
@@ -6,6 +6,8 @@
 
 execute(_Ctx, _Obj, <<"field">>, _Attrs) ->
     {ok, <<"Test field">>};
+execute(_Ctx, _Obj, <<"fieldDP">>, _Attrs) ->
+    {ok, <<"Test field">>};
 execute(_Ctx, _Obj, <<"id">>, #{<<"value">> := Value}) ->
     {ok, Value};
 execute(_Ctx, _Obj, Field, _Attrs) ->


### PR DESCRIPTION
This PR addresses [MIM-1639](https://erlangsolutions.atlassian.net/browse/MIM-1639) and adds support for admin per domain. It introduces the third GraphQL listener that exposes the admin schema, but queries are restricted to the authorized domain admin. That means that the admin authorized for the `localhost` domain cannot execute queries for other domains (e.g. `localhost2`).

The domain admin credentials are stored in the new table `domain_admin`. Currently, the password is stored in plain form. The logic to manage domain admin was added to the `mongoose_domain_api` module.

The permissions, whether the given domain admin can execute queries are checked in the `mongoose_graphql_permissions` module. This module ensures that domain-protected field arguments cannot contain unauthorized domains.

The domain-protected field has to contain the following directive in the admin schema:
```graphql
field(argA: String): String @protected(type: DOMAIN, args: ["argA"])
```
The directive `type` argument value `DOMAIN` means that the field must be domain checked, and the `args` argument stores field arguments to check.

The domain admin request authorization basic token should be encoded from the pattern`admin@$domain:$password`.

### Fix the field() type
The `field()` type from the graphql core library was incorrect and to fix the dialyzer it had to be changed. I change the graphql dependency to the branch with the fix. It should be changed back after we merge the fix.
https://github.com/Premwoik/graphql-erlang/pull/2

### Next steps
- Store the domain admin credentials in a more secure way.
- Allow restricting fields to be executable only by global admin (not by domain admins).
- Extend domain check for the domain-protected fields to support subdomains, JIDs, and input types.
- Decide and mark fields that should be domain protected or executable only by global admin.
- Add other missing test cases.

### Questions
- _Make it possible to use domain admin not only for the RDBMS backends?_
   **Answer**: There is no such need for now.

