### PR TITLE
GraphQL - Finish admin per domain support

### DIFF
--- a/priv/graphql/schemas/admin/account.gql
+++ b/priv/graphql/schemas/admin/account.gql
@@ -4,18 +4,25 @@ Allow admin to get information about accounts.
 type AccountAdminQuery @protected{
   "List users per domain"
   listUsers(domain: String!): [String!]!
+    @protected(type: DOMAIN, args: ["domain"])
   "List users that didn't log in the last days or have never logged in. Globally or for a specified domain"
   listOldUsers(domain: String, days: Int!): [String!]!
+    @protected(type: DOMAIN, args: ["domain"])
   "Get number of users per domain"
   countUsers(domain: String!): Int!
+    @protected(type: DOMAIN, args: ["domain"])
   "Get number of users active in last days"
   countActiveUsers(domain: String!, days: Int!): Int
+    @protected(type: DOMAIN, args: ["domain"])
   "Check if a password is correct"
   checkPassword(user: JID!, password: String!): CheckPasswordPayload
+    @protected(type: DOMAIN, args: ["user"])
   "Check if a password hash is correct (allowed methods: md5, sha). Works only for a plain passwords"
   checkPasswordHash(user: JID!, passwordHash: String!, hashMethod: String!): CheckPasswordPayload
+    @protected(type: DOMAIN, args: ["user"])
   "Check if a user exists"
   checkUser(user: JID!): CheckUserPayload
+    @protected(type: DOMAIN, args: ["user"])
 }
 
 """
@@ -24,17 +31,22 @@ Allow admin to manage user accounts.
 type AccountAdminMutation @protected{
   "Register a user. Username will be generated when skipped"
   registerUser(domain: String!, username: String, password: String!): UserPayload
+    @protected(type: DOMAIN, args: ["domain"])
   "Remove a user"
   removeUser(user: JID!): UserPayload
+    @protected(type: DOMAIN, args: ["user"])
   """
   Delete users that didn't log in the last days or have never logged in. Globally or for a specified domain.
   Please use listOldUsers to check which users will be deleted
   """
   removeOldUsers(domain: String, days: Int!): OldUsersPayload
+    @protected(type: DOMAIN, args: ["domain"])
   "Ban an account: kick sessions and set a random password"
   banUser(user: JID!, reason: String!): UserPayload 
+    @protected(type: DOMAIN, args: ["user"])
   "Change the password of a user"
   changeUserPassword(user: JID!, newPassword: String!): UserPayload 
+    @protected(type: DOMAIN, args: ["user"])
 }
 
 "Remove old users payload"

--- a/priv/graphql/schemas/admin/domain.gql
+++ b/priv/graphql/schemas/admin/domain.gql
@@ -1,23 +1,31 @@
 type DomainAdminQuery @protected{
   "Get all enabled domains by hostType"
   domainsByHostType(hostType: String!): [String!]
+    @protected(type: GLOBAL)
   "Get information about the domain"
   domainDetails(domain: String!): Domain
+    @protected(type: DOMAIN, args: ["user"])
 }
 
 type DomainAdminMutation @protected{
   "Add new domain"
   addDomain(domain: String!, hostType: String!): Domain
+    @protected(type: GLOBAL)
   "Remove domain"
   removeDomain(domain: String!, hostType: String!): RemoveDomainPayload
+    @protected(type: GLOBAL)
   "Enable domain"
   enableDomain(domain: String!): Domain
+    @protected(type: GLOBAL)
   "Disable domain"
   disableDomain(domain: String!): Domain
+    @protected(type: GLOBAL)
   "Create or update domain admin password"
   setDomainPassword(domain: String!, password: String!): String
+    @protected(type: DOMAIN, args: ["domain"])
   "Delete domain admin password"
   deleteDomainPassword(domain: String!): String
+    @protected(type: GLOBAL)
 }
 
 "A result of domain removal"

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -4,26 +4,37 @@ Allow admin to manage Multi-User Chat rooms.
 type MUCAdminMutation @protected{
   "Create a MUC room under the given XMPP hostname"
   createInstantRoom(mucDomain: String!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
+    @protected(type: DOMAIN, args: ["mucDomain"])
   "Invite a user to a MUC room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
+    @protected(type: DOMAIN, args: ["room", "sender"])
   "Kick a user from a MUC room"
   kickUser(room: JID!, nick: String!, reason: String): String
+    @protected(type: DOMAIN, args: ["room"])
   "Send a message to a MUC room"
   sendMessageToRoom(room: JID!, from: FullJID!, body: String!): String
+    @protected(type: DOMAIN, args: ["room", "from"])
   "Send a private message to a MUC room user"
   sendPrivateMessage(room: JID!, from: FullJID!, toNick: String!, body: String!): String
+    @protected(type: DOMAIN, args: ["room", "from"])
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String
+    @protected(type: DOMAIN, args: ["room"])
   "Change configuration of a MUC room"
   changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+    @protected(type: DOMAIN, args: ["room"])
   "Change a user role"
   setUserRole(room: JID!, nick: String!, role: MUCRole!): String
+    @protected(type: DOMAIN, args: ["room"])
   "Change a user affiliation"
   setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
+    @protected(type: DOMAIN, args: ["room"])
   "Make a user enter the room with a given nick"
   enterRoom(room: JID!, user: FullJID!, nick: String!, password: String): String
+    @protected(type: DOMAIN, args: ["room", "user"])
   "Make a user with the given nick exit the room"
   exitRoom(room: JID!, user: FullJID!, nick: String!): String
+    @protected(type: DOMAIN, args: ["room", "user"])
 }
 
 """
@@ -32,12 +43,17 @@ Allow admin to get information about Multi-User Chat rooms.
 type MUCAdminQuery @protected{
   "Get MUC rooms under the given MUC domain"
   listRooms(mucDomain: String!, from: JID, limit: Int, index: Int): MUCRoomsPayload!
+    @protected(type: DOMAIN, args: ["from"])
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig
+    @protected(type: DOMAIN, args: ["room"])
   "Get the user list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
+    @protected(type: DOMAIN, args: ["room"])
   "Get the affiliation list of given MUC room"
   listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
+    @protected(type: DOMAIN, args: ["room"])
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+    @protected(type: DOMAIN, args: ["room"])
 }

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -7,13 +7,13 @@ type MUCAdminMutation @protected{
     @protected(type: DOMAIN, args: ["mucDomain"])
   "Invite a user to a MUC room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
-    @protected(type: DOMAIN, args: ["room", "sender"])
+    @protected(type: DOMAIN, args: ["sender"])
   "Kick a user from a MUC room"
   kickUser(room: JID!, nick: String!, reason: String): String
     @protected(type: DOMAIN, args: ["room"])
   "Send a message to a MUC room"
   sendMessageToRoom(room: JID!, from: FullJID!, body: String!): String
-    @protected(type: DOMAIN, args: ["room", "from"])
+    @protected(type: DOMAIN, args: ["from"])
   "Send a private message to a MUC room user"
   sendPrivateMessage(room: JID!, from: FullJID!, toNick: String!, body: String!): String
     @protected(type: DOMAIN, args: ["room", "from"])
@@ -31,10 +31,10 @@ type MUCAdminMutation @protected{
     @protected(type: DOMAIN, args: ["room"])
   "Make a user enter the room with a given nick"
   enterRoom(room: JID!, user: FullJID!, nick: String!, password: String): String
-    @protected(type: DOMAIN, args: ["room", "user"])
+    @protected(type: DOMAIN, args: ["user"])
   "Make a user with the given nick exit the room"
   exitRoom(room: JID!, user: FullJID!, nick: String!): String
-    @protected(type: DOMAIN, args: ["room", "user"])
+    @protected(type: DOMAIN, args: ["user"])
 }
 
 """

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -4,18 +4,25 @@ Allow admin to manage Multi-User Chat Light rooms.
 type MUCLightAdminMutation @protected{
   "Create a MUC light room under the given XMPP hostname"
   createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: NonEmptyString): Room
+    @protected(type: DOMAIN, args: ["mucDomain"])
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!): Room
+    @protected(type: DOMAIN, args: ["room", "owner"])
   "Invite a user to a MUC Light room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!): String
+    @protected(type: DOMAIN, args: ["room", "sender"])
   "Remove a MUC Light room"
   deleteRoom(room: JID!): String
+    @protected(type: DOMAIN, args: ["room"])
   "Kick a user from a MUC Light room"
   kickUser(room: JID!, user: JID!): String
+    @protected(type: DOMAIN, args: ["room"])
   "Send a message to a MUC Light room"
   sendMessageToRoom(room: JID!, from: JID!, body: String!): String
+    @protected(type: DOMAIN, args: ["room", "from"])
   "Set the user blocking list"
   setBlockingList(user: JID!, items: [BlockingInput!]!): String
+    @protected(type: DOMAIN, args: ["user"])
 }
 
 """
@@ -24,12 +31,17 @@ Allow admin to get information about Multi-User Chat Light rooms.
 type MUCLightAdminQuery @protected{
   "Get the MUC Light room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+    @protected(type: DOMAIN, args: ["room"])
   "Get configuration of the MUC Light room"
   getRoomConfig(room: JID!): Room
+    @protected(type: DOMAIN, args: ["room"])
   "Get users list of given MUC Light room"
   listRoomUsers(room: JID!): [RoomUser!]
+    @protected(type: DOMAIN, args: ["room"])
   "Get the list of MUC Light rooms that the user participates in"
   listUserRooms(user: JID!): [JID!]
+    @protected(type: DOMAIN, args: ["user"])
   "Get the user blocking list"
   getBlockingList(user: JID!): [BlockingItem!]
+    @protected(type: DOMAIN, args: ["user"])
 }

--- a/priv/graphql/schemas/admin/roster.gql
+++ b/priv/graphql/schemas/admin/roster.gql
@@ -4,20 +4,28 @@ Allow admin to manage user rester/contacts.
 type RosterAdminMutation @protected{
   "Add a new contact to a user's roster without subscription"
   addContact(user: JID!, contact: JID!, name: String, groups: [String!]): String
+    @protected(type: DOMAIN, args: ["user"])
   "Add new contacts to a user's roster without subscription"
   addContacts(user: JID!, contacts: [ContactInput!]!) : [String]!
+    @protected(type: DOMAIN, args: ["user"])
   "Manage the user's subscription to the contact"
   subscription(user: JID!, contact: JID!, action: SubAction): String
+    @protected(type: DOMAIN, args: ["user"])
   "Delete user's contact"
   deleteContact(user: JID!, contact: JID!): String
+    @protected(type: DOMAIN, args: ["user"])
   "Delete user's contacts"
   deleteContacts(user: JID!, contacts: [JID!]!): [String]!
+    @protected(type: DOMAIN, args: ["user"])
   "Manage mutual subscription between given users"
   setMutualSubscription(userA: JID!, userB: JID!, action: MutualSubAction!): String
+    @protected(type: DOMAIN, args: ["user", "userB"])
   "Set mutual subscriptions between the user and each of the given contacts"
   subscribeToAll(user: ContactInput!, contacts: [ContactInput!]!): [String]!
+    @protected(type: DOMAIN, args: ["user"])
   "Set mutual subscriptions between all of the given contacts"
   subscribeAllToAll(contacts: [ContactInput!]): [String]!
+    @protected(type: DOMAIN, args: ["contacts.jid"])
 }
 
 """
@@ -26,6 +34,8 @@ Allow admin to get information about user roster/contacts.
 type RosterAdminQuery @protected{
   "Get the user's roster/contacts"
   listContacts(user: JID!): [Contact!] 
+    @protected(type: DOMAIN, args: ["user"])
   "Get the user's contact"
   getContact(user: JID!, contact: JID!): Contact
+    @protected(type: DOMAIN, args: ["user"])
 }

--- a/priv/graphql/schemas/admin/roster.gql
+++ b/priv/graphql/schemas/admin/roster.gql
@@ -19,7 +19,7 @@ type RosterAdminMutation @protected{
     @protected(type: DOMAIN, args: ["user"])
   "Manage mutual subscription between given users"
   setMutualSubscription(userA: JID!, userB: JID!, action: MutualSubAction!): String
-    @protected(type: DOMAIN, args: ["user", "userB"])
+    @protected(type: DOMAIN, args: ["userA", "userB"])
   "Set mutual subscriptions between the user and each of the given contacts"
   subscribeToAll(user: ContactInput!, contacts: [ContactInput!]!): [String]!
     @protected(type: DOMAIN, args: ["user"])

--- a/priv/graphql/schemas/admin/session.gql
+++ b/priv/graphql/schemas/admin/session.gql
@@ -4,18 +4,25 @@ Allow admin to get information about sessions.
 type SessionAdminQuery @protected{
   "Get the list of established sessions for a specified domain or globally"
   listSessions(domain: String): [Session!]
+    @protected(type: DOMAIN, args: ["domain"])
   "Get the number of established sessions for a specified domain or globally"
   countSessions(domain: String): Int 
+    @protected(type: DOMAIN, args: ["domain"])
   "Get information about all sessions of a user"
   listUserSessions(user: JID!): [Session!]
+    @protected(type: DOMAIN, args: ["user"])
   "Get the number of resources of a user"
   countUserResources(user: JID!): Int
+    @protected(type: DOMAIN, args: ["user"])
   "Get the resource string of the n-th session of a user"
   getUserResource(user: JID!, number: Int): String
+    @protected(type: DOMAIN, args: ["user"])
   "Get the list of logged users with this status for a specified domain or globally"
   listUsersWithStatus(domain: String, status: String!): [UserStatus!]
+    @protected(type: DOMAIN, args: ["domain"])
   "Get the number of logged users with this status for a specified domain or globally"
   countUsersWithStatus(domain: String, status: String!): Int
+    @protected(type: DOMAIN, args: ["domain"])
 }
 
 """
@@ -24,8 +31,10 @@ Allow admin to manage sessions.
 type SessionAdminMutation @protected{
   "Kick a user session. User JID should contain resource"
   kickUser(user: JID!, reason: String!): SessionPayload
+    @protected(type: DOMAIN, args: ["user"])
   "Set presence of a session. User JID should contain resource"
   setPresence(user: JID!, type: PresenceType!, show: PresenceShow, status: String, priority: Int): SessionPayload
+    @protected(type: DOMAIN, args: ["user"])
 }
 
 "Presence type field values"

--- a/priv/graphql/schemas/admin/stanza.gql
+++ b/priv/graphql/schemas/admin/stanza.gql
@@ -1,13 +1,17 @@
 type StanzaAdminQuery @protected{
   "Get n last messages to/from a given contact (optional) with limit and optional date"
   getLastMessages(caller: JID!, with: JID, limit: Int = 50, before: DateTime): StanzasPayload
+    @protected(type: DOMAIN, args: ["caller"])
 }
 
 type StanzaAdminMutation @protected{
   "Send a chat message to a local or remote bare or full JID"
   sendMessage(from: JID!, to: JID!, body: String!): SendStanzaPayload
+    @protected(type: DOMAIN, args: ["from"])
   "Send a headline message to a local or remote bare or full JID"
   sendMessageHeadLine(from: JID!, to: JID!, subject: String, body: String): SendStanzaPayload
+    @protected(type: DOMAIN, args: ["from"])
   "Send an arbitrary stanza"
   sendStanza(stanza: Stanza): SendStanzaPayload
+    @protected(type: GLOBAL)
 }

--- a/priv/graphql/schemas/global/protected_dir.gql
+++ b/priv/graphql/schemas/global/protected_dir.gql
@@ -1,7 +1,8 @@
 "Marks the resource to be accessed only by authorized requests"
-directive @protected (type: String = ALL, args: [String!] = []) on FIELD_DEFINITION | OBJECT | INTERFACE
+directive @protected (type: String = DEFAULT, args: [String!] = []) on FIELD_DEFINITION | OBJECT | INTERFACE
 
 enum ProtectedType{
+  DEFAULT
   DOMAIN
-  ALL
+  GLOBAL
 }

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -732,7 +732,7 @@ CREATE INDEX i_offline_markers ON offline_markers(jid);
 
 CREATE TABLE domain_admins(
      domain VARCHAR(250) NOT NULL PRIMARY KEY,
-     password VARCHAR(250) NOT NULL
+     pass_details NVARCHAR(max) NOT NULL
 );
 
 -- Mapping from domain hostname to host_type.

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -523,7 +523,7 @@ CREATE INDEX i_offline_markers ON offline_markers(jid);
 
 CREATE TABLE domain_admins(
      domain VARCHAR(250) NOT NULL,
-     password VARCHAR(250) NOT NULL,
+     pass_details text NOT NULL,
      PRIMARY KEY(domain)
 );
 

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -480,7 +480,7 @@ CREATE INDEX i_offline_markers ON offline_markers(jid);
 
 CREATE TABLE domain_admins(
      domain VARCHAR(250) NOT NULL,
-     password VARCHAR(250) NOT NULL,
+     pass_details TEXT NOT NULL,
      PRIMARY KEY(domain)
 );
 

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -176,7 +176,9 @@ select_domain_admin(Domain) ->
     end.
 
 set_domain_admin(Domain, Password) ->
-    PassDetails = mongoose_scram:serialize(mongoose_scram:password_to_scram(Password)),
+    Iterations = mongoose_scram:iterations(),
+    HashMap = mongoose_scram:password_to_scram_sha(Password, Iterations, sha512),
+    PassDetails = mongoose_scram:serialize(HashMap),
     transaction(fun(Pool) ->
                     case select_domain_admin(Domain) of
                         {ok, _} ->

--- a/src/graphql/mongoose_graphql_errors.erl
+++ b/src/graphql/mongoose_graphql_errors.erl
@@ -99,7 +99,10 @@ authorize_err_msg(wrong_credentials) ->
     "The provided credentials are wrong";
 authorize_err_msg({no_permissions, Op}) ->
     io_lib:format("Cannot execute query ~s without permissions", [Op]);
-authorize_err_msg({no_permissions, Op, Res, InvalidArgs}) ->
+authorize_err_msg({no_permissions, Op, #{type := global}}) ->
+    Format = "Cannot execute query ~s without a global admin permissions",
+    io_lib:format(Format, [Op]);
+authorize_err_msg({no_permissions, Op, #{type := Res, invalid_args := InvalidArgs}}) ->
     InvalidArgs2 = lists:join(", ", InvalidArgs),
     Format = "Cannot execute query ~s without permissions to the given ~s. "
                 ++ "Args with invalid value: ~s",

--- a/src/graphql/mongoose_graphql_permissions.erl
+++ b/src/graphql/mongoose_graphql_permissions.erl
@@ -144,6 +144,8 @@ check_field_args(<<"DOMAIN">>, #{domain := Domain}, ProtectedArgs, Args) ->
     InvalidArgs =
         lists:filter(fun(N) -> not arg_eq(get_arg(N, Args), Domain) end, ProtectedArgs),
     make_result(InvalidArgs, domain);
+check_field_args(<<"GLOBAL">>, #{domain := _}, _, _Args) ->
+    make_result(no_args, global);
 check_field_args(<<"DEFAULT">>, _Ctx, _ProtectedArgs, _Args) ->
     ok.
 
@@ -185,6 +187,8 @@ arg_eq(_, _) ->
 
 make_result([], _) ->
     ok;
+make_result(no_args, Type) when is_atom(Type) ->
+    #{type => Type, path => [], invalid => []};
 make_result(InvalidArgs, Type) when is_atom(Type) ->
     #{type => Type, path => [], invalid => InvalidArgs}.
 

--- a/src/graphql/mongoose_graphql_permissions.erl
+++ b/src/graphql/mongoose_graphql_permissions.erl
@@ -41,7 +41,7 @@
                       atom() => any()}.
 -type no_access_info() :: #{path := [binary()],
                             type := atom(),
-                            invalid := [binary()]}.
+                            invalid_args => [binary()]}.
 -type field_check_result() :: ok | no_access_info().
 -type document() :: #document{}.
 -type definitions() :: [any()].
@@ -101,9 +101,9 @@ check_domain_authorized_request_permissions(OpName, Domain, Params, Definitions)
             case check_fields(#{domain => Domain}, Params, Set) of
                 ok ->
                     ok;
-                #{invalid := Args, path := Path, type := Type} ->
+                #{path := Path} = NoAccessInfo ->
                     OpName2 = op_name(OpName),
-                    Error = {no_permissions, OpName2, Type, Args},
+                    Error = {no_permissions, OpName2, NoAccessInfo},
                     Path2 = lists:reverse([OpName2 | Path]),
                     graphql_err:abort(Path2, authorize, Error)
             end;
@@ -141,11 +141,14 @@ check_field_args(Ctx, Args, Directives) ->
 
 -spec check_field_args(binary(), map(), [binary()], map()) -> field_check_result().
 check_field_args(<<"DOMAIN">>, #{domain := Domain}, ProtectedArgs, Args) ->
-    InvalidArgs =
-        lists:filter(fun(N) -> not arg_eq(get_arg(N, Args), Domain) end, ProtectedArgs),
-    make_result(InvalidArgs, domain);
+    case lists:filter(fun(N) -> not arg_eq(get_arg(N, Args), Domain) end, ProtectedArgs) of
+        [] ->
+            ok;
+        InvalidArgs ->
+            #{type => domain, path => [], invalid_args => InvalidArgs}
+    end;
 check_field_args(<<"GLOBAL">>, #{domain := _}, _, _Args) ->
-    make_result(no_args, global);
+    #{type => global, path => []};
 check_field_args(<<"DEFAULT">>, _Ctx, _ProtectedArgs, _Args) ->
     ok.
 
@@ -164,33 +167,32 @@ get_arg(Name, Args) when is_binary(Name)->
     Path = binary:split(Name, <<".">>, [global]),
     get_arg(Path, Args);
 get_arg([], Value) -> Value;
-get_arg(_, null) -> null;
+get_arg(_, undefined) -> undefined;
 get_arg(Path, List) when is_list(List) ->
     [get_arg(Path, ArgsMap) || ArgsMap <- List];
 get_arg([Name | Path], ArgsMap) ->
-    get_arg(Path, maps:get(Name, ArgsMap, null)).
+    get_arg(Path, maps:get(Name, ArgsMap, undefined)).
 
 arg_eq(Args, Domain) when is_list(Args) ->
     lists:all(fun(Arg) -> arg_eq(Arg, Domain) end, Args);
 arg_eq(Domain, Domain) ->
     true;
 arg_eq(Subdomain, Domain) when is_binary(Subdomain), is_binary(Domain) ->
-    nomatch =/= re:run(Subdomain, io_lib:format("\\.~s$", [Domain]));
+    check_subdomain(Subdomain, Domain);
 arg_eq(#jid{lserver = Domain1}, Domain2) ->
     arg_eq(Domain1, Domain2);
-arg_eq(null, _) ->
+arg_eq(undefined, _) ->
     % The arg is optional, and the value is not present, so we assume that
     % the domain admin has access.
     true;
 arg_eq(_, _) ->
     false.
 
-make_result([], _) ->
-    ok;
-make_result(no_args, Type) when is_atom(Type) ->
-    #{type => Type, path => [], invalid => []};
-make_result(InvalidArgs, Type) when is_atom(Type) ->
-    #{type => Type, path => [], invalid => InvalidArgs}.
+check_subdomain(Subdomain, Domain) ->
+    case mongoose_domain_api:get_subdomain_info(Subdomain) of
+        {ok, #{parent_domain := ParentDomain}} -> ParentDomain =:= Domain;
+        {error, not_found} -> false
+    end.
 
 add_path(ok, _) -> ok;
 add_path(#{path := Path} = Acc, FieldName) ->

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -11,6 +11,7 @@
          enabled/2,
          iterations/0,
          iterations/1,
+         password_to_scram/1,
          password_to_scram/2,
          password_to_scram/3,
          check_password/2,
@@ -80,6 +81,13 @@ iterations() -> ?SCRAM_DEFAULT_ITERATION_COUNT.
 
 iterations(HostType) ->
     mongoose_config:get_opt([{auth, HostType}, password, scram_iterations]).
+
+password_to_scram(Password) ->
+    IterationCount = ?SCRAM_DEFAULT_ITERATION_COUNT,
+    ServerStoredKeys = [do_password_to_scram(Password, IterationCount, HashType)
+                        || {HashType, _Prefix} <- supported_sha_types()],
+    ResultList = lists:merge([{iteration_count, IterationCount}], ServerStoredKeys),
+    maps:from_list(ResultList).
 
 password_to_scram(HostType, Password) ->
     password_to_scram(HostType, Password, ?SCRAM_DEFAULT_ITERATION_COUNT).

--- a/src/mongoose_scram.erl
+++ b/src/mongoose_scram.erl
@@ -11,9 +11,9 @@
          enabled/2,
          iterations/0,
          iterations/1,
-         password_to_scram/1,
          password_to_scram/2,
          password_to_scram/3,
+         password_to_scram_sha/3,
          check_password/2,
          check_digest/4
         ]).
@@ -82,12 +82,9 @@ iterations() -> ?SCRAM_DEFAULT_ITERATION_COUNT.
 iterations(HostType) ->
     mongoose_config:get_opt([{auth, HostType}, password, scram_iterations]).
 
-password_to_scram(Password) ->
-    IterationCount = ?SCRAM_DEFAULT_ITERATION_COUNT,
-    ServerStoredKeys = [do_password_to_scram(Password, IterationCount, HashType)
-                        || {HashType, _Prefix} <- supported_sha_types()],
-    ResultList = lists:merge([{iteration_count, IterationCount}], ServerStoredKeys),
-    maps:from_list(ResultList).
+password_to_scram_sha(Password, IterationCount, HashType) ->
+    ScramHash = do_password_to_scram(Password, IterationCount, HashType),
+    maps:from_list([{iteration_count, IterationCount}, ScramHash]).
 
 password_to_scram(HostType, Password) ->
     password_to_scram(HostType, Password, ?SCRAM_DEFAULT_ITERATION_COUNT).

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -14,7 +14,8 @@
         ?assertMatch(ok, check_permissions(Config, false, Doc))).
 
 -define(assertDomainPermissionsFailed(Config, Domain, Args, Doc),
-        ?assertThrow({error, #{error_term := {no_permissions, _, domain, Args}}},
+        ?assertThrow({error, #{error_term := {no_permissions, _,#{type := domain,
+                                                                  invalid_args := Args}}}},
                      check_domain_permissions(Config, Domain, Doc))).
 -define(assertPermissionsSuccess(Config, Domain, Doc),
         ?assertMatch(ok, check_domain_permissions(Config, Domain, Doc))).
@@ -95,6 +96,7 @@ domain_permissions() ->
     [check_field_domain_permissions,
      check_field_input_arg_domain_permissions,
      check_field_list_arg_domain_permissions,
+     check_field_null_arg_domain_permissions,
      check_field_jid_arg_domain_permissions,
      check_child_object_field_domain_permissions,
      check_field_subdomain_permissions,
@@ -114,6 +116,7 @@ domain_admin_listener() ->
      auth_domain_admin_wrong_password_error,
      auth_domain_admin_nonexistent_domain_error,
      auth_domain_admin_cannot_access_other_domain,
+     auth_domain_admin_cannot_access_global,
      auth_domain_admin_can_access_owned_domain
      | common_tests()].
 
@@ -160,8 +163,24 @@ init_per_group(domain_admin_listener, Config) ->
                     (<<"localhost">>, _) -> {error, wrong_password};
                     (_, _) -> {error, not_found}
                 end),
+    meck:expect(mongoose_domain_api, get_subdomain_info,
+                fun (_) -> {error, not_found} end),
     ListenerOpts = [{schema_endpoint, <<"domain_admin">>}],
-    init_ep_listener(5560, adminn_schema_ep, ListenerOpts, Config);
+    init_ep_listener(5560, domain_admin_schema_ep, ListenerOpts, Config);
+init_per_group(domain_permissions, Config) ->
+    meck:new(mongoose_domain_api, [no_link]),
+    meck:expect(mongoose_domain_api, get_subdomain_info,
+                fun
+                    (<<"subdomain.test-domain.com">>) ->
+                        {ok, #{parent_domain => <<"test-domain.com">>}};
+                    (<<"subdomain.test-domain2.com">>) ->
+                        {ok, #{parent_domain => <<"test-domain2.com">>}};
+                    (_) ->
+                        {error, not_found}
+                end),
+    Domains = [{<<"subdomain.test-domain.com">>, <<"test-domain.com">>},
+               {<<"subdomain.test-domain2.com">>, <<"test-domain2.com">>}],
+    [{domains, Domains} | Config];
 init_per_group(_G, Config) ->
     Config.
 
@@ -176,6 +195,8 @@ end_per_group(domain_admin_listener, Config) ->
     meck:unload(mongoose_domain_api),
     ?config(test_process, Config) ! stop,
     Config;
+end_per_group(domain_permissions, _Config) ->
+    meck:unload(mongoose_domain_api);
 end_per_group(_, Config) ->
     Config.
 
@@ -213,6 +234,7 @@ init_per_testcase(C, Config) when C =:= check_object_permissions;
                                   C =:= check_field_domain_permissions;
                                   C =:= check_field_input_arg_domain_permissions;
                                   C =:= check_field_list_arg_domain_permissions;
+                                  C =:= check_field_null_arg_domain_permissions;
                                   C =:= check_field_jid_arg_domain_permissions;
                                   C =:= check_field_subdomain_permissions;
                                   C =:= check_field_global_permissions;
@@ -421,13 +443,13 @@ check_interface_permissions(Config) ->
 
 check_interface_field_permissions(Config) ->
     Doc = <<"{ interface { protectedName } }">>,
-    FieldProtectedNotEnaugh = <<"{ obj { protectedName } }">>,
-    FieldProtectedEnaugh = <<"{ obj { otherName } }">>,
-    % Field is protected in interface and object, so cannot be accessed.
+    FieldProtectedNotEnough = <<"{ obj { protectedName } }">>,
+    FieldProtectedEnough = <<"{ obj { otherName } }">>,
+    % Field is protected in interface and object, so it cannot be accessed.
     ?assertPermissionsFailed(Config, Doc),
-    ?assertPermissionsFailed(Config, FieldProtectedEnaugh),
-    % Field is protected only in an interface, so can be accessed from implementing objects.
-    ?assertPermissionsSuccess(Config, FieldProtectedNotEnaugh).
+    ?assertPermissionsFailed(Config, FieldProtectedEnough),
+    % Field is protected only in an interface, so it can be accessed from implementing objects.
+    ?assertPermissionsSuccess(Config, FieldProtectedNotEnough).
 
 check_inline_fragment_permissions(Config) ->
     Doc = <<"{ interface { name otherName ... on Object { field } } }">>,
@@ -478,16 +500,16 @@ check_interface_field_domain_permissions(Config) ->
     OkDomain2 = <<"{ obj { domainName(domain: \"my-domain.com\") } }">>,
     WrongDomain = <<"{ interface { protectedDomainName(domain: \"domain.com\") } }">>,
     WrongDomain1 = <<"{ obj { domainName(domain: \"domain.com\") } }">>,
-    ProtectedNotEnaugh = <<"{ obj { protectedDomainName(domain: \"domain.com\") } }">>,
+    ProtectedNotEnough = <<"{ obj { protectedDomainName(domain: \"domain.com\") } }">>,
     ?assertPermissionsSuccess(Config, Domain, OkDomain),
     ?assertPermissionsSuccess(Config, Domain, OkDomain1),
     ?assertPermissionsSuccess(Config, Domain, OkDomain2),
-    % Field is protected in interface and object, so cannot be accessed with the wrong domain.
+    % Field is protected in interface and object, so it cannot be accessed with the wrong domain.
     ?assertDomainPermissionsFailed(Config, Domain, [<<"domain">>], WrongDomain),
     ?assertDomainPermissionsFailed(Config, Domain, [<<"domain">>], WrongDomain1),
-    % Field is protected only in an interface, so can be accessed from implementing objects
+    % Field is protected only in an interface, so it can be accessed from implementing objects
     % with the wrong domain.
-    ?assertPermissionsSuccess(Config, Domain, ProtectedNotEnaugh).
+    ?assertPermissionsSuccess(Config, Domain, ProtectedNotEnough).
 
 check_field_input_arg_domain_permissions(Config) ->
     Domain = <<"my-domain.com">>,
@@ -504,10 +526,9 @@ check_field_input_arg_domain_permissions(Config) ->
 
 
 check_field_list_arg_domain_permissions(Config) ->
-    Domain = <<"my-domain.com">>,
+    [{Subdomain, Domain} | _] = ?config(domains, Config),
     Domains = [#{<<"domain">> => Domain, <<"notDomain">> => <<"random text here">>},
-               #{<<"domain">> => <<"muc.", Domain/binary>>,
-                 <<"domains">> => #{<<"domain">> => Domain}}],
+               #{<<"domain">> => Subdomain}],
     Config2 = [{op, <<"Q1">>}, {args, #{<<"domains">> => Domains}} | Config],
     Doc = <<"query Q1($domains: [DomainInput!]) "
             "{ domainListInputProtectedField(domains: $domains) }">>,
@@ -515,6 +536,11 @@ check_field_list_arg_domain_permissions(Config) ->
     FDoc = <<"{ domainListInputProtectedField(domains: [{ domain: \"do.com\" }]) }">>,
     ?assertPermissionsSuccess(Config2, Domain, Doc),
     ?assertDomainPermissionsFailed(Config, Domain, [<<"domains.domain">>], FDoc).
+
+check_field_null_arg_domain_permissions(Config) ->
+    [{_, Domain} | _] = ?config(domains, Config),
+    Doc = <<"{ domainProtectedField domainInputProtectedField }">>,
+    ?assertPermissionsSuccess(Config, Domain, Doc).
 
 check_field_jid_arg_domain_permissions(Config) ->
     Domain = <<"my-domain.com">>,
@@ -526,9 +552,7 @@ check_field_jid_arg_domain_permissions(Config) ->
     ?assertDomainPermissionsFailed(Config, Domain, [<<"argA">>], FDoc).
 
 check_field_subdomain_permissions(Config) ->
-    Domain = <<"my-domain.com">>,
-    Subdomain = <<"test.", Domain/binary>>,
-    FSubdomain = <<"test.1", Domain/binary>>,
+    [{Subdomain, Domain}, {FSubdomain, _Domain2}] = ?config(domains, Config),
     Config2 = [{op, <<"Q1">>}, {args, #{<<"domain">> => Subdomain}} | Config],
     FConfig2 = [{op, <<"Q1">>}, {args, #{<<"domain">> => FSubdomain}} | Config],
     Doc = <<"query Q1($domain: String) "
@@ -540,7 +564,7 @@ check_field_global_permissions(Config) ->
     Domain = <<"my-domain.com">>,
     Doc = <<"{ protectedField onlyForGlobalAdmin }">>,
     ?assertMatch(ok, check_permissions(Config, true, Doc)),
-    ?assertThrow({error, #{error_term := {no_permissions, _, global, []}}},
+    ?assertThrow({error, #{error_term := {no_permissions, _, #{type := global}}}},
                  check_domain_permissions(Config, Domain, Doc)).
 
 %% Error formatting
@@ -668,6 +692,12 @@ auth_domain_admin_can_access_owned_domain(Config) ->
 auth_domain_admin_cannot_access_other_domain(Config) ->
     Ep = ?config(endpoint_addr, Config),
     Body = #{query => "{ field fieldDP(argA: \"domain.com\") }"},
+    {Status, Data} = execute(Ep, Body, {<<"admin@localhost">>, <<"makota">>}),
+    assert_no_permissions(no_permissions, Status, Data).
+
+auth_domain_admin_cannot_access_global(Config) ->
+    Ep = ?config(endpoint_addr, Config),
+    Body = #{query => "{ fieldGlobal(argA: \"localhost\") }"},
     {Status, Data} = execute(Ep, Body, {<<"admin@localhost">>, <<"makota">>}),
     assert_no_permissions(no_permissions, Status, Data).
 

--- a/test/mongoose_graphql_SUITE_data/listener_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/listener_schema.gql
@@ -8,6 +8,7 @@ directive @protected (type: ProtectionType = DEFAULT, args: [String!] = [])
 
 enum ProtectionType{
   DOMAIN
+  GLOBAL
   DEFAULT
 }
 
@@ -16,7 +17,10 @@ Contains all available queries.
 """
 type Query @protected{
   field: String
-  fieldDP(argA: String): String @protected(type: DOMAIN, args: ["argA"])
+  fieldDP(argA: String): String
+    @protected(type: DOMAIN, args: ["argA"])
+  fieldGlobal(argA: String): String
+    @protected(type: GLOBAL)
 }
 
 """

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -22,7 +22,7 @@ type UserQuery{
   domainInputProtectedField(argA: String, argB: DomainInput):
     String @protected(type: DOMAIN, args: ["argA", "argB.domain"])
   domainListInputProtectedField(domains: [DomainInput!]):
-    String @protected(type: DOMAIN, args: ["domains.domain", "domains.domains.domain"])
+    String @protected(type: DOMAIN, args: ["domains.domain"])
   domainJIDProtectedField(argA: JID, argB: JID):
     String @protected(type: DOMAIN, args: ["argA"])
   onlyForGlobalAdmin: String @protected(type: GLOBAL)
@@ -91,6 +91,5 @@ union UnionT = O1 | O2
 
 input DomainInput{
   domain: String!
-  domains: [DomainInput!]
   notDomain: String
 }

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -42,6 +42,9 @@ interface Interface{
   name: String
   otherName: String
   protectedName: String @protected
+  protectedDomainName(domain: String):
+    String @protected(type: DOMAIN, args: ["domain"])
+  domainName(domain: String): String
 }
 
 interface ProtectedInterface @protected{
@@ -52,6 +55,9 @@ type Object implements Interface{
   name: String
   otherName: String @protected
   protectedName: String
+  protectedDomainName(domain: String): String
+  domainName(domain: String):
+    String @protected(type: DOMAIN, args: ["domain"])
   protectedField: String @protected
   domainProtectedField(argA: String, argB: String):
     String @protected(type: DOMAIN, args: ["argA"])
@@ -62,6 +68,8 @@ type ProtectedObject implements Interface @protected{
   name: String
   otherName: String
   protectedName: String
+  domainName(domain: String): String
+  protectedDomainName(domain: String): String
   type: String
 }
 

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -11,10 +11,16 @@ enum ProtectionType{
   DEFAULT
 }
 
+scalar JID
+
 type UserQuery{
   field: String
   protectedField: String @protected
   domainProtectedField(argA: String, argB: String):
+    String @protected(type: DOMAIN, args: ["argA"])
+  domainInputProtectedField(argA: String, argB: DomainInput):
+    String @protected(type: DOMAIN, args: ["argA", "argB.domain"])
+  domainJIDProtectedField(argA: JID, argB: JID):
     String @protected(type: DOMAIN, args: ["argA"])
   interface: Interface
   union: UnionT
@@ -70,3 +76,8 @@ type O2 @protected{
 }
 
 union UnionT = O1 | O2
+
+input DomainInput{
+  domain: String!
+  notDomain: String
+}

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -20,6 +20,8 @@ type UserQuery{
     String @protected(type: DOMAIN, args: ["argA"])
   domainInputProtectedField(argA: String, argB: DomainInput):
     String @protected(type: DOMAIN, args: ["argA", "argB.domain"])
+  domainListInputProtectedField(domains: [DomainInput!]):
+    String @protected(type: DOMAIN, args: ["domains.domain", "domains.domains.domain"])
   domainJIDProtectedField(argA: JID, argB: JID):
     String @protected(type: DOMAIN, args: ["argA"])
   interface: Interface
@@ -79,5 +81,6 @@ union UnionT = O1 | O2
 
 input DomainInput{
   domain: String!
+  domains: [DomainInput!]
   notDomain: String
 }

--- a/test/mongoose_graphql_SUITE_data/permissions_schema.gql
+++ b/test/mongoose_graphql_SUITE_data/permissions_schema.gql
@@ -8,6 +8,7 @@ directive @protected (type: ProtectionType = DEFAULT, args: [String!] = [])
 
 enum ProtectionType{
   DOMAIN
+  GLOBAL
   DEFAULT
 }
 
@@ -24,6 +25,7 @@ type UserQuery{
     String @protected(type: DOMAIN, args: ["domains.domain", "domains.domains.domain"])
   domainJIDProtectedField(argA: JID, argB: JID):
     String @protected(type: DOMAIN, args: ["argA"])
+  onlyForGlobalAdmin: String @protected(type: GLOBAL)
   interface: Interface
   union: UnionT
   obj: Object


### PR DESCRIPTION
This PR addresses [MIM-1644](https://erlangsolutions.atlassian.net/browse/MIM-1644) and finishes the admin per domain support. 

- [x] Secure storing of passwords (store salted hashes instead of plain passwords), see mongoose_scram:(de)serialize
- [x] Allow restricting fields to be executable only by global admin (not by domain admins).
- [x] Extend domain check for the domain-protected fields to support subdomains, JIDs, and input types.
- [x] Extend domain check for the domain-protected fields to support lists.
- [x] Decide and mark fields that should be domain protected or executable only by global admin.
- [x] Add other missing test cases.

Currently, the password storing method is not configurable, and it uses the SCRAM with default values.

Types of the permission check:
- **GLOBAL** - only global admin can execute field;
- **DOMAIN** - domain admin can execute field only with own domain;
- **DEFAULT** - anyone authorized can execute.
