### PR TITLE
Use metric probes instead of eval for slow calculated metrics

### DIFF
--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -208,9 +208,12 @@ one_presence_error(Config) ->
         {xmppErrorPresence, 1}]).
 
 session_counters(Config) ->
+    Names = [totalSessionCount, uniqueSessionCount, nodeSessionCount],
     escalus:story
       (Config, [{alice, 2}, {bob, 1}],
        fun(_User11, _User12, _User2) ->
+               %% Force update
+               lists:foreach(fun metrics_helper:sample/1, Names),
                ?assertEqual(3, fetch_global_gauge_value(totalSessionCount, Config)),
                ?assertEqual(2, fetch_global_gauge_value(uniqueSessionCount, Config)),
                ?assertEqual(3, fetch_global_gauge_value(nodeSessionCount, Config))

--- a/big_tests/tests/metrics_helper.erl
+++ b/big_tests/tests/metrics_helper.erl
@@ -27,6 +27,9 @@ get_counter_value(HostType, Metric) ->
             {error, unknown_counter}
     end.
 
+sample(Name) ->
+    rpc(mim(), mongoose_metrics, sample_metric, [[global, Name]]).
+
 assert_counter(Value, CounterName) ->
     assert_counter(domain_helper:host_type(mim), Value, CounterName).
 

--- a/big_tests/tests/metrics_session_SUITE.erl
+++ b/big_tests/tests/metrics_session_SUITE.erl
@@ -109,15 +109,14 @@ auth_failed(Config) ->
 
 session_global(Config) ->
     escalus:story(Config, [{alice, 1}], fun(_Alice) ->
-
+        metrics_helper:sample(totalSessionCount),
         wait_for_counter(global, 1, totalSessionCount)
-
         end).
 
 session_unique(Config) ->
     escalus:story(Config, [{alice, 2}], fun(_Alice1, _Alice2) ->
-
+        metrics_helper:sample(uniqueSessionCount),
+        metrics_helper:sample(totalSessionCount),
         wait_for_counter(global, 1, uniqueSessionCount),
         wait_for_counter(global, 2, totalSessionCount)
-
         end).

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -28,6 +28,7 @@
          get_metric_value/1,
          get_metric_values/1,
          get_metric_value/2,
+         sample_metric/1,
          get_host_type_metric_names/1,
          get_global_metric_names/0,
          get_aggregated_values/1,
@@ -44,7 +45,8 @@
 
 -ignore_xref([get_dist_data_stats/0, get_mnesia_running_db_nodes_count/0,
               get_rdbms_data_stats/0, get_rdbms_data_stats/1, get_up_time/0,
-              remove_host_type_metrics/1, get_report_interval/0]).
+              remove_host_type_metrics/1, get_report_interval/0,
+              sample_metric/1]).
 
 -define(DEFAULT_REPORT_INTERVAL, 60000). %%60s
 
@@ -130,6 +132,10 @@ get_metric_values(Metric) when is_list(Metric) ->
     exometer:get_values(Metric);
 get_metric_values(HostType) ->
     exometer:get_values([HostType]).
+
+%% Force update a probe metric
+sample_metric(Metric) ->
+    exometer:sample(Metric).
 
 get_host_type_metric_names(HostType) ->
     HostTypeName = make_host_type_name(HostType),

--- a/src/metrics/mongoose_metrics_definitions.hrl
+++ b/src/metrics/mongoose_metrics_definitions.hrl
@@ -38,32 +38,26 @@
     sessionCount
 ]).
 
--define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}],[value]}).
+-define(REPORT_INTERVAL, mongoose_metrics:get_report_interval()).
+
+-define(PROBE(Name, Module),
+        {Name,
+          {probe,
+           [{callback_module, Module},
+            {sample_interval, ?REPORT_INTERVAL}]}}).
 
 -define(GLOBAL_COUNTERS,
-        [{totalSessionCount,
-          {function, ejabberd_sm, get_total_sessions_number, [],
-           eval, ?EX_EVAL_SINGLE_VALUE}},
-         {uniqueSessionCount,
-          {function, ejabberd_sm, get_unique_sessions_number, [],
-           eval, ?EX_EVAL_SINGLE_VALUE}},
-         {nodeSessionCount,
-          {function, ejabberd_sm, get_node_sessions_number, [],
-           eval, ?EX_EVAL_SINGLE_VALUE}},
-         {nodeUpTime,
+        [{nodeUpTime,
           {function, mongoose_metrics, get_up_time, [],
            tagged, [value]}},
          {clusterSize,
           {function, mongoose_metrics, get_mnesia_running_db_nodes_count, [],
            tagged, [value]}},
-         {tcpPortsUsed,
-          {probe,
-           [{callback_module, mongoose_metrics_probe_tcp},
-            {sample_interval, timer:seconds(30)}]}},
-         {processQueueLengths,
-          {probe,
-           [{callback_module, mongoose_metrics_probe_queues},
-            {sample_interval, timer:seconds(30)}]}}
+         ?PROBE(totalSessionCount, mongoose_metrics_probe_total_sessions),
+         ?PROBE(uniqueSessionCount, mongoose_metrics_probe_unique_sessions),
+         ?PROBE(nodeSessionCount, mongoose_metrics_probe_node_sessions),
+         ?PROBE(tcpPortsUsed, mongoose_metrics_probe_tcp),
+         ?PROBE(processQueueLengths, mongoose_metrics_probe_queues)
         ]
 ).
 

--- a/src/metrics/mongoose_metrics_probe_muc_hibernated_rooms.erl
+++ b/src/metrics/mongoose_metrics_probe_muc_hibernated_rooms.erl
@@ -1,0 +1,25 @@
+%%==============================================================================
+%% Copyright 2019 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mongoose_metrics_probe_muc_hibernated_rooms).
+-behaviour(mongoose_metrics_probe).
+
+-export([sample/0, datapoints/0]).
+
+datapoints() ->
+    [value].
+
+sample() ->
+    #{value => mod_muc:hibernated_rooms_number()}.

--- a/src/metrics/mongoose_metrics_probe_muc_online_rooms.erl
+++ b/src/metrics/mongoose_metrics_probe_muc_online_rooms.erl
@@ -1,0 +1,25 @@
+%%==============================================================================
+%% Copyright 2019 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mongoose_metrics_probe_muc_online_rooms).
+-behaviour(mongoose_metrics_probe).
+
+-export([sample/0, datapoints/0]).
+
+datapoints() ->
+    [value].
+
+sample() ->
+    #{value => mod_muc:online_rooms_number()}.

--- a/src/metrics/mongoose_metrics_probe_node_sessions.erl
+++ b/src/metrics/mongoose_metrics_probe_node_sessions.erl
@@ -1,0 +1,25 @@
+%%==============================================================================
+%% Copyright 2019 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mongoose_metrics_probe_node_sessions).
+-behaviour(mongoose_metrics_probe).
+
+-export([sample/0, datapoints/0]).
+
+datapoints() ->
+    [value].
+
+sample() ->
+    #{value => ejabberd_sm:get_node_sessions_number()}.

--- a/src/metrics/mongoose_metrics_probe_total_sessions.erl
+++ b/src/metrics/mongoose_metrics_probe_total_sessions.erl
@@ -1,0 +1,25 @@
+%%==============================================================================
+%% Copyright 2019 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mongoose_metrics_probe_total_sessions).
+-behaviour(mongoose_metrics_probe).
+
+-export([sample/0, datapoints/0]).
+
+datapoints() ->
+    [value].
+
+sample() ->
+    #{value => ejabberd_sm:get_total_sessions_number()}.

--- a/src/metrics/mongoose_metrics_probe_unique_sessions.erl
+++ b/src/metrics/mongoose_metrics_probe_unique_sessions.erl
@@ -1,0 +1,25 @@
+%%==============================================================================
+%% Copyright 2019 Erlang Solutions Ltd.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+-module(mongoose_metrics_probe_unique_sessions).
+-behaviour(mongoose_metrics_probe).
+
+-export([sample/0, datapoints/0]).
+
+datapoints() ->
+    [value].
+
+sample() ->
+    #{value => ejabberd_sm:get_unique_sessions_number()}.

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1355,17 +1355,17 @@ count_hibernated_rooms(Pid, Count) ->
             Count
     end.
 
--define(EX_EVAL_SINGLE_VALUE, {[{l, [{t, [value, {v, 'Value'}]}]}], [value]}).
 ensure_metrics(_Host) ->
+    Interval = mongoose_metrics:get_report_interval(),
     mongoose_metrics:ensure_metric(global, [mod_muc, deep_hibernations], spiral),
     mongoose_metrics:ensure_metric(global, [mod_muc, process_recreations], spiral),
     mongoose_metrics:ensure_metric(global, [mod_muc, hibernations], spiral),
-    mongoose_metrics:ensure_metric(global, [mod_muc, hibernated_rooms],
-                                   {function, mod_muc, hibernated_rooms_number, [],
-                                    eval, ?EX_EVAL_SINGLE_VALUE}),
-    mongoose_metrics:ensure_metric(global, [mod_muc, online_rooms],
-                                   {function, mod_muc, online_rooms_number, [],
-                                    eval, ?EX_EVAL_SINGLE_VALUE}).
+    M1 = [{callback_module, mongoose_metrics_probe_muc_hibernated_rooms},
+          {sample_interval, Interval}],
+    M2 = [{callback_module, mongoose_metrics_probe_muc_online_rooms},
+          {sample_interval, Interval}],
+    mongoose_metrics:ensure_metric(global, [mod_muc, hibernated_rooms], {probe, M1}),
+    mongoose_metrics:ensure_metric(global, [mod_muc, online_rooms], {probe, M2}).
 
 -spec config_metrics(mongooseim:host_type()) -> [{gen_mod:opt_key(), gen_mod:opt_value()}].
 config_metrics(HostType) ->


### PR DESCRIPTION
This PR addresses "MIM-1637 Fix metrics being null"


```
There is a bug in how we handle computed metrics.
Computed metrics should take constant amount of time and be calculated fast.

But, uniqueSessionCount could be too slow for >600k users.
This means that exometer reporter takes longer, this means exometer misses a report window for graphite, this means missing metrics.
```

Proposed changes include:
 - use probe metric type for non-constant calculation time metrics. Probe metrics have a separate process for calculations, so they don't block the reporter process.
 - add sample/1 function to our metrics API, so we can force update metric value without waiting one minute in our tests.
 - clusterSize metric could remain eval - it is really fast call and having the most recent value for **fast** metrics is beneficial.
 


