### PR TITLE
Skip pretty-printing of unused accumulator field

### DIFF
--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -81,7 +81,6 @@
         timestamp := integer(), %microsecond
         origin_pid := pid(),
         origin_location := location(),
-        origin_stanza := binary() | undefined,
         stanza := stanza_metadata() | undefined,
         lserver := jid:lserver(),
         host_type := binary() | undefined,
@@ -124,11 +123,10 @@
 
 -spec new(Params :: new_acc_params()) -> t().
 new(#{ location := Location, lserver := LServer } = Params) ->
-    {ElementBin, Stanza} =
-    case maps:get(element, Params, undefined) of
-        undefined -> {undefined, undefined};
-        Element -> {exml:to_binary(Element), stanza_from_params(Params)}
-    end,
+    Stanza = case maps:get(element, Params, undefined) of
+                 undefined -> undefined;
+                 _Element -> stanza_from_params(Params)
+             end,
     HostType = get_host_type(Params),
     #{
       mongoose_acc => true,
@@ -136,7 +134,6 @@ new(#{ location := Location, lserver := LServer } = Params) ->
       timestamp => os:system_time(microsecond),
       origin_pid => self(),
       origin_location => Location,
-      origin_stanza => ElementBin,
       stanza => Stanza,
       lserver => LServer,
       host_type => HostType,
@@ -341,7 +338,6 @@ default_non_strippable() ->
      timestamp,
      origin_pid,
      origin_location,
-     origin_stanza,
      stanza,
      lserver,
      host_type,

--- a/test/json_formatter_SUITE.erl
+++ b/test/json_formatter_SUITE.erl
@@ -346,6 +346,9 @@ large_event_dont_crash_formatter(_Config) ->
 %%
 
 example_acc(Body) ->
+    Elem = {xmlel, <<"message">>,
+            [{<<"type">>, <<"chat">>}, {<<"id">>, <<"1111">>}],
+            [{xmlel, <<"body">>,[], [{xmlcdata, Body}]}]},
     #{lserver => <<"localhost">>,
       mongoose_acc => true,
       non_strippable => [],
@@ -353,14 +356,8 @@ example_acc(Body) ->
                            line => 116,
                            mfa => {ejabberd_router,route,3}},
       origin_pid => self(),
-      origin_stanza => <<"<message type='chat' id='1111'><body>",
-                         Body/binary,
-                         "</body></message>">>,
       ref => make_ref(),
-      stanza => #{element => {xmlel,<<"message">>,
-                              [{<<"type">>,<<"chat">>},{<<"id">>,<<"1111">>}],
-                              [{xmlel,<<"body">>,[],
-                                [{xmlcdata,Body}]}]},
+      stanza => #{element => Elem,
                   from_jid => {jid,<<"userA">>,<<"localhost">>,<<>>,<<"usera">>,<<"localhost">>,<<>>},
                   name => <<"message">>,
                   ref => make_ref(),


### PR DESCRIPTION
Another low-hanging fruit. This field is actually never used anywhere in MongooseIM code ~so it could even be dropped altogether, but at the very least we can just skip the to_binary until it is used, if ever~, and in the logger we now have selective pretty-printers, so we can drop it altogether.