### PR TITLE
Add CI_CERT_KEY_VERSION environment variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
     steps:
       - run:
           name: Prepare cache key
-          command: tools/make-certs-cache-key.sh > certs_cache_key
+          command: tools/make-certs-cache-key.sh > certs_cache_key && cat certs_cache_key
       - restore_cache:
           name: Restore certificates
           key: *CERT_KEY
@@ -42,7 +42,7 @@ commands:
           name: Print cert hashes for debugging
           command: find tools/ssl -type f -exec md5sum {} \; | sort
       - run:
-          name: Continue if certificate data is valid
+          name: Continue if certificate exists
           command: test -f tools/ssl/mongooseim/key.pem
       - save_cache:
           name: Cache built certs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ commands:
       - run:
           name: Print cert hashes for debugging
           command: find tools/ssl -type f -exec md5sum {} \; | sort
+      - run:
+          name: Continue if certificate data is valid
+          command: test -f tools/ssl/mongooseim/key.pem
       - save_cache:
           name: Cache built certs
           key: *CERT_KEY

--- a/tools/make-certs-cache-key.sh
+++ b/tools/make-certs-cache-key.sh
@@ -5,4 +5,13 @@ week=$(date "+%V")
 year=$(date "+%Y")
 makefile_sum=$(sha1sum tools/ssl/Makefile | cut -d " " -f1)
 
-echo "${year}-week${num}-${makefile_sum}-1"
+# Change it once incompatible changes are made in tools/ssl/ directory
+CERT_KEY_VERSION=1
+
+# CI_CERT_KEY_VERSION could be set in
+# https://app.circleci.com/settings/project/github/esl/MongooseIM/environment-variables
+# It takes integer values 1, 2, 3...
+# Change it to invalidate cache without making code changes
+# There is no way to see the current value in the Circle CI settings though.
+# To get the current value, run a CI job and check the output of the "Prepare cache key" task.
+echo "${year}-week${num}-${makefile_sum}-${CERT_KEY_VERSION}-${CI_CERT_KEY_VERSION}"


### PR DESCRIPTION
This PR addresses "There is no easy way to reset cache without making new changes into the code. And sometimes cache breaks, because a committer did something wrong".

Proposed changes include:
* Use CI_CERT_KEY_VERSION env variable to change the key externally.
* Avoid caching invalid certificate data. It should make fixing bugs with certificates a bit easier.