### PR TITLE
Rework HTTP handler configuration

### DIFF
--- a/big_tests/tests/domain_rest_helper.erl
+++ b/big_tests/tests/domain_rest_helper.erl
@@ -114,9 +114,10 @@ listener_opts(Params) ->
              transport => config([listen, http, transport], #{num_acceptors => 10})}).
 
 domain_handler(Params) ->
-    {"localhost", "/api", mongoose_domain_handler, handler_opts(Params)}.
+    maps:merge(#{host => "localhost", path => "/api", module => mongoose_domain_handler},
+               handler_opts(Params)).
 
 handler_opts(#{skip_auth := true}) ->
-    [];
+    #{};
 handler_opts(_Params) ->
-    [{password, <<"secret">>}, {username, <<"admin">>}].
+    #{password => <<"secret">>, username => <<"admin">>}.

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -277,35 +277,29 @@ start_admin_listener(Creds) ->
     NewOpts = insert_creds(Opts, Creds),
     rpc(mim(), mongoose_listener, start_listener, [NewOpts]).
 
-insert_creds(Opts = #{handlers := Modules}, Creds) ->
-    {Host, Path, mongoose_api_admin, PathOpts} = lists:keyfind(mongoose_api_admin, 3, Modules),
-    NewPathOpts = inject_creds_to_opts(PathOpts, Creds),
-    NewModules = lists:keyreplace(mongoose_api_admin, 3, Modules,
-                                  {Host, Path, mongoose_api_admin,  NewPathOpts}),
-    Opts#{handlers := NewModules}.
+insert_creds(Opts = #{handlers := Handlers}, Creds) ->
+    NewHandlers = [inject_creds_to_opts(Handler, Creds) || Handler <- Handlers],
+    Opts#{handlers := NewHandlers}.
 
-inject_creds_to_opts(PathOpts, any) ->
-    lists:keydelete(auth, 1, PathOpts);
-inject_creds_to_opts(PathOpts, Creds) ->
-    case lists:keymember(auth, 1, PathOpts) of
-        true ->
-            lists:keyreplace(auth, 1, PathOpts, {auth, Creds});
-        false ->
-            lists:append(PathOpts, [{auth, Creds}])
-    end.
+inject_creds_to_opts(Handler = #{module := mongoose_api_admin}, Creds) ->
+    case Creds of
+        {UserName, Password} ->
+            Handler#{username => UserName, password => Password};
+        any ->
+            maps:without([username, password], Handler)
+    end;
+inject_creds_to_opts(Handler, _Creds) ->
+    Handler.
 
 % @doc Checks whether a config for a port is an admin or client one.
-% This is determined based on modules used. If there is any mongoose_api_admin module used,
-% it is admin config. If not and there is at least one mongoose_api_client* module used,
-% it's clients.
-is_roles_config(#{module := ejabberd_cowboy, handlers := Modules}, admin) ->
-    lists:any(fun({_, _Path,  Mod, _Args}) -> Mod == mongoose_api_admin; (_) -> false  end, Modules);
-is_roles_config(#{module := ejabberd_cowboy, handlers := Modules}, client) ->
-    ModulesTokens = lists:map(fun({_, _Path, Mod, _}) -> string:tokens(atom_to_list(Mod), "_");
-                                 (_) -> []
-                              end, Modules),
-    lists:any(fun(["mongoose", "client", "api" | _T]) -> true; (_) -> false end, ModulesTokens);
+% This is determined based on handler modules used.
+is_roles_config(#{module := ejabberd_cowboy, handlers := Handlers}, Role) ->
+    RoleModule = role_to_module(Role),
+    lists:any(fun(#{module := Module}) -> Module =:= RoleModule end, Handlers);
 is_roles_config(_, _) -> false.
+
+role_to_module(admin) -> mongoose_api_admin;
+role_to_module(client) -> mongoose_client_api.
 
 mapfromlist(L) ->
     Nl = lists:map(fun({K, {V}}) when is_list(V) ->

--- a/doc/migrations/5.0.0_5.1.0.md
+++ b/doc/migrations/5.0.0_5.1.0.md
@@ -2,6 +2,10 @@
 
 The configuration format has slightly changed and you might need to amend `mongooseim.toml`.
 
+### Section `listen`
+
+There is a new, simplified configuration format for `mongoose_client_api`. You need to change the `listen` section unless you have disabled the client API in your configuration file. Consult the [option description](../configuration/listen.md#handler-types-rest-api-client-mongoose_client_api) and the [example configuration](http://localhost:8000/configuration/listen/#example-3-client-api) for details.
+
 ### Section `acl`
 
 The implicit check for user's domain in patterns is now configurable and the default behaviour (previously undocumented) is more consistent - the check is always performed unless disabled with `match = "all"`.

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -59,6 +59,7 @@
   [[listen.http.handlers.mongoose_api_admin]]
     host = "localhost"
     path = "/api"
+
   [[listen.http.handlers.mongoose_domain_handler]]
     host = "localhost"
     path = "/api"
@@ -74,49 +75,9 @@
   {{{https_config}}}
   {{/https_config}}
 
-  [[listen.http.handlers.lasse_handler]]
+  [[listen.http.handlers.mongoose_client_api]]
     host = "_"
-    path = "/api/sse"
-    module = "mongoose_client_api_sse"
-
-  [[listen.http.handlers.mongoose_client_api_messages]]
-    host = "_"
-    path = "/api/messages/[:with]"
-
-  [[listen.http.handlers.mongoose_client_api_contacts]]
-    host = "_"
-    path = "/api/contacts/[:jid]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms]]
-    host = "_"
-    path = "/api/rooms/[:id]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_config]]
-    host = "_"
-    path = "/api/rooms/[:id]/config"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_users]]
-    host = "_"
-    path = "/api/rooms/:id/users/[:user]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_messages]]
-    host = "_"
-    path = "/api/rooms/[:id]/messages"
-
-  [[listen.http.handlers.cowboy_swagger_redirect_handler]]
-    host = "_"
-    path = "/api-docs"
-
-  [[listen.http.handlers.cowboy_swagger_json_handler]]
-    host = "_"
-    path = "/api-docs/swagger.json"
-
-  [[listen.http.handlers.cowboy_static]]
-    host = "_"
-    path = "/api-docs/[...]"
-    type = "priv_dir"
-    app = "cowboy_swagger"
-    content_path = "swagger"
+    path = "/api"
 
 [[listen.http]]
   {{#http_api_old_endpoint}}
@@ -128,7 +89,6 @@
   [[listen.http.handlers.mongoose_api]]
     host = "localhost"
     path = "/api"
-    handlers = ["mongoose_api_metrics", "mongoose_api_users"]
 
 [[listen.c2s]]
   port = {{{c2s_port}}}

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -5,6 +5,9 @@
 
 -export([parse_file/1]).
 
+%% Utilities for section manipulation
+-export([process/3]).
+
 -ifdef(TEST).
 -export([process/1,
          extract_errors/1]).

--- a/src/config/mongoose_config_utils.erl
+++ b/src/config/mongoose_config_utils.erl
@@ -2,8 +2,8 @@
 %% This stuff can be pure, but most likely not.
 %% It's for generic functions.
 -module(mongoose_config_utils).
--export([exit_or_halt/1]).
--export([section_to_defaults/1]).
+-export([exit_or_halt/1, section_to_defaults/1, merge_sections/2]).
+
 -ignore_xref([section_to_defaults/1]).
 
 -include("mongoose_config_spec.hrl").
@@ -21,3 +21,22 @@ exit_or_halt(ExitText) ->
 
 section_to_defaults(#section{defaults = Defaults}) ->
     Defaults.
+
+-spec merge_sections(mongoose_config_spec:config_section(),
+                     mongoose_config_spec:config_section()) ->
+          mongoose_config_spec:config_section().
+merge_sections(BasicSection, ExtraSection) ->
+    #section{items = Items1, required = Required1, defaults = Defaults1,
+             process = Process1} = BasicSection,
+    #section{items = Items2, required = Required2, defaults = Defaults2,
+             process = Process2} = ExtraSection,
+    BasicSection#section{items = maps:merge(Items1, Items2),
+                         required = Required1 ++ Required2,
+                         defaults = maps:merge(Defaults1, Defaults2),
+                         process = merge_process_functions(Process1, Process2)}.
+
+merge_process_functions(Process1, Process2) ->
+    fun(Path, V) ->
+            V1 = mongoose_config_parser_toml:process(Path, V, Process1),
+            mongoose_config_parser_toml:process(Path, V1, Process2)
+    end.

--- a/src/config/mongoose_config_validator.erl
+++ b/src/config/mongoose_config_validator.erl
@@ -5,7 +5,6 @@
          validate_list/2]).
 
 -include("mongoose.hrl").
--include("mongoose_config_spec.hrl").
 -include_lib("jid/include/jid.hrl").
 
 -type validator() ::

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -44,11 +44,6 @@
               start_cowboy/4, start_link/1, start_listener/2, start_listener/1, stop_cowboy/1]).
 
 -include("mongoose.hrl").
--type options() :: [any()].
--type path() :: binary().
--type paths() :: [path()].
--type route() :: {path() | paths(), module(), options()}.
--type implemented_result() :: [route()].
 
 -type listener_options() :: #{port := inet:port_number(),
                               ip_tuple := inet:ip_address(),
@@ -59,13 +54,6 @@
                               transport := ranch:opts(),
                               protocol := cowboy:opts(),
                               atom() => any()}.
-
--export_type([options/0]).
--export_type([path/0]).
--export_type([route/0]).
--export_type([implemented_result/0]).
-
--callback cowboy_router_paths(path(), options()) -> implemented_result().
 
 -record(cowboy_state, {ref :: atom(), opts :: listener_options()}).
 
@@ -162,12 +150,13 @@ start_cowboy(Ref, Opts, Retries, SleepTime) ->
 
 -spec do_start_cowboy(atom(), listener_options()) -> {ok, pid()} | {error, any()}.
 do_start_cowboy(Ref, Opts) ->
-    #{ip_tuple := IPTuple, port := Port, handlers := Modules,
+    #{ip_tuple := IPTuple, port := Port, handlers := Handlers,
       transport := TransportOpts0, protocol := ProtocolOpts0} = Opts,
-    Dispatch = cowboy_router:compile(get_routes(Modules)),
+    Routes = mongoose_http_handler:get_routes(Handlers),
+    Dispatch = cowboy_router:compile(Routes),
     ProtocolOpts = ProtocolOpts0#{env => #{dispatch => Dispatch}},
     TransportOpts = TransportOpts0#{socket_opts => [{port, Port}, {ip, IPTuple}]},
-    ok = trails_store(Modules),
+    store_trails(Routes),
     case catch start_http_or_https(Opts, Ref, TransportOpts, ProtocolOpts) of
         {error, {{shutdown,
                   {failed_to_start_child, ranch_acceptors_sup,
@@ -200,8 +189,8 @@ add_common_middleware(Map = #{ middlewares := Middlewares }) ->
 add_common_middleware(Map) ->
     Map#{ middlewares => [cowboy_router, ?MODULE, cowboy_handler] }.
 
-reload_dispatch(Ref, #{handlers := Modules}) ->
-    Dispatch = cowboy_router:compile(get_routes(Modules)),
+reload_dispatch(Ref, #{handlers := Handlers}) ->
+    Dispatch = cowboy_router:compile(mongoose_http_handler:get_routes(Handlers)),
     cowboy:set_env(Ref, dispatch, Dispatch).
 
 stop_cowboy(Ref) ->
@@ -212,49 +201,6 @@ ref(Listener) ->
     Ref = handler(Listener),
     ModRef = [?MODULE_STRING, <<"_">>, Ref],
     list_to_atom(binary_to_list(iolist_to_binary(ModRef))).
-
-%% @doc Cowboy will search for a matching Host, then for a matching Path.  If no
-%% Path matches, Cowboy will not search for another matching Host.  So, we must
-%% merge all Paths for each Host, add any wildcard Paths to each Host, and
-%% ensure that the wildcard Host is listed last.  A dict would be slightly
-%% easier to use here, but a proplist ensures that the user can influence Host
-%% ordering if other wildcards like "[...]" are used.
-get_routes(Modules) ->
-    Routes = get_routes(Modules, []),
-    WildcardPaths = proplists:get_value('_', Routes, []),
-    Merge = fun(Paths) -> Paths ++ WildcardPaths end,
-    Merged = lists:keymap(Merge, 2, proplists:delete('_', Routes)),
-    Final = Merged ++ [{'_', WildcardPaths}],
-    ?LOG_DEBUG(#{what => configured_cowboy_routes, routes => Final}),
-    Final.
-
-get_routes([], Routes) ->
-    Routes;
-get_routes([{Host, BasePath, Module} | Tail], Routes) ->
-    get_routes([{Host, BasePath, Module, []} | Tail], Routes);
-get_routes([{Host, BasePath, Module, Opts} | Tail], Routes) ->
-    %% "_" is used in TOML and translated to '_' here.
-    CowboyHost = case Host of
-        "_" -> '_';
-        _ -> Host
-    end,
-    ensure_loaded_module(Module),
-    Paths = proplists:get_value(CowboyHost, Routes, []) ++
-    case erlang:function_exported(Module, cowboy_router_paths, 2) of
-        true -> Module:cowboy_router_paths(BasePath, Opts);
-        _ -> [{BasePath, Module, Opts}]
-    end,
-    get_routes(Tail, lists:keystore(CowboyHost, 1, Routes, {CowboyHost, Paths})).
-
-ensure_loaded_module(Module) ->
-    case code:ensure_loaded(Module) of
-        {module, Module} ->
-            ok;
-        Other ->
-            erlang:error(#{issue => ensure_loaded_module_failed,
-                           modue => Module,
-                           reason => Other})
-    end.
 
 maybe_set_verify_fun(SSLOptions) ->
     case lists:keytake(verify_mode, 1, SSLOptions) of
@@ -273,27 +219,16 @@ maybe_set_verify_fun(SSLOptions) ->
 %% The modules must be added into `mongooseim.toml' in the `swagger' section.
 %% @end
 %% -------------------------------------------------------------------
-trails_store(Modules) ->
+store_trails(Routes) ->
+    AllModules = lists:usort(lists:flatmap(fun({_Host, HostRoutes}) ->
+                                                   [Module || {_Path, Module, _Opts} <- HostRoutes]
+                                           end, Routes)),
+    TrailModules = lists:filter(fun(Module) ->
+                                        backend_module:is_exported(Module, trails, 0)
+                                end, AllModules),
     try
-        trails:store(trails:trails(collect_trails(Modules, [])))
-    catch Class:Reason ->
-              ?LOG_WARNING(#{what => caught_exception, class => Class, reason => Reason})
+        trails:store(trails:trails(TrailModules))
+    catch Class:Reason:Stacktrace ->
+              ?LOG_WARNING(#{what => store_trails_failed,
+                             class => Class, reason => Reason, stacktrace => Stacktrace})
     end.
-
-%% -------------------------------------------------------------------
-%% @private
-%% @doc
-%% Helper of store trails for collect trails modules
-%% @end
-%% -------------------------------------------------------------------
-collect_trails([], Acc) ->
-    Acc;
-collect_trails([{Host, BasePath, Module} | T], Acc) ->
-    collect_trails([{Host, BasePath, Module, []} | T], Acc);
-collect_trails([{_, _, Module, _} | T], Acc) ->
-    case erlang:function_exported(Module, trails, 0) of
-      true ->
-          collect_trails(T, [Module | Acc]);
-      _ ->
-          collect_trails(T, Acc)
-  end.

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -9,6 +9,7 @@
 -behaviour(mongoose_module_metrics).
 %% cowboy_loop is a long polling handler
 -behaviour(cowboy_loop).
+
 -xep([{xep, 206}, {version, "1.4"}]).
 -xep([{xep, 124}, {version, "1.11"}]).
 
@@ -130,8 +131,7 @@ node_cleanup(Acc, Node) ->
 %% cowboy_loop_handler callbacks
 %%--------------------------------------------------------------------
 
--type option() :: {atom(), any()}.
--spec init(req(), _Opts :: [option()]) -> {cowboy_loop, req(), rstate()}.
+-spec init(req(), mongoose_http_handler:options()) -> {cowboy_loop, req(), rstate()}.
 init(Req, _Opts) ->
     ?LOG_DEBUG(#{what => bosh_init, req => Req}),
     Msg = init_msg(Req),

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -32,8 +32,8 @@
 config_spec() ->
     HandlerModules = [Module || {_, Module, _} <- api_paths()],
     #section{items = #{<<"handlers">> => #list{items = #option{type = atom,
-                                                              validate = {enum, HandlerModules}},
-                                              validate = unique},
+                                                               validate = {enum, HandlerModules}},
+                                               validate = unique},
                        <<"docs">> => #option{type = boolean}},
              defaults = #{<<"handlers">> => HandlerModules,
                           <<"docs">> => true},

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -1,5 +1,10 @@
 -module(mongoose_client_api).
 
+-behaviour(mongoose_http_handler).
+
+%% mongoose_http_handler callbacks
+-export([config_spec/0, routes/1]).
+
 -export([init/2]).
 -export([content_types_provided/2]).
 -export([is_authorized/2]).
@@ -16,7 +21,49 @@
               options/2, to_json/2]).
 
 -include("mongoose.hrl").
--include("jlib.hrl").
+-include("mongoose_config_spec.hrl").
+
+-type handler_options() :: #{path := string(), handlers := [module()], docs := boolean(),
+                             atom() => any()}.
+
+%% mongoose_http_handler callbacks
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    HandlerModules = [Module || {_, Module, _} <- api_paths()],
+    #section{items = #{<<"handlers">> => #list{items = #option{type = atom,
+                                                              validate = {enum, HandlerModules}},
+                                              validate = unique},
+                       <<"docs">> => #option{type = boolean}},
+             defaults = #{<<"handlers">> => HandlerModules,
+                          <<"docs">> => true},
+             format_items = map}.
+
+-spec routes(handler_options()) -> mongoose_http_handler:routes().
+routes(Opts = #{path := BasePath}) ->
+    [{[BasePath, Path], Module, ModuleOpts}
+     || {Path, Module, ModuleOpts} <- api_paths(Opts)] ++ api_doc_paths(Opts).
+
+api_paths(#{handlers := HandlerModules}) ->
+    lists:filter(fun({_, Module, _}) -> lists:member(Module, HandlerModules) end, api_paths()).
+
+api_paths() ->
+    [{"/sse", lasse_handler, #{module => mongoose_client_api_sse}},
+     {"/messages/[:with]", mongoose_client_api_messages, #{}},
+     {"/contacts/[:jid]", mongoose_client_api_contacts, #{}},
+     {"/rooms/[:id]", mongoose_client_api_rooms, #{}},
+     {"/rooms/[:id]/config", mongoose_client_api_rooms_config, #{}},
+     {"/rooms/:id/users/[:user]", mongoose_client_api_rooms_users, #{}},
+     {"/rooms/[:id]/messages", mongoose_client_api_rooms_messages, #{}}].
+
+api_doc_paths(#{docs := true}) ->
+    [{"/api-docs", cowboy_swagger_redirect_handler, #{}},
+     {"/api-docs/swagger.json", cowboy_swagger_json_handler, #{}},
+     {"/api-docs/[...]", cowboy_static, {priv_dir, cowboy_swagger, "swagger",
+                                         [{mimetypes, cow_mimetypes, all}]}
+     }];
+api_doc_paths(#{docs := false}) ->
+    [].
 
 init(Req, _Opts) ->
     State = #{},

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -1,0 +1,88 @@
+%% @doc Manage the configuration and initialization of HTTP handlers
+
+-module(mongoose_http_handler).
+
+-export([config_spec/0, process_config/2, cowboy_host/1, get_routes/1]).
+
+-type options() :: #{host := '_' | string(),
+                     path := string(),
+                     module := module(),
+                     atom() => any()}.
+
+-type path() :: iodata().
+-type routes() :: [{path(), module(), options()}].
+
+-export_type([options/0, path/0, routes/0]).
+
+-callback config_spec() -> mongoose_config_spec:config_section().
+-callback routes(options()) -> routes().
+
+-optional_callbacks([config_spec/0, routes/1]).
+
+-include("mongoose.hrl").
+-include("mongoose_config_spec.hrl").
+
+%% @doc Return a config section with a list of sections for each handler type
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    Items = maps:from_list([{atom_to_binary(Module),
+                             #list{items = handler_config_spec(Module),
+                                   wrap = none}}
+                            || Module <- configurable_handler_modules()]),
+    #section{items = Items#{default => #list{items = common_handler_config_spec(),
+                                             wrap = none}},
+             validate_keys = module,
+             include = always}.
+
+%% @doc Return a config section with handler options
+-spec handler_config_spec(module()) -> mongoose_config_spec:config_section().
+handler_config_spec(Module) ->
+    mongoose_config_utils:merge_sections(common_handler_config_spec(), Module:config_spec()).
+
+common_handler_config_spec() ->
+    #section{items = #{<<"host">> => #option{type = string,
+                                             validate = non_empty,
+                                             process = fun ?MODULE:cowboy_host/1},
+                       <<"path">> => #option{type = string}
+                      },
+             required = [<<"host">>, <<"path">>],
+             format_items = map,
+             process = fun ?MODULE:process_config/2}.
+
+process_config([item, HandlerType | _], Opts) ->
+    Opts#{module => binary_to_atom(HandlerType)}.
+
+%% @doc Return the list of Cowboy routes for the specified handler configuration.
+%% Cowboy will search for a matching Host, then for a matching Path. If no Path matches,
+%% Cowboy will not search for another matching Host. So, we must merge all Paths for each Host,
+%% add any wildcard Paths to each Host, and ensure that the wildcard Host '_' is listed last.
+%% A proplist ensures that the user can influence Host ordering if wildcards like "[...]" are used.
+-spec get_routes([options()]) -> cowboy_router:routes().
+get_routes(Handlers) ->
+    Routes = lists:foldl(fun add_handler_routes/2, [], Handlers),
+    WildcardPaths = proplists:get_value('_', Routes, []),
+    Merge = fun(Paths) -> Paths ++ WildcardPaths end,
+    Merged = lists:keymap(Merge, 2, proplists:delete('_', Routes)),
+    Final = Merged ++ [{'_', WildcardPaths}],
+    ?LOG_DEBUG(#{what => configured_cowboy_routes, routes => Final}),
+    Final.
+
+add_handler_routes(#{host := Host, path := Path, module := Module} = HandlerOpts, Routes) ->
+    HandlerRoutes = case backend_module:is_exported(Module, routes, 1) of
+                        true -> Module:routes(HandlerOpts);
+                        false -> [{Path, Module, HandlerOpts}]
+                    end,
+    HostRoutes = proplists:get_value(Host, Routes, []),
+    lists:keystore(Host, 1, Routes, {Host, HostRoutes ++ HandlerRoutes}).
+
+%% @doc Translate "_" used in TOML to '_' expected by COwboy
+cowboy_host("_") -> '_';
+cowboy_host(Host) -> Host.
+
+%% @doc All handlers implementing config_spec/0 are listed here
+configurable_handler_modules() ->
+    [mod_websockets,
+     mongoose_client_api,
+     mongoose_api,
+     mongoose_api_admin,
+     mongoose_domain_handler].

--- a/test/commands_backend_SUITE.erl
+++ b/test/commands_backend_SUITE.erl
@@ -109,7 +109,7 @@ setup(Module) ->
              port => ?PORT,
              ip_tuple => ?IP,
              proto => tcp,
-             handlers => [{"localhost", "/api", Module, []}]},
+             handlers => [#{host => "localhost", path => "/api", module => Module}]},
     ejabberd_cowboy:start_listener(Opts).
 
 teardown() ->

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -78,49 +78,9 @@
   tls.keyfile = "priv/dc1.pem"
   tls.password = ""
 
-  [[listen.http.handlers.lasse_handler]]
+  [[listen.http.handlers.mongoose_client_api]]
     host = "_"
-    path = "/api/sse"
-    module = "mongoose_client_api_sse"
-
-  [[listen.http.handlers.mongoose_client_api_messages]]
-    host = "_"
-    path = "/api/messages/[:with]"
-
-  [[listen.http.handlers.mongoose_client_api_contacts]]
-    host = "_"
-    path = "/api/contacts/[:jid]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms]]
-    host = "_"
-    path = "/api/rooms/[:id]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_config]]
-    host = "_"
-    path = "/api/rooms/[:id]/config"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_users]]
-    host = "_"
-    path = "/api/rooms/:id/users/[:user]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_messages]]
-    host = "_"
-    path = "/api/rooms/[:id]/messages"
-
-  [[listen.http.handlers.cowboy_swagger_redirect_handler]]
-    host = "_"
-    path = "/api-docs"
-
-  [[listen.http.handlers.cowboy_swagger_json_handler]]
-    host = "_"
-    path = "/api-docs/swagger.json"
-
-  [[listen.http.handlers.cowboy_static]]
-    host = "_"
-    path = "/api-docs/[...]"
-    type = "priv_dir"
-    app = "cowboy_swagger"
-    content_path = "swagger"
+    path = "/api"
 
 [[listen.http]]
   port = 5288
@@ -131,7 +91,6 @@
   [[listen.http.handlers.mongoose_api]]
     host = "localhost"
     path = "/api"
-    handlers = ["mongoose_api_metrics", "mongoose_api_users"]
 
 [[listen.c2s]]
   port = 5222

--- a/test/mod_websockets_SUITE.erl
+++ b/test/mod_websockets_SUITE.erl
@@ -12,7 +12,7 @@
 %The 300ms is just an additional overhead
 -define(IDLE_TIMEOUT, ?NEW_TIMEOUT * 2 + 300).
 
--import(config_parser_helper, [default_config/1]).
+-import(config_parser_helper, [config/2, default_config/1]).
 
 all() ->
     ping_tests() ++ subprotocol_header_tests() ++ timeout_tests().
@@ -63,10 +63,11 @@ setup() ->
                 end),
     %% Start websocket cowboy listening
 
-    Handlers = [{"_", "/http-bind", mod_bosh},
-                {"_", "/ws-xmpp", mod_websockets,
-                 [{timeout, ?IDLE_TIMEOUT},
-                  {ping_rate, ?FAST_PING_RATE}]}],
+    Handlers = [config([listen, http, handlers, mod_bosh],
+                       #{host => '_', path => "/http-bind"}),
+                config([listen, http, handlers, mod_websockets],
+                       #{host => '_', path => "/ws-xmpp",
+                         timeout => ?IDLE_TIMEOUT, ping_rate => ?FAST_PING_RATE})],
     ejabberd_cowboy:start_listener(#{port => ?PORT,
                                      ip_tuple => ?IP,
                                      ip_address => "127.0.0.1",

--- a/test/mongoose_listener_SUITE_data/mongooseim.basic.toml
+++ b/test/mongoose_listener_SUITE_data/mongooseim.basic.toml
@@ -16,7 +16,6 @@
   [[listen.http.handlers.mongoose_api]]
     host = "localhost"
     path = "/api"
-    handlers = ["mongoose_api_metrics", "mongoose_api_users"]
 
 [[listen.c2s]]
   port = 5222


### PR DESCRIPTION
The main goal is to use maps with defaults for the handler-specific options of all HTTP handlers in the `listen` section.

Because the rework is significant, it turned out that it makes sense to simplify the configuration of `mongoose_client_api`, which was way too complicated for the end user (and some options were giving the illusion of being configurable, while only the initial values worked, e.g. Swagger path). Now all handlers are enabled by default and the user can set a custom list (with `handlers = [...]`) or disable the Swagger docs (with `docs = false`). For simplicity and consistency, all handlers are also enabled by default for `mongoose_api`.

A new behaviour, `mongoose_http_handler`, is introduced. Its introduction improved the separation between the listener implementation (`ejabberd_cowboy`) and the API module for managing handlers. There are two optional callbacks:

- `config_spec/0` returning config specification for the handler, if it has any options
- `routes/1` returning Cowboy routes, if different from the default

**Excluded from this PR:**
- `mod_bosh` does not implement the new behaviour because of a callback name clash for `config_spec`. If it requires any options or more complex routes, we could implement  a new module with these functions. This would separate module-specific logic from handler-specific logic.
- `mongoose_api_client` is very confusing as there is `mongoose_client_api` as well. The former is obsolete, undocumented, but apparently still offers some unique functionality (e.g. `change_password`, `subscription`). It needs to be fully replaced by the latter, but this is out of scope for now. I think we could sort this out soon as a part of our ongoing API rework.